### PR TITLE
Fix GPS presence gating on optional-GPSDO Flex radios

### DIFF
--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -169,7 +169,8 @@ RadioCapabilities FlexBackend::capabilities() const
     //     fact, which is what the capability seam is for and all a backend can
     //     honestly assert before any status has arrived;
     //   - hasGpsHardware(): "does THIS unit have it" — model name (8400/8600/
-    //     AU-) OR a live `gps` status that is not "Not Present".
+    //     AU-), a live oscillator presence flag, OR a `gps` status that is not
+    //     "Not Present".
     //
     // Do not narrow this to the model-name test to match. That clause is one
     // half of an OR: a FLEX-6700 with an optional GPSDO installed answers true
@@ -177,12 +178,8 @@ RadioCapabilities FlexBackend::capabilities() const
     // exactly those radios — a regression in the opposite direction from the one
     // it would appear to fix.
     //
-    // Consequence, and it is pre-existing rather than introduced by the
-    // capability gate: a GPSDO-less 6000-series still shows the GPS button
-    // reading [Waiting] forever, because this flag alone gates it. Fixing that
-    // means the gate consulting both — see the follow-up issue; it is not a
-    // one-line change, because the gate's test helper mirrors
-    // `!connected || declared` exactly.
+    // MainWindow therefore combines this family declaration with
+    // RadioModel::hasGpsHardware() while connected.
     caps.hasGpsLocation = true;
     // The radio owns the memory slots and re-dumps them on every connect, so
     // the client must NOT keep a local bank for a Flex — two stores that both

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2128,7 +2128,15 @@ MainWindow::MainWindow(QWidget* parent)
 
     // Frequency reference label from oscillator status (#478)
     // Show radio oscillator state immediately; GPS status only adds details.
-    connect(&m_radioModel, &RadioModel::oscillatorChanged, this, updateFrequencyReferenceLabel);
+    connect(&m_radioModel, &RadioModel::oscillatorChanged, this,
+            [this, updateFrequencyReferenceLabel] {
+        updateFrequencyReferenceLabel();
+        // Optional GPSDO presence arrives after the connection capability
+        // event, so re-evaluate the unit-level GPS gate on live oscillator
+        // status rather than leaving the initial hidden state latched.
+        applyCapabilitiesToUi(m_radioModel.isConnected(),
+                              m_radioModel.backendCapabilities());
+    });
     updateFrequencyReferenceLabel();
 
     connect(&m_radioModel, &RadioModel::gpsStatusChanged,
@@ -2138,6 +2146,10 @@ MainWindow::MainWindow(QWidget* parent)
                          const QString& /*lat*/, const QString& /*lon*/,
                          const QString& utcTime) {
         updateFrequencyReferenceLabel();
+        // Some firmware establishes presence through the GPS status object
+        // rather than an oscillator flag.
+        applyCapabilitiesToUi(m_radioModel.isConnected(),
+                              m_radioModel.backendCapabilities());
 
         // Use GPS UTC time only when GPSDO is installed and locked.
         // GPS with no antenna/lock sends stale "00:00:00Z" — fall back to system clock.
@@ -6375,19 +6387,17 @@ void MainWindow::applyCapabilitiesToUi(bool connected, const RadioCapabilities& 
 
     // ── GPS: the status-bar position readout and the dialog it opens ────────
     //
-    // Measured on a live Hermes-Lite 2 before this gate existed: the button sat
-    // `visible:true, enabled:true` reading **"[Waiting]"** indefinitely, because
-    // that radio has no GNSS receiver and so never sends a `gps` status at all.
-    // A control that can only ever say "waiting" is worse than an absent one —
-    // it reads as a fix that has not arrived yet rather than a receiver that
-    // does not exist.
+    // Family capability and unit presence are separate facts. Flex radios can
+    // support GPS, but optional-GPSDO 6000-series units must not expose the
+    // dashboard until oscillator/GPS status confirms that this unit has one.
+    // A control that can only ever wait is worse than an absent one — it reads
+    // as a fix that has not arrived yet rather than a receiver that does not
+    // exist.
     //
     // NB this stack carries the 10 MHz reference readout as well as the
     // satellite count, so hiding it removes both. That is right for a radio
-    // declaring no position source — the reference lock is a GPSDO/external-10M
-    // concept and the same stack's tooltip already read "Actual: Unknown /
-    // Lock: Unlocked" on the HL2 — but it is a second surface, so it is called
-    // out here rather than left for a reviewer to find.
+    // declaring no GPS position source. The reference readout remains part of
+    // this GPS-specific stack, so it follows the same unit-presence gate.
     //
     // Hidden WITH its trailing separator, or the divider is left stranded
     // between the neighbouring telemetry stacks.
@@ -6396,7 +6406,8 @@ void MainWindow::applyCapabilitiesToUi(bool connected, const RadioCapabilities& 
     // the Profile Manager is above: a live GPS dashboard left on screen against
     // a radio that has no receiver reports "Waiting for a valid GPS fix"
     // forever, which reads as a broken fix rather than an absent one.
-    const bool gps = !connected || caps.hasGpsLocation;
+    const bool gps = !connected
+        || (caps.hasGpsLocation && m_radioModel.hasGpsHardware());
     if (m_gpsStatusButton) {
         m_gpsStatusButton->setVisible(gps);
     }

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -5527,6 +5527,28 @@ void RadioModel::onDisconnected()
     m_maxSlices = 4;
     m_model.clear();
     m_version.clear();
+    m_oscState.clear();
+    m_oscSetting = QStringLiteral("auto");
+    m_oscLocked = false;
+    m_extPresent = false;
+    m_gpsdoPresent = false;
+    m_tcxoPresent = false;
+    m_gpsStatus.clear();
+    m_gpsTracked = 0;
+    m_gpsVisible = 0;
+    m_gpsGrid.clear();
+    m_gpsAltitude.clear();
+    m_gpsLat.clear();
+    m_gpsLon.clear();
+    m_gpsTime.clear();
+    m_gpsSpeed.clear();
+    m_gpsTrack.clear();
+    m_gpsFreqError.clear();
+    m_automationGpsNtpServerAddress.clear();
+    emit oscillatorChanged();
+    emit gpsStatusChanged(m_gpsStatus, m_gpsTracked, m_gpsVisible,
+                          m_gpsGrid, m_gpsAltitude, m_gpsLat, m_gpsLon,
+                          m_gpsTime);
     // Cleared beside m_version rather than relying on the next connect to
     // reassign it: this block's contract is that everything here is re-derived
     // from the new radio's status, and a path that reaches a Flex without
@@ -7798,9 +7820,14 @@ void RadioModel::onStatusReceived(const QString& object,
         if (kvs.contains("setting"))      m_oscSetting  = kvs["setting"];
         if (kvs.contains("locked"))       m_oscLocked   = kvs["locked"] == "1";
         if (kvs.contains("ext_present"))  m_extPresent  = kvs["ext_present"] == "1";
-        if (kvs.contains("gpsdo_present"))m_gpsdoPresent= kvs["gpsdo_present"] == "1";
+        if (kvs.contains("gpsdo_present") || kvs.contains("gnss_present")) {
+            // Firmware generations use either spelling. Treat them as aliases
+            // within this status update; do not latch a previous true value
+            // when a later update explicitly reports that the source is gone.
+            m_gpsdoPresent = kvs.value("gpsdo_present") == QLatin1String("1")
+                || kvs.value("gnss_present") == QLatin1String("1");
+        }
         if (kvs.contains("tcxo_present")) m_tcxoPresent = kvs["tcxo_present"] == "1";
-        if (kvs.contains("gnss_present")) m_gpsdoPresent= m_gpsdoPresent || kvs["gnss_present"] == "1";
         emit oscillatorChanged();
         emit infoChanged();
         return;

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -403,14 +403,15 @@ public:
     bool    extPresent()   const { return m_extPresent; }
     bool    gpsdoPresent() const { return m_gpsdoPresent; }
 
-    // True when the radio delivers GPS data: FLEX-8000 class (8400, 8600) and
-    // Aurora by model, or any radio whose "gps" status object has arrived — a
-    // 6000-series with the optional GPSDO reports the same object (and sends
-    // no gpsdo_present oscillator flag, so presence is only detectable from
-    // the data itself).
+    // True when this unit has a GPS position source: FLEX-8000 class (8400,
+    // 8600) and Aurora by model, a live oscillator presence flag, or a `gps`
+    // status object reporting data. The live signals cover optional GPSDOs on
+    // 6000-series radios without turning the family-level capability into a
+    // per-unit presence claim.
     bool hasGpsHardware() const {
         return m_model.contains("8400") || m_model.contains("8600")
                || m_model.startsWith("AU-")
+               || m_gpsdoPresent
                || (!m_gpsStatus.isEmpty()
                    && m_gpsStatus != QLatin1String("Not Present"));
     }

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -79,6 +79,14 @@ static bool uiWouldShow(bool connected, bool declared)
     return !connected || declared;
 }
 
+// GPS presence has two layers: the family must support a position source and
+// this connected unit must actually report one. Unlike the shared capability
+// helper above, either connected-layer false is enough to hide the surface.
+static bool gpsUiWouldShow(bool connected, bool familySupportsGps, bool unitHasGps)
+{
+    return !connected || (familySupportsGps && unitHasGps);
+}
+
 static RadioInfo hl2Info()
 {
     RadioInfo i;
@@ -153,6 +161,49 @@ int main(int argc, char** argv)
         check(caps.clientSettingsDomains
                   == RadioCapabilities::ClientSettingsDomains{},
               "Flex declares clientSettingsDomains EMPTY (radio-authoritative)");
+
+        check(!gpsUiWouldShow(true, caps.hasGpsLocation, model.hasGpsHardware()),
+              "connected GPSDO-less Flex hides the GPS stack");
+
+        const auto applyOscillatorPresence = [&model](const char* key, bool present) {
+            const QMap<QString, QString> status{
+                {QString::fromLatin1(key), present ? QStringLiteral("1")
+                                                   : QStringLiteral("0")}
+            };
+            const QString object = QStringLiteral("radio oscillator");
+            return QMetaObject::invokeMethod(
+                &model, "onStatusReceived", Qt::DirectConnection,
+                QGenericArgument("QString", &object),
+                QGenericArgument("QMap<QString,QString>", &status));
+        };
+
+        check(applyOscillatorPresence("gpsdo_present", true),
+              "GPSDO presence fixture reached RadioModel");
+        check(model.hasGpsHardware(),
+              "gpsdo_present=1 marks an optional 6000-series GPSDO present");
+        check(gpsUiWouldShow(true, caps.hasGpsLocation, model.hasGpsHardware()),
+              "connected optional-GPSDO Flex shows the GPS stack");
+        check(applyOscillatorPresence("gpsdo_present", false),
+              "GPSDO absence fixture reached RadioModel");
+        check(!model.hasGpsHardware(),
+              "gpsdo_present=0 clears optional GPSDO presence");
+
+        check(applyOscillatorPresence("gnss_present", true),
+              "GNSS presence fixture reached RadioModel");
+        check(model.hasGpsHardware(),
+              "gnss_present=1 marks on-board GNSS present");
+        check(applyOscillatorPresence("gnss_present", false),
+              "GNSS absence fixture reached RadioModel");
+        check(!model.hasGpsHardware(),
+              "gnss_present=0 clears on-board GNSS presence instead of latching");
+
+        check(applyOscillatorPresence("gpsdo_present", true),
+              "GPSDO reconnect fixture reached RadioModel");
+        check(QMetaObject::invokeMethod(
+                  &model, "onDisconnected", Qt::DirectConnection),
+              "disconnect fixture reached RadioModel");
+        check(!model.hasGpsHardware(),
+              "GPS presence does not leak from the previous radio session");
     }
 
     // ---- HL2 declares none of them ---------------------------------------


### PR DESCRIPTION
## Summary

Fixes #4598.

Gate the GPS status-bar stack on both the backend family capability and live unit-level GPS hardware presence. RadioModel now recognizes both `gpsdo_present` and `gnss_present` without latching stale truth, clears GPS/oscillator state between sessions, and causes capability UI to be reevaluated when the relevant live status arrives.

## Constitution principle honored

Principle II — radio-authoritative live state. The UI follows the connected radio unit presence flags instead of treating a family-wide capability declaration as installed hardware.

## Test plan

- [x] Native macOS ARM64 all-target build passes (`cmake --build build-arm64 -j12`)
- [x] Focused `radio_capability_gating_test` passes
- [x] Strict engine-boundary check passes with 86 tracked warnings and 0 blockers
- [x] Reproduction verified through the automation bridge against a loopback FLEX-6700 fixture reporting `gpsdo_present=0 gnss_present=0`
- [x] Baseline: `gpsStatusButton visible:true`; fixed: `gpsStatusButton visible:false`
- [x] Bridge identity confirmed `txAllowed=false`; fixture remained non-transmitting
- [ ] Behavior verified on a physical optional-GPSDO 6000-series radio
- [ ] Existing tests pass in CI

## Checklist

- [x] Commit is signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room
- [x] No meter UI changes
- [ ] Documentation updated if user-visible behavior changed
- [x] No security-sensitive changes

Generated with OpenAI Codex.