### PR TITLE
fix(gui): header speaker emoji follows AudioEngine mute state

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1924,6 +1924,9 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_titleBar, &TitleBar::lineoutMuteChanged, this, [this](bool muted) {
         m_audio->setMuted(muted);
         m_radioModel.sendCommand(QString("mixer lineout mute %1").arg(muted ? 1 : 0));
+    });
+    connect(m_audio, &AudioEngine::mutedChanged, this, [this](bool muted) {
+        m_titleBar->setLineoutMuted(muted);
         auto& s = AppSettings::instance();
         s.setValue("PcAudioMuted", muted ? "True" : "False");
         s.save();
@@ -1971,7 +1974,6 @@ MainWindow::MainWindow(QWidget* parent)
     bool savedMute = AppSettings::instance().value("PcAudioMuted", "False").toString() == "True";
     if (savedMute) {
         m_audio->setMuted(true);
-        m_titleBar->setLineoutMuted(true);
     }
 
 


### PR DESCRIPTION
Sync the header bar speaker emoji with AudioEngine's `mutedChanged` signal so it accurately tracks local PC audio mute state.

The emoji now tracks local PC audio mute, while clicking the same button still commands the radio's line out.