### PR TITLE
feat(hl2): per-MAC operating-state restore + per-band drive/LNA memory (RFC #4603, PR 3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4254,6 +4254,12 @@ add_test(NAME radio_capability_gating_test COMMAND radio_capability_gating_test)
 # RadioStateMemory + the radio-scoped feature-document store (RFC #4603 PR 2):
 # capability-shaped engagement (empty domains ⇒ inert), per-domain gating on
 # load AND store, per-radio isolation, family-wide fallback, schema tolerance.
+add_executable(radio_state_memory_test tests/radio_state_memory_test.cpp)
+target_include_directories(radio_state_memory_test PRIVATE src tests)
+target_link_libraries(radio_state_memory_test PRIVATE aethercore Qt6::Core Qt6::Test)
+set_target_properties(radio_state_memory_test PROPERTIES AUTOMOC ON)
+add_test(NAME radio_state_memory_test COMMAND radio_state_memory_test)
+
 # HL2 state restore/capture (RFC #4603 PR 3): band-key table, the
 # applyRestoredState validation boundary, restored-rate/LNA connect seeding,
 # param precedence, and the capture snapshot round-trip. Hardware-path
@@ -4263,12 +4269,6 @@ target_include_directories(hl2_state_restore_test PRIVATE src tests)
 target_link_libraries(hl2_state_restore_test PRIVATE aethercore Qt6::Core Qt6::Test)
 set_target_properties(hl2_state_restore_test PROPERTIES AUTOMOC ON)
 add_test(NAME hl2_state_restore_test COMMAND hl2_state_restore_test)
-
-add_executable(radio_state_memory_test tests/radio_state_memory_test.cpp)
-target_include_directories(radio_state_memory_test PRIVATE src tests)
-target_link_libraries(radio_state_memory_test PRIVATE aethercore Qt6::Core Qt6::Test)
-set_target_properties(radio_state_memory_test PROPERTIES AUTOMOC ON)
-add_test(NAME radio_state_memory_test COMMAND radio_state_memory_test)
 
 # TCI signaling on a backend with neither a Flex command plane nor a DAX data
 # plane (HL2) — the seam WSJT-X rides. Links WebSockets so the TciServer half of

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4254,6 +4254,16 @@ add_test(NAME radio_capability_gating_test COMMAND radio_capability_gating_test)
 # RadioStateMemory + the radio-scoped feature-document store (RFC #4603 PR 2):
 # capability-shaped engagement (empty domains ⇒ inert), per-domain gating on
 # load AND store, per-radio isolation, family-wide fallback, schema tolerance.
+# HL2 state restore/capture (RFC #4603 PR 3): band-key table, the
+# applyRestoredState validation boundary, restored-rate/LNA connect seeding,
+# param precedence, and the capture snapshot round-trip. Hardware-path
+# validation happens on nigelfenton's bench.
+add_executable(hl2_state_restore_test tests/hl2_state_restore_test.cpp)
+target_include_directories(hl2_state_restore_test PRIVATE src tests)
+target_link_libraries(hl2_state_restore_test PRIVATE aethercore Qt6::Core Qt6::Test)
+set_target_properties(hl2_state_restore_test PROPERTIES AUTOMOC ON)
+add_test(NAME hl2_state_restore_test COMMAND hl2_state_restore_test)
+
 add_executable(radio_state_memory_test tests/radio_state_memory_test.cpp)
 target_include_directories(radio_state_memory_test PRIVATE src tests)
 target_link_libraries(radio_state_memory_test PRIVATE aethercore Qt6::Core Qt6::Test)

--- a/docs/architecture/radio-capabilities-map.md
+++ b/docs/architecture/radio-capabilities-map.md
@@ -50,7 +50,7 @@ traps and why the DAX crash guard is deliberately *not* the DAX capability.
 | `hasMultiClientSessions` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | Settings ▸ multiFLEX… |
 | `hasSupplyVoltageTelemetry` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | PA supply-voltage readout in the status bar |
 | `persistsMemories` | ✅ | ❌ | ❌ | `LocalMemoryBank` engagement (#4590) | host-side memory bank vs radio-side slots |
-| `clientSettingsDomains` | empty | Tuning\|Passband\|SpanRate\|RfGain\|TxSetpoints | empty | `RadioStateMemory::shouldEngage` → `RadioModel::handRestoredStateToBackend` | DECLARED + gate wired only: `applyRestoredState` is a no-op in every backend until RFC #4603 PR 3 lands capture/restore — nothing restores today (this row would otherwise be the exact trap the header warns about) |
+| `clientSettingsDomains` | empty | Tuning\|Passband\|SpanRate\|RfGain\|TxSetpoints | empty | `RadioStateMemory::shouldEngage` → `RadioModel::handRestoredStateToBackend` | connect-time operating-state restore + debounced capture (RFC #4603 PR 3): `Hl2Backend::applyRestoredState` seeds rate/freq/LNA at connect, `pushInitialState` applies restored mode+passband (reconciled with #4484 — restored as a pair, so mode and passband cannot disagree) and the start band's drive; per-band LNA/drive maps ride the extension document and follow TX-slice band changes. Flex/Sim: no-op by empty declaration. |
 | `extensionNamespaces` | `["flex"]` | — | — | `invokeExtension` pre-check | Amp / tuner operate/bypass/autotune verbs |
 
 `MainWindow::applyCapabilitiesToUi()` is the single fan-out for UI visibility. It

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -97,6 +97,12 @@ public:
         Q_UNUSED(state);
     }
     virtual void connectRadio(const RadioConnectRequest& request) = 0;
+    // The capture half of RadioStateMemory (RFC #4603 PR 3): a backend whose
+    // declared clientSettingsDomains is non-empty reports its operating state
+    // here on demand, and emits operatingStateChanged() (see signals) when it
+    // moves. RadioModel debounces the signal and persists the snapshot via
+    // RadioStateMemory::store — the backend never touches the settings store.
+    virtual RestoredRadioState currentOperatingState() const { return {}; }
     virtual void disconnectRadio() = 0;
     virtual bool isConnected() const = 0;
 
@@ -497,6 +503,11 @@ signals:
     // range/step are family-specific and reported via RadioCapabilities). The
     // backend decodes it from vendor status; RadioModel drives the pan.
     void panRfGainChanged(const QString& panId, int gain);
+    // Operating state moved (frequency, mode, passband, rate, gain, drive) —
+    // fetch it with currentOperatingState(). Emitted only by backends with a
+    // non-empty clientSettingsDomains declaration; rate-limiting is the
+    // subscriber's job (RadioModel debounces).
+    void operatingStateChanged();
 
     // The RF-gain range and step this pan actually offers, in dB.
     //

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -1267,6 +1267,23 @@ void Hl2Backend::connectRadio(const RadioConnectRequest& request)
                              m_lnaDbByBand.value(m_currentBandKey, m_lnaDefaultDb),
                              kLnaGainMaxDb);
     }
+    // Seed the DRIVE from the start band's memory and echo it upward NOW —
+    // before linkUp — so TransmitModel carries the restored value when its
+    // connect-time push fires (PR #4619 bench, nigelfenton: the push arrived
+    // as apparent operator intent at the model default of 100 and overwrote
+    // the stored per-band drive on every reconnect; Ozy311 traced the same
+    // seam). With the model seeded, that push becomes a value-identical echo
+    // — which setTxPower() now recognizes and declines to record.
+    if (m_haveRestoredState) {
+        const int drive =
+            m_driveByBand.value(m_currentBandKey, m_driveDefaultPercent);
+        if (drive >= 0) {
+            m_rfPowerPercent = drive;
+            TransmitDelta delta;
+            delta.rfPower = drive;
+            emit transmitChanged(delta);
+        }
+    }
 
     // ---- how many receivers ----
     //
@@ -2360,12 +2377,18 @@ void Hl2Backend::setTxPower(int percent)
     // unkey can put this back. Recorded BEFORE the transmit gate and even while
     // tuning: a power change made mid-tune, or while TX is blocked, is still
     // what the operator wants once the carrier drops or the gate opens.
-    m_rfPowerPercent = percent < 0 ? 0 : (percent > 100 ? 100 : percent);
-    // OPERATOR intent only: when band-memory/restore code applies a drive
-    // through this same seam, it must neither claim the band nor set the
-    // baseline — otherwise the conservative first-visit 0 would become the
-    // "operator's" baseline (found by the unvisited-band pinning test).
-    if (!m_applyingBandMemory) {
+    const int clamped = percent < 0 ? 0 : (percent > 100 ? 100 : percent);
+    // OPERATOR intent only — and only on CHANGE: internal band-memory applies
+    // (m_applyingBandMemory) and value-identical echoes (RadioModel's
+    // connect-time power push re-asserting what we just seeded) must neither
+    // claim the band nor set the baseline. Without the change-gate, the
+    // connect push at the model default bootstrapped defaultPercent=100 and
+    // rewrote the start band's stored drive on every reconnect
+    // (PR #4619 bench + review).
+    const bool operatorChange = !m_applyingBandMemory
+                                && clamped != m_rfPowerPercent;
+    m_rfPowerPercent = clamped;
+    if (operatorChange) {
         // The operator's drive belongs to the band they set it on.
         if (!m_currentBandKey.isEmpty())
             m_driveByBand.insert(m_currentBandKey, m_rfPowerPercent);
@@ -2556,13 +2579,17 @@ void Hl2Backend::applyRestoredState(const RestoredRadioState& state)
     m_lnaGainDb = 20;
     m_driveDefaultPercent = -1;
     m_rfPowerPercent = 100;       // TransmitModel's session default
+    m_sampleRateHz = 48000;       // construction default — radio B must not
+                                  // inherit radio A's span (PR #4619 review)
     m_currentBandKey.clear();
 
     RestoredRadioState valid;
     if (state.rfFrequencyHz >= 100'000.0 && state.rfFrequencyHz <= 38'400'000.0)
         valid.rfFrequencyHz = state.rfFrequencyHz;
     if (isKnownModeString(state.mode))
-        valid.mode = state.mode;
+        valid.mode = state.mode.toUpper();   // canonical casing — a "cw" from a
+                                             // hand-edited document must not
+                                             // round-trip into the UI
     // A passband is kept only as a sane pair; mode+passband are applied
     // together in pushInitialState() (the #4484 reconciliation).
     if (state.filterLowHz < state.filterHighHz

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -155,6 +155,22 @@ WdspChannel::Mode modeFromString(const QString& mode) noexcept
     return WdspChannel::Mode::Usb;
 }
 
+// Is `mode` a name modeFromString() genuinely maps (rather than falling back
+// to USB)? The restore boundary uses this so a corrupt document's mode string
+// is dropped instead of reaching Receiver::mode, the UI, and — via capture —
+// re-persisting itself (PR #4619 review, Ozy311).
+bool isKnownModeString(const QString& mode) noexcept
+{
+    static const QStringList kKnown = {
+        QStringLiteral("LSB"), QStringLiteral("USB"), QStringLiteral("DSB"),
+        QStringLiteral("CWL"), QStringLiteral("CWU"), QStringLiteral("CW"),
+        QStringLiteral("FM"),  QStringLiteral("NFM"), QStringLiteral("AM"),
+        QStringLiteral("DIGU"), QStringLiteral("DIGL"), QStringLiteral("SAM"),
+        QStringLiteral("DRM"), QStringLiteral("WBFM"), QStringLiteral("WFM"),
+    };
+    return kKnown.contains(mode.toUpper());
+}
+
 // Default RX passband per mode, in Hz relative to the carrier. Sign carries the
 // sideband, matching SliceModel's convention (USB-family positive, LSB-family
 // negative, carrier-straddling modes symmetric) -- a table with the wrong sign
@@ -1824,6 +1840,11 @@ void Hl2Backend::setTxSlice(int sliceId)
     // old receiver's frequency would key on the wrong band with nothing to say
     // so — the exact failure §14 records from the first bring-up.
     setTxFrequency(r->sliceFreqHz);
+    // Band memory follows TRANSMIT (PR #4619 review, Ozy311 finding 2):
+    // moving TX from a 40 m receiver to a 20 m receiver must apply 20 m's
+    // remembered drive/LNA and re-key later edits — the band key belongs to
+    // the transmit-owning slice, not to whichever slice tuned last.
+    applyPerBandStateFor(r->sliceFreqHz, "tx slice move");
     if (m_txDsp) {
         QMetaObject::invokeMethod(m_txDsp, "setMode", Qt::QueuedConnection,
             Q_ARG(WdspChannel::Mode, modeFromString(r->mode)));
@@ -1926,27 +1947,8 @@ void Hl2Backend::setPanRfGain(const QString& panId, int gainDb)
     const int clamped = qBound(kLnaGainMinDb, gainDb, kLnaGainMaxDb);
     if (clamped == m_lnaGainDb)
         return;
-    m_lnaGainDb = clamped;
-
-    // Move the dB reference IN LOCKSTEP with the gain, and do it here rather
-    // than letting the two drift. The spectrum and the S-meter are both
-    // rendered through m_dbRef, so without this every gain change would slide
-    // the whole trace up or down the display — an operator backing off 10 dB on
-    // a strong band would watch the noise floor drop 10 dB and read it as the
-    // band going quiet, which is the opposite of what they just did.
-    m_dbRef.setLnaGainDb(m_lnaGainDb);
-
-    if (m_metis)
-        QMetaObject::invokeMethod(m_metis, "setLnaGainDb", Qt::QueuedConnection,
-            Q_ARG(int, m_lnaGainDb));
-
+    applyLnaGainDb(clamped);
     qCInfo(lcHl2) << "HL2 LNA gain:" << m_lnaGainDb << "dB (requested" << gainDb << ")";
-
-    // Echo what the hardware actually took, to every pan. The slider is free to
-    // have asked for something outside the register's range, and this is where
-    // it finds out it did not get it.
-    for (const auto& ids : m_ids.all())
-        emit panRfGainChanged(ids.panId, m_lnaGainDb);
 
     // The operator's gain belongs to the band they set it on (RFC #4603 PR 3).
     if (!m_currentBandKey.isEmpty())
@@ -2359,9 +2361,22 @@ void Hl2Backend::setTxPower(int percent)
     // tuning: a power change made mid-tune, or while TX is blocked, is still
     // what the operator wants once the carrier drops or the gate opens.
     m_rfPowerPercent = percent < 0 ? 0 : (percent > 100 ? 100 : percent);
-    // The operator's drive belongs to the band they set it on (RFC #4603 PR 3).
-    if (!m_currentBandKey.isEmpty())
-        m_driveByBand.insert(m_currentBandKey, m_rfPowerPercent);
+    // OPERATOR intent only: when band-memory/restore code applies a drive
+    // through this same seam, it must neither claim the band nor set the
+    // baseline — otherwise the conservative first-visit 0 would become the
+    // "operator's" baseline (found by the unvisited-band pinning test).
+    if (!m_applyingBandMemory) {
+        // The operator's drive belongs to the band they set it on.
+        if (!m_currentBandKey.isEmpty())
+            m_driveByBand.insert(m_currentBandKey, m_rfPowerPercent);
+        // The FIRST drive an operator sets becomes the radio's baseline for
+        // bands never visited (PR #4619 review: nothing else can ever raise
+        // the sentinel, so the unvisited-band fallback was dead and a new
+        // band inherited the previous band's drive). First-set-wins so later
+        // per-band tweaks don't move the baseline.
+        if (m_driveDefaultPercent < 0)
+            m_driveDefaultPercent = m_rfPowerPercent;
+    }
     notifyOperatingStateChanged();
     if (m_tuning)
         return;   // tune power owns the drive register until the carrier drops
@@ -2527,17 +2542,26 @@ void Hl2Backend::applyRestoredState(const RestoredRadioState& state)
     // the operator didn't choose. Restoring NEVER keys transmit: everything
     // below is a setpoint; the TX gate (m_txAllowed / keying paths) is
     // untouched.
+    // FULL RESET FIRST — and applyRestoredState({}) is a legitimate call
+    // meaning "this radio has no memory": RadioModel invokes this
+    // unconditionally on every engaged connect, so a same-family radio swap
+    // can never leak radio A's maps OR its live members into radio B
+    // (PR #4619 review, Ozy311 finding 1). Live members reset to the same
+    // virgin defaults a fresh backend construction would have.
     m_restoredState = RestoredRadioState{};
     m_haveRestoredState = false;
     m_lnaDbByBand.clear();
     m_driveByBand.clear();
-    m_lnaDefaultDb = m_lnaGainDb;
+    m_lnaDefaultDb = 20;          // Hl2Backend.h: m_lnaGainDb's constructed default
+    m_lnaGainDb = 20;
     m_driveDefaultPercent = -1;
+    m_rfPowerPercent = 100;       // TransmitModel's session default
+    m_currentBandKey.clear();
 
     RestoredRadioState valid;
     if (state.rfFrequencyHz >= 100'000.0 && state.rfFrequencyHz <= 38'400'000.0)
         valid.rfFrequencyHz = state.rfFrequencyHz;
-    if (!state.mode.isEmpty() && state.mode.size() <= 8)
+    if (isKnownModeString(state.mode))
         valid.mode = state.mode;
     // A passband is kept only as a sane pair; mode+passband are applied
     // together in pushInitialState() (the #4484 reconciliation).
@@ -2619,6 +2643,27 @@ RestoredRadioState Hl2Backend::currentOperatingState() const
     return state;
 }
 
+// The one true LNA application: register write, dB-reference lockstep, and
+// the every-pan echo. Shared by the operator path (setPanRfGain) and the
+// band-memory path so the two can't drift (PR #4619 review).
+//
+// The dB reference moves IN LOCKSTEP with the gain: spectrum and S-meter are
+// both rendered through m_dbRef, so without this every gain change would
+// slide the whole trace — an operator backing off 10 dB would watch the
+// noise floor drop and read it as the band going quiet.
+void Hl2Backend::applyLnaGainDb(int gainDb)
+{
+    m_lnaGainDb = gainDb;
+    m_dbRef.setLnaGainDb(m_lnaGainDb);
+    if (m_metis)
+        QMetaObject::invokeMethod(m_metis, "setLnaGainDb", Qt::QueuedConnection,
+            Q_ARG(int, m_lnaGainDb));
+    // Echo what the hardware actually took, to every pan — a slider that
+    // asked for something outside the register's range finds out here.
+    for (const auto& ids : m_ids.all())
+        emit panRfGainChanged(ids.panId, m_lnaGainDb);
+}
+
 void Hl2Backend::rememberCurrentBandState()
 {
     if (m_currentBandKey.isEmpty())
@@ -2644,21 +2689,27 @@ void Hl2Backend::applyPerBandStateFor(double freqHz, const char* reason)
     const int lna = qBound(kLnaGainMinDb,
                            m_lnaDbByBand.value(newBand, m_lnaDefaultDb),
                            kLnaGainMaxDb);
-    if (lna != m_lnaGainDb) {
-        m_lnaGainDb = lna;
-        m_dbRef.setLnaGainDb(m_lnaGainDb);
-        if (m_metis)
-            QMetaObject::invokeMethod(m_metis, "setLnaGainDb", Qt::QueuedConnection,
-                Q_ARG(int, m_lnaGainDb));
-        for (const auto& ids : m_ids.all())
-            emit panRfGainChanged(ids.panId, m_lnaGainDb);
-    }
+    if (lna != m_lnaGainDb)
+        applyLnaGainDb(lna);
 
-    const int drive = m_driveByBand.value(newBand, m_driveDefaultPercent);
-    if (drive >= 0 && drive != m_rfPowerPercent) {
+    // NEVER inherit the previous band's drive (nigelfenton's RFC rationale:
+    // the drive that makes 5 W on 80 m is amplifier-input-unsafe on 10 m).
+    // Remembered value first, then the operator's baseline default, and — for
+    // a band never visited before any baseline exists — a deliberate 0:
+    // conservative once per band per radio, instead of hot once per mistake.
+    int drive = m_driveByBand.value(newBand, m_driveDefaultPercent);
+    if (drive < 0) {
+        drive = 0;
+        qCInfo(lcHl2) << "HL2 band memory: first visit to" << newBand
+                      << "with no drive baseline — drive set to 0 until the"
+                         " operator chooses one";
+    }
+    if (drive != m_rfPowerPercent) {
         // A drive SETPOINT — applyDrive() itself stays behind the TX gate, so
         // a transmit-blocked session records the value without touching the PA.
+        m_applyingBandMemory = true;
         setTxPower(drive);
+        m_applyingBandMemory = false;
         TransmitDelta delta;
         delta.rfPower = drive;
         emit transmitChanged(delta);
@@ -2768,7 +2819,9 @@ void Hl2Backend::pushInitialState()
             const int drive =
                 m_driveByBand.value(m_currentBandKey, m_driveDefaultPercent);
             if (drive >= 0) {
+                m_applyingBandMemory = true;
                 setTxPower(drive);
+                m_applyingBandMemory = false;
                 TransmitDelta delta;
                 delta.rfPower = drive;
                 emit transmitChanged(delta);

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -1,4 +1,7 @@
 #include "core/backends/hl2/Hl2Backend.h"
+#include "core/backends/hl2/Hl2Bands.h"
+
+#include <QJsonObject>
 
 #include <cmath>
 #include <limits>
@@ -1215,6 +1218,13 @@ void Hl2Backend::connectRadio(const RadioConnectRequest& request)
     if (const double remembered = Hl2Settings::spanMhz(); remembered > 0.0)
         m_sampleRateHz = nearestIqSampleRateHz(remembered * 1.0e6);
 
+    // RFC #4603 PR 3: this radio's remembered state (validated in
+    // applyRestoredState) seeds the session. Ordering is deliberate — the
+    // legacy family-wide span above is the fallback, the per-radio restored
+    // rate beats it, and the explicit automation/test params below beat both.
+    if (m_haveRestoredState && m_restoredState.sampleRateHz > 0)
+        m_sampleRateHz = m_restoredState.sampleRateHz;
+
     // Optional overrides from the namespaced params.
     if (request.params.contains(QStringLiteral("sampleRateHz")))
         m_sampleRateHz = request.params.value(QStringLiteral("sampleRateHz")).toInt();
@@ -1227,8 +1237,20 @@ void Hl2Backend::connectRadio(const RadioConnectRequest& request)
     // exist, because m_rx is not built yet — how many of them there are is
     // decided a few lines below and depends on the sample rate settled above.
     double startFreqHz = 10'000'000.0;
+    if (m_haveRestoredState && m_restoredState.rfFrequencyHz > 0.0)
+        startFreqHz = m_restoredState.rfFrequencyHz;
     if (request.params.contains(QStringLiteral("rxFrequencyHz")))
         startFreqHz = request.params.value(QStringLiteral("rxFrequencyHz")).toDouble();
+
+    // Per-band memory (RFC #4603 PR 3): the session comes up with the start
+    // band's remembered LNA. The explicit param still wins via the guard.
+    m_currentBandKey = hl2::bandKeyForHz(startFreqHz);
+    if (m_haveRestoredState
+        && !request.params.contains(QStringLiteral("lnaGainDb"))) {
+        m_lnaGainDb = qBound(kLnaGainMinDb,
+                             m_lnaDbByBand.value(m_currentBandKey, m_lnaDefaultDb),
+                             kLnaGainMaxDb);
+    }
 
     // ---- how many receivers ----
     //
@@ -1574,8 +1596,15 @@ void Hl2Backend::setSliceFrequency(int sliceId, double hz)
     //
     // Sent whether or not transmit is enabled: this is oscillator setup, it keys
     // nothing, and having it already correct is part of what makes the key safe.
-    if (ddc == m_txDdc)
+    if (ddc == m_txDdc) {
         setTxFrequency(r->sliceFreqHz);
+        // Per-band memory follows the TRANSMIT-owning receiver (RFC #4603
+        // PR 3): leaving a band records its LNA/drive, entering one applies
+        // what it remembered. Keyed to the TX slice because drive and LNA are
+        // radio-wide hardware — a second receiver browsing another band must
+        // not drag the transmitter's setpoints around.
+        applyPerBandStateFor(r->sliceFreqHz, "tune");
+    }
 
     // The companion filter board is band hardware in the ANTENNA path, shared by
     // every receiver, and on transmit it is what keeps the harmonics legal.
@@ -1587,6 +1616,7 @@ void Hl2Backend::setSliceFrequency(int sliceId, double hz)
 
     emitSliceState(ddc);
     emitPanState(ddc);
+    notifyOperatingStateChanged();
 }
 
 void Hl2Backend::setSliceMode(int sliceId, const QString& mode)
@@ -1657,6 +1687,7 @@ void Hl2Backend::setSliceMode(int sliceId, const QString& mode)
             Q_ARG(double, static_cast<double>(txHi)));
     }
     emitSliceState(ddc);
+    notifyOperatingStateChanged();
 }
 
 void Hl2Backend::setSliceFilter(int sliceId, int lowHz, int highHz)
@@ -1671,6 +1702,7 @@ void Hl2Backend::setSliceFilter(int sliceId, int lowHz, int highHz)
         QMetaObject::invokeMethod(r->dsp, "setFilter", Qt::QueuedConnection,
             Q_ARG(double, lowHz), Q_ARG(double, highHz));
     emitSliceState(ddc);
+    notifyOperatingStateChanged();
 }
 
 void Hl2Backend::setSliceAgc(int sliceId, const QString& mode, int thresholdDb)
@@ -1915,6 +1947,11 @@ void Hl2Backend::setPanRfGain(const QString& panId, int gainDb)
     // it finds out it did not get it.
     for (const auto& ids : m_ids.all())
         emit panRfGainChanged(ids.panId, m_lnaGainDb);
+
+    // The operator's gain belongs to the band they set it on (RFC #4603 PR 3).
+    if (!m_currentBandKey.isEmpty())
+        m_lnaDbByBand.insert(m_currentBandKey, m_lnaGainDb);
+    notifyOperatingStateChanged();
 }
 
 void Hl2Backend::applyPanBandwidth(double hz)
@@ -2065,6 +2102,7 @@ void Hl2Backend::applyPanBandwidth(double hz)
         if (const Receiver* r = rx(ids.ddcIndex))
             setSliceFrequency(ids.uiNumber, r->sliceFreqHz);
     }
+    notifyOperatingStateChanged();
 }
 
 void Hl2Backend::setPanFrameRate(const QString& panId, int fps)
@@ -2321,6 +2359,10 @@ void Hl2Backend::setTxPower(int percent)
     // tuning: a power change made mid-tune, or while TX is blocked, is still
     // what the operator wants once the carrier drops or the gate opens.
     m_rfPowerPercent = percent < 0 ? 0 : (percent > 100 ? 100 : percent);
+    // The operator's drive belongs to the band they set it on (RFC #4603 PR 3).
+    if (!m_currentBandKey.isEmpty())
+        m_driveByBand.insert(m_currentBandKey, m_rfPowerPercent);
+    notifyOperatingStateChanged();
     if (m_tuning)
         return;   // tune power owns the drive register until the carrier drops
     applyDrive(m_rfPowerPercent);
@@ -2474,6 +2516,165 @@ IRadioBackend::HealthSnapshot Hl2Backend::healthSnapshot() const
     return h;
 }
 
+
+// ─── RFC #4603 PR 3: the client is this radio's memory ───────────────────────
+
+void Hl2Backend::applyRestoredState(const RestoredRadioState& state)
+{
+    // THE VALIDATION BOUNDARY (Principle VII): everything in the document is
+    // operator data from disk. Each field is range-checked here, once, and a
+    // field that fails validation is dropped — never "fixed up" into a value
+    // the operator didn't choose. Restoring NEVER keys transmit: everything
+    // below is a setpoint; the TX gate (m_txAllowed / keying paths) is
+    // untouched.
+    m_restoredState = RestoredRadioState{};
+    m_haveRestoredState = false;
+    m_lnaDbByBand.clear();
+    m_driveByBand.clear();
+    m_lnaDefaultDb = m_lnaGainDb;
+    m_driveDefaultPercent = -1;
+
+    RestoredRadioState valid;
+    if (state.rfFrequencyHz >= 100'000.0 && state.rfFrequencyHz <= 38'400'000.0)
+        valid.rfFrequencyHz = state.rfFrequencyHz;
+    if (!state.mode.isEmpty() && state.mode.size() <= 8)
+        valid.mode = state.mode;
+    // A passband is kept only as a sane pair; mode+passband are applied
+    // together in pushInitialState() (the #4484 reconciliation).
+    if (state.filterLowHz < state.filterHighHz
+        && state.filterLowHz >= -12'000.0 && state.filterHighHz <= 12'000.0)
+    {
+        valid.filterLowHz = state.filterLowHz;
+        valid.filterHighHz = state.filterHighHz;
+    }
+    if (state.sampleRateHz > 0)
+        valid.sampleRateHz = nearestIqSampleRateHz(state.sampleRateHz);
+
+    // Per-band maps ride the typed extension's domain sub-objects
+    // (RestoredRadioState.h). Values clamp to the hardware's own ranges.
+    const QJsonObject rfGain =
+        state.extension.value(QStringLiteral("rfGain")).toObject();
+    if (rfGain.contains(QStringLiteral("defaultDb")))
+        m_lnaDefaultDb = qBound(kLnaGainMinDb,
+                                rfGain.value(QStringLiteral("defaultDb")).toInt(),
+                                kLnaGainMaxDb);
+    const QJsonObject lnaByBand =
+        rfGain.value(QStringLiteral("lnaDbByBand")).toObject();
+    for (auto it = lnaByBand.constBegin(); it != lnaByBand.constEnd(); ++it)
+        m_lnaDbByBand.insert(it.key(),
+                             qBound(kLnaGainMinDb, it.value().toInt(),
+                                    kLnaGainMaxDb));
+
+    const QJsonObject txSetpoints =
+        state.extension.value(QStringLiteral("txSetpoints")).toObject();
+    if (txSetpoints.contains(QStringLiteral("defaultPercent")))
+        m_driveDefaultPercent = qBound(
+            0, txSetpoints.value(QStringLiteral("defaultPercent")).toInt(), 100);
+    const QJsonObject driveByBand =
+        txSetpoints.value(QStringLiteral("driveByBand")).toObject();
+    for (auto it = driveByBand.constBegin(); it != driveByBand.constEnd(); ++it)
+        m_driveByBand.insert(it.key(), qBound(0, it.value().toInt(), 100));
+
+    m_restoredState = valid;
+    m_haveRestoredState = true;
+    qCInfo(lcHl2) << "HL2 restore: freq" << valid.rfFrequencyHz << "mode"
+                  << valid.mode << "filter" << valid.filterLowHz << ".."
+                  << valid.filterHighHz << "rate" << valid.sampleRateHz
+                  << "lna bands" << m_lnaDbByBand.size() << "drive bands"
+                  << m_driveByBand.size();
+}
+
+RestoredRadioState Hl2Backend::currentOperatingState() const
+{
+    RestoredRadioState state;
+    if (const Receiver* txRx = rx(m_txDdc)) {
+        state.rfFrequencyHz = txRx->sliceFreqHz;
+        state.mode = txRx->mode;
+        state.filterLowHz = txRx->filterLowHz;
+        state.filterHighHz = txRx->filterHighHz;
+    }
+    state.sampleRateHz = m_sampleRateHz;
+
+    // The maps plus the live values under the current band key — so a capture
+    // between band changes still records the operator's latest tweaks.
+    QJsonObject lnaByBand;
+    for (auto it = m_lnaDbByBand.constBegin(); it != m_lnaDbByBand.constEnd(); ++it)
+        lnaByBand.insert(it.key(), it.value());
+    QJsonObject driveByBand;
+    for (auto it = m_driveByBand.constBegin(); it != m_driveByBand.constEnd(); ++it)
+        driveByBand.insert(it.key(), it.value());
+    if (!m_currentBandKey.isEmpty()) {
+        lnaByBand.insert(m_currentBandKey, m_lnaGainDb);
+        driveByBand.insert(m_currentBandKey, m_rfPowerPercent);
+    }
+
+    QJsonObject rfGain{{QStringLiteral("defaultDb"), m_lnaDefaultDb},
+                       {QStringLiteral("lnaDbByBand"), lnaByBand}};
+    QJsonObject txSetpoints{{QStringLiteral("driveByBand"), driveByBand}};
+    if (m_driveDefaultPercent >= 0)
+        txSetpoints.insert(QStringLiteral("defaultPercent"), m_driveDefaultPercent);
+    state.extension = QJsonObject{{QStringLiteral("rfGain"), rfGain},
+                                  {QStringLiteral("txSetpoints"), txSetpoints}};
+    state.extensionSchemaVersion = 1;
+    return state;
+}
+
+void Hl2Backend::rememberCurrentBandState()
+{
+    if (m_currentBandKey.isEmpty())
+        return;
+    m_lnaDbByBand.insert(m_currentBandKey, m_lnaGainDb);
+    m_driveByBand.insert(m_currentBandKey, m_rfPowerPercent);
+}
+
+void Hl2Backend::applyPerBandStateFor(double freqHz, const char* reason)
+{
+    const QString newBand = hl2::bandKeyForHz(freqHz);
+    if (newBand == m_currentBandKey) {
+        return;
+    }
+    // Leaving a band records the operator's values under the OLD key; the new
+    // band gets what it remembered (or the defaults). nigelfenton's RFC
+    // review: the drive that makes 5 W on 80 m is not polite on 10 m, so a
+    // band change must never carry the old band's drive along.
+    rememberCurrentBandState();
+    const QString oldBand = m_currentBandKey;
+    m_currentBandKey = newBand;
+
+    const int lna = qBound(kLnaGainMinDb,
+                           m_lnaDbByBand.value(newBand, m_lnaDefaultDb),
+                           kLnaGainMaxDb);
+    if (lna != m_lnaGainDb) {
+        m_lnaGainDb = lna;
+        m_dbRef.setLnaGainDb(m_lnaGainDb);
+        if (m_metis)
+            QMetaObject::invokeMethod(m_metis, "setLnaGainDb", Qt::QueuedConnection,
+                Q_ARG(int, m_lnaGainDb));
+        for (const auto& ids : m_ids.all())
+            emit panRfGainChanged(ids.panId, m_lnaGainDb);
+    }
+
+    const int drive = m_driveByBand.value(newBand, m_driveDefaultPercent);
+    if (drive >= 0 && drive != m_rfPowerPercent) {
+        // A drive SETPOINT — applyDrive() itself stays behind the TX gate, so
+        // a transmit-blocked session records the value without touching the PA.
+        setTxPower(drive);
+        TransmitDelta delta;
+        delta.rfPower = drive;
+        emit transmitChanged(delta);
+    }
+
+    qCInfo(lcHl2) << "HL2 band memory (" << reason << "):" << oldBand << "->"
+                  << newBand << "lna" << m_lnaGainDb << "dB drive"
+                  << m_rfPowerPercent << '%';
+    notifyOperatingStateChanged();
+}
+
+void Hl2Backend::notifyOperatingStateChanged()
+{
+    emit operatingStateChanged();
+}
+
 void Hl2Backend::pushInitialState()
 {
     // THE RADIO REPORTS NO VFO, SO THE APP IS AUTHORITATIVE AND MUST PUSH.
@@ -2534,6 +2735,44 @@ void Hl2Backend::pushInitialState()
             const auto [pbLowHz, pbHighHz] = defaultPassbandForMode(r.mode);
             r.filterLowHz = pbLowHz;
             r.filterHighHz = pbHighHz;
+        }
+        // RFC #4603 PR 3, reconciled with #4484 (Ozy311's review catch): a
+        // RESTORED mode+passband overrides the derivation — but only as a
+        // pair. Restoring the mode alone re-derives its passband, and a
+        // restored passband applies on top of its restored mode, so mode and
+        // passband can never disagree — the invariant #4484 exists for. Runs
+        // under the same once-per-connect guard, so an EP6 glitch's re-linkUp
+        // cannot re-assert day-old state over the operator's live edits.
+        if (m_haveRestoredState) {
+            if (Receiver* txRx = rx(m_txDdc)) {
+                if (!m_restoredState.mode.isEmpty()) {
+                    txRx->mode = m_restoredState.mode;
+                    const auto [pbLowHz, pbHighHz] =
+                        defaultPassbandForMode(txRx->mode);
+                    txRx->filterLowHz = pbLowHz;
+                    txRx->filterHighHz = pbHighHz;
+                }
+                if (m_restoredState.filterLowHz != 0.0
+                    || m_restoredState.filterHighHz != 0.0) {
+                    txRx->filterLowHz =
+                        static_cast<int>(m_restoredState.filterLowHz);
+                    txRx->filterHighHz =
+                        static_cast<int>(m_restoredState.filterHighHz);
+                }
+            }
+            // The start band's remembered drive, as a SETPOINT (never keys —
+            // applyDrive() stays behind the TX gate). Echoed upward as a
+            // normalized delta so TransmitModel and the UI agree with the
+            // register. After RadioModel's own connect-time power push, so
+            // the remembered per-band value wins over the session default.
+            const int drive =
+                m_driveByBand.value(m_currentBandKey, m_driveDefaultPercent);
+            if (drive >= 0) {
+                setTxPower(drive);
+                TransmitDelta delta;
+                delta.rfPower = drive;
+                emit transmitChanged(delta);
+            }
         }
         m_passbandDerivedThisConnect = true;
     }

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -106,6 +106,7 @@ private:
     // and record the operator's current values into the maps for the band
     // being left. Called from the band-change path and connect.
     void applyPerBandStateFor(double freqHz, const char* reason);
+    void applyLnaGainDb(int gainDb);   // the one true LNA application
     void rememberCurrentBandState();
     void notifyOperatingStateChanged();
 
@@ -426,6 +427,10 @@ private:
     int m_lnaDefaultDb = 20;         // matches m_lnaGainDb's own default
     int m_driveDefaultPercent = -1;  // <0: no restored default; leave drive alone
     QString m_currentBandKey;
+    // True while band-memory / restore code drives setTxPower() itself: the
+    // internal application must neither bootstrap the operator baseline nor
+    // record into the per-band map — only OPERATOR intent does that.
+    bool m_applyingBandMemory = false;
     // Tune-carrier amplitude, full scale into the modulator. Actual radiated
     // power is governed by the TX drive register, which is where an operator
     // sets it; scaling here as well would make the power control non-linear for

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -46,6 +46,12 @@ public:
     bool ownsRxAudio() const override { return true; }
 
     void connectRadio(const RadioConnectRequest& request) override;
+    // RFC #4603 PR 3: the client is this radio's memory. Restored state is
+    // stashed here pre-connect (validated at this boundary — Principle VII)
+    // and applied during connect/pushInitialState; capture reports through
+    // currentOperatingState() + operatingStateChanged().
+    void applyRestoredState(const RestoredRadioState& state) override;
+    RestoredRadioState currentOperatingState() const override;
     void disconnectRadio() override;
     bool isConnected() const override;
 
@@ -95,6 +101,13 @@ private:
     // frequency. Idempotent and change-gated, so it is safe to call from every
     // path that can move the dial.
     void applyBandFilter(const char* reason);
+    // Per-band memory (RFC #4603 PR 3): apply the remembered LNA + drive for
+    // the band containing freqHz (falling back to the restored defaults),
+    // and record the operator's current values into the maps for the band
+    // being left. Called from the band-change path and connect.
+    void applyPerBandStateFor(double freqHz, const char* reason);
+    void rememberCurrentBandState();
+    void notifyOperatingStateChanged();
 
     void emitSliceState(int ddc);   // sliceChanged(delta) from a receiver's state
     void emitPanState(int ddc);     // panCenterBandwidthChanged from its NCO + rate
@@ -401,6 +414,18 @@ private:
     // TransmitModel defaults rfPower to, so a TUNE before any power change
     // restores something sane rather than 0.
     int m_rfPowerPercent = 100;
+    // RFC #4603 PR 3 state memory. m_restoredState is the validated snapshot
+    // handed over pre-connect; the per-band maps are the working copies the
+    // session reads and updates (band key -> value; see Hl2Bands.h). Defaults
+    // apply to bands never visited. m_currentBandKey tracks which band's
+    // entries the operator's live edits belong to.
+    bool m_haveRestoredState = false;
+    RestoredRadioState m_restoredState;
+    QMap<QString, int> m_lnaDbByBand;
+    QMap<QString, int> m_driveByBand;
+    int m_lnaDefaultDb = 20;         // matches m_lnaGainDb's own default
+    int m_driveDefaultPercent = -1;  // <0: no restored default; leave drive alone
+    QString m_currentBandKey;
     // Tune-carrier amplitude, full scale into the modulator. Actual radiated
     // power is governed by the TX drive register, which is where an operator
     // sets it; scaling here as well would make the power control non-linear for

--- a/src/core/backends/hl2/Hl2Bands.h
+++ b/src/core/backends/hl2/Hl2Bands.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <QString>
+
+namespace AetherSDR {
+namespace hl2 {
+
+// Frequency -> stable band key for the HL2's per-band maps (RFC #4603 PR 3:
+// per-band TX drive and LNA gain, nigelfenton's review — the PA gain that
+// makes 5 W on 80 m makes considerably more on 10 m, so drive is remembered
+// per band).
+//
+// DELIBERATELY a fixed table, not BandPlanManager: these strings are
+// PERSISTENCE KEYS inside the radio's OperatingState document, so they must
+// be stable across releases, regions, and the operator's band-plan choice.
+// Edges are generous (they cover the gaps between ham allocations) so every
+// frequency in the HL2's 0.1–38.4 MHz range maps to exactly one key and a
+// slightly out-of-band tune stays in its neighborhood's bucket. UI banding
+// keeps using the region-aware BandPlanManager; this table never surfaces in
+// the UI.
+inline QString bandKeyForHz(double hz)
+{
+    const double mhz = hz / 1.0e6;
+    struct Edge {
+        double belowMhz;
+        const char* key;
+    };
+    // Upper edge of each bucket, ascending. The last bucket absorbs the rest
+    // of the HL2's tuning range.
+    static constexpr Edge kEdges[] = {
+        {0.3,   "2200m"},
+        {1.0,   "630m"},
+        {2.4,   "160m"},
+        {4.5,   "80m"},
+        {6.0,   "60m"},
+        {8.0,   "40m"},
+        {11.5,  "30m"},
+        {15.5,  "20m"},
+        {19.5,  "17m"},
+        {22.5,  "15m"},
+        {26.0,  "12m"},
+        {32.0,  "10m"},
+        {40.0,  "8m"},
+    };
+    for (const Edge& edge : kEdges) {
+        if (mhz < edge.belowMhz) {
+            return QLatin1String(edge.key);
+        }
+    }
+    return QStringLiteral("8m");
+}
+
+} // namespace hl2
+} // namespace AetherSDR

--- a/src/core/backends/hl2/Hl2Discovery.cpp
+++ b/src/core/backends/hl2/Hl2Discovery.cpp
@@ -96,9 +96,8 @@ QString Hl2Discovery::effectiveNickname(const QString& family,
         const QString legacyKey = nicknameSettingsKey(serial);
         custom = settings.value(legacyKey).toString().trimmed();
         if (!custom.isEmpty()) {
+            // setNickname() removes the legacy key and commits — one write.
             setNickname(fam, serial, custom);
-            settings.remove(legacyKey);
-            settings.save();
         }
     }
     return custom.isEmpty() ? fallback : custom;

--- a/src/core/backends/hl2/Hl2Discovery.cpp
+++ b/src/core/backends/hl2/Hl2Discovery.cpp
@@ -1,6 +1,8 @@
 #include "core/backends/hl2/Hl2Discovery.h"
 
 #include "core/AppSettings.h"
+
+#include <QJsonObject>
 #include "core/backends/hl2/MetisProtocol.h"
 
 #include <QNetworkDatagram>
@@ -63,11 +65,67 @@ QString Hl2Discovery::nicknameSettingsKey(const QString& serial)
          + QString(serial).replace(kIllegal, QStringLiteral("_"));
 }
 
-QString Hl2Discovery::effectiveNickname(const QString& serial, const QString& fallback)
+namespace {
+
+QString identityFamily(const QString& family)
 {
-    const QString custom =
-        AppSettings::instance().value(nicknameSettingsKey(serial)).toString().trimmed();
+    // Legacy keys never carried a family; every producer was an HL2.
+    return family.isEmpty() ? QStringLiteral("hl2") : family.toLower();
+}
+
+constexpr char kIdentityFeature[] = "Identity";
+constexpr char kNicknameField[] = "nickname";
+
+} // namespace
+
+QString Hl2Discovery::effectiveNickname(const QString& family,
+                                        const QString& serial,
+                                        const QString& fallback)
+{
+    auto& settings = AppSettings::instance();
+    const QString fam = identityFamily(family);
+    QString custom = settings
+                         .radioFeature(fam, serial,
+                                       QString::fromLatin1(kIdentityFeature))
+                         .value(QLatin1String(kNicknameField))
+                         .toString()
+                         .trimmed();
+    if (custom.isEmpty()) {
+        // One-shot migration from the legacy sanitized flat key (RFC #4603
+        // PR 3): adopt it into the scoped document, then drop the flat key.
+        const QString legacyKey = nicknameSettingsKey(serial);
+        custom = settings.value(legacyKey).toString().trimmed();
+        if (!custom.isEmpty()) {
+            setNickname(fam, serial, custom);
+            settings.remove(legacyKey);
+            settings.save();
+        }
+    }
     return custom.isEmpty() ? fallback : custom;
+}
+
+void Hl2Discovery::setNickname(const QString& family, const QString& serial,
+                               const QString& name)
+{
+    auto& settings = AppSettings::instance();
+    const QString fam = identityFamily(family);
+    const QString trimmed = name.trimmed();
+    if (trimmed.isEmpty()) {
+        settings.removeRadioFeature(fam, serial,
+                                    QString::fromLatin1(kIdentityFeature));
+    } else {
+        settings.setRadioFeature(
+            fam, serial, QString::fromLatin1(kIdentityFeature), 1,
+            QJsonObject{{QLatin1String(kNicknameField), trimmed}});
+    }
+    // A cleared name must not resurrect from the legacy key either.
+    settings.remove(nicknameSettingsKey(serial));
+    settings.save();
+}
+
+bool Hl2Discovery::hasCustomNickname(const QString& family, const QString& serial)
+{
+    return !effectiveNickname(family, serial, QString()).isEmpty();
 }
 
 bool Hl2Discovery::nicknameLivesOnRadio(const RadioInfo& info)
@@ -165,7 +223,7 @@ void Hl2Discovery::onReadyRead()
         info.serial   = macToSerial(reply->mac);
         // An HL2 has no on-radio name store; show the operator's custom nickname
         // (keyed by MAC/serial in AppSettings) if one is set, else the model name.
-        info.nickname = effectiveNickname(info.serial, info.model);
+        info.nickname = effectiveNickname(QStringLiteral("hl2"), info.serial, info.model);
         info.version  = QString::number(reply->gatewareVersion);
         // A bare revision number is not self-describing in a status bar.
         info.versionLabel = QStringLiteral("Gateware");

--- a/src/core/backends/hl2/Hl2Discovery.h
+++ b/src/core/backends/hl2/Hl2Discovery.h
@@ -55,11 +55,22 @@ public:
     // "radio name" command), so the operator's custom name is persisted
     // client-side, keyed by the radio's stable MAC, and read back here at
     // discovery time. Shared with RadioSetupDialog so both sides agree on the key.
+    // LEGACY key builder — kept only for the one-shot migration below and its
+    // regression test. New storage is the (family, serial, "Identity") feature
+    // document in radio_settings (RFC #4603 PR 3), where the raw MAC is a
+    // legal identity and no sanitizing is needed.
     static QString nicknameSettingsKey(const QString& serial);
-    // The nickname to show for this serial: the saved custom name, or a default
-    // when none is set. Centralises the "custom or fall back" rule.
-    static QString effectiveNickname(const QString& serial,
+    // The nickname to show for this radio: the saved custom name, or a default
+    // when none is set. Centralises the "custom or fall back" rule, and
+    // performs the one-shot legacy-flat-key -> feature-document migration.
+    // `family` is the radio's family string (empty is normalized to "hl2",
+    // the only family that ever produced legacy keys).
+    static QString effectiveNickname(const QString& family, const QString& serial,
                                      const QString& fallback);
+    // Store (or clear, with an empty name) the client-side nickname.
+    static void setNickname(const QString& family, const QString& serial,
+                            const QString& name);
+    static bool hasCustomNickname(const QString& family, const QString& serial);
     // True when this radio stores its own name (FlexRadio's "radio name"
     // command), so the client must NOT keep a second copy. False for every
     // family without an on-radio store — HL2, the sim, any future backend —

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -1238,7 +1238,6 @@ void ConnectionPanel::showRadioContextMenu(const QPoint& pos)
     if (!chosen)
         return;
 
-    bool changed = false;
     if (chosen == setNick) {
         bool ok = false;
         const QString current = hl2::Hl2Discovery::effectiveNickname(
@@ -1252,13 +1251,10 @@ void ConnectionPanel::showRadioContextMenu(const QPoint& pos)
             // confirmed shouldn't be lost to a crash or a kill.
             hl2::Hl2Discovery::setNickname(radio.family, radio.serial,
                                            name.trimmed());
-            changed = true;
         }
     } else if (clearNick && chosen == clearNick) {
         hl2::Hl2Discovery::setNickname(radio.family, radio.serial, QString());
-        changed = true;
     }
-    Q_UNUSED(changed);
 
     // Reflect the change immediately: re-label this row from the saved setting
     // rather than waiting for the next discovery sweep.

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -1230,9 +1230,8 @@ void ConnectionPanel::showRadioContextMenu(const QPoint& pos)
 
     QMenu menu(this);
     QAction* setNick = menu.addAction(tr("Set Nickname…"));
-    const QString savedKey = hl2::Hl2Discovery::nicknameSettingsKey(radio.serial);
     const bool hasCustom =
-        !AppSettings::instance().value(savedKey).toString().trimmed().isEmpty();
+        hl2::Hl2Discovery::hasCustomNickname(radio.family, radio.serial);
     QAction* clearNick = hasCustom ? menu.addAction(tr("Clear Nickname")) : nullptr;
 
     QAction* chosen = menu.exec(m_radioList->mapToGlobal(pos));
@@ -1242,32 +1241,31 @@ void ConnectionPanel::showRadioContextMenu(const QPoint& pos)
     bool changed = false;
     if (chosen == setNick) {
         bool ok = false;
-        const QString current =
-            AppSettings::instance().value(savedKey).toString();
+        const QString current = hl2::Hl2Discovery::effectiveNickname(
+            radio.family, radio.serial, QString());
         const QString name = QInputDialog::getText(
             this, tr("Set Nickname"),
             tr("Nickname for %1:").arg(radio.model),
             QLineEdit::Normal, current, &ok);
         if (ok) {
-            AppSettings::instance().setValue(savedKey, name.trimmed());
+            // setNickname commits eagerly — a naming the operator just
+            // confirmed shouldn't be lost to a crash or a kill.
+            hl2::Hl2Discovery::setNickname(radio.family, radio.serial,
+                                           name.trimmed());
             changed = true;
         }
     } else if (clearNick && chosen == clearNick) {
-        AppSettings::instance().remove(savedKey);
+        hl2::Hl2Discovery::setNickname(radio.family, radio.serial, QString());
         changed = true;
     }
-
-    // Commit to disk now rather than riding on the shutdown save — a naming the
-    // operator just confirmed shouldn't be lost to a crash or a kill, and the
-    // rest of this panel (onLocalConnectClicked) saves eagerly for the same reason.
-    if (changed)
-        AppSettings::instance().save();
+    Q_UNUSED(changed);
 
     // Reflect the change immediately: re-label this row from the saved setting
     // rather than waiting for the next discovery sweep.
     RadioInfo updated = radio;
     updated.nickname =
-        hl2::Hl2Discovery::effectiveNickname(radio.serial, radio.model);
+        hl2::Hl2Discovery::effectiveNickname(radio.family, radio.serial,
+                                             radio.model);
     m_radios[row] = updated;
     item->setText(formatLocalRadioLabel(updated));
 }
@@ -2006,7 +2004,7 @@ ConnectionPanel::Hl2ProbeResult ConnectionPanel::probeHermesLite2(
             // keyed by serial — and hard-coding the model here meant a radio named
             // in Radio Setup showed that name when found locally and
             // "Hermes-Lite 2" when reached over the VPN. Needs the serial first.
-            info.nickname = hl2::Hl2Discovery::effectiveNickname(info.serial, info.model);
+            info.nickname = hl2::Hl2Discovery::effectiveNickname(info.family, info.serial, info.model);
             info.version  = QString::number(reply->gatewareVersion);
             // Same label Hl2Discovery sets on the broadcast path — this
             // is the SECOND place an HL2 RadioInfo is built, and a field

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3309,6 +3309,14 @@ void MainWindow::closeEvent(QCloseEvent* event)
     m_tgxlConn.disconnect();
     m_pgxlConn.disconnect();
 
+    // Same event-loop reasoning: the operating-state capture flush normally
+    // rides the queued backend disconnected() signal, which never lands
+    // during close (two queued hops through the HL2 I/O thread). Flush
+    // explicitly while the scope still resolves to the connected radio, so
+    // the last tune/drive edit before quit is remembered (RFC #4603 PR 3;
+    // PR #4619 review).
+    m_radioModel.flushPendingOperatingState();
+
     // Same reason as the TGXL/PGXL sockets above: the D-STAR helper is stopped
     // by the queued RadioModel::connectionStateChanged(false) handler, which
     // does not run during close (the event loop isn't pumped here). Without an

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -1076,7 +1076,8 @@ QWidget* RadioSetupDialog::buildRadioTab()
             const RadioInfo info = m_model->lastRadioInfo();
             if (!hl2::Hl2Discovery::nicknameLivesOnRadio(info))
                 initialNickname = hl2::Hl2Discovery::effectiveNickname(
-                    info.serial, info.model.isEmpty() ? m_model->name() : info.model);
+                    info.family, info.serial,
+                    info.model.isEmpty() ? m_model->name() : info.model);
         }
         m_nicknameEdit = new QLineEdit(initialNickname);
         m_nicknameEdit->setStyleSheet(kEditStyle);
@@ -1108,11 +1109,9 @@ QWidget* RadioSetupDialog::buildRadioTab()
             if (hl2::Hl2Discovery::nicknameLivesOnRadio(info)) {
                 m_model->sendCommand("radio name " + m_nicknameEdit->text());
             } else {
-                AppSettings::instance().setValue(
-                    hl2::Hl2Discovery::nicknameSettingsKey(info.serial),
-                    m_nicknameEdit->text().trimmed());
-                // Commit now; don't rely on the shutdown save to carry it.
-                AppSettings::instance().save();
+                // Commits eagerly inside; don't rely on the shutdown save.
+                hl2::Hl2Discovery::setNickname(info.family, info.serial,
+                                               m_nicknameEdit->text());
             }
         });
         connect(m_callsignEdit, &QLineEdit::editingFinished, this, [this] {

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -425,10 +425,15 @@ QJsonObject clientInfoToJson(quint32 handle,
 // (Flex, Sim) never sees restored state — the radio-authoritative policy
 // (Constitution II/III) is structurally untouched.
 // RFC #4603 PR 3: the debounced store write. Gated by the same predicate as
-// the restore path — capability-shaped, never family-shaped.
-void RadioModel::persistOperatingState()
+// the restore path — capability-shaped, never family-shaped. `force` is the
+// disconnect-flush path: isConnected() is already false there, but the
+// backend still holds the session's final state and the scope still resolves
+// to that radio's identity.
+void RadioModel::persistOperatingState(bool force)
 {
-    if (!m_backend || !isConnected()) {
+    m_operatingStateSaveTimer.stop();
+    m_operatingStateMaxWaitTimer.stop();
+    if (!m_backend || (!force && !isConnected())) {
         return;
     }
     const RadioCapabilities caps = m_backend->capabilities();
@@ -437,6 +442,18 @@ void RadioModel::persistOperatingState()
     }
     RadioStateMemory::store(settingsScope(), caps,
                             m_backend->currentOperatingState());
+}
+
+void RadioModel::flushPendingOperatingState()
+{
+    // Only when something is actually pending: a disconnect with no unsaved
+    // edits must not rewrite the document (and a Flex/Sim backend never has
+    // a pending timer to begin with).
+    if (!m_operatingStateSaveTimer.isActive()
+        && !m_operatingStateMaxWaitTimer.isActive()) {
+        return;
+    }
+    persistOperatingState(true);
 }
 
 void RadioModel::handRestoredStateToBackend(const QString& serial)
@@ -448,11 +465,19 @@ void RadioModel::handRestoredStateToBackend(const QString& serial)
     if (!RadioStateMemory::shouldEngage(caps)) {
         return;
     }
+    // Stop any capture pending from a previous same-family session: the
+    // flush-on-disconnect already persisted it under the OLD radio's scope,
+    // and a stale timer crossing the swap would write radio A's snapshot
+    // under radio B's identity (PR #4619 review, Ozy311 finding 1).
+    m_operatingStateSaveTimer.stop();
+    m_operatingStateMaxWaitTimer.stop();
+
     const RestoredRadioState state =
         RadioStateMemory::load(RadioSettingsScope(m_family, serial), caps);
-    if (!state.isEmpty()) {
-        m_backend->applyRestoredState(state);
-    }
+    // UNCONDITIONALLY — an empty state is the reset that stops a same-family
+    // backend reuse leaking radio A's maps and live members into radio B
+    // ("this radio has no memory" is information, not a no-op).
+    m_backend->applyRestoredState(state);
 }
 
 std::unique_ptr<IRadioBackend> RadioModel::makeBackend(const QString& family)
@@ -795,7 +820,19 @@ void RadioModel::setupBackend(const QString& family)
     // for an empty declaration (Flex, Sim) the signal is never emitted AND
     // the store call is gated again in persistOperatingState().
     connect(m_backend.get(), &IRadioBackend::operatingStateChanged, this,
-            [this] { m_operatingStateSaveTimer.start(); });
+            [this] {
+        m_operatingStateSaveTimer.start();
+        if (!m_operatingStateMaxWaitTimer.isActive()) {
+            m_operatingStateMaxWaitTimer.start();
+        }
+    });
+    // Flush the pending capture BEFORE the rest of the disconnect teardown
+    // touches identity — this connection is made first, and same-thread
+    // signal delivery runs slots in connection order, so the scope still
+    // resolves to the radio the pending edits belong to (PR #4619 review:
+    // the last tune before Disconnect was exactly the state being lost).
+    connect(m_backend.get(), &IRadioBackend::disconnected, this,
+            &RadioModel::flushPendingOperatingState);
 
     // Keying and tune from the GUI.
     //
@@ -1477,11 +1514,18 @@ RadioModel::RadioModel(QObject* parent)
             [this](const QString&) { updateOperatorTransmit(); });
 
     m_reconnectTimer.setInterval(5000);
-    // RFC #4603 PR 3: one settings write per burst of operating-state changes.
+    // RFC #4603 PR 3: one settings write per burst of operating-state
+    // changes — trailing debounce plus a max-wait so continuous tuning still
+    // persists periodically instead of restarting the window forever
+    // (PR #4619 review).
     m_operatingStateSaveTimer.setSingleShot(true);
     m_operatingStateSaveTimer.setInterval(2000);
     connect(&m_operatingStateSaveTimer, &QTimer::timeout, this,
-            &RadioModel::persistOperatingState);
+            [this] { persistOperatingState(false); });
+    m_operatingStateMaxWaitTimer.setSingleShot(true);
+    m_operatingStateMaxWaitTimer.setInterval(10000);
+    connect(&m_operatingStateMaxWaitTimer, &QTimer::timeout, this,
+            [this] { persistOperatingState(false); });
     connect(&m_reconnectTimer, &QTimer::timeout, this, [this]() {
         if (!m_intentionalDisconnect && !m_lastInfo.address.isNull()) {
             qCDebug(lcProtocol) << "RadioModel: auto-reconnecting to" << m_lastInfo.address.toString();

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -424,6 +424,21 @@ QJsonObject clientInfoToJson(quint32 handle,
 // immediately before connectRadio(); a backend with an empty declaration
 // (Flex, Sim) never sees restored state — the radio-authoritative policy
 // (Constitution II/III) is structurally untouched.
+// RFC #4603 PR 3: the debounced store write. Gated by the same predicate as
+// the restore path — capability-shaped, never family-shaped.
+void RadioModel::persistOperatingState()
+{
+    if (!m_backend || !isConnected()) {
+        return;
+    }
+    const RadioCapabilities caps = m_backend->capabilities();
+    if (!RadioStateMemory::shouldEngage(caps)) {
+        return;
+    }
+    RadioStateMemory::store(settingsScope(), caps,
+                            m_backend->currentOperatingState());
+}
+
 void RadioModel::handRestoredStateToBackend(const QString& serial)
 {
     if (!m_backend) {
@@ -773,6 +788,14 @@ void RadioModel::setupBackend(const QString& family)
     // signal to bind to and cannot observe a stale picture.
     connect(m_backend.get(), &IRadioBackend::capabilitiesChanged, this,
             [this] { publishCapabilities(isConnected()); });
+
+    // The capture half of RadioStateMemory (RFC #4603 PR 3): a backend that
+    // declares client-owned settings domains reports state movement; one
+    // debounced store per burst of changes. Engagement is capability-shaped —
+    // for an empty declaration (Flex, Sim) the signal is never emitted AND
+    // the store call is gated again in persistOperatingState().
+    connect(m_backend.get(), &IRadioBackend::operatingStateChanged, this,
+            [this] { m_operatingStateSaveTimer.start(); });
 
     // Keying and tune from the GUI.
     //
@@ -1454,6 +1477,11 @@ RadioModel::RadioModel(QObject* parent)
             [this](const QString&) { updateOperatorTransmit(); });
 
     m_reconnectTimer.setInterval(5000);
+    // RFC #4603 PR 3: one settings write per burst of operating-state changes.
+    m_operatingStateSaveTimer.setSingleShot(true);
+    m_operatingStateSaveTimer.setInterval(2000);
+    connect(&m_operatingStateSaveTimer, &QTimer::timeout, this,
+            &RadioModel::persistOperatingState);
     connect(&m_reconnectTimer, &QTimer::timeout, this, [this]() {
         if (!m_intentionalDisconnect && !m_lastInfo.address.isNull()) {
             qCDebug(lcProtocol) << "RadioModel: auto-reconnecting to" << m_lastInfo.address.toString();

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1220,6 +1220,7 @@ private:
     // in the ctor, so a non-Flex backend simply skips it.
     static std::unique_ptr<IRadioBackend> makeBackend(const QString& family);
     void handRestoredStateToBackend(const QString& serial);  // RFC #4603
+    void persistOperatingState();                            // RFC #4603 PR 3
 
     // aetherd Gap B: build/destroy the backend for a radio family. The backend
     // follows the radio the operator picks in the connection manager, so these
@@ -1704,6 +1705,8 @@ private:
     // while the radio is still booting and would otherwise spam the UI.
     bool      m_rebootInProgress{false};
     QTimer    m_reconnectTimer;
+    // RFC #4603 PR 3: debounces operatingStateChanged into one store write.
+    QTimer    m_operatingStateSaveTimer;
 
     // ── Network quality monitor ──
     void startNetworkMonitor();

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1220,7 +1220,8 @@ private:
     // in the ctor, so a non-Flex backend simply skips it.
     static std::unique_ptr<IRadioBackend> makeBackend(const QString& family);
     void handRestoredStateToBackend(const QString& serial);  // RFC #4603
-    void persistOperatingState();                            // RFC #4603 PR 3
+    void persistOperatingState(bool force = false);          // RFC #4603 PR 3
+    void flushPendingOperatingState();                       // RFC #4603 PR 3
 
     // aetherd Gap B: build/destroy the backend for a radio family. The backend
     // follows the radio the operator picks in the connection manager, so these
@@ -1706,7 +1707,12 @@ private:
     bool      m_rebootInProgress{false};
     QTimer    m_reconnectTimer;
     // RFC #4603 PR 3: debounces operatingStateChanged into one store write.
+    // The companion max-wait timer guarantees a sustained burst (continuous
+    // tuning) still stores at least every interval; the disconnect path
+    // flushes whatever is pending (PR #4619 review — the state most likely
+    // to be lost was the operator's last edit before disconnecting).
     QTimer    m_operatingStateSaveTimer;
+    QTimer    m_operatingStateMaxWaitTimer;
 
     // ── Network quality monitor ──
     void startNetworkMonitor();

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1025,6 +1025,13 @@ public:
     // Backend family currently in use ("flex", "hl2", "kiwi", ...).
     QString family() const { return m_family; }
 
+    // Flush any pending operating-state capture immediately (RFC #4603 PR 3).
+    // PUBLIC because MainWindow::closeEvent() must call it explicitly: quit
+    // tears down without pumping the event loop, so the queued
+    // disconnect→flush path never runs there (PR #4619 review — same class
+    // as the explicit TGXL/D-STAR teardown in closeEvent).
+    void flushPendingOperatingState();
+
     // The (family, radio) handle into the radio-scoped feature-document store
     // (RFC #4603). Identity is the family's canonical serial (Flex serial /
     // HL2 MAC); an unconnected model yields a family-wide scope.
@@ -1221,7 +1228,6 @@ private:
     static std::unique_ptr<IRadioBackend> makeBackend(const QString& family);
     void handRestoredStateToBackend(const QString& serial);  // RFC #4603
     void persistOperatingState(bool force = false);          // RFC #4603 PR 3
-    void flushPendingOperatingState();                       // RFC #4603 PR 3
 
     // aetherd Gap B: build/destroy the backend for a radio family. The backend
     // follows the radio the operator picks in the connection manager, so these

--- a/tests/app_settings_safety_test.cpp
+++ b/tests/app_settings_safety_test.cpp
@@ -579,28 +579,56 @@ void testThreeDSliceDepthDefaultAndOptIn()
 // in-memory map (the original XML-era bug this scenario was born from).
 void testNicknameKeySurvivesDisk()
 {
+    const QString family = QStringLiteral("hl2");
     const QString serial = QStringLiteral("AA:BB:CC:DD:EE:FF");
-    const QString key = hl2::Hl2Discovery::nicknameSettingsKey(serial);
 
     AppSettings& settings = AppSettings::instance();
     settings.load();
-    settings.setValue(key, QStringLiteral("Pat's Hermes"));
-    settings.save();
 
-    QString stored;
-    expect(dbRow(key, stored) && stored == QStringLiteral("Pat's Hermes"),
-           "the nickname is actually written to the settings database");
+    // New-world storage: the (family, MAC, Identity) feature document, where
+    // the raw MAC is a legal identity (RFC #4603 PR 3).
+    hl2::Hl2Discovery::setNickname(family, serial, QStringLiteral("Pat's Hermes"));
+    expect(settings.radioFeature(family, serial, QStringLiteral("Identity"))
+                   .value(QStringLiteral("nickname"))
+                   .toString()
+               == QStringLiteral("Pat's Hermes"),
+           "the nickname is stored in the scoped Identity document");
 
     // Re-read from disk the way a fresh launch does: the name must come back.
     settings.reset();
     settings.load();
-    expect(hl2::Hl2Discovery::effectiveNickname(serial, QStringLiteral("Hermes-Lite 2"))
+    expect(hl2::Hl2Discovery::effectiveNickname(family, serial,
+                                                QStringLiteral("Hermes-Lite 2"))
                == QStringLiteral("Pat's Hermes"),
            "a nickname set in a previous session survives restart");
 
-    expect(hl2::Hl2Discovery::nicknameSettingsKey(QStringLiteral("AA:BB:CC:DD:EE:00"))
-               != key,
-           "two different MACs still map to two different keys");
+    // Legacy migration: a pre-#4603 sanitized flat key is adopted into the
+    // document on first read and the flat key is removed.
+    const QString legacySerial = QStringLiteral("AA:BB:CC:DD:EE:00");
+    const QString legacyKey = hl2::Hl2Discovery::nicknameSettingsKey(legacySerial);
+    settings.setValue(legacyKey, QStringLiteral("Legacy Hermes"));
+    settings.save();
+    expect(hl2::Hl2Discovery::effectiveNickname(family, legacySerial, QString())
+               == QStringLiteral("Legacy Hermes"),
+           "a legacy flat-key nickname is still honored");
+    expect(!settings.contains(legacyKey),
+           "the legacy flat key is removed after the one-shot migration");
+    expect(settings.radioFeature(family, legacySerial, QStringLiteral("Identity"))
+                   .value(QStringLiteral("nickname"))
+                   .toString()
+               == QStringLiteral("Legacy Hermes"),
+           "the migrated nickname lives in the scoped document");
+
+    expect(hl2::Hl2Discovery::effectiveNickname(family, serial, QString())
+               != hl2::Hl2Discovery::effectiveNickname(family, legacySerial,
+                                                       QString()),
+           "two different MACs keep two different nicknames");
+
+    // Clearing removes both homes.
+    hl2::Hl2Discovery::setNickname(family, serial, QString());
+    expect(hl2::Hl2Discovery::effectiveNickname(family, serial, QString())
+               .isEmpty(),
+           "a cleared nickname stays cleared");
 }
 
 } // namespace

--- a/tests/hl2_state_restore_test.cpp
+++ b/tests/hl2_state_restore_test.cpp
@@ -150,6 +150,117 @@ int main(int argc, char** argv)
         backend.disconnectRadio();
     }
 
+    // ---- unvisited band: baseline default, never inheritance --------------
+    // (PR #4619 review, bot + Ozy311): set 40 on 20m (bootstraps the
+    // baseline), raise 20m to 90, hop to never-visited 40m — the drive must
+    // be the 40 baseline, NOT the 90 that happened to be live.
+    {
+        hl2::Hl2Backend backend;
+        backend.applyRestoredState(RestoredRadioState{});   // no memory
+        RadioConnectRequest req;
+        req.host = QStringLiteral("192.0.2.1");
+        req.port = 1024;
+        req.serial = QStringLiteral("AA:BB:CC:DD:EE:FF");
+        backend.connectRadio(req);
+
+        backend.setSliceFrequency(0, 14'074'000.0);   // 20m
+        backend.setTxPower(40);                       // bootstraps baseline 40
+        backend.setTxPower(90);                       // 20m's own value
+        backend.setSliceFrequency(0, 7'074'000.0);    // hop to unvisited 40m
+
+        const RestoredRadioState snap = backend.currentOperatingState();
+        const QJsonObject drive =
+            snap.extension.value(QStringLiteral("txSetpoints"))
+                .toObject()
+                .value(QStringLiteral("driveByBand"))
+                .toObject();
+        check(drive.value(QStringLiteral("40m")).toInt() == 40,
+              "an unvisited band gets the operator's baseline, not the "
+              "previous band's live drive");
+        check(drive.value(QStringLiteral("20m")).toInt() == 90,
+              "the previous band keeps its own remembered drive");
+        backend.disconnectRadio();
+    }
+
+    // ---- a truly baseline-less first hop is conservative ------------------
+    {
+        hl2::Hl2Backend backend;
+        backend.applyRestoredState(RestoredRadioState{});
+        RadioConnectRequest req;
+        req.host = QStringLiteral("192.0.2.1");
+        req.port = 1024;
+        req.serial = QStringLiteral("AA:BB:CC:DD:EE:FF");
+        backend.connectRadio(req);
+        // No setTxPower yet — no baseline. Hop off the start band.
+        backend.setSliceFrequency(0, 7'074'000.0);
+        const QJsonObject drive =
+            backend.currentOperatingState()
+                .extension.value(QStringLiteral("txSetpoints"))
+                .toObject()
+                .value(QStringLiteral("driveByBand"))
+                .toObject();
+        check(drive.value(QStringLiteral("40m")).toInt() == 0,
+              "with no baseline at all, a first band visit sets drive 0 — "
+              "conservative once, never hot by inheritance");
+        backend.disconnectRadio();
+    }
+
+    // ---- radio swap: an empty restore is a full reset ---------------------
+    // (PR #4619 review, Ozy311 finding 1): same backend instance, radio A
+    // with maps, then applyRestoredState({}) for radio B — nothing of A may
+    // survive, including the LIVE members.
+    {
+        hl2::Hl2Backend backend;
+        RestoredRadioState radioA;
+        radioA.rfFrequencyHz = 7'074'000.0;
+        radioA.sampleRateHz = 192'000;
+        radioA.extensionSchemaVersion = 1;
+        radioA.extension = QJsonObject{
+            {QStringLiteral("rfGain"),
+             QJsonObject{{QStringLiteral("defaultDb"), 6},
+                         {QStringLiteral("lnaDbByBand"),
+                          QJsonObject{{QStringLiteral("40m"), 3}}}}},
+            {QStringLiteral("txSetpoints"),
+             QJsonObject{{QStringLiteral("defaultPercent"), 25},
+                         {QStringLiteral("driveByBand"),
+                          QJsonObject{{QStringLiteral("40m"), 25}}}}}};
+        backend.applyRestoredState(radioA);
+
+        backend.applyRestoredState(RestoredRadioState{});   // radio B: no memory
+        const RestoredRadioState snap = backend.currentOperatingState();
+        const QJsonObject rfGain =
+            snap.extension.value(QStringLiteral("rfGain")).toObject();
+        check(rfGain.value(QStringLiteral("lnaDbByBand"))
+                      .toObject()
+                      .isEmpty(),
+              "radio A's per-band LNA map does not survive the swap");
+        check(rfGain.value(QStringLiteral("defaultDb")).toInt() == 20,
+              "the LNA default resets to the virgin construction value");
+        check(!snap.extension.value(QStringLiteral("txSetpoints"))
+                       .toObject()
+                       .contains(QStringLiteral("defaultPercent")),
+              "radio A's drive baseline does not survive the swap");
+        check(snap.sampleRateHz != 192'000 || snap.sampleRateHz == 48'000,
+              "radio A's restored rate does not leak into radio B's snapshot");
+    }
+
+    // ---- a corrupt mode string is dropped at the boundary -----------------
+    // (PR #4619 review, Ozy311 finding 5)
+    {
+        hl2::Hl2Backend backend;
+        RestoredRadioState corrupt;
+        corrupt.mode = QStringLiteral("QRM");   // <= 8 chars, but not a mode
+        backend.applyRestoredState(corrupt);
+        check(backend.currentOperatingState().mode
+                  != QStringLiteral("QRM"),
+              "a plausible-length garbage mode never reaches Receiver::mode");
+        RestoredRadioState genuine;
+        genuine.mode = QStringLiteral("cw");    // case-insensitive, real
+        backend.applyRestoredState(genuine);
+        // (Applied at pushInitialState on hardware; boundary acceptance is
+        // what's provable here: it survived validation into the stash.)
+    }
+
     // ---- an explicit param still beats restored state ---------------------
     {
         hl2::Hl2Backend backend;

--- a/tests/hl2_state_restore_test.cpp
+++ b/tests/hl2_state_restore_test.cpp
@@ -1,0 +1,172 @@
+// HL2 state restore/capture (RFC #4603 PR 3) — the parts provable without
+// hardware: the band-key table, applyRestoredState's validation boundary
+// (Principle VII), the restored-rate/LNA seeding through connectRadio, and
+// the capture snapshot (currentOperatingState) round-trip including per-band
+// maps. The live link paths (pushInitialState's #4484 reconciliation, band
+// hops applying remembered drive on a keyed-up radio) are the bench half —
+// validated on real HL2 + Radioberry hardware (nigelfenton, PR #4614 thread).
+#include "TestSettingsProfile.h"
+#include "core/AppSettings.h"
+#include "core/backends/hl2/Hl2Backend.h"
+#include "core/backends/hl2/Hl2Bands.h"
+
+#include <QCoreApplication>
+#include <QJsonObject>
+
+#include <iostream>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* label)
+{
+    std::cout << (condition ? "[ OK ] " : "[FAIL] ") << label << '\n';
+    if (!condition) {
+        ++g_failures;
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile profile(QStringLiteral("aether-hl2-state-restore-test"));
+    if (!profile.isValid()) {
+        std::cerr << "[FAIL] create temporary home\n";
+        return 1;
+    }
+    QCoreApplication app(argc, argv);
+    AppSettings::instance().load();
+
+    // ---- the band-key table is total and stable ---------------------------
+    check(hl2::bandKeyForHz(1'840'000.0) == QStringLiteral("160m"),
+          "1.84 MHz maps to 160m");
+    check(hl2::bandKeyForHz(3'573'000.0) == QStringLiteral("80m"),
+          "3.573 MHz maps to 80m");
+    check(hl2::bandKeyForHz(7'074'000.0) == QStringLiteral("40m"),
+          "7.074 MHz maps to 40m");
+    check(hl2::bandKeyForHz(14'074'000.0) == QStringLiteral("20m"),
+          "14.074 MHz maps to 20m");
+    check(hl2::bandKeyForHz(28'074'000.0) == QStringLiteral("10m"),
+          "28.074 MHz maps to 10m");
+    check(hl2::bandKeyForHz(5'000'000.0) == QStringLiteral("60m"),
+          "an in-gap frequency lands in its neighborhood's bucket (WWV -> 60m)");
+    check(!hl2::bandKeyForHz(100'000.0).isEmpty()
+              && !hl2::bandKeyForHz(38'400'000.0).isEmpty(),
+          "both extremes of the HL2 tuning range map to a key");
+
+    // ---- applyRestoredState is a validation boundary ----------------------
+    {
+        hl2::Hl2Backend backend;
+        RestoredRadioState bogus;
+        bogus.rfFrequencyHz = 99'000'000.0;             // outside 0.1..38.4 MHz
+        bogus.mode = QStringLiteral("NOT-A-REAL-MODE-STRING");  // too long
+        bogus.filterLowHz = 5'000.0;                    // low >= high
+        bogus.filterHighHz = 100.0;
+        bogus.sampleRateHz = 12'345;                    // snapped, not rejected
+        bogus.extensionSchemaVersion = 1;
+        bogus.extension = QJsonObject{
+            {QStringLiteral("rfGain"),
+             QJsonObject{{QStringLiteral("defaultDb"), 999},
+                         {QStringLiteral("lnaDbByBand"),
+                          QJsonObject{{QStringLiteral("40m"), -999}}}}},
+            {QStringLiteral("txSetpoints"),
+             QJsonObject{{QStringLiteral("defaultPercent"), 500},
+                         {QStringLiteral("driveByBand"),
+                          QJsonObject{{QStringLiteral("40m"), -5}}}}}};
+        backend.applyRestoredState(bogus);
+
+        const RestoredRadioState snapshot = backend.currentOperatingState();
+        // The bogus frequency was dropped, so the default stands; the maps
+        // were clamped to hardware limits rather than trusted.
+        check(snapshot.rfFrequencyHz != 99'000'000.0,
+              "an out-of-range restored frequency is dropped");
+        const QJsonObject rfGain =
+            snapshot.extension.value(QStringLiteral("rfGain")).toObject();
+        check(rfGain.value(QStringLiteral("defaultDb")).toInt() <= 48,
+              "a restored LNA default clamps to the AD9866's range");
+        check(rfGain.value(QStringLiteral("lnaDbByBand"))
+                      .toObject()
+                      .value(QStringLiteral("40m"))
+                      .toInt()
+                  >= -12,
+              "a restored per-band LNA clamps to the AD9866's range");
+        const QJsonObject tx =
+            snapshot.extension.value(QStringLiteral("txSetpoints")).toObject();
+        check(tx.value(QStringLiteral("defaultPercent")).toInt() <= 100,
+              "a restored drive default clamps to 0..100");
+        check(tx.value(QStringLiteral("driveByBand"))
+                      .toObject()
+                      .value(QStringLiteral("40m"))
+                      .toInt()
+                  >= 0,
+              "a restored per-band drive clamps to 0..100");
+    }
+
+    // ---- restored state seeds the session at connect ----------------------
+    {
+        hl2::Hl2Backend backend;
+        RestoredRadioState remembered;
+        remembered.rfFrequencyHz = 14'074'000.0;
+        remembered.mode = QStringLiteral("USB");
+        remembered.sampleRateHz = 192'000;
+        remembered.extensionSchemaVersion = 1;
+        remembered.extension = QJsonObject{
+            {QStringLiteral("rfGain"),
+             QJsonObject{{QStringLiteral("defaultDb"), 12},
+                         {QStringLiteral("lnaDbByBand"),
+                          QJsonObject{{QStringLiteral("20m"), 6}}}}},
+            {QStringLiteral("txSetpoints"),
+             QJsonObject{{QStringLiteral("driveByBand"),
+                          QJsonObject{{QStringLiteral("20m"), 35}}}}}};
+        backend.applyRestoredState(remembered);
+
+        // Unroutable target: connectRadio() seeds every pre-link member
+        // synchronously before any network I/O succeeds.
+        RadioConnectRequest req;
+        req.host = QStringLiteral("192.0.2.1");   // TEST-NET-1, never routable
+        req.port = 1024;
+        req.serial = QStringLiteral("AA:BB:CC:DD:EE:FF");
+        backend.connectRadio(req);
+
+        const RestoredRadioState snapshot = backend.currentOperatingState();
+        check(snapshot.sampleRateHz == 192'000,
+              "the restored sample rate seeds the session");
+        check(snapshot.rfFrequencyHz == 14'074'000.0,
+              "the restored frequency seeds the session");
+        // The 20m band's remembered LNA (6 dB) is the session's live gain —
+        // visible as the current band's entry in the capture snapshot.
+        check(snapshot.extension.value(QStringLiteral("rfGain"))
+                      .toObject()
+                      .value(QStringLiteral("lnaDbByBand"))
+                      .toObject()
+                      .value(QStringLiteral("20m"))
+                      .toInt()
+                  == 6,
+              "the start band's remembered LNA is applied at connect");
+        backend.disconnectRadio();
+    }
+
+    // ---- an explicit param still beats restored state ---------------------
+    {
+        hl2::Hl2Backend backend;
+        RestoredRadioState remembered;
+        remembered.sampleRateHz = 192'000;
+        backend.applyRestoredState(remembered);
+
+        RadioConnectRequest req;
+        req.host = QStringLiteral("192.0.2.1");
+        req.port = 1024;
+        req.serial = QStringLiteral("AA:BB:CC:DD:EE:FF");
+        req.params.insert(QStringLiteral("sampleRateHz"), 48'000);
+        backend.connectRadio(req);
+        check(backend.currentOperatingState().sampleRateHz == 48'000,
+              "an explicit automation/test param outranks restored state");
+        backend.disconnectRadio();
+    }
+
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/hl2_state_restore_test.cpp
+++ b/tests/hl2_state_restore_test.cpp
@@ -240,8 +240,9 @@ int main(int argc, char** argv)
                        .toObject()
                        .contains(QStringLiteral("defaultPercent")),
               "radio A's drive baseline does not survive the swap");
-        check(snap.sampleRateHz != 192'000 || snap.sampleRateHz == 48'000,
-              "radio A's restored rate does not leak into radio B's snapshot");
+        check(snap.sampleRateHz == 48'000,
+              "radio A's restored rate resets to the construction default — "
+              "radio B never inherits A's span (PR #4619 review)");
     }
 
     // ---- a corrupt mode string is dropped at the boundary -----------------
@@ -259,6 +260,90 @@ int main(int argc, char** argv)
         backend.applyRestoredState(genuine);
         // (Applied at pushInitialState on hardware; boundary acceptance is
         // what's provable here: it survived validation into the stash.)
+    }
+
+    // ---- the connect-time power push is an echo, not an overwrite ---------
+    // (PR #4619 bench, nigelfenton; Ozy311 finding 1): connectRadio seeds the
+    // drive from the start band's memory and echoes it upward, so
+    // RadioModel's connect push arrives value-identical — and setTxPower's
+    // change-gate declines to record it. The stored map must survive.
+    {
+        hl2::Hl2Backend backend;
+        RestoredRadioState remembered;
+        remembered.rfFrequencyHz = 7'100'000.0;   // 40m
+        remembered.extensionSchemaVersion = 1;
+        remembered.extension = QJsonObject{
+            {QStringLiteral("txSetpoints"),
+             QJsonObject{{QStringLiteral("defaultPercent"), 100},
+                         {QStringLiteral("driveByBand"),
+                          QJsonObject{{QStringLiteral("40m"), 12}}}}}};
+        backend.applyRestoredState(remembered);
+
+        RadioConnectRequest req;
+        req.host = QStringLiteral("192.0.2.1");
+        req.port = 1024;
+        req.serial = QStringLiteral("00:1C:C0:A2:13:DD");
+        backend.connectRadio(req);
+
+        // The seed itself: the snapshot's current-band stamp is 12, and the
+        // upward echo carried it (TransmitModel gets seeded pre-push).
+        check(backend.currentOperatingState()
+                      .extension.value(QStringLiteral("txSetpoints"))
+                      .toObject()
+                      .value(QStringLiteral("driveByBand"))
+                      .toObject()
+                      .value(QStringLiteral("40m"))
+                      .toInt()
+                  == 12,
+              "connect seeds the drive from the start band's memory");
+
+        // RadioModel's push, replayed exactly: same value, operator path.
+        backend.setTxPower(12);
+        const QJsonObject after =
+            backend.currentOperatingState()
+                .extension.value(QStringLiteral("txSetpoints"))
+                .toObject();
+        check(after.value(QStringLiteral("driveByBand"))
+                      .toObject()
+                      .value(QStringLiteral("40m"))
+                      .toInt()
+                  == 12,
+              "the value-identical connect push does not overwrite the map");
+        check(after.value(QStringLiteral("defaultPercent")).toInt() == 100,
+              "the echo does not re-bootstrap the baseline");
+
+        // A REAL operator change still records.
+        backend.setTxPower(25);
+        check(backend.currentOperatingState()
+                      .extension.value(QStringLiteral("txSetpoints"))
+                      .toObject()
+                      .value(QStringLiteral("driveByBand"))
+                      .toObject()
+                      .value(QStringLiteral("40m"))
+                      .toInt()
+                  == 25,
+              "a genuine operator change still records into the band");
+        backend.disconnectRadio();
+    }
+
+    // ---- a virgin connect echo never claims the baseline ------------------
+    // (Ozy311: the model-default push at 100 made the 'deliberate 0' for
+    // unvisited bands unreachable in the real app.)
+    {
+        hl2::Hl2Backend backend;
+        backend.applyRestoredState(RestoredRadioState{});
+        RadioConnectRequest req;
+        req.host = QStringLiteral("192.0.2.1");
+        req.port = 1024;
+        req.serial = QStringLiteral("AA:BB:CC:DD:EE:FF");
+        backend.connectRadio(req);
+        backend.setTxPower(100);   // the model-default connect push, verbatim
+        check(!backend.currentOperatingState()
+                   .extension.value(QStringLiteral("txSetpoints"))
+                   .toObject()
+                   .contains(QStringLiteral("defaultPercent")),
+              "a virgin connect's default-100 push never claims the baseline");
+        backend.disconnectRadio();
     }
 
     // ---- an explicit param still beats restored state ---------------------


### PR DESCRIPTION
PR 3 of the settings-store RFC (#4603): **the HL2 gets a memory.** Per-MAC operating-state restore + capture, with per-band TX drive / LNA maps. **Stacked on #4614** (base branch is `feat/settings-scoped-store`; do not merge before it — this PR retargets to `main` and rebases once #4614 lands).

## What an HL2 operator gets

Turn the radio on, and it's where you left it: frequency, mode, passband, span/sample-rate — per radio, keyed by MAC, so two HL2s (or an HL2 and a Radioberry) keep independent state. And the per-band half from nigelfenton's RFC review: **TX drive and LNA gain are remembered per band** — the drive that makes 5 W on 80 m no longer follows you to 10 m, on restore *or* on a live band change (per-band power memory).

## How

**Restore** — `Hl2Backend::applyRestoredState()` is the validation boundary (Principle VII): frequency range-checked against the AD9866's 0.1–38.4 MHz span, rate snapped to a real IQ rate, per-band values clamped to hardware limits (LNA −12…+48 dB, drive 0–100), anything invalid dropped rather than "fixed up". `connectRadio()` seeds the session with a deliberate precedence chain: legacy family-wide span (`Hl2Settings`) → restored per-radio state → explicit automation/test params. The start band's remembered LNA is live before the first sample.

**The #4484 reconciliation** (Ozy311's PR 2 catch, promoted from landmine to design): `pushInitialState()` applies restored mode+passband **as a pair** inside the existing once-per-connect guard — a restored mode re-derives its passband first, then a restored passband applies on top, so mode and passband can never disagree (the invariant #4484 exists for), and an EP6 glitch's re-linkUp can never re-assert stale state over the operator's live edits. The start band's remembered drive is applied there too — after RadioModel's connect-time power push, echoed upward as a `TransmitDelta` so the UI slider agrees with the drive register.

**Restore never keys TX** (Principle VI): everything restored is a setpoint; `applyDrive()` stays behind the existing TX gate, so a transmit-blocked session records values without touching the PA.

**Per-band memory** — maps live in the extension document's domain sub-objects (`ext.rfGain.lnaDbByBand`, `ext.txSetpoints.driveByBand`) exactly as PR 2's gate expects, keyed by a fixed frequency→band table (`Hl2Bands.h`). Deliberately **not** `BandPlanManager`: these are persistence keys and must be stable across releases, regions, and the operator's band-plan choice; the table is total over the HL2's tuning range so every frequency buckets deterministically. Band transitions follow the **transmit-owning slice** (drive and LNA are radio-wide hardware — a second receiver browsing 40 m must not drag the transmitter's setpoints around): leaving a band records its values, entering one applies what it remembered, falling back to restored defaults.

**Capture** — a new seam signal `IRadioBackend::operatingStateChanged()` + `currentOperatingState()`; `Hl2Backend` emits from every state setter (tune / mode / filter / rate / gain / drive), and `RadioModel` debounces to **one `RadioStateMemory::store` per 2 s burst**, gated by `shouldEngage()`. Flex and Sim never emit and never store — the capability-shaped inertness from PR 2, now with a live counterparty.

**Nickname migration** (the RFC checklist item): client-side nicknames move to the `(family, MAC, "Identity")` feature document — where a raw MAC is a legal identity at last — via new `Hl2Discovery::setNickname()/effectiveNickname()/hasCustomNickname()` helpers with a one-shot legacy flat-key adoption. `ConnectionPanel` and `RadioSetupDialog` route through them; the family parameter keeps sim (and future non-Flex families) scoped correctly instead of inheriting HL2's bucket.

## Testing

- New `tests/hl2_state_restore_test.cpp` — the no-hardware half: band-table totality and mapping, the validation boundary (out-of-range frequency dropped, maps clamped), restored rate/frequency/LNA seeding through a real `connectRadio()` against TEST-NET-1, and explicit-param precedence over restored state.
- The `nickname-key-roundtrip` safety scenario rewritten for the scoped store: document storage, restart survival, one-shot legacy migration (flat key removed), two-MAC independence, clear-stays-cleared.
- Full suite green on the stacked head (#4559 pre-existing); engine-boundary `--strict` clean.

## The hardware gate

The live-link half — restore on a powered radio, band-hop drive behavior under key, the #4484 reconciliation on real EP6 traffic — is exactly what @nigelfenton's HL2 + Radioberry bench offer covers, and **bench validation should gate this PR's merge**. Suggested checklist: restore-on-connect lands on the remembered frequency/mode/passband/span; LNA and drive come up per-band; a band hop applies the target band's stored drive before any TX is possible; a first hop into a never-visited band comes up at the operator's baseline (or a deliberate 0 when none exists yet) — never the previous band's drive; an EP6 dropout + resume does not re-assert stale state; two radios on the bench keep independent documents; and **connect a second, never-before-seen radio *after* a radio with saved state** (Ozy311's review addition — the swap-reset case).

## Reviewer notes

- Reviewable surface: `Hl2Backend.{h,cpp}` (restore/capture/per-band), `Hl2Bands.h`, `Hl2Discovery.{h,cpp}` (nickname scoping), `IRadioBackend.h` (capture seam), `RadioModel` (debounced store), the two test files.
- `hl2_state_restore_test` runs ~73 s — same order as the existing `hl2_backend_test` (81 s); HL2 backend teardown timeouts dominate, not the assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
