### PR TITLE
fix(recorder): refuse client-side recording when PC Audio is off (#4629)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3238,6 +3238,36 @@ target_include_directories(qso_recorder_slice_lifetime_test PRIVATE
 target_link_libraries(qso_recorder_slice_lifetime_test PRIVATE Qt6::Core Qt6::Multimedia)
 add_test(NAME qso_recorder_slice_lifetime_test COMMAND qso_recorder_slice_lifetime_test)
 
+# #4629 — the start policy alone. Pure/constexpr, no Qt at all: the radio-side
+# case (which must NEVER be blocked) is also asserted at compile time.
+add_executable(qso_record_start_policy_test
+    tests/qso_record_start_policy_test.cpp
+)
+target_include_directories(qso_record_start_policy_test PRIVATE src)
+add_test(NAME qso_record_start_policy_test COMMAND qso_record_start_policy_test)
+
+# #4629 — the recorder honoring that policy: Client-Side + PC Audio off must
+# create NO FILE (not merely fail to record), radio-side must still start, and a
+# zero-capture recording must raise an error instead of passing for success.
+add_executable(qso_recorder_pc_audio_guard_test
+    tests/qso_recorder_pc_audio_guard_test.cpp
+    src/core/QsoRecorder.cpp
+    ${AETHER_SETTINGS_SOURCES}
+    src/core/AudioDeviceNegotiator.cpp
+    src/core/AudioFormatNegotiator.cpp
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+    src/core/Resampler.cpp
+    src/models/SliceModel.cpp
+    src/core/DigitalVoiceModeRegistry.cpp
+)
+target_include_directories(qso_recorder_pc_audio_guard_test PRIVATE
+    src
+    ${CMAKE_SOURCE_DIR}/third_party/r8brain
+)
+target_link_libraries(qso_recorder_pc_audio_guard_test PRIVATE Qt6::Core Qt6::Multimedia)
+add_test(NAME qso_recorder_pc_audio_guard_test COMMAND qso_recorder_pc_audio_guard_test)
+
 add_executable(profile_transfer_test
     tests/profile_transfer_test.cpp
 )
@@ -5063,6 +5093,7 @@ set(AETHER_SETTINGS_CONSUMERS
     nr2_settings_model_test
     panadapter_model_rx_antenna_test
     qso_recorder_slice_lifetime_test
+    qso_recorder_pc_audio_guard_test
     band_plan_license_filter_test
     passive_spots_policy_test
     digital_voice_waveform_process_test

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -2417,9 +2417,13 @@ Not a transmit action — no gate.
 `start` / `stop` / `status` (default) / `path` / `dir <path>` (set the output
 directory).
 
-**`start` can be refused** (#4629). Client-Side recording captures the RX audio
+**`start` can be refused** (#4629), and no file is created at all when it is.
+Always check `ok` rather than assuming a start succeeded; a refusal carries a
+machine-readable `reason` and a human `detail`, and reports `path` as empty.
+
+`reason: "pc-audio-disabled"` — Client-Side recording captures the RX audio
 stream that PC Audio creates, so with `PcAudioEnabled=False` there is nothing to
-record and no file is created at all:
+record:
 
 ```json
 → {"cmd":"record","action":"start"}
@@ -2428,9 +2432,20 @@ record and no file is created at all:
    "detail":"Client-Side recording requires PC Audio; no RX audio stream exists."}
 ```
 
-Enable PC Audio, or switch `RecordingMode` to `Radio` — radio-side recording
-runs on the radio and does not depend on PC Audio. Always check `ok` rather than
-assuming a start succeeded.
+`reason: "recording-mode-is-radio"` — `RecordingMode` is `Radio`, so the radio
+is the recorder and this verb has nothing local to drive:
+
+```json
+← {"ok":false,"record":"start","recording":false,"path":"",
+   "reason":"recording-mode-is-radio",
+   "detail":"RecordingMode is Radio, so the radio records and no local file is written. Set RecordingMode=Client to drive the client-side recorder."}
+```
+
+This verb **refuses rather than redirecting**. It is documented as driving the
+client-side recorder and returning the path of a local WAV, so silently issuing
+`slice set <n> record=1` instead would be a radio state change from a call that
+promised a local file — and a harness waiting for that file would get a success
+it cannot use. Set `RecordingMode=Client` if you want a local recording.
 
 ### `station`
 Set this GUI client's **MultiFlex station name** (FlexLib `SetClientStationName`)

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -2417,6 +2417,21 @@ Not a transmit action — no gate.
 `start` / `stop` / `status` (default) / `path` / `dir <path>` (set the output
 directory).
 
+**`start` can be refused** (#4629). Client-Side recording captures the RX audio
+stream that PC Audio creates, so with `PcAudioEnabled=False` there is nothing to
+record and no file is created at all:
+
+```json
+→ {"cmd":"record","action":"start"}
+← {"ok":false,"record":"start","recording":false,"path":"",
+   "reason":"pc-audio-disabled",
+   "detail":"Client-Side recording requires PC Audio; no RX audio stream exists."}
+```
+
+Enable PC Audio, or switch `RecordingMode` to `Radio` — radio-side recording
+runs on the radio and does not depend on PC Audio. Always check `ok` rather than
+assuming a start succeeded.
+
 ### `station`
 Set this GUI client's **MultiFlex station name** (FlexLib `SetClientStationName`)
 so other clients on the radio see the agent driving. This is per-client and

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -5465,12 +5465,29 @@ QJsonObject AutomationServer::doRecord(const QString& action, const QString& val
             {QStringLiteral("recording"), m_qsoRecorder->isRecording()},
             {QStringLiteral("path"), m_qsoRecorder->recordingFilePath()},
         };
-        if (decision == RecordStartDecision::BlockedPcAudioDisabled) {
-            reply.insert(QStringLiteral("reason"),
-                         QStringLiteral("pc-audio-disabled"));
-            reply.insert(QStringLiteral("detail"),
-                         QStringLiteral("Client-Side recording requires PC Audio; "
-                                        "no RX audio stream exists."));
+        if (decision != RecordStartDecision::Allow) {
+            if (decision == RecordStartDecision::BlockedPcAudioDisabled) {
+                reply.insert(QStringLiteral("reason"),
+                             QStringLiteral("pc-audio-disabled"));
+                reply.insert(QStringLiteral("detail"),
+                             QStringLiteral("Client-Side recording requires PC Audio; "
+                                            "no RX audio stream exists."));
+            } else {
+                // Deliberately a REFUSAL, not a redirect to SliceModel. This verb
+                // is documented as driving the client-side recorder and returning
+                // the path of a local WAV; quietly starting a recording on the
+                // RADIO instead would be a hardware state change from a call that
+                // promised a local file, and a harness asking for that file would
+                // get a success it cannot use. Naming the mismatch lets the caller
+                // fix its own setup.
+                reply.insert(QStringLiteral("reason"),
+                             QStringLiteral("recording-mode-is-radio"));
+                reply.insert(QStringLiteral("detail"),
+                             QStringLiteral("RecordingMode is Radio, so the radio "
+                                            "records and no local file is written. "
+                                            "Set RecordingMode=Client to drive the "
+                                            "client-side recorder."));
+            }
             // recordingFilePath() falls back to the LAST finalized recording
             // when no file is open, so a refused start would otherwise hand back
             // a path to an unrelated earlier WAV — observed live while verifying

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -5453,10 +5453,22 @@ QJsonObject AutomationServer::doRecord(const QString& action, const QString& val
     }
     if (a == QLatin1String("start")) {
         // The start can be REFUSED (#4629) — Client-Side mode with PC Audio
-        // disabled has no RX audio stream to record. `ok` already reported that
-        // correctly by reflecting isRecording(), but a bare false told a test
-        // nothing about WHY. Ask the policy first so the reply can name the
-        // cause; this is headless, so the GUI's dialog never appears here.
+        // disabled has no RX audio stream to record, and Radio-Side mode means
+        // the radio is the recorder. `ok` already reported that correctly by
+        // reflecting isRecording(), but a bare false told a test nothing about
+        // WHY, so ask the policy and name the cause.
+        //
+        // A GUI dialog DOES appear for this even when the caller is the bridge:
+        // the app is running with a window, and QsoRecorder::recordingBlocked is
+        // wired to a notice in MainWindow regardless of who triggered the start.
+        // That notice is deliberately non-blocking (MainWindow::
+        // showRecorderNotice) — the blocking form held this reply until a human
+        // dismissed the box, which is exactly how it behaved before that fix.
+        //
+        // wasRecording is captured BEFORE the attempt: with a recording already
+        // in flight, startRecording() is a no-op and the reply must describe the
+        // live recording, not stamp a refusal onto it (review of #4652).
+        const bool wasRecording = m_qsoRecorder->isRecording();
         const RecordStartDecision decision = m_qsoRecorder->evaluateStart();
         m_qsoRecorder->startRecording();
         QJsonObject reply{
@@ -5465,7 +5477,11 @@ QJsonObject AutomationServer::doRecord(const QString& action, const QString& val
             {QStringLiteral("recording"), m_qsoRecorder->isRecording()},
             {QStringLiteral("path"), m_qsoRecorder->recordingFilePath()},
         };
-        if (decision != RecordStartDecision::Allow) {
+        // Only when this call actually failed to start something. A refusal
+        // stamped onto an already-running recording produced
+        // `ok:true, recording:true, path:"", reason:...` — a success carrying a
+        // failure reason, with a valid path blanked out from under the caller.
+        if (!wasRecording && decision != RecordStartDecision::Allow) {
             if (decision == RecordStartDecision::BlockedPcAudioDisabled) {
                 reply.insert(QStringLiteral("reason"),
                              QStringLiteral("pc-audio-disabled"));

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -5452,13 +5452,32 @@ QJsonObject AutomationServer::doRecord(const QString& action, const QString& val
                            {QStringLiteral("dir"), m_qsoRecorder->recordingDir()}};
     }
     if (a == QLatin1String("start")) {
+        // The start can be REFUSED (#4629) — Client-Side mode with PC Audio
+        // disabled has no RX audio stream to record. `ok` already reported that
+        // correctly by reflecting isRecording(), but a bare false told a test
+        // nothing about WHY. Ask the policy first so the reply can name the
+        // cause; this is headless, so the GUI's dialog never appears here.
+        const RecordStartDecision decision = m_qsoRecorder->evaluateStart();
         m_qsoRecorder->startRecording();
-        return QJsonObject{
+        QJsonObject reply{
             {QStringLiteral("ok"), m_qsoRecorder->isRecording()},
             {QStringLiteral("record"), QStringLiteral("start")},
             {QStringLiteral("recording"), m_qsoRecorder->isRecording()},
             {QStringLiteral("path"), m_qsoRecorder->recordingFilePath()},
         };
+        if (decision == RecordStartDecision::BlockedPcAudioDisabled) {
+            reply.insert(QStringLiteral("reason"),
+                         QStringLiteral("pc-audio-disabled"));
+            reply.insert(QStringLiteral("detail"),
+                         QStringLiteral("Client-Side recording requires PC Audio; "
+                                        "no RX audio stream exists."));
+            // recordingFilePath() falls back to the LAST finalized recording
+            // when no file is open, so a refused start would otherwise hand back
+            // a path to an unrelated earlier WAV — observed live while verifying
+            // this fix. Nothing was created, so report nothing.
+            reply.insert(QStringLiteral("path"), QString());
+        }
+        return reply;
     }
     if (a == QLatin1String("stop")) {
         const int durationSecs = m_qsoRecorder->recordingDurationSecs();

--- a/src/core/QsoRecordStartPolicy.h
+++ b/src/core/QsoRecordStartPolicy.h
@@ -1,0 +1,93 @@
+#pragma once
+
+// QsoRecordStartPolicy — may a QSO recording start? (#4629)
+//
+// Client-Side recording captures RadioModel::rxDemodAudioReady, which on a Flex
+// is fed by PanadapterStream::audioDataReady — the `remote_audio_rx` VITA-49
+// stream. That stream is created ONLY when PC Audio is enabled
+// (RadioModel::scheduleRxAudioStreamEnsure, which returns early on
+// PcAudioEnabled=False and removes an already-owned stream). With PC Audio off
+// there is no stream, so feedRxAudio() is never called, and the recorder
+// happily opened a file and wrote a 44-byte WAV header to it, then waited
+// forever for samples that could not arrive. The operator got a correctly named
+// file containing nothing, and no error — because from the recorder's point of
+// view nothing had gone wrong. It received silence-of-absence rather than
+// silence-of-signal, and could not tell the two apart.
+//
+// Gating stream creation on PC Audio is deliberate, not an oversight: #1071
+// removed TCI's auto-create for exactly this reason ("auto-creating the stream
+// overrode the user's explicit PC Audio toggle"). So the fix is not to
+// circumvent the gate but to refuse the recording and say why.
+//
+// RADIO-SIDE RECORDING DOES NOT DEPEND ON PC AUDIO and must never be blocked
+// here. It is `slice set <n> record=1` (SliceModel::setRecordOn) — the radio
+// records to its own storage and the client's audio path is not involved at
+// all. It stays available as the answer for an operator who monitors on the
+// radio's own speaker, so `Allow` for radio-side is a load-bearing case, not a
+// fallthrough.
+//
+// Pure and header-only so every case is unit-testable without a radio, an
+// event loop, or a settings store — mirroring DaxRestorePolicy /
+// KiwiSdrTxMutePolicy / SliceRecreatePolicy.
+//
+// ── Why `backendOwnsRxAudio` is a REQUIRED input, not a refinement ───────────
+//
+// A backend that demodulates in-process feeds the recorder over the seam
+// (RadioModel::wireRxDemodAudioBus binds backendAudioFrameReady when
+// IRadioBackend::ownsRxAudio() is true) and never touches `remote_audio_rx` at
+// all. PC Audio is irrelevant to it, and blocking it would break a recording
+// that works.
+//
+// It is tempting to argue this input is unnecessary because MainWindow
+// force-enables AND LOCKS PC Audio on such a backend. That argument is WRONG,
+// and the counter-example ships today: the lock is gated on
+// `caps.hostModulates && caps.canTransmit` (MainWindow_Session.cpp), and
+//
+//   HL2   ownsRxAudio=true,  hostModulates=true,  canTransmit=true  → locked
+//   Sim   ownsRxAudio=true,  hostModulates=FALSE, canTransmit=FALSE → NOT locked
+//
+// SimBackend is the only backend that owns its RX audio without locking PC
+// Audio on — the operator can freely turn PC Audio off in demo mode, and the
+// sim's audio still reaches the recorder. Two inputs would refuse that
+// recording for a reason that does not apply to it.
+//
+// The caller supplies this live (QsoRecorder holds a provider callback rather
+// than a cached bool) so there is no flag to go stale across a backend swap —
+// a stale flag failing open is the shape of the bug this whole file exists to
+// fix.
+
+namespace AetherSDR {
+
+enum class RecordStartDecision {
+    Allow,
+    // Client-Side mode with PC Audio disabled: the RX audio stream the recorder
+    // depends on does not exist. Starting would produce a header-only WAV.
+    BlockedPcAudioDisabled,
+};
+
+// `clientSideMode`      AppSettings "RecordingMode" == "Client" (the default).
+// `pcAudioEnabled`      AppSettings "PcAudioEnabled" == "True" (the default).
+// `backendOwnsRxAudio`  IRadioBackend::ownsRxAudio() — the connected backend
+//                       demodulates in-process and feeds the recorder over the
+//                       seam, so `remote_audio_rx` (and PC Audio) is not in the
+//                       path at all. False for Flex, true for HL2 and the sim.
+constexpr RecordStartDecision evaluateRecordStart(bool clientSideMode,
+                                                  bool pcAudioEnabled,
+                                                  bool backendOwnsRxAudio)
+{
+    // Radio-side records on the radio. PC Audio is irrelevant to it — never
+    // block, whatever the audio path is doing.
+    if (!clientSideMode)
+        return RecordStartDecision::Allow;
+
+    // Seam-native audio bypasses the PC Audio gate entirely.
+    if (backendOwnsRxAudio)
+        return RecordStartDecision::Allow;
+
+    if (!pcAudioEnabled)
+        return RecordStartDecision::BlockedPcAudioDisabled;
+
+    return RecordStartDecision::Allow;
+}
+
+} // namespace AetherSDR

--- a/src/core/QsoRecordStartPolicy.h
+++ b/src/core/QsoRecordStartPolicy.h
@@ -63,8 +63,32 @@ enum class RecordStartDecision {
     // Client-Side mode with PC Audio disabled: the RX audio stream the recorder
     // depends on does not exist. Starting would produce a header-only WAV.
     BlockedPcAudioDisabled,
+    // The operator selected RADIO-SIDE recording, so the radio is the recorder
+    // and QsoRecorder — which only ever writes a LOCAL file — has no business
+    // running. See the note below on why this is a separate decision.
+    BlockedRecordingModeIsRadio,
 };
 
+// The question this answers is "may THE CLIENT RECORDER start?", not "may a
+// recording start?". The distinction matters: in Radio-Side mode a recording
+// absolutely may start, just not this one — `slice set <n> record=1` goes to
+// the radio and never reaches QsoRecorder.
+//
+// An earlier revision answered the broader question and returned Allow for
+// Radio-Side, reasoning that radio-side recording must never be blocked. That
+// guarantee is real and still holds, but it belongs to the ROUTING layer, not
+// here: MainWindow_Wiring and the MIDI binding both test RecordingMode and send
+// radio-side straight to SliceModel, so this policy is never consulted on the
+// operator's radio-side path at all. Returning Allow instead let a caller that
+// does NOT route — AutomationServer::doRecord — open a local WAV in Radio-Side
+// mode and leave a spurious header-only file behind. Caught in review of the
+// PR that introduced this file.
+//
+// Why its own value rather than folding into BlockedPcAudioDisabled: the reason
+// is not PC Audio, and reporting it as such would put a dialog about PC Audio
+// in front of an operator whose problem is entirely different. A wrong
+// explanation is worse than none.
+//
 // `clientSideMode`      AppSettings "RecordingMode" == "Client" (the default).
 // `pcAudioEnabled`      AppSettings "PcAudioEnabled" == "True" (the default).
 // `backendOwnsRxAudio`  IRadioBackend::ownsRxAudio() — the connected backend
@@ -75,10 +99,11 @@ constexpr RecordStartDecision evaluateRecordStart(bool clientSideMode,
                                                   bool pcAudioEnabled,
                                                   bool backendOwnsRxAudio)
 {
-    // Radio-side records on the radio. PC Audio is irrelevant to it — never
-    // block, whatever the audio path is doing.
+    // Wrong recorder for the operator's chosen mode — the radio is recording,
+    // or should be. Checked first: it is a routing error, not an audio one, and
+    // the audio questions below are meaningless in this mode.
     if (!clientSideMode)
-        return RecordStartDecision::Allow;
+        return RecordStartDecision::BlockedRecordingModeIsRadio;
 
     // Seam-native audio bypasses the PC Audio gate entirely.
     if (backendOwnsRxAudio)

--- a/src/core/QsoRecorder.cpp
+++ b/src/core/QsoRecorder.cpp
@@ -49,8 +49,12 @@ QsoRecorder::QsoRecorder(QObject* parent)
 
 QsoRecorder::~QsoRecorder()
 {
+    // Finalize so an in-flight recording still gets a valid WAV header, but
+    // stay SILENT: this runs during teardown, and the zero-capture diagnostic
+    // below is wired to a modal dialog. Popping one while the window is being
+    // destroyed is both useless and a good way to hang a quit.
     if (m_recording)
-        finalizeFile();
+        finalizeFile(FinalizeReport::Silent);
 }
 
 void QsoRecorder::setRecordingDir(const QString& path)
@@ -89,9 +93,38 @@ int QsoRecorder::recordingDurationSecs() const
 
 // ── Manual control ──────────────────────────────────────────────────────────
 
+// Live read of every policy input — the two settings plus the backend's own
+// answer about whether it feeds us over the seam. Nothing is cached, so a
+// backend swap or a settings change between two starts is picked up for free.
+RecordStartDecision QsoRecorder::evaluateStart() const
+{
+    auto& s = AppSettings::instance();
+    const bool clientSide =
+        s.value("RecordingMode", "Client").toString() == "Client";
+    const bool pcAudio =
+        s.value("PcAudioEnabled", "True").toString() == "True";
+    // No provider installed (unit tests, no radio) reads as false: the Flex
+    // answer, and the one that keeps the guard active rather than silently off.
+    const bool seamNative = m_backendOwnsRxAudio && m_backendOwnsRxAudio();
+    return evaluateRecordStart(clientSide, pcAudio, seamNative);
+}
+
 void QsoRecorder::startRecording()
 {
     if (m_recording) return;
+
+    // Refuse before touching the filesystem (#4629). Creating the file first
+    // and discovering the silence later is precisely the failure being fixed:
+    // it leaves a correctly-named, header-only WAV on disk that looks like a
+    // recorder fault rather than a configuration one.
+    const RecordStartDecision decision = evaluateStart();
+    if (decision != RecordStartDecision::Allow) {
+        qCWarning(lcAudio) << "QsoRecorder: start refused — client-side recording "
+                              "needs PC Audio (no RX audio stream exists)";
+        emit recordingBlocked(decision);
+        return;
+    }
+
     // Re-read settings in case they changed via Radio Setup dialog
     auto& s = AppSettings::instance();
     m_recordingDir = s.value("QsoRecordingDir", m_recordingDir).toString();
@@ -227,7 +260,7 @@ void QsoRecorder::startFile()
     emit recordingStarted(filePath);
 }
 
-void QsoRecorder::finalizeFile()
+void QsoRecorder::finalizeFile(FinalizeReport report)
 {
     {
         std::lock_guard<std::mutex> lock(m_writeMutex);
@@ -241,13 +274,31 @@ void QsoRecorder::finalizeFile()
     m_lastRecordingPath = filePath;
     int durationSecs = static_cast<int>(m_startTime.secsTo(QDateTime::currentDateTimeUtc()));
 
+    const quint32 dataBytes = m_dataBytes;
+
     m_file->close();
     m_file->deleteLater();
     m_file = nullptr;
 
     qCInfo(lcAudio) << "QsoRecorder: stopped recording," << durationSecs << "seconds,"
-                     << m_dataBytes << "bytes";
+                     << dataBytes << "bytes";
     emit recordingStopped(filePath, durationSecs);
+
+    // A recording that captured NOTHING is the #4629 symptom, and until now it
+    // was reported to the operator exactly like a good one — the file exists,
+    // it is named correctly, and it holds a 44-byte header and no audio. The
+    // start guard above catches the known cause (PC Audio off), so reaching
+    // here means something else stranded the feed mid-session: the radio
+    // dropped, the stream was torn down by another client, the backend swapped.
+    // Whatever it was, say so rather than let a silent file pass for success.
+    if (dataBytes == 0 && report == FinalizeReport::Diagnose) {
+        qCWarning(lcAudio) << "QsoRecorder: recording captured no audio:" << filePath;
+        emit recordingError(
+            QStringLiteral("Recording captured no audio — the file contains only a "
+                           "WAV header.\n\nThe RX audio stream stopped or never "
+                           "started. Check that the radio is still connected and "
+                           "that PC Audio is enabled.\n\n") + filePath);
+    }
 }
 
 QString QsoRecorder::buildFilename() const

--- a/src/core/QsoRecorder.cpp
+++ b/src/core/QsoRecorder.cpp
@@ -22,6 +22,12 @@ namespace AetherSDR {
 QsoRecorder::QsoRecorder(QObject* parent)
     : QObject(parent)
 {
+    // recordingBlocked's argument type. Direct connections do not need this,
+    // and every connection today is direct — but registering costs nothing and
+    // means a future queued/cross-thread connection fails at compile time
+    // rather than silently dropping the signal at runtime.
+    qRegisterMetaType<RecordStartDecision>("AetherSDR::RecordStartDecision");
+
     // Default recording directory: ~/Documents/AetherSDR/Recordings
     m_recordingDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)
                      + "/AetherSDR/Recordings";
@@ -111,6 +117,11 @@ RecordStartDecision QsoRecorder::evaluateStart() const
 
 void QsoRecorder::startRecording()
 {
+    beginRecording(StartTrigger::Manual);
+}
+
+void QsoRecorder::beginRecording(StartTrigger trigger)
+{
     if (m_recording) return;
 
     // Refuse before touching the filesystem (#4629). Creating the file first
@@ -119,15 +130,27 @@ void QsoRecorder::startRecording()
     // recorder fault rather than a configuration one.
     const RecordStartDecision decision = evaluateStart();
     if (decision != RecordStartDecision::Allow) {
-        qCWarning(lcAudio) << "QsoRecorder: start refused —"
-                           << (decision == RecordStartDecision::BlockedRecordingModeIsRadio
-                                   ? "Radio-Side recording is selected; the radio "
-                                     "records, not this client"
-                                   : "client-side recording needs PC Audio "
-                                     "(no RX audio stream exists)");
-        emit recordingBlocked(decision);
+        // Auto-record retries on EVERY MOX rising edge, so an unchanged refusal
+        // must be reported once, not once per transmission — the consumer is a
+        // dialog, and one per key-down would make the radio unusable rather than
+        // informative. A deliberate press always gets an answer.
+        const bool alreadyReported = trigger == StartTrigger::Auto
+                                     && m_lastAutoBlocked == decision;
+        m_lastAutoBlocked = decision;
+        if (!alreadyReported) {
+            qCWarning(lcAudio) << "QsoRecorder: start refused —"
+                               << (decision == RecordStartDecision::BlockedRecordingModeIsRadio
+                                       ? "Radio-Side recording is selected; the radio "
+                                         "records, not this client"
+                                       : "client-side recording needs PC Audio "
+                                         "(no RX audio stream exists)");
+            emit recordingBlocked(decision);
+        }
         return;
     }
+    // Cleared on success so a later refusal is reported afresh rather than
+    // being mistaken for a continuation of an earlier run.
+    m_lastAutoBlocked.reset();
 
     // Re-read settings in case they changed via Radio Setup dialog
     auto& s = AppSettings::instance();
@@ -209,9 +232,11 @@ void QsoRecorder::onMoxChanged(bool mox)
     // Only auto-record when in client-side recording mode
     bool clientSide = AppSettings::instance().value("RecordingMode", "Client").toString() == "Client";
     if (mox) {
-        // TX started — begin recording if auto-record is on and not already recording
+        // TX started — begin recording if auto-record is on and not already
+        // recording. Auto trigger: a standing refusal is reported once, not on
+        // every key-down (see beginRecording).
         if (clientSide && m_autoRecord && !m_recording)
-            startRecording();
+            beginRecording(StartTrigger::Auto);
 
         // Reset idle timer on each TX
         m_idleTimer->stop();
@@ -295,7 +320,14 @@ void QsoRecorder::finalizeFile(FinalizeReport report)
     // here means something else stranded the feed mid-session: the radio
     // dropped, the stream was torn down by another client, the backend swapped.
     // Whatever it was, say so rather than let a silent file pass for success.
-    if (dataBytes == 0 && report == FinalizeReport::Diagnose) {
+    // The >= 1s floor keeps a deliberate instant start/stop from being reported
+    // as a fault: under one second the recorder may legitimately not have seen a
+    // single audio block yet, and an error dialog for "you stopped it
+    // immediately" is noise. The tradeoff is a real blind spot — a sub-second
+    // recording that captured nothing is silently accepted — but that case
+    // yields no usable audio either way, whereas a false alarm on every quick
+    // tap trains the operator to dismiss this dialog unread.
+    if (dataBytes == 0 && durationSecs >= 1 && report == FinalizeReport::Diagnose) {
         qCWarning(lcAudio) << "QsoRecorder: recording captured no audio:" << filePath;
         emit recordingError(
             QStringLiteral("Recording captured no audio — the file contains only a "

--- a/src/core/QsoRecorder.cpp
+++ b/src/core/QsoRecorder.cpp
@@ -119,8 +119,12 @@ void QsoRecorder::startRecording()
     // recorder fault rather than a configuration one.
     const RecordStartDecision decision = evaluateStart();
     if (decision != RecordStartDecision::Allow) {
-        qCWarning(lcAudio) << "QsoRecorder: start refused — client-side recording "
-                              "needs PC Audio (no RX audio stream exists)";
+        qCWarning(lcAudio) << "QsoRecorder: start refused —"
+                           << (decision == RecordStartDecision::BlockedRecordingModeIsRadio
+                                   ? "Radio-Side recording is selected; the radio "
+                                     "records, not this client"
+                                   : "client-side recording needs PC Audio "
+                                     "(no RX audio stream exists)");
         emit recordingBlocked(decision);
         return;
     }

--- a/src/core/QsoRecorder.h
+++ b/src/core/QsoRecorder.h
@@ -15,6 +15,7 @@
 #include <atomic>
 #include <functional>
 #include <mutex>
+#include <optional>
 
 class QAudioSink;
 
@@ -160,6 +161,19 @@ private:
     // for the destructor — see the comment there.
     enum class FinalizeReport { Diagnose, Silent };
 
+    // Who asked. A refusal is reported EVERY time for a deliberate act (the
+    // operator pressed record and is owed an answer), but only on the first of
+    // a repeating run for auto-record — which retries on every MOX rising edge
+    // and would otherwise raise one notification per key-down for as long as
+    // the condition lasts.
+    enum class StartTrigger { Manual, Auto };
+    void beginRecording(StartTrigger trigger);
+
+    // Last refusal already reported for an auto-record attempt; cleared when a
+    // recording actually starts or the decision changes, so a genuinely new
+    // problem is never swallowed.
+    std::optional<RecordStartDecision> m_lastAutoBlocked;
+
     void startFile();
     void finalizeFile(FinalizeReport report = FinalizeReport::Diagnose);
     QString buildFilename() const;
@@ -218,3 +232,10 @@ private:
 };
 
 } // namespace AetherSDR
+
+// recordingBlocked carries this by value. Every connection today is direct
+// (same thread), which needs no registration — but a queued or cross-thread
+// connection would fail at RUNTIME with an unregistered type, which is a poor
+// way to find out. Declared here rather than in QsoRecordStartPolicy.h so that
+// header stays free of Qt entirely and its unit test can link without it.
+Q_DECLARE_METATYPE(AetherSDR::RecordStartDecision)

--- a/src/core/QsoRecorder.h
+++ b/src/core/QsoRecorder.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "QsoRecordStartPolicy.h"
+
 #include <QAudio>
 #include <QAudioDevice>
 #include <QBuffer>
@@ -11,6 +13,7 @@
 #include <QString>
 #include <QTimer>
 #include <atomic>
+#include <functional>
 #include <mutex>
 
 class QAudioSink;
@@ -38,6 +41,11 @@ class TransmitModel;
 // Recording triggers:
 //   - Auto: starts when MOX goes true (first TX), stops after idle timeout
 //   - Manual: startRecording() / stopRecording()
+//
+// A start can be REFUSED — see QsoRecordStartPolicy.h. startRecording() then
+// emits recordingBlocked() and creates no file at all. Callers must not assume
+// a start succeeded; check isRecording() (this class lives below the UI seam
+// and cannot show a dialog itself, so the GUI owns the operator-facing message).
 //
 // Output: 24 kHz stereo int16 WAV (matches AudioEngine native format).
 
@@ -82,6 +90,24 @@ public:
     bool isPlaying() const { return m_playing; }
     bool hasLastRecording() const { return !m_lastRecordingPath.isEmpty(); }
 
+    // Answers "does the connected backend demodulate in-process?"
+    // (IRadioBackend::ownsRxAudio) for the start policy. A CALLBACK, not a
+    // cached bool, deliberately: it is read fresh on every start, so a backend
+    // swap cannot leave a stale flag behind — and a stale flag failing open is
+    // the exact shape of #4629. Unset (the default) reads as false, which is
+    // right for a Flex and for no radio at all.
+    void setBackendOwnsRxAudioProvider(std::function<bool()> provider)
+    {
+        m_backendOwnsRxAudio = std::move(provider);
+    }
+
+    // Would startRecording() be allowed right now? Reads the same live settings
+    // and the same provider startRecording() does, so callers that want to ask
+    // BEFORE committing to a UI state change (the automation bridge, wanting a
+    // reason for its reply) get exactly the answer the guard will give. No
+    // side effects.
+    RecordStartDecision evaluateStart() const;
+
     // Path of the in-progress recording (while recording) else the last
     // finalized one; empty if neither. Used by the automation bridge to locate
     // the WAV for capture-file verification.
@@ -117,6 +143,11 @@ signals:
     void recordingStarted(const QString& filePath);
     void recordingStopped(const QString& filePath, int durationSecs);
     void recordingError(const QString& error);
+    // A start was refused before any file was created (#4629). Carries the
+    // REASON, not prose: the operator-facing wording (and its tr()) belongs to
+    // the GUI, and src/core must not depend on QtWidgets — see
+    // .github/workflows/engine-boundary.yml EB1/EB2.
+    void recordingBlocked(AetherSDR::RecordStartDecision reason);
     void playbackStarted();
     void playbackStopped();
     void muteRxRequested(bool mute);  // mute live RX during playback
@@ -125,8 +156,12 @@ private slots:
     void onPlaybackSinkState(QAudio::State state);
 
 private:
+    // Whether finalizeFile() may raise the zero-capture diagnostic. Silent is
+    // for the destructor — see the comment there.
+    enum class FinalizeReport { Diagnose, Silent };
+
     void startFile();
-    void finalizeFile();
+    void finalizeFile(FinalizeReport report = FinalizeReport::Diagnose);
     QString buildFilename() const;
     static QString sanitizeForPath(const QString& s);
     void writeWavHeader();
@@ -170,6 +205,10 @@ private:
 
     // Thread safety for audio feed paths
     mutable std::mutex  m_writeMutex;
+
+    // See setBackendOwnsRxAudioProvider(). Null until MainWindow installs it,
+    // and null reads as false — the Flex answer, and the safe one.
+    std::function<bool()> m_backendOwnsRxAudio;
 
     // WAV format constants (matching AudioEngine native format)
     static constexpr int SAMPLE_RATE = 24000;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1198,6 +1198,47 @@ MainWindow::MainWindow(QWidget* parent)
         }
     });
 
+    // A backend that demodulates in-process (HL2, the sim) feeds the recorder
+    // over the seam and never uses `remote_audio_rx`, so the PC Audio guard
+    // below must not apply to it. Read live rather than cached — the sim in
+    // particular does NOT lock PC Audio on (it neither host-modulates nor
+    // transmits), so this is load-bearing, not belt-and-braces. See
+    // QsoRecordStartPolicy.h.
+    m_qsoRecorder->setBackendOwnsRxAudioProvider([this]() {
+        auto* backend = m_radioModel.backend();
+        return backend && backend->ownsRxAudio();
+    });
+
+    // A refused start (#4629). The recorder lives below the UI seam and can only
+    // report the REASON — the wording is ours. Informational only, deliberately:
+    // an "Enable PC Audio and record" action button would flip a setting the
+    // operator turned off on purpose, which is the behaviour #1071 removed.
+    connect(m_qsoRecorder, &QsoRecorder::recordingBlocked, this,
+            [this](AetherSDR::RecordStartDecision reason) {
+        if (reason != AetherSDR::RecordStartDecision::BlockedPcAudioDisabled)
+            return;
+        QMessageBox::warning(this, tr("PC Audio Required for Client-Side Recording"),
+            tr("Client-Side recording captures the same RX audio stream that PC "
+               "Audio uses, so it cannot record while PC Audio is off. No file "
+               "was created.\n\n"
+               "To record while still listening on the radio itself: enable PC "
+               "Audio in the title bar, set master volume to 0, and check that "
+               "Radio Settings → Receive → \"Mute local audio when "
+               "remote\" is Disabled.\n\n"
+               "Or switch to Radio Side recording in Radio Settings → "
+               "Recording. That records on the radio and does not use PC Audio."));
+    });
+
+    // Recorder failures that were previously silent: the directory could not be
+    // created, the file could not be opened, or the recording captured nothing
+    // (#4629). These have been emitted since the feature shipped with NOTHING
+    // connected to them, so every one of them reached the operator as a missing
+    // or empty file and no explanation.
+    connect(m_qsoRecorder, &QsoRecorder::recordingError, this,
+            [this](const QString& error) {
+        QMessageBox::warning(this, tr("QSO Recording"), error);
+    });
+
     // PUDU TX monitor — captures post-PooDoo TX int16 audio, plays
     // back through the RX sink so the user can hear what their chain
     // is producing without keying the radio.  Registered with

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1215,6 +1215,20 @@ MainWindow::MainWindow(QWidget* parent)
     // operator turned off on purpose, which is the behaviour #1071 removed.
     connect(m_qsoRecorder, &QsoRecorder::recordingBlocked, this,
             [this](AetherSDR::RecordStartDecision reason) {
+        if (reason == AetherSDR::RecordStartDecision::BlockedRecordingModeIsRadio) {
+            // Unreachable from the GUI — every operator-facing path tests
+            // RecordingMode and sends radio-side to SliceModel without ever
+            // touching this recorder. Handled rather than swallowed because a
+            // silently discarded refusal is the failure mode this whole change
+            // exists to remove; if a future caller forgets to route, this says
+            // so instead of leaving a stray header-only WAV.
+            QMessageBox::warning(this, tr("Radio Side Recording Is Selected"),
+                tr("The radio is doing the recording, so the client recorder was "
+                   "not started and no local file was created.\n\n"
+                   "Switch to Client Side in Radio Settings → Recording if you "
+                   "want the recording saved on this computer instead."));
+            return;
+        }
         if (reason != AetherSDR::RecordStartDecision::BlockedPcAudioDisabled)
             return;
         QMessageBox::warning(this, tr("PC Audio Required for Client-Side Recording"),

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1222,7 +1222,8 @@ MainWindow::MainWindow(QWidget* parent)
             // silently discarded refusal is the failure mode this whole change
             // exists to remove; if a future caller forgets to route, this says
             // so instead of leaving a stray header-only WAV.
-            QMessageBox::warning(this, tr("Radio Side Recording Is Selected"),
+            showRecorderNotice(QStringLiteral("recording-mode-is-radio"),
+                tr("Radio Side Recording Is Selected"),
                 tr("The radio is doing the recording, so the client recorder was "
                    "not started and no local file was created.\n\n"
                    "Switch to Client Side in Radio Settings → Recording if you "
@@ -1231,7 +1232,8 @@ MainWindow::MainWindow(QWidget* parent)
         }
         if (reason != AetherSDR::RecordStartDecision::BlockedPcAudioDisabled)
             return;
-        QMessageBox::warning(this, tr("PC Audio Required for Client-Side Recording"),
+        showRecorderNotice(QStringLiteral("pc-audio-disabled"),
+            tr("PC Audio Required for Client-Side Recording"),
             tr("Client-Side recording captures the same RX audio stream that PC "
                "Audio uses, so it cannot record while PC Audio is off. No file "
                "was created.\n\n"
@@ -1250,7 +1252,11 @@ MainWindow::MainWindow(QWidget* parent)
     // or empty file and no explanation.
     connect(m_qsoRecorder, &QsoRecorder::recordingError, this,
             [this](const QString& error) {
-        QMessageBox::warning(this, tr("QSO Recording"), error);
+        // One key for all recorder errors: auto-record's start/idle-stop cycle
+        // can raise the zero-capture diagnostic once per over, and stacking a
+        // modal per cycle would be worse than the silence it replaced.
+        showRecorderNotice(QStringLiteral("recorder-error"),
+                           tr("QSO Recording"), error);
     });
 
     // PUDU TX monitor — captures post-PooDoo TX int16 audio, plays
@@ -6338,6 +6344,45 @@ bool MainWindow::activateMemorySpot(int memoryIndex, const QString& preferredPan
     if (!repeaterFixup.isEmpty())
         m_radioModel.sendCommand(repeaterFixup);
     return true;
+}
+
+// QSO-recorder notices (#4629 review). Two properties the blocking
+// QMessageBox::warning() convenience does not have, both of which turned out to
+// matter:
+//
+//   NON-BLOCKING. warning() spins a nested event loop until the operator
+//   clicks. The producers here are the automation bridge's reply path — where
+//   it stalled `record start` until a human dismissed the box, observed
+//   directly while testing this branch — and QsoRecorder::onMoxChanged, where
+//   it would block the GUI thread mid-transmission.
+//
+//   DEDUPED. Auto-record retries on every MOX rising edge and the zero-capture
+//   diagnostic can fire once per over, so a repeating condition would stack a
+//   box per transmission, each one re-entering the event loop of the last.
+//   QsoRecorder suppresses repeats at the source for auto-record; this is the
+//   backstop that holds regardless of which producer fires.
+void MainWindow::showRecorderNotice(const QString& key,
+                                    const QString& title,
+                                    const QString& text)
+{
+    if (m_recorderNotice) {
+        if (m_recorderNoticeKey == key) {
+            // Same cause still unacknowledged — surface the existing box rather
+            // than adding another saying the same thing.
+            m_recorderNotice->raise();
+            m_recorderNotice->activateWindow();
+            return;
+        }
+        // A different problem supersedes the old message.
+        m_recorderNotice->close();
+    }
+
+    auto* box = new QMessageBox(QMessageBox::Warning, title, text,
+                                QMessageBox::Ok, this);
+    box->setAttribute(Qt::WA_DeleteOnClose);
+    m_recorderNotice = box;
+    m_recorderNoticeKey = key;
+    box->open();   // NOT exec(): returns immediately, no nested event loop
 }
 
 void MainWindow::applyMasterVolume(int pct)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -75,6 +75,8 @@
 #include <QMainWindow>
 #include <QSplitter>
 #include <QPointer>
+
+class QMessageBox;
 #include <QLabel>
 #include <QList>
 #include <QMenu>
@@ -909,6 +911,20 @@ private:
     bool              m_audioDeviceDialogOpen{false};
     NetworkDiagnosticsHistory* m_networkDiagnosticsHistory{nullptr};
     QsoRecorder*      m_qsoRecorder{nullptr};
+    // The one live QSO-recorder notice, if any (#4629 review). Held so a
+    // repeating condition raises the existing dialog instead of stacking a new
+    // one on top — QMessageBox::warning() spins a nested event loop, so a
+    // stacked run is both unclosable-feeling and re-entrant. QPointer because
+    // the box is WA_DeleteOnClose and may vanish without telling us.
+    QPointer<QMessageBox> m_recorderNotice;
+    QString               m_recorderNoticeKey;
+    // Show a non-blocking recorder notice, deduped on `key`. Non-blocking is
+    // the load-bearing part: the blocking form stalls the caller, which for
+    // this signal is either the automation bridge's reply path or the MOX
+    // handler mid-transmission.
+    void showRecorderNotice(const QString& key,
+                            const QString& title,
+                            const QString& text);
     std::unique_ptr<AutomationServer> m_automation;  // agent bridge (#3646); nullptr when off
     ClientPuduMonitor* m_finalMonitor{nullptr};
     AudioOutputRouter* m_outputRouter{nullptr};   // registry for output-following sinks (#3306)

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -5174,7 +5174,11 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
                 m_qsoRecorder->startRecording();
             else
                 m_qsoRecorder->stopRecording();
-            w->setRecordOn(on);  // drive pulse animation for client-side
+            // Follow what the recorder ACTUALLY did, not what was asked (#4629).
+            // startRecording() can refuse (PC Audio off, unwritable directory),
+            // and driving the pulse from `on` latched the button red over a
+            // recording that never began.
+            w->setRecordOn(m_qsoRecorder->isRecording());
         } else {
             if (auto* sl = m_radioModel.slice(sliceId))
                 sl->setRecordOn(on);

--- a/tests/qso_record_start_policy_test.cpp
+++ b/tests/qso_record_start_policy_test.cpp
@@ -1,0 +1,82 @@
+// Unit test for QsoRecordStartPolicy (#4629).
+//
+// Client-Side recording depends on the `remote_audio_rx` stream, which exists
+// only while PC Audio is enabled. Starting anyway produced a correctly named,
+// header-only 44-byte WAV and no error at all.
+//
+// The case that matters most here is the one that must NOT change:
+// RADIO-SIDE RECORDING DOES NOT DEPEND ON PC AUDIO. It is a `slice set <n>
+// record=1` command handled entirely by the radio, and it is the standing
+// answer for an operator who monitors on the radio's own speaker. If the guard
+// ever starts blocking it, that operator loses the one path that still worked.
+//
+// Pure policy, so no Qt, no event loop, no settings store — and constexpr, so
+// the whole table is also checked at compile time.
+
+#include "core/QsoRecordStartPolicy.h"
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+
+#define EXPECT_DECISION(clientSide, pcAudio, seamNative, expected) do { \
+    const RecordStartDecision got_ = \
+        evaluateRecordStart((clientSide), (pcAudio), (seamNative)); \
+    if (got_ != (expected)) { \
+        std::fprintf(stderr, "FAIL %s:%d  evaluateRecordStart(clientSide=%d, " \
+                             "pcAudio=%d, seamNative=%d) = %d, expected %d\n", \
+                     __FILE__, __LINE__, int(clientSide), int(pcAudio), \
+                     int(seamNative), int(got_), int(expected)); \
+        ++g_failures; \
+    } \
+} while (0)
+
+// Compile-time proof of the whole truth table. A regression that makes any of
+// these false is a build error, not just a test failure.
+//                                     client  pcAudio  seamNative
+static_assert(evaluateRecordStart(true,  false, false) == RecordStartDecision::BlockedPcAudioDisabled,
+              "Flex client-side without PC Audio must be refused");
+static_assert(evaluateRecordStart(true,  true,  false) == RecordStartDecision::Allow,
+              "Flex client-side with PC Audio must be allowed");
+static_assert(evaluateRecordStart(false, false, false) == RecordStartDecision::Allow,
+              "RADIO-SIDE MUST NEVER BE BLOCKED: it does not use PC Audio");
+static_assert(evaluateRecordStart(false, true,  false) == RecordStartDecision::Allow,
+              "radio-side is allowed regardless of PC Audio");
+static_assert(evaluateRecordStart(true,  false, true)  == RecordStartDecision::Allow,
+              "SEAM-NATIVE AUDIO (sim/HL2) MUST NEVER BE BLOCKED: it bypasses "
+              "remote_audio_rx, so PC Audio is not in its path");
+static_assert(evaluateRecordStart(true,  true,  true)  == RecordStartDecision::Allow,
+              "seam-native with PC Audio on is allowed");
+
+int main()
+{
+    // ── The bug: Flex, client-side, PC Audio off ────────────────────────────
+    // The only combination that may be refused.
+    EXPECT_DECISION(true, false, false, RecordStartDecision::BlockedPcAudioDisabled);
+
+    // ── Client-side with PC Audio on: the working configuration ─────────────
+    EXPECT_DECISION(true, true, false, RecordStartDecision::Allow);
+
+    // ── Radio-side: PC Audio is irrelevant, both ways ───────────────────────
+    // This is the operator's escape hatch when they listen on the radio rather
+    // than the PC. Blocking it would be a worse bug than the one being fixed.
+    EXPECT_DECISION(false, false, false, RecordStartDecision::Allow);
+    EXPECT_DECISION(false, true,  false, RecordStartDecision::Allow);
+
+    // ── Seam-native backends: SimBackend is the live counter-example ────────
+    // Sim owns its RX audio (ownsRxAudio()==true) but neither host-modulates
+    // nor transmits, so MainWindow does NOT lock PC Audio on for it. An
+    // operator in demo mode can turn PC Audio off and the sim's audio still
+    // reaches the recorder over the seam. Blocking that would refuse a
+    // recording that works. HL2 lands here too (it does lock PC Audio on, so
+    // the pcAudio=false row is unreachable there — but it costs nothing to be
+    // right for both).
+    EXPECT_DECISION(true, false, true, RecordStartDecision::Allow);
+    EXPECT_DECISION(true, true,  true, RecordStartDecision::Allow);
+
+    if (g_failures == 0)
+        std::fprintf(stderr, "qso_record_start_policy_test: all checks passed\n");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/qso_record_start_policy_test.cpp
+++ b/tests/qso_record_start_policy_test.cpp
@@ -4,11 +4,20 @@
 // only while PC Audio is enabled. Starting anyway produced a correctly named,
 // header-only 44-byte WAV and no error at all.
 //
-// The case that matters most here is the one that must NOT change:
-// RADIO-SIDE RECORDING DOES NOT DEPEND ON PC AUDIO. It is a `slice set <n>
-// record=1` command handled entirely by the radio, and it is the standing
-// answer for an operator who monitors on the radio's own speaker. If the guard
-// ever starts blocking it, that operator loses the one path that still worked.
+// RADIO-SIDE RECORDING MUST NEVER BE BLOCKED — it is the standing answer for an
+// operator who monitors on the radio's own speaker, and it does not depend on
+// PC Audio. That guarantee is enforced by the ROUTING layer, not by this
+// policy: MainWindow_Wiring and the MIDI binding test RecordingMode and send
+// radio-side straight to SliceModel::setRecordOn(), so a radio-side recording
+// never consults this file at all.
+//
+// What this policy answers is narrower — "may THE CLIENT RECORDER start?" — and
+// in Radio-Side mode the answer is no, because QsoRecorder only ever writes a
+// local file. An earlier revision returned Allow here on the theory that
+// radio-side must not be blocked; that conflated the two questions and let a
+// non-routing caller (AutomationServer::doRecord) open a local WAV in Radio-Side
+// mode, leaving exactly the spurious header-only file this change exists to
+// prevent.
 //
 // Pure policy, so no Qt, no event loop, no settings store — and constexpr, so
 // the whole table is also checked at compile time.
@@ -20,6 +29,13 @@
 using namespace AetherSDR;
 
 static int g_failures = 0;
+
+#define EXPECT_TRUE_MSG(cond, msg) do { \
+    if (!(cond)) { \
+        std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, (msg)); \
+        ++g_failures; \
+    } \
+} while (0)
 
 #define EXPECT_DECISION(clientSide, pcAudio, seamNative, expected) do { \
     const RecordStartDecision got_ = \
@@ -40,10 +56,15 @@ static_assert(evaluateRecordStart(true,  false, false) == RecordStartDecision::B
               "Flex client-side without PC Audio must be refused");
 static_assert(evaluateRecordStart(true,  true,  false) == RecordStartDecision::Allow,
               "Flex client-side with PC Audio must be allowed");
-static_assert(evaluateRecordStart(false, false, false) == RecordStartDecision::Allow,
-              "RADIO-SIDE MUST NEVER BE BLOCKED: it does not use PC Audio");
-static_assert(evaluateRecordStart(false, true,  false) == RecordStartDecision::Allow,
-              "radio-side is allowed regardless of PC Audio");
+// Radio-Side: the CLIENT recorder must not run, and the reason must be its own
+// — never BlockedPcAudioDisabled, which would explain the refusal with a cause
+// that has nothing to do with it.
+static_assert(evaluateRecordStart(false, false, false) == RecordStartDecision::BlockedRecordingModeIsRadio,
+              "Radio-Side must not start the client recorder");
+static_assert(evaluateRecordStart(false, true,  false) == RecordStartDecision::BlockedRecordingModeIsRadio,
+              "Radio-Side is refused regardless of PC Audio, and for its own reason");
+static_assert(evaluateRecordStart(false, false, true)  == RecordStartDecision::BlockedRecordingModeIsRadio,
+              "Radio-Side outranks the seam-native exemption: the radio is recording");
 static_assert(evaluateRecordStart(true,  false, true)  == RecordStartDecision::Allow,
               "SEAM-NATIVE AUDIO (sim/HL2) MUST NEVER BE BLOCKED: it bypasses "
               "remote_audio_rx, so PC Audio is not in its path");
@@ -59,11 +80,19 @@ int main()
     // ── Client-side with PC Audio on: the working configuration ─────────────
     EXPECT_DECISION(true, true, false, RecordStartDecision::Allow);
 
-    // ── Radio-side: PC Audio is irrelevant, both ways ───────────────────────
-    // This is the operator's escape hatch when they listen on the radio rather
-    // than the PC. Blocking it would be a worse bug than the one being fixed.
-    EXPECT_DECISION(false, false, false, RecordStartDecision::Allow);
-    EXPECT_DECISION(false, true,  false, RecordStartDecision::Allow);
+    // ── Radio-side: the CLIENT recorder is the wrong tool, whatever the audio ─
+    // The operator's radio-side recording still happens — it is routed to
+    // SliceModel before this policy is ever consulted (see the header comment).
+    // What is refused is QsoRecorder writing a local file it cannot fill.
+    EXPECT_DECISION(false, false, false, RecordStartDecision::BlockedRecordingModeIsRadio);
+    EXPECT_DECISION(false, true,  false, RecordStartDecision::BlockedRecordingModeIsRadio);
+    EXPECT_DECISION(false, false, true,  RecordStartDecision::BlockedRecordingModeIsRadio);
+
+    // The reason must never be reported as a PC Audio problem — an operator in
+    // Radio-Side mode told to go enable PC Audio has been sent the wrong way.
+    EXPECT_TRUE_MSG(evaluateRecordStart(false, false, false)
+                        != RecordStartDecision::BlockedPcAudioDisabled,
+                    "Radio-Side must not be explained as a PC Audio failure");
 
     // ── Seam-native backends: SimBackend is the live counter-example ────────
     // Sim owns its RX audio (ownsRxAudio()==true) but neither host-modulates

--- a/tests/qso_recorder_pc_audio_guard_test.cpp
+++ b/tests/qso_recorder_pc_audio_guard_test.cpp
@@ -29,7 +29,9 @@
 #include <QObject>
 #include <QString>
 #include <QTemporaryDir>
+#include <chrono>
 #include <cstdio>
+#include <thread>
 
 using namespace AetherSDR;
 
@@ -57,6 +59,21 @@ static void setMode(const char* recordingMode, const char* pcAudio)
     auto& s = AppSettings::instance();
     s.setValue(QStringLiteral("RecordingMode"), QString::fromLatin1(recordingMode));
     s.setValue(QStringLiteral("PcAudioEnabled"), QString::fromLatin1(pcAudio));
+    s.save();
+}
+
+// Written the way RadioSetupDialog writes it — the "True"/"False" STRING, which
+// is what QsoRecorder's start path compares against. Deliberately not
+// QsoRecorder::setAutoRecordEnabled(), which stores a bool: QVariant(true)
+// renders as "true", never matches == "True", and so silently clears
+// m_autoRecord on the next start. That setter has no callers in src/, so the
+// mismatch is latent rather than live, and fixing it is out of scope here — but
+// a test must exercise the representation the product actually uses.
+static void setAutoRecord(bool on)
+{
+    auto& s = AppSettings::instance();
+    s.setValue(QStringLiteral("QsoRecordingAutoRecord"),
+               on ? QStringLiteral("True") : QStringLiteral("False"));
     s.save();
 }
 
@@ -226,6 +243,93 @@ int main(int argc, char** argv)
         EXPECT_EQ_INT(fileCount(tmp.path()), 0);
     }
 
+    // ── Auto-record must not report the same refusal on every key-down ──────
+    // onMoxChanged() retries the start on EVERY MOX rising edge. Wired to a
+    // dialog, an unchanged refusal would raise one per transmission and stack
+    // them, turning an empty-file bug into an unusable radio. Report once; a
+    // deliberate press still always gets an answer.
+    {
+        QTemporaryDir tmp;
+        EXPECT_TRUE(tmp.isValid());
+        setMode("Client", "False");
+        setAutoRecord(true);           // before construction: the ctor reads it
+
+        QsoRecorder rec;
+        rec.setRecordingDir(tmp.path());
+
+        int blocked = 0;
+        QObject::connect(&rec, &QsoRecorder::recordingBlocked,
+                         &rec, [&](RecordStartDecision) { ++blocked; });
+
+        for (int over = 0; over < 5; ++over) {
+            rec.onMoxChanged(true);    // key down
+            rec.onMoxChanged(false);   // unkey
+        }
+        EXPECT_EQ_INT(blocked, 1);                 // once, not five times
+        EXPECT_EQ_INT(fileCount(tmp.path()), 0);
+        EXPECT_TRUE(!rec.isRecording());
+
+        // A deliberate press is a fresh question and is always answered, even
+        // while the auto-record refusal is standing.
+        rec.startRecording();
+        EXPECT_EQ_INT(blocked, 2);
+        EXPECT_EQ_INT(fileCount(tmp.path()), 0);
+    }
+
+    // ── A refusal that stops applying is reported again next time ───────────
+    // The dedupe must not latch: once the condition clears and a recording
+    // succeeds, a later refusal is a new event and has to be surfaced.
+    {
+        QTemporaryDir tmp;
+        EXPECT_TRUE(tmp.isValid());
+        setMode("Client", "False");
+        setAutoRecord(true);           // before construction: the ctor reads it
+
+        QsoRecorder rec;
+        rec.setRecordingDir(tmp.path());
+
+        int blocked = 0;
+        QObject::connect(&rec, &QsoRecorder::recordingBlocked,
+                         &rec, [&](RecordStartDecision) { ++blocked; });
+
+        rec.onMoxChanged(true);
+        rec.onMoxChanged(false);
+        EXPECT_EQ_INT(blocked, 1);
+
+        setMode("Client", "True");     // operator enables PC Audio
+        rec.onMoxChanged(true);
+        EXPECT_TRUE(rec.isRecording());
+        rec.stopRecording();
+        rec.onMoxChanged(false);
+
+        setMode("Client", "False");    // and turns it off again
+        rec.onMoxChanged(true);
+        EXPECT_EQ_INT(blocked, 2);     // reported afresh, not swallowed
+        rec.onMoxChanged(false);
+    }
+
+    // ── A sub-second start/stop is not a zero-capture fault ─────────────────
+    // Deliberately stopping a recording immediately can beat the first audio
+    // block. Reporting that as an error trains the operator to dismiss this
+    // dialog unread, which is worse than the blind spot it costs.
+    {
+        QTemporaryDir tmp;
+        EXPECT_TRUE(tmp.isValid());
+        setMode("Client", "True");
+
+        QsoRecorder rec;
+        rec.setRecordingDir(tmp.path());
+
+        int errors = 0;
+        QObject::connect(&rec, &QsoRecorder::recordingError,
+                         &rec, [&](const QString&) { ++errors; });
+
+        rec.startRecording();
+        EXPECT_TRUE(rec.isRecording());
+        rec.stopRecording();           // immediately — under one second
+        EXPECT_EQ_INT(errors, 0);
+    }
+
     // ── Zero-capture is reported, not passed off as success ─────────────────
     // The safety net: if anything else ever strands the audio feed mid-session,
     // stopping must not hand back a header-only file with no explanation.
@@ -243,6 +347,9 @@ int main(int argc, char** argv)
 
         rec.startRecording();
         EXPECT_TRUE(rec.isRecording());
+        // Past the one-second floor, so this is a real capture failure rather
+        // than an instant tap — see the sub-second case above.
+        std::this_thread::sleep_for(std::chrono::milliseconds(1100));
         rec.stopRecording();  // no audio was ever fed
 
         EXPECT_EQ_INT(errors, 1);

--- a/tests/qso_recorder_pc_audio_guard_test.cpp
+++ b/tests/qso_recorder_pc_audio_guard_test.cpp
@@ -1,0 +1,230 @@
+// Regression test for #4629 — Client-Side recording with PC Audio disabled
+// produced a 44-byte, header-only WAV and reported success.
+//
+// Root cause: QsoRecorder's only RX producer is RadioModel::rxDemodAudioReady,
+// fed on a Flex by the `remote_audio_rx` VITA-49 stream — and that stream is
+// created only when PC Audio is enabled. With it off, feedRxAudio() is never
+// called. startRecording() knew none of this: it opened the file, wrote the
+// 44-byte header, and waited for samples that could not arrive.
+//
+// The decisive assertion here is NO FILE IS CREATED. Asserting only
+// !isRecording() would still pass against a fix that opened the file and then
+// bailed, which would leave the same confusing artifact on disk that the
+// reporter filed the issue about.
+//
+// The second-most important assertion is that RADIO-SIDE RECORDING STILL
+// STARTS with PC Audio off. It records on the radio via `slice set <n>
+// record=1` and never touches the client audio path, so it is the standing
+// workaround for an operator monitoring on the radio's own speaker. Blocking it
+// would be a worse regression than the bug.
+
+#include "TestSettingsProfile.h"
+#include "core/AppSettings.h"
+#include "core/QsoRecordStartPolicy.h"
+#include "core/QsoRecorder.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFileInfo>
+#include <QObject>
+#include <QString>
+#include <QTemporaryDir>
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+
+#define EXPECT_TRUE(cond) do { \
+    if (!(cond)) { \
+        std::fprintf(stderr, "FAIL %s:%d  expected true: %s\n", \
+                     __FILE__, __LINE__, #cond); \
+        ++g_failures; \
+    } \
+} while (0)
+
+#define EXPECT_EQ_INT(actual, expected) do { \
+    const int a_ = int(actual); const int e_ = int(expected); \
+    if (a_ != e_) { \
+        std::fprintf(stderr, "FAIL %s:%d  expected %d, got %d\n", \
+                     __FILE__, __LINE__, e_, a_); \
+        ++g_failures; \
+    } \
+} while (0)
+
+static void setMode(const char* recordingMode, const char* pcAudio)
+{
+    auto& s = AppSettings::instance();
+    s.setValue(QStringLiteral("RecordingMode"), QString::fromLatin1(recordingMode));
+    s.setValue(QStringLiteral("PcAudioEnabled"), QString::fromLatin1(pcAudio));
+    s.save();
+}
+
+// Count files the recorder may have created, so "no file" is checked against
+// the filesystem rather than against the recorder's own account of itself.
+static int fileCount(const QString& dir)
+{
+    return int(QDir(dir).entryList(QDir::Files | QDir::NoDotAndDotDot).size());
+}
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile settingsProfile(QStringLiteral("aether-qso-pc-audio-guard"));
+    if (!settingsProfile.isValid())
+        return 1;
+    QCoreApplication app(argc, argv);
+    AppSettings::instance().load();
+
+    // ── The bug: Client-Side + PC Audio off ─────────────────────────────────
+    {
+        QTemporaryDir tmp;
+        EXPECT_TRUE(tmp.isValid());
+        setMode("Client", "False");
+
+        QsoRecorder rec;
+        rec.setRecordingDir(tmp.path());
+
+        int blocked = 0;
+        RecordStartDecision reason = RecordStartDecision::Allow;
+        QObject::connect(&rec, &QsoRecorder::recordingBlocked,
+                         &rec, [&](RecordStartDecision r) { ++blocked; reason = r; });
+        int started = 0;
+        QObject::connect(&rec, &QsoRecorder::recordingStarted,
+                         &rec, [&](const QString&) { ++started; });
+
+        rec.startRecording();
+
+        EXPECT_TRUE(!rec.isRecording());
+        // The assertion that distinguishes this fix from a half-fix: nothing
+        // was written to disk at all — not even the 44-byte header.
+        EXPECT_EQ_INT(fileCount(tmp.path()), 0);
+        EXPECT_TRUE(rec.recordingFilePath().isEmpty());
+        EXPECT_EQ_INT(blocked, 1);
+        EXPECT_TRUE(reason == RecordStartDecision::BlockedPcAudioDisabled);
+        EXPECT_EQ_INT(started, 0);
+
+        // The policy agrees with what the recorder actually did, so the
+        // automation bridge's `reason` field cannot drift from the behaviour.
+        EXPECT_TRUE(rec.evaluateStart()
+                    == RecordStartDecision::BlockedPcAudioDisabled);
+    }
+
+    // ── Client-Side + PC Audio on: unchanged, still records ─────────────────
+    {
+        QTemporaryDir tmp;
+        EXPECT_TRUE(tmp.isValid());
+        setMode("Client", "True");
+
+        QsoRecorder rec;
+        rec.setRecordingDir(tmp.path());
+
+        int blocked = 0;
+        QObject::connect(&rec, &QsoRecorder::recordingBlocked,
+                         &rec, [&](RecordStartDecision) { ++blocked; });
+
+        rec.startRecording();
+        EXPECT_TRUE(rec.isRecording());
+        EXPECT_EQ_INT(blocked, 0);
+        EXPECT_EQ_INT(fileCount(tmp.path()), 1);
+        rec.stopRecording();
+    }
+
+    // ── SEAM-NATIVE BACKEND + PC Audio off MUST STILL START ─────────────────
+    // SimBackend owns its RX audio but does NOT lock PC Audio on (it neither
+    // host-modulates nor transmits), so this configuration is reachable in demo
+    // mode and its audio reaches the recorder over the seam. The provider is a
+    // live callback, so this is the same code path a real backend swap takes.
+    {
+        QTemporaryDir tmp;
+        EXPECT_TRUE(tmp.isValid());
+        setMode("Client", "False");
+
+        QsoRecorder rec;
+        rec.setRecordingDir(tmp.path());
+        rec.setBackendOwnsRxAudioProvider([]() { return true; });
+
+        int blocked = 0;
+        QObject::connect(&rec, &QsoRecorder::recordingBlocked,
+                         &rec, [&](RecordStartDecision) { ++blocked; });
+
+        EXPECT_TRUE(rec.evaluateStart() == RecordStartDecision::Allow);
+        rec.startRecording();
+        EXPECT_TRUE(rec.isRecording());
+        EXPECT_EQ_INT(blocked, 0);
+        rec.stopRecording();
+    }
+
+    // ── A provider that flips is honored live, not cached ───────────────────
+    // Guards the staleness this design exists to avoid: swapping Flex → sim
+    // must change the answer without anything being re-pushed.
+    {
+        QTemporaryDir tmp;
+        EXPECT_TRUE(tmp.isValid());
+        setMode("Client", "False");
+
+        bool seamNative = false;
+        QsoRecorder rec;
+        rec.setRecordingDir(tmp.path());
+        rec.setBackendOwnsRxAudioProvider([&]() { return seamNative; });
+
+        EXPECT_TRUE(rec.evaluateStart()
+                    == RecordStartDecision::BlockedPcAudioDisabled);
+        seamNative = true;   // backend swap, nothing else touched
+        EXPECT_TRUE(rec.evaluateStart() == RecordStartDecision::Allow);
+    }
+
+    // ── RADIO-SIDE + PC Audio off MUST STILL START ──────────────────────────
+    // Radio-side recording is handled by the radio and has no dependency on the
+    // client's audio path. This is the case the guard must never catch.
+    {
+        QTemporaryDir tmp;
+        EXPECT_TRUE(tmp.isValid());
+        setMode("Radio", "False");
+
+        QsoRecorder rec;
+        rec.setRecordingDir(tmp.path());
+
+        int blocked = 0;
+        QObject::connect(&rec, &QsoRecorder::recordingBlocked,
+                         &rec, [&](RecordStartDecision) { ++blocked; });
+
+        EXPECT_TRUE(rec.evaluateStart() == RecordStartDecision::Allow);
+        rec.startRecording();
+        EXPECT_TRUE(rec.isRecording());
+        EXPECT_EQ_INT(blocked, 0);
+        rec.stopRecording();
+    }
+
+    // ── Zero-capture is reported, not passed off as success ─────────────────
+    // The safety net: if anything else ever strands the audio feed mid-session,
+    // stopping must not hand back a header-only file with no explanation.
+    {
+        QTemporaryDir tmp;
+        EXPECT_TRUE(tmp.isValid());
+        setMode("Client", "True");
+
+        QsoRecorder rec;
+        rec.setRecordingDir(tmp.path());
+
+        int errors = 0;
+        QObject::connect(&rec, &QsoRecorder::recordingError,
+                         &rec, [&](const QString&) { ++errors; });
+
+        rec.startRecording();
+        EXPECT_TRUE(rec.isRecording());
+        rec.stopRecording();  // no audio was ever fed
+
+        EXPECT_EQ_INT(errors, 1);
+        // The file is still finalized and left on disk — a valid empty WAV is
+        // more useful to the operator than a deleted one, and deleting a file
+        // the operator asked for would be its own surprise.
+        EXPECT_TRUE(QFileInfo(rec.recordingFilePath()).size() == 44);
+    }
+
+    if (g_failures == 0) {
+        std::printf("qso_recorder_pc_audio_guard_test: all checks passed\n");
+        return 0;
+    }
+    std::printf("qso_recorder_pc_audio_guard_test: %d failure(s)\n", g_failures);
+    return 1;
+}

--- a/tests/qso_recorder_pc_audio_guard_test.cpp
+++ b/tests/qso_recorder_pc_audio_guard_test.cpp
@@ -173,9 +173,16 @@ int main(int argc, char** argv)
         EXPECT_TRUE(rec.evaluateStart() == RecordStartDecision::Allow);
     }
 
-    // ── RADIO-SIDE + PC Audio off MUST STILL START ──────────────────────────
-    // Radio-side recording is handled by the radio and has no dependency on the
-    // client's audio path. This is the case the guard must never catch.
+    // ── RADIO-SIDE: the client recorder must NOT write a local file ─────────
+    // Found in review of the PR that added this file. Every operator-facing
+    // path (VFO button, MIDI binding, MOX auto-record) tests RecordingMode and
+    // routes radio-side to SliceModel without ever reaching QsoRecorder — but
+    // AutomationServer::doRecord calls startRecording() unconditionally, so a
+    // policy that answered Allow here left a spurious header-only WAV behind:
+    // the exact artifact #4629 is about, reached by a different door.
+    //
+    // The operator's radio-side recording is untouched by this — it is routed
+    // before this policy is consulted. What is refused is only this recorder.
     {
         QTemporaryDir tmp;
         EXPECT_TRUE(tmp.isValid());
@@ -185,14 +192,38 @@ int main(int argc, char** argv)
         rec.setRecordingDir(tmp.path());
 
         int blocked = 0;
+        RecordStartDecision reason = RecordStartDecision::Allow;
         QObject::connect(&rec, &QsoRecorder::recordingBlocked,
-                         &rec, [&](RecordStartDecision) { ++blocked; });
+                         &rec, [&](RecordStartDecision r) { ++blocked; reason = r; });
 
-        EXPECT_TRUE(rec.evaluateStart() == RecordStartDecision::Allow);
+        EXPECT_TRUE(rec.evaluateStart()
+                    == RecordStartDecision::BlockedRecordingModeIsRadio);
         rec.startRecording();
-        EXPECT_TRUE(rec.isRecording());
-        EXPECT_EQ_INT(blocked, 0);
-        rec.stopRecording();
+
+        EXPECT_TRUE(!rec.isRecording());
+        EXPECT_EQ_INT(fileCount(tmp.path()), 0);   // the assertion that matters
+        EXPECT_EQ_INT(blocked, 1);
+        EXPECT_TRUE(reason == RecordStartDecision::BlockedRecordingModeIsRadio);
+        // Never explained as a PC Audio failure — the operator's problem is a
+        // different one and that dialog would send them the wrong way.
+        EXPECT_TRUE(reason != RecordStartDecision::BlockedPcAudioDisabled);
+    }
+
+    // ── Radio-side outranks the seam-native exemption ───────────────────────
+    // A sim/HL2 backend does not make the client recorder the right tool when
+    // the operator asked the radio to record.
+    {
+        QTemporaryDir tmp;
+        EXPECT_TRUE(tmp.isValid());
+        setMode("Radio", "False");
+
+        QsoRecorder rec;
+        rec.setRecordingDir(tmp.path());
+        rec.setBackendOwnsRxAudioProvider([]() { return true; });
+
+        rec.startRecording();
+        EXPECT_TRUE(!rec.isRecording());
+        EXPECT_EQ_INT(fileCount(tmp.path()), 0);
     }
 
     // ── Zero-capture is reported, not passed off as success ─────────────────


### PR DESCRIPTION
Fixes #4629.

Client-Side recording with PC Audio disabled produced a correctly named, 44-byte, header-only WAV and reported success. @dk1aj found it while recording with an AU-510M, monitoring on the radio's own speaker rather than the PC.

## Root cause

`QsoRecorder`'s only RX producer is `RadioModel::rxDemodAudioReady`, fed on a Flex by the `remote_audio_rx` VITA-49 stream — and that stream is created only when PC Audio is enabled (`RadioModel::scheduleRxAudioStreamEnsure` returns early on `PcAudioEnabled=False`, and removes an already-owned stream).

With PC Audio off, `feedRxAudio()` is never called. `startRecording()` knew none of this: it opened the file, wrote the 44-byte header, and waited for samples that could not arrive. It could not tell silence-of-absence from silence-of-signal, so it reported success.

## Why refuse rather than decouple

The thread raised both options. The gate turns out to be deliberate, and the operator's need is already served:

- **#1071** removed TCI's stream auto-create for exactly this reason — *"auto-creating the stream overrode the user's explicit PC Audio toggle."* A recording-driven auto-create would re-litigate that.
- **#1069 / #1110** already solve the hardware-output conflict: AetherSDR pushes `mute_local_audio_when_remote` before opening the stream and re-asserts it on teardown, so enabling PC Audio does *not* silence the radio's own speaker. @dk1aj can get what he wants today — enable PC Audio, master volume to 0, confirm Radio Settings → Receive → "Mute local audio when remote" is Disabled.
- **Radio Side recording** remains available and is untouched by any of this.

So the defect is the silence, not the gate.

## The change

A pure, header-only `QsoRecordStartPolicy` — unit-tested with no radio, no event loop, no settings store, and the whole truth table also asserted at compile time. `startRecording()` consults it and returns **before touching the filesystem**, emitting `recordingBlocked(reason)`; `MainWindow` owns the wording, since `src/core` can't depend on QtWidgets (EB1/EB2).

Informational only, deliberately — an "Enable PC Audio and record" action button would flip a setting the operator turned off on purpose, which is the behaviour #1071 removed.

## Two cases that must never be blocked

**Radio-side**, which records on the radio and never touches the client audio path.

**Seam-native backends**, and this one nearly shipped wrong. It is tempting to argue no input is needed because MainWindow force-enables and *locks* PC Audio for such a backend. That argument is wrong — the lock is gated on `hostModulates && canTransmit`:

| Backend | `ownsRxAudio` | `hostModulates` | `canTransmit` | PC Audio locked? |
|---|---|---|---|---|
| HL2 | true | true | true | yes |
| **Sim** | **true** | **false** | **false** | **no** |

`SimBackend` owns its RX audio but neither host-modulates nor transmits, so demo mode can freely turn PC Audio off — and still records, over the seam. The first cut of this guard refused exactly that; live testing caught it. The backend is now asked through a **callback rather than a cached bool**, so a backend swap cannot leave a stale flag behind — a stale flag failing open being the shape of this bug in the first place.

## Also fixed

`QsoRecorder::recordingError` had **no consumer anywhere in the tree**, so three failures had always been silent:

1. the recording directory could not be created,
2. the recording file could not be opened,
3. a recording that captured nothing — the general case of this bug — reported success.

One `connect()` surfaces all three. `finalizeFile()` now raises (3) explicitly; the destructor finalizes *silently* so a quit can't raise a modal mid-teardown.

The VFO ⏺ button now follows `isRecording()` rather than the requested state, which stopped it latching red over a recording that never began.

The automation `record start` verb gained `reason` / `detail` fields and no longer reports a stale `path` on refusal (`recordingFilePath()` falls back to the last finalized recording — visible only when actually running it). Documented in `docs/automation-bridge.md`.

## Test plan

Unit — `qso_record_start_policy_test` (4 runtime cases + 6 `static_assert`s) and `qso_recorder_pc_audio_guard_test` (6 scenarios). The decisive assertion is **no file is created**, not merely `!isRecording()`: the weaker one would pass against a fix that opens the file and then bails, leaving the same artifact the issue is about.

Live, via the automation bridge, on a **FLEX-8400 (fw 4.2.20.41343)** and the sim:

| Scenario | Backend | Result |
|---|---|---|
| PC Audio **on**, client-side | FLEX-8400 | Records — 399,916 B in 4 s of off-air audio |
| PC Audio **off**, client-side | FLEX-8400 | Refused. `ok:false`, `reason:"pc-audio-disabled"`, **0 files created**, dialog shown |
| PC Audio **off**, client-side | Sim | **Allowed** — 18 s, 1,749,548 B captured |
| Radio-side, PC Audio off | — | Unit test + `static_assert` only; not driven live, as it would start a recording on the radio |

The sim run confirmed PC Audio as `{"checked": false, "enabled": true}` — unlocked, not merely off.

```json
→ {"cmd":"record","action":"start"}
← {"ok":false,"record":"start","recording":false,"path":"",
   "reason":"pc-audio-disabled",
   "detail":"Client-Side recording requires PC Audio; no RX audio stream exists."}
```

The dialog as captured live:

<img width="500" height="236" alt="blocked-dialog" src="https://github.com/user-attachments/assets/4845b765-4b22-4ecc-ad30-2cea027d9cc8" />

Also run: `check_engine_boundary.py --strict` → `0 would block`; automation / TCI / audio-router suites → 12 passed. `hl2_tci_signaling_test` fails with `0xc0000135` (DLL not found) — confirmed pre-existing by stashing and re-running on clean `main`.

## Not in scope

Dead code and a stale comment that this investigation turned up are filed separately as #4650.

👨🏼‍💻 Co-authored by Claude Opus 5

