### PR TITLE
fix(statusbar): label the HL2 gateware version and fit a long nickname on one line

### DIFF
--- a/src/core/RadioDiscovery.h
+++ b/src/core/RadioDiscovery.h
@@ -59,6 +59,17 @@ struct RadioInfo {
     QString model;
     QString serial;
     QString version;
+    // What the radio calls its version, when a bare number would not be
+    // self-describing. The HL2 reports a gateware revision ("75"), which says
+    // nothing on its own; a Flex reports a software version ("4.2.20.41343"),
+    // which does. Empty means "render the version alone", so every existing
+    // backend is unchanged by omitting it.
+    //
+    // DISPLAY ONLY, and deliberately a separate field rather than a prefix
+    // baked into `version`: that value is also served over rigctl
+    // (RigctlProtocol) and the automation bridge, where clients parse it as a
+    // version token.
+    QString versionLabel;
     QString nickname;
     QString callsign;
     QHostAddress address;

--- a/src/core/backends/hl2/Hl2Discovery.cpp
+++ b/src/core/backends/hl2/Hl2Discovery.cpp
@@ -167,6 +167,8 @@ void Hl2Discovery::onReadyRead()
         // (keyed by MAC/serial in AppSettings) if one is set, else the model name.
         info.nickname = effectiveNickname(info.serial, info.model);
         info.version  = QString::number(reply->gatewareVersion);
+        // A bare revision number is not self-describing in a status bar.
+        info.versionLabel = QStringLiteral("Gateware");
         // A radio already streaming to another client answers with 0x03. Show it
         // as present-but-taken rather than hiding it.
         info.inUse    = reply->streaming;

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -2008,6 +2008,10 @@ ConnectionPanel::Hl2ProbeResult ConnectionPanel::probeHermesLite2(
             // "Hermes-Lite 2" when reached over the VPN. Needs the serial first.
             info.nickname = hl2::Hl2Discovery::effectiveNickname(info.serial, info.model);
             info.version  = QString::number(reply->gatewareVersion);
+            // Same label Hl2Discovery sets on the broadcast path — this
+            // is the SECOND place an HL2 RadioInfo is built, and a field
+            // set in only one of them is not set at all.
+            info.versionLabel = QStringLiteral("Gateware");
             // Streaming (status byte 0x03) means another client already owns
             // the radio. Reflect it rather than hard-coding Available.
             info.inUse    = reply->streaming;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -177,6 +177,7 @@
 #include <QBuffer>
 #include <QFont>
 #include <QFontMetrics>
+#include <QRegularExpression>
 #include <QWidgetAction>
 #include <QPainter>
 #include <QVBoxLayout>
@@ -321,15 +322,102 @@ void reserveStatusBarStackWidth(QWidget* stack, const QStringList& samples, int 
     stack->setMinimumWidth(qMax(minimumWidth, statusBarCompactTextWidth(samples, 16)));
 }
 
+// The station label's resting type size. Single-token values keep it.
+constexpr int kStationFontPx = 21;
+
+// Property carrying the size the label is currently styled at, so the
+// stylesheet is only re-applied when it actually changes.
+constexpr char kStationFontPxProperty[] = "aetherStationFontPx";
+
+QString statusBarStationLabelStyle(int fontPx)
+{
+    return QStringLiteral(
+        "QLabel { color: {{color.text.primary}}; font-size: %1px; "
+        "background: {{color.background.0}}; "
+        "border: 1px solid rgba(255,255,255,128); padding: 2px 12px; }")
+        .arg(fontPx);
+}
+
+// Floor for the shrink below. Smaller than this stops reading as the station
+// identity and starts reading as one more compact telemetry label (those are
+// 12px), so a name that will not fit even here is elided instead.
+constexpr int kStationMinFontPx = 15;
+
+// Text width a multi-word nickname may occupy before it is shrunk. This is a
+// layout budget, not a measurement of any particular string: the station box
+// is centred between the radio-info stack and the GPS/reference stack, and at
+// full size a two-word nickname pushes into the latter. Against our HL2 this
+// resolves to kStationMinFontPx for "Hermes-Lite 2".
+constexpr int kStationWideTextBudgetPx = 105;
+
+// The largest size in [kStationMinFontPx, kStationFontPx] at which the text
+// still fits the budget on ONE line. Returns the floor when nothing fits;
+// stationFittedText() then elides at that size.
+int stationFittedFontPx(const QString& text)
+{
+    for (int px = kStationFontPx; px >= kStationMinFontPx; --px) {
+        QFont candidate = QApplication::font();
+        candidate.setPixelSize(px);
+        if (QFontMetrics(candidate).horizontalAdvance(text)
+                <= kStationWideTextBudgetPx) {
+            return px;
+        }
+    }
+    return kStationMinFontPx;
+}
+
+// One line, elided only if it still overruns the budget at the floor size.
+QString stationFittedText(const QString& text, int fontPx)
+{
+    QFont font = QApplication::font();
+    font.setPixelSize(fontPx);
+    const QFontMetrics metrics(font);
+    if (metrics.horizontalAdvance(text) <= kStationWideTextBudgetPx) {
+        return text;
+    }
+    return metrics.elidedText(text, Qt::ElideRight, kStationWideTextBudgetPx);
+}
+
+// A callsign or a radio nickname. Single-token values (N0CALL, ANT1-AV640,
+// 70CM-RXA-XVTR) render at kStationFontPx, byte-identical to before. A value
+// containing whitespace is shrunk to fit on ONE line instead of widening the
+// status bar, down to kStationMinFontPx, eliding below that.
+//
+// WHITESPACE IS THE TRIGGER, NOT WIDTH, and that is not a detail: measured on
+// real radios, the widest nickname in the lab is a FLEX one — "ANT1-AV640"
+// occupies 174px against the HL2's "Hermes-Lite 2" at 170px. A width
+// threshold would therefore wrap the Flex and leave the HL2 on one line,
+// which is backwards. What actually distinguishes them is that the HL2 has no
+// operator-set nickname, so Hl2Discovery::effectiveNickname() substitutes the
+// model string — two words — while every real callsign and Flex nickname is a
+// single token.
+//
+// A width threshold cannot be used in its place: measured at kStationFontPx on
+// real radios, "ANT1-AV640" occupies 157px against "Hermes-Lite 2" at 170px.
+// The two are 13px apart, so any budget low enough to shrink the HL2 name
+// would shrink the Flex one almost as far.
 bool setStatusBarStationText(QLabel* label, const QString& text)
 {
     if (!label) {
         return false;
     }
 
+    const QString trimmed = text.trimmed();
+    const bool multiWord =
+        trimmed.contains(QRegularExpression(QStringLiteral("\\s")));
+    const int fontPx = multiWord ? stationFittedFontPx(trimmed) : kStationFontPx;
+    const QString rendered =
+        multiWord ? stationFittedText(trimmed, fontPx) : text;
+
     bool changed = false;
-    if (label->text() != text) {
-        label->setText(text);
+    if (label->property(kStationFontPxProperty).toInt() != fontPx) {
+        label->setProperty(kStationFontPxProperty, fontPx);
+        AetherSDR::ThemeManager::instance().applyStyleSheet(
+            label, statusBarStationLabelStyle(fontPx));
+        changed = true;
+    }
+    if (label->text() != rendered) {
+        label->setText(rendered);
         changed = true;
     }
     label->ensurePolished();
@@ -339,6 +427,17 @@ bool setStatusBarStationText(QLabel* label, const QString& text)
         changed = true;
     }
     return changed;
+}
+
+// "Gateware 75" on a radio that supplies a label, "4.2.20.41343" on one that
+// does not. The caller never asks which family it is talking to — the word
+// arrives from the backend, so a future Icom/Yaesu gets this for free.
+QString statusBarVersionText(const QString& label, const QString& version)
+{
+    if (version.isEmpty() || label.isEmpty()) {
+        return version;
+    }
+    return QStringLiteral("%1 %2").arg(label, version);
 }
 
 QString vfoFrequencyText(double mhz)
@@ -1568,7 +1667,8 @@ MainWindow::MainWindow(QWidget* parent)
         if (m_radioInfoLabel && !m_radioModel.model().isEmpty())
             m_radioInfoLabel->setText(m_radioModel.model());
         if (m_radioVersionLabel && !m_radioModel.version().isEmpty())
-            m_radioVersionLabel->setText(m_radioModel.version());
+            m_radioVersionLabel->setText(statusBarVersionText(
+                m_radioModel.versionLabel(), m_radioModel.version()));
         // The station/nickname label is set once in onConnectionStateChanged, but
         // the nickname can land afterwards via a radio-status delta — for a real
         // radio the async "info" reply corrects it, and for the demo SimBackend
@@ -4627,8 +4727,9 @@ void MainWindow::buildUI()
     hbox->addStretch(1);
 
     m_stationNickLabel = new QLabel("N0CALL");
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_stationNickLabel, "QLabel { color: {{color.text.primary}}; font-size: 21px; background: {{color.background.0}}; "
-        "border: 1px solid rgba(255,255,255,128); padding: 2px 12px; }");
+    AetherSDR::ThemeManager::instance().applyStyleSheet(
+        m_stationNickLabel, statusBarStationLabelStyle(kStationFontPx));
+    m_stationNickLabel->setProperty(kStationFontPxProperty, kStationFontPx);
     m_stationNickLabel->setAlignment(Qt::AlignCenter);
     m_stationNickLabel->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
     setStatusBarStationText(m_stationNickLabel, m_stationNickLabel->text());
@@ -5191,7 +5292,8 @@ void MainWindow::onConnectionStateChanged(bool connected)
         m_suppressStartupPanLayoutRearrange = false;
         m_layoutRestoreUntilMs = kPanLayoutRestoreWaitingForFirstPan;
         m_radioInfoLabel->setText(m_radioModel.model());
-        m_radioVersionLabel->setText(m_radioModel.version());
+        m_radioVersionLabel->setText(statusBarVersionText(
+            m_radioModel.versionLabel(), m_radioModel.version()));
         setStatusBarStationText(m_stationLabel, m_radioModel.nickname());
         updateStatusBarMinimumWidth();
         m_connStatusLabel->setText("Connected");

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -177,7 +177,6 @@
 #include <QBuffer>
 #include <QFont>
 #include <QFontMetrics>
-#include <QRegularExpression>
 #include <QWidgetAction>
 #include <QPainter>
 #include <QVBoxLayout>
@@ -383,14 +382,10 @@ QString stationFittedText(const QString& text, int fontPx)
 // containing whitespace is shrunk to fit on ONE line instead of widening the
 // status bar, down to kStationMinFontPx, eliding below that.
 //
-// WHITESPACE IS THE TRIGGER, NOT WIDTH, and that is not a detail: measured on
-// real radios, the widest nickname in the lab is a FLEX one — "ANT1-AV640"
-// occupies 174px against the HL2's "Hermes-Lite 2" at 170px. A width
-// threshold would therefore wrap the Flex and leave the HL2 on one line,
-// which is backwards. What actually distinguishes them is that the HL2 has no
-// operator-set nickname, so Hl2Discovery::effectiveNickname() substitutes the
-// model string — two words — while every real callsign and Flex nickname is a
-// single token.
+// WHITESPACE IS THE TRIGGER, NOT WIDTH, and that is not a detail: what
+// distinguishes the two is that the HL2 has no operator-set nickname, so
+// Hl2Discovery::effectiveNickname() substitutes the model string — two words
+// — while every real callsign and Flex nickname is a single token.
 //
 // A width threshold cannot be used in its place: measured at kStationFontPx on
 // real radios, "ANT1-AV640" occupies 157px against "Hermes-Lite 2" at 170px.
@@ -403,8 +398,11 @@ bool setStatusBarStationText(QLabel* label, const QString& text)
     }
 
     const QString trimmed = text.trimmed();
-    const bool multiWord =
-        trimmed.contains(QRegularExpression(QStringLiteral("\\s")));
+    // std::any_of over QChar::isSpace rather than a QRegularExpression: this is
+    // reached from the MeterModel::hwTelemetryChanged handler, so a per-call
+    // pattern compile would land on every PA-temperature delta.
+    const bool multiWord = std::any_of(trimmed.cbegin(), trimmed.cend(),
+                                       [](QChar c) { return c.isSpace(); });
     const int fontPx = multiWord ? stationFittedFontPx(trimmed) : kStationFontPx;
     const QString rendered =
         multiWord ? stationFittedText(trimmed, fontPx) : text;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2314,6 +2314,7 @@ void RadioModel::connectToRadio(const RadioInfo& info)
     m_name    = info.name;
     m_model   = info.model;
     m_version = info.version;
+    m_versionLabel = info.versionLabel;
     // Seed nickname/callsign from the discovery packet so the status-bar station
     // label is correct the instant onConnectionStateChanged(true) reads it. These
     // were previously only set later from the async "info" reply, so on connect

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -5211,6 +5211,11 @@ void RadioModel::onDisconnected()
     m_maxSlices = 4;
     m_model.clear();
     m_version.clear();
+    // Cleared beside m_version rather than relying on the next connect to
+    // reassign it: this block's contract is that everything here is re-derived
+    // from the new radio's status, and a path that reaches a Flex without
+    // going through connectToRadio() would otherwise inherit an HL2's word.
+    m_versionLabel.clear();
     // Remember which radio the surviving pan/slice models belong to so the
     // next connect can refuse to reclaim them against a different radio.
     // Keep the previous value if this disconnect never learned a serial

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -133,6 +133,10 @@ public:
     QString name()    const { return m_name; }
     QString model()   const { return m_model; }
     QString version() const { return m_version; }
+    // Backend-supplied word for what `version` IS ("Gateware" on an HL2),
+    // empty when the bare value speaks for itself. Display only — version()
+    // stays the unadorned token that rigctl and the bridge serve.
+    QString versionLabel() const { return m_versionLabel; }
     bool isConnected() const;
     bool fullDuplexEnabled() const { return m_fullDuplex; }
     void setFullDuplex(bool on) { m_fullDuplex = on; emit infoChanged(); }
@@ -1190,6 +1194,7 @@ private:
     QStringList m_declaredBands;    // optional "bands=" declaration (see declaredBands())
     int         m_maxSlices{4};
     QString     m_version;          // software version from discovery (e.g. "4.1.5")
+    QString     m_versionLabel;     // display-only word for it (Gateware on an HL2)
     QString     m_protocolVersion;  // protocol version from V line (e.g. "1.4.0.0")
     float       m_paTemp{0.0f};
     float       m_txPower{0.0f};


### PR DESCRIPTION
## Summary

Two halves of one HL2 status-bar item, both visible only on a Hermes-Lite 2. Moved here
from `jensenpat/AetherSDR#5` at @jensenpat's request — GitHub cannot retarget a PR across
repositories, so that one is closed with a pointer to this. It was originally opened as
#4544 and stacked on `feat/capabilities-flex-only-ui` to avoid a `RadioModel` overlap;
that overlap no longer applies, and nothing in this diff touches `RadioCapabilities`, so
it stands alone on `main`.

**Gateware label.** The HL2 reports a gateware revision, which the status bar printed as a
bare `75` under the model name — a number with nothing saying what it counts. A Flex
reports `4.2.20.41343`, which speaks for itself. Rather than teach the status bar which
radio it is talking to, the *backend* now supplies the word: `RadioInfo::versionLabel`, set
to `"Gateware"` by the HL2 and left empty by everyone else, rendered as `label + version`
by a call site that never asks about family. A future Icom or Yaesu gets this by filling in
one field.

`versionLabel` is a **separate field rather than a prefix baked into `version`**, and that
is the load-bearing decision here — see below.

Set at **both** sites that build an HL2 `RadioInfo`: `Hl2Discovery`'s broadcast path and
`ConnectionPanel`'s manual Connect-by-IP path. Only the first was done initially and the
label silently never appeared, because the automation bridge connects by IP. A field set in
one of two constructors is not set at all.

**Station nickname.** The same label holds a callsign or nickname. An HL2 has no operator
nickname, so the model string is substituted — `Hermes-Lite 2`, two words, crowding the
reference stack beside it. It is now shrunk to fit on one line instead of widening the bar,
down to a floor of 15px and elided below that. The wrapped size is derived from live font
metrics, not hard-coded, so the bar can never grow.

**Whitespace is the trigger, not width.** Measured at full size on real radios,
`ANT1-AV640` occupies 157px against `Hermes-Lite 2` at 170px — 13px apart. Any width budget
low enough to shrink the HL2 name would shrink the Flex one almost as far. Single-token
values never enter the path, so no callsign and no Flex nickname can be affected.

### Two things this deliberately does not fix

**`kStationWideTextBudgetPx` is a provisional constant, and a follow-up should remove it.**
The budget is a hard-coded 105px, tuned so that `Hermes-Lite 2` resolves to the floor size.
It is not derived from the space actually free between the radio-info stack and the
GPS/reference stack at the current window width, and it should be. Relatedly, the trigger
here is whitespace rather than width, which means a **long single-token nickname is not
covered**: on a FLEX-6500 a station name like `70CM-RXA-XVTR` still renders at full size and
overruns into the reference stack, visibly overlapping `OCXO_GPSD [Locked]`. That is a
pre-existing bug, it reproduces on unmodified `main`, and it affects every backend — so it
wants one width-derived mechanism applied to all values rather than a second special case. I
intend to follow up with exactly that, replacing this constant. Flagging it here rather than
letting the magic number arrive unexplained.

**`Hl2Discovery::effectiveNickname()` substituting the *model* into a *station* field** is
arguably the real fix for the HL2 half, and would also remove the duplicate model display.
That is a backend-behaviour change on someone else's seam, so it is raised rather than
patched.

## Constitution principle honored

**Principle II — the radio is authoritative on live state; the client mirrors it.**

`RadioModel::version()` is served onward over rigctl (`RigctlProtocol.cpp`) and the
automation bridge (`AutomationServer.cpp`), where clients parse it as a version token.
Baking `"Gateware "` into `version` would mean the value the client mirrors is no longer the
value the radio reported, and a WSJT-X or fldigi session would parse the difference — a
protocol regression, not a cosmetic one. Keeping the label in its own field means the
mirrored value stays exactly what the radio said, and only the *presentation* adds the word.

**Principle X**, on process: the base was verified against current `main` and intervening
commits inspected for overlap on the files touched. That surfaced #4528, which restructured
the manual Connect-by-IP probe into a `probeHermesLite2` / `probeFlexRadio` split — the
exact site of the second writer above. The hunk was re-placed against the new structure
rather than force-applied.

## Test plan

- [x] Local build passes (`cmake --build build`) — Nobara 43, Qt 6.10.3, gcc 15.2.1, Ninja
- [x] Behavior verified on a real radio — Hermes-Lite 2, **RX only, no TX at any point**
- [x] Existing tests pass — **193/194** on this branch, and **193/194** on a fully-built
      unmodified build of the same base. The single failure is `cross_needle_meter_test` in
      both, so it is pre-existing and not caused by this change; `crdv_quarantined_test` is
      skipped by design in both. Test counts are identical (194), as this adds none.
- [x] Reproduction steps documented — see below

Verified through the automation bridge against live hardware, RX only. Both legs are an A/B
against a build of the **same base** (`553aa8a0`) with this commit absent, measured by
dumping every `QStatusBar` `QLabel` with its geometry — not by eye:

| | control @ `553aa8a0` | this branch |
|---|---|---|
| HL2 version row | `75` | **`Gateware 75`** |
| HL2 station box width | 170px | **137px** |
| HL2 reference stack x | 892 | **859** (33px more clearance) |
| status bar height | 41px | 41px (unchanged) |
| neighbouring row y | 762 / 777 | 762 / 777 (unchanged) |
| FLEX-6700 version row | `4.2.20.41343` | `4.2.20.41343` (unprefixed) |
| FLEX-6700 `ANT1-AV640` width | 157px | 157px (identical) |
| FLEX-6700 reference stack x | 879 | 879 (identical) |

The Flex control leg is identical on every geometry field, which is the point: a Flex sees
no change at all. The HL2 gains the label and returns 33px to the reference stack without
the bar growing or any neighbour moving.

Reproduction (control build, HL2 connected): the version row under the model name reads a
bare `75` with nothing saying what it counts, and the station box renders `Hermes-Lite 2` at
full size.

Worth noting from the same control run, as evidence for the follow-up described above: on the
FLEX-6700 the station box `ANT1-AV640` ends at x=873 against the reference stack at x=879 —
six pixels of clearance at this window width. A longer single-token name runs straight
through it, which is the pre-existing overflow this PR does not address.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no persistence change in this diff
- [x] Code is clean-room — written against the openHPSDR/Hermes-Lite gateware docs and this
      repo's own protocol code; nothing decompiled or reverse-engineered
- [x] All meter UI uses `MeterSmoother` — no meter UI touched
- [x] Documentation updated if user-visible behavior changed — status-bar presentation only
- [x] Security-sensitive changes reference a GHSA if applicable — n/a

Related: `jensenpat/AetherSDR#4` (gate the status-bar PA supply voltage on declared
telemetry) stays on that fork, because it genuinely depends on the `RadioCapabilities`
field added by #4508. Both edit status-bar code in `MainWindow.cpp`, so whichever lands
second will want a rebase.

---

73, Ozy **K6OZY**
