### PR TITLE
feat(tci): log the PTT slice-routing decision (#4547)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **The TCI PTT slice-routing decision is now logged (#4547).** Reports of TCI
+  keying the wrong slice have been arriving without logs because there were
+  none to send: the server logged audio, IQ, DAX and client connections, but
+  the decision that picks which slice transmits was silent. One line now
+  records the whole decision — the requested receiver, the slice it maps to,
+  the slice that was chosen and whether that is the one asked for, the slice
+  that actually holds transmit, and the cached route it was compared against —
+  which separates the three failure modes behind #4547 that otherwise look
+  identical to an operator. Slice ids are printed with their receiver number
+  (`0(trx0)`) so the line can be read against a client's own transcript.
+
+  It is off by default; turn it on with
+  `QT_LOGGING_RULES="aether.cat.info=true"` before starting AetherSDR, and
+  include the output when reporting a TCI routing problem. Three cases that
+  previously dropped a PTT request with no trace — unresolvable receiver,
+  resolved slice gone, and transmit-inhibited panadapter — now say so at the
+  normal logging level, no rule needed.
+
 ### Theme fallback colours corrected on themes that predate the token (#3184)
 
 - **Slice colours A–H and `color.accent.dim` now match the bundled themes.**

--- a/src/core/TciRoutingState.h
+++ b/src/core/TciRoutingState.h
@@ -38,6 +38,12 @@ public:
         TxRouteOwner owner { TxRouteOwner::None };
     };
 
+    // The slice that actually holds transmit right now, straight from the live
+    // endpoint list; -1 when no slice is TX. Public so a caller comparing the
+    // cached route against the live assignment uses this class's own notion of
+    // "the live TX slice" rather than a second copy that can drift from it.
+    static int currentTxSlice(const QVector<TciSliceEndpoint>& endpoints);
+
     RouteDecision resolveVfoB(int rxSliceId, const QVector<TciSliceEndpoint>& endpoints);
     int resolvePttSlice(int rxSliceId, const QVector<TciSliceEndpoint>& endpoints);
 
@@ -71,7 +77,6 @@ public:
 
 private:
     static bool contains(const QVector<TciSliceEndpoint>& endpoints, int sliceId);
-    static int currentTxSlice(const QVector<TciSliceEndpoint>& endpoints);
 
     bool m_splitRequested { false };
     int m_rxSliceId { -1 };

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -1167,19 +1167,6 @@ SliceModel* TciServer::sliceForTrx(int trx) const
     return m_trxMap.sliceForTrx(m_model, trx);
 }
 
-// The slice that actually holds transmit right now, straight from the live
-// endpoint list - the value a cached route is supposed to agree with.
-// -1 when no slice is currently TX.
-int TciServer::liveTxSlice(const QVector<TciSliceEndpoint>& endpoints)
-{
-    for (const TciSliceEndpoint& endpoint : endpoints) {
-        if (endpoint.isTx) {
-            return endpoint.sliceId;
-        }
-    }
-    return -1;
-}
-
 const char* TciServer::txRouteOwnerName(TciRoutingState::TxRouteOwner owner)
 {
     switch (owner) {
@@ -1882,7 +1869,14 @@ void TciServer::handleTrxRequest(QWebSocket* client, const TciProtocol::TrxReque
         return;
     }
     const QVector<TciSliceEndpoint> endpoints = routingEndpoints();
-    const int liveTx = liveTxSlice(endpoints);
+    const int liveTx = TciRoutingState::currentTxSlice(endpoints);
+    // Sample the cached route BEFORE resolving. resolvePttSlice() writes the
+    // live TX assignment through to the cache on the external-TX branch, so
+    // reading these afterwards would always show the cache agreeing with
+    // liveTx - erasing exactly the disagreement this line exists to catch.
+    const int cachedTx = m_routingState.txSliceId();
+    const int cachedRx = m_routingState.rxSliceId();
+    const char* const cachedOwner = txRouteOwnerName(m_routingState.owner());
     const int txSliceId = m_routingState.resolvePttSlice(rxSlice->sliceId(), endpoints);
 
     // Why did transmit land where it did?  Every TCI routing fault reported so
@@ -1891,22 +1885,17 @@ void TciServer::handleTrxRequest(QWebSocket* client, const TciProtocol::TrxReque
     // live TX assignment, or two clients addressing the same trx.  Log the
     // whole decision - request, live state, cached state, result - so a report
     // can be diagnosed from a log instead of a reproduction.
-    qCInfo(lcCat).nospace()
+    qCInfo(lcCat).nospace().noquote()
         << "TCI PTT route: trx=" << request.trx
         << " rxSlice=" << rxSlice->sliceId()
         << " -> txSlice=" << txSliceId
         << (txSliceId == rxSlice->sliceId() ? " (requested)" : " (NOT the requested slice)")
         << " | liveTx=" << liveTx
-        << " cachedTx=" << m_routingState.txSliceId()
-        << " cachedRx=" << m_routingState.rxSliceId()
-        << " owner=" << txRouteOwnerName(m_routingState.owner())
+        << " cachedTx=" << cachedTx
+        << " cachedRx=" << cachedRx
+        << " owner=" << cachedOwner
         << " split=" << (m_routingState.splitRequested() ? "true" : "false")
         << " source=" << (request.source.isEmpty() ? QStringLiteral("(none)") : request.source);
-
-    if (liveTx >= 0 && txSliceId != liveTx) {
-        qCInfo(lcCat) << "TCI PTT: transmit moves from slice" << liveTx
-                      << "to slice" << txSliceId;
-    }
 
     SliceModel* txSlice = m_model->slice(txSliceId);
     if (!txSlice) {
@@ -1919,6 +1908,14 @@ void TciServer::handleTrxRequest(QWebSocket* client, const TciProtocol::TrxReque
         qCWarning(lcCat) << "TCI PTT: slice" << txSliceId
                          << "is transmit-inhibited -" << inhibitReason;
         return;
+    }
+
+    // Stated as intent, and only once the drop paths above are behind us: the
+    // promote below is asynchronous and can still come back unselected, so
+    // this is the request that survived every guard, not a completed move.
+    if (liveTx >= 0 && txSliceId != liveTx) {
+        qCInfo(lcCat) << "TCI PTT: transmit will move from slice" << liveTx
+                      << "to slice" << txSliceId;
     }
 
     const QString mode = txSlice->mode().trimmed().toUpper();

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -1167,6 +1167,32 @@ SliceModel* TciServer::sliceForTrx(int trx) const
     return m_trxMap.sliceForTrx(m_model, trx);
 }
 
+// The slice that actually holds transmit right now, straight from the live
+// endpoint list - the value a cached route is supposed to agree with.
+// -1 when no slice is currently TX.
+int TciServer::liveTxSlice(const QVector<TciSliceEndpoint>& endpoints)
+{
+    for (const TciSliceEndpoint& endpoint : endpoints) {
+        if (endpoint.isTx) {
+            return endpoint.sliceId;
+        }
+    }
+    return -1;
+}
+
+const char* TciServer::txRouteOwnerName(TciRoutingState::TxRouteOwner owner)
+{
+    switch (owner) {
+    case TciRoutingState::TxRouteOwner::None:
+        return "none";
+    case TciRoutingState::TxRouteOwner::External:
+        return "external";
+    case TciRoutingState::TxRouteOwner::TciCreated:
+        return "tci-created";
+    }
+    return "unknown";
+}
+
 QVector<TciSliceEndpoint> TciServer::routingEndpoints() const
 {
     QVector<TciSliceEndpoint> endpoints;
@@ -1851,11 +1877,47 @@ void TciServer::handleTrxRequest(QWebSocket* client, const TciProtocol::TrxReque
 
     SliceModel* rxSlice = sliceForTrx(request.trx);
     if (!rxSlice) {
+        qCWarning(lcCat) << "TCI PTT: trx" << request.trx
+                         << "resolves to no owned slice - request dropped";
         return;
     }
-    const int txSliceId = m_routingState.resolvePttSlice(rxSlice->sliceId(), routingEndpoints());
+    const QVector<TciSliceEndpoint> endpoints = routingEndpoints();
+    const int liveTx = liveTxSlice(endpoints);
+    const int txSliceId = m_routingState.resolvePttSlice(rxSlice->sliceId(), endpoints);
+
+    // Why did transmit land where it did?  Every TCI routing fault reported so
+    // far reduces to one of three things, and all three are invisible without
+    // this line: the requested trx resolved away, a cached route outliving the
+    // live TX assignment, or two clients addressing the same trx.  Log the
+    // whole decision - request, live state, cached state, result - so a report
+    // can be diagnosed from a log instead of a reproduction.
+    qCInfo(lcCat).nospace()
+        << "TCI PTT route: trx=" << request.trx
+        << " rxSlice=" << rxSlice->sliceId()
+        << " -> txSlice=" << txSliceId
+        << (txSliceId == rxSlice->sliceId() ? " (requested)" : " (NOT the requested slice)")
+        << " | liveTx=" << liveTx
+        << " cachedTx=" << m_routingState.txSliceId()
+        << " cachedRx=" << m_routingState.rxSliceId()
+        << " owner=" << txRouteOwnerName(m_routingState.owner())
+        << " split=" << (m_routingState.splitRequested() ? "true" : "false")
+        << " source=" << (request.source.isEmpty() ? QStringLiteral("(none)") : request.source);
+
+    if (liveTx >= 0 && txSliceId != liveTx) {
+        qCInfo(lcCat) << "TCI PTT: transmit moves from slice" << liveTx
+                      << "to slice" << txSliceId;
+    }
+
     SliceModel* txSlice = m_model->slice(txSliceId);
-    if (!txSlice || !m_model->panTransmitInhibitReason(txSlice->panId()).isEmpty()) {
+    if (!txSlice) {
+        qCWarning(lcCat) << "TCI PTT: resolved tx slice" << txSliceId
+                         << "does not exist - request dropped";
+        return;
+    }
+    const QString inhibitReason = m_model->panTransmitInhibitReason(txSlice->panId());
+    if (!inhibitReason.isEmpty()) {
+        qCWarning(lcCat) << "TCI PTT: slice" << txSliceId
+                         << "is transmit-inhibited -" << inhibitReason;
         return;
     }
 

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -1180,6 +1180,26 @@ const char* TciServer::txRouteOwnerName(TciRoutingState::TxRouteOwner owner)
     return "unknown";
 }
 
+QString TciServer::sliceTag(int sliceId) const
+{
+    // Everything a TCI client sees on the wire is a receiver number: trx:,
+    // tx_enable:, lock: and rx_filter_band: all carry m_trxMap.trxForSlice().
+    // The routing state speaks raw Flex slice ids instead, and since #4567
+    // pinned receiver numbers across a slice recreate the two genuinely
+    // diverge. A diagnostic that prints one and is read against the other
+    // manufactures agreements and disagreements that are not there, so print
+    // both wherever a slice id appears.
+    if (sliceId < 0) {
+        return QStringLiteral("none");
+    }
+    SliceModel* slice = m_model ? m_model->slice(sliceId) : nullptr;
+    if (!slice) {
+        // A cached route can outlive its slice; that is a finding, not a gap.
+        return QStringLiteral("%1(gone)").arg(sliceId);
+    }
+    return QStringLiteral("%1(trx%2)").arg(sliceId).arg(m_trxMap.trxForSlice(m_model, slice));
+}
+
 QVector<TciSliceEndpoint> TciServer::routingEndpoints() const
 {
     QVector<TciSliceEndpoint> endpoints;
@@ -1864,8 +1884,19 @@ void TciServer::handleTrxRequest(QWebSocket* client, const TciProtocol::TrxReque
 
     SliceModel* rxSlice = sliceForTrx(request.trx);
     if (!rxSlice) {
+        // Two very different situations reach here and they want different
+        // operator responses. TciTrxMap holds a receiver's binding across a
+        // band-change recreate and answers null rather than re-pointing it at
+        // whichever slice now sits at that index (#4577) — transient, and the
+        // next request succeeds. With no slices at all the session cannot key
+        // anything. Naming them apart is the whole point of logging this.
+        const bool haveSlices = m_model->isConnected() && !m_model->slices().isEmpty();
         qCWarning(lcCat) << "TCI PTT: trx" << request.trx
-                         << "resolves to no owned slice - request dropped";
+                         << (haveSlices
+                                    ? "maps to no live slice (unknown receiver, or its slice is"
+                                      " mid-recreate) - request dropped"
+                                    : "cannot be resolved - radio not connected, or no slices"
+                                      " - request dropped");
         return;
     }
     const QVector<TciSliceEndpoint> endpoints = routingEndpoints();
@@ -1885,28 +1916,40 @@ void TciServer::handleTrxRequest(QWebSocket* client, const TciProtocol::TrxReque
     // live TX assignment, or two clients addressing the same trx.  Log the
     // whole decision - request, live state, cached state, result - so a report
     // can be diagnosed from a log instead of a reproduction.
+    //
+    // source= is client-supplied and goes out last. simplified() collapses any
+    // embedded newline, because .noquote() means whatever a client puts in that
+    // field lands in the log verbatim — and a forged "TCI PTT route:" line in
+    // the evidence a reporter attaches is a worse failure than no line at all.
     qCInfo(lcCat).nospace().noquote()
         << "TCI PTT route: trx=" << request.trx
-        << " rxSlice=" << rxSlice->sliceId()
-        << " -> txSlice=" << txSliceId
-        << (txSliceId == rxSlice->sliceId() ? " (requested)" : " (NOT the requested slice)")
-        << " | liveTx=" << liveTx
-        << " cachedTx=" << cachedTx
-        << " cachedRx=" << cachedRx
+        << (m_trxMap.trxForSlice(m_model, rxSlice) == request.trx ? "" : " [trx fallback]")
+        << " rxSlice=" << sliceTag(rxSlice->sliceId())
+        << " -> txSlice=" << sliceTag(txSliceId)
+        << (txSliceId == rxSlice->sliceId() ? " (the requested slice)"
+                                            : " (NOT the requested slice)")
+        << " | liveTx=" << sliceTag(liveTx)
+        << " cachedTx=" << sliceTag(cachedTx)
+        << " cachedRx=" << sliceTag(cachedRx)
         << " owner=" << cachedOwner
         << " split=" << (m_routingState.splitRequested() ? "true" : "false")
-        << " source=" << (request.source.isEmpty() ? QStringLiteral("(none)") : request.source);
+        << " source="
+        << (request.source.isEmpty() ? QStringLiteral("(none)")
+                                     : request.source.simplified().left(32));
 
     SliceModel* txSlice = m_model->slice(txSliceId);
     if (!txSlice) {
-        qCWarning(lcCat) << "TCI PTT: resolved tx slice" << txSliceId
-                         << "does not exist - request dropped";
+        qCWarning(lcCat).noquote() << "TCI PTT: resolved tx slice" << sliceTag(txSliceId)
+                                   << "does not exist - request dropped";
         return;
     }
     const QString inhibitReason = m_model->panTransmitInhibitReason(txSlice->panId());
     if (!inhibitReason.isEmpty()) {
-        qCWarning(lcCat) << "TCI PTT: slice" << txSliceId
-                         << "is transmit-inhibited -" << inhibitReason;
+        // simplified() for the same reason as source= above, and because a
+        // reason that is one grep-able line is worth more in a bug report
+        // than one that wraps: this is a translated sentence, not a token.
+        qCWarning(lcCat).noquote() << "TCI PTT: slice" << sliceTag(txSliceId)
+                                   << "is transmit-inhibited -" << inhibitReason.simplified();
         return;
     }
 
@@ -1914,8 +1957,8 @@ void TciServer::handleTrxRequest(QWebSocket* client, const TciProtocol::TrxReque
     // promote below is asynchronous and can still come back unselected, so
     // this is the request that survived every guard, not a completed move.
     if (liveTx >= 0 && txSliceId != liveTx) {
-        qCInfo(lcCat) << "TCI PTT: transmit will move from slice" << liveTx
-                      << "to slice" << txSliceId;
+        qCInfo(lcCat).noquote() << "TCI PTT: transmit will move from slice" << sliceTag(liveTx)
+                                << "to slice" << sliceTag(txSliceId);
     }
 
     const QString mode = txSlice->mode().trimmed().toUpper();

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -180,8 +180,13 @@ private:
     void broadcastBinary(const QByteArray& data);
     SliceModel* sliceForTrx(int trx) const;
     QVector<TciSliceEndpoint> routingEndpoints() const;
-    // Diagnostics helper for the PTT routing decision log.
+    // Diagnostics helpers for the PTT routing decision log.
     static const char* txRouteOwnerName(TciRoutingState::TxRouteOwner owner);
+    // "<sliceId>(trx<n>)", "<sliceId>(gone)" for a slice that is no longer
+    // live, "none" for a negative id. The wire speaks trx and the router
+    // speaks slice ids; the log has to state both or it cannot be read
+    // against a client transcript.
+    QString sliceTag(int sliceId) const;
     void handleVfoRequest(QWebSocket* client, const TciProtocol::VfoRequest& request);
     void handleSplitRequest(QWebSocket* client, const TciProtocol::SplitRequest& request);
     void handleTrxRequest(QWebSocket* client, const TciProtocol::TrxRequest& request);

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -180,6 +180,9 @@ private:
     void broadcastBinary(const QByteArray& data);
     SliceModel* sliceForTrx(int trx) const;
     QVector<TciSliceEndpoint> routingEndpoints() const;
+    // Diagnostics helpers for the PTT routing decision log.
+    static int liveTxSlice(const QVector<TciSliceEndpoint>& endpoints);
+    static const char* txRouteOwnerName(TciRoutingState::TxRouteOwner owner);
     void handleVfoRequest(QWebSocket* client, const TciProtocol::VfoRequest& request);
     void handleSplitRequest(QWebSocket* client, const TciProtocol::SplitRequest& request);
     void handleTrxRequest(QWebSocket* client, const TciProtocol::TrxRequest& request);

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -180,8 +180,7 @@ private:
     void broadcastBinary(const QByteArray& data);
     SliceModel* sliceForTrx(int trx) const;
     QVector<TciSliceEndpoint> routingEndpoints() const;
-    // Diagnostics helpers for the PTT routing decision log.
-    static int liveTxSlice(const QVector<TciSliceEndpoint>& endpoints);
+    // Diagnostics helper for the PTT routing decision log.
     static const char* txRouteOwnerName(TciRoutingState::TxRouteOwner owner);
     void handleVfoRequest(QWebSocket* client, const TciProtocol::VfoRequest& request);
     void handleSplitRequest(QWebSocket* client, const TciProtocol::SplitRequest& request);

--- a/tests/tci_server_review_test.cpp
+++ b/tests/tci_server_review_test.cpp
@@ -13,7 +13,9 @@
 #include <QCoreApplication>
 #include <QEventLoop>
 #include <QJsonObject>
+#include <QLoggingCategory>
 #include <QSet>
+#include <QStringList>
 #include <QTimer>
 #include <QWebSocket>
 
@@ -21,6 +23,49 @@
 
 namespace AetherSDR
 {
+
+namespace
+{
+
+QStringList* g_logSink = nullptr;
+
+void captureLogHandler(QtMsgType, const QMessageLogContext&, const QString& msg)
+{
+    if (g_logSink) {
+        *g_logSink << msg;
+    }
+}
+
+// Collect everything logged while `body` runs. aether.cat defaults to
+// QtWarningMsg, so the info-level route line needs the rule as well as the
+// handler.
+template <typename Body>
+QStringList captureCatLog(Body body)
+{
+    QStringList captured;
+    g_logSink = &captured;
+    const QtMessageHandler previous = qInstallMessageHandler(captureLogHandler);
+    QLoggingCategory::setFilterRules(QStringLiteral("aether.cat.info=true"));
+
+    body();
+
+    QLoggingCategory::setFilterRules(QString());
+    qInstallMessageHandler(previous);
+    g_logSink = nullptr;
+    return captured;
+}
+
+QString findLine(const QStringList& lines, const char* prefix)
+{
+    for (const QString& line : lines) {
+        if (line.startsWith(QLatin1String(prefix))) {
+            return line;
+        }
+    }
+    return QString();
+}
+
+} // namespace
 
 class TciServerReviewTest
 {
@@ -85,6 +130,204 @@ public:
         return !server.m_routingState.splitRequested()
             && snapshot.value(QStringLiteral("lastRouteError")).toString()
                 == QStringLiteral("capacity test");
+    }
+
+    // ── #4547 PTT routing diagnostic ────────────────────────────────────────
+
+    // Two slices, slice 1 holding transmit, and a routing cache still pointing
+    // at slice 0 from when slice 0 was TX. This is the exact state behind the
+    // fldigi capture on #4547: the client addresses the slice that genuinely
+    // has TX, branch 1 of resolvePttSlice is therefore skipped, and the stale
+    // cache drags transmit back to slice 0 — wrong band, wrong antenna.
+    static bool pttRouteFixture(RadioModel& model, TciServer& server)
+    {
+        QString error;
+        if (!model.automationApplySliceFixture(0, QString(), &error)
+            || !model.automationApplySliceFixture(1, QString(), &error)) {
+            std::fprintf(stderr, "ptt route fixtures failed: %s\n",
+                         error.toUtf8().constData());
+            return false;
+        }
+        SliceModel* s1 = model.slice(1);
+        if (!s1) {
+            return false;
+        }
+        // The TX flag is radio-authoritative — drive the status path the way
+        // the radio would, rather than calling setTxSlice() (which only sends).
+        SliceDelta txOn;
+        txOn.txSlice = true;
+        s1->applyChanges(txOn);
+
+        // The stale route: bound while slice 0 held transmit, never refreshed.
+        server.m_routingState.bindCreatedRoute(1, 0);
+        return true;
+    }
+
+    // The diagnostic's whole reason to exist is showing the cached route
+    // DISAGREEING with the live TX assignment. Pinned because the sampling
+    // order that makes it possible is load-bearing and invisible:
+    // resolvePttSlice() writes the live assignment through to the cache on its
+    // external-TX branch, so reading cachedTx AFTER the resolve reports the
+    // cache agreeing with liveTx on every path — the line stays plausible and
+    // says nothing. Move those three reads below the resolve and this fails.
+    static bool pttRouteLogExposesStaleCache()
+    {
+        RadioModel model;
+        TciServer server(&model);
+        QWebSocket client;
+        if (!pttRouteFixture(model, server)) {
+            return false;
+        }
+
+        const QStringList log = captureCatLog([&] {
+            server.handleTrxRequest(&client, TciProtocol::TrxRequest{
+                1, true, QStringLiteral("tci")
+            });
+        });
+
+        const QString route = findLine(log, "TCI PTT route:");
+        if (route.isEmpty()) {
+            std::fprintf(stderr, "no TCI PTT route line was logged\n");
+            return false;
+        }
+        // Slice ids carry their receiver number, because the wire speaks trx
+        // and a reader correlating the two must not have to guess (#4567).
+        const char* const required[] = {
+            "trx=1",
+            "rxSlice=1(trx1)",
+            "-> txSlice=0(trx0)",
+            "(NOT the requested slice)",
+            "liveTx=1(trx1)",       // transmit is really on slice 1...
+            "cachedTx=0(trx0)",     // ...and the cache still says slice 0
+            "owner=tci-created",
+        };
+        for (const char* needle : required) {
+            if (!route.contains(QLatin1String(needle))) {
+                std::fprintf(stderr, "route line missing %s\n  got: %s\n",
+                             needle, route.toUtf8().constData());
+                return false;
+            }
+        }
+        // And the move away from the slice that actually holds transmit.
+        return !findLine(log, "TCI PTT: transmit will move from slice 1(trx1) "
+                              "to slice 0(trx0)")
+                    .isEmpty();
+    }
+
+    // The other half of the same defect, and the one that pins the sampling
+    // ORDER. Here the client addresses a slice that is NOT the transmitter, so
+    // resolvePttSlice() takes its external-TX branch — and that branch writes
+    // the live assignment through to the cache (m_txSliceId, m_rxSliceId,
+    // m_owner) before returning. Read cachedTx AFTER the resolve and it always
+    // equals liveTx: the line still prints, still looks reasonable, and has
+    // quietly stopped reporting the disagreement it exists for. That is what
+    // 60b78967 shipped and 0610df79 fixed. Move the three reads below the
+    // resolve and this test fails; the one above it does not.
+    static bool pttRouteLogSamplesCacheBeforeResolve()
+    {
+        RadioModel model;
+        TciServer server(&model);
+        QWebSocket client;
+        if (!pttRouteFixture(model, server)) {
+            return false;
+        }
+        SliceModel* s1 = model.slice(1);
+        if (!s1) {
+            return false;
+        }
+        // Inhibit the slice that holds transmit. The route line is logged
+        // before this guard, so the decision is still fully recorded — and the
+        // request stops here instead of running on into a real key-down.
+        model.setPanTransmitInhibited(s1->panId(), true,
+                                      QStringLiteral("inhibited for test"));
+
+        // trx 0 addresses slice 0, which is not the TX slice: the requested
+        // receiver is resolved away onto slice 1. Defect 1 of #4547.
+        const QStringList log = captureCatLog([&] {
+            server.handleTrxRequest(&client, TciProtocol::TrxRequest{
+                0, true, QStringLiteral("tci")
+            });
+        });
+
+        const QString route = findLine(log, "TCI PTT route:");
+        if (route.isEmpty()) {
+            std::fprintf(stderr, "no TCI PTT route line was logged\n");
+            return false;
+        }
+        const char* const required[] = {
+            "trx=0",
+            "rxSlice=0(trx0)",
+            "-> txSlice=1(trx1)",
+            "(NOT the requested slice)",
+            "liveTx=1(trx1)",
+            "cachedTx=0(trx0)",     // post-resolve this reads 1(trx1)
+            "cachedRx=1(trx1)",     // post-resolve this reads 0(trx0)
+            "owner=tci-created",    // post-resolve this reads external
+        };
+        for (const char* needle : required) {
+            if (!route.contains(QLatin1String(needle))) {
+                std::fprintf(stderr, "route line missing %s\n  got: %s\n",
+                             needle, route.toUtf8().constData());
+                return false;
+            }
+        }
+        // The drop reason is stated, and names the slice in both numberings.
+        return !findLine(log, "TCI PTT: slice 1(trx1) is transmit-inhibited - "
+                              "inhibited for test")
+                    .isEmpty();
+    }
+
+    // source= is client-supplied and printed with .noquote(), so without
+    // sanitising, any TCI client could emit a newline and forge a second
+    // "TCI PTT route:" line into the log a reporter attaches to an issue.
+    // Drop the simplified() call and this fails.
+    static bool pttRouteLogSanitizesClientSource()
+    {
+        RadioModel model;
+        TciServer server(&model);
+        QWebSocket client;
+        if (!pttRouteFixture(model, server)) {
+            return false;
+        }
+
+        const QStringList log = captureCatLog([&] {
+            server.handleTrxRequest(&client, TciProtocol::TrxRequest{
+                1, true,
+                QStringLiteral("dax\nTCI PTT route: trx=9 rxSlice=9(trx9)")
+            });
+        });
+
+        int routeLines = 0;
+        for (const QString& line : log) {
+            if (line.contains(QLatin1String("TCI PTT route:"))) {
+                ++routeLines;
+            }
+        }
+        if (routeLines != 1) {
+            std::fprintf(stderr, "expected 1 route line, got %d\n", routeLines);
+            return false;
+        }
+        const QString route = findLine(log, "TCI PTT route:");
+        if (route.contains(QLatin1Char('\n'))) {
+            std::fprintf(stderr, "route line carries an embedded newline: %s\n",
+                         route.toUtf8().constData());
+            return false;
+        }
+        // Neutralised in place and bounded, not silently dropped — the field
+        // is still evidence about which client sent the request. source= is
+        // last on the line, so what follows it is exactly the rendered field.
+        const QString source = route.section(QLatin1String(" source="), 1);
+        if (!source.startsWith(QLatin1String("dax TCI PTT route:"))) {
+            std::fprintf(stderr, "source not neutralised in place: '%s'\n",
+                         source.toUtf8().constData());
+            return false;
+        }
+        if (source.size() > 32) {
+            std::fprintf(stderr, "source not bounded: %lld chars\n",
+                         static_cast<long long>(source.size()));
+            return false;
+        }
+        return true;
     }
 
     // ── #4161 power / flag broadcast internals ──────────────────────────────
@@ -827,6 +1070,12 @@ int main(int argc, char** argv)
         = AetherSDR::TciServerReviewTest::liveSlicesKeepDistinctTrxAfterReconnect();
     const bool heldTrxRefuses
         = AetherSDR::TciServerReviewTest::heldTrxRefusesInsteadOfRepointing();
+    const bool routeLogStaleCache
+        = AetherSDR::TciServerReviewTest::pttRouteLogExposesStaleCache();
+    const bool routeLogSampleOrder
+        = AetherSDR::TciServerReviewTest::pttRouteLogSamplesCacheBeforeResolve();
+    const bool routeLogSanitizes
+        = AetherSDR::TciServerReviewTest::pttRouteLogSanitizesClientSource();
 
     std::printf("%s  isolated settings profile\n",
                 validProfile ? "PASS" : "FAIL");
@@ -863,6 +1112,15 @@ int main(int argc, char** argv)
                 vfoConfirmsRefusal ? "PASS" : "FAIL");
     std::printf("%s  vfo: SET still acknowledges a no-op\n",
                 vfoAcksNoOp ? "PASS" : "FAIL");
+    std::printf("%s  PTT route log shows the cache disagreeing with live TX "
+                "(#4547)\n",
+                routeLogStaleCache ? "PASS" : "FAIL");
+    std::printf("%s  PTT route log samples the cache before the resolve "
+                "(#4547)\n",
+                routeLogSampleOrder ? "PASS" : "FAIL");
+    std::printf("%s  PTT route log neutralises a client-supplied source "
+                "(#4547)\n",
+                routeLogSanitizes ? "PASS" : "FAIL");
 
     return validProfile && deferredAbort && observableFailure
         && powerRateLimits && trxCacheHolds && cacheResets && flagSeedsDeDups
@@ -870,5 +1128,6 @@ int main(int argc, char** argv)
         && activeSliceSeed && activeSliceRemoval && trxStableRecreate
         && trxDistinctReconnect && heldTrxRefuses
         && vfoConfirmsAccepted && vfoConfirmsRefusal && vfoAcksNoOp
+        && routeLogStaleCache && routeLogSampleOrder && routeLogSanitizes
         ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Adds a diagnostic log for the TCI PTT slice-routing decision. **No behaviour change** — same resolution, same order, same returns.

This is aimed squarely at the problem raised in #4547 and repeated on the reports behind #4514: the routing faults are real, but nobody can produce a log for them, because there is nothing that logs the decision. `TciServer` logs audio, IQ, DAX and client connections; the PTT slice resolution itself is silent, and `TciRoutingState` has no logging at all.

## Why

The three failure modes in #4547 are individually indistinguishable in the field today:

1. the requested trx is resolved away,
2. a cached route outlives the live TX assignment and moves transmit to a stale slice,
3. two clients address the same trx.

All three present identically to an operator — *"it keyed the wrong slice."* One line at the point of decision separates them. An external TX assignment winning over a stale cached route:

```
TCI PTT route: trx=1 rxSlice=1 -> txSlice=2 (NOT the requested slice) | liveTx=2 cachedTx=0 cachedRx=1 owner=tci-created split=false source=tci
```

- `-> txSlice` versus `rxSlice` shows case 1 directly, and is labelled in words so it does not depend on the reader knowing the mapping.
- `cachedTx` versus `liveTx` shows case 2 — the cached route disagreeing with the live assignment is the whole of that defect. The cached fields are sampled **before** `resolvePttSlice()`, which writes the live assignment through to the cache on that branch; read afterwards they would always agree with `liveTx` and case 2 would be invisible.
- `trx=` plus repeated lines shows case 3 across clients.
- `owner` / `split` / `source` give the branch context without needing the reader to replay `resolvePttSlice` by hand.

A second line records a move away from the slice that currently holds transmit — the cached route outliving the live assignment and keying a stale slice:

```
TCI PTT route: trx=1 rxSlice=1 -> txSlice=0 (NOT the requested slice) | liveTx=1 cachedTx=0 cachedRx=1 owner=tci-created split=false source=tci
TCI PTT: transmit will move from slice 1 to slice 0
```

It sits below the existence and inhibit guards and is worded as intent: `promoteTxSliceAndContinue()` is asynchronous and can still come back unselected, so this is the request that survived every guard, not a completed move.

The three silent early-returns below the decision now say why they fired instead of dropping the request without a trace: no owned slice for the requested trx, resolved slice no longer exists, pan transmit-inhibited (with the reason).

## Scope

- `routingEndpoints()` is evaluated once into a local and reused, rather than being called inline in the `resolvePttSlice` argument. Same value, one call.
- The combined `!txSlice || !inhibitReason.isEmpty()` guard is split into two, so each can name its own reason. Identical control flow.
- One small private static helper on `TciServer`: `txRouteOwnerName()` (enum → string for the log).
- `TciRoutingState::currentTxSlice()` goes from private static to **public** static, and `TciServer` no longer carries a verbatim copy of it. No logging is added to the routing class and its behaviour is unchanged — the point is that the diagnostic and the router now share one definition of "the live TX slice", so a future change to one cannot silently make the other lie.
- The decision is still logged at the call site, using the routing state's existing public accessors.

## Logging levels

The two route lines are `qCInfo` on `aether.cat`, whose default level is `QtWarningMsg`, so they are off unless asked for:

```
QT_LOGGING_RULES="aether.cat.info=true" ./AetherSDR
```

The three drop-reason lines are `qCWarning` and are therefore **on at the default level**. That is deliberate — a PTT that gets dropped without a trace is exactly what #4547 is about — but it does mean this PR adds default-level output on those three paths, not just opt-in output. Happy to demote them if that is not the call you want.

## Verification

- Full build clean (`ninja -C build`, all targets, exit 0).
- `ctest -R tci` — 4/4 pass on freshly relinked binaries: `tci_protocol_test`, `tci_automation_test`, `tci_server_review_test`, `hl2_tci_signaling_test`.
- `QString` rendering checked against a standalone Qt 6.10.3 probe rather than assumed: `.nospace()` alone prints `source="dax"`, `.nospace().noquote()` prints `source=dax`.
- Verified on a FLEX-6700 and a Hermes-Lite 2 (RX-only; the keying capture is the operator's).

## Constitution principle honored

**Principle I — FlexLib is protocol authority.** The log reports the slice the protocol resolution actually chose, rather than the one a reader might infer from the wire request; it makes the client-visible protocol behaviour observable instead of assumed.

## Test plan

- [x] Full build clean on Linux (Nobara 43, Qt 6.10.3, gcc 15.2.1)
- [x] `ctest -R tci` 4/4 pass
- [x] Log strings verified present in the binary
- [x] `noquote()` rendering verified against a live Qt probe
- [ ] Capture from a live two-slice keying session — operator's to run

## Checklist

- [x] Commits are signed (docs/COMMIT-SIGNING.md)
- [x] No new flat-key AppSettings calls (Principle V)
- [x] All meter UI uses MeterSmoother (Principle II)

Refs #4547

---

73, Ozy **K6OZY**  · cost: $99.83 · model: claude-opus-5
