### PR TITLE
fix(gui): stop AetherVoice waveform starving the waterfall

### DIFF
--- a/src/gui/StripWaveformPanel.cpp
+++ b/src/gui/StripWaveformPanel.cpp
@@ -106,11 +106,11 @@ StripWaveformPanel::StripWaveformPanel(AudioEngine* engine, QWidget* parent)
         m_windowSlider->setValue(savedSec);
     }
     applyWindowSec(savedSec);
-    // 90 Hz repaint rate so the long-window scroll reads as smooth
-    // motion.  The engine's post-chain scope tap fires up to ~125 Hz
-    // (kTxPostChainEmitMinIntervalMs = 8 ms) so the widget always
-    // has fresh data on every frame.
-    m_waveform->setRefreshRateHz(90);
+    // Match the standalone WAVE applet's 25 Hz cadence. WaveformWidget is
+    // QRhi-backed and shares the GUI/render thread with the panadapter; the
+    // previous 90 Hz target starved waterfall rendering as this panel widened
+    // (#4616).
+    m_waveform->setRefreshRateHz(25);
     // Default render path — pinned TX in the constructor so the
     // initial paint is consistent.  showForRx() flips the pin and
     // re-wires the source tap to the RX-side scope signal.


### PR DESCRIPTION
## Summary

Fixes #4616.

The AetherVoice channel-strip waveform independently requested QRhi repaints at 90 Hz. `WaveformWidget` shares the GUI/render thread with the panadapter, and its work grows with the strip width, so enlarging the channel strip consumed render time that the waterfall needed.

Match the existing standalone WAVE applet cadence of 25 Hz. This keeps the live scope responsive while removing the channel strip's oversized render demand; no signal routing, DSP, or radio state changes.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The agent automation bridge reproduced the issue on the unfixed build and repeated the same 1600 x 1000, 761 px-wide AetherVoice scenario with the fix. The final commit was then rebased onto current `upstream/main` and fully rebuilt, including the newly landed `DssRenderer` waterfall change.

## Agent automation bridge proof

Both samples used the same live FLEX-6700 session, window geometry, widened channel strip, and RX-only automation mode:

| Counter | Before (90 Hz target) | After (25 Hz target) | Change |
|---|---:|---:|---:|
| AetherVoice waveform paints/s | 21.119 | 10.793 | -48.9% |
| AetherVoice waveform paint ms/s | 2.683 | 1.463 | -45.5% |
| Panadapter GPU frames/s | 33.226 | 43.495 | +30.9% |
| Average panadapter GPU frame | 4,861 us | 1,839 us | -62.2% |
| Measured main-thread render work | 168.342 ms/s | 86.203 ms/s | -48.8% |
| Panadapter FFT input | 24.617 fps | 24.740 fps | +0.5% |
| Waterfall input | 12.376 updates/s | 12.503 updates/s | +1.0% |

The input rates stayed stable while AetherVoice's independent repaint load fell and the panadapter gained rendering headroom. The bridge reported `transmitting: false` and `txPower: 0` before and after; `AETHER_AUTOMATION_NO_TX=1` remained enabled throughout.

## Proof

Still images cannot show temporal jitter by themselves; these pairs document the identical enlarged AetherVoice geometry and live pan/waterfall state used for the measured A/B comparison.

### Enlarged AetherVoice channel strip

Before (90 Hz target):

![Before: enlarged AetherVoice channel strip](https://raw.githubusercontent.com/rfoust/AetherSDR/fix-4616-assets/.pr-assets/4616-before-aethervoice.png)

After (25 Hz target):

![After: enlarged AetherVoice channel strip](https://raw.githubusercontent.com/rfoust/AetherSDR/fix-4616-assets/.pr-assets/4616-after-aethervoice.png)

### Panadapter and waterfall

Before (90 Hz target):

![Before: live panadapter and waterfall](https://raw.githubusercontent.com/rfoust/AetherSDR/fix-4616-assets/.pr-assets/4616-before-pan.png)

After (25 Hz target):

![After: live panadapter and waterfall](https://raw.githubusercontent.com/rfoust/AetherSDR/fix-4616-assets/.pr-assets/4616-after-pan.png)

## Test plan

- [x] Full native arm64 all-target build passes (`cmake --build build -j16`) on current `upstream/main`
- [x] Behavior verified on a real FLEX-6700 running firmware 4.2.18.41174 via the agent automation bridge, RX-only
- [x] Focused tests pass: `panadapter_message_overlay_test`, `waveform_scope_model_test`, `dss_renderer_test`, `waterfall_history_buffer_test`
- [x] Strict engine-boundary check passes with zero blockers
- [x] Reproduction steps documented in #4616 and repeated with the widened channel strip

Proof limitations: the reporter's Windows 11 / RTX 2060 / FLEX-8600 setup was not available locally. A fully exposed dual-monitor/maximized capture was also unavailable in the headless macOS bridge session because occluded QRhi widgets stop painting, so those invalid intervals were discarded. The controlled before/after evidence above uses identical 1600 x 1000 live sessions instead.

## Checklist

- [x] Commit is signed and verified locally
- [x] No `AppSettings` changes
- [x] Code is clean-room; no proprietary implementation was inspected
- [x] No meter UI changes
- [x] No documentation change required; this corrects an internal rendering cadence
- [x] No security-sensitive changes

Generated with OpenAI Codex.
