### PR TITLE
fix(gui): APF level slider follows APF engagement (#4658)

### DIFF
--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -2038,7 +2038,7 @@ void VfoWidget::buildTabContent()
             m_apfSlider->setRange(0, 100);
             m_apfSlider->setValue(50);
             applyPrimarySliderStyle(m_apfSlider);
-            m_apfSlider->setToolTip("Adjusts APF bandwidth. Higher values narrow the peak for better CW selectivity.");
+            m_apfSlider->setToolTip("Adjusts APF bandwidth. Higher values narrow the peak for better CW selectivity. Enabled when APF is on in the DSP grid.");
             apfVb->addWidget(m_apfSlider, 1);
             m_apfValueLbl = new QLabel("50");
             m_apfValueLbl->setStyleSheet(kLabelStyle);
@@ -2051,6 +2051,11 @@ void VfoWidget::buildTabContent()
                 if (!m_updatingFromModel && m_slice) m_slice->setApfLevel(v);
             });
 
+            // Level is only reachable while the filter is engaged — same rule
+            // as every other DSP parameter. Kept VISIBLE (disabled) in CW so
+            // the control stays discoverable; hiding it was how operators
+            // ended up dragging a live slider into a disengaged filter (#4658).
+            m_apfContainer->setEnabled(false);
             m_apfContainer->hide();
             dspVb->addWidget(m_apfContainer);
         }
@@ -4498,6 +4503,11 @@ void VfoWidget::setSlice(SliceModel* slice)
     connectLeveledDsp(&SliceModel::anflChanged, m_anflBtn, LvlAnfl);
     connectDsp(&SliceModel::anftChanged, m_anftBtn);   // toggle-only, no level
     connectDsp(&SliceModel::apfChanged, m_apfBtn);     // own level row
+    // The level row follows the filter's engagement, radio-echo included —
+    // a slider that talks to a disengaged filter reads as "APF is broken" (#4658).
+    connect(m_slice, &SliceModel::apfChanged, this, [this](bool on) {
+        m_apfContainer->setEnabled(on);
+    });
     connect(m_slice, &SliceModel::apfLevelChanged, this, [this](int v) {
         m_updatingFromModel = true;
         m_apfSlider->setValue(v);
@@ -4948,6 +4958,7 @@ void VfoWidget::syncFromSlice()
         QSignalBlocker sb(m_apfSlider);
         m_apfSlider->setValue(m_slice->apfLevel());
         m_apfValueLbl->setText(QString::number(m_slice->apfLevel()));
+        m_apfContainer->setEnabled(m_slice->apfOn());   // slice-switch sync (#4658)
     }
 
     // DAX


### PR DESCRIPTION
Fixes the defect half of #4658 (the CW workflow roadmap items remain open there).

## Root cause

The CW APF level slider (`VfoWidget.cpp`) is shown/hidden purely by mode — `m_apfContainer->setVisible(isCw)` in both the `modeChanged` handler and `syncFromSlice()` — and its `valueChanged` forwards `apf_level` to the radio unconditionally. Nothing ever consults `SliceModel::apfOn()`, so with APF disengaged the slider drags, the value label updates, `slice set N apf_level=` goes to the radio, and the audio is untouched. Every other DSP parameter in the app is unreachable until its filter is on; APF predates that convention and never joined it. That mismatch is exactly what cost the reporting operator a session ("I was using the APF slider and saying it does not work").

## Fix

Gate the slider container's **enabled** state on APF engagement, from all three paths that own it:

- construction: starts disabled;
- a `SliceModel::apfChanged` connection (radio echo included) — the signal already existed, wired only to the button;
- `syncFromSlice()` for slice switches.

Deliberately **visible-but-disabled** in CW rather than hidden: the field report shows the failure mode is discoverability. A greyed slider teaches "this needs APF on" (tooltip now says so); a hidden one buries the feature the report was praising.

## Proof — agent automation bridge

Driven via the bridge (`dumpTree` / `invoke`) against a live radio connection, CW mode, cycling the APF button off→on→off and reading the slider's `enabled`:

| State | main (`8843f6d0`) | this branch |
|---|---|---|
| APF **off** | `enabled: true` ← defect | `enabled: false` |
| APF **on** | `enabled: true` | `enabled: true` |
| APF **off** again | `enabled: true` | `enabled: false` |

Button remains clickable and the row remains visible in CW throughout. RX-only; no TX verbs used.

| main — APF off, slider live (the bug) | fixed — APF off, slider gated | fixed — APF on, slider live |
|---|---|---|
| ![old](https://raw.githubusercontent.com/nigelfenton/AetherSDR/fix-4658-assets/.pr-assets/old-apf-off.png) | ![new-off](https://raw.githubusercontent.com/nigelfenton/AetherSDR/fix-4658-assets/.pr-assets/new-apf-off.png) | ![new-on](https://raw.githubusercontent.com/nigelfenton/AetherSDR/fix-4658-assets/.pr-assets/new-apf-on.png) |

Not exercised: the APF audio effect itself on a real 8000-series (the defect and fix are client-side state gating, platform- and radio-independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)