### PR TITLE
fix(transmit): report when the TX filter is removing transmit audio (#4649)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1252,12 +1252,23 @@ MainWindow::MainWindow(QWidget* parent)
     });
     connect(&m_radioModel, &RadioModel::interlockNotificationRequested,
             this, &MainWindow::showPanadapterInterlockNotification);
-    // Surfaced in the status bar rather than the panadapter overlay: this is
-    // a settings problem the operator has to go and fix, not a transient
-    // interlock event (#4649).
+    // Goes on the panadapter as a transient card, NOT the status bar (#4649).
+    // A QStatusBar temporary message hides every permanent widget for its whole
+    // duration -- the TX indicator, PA temperature and supply voltage among
+    // them -- so putting it there blanks exactly the telemetry an operator
+    // wants while transmitting, at the one moment they are transmitting.
+    // The status bar stays as a fallback for the case where no panadapter can
+    // be resolved, so the warning is never simply dropped.
     connect(&m_radioModel, &RadioModel::txFilterBlockingAudio,
-            this, [this](const QString& message) {
-                statusBar()->showMessage(message, 10000);
+            this, [this](const QString& title, const QString& detail,
+                         const QString& panId) {
+                if (!panId.trimmed().isEmpty() && m_panStack) {
+                    if (SpectrumWidget* sw = m_panStack->spectrum(panId.trimmed())) {
+                        sw->showTxFilterNotification(title, detail, 8000);
+                        return;
+                    }
+                }
+                statusBar()->showMessage(title + QStringLiteral(" - ") + detail, 8000);
             });
 
     m_networkDiagnosticsHistory = new NetworkDiagnosticsHistory(&m_radioModel, m_audio, this);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1252,6 +1252,13 @@ MainWindow::MainWindow(QWidget* parent)
     });
     connect(&m_radioModel, &RadioModel::interlockNotificationRequested,
             this, &MainWindow::showPanadapterInterlockNotification);
+    // Surfaced in the status bar rather than the panadapter overlay: this is
+    // a settings problem the operator has to go and fix, not a transient
+    // interlock event (#4649).
+    connect(&m_radioModel, &RadioModel::txFilterBlockingAudio,
+            this, [this](const QString& message) {
+                statusBar()->showMessage(message, 10000);
+            });
 
     m_networkDiagnosticsHistory = new NetworkDiagnosticsHistory(&m_radioModel, m_audio, this);
     connect(&m_radioModel, &RadioModel::digitalVoiceWaveformDegradationStarted,

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -6546,6 +6546,27 @@ void SpectrumWidget::showInterlockNotification(const QString& message,
     upsertOverlayMessage(std::move(overlay));
 }
 
+void SpectrumWidget::showTxFilterNotification(const QString& title,
+                                              const QString& detail,
+                                              int durationMs)
+{
+    if (title.trimmed().isEmpty() && detail.trimmed().isEmpty()) {
+        return;
+    }
+    PanadapterOverlayMessage overlay;
+    // Own id, so re-keying replaces this card in place rather than stacking,
+    // and so it never collides with "interlock.active" -- the two describe
+    // different things and either must be able to appear without evicting the
+    // other.
+    overlay.id = QStringLiteral("txfilter.audio-loss");
+    overlay.title = title;
+    overlay.detail = detail;
+    overlay.timeoutMs = qMax(1, durationMs);
+    overlay.dismissible = true;
+    overlay.tone = PanadapterOverlayMessageTone::Warning;
+    upsertOverlayMessage(std::move(overlay));
+}
+
 void SpectrumWidget::drawConnectionAnimation(QPainter& p, const QRect& contentRect)
 {
     if (!m_connectionAnimationVisible || !m_connectionAnimationClock.isValid()) {

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -201,6 +201,12 @@ public:
     Q_INVOKABLE bool automationRemoveOverlayMessage(const QString& id);
     Q_INVOKABLE void automationClearOverlayMessages();
     Q_INVOKABLE QVariantList overlayMessageSnapshot() const;
+    // Transient card for a TX filter that is swallowing the transmit audio
+    // (#4649). Separate from showInterlockNotification: nothing is refusing
+    // to key here, so it must not claim "Transmit disabled".
+    void showTxFilterNotification(const QString& title,
+                                  const QString& detail,
+                                  int durationMs);
     void showInterlockNotification(const QString& message,
                                    const QString& key = QString(),
                                    int durationMs = 5000);

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -142,12 +142,22 @@ void MeterModel::defineMeter(const MeterDef& def)
         m_hwAlcIdx = def.index;
     else if (def.name == "ALC")
         m_swAlcIdx = def.index;
-    else if (isTxWaveformMeter(def) && def.name == "SC_MIC")
-        m_scMicIdx = def.index;
-    else if (isTxWaveformMeter(def) && def.name == "SC_FILT_1")
-        m_scFilt1Idx = def.index;
-    else if (isTxWaveformMeter(def) && def.name == "SC_FILT_2")
-        m_scFilt2Idx = def.index;
+    else if (isTxWaveformMeter(def)
+             && (def.name == "SC_MIC" || def.name == "SC_FILT_1"
+                 || def.name == "SC_FILT_2")) {
+        // Same resolution COMPPEAK uses: key by explicit TX-waveform
+        // sourceIndex where the radio supplies one, otherwise by the slice
+        // context the manifest was in when this block arrived.
+        const bool explicitSource = hasExplicitTxWaveformSourceIndex(def);
+        const int key = explicitSource ? def.sourceIndex
+                                       : implicitTxWaveformSliceIndex();
+        if (def.name == "SC_MIC")
+            (explicitSource ? m_scMicIdxByTxSource : m_scMicIdxBySlice)[key] = def.index;
+        else if (def.name == "SC_FILT_1")
+            (explicitSource ? m_scFilt1IdxByTxSource : m_scFilt1IdxBySlice)[key] = def.index;
+        else
+            (explicitSource ? m_scFilt2IdxByTxSource : m_scFilt2IdxBySlice)[key] = def.index;
+    }
     else if (def.source != "AMP" && def.name == "PATEMP")
         m_paTempIdx = def.index;
     else if (def.name == "+13.8A")
@@ -226,9 +236,23 @@ void MeterModel::removeMeter(int index)
     if (index == m_compLevelIdx) m_compLevelIdx = -1;
     if (index == m_hwAlcIdx)     m_hwAlcIdx = -1;
     if (index == m_swAlcIdx)     m_swAlcIdx = -1;
-    if (index == m_scMicIdx)   { m_scMicIdx = -1;   m_hasScMicValue = false; }
-    if (index == m_scFilt1Idx) { m_scFilt1Idx = -1; m_hasScFilt1Value = false; }
-    if (index == m_scFilt2Idx) { m_scFilt2Idx = -1; m_hasScFilt2Value = false; }
+    // A level must never outlive the meter it describes.
+    // Resolve the ACTIVE indices BEFORE erasing: once the entry is gone the
+    // resolver returns -1 and the has-a-sample flag would never be cleared.
+    const int activeScMic   = scMicIndexForActiveTxSlice();
+    const int activeScFilt1 = scFilt1IndexForActiveTxSlice();
+    const int activeScFilt2 = scFilt2IndexForActiveTxSlice();
+    for (QMap<int, int>* m : {&m_scMicIdxByTxSource, &m_scMicIdxBySlice,
+                              &m_scFilt1IdxByTxSource, &m_scFilt1IdxBySlice,
+                              &m_scFilt2IdxByTxSource, &m_scFilt2IdxBySlice}) {
+        for (auto it = m->begin(); it != m->end(); ) {
+            if (it.value() == index) it = m->erase(it);
+            else ++it;
+        }
+    }
+    if (index == activeScMic)   m_hasScMicValue = false;
+    if (index == activeScFilt1) m_hasScFilt1Value = false;
+    if (index == activeScFilt2) m_hasScFilt2Value = false;
     if (index == m_paTempIdx)    m_paTempIdx = -1;
     if (index == m_supplyIdx) {
         m_supplyIdx = -1;
@@ -321,9 +345,12 @@ void MeterModel::clear()
     m_hwAlcIdx = -1;
     m_swAlcIdx = -1;
     m_paTempIdx = -1;
-    m_scMicIdx = -1;
-    m_scFilt1Idx = -1;
-    m_scFilt2Idx = -1;
+    m_scMicIdxByTxSource.clear();
+    m_scMicIdxBySlice.clear();
+    m_scFilt1IdxByTxSource.clear();
+    m_scFilt1IdxBySlice.clear();
+    m_scFilt2IdxByTxSource.clear();
+    m_scFilt2IdxBySlice.clear();
     m_hasScMicValue = false;
     m_hasScFilt1Value = false;
     m_hasScFilt2Value = false;
@@ -367,6 +394,11 @@ void MeterModel::setActiveTxSlice(int sliceIndex)
         return;
 
     m_activeTxSlice = sliceIndex;
+    // The stored filter levels describe the PREVIOUS slice's chain; drop
+    // them so a comparison cannot straddle a slice change (#4649).
+    m_hasScMicValue = false;
+    m_hasScFilt1Value = false;
+    m_hasScFilt2Value = false;
     clearCompressionState();
     logCompressionSummary("active-slice-change", true);
     emit micMetersChanged(m_micLevel, m_compLevel, m_micPeak, m_compPeak);
@@ -543,6 +575,11 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
     const int n = qMin(ids.size(), vals.size());
     const qint64 packetUpdatedMs = QDateTime::currentMSecsSinceEpoch();
     const int activeCompPeakIdx = compPeakIndexForActiveTxSlice();
+    // Resolved once per packet, same shape as activeCompPeakIdx: these must
+    // track the ACTIVE TX slice, not whichever block was defined last.
+    const int activeScMicIdx   = scMicIndexForActiveTxSlice();
+    const int activeScFilt1Idx = scFilt1IndexForActiveTxSlice();
+    const int activeScFilt2Idx = scFilt2IndexForActiveTxSlice();
     // sLevelChanged is emitted per-slice inline in the loop below
     bool txChanged = false;
     bool directionalChanged = false;
@@ -656,17 +693,22 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
         } else if (idx == m_swAlcIdx) {
             m_swAlc = v;
             swAlcChangedFlag = true;
-        } else if (idx == m_scMicIdx) {
+        } else if (activeScMicIdx >= 0 && idx == activeScMicIdx) {
             m_scMic = v;
             m_hasScMicValue = true;
-            txFilterLevelsChangedFlag = true;
-        } else if (idx == m_scFilt1Idx) {
+        } else if (activeScFilt1Idx >= 0 && idx == activeScFilt1Idx) {
             m_scFilt1 = v;
             m_hasScFilt1Value = true;
-            txFilterLevelsChangedFlag = true;
-        } else if (idx == m_scFilt2Idx) {
+        } else if (activeScFilt2Idx >= 0 && idx == activeScFilt2Idx) {
             m_scFilt2 = v;
             m_hasScFilt2Value = true;
+            // Publish on the SLOWER tap only. SC_FILT_1 runs at 20 fps and
+            // SC_FILT_2 at 10, so emitting on either would hand the consumer
+            // one fresh value and a partner up to 100 ms old -- and at
+            // key-down SC_FILT_1 rises first while SC_FILT_2 is still at the
+            // floor, which is exactly the shape a loss detector misreads.
+            // Emitting here bounds the partner's age at ~one SC_FILT_1
+            // period (~50 ms) instead.
             txFilterLevelsChangedFlag = true;
         } else if (idx == m_paTempIdx) {
             m_paTemp = v;
@@ -759,13 +801,55 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
     if (swAlcChangedFlag)
         emit this->swAlcChanged(m_swAlc);
     if (txFilterLevelsChangedFlag)
-        emit txFilterLevelsChanged(m_scMic, m_scFilt1, m_scFilt2);
+        emit txFilterLevelsChanged(m_scFilt1, m_scFilt2);
     if (hwChanged)
         emit hwTelemetryChanged(m_paTemp, m_supplyVolts);
     if (ampChanged)
         emit ampMetersChanged(m_ampFwdPwr, m_ampSwr, m_ampTemp);
     if (tgxlChanged)
         emit tgxlMetersChanged(m_tgxlFwdPwr, m_tgxlSwr);
+}
+
+static int resolveTxWaveformIndex(const QMap<int, int>& byTxSource,
+                                  const QMap<int, int>& bySlice,
+                                  int txSource, int activeSlice)
+{
+    if (txSource >= 0 && byTxSource.contains(txSource))
+        return byTxSource.value(txSource);
+    return bySlice.value(activeSlice, -1);
+}
+
+int MeterModel::scMicIndexForActiveTxSlice() const
+{
+    return resolveTxWaveformIndex(m_scMicIdxByTxSource, m_scMicIdxBySlice,
+                                  activeTxWaveformSourceIndex(), m_activeTxSlice);
+}
+
+int MeterModel::scFilt1IndexForActiveTxSlice() const
+{
+    return resolveTxWaveformIndex(m_scFilt1IdxByTxSource, m_scFilt1IdxBySlice,
+                                  activeTxWaveformSourceIndex(), m_activeTxSlice);
+}
+
+int MeterModel::scFilt2IndexForActiveTxSlice() const
+{
+    return resolveTxWaveformIndex(m_scFilt2IdxByTxSource, m_scFilt2IdxBySlice,
+                                  activeTxWaveformSourceIndex(), m_activeTxSlice);
+}
+
+qint64 MeterModel::txFilterLevelSkewMs() const
+{
+    if (!m_hasScFilt1Value || !m_hasScFilt2Value)
+        return -1;
+    const int i1 = scFilt1IndexForActiveTxSlice();
+    const int i2 = scFilt2IndexForActiveTxSlice();
+    if (i1 < 0 || i2 < 0)
+        return -1;
+    const qint64 a = m_valueUpdatedMs.value(i1, 0);
+    const qint64 b = m_valueUpdatedMs.value(i2, 0);
+    if (a <= 0 || b <= 0)
+        return -1;
+    return qAbs(a - b);
 }
 
 const MeterDef* MeterModel::meterDef(int index) const

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -142,6 +142,10 @@ void MeterModel::defineMeter(const MeterDef& def)
         m_hwAlcIdx = def.index;
     else if (def.name == "ALC")
         m_swAlcIdx = def.index;
+    else if (isTxWaveformMeter(def) && def.name == "SC_MIC")
+        m_scMicIdx = def.index;
+    else if (isTxWaveformMeter(def) && def.name == "SC_FILT_2")
+        m_scFilt2Idx = def.index;
     else if (def.source != "AMP" && def.name == "PATEMP")
         m_paTempIdx = def.index;
     else if (def.name == "+13.8A")
@@ -220,6 +224,8 @@ void MeterModel::removeMeter(int index)
     if (index == m_compLevelIdx) m_compLevelIdx = -1;
     if (index == m_hwAlcIdx)     m_hwAlcIdx = -1;
     if (index == m_swAlcIdx)     m_swAlcIdx = -1;
+    if (index == m_scMicIdx)   { m_scMicIdx = -1;   m_hasScMicValue = false; }
+    if (index == m_scFilt2Idx) { m_scFilt2Idx = -1; m_hasScFilt2Value = false; }
     if (index == m_paTempIdx)    m_paTempIdx = -1;
     if (index == m_supplyIdx) {
         m_supplyIdx = -1;
@@ -312,6 +318,10 @@ void MeterModel::clear()
     m_hwAlcIdx = -1;
     m_swAlcIdx = -1;
     m_paTempIdx = -1;
+    m_scMicIdx = -1;
+    m_scFilt2Idx = -1;
+    m_hasScMicValue = false;
+    m_hasScFilt2Value = false;
     m_supplyIdx = -1;
     m_hasSupplyVoltsValue = false;
     m_ampFwdPwrIdx = -1;
@@ -535,6 +545,7 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
     bool micChanged = false;
     bool hwAlcChangedFlag = false;
     bool swAlcChangedFlag = false;
+    bool txFilterLevelsChangedFlag = false;
     bool hwChanged = false;
     bool ampChanged = false;
     bool tgxlChanged = false;
@@ -640,6 +651,14 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
         } else if (idx == m_swAlcIdx) {
             m_swAlc = v;
             swAlcChangedFlag = true;
+        } else if (idx == m_scMicIdx) {
+            m_scMic = v;
+            m_hasScMicValue = true;
+            txFilterLevelsChangedFlag = true;
+        } else if (idx == m_scFilt2Idx) {
+            m_scFilt2 = v;
+            m_hasScFilt2Value = true;
+            txFilterLevelsChangedFlag = true;
         } else if (idx == m_paTempIdx) {
             m_paTemp = v;
             hwChanged = true;
@@ -730,6 +749,8 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
         emit this->hwAlcChanged(m_hwAlc);
     if (swAlcChangedFlag)
         emit this->swAlcChanged(m_swAlc);
+    if (txFilterLevelsChangedFlag)
+        emit txFilterLevelsChanged(m_scMic, m_scFilt2);
     if (hwChanged)
         emit hwTelemetryChanged(m_paTemp, m_supplyVolts);
     if (ampChanged)

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -144,6 +144,8 @@ void MeterModel::defineMeter(const MeterDef& def)
         m_swAlcIdx = def.index;
     else if (isTxWaveformMeter(def) && def.name == "SC_MIC")
         m_scMicIdx = def.index;
+    else if (isTxWaveformMeter(def) && def.name == "SC_FILT_1")
+        m_scFilt1Idx = def.index;
     else if (isTxWaveformMeter(def) && def.name == "SC_FILT_2")
         m_scFilt2Idx = def.index;
     else if (def.source != "AMP" && def.name == "PATEMP")
@@ -225,6 +227,7 @@ void MeterModel::removeMeter(int index)
     if (index == m_hwAlcIdx)     m_hwAlcIdx = -1;
     if (index == m_swAlcIdx)     m_swAlcIdx = -1;
     if (index == m_scMicIdx)   { m_scMicIdx = -1;   m_hasScMicValue = false; }
+    if (index == m_scFilt1Idx) { m_scFilt1Idx = -1; m_hasScFilt1Value = false; }
     if (index == m_scFilt2Idx) { m_scFilt2Idx = -1; m_hasScFilt2Value = false; }
     if (index == m_paTempIdx)    m_paTempIdx = -1;
     if (index == m_supplyIdx) {
@@ -319,8 +322,10 @@ void MeterModel::clear()
     m_swAlcIdx = -1;
     m_paTempIdx = -1;
     m_scMicIdx = -1;
+    m_scFilt1Idx = -1;
     m_scFilt2Idx = -1;
     m_hasScMicValue = false;
+    m_hasScFilt1Value = false;
     m_hasScFilt2Value = false;
     m_supplyIdx = -1;
     m_hasSupplyVoltsValue = false;
@@ -655,6 +660,10 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
             m_scMic = v;
             m_hasScMicValue = true;
             txFilterLevelsChangedFlag = true;
+        } else if (idx == m_scFilt1Idx) {
+            m_scFilt1 = v;
+            m_hasScFilt1Value = true;
+            txFilterLevelsChangedFlag = true;
         } else if (idx == m_scFilt2Idx) {
             m_scFilt2 = v;
             m_hasScFilt2Value = true;
@@ -750,7 +759,7 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
     if (swAlcChangedFlag)
         emit this->swAlcChanged(m_swAlc);
     if (txFilterLevelsChangedFlag)
-        emit txFilterLevelsChanged(m_scMic, m_scFilt2);
+        emit txFilterLevelsChanged(m_scMic, m_scFilt1, m_scFilt2);
     if (hwChanged)
         emit hwTelemetryChanged(m_paTemp, m_supplyVolts);
     if (ampChanged)

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -164,14 +164,22 @@ public:
     float scMic() const { return m_scMic; }
     float scFilt1() const { return m_scFilt1; }
     float scFilt2() const { return m_scFilt2; }
-    // Whether a SAMPLE has landed for BOTH -- the same distinction
+    // Whether a SAMPLE has landed for BOTH FILTER TAPS -- the same distinction
     // hasSupplyVoltage() draws above, and load-bearing for the same reason: the
     // index is set when the meter DEFINITION arrives while the value sits at its
     // 0.0f initialiser until a VALUE packet lands.  0 dBFS is a very loud
     // signal, so a comparison keyed on the index alone would read the
     // initialiser as full-scale transmit audio.
     bool hasTxFilterLevels() const
-    { return m_hasScMicValue && m_hasScFilt1Value && m_hasScFilt2Value; }
+    { return m_hasScFilt1Value && m_hasScFilt2Value; }
+    // Age gap between the two filter taps, ms. They publish at different
+    // rates, so a comparison across them is only meaningful while the pair
+    // is close in time; -1 when either has never produced a sample.
+    qint64 txFilterLevelSkewMs() const;
+    // Resolved for the ACTIVE TX slice; -1 when that slice has no such meter.
+    int scMicIndexForActiveTxSlice() const;
+    int scFilt1IndexForActiveTxSlice() const;
+    int scFilt2IndexForActiveTxSlice() const;
 
     // Convenience: PA heatsink temperature (°C).
     float paTemp() const { return m_paTemp; }
@@ -240,7 +248,7 @@ signals:
     void swAlcChanged(float dbfs);
 
     // Emitted when either side of the TX-filter pair changes (dBFS in, dBFS out).
-    void txFilterLevelsChanged(float scMic, float scFilt1, float scFilt2);
+    void txFilterLevelsChanged(float scFilt1, float scFilt2);
 
     // Emitted when hardware telemetry meters change (PA temp, supply voltage).
     void hwTelemetryChanged(float paTemp, float supplyVolts);
@@ -289,9 +297,17 @@ private:
     int m_compLevelIdx{-1};  // "TX" / "COMP" (instantaneous)
     int m_hwAlcIdx{-1};      // "TX" / "HWALC" — external RCA jack voltage
     int m_swAlcIdx{-1};      // "TX" / "ALC"   — post-software-ALC SSB peak
-    int m_scMicIdx{-1};      // "TX" / "SC_MIC"    — PC/remote audio entering TX
-    int m_scFilt1Idx{-1};    // "TX" / "SC_FILT_1" — after the first TX filter
-    int m_scFilt2Idx{-1};    // "TX" / "SC_FILT_2" — after the second TX filter
+    // Per-slice, exactly like COMPPEAK above: a radio can publish one TX
+    // waveform meter block PER ACTIVE SLICE (6600 uses distinct sourceIndex
+    // values, 8000 repeats "TX- num=0" after each SLC block). A single index
+    // per meter would be last-definition-wins, and the TX-filter check would
+    // silently watch some other slice's filter.
+    QMap<int, int> m_scMicIdxByTxSource;    // "TX" / "SC_MIC"    (explicit sourceIndex)
+    QMap<int, int> m_scMicIdxBySlice;       //                    (implicit, num=0)
+    QMap<int, int> m_scFilt1IdxByTxSource;  // "TX" / "SC_FILT_1"
+    QMap<int, int> m_scFilt1IdxBySlice;
+    QMap<int, int> m_scFilt2IdxByTxSource;  // "TX" / "SC_FILT_2"
+    QMap<int, int> m_scFilt2IdxBySlice;
     int m_paTempIdx{-1};     // "RAD" / "PATEMP"
     int m_supplyIdx{-1};     // "RAD" / "+13.8A" (supply voltage, point A = before fuse)
     int m_ampFwdPwrIdx{-1};  // "AMP" / "FWD" (PGXL)

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -162,6 +162,7 @@ public:
     // operator's low/high cut can silence.  Comparing the two is what makes
     // "the TX filter removed the audio" measurable instead of inferred (#4649).
     float scMic() const { return m_scMic; }
+    float scFilt1() const { return m_scFilt1; }
     float scFilt2() const { return m_scFilt2; }
     // Whether a SAMPLE has landed for BOTH -- the same distinction
     // hasSupplyVoltage() draws above, and load-bearing for the same reason: the
@@ -169,7 +170,8 @@ public:
     // 0.0f initialiser until a VALUE packet lands.  0 dBFS is a very loud
     // signal, so a comparison keyed on the index alone would read the
     // initialiser as full-scale transmit audio.
-    bool hasTxFilterLevels() const { return m_hasScMicValue && m_hasScFilt2Value; }
+    bool hasTxFilterLevels() const
+    { return m_hasScMicValue && m_hasScFilt1Value && m_hasScFilt2Value; }
 
     // Convenience: PA heatsink temperature (°C).
     float paTemp() const { return m_paTemp; }
@@ -238,7 +240,7 @@ signals:
     void swAlcChanged(float dbfs);
 
     // Emitted when either side of the TX-filter pair changes (dBFS in, dBFS out).
-    void txFilterLevelsChanged(float scMic, float scFilt2);
+    void txFilterLevelsChanged(float scMic, float scFilt1, float scFilt2);
 
     // Emitted when hardware telemetry meters change (PA temp, supply voltage).
     void hwTelemetryChanged(float paTemp, float supplyVolts);
@@ -288,6 +290,7 @@ private:
     int m_hwAlcIdx{-1};      // "TX" / "HWALC" — external RCA jack voltage
     int m_swAlcIdx{-1};      // "TX" / "ALC"   — post-software-ALC SSB peak
     int m_scMicIdx{-1};      // "TX" / "SC_MIC"    — PC/remote audio entering TX
+    int m_scFilt1Idx{-1};    // "TX" / "SC_FILT_1" — after the first TX filter
     int m_scFilt2Idx{-1};    // "TX" / "SC_FILT_2" — after the second TX filter
     int m_paTempIdx{-1};     // "RAD" / "PATEMP"
     int m_supplyIdx{-1};     // "RAD" / "+13.8A" (supply voltage, point A = before fuse)
@@ -325,10 +328,12 @@ private:
     float m_hwAlc{0.0f};
     float m_swAlc{0.0f};
     float m_scMic{0.0f};
+    float m_scFilt1{0.0f};
     float m_scFilt2{0.0f};
     // Cleared wherever the matching index is, so a level can never
     // outlive the meter it describes. See hasTxFilterLevels().
     bool m_hasScMicValue{false};
+    bool m_hasScFilt1Value{false};
     bool m_hasScFilt2Value{false};
     float m_paTemp{0.0f};
     float m_supplyVolts{0.0f};

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -156,6 +156,21 @@ public:
     // and CW keying envelope.  Drives the ALC gauges in the Phone/CW applet.
     float swAlc() const { return m_swAlc; }
 
+    // Convenience: the TX-filter input/output pair (dBFS, from TX "SC_MIC" and
+    // TX "SC_FILT_2").  SC_MIC is where PC/remote audio enters the TX chain;
+    // SC_FILT_2 is the level after the second TX filter -- the last stage the
+    // operator's low/high cut can silence.  Comparing the two is what makes
+    // "the TX filter removed the audio" measurable instead of inferred (#4649).
+    float scMic() const { return m_scMic; }
+    float scFilt2() const { return m_scFilt2; }
+    // Whether a SAMPLE has landed for BOTH -- the same distinction
+    // hasSupplyVoltage() draws above, and load-bearing for the same reason: the
+    // index is set when the meter DEFINITION arrives while the value sits at its
+    // 0.0f initialiser until a VALUE packet lands.  0 dBFS is a very loud
+    // signal, so a comparison keyed on the index alone would read the
+    // initialiser as full-scale transmit audio.
+    bool hasTxFilterLevels() const { return m_hasScMicValue && m_hasScFilt2Value; }
+
     // Convenience: PA heatsink temperature (°C).
     float paTemp() const { return m_paTemp; }
 
@@ -222,6 +237,9 @@ signals:
     // Drives the in-app ALC gauges; fires during voice peaks and CW keying.
     void swAlcChanged(float dbfs);
 
+    // Emitted when either side of the TX-filter pair changes (dBFS in, dBFS out).
+    void txFilterLevelsChanged(float scMic, float scFilt2);
+
     // Emitted when hardware telemetry meters change (PA temp, supply voltage).
     void hwTelemetryChanged(float paTemp, float supplyVolts);
 
@@ -269,6 +287,8 @@ private:
     int m_compLevelIdx{-1};  // "TX" / "COMP" (instantaneous)
     int m_hwAlcIdx{-1};      // "TX" / "HWALC" — external RCA jack voltage
     int m_swAlcIdx{-1};      // "TX" / "ALC"   — post-software-ALC SSB peak
+    int m_scMicIdx{-1};      // "TX" / "SC_MIC"    — PC/remote audio entering TX
+    int m_scFilt2Idx{-1};    // "TX" / "SC_FILT_2" — after the second TX filter
     int m_paTempIdx{-1};     // "RAD" / "PATEMP"
     int m_supplyIdx{-1};     // "RAD" / "+13.8A" (supply voltage, point A = before fuse)
     int m_ampFwdPwrIdx{-1};  // "AMP" / "FWD" (PGXL)
@@ -304,6 +324,12 @@ private:
     float m_compLevel{0.0f};
     float m_hwAlc{0.0f};
     float m_swAlc{0.0f};
+    float m_scMic{0.0f};
+    float m_scFilt2{0.0f};
+    // Cleared wherever the matching index is, so a level can never
+    // outlive the meter it describes. See hasTxFilterLevels().
+    bool m_hasScMicValue{false};
+    bool m_hasScFilt2Value{false};
     float m_paTemp{0.0f};
     float m_supplyVolts{0.0f};
     // Set when a "+13.8A" value packet lands, cleared wherever m_supplyIdx is,

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1259,10 +1259,16 @@ void RadioModel::evaluateTxFilterAudioLoss(float scMic, float scFilt1, float scF
     // transmission actually making 2.3 W. The attenuation is the quantity the
     // comparison is built from, so it is settled by construction and cannot
     // contradict the reason the message appeared.
+    // State the OBSERVATION, not a culprit. This measures that the audio and
+    // the passband do not overlap; it cannot tell whether the cuts were moved
+    // or the audio's pitch was. Blaming the filter outright sends an operator
+    // whose cuts are fine looking in the wrong place -- which is exactly how
+    // the first screenshot of this feature was misread.
     emit txFilterBlockingAudio(
-        tr("TX filter is removing your transmit audio"),
+        tr("Almost no transmit audio is getting through the TX filter"),
         tr("Passband %1-%2 Hz is cutting it by %3 dB, so almost no RF is "
-           "leaving the radio. Check TX Low/High Cut.")
+           "leaving the radio. Check your TX Low/High Cut, and the pitch of "
+           "your transmit audio.")
             .arg(m_transmitModel.txFilterLow())
             .arg(m_transmitModel.txFilterHigh())
             .arg(qRound(scFilt1 - scFilt2)),

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1199,6 +1199,11 @@ constexpr float kTxFilterKillDeltaDb = 40.0f;
 // key-down -- SC_MIC rises before SC_FILT_2 settles -- so a single sample is
 // not evidence. Meters arrive at roughly 10-20 Hz, so this is ~0.3 s.
 constexpr int kTxFilterKillConfirmSamples = 5;
+// The two filter taps publish at 20 fps and 10 fps. Emission is tied to the
+// slower one, so in steady state the partner is ~50 ms old; anything much
+// beyond that means one tap has stalled and the pair no longer describes the
+// same moment.
+constexpr qint64 kTxFilterMaxTapSkewMs = 150;
 }  // namespace
 
 // A TX low/high cut that excludes the transmit audio produces no RF, and nothing
@@ -1206,7 +1211,7 @@ constexpr int kTxFilterKillConfirmSamples = 5;
 // The radio publishes both sides of the filter, so this MEASURES the loss rather
 // than inferring it from the cut values -- which is what makes it safe to state
 // plainly to the operator instead of as a guess.
-void RadioModel::evaluateTxFilterAudioLoss(float scMic, float scFilt1, float scFilt2)
+void RadioModel::evaluateTxFilterAudioLoss(float scFilt1, float scFilt2)
 {
     // Our own transmission only. isOperatorTransmitting() is deliberately NOT
     // used here: it is false for DAX transmits, which is exactly the digital
@@ -1217,9 +1222,16 @@ void RadioModel::evaluateTxFilterAudioLoss(float scMic, float scFilt1, float scF
         m_txFilterKillReported = false;
         return;
     }
-    // Both taps must have produced a real sample; see hasTxFilterLevels().
+    // Both filter taps must have produced a real sample; see
+    // hasTxFilterLevels(). They also publish at different rates, so only
+    // compare them while the pair is close in time.
     if (!m_meterModel.hasTxFilterLevels())
         return;
+    const qint64 skewMs = m_meterModel.txFilterLevelSkewMs();
+    if (skewMs < 0 || skewMs > kTxFilterMaxTapSkewMs) {
+        m_txFilterKillSamples = 0;
+        return;
+    }
 
     // CW never routes operator audio through the TX filter, so a low SC_FILT_2
     // there carries no information. Excluded explicitly rather than trusting
@@ -1227,6 +1239,7 @@ void RadioModel::evaluateTxFilterAudioLoss(float scMic, float scFilt1, float scF
     const SliceModel* tx = txSlice();
     if (tx && tx->mode().trimmed().toUpper().startsWith(QStringLiteral("CW"))) {
         m_txFilterKillSamples = 0;
+        m_txFilterKillReported = false;
         return;
     }
 
@@ -1240,8 +1253,14 @@ void RadioModel::evaluateTxFilterAudioLoss(float scMic, float scFilt1, float scF
     // audio inside the passband ran -7.73 -> -5.23 dBFS across the two
     // filter taps, audio outside it -9.79 -> -68.18 -- a wider separation
     // than the mic-referenced comparison, and immune to everything before.
-    const bool audioReachedFilter = scMic   > kTxAudioPresentFloorDbfs
-                                 && scFilt1 > kTxAudioPresentFloorDbfs;
+    // Gate on SC_FILT_1 ALONE, never SC_MIC. SC_MIC is the PC/remote-audio
+    // entry point only: a hardware mic (BAL/LINE/ACC) joins the chain later,
+    // through the CODEC ADC, and never registers there
+    // (docs/architecture/tx-audio-signal-path.md). Requiring SC_MIC would
+    // silently switch this whole check off for every operator on a real
+    // microphone -- the people running tight voice filters in the first
+    // place. SC_FILT_1 proves audio reached the filter whatever path it took.
+    const bool audioReachedFilter = scFilt1 > kTxAudioPresentFloorDbfs;
     const bool filterRemoved      = scFilt2 < scFilt1 - kTxFilterKillDeltaDb;
     if (!audioReachedFilter || !filterRemoved) {
         m_txFilterKillSamples = 0;
@@ -1295,6 +1314,15 @@ RadioModel::RadioModel(QObject* parent)
     // audio can be reported to the operator instead of failing silently (#4649).
     connect(&m_meterModel, &MeterModel::txFilterLevelsChanged,
             this, &RadioModel::evaluateTxFilterAudioLoss);
+    // Arm/disarm on the TX edge, NOT from the meter path. A radio with
+    // met_in_rx off publishes no TX- meters between transmissions, so a latch
+    // cleared only inside the meter handler would never clear at all -- the
+    // card would appear on the first bad transmission of a session and never
+    // again.
+    connect(this, &RadioModel::radioTransmittingChanged, this, [this](bool) {
+        m_txFilterKillSamples = 0;
+        m_txFilterKillReported = false;
+    });
     qRegisterMetaType<ProfileDelta>();
     qRegisterMetaType<AmpDelta>();
     qRegisterMetaType<TunerDelta>();

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1173,17 +1173,28 @@ void RadioModel::teardownBackend()
 }
 
 namespace {
-// Audio must actually be entering the TX chain before a low post-filter level
+// Audio must actually be reaching the filter before a low post-filter level
 // means anything. Silence reads the meter floor (-150 dBFS on a FLEX-6700);
-// a live tone measured -12 dBFS. -60 sits far above the floor and far below
-// any real transmit audio.
+// a live tone measured -12 dBFS at SC_MIC and -9.8 at SC_FILT_1. -60 sits
+// far above the floor and far below any real transmit audio.
 constexpr float kTxAudioPresentFloorDbfs = -60.0f;
-// How far SC_FILT_2 must sit below SC_MIC before we call the audio "removed".
-// Measured on a FLEX-6700 (#4649): audio INSIDE the passband left filter 2
-// ABOVE its own input (-12.32 -> -5.23 dBFS; there are gain stages between the
-// taps), while audio OUTSIDE it collapsed to -68.16 dBFS -- a 56 dB drop with
-// forward power falling 43.75 W -> 2.0 W. 30 dB sits clearly inside that cliff.
-constexpr float kTxFilterKillDeltaDb = 30.0f;
+// How far SC_FILT_2 must sit below SC_FILT_1 before we call the audio
+// "removed". Chosen from a tone sweep across the filter skirt on a FLEX-6700
+// with a 100-2900 Hz passband (#4649), because the corner is soft and a
+// too-eager threshold produces a confidently wrong message:
+//
+//   tone   SC_FILT_1 -> SC_FILT_2   delta    forward power
+//   2800     -7.76      -5.56       -2.2 dB    43.66 W   (in band)
+//   2900     -7.70     -11.31        3.6 dB    38.9  W   (at the cut, still fine)
+//   3000     -8.30     -38.95       30.7 dB    17.73 W   (attenuated, NOT dead)
+//   3100     -8.88     -64.98       56.1 dB     5.82 W   (effectively dead)
+//   3300     -9.16     -55.85       46.7 dB     3.08 W
+//
+// At 30 dB this fires while the radio is still making 17.7 W -- 40% of full
+// output -- which would be reported to the operator as a dead transmitter.
+// 40 dB sits between the 30.7 dB case we must NOT flag and the 46.7 dB case we
+// must, and only fires once output has collapsed to a few percent.
+constexpr float kTxFilterKillDeltaDb = 40.0f;
 // Consecutive qualifying meter packets before we speak. The chain ramps at
 // key-down -- SC_MIC rises before SC_FILT_2 settles -- so a single sample is
 // not evidence. Meters arrive at roughly 10-20 Hz, so this is ~0.3 s.
@@ -1195,7 +1206,7 @@ constexpr int kTxFilterKillConfirmSamples = 5;
 // The radio publishes both sides of the filter, so this MEASURES the loss rather
 // than inferring it from the cut values -- which is what makes it safe to state
 // plainly to the operator instead of as a guess.
-void RadioModel::evaluateTxFilterAudioLoss(float scMic, float scFilt2)
+void RadioModel::evaluateTxFilterAudioLoss(float scMic, float scFilt1, float scFilt2)
 {
     // Our own transmission only. isOperatorTransmitting() is deliberately NOT
     // used here: it is false for DAX transmits, which is exactly the digital
@@ -1220,9 +1231,20 @@ void RadioModel::evaluateTxFilterAudioLoss(float scMic, float scFilt2)
         }
     }
 
-    const bool audioPresent   = scMic > kTxAudioPresentFloorDbfs;
-    const bool filterRemoved  = scFilt2 < scMic - kTxFilterKillDeltaDb;
-    if (!audioPresent || !filterRemoved) {
+    // Measure ACROSS THE FILTER STAGES, not from the microphone tap.
+    // SC_MIC -> SC_FILT_2 spans mic gain, the equaliser, the speech
+    // processor and ALC, so anything upstream collapsing -- a closed DEXP
+    // gate, mic gain at zero, a processor fault -- would be reported to the
+    // operator as a TX-filter problem, which is a confident wrong answer.
+    // SC_FILT_1 sits immediately before the stage the operator's low/high
+    // cut actually controls, so this pair isolates it. Measured (#4649):
+    // audio inside the passband ran -7.73 -> -5.23 dBFS across the two
+    // filter taps, audio outside it -9.79 -> -68.18 -- a wider separation
+    // than the mic-referenced comparison, and immune to everything before.
+    const bool audioReachedFilter = scMic   > kTxAudioPresentFloorDbfs
+                                 && scFilt1 > kTxAudioPresentFloorDbfs;
+    const bool filterRemoved      = scFilt2 < scFilt1 - kTxFilterKillDeltaDb;
+    if (!audioReachedFilter || !filterRemoved) {
         m_txFilterKillSamples = 0;
         return;
     }
@@ -1232,13 +1254,19 @@ void RadioModel::evaluateTxFilterAudioLoss(float scMic, float scFilt2)
         return;   // once per transmission, not once per meter packet
     m_txFilterKillReported = true;
 
-    // Name the actual cut values: the whole complaint is that the operator
-    // cannot tell this apart from a dead DAX stream or a hardware fault.
+    // Name the actual cut values and the measured attenuation. Deliberately
+    // NOT the forward-power reading: this fires ~0.3 s after key-down, before
+    // the smoothed power meter has settled, so it reported "0.0 W" on a
+    // transmission actually making 2.3 W. The attenuation is the quantity the
+    // comparison is built from, so it is settled by construction and cannot
+    // contradict the reason the message appeared.
     emit txFilterBlockingAudio(
-        tr("TX filter is removing your transmit audio - passband %1-%2 Hz, "
-           "no RF is being produced. Check TX Low/High Cut.")
+        tr("TX filter is removing your transmit audio - passband %1-%2 Hz "
+           "is cutting it by %3 dB, so almost no RF is leaving the radio. "
+           "Check TX Low/High Cut.")
             .arg(m_transmitModel.txFilterLow())
-            .arg(m_transmitModel.txFilterHigh()));
+            .arg(m_transmitModel.txFilterHigh())
+            .arg(qRound(scFilt1 - scFilt2)));
 }
 
 RadioModel::RadioModel(QObject* parent)

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1224,11 +1224,10 @@ void RadioModel::evaluateTxFilterAudioLoss(float scMic, float scFilt1, float scF
     // CW never routes operator audio through the TX filter, so a low SC_FILT_2
     // there carries no information. Excluded explicitly rather than trusting
     // SC_MIC to sit at the floor during CW -- that has not been measured.
-    if (const SliceModel* tx = txSlice()) {
-        if (tx->mode().trimmed().toUpper().startsWith(QStringLiteral("CW"))) {
-            m_txFilterKillSamples = 0;
-            return;
-        }
+    const SliceModel* tx = txSlice();
+    if (tx && tx->mode().trimmed().toUpper().startsWith(QStringLiteral("CW"))) {
+        m_txFilterKillSamples = 0;
+        return;
     }
 
     // Measure ACROSS THE FILTER STAGES, not from the microphone tap.
@@ -1261,12 +1260,13 @@ void RadioModel::evaluateTxFilterAudioLoss(float scMic, float scFilt1, float scF
     // comparison is built from, so it is settled by construction and cannot
     // contradict the reason the message appeared.
     emit txFilterBlockingAudio(
-        tr("TX filter is removing your transmit audio - passband %1-%2 Hz "
-           "is cutting it by %3 dB, so almost no RF is leaving the radio. "
-           "Check TX Low/High Cut.")
+        tr("TX filter is removing your transmit audio"),
+        tr("Passband %1-%2 Hz is cutting it by %3 dB, so almost no RF is "
+           "leaving the radio. Check TX Low/High Cut.")
             .arg(m_transmitModel.txFilterLow())
             .arg(m_transmitModel.txFilterHigh())
-            .arg(qRound(scFilt1 - scFilt2)));
+            .arg(qRound(scFilt1 - scFilt2)),
+        tx ? tx->panId() : QString());
 }
 
 RadioModel::RadioModel(QObject* parent)

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1172,6 +1172,75 @@ void RadioModel::teardownBackend()
     m_backendPanBandwidthMhz.clear();
 }
 
+namespace {
+// Audio must actually be entering the TX chain before a low post-filter level
+// means anything. Silence reads the meter floor (-150 dBFS on a FLEX-6700);
+// a live tone measured -12 dBFS. -60 sits far above the floor and far below
+// any real transmit audio.
+constexpr float kTxAudioPresentFloorDbfs = -60.0f;
+// How far SC_FILT_2 must sit below SC_MIC before we call the audio "removed".
+// Measured on a FLEX-6700 (#4649): audio INSIDE the passband left filter 2
+// ABOVE its own input (-12.32 -> -5.23 dBFS; there are gain stages between the
+// taps), while audio OUTSIDE it collapsed to -68.16 dBFS -- a 56 dB drop with
+// forward power falling 43.75 W -> 2.0 W. 30 dB sits clearly inside that cliff.
+constexpr float kTxFilterKillDeltaDb = 30.0f;
+// Consecutive qualifying meter packets before we speak. The chain ramps at
+// key-down -- SC_MIC rises before SC_FILT_2 settles -- so a single sample is
+// not evidence. Meters arrive at roughly 10-20 Hz, so this is ~0.3 s.
+constexpr int kTxFilterKillConfirmSamples = 5;
+}  // namespace
+
+// A TX low/high cut that excludes the transmit audio produces no RF, and nothing
+// else in the client can tell the operator their filter is the cause (#4649).
+// The radio publishes both sides of the filter, so this MEASURES the loss rather
+// than inferring it from the cut values -- which is what makes it safe to state
+// plainly to the operator instead of as a guess.
+void RadioModel::evaluateTxFilterAudioLoss(float scMic, float scFilt2)
+{
+    // Our own transmission only. isOperatorTransmitting() is deliberately NOT
+    // used here: it is false for DAX transmits, which is exactly the digital
+    // path this defect is reported on. txOwnedByUs() is derived from the
+    // interlock's tx_client_handle, so it covers DAX and TCI alike.
+    if (!m_radioTransmitting || !m_txOwnedByUs) {
+        m_txFilterKillSamples = 0;
+        m_txFilterKillReported = false;
+        return;
+    }
+    // Both taps must have produced a real sample; see hasTxFilterLevels().
+    if (!m_meterModel.hasTxFilterLevels())
+        return;
+
+    // CW never routes operator audio through the TX filter, so a low SC_FILT_2
+    // there carries no information. Excluded explicitly rather than trusting
+    // SC_MIC to sit at the floor during CW -- that has not been measured.
+    if (const SliceModel* tx = txSlice()) {
+        if (tx->mode().trimmed().toUpper().startsWith(QStringLiteral("CW"))) {
+            m_txFilterKillSamples = 0;
+            return;
+        }
+    }
+
+    const bool audioPresent   = scMic > kTxAudioPresentFloorDbfs;
+    const bool filterRemoved  = scFilt2 < scMic - kTxFilterKillDeltaDb;
+    if (!audioPresent || !filterRemoved) {
+        m_txFilterKillSamples = 0;
+        return;
+    }
+    if (++m_txFilterKillSamples < kTxFilterKillConfirmSamples)
+        return;
+    if (m_txFilterKillReported)
+        return;   // once per transmission, not once per meter packet
+    m_txFilterKillReported = true;
+
+    // Name the actual cut values: the whole complaint is that the operator
+    // cannot tell this apart from a dead DAX stream or a hardware fault.
+    emit txFilterBlockingAudio(
+        tr("TX filter is removing your transmit audio - passband %1-%2 Hz, "
+           "no RF is being produced. Check TX Low/High Cut.")
+            .arg(m_transmitModel.txFilterLow())
+            .arg(m_transmitModel.txFilterHigh()));
+}
+
 RadioModel::RadioModel(QObject* parent)
     : QObject(parent)
 {
@@ -1187,6 +1256,11 @@ RadioModel::RadioModel(QObject* parent)
     qRegisterMetaType<RadioDelta>();
     qRegisterMetaType<GpsDelta>();
     qRegisterMetaType<MemoryDelta>();
+
+    // Watch both sides of the TX filter so a cut that silences the transmit
+    // audio can be reported to the operator instead of failing silently (#4649).
+    connect(&m_meterModel, &MeterModel::txFilterLevelsChanged,
+            this, &RadioModel::evaluateTxFilterAudioLoss);
     qRegisterMetaType<ProfileDelta>();
     qRegisterMetaType<AmpDelta>();
     qRegisterMetaType<TunerDelta>();

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -970,6 +970,10 @@ signals:
     void interlockNotificationRequested(const QString& message,
                                         const QString& key,
                                         const QString& panId);
+    // Emitted at most once per transmission when the TX filter is measurably
+    // removing the operator's transmit audio (#4649). Carries a ready-to-show
+    // operator-facing message naming the offending passband.
+    void txFilterBlockingAudio(const QString& message);
     // Emitted when global profile list or active profile changes.
     void globalProfilesChanged();
     void profileDatabaseImportingChanged(bool importing);
@@ -1432,6 +1436,8 @@ private:
     bool        m_txAudioGate{false}; // actual TX audio gate state
     bool        m_radioTransmitting{false}; // raw interlock TX state, any owner
     bool        m_operatorTransmitting{false}; // owned MOX/PTT/VOX (not tune/ATU/TCI/DAX)
+    int         m_txFilterKillSamples{0};      // consecutive qualifying meter packets (#4649)
+    bool        m_txFilterKillReported{false}; // latched, so we speak once per transmission
     QString     m_lastInterlockNotificationKey;
     qint64      m_lastInterlockNotificationMs{0};
     qint64      m_interlockNotificationArmedUntilMs{0};
@@ -1534,6 +1540,7 @@ private:
     QString localPttInterlockMessage(TransmitModel::PttSource source) const;
     QString txFilterFrequencyLimitMessage(int lowHz, int highHz) const;
     QString radioInterlockNotificationMessage(const QMap<QString, QString>& kvs) const;
+    void evaluateTxFilterAudioLoss(float scMic, float scFilt2);
     void armInterlockNotification(TransmitModel::PttSource source = TransmitModel::PttSource::Mox);
     // Recompute the operator-transmit predicate and emit operatorTransmitChanged
     // on a rising/falling edge. Cheap; safe to call from every TX-state path.

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1540,7 +1540,7 @@ private:
     QString localPttInterlockMessage(TransmitModel::PttSource source) const;
     QString txFilterFrequencyLimitMessage(int lowHz, int highHz) const;
     QString radioInterlockNotificationMessage(const QMap<QString, QString>& kvs) const;
-    void evaluateTxFilterAudioLoss(float scMic, float scFilt2);
+    void evaluateTxFilterAudioLoss(float scMic, float scFilt1, float scFilt2);
     void armInterlockNotification(TransmitModel::PttSource source = TransmitModel::PttSource::Mox);
     // Recompute the operator-transmit predicate and emit operatorTransmitChanged
     // on a rising/falling edge. Cheap; safe to call from every TX-state path.

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -973,7 +973,9 @@ signals:
     // Emitted at most once per transmission when the TX filter is measurably
     // removing the operator's transmit audio (#4649). Carries a ready-to-show
     // operator-facing message naming the offending passband.
-    void txFilterBlockingAudio(const QString& message);
+    void txFilterBlockingAudio(const QString& title,
+                               const QString& detail,
+                               const QString& panId);
     // Emitted when global profile list or active profile changes.
     void globalProfilesChanged();
     void profileDatabaseImportingChanged(bool importing);

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1542,7 +1542,7 @@ private:
     QString localPttInterlockMessage(TransmitModel::PttSource source) const;
     QString txFilterFrequencyLimitMessage(int lowHz, int highHz) const;
     QString radioInterlockNotificationMessage(const QMap<QString, QString>& kvs) const;
-    void evaluateTxFilterAudioLoss(float scMic, float scFilt1, float scFilt2);
+    void evaluateTxFilterAudioLoss(float scFilt1, float scFilt2);
     void armInterlockNotification(TransmitModel::PttSource source = TransmitModel::PttSource::Mox);
     // Recompute the operator-transmit predicate and emit operatorTransmitChanged
     // on a rising/falling edge. Cheap; safe to call from every TX-state path.

--- a/tests/meter_model_test.cpp
+++ b/tests/meter_model_test.cpp
@@ -610,6 +610,116 @@ void testSwrLivenessAgreesWithTxMeterFreshness()
 
 } // namespace
 
+
+// --- TX-filter taps (#4649) -------------------------------------------------
+
+// Regression guard for the bug that would have shipped: the check used to also
+// require SC_MIC, which is the PC/remote-audio entry point ONLY. A hardware mic
+// (BAL/LINE/ACC) joins the chain later via the CODEC ADC and never registers
+// there, so requiring it silently disabled the whole feature for every operator
+// on a real microphone. The filter taps alone must be sufficient.
+void testTxFilterLevelsDoNotRequireScMic()
+{
+    MeterModel model;
+    model.defineMeter(slcMeter(10, 0));
+    model.defineMeter(txMeter(29, "SC_FILT_1", "dBFS"));
+    model.defineMeter(txMeter(32, "SC_FILT_2", "dBFS"));
+    model.setActiveTxSlice(0);
+
+    // No SC_MIC meter defined at all, and none ever published.
+    model.updateValues({29, 32}, {rawDb(-8.0f), rawDb(-70.0f)});
+
+    report("TX filter levels are usable without SC_MIC (hardware-mic operators)",
+           model.hasTxFilterLevels()
+               && nearlyEqual(model.scFilt1(), -8.0f)
+               && nearlyEqual(model.scFilt2(), -70.0f));
+}
+
+// SC_FILT_1 publishes at 20 fps and SC_FILT_2 at 10, so emitting on whichever
+// arrives would hand a consumer one fresh value and a partner up to 100 ms old.
+// Publication is tied to the slower tap; a lone SC_FILT_1 update must stay quiet.
+void testTxFilterLevelsPublishOnTheSlowerTap()
+{
+    MeterModel model;
+    model.defineMeter(slcMeter(10, 0));
+    model.defineMeter(txMeter(29, "SC_FILT_1", "dBFS"));
+    model.defineMeter(txMeter(32, "SC_FILT_2", "dBFS"));
+    model.setActiveTxSlice(0);
+
+    int emissions = 0;
+    QObject::connect(&model, &MeterModel::txFilterLevelsChanged,
+                     &model, [&emissions](float, float) { ++emissions; });
+
+    model.updateValues({29}, {rawDb(-8.0f)});          // fast tap alone
+    const bool quietOnFastTap = (emissions == 0);
+
+    model.updateValues({32}, {rawDb(-70.0f)});         // slow tap closes the pair
+    const bool emitsOnSlowTap = (emissions == 1);
+
+    report("TX filter levels publish on the slower tap only",
+           quietOnFastTap && emitsOnSlowTap);
+}
+
+// A radio can publish one TX waveform meter block per active slice. Keying a
+// single index per meter would be last-definition-wins, and the TX-filter check
+// would silently watch some other slice's filter.
+void testActiveTxSliceSelectsTxFilterTaps()
+{
+    MeterModel model;
+    model.defineMeter(slcMeter(10, 0));
+    model.defineMeter(slcMeter(11, 1));
+    model.defineMeter(txMeter(29, "SC_FILT_1", "dBFS", 8));
+    model.defineMeter(txMeter(32, "SC_FILT_2", "dBFS", 8));
+    model.defineMeter(txMeter(59, "SC_FILT_1", "dBFS", 9));
+    model.defineMeter(txMeter(62, "SC_FILT_2", "dBFS", 9));
+
+    model.setActiveTxSlice(1);
+    model.updateValues({29, 32, 59, 62},
+                       {rawDb(-1.0f), rawDb(-2.0f), rawDb(-8.0f), rawDb(-70.0f)});
+
+    report("active TX slice selects its own TX filter taps",
+           model.hasTxFilterLevels()
+               && nearlyEqual(model.scFilt1(), -8.0f)
+               && nearlyEqual(model.scFilt2(), -70.0f));
+}
+
+// The stored levels describe one slice's chain. After a slice change a
+// comparison must not straddle the two.
+void testChangingActiveTxSliceDropsStaleFilterLevels()
+{
+    MeterModel model;
+    model.defineMeter(slcMeter(10, 0));
+    model.defineMeter(slcMeter(11, 1));
+    model.defineMeter(txMeter(29, "SC_FILT_1", "dBFS", 8));
+    model.defineMeter(txMeter(32, "SC_FILT_2", "dBFS", 8));
+    model.setActiveTxSlice(0);
+    model.updateValues({29, 32}, {rawDb(-8.0f), rawDb(-70.0f)});
+    const bool hadLevels = model.hasTxFilterLevels();
+
+    model.setActiveTxSlice(1);
+
+    report("changing the active TX slice drops stale filter levels",
+           hadLevels && !model.hasTxFilterLevels());
+}
+
+// Removing either tap must invalidate the pair rather than leave a level
+// describing a meter that no longer exists.
+void testRemovingATxFilterTapInvalidatesThePair()
+{
+    MeterModel model;
+    model.defineMeter(slcMeter(10, 0));
+    model.defineMeter(txMeter(29, "SC_FILT_1", "dBFS"));
+    model.defineMeter(txMeter(32, "SC_FILT_2", "dBFS"));
+    model.setActiveTxSlice(0);
+    model.updateValues({29, 32}, {rawDb(-8.0f), rawDb(-70.0f)});
+    const bool hadLevels = model.hasTxFilterLevels();
+
+    model.removeMeter(32);
+
+    report("removing a TX filter tap invalidates the pair",
+           hadLevels && !model.hasTxFilterLevels());
+}
+
 int main(int argc, char** argv)
 {
     QCoreApplication app(argc, argv);
@@ -637,6 +747,12 @@ int main(int argc, char** argv)
     testStaleTxMetersDoNotSuppressReceiveMeters();
     testSwrRecoversAfterAFreshSampleFollowsAStaleWindow();
     testSwrLivenessAgreesWithTxMeterFreshness();
+
+    testTxFilterLevelsDoNotRequireScMic();
+    testTxFilterLevelsPublishOnTheSlowerTap();
+    testActiveTxSliceSelectsTxFilterTaps();
+    testChangingActiveTxSliceDropsStaleFilterLevels();
+    testRemovingATxFilterTapInvalidatesThePair();
 
     return g_failed == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

**A large attenuation between the two TX filter stages is almost never something the operator did on purpose.** That is the whole idea. Nobody keys up intending to radiate nothing, so when the audio arrives at the filter and does not come out the other side, that combination is worth saying out loud.

Today nothing says it. A TX low/high cut that excludes the transmit audio keys the radio normally and produces almost no RF, and the client never connects the two. In DIGU/DIGL there is no cue at all — the digital app reports a normal transmit cycle while forward power sits at zero.

This compares the radio's own taps either side of the filter and, when the audio goes in and does not come out, raises a transient card on the panadapter naming the passband and the measured loss.

![TX cuts at 100-300 Hz with ordinary 1500 Hz audio](https://raw.githubusercontent.com/Ozy311/AetherSDR/fix-4649-assets/.pr-assets/4649-statusbar-ab.png)

Captured in the reported scenario: **TX cuts squeezed to 100–300 Hz** with an ordinary **1500 Hz** digital audio offset. `SC_MIC −12.33` → `SC_FILT_1 −7.73` → `SC_FILT_2 −92.70`: the audio reaches the filter untouched and leaves it 85 dB down. Shot on the FLEX-6700 at **0 W**, and the two radio-global settings it changes (`filter_low`/`filter_high`, `rfpower`) are restored afterwards — verified back at 100–2900 Hz / 50%.

## Why

In phone modes the operator hears the monitor drop out and investigates. In **DIGU/DIGL** there is no cue at all: WSJT-X/JS8 report a normal transmit cycle, the radio shows TX, forward power sits at zero, and the operator has no way to connect that to a filter they may have changed days earlier for something unrelated. #4649 has the full report.

The point is that this does **not** have to be inferred from the cut values. The radio publishes both sides of the TX filter as TX-waveform meters, so the condition is measured directly.

## What it keys on

The comparison is **across the filter stages** — `SC_FILT_1` → `SC_FILT_2` — not from the microphone tap. `SC_MIC` → `SC_FILT_2` spans mic gain, the equaliser, the speech processor and ALC, so anything upstream collapsing (a closed DEXP gate, mic gain at zero) would have been reported as a TX-filter fault. `SC_FILT_1` sits immediately before the stage the operator's cuts control.

Threshold and wording come from a second experiment: rather than narrowing the filter, hold the passband at 100–2900 Hz and sweep the **tone** across its edge. That maps the skirt in one keyed pass without touching a radio-global setting, and it is how the 40 dB figure was chosen:

| tone | `SC_FILT_1` | `SC_FILT_2` | Δ | forward power | warns? |
|---|---|---|---|---|---|
| 1500 | −7.73 | −5.23 | −2.5 dB | 43.75 W | no |
| 2800 | −7.76 | −5.56 | −2.2 dB | 43.66 W | no |
| 2900 *(at the cut)* | −7.70 | −11.31 | 3.6 dB | 38.9 W | no |
| 3000 | −8.30 | −38.95 | 30.7 dB | 17.73 W | **no** |
| 3100 | −8.88 | −64.98 | 56.1 dB | 5.82 W | yes |
| 3300 | −9.16 | −55.85 | 46.7 dB | 3.08 W | yes |

Two things fall out of that sweep, and both changed the implementation:

- **The corner is soft.** At 2900 Hz — exactly the high cut — the radio still makes 38.9 W. An earlier 30 dB threshold fired at 3000 Hz while the transmitter was producing **17.7 W**, 40% of full output, and told the operator it was dead. The threshold is now **40 dB**, which sits between the case that must not be flagged and the case that must.
- **Forward power is not settled when the check fires.** The message originally quoted it and printed "0.0 W" on a transmission actually making 2.3 W, because the check fires ~0.3 s after key-down. It now reports the measured attenuation — the quantity the comparison is built from, so it cannot contradict the reason the message appeared.

## False positives — what was tested

Every case below was measured on a FLEX-6700 at **0 W**, with `filter_low`/`filter_high`/`rfpower` recorded and restored afterwards. The number reported is the loss across the filter, `SC_FILT_1 − SC_FILT_2`; the trigger needs **40 dB**.

### 1. Real speech under deliberate DX chopping

Operators intentionally run a tight TX filter on voice so the audio cuts through a pileup. Two synthesized samples were fed into the TX capture path — one male, one female (deliberately bright, to push high-frequency energy) — reading the same script, which stacks low chest tones against heavy sibilance and closes with a phonetic `Kilo Six Oscar Zulu` ident:

| TX filter | male | female |
|---|---|---|
| 100–2900 *(stock)* | −0.73 dB *(gain)* | −0.74 dB *(gain)* |
| 400–2400 *(moderate chop)* | 1.79 | 2.40 |
| 500–2000 *(aggressive chop)* | 2.95 | 2.89 |
| **700–1800** *(extreme, 1100 Hz wide)* | **5.08** | **4.58** |

Worst case **5.08 dB against a 40 dB threshold — 35 dB of margin.** This holds even though the *dominant* energy in both samples sits below 500 Hz (−25.2 / −24.4 dB, against −31.5 / −28.8 for the 500–2000 core), so an aggressive chop is discarding the loudest part of the voice and still nowhere near tripping it. Speech always retains energy inside its own passband, and the mic gain / AGC ahead of the filter recovers the level.

![voice spectra](https://raw.githubusercontent.com/Ozy311/AetherSDR/fix-4649-assets/.pr-assets/4649-voice-spectra.png)

Samples, if anyone wants to reproduce it:
[male](https://raw.githubusercontent.com/Ozy311/AetherSDR/fix-4649-assets/.pr-assets/4649-voice-male-k6ozy.mp3) ·
[female](https://raw.githubusercontent.com/Ozy311/AetherSDR/fix-4649-assets/.pr-assets/4649-voice-female-k6ozy.mp3)

(Those two files were re-cut from the same script so the station ident is complete — `K6OZY` in full. The numbers in the table above were measured on an earlier take of the identical script; the ident word doesn't change what the filter does to the audio, so the measurements stand as recorded.)

### 2. A tone swept across a DX-chopped filter

Same two chop settings, single tone stepped across the voice band. Everything in the voice core leaves the filter with a ~2.4 dB **gain**; the worst legitimate point is 30.5 dB (a 300 Hz tone against a 500–2000 chop), still 10 dB clear. The only cell that fired was a pure 2400 Hz tone against a 500–2000 filter (54.6 dB) — a signal wholly outside the passband, which genuinely produces no output, so the card is correct there rather than false.

### 3. RADE with a matched filter

Raised by NF0T: RADE is a narrow waveform whose recommended TX filter is ~800–2200 Hz to trim sideband noise. Measured with RADE keyed and cuts at 800–2200:

| | `SC_MIC` | `SC_FILT_1` | `SC_FILT_2` | Δ |
|---|---|---|---|---|
| RADE, matched 800–2200 filter | −2.3 … −2.8 | −2.3 … −2.8 | **−1.0 … −1.6** | **−1.0 to −1.6 dB** |

The signal leaves the filter **stronger than it arrives** — about 1.3 dB of gain. Against a 40 dB *loss* threshold that is ~41 dB of margin, on the opposite side of zero.

The signal leaves the filter **stronger than it arrives** — about 1.3 dB of gain.

Note a mode gate could not have covered RADE: it runs under DIGU/DIGL, the very modes this targets. Measurement is what rules it out.

### The common property

A filter *matched* to its signal passes it, so the loss stays near zero — that is why none of the above fires. Only a filter that **excludes** the signal produces the collapse this looks for. The skirt sweep agrees from the other direction: a tone entirely outside the passband, 100 Hz past the cut, still only reached 30.7 dB and deliberately did not fire, because the radio was still making 17.7 W.

## Scope

- `MeterModel` caches the `SC_MIC` / `SC_FILT_1` / `SC_FILT_2` triple alongside the meters it already tracks and publishes them via one new signal. All three values were already arriving and being stored — only the cached indices and accessors are new, so there is no new subscription and no protocol change.
- `RadioModel` compares the pair while transmitting and raises **one** operator-facing message per transmission.
- `SpectrumWidget` gains one entry point that posts a card to the existing panadapter message overlay (the surface interlock notifications already use); `MainWindow` routes the signal to the TX slice's panadapter, falling back to the status bar only when no panadapter can be resolved.
- No persistence, no protocol change, no change to TX behaviour. This only reports.

**Deliberate choices worth review:**

1. **Not gated to DIGU/DIGL**, despite the report being about digital modes. It reproduced in **USB**; the failing stage is the TX filter, which is not mode-specific. What *is* mode-specific is whether the operator notices. Gating to digital would leave the same silent failure in RTTY and FDV.
2. **CW is excluded explicitly** rather than relying on `SC_MIC` sitting at the floor during CW keying. CW never routes operator audio through the TX filter, and I have not measured `SC_MIC` on a CW transmit — so the guard is stated rather than assumed.
3. Ownership uses `txOwnedByUs()` (derived from the interlock's `tx_client_handle`), **not** `isOperatorTransmitting()` — the latter is false for DAX transmits, which is exactly the path this defect is reported on.
4. **Not the status bar.** `showMessage()` hides *every* permanent status-bar widget for its duration — radio model, antenna, GPSDO lock, CPU, network, supply voltage, PA temperature and the TX indicator — while transmitting, which is exactly when those matter. (Measured, not assumed: window geometry is byte-identical at 2274x2100 in both captures, so nothing is resized; the row is evicted and restored.) The card also gets its own id rather than reusing `showInterlockNotification`, whose cards are all titled "Transmit disabled" — nothing is refusing to key here.

## Constitution principle honored

**Principle I — FlexLib is protocol authority.** The warning is raised from the radio's own published TX-chain meters, which are the authority for what actually happened to the audio. The client does not model the filter or predict its effect from the cut values; it reports the radio's measurement of its own signal path, and quotes only quantities that measurement supports.

## Test plan

- [x] Full build clean on Linux (Nobara 43, Qt 6.10.3, gcc 15.2.1) — exit 0, no `error:` / `FAILED:` lines
- [x] `ctest -R "meter|transmit|radio"` — 16/17 pass. The one failure, `cross_needle_meter_test` ("SWR label placement cache is keyed by the rendered font"), **fails identically on unmodified `upstream/main`** on the same machine, so it is pre-existing and unrelated
- [x] Message string and all three meter names verified present in the linked binary
- [x] Verified live in the **reported scenario** — cuts narrowed to 100–300 Hz with ordinary 1500 Hz audio, at 0 W; card appears reporting 85 dB, matching the meters (−7.73 → −92.70). Radio-global settings restored and re-read afterwards
- [x] Also verified with the passband left normal and the tone moved outside it — same condition reached from the other direction (53 dB, −9.87 → −62.63)
- [x] Confirmed the message does **not** appear on unmodified `upstream/main` under the identical condition
- [x] Card verified on the panadapter with the status bar's permanent widgets (TX indicator, PA temp, supply volts) still visible throughout the transmission
- [x] **Filter skirt characterised** (table above) — the partial-overlap region is no longer uncharacterised, and the threshold is placed from that data rather than from the empty-intersection case alone
- [ ] Not exercised on a Hermes-Lite 2 — these are Flex TX-waveform meters, so the detector no-ops there (indices stay `-1`, `hasTxFilterLevels()` false)
- [ ] `SC_MIC` behaviour during a CW transmit is unmeasured; CW is excluded by mode rather than relying on the level gate

<details>
<summary>Full window, message active during transmit</summary>

![full window](https://raw.githubusercontent.com/Ozy311/AetherSDR/fix-4649-assets/.pr-assets/4649-after-full.png)

</details>

## Checklist

- [x] Commits are signed (docs/COMMIT-SIGNING.md)
- [x] No new flat-key AppSettings calls (Principle V) — this change adds no settings
- [x] All meter UI uses MeterSmoother (Principle II) — no meter UI is added here; the meters are read for a diagnostic comparison, not rendered, and smoothing would blur the very edge being detected

Closes #4649
Refs #4640

---

73, Ozy **K6OZY**  · cost: $304.42 · model: claude-opus-5
