### PR TITLE
test(gui): make ConnectionPanel growth path deterministic

### DIFF
--- a/tests/connection_panel_size_test.cpp
+++ b/tests/connection_panel_size_test.cpp
@@ -10,14 +10,17 @@
 #include <QComboBox>
 #include <QFont>
 #include <QLabel>
+#include <QLayout>
 #include <QPushButton>
 #include <QScreen>
 #include <QScrollArea>
 #include <QScrollBar>
+#include <QSpacerItem>
 #include <QStyle>
 #include <QToolButton>
 
 #include <cstdio>
+#include <memory>
 #include <string>
 
 using namespace AetherSDR;
@@ -322,29 +325,78 @@ int main(int argc, char** argv)
     // recovers; without the second half a deliberately short window springs
     // back on every reopen.
     //
-    // Run at 150 %, because that is where the fixed 660 px opening height was
-    // short of the body — at 100 % it happens to be enough and growth would go
-    // untested.
     {
-        std::string fontDetail;
-        setScaledApplicationFont(app, originalFont, 1.5, &fontDetail);
         ConnectionPanel growPanel;
         growPanel.setFramelessMode(true);
         growPanel.show();
         QApplication::processEvents();
+
+        // Establish a height owned by fitToScreen(), then make the body's
+        // content-derived target taller by a deterministic amount that still
+        // fits the available screen. Font scaling is not a growth precondition:
+        // available fonts/styles can leave the target exactly at the nominal
+        // 660 px opening height even at 150 % (#4680).
         growPanel.fitToScreen(screen);
         QApplication::processEvents();
-        const int autoHeight = growPanel.height();
+        const int autoFitOwnedHeight = growPanel.height();
         QScrollArea* body = growPanel.findChild<QScrollArea*>(
             QStringLiteral("connectionBodyScrollArea"));
+        QWidget* bodyContent = growPanel.findChild<QWidget*>(
+            QStringLiteral("connectionBodyContent"));
+        const QMargins frameMargins = growPanel.screenFitFrameMargins();
+        const int maximumClientHeight = screen
+            ? screen->availableGeometry().height() - frameMargins.top()
+                - frameMargins.bottom()
+            : 0;
+        const int growthRoom = maximumClientHeight - autoFitOwnedHeight;
+        const int growthDelta = qMin(40, growthRoom);
+        const int rawPreferredHeight = body && bodyContent
+            ? growPanel.sizeHint().height() - body->sizeHint().height()
+                + bodyContent->sizeHint().height()
+            : 0;
+        const int spacerHeight =
+            autoFitOwnedHeight - rawPreferredHeight + growthDelta;
+        report("screen leaves room to exercise automatic growth",
+               body && bodyContent && growthDelta > 0 && spacerHeight > 0,
+               "height=" + std::to_string(autoFitOwnedHeight)
+                   + " rawPreferredHeight=" + std::to_string(rawPreferredHeight)
+                   + " maximumClientHeight=" + std::to_string(maximumClientHeight));
+        std::unique_ptr<QSpacerItem> growthSpacer;
+        if (body && bodyContent && growthDelta > 0 && spacerHeight > 0) {
+            growthSpacer = std::make_unique<QSpacerItem>(
+                0, spacerHeight, QSizePolicy::Minimum, QSizePolicy::Fixed);
+            bodyContent->layout()->addItem(growthSpacer.get());
+            bodyContent->updateGeometry();
+            growPanel.layout()->activate();
+            QApplication::processEvents();
+        }
+
+        growPanel.fitToScreen(screen);
+        QApplication::processEvents();
+        const int grownHeight = growPanel.height();
+        report("auto-sized panel grows from an auto-fit-owned height",
+               grownHeight > autoFitOwnedHeight,
+               "before=" + std::to_string(autoFitOwnedHeight)
+                   + " after=" + std::to_string(grownHeight));
         report("auto-sized panel opens without needing to scroll",
                body && body->verticalScrollBar()->maximum() == 0,
-               "height=" + std::to_string(autoHeight) + " vbarMax="
+               "height=" + std::to_string(grownHeight) + " vbarMax="
                    + std::to_string(body ? body->verticalScrollBar()->maximum() : -1));
-        report("auto-sized panel grows past the nominal opening height",
-               autoHeight > ConnectionPanel::kPreferredHeight,
-               "height=" + std::to_string(autoHeight) + " kPreferredHeight="
-                   + std::to_string(ConnectionPanel::kPreferredHeight));
+
+        // Remove the deterministic content pressure. Because the current
+        // height is one fitToScreen() chose, it may reclaim the unused room.
+        if (bodyContent && growthSpacer) {
+            bodyContent->layout()->removeItem(growthSpacer.get());
+            bodyContent->updateGeometry();
+            growPanel.layout()->activate();
+            QApplication::processEvents();
+        }
+        growPanel.fitToScreen(screen);
+        QApplication::processEvents();
+        report("a height fit-to-screen set is reclaimed toward the body",
+               growPanel.height() == autoFitOwnedHeight,
+               "height=" + std::to_string(growPanel.height())
+                   + " initialAutoHeight=" + std::to_string(autoFitOwnedHeight));
 
         // Simulate the operator dragging it short, then reopening.
         growPanel.resize(growPanel.width(), ConnectionPanel::kSafeMinimumHeight);
@@ -353,15 +405,6 @@ int main(int argc, char** argv)
         report("a height the operator chose survives a re-fit",
                growPanel.height() == ConnectionPanel::kSafeMinimumHeight,
                "height=" + std::to_string(growPanel.height()));
-
-        // A height fitToScreen() itself set is fair game to reclaim.
-        growPanel.resize(growPanel.width(), autoHeight);
-        growPanel.fitToScreen(screen);
-        QApplication::processEvents();
-        report("a height fit-to-screen set is reclaimed toward the body",
-               growPanel.height() == autoHeight,
-               "height=" + std::to_string(growPanel.height())
-                   + " autoHeight=" + std::to_string(autoHeight));
     }
 
     app.setFont(originalFont);


### PR DESCRIPTION
## Summary

Fixes #4680. The ConnectionPanel size harness assumed that 150% font scaling always makes the content-derived opening height exceed the nominal 660 px height. On macOS 26.5.1 with Qt 6.11.1/offscreen, the product invariant passed (`height=660 vbarMax=0`) while that setup assumption failed (`height=660 kPreferredHeight=660`).

Make the growth path deterministic by first establishing an auto-fit-owned height, then adding temporary layout content sized to request 40 px of growth within the available screen. The test now directly proves automatic growth, no unnecessary scrolling, reclaim after content pressure is removed, preservation of an operator-chosen short height, screen clamping, and the fixed Disconnect footer. Production code is unchanged.

## Constitution principle honored

Principle VIII — Evidence Over Assertion. The growth precondition is created explicitly and the production guard is mutation-tested instead of inferred from platform font metrics.

## Test plan

- [x] Local build passes (`cmake --build build-native --target AetherSDR -j8`)
- [x] Behavior verified on a real radio if applicable — not applicable; this is a standalone headless GUI test-harness fix and no radio was launched or connected
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Local configuration used native arm64 with `ENABLE_RADE=OFF` because this Codex shell runs under Rosetta while the installed Homebrew Qt is arm64; RADE is unrelated to this test.

- Pre-fix: `QT_QPA_PLATFORM=offscreen ./build-native/connection_panel_size_test` reproduced the single `660 == 660` failure while the preceding no-scroll invariant passed.
- Focused executable: passed 10 consecutive runs.
- Focused CTest: `ctest --test-dir build-native -R '^connection_panel_size_test$' --output-on-failure` — 1/1 passed.
- Adjacent size harnesses: `flex_control_dialog_size_test`, `connection_panel_size_test`, and `pan_layout_dialog_size_test` — 3/3 passed.
- Mutation proof: temporarily disabling the production `height() == m_autoFitHeight` growth guard made the revised harness fail (`height=660 vbarMax=40`); restoring it returned `ALL PASS`.
- App target: `cmake --build build-native --target AetherSDR -j8` passed.

The agent automation bridge cannot launch or inspect this standalone executable or inject the deterministic `QLayout` fixture. Launching the full app or connecting to a radio would not prove this harness behavior, so proof uses the focused executable, CTest, and deliberate mutation instead. A useful bridge extension would be a generic standalone Qt-test runner with captured exit status/output or a test-fixture hook.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention) — not applicable; no meter code changed
- [x] Documentation updated if user-visible behavior changed — not applicable; test infrastructure only
- [x] Security-sensitive changes reference a GHSA if applicable — not applicable

Generated with OpenAI Codex.
