### PR TITLE
fix(demo): powerline hum is a phase accumulator; 50/60 Hz changes bend, not click (#4668)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **Demo mode's power-line hum clicked instead of bending when you moved its
+  50/60 Hz slider (#4668).** The hum's six harmonics were synthesized from
+  absolute time × the current mains frequency, so every move of **Power-line**
+  in the Demo applet jumped all six phases at once rather than changing their
+  frequency — and because that jump scales with the harmonic number, the high
+  harmonics stepped hardest and the click grew with how long the session had
+  been running. The hum now accumulates phase per sample the way the CW tone
+  (#4618) and the birdie carrier already did, deriving every harmonic from one
+  shared fundamental so they stay locked to each other, and bends smoothly to
+  the new frequency. This was the last generator in the demo mixer still keyed
+  off absolute time. Demo mode only — no radio, protocol, or transmit path is
+  involved.
+
 - **Amplifier bar gauges no longer keep painting the old scale after the range
   changes (#4636).** When a gauge's scale is re-derived from live telemetry —
   the ACOM auto-range as forward power outgrows its tier, an SPE LOW/MID/HIGH

--- a/src/core/backends/sim/NoiseMixer.cpp
+++ b/src/core/backends/sim/NoiseMixer.cpp
@@ -364,8 +364,11 @@ void NoiseMixer::genPowerline(const ChannelState& c, float* out)
         for (int h : {1, 3, 5, 7, 9, 11}) v += (1.0 / h) * std::sin(h * m_plPhaseRad);
         out[i] = static_cast<float>(v * kNoiseRef * 0.5);
         m_plPhaseRad += dphi;
+        // fmod, not a single subtraction, to match genCw and genBirdie: freq is
+        // an unclamped knob, so a caller sending f0 >= kSampleRate would leave a
+        // one-shot subtraction permanently behind and φ would grow without bound.
         if (m_plPhaseRad >= kTwoPi)
-            m_plPhaseRad -= kTwoPi;
+            m_plPhaseRad = std::fmod(m_plPhaseRad, kTwoPi);
     }
 }
 

--- a/src/core/backends/sim/NoiseMixer.cpp
+++ b/src/core/backends/sim/NoiseMixer.cpp
@@ -351,13 +351,22 @@ void NoiseMixer::genQrn(const ChannelState& c, float* out)
 void NoiseMixer::genPowerline(const ChannelState& c, float* out)
 {
     const double f0 = c.freq > 0 ? c.freq : 60.0;
+    // Continuous phase accumulation, same cure as the birdie and the CW tone
+    // (#4637): advance the FUNDAMENTAL's phase by 2π·f0/rate per sample and
+    // derive harmonic h as sin(h·φ). A live 50↔60 Hz change (the Demo applet's
+    // Power-line slider) then bends all six harmonics smoothly from their
+    // current phase; the old sin(2π·f0·h·t_absolute) teleported each by
+    // 2π·Δf·h·t at once — a hard click, worst on the high harmonics (#4668).
+    // Wrapping φ keeps sin(h·φ) exact for integer h: sin(h·(φ−2π)) == sin(h·φ).
+    const double dphi = kTwoPi * f0 / kSampleRate;
     for (int i = 0; i < kFrameLen; ++i) {
-        const double tt = static_cast<double>(m_plPhase + i) / kSampleRate;
         double v = 0.0;
-        for (int h : {1, 3, 5, 7, 9, 11}) v += (1.0 / h) * std::sin(kTwoPi * f0 * h * tt);
+        for (int h : {1, 3, 5, 7, 9, 11}) v += (1.0 / h) * std::sin(h * m_plPhaseRad);
         out[i] = static_cast<float>(v * kNoiseRef * 0.5);
+        m_plPhaseRad += dphi;
+        if (m_plPhaseRad >= kTwoPi)
+            m_plPhaseRad -= kTwoPi;
     }
-    m_plPhase += kFrameLen;
 }
 
 void NoiseMixer::genCrashes(const ChannelState& c, float* out)

--- a/src/core/backends/sim/NoiseMixer.h
+++ b/src/core/backends/sim/NoiseMixer.h
@@ -154,7 +154,10 @@ private:
     // phase jump is exactly the click genCw's 5 ms raised-cosine edges exist
     // to prevent. m_cwPhase stays purely as the keying-schedule clock. (#4618)
     double m_cwPhaseRad = 0.0;
-    qint64 m_plPhase = 0;      // sample counter; long overflows in ~25 h on LLP64 (#4618)
+    // Power-line fundamental phase as CONTINUOUS RADIANS (harmonic h derives as
+    // sin(h·φ)) — the last absolute-time oscillator, converted in #4668 so a
+    // live 50↔60 Hz change bends instead of teleporting. Wrapped to [0, 2π).
+    double m_plPhaseRad = 0.0;
     // Voice playback: the bundled speech clip's samples (mono float, 24 kHz),
     // loaded once, and the loop read position.
     std::vector<float> m_voiceSamples;

--- a/tests/noise_mixer_test.cpp
+++ b/tests/noise_mixer_test.cpp
@@ -291,6 +291,57 @@ void testCwPitchChangeSlidesWithoutClick()
            magAt(at650, 650.0) > 20.0 * magAt(at650, 550.0));
 }
 
+
+// #4668: genPowerline was the last absolute-time oscillator left after #4637.
+// The Demo applet ships the Power-line row's 50-60 Hz slider straight to
+// setKnob(Powerline, "freq", ...), and with sin(2*pi*f0*h*t_absolute) a 60->50
+// flip teleports all six harmonics' phase by 2*pi*dF*h*t at once. Same two-half
+// structure as the CW test above, for the same reason: continuity alone is also
+// satisfied by a generator that ignores the knob, so the frequency half pins
+// the knob to the oscillator.
+void testPowerlineFreqChangeStaysContinuous()
+{
+    // ---- half 1: no phase jump across repeated 50 <-> 60 flips --------------
+    NoiseMixer mx;
+    mx.setEnabled(Channel::Powerline, true);
+
+    QVector<float> audio;
+    for (int f = 0; f < 400; ++f) {
+        if (f % 10 == 0)
+            mx.setKnob(Channel::Powerline, QStringLiteral("freq"),
+                       (f % 20 == 0) ? 60.0 : 50.0);
+        audio += mx.mixFrame();
+    }
+
+    float amp = 0.0f;
+    for (float v : audio) amp = std::max(amp, std::abs(v));
+
+    // Each harmonic h carries amplitude ~1/h and slope amp_h*2*pi*60h/24000, so
+    // the 1/h weighting cancels h and all six contribute equal slope. Measured
+    // worst sample step: 0.10 of peak with the accumulator, 1.68 with absolute
+    // time (a teleport can step nearly the full harmonic sum at once). 0.30
+    // separates them by >3x on either side.
+    float worst = 0.0f;
+    for (int i = 1; i < audio.size(); ++i)
+        worst = std::max(worst, std::abs(audio[i] - audio[i - 1]));
+
+    report("powerline freq change keeps all harmonics phase continuous",
+           amp > 0.0f && worst < 0.30f * amp);
+
+    // ---- half 2: the fundamental lands ON the commanded mains freq ----------
+    auto holdFreq = [](double hz) {
+        NoiseMixer m;
+        m.setEnabled(Channel::Powerline, true);
+        m.setKnob(Channel::Powerline, QStringLiteral("freq"), hz);
+        return collect(m, 400);
+    };
+    const QVector<float> at50 = holdFreq(50.0);
+    const QVector<float> at60 = holdFreq(60.0);
+    report("powerline fundamental follows the freq knob",
+           magAt(at50, 50.0) > 5.0 * magAt(at50, 60.0) &&
+           magAt(at60, 60.0) > 5.0 * magAt(at60, 50.0));
+}
+
 void testLevelScalesNoiseHeight()
 {
     auto top = [](double lvl) {
@@ -319,6 +370,7 @@ int main(int argc, char** argv)
     testVoiceChannelSafeWithoutClip();
     testCwKeysDecodableMorse();
     testCwPitchChangeSlidesWithoutClick();
+    testPowerlineFreqChangeStaysContinuous();
     std::printf("\n%s\n", g_failed == 0 ? "ALL PASS" : "FAILURES ABOVE");
     return g_failed == 0 ? 0 : 1;
 }


### PR DESCRIPTION
Fixes #4668.

## Root cause

`genPowerline` was the last absolute-time oscillator left after #4637. The Demo applet ships the Power-line row's 50–60 Hz slider straight to `setKnob(Powerline, "freq", …)` (only Birdie/hz is intercepted in `SimBackend::setDemoNoiseKnob`), and `sin(2π·f0·h·t_absolute)` teleports all six harmonics' phase by `2π·Δf·h·t` on every flip — a hard click, worst on the high harmonics.

## Fix

Same cure as the birdie and the CW tone (#4637): accumulate the **fundamental's** phase in radians, derive harmonic *h* as `sin(h·φ)`, wrap φ to [0, 2π) — exact for integer *h* since `sin(h·(φ−2π)) == sin(h·φ)`. The retired `m_plPhase` sample counter also takes its ~25 h LLP64 overflow (#4618's note) with it.

## Test

`noise_mixer_test` gains the same **two-half** guard as #4637's CW test, both halves load-bearing (continuity alone is also satisfied by a generator that ignores the knob):

- worst sample step across repeated 50↔60 flips: measured **0.102 of peak** with the accumulator vs **1.683** with absolute time; thresholded at 0.30, which clears the passing side by ~2.9× and the failing side by ~5.6×. Red on the unfixed code:
  ```
  [FAIL] powerline freq change keeps all harmonics phase continuous   (ratio 1.683)
  ```
- Goertzel check that the fundamental actually lands on the commanded mains frequency (50 vs 60 Hz, >5× dominance both ways).

Full `noise_mixer_test`: **ALL PASS**, rc=0, real stdout, Windows/MSVC.

`noise_mixer_test` is registered via `add_test` (`CMakeLists.txt:4543`), so it is skipped by `ci.yml`'s per-job `ctest -R` allow-lists but *does* run in `sanitizers.yml`'s bare `ctest` — i.e. the new guard is not exercised by PR CI, but it does go live in the weekly ASan/UBSan/TSan sweep.

## Review follow-ups

Applied during maintainer review (#4681):

- **Wrap with `fmod`, matching `genCw` and `genBirdie`.** `freq` is an unclamped knob; a single conditional subtraction only holds while `dphi < 2π`, so a caller sending `f0 >= kSampleRate` would leave φ growing without bound. Unreachable from today's UI (the Demo applet slider is an integer 50–60, presets set levels only), but the file now wraps one way rather than two.
- **CHANGELOG entry** under `[Unreleased]`, matching the one #4637 added for the sibling CW fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
