### PR TITLE
feat(settings): Settings Browser dialog (RFC #4603 PR 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - **New `--config` command line**: `aethersdr --config list|get|set|unset|
   export|path` inspects or repairs settings without starting the GUI —
   the escape hatch when a broken stored value prevents startup.
+- **New Settings Browser** (Settings ▸ Settings Browser…): browse and edit
+  the whole settings store — app keys, the station section, and each
+  radio's stored feature documents — with live filtering, guarded
+  editing (True/False picker, JSON validation, confirmations), and a
+  sanitized diagnostic export. Credential-shaped values are masked and
+  read-only; a store from a newer version browses read-only.
 - Fixes a latent threading race in the settings core (#4602).
 
 ## [v26.7.4.1] — 2026-07-27

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2867,6 +2867,23 @@ set_tests_properties(panadapter_message_overlay_test PROPERTIES
 # AppSettings persistence safety. Each scenario is a separate process because
 # AppSettings is a process-wide singleton and load state must not leak between
 # cases.
+add_executable(settings_browser_dialog_test
+    tests/settings_browser_dialog_test.cpp
+    src/gui/SettingsBrowserDialog.cpp
+    src/gui/PersistentDialog.cpp
+    src/gui/FramelessResizer.cpp
+    src/gui/FramelessWindowTitleBar.cpp
+    src/gui/FramelessMessageBox.cpp
+)
+target_include_directories(settings_browser_dialog_test PRIVATE src tests)
+target_link_libraries(settings_browser_dialog_test PRIVATE
+    aethercore Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Network Qt6::Test
+)
+set_target_properties(settings_browser_dialog_test PROPERTIES AUTOMOC ON)
+add_test(NAME settings_browser_dialog COMMAND settings_browser_dialog_test)
+set_tests_properties(settings_browser_dialog PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 add_executable(app_settings_safety_test
     tests/app_settings_safety_test.cpp
     ${AETHER_SETTINGS_SOURCES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -850,6 +850,7 @@ set(GUI_SOURCES
     src/gui/PersistentDialog.cpp
     src/gui/FramelessMessageBox.cpp
     src/gui/ProfileManagerDialog.cpp
+    src/gui/SettingsBrowserDialog.cpp
     src/gui/ProfileImportExportDialog.cpp
     src/gui/TxBandDialog.cpp
     src/gui/PanadapterApplet.cpp
@@ -2893,7 +2894,8 @@ foreach(APP_SETTINGS_SCENARIO
         newer-schema-readonly
         dirty-row-save
         display-slice-depth-default
-        nickname-key-roundtrip)
+        nickname-key-roundtrip
+        browser-api)
     add_test(
         NAME app_settings_safety_${APP_SETTINGS_SCENARIO}
         COMMAND app_settings_safety_test ${APP_SETTINGS_SCENARIO})

--- a/docs/settings-store-sqlite-design.md
+++ b/docs/settings-store-sqlite-design.md
@@ -186,6 +186,13 @@ worker-thread event-loop code is fine — that is precisely the #4602 case.
 
 ## Testing
 
+`tests/settings_browser_dialog_test.cpp` drives the real Settings Browser
+widget for the guarantees the automation bridge cannot reach (it has no
+double-click or key-injection verb): masked rows are read-only with a clean
+control row that stays editable, `cellActivated` is structurally unconnected
+(so no style can pop the modal on a single click), and an unparseable
+document is labelled rather than rendered as empty with Edit disabled.
+
 `tests/app_settings_safety_test.cpp` — 17 one-process-per-scenario cases
 (CMake `foreach`) covering the matrix above; `tests/TestSettingsProfile.h`
 still provides isolation. The migration was additionally soak-tested against

--- a/docs/settings-store-sqlite-design.md
+++ b/docs/settings-store-sqlite-design.md
@@ -186,7 +186,7 @@ worker-thread event-loop code is fine — that is precisely the #4602 case.
 
 ## Testing
 
-`tests/app_settings_safety_test.cpp` — 15 one-process-per-scenario cases
+`tests/app_settings_safety_test.cpp` — 17 one-process-per-scenario cases
 (CMake `foreach`) covering the matrix above; `tests/TestSettingsProfile.h`
 still provides isolation. The migration was additionally soak-tested against
 a real 391-key production settings file with a key-for-key parity diff

--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -1025,6 +1025,23 @@ bool AppSettings::storeWritable() const
     return m_loadState == LoadState::ReadyToSave;
 }
 
+bool AppSettings::readAppRowFromDisk(const QString& key, QString& value) const
+{
+    return SettingsDatabase::readAppValueFromFile(m_filePath, key, value);
+}
+
+bool AppSettings::readStationRowFromDisk(const QString& key,
+                                         QString& value) const
+{
+    QString station;
+    {
+        QReadLocker locker(&m_lock);
+        station = m_stationName;
+    }
+    return SettingsDatabase::readStationValueFromFile(m_filePath, station, key,
+                                                      value);
+}
+
 // ─── Radio-scoped feature documents (RFC #4603) ──────────────────────────────
 
 QJsonObject AppSettings::radioFeatureExact(const QString& family,

--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -985,15 +985,8 @@ QStringList AppSettings::stationKeysForDiagnostics() const
 
 QList<QPair<QString, QString>> AppSettings::radioFeaturesForDiagnostics() const
 {
-    QMutexLocker ioLocker(&m_saveMutex);
     QList<QPair<QString, QString>> out;
-    if (!m_db || !m_db->isOpen()) {
-        return out;
-    }
-    QList<SettingsDatabase::RadioFeatureRow> rows;
-    if (!m_db->listRadioFeatures(rows)) {
-        return out;
-    }
+    const QList<RadioFeatureEntry> rows = radioFeatureEntriesForDiagnostics();
     for (const auto& row : rows) {
         out.append({QStringLiteral("%1/%2/%3@v%4")
                         .arg(row.family,
@@ -1004,6 +997,32 @@ QList<QPair<QString, QString>> AppSettings::radioFeaturesForDiagnostics() const
                     row.value});
     }
     return out;
+}
+
+QList<AppSettings::RadioFeatureEntry>
+AppSettings::radioFeatureEntriesForDiagnostics() const
+{
+    QMutexLocker ioLocker(&m_saveMutex);
+    QList<RadioFeatureEntry> out;
+    if (!m_db || !m_db->isOpen()) {
+        return out;
+    }
+    QList<SettingsDatabase::RadioFeatureRow> rows;
+    if (!m_db->listRadioFeatures(rows)) {
+        return out;
+    }
+    out.reserve(rows.size());
+    for (const auto& row : rows) {
+        out.append({row.family, row.radioId, row.feature, row.schemaVersion,
+                    row.value});
+    }
+    return out;
+}
+
+bool AppSettings::storeWritable() const
+{
+    QReadLocker locker(&m_lock);
+    return m_loadState == LoadState::ReadyToSave;
 }
 
 // ─── Radio-scoped feature documents (RFC #4603) ──────────────────────────────
@@ -1172,6 +1191,15 @@ void AppSettings::setStationValue(const QString& key, const QVariant& val)
     }
     m_stationSettings.insert(key, str);
     m_dirtyStationKeys.insert(key);
+}
+
+void AppSettings::removeStationValue(const QString& key)
+{
+    QWriteLocker locker(&m_lock);
+    if (m_stationSettings.remove(key) > 0) {
+        m_dirtyStationKeys.insert(key);   // a dirty key absent from the cache
+                                          // becomes a row delete in save()
+    }
 }
 
 QString AppSettings::stationName() const

--- a/src/core/AppSettings.h
+++ b/src/core/AppSettings.h
@@ -112,6 +112,15 @@ public:
     // one save() at a time.
     bool storeWritable() const;
 
+    // Evidence-over-assertion verification reads: fetch the row from the
+    // database FILE, not the cache. A failed save() deliberately keeps the
+    // change in memory (dirty, for retry), so a cache re-read after save()
+    // matches even when nothing was committed — only a file read proves
+    // persistence (the --config set pattern; PR #4631 review). Returns
+    // false when the row does not exist on disk.
+    bool readAppRowFromDisk(const QString& key, QString& value) const;
+    bool readStationRowFromDisk(const QString& key, QString& value) const;
+
     // Path of the settings database (the store this class persists to).
     QString filePath() const { return m_filePath; }
     // The frozen pre-SQLite XML snapshot (may not exist).

--- a/src/core/AppSettings.h
+++ b/src/core/AppSettings.h
@@ -56,6 +56,7 @@ public:
     // Per-station settings (rows in station_settings keyed by station name).
     QVariant stationValue(const QString& key, const QVariant& defaultValue = {}) const;
     void setStationValue(const QString& key, const QVariant& val);
+    void removeStationValue(const QString& key);
 
     // ── Radio-scoped feature documents (RFC #4603 proposals A/B) ─────────────
     // One versioned JSON document per (family, radio, feature) — Constitution
@@ -93,6 +94,23 @@ public:
     // for the sanitizer's dump — the third table is part of "the whole store"
     // (PR #4614 review).
     QList<QPair<QString, QString>> radioFeaturesForDiagnostics() const;
+    // The same enumeration, structured — for the Settings Browser (RFC #4603
+    // proposal D), which needs the scope coordinates as data, not a display
+    // string. Same diagnostics-only contract as the accessors above.
+    struct RadioFeatureEntry {
+        QString family;
+        QString radioId;        // "" = family-wide default row
+        QString feature;
+        int schemaVersion = 0;
+        QString value;          // the JSON document, as stored
+    };
+    QList<RadioFeatureEntry> radioFeatureEntriesForDiagnostics() const;
+
+    // True when the store accepts writes this session (loaded, not the
+    // newer-schema read-only mode, not failed). The Settings Browser uses
+    // this to disable its edit affordances instead of letting writes fail
+    // one save() at a time.
+    bool storeWritable() const;
 
     // Path of the settings database (the store this class persists to).
     QString filePath() const { return m_filePath; }

--- a/src/core/SettingsDatabase.cpp
+++ b/src/core/SettingsDatabase.cpp
@@ -607,4 +607,40 @@ bool SettingsDatabase::readAppValueFromFile(const QString& path,
     return found;
 }
 
+bool SettingsDatabase::readStationValueFromFile(const QString& path,
+                                                const QString& station,
+                                                const QString& key,
+                                                QString& value)
+{
+    sqlite3* db = nullptr;
+    const QByteArray utf8Path = path.toUtf8();
+    if (sqlite3_open_v2(utf8Path.constData(), &db, SQLITE_OPEN_READONLY, nullptr)
+        != SQLITE_OK) {
+        sqlite3_close(db);
+        return false;
+    }
+    sqlite3_busy_timeout(db, 2000);
+    bool found = false;
+    sqlite3_stmt* stmt = nullptr;
+    if (sqlite3_prepare_v2(
+            db,
+            "SELECT value FROM station_settings WHERE station = ?1 AND key = ?2;",
+            -1, &stmt, nullptr)
+        == SQLITE_OK) {
+        const QByteArray utf8Station = station.toUtf8();
+        const QByteArray utf8Key = key.toUtf8();
+        sqlite3_bind_text(stmt, 1, utf8Station.constData(), utf8Station.size(),
+                          SQLITE_TRANSIENT);
+        sqlite3_bind_text(stmt, 2, utf8Key.constData(), utf8Key.size(),
+                          SQLITE_TRANSIENT);
+        if (sqlite3_step(stmt) == SQLITE_ROW) {
+            value = columnText(stmt, 0);
+            found = true;
+        }
+    }
+    sqlite3_finalize(stmt);
+    sqlite3_close(db);
+    return found;
+}
+
 } // namespace AetherSDR

--- a/src/core/SettingsDatabase.h
+++ b/src/core/SettingsDatabase.h
@@ -122,6 +122,12 @@ public:
     // bootstrap path (SettingsBootstrap). Returns true iff the row exists.
     static bool readAppValueFromFile(const QString& path, const QString& key,
                                      QString& value);
+    // Same one-shot read-only fetch for a station_settings row — the
+    // evidence-over-assertion verification read (a failed save() keeps the
+    // change in the CACHE for retry, so only a file read proves persistence).
+    static bool readStationValueFromFile(const QString& path,
+                                         const QString& station,
+                                         const QString& key, QString& value);
 
 private:
     bool exec(const char* sql);

--- a/src/core/SettingsSanitizer.cpp
+++ b/src/core/SettingsSanitizer.cpp
@@ -47,7 +47,33 @@ QJsonValue redactJsonValue(const QJsonValue& value)
     return value;
 }
 
+bool valueContainsSecretField(const QJsonValue& value)
+{
+    if (value.isObject()) {
+        return containsSecretField(value.toObject());
+    }
+    if (value.isArray()) {
+        const QJsonArray in = value.toArray();
+        for (const QJsonValue& element : in) {
+            if (valueContainsSecretField(element)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 } // namespace
+
+bool containsSecretField(const QJsonObject& doc)
+{
+    for (auto it = doc.constBegin(); it != doc.constEnd(); ++it) {
+        if (isSecretKey(it.key()) || valueContainsSecretField(it.value())) {
+            return true;
+        }
+    }
+    return false;
+}
 
 bool isSecretKey(const QString& key)
 {

--- a/src/core/SettingsSanitizer.h
+++ b/src/core/SettingsSanitizer.h
@@ -2,6 +2,8 @@
 
 #include <QString>
 
+class QJsonObject;
+
 namespace AetherSDR {
 
 // Secret-safe rendering of the settings store for diagnostics (the support
@@ -17,6 +19,13 @@ namespace SettingsSanitizer {
 
 // True when a key/field name looks credential-bearing.
 bool isSecretKey(const QString& key);
+
+// True when the document contains a credential-shaped FIELD at any depth —
+// the editability twin of redactedValue()'s recursive masking. A UI that
+// shows a value redacted must not let the operator edit (and write the
+// redaction placeholder over) the original; this is the one predicate both
+// decisions derive from (PR #4631 review).
+bool containsSecretField(const QJsonObject& doc);
 
 // Redact `value` for display under `key`: whole-value redaction when the key
 // is secret-shaped, recursive field redaction when the value is a JSON

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -119,6 +119,7 @@ class BandPlanManager;
 class NetworkDiagnosticsHistory;
 class WhatsNewDialog;
 class ProfileManagerDialog;
+class SettingsBrowserDialog;
 class ProfileImportExportDialog;
 class RadioSetupDialog;
 class NetworkDiagnosticsDialog;
@@ -1207,6 +1208,7 @@ private:
 #endif
     QPointer<WaveformsDialog> m_waveformsDialog;
     QPointer<ProfileManagerDialog> m_profileManagerDialog;
+    QPointer<SettingsBrowserDialog> m_settingsBrowserDialog;
     QPointer<ProfileImportExportDialog> m_profileImportExportDialog;
 #ifdef HAVE_MIDI
     QPointer<MidiMappingDialog> m_midiDialog;

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -36,6 +36,7 @@
 #include "MidiMappingDialog.h"
 #include "ProfileImportExportDialog.h"
 #include "ProfileManagerDialog.h"
+#include "SettingsBrowserDialog.h"
 #include "ThemeEditorDialog.h"
 #include "TxBandDialog.h"
 #include "UlanziDialMapperDialog.h"
@@ -616,6 +617,13 @@ void MainWindow::buildMenuBar()
     dspAction->setMenuRole(QAction::NoRole);        // prevent macOS auto-reparenting (#883)
     connect(dspAction, &QAction::triggered, this, [this] {
         ensureAetherDspDialog();
+    });
+
+    auto* settingsBrowserAction = settingsMenu->addAction("Settings Browser...");
+    settingsBrowserAction->setMenuRole(QAction::NoRole);  // "Settings" in the
+                                                          // title — macOS #883
+    connect(settingsBrowserAction, &QAction::triggered, this, [this] {
+        showOrRaisePersistent(m_settingsBrowserDialog);
     });
     // RX chain DSP tile double-click also opens the full AetherDSP
     // Settings dialog — same entry point as the Settings menu action.

--- a/src/gui/SettingsBrowserDialog.cpp
+++ b/src/gui/SettingsBrowserDialog.cpp
@@ -21,6 +21,7 @@
 #include <QLineEdit>
 #include <QPlainTextEdit>
 #include <QPushButton>
+#include <QShortcut>
 #include <QShowEvent>
 #include <QSplitter>
 #include <QStyledItemDelegate>
@@ -40,6 +41,11 @@ constexpr int kRoleFamily = Qt::UserRole + 1;
 constexpr int kRoleRadioId = Qt::UserRole + 2;
 constexpr int kRoleKey = Qt::UserRole + 3;       // app/station key, or feature
 constexpr int kRoleSecret = Qt::UserRole + 4;    // bool: rendered redacted
+// The document row's stored bytes, so the viewer can tell a CORRUPT document
+// (present, unparseable) from an ABSENT one — both read back as an empty
+// object through the typed API (PR #4631 review, NF0T). Feature rows only;
+// never carries a flat value, so no plaintext is stashed for a copy action.
+constexpr int kRoleRawValue = Qt::UserRole + 5;
 
 const QString kDialogStyle =
     "QDialog { background: #0f0f1a; color: #c8d8e8; }"
@@ -214,10 +220,18 @@ SettingsBrowserDialog::SettingsBrowserDialog(QWidget* parent)
     m_table->setAccessibleName("Settings for selected scope");
     connect(m_table, &QTableWidget::itemChanged, this,
             &SettingsBrowserDialog::onTableItemChanged);
-    connect(m_table, &QTableWidget::cellActivated, this,
-            [this](int row, int) { onTableActivated(row); });
+    // ONLY doubleClicked — not activated. Both fire from
+    // QAbstractItemView::mouseDoubleClickEvent(), and `activated` also fires
+    // on a SINGLE click under styles where ActivateItemOnSingleClick is true
+    // (Breeze, some GTK themes), which would pop this modal on a stray click.
+    // Keyboard open is bound explicitly below instead (PR #4631 review, NF0T).
     connect(m_table, &QTableWidget::cellDoubleClicked, this,
             [this](int row, int) { onTableActivated(row); });
+    auto* openDocShortcut =
+        new QShortcut(QKeySequence(Qt::Key_Return), m_table);
+    openDocShortcut->setContext(Qt::WidgetShortcut);
+    connect(openDocShortcut, &QShortcut::activated, this,
+            [this] { onTableActivated(m_table->currentRow()); });
     connect(m_table, &QTableWidget::itemSelectionChanged, this,
             [this] { updateButtonState(); });
     right->addWidget(m_table, 1);
@@ -472,6 +486,7 @@ void SettingsBrowserDialog::populateTable()
             auto* featureItem = new QTableWidgetItem(entry.feature);
             featureItem->setFlags(featureItem->flags() & ~Qt::ItemIsEditable);
             featureItem->setData(kRoleKey, entry.feature);
+            featureItem->setData(kRoleRawValue, entry.value);
             m_table->setItem(row, 0, featureItem);
 
             auto* versionItem = new QTableWidgetItem(
@@ -541,22 +556,34 @@ void SettingsBrowserDialog::onTableItemChanged(QTableWidgetItem* item)
     }
     s.save();
 
-    // Verify by reading back — the honest check that the write both survived
-    // the credential seam and reached a writable store (mirrors --config set).
-    const QString stored = scope.kind == ScopeKind::App
-                               ? s.value(key).toString()
-                               : s.stationValue(key).toString();
-    if (stored == newValue) {
+    // Verify from the DATABASE FILE, not the cache: a failed save() keeps the
+    // change in memory for retry, so a cache re-read would report "Saved" for
+    // a write that never reached disk (PR #4631 review, NF0T). This is what
+    // `--config set` does, and what AGENTS.md means by checking the write
+    // result — the credential-divert case is caught either way, but a genuine
+    // commit failure is only visible on disk.
+    QString stored;
+    const bool onDisk = scope.kind == ScopeKind::App
+                            ? s.readAppRowFromDisk(key, stored)
+                            : s.readStationRowFromDisk(key, stored);
+    if (onDisk && stored == newValue) {
         setStatus(QStringLiteral("Saved %1").arg(key), false);
     } else {
-        setStatus(QStringLiteral("Write to %1 was refused — value reverted")
+        setStatus(QStringLiteral("%1 was NOT written to the store — value "
+                                 "reverted")
                       .arg(key),
                   true);
-        // Deferred: we are inside this item's own itemChanged emission, and
-        // repopulating clears the table — deleting the emitting item out
-        // from under the model (PR #4631 review).
-        QMetaObject::invokeMethod(
-            this, [this] { populateTable(); }, Qt::QueuedConnection);
+        // Revert IN PLACE rather than repopulating: we are inside this
+        // item's own itemChanged emission (rebuilding would delete the
+        // emitting item mid-signal), and an in-place revert also keeps the
+        // filter, selection, and scroll position (PR #4631 review).
+        const QString truth = scope.kind == ScopeKind::App
+                                  ? s.value(key).toString()
+                                  : s.stationValue(key).toString();
+        const bool wasPopulating = m_populating;
+        m_populating = true;   // the revert must not re-enter this handler
+        item->setText(SettingsSanitizer::redactedValue(key, truth));
+        m_populating = wasPopulating;
     }
 }
 
@@ -571,12 +598,14 @@ void SettingsBrowserDialog::onTableActivated(int row)
         return;
     }
     openDocumentViewer(scope.family, scope.radioId,
-                       featureItem->data(kRoleKey).toString());
+                       featureItem->data(kRoleKey).toString(),
+                       featureItem->data(kRoleRawValue).toString());
 }
 
 void SettingsBrowserDialog::openDocumentViewer(const QString& family,
                                                const QString& radioId,
-                                               const QString& feature)
+                                               const QString& feature,
+                                               const QString& rawValue)
 {
     // A double-click delivers cellActivated AND cellDoubleClicked on some
     // platforms — one viewer per gesture (PR #4631 review).
@@ -589,6 +618,17 @@ void SettingsBrowserDialog::openDocumentViewer(const QString& family,
     int schemaVersion = 0;
     const QJsonObject doc =
         s.radioFeatureExact(family, radioId, feature, &schemaVersion);
+
+    // A row that is PRESENT but unparseable reads back as an empty object
+    // through the typed API, indistinguishable from an absent row — and
+    // saving over it would write {} at v0 across someone's damaged-but-
+    // recoverable document. Detect it from the stored bytes and refuse to
+    // edit (PR #4631 review, NF0T).
+    QJsonParseError storedError{};
+    const bool corrupt =
+        !rawValue.trimmed().isEmpty()
+        && (QJsonDocument::fromJson(rawValue.toUtf8(), &storedError).isNull()
+            || storedError.error != QJsonParseError::NoError);
 
     // Same recursive masking as the table and the sanitized dump — the
     // viewer must not be the one path that renders a credential-shaped
@@ -613,14 +653,25 @@ void SettingsBrowserDialog::openDocumentViewer(const QString& family,
         QStringLiteral("%1 / %2 / %3 — schema v%4%5")
             .arg(family, scopeLabelForRadioId(radioId), feature)
             .arg(schemaVersion)
-            .arg(hasSecret
-                     ? QStringLiteral("  ·  credential fields masked, read-only")
-                     : QString()));
+            .arg(corrupt
+                     ? QStringLiteral("  ·  DOES NOT PARSE — read-only")
+                     : hasSecret
+                           ? QStringLiteral(
+                                 "  ·  credential fields masked, read-only")
+                           : QString()));
     layout->addWidget(header);
 
     auto* text = new QPlainTextEdit;
-    text->setPlainText(QString::fromUtf8(
-        QJsonDocument(displayDoc).toJson(QJsonDocument::Indented)));
+    text->setPlainText(
+        corrupt ? QStringLiteral(
+                      "This document is stored but does not parse as JSON "
+                      "(%1 at offset %2), so it cannot be edited here without "
+                      "overwriting it.\n\nStored bytes:\n\n%3")
+                      .arg(storedError.errorString())
+                      .arg(storedError.offset)
+                      .arg(SettingsSanitizer::redactedValue(feature, rawValue))
+                : QString::fromUtf8(
+                      QJsonDocument(displayDoc).toJson(QJsonDocument::Indented)));
     text->setReadOnly(true);
     text->setAccessibleName(
         QStringLiteral("%1 document contents").arg(feature));
@@ -633,8 +684,13 @@ void SettingsBrowserDialog::openDocumentViewer(const QString& family,
     // masked flat rows. (Delete stays available: a whole-document delete is
     // the sanctioned remediation for a legacy store that still carries a
     // credential-bearing document, and destroys rather than corrupts.)
-    editBtn->setEnabled(m_storeWritable && !hasSecret);
-    if (hasSecret) {
+    editBtn->setEnabled(m_storeWritable && !hasSecret && !corrupt);
+    if (corrupt) {
+        editBtn->setToolTip(
+            "This document does not parse — editing here would overwrite "
+            "recoverable bytes. Repair it with --config, or delete it to let "
+            "the owning feature start fresh.");
+    } else if (hasSecret) {
         editBtn->setToolTip(
             "This document contains a credential-shaped field — edit it "
             "through the owning feature's UI, which keeps the secret in the "
@@ -766,15 +822,16 @@ void SettingsBrowserDialog::addKey()
         s.setStationValue(key, valueEdit->text());
     }
     s.save();
-    // Same read-back verification as the inline-edit path — "Added" must
-    // mean the row survived the seam and the store (PR #4631 review).
-    const QString stored = scope.kind == ScopeKind::App
-                               ? s.value(key).toString()
-                               : s.stationValue(key).toString();
-    if (stored == valueEdit->text()) {
+    // Same on-disk verification as the inline-edit path — "Added" must mean
+    // the row reached the database, not just the cache (PR #4631 review).
+    QString stored;
+    const bool onDisk = scope.kind == ScopeKind::App
+                            ? s.readAppRowFromDisk(key, stored)
+                            : s.readStationRowFromDisk(key, stored);
+    if (onDisk && stored == valueEdit->text()) {
         setStatus(QStringLiteral("Added %1").arg(key), false);
     } else {
-        setStatus(QStringLiteral("Add of %1 was refused by the store").arg(key),
+        setStatus(QStringLiteral("%1 was NOT written to the store").arg(key),
                   true);
     }
     populateTable();

--- a/src/gui/SettingsBrowserDialog.cpp
+++ b/src/gui/SettingsBrowserDialog.cpp
@@ -1,0 +1,797 @@
+#include "SettingsBrowserDialog.h"
+#include "FramelessMessageBox.h"
+#include "core/AppSettings.h"
+#include "core/SettingsCredentialPolicy.h"
+#include "core/SettingsSanitizer.h"
+#include "core/ThemeManager.h"
+
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QDir>
+#include <QFile>
+#include <QFileDialog>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QShowEvent>
+#include <QSplitter>
+#include <QStyledItemDelegate>
+#include <QTableWidget>
+#include <QTreeWidget>
+#include <QVBoxLayout>
+
+#include <functional>
+
+namespace AetherSDR {
+
+namespace {
+
+// Tree/table item data roles for the scope coordinates a row addresses.
+constexpr int kRoleKind = Qt::UserRole;          // int(ScopeKind)
+constexpr int kRoleFamily = Qt::UserRole + 1;
+constexpr int kRoleRadioId = Qt::UserRole + 2;
+constexpr int kRoleKey = Qt::UserRole + 3;       // app/station key, or feature
+constexpr int kRoleSecret = Qt::UserRole + 4;    // bool: rendered redacted
+
+const QString kDialogStyle =
+    "QDialog { background: #0f0f1a; color: #c8d8e8; }"
+    "QLabel { color: #c8d8e8; }"
+    "QLineEdit { background: #0a0a18; border: 1px solid #1e2e3e; border-radius: 3px;"
+    "  padding: 4px 6px; color: #c8d8e8; }"
+    "QTreeWidget { background: #0a0a18; border: 1px solid #1e2e3e; border-radius: 3px;"
+    "  color: #c8d8e8; outline: none; }"
+    "QTreeWidget::item { min-height: 22px; padding: 1px 4px; }"
+    "QTreeWidget::item:selected { background: #0070c0; color: #ffffff; }"
+    "QTreeWidget::item:hover:!selected { background: #1a2a3a; }"
+    "QTableWidget { background: #0a0a18; border: 1px solid #1e2e3e; border-radius: 3px;"
+    "  color: #c8d8e8; gridline-color: #14202f;"
+    "  selection-background-color: #1b3650; selection-color: #e8f4ff; }"
+    "QHeaderView::section { color: #8d99ad; background: #101c2a; border: none;"
+    "  border-bottom: 1px solid #233246; padding: 4px 8px; font-size: 11px; }"
+    "QPlainTextEdit { background: #0a0a18; border: 1px solid #1e2e3e;"
+    "  border-radius: 3px; color: #c8d8e8;"
+    "  font-family: \"SF Mono\", \"Menlo\", \"Consolas\", monospace; }"
+    "QPushButton { background: #1a2a3a; border: 1px solid #203040;"
+    "  border-radius: 3px; padding: 4px 12px; color: #c8d8e8; }"
+    "QPushButton:hover { background: #2a3a4a; }"
+    "QPushButton:disabled { background: #141c26; border: 1px solid #1a2632;"
+    "  color: #5a6a78; }"
+    "QComboBox { background: #0a0a18; border: 1px solid #1e2e3e; border-radius: 3px;"
+    "  padding: 2px 6px; color: #c8d8e8; }";
+
+// Same result-line styling as ProfileManagerDialog / ConnectionPanel so the
+// status messages read as the same kind of message app-wide.
+const char* kResultInfoStyle =
+    "QLabel { color: #9bd1ff; font-size: 11px; background: transparent; border: none; }";
+const char* kResultErrorStyle =
+    "QLabel { color: #ff8f8f; font-size: 11px; background: transparent; border: none; }";
+const char* kBannerStyle =
+    "QLabel { color: #ffc978; font-size: 11px; background: #241c10;"
+    "  border: 1px solid #4a3a1a; border-radius: 3px; padding: 5px 8px; }";
+
+// Values that are exactly "True"/"False" (the store's boolean convention) get
+// a two-entry combo instead of free text, so a typo can't produce "Ture".
+class BoolAwareValueDelegate : public QStyledItemDelegate {
+public:
+    using QStyledItemDelegate::QStyledItemDelegate;
+
+    QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option,
+                          const QModelIndex& index) const override
+    {
+        const QString value = index.data(Qt::EditRole).toString();
+        if (value == QLatin1String("True") || value == QLatin1String("False")) {
+            auto* combo = new QComboBox(parent);
+            combo->addItems({QStringLiteral("True"), QStringLiteral("False")});
+            combo->setCurrentText(value);
+            return combo;
+        }
+        return QStyledItemDelegate::createEditor(parent, option, index);
+    }
+
+    void setModelData(QWidget* editor, QAbstractItemModel* model,
+                      const QModelIndex& index) const override
+    {
+        if (auto* combo = qobject_cast<QComboBox*>(editor)) {
+            model->setData(index, combo->currentText(), Qt::EditRole);
+            return;
+        }
+        QStyledItemDelegate::setModelData(editor, model, index);
+    }
+};
+
+QString scopeLabelForRadioId(const QString& radioId)
+{
+    return radioId.isEmpty() ? QStringLiteral("(family-wide defaults)") : radioId;
+}
+
+// Display name for a radio scope: the nickname from its Identity document
+// when one exists (family-agnostic — driven by the data, not the backend).
+QString nicknameFor(const QList<AppSettings::RadioFeatureEntry>& rows,
+                    const QString& family, const QString& radioId)
+{
+    for (const auto& row : rows) {
+        if (row.family != family || row.radioId != radioId
+            || row.feature != QLatin1String("Identity")) {
+            continue;
+        }
+        const QJsonDocument doc = QJsonDocument::fromJson(row.value.toUtf8());
+        return doc.object().value(QLatin1String("nickname")).toString();
+    }
+    return {};
+}
+
+} // namespace
+
+SettingsBrowserDialog::SettingsBrowserDialog(QWidget* parent)
+    : PersistentDialog("Settings Browser", "SettingsBrowserDialogGeometry", parent)
+{
+    theme::setContainer(this, QStringLiteral("dialog/settingsBrowser"));
+    setMinimumSize(760, 480);
+    setStyleSheet(kDialogStyle);
+
+    auto* root = new QVBoxLayout(bodyWidget());
+    root->setSpacing(9);
+
+    m_banner = new QLabel(
+        "Advanced — edits apply immediately and bypass each feature's own "
+        "validation. Prefer the feature's UI when one exists.");
+    m_banner->setStyleSheet(kBannerStyle);
+    m_banner->setWordWrap(true);
+    root->addWidget(m_banner);
+
+    auto* splitter = new QSplitter(Qt::Horizontal);
+    splitter->setChildrenCollapsible(false);
+
+    m_tree = new QTreeWidget;
+    m_tree->setHeaderHidden(true);
+    m_tree->setMinimumWidth(190);
+    m_tree->setAccessibleName("Settings scopes");
+    m_tree->setAccessibleDescription(
+        "Scopes in the settings store: application, station, and each "
+        "radio's feature documents");
+    connect(m_tree, &QTreeWidget::currentItemChanged, this,
+            [this] { populateTable(); });
+    splitter->addWidget(m_tree);
+
+    auto* rightHost = new QWidget;
+    auto* right = new QVBoxLayout(rightHost);
+    right->setContentsMargins(0, 0, 0, 0);
+    right->setSpacing(6);
+
+    m_search = new QLineEdit;
+    m_search->setPlaceholderText("Filter keys and values…");
+    m_search->setClearButtonEnabled(true);
+    m_search->setAccessibleName("Settings filter");
+    m_search->setAccessibleDescription(
+        "Case-insensitive substring match over the keys and values of the "
+        "selected scope");
+    connect(m_search, &QLineEdit::textChanged, this,
+            [this] { applyFilter(); });
+    right->addWidget(m_search);
+
+    m_table = new QTableWidget;
+    m_table->setColumnCount(2);
+    m_table->verticalHeader()->setVisible(false);
+    m_table->horizontalHeader()->setStretchLastSection(true);
+    m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_table->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_table->setEditTriggers(QAbstractItemView::DoubleClicked
+                             | QAbstractItemView::EditKeyPressed);
+    m_table->setItemDelegateForColumn(1, new BoolAwareValueDelegate(m_table));
+    m_table->setAccessibleName("Settings for selected scope");
+    connect(m_table, &QTableWidget::itemChanged, this,
+            &SettingsBrowserDialog::onTableItemChanged);
+    connect(m_table, &QTableWidget::cellActivated, this,
+            [this](int row, int) { onTableActivated(row); });
+    connect(m_table, &QTableWidget::cellDoubleClicked, this,
+            [this](int row, int) { onTableActivated(row); });
+    connect(m_table, &QTableWidget::itemSelectionChanged, this,
+            [this] { updateButtonState(); });
+    right->addWidget(m_table, 1);
+
+    splitter->addWidget(rightHost);
+    splitter->setStretchFactor(0, 0);
+    splitter->setStretchFactor(1, 1);
+    root->addWidget(splitter, 1);
+
+    m_status = new QLabel;
+    m_status->setStyleSheet(kResultInfoStyle);
+    m_status->setVisible(false);
+    m_status->setWordWrap(true);
+    root->addWidget(m_status);
+
+    auto* buttons = new QHBoxLayout;
+    m_addBtn = new QPushButton("Add Key…");
+    m_addBtn->setAccessibleName("Add settings key");
+    connect(m_addBtn, &QPushButton::clicked, this,
+            &SettingsBrowserDialog::addKey);
+    buttons->addWidget(m_addBtn);
+
+    m_deleteBtn = new QPushButton("Delete");
+    m_deleteBtn->setAccessibleName("Delete selected setting");
+    connect(m_deleteBtn, &QPushButton::clicked, this,
+            &SettingsBrowserDialog::deleteSelected);
+    buttons->addWidget(m_deleteBtn);
+
+    m_refreshBtn = new QPushButton("Refresh");
+    m_refreshBtn->setAccessibleName("Refresh settings view");
+    connect(m_refreshBtn, &QPushButton::clicked, this,
+            [this] { rebuildTree(); });
+    buttons->addWidget(m_refreshBtn);
+
+    buttons->addStretch();
+
+    m_exportBtn = new QPushButton("Export Sanitized…");
+    m_exportBtn->setAccessibleName("Export sanitized settings dump");
+    m_exportBtn->setAccessibleDescription(
+        "Writes the secret-redacted diagnostic dump — not a restorable backup");
+    connect(m_exportBtn, &QPushButton::clicked, this,
+            &SettingsBrowserDialog::exportSanitized);
+    buttons->addWidget(m_exportBtn);
+
+    auto* closeBtn = new QPushButton("Close");
+    connect(closeBtn, &QPushButton::clicked, this, &QDialog::accept);
+    buttons->addWidget(closeBtn);
+    root->addLayout(buttons);
+
+    rebuildTree();
+}
+
+void SettingsBrowserDialog::showEvent(QShowEvent* event)
+{
+    PersistentDialog::showEvent(event);
+    // The store changes underneath us (features write documents debounced) —
+    // re-read on every show so a re-raised dialog isn't showing stale rows.
+    rebuildTree();
+}
+
+void SettingsBrowserDialog::rebuildTree()
+{
+    const Scope remembered = currentScope();
+    auto& s = AppSettings::instance();
+
+    m_storeWritable = s.storeWritable();
+    if (m_storeWritable) {
+        m_banner->setText(
+            "Advanced — edits apply immediately and bypass each feature's own "
+            "validation. Prefer the feature's UI when one exists.");
+    } else {
+        const QString notice = s.loadNotice();
+        m_banner->setText(
+            "This settings store is read-only this session"
+            + (notice.isEmpty() ? QString(".") : QString(": ") + notice));
+    }
+
+    m_populating = true;
+    m_tree->clear();
+
+    auto* appItem = new QTreeWidgetItem(
+        m_tree, {QStringLiteral("App Settings (%1)")
+                     .arg(s.allKeysForDiagnostics().size())});
+    appItem->setData(0, kRoleKind, int(ScopeKind::App));
+
+    auto* stationItem = new QTreeWidgetItem(
+        m_tree, {QStringLiteral("Station: %1 (%2)")
+                     .arg(s.stationName())
+                     .arg(s.stationKeysForDiagnostics().size())});
+    stationItem->setData(0, kRoleKind, int(ScopeKind::Station));
+
+    const QList<AppSettings::RadioFeatureEntry> rows =
+        s.radioFeatureEntriesForDiagnostics();
+    if (!rows.isEmpty()) {
+        auto* radiosItem = new QTreeWidgetItem(m_tree, {QStringLiteral("Radios")});
+        radiosItem->setFlags(radiosItem->flags() & ~Qt::ItemIsSelectable);
+
+        // family -> ordered unique radioIds ('' first when present)
+        QMap<QString, QStringList> radiosByFamily;
+        for (const auto& row : rows) {
+            QStringList& ids = radiosByFamily[row.family];
+            if (!ids.contains(row.radioId)) {
+                ids.append(row.radioId);
+            }
+        }
+        for (auto it = radiosByFamily.cbegin(); it != radiosByFamily.cend();
+             ++it) {
+            auto* familyItem = new QTreeWidgetItem(radiosItem, {it.key()});
+            familyItem->setFlags(familyItem->flags() & ~Qt::ItemIsSelectable);
+            QStringList ids = it.value();
+            ids.sort();
+            for (const QString& radioId : ids) {
+                const QString nickname = nicknameFor(rows, it.key(), radioId);
+                const QString label =
+                    nickname.isEmpty()
+                        ? scopeLabelForRadioId(radioId)
+                        : QStringLiteral("%1 (%2)").arg(nickname, radioId);
+                auto* radioItem = new QTreeWidgetItem(familyItem, {label});
+                radioItem->setData(0, kRoleKind, int(ScopeKind::RadioScope));
+                radioItem->setData(0, kRoleFamily, it.key());
+                radioItem->setData(0, kRoleRadioId, radioId);
+            }
+        }
+        radiosItem->setExpanded(true);
+        for (int i = 0; i < radiosItem->childCount(); ++i) {
+            radiosItem->child(i)->setExpanded(true);
+        }
+    }
+
+    m_populating = false;
+    selectScopeItem(remembered.kind == ScopeKind::None
+                        ? Scope{ScopeKind::App, {}, {}}
+                        : remembered);
+    populateTable();
+}
+
+SettingsBrowserDialog::Scope SettingsBrowserDialog::currentScope() const
+{
+    Scope scope;
+    const QTreeWidgetItem* item = m_tree->currentItem();
+    if (item == nullptr || item->data(0, kRoleKind).isNull()) {
+        return scope;
+    }
+    scope.kind = ScopeKind(item->data(0, kRoleKind).toInt());
+    scope.family = item->data(0, kRoleFamily).toString();
+    scope.radioId = item->data(0, kRoleRadioId).toString();
+    return scope;
+}
+
+void SettingsBrowserDialog::selectScopeItem(const Scope& scope)
+{
+    std::function<QTreeWidgetItem*(QTreeWidgetItem*)> find =
+        [&](QTreeWidgetItem* item) -> QTreeWidgetItem* {
+        if (item != nullptr && !item->data(0, kRoleKind).isNull()
+            && ScopeKind(item->data(0, kRoleKind).toInt()) == scope.kind
+            && item->data(0, kRoleFamily).toString() == scope.family
+            && item->data(0, kRoleRadioId).toString() == scope.radioId) {
+            return item;
+        }
+        for (int i = 0; item != nullptr && i < item->childCount(); ++i) {
+            if (QTreeWidgetItem* hit = find(item->child(i))) {
+                return hit;
+            }
+        }
+        return nullptr;
+    };
+    for (int i = 0; i < m_tree->topLevelItemCount(); ++i) {
+        if (QTreeWidgetItem* hit = find(m_tree->topLevelItem(i))) {
+            m_tree->setCurrentItem(hit);
+            return;
+        }
+    }
+    if (m_tree->topLevelItemCount() > 0) {
+        m_tree->setCurrentItem(m_tree->topLevelItem(0));
+    }
+}
+
+void SettingsBrowserDialog::populateTable()
+{
+    if (m_populating) {
+        return;
+    }
+    const Scope scope = currentScope();
+    auto& s = AppSettings::instance();
+
+    m_populating = true;
+    m_table->clearContents();
+    m_table->setRowCount(0);
+
+    const bool docScope = scope.kind == ScopeKind::RadioScope;
+    m_table->setColumnCount(docScope ? 3 : 2);
+    m_table->setHorizontalHeaderLabels(
+        docScope ? QStringList{"Feature", "Schema", "Document"}
+                 : QStringList{"Key", "Value"});
+
+    auto addRow = [this](const QString& key, const QString& value,
+                         bool editable) {
+        const int row = m_table->rowCount();
+        m_table->insertRow(row);
+        const bool secret = SettingsSanitizer::isSecretKey(key);
+
+        auto* keyItem = new QTableWidgetItem(key);
+        keyItem->setFlags(keyItem->flags() & ~Qt::ItemIsEditable);
+        keyItem->setData(kRoleKey, key);
+        m_table->setItem(row, 0, keyItem);
+
+        auto* valueItem = new QTableWidgetItem(
+            SettingsSanitizer::redactedValue(key, value));
+        valueItem->setData(kRoleSecret, secret);
+        if (secret || !editable || !m_storeWritable) {
+            valueItem->setFlags(valueItem->flags() & ~Qt::ItemIsEditable);
+        }
+        if (secret) {
+            valueItem->setToolTip(
+                "Credential-shaped values are masked and read-only here — "
+                "credentials belong in the OS keychain, not this store");
+        }
+        m_table->setItem(row, 1, valueItem);
+    };
+
+    switch (scope.kind) {
+    case ScopeKind::App: {
+        const QStringList keys = s.allKeysForDiagnostics();
+        for (const QString& key : keys) {
+            addRow(key, s.value(key).toString(), true);
+        }
+        break;
+    }
+    case ScopeKind::Station: {
+        const QStringList keys = s.stationKeysForDiagnostics();
+        for (const QString& key : keys) {
+            addRow(key, s.stationValue(key).toString(), true);
+        }
+        break;
+    }
+    case ScopeKind::RadioScope: {
+        const QList<AppSettings::RadioFeatureEntry> rows =
+            s.radioFeatureEntriesForDiagnostics();
+        for (const auto& entry : rows) {
+            if (entry.family != scope.family
+                || entry.radioId != scope.radioId) {
+                continue;
+            }
+            const int row = m_table->rowCount();
+            m_table->insertRow(row);
+
+            auto* featureItem = new QTableWidgetItem(entry.feature);
+            featureItem->setFlags(featureItem->flags() & ~Qt::ItemIsEditable);
+            featureItem->setData(kRoleKey, entry.feature);
+            m_table->setItem(row, 0, featureItem);
+
+            auto* versionItem = new QTableWidgetItem(
+                QStringLiteral("v%1").arg(entry.schemaVersion));
+            versionItem->setFlags(versionItem->flags() & ~Qt::ItemIsEditable);
+            m_table->setItem(row, 1, versionItem);
+
+            const QJsonDocument doc =
+                QJsonDocument::fromJson(entry.value.toUtf8());
+            auto* docItem = new QTableWidgetItem(
+                QString::fromUtf8(doc.toJson(QJsonDocument::Compact)));
+            docItem->setFlags(docItem->flags() & ~Qt::ItemIsEditable);
+            docItem->setToolTip("Double-click to view the document");
+            m_table->setItem(row, 2, docItem);
+        }
+        break;
+    }
+    case ScopeKind::None:
+        break;
+    }
+
+    m_table->resizeColumnToContents(0);
+    if (docScope) {
+        m_table->resizeColumnToContents(1);
+    }
+    m_populating = false;
+    applyFilter();
+    updateButtonState();
+}
+
+void SettingsBrowserDialog::applyFilter()
+{
+    const QString needle = m_search->text().trimmed();
+    for (int row = 0; row < m_table->rowCount(); ++row) {
+        bool match = needle.isEmpty();
+        for (int col = 0; !match && col < m_table->columnCount(); ++col) {
+            const QTableWidgetItem* item = m_table->item(row, col);
+            match = item != nullptr
+                    && item->text().contains(needle, Qt::CaseInsensitive);
+        }
+        m_table->setRowHidden(row, !match);
+    }
+}
+
+void SettingsBrowserDialog::onTableItemChanged(QTableWidgetItem* item)
+{
+    if (m_populating || item == nullptr || item->column() != 1) {
+        return;
+    }
+    const Scope scope = currentScope();
+    if (scope.kind != ScopeKind::App && scope.kind != ScopeKind::Station) {
+        return;
+    }
+    const QTableWidgetItem* keyItem = m_table->item(item->row(), 0);
+    if (keyItem == nullptr) {
+        return;
+    }
+    const QString key = keyItem->data(kRoleKey).toString();
+    const QString newValue = item->text();
+
+    auto& s = AppSettings::instance();
+    if (scope.kind == ScopeKind::App) {
+        s.setValue(key, newValue);
+    } else {
+        s.setStationValue(key, newValue);
+    }
+    s.save();
+
+    // Verify by reading back — the honest check that the write both survived
+    // the credential seam and reached a writable store (mirrors --config set).
+    const QString stored = scope.kind == ScopeKind::App
+                               ? s.value(key).toString()
+                               : s.stationValue(key).toString();
+    if (stored == newValue) {
+        setStatus(QStringLiteral("Saved %1").arg(key), false);
+    } else {
+        setStatus(QStringLiteral("Write to %1 was refused — value reverted")
+                      .arg(key),
+                  true);
+        populateTable();
+    }
+}
+
+void SettingsBrowserDialog::onTableActivated(int row)
+{
+    const Scope scope = currentScope();
+    if (scope.kind != ScopeKind::RadioScope) {
+        return;   // app/station rows edit inline via the delegate
+    }
+    const QTableWidgetItem* featureItem = m_table->item(row, 0);
+    if (featureItem == nullptr) {
+        return;
+    }
+    openDocumentViewer(scope.family, scope.radioId,
+                       featureItem->data(kRoleKey).toString());
+}
+
+void SettingsBrowserDialog::openDocumentViewer(const QString& family,
+                                               const QString& radioId,
+                                               const QString& feature)
+{
+    auto& s = AppSettings::instance();
+    int schemaVersion = 0;
+    const QJsonObject doc =
+        s.radioFeatureExact(family, radioId, feature, &schemaVersion);
+
+    QDialog viewer(this);
+    viewer.setWindowTitle(QStringLiteral("%1 — %2 / %3").arg(
+        feature, family, scopeLabelForRadioId(radioId)));
+    viewer.setMinimumSize(520, 420);
+    viewer.setStyleSheet(kDialogStyle);
+    auto* layout = new QVBoxLayout(&viewer);
+
+    auto* header = new QLabel(
+        QStringLiteral("%1 / %2 / %3 — schema v%4")
+            .arg(family, scopeLabelForRadioId(radioId), feature)
+            .arg(schemaVersion));
+    layout->addWidget(header);
+
+    auto* text = new QPlainTextEdit;
+    text->setPlainText(QString::fromUtf8(
+        QJsonDocument(doc).toJson(QJsonDocument::Indented)));
+    text->setReadOnly(true);
+    text->setAccessibleName(
+        QStringLiteral("%1 document contents").arg(feature));
+    layout->addWidget(text, 1);
+
+    auto* buttons = new QHBoxLayout;
+    auto* editBtn = new QPushButton("Edit Raw JSON…");
+    editBtn->setEnabled(m_storeWritable);
+    auto* saveBtn = new QPushButton("Save");
+    saveBtn->setEnabled(false);
+    auto* closeBtn = new QPushButton("Close");
+    buttons->addWidget(editBtn);
+    buttons->addStretch();
+    buttons->addWidget(saveBtn);
+    buttons->addWidget(closeBtn);
+    layout->addLayout(buttons);
+
+    connect(editBtn, &QPushButton::clicked, &viewer, [text, saveBtn, editBtn] {
+        text->setReadOnly(false);
+        saveBtn->setEnabled(true);
+        editBtn->setEnabled(false);
+        text->setFocus();
+    });
+    connect(closeBtn, &QPushButton::clicked, &viewer, &QDialog::reject);
+    connect(saveBtn, &QPushButton::clicked, &viewer,
+            [this, &viewer, text, family, radioId, feature, schemaVersion] {
+        QJsonParseError parseError{};
+        const QJsonDocument parsed = QJsonDocument::fromJson(
+            text->toPlainText().toUtf8(), &parseError);
+        if (parsed.isNull() || !parsed.isObject()) {
+            FramelessMessageBox::warning(
+                &viewer, "Invalid JSON",
+                parseError.error != QJsonParseError::NoError
+                    ? QStringLiteral("Not saved — %1 at offset %2.")
+                          .arg(parseError.errorString())
+                          .arg(parseError.offset)
+                    : QStringLiteral(
+                          "Not saved — the document must be a JSON object."));
+            return;
+        }
+        if (!AppSettings::instance().setRadioFeature(
+                family, radioId, feature, schemaVersion, parsed.object())) {
+            FramelessMessageBox::warning(
+                &viewer, "Write Refused",
+                "The store refused this write (read-only session, or the "
+                "stored document is from a newer version). Nothing changed.");
+            return;
+        }
+        setStatus(QStringLiteral("Saved document %1").arg(feature), false);
+        viewer.accept();
+    });
+
+    viewer.exec();
+    populateTable();
+}
+
+void SettingsBrowserDialog::addKey()
+{
+    const Scope scope = currentScope();
+    if (scope.kind != ScopeKind::App && scope.kind != ScopeKind::Station) {
+        return;
+    }
+    const QString scopeName = scope.kind == ScopeKind::App
+                                  ? QStringLiteral("App Settings")
+                                  : QStringLiteral("Station: %1").arg(
+                                        AppSettings::instance().stationName());
+
+    QDialog dlg(this);
+    dlg.setWindowTitle("Add Key");
+    dlg.setStyleSheet(kDialogStyle);
+    auto* form = new QFormLayout(&dlg);
+    auto* keyEdit = new QLineEdit;
+    keyEdit->setAccessibleName("New key name");
+    auto* valueEdit = new QLineEdit;
+    valueEdit->setAccessibleName("New key value");
+    form->addRow(new QLabel(QStringLiteral("Scope: %1").arg(scopeName)));
+    form->addRow("Key:", keyEdit);
+    form->addRow("Value:", valueEdit);
+    auto* box = new QDialogButtonBox(QDialogButtonBox::Ok
+                                     | QDialogButtonBox::Cancel);
+    connect(box, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
+    connect(box, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
+    form->addRow(box);
+    if (dlg.exec() != QDialog::Accepted) {
+        return;
+    }
+
+    const QString key = keyEdit->text().trimmed();
+    if (key.isEmpty()) {
+        return;
+    }
+    auto& s = AppSettings::instance();
+    if (SettingsCredentialPolicy::isFlatCredentialKey(key)
+        || SettingsSanitizer::isSecretKey(key)) {
+        FramelessMessageBox::warning(
+            this, "Credential Key Refused",
+            "Credentials are never stored in the settings database — they "
+            "belong in the OS keychain, via the owning feature's own UI.");
+        return;
+    }
+    const bool exists = scope.kind == ScopeKind::App
+                            ? s.contains(key)
+                            : s.stationKeysForDiagnostics().contains(key);
+    if (!exists
+        && FramelessMessageBox::question(
+               this, "Create Raw Key?",
+               QStringLiteral("Create %1 in %2?\n\nThis writes a raw key the "
+                              "app may never read. Continue?")
+                   .arg(key, scopeName))
+               != FramelessMessageBox::Yes) {
+        return;
+    }
+    if (scope.kind == ScopeKind::App) {
+        s.setValue(key, valueEdit->text());
+    } else {
+        s.setStationValue(key, valueEdit->text());
+    }
+    s.save();
+    setStatus(QStringLiteral("Added %1").arg(key), false);
+    populateTable();
+}
+
+void SettingsBrowserDialog::deleteSelected()
+{
+    const Scope scope = currentScope();
+    const int row = m_table->currentRow();
+    if (row < 0) {
+        return;
+    }
+    const QTableWidgetItem* keyItem = m_table->item(row, 0);
+    if (keyItem == nullptr) {
+        return;
+    }
+    const QString key = keyItem->data(kRoleKey).toString();
+    auto& s = AppSettings::instance();
+
+    QString prompt;
+    switch (scope.kind) {
+    case ScopeKind::App:
+        prompt = QStringLiteral("Delete app setting %1?").arg(key);
+        break;
+    case ScopeKind::Station:
+        prompt = QStringLiteral("Delete station setting %1?").arg(key);
+        break;
+    case ScopeKind::RadioScope:
+        prompt = QStringLiteral(
+                     "Delete the %1 document for %2 / %3?\n\nThe owning "
+                     "feature will start from scratch — for a radio-state "
+                     "document that means the radio's remembered operating "
+                     "state is gone.")
+                     .arg(key, scope.family, scopeLabelForRadioId(scope.radioId));
+        break;
+    case ScopeKind::None:
+        return;
+    }
+    if (FramelessMessageBox::question(this, "Delete Setting?", prompt)
+        != FramelessMessageBox::Yes) {
+        return;
+    }
+
+    switch (scope.kind) {
+    case ScopeKind::App:
+        s.remove(key);
+        s.save();
+        break;
+    case ScopeKind::Station:
+        s.removeStationValue(key);
+        s.save();
+        break;
+    case ScopeKind::RadioScope:
+        if (!s.removeRadioFeature(scope.family, scope.radioId, key)) {
+            setStatus(QStringLiteral("Delete of %1 was refused").arg(key),
+                      true);
+            return;
+        }
+        break;
+    case ScopeKind::None:
+        return;
+    }
+    setStatus(QStringLiteral("Deleted %1").arg(key), false);
+    rebuildTree();
+}
+
+void SettingsBrowserDialog::exportSanitized()
+{
+    const QString path = QFileDialog::getSaveFileName(
+        this, "Export Sanitized Settings",
+        QDir::home().filePath(QStringLiteral("AetherSDR-settings.txt")),
+        "Text files (*.txt);;All files (*)");
+    if (path.isEmpty()) {
+        return;
+    }
+    QFile file(path);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        setStatus(QStringLiteral("Could not write %1: %2")
+                      .arg(path, file.errorString()),
+                  true);
+        return;
+    }
+    file.write(SettingsSanitizer::dump().toUtf8());
+    file.close();
+    setStatus(QStringLiteral("Exported sanitized dump to %1").arg(path), false);
+}
+
+void SettingsBrowserDialog::setStatus(const QString& text, bool error)
+{
+    m_status->setStyleSheet(error ? kResultErrorStyle : kResultInfoStyle);
+    m_status->setText(text);
+    m_status->setVisible(!text.isEmpty());
+}
+
+void SettingsBrowserDialog::updateButtonState()
+{
+    const Scope scope = currentScope();
+    const bool flatScope = scope.kind == ScopeKind::App
+                           || scope.kind == ScopeKind::Station;
+    m_addBtn->setEnabled(m_storeWritable && flatScope);
+
+    bool deletable = false;
+    const int row = m_table->currentRow();
+    if (m_storeWritable && row >= 0 && scope.kind != ScopeKind::None) {
+        const QTableWidgetItem* valueItem = m_table->item(row, 1);
+        // A masked (credential-shaped) row is fully read-only here — deleting
+        // blind is as unsafe as editing blind.
+        deletable = scope.kind == ScopeKind::RadioScope
+                    || valueItem == nullptr
+                    || !valueItem->data(kRoleSecret).toBool();
+    }
+    m_deleteBtn->setEnabled(deletable);
+}
+
+} // namespace AetherSDR

--- a/src/gui/SettingsBrowserDialog.cpp
+++ b/src/gui/SettingsBrowserDialog.cpp
@@ -13,6 +13,7 @@
 #include <QFormLayout>
 #include <QHBoxLayout>
 #include <QHeaderView>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonParseError>
@@ -75,6 +76,33 @@ const char* kResultErrorStyle =
 const char* kBannerStyle =
     "QLabel { color: #ffc978; font-size: 11px; background: #241c10;"
     "  border: 1px solid #4a3a1a; border-radius: 3px; padding: 5px 8px; }";
+
+const char* kAdvancedBannerText =
+    "Advanced — edits apply immediately and bypass each feature's own "
+    "validation. Prefer the feature's UI when one exists.";
+
+// True when a stored VALUE is a JSON document holding a credential-shaped
+// field at any depth. Such a row renders partially redacted, so it must be
+// read-only too — otherwise committing an edit writes the "[REDACTED]"
+// placeholder over the real secret (PR #4631 review, both reviewers).
+bool valueHidesSecret(const QString& value)
+{
+    const QByteArray raw = value.toUtf8().trimmed();
+    if (!raw.startsWith('{') && !raw.startsWith('[')) {
+        return false;
+    }
+    QJsonParseError parseError{};
+    const QJsonDocument doc = QJsonDocument::fromJson(raw, &parseError);
+    if (parseError.error != QJsonParseError::NoError || doc.isNull()) {
+        return false;
+    }
+    if (doc.isObject()) {
+        return SettingsSanitizer::containsSecretField(doc.object());
+    }
+    // Top-level array: wrap so the recursive object check walks it.
+    return SettingsSanitizer::containsSecretField(
+        QJsonObject{{QStringLiteral("_"), doc.array()}});
+}
 
 // Values that are exactly "True"/"False" (the store's boolean convention) get
 // a two-entry combo instead of free text, so a typo can't produce "Ture".
@@ -139,9 +167,7 @@ SettingsBrowserDialog::SettingsBrowserDialog(QWidget* parent)
     auto* root = new QVBoxLayout(bodyWidget());
     root->setSpacing(9);
 
-    m_banner = new QLabel(
-        "Advanced — edits apply immediately and bypass each feature's own "
-        "validation. Prefer the feature's UI when one exists.");
+    m_banner = new QLabel(kAdvancedBannerText);
     m_banner->setStyleSheet(kBannerStyle);
     m_banner->setWordWrap(true);
     root->addWidget(m_banner);
@@ -259,9 +285,7 @@ void SettingsBrowserDialog::rebuildTree()
 
     m_storeWritable = s.storeWritable();
     if (m_storeWritable) {
-        m_banner->setText(
-            "Advanced — edits apply immediately and bypass each feature's own "
-            "validation. Prefer the feature's UI when one exists.");
+        m_banner->setText(kAdvancedBannerText);
     } else {
         const QString notice = s.loadNotice();
         m_banner->setText(
@@ -321,10 +345,12 @@ void SettingsBrowserDialog::rebuildTree()
         }
     }
 
-    m_populating = false;
+    // Select while m_populating still holds so currentItemChanged's populate
+    // no-ops — one explicit populate below, not two (PR #4631 review).
     selectScopeItem(remembered.kind == ScopeKind::None
                         ? Scope{ScopeKind::App, {}, {}}
                         : remembered);
+    m_populating = false;
     populateTable();
 }
 
@@ -391,7 +417,12 @@ void SettingsBrowserDialog::populateTable()
                          bool editable) {
         const int row = m_table->rowCount();
         m_table->insertRow(row);
-        const bool secret = SettingsSanitizer::isSecretKey(key);
+        // Masked = the display differs from the stored truth, whether the
+        // whole row is credential-shaped or a JSON value hides a secret
+        // field. Either way editing the displayed text would commit
+        // "[REDACTED]" over the real value, so masked rows are read-only.
+        const bool secret =
+            SettingsSanitizer::isSecretKey(key) || valueHidesSecret(value);
 
         auto* keyItem = new QTableWidgetItem(key);
         keyItem->setFlags(keyItem->flags() & ~Qt::ItemIsEditable);
@@ -448,10 +479,11 @@ void SettingsBrowserDialog::populateTable()
             versionItem->setFlags(versionItem->flags() & ~Qt::ItemIsEditable);
             m_table->setItem(row, 1, versionItem);
 
-            const QJsonDocument doc =
-                QJsonDocument::fromJson(entry.value.toUtf8());
+            // Redacted like every other rendering path — the preview column
+            // is a display of the document, not an exception to the policy
+            // (found while fixing the viewer leak from the #4631 review).
             auto* docItem = new QTableWidgetItem(
-                QString::fromUtf8(doc.toJson(QJsonDocument::Compact)));
+                SettingsSanitizer::redactedValue(entry.feature, entry.value));
             docItem->setFlags(docItem->flags() & ~Qt::ItemIsEditable);
             docItem->setToolTip("Double-click to view the document");
             m_table->setItem(row, 2, docItem);
@@ -520,7 +552,11 @@ void SettingsBrowserDialog::onTableItemChanged(QTableWidgetItem* item)
         setStatus(QStringLiteral("Write to %1 was refused — value reverted")
                       .arg(key),
                   true);
-        populateTable();
+        // Deferred: we are inside this item's own itemChanged emission, and
+        // repopulating clears the table — deleting the emitting item out
+        // from under the model (PR #4631 review).
+        QMetaObject::invokeMethod(
+            this, [this] { populateTable(); }, Qt::QueuedConnection);
     }
 }
 
@@ -542,10 +578,29 @@ void SettingsBrowserDialog::openDocumentViewer(const QString& family,
                                                const QString& radioId,
                                                const QString& feature)
 {
+    // A double-click delivers cellActivated AND cellDoubleClicked on some
+    // platforms — one viewer per gesture (PR #4631 review).
+    if (m_docViewerOpen) {
+        return;
+    }
+    m_docViewerOpen = true;
+
     auto& s = AppSettings::instance();
     int schemaVersion = 0;
     const QJsonObject doc =
         s.radioFeatureExact(family, radioId, feature, &schemaVersion);
+
+    // Same recursive masking as the table and the sanitized dump — the
+    // viewer must not be the one path that renders a credential-shaped
+    // field in cleartext (PR #4631 review, nigelfenton's bench probe).
+    const bool hasSecret = SettingsSanitizer::containsSecretField(doc);
+    QJsonObject displayDoc = doc;
+    if (hasSecret) {
+        const QString redacted = SettingsSanitizer::redactedValue(
+            feature, QString::fromUtf8(
+                         QJsonDocument(doc).toJson(QJsonDocument::Compact)));
+        displayDoc = QJsonDocument::fromJson(redacted.toUtf8()).object();
+    }
 
     QDialog viewer(this);
     viewer.setWindowTitle(QStringLiteral("%1 — %2 / %3").arg(
@@ -555,14 +610,17 @@ void SettingsBrowserDialog::openDocumentViewer(const QString& family,
     auto* layout = new QVBoxLayout(&viewer);
 
     auto* header = new QLabel(
-        QStringLiteral("%1 / %2 / %3 — schema v%4")
+        QStringLiteral("%1 / %2 / %3 — schema v%4%5")
             .arg(family, scopeLabelForRadioId(radioId), feature)
-            .arg(schemaVersion));
+            .arg(schemaVersion)
+            .arg(hasSecret
+                     ? QStringLiteral("  ·  credential fields masked, read-only")
+                     : QString()));
     layout->addWidget(header);
 
     auto* text = new QPlainTextEdit;
     text->setPlainText(QString::fromUtf8(
-        QJsonDocument(doc).toJson(QJsonDocument::Indented)));
+        QJsonDocument(displayDoc).toJson(QJsonDocument::Indented)));
     text->setReadOnly(true);
     text->setAccessibleName(
         QStringLiteral("%1 document contents").arg(feature));
@@ -570,7 +628,18 @@ void SettingsBrowserDialog::openDocumentViewer(const QString& family,
 
     auto* buttons = new QHBoxLayout;
     auto* editBtn = new QPushButton("Edit Raw JSON…");
-    editBtn->setEnabled(m_storeWritable);
+    // Editing a redacted buffer would save "[REDACTED]" over the live
+    // credential — documents holding one are read-only here, matching the
+    // masked flat rows. (Delete stays available: a whole-document delete is
+    // the sanctioned remediation for a legacy store that still carries a
+    // credential-bearing document, and destroys rather than corrupts.)
+    editBtn->setEnabled(m_storeWritable && !hasSecret);
+    if (hasSecret) {
+        editBtn->setToolTip(
+            "This document contains a credential-shaped field — edit it "
+            "through the owning feature's UI, which keeps the secret in the "
+            "OS keychain");
+    }
     auto* saveBtn = new QPushButton("Save");
     saveBtn->setEnabled(false);
     auto* closeBtn = new QPushButton("Close");
@@ -603,6 +672,21 @@ void SettingsBrowserDialog::openDocumentViewer(const QString& family,
                           "Not saved — the document must be a JSON object."));
             return;
         }
+        // The store changes underneath an open viewer (features write
+        // debounced). Saving open-time content over a document that has
+        // since moved — or reasserting the open-time schema version — is a
+        // silent clobber; make the operator re-open against current truth.
+        int nowVersion = 0;
+        AppSettings::instance().radioFeatureExact(family, radioId, feature,
+                                                  &nowVersion);
+        if (nowVersion != schemaVersion) {
+            FramelessMessageBox::warning(
+                &viewer, "Document Changed",
+                "This document was rewritten by its owning feature while the "
+                "viewer was open. Nothing saved — close and re-open to edit "
+                "the current version.");
+            return;
+        }
         if (!AppSettings::instance().setRadioFeature(
                 family, radioId, feature, schemaVersion, parsed.object())) {
             FramelessMessageBox::warning(
@@ -616,6 +700,7 @@ void SettingsBrowserDialog::openDocumentViewer(const QString& family,
     });
 
     viewer.exec();
+    m_docViewerOpen = false;
     populateTable();
 }
 
@@ -681,7 +766,17 @@ void SettingsBrowserDialog::addKey()
         s.setStationValue(key, valueEdit->text());
     }
     s.save();
-    setStatus(QStringLiteral("Added %1").arg(key), false);
+    // Same read-back verification as the inline-edit path — "Added" must
+    // mean the row survived the seam and the store (PR #4631 review).
+    const QString stored = scope.kind == ScopeKind::App
+                               ? s.value(key).toString()
+                               : s.stationValue(key).toString();
+    if (stored == valueEdit->text()) {
+        setStatus(QStringLiteral("Added %1").arg(key), false);
+    } else {
+        setStatus(QStringLiteral("Add of %1 was refused by the store").arg(key),
+                  true);
+    }
     populateTable();
 }
 
@@ -762,8 +857,16 @@ void SettingsBrowserDialog::exportSanitized()
                   true);
         return;
     }
-    file.write(SettingsSanitizer::dump().toUtf8());
+    const QByteArray payload = SettingsSanitizer::dump().toUtf8();
+    const bool wrote = file.write(payload) == payload.size() && file.flush();
     file.close();
+    if (!wrote || file.error() != QFileDevice::NoError) {
+        setStatus(QStringLiteral("Export to %1 failed: %2 — file may be "
+                                 "truncated")
+                      .arg(path, file.errorString()),
+                  true);
+        return;
+    }
     setStatus(QStringLiteral("Exported sanitized dump to %1").arg(path), false);
 }
 

--- a/src/gui/SettingsBrowserDialog.cpp
+++ b/src/gui/SettingsBrowserDialog.cpp
@@ -227,11 +227,12 @@ SettingsBrowserDialog::SettingsBrowserDialog(QWidget* parent)
     // Keyboard open is bound explicitly below instead (PR #4631 review, NF0T).
     connect(m_table, &QTableWidget::cellDoubleClicked, this,
             [this](int row, int) { onTableActivated(row); });
-    auto* openDocShortcut =
-        new QShortcut(QKeySequence(Qt::Key_Return), m_table);
-    openDocShortcut->setContext(Qt::WidgetShortcut);
-    connect(openDocShortcut, &QShortcut::activated, this,
-            [this] { onTableActivated(m_table->currentRow()); });
+    for (const int key : {Qt::Key_Return, Qt::Key_Enter}) {   // Enter = numpad
+        auto* openDocShortcut = new QShortcut(QKeySequence(key), m_table);
+        openDocShortcut->setContext(Qt::WidgetShortcut);
+        connect(openDocShortcut, &QShortcut::activated, this,
+                [this] { onTableActivated(m_table->currentRow()); });
+    }
     connect(m_table, &QTableWidget::itemSelectionChanged, this,
             [this] { updateButtonState(); });
     right->addWidget(m_table, 1);
@@ -443,8 +444,15 @@ void SettingsBrowserDialog::populateTable()
         keyItem->setData(kRoleKey, key);
         m_table->setItem(row, 0, keyItem);
 
+        // Only masked rows go through the sanitizer. redactedValue() also
+        // re-serialises clean JSON (QJsonObject sorts keys, numbers
+        // normalise), so routing every row through it would leave an
+        // EDITABLE row displaying something other than the stored bytes,
+        // and committing would persist the re-serialisation. Masked rows
+        // are read-only, so there the divergence is the point; everywhere
+        // else display now equals stored truth (PR #4631, NF0T).
         auto* valueItem = new QTableWidgetItem(
-            SettingsSanitizer::redactedValue(key, value));
+            secret ? SettingsSanitizer::redactedValue(key, value) : value);
         valueItem->setData(kRoleSecret, secret);
         if (secret || !editable || !m_storeWritable) {
             valueItem->setFlags(valueItem->flags() & ~Qt::ItemIsEditable);
@@ -582,7 +590,11 @@ void SettingsBrowserDialog::onTableItemChanged(QTableWidgetItem* item)
                                   : s.stationValue(key).toString();
         const bool wasPopulating = m_populating;
         m_populating = true;   // the revert must not re-enter this handler
-        item->setText(SettingsSanitizer::redactedValue(key, truth));
+        // Same display rule as addRow(): stored bytes verbatim unless the
+        // row is masked (an editable row's text must equal stored truth).
+        item->setText(item->data(kRoleSecret).toBool()
+                          ? SettingsSanitizer::redactedValue(key, truth)
+                          : truth);
         m_populating = wasPopulating;
     }
 }
@@ -625,10 +637,19 @@ void SettingsBrowserDialog::openDocumentViewer(const QString& family,
     // recoverable document. Detect it from the stored bytes and refuse to
     // edit (PR #4631 review, NF0T).
     QJsonParseError storedError{};
-    const bool corrupt =
-        !rawValue.trimmed().isEmpty()
-        && (QJsonDocument::fromJson(rawValue.toUtf8(), &storedError).isNull()
-            || storedError.error != QJsonParseError::NoError);
+    const QJsonDocument storedDoc =
+        QJsonDocument::fromJson(rawValue.toUtf8(), &storedError);
+    // Mirror radioFeatureExact()'s OWN condition, including !isObject(): a
+    // stored JSON *array* parses cleanly, so a parse-only check calls it
+    // healthy while the API returns {} at version 0 — Edit enabled, Save
+    // writing {} and downgrading the row's schema_version to 0, with no
+    // guard downstream (setRadioFeature has no version check; the upsert
+    // takes excluded.schema_version). Same threat model as the redaction
+    // work: foreign, hand-edited, or older-build stores (PR #4631, NF0T).
+    const bool corrupt = !rawValue.trimmed().isEmpty()
+                         && (storedDoc.isNull()
+                             || storedError.error != QJsonParseError::NoError
+                             || !storedDoc.isObject());
 
     // Same recursive masking as the table and the sanitized dump — the
     // viewer must not be the one path that renders a credential-shaped
@@ -713,7 +734,8 @@ void SettingsBrowserDialog::openDocumentViewer(const QString& family,
     });
     connect(closeBtn, &QPushButton::clicked, &viewer, &QDialog::reject);
     connect(saveBtn, &QPushButton::clicked, &viewer,
-            [this, &viewer, text, family, radioId, feature, schemaVersion] {
+            [this, &viewer, text, family, radioId, feature, schemaVersion,
+             openTimeDoc = doc] {
         QJsonParseError parseError{};
         const QJsonDocument parsed = QJsonDocument::fromJson(
             text->toPlainText().toUtf8(), &parseError);
@@ -729,13 +751,16 @@ void SettingsBrowserDialog::openDocumentViewer(const QString& family,
             return;
         }
         // The store changes underneath an open viewer (features write
-        // debounced). Saving open-time content over a document that has
-        // since moved — or reasserting the open-time schema version — is a
-        // silent clobber; make the operator re-open against current truth.
+        // debounced). Compare CONTENT, not just the schema version: a
+        // feature rewriting its document at the same version is the common
+        // case by a wide margin, and a version-only check would pass it
+        // through and commit the open-time buffer over the newer content —
+        // a guard that reads right and checks the wrong quantity (PR #4631,
+        // NF0T, same class as the cache-vs-disk finding).
         int nowVersion = 0;
-        AppSettings::instance().radioFeatureExact(family, radioId, feature,
-                                                  &nowVersion);
-        if (nowVersion != schemaVersion) {
+        const QJsonObject nowDoc = AppSettings::instance().radioFeatureExact(
+            family, radioId, feature, &nowVersion);
+        if (nowVersion != schemaVersion || nowDoc != openTimeDoc) {
             FramelessMessageBox::warning(
                 &viewer, "Document Changed",
                 "This document was rewritten by its owning feature while the "

--- a/src/gui/SettingsBrowserDialog.h
+++ b/src/gui/SettingsBrowserDialog.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "PersistentDialog.h"
+
+#include <QString>
+
+class QLabel;
+class QLineEdit;
+class QPushButton;
+class QShowEvent;
+class QTableWidget;
+class QTableWidgetItem;
+class QTreeWidget;
+class QTreeWidgetItem;
+
+namespace AetherSDR {
+
+// Settings Browser (RFC #4603 proposal D, PR 5) — a scope-grouped view over
+// the whole settings store: app keys, the station section, and every
+// radio-scoped feature document, mirrored as a tree of the scopes the store
+// actually contains. All edits go through the AppSettings API — never raw
+// SQL — so the running app's cache and the database stay coherent, and the
+// credential seam / newer-schema refusals apply to browser edits exactly as
+// they do to feature code.
+//
+// Guardrails (RFC-ratified):
+//   * meta is not shown (AppSettings does not expose it).
+//   * Credential-shaped rows render redacted and are read-only here.
+//   * Feature documents open pretty-printed read-only; editing raw JSON is
+//     an explicit second step and the document must parse as a JSON object.
+//   * A newer-schema (read-only) store disables every edit affordance.
+//   * Export reuses the sanitizer dump — diagnostic text, not a backup.
+class SettingsBrowserDialog : public PersistentDialog {
+    Q_OBJECT
+
+public:
+    explicit SettingsBrowserDialog(QWidget* parent = nullptr);
+
+protected:
+    void showEvent(QShowEvent* event) override;
+
+private:
+    // What a tree row addresses. App/Station are single scopes; RadioScope
+    // carries (family, radioId) with radioId "" = the family-wide default row.
+    enum class ScopeKind { None, App, Station, RadioScope };
+
+    struct Scope {
+        ScopeKind kind{ScopeKind::None};
+        QString family;
+        QString radioId;
+    };
+
+    void rebuildTree();
+    void populateTable();
+    void applyFilter();
+    Scope currentScope() const;
+    void selectScopeItem(const Scope& scope);
+
+    void onTableItemChanged(QTableWidgetItem* item);
+    void onTableActivated(int row);
+    void addKey();
+    void deleteSelected();
+    void exportSanitized();
+    void openDocumentViewer(const QString& family, const QString& radioId,
+                            const QString& feature);
+
+    void setStatus(const QString& text, bool error);
+    void updateButtonState();
+
+    QTreeWidget*  m_tree{nullptr};
+    QTableWidget* m_table{nullptr};
+    QLineEdit*    m_search{nullptr};
+    QLabel*       m_banner{nullptr};
+    QLabel*       m_status{nullptr};
+    QPushButton*  m_addBtn{nullptr};
+    QPushButton*  m_deleteBtn{nullptr};
+    QPushButton*  m_refreshBtn{nullptr};
+    QPushButton*  m_exportBtn{nullptr};
+
+    bool m_populating{false};
+    bool m_storeWritable{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/SettingsBrowserDialog.h
+++ b/src/gui/SettingsBrowserDialog.h
@@ -62,7 +62,7 @@ private:
     void deleteSelected();
     void exportSanitized();
     void openDocumentViewer(const QString& family, const QString& radioId,
-                            const QString& feature);
+                            const QString& feature, const QString& rawValue);
 
     void setStatus(const QString& text, bool error);
     void updateButtonState();

--- a/src/gui/SettingsBrowserDialog.h
+++ b/src/gui/SettingsBrowserDialog.h
@@ -79,6 +79,8 @@ private:
 
     bool m_populating{false};
     bool m_storeWritable{false};
+    bool m_docViewerOpen{false};   // double-click emits activated too — one
+                                   // viewer per gesture, not two
 };
 
 } // namespace AetherSDR

--- a/tests/app_settings_safety_test.cpp
+++ b/tests/app_settings_safety_test.cpp
@@ -733,6 +733,40 @@ void testBrowserApi()
     expect(redacted.contains(QStringLiteral("[REDACTED]"))
                && !redacted.contains(QStringLiteral("SUPERSECRET")),
            "display redaction masks the nested field the predicate flagged");
+
+    // Cache-vs-disk verification (PR #4631 review, NF0T): a failed save()
+    // deliberately KEEPS the change in memory for retry, so a cache re-read
+    // is not evidence of persistence. The browser's verification therefore
+    // reads the database file. Falsifiable by construction — the control
+    // below proves the cache would have lied.
+    settings.setValue(QStringLiteral("DiskProbe"), QStringLiteral("committed"));
+    settings.save();
+    QString disk;
+    expect(settings.readAppRowFromDisk(QStringLiteral("DiskProbe"), disk)
+               && disk == QStringLiteral("committed"),
+           "a committed app row reads back from the database file");
+    expect(!settings.readAppRowFromDisk(QStringLiteral("NeverWritten"), disk),
+           "a key that was never written is absent from the file");
+
+    // The control: mutate the cache WITHOUT saving. The cache now reports
+    // the new value (what the old verification read) while the file still
+    // holds the old one (what the browser now reads).
+    settings.setValue(QStringLiteral("DiskProbe"), QStringLiteral("uncommitted"));
+    expect(settings.value(QStringLiteral("DiskProbe")).toString()
+               == QStringLiteral("uncommitted"),
+           "control: the cache reports an unsaved change as current");
+    expect(settings.readAppRowFromDisk(QStringLiteral("DiskProbe"), disk)
+               && disk == QStringLiteral("committed"),
+           "the file still holds the last COMMITTED value — a cache read "
+           "would have reported an unwritten change as saved");
+
+    settings.setStationValue(QStringLiteral("DiskProbeStation"),
+                             QStringLiteral("s1"));
+    settings.save();
+    expect(settings.readStationRowFromDisk(QStringLiteral("DiskProbeStation"),
+                                           disk)
+               && disk == QStringLiteral("s1"),
+           "a committed station row reads back from the database file");
 }
 
 } // namespace

--- a/tests/app_settings_safety_test.cpp
+++ b/tests/app_settings_safety_test.cpp
@@ -22,6 +22,7 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QJsonDocument>
 #include <QJsonObject>
 #include <QMap>
 #include <QStandardPaths>
@@ -705,6 +706,33 @@ void testBrowserApi()
     expect(formattedSeen,
            "the display-string diagnostics stay in lockstep with the "
            "structured enumeration");
+
+    // The Settings Browser's masking parity (PR #4631 review): the SAME
+    // predicate that drives recursive display redaction must drive
+    // editability, or an operator edits a "[REDACTED]" buffer and saves it
+    // over the live secret. Pin the predicate on nigelfenton's bench probe
+    // shape — a credential field nested inside an innocuously-named doc.
+    const QJsonObject probeDoc{
+        {QStringLiteral("enabled"), true},
+        {QStringLiteral("nested"),
+         QJsonObject{{QStringLiteral("AsrRemoteApiKey"),
+                      QStringLiteral("sk-live-SUPERSECRET")}}}};
+    expect(SettingsSanitizer::containsSecretField(probeDoc),
+           "containsSecretField finds a credential field at depth");
+    expect(!SettingsSanitizer::containsSecretField(
+               QJsonObject{{QStringLiteral("frequencyHz"), 7100000},
+                           {QStringLiteral("mode"), QStringLiteral("CW")}}),
+           "containsSecretField stays quiet on a clean operating-state doc");
+    // And the two stay in agreement: whatever the display path would mask,
+    // the editability predicate must flag (break one on purpose and this
+    // pair diverges).
+    const QString probeJson = QString::fromUtf8(
+        QJsonDocument(probeDoc).toJson(QJsonDocument::Compact));
+    const QString redacted =
+        SettingsSanitizer::redactedValue(QStringLiteral("CopyAssist"), probeJson);
+    expect(redacted.contains(QStringLiteral("[REDACTED]"))
+               && !redacted.contains(QStringLiteral("SUPERSECRET")),
+           "display redaction masks the nested field the predicate flagged");
 }
 
 } // namespace

--- a/tests/app_settings_safety_test.cpp
+++ b/tests/app_settings_safety_test.cpp
@@ -22,6 +22,7 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QJsonObject>
 #include <QMap>
 #include <QStandardPaths>
 #include <QXmlStreamWriter>
@@ -521,6 +522,9 @@ void testNewerSchemaOpensReadOnly()
     expect(dbRow(QStringLiteral("FromTheFuture"), value)
                && value == QStringLiteral("yes"),
            "a newer-schema database is never written by an older binary");
+    expect(!settings.storeWritable(),
+           "storeWritable() reports the read-only session, so the Settings "
+           "Browser disables its edit affordances");
 }
 
 void testDirtyRowSaves()
@@ -631,6 +635,78 @@ void testNicknameKeySurvivesDisk()
            "a cleared nickname stays cleared");
 }
 
+// The AppSettings surface the Settings Browser rides on (RFC #4603 PR 5):
+// station-row deletion, the structured radio_settings enumeration, and the
+// writability probe. Exercised through reset()+load() round-trips so every
+// claim is about the persisted file, not the in-memory cache.
+void testBrowserApi()
+{
+    AppSettings& settings = AppSettings::instance();
+    settings.load();
+    expect(settings.storeWritable(),
+           "a freshly loaded healthy store reports writable");
+
+    // removeStationValue: the deletion must reach the station_settings rows.
+    settings.setStationValue(QStringLiteral("BrowserKeep"), QStringLiteral("k"));
+    settings.setStationValue(QStringLiteral("BrowserDrop"), QStringLiteral("d"));
+    settings.save();
+    settings.removeStationValue(QStringLiteral("BrowserDrop"));
+    settings.save();
+    settings.reset();
+    settings.load();
+    expect(settings.stationValue(QStringLiteral("BrowserKeep")).toString()
+               == QStringLiteral("k"),
+           "an untouched station sibling survives the removal save");
+    expect(settings.stationValue(QStringLiteral("BrowserDrop"),
+                                 QStringLiteral("<absent>"))
+                   .toString()
+               == QStringLiteral("<absent>"),
+           "a removed station key is deleted from the persisted rows");
+
+    // Structured enumeration: coordinates come back as data, and the
+    // family-wide row keeps its "" radioId (the display layer, not the API,
+    // owns the "(family-wide)" label).
+    settings.setRadioFeature(QStringLiteral("hl2"),
+                             QStringLiteral("AA:BB:CC:DD:EE:22"),
+                             QStringLiteral("BrowserProbe"), 3,
+                             QJsonObject{{QStringLiteral("x"), 1}});
+    settings.setRadioFeature(QStringLiteral("hl2"), QString(),
+                             QStringLiteral("BrowserProbe"), 3,
+                             QJsonObject{{QStringLiteral("x"), 2}});
+    bool exactSeen = false;
+    bool familySeen = false;
+    const auto entries = settings.radioFeatureEntriesForDiagnostics();
+    for (const auto& entry : entries) {
+        if (entry.family != QStringLiteral("hl2")
+            || entry.feature != QStringLiteral("BrowserProbe")) {
+            continue;
+        }
+        if (entry.radioId == QStringLiteral("AA:BB:CC:DD:EE:22")) {
+            exactSeen = entry.schemaVersion == 3
+                        && entry.value.contains(QStringLiteral("\"x\""));
+        } else if (entry.radioId.isEmpty()) {
+            familySeen = true;
+        }
+    }
+    expect(exactSeen,
+           "the structured enumeration returns the per-radio row with its "
+           "schema version and document");
+    expect(familySeen,
+           "the family-wide default row enumerates with an empty radioId");
+
+    // The formatted diagnostics view is derived from the same enumeration.
+    bool formattedSeen = false;
+    const auto formatted = settings.radioFeaturesForDiagnostics();
+    for (const auto& pair : formatted) {
+        if (pair.first == QStringLiteral("hl2/AA:BB:CC:DD:EE:22/BrowserProbe@v3")) {
+            formattedSeen = true;
+        }
+    }
+    expect(formattedSeen,
+           "the display-string diagnostics stay in lockstep with the "
+           "structured enumeration");
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -680,6 +756,8 @@ int main(int argc, char** argv)
         testThreeDSliceDepthDefaultAndOptIn();
     } else if (scenario == QStringLiteral("nickname-key-roundtrip")) {
         testNicknameKeySurvivesDisk();
+    } else if (scenario == QStringLiteral("browser-api")) {
+        testBrowserApi();
     } else {
         std::fprintf(stderr, "unknown scenario: %s\n", argv[1]);
         return 2;

--- a/tests/settings_browser_dialog_test.cpp
+++ b/tests/settings_browser_dialog_test.cpp
@@ -1,0 +1,357 @@
+// Settings Browser guardrail tests (RFC #4603 PR 5, review round #4631).
+//
+// These pin the two claims the automation bridge cannot drive — it has no
+// double-click and no key-injection verb — so they were argued rather than
+// demonstrated in review. Both reviewers built standalone harnesses that
+// REPRODUCED the wiring; this drives the real dialog instead, so the test
+// stays true when the wiring changes.
+//
+// Each case is falsifiable by construction: break the guard on purpose and
+// the paired control assertion diverges.
+#include "TestSettingsProfile.h"
+#include "core/AppSettings.h"
+#include "core/SettingsDatabase.h"
+#include "core/SettingsPaths.h"
+#include "gui/SettingsBrowserDialog.h"
+
+#include <QApplication>
+#include <QHeaderView>
+#include <QJsonObject>
+#include <QLabel>
+#include <QMouseEvent>
+#include <QStyle>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QTableWidget>
+#include <QTest>
+#include <QTimer>
+#include <QTreeWidget>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failures = 0;
+
+void expect(bool condition, const char* description)
+{
+    std::printf("%s %s\n", condition ? "[ OK ]" : "[FAIL]", description);
+    if (!condition) {
+        ++g_failures;
+    }
+}
+
+QTableWidget* tableOf(SettingsBrowserDialog& dlg)
+{
+    return dlg.findChild<QTableWidget*>();
+}
+
+QTreeWidget* treeOf(SettingsBrowserDialog& dlg)
+{
+    return dlg.findChild<QTreeWidget*>();
+}
+
+int rowForKey(QTableWidget* table, const QString& key)
+{
+    for (int row = 0; row < table->rowCount(); ++row) {
+        if (table->item(row, 0) != nullptr
+            && table->item(row, 0)->text() == key) {
+            return row;
+        }
+    }
+    return -1;
+}
+
+// Select the tree item whose label contains `needle` (walks the whole tree).
+bool selectScope(QTreeWidget* tree, const QString& needle)
+{
+    QTreeWidgetItemIterator it(tree);
+    while (*it != nullptr) {
+        if ((*it)->text(0).contains(needle)
+            && ((*it)->flags() & Qt::ItemIsSelectable)) {
+            tree->setCurrentItem(*it);
+            return true;
+        }
+        ++it;
+    }
+    return false;
+}
+
+// Deliver a double-click as real events. Under the offscreen platform the
+// window is never "active", so QTest::mouseDClick's synthetic clicks are
+// dropped before reaching the viewport; press + DblClick is what
+// QAbstractItemView actually consumes, and mouseDoubleClickEvent() is the
+// emitter of BOTH cellDoubleClicked and cellActivated.
+void sendDoubleClick(QTableWidget* table, int row, int column)
+{
+    const QRect cell = table->visualRect(table->model()->index(row, column));
+    const QPointF pos = cell.center();
+    const QPointF global = table->viewport()->mapToGlobal(cell.center());
+    QMouseEvent press(QEvent::MouseButtonPress, pos, global, Qt::LeftButton,
+                      Qt::LeftButton, Qt::NoModifier);
+    QApplication::sendEvent(table->viewport(), &press);
+    QMouseEvent dbl(QEvent::MouseButtonDblClick, pos, global, Qt::LeftButton,
+                    Qt::LeftButton, Qt::NoModifier);
+    QApplication::sendEvent(table->viewport(), &dbl);
+}
+
+void settle()
+{
+    for (int i = 0; i < 20; ++i) {
+        QApplication::processEvents();
+        QTest::qWait(10);
+    }
+}
+
+// QObject::receivers() is protected, so borrow it the sanctioned way: a
+// throwaway subclass exposing the count for the signal we care about.
+bool cellActivatedIsUnconnected(QTableWidget* table)
+{
+    struct Probe : QTableWidget {
+        using QTableWidget::receivers;
+    };
+    return static_cast<Probe*>(table)->receivers(
+               SIGNAL(cellActivated(int, int)))
+           == 0;
+}
+
+// Double-click the centre of a cell and count how many modal viewers the
+// gesture opened. The viewer runs a nested exec(), so the counting timer
+// fires INSIDE that loop: it closes whatever modal is up and tallies it,
+// which is what makes a second viewer observable rather than invisible.
+int viewersOpenedByDoubleClick(QTableWidget* table, int row, int column)
+{
+    int opened = 0;
+    int dblSignals = 0;
+    QObject::connect(table, &QTableWidget::cellDoubleClicked, table,
+                     [&dblSignals](int, int) { ++dblSignals; });
+    int activatedSignals = 0;
+    QObject::connect(table, &QTableWidget::cellActivated, table,
+                     [&activatedSignals](int, int) { ++activatedSignals; });
+    auto* closer = new QTimer(table);
+    closer->setInterval(10);
+    QObject::connect(closer, &QTimer::timeout, table, [&opened] {
+        if (QWidget* modal = QApplication::activeModalWidget()) {
+            ++opened;
+            modal->close();
+        }
+    });
+    closer->start();
+
+    sendDoubleClick(table, row, column);
+    settle();
+    closer->stop();
+    closer->deleteLater();
+    std::printf("       (cellDoubleClicked: %d  cellActivated: %d  "
+                "ActivateItemOnSingleClick: %d  itemAt non-null: %d)\n",
+                dblSignals, activatedSignals,
+                table->style()->styleHint(
+                    QStyle::SH_ItemView_ActivateItemOnSingleClick, nullptr,
+                    table),
+                table->itemAt(table->visualRect(table->model()->index(row, column))
+                                  .center()) != nullptr);
+    return opened;
+}
+
+void seedStore()
+{
+    AppSettings& s = AppSettings::instance();
+    s.load();
+
+    // A flat row whose KEY is innocuous but whose VALUE hides a credential
+    // field — the bot's data-loss finding. Display masks it; editability
+    // must follow, or committing writes "[REDACTED]" over the real value.
+    s.setValue(QStringLiteral("VoiceChainCfg"),
+               QStringLiteral("{\"enabled\":true,"
+                              "\"asr_remote_api_key\":\"sk-live-PROBE\"}"));
+    // The control: same shape, no credential-shaped field anywhere.
+    s.setValue(QStringLiteral("PlainCfg"),
+               QStringLiteral("{\"enabled\":true,\"gainDb\":12}"));
+    s.save();
+
+    // Radio-scope documents: clean, and present-but-unparseable.
+    s.setRadioFeature(QStringLiteral("hl2"), QStringLiteral("AA:BB:CC:DD:EE:01"),
+                      QStringLiteral("CleanDoc"), 1,
+                      QJsonObject{{QStringLiteral("mode"), QStringLiteral("CW")}});
+}
+
+void testMaskedRowsAreReadOnly()
+{
+    SettingsBrowserDialog dlg;
+    QTableWidget* table = tableOf(dlg);
+    expect(table != nullptr, "the browser builds its table");
+    if (table == nullptr) {
+        return;
+    }
+
+    const int secretRow = rowForKey(table, QStringLiteral("VoiceChainCfg"));
+    const int plainRow = rowForKey(table, QStringLiteral("PlainCfg"));
+    expect(secretRow >= 0 && plainRow >= 0,
+           "both probe rows are present in the App scope");
+    if (secretRow < 0 || plainRow < 0) {
+        return;
+    }
+
+    const QTableWidgetItem* secretItem = table->item(secretRow, 1);
+    const QTableWidgetItem* plainItem = table->item(plainRow, 1);
+
+    expect(secretItem->text().contains(QStringLiteral("[REDACTED]"))
+               && !secretItem->text().contains(QStringLiteral("sk-live-PROBE")),
+           "a nested credential field renders redacted in the value cell");
+    expect(!(secretItem->flags() & Qt::ItemIsEditable),
+           "a row whose DISPLAY is masked is read-only — editing it would "
+           "commit the mask over the real value");
+
+    // The control proves the guard is doing work rather than the whole
+    // table being read-only: an identically-shaped clean row IS editable.
+    expect(plainItem->text().contains(QStringLiteral("gainDb")),
+           "control: the clean JSON row renders verbatim");
+    expect(plainItem->flags() & Qt::ItemIsEditable,
+           "control: a clean JSON row stays editable");
+}
+
+void testDoubleClickOpensOneViewer()
+{
+    SettingsBrowserDialog dlg;
+    dlg.resize(900, 600);
+    dlg.show();
+    QTest::qWaitForWindowExposed(&dlg);
+
+    QTreeWidget* tree = treeOf(dlg);
+    QTableWidget* table = tableOf(dlg);
+    expect(tree != nullptr && table != nullptr, "tree and table exist");
+    if (tree == nullptr || table == nullptr) {
+        return;
+    }
+    expect(selectScope(tree, QStringLiteral("AA:BB:CC:DD:EE:01")),
+           "the seeded radio scope is selectable in the tree");
+    QApplication::processEvents();
+
+    const int docRow = rowForKey(table, QStringLiteral("CleanDoc"));
+    expect(docRow >= 0, "the seeded document is listed in the radio scope");
+    if (docRow < 0) {
+        return;
+    }
+
+    // Structural assertion FIRST, before this test attaches its own probes:
+    // the dialog must not listen to cellActivated at all. Both signals fire
+    // from mouseDoubleClickEvent (measured below), and `activated` ALSO
+    // fires on a single click under styles where ActivateItemOnSingleClick
+    // is true — a modal on a stray click. Asserting the connection's absence
+    // is falsifiable in a way that counting viewers is not: re-adding the
+    // connection is masked at runtime by the post-exec repopulate
+    // invalidating the held index (NF0T's finding — load-bearing by
+    // accident), so only the wiring itself is a reliable guard.
+    expect(cellActivatedIsUnconnected(table),
+           "the table's cellActivated is NOT connected — double-click opens "
+           "via cellDoubleClicked alone, and a single click never can");
+
+    const int opened = viewersOpenedByDoubleClick(table, docRow, 2);
+    std::printf("       (viewers opened by one double-click: %d)\n", opened);
+    expect(opened == 1,
+           "a double-click opens exactly one document viewer");
+}
+
+void testCorruptDocumentIsNotEditable()
+{
+    // The unparseable document (planted in main()) reads back through the
+    // typed API as an empty object — indistinguishable from an absent row —
+    // so the viewer must judge the stored BYTES.
+    SettingsBrowserDialog dlg;
+    dlg.resize(900, 600);
+    dlg.show();
+    QTest::qWaitForWindowExposed(&dlg);
+    QTreeWidget* tree = treeOf(dlg);
+    QTableWidget* table = tableOf(dlg);
+    if (tree == nullptr || table == nullptr
+        || !selectScope(tree, QStringLiteral("AA:BB:CC:DD:EE:01"))) {
+        expect(false, "radio scope reachable for the corrupt-document case");
+        return;
+    }
+    QApplication::processEvents();
+
+    const int docRow = rowForKey(table, QStringLiteral("CorruptDoc"));
+    expect(docRow >= 0, "the unparseable document still LISTS (it exists)");
+    if (docRow < 0) {
+        return;
+    }
+
+    // Open the viewer and inspect it from inside its own nested loop.
+    bool sawNotParse = false;
+    bool editDisabled = false;
+    auto* probe = new QTimer(table);
+    probe->setInterval(10);
+    QObject::connect(probe, &QTimer::timeout, table,
+                     [&sawNotParse, &editDisabled] {
+        QWidget* modal = QApplication::activeModalWidget();
+        if (modal == nullptr) {
+            return;
+        }
+        const auto labels = modal->findChildren<QLabel*>();
+        for (const QLabel* label : labels) {
+            if (label->text().contains(QStringLiteral("DOES NOT PARSE"))) {
+                sawNotParse = true;
+            }
+        }
+        const auto buttons = modal->findChildren<QPushButton*>();
+        for (const QPushButton* button : buttons) {
+            if (button->text().startsWith(QStringLiteral("Edit Raw JSON"))) {
+                editDisabled = !button->isEnabled();
+            }
+        }
+        modal->close();
+    });
+    probe->start();
+
+    sendDoubleClick(table, docRow, 2);
+    settle();
+    probe->stop();
+
+    expect(sawNotParse,
+           "an unparseable document is labelled as such, not shown as empty");
+    expect(editDisabled,
+           "Edit Raw JSON is disabled on an unparseable document — saving "
+           "would overwrite recoverable bytes");
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile profile(QStringLiteral("aether-settings-browser-test"));
+    if (!profile.isValid()) {
+        std::fprintf(stderr, "[FAIL] could not create settings profile\n");
+        return 1;
+    }
+    if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM")) {
+        qputenv("QT_QPA_PLATFORM", "offscreen");
+    }
+    QApplication app(argc, argv);
+
+    seedStore();
+
+    // The unparseable row cannot go in through the typed API (it only
+    // accepts a QJsonObject), which is exactly why the viewer has to judge
+    // the stored bytes: such a row can only ARRIVE from a damaged store, a
+    // partial write, or another build. Plant it the same way — straight
+    // into the file on a second connection (WAL allows it).
+    {
+        SettingsDatabase raw;
+        if (raw.open(SettingsPaths::databasePath())) {
+            raw.upsertRadioFeature(QStringLiteral("hl2"),
+                                   QStringLiteral("AA:BB:CC:DD:EE:01"),
+                                   QStringLiteral("CorruptDoc"), 1,
+                                   QStringLiteral("{\"frequencyHz\":710000"));
+            raw.close();
+        }
+    }
+
+    testMaskedRowsAreReadOnly();
+    testDoubleClickOpensOneViewer();
+    testCorruptDocumentIsNotEditable();
+
+    std::printf("\n%s\n", g_failures == 0 ? "PASS" : "FAIL");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/settings_browser_dialog_test.cpp
+++ b/tests/settings_browser_dialog_test.cpp
@@ -166,9 +166,14 @@ void seedStore()
     s.setValue(QStringLiteral("VoiceChainCfg"),
                QStringLiteral("{\"enabled\":true,"
                               "\"asr_remote_api_key\":\"sk-live-PROBE\"}"));
-    // The control: same shape, no credential-shaped field anywhere.
+    // The control: same shape, no credential-shaped field anywhere. The
+    // key ORDER and number format are deliberately not canonical — a
+    // re-serialising display path would reorder to {"alpha":2.5,...} and
+    // the divergence would be visible, which is what makes the
+    // display-equals-stored-bytes assertion discriminating rather than
+    // accidentally true.
     s.setValue(QStringLiteral("PlainCfg"),
-               QStringLiteral("{\"enabled\":true,\"gainDb\":12}"));
+               QStringLiteral("{\"zulu\":1, \"alpha\":2.50}"));
     s.save();
 
     // Radio-scope documents: clean, and present-but-unparseable.
@@ -206,7 +211,7 @@ void testMaskedRowsAreReadOnly()
 
     // The control proves the guard is doing work rather than the whole
     // table being read-only: an identically-shaped clean row IS editable.
-    expect(plainItem->text().contains(QStringLiteral("gainDb")),
+    expect(plainItem->text().contains(QStringLiteral("zulu")),
            "control: the clean JSON row renders verbatim");
     expect(plainItem->flags() & Qt::ItemIsEditable,
            "control: a clean JSON row stays editable");
@@ -316,6 +321,105 @@ void testCorruptDocumentIsNotEditable()
            "would overwrite recoverable bytes");
 }
 
+// A stored JSON ARRAY parses cleanly but is not an object, so
+// radioFeatureExact() rejects it and returns {} at version 0 — a
+// parse-only check would call the row healthy, enable Edit, and let Save
+// write {} while DOWNGRADING schema_version to 0 (setRadioFeature has no
+// version guard; the upsert takes excluded.schema_version). The viewer
+// must mirror the API's own condition (PR #4631 review, NF0T).
+void testArrayDocumentIsTreatedAsCorrupt()
+{
+    SettingsBrowserDialog dlg;
+    dlg.resize(900, 600);
+    dlg.show();
+    QTest::qWaitForWindowExposed(&dlg);
+    QTreeWidget* tree = treeOf(dlg);
+    QTableWidget* table = tableOf(dlg);
+    if (tree == nullptr || table == nullptr
+        || !selectScope(tree, QStringLiteral("AA:BB:CC:DD:EE:01"))) {
+        expect(false, "radio scope reachable for the array-document case");
+        return;
+    }
+    QApplication::processEvents();
+
+    const int docRow = rowForKey(table, QStringLiteral("ArrayDoc"));
+    expect(docRow >= 0, "the array document lists in the radio scope");
+    if (docRow < 0) {
+        return;
+    }
+
+    bool editDisabled = false;
+    bool sawNotParse = false;
+    auto* probe = new QTimer(table);
+    probe->setInterval(10);
+    QObject::connect(probe, &QTimer::timeout, table,
+                     [&editDisabled, &sawNotParse] {
+        QWidget* modal = QApplication::activeModalWidget();
+        if (modal == nullptr) {
+            return;
+        }
+        for (const QLabel* label : modal->findChildren<QLabel*>()) {
+            if (label->text().contains(QStringLiteral("DOES NOT PARSE"))) {
+                sawNotParse = true;
+            }
+        }
+        for (const QPushButton* button : modal->findChildren<QPushButton*>()) {
+            if (button->text().startsWith(QStringLiteral("Edit Raw JSON"))) {
+                editDisabled = !button->isEnabled();
+            }
+        }
+        modal->close();
+    });
+    probe->start();
+    sendDoubleClick(table, docRow, 2);
+    settle();
+    probe->stop();
+
+    expect(sawNotParse && editDisabled,
+           "a stored JSON ARRAY is treated as unreadable, not as an empty "
+           "document at v0 — Edit stays disabled");
+
+    // The row must still be intact afterwards: nothing wrote {} over it.
+    QString stillThere;
+    SettingsDatabase check;
+    bool intact = false;
+    if (check.open(SettingsPaths::databasePath())) {
+        int version = 0;
+        intact = check.readRadioFeature(QStringLiteral("hl2"),
+                                        QStringLiteral("AA:BB:CC:DD:EE:01"),
+                                        QStringLiteral("ArrayDoc"), version,
+                                        stillThere)
+                 && stillThere.startsWith(QLatin1Char('['))
+                 && version == 4;
+        check.close();
+    }
+    expect(intact,
+           "the array document survives the visit with its bytes and schema "
+           "version 4 intact");
+}
+
+// Editable rows must display exactly what is stored: redactedValue()
+// re-serialises JSON (keys sort, numbers normalise), so routing a CLEAN
+// row through it would leave the cell showing something the store does
+// not contain — and committing would persist that (PR #4631, NF0T).
+void testEditableRowShowsStoredBytes()
+{
+    const QString stored =
+        AppSettings::instance().value(QStringLiteral("PlainCfg")).toString();
+    SettingsBrowserDialog dlg;
+    QTableWidget* table = tableOf(dlg);
+    const int row = rowForKey(table, QStringLiteral("PlainCfg"));
+    if (row < 0) {
+        expect(false, "the clean JSON row is present");
+        return;
+    }
+    const QTableWidgetItem* item = table->item(row, 1);
+    expect(item->text() == stored,
+           "an editable JSON row displays the stored bytes verbatim");
+    expect(item->flags() & Qt::ItemIsEditable,
+           "control: that row is the editable one (masked rows may diverge)");
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -344,13 +448,20 @@ int main(int argc, char** argv)
                                    QStringLiteral("AA:BB:CC:DD:EE:01"),
                                    QStringLiteral("CorruptDoc"), 1,
                                    QStringLiteral("{\"frequencyHz\":710000"));
+            // Valid JSON, wrong shape: parses, but is not an object.
+            raw.upsertRadioFeature(QStringLiteral("hl2"),
+                                   QStringLiteral("AA:BB:CC:DD:EE:01"),
+                                   QStringLiteral("ArrayDoc"), 4,
+                                   QStringLiteral("[{\"slot\":1}]"));
             raw.close();
         }
     }
 
     testMaskedRowsAreReadOnly();
+    testEditableRowShowsStoredBytes();
     testDoubleClickOpensOneViewer();
     testCorruptDocumentIsNotEditable();
+    testArrayDocumentIsTreatedAsCorrupt();
 
     std::printf("\n%s\n", g_failures == 0 ? "PASS" : "FAIL");
     return g_failures == 0 ? 0 : 1;


### PR DESCRIPTION
PR 5 of the settings-store RFC (#4603) — the final implementation phase: **the Settings Browser dialog** (proposal D, GUI layer). Based on `main`; independent of the docs PR #4624.

## UX (maintainer-ratified 2026-07-31)

Three calls were the maintainer's to make, and all three are implemented as ruled:

- **Layout: scope tree + table.** The left tree mirrors what the store *actually contains* — App keys (with count), the station section by name, then Radios → family → radio. Radio scopes are labelled by nickname from their `Identity` document (family-agnostic, data-driven); the `radio_id=''` row shows as "(family-wide defaults)". The right side is a live-filtered key/value table — or Feature / Schema / Document columns for a radio scope.
- **Placement: Settings ▸ Settings Browser…** (with `QAction::NoRole` — the title contains "Settings", the #883 macOS auto-reparenting trap).
- **Edit level: guarded full CRUD.** Friction proportional to risk — details below.

## The guardrails (the part reviewers should attack)

- **Every edit goes through the AppSettings API — never raw SQL** (the RFC's binding rule). The running app's cache and the DB stay coherent by construction, and the credential seam + newer-schema refusals bind browser edits exactly as they bind feature code.
- **Inline edits verify by read-back** (the `--config set` pattern): if the seam diverted or the store refused, the browser says so and reverts the row — it never reports a save it didn't confirm on re-read.
- **`True`/`False` values edit through a two-entry combo** (delegate), not free text.
- **Feature documents open pretty-printed read-only**; *Edit Raw JSON…* is an explicit second step, and Save requires a parseable JSON **object**, written at the same stored schema version through `setRadioFeature()` — so the store-side newer-schema refusal still applies.
- **Credential-shaped rows render redacted and fully read-only** (edit *and* delete disabled — deleting blind is as unsafe as editing blind), and Add refuses credential-named keys outright, same message as the CLI.
- **A read-only session** (newer-schema store) swaps the advanced-warning banner for the `loadNotice` and disables every edit affordance via the new `storeWritable()` probe — not one failed `save()` at a time.
- **`meta` is invisible by construction** — AppSettings does not expose it, and the browser has no other data path.
- **Export Sanitized…** reuses `SettingsSanitizer::dump()` — diagnostic text, not a backup, labelled as such in the accessible description.

## AppSettings additions

Diagnostics-contract only (feature code still never enumerates the shared namespace):

- `radioFeatureEntriesForDiagnostics()` — the structured form of the existing enumeration; the display-string `radioFeaturesForDiagnostics()` is now derived from it, so the two cannot drift.
- `removeStationValue()` — `save()` already turned an absent dirty key into a row delete; this is the missing mirror of `remove()`.
- `storeWritable()` — the read-only probe.

## Chrome

`PersistentDialog` base (#2605), `theme::setContainer`, house dialog styling, accessible names/descriptions on every interactive control (`tools/check_a11y.py`: **0 findings**), lazy-construct + geometry persistence + frameless propagation via the standard `showOrRaisePersistent` path. Data refreshes on every show — features write documents debounced underneath an open dialog.

## Testing

- New `browser-api` safety scenario (17th): `removeStationValue` against the persisted rows, structured enumeration returns coordinates as data (incl. the `''` family-wide row), display-string diagnostics stay in lockstep. The `newer-schema-readonly` scenario now pins `storeWritable()==false`.
- Full suite green (`cross_needle_meter_test` pre-existing, #4559).
- **Offscreen GUI smoke via the automation bridge** on a scratch profile: menu action resolves headlessly, tree renders App/Station/Radios with seeded hl2 documents and nickname labels, radio scope lists Feature/Schema/Document, the filter narrows 72 rows to 2, Add Key disabled outside flat scopes, Delete disabled with no selection and on masked rows.
- Live desktop test session by the maintainer against the real store.

## Reviewer notes

- The document-viewer double-click path was exercised manually (the bridge has no double-click verb) — worth a second pair of hands.
- The viewer sub-dialog is deliberately modal (`exec()`) — it's a focused edit task, transient like `FramelessMessageBox`; the browser itself is non-modal per house pattern.
- This closes the RFC #4603 implementation checklist; the docs canon PR #4624 remains open separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
