### PR TITLE
fix(model): don't mint a neutral pan for a backend that vends its own wire (#4671)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ section.
 
 ### Fixed
 
+- **Demo mode no longer opens with a ghost "Slice A" panadapter (#4671).** The
+  demo's simulator claims its panadapter from its own synthetic wire, but the
+  model treated every non-Flex backend as wire-less and minted a *second*,
+  ownerless pan in the neutral id space on the seam's geometry edge — a pane the
+  user could neither use nor delete. The same assumption re-addressed the demo's
+  slice into that neutral space, so the slice pointed at the ghost rather than
+  at its real pan; with the ghost gone it would have pointed at nothing. Both
+  now key off whether the backend vends its own connection, so the demo opens
+  with one panadapter and a slice that belongs to it — restoring the pan title
+  bar, adaptive RX filter, auto-squelch, centre-lock and band recall on demo
+  mode. Hermes-Lite 2 and other wire-less backends keep the neutral mapping.
+
 - **Amplifier bar gauges no longer keep painting the old scale after the range
   changes (#4636).** When a gauge's scale is re-derived from live telemetry —
   the ACOM auto-range as forward power outgrows its tier, an SPE LOW/MID/HIGH

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -601,12 +601,18 @@ void RadioModel::setupBackend(const QString& family)
             m_backendPanBandwidthMhz[panIdx] = bandwidthMhz;
         }
         auto* pan = resolveBackendPan(panId);
-        if (!pan && !m_flexBackend) {
-            // aetherd Gap B (Step 2c): materialise the pan for a non-Flex backend.
-            // No Flex "display pan" status exists to create one, so without this
-            // there is no PanadapterModel to route frames to and the UI never
-            // builds a pane — the render path was falling back to the active
-            // spectrum widget, which is null when no pan applet exists.
+        if (!pan && !m_flexBackend && !m_connection) {
+            // aetherd Gap B (Step 2c): materialise the pan for a non-Flex backend
+            // WITHOUT a wire. No Flex "display pan" status exists to create one,
+            // so without this there is no PanadapterModel to route frames to and
+            // the UI never builds a pane — the render path was falling back to the
+            // active spectrum widget, which is null when no pan applet exists.
+            //
+            // The !m_connection gate: a backend that vends its own RadioConnection
+            // (the demo's Route A SimBackend) claims its pans from its own wire
+            // status, so minting a neutral twin here created a second, ownerless
+            // pan applet — the ghost "Slice A" of #4671. Its pans arrive through
+            // the claim path; only truly wire-less backends (HL2) materialise.
             //
             // One pane per backend pan id, so a multi-receiver backend gets a
             // pane each instead of four receivers sharing one.
@@ -7312,6 +7318,15 @@ PanadapterModel* RadioModel::resolveBackendPan(const QString& backendPanId)
     // Flex keeps its existing behaviour: its pan ids ARE the model keys.
     if (m_flexBackend)
         return resolvePan(backendPanId);
+    // A non-Flex backend that vends its own RadioConnection (the demo's Route A
+    // SimBackend) claims pans from its own synthetic wire status, so — exactly
+    // like Flex — its pan ids ARE the model keys. Exact lookup, deliberately NOT
+    // resolvePan(): a geometry edge can outrun the wire claim during connect,
+    // and the active-pan fallback would re-introduce the wrong-pan hazard this
+    // helper exists to prevent. A miss returns null and the caller skips; the
+    // wire claim carries the same values moments later. (#4671)
+    if (m_connection)
+        return panadapter(backendPanId);
     return panadapter(neutralPanIdString(neutralPanIndexFor(backendPanId)));
 }
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -941,8 +941,16 @@ void RadioModel::setupBackend(const QString& family)
         // unmapped the slice belongs to no pan, so no slice flag is drawn on the
         // panadapter even though the VFO shows the right frequency. Re-address the
         // delta at the pan we materialised.
+        //
+        // ...but ONLY when we materialised one. A backend that vends its own
+        // RadioConnection claims its pans from its own wire, so its pan ids ARE
+        // the model keys — the same discriminator resolveBackendPan() uses. The
+        // demo announces slice.panId = "0x40000000", already a key; rewriting it
+        // into the neutral space pointed the slice at a pan nothing holds, and
+        // every slice-to-pane association keys off that exact equality (pan title
+        // bar, adaptive RX filter, auto-squelch, centre-lock, band recall). (#4671)
         SliceDelta mapped = delta;
-        if (!m_flexBackend && mapped.panId) {
+        if (!m_flexBackend && !m_connection && mapped.panId) {
             // Through the SAME allocator the geometry handler uses, so a slice
             // lands on the pane its own receiver feeds. Pinned to index 0 while
             // one pan existed; at four receivers that put every slice flag on
@@ -7323,10 +7331,14 @@ PanadapterModel* RadioModel::resolveBackendPan(const QString& backendPanId)
     // like Flex — its pan ids ARE the model keys. Exact lookup, deliberately NOT
     // resolvePan(): a geometry edge can outrun the wire claim during connect,
     // and the active-pan fallback would re-introduce the wrong-pan hazard this
-    // helper exists to prevent. A miss returns null and the caller skips; the
-    // wire claim carries the same values moments later. (#4671)
+    // helper exists to prevent. A miss returns null and the caller skips — and on
+    // the demo that DROPS the geometry rather than deferring it: the synthetic
+    // wire's `display pan center=…` is decoded only through m_flexBackend (see
+    // handlePanadapterStatus), which is why RFC #4288 added this seam emit at all.
+    // What keeps the ordering safe is SimBackend's 150 ms delay before
+    // emitInitialState() (SimBackend.cpp) — do not shorten it. (#4671)
     if (m_connection)
-        return panadapter(backendPanId);
+        return panadapter(normalizePanadapterId(backendPanId));
     return panadapter(neutralPanIdString(neutralPanIndexFor(backendPanId)));
 }
 

--- a/tests/demo_backend_swap_test.cpp
+++ b/tests/demo_backend_swap_test.cpp
@@ -23,6 +23,7 @@
 //       connection's lifecycle as its own seam signals, so a model that listens to
 //       both hears every connect twice.
 
+#include "models/PanadapterModel.h"
 #include "models/RadioModel.h"
 #include "core/RadioDiscovery.h"
 #include "core/backends/sim/SimBackend.h"
@@ -119,6 +120,27 @@ int main(int argc, char** argv)
     check(errSpy.isEmpty(),
           "R2: no connection error within the UDP-health window on the demo");
     check(model.isConnected(), "still connected after the watchdog window");
+
+    // ---- R4: exactly one pan, and it is the wire-claimed one (#4671) ----
+    // SimBackend claims its pan from its own synthetic wire status AND emits the
+    // seam's panCenterBandwidthChanged. The Gap B materialise path treated every
+    // non-Flex backend as wire-less, so the seam edge minted a SECOND, ownerless
+    // pan in the neutral 0xE1000000 space — a ghost "Slice A" the user could
+    // neither use nor delete. Both edges have long arrived by this point in the
+    // test, so a duplicate would be visible here.
+    {
+        const auto pans = model.panadapters();
+        for (const PanadapterModel* p : pans)
+            std::fprintf(stderr, "  pan present: %s\n", qPrintable(p->panId()));
+        check(pans.size() == 1,
+              "R4: the demo session holds exactly one panadapter (no neutral ghost)");
+        bool neutralGhost = false;
+        for (const PanadapterModel* p : pans)
+            if (p->panId().startsWith(QStringLiteral("0xe1"), Qt::CaseInsensitive))
+                neutralGhost = true;
+        check(!neutralGhost,
+              "R4: no pan lives in the neutral 0xE1000000 space on the demo");
+    }
 
     // ---- sim -> flex round trip ----
     model.connectToRadio(flexInfo());

--- a/tests/demo_backend_swap_test.cpp
+++ b/tests/demo_backend_swap_test.cpp
@@ -140,6 +140,18 @@ int main(int argc, char** argv)
                 neutralGhost = true;
         check(!neutralGhost,
               "R4: no pan lives in the neutral 0xE1000000 space on the demo");
+
+        // …and the slice the demo announced points AT that pan. SimBackend sends
+        // slice.panId = "0x40000000", already a model key, so the sliceChanged
+        // handler must not rewrite it into the neutral space either. Killing the
+        // ghost without this turns "binds to the wrong pan" into "binds to
+        // nothing" — every slice-to-pane lookup is an exact panId match. (#4671)
+        for (const SliceModel* s : model.slices())
+            std::fprintf(stderr, "  slice %d panId=%s\n",
+                         s->sliceId(), qPrintable(s->panId()));
+        for (const SliceModel* s : model.slices())
+            check(!s->panId().isEmpty() && model.panadapter(s->panId()) != nullptr,
+                  "R4: the demo slice points at a panadapter that exists");
     }
 
     // ---- sim -> flex round trip ----


### PR DESCRIPTION
Fixes #4671.

## Root cause

The Gap B (Step 2c) pan-materialise path in `RadioModel` treated every non-Flex backend as wire-less. True for the HL2; false for the demo's Route A `SimBackend`, which claims its pan (`0x40000000`) from its own synthetic wire status. The seam's `panCenterBandwidthChanged` edge then minted a **second, ownerless pan** in the neutral `0xE1000000` space: the ghost "Slice A" reported in #4671 — no RX flag, undeletable (its command plane drops every send), auto-range walking down 24 dB/s indefinitely against no data.

## Fix

One discriminator, two sites — `m_connection` is non-null exactly when the backend vends its own `RadioConnection` (Flex, sim), i.e. when its pans arrive through the wire-claim path:

- `resolveBackendPan()`: a wire-vending backend's pan ids ARE the model keys, exactly like Flex. Exact lookup, deliberately not `resolvePan()` — a geometry edge that outruns the wire claim during connect misses harmlessly instead of falling back to the active pan (the wrong-pan hazard this helper exists to prevent).
- The materialise path only runs for truly wire-less backends (HL2 today).

## Regression test

`demo_backend_swap_test` gains **R4**: after a real synthetic demo connect, the model holds exactly one panadapter and none in the neutral id space. Proven falsifiable — on the unfixed code it fails with both pans listed:

```
  pan present: 0x40000000
  pan present: 0xe1000000
FAIL: R4: the demo session holds exactly one panadapter (no neutral ghost)
```

With the fix: `demo_backend_swap_test: all checks passed` (R1–R4). `hl2_family_transition_test` and `radio_capability_gating_test` also pass (all checks, real stdout, Windows/MSVC).

## Proof via the agent automation bridge

**Before** (unfixed, demo connect): log shows both claims (`0x40000000` then `0xe1000000` ~1 s later), `dumpTree` counts 2 VFO widgets for 1 model slice, and the ghost pan renders as a dead black pane titled "Slice A":

![before — the ghost pan](https://raw.githubusercontent.com/nigelfenton/AetherSDR/fix-4671-assets/.pr-assets/fb4671-before.png)

**After** (fixed, demo connect): exactly one claim, one pan, zero `implausible dBm range` warnings over a 60 s soak (the unfixed build warned at 1 Hz indefinitely — one session reached −5410 dBm):

![after — one live pan](https://raw.githubusercontent.com/nigelfenton/AetherSDR/fix-4671-assets/.pr-assets/fb4671-after.png)

**Family-switch matrix** (suggested by @jensenpat) — one live session on the fixed build, driven over the bridge, every leg via `connect local serial` + `connect wait`:

| leg | switch | claim(s) | result |
|---|---|---|---|
| flex-sim | sim → flex | `0x40000000` | 1 slice / 1 VFO, clean |
| demo | flex → sim | `0x40000000` only | no ghost |
| **HL2 (real, gw74, RX only)** | sim → hl2 | **`0xe1000000`** | neutral materialise still runs — HL2 keeps its pan |
| demo | hl2 → sim | `0x40000000` only | no ghost |

Two pre-existing behaviours observed during the matrix, **unchanged by this PR** (verified identical on the unfixed build):
- the HL2 pan applet stacks two `VfoWidget`s at identical geometry (parity on unfixed — separate issue to file);
- a connected Flex pan receiving no data walks its auto-range down at −24 dB/s until the session ends (seen on a second-client flex-sim connect; the ghost was the *indefinite* case of this). Hardening the implausible-range guard to stop the walk is noted in #4671 as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
