### PR TITLE
ci(canary): raise the sid ccache cap to 1000M — 500M saturated on run one

### DIFF
--- a/.github/workflows/system-libs-canary.yml
+++ b/.github/workflows/system-libs-canary.yml
@@ -55,10 +55,20 @@ jobs:
 
     env:
       CCACHE_DIR: /ccache
-      # Smaller than ci.yml's build (1000M): this tree is configured with
-      # ENABLE_RADE=OFF and system libraries in place of several vendored
-      # third_party builds, so it compiles less.
-      CCACHE_MAXSIZE: 500M
+      # 1000M, matching ci.yml's build. This was 500M on the assumption that
+      # ENABLE_RADE=OFF plus system libraries replacing vendored third_party
+      # builds meant materially less compiling. The first real run disproved
+      # that: 1678 cacheable calls here against 1980 in ci.yml's build — 15%
+      # fewer, not a different order of magnitude — and the working set filled
+      # 98.33% of the 500M cap in that single run.
+      #
+      # A cap that sits on the working set is worse than a smaller cache:
+      # entries are evicted before the next run can reuse them, so the hit rate
+      # stays pinned near its cold value instead of climbing. ci.yml's build
+      # settles at ~0.5 GB against 1000M and stays healthy; this tree needs the
+      # same headroom. Verify from the "ccache stats" step rather than assuming:
+      # a "Cache size" line near 100% means this needs raising again.
+      CCACHE_MAXSIZE: 1000M
       # NOT the default (mtime). sid reinstalls the toolchain from apt on every
       # run, so the compiler binary's identity is the one input that genuinely
       # could go stale here — hash its contents rather than trusting size+mtime.


### PR DESCRIPTION
Follow-up to #4656. Refs #4655.

The sid canary's ccache cap was set to **500M** on the assumption that `ENABLE_RADE=OFF` plus system libraries replacing several vendored `third_party` builds meant this tree compiles materially less than `ci.yml`'s `build`. The job's first real run — which could only happen after merge, since it triggers on `push: main` and not on PRs — disproved that.

```
Cacheable calls:   1678 / 1678 (100.0%)
  Hits:             398 / 1678 (23.72%)
  Misses:          1280 / 1678 (76.28%)
  Cache size (GB):  0.5 /  0.5 (98.33%)     ← saturated on a single run
```

**1678 cacheable calls here against 1980 in `ci.yml`'s build** — 15% fewer, not a different order of magnitude. Both working sets land at ~0.5 GB.

## Why this matters rather than being cosmetic

A cap that sits on the working set is worse than a smaller cache: entries are evicted before the next run can reuse them, so the hit rate stays pinned near its cold value instead of climbing. That first run showed 23.72% hits and 26 min against a 31 min uncached mean, and without headroom it would not have improved from there — which defeats the point of adding the cache at all. Compare `ci.yml`'s `build`, which settles at ~0.5 GB against a 1000M cap and went 28 min → 3.3 min at 99.80% hits.

Budget is not the constraint: CodeQL was the largest single consumer of the repo's 10 GB Actions cache at **~4.3 GB across 5 entries**, and #4656 took CodeQL off the PR path entirely.

## Note on how this happened

This repeats, in the opposite direction, a sizing error I argued against during review of #4656. @aethersdr-agent proposed 500M for `ci.yml`'s build; I rejected it on the grounds that 500M sits exactly on the measured working set and would thrash — and then assumed my way into the same cap here rather than measuring. The reviewer's instinct about cap sizing was sound; my justification for applying it in one place and not the other was not.

The comment now points at the job's own `ccache stats` step as the way to check, rather than reasoning about what a configuration ought to compile.

## Verification

`actionlint` clean, no new structural findings. The behavioural proof is the **next** `push: main` run of this job — look for `Cache size` comfortably below the cap and a hit rate above the 23.72% baseline. This workflow does not run on PRs by design, so CI here will not exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)