### PR TITLE
ci(docker): build the CI image against Qt 6.8.3 instead of Ubuntu's 6.4.2

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -2,13 +2,23 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Links this package to the repository on GHCR, which is what makes the
-# repo's GITHUB_TOKEN able to pull it. Without the label the package is
-# unattached: private and unreachable from CI, with no in-repo fix.
+# Links this package to its repository on GHCR. It is what attaches the
+# package to aethersdr/AetherSDR — the source link on the package page, and
+# the repo-scoped access a private package would inherit. The package is
+# public today, so nothing depends on the access half; the attachment is
+# worth keeping regardless.
 LABEL org.opencontainers.image.source=https://github.com/aethersdr/AetherSDR
 
-# Build dependencies for AetherSDR CI
-# Must include everything CMakeLists.txt can find_package() for
+# Qt comes from aqtinstall, NOT from the distro — see the Qt layer below.
+# Ubuntu 24.04 ships Qt 6.4.2, which is seven minor versions behind current and
+# has been EOL upstream since the 6.4 series ended at 6.4.3. It is also BELOW
+# what AetherSDR ships: release binaries are built against Qt 6.8.3 LTS
+# (.github/workflows/appimage.yml, and check-windows pins the same 6.8.3). A CI
+# image on 6.4.2 therefore tested a Qt nobody runs, and rejected code that is
+# valid on every shipped configuration — PR #4646 hit exactly that with
+# QList::assign(), a Qt 6.6 addition.
+#
+# The base image still supplies gcc and glibc; only Qt is taken from aqt.
 RUN apt-get update && apt-get install -y \
     cmake \
     ninja-build \
@@ -20,18 +30,11 @@ RUN apt-get update && apt-get install -y \
     curl \
     make \
     python3 \
-    qt6-base-dev \
-    qt6-multimedia-dev \
-    qt6-websockets-dev \
-    qt6-serialport-dev \
-    qt6-base-private-dev \
-    qt6-shader-baker \
-    qt6-shadertools-dev \
+    python3-venv \
     libgl1-mesa-dev \
     libasound2-dev \
     libfftw3-dev \
     libhidapi-dev \
-    qtkeychain-qt6-dev \
     portaudio19-dev \
     libpipewire-0.3-dev \
     autoconf \
@@ -40,4 +43,91 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     libmosquitto-dev \
     ca-certificates \
+    libdbus-1-dev \
+    libglib2.0-dev \
+    libfontconfig1-dev \
+    libfreetype6-dev \
+    # libQt6Multimedia.so from aqt is linked against PulseAudio; without this,
+    # every target using Qt6::Multimedia fails at link with undefined
+    # pa_*@PULSE_0 references. The distro qt6-multimedia-dev pulled it in.
+    libpulse-dev \
+    libx11-dev \
+    libx11-xcb-dev \
+    libxcb1-dev \
+    libxcb-cursor0 \
+    libxcb-glx0 \
+    libxcb-icccm4 \
+    libxcb-image0 \
+    libxcb-keysyms1 \
+    libxcb-randr0 \
+    libxcb-render-util0 \
+    libxcb-shape0 \
+    libxcb-sync1 \
+    libxcb-util1 \
+    libxcb-xfixes0 \
+    libxcb-xinerama0 \
+    libxcb-xkb1 \
+    libxkbcommon-dev \
+    libxkbcommon-x11-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# ── Qt 6.8.3 LTS ─────────────────────────────────────────────────────────
+# Version and module list deliberately match appimage.yml and the Windows leg
+# in ci.yml, so every artifact and every CI check compiles against one Qt.
+# Bumping it means bumping all three together.
+#
+# The xcb/xkb/fontconfig -dev packages above are named explicitly because the
+# distro qt6-*-dev packages used to pull them in transitively; without them,
+# linking Qt6::Gui/Widgets fails on missing sonames.
+#
+# Ubuntu 24.04's pip is PEP 668 externally-managed, so aqt goes in a venv
+# rather than --break-system-packages; the venv is removed in the same layer.
+ENV QT_VERSION=6.8.3
+ENV QT_ROOT=/opt/Qt/6.8.3/gcc_64
+RUN python3 -m venv /tmp/aqt-venv \
+    && /tmp/aqt-venv/bin/pip install --no-cache-dir aqtinstall \
+    && /tmp/aqt-venv/bin/aqt install-qt linux desktop "${QT_VERSION}" linux_gcc_64 \
+        -m qtmultimedia qtwebsockets qtserialport qtshadertools \
+        --outputdir /opt/Qt \
+    && test -x "${QT_ROOT}/bin/qmake" \
+    && "${QT_ROOT}/bin/qmake" -query QT_VERSION \
+    && rm -rf /tmp/aqt-venv
+
+# ── qtkeychain, built against THAT Qt ────────────────────────────────────
+# Not the distro's qtkeychain-qt6-dev: that is compiled against Ubuntu's Qt
+# 6.4.2, and mixing it with an aqt 6.8.3 build is the ABI mismatch
+# scripts/setup/setup-qtkeychain.sh exists to avoid (see its header, and
+# #3639 for what a missing keychain costs — SmartLink credential persistence
+# silently compiles out via find_package(Qt6Keychain QUIET)).
+#
+# Version and commit pin are kept in step with scripts/setup/setup-qtkeychain.sh;
+# LIBSECRET_SUPPORT=OFF selects the pure Qt-D-Bus Secret Service backend for the
+# same reason it does there.
+ENV QTKEYCHAIN_VERSION=0.16.0
+ENV QTKEYCHAIN_COMMIT=aa6da344e1a20b9194e12bace3665caeea6b6304
+ENV QTKEYCHAIN_ROOT=/opt/qtkeychain
+RUN git clone --depth 1 --branch "${QTKEYCHAIN_VERSION}" \
+        https://github.com/frankosterfeld/qtkeychain.git /tmp/qtkeychain-src \
+    && test "$(git -C /tmp/qtkeychain-src rev-parse HEAD)" = "${QTKEYCHAIN_COMMIT}" \
+    && cmake -B /tmp/qtkeychain-build -S /tmp/qtkeychain-src -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_WITH_QT6=ON \
+        -DBUILD_SHARED_LIBS=ON \
+        -DBUILD_TRANSLATIONS=OFF \
+        -DLIBSECRET_SUPPORT=OFF \
+        -DCMAKE_PREFIX_PATH="${QT_ROOT}" \
+        -DCMAKE_INSTALL_PREFIX="${QTKEYCHAIN_ROOT}" \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+    && cmake --build /tmp/qtkeychain-build -j"$(nproc)" \
+    && cmake --install /tmp/qtkeychain-build \
+    && test -f "${QTKEYCHAIN_ROOT}/lib/cmake/Qt6Keychain/Qt6KeychainConfig.cmake" \
+    && rm -rf /tmp/qtkeychain-src /tmp/qtkeychain-build
+
+# CMake reads CMAKE_PREFIX_PATH from the environment, so ci.yml / codeql.yml /
+# sanitizers.yml need no Qt-specific configure flags — their plain
+# `cmake -B build` finds this Qt and this qtkeychain. LD_LIBRARY_PATH is what
+# lets the offscreen ctest targets actually run.
+ENV CMAKE_PREFIX_PATH=${QT_ROOT}:${QTKEYCHAIN_ROOT}
+ENV Qt6_DIR=${QT_ROOT}/lib/cmake/Qt6
+ENV PATH=${QT_ROOT}/bin:${PATH}
+ENV LD_LIBRARY_PATH=${QT_ROOT}/lib:${QTKEYCHAIN_ROOT}/lib

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -84,13 +84,25 @@ RUN apt-get update && apt-get install -y \
 # rather than --break-system-packages; the venv is removed in the same layer.
 ENV QT_VERSION=6.8.3
 ENV QT_ROOT=/opt/Qt/6.8.3/gcc_64
+# aqtinstall is pinned. It is the tool that decides what Qt lands in this image,
+# so leaving it floating means a cache-miss rebuild months from now silently
+# fetches a different installer than the one this image was validated with.
+ENV AQTINSTALL_VERSION=3.3.0
 RUN python3 -m venv /tmp/aqt-venv \
-    && /tmp/aqt-venv/bin/pip install --no-cache-dir aqtinstall \
+    && /tmp/aqt-venv/bin/pip install --no-cache-dir "aqtinstall==${AQTINSTALL_VERSION}" \
     && /tmp/aqt-venv/bin/aqt install-qt linux desktop "${QT_VERSION}" linux_gcc_64 \
         -m qtmultimedia qtwebsockets qtserialport qtshadertools \
         --outputdir /opt/Qt \
     && test -x "${QT_ROOT}/bin/qmake" \
     && "${QT_ROOT}/bin/qmake" -query QT_VERSION \
+    # qmake alone only proves qtbase landed. Assert each addon module's CMake
+    # package too: a partial aqt install that still exits 0 would otherwise
+    # surface much later as a confusing find_package(Qt6 COMPONENTS Multimedia)
+    # miss during ci.yml's configure, with nothing pointing back here.
+    && for m in Multimedia WebSockets SerialPort ShaderTools; do \
+           test -f "${QT_ROOT}/lib/cmake/Qt6${m}/Qt6${m}Config.cmake" \
+           || { echo "aqt did not install Qt6${m}"; exit 1; }; \
+       done \
     && rm -rf /tmp/aqt-venv
 
 # ── qtkeychain, built against THAT Qt ────────────────────────────────────
@@ -100,9 +112,13 @@ RUN python3 -m venv /tmp/aqt-venv \
 # #3639 for what a missing keychain costs — SmartLink credential persistence
 # silently compiles out via find_package(Qt6Keychain QUIET)).
 #
-# Version and commit pin are kept in step with scripts/setup/setup-qtkeychain.sh;
 # LIBSECRET_SUPPORT=OFF selects the pure Qt-D-Bus Secret Service backend for the
 # same reason it does there.
+#
+# The version, commit pin and flags below are hand-duplicated from
+# scripts/setup/setup-qtkeychain.sh rather than sourced from it: this image is
+# built with `context: .github/docker` (see docker-ci-image.yml), so COPY cannot
+# reach a file outside that directory. BUMPING QTKEYCHAIN MEANS EDITING BOTH.
 ENV QTKEYCHAIN_VERSION=0.16.0
 ENV QTKEYCHAIN_COMMIT=aa6da344e1a20b9194e12bace3665caeea6b6304
 ENV QTKEYCHAIN_ROOT=/opt/qtkeychain


### PR DESCRIPTION
The Linux CI image takes Qt from Ubuntu 24.04's distro packages — **6.4.2**, seven minor versions behind current and EOL upstream since the 6.4 series ended at 6.4.3. Every artifact AetherSDR actually ships is built against **Qt 6.8.3 LTS**: both AppImage arches and the Windows installer, with macOS newer still. So the fast per-PR Linux leg was the only thing testing a Qt nobody runs.

That is not academic. **PR #4646 was failed by CI for calling `QList::assign()`** — a Qt 6.6 addition that compiles on every configuration the project ships. The gap cuts the other way too: no per-PR Linux job compiled against 6.8.3, so a 6.9/6.10-only API would have passed every check and broken the AppImage at release-tag time.

Qt now comes from aqtinstall at the same 6.8.3, with the same module list `appimage.yml` and the Windows leg use. The base image still supplies gcc and glibc.

## Two things the swap required

Both were found by building locally, not by guessing:

- **qtkeychain is built from source** against the aqt Qt rather than taken from `qtkeychain-qt6-dev`, which is compiled against the distro's 6.4.2. Same ABI reasoning `scripts/setup/setup-qtkeychain.sh` already documents; getting it wrong loses SmartLink credential persistence *silently*, via `find_package(Qt6Keychain QUIET)` (#3639).
- **`libpulse-dev` is named explicitly.** aqt's `libQt6Multimedia.so` links PulseAudio, which `qt6-multimedia-dev` pulled in transitively; without it every `Qt6::Multimedia` target fails to link on `pa_*@PULSE_0`. The xcb/xkb/fontconfig `-dev` packages are there for the same reason.

## Scope

This changes **only the image**. `CMakeLists.txt` still declares a 6.2 minimum, which 6.8.3 satisfies, so main and every in-flight PR keep building exactly as before. The floor bump follows separately, stacked on this branch — it cannot go first, because CI pulls `:latest` and would be asked for 6.8 while still running 6.4.2.

## Verified locally

Built the image and built AetherSDR inside it:

- **2086 targets, zero errors**
- `ctest` **233/238**. Of the five: one (`radio_capability_gating_test`) is a `-j8` timing flake that passes serially; the other four fail **identically on unmodified main in the old 6.4.2 image** — they need an accessibility bridge no container has, and CI never saw them because the Linux job runs only two named tests.
- Configure inside the container using **only the image environment**, no Qt flags — exactly what `ci.yml`'s Configure step does: finds Qt 6.8.3, finds Qt6Keychain, and **enables GPU spectrum rendering (QRhi)**, which 6.4.2 had compiled out.
- A compile-only probe of `QList::assign` **fails on the old image and compiles on this one**.

Image size grows **1.91 GB → 3.66 GB**. Per-PR install cost stays zero since it is baked in.

## Note on blast radius

Consumers track `:latest`, so once this merges and republishes, **every open PR starts building against Qt 6.8.3** — including the 14 of 16 currently open that come from forks. That is the intended behaviour and the reason `:latest` was kept in #4683, but it is a wide change from a single merge. Worth merging when someone can watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)