### PR TITLE
build(qt): raise the minimum Qt to 6.8, matching every shipped artifact

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -476,9 +476,11 @@ granularity, then **stop**: if tempted to subdivide one subsystem into several
 thin TUs, extract a real class instead (the #3557 direction) — that's the only
 move that actually decouples.
 
-Sibling TUs must **carry their includes explicitly** — the Linux CI floor is
-Qt 6.4.2; don't rely on transitive includes (this broke #3532). When you move
-the last user of a header out of `MainWindow.cpp`, drop that `#include` too.
+Sibling TUs must **carry their includes explicitly** — the Linux CI image is on
+Qt 6.8.3 while macOS runs 6.11.x, so a header that resolves transitively on the
+newer Qt need not on 6.8.3; don't rely on transitive includes (this broke
+#3532). When you move the last user of a header out of `MainWindow.cpp`, drop
+that `#include` too.
 
 Full map + decision guide:
 **[`docs/architecture/mainwindow-decomposition.md`](docs/architecture/mainwindow-decomposition.md)**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Minimum Qt raised to 6.8 — source builds on Ubuntu 24.04 need a newer Qt
+
+**Building from source now requires Qt 6.8 or newer.** Nothing changes for
+users of the release binaries: the AppImage, the Windows installer and the
+macOS build were already compiled against Qt 6.8.3 LTS, and still are.
+
+The old floor said 6.2 and nothing enforced it. The only CI leg near it was the
+Linux container on Ubuntu 24.04's **Qt 6.4.2** — seven minor versions behind
+current, and EOL upstream since the 6.4 series ended at 6.4.3. So the project
+was testing a Qt no artifact shipped, and *rejecting* code that is valid on
+every configuration it actually ships: PR #4646 was failed by CI for using
+`QList::assign()`, a Qt 6.6 addition that works fine on all three release
+builds. The reverse risk was live too, since no per-PR Linux job compiled
+against 6.8.3 — the AppImage first sees that Qt at release-tag time.
+
+The CI image now installs Qt 6.8.3 via aqtinstall instead of using the distro's,
+matching `appimage.yml` and the Windows leg, so one Qt version covers every
+check and every artifact. It also builds qtkeychain from source against that Qt,
+since the distro package is compiled against 6.4.2. A side effect: the CI image
+clears the QRhi floor (6.7+), so GPU spectrum rendering is no longer silently
+compiled out of Linux CI builds.
+
+Distro Qt satisfies 6.8 on Debian Trixie, Ubuntu 25.10+, Fedora 41+ and Arch.
+On **Ubuntu 24.04 LTS** it does not — build against a Qt from aqtinstall or the
+Qt online installer and pass
+`-DCMAKE_PREFIX_PATH=/path/to/Qt/6.8.3/gcc_64`. See the README's dependency
+section.
+
 ### Fixed
 
 - **Amplifier bar gauges no longer keep painting the old scale after the range

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,30 @@ endif()
 # distro carrying it (Debian Trixie, Ubuntu 25.10+, Fedora 41+, Arch).
 # 6.8 also clears QRhiWidget (6.7+), so the GPU spectrum path is no longer
 # conditionally compiled out on Linux CI.
+#
+# Probe QUIET first so a below-floor Qt gets an actionable error instead of
+# CMake's bare "the version found is not compatible", which names neither the
+# floor as a project decision nor the way out. Ubuntu 24.04 LTS (Qt 6.4.2) is
+# the common case, it has the largest install base of any supported distro, and
+# it was a documented apt line here until this floor moved — so the people most
+# likely to hit this have the least context for it, and the README they need is
+# a document they have already scrolled past.
+#
+# Falls through untouched when Qt is absent entirely (the REQUIRED call below
+# emits the normal not-found error) or already satisfies the floor.
+find_package(Qt6 QUIET COMPONENTS Core)
+if(Qt6_FOUND AND Qt6_VERSION VERSION_LESS 6.8)
+    message(FATAL_ERROR
+        "Qt ${Qt6_VERSION} found, but AetherSDR requires Qt 6.8 or newer.\n"
+        "This is the Qt every AetherSDR release binary is built against.\n"
+        "Ubuntu 24.04 LTS ships 6.4.2; Debian Trixie, Ubuntu 25.10+, "
+        "Fedora 41+ and Arch all ship 6.8 or newer.\n"
+        "To build on a distro below the floor, install Qt 6.8+ with aqtinstall "
+        "or the Qt online installer and re-run with "
+        "-DCMAKE_PREFIX_PATH=/path/to/Qt/6.8.3/gcc_64 — see the README's "
+        "\"Building from Source\" dependency section.")
+endif()
+
 find_package(Qt6 6.8 REQUIRED COMPONENTS
     Core
     Concurrent
@@ -350,7 +374,11 @@ endif()
 if(AETHER_GPU_SPECTRUM)
     if(Qt6_VERSION VERSION_LESS "6.7")
         set(AETHER_GPU_SPECTRUM OFF)
-        message(STATUS "GPU spectrum rendering disabled (requires Qt 6.7+, found ${Qt6_VERSION} — pass -DCMAKE_PREFIX_PATH=/path/to/Qt/6.7.x/gcc_64 to use a newer Qt installation)")
+        # 6.8.3, not 6.7.x, in the suggested path: this guard is unreachable
+        # while the floor is 6.8, so if it ever fires the floor has been
+        # lowered — and pointing that reader at a 6.7 install would send them
+        # to a Qt find_package still rejects.
+        message(STATUS "GPU spectrum rendering disabled (QRhiWidget requires Qt 6.7+, found ${Qt6_VERSION} — pass -DCMAKE_PREFIX_PATH=/path/to/Qt/6.8.3/gcc_64 to use a newer Qt installation)")
     else()
         find_package(Qt6 REQUIRED COMPONENTS ShaderTools)
         # Qt6GuiPrivate provides QRhi headers needed for GPU rendering.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,11 +91,24 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 # Qt6 components
-# Qt 6.2 minimum: matches Ubuntu 22.04 LTS (our oldest supported distro)
-# and is the floor where QWindow::startSystemMove() — used by the
-# frameless title-bar drag in TitleBar / ContainerWidget / PanadapterApplet
-# — became available.  Binary distributions bundle Qt 6.7+ for QRhiWidget.
-find_package(Qt6 6.2 REQUIRED COMPONENTS
+# Qt 6.8 minimum, matching the Qt every shipped artifact is built against:
+# the AppImage (both arches, .github/workflows/appimage.yml), the Windows
+# installer (check-windows pins 6.8.3 in ci.yml), and the Linux CI image
+# (.github/docker/Dockerfile installs 6.8.3 via aqt). One number, so a Qt API
+# that compiles in CI also compiles for a release build.
+#
+# Raised from 6.2 deliberately. The old floor was nominal — nothing tested it
+# after Ubuntu 22.04 left the matrix, and the only leg anywhere near it was the
+# CI image on Ubuntu 24.04's Qt 6.4.2, a release EOL upstream since the 6.4
+# series ended at 6.4.3. That gap rejected valid code (PR #4646, QList::assign)
+# while testing a Qt no artifact shipped.
+#
+# Consequence for source builds: Ubuntu 24.04's distro Qt (6.4.2) no longer
+# satisfies this — build against 6.8+ from aqt/Qt online installer, or use a
+# distro carrying it (Debian Trixie, Ubuntu 25.10+, Fedora 41+, Arch).
+# 6.8 also clears QRhiWidget (6.7+), so the GPU spectrum path is no longer
+# conditionally compiled out on Linux CI.
+find_package(Qt6 6.8 REQUIRED COMPONENTS
     Core
     Concurrent
     Widgets
@@ -331,7 +344,9 @@ endif()
 
 # GPU-accelerated spectrum/waterfall rendering via QRhi (#391)
 # Requires: Qt 6.7+ (QRhiWidget), Qt6::ShaderTools (build-time shader compilation)
-# Defaults to ON but auto-disables on Qt < 6.7 (e.g. Ubuntu 24.04 ships Qt 6.4).
+# The version guard below is unreachable now that find_package demands 6.8 — it
+# is kept as a cheap backstop so lowering the floor again can't silently produce
+# a build that references QRhiWidget on a Qt that lacks it.
 if(AETHER_GPU_SPECTRUM)
     if(Qt6_VERSION VERSION_LESS "6.7")
         set(AETHER_GPU_SPECTRUM OFF)

--- a/README.md
+++ b/README.md
@@ -111,13 +111,21 @@ Pre-built binaries are available from [Releases](https://github.com/aethersdr/Ae
 
 Install all dependencies for a full-featured build. Optional packages are noted — the build succeeds without them but the corresponding features are disabled.
 
+**Qt 6.8 or newer is required.** This is the same Qt the release binaries are
+built against (6.8.3 LTS), so what CI compiles is what ships. Distro Qt clears
+it on Debian Trixie, Ubuntu 25.10+, Fedora 41+ and Arch. It does **not** clear
+on **Ubuntu 24.04 LTS**, which ships Qt 6.4.2 — build there against a Qt from
+[aqtinstall](https://github.com/miurahr/aqtinstall) or the Qt online installer
+and point CMake at it with `-DCMAKE_PREFIX_PATH=/path/to/Qt/6.8.3/gcc_64`.
+
 ```bash
 # Arch / CachyOS / Manjaro
 sudo pacman -S qt6-base qt6-multimedia qt6-websockets qt6-serialport \
   qt6-shadertools cmake ninja pkgconf autoconf automake libtool \
   fftw portaudio hidapi qtkeychain-qt6
 
-# Ubuntu 24.04+ / Debian / Linux Mint
+# Debian Trixie / Ubuntu 25.10+ / Linux Mint 23+
+# (Ubuntu 24.04's Qt is 6.4.2 — below the floor; see the note above.)
 sudo apt install qt6-base-dev qt6-base-private-dev qt6-multimedia-dev \
   qt6-websockets-dev qt6-serialport-dev qt6-shader-baker qt6-shadertools-dev \
   cmake ninja-build pkg-config autoconf automake libtool \
@@ -178,8 +186,8 @@ is required during configure or build.
 ### Windows 11
 
 Prerequisites: Visual Studio 2022 (Build Tools, Community, or higher) with the
-MSVC C++ workload, CMake 3.25+, Ninja, and Qt 6.7+ (`msvc2022_64`; the release
-binaries ship 6.8.3 LTS).
+MSVC C++ workload, CMake 3.25+, Ninja, and Qt 6.8+ (`msvc2022_64`; both CI and
+the release binaries use 6.8.3 LTS).
 
 ```bat
 :: 1. Activate the MSVC environment. Adjust the edition (BuildTools / Community /
@@ -214,9 +222,9 @@ cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH="%
 cmake --build build --target AetherSDR
 ```
 
-### Qt 6.7+ for GPU Spectrum Rendering
+### GPU Spectrum Rendering
 
-GPU-accelerated spectrum/waterfall rendering requires Qt 6.7 or greater. If your distribution ships with an older version (e.g., Ubuntu 24.04, Debian 12, or Mint 21–22 include Qt 6.4.2), the build system automatically disables GPU rendering and falls back to the CPU-based `QPainter` path. (Release binaries ship Qt 6.8.3 LTS — the aarch64 AppImage included — so every release binary renders via QRhi; the 6.7 floor is the source-build minimum.)
+GPU-accelerated spectrum/waterfall rendering requires Qt 6.7 or greater (`QRhiWidget`). Since the build now requires Qt 6.8 as a minimum, every build — source or release binary, the aarch64 AppImage included — clears that floor and renders via QRhi. The CPU-based `QPainter` path remains as a runtime fallback for machines where GPU initialisation fails, not as a Qt-version fallback.
 
 Going the other way, `AETHER_NO_GPU=1` forces software OpenGL on an already-built binary, without a rebuild:
 
@@ -226,7 +234,7 @@ AETHER_NO_GPU=1 ./AetherSDR-*.AppImage
 
 That is the escape hatch if a GPU or driver renders the spectrum incorrectly — worth trying first on Raspberry Pi and other systems whose Mesa driver is newer than its hardware.
 
-To use GPU acceleration on these systems, install Qt 6.7+ manually:
+On a distribution whose Qt is older than the required 6.8 (notably Ubuntu 24.04 LTS at 6.4.2), install a newer Qt manually:
 
 1. **Option 1: Using a PPA (Ubuntu/Mint)**
    The `kubuntu-backports` PPA may provide a newer Qt — verify the version it ships before relying on it.

--- a/docs/architecture/mainwindow-decomposition.md
+++ b/docs/architecture/mainwindow-decomposition.md
@@ -104,8 +104,9 @@ TU — the whole point is to stop `MainWindow.cpp` from re-accreting.
 
 - **It's the same class.** Define `void MainWindow::foo()` in the sibling TU;
   declare `foo()` in `MainWindow.h` as usual. No `friend`, no new class.
-- **Carry includes explicitly.** The Linux CI floor is **Qt 6.4.2**; do not rely
-  on transitive includes that only resolve on newer Qt. A sibling TU must
+- **Carry includes explicitly.** The Linux CI image is on **Qt 6.8.3** while
+  macOS runs 6.11.x; do not rely on transitive includes that only resolve on
+  the newer Qt. A sibling TU must
   `#include` every header for the symbols *it* uses, even if `MainWindow.cpp`
   already included them. (This bit #3532; grep moved code for `Q[A-Z]` symbols
   and add the includes.)


### PR DESCRIPTION
With the CI image now on Qt 6.8.3 (#4685), declare it.

`find_package` asked for **6.2** — a floor nothing had tested since Ubuntu 22.04 left the matrix, and one no artifact was ever built against. The AppImage (both arches), the Windows installer and the CI image are all 6.8.3; macOS is newer. One number now covers CI and every artifact, so a Qt API that compiles in CI also compiles for a release build.

This is the second half of the change #4685 started, and it deliberately goes second: it could not land first, because CI pulls `:latest` and would have been asked for 6.8 while still running 6.4.2.

## Why the old floor was worse than nominal

It was not merely untested — it actively cost us. The only CI leg anywhere near it was the Linux container on Ubuntu 24.04's **Qt 6.4.2**, a release EOL upstream since the 6.4 series ended at 6.4.3. **PR #4646 was failed by CI for calling `QList::assign()`**, a Qt 6.6 addition that compiles on every configuration the project ships.

The gap cut the other way too: no per-PR Linux job compiled against 6.8.3, so a 6.9/6.10-only API would have passed every check and broken the AppImage at release-tag time.

## Consequence for source builds

**Ubuntu 24.04's distro Qt (6.4.2) no longer satisfies the floor.** The README now documents building there against an aqtinstall or Qt-online-installer Qt with `-DCMAKE_PREFIX_PATH=/path/to/Qt/6.8.3/gcc_64`.

Distro Qt clears 6.8 on **Debian Trixie, Ubuntu 25.10+, Fedora 41+ and Arch** — and Trixie mattering here is deliberate, since #4670's comments call it the supported Pi baseline.

Every CI leg clears it: Windows 6.8.3, macOS 6.11.1, and `check-system-libs-linux` on `debian:sid` at 6.10.2.

## Side effect worth having

6.8 clears the `QRhiWidget` floor (6.7+), so GPU spectrum rendering is no longer compiled out of Linux CI builds — that path now actually gets exercised. The version guard around `AETHER_GPU_SPECTRUM` becomes unreachable and is kept only as a backstop against the floor being lowered again; its comment says so.

## Docs corrected

Four stale claims, all of which would have misled the next reader:

- `AGENTS.md` and `docs/architecture/mainwindow-decomposition.md` both stated "the Linux CI floor is Qt 6.4.2". The carry-your-includes rule they attach it to **survives** the floor change — the reason is now that the CI image is on 6.8.3 while macOS runs 6.11.x, so a header resolving transitively on the newer Qt need not on 6.8.3.
- `README.md`'s dependency section and its GPU-rendering section, which described a Qt-version fallback that can no longer trigger.

## Verified

- Configure passes against **Qt 6.11.1** locally, so the floor does not exclude newer Qt.
- Configure passes against **6.8.3 inside the CI image**, using only the image environment with no Qt flags — exactly what `ci.yml`'s Configure step does.
- Full in-container build on the 6.8.3 image: **2086 targets, zero errors**.

## Note on review

`AGENTS.md` is Tier 1 in CODEOWNERS, so this needs `@aethersdr/maintainers` rather than `@aethersdr/infrastructure` — unlike #4685. If that is inconvenient, the `AGENTS.md` hunk can be split into a follow-up and the rest reviewed at Tier 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)