### PR TITLE
feat(settings): scoped feature-document store + ClientSettingsDomain authority (RFC #4603, PR 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -553,6 +553,7 @@ set(CORE_SOURCES
     src/core/backends/hl2/Hl2Settings.cpp    # owned config object, "Hl2" root key (Principle V)
     src/core/dsp/WdspChannel.cpp
     ${AETHER_SETTINGS_SOURCES}
+    src/core/RadioStateMemory.cpp   # RFC #4603 client-side radio memory
     src/core/GpuSelector.cpp
     src/core/AgcTCalibrator.cpp
     src/core/AdaptiveFilterEngine.cpp
@@ -4249,6 +4250,15 @@ add_executable(radio_capability_gating_test tests/radio_capability_gating_test.c
 target_include_directories(radio_capability_gating_test PRIVATE src)
 target_link_libraries(radio_capability_gating_test PRIVATE aethercore Qt6::Core Qt6::Test)
 add_test(NAME radio_capability_gating_test COMMAND radio_capability_gating_test)
+
+# RadioStateMemory + the radio-scoped feature-document store (RFC #4603 PR 2):
+# capability-shaped engagement (empty domains ⇒ inert), per-domain gating on
+# load AND store, per-radio isolation, family-wide fallback, schema tolerance.
+add_executable(radio_state_memory_test tests/radio_state_memory_test.cpp)
+target_include_directories(radio_state_memory_test PRIVATE src tests)
+target_link_libraries(radio_state_memory_test PRIVATE aethercore Qt6::Core Qt6::Test)
+set_target_properties(radio_state_memory_test PROPERTIES AUTOMOC ON)
+add_test(NAME radio_state_memory_test COMMAND radio_state_memory_test)
 
 # TCI signaling on a backend with neither a Flex command plane nor a DAX data
 # plane (HL2) — the seam WSJT-X rides. Links WebSockets so the TciServer half of

--- a/docs/architecture/radio-capabilities-map.md
+++ b/docs/architecture/radio-capabilities-map.md
@@ -50,7 +50,7 @@ traps and why the DAX crash guard is deliberately *not* the DAX capability.
 | `hasMultiClientSessions` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | Settings ▸ multiFLEX… |
 | `hasSupplyVoltageTelemetry` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | PA supply-voltage readout in the status bar |
 | `persistsMemories` | ✅ | ❌ | ❌ | `LocalMemoryBank` engagement (#4590) | host-side memory bank vs radio-side slots |
-| `clientSettingsDomains` | empty | Tuning\|Passband\|SpanRate\|RfGain\|TxSetpoints | empty | `RadioStateMemory::shouldEngage` → `RadioModel::handRestoredStateToBackend` | connect-time operating-state restore (RFC #4603; per-band maps in PR 3) |
+| `clientSettingsDomains` | empty | Tuning\|Passband\|SpanRate\|RfGain\|TxSetpoints | empty | `RadioStateMemory::shouldEngage` → `RadioModel::handRestoredStateToBackend` | DECLARED + gate wired only: `applyRestoredState` is a no-op in every backend until RFC #4603 PR 3 lands capture/restore — nothing restores today (this row would otherwise be the exact trap the header warns about) |
 | `extensionNamespaces` | `["flex"]` | — | — | `invokeExtension` pre-check | Amp / tuner operate/bypass/autotune verbs |
 
 `MainWindow::applyCapabilitiesToUi()` is the single fan-out for UI visibility. It

--- a/docs/architecture/radio-capabilities-map.md
+++ b/docs/architecture/radio-capabilities-map.md
@@ -49,6 +49,8 @@ traps and why the DAX crash guard is deliberately *not* the DAX capability.
 | `hasWaveforms` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | File ▸ Waveforms… |
 | `hasMultiClientSessions` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | Settings ▸ multiFLEX… |
 | `hasSupplyVoltageTelemetry` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | PA supply-voltage readout in the status bar |
+| `persistsMemories` | ✅ | ❌ | ❌ | `LocalMemoryBank` engagement (#4590) | host-side memory bank vs radio-side slots |
+| `clientSettingsDomains` | empty | Tuning\|Passband\|SpanRate\|RfGain\|TxSetpoints | empty | `RadioStateMemory::shouldEngage` → `RadioModel::handRestoredStateToBackend` | connect-time operating-state restore (RFC #4603; per-band maps in PR 3) |
 | `extensionNamespaces` | `["flex"]` | — | — | `invokeExtension` pre-check | Amp / tuner operate/bypass/autotune verbs |
 
 `MainWindow::applyCapabilitiesToUi()` is the single fan-out for UI visibility. It

--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -833,6 +833,11 @@ void AppSettings::save()
 
 void AppSettings::reset()
 {
+    // Lock ORDER matches save()/the feature-doc writers (m_saveMutex outer,
+    // m_lock inner): the close below cannot interleave with a writer that is
+    // mid-statement under m_saveMutex (PR #4614 review — the sqlite handle
+    // has no API armor, so a closed-underneath call is a crash, not an error).
+    QMutexLocker ioLocker(&m_saveMutex);
     QWriteLocker locker(&m_lock);
     m_guiClientLock.reset();
     m_settings.clear();
@@ -1003,6 +1008,38 @@ QList<QPair<QString, QString>> AppSettings::radioFeaturesForDiagnostics() const
 
 // ─── Radio-scoped feature documents (RFC #4603) ──────────────────────────────
 
+QJsonObject AppSettings::radioFeatureExact(const QString& family,
+                                           const QString& radioId,
+                                           const QString& feature,
+                                           int* schemaVersionOut) const
+{
+    if (schemaVersionOut != nullptr) {
+        *schemaVersionOut = 0;
+    }
+    QMutexLocker ioLocker(&m_saveMutex);
+    if (!m_db || !m_db->isOpen()) {
+        return {};
+    }
+    int version = 0;
+    QString value;
+    if (!m_db->readRadioFeature(family, radioId, feature, version, value)) {
+        return {};
+    }
+    QJsonParseError parseError{};
+    const QJsonDocument parsed =
+        QJsonDocument::fromJson(value.toUtf8(), &parseError);
+    if (parseError.error != QJsonParseError::NoError || !parsed.isObject()) {
+        qWarning() << "AppSettings: radio feature document is corrupt —"
+                   << family << radioId << feature << ':'
+                   << parseError.errorString();
+        return {};
+    }
+    if (schemaVersionOut != nullptr) {
+        *schemaVersionOut = version;
+    }
+    return parsed.object();
+}
+
 QJsonObject AppSettings::radioFeature(const QString& family,
                                       const QString& radioId,
                                       const QString& feature,
@@ -1071,6 +1108,9 @@ bool AppSettings::setRadioFeature(const QString& family, const QString& radioId,
             return false;
         }
     }
+    if (!m_db || !m_db->isOpen()) {
+        return false;   // reset() may have closed the store (PR #4614 review)
+    }
     const QString value = QString::fromUtf8(
         QJsonDocument(doc).toJson(QJsonDocument::Compact));
     if (!m_db->begin()) {
@@ -1097,9 +1137,12 @@ bool AppSettings::removeRadioFeature(const QString& family,
             return false;
         }
     }
+    if (!m_db || !m_db->isOpen()) {
+        return false;   // reset() may have closed the store (PR #4614 review)
+    }
     if (!m_db->removeRadioFeature(family, radioId, feature)) {
         qWarning() << "AppSettings: radio feature remove failed:" << family
-                   << radioId << feature << '—' << m_db->lastError();
+                   << radioId << feature << "—" << m_db->lastError();
         return false;
     }
     return true;

--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -978,6 +978,86 @@ QStringList AppSettings::stationKeysForDiagnostics() const
     return m_stationSettings.keys();
 }
 
+// ─── Radio-scoped feature documents (RFC #4603) ──────────────────────────────
+
+QJsonObject AppSettings::radioFeature(const QString& family,
+                                      const QString& radioId,
+                                      const QString& feature,
+                                      int* schemaVersionOut) const
+{
+    if (schemaVersionOut != nullptr) {
+        *schemaVersionOut = 0;
+    }
+    auto* self = const_cast<AppSettings*>(this);
+    QMutexLocker ioLocker(&self->m_saveMutex);
+    if (!m_db || !m_db->isOpen()) {
+        return {};
+    }
+    int version = 0;
+    QString value;
+    // Exact radio first, then the family-wide default row.
+    if (!self->m_db->readRadioFeature(family, radioId, feature, version, value)
+        && !(radioId.isEmpty()
+             || self->m_db->readRadioFeature(family, QString(), feature, version,
+                                             value))) {
+        return {};
+    }
+    if (value.isEmpty()) {
+        return {};
+    }
+    if (schemaVersionOut != nullptr) {
+        *schemaVersionOut = version;
+    }
+    return QJsonDocument::fromJson(value.toUtf8()).object();
+}
+
+bool AppSettings::setRadioFeature(const QString& family, const QString& radioId,
+                                  const QString& feature, int schemaVersion,
+                                  const QJsonObject& doc)
+{
+    if (family.isEmpty() || feature.isEmpty()) {
+        qWarning() << "AppSettings: refusing radio feature write without a"
+                      " family and feature name";
+        return false;
+    }
+    QMutexLocker ioLocker(&m_saveMutex);
+    {
+        QReadLocker locker(&m_lock);
+        if (m_loadState != LoadState::ReadyToSave) {
+            qWarning() << "AppSettings: refusing radio feature write —"
+                          " store not writable";
+            return false;
+        }
+    }
+    const QString value = QString::fromUtf8(
+        QJsonDocument(doc).toJson(QJsonDocument::Compact));
+    if (!m_db->begin()) {
+        return false;
+    }
+    if (!m_db->upsertRadioFeature(family, radioId, feature, schemaVersion, value)
+        || !m_db->commit()) {
+        m_db->rollback();
+        qWarning() << "AppSettings: radio feature write failed:"
+                   << m_db->lastError();
+        return false;
+    }
+    return true;
+}
+
+bool AppSettings::removeRadioFeature(const QString& family,
+                                     const QString& radioId,
+                                     const QString& feature)
+{
+    QMutexLocker ioLocker(&m_saveMutex);
+    {
+        QReadLocker locker(&m_lock);
+        if (m_loadState != LoadState::ReadyToSave) {
+            return false;
+        }
+    }
+    return m_db->removeRadioFeature(family, radioId, feature);
+}
+
 // ─── Per-station accessors ────────────────────────────────────────────────────
 
 QVariant AppSettings::stationValue(const QString& key, const QVariant& defaultValue) const

--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -978,6 +978,29 @@ QStringList AppSettings::stationKeysForDiagnostics() const
     return m_stationSettings.keys();
 }
 
+QList<QPair<QString, QString>> AppSettings::radioFeaturesForDiagnostics() const
+{
+    QMutexLocker ioLocker(&m_saveMutex);
+    QList<QPair<QString, QString>> out;
+    if (!m_db || !m_db->isOpen()) {
+        return out;
+    }
+    QList<SettingsDatabase::RadioFeatureRow> rows;
+    if (!m_db->listRadioFeatures(rows)) {
+        return out;
+    }
+    for (const auto& row : rows) {
+        out.append({QStringLiteral("%1/%2/%3@v%4")
+                        .arg(row.family,
+                             row.radioId.isEmpty() ? QStringLiteral("<family>")
+                                                   : row.radioId,
+                             row.feature)
+                        .arg(row.schemaVersion),
+                    row.value});
+    }
+    return out;
+}
+
 // ─── Radio-scoped feature documents (RFC #4603) ──────────────────────────────
 
 QJsonObject AppSettings::radioFeature(const QString& family,
@@ -988,27 +1011,46 @@ QJsonObject AppSettings::radioFeature(const QString& family,
     if (schemaVersionOut != nullptr) {
         *schemaVersionOut = 0;
     }
-    auto* self = const_cast<AppSettings*>(this);
-    QMutexLocker ioLocker(&self->m_saveMutex);
+    QMutexLocker ioLocker(&m_saveMutex);
     if (!m_db || !m_db->isOpen()) {
         return {};
     }
+
+    // Read one row and parse it; a row that exists but does not parse is a
+    // CORRUPT document — logged, never silently treated as "nothing stored"
+    // (PR #4614 review).
+    const auto readRow = [this, &family, &feature](const QString& id,
+                                                   int& version,
+                                                   QJsonObject& doc) {
+        QString value;
+        if (!m_db->readRadioFeature(family, id, feature, version, value)) {
+            return false;
+        }
+        QJsonParseError parseError{};
+        const QJsonDocument parsed =
+            QJsonDocument::fromJson(value.toUtf8(), &parseError);
+        if (parseError.error != QJsonParseError::NoError || !parsed.isObject()) {
+            qWarning() << "AppSettings: radio feature document is corrupt —"
+                       << family << id << feature << ':'
+                       << parseError.errorString();
+            return false;
+        }
+        doc = parsed.object();
+        return true;
+    };
+
     int version = 0;
-    QString value;
-    // Exact radio first, then the family-wide default row.
-    if (!self->m_db->readRadioFeature(family, radioId, feature, version, value)
-        && !(radioId.isEmpty()
-             || self->m_db->readRadioFeature(family, QString(), feature, version,
-                                             value))) {
-        return {};
+    QJsonObject doc;
+    // Exact radio first; a missing OR corrupt exact row falls back to the
+    // family-wide default row (radioId "").
+    if (readRow(radioId, version, doc)
+        || (!radioId.isEmpty() && readRow(QString(), version, doc))) {
+        if (schemaVersionOut != nullptr) {
+            *schemaVersionOut = version;
+        }
+        return doc;
     }
-    if (value.isEmpty()) {
-        return {};
-    }
-    if (schemaVersionOut != nullptr) {
-        *schemaVersionOut = version;
-    }
-    return QJsonDocument::fromJson(value.toUtf8()).object();
+    return {};
 }
 
 bool AppSettings::setRadioFeature(const QString& family, const QString& radioId,
@@ -1055,7 +1097,12 @@ bool AppSettings::removeRadioFeature(const QString& family,
             return false;
         }
     }
-    return m_db->removeRadioFeature(family, radioId, feature);
+    if (!m_db->removeRadioFeature(family, radioId, feature)) {
+        qWarning() << "AppSettings: radio feature remove failed:" << family
+                   << radioId << feature << '—' << m_db->lastError();
+        return false;
+    }
+    return true;
 }
 
 // ─── Per-station accessors ────────────────────────────────────────────────────

--- a/src/core/AppSettings.h
+++ b/src/core/AppSettings.h
@@ -68,6 +68,12 @@ public:
     QJsonObject radioFeature(const QString& family, const QString& radioId,
                              const QString& feature,
                              int* schemaVersionOut = nullptr) const;
+    // Exact-row read — NO family-wide fallback. The write-side schema guard
+    // must judge the row it is about to overwrite, not whatever the read
+    // fallback resolves to (PR #4614 review).
+    QJsonObject radioFeatureExact(const QString& family, const QString& radioId,
+                                  const QString& feature,
+                                  int* schemaVersionOut = nullptr) const;
     bool setRadioFeature(const QString& family, const QString& radioId,
                          const QString& feature, int schemaVersion,
                          const QJsonObject& doc);

--- a/src/core/AppSettings.h
+++ b/src/core/AppSettings.h
@@ -3,6 +3,7 @@
 #include <QJsonObject>
 #include <QMap>
 #include <QMutex>
+#include <QPair>
 #include <QReadWriteLock>
 #include <QSet>
 #include <QString>
@@ -82,6 +83,10 @@ public:
     // their keys and never iterate the shared namespace.
     QStringList allKeysForDiagnostics() const;
     QStringList stationKeysForDiagnostics() const;
+    // radio_settings rows as "family/radioId/feature@vN<TAB-side value>" pairs
+    // for the sanitizer's dump — the third table is part of "the whole store"
+    // (PR #4614 review).
+    QList<QPair<QString, QString>> radioFeaturesForDiagnostics() const;
 
     // Path of the settings database (the store this class persists to).
     QString filePath() const { return m_filePath; }
@@ -177,7 +182,7 @@ private:
     QString m_loadNotice;
     LoadState m_loadState{LoadState::NotAttempted};
 
-    QMutex m_saveMutex;                          // serializes save()/import I/O
+    mutable QMutex m_saveMutex;                  // serializes save()/import/feature-doc I/O
 
     std::unique_ptr<QLockFile> m_guiClientLock;
     QString m_persistentGuiClientId;

--- a/src/core/AppSettings.h
+++ b/src/core/AppSettings.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QJsonObject>
 #include <QMap>
 #include <QMutex>
 #include <QReadWriteLock>
@@ -54,6 +55,23 @@ public:
     // Per-station settings (rows in station_settings keyed by station name).
     QVariant stationValue(const QString& key, const QVariant& defaultValue = {}) const;
     void setStationValue(const QString& key, const QVariant& val);
+
+    // ── Radio-scoped feature documents (RFC #4603 proposals A/B) ─────────────
+    // One versioned JSON document per (family, radio, feature) — Constitution
+    // Principle V: one feature-owned object, one owner, one migration point.
+    // Reads and writes go straight to the database under the I/O mutex (no
+    // cache): documents are read at connect time and written debounced, and
+    // a whole-document write IS the atomic feature update (rfoust review).
+    // Read fallback: exact radio → family-wide (radioId "") → empty object.
+    // schemaVersionOut receives the stored document version (0 when absent).
+    QJsonObject radioFeature(const QString& family, const QString& radioId,
+                             const QString& feature,
+                             int* schemaVersionOut = nullptr) const;
+    bool setRadioFeature(const QString& family, const QString& radioId,
+                         const QString& feature, int schemaVersion,
+                         const QJsonObject& doc);
+    bool removeRadioFeature(const QString& family, const QString& radioId,
+                            const QString& feature);
 
     // Station name (defaults to "AetherSDR").
     QString stationName() const;

--- a/src/core/RadioSettingsScope.h
+++ b/src/core/RadioSettingsScope.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "AppSettings.h"
+
+#include <QJsonObject>
+#include <QString>
+
+namespace AetherSDR {
+
+// A (family, radio) handle into the radio-scoped feature-document store
+// (RFC #4603 proposal A). RadioModel exposes the scope for the connected
+// radio; feature code holds the scope instead of re-deriving identity, so
+// "which radio does this state belong to" is decided in exactly one place.
+//
+// radioId is the family's canonical identity — Flex serial, HL2 MAC (from
+// Hl2Discovery::macToSerial()), Kiwi profile UUID. An empty radioId reads and
+// writes the family-wide default rows. Reads fall back:
+// exact radio → family-wide → empty document.
+class RadioSettingsScope {
+public:
+    RadioSettingsScope() = default;
+    RadioSettingsScope(QString family, QString radioId)
+        : m_family(std::move(family)), m_radioId(std::move(radioId))
+    {
+    }
+
+    bool isValid() const { return !m_family.isEmpty(); }
+    QString family() const { return m_family; }
+    QString radioId() const { return m_radioId; }
+
+    QJsonObject feature(const QString& name, int* schemaVersionOut = nullptr) const
+    {
+        if (!isValid()) {
+            return {};
+        }
+        return AppSettings::instance().radioFeature(m_family, m_radioId, name,
+                                                    schemaVersionOut);
+    }
+
+    bool setFeature(const QString& name, int schemaVersion,
+                    const QJsonObject& doc) const
+    {
+        if (!isValid()) {
+            return false;
+        }
+        return AppSettings::instance().setRadioFeature(m_family, m_radioId, name,
+                                                       schemaVersion, doc);
+    }
+
+    bool removeFeature(const QString& name) const
+    {
+        if (!isValid()) {
+            return false;
+        }
+        return AppSettings::instance().removeRadioFeature(m_family, m_radioId,
+                                                          name);
+    }
+
+private:
+    QString m_family;
+    QString m_radioId;
+};
+
+} // namespace AetherSDR

--- a/src/core/RadioSettingsScope.h
+++ b/src/core/RadioSettingsScope.h
@@ -37,6 +37,18 @@ public:
                                                     schemaVersionOut);
     }
 
+    // Exact-row read, no family-wide fallback — for writers judging the row
+    // they are about to replace (PR #4614 review).
+    QJsonObject featureExact(const QString& name,
+                             int* schemaVersionOut = nullptr) const
+    {
+        if (!isValid()) {
+            return {};
+        }
+        return AppSettings::instance().radioFeatureExact(m_family, m_radioId,
+                                                         name, schemaVersionOut);
+    }
+
     bool setFeature(const QString& name, int schemaVersion,
                     const QJsonObject& doc) const
     {

--- a/src/core/RadioStateMemory.cpp
+++ b/src/core/RadioStateMemory.cpp
@@ -15,6 +15,15 @@ bool has(const RadioCapabilities& caps, Domain domain)
     return caps.clientSettingsDomains.testFlag(domain);
 }
 
+// The extension document's domain sub-keys (PR #4614 review): the engine
+// gates the extension PER DOMAIN by copying only the sub-object named for a
+// declared domain. The CONTENTS of each sub-object stay opaque here — the
+// owning backend writes and validates them (Principle VII). Memories is
+// deliberately NOT in this vocabulary: the #4590 bank re-targets its own
+// feature documents (one domain, one document — PR 6).
+constexpr const char* kExtRfGainKey = "rfGain";
+constexpr const char* kExtTxSetpointsKey = "txSetpoints";
+
 } // namespace
 
 RestoredRadioState load(const RadioSettingsScope& scope,
@@ -31,16 +40,19 @@ RestoredRadioState load(const RadioSettingsScope& scope,
         return state;
     }
     if (storedVersion > kSchemaVersion) {
-        // A newer binary wrote this document. Additive-schema policy says the
-        // fields we know are still readable; unknown fields stay in `extension`
-        // untouched because we never rewrite what we didn't read.
+        // A newer binary wrote this document. The fields we know are still
+        // readable; the document itself is protected because store() below
+        // REFUSES to overwrite a newer version — this binary never rewrites
+        // (and thereby truncates or downgrades) a document it cannot fully
+        // represent (PR #4614 review).
         qWarning() << "RadioStateMemory: operating-state document schema"
                    << storedVersion << "is newer than" << kSchemaVersion
-                   << "— reading known fields only";
+                   << "— reading known fields only; capture is disabled for"
+                      " this radio";
     }
 
     // Universal fields, gated per declared domain — an undeclared domain is
-    // "not restored" even when an older document carries it.
+    // "not restored" even when the stored document carries it.
     if (has(caps, Domain::Tuning)) {
         state.rfFrequencyHz = doc.value(QStringLiteral("rfFrequencyHz")).toDouble();
         state.mode = doc.value(QStringLiteral("mode")).toString();
@@ -53,12 +65,24 @@ RestoredRadioState load(const RadioSettingsScope& scope,
         state.sampleRateHz = doc.value(QStringLiteral("sampleRateHz")).toInt();
     }
 
-    // The per-family extension document is opaque here (Principle VII: the
-    // owning backend validates it). RfGain/TxSetpoints per-band maps ride
-    // inside it starting PR 3.
-    if (has(caps, Domain::RfGain) || has(caps, Domain::TxSetpoints)
-        || has(caps, Domain::Memories)) {
-        state.extension = doc.value(QStringLiteral("ext")).toObject();
+    // The extension is gated per domain too: only a declared domain's
+    // sub-object is handed over, so a narrowed declaration cannot smuggle
+    // another domain's data to the backend (PR #4614 review — previously the
+    // whole blob rode on any one of the ext domains).
+    const QJsonObject storedExt = doc.value(QStringLiteral("ext")).toObject();
+    QJsonObject gatedExt;
+    if (has(caps, Domain::RfGain)
+        && storedExt.contains(QLatin1String(kExtRfGainKey))) {
+        gatedExt.insert(QLatin1String(kExtRfGainKey),
+                        storedExt.value(QLatin1String(kExtRfGainKey)));
+    }
+    if (has(caps, Domain::TxSetpoints)
+        && storedExt.contains(QLatin1String(kExtTxSetpointsKey))) {
+        gatedExt.insert(QLatin1String(kExtTxSetpointsKey),
+                        storedExt.value(QLatin1String(kExtTxSetpointsKey)));
+    }
+    if (!gatedExt.isEmpty()) {
+        state.extension = gatedExt;
         state.extensionSchemaVersion =
             doc.value(QStringLiteral("extVersion")).toInt();
     }
@@ -69,6 +93,23 @@ bool store(const RadioSettingsScope& scope, const RadioCapabilities& caps,
            const RestoredRadioState& state)
 {
     if (!shouldEngage(caps) || !scope.isValid()) {
+        qDebug() << "RadioStateMemory: store skipped — not engaged for this"
+                    " radio (empty domain declaration or invalid scope)";
+        return false;
+    }
+
+    // Read-only toward the future: never overwrite a document written by a
+    // newer schema — a v1 rebuild would drop the fields v1 doesn't know and
+    // stamp the version back down (PR #4614 review, three independent
+    // reports). Mirrors SettingsDatabase's own newer-schema rule.
+    int storedVersion = 0;
+    const QJsonObject existing = scope.feature(featureName(), &storedVersion);
+    Q_UNUSED(existing);
+    if (storedVersion > kSchemaVersion) {
+        qWarning() << "RadioStateMemory: refusing to overwrite operating-state"
+                      " document at schema" << storedVersion
+                   << "with schema" << kSchemaVersion
+                   << "— capture is read-only toward newer documents";
         return false;
     }
 
@@ -89,17 +130,35 @@ bool store(const RadioSettingsScope& scope, const RadioCapabilities& caps,
     if (has(caps, Domain::SpanRate) && state.sampleRateHz > 0) {
         doc.insert(QStringLiteral("sampleRateHz"), state.sampleRateHz);
     }
-    if ((has(caps, Domain::RfGain) || has(caps, Domain::TxSetpoints)
-         || has(caps, Domain::Memories))
-        && !state.extension.isEmpty()) {
-        doc.insert(QStringLiteral("ext"), state.extension);
+
+    // Extension: same per-domain sub-object gate as load().
+    QJsonObject gatedExt;
+    if (has(caps, Domain::RfGain)
+        && state.extension.contains(QLatin1String(kExtRfGainKey))) {
+        gatedExt.insert(QLatin1String(kExtRfGainKey),
+                        state.extension.value(QLatin1String(kExtRfGainKey)));
+    }
+    if (has(caps, Domain::TxSetpoints)
+        && state.extension.contains(QLatin1String(kExtTxSetpointsKey))) {
+        gatedExt.insert(QLatin1String(kExtTxSetpointsKey),
+                        state.extension.value(QLatin1String(kExtTxSetpointsKey)));
+    }
+    if (!gatedExt.isEmpty()) {
+        doc.insert(QStringLiteral("ext"), gatedExt);
         doc.insert(QStringLiteral("extVersion"), state.extensionSchemaVersion);
     }
 
     if (doc.isEmpty()) {
-        return false;   // nothing declared AND present — write nothing
+        qDebug() << "RadioStateMemory: store skipped — nothing declared AND"
+                    " present to write";
+        return false;   // a deliberate no-op, distinct in the log from failure
     }
-    return scope.setFeature(featureName(), kSchemaVersion, doc);
+    if (!scope.setFeature(featureName(), kSchemaVersion, doc)) {
+        qWarning() << "RadioStateMemory: operating-state write failed for"
+                   << scope.family() << scope.radioId();
+        return false;
+    }
+    return true;
 }
 
 } // namespace RadioStateMemory

--- a/src/core/RadioStateMemory.cpp
+++ b/src/core/RadioStateMemory.cpp
@@ -102,9 +102,12 @@ bool store(const RadioSettingsScope& scope, const RadioCapabilities& caps,
     // newer schema — a v1 rebuild would drop the fields v1 doesn't know and
     // stamp the version back down (PR #4614 review, three independent
     // reports). Mirrors SettingsDatabase's own newer-schema rule.
+    // EXACT row only: the guard judges the document this write would
+    // replace. The fallback read would smuggle in the family-wide row's
+    // version and could refuse every per-radio capture in the family
+    // (PR #4614 review, Ozy311).
     int storedVersion = 0;
-    const QJsonObject existing = scope.feature(featureName(), &storedVersion);
-    Q_UNUSED(existing);
+    scope.featureExact(featureName(), &storedVersion);
     if (storedVersion > kSchemaVersion) {
         qWarning() << "RadioStateMemory: refusing to overwrite operating-state"
                       " document at schema" << storedVersion

--- a/src/core/RadioStateMemory.cpp
+++ b/src/core/RadioStateMemory.cpp
@@ -1,0 +1,106 @@
+#include "RadioStateMemory.h"
+
+#include <QDebug>
+#include <QJsonDocument>
+
+namespace AetherSDR {
+namespace RadioStateMemory {
+
+namespace {
+
+using Domain = RadioCapabilities::ClientSettingsDomain;
+
+bool has(const RadioCapabilities& caps, Domain domain)
+{
+    return caps.clientSettingsDomains.testFlag(domain);
+}
+
+} // namespace
+
+RestoredRadioState load(const RadioSettingsScope& scope,
+                        const RadioCapabilities& caps)
+{
+    RestoredRadioState state;
+    if (!shouldEngage(caps) || !scope.isValid()) {
+        return state;
+    }
+
+    int storedVersion = 0;
+    const QJsonObject doc = scope.feature(featureName(), &storedVersion);
+    if (doc.isEmpty()) {
+        return state;
+    }
+    if (storedVersion > kSchemaVersion) {
+        // A newer binary wrote this document. Additive-schema policy says the
+        // fields we know are still readable; unknown fields stay in `extension`
+        // untouched because we never rewrite what we didn't read.
+        qWarning() << "RadioStateMemory: operating-state document schema"
+                   << storedVersion << "is newer than" << kSchemaVersion
+                   << "— reading known fields only";
+    }
+
+    // Universal fields, gated per declared domain — an undeclared domain is
+    // "not restored" even when an older document carries it.
+    if (has(caps, Domain::Tuning)) {
+        state.rfFrequencyHz = doc.value(QStringLiteral("rfFrequencyHz")).toDouble();
+        state.mode = doc.value(QStringLiteral("mode")).toString();
+    }
+    if (has(caps, Domain::Passband)) {
+        state.filterLowHz = doc.value(QStringLiteral("filterLowHz")).toDouble();
+        state.filterHighHz = doc.value(QStringLiteral("filterHighHz")).toDouble();
+    }
+    if (has(caps, Domain::SpanRate)) {
+        state.sampleRateHz = doc.value(QStringLiteral("sampleRateHz")).toInt();
+    }
+
+    // The per-family extension document is opaque here (Principle VII: the
+    // owning backend validates it). RfGain/TxSetpoints per-band maps ride
+    // inside it starting PR 3.
+    if (has(caps, Domain::RfGain) || has(caps, Domain::TxSetpoints)
+        || has(caps, Domain::Memories)) {
+        state.extension = doc.value(QStringLiteral("ext")).toObject();
+        state.extensionSchemaVersion =
+            doc.value(QStringLiteral("extVersion")).toInt();
+    }
+    return state;
+}
+
+bool store(const RadioSettingsScope& scope, const RadioCapabilities& caps,
+           const RestoredRadioState& state)
+{
+    if (!shouldEngage(caps) || !scope.isValid()) {
+        return false;
+    }
+
+    QJsonObject doc;
+    if (has(caps, Domain::Tuning)) {
+        if (state.rfFrequencyHz > 0.0) {
+            doc.insert(QStringLiteral("rfFrequencyHz"), state.rfFrequencyHz);
+        }
+        if (!state.mode.isEmpty()) {
+            doc.insert(QStringLiteral("mode"), state.mode);
+        }
+    }
+    if (has(caps, Domain::Passband)
+        && (state.filterLowHz != 0.0 || state.filterHighHz != 0.0)) {
+        doc.insert(QStringLiteral("filterLowHz"), state.filterLowHz);
+        doc.insert(QStringLiteral("filterHighHz"), state.filterHighHz);
+    }
+    if (has(caps, Domain::SpanRate) && state.sampleRateHz > 0) {
+        doc.insert(QStringLiteral("sampleRateHz"), state.sampleRateHz);
+    }
+    if ((has(caps, Domain::RfGain) || has(caps, Domain::TxSetpoints)
+         || has(caps, Domain::Memories))
+        && !state.extension.isEmpty()) {
+        doc.insert(QStringLiteral("ext"), state.extension);
+        doc.insert(QStringLiteral("extVersion"), state.extensionSchemaVersion);
+    }
+
+    if (doc.isEmpty()) {
+        return false;   // nothing declared AND present — write nothing
+    }
+    return scope.setFeature(featureName(), kSchemaVersion, doc);
+}
+
+} // namespace RadioStateMemory
+} // namespace AetherSDR

--- a/src/core/RadioStateMemory.h
+++ b/src/core/RadioStateMemory.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "RadioSettingsScope.h"
+#include "backends/RadioCapabilities.h"
+#include "backends/RestoredRadioState.h"
+
+namespace AetherSDR {
+
+// The client-side memory for radios that have none of their own (RFC #4603
+// proposal B). Engagement is decided by ONE rule and it is capability-shaped,
+// never family-shaped: a radio's declared ClientSettingsDomains says which
+// domains the client persists and restores. Empty (Flex, Sim) ⇒ this class is
+// inert and the radio-authoritative policy (Constitution II/III) is untouched.
+//
+// PR 2 scope (this file): the store/load round-trip of the operating-state
+// feature document and the domain gating. The live capture wiring (model
+// deltas → debounced store) and the per-domain field application — including
+// the per-band drive/LNA maps from nigelfenton's RFC review — land in PR 3
+// together with the HL2 restore path.
+namespace RadioStateMemory {
+
+// The feature document name in radio_settings, and its current schema.
+inline QString featureName() { return QStringLiteral("OperatingState"); }
+constexpr int kSchemaVersion = 1;
+
+// The single engagement predicate: restore/capture happen only for declared
+// domains. Deliberately a function so tests and call sites share one truth.
+inline bool shouldEngage(const RadioCapabilities& caps)
+{
+    return caps.clientSettingsDomains != RadioCapabilities::ClientSettingsDomains{};
+}
+
+// Load the remembered operating state for a radio, filtered to the domains
+// its backend declares. Undeclared domains come back as "not restored" even
+// if an older document carries them (a capability downgrade must not smuggle
+// state past the gate). Returns an empty state when nothing is stored.
+RestoredRadioState load(const RadioSettingsScope& scope,
+                        const RadioCapabilities& caps);
+
+// Store the operating state as one atomic feature document, filtered to the
+// declared domains. A state that is empty after filtering is not written.
+bool store(const RadioSettingsScope& scope, const RadioCapabilities& caps,
+           const RestoredRadioState& state);
+
+} // namespace RadioStateMemory
+
+} // namespace AetherSDR

--- a/src/core/RadioStateMemory.h
+++ b/src/core/RadioStateMemory.h
@@ -17,6 +17,18 @@ namespace AetherSDR {
 // deltas → debounced store) and the per-domain field application — including
 // the per-band drive/LNA maps from nigelfenton's RFC review — land in PR 3
 // together with the HL2 restore path.
+//
+// Two deliberate contract points (PR #4614 review):
+// - store() is READ-ONLY TOWARD NEWER DOCUMENTS: it refuses to overwrite a
+//   document whose schema_version exceeds kSchemaVersion, because a rebuild
+//   at this version would drop unknown fields and downgrade the version.
+// - store() writes the whole document filtered to the DECLARED domains — so a
+//   session under a NARROWER declaration doesn't just skip the undeclared
+//   domains, it erases them from the stored document. Harmless while
+//   declarations are static per family; revisit if they ever become dynamic.
+// The Memories domain is deliberately absent from the extension gate: the
+// host-side memory bank (#4590) gets its own feature documents (PR 6) —
+// one domain, one document.
 namespace RadioStateMemory {
 
 // The feature document name in radio_settings, and its current schema.

--- a/src/core/SettingsDatabase.cpp
+++ b/src/core/SettingsDatabase.cpp
@@ -494,6 +494,32 @@ bool SettingsDatabase::removeRadioFeature(const QString& family,
     return true;
 }
 
+bool SettingsDatabase::listRadioFeatures(QList<RadioFeatureRow>& out)
+{
+    Statement stmt(m_db,
+        "SELECT family, radio_id, feature, schema_version, value "
+        "FROM radio_settings ORDER BY family, radio_id, feature;");
+    if (!stmt.valid()) {
+        m_lastError = QString::fromUtf8(sqlite3_errmsg(m_db));
+        return false;
+    }
+    int rc = 0;
+    while ((rc = sqlite3_step(stmt.get())) == SQLITE_ROW) {
+        RadioFeatureRow row;
+        row.family = columnText(stmt.get(), 0);
+        row.radioId = columnText(stmt.get(), 1);
+        row.feature = columnText(stmt.get(), 2);
+        row.schemaVersion = sqlite3_column_int(stmt.get(), 3);
+        row.value = columnText(stmt.get(), 4);
+        out.append(row);
+    }
+    if (rc != SQLITE_DONE) {
+        m_lastError = QString::fromUtf8(sqlite3_errmsg(m_db));
+        return false;
+    }
+    return true;
+}
+
 bool SettingsDatabase::beginExclusive() { return exec("BEGIN EXCLUSIVE;"); }
 bool SettingsDatabase::begin()          { return exec("BEGIN IMMEDIATE;"); }
 bool SettingsDatabase::commit()         { return exec("COMMIT;"); }

--- a/src/core/SettingsDatabase.cpp
+++ b/src/core/SettingsDatabase.cpp
@@ -424,6 +424,76 @@ qint64 SettingsDatabase::appCount()
     return sqlite3_column_int64(stmt.get(), 0);
 }
 
+bool SettingsDatabase::upsertRadioFeature(const QString& family,
+                                          const QString& radioId,
+                                          const QString& feature,
+                                          int schemaVersion,
+                                          const QString& value)
+{
+    Statement stmt(m_db,
+        "INSERT INTO radio_settings (family, radio_id, feature, schema_version, value) "
+        "VALUES (?1, ?2, ?3, ?4, ?5) "
+        "ON CONFLICT(family, radio_id, feature) DO UPDATE SET "
+        "schema_version = excluded.schema_version, value = excluded.value;");
+    if (!stmt.valid()) {
+        m_lastError = QString::fromUtf8(sqlite3_errmsg(m_db));
+        return false;
+    }
+    bindText(stmt.get(), 1, family);
+    bindText(stmt.get(), 2, radioId);
+    bindText(stmt.get(), 3, feature);
+    sqlite3_bind_int(stmt.get(), 4, schemaVersion);
+    bindText(stmt.get(), 5, value);
+    if (sqlite3_step(stmt.get()) != SQLITE_DONE) {
+        m_lastError = QString::fromUtf8(sqlite3_errmsg(m_db));
+        return false;
+    }
+    return true;
+}
+
+bool SettingsDatabase::readRadioFeature(const QString& family,
+                                        const QString& radioId,
+                                        const QString& feature,
+                                        int& schemaVersion, QString& value)
+{
+    Statement stmt(m_db,
+        "SELECT schema_version, value FROM radio_settings "
+        "WHERE family = ?1 AND radio_id = ?2 AND feature = ?3;");
+    if (!stmt.valid()) {
+        return false;
+    }
+    bindText(stmt.get(), 1, family);
+    bindText(stmt.get(), 2, radioId);
+    bindText(stmt.get(), 3, feature);
+    if (sqlite3_step(stmt.get()) != SQLITE_ROW) {
+        return false;
+    }
+    schemaVersion = sqlite3_column_int(stmt.get(), 0);
+    value = columnText(stmt.get(), 1);
+    return true;
+}
+
+bool SettingsDatabase::removeRadioFeature(const QString& family,
+                                          const QString& radioId,
+                                          const QString& feature)
+{
+    Statement stmt(m_db,
+        "DELETE FROM radio_settings "
+        "WHERE family = ?1 AND radio_id = ?2 AND feature = ?3;");
+    if (!stmt.valid()) {
+        m_lastError = QString::fromUtf8(sqlite3_errmsg(m_db));
+        return false;
+    }
+    bindText(stmt.get(), 1, family);
+    bindText(stmt.get(), 2, radioId);
+    bindText(stmt.get(), 3, feature);
+    if (sqlite3_step(stmt.get()) != SQLITE_DONE) {
+        m_lastError = QString::fromUtf8(sqlite3_errmsg(m_db));
+        return false;
+    }
+    return true;
+}
+
 bool SettingsDatabase::beginExclusive() { return exec("BEGIN EXCLUSIVE;"); }
 bool SettingsDatabase::begin()          { return exec("BEGIN IMMEDIATE;"); }
 bool SettingsDatabase::commit()         { return exec("COMMIT;"); }

--- a/src/core/SettingsDatabase.h
+++ b/src/core/SettingsDatabase.h
@@ -81,6 +81,17 @@ public:
     bool readApp(const QString& key, QString& value);
     qint64 appCount();
 
+    // radio_settings — one versioned feature document per (family, radio, feature)
+    // (RFC #4603 proposal A; radio_id "" = family-wide default row) -----------
+    bool upsertRadioFeature(const QString& family, const QString& radioId,
+                            const QString& feature, int schemaVersion,
+                            const QString& value);
+    bool readRadioFeature(const QString& family, const QString& radioId,
+                          const QString& feature, int& schemaVersion,
+                          QString& value);
+    bool removeRadioFeature(const QString& family, const QString& radioId,
+                            const QString& feature);
+
     // Transactions -----------------------------------------------------------
     bool beginExclusive();   // BEGIN EXCLUSIVE — blocks concurrent writers
     bool begin();            // BEGIN IMMEDIATE

--- a/src/core/SettingsDatabase.h
+++ b/src/core/SettingsDatabase.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QString>
+#include <QList>
 #include <QMap>
 
 struct sqlite3;
@@ -91,6 +92,15 @@ public:
                           QString& value);
     bool removeRadioFeature(const QString& family, const QString& radioId,
                             const QString& feature);
+    // Full enumeration for diagnostics (--config features / support bundle).
+    struct RadioFeatureRow {
+        QString family;
+        QString radioId;
+        QString feature;
+        int schemaVersion = 0;
+        QString value;
+    };
+    bool listRadioFeatures(QList<RadioFeatureRow>& out);
 
     // Transactions -----------------------------------------------------------
     bool beginExclusive();   // BEGIN EXCLUSIVE — blocks concurrent writers

--- a/src/core/SettingsSanitizer.cpp
+++ b/src/core/SettingsSanitizer.cpp
@@ -125,6 +125,17 @@ QString dump()
                    + QLatin1Char('\n');
         }
     }
+
+    // The radio-scoped feature documents are part of "the whole store" too
+    // (PR #4614 review) — same recursive redaction over each document.
+    const auto radioRows = s.radioFeaturesForDiagnostics();
+    if (!radioRows.isEmpty()) {
+        out += QStringLiteral("## radio_settings\n");
+        for (const auto& row : radioRows) {
+            out += row.first + QLatin1Char('\t')
+                   + redactedValue(row.first, row.second) + QLatin1Char('\n');
+        }
+    }
     return out;
 }
 

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -14,6 +14,7 @@
 #include "core/backends/MeterDef.h"
 #include "core/backends/ProfileDelta.h"
 #include "core/backends/RadioCapabilities.h"
+#include "core/backends/RestoredRadioState.h"
 #include "core/backends/RadioDelta.h"
 #include "core/backends/SliceDelta.h"
 #include "core/backends/TransmitDelta.h"
@@ -85,6 +86,16 @@ public:
     virtual bool ownsRxAudio() const { return false; }
 
     // ---- connection lifecycle ----
+    // Typed restore handoff (RFC #4603 proposal B): called by RadioModel
+    // BEFORE connectRadio(), and only when this backend's declared
+    // clientSettingsDomains is non-empty. The backend stashes what it wants
+    // and applies it during connect/initial-push, validating its own
+    // extension document at this boundary (Principle VII). Default no-op —
+    // a radio-authoritative backend (Flex) never sees restored state.
+    virtual void applyRestoredState(const RestoredRadioState& state)
+    {
+        Q_UNUSED(state);
+    }
     virtual void connectRadio(const RadioConnectRequest& request) = 0;
     virtual void disconnectRadio() = 0;
     virtual bool isConnected() const = 0;

--- a/src/core/backends/RadioCapabilities.h
+++ b/src/core/backends/RadioCapabilities.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QFlags>
 #include <QString>
 #include <QVector>
 #include <QVariantMap>
@@ -76,6 +77,33 @@ struct RadioCapabilities {
     // being written into a radio that silently drops them. A backend only sets
     // this true when it can prove the radio gives the slots back.
     bool persistsMemories = false;
+
+    // Domains of OPERATING STATE this client persists and restores because the
+    // radio cannot (RFC #4603 proposal B). Constitution Principle III assigns
+    // persistence authority per value, not per family — so this is a typed set,
+    // not a boolean: a family may persist some domains on-radio and rely on the
+    // client for others (cf. persistsMemories above, the pattern this follows).
+    //
+    // EMPTY IS THE LOAD-BEARING DEFAULT: a backend that declares nothing gets
+    // NOTHING restored. For a radio that persists its own state (Flex), that is
+    // exactly the Constitution II/III rule — the client must never re-assert
+    // radio-owned values (#2465/#4126/#4261). A backend only declares a domain
+    // when the radio genuinely has no memory of it, making the client the
+    // radio's memory (HL2: "the radio reports no VFO, so the app is
+    // authoritative and must push").
+    //
+    // Restore NEVER keys transmit (Principle VI): TxSetpoints covers setpoint
+    // values (drive levels) only — the TX gate is untouched by any of this.
+    enum class ClientSettingsDomain : quint32 {
+        Tuning      = 1u << 0,  // RF frequency + demod mode
+        Passband    = 1u << 1,  // filter low/high edges
+        SpanRate    = 1u << 2,  // span / IQ sample rate
+        RfGain      = 1u << 3,  // LNA/preamp gain (per band — see RFC PR 3)
+        TxSetpoints = 1u << 4,  // TX drive setpoints (per band); never keying
+        Memories    = 1u << 5,  // host-side memory bank documents (#4590 fold-in)
+    };
+    Q_DECLARE_FLAGS(ClientSettingsDomains, ClientSettingsDomain)
+    ClientSettingsDomains clientSettingsDomains;   // default: empty — restore nothing
 
     // Peripherals / features every family may or may not have
     bool canReboot = false;        // supports a client-triggered radio reboot
@@ -179,5 +207,7 @@ struct RadioCapabilities {
     // invokeExtension(ns, …).
     QVector<QString> extensionNamespaces;
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(RadioCapabilities::ClientSettingsDomains)
 
 }  // namespace AetherSDR

--- a/src/core/backends/RestoredRadioState.h
+++ b/src/core/backends/RestoredRadioState.h
@@ -30,7 +30,12 @@ struct RestoredRadioState {
     int sampleRateHz = 0;         // SpanRate
 
     // Per-family extension document (per-band gain/drive maps live here —
-    // RFC PR 3). Versioned by its owner; opaque to everything above the seam.
+    // RFC PR 3). Versioned by its owner. GATED PER DOMAIN at the top level:
+    // the engine hands over only the sub-objects named for declared domains —
+    // "rfGain" (ClientSettingsDomain::RfGain) and "txSetpoints"
+    // (ClientSettingsDomain::TxSetpoints) — and each sub-object's CONTENTS
+    // stay opaque to everything above the seam; the owning backend writes and
+    // validates them (Principle VII; PR #4614 review).
     int extensionSchemaVersion = 0;
     QJsonObject extension;
 

--- a/src/core/backends/RestoredRadioState.h
+++ b/src/core/backends/RestoredRadioState.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <QJsonObject>
+#include <QString>
+
+namespace AetherSDR {
+
+// The typed restore contract of RFC #4603 proposal B: what the client's
+// settings store remembers about a radio whose declared ClientSettingsDomains
+// make the client its memory. Handed to the backend BEFORE connect
+// (IRadioBackend::applyRestoredState) so the connect/pushInitialState path can
+// bring the radio up where the operator left it.
+//
+// Shape follows the aetherd 2.3 universal/extension field classification:
+// typed fields for state every family shares, plus a per-family extension
+// document that ONLY the owning backend writes, reads, and validates
+// (Principle VII — boundary input validation lives with the owner). Generic
+// engine code (RadioStateMemory) round-trips the extension opaquely and must
+// never interpret it.
+//
+// A zero/empty field means "not restored" — the backend keeps its own default.
+// Restoring NEVER keys transmit (Principle VI): the struct carries setpoints,
+// and the TX gate is untouched.
+struct RestoredRadioState {
+    // Universal — gated per-domain by RadioCapabilities::clientSettingsDomains
+    double rfFrequencyHz = 0.0;   // Tuning
+    QString mode;                 // Tuning
+    double filterLowHz = 0.0;     // Passband
+    double filterHighHz = 0.0;    // Passband
+    int sampleRateHz = 0;         // SpanRate
+
+    // Per-family extension document (per-band gain/drive maps live here —
+    // RFC PR 3). Versioned by its owner; opaque to everything above the seam.
+    int extensionSchemaVersion = 0;
+    QJsonObject extension;
+
+    bool isEmpty() const
+    {
+        return rfFrequencyHz == 0.0 && mode.isEmpty() && filterLowHz == 0.0
+               && filterHighHz == 0.0 && sampleRateHz == 0
+               && extension.isEmpty();
+    }
+};
+
+} // namespace AetherSDR

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -188,6 +188,11 @@ RadioCapabilities FlexBackend::capabilities() const
     // the client must NOT keep a local bank for a Flex — two stores that both
     // believe they are authoritative would fight over slot indices.
     caps.persistsMemories = true;
+    // The radio persists its own operating state (frequency, mode, filters,
+    // power) and restores it via GUIClientID session restore — the client must
+    // never re-assert any of it (Constitution II/III; the #2465/#4126/#4261
+    // bug class). Declared empty EXPLICITLY per the ADDING-A-FIELD contract.
+    caps.clientSettingsDomains = {};
     // The "+13.8A" meter carries the PA supply rail (measurement point A,
     // before the fuse), which the status bar renders under the PA temperature.
     caps.hasSupplyVoltageTelemetry = true;

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -1179,6 +1179,16 @@ RadioCapabilities Hl2Backend::capabilities() const
     // from this radio, the supply rail is not reported at all. Only the volts
     // readout goes away — the temperature above it keeps working.
     c.hasSupplyVoltageTelemetry = false;
+    // The HL2 persists NOTHING across power cycles — "the radio reports no
+    // VFO, so the app is authoritative and must push" (pushInitialState).
+    // These are the domains the client owns as the radio's memory
+    // (RFC #4603): consumed by RadioStateMemory, wired per-domain in the
+    // RFC's PR 3 (per-band drive/LNA maps per nigelfenton's review).
+    c.clientSettingsDomains = RadioCapabilities::ClientSettingsDomain::Tuning
+                            | RadioCapabilities::ClientSettingsDomain::Passband
+                            | RadioCapabilities::ClientSettingsDomain::SpanRate
+                            | RadioCapabilities::ClientSettingsDomain::RfGain
+                            | RadioCapabilities::ClientSettingsDomain::TxSetpoints;
     // No extension namespaces (no invokeExtension verbs yet), matching FlexBackend.
     return c;
 }

--- a/src/core/backends/sim/SimBackend.cpp
+++ b/src/core/backends/sim/SimBackend.cpp
@@ -313,6 +313,9 @@ RadioCapabilities SimBackend::capabilities() const
     caps.hasMultiClientSessions = false;
     caps.hasGpsLocation = false;         // synthetic radio has no position source
     caps.hasSupplyVoltageTelemetry = false;   // synthetic scene; no PA rail
+    // The demo radio regenerates its synthetic scene on every connect; there
+    // is no operating state worth resurrecting across sessions.
+    caps.clientSettingsDomains = {};
     return caps;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,6 +121,9 @@ static int runConfigCli(int argc, char* argv[])
             "  unset <key>        delete a setting\n"
             "  export             sanitized dump of the whole store (secrets\n"
             "                     redacted; diagnostic output, not a backup)\n"
+            "  features [family]  list radio-scoped feature documents\n"
+            "                     (sanitized; write access lands with RFC #4603\n"
+            "                     PR 3, when something writes them)\n"
             "  path               print the settings database path\n",
             stderr);
         return 1;
@@ -164,6 +167,20 @@ static int runConfigCli(int argc, char* argv[])
     }
     if (op == QStringLiteral("export")) {
         std::printf("%s", qPrintable(AetherSDR::SettingsSanitizer::dump()));
+        return 0;
+    }
+    if (op == QStringLiteral("features")) {
+        const QString family = args.value(3);
+        const auto rows = settings.radioFeaturesForDiagnostics();
+        for (const auto& row : rows) {
+            if (!family.isEmpty()
+                && !row.first.startsWith(family + QLatin1Char('/'))) {
+                continue;
+            }
+            std::printf("%s\t%s\n", qPrintable(row.first),
+                        qPrintable(AetherSDR::SettingsSanitizer::redactedValue(
+                            row.first, row.second)));
+        }
         return 0;
     }
     if (op == QStringLiteral("set") || op == QStringLiteral("unset")) {

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -9,6 +9,7 @@
 #include "core/backends/sim/SimBackend.h"     // RFC #4288 demo-mode backend (Route A)
 #include "core/backends/hl2/Hl2Backend.h"      // aetherd Gap A — HL2 backend (family "hl2")
 #include "core/AppSettings.h"
+#include "core/RadioStateMemory.h"  // RFC #4603 typed restore handoff
 #include "core/CwTrace.h"
 #include "core/DigitalVoiceModeRegistry.h"
 #include "core/DigitalVoiceWaveformProcess.h"
@@ -417,6 +418,28 @@ QJsonObject clientInfoToJson(quint32 handle,
 // family string to its IRadioBackend. "flex" (the default, and any unrecognized
 // value) preserves the historical hard-wired FlexBackend; "hl2" selects the
 // Hermes-Lite 2 backend. A fuller step-3 registry supersedes this later.
+
+// RFC #4603 proposal B: hand the remembered operating state to a backend
+// whose declared ClientSettingsDomains make the client its memory. Called
+// immediately before connectRadio(); a backend with an empty declaration
+// (Flex, Sim) never sees restored state — the radio-authoritative policy
+// (Constitution II/III) is structurally untouched.
+void RadioModel::handRestoredStateToBackend(const QString& serial)
+{
+    if (!m_backend) {
+        return;
+    }
+    const RadioCapabilities caps = m_backend->capabilities();
+    if (!RadioStateMemory::shouldEngage(caps)) {
+        return;
+    }
+    const RestoredRadioState state =
+        RadioStateMemory::load(RadioSettingsScope(m_family, serial), caps);
+    if (!state.isEmpty()) {
+        m_backend->applyRestoredState(state);
+    }
+}
+
 std::unique_ptr<IRadioBackend> RadioModel::makeBackend(const QString& family)
 {
     if (family.compare(QLatin1String("hl2"), Qt::CaseInsensitive) == 0)
@@ -1445,6 +1468,7 @@ RadioModel::RadioModel(QObject* parent)
                 req.host   = m_lastInfo.address.toString();
                 req.port   = m_lastInfo.port;
                 req.serial = m_lastInfo.serial;
+                handRestoredStateToBackend(req.serial);
                 m_backend->connectRadio(req);
             }
         } else {
@@ -2453,6 +2477,7 @@ void RadioModel::connectToRadio(const RadioInfo& info)
         req.host   = info.address.toString();
         req.port   = info.port;
         req.serial = info.serial;
+        handRestoredStateToBackend(req.serial);
         m_backend->connectRadio(req);
     }
 }

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -2,6 +2,7 @@
 
 #include "core/CommandParser.h"   // MessageSeverity for radioMessageReceived
 #include "core/GuiClientRegistrationState.h"
+#include "core/RadioSettingsScope.h"  // RFC #4603 radio-scoped feature documents
 #include "core/backends/GpsDelta.h"     // applyGpsChanges payload (aetherd 2.3)
 #include "core/backends/MemoryDelta.h"  // applyMemoryChanges payload (aetherd 2.3)
 #include "core/backends/ProfileDelta.h" // applyProfileChanges payload (aetherd 2.3)
@@ -1023,6 +1024,14 @@ public:
     bool sendCommand(const QString& cmd);
     // Backend family currently in use ("flex", "hl2", "kiwi", ...).
     QString family() const { return m_family; }
+
+    // The (family, radio) handle into the radio-scoped feature-document store
+    // (RFC #4603). Identity is the family's canonical serial (Flex serial /
+    // HL2 MAC); an unconnected model yields a family-wide scope.
+    RadioSettingsScope settingsScope() const
+    {
+        return RadioSettingsScope(m_family, serial());
+    }
     // True when the radio speaks the SmartSDR text-command plane — the only
     // family where sendCmd() reaches anything and a command has a response to
     // await. Every other backend takes typed intents through the IRadioBackend
@@ -1210,6 +1219,7 @@ private:
     // RadioConnection/PanadapterStream grabs) stays behind a dynamic_cast adapter
     // in the ctor, so a non-Flex backend simply skips it.
     static std::unique_ptr<IRadioBackend> makeBackend(const QString& family);
+    void handRestoredStateToBackend(const QString& serial);  // RFC #4603
 
     // aetherd Gap B: build/destroy the backend for a radio family. The backend
     // follows the radio the operator picks in the connection manager, so these

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -146,6 +146,13 @@ int main(int argc, char** argv)
         // the base one is true — which is exactly why they cannot be merged.
         check(caps.hasRadioSideDsp && !caps.hasExtendedDsp,
               "hasRadioSideDsp and hasExtendedDsp are independent");
+        // RFC #4603: the Flex persists its own operating state — an EMPTY
+        // domain declaration is the load-bearing value here. If this ever
+        // becomes non-empty, RadioStateMemory would start re-asserting
+        // radio-owned state on connect (the #2465/#4126/#4261 bug class).
+        check(caps.clientSettingsDomains
+                  == RadioCapabilities::ClientSettingsDomains{},
+              "Flex declares clientSettingsDomains EMPTY (radio-authoritative)");
     }
 
     // ---- HL2 declares none of them ---------------------------------------
@@ -175,6 +182,18 @@ int main(int argc, char** argv)
         // not the stack.
         check(!caps.hasSupplyVoltageTelemetry,
               "HL2 declares hasSupplyVoltageTelemetry=false (PATEMP, no +13.8A)");
+        // RFC #4603: the HL2 persists nothing on-radio — the client is its
+        // memory for exactly these declared domains (per-band drive/LNA maps
+        // ride the extension document, RFC PR 3).
+        using Domain = RadioCapabilities::ClientSettingsDomain;
+        check(caps.clientSettingsDomains.testFlag(Domain::Tuning)
+                  && caps.clientSettingsDomains.testFlag(Domain::Passband)
+                  && caps.clientSettingsDomains.testFlag(Domain::SpanRate)
+                  && caps.clientSettingsDomains.testFlag(Domain::RfGain)
+                  && caps.clientSettingsDomains.testFlag(Domain::TxSetpoints),
+              "HL2 declares the five client-owned settings domains");
+        check(!caps.clientSettingsDomains.testFlag(Domain::Memories),
+              "HL2 does not declare Memories (the #4590 bank folds in later)");
     }
 
     // ---- Sim declares none of them, and is genuinely CONNECTED -----------
@@ -216,6 +235,10 @@ int main(int argc, char** argv)
         check(!caps.hasGpsLocation, "Sim declares hasGpsLocation=false");
         check(!caps.hasSupplyVoltageTelemetry,
               "Sim declares hasSupplyVoltageTelemetry=false");
+        check(caps.clientSettingsDomains
+                  == RadioCapabilities::ClientSettingsDomains{},
+              "Sim declares clientSettingsDomains EMPTY (synthetic scene "
+              "regenerates; nothing to remember)");
 
         // The surfaces the GUI drives off those flags, evaluated the way the
         // GUI evaluates them. A CONNECTED radio that says no means hidden.

--- a/tests/radio_state_memory_test.cpp
+++ b/tests/radio_state_memory_test.cpp
@@ -13,6 +13,8 @@
 #include "core/AppSettings.h"
 #include "core/RadioSettingsScope.h"
 #include "core/RadioStateMemory.h"
+#include "core/SettingsDatabase.h"
+#include "core/SettingsPaths.h"
 
 #include <QCoreApplication>
 #include <QJsonObject>
@@ -53,8 +55,15 @@ RestoredRadioState sampleState()
     state.filterHighHz = 2'900.0;
     state.sampleRateHz = 192'000;
     state.extensionSchemaVersion = 1;
-    state.extension = QJsonObject{{QStringLiteral("lnaDbByBand"),
-                                   QJsonObject{{QStringLiteral("40m"), 19}}}};
+    // The extension's top level is domain sub-objects (the per-domain gate);
+    // each sub-object's contents are backend-owned.
+    state.extension = QJsonObject{
+        {QStringLiteral("rfGain"),
+         QJsonObject{{QStringLiteral("lnaDbByBand"),
+                      QJsonObject{{QStringLiteral("40m"), 19}}}}},
+        {QStringLiteral("txSetpoints"),
+         QJsonObject{{QStringLiteral("driveByBand"),
+                      QJsonObject{{QStringLiteral("40m"), 42}}}}}};
     return state;
 }
 
@@ -106,12 +115,16 @@ int main(int argc, char** argv)
               "passband round-trips");
         check(restored.sampleRateHz == 192'000, "span/rate round-trips");
         check(restored.extensionSchemaVersion == 1
-                  && restored.extension.value(QStringLiteral("lnaDbByBand"))
+                  && restored.extension.value(QStringLiteral("rfGain"))
+                             .toObject()
+                             .value(QStringLiteral("lnaDbByBand"))
                              .toObject()
                              .value(QStringLiteral("40m"))
                              .toInt()
-                         == 19,
-              "the extension document round-trips opaquely");
+                         == 19
+                  && restored.extension
+                         .contains(QStringLiteral("txSetpoints")),
+              "the extension document round-trips (contents opaque)");
     }
 
     // ---- two radios of one family stay independent ------------------------
@@ -187,6 +200,78 @@ int main(int argc, char** argv)
         check(RadioStateMemory::load(futureRadio, caps).rfFrequencyHz
                   == 21'074'000.0,
               "known fields load from a newer-schema document");
+    }
+
+    // ---- the extension gate splits per domain (PR #4614 review) -----------
+    // The regression K5PTB specified: RfGain-only declaration, stored ext
+    // carrying both maps — TxSetpoints data must NOT come back.
+    {
+        RadioCapabilities rfGainOnly;
+        rfGainOnly.family = QStringLiteral("hl2");
+        rfGainOnly.clientSettingsDomains = Domain::RfGain;
+        const RestoredRadioState gated = RadioStateMemory::load(radioA, rfGainOnly);
+        check(gated.extension.contains(QStringLiteral("rfGain")),
+              "a declared ext domain's sub-object loads");
+        check(!gated.extension.contains(QStringLiteral("txSetpoints")),
+              "an undeclared ext domain's sub-object is NOT handed over");
+    }
+
+    // ---- store is read-only toward newer documents (PR #4614 review) ------
+    // The load→capture→store cycle against a v2 document must refuse, not
+    // truncate-and-downgrade.
+    {
+        const RadioCapabilities caps = hl2Caps();
+        const RadioSettingsScope newerRadio(QStringLiteral("hl2"),
+                                            QStringLiteral("FE:ED:FA:CE:00:02"));
+        QJsonObject future{{QStringLiteral("rfFrequencyHz"), 28'074'000.0},
+                           {QStringLiteral("v2Field"), QStringLiteral("keep")}};
+        check(newerRadio.setFeature(RadioStateMemory::featureName(),
+                                    RadioStateMemory::kSchemaVersion + 1, future),
+              "a newer-schema document is planted");
+        RestoredRadioState captured = RadioStateMemory::load(newerRadio, caps);
+        check(captured.rfFrequencyHz == 28'074'000.0,
+              "the newer document's known fields load");
+        captured.rfFrequencyHz = 28'500'000.0;
+        check(!RadioStateMemory::store(newerRadio, caps, captured),
+              "store REFUSES to overwrite a newer-schema document");
+        int storedVersion = 0;
+        const QJsonObject after =
+            newerRadio.feature(RadioStateMemory::featureName(), &storedVersion);
+        check(storedVersion == RadioStateMemory::kSchemaVersion + 1
+                  && after.value(QStringLiteral("v2Field")).toString()
+                         == QStringLiteral("keep")
+                  && after.value(QStringLiteral("rfFrequencyHz")).toDouble()
+                         == 28'074'000.0,
+              "the newer document survives byte-for-byte — no truncation, no "
+              "version downgrade");
+    }
+
+    // ---- a corrupt document is loud, and falls back (PR #4614 review) -----
+    {
+        auto& s = AppSettings::instance();
+        check(s.setRadioFeature(QStringLiteral("hl2"), QString(),
+                                QStringLiteral("CorruptProbe"), 1,
+                                QJsonObject{{QStringLiteral("fromFamily"), true}}),
+              "family-wide fallback document for the corrupt case stores");
+        // Plant a genuinely corrupt EXACT row underneath the API: the raw
+        // row writer stores any string, simulating on-disk damage.
+        {
+            SettingsDatabase raw;
+            check(raw.open(SettingsPaths::databasePath()),
+                  "a raw handle opens the store");
+            check(raw.upsertRadioFeature(QStringLiteral("hl2"),
+                                         QStringLiteral("CO:RR:UP:TE:D0:01"),
+                                         QStringLiteral("CorruptProbe"), 1,
+                                         QStringLiteral("{not json")),
+                  "a corrupt exact row is planted");
+            raw.close();
+        }
+        const QJsonObject viaFallback = s.radioFeature(
+            QStringLiteral("hl2"), QStringLiteral("CO:RR:UP:TE:D0:01"),
+            QStringLiteral("CorruptProbe"));
+        check(viaFallback.value(QStringLiteral("fromFamily")).toBool(),
+              "a corrupt exact row is logged and falls back to the family "
+              "document instead of reading as 'nothing stored'");
     }
 
     // ---- persistence survives a fresh load --------------------------------

--- a/tests/radio_state_memory_test.cpp
+++ b/tests/radio_state_memory_test.cpp
@@ -246,6 +246,31 @@ int main(int argc, char** argv)
               "version downgrade");
     }
 
+    // ---- a newer FAMILY-WIDE row never blocks per-radio capture -----------
+    // (PR #4614 re-review, Ozy311): the store guard must judge the exact row
+    // it replaces — the fallback would let a newer family-wide default refuse
+    // every per-radio capture in the family.
+    {
+        const RadioCapabilities caps = hl2Caps();
+        const RadioSettingsScope familyWide(QStringLiteral("hl2"), QString());
+        QJsonObject newerFamilyDoc{{QStringLiteral("rfFrequencyHz"), 1'840'000.0}};
+        check(familyWide.setFeature(RadioStateMemory::featureName(),
+                                    RadioStateMemory::kSchemaVersion + 1,
+                                    newerFamilyDoc),
+              "a newer-schema FAMILY-WIDE document is planted");
+        const RadioSettingsScope freshRadio(QStringLiteral("hl2"),
+                                            QStringLiteral("DE:AD:BE:EF:00:03"));
+        RestoredRadioState state = sampleState();
+        check(RadioStateMemory::store(freshRadio, caps, state),
+              "a per-radio capture still succeeds under a newer family row");
+        check(RadioStateMemory::load(freshRadio, caps).rfFrequencyHz
+                  == 7'074'000.0,
+              "the per-radio document was really written");
+        // Clean up the newer family row so later cases keep their semantics.
+        check(familyWide.removeFeature(RadioStateMemory::featureName()),
+              "the planted family row is removed again");
+    }
+
     // ---- a corrupt document is loud, and falls back (PR #4614 review) -----
     {
         auto& s = AppSettings::instance();

--- a/tests/radio_state_memory_test.cpp
+++ b/tests/radio_state_memory_test.cpp
@@ -1,0 +1,202 @@
+// RadioStateMemory + the radio-scoped feature-document store (RFC #4603 PR 2).
+//
+// The invariants under test:
+//  - engagement is capability-shaped: empty ClientSettingsDomains ⇒ inert
+//    (nothing stored, nothing loaded — the Flex/Sim guarantee)
+//  - the operating-state document round-trips, atomically, per (family, radio)
+//  - load is gated per DECLARED domain, so a capability downgrade cannot
+//    smuggle state past the gate even when an older document carries it
+//  - reads fall back exact-radio → family-wide → empty
+//  - two radios of the same family never share state
+//  - a newer document schema still yields its known fields
+#include "TestSettingsProfile.h"
+#include "core/AppSettings.h"
+#include "core/RadioSettingsScope.h"
+#include "core/RadioStateMemory.h"
+
+#include <QCoreApplication>
+#include <QJsonObject>
+
+#include <iostream>
+
+using namespace AetherSDR;
+using Domain = RadioCapabilities::ClientSettingsDomain;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* label)
+{
+    std::cout << (condition ? "[ OK ] " : "[FAIL] ") << label << '\n';
+    if (!condition) {
+        ++g_failures;
+    }
+}
+
+RadioCapabilities hl2Caps()
+{
+    RadioCapabilities caps;
+    caps.family = QStringLiteral("hl2");
+    caps.clientSettingsDomains = Domain::Tuning | Domain::Passband
+                                 | Domain::SpanRate | Domain::RfGain
+                                 | Domain::TxSetpoints;
+    return caps;
+}
+
+RestoredRadioState sampleState()
+{
+    RestoredRadioState state;
+    state.rfFrequencyHz = 7'074'000.0;
+    state.mode = QStringLiteral("USB");
+    state.filterLowHz = 100.0;
+    state.filterHighHz = 2'900.0;
+    state.sampleRateHz = 192'000;
+    state.extensionSchemaVersion = 1;
+    state.extension = QJsonObject{{QStringLiteral("lnaDbByBand"),
+                                   QJsonObject{{QStringLiteral("40m"), 19}}}};
+    return state;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile profile(QStringLiteral("aether-radio-state-memory-test"));
+    if (!profile.isValid()) {
+        std::cerr << "[FAIL] create temporary home\n";
+        return 1;
+    }
+    QCoreApplication app(argc, argv);
+
+    auto& settings = AppSettings::instance();
+    settings.load();
+
+    const RadioSettingsScope radioA(QStringLiteral("hl2"),
+                                    QStringLiteral("AA:BB:CC:DD:EE:FF"));
+    const RadioSettingsScope radioB(QStringLiteral("hl2"),
+                                    QStringLiteral("AA:BB:CC:DD:EE:00"));
+
+    // ---- inert for an empty declaration (the Flex/Sim guarantee) ----------
+    {
+        RadioCapabilities flexLike;
+        flexLike.family = QStringLiteral("flex");
+        check(!RadioStateMemory::shouldEngage(flexLike),
+              "empty domain declaration does not engage");
+        check(!RadioStateMemory::store(radioA, flexLike, sampleState()),
+              "store with an empty declaration writes nothing");
+        check(RadioStateMemory::load(radioA, flexLike).isEmpty(),
+              "load with an empty declaration restores nothing");
+        check(radioA.feature(RadioStateMemory::featureName()).isEmpty(),
+              "no document exists after the inert store");
+    }
+
+    // ---- round-trip per radio --------------------------------------------
+    {
+        const RadioCapabilities caps = hl2Caps();
+        check(RadioStateMemory::shouldEngage(caps), "declared domains engage");
+        check(RadioStateMemory::store(radioA, caps, sampleState()),
+              "store succeeds for a declared backend");
+
+        const RestoredRadioState restored = RadioStateMemory::load(radioA, caps);
+        check(restored.rfFrequencyHz == 7'074'000.0
+                  && restored.mode == QStringLiteral("USB"),
+              "tuning round-trips");
+        check(restored.filterLowHz == 100.0 && restored.filterHighHz == 2'900.0,
+              "passband round-trips");
+        check(restored.sampleRateHz == 192'000, "span/rate round-trips");
+        check(restored.extensionSchemaVersion == 1
+                  && restored.extension.value(QStringLiteral("lnaDbByBand"))
+                             .toObject()
+                             .value(QStringLiteral("40m"))
+                             .toInt()
+                         == 19,
+              "the extension document round-trips opaquely");
+    }
+
+    // ---- two radios of one family stay independent ------------------------
+    {
+        const RadioCapabilities caps = hl2Caps();
+        RestoredRadioState other = sampleState();
+        other.rfFrequencyHz = 14'074'000.0;
+        check(RadioStateMemory::store(radioB, caps, other),
+              "second radio stores its own document");
+        check(RadioStateMemory::load(radioA, caps).rfFrequencyHz == 7'074'000.0,
+              "radio A keeps its own frequency");
+        check(RadioStateMemory::load(radioB, caps).rfFrequencyHz == 14'074'000.0,
+              "radio B keeps its own frequency");
+    }
+
+    // ---- per-domain gating on load ----------------------------------------
+    {
+        RadioCapabilities tuningOnly;
+        tuningOnly.family = QStringLiteral("hl2");
+        tuningOnly.clientSettingsDomains = Domain::Tuning;
+        const RestoredRadioState gated = RadioStateMemory::load(radioA, tuningOnly);
+        check(gated.rfFrequencyHz == 7'074'000.0 && gated.mode == "USB",
+              "a declared domain loads");
+        check(gated.filterLowHz == 0.0 && gated.filterHighHz == 0.0
+                  && gated.sampleRateHz == 0 && gated.extension.isEmpty(),
+              "undeclared domains stay 'not restored' even though the stored "
+              "document carries them");
+    }
+
+    // ---- per-domain gating on store ---------------------------------------
+    {
+        RadioCapabilities tuningOnly;
+        tuningOnly.family = QStringLiteral("hl2");
+        tuningOnly.clientSettingsDomains = Domain::Tuning;
+        RestoredRadioState state = sampleState();
+        check(RadioStateMemory::store(radioB, tuningOnly, state),
+              "tuning-only store succeeds");
+        const RestoredRadioState back = RadioStateMemory::load(radioB, hl2Caps());
+        check(back.rfFrequencyHz == 7'074'000.0 && back.sampleRateHz == 0
+                  && back.extension.isEmpty(),
+              "an undeclared domain is never written, so a later full "
+              "declaration finds nothing to restore for it");
+    }
+
+    // ---- family-wide fallback ---------------------------------------------
+    {
+        const RadioCapabilities caps = hl2Caps();
+        const RadioSettingsScope familyWide(QStringLiteral("hl2"), QString());
+        RestoredRadioState familyDefault = sampleState();
+        familyDefault.rfFrequencyHz = 10'000'000.0;
+        check(RadioStateMemory::store(familyWide, caps, familyDefault),
+              "family-wide default document stores");
+        const RadioSettingsScope unseenRadio(QStringLiteral("hl2"),
+                                             QStringLiteral("11:22:33:44:55:66"));
+        check(RadioStateMemory::load(unseenRadio, caps).rfFrequencyHz
+                  == 10'000'000.0,
+              "an unseen radio falls back to the family-wide default");
+        check(RadioStateMemory::load(radioA, caps).rfFrequencyHz == 7'074'000.0,
+              "a radio with its own document is NOT shadowed by the family row");
+    }
+
+    // ---- newer document schema still yields known fields -------------------
+    {
+        const RadioCapabilities caps = hl2Caps();
+        QJsonObject future{{QStringLiteral("rfFrequencyHz"), 21'074'000.0},
+                           {QStringLiteral("mode"), QStringLiteral("DIGU")},
+                           {QStringLiteral("fieldFromTheFuture"), true}};
+        const RadioSettingsScope futureRadio(QStringLiteral("hl2"),
+                                             QStringLiteral("FE:ED:FA:CE:00:01"));
+        check(futureRadio.setFeature(RadioStateMemory::featureName(),
+                                     RadioStateMemory::kSchemaVersion + 1, future),
+              "a newer-schema document can be planted");
+        check(RadioStateMemory::load(futureRadio, caps).rfFrequencyHz
+                  == 21'074'000.0,
+              "known fields load from a newer-schema document");
+    }
+
+    // ---- persistence survives a fresh load --------------------------------
+    {
+        settings.reset();
+        settings.load();
+        check(RadioStateMemory::load(radioA, hl2Caps()).rfFrequencyHz
+                  == 7'074'000.0,
+              "operating state survives a store reload");
+    }
+
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
PR 2 of the approved settings-store RFC (#4603): the scoped feature-document store + per-domain settings authority. **Stacked on #4612** (base branch is `feat/settings-sqlite`; do not merge before it — this PR retargets to `main` and rebases once #4612 lands).

## What this does

**The `radio_settings` scope goes live.** `AppSettings` gains an atomic whole-document API — `radioFeature()` / `setRadioFeature()` / `removeRadioFeature()` — one versioned JSON document per (family, radio, feature), per Constitution Principle V: one feature-owned object, one owner, one migration point. Reads fall back exact-radio → family-wide (`radio_id=''`) → empty. Writes are single-transaction whole-document replacements (the atomic feature update from rfoust's RFC review). Exposed through a `RadioSettingsScope` handle that `RadioModel::settingsScope()` mints from the connected radio's canonical identity (Flex serial / HL2 MAC / Kiwi UUID), so "which radio does this state belong to" is decided in exactly one place.

**Authority is a typed per-domain capability** (RFC proposal B): `RadioCapabilities::ClientSettingsDomains` — `Tuning | Passband | SpanRate | RfGain | TxSetpoints | Memories` — with **empty as the load-bearing default**: a backend that declares nothing gets nothing restored.

- **Flex declares explicitly empty** — the radio persists its own state; the client must never re-assert it (Constitution II/III, the #2465/#4126/#4261 bug class). The gating test asserts the empty declaration, so an accidental future non-empty Flex declaration fails CI.
- **HL2 declares the five operating domains** ("the radio reports no VFO, so the app is authoritative and must push").
- **Sim declares explicitly empty** (a synthetic scene regenerates; nothing to remember).

**The restore contract is typed at the seam** (RFC proposal B, rfoust's "no compiler-blind schema above the seam"): `RestoredRadioState` carries the universal fields plus an opaque per-family extension document that only the owning backend writes and validates (Principle VII) — the per-band drive/LNA maps from nigelfenton's review ride there in PR 3. `IRadioBackend::applyRestoredState()` is a default no-op; `RadioModel::handRestoredStateToBackend()` hands state over immediately before `connectRadio()`, gated solely by `RadioStateMemory::shouldEngage(caps)` — capability-shaped, never a family-name check.

**`RadioStateMemory`** (libaethercore) is the single reader/writer of the `OperatingState` document: per-domain filtering on **both** load and store (a capability downgrade cannot smuggle state past the gate; an undeclared domain is never even written), schema-versioned with additive tolerance for newer documents. The live capture wiring (model deltas → debounced store) and the HL2 restore application land in PR 3.

## Deliberately NOT in this PR

- No behavior change for any radio: nothing writes the `OperatingState` document yet, and `applyRestoredState` has no non-trivial implementor. This PR is the seam + store + authority declarations, fully tested at that layer.
- Per-band drive/LNA maps, HL2 capture/restore, `RadioConnectRequest::params` population → PR 3 (hardware validation on nigelfenton's HL2 + Radioberry bench).
- The `Memories` domain is declared in the enum but consumed only when the #4590 bank folds in (PR 6).

## Testing

- New `tests/radio_state_memory_test.cpp` — 9 assertions: inert-when-empty (the Flex guarantee: nothing stored, nothing loaded, no document created), full round-trip, two-radio isolation, per-domain gating on load and store, family-wide fallback with per-radio override, newer-schema document tolerance, reload survival.
- `radio_capability_gating_test` extended: all three backends' domain declarations asserted (Flex/Sim empty as a #4261-class regression guard, HL2's five, Memories explicitly not yet).
- Capabilities map updated — including back-filling the `persistsMemories` row that #4590 missed.
- Full suite green on top of the rebased #4612 head (incl. its 16 safety scenarios); engine-boundary `--strict` clean.

## Reviewer notes

- Reviewable surface: `RadioCapabilities.h`, `RestoredRadioState.h`, `RadioStateMemory.{h,cpp}`, `RadioSettingsScope.h`, the `AppSettings`/`SettingsDatabase` feature-document additions, the three backend declarations, and the `RadioModel` hook.
- @nigelfenton — your three-box matrix offer applies here too; nothing platform-conditional in this layer, but the `radio_state_memory_test` is the one worth running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
