### PR TITLE
Fix Region 1 80m band plan

### DIFF
--- a/resources/bandplans/iaru-region1.json
+++ b/resources/bandplans/iaru-region1.json
@@ -12,7 +12,7 @@
     {"low": 3.510, "high": 3.560, "label": "CW", "license": "", "color": "#3060ff"},
     {"low": 3.560, "high": 3.570, "label": "CW", "license": "", "color": "#3060ff"},
     {"low": 3.570, "high": 3.600, "label": "NB DIGI", "license": "", "color": "#c03030"},
-    {"low": 3.600, "high": 3.620, "label": "DIGI", "license": "", "color": "#c03030"},
+    {"low": 3.600, "high": 3.620, "label": "ALL", "license": "", "color": "#ff8000"},
     {"low": 3.620, "high": 3.800, "label": "ALL", "license": "", "color": "#ff8000"},
 
     {"low": 5.3515, "high": 5.354, "label": "CW/NB", "license": "", "color": "#3060ff"},


### PR DESCRIPTION
## Summary\n\nFixes #4610\n\nThe IARU Region 1 band-plan resource classified 3.600-3.620 MHz as DIGI with the narrow-band digital color. BandPlanManager and SpectrumWidget consume the resource label and color verbatim, so the panadapter displayed the wrong classification. This changes that one segment to ALL with the existing all-modes color, matching the adjacent Region 1 segment and the official IARU Region 1 band plan.\n\nOfficial source: https://www.iaru-r1.org/wp-content/uploads/2021/06/hf_r1_bandplan.pdf\n\n![Current-base agent automation bridge proof](https://raw.githubusercontent.com/rfoust/AetherSDR/fix-4610-assets/.pr-assets/4610-after.png)\n\n## Constitution principle honored\n\nPrinciple XI — Fixes Are Demonstrated. The fix is a one-line declarative correction, verified by an exact resource assertion, a focused unit test, a current-base application build, and the authenticated agent automation bridge.\n\n## Test plan\n\n- [x] Local arm64 application build passes (cmake --build build --target AetherSDR -j8)\n- [x] Focused test passes (band_plan_license_filter_test)\n- [x] Reproduction verified through the authenticated agent automation bridge using DEMO-0001 at 3.610 MHz\n- [x] Bridge state confirmed transmitting=false, MOX off, tuning off, and TX automation disabled\n- [ ] Existing tests pass in CI\n- [x] Real-radio proof is not applicable to this static display-resource correction\n\n## Checklist\n\n- [x] Commit is signed and verified with the configured ED25519 SSH signing key\n- [x] No AppSettings calls added\n- [x] Code and source material are clean-room; the classification comes from the public IARU Region 1 band plan\n- [x] Meter UI is not touched\n- [x] No documentation update is required; the shipped band-plan resource itself is corrected\n- [x] No security-sensitive behavior is changed\n\nGenerated with OpenAI Codex.