### PR TITLE
fix(model): install every model-lifetime callback once (#4599)

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -501,6 +501,16 @@ void RadioModel::setupBackend(const QString& family)
     // connection made here has the backend (or a backend-owned object) as sender
     // or receiver, so destroying the old backend in teardownBackend() removes
     // them all automatically and re-running cannot duplicate them.
+    //
+    // That is a RULE for anything added here, not an observation. Qt drops a
+    // connection only when one of its two objects dies, so a connection whose
+    // sender AND receiver both outlive the backend — `this` on both ends, or a
+    // RadioModel value member such as m_transmitModel as sender — is invisible
+    // to teardownBackend() and gains one live copy per family switch (#4599).
+    // Those belong in the constructor's model-lifetime block instead, even when
+    // the lambda body talks to m_backend: re-reading m_backend and m_family at
+    // call time is exactly what makes a once-installed callback correct across
+    // a swap.
     m_family = family.isEmpty() ? QStringLiteral("flex") : family.toLower();
 
     {
@@ -801,13 +811,6 @@ void RadioModel::setupBackend(const QString& family)
     connect(m_backend.get(), &IRadioBackend::meterRemoved, this,
             [this](int index) { m_meterModel.removeMeter(index); });
 
-    // RF power to a backend that owns a drive register. Flex takes it as a text
-    // command from TransmitModel and ignores this.
-    connect(&m_transmitModel, &TransmitModel::rfPowerChanged, this,
-            [this](int percent) {
-        if (m_backend)
-            m_backend->setTxPower(percent);
-    });
     // A backend may revise its own capabilities mid-session (SimBackend does so
     // on connect; a Flex refines its seeded table as touchpoints convert), and
     // until now nothing above the seam listened — connectionStateChanged was the
@@ -836,59 +839,6 @@ void RadioModel::setupBackend(const QString& family)
     // the last tune before Disconnect was exactly the state being lost).
     connect(m_backend.get(), &IRadioBackend::disconnected, this,
             &RadioModel::flushPendingOperatingState);
-
-    // Keying and tune from the GUI.
-    //
-    // These paths never reached a non-Flex backend: the MOX button goes through
-    // TransmitModel::setMox, which emits the Flex text command "xmit 1" and
-    // nothing else, and TUNE emits "transmit tune 1" the same way. Only the
-    // automation bridge's key verb went through setTransmit() and therefore
-    // through the seam — which is exactly why keying worked under test and did
-    // nothing when the operator pressed MOX.
-    //
-    // Gated to non-Flex families ON PURPOSE: for Flex the text command above
-    // already keys the radio, and routing this as well would send "xmit 1"
-    // twice.
-    connect(&m_transmitModel, &TransmitModel::moxCommandIssued, this,
-            [this](bool on) {
-        if (m_backend && m_family != QLatin1String("flex")) {
-            if (on && !refuseKeyOnTransmitIncapableBackend())
-                return;
-            m_backend->setKeying(on);
-            // The MOX button and the PTT coordinator key here, NOT through
-            // setTransmit(), so the raw-TX edge has to be published on this path
-            // too — otherwise a TCI client watching an operator-initiated
-            // transmit sees nothing. See publishBackendTransmitEdge().
-            publishBackendTransmitEdge(on);
-        }
-    });
-    connect(&m_transmitModel, &TransmitModel::tuneCommandIssued, this,
-            [this](bool on) {
-        if (m_backend && m_family != QLatin1String("flex")) {
-            if (on && !refuseKeyOnTransmitIncapableBackend()) {
-                // Un-latch TUNE as well. m_tune was already set optimistically
-                // (TransmitModel::startTune), and the button's toggle reads it,
-                // so leaving it set would strand TUNE "on" against a radio that
-                // never keyed. The re-entry through this same slot carries
-                // on=false and so skips the guard.
-                m_transmitModel.stopTune();
-                return;
-            }
-            // Hand the backend the operator's TUNE power. A host-modulated
-            // backend has no other path to it — see IRadioBackend::setTune().
-            m_backend->setTune(on, m_transmitModel.tunePower());
-            // A tune carrier is a transmission. Hl2Backend::setTune() calls
-            // setKeying(), so the radio is on the air — the raw-TX edge has to
-            // be published here for the same reason it is on the MOX path, and
-            // for one more that is specific to tune: TciServer's
-            // "already transmitting" guard reads isRadioTransmitting(), so
-            // leaving it false let a TCI client key ON TOP of a live tune
-            // carrier, and that client's unkey then dropped the key while tune
-            // still believed it owned it. A TCI-driven amplifier also never saw
-            // trx:true for the carrier operators most often tune INTO an amp.
-            publishBackendTransmitEdge(on);
-        }
-    });
 
     // Meter VALUES from a backend that decodes its own telemetry.
     //
@@ -1500,26 +1450,20 @@ RadioModel::RadioModel(QObject* parent)
         }
     });
 
-    // aetherd RFC step 2.2b: the radio-facing seam owns the wire objects. The
-    // FlexBackend creates the RadioConnection and PanadapterStream on their
-    // worker threads (in the load-bearing #502 order — panStream first) and
-    // tears them down. RadioModel keeps non-owning pointers, obtained here, so
-    // all the signal wiring and command/WAN orchestration below is byte-for-byte
-    // as before — the move is ownership-only.
+    // ── Model-lifetime wiring ───────────────────────────────────────────────
     //
-    // Note: the threads now start here (as the ctor's first statement) rather
-    // than adjacent to their signal wiring below. Safe because RadioConnection::
-    // init()/PanadapterStream::init() only allocate sockets/timers and neither
-    // auto-connects nor emits — so there is no lost-signal window before our
-    // statusReceived/etc. connections are made. Keep that true if init() grows.
-    // Default to Flex; the backend is swapped in connectToRadio() to match
-    // whichever radio the operator picks in the connection manager.
-    setupBackend(QStringLiteral("flex"));
+    // Every connection below has RadioModel on BOTH ends: `this` as receiver,
+    // and as sender either `this` or a RadioModel value member. Nothing here
+    // dies with the backend, so nothing here may live in the rerunnable
+    // setupBackend() — installed there, these survived teardownBackend() and
+    // accumulated one live copy per family switch for the rest of the session
+    // (#4599). They follow whichever backend is current all the same, because
+    // each lambda re-reads m_backend / m_family at call time.
+    //
+    // Installed BEFORE the first setupBackend() below so no connection edge can
+    // ever precede its own callback. Nothing emits during setupBackend() today;
+    // this makes that a property of the code rather than of an audit.
 
-    // These connection-edge callbacks follow whichever backend is current, but
-    // neither connection is owned by that backend. Install them once for the
-    // RadioModel lifetime rather than once per setupBackend() call.
-    //
     // Tell the transmit model whether the HOST modulates. It drives the
     // mic-source list: a backend that modulates here has no physical input jacks
     // to choose between, so "PC" is the only truthful answer.
@@ -1537,6 +1481,83 @@ RadioModel::RadioModel(QObject* parent)
             m_backend->setTxPower(m_transmitModel.rfPower());
         }
     });
+
+    // RF power to a backend that owns a drive register. Flex takes it as a text
+    // command from TransmitModel and ignores this.
+    connect(&m_transmitModel, &TransmitModel::rfPowerChanged, this,
+            [this](int percent) {
+        if (m_backend)
+            m_backend->setTxPower(percent);
+    });
+
+    // Keying and tune from the GUI.
+    //
+    // These paths never reached a non-Flex backend: the MOX button goes through
+    // TransmitModel::setMox, which emits the Flex text command "xmit 1" and
+    // nothing else, and TUNE emits "transmit tune 1" the same way. Only the
+    // automation bridge's key verb went through setTransmit() and therefore
+    // through the seam — which is exactly why keying worked under test and did
+    // nothing when the operator pressed MOX.
+    //
+    // Gated to non-Flex families ON PURPOSE: for Flex the text command above
+    // already keys the radio, and routing this as well would send "xmit 1"
+    // twice.
+    connect(&m_transmitModel, &TransmitModel::moxCommandIssued, this,
+            [this](bool on) {
+        if (m_backend && m_family != QLatin1String("flex")) {
+            if (on && !refuseKeyOnTransmitIncapableBackend())
+                return;
+            m_backend->setKeying(on);
+            // The MOX button and the PTT coordinator key here, NOT through
+            // setTransmit(), so the raw-TX edge has to be published on this path
+            // too — otherwise a TCI client watching an operator-initiated
+            // transmit sees nothing. See publishBackendTransmitEdge().
+            publishBackendTransmitEdge(on);
+        }
+    });
+    connect(&m_transmitModel, &TransmitModel::tuneCommandIssued, this,
+            [this](bool on) {
+        if (m_backend && m_family != QLatin1String("flex")) {
+            if (on && !refuseKeyOnTransmitIncapableBackend()) {
+                // Un-latch TUNE as well. m_tune was already set optimistically
+                // (TransmitModel::startTune), and the button's toggle reads it,
+                // so leaving it set would strand TUNE "on" against a radio that
+                // never keyed. The re-entry through this same slot carries
+                // on=false and so skips the guard.
+                m_transmitModel.stopTune();
+                return;
+            }
+            // Hand the backend the operator's TUNE power. A host-modulated
+            // backend has no other path to it — see IRadioBackend::setTune().
+            m_backend->setTune(on, m_transmitModel.tunePower());
+            // A tune carrier is a transmission. Hl2Backend::setTune() calls
+            // setKeying(), so the radio is on the air — the raw-TX edge has to
+            // be published here for the same reason it is on the MOX path, and
+            // for one more that is specific to tune: TciServer's
+            // "already transmitting" guard reads isRadioTransmitting(), so
+            // leaving it false let a TCI client key ON TOP of a live tune
+            // carrier, and that client's unkey then dropped the key while tune
+            // still believed it owned it. A TCI-driven amplifier also never saw
+            // trx:true for the carrier operators most often tune INTO an amp.
+            publishBackendTransmitEdge(on);
+        }
+    });
+
+    // aetherd RFC step 2.2b: the radio-facing seam owns the wire objects. The
+    // FlexBackend creates the RadioConnection and PanadapterStream on their
+    // worker threads (in the load-bearing #502 order — panStream first) and
+    // tears them down. RadioModel keeps non-owning pointers, obtained here, so
+    // all the signal wiring and command/WAN orchestration below is byte-for-byte
+    // as before — the move is ownership-only.
+    //
+    // Note: the threads now start here (as the ctor's first statement) rather
+    // than adjacent to their signal wiring below. Safe because RadioConnection::
+    // init()/PanadapterStream::init() only allocate sockets/timers and neither
+    // auto-connects nor emits — so there is no lost-signal window before our
+    // statusReceived/etc. connections are made. Keep that true if init() grows.
+    // Default to Flex; the backend is swapped in connectToRadio() to match
+    // whichever radio the operator picks in the connection manager.
+    setupBackend(QStringLiteral("flex"));
 
     // #4142 — single owner of the deferred pan-write replay. Armed by the
     // defer path (armProfileLoadPanWriteFlush), hold-relative, self-re-arming;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -808,12 +808,6 @@ void RadioModel::setupBackend(const QString& family)
         if (m_backend)
             m_backend->setTxPower(percent);
     });
-    // Tell the transmit model whether the HOST modulates. It drives the
-    // mic-source list: a backend that modulates here has no physical input jacks
-    // to choose between, so "PC" is the only truthful answer.
-    connect(this, &RadioModel::connectionStateChanged, this,
-            [this](bool connected) { publishCapabilities(connected); });
-
     // A backend may revise its own capabilities mid-session (SimBackend does so
     // on connect; a Flex refines its seeded table as touchpoints convert), and
     // until now nothing above the seam listened — connectionStateChanged was the
@@ -894,17 +888,6 @@ void RadioModel::setupBackend(const QString& family)
             // trx:true for the carrier operators most often tune INTO an amp.
             publishBackendTransmitEdge(on);
         }
-    });
-
-    // Push the CURRENT power on connect, not only on change. rfPowerChanged
-    // fires on edges, so a session that never touches the control left the
-    // radio at whatever its own default was — on the HL2 that is drive 0, which
-    // also leaves the PA disabled, so a perfectly correct keyed transmission
-    // produced no RF at all. Measured: forward-power counts stuck at zero.
-    connect(this, &RadioModel::connectionStateChanged, this,
-            [this](bool connected) {
-        if (connected && m_backend)
-            m_backend->setTxPower(m_transmitModel.rfPower());
     });
 
     // Meter VALUES from a backend that decodes its own telemetry.
@@ -1532,6 +1515,28 @@ RadioModel::RadioModel(QObject* parent)
     // Default to Flex; the backend is swapped in connectToRadio() to match
     // whichever radio the operator picks in the connection manager.
     setupBackend(QStringLiteral("flex"));
+
+    // These connection-edge callbacks follow whichever backend is current, but
+    // neither connection is owned by that backend. Install them once for the
+    // RadioModel lifetime rather than once per setupBackend() call.
+    //
+    // Tell the transmit model whether the HOST modulates. It drives the
+    // mic-source list: a backend that modulates here has no physical input jacks
+    // to choose between, so "PC" is the only truthful answer.
+    connect(this, &RadioModel::connectionStateChanged, this,
+            [this](bool connected) { publishCapabilities(connected); });
+
+    // Push the CURRENT power on connect, not only on change. rfPowerChanged
+    // fires on edges, so a session that never touches the control left the
+    // radio at whatever its own default was — on the HL2 that is drive 0, which
+    // also leaves the PA disabled, so a perfectly correct keyed transmission
+    // produced no RF at all. Measured: forward-power counts stuck at zero.
+    connect(this, &RadioModel::connectionStateChanged, this,
+            [this](bool connected) {
+        if (connected && m_backend) {
+            m_backend->setTxPower(m_transmitModel.rfPower());
+        }
+    });
 
     // #4142 — single owner of the deferred pan-write replay. Armed by the
     // defer path (armProfileLoadPanWriteFlush), hold-relative, self-re-arming;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -511,6 +511,14 @@ void RadioModel::setupBackend(const QString& family)
     // the lambda body talks to m_backend: re-reading m_backend and m_family at
     // call time is exactly what makes a once-installed callback correct across
     // a swap.
+    //
+    // One carve-out, already below: the per-slice intents wired inside the
+    // sliceChanged handler name a SliceModel as sender, and that is a RadioModel
+    // child, so teardownBackend() does not drop those either. They are still
+    // right here — each connect runs once per slice CREATION (guarded on !s),
+    // and dropAllSessionModelsForFamilySwitch() deletes every slice before the
+    // swap. What the rule is really about is a sender that lives as long as the
+    // RadioModel: `this`, or a value member such as m_transmitModel.
     m_family = family.isEmpty() ? QStringLiteral("flex") : family.toLower();
 
     {
@@ -1452,8 +1460,10 @@ RadioModel::RadioModel(QObject* parent)
 
     // ── Model-lifetime wiring ───────────────────────────────────────────────
     //
-    // Every connection below has RadioModel on BOTH ends: `this` as receiver,
-    // and as sender either `this` or a RadioModel value member. Nothing here
+    // Every connection in THIS BLOCK (down to the aetherd RFC 2.2b note) has
+    // RadioModel on BOTH ends: `this` as receiver, and as sender either `this`
+    // or a RadioModel value member. The rest of the constructor is ordinary
+    // model wiring and carries no such claim. Nothing here
     // dies with the backend, so nothing here may live in the rerunnable
     // setupBackend() — installed there, these survived teardownBackend() and
     // accumulated one live copy per family switch for the rest of the session
@@ -1550,8 +1560,10 @@ RadioModel::RadioModel(QObject* parent)
     // all the signal wiring and command/WAN orchestration below is byte-for-byte
     // as before — the move is ownership-only.
     //
-    // Note: the threads now start here (as the ctor's first statement) rather
-    // than adjacent to their signal wiring below. Safe because RadioConnection::
+    // Note: the threads start at THIS call rather than adjacent to their signal
+    // wiring below. (It used to be the ctor's first statement; the model-lifetime
+    // block above and the DV/meter wiring before it now precede it, and none of
+    // that touches the wire.) Safe because RadioConnection::
     // init()/PanadapterStream::init() only allocate sockets/timers and neither
     // auto-connects nor emits — so there is no lost-signal window before our
     // statusReceived/etc. connections are made. Keep that true if init() grows.

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -451,6 +451,23 @@ int main(int argc, char** argv)
               "round-trip: Flex regains hasSupplyVoltageTelemetry after sim -> Flex");
     }
 
+    // ---- Family swaps do not duplicate the connection-edge relay -----------
+    //
+    // setupBackend() ran once for each of Flex -> HL2 -> Sim -> Flex above.
+    // A RadioModel-owned connection installed there survives teardownBackend(),
+    // so one connectionStateChanged edge would fan out once per family visited.
+    // Invoke the signal synchronously to isolate this ownership invariant from
+    // any backend's asynchronous connect lifecycle or capabilitiesChanged signal.
+    {
+        QSignalSpy spy(&model, &RadioModel::capabilitiesChanged);
+        const bool invoked = QMetaObject::invokeMethod(
+            &model, "connectionStateChanged", Qt::DirectConnection,
+            Q_ARG(bool, true));
+        check(invoked, "connectionStateChanged can be invoked for the ownership check");
+        check(spy.count() == 1,
+              "family swaps leave exactly one connection-edge capability relay");
+    }
+
     // ---- Flex extended DSP is unchanged by the reconciliation -------------
     //
     // The byte-identical claim: FlexBackend computes caps.hasExtendedDsp as

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -421,6 +421,43 @@ int main(int argc, char** argv)
               "disconnected: hasRadioSideWaterfallAutoBlack() goes permissive, HW back");
     }
 
+    // ---- The TX-intent callbacks are installed once too --------------------
+    //
+    // Same ownership rule as the connection-edge relay checked further down, on
+    // the other three connections setupBackend() used to make with RadioModel on
+    // both ends: rfPowerChanged, moxCommandIssued and tuneCommandIssued (sender
+    // &m_transmitModel, a RadioModel value member; receiver `this`). They are
+    // installed as one block, so counting one of them counts all three.
+    // setupBackend() has run three times by here — ctor Flex, HL2, Sim — so a
+    // per-backend installation leaves three live copies.
+    //
+    // Counted through the refusal cascade, the one publicly observable
+    // consequence of a duplicate: the sim declares canTransmit=false, so a TUNE
+    // intent is refused, and the refusal calls TransmitModel::stopTune(), which
+    // re-emits tuneCommandIssued(false) unconditionally. One live callback =>
+    // one unlatch. Nothing is keyed and nothing reaches a radio: the model is
+    // disconnected, the backend is the simulator, and the path under test is the
+    // one that REFUSES to transmit.
+    //
+    // The signal is invoked directly for the same reason the relay check does
+    // it below — this asserts the WIRING, not TransmitModel's PTT preflight.
+    // (If stopTune() ever stops re-emitting unconditionally the count changes;
+    // this comment is the place to start reading when it does.)
+    {
+        check(!model.isConnected() && model.family() == QLatin1String("sim"),
+              "TX-intent ownership check runs disconnected, on the sim backend");
+        check(!model.backendCapabilities().canTransmit,
+              "TX-intent ownership check runs against an RX-only backend");
+        QSignalSpy spy(&model.transmitModel(), &TransmitModel::tuneCommandIssued);
+        const bool invoked = QMetaObject::invokeMethod(
+            &model.transmitModel(), "tuneCommandIssued", Qt::DirectConnection,
+            Q_ARG(bool, true));
+        check(invoked, "tuneCommandIssued can be invoked for the ownership check");
+        check(spy.count() == 2,
+              "family swaps leave exactly one TX-intent callback (one TUNE "
+              "intent, one refusal unlatch)");
+    }
+
     // ---- Round-trip back to Flex ------------------------------------------
     //
     // Capabilities track the LIVE backend, so nothing an earlier family
@@ -458,6 +495,11 @@ int main(int argc, char** argv)
     // so one connectionStateChanged edge would fan out once per family visited.
     // Invoke the signal synchronously to isolate this ownership invariant from
     // any backend's asynchronous connect lifecycle or capabilitiesChanged signal.
+    //
+    // The TX-power push installed beside the relay has no observable of its own
+    // (it calls IRadioBackend::setTxPower and nothing else), but the two are one
+    // adjacent block in the constructor, so this count stands for both — the
+    // same reasoning the TX-intent check above uses for its three.
     {
         QSignalSpy spy(&model, &RadioModel::capabilitiesChanged);
         const bool invoked = QMetaObject::invokeMethod(


### PR DESCRIPTION
## Summary

Fixes #4599.

`RadioModel::setupBackend()` is rerunnable, but its two
`RadioModel::connectionStateChanged` self-connections were owned by the
`RadioModel`, not by the replaceable backend. Destroying the old backend
therefore left those callbacks alive, so every Flex/HL2/Sim family switch
accumulated another capability publication and TX-power push.

Install both model-lifetime callbacks once in the `RadioModel` constructor and
leave only backend-lifetime wiring in `setupBackend()`. Add a regression that
cycles Flex -> HL2 -> Sim -> Flex and verifies a subsequent connection edge
publishes capabilities exactly once.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The regression is red on the unfixed
code and green on the fix, reproduced independently on Linux, Windows and
macOS; the squash-merge CI run on `main` is the independent verification.

(An earlier revision of this section cited Principle X — Claims Are Atomic And
Mortal. That principle governs an agent's claim on an *issue* — verifying the
base is current, not silently overwriting concurrent work — not the lifetime of
a Qt connection. The lifetime-vs-claim wordplay was nice; the citation was
wrong.)

## Follow-up commits on this branch

- `18151726` extends the sweep to the three `&m_transmitModel` senders
  (`rfPowerChanged`, `moxCommandIssued`, `tuneCommandIssued`) that #4599's
  inventory missed but that have the same ownership shape, moves the block
  ahead of the first `setupBackend()` call, and adds a TX-intent regression.
- `3bb08645` bounds the new ownership rule: the per-slice intents wired inside
  the `sliceChanged` handler also have a sender that outlives the backend and
  are still correct in `setupBackend()`, because each connect runs once per
  slice creation and every slice is deleted before a family swap.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio if applicable
- [x] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Local evidence:

- Red regression on the unfixed code:
  `FAIL: family swaps leave exactly one connection-edge capability relay`
- Green regression on the fix:
  `radio_capability_gating_test: all checks passed`
- Adjacent backend tests:
  `demo_backend_swap_test: all checks passed`
  and `hl2_family_transition_test: all checks passed`
- Full native arm64 RelWithDebInfo build completed and linked
  `AetherSDR.app/Contents/MacOS/AetherSDR`
- `tools/check_engine_boundary.py --strict`: 919 files scanned, 86 tracked
  legacy findings, 0 blockers
- `git diff --check`: clean

Agent automation bridge proof (RX-only, TX permission disabled):

- Identity reported `txAllowed: false`
- Initial state: disconnected and not transmitting
- Connected to `DEMO-0001`: simulator connected, one owned slice, two pans,
  not transmitting
- Disconnected, then connected to a real FLEX-6700
  (`4213-3107-6700-8545`, firmware `4.2.18.41174`): connected, one owned slice,
  one pan, not transmitting
- Transmit state remained `transmitting: false`, `mox: false`,
  `tuning: false`
- Final state after disconnect: disconnected and not transmitting

The bridge can exercise and observe family transitions, but it does not expose
Qt receiver counts or per-edge signal-delivery counts. The exact pre-fix
four-delivery/post-fix one-delivery proof therefore comes from `QSignalSpy`.
No screenshot is included because this is a nonvisual connection-lifetime
defect.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (not applicable; no meter UI changed)
- [x] Documentation updated if user-visible behavior changed (not applicable;
      no user-visible behavior changed)
- [x] Security-sensitive changes reference a GHSA if applicable (not
      applicable)

Related: #4473, #4508, #4538.

Generated with OpenAI Codex.

