### PR TITLE
fix(demo): give the sim CW channel's Morse id standard element spacing

### DIFF
--- a/src/core/backends/sim/NoiseMixer.cpp
+++ b/src/core/backends/sim/NoiseMixer.cpp
@@ -159,28 +159,56 @@ QVector<float> NoiseMixer::applyNotch(const QVector<float>& in, double fHz, doub
 // ---- generators ---------------------------------------------------------------
 void NoiseMixer::genCw(const ChannelState& c, float* out)
 {
-    // A keyed CW id (dit/dah pattern) with raised-cosine edges (no key clicks).
+    // Keys the CW id in real Morse — 18 WPM, standard 1/3/7-dit
+    // element/character/word spacing, raised-cosine edges (no key clicks) — so
+    // the demo CW channel is decodable by ear, by CwDecoder, or by an external
+    // decoder fed over TCI. The schedule is built from kMsg, so a longer id
+    // (e.g. "CQ CQ DE AETHER") is a one-line change.
     const double hz = c.hz > 0 ? c.hz : 700.0;
     const double wpm = 18.0, dit = 1.2 / wpm;
-    static const int elems[] = {1, 3, 1, 1, 3, 0, 0};  // ·—·· + gaps
-    double total = 0.0;
-    for (int e : elems) total += (e ? e : 1) * dit;
+    struct Span { double on, off; };            // one key-down interval, in dits
+    struct Schedule { std::vector<Span> spans; double total = 0.0; };
+    static const Schedule sched = [] {
+        static const char* kMsg = "L";              // ·—·· — the original id
+        auto code = [](char ch) -> const char* {
+            switch (ch) {
+                case 'A': return ".-";   case 'C': return "-.-.";
+                case 'D': return "-..";  case 'E': return ".";
+                case 'H': return "...."; case 'L': return ".-..";
+                case 'Q': return "--.-"; case 'R': return ".-.";
+                case 'T': return "-";
+                default:  return "";
+            }
+        };
+        Schedule s;
+        double t = 0.0;
+        for (const char* p = kMsg; *p; ++p) {
+            if (*p == ' ') { t += 4.0; continue; }     // char gap 3 + 4 = 7-dit word gap
+            for (const char* e = code(*p); *e; ++e) {
+                const double dur = (*e == '-') ? 3.0 : 1.0;
+                s.spans.push_back({t, t + dur});
+                t += dur + 1.0;                        // element + 1-dit element gap
+            }
+            t += 2.0;                                  // element gap 1 + 2 = 3-dit char gap
+        }
+        s.total = t + 4.0;                             // loop restart = 7-dit word gap
+        return s;
+    }();
+    const int nSpans = static_cast<int>(sched.spans.size());
     for (int i = 0; i < kFrameLen; ++i) {
         const double tt = static_cast<double>(m_cwPhase + i) / kSampleRate;
-        const double pos = std::fmod(tt, total);
-        double acc = 0.0, key = 0.0;
-        for (int e : elems) {
-            const double dur = (e ? e : 1) * dit;
-            if (pos >= acc && pos < acc + dur) {
-                if (e) {
-                    key = 1.0;
-                    const double edge = 0.005, into = pos - acc, left = acc + dur - pos;
-                    if (into < edge)      key = 0.5 - 0.5 * std::cos((kTwoPi / 2.0) * into / edge);
-                    else if (left < edge) key = 0.5 - 0.5 * std::cos((kTwoPi / 2.0) * left / edge);
-                }
-                break;
-            }
-            acc += dur;
+        const double pos = std::fmod(tt, sched.total * dit);
+        if (pos < m_cwPos) m_cwSpan = 0;               // new message cycle
+        m_cwPos = pos;
+        while (m_cwSpan < nSpans && pos >= sched.spans[m_cwSpan].off * dit) ++m_cwSpan;
+        double key = 0.0;
+        if (m_cwSpan < nSpans && pos >= sched.spans[m_cwSpan].on * dit) {
+            const double start = sched.spans[m_cwSpan].on * dit;
+            const double end   = sched.spans[m_cwSpan].off * dit;
+            key = 1.0;
+            const double edge = 0.005, into = pos - start, left = end - pos;
+            if (into < edge)      key = 0.5 - 0.5 * std::cos((kTwoPi / 2.0) * into / edge);
+            else if (left < edge) key = 0.5 - 0.5 * std::cos((kTwoPi / 2.0) * left / edge);
         }
         out[i] = static_cast<float>(key * std::sin(kTwoPi * hz * tt));
     }

--- a/src/core/backends/sim/NoiseMixer.h
+++ b/src/core/backends/sim/NoiseMixer.h
@@ -145,7 +145,10 @@ private:
     std::map<Channel, ChannelState> m_ch;
 
     // phase counters (deterministic tone/buzz generators)
-    long m_cwPhase = 0, m_plPhase = 0;
+    qint64 m_cwPhase = 0;      // sample counter; long overflows in ~25 h on LLP64
+    int    m_cwSpan  = 0;      // current schedule span (persistent, no per-sample rescan)
+    double m_cwPos   = 0.0;    // last in-cycle position, for wrap detection
+    long m_plPhase = 0;
     // Voice playback: the bundled speech clip's samples (mono float, 24 kHz),
     // loaded once, and the loop read position.
     std::vector<float> m_voiceSamples;

--- a/tests/noise_mixer_test.cpp
+++ b/tests/noise_mixer_test.cpp
@@ -190,7 +190,7 @@ void testCwKeysDecodableMorse()
     QVector<double> env;
     for (int i = 0; i + blk <= audio.size(); i += blk) {
         double acc = 0.0;
-        for (int j = 0; j < blk; ++j) acc += audio[i + j] * audio[i + j];
+        for (int j = 0; j < blk; ++j) acc += static_cast<double>(audio[i + j]) * audio[i + j];
         env.append(std::sqrt(acc / blk));
     }
     double emax = 0.0;

--- a/tests/noise_mixer_test.cpp
+++ b/tests/noise_mixer_test.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <map>
 
 using AetherSDR::NoiseMixer;
 using Channel = NoiseMixer::Channel;
@@ -171,6 +172,67 @@ void testNoiseBlankerKnocksDownImpulses()
     report("noise blanker knocks down impulse peaks", on < off * 0.6);
 }
 
+// The CW channel must key REAL Morse (the voice channel's analogue: genuine
+// content a decoder can read). This test does NOT mirror genCw's schedule —
+// it envelope-detects the audio, classifies mark/space runs by duration, and
+// decodes them through its own independent Morse table. It fails on the old
+// gap-less keying (one fused 9-dit tone) and passes only if the audio reads
+// the intended id — repeating "L" with word gaps between repeats.
+void testCwKeysDecodableMorse()
+{
+    NoiseMixer mx;
+    mx.setEnabled(Channel::Cw, true);
+
+    // ~20 s of audio (>2 full message cycles), envelope in 1 ms blocks.
+    QVector<float> audio;
+    for (int f = 0; f < 3750; ++f) audio += mx.mixFrame();
+    const int blk = NoiseMixer::kSampleRate / 1000;
+    QVector<double> env;
+    for (int i = 0; i + blk <= audio.size(); i += blk) {
+        double acc = 0.0;
+        for (int j = 0; j < blk; ++j) acc += audio[i + j] * audio[i + j];
+        env.append(std::sqrt(acc / blk));
+    }
+    double emax = 0.0;
+    for (double e : env) emax = std::max(emax, e);
+    const double thresh = emax * 0.5;
+
+    // Mark/space run lengths in ms.
+    struct Run { bool on; int ms; };
+    QVector<Run> runs;
+    for (double e : env) {
+        const bool on = e > thresh;
+        if (!runs.isEmpty() && runs.last().on == on) ++runs.last().ms;
+        else runs.append({on, 1});
+    }
+    if (runs.size() > 2) { runs.removeFirst(); runs.removeLast(); }  // partial edges
+
+    // Independent decode: dit at 18 WPM = 66.7 ms; mark <2 dits = dit; space
+    // >=5 dits = word gap, >=2 = char gap.
+    const double dit = 1200.0 / 18.0;
+    QString text, sym;
+    auto flush = [&](bool word) {
+        static const std::map<QString, QChar> kMorse = {
+            {".-", 'A'}, {"-.-.", 'C'}, {"-..", 'D'}, {".", 'E'},
+            {"....", 'H'}, {".-..", 'L'}, {"--.-", 'Q'}, {".-.", 'R'},
+            {"-", 'T'}};
+        if (!sym.isEmpty()) {
+            const auto it = kMorse.find(sym);
+            text += (it != kMorse.end()) ? it->second : QChar('?');
+            sym.clear();
+        }
+        if (word && !text.isEmpty() && !text.endsWith(' ')) text += ' ';
+    };
+    for (const Run& r : runs) {
+        if (r.on) sym += (r.ms < 2.0 * dit) ? '.' : '-';
+        else if (r.ms >= 5.0 * dit) flush(true);
+        else if (r.ms >= 2.0 * dit) flush(false);
+    }
+    flush(false);
+    report("cw channel decodes as repeating \"L\" id",
+           text.contains(QStringLiteral("L L L")));
+}
+
 void testLevelScalesNoiseHeight()
 {
     auto top = [](double lvl) {
@@ -197,6 +259,7 @@ int main(int argc, char** argv)
     testLevelScalesNoiseHeight();
     testNoiseBlankerKnocksDownImpulses();
     testVoiceChannelSafeWithoutClip();
+    testCwKeysDecodableMorse();
     std::printf("\n%s\n", g_failed == 0 ? "ALL PASS" : "FAILURES ABOVE");
     return g_failed == 0 ? 0 : 1;
 }


### PR DESCRIPTION
Fixes #4593

## What

`genCw()`'s element table conflated duration with key state — every non-zero entry keyed, so the 1-dit inter-element gaps were missing and the trailing `3` (the intended character gap) keyed as a fifth dah, rendering one continuous ~600 ms tone (per the agent's root-cause analysis on #4593).

The schedule is now built once from a message string with standard 1/3/7-dit element/character/word spacing — key state explicit per span — keeping 18 WPM, the 700 Hz default pitch, and the 5 ms raised-cosine edges. The channel keys the intended repeating `L` (`·—··`).

Both implementation notes from the issue analysis are incorporated: the schedule is built from a char→pattern map (not a hand-written span list), and a persistent span cursor advances with `m_cwPhase` instead of a per-sample rescan. `m_cwPhase` is now `qint64` (the `long`-on-LLP64 ~25 h overflow noted there).

## Test

The new unit test does not mirror `genCw`'s schedule: it envelope-detects the generated audio, classifies mark/space runs by duration, and decodes them through its own independent Morse table. It fails against the old gap-less keying and passes only when the audio reads a repeating `L` with word gaps.

## Verification

- `noise_mixer_test`: ALL PASS with the fix; the new test FAILS against the old generator (checked both ways).
- Measured envelope runs: mark+gap = 133 ms = 2 dit units, dah+gap = 267 ms = 4 units, word gap = 8 units — exact PARIS spacing at 18 WPM (dit 66.7 ms).
- On-Mac demo session: audibly `·—··`; fldigi connected over TCI (RigCAT-free, audio via the TCI device) decodes the stream as repeating `L`, with fldigi's tracked receive speed reading 17–18 WPM. *Decode screenshot attached below (fldigi receive pane + waterfall).*

## Scope

Demo-mode-only (`SimBackend` CW channel); no protocol or hardware surface. The schedule is message-driven, so a longer id (e.g. `CQ CQ DE AETHER`) is a one-line change here plus a fuller character table — `CwxLocalKeyer`'s file-local `morseTable()` could be hoisted to a shared header for that; it can follow as a separate PR if directed.

<img width="970" height="445" alt="Screenshot 2026-07-29 at 5 37 45 PM" src="https://github.com/user-attachments/assets/3bce0b06-3185-4f66-b62c-19446d88cfed" />



Decoding client: an fldigi build with native TCI support (K5PTB fork)

— authored by agent (Claude Code) on behalf of @skerker
