### PR TITLE
fix(gui): gate the DVK button on the radio's SmartSDR+ entitlement. Principle II.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3528,6 +3528,15 @@ target_include_directories(waveform_install_gate_test PRIVATE src)
 target_link_libraries(waveform_install_gate_test PRIVATE Qt6::Core)
 add_test(NAME waveform_install_gate_test COMMAND waveform_install_gate_test)
 
+# DVK indicator availability — TX-slice mode + the radio's DVK entitlement.
+# Header-only, pure logic.
+add_executable(dvk_availability_gate_test
+    tests/dvk_availability_gate_test.cpp
+)
+target_include_directories(dvk_availability_gate_test PRIVATE src)
+target_link_libraries(dvk_availability_gate_test PRIVATE Qt6::Core)
+add_test(NAME dvk_availability_gate_test COMMAND dvk_availability_gate_test)
+
 add_executable(digital_voice_waveform_process_test
     tests/digital_voice_waveform_process_test.cpp
     src/core/DigitalVoiceWaveformTelemetry.cpp

--- a/src/gui/DvkAvailabilityGate.h
+++ b/src/gui/DvkAvailabilityGate.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <QLatin1String>
+#include <QString>
+
+namespace AetherSDR {
+
+// The radio's name for the DVK entitlement in a "license feature" status
+// message. Authority: FlexLib FeatureLicense.ParseLicenseFeature() maps
+// name="digital_voice_keyer" to LicenseFeatDVK (reference/
+// FlexLib_API_v4.1.5.39794/FlexLib/FeatureLicense.cs:107-112). Principle I.
+inline constexpr QLatin1String kDvkLicenseFeature{"digital_voice_keyer"};
+
+// Why the status-bar DVK indicator is dimmed, or None if it should be live.
+//
+// Two independent gates, both radio-authoritative (Principle II):
+//
+//  * TxModeNotVoice — the DVK keys the TX slice, so it follows that slice's
+//    mode exactly as CWX does (#4173).
+//  * NotLicensed — the radio reports "license feature name=digital_voice_keyer
+//    enabled=0", i.e. the operator has no SmartSDR+ entitlement for it. Before
+//    this gate the button stayed live and every dvk command was refused by the
+//    radio, which read as a dead feature rather than an unlicensed one.
+//
+// Fail OPEN when the entitlement is unknown. `licenseSeen` is false until a
+// "license feature" status for DVK actually arrives — pre-subscription window,
+// firmware that never emits one, or a non-Flex backend that has no such notion.
+// Treating unknown as unlicensed is the #4210 bug class: a license-derived
+// gate that blocked a radio which would have honoured the command just fine.
+// The radio must SAY no before the UI says no.
+enum class DvkIndicatorBlocker {
+    None,           // live
+    NotLicensed,    // radio reports the DVK feature disabled
+    TxModeNotVoice, // TX slice is CW/DIGU/DIGL, or there is no TX slice
+};
+
+inline DvkIndicatorBlocker dvkIndicatorBlocker(bool txModeIsVoice,
+                                               bool licenseSeen,
+                                               bool licenseEnabled)
+{
+    // Entitlement outranks mode: a radio without the feature never gains it by
+    // switching to USB, so the operator gets the durable reason, not a
+    // transient one that implies a mode change would help.
+    if (licenseSeen && !licenseEnabled) {
+        return DvkIndicatorBlocker::NotLicensed;
+    }
+    if (!txModeIsVoice) {
+        return DvkIndicatorBlocker::TxModeNotVoice;
+    }
+    return DvkIndicatorBlocker::None;
+}
+
+// Tooltip for the DVK indicator, dimmed or not. The gated text names the
+// requirement outright instead of echoing FlexLib's marketing copy ("Subscribe
+// to SmartSDR+ to use this feature!"), which tells an operator to buy something
+// without saying what the button needs.
+//
+// DVK is a SmartSDR+ feature and the text can say so unconditionally: FlexLib
+// gates it through the subscription-backed Feature record, and a FLEX-8600 on
+// fw 4.2.18 reports `reason=PLUS` for it. The `reason` field is therefore not
+// worth branching on here — it only ever distinguishes which subscription a
+// DIFFERENT feature wants, and a wrong-but-specific requirement would be worse
+// than this one.
+inline QString dvkIndicatorTooltip(DvkIndicatorBlocker blocker)
+{
+    if (blocker == DvkIndicatorBlocker::NotLicensed) {
+        return QStringLiteral(
+            "Digital Voice Keyer — requires an active SmartSDR+ subscription");
+    }
+    return QStringLiteral("Digital Voice Keyer — click to toggle");
+}
+
+}  // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -108,6 +108,7 @@
 #include "Ax25HfPacketDecodeDialog.h"
 #include "FlexControlDialog.h"
 #include "CwxPanel.h"
+#include "DvkAvailabilityGate.h"
 #include "DvkPanel.h"
 #include "core/DvkWavTransfer.h"
 #include "AmpApplet.h"
@@ -1706,6 +1707,15 @@ MainWindow::MainWindow(QWidget* parent)
             }
         }
     });
+
+    // "license feature" statuses answer "sub license all" asynchronously, well
+    // after the DVK indicator is first painted, and the set is cleared on
+    // disconnect — so the DVK entitlement gate has to be re-evaluated on every
+    // change rather than sampled once. (The clear-on-disconnect emit is what
+    // returns the indicator to its unknown-entitlement, fail-open state before
+    // the next radio's statuses arrive.)
+    connect(&m_radioModel, &RadioModel::licenseFeaturesChanged, this,
+            &MainWindow::updateKeyerAvailability);
 
     // Client-side DSP buttons (NR2 / NR4 / MNR / BNR / DFNR / RN2) now
     // live only in the AetherDSP applet, which owns its own
@@ -8295,8 +8305,20 @@ void MainWindow::updateKeyerAvailability()
                           || txMode == "FM" || txMode == "NFM"
                           || txMode == "DFM");
 
+    // DVK carries a second, mode-independent gate: the radio's own DVK
+    // entitlement. Unlike the mode gate it survives every mode change, so it is
+    // evaluated once here and applied to the indicator, the panel and the
+    // F1-F12 shortcuts alike — otherwise the keys stay armed and each keypress
+    // is refused by the radio (the "silently does nothing" report).
+    const DvkIndicatorBlocker dvkBlocker = dvkIndicatorBlocker(
+        txIsSsb,
+        m_radioModel.licenseFeatureSeen(kDvkLicenseFeature),
+        m_radioModel.licenseFeatureEnabled(kDvkLicenseFeature));
+    const bool dvkAvailable = (dvkBlocker == DvkIndicatorBlocker::None);
+    const bool dvkUnlicensed = (dvkBlocker == DvkIndicatorBlocker::NotLicensed);
+
     if (m_cwxPanel) m_cwxPanel->setShortcutsEnabled(txIsCw);
-    if (m_dvkPanel) m_dvkPanel->setShortcutsEnabled(txIsSsb);
+    if (m_dvkPanel) m_dvkPanel->setShortcutsEnabled(dvkAvailable);
 
     // Only auto-hide an open panel when a TX slice *exists* and is in the wrong
     // mode (a deliberate mode change).  A momentary "no TX slice" — during a TX
@@ -8314,17 +8336,26 @@ void MainWindow::updateKeyerAvailability()
     }
     m_cwxIndicator->setCursor(txIsCw ? Qt::PointingHandCursor : Qt::ArrowCursor);
 
-    // DVK: available in voice modes (SSB, AM, FM — not DIGU/DIGL)
-    m_dvkIndicator->setEnabled(txIsSsb);
-    if (txSlice && !txIsSsb && m_dvkPanel->isVisible()) {
+    // DVK: available in voice modes (SSB, AM, FM — not DIGU/DIGL), and only on
+    // a radio that reports the DVK entitlement (see dvkIndicatorBlocker).
+    m_dvkIndicator->setEnabled(dvkAvailable);
+    // An unlicensed radio said so itself, so hide an open panel whether or not
+    // a TX slice currently exists — the mode gate's "keep it open across a
+    // transient no-TX-slice" caveat (#4173) applies only to the mode gate.
+    if ((dvkUnlicensed || (txSlice && !txIsSsb)) && m_dvkPanel->isVisible()) {
         m_dvkPanel->hide();
         m_dvkIndicator->setStyleSheet(kDisabled);
     } else if (m_dvkPanel->isVisible()) {
         m_dvkIndicator->setStyleSheet(kActive);
     } else {
-        m_dvkIndicator->setStyleSheet(txIsSsb ? kAvail : kDisabled);
+        m_dvkIndicator->setStyleSheet(dvkAvailable ? kAvail : kDisabled);
     }
-    m_dvkIndicator->setCursor(txIsSsb ? Qt::PointingHandCursor : Qt::ArrowCursor);
+    m_dvkIndicator->setCursor(dvkAvailable ? Qt::PointingHandCursor
+                                           : Qt::ArrowCursor);
+    // An unlicensed radio gets a tooltip naming the missing subscription; the
+    // mode gate keeps the normal one, since the panel's own title and the F-key
+    // rows already make "wrong mode" obvious once it opens.
+    m_dvkIndicator->setToolTip(dvkIndicatorTooltip(dvkBlocker));
 
 #ifdef AETHER_ASR_ENABLED
     // ASR (Copy Assist): the inverse of CWX — available in voice modes only,

--- a/tests/dvk_availability_gate_test.cpp
+++ b/tests/dvk_availability_gate_test.cpp
@@ -1,0 +1,90 @@
+// Unit tests for the DVK indicator availability policy.
+//
+// Two regression guards matter here:
+//
+//  1. The reported bug: on a radio without the DVK entitlement the button was
+//     live and every dvk command was refused, so the feature read as broken
+//     rather than unlicensed.
+//  2. The opposite failure, and the more damaging one — #4210, where a
+//     license-derived gate disabled a feature on radios that would have
+//     honoured the command. An entitlement we have NOT been told about must
+//     never block: the radio has to say no before the UI says no.
+
+#include "gui/DvkAvailabilityGate.h"
+
+#include <cstdio>
+
+using namespace AetherSDR;
+using B = DvkIndicatorBlocker;
+
+namespace {
+
+int g_failed = 0;
+int g_total = 0;
+
+void report(const char* label, bool ok)
+{
+    ++g_total;
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", label);
+    if (!ok) {
+        ++g_failed;
+    }
+}
+
+B gate(bool txModeIsVoice, bool licenseSeen, bool licenseEnabled)
+{
+    return dvkIndicatorBlocker(txModeIsVoice, licenseSeen, licenseEnabled);
+}
+
+}  // namespace
+
+int main()
+{
+    // ── Licensed radio: mode is the only gate, exactly as before ────────────
+    report("licensed + voice TX mode -> None",
+           gate(true, true, true) == B::None);
+    report("licensed + non-voice TX mode -> TxModeNotVoice",
+           gate(false, true, true) == B::TxModeNotVoice);
+
+    // ── The reported bug: entitlement refused ───────────────────────────────
+    report("unlicensed + voice TX mode -> NotLicensed",
+           gate(true, true, false) == B::NotLicensed);
+    // Entitlement outranks mode: switching to USB will never unlock a feature
+    // the radio does not have, so the durable reason is the one to show.
+    report("unlicensed + non-voice TX mode -> NotLicensed (entitlement wins)",
+           gate(false, true, false) == B::NotLicensed);
+
+    // ── The #4210 guard: unknown entitlement must fail OPEN ─────────────────
+    // No "license feature" status for DVK has arrived: pre-subscription window,
+    // firmware that never emits one, or a non-Flex backend. Behaviour must be
+    // identical to a licensed radio — mode gate only.
+    report("entitlement unseen + voice -> None (never blocks on unknown)",
+           gate(true, false, false) == B::None);
+    report("entitlement unseen + non-voice -> TxModeNotVoice (not NotLicensed)",
+           gate(false, false, false) == B::TxModeNotVoice);
+    // enabled=true while seen=false is a nonsense pairing from a caller reading
+    // a default-constructed LicenseFeatureState; it must still fail open.
+    report("entitlement unseen but enabled flag set -> None",
+           gate(true, false, true) == B::None);
+
+    // ── Tooltip names the missing subscription ──────────────────────────────
+    // The whole point of the gate: a dimmed button has to say what it needs, or
+    // it is just as mute as the silently-refused command it replaced.
+    report("unlicensed tooltip names an active SmartSDR+ subscription",
+           dvkIndicatorTooltip(B::NotLicensed)
+               == QStringLiteral("Digital Voice Keyer — requires an active "
+                                 "SmartSDR+ subscription"));
+    report("mode-gated tooltip stays the normal one",
+           dvkIndicatorTooltip(B::TxModeNotVoice)
+               == QStringLiteral("Digital Voice Keyer — click to toggle"));
+    report("available tooltip stays the normal one",
+           dvkIndicatorTooltip(B::None)
+               == QStringLiteral("Digital Voice Keyer — click to toggle"));
+
+    // ── The feature name is the FlexLib one ─────────────────────────────────
+    report("license feature name matches FlexLib's digital_voice_keyer",
+           QString(kDvkLicenseFeature) == QStringLiteral("digital_voice_keyer"));
+
+    std::printf("\n%d/%d passed\n", g_total - g_failed, g_total);
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Problem

DVK requires a SmartSDR+ subscription. AetherSDR never checked, so on a radio
without the entitlement the DVK button was fully live: it opened the panel, the
radio refused every `dvk` command, and the feature read as **broken** rather
than **unlicensed**. (#3377 already surfaces per-command rejections in the
panel's status label, but by then the operator has recorded into a slot that
was never going to work.)

## Fix

Gate the indicator on the radio's own answer. FlexLib's `FeatureLicense` maps
`license feature name=digital_voice_keyer enabled=<0|1> reason=...` to
`LicenseFeatDVK` (`FeatureLicense.cs:107-112`), and `RadioModel` already
subscribes with `sub license all` and parses those statuses into
`licenseFeature{Seen,Enabled,Reason}()` — the plumbing existed and simply had no
consumer. Nothing new is asked of the wire.

When the radio reports the feature disabled, the button takes **the exact
disabled presentation it already uses in CW mode** — `setEnabled(false)`, the
`kDisabled` stylesheet, arrow cursor — and its tooltip becomes
"Digital Voice Keyer — requires an active SmartSDR+ subscription", so a dimmed
button states what it needs instead of being as mute as the refused command it
replaced. The F1-F12 shortcuts and any open panel follow the same gate, so no
entry point is left to fail silently.

Entitlement outranks mode: an unlicensed radio never becomes licensed by
switching to USB, so the operator sees the durable reason rather than one
implying a mode change would help.

## The gate fails OPEN — deliberately

`licenseFeatureSeen()` stays false until a DVK license status actually arrives
(pre-subscription window, firmware that never emits one, a non-Flex backend),
and in that state behaviour is identical to today's. **The radio must
positively deny the feature before the UI does.**

This is the #4210 failure mode in reverse — a license-derived gate that blocked
radios which would have honoured the command. That precedent is live on the
test radio here, which reports `WFP enabled=0` while WFP works.

## Verification

Against a FLEX-8600 on fw 4.2.18, driven through the automation bridge:

- The radio reports `license feature name=DIGITAL_VOICE_KEYER enabled=1
  reason=PLUS` (confirming both the FlexLib feature name and that DVK is a
  SmartSDR+ feature). The button stays live in USB with its normal tooltip —
  the non-regression case.
- Pointing the same gate at a feature that radio reports `enabled=0` produced
  `enabled: false`, `cursor: arrow`, tooltip
  "Digital Voice Keyer — requires an active SmartSDR+ subscription" — the whole
  chain (status → parse → `licenseFeaturesChanged` → gate → indicator) with no
  test hooks in shipping code. Reverted before commit.
- Note the radio sends the name **uppercase** (`DIGITAL_VOICE_KEYER`);
  `RadioModel::normalizedLicenseFeatureName()` lower-cases it, matching
  FlexLib, which lower-cases the whole status line before dispatch.

`dvk_availability_gate_test` (new, 11 cases) covers the policy and both tooltip
states, including every fail-open case. Full suite otherwise unchanged;
`engine-boundary --strict` reports 0 blocking findings and the a11y check none
in the touched files.

## Follow-ups noticed, not included

- `DvkModel::enabled()` / `Status::Disabled` are parsed from
  `dvk status=... enabled=0` but nothing consumes them — a second, independent
  radio-side signal that DVK is unavailable.
- Before any radio connects, the DVK indicator sits enabled with a pointing-hand
  cursor, because `updateKeyerAvailability()` only runs on slice/TX events.
  Pre-existing, and true of CWX too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)