### PR TITLE
feat(memory): host-side memory bank for radios with no memory slots (HL2, Kiwi, demo)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -523,6 +523,7 @@ endif()
 
 # Sources
 set(CORE_SOURCES
+    src/core/backends/MemoryWireCodec.cpp    # memory kv-set decode, shared by Flex + local bank
     src/core/backends/flex/FlexBackend.cpp   # aetherd RFC step 2.2 (§5.5)
     src/core/backends/sim/SimBackend.cpp     # demo mode — 2nd IRadioBackend (RFC #4288)
     src/core/backends/sim/SpectrumPatternGenerator.cpp  # demo mode — signal engine (RFC #4288 Phase 2)
@@ -667,6 +668,8 @@ set(CORE_SOURCES
     src/core/DxccWorkedStatus.cpp
     src/core/DxccColorProvider.cpp
     src/core/SleepInhibitor.cpp
+    src/core/LocalMemoryBank.cpp
+    src/core/LocalMemoryStore.cpp
     src/core/MemoryCsvCompat.cpp
     src/core/MemoryFieldValues.cpp
     src/core/MemoryRecallPolicy.cpp
@@ -4382,6 +4385,27 @@ add_executable(memory_field_values_test
 target_include_directories(memory_field_values_test PRIVATE src)
 target_link_libraries(memory_field_values_test PRIVATE Qt6::Core)
 add_test(NAME memory_field_values_test COMMAND memory_field_values_test)
+
+add_executable(local_memory_store_test
+    tests/local_memory_store_test.cpp
+    src/core/LocalMemoryStore.cpp
+)
+target_include_directories(local_memory_store_test PRIVATE src)
+target_link_libraries(local_memory_store_test PRIVATE Qt6::Core)
+add_test(NAME local_memory_store_test COMMAND local_memory_store_test)
+
+add_executable(local_memory_bank_test
+    tests/local_memory_bank_test.cpp
+    src/core/LocalMemoryBank.cpp
+    src/core/LocalMemoryStore.cpp
+    src/core/backends/MemoryWireCodec.cpp
+    src/core/AsyncLogWriter.cpp
+    src/core/LogManager.cpp
+    src/core/AppSettings.cpp
+)
+target_include_directories(local_memory_bank_test PRIVATE src)
+target_link_libraries(local_memory_bank_test PRIVATE Qt6::Core)
+add_test(NAME local_memory_bank_test COMMAND local_memory_bank_test)
 
 add_executable(memory_csv_compat_test
     tests/memory_csv_compat_test.cpp

--- a/docs/architecture/aetherd-hl2-backend-design.md
+++ b/docs/architecture/aetherd-hl2-backend-design.md
@@ -158,13 +158,64 @@ caps.txPowerMaxWatts     = 0.0;
 caps.hasTuner            = false;
 caps.hasAmplifier        = false;
 caps.hasExtendedDsp      = false;                 // DSP is engine-side, not firmware
+caps.persistsMemories    = false;                 // no radio-side memory slots
 caps.extensionNamespaces = {};                    // advertise NONE until step 3
 ```
+
+`persistsMemories = false` is the struct's default, so HL2 gets it by saying
+nothing — see §4a.
 
 The empty `extensionNamespaces` follows FlexBackend's deliberate precedent
 (FlexBackend's capabilities setup): advertising a namespace whose `invokeExtension`
 can't yet reply would hang a client. HL2 keeps it empty until the step-3 encode
 path lands.
+
+---
+
+## 4a. Memory channels have nowhere to live on an HL2
+
+A Flex stores memory slots in the radio and re-dumps them to every client on
+connect. The HL2 has no such storage, so the entire memory feature — the Memory
+dialog, the browse panel, CSV import/export, the panadapter memory-spot feed,
+the automation `memory activate` verb — had nothing underneath it: `memory
+create` went to a command plane the backend does not own and was dropped, and
+nothing ever came back.
+
+The client keeps its own bank instead, selected by capability rather than by
+family name:
+
+| | Flex | HL2 / Kiwi / demo / not connected |
+|---|---|---|
+| `persistsMemories` | `true` | `false` (the default) |
+| Slots live in | the radio | `~/.config/AetherSDR/memories.json` |
+| Populated by | radio memory status on connect | `RadioModel::publishLocalMemories()` |
+
+Three pieces, and one seam:
+
+- **`LocalMemoryStore`** — versioned JSON (`aether.memories` v1), atomic writes
+  via `QSaveFile`, sparse slot indices preserved. A file whose version is newer
+  than the build fails the whole read and is never written back, so a downgrade
+  cannot silently delete fields it does not understand.
+- **`LocalMemoryBank`** — owns the slots, allocates the lowest free index,
+  answers `memory create` / `set` / `remove` / `apply`, and debounces saves.
+- **`RadioModel::tryLocalMemoryCommand()`** — the seam, in `sendCmd()`. Every
+  memory path in the app funnels through those four commands, so answering them
+  there is what let all of the UX above keep working with **no changes to the
+  memory dialog, the browse panel, the CSV codec, or the spot feed**.
+
+Two ordering rules are load-bearing:
+
+1. The bank stores what `RadioModel::applyMemoryChanges()` produced, not the
+   kv-set that came in — that method owns the `0x7f`→space decode and the
+   control-byte sanitisation, so persisting its output is what keeps the file
+   identical to what the UI and a CSV export see.
+2. Both stores number slots from 0. `syncMemoryStoreForSession()` clears the
+   cache when connecting to a radio that owns its slots, so a locally-banked
+   slot 0 published while disconnected cannot masquerade as the radio's.
+
+The decode itself is shared: `MemoryWire::decodeStatus()` is used by both
+`FlexBackend::decodeMemoryStatus()` and the bank, so a channel saved locally and
+one read back from a Flex cannot land in `MemoryEntry` differently.
 
 ---
 

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -1100,6 +1100,18 @@ only.
 ← {"ok":true,"memory":"activate","index":12,"panId":"0x40000000"}
 ```
 
+Works the same whether the slots live in the radio (Flex) or in the host-side
+memory bank (`LocalMemoryBank`, used by HL2/Kiwi/demo and whenever no radio is
+connected). On the local bank there is no radio-side `memory apply`, so
+`RadioModel::recallLocalMemory()` applies the stored channel to the active slice
+through SliceModel's operator-issue setters — the same path the panel controls
+use, so the write reaches the radio through the backend seam.
+
+`activate` is currently the only action. Saving, listing, and removing memories
+still require driving the GUI (the Memory dialog's Import/Export use NATIVE file
+dialogs, which the bridge cannot reach at all) — see the verb suggestions at the
+end of this document.
+
 ### `slice`
 Slice lifecycle, mode, diversity, Center Lock, Slice Link, TX assignment,
 antennas, and receive source. All actions are RX/config — none keys the
@@ -2702,3 +2714,32 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `qrz` | — | qrz <status\|cached\|lookup\|spottext> [args] |
 
 <!-- END GENERATED VERB TABLE -->
+
+---
+
+## Suggested verbs
+
+Gaps found while proving a feature against real hardware, kept here so the next
+person hits a note instead of the wall.
+
+### `memory save|list|remove`
+
+`memory` can only `activate`. Everything else about a memory channel has to be
+driven through the GUI: quick-save is a modal dialog whose QLineEdit has no
+`objectName` (it is reachable only via the scoped `QDialog/QLineEdit` form), and
+the Memory dialog's **Import…/Export… open NATIVE file dialogs, which the bridge
+cannot drive at all**. So the CSV round trip — the thing most likely to regress,
+because it is a chained `create`→`set` per record — has no automated proof at
+the GUI level today.
+
+Proposed:
+
+| Verb | Purpose |
+|---|---|
+| `memory save <name>` | Save the active slice as a memory; returns the new index. Covers `createMemoryFromSlice()` without the modal. |
+| `memory list` | Dump the memory cache as JSON — lets a test assert on channels without screenshotting a table. |
+| `memory remove <index>` | Delete a slot; makes tests self-cleaning instead of leaving channels in the operator's bank. |
+| `memory import <path>` / `memory export <path>` | Take a path directly, bypassing the native file dialog. The only way to get the CSV flows under automation. |
+
+All four are RX/config, no TX gate. `memory list` in particular would have
+replaced several screenshots in this feature's verification.

--- a/src/core/LocalMemoryBank.cpp
+++ b/src/core/LocalMemoryBank.cpp
@@ -5,6 +5,7 @@
 #include "core/backends/MemoryWireCodec.h"
 
 #include <QDateTime>
+#include <QFileInfo>
 
 namespace AetherSDR {
 
@@ -57,18 +58,32 @@ void LocalMemoryBank::load()
 
     const LocalMemoryStore::ParseResult parsed = LocalMemoryStore::load(m_filePath);
     m_entries = parsed.memories;
-    m_loaded = true;
     m_dirty = false;
+
+    // TWO facts, deliberately separate, because one flag could not carry both:
+    //
+    //   m_loaded   — the read has been ATTEMPTED. Latches true no matter how the
+    //                read went, so nothing re-reads.
+    //   m_writable — the file was UNDERSTOOD, so replacing it is safe.
+    //
+    // Using m_loaded for both was wrong in both directions. Leaving it true on a
+    // failed read made the bank writable, so the next flush() replaced a damaged
+    // file with the empty bank it had just parsed out of it. And clearing it to
+    // withhold write permission also cleared "already read", so handleCommand()'s
+    // load() re-ran on EVERY command and wiped m_entries between `memory create`
+    // and `memory set` — every Add failing with "There is no memory in slot N",
+    // and the reset m_dirty suppressing the warning that would have explained it.
+    m_loaded = true;
+    m_writable = parsed.overwritable();
+    // Baseline for the concurrent-writer check in flush().
+    rememberFileState();
 
     if (!parsed.ok()) {
         m_lastError = parsed.errors.join(QStringLiteral("; "));
         qCWarning(lcProtocol).noquote()
-            << "LocalMemoryBank: problems reading" << m_filePath << "—" << m_lastError;
-        // A version-too-new file parses to nothing. Do NOT let a later edit
-        // save over it: that would replace channels this build cannot read with
-        // the empty bank it read instead.
-        if (parsed.version > LocalMemoryStore::kFormatVersion)
-            m_loaded = false;
+            << "LocalMemoryBank: problems reading" << m_filePath << "—" << m_lastError
+            << (m_writable ? "(bank is still writable)"
+                           : "(bank is READ-ONLY; edits will be refused)");
         return;
     }
 
@@ -110,6 +125,16 @@ LocalMemoryBank::CommandResult LocalMemoryBank::handleCommand(const QString& com
         result.body = reason;
         return result;
     };
+
+    // Refuse every write up front when the file could not be read, and say why.
+    // Without this the command runs against an in-memory bank that flush() will
+    // then decline to persist, so the operator sees an Add "succeed" and vanish
+    // at restart. Naming the file is the point — the fix is theirs to make.
+    if (!m_writable) {
+        return reject(QString("The memory file at %1 could not be read, so it "
+                              "will not be overwritten: %2")
+                          .arg(m_filePath, m_lastError));
+    }
 
     // The index argument for every verb that takes one.
     auto slotArgument = [&tail](bool* ok) {
@@ -233,12 +258,33 @@ void LocalMemoryBank::flush()
     if (!m_dirty)
         return;
 
-    // Not loaded means load() refused to take ownership of the file (a version
-    // this build cannot read). Writing would destroy it.
-    if (!m_loaded) {
+    // Not writable means load() could not understand the file — a version this
+    // build cannot read, a foreign format id, or JSON it could not parse.
+    // Writing would destroy it.
+    if (!m_writable) {
         qCWarning(lcProtocol).noquote()
             << "LocalMemoryBank: refusing to overwrite an unreadable bank at" << m_filePath;
         return;
+    }
+
+    // Somebody else wrote the file since we read it.
+    //
+    // The bank is replaced WHOLESALE and read once per process, so a second
+    // instance sharing the same config dir (two AetherSDR windows, a test
+    // instance on the same $HOME) would have its channels silently discarded by
+    // whichever process saved last. Refusing is deliberately not a merge: which
+    // side wins per slot is a design decision, not something to infer here. This
+    // turns silent loss into a visible, recoverable error — the entries stay in
+    // memory and dirty, and the operator is told rather than finding out later.
+    if (foreignWriteDetected()) {
+        m_lastError = QString("The memory file at %1 was changed by another "
+                              "program or window since it was read. Nothing was "
+                              "saved, so neither copy is lost — reopen the memory "
+                              "panel to pick up the other changes.")
+                          .arg(m_filePath);
+        qCWarning(lcProtocol).noquote() << "LocalMemoryBank:" << m_lastError;
+        emit saveFailed(m_lastError);
+        return;   // stays dirty
     }
 
     QString error;
@@ -255,8 +301,38 @@ void LocalMemoryBank::flush()
 
     m_dirty = false;
     m_lastError.clear();
+    // Our own write moved the mtime; re-baseline or the NEXT flush would mistake
+    // it for someone else's.
+    rememberFileState();
     qCDebug(lcProtocol).noquote()
         << "LocalMemoryBank: saved" << m_entries.size() << "memories to" << m_filePath;
+}
+
+void LocalMemoryBank::rememberFileState()
+{
+    const QFileInfo info(m_filePath);
+    m_seenExists = info.exists();
+    m_seenMtime = m_seenExists ? info.lastModified() : QDateTime();
+    m_seenSize = m_seenExists ? info.size() : -1;
+}
+
+bool LocalMemoryBank::foreignWriteDetected() const
+{
+    const QFileInfo info(m_filePath);
+    // Appearing counts: we read "no file, empty bank", so a file that exists now
+    // holds channels somebody else created, and our empty-ish bank would erase
+    // them. Disappearing does not — a deleted bank is nothing to preserve, and
+    // refusing there would strand the operator's edits with nowhere to go.
+    if (!info.exists())
+        return false;
+    if (!m_seenExists)
+        return true;
+    // Size as well as mtime: a coarse filesystem timestamp can collide on two
+    // writes inside the same tick, and a channel edit almost always changes the
+    // length. Neither is a substitute for a lock, and this does not claim to be
+    // one — it catches the realistic case (a human editing in two windows),
+    // not a deliberate race.
+    return info.lastModified() != m_seenMtime || info.size() != m_seenSize;
 }
 
 }  // namespace AetherSDR

--- a/src/core/LocalMemoryBank.cpp
+++ b/src/core/LocalMemoryBank.cpp
@@ -1,0 +1,262 @@
+#include "core/LocalMemoryBank.h"
+
+#include "core/LocalMemoryStore.h"
+#include "core/LogManager.h"
+#include "core/backends/MemoryWireCodec.h"
+
+#include <QDateTime>
+
+namespace AetherSDR {
+
+namespace {
+
+// Writes are coalesced: a CSV import runs create+set per record back to back,
+// and rewriting the whole file on each one would turn a 500-channel import into
+// 1000 file writes. Every path that could lose the window (disconnect,
+// teardown) calls flush().
+constexpr int kSaveDebounceMs = 750;
+
+// Internal sentinel for a memory command the local bank rejected. Not a
+// SmartSDR protocol response code — it just has to be non-zero, which is what
+// the client's response callback reads as a failure, and distinguishable in a
+// log. Numbered alongside kProfileLoadSuppressedCommandCode (0x50000061).
+constexpr int kLocalMemoryError = 0x50000062;
+
+}  // namespace
+
+LocalMemoryBank::LocalMemoryBank(QObject* parent)
+    : QObject(parent)
+{
+    m_filePath = LocalMemoryStore::defaultFilePath();
+    m_saveTimer.setSingleShot(true);
+    m_saveTimer.setInterval(kSaveDebounceMs);
+    connect(&m_saveTimer, &QTimer::timeout, this, &LocalMemoryBank::flush);
+}
+
+LocalMemoryBank::~LocalMemoryBank()
+{
+    flush();
+}
+
+void LocalMemoryBank::setFilePath(const QString& path)
+{
+    if (path == m_filePath)
+        return;
+    // Anything pending belongs to the OLD file — write it there before moving,
+    // or switching paths (only tests do today) would silently discard it.
+    flush();
+    m_filePath = path;
+    m_loaded = false;
+    m_entries.clear();
+}
+
+void LocalMemoryBank::load()
+{
+    if (m_loaded)
+        return;
+
+    const LocalMemoryStore::ParseResult parsed = LocalMemoryStore::load(m_filePath);
+    m_entries = parsed.memories;
+    m_loaded = true;
+    m_dirty = false;
+
+    if (!parsed.ok()) {
+        m_lastError = parsed.errors.join(QStringLiteral("; "));
+        qCWarning(lcProtocol).noquote()
+            << "LocalMemoryBank: problems reading" << m_filePath << "—" << m_lastError;
+        // A version-too-new file parses to nothing. Do NOT let a later edit
+        // save over it: that would replace channels this build cannot read with
+        // the empty bank it read instead.
+        if (parsed.version > LocalMemoryStore::kFormatVersion)
+            m_loaded = false;
+        return;
+    }
+
+    m_lastError.clear();
+    qCInfo(lcProtocol).noquote()
+        << "LocalMemoryBank: loaded" << m_entries.size() << "memories from" << m_filePath;
+}
+
+int LocalMemoryBank::allocateSlot() const
+{
+    // Lowest free index, so removing a channel and adding another reuses the
+    // hole instead of growing the numbering forever. Matches how the slot
+    // numbers read in the browse panel.
+    int index = 0;
+    while (m_entries.contains(index))
+        ++index;
+    return index;
+}
+
+LocalMemoryBank::CommandResult LocalMemoryBank::handleCommand(const QString& command)
+{
+    CommandResult result;
+
+    const QString trimmed = command.trimmed();
+    if (!trimmed.startsWith(QLatin1String("memory ")))
+        return result;
+
+    const QString rest = trimmed.mid(7).trimmed();
+    const QString verb = rest.section(QLatin1Char(' '), 0, 0);
+    const QString tail = rest.section(QLatin1Char(' '), 1).trimmed();
+
+    // The bank must be readable before it is written, or a create would
+    // allocate slot 0 on top of an existing channel list.
+    load();
+
+    auto reject = [&result](const QString& reason) {
+        result.handled = true;
+        result.code = kLocalMemoryError;
+        result.body = reason;
+        return result;
+    };
+
+    // The index argument for every verb that takes one.
+    auto slotArgument = [&tail](bool* ok) {
+        return tail.section(QLatin1Char(' '), 0, 0).toInt(ok);
+    };
+
+    if (verb == QLatin1String("create")) {
+        if (m_entries.size() >= kMaxSlots) {
+            return reject(QStringLiteral("The memory bank is full (%1 channels).")
+                              .arg(kMaxSlots));
+        }
+
+        const int index = allocateSlot();
+        MemoryEntry entry;
+        entry.index = index;
+        m_entries.insert(index, entry);
+        scheduleSave();
+
+        result.handled = true;
+        result.code = 0;
+        // The client parses this as the new slot id, exactly as it parses the
+        // radio's create response.
+        result.body = QString::number(index);
+        result.delta = MemoryWire::decodeStatus(index, {});
+        return result;
+    }
+
+    if (verb == QLatin1String("set")) {
+        bool ok = false;
+        const int index = slotArgument(&ok);
+        if (!ok)
+            return reject(QStringLiteral("The memory id isn't a number."));
+        if (!m_entries.contains(index))
+            return reject(QString("There is no memory in slot %1.").arg(index));
+
+        const QString kvTail = tail.section(QLatin1Char(' '), 1).trimmed();
+        const QMap<QString, QString> kvs = MemoryWire::parseKvTail(kvTail);
+        if (kvs.isEmpty())
+            return reject(QStringLiteral("The memory update had no fields to set."));
+
+        result.handled = true;
+        result.code = 0;
+        // RadioModel applies this and calls record() with the decoded entry —
+        // that is what reaches the file, not the wire-encoded text here.
+        result.delta = MemoryWire::decodeStatus(index, kvs);
+        return result;
+    }
+
+    if (verb == QLatin1String("remove")) {
+        bool ok = false;
+        const int index = slotArgument(&ok);
+        if (!ok)
+            return reject(QStringLiteral("The memory id isn't a number."));
+        // Removing something already gone is not an error. The dialog's
+        // create→set→remove cleanup path can arrive here after the slot went,
+        // and failing it would report a cleanup problem that does not exist.
+        forget(index);
+
+        result.handled = true;
+        result.code = 0;
+        MemoryDelta delta;
+        delta.index = index;
+        delta.removed = true;
+        result.delta = delta;
+        return result;
+    }
+
+    if (verb == QLatin1String("apply")) {
+        bool ok = false;
+        const int index = slotArgument(&ok);
+        if (!ok)
+            return reject(QStringLiteral("The memory id isn't a number."));
+        if (!m_entries.contains(index))
+            return reject(QString("There is no memory in slot %1.").arg(index));
+
+        result.handled = true;
+        result.code = 0;
+        // No radio-side apply exists — the caller recalls it onto the active
+        // slice itself.
+        result.recallIndex = index;
+        return result;
+    }
+
+    // Some other `memory …` verb. Leave it alone rather than answering for it.
+    return result;
+}
+
+void LocalMemoryBank::record(int index, const MemoryEntry& entry)
+{
+    if (index < 0)
+        return;
+
+    MemoryEntry stored = entry;
+    stored.index = index;
+
+    // The dialog re-asserts the kv-set it just sent (handleMemoryStatus), so an
+    // unconditional insert would mark the bank dirty twice per edit.
+    const auto existing = m_entries.constFind(index);
+    if (existing != m_entries.constEnd() && existing.value() == stored)
+        return;
+
+    m_entries.insert(index, stored);
+    scheduleSave();
+}
+
+void LocalMemoryBank::forget(int index)
+{
+    if (m_entries.remove(index) > 0)
+        scheduleSave();
+}
+
+void LocalMemoryBank::scheduleSave()
+{
+    m_dirty = true;
+    m_saveTimer.start();
+}
+
+void LocalMemoryBank::flush()
+{
+    m_saveTimer.stop();
+    if (!m_dirty)
+        return;
+
+    // Not loaded means load() refused to take ownership of the file (a version
+    // this build cannot read). Writing would destroy it.
+    if (!m_loaded) {
+        qCWarning(lcProtocol).noquote()
+            << "LocalMemoryBank: refusing to overwrite an unreadable bank at" << m_filePath;
+        return;
+    }
+
+    QString error;
+    const QString savedAt = QDateTime::currentDateTimeUtc().toString(Qt::ISODate);
+    if (!LocalMemoryStore::save(m_filePath, m_entries, savedAt, &error)) {
+        m_lastError = error;
+        qCWarning(lcProtocol).noquote() << "LocalMemoryBank: save failed —" << error;
+        emit saveFailed(error);
+        // Stay dirty: the next edit (or flush) retries. A transient failure —
+        // a config dir that is briefly unwritable — must not cost the operator
+        // every channel they saved since.
+        return;
+    }
+
+    m_dirty = false;
+    m_lastError.clear();
+    qCDebug(lcProtocol).noquote()
+        << "LocalMemoryBank: saved" << m_entries.size() << "memories to" << m_filePath;
+}
+
+}  // namespace AetherSDR

--- a/src/core/LocalMemoryBank.h
+++ b/src/core/LocalMemoryBank.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include "core/backends/MemoryDelta.h"
+#include "models/MemoryEntry.h"
+
+#include <optional>
+
+#include <QMap>
+#include <QObject>
+#include <QString>
+#include <QTimer>
+
+namespace AetherSDR {
+
+// The client-side memory bank: what a radio's memory slots would be, for a
+// radio that has none. Standing in for the radio is deliberate — it is what
+// lets every existing memory path keep working untouched.
+//
+// The whole memory UX (the dialog, the browse panel, CSV import/export, the
+// panadapter memory-spot feed, the automation `memory activate` verb) is built
+// on two things: RadioModel's memory cache, and the four commands the client
+// issues to change it — `memory create`, `memory set <idx> <kv…>`,
+// `memory remove <idx>`, `memory apply <idx>`. On a Flex those go to the radio
+// and come back as memory status. Here they are answered locally, in the same
+// shape, with the same kv-set decode (MemoryWire::decodeStatus), so nothing
+// upstream needs to know which kind of radio it is talking to.
+//
+// Ownership split with RadioModel is one-way and worth keeping straight:
+//   * The bank answers commands and hands back a MemoryDelta.
+//   * RadioModel applies that delta — it owns the 0x7f→' ' decode and the
+//     control-byte sanitisation, and it emits the memoryChanged/memoryRemoved
+//     signals the UI listens to.
+//   * RadioModel then calls record() with its post-decode MemoryEntry, which is
+//     what gets persisted.
+// So the JSON on disk is byte-for-byte what the UI and a CSV export see, rather
+// than a second, wire-encoded interpretation of it that could drift.
+class LocalMemoryBank : public QObject {
+    Q_OBJECT
+
+public:
+    // The answer to one intercepted `memory …` command.
+    struct CommandResult {
+        // False means "not a command this bank owns" — the caller lets it take
+        // its normal path rather than swallowing it.
+        bool handled{false};
+
+        // Response the client's callback receives. Non-zero code is a failure
+        // and `body` is the reason, matching how a radio rejection reads.
+        int code{0};
+        QString body;
+
+        // Apply through RadioModel so the cache and signals stay on one path.
+        std::optional<MemoryDelta> delta;
+
+        // >= 0 for `memory apply` — the slot the caller should recall onto the
+        // active slice. There is no radio to do it for us.
+        int recallIndex{-1};
+    };
+
+    explicit LocalMemoryBank(QObject* parent = nullptr);
+    ~LocalMemoryBank() override;
+
+    // Defaults to LocalMemoryStore::defaultFilePath(). Setting it drops the
+    // loaded state so the next load() reads the new file.
+    void setFilePath(const QString& path);
+    QString filePath() const { return m_filePath; }
+
+    // Read the bank from disk. Idempotent: a second call without an intervening
+    // setFilePath() is a no-op, so reconnecting does not re-read the file (and
+    // cannot lose an unsaved edit made while disconnected).
+    void load();
+    bool isLoaded() const { return m_loaded; }
+
+    const QMap<int, MemoryEntry>& entries() const { return m_entries; }
+
+    // Handle one `memory …` command. Returns handled=false for anything outside
+    // the four verbs above.
+    CommandResult handleCommand(const QString& command);
+
+    // RadioModel's post-decode view of a slot, and the authoritative one.
+    void record(int index, const MemoryEntry& entry);
+    void forget(int index);
+
+    // Write now if anything is pending. Called on disconnect and at teardown so
+    // the debounce window can never be the reason an edit is lost.
+    void flush();
+
+    // Last file-write failure, empty when the last save succeeded. Surfaced so a
+    // read-only config dir shows up as something other than memories that
+    // quietly fail to come back.
+    QString lastError() const { return m_lastError; }
+
+    // A bank this large is a runaway import, not an operator's channel list.
+    // Refusing past it keeps a loop bug from growing the file without bound.
+    static constexpr int kMaxSlots = 10000;
+
+signals:
+    // A save failed. Emitted once per failure, not once per debounce tick.
+    void saveFailed(const QString& error);
+
+private:
+    int allocateSlot() const;
+    void scheduleSave();
+
+    QString m_filePath;
+    QMap<int, MemoryEntry> m_entries;
+    QTimer m_saveTimer;
+    QString m_lastError;
+    bool m_loaded{false};
+    bool m_dirty{false};
+};
+
+}  // namespace AetherSDR

--- a/src/core/LocalMemoryBank.h
+++ b/src/core/LocalMemoryBank.h
@@ -5,6 +5,7 @@
 
 #include <optional>
 
+#include <QDateTime>
 #include <QMap>
 #include <QObject>
 #include <QString>
@@ -70,6 +71,10 @@ public:
     // cannot lose an unsaved edit made while disconnected).
     void load();
     bool isLoaded() const { return m_loaded; }
+    // False when the file could not be understood, so edits are refused and the
+    // file is never replaced. Distinct from isLoaded(), which only says the read
+    // was attempted — see load().
+    bool isWritable() const { return m_writable; }
 
     const QMap<int, MemoryEntry>& entries() const { return m_entries; }
 
@@ -101,13 +106,27 @@ signals:
 private:
     int allocateSlot() const;
     void scheduleSave();
+    // Concurrent-writer detection: snapshot the file's identity at load and
+    // after each save, and compare before the next save. Best-effort, not a
+    // lock — see flush().
+    void rememberFileState();
+    bool foreignWriteDetected() const;
 
     QString m_filePath;
     QMap<int, MemoryEntry> m_entries;
     QTimer m_saveTimer;
     QString m_lastError;
+    // The read has been attempted (latches; nothing re-reads).
     bool m_loaded{false};
+    // The file was understood, so replacing it wholesale is safe. False for a
+    // file this build cannot read — see load(), which explains why these must
+    // be two flags and not one.
+    bool m_writable{true};
     bool m_dirty{false};
+    // File identity as of the last read or our own last write.
+    bool m_seenExists{false};
+    QDateTime m_seenMtime;
+    qint64 m_seenSize{-1};
 };
 
 }  // namespace AetherSDR

--- a/src/core/LocalMemoryStore.cpp
+++ b/src/core/LocalMemoryStore.cpp
@@ -101,21 +101,34 @@ LocalMemoryStore::ParseResult LocalMemoryStore::parse(const QByteArray& bytes)
     if (bytes.trimmed().isEmpty())
         return result;
 
+    // Every branch below that cannot make sense of the file marks it UNREADABLE,
+    // not merely errored. A caller may not overwrite what it could not read: the
+    // bytes are channels somebody saved, and replacing them with the empty bank
+    // this parse produced is data loss, not a lost field.
     QJsonParseError perr;
     const QJsonDocument doc = QJsonDocument::fromJson(bytes, &perr);
     if (doc.isNull()) {
         result.errors << QString("Invalid JSON: %1").arg(perr.errorString());
+        result.unreadable = true;
         return result;
     }
     if (!doc.isObject()) {
         result.errors << QStringLiteral("Top-level JSON is not an object");
+        result.unreadable = true;
         return result;
     }
 
     const QJsonObject root = doc.object();
     const QString format = root.value("format").toString();
-    if (!format.isEmpty() && format != QLatin1String(kFormatId))
+    // A MISSING format id is tolerated — an early hand-written file, and the
+    // memories still parse. A PRESENT but foreign one is another application's
+    // file that happens to live at our path, so stop: reading its "memories"
+    // array and then saving our envelope over it would clobber it.
+    if (!format.isEmpty() && format != QLatin1String(kFormatId)) {
         result.errors << QString("Unexpected format \"%1\"").arg(format);
+        result.unreadable = true;
+        return result;
+    }
 
     result.version = root.value("version").toInt(0);
     if (result.version > kFormatVersion) {
@@ -125,6 +138,7 @@ LocalMemoryStore::ParseResult LocalMemoryStore::parse(const QByteArray& bytes)
         result.errors << QString("File version %1 is newer than supported version %2")
                              .arg(result.version)
                              .arg(kFormatVersion);
+        result.unreadable = true;
         return result;
     }
 

--- a/src/core/LocalMemoryStore.cpp
+++ b/src/core/LocalMemoryStore.cpp
@@ -1,0 +1,220 @@
+#include "core/LocalMemoryStore.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSaveFile>
+#include <QStandardPaths>
+
+namespace AetherSDR {
+
+namespace {
+
+// Every MemoryEntry field is written — this is the bank's own canonical form,
+// not the portable net-schedule preset, so a load has to reproduce the slot
+// exactly as the operator saved it. `index` rides in the object rather than
+// being implied by array position; see the header.
+QJsonObject entryToJson(const MemoryEntry& m)
+{
+    QJsonObject o;
+    o["index"] = m.index;
+    o["group"] = m.group;
+    o["owner"] = m.owner;
+    o["freq"] = m.freq;
+    o["name"] = m.name;
+    o["mode"] = m.mode;
+    o["step"] = m.step;
+    o["offsetDir"] = m.offsetDir;
+    o["repeaterOffset"] = m.repeaterOffset;
+    o["toneMode"] = m.toneMode;
+    o["toneValue"] = m.toneValue;
+    o["squelch"] = m.squelch;
+    o["squelchLevel"] = m.squelchLevel;
+    o["rxFilterLow"] = m.rxFilterLow;
+    o["rxFilterHigh"] = m.rxFilterHigh;
+    o["rttyMark"] = m.rttyMark;
+    o["rttyShift"] = m.rttyShift;
+    o["diglOffset"] = m.diglOffset;
+    o["diguOffset"] = m.diguOffset;
+    return o;
+}
+
+MemoryEntry entryFromJson(const QJsonObject& o)
+{
+    MemoryEntry m;
+    m.index = o.value("index").toInt(m.index);
+    m.group = o.value("group").toString(m.group);
+    m.owner = o.value("owner").toString(m.owner);
+    m.freq = o.value("freq").toDouble(m.freq);
+    m.name = o.value("name").toString(m.name);
+    m.mode = o.value("mode").toString(m.mode);
+    m.step = o.value("step").toInt(m.step);
+    m.offsetDir = o.value("offsetDir").toString(m.offsetDir);
+    m.repeaterOffset = o.value("repeaterOffset").toDouble(m.repeaterOffset);
+    m.toneMode = o.value("toneMode").toString(m.toneMode);
+    m.toneValue = o.value("toneValue").toDouble(m.toneValue);
+    m.squelch = o.value("squelch").toBool(m.squelch);
+    m.squelchLevel = o.value("squelchLevel").toInt(m.squelchLevel);
+    m.rxFilterLow = o.value("rxFilterLow").toInt(m.rxFilterLow);
+    m.rxFilterHigh = o.value("rxFilterHigh").toInt(m.rxFilterHigh);
+    m.rttyMark = o.value("rttyMark").toInt(m.rttyMark);
+    m.rttyShift = o.value("rttyShift").toInt(m.rttyShift);
+    m.diglOffset = o.value("diglOffset").toInt(m.diglOffset);
+    m.diguOffset = o.value("diguOffset").toInt(m.diguOffset);
+    return m;
+}
+
+}  // namespace
+
+QByteArray LocalMemoryStore::serialize(const QMap<int, MemoryEntry>& memories,
+                                       const QString& savedAtIso)
+{
+    QJsonObject root;
+    root["format"] = kFormatId;
+    root["version"] = kFormatVersion;
+    if (!savedAtIso.isEmpty())
+        root["savedAt"] = savedAtIso;
+    root["savedBy"] = "AetherSDR";
+
+    // QMap iterates in key order, so the array comes out sorted by slot index.
+    QJsonArray arr;
+    for (auto it = memories.constBegin(); it != memories.constEnd(); ++it) {
+        MemoryEntry entry = it.value();
+        entry.index = it.key();   // the map key is authoritative
+        arr.append(entryToJson(entry));
+    }
+    root["memories"] = arr;
+
+    return QJsonDocument(root).toJson(QJsonDocument::Indented);
+}
+
+LocalMemoryStore::ParseResult LocalMemoryStore::parse(const QByteArray& bytes)
+{
+    ParseResult result;
+
+    // An empty file is an empty bank, not a corrupt one. Treating it as an
+    // error would make a zero-byte file left by a full disk look like data
+    // loss the operator has to act on.
+    if (bytes.trimmed().isEmpty())
+        return result;
+
+    QJsonParseError perr;
+    const QJsonDocument doc = QJsonDocument::fromJson(bytes, &perr);
+    if (doc.isNull()) {
+        result.errors << QString("Invalid JSON: %1").arg(perr.errorString());
+        return result;
+    }
+    if (!doc.isObject()) {
+        result.errors << QStringLiteral("Top-level JSON is not an object");
+        return result;
+    }
+
+    const QJsonObject root = doc.object();
+    const QString format = root.value("format").toString();
+    if (!format.isEmpty() && format != QLatin1String(kFormatId))
+        result.errors << QString("Unexpected format \"%1\"").arg(format);
+
+    result.version = root.value("version").toInt(0);
+    if (result.version > kFormatVersion) {
+        // Fail the whole read. Parsing what this build understands and then
+        // saving over the file would silently delete every field a newer
+        // version added.
+        result.errors << QString("File version %1 is newer than supported version %2")
+                             .arg(result.version)
+                             .arg(kFormatVersion);
+        return result;
+    }
+
+    const QJsonArray arr = root.value("memories").toArray();
+    for (const QJsonValue& v : arr) {
+        if (!v.isObject())
+            continue;
+        const MemoryEntry entry = entryFromJson(v.toObject());
+        // A slot with no usable index has no handle the UX could address it by,
+        // and silently renumbering it would move somebody else's channel.
+        if (entry.index < 0) {
+            result.errors << QStringLiteral("Skipped a memory with no valid slot index");
+            continue;
+        }
+        if (result.memories.contains(entry.index)) {
+            result.errors << QString("Skipped a duplicate memory for slot %1")
+                                 .arg(entry.index);
+            continue;
+        }
+        result.memories.insert(entry.index, entry);
+    }
+
+    return result;
+}
+
+QString LocalMemoryStore::defaultFilePath()
+{
+    // GenericConfigLocation, matching AppSettings: a plain base dir on every
+    // platform (~/.config on Linux/macOS, %LOCALAPPDATA% on Windows) with no
+    // org/app suffix, so appending "/AetherSDR" cannot produce the triple-nested
+    // path ConfigLocation gives on Windows and macOS.
+    const QString base =
+        QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);
+    if (base.isEmpty())
+        return {};
+    return base + QStringLiteral("/AetherSDR/memories.json");
+}
+
+LocalMemoryStore::ParseResult LocalMemoryStore::load(const QString& path)
+{
+    ParseResult result;
+    if (path.isEmpty()) {
+        result.errors << QStringLiteral("No memory bank path is available");
+        return result;
+    }
+
+    QFile file(path);
+    if (!file.exists())
+        return result;   // first run — an empty bank, not a failure
+
+    if (!file.open(QIODevice::ReadOnly)) {
+        result.errors << QString("Couldn't open %1: %2").arg(path, file.errorString());
+        return result;
+    }
+    return parse(file.readAll());
+}
+
+bool LocalMemoryStore::save(const QString& path,
+                            const QMap<int, MemoryEntry>& memories,
+                            const QString& savedAtIso,
+                            QString* error)
+{
+    auto fail = [error](const QString& message) {
+        if (error)
+            *error = message;
+        return false;
+    };
+
+    if (path.isEmpty())
+        return fail(QStringLiteral("No memory bank path is available"));
+
+    const QString dir = QFileInfo(path).absolutePath();
+    if (!QDir().mkpath(dir))
+        return fail(QString("Couldn't create %1").arg(dir));
+
+    QSaveFile file(path);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate))
+        return fail(QString("Couldn't write %1: %2").arg(path, file.errorString()));
+
+    const QByteArray bytes = serialize(memories, savedAtIso);
+    if (file.write(bytes) != bytes.size()) {
+        file.cancelWriting();
+        return fail(QString("Couldn't write %1: %2").arg(path, file.errorString()));
+    }
+    if (!file.commit())
+        return fail(QString("Couldn't commit %1: %2").arg(path, file.errorString()));
+
+    if (error)
+        error->clear();
+    return true;
+}
+
+}  // namespace AetherSDR

--- a/src/core/LocalMemoryStore.h
+++ b/src/core/LocalMemoryStore.h
@@ -42,8 +42,21 @@ public:
         QMap<int, MemoryEntry> memories;
         QStringList errors;
         int version{0};
+        // The file exists but could not be UNDERSTOOD: unparseable JSON, a
+        // non-object root, a foreign format id, or a version newer than this
+        // build. Distinct from `errors`, which also carries recoverable
+        // complaints (a skipped duplicate slot, an entry with no index) where
+        // everything else in the file was read correctly.
+        //
+        // This is the flag that decides whether overwriting is safe. Anything
+        // this build could not read is somebody's data it cannot represent, so
+        // saving over it would destroy channels rather than lose a field —
+        // which is the whole reason the version check exists (see above).
+        bool unreadable{false};
 
         bool ok() const { return errors.isEmpty(); }
+        // Safe to replace this file wholesale with what we parsed?
+        bool overwritable() const { return !unreadable; }
     };
 
     // Serialize to pretty-printed JSON bytes, ordered by slot index so the file

--- a/src/core/LocalMemoryStore.h
+++ b/src/core/LocalMemoryStore.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "models/MemoryEntry.h"
+
+#include <QByteArray>
+#include <QMap>
+#include <QString>
+#include <QStringList>
+
+namespace AetherSDR {
+
+// Portable, versioned JSON persistence for the CLIENT-side memory bank — the
+// channels an operator saves on a radio that has no memory storage of its own
+// (Hermes-Lite 2, Kiwi, the demo backend). On a Flex the radio owns the slots
+// and this file is never touched; see RadioCapabilities::persistsMemories.
+//
+// Envelope:
+//   {
+//     "format": "aether.memories",
+//     "version": 1,
+//     "savedAt": "2026-07-29T14:00:00Z",
+//     "savedBy": "AetherSDR",
+//     "memories": [ { "index": 0, ...MemoryEntry... } ]
+//   }
+//
+// Evolved additively the same way the net schedule is: new fields are optional
+// with MemoryEntry's defaults, unknown fields are ignored, and a file whose
+// version is NEWER than this build is reported as an error rather than
+// half-read — a downgrade must not silently drop channels it cannot represent
+// and then write the loss back to disk.
+//
+// The slot index is stored, not derived from array position. It is the handle
+// the whole memory UX addresses a channel by (spot ids, `memory apply`, the
+// browse panel), so it has to survive a save/load cycle intact even when the
+// bank is sparse.
+class LocalMemoryStore {
+public:
+    static constexpr int kFormatVersion = 1;
+    static constexpr const char* kFormatId = "aether.memories";
+
+    struct ParseResult {
+        QMap<int, MemoryEntry> memories;
+        QStringList errors;
+        int version{0};
+
+        bool ok() const { return errors.isEmpty(); }
+    };
+
+    // Serialize to pretty-printed JSON bytes, ordered by slot index so the file
+    // stays diffable across saves. `savedAtIso` is stamped into the envelope —
+    // a parameter rather than a clock read so this stays deterministic and
+    // testable (the same reason NetScheduleStore takes one).
+    static QByteArray serialize(const QMap<int, MemoryEntry>& memories,
+                                const QString& savedAtIso = {});
+
+    static ParseResult parse(const QByteArray& bytes);
+
+    // ~/.config/AetherSDR/memories.json (and the platform equivalents), matching
+    // the GenericConfigLocation base AppSettings uses. Empty only if Qt cannot
+    // resolve a writable config location at all.
+    static QString defaultFilePath();
+
+    // Reads `path`. A missing file is NOT an error — it is an empty bank, which
+    // is what a first run looks like.
+    static ParseResult load(const QString& path);
+
+    // Atomic write via QSaveFile: the bank is only ever replaced wholesale, so a
+    // crash mid-save must leave the previous file intact rather than a truncated
+    // one. Returns false and fills `error` on failure.
+    static bool save(const QString& path,
+                     const QMap<int, MemoryEntry>& memories,
+                     const QString& savedAtIso = {},
+                     QString* error = nullptr);
+};
+
+}  // namespace AetherSDR

--- a/src/core/backends/MemoryWireCodec.cpp
+++ b/src/core/backends/MemoryWireCodec.cpp
@@ -1,0 +1,57 @@
+#include "core/backends/MemoryWireCodec.h"
+
+// The present-only + ok-guarded carry() family. It lives under flex/ because
+// the Flex status decoders were its first callers, but the contract it encodes
+// is the wire-decode contract, not a Flex one — the memory kv-set has the same
+// shape whoever produced it.
+#include "core/backends/flex/FlexKvCarry.h"
+
+namespace AetherSDR::MemoryWire {
+
+using namespace flexkv;
+
+MemoryDelta decodeStatus(int index, const QMap<QString, QString>& kvs)
+{
+    MemoryDelta d;
+    d.index = index;
+    if (kvs.value(QStringLiteral("in_use")) == QLatin1String("0")
+        || kvs.contains(QStringLiteral("removed"))) {
+        d.removed = true;
+        return d;
+    }
+
+    carry(kvs, "group", d.group);
+    carry(kvs, "owner", d.owner);
+    carry(kvs, "name", d.name);
+    carry(kvs, "mode", d.mode);
+    carry(kvs, "repeater", d.offsetDir);
+    carry(kvs, "tone_mode", d.toneMode);
+
+    carry(kvs, "freq", d.freq);
+    carry(kvs, "repeater_offset", d.repeaterOffset);
+    carry(kvs, "tone_value", d.toneValue);
+    carry(kvs, "step", d.step);
+    carry(kvs, "squelch", d.squelch);
+    carry(kvs, "squelch_level", d.squelchLevel);
+    carry(kvs, "rx_filter_low", d.rxFilterLow);
+    carry(kvs, "rx_filter_high", d.rxFilterHigh);
+    carry(kvs, "rtty_mark", d.rttyMark);
+    carry(kvs, "rtty_shift", d.rttyShift);
+    carry(kvs, "digl_offset", d.diglOffset);
+    carry(kvs, "digu_offset", d.diguOffset);
+    return d;
+}
+
+QMap<QString, QString> parseKvTail(const QString& tail)
+{
+    QMap<QString, QString> kvs;
+    for (const QString& token : tail.split(QLatin1Char(' '), Qt::SkipEmptyParts)) {
+        const int eq = token.indexOf(QLatin1Char('='));
+        if (eq <= 0)
+            continue;
+        kvs.insert(token.left(eq), token.mid(eq + 1));
+    }
+    return kvs;
+}
+
+}  // namespace AetherSDR::MemoryWire

--- a/src/core/backends/MemoryWireCodec.h
+++ b/src/core/backends/MemoryWireCodec.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "core/backends/MemoryDelta.h"
+
+#include <QMap>
+#include <QString>
+
+namespace AetherSDR {
+
+// One decoder for a memory-slot kv-set, shared by every producer of one.
+//
+// Two callers reach this: FlexBackend::decodeMemoryStatus, decoding what the
+// radio reported, and the local memory bank, decoding the `memory set` a client
+// just issued against a radio that has no memory storage of its own. They MUST
+// agree — a slot written locally and a slot read back from a Flex have to land
+// in MemoryEntry identically or the same CSV export would depend on which radio
+// happened to be connected. Keeping the decode in one place is what makes that
+// structural rather than a thing two copies are trusted to preserve.
+//
+// Contract (unchanged from the Flex decoder this was lifted from): present-only
+// — absent keys leave their optional disengaged so the model keeps the slot's
+// prior value; numerics are ok-guarded, so a malformed *present* value is
+// dropped rather than applied as 0. Text rides raw: the protocol space-encoding
+// (0x7f→' ') and the NUL/control-byte sanitisation are a models/ concern applied
+// in RadioModel::applyMemoryChanges, so this stays free of any models/ include.
+namespace MemoryWire {
+
+// Decode a memory-slot kv-set into a typed delta. `removed` is set when the
+// wire signalled the slot is gone — "in_use=0" or a bare "removed" key.
+MemoryDelta decodeStatus(int index, const QMap<QString, QString>& kvs);
+
+// Split a `memory set` argument tail ("group=Foo freq=14.074000 …") into its
+// kv-set. Safe to split on spaces: free-text fields are space-encoded (0x7f) by
+// encodeMemoryText() before they ever reach a command string, so a space in the
+// tail is always a field separator. Tokens without '=' are ignored.
+QMap<QString, QString> parseKvTail(const QString& tail);
+
+}  // namespace MemoryWire
+
+}  // namespace AetherSDR

--- a/src/core/backends/RadioCapabilities.h
+++ b/src/core/backends/RadioCapabilities.h
@@ -66,6 +66,17 @@ struct RadioCapabilities {
     // non-Flex backend must NOT open the mic on connect. (#4449 review)
     bool hostModulates = false;
 
+    // The RADIO stores memory channels and re-dumps them on connect. True for a
+    // Flex, whose memory slots live in the radio and are shared by every client
+    // attached to it; false for a direct-sampling or receiver-only backend (HL2,
+    // Kiwi, demo) that has nowhere to put them.
+    //
+    // False is the load-bearing default: a backend that says nothing gets the
+    // client-side memory bank, so an operator's channels survive rather than
+    // being written into a radio that silently drops them. A backend only sets
+    // this true when it can prove the radio gives the slots back.
+    bool persistsMemories = false;
+
     // Peripherals / features every family may or may not have
     bool canReboot = false;        // supports a client-triggered radio reboot
     bool hasTuner = false;         // antenna tuner / ATU

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -7,6 +7,7 @@
 #include "core/LogManager.h"
 #include "core/RadioConnection.h"
 #include "core/PanadapterStream.h"
+#include "core/backends/MemoryWireCodec.h"
 #include "core/backends/flex/FlexKvCarry.h"
 #include "models/ModelCapabilities.h"
 
@@ -183,6 +184,10 @@ RadioCapabilities FlexBackend::capabilities() const
     // one-line change, because the gate's test helper mirrors
     // `!connected || declared` exactly.
     caps.hasGpsLocation = true;
+    // The radio owns the memory slots and re-dumps them on every connect, so
+    // the client must NOT keep a local bank for a Flex — two stores that both
+    // believe they are authoritative would fight over slot indices.
+    caps.persistsMemories = true;
 
     // Advertise the "flex" extension namespace: the amp/tuner operate/bypass/
     // autotune verbs are now routed through invokeExtension() (#4092/#4094), and
@@ -974,42 +979,10 @@ void FlexBackend::decodeGpsStatus(const QString& rawBody)
 void FlexBackend::decodeMemoryStatus(int index, const QMap<QString, QString>& kvs)
 {
     // Memory-slot status → typed MemoryDelta (aetherd RFC 2.3 — RadioModel
-    // residual). Removal: the radio sends "in_use=0" or a bare "removed".
-    MemoryDelta d;
-    d.index = index;
-    if (kvs.value(QStringLiteral("in_use")) == QLatin1String("0")
-        || kvs.contains(QStringLiteral("removed"))) {
-        d.removed = true;
-        emit memoryChanged(d);
-        return;
-    }
-
-    // Text fields ride raw — the protocol space-encoding (0x7f→' ') and the
-    // NUL/control-byte sanitisation (MemoryFields) are a model concern applied in
-    // RadioModel::applyMemoryChanges, so the backend keeps no models/ dependency.
-    carry(kvs, "group", d.group);
-    carry(kvs, "owner", d.owner);
-    carry(kvs, "name", d.name);
-    carry(kvs, "mode", d.mode);
-    carry(kvs, "repeater", d.offsetDir);
-    carry(kvs, "tone_mode", d.toneMode);
-    // Numeric fields — ok-guarded (a malformed *present* value is dropped, so the
-    // model keeps the slot's prior value rather than clobbering it with 0). The
-    // old handler applied an unguarded toInt/toDouble (→0); the carry() guard is
-    // the same fail-closed improvement made at the slice/transmit sites.
-    carry(kvs, "freq", d.freq);
-    carry(kvs, "repeater_offset", d.repeaterOffset);
-    carry(kvs, "tone_value", d.toneValue);
-    carry(kvs, "step", d.step);
-    carry(kvs, "squelch", d.squelch);
-    carry(kvs, "squelch_level", d.squelchLevel);
-    carry(kvs, "rx_filter_low", d.rxFilterLow);
-    carry(kvs, "rx_filter_high", d.rxFilterHigh);
-    carry(kvs, "rtty_mark", d.rttyMark);
-    carry(kvs, "rtty_shift", d.rttyShift);
-    carry(kvs, "digl_offset", d.diglOffset);
-    carry(kvs, "digu_offset", d.diguOffset);
-    emit memoryChanged(d);
+    // residual). The decode itself moved to MemoryWire::decodeStatus so the
+    // local memory bank — which decodes the very same kv-set for a radio that
+    // has no memory storage of its own — cannot drift from what a Flex reports.
+    emit memoryChanged(MemoryWire::decodeStatus(index, kvs));
 }
 
 void FlexBackend::decodeProfileStatus(const QString& profileType, const QString& rawBody)

--- a/src/models/MemoryEntry.h
+++ b/src/models/MemoryEntry.h
@@ -24,6 +24,12 @@ struct MemoryEntry {
     int     rttyShift{170};
     int     diglOffset{2210};
     int     diguOffset{1500};
+
+    // Field-wise equality. The local memory bank uses it to skip re-saving a
+    // slot that did not actually change — the memory dialog re-asserts the
+    // kv-set it just sent, so without this a single edit writes the bank file
+    // twice.
+    bool operator==(const MemoryEntry&) const = default;
 };
 
 } // namespace AetherSDR

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -14,6 +14,7 @@
 #include "core/DigitalVoiceWaveformProcess.h"
 #include "core/LogManager.h"
 #include "core/MemoryFieldValues.h"
+#include "core/backends/MemoryWireCodec.h"
 #include "core/PerfTelemetry.h"
 #include "core/StreamStatus.h"
 #include "core/UdpRegistrationPolicy.h"
@@ -46,6 +47,10 @@ namespace {
 // the radio-assigned Flex stream-ids. streamId = base + panId. (Step 3 will
 // namespace this by session so ids stay unique across concurrent radios.)
 constexpr quint32 kNeutralPanStreamIdBase = 0xE1000000u;
+// Internal sentinel for a command issued to a backend that owns no command
+// plane. Not a SmartSDR protocol response code; numbered alongside
+// kProfileLoadSuppressedCommandCode (0x50000061), the other such drop.
+constexpr int kNoCommandPlaneCode = 0x50000063;
 // Waterfall ids must be distinct from pan ids: the UI routes waterfall rows by
 // PanadapterModel::wfStreamId() and spectrum frames by panStreamId().
 constexpr quint32 kNeutralWfStreamIdBase  = 0xE2000000u;
@@ -1010,6 +1015,14 @@ RadioModel::RadioModel(QObject* parent)
     qRegisterMetaType<ProfileDelta>();
     qRegisterMetaType<AmpDelta>();
     qRegisterMetaType<TunerDelta>();
+
+    // Publish the host-side memory bank once the event loop turns. Deferred
+    // rather than done here because MainWindow connects to memoryChanged AFTER
+    // constructing this model — emitting inside the ctor would reach nobody and
+    // the browse panel would sit empty until the first connect. With no radio
+    // attached yet, usesLocalMemoryBank() is true, so a Flex-only operator with
+    // an empty bank file publishes nothing and sees no change.
+    QTimer::singleShot(0, this, [this]() { publishLocalMemories(); });
 
     DigitalVoiceWaveformProcess& digitalVoiceProcess =
         DigitalVoiceWaveformProcess::instance();
@@ -3855,8 +3868,20 @@ bool RadioModel::dispatchPanBand(const QString& panId, const QString& bandKey)
 
     emit panBandAboutToDispatch(panId);
     if (!sendCommand(command)) {
-        qCWarning(lcProtocol).noquote()
-            << "RadioModel: pan band write not dispatched —" << command;
+        // The band stack is a Flex concept. On a backend with no command plane
+        // this write was never going to land — that is expected, not the #4142
+        // signature the warning exists to catch, and warning on it would fire on
+        // every band change the operator makes on an HL2. The failure signal
+        // still goes out either way: it restores the KiwiSDR mute handoff that
+        // panBandAboutToDispatch just lifted, which is needed precisely BECAUSE
+        // the write did not reach the radio.
+        if (hasCommandPlane()) {
+            qCWarning(lcProtocol).noquote()
+                << "RadioModel: pan band write not dispatched —" << command;
+        } else {
+            qCDebug(lcProtocol).noquote()
+                << "RadioModel: no command plane for the band stack, skipping" << command;
+        }
         emit panBandDispatchFailed(panId);
         return false;
     }
@@ -4238,6 +4263,11 @@ void RadioModel::onConnected()
         m_sleepInhibitor.acquire("AetherSDR connected to radio");
 
     emit connectionStateChanged(true);
+    // A Flex dumps its memory slots as status during the handshake below. A
+    // radio without any has nothing to dump, so the bank is what populates the
+    // cache — settle which store owns the session here, on the same edge, so
+    // the browse panel and the memory-spot feed come up populated either way.
+    syncMemoryStoreForSession();
     // Delay network monitor until after client gui registration
     // (pings sent before registration cause "Malformed command" on WAN)
 
@@ -5317,6 +5347,16 @@ void RadioModel::onDisconnected()
         m_memories.clear();
         emit memoriesCleared();
     }
+    // The cache is connection-scoped and just went; the bank on disk is not.
+    // Write out anything still inside the debounce window before the session
+    // that made those edits ends.
+    m_localMemories.flush();
+    // Then put the bank straight back. Host-side memories are not the radio's
+    // to take away — the Memory dialog stays open and fully usable while
+    // disconnected (Add, Import and Export are all live there), so leaving the
+    // cache empty would show an operator an empty channel list and let them
+    // import into a bank they cannot see.
+    publishLocalMemories();
     m_clientStations.clear();
     m_clientInfoMap.clear();
     // #3977: handles are radio-boot-scoped and recycled across connections —
@@ -5855,7 +5895,172 @@ void RadioModel::handleMemoryStatus(int index, const QMap<QString, QString>& kvs
     // moved to FlexBackend::decodeMemoryStatus → memoryChanged → applyMemoryChanges
     // (the model-side MemoryEntry update, text sanitisation, and emits). Thin
     // forwarder behind the seam.
-    if (m_flexBackend) m_flexBackend->decodeMemoryStatus(index, kvs);
+    if (m_flexBackend) {
+        m_flexBackend->decodeMemoryStatus(index, kvs);
+        return;
+    }
+    // No Flex backend means no decoder on the other side of the seam, and this
+    // used to be a silent no-op. The memory dialog calls it after every
+    // successful write to fold the values it just sent into the cache, so on a
+    // locally-banked radio dropping it left the UI showing a channel that never
+    // updated. Same decoder, same delta path.
+    if (usesLocalMemoryBank())
+        applyMemoryChanges(MemoryWire::decodeStatus(index, kvs));
+}
+
+bool RadioModel::usesLocalMemoryBank() const
+{
+    // While nothing is connected, no radio owns the slots, so the host bank
+    // does. This is not just tidiness: a backend object exists from startup and
+    // defaults to the Flex family, so keying off capabilities alone would call
+    // the bank unused before the operator has connected to anything — and the
+    // Memory dialog is fully usable right there, with Add, Import and Export
+    // all live. Connecting to a radio that does own its slots hands ownership
+    // back; see syncMemoryStoreForSession().
+    if (!isConnected())
+        return true;
+    return !backendCapabilities().persistsMemories;
+}
+
+std::optional<quint32> RadioModel::tryLocalMemoryCommand(
+    const QString& command, const RadioConnection::ResponseCallback& cb)
+{
+    if (!usesLocalMemoryBank())
+        return std::nullopt;
+    if (!command.startsWith(QLatin1String("memory ")))
+        return std::nullopt;
+
+    const LocalMemoryBank::CommandResult result = m_localMemories.handleCommand(command);
+    if (!result.handled)
+        return std::nullopt;
+
+    if (result.delta) {
+        applyMemoryChanges(*result.delta);
+        // applyMemoryChanges owns the space-decode and sanitisation, so read the
+        // slot back out of the cache to persist: the file then holds exactly
+        // what the UI and a CSV export see, not a second interpretation of the
+        // same kv-set.
+        if (result.delta->removed) {
+            m_localMemories.forget(result.delta->index);
+        } else if (const auto it = m_memories.constFind(result.delta->index);
+                   it != m_memories.constEnd()) {
+            m_localMemories.record(result.delta->index, it.value());
+        }
+    }
+
+    if (result.recallIndex >= 0)
+        recallLocalMemory(result.recallIndex);
+
+    const quint32 seq = m_seqCounter.fetch_add(1);
+    if (cb) {
+        // Queued, never re-entrant. On the wire a response always arrives on a
+        // later turn of the event loop, and the CSV import chains its next
+        // record from inside this callback — answering inline would recurse two
+        // frames per imported channel and blow the stack on a large file.
+        QMetaObject::invokeMethod(this, [cb, code = result.code, body = result.body]() {
+            cb(code, body);
+        }, Qt::QueuedConnection);
+    }
+    return seq;
+}
+
+void RadioModel::syncMemoryStoreForSession()
+{
+    if (usesLocalMemoryBank()) {
+        publishLocalMemories();
+        return;
+    }
+    // This radio owns its memory slots and is about to dump them. Anything the
+    // local bank published while we were disconnected has to go first: both
+    // number their slots from 0, so a leftover local slot 0 would sit in the
+    // cache pretending to be the radio's slot 0 until the dump overwrote it —
+    // and any local slot the radio doesn't have would never be overwritten at
+    // all.
+    if (!m_memories.isEmpty()) {
+        m_memories.clear();
+        emit memoriesCleared();
+    }
+}
+
+void RadioModel::publishLocalMemories()
+{
+    if (!usesLocalMemoryBank())
+        return;
+
+    m_localMemories.load();
+    const QMap<int, MemoryEntry>& stored = m_localMemories.entries();
+    if (stored.isEmpty())
+        return;
+
+    for (auto it = stored.constBegin(); it != stored.constEnd(); ++it) {
+        MemoryEntry entry = it.value();
+        entry.index = it.key();
+        m_memories.insert(it.key(), entry);
+        emit memoryChanged(it.key());
+    }
+    qCInfo(lcProtocol).noquote()
+        << "RadioModel: published" << stored.size() << "memories from the local bank";
+}
+
+void RadioModel::recallLocalMemory(int index)
+{
+    const auto it = m_memories.constFind(index);
+    if (it == m_memories.constEnd()) {
+        qCWarning(lcProtocol) << "RadioModel: local memory recall for unknown slot" << index;
+        return;
+    }
+    // `memory apply` lands on the ACTIVE slice on a Flex, so resolve the same
+    // one here. MainWindow has already made its recall target active by the
+    // time this runs. The first slice is the fallback for a single-slice
+    // backend that never marks one active — better than dropping the recall.
+    SliceModel* target = nullptr;
+    for (SliceModel* s : m_slices) {
+        if (s && s->isActive()) {
+            target = s;
+            break;
+        }
+    }
+    if (!target && !m_slices.isEmpty())
+        target = m_slices.first();
+    if (!target) {
+        qCWarning(lcProtocol) << "RadioModel: local memory recall with no slice to apply it to";
+        return;
+    }
+
+    const MemoryEntry& memory = it.value();
+
+    // These are the operator-issue setters, the same ones the panel controls
+    // call, so each emits its *CommandIssued signal and reaches the radio
+    // through the backend seam. Order matches what `memory apply` does on a
+    // Flex: mode first (it resets the filter to the mode default), then the
+    // stored filter, then frequency.
+    if (!memory.mode.isEmpty())
+        target->setMode(memory.mode);
+    if (memory.rxFilterLow != 0 || memory.rxFilterHigh != 0)
+        target->setFilterWidth(memory.rxFilterLow, memory.rxFilterHigh);
+
+    // FM repeater and tone fields have no seam route today — a non-Flex backend
+    // never sees SliceModel's Flex wire text for them. Applying them anyway
+    // keeps the model and the UI honest about what the recalled channel is; on
+    // a backend that grows FM support they will already be set.
+    if (!memory.offsetDir.isEmpty()) {
+        target->setRepeaterOffsetDir(memory.offsetDir);
+        target->setFmRepeaterOffsetFreq(std::abs(memory.repeaterOffset));
+    }
+    if (!memory.toneMode.isEmpty()) {
+        target->setFmToneMode(memory.toneMode);
+        target->setFmToneValue(QString::number(memory.toneValue, 'f', 1));
+    }
+    target->setSquelch(memory.squelch, memory.squelchLevel);
+
+    if (memory.freq > 0.0)
+        target->setFrequency(memory.freq);
+
+    qCInfo(lcProtocol).noquote().nospace()
+        << "RadioModel: recalled local memory " << index
+        << " onto slice " << target->sliceId()
+        << " freq=" << QString::number(memory.freq, 'f', 6)
+        << " mode=" << memory.mode;
 }
 
 void RadioModel::applyMemoryChanges(const MemoryDelta& d)
@@ -6308,6 +6513,17 @@ quint32 RadioModel::sendCmd(const QString& command, ResponseCallback cb)
         perf.recordPanCenterCommand();
     }
 
+    // Memory commands against a radio with no memory slots are answered by the
+    // local bank, before anything else looks at them. This is the single seam
+    // that keeps the whole memory feature working off-Flex: the dialog, the
+    // browse panel, CSV import/export, the spot feed and the automation verb
+    // all reach the radio through these four commands, so answering them here
+    // means none of them needed changing. It sits above the profile-load hold
+    // deliberately — a local bank edit is not a radio-state write and has
+    // nothing to reconcile with a profile load.
+    if (const auto seq = tryLocalMemoryCommand(command, cb))
+        return *seq;
+
     const ProfileLoadCommand profileLoad = parseProfileLoadCommand(command);
     if (profileLoad.valid) {
         const bool topologyProfile = profileLoadMayRebuildRadioTopology(profileLoad.type);
@@ -6398,6 +6614,19 @@ quint32 RadioModel::sendCmd(const QString& command, ResponseCallback cb)
 
     if (m_wanConn)
         return m_wanConn->sendCommand(command, std::move(cb));
+
+    // A backend that is not Flex or Sim owns no RadioConnection, so there is
+    // nothing to write to — invokeMethod() below would dereference null. This
+    // is reachable on the memory-recall path (MainWindow follows `memory apply`
+    // with a `slice tune`, and the tune is Flex wire text), so fail the way the
+    // rest of sendCmd's drops do: sequence 0, meaning "not dispatched".
+    if (!hasCommandPlane()) {
+        qCDebug(lcProtocol).noquote()
+            << "RadioModel: no command plane for this backend, dropping" << command;
+        if (cb)
+            cb(kNoCommandPlaneCode, QStringLiteral("this radio has no command plane"));
+        return 0;
+    }
 
     // Allocate seq on main thread, store callback locally. (#502)
     const quint32 seq = m_seqCounter.fetch_add(1);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -5386,6 +5386,15 @@ void RadioModel::onDisconnected()
         qCDebug(lcProtocol) << "RadioModel: unexpected disconnect — reconnecting in 3s";
         m_reconnectTimer.start();
     }
+
+    // Release memory-slot ownership only when the session is really over. While
+    // a reconnect is armed the radio still owns its slots, so the host bank must
+    // not start answering writes that reconnect would discard — the phantom
+    // channel described on m_sessionRadioOwnsMemories. An intentional disconnect
+    // (or no address to return to) genuinely ends the session and hands the bank
+    // back, which is the same state the app starts in.
+    if (m_intentionalDisconnect || m_lastInfo.address.isNull())
+        m_sessionRadioOwnsMemories = false;
 }
 
 void RadioModel::onConnectionError(const QString& msg)
@@ -5917,8 +5926,16 @@ bool RadioModel::usesLocalMemoryBank() const
     // Memory dialog is fully usable right there, with Add, Import and Export
     // all live. Connecting to a radio that does own its slots hands ownership
     // back; see syncMemoryStoreForSession().
+    // Disconnected: the host bank owns the slots UNLESS this session's radio
+    // does and is expected back. Keying on isConnected() alone handed ownership
+    // to the bank during any link blip — and a Flex drop does not clear
+    // m_slices, so the Memory dialog's Add stayed live, was answered by the
+    // bank, reported success, and was then wiped by
+    // syncMemoryStoreForSession() on reconnect. The channel never reached the
+    // radio and left a stray slot behind that resurfaced on every future
+    // disconnect.
     if (!isConnected())
-        return true;
+        return !m_sessionRadioOwnsMemories;
     return !backendCapabilities().persistsMemories;
 }
 
@@ -5966,6 +5983,11 @@ std::optional<quint32> RadioModel::tryLocalMemoryCommand(
 
 void RadioModel::syncMemoryStoreForSession()
 {
+    // Latch who owns the slots for THIS session, on the connect edge, before the
+    // question is asked below. Held across an unexpected drop so a blip cannot
+    // silently move ownership to the host bank mid-session.
+    m_sessionRadioOwnsMemories = isConnected() && backendCapabilities().persistsMemories;
+
     if (usesLocalMemoryBank()) {
         publishLocalMemories();
         return;
@@ -6052,6 +6074,14 @@ void RadioModel::recallLocalMemory(int index)
         target->setFmToneValue(QString::number(memory.toneValue, 'f', 1));
     }
     target->setSquelch(memory.squelch, memory.squelchLevel);
+
+    // The tuning step, applied directly rather than commanded. On a Flex the
+    // panel's follow-up `slice set N step=` round-trips through the radio and
+    // comes back as status; on a host-bank backend that command has no command
+    // plane to travel on and is dropped, so nothing was setting the step and a
+    // recalled channel tuned in whatever increment happened to be current.
+    if (memory.step > 0)
+        target->applyRecalledStepHz(memory.step);
 
     if (memory.freq > 0.0)
         target->setFrequency(memory.freq);

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -13,8 +13,10 @@
 #include "core/PanadapterStream.h"
 #include "core/SleepInhibitor.h"
 #include "core/DaxTxPolicy.h"
+#include "core/LocalMemoryBank.h"   // memory channels for a radio that has none
 #include "core/DigitalVoiceWaveformTelemetry.h"
 #include <QThread>
+#include <optional>
 #include "SliceModel.h"
 #include "MeterModel.h"
 #include "PanadapterModel.h"
@@ -412,6 +414,34 @@ public:
     void loadGlobalProfile(const QString& name);
     void buildBackend();   // RFC #4288 Route A: create + wire m_backend (Sim/Flex)
     void resetPanState();
+
+    // True when a text command issued through sendCmd() can actually reach the
+    // radio. False for a backend that owns no RadioConnection (HL2 and any
+    // other family that takes typed intents through the IRadioBackend seam) —
+    // there, Flex wire text has nowhere to go and is dropped at the sink.
+    bool hasCommandPlane() const { return m_wanConn != nullptr || m_connection != nullptr; }
+
+    // ── Local memory bank (radios with no memory slots of their own) ─────────
+    //
+    // Answer a `memory …` command out of the local bank. Returns the sequence
+    // number sendCmd() would have returned (non-zero — sendCommand() reads that
+    // as "dispatched"), or nullopt when the command is not one the bank owns
+    // and must take its normal path.
+    // (spelled out rather than the ResponseCallback alias — that is declared
+    // further down this class.)
+    std::optional<quint32> tryLocalMemoryCommand(
+        const QString& command, const RadioConnection::ResponseCallback& cb);
+    // Settle which store owns the memory cache for the session being started:
+    // the local bank, or the radio's own slots.
+    void syncMemoryStoreForSession();
+    // Push the loaded bank into m_memories, emitting per-slot memoryChanged so
+    // the browse panel and the panadapter memory-spot feed populate exactly as
+    // they do from a Flex's memory-status dump.
+    void publishLocalMemories();
+    // Apply a stored channel to the active slice. This is what `memory apply`
+    // does on a Flex; with no radio to do it, the model drives SliceModel's
+    // operator-issue setters so the change routes through the backend seam.
+    void recallLocalMemory(int index);
     void createAudioStream();
     bool ensureDaxTxStream(DaxTxRequestReason reason);
     bool prepareWsprTransmit();
@@ -449,6 +479,15 @@ public:
     // Memory channel cache
     const QMap<int, MemoryEntry>& memories() const { return m_memories; }
     void handleMemoryStatus(int index, const QMap<QString, QString>& kvs);
+
+    // True when memory channels live in a file on THIS host rather than in the
+    // radio — the HL2/Kiwi/demo case, and the disconnected case. Driven by
+    // RadioCapabilities::persistsMemories, so a new backend gets the local bank
+    // by default rather than writing channels into a radio that drops them.
+    bool usesLocalMemoryBank() const;
+    // The bank itself, for the automation bridge and tests. Empty and unread
+    // until the first local memory command or connect.
+    LocalMemoryBank& localMemoryBank() { return m_localMemories; }
     bool    lowLatencyDigital()        const { return m_lowLatencyDigital; }
     bool    hasStaticIp()     const { return m_hasStaticIp; }
     QString staticIp()        const { return m_staticIp; }
@@ -1469,6 +1508,10 @@ private:
     quint32 m_staleSessionOwnHandle{0};
     quint32 m_ownSessionHandle{0};   // this session's handle, set at registration
     QMap<int, MemoryEntry> m_memories;
+    // Backing store for m_memories when the radio has no memory slots of its
+    // own. It is always constructed but only read/written on that path, so a
+    // Flex session never touches the file.
+    LocalMemoryBank m_localMemories;
     QStringList m_globalProfiles;
     QString     m_activeGlobalProfile;
     bool        m_profileDatabaseImporting{false};

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1512,6 +1512,15 @@ private:
     // own. It is always constructed but only read/written on that path, so a
     // Flex session never touches the file.
     LocalMemoryBank m_localMemories;
+    // Does the radio THIS SESSION belongs to own its memory slots? Latched on the
+    // connect edge and held across an unexpected drop, because isConnected()
+    // alone cannot tell "never connected" from "the link blipped and a reconnect
+    // is armed" — and during a blip the Memory dialog stays fully usable, so an
+    // Add would be answered by the host bank, reported as saved, then wiped by
+    // syncMemoryStoreForSession() on reconnect, leaving a phantom channel in
+    // memories.json that reappears on every later disconnect. Cleared only when
+    // the session really ends. See usesLocalMemoryBank().
+    bool        m_sessionRadioOwnsMemories{false};
     QStringList m_globalProfiles;
     QString     m_activeGlobalProfile;
     bool        m_profileDatabaseImporting{false};

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -1438,6 +1438,9 @@ void SliceModel::applyChanges(const SliceDelta& d)
         emit fmDeviationChanged(m_fmDeviation);
     }
 
+    // (applyRecalledStepHz is defined next to the status decode on purpose: the
+    // two are the only writers of m_stepHz, and a future edit to one should see
+    // the other.)
     if (d.step.has_value() || d.stepList.has_value()) {
         bool changed = false;
         if (d.step.has_value()) {
@@ -1463,6 +1466,23 @@ void SliceModel::applyChanges(const SliceDelta& d)
         emit frequencyChanged(m_frequency);
     if (modeChanged_)   emit modeChanged(m_mode);
     if (filterChanged_) emit filterChanged(m_filterLow, m_filterHigh);
+}
+
+void SliceModel::applyRecalledStepHz(int hz)
+{
+    // Host-bank recall only — see the header for why this is the one sanctioned
+    // client-side write of a radio-authoritative field.
+    //
+    // No command is emitted: there is no wire to send it over on a backend
+    // without a command plane, which is exactly why the recalled step was being
+    // lost. stepChanged() is what the tuning-step control and the tuning wheel
+    // listen to, so the value takes effect in the UI just as a radio-sourced one
+    // would, and a later status update from a radio that does own the field
+    // still wins by overwriting it.
+    if (hz <= 0 || hz == m_stepHz)
+        return;
+    m_stepHz = hz;
+    emit stepChanged(m_stepHz, m_stepList);
 }
 
 QStringList SliceModel::drainPendingCommands()

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -138,6 +138,15 @@ public:
     bool    xitOn()       const { return m_xitOn; }
     int     xitFreq()     const { return m_xitFreq; }
     int     stepHz()      const { return m_stepHz; }
+    // HOST-BANK MEMORY RECALL ONLY — do not call this on a radio that owns its
+    // slots. Step size is radio-authoritative (AGENTS.md, Principle II): on a
+    // Flex it arrives as `slice` status and the client must never assert it, or
+    // the two fight on reconnect. On a backend with no command plane there is no
+    // radio opinion to defer to, the host bank owns the channel, and a recalled
+    // step would otherwise never take because the wire command that normally
+    // round-trips it is dropped. Named for its one caller so the exception stays
+    // visible; see RadioModel::recallLocalMemory().
+    void    applyRecalledStepHz(int hz);
     QVector<int> stepList() const { return m_stepList; }
     int     daxChannel()  const { return m_daxChannel; }
     int     rttyMark()        const { return m_rttyMark; }

--- a/tests/local_memory_bank_test.cpp
+++ b/tests/local_memory_bank_test.cpp
@@ -172,8 +172,24 @@ int main(int argc, char** argv)
         bank.setFilePath(futurePath);
         bank.load();
         ok &= expect(bank.entries().isEmpty(), "a too-new bank reads as empty");
-        ok &= expect(!bank.isLoaded(), "a too-new bank is not marked loaded");
+        // The read WAS attempted (so nothing re-reads and thrashes m_entries);
+        // what it is not, is writable. These are two facts and used to be one
+        // flag, which is what let a create/set pair fail with "no memory in
+        // slot 0" on this fixture.
+        ok &= expect(bank.isLoaded(), "a too-new bank counts as read");
+        ok &= expect(!bank.isWritable(), "a too-new bank is not writable");
         ok &= expect(!bank.lastError().isEmpty(), "a too-new bank reports why");
+
+        // A create/set PAIR — the shape every Add and CSV-import row takes. The
+        // second command must not find an empty bank because the first
+        // command's load() re-ran and cleared it.
+        const auto created = bank.handleCommand("memory create");
+        ok &= expect(created.handled, "an unreadable bank still answers");
+        ok &= expect(created.code != 0, "create is refused, not silently accepted");
+        ok &= expect(created.body.contains("could not be read"),
+                     "the refusal explains that the file is unreadable");
+        ok &= expect(!created.body.contains("no memory in slot"),
+                     "the refusal is not the misleading empty-slot error");
 
         // An edit made against it must not be written back — that would replace
         // channels this build cannot represent with the empty bank it read.
@@ -198,33 +214,37 @@ int main(int argc, char** argv)
         bank.flush();
         ok &= expect(QFile::exists(noopPath), "the first record saved");
 
-        // Overwrite the file with a sentinel. A rewrite would destroy it —
-        // deterministic where comparing mtimes would depend on filesystem
-        // timestamp granularity.
-        {
-            QFile f(noopPath);
-            ok &= expect(f.open(QIODevice::WriteOnly | QIODevice::Truncate),
-                         "sentinel written over the bank file");
-            f.write("sentinel");
-        }
+        // Snapshot the file's CONTENT rather than overwriting it with a
+        // sentinel. The sentinel trick was an external write to the bank's own
+        // file, which the concurrent-writer guard in flush() now (correctly)
+        // refuses to clobber — so it would have measured that refusal instead of
+        // the no-op logic it is actually about. Content comparison tests the same
+        // property and stays independent of filesystem timestamp granularity,
+        // which was the original reason for avoiding mtimes.
+        auto contentOf = [&](const QString& p) {
+            QFile f(p);
+            return f.open(QIODevice::ReadOnly) ? f.readAll() : QByteArray("<unreadable>");
+        };
+        const QByteArray afterFirstSave = contentOf(noopPath);
+        ok &= expect(afterFirstSave != "<unreadable>", "the saved bank is readable");
 
         // Re-asserting the same values (what the dialog does via
         // handleMemoryStatus after every successful write) must not dirty it.
         bank.record(0, entry);
         bank.flush();
-
-        QFile f(noopPath);
-        ok &= expect(f.open(QIODevice::ReadOnly), "the sentinel file is readable");
-        ok &= expect(f.readAll() == "sentinel",
+        ok &= expect(contentOf(noopPath) == afterFirstSave,
                      "re-recording identical values does not rewrite the file");
 
-        // A real change still saves.
+        // A real change still saves. The envelope carries a savedAt stamp, so a
+        // rewrite is visible even if the entry diff were somehow byte-identical.
         entry.freq = 21.075;
         bank.record(0, entry);
         bank.flush();
-        QFile changed(noopPath);
-        ok &= expect(changed.open(QIODevice::ReadOnly), "the rewritten file is readable");
-        ok &= expect(changed.readAll() != "sentinel", "a changed value does rewrite the file");
+        const QByteArray afterChange = contentOf(noopPath);
+        ok &= expect(afterChange != afterFirstSave, "a changed value does rewrite the file");
+        ok &= expect(afterChange.contains("21.075"), "the rewrite carries the new value");
+        ok &= expect(bank.lastError().isEmpty(),
+                     "a legitimate consecutive save is not mistaken for a foreign write");
     }
 
     // --- a CSV-import-shaped run of many records --------------------------
@@ -269,6 +289,110 @@ int main(int argc, char** argv)
         reopened.load();
         ok &= expect(reopened.entries().size() == kRecords,
                      "the whole bulk bank round-trips through the file");
+    }
+
+    // --- an UNPARSEABLE bank is never overwritten --------------------------
+    //
+    // The version guard covered the unlikely case. "We could not read this file
+    // at all" was unprotected: load() marked the bank writable anyway, so the
+    // next flush() replaced a damaged file with the empty bank parsed out of it.
+    {
+        struct Case { const char* what; QByteArray bytes; };
+        const QList<Case> cases = {
+            {"truncated JSON",
+             QByteArray(R"({"format":"aether.memories","version":1,"memories":[{"index":0,)")},
+            {"a JSON array at the root",
+             QByteArray(R"([{"index":0,"freq":7.2}])")},
+            {"a foreign format id",
+             QByteArray(R"({"format":"someone.else","version":1,
+                            "memories":[{"index":0,"freq":7.2,"name":"Theirs"}]})")},
+        };
+
+        for (int ci = 0; ci < cases.size(); ++ci) {
+            const Case& c = cases.at(ci);
+            const QString p = dir.path() + QString("/damaged-%1.json").arg(ci);
+            {
+                QFile f(p);
+                ok &= expect(f.open(QIODevice::WriteOnly), "damaged fixture written");
+                f.write(c.bytes);
+            }
+
+            LocalMemoryBank bank;
+            bank.setFilePath(p);
+            bank.load();
+            ok &= expect(!bank.isWritable(), c.what);
+            // The foreign-format case also must not ADOPT the memories it parsed
+            // out of somebody else's file.
+            ok &= expect(bank.entries().isEmpty(),
+                         "an unreadable bank exposes no channels");
+
+            bank.record(0, MemoryEntry{});
+            bank.flush();
+
+            QFile f(p);
+            ok &= expect(f.open(QIODevice::ReadOnly), "the damaged fixture still opens");
+            ok &= expect(f.readAll() == c.bytes,
+                         "a damaged bank is left byte-for-byte intact");
+        }
+    }
+
+    // --- a concurrent writer is detected, not clobbered --------------------
+    //
+    // The bank is replaced wholesale and read once per process, so two instances
+    // sharing a config dir used to silently discard each other's channels.
+    {
+        const QString p = dir.path() + "/shared.json";
+
+        LocalMemoryBank first;
+        first.setFilePath(p);
+        first.handleCommand("memory create");
+        first.flush();
+        ok &= expect(QFile::exists(p), "the first instance saved");
+
+        // A second process writes its own channels behind our back.
+        const QByteArray theirs = LocalMemoryStore::serialize(
+            [] {
+                QMap<int, MemoryEntry> m;
+                MemoryEntry e;
+                e.index = 5;
+                e.freq = 14.074;
+                e.name = "Theirs";
+                m.insert(5, e);
+                return m;
+            }(),
+            "2026-07-30T00:00:00Z");
+        {
+            QFile f(p);
+            ok &= expect(f.open(QIODevice::WriteOnly | QIODevice::Truncate),
+                         "the other instance wrote the shared bank");
+            f.write(theirs);
+        }
+
+        // Our next edit must NOT replace their file.
+        first.record(1, MemoryEntry{});
+        first.flush();
+
+        QFile f(p);
+        ok &= expect(f.open(QIODevice::ReadOnly), "the shared bank still opens");
+        ok &= expect(f.readAll() == theirs,
+                     "a foreign write is not clobbered by our flush");
+        ok &= expect(first.lastError().contains("changed by another"),
+                     "the refusal names the concurrent-write reason");
+
+        // And our own save must re-baseline, or the very next flush would
+        // mistake our own mtime for somebody else's and refuse forever.
+        LocalMemoryBank fresh;
+        fresh.setFilePath(p);
+        fresh.load();
+        fresh.record(9, MemoryEntry{});
+        fresh.flush();
+        fresh.record(10, MemoryEntry{});
+        fresh.flush();
+        LocalMemoryBank reread;
+        reread.setFilePath(p);
+        reread.load();
+        ok &= expect(reread.entries().contains(9) && reread.entries().contains(10),
+                     "consecutive flushes both land after a clean load");
     }
 
     if (ok)

--- a/tests/local_memory_bank_test.cpp
+++ b/tests/local_memory_bank_test.cpp
@@ -1,0 +1,277 @@
+#include "core/LocalMemoryBank.h"
+#include "core/LocalMemoryStore.h"
+
+#include <QCoreApplication>
+#include <QFile>
+#include <QTemporaryDir>
+
+#include <iostream>
+
+using namespace AetherSDR;
+
+namespace {
+
+bool expect(bool condition, const char* message)
+{
+    if (!condition)
+        std::cerr << "FAIL: " << message << '\n';
+    return condition;
+}
+
+// The kv tail the client actually builds (MemoryCommands::buildMemoryUpdateData):
+// space-encoded free text, so splitting the tail on spaces is unambiguous.
+QString setTail(int index, const QString& name, double freqMhz, const QString& mode)
+{
+    return QString("memory set %1 group=Default owner=KI6BCJ freq=%2 name=%3 mode=%4 step=100")
+        .arg(index)
+        .arg(freqMhz, 0, 'f', 6)
+        .arg(QString(name).replace(' ', QChar(0x7f)))
+        .arg(mode);
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    bool ok = true;
+
+    QTemporaryDir dir;
+    ok &= expect(dir.isValid(), "temp dir created");
+    const QString path = dir.path() + "/memories.json";
+
+    // --- slot allocation --------------------------------------------------
+    {
+        LocalMemoryBank bank;
+        bank.setFilePath(path);
+
+        const auto first = bank.handleCommand("memory create");
+        ok &= expect(first.handled, "create is handled");
+        ok &= expect(first.code == 0, "create succeeds");
+        ok &= expect(first.body == "0", "the first slot is 0");
+        ok &= expect(first.delta.has_value() && first.delta->index == 0,
+                     "create yields a delta for the new slot");
+
+        const auto second = bank.handleCommand("memory create");
+        ok &= expect(second.body == "1", "the second slot is 1");
+
+        // Freeing a hole and re-creating must reuse it rather than grow the
+        // numbering — the slot number is what the browse panel shows.
+        const auto removed = bank.handleCommand("memory remove 0");
+        ok &= expect(removed.handled && removed.code == 0, "remove succeeds");
+        ok &= expect(removed.delta.has_value() && removed.delta->removed,
+                     "remove yields a removal delta");
+        ok &= expect(bank.handleCommand("memory create").body == "0",
+                     "the freed slot is reused");
+    }
+
+    // --- set / apply ------------------------------------------------------
+    {
+        LocalMemoryBank bank;
+        bank.setFilePath(dir.path() + "/set.json");
+        bank.handleCommand("memory create");
+
+        const auto set = bank.handleCommand(setTail(0, "Bay Net", 14.074, "DIGU"));
+        ok &= expect(set.handled && set.code == 0, "set on an existing slot succeeds");
+        ok &= expect(set.delta.has_value(), "set yields a delta");
+        ok &= expect(set.delta->freq.has_value() && *set.delta->freq == 14.074,
+                     "the delta carries the frequency");
+        ok &= expect(set.delta->mode.value_or(QString()) == "DIGU",
+                     "the delta carries the mode");
+        // Text rides raw — the 0x7f decode belongs to RadioModel, not here.
+        ok &= expect(set.delta->name.value_or(QString()).contains(QChar(0x7f)),
+                     "free text is carried wire-encoded, for the model to decode");
+
+        const auto apply = bank.handleCommand("memory apply 0");
+        ok &= expect(apply.handled && apply.code == 0, "apply on an existing slot succeeds");
+        ok &= expect(apply.recallIndex == 0, "apply asks the caller to recall slot 0");
+        ok &= expect(!apply.delta.has_value(), "apply changes no stored state");
+    }
+
+    // --- rejections -------------------------------------------------------
+    {
+        LocalMemoryBank bank;
+        bank.setFilePath(dir.path() + "/reject.json");
+
+        const auto missingSet = bank.handleCommand("memory set 5 freq=7.200000");
+        ok &= expect(missingSet.handled, "a set for a missing slot is still handled");
+        ok &= expect(missingSet.code != 0, "a set for a missing slot fails");
+        ok &= expect(!missingSet.body.isEmpty(), "the failure carries a reason");
+
+        ok &= expect(bank.handleCommand("memory apply 5").code != 0,
+                     "an apply for a missing slot fails");
+        ok &= expect(bank.handleCommand("memory set x freq=7.2").code != 0,
+                     "a non-numeric id fails");
+
+        bank.handleCommand("memory create");
+        ok &= expect(bank.handleCommand("memory set 0").code != 0,
+                     "a set with no fields fails");
+
+        // Removing something already gone is NOT an error: the dialog's
+        // create→set→remove cleanup can land here after the slot went, and
+        // failing it would report a cleanup problem that does not exist.
+        ok &= expect(bank.handleCommand("memory remove 42").code == 0,
+                     "removing a missing slot succeeds");
+    }
+
+    // --- commands the bank does not own are left alone --------------------
+    {
+        LocalMemoryBank bank;
+        bank.setFilePath(dir.path() + "/passthrough.json");
+        ok &= expect(!bank.handleCommand("memory list").handled,
+                     "an unknown memory verb is not answered");
+        ok &= expect(!bank.handleCommand("slice tune 0 14.074000").handled,
+                     "a non-memory command is not answered");
+    }
+
+    // --- persistence across bank instances --------------------------------
+    {
+        const QString persistPath = dir.path() + "/persist.json";
+        MemoryEntry stored;
+        stored.freq = 7.200;
+        stored.name = "Dummy Load";   // decoded form, as RadioModel records it
+        stored.mode = "LSB";
+
+        {
+            LocalMemoryBank bank;
+            bank.setFilePath(persistPath);
+            bank.handleCommand("memory create");
+            bank.record(0, stored);
+            bank.flush();
+        }
+
+        ok &= expect(QFile::exists(persistPath), "flush wrote the bank");
+
+        LocalMemoryBank reopened;
+        reopened.setFilePath(persistPath);
+        reopened.load();
+        ok &= expect(reopened.entries().size() == 1, "the reopened bank has the slot");
+        const MemoryEntry& back = reopened.entries().value(0);
+        ok &= expect(back.freq == 7.200 && back.name == "Dummy Load" && back.mode == "LSB",
+                     "the stored channel survives a reopen");
+        ok &= expect(back.index == 0, "the slot index survives a reopen");
+
+        // A reopened bank must allocate AROUND what it loaded, not on top of it.
+        ok &= expect(reopened.handleCommand("memory create").body == "1",
+                     "create allocates past the loaded slots");
+    }
+
+    // --- a bank this build cannot read is never overwritten ----------------
+    {
+        const QString futurePath = dir.path() + "/future.json";
+        const QByteArray future =
+            R"({"format":"aether.memories","version":999,
+                "memories":[{"index":0,"freq":7.2,"name":"Precious"}]})";
+        {
+            QFile f(futurePath);
+            ok &= expect(f.open(QIODevice::WriteOnly), "future-version fixture written");
+            f.write(future);
+        }
+
+        LocalMemoryBank bank;
+        bank.setFilePath(futurePath);
+        bank.load();
+        ok &= expect(bank.entries().isEmpty(), "a too-new bank reads as empty");
+        ok &= expect(!bank.isLoaded(), "a too-new bank is not marked loaded");
+        ok &= expect(!bank.lastError().isEmpty(), "a too-new bank reports why");
+
+        // An edit made against it must not be written back — that would replace
+        // channels this build cannot represent with the empty bank it read.
+        bank.record(0, MemoryEntry{});
+        bank.flush();
+
+        QFile f(futurePath);
+        ok &= expect(f.open(QIODevice::ReadOnly), "the fixture is still readable");
+        ok &= expect(f.readAll() == future, "the unreadable bank was left untouched");
+    }
+
+    // --- record() skips a genuine no-op ------------------------------------
+    {
+        const QString noopPath = dir.path() + "/noop.json";
+        LocalMemoryBank bank;
+        bank.setFilePath(noopPath);
+        bank.handleCommand("memory create");
+
+        MemoryEntry entry;
+        entry.freq = 21.074;
+        bank.record(0, entry);
+        bank.flush();
+        ok &= expect(QFile::exists(noopPath), "the first record saved");
+
+        // Overwrite the file with a sentinel. A rewrite would destroy it —
+        // deterministic where comparing mtimes would depend on filesystem
+        // timestamp granularity.
+        {
+            QFile f(noopPath);
+            ok &= expect(f.open(QIODevice::WriteOnly | QIODevice::Truncate),
+                         "sentinel written over the bank file");
+            f.write("sentinel");
+        }
+
+        // Re-asserting the same values (what the dialog does via
+        // handleMemoryStatus after every successful write) must not dirty it.
+        bank.record(0, entry);
+        bank.flush();
+
+        QFile f(noopPath);
+        ok &= expect(f.open(QIODevice::ReadOnly), "the sentinel file is readable");
+        ok &= expect(f.readAll() == "sentinel",
+                     "re-recording identical values does not rewrite the file");
+
+        // A real change still saves.
+        entry.freq = 21.075;
+        bank.record(0, entry);
+        bank.flush();
+        QFile changed(noopPath);
+        ok &= expect(changed.open(QIODevice::ReadOnly), "the rewritten file is readable");
+        ok &= expect(changed.readAll() != "sentinel", "a changed value does rewrite the file");
+    }
+
+    // --- a CSV-import-shaped run of many records --------------------------
+    {
+        // MemoryDialog's import is a create→set chain, re-entered per record.
+        // Allocation has to keep up across the whole file: every record must
+        // land in its own slot, in order, with none reused or skipped.
+        LocalMemoryBank bank;
+        bank.setFilePath(dir.path() + "/bulk.json");
+
+        const int kRecords = 500;
+        bool allOk = true;
+        for (int i = 0; i < kRecords; ++i) {
+            const auto created = bank.handleCommand("memory create");
+            if (!created.handled || created.code != 0
+                || created.body.toInt() != i) {
+                allOk = false;
+                break;
+            }
+            const auto set = bank.handleCommand(
+                setTail(i, QString("Chan %1").arg(i), 14.0 + i * 0.001, "USB"));
+            if (!set.handled || set.code != 0)
+                allOk = false;
+            // RadioModel records the decoded entry; stand in for it here.
+            MemoryEntry entry;
+            entry.index = i;
+            entry.freq = 14.0 + i * 0.001;
+            entry.name = QString("Chan %1").arg(i);
+            entry.mode = "USB";
+            bank.record(i, entry);
+            if (!allOk)
+                break;
+        }
+        ok &= expect(allOk, "500 import-shaped records allocate sequential slots");
+        ok &= expect(bank.entries().size() == kRecords, "every record is in the bank");
+        ok &= expect(bank.entries().value(499).name == "Chan 499",
+                     "the last record survived");
+
+        bank.flush();
+        LocalMemoryBank reopened;
+        reopened.setFilePath(dir.path() + "/bulk.json");
+        reopened.load();
+        ok &= expect(reopened.entries().size() == kRecords,
+                     "the whole bulk bank round-trips through the file");
+    }
+
+    if (ok)
+        std::cout << "local_memory_bank_test: all checks passed\n";
+    return ok ? 0 : 1;
+}

--- a/tests/local_memory_store_test.cpp
+++ b/tests/local_memory_store_test.cpp
@@ -1,0 +1,191 @@
+#include "core/LocalMemoryStore.h"
+
+#include <QByteArray>
+#include <QDir>
+#include <QFile>
+#include <QTemporaryDir>
+
+#include <iostream>
+
+using namespace AetherSDR;
+
+namespace {
+
+bool expect(bool condition, const char* message)
+{
+    if (!condition)
+        std::cerr << "FAIL: " << message << '\n';
+    return condition;
+}
+
+MemoryEntry sampleMemory(int index)
+{
+    MemoryEntry m;
+    m.index = index;
+    m.group = "Local Repeaters";
+    m.owner = "KI6BCJ";
+    m.freq = 146.94;
+    m.name = "W6ABC Mt Diablo";
+    m.mode = "FM";
+    m.step = 5000;
+    m.offsetDir = "down";
+    m.repeaterOffset = 0.6;
+    m.toneMode = "ctcss_tx";
+    m.toneValue = 103.5;
+    m.squelch = true;
+    m.squelchLevel = 20;
+    m.rxFilterLow = -8000;
+    m.rxFilterHigh = 8000;
+    m.rttyMark = 2125;
+    m.rttyShift = 170;
+    m.diglOffset = 2210;
+    m.diguOffset = 1500;
+    return m;
+}
+
+}  // namespace
+
+int main()
+{
+    bool ok = true;
+
+    // --- round-trip -----------------------------------------------------
+    {
+        QMap<int, MemoryEntry> memories;
+        memories.insert(0, sampleMemory(0));
+        memories.insert(7, sampleMemory(7));
+
+        const QByteArray json =
+            LocalMemoryStore::serialize(memories, "2026-07-29T14:00:00Z");
+        const auto result = LocalMemoryStore::parse(json);
+
+        ok &= expect(result.ok(), "round-trip parses without errors");
+        ok &= expect(result.version == LocalMemoryStore::kFormatVersion,
+                     "version preserved");
+        ok &= expect(result.memories.size() == 2, "both slots round-tripped");
+        // The sparse index is the whole point: slot 7 must come back as 7.
+        ok &= expect(result.memories.contains(7), "sparse slot index preserved");
+
+        const MemoryEntry& g = result.memories.value(7);
+        ok &= expect(g == sampleMemory(7), "every MemoryEntry field preserved");
+    }
+
+    // --- the map key wins over a disagreeing index field ------------------
+    {
+        QMap<int, MemoryEntry> memories;
+        MemoryEntry stale = sampleMemory(3);
+        stale.index = 99;   // stale field, e.g. a caller that renumbered
+        memories.insert(3, stale);
+
+        const auto result = LocalMemoryStore::parse(LocalMemoryStore::serialize(memories));
+        ok &= expect(result.memories.contains(3), "serialize uses the map key");
+        ok &= expect(result.memories.value(3).index == 3, "index field rewritten to the key");
+    }
+
+    // --- tolerant parsing ------------------------------------------------
+    {
+        // Unknown future field ignored; absent fields take MemoryEntry defaults.
+        const QByteArray json = R"({
+            "format": "aether.memories",
+            "version": 1,
+            "memories": [
+                { "index": 2, "freq": 14.074, "mode": "DIGU", "futureField": 42 }
+            ]
+        })";
+        const auto result = LocalMemoryStore::parse(json);
+        ok &= expect(result.ok(), "tolerant parse of a minimal entry");
+        ok &= expect(result.memories.size() == 1, "minimal entry parsed");
+        const MemoryEntry& m = result.memories.value(2);
+        ok &= expect(m.freq == 14.074 && m.mode == "DIGU", "stated fields parsed");
+        ok &= expect(m.step == 100, "absent step takes the MemoryEntry default");
+        ok &= expect(m.rttyMark == 2125, "absent rttyMark takes the MemoryEntry default");
+    }
+
+    // --- an empty file is an empty bank, not a corrupt one -----------------
+    {
+        ok &= expect(LocalMemoryStore::parse("").ok(), "empty bytes parse clean");
+        ok &= expect(LocalMemoryStore::parse("   \n").ok(), "whitespace-only parses clean");
+        ok &= expect(LocalMemoryStore::parse("").memories.isEmpty(), "empty bytes give no slots");
+    }
+
+    // --- error handling ----------------------------------------------------
+    {
+        ok &= expect(!LocalMemoryStore::parse("{ not json ").ok(),
+                     "malformed JSON reports an error");
+        ok &= expect(!LocalMemoryStore::parse("[1,2,3]").ok(),
+                     "non-object top level reports an error");
+
+        const QByteArray wrongFormat =
+            R"({"format":"aether.netschedule","version":1,"memories":[]})";
+        ok &= expect(!LocalMemoryStore::parse(wrongFormat).ok(),
+                     "a different format id reports an error");
+
+        // A newer version must fail the WHOLE read. Parsing what we understand
+        // and saving over it would delete the fields we do not.
+        const QByteArray future =
+            R"({"format":"aether.memories","version":999,
+                "memories":[{"index":0,"freq":7.2}]})";
+        const auto futureResult = LocalMemoryStore::parse(future);
+        ok &= expect(!futureResult.ok(), "a newer version reports an error");
+        ok &= expect(futureResult.memories.isEmpty(),
+                     "a newer version yields no slots rather than a partial read");
+        ok &= expect(futureResult.version == 999, "the newer version is reported back");
+    }
+
+    // --- malformed rows are skipped, not silently renumbered ---------------
+    {
+        const QByteArray json = R"({
+            "format": "aether.memories",
+            "version": 1,
+            "memories": [
+                { "index": 0, "freq": 7.2 },
+                { "freq": 14.2 },
+                { "index": -1, "freq": 21.2 },
+                { "index": 0, "freq": 28.2 }
+            ]
+        })";
+        const auto result = LocalMemoryStore::parse(json);
+        ok &= expect(!result.ok(), "skipped rows are reported");
+        ok &= expect(result.memories.size() == 1, "only the valid row is kept");
+        ok &= expect(result.memories.value(0).freq == 7.2,
+                     "the duplicate does not overwrite the first slot");
+    }
+
+    // --- file load / save --------------------------------------------------
+    {
+        QTemporaryDir dir;
+        ok &= expect(dir.isValid(), "temp dir created");
+        const QString path = dir.path() + "/nested/memories.json";
+
+        // A missing file is a first run, not a failure.
+        const auto missing = LocalMemoryStore::load(path);
+        ok &= expect(missing.ok(), "a missing file loads clean");
+        ok &= expect(missing.memories.isEmpty(), "a missing file is an empty bank");
+
+        QMap<int, MemoryEntry> memories;
+        memories.insert(4, sampleMemory(4));
+        QString error;
+        ok &= expect(LocalMemoryStore::save(path, memories, "2026-07-29T14:00:00Z", &error),
+                     "save succeeds and creates the directory");
+        ok &= expect(error.isEmpty(), "a successful save clears the error");
+        ok &= expect(QFile::exists(path), "the file is on disk");
+
+        const auto reloaded = LocalMemoryStore::load(path);
+        ok &= expect(reloaded.ok(), "reload parses clean");
+        ok &= expect(reloaded.memories.value(4) == sampleMemory(4),
+                     "the slot survives a save/load cycle");
+    }
+
+    // --- an unwritable path fails loudly rather than silently --------------
+    {
+        QString error;
+        const bool saved = LocalMemoryStore::save(
+            QString(), QMap<int, MemoryEntry>{}, QString(), &error);
+        ok &= expect(!saved, "an empty path fails");
+        ok &= expect(!error.isEmpty(), "the failure reports a reason");
+    }
+
+    if (ok)
+        std::cout << "local_memory_store_test: all checks passed\n";
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## What

Memory channels only ever worked on a Flex. The slots live in the radio there, and the whole memory feature is built on four commands the client sends it — `memory create`, `memory set`, `memory remove`, `memory apply`. On a Hermes-Lite 2 those go to a command plane the backend does not own, get dropped, and nothing comes back: saving a channel did nothing, the browse panel stayed empty, and the memory-spot feed had no memories to draw.

This stores them on the host instead, so the entire existing memory UX works on an HL2 — **with no changes to the memory dialog, the browse panel, the CSV codec, or the spot feed**.

## How

Chosen by capability, not family name. `RadioCapabilities::persistsMemories` defaults to **false**, so a backend gets the local bank by saying nothing — the safe direction, since the alternative is writing an operator's channels into a radio that drops them. `FlexBackend` sets it true.

|  | Flex | HL2 / Kiwi / demo / not connected |
|---|---|---|
| `persistsMemories` | `true` | `false` (default) |
| Slots live in | the radio | `~/.config/AetherSDR/memories.json` |
| Populated by | radio memory status on connect | `RadioModel::publishLocalMemories()` |

Three pieces and one seam:

- **`LocalMemoryStore`** — versioned JSON (`aether.memories` v1), atomic via `QSaveFile`, sparse slot indices preserved. A file newer than this build fails the whole read and is never written back, so a downgrade cannot quietly delete fields it does not understand.
- **`LocalMemoryBank`** — owns the slots, allocates the lowest free index, answers the four commands, debounces saves.
- **`RadioModel::tryLocalMemoryCommand()`** — the seam, in `sendCmd()`. Every memory path funnels through those four commands, so answering them there is what let everything above keep working untouched.

Two orderings are load-bearing:

1. The bank persists what `applyMemoryChanges()` produced, not the incoming kv-set — that method owns the `0x7f`→space decode and the control-byte sanitisation, so storing its output keeps the file identical to what the UI and a CSV export see.
2. Both stores number slots from 0, so `syncMemoryStoreForSession()` clears the cache when connecting to a radio that owns its slots — a local slot 0 published while disconnected cannot masquerade as the radio's.

The bank is also the store while **nothing is connected**. The Memory dialog is fully usable there (Add, Import and Export are all live), so leaving the cache empty would show an operator an empty channel list and let them import into a bank they could not see.

`memory apply` has no radio to apply it, so `recallLocalMemory()` drives SliceModel's operator-issue setters — the same path the panel controls use, so the write reaches the radio through the backend seam.

## Two things found on the way

- `sendCmd()` called `QMetaObject::invokeMethod()` on a **null RadioConnection** for any backend that owns none. Now guarded, returning sequence 0 the way its other drops do. `dispatchPanBand()` logs at debug rather than warning when there is no command plane — the band stack is a Flex concept, and warning fired on every HL2 band change.
- The memory kv-set decode is now `MemoryWire::decodeStatus()`, shared by `FlexBackend` and the bank, so a channel saved locally and one read back from a Flex cannot land in `MemoryEntry` differently.

## Proof — Hermes-Lite 2, gateware 74, over the automation bridge

Saved a channel through the **real Save Memory dialog** (not a bridge shortcut):

![Save Memory dialog](https://raw.githubusercontent.com/jensenpat/AetherSDR/assets/local-memory-store/pr-save.png)

Recalled it from 10.136 MHz and the HL2 switched its band filter — the recall reached the **hardware**, not just the model:

```
RadioModel: recalled local memory 0 onto slice 0 freq=14.074000 mode=USB
HL2 band filter: "0x48" (HPF + 30/20m LPF) for "14.074000" MHz — was "0x44", trigger=tune
```

Survived a full app restart and repopulated the browse panel:

![Memory browse panel after restart](https://raw.githubusercontent.com/jensenpat/AetherSDR/assets/local-memory-store/pr-panel.png)

Rendered as a memory spot on the panadapter:

![Memory spot on the panadapter](https://raw.githubusercontent.com/jensenpat/AetherSDR/assets/local-memory-store/pr-spot.png)

And present with **no radio connected at all** — the gap this PR also fixes:

![Memory dialog with no radio connected](https://raw.githubusercontent.com/jensenpat/AetherSDR/assets/local-memory-store/pr-dialog.png)

## Tests

- `local_memory_store_test` — round-trip, sparse indices, tolerant parse, version refusal, malformed-row skipping, atomic file I/O.
- `local_memory_bank_test` — slot allocation and reuse, rejections, persistence across instances, refusing to overwrite an unreadable bank, and a 500-record import-shaped run.

196/197 suite passes. `hl2_tx_loopback_test` fails **identically on the unmodified base** (verified by stashing this branch and rebuilding) — pre-existing, unrelated.

## CSV import verified by the maintainer

A real SmartSDR CSV backup was imported through the Memory dialog on this build and came in clean — every row, correct names, no rejected records. That was the one path automation could not reach, so it is now covered by an operator run against actual backup data rather than by a synthetic stand-in.

The bank-level 500-record test still guards the same chain in CI.

## Not covered

The Memory dialog's **Import…/Export… use native file dialogs**, which the automation bridge cannot drive — so the CSV flows have no *automated* regression test, only the maintainer run above plus the bank-level chain test. `docs/automation-bridge.md` now proposes `memory save|list|remove|import|export` to close that gap.

Also untested against a real Flex — none on the network at the time. The Flex path is unchanged apart from `persistsMemories = true` and the shared decoder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

