### PR TITLE
fix(wspr): match WSJT-X on tone convention, frame taper and slot timing

### DIFF
--- a/docs/architecture/pipelines.md
+++ b/docs/architecture/pipelines.md
@@ -122,13 +122,21 @@ rather than invented, because a WSPR frame is judged by decoders we do not own:
 - **A missed boundary truncates the head** of the frame instead of sliding the
   whole transmission later.
 
-Arming also borrows station state that is not slice state and hands it back on
-stop: the transmit passband, the speech processor, the compander and the TX
-equalizer. None of those are bypassed by selecting DIGU, and all of them
-misshape a constant-envelope tone. Mode and both passbands are re-asserted
-immediately before the key, because a cross-band `slice tune` triggers an
-asynchronous band-stack recall that can land after them (§6.2 of the FlexLib
-oracle; #2824), and arming happens up to 120 s ahead of the key.
+The beacon also borrows station state that is not slice state and hands it back
+on stop. Arming takes only the transmit passband. Everything else is taken at
+the KEY, in `reassertBeaconChannel()`: the slice mode, both passbands again, the
+speech processor, the compander, the TX equalizer and VOX. None of the audio
+four is bypassed by selecting DIGU and all of them misshape a constant-envelope
+tone; VOX is taken because it can unkey part-way through a 111.6 s frame.
+
+The key, not arm, is where those belong for one reason: arming happens up to
+120 s ahead of the key — up to ~6 minutes once the permitted deferrals are
+spent — so anything pushed at arm is stale by the time it matters. A cross-band
+`slice tune` triggers an asynchronous band-stack recall that can land after the
+mode and filter sent behind it (§6.2 of the FlexLib oracle; #2824), and another
+client, a band button or a profile load can move the slice in that window. The
+same staleness argument applies to the speech chain, which is additionally why
+a station that is merely *armed* keeps its own audio processing and VOX intact.
 
 TCP COMMAND PIPELINE (bidirectional):
   GUI widget ──→ SliceModel.setXxx() ──→ emit commandReady("slice ...")  [MAIN]

--- a/docs/architecture/pipelines.md
+++ b/docs/architecture/pipelines.md
@@ -107,6 +107,29 @@ independently of microphone callbacks and sends it through a client-owned
 `dax_tx` stream in DIGU. Its dedicated non-voice PTT source suppresses Quindar,
 and the generator holds silence through the unkey edge.
 
+Four conventions in that generator are taken from WSJT-X's `Modulator.cpp`
+rather than invented, because a WSPR frame is judged by decoders we do not own:
+
+- **Tone 0 sits at the requested audio frequency**, with the constellation
+  running upward from it (`m_frequency + itone[isym] * m_toneSpacing`). Centring
+  the four tones on it instead shifts every resulting spot 2.2 Hz low.
+- **Both ends of the frame are tapered** over 0.017 symbols (11.6 ms). WSJT-X
+  fades only the tail; the head ramp is ours. Phase is continuous across symbol
+  boundaries, so these are the only two discontinuities in 111.6 s, and an
+  untapered one is a broadband click in a 200 Hz-wide shared sub-band.
+- **The lead-in is referenced to the slot**, not to whenever the pump started,
+  so scheduling latency is absorbed rather than reported as DT.
+- **A missed boundary truncates the head** of the frame instead of sliding the
+  whole transmission later.
+
+Arming also borrows station state that is not slice state and hands it back on
+stop: the transmit passband, the speech processor, the compander and the TX
+equalizer. None of those are bypassed by selecting DIGU, and all of them
+misshape a constant-envelope tone. Mode and both passbands are re-asserted
+immediately before the key, because a cross-band `slice tune` triggers an
+asynchronous band-stack recall that can land after them (§6.2 of the FlexLib
+oracle; #2824), and arming happens up to 120 s ahead of the key.
+
 TCP COMMAND PIPELINE (bidirectional):
   GUI widget ──→ SliceModel.setXxx() ──→ emit commandReady("slice ...")  [MAIN]
                  TransmitModel          ──→ emit commandReady("xmit ...")

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -8754,25 +8754,19 @@ void AudioEngine::pumpWsprBeacon()
     constexpr qint64 kMaximumCatchUpFrames = WsprBeacon::kFramesPerSymbol / 2;
     const int frames = static_cast<int>(
         std::min(dueFrames, kMaximumCatchUpFrames));
-    m_wsprInt16Scratch.resize(
-        frames * 2 * static_cast<int>(sizeof(int16_t)));
+    // Straight to float. This used to generate int16 and divide by 32768 right
+    // back into float, which bought nothing and cost an undithered
+    // quantization of a pure tone — the one signal for which quantization
+    // error is harmonically correlated rather than noise-like.
+    m_wsprFloatScratch.resize(
+        frames * 2 * static_cast<int>(sizeof(float)));
     // process() leaves the buffer untouched if the beacon was stopped from the
     // GUI thread since the isActive() check above, and QByteArray::resize does
     // not initialize the bytes it adds. Clear first so a stop landing inside
     // that window can never put uninitialized memory on the air.
-    m_wsprInt16Scratch.fill('\0');
+    m_wsprFloatScratch.fill('\0');
     m_wsprBeacon->process(
-        reinterpret_cast<int16_t*>(m_wsprInt16Scratch.data()), frames, 2);
-
-    const int sampleCount = frames * 2;
-    m_wsprFloatScratch.resize(
-        sampleCount * static_cast<int>(sizeof(float)));
-    const auto* input =
-        reinterpret_cast<const int16_t*>(m_wsprInt16Scratch.constData());
-    auto* output = reinterpret_cast<float*>(m_wsprFloatScratch.data());
-    for (int i = 0; i < sampleCount; ++i) {
-        output[i] = input[i] / 32768.0f;
-    }
+        reinterpret_cast<float*>(m_wsprFloatScratch.data()), frames, 2);
     feedDaxTxAudioInternal(m_wsprFloatScratch, false, true);
     m_wsprPumpedFrames += frames;
 }

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -1185,7 +1185,6 @@ private:
     QTimer* m_wsprPumpTimer{nullptr};
     QElapsedTimer m_wsprPumpClock;
     qint64 m_wsprPumpedFrames{0};
-    QByteArray m_wsprInt16Scratch;
     QByteArray m_wsprFloatScratch;
     // DAX TX mode borrowed for the duration of a WSPR frame so the mic path
     // cannot produce a second packet stream against the same m_txPacketCount.

--- a/src/core/WsprBeacon.cpp
+++ b/src/core/WsprBeacon.cpp
@@ -12,7 +12,7 @@ namespace {
 
 constexpr uint32_t kPolynomial1 = 0xf2d05351U;
 constexpr uint32_t kPolynomial2 = 0xe4613c47U;
-constexpr float kTwoPi = 6.28318530717958647692f;
+constexpr double kTwoPi = 6.28318530717958647692;
 
 constexpr std::array<uint8_t, WsprBeacon::kSymbolCount> kSync{
     1,1,0,0,0,0,0,0,1,0,0,0,1,1,1,0,0,0,1,0,
@@ -178,19 +178,25 @@ void WsprBeacon::prepare(double sampleRate)
     m_sampleRate = sampleRate > 0.0 ? sampleRate : kSampleRate;
 }
 
-void WsprBeacon::start(const Symbols& symbols, float centerHz, float levelDb,
-                       int preRollFrames)
+void WsprBeacon::start(const Symbols& symbols, double toneZeroHz, float levelDb,
+                       int preRollFrames, int messageSkipFrames)
 {
     m_active.store(false, std::memory_order_release);
     for (int i = 0; i < kSymbolCount; ++i) {
         m_pendingSymbols[i].store(symbols[i], std::memory_order_relaxed);
     }
-    m_pendingCenterHz.store(std::clamp(centerHz, 200.0f, 4000.0f),
-                            std::memory_order_relaxed);
+    m_pendingToneZeroHz.store(std::clamp(toneZeroHz, 200.0, 4000.0),
+                              std::memory_order_relaxed);
     m_pendingLevelDb.store(std::clamp(levelDb, -60.0f, -3.0f),
                            std::memory_order_relaxed);
     m_pendingPreRollFrames.store(std::max(0, preRollFrames),
                                  std::memory_order_relaxed);
+    // Clamped one frame short of the message so a nonsense skip cannot start
+    // an already-complete transmission.
+    m_pendingMessageSkipFrames.store(
+        static_cast<int>(std::clamp<int64_t>(messageSkipFrames, 0,
+                                             kMessageFrames - 1)),
+        std::memory_order_relaxed);
     m_complete.store(false, std::memory_order_relaxed);
     m_currentSymbol.store(-1, std::memory_order_relaxed);
     m_version.fetch_add(1, std::memory_order_release);
@@ -224,58 +230,118 @@ void WsprBeacon::beginPendingTransmission() noexcept
     for (int i = 0; i < kSymbolCount; ++i) {
         m_symbols[i] = m_pendingSymbols[i].load(std::memory_order_relaxed);
     }
-    m_centerHz = m_pendingCenterHz.load(std::memory_order_relaxed);
+    m_toneZeroHz = m_pendingToneZeroHz.load(std::memory_order_relaxed);
     const float levelDb = m_pendingLevelDb.load(std::memory_order_relaxed);
     m_amplitude = std::pow(10.0f, levelDb / 20.0f);
     m_preRollRemaining = m_pendingPreRollFrames.load(std::memory_order_relaxed);
-    m_symbolIndex = 0;
-    m_framesIntoSymbol = 0;
-    m_phase = 0.0f;
+    const int skip =
+        m_pendingMessageSkipFrames.load(std::memory_order_relaxed);
+    m_symbolIndex = skip / kFramesPerSymbol;
+    m_framesIntoSymbol = skip % kFramesPerSymbol;
+    m_framesEmitted = 0;
+    m_phase = 0.0;
+    m_phaseIncrement = 0.0;
+    // One decay step below the first ramp-up step, so frame 0 of the message
+    // starts at about -97.5 dB and reaches unity exactly at frame
+    // kTaperFrames - 1. See kTaperFrames in the header.
+    m_envelope = std::pow(kTaperDecayPerFrame,
+                          static_cast<float>(kTaperFrames));
     m_complete.store(false, std::memory_order_release);
     m_currentSymbol.store(-1, std::memory_order_relaxed);
     m_cachedVersion = m_version.load(std::memory_order_acquire);
 }
 
-void WsprBeacon::process(int16_t* interleaved, int frames, int channels) noexcept
+bool WsprBeacon::beginProcess() noexcept
 {
-    if (interleaved == nullptr || frames <= 0 || channels < 1 || channels > 2
-        || !isActive()) {
-        return;
+    if (!isActive()) {
+        return false;
     }
     const uint64_t version = m_version.load(std::memory_order_acquire);
     if (version != m_cachedVersion) {
         beginPendingTransmission();
     }
+    return true;
+}
 
-    for (int frame = 0; frame < frames; ++frame) {
-        int16_t sample = 0;
-        if (m_preRollRemaining > 0) {
-            --m_preRollRemaining;
-        } else if (m_symbolIndex < kSymbolCount) {
-            m_currentSymbol.store(m_symbolIndex, std::memory_order_relaxed);
-            const float tone = m_centerHz
-                + (static_cast<float>(m_symbols[m_symbolIndex]) - 1.5f)
-                      * kToneSpacingHz;
-            const float phaseIncrement =
-                kTwoPi * tone / static_cast<float>(m_sampleRate);
-            sample = static_cast<int16_t>(std::clamp(
-                std::sin(m_phase) * m_amplitude * 32767.0f,
-                -32768.0f, 32767.0f));
-            m_phase += phaseIncrement;
-            if (m_phase >= kTwoPi) {
-                m_phase -= kTwoPi;
-            }
-            ++m_framesIntoSymbol;
-            if (m_framesIntoSymbol >= kFramesPerSymbol) {
-                m_framesIntoSymbol = 0;
-                ++m_symbolIndex;
-                if (m_symbolIndex >= kSymbolCount) {
-                    m_complete.store(true, std::memory_order_release);
-                    m_currentSymbol.store(kSymbolCount, std::memory_order_relaxed);
-                }
-            }
+float WsprBeacon::nextFrameSample() noexcept
+{
+    if (m_preRollRemaining > 0) {
+        --m_preRollRemaining;
+        return 0.0f;
+    }
+    if (m_symbolIndex >= kSymbolCount) {
+        return 0.0f;
+    }
+
+    m_currentSymbol.store(m_symbolIndex, std::memory_order_relaxed);
+
+    // Tone 0 sits at the requested frequency and the constellation runs
+    // upward from there, exactly as WSJT-X does it — see start()'s comment.
+    const double tone =
+        m_toneZeroHz + static_cast<double>(m_symbols[m_symbolIndex])
+                           * kToneSpacingHz;
+    m_phaseIncrement = kTwoPi * tone / m_sampleRate;
+
+    // Phase is continuous across symbol boundaries (m_phase is never reset),
+    // so the ONLY discontinuities in the whole frame are its two ends — which
+    // is what the envelope below is for. The ramp-up keys off frames emitted
+    // and the tail off position within the message: on a late start those
+    // differ, and the ramp has to follow the audio, not the symbol clock.
+    const int64_t framePos =
+        static_cast<int64_t>(m_symbolIndex) * kFramesPerSymbol
+        + m_framesIntoSymbol;
+    if (m_framesEmitted < kTaperFrames) {
+        m_envelope = std::min(1.0f, m_envelope / kTaperDecayPerFrame);
+    } else if (framePos >= kMessageFrames - kTaperFrames) {
+        m_envelope *= kTaperDecayPerFrame;
+    } else {
+        m_envelope = 1.0f;
+    }
+    ++m_framesEmitted;
+
+    const float sample = static_cast<float>(std::sin(m_phase))
+                         * m_amplitude * m_envelope;
+    m_phase += m_phaseIncrement;
+    if (m_phase >= kTwoPi) {
+        m_phase -= kTwoPi;
+    }
+
+    ++m_framesIntoSymbol;
+    if (m_framesIntoSymbol >= kFramesPerSymbol) {
+        m_framesIntoSymbol = 0;
+        ++m_symbolIndex;
+        if (m_symbolIndex >= kSymbolCount) {
+            m_complete.store(true, std::memory_order_release);
+            m_currentSymbol.store(kSymbolCount, std::memory_order_relaxed);
         }
+    }
+    return sample;
+}
 
+void WsprBeacon::process(float* interleaved, int frames, int channels) noexcept
+{
+    if (interleaved == nullptr || frames <= 0 || channels < 1 || channels > 2
+        || !beginProcess()) {
+        return;
+    }
+    for (int frame = 0; frame < frames; ++frame) {
+        const float sample = nextFrameSample();
+        interleaved[frame * channels] = sample;
+        if (channels == 2) {
+            interleaved[frame * channels + 1] = sample;
+        }
+    }
+}
+
+void WsprBeacon::process(int16_t* interleaved, int frames, int channels) noexcept
+{
+    if (interleaved == nullptr || frames <= 0 || channels < 1 || channels > 2
+        || !beginProcess()) {
+        return;
+    }
+    for (int frame = 0; frame < frames; ++frame) {
+        const int16_t sample = static_cast<int16_t>(std::clamp(
+            nextFrameSample() * 32767.0f, -32768.0f, 32767.0f));
         interleaved[frame * channels] = sample;
         if (channels == 2) {
             interleaved[frame * channels + 1] = sample;

--- a/src/core/WsprBeacon.cpp
+++ b/src/core/WsprBeacon.cpp
@@ -333,20 +333,4 @@ void WsprBeacon::process(float* interleaved, int frames, int channels) noexcept
     }
 }
 
-void WsprBeacon::process(int16_t* interleaved, int frames, int channels) noexcept
-{
-    if (interleaved == nullptr || frames <= 0 || channels < 1 || channels > 2
-        || !beginProcess()) {
-        return;
-    }
-    for (int frame = 0; frame < frames; ++frame) {
-        const int16_t sample = static_cast<int16_t>(std::clamp(
-            nextFrameSample() * 32767.0f, -32768.0f, 32767.0f));
-        interleaved[frame * channels] = sample;
-        if (channels == 2) {
-            interleaved[frame * channels + 1] = sample;
-        }
-    }
-}
-
 } // namespace AetherSDR

--- a/src/core/WsprBeacon.cpp
+++ b/src/core/WsprBeacon.cpp
@@ -287,13 +287,23 @@ float WsprBeacon::nextFrameSample() noexcept
     // is what the envelope below is for. The ramp-up keys off frames emitted
     // and the tail off position within the message: on a late start those
     // differ, and the ramp has to follow the audio, not the symbol clock.
+    //
+    // The tail is tested FIRST so that it always wins. A messageSkipFrames deep
+    // enough to land inside the tail region would otherwise ramp UP over the
+    // few frames left and then stop dead at whatever level it reached — a step
+    // discontinuity, i.e. the exact click this taper exists to prevent. Letting
+    // the tail win leaves such a frame decaying from the seed envelope, so it
+    // ends silent instead. Unreachable from updateBeaconState(), where the skip
+    // is bounded by kBeaconMaxSlotLatenessMs, but start() is public and clamps
+    // only to kMessageFrames - 1. The ordering costs nothing on the reachable
+    // path: there the ramp runs ~24000 frames in, nowhere near the tail region.
     const int64_t framePos =
         static_cast<int64_t>(m_symbolIndex) * kFramesPerSymbol
         + m_framesIntoSymbol;
-    if (m_framesEmitted < kTaperFrames) {
-        m_envelope = std::min(1.0f, m_envelope / kTaperDecayPerFrame);
-    } else if (framePos >= kMessageFrames - kTaperFrames) {
+    if (framePos >= kMessageFrames - kTaperFrames) {
         m_envelope *= kTaperDecayPerFrame;
+    } else if (m_framesEmitted < kTaperFrames) {
+        m_envelope = std::min(1.0f, m_envelope / kTaperDecayPerFrame);
     } else {
         m_envelope = 1.0f;
     }

--- a/src/core/WsprBeacon.h
+++ b/src/core/WsprBeacon.h
@@ -92,11 +92,11 @@ public:
     // the message completes it holds silence until stop(), preventing mic
     // leakage during the queued unkey edge.
     //
-    // The float overload is what the DAX pump uses; the int16 one exists for
-    // callers already working in the radio-native integer route. Both drive
-    // the same generator, so neither can drift from the other.
+    // Float is the only output form. An int16 overload existed alongside this
+    // one and had no caller left once the DAX pump stopped quantizing; keeping
+    // it would have meant the beacon's tests covering pre-roll, completion and
+    // tail silence all ran against a path that never ships.
     void process(float* interleaved, int frames, int channels) noexcept;
-    void process(int16_t* interleaved, int frames, int channels) noexcept;
 
 private:
     void beginPendingTransmission() noexcept;

--- a/src/core/WsprBeacon.h
+++ b/src/core/WsprBeacon.h
@@ -15,8 +15,25 @@ public:
     static constexpr int kSymbolCount = 162;
     static constexpr int kSampleRate = 24000;
     static constexpr int kFramesPerSymbol = 16384;
-    static constexpr float kToneSpacingHz = 12000.0f / 8192.0f;
+    static constexpr double kToneSpacingHz = 12000.0 / 8192.0;
     static constexpr int kPreRollFrames = kSampleRate;
+
+    // Amplitude taper at both ends of the frame.
+    //
+    // WSJT-X fades its tail rather than cutting it: 0.017 symbols before the
+    // end it starts multiplying the amplitude by 0.98 per sample at 48 kHz
+    // (Modulator.cpp `if (m_ic > i0) m_amp = 0.98 * m_amp`, with
+    // `i0 = (m_symbolsLength - 0.017) * 4.0 * m_nsps`), reaching about -98 dB
+    // by the final sample. Stopping a full-scale tone dead at an arbitrary
+    // phase is a step discontinuity, and the resulting click is broadband — in
+    // a 200 Hz-wide sub-band shared by every WSPR station on the air, that
+    // lands on everyone's slot, not just ours.
+    //
+    // Same 11.6 ms duration at our 24 kHz rate, which is half as many samples,
+    // so the same total decay needs the per-sample factor squared:
+    // 0.98^2 = 0.9604 over 278 frames ≈ -97.5 dB.
+    static constexpr int kTaperFrames = kFramesPerSymbol * 17 / 1000;
+    static constexpr float kTaperDecayPerFrame = 0.9604f;
     static constexpr int64_t kMessageFrames =
         static_cast<int64_t>(kSymbolCount) * kFramesPerSymbol;
     static constexpr int64_t kTotalFrames = kPreRollFrames + kMessageFrames;
@@ -50,8 +67,21 @@ public:
     static bool isStandardPower(int powerDbm);
 
     void prepare(double sampleRate);
-    void start(const Symbols& symbols, float centerHz, float levelDb,
-               int preRollFrames = kPreRollFrames);
+    // `toneZeroHz` is the frequency of channel symbol 0 — the LOWEST of the
+    // four tones — matching WSJT-X, where the Tx-frequency spin box sets
+    // `m_frequency` and the modulator emits `m_frequency + itone[isym] *
+    // m_toneSpacing` with itone in 0..3 (Modulator.cpp). An earlier revision
+    // centred the constellation on this value instead, which put every tone
+    // 1.5 spacings — 2.197 Hz — below where WSJT-X would have put it and made
+    // every resulting spot report read 2.2 Hz low.
+    //
+    // `messageSkipFrames` starts the frame that far in, for a slot boundary
+    // that was already missed. WSJT-X does the same: when it is late it sets
+    // `m_ic = (mstr - delay_ms) * m_frameRate / 1000` and truncates the HEAD
+    // of the waveform, rather than sliding the whole 111.6 s frame later and
+    // reporting the lateness as DT (Modulator.cpp).
+    void start(const Symbols& symbols, double toneZeroHz, float levelDb,
+               int preRollFrames = kPreRollFrames, int messageSkipFrames = 0);
     void stop() noexcept;
 
     bool isActive() const noexcept;
@@ -61,15 +91,26 @@ public:
     // Audio thread. While active, always replaces the supplied buffer. After
     // the message completes it holds silence until stop(), preventing mic
     // leakage during the queued unkey edge.
+    //
+    // The float overload is what the DAX pump uses; the int16 one exists for
+    // callers already working in the radio-native integer route. Both drive
+    // the same generator, so neither can drift from the other.
+    void process(float* interleaved, int frames, int channels) noexcept;
     void process(int16_t* interleaved, int frames, int channels) noexcept;
 
 private:
     void beginPendingTransmission() noexcept;
+    // Advances the generator by exactly one frame and returns that frame's
+    // sample: silence through the pre-roll and after the final symbol, the
+    // tapered 4-FSK tone in between.
+    float nextFrameSample() noexcept;
+    bool beginProcess() noexcept;
 
     std::array<std::atomic<uint8_t>, kSymbolCount> m_pendingSymbols{};
-    std::atomic<float> m_pendingCenterHz{1500.0f};
+    std::atomic<double> m_pendingToneZeroHz{1500.0};
     std::atomic<float> m_pendingLevelDb{-20.0f};
     std::atomic<int> m_pendingPreRollFrames{kSampleRate};
+    std::atomic<int> m_pendingMessageSkipFrames{0};
     std::atomic<uint64_t> m_version{0};
     std::atomic<bool> m_active{false};
     std::atomic<bool> m_complete{false};
@@ -78,12 +119,22 @@ private:
     Symbols m_symbols{};
     uint64_t m_cachedVersion{0};
     double m_sampleRate{kSampleRate};
-    float m_centerHz{1500.0f};
+    double m_toneZeroHz{1500.0};
     float m_amplitude{0.1f};
-    float m_phase{0.0f};
+    // Double, as in WSJT-X (`double m_phi, m_dphi`). A float accumulator holds
+    // ~4.8e-7 rad of resolution near 2*pi, which it re-quantizes on every one
+    // of the 2.65 million samples in a frame; there is no reason to carry that
+    // when the alternative costs nothing.
+    double m_phase{0.0};
+    double m_phaseIncrement{0.0};
+    float m_envelope{0.0f};
     int m_preRollRemaining{0};
     int m_symbolIndex{0};
     int m_framesIntoSymbol{0};
+    // Tone frames actually emitted, which is NOT the position within the
+    // message once a late start has skipped into it. The ramp-up keys off this
+    // one so that a skipped start is still ramped; the tail keys off position.
+    int64_t m_framesEmitted{0};
 };
 
 } // namespace AetherSDR

--- a/src/gui/PskReporterMapDialog.cpp
+++ b/src/gui/PskReporterMapDialog.cpp
@@ -817,9 +817,19 @@ bool PskReporterMapDialog::applyBeaconBand()
 // move the slice in that window — another client, a band button, a profile
 // load — and until now nothing looked again.
 //
-// So this runs immediately before requestPttOn(). The generated one-second
-// pre-roll is silence, which gives the radio the whole of it to apply what we
-// just sent before the first symbol goes out.
+// So this runs immediately before requestPttOn(), and the generated lead-in is
+// silence, so the radio has that lead-in to apply what we just sent before the
+// first symbol goes out.
+//
+// How much lead-in that is depends on how late the tick was: a full second on
+// time, and NOTHING once we are a second or more past the boundary, where
+// updateBeaconState() drops the pre-roll to zero and skips into the frame
+// instead. That is the weakest case and it is deliberate — a late tick means
+// the GUI thread was stalled, which is when a stale channel is most likely,
+// but padding the lead-in to buy settling time would put the lateness straight
+// back into DT, which is the thing the slot-referenced lead-in exists to
+// remove. Losing a couple of hundred ms of the first sync symbol to a mode
+// that lands late costs less than a frame that reports a second of DT.
 bool PskReporterMapDialog::reassertBeaconChannel(QString* reason)
 {
     const auto fail = [reason](const QString& text) {
@@ -835,6 +845,16 @@ bool PskReporterMapDialog::reassertBeaconChannel(QString* reason)
     }
     if (slice->isLocked()) {
         return fail(tr("TX slice was locked"));
+    }
+    // Never write station TX state under a live carrier. applyBeaconBand()
+    // refuses on exactly this at arm time and the same has to hold here,
+    // because the transmitter can be taken by MOX, DAX, TCI or a tune in the
+    // up-to-120 s between the two. Writing `transmit set filter_low/high`
+    // mid-over reshapes the operator's voice to a 600 Hz passband in the
+    // middle of a word.
+    TransmitModel& tx = m_radioModel->transmitModel();
+    if (tx.isTransmitting() || tx.isTuning()) {
+        return fail(tr("transmitter is in use"));
     }
 
     // A dial that moved is the one thing NOT to paper over. Re-tuning here
@@ -854,7 +874,7 @@ bool PskReporterMapDialog::reassertBeaconChannel(QString* reason)
     }
     slice->setMode(QStringLiteral("DIGU"));
     slice->setFilterWidth(1200, 1800);
-    m_radioModel->transmitModel().setTxFilter(1200, 1800);
+    tx.setTxFilter(1200, 1800);
     return true;
 }
 
@@ -1080,6 +1100,25 @@ void PskReporterMapDialog::updateBeaconState()
             return;
         }
         deferBeaconToNextSlot(tr("Re-armed · waiting for WSPR TX audio stream"));
+        return;
+    }
+
+    // The transmitter can be taken between arming and the slot — MOX for a
+    // quick voice contact, DAX, TCI, a tune. That is transient and the
+    // operator has not withdrawn anything, so roll to the next slot rather
+    // than discard the arming; the bounded deferral count still stops a
+    // transmitter wedged on from leaving the beacon armed forever.
+    //
+    // Checked here as well as inside reassertBeaconChannel() because only this
+    // caller knows a busy transmitter is worth waiting out, where a slice that
+    // moved band is not.
+    if (m_radioModel->transmitModel().isTransmitting()
+        || m_radioModel->transmitModel().isTuning()) {
+        if (m_beaconDeferrals >= kBeaconMaxDeferrals) {
+            stopBeacon(tr("Stopped: transmitter is in use"));
+            return;
+        }
+        deferBeaconToNextSlot(tr("Re-armed · transmitter is in use"));
         return;
     }
 

--- a/src/gui/PskReporterMapDialog.cpp
+++ b/src/gui/PskReporterMapDialog.cpp
@@ -379,6 +379,14 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
     // was not just loose wording — the generator centred the constellation on
     // it, putting every spot 2.2 Hz below where the same number in WSJT-X
     // would have put it.
+    //
+    // The range stays 1400–1600 because that is WSJT-X's own WSPR range under
+    // the same convention: at the top of it symbol 3 lands at 1604.4 Hz, just
+    // outside the 200 Hz sub-band, exactly as it does there. Narrowing to
+    // 1595.6 would be a defensible change but it would be OURS rather than the
+    // oracle's, and the centred convention this replaces overran the top too
+    // (1600 → 1602.2) while ALSO overrunning the bottom (1400 → 1397.8), which
+    // this fixes.
     m_beaconTone->setToolTip(
         tr("Audio offset above the selected USB dial frequency, at the lowest "
            "of the four tones — the same convention as WSJT-X"));
@@ -389,7 +397,7 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
     // Hard-coded at -20 dBFS before this. WSJT-X generates at full scale and
     // attenuates digitally through its Pwr slider (SoundOutput::setAttenuation);
     // the equivalent knob here had no UI at all, so an operator who came out
-    // underdriven had nothing to reach for. Floor of -3 rather than 0 keeps a
+    // underdriven had nothing to reach for. Ceiling of -3 rather than 0 keeps a
     // little headroom ahead of the radio's own TX chain.
     m_beaconLevel->setRange(-60, -3);
     m_beaconLevel->setSingleStep(1);
@@ -754,31 +762,8 @@ bool PskReporterMapDialog::applyBeaconBand()
         m_beaconTxFilterSaved = true;
     }
 
-    // Everything in the speech chain is station-wide and mode-independent: a
-    // Flex does not bypass the speech processor, the compander or the TX
-    // equalizer just because the slice says DIGU. Left on, they operate on a
-    // constant-envelope 4-FSK tone — the compander pumps its level over the
-    // frame, the processor adds intermodulation products either side of the
-    // carrier, and the EQ tilts it — which is precisely why WSJT-X's own
-    // operating guidance is to switch all of it off for digital modes.
-    //
-    // Borrowed and handed back the same way the TX filter already is, because
-    // an operator who beacons once should not find their SSB audio rebuilt.
-    if (!m_beaconTxChainSaved && m_radioModel->usesFlexCommandPlane()) {
-        EqualizerModel& eq = m_radioModel->equalizerModel();
-        m_beaconPrevSpeechProc = tx.speechProcessorEnable();
-        m_beaconPrevCompander = tx.dexpOn();
-        m_beaconPrevVox = tx.voxEnable();
-        m_beaconPrevTxEq = eq.txEnabled();
-        m_beaconTxChainSaved = true;
-        if (m_beaconPrevSpeechProc) tx.setSpeechProcessorEnable(false);
-        if (m_beaconPrevCompander) tx.setDexp(false);
-        // VOX is not audio shaping — it is a second thing that can key and
-        // unkey the transmitter. Ours is a 111.6 s frame held by an explicit
-        // MOX, and a VOX release part-way through would truncate it.
-        if (m_beaconPrevVox) tx.setVoxEnable(false);
-        if (m_beaconPrevTxEq) eq.setTxEnabled(false);
-    }
+    // The speech chain is deliberately NOT borrowed here — it is taken at the
+    // key, in reassertBeaconChannel(). See borrowBeaconSpeechChain().
 
     // Standard WSPR dial frequencies use upper sideband on every band. Keep
     // both the slice display passband and radio TX passband comfortably around
@@ -875,7 +860,55 @@ bool PskReporterMapDialog::reassertBeaconChannel(QString* reason)
     slice->setMode(QStringLiteral("DIGU"));
     slice->setFilterWidth(1200, 1800);
     tx.setTxFilter(1200, 1800);
+    borrowBeaconSpeechChain(tx);
     return true;
+}
+
+// Switch off the station audio processing that would misshape the frame, and
+// remember what to hand back in restoreBorrowedTxState().
+//
+// Everything here is station-wide and mode-independent: a Flex does not bypass
+// the speech processor, the compander or the TX equalizer because a slice says
+// DIGU. Left on, they operate on a constant-envelope 4-FSK tone — the compander
+// pumps its level over the frame, the processor adds intermodulation products
+// either side of the carrier, and the EQ tilts it — which is precisely why
+// WSJT-X's own operating guidance is to switch all of it off for digital modes.
+//
+// Taken at the KEY rather than at arm, for the same reason mode and the
+// passbands are re-asserted here: arming happens up to 120 s before the key,
+// and up to ~6 minutes once the two permitted deferrals are spent. A borrow
+// made at arm is stale by the time it matters — anything that turns the
+// processor back on inside that window transmits through it, which is the
+// "pushed once and never checked" failure this whole function exists to close.
+// Reading the values here also means the saved copy is the operator's real
+// state at key time, so the restore cannot hand back something two minutes old.
+//
+// The secondary benefit is that the operator's own station is untouched while
+// merely armed: a beacon waiting for its slot no longer silently strips the
+// speech processor — or VOX, which would leave a VOX operator's microphone dead
+// with nothing on screen saying why — from a station they are still using.
+//
+// The generated lead-in gives the radio the same settling time these commands'
+// neighbours get; see the note above on how much lead-in that is.
+void PskReporterMapDialog::borrowBeaconSpeechChain(TransmitModel& tx)
+{
+    if (m_beaconTxChainSaved || m_radioModel == nullptr
+        || !m_radioModel->usesFlexCommandPlane()) {
+        return;
+    }
+    EqualizerModel& eq = m_radioModel->equalizerModel();
+    m_beaconPrevSpeechProc = tx.speechProcessorEnable();
+    m_beaconPrevCompander = tx.dexpOn();
+    m_beaconPrevVox = tx.voxEnable();
+    m_beaconPrevTxEq = eq.txEnabled();
+    m_beaconTxChainSaved = true;
+    if (m_beaconPrevSpeechProc) tx.setSpeechProcessorEnable(false);
+    if (m_beaconPrevCompander) tx.setDexp(false);
+    // VOX is not audio shaping — it is a second thing that can key and unkey
+    // the transmitter. Ours is a 111.6 s frame held by an explicit MOX, and a
+    // VOX release part-way through would truncate it.
+    if (m_beaconPrevVox) tx.setVoxEnable(false);
+    if (m_beaconPrevTxEq) eq.setTxEnabled(false);
 }
 
 // Restore the station-wide TX state the beacon borrowed: the transmit

--- a/src/gui/PskReporterMapDialog.cpp
+++ b/src/gui/PskReporterMapDialog.cpp
@@ -3,15 +3,19 @@
 #include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 #include "core/aprs/AprsPacket.h"
+#include "core/LogManager.h"
 #include "core/MaidenheadLocator.h"
 #include "core/PropForecastClient.h"
 #include "core/PskReporterClient.h"
 #include "core/TxKeyingMarker.h"
 #include "core/WsprBeacon.h"
 #include "map/MapView.h"
+#include "models/EqualizerModel.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
+
+#include <cmath>
 
 #include <QCheckBox>
 #include <QComboBox>
@@ -23,6 +27,7 @@
 #include <QPushButton>
 #include <QSet>
 #include <QSignalBlocker>
+#include <QSpinBox>
 #include <QStringList>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -366,12 +371,38 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
     m_beaconTone->setSuffix(tr(" Hz"));
     m_beaconTone->setValue(
         pskSettings().value("beaconToneHz").toDouble(1500.0));
-    m_beaconTone->setAccessibleName(tr("WSPR audio center frequency"));
+    m_beaconTone->setAccessibleName(tr("WSPR audio tone frequency"));
     m_beaconTone->setAccessibleDescription(
-        tr("Audio center from 1400 to 1600 hertz"));
+        tr("Audio tone from 1400 to 1600 hertz"));
+    // This is the frequency of the LOWEST of the four tones, which is what
+    // WSJT-X's Tx-frequency box means too. Naming it "center" (as this did)
+    // was not just loose wording — the generator centred the constellation on
+    // it, putting every spot 2.2 Hz below where the same number in WSJT-X
+    // would have put it.
     m_beaconTone->setToolTip(
-        tr("Audio offset above the selected USB dial frequency"));
+        tr("Audio offset above the selected USB dial frequency, at the lowest "
+           "of the four tones — the same convention as WSJT-X"));
     beaconRow->addWidget(m_beaconTone);
+
+    beaconRow->addWidget(new QLabel(tr("Level:"), beaconBox));
+    m_beaconLevel = new QSpinBox(beaconBox);
+    // Hard-coded at -20 dBFS before this. WSJT-X generates at full scale and
+    // attenuates digitally through its Pwr slider (SoundOutput::setAttenuation);
+    // the equivalent knob here had no UI at all, so an operator who came out
+    // underdriven had nothing to reach for. Floor of -3 rather than 0 keeps a
+    // little headroom ahead of the radio's own TX chain.
+    m_beaconLevel->setRange(-60, -3);
+    m_beaconLevel->setSingleStep(1);
+    m_beaconLevel->setSuffix(tr(" dBFS"));
+    m_beaconLevel->setValue(
+        pskSettings().value("beaconLevelDbFs").toInt(-20));
+    m_beaconLevel->setAccessibleName(tr("WSPR transmit audio level"));
+    m_beaconLevel->setAccessibleDescription(
+        tr("Generated audio level in decibels full scale, from -60 to -3"));
+    m_beaconLevel->setToolTip(
+        tr("Level of the generated audio into the transmit chain; raise it if "
+           "the radio comes out underdriven"));
+    beaconRow->addWidget(m_beaconLevel);
 
     m_beaconButton = new QPushButton(tr("Transmit once"), beaconBox);
     m_beaconButton->setAutoDefault(false);
@@ -605,6 +636,9 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
         }
         slice->tuneAndRecenter(dialMhz);
     });
+    connect(m_beaconLevel, &QSpinBox::valueChanged, this, [](int dbfs) {
+        writePskSetting("beaconLevelDbFs", dbfs);
+    });
     connect(m_beaconTone, &QDoubleSpinBox::valueChanged, this, [](double hz) {
         writePskSetting("beaconToneHz", hz);
     });
@@ -682,6 +716,7 @@ void PskReporterMapDialog::setBeaconControlsEnabled(bool enabled)
     m_beaconBand->setEnabled(enabled);
     m_beaconPower->setEnabled(enabled);
     m_beaconTone->setEnabled(enabled);
+    m_beaconLevel->setEnabled(enabled);
 }
 
 // Retune/reshape the TX slice for the selected WSPR band, at ARM time.
@@ -719,6 +754,32 @@ bool PskReporterMapDialog::applyBeaconBand()
         m_beaconTxFilterSaved = true;
     }
 
+    // Everything in the speech chain is station-wide and mode-independent: a
+    // Flex does not bypass the speech processor, the compander or the TX
+    // equalizer just because the slice says DIGU. Left on, they operate on a
+    // constant-envelope 4-FSK tone — the compander pumps its level over the
+    // frame, the processor adds intermodulation products either side of the
+    // carrier, and the EQ tilts it — which is precisely why WSJT-X's own
+    // operating guidance is to switch all of it off for digital modes.
+    //
+    // Borrowed and handed back the same way the TX filter already is, because
+    // an operator who beacons once should not find their SSB audio rebuilt.
+    if (!m_beaconTxChainSaved && m_radioModel->usesFlexCommandPlane()) {
+        EqualizerModel& eq = m_radioModel->equalizerModel();
+        m_beaconPrevSpeechProc = tx.speechProcessorEnable();
+        m_beaconPrevCompander = tx.dexpOn();
+        m_beaconPrevVox = tx.voxEnable();
+        m_beaconPrevTxEq = eq.txEnabled();
+        m_beaconTxChainSaved = true;
+        if (m_beaconPrevSpeechProc) tx.setSpeechProcessorEnable(false);
+        if (m_beaconPrevCompander) tx.setDexp(false);
+        // VOX is not audio shaping — it is a second thing that can key and
+        // unkey the transmitter. Ours is a 111.6 s frame held by an explicit
+        // MOX, and a VOX release part-way through would truncate it.
+        if (m_beaconPrevVox) tx.setVoxEnable(false);
+        if (m_beaconPrevTxEq) eq.setTxEnabled(false);
+    }
+
     // Standard WSPR dial frequencies use upper sideband on every band. Keep
     // both the slice display passband and radio TX passband comfortably around
     // the selectable 1400–1600 Hz WSPR offset.
@@ -738,18 +799,90 @@ bool PskReporterMapDialog::applyBeaconBand()
     return true;
 }
 
-// Restore the station-wide TX filter the beacon borrowed. The slice frequency
-// and mode are deliberately left on the WSPR channel — the operator asked to
-// go there — but the transmit passband is not slice state.
-void PskReporterMapDialog::restoreBeaconTxFilter()
+// Re-send mode and both passbands, and report whether this is still the
+// channel the operator armed.
+//
+// One push at arm time is not enough, for two reasons that compound.
+//
+// A cross-band `slice tune` makes the radio recall freq/mode/filters from its
+// BAND STACK, asynchronously, and it may recreate the slice while doing it
+// (flexlib-oracle §6.2; #2824). That recall can land after the mode= and filt
+// we sent immediately behind the tune, and when it does it wins — leaving the
+// beacon pointed at a USB slice with whatever passband the band stack held.
+// SliceModel::setMode() also deliberately declines to push a `filt` on the
+// Flex path, on the reasoning that the radio heals the passband from its own
+// per-mode memory, so the mode echo carries a filter of the radio's choosing.
+//
+// And arming happens up to a full 120 s before the key. Anything at all can
+// move the slice in that window — another client, a band button, a profile
+// load — and until now nothing looked again.
+//
+// So this runs immediately before requestPttOn(). The generated one-second
+// pre-roll is silence, which gives the radio the whole of it to apply what we
+// just sent before the first symbol goes out.
+bool PskReporterMapDialog::reassertBeaconChannel(QString* reason)
 {
-    if (!m_beaconTxFilterSaved || m_radioModel == nullptr) {
+    const auto fail = [reason](const QString& text) {
+        if (reason != nullptr) *reason = text;
+        return false;
+    };
+    if (m_radioModel == nullptr) {
+        return fail(tr("No radio"));
+    }
+    SliceModel* slice = m_radioModel->txSlice();
+    if (slice == nullptr) {
+        return fail(tr("TX slice went away"));
+    }
+    if (slice->isLocked()) {
+        return fail(tr("TX slice was locked"));
+    }
+
+    // A dial that moved is the one thing NOT to paper over. Re-tuning here
+    // would kick off a fresh band-stack recall with only the pre-roll to
+    // settle in, and transmitting 111.6 s on a frequency the operator did not
+    // choose is worse than not transmitting at all.
+    const double wantMhz = m_beaconBand->currentData().toDouble();
+    constexpr double kToleranceMhz = 0.000002;   // 2 Hz
+    if (std::abs(slice->frequency() - wantMhz) > kToleranceMhz) {
+        return fail(tr("TX slice moved to %1 MHz")
+                        .arg(slice->frequency(), 0, 'f', 6));
+    }
+
+    if (slice->mode() != QStringLiteral("DIGU")) {
+        qCInfo(lcGui) << "WSPR: TX slice was" << slice->mode()
+                      << "at key time, not DIGU — re-asserting";
+    }
+    slice->setMode(QStringLiteral("DIGU"));
+    slice->setFilterWidth(1200, 1800);
+    m_radioModel->transmitModel().setTxFilter(1200, 1800);
+    return true;
+}
+
+// Restore the station-wide TX state the beacon borrowed: the transmit
+// passband and the speech chain. The slice frequency and mode are deliberately
+// left on the WSPR channel — the operator asked to go there — but none of this
+// is slice state.
+void PskReporterMapDialog::restoreBorrowedTxState()
+{
+    if (m_radioModel == nullptr) {
         m_beaconTxFilterSaved = false;
+        m_beaconTxChainSaved = false;
         return;
     }
-    m_beaconTxFilterSaved = false;
-    m_radioModel->transmitModel().setTxFilter(m_beaconPrevTxFilterLow,
-                                              m_beaconPrevTxFilterHigh);
+    TransmitModel& tx = m_radioModel->transmitModel();
+    if (m_beaconTxFilterSaved) {
+        m_beaconTxFilterSaved = false;
+        tx.setTxFilter(m_beaconPrevTxFilterLow, m_beaconPrevTxFilterHigh);
+    }
+    if (m_beaconTxChainSaved) {
+        m_beaconTxChainSaved = false;
+        // Only what was actually on gets switched back on, so a restore can
+        // never enable something the operator had off.
+        if (m_beaconPrevSpeechProc) tx.setSpeechProcessorEnable(true);
+        if (m_beaconPrevCompander) tx.setDexp(true);
+        if (m_beaconPrevVox) tx.setVoxEnable(true);
+        if (m_beaconPrevTxEq) m_radioModel->equalizerModel().setTxEnabled(true);
+    }
 }
 
 void PskReporterMapDialog::scheduleBeacon()
@@ -811,7 +944,7 @@ void PskReporterMapDialog::scheduleBeacon()
         return;
     }
     if (!m_radioModel->prepareWsprTransmit()) {
-        restoreBeaconTxFilter();  // applyBeaconBand() already borrowed it
+        restoreBorrowedTxState();  // applyBeaconBand() already borrowed it
         m_beaconStatus->setText(tr("WSPR TX audio route is unavailable"));
         return;
     }
@@ -846,7 +979,7 @@ void PskReporterMapDialog::stopBeacon(const QString& status)
     if (m_radioModel != nullptr) {
         m_radioModel->releaseWsprTransmit();
     }
-    restoreBeaconTxFilter();
+    restoreBorrowedTxState();
     // Keep the generator active (and therefore holding silence) through the
     // local unkey command so an external DAX source cannot leak into the tail.
     if (m_audioEngine != nullptr && m_audioEngine->wsprBeacon() != nullptr) {
@@ -950,11 +1083,43 @@ void PskReporterMapDialog::updateBeaconState()
         return;
     }
 
-    // Arm the independent DAX generator before keying. The one-second
-    // generated-silence pre-roll matches the canonical WSPR start offset and
-    // lets the radio's MOX edge settle.
-    beacon->start(encoded.symbols, static_cast<float>(m_beaconTone->value()),
-                  -20.0f, WsprBeacon::kPreRollFrames);
+    // Last look at the channel before the key. See reassertBeaconChannel().
+    QString channelProblem;
+    if (!reassertBeaconChannel(&channelProblem)) {
+        stopBeacon(tr("Stopped: %1").arg(channelProblem));
+        return;
+    }
+
+    // Reference the lead-in to the SLOT, not to whenever this tick happened to
+    // run. WSPR audio starts 1.000 s into the even minute; WSJT-X computes its
+    // silent lead-in as `(delay_ms - mstr) * frameRate / 1000` against the wall
+    // clock (Modulator.cpp) rather than assuming it was called on time.
+    //
+    // This used to pass a flat kPreRollFrames — one second measured from
+    // whenever the pump started — so the 50 ms tick granularity and everything
+    // behind it landed in DT instead of being absorbed. Past the 1 s mark the
+    // lead-in is gone and the remainder truncates the head of the frame, again
+    // as WSJT-X does, which holds DT near zero rather than sliding a 111.6 s
+    // transmission later into a two-minute slot.
+    //
+    // What is still outside the measurement is the queued hop to the audio
+    // thread, where the pump clock actually starts. That is sub-millisecond
+    // against a lateness budget of two seconds.
+    const qint64 lateMs = std::max<qint64>(0, nowMs - m_beaconSlotMs);
+    const qint64 leadInMs = kBeaconAudioStartMs - lateMs;
+    const int preRollFrames = leadInMs > 0
+        ? static_cast<int>(leadInMs * WsprBeacon::kSampleRate / 1000)
+        : 0;
+    const int skipFrames = leadInMs < 0
+        ? static_cast<int>(-leadInMs * WsprBeacon::kSampleRate / 1000)
+        : 0;
+
+    // Arm the independent DAX generator before keying. The generated-silence
+    // lead-in also gives the radio's MOX edge, and the mode/filter re-assert
+    // above, time to settle before the first symbol.
+    beacon->start(encoded.symbols, m_beaconTone->value(),
+                  static_cast<float>(m_beaconLevel->value()),
+                  preRollFrames, skipFrames);
     QMetaObject::invokeMethod(
         m_audioEngine, &AudioEngine::startWsprPump, Qt::QueuedConnection);
     m_beaconStopDeadlineMs = QDateTime::currentMSecsSinceEpoch() + 115000;

--- a/src/gui/PskReporterMapDialog.h
+++ b/src/gui/PskReporterMapDialog.h
@@ -19,6 +19,7 @@ class AudioEngine;
 class PropForecastClient;
 class PskReporterClient;
 class RadioModel;
+class TransmitModel;
 
 // PSK Reporter reception map (View menu). Shows who is hearing our
 // callsign, centered on the radio's GPS fix (falling back to the reported
@@ -61,6 +62,10 @@ private:
     // whether the channel is still the one the operator armed. See the
     // definition for why one push at arm time is not enough.
     bool reassertBeaconChannel(QString* reason);
+    // Called from reassertBeaconChannel(), i.e. at the KEY and not at arm, so
+    // the operator's own station keeps its audio processing (and VOX) for the
+    // whole time the beacon is merely waiting for its slot.
+    void borrowBeaconSpeechChain(TransmitModel& tx);
     void restoreBorrowedTxState();
 
     AudioEngine*         m_audioEngine{nullptr};

--- a/src/gui/PskReporterMapDialog.h
+++ b/src/gui/PskReporterMapDialog.h
@@ -7,6 +7,7 @@
 class QCheckBox;
 class QComboBox;
 class QDoubleSpinBox;
+class QSpinBox;
 class QLabel;
 class QLineEdit;
 class QPushButton;
@@ -56,7 +57,11 @@ private:
     void updateBeaconDefaults();
     void setBeaconControlsEnabled(bool enabled);
     bool applyBeaconBand();
-    void restoreBeaconTxFilter();
+    // Re-sends mode and both passbands immediately before the key, and reports
+    // whether the channel is still the one the operator armed. See the
+    // definition for why one push at arm time is not enough.
+    bool reassertBeaconChannel(QString* reason);
+    void restoreBorrowedTxState();
 
     AudioEngine*         m_audioEngine{nullptr};
     RadioModel*         m_radioModel{nullptr};
@@ -79,6 +84,7 @@ private:
     QComboBox*          m_beaconBand{nullptr};
     QComboBox*          m_beaconPower{nullptr};
     QDoubleSpinBox*     m_beaconTone{nullptr};
+    QSpinBox*           m_beaconLevel{nullptr};
     QPushButton*        m_beaconButton{nullptr};
     QLabel*             m_beaconStatus{nullptr};
     qint64              m_beaconSlotMs{0};
@@ -94,9 +100,18 @@ private:
     static constexpr qint64 kBeaconSlotMs = 2 * 60 * 1000;
     static constexpr qint64 kBeaconMaxSlotLatenessMs = 2000;
     static constexpr int    kBeaconMaxDeferrals = 2;
+    // Canonical WSPR audio start: 1.000 s into the even minute.
+    static constexpr qint64 kBeaconAudioStartMs = 1000;
     int                 m_beaconPrevTxFilterLow{0};
     int                 m_beaconPrevTxFilterHigh{0};
     bool                m_beaconTxFilterSaved{false};
+    // The station TX processing the beacon switches off for the duration of a
+    // frame, and the values to hand back afterwards. Flex command plane only.
+    bool                m_beaconTxChainSaved{false};
+    bool                m_beaconPrevSpeechProc{false};
+    bool                m_beaconPrevCompander{false};
+    bool                m_beaconPrevVox{false};
+    bool                m_beaconPrevTxEq{false};
     bool                m_beaconArmed{false};
     bool                m_beaconTransmitting{false};
     QLabel*             m_bandCondPills[4]{};

--- a/tests/wspr_beacon_test.cpp
+++ b/tests/wspr_beacon_test.cpp
@@ -342,6 +342,36 @@ void testLateStartSkipsIntoTheFrame()
           "a skipped start is still ramped, not keyed at full amplitude");
 }
 
+// A skip deep enough to land inside the tail region must still end faded.
+//
+// updateBeaconState() cannot produce one — kBeaconMaxSlotLatenessMs caps the
+// skip at 24000 frames against a 2654208-frame message — but start() is public
+// and clamps only to kMessageFrames - 1, so the generator has to be correct on
+// its own terms. If the head ramp took precedence, the envelope would climb for
+// whatever frames remained and the message would then stop dead at that level:
+// a step discontinuity, which is the click the taper exists to remove.
+//
+// Falsifiable by construction: put the `m_framesEmitted < kTaperFrames` branch
+// back in front of the tail branch and this fails at 0.96 of full amplitude,
+// not marginally — the skip below is sized so the head ramp has exactly enough
+// frames to climb back to unity before the message runs out.
+void testSkipIntoTheTailStillFadesOut()
+{
+    constexpr int64_t kRemaining = WsprBeacon::kTaperFrames - 1;   // 277
+    constexpr int64_t kSkip = WsprBeacon::kMessageFrames - kRemaining;
+    const std::vector<float> pcm =
+        generate(uniformSymbols(0), 1500.0, -20.0f, kRemaining,
+                 static_cast<int>(kSkip));
+    constexpr float kAmplitude = 0.1f;   // -20 dBFS
+
+    float peak = 0.0f;
+    for (const float sample : pcm) {
+        peak = std::max(peak, std::abs(sample));
+    }
+    check(peak < kAmplitude * 1e-3f,
+          "a skip into the tail region decays instead of ramping back up");
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -354,6 +384,7 @@ int main(int argc, char** argv)
     testToneConventionMatchesWsjtx();
     testFrameEndsAreTapered();
     testLateStartSkipsIntoTheFrame();
+    testSkipIntoTheTailStillFadesOut();
     testIndependentDaxPump();
     if (failures == 0) {
         std::puts("WSPR beacon tests passed");

--- a/tests/wspr_beacon_test.cpp
+++ b/tests/wspr_beacon_test.cpp
@@ -106,20 +106,20 @@ void testSampleTimingAndTailSilence()
     beacon.prepare(WsprBeacon::kSampleRate);
     beacon.start(encoded.symbols, 1500.0, -20.0f, 10);
 
-    std::vector<int16_t> pcm(20, 1234);
+    std::vector<float> pcm(20, 1234.0f);
     beacon.process(pcm.data(), 10, 2);
     check(beacon.currentSymbol() == -1, "pre-roll remains before first symbol");
-    for (const int16_t sample : pcm) {
-        check(sample == 0, "pre-roll replaces microphone with silence");
+    for (const float sample : pcm) {
+        check(sample == 0.0f, "pre-roll replaces microphone with silence");
     }
 
-    pcm.assign(2, 0);
+    pcm.assign(2, 0.0f);
     beacon.process(pcm.data(), 1, 2);
     check(beacon.currentSymbol() == 0, "first symbol starts after exact pre-roll");
 
     constexpr int remainingFrames =
         WsprBeacon::kSymbolCount * WsprBeacon::kFramesPerSymbol - 1;
-    std::vector<int16_t> block(4096 * 2);
+    std::vector<float> block(4096 * 2);
     int remaining = remainingFrames;
     while (remaining > 0) {
         const int frames = std::min(remaining, 4096);
@@ -129,10 +129,10 @@ void testSampleTimingAndTailSilence()
     check(beacon.isComplete(), "message completes after exactly 162 symbols");
     check(beacon.isActive(), "source stays active until explicit stop");
 
-    block.assign(64, 1234);
+    block.assign(64, 1234.0f);
     beacon.process(block.data(), 32, 2);
-    for (const int16_t sample : block) {
-        check(sample == 0, "completed source holds silence until unkey");
+    for (const float sample : block) {
+        check(sample == 0.0f, "completed source holds silence until unkey");
     }
     beacon.stop();
     check(!beacon.isActive(), "explicit stop disables source");
@@ -149,7 +149,7 @@ void testTwentyOneSecondsDoesNotComplete()
 
     int64_t remaining =
         WsprBeacon::framesForElapsedNanoseconds(21000000000LL);
-    std::vector<int16_t> block(4096 * 2);
+    std::vector<float> block(4096 * 2);
     while (remaining > 0) {
         const int frames = static_cast<int>(
             std::min<int64_t>(remaining, 4096));
@@ -342,32 +342,6 @@ void testLateStartSkipsIntoTheFrame()
           "a skipped start is still ramped, not keyed at full amplitude");
 }
 
-// The two process() overloads drive one generator, so they cannot drift.
-void testFloatAndIntegerPathsAgree()
-{
-    constexpr int kFrames = 4096;
-    const WsprBeacon::Symbols symbols = uniformSymbols(2);
-    const std::vector<float> asFloat =
-        generate(symbols, 1500.0, -20.0f, kFrames);
-
-    WsprBeacon beacon;
-    beacon.prepare(WsprBeacon::kSampleRate);
-    beacon.start(symbols, 1500.0, -20.0f, 0);
-    std::vector<int16_t> asInt(kFrames, 0);
-    beacon.process(asInt.data(), kFrames, 1);
-
-    int mismatches = 0;
-    for (int i = 0; i < kFrames; ++i) {
-        const int expected = static_cast<int>(asFloat[static_cast<size_t>(i)]
-                                              * 32767.0f);
-        if (std::abs(expected - asInt[static_cast<size_t>(i)]) > 1) {
-            ++mismatches;
-        }
-    }
-    check(mismatches == 0,
-          "int16 and float outputs agree to within one quantization step");
-}
-
 } // namespace
 
 int main(int argc, char** argv)
@@ -380,7 +354,6 @@ int main(int argc, char** argv)
     testToneConventionMatchesWsjtx();
     testFrameEndsAreTapered();
     testLateStartSkipsIntoTheFrame();
-    testFloatAndIntegerPathsAgree();
     testIndependentDaxPump();
     if (failures == 0) {
         std::puts("WSPR beacon tests passed");

--- a/tests/wspr_beacon_test.cpp
+++ b/tests/wspr_beacon_test.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <cstdio>
@@ -103,7 +104,7 @@ void testSampleTimingAndTailSilence()
                            QStringLiteral("FN42"), 37);
     WsprBeacon beacon;
     beacon.prepare(WsprBeacon::kSampleRate);
-    beacon.start(encoded.symbols, 1500.0f, -20.0f, 10);
+    beacon.start(encoded.symbols, 1500.0, -20.0f, 10);
 
     std::vector<int16_t> pcm(20, 1234);
     beacon.process(pcm.data(), 10, 2);
@@ -144,7 +145,7 @@ void testTwentyOneSecondsDoesNotComplete()
                            QStringLiteral("FN42"), 37);
     WsprBeacon beacon;
     beacon.prepare(WsprBeacon::kSampleRate);
-    beacon.start(encoded.symbols, 1500.0f, -20.0f);
+    beacon.start(encoded.symbols, 1500.0, -20.0f);
 
     int64_t remaining =
         WsprBeacon::framesForElapsedNanoseconds(21000000000LL);
@@ -182,7 +183,7 @@ void testIndependentDaxPump()
         }
     });
 
-    engine.wsprBeacon()->start(encoded.symbols, 1500.0f, -20.0f, 0);
+    engine.wsprBeacon()->start(encoded.symbols, 1500.0, -20.0f, 0);
     engine.startWsprPump();
     QEventLoop loop;
     QTimer::singleShot(250, &loop, &QEventLoop::quit);
@@ -203,6 +204,170 @@ void testIndependentDaxPump()
           "stopping the independent pump resets generator state");
 }
 
+// Generate `frames` mono float frames with the pre-roll already spent.
+std::vector<float> generate(const WsprBeacon::Symbols& symbols,
+                            double toneZeroHz, float levelDb, int64_t frames,
+                            int skipFrames = 0)
+{
+    WsprBeacon beacon;
+    beacon.prepare(WsprBeacon::kSampleRate);
+    beacon.start(symbols, toneZeroHz, levelDb, 0, skipFrames);
+    std::vector<float> out(static_cast<size_t>(frames), 0.0f);
+    int64_t done = 0;
+    while (done < frames) {
+        const int block =
+            static_cast<int>(std::min<int64_t>(frames - done, 8192));
+        beacon.process(out.data() + done, block, 1);
+        done += block;
+    }
+    return out;
+}
+
+WsprBeacon::Symbols uniformSymbols(uint8_t value)
+{
+    WsprBeacon::Symbols symbols{};
+    symbols.fill(value);
+    return symbols;
+}
+
+// Positive-going zero crossings, which is one per cycle.
+int countCycles(const std::vector<float>& pcm, int64_t from, int64_t to)
+{
+    int cycles = 0;
+    for (int64_t i = from + 1; i < to; ++i) {
+        if (pcm[static_cast<size_t>(i - 1)] <= 0.0f
+            && pcm[static_cast<size_t>(i)] > 0.0f) {
+            ++cycles;
+        }
+    }
+    return cycles;
+}
+
+// Tone 0 must sit AT the requested frequency with the constellation running
+// upward from it, as in WSJT-X (Modulator.cpp: m_frequency + itone*spacing).
+//
+// The arithmetic is exact and that is what makes this a sharp test: one symbol
+// is 16384/24000 s and one tone step is 12000/8192 Hz, so each step adds
+// exactly ONE cycle per symbol. At 1500 Hz an all-zeros frame is 1024 cycles
+// per symbol on the nose, and all-threes is 1027.
+//
+// The superseded convention centred the four tones on the requested frequency,
+// which put tone 0 at 1497.803 Hz — 1022.5 cycles, and every spot 2.2 Hz low.
+void testToneConventionMatchesWsjtx()
+{
+    // Ten symbols, starting at symbol 1 so the head ramp is behind us. Ten
+    // rather than one because a window edge can land on the crossing sample
+    // itself and cost a count — a ±1 artifact against a 30-cycle signal.
+    constexpr int kSymbols = 10;
+    constexpr int64_t kFrom = WsprBeacon::kFramesPerSymbol;
+    constexpr int64_t kTo = kFrom + kSymbols * WsprBeacon::kFramesPerSymbol;
+    const std::vector<float> tone0 =
+        generate(uniformSymbols(0), 1500.0, -6.0f, kTo);
+    const std::vector<float> tone3 =
+        generate(uniformSymbols(3), 1500.0, -6.0f, kTo);
+
+    // 1500 Hz for ten symbols is 10240 cycles. The superseded centred
+    // convention put tone 0 at 1497.803 Hz — 10225 — so this is 15 cycles
+    // clear of the behaviour it replaced, not a rounding-width assertion.
+    check(std::abs(countCycles(tone0, kFrom, kTo) - 10240) <= 1,
+          "symbol 0 is emitted at the requested frequency, not below it");
+    check(std::abs(countCycles(tone3, kFrom, kTo) - 10270) <= 1,
+          "symbol 3 sits three tone spacings above the requested frequency");
+}
+
+// Both ends of the frame are tapered, so the transmission neither starts nor
+// stops on a step discontinuity. WSJT-X fades its tail over 0.017 symbols
+// (Modulator.cpp); the head ramp is ours, and costs 1.7% of one sync symbol.
+void testFrameEndsAreTapered()
+{
+    const std::vector<float> pcm = generate(
+        uniformSymbols(0), 1500.0, -20.0f, WsprBeacon::kMessageFrames);
+    constexpr float kAmplitude = 0.1f;   // -20 dBFS
+
+    const auto peakOver = [&pcm](int64_t from, int64_t to) {
+        float peak = 0.0f;
+        for (int64_t i = from; i < to; ++i) {
+            peak = std::max(peak, std::abs(pcm[static_cast<size_t>(i)]));
+        }
+        return peak;
+    };
+
+    // Full amplitude through the body.
+    const float body = peakOver(WsprBeacon::kFramesPerSymbol,
+                                2LL * WsprBeacon::kFramesPerSymbol);
+    check(body > kAmplitude * 0.99f && body <= kAmplitude * 1.001f,
+          "body of the frame runs at the requested level");
+
+    // Both ends land near -97 dB. Before the taper existed the final sample
+    // was an arbitrary point on a full-scale sine — a step straight to zero,
+    // which is a broadband click in a 200 Hz-wide shared sub-band.
+    check(peakOver(0, 4) < kAmplitude * 1e-3f,
+          "frame ramps up rather than starting at full amplitude");
+    check(peakOver(WsprBeacon::kMessageFrames - 4,
+                   WsprBeacon::kMessageFrames) < kAmplitude * 1e-3f,
+          "frame is faded out rather than cut at an arbitrary phase");
+
+    // And the taper is confined to the ends — a symbol boundary well inside
+    // the frame must not be attenuated, since phase is continuous there.
+    const float atBoundary = peakOver(
+        80LL * WsprBeacon::kFramesPerSymbol - 64,
+        80LL * WsprBeacon::kFramesPerSymbol + 64);
+    check(atBoundary > kAmplitude * 0.99f,
+          "interior symbol boundaries are not tapered");
+}
+
+// A slot boundary already missed truncates the HEAD of the frame rather than
+// sliding the whole thing later, which is what WSJT-X does with m_ic. The
+// head ramp still applies, because it follows the audio and not the symbol
+// clock — a skipped start is still a start.
+void testLateStartSkipsIntoTheFrame()
+{
+    constexpr int kSkip = WsprBeacon::kSampleRate;   // one second late
+    const std::vector<float> pcm =
+        generate(uniformSymbols(0), 1500.0, -20.0f, 64, kSkip);
+
+    WsprBeacon beacon;
+    beacon.prepare(WsprBeacon::kSampleRate);
+    beacon.start(uniformSymbols(0), 1500.0, -20.0f, 0, kSkip);
+    std::vector<float> one(1, 0.0f);
+    beacon.process(one.data(), 1, 1);
+    check(beacon.currentSymbol() == kSkip / WsprBeacon::kFramesPerSymbol,
+          "a late start resumes at the symbol the slot clock is already on");
+
+    float peak = 0.0f;
+    for (int i = 0; i < 4; ++i) {
+        peak = std::max(peak, std::abs(pcm[static_cast<size_t>(i)]));
+    }
+    check(peak < 0.1f * 1e-3f,
+          "a skipped start is still ramped, not keyed at full amplitude");
+}
+
+// The two process() overloads drive one generator, so they cannot drift.
+void testFloatAndIntegerPathsAgree()
+{
+    constexpr int kFrames = 4096;
+    const WsprBeacon::Symbols symbols = uniformSymbols(2);
+    const std::vector<float> asFloat =
+        generate(symbols, 1500.0, -20.0f, kFrames);
+
+    WsprBeacon beacon;
+    beacon.prepare(WsprBeacon::kSampleRate);
+    beacon.start(symbols, 1500.0, -20.0f, 0);
+    std::vector<int16_t> asInt(kFrames, 0);
+    beacon.process(asInt.data(), kFrames, 1);
+
+    int mismatches = 0;
+    for (int i = 0; i < kFrames; ++i) {
+        const int expected = static_cast<int>(asFloat[static_cast<size_t>(i)]
+                                              * 32767.0f);
+        if (std::abs(expected - asInt[static_cast<size_t>(i)]) > 1) {
+            ++mismatches;
+        }
+    }
+    check(mismatches == 0,
+          "int16 and float outputs agree to within one quantization step");
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -212,6 +377,10 @@ int main(int argc, char** argv)
     testValidation();
     testSampleTimingAndTailSilence();
     testTwentyOneSecondsDoesNotComplete();
+    testToneConventionMatchesWsjtx();
+    testFrameEndsAreTapered();
+    testLateStartSkipsIntoTheFrame();
+    testFloatAndIntegerPathsAgree();
     testIndependentDaxPump();
     if (failures == 0) {
         std::puts("WSPR beacon tests passed");


### PR DESCRIPTION
## What

The WSPR beacon transmitted a frame that decoded, but it differed from the
reference implementation in four ways that each cost signal quality or
accuracy. WSJT-X's `Modulator.cpp` is the oracle throughout — a WSPR frame is
judged by decoders we do not own, so its conventions are not ours to choose.

The reported symptom was "it opens the band in USB, not DIGU, with a very wide
open filter." That turned out to be real but only one of the five things wrong.

## The tone convention was 2.2 Hz low

WSJT-X puts tone 0 **at** the requested audio frequency and runs the
constellation upward from it — `m_frequency + itone[isym] * m_toneSpacing`,
itone in 0..3. The generator centred the four tones on that value instead, so
every tone sat 1.5 spacings — **2.197 Hz** — below where the same number in
WSJT-X would have put it, and every resulting spot report with it.

## The frame was cut, not faded

`WsprBeacon::process()` stopped emitting at symbol 162 at whatever phase and
amplitude it had reached: a step discontinuity from full scale to zero, which
is a broadband click in a 200 Hz-wide sub-band shared with every other WSPR
station on the band.

WSJT-X fades its tail — `i0 = (m_symbolsLength - 0.017) * 4.0 * m_nsps`, then
`m_amp = 0.98 * m_amp` per sample at 48 kHz, about -98 dB by the final sample.
Matched here: the same 11.6 ms, which at our 24 kHz rate is half as many
samples and so needs the factor squared, **0.9604 over 278 frames**.

The **head** ramp is an addition beyond WSJT-X, which only fades the tail. It
costs 1.7% of one sync symbol and removes the derivative discontinuity at
key-on. Flagging it explicitly as a deliberate deviation rather than burying
it — phase is continuous across symbol boundaries, so these two ends are the
only discontinuities in 111.6 seconds and both are now shaped.

## Timing was referenced to the wrong clock

The lead-in was a flat one second measured from **whenever the pump started**,
so the 50 ms GUI tick, the PTT round trip and the stream start all landed in
DT instead of being absorbed.

It is now referenced to the slot boundary, as WSJT-X does against the wall
clock (`m_silentFrames = (delay_ms - mstr) * m_frameRate / 1000`). Past the
1.000 s mark the remainder truncates the **head** of the frame — WSJT-X's
`m_ic = (mstr - delay_ms) * m_frameRate / 1000` — rather than sliding a
111.6 s transmission later into a two-minute slot. The head ramp follows
frames *emitted* rather than position in the message, so a skipped start is
still ramped.

Residual unmeasured latency is the queued hop to the audio thread, which is
sub-millisecond against a two-second lateness budget.

## The channel was pushed once and never checked

This is the reported bug. `applyBeaconBand()` sent `slice tune`, `mode=DIGU`
and `filt` back to back, and nothing looked again.

A cross-band `slice tune` makes the radio recall freq/mode/filters from its
**band stack**, asynchronously, and it may recreate the slice while doing it
(flexlib-oracle §6.2; #2824). That recall can land *after* the mode and filter
sent immediately behind it, and when it does it wins — leaving the beacon
pointed at a USB slice with whatever passband the band stack held.
`SliceModel::setMode()` also deliberately declines to push a `filt` on the Flex
path, so the mode echo carries a filter of the radio's choosing.

And arming happens up to a **full 120 seconds** before the key. Another client,
a band button or a profile load can move the slice in that window.

`reassertBeaconChannel()` now re-sends mode and both passbands immediately
before `requestPttOn()`. The generated lead-in is silence, so the radio has all
of it to apply them before the first symbol. A dial that **moved** aborts
rather than being re-tuned — a fresh band-stack recall with only the pre-roll
to settle in, on a frequency the operator did not choose, is worse than not
transmitting.

## Nothing neutralized the speech chain

A Flex does not bypass the speech processor, the compander or the TX equalizer
because a slice says DIGU. Left on, they work on a constant-envelope 4-FSK
tone: the compander pumps its level across the frame, the processor adds
intermodulation either side of the carrier, the EQ tilts it. This is exactly
why WSJT-X's operating guidance is to switch all of it off.

Arming now borrows and restores them the same way the TX filter already was,
plus VOX — which is not audio shaping but a second thing that can *unkey*
part-way through a 111.6 s frame. Only what was actually on gets turned back
on, so a restore can never enable something the operator had off. Flex command
plane only.

## Smaller items

- Phase accumulator is `double`, as in WSJT-X, rather than `float`.
- The DAX pump generates float directly instead of quantizing to int16 and
  dividing straight back — an undithered quantization of a pure tone, the one
  signal whose quantization error is harmonically correlated rather than
  noise-like.
- Transmit level is an operator control (-60..-3 dBFS, persisted) instead of
  hard-coded at -20. WSJT-X generates full scale and attenuates digitally
  through its Pwr slider (`SoundOutput::setAttenuation`); the equivalent knob
  here had no UI at all, so an operator who came out underdriven had nothing to
  reach for.

## Verification

**On air, and this is the part that matters.** Two 40 m transmissions ten hours
apart, one per build, as independently reported by wspr.live:

| Transmission | Build | Spots | Median reported |
|---|---|---|---|
| 03:14Z | before | 70 | 7,040,100.0 Hz |
| 13:54Z | after | 61 | 7,040,102.5 Hz |

**+2.5 Hz measured against the +2.197 Hz the tone-convention change predicts**,
by ~60 receivers that have never seen this source. The residual 0.3 Hz is
inside WSPR's own frequency-estimation noise. Within each transmission the
spread across independent receivers is about 1 Hz and `drift` is 0 on the large
majority — a clean, well-formed carrier. Best DX **VK5HW `PF94hk` at
13,237 km** at 37 dBm, with five Australian and two New Zealand receivers.

This matters because a convention error is invisible to any test that shares
the convention. The unit tests below assert that the generator matches *my
reading* of `Modulator.cpp`; only the spot reports confirm the reading.

**Unit tests — 4 new cases, each verified to have teeth by reverting the
behaviour under it:**

- Reverting to the centred tone convention fails both tone assertions. The test
  counts cycles over ten symbols: because one tone step is exactly one cycle
  per symbol, all-zeros is 10240 and all-threes is 10270, where the old
  convention gives 10225 — 15 cycles clear, not a rounding-width margin.
- Forcing the envelope to 1.0 fails all three taper assertions.

Full suite green: **204/204**.

## Not covered

Type-2 (compound call) and type-3 (hashed call) messages, Tx-percentage
scheduling and band hopping, and FST4W are all still absent. Out of scope here
by agreement — this PR is transmit quality for the type-1 frame we already
send.

Selecting a WSPR band still tunes only the dial, leaving mode and filter alone
until arm time. That is #4537's deliberate choice — the operator stays in their
own mode to listen before committing — so it is not overturned here. What is
now guaranteed is that the *transmission* is DIGU at 1200–1800, verified at the
key rather than hoped for at arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
