### PR TITLE
Fix pre-existing stack overflow: stop embedding DssRenderer by value in WaterfallStreamState

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -6174,7 +6174,7 @@ void SpectrumWidget::saveCurrentWaterfallStreamState()
     updated.kiwiLastWaterfallCenterMhz = m_kiwiSdrLastWaterfallCenterMhz;
     updated.kiwiLastWaterfallBandwidthMhz = m_kiwiSdrLastWaterfallBandwidthMhz;
     updated.kiwiLastWaterfallFrameValid = m_kiwiSdrLastWaterfallFrameValid;
-    updated.dss = std::make_shared<DssRenderer>(std::move(m_dss));
+    *updated.dss = std::move(m_dss);
     updated.kiwiDisplayFloorDbm = m_kiwiSdrDisplayFloorDbm;
     updated.kiwiDisplayCeilDbm = m_kiwiSdrDisplayCeilDbm;
     updated.kiwiDisplayRangeValid = m_kiwiSdrDisplayRangeValid;

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1094,9 +1094,9 @@ QVariantMap SpectrumWidget::panstatsSnapshot(bool reset)
             state.waterfallHistory.allocatedBytes());
         cachedWaterfallHistoryBytes += static_cast<quint64>(
             state.waterfallSupplementalHistory.allocatedBytes());
-        dssFixedBytes += state.dss.fixedStorageBytes();
-        dssHistoryBytes += state.dss.historyStorageBytes();
-        dssCacheBytes += state.dss.cacheStorageBytes();
+        dssFixedBytes += state.dss->fixedStorageBytes();
+        dssHistoryBytes += state.dss->historyStorageBytes();
+        dssCacheBytes += state.dss->cacheStorageBytes();
         ++dssRendererCount;
     };
     accountState(m_nativeWaterfallState);
@@ -1788,12 +1788,12 @@ QVariantMap SpectrumWidget::traceDebugSnapshot()
     m[QStringLiteral("dssRows")] = m_dss.visibleRowCount();
     m[QStringLiteral("dssCapacityRows")] = m_dss.rows();
     const DssRenderer& flexDss =
-        m_kiwiSdrWaterfallActive ? m_nativeWaterfallState.dss : m_dss;
+        m_kiwiSdrWaterfallActive ? *m_nativeWaterfallState.dss : m_dss;
     m[QStringLiteral("flexDssRows")] = flexDss.visibleRowCount();
     const WaterfallStreamState* kiwiState = activeKiwiWaterfallStateConst();
     m[QStringLiteral("kiwiDssRows")] = m_kiwiSdrWaterfallActive
         ? m_dss.visibleRowCount()
-        : (kiwiState ? kiwiState->dss.visibleRowCount() : 0);
+        : (kiwiState ? kiwiState->dss->visibleRowCount() : 0);
 
     m[QStringLiteral("kiwiDisplayRangeValid")] = m_kiwiSdrDisplayRangeValid;
     m[QStringLiteral("kiwiDisplayRangeAutoRange")] =
@@ -2882,7 +2882,7 @@ void SpectrumWidget::prepareForFftPixelScaleChange()
     // rejects ambiguous in-flight rows; only its temporal filter inputs need
     // resetting. Keep Kiwi state untouched when the hidden Flex decoder changes.
     DssRenderer& flexDss = m_kiwiSdrWaterfallActive
-        ? m_nativeWaterfallState.dss
+        ? *m_nativeWaterfallState.dss
         : m_dss;
     flexDss.resetInputSmoothing();
 }
@@ -4491,11 +4491,11 @@ void SpectrumWidget::setSpectrumRenderMode(int mode) {
             ensureWaterfallHistory();
         } else {
             m_dss.setHistoryCapacityRows(0);
-            m_nativeWaterfallState.dss.setHistoryCapacityRows(0);
-            m_kiwiWaterfallState.dss.setHistoryCapacityRows(0);
+            m_nativeWaterfallState.dss->setHistoryCapacityRows(0);
+            m_kiwiWaterfallState.dss->setHistoryCapacityRows(0);
             for (auto it = m_kiwiProfileWaterfallStates.begin();
                  it != m_kiwiProfileWaterfallStates.end(); ++it) {
-                it->dss.setHistoryCapacityRows(0);
+                it->dss->setHistoryCapacityRows(0);
             }
         }
         // Force a full rebuild of the 3DSS surface + its GPU texture, and the
@@ -6174,7 +6174,7 @@ void SpectrumWidget::saveCurrentWaterfallStreamState()
     updated.kiwiLastWaterfallCenterMhz = m_kiwiSdrLastWaterfallCenterMhz;
     updated.kiwiLastWaterfallBandwidthMhz = m_kiwiSdrLastWaterfallBandwidthMhz;
     updated.kiwiLastWaterfallFrameValid = m_kiwiSdrLastWaterfallFrameValid;
-    updated.dss = std::move(m_dss);
+    updated.dss = std::make_shared<DssRenderer>(std::move(m_dss));
     updated.kiwiDisplayFloorDbm = m_kiwiSdrDisplayFloorDbm;
     updated.kiwiDisplayCeilDbm = m_kiwiSdrDisplayCeilDbm;
     updated.kiwiDisplayRangeValid = m_kiwiSdrDisplayRangeValid;
@@ -6208,7 +6208,7 @@ void SpectrumWidget::discardRetainedHistory(WaterfallStreamState& state)
     state.historySupplementalBwMhz.clear();
     state.rowsSinceRateChange = 0;
     state.live = true;
-    state.dss.setHistoryCapacityRows(0);
+    state.dss->setHistoryCapacityRows(0);
 }
 
 void SpectrumWidget::restoreCurrentWaterfallStreamState()
@@ -6306,7 +6306,7 @@ void SpectrumWidget::restoreCurrentWaterfallStreamState()
     m_kiwiSdrLastWaterfallCenterMhz = restored.kiwiLastWaterfallCenterMhz;
     m_kiwiSdrLastWaterfallBandwidthMhz = restored.kiwiLastWaterfallBandwidthMhz;
     m_kiwiSdrLastWaterfallFrameValid = restored.kiwiLastWaterfallFrameValid;
-    m_dss = std::move(restored.dss);
+    m_dss = std::move(*restored.dss);
     m_kiwiSdrDisplayFloorDbm = restored.kiwiDisplayFloorDbm;
     m_kiwiSdrDisplayCeilDbm = restored.kiwiDisplayCeilDbm;
     m_kiwiSdrDisplayRangeValid = restored.kiwiDisplayRangeValid;
@@ -11417,8 +11417,8 @@ void SpectrumWidget::pushDssRowForWaterfallStream(bool kiwiStream,
     }
 
     DssRenderer& dss = kiwiStream
-        ? activeKiwiWaterfallState().dss
-        : m_nativeWaterfallState.dss;
+        ? *activeKiwiWaterfallState().dss
+        : *m_nativeWaterfallState.dss;
     const bool live = kiwiStream
         ? activeKiwiWaterfallState().live
         : m_nativeWaterfallState.live;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -973,6 +973,9 @@ private:
         quint64 dssMeshRowGenUploaded{~0ull};
 #endif
     };
+    // #4595: this type is materialized as a stack local by save/restore; keep
+    // large fixed buffers behind indirection so this can't silently regress.
+    static_assert(sizeof(WaterfallStreamState) < 16 * 1024);
     void clearCurrentWaterfallRows();
     void resetKiwiSdrWaterfallDisplayRange();
     void resetCurrentWaterfallRowsForSize(const QSize& waterfallSize,

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -943,7 +943,7 @@ private:
         double kiwiLastWaterfallCenterMhz{0.0};
         double kiwiLastWaterfallBandwidthMhz{0.0};
         bool kiwiLastWaterfallFrameValid{false};
-        // Heap-indirected (#4423): DssRenderer embeds four fixed-size
+        // Heap-indirected (#4595): DssRenderer embeds four fixed-size
         // std::array<std::array<...>> row buffers (~800KB total). Storing it
         // by value here meant every stack-local WaterfallStreamState — e.g.
         // restoreCurrentWaterfallStreamState()'s `restored` / `updated` —

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -916,6 +916,33 @@ private:
     void schedulePanDragSettleUpdate();
     void scheduleFrequencyRangeSettleUpdate(double centerMhz, double bandwidthMhz);
     void finishFrequencyRangeSettleUpdate();
+    // Deep-copies its DssRenderer on copy but stays a cheap pointer move on
+    // move, so WaterfallStreamState keeps the value semantics QHash's
+    // copy-on-write detach expects: relocating entries on rehash never
+    // aliases two profile states onto one DssRenderer the way a bare
+    // shared_ptr<DssRenderer> would. Const accessors also restore the const
+    // propagation a raw shared_ptr member loses through
+    // `const WaterfallStreamState&`.
+    class DeepCopyDssPtr {
+    public:
+        DeepCopyDssPtr() : m_ptr(std::make_shared<DssRenderer>()) {}
+        DeepCopyDssPtr(const DeepCopyDssPtr& other)
+            : m_ptr(std::make_shared<DssRenderer>(*other.m_ptr)) {}
+        DeepCopyDssPtr(DeepCopyDssPtr&&) noexcept = default;
+        DeepCopyDssPtr& operator=(const DeepCopyDssPtr& other) {
+            m_ptr = std::make_shared<DssRenderer>(*other.m_ptr);
+            return *this;
+        }
+        DeepCopyDssPtr& operator=(DeepCopyDssPtr&&) noexcept = default;
+
+        DssRenderer& operator*() { return *m_ptr; }
+        const DssRenderer& operator*() const { return *m_ptr; }
+        DssRenderer* operator->() { return m_ptr.get(); }
+        const DssRenderer* operator->() const { return m_ptr.get(); }
+
+    private:
+        std::shared_ptr<DssRenderer> m_ptr;
+    };
     struct WaterfallStreamState {
         QImage waterfall;
         QImage waterfallSupplemental;
@@ -948,15 +975,16 @@ private:
         // by value here meant every stack-local WaterfallStreamState — e.g.
         // restoreCurrentWaterfallStreamState()'s `restored` / `updated` —
         // materialized a full ~800KB copy on the stack just to move-construct
-        // it, which could exhaust a thread's stack on its own. shared_ptr (not
-        // unique_ptr) because m_kiwiProfileWaterfallStates is a
+        // it, which could exhaust a thread's stack on its own. DeepCopyDssPtr
+        // (not a bare shared_ptr) because m_kiwiProfileWaterfallStates is a
         // QHash<QString, WaterfallStreamState>, and QHash's internal
         // rehash/detach needs the value type to stay copy-constructible; every
         // real use in this file is std::move(), so the only implicit copy is
-        // QHash relocating entries on rehash, where sharing the pointee is
-        // harmless. Always non-null: default-constructed here and on every
-        // reset via `= WaterfallStreamState{}`.
-        std::shared_ptr<DssRenderer> dss = std::make_shared<DssRenderer>();
+        // QHash relocating entries on rehash, which now deep-copies the
+        // renderer exactly as a by-value DssRenderer member would have —
+        // no aliasing between profile states. Always non-null: default-
+        // constructed here and on every reset via `= WaterfallStreamState{}`.
+        DeepCopyDssPtr dss;
         float kiwiDisplayFloorDbm{-110.0f};
         float kiwiDisplayCeilDbm{-10.0f};
         bool kiwiDisplayRangeValid{false};

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <array>
 #include <functional>
+#include <memory>
 #include <QHash>
 #include <QWidget>
 #include <QPushButton>
@@ -942,7 +943,20 @@ private:
         double kiwiLastWaterfallCenterMhz{0.0};
         double kiwiLastWaterfallBandwidthMhz{0.0};
         bool kiwiLastWaterfallFrameValid{false};
-        DssRenderer dss;
+        // Heap-indirected (#4423): DssRenderer embeds four fixed-size
+        // std::array<std::array<...>> row buffers (~800KB total). Storing it
+        // by value here meant every stack-local WaterfallStreamState — e.g.
+        // restoreCurrentWaterfallStreamState()'s `restored` / `updated` —
+        // materialized a full ~800KB copy on the stack just to move-construct
+        // it, which could exhaust a thread's stack on its own. shared_ptr (not
+        // unique_ptr) because m_kiwiProfileWaterfallStates is a
+        // QHash<QString, WaterfallStreamState>, and QHash's internal
+        // rehash/detach needs the value type to stay copy-constructible; every
+        // real use in this file is std::move(), so the only implicit copy is
+        // QHash relocating entries on rehash, where sharing the pointee is
+        // harmless. Always non-null: default-constructed here and on every
+        // reset via `= WaterfallStreamState{}`.
+        std::shared_ptr<DssRenderer> dss = std::make_shared<DssRenderer>();
         float kiwiDisplayFloorDbm{-110.0f};
         float kiwiDisplayCeilDbm{-10.0f};
         bool kiwiDisplayRangeValid{false};


### PR DESCRIPTION
## Summary
- Split out of #4441 per @jensenpat's review — this fix is unrelated to that PR's KiwiSDR CW BFO offset work and belongs in its own PR.
- `DssRenderer` embeds four fixed `std::array<std::array<T, 768>, 104>` row buffers directly (~798KB) plus ~22KB of smaller fixed arrays, making it ~801KB per instance. `WaterfallStreamState` held one of these **by value**, and both `saveCurrentWaterfallStreamState()` and `restoreCurrentWaterfallStreamState()` materialize stack-local `WaterfallStreamState` objects to shuffle state between the live renderer and saved-per-source slots — each a ~801KB stack allocation, sometimes two alive at once.
- This reliably crashed the app with `STATUS_STACK_OVERFLOW` when switching a slice's antenna from local to a KiwiSDR virtual antenna.
- Fix: `WaterfallStreamState::dss` is now a `shared_ptr<DssRenderer>` instead of an embedded value, so save/restore only copies a pointer.

## Test plan
- [x] Confirmed via hand-rolled diagnostics (recursion-depth counters, stack-address probes, `GetCurrentThreadStackLimits`, minidump parsing) that the oversized stack-local frame — not accumulated recursion — was the crash cause.
- [x] Built and manually verified on Windows: switching a slice's antenna from local to a KiwiSDR virtual antenna no longer crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)