### PR TITLE
fix(asr): capability-gate the default compute device; persist the model tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **Copy Assist no longer auto-selects a GPU that can't run the decoder
+  (#4676).** On Intel Macs the first enumerated Metal device — e.g. a Radeon
+  Pro 560X that fails every ggml capability check — became the default compute
+  device, producing unreadable transcription at every model tier and an abort
+  in ggml's discrete-GPU transfer path. The default now resolves to the first
+  device that passes a capability probe (public `ggml_backend_dev_supports_op`,
+  so Vulkan/CUDA hosts benefit unchanged), else CPU; capability-failing devices
+  stay selectable but are labeled "(unsupported)". The Large-v3-Turbo default
+  tier now applies only when decode actually lands on a usable GPU, and the
+  chosen model tier persists across restarts.
+
 - **Amplifier bar gauges no longer keep painting the old scale after the range
   changes (#4636).** When a gauge's scale is re-derived from live telemetry —
   the ACOM auto-range as forward power outgrows its tier, an SPE LOW/MID/HIGH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   Pro 560X that fails every ggml capability check — became the default compute
   device, producing unreadable transcription at every model tier and an abort
   in ggml's discrete-GPU transfer path. The default now resolves to the first
-  device that passes a capability probe (public `ggml_backend_dev_supports_op`,
+  device that passes a capability probe covering the soft-max, mat-mul, and
+  flash-attention ops whisper schedules (public `ggml_backend_dev_supports_op`,
   so Vulkan/CUDA hosts benefit unchanged), else CPU; capability-failing devices
   stay selectable but are labeled "(unsupported)". The Large-v3-Turbo default
   tier now applies only when decode actually lands on a usable GPU, and the

--- a/docs/asr-copy-assist.md
+++ b/docs/asr-copy-assist.md
@@ -88,7 +88,7 @@ is accepted:
 | tiny | 74 MB | fastest, roughest |
 | **base** | 141 MB | default on CPU/ARM (incl. Raspberry Pi 5) |
 | small | 465 MB | desktop CPU |
-| **large-v3-turbo** | 1.6 GB | default when a GPU is available |
+| **large-v3-turbo** | 1.6 GB | default when a *usable* GPU is available (see GPU acceleration) |
 
 Offline/air-gapped: drop the `ggml-*.bin` file into the models dir manually.
 
@@ -102,8 +102,16 @@ and it runs on the selected compute device like any built-in tier.
 
 ## GPU acceleration
 
-The selected model runs on the **GPU when one is available**, else CPU
-(automatic fallback). GPU is auto-detected at build time and used at runtime via
+The selected model runs on the **GPU when a usable one is available**, else CPU
+(automatic fallback). At startup each enumerated GPU is probed for the ops
+whisper's decode actually schedules (soft-max, mat-mul, flash attention); only
+a device that passes all three is offered as the default. Devices that fail
+the probe stay selectable in the compute-device picker but are labeled
+**"(unsupported)"** — picking one is allowed (e.g. for diagnostics) but decode
+quality/stability is not guaranteed there (#4676). An explicitly chosen device
+and the chosen model tier both persist across restarts; the tier picker's
+default (Large-v3-Turbo) applies only when decode lands on a usable GPU. GPU
+support is auto-detected at build time and used at runtime via
 `ggml_backend_dev_by_type(GPU)`:
 
 - **Vulkan** — Linux/Windows (NVIDIA/AMD/Intel). Requires the Vulkan

--- a/src/asr/WhisperAsrBackend.cpp
+++ b/src/asr/WhisperAsrBackend.cpp
@@ -225,8 +225,9 @@ std::function<std::unique_ptr<IAsrBackend>()> whisperAsrBackendFactory(const QSt
 namespace {
 // Whether `dev` can run the kernels whisper's heavy path schedules on the GPU.
 // Probed through the public ggml_backend_dev_supports_op with synthetic ops —
-// a contiguous F32 soft-max (gated on has_simdgroup_reduction in the Metal
-// backend) and an F16 mat-mul (gated on has_simdgroup_mm) — rather than by
+// a contiguous F32 soft-max and an F16 mat-mul (both gated on
+// has_simdgroup_reduction in the Metal backend) and a flash-attention op
+// (the only op gated on has_simdgroup_mm) — rather than by
 // reading backend-internal device props, so it works unchanged for Vulkan/CUDA
 // hosts. supports_op only consults device properties: nothing is compiled or
 // allocated (no_alloc context, freed before returning).
@@ -243,8 +244,19 @@ bool asrDeviceUsableForDecode(ggml_backend_dev_t dev)
     ggml_tensor* softMax = ggml_soft_max(ctx, act);
     ggml_tensor* weights = ggml_new_tensor_2d(ctx, GGML_TYPE_F16, 64, 64);
     ggml_tensor* mulMat = ggml_mul_mat(ctx, weights, act);
+    // FLASH_ATTN_EXT is the only op the Metal backend gates on
+    // has_simdgroup_mm, and whisper turns flash attention on unconditionally
+    // (whisper_context_default_params), so it has to be probed separately —
+    // a Metal3-but-not-Apple7 dGPU passes the two ops above and still gets a
+    // split graph without it. Head dim 64 + F16 K/V mirrors whisper's encoder.
+    ggml_tensor* q = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, 64, 4, 8);
+    ggml_tensor* k = ggml_new_tensor_3d(ctx, GGML_TYPE_F16, 64, 4, 8);
+    ggml_tensor* v = ggml_new_tensor_3d(ctx, GGML_TYPE_F16, 64, 4, 8);
+    ggml_tensor* flashAttn =
+        ggml_flash_attn_ext(ctx, q, k, v, nullptr, 1.0f, 0.0f, 0.0f);
     const bool usable = ggml_backend_dev_supports_op(dev, softMax)
-        && ggml_backend_dev_supports_op(dev, mulMat);
+        && ggml_backend_dev_supports_op(dev, mulMat)
+        && ggml_backend_dev_supports_op(dev, flashAttn);
     ggml_free(ctx);
     return usable;
 }

--- a/src/asr/WhisperAsrBackend.cpp
+++ b/src/asr/WhisperAsrBackend.cpp
@@ -222,6 +222,34 @@ std::function<std::unique_ptr<IAsrBackend>()> whisperAsrBackendFactory(const QSt
     };
 }
 
+namespace {
+// Whether `dev` can run the kernels whisper's heavy path schedules on the GPU.
+// Probed through the public ggml_backend_dev_supports_op with synthetic ops —
+// a contiguous F32 soft-max (gated on has_simdgroup_reduction in the Metal
+// backend) and an F16 mat-mul (gated on has_simdgroup_mm) — rather than by
+// reading backend-internal device props, so it works unchanged for Vulkan/CUDA
+// hosts. supports_op only consults device properties: nothing is compiled or
+// allocated (no_alloc context, freed before returning).
+bool asrDeviceUsableForDecode(ggml_backend_dev_t dev)
+{
+    ggml_init_params params = {};
+    params.mem_size = 16 * 1024;
+    params.no_alloc = true;
+    ggml_context* ctx = ggml_init(params);
+    if (!ctx) {
+        return false;
+    }
+    ggml_tensor* act = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 64, 64);
+    ggml_tensor* softMax = ggml_soft_max(ctx, act);
+    ggml_tensor* weights = ggml_new_tensor_2d(ctx, GGML_TYPE_F16, 64, 64);
+    ggml_tensor* mulMat = ggml_mul_mat(ctx, weights, act);
+    const bool usable = ggml_backend_dev_supports_op(dev, softMax)
+        && ggml_backend_dev_supports_op(dev, mulMat);
+    ggml_free(ctx);
+    return usable;
+}
+} // namespace
+
 std::vector<AsrGpuDevice> asrGpuDevices()
 {
     if (!asrMetalUsableHost()) {
@@ -239,10 +267,25 @@ std::vector<AsrGpuDevice> asrGpuDevices()
             AsrGpuDevice d;
             d.index = index++;
             d.name = QString::fromUtf8(ggml_backend_dev_description(dev));
+            d.usable = asrDeviceUsableForDecode(dev);
+            if (!d.usable) {
+                qCInfo(lcAsrWhisper) << "GPU device" << d.index << d.name
+                                     << "fails the decode capability probe - not offered as default";
+            }
             devices.push_back(std::move(d));
         }
     }
     return devices;
+}
+
+int asrResolveDefaultGpuIndex(const std::vector<AsrGpuDevice>& devices)
+{
+    for (const AsrGpuDevice& d : devices) {
+        if (d.usable) {
+            return d.index;
+        }
+    }
+    return -1;
 }
 
 bool asrGpuAvailable()

--- a/src/asr/WhisperAsrBackend.h
+++ b/src/asr/WhisperAsrBackend.h
@@ -40,7 +40,18 @@ private:
 struct AsrGpuDevice {
     int index = 0;
     QString name;
+    // Whether the device supports the kernels whisper's heavy path needs
+    // (probed via ggml_backend_dev_supports_op — see asrGpuDevices()). An
+    // unusable device stays selectable for diagnostics but must never be the
+    // default: on such devices the scheduler splits the graph across GPU and
+    // CPU, producing wrong output and reaching an aborting transfer path
+    // (#4676).
+    bool usable = true;
 };
+
+// The device auto-selection policy (#4676): index of the first usable device,
+// or -1 (CPU) when none qualifies. Pure so the unit test can pin the contract.
+int asrResolveDefaultGpuIndex(const std::vector<AsrGpuDevice>& devices);
 
 // Factory for wiring AsrEngine to the production whisper backend. Kept here so
 // AsrEngine.cpp never references whisper (keeping the engine — and its unit

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -156,6 +156,16 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
         CopyAssistSettings::value(QStringLiteral("AsrGpuDevice"), QString()).toString();
     if (!savedGpu.isEmpty()) {
         m_gpuDevice = savedGpu.toInt(); // an explicit compute-device choice always wins
+        m_gpuDeviceExplicit = true;
+    }
+    // A previously chosen catalog tier survives restart (#4676). Remote is
+    // restored above; custom/sherpa keep their own path keys and re-prompt.
+    const QString savedTier =
+        CopyAssistSettings::value(QStringLiteral("AsrTier"), QString()).toString();
+    if (m_backend == AsrBackendKind::Whisper && !savedTier.isEmpty()
+        && AsrModelCatalog::tierById(savedTier) != nullptr) {
+        m_tierId = savedTier;
+        m_useGpuDefaultIfAvailable = false;
     }
     m_settings->setCurrentTier(m_tierId);
 
@@ -229,6 +239,7 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
             return;
         }
         m_gpuDevice = index;
+        m_gpuDeviceExplicit = true;
         saveInt("AsrGpuDevice", index);
         if (m_backend != AsrBackendKind::Remote) {
             m_tap->setEnabled(false);
@@ -478,23 +489,37 @@ void CopyAssistController::applyGpuDevices(const std::vector<AsrGpuDevice>& gpus
 
         if (!gpus.empty()) {
             for (const AsrGpuDevice& gpu : gpus) {
-                m_settings->addGpuDevice(gpu.index, gpu.name);
+                // An unusable device stays selectable for diagnostics, but the
+                // combo says why it isn't the default (#4676).
+                m_settings->addGpuDevice(gpu.index,
+                                         gpu.usable ? gpu.name
+                                                    : tr("%1 (unsupported)").arg(gpu.name));
             }
             m_settings->addGpuDevice(-1, tr("CPU")); // explicit force-CPU option
 
-            if (resolvedDevice != -1
+            const bool outOfRange = resolvedDevice != -1
                 && (resolvedDevice < 0
-                    || resolvedDevice >= static_cast<int>(gpus.size()))) {
-                resolvedDevice = 0;
-                persistResolvedDevice = true;
+                    || resolvedDevice >= static_cast<int>(gpus.size()));
+            if (!m_gpuDeviceExplicit || outOfRange) {
+                // Default to the first device that passes the decode capability
+                // probe, else CPU. A device that fails the probe runs a mixed
+                // GPU/CPU graph: wrong output at every tier, and an aborting
+                // transfer path on discrete GPUs (#4676). Only an out-of-range
+                // clamp is persisted — a computed default stays recomputable.
+                resolvedDevice = asrResolveDefaultGpuIndex(gpus);
+                persistResolvedDevice = outOfRange;
             }
             m_settings->setCurrentGpu(resolvedDevice);
             m_settings->setGpuSelectorVisible(true);
             m_settings->setGpuSelectorEnabled(true);
 
-            // Preserve the existing GPU-host default, but only while the
-            // operator has not made an explicit model choice during the probe.
-            if (m_useGpuDefaultIfAvailable) {
+            // Preserve the GPU-host default tier, but only while the operator
+            // has not made an explicit model choice, and only when the decode
+            // will actually run on a usable GPU — a CPU or capability-failing
+            // resolution must not select the heaviest model (#4676).
+            if (m_useGpuDefaultIfAvailable && resolvedDevice >= 0
+                && resolvedDevice < static_cast<int>(gpus.size())
+                && gpus[resolvedDevice].usable) {
                 m_tierId = QStringLiteral("large-v3-turbo");
                 m_settings->setCurrentTier(m_tierId);
             }
@@ -657,7 +682,16 @@ void CopyAssistController::onTierChanged(const QString& tierId)
                                  tr("Sherpa: %1").arg(QDir(dir).dirName()));
         setBackend(AsrBackendKind::SherpaOnnx, tierId);
     } else {
+        // A catalog tier is an explicit, restorable choice — persist it so it
+        // survives restart (#4676). Special tiers keep their own keys and the
+        // stale catalog choice must not resurrect over them.
+        CopyAssistSettings::setValue(QStringLiteral("AsrTier"), tierId);
         setBackend(backendForTier(tierId), tierId);
+    }
+    if (tierId == QString::fromLatin1(kRemoteTierId)
+        || tierId == QString::fromLatin1(kCustomTierId)
+        || tierId == QString::fromLatin1(kSherpaTierId)) {
+        CopyAssistSettings::setValue(QStringLiteral("AsrTier"), QString());
     }
 
     if (m_enabled) {

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -165,6 +165,10 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     if (m_backend == AsrBackendKind::Whisper && !savedTier.isEmpty()
         && AsrModelCatalog::tierById(savedTier) != nullptr) {
         m_tierId = savedTier;
+        // Every catalog tier is Whisper-family today, but route through the
+        // same mapping the picker uses so a future non-Whisper catalog tier
+        // restores with the right engine instead of failing silently.
+        m_backend = backendForTier(savedTier);
         m_useGpuDefaultIfAvailable = false;
     }
     m_settings->setCurrentTier(m_tierId);
@@ -477,7 +481,6 @@ void CopyAssistController::applyGpuDevices(const std::vector<AsrGpuDevice>& gpus
 {
     const int previousDevice = m_gpuDevice;
     int resolvedDevice = previousDevice;
-    bool persistResolvedDevice = false;
 
     // Adding or clearing combo items changes its current index. Suppress the
     // dialog's outward gpuChanged/tierChanged signals while discovery state is
@@ -504,10 +507,11 @@ void CopyAssistController::applyGpuDevices(const std::vector<AsrGpuDevice>& gpus
                 // Default to the first device that passes the decode capability
                 // probe, else CPU. A device that fails the probe runs a mixed
                 // GPU/CPU graph: wrong output at every tier, and an aborting
-                // transfer path on discrete GPUs (#4676). Only an out-of-range
-                // clamp is persisted — a computed default stays recomputable.
+                // transfer path on discrete GPUs (#4676).
+                // Not persisted: an out-of-range explicit choice can become
+                // valid again when the device returns, and overwriting it with
+                // a computed value would pin that computation permanently.
                 resolvedDevice = asrResolveDefaultGpuIndex(gpus);
-                persistResolvedDevice = outOfRange;
             }
             m_settings->setCurrentGpu(resolvedDevice);
             m_settings->setGpuSelectorVisible(true);
@@ -517,9 +521,17 @@ void CopyAssistController::applyGpuDevices(const std::vector<AsrGpuDevice>& gpus
             // has not made an explicit model choice, and only when the decode
             // will actually run on a usable GPU — a CPU or capability-failing
             // resolution must not select the heaviest model (#4676).
-            if (m_useGpuDefaultIfAvailable && resolvedDevice >= 0
-                && resolvedDevice < static_cast<int>(gpus.size())
-                && gpus[resolvedDevice].usable) {
+            // resolvedDevice is an AsrGpuDevice::index; asrGpuDevices() assigns
+            // it densely so it equals the vector position today, but look up by
+            // the index field so the two keys can't silently diverge.
+            const AsrGpuDevice* resolved = nullptr;
+            for (const AsrGpuDevice& g : gpus) {
+                if (g.index == resolvedDevice) {
+                    resolved = &g;
+                    break;
+                }
+            }
+            if (m_useGpuDefaultIfAvailable && resolved && resolved->usable) {
                 m_tierId = QStringLiteral("large-v3-turbo");
                 m_settings->setCurrentTier(m_tierId);
             }
@@ -535,9 +547,6 @@ void CopyAssistController::applyGpuDevices(const std::vector<AsrGpuDevice>& gpus
     }
 
     m_gpuDevice = resolvedDevice;
-    if (persistResolvedDevice) {
-        saveInt("AsrGpuDevice", resolvedDevice);
-    }
     if (resolvedDevice != previousDevice && m_backend == AsrBackendKind::Whisper) {
         m_tap->setEnabled(false);
         buildEngine();
@@ -658,6 +667,9 @@ void CopyAssistController::onTierChanged(const QString& tierId)
             m_settings->setCurrentTier(m_tierId); // user cancelled — revert
             return;
         }
+        // A special tier owns its own keys — a stale catalog choice must not
+        // resurrect over it on the next launch (same in the two branches below).
+        CopyAssistSettings::setValue(QStringLiteral("AsrTier"), QString());
         setBackend(AsrBackendKind::Remote, tierId);
     } else if (tierId == QString::fromLatin1(kCustomTierId)) {
         const QString path = promptCustomModel();
@@ -666,6 +678,7 @@ void CopyAssistController::onTierChanged(const QString& tierId)
             return;
         }
         m_customModelPath = path;
+        CopyAssistSettings::setValue(QStringLiteral("AsrTier"), QString());
         CopyAssistSettings::setValue(QStringLiteral("AsrCustomModelPath"), path);
         m_settings->setTierLabel(QString::fromLatin1(kCustomTierId),
                                  tr("Custom: %1").arg(QFileInfo(path).fileName()));
@@ -677,6 +690,7 @@ void CopyAssistController::onTierChanged(const QString& tierId)
             return;
         }
         m_sherpaModelDir = dir;
+        CopyAssistSettings::setValue(QStringLiteral("AsrTier"), QString());
         CopyAssistSettings::setValue(QStringLiteral("AsrSherpaModelDir"), dir);
         m_settings->setTierLabel(QString::fromLatin1(kSherpaTierId),
                                  tr("Sherpa: %1").arg(QDir(dir).dirName()));
@@ -687,11 +701,6 @@ void CopyAssistController::onTierChanged(const QString& tierId)
         // stale catalog choice must not resurrect over them.
         CopyAssistSettings::setValue(QStringLiteral("AsrTier"), tierId);
         setBackend(backendForTier(tierId), tierId);
-    }
-    if (tierId == QString::fromLatin1(kRemoteTierId)
-        || tierId == QString::fromLatin1(kCustomTierId)
-        || tierId == QString::fromLatin1(kSherpaTierId)) {
-        CopyAssistSettings::setValue(QStringLiteral("AsrTier"), QString());
     }
 
     if (m_enabled) {

--- a/src/gui/CopyAssistController.h
+++ b/src/gui/CopyAssistController.h
@@ -100,6 +100,8 @@ private:
     bool m_gpuDiscoveryPending = true;
     bool m_enableAfterGpuDiscovery = false;
     int m_gpuDevice = 0; // resolved default or explicit setting; -1 forces CPU
+    bool m_gpuDeviceExplicit = false; // true only for a user/persisted choice —
+                                      // a computed default stays recomputable (#4676)
     QString m_tierId;
     QString m_customModelPath; // user-picked local model (for the "Custom model…" tier)
     QString m_sherpaModelDir;  // user-picked sherpa-onnx model directory

--- a/tests/asr_gpu_probe_test.cpp
+++ b/tests/asr_gpu_probe_test.cpp
@@ -36,6 +36,7 @@
 #include <QElapsedTimer>
 #include <QtGlobal>
 
+#include <algorithm>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
@@ -143,7 +144,41 @@ int main()
     std::printf("[ok] full GPU probe returned: %zu device(s) in %lld ms\n",
                 devices.size(), static_cast<long long>(probeMs));
     for (const AsrGpuDevice& d : devices) {
-        std::printf("     device %d: %s\n", d.index, qPrintable(d.name));
+        std::printf("     device %d: %s (usable=%s)\n", d.index, qPrintable(d.name),
+                    d.usable ? "true" : "false");
+    }
+
+    // #4676 default-selection contract, on the real enumeration: the resolved
+    // default is either CPU (-1) or a device that passed the capability probe.
+    // A capability-failing device as default runs a mixed GPU/CPU graph: wrong
+    // output at every tier, and an aborting transfer path on discrete GPUs.
+    {
+        const int def = asrResolveDefaultGpuIndex(devices);
+        if (def != -1) {
+            const auto it = std::find_if(devices.begin(), devices.end(),
+                                         [def](const AsrGpuDevice& d) { return d.index == def; });
+            if (it == devices.end() || !it->usable) {
+                std::fprintf(stderr, "[FAIL] default resolved to device %d, which is "
+                                     "not a usable enumerated device (#4676)\n", def);
+                return 1;
+            }
+        }
+        std::printf("[ok] #4676 default resolution: %d\n", def);
+
+        // And the pure contract, host-independent: first usable wins; no usable
+        // device means CPU.
+        const std::vector<AsrGpuDevice> noneUsable = {
+            {0, QStringLiteral("dGPU"), false}, {1, QStringLiteral("iGPU"), false}};
+        const std::vector<AsrGpuDevice> secondUsable = {
+            {0, QStringLiteral("dGPU"), false}, {1, QStringLiteral("iGPU"), true}};
+        if (asrResolveDefaultGpuIndex({}) != -1
+            || asrResolveDefaultGpuIndex(noneUsable) != -1
+            || asrResolveDefaultGpuIndex(secondUsable) != 1) {
+            std::fprintf(stderr, "[FAIL] asrResolveDefaultGpuIndex contract broken "
+                                 "(#4676)\n");
+            return 1;
+        }
+        std::printf("[ok] #4676 resolution contract (empty/none-usable/mixed lists)\n");
     }
 
 #ifdef Q_OS_MACOS

--- a/tests/copy_assist_settings_dialog_test.cpp
+++ b/tests/copy_assist_settings_dialog_test.cpp
@@ -79,6 +79,27 @@ int main(int argc, char** argv)
                "setValue then value round-trips through the nested object");
     }
 
+    // ---- AsrTier persistence contract (#4676) --------------------------------
+    // A chosen catalog tier is written to the nested store and restorable; the
+    // special tiers clear it with an empty write. Pinned here so a controller
+    // refactor can't silently drop the restart-survival half of the fix.
+    {
+        auto& s = AppSettings::instance();
+        CopyAssistSettings::setValue(QStringLiteral("AsrTier"),
+                                     QStringLiteral("small"));
+        expect(CopyAssistSettings::value(QStringLiteral("AsrTier"), QString())
+                       .toString() == QStringLiteral("small"),
+               "AsrTier catalog choice round-trips through the nested store");
+        expect(!s.contains(QStringLiteral("AsrTier")),
+               "AsrTier lives only in the nested CopyAssist object, never flat");
+
+        CopyAssistSettings::setValue(QStringLiteral("AsrTier"), QString());
+        expect(CopyAssistSettings::value(QStringLiteral("AsrTier"), QString())
+                       .toString().isEmpty(),
+               "special tiers clear AsrTier so a stale catalog choice cannot "
+               "resurrect");
+    }
+
     // Frameless-window behavior (from #4414) shares this offscreen harness.
     AppSettings::instance().setValue(QStringLiteral("FramelessWindow"),
                                      QStringLiteral("True"));


### PR DESCRIPTION
Fixes #4676.

## Root cause

Two defaults compound on any host whose GPU enumerates but fails ggml's capability checks — since #4553, that includes Intel Macs:

- `src/gui/CopyAssistController.h` — `m_gpuDevice = 0`: the first enumerated GPU is selected with no user action.
- `src/gui/CopyAssistController.cpp` — the model tier was never persisted, and any non-empty GPU list reset it to `large-v3-turbo` at each launch (a heuristic from when a non-empty list implied Apple Silicon).

On such a device the scheduler splits the whisper graph across GPU and CPU: unreadable transcription at every model tier, and on discrete GPUs an abort in the transfer path (`GGML_ASSERT(buf_dst)`, `ggml-metal-device.m:1843` — 2/2 reproductions on the #4676 machine).

## The fix

- `AsrGpuDevice` gains `usable`, probed per device in `asrGpuDevices()` through the **public** `ggml_backend_dev_supports_op` with three synthetic ops — a contiguous F32 soft-max and an F16 mat-mul (both gated on `has_simdgroup_reduction` in the Metal backend) and a flash-attention op (the only op gated on `has_simdgroup_mm`, which whisper enables unconditionally) — no backend-internal headers, and the same probe works for Vulkan/CUDA hosts.
- New pure `asrResolveDefaultGpuIndex()`: first usable device, else −1 (CPU). The controller uses it whenever the user has not made an explicit device choice (`m_gpuDeviceExplicit`); a computed default is never persisted, so hardware/driver changes re-evaluate. Capability-failing devices stay selectable, labeled "(unsupported)".
- The Large-v3-Turbo default tier applies only when decode actually lands on a usable GPU.
- A chosen catalog tier persists (`AsrTier`) and is restored at startup; special tiers (remote/custom/sherpa) clear it and keep their own keys.
- `tests/asr_gpu_probe_test` prints per-device usability and asserts the resolved default is CPU-or-usable on the real enumeration, plus the pure resolution contract on synthetic lists.

Deliberately out of scope: the ggml hardening (fall back instead of aborting when `newBufferWithBytesNoCopy` returns nil) — vendored-tree change, tracked as a follow-up in #4676.

## Verification — agent automation bridge, on the #4676 reporter machine

MacBook Pro 15" 2019 (Radeon Pro 560X), macOS 15.7.7. Fresh settings store, About SHA verified `1931227b`+fix. Before-values are the same bridge readings captured on unfixed main (`03173c13`) while producing the #4676 evidence.

| bridge reading (fresh store, no user input) | unfixed main | this PR |
|---|---|---|
| `CopyAssistGpuCombo` value | AMD Radeon Pro 560X | **CPU** |
| `CopyAssistGpuCombo` items | "AMD Radeon Pro 560X" | "AMD Radeon Pro 560X **(unsupported)**", "CPU" |
| `CopyAssistModelCombo` value | Large v3 Turbo | **Base** |
| demo Voice transcription | `.fl ���������.fa, orthog��…` @ queue 120 s | correct Harvard sentences @ **queue 0.0 s** |
| whisper init | `use gpu = 1` | `use gpu = 0`, `whisper_backend_init_gpu: no GPU found` |
| after quit | SIGABRT draining backlog (2/2 runs) | clean exit |
| model tier after restart | reset to Large v3 Turbo | **restored (Small)**; store shows `AsrTier`, no persisted device key |

Runtime log lines from the fixed build (About SHA verified):

```
# app category log — the new capability probe:
[13:00:54.030] INF aether.asr.whisper: GPU device 0 "AMD Radeon Pro 560X" fails the decode capability probe - not offered as default

# whisper engine init (stderr), Base and Small builds:
whisper_init_with_params_no_state: use gpu    = 0
whisper_model_load: type          = 2 (base)
whisper_backend_init_gpu: no GPU found
whisper_init_with_params_no_state: use gpu    = 0
whisper_model_load: type          = 3 (small)
whisper_backend_init_gpu: no GPU found
```

`asr_gpu_probe_test` on the reporter machine:

```
[ok] precompiled build, no host gate: 1 device(s) in 102 ms (Intel)
[ok] full GPU probe returned: 1 device(s) in 0 ms
     device 0: AMD Radeon Pro 560X (usable=false)
[ok] #4676 default resolution: -1
[ok] #4676 resolution contract (empty/none-usable/mixed lists)
[ok] embedded PRECOMPILED metallib loaded (no runtime shader compile)
1/1 Test #125: asr_gpu_probe_test ...............   Passed
```

`asr_gpu_probe_test` on this machine: `device 0: AMD Radeon Pro 560X (usable=false)` → `#4676 default resolution: -1`, contract checks pass, probe 758 ms, precompiled metallib load intact. Full ctest: green except `connection_panel_size_test`, which fails identically on unmodified main on this machine (display-geometry, pre-existing).

On this machine the default options are Base model and CPU compute - the user gets a workable combination:

<img width="525" height="141" alt="default" src="https://github.com/user-attachments/assets/9d11e893-df5e-423d-8bf0-417838948675" />

Unsupported device is indicated:

<img width="522" height="147" alt="dropdown" src="https://github.com/user-attachments/assets/e53f9170-47ec-4594-a7b9-b9ca0e62a1c2" />



Vulkan-host verification (capable GPU stays default, `usable=true`) follows on a Linux/NVIDIA machine (see comment below)

— authored by agent (Claude Code) on behalf of @skerker

🤖 Generated with [Claude Code](https://claude.com/claude-code)


