### PR TITLE
fix(tests): make the cross-needle font-cache case exercise the cache, and run the suite in CI

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -34,4 +34,14 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     libmosquitto-dev \
     ca-certificates \
+    fonts-dejavu-core \
     && rm -rf /var/lib/apt/lists/*
+
+# fonts-dejavu-core is listed explicitly rather than left to fontconfig's
+# Recommends, which is where the image gets it today. Nothing is broken now —
+# it is pinning a dependency the suite already relies on: the face/geometry
+# tests measure REAL font metrics (cross_needle_meter_test lays the SWR numbers
+# out with QFontMetricsF and renders the meter face), and with no font file
+# installed Qt has nothing to measure and those cases fail. Verified locally by
+# pointing FONTCONFIG_FILE at an empty config. The transitive route survives
+# only until someone adds --no-install-recommends to the apt line above.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,40 @@ jobs:
       - name: Build
         run: cmake --build build -j$(nproc)
 
+      # The build above already produces every test binary (it builds `all`),
+      # and until now nothing on the PR path ran any of them: this job and
+      # check-macos built the suite and ran nothing, while check-windows runs
+      # four portability cases by design. A test that is compiled but never run
+      # only proves it still compiles.
+      #
+      # The suite was not entirely unwatched — sanitizers.yml runs it weekly in
+      # this same container — but a weekly job that files one sticky issue per
+      # sanitizer is a poor regression gate: cross_needle_meter_test had been
+      # failing there since it was written (#4274), reported inside #4330 where
+      # it read as sanitizer noise rather than as a broken test, and nothing on
+      # any PR ever went red for it. Blocking the merge is what makes it stick.
+      #
+      # Runtime is the whole added cost and it is small: ~90 s wall clock for
+      # the full suite at -j$(nproc), against a build measured in tens of
+      # minutes.
+      #
+      # QT_QPA_PLATFORM=offscreen because the container has no display. The
+      # widget tests are written against it — they grab framebuffers rather
+      # than showing windows — so it is the platform they target, not a
+      # workaround.
+      #
+      # -j4 is pinned rather than $(nproc). A few tests are timing-sensitive and
+      # start failing under heavy oversubscription rather than for any real
+      # reason: wdsp_channel_test and radio_capability_gating_test both fail at
+      # -j32 on a 32-core box and pass in isolation and at -j4. ubuntu-latest is
+      # 4 vCPU today, so $(nproc) would resolve to 4 anyway — pinning it means a
+      # bigger runner later turns into a faster build, not a flaky suite.
+      - name: Test
+        timeout-minutes: 20
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: ctest --test-dir build -j4 --output-on-failure
+
       # #4146 turned liquid-dsp off by default, so the main build above no
       # longer proves the vendored snapshot still compiles. Build only the
       # liquid-static target (separate build dir, opt-in flag) so a bitrotted
@@ -263,8 +297,9 @@ jobs:
         # linking the app plus the handful of portability tests run below, NOT the
         # default `all` target. Building every *_test.exe relinked the same
         # libraries into hundreds of tiny executables for no added Windows coverage
-        # (cross-platform test linkage is already exercised by the Linux/macOS CI
-        # that build AND run the full suite), and that link tail was stalling for
+        # (cross-platform test linkage is exercised by the Linux `build` job, which
+        # builds the suite and — as of #4568 — runs it; check-macos builds it but
+        # still runs nothing), and that link tail was stalling for
         # hours on the runner. timeout-minutes fails fast (with logs) if it ever
         # hangs again, instead of running to the 6-hour job limit.
         timeout-minutes: 45

--- a/tests/cross_needle_meter_test.cpp
+++ b/tests/cross_needle_meter_test.cpp
@@ -889,17 +889,42 @@ void testResourceAndConstruction() {
     report("SWR contour ink survives applet-size downsampling",
            geometry.swrStyle.guideWidth >= 3.0);
 
-    QFont wideSwrLabelFont = swrLabelFont;
-    wideSwrLabelFont.setStretch(175);
-    const QFontMetricsF wideSwrLabelMetrics(wideSwrLabelFont);
-    QVector<QRectF> wideLabelRects;
+    // A different rendered font must invalidate the placement cache, and the
+    // only black-box evidence of that is the layout moving. So the perturbation
+    // has to be one the declutter cannot absorb.
+    //
+    // A stretch cannot: it widens the boxes but leaves their height alone, and
+    // what binds this layout is VERTICAL — the numbers stack along their own
+    // contours with far more horizontal room than vertical. Measured across
+    // Noto Sans, DejaVu Sans, Liberation Sans, FreeSans and Cantarell,
+    // setStretch(175) repositions 0 of 12 labels on every one of them: every
+    // box still clears at its original anchor, so the assertion below silently
+    // tested nothing at best and failed for the wrong reason at worst.
+    //
+    // A size change moves both dimensions and does force a relayout. 1.75x is
+    // chosen from the middle of the working range: at 1.25x two of those five
+    // families still move nothing, and by 2.5x the declutter starts failing to
+    // place labels at all (NaN centres), which would make this case pass for a
+    // reason that has nothing to do with the cache. 1.5x-2x repositions 3-5
+    // labels on all five with no placement failures.
+    QFont largerSwrLabelFont = swrLabelFont;
+    largerSwrLabelFont.setPixelSize(qRound(
+        1.75 * static_cast<double>(geometry.typography.swrNumberPixels)));
+    const QFontMetricsF largerSwrLabelMetrics(largerSwrLabelFont);
+    QVector<QRectF> largerLabelRects;
     bool fontChangeRepositionedLabels = false;
-    bool wideLabelBoxesSeparated = true;
-    bool wideLabelBoxesClearMask = true;
+    bool largerLabelsPlaced = true;
+    bool largerLabelBoxesSeparated = true;
+    bool largerLabelBoxesClearMask = true;
     for (int index = 0; index < geometry.swrGuides.size(); ++index) {
         const CrossNeedleMeterGeometry::SwrGuide &guide = geometry.swrGuides[index];
         const QPointF center =
-            geometry.swrGuideLabelCenter(guide, wideSwrLabelFont);
+            geometry.swrGuideLabelCenter(guide, largerSwrLabelFont);
+        // A guide the declutter could not place at all comes back NaN. Track it
+        // separately: without this, a total placement failure would look like a
+        // repositioning and quietly satisfy the cache assertion.
+        largerLabelsPlaced = largerLabelsPlaced && !std::isnan(center.x()) &&
+                             !std::isnan(center.y());
         fontChangeRepositionedLabels =
             fontChangeRepositionedLabels ||
             std::hypot(center.x() - labelCenters[index].x(),
@@ -908,26 +933,30 @@ void testResourceAndConstruction() {
                                     ? QString::fromUtf8("\xe2\x88\x9e")
                                     : guide.displayLabel;
         QRectF box =
-            wideSwrLabelMetrics.boundingRect(display).adjusted(-3.0, -2.0, 3.0, 2.0);
+            largerSwrLabelMetrics.boundingRect(display).adjusted(-3.0, -2.0, 3.0, 2.0);
         box.moveCenter(center);
-        wideLabelBoxesClearMask =
-            wideLabelBoxesClearMask &&
+        largerLabelBoxesClearMask =
+            largerLabelBoxesClearMask &&
             box.bottom() + 3.0 < maskBoundaryYAtX(geometry, box.left()) &&
             box.bottom() + 3.0 < maskBoundaryYAtX(geometry, box.center().x()) &&
             box.bottom() + 3.0 < maskBoundaryYAtX(geometry, box.right());
-        wideLabelRects.append(box);
+        largerLabelRects.append(box);
     }
-    for (int first = 0; first < wideLabelRects.size(); ++first) {
-        for (int second = first + 1; second < wideLabelRects.size(); ++second) {
-            wideLabelBoxesSeparated =
-                wideLabelBoxesSeparated &&
-                !wideLabelRects[first].intersects(wideLabelRects[second]);
+    for (int first = 0; first < largerLabelRects.size(); ++first) {
+        for (int second = first + 1; second < largerLabelRects.size(); ++second) {
+            largerLabelBoxesSeparated =
+                largerLabelBoxesSeparated &&
+                !largerLabelRects[first].intersects(largerLabelRects[second]);
         }
     }
+    // Precondition for the case below: if the larger font failed to place a
+    // label, "the centres moved" no longer says anything about the cache.
+    report("a larger rendered font still places every SWR number",
+           largerLabelsPlaced);
     report("SWR label placement cache is keyed by the rendered font",
-           fontChangeRepositionedLabels);
-    report("wider rendered-font SWR labels remain collision-free",
-           wideLabelBoxesSeparated && wideLabelBoxesClearMask);
+           fontChangeRepositionedLabels && largerLabelsPlaced);
+    report("larger rendered-font SWR labels remain collision-free",
+           largerLabelBoxesSeparated && largerLabelBoxesClearMask);
 
     bool maskSymmetric = true;
     for (int i = 0; i < geometry.mask.boundary.size(); ++i) {


### PR DESCRIPTION
`cross_needle_meter_test` fails on `main`. The cache it tests is fine — the test's premise isn't. Fixes that, then closes the gap that let it stay red.

## The test

The case proves cache keying indirectly: change the font, expect the layout to move. It changed the font with `setStretch(175)`, which widens the label boxes and leaves their height alone. What constrains this layout is **vertical** — the SWR numbers stack along their own contours with far more horizontal room than vertical — so every box still clears at its original anchor and nothing moves.

Measured across five font families:

| perturbation | Noto Sans | DejaVu Sans | Liberation Sans | FreeSans | Cantarell |
|---|---|---|---|---|---|
| `setStretch(175)` | 0/12 | 0/12 | 0/12 | 0/12 | 0/12 |
| 1.25x size | 4/12 | 4/12 | **0/12** | 1/12 | **0/12** |
| 1.75x size | 4/12 | 4/12 | 4/12 | 4/12 | 3/12 |
| 2.5x size | 4/12 ⚠ | 4/12 ⚠ | 6/12 | 6/12 | 6/12 |

⚠ = the declutter starts failing to place labels at all (NaN centres), which would have made the case pass for a reason unrelated to the cache.

The metrics genuinely do change under stretch — a `"2.0"` box goes 29 px → 48 px — the layout just absorbs it. So the assertion could not hold on any of those font stacks.

**This was never a regression.** No label-layout constant has changed since the case landed in #4274, and the only geometry commit since (#4376) memoized guide samples, which the placement path does not use. It has been failing since it was written.

The fix swaps the perturbation for a **1.75x pixel size**, from the middle of the working range, and adds `a larger rendered font still places every SWR number` as an explicit precondition that the cache assertion is gated on — so a future font that pushes the declutter past its limit is diagnosed as a placement failure instead of silently satisfying the cache case.

**Production code is untouched.** `swrLabelCenters()` keys on `QFont::key()`, which carries both size and stretch, and is correct as it stands.

Verified by mutation: dropping the font key from the cache lookup makes the case fail with exactly this message; restoring it passes.

## Why it stayed red

Nothing on the PR path ran a test. The Linux `build` job and `check-macos` both build `all` — every test binary — and execute none. `check-windows` runs four portability cases by design.

The suite was not entirely unwatched: `sanitizers.yml` runs it weekly in the same container. But a weekly job filing one sticky issue per sanitizer is a poor regression gate — this failure is sitting in #4330 right now, where it reads as sanitizer noise rather than as a broken test, and no PR ever went red for it.

So this adds a `Test` step to the Linux job. The binaries are already built, so runtime is the entire added cost: **~100 s for 217 tests**, against a build measured in tens of minutes.

- `-j4` pinned rather than `$(nproc)`: a few tests are timing-sensitive and fail under heavy oversubscription rather than for any real reason — `wdsp_channel_test` and `radio_capability_gating_test` both fail at `-j32` on a 32-core box and pass in isolation and at `-j4`. `ubuntu-latest` is 4 vCPU today so `$(nproc)` resolves to 4 anyway; pinning means a bigger runner later becomes a faster build rather than a flaky suite. Three consecutive clean runs at `-j4` (217/217, 101–110 s).
- `QT_QPA_PLATFORM=offscreen` because the container has no display. The widget tests are written against it — they grab framebuffers rather than showing windows — so it is the platform they target, not a workaround.
- Pins `fonts-dejavu-core` in the CI image, which currently arrives only via `fontconfig`'s Recommends. Nothing is broken today; it makes explicit a dependency the suite already has, since the face and geometry tests measure real font metrics and fail outright with no font installed (verified by pointing `FONTCONFIG_FILE` at an empty config).
- Corrects the `check-windows` comment, which claimed the Linux/macOS jobs already "build AND run the full suite". They did not, and that belief is part of why this went unnoticed.

## Testing

Full suite **217/217** locally (Linux, RelWithDebInfo, Qt 6), up from 216/217. Three repeat runs at `-j4` for flake confidence.

## Note for the reviewer

The Dockerfile change will trigger `docker-ci-image.yml` on merge, which rebuilds the image and opens the usual digest-bump PR. `ci.yml` tracks `:latest`, so it picks the new image up on its own.

Watch this PR's own `build` job — it is the first time the suite has gated a PR, so it is also the first real evidence that all 217 pass in the container rather than only on a dev box. `s_meter_geometry_test` was also failing in that #4330 sanitizer run; it passes locally here in RelWithDebInfo, so it looks ASan/Debug-specific, but this job is what will confirm it.
