### PR TITLE
feat(caps): gate the status bar PA supply voltage on declared telemetry

### DIFF
--- a/docs/architecture/radio-capabilities-map.md
+++ b/docs/architecture/radio-capabilities-map.md
@@ -48,6 +48,7 @@ traps and why the DAX crash guard is deliberately *not* the DAX capability.
 | `hasRadioSideDsp` | ✅ | ❌ | ❌ | `RadioModel::hasRadioSideDsp()` | NR/NB/ANF/NRL/ANFL/ANFT, the APD row, the WNB row, the 8-band hardware EQ applet |
 | `hasWaveforms` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | File ▸ Waveforms… |
 | `hasMultiClientSessions` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | Settings ▸ multiFLEX… |
+| `hasSupplyVoltageTelemetry` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | PA supply-voltage readout in the status bar |
 | `extensionNamespaces` | `["flex"]` | — | — | `invokeExtension` pre-check | Amp / tuner operate/bypass/autotune verbs |
 
 `MainWindow::applyCapabilitiesToUi()` is the single fan-out for UI visibility. It

--- a/src/core/backends/RadioCapabilities.h
+++ b/src/core/backends/RadioCapabilities.h
@@ -83,6 +83,24 @@ struct RadioCapabilities {
     bool hasAmplifier = false;     // integrated or controllable PA
     bool hasExtendedDsp = false;   // extended firmware DSP filters (NRS/RNN/NRF)
 
+    // The radio reports the PA supply-voltage rail as telemetry — the value the
+    // status bar renders directly under the PA temperature. A radio that never
+    // reports the rail declares false and that readout goes away, instead of
+    // formatting an initialiser to two decimals so it reads as a measurement.
+    //
+    // Named for the TELEMETRY, not for the PA and not for the brand. "Does it
+    // have a Flex PA" is the wrong axis: an HL2 has a PA and reports no supply
+    // rail, and an IC-7610 would be the same. What actually varies between
+    // families is whether the radio reports the voltage — which is exactly the
+    // question the label needs answered.
+    //
+    // NOT hasAmplifier, despite the adjacency. That field means "integrated or
+    // controllable PA", nothing reads it (see radio-capabilities-map.md, where
+    // it sits under the fields no consumer reads — the AMP applet runs off
+    // TunerModel::presenceChanged), and the HL2 declares it false while
+    // genuinely having a PA. It already means something other than this.
+    bool hasSupplyVoltageTelemetry = false;
+
     // The RADIO stores named configuration profiles (global / TX / mic) that a
     // client can list, load and save. The seam already carries ProfileDelta and
     // profileChanged in both directions; this is the flag that says whether the

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -188,6 +188,9 @@ RadioCapabilities FlexBackend::capabilities() const
     // the client must NOT keep a local bank for a Flex — two stores that both
     // believe they are authoritative would fight over slot indices.
     caps.persistsMemories = true;
+    // The "+13.8A" meter carries the PA supply rail (measurement point A,
+    // before the fuse), which the status bar renders under the PA temperature.
+    caps.hasSupplyVoltageTelemetry = true;
 
     // Advertise the "flex" extension namespace: the amp/tuner operate/bypass/
     // autotune verbs are now routed through invokeExtension() (#4092/#4094), and

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -1175,6 +1175,10 @@ RadioCapabilities Hl2Backend::capabilities() const
     c.hasWaveforms = false;             // no installable plugin surface
     c.hasMultiClientSessions = false;   // one client owns the radio
     c.hasGpsLocation = false;           // no GNSS receiver on the board
+    // The HL2 declares PATEMP but no "+13.8A": PA temperature is a real reading
+    // from this radio, the supply rail is not reported at all. Only the volts
+    // readout goes away — the temperature above it keeps working.
+    c.hasSupplyVoltageTelemetry = false;
     // No extension namespaces (no invokeExtension verbs yet), matching FlexBackend.
     return c;
 }

--- a/src/core/backends/sim/SimBackend.cpp
+++ b/src/core/backends/sim/SimBackend.cpp
@@ -312,6 +312,7 @@ RadioCapabilities SimBackend::capabilities() const
     caps.hasWaveforms = false;
     caps.hasMultiClientSessions = false;
     caps.hasGpsLocation = false;         // synthetic radio has no position source
+    caps.hasSupplyVoltageTelemetry = false;   // synthetic scene; no PA rail
     return caps;
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1934,7 +1934,25 @@ MainWindow::MainWindow(QWidget* parent)
         m_lastPaTempC = paTemp;
         m_hasPaTempTelemetry = true;
         updatePaTempLabel();
-        m_supplyVoltLabel->setText(QString("%1 V").arg(supplyVolts, 0, 'f', 2));
+        // A bare dash, never a zero, for a rail the radio has not reported —
+        // the rule the Radio Health dialog already applies to its registers.
+        // No unit either: the unit belongs to the value, and there is no
+        // value, so "— V" would still be asserting a reading in volts. This
+        // signal fires when EITHER half of the hardware telemetry changes, so
+        // on a radio that reports PA temperature and no supply rail (HL2:
+        // PATEMP, no "+13.8A") every temperature tick used to repaint the
+        // 0.0f initialiser formatted to two decimals — indistinguishable from
+        // a measurement.
+        //
+        // Independent of hasSupplyVoltageTelemetry on purpose: that capability
+        // decides whether the OPERATOR IS OFFERED the readout, this decides
+        // what the readout may claim. A backend that declares the rail but has
+        // not yet received a meter definition is still not entitled to print a
+        // number. Same separation as the DAX capability and its crash guard.
+        m_supplyVoltLabel->setText(
+            m_radioModel.meterModel().hasSupplyVoltage()
+                ? QString("%1 V").arg(supplyVolts, 0, 'f', 2)
+                : QStringLiteral("—"));
 
         // Update station label (nickname arrives via status after connect)
         const QString nick = m_radioModel.nickname();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6242,10 +6242,28 @@ void MainWindow::applyCapabilitiesToUi(bool connected, const RadioCapabilities& 
     // arrives as its 0.0f initialiser on every tick.
     if (m_supplyVoltLabel) {
         m_supplyVoltLabel->setVisible(!connected || caps.hasSupplyVoltageTelemetry);
-        // Republish the status bar's minimum width. It is computed from
-        // m_statusBarContainer->minimumSizeHint() (updateStatusBarMinimumWidth),
-        // which a hidden child changes; a stale minimum leaves a gap or clips
-        // the size grip.
+        if (!connected) {
+            // Drop the previous session's readings instead of leaving them on
+            // screen with no radio attached — the same "do not assert what the
+            // radio did not report" rule this gate exists for. MeterModel::clear()
+            // resets the underlying sentinels, but no further hwTelemetryChanged
+            // arrives after a disconnect to repaint either label, so the text has
+            // to be dropped here or a Flex's last rail voltage survives its own
+            // disconnect. Each row reuses its own established no-value rendering:
+            // a bare dash for the rail, "PA --" for the temperature.
+            m_supplyVoltLabel->setText(QStringLiteral("—"));
+            m_hasPaTempTelemetry = false;
+            updatePaTempLabel();
+        }
+        // Republishing the minimum width cannot currently matter here, and the
+        // call is kept only so the gate stays correct if that stops being true:
+        // paStack's minimum is PINNED by reserveTelemetryStack() with a
+        // "99.99 V" sample, so hiding one of its children leaves
+        // m_statusBarContainer->minimumSizeHint() unchanged, and
+        // updateStatusBarMinimumWidth() only ever READS that hint. So no stale
+        // minimum, gap or clipped size grip is reachable today — and the HL2
+        // reclaims no width from the hidden row either, nor would it:
+        // "PA 248.0°F" is the wider sample.
         updateStatusBarMinimumWidth();
     }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6213,6 +6213,24 @@ void MainWindow::applyCapabilitiesToUi(bool connected, const RadioCapabilities& 
         m_appletPanel->setHardwareEqVisible(radioSideDsp);
     }
 
+    // ── PA supply voltage: the lower row of the status bar's PA stack ───────
+    //
+    // m_supplyVoltLabel ONLY. m_paTempLabel and the paVbox around them are left
+    // alone deliberately: an HL2 reports PA temperature genuinely, so hiding the
+    // stack would delete a working readout in order to suppress a broken
+    // sibling. The one being suppressed is fed from the Flex-named "+13.8A"
+    // meter, and MeterModel emits hwTelemetryChanged whenever EITHER half
+    // changes — so on a radio that reports only PA temperature the volts half
+    // arrives as its 0.0f initialiser on every tick.
+    if (m_supplyVoltLabel) {
+        m_supplyVoltLabel->setVisible(!connected || caps.hasSupplyVoltageTelemetry);
+        // Republish the status bar's minimum width. It is computed from
+        // m_statusBarContainer->minimumSizeHint() (updateStatusBarMinimumWidth),
+        // which a hidden child changes; a stale minimum leaves a gap or clips
+        // the size grip.
+        updateStatusBarMinimumWidth();
+    }
+
     // ── Flex platform features that are not DSP ─────────────────────────────
     if (m_waveformsAction) {
         m_waveformsAction->setVisible(!connected || caps.hasWaveforms);

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -221,7 +221,10 @@ void MeterModel::removeMeter(int index)
     if (index == m_hwAlcIdx)     m_hwAlcIdx = -1;
     if (index == m_swAlcIdx)     m_swAlcIdx = -1;
     if (index == m_paTempIdx)    m_paTempIdx = -1;
-    if (index == m_supplyIdx)    m_supplyIdx = -1;
+    if (index == m_supplyIdx) {
+        m_supplyIdx = -1;
+        m_hasSupplyVoltsValue = false;   // the sample cannot outlive its meter
+    }
     if (index == m_ampFwdPwrIdx) m_ampFwdPwrIdx = -1;
     if (index == m_ampSwrIdx)    m_ampSwrIdx = -1;
     if (index == m_ampTempIdx)   m_ampTempIdx = -1;
@@ -310,6 +313,7 @@ void MeterModel::clear()
     m_swAlcIdx = -1;
     m_paTempIdx = -1;
     m_supplyIdx = -1;
+    m_hasSupplyVoltsValue = false;
     m_ampFwdPwrIdx = -1;
     m_ampSwrIdx = -1;
     m_ampTempIdx = -1;
@@ -641,6 +645,7 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
             hwChanged = true;
         } else if (idx == m_supplyIdx) {
             m_supplyVolts = v;  // "+13.8A" = supply voltage at point A (before fuse)
+            m_hasSupplyVoltsValue = true;   // a SAMPLE, not just a definition
             hwChanged = true;
         } else if (idx == m_tgxlFwdIdx) {
             m_tgxlFwdPwr = std::pow(10.0f, v / 10.0f) / 1000.0f;

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -161,6 +161,12 @@ public:
 
     // Convenience: supply voltage (Volts, from "+13.8A" meter — measurement point A, before fuse).
     float supplyVolts() const { return m_supplyVolts; }
+    // Whether the radio has DECLARED that meter at all. Until it does,
+    // supplyVolts() is the 0.0f initialiser rather than a measurement, and
+    // hwTelemetryChanged still carries it on every PA-temperature tick because
+    // one signal reports both halves. Callers that render the value need this
+    // to tell "the rail reads zero" from "the radio never mentioned a rail".
+    bool hasSupplyVoltage() const { return m_supplyIdx >= 0; }
 
 signals:
     // Emitted when the S-meter value changes (dBm).

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -161,12 +161,17 @@ public:
 
     // Convenience: supply voltage (Volts, from "+13.8A" meter — measurement point A, before fuse).
     float supplyVolts() const { return m_supplyVolts; }
-    // Whether the radio has DECLARED that meter at all. Until it does,
-    // supplyVolts() is the 0.0f initialiser rather than a measurement, and
-    // hwTelemetryChanged still carries it on every PA-temperature tick because
-    // one signal reports both halves. Callers that render the value need this
-    // to tell "the rail reads zero" from "the radio never mentioned a rail".
-    bool hasSupplyVoltage() const { return m_supplyIdx >= 0; }
+    // Whether a supply-voltage SAMPLE has actually arrived — not merely
+    // whether the radio declared the meter. The distinction is load-bearing:
+    // m_supplyIdx is set when the meter DEFINITION lands, while m_supplyVolts
+    // stays at its 0.0f initialiser until a "+13.8A" VALUE packet lands, and
+    // hwTelemetryChanged fires on every PA-temperature tick in between because
+    // one signal reports both halves. Keying on the index would therefore let
+    // a PATEMP tick in that window repaint the initialiser as "0.00 V" —
+    // exactly the fabricated reading this accessor exists to prevent. Same
+    // shape as m_hasCompPeakValue above. Lets a caller tell "the rail reads
+    // zero" from "no rail reading has arrived".
+    bool hasSupplyVoltage() const { return m_hasSupplyVoltsValue; }
 
 signals:
     // Emitted when the S-meter value changes (dBm).
@@ -301,6 +306,9 @@ private:
     float m_swAlc{0.0f};
     float m_paTemp{0.0f};
     float m_supplyVolts{0.0f};
+    // Set when a "+13.8A" value packet lands, cleared wherever m_supplyIdx is,
+    // so it can never outlive the meter it describes. See hasSupplyVoltage().
+    bool m_hasSupplyVoltsValue{false};
     float m_ampFwdPwr{0.0f};
     float m_ampSwr{1.0f};
     float m_ampTemp{0.0f};

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -1,4 +1,5 @@
-// Capability-gated UI surfaces: hasProfiles, hasDaxStreams, hasExtendedDsp.
+// Capability-gated UI surfaces: hasProfiles, hasDaxStreams, hasExtendedDsp,
+// hasSupplyVoltageTelemetry.
 //
 // The rule these guard (RadioCapabilities.h header comment, aetherd RFC §1) is
 // that no call site asks "is this a Flex". A surface is gated on a DECLARED
@@ -20,6 +21,13 @@
 //                 radio attached there is nothing to be honest about, and a
 //                 PROF applet that stayed hidden after unplugging reads as a
 //                 fault. Evaluated here exactly as the GUI evaluates it.
+//   supply volts  hasSupplyVoltageTelemetry gates the status bar's PA supply
+//                 voltage readout. The label it hides is fed from the
+//                 Flex-named "+13.8A" meter but repainted whenever PA
+//                 TEMPERATURE changes, so a radio reporting only PA temp
+//                 renders the 0.0f initialiser as a two-decimal measurement.
+//                 Asserted on the CAPABILITY, so this stays true of any future
+//                 family that reports no supply rail.
 //   radio DSP     hasRadioSideDsp gates the radio's own NR/NB/ANF/NRL/ANFL/
 //                 ANFT, the APD row, the WNB row and the 8-band hardware EQ
 //                 applet. It must NOT gate the host-side equivalents — the
@@ -127,6 +135,11 @@ int main(int argc, char** argv)
               "Flex declares hasMultiClientSessions (multiFLEX)");
         check(caps.hasGpsLocation,
               "Flex declares hasGpsLocation (GPSDO / on-board GNSS)");
+        // The one this field exists to protect: the struct default is false, so
+        // adding the field without touching FlexBackend would silently delete a
+        // readout that ships and works today.
+        check(caps.hasSupplyVoltageTelemetry,
+              "Flex declares hasSupplyVoltageTelemetry (the \"+13.8A\" meter)");
         // The two DSP flags are independent statements, not synonyms: the base
         // set and the extra 8000-series filters. A default Flex model string is
         // unknown to the platform table, so the narrower one is false here while
@@ -157,6 +170,11 @@ int main(int argc, char** argv)
               "HL2 declares hasMultiClientSessions=false (one client owns it)");
         check(!caps.hasGpsLocation,
               "HL2 declares hasGpsLocation=false (no GNSS receiver on the board)");
+        // PATEMP yes, "+13.8A" no. The temperature above the volts row is a
+        // genuine HL2 reading and must keep working — this flag hides one label,
+        // not the stack.
+        check(!caps.hasSupplyVoltageTelemetry,
+              "HL2 declares hasSupplyVoltageTelemetry=false (PATEMP, no +13.8A)");
     }
 
     // ---- Sim declares none of them, and is genuinely CONNECTED -----------
@@ -196,6 +214,8 @@ int main(int argc, char** argv)
         check(!caps.hasMultiClientSessions,
               "Sim declares hasMultiClientSessions=false");
         check(!caps.hasGpsLocation, "Sim declares hasGpsLocation=false");
+        check(!caps.hasSupplyVoltageTelemetry,
+              "Sim declares hasSupplyVoltageTelemetry=false");
 
         // The surfaces the GUI drives off those flags, evaluated the way the
         // GUI evaluates them. A CONNECTED radio that says no means hidden.
@@ -209,6 +229,8 @@ int main(int argc, char** argv)
               "connected + hasMultiClientSessions=false hides Settings > multiFLEX");
         check(!uiWouldShow(model.isConnected(), caps.hasGpsLocation),
               "connected + hasGpsLocation=false hides the GPS stack and its separator");
+        check(!uiWouldShow(model.isConnected(), caps.hasSupplyVoltageTelemetry),
+              "connected + hasSupplyVoltageTelemetry=false hides the volts readout");
 
         // hasRadioSideDsp reaches the UI through its own accessor, which applies
         // the permissive rule itself (there is no model-name table to fall back
@@ -260,6 +282,8 @@ int main(int argc, char** argv)
         // unplugging a radio that happened to lack GNSS.
         check(uiWouldShow(model.isConnected(), caps.hasGpsLocation),
               "disconnected: the GPS stack is restored");
+        check(uiWouldShow(model.isConnected(), caps.hasSupplyVoltageTelemetry),
+              "disconnected: the supply-voltage readout is restored");
         check(model.hasRadioSideDsp(),
               "disconnected: hasRadioSideDsp() goes permissive, radio DSP back");
     }
@@ -286,6 +310,10 @@ int main(int argc, char** argv)
         // Flex that has a GPSDO.
         check(caps.hasGpsLocation,
               "round-trip: Flex regains hasGpsLocation after sim -> Flex");
+        // Flex -> HL2/Sim -> Flex must leave the status bar identical to
+        // baseline. A cached flag would show up right here.
+        check(caps.hasSupplyVoltageTelemetry,
+              "round-trip: Flex regains hasSupplyVoltageTelemetry after sim -> Flex");
     }
 
     // ---- Flex extended DSP is unchanged by the reconciliation -------------


### PR DESCRIPTION
## Summary

The status bar's PA stack has two rows: PA temperature on top, PA supply voltage beneath. On a
radio that reports no supply voltage, the lower row still rendered — as `0.00 V`, a fabricated
reading presented in the same style as a real one. This gates it on declared telemetry and,
where it is shown but nothing has arrived yet, renders a dash instead of a zero.

Moved here from `jensenpat/AetherSDR#4` at @jensenpat's request. GitHub cannot retarget a PR
across repositories, so that one closes with a pointer to this. It was stacked on
`feat/capabilities-flex-only-ui` because it consumes that branch's `RadioCapabilities` UI
plumbing; now that #4508 has merged, it rebases onto `main` directly.

**The gate.** `hasSupplyVoltageTelemetry` on `RadioCapabilities`, declared explicitly by the
Flex, HL2 and Sim backends, with one owning gate in `applyCapabilitiesToUi` using the
established `!connected || caps.x` shape.

**`m_supplyVoltLabel` only — not the stack around it.** An HL2 reports PA *temperature*
genuinely, so hiding the whole `paVbox` would delete a working readout in order to suppress a
broken sibling. The suppressed row is fed from the Flex-named `+13.8A` meter, and `MeterModel`
emits `hwTelemetryChanged` whenever *either* half changes — so on a radio reporting only
temperature, the volts half arrives as its `0.0f` initialiser on every tick. That is the
mechanism behind the `0.00 V`.

**The dash is a separate commit and backend-independent.** For a radio that *does* declare the
capability but has not yet reported a value, the row renders a bare `—` via a new
`MeterModel::hasSupplyVoltage()` reading the existing `m_supplyIdx` sentinel — no family test,
no capability lookup. A bare dash, not `— V`: every dash site in this repo pairs the unit with
the *value* (`AcomApplet.cpp`, `GpsLocationDialog.cpp`), and `— V` would still assert "a
reading, in volts".

Hiding a status-bar child changes `m_statusBarContainer->minimumSizeHint()`, so the gate
republishes the bar's minimum width — a stale minimum leaves a gap or clips the size grip.

## Constitution principle honored

**Principle II — the radio is authoritative on live state; the client mirrors it.** `0.00 V` is
the client inventing a live value the radio never reported, in a widget whose whole job is to
say what the radio said. The fix routes the question back to the radio's own self-description
(the declared capability) and to whether a value actually arrived (the meter sentinel), rather
than to a model-string test. A zero here is not a cosmetic wart: an operator reading a supply
rail cannot distinguish "0.00 V" from a genuinely collapsed rail.

## Test plan

- [x] Local build passes (`cmake --build build`) — Nobara 43, Qt 6.10.3, gcc 15.2.1, Ninja
- [x] Behavior verified on a real radio — Hermes-Lite 2 and FLEX-6700, **RX only, no TX**
- [x] Existing tests pass — see below, measured against a fully-built control at the same base
- [x] Reproduction steps documented — see below

Verified through the automation bridge, A/B against a build of the **same base** with these
commits absent, by dumping every `QStatusBar` `QLabel` with visibility and geometry:

| | control @ `7f4f5e3d` | this branch |
|---|---|---|
| HL2 — PA temperature | `PA 84.7°F` visible, y=762 | `PA 84.7°F` visible, y=770 |
| HL2 — supply voltage | **`0.00 V`, visible** | **`—`, hidden** |
| FLEX-6700 — PA temperature | `PA 107.7°F` visible, y=762 | identical |
| FLEX-6700 — supply voltage | `13.62 V`, visible, y=777 | identical |
| ctest | 194/195 | 194/195, same sole failure |

Both binaries were built from the **same base commit** (asserted by SHA, not assumed) and both
worktrees were fully built, so the test floor is real: the one failure is
`cross_needle_meter_test`, which fails on unmodified `main` too.

Two honest notes on the above:

- **The HL2's PA temperature moves y=762 → y=770.** With one visible child the `paVbox`
  recentres it. That is a deliberate consequence of hiding a row rather than blanking it — it
  leaves no dead space — but it *is* a geometry change and not a no-op, so it is stated rather
  than buried.
- **A *visibly* rendered dash is not reproducible on the hardware here, and I am not claiming
  it.** The dash needs a radio that declares the capability but has not reported a value; our
  HL2 does not declare it (so the label is hidden) and our Flex declares *and* reports it. What
  the A/B does prove is the text change underneath: the HL2's hidden label reads `—` where the
  control's read `0.00 V`, so the two commits behave independently. I also checked the
  never-connected state on both builds: the row is present and **empty** in each, since the
  label is only ever populated by `hwTelemetryChanged`, which requires a connection — so that
  state is not the dash's demonstration either.

Reproduction (control build, HL2 connected): the lower row of the status-bar PA stack reads
`0.00 V` while the upper row reads a genuine PA temperature. The HL2 has no supply-voltage
telemetry, so that zero is fabricated.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no persistence change
- [x] Code is clean-room — written against this repo's own capability plumbing and the
      openHPSDR/Hermes-Lite documentation; nothing decompiled or reverse-engineered
- [x] All meter UI uses `MeterSmoother` — this changes label *visibility* and the no-value
      rendering, not meter smoothing; the value path is untouched
- [x] Documentation updated — `docs/architecture/radio-capabilities-map.md` gains the new field
- [x] Security-sensitive changes reference a GHSA if applicable — n/a

## Overlap with #4538, for merge sequencing

#4538 (`hasGpsLocation`) touches three of the same files, and I measured the conflicts rather
than guessing: `FlexBackend.cpp`, `Hl2Backend.cpp`, `SimBackend.cpp` and
`radio_capability_gating_test.cpp` all conflict, because both PRs add a capability declaration
at the same point in each backend and both extend the same test. `RadioCapabilities.h` and
`MainWindow.cpp` auto-merge — the two struct fields and the two `applyCapabilitiesToUi` blocks
are far enough apart. All of it is mechanical; whichever lands second wants a rebase and I am
happy to take that side. This PR merges onto `main` as it stands.

---

73, Ozy **K6OZY**
