### PR TITLE
docs(settings): align the canon with the shipped RFC #4603 architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -585,7 +585,7 @@ if (!scope.setFeature("MyFeature", kMySchemaVersion, doc)) {
   (see `RadioStateMemory::store()` for the canonical shape).
 - Shipped precedents: the HL2 `OperatingState` document (per-band drive/LNA
   maps in its extension), the `Identity` nickname document, and `BandStack`
-  (#4621); the shared memory bank follows in #4623.
+  (#4621), and the shared memory bank at `(local, '', MemoryBank)` (#4623).
 
 ### Client-Side Radio State Memory (capture/restore)
 
@@ -631,7 +631,7 @@ touches it.)
 
 **Migrating a legacy side file into scoped documents** follows the
 claim-and-freeze pattern (precedents: `Hl2Discovery` nicknames and
-`BandStackSettings`; `LocalMemoryBank` follows in #4623):
+`BandStackSettings`, `LocalMemoryBank`):
 
 - Claim lazily, per scope, on first access — the document needs the radio's
   FAMILY, which only the live scope knows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ tool. Each tool has its own well-known file at a different path
 project-wide lives in **this** file.
 
 If you are an AI assistant: read this file end-to-end before writing
-code or recommending merges. The file is ~440 lines; that's the cost
+code or recommending merges. The file is ~830 lines; that is the cost
 of doing the job right on this codebase.
 
 ## Project Goal
@@ -535,15 +535,72 @@ Rules that come with the store:
 - **Credentials never go in the settings store.** QtKeychain (service
   `"AetherSDR"`) is the only persistent credential store; without keychain
   support a credential is session-only via
-  `AppSettings::setSessionCredential()`. Follow the patterns in
+  `AppSettings::setSessionCredential()`. The known credential names live in
+  ONE table — `src/core/SettingsCredentialPolicy.h` — shared by the import
+  exodus, the export sanitizer, the `setValue()` seam guard, and the CLI, so
+  add new credentials THERE (the seam then enforces the policy for you).
+  Follow the patterns in
   `MqttSettings`/`AutomationBridgeSettings`/`CopyAssistSettings`.
 - The legacy XML file (`AetherSDR.settings`) is a **frozen snapshot** from the
   one-time import — never write to it, never delete it outside Reset Settings.
 - Pre-`QApplication` code reads via `SettingsBootstrap::readValue()` and paths
   come from `SettingsPaths` — never hand-build a config path.
-- The `AetherSDR --config <list|get|set|unset|export|path>` CLI inspects and
+- The `AetherSDR --config <list|get|set|unset|export|features|path>` CLI inspects and
   repairs the store without starting the GUI (the recovery path when a stored
   value breaks startup).
+
+### Radio-Scoped Feature Documents (`radio_settings`)
+
+Radio-scoped configuration — state that belongs to one physical radio or one
+backend family — does NOT go in flat `AppSettings` keys. It goes in the
+`radio_settings` table as **one versioned JSON document per feature per scope**
+(Constitution Principle V, realized in the store):
+
+```cpp
+const RadioSettingsScope scope = m_radioModel.settingsScope();  // (family, serial)
+QJsonObject doc = scope.feature("MyFeature");          // exact → family-wide → {}
+scope.setFeature("MyFeature", kMySchemaVersion, doc);  // atomic whole-document write
+```
+
+- Identity comes from `RadioModel::settingsScope()` (Flex serial / HL2 MAC /
+  Kiwi UUID) — never re-derive it yourself. An empty `radio_id` row is the
+  family-wide default; guard against writing one by accident when the serial
+  isn't known yet (see `BandStackSettings` for the pattern).
+- **Check the write result.** `setFeature()` can refuse (read-only store,
+  reset in progress); a mutation that silently doesn't persist while the UI
+  repaints from the store is the worst failure shape (PR #4621 review). Log
+  loudly at minimum.
+- Writers judging the row they're about to replace use the **exact** read
+  (`featureExact()`), not the fallback-composed one; and never overwrite a
+  document whose `schema_version` is newer than yours — refuse and log
+  (see `RadioStateMemory::store()` for the canonical shape).
+- Shipped precedents: the HL2 `OperatingState` document (per-band drive/LNA
+  maps in its extension), the `Identity` nickname document; `BandStack` and
+  the shared memory bank follow in #4621/#4623.
+
+### Client-Side Radio State Memory (capture/restore)
+
+For radios that persist nothing themselves, the client is the radio's memory —
+but only through the one sanctioned pipeline:
+
+- A backend declares WHICH state the client owns via
+  `RadioCapabilities::clientSettingsDomains` (typed per-domain flags; empty =
+  restore nothing). **Flex and Sim declare explicitly empty** — a CI test
+  guards this, because a non-empty Flex declaration would re-introduce the
+  #2465/#4126/#4261 re-assert-stale-state bug class.
+- `RadioStateMemory` is the ONLY reader/writer of the `OperatingState`
+  document; engagement is `shouldEngage(caps)` — capability-shaped, **never a
+  family-name check**. `RadioModel` hands restored state to the backend
+  unconditionally before `connectRadio()` (an empty state is the reset that
+  prevents same-family radio-swap bleed), and debounces capture (2 s trailing
+  + 10 s max-wait) with an explicit flush on disconnect AND in
+  `MainWindow::closeEvent()` (quit doesn't pump the queued path).
+- The backend validates everything it restores at its own boundary
+  (Principle VII) and **restore never keys transmit** (Principle VI) —
+  restored values are setpoints; the TX gate is untouched.
+- The extension document's top level is domain-named sub-objects gated
+  per-domain by the engine; the CONTENTS of each sub-object are the backend's
+  own (opaque above the seam).
 
 ### Settings Migration
 
@@ -563,21 +620,46 @@ Run once at app or feature startup, not on every access. (The XML→SQLite store
 migration itself is automatic inside `AppSettings::load()` — feature code never
 touches it.)
 
-### Radio-Authoritative Settings Policy
+**Migrating a legacy side file into scoped documents** follows the
+claim-and-freeze pattern (precedents: `Hl2Discovery` nicknames,
+`BandStackSettings`, `LocalMemoryBank`):
 
-**The radio is always authoritative for any setting it stores** (Constitution
-Principles II & III). AetherSDR must never save, recall, or override radio-side
-settings from client-side persistence. Only save client-side settings for things
-the radio does NOT save.
+- Claim lazily, per scope, on first access — the document needs the radio's
+  FAMILY, which only the live scope knows.
+- The document's existence is the migration marker; a **present-but-empty**
+  document blocks re-import (an operator who emptied a store must not have it
+  resurrected by a restored backup).
+- The legacy source stays **frozen** (or per-section-pruned, for multi-radio
+  files) as the downgrade snapshot — never rewritten with new data.
+- Memoize only *settled* states (document exists, claim succeeded, section
+  confirmed absent); every retryable condition (file missing, unparseable,
+  write refused) must retry on the next access, not be latched away.
 
-**Radio-authoritative (do NOT persist):** frequency, mode, filter, step size,
-AGC, squelch, DSP flags, antennas, TX power, panadapter *count* and per-pan
-state (center, bandwidth, min/max dBm, FFT average/FPS/weighted-average, and
-waterfall line duration).
+### Settings Authority Policy (radio-authoritative vs client-owned)
 
-**Client-authoritative (persist in AppSettings):** window geometry, layout
-arrangement (`PanadapterLayout`, applet order/visibility), client-side DSP
-(NR2/RN2/NR4/DFNR), UI preferences, client-only display appearance
+**The radio is always authoritative for any setting it can store** (Constitution
+Principles II & III) — and the deciding test is Constitution III's own:
+*whether THIS radio can save and restore the value*, which since RFC #4603 is a
+**declared capability, not a family assumption**:
+
+- **On a radio that persists its own state (Flex)**: never save, recall, or
+  override radio-side settings from client-side persistence. The lists below
+  apply verbatim, and `clientSettingsDomains` is declared EMPTY.
+- **On a radio that persists nothing (HL2; Sim/Kiwi as applicable)**: the
+  client IS the radio's memory — for exactly the domains the backend declares
+  in `RadioCapabilities::clientSettingsDomains`, persisted ONLY through
+  `RadioStateMemory`'s `OperatingState` document (see "Client-Side Radio State
+  Memory" above). Never in flat `AppSettings` keys, and never via ad-hoc code
+  paths — the one pipeline is what keeps the Flex guarantees provable.
+
+**Radio-authoritative on Flex (do NOT persist client-side):** frequency, mode,
+filter, step size, AGC, squelch, DSP flags, antennas, TX power, panadapter
+*count* and per-pan state (center, bandwidth, min/max dBm, FFT
+average/FPS/weighted-average, and waterfall line duration).
+
+**Client-authoritative everywhere (persist in AppSettings):** window geometry,
+layout arrangement (`PanadapterLayout`, applet order/visibility), client-side
+DSP (NR2/RN2/NR4/DFNR), UI preferences, client-only display appearance
 preferences, spot settings.
 
 **Why:** When both persist the same setting, they fight on reconnect. The

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -558,8 +558,17 @@ backend family — does NOT go in flat `AppSettings` keys. It goes in the
 
 ```cpp
 const RadioSettingsScope scope = m_radioModel.settingsScope();  // (family, serial)
-QJsonObject doc = scope.feature("MyFeature");          // exact → family-wide → {}
-scope.setFeature("MyFeature", kMySchemaVersion, doc);  // atomic whole-document write
+// Read-modify-write uses the EXACT row (no family-wide fallback — you must
+// not clone the family default into a per-radio row), and the write result
+// is checked: a refused write that the UI repaints over is the worst
+// failure shape.
+QJsonObject doc = scope.featureExact("MyFeature");
+doc.insert("field", newValue);
+if (!scope.setFeature("MyFeature", kMySchemaVersion, doc)) {
+    qWarning() << "MyFeature: settings write did not persist";
+}
+// (scope.feature() — exact → family-wide → {} — is for CONSUMERS reading
+// effective config, not for writers.)
 ```
 
 - Identity comes from `RadioModel::settingsScope()` (Flex serial / HL2 MAC /
@@ -575,8 +584,8 @@ scope.setFeature("MyFeature", kMySchemaVersion, doc);  // atomic whole-document 
   document whose `schema_version` is newer than yours — refuse and log
   (see `RadioStateMemory::store()` for the canonical shape).
 - Shipped precedents: the HL2 `OperatingState` document (per-band drive/LNA
-  maps in its extension), the `Identity` nickname document; `BandStack` and
-  the shared memory bank follow in #4621/#4623.
+  maps in its extension), the `Identity` nickname document, and `BandStack`
+  (#4621); the shared memory bank follows in #4623.
 
 ### Client-Side Radio State Memory (capture/restore)
 
@@ -621,8 +630,8 @@ migration itself is automatic inside `AppSettings::load()` — feature code neve
 touches it.)
 
 **Migrating a legacy side file into scoped documents** follows the
-claim-and-freeze pattern (precedents: `Hl2Discovery` nicknames,
-`BandStackSettings`, `LocalMemoryBank`):
+claim-and-freeze pattern (precedents: `Hl2Discovery` nicknames and
+`BandStackSettings`; `LocalMemoryBank` follows in #4623):
 
 - Claim lazily, per scope, on first access — the document needs the radio's
   FAMILY, which only the live scope knows.
@@ -645,9 +654,10 @@ Principles II & III) — and the deciding test is Constitution III's own:
 - **On a radio that persists its own state (Flex)**: never save, recall, or
   override radio-side settings from client-side persistence. The lists below
   apply verbatim, and `clientSettingsDomains` is declared EMPTY.
-- **On a radio that persists nothing (HL2; Sim/Kiwi as applicable)**: the
+- **On a radio that persists nothing and declares so (HL2 today)**: the
   client IS the radio's memory — for exactly the domains the backend declares
-  in `RadioCapabilities::clientSettingsDomains`, persisted ONLY through
+  in `RadioCapabilities::clientSettingsDomains` (Sim deliberately declares
+  none: a synthetic scene has nothing worth remembering), persisted ONLY through
   `RadioStateMemory`'s `OperatingState` document (see "Client-Side Radio State
   Memory" above). Never in flat `AppSettings` keys, and never via ad-hoc code
   paths — the one pipeline is what keeps the Flex guarantees provable.
@@ -662,8 +672,11 @@ layout arrangement (`PanadapterLayout`, applet order/visibility), client-side
 DSP (NR2/RN2/NR4/DFNR), UI preferences, client-only display appearance
 preferences, spot settings.
 
-**Why:** When both persist the same setting, they fight on reconnect. The
-radio's GUIClientID session restore is always more current than our saved state.
+**Why (the Flex half):** when both the client and a self-persisting radio
+store the same setting, they fight on reconnect — the radio's GUIClientID
+session restore is always more current than our saved copy. On a declared-
+domain radio there is no second store to fight with, which is exactly why the
+client may hold the state there and only there.
 
 **Anti-pattern (recurring — see #4261):** Do not write a radio-echoed status
 value into a setter that *also* persists it to `AppSettings`. That makes the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,12 +89,19 @@ changes.
   (`AetherSDR.db`, RFC #4603) — never include `sqlite3.h` outside
   `SettingsDatabase.cpp`, and **never put a credential in the settings
   store**: QtKeychain only (see AGENTS.md "Settings Persistence").
-- **Radio-authoritative**: Never persist or override settings the radio manages
-  (frequency, mode, filter, step size, AGC, squelch, DSP flags, antennas, TX
-  power, panadapter *count* and per-pan state — including FFT
-  average/FPS/weighted-average and waterfall line duration). Never write a
-  radio-echoed status value into a setter that also persists to `AppSettings`
-  (the recurring #4261 anti-pattern). See `AGENTS.md` for the full list.
+- **Settings authority is capability-shaped** (RFC #4603): on a radio that
+  persists its own state (Flex), never persist or override radio-managed
+  settings client-side (frequency, mode, filter, AGC, TX power, per-pan
+  state, …) and never write a radio-echoed status value into a setter that
+  also persists (the recurring #4261 anti-pattern). On a radio that persists
+  NOTHING (HL2), the client is its memory — but only for the domains the
+  backend declares in `RadioCapabilities::clientSettingsDomains`, and only
+  through `RadioStateMemory`'s document, never flat `AppSettings` keys or
+  ad-hoc paths. See AGENTS.md "Settings Authority Policy" for the full rules.
+- **Radio-scoped config** goes in `radio_settings` feature documents via
+  `RadioModel::settingsScope()` — one versioned JSON document per feature
+  (Principle V), atomic whole-document writes, write failures surfaced. See
+  AGENTS.md "Radio-Scoped Feature Documents".
 
 ### Working in MainWindow
 

--- a/docs/settings-store-sqlite-design.md
+++ b/docs/settings-store-sqlite-design.md
@@ -1,6 +1,8 @@
 # Client Settings Store — SQLite Design (RFC #4603)
 
-Status: **implemented** (PR 1 of the RFC's phased plan)
+Status: **implemented through PR 3** (storage engine #4612, scoped store +
+authority #4614, HL2 state memory #4619 — all merged; BandStack #4621 and the
+memory bank #4623 in review; the Settings Browser is the remaining phase)
 RFC / tracking issue: [#4603](https://github.com/aethersdr/AetherSDR/issues/4603)
 Closes: [#4602](https://github.com/aethersdr/AetherSDR/issues/4602) (thread safety)
 
@@ -61,9 +63,15 @@ radio_settings   (family, radio_id, feature, schema_version, value;
                   PRIMARY KEY (family, radio_id, feature))
 ```
 
-All four tables exist from v1 so the file format is stable, even though
-`radio_settings` (one **versioned JSON document per feature per scope**,
-Constitution Principle V) is consumed starting with RFC PR 2. `radio_id` is
+All four tables exist from v1 so the file format is stable. `radio_settings`
+holds one **versioned JSON document per feature per scope** (Constitution
+Principle V) and is live: the HL2 `OperatingState` document (universal fields
+plus per-band drive/LNA maps in domain-gated extension sub-objects), the
+`Identity` nickname document, and — in review — `BandStack` and the shared
+memory bank at `(local, '', MemoryBank)`. Writers judge the exact row they
+replace (`radioFeatureExact`, no family-wide fallback) and refuse to overwrite
+a newer `schema_version` — read-only toward the future, at both the store and
+the document layer. `radio_id` is
 the per-family canonical identity (Flex serial / HL2 MAC / Kiwi profile UUID);
 `radio_id=''` rows are family-wide defaults. Values are TEXT throughout; the
 `"True"`/`"False"` boolean convention is unchanged.
@@ -146,6 +154,32 @@ worker-thread event-loop code is fine — that is precisely the #4602 case.
   not a backup.
 - The support bundle's `settings.txt` is the same sanitized dump plus the
   current load notice and migration stamps.
+
+## Shipped hardening beyond the original design (review rounds)
+
+- **Credential seam**: `SettingsCredentialPolicy.h` is the single table of
+  credential names, shared by the import exodus, the sanitizer (exact names +
+  shape regex, recursive over JSON values), the `setValue()` seam guard
+  (flat keys divert to the session vault; document fields are stripped), and
+  the CLI's `set` refusal.
+- **Busy is not corrupt**: `SQLITE_BUSY/LOCKED` anywhere in the open sequence
+  fails the session instead of quarantining (POSIX `rename()` succeeds on
+  open files — quarantining a live store split-brains a concurrent writer);
+  quarantine+restore is serialized under a `QLockFile`.
+- **Newer-schema stores reopen `SQLITE_OPEN_READONLY`** — engine-enforced,
+  and `close()` never checkpoints (writes) a newer binary's file.
+- **Test isolation**: `SettingsPaths::configDir()` honors the
+  `AETHER_SETTINGS_DIR` override on every platform (Windows ignores env
+  redirects through `QStandardPaths`); `TestSettingsProfile` sets it, and
+  every store path — including side-file consumers like `BandStackSettings` —
+  must route through `SettingsPaths`.
+- **Capture/restore lifecycle** (PR 3): `RadioStateMemory` engagement is
+  capability-shaped (`clientSettingsDomains`, empty = inert, Flex/Sim guarded
+  by CI); restore is handed over unconditionally pre-connect (empty = the
+  radio-swap reset); capture debounces 2 s with a 10 s max-wait, flushes on
+  disconnect and explicitly in `closeEvent`; the connect-time power push is a
+  seeded value-identical echo that records nothing (bench-found on real
+  hardware — the review record on #4619 is the case study).
 
 ## Testing
 

--- a/docs/settings-store-sqlite-design.md
+++ b/docs/settings-store-sqlite-design.md
@@ -1,8 +1,8 @@
 # Client Settings Store — SQLite Design (RFC #4603)
 
-Status: **implemented through PR 4** (storage engine #4612, scoped store +
-authority #4614, HL2 state memory #4619, BandStack #4621 — all merged; the
-memory bank #4623 in review; the Settings Browser is the remaining phase)
+Status: **implemented through PR 6** (storage engine #4612, scoped store +
+authority #4614, HL2 state memory #4619, BandStack #4621, memory bank #4623 —
+all merged; the Settings Browser is the remaining phase)
 RFC / tracking issue: [#4603](https://github.com/aethersdr/AetherSDR/issues/4603)
 Closes: [#4602](https://github.com/aethersdr/AetherSDR/issues/4602) (thread safety)
 
@@ -67,9 +67,11 @@ All four tables exist from v1 so the file format is stable. `radio_settings`
 holds one **versioned JSON document per feature per scope** (Constitution
 Principle V) and is live: the HL2 `OperatingState` document (universal fields
 plus per-band drive/LNA maps in domain-gated extension sub-objects), the
-`Identity` nickname document, and `BandStack` (#4621); the shared memory bank
-at `(local, '', MemoryBank)` follows in #4623 (its shared-vs-per-radio scoping
-awaits the #4590 author's blessing there — re-check this sentence if re-cut). Writers judge the exact row they
+`Identity` nickname document, and `BandStack` (#4621); and the shared memory bank
+at `(local, '', MemoryBank)` (#4623 — deliberately ONE shared document
+preserving #4590's cross-radio channel list; nigelfenton's review supplied the
+stronger justification: the bank engages on exactly the radios whose identity
+is least stable, so per-radio keying would fragment channels on a NIC swap). Writers judge the exact row they
 replace (`radioFeatureExact`, no family-wide fallback) and refuse to overwrite
 a newer `schema_version` — read-only toward the future, at both the store and
 the document layer. `radio_id` is

--- a/docs/settings-store-sqlite-design.md
+++ b/docs/settings-store-sqlite-design.md
@@ -1,7 +1,7 @@
 # Client Settings Store — SQLite Design (RFC #4603)
 
-Status: **implemented through PR 3** (storage engine #4612, scoped store +
-authority #4614, HL2 state memory #4619 — all merged; BandStack #4621 and the
+Status: **implemented through PR 4** (storage engine #4612, scoped store +
+authority #4614, HL2 state memory #4619, BandStack #4621 — all merged; the
 memory bank #4623 in review; the Settings Browser is the remaining phase)
 RFC / tracking issue: [#4603](https://github.com/aethersdr/AetherSDR/issues/4603)
 Closes: [#4602](https://github.com/aethersdr/AetherSDR/issues/4602) (thread safety)
@@ -67,8 +67,9 @@ All four tables exist from v1 so the file format is stable. `radio_settings`
 holds one **versioned JSON document per feature per scope** (Constitution
 Principle V) and is live: the HL2 `OperatingState` document (universal fields
 plus per-band drive/LNA maps in domain-gated extension sub-objects), the
-`Identity` nickname document, and — in review — `BandStack` and the shared
-memory bank at `(local, '', MemoryBank)`. Writers judge the exact row they
+`Identity` nickname document, and `BandStack` (#4621); the shared memory bank
+at `(local, '', MemoryBank)` follows in #4623 (its shared-vs-per-radio scoping
+awaits the #4590 author's blessing there — re-check this sentence if re-cut). Writers judge the exact row they
 replace (`radioFeatureExact`, no family-wide fallback) and refuse to overwrite
 a newer `schema_version` — read-only toward the future, at both the store and
 the document layer. `radio_id` is

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -122,8 +122,8 @@ static int runConfigCli(int argc, char* argv[])
             "  export             sanitized dump of the whole store (secrets\n"
             "                     redacted; diagnostic output, not a backup)\n"
             "  features [family]  list radio-scoped feature documents\n"
-            "                     (sanitized; write access lands with RFC #4603\n"
-            "                     PR 3, when something writes them)\n"
+            "                     (sanitized; written by the app's own\n"
+            "                     features — HL2 state, nicknames, band stacks)\n"
             "  path               print the settings database path\n",
             stderr);
         return 1;


### PR DESCRIPTION
Documentation audit of the project canon (AGENTS.md, CONTRIBUTING.md, GOVERNANCE.md, CONSTITUTION.md, the settings design doc) against the shipped RFC #4603 architecture (PRs 1–3 merged; #4621/#4623 in review). Maintainer-requested.

## The load-bearing fix

**AGENTS.md's "Radio-Authoritative Settings Policy" and CONTRIBUTING's mirror stated the rule family-blind** — a flat *"do NOT persist: frequency, mode, filter, TX power…"*. That was correct doctrine for Flex, and it is now **exactly what the client does for the HL2** (#4619, bench-validated). An agent following those sections literally would flag shipped behavior as a constitution violation.

Both are rewritten **capability-shaped**, anchored on Constitution III's own deciding test (*whether THIS radio can save and restore the value*):
- Flex keeps the verbatim prohibition list and the #4261 anti-pattern, with `clientSettingsDomains` declared empty (CI-guarded).
- Declared-domain radios persist **only** through `RadioStateMemory`'s `OperatingState` document — never flat `AppSettings` keys, never ad-hoc paths.

## New AGENTS.md sections

- **Radio-Scoped Feature Documents** — the `RadioModel::settingsScope()` API, one versioned document per feature (Principle V), atomic whole-document writes, *check the write result* (the #4621 silent-loss lesson), exact-row reads for writers, newer-schema refusal, shipped precedents.
- **Client-Side Radio State Memory** — per-domain declarations with the Flex/Sim explicit-empty guard, the unconditional pre-connect handover (radio-swap reset), the capture lifecycle (2 s debounce, 10 s max-wait, disconnect flush, explicit `closeEvent` flush), boundary validation, restore-never-keys, domain-gated extension sub-objects.
- **Settings Migration** gains the claim-and-freeze side-file pattern: frozen legacy source, document-existence marker, present-but-empty blocks resurrection, memoize-only-settled (the nickname / BandStack / memory-bank precedents).

## Smaller corrections

- Credentials bullet names `SettingsCredentialPolicy.h` as THE single credential table with seam enforcement (add new credentials there; the seam enforces for you).
- `--config` synopsis gains `features`.
- Design doc: status reflects PRs 1–3 shipped + 4/6 in review; the schema section describes the *live* `radio_settings` consumers; a "shipped hardening beyond the original design" section records the review-round changes (credential seam, busy-is-not-corrupt, read-only reopen, `AETHER_SETTINGS_DIR`, capture lifecycle) so the doc matches the code, not the plan.
- AGENTS.md's self-description said "~440 lines"; it is ~830.

## Reviewed and deliberately unchanged

- **GOVERNANCE.md** — no settings content; its RFC process is what produced this architecture, working as designed.
- **CONSTITUTION.md** — Principle III's own test already accommodates the per-domain model; the constitution was ahead of its commentary, and only derived docs had fossilized it into a Flex-shaped list. Principles V and XIV's examples remain accurate. (Two cosmetic possibilities — a `radio_settings` mention in V's example, and codifying the mutation-test verification standard from the #4621 thread into CONTRIBUTING — were flagged to the maintainer and deliberately left out of this PR pending his call.)

Docs-only; no code changes; no rebuild required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
