### PR TITLE
fix(clock): feed AetherClock from per-slice audio on backends without DAX

### DIFF
--- a/src/core/AetherClockEngine.cpp
+++ b/src/core/AetherClockEngine.cpp
@@ -110,6 +110,7 @@ struct AetherClockEngine::Impl {
     // with DaxConsumer::Clock; the engine drives these with the bound channel.
     std::function<void(int)> acquireCh;
     std::function<void(int)> releaseCh;
+    std::function<bool()> daxAvailable;               // unset = assume DAX
 
     QPointer<SliceModel> slice;
     std::unique_ptr<IDecoder> decoder;
@@ -153,6 +154,8 @@ struct AetherClockEngine::Impl {
     bool haveFrame = false;
 
     std::vector<float> monoScratch;
+
+    void ingest(const QByteArray& pcm);
 
     QMetaObject::Connection connDax;
     QMetaObject::Connection connDestroyed;
@@ -307,6 +310,11 @@ void AetherClockEngine::setDaxChannelProvider(std::function<void(int)> acquire,
     m_impl->releaseCh = std::move(release);
 }
 
+void AetherClockEngine::setDaxAvailabilityProvider(
+    std::function<bool()> hasDaxStreams) {
+    m_impl->daxAvailable = std::move(hasDaxStreams);
+}
+
 void AetherClockEngine::setHostClock(std::function<qint64()> nowUtcMs) {
     if (nowUtcMs)
         m_impl->nowUtcMs = std::move(nowUtcMs);
@@ -413,6 +421,11 @@ void AetherClockEngine::start(SliceModel* slice, ClockStation station) {
     } else if (ch >= 1 && ch <= 4) {
         d.heldChannel = ch;
         d.acquireCh(ch);
+    } else if (d.daxAvailable && !d.daxAvailable()) {
+        // Seam-native backend: the radio declares no DAX plane, so there is no
+        // channel to assign and nothing to hold. Audio arrives through
+        // feedRxSliceAudio() instead. Warning here would be true-sounding and
+        // wrong, and would send the reader debugging the wrong subsystem.
     } else {
         qWarning() << "AetherClockEngine::start: slice" << slice->sliceId()
                    << "has no DAX channel assigned - audio will not flow";
@@ -499,11 +512,11 @@ void AetherClockEngine::applyStationPreset(SliceModel* slice, ClockStation stati
         slice->setAgcMode(QStringLiteral("off"));
 }
 
-void AetherClockEngine::feedRxAudio(int channel, const QByteArray& pcm) {
-    auto& d = *m_impl;
-    if (!d.running || !d.decoder || !d.slice) return;
-    if (channel != d.slice->daxChannel()) return;  // live channel filter
-
+// Shared PCM tail for both ingest slots. The two public slots are a filter
+// each - channel-keyed for DAX, slice-keyed for the seam - and the DSP body
+// exists exactly once here.
+void AetherClockEngine::Impl::ingest(const QByteArray& pcm) {
+    auto& d = *this;
     // Payload contract (shared with the Bridge/Tci/Rade DAX consumers):
     // float32 interleaved stereo, native-endian, 24 kHz, 8 bytes per frame,
     // 4-byte-aligned buffer. A trailing partial frame is deliberately floored
@@ -523,6 +536,22 @@ void AetherClockEngine::feedRxAudio(int channel, const QByteArray& pcm) {
     d.anchorSamples = d.decoder->samplesConsumed() + static_cast<std::int64_t>(n);
     d.anchorHostMs = d.nowUtcMs();
     d.decoder->process(d.monoScratch.data(), n);
+}
+
+void AetherClockEngine::feedRxAudio(int channel, const QByteArray& pcm) {
+    auto& d = *m_impl;
+    if (!d.running || !d.decoder || !d.slice) return;
+    if (channel != d.slice->daxChannel()) return;  // live channel filter
+    d.ingest(pcm);
+}
+
+void AetherClockEngine::feedRxSliceAudio(int sliceId, const QByteArray& pcm) {
+    auto& d = *m_impl;
+    if (!d.running || !d.decoder || !d.slice) return;
+    // Live slice filter. Deliberately NOT a daxChannel() compare: the sender
+    // already identified the slice, and a seam backend's daxChannel() is 0.
+    if (sliceId != d.slice->sliceId()) return;
+    d.ingest(pcm);
 }
 
 // ---- Station preset statics ----

--- a/src/core/AetherClockEngine.h
+++ b/src/core/AetherClockEngine.h
@@ -62,6 +62,14 @@ public:
     void setDaxChannelProvider(std::function<void(int)> acquire,
                                std::function<void(int)> release);
 
+    // Radio DAX-availability hook — reports whether the connected radio
+    // exposes a DAX plane at all (RadioCapabilities::hasDaxStreams, routed in
+    // by the wiring layer). A backend that demodulates in-process has none and
+    // drives feedRxSliceAudio() instead, so start() must not warn there about
+    // an unassigned DAX channel. Unset defaults to "DAX exists", which keeps
+    // the Flex path and existing callers byte-unchanged.
+    void setDaxAvailabilityProvider(std::function<bool()> hasDaxStreams);
+
     // Host-clock READ hook (UTC ms since epoch). Defaults to
     // QDateTime::currentMSecsSinceEpoch. Tests inject a fake clock. The
     // engine never writes the OS clock.
@@ -114,6 +122,14 @@ public slots:
     // seam. Samples whose channel differs from the bound slice's live
     // daxChannel() are ignored.
     void feedRxAudio(int channel, const QByteArray& pcm);
+
+    // Per-slice PCM ingest — the seam-native counterpart of feedRxAudio(),
+    // with the identical payload contract (float32 interleaved stereo,
+    // native-endian, 24 kHz). For backends that demodulate in-process and so
+    // have no DAX channel to key on: the sender names the slice directly, so
+    // this filters on the bound slice id and carries no channel semantics.
+    // Payload for any other slice is ignored.
+    void feedRxSliceAudio(int sliceId, const QByteArray& pcm);
 
 signals:
     void runningChanged(bool running);

--- a/src/gui/AetherClockApplet.cpp
+++ b/src/gui/AetherClockApplet.cpp
@@ -1170,7 +1170,10 @@ void AetherClockApplet::refreshDaxUi()
 
     // A running bound slice with no DAX channel is the no-audio condition that
     // drives the warning banner.
-    const bool noDaxWhileRunning = running && bound && bound->daxChannel() == 0;
+    // Gated on the DAX surface being applicable at all: on a seam-native radio
+    // a zero daxChannel() is the normal, correct state and audio is flowing.
+    const bool noDaxWhileRunning =
+        m_daxControlsVisible && running && bound && bound->daxChannel() == 0;
 
     // Warning banner toggles height, so re-run the geometry path (mirroring
     // setSettingsExpanded) only when its visibility actually flips.
@@ -1182,6 +1185,17 @@ void AetherClockApplet::refreshDaxUi()
         if (auto* p = parentWidget())
             p->updateGeometry();
     }
+}
+
+void AetherClockApplet::setDaxControlsVisible(bool visible)
+{
+    if (m_daxControlsVisible == visible) return;
+    m_daxControlsVisible = visible;
+    if (m_daxCombo) m_daxCombo->setVisible(visible);
+    // The banner is owned by refreshDaxUi() (it re-runs the geometry path when
+    // visibility flips), so re-run that rather than setting it here — a direct
+    // setVisible() would be overwritten on the next refresh.
+    refreshDaxUi();
 }
 
 void AetherClockApplet::updateDecodeAnchor()

--- a/src/gui/AetherClockApplet.h
+++ b/src/gui/AetherClockApplet.h
@@ -49,6 +49,13 @@ public:
 
     ClockAlignmentWidget* alignmentWidget() const { return m_scope; }
 
+    // DAX-surface gate, driven by AppletPanel::setDaxStreamsVisible (i.e. by
+    // RadioCapabilities::hasDaxStreams). On a radio with no DAX plane the
+    // chooser cannot do anything and the amber "no DAX channel" banner names
+    // a cause that is not the cause — while audio flows fine over the
+    // seam-native feed. Hiding both is what makes the applet honest there.
+    void setDaxControlsVisible(bool visible);
+
 public slots:
     // AppletPanel::setSlice forwarding (per-applet, explicit).
     void setSlice(SliceModel* slice);
@@ -116,6 +123,7 @@ private:
     QPushButton* m_drawerToggle{nullptr};
     GuardedComboBox* m_presetCombo{nullptr};
     GuardedComboBox* m_daxCombo{nullptr};  // DAX chooser for the selected slice
+    bool m_daxControlsVisible{true};       // false = radio declares no DAX plane
     QPushButton* m_tuneButton{nullptr};
     QPushButton* m_startStopButton{nullptr};
     QLabel* m_presetNote{nullptr};  // per-preset dial note (+ WWVB AGC note)

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -1475,6 +1475,12 @@ void AppletPanel::setDaxStreamsVisible(bool visible)
                               QStringLiteral("Applet_DAX"), visible);
     applyCapabilityVisibility(QStringLiteral("IQ"),
                               QStringLiteral("Applet_IQ"), visible);
+    // The AetherClock applet is NOT a DAX tile — it stays visible on every
+    // radio — but its DAX chooser and no-DAX banner are the same capability.
+    // Forwarded directly rather than through applyCapabilityVisibility, which
+    // persists an Applet_* preference and hides a whole tile.
+    if (m_aetherClockApplet)
+        m_aetherClockApplet->setDaxControlsVisible(visible);
 }
 
 void AppletPanel::setHardwareEqVisible(bool visible)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1477,6 +1477,7 @@ private:
     AetherClockEngine* m_clockEngine{nullptr};
     AetherClockModel* m_clockModel{nullptr};
     QMetaObject::Connection m_clockDaxConn;  // daxAudioReady feed — live only while the engine runs
+    QMetaObject::Connection m_clockSliceAudioConn;  // seam per-slice audio feed — same lifetime
     void setupAetherClock();
 
 #ifdef HAVE_RADE

--- a/src/gui/MainWindow_AetherClock.cpp
+++ b/src/gui/MainWindow_AetherClock.cpp
@@ -17,7 +17,8 @@
 // while started, which requires a live slice and therefore a live backend),
 // and the daxAudioReady feed is connected on runningChanged(true) and torn
 // down on runningChanged(false). The engine itself ignores PCM whose
-// channel differs from the bound slice's live daxChannel().
+// channel differs from the bound slice's live daxChannel(), and PCM whose
+// slice id differs from the bound slice on the seam-native feed.
 
 #include "MainWindow.h"
 
@@ -48,6 +49,14 @@ void MainWindow::setupAetherClock()
                 ps->releaseDaxChannel(ch, PanadapterStream::DaxConsumer::Clock);
         });
 
+    // Whether this radio has a DAX plane at all. Resolved at call time for the
+    // same reason as the provider above — no backend exists at construction.
+    // Gates start()'s "no DAX channel assigned" warning, which is a correct
+    // diagnosis on a Flex and a misleading one on a backend that demodulates
+    // in-process and feeds feedRxSliceAudio() instead.
+    m_clockEngine->setDaxAvailabilityProvider(
+        [this] { return m_radioModel.hasDaxStreams(); });
+
     connect(m_clockEngine, &AetherClockEngine::runningChanged,
             this, [this](bool running) {
                 // The engine is the slice-binding authority; mirror it into
@@ -61,9 +70,29 @@ void MainWindow::setupAetherClock()
                             ps, &PanadapterStream::daxAudioReady,
                             m_clockEngine, &AetherClockEngine::feedRxAudio,
                             Qt::QueuedConnection);
-                } else if (m_clockDaxConn) {
-                    disconnect(m_clockDaxConn);
-                    m_clockDaxConn = {};
+                    // Seam-native per-slice audio (MainWindow_Session.cpp:1811
+                    // feeds TciServer from the same signal for the same
+                    // reason). A backend that demodulates in-process has no
+                    // PanadapterStream, so the connect above binds nothing and
+                    // the engine would never see a sample. A Flex never emits
+                    // this signal, so there is no double-feed and the Flex path
+                    // is unchanged; the engine's own slice filter does the rest.
+                    if (!m_clockSliceAudioConn)
+                        m_clockSliceAudioConn = connect(
+                            &m_radioModel,
+                            &RadioModel::backendSliceAudioFrameReady,
+                            m_clockEngine,
+                            &AetherClockEngine::feedRxSliceAudio,
+                            Qt::QueuedConnection);
+                } else {
+                    if (m_clockDaxConn) {
+                        disconnect(m_clockDaxConn);
+                        m_clockDaxConn = {};
+                    }
+                    if (m_clockSliceAudioConn) {
+                        disconnect(m_clockSliceAudioConn);
+                        m_clockSliceAudioConn = {};
+                    }
                 }
             });
 

--- a/tests/aetherclock_engine_test.cpp
+++ b/tests/aetherclock_engine_test.cpp
@@ -36,6 +36,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <functional>
 #include <utility>
 #include <vector>
 
@@ -217,9 +218,9 @@ qint64 synthEpochMs(const Truth& g, const SynthOpts& o) {
 // mono = 0.5*(L+R), recovering the original). When `advanceClock`, *fakeNow is
 // updated per block to model host = epoch + samplesFed/24 kHz + skew at the END
 // of the block (the anchor point). processEvents() drains any queued paths.
-void feedStereo(AetherClockEngine& eng, int channel, const std::vector<float>& mono,
-                qint64 epochMs, qint64 skewMs,
-                qint64& samplesFed, qint64& fakeNow, bool advanceClock) {
+void feedStereoVia(const std::function<void(const QByteArray&)>& sink,
+                   const std::vector<float>& mono, qint64 epochMs, qint64 skewMs,
+                   qint64& samplesFed, qint64& fakeNow, bool advanceClock) {
     constexpr size_t kBlockFrames = 4800;   // 200 ms @ 24 kHz
     for (size_t i = 0; i < mono.size(); i += kBlockFrames) {
         const size_t n = std::min(kBlockFrames, mono.size() - i);
@@ -233,9 +234,26 @@ void feedStereo(AetherClockEngine& eng, int channel, const std::vector<float>& m
         samplesFed += static_cast<qint64>(n);
         if (advanceClock)
             fakeNow = epochMs + samplesFed * 1000 / kFs + skewMs;
-        eng.feedRxAudio(channel, block);
+        sink(block);
         QCoreApplication::processEvents();
     }
+}
+
+// Channel-keyed feed (Flex / daxAudioReady).
+void feedStereo(AetherClockEngine& eng, int channel, const std::vector<float>& mono,
+                qint64 epochMs, qint64 skewMs,
+                qint64& samplesFed, qint64& fakeNow, bool advanceClock) {
+    feedStereoVia([&eng, channel](const QByteArray& b) { eng.feedRxAudio(channel, b); },
+                  mono, epochMs, skewMs, samplesFed, fakeNow, advanceClock);
+}
+
+// Slice-keyed feed (seam-native / backendSliceAudioFrameReady). Same payload
+// bytes, different slot — that parity is part of what these tests assert.
+void feedStereoSlice(AetherClockEngine& eng, int sliceId, const std::vector<float>& mono,
+                     qint64 epochMs, qint64 skewMs,
+                     qint64& samplesFed, qint64& fakeNow, bool advanceClock) {
+    feedStereoVia([&eng, sliceId](const QByteArray& b) { eng.feedRxSliceAudio(sliceId, b); },
+                  mono, epochMs, skewMs, samplesFed, fakeNow, advanceClock);
 }
 
 using Clock = PanadapterStream::DaxConsumer;   // ::Clock == time-signal consumer
@@ -658,6 +676,86 @@ void sectionDiagnosticsTelemetry() {
     CHECK(dStop.classifiedPct == 0);    // ring cleared
 }
 
+// [12] Seam-native per-slice ingest — the Hermes-Lite 2 shape: a bound slice
+// with NO DAX channel, on a radio that declares no DAX plane at all. Asserts
+// the sibling slot accepts the bound slice id and rejects any other, that a
+// dax==0 slice decodes fine through it, and that nothing is acquired on a
+// DAX registry that does not exist here.
+void sectionSeamSliceAudio() {
+    SynthOpts opts;
+    const std::vector<float> mono = synthWwv(kGold, opts);
+    const qint64 epochMs = synthEpochMs(kGold, opts);
+
+    PanadapterStream stream;
+    SliceModel slice(0);
+    CHECK(slice.daxChannel() == 0);        // HL2: none assigned, none ever will be
+
+    AetherClockEngine engine;
+    wireProvider(engine, stream);
+    engine.setDaxAvailabilityProvider([] { return false; });   // no DAX plane
+    qint64 fakeNow = epochMs + kSkewMs;
+    engine.setHostClock([&fakeNow] { return fakeNow; });
+
+    QSignalSpy spyAlign(&engine, &AetherClockEngine::alignmentFrame);
+    QSignalSpy spyTime(&engine, &AetherClockEngine::timeDecoded);
+
+    engine.start(&slice, ClockStation::Wwv);
+    CHECK(engine.isRunning());
+    for (int ch = 1; ch <= 4; ++ch)        // nothing held; there is nothing to hold
+        CHECK(!stream.daxChannelHeldBy(ch, Clock::Clock));
+
+    // Another slice's audio is ignored.
+    qint64 samplesFed = 0;
+    feedStereoSlice(engine, 1, mono, epochMs, kSkewMs, samplesFed, fakeNow, /*advance*/ true);
+    CHECK(spyAlign.isEmpty());
+    CHECK(spyTime.isEmpty());
+
+    // The bound slice decodes — on a slice whose daxChannel() is 0. The decoder
+    // consumed nothing above, so the fake clock rewinds with the feed.
+    samplesFed = 0;
+    fakeNow = epochMs + kSkewMs;
+    feedStereoSlice(engine, 0, mono, epochMs, kSkewMs, samplesFed, fakeNow, /*advance*/ true);
+    CHECK(!spyAlign.isEmpty());
+    CHECK(!spyTime.isEmpty());
+
+    engine.stop();
+}
+
+// [13] Flex regression guard for the channel-keyed slot. A Flex slice may sit
+// at daxChannel()==0 (unassigned) while the radio's DAX plane is very much
+// alive. Loosening the filter to `want != 0 && channel != want` — the tempting
+// way to make HL2 work without a sibling slot — would make THIS slice accept
+// every other slice's DAX audio, which is exactly what the filter exists to
+// prevent. Nothing may be accepted here.
+void sectionDaxZeroChannelStillFilters() {
+    SynthOpts opts;
+    const std::vector<float> mono = synthWwv(kGold, opts);
+    const qint64 epochMs = synthEpochMs(kGold, opts);
+
+    PanadapterStream stream;
+    SliceModel slice(0);
+    CHECK(slice.daxChannel() == 0);        // unassigned, on a DAX-capable radio
+
+    AetherClockEngine engine;
+    wireProvider(engine, stream);
+    engine.setDaxAvailabilityProvider([] { return true; });    // Flex: DAX exists
+    qint64 fakeNow = epochMs + kSkewMs;
+    engine.setHostClock([&fakeNow] { return fakeNow; });
+
+    QSignalSpy spyAlign(&engine, &AetherClockEngine::alignmentFrame);
+    QSignalSpy spyTime(&engine, &AetherClockEngine::timeDecoded);
+
+    engine.start(&slice, ClockStation::Wwv);
+    qint64 samplesFed = 0;
+    feedStereo(engine, 1, mono, epochMs, kSkewMs, samplesFed, fakeNow, /*advance*/ true);
+
+    CHECK(spyAlign.isEmpty());             // ch 1 MUST NOT reach a dax==0 slice
+    CHECK(spyTime.isEmpty());
+    CHECK(engine.lockState() == ClockLockState::NoSignal);
+
+    engine.stop();
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -680,6 +778,8 @@ int main(int argc, char** argv) {
     sectionLockDecayNoSignalStable();
     sectionLockDecayDemotes();
     sectionDiagnosticsTelemetry();
+    sectionSeamSliceAudio();
+    sectionDaxZeroChannelStillFilters();
 
     if (g_failures == 0) {
         std::printf("aetherclock_engine_test: all checks passed\n");


### PR DESCRIPTION
## Summary

AetherClock is silently dead on a Hermes-Lite 2. `setupAetherClock()` gates its audio connect on `m_radioModel.panStream()` (`MainWindow_AetherClock.cpp:59`), and a backend that demodulates in-process has no `PanadapterStream` at all — so the connect never happens, the engine starts, and no PCM ever arrives. The applet's amber *"Bound slice has no DAX channel — no audio"* is the closest thing to a diagnosis, and it names the wrong cause.

`TciServer` hit this exact bug one consumer earlier and it is already fixed: `MainWindow_Session.cpp:1811` feeds it from `RadioModel::backendSliceAudioFrameReady` (#4471, re-pointed at the per-slice signal in #4545). This applies that same shipped pattern to AetherClock.

- **`AetherClockEngine::feedRxSliceAudio(sliceId, pcm)`** — a sibling ingest slot with no channel semantics, because the wiring layer has already filtered by slice. The shared downmix/anchor/process tail moves into a private `Impl::ingest()` so the two slots are one filter each and the DSP body exists exactly once.
- **`start()` no longer warns** *"slice N has no DAX channel assigned"* on a radio that declares no DAX plane, where a zero channel is correct and audio is flowing. Gated on a new injected availability provider reading `RadioCapabilities::hasDaxStreams` — the concept flag, not a family-name test.
- **`MainWindow_AetherClock.cpp`** connects `backendSliceAudioFrameReady` directly to the new slot, torn down beside `m_clockDaxConn`. A Flex never emits that signal, so there is no double-feed and the Flex path is byte-unchanged — the same argument the comment at `MainWindow_Session.cpp:1808` makes.
- **`AppletPanel::setDaxStreamsVisible()`** forwards to a new `AetherClockApplet::setDaxControlsVisible()`, hiding the inert DAX chooser and suppressing the misleading banner where no DAX plane exists.

Closes the HL2 case of the same seam gap #4471/#4545 closed for TCI.

**Rebased onto `fae21429` (#4612, the SQLite settings-store swap)** and fully re-verified there — clean rebase, no conflicts, no file overlap. Re-verified rather than assumed because #4612 rewires `AppSettings` and `CMakeLists.txt` and vendors SQLite, and one of the files here (`AppletPanel.cpp`) is an `AppSettings` consumer; a clean textual merge does not prove it compiles.

## Constitution principle honored

**Principle II — the radio is authoritative on live state; the client mirrors it.** The amber *"no DAX channel"* banner and the DAX chooser are the client asserting a diagnosis the radio's own declared capabilities contradict: an HL2 reports `hasDaxStreams = false`, so a zero DAX channel is not a misconfiguration to warn about, it is the correct and only possible state. This routes both the warning and the UI surface back to the radio's self-description rather than to a model-name test, and the engine's new slot filters on the bound slice's live `sliceId()` rather than inventing a channel number for a plane that does not exist. Following #4597's precedent, the gate rides `RadioCapabilities::hasDaxStreams` — named for the concept, not the brand.

## Scope

- 8 files, +217 / −14 (4 source files, 3 headers, 1 test file)
- No protocol change, no persistence change, no new `AppSettings` keys
- UX change is subtractive and capability-gated: on a radio declaring `hasDaxStreams`, every surface is byte-identical

## Deliberately not done

**Loosening the channel filter to `if (want != 0 && channel != want)`.** That is the tempting one-line way to make HL2 work without a sibling slot, and it is a real regression: a *Flex* slice sitting at `dax=0` would then accept every other slice's DAX audio, which is precisely what the filter exists to prevent. `tests/aetherclock_engine_test.cpp` covers it as a positive control — with that shortcut injected, the new `sectionDaxZeroChannelStillFilters` fails on all three assertions; reverted, the suite passes.

Also rejected: having the adapter pass `0` to the existing `feedRxAudio` (works only because both sides are coincidentally `0`, with nothing stating the invariant), and gating the applet on `hostModulates` (a brand-correlated proxy where `hasDaxStreams` is the actual concept).

## Alternative, costed — a per-slice bus (yours to call)

This is the **third** pseudo-DAX adapter; you wrote the other two and refined one in #4545. The larger alternative is to add the missing family-blind per-slice bus — `RadioModel::rxSliceDemodAudioReady` plus a `wireRxSliceDemodAudioBus()` twin of the existing `wireRxDemodAudioBus()` (`RadioModel.cpp:1783`) — relaying `backendSliceAudioFrameReady` on a seam backend and fanning `daxAudioReady` out per matching slice on a Flex. We costed that at **~150–200 lines across 4–5 files plus tests**, and it would retire the `sliceId + 1` adapter at `MainWindow_Session.cpp:1811` and give RADE the same seam, instead of adding a third workaround.

We did not take it because it needs a contract call that is yours, not ours: Flex channel→slice is not 1:1 (`SliceModel::m_daxChannel` defaults to `0` = unassigned and uniqueness is unenforced), and there is no channel→slice lookup anywhere in the tree today — every consumer goes the forward direction. Our reading is that it dissolves rather than blocks (two slices sharing a channel genuinely carry the same audio; `dax=0` never matches), but that is a bus-contract decision for you. **This PR does not block that work and B subsumes C cleanly** — happy to close this in favour of the bus if you'd rather take it now that a third consumer exists.

## Test plan

- [x] Local build clean on **Linux** (Nobara 43, Qt 6.10.3, gcc 15.2.1) — zero `error:` / `FAILED:`; rebuilt on the rebased base
- [x] Local build clean on **Windows / MSVC** (`wt.sh`, `WT-WIN-OK`, `windeployqt` verified) — rebuilt on the rebased base, so MSVC has compiled #4612's vendored `sqlite3.c` alongside this change
- [x] Local build clean on **macOS** (Apple Silicon, macOS 26.5.2) — zero `error:` / `FAILED:`; rebuilt on the rebased base
- [x] `ctest`: **206/207 passed, 1 skipped** on this branch, rebased onto `fae21429` (#4612). `cross_needle_meter_test` is the only failure, and it fails identically on an unmodified upstream tree (verified at `e8a4e950`; tracked as upstream #4559) — pre-existing, not from this change. Both `aetherclock_engine_test` and `aetherclock_model_test` pass
- [x] New engine tests: seam-native ingest accept/reject by slice id, plus the Flex regression positive control
- [x] Hardware, RX-only, on a real Hermes-Lite 2 and a FLEX-6700 — see below. **Includes a full WWV lock on the HL2** (operator's own session, this branch's build)

## Hardware verification (RX-only)

**Two separate claims — audio flowing is not the clock locking. Both now pass, but they were established independently and hours apart.**

**Claim 1 — audio flows on HL2: PASSED.** Baseline on `AetherSDR-current` @ `e8a4e950`, HL2, WWV 10 MHz (slice at 9.999 USB), engine running and bound to slice 0, observed for 60 s:

```
toneDetected=False  toneSnrDb=0  classifiedPct=0  framesInWindow=0  state=NoSignal   (flat, all four samples)
```

Same sequence on this branch:

```
t+10s   toneDetected=True   toneSnrDb=5.43  classifiedPct=6    state=Acquiring
t+70s   toneDetected=True   toneSnrDb=8.10  classifiedPct=100  state=Acquiring
t+250s  toneDetected=True   toneSnrDb=5.38  classifiedPct=93   state=Acquiring
```

Zero → 100% of seconds classified. The audio path is fixed.

**Claim 2 — the clock locks on HL2: PASSED**, later the same afternoon, on the operator's own GUI session running this branch's build.

My earlier headless runs did **not** lock — `anchored` stayed `false` and `framesInWindow` `0` across ~7 min on WWV 10 MHz and ~3 min on 15 MHz, at 5–9 dB tone SNR. Every second classified; marker frame-sync never anchored. I reported that as a null result rather than chase it. It turned out to be **reception, not the decoder** — mid-afternoon absorption on 10/15 MHz. Once conditions came up, the same build locked, read live off the bridge:

```
stateName      : Locked          anchored      : true
framesInWindow : 3               windowSize    : 8
lockQuality    : 64              voteQuality   : 0.637
decodedUtc     : 2026-07-30T23:27:59.000Z
offsetMs       : -62.7           delayEstMs    : 12.6
stationName    : WWV             toneSnrDb     : 9.31
```

The applet's five-stage funnel goes fully green — `Car 9dB` · `Tick` · `Frm :34` · `Dec 100%` · `Vote 3/8`, with the status line reading **"Locked — all stages green"**, station **WWV**, `q64 · 34s`, decoded `23:28:33`, offset `-0.06 s`. That is a real WWV decode on a Hermes-Lite 2, which was not previously possible at all — the engine never received a sample.

Worth keeping the earlier null in view: at 5–9 dB the decoder classifies every second and still won't anchor, so **marginal-SNR HL2 audio has a real acquisition floor**. That's a decoder-tuning question, not a plumbing one, and it's out of scope here.

**Flex no-regression A/B: PASSED.** FLEX-6700 on **RX A** (a mag-loop; the AV-640 is on the Hermes right now, so this leg is a plumbing check, not a sensitivity comparison). Identical setup, `-current` vs this branch:

| t | `-current` toneSnrDb | this branch |
|---|---|---|
| +12s | 1.34 | 1.53 |
| +42s | 0.71 | 0.78 |
| +72s | 0.63 | 0.61 |
| +102s | 0.43 | 0.59 |

Indistinguishable. Both `NoSignal`, both `classifiedPct=0`, both showing live varying noise — i.e. DAX audio reaching the engine on both, too weak on that antenna for tone detection. No regression.

**UI gate, via `dumpTree`:** on the HL2 `clockDaxCombo` goes visible → **hidden** (it was visible and inert before); on the FLEX-6700 it stays **visible**, so the gate does not over-fire.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no new settings at all (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` — no meter UI touched (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed — the behavior change is a dead control disappearing on radios that never supported it; no doc references it
- [ ] Security-sensitive changes reference a GHSA if applicable — n/a

---

73, Ozy **K6OZY**  · cost: $42.89 · model: claude-opus-5
