### PR TITLE
feat(settings): BandStack fold-in — per-radio feature documents, write-through, lazy legacy claim (RFC #4603, PR 4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4270,6 +4270,15 @@ target_link_libraries(hl2_state_restore_test PRIVATE aethercore Qt6::Core Qt6::T
 set_target_properties(hl2_state_restore_test PROPERTIES AUTOMOC ON)
 add_test(NAME hl2_state_restore_test COMMAND hl2_state_restore_test)
 
+# BandStack fold-in (RFC #4603 PR 4): per-radio feature documents,
+# write-through mutations, lazy per-radio legacy import with side-file
+# retirement, panel prefs in AppSettings.
+add_executable(bandstack_scoped_test tests/bandstack_scoped_test.cpp)
+target_include_directories(bandstack_scoped_test PRIVATE src tests)
+target_link_libraries(bandstack_scoped_test PRIVATE aethercore Qt6::Core Qt6::Test)
+set_target_properties(bandstack_scoped_test PROPERTIES AUTOMOC ON)
+add_test(NAME bandstack_scoped_test COMMAND bandstack_scoped_test)
+
 # TCI signaling on a backend with neither a Flex command plane nor a DAX data
 # plane (HL2) — the seam WSJT-X rides. Links WebSockets so the TciServer half of
 # the file compiles wherever HAVE_WEBSOCKETS is set for aethercore.

--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -1109,7 +1109,9 @@ bool AppSettings::setRadioFeature(const QString& family, const QString& radioId,
         }
     }
     if (!m_db || !m_db->isOpen()) {
-        return false;   // reset() may have closed the store (PR #4614 review)
+        qWarning() << "AppSettings: radio feature write refused — the store is"
+                      " closed (reset in progress?)";
+        return false;
     }
     const QString value = QString::fromUtf8(
         QJsonDocument(doc).toJson(QJsonDocument::Compact));

--- a/src/core/BandStackSettings.cpp
+++ b/src/core/BandStackSettings.cpp
@@ -320,7 +320,13 @@ void BandStackSettings::load()
                               QString::number(legacy.autoSaveDwellSeconds));
         }
     }
-    settings.setValue(kPrefsMigratedKey, QStringLiteral("True"));
+    // Stamp only when the migration actually happened (file parsed) or there
+    // is genuinely nothing to migrate — a transiently unreadable side file
+    // must retry next launch, matching ensureScopeMigrated()'s behavior for
+    // the entries in the very same file (PR #4621 review, Ozy311).
+    if (legacy.parsed || !QFile::exists(m_legacyFilePath)) {
+        settings.setValue(kPrefsMigratedKey, QStringLiteral("True"));
+    }
     settings.save();
 }
 
@@ -333,29 +339,36 @@ void BandStackSettings::ensureScopeMigrated(const RadioSettingsScope& scope)
     if (m_scopesChecked.contains(memo)) {
         return;
     }
-    m_scopesChecked.insert(memo);
 
-    // Already migrated (or born scoped): the document exists.
+    // Already migrated (or born scoped): the document exists. This includes a
+    // stack the operator deliberately EMPTIED — {"entries": []} is a present
+    // document, distinguishable from an absent row, and it must block
+    // re-import (no bookmark resurrection from a restored side file).
     if (!scope.featureExact(featureName()).isEmpty()) {
+        m_scopesChecked.insert(memo);
         return;
     }
+    // NO memo when there is nothing to claim yet: a side file restored from a
+    // backup mid-session must still be claimable on this radio's next access
+    // (PR #4621 review, Ozy311).
     if (!QFile::exists(m_legacyFilePath)) {
         return;
     }
     const LegacyFile legacy = parseLegacyFile(m_legacyFilePath);
     if (!legacy.parsed) {
-        return;   // unreadable legacy file: leave it for inspection
+        return;   // unreadable legacy file: leave it, retry next access
     }
     const QString section = sanitizeSerial(scope.radioId());
     if (!legacy.sections.contains(section)) {
+        m_scopesChecked.insert(memo);
         return;
     }
     if (!writeEntries(scope, legacy.sections.value(section))) {
         // The claim failed (read-only store?): leave the legacy section in
-        // place so a later launch can retry.
-        m_scopesChecked.remove(memo);
+        // place so a later access can retry.
         return;
     }
+    m_scopesChecked.insert(memo);
     rewriteLegacyWithout(m_legacyFilePath, legacy, section);
     qDebug() << "BandStackSettings: migrated" << legacy.sections.value(section).size()
              << "bookmarks for" << scope.family() << scope.radioId()
@@ -365,6 +378,13 @@ void BandStackSettings::ensureScopeMigrated(const RadioSettingsScope& scope)
 QVector<BandStackEntry> BandStackSettings::readEntries(const RadioSettingsScope& scope)
 {
     QVector<BandStackEntry> out;
+    // The class already decided an empty radioId is not a BandStack target
+    // (ensureScopeMigrated guards it); the readers/writers must agree, or a
+    // mutation landing before the serial is known would write one radio's
+    // bookmarks as the FAMILY-WIDE default row (PR #4621 review, Ozy311).
+    if (!scope.isValid() || scope.radioId().isEmpty()) {
+        return out;
+    }
     const QJsonArray array =
         scope.featureExact(featureName()).value(QStringLiteral("entries")).toArray();
     out.reserve(array.size());
@@ -377,6 +397,11 @@ QVector<BandStackEntry> BandStackSettings::readEntries(const RadioSettingsScope&
 bool BandStackSettings::writeEntries(const RadioSettingsScope& scope,
                                      const QVector<BandStackEntry>& entries)
 {
+    if (!scope.isValid() || scope.radioId().isEmpty()) {
+        qWarning() << "BandStackSettings: refusing a bookmark write without a"
+                      " radio identity (would create a family-wide row)";
+        return false;
+    }
     QJsonArray array;
     for (const BandStackEntry& e : entries) {
         array.append(entryToJson(e));
@@ -397,7 +422,14 @@ void BandStackSettings::addEntry(const RadioSettingsScope& scope,
     ensureScopeMigrated(scope);
     QVector<BandStackEntry> all = readEntries(scope);
     all.append(entry);
-    writeEntries(scope, all);
+    if (!writeEntries(scope, all)) {
+        // The write-through IS the durability story — a refused write must be
+        // loud, not a bookmark that silently repaints as absent on the next
+        // panel reload (PR #4621 review, Ozy311).
+        qWarning() << "BandStackSettings: bookmark add did NOT persist for"
+                   << scope.family() << scope.radioId()
+                   << "— the settings store refused the write";
+    }
 }
 
 void BandStackSettings::removeEntry(const RadioSettingsScope& scope, int index)
@@ -408,13 +440,19 @@ void BandStackSettings::removeEntry(const RadioSettingsScope& scope, int index)
         return;
     }
     all.removeAt(index);
-    writeEntries(scope, all);
+    if (!writeEntries(scope, all)) {
+        qWarning() << "BandStackSettings: bookmark removal did NOT persist for"
+                   << scope.family() << scope.radioId();
+    }
 }
 
 void BandStackSettings::clearAllEntries(const RadioSettingsScope& scope)
 {
     ensureScopeMigrated(scope);
-    writeEntries(scope, {});
+    if (!writeEntries(scope, {})) {
+        qWarning() << "BandStackSettings: bookmark clear did NOT persist for"
+                   << scope.family() << scope.radioId();
+    }
 }
 
 void BandStackSettings::clearBandEntries(const RadioSettingsScope& scope,
@@ -429,8 +467,9 @@ void BandStackSettings::clearBandEntries(const RadioSettingsScope& scope,
                                         && e.frequencyMhz <= highMhz;
                              }),
               all.end());
-    if (all.size() != before) {
-        writeEntries(scope, all);
+    if (all.size() != before && !writeEntries(scope, all)) {
+        qWarning() << "BandStackSettings: band clear did NOT persist for"
+                   << scope.family() << scope.radioId();
     }
 }
 
@@ -449,8 +488,13 @@ int BandStackSettings::removeExpiredEntries(const RadioSettingsScope& scope,
                              }),
               all.end());
     const int removed = before - all.size();
-    if (removed > 0) {
-        writeEntries(scope, all);
+    if (removed > 0 && !writeEntries(scope, all)) {
+        // The caller acts on this count (MainWindow reloads the panel) — a
+        // prune that did not persist must report 0, or the panel repaints
+        // the expired entries right back (PR #4621 review, Ozy311).
+        qWarning() << "BandStackSettings: expiry prune did NOT persist for"
+                   << scope.family() << scope.radioId();
+        return 0;
     }
     return removed;
 }

--- a/src/core/BandStackSettings.cpp
+++ b/src/core/BandStackSettings.cpp
@@ -1,21 +1,285 @@
 #include "BandStackSettings.h"
 
-#include <QStandardPaths>
-#include <QDir>
-#include <QFile>
-#include <QXmlStreamReader>
-#include <QXmlStreamWriter>
+#include "AppSettings.h"
+#include "SettingsPaths.h"
+
 #include <QDateTime>
 #include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QMap>
+#include <QStandardPaths>
+#include <QXmlStreamReader>
+#include <QXmlStreamWriter>
 
 #include <algorithm>
 
 namespace AetherSDR {
 
+namespace {
+
+// Panel-wide preference keys (AppSettings; the legacy file's header fields).
+const QString kExpiryKey = QStringLiteral("BandStackAutoExpiryMinutes");
+const QString kGroupKey = QStringLiteral("BandStackGroupByBand");
+const QString kDwellKey = QStringLiteral("BandStackAutoSaveDwellSeconds");
+const QString kPrefsMigratedKey = QStringLiteral("BandStackPrefsMigrated");
+
+QJsonObject entryToJson(const BandStackEntry& e)
+{
+    QJsonObject o;
+    o.insert(QStringLiteral("frequencyMhz"), e.frequencyMhz);
+    o.insert(QStringLiteral("mode"), e.mode);
+    o.insert(QStringLiteral("filterLow"), e.filterLow);
+    o.insert(QStringLiteral("filterHigh"), e.filterHigh);
+    o.insert(QStringLiteral("rxAntenna"), e.rxAntenna);
+    o.insert(QStringLiteral("txAntenna"), e.txAntenna);
+    o.insert(QStringLiteral("agcMode"), e.agcMode);
+    o.insert(QStringLiteral("agcThreshold"), e.agcThreshold);
+    o.insert(QStringLiteral("audioGain"), e.audioGain);
+    o.insert(QStringLiteral("nbOn"), e.nbOn);
+    o.insert(QStringLiteral("nbLevel"), e.nbLevel);
+    o.insert(QStringLiteral("nrOn"), e.nrOn);
+    o.insert(QStringLiteral("nrLevel"), e.nrLevel);
+    o.insert(QStringLiteral("wnbOn"), e.wnbOn);
+    o.insert(QStringLiteral("wnbLevel"), e.wnbLevel);
+    if (e.createdAtMs > 0) {
+        o.insert(QStringLiteral("createdAtMs"), static_cast<double>(e.createdAtMs));
+    }
+    if (e.autoSaved) {
+        o.insert(QStringLiteral("autoSaved"), true);
+    }
+    return o;
+}
+
+BandStackEntry entryFromJson(const QJsonObject& o)
+{
+    BandStackEntry e;
+    e.frequencyMhz = o.value(QStringLiteral("frequencyMhz")).toDouble();
+    e.mode = o.value(QStringLiteral("mode")).toString();
+    e.filterLow = o.value(QStringLiteral("filterLow")).toInt();
+    e.filterHigh = o.value(QStringLiteral("filterHigh")).toInt();
+    e.rxAntenna = o.value(QStringLiteral("rxAntenna")).toString();
+    e.txAntenna = o.value(QStringLiteral("txAntenna")).toString();
+    e.agcMode = o.value(QStringLiteral("agcMode")).toString();
+    e.agcThreshold = o.value(QStringLiteral("agcThreshold")).toInt();
+    e.audioGain = o.value(QStringLiteral("audioGain")).toInt(50);
+    e.nbOn = o.value(QStringLiteral("nbOn")).toBool();
+    e.nbLevel = o.value(QStringLiteral("nbLevel")).toInt(50);
+    e.nrOn = o.value(QStringLiteral("nrOn")).toBool();
+    e.nrLevel = o.value(QStringLiteral("nrLevel")).toInt(50);
+    e.wnbOn = o.value(QStringLiteral("wnbOn")).toBool();
+    e.wnbLevel = o.value(QStringLiteral("wnbLevel")).toInt(50);
+    e.createdAtMs =
+        static_cast<qint64>(o.value(QStringLiteral("createdAtMs")).toDouble());
+    e.autoSaved = o.value(QStringLiteral("autoSaved")).toBool();
+    return e;
+}
+
+// The legacy XML side file, parsed whole: header preferences + per-section
+// entry lists. Reader logic preserved verbatim from the XML era so migration
+// reads exactly what that code wrote.
+struct LegacyFile {
+    int autoExpiryMinutes = 0;
+    bool groupByBand = false;
+    int autoSaveDwellSeconds = 0;
+    QMap<QString, QVector<BandStackEntry>> sections;   // Radio_<sanitized> -> entries
+    bool parsed = false;
+};
+
+LegacyFile parseLegacyFile(const QString& path)
+{
+    LegacyFile result;
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        return result;
+    }
+
+    QXmlStreamReader xml(&file);
+    QString currentRadio;
+    BandStackEntry currentEntry;
+    bool inEntry = false;
+
+    while (!xml.atEnd()) {
+        xml.readNext();
+        if (xml.isStartElement()) {
+            const QString name = xml.name().toString();
+            if (name == QLatin1String("BandStack")) {
+                continue;
+            } else if (name == QLatin1String("AutoExpiryMinutes")) {
+                result.autoExpiryMinutes = xml.readElementText().toInt();
+            } else if (name == QLatin1String("GroupByBand")) {
+                result.groupByBand = xml.readElementText() == QLatin1String("True");
+            } else if (name == QLatin1String("AutoSaveDwellSeconds")) {
+                result.autoSaveDwellSeconds = xml.readElementText().toInt();
+            } else if (name.startsWith(QLatin1String("Radio_"))) {
+                currentRadio = name;
+            } else if (name.startsWith(QLatin1String("Entry_"))
+                       && !currentRadio.isEmpty()) {
+                inEntry = true;
+                currentEntry = BandStackEntry{};
+            } else if (inEntry) {
+                const QString text = xml.readElementText();
+                if (name == QLatin1String("FrequencyMhz")) {
+                    currentEntry.frequencyMhz = text.toDouble();
+                } else if (name == QLatin1String("Mode")) {
+                    currentEntry.mode = text;
+                } else if (name == QLatin1String("FilterLow")) {
+                    currentEntry.filterLow = text.toInt();
+                } else if (name == QLatin1String("FilterHigh")) {
+                    currentEntry.filterHigh = text.toInt();
+                } else if (name == QLatin1String("RxAntenna")) {
+                    currentEntry.rxAntenna = text;
+                } else if (name == QLatin1String("TxAntenna")) {
+                    currentEntry.txAntenna = text;
+                } else if (name == QLatin1String("AgcMode")) {
+                    currentEntry.agcMode = text;
+                } else if (name == QLatin1String("AgcThreshold")) {
+                    currentEntry.agcThreshold = text.toInt();
+                } else if (name == QLatin1String("AudioGain")) {
+                    currentEntry.audioGain = text.toInt();
+                } else if (name == QLatin1String("NbOn")) {
+                    currentEntry.nbOn = text == QLatin1String("True");
+                } else if (name == QLatin1String("NbLevel")) {
+                    currentEntry.nbLevel = text.toInt();
+                } else if (name == QLatin1String("NrOn")) {
+                    currentEntry.nrOn = text == QLatin1String("True");
+                } else if (name == QLatin1String("NrLevel")) {
+                    currentEntry.nrLevel = text.toInt();
+                } else if (name == QLatin1String("WnbOn")) {
+                    currentEntry.wnbOn = text == QLatin1String("True");
+                } else if (name == QLatin1String("WnbLevel")) {
+                    currentEntry.wnbLevel = text.toInt();
+                } else if (name == QLatin1String("CreatedAtMs")) {
+                    currentEntry.createdAtMs = text.toLongLong();
+                } else if (name == QLatin1String("AutoSaved")) {
+                    currentEntry.autoSaved = text == QLatin1String("True");
+                }
+            }
+        } else if (xml.isEndElement()) {
+            const QString name = xml.name().toString();
+            if (name.startsWith(QLatin1String("Entry_")) && inEntry) {
+                result.sections[currentRadio].append(currentEntry);
+                inEntry = false;
+            } else if (name.startsWith(QLatin1String("Radio_"))) {
+                currentRadio.clear();
+            }
+        }
+    }
+
+    if (xml.hasError()) {
+        qWarning() << "BandStackSettings: legacy XML parse error:"
+                   << xml.errorString();
+        return result;
+    }
+    result.parsed = true;
+    return result;
+}
+
+// Rewrite the legacy file WITHOUT the claimed section (or delete the file
+// outright when no sections remain). The header preferences are preserved so
+// a downgrade still finds them.
+void rewriteLegacyWithout(const QString& path, const LegacyFile& legacy,
+                          const QString& claimedSection)
+{
+    QMap<QString, QVector<BandStackEntry>> remaining = legacy.sections;
+    remaining.remove(claimedSection);
+
+    if (remaining.isEmpty()) {
+        QFile::remove(path);
+        QFile::remove(path + QStringLiteral(".tmp"));
+        qDebug() << "BandStackSettings: legacy side file retired —"
+                    " every radio section has been migrated";
+        return;
+    }
+
+    const QString tmpPath = path + QStringLiteral(".tmp");
+    QFile file(tmpPath);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qWarning() << "BandStackSettings: cannot rewrite legacy file" << tmpPath;
+        return;
+    }
+    QXmlStreamWriter xml(&file);
+    xml.setAutoFormatting(true);
+    xml.setAutoFormattingIndent(2);
+    xml.writeStartDocument();
+    xml.writeStartElement(QStringLiteral("BandStack"));
+    xml.writeTextElement(QStringLiteral("AutoExpiryMinutes"),
+                         QString::number(legacy.autoExpiryMinutes));
+    xml.writeTextElement(QStringLiteral("GroupByBand"),
+                         legacy.groupByBand ? QStringLiteral("True")
+                                            : QStringLiteral("False"));
+    xml.writeTextElement(QStringLiteral("AutoSaveDwellSeconds"),
+                         QString::number(legacy.autoSaveDwellSeconds));
+    for (auto it = remaining.constBegin(); it != remaining.constEnd(); ++it) {
+        if (it.value().isEmpty()) {
+            continue;
+        }
+        xml.writeStartElement(it.key());
+        for (int i = 0; i < it.value().size(); ++i) {
+            const BandStackEntry& e = it.value().at(i);
+            xml.writeStartElement(QStringLiteral("Entry_%1").arg(i));
+            xml.writeTextElement(QStringLiteral("FrequencyMhz"),
+                                 QString::number(e.frequencyMhz, 'f', 6));
+            xml.writeTextElement(QStringLiteral("Mode"), e.mode);
+            xml.writeTextElement(QStringLiteral("FilterLow"),
+                                 QString::number(e.filterLow));
+            xml.writeTextElement(QStringLiteral("FilterHigh"),
+                                 QString::number(e.filterHigh));
+            xml.writeTextElement(QStringLiteral("RxAntenna"), e.rxAntenna);
+            xml.writeTextElement(QStringLiteral("TxAntenna"), e.txAntenna);
+            xml.writeTextElement(QStringLiteral("AgcMode"), e.agcMode);
+            xml.writeTextElement(QStringLiteral("AgcThreshold"),
+                                 QString::number(e.agcThreshold));
+            xml.writeTextElement(QStringLiteral("AudioGain"),
+                                 QString::number(e.audioGain));
+            xml.writeTextElement(QStringLiteral("NbOn"),
+                                 e.nbOn ? QStringLiteral("True")
+                                        : QStringLiteral("False"));
+            xml.writeTextElement(QStringLiteral("NbLevel"),
+                                 QString::number(e.nbLevel));
+            xml.writeTextElement(QStringLiteral("NrOn"),
+                                 e.nrOn ? QStringLiteral("True")
+                                        : QStringLiteral("False"));
+            xml.writeTextElement(QStringLiteral("NrLevel"),
+                                 QString::number(e.nrLevel));
+            xml.writeTextElement(QStringLiteral("WnbOn"),
+                                 e.wnbOn ? QStringLiteral("True")
+                                         : QStringLiteral("False"));
+            xml.writeTextElement(QStringLiteral("WnbLevel"),
+                                 QString::number(e.wnbLevel));
+            if (e.createdAtMs > 0) {
+                xml.writeTextElement(QStringLiteral("CreatedAtMs"),
+                                     QString::number(e.createdAtMs));
+            }
+            if (e.autoSaved) {
+                xml.writeTextElement(QStringLiteral("AutoSaved"),
+                                     QStringLiteral("True"));
+            }
+            xml.writeEndElement();  // Entry_N
+        }
+        xml.writeEndElement();  // Radio_XXXX
+    }
+    xml.writeEndElement();  // BandStack
+    xml.writeEndDocument();
+    file.close();
+
+    QFile::remove(path);
+    QFile::rename(tmpPath, path);
+}
+
+} // namespace
+
 BandStackSettings::BandStackSettings()
 {
-    m_filePath = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)
-                 + "/AetherSDR/BandStack.settings";
+    // Through SettingsPaths, not raw QStandardPaths: the settings dir has ONE
+    // source of truth (and the AETHER_SETTINGS_DIR test-isolation override
+    // must reach this file too — found by bandstack_scoped_test landing its
+    // fixture in a different directory than this constructor looked in).
+    m_legacyFilePath =
+        SettingsPaths::configDir() + QStringLiteral("/BandStack.settings");
 }
 
 BandStackSettings& BandStackSettings::instance()
@@ -26,223 +290,209 @@ BandStackSettings& BandStackSettings::instance()
 
 QString BandStackSettings::sanitizeSerial(const QString& serial)
 {
-    // XML element names: ^[A-Za-z_][A-Za-z0-9_]*$
+    // XML element names: ^[A-Za-z_][A-Za-z0-9_]*$ — the legacy convention.
     QString s = serial;
-    s.replace('-', '_');
-    s.replace(' ', '_');
-    return "Radio_" + s;
-}
-
-QVector<BandStackEntry> BandStackSettings::entries(const QString& radioSerial) const
-{
-    return m_entries.value(sanitizeSerial(radioSerial));
-}
-
-void BandStackSettings::addEntry(const QString& radioSerial, const BandStackEntry& entry)
-{
-    m_entries[sanitizeSerial(radioSerial)].append(entry);
-}
-
-void BandStackSettings::removeEntry(const QString& radioSerial, int index)
-{
-    QString key = sanitizeSerial(radioSerial);
-    if (!m_entries.contains(key)) return;
-    auto& vec = m_entries[key];
-    if (index >= 0 && index < vec.size()) {
-        vec.removeAt(index);
-    }
-}
-
-void BandStackSettings::clearAllEntries(const QString& radioSerial)
-{
-    QString key = sanitizeSerial(radioSerial);
-    m_entries[key].clear();
-}
-
-void BandStackSettings::clearBandEntries(const QString& radioSerial,
-                                         double lowMhz, double highMhz)
-{
-    QString key = sanitizeSerial(radioSerial);
-    if (!m_entries.contains(key)) return;
-    auto& vec = m_entries[key];
-    vec.erase(std::remove_if(vec.begin(), vec.end(),
-        [lowMhz, highMhz](const BandStackEntry& e) {
-            return e.frequencyMhz >= lowMhz && e.frequencyMhz <= highMhz;
-        }), vec.end());
-}
-
-int BandStackSettings::removeExpiredEntries(const QString& radioSerial,
-                                            qint64 maxAgeMs)
-{
-    QString key = sanitizeSerial(radioSerial);
-    if (!m_entries.contains(key)) return 0;
-    auto& vec = m_entries[key];
-    qint64 now = QDateTime::currentMSecsSinceEpoch();
-    int before = vec.size();
-    vec.erase(std::remove_if(vec.begin(), vec.end(),
-        [now, maxAgeMs](const BandStackEntry& e) {
-            // Legacy entries (createdAtMs == 0) never expire
-            return e.createdAtMs > 0 && (now - e.createdAtMs) > maxAgeMs;
-        }), vec.end());
-    return before - vec.size();
+    s.replace(QLatin1Char('-'), QLatin1Char('_'));
+    s.replace(QLatin1Char(' '), QLatin1Char('_'));
+    return QStringLiteral("Radio_") + s;
 }
 
 void BandStackSettings::load()
 {
-    m_entries.clear();
-
-    QFile file(m_filePath);
-    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        return;  // no file yet — first run
+    // One-shot: the legacy file's panel-wide preferences move to AppSettings.
+    auto& settings = AppSettings::instance();
+    if (settings.value(kPrefsMigratedKey).toString() == QLatin1String("True")) {
+        return;
     }
-
-    QXmlStreamReader xml(&file);
-
-    // Structure: <BandStack> <Radio_XXXX> <Entry_N> <FrequencyMhz>... </Entry_N> </Radio_XXXX> </BandStack>
-    QString currentRadio;
-    BandStackEntry currentEntry;
-    bool inEntry = false;
-
-    while (!xml.atEnd()) {
-        xml.readNext();
-
-        if (xml.isStartElement()) {
-            const QString name = xml.name().toString();
-
-            if (name == "BandStack") {
-                continue;
-            } else if (name == "AutoExpiryMinutes") {
-                m_autoExpiryMinutes = xml.readElementText().toInt();
-            } else if (name == "GroupByBand") {
-                m_groupByBand = xml.readElementText() == "True";
-            } else if (name == "AutoSaveDwellSeconds") {
-                m_autoSaveDwellSeconds = xml.readElementText().toInt();
-            } else if (name.startsWith("Radio_")) {
-                currentRadio = name;
-            } else if (name.startsWith("Entry_") && !currentRadio.isEmpty()) {
-                inEntry = true;
-                currentEntry = BandStackEntry{};
-            } else if (inEntry) {
-                // Read field value
-                QString text = xml.readElementText();
-                if (name == "FrequencyMhz") {
-                    currentEntry.frequencyMhz = text.toDouble();
-                } else if (name == "Mode") {
-                    currentEntry.mode = text;
-                } else if (name == "FilterLow") {
-                    currentEntry.filterLow = text.toInt();
-                } else if (name == "FilterHigh") {
-                    currentEntry.filterHigh = text.toInt();
-                } else if (name == "RxAntenna") {
-                    currentEntry.rxAntenna = text;
-                } else if (name == "TxAntenna") {
-                    currentEntry.txAntenna = text;
-                } else if (name == "AgcMode") {
-                    currentEntry.agcMode = text;
-                } else if (name == "AgcThreshold") {
-                    currentEntry.agcThreshold = text.toInt();
-                } else if (name == "AudioGain") {
-                    currentEntry.audioGain = text.toInt();
-                } else if (name == "NbOn") {
-                    currentEntry.nbOn = text == "True";
-                } else if (name == "NbLevel") {
-                    currentEntry.nbLevel = text.toInt();
-                } else if (name == "NrOn") {
-                    currentEntry.nrOn = text == "True";
-                } else if (name == "NrLevel") {
-                    currentEntry.nrLevel = text.toInt();
-                } else if (name == "WnbOn") {
-                    currentEntry.wnbOn = text == "True";
-                } else if (name == "WnbLevel") {
-                    currentEntry.wnbLevel = text.toInt();
-                } else if (name == "CreatedAtMs") {
-                    currentEntry.createdAtMs = text.toLongLong();
-                } else if (name == "AutoSaved") {
-                    currentEntry.autoSaved = text == "True";
-                }
-            }
-        } else if (xml.isEndElement()) {
-            const QString name = xml.name().toString();
-            if (name.startsWith("Entry_") && inEntry) {
-                m_entries[currentRadio].append(currentEntry);
-                inEntry = false;
-            } else if (name.startsWith("Radio_")) {
-                currentRadio.clear();
-            }
+    const LegacyFile legacy = parseLegacyFile(m_legacyFilePath);
+    if (legacy.parsed) {
+        if (!settings.contains(kExpiryKey)) {
+            settings.setValue(kExpiryKey,
+                              QString::number(legacy.autoExpiryMinutes));
+        }
+        if (!settings.contains(kGroupKey)) {
+            settings.setValue(kGroupKey, legacy.groupByBand
+                                             ? QStringLiteral("True")
+                                             : QStringLiteral("False"));
+        }
+        if (!settings.contains(kDwellKey)) {
+            settings.setValue(kDwellKey,
+                              QString::number(legacy.autoSaveDwellSeconds));
         }
     }
+    settings.setValue(kPrefsMigratedKey, QStringLiteral("True"));
+    settings.save();
+}
 
-    if (xml.hasError()) {
-        qWarning() << "BandStackSettings: XML parse error:" << xml.errorString();
+void BandStackSettings::ensureScopeMigrated(const RadioSettingsScope& scope)
+{
+    if (!scope.isValid() || scope.radioId().isEmpty()) {
+        return;
+    }
+    const QString memo = scope.family() + QLatin1Char('/') + scope.radioId();
+    if (m_scopesChecked.contains(memo)) {
+        return;
+    }
+    m_scopesChecked.insert(memo);
+
+    // Already migrated (or born scoped): the document exists.
+    if (!scope.featureExact(featureName()).isEmpty()) {
+        return;
+    }
+    if (!QFile::exists(m_legacyFilePath)) {
+        return;
+    }
+    const LegacyFile legacy = parseLegacyFile(m_legacyFilePath);
+    if (!legacy.parsed) {
+        return;   // unreadable legacy file: leave it for inspection
+    }
+    const QString section = sanitizeSerial(scope.radioId());
+    if (!legacy.sections.contains(section)) {
+        return;
+    }
+    if (!writeEntries(scope, legacy.sections.value(section))) {
+        // The claim failed (read-only store?): leave the legacy section in
+        // place so a later launch can retry.
+        m_scopesChecked.remove(memo);
+        return;
+    }
+    rewriteLegacyWithout(m_legacyFilePath, legacy, section);
+    qDebug() << "BandStackSettings: migrated" << legacy.sections.value(section).size()
+             << "bookmarks for" << scope.family() << scope.radioId()
+             << "into the scoped store";
+}
+
+QVector<BandStackEntry> BandStackSettings::readEntries(const RadioSettingsScope& scope)
+{
+    QVector<BandStackEntry> out;
+    const QJsonArray array =
+        scope.featureExact(featureName()).value(QStringLiteral("entries")).toArray();
+    out.reserve(array.size());
+    for (const QJsonValue& value : array) {
+        out.append(entryFromJson(value.toObject()));
+    }
+    return out;
+}
+
+bool BandStackSettings::writeEntries(const RadioSettingsScope& scope,
+                                     const QVector<BandStackEntry>& entries)
+{
+    QJsonArray array;
+    for (const BandStackEntry& e : entries) {
+        array.append(entryToJson(e));
+    }
+    return scope.setFeature(featureName(), kSchemaVersion,
+                            QJsonObject{{QStringLiteral("entries"), array}});
+}
+
+QVector<BandStackEntry> BandStackSettings::entries(const RadioSettingsScope& scope)
+{
+    ensureScopeMigrated(scope);
+    return readEntries(scope);
+}
+
+void BandStackSettings::addEntry(const RadioSettingsScope& scope,
+                                 const BandStackEntry& entry)
+{
+    ensureScopeMigrated(scope);
+    QVector<BandStackEntry> all = readEntries(scope);
+    all.append(entry);
+    writeEntries(scope, all);
+}
+
+void BandStackSettings::removeEntry(const RadioSettingsScope& scope, int index)
+{
+    ensureScopeMigrated(scope);
+    QVector<BandStackEntry> all = readEntries(scope);
+    if (index < 0 || index >= all.size()) {
+        return;
+    }
+    all.removeAt(index);
+    writeEntries(scope, all);
+}
+
+void BandStackSettings::clearAllEntries(const RadioSettingsScope& scope)
+{
+    ensureScopeMigrated(scope);
+    writeEntries(scope, {});
+}
+
+void BandStackSettings::clearBandEntries(const RadioSettingsScope& scope,
+                                         double lowMhz, double highMhz)
+{
+    ensureScopeMigrated(scope);
+    QVector<BandStackEntry> all = readEntries(scope);
+    const int before = all.size();
+    all.erase(std::remove_if(all.begin(), all.end(),
+                             [lowMhz, highMhz](const BandStackEntry& e) {
+                                 return e.frequencyMhz >= lowMhz
+                                        && e.frequencyMhz <= highMhz;
+                             }),
+              all.end());
+    if (all.size() != before) {
+        writeEntries(scope, all);
     }
 }
 
-void BandStackSettings::save()
+int BandStackSettings::removeExpiredEntries(const RadioSettingsScope& scope,
+                                            qint64 maxAgeMs)
 {
-    QDir().mkpath(QFileInfo(m_filePath).absolutePath());
-
-    const QString tmpPath = m_filePath + ".tmp";
-    QFile file(tmpPath);
-    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
-        qWarning() << "BandStackSettings: cannot write" << tmpPath;
-        return;
+    ensureScopeMigrated(scope);
+    QVector<BandStackEntry> all = readEntries(scope);
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    const int before = all.size();
+    all.erase(std::remove_if(all.begin(), all.end(),
+                             [now, maxAgeMs](const BandStackEntry& e) {
+                                 // Legacy entries (createdAtMs == 0) never expire.
+                                 return e.createdAtMs > 0
+                                        && (now - e.createdAtMs) > maxAgeMs;
+                             }),
+              all.end());
+    const int removed = before - all.size();
+    if (removed > 0) {
+        writeEntries(scope, all);
     }
+    return removed;
+}
 
-    QXmlStreamWriter xml(&file);
-    xml.setAutoFormatting(true);
-    xml.setAutoFormattingIndent(2);
-    xml.writeStartDocument();
-    xml.writeStartElement("BandStack");
+int BandStackSettings::autoExpiryMinutes() const
+{
+    return AppSettings::instance().value(kExpiryKey, QStringLiteral("0"))
+        .toString()
+        .toInt();
+}
 
-    // Global settings
-    xml.writeTextElement("AutoExpiryMinutes", QString::number(m_autoExpiryMinutes));
-    xml.writeTextElement("GroupByBand", m_groupByBand ? "True" : "False");
-    xml.writeTextElement("AutoSaveDwellSeconds", QString::number(m_autoSaveDwellSeconds));
+void BandStackSettings::setAutoExpiryMinutes(int minutes)
+{
+    AppSettings::instance().setValue(kExpiryKey, QString::number(minutes));
+    AppSettings::instance().save();
+}
 
-    QList<QString> radios = m_entries.keys();
-    std::sort(radios.begin(), radios.end());
+bool BandStackSettings::groupByBand() const
+{
+    return AppSettings::instance().value(kGroupKey, QStringLiteral("False"))
+               .toString()
+           == QLatin1String("True");
+}
 
-    for (const QString& radio : radios) {
-        const auto& vec = m_entries[radio];
-        if (vec.isEmpty()) continue;
+void BandStackSettings::setGroupByBand(bool grouped)
+{
+    AppSettings::instance().setValue(
+        kGroupKey, grouped ? QStringLiteral("True") : QStringLiteral("False"));
+    AppSettings::instance().save();
+}
 
-        xml.writeStartElement(radio);
-        for (int i = 0; i < vec.size(); ++i) {
-            const BandStackEntry& e = vec[i];
-            xml.writeStartElement(QString("Entry_%1").arg(i));
-            xml.writeTextElement("FrequencyMhz", QString::number(e.frequencyMhz, 'f', 6));
-            xml.writeTextElement("Mode", e.mode);
-            xml.writeTextElement("FilterLow", QString::number(e.filterLow));
-            xml.writeTextElement("FilterHigh", QString::number(e.filterHigh));
-            xml.writeTextElement("RxAntenna", e.rxAntenna);
-            xml.writeTextElement("TxAntenna", e.txAntenna);
-            xml.writeTextElement("AgcMode", e.agcMode);
-            xml.writeTextElement("AgcThreshold", QString::number(e.agcThreshold));
-            xml.writeTextElement("AudioGain", QString::number(e.audioGain));
-            xml.writeTextElement("NbOn", e.nbOn ? "True" : "False");
-            xml.writeTextElement("NbLevel", QString::number(e.nbLevel));
-            xml.writeTextElement("NrOn", e.nrOn ? "True" : "False");
-            xml.writeTextElement("NrLevel", QString::number(e.nrLevel));
-            xml.writeTextElement("WnbOn", e.wnbOn ? "True" : "False");
-            xml.writeTextElement("WnbLevel", QString::number(e.wnbLevel));
-            if (e.createdAtMs > 0) {
-                xml.writeTextElement("CreatedAtMs", QString::number(e.createdAtMs));
-            }
-            if (e.autoSaved) {
-                xml.writeTextElement("AutoSaved", "True");
-            }
-            xml.writeEndElement();  // Entry_N
-        }
-        xml.writeEndElement();  // Radio_XXXX
-    }
+int BandStackSettings::autoSaveDwellSeconds() const
+{
+    return AppSettings::instance().value(kDwellKey, QStringLiteral("0"))
+        .toString()
+        .toInt();
+}
 
-    xml.writeEndElement();  // BandStack
-    xml.writeEndDocument();
-    file.close();
-
-    // Atomic rename
-    QFile::remove(m_filePath);
-    QFile::rename(tmpPath, m_filePath);
+void BandStackSettings::setAutoSaveDwellSeconds(int seconds)
+{
+    AppSettings::instance().setValue(kDwellKey, QString::number(seconds));
+    AppSettings::instance().save();
 }
 
 } // namespace AetherSDR

--- a/src/core/BandStackSettings.h
+++ b/src/core/BandStackSettings.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "RadioSettingsScope.h"
+
+#include <QSet>
 #include <QString>
 #include <QVector>
-#include <QMap>
 
 namespace AetherSDR {
 
@@ -26,47 +28,66 @@ struct BandStackEntry {
     bool autoSaved{false};  // true if added by auto-save dwell; false = manual
 };
 
-// Persistence for user frequency bookmarks, stored per-radio in
-// ~/.config/AetherSDR/BandStack.settings (XML, atomic save).
+// User frequency bookmarks, stored per radio as ONE feature document —
+// (family, serial, "BandStack") in radio_settings (RFC #4603 PR 4). Every
+// mutation writes the whole document through immediately (atomic, Principle
+// V), so there is no separate save() step anymore and a crash can't lose a
+// bookmark the operator just made.
+//
+// The legacy side file (~/.config/AetherSDR/BandStack.settings) is imported
+// LAZILY, one radio at a time, on that radio's first access — because the
+// document needs the radio's FAMILY, which only the live scope knows (the
+// legacy file keyed sections by serial alone). A migrated section is removed
+// from the side file; the file itself is deleted when its last radio section
+// has been claimed. Sections for radios that never connect again simply wait
+// there, harmlessly. The three panel-wide preferences move to AppSettings
+// keys (they were never per-radio) via a one-shot in load().
 class BandStackSettings {
 public:
+    static constexpr int kSchemaVersion = 1;
+    static QString featureName() { return QStringLiteral("BandStack"); }
+
     static BandStackSettings& instance();
 
+    // One-shot migration of the legacy file's panel-wide preferences into
+    // AppSettings. Idempotent; call once after AppSettings::load().
     void load();
-    void save();
 
-    QVector<BandStackEntry> entries(const QString& radioSerial) const;
-    void addEntry(const QString& radioSerial, const BandStackEntry& entry);
-    void removeEntry(const QString& radioSerial, int index);
-    void clearAllEntries(const QString& radioSerial);
-    void clearBandEntries(const QString& radioSerial, double lowMhz, double highMhz);
+    QVector<BandStackEntry> entries(const RadioSettingsScope& scope);
+    void addEntry(const RadioSettingsScope& scope, const BandStackEntry& entry);
+    void removeEntry(const RadioSettingsScope& scope, int index);
+    void clearAllEntries(const RadioSettingsScope& scope);
+    void clearBandEntries(const RadioSettingsScope& scope, double lowMhz,
+                          double highMhz);
 
     // Remove entries older than maxAgeMs; returns number removed.
-    int removeExpiredEntries(const QString& radioSerial, qint64 maxAgeMs);
+    int removeExpiredEntries(const RadioSettingsScope& scope, qint64 maxAgeMs);
 
-    int autoExpiryMinutes() const { return m_autoExpiryMinutes; }
-    void setAutoExpiryMinutes(int minutes) { m_autoExpiryMinutes = minutes; }
-
-    bool groupByBand() const { return m_groupByBand; }
-    void setGroupByBand(bool grouped) { m_groupByBand = grouped; }
-
+    // Panel-wide preferences (AppSettings-backed; setters persist).
+    int autoExpiryMinutes() const;
+    void setAutoExpiryMinutes(int minutes);
+    bool groupByBand() const;
+    void setGroupByBand(bool grouped);
     // Auto-save: seconds the active slice must dwell on a frequency before
-    // being added to the stack automatically.  0 = disabled.
-    int autoSaveDwellSeconds() const { return m_autoSaveDwellSeconds; }
-    void setAutoSaveDwellSeconds(int seconds) { m_autoSaveDwellSeconds = seconds; }
+    // being added to the stack automatically. 0 = disabled.
+    int autoSaveDwellSeconds() const;
+    void setAutoSaveDwellSeconds(int seconds);
 
 private:
     BandStackSettings();
     BandStackSettings(const BandStackSettings&) = delete;
     BandStackSettings& operator=(const BandStackSettings&) = delete;
 
+    // Legacy side-file section name for a serial (XML element-name rules).
     static QString sanitizeSerial(const QString& serial);
 
-    QMap<QString, QVector<BandStackEntry>> m_entries;
-    QString m_filePath;
-    int m_autoExpiryMinutes{0};      // 0 = disabled
-    bool m_groupByBand{false};
-    int m_autoSaveDwellSeconds{0};   // 0 = disabled
+    void ensureScopeMigrated(const RadioSettingsScope& scope);
+    QVector<BandStackEntry> readEntries(const RadioSettingsScope& scope);
+    bool writeEntries(const RadioSettingsScope& scope,
+                      const QVector<BandStackEntry>& entries);
+
+    QString m_legacyFilePath;
+    QSet<QString> m_scopesChecked;   // per-process migration memo
 };
 
 } // namespace AetherSDR

--- a/src/gui/BandStackPanel.cpp
+++ b/src/gui/BandStackPanel.cpp
@@ -169,10 +169,10 @@ QString BandStackPanel::bandNameForFrequency(double freqMhz)
     return "Other";
 }
 
-void BandStackPanel::loadBookmarks(const QString& radioSerial, const BandPlanManager* bpm)
+void BandStackPanel::loadBookmarks(const RadioSettingsScope& scope, const BandPlanManager* bpm)
 {
     clear();
-    const auto entries = BandStackSettings::instance().entries(radioSerial);
+    const auto entries = BandStackSettings::instance().entries(scope);
     for (int i = 0; i < entries.size(); ++i) {
         const BandStackEntry& entry = entries[i];
         Bookmark bm;

--- a/src/gui/BandStackPanel.h
+++ b/src/gui/BandStackPanel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/BandStackSettings.h"
+#include "core/RadioSettingsScope.h"
 
 #include <QWidget>
 #include <QVector>
@@ -25,7 +26,7 @@ public:
     explicit BandStackPanel(QWidget* parent = nullptr);
 
     // Load all bookmarks for a radio, looking up colors from band plan
-    void loadBookmarks(const QString& radioSerial, const BandPlanManager* bpm);
+    void loadBookmarks(const RadioSettingsScope& scope, const BandPlanManager* bpm);
 
     // Clear all bookmarks (on disconnect)
     void clear();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4285,10 +4285,9 @@ void MainWindow::buildUI()
             entry.wnbLevel = pan->wnbLevel();
         }
 
-        BandStackSettings::instance().addEntry(m_radioModel.serial(), entry);
-        BandStackSettings::instance().save();
+        BandStackSettings::instance().addEntry(m_radioModel.settingsScope(), entry);
         m_panStack->bandStackPanel()->loadBookmarks(
-            m_radioModel.serial(), m_bandPlanMgr);
+            m_radioModel.settingsScope(), m_bandPlanMgr);
     });
     connect(bsPanel, &BandStackPanel::recallRequested, this,
             [this](const BandStackEntry& e) {
@@ -4352,53 +4351,47 @@ void MainWindow::buildUI()
     });
     connect(bsPanel, &BandStackPanel::removeRequested, this,
             [this](int index) {
-        BandStackSettings::instance().removeEntry(m_radioModel.serial(), index);
-        BandStackSettings::instance().save();
+        BandStackSettings::instance().removeEntry(m_radioModel.settingsScope(), index);
         m_panStack->bandStackPanel()->loadBookmarks(
-            m_radioModel.serial(), m_bandPlanMgr);
+            m_radioModel.settingsScope(), m_bandPlanMgr);
     });
 
     // Clear All — with confirmation to avoid accidental loss during contests
     connect(bsPanel, &BandStackPanel::clearAllRequested, this, [this]() {
-        if (BandStackSettings::instance().entries(m_radioModel.serial()).isEmpty())
+        if (BandStackSettings::instance().entries(m_radioModel.settingsScope()).isEmpty())
             return;
         auto answer = QMessageBox::question(
             this, "Clear All Bookmarks",
             "Remove all band stack bookmarks?",
             QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
         if (answer != QMessageBox::Yes) return;
-        BandStackSettings::instance().clearAllEntries(m_radioModel.serial());
-        BandStackSettings::instance().save();
+        BandStackSettings::instance().clearAllEntries(m_radioModel.settingsScope());
         m_panStack->bandStackPanel()->loadBookmarks(
-            m_radioModel.serial(), m_bandPlanMgr);
+            m_radioModel.settingsScope(), m_bandPlanMgr);
     });
 
     // Clear band bookmarks (from grouped header right-click)
     connect(bsPanel, &BandStackPanel::clearBandRequested, this,
             [this](double lowMhz, double highMhz) {
         BandStackSettings::instance().clearBandEntries(
-            m_radioModel.serial(), lowMhz, highMhz);
-        BandStackSettings::instance().save();
+            m_radioModel.settingsScope(), lowMhz, highMhz);
         m_panStack->bandStackPanel()->loadBookmarks(
-            m_radioModel.serial(), m_bandPlanMgr);
+            m_radioModel.settingsScope(), m_bandPlanMgr);
     });
 
     // Group by band toggle
     connect(bsPanel, &BandStackPanel::groupByBandChanged, this, [](bool grouped) {
         BandStackSettings::instance().setGroupByBand(grouped);
-        BandStackSettings::instance().save();
     });
 
     // Auto-expiry setting changed
     connect(bsPanel, &BandStackPanel::autoExpiryChanged, this, [](int minutes) {
         BandStackSettings::instance().setAutoExpiryMinutes(minutes);
-        BandStackSettings::instance().save();
     });
 
     // Auto-save dwell setting changed
     connect(bsPanel, &BandStackPanel::autoSaveDwellChanged, this, [this](int seconds) {
         BandStackSettings::instance().setAutoSaveDwellSeconds(seconds);
-        BandStackSettings::instance().save();
         if (!m_bsAutoSaveTimer) return;
         if (seconds <= 0) {
             m_bsAutoSaveTimer->stop();
@@ -4419,11 +4412,10 @@ void MainWindow::buildUI()
         if (m_radioModel.serial().isEmpty()) return;
         qint64 maxAge = static_cast<qint64>(minutes) * 60 * 1000;
         int removed = BandStackSettings::instance().removeExpiredEntries(
-            m_radioModel.serial(), maxAge);
+                    m_radioModel.settingsScope(), maxAge);
         if (removed > 0) {
-            BandStackSettings::instance().save();
             m_panStack->bandStackPanel()->loadBookmarks(
-                m_radioModel.serial(), m_bandPlanMgr);
+            m_radioModel.settingsScope(), m_bandPlanMgr);
         }
     });
 
@@ -4446,7 +4438,7 @@ void MainWindow::buildUI()
 
         // Skip if any existing entry is within ±100 Hz on this radio
         // (avoids re-stacking the exact same station after a brief retune).
-        auto existing = BandStackSettings::instance().entries(m_radioModel.serial());
+        auto existing = BandStackSettings::instance().entries(m_radioModel.settingsScope());
         for (const auto& e : existing) {
             if (std::abs(e.frequencyMhz - freqMhz) < 0.0001) return;
         }
@@ -4480,7 +4472,7 @@ void MainWindow::buildUI()
             }
             if (autoCount >= kMaxAutoPerBand && oldestAutoIdx >= 0) {
                 BandStackSettings::instance().removeEntry(
-                    m_radioModel.serial(), oldestAutoIdx);
+                    m_radioModel.settingsScope(), oldestAutoIdx);
             }
         }
 
@@ -4504,10 +4496,9 @@ void MainWindow::buildUI()
             entry.wnbOn = pan->wnbActive();
             entry.wnbLevel = pan->wnbLevel();
         }
-        BandStackSettings::instance().addEntry(m_radioModel.serial(), entry);
-        BandStackSettings::instance().save();
+        BandStackSettings::instance().addEntry(m_radioModel.settingsScope(), entry);
         m_panStack->bandStackPanel()->loadBookmarks(
-            m_radioModel.serial(), m_bandPlanMgr);
+            m_radioModel.settingsScope(), m_bandPlanMgr);
     });
     refreshMemoryBrowsePanel();
 
@@ -5377,10 +5368,8 @@ void MainWindow::onConnectionStateChanged(bool connected)
         int expiryMin = BandStackSettings::instance().autoExpiryMinutes();
         if (expiryMin > 0) {
             qint64 maxAge = static_cast<qint64>(expiryMin) * 60 * 1000;
-            if (BandStackSettings::instance().removeExpiredEntries(
-                    m_radioModel.serial(), maxAge) > 0) {
-                BandStackSettings::instance().save();
-            }
+            BandStackSettings::instance().removeExpiredEntries(
+                m_radioModel.settingsScope(), maxAge);
         }
         BandStackPanel* bandStackPanel =
             m_panStack ? m_panStack->bandStackPanel() : nullptr;
@@ -5396,7 +5385,8 @@ void MainWindow::onConnectionStateChanged(bool connected)
         // while the radio finishes pushing initial slice/pan state.
         m_bsConnectGraceUntilMs = QDateTime::currentMSecsSinceEpoch() + 5000;
         if (bandStackPanel) {
-            bandStackPanel->loadBookmarks(m_radioModel.serial(), m_bandPlanMgr);
+            bandStackPanel->loadBookmarks(
+            m_radioModel.settingsScope(), m_bandPlanMgr);
         }
         refreshMemoryBrowsePanel();
         updateBandStackIndicator();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4415,7 +4415,7 @@ void MainWindow::buildUI()
                     m_radioModel.settingsScope(), maxAge);
         if (removed > 0) {
             m_panStack->bandStackPanel()->loadBookmarks(
-            m_radioModel.settingsScope(), m_bandPlanMgr);
+                m_radioModel.settingsScope(), m_bandPlanMgr);
         }
     });
 
@@ -5386,7 +5386,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
         m_bsConnectGraceUntilMs = QDateTime::currentMSecsSinceEpoch() + 5000;
         if (bandStackPanel) {
             bandStackPanel->loadBookmarks(
-            m_radioModel.settingsScope(), m_bandPlanMgr);
+                m_radioModel.settingsScope(), m_bandPlanMgr);
         }
         refreshMemoryBrowsePanel();
         updateBandStackIndicator();

--- a/tests/bandstack_scoped_test.cpp
+++ b/tests/bandstack_scoped_test.cpp
@@ -1,0 +1,203 @@
+// BandStack fold-in (RFC #4603 PR 4): bookmarks live as one feature document
+// per radio in radio_settings, mutations write through (no save() step), the
+// legacy XML side file is claimed lazily per radio — with the file retiring
+// when its last section migrates — and the panel-wide preferences move to
+// AppSettings.
+#include "TestSettingsProfile.h"
+#include "core/AppSettings.h"
+#include "core/BandStackSettings.h"
+#include "core/RadioSettingsScope.h"
+#include "core/SettingsPaths.h"
+
+#include <QCoreApplication>
+#include <QFile>
+
+#include <iostream>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* label)
+{
+    std::cout << (condition ? "[ OK ] " : "[FAIL] ") << label << '\n';
+    if (!condition) {
+        ++g_failures;
+    }
+}
+
+QString legacyPath()
+{
+    return SettingsPaths::configDir() + QStringLiteral("/BandStack.settings");
+}
+
+bool writeLegacyFixture()
+{
+    // Two radios' worth of legacy bookmarks plus header preferences, in the
+    // exact shape the XML-era writer produced.
+    const char* doc = R"(<?xml version="1.0" encoding="UTF-8"?>
+<BandStack>
+  <AutoExpiryMinutes>120</AutoExpiryMinutes>
+  <GroupByBand>True</GroupByBand>
+  <AutoSaveDwellSeconds>30</AutoSaveDwellSeconds>
+  <Radio_2125_1213_8600_8895>
+    <Entry_0>
+      <FrequencyMhz>14.225000</FrequencyMhz>
+      <Mode>USB</Mode>
+      <FilterLow>100</FilterLow>
+      <FilterHigh>2900</FilterHigh>
+      <AgcMode>med</AgcMode>
+      <AgcThreshold>65</AgcThreshold>
+      <AudioGain>50</AudioGain>
+      <NbOn>False</NbOn>
+      <NbLevel>50</NbLevel>
+      <NrOn>False</NrOn>
+      <NrLevel>50</NrLevel>
+      <WnbOn>False</WnbOn>
+      <WnbLevel>50</WnbLevel>
+    </Entry_0>
+  </Radio_2125_1213_8600_8895>
+  <Radio_3419_0000_6600_0001>
+    <Entry_0>
+      <FrequencyMhz>7.074000</FrequencyMhz>
+      <Mode>DIGU</Mode>
+      <FilterLow>0</FilterLow>
+      <FilterHigh>3000</FilterHigh>
+      <AgcMode>med</AgcMode>
+      <AgcThreshold>65</AgcThreshold>
+      <AudioGain>50</AudioGain>
+      <NbOn>False</NbOn>
+      <NbLevel>50</NbLevel>
+      <NrOn>False</NrOn>
+      <NrLevel>50</NrLevel>
+      <WnbOn>False</WnbOn>
+      <WnbLevel>50</WnbLevel>
+    </Entry_0>
+  </Radio_3419_0000_6600_0001>
+</BandStack>
+)";
+    QFile file(legacyPath());
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        return false;
+    }
+    file.write(doc);
+    return true;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile profile(QStringLiteral("aether-bandstack-scoped-test"));
+    if (!profile.isValid()) {
+        std::cerr << "[FAIL] create temporary home\n";
+        return 1;
+    }
+    QCoreApplication app(argc, argv);
+    AppSettings::instance().load();
+
+    auto& stack = BandStackSettings::instance();
+    // CRUD exercises its own radio so the migration scopes below stay virgin
+    // (a radio that already owns a document must never re-import legacy —
+    // asserted explicitly at the end).
+    const RadioSettingsScope crudScope(QStringLiteral("flex"),
+                                       QStringLiteral("0001-0000-0000-0001"));
+    const RadioSettingsScope flexScope(QStringLiteral("flex"),
+                                       QStringLiteral("2125-1213-8600-8895"));
+    const RadioSettingsScope hl2Scope(QStringLiteral("hl2"),
+                                      QStringLiteral("AA:BB:CC:DD:EE:FF"));
+
+    // ---- write-through CRUD, per scope ------------------------------------
+    {
+        BandStackEntry entry;
+        entry.frequencyMhz = 21.074;
+        entry.mode = QStringLiteral("DIGU");
+        entry.createdAtMs = 1'000;
+        stack.addEntry(crudScope, entry);
+        check(stack.entries(crudScope).size() == 1, "an added entry reads back");
+        check(stack.entries(hl2Scope).isEmpty(),
+              "the other radio's stack stays empty (per-radio isolation)");
+
+        // No save() call anywhere — the mutation must already be durable.
+        AppSettings::instance().reset();
+        AppSettings::instance().load();
+        check(stack.entries(crudScope).size() == 1
+                  && stack.entries(crudScope).first().frequencyMhz == 21.074,
+              "a bookmark survives a store reload with no explicit save");
+
+        stack.removeEntry(crudScope, 0);
+        check(stack.entries(crudScope).isEmpty(), "removeEntry writes through");
+    }
+
+    // ---- expiry: legacy entries never expire ------------------------------
+    {
+        BandStackEntry old;
+        old.frequencyMhz = 3.573;
+        old.createdAtMs = 1;             // ancient
+        BandStackEntry legacy;
+        legacy.frequencyMhz = 1.840;
+        legacy.createdAtMs = 0;          // legacy sentinel
+        stack.addEntry(crudScope, old);
+        stack.addEntry(crudScope, legacy);
+        check(stack.removeExpiredEntries(crudScope, 1000) == 1,
+              "an aged entry expires");
+        const auto rest = stack.entries(crudScope);
+        check(rest.size() == 1 && rest.first().createdAtMs == 0,
+              "a legacy (createdAtMs=0) entry never expires");
+        stack.clearAllEntries(crudScope);
+    }
+
+    // ---- legacy side-file migration ---------------------------------------
+    {
+        check(writeLegacyFixture(), "legacy fixture is written");
+        BandStackSettings::instance().load();   // prefs one-shot
+        check(stack.autoExpiryMinutes() == 120 && stack.groupByBand()
+                  && stack.autoSaveDwellSeconds() == 30,
+              "panel-wide preferences migrate to AppSettings");
+
+        // Both fixture sections use the legacy sanitizer's convention
+        // ('-' -> '_'). (An HL2 MAC could never appear: colons are invalid
+        // XML element names, so the XML-era writer could not store one — a
+        // legacy limitation this fold-in removes.)
+        const auto flexEntries = stack.entries(flexScope);
+        check(flexEntries.size() == 1
+                  && flexEntries.first().frequencyMhz == 14.225
+                  && flexEntries.first().mode == QStringLiteral("USB"),
+              "the Flex radio's legacy section migrates on first access");
+        check(QFile::exists(legacyPath()),
+              "the side file survives while another radio's section remains");
+
+        AppSettings::instance().reset();
+        AppSettings::instance().load();
+        check(stack.entries(flexScope).size() == 1,
+              "a migrated stack is durable across reloads");
+
+        // Claiming the LAST remaining section retires the side file.
+        const RadioSettingsScope secondScope(QStringLiteral("flex"),
+                                             QStringLiteral("3419-0000-6600-0001"));
+        const auto secondEntries = stack.entries(secondScope);
+        check(secondEntries.size() == 1
+                  && secondEntries.first().mode == QStringLiteral("DIGU"),
+              "the second radio's legacy section migrates on ITS first access");
+        check(!QFile::exists(legacyPath()),
+              "the side file retires once its last section is claimed");
+    }
+
+    // ---- an existing document never re-imports legacy ---------------------
+    // A radio that already owns a document — including one the operator
+    // deliberately EMPTIED — must not resurrect bookmarks from a legacy file
+    // that reappears (backup restore, sync tooling).
+    {
+        check(writeLegacyFixture(), "legacy fixture is re-planted");
+        // crudScope's document exists (emptied above). Section
+        // Radio_0001_0000_0000_0001 is absent from the fixture anyway, so
+        // plant one for it by claiming through a scope whose doc exists:
+        check(stack.entries(crudScope).isEmpty(),
+              "an emptied stack stays empty when a legacy file reappears");
+        QFile::remove(legacyPath());
+    }
+
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/bandstack_scoped_test.cpp
+++ b/tests/bandstack_scoped_test.cpp
@@ -11,6 +11,8 @@
 
 #include <QCoreApplication>
 #include <QFile>
+#include <QJsonArray>
+#include <QJsonObject>
 
 #include <iostream>
 
@@ -186,16 +188,48 @@ int main(int argc, char** argv)
     }
 
     // ---- an existing document never re-imports legacy ---------------------
-    // A radio that already owns a document — including one the operator
-    // deliberately EMPTIED — must not resurrect bookmarks from a legacy file
-    // that reappears (backup restore, sync tooling).
+    // The load-bearing subtlety (PR #4621 review, Ozy311 — the first version
+    // of this test could not fail): clearAllEntries() writes {"entries": []},
+    // and a PRESENT-but-empty document is distinguishable from an absent row;
+    // that presence is what blocks re-import. To make the guard falsifiable,
+    // BOTH scopes below have their sections in the same freshly planted
+    // legacy file and neither has a migration memo — the only difference is
+    // the planted empty document, and only the document-less scope imports.
     {
-        check(writeLegacyFixture(), "legacy fixture is re-planted");
-        // crudScope's document exists (emptied above). Section
-        // Radio_0001_0000_0000_0001 is absent from the fixture anyway, so
-        // plant one for it by claiming through a scope whose doc exists:
-        check(stack.entries(crudScope).isEmpty(),
-              "an emptied stack stays empty when a legacy file reappears");
+        const RadioSettingsScope emptiedScope(QStringLiteral("flex"),
+                                              QStringLiteral("9999-8888-7777-6666"));
+        const RadioSettingsScope virginScope(QStringLiteral("flex"),
+                                             QStringLiteral("5555-4444-3333-2222"));
+        const char* doc = R"(<?xml version="1.0" encoding="UTF-8"?>
+<BandStack>
+  <Radio_9999_8888_7777_6666>
+    <Entry_0><FrequencyMhz>10.136000</FrequencyMhz><Mode>DIGU</Mode></Entry_0>
+  </Radio_9999_8888_7777_6666>
+  <Radio_5555_4444_3333_2222>
+    <Entry_0><FrequencyMhz>5.357000</FrequencyMhz><Mode>USB</Mode></Entry_0>
+  </Radio_5555_4444_3333_2222>
+</BandStack>
+)";
+        {
+            QFile f(legacyPath());
+            check(f.open(QIODevice::WriteOnly | QIODevice::Truncate)
+                      && f.write(doc) > 0,
+                  "resurrection fixture is planted");
+        }
+        // The deliberately-emptied document, planted beneath BandStackSettings
+        // so no migration memo exists for its scope.
+        check(AppSettings::instance().setRadioFeature(
+                  emptiedScope.family(), emptiedScope.radioId(),
+                  BandStackSettings::featureName(), 1,
+                  QJsonObject{{QStringLiteral("entries"), QJsonArray{}}}),
+              "an emptied document is planted for a never-accessed scope");
+
+        check(stack.entries(emptiedScope).isEmpty(),
+              "a present-but-EMPTY document blocks legacy re-import "
+              "(no bookmark resurrection)");
+        check(stack.entries(virginScope).size() == 1,
+              "the SAME file's section imports for the document-less scope — "
+              "proving the file was claimable and only the document blocked");
         QFile::remove(legacyPath());
     }
 


### PR DESCRIPTION
PR 4 of the settings-store RFC (#4603): **the BandStack fold-in.** Based directly on `main` (needs only PR 2's feature-document API) — independent of #4619, mergeable in either order.

## What this does

**Bookmarks become per-radio feature documents** — `(family, serial, "BandStack")` rows in `radio_settings`, one atomic whole-document write per mutation (Principle V). The separate `save()` step is **gone** (ten call sites deleted): a bookmark the operator just made is durable the moment it exists, instead of riding on a later explicit save that a crash could beat.

**The API takes `RadioSettingsScope`** (callers pass `RadioModel::settingsScope()`), which retires the last consumer of the XML-era serial sanitizing. A side effect worth naming: the legacy XML writer **could never store an HL2 band stack at all** — a MAC's colons are invalid XML element names, so the section element was unwritable. HL2 (and Kiwi, and sim) band stacks genuinely begin working with this PR, which is the "client-authoritative state becomes first-class" payoff the RFC promised for this phase.

## The lazy migration

The legacy side file (`~/.config/AetherSDR/BandStack.settings`) keyed sections by serial alone, but a feature document needs the radio's **family** — which only the live scope knows. So migration is per-radio, on first access:

- A radio's first `entries()`/mutation claims its `Radio_<serial>` section into the scoped document and rewrites the side file without it.
- The side file **retires when its last section is claimed**; sections for radios that never reconnect wait harmlessly (still readable by a downgrade, matching the frozen-XML philosophy from PR 1).
- **No resurrection**: a radio that already owns a document — including one the operator deliberately *emptied* — never re-imports from a legacy file that reappears (backup restore, sync tooling). Pinned by a test.
- The three panel-wide preferences (auto-expiry, group-by-band, auto-save dwell) were never per-radio; they move to `AppSettings` keys via a one-shot in `load()`, with the legacy header preserved in the file for downgrades until it retires.

## A drive-by unification

The new test's isolation caught `BandStackSettings` hand-building its path from raw `QStandardPaths`, bypassing the `AETHER_SETTINGS_DIR` override that PR 1's review added — the fixture landed in one directory while the constructor read another. It now routes through `SettingsPaths` like every other store path; one source of truth again.

## Testing

New `tests/bandstack_scoped_test.cpp` — 15 assertions: write-through CRUD; per-radio isolation; reload durability **with zero explicit saves**; expiry semantics including the never-expiring `createdAtMs=0` legacy sentinel; panel-prefs migration; two-radio lazy claim with side-file survival-then-retirement; and the no-resurrection contract. Full suite green (#4559 pre-existing); engine-boundary `--strict` clean.

## Reviewer notes

- Reviewable surface: `BandStackSettings.{h,cpp}` (rewrite), the mechanical `MainWindow.cpp` call-site conversion (serial→scope, saves deleted), `BandStackPanel.{h,cpp}` (signature), the test.
- The legacy XML **reader** is preserved verbatim from the old implementation so migration reads exactly what the old writer wrote; the legacy **writer** survives only as the section-removal rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
