### PR TITLE
Fix RN2 remote TX audio pacing recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed: transmit audio breaking up with RN2 enabled (#4584)
+
+**Your transmitted audio no longer breaks up when RN2 is on.** Remote transmit
+audio reaches the radio as one small Opus packet every 10 ms. RN2 runs on the
+same thread as the timer that paces those packets, so when RN2 delayed a tick
+the pacer had no way to make the time back up — it sent one packet per tick no
+matter how far behind it had fallen. Packets piled up until a 200 ms cap began
+deleting them outright, and the other station heard the gaps. It was worst on
+slower machines and over SmartLink/WAN, and every deleted packet also left a
+hole in the transmit sequence numbering the radio checks.
+
+The pacer now follows real elapsed time and may send a small burst (up to three
+packets) to recover from a late tick, and the sequence number is assigned when a
+packet actually goes out rather than when it is queued, so the numbering stays
+unbroken even if the queue does overflow. An overflow is now written to the log
+instead of failing silently — the old behaviour left no trace in a support
+bundle, which is why this kept arriving as unexplained "audio break up". Live
+pacing counters are exposed to the automation bridge (`get audio` →
+`opusTxPacing`) for diagnosing future reports.
+
+Reported by @Bill6000 on a FLEX-6500 under Linux Mint.
+
 ### Minimum Qt raised to 6.8 — source builds on Ubuntu 24.04 need a newer Qt
 
 **Building from source now requires Qt 6.8 or newer.** Nothing changes for

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -700,6 +700,7 @@ set(CORE_SOURCES
     src/core/OleCompoundFile.cpp
     src/core/CabExtractor.cpp
     src/core/RNNoiseFilter.cpp
+    src/core/OpusTxPacer.cpp
     src/core/SpecbleachFilter.cpp
     src/core/CwDecoder.cpp
     src/core/CwCallsignSpotter.cpp
@@ -3550,6 +3551,14 @@ add_executable(rnnoise_filter_test
 )
 target_link_libraries(rnnoise_filter_test PRIVATE aethercore Qt6::Core)
 add_test(NAME rnnoise_filter_test COMMAND rnnoise_filter_test)
+
+add_executable(opus_tx_pacer_test
+    tests/opus_tx_pacer_test.cpp
+    src/core/OpusTxPacer.cpp
+)
+target_include_directories(opus_tx_pacer_test PRIVATE src)
+target_link_libraries(opus_tx_pacer_test PRIVATE Qt6::Core)
+add_test(NAME opus_tx_pacer_test COMMAND opus_tx_pacer_test)
 
 add_executable(adaptive_filter_test
     tests/adaptive_filter_test.cpp

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -672,7 +672,7 @@ connects).
 
 | `model` | `selector` | returns |
 |---|---|---|
-| `audio` | — | audio-engine snapshot (RX/TX stream state, mute, buffer counters, KiwiSDR TX mute gate, Receive Presentation output-signal counters) |
+| `audio` | — | audio-engine snapshot (RX/TX stream state, mute, buffer counters, Opus TX pacing counters, KiwiSDR TX mute gate, Receive Presentation output-signal counters) |
 | `dsp` | — | client-side AetherDSP noise-reduction state — see [`get dsp`](#get-dsp) |
 | `radio` | — | radio snapshot (name, model, version, connected, fullDuplex, transmitting, txPower, paTemp, slice/pan counts) |
 | `gps` | — | GPS status, tracked/visible counts, grid, radio-format coordinates, altitude, speed, course, UTC time, frequency error, and oscillator-reference state |
@@ -701,6 +701,12 @@ chunks dispatched to Receive Presentation Sync analysis, while
 `receivePresentationOutputSignalSuppressedCount` counts non-empty output chunks
 that were captured for automation but skipped because no KiwiSDR audio source
 was active.
+
+`opusTxPacing` reports the live remote-audio TX pacing queue:
+`queueDepth`, lifetime `maxQueueDepth`, `packetsSent`, `catchUpPackets`, and
+`droppedPackets`. A late audio-thread timer increments `catchUpPackets` when the
+pacer repays missed 10 ms deadlines; `droppedPackets` must remain zero during a
+healthy TX-mic run.
 
 The TX input endpoint also exposes in-memory capture-health evidence for TCI
 handoffs: `buffer_bytes_available`, `buffer_capacity_bytes`,

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -71,6 +71,7 @@
 #include <cstring>
 #include <functional>
 #include <optional>
+#include <utility>
 
 namespace AetherSDR {
 
@@ -1839,16 +1840,20 @@ AudioEngine::AudioEngine(QObject* parent)
         DeviceDiagnostics::buildAudioStartupSnapshot(this, QJsonObject{}));
     logNr2WisdomSummary(QStringLiteral("startup"));
 
-    // Opus TX pacing timer — sends one queued packet every 10ms for even
-    // delivery timing. Without this, QAudioSource delivers bursts of samples
-    // that get Opus-encoded and sent back-to-back, causing jitter-induced
-    // crackling on SmartLink/WAN connections.
+    // Opus TX pacing timer — follows a 10 ms wall-clock schedule. The mic
+    // callback and RN2 share this event loop, so late timer events drain a
+    // small bounded catch-up batch rather than permanently losing ground.
     m_opusTxPaceTimer = new QTimer(this);
     m_opusTxPaceTimer->setTimerType(Qt::PreciseTimer);
     m_opusTxPaceTimer->setInterval(10);
+    m_opusTxPaceClock.start();
     connect(m_opusTxPaceTimer, &QTimer::timeout, this, [this]() {
-        if (m_opusTxQueue.isEmpty()) return;
-        emit txPacketReady(m_opusTxQueue.takeFirst());
+        OpusTxPacer::DrainResult drain =
+            m_opusTxPacer.takeDue(m_opusTxPaceClock.elapsed(),
+                                  m_txPacketCount);
+        for (const QByteArray& packet : drain.packets) {
+            emit txPacketReady(packet);
+        }
     });
     m_opusTxPaceTimer->start();
 
@@ -7091,6 +7096,20 @@ void AudioEngine::setRn2TxEnabled(bool on)
     emit rn2TxEnabledChanged(on);
 }
 
+QJsonObject AudioEngine::opusTxPacingDiagnostics() const
+{
+    return QJsonObject{
+        {QStringLiteral("queueDepth"), m_opusTxPacer.queueDepth()},
+        {QStringLiteral("maxQueueDepth"), m_opusTxPacer.maxQueueDepth()},
+        {QStringLiteral("packetsSent"),
+         static_cast<double>(m_opusTxPacer.packetsSent())},
+        {QStringLiteral("catchUpPackets"),
+         static_cast<double>(m_opusTxPacer.catchUpPackets())},
+        {QStringLiteral("droppedPackets"),
+         static_cast<double>(m_opusTxPacer.droppedPackets())},
+    };
+}
+
 // ─── DFNR (DeepFilterNet3 neural noise reduction) ────────────────────────────
 
 #ifdef HAVE_DFNR
@@ -8257,8 +8276,7 @@ void AudioEngine::onTxAudioReady()
             // Word 0: type=3 (ExtDataWithStream), C=1, T=0, TSI=3, TSF=1
             p[0] = qToBigEndian<quint32>(
                 (3u << 28) | (1u << 27) | (3u << 22) | (1u << 20)
-                | ((m_txPacketCount & 0x0F) << 16) | sizeWords);
-            m_txPacketCount = (m_txPacketCount + 1) & 0x0F;
+                | sizeWords);
             p[1] = qToBigEndian(m_remoteTxStreamId);    // remote_audio_tx stream
             p[2] = qToBigEndian<quint32>(0x00001C2D);   // OUI (FlexRadio)
             p[3] = qToBigEndian<quint32>(0x534C0000 | 0x8005);  // ICC=0x534C, PCC=0x8005
@@ -8267,12 +8285,22 @@ void AudioEngine::onTxAudioReady()
             memcpy(pkt.data() + 28, opus.constData(), opus.size());
 
             // Queue for paced delivery instead of sending immediately.
-            // The 10ms pacing timer drains one packet per tick for even
-            // timing over SmartLink/WAN. Cap queue to ~200ms to prevent
-            // runaway growth if the mic delivers faster than real-time.
-            m_opusTxQueue.append(pkt);
-            if (m_opusTxQueue.size() > 20)
-                m_opusTxQueue.removeFirst();
+            // The 10 ms pacer follows elapsed deadlines and drains a bounded
+            // catch-up batch after a late timer event. Cap the queue to
+            // ~200 ms if the producer still outruns that recovery.
+            if (m_opusTxPacer.enqueue(std::move(pkt))) {
+                ++m_opusTxDropsSinceLog;
+                if (!m_opusTxDropLogTimer.isValid()
+                    || m_opusTxDropLogTimer.hasExpired(1000)) {
+                    qCWarning(lcAudio)
+                        << "AudioEngine: Opus TX pacing queue overflow — dropped"
+                        << m_opusTxDropsSinceLog
+                        << "oldest 10 ms packet(s); queue depth"
+                        << m_opusTxPacer.queueDepth();
+                    m_opusTxDropsSinceLog = 0;
+                    m_opusTxDropLogTimer.restart();
+                }
+            }
         }
         return;
     }
@@ -8520,7 +8548,7 @@ void AudioEngine::setTransmitting(bool tx)
         m_txAccumulator.clear();
         m_txFloatAccumulator.clear();
         m_daxPreTxBuffer.clear();
-        m_opusTxQueue.clear();
+        m_opusTxPacer.clear();
     }
 }
 

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -26,6 +26,7 @@
 #include "TxMicChannelNormalizer.h"
 #include "TxCaptureHealthTracker.h"
 #include "SpectralNR.h"
+#include "OpusTxPacer.h"
 
 class QMediaDevices;
 
@@ -229,6 +230,7 @@ public:
     void setNr2NpeMethod(int method);
     void setNr2AeFilter(bool on);
     QJsonObject nr2RuntimeDiagnostics() const;
+    QJsonObject opusTxPacingDiagnostics() const;
     Q_INVOKABLE void setNr2UseOriginalGeometry(bool useOriginal);
     // Tell the engine the main RX source is (or is not) the demo, so the main NR2
     // filter uses the original 256/2 geometry the demo's tiny frames need. Rebuilds
@@ -940,8 +942,11 @@ private:
     std::atomic<bool>  m_opusTxEnabled{false}; // Opus TX encoding for SmartLink
     std::unique_ptr<class OpusCodec> m_opusTxCodec; // lazy-init on first TX with Opus
     QByteArray    m_opusTxAccumulator;  // accumulate stereo samples for Opus frame
-    QVector<QByteArray> m_opusTxQueue;  // pacing queue for even 10ms packet delivery
+    OpusTxPacer   m_opusTxPacer;
     QTimer*       m_opusTxPaceTimer{nullptr};
+    QElapsedTimer m_opusTxPaceClock;
+    QElapsedTimer m_opusTxDropLogTimer;
+    quint64       m_opusTxDropsSinceLog{0};
 
     // Client-side PC mic metering (accumulated over ~50ms window)
     float         m_pcMicPeak{0.0f};

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1832,6 +1832,8 @@ QJsonObject audioSnapshot(const AudioEngine* audio)
         {QStringLiteral("receivePresentationOutputSignalSuppressedCount"),
             static_cast<double>(
                 audio->receivePresentationOutputSignalSuppressedCount())},
+        {QStringLiteral("opusTxPacing"),
+            audio->opusTxPacingDiagnostics()},
         {QStringLiteral("endpoints"),
             audio->audioEndpointDiagnostics()},
     };

--- a/src/core/OpusTxPacer.cpp
+++ b/src/core/OpusTxPacer.cpp
@@ -27,6 +27,18 @@ OpusTxPacer::DrainResult OpusTxPacer::takeDue(qint64 nowMs,
 {
     DrainResult result;
     if (m_queue.isEmpty()) {
+        // The pacing timer free-runs from the AudioEngine constructor, so this
+        // fires on every 10 ms tick with no audio queued — between overs, on a
+        // mic xrun, while RN2 re-warms. No deadline was actually missed on
+        // those ticks, so re-anchor to the next interval. Leaving the deadline
+        // behind the wall clock books debt repayable only at one extra packet
+        // per drain, which a real-time producer never affords: the pacer would
+        // degrade into "flush up to kMaxPacketsPerDrain whenever packets exist"
+        // for the rest of the over — the back-to-back bursts it exists to
+        // smooth. A 30 ms drought was enough to trigger this permanently.
+        if (m_nextSendDeadlineMs >= 0 && nowMs >= m_nextSendDeadlineMs) {
+            m_nextSendDeadlineMs = nowMs + kPacketIntervalMs;
+        }
         return result;
     }
 
@@ -69,7 +81,11 @@ void OpusTxPacer::clear()
 
 void OpusTxPacer::stampPacketCount(QByteArray& packet, quint8 packetCount)
 {
-    if (packet.size() < static_cast<int>(sizeof(quint32))) {
+    // The only producer builds a full 28-byte VITA-49 ExtDataWithStream
+    // header (AudioEngine::onTxAudioReady). Anything shorter is not a packet
+    // this pacer knows how to stamp, so leave it untouched rather than
+    // rewriting whatever happens to occupy the first word.
+    if (packet.size() < kVitaHeaderBytes) {
         return;
     }
 

--- a/src/core/OpusTxPacer.cpp
+++ b/src/core/OpusTxPacer.cpp
@@ -1,0 +1,85 @@
+#include "OpusTxPacer.h"
+
+#include <QtEndian>
+
+#include <algorithm>
+#include <utility>
+
+namespace AetherSDR {
+
+bool OpusTxPacer::enqueue(QByteArray packet)
+{
+    bool droppedOldest = false;
+    if (m_queue.size() >= kMaxQueuePackets) {
+        m_queue.removeFirst();
+        ++m_droppedPackets;
+        droppedOldest = true;
+    }
+
+    m_queue.append(std::move(packet));
+    m_maxQueueDepth = std::max(
+        m_maxQueueDepth, static_cast<int>(m_queue.size()));
+    return droppedOldest;
+}
+
+OpusTxPacer::DrainResult OpusTxPacer::takeDue(qint64 nowMs,
+                                              quint8& packetCount)
+{
+    DrainResult result;
+    if (m_queue.isEmpty()) {
+        return result;
+    }
+
+    if (m_nextSendDeadlineMs < 0) {
+        m_nextSendDeadlineMs = nowMs;
+    }
+    if (nowMs < m_nextSendDeadlineMs) {
+        return result;
+    }
+
+    const qint64 overdueIntervals =
+        (nowMs - m_nextSendDeadlineMs) / kPacketIntervalMs;
+    const int duePackets = static_cast<int>(std::min<qint64>(
+        kMaxPacketsPerDrain, overdueIntervals + 1));
+    const int sendCount = std::min(
+        duePackets, static_cast<int>(m_queue.size()));
+    result.packets.reserve(sendCount);
+
+    for (int i = 0; i < sendCount; ++i) {
+        QByteArray packet = m_queue.takeFirst();
+        stampPacketCount(packet, packetCount);
+        packetCount = static_cast<quint8>((packetCount + 1) & 0x0F);
+        result.packets.append(std::move(packet));
+    }
+
+    result.catchUpPackets = std::max(0, sendCount - 1);
+    m_packetsSent += static_cast<quint64>(sendCount);
+    m_catchUpPackets += static_cast<quint64>(result.catchUpPackets);
+    m_nextSendDeadlineMs +=
+        static_cast<qint64>(sendCount) * kPacketIntervalMs;
+
+    return result;
+}
+
+void OpusTxPacer::clear()
+{
+    m_queue.clear();
+    m_nextSendDeadlineMs = -1;
+}
+
+void OpusTxPacer::stampPacketCount(QByteArray& packet, quint8 packetCount)
+{
+    if (packet.size() < static_cast<int>(sizeof(quint32))) {
+        return;
+    }
+
+    const auto* source =
+        reinterpret_cast<const uchar*>(packet.constData());
+    quint32 header = qFromBigEndian<quint32>(source);
+    header &= ~(0x0Fu << 16);
+    header |= (static_cast<quint32>(packetCount & 0x0F) << 16);
+    qToBigEndian<quint32>(
+        header, reinterpret_cast<uchar*>(packet.data()));
+}
+
+} // namespace AetherSDR

--- a/src/core/OpusTxPacer.h
+++ b/src/core/OpusTxPacer.h
@@ -9,11 +9,18 @@ namespace AetherSDR {
 // QAudioSource and DSP processing share AudioEngine's event loop with the
 // pacing timer, so a late timer event must recover missed deadlines instead of
 // permanently falling behind the microphone producer.
+//
+// Catch-up is owed only for deadlines that passed with audio actually waiting.
+// Ticks that find the queue empty re-anchor the schedule instead — see
+// takeDue() — so a silent gap cannot leave the pacer permanently "behind" and
+// flushing bursts.
 class OpusTxPacer {
 public:
     static constexpr qint64 kPacketIntervalMs = 10;
     static constexpr int kMaxQueuePackets = 20;
     static constexpr int kMaxPacketsPerDrain = 3;
+    // VITA-49 ExtDataWithStream header AudioEngine prepends to every payload.
+    static constexpr int kVitaHeaderBytes = 28;
 
     struct DrainResult {
         QVector<QByteArray> packets;

--- a/src/core/OpusTxPacer.h
+++ b/src/core/OpusTxPacer.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <QByteArray>
+#include <QVector>
+
+namespace AetherSDR {
+
+// Keeps remote_audio_tx Opus packets on a 10 ms wall-clock schedule.
+// QAudioSource and DSP processing share AudioEngine's event loop with the
+// pacing timer, so a late timer event must recover missed deadlines instead of
+// permanently falling behind the microphone producer.
+class OpusTxPacer {
+public:
+    static constexpr qint64 kPacketIntervalMs = 10;
+    static constexpr int kMaxQueuePackets = 20;
+    static constexpr int kMaxPacketsPerDrain = 3;
+
+    struct DrainResult {
+        QVector<QByteArray> packets;
+        int catchUpPackets{0};
+    };
+
+    // Returns true when the oldest queued packet had to be dropped.
+    bool enqueue(QByteArray packet);
+    DrainResult takeDue(qint64 nowMs, quint8& packetCount);
+    void clear();
+
+    int queueDepth() const { return static_cast<int>(m_queue.size()); }
+    int maxQueueDepth() const { return m_maxQueueDepth; }
+    quint64 packetsSent() const { return m_packetsSent; }
+    quint64 catchUpPackets() const { return m_catchUpPackets; }
+    quint64 droppedPackets() const { return m_droppedPackets; }
+
+private:
+    static void stampPacketCount(QByteArray& packet, quint8 packetCount);
+
+    QVector<QByteArray> m_queue;
+    qint64 m_nextSendDeadlineMs{-1};
+    int m_maxQueueDepth{0};
+    quint64 m_packetsSent{0};
+    quint64 m_catchUpPackets{0};
+    quint64 m_droppedPackets{0};
+};
+
+} // namespace AetherSDR

--- a/tests/opus_tx_pacer_test.cpp
+++ b/tests/opus_tx_pacer_test.cpp
@@ -2,6 +2,7 @@
 
 #include <QtEndian>
 
+#include <algorithm>
 #include <cstdio>
 #include <limits>
 
@@ -9,15 +10,26 @@ using AetherSDR::OpusTxPacer;
 
 namespace {
 
+constexpr quint32 kHeaderWithoutCount = 0x38D00010u;
+constexpr int kMarkerOffset = OpusTxPacer::kVitaHeaderBytes;
+
+// A packet shaped like the ones AudioEngine::onTxAudioReady() builds: a full
+// 28-byte VITA-49 ExtDataWithStream header followed by payload. The marker
+// byte sits in the payload so a test can follow an individual packet through
+// the queue without disturbing any header field.
 QByteArray makePacket(quint8 marker)
 {
-    constexpr quint32 kHeaderWithoutCount = 0x38D00010u;
-    QByteArray packet(8, '\0');
+    QByteArray packet(OpusTxPacer::kVitaHeaderBytes + 4, '\0');
     qToBigEndian<quint32>(
         kHeaderWithoutCount,
         reinterpret_cast<uchar*>(packet.data()));
-    packet[4] = static_cast<char>(marker);
+    packet[kMarkerOffset] = static_cast<char>(marker);
     return packet;
+}
+
+quint8 markerOf(const QByteArray& packet)
+{
+    return static_cast<quint8>(packet[kMarkerOffset]);
 }
 
 int packetCount(const QByteArray& packet)
@@ -30,12 +42,13 @@ int packetCount(const QByteArray& packet)
 bool packetHeaderExceptCountIsPreserved(const QByteArray& packet)
 {
     constexpr quint32 kCountMask = 0x000F0000u;
-    constexpr quint32 kHeaderWithoutCount = 0x38D00010u;
     const quint32 header = qFromBigEndian<quint32>(
         reinterpret_cast<const uchar*>(packet.constData()));
     return (header & ~kCountMask) == kHeaderWithoutCount;
 }
 
+// A genuinely late timer event — packets were queued and waiting across the
+// missed deadlines, so the pacer legitimately owes catch-up.
 bool testLateTimerCatchesUp()
 {
     OpusTxPacer pacer;
@@ -102,7 +115,7 @@ bool testOverflowKeepsWireCountsContiguous()
     }
 
     if (sent.size() != OpusTxPacer::kMaxQueuePackets
-        || static_cast<quint8>(sent.first()[4]) != 1) {
+        || markerOf(sent.first()) != 1) {
         std::printf("overflow did not discard exactly the oldest packet\n");
         return false;
     }
@@ -138,7 +151,10 @@ bool testIdleQueueResumesWithoutDelay()
     return true;
 }
 
-bool testLateProducerUsesExistingSchedule()
+// A drained queue must not bank catch-up credit. Ticks 110 and 120 find the
+// queue empty; nothing was owed on them, so the packets that arrive afterwards
+// are paced normally rather than flushed as a burst.
+bool testDrainedQueueDoesNotBankCatchUp()
 {
     OpusTxPacer pacer;
     quint8 count = 0;
@@ -148,18 +164,96 @@ bool testLateProducerUsesExistingSchedule()
         return false;
     }
 
+    pacer.takeDue(110, count);   // free-running timer, nothing queued
+    pacer.takeDue(120, count);
+
     for (int i = 1; i <= 4; ++i) {
         pacer.enqueue(makePacket(static_cast<quint8>(i)));
     }
-    const OpusTxPacer::DrainResult recovered = pacer.takeDue(130, count);
-    if (recovered.packets.size() != 3
-        || recovered.catchUpPackets != 2
-        || pacer.queueDepth() != 1) {
+    const OpusTxPacer::DrainResult resumed = pacer.takeDue(130, count);
+    if (resumed.packets.size() != 1
+        || resumed.catchUpPackets != 0
+        || pacer.queueDepth() != 3) {
         std::printf(
-            "drained queue lost its schedule: sent=%lld catchUp=%d depth=%d\n",
-            static_cast<long long>(recovered.packets.size()),
-            recovered.catchUpPackets,
+            "drained queue banked catch-up: sent=%lld catchUp=%d depth=%d\n",
+            static_cast<long long>(resumed.packets.size()),
+            resumed.catchUpPackets,
             pacer.queueDepth());
+        return false;
+    }
+    return true;
+}
+
+// End-to-end regression for the pacer's whole reason to exist, driven the way
+// AudioEngine drives it: a free-running 10 ms timer plus a bursty QAudioSource
+// producer, with a mid-transmission producer drought. Before the empty-tick
+// re-anchor in takeDue(), a drought as short as 30 ms permanently converted the
+// pacer into "flush kMaxPacketsPerDrain back-to-back, then idle" — the jitter
+// the pacer was added to remove.
+bool testPacingSurvivesProducerDrought()
+{
+    for (const qint64 droughtMs : {30, 100, 1000}) {
+        OpusTxPacer pacer;
+        quint8 count = 0;
+        qint64 t = 0;
+
+        // Audio flowing at real time — primes the schedule.
+        for (int i = 0; i < 20; ++i, t += OpusTxPacer::kPacketIntervalMs) {
+            pacer.enqueue(makePacket(0));
+            pacer.takeDue(t, count);
+        }
+
+        // Producer stalls; the pacing timer keeps firing on an empty queue.
+        for (qint64 end = t + droughtMs; t < end;
+             t += OpusTxPacer::kPacketIntervalMs) {
+            pacer.takeDue(t, count);
+        }
+
+        // Producer resumes, handing over four 10 ms packets every 40 ms.
+        int worstTick = 0;
+        for (int i = 0; i < 200; ++i, t += OpusTxPacer::kPacketIntervalMs) {
+            if (i % 4 == 0) {
+                for (int k = 0; k < 4; ++k) {
+                    pacer.enqueue(makePacket(0));
+                }
+            }
+            worstTick = std::max<int>(
+                worstTick, pacer.takeDue(t, count).packets.size());
+        }
+
+        if (worstTick != 1) {
+            std::printf(
+                "pacing lost after %lld ms drought: %d packets in one tick\n",
+                static_cast<long long>(droughtMs), worstTick);
+            return false;
+        }
+        if (pacer.droppedPackets() != 0) {
+            std::printf("unexpected drops after %lld ms drought: %llu\n",
+                        static_cast<long long>(droughtMs),
+                        static_cast<unsigned long long>(pacer.droppedPackets()));
+            return false;
+        }
+    }
+    return true;
+}
+
+// Anything shorter than the VITA header is not ours to rewrite.
+bool testShortPacketIsNotStamped()
+{
+    OpusTxPacer pacer;
+    quint8 count = 7;
+    QByteArray runt(OpusTxPacer::kVitaHeaderBytes - 1, '\0');
+    const QByteArray original = runt;
+    pacer.enqueue(runt);
+
+    const OpusTxPacer::DrainResult drained = pacer.takeDue(0, count);
+    if (drained.packets.size() != 1 || drained.packets.first() != original) {
+        std::printf("short packet was modified\n");
+        return false;
+    }
+    // The wire counter still advances so a following full packet is contiguous.
+    if (count != 8) {
+        std::printf("packet count did not advance: %d\n", int(count));
         return false;
     }
     return true;
@@ -173,7 +267,9 @@ int main()
         || !testCatchUpIsBounded()
         || !testOverflowKeepsWireCountsContiguous()
         || !testIdleQueueResumesWithoutDelay()
-        || !testLateProducerUsesExistingSchedule()) {
+        || !testDrainedQueueDoesNotBankCatchUp()
+        || !testPacingSurvivesProducerDrought()
+        || !testShortPacketIsNotStamped()) {
         return 1;
     }
     std::printf("opus_tx_pacer_test passed\n");

--- a/tests/opus_tx_pacer_test.cpp
+++ b/tests/opus_tx_pacer_test.cpp
@@ -1,0 +1,181 @@
+#include "core/OpusTxPacer.h"
+
+#include <QtEndian>
+
+#include <cstdio>
+#include <limits>
+
+using AetherSDR::OpusTxPacer;
+
+namespace {
+
+QByteArray makePacket(quint8 marker)
+{
+    constexpr quint32 kHeaderWithoutCount = 0x38D00010u;
+    QByteArray packet(8, '\0');
+    qToBigEndian<quint32>(
+        kHeaderWithoutCount,
+        reinterpret_cast<uchar*>(packet.data()));
+    packet[4] = static_cast<char>(marker);
+    return packet;
+}
+
+int packetCount(const QByteArray& packet)
+{
+    const quint32 header = qFromBigEndian<quint32>(
+        reinterpret_cast<const uchar*>(packet.constData()));
+    return static_cast<int>((header >> 16) & 0x0F);
+}
+
+bool packetHeaderExceptCountIsPreserved(const QByteArray& packet)
+{
+    constexpr quint32 kCountMask = 0x000F0000u;
+    constexpr quint32 kHeaderWithoutCount = 0x38D00010u;
+    const quint32 header = qFromBigEndian<quint32>(
+        reinterpret_cast<const uchar*>(packet.constData()));
+    return (header & ~kCountMask) == kHeaderWithoutCount;
+}
+
+bool testLateTimerCatchesUp()
+{
+    OpusTxPacer pacer;
+    for (int i = 0; i < 6; ++i) {
+        pacer.enqueue(makePacket(static_cast<quint8>(i)));
+    }
+
+    quint8 count = 0;
+    const OpusTxPacer::DrainResult first = pacer.takeDue(100, count);
+    const OpusTxPacer::DrainResult late = pacer.takeDue(130, count);
+
+    if (first.packets.size() != 1 || late.packets.size() != 3
+        || late.catchUpPackets != 2 || pacer.queueDepth() != 2) {
+        std::printf(
+            "late catch-up mismatch: first=%lld late=%lld catchUp=%d depth=%d\n",
+            static_cast<long long>(first.packets.size()),
+            static_cast<long long>(late.packets.size()),
+            late.catchUpPackets,
+            pacer.queueDepth());
+        return false;
+    }
+    return true;
+}
+
+bool testCatchUpIsBounded()
+{
+    OpusTxPacer pacer;
+    for (int i = 0; i < 10; ++i) {
+        pacer.enqueue(makePacket(static_cast<quint8>(i)));
+    }
+
+    quint8 count = 0;
+    pacer.takeDue(0, count);
+    const OpusTxPacer::DrainResult veryLate =
+        pacer.takeDue(std::numeric_limits<qint64>::max(), count);
+    if (veryLate.packets.size() != OpusTxPacer::kMaxPacketsPerDrain) {
+        std::printf("unbounded catch-up: sent=%lld\n",
+                    static_cast<long long>(veryLate.packets.size()));
+        return false;
+    }
+    return true;
+}
+
+bool testOverflowKeepsWireCountsContiguous()
+{
+    OpusTxPacer pacer;
+    bool dropped = false;
+    for (int i = 0; i <= OpusTxPacer::kMaxQueuePackets; ++i) {
+        dropped = pacer.enqueue(makePacket(static_cast<quint8>(i))) || dropped;
+    }
+    if (!dropped || pacer.droppedPackets() != 1
+        || pacer.queueDepth() != OpusTxPacer::kMaxQueuePackets) {
+        std::printf("overflow accounting mismatch\n");
+        return false;
+    }
+
+    quint8 count = 14;
+    QVector<QByteArray> sent;
+    qint64 nowMs = 0;
+    while (pacer.queueDepth() > 0) {
+        const OpusTxPacer::DrainResult result = pacer.takeDue(nowMs, count);
+        sent.append(result.packets);
+        nowMs += 30;
+    }
+
+    if (sent.size() != OpusTxPacer::kMaxQueuePackets
+        || static_cast<quint8>(sent.first()[4]) != 1) {
+        std::printf("overflow did not discard exactly the oldest packet\n");
+        return false;
+    }
+    for (int i = 0; i < sent.size(); ++i) {
+        const int expected = (14 + i) & 0x0F;
+        if (packetCount(sent[i]) != expected) {
+            std::printf("packet count gap at %d: got=%d expected=%d\n",
+                        i, packetCount(sent[i]), expected);
+            return false;
+        }
+        if (!packetHeaderExceptCountIsPreserved(sent[i])) {
+            std::printf("packet header changed outside count at %d\n", i);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool testIdleQueueResumesWithoutDelay()
+{
+    OpusTxPacer pacer;
+    quint8 count = 0;
+    pacer.enqueue(makePacket(1));
+    if (pacer.takeDue(10, count).packets.size() != 1) {
+        return false;
+    }
+
+    pacer.enqueue(makePacket(2));
+    if (pacer.takeDue(5000, count).packets.size() != 1) {
+        std::printf("idle queue did not resume immediately\n");
+        return false;
+    }
+    return true;
+}
+
+bool testLateProducerUsesExistingSchedule()
+{
+    OpusTxPacer pacer;
+    quint8 count = 0;
+    pacer.enqueue(makePacket(0));
+    if (pacer.takeDue(100, count).packets.size() != 1
+        || pacer.queueDepth() != 0) {
+        return false;
+    }
+
+    for (int i = 1; i <= 4; ++i) {
+        pacer.enqueue(makePacket(static_cast<quint8>(i)));
+    }
+    const OpusTxPacer::DrainResult recovered = pacer.takeDue(130, count);
+    if (recovered.packets.size() != 3
+        || recovered.catchUpPackets != 2
+        || pacer.queueDepth() != 1) {
+        std::printf(
+            "drained queue lost its schedule: sent=%lld catchUp=%d depth=%d\n",
+            static_cast<long long>(recovered.packets.size()),
+            recovered.catchUpPackets,
+            pacer.queueDepth());
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+int main()
+{
+    if (!testLateTimerCatchesUp()
+        || !testCatchUpIsBounded()
+        || !testOverflowKeepsWireCountsContiguous()
+        || !testIdleQueueResumesWithoutDelay()
+        || !testLateProducerUsesExistingSchedule()) {
+        return 1;
+    }
+    std::printf("opus_tx_pacer_test passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes #4584.

RN2 runs on the same `AudioEngine` event loop as the 10 ms remote-audio TX pacing timer. When RN2 delayed that loop, Qt coalesced missed timer events, while the old callback emitted only one queued Opus packet per delivered timeout. The pacer could therefore never repay lost deadlines; recovered microphone frames accumulated until the 20-packet cap discarded audio. Packet counts were also assigned before that discard, creating avoidable VITA sequence gaps.

This change introduces a small `OpusTxPacer` that follows elapsed 10 ms deadlines, drains at most three packets per callback for bounded catch-up, and assigns the four-bit VITA packet count only when a datagram is actually emitted. It also exposes queue/catch-up/drop counters through `get audio` and adds focused regression coverage for late timers, bounded recovery, overflow, count wrap, header preservation, long idle periods, and the drained-queue edge case.

The packet-count ordering agrees with the public FlexLib TX remote-audio example, which sends a packet before incrementing its count: https://github.com/mgi2212/FlexLibDemos/blob/8383927fc7a32560ba93e56a61c1ed27cd555841/FlexLib/TXRemoteAudioStream.cs

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The timing failure has a deterministic regression test, live pacing diagnostics are automation-visible, and the built app was exercised against a real FLEX radio with TX physically inhibited by the bridge policy.

Principle IV — Clean-Room Contributions. The implementation was derived from AetherSDR source behavior, reporter logs, Qt timer semantics, and the cited public FlexLib source; no proprietary binary was decompiled or disassembled.

## Test plan

- [x] Local build passes (`arch -arm64 /opt/homebrew/bin/cmake --build build-arm64 --target AetherSDR -j16`)
- [x] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

| Evidence | Result |
|---|---|
| Native macOS arm64 full application build on current `upstream/main` | Pass |
| `opus_tx_pacer_test` | Pass |
| `rnnoise_filter_test` | Pass |
| `tools/gen_bridge_docs.py --check` | Pass |
| `tools/check_engine_boundary.py --strict` | Pass; 86 tracked warnings, 0 blocking findings |
| `git diff --check upstream/main...HEAD` | Pass |
| Automation bridge, FLEX-6700 fw 4.2.18.41174, RN2 enabled for 15 seconds | 3,254 packets sent, 299 catch-up packets, 0 drops; radio remained `transmitting=false`, `txPower=0` |

The live run used `AETHER_AUTOMATION_NO_TX=1` and never invoked MOX, TUNE, CW keying, or any transmit-authorizing bridge flag. UI state was restored afterward.

Bridge limitation: the current bridge cannot capture outbound VITA datagrams or inspect their packet-count nibble directly. The live bridge run therefore proves bounded recovery and zero queue loss under RN2, while the focused unit test proves contiguous wire counts across overflow and 15-to-0 wrap.

Screenshots: not applicable; this is a transport-timing change with no visual output change.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention; no meter UI changed)
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable (not applicable)

Generated with OpenAI Codex.
