### PR TITLE
fix(test): close the read handle before flushing in local_memory_bank_test

### DIFF
--- a/tests/local_memory_bank_test.cpp
+++ b/tests/local_memory_bank_test.cpp
@@ -372,10 +372,18 @@ int main(int argc, char** argv)
         first.record(1, MemoryEntry{});
         first.flush();
 
-        QFile f(p);
-        ok &= expect(f.open(QIODevice::ReadOnly), "the shared bank still opens");
-        ok &= expect(f.readAll() == theirs,
-                     "a foreign write is not clobbered by our flush");
+        // Scoped, so the read handle is CLOSED before the flushes below. On
+        // Windows an open handle blocks QSaveFile::commit()'s atomic rename
+        // ("Access is denied"), so leaving it open made both saves fail — the
+        // assertion at the end of this block then read as a re-baselining bug
+        // that was not there. POSIX permits the rename, which is why this only
+        // ever failed on Windows.
+        {
+            QFile f(p);
+            ok &= expect(f.open(QIODevice::ReadOnly), "the shared bank still opens");
+            ok &= expect(f.readAll() == theirs,
+                         "a foreign write is not clobbered by our flush");
+        }
         ok &= expect(first.lastError().contains("changed by another"),
                      "the refusal names the concurrent-write reason");
 


### PR DESCRIPTION
`local_memory_bank_test` has been failing on Windows since #4590 landed, on the concurrent-writer block's final assertion:

```
FAIL: consecutive flushes both land after a clean load
```

Deterministic — every run, not a flake.

## Root cause: an open read handle, not the re-baselining logic

The assertion's own comment points at the mtime baseline ("our own save must re-baseline, or the very next flush would mistake our own mtime for somebody else's"), and that is a plausible-looking place for a bug — two default-constructed `MemoryEntry{}` values serialize to the same length, so a coarse timestamp plus an unchanged size *could* in principle collide. That was my first hypothesis and it was wrong.

Instrumenting the actual state showed something else:

```
PROBE has9=0 has10=0
freshErr="Couldn't commit .../shared.json: Access is denied."
```

**Neither** slot lands, and execution never reaches `foreignWriteDetected()`. The `QFile f(p)` opened at line 375 to verify the foreign write is still open when the two `flush()` calls below it run. On Windows an open handle blocks `QSaveFile::commit()`'s atomic rename, so both saves fail outright. POSIX permits renaming over an open file, which is why Linux and macOS never saw this.

So the failure was a test bug masquerading as a re-baselining defect in `LocalMemoryBank`. The production code is fine.

## The fix

Scope the read handle so it closes before the flushes — matching the idiom the same block already uses a few lines above, where the simulated foreign write is written inside its own `{ ... }`.

## Verification

| Platform | Toolchain | before | after |
|---|---|---|---|
| Windows 11 x64 | MSVC | **FAIL** | all checks passed |
| Linux x86_64 | GCC | pass | pass |
| macOS arm64 | AppleClang | pass | pass |
| Raspberry Pi 5 (aarch64) | GCC | pass | pass |

Before/after on Windows was confirmed both ways: adding the scope makes it pass, reverting brings the identical failure straight back.

## Why CI did not catch it

The Windows job executes four tests (`thumbdv_queue_test`, `dstar_model_test`, `digital_voice_waveform_process_test`, `aether_dv_waveform_no_args`); `local_memory_bank_test` is compiled but never run. On Linux it is run and passes, since the defect is Windows-only. No existing CI configuration would have surfaced this.

## Note on overlap with RFC #4603 PR 6

#4623 moves the bank into the settings store, replacing this `QSaveFile` path with a database write — so this failure disappears on that branch regardless. That is worth fixing here anyway: the bug is live on `main` today, and if #4623 merges first it gets buried rather than fixed, leaving a false record that this test was always green on Windows. The fix is confined to the test and does not conflict with #4623's rewrite of the same block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
