### PR TITLE
fix(automation): dumpTree serializes a floated pan window once, not twice (#4674)

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -408,6 +408,11 @@ your "DOM snapshot" for controls.
 ← {"ok":true,"roots":[ <node>, <node>, … ]}
 ```
 
+A widget that is itself a window — a floated pan, a dialog, a popup menu —
+appears exactly once, as a **root**, never nested under its `QObject` parent
+even when it has one. Walk `roots` to find them; do not expect to reach a
+floated pan (or a parented context menu) by descending from `MainWindow`.
+
 Each `<node>`:
 
 ```jsonc

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -554,12 +554,15 @@ QJsonObject describeWidget(const QWidget* w)
     const QObjectList children = w->children();
     for (const QObject* child : children) {
         if (auto* cw = qobject_cast<const QWidget*>(child)) {
-            // A child that is itself a window (a floated pan's
-            // PanFloatingWindow is a Qt::Window parented to MainWindow for
-            // z-order/lifetime) is already enumerated by doDumpTree()'s
-            // topLevelWidgets() loop. Describing it here too serialized the
-            // whole window twice, so every widget inside a floated pan
-            // appeared as a duplicate — two VfoWidgets for one slice.
+            // Any child that is itself a window is already enumerated by
+            // doDumpTree()'s topLevelWidgets() loop — in Qt 6 that list is
+            // exactly the isWindow() set, so skipping here drops a duplicate
+            // and never the only copy. This covers a floated pan's
+            // PanFloatingWindow (a Qt::Window parented to MainWindow for
+            // z-order/lifetime) and equally parented QMenu popups and
+            // dialogs. Describing them here too serialized the whole window
+            // twice, so every widget inside a floated pan appeared as a
+            // duplicate — two VfoWidgets for one slice.
             if (cw->isWindow())
                 continue;
             kids.append(describeWidget(cw));
@@ -3466,11 +3469,21 @@ QJsonObject AutomationServer::doDumpTree() const
 QJsonObject AutomationServer::doFloors() const
 {
     QJsonArray arr;
+    QSet<const QWidget*> visited;
     const QWidgetList tops = QApplication::topLevelWidgets();
     for (QWidget* tlw : tops) {
         QList<QWidget*> scan = tlw->findChildren<QWidget*>();
         scan.prepend(tlw);
         for (QWidget* w : scan) {
+            // findChildren() recurses straight through a parented Qt::Window,
+            // which is ALSO its own entry in tops — so a floated pan's
+            // SpectrumWidget was reached twice and emitted two entries with the
+            // same panIndex. floors is documented for 20 Hz polling, so a driver
+            // that averages or zips the array silently double-weighted every
+            // floated pan. Visit each widget once. (#4674)
+            if (visited.contains(w))
+                continue;
+            visited.insert(w);
             const QVariant nf = w->property("noiseFloorDbm");
             if (!nf.isValid())
                 continue;   // not a spectrum — property absent

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -553,8 +553,17 @@ QJsonObject describeWidget(const QWidget* w)
     QJsonArray kids;
     const QObjectList children = w->children();
     for (const QObject* child : children) {
-        if (auto* cw = qobject_cast<const QWidget*>(child))
+        if (auto* cw = qobject_cast<const QWidget*>(child)) {
+            // A child that is itself a window (a floated pan's
+            // PanFloatingWindow is a Qt::Window parented to MainWindow for
+            // z-order/lifetime) is already enumerated by doDumpTree()'s
+            // topLevelWidgets() loop. Describing it here too serialized the
+            // whole window twice, so every widget inside a floated pan
+            // appeared as a duplicate — two VfoWidgets for one slice.
+            if (cw->isWindow())
+                continue;
             kids.append(describeWidget(cw));
+        }
     }
 
     if (auto* menu = qobject_cast<const QMenu*>(w)) {

--- a/tests/automation_drag_at_test.cpp
+++ b/tests/automation_drag_at_test.cpp
@@ -9,8 +9,10 @@
 #include <QCoreApplication>
 #include <QElapsedTimer>
 #include <QEventLoop>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QJsonValue>
 #include <QLocalSocket>
 #include <QMouseEvent>
 #include <QTemporaryDir>
@@ -154,6 +156,28 @@ bool hasExpectedMouseEvents(const QVector<RecordedMouseEvent>& events)
     return true;
 }
 
+// Count nodes with a given objectName anywhere in a dumpTree subtree. A window
+// parented to another widget is enumerated as a root by topLevelWidgets() AND
+// was recursed into by its parent's node, so the duplicate shows up as a count
+// of 2 rather than as a malformed tree. (#4674)
+int countNodes(const QJsonObject& node, const QString& name)
+{
+    int n = node.value(QStringLiteral("objectName")).toString() == name ? 1 : 0;
+    for (const QJsonValue& kid : node.value(QStringLiteral("children")).toArray()) {
+        n += countNodes(kid.toObject(), name);
+    }
+    return n;
+}
+
+int countNodesInTree(const QJsonObject& tree, const QString& name)
+{
+    int n = 0;
+    for (const QJsonValue& root : tree.value(QStringLiteral("roots")).toArray()) {
+        n += countNodes(root.toObject(), name);
+    }
+    return n;
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -264,6 +288,48 @@ int main(int argc, char** argv)
                && activatedMemoryPan == QStringLiteral("0x40000000"),
            QString::fromUtf8(
                QJsonDocument(memory).toJson(QJsonDocument::Compact)));
+
+    // ---- a parented window is serialized once, not twice (#4674) ----
+    // PanFloatingWindow is a Qt::Window parented to MainWindow for z-order and
+    // lifetime. In Qt 6 topLevelWidgets() is exactly the isWindow() set, so such
+    // a widget is enumerated as a root AND was recursed into by its parent's
+    // node — every widget inside a floated pan appeared twice (two VfoWidgets
+    // for one slice). A bare QWidget reproduces it without a radio.
+    QWidget floated(&target, Qt::Window);
+    floated.setObjectName(QStringLiteral("automationFloatedProbe"));
+    floated.resize(80, 60);
+    QWidget inner(&floated);
+    inner.setObjectName(QStringLiteral("automationFloatedChildProbe"));
+    // floors keys off the property, not the concrete type, so a plain widget
+    // stands in for a floated pan's SpectrumWidget here.
+    inner.setProperty("noiseFloorDbm", -122.5);
+    inner.setProperty("panIndex", 1);
+    floated.show();
+    QCoreApplication::processEvents();
+
+    const QJsonObject tree = request(socket, QByteArrayLiteral("dumpTree"));
+    const int windowNodes =
+        countNodesInTree(tree, QStringLiteral("automationFloatedProbe"));
+    const int childNodes =
+        countNodesInTree(tree, QStringLiteral("automationFloatedChildProbe"));
+    report("parented window serialized once",
+           windowNodes == 1, QStringLiteral("count=%1").arg(windowNodes));
+    report("its child serialized once",
+           childNodes == 1, QStringLiteral("count=%1").arg(childNodes));
+
+    // Same double-count, different verb: findChildren() also recurses through a
+    // parented window, so one spectrum yielded two floors entries with the same
+    // panIndex — and floors is documented for 20 Hz polling, so a driver that
+    // averages the array silently double-weighted every floated pan. (#4674)
+    const QJsonObject floors = request(socket, QByteArrayLiteral("floors"));
+    int floorEntries = 0;
+    for (const QJsonValue& entry : floors.value(QStringLiteral("floors")).toArray()) {
+        if (entry.toObject().value(QStringLiteral("panIndex")).toInt() == 1) {
+            ++floorEntries;
+        }
+    }
+    report("floors reports one entry per spectrum",
+           floorEntries == 1, QStringLiteral("count=%1").arg(floorEntries));
 
     target.mouseEvents.clear();
     server.setAuthToken(QStringLiteral("test-token"));


### PR DESCRIPTION
Fixes #4674.

## Root cause

`doDumpTree()` iterates `QApplication::topLevelWidgets()`, which includes `PanFloatingWindow` — a `Qt::Window` widget is a top-level window even when it has a QObject parent (it is parented to MainWindow deliberately, for z-order and lifetime). `describeWidget()`'s recursion over `w->children()` reaches the same window again through MainWindow, so a floated pan's entire subtree was serialized twice: two `PanFloatingWindow`s, two `PanadapterApplet`s, two `VfoWidget`s with the same `sliceId` for a single slice. It presented as a real UI duplication during the #4672 verification matrix and cost an investigation to un-believe — the "bridge confidently wrong" failure mode from #3845.

## Fix

Skip children that are themselves windows in `describeWidget()`'s recursion — they are already enumerated as roots. One canonical location per window, matching `topLevelWidgets()` semantics. Docked pans are unaffected (they were never double-listed).

## Proof via the agent automation bridge

Same scenario both sides: HL2 session (real gw74 radio, RX only) with its pan floated (`FloatingPanIds` restore).

**Before** (three independent confirmations that it is ONE object listed twice, not two objects):
- `dumpTree`: 2 `PanFloatingWindow` / 2 `VfoWidget` nodes, identical geometry and `sliceId`, for `get slices` count 1 and `layout get` → `floatingCount: 1`
- instrumented `floatPanadapter()`: exactly one `new PanFloatingWindow` per session
- `resize 997 313 PanFloatingWindow`: **both** nodes changed `1053x316 → 997x313` in the same dump

**After** (this fix):
```
PanFloatingWindow nodes: 1
VfoWidget nodes:         1
floated window present as a root: True    <- still fully reachable, just not duplicated
model slices: 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
