### PR TITLE
feat(hl2): live connection health — blinking heartbeat, status bar, and network diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2720,6 +2720,16 @@ target_include_directories(hl2_link_stats_test PRIVATE src tests)
 target_link_libraries(hl2_link_stats_test PRIVATE aethercore Qt6::Core Qt6::Network Qt6::Test)
 add_test(NAME hl2_link_stats_test COMMAND hl2_link_stats_test)
 
+# The CONSUMER half of the same seam. The backend can publish a perfect snapshot
+# while every readout downstream still lies, so this drives a real RadioModel
+# against a fake HL2: the readouts leaving their structural zero, the
+# absent-vs-zero predicates on BOTH sides of the disconnect edge, and the
+# per-session reset the two scoring-session entry points share.
+add_executable(hl2_link_stats_model_test tests/hl2_link_stats_model_test.cpp)
+target_include_directories(hl2_link_stats_model_test PRIVATE src tests)
+target_link_libraries(hl2_link_stats_model_test PRIVATE aethercore Qt6::Core Qt6::Network Qt6::Test)
+add_test(NAME hl2_link_stats_model_test COMMAND hl2_link_stats_model_test)
+
 # HL2 receiver churn — add/close receivers against a LIVE EP6 stream. The only
 # test that puts the m_rx reshape and the I/O-thread fan-out in contention, which
 # is what lets the weekly TSan job (.github/workflows/sanitizers.yml) exercise the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2712,6 +2712,14 @@ target_include_directories(hl2_backend_test PRIVATE src)
 target_link_libraries(hl2_backend_test PRIVATE aethercore Qt6::Core Qt6::Network Qt6::Test)
 add_test(NAME hl2_backend_test COMMAND hl2_backend_test)
 
+# HL2 transport telemetry — the IRadioBackend::linkStats seam that feeds the
+# heartbeat indicator, the status-bar Network field and the diagnostics pane on
+# a family that owns no RadioConnection and no PanadapterStream.
+add_executable(hl2_link_stats_test tests/hl2_link_stats_test.cpp)
+target_include_directories(hl2_link_stats_test PRIVATE src tests)
+target_link_libraries(hl2_link_stats_test PRIVATE aethercore Qt6::Core Qt6::Network Qt6::Test)
+add_test(NAME hl2_link_stats_test COMMAND hl2_link_stats_test)
+
 # HL2 receiver churn — add/close receivers against a LIVE EP6 stream. The only
 # test that puts the m_rx reshape and the I/O-thread fan-out in contention, which
 # is what lets the weekly TSan job (.github/workflows/sanitizers.yml) exercise the

--- a/HERMES.md
+++ b/HERMES.md
@@ -2839,10 +2839,28 @@ transport carrying everything in one stream has no such split, and five rows of
 `0 / 0 packets` read as five dead streams rather than as a distinction that
 does not apply.
 
+`hasLinkTiming()` is the third, and it exists because a backend is `reported`
+from its *first* tick on purpose — otherwise the consumer's first second keeps
+the Flex sources and renders the blank readout this whole path exists to fix.
+But `MetisClient` only fills the gap figures when a publish window closes with
+samples in it, so for about a second `gapMs` is `-1` while `reported` is already
+true. The model clamps that `-1` to `0` so the charts stay numeric, and `0` is
+`< 1 ms` again. Same trap, one field over.
+
 **The rule this generalises to:** when a readout is ported to a transport that
 cannot produce one of its figures, the figure must render as *absent*, not as
 zero. A measurement of nothing and the absence of a measurement are different
 claims about the link, and only one of them is true.
+
+**And the corollary that is easy to miss:** these predicates answer for the
+*wire*, not for the moment. `stopNetworkMonitor()` drops the snapshot on
+disconnect — those counters belong to the session that ended — but "this
+transport has no round trip to time" stays true while the transport is down. A
+predicate derived from the live snapshot alone flips back to the Flex default
+the instant the session ends, and the pane an operator left open goes from
+`n/a` to `< 1 ms` on a radio that is not even connected. `RadioModel` latches
+the transport's *shape* (`BackendLinkShape`) separately from its counters, and
+the shape dies with the backend, not with the session.
 
 ### 21.4 What IS measurable, and how it is scored
 
@@ -2887,6 +2905,11 @@ Against the HL2 at 192.168.1.21, RX-only:
   1 ms, RTT `not measured on this link` in all four places.
 
 `hl2_link_stats_test` covers the seam contract, including the silent-link case
-and the honesty invariant. Per §7 that is necessary and not sufficient — but
-the RTT and category predicates are decisions about what we *refuse* to claim,
-which is one of the few things a fixture can check honestly.
+and the honesty invariant. `hl2_link_stats_model_test` covers the half that is
+downstream of it, because the backend can publish a perfect snapshot while every
+readout still lies: it drives a real `RadioModel` against a fake HL2 and pins the
+readouts leaving their structural zero, the predicates on **both** sides of the
+disconnect edge, and the per-session reset the two scoring-session entry points
+share. Per §7 that is necessary and not sufficient — but the RTT and category
+predicates are decisions about what we *refuse* to claim, which is one of the few
+things a fixture can check honestly.

--- a/HERMES.md
+++ b/HERMES.md
@@ -2755,3 +2755,138 @@ confirming it (§7, and the wrong-sideband account in §14.6).
 - **None of it is automated yet.** Hardware verification does not survive a
   refactor; §20.15 lists the invariants to turn into certification cases so that
   it does.
+
+## 21. The network readouts, on a radio with no command plane
+
+The heartbeat dot in the title bar sat amber for a whole HL2 session. The
+status-bar `Network:` field was blank. Opening Network Diagnostics on a radio
+that was streaming 12.8 Mbps flawlessly showed 0 kbps, 0 packets, 0 bytes, and
+`Off`.
+
+None of that was a bug in those readouts. Every one of them was reading the
+Flex stack directly.
+
+### 21.1 The shape of the problem
+
+Three widgets, one root cause:
+
+| Readout | Source it read | On an HL2 |
+|---|---|---|
+| Title-bar heartbeat | `RadioModel::pingReceived`, emitted from the TCP `ping` reply | never fires |
+| Status-bar `Network:` | `networkQualityChanged`, emitted from `evaluateNetworkQuality()` | early-returned on `!m_panStream` |
+| Diagnostics pane | `RadioModel` getters, each `m_panStream ? … : 0` | structural zero |
+
+`startNetworkMonitor()` is called from exactly one place — the Flex `client
+gui` reply handler. A family that reaches `onConnected()` through the
+`IRadioBackend` seam never runs it, so the ping timer never starts, the score
+is never computed, and `m_netState` stays `Off` for the life of the session.
+
+The fix is not to make HL2 answer pings. It has nothing to answer them with
+(§21.3). The fix is that **the counters have to come from whoever owns the
+socket**, which is the backend.
+
+### 21.2 `IRadioBackend::LinkStats` — the seam addition
+
+A neutral transport snapshot, published on a fixed cadence:
+
+```
+MetisClient::LinkCounters   (I/O thread, published ~1 Hz from the receive path)
+  → Hl2Backend              (mirrored onto the GUI thread, like m_drops already was)
+    → linkStatsUpdated()    (fixed 1 Hz timer — NOT the receive path)
+      → RadioModel          (feeds the SAME scorer the Flex path uses)
+```
+
+Three decisions in there are load-bearing:
+
+**`reported` defaults to false.** A backend that does not override
+`linkStats()` sends nothing, and every consumer keeps its existing source. That
+is what makes this additive — the Flex path never sees a `LinkStats` at all,
+and `usesBackendLinkStats()` is `!m_panStream && m_linkStats.reported`, so both
+halves must be true before any fallback engages.
+
+**The publish timer lives in `Hl2Backend`, not in `MetisClient`.** The tick has
+to keep coming *after the radio goes quiet*, because "nothing arrived this
+second" is the observation the heartbeat's alarm path is waiting for. A
+backend that emits only on receive can never report its own silence. So
+`MetisClient` publishes counters from the receive path (and stops when EP6
+stops), and `Hl2Backend`'s own timer turns the frozen counter into
+`alive = false`.
+
+**`alive` is a per-tick difference, not a cumulative total.** `rxPackets`
+alone cannot distinguish a dead link from reading the same counter twice.
+
+### 21.3 There is no RTT, and saying so is the whole point
+
+Protocol 1 is a one-way stream. EP2 goes out on a wall clock, EP6 comes back
+free-running, and **no frame in either direction answers a specific frame in
+the other**. There is no round trip to time.
+
+The trap is that `lastPingRtt()` answers `0` when nothing measured it, and
+`formatNetworkMs(0)` renders `< 1 ms`. Left alone, the diagnostics pane would
+have advertised the best latency the app can display, from a measurement that
+never happened — and the *chart* would have drawn a confident flat 0 ms trace
+under the real ones, which is more believable than the number.
+
+So `LinkStats::rttMs` is `-1` for "not measured", `RadioModel::hasLinkRtt()`
+is the predicate every RTT surface asks first, and there are four of them:
+the status-bar tooltip, the Connection Details rows, the Latency tile, and the
+latency *series* — which is omitted from the graph rather than zeroed.
+
+`hasStreamCategoryStats()` is the same idea for the per-stream Audio/FFT/
+Waterfall/Meter/DAX breakdown. That is a property of the VITA-49 multiplex,
+where each category is a separately-sequenced stream sharing one socket. A
+transport carrying everything in one stream has no such split, and five rows of
+`0 / 0 packets` read as five dead streams rather than as a distinction that
+does not apply.
+
+**The rule this generalises to:** when a readout is ported to a transport that
+cannot produce one of its figures, the figure must render as *absent*, not as
+zero. A measurement of nothing and the absence of a measurement are different
+claims about the link, and only one of them is true.
+
+### 21.4 What IS measurable, and how it is scored
+
+Delivery timing, and it is timed **once per socket wakeup, not once per
+datagram**. A wakeup drains everything queued behind it, so successive
+datagrams inside one drain are microseconds apart no matter how badly the link
+is behaving — per-datagram timing reports a rock-steady 0 ms straight through a
+stall that silenced the audio.
+
+From that: `meanGapMs` and `maxGapMs` over the publish window, and jitter as
+their difference — the *spread* of delivery. On a healthy link that is a
+fraction of a millisecond; a congested one stalls and resumes, which is exactly
+what the operator hears. Sequence gaps come from the EP6 counter that already
+existed.
+
+Those feed `evaluateNetworkQuality()` unchanged, so `Fair` means the same thing
+to the operator on either radio.
+
+### 21.5 A Flex bug the HL2 work exposed
+
+`stopNetworkMonitor()` set `m_netState = Off` and emitted nothing. The
+status-bar field is written *only* from `networkQualityChanged`, and every
+emitter of that signal hangs off the ping/transport path being torn down — so
+the last quality the link ever had stayed on screen after disconnect. A
+disconnected radio reading `Excellent`, until the next connection happened to
+overwrite it.
+
+Pre-existing on the Flex path, invisible there only because nobody looked at
+the field after disconnecting. It is fixed for both families in
+`stopNetworkMonitor()`.
+
+### 21.6 Verified on hardware
+
+Against the HL2 at 192.168.1.21, RX-only:
+
+- Heartbeat samples `#20c060` green at ~1 Hz with idle grey between — no amber.
+  (Sampled by grabbing the title bar 40× at 50 ms and reading the dot pixel;
+  the green flash is a 100 ms window in a 1 s beat, so a single screenshot
+  catches it about one time in ten.)
+- Status bar `Network: [Excellent]` while connected, `[Off]` after disconnect.
+- 353 544 EP6 packets, 0 sequence gaps, 12.8 Mbps RX / 3.2 Mbps TX, arrival gap
+  1 ms, RTT `not measured on this link` in all four places.
+
+`hl2_link_stats_test` covers the seam contract, including the silent-link case
+and the honesty invariant. Per §7 that is necessary and not sufficient — but
+the RTT and category predicates are decisions about what we *refuse* to claim,
+which is one of the few things a fixture can check honestly.

--- a/docs/architecture/radio-capabilities-map.md
+++ b/docs/architecture/radio-capabilities-map.md
@@ -102,6 +102,29 @@ pattern in the Flex column: five fields across this table and the one above are
 left at their defaults, and every one of them is correct only by accident or
 inert only by luck. That is the trap in rule 1 above, sitting in the tree.
 
+## Not a capability field, but the same contract
+
+`IRadioBackend::linkStats()` / `linkStatsUpdated()` — the transport counters
+behind the title-bar heartbeat, the status-bar `Network:` field and the whole
+Network Diagnostics pane. Not in `RadioCapabilities` because it carries live
+values rather than a yes/no, but it follows rule 1 in the same shape and belongs
+on the same checklist when you add a backend.
+
+| | Flex | HL2 | Sim |
+|---|:--:|:--:|:--:|
+| overrides `linkStats()` | ❌ | ✅ | ❌ |
+
+`LinkStats::reported` defaults to **false**, and that default is the compatible
+one for once: a backend that says nothing leaves every consumer on the source it
+already had (the Flex `RadioConnection` + `PanadapterStream`). A backend that
+owns its own socket must override it, or its operator gets a connected radio
+reporting 0 kbps.
+
+Within the struct, individual figures a transport cannot measure are `-1`, not
+`0` — `RadioModel::hasLinkRtt()` and `hasStreamCategoryStats()` are the
+predicates the readouts ask before printing. See [`HERMES.md`](../../HERMES.md)
+§21.3 for why a zero there is a claim the app cannot support.
+
 ## Where the values come from
 
 - **FlexBackend** seeds `maxSlices`, `maxPanadapters` and `hasExtendedDsp` from

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -320,6 +320,55 @@ public:
     };
     virtual HealthSnapshot healthSnapshot() const { return {}; }
 
+    // The state of the TRANSPORT carrying this radio's streams, as opposed to
+    // the state of the radio itself (which is healthSnapshot's job).
+    //
+    // The network readouts — the title-bar heartbeat, the status-bar Network
+    // field, the whole Network Diagnostics dialog — were built against the Flex
+    // stack and read their numbers off a RadioConnection (TCP ping RTT) and a
+    // PanadapterStream (VITA-49 byte and sequence counters). A family that owns
+    // neither has both of those as nullptr, so every one of those surfaces read
+    // a hard zero: the heartbeat never left its pre-connect amber, and the
+    // diagnostics pane reported a connected radio pushing 0 kbps with 0 packets.
+    // Not degraded — structurally blank, on a link that was working fine.
+    //
+    // So the counters have to come from whoever owns the socket, which is the
+    // backend. This is the neutral shape of that, and it is deliberately about
+    // a TRANSPORT rather than about UDP or VITA-49: a backend gets to report
+    // the subset it can actually measure, and says so.
+    //
+    // `reported` false — the default, and what every backend that does not
+    // override this answers — means "I measure no transport", and the consumer
+    // keeps whatever source it was already using. That is what makes this
+    // additive: the Flex path never sees a LinkStats at all.
+    struct LinkStats {
+        // False: this backend measures nothing; ignore every field below.
+        bool reported = false;
+        // Traffic arrived from the radio since the PREVIOUS snapshot. This is
+        // the proof-of-life the heartbeat indicator runs on — a link that is
+        // bound and counting but has gone silent must read as dead, and a
+        // cumulative counter alone cannot say that.
+        bool alive = false;
+
+        qint64  rxBytes = 0;
+        qint64  txBytes = 0;
+        quint64 rxPackets = 0;         // cumulative, this session
+        quint64 rxPacketsLost = 0;     // cumulative sequence gaps, this session
+
+        // Negative means NOT MEASURED, which is not the same as zero and must
+        // not render as one. A stream-only transport has no request/response
+        // exchange to time, so its RTT is genuinely unknown — printing "< 1 ms"
+        // there would be the readout inventing a measurement it never took.
+        int rttMs    = -1;
+        int jitterMs = -1;
+        int gapMs    = -1;
+        int gapMaxMs = -1;
+
+        // "ip:port" of the local socket, empty when not bound.
+        QString localEndpoint;
+    };
+    virtual LinkStats linkStats() const { return {}; }
+
     // ---- vendor extensions (namespaced, capability-advertised) ----
     // Vendor-specific verbs that are NOT part of the core profile. Clients
     // discover available namespaces via capabilities().extensionNamespaces.
@@ -339,6 +388,13 @@ signals:
     void disconnected();
     void connectionError(const QString& reason);
     void capabilitiesChanged();
+
+    // A fresh transport snapshot. Emitted on a FIXED cadence while connected,
+    // not when traffic arrives — the tick has to keep coming after the radio
+    // goes quiet, because "nothing arrived this second" is the observation the
+    // heartbeat's alarm path is waiting for. A backend that emits only on
+    // receive can never report its own silence.
+    void linkStatsUpdated(const IRadioBackend::LinkStats& stats);
 
     // ---- vendor-extension replies UP (correlate to invokeExtension) ----
     // The async result of an invokeExtension() call, keyed by the caller's
@@ -527,3 +583,10 @@ signals:
 };
 
 }  // namespace AetherSDR
+
+// linkStatsUpdated is direct-connected today (Hl2Backend's cadence timer lives
+// on the same thread as its consumer), but a backend whose socket owner emits
+// it from a worker thread would need the queued path — which silently drops the
+// signal unless the type is registered. Declared here so that stays a
+// non-event.
+Q_DECLARE_METATYPE(AetherSDR::IRadioBackend::LinkStats)

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -305,6 +305,13 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
     // Link lifecycle: first EP6 -> connected; stop -> disconnected.
     connect(m_metis, &MetisClient::linkUp, this, [this] {
         m_connected = true;
+        // Started here rather than in connectRadio(): before the first EP6 there
+        // is no link to describe, and ticking through the connect attempt would
+        // publish a "reported" snapshot of zeros that reads as a dead link
+        // rather than as one that has not come up yet.
+        m_link = LinkStats{};
+        m_linkRxPacketsAtLastTick = 0;
+        m_linkStatsTimer->start();
         emit connected();
         // Publish initial slice/pan state AFTER connected(), not in connectRadio():
         // RadioModel::onConnected() stages every existing model as "previous
@@ -347,6 +354,7 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
     connect(m_metis, &MetisClient::linkDown, this, [this] {
         if (m_connected) {
             m_connected = false;
+            m_linkStatsTimer->stop();
             emit disconnected();
         }
     });
@@ -361,6 +369,7 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
         // destructor also guards against.
         QMetaObject::invokeMethod(m_metis, "stop", Qt::QueuedConnection);
         m_connected = false;
+        m_linkStatsTimer->stop();
         emit connectionError(QStringLiteral("Hermes-Lite 2: %1").arg(reason));
     });
 
@@ -382,6 +391,64 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
     // without touching an object that lives on the I/O thread.
     connect(m_metis, &MetisClient::dropsUpdated, this,
             [this](quint64 drops) { m_drops = drops; });
+    // Same mirror, for the transport counters linkStats() reports. The wire
+    // shape is translated to the seam shape HERE, so linkStats() is a plain
+    // read of a value that already lives on the reader's thread.
+    connect(m_metis, &MetisClient::linkCountersUpdated, this,
+            [this](const MetisClient::LinkCounters& c) {
+        // `reported` and `alive` are deliberately NOT set here — they are
+        // statements about the connection and the tick, not about the counters,
+        // and both publishers below own them.
+        m_link.rxBytes = static_cast<qint64>(c.rxBytes);
+        m_link.txBytes = static_cast<qint64>(c.txBytes);
+        m_link.rxPackets = c.rxPackets;
+        m_link.rxPacketsLost = c.drops;
+        // Protocol 1 is a one-way stream with no request/response exchange: EP2
+        // goes out on a wall clock and EP6 comes back free-running, and no frame
+        // in either direction answers a specific frame in the other. There is
+        // therefore no round trip to time, and -1 says exactly that rather than
+        // presenting a 0 that every readout formats as "< 1 ms".
+        m_link.rttMs = -1;
+        m_link.gapMs = c.meanGapMs;
+        m_link.gapMaxMs = c.maxGapMs;
+        // Jitter as the SPREAD of delivery within the window. On a stream with
+        // no round trip this is the honest latency-variation figure: a healthy
+        // link delivers on a metronome and reads a fraction of a millisecond,
+        // while a congested one stalls and resumes — which is precisely what the
+        // operator hears. Undefined until a window has closed with samples in it.
+        m_link.jitterMs = (c.maxGapMs >= 0 && c.meanGapMs >= 0)
+                              ? c.maxGapMs - c.meanGapMs
+                              : -1;
+        m_link.localEndpoint = c.localEndpoint;
+    });
+
+    m_linkStatsTimer = new QTimer(this);
+    m_linkStatsTimer->setInterval(kLinkStatsIntervalMs);
+    connect(m_linkStatsTimer, &QTimer::timeout, this, &Hl2Backend::publishLinkStats);
+}
+
+void Hl2Backend::publishLinkStats()
+{
+    LinkStats s = m_link;
+    // The link is REPORTED from the moment we are connected, even before the
+    // first counter snapshot has crossed from the I/O thread. Otherwise the
+    // consumer's first tick sees reported=false, keeps its Flex sources, and
+    // renders the blank readout this whole path exists to fix.
+    s.reported = true;
+    // Fresh packets since the last tick — the transport-level proof of life the
+    // heartbeat runs on. Computed here rather than in linkStats() because the
+    // comparison CONSUMES the previous value, and linkStats() is a const getter
+    // any caller may poll at any rate.
+    s.alive = m_connected && m_link.rxPackets != m_linkRxPacketsAtLastTick;
+    m_linkRxPacketsAtLastTick = m_link.rxPackets;
+    emit linkStatsUpdated(s);
+}
+
+IRadioBackend::LinkStats Hl2Backend::linkStats() const
+{
+    LinkStats s = m_link;
+    s.reported = m_connected;
+    return s;
 }
 
 Hl2Backend::Receiver* Hl2Backend::rx(int ddc)

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -89,8 +89,13 @@ public:
                          const QVariant& arg) override;
 
     HealthSnapshot healthSnapshot() const override;
+    LinkStats linkStats() const override;
 
 private:
+    // Publish linkStats() on the fixed cadence the seam promises. Driven by a
+    // timer here rather than by MetisClient's receive path so the tick survives
+    // the radio going silent — which is the case the heartbeat has to detect.
+    void publishLinkStats();
     // Re-select the companion filter board's band filter for the current slice
     // frequency. Idempotent and change-gated, so it is safe to call from every
     // path that can move the dial.
@@ -392,6 +397,19 @@ private:
     // MetisClient::droppedPackets(): that object lives on the I/O thread, and
     // healthSnapshot() is read from the GUI thread.
     quint64 m_drops = 0;
+    // Transport counters, mirrored onto THIS thread from
+    // MetisClient::linkCountersUpdated for the same reason m_drops is.
+    //
+    // Held as the SEAM's type rather than the client's: MetisClient is only
+    // forward-declared here, so a nested type of it cannot be a member, and
+    // translating at the receive lambda (where MetisClient.h is included) keeps
+    // the wire-shape-to-seam-shape mapping in exactly one place.
+    LinkStats m_link;
+    QTimer* m_linkStatsTimer = nullptr;
+    // rxPackets as of the PREVIOUS tick. The difference is the only thing that
+    // can answer "is the radio still sending", which a cumulative total cannot.
+    quint64 m_linkRxPacketsAtLastTick = 0;
+    static constexpr int kLinkStatsIntervalMs = 1000;
     bool m_adcOverload = false;
     bool m_keyed = false;
     bool m_tuning = false;

--- a/src/core/backends/hl2/MetisClient.cpp
+++ b/src/core/backends/hl2/MetisClient.cpp
@@ -34,12 +34,15 @@ std::span<const std::uint8_t> asBytes(const QByteArray& d) noexcept
     return {reinterpret_cast<const std::uint8_t*>(d.constData()), static_cast<std::size_t>(d.size())};
 }
 
-// Send a fixed-size wire buffer.
+// Send a fixed-size wire buffer. Returns the bytes the socket accepted (<0 on
+// failure), so callers can meter what actually went out rather than what they
+// asked for.
 template <std::size_t N>
-void sendTo(QUdpSocket& s, const std::array<std::uint8_t, N>& buf,
-            const QHostAddress& host, quint16 port)
+qint64 sendTo(QUdpSocket& s, const std::array<std::uint8_t, N>& buf,
+              const QHostAddress& host, quint16 port)
 {
-    s.writeDatagram(reinterpret_cast<const char*>(buf.data()), static_cast<qint64>(N), host, port);
+    return s.writeDatagram(reinterpret_cast<const char*>(buf.data()),
+                           static_cast<qint64>(N), host, port);
 }
 
 // QUdpSocket does not enable SO_BROADCAST on its own; set it on the native
@@ -65,6 +68,8 @@ MetisClient::MetisClient(QObject* parent) : QObject(parent) {
     // signal argument; without registration Qt drops the emission with only a
     // warning, and the meters would simply never move.
     qRegisterMetaType<AetherSDR::hl2::Hl2Telemetry>("AetherSDR::hl2::Hl2Telemetry");
+    qRegisterMetaType<AetherSDR::hl2::MetisClient::LinkCounters>(
+        "AetherSDR::hl2::MetisClient::LinkCounters");
 
     // Seed the C&C banks from the Params defaults rather than leaving them
     // zero-initialised until start().
@@ -132,7 +137,7 @@ MetisClient::MetisClient(QObject* parent) : QObject(parent) {
             return;   // the connect watchdog reports the failure
         }
         ++m_startAttempts;
-        sendTo(*m_socket, metisStart(m_watchdogEnabled), m_host, m_port);
+        countTx(sendTo(*m_socket, metisStart(m_watchdogEnabled), m_host, m_port));
     });
 
     m_connectWatchdog = new QTimer(this);
@@ -232,6 +237,20 @@ bool MetisClient::start(const Params& params)
     m_socket->setReadBufferSize(1 << 21);   // absorb the continuous EP6 torrent
     connect(m_socket, &QUdpSocket::readyRead, this, &MetisClient::onReadyRead);
 
+    // Counters belong to the SESSION, so they are zeroed here rather than in the
+    // constructor: a reconnect must not present the previous link's byte totals
+    // as this one's. The endpoint is captured now because it is only knowable
+    // after the bind, and it does not change for the life of the socket.
+    m_link = LinkCounters{};
+    m_link.localEndpoint = QStringLiteral("%1:%2")
+                               .arg(m_socket->localAddress().toString())
+                               .arg(m_socket->localPort());
+    m_linkWindowClock.restart();
+    m_sinceLastWakeup.invalidate();
+    m_linkWindowWakeups = 0;
+    m_linkWindowGapSumUs = 0;
+    m_linkWindowGapMaxUs = 0;
+
     // Order matters. Prime with real C&C frames FIRST so the DDC latches the
     // sample rate, NCO and receiver count, then start the stream, then prime
     // again so nothing is lost to the start transition. Starting before any C&C
@@ -248,7 +267,7 @@ bool MetisClient::start(const Params& params)
                      metisStop(m_watchdogEnabled));
 
     sendPrimingBurst(3);
-    sendTo(*m_socket, metisStart(m_watchdogEnabled), m_host, m_port);
+    countTx(sendTo(*m_socket, metisStart(m_watchdogEnabled), m_host, m_port));
     sendPrimingBurst(3);
 
     // NOT the RX sample rate: EP2 is the 48 kHz TX/audio stream (see the header).
@@ -313,7 +332,7 @@ void MetisClient::stop()
     if (m_watchdogTimer)   m_watchdogTimer->stop();
     if (m_connectWatchdog) m_connectWatchdog->stop();
     if (m_socket) {
-        sendTo(*m_socket, metisStop(m_watchdogEnabled), m_host, m_port);
+        countTx(sendTo(*m_socket, metisStop(m_watchdogEnabled), m_host, m_port));
         // Disarm only AFTER the normal stop has gone out, and before the
         // descriptor is closed. Disarming earlier would leave a window where a
         // signal arriving mid-teardown released nothing; later would leave a
@@ -407,7 +426,7 @@ void MetisClient::setReceiverCount(int count)
 
     // STOP first. Past this point the radio sends nothing, so there is no packet
     // that could be decoded against the wrong layout.
-    sendTo(*m_socket, metisStop(m_watchdogEnabled), m_host, m_port);
+    countTx(sendTo(*m_socket, metisStop(m_watchdogEnabled), m_host, m_port));
 
     m_ccConfig = ccConfig(m_params.sampleRate, after, m_params.ocFilterByte);
     m_ccRxFreq.clear();
@@ -454,7 +473,7 @@ void MetisClient::setReceiverCount(int count)
     m_expectedRxSeq = 0;
     m_sinceLastEp6.restart();
 
-    sendTo(*m_socket, metisStart(m_watchdogEnabled), m_host, m_port);
+    countTx(sendTo(*m_socket, metisStart(m_watchdogEnabled), m_host, m_port));
     sendPrimingBurst(3);
 
     // ARM THE RETRY, exactly as start() does. This start datagram is as losable
@@ -663,18 +682,72 @@ void MetisClient::sendControlPacket()
     // device leaves every receiver unassigned (and therefore emits all-zero IQ)
     // until it has seen it. Re-asserting it rather than sending it once keeps a
     // device that reconnects or resets mid-session from silently going quiet.
-    sendTo(*m_socket, buildNextControlPacket(), m_host, m_port);
+    countTx(sendTo(*m_socket, buildNextControlPacket(), m_host, m_port));
+}
+
+void MetisClient::countTx(qint64 bytesWritten) noexcept
+{
+    if (bytesWritten <= 0)
+        return;
+    m_link.txBytes += static_cast<quint64>(bytesWritten);
+    ++m_link.txPackets;
+}
+
+void MetisClient::accountReceiveWakeup()
+{
+    // Gap from the previous wakeup. The FIRST wakeup of a session has nothing
+    // to measure from, so it seeds the clock and contributes no sample —
+    // otherwise the interval since start() (which includes the priming bursts
+    // and the radio's own start latency) would land in the window as if it
+    // were a delivery stall.
+    if (m_sinceLastWakeup.isValid()) {
+        const qint64 gapUs = m_sinceLastWakeup.nsecsElapsed() / 1000;
+        ++m_linkWindowWakeups;
+        m_linkWindowGapSumUs += gapUs;
+        m_linkWindowGapMaxUs = std::max(m_linkWindowGapMaxUs, gapUs);
+    }
+    m_sinceLastWakeup.restart();
+
+    if (m_linkWindowClock.isValid() && m_linkWindowClock.elapsed() < kLinkPublishIntervalMs)
+        return;
+
+    // Round to the nearest millisecond rather than truncating: at 384 kHz the
+    // mean gap is a few hundred microseconds, and truncation would publish a
+    // flat 0 ms for every healthy link — indistinguishable from not measuring.
+    auto usToMs = [](qint64 us) { return static_cast<int>((us + 500) / 1000); };
+    m_link.meanGapMs = m_linkWindowWakeups > 0
+                           ? usToMs(m_linkWindowGapSumUs / m_linkWindowWakeups)
+                           : -1;
+    m_link.maxGapMs = m_linkWindowWakeups > 0 ? usToMs(m_linkWindowGapMaxUs) : -1;
+
+    emit linkCountersUpdated(m_link);
+
+    // The gap figures describe the window that just closed, so the window is
+    // reset here. The cumulative byte/packet totals are NOT — those are session
+    // figures and the consumer diffs them itself.
+    m_linkWindowClock.restart();
+    m_linkWindowWakeups = 0;
+    m_linkWindowGapSumUs = 0;
+    m_linkWindowGapMaxUs = 0;
 }
 
 void MetisClient::onReadyRead()
 {
+    accountReceiveWakeup();
+
     while (m_socket && m_socket->hasPendingDatagrams()) {
         const QNetworkDatagram dg = m_socket->receiveDatagram();
         const auto bytes = asBytes(dg.data());
+        // Counted before the EP6 test: these bytes crossed the wire and were
+        // read off this socket whatever they turned out to be, and a receive
+        // total that silently omits traffic is worse than one that includes a
+        // stray discovery reply.
+        m_link.rxBytes += static_cast<quint64>(dg.data().size());
 
         const auto seq = ep6Seq(bytes);
         if (!seq)
             continue;   // not an EP6 packet (e.g. a stray discovery reply)
+        ++m_link.rxPackets;
 
         // Restarted on every packet: this is the one piece of state that says how
         // recently the stream produced anything, which both the silence watchdog
@@ -696,6 +769,7 @@ void MetisClient::onReadyRead()
             const std::uint32_t gap = *seq - m_expectedRxSeq;   // unsigned wrap
             if (gap < 0x80000000u) {                            // forward gap = real loss
                 m_drops += gap;
+                m_link.drops = m_drops;
                 emit dropsUpdated(m_drops);
             }
         }

--- a/src/core/backends/hl2/MetisClient.cpp
+++ b/src/core/backends/hl2/MetisClient.cpp
@@ -239,12 +239,19 @@ bool MetisClient::start(const Params& params)
 
     // Counters belong to the SESSION, so they are zeroed here rather than in the
     // constructor: a reconnect must not present the previous link's byte totals
-    // as this one's. The endpoint is captured now because it is only knowable
-    // after the bind, and it does not change for the life of the socket.
+    // as this one's.
+    //
+    // The port is knowable now; the ADDRESS is not. The bind above is a wildcard,
+    // so localAddress() answers 0.0.0.0 — which names no interface to an operator
+    // debugging a multi-homed host, where the Flex readout shows a real one in the
+    // same field. Which interface actually reaches the radio is a routing decision
+    // the kernel makes per datagram, and receiveDatagram() already asks for that
+    // metadata, so onReadyRead() upgrades this from the first datagram that
+    // carries a destination. "*" states the wildcard in the meantime rather than
+    // dressing it up as an address.
     m_link = LinkCounters{};
-    m_link.localEndpoint = QStringLiteral("%1:%2")
-                               .arg(m_socket->localAddress().toString())
-                               .arg(m_socket->localPort());
+    m_link.localEndpoint = QStringLiteral("*:%1").arg(m_socket->localPort());
+    m_linkEndpointResolved = false;
     m_linkWindowClock.restart();
     m_sinceLastWakeup.invalidate();
     m_linkWindowWakeups = 0;
@@ -707,7 +714,10 @@ void MetisClient::accountReceiveWakeup()
         m_linkWindowGapMaxUs = std::max(m_linkWindowGapMaxUs, gapUs);
     }
     m_sinceLastWakeup.restart();
+}
 
+void MetisClient::publishLinkCountersIfDue()
+{
     if (m_linkWindowClock.isValid() && m_linkWindowClock.elapsed() < kLinkPublishIntervalMs)
         return;
 
@@ -743,6 +753,20 @@ void MetisClient::onReadyRead()
         // total that silently omits traffic is worse than one that includes a
         // stray discovery reply.
         m_link.rxBytes += static_cast<quint64>(dg.data().size());
+
+        // The local address the kernel actually delivered on, which a wildcard
+        // bind cannot tell us (see start()). Latched once: it is a routing fact
+        // about this socket, and re-testing it per datagram would cost a string
+        // compare on the hot path for an answer that does not change.
+        if (!m_linkEndpointResolved) {
+            const QHostAddress dest = dg.destinationAddress();
+            if (!dest.isNull()) {
+                m_link.localEndpoint = QStringLiteral("%1:%2")
+                                           .arg(dest.toString())
+                                           .arg(m_socket->localPort());
+                m_linkEndpointResolved = true;
+            }
+        }
 
         const auto seq = ep6Seq(bytes);
         if (!seq)
@@ -820,6 +844,12 @@ void MetisClient::onReadyRead()
             emit iqBlocksReady(m_blocks);
         }
     }
+
+    // AFTER the drain, not before it. The gap sample belongs to the wakeup and is
+    // taken at the top, but the byte and packet totals only become true once the
+    // datagrams behind this wakeup have been counted — publishing first shipped a
+    // snapshot that was one full drain out of date.
+    publishLinkCountersIfDue();
 }
 
 }  // namespace AetherSDR::hl2

--- a/src/core/backends/hl2/MetisClient.h
+++ b/src/core/backends/hl2/MetisClient.h
@@ -89,9 +89,20 @@ public:
         // reported as if it were still happening. Negative = nothing measured.
         int meanGapMs = -1;
         int maxGapMs = -1;
-        QString localEndpoint;      // "ip:port" of our bound socket
+        // "ip:port" of our bound socket. The address is the one the KERNEL
+        // delivered on, taken from the first datagram that carries a
+        // destination — a wildcard bind knows only the port, and "0.0.0.0"
+        // names no interface to an operator debugging a multi-homed host.
+        // "*:<port>" until (or unless) the platform supplies it.
+        QString localEndpoint;
     };
-    [[nodiscard]] const LinkCounters& linkCounters() const noexcept { return m_link; }
+    // I/O-THREAD ONLY, exactly like droppedPackets(): m_link is written from the
+    // receive path and this object lives on the I/O thread. Returned BY VALUE
+    // rather than by reference because LinkCounters holds a QString — handing out
+    // a reference to one that another thread is assigning is an implicit-sharing
+    // refcount race, not merely a torn integer. GUI-thread consumers read the
+    // copy Hl2Backend mirrors from linkCountersUpdated instead.
+    [[nodiscard]] LinkCounters linkCounters() const { return m_link; }
 
     // Blocking discovery broadcast; returns HPSDR/HL2 replies (deduped by MAC)
     // seen within timeoutMs. Safe to call before start().
@@ -265,9 +276,13 @@ private slots:
 
 private:
     void sendControlPacket();           // one round-robin EP2 C&C packet
-    // Accumulate one socket wakeup into the gap window and publish the counters
-    // if the window has elapsed.
+    // Accumulate one socket wakeup into the gap window. Called at the TOP of
+    // onReadyRead, because the instant the wakeup happened is what it measures.
     void accountReceiveWakeup();
+    // Emit the counters if the publish window has elapsed. Called at the END of
+    // onReadyRead, because the byte and packet totals are only true once this
+    // wakeup's datagrams have been drained and counted.
+    void publishLinkCountersIfDue();
     // Meter one outgoing datagram. Takes the socket's return value, so a write
     // the kernel refused is not counted as traffic that left the host.
     void countTx(qint64 bytesWritten) noexcept;
@@ -364,6 +379,7 @@ private:
 
     // ---- transport counters (see LinkCounters) ----
     LinkCounters  m_link;
+    bool          m_linkEndpointResolved = false;   // a datagram named our local address
     QElapsedTimer m_linkWindowClock;    // time since the last publish
     QElapsedTimer m_sinceLastWakeup;    // socket wakeup spacing
     int           m_linkWindowWakeups = 0;

--- a/src/core/backends/hl2/MetisClient.h
+++ b/src/core/backends/hl2/MetisClient.h
@@ -69,6 +69,30 @@ public:
         QHostAddress address;
     };
 
+    // Transport counters for the network readouts. Everything here is measured
+    // on THIS socket, which is why it lives at this level and not above it:
+    // nothing further up the stack ever sees a datagram.
+    //
+    // The gap figures are timed once per SOCKET WAKEUP, not once per datagram,
+    // and that distinction is the whole reason they are usable. A wakeup drains
+    // every datagram queued behind it, so successive datagrams inside one drain
+    // are microseconds apart no matter how badly the link is behaving — timing
+    // those would report a rock-steady 0 ms through a stall that silenced the
+    // audio. Wakeup-to-wakeup is when packets actually reached us.
+    struct LinkCounters {
+        quint64 rxBytes = 0;
+        quint64 txBytes = 0;
+        quint64 rxPackets = 0;      // EP6 datagrams accepted
+        quint64 txPackets = 0;      // datagrams sent (EP2 + start/stop)
+        quint64 drops = 0;          // cumulative EP6 sequence gaps
+        // Over the publish window only, so a stall that has ended stops being
+        // reported as if it were still happening. Negative = nothing measured.
+        int meanGapMs = -1;
+        int maxGapMs = -1;
+        QString localEndpoint;      // "ip:port" of our bound socket
+    };
+    [[nodiscard]] const LinkCounters& linkCounters() const noexcept { return m_link; }
+
     // Blocking discovery broadcast; returns HPSDR/HL2 replies (deduped by MAC)
     // seen within timeoutMs. Safe to call before start().
     QList<Discovered> discover(int timeoutMs = 2000,
@@ -218,6 +242,14 @@ signals:
     // this object reuses, so a receiver must copy anything it keeps.
     void iqBlocksReady(const std::vector<std::vector<std::complex<float>>>& blocks);
     void dropsUpdated(quint64 drops);                             // cumulative EP6 gaps
+    // Transport counters, published about once a second from the receive path.
+    // Rate-limited for the same reason telemetryUpdated is: this would otherwise
+    // cross to the GUI thread thousands of times a second to move a byte count.
+    //
+    // It stops arriving when EP6 stops, and that is load-bearing — the consumer
+    // reads the absence as the link having gone quiet. Do NOT "fix" this by
+    // driving it from a timer here.
+    void linkCountersUpdated(const AetherSDR::hl2::MetisClient::LinkCounters& c);
     // Radio telemetry decoded from the EP6 C&C bytes: forward/reverse power,
     // temperature, TX FIFO depth, ADC overload, PTT. Free-running, so it
     // arrives without us issuing a request.
@@ -233,6 +265,12 @@ private slots:
 
 private:
     void sendControlPacket();           // one round-robin EP2 C&C packet
+    // Accumulate one socket wakeup into the gap window and publish the counters
+    // if the window has elapsed.
+    void accountReceiveWakeup();
+    // Meter one outgoing datagram. Takes the socket's return value, so a write
+    // the kernel refused is not counted as traffic that left the host.
+    void countTx(qint64 bytesWritten) noexcept;
     // Send countPerBank C&C frames, pause, then countPerBank more. Run BEFORE
     // metis-start so the DDC latches sample rate / NCO / receiver count from a
     // real C&C frame; a stream started before any C&C has landed emits ADC-idle
@@ -323,6 +361,15 @@ private:
     // publishTelemetry() does not flood the GUI thread. (#4449 review)
     QElapsedTimer m_telemetryEmitClock;
     static constexpr qint64 kTelemetryMinIntervalMs = 100;
+
+    // ---- transport counters (see LinkCounters) ----
+    LinkCounters  m_link;
+    QElapsedTimer m_linkWindowClock;    // time since the last publish
+    QElapsedTimer m_sinceLastWakeup;    // socket wakeup spacing
+    int           m_linkWindowWakeups = 0;
+    qint64        m_linkWindowGapSumUs = 0;
+    qint64        m_linkWindowGapMaxUs = 0;
+    static constexpr qint64 kLinkPublishIntervalMs = 1000;
 };
 
 }  // namespace AetherSDR::hl2
@@ -332,3 +379,5 @@ private:
 // deliberately Qt-free so the wire primitives unit-test without linking Qt,
 // and hl2_metis_protocol_test does exactly that.
 Q_DECLARE_METATYPE(AetherSDR::hl2::Hl2Telemetry)
+// Same reason: LinkCounters crosses the I/O thread to the GUI thread queued.
+Q_DECLARE_METATYPE(AetherSDR::hl2::MetisClient::LinkCounters)

--- a/src/gui/MainWindowHelpers.cpp
+++ b/src/gui/MainWindowHelpers.cpp
@@ -41,6 +41,11 @@ bool macDaxDriverInstalled()
 
 // ─── Network diagnostics tooltip ─────────────────────────────────────────────
 
+// Shown where a figure exists in the readout but this transport cannot produce
+// it. Deliberately not "0" or "—": the operator must be able to tell a
+// measurement of nothing from the absence of a measurement.
+const QString kNetworkNotMeasured = QStringLiteral("not measured on this link");
+
 QString formatNetworkMs(int ms)
 {
     return ms < 1 ? "< 1 ms" : QString("%1 ms").arg(ms);
@@ -153,10 +158,18 @@ QString buildNetworkTooltip(const RadioModel& model,
     }
 
     html += networkTooltipSection(QStringLiteral("LINK TIMING"));
-    html += networkTooltipRow(QStringLiteral("Current RTT"),
-                              formatNetworkMs(model.lastPingRtt()));
-    html += networkTooltipRow(QStringLiteral("Session maximum"),
-                              formatNetworkMs(model.maxPingRtt()));
+    // A transport with no request/response exchange has no round trip to time.
+    // formatNetworkMs(0) renders "< 1 ms", so printing the getter unconditionally
+    // would show the best possible latency on a link nothing ever pinged.
+    if (model.hasLinkRtt()) {
+        html += networkTooltipRow(QStringLiteral("Current RTT"),
+                                  formatNetworkMs(model.lastPingRtt()));
+        html += networkTooltipRow(QStringLiteral("Session maximum"),
+                                  formatNetworkMs(model.maxPingRtt()));
+    } else {
+        html += networkTooltipRow(QStringLiteral("Current RTT"),
+                                  kNetworkNotMeasured);
+    }
     html += networkTooltipRow(QStringLiteral("Network jitter"),
                               formatNetworkMs(model.audioPacketJitterMs()));
     html += networkTooltipRow(
@@ -174,13 +187,20 @@ QString buildNetworkTooltip(const RadioModel& model,
         QStringLiteral("Session sequence gaps"),
         formatNetworkSeqErrors(model.packetDropCount(), model.packetTotalCount()));
 
-    html += networkTooltipSection(QStringLiteral("STREAM SEQUENCE GAPS"));
-    html += networkTooltipRow(QStringLiteral("Audio"), formatCategorySeqErrors(audioStats));
-    html += networkTooltipRow(QStringLiteral("FFT"), formatCategorySeqErrors(fftStats));
-    html += networkTooltipRow(QStringLiteral("Waterfall"),
-                              formatCategorySeqErrors(waterfallStats));
-    html += networkTooltipRow(QStringLiteral("Meters"), formatCategorySeqErrors(meterStats));
-    html += networkTooltipRow(QStringLiteral("DAX"), formatCategorySeqErrors(daxStats));
+    // Per-category counters are a property of the VITA-49 multiplex, where each
+    // category is a separately-sequenced stream sharing one socket. A transport
+    // that carries everything in a single stream has no such breakdown, and five
+    // rows of "0 / 0 packets" would read as five dead streams rather than as a
+    // distinction that does not apply.
+    if (model.hasStreamCategoryStats()) {
+        html += networkTooltipSection(QStringLiteral("STREAM SEQUENCE GAPS"));
+        html += networkTooltipRow(QStringLiteral("Audio"), formatCategorySeqErrors(audioStats));
+        html += networkTooltipRow(QStringLiteral("FFT"), formatCategorySeqErrors(fftStats));
+        html += networkTooltipRow(QStringLiteral("Waterfall"),
+                                  formatCategorySeqErrors(waterfallStats));
+        html += networkTooltipRow(QStringLiteral("Meters"), formatCategorySeqErrors(meterStats));
+        html += networkTooltipRow(QStringLiteral("DAX"), formatCategorySeqErrors(daxStats));
+    }
 
     html += networkTooltipSection(QStringLiteral("UDP TRAFFIC"));
     html += networkTooltipRow(QStringLiteral("Received"),

--- a/src/gui/MainWindowHelpers.cpp
+++ b/src/gui/MainWindowHelpers.cpp
@@ -170,13 +170,22 @@ QString buildNetworkTooltip(const RadioModel& model,
         html += networkTooltipRow(QStringLiteral("Current RTT"),
                                   kNetworkNotMeasured);
     }
-    html += networkTooltipRow(QStringLiteral("Network jitter"),
-                              formatNetworkMs(model.audioPacketJitterMs()));
-    html += networkTooltipRow(
-        QStringLiteral("Audio gap"),
-        QStringLiteral("%1 · max %2")
-            .arg(formatNetworkMs(model.audioPacketGapMs()),
-                 formatNetworkMs(model.audioPacketGapMaxMs())));
+    // Same rule, one field over. A backend is `reported` from its first tick on
+    // purpose, but its first delivery-timing window has not closed yet, and the
+    // getters clamp that "not measured" sentinel to 0 for the charts — which
+    // reads here as the best delivery the app can display.
+    if (model.hasLinkTiming()) {
+        html += networkTooltipRow(QStringLiteral("Network jitter"),
+                                  formatNetworkMs(model.audioPacketJitterMs()));
+        html += networkTooltipRow(
+            QStringLiteral("Audio gap"),
+            QStringLiteral("%1 · max %2")
+                .arg(formatNetworkMs(model.audioPacketGapMs()),
+                     formatNetworkMs(model.audioPacketGapMaxMs())));
+    } else {
+        html += networkTooltipRow(QStringLiteral("Network jitter"), kNetworkNotMeasured);
+        html += networkTooltipRow(QStringLiteral("Audio gap"), kNetworkNotMeasured);
+    }
 
     html += networkTooltipSection(QStringLiteral("PACKET INTEGRITY"));
     html += networkTooltipRow(

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -58,10 +58,11 @@
 
 namespace AetherSDR {
 
-// Shown wherever a latency figure is displayed on a transport that has no round
-// trip to time. Distinct from "0" on purpose — a measurement of nothing and the
-// absence of a measurement are different claims about the link.
-const QString kRttNotMeasured = QStringLiteral("not measured on this link");
+// Shown wherever a figure is displayed that THIS transport cannot produce —
+// latency on a stream with no round trip to time, delivery spacing before the
+// first timing window has closed. Distinct from "0" on purpose: a measurement of
+// nothing and the absence of a measurement are different claims about the link.
+const QString kNotMeasuredOnLink = QStringLiteral("not measured on this link");
 
 constexpr const char* kNetworkDiagnosticsStyle = R"(
 QWidget {
@@ -3248,7 +3249,7 @@ void NetworkDiagnosticsDialog::refresh()
     const int rtt = m_model->lastPingRtt();
     const QString rttText = haveRtt
         ? (rtt < 1 ? QStringLiteral("< 1 ms") : QStringLiteral("%1 ms").arg(rtt))
-        : kRttNotMeasured;
+        : kNotMeasuredOnLink;
     m_rttLabel->setText(rttText);
     m_overviewStatusValue->setText(m_model->networkQuality());
     m_overviewLatencyValue->setText(haveRtt ? rttText : QStringLiteral("n/a"));
@@ -3256,7 +3257,7 @@ void NetworkDiagnosticsDialog::refresh()
     const int maxRtt = m_model->maxPingRtt();
     m_maxRttLabel->setText(
         haveRtt ? (maxRtt < 1 ? QStringLiteral("< 1 ms") : QStringLiteral("%1 ms").arg(maxRtt))
-                : kRttNotMeasured);
+                : kNotMeasuredOnLink);
 
     // Per-category rates
     static constexpr PanadapterStream::StreamCategory cats[] = {
@@ -3343,9 +3344,18 @@ void NetworkDiagnosticsDialog::refresh()
         m_audioUnderrunLabel->setText(QString::number(underruns));
         m_audioUnderrunRateLabel->setText(QString::number(sample.underrunsPerSecond, 'f', 0));
 
-        m_audioPacketGapLabel->setText(formatMsValue(m_model->audioPacketGapMs()));
-        m_audioPacketGapMaxLabel->setText(formatMsValue(m_model->audioPacketGapMaxMs()));
-        m_audioJitterLabel->setText(formatMsValue(m_model->audioPacketJitterMs()));
+        // formatMsValue(0) is "< 1 ms", and the model clamps the seam's
+        // "not measured" sentinel to 0 so the charts stay numeric — so these
+        // three ask the same question the RTT rows above do before printing.
+        // A backend is `reported` from its first tick, a second before its first
+        // delivery-timing window closes.
+        const bool haveTiming = m_model->hasLinkTiming();
+        m_audioPacketGapLabel->setText(
+            haveTiming ? formatMsValue(m_model->audioPacketGapMs()) : kNotMeasuredOnLink);
+        m_audioPacketGapMaxLabel->setText(
+            haveTiming ? formatMsValue(m_model->audioPacketGapMaxMs()) : kNotMeasuredOnLink);
+        m_audioJitterLabel->setText(
+            haveTiming ? formatMsValue(m_model->audioPacketJitterMs()) : kNotMeasuredOnLink);
         m_audioStreamLabel->setText(formatAudioStream(sample, sliceLabels));
         m_audioFeedRateLabel->setText(formatFeedRate(sample.audioFeedRateHz, sample.audioStreamCount));
         m_audioFeedDeficitLabel->setText(formatFeedDeficit(sample.audioFeedDeficitMs));

--- a/src/gui/NetworkDiagnosticsDialog.cpp
+++ b/src/gui/NetworkDiagnosticsDialog.cpp
@@ -58,6 +58,11 @@
 
 namespace AetherSDR {
 
+// Shown wherever a latency figure is displayed on a transport that has no round
+// trip to time. Distinct from "0" on purpose — a measurement of nothing and the
+// absence of a measurement are different claims about the link.
+const QString kRttNotMeasured = QStringLiteral("not measured on this link");
+
 constexpr const char* kNetworkDiagnosticsStyle = R"(
 QWidget {
     color: #aeb9cc;
@@ -2739,7 +2744,9 @@ void NetworkDiagnosticsHistory::sampleNow()
     const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
     const double elapsedSeconds = std::max(0.001, (nowMs - m_lastSampleMs) / 1000.0);
     sample.timestampMs = nowMs;
-    sample.rttMs = m_model->lastPingRtt();
+    // -1 means "this transport has no round trip to time", so the trace can be
+    // omitted rather than drawn as a flat 0 ms line. See the latency series.
+    sample.rttMs = m_model->hasLinkRtt() ? m_model->lastPingRtt() : -1;
 
     static constexpr PanadapterStream::StreamCategory cats[] = {
         PanadapterStream::CatAudio, PanadapterStream::CatFFT,
@@ -3234,13 +3241,22 @@ void NetworkDiagnosticsDialog::refresh()
     m_udpEndpointLabel->setText(m_model->localUdpEndpoint());
     m_udpSeenLabel->setText(m_model->firstUdpPacketSeen() ? "Yes" : "No");
 
+    // "< 1 ms" is what a zero RTT formats to, so on a transport that has no
+    // round trip to time these three would advertise the best latency the app
+    // can display — from a measurement nothing ever took. Say so instead.
+    const bool haveRtt = m_model->hasLinkRtt();
     const int rtt = m_model->lastPingRtt();
-    m_rttLabel->setText(rtt < 1 ? "< 1 ms" : QString("%1 ms").arg(rtt));
+    const QString rttText = haveRtt
+        ? (rtt < 1 ? QStringLiteral("< 1 ms") : QStringLiteral("%1 ms").arg(rtt))
+        : kRttNotMeasured;
+    m_rttLabel->setText(rttText);
     m_overviewStatusValue->setText(m_model->networkQuality());
-    m_overviewLatencyValue->setText(rtt < 1 ? "< 1 ms" : QString("%1 ms").arg(rtt));
+    m_overviewLatencyValue->setText(haveRtt ? rttText : QStringLiteral("n/a"));
 
     const int maxRtt = m_model->maxPingRtt();
-    m_maxRttLabel->setText(maxRtt < 1 ? "< 1 ms" : QString("%1 ms").arg(maxRtt));
+    m_maxRttLabel->setText(
+        haveRtt ? (maxRtt < 1 ? QStringLiteral("< 1 ms") : QStringLiteral("%1 ms").arg(maxRtt))
+                : kRttNotMeasured);
 
     // Per-category rates
     static constexpr PanadapterStream::StreamCategory cats[] = {
@@ -3250,7 +3266,21 @@ void NetworkDiagnosticsDialog::refresh()
     QLabel* rateLabels[] = { m_audioRateLabel, m_fftRateLabel, m_wfRateLabel, m_meterRateLabel };
     QLabel* dropLabels[] = { m_audioDropLabel, m_fftDropLabel, m_wfDropLabel, m_meterDropLabel };
 
+    // The per-category breakdown describes the VITA-49 multiplex: five
+    // separately-sequenced streams sharing one socket. A transport that carries
+    // everything in a single stream has no such split, and printing "0 kbps ·
+    // 0 / 0 packets" on five rows reads as five dead streams rather than as a
+    // distinction that does not apply to this radio. The TOTAL rx/tx rows below
+    // are real on both and are left alone.
+    const bool perStream = m_model->hasStreamCategoryStats();
+    const QString notApplicable = QStringLiteral("n/a");
+
     for (int i = 0; i < 4; ++i) {
+        if (!perStream) {
+            rateLabels[i]->setText(notApplicable);
+            dropLabels[i]->setText(notApplicable);
+            continue;
+        }
         PanadapterStream::CategoryStats cs = m_model->categoryStats(cats[i]);
         double rateKbps = 0.0;
         if (cats[i] == PanadapterStream::CatAudio) {
@@ -3267,7 +3297,10 @@ void NetworkDiagnosticsDialog::refresh()
     }
 
     // DAX traffic
-    {
+    if (!perStream) {
+        m_daxRateLabel->setText(notApplicable);
+        m_daxDropLabel->setText(notApplicable);
+    } else {
         PanadapterStream::CategoryStats cs = m_model->categoryStats(PanadapterStream::CatDAX);
         m_daxRateLabel->setText(QString("%1 kbps").arg(static_cast<int>(sample.daxKbps)));
         m_daxDropLabel->setText(formatDrop(cs));
@@ -3534,27 +3567,42 @@ void NetworkDiagnosticsDialog::updateCharts()
         return series;
     };
 
-    QVector<TimeSeriesGraphWidget::Series> latencySeries{
-        buildSeriesWithUnit("RTT", QColor("#00b4d8"), " ms", [](const NetworkDiagnosticsSample& s) { return static_cast<double>(s.rttMs); }),
-        buildSeriesWithUnit("Arrival gap", QColor("#f2c94c"), " ms", [](const NetworkDiagnosticsSample& s) { return static_cast<double>(s.audioGapMs); }),
-        buildSeriesWithUnit("Jitter", QColor("#eb5757"), " ms", [](const NetworkDiagnosticsSample& s) { return static_cast<double>(s.audioJitterMs); })
-    };
+    // The RTT trace is OMITTED, not zeroed, on a transport with no round trip to
+    // time. Samples carry -1 for "not measured", and std::max(0.0, …) inside the
+    // series builders would flatten that to a confident 0 ms line running under
+    // the real traces — the chart contradicting the "n/a" the latency tile
+    // already shows, and the more believable of the two because it is drawn.
+    QVector<TimeSeriesGraphWidget::Series> latencySeries;
+    if (m_model->hasLinkRtt()) {
+        latencySeries.push_back(buildSeriesWithUnit("RTT", QColor("#00b4d8"), " ms", [](const NetworkDiagnosticsSample& s) { return static_cast<double>(s.rttMs); }));
+    }
+    latencySeries.push_back(buildSeriesWithUnit("Arrival gap", QColor("#f2c94c"), " ms", [](const NetworkDiagnosticsSample& s) { return static_cast<double>(s.audioGapMs); }));
+    latencySeries.push_back(buildSeriesWithUnit("Jitter", QColor("#eb5757"), " ms", [](const NetworkDiagnosticsSample& s) { return static_cast<double>(s.audioJitterMs); }));
+
+    // Same reasoning for the per-category rate traces: five flat zero lines
+    // would claim five dead streams on a transport that never had five.
     QVector<TimeSeriesGraphWidget::Series> rateSeries{
-        buildSeriesWithUnit("RX total", QColor("#00b4d8"), " kbps", [](const NetworkDiagnosticsSample& s) { return s.rxKbps; }),
-        buildSeriesWithUnit("Audio", QColor("#6fcf97"), " kbps", [](const NetworkDiagnosticsSample& s) { return s.audioKbps; }),
-        buildSeriesWithUnit("FFT", QColor("#bb6bd9"), " kbps", [](const NetworkDiagnosticsSample& s) { return s.fftKbps; }),
-        buildSeriesWithUnit("Waterfall", QColor("#f2994a"), " kbps", [](const NetworkDiagnosticsSample& s) { return s.waterfallKbps; }),
-        buildSeriesWithUnit("Meters", QColor("#56ccf2"), " kbps", [](const NetworkDiagnosticsSample& s) { return s.meterKbps; }),
-        buildSeriesWithUnit("DAX", QColor("#bdbdbd"), " kbps", [](const NetworkDiagnosticsSample& s) { return s.daxKbps; })
+        buildSeriesWithUnit("RX total", QColor("#00b4d8"), " kbps", [](const NetworkDiagnosticsSample& s) { return s.rxKbps; })
     };
+    if (m_model->hasStreamCategoryStats()) {
+        rateSeries.push_back(buildSeriesWithUnit("Audio", QColor("#6fcf97"), " kbps", [](const NetworkDiagnosticsSample& s) { return s.audioKbps; }));
+        rateSeries.push_back(buildSeriesWithUnit("FFT", QColor("#bb6bd9"), " kbps", [](const NetworkDiagnosticsSample& s) { return s.fftKbps; }));
+        rateSeries.push_back(buildSeriesWithUnit("Waterfall", QColor("#f2994a"), " kbps", [](const NetworkDiagnosticsSample& s) { return s.waterfallKbps; }));
+        rateSeries.push_back(buildSeriesWithUnit("Meters", QColor("#56ccf2"), " kbps", [](const NetworkDiagnosticsSample& s) { return s.meterKbps; }));
+        rateSeries.push_back(buildSeriesWithUnit("DAX", QColor("#bdbdbd"), " kbps", [](const NetworkDiagnosticsSample& s) { return s.daxKbps; }));
+    }
+    // The TOTAL loss trace is real on both transports — it is the per-category
+    // breakdown underneath it that only the VITA-49 multiplex has.
     QVector<TimeSeriesGraphWidget::Series> lossSeries{
-        buildSeriesWithUnit("Recent total", QColor("#eb5757"), "%", [](const NetworkDiagnosticsSample& s) { return s.packetLossPct; }),
-        buildSeriesWithUnit("Audio", QColor("#6fcf97"), "%", [](const NetworkDiagnosticsSample& s) { return s.audioLossPct; }),
-        buildSeriesWithUnit("FFT", QColor("#bb6bd9"), "%", [](const NetworkDiagnosticsSample& s) { return s.fftLossPct; }),
-        buildSeriesWithUnit("Waterfall", QColor("#f2994a"), "%", [](const NetworkDiagnosticsSample& s) { return s.waterfallLossPct; }),
-        buildSeriesWithUnit("Meters", QColor("#56ccf2"), "%", [](const NetworkDiagnosticsSample& s) { return s.meterLossPct; }),
-        buildSeriesWithUnit("DAX", QColor("#bdbdbd"), "%", [](const NetworkDiagnosticsSample& s) { return s.daxLossPct; })
+        buildSeriesWithUnit("Recent total", QColor("#eb5757"), "%", [](const NetworkDiagnosticsSample& s) { return s.packetLossPct; })
     };
+    if (m_model->hasStreamCategoryStats()) {
+        lossSeries.push_back(buildSeriesWithUnit("Audio", QColor("#6fcf97"), "%", [](const NetworkDiagnosticsSample& s) { return s.audioLossPct; }));
+        lossSeries.push_back(buildSeriesWithUnit("FFT", QColor("#bb6bd9"), "%", [](const NetworkDiagnosticsSample& s) { return s.fftLossPct; }));
+        lossSeries.push_back(buildSeriesWithUnit("Waterfall", QColor("#f2994a"), "%", [](const NetworkDiagnosticsSample& s) { return s.waterfallLossPct; }));
+        lossSeries.push_back(buildSeriesWithUnit("Meters", QColor("#56ccf2"), "%", [](const NetworkDiagnosticsSample& s) { return s.meterLossPct; }));
+        lossSeries.push_back(buildSeriesWithUnit("DAX", QColor("#bdbdbd"), "%", [](const NetworkDiagnosticsSample& s) { return s.daxLossPct; }));
+    }
     QVector<TimeSeriesGraphWidget::Series> audioBufferSeries{
         buildSeriesWithUnit("Buffer", QColor("#00b4d8"), " ms", [](const NetworkDiagnosticsSample& s) { return s.audioBufferMs; }),
         buildSeriesWithUnit("Slow delivery", QColor("#f2c94c"), " ms", [](const NetworkDiagnosticsSample& s) { return s.audioFeedDeficitMs; }),

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1069,16 +1069,30 @@ void RadioModel::applyBackendLinkStats(const IRadioBackend::LinkStats& stats)
 
     const bool first = !m_linkStats.reported;
     m_linkStats = stats;
+    // What this transport can MEASURE, latched separately from what it measured
+    // this second. Sticky-once-true so a window that closes with no samples in
+    // it does not flip a readout back to "not measured" mid-session, and read by
+    // hasLinkRtt() / hasLinkTiming() after stopNetworkMonitor() has dropped the
+    // counters. See the member declaration for why the distinction matters.
+    m_backendLinkShape.reports = true;
+    if (stats.rttMs >= 0)
+        m_backendLinkShape.hasRtt = true;
+    if (stats.gapMs >= 0)
+        m_backendLinkShape.hasTiming = true;
+
     if (first) {
-        // First snapshot of the session. resetNetworkHealthSamples() now reads
-        // the new source, so the deltas are seeded from THIS snapshot rather
-        // than from zero — otherwise a reconnect's entire prior packet count
-        // lands in the first loss-window sample and scores the link as a
-        // catastrophe on its first second.
-        m_netState = NetState::Excellent;
-        m_networkQualityScore = 100.0;
-        m_maxPingRtt = 0;
-        resetNetworkHealthSamples();
+        // First snapshot of the session. resetNetworkHealthSamples() (called
+        // from the shared reset) now reads the new source, so the deltas are
+        // seeded from THIS snapshot rather than from zero — otherwise a
+        // reconnect's entire prior packet count lands in the first loss-window
+        // sample and scores the link as a catastrophe on its first second.
+        //
+        // Shared with startNetworkMonitor() rather than open-coded: the two
+        // drifted once, and the field this path had forgotten (m_lastPingRtt)
+        // is invisible on a transport that reports rttMs < 0, so the previous
+        // Flex session's RTT scored the HL2 link with nothing on screen to
+        // contradict it.
+        resetNetworkQualitySession();
     }
 
     if (stats.rttMs >= 0)
@@ -1125,6 +1139,10 @@ void RadioModel::teardownBackend()
     m_backendPanIdByIndex.clear();
     m_backendPanCenterMhz.clear();
     m_backendPanBandwidthMhz.clear();
+    // What the transport could measure was a fact about the backend that just
+    // died, not about the app. A Flex arriving after an HL2 must not inherit
+    // "this wire has no round trip to time".
+    m_backendLinkShape = {};
 }
 
 RadioModel::RadioModel(QObject* parent)
@@ -5616,20 +5634,41 @@ int saturatingInt(quint64 v)
 }
 }  // namespace
 
+void RadioModel::resetNetworkQualitySession()
+{
+    // Everything a new scoring session must forget, in ONE place. Two paths
+    // start a session — startNetworkMonitor() for the Flex ping timer, and the
+    // first backend LinkStats snapshot for a family that has no command plane —
+    // and when this was open-coded in both they drifted: the backend path kept
+    // the previous session's m_lastPingRtt, which evaluateNetworkQuality() then
+    // scored the new link with. A stale WAN RTT against LAN_PING_POOR_MS caps
+    // the target score at 45 and engages the adaptive frame-rate throttle on a
+    // radio that is streaming perfectly, and hasLinkRtt() hides the number, so
+    // nothing on screen contradicts it.
+    m_netState = NetState::Excellent;
+    m_networkQualityScore = 100.0;
+    m_lastPingRtt = 0;
+    m_maxPingRtt = 0;
+    // Pure state, so it is safe on both paths. The MainWindow-side clear that
+    // startNetworkMonitor() emits below is deliberately NOT here: MainWindow
+    // already drops m_adaptiveThrottleActive on the disconnect edge, and the
+    // handler's !active branch re-asserts every pan's display rate — which on
+    // the backend path would fire against LIVE pans (they are published a
+    // second before the first link-stats tick), making the client re-assert
+    // state the radio owns. Principles II/III.
+    m_pendingThrottleLift = false;
+    resetNetworkHealthSamples();
+}
+
 void RadioModel::startNetworkMonitor()
 {
     m_pingTimer.stop();
     m_pingTimer.disconnect();
-    m_netState = NetState::Excellent;
-    m_networkQualityScore = 100.0;
-    resetNetworkHealthSamples();
-    m_lastPingRtt = 0;
-    m_maxPingRtt = 0;
+    resetNetworkQualitySession();
     m_pingMissCount = 0;
     m_pingDisconnectTriggered = false;
     m_lastMultiFlexClientConnectMs = 0;
     m_multiFlexPingGraceUntilMs = 0;
-    m_pendingThrottleLift = false;
     // Safety: ensure MainWindow's m_adaptiveThrottleActive is cleared even if
     // the connectionStateChanged(false) path was somehow skipped.  Pans are not
     // yet rebuilt at this point so the fps-restore loop in the handler is a no-op.
@@ -5854,13 +5893,19 @@ double RadioModel::networkQualityTargetScore(int pingMs) const
         }
     }
 
-    const int jitterMs = audioPacketJitterMs();
-    if (jitterMs >= poorJitterMs) {
-        score = std::min(score, 42.0);
-    } else if (jitterMs >= fairJitterMs) {
-        score = std::min(score, 58.0);
-    } else if (jitterMs >= goodJitterMs) {
-        score = std::min(score, 74.0);
+    // Skipped rather than scored as 0 when the transport has not produced a
+    // delivery-timing window yet: the getter clamps the seam's "not measured"
+    // sentinel to 0 for the charts, and a 0 here is the best possible jitter —
+    // a free pass on the first tick of every backend session.
+    if (hasLinkTiming()) {
+        const int jitterMs = audioPacketJitterMs();
+        if (jitterMs >= poorJitterMs) {
+            score = std::min(score, 42.0);
+        } else if (jitterMs >= fairJitterMs) {
+            score = std::min(score, 58.0);
+        } else if (jitterMs >= goodJitterMs) {
+            score = std::min(score, 74.0);
+        }
     }
 
     return score;
@@ -9678,6 +9723,7 @@ QJsonObject RadioModel::troubleshootingSnapshot() const
     // and an assertion that reads it without this would pass on a link nothing
     // measured. Same question the GUI readouts ask before printing "< 1 ms".
     network["rtt_measured"] = hasLinkRtt();
+    network["timing_measured"] = hasLinkTiming();
     network["stream_categories_measured"] = hasStreamCategoryStats();
     network["source"] = usesBackendLinkStats() ? QStringLiteral("backend_link")
                                                : QStringLiteral("vita49_stream");

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1050,10 +1050,48 @@ void RadioModel::setupBackend(const QString& family)
                 this, &RadioModel::onConnectionError);
     }
 
+    // Transport counters from a backend that owns its own socket. Wired
+    // unconditionally: a backend that measures nothing never emits this, and one
+    // that does is the only source the network readouts have.
+    connect(m_backend.get(), &IRadioBackend::linkStatsUpdated,
+            this, &RadioModel::applyBackendLinkStats);
+
     // Forward VITA-49 meter packets to MeterModel (cross-thread, auto-queued)
     if (m_panStream)
     connect(m_panStream, &PanadapterStream::meterDataReady,
             &m_meterModel, &MeterModel::updateValues);
+}
+
+void RadioModel::applyBackendLinkStats(const IRadioBackend::LinkStats& stats)
+{
+    if (!stats.reported)
+        return;
+
+    const bool first = !m_linkStats.reported;
+    m_linkStats = stats;
+    if (first) {
+        // First snapshot of the session. resetNetworkHealthSamples() now reads
+        // the new source, so the deltas are seeded from THIS snapshot rather
+        // than from zero — otherwise a reconnect's entire prior packet count
+        // lands in the first loss-window sample and scores the link as a
+        // catastrophe on its first second.
+        m_netState = NetState::Excellent;
+        m_networkQualityScore = 100.0;
+        m_maxPingRtt = 0;
+        resetNetworkHealthSamples();
+    }
+
+    if (stats.rttMs >= 0)
+        m_lastPingRtt = stats.rttMs;
+
+    evaluateNetworkQuality();
+
+    // The heartbeat is a statement about the RADIO, not about the timer that
+    // asked. Only a tick that saw fresh traffic counts as a beat; a tick on a
+    // silent link deliberately says nothing, so MainWindow's miss timer runs
+    // out and the indicator goes to its alarm state.
+    if (stats.alive)
+        emit pingReceived();
 }
 
 void RadioModel::teardownBackend()
@@ -5564,6 +5602,20 @@ void RadioModel::onVersionReceived(const QString& v)
 
 // ─── Network quality monitor ─────────────────────────────────────────────────
 
+namespace {
+// The loss window and every packet-count getter are int, matching the Flex
+// stream's own counters. A backend reports quint64, and an HL2 at 384 kHz puts
+// ~3000 EP6 packets a second on the wire — about eight days to reach INT_MAX.
+// CLAMP rather than let it wrap: a wrapped negative count turns the loss
+// percentage into nonsense and would drive the adaptive throttle off it. At the
+// ceiling the deltas simply go to zero, so the readout freezes instead of lying.
+int saturatingInt(quint64 v)
+{
+    constexpr quint64 kMax = static_cast<quint64>(std::numeric_limits<int>::max());
+    return static_cast<int>(std::min(v, kMax));
+}
+}  // namespace
+
 void RadioModel::startNetworkMonitor()
 {
     m_pingTimer.stop();
@@ -5662,14 +5714,40 @@ void RadioModel::stopNetworkMonitor()
         m_networkPingConnection = {};
     }
     m_netState = NetState::Off;
+    // Drop the backend transport snapshot on the same edge. Its counters belong
+    // to the session that just ended; carrying them into the next one would show
+    // the previous link's byte totals against a radio that has sent nothing.
+    // Clearing `reported` also puts every getter back on its Flex branch, so a
+    // disconnected model answers exactly what it did before this existed.
+    m_linkStats = {};
+
+    // ANNOUNCE the reset. m_netState going to Off is not observable on its own:
+    // the status-bar field is written only from this signal, and every emitter
+    // of it hangs off the ping/transport path that has just been torn down. So
+    // the last quality the link ever had stayed on screen after disconnect —
+    // a disconnected radio reading "Excellent" — until the next connection
+    // happened to overwrite it. Pre-existing on the Flex path too, and fixed
+    // for both here rather than only where it was noticed.
+    emit networkQualityChanged(networkQuality(), 0);
 }
 
 void RadioModel::evaluateNetworkQuality()
 {
-    if (!m_panStream)
-        return;   // non-Flex backend: no VITA-49 stream to score
-    const int currentErrors = m_panStream->packetErrorCount();
-    const int currentPackets = m_panStream->packetTotalCount();
+    // Two sources, one scorer. The Flex VITA-49 stream is consulted first and
+    // its behavior is untouched; a backend that reports its own transport is
+    // scored by exactly the same thresholds, because "the link is Fair" has to
+    // mean the same thing to the operator on either radio.
+    int currentErrors = 0;
+    int currentPackets = 0;
+    if (m_panStream) {
+        currentErrors = m_panStream->packetErrorCount();
+        currentPackets = m_panStream->packetTotalCount();
+    } else if (m_linkStats.reported) {
+        currentErrors = saturatingInt(m_linkStats.rxPacketsLost);
+        currentPackets = saturatingInt(m_linkStats.rxPackets);
+    } else {
+        return;   // nothing measures this transport
+    }
     recordNetworkHealthSample(currentErrors, currentPackets);
     const int ping = m_lastPingRtt;
 
@@ -5704,8 +5782,16 @@ void RadioModel::evaluateNetworkQuality()
 
 void RadioModel::resetNetworkHealthSamples()
 {
-    m_lastErrorCount = m_panStream ? m_panStream->packetErrorCount() : 0;
-    m_lastPacketCount = m_panStream ? m_panStream->packetTotalCount() : 0;
+    if (m_panStream) {
+        m_lastErrorCount = m_panStream->packetErrorCount();
+        m_lastPacketCount = m_panStream->packetTotalCount();
+    } else if (m_linkStats.reported) {
+        m_lastErrorCount = saturatingInt(m_linkStats.rxPacketsLost);
+        m_lastPacketCount = saturatingInt(m_linkStats.rxPackets);
+    } else {
+        m_lastErrorCount = 0;
+        m_lastPacketCount = 0;
+    }
     for (int i = 0; i < NETWORK_LOSS_WINDOW_SAMPLES; ++i) {
         m_lossSamplePackets[i] = 0;
         m_lossSampleErrors[i] = 0;
@@ -5927,39 +6013,58 @@ double RadioModel::packetLossPercent() const
     return (m_packetLossWindowErrors * 100.0) / m_packetLossWindowPackets;
 }
 
+// Each of the six below reads the Flex VITA-49 stream when there is one and the
+// backend's own transport counters when there is not. The Flex branch is first
+// and unchanged in every case; usesBackendLinkStats() is false unless a backend
+// has actually reported, so a family that measures nothing still answers the
+// same zeros it always did.
 int RadioModel::audioPacketGapMs() const
 {
-    return m_panStream ? m_panStream->audioPacketGapMs() : 0;
+    if (m_panStream)
+        return m_panStream->audioPacketGapMs();
+    return usesBackendLinkStats() ? std::max(0, m_linkStats.gapMs) : 0;
 }
 
 int RadioModel::audioPacketGapMaxMs() const
 {
-    return m_panStream ? m_panStream->audioPacketGapMaxMs() : 0;
+    if (m_panStream)
+        return m_panStream->audioPacketGapMaxMs();
+    return usesBackendLinkStats() ? std::max(0, m_linkStats.gapMaxMs) : 0;
 }
 
 int RadioModel::audioPacketJitterMs() const
 {
-    return m_panStream ? m_panStream->audioPacketJitterMs() : 0;
+    if (m_panStream)
+        return m_panStream->audioPacketJitterMs();
+    return usesBackendLinkStats() ? std::max(0, m_linkStats.jitterMs) : 0;
 }
 
 int RadioModel::packetDropCount() const
 {
-    return m_panStream ? m_panStream->packetErrorCount() : 0;
+    if (m_panStream)
+        return m_panStream->packetErrorCount();
+    return usesBackendLinkStats() ? saturatingInt(m_linkStats.rxPacketsLost) : 0;
 }
 
 int RadioModel::packetTotalCount() const
 {
-    return m_panStream ? m_panStream->packetTotalCount() : 0;
+    if (m_panStream)
+        return m_panStream->packetTotalCount();
+    return usesBackendLinkStats() ? saturatingInt(m_linkStats.rxPackets) : 0;
 }
 
 qint64 RadioModel::rxBytes() const
 {
-    return m_panStream ? m_panStream->totalRxBytes() : 0;
+    if (m_panStream)
+        return m_panStream->totalRxBytes();
+    return usesBackendLinkStats() ? m_linkStats.rxBytes : 0;
 }
 
 qint64 RadioModel::txBytes() const
 {
-    return m_panStream ? m_panStream->totalTxBytes() : 0;
+    if (m_panStream)
+        return m_panStream->totalTxBytes();
+    return usesBackendLinkStats() ? m_linkStats.txBytes : 0;
 }
 
 QString RadioModel::targetRadioIp() const
@@ -5990,8 +6095,14 @@ QString RadioModel::localTcpEndpoint() const
     if (m_wanConn)
         return QStringLiteral("SmartLink/WAN");
 
-    if (!m_connection)
+    if (!m_connection) {
+        // "Not connected" is true for a family that has no TCP command plane at
+        // all, and reads as a fault when the radio is streaming perfectly well.
+        // Say which it is.
+        if (usesBackendLinkStats())
+            return QStringLiteral("None (stream transport only)");
         return QStringLiteral("Not connected");
+    }
     const QHostAddress localAddr = m_connection->localAddress();
     const quint16 localPort = m_connection->localTcpPort();
     if (localAddr.isNull() || localPort == 0)
@@ -6001,8 +6112,11 @@ QString RadioModel::localTcpEndpoint() const
 
 QString RadioModel::localUdpEndpoint() const
 {
-    if (!m_panStream)
+    if (!m_panStream) {
+        if (usesBackendLinkStats() && !m_linkStats.localEndpoint.isEmpty())
+            return m_linkStats.localEndpoint;
         return QStringLiteral("Not bound");
+    }
     const QHostAddress localAddr = m_panStream->localAddress();
     const quint16 localPort = m_panStream->localPort();
     if (localAddr.isNull() || localPort == 0)
@@ -6012,7 +6126,9 @@ QString RadioModel::localUdpEndpoint() const
 
 bool RadioModel::firstUdpPacketSeen() const
 {
-    return m_panStream && m_panStream->hasReceivedPackets();
+    if (m_panStream)
+        return m_panStream->hasReceivedPackets();
+    return usesBackendLinkStats() && m_linkStats.rxPackets > 0;
 }
 
 PanadapterStream::CategoryStats RadioModel::categoryStats(PanadapterStream::StreamCategory cat) const
@@ -9557,6 +9673,14 @@ QJsonObject RadioModel::troubleshootingSnapshot() const
     network["audio_packet_jitter_ms"] = audioPacketJitterMs();
     network["rx_bytes"] = static_cast<qint64>(rxBytes());
     network["tx_bytes"] = static_cast<qint64>(txBytes());
+    // So a test can tell "the RTT is zero" from "this transport has no round
+    // trip to time" — the two are indistinguishable in last_ping_rtt_ms alone,
+    // and an assertion that reads it without this would pass on a link nothing
+    // measured. Same question the GUI readouts ask before printing "< 1 ms".
+    network["rtt_measured"] = hasLinkRtt();
+    network["stream_categories_measured"] = hasStreamCategoryStats();
+    network["source"] = usesBackendLinkStats() ? QStringLiteral("backend_link")
+                                               : QStringLiteral("vita49_stream");
     QJsonObject streamCategories;
     streamCategories["audio"] = categoryStatsToJson(PanadapterStream::CatAudio);
     streamCategories["fft"] = categoryStatsToJson(PanadapterStream::CatFFT);

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1699,6 +1699,10 @@ private:
     // Take a transport snapshot from the backend seam: feed the loss window,
     // rescore the link, and beat the heartbeat if traffic actually arrived.
     void applyBackendLinkStats(const IRadioBackend::LinkStats& stats);
+    // Everything a new scoring session must forget. Shared by the two paths that
+    // start one — the Flex ping timer and the first backend LinkStats snapshot —
+    // because when it was open-coded in both they drifted.
+    void resetNetworkQualitySession();
     void startNetworkMonitor();
     void stopNetworkMonitor();
     void evaluateNetworkQuality();
@@ -1768,6 +1772,23 @@ private:
     // gated on it, and the Flex sources are always consulted first.
     IRadioBackend::LinkStats m_linkStats;
 
+    // What this backend's transport can MEASURE, as opposed to what it measured
+    // this second. m_linkStats above holds live counters and stopNetworkMonitor()
+    // drops it, because those numbers belong to the session that just ended —
+    // but "does this wire have a round trip to time" is a fact about the WIRE and
+    // stays true while it is down. Without the distinction a disconnected HL2
+    // falls back to the Flex branch, and lastPingRtt()'s 0 renders as "< 1 ms":
+    // the exact claim HERMES.md § 21.3 exists to forbid, one state transition
+    // later. Latched sticky-once-true so a window that closes with no samples in
+    // it cannot flip a readout mid-session, and reset in teardownBackend(),
+    // because only a new backend can change the answer.
+    struct BackendLinkShape {
+        bool reports   = false;   // a backend has published a LinkStats at all
+        bool hasRtt    = false;   // ...and that transport times a round trip
+        bool hasTiming = false;   // ...and it measures delivery spacing
+    };
+    BackendLinkShape m_backendLinkShape;
+
     // True when the network figures come from the backend seam rather than from
     // a Flex PanadapterStream. The single predicate every fallback branches on.
     bool usesBackendLinkStats() const { return !m_panStream && m_linkStats.reported; }
@@ -1787,8 +1808,31 @@ public:
     // fake one. Every RTT readout must ask this first: lastPingRtt() answers 0
     // when nothing measured it, and 0 renders as "< 1 ms", which is a link
     // quality claim the app never made a measurement to support.
+    // Answers for the WIRE, not for the moment — which is why the last branch
+    // consults the latched shape rather than the live snapshot. While connected
+    // the snapshot is authoritative; between sessions m_linkStats is cleared and
+    // the honest answer is still "this transport never had an RTT", not the Flex
+    // default.
     bool    hasLinkRtt() const {
-        return !usesBackendLinkStats() || m_linkStats.rttMs >= 0;
+        if (m_panStream)
+            return true;                        // Flex VITA-49 stack: TCP ping RTT
+        if (m_linkStats.reported)
+            return m_linkStats.rttMs >= 0;      // live snapshot from the seam
+        return !m_backendLinkShape.reports || m_backendLinkShape.hasRtt;
+    }
+    // Whether the transport has produced a delivery-timing window yet. Same trap
+    // as the RTT: the seam's -1 means "not measured", the getters clamp it to 0
+    // for the charts, and formatNetworkMs(0) renders "< 1 ms". A backend is
+    // `reported` from its first tick on purpose (so the readouts leave the Flex
+    // branch immediately), but its first gap window has not closed yet — so for
+    // about a second the pane would advertise sub-millisecond delivery it has
+    // not measured.
+    bool    hasLinkTiming() const {
+        if (m_panStream)
+            return true;
+        if (m_linkStats.reported)
+            return m_linkStats.gapMs >= 0;
+        return !m_backendLinkShape.reports || m_backendLinkShape.hasTiming;
     }
     // Whether per-stream (Audio / FFT / Waterfall / Meter / DAX) sequence
     // counters exist. They are a property of the Flex VITA-49 multiplex, where

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1696,6 +1696,9 @@ private:
     QTimer    m_reconnectTimer;
 
     // ── Network quality monitor ──
+    // Take a transport snapshot from the backend seam: feed the loss window,
+    // rescore the link, and beat the heartbeat if traffic actually arrived.
+    void applyBackendLinkStats(const IRadioBackend::LinkStats& stats);
     void startNetworkMonitor();
     void stopNetworkMonitor();
     void evaluateNetworkQuality();
@@ -1751,12 +1754,49 @@ private:
     qint64 m_lastThrottleEngageMs{0};   // QDateTime::currentMSecsSinceEpoch() at last engage
     bool   m_pendingThrottleLift{false}; // lift deferred by min-dwell; fired in evaluateNetworkQuality()
 
+    // ── Backend-reported transport (non-Flex families) ──
+    //
+    // The Flex path measures the network off m_connection (TCP ping RTT) and
+    // m_panStream (VITA-49 counters). A family that owns neither has both null,
+    // and every getter below used to answer a flat zero for it — so the whole
+    // network readout rendered "connected, 0 kbps, 0 packets" on a link that was
+    // working. This is the same data arriving from the other side of the seam.
+    //
+    // Populated ONLY from IRadioBackend::linkStatsUpdated, and only a backend
+    // that overrides linkStats() ever sends one. `reported` staying false is
+    // what keeps the Flex path bit-for-bit unchanged: every fallback below is
+    // gated on it, and the Flex sources are always consulted first.
+    IRadioBackend::LinkStats m_linkStats;
+
+    // True when the network figures come from the backend seam rather than from
+    // a Flex PanadapterStream. The single predicate every fallback branches on.
+    bool usesBackendLinkStats() const { return !m_panStream && m_linkStats.reported; }
+
     // Network diagnostics — byte counters for rate calculation
 
 public:
     // Network diagnostics getters
     int     lastPingRtt()      const { return m_lastPingRtt; }
     int     maxPingRtt()       const { return m_maxPingRtt; }
+
+    // Whether the current transport has a round trip to time at all.
+    //
+    // Not every link does. Protocol 1 is a one-way stream — EP2 out on a wall
+    // clock, EP6 back free-running, and nothing in either direction answering
+    // anything in the other — so there is no RTT to report and no honest way to
+    // fake one. Every RTT readout must ask this first: lastPingRtt() answers 0
+    // when nothing measured it, and 0 renders as "< 1 ms", which is a link
+    // quality claim the app never made a measurement to support.
+    bool    hasLinkRtt() const {
+        return !usesBackendLinkStats() || m_linkStats.rttMs >= 0;
+    }
+    // Whether per-stream (Audio / FFT / Waterfall / Meter / DAX) sequence
+    // counters exist. They are a property of the Flex VITA-49 multiplex, where
+    // each category is a separately-sequenced stream on one socket. A transport
+    // that carries everything in one stream has nothing to break down, and
+    // rendering five rows of "0 / 0 packets" for it invents a distinction the
+    // wire does not have.
+    bool    hasStreamCategoryStats() const { return m_panStream != nullptr; }
     bool    pendingThrottleLift() const { return m_pendingThrottleLift; }
     int     currentAdaptiveFpsCap() const;  // 0 = throttle inactive
     // Waterfall line-duration the adaptive throttle caps to for a given fps cap.

--- a/tests/hl2_link_stats_model_test.cpp
+++ b/tests/hl2_link_stats_model_test.cpp
@@ -1,0 +1,193 @@
+// The MODEL half of the HL2 link-stats seam — RadioModel driven by a real
+// Hl2Backend against a fake HL2 on localhost.
+//
+// hl2_link_stats_test covers the backend side: that a transport snapshot is
+// published on a cadence and that its numbers are real. Everything the OPERATOR
+// actually sees is downstream of that, in RadioModel, and that half is where the
+// interesting mistakes live — the seam can be perfect while every readout still
+// lies. This pins the consumer contract:
+//
+//   • the readouts leave their structural zero (the reported symptom: a radio
+//     streaming happily while the pane showed 0 packets, 0 bytes, "Off");
+//   • a figure this transport cannot produce reads as ABSENT, and keeps reading
+//     absent after the session ends — "no round trip to time" is a fact about
+//     the wire, not about whether the wire is currently up;
+//   • starting a scoring session forgets the PREVIOUS session's ping RTT, which
+//     is the field the two reset paths drifted on;
+//   • the heartbeat beats, and the status field is announced as Off on the
+//     disconnect edge rather than freezing on the last quality the link had.
+
+#include "models/RadioModel.h"
+#include "TestSettingsProfile.h"
+
+#include "core/backends/hl2/MetisProtocol.h"
+
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QHostAddress>
+#include <QJsonObject>
+#include <QNetworkDatagram>
+#include <QSignalSpy>
+#include <QTimer>
+#include <QUdpSocket>
+
+#include <cstdint>
+#include <cstdio>
+
+using namespace AetherSDR;
+namespace hl2 = AetherSDR::hl2;
+
+static int g_failures = 0;
+static void check(bool cond, const char* what)
+{
+    if (!cond) {
+        std::fprintf(stderr, "FAIL: %s\n", what);
+        ++g_failures;
+    }
+}
+
+static QByteArray fakeEp6(std::uint32_t seq)
+{
+    QByteArray p(static_cast<int>(hl2::kUsbPacketSize), 0);
+    auto* b = reinterpret_cast<std::uint8_t*>(p.data());
+    b[0] = 0xEF; b[1] = 0xFE; b[2] = 0x01; b[3] = 0x06;
+    b[4] = static_cast<std::uint8_t>(seq >> 24); b[5] = static_cast<std::uint8_t>(seq >> 16);
+    b[6] = static_cast<std::uint8_t>(seq >> 8);  b[7] = static_cast<std::uint8_t>(seq);
+    b[8] = b[9] = b[10] = 0x7F;
+    b[8 + hl2::kFrameSize] = b[9 + hl2::kFrameSize] = b[10 + hl2::kFrameSize] = 0x7F;
+    return p;
+}
+
+static void spin(int ms)
+{
+    QEventLoop loop;
+    QTimer::singleShot(ms, &loop, &QEventLoop::quit);
+    loop.exec();
+}
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile settingsProfile(QStringLiteral("hl2-link-stats-model-test"));
+    if (!settingsProfile.isValid()) {
+        std::fprintf(stderr, "FAIL: could not create an isolated settings profile\n");
+        return 1;
+    }
+
+    QCoreApplication app(argc, argv);
+
+    // Same thinned fake radio hl2_link_stats_test uses, and for the same reason:
+    // one EP6 per EP2 runs the full demod for content nothing here reads.
+    constexpr int kAnswerEvery = 8;
+    QUdpSocket radio;
+    check(radio.bind(QHostAddress::LocalHost, 0), "fake radio binds");
+    const quint16 radioPort = radio.localPort();
+    std::uint32_t seq = 0;
+    int requests = 0;
+    bool radioAnswering = true;
+    QObject::connect(&radio, &QUdpSocket::readyRead, &radio, [&] {
+        while (radio.hasPendingDatagrams()) {
+            const QNetworkDatagram dg = radio.receiveDatagram();
+            if (radioAnswering && (++requests % kAnswerEvery) == 0)
+                radio.writeDatagram(fakeEp6(seq++), dg.senderAddress(), dg.senderPort());
+        }
+    });
+
+    RadioModel model;
+
+    RadioInfo info;
+    info.family  = QStringLiteral("hl2");
+    info.serial  = QStringLiteral("00:1C:C0:00:00:01");
+    info.address = QHostAddress(QHostAddress::LocalHost);
+    info.port    = radioPort;
+
+    QSignalSpy heartbeatSpy(&model, &RadioModel::pingReceived);
+    QSignalSpy qualitySpy(&model, &RadioModel::networkQualityChanged);
+
+    model.connectToRadio(info);
+    check(model.panStream() == nullptr, "HL2 owns no PanadapterStream");
+
+    // Long enough for the connect handshake plus several 1 s publish ticks.
+    spin(3600);
+
+    // ---- the reported symptom: the readouts are no longer structurally zero ----
+    check(model.packetTotalCount() > 0,
+          "packet total reaches the readout on a family with no PanadapterStream");
+    check(model.rxBytes() > 0, "received bytes reach the readout");
+    check(model.firstUdpPacketSeen(), "the first UDP packet is seen");
+    check(model.networkQuality() != QStringLiteral("Off"),
+          "a streaming HL2 is scored, not left Off for the session");
+    check(!model.localUdpEndpoint().isEmpty()
+              && model.localUdpEndpoint() != QStringLiteral("Not bound"),
+          "the bound UDP endpoint is reported");
+    check(model.localTcpEndpoint() == QStringLiteral("None (stream transport only)"),
+          "no command plane is stated as such, not as a fault");
+
+    // ---- the heartbeat beats ----
+    check(heartbeatSpy.count() >= 2,
+          "traffic arriving beats the heartbeat on a family that answers no ping");
+
+    // ---- absent is not zero ----
+    check(!model.hasLinkRtt(),
+          "a stream-only transport reports no round trip to time");
+    check(!model.hasStreamCategoryStats(),
+          "a single-stream transport has no per-category breakdown");
+    check(model.hasLinkTiming(),
+          "delivery spacing IS measurable, and is reported once a window closes");
+
+    // THE RESET INVARIANT. Both paths that start a scoring session go through
+    // resetNetworkQualitySession(); when this was open-coded in each of them they
+    // drifted, and the field the backend path forgot was m_lastPingRtt. On a
+    // transport that reports rttMs < 0 nothing ever overwrites it, so a previous
+    // Flex/WAN session's RTT would score THIS link — invisibly, because
+    // hasLinkRtt() correctly hides it from every readout.
+    check(model.lastPingRtt() == 0,
+          "no RTT is carried into a session on a transport that measures none");
+    check(model.maxPingRtt() == 0, "the session RTT maximum starts clean");
+
+    const QJsonObject snapshot = model.troubleshootingSnapshot();
+    const QJsonObject network = snapshot.value(QStringLiteral("radio"))
+                                    .toObject()
+                                    .value(QStringLiteral("network"))
+                                    .toObject();
+    // Guard the path itself: every check below reads a bool that defaults to
+    // false on a missing key, so a wrong path would pass three of them silently.
+    check(!network.isEmpty(), "the snapshot carries a radio.network block");
+    check(network.value(QStringLiteral("source")).toString()
+              == QStringLiteral("backend_link"),
+          "the snapshot names the backend seam as the source");
+    check(!network.value(QStringLiteral("rtt_measured")).toBool(),
+          "the snapshot distinguishes an unmeasured RTT from a zero one");
+    check(network.value(QStringLiteral("timing_measured")).toBool(),
+          "the snapshot reports delivery timing as measured");
+    check(!network.value(QStringLiteral("stream_categories_measured")).toBool(),
+          "the snapshot reports the per-category split as inapplicable");
+
+    // ---- the disconnect edge ----
+    const int qualityBefore = qualitySpy.count();
+    model.disconnectFromRadio();
+    spin(600);
+
+    // § 21.5: m_netState going to Off is not observable on its own — the status
+    // field is written ONLY from this signal, and every other emitter of it hangs
+    // off the transport being torn down. Without this the last quality the link
+    // ever had stays on screen against a disconnected radio.
+    check(qualitySpy.count() > qualityBefore,
+          "the disconnect edge announces the network state rather than going quiet");
+    check(model.networkQuality() == QStringLiteral("Off"),
+          "a disconnected radio reads Off");
+
+    // § 21.3, one state transition later. stopNetworkMonitor() drops the COUNTERS
+    // — they belong to the session that ended — but whether this wire has a round
+    // trip to time is a fact about the wire. Answering "yes" here puts every RTT
+    // readout back on its Flex branch, where lastPingRtt()'s 0 renders as
+    // "< 1 ms": the best latency the app can display, from a measurement that
+    // never happened, on a radio that is not even connected.
+    check(!model.hasLinkRtt(),
+          "a disconnected stream-only transport still reports no round trip to time");
+    check(!model.hasStreamCategoryStats(),
+          "and still has no per-category breakdown");
+
+    if (g_failures == 0)
+        std::fprintf(stderr, "hl2_link_stats_model_test: all checks passed\n");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/hl2_link_stats_test.cpp
+++ b/tests/hl2_link_stats_test.cpp
@@ -1,0 +1,202 @@
+// HL2 transport telemetry — the IRadioBackend::linkStats seam.
+//
+// The network readouts (title-bar heartbeat, status-bar Network field, the
+// Network Diagnostics pane) were written against the Flex stack and read their
+// numbers off a RadioConnection and a PanadapterStream. The HL2 owns neither,
+// so every one of them rendered a structural zero on a link that was working:
+// the heartbeat never left its pre-connect amber and the diagnostics pane
+// reported a connected radio pushing 0 kbps.
+//
+// This covers the replacement end to end against a fake HL2 on localhost: that
+// the backend publishes a transport snapshot on a fixed cadence, that the
+// counters in it are real, that "the radio has gone quiet" is distinguishable
+// from "the link is fine", and — the one that is easy to get wrong — that a
+// figure this transport CANNOT measure is reported as absent rather than as
+// zero. A zero RTT formats as "< 1 ms", which is a link-quality claim nothing
+// ever measured.
+
+#include "core/backends/IRadioBackend.h"
+#include "TestSettingsProfile.h"
+
+#include "core/backends/hl2/Hl2Backend.h"
+#include "core/backends/hl2/MetisProtocol.h"
+
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QHostAddress>
+#include <QNetworkDatagram>
+#include <QSignalSpy>
+#include <QTimer>
+#include <QUdpSocket>
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+using namespace AetherSDR;
+using AetherSDR::hl2::Hl2Backend;
+namespace hl2 = AetherSDR::hl2;
+
+static int g_failures = 0;
+static void check(bool cond, const char* what)
+{
+    if (!cond) {
+        std::fprintf(stderr, "FAIL: %s\n", what);
+        ++g_failures;
+    }
+}
+
+static QByteArray fakeEp6(std::uint32_t seq)
+{
+    QByteArray p(static_cast<int>(hl2::kUsbPacketSize), 0);
+    auto* b = reinterpret_cast<std::uint8_t*>(p.data());
+    b[0] = 0xEF; b[1] = 0xFE; b[2] = 0x01; b[3] = 0x06;
+    b[4] = static_cast<std::uint8_t>(seq >> 24); b[5] = static_cast<std::uint8_t>(seq >> 16);
+    b[6] = static_cast<std::uint8_t>(seq >> 8);  b[7] = static_cast<std::uint8_t>(seq);
+    b[8] = b[9] = b[10] = 0x7F;
+    b[8 + hl2::kFrameSize] = b[9 + hl2::kFrameSize] = b[10 + hl2::kFrameSize] = 0x7F;
+    return p;
+}
+
+static void spin(int ms)
+{
+    QEventLoop loop;
+    QTimer::singleShot(ms, &loop, &QEventLoop::quit);
+    loop.exec();
+}
+
+int main(int argc, char** argv)
+{
+    // Isolated settings, for the same reason hl2_backend_test uses one: the
+    // backend persists span state at connect, and a test must never write it
+    // into the operator's real configuration.
+    TestSettingsProfile settingsProfile(QStringLiteral("hl2-link-stats-test"));
+    if (!settingsProfile.isValid()) {
+        std::fprintf(stderr, "FAIL: could not create an isolated settings profile\n");
+        return 1;
+    }
+
+    QCoreApplication app(argc, argv);
+
+    // ---- fake HL2: a thinned EP6 stream, until told to go quiet ----
+    //
+    // One EP6 per EP2 would be the real 381 packets/s, and every one of them
+    // runs the full WDSP demod inside the backend — for a stream whose CONTENT
+    // nothing here looks at. Answering one request in eight keeps the counters,
+    // the wakeup cadence and the sequence continuity all real at an eighth of
+    // the sample-path cost. (hl2_backend_test caps its stream outright for the
+    // same reason.) Wall time is dominated by WDSP channel setup either way;
+    // the saving is CPU, which is what matters under the weekly TSan job.
+    constexpr int kAnswerEvery = 8;
+    QUdpSocket radio;
+    check(radio.bind(QHostAddress::LocalHost, 0), "fake radio binds");
+    const quint16 radioPort = radio.localPort();
+    std::uint32_t seq = 0;
+    int requests = 0;
+    bool radioAnswering = true;
+    QObject::connect(&radio, &QUdpSocket::readyRead, &radio, [&] {
+        while (radio.hasPendingDatagrams()) {
+            const QNetworkDatagram dg = radio.receiveDatagram();
+            if (radioAnswering && (++requests % kAnswerEvery) == 0)
+                radio.writeDatagram(fakeEp6(seq++), dg.senderAddress(), dg.senderPort());
+        }
+    });
+
+    Hl2Backend backend;
+
+    // Before a connection there is no transport to describe. A snapshot that
+    // claimed to report while every counter was zero would be indistinguishable
+    // from a dead link, which is the state this whole path exists to stop
+    // misrendering.
+    check(!backend.linkStats().reported,
+          "linkStats() does not claim to report before connect");
+
+    std::vector<IRadioBackend::LinkStats> ticks;
+    QObject::connect(&backend, &IRadioBackend::linkStatsUpdated, &backend,
+                     [&](const IRadioBackend::LinkStats& s) { ticks.push_back(s); });
+
+    QSignalSpy connectedSpy(&backend, &IRadioBackend::connected);
+    RadioConnectRequest req;
+    req.host = QHostAddress(QHostAddress::LocalHost).toString();
+    req.port = radioPort;
+    backend.connectRadio(req);
+
+    // Long enough for the connect handshake plus at least two publish ticks
+    // (the cadence is 1 s).
+    spin(2600);
+    check(connectedSpy.count() == 1, "backend connected on first EP6");
+
+    check(ticks.size() >= 2, "linkStatsUpdated ticks on its fixed cadence while connected");
+    if (ticks.empty()) {
+        std::fprintf(stderr, "FAIL: no link-stats ticks; remaining checks skipped\n");
+        return 1;
+    }
+
+    const IRadioBackend::LinkStats& live = ticks.back();
+    check(live.reported, "a connected backend reports its transport");
+    check(live.alive, "traffic arriving marks the link alive");
+    check(live.rxPackets > 0, "EP6 packets are counted");
+    check(live.rxBytes > 0, "received bytes are counted");
+    // EP2 is paced off a wall clock and flows whether or not the radio answers,
+    // so a connected session always has outbound traffic to report.
+    check(live.txBytes > 0, "sent bytes are counted");
+    check(!live.localEndpoint.isEmpty(), "the bound local endpoint is reported");
+    check(live.rxPacketsLost == 0, "an ordered loopback stream loses nothing");
+
+    // THE HONESTY INVARIANT. Protocol 1 is a one-way stream: EP2 goes out on a
+    // wall clock, EP6 comes back free-running, and no frame in either direction
+    // answers a specific frame in the other. There is no round trip to time, so
+    // the field must read "not measured" (negative) and never 0 — every readout
+    // formats a 0 as "< 1 ms" and would advertise a latency nobody measured.
+    check(live.rttMs < 0, "RTT is reported as not-measured, not as zero");
+    // The gap figures ARE measurable on this transport, and are what the
+    // quality score has to run on instead.
+    check(live.gapMs >= 0, "inter-arrival gap is measured");
+    check(live.gapMaxMs >= live.gapMs, "the window maximum is not below its mean");
+    check(live.jitterMs >= 0, "delivery spread is measured");
+
+    // Counters are cumulative across ticks, never per-window.
+    if (ticks.size() >= 2) {
+        const IRadioBackend::LinkStats& earlier = ticks[ticks.size() - 2];
+        check(live.rxBytes >= earlier.rxBytes, "rx bytes accumulate across ticks");
+        check(live.rxPackets >= earlier.rxPackets, "rx packets accumulate across ticks");
+    }
+
+    // ---- the radio goes quiet ----
+    //
+    // This is the case the heartbeat exists for, and a cumulative counter alone
+    // cannot express it: the totals simply stop moving, which is identical to
+    // reading them twice quickly. `alive` is the per-tick difference, so a tick
+    // over a silent second must say so while still reporting the link.
+    //
+    // Sampled inside the client's own silence window (2 s), so this observes the
+    // quiet link rather than the disconnect that eventually follows it.
+    radioAnswering = false;
+    const std::size_t ticksBeforeSilence = ticks.size();
+    spin(1500);
+    bool sawSilentTick = false;
+    bool silentTickStillReported = true;
+    for (std::size_t i = ticksBeforeSilence; i < ticks.size(); ++i) {
+        if (!ticks[i].alive) {
+            sawSilentTick = true;
+            silentTickStillReported = silentTickStillReported && ticks[i].reported;
+        }
+    }
+    check(sawSilentTick, "a tick over a silent second reports the link as not alive");
+    check(silentTickStillReported,
+          "a silent link is still reported — quiet is not the same as unmeasured");
+
+    // ---- disconnect stops the cadence ----
+    backend.disconnectRadio();
+    spin(300);
+    const std::size_t ticksAtDisconnect = ticks.size();
+    spin(1500);
+    check(ticks.size() == ticksAtDisconnect,
+          "no link-stats ticks after disconnect");
+    check(!backend.linkStats().reported,
+          "a disconnected backend stops claiming to report a transport");
+
+    if (g_failures == 0)
+        std::fprintf(stderr, "hl2_link_stats_test: all checks passed\n");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/hl2_metis_client_test.cpp
+++ b/tests/hl2_metis_client_test.cpp
@@ -101,6 +101,27 @@ int main(int argc, char** argv)
           "decoded block carries 126 IQ samples");
     check(client.droppedPackets() == 0, "no drops on an ordered loopback stream");
 
+    // ---- transport counters (the network readouts' only source on this family) ----
+    //
+    // Published on a ~1 s window, so this spins past one boundary rather than
+    // reading the accessor: the SIGNAL is what Hl2Backend mirrors, and a counter
+    // that increments without ever being published reaches no readout.
+    QSignalSpy linkSpy(&client, &MetisClient::linkCountersUpdated);
+    spin(1200);
+    check(linkSpy.count() >= 1, "linkCountersUpdated published on its window");
+    const MetisClient::LinkCounters& lc = client.linkCounters();
+    check(lc.rxPackets > 0, "EP6 packets counted");
+    check(lc.rxBytes >= lc.rxPackets * kUsbPacketSize, "received bytes counted");
+    // EP2 is paced off a wall clock, so it flows regardless of what comes back.
+    check(lc.txPackets > 0 && lc.txBytes > 0, "sent datagrams counted");
+    check(lc.drops == 0, "ordered loopback stream loses nothing");
+    check(!lc.localEndpoint.isEmpty(), "bound local endpoint captured");
+    // Timed once per socket wakeup, not once per datagram: successive datagrams
+    // inside one drain are microseconds apart no matter how the link behaves, so
+    // per-datagram timing would report a steady 0 ms straight through a stall.
+    check(lc.meanGapMs >= 0 && lc.maxGapMs >= lc.meanGapMs,
+          "inter-arrival gap measured, maximum not below the mean");
+
     // ---- live control does not disrupt the stream ----
     const int before = iqCount;
     client.setRxFrequencyHz(14'100'000);

--- a/tests/hl2_metis_client_test.cpp
+++ b/tests/hl2_metis_client_test.cpp
@@ -109,13 +109,30 @@ int main(int argc, char** argv)
     QSignalSpy linkSpy(&client, &MetisClient::linkCountersUpdated);
     spin(1200);
     check(linkSpy.count() >= 1, "linkCountersUpdated published on its window");
-    const MetisClient::LinkCounters& lc = client.linkCounters();
+    // By value: the accessor is I/O-thread-only and hands out a copy, because a
+    // reference to a struct holding a QString is a refcount race, not a read.
+    const MetisClient::LinkCounters lc = client.linkCounters();
     check(lc.rxPackets > 0, "EP6 packets counted");
     check(lc.rxBytes >= lc.rxPackets * kUsbPacketSize, "received bytes counted");
     // EP2 is paced off a wall clock, so it flows regardless of what comes back.
     check(lc.txPackets > 0 && lc.txBytes > 0, "sent datagrams counted");
     check(lc.drops == 0, "ordered loopback stream loses nothing");
     check(!lc.localEndpoint.isEmpty(), "bound local endpoint captured");
+    // The socket is bound wildcard, so localAddress() is 0.0.0.0 and naming it
+    // would tell an operator nothing about which interface reaches the radio.
+    // The kernel knows, per datagram, and ReceivePacketDestinationAddress is how
+    // we ask — on loopback that resolves to 127.0.0.1. If a platform refuses the
+    // option the endpoint stays "*:<port>", which is at least not a claim.
+    check(!lc.localEndpoint.startsWith(QStringLiteral("0.0.0.0")),
+          "local endpoint is not the wildcard address a bare bind reports");
+    check(lc.localEndpoint.startsWith(QStringLiteral("127.0.0.1:")),
+          "local endpoint resolves to the interface the datagrams arrived on");
+    // Published AFTER the drain that carries them: a snapshot emitted before the
+    // wakeup's own datagrams were counted is one full drain out of date.
+    const auto& published = qvariant_cast<MetisClient::LinkCounters>(
+        linkSpy.at(linkSpy.count() - 1).at(0));
+    check(published.rxPackets > 0,
+          "the published snapshot carries the packets of its own drain");
     // Timed once per socket wakeup, not once per datagram: successive datagrams
     // inside one drain are microseconds apart no matter how the link behaves, so
     // per-datagram timing would report a steady 0 ms straight through a stall.


### PR DESCRIPTION
## What

Two HL2 bring-up fit-and-finish items, which turned out to be the same root cause.

1. The title-bar status indicator stayed amber for a whole session instead of blinking green on a live connection.
2. Connection health on the status bar and in the Network Statistics pane was blank / all zeros.

**No behaviour change on the FlexRadio path.** Every fallback added here is gated on `!m_panStream && m_linkStats.reported`, and `reported` defaults to false — a backend that does not override `linkStats()` sends nothing and every consumer keeps the source it already had. The one Flex-visible change is a bug fix (§ *Flex bug this exposed* below).

## Why it was broken

None of it was a bug in the readouts. All three read the Flex stack directly:

| Readout | Source it read | On an HL2 |
|---|---|---|
| Title-bar heartbeat | `RadioModel::pingReceived`, emitted from the TCP `ping` reply | never fires |
| Status-bar `Network:` | `networkQualityChanged` from `evaluateNetworkQuality()` | early-returned on `!m_panStream` |
| Network Diagnostics | `RadioModel` getters, each `m_panStream ? … : 0` | structural zero |

`startNetworkMonitor()` is called from exactly one place — the Flex `client gui` reply handler — so on a family that reaches `onConnected()` through the `IRadioBackend` seam it never ran at all. A radio streaming 12.8 Mbps with zero sequence gaps reported `Off`, 0 kbps, 0 packets.

The counters have to come from whoever owns the socket, which is the backend.

## How

Adds `IRadioBackend::LinkStats` + `linkStatsUpdated()` — a neutral transport snapshot on a fixed cadence:

```
MetisClient::LinkCounters   (I/O thread, published ~1 Hz from the receive path)
  → Hl2Backend              (mirrored onto the GUI thread, as m_drops already was)
    → linkStatsUpdated()    (fixed 1 Hz timer — NOT the receive path)
      → RadioModel          (feeds the SAME scorer the Flex path uses)
```

Two details are load-bearing:

- **The publish timer lives in `Hl2Backend`, not `MetisClient`.** The tick has to keep coming *after the radio goes quiet*, because "nothing arrived this second" is the observation the heartbeat's alarm path is waiting for. A backend that emits only on receive can never report its own silence. `alive` is a per-tick packet-count difference, not a cumulative total.
- **Delivery gaps are timed once per socket wakeup, not per datagram.** A wakeup drains everything queued behind it, so successive datagrams inside one drain are microseconds apart no matter how badly the link is behaving — per-datagram timing reports a rock-steady 0 ms straight through a stall that silenced the audio.

Mean/max gap and their difference (delivery spread, used as jitter) plus the existing EP6 sequence-gap counter feed `evaluateNetworkQuality()` unchanged, so `Fair` means the same thing to the operator on either radio.

## Absent is not zero

Protocol 1 is a one-way stream: EP2 goes out on a wall clock, EP6 comes back free-running, and no frame in either direction answers a specific frame in the other. **There is no round trip to time.**

`lastPingRtt()` answers `0` when nothing measured it, and `formatNetworkMs(0)` renders `< 1 ms` — so left alone the pane would have advertised the best latency the app can display, from a measurement that never happened, with a confident flat 0 ms chart trace drawn under the real ones.

`LinkStats::rttMs` is `-1` for "not measured". `RadioModel::hasLinkRtt()` is the predicate all four RTT surfaces ask first (status-bar tooltip, Connection Details rows, Latency tile, and the latency *series*, which is omitted from the graph rather than zeroed). `hasStreamCategoryStats()` does the same for the per-stream Audio/FFT/Waterfall/Meter/DAX breakdown — a property of the VITA-49 multiplex that a single-stream transport has no equivalent of, where five rows of `0 / 0 packets` read as five dead streams.

## Flex bug this exposed

`stopNetworkMonitor()` set `m_netState = Off` and emitted nothing. The status-bar field is written *only* from `networkQualityChanged`, and every emitter of that signal hangs off the ping/transport path being torn down — so the last quality the link ever had stayed on screen after disconnect. A disconnected radio reading `Excellent`, until the next connection happened to overwrite it. Pre-existing on the Flex path, invisible there only because nobody looked at the field after disconnecting. Fixed for both families.

## Screenshots — real HL2 at 192.168.1.21, RX-only

**1. Title-bar indicator.** The green flash is a 100 ms window in a 1 s beat, so a single screenshot catches it about one time in ten; sampled by grabbing the title bar 40× at 50 ms and reading the dot pixel — 4/40 frames were `#20c060`, the rest idle grey, none amber.

![heartbeat before and after](https://raw.githubusercontent.com/jensenpat/AetherSDR/pr-assets-hl2-connection-health/shots/heartbeat.png)

**2. Status bar — connected, then disconnected.**

![status bar connected](https://raw.githubusercontent.com/jensenpat/AetherSDR/pr-assets-hl2-connection-health/shots/statusbar-connected.png)
![status bar disconnected](https://raw.githubusercontent.com/jensenpat/AetherSDR/pr-assets-hl2-connection-health/shots/statusbar-disconnected.png)

**3. Network Diagnostics — Overview.** Latency reads `n/a` and the RTT series is absent from the Latency and Jitter chart; everything else is live.

![diagnostics overview](https://raw.githubusercontent.com/jensenpat/AetherSDR/pr-assets-hl2-connection-health/shots/netdiag-overview.png)

**4. Network Diagnostics — Connection Details.** `Local TCP: None (stream transport only)`, RTT rows `not measured on this link`, per-category loss `n/a`, and the real totals underneath: 0 / 353544 dropped.

![diagnostics connection details](https://raw.githubusercontent.com/jensenpat/AetherSDR/pr-assets-hl2-connection-health/shots/netdiag-details.png)

## Testing

- `hl2_link_stats_test` (new) — the seam contract end to end against a fake HL2: cadence, real counters, the silent-link case (a tick over a quiet second reports `alive=false` while still reporting the link), no ticks after disconnect, and the not-measured invariant.
- `hl2_metis_client_test` — gains transport-counter coverage, including that the gap is timed per wakeup.
- **205/205 pass** headless (`QT_QPA_PLATFORM=offscreen ctest --test-dir build -j8`).
- Hardware: 353 544 EP6 packets, 0 sequence gaps, 12.8 Mbps RX / 3.2 Mbps TX, arrival gap 1 ms. No new warnings in the app log.

Per HERMES.md §7, a fixture failing to contradict a wire convention is not hardware confirming it — but the RTT and category predicates are decisions about what we *refuse* to claim, which is one of the few things a fixture can check honestly.

## Docs

- `HERMES.md` §21 — the seam, the two threading decisions, why there is no RTT, and the absent-vs-zero rule.
- `docs/architecture/radio-capabilities-map.md` — `linkStats()` added to the add-a-backend checklist.

## Suggested new automation verbs

The network block in `troubleshootingSnapshot()` now populates on HL2 (with `rtt_measured`, `stream_categories_measured` and `source` added so a test can tell "zero" from "not measured"), but it is only reachable through the Slice Troubleshooting dialog. A `get_state model=network` verb would let the bridge assert link health directly — it would have replaced the pixel-sampling used for the heartbeat proof above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
