### PR TITLE
ci: pin the Windows Qt exactly and guard GPU spectrum on every artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,8 +507,12 @@ jobs:
 
       - name: Configure
         run: |
-          # See the Linux build job: pipefail so the tee can't mask a cmake
-          # failure, and AETHER_GPU_SPECTRUM stated rather than defaulted.
+          # pipefail so the tee below can't mask a cmake failure — GitHub's
+          # default bash is -e without it. The Linux build job cannot do this
+          # and redirects instead: it runs in the CI container, which has no
+          # bash, so GitHub falls back to dash. macOS runners have bash.
+          # AETHER_GPU_SPECTRUM is stated rather than defaulted for the same
+          # reason as there — the assertion needs a request to check against.
           set -o pipefail
           cmake -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,15 +88,25 @@ jobs:
 
       - name: Configure
         run: |
-          # Without pipefail the step's exit status is tee's, so a cmake failure
-          # would look green. GitHub's default bash is -e without it.
-          set -o pipefail
+          # Redirect, not `| tee`: this job runs in the CI container, which
+          # ships no bash, so GitHub falls back to `sh -e {0}` — dash, where
+          # `set -o pipefail` is not a valid option and fails the step outright
+          # (exit 2). Without pipefail a pipeline's status is tee's, which would
+          # mask a cmake failure, so the safe form here is no pipeline at all:
+          # cmake's own exit status is the step's, and the log is echoed after
+          # so a failed configure stays readable in the step output. The other
+          # two jobs run on real runners and keep the `tee` form.
+          #
           # AETHER_GPU_SPECTRUM=ON is stated rather than left to the CMake
           # default so the assertion below has a request to check against.
           cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_NVIDIA_AFX=ON \
             -DAETHER_GPU_SPECTRUM=ON \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache 2>&1 | tee configure.log
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache > configure.log 2>&1 || {
+            cat configure.log
+            exit 1
+          }
+          cat configure.log
 
       # AETHER_GPU_SPECTRUM=ON is a request, not a guarantee: CMake flips it
       # back OFF without failing when Qt6GuiPrivate can't be located, so a build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,40 @@ jobs:
 
       - name: Configure
         run: |
+          # Without pipefail the step's exit status is tee's, so a cmake failure
+          # would look green. GitHub's default bash is -e without it.
+          set -o pipefail
+          # AETHER_GPU_SPECTRUM=ON is stated rather than left to the CMake
+          # default so the assertion below has a request to check against.
           cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_NVIDIA_AFX=ON \
+            -DAETHER_GPU_SPECTRUM=ON \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache 2>&1 | tee configure.log
+
+      # AETHER_GPU_SPECTRUM=ON is a request, not a guarantee: CMake flips it
+      # back OFF without failing when Qt6GuiPrivate can't be located, so a build
+      # can ship the CPU QPainter fallback with its workflow green — the failure
+      # #4000 shipped on aarch64.
+      #
+      # appimage.yml, macos-dmg.yml and windows-installer.yml all assert this,
+      # but every one of them is tag-triggered. Until this step existed nothing
+      # checked it on a pull request, so a change that silently flipped the
+      # feature off could sit on main until someone cut a release. Here it costs
+      # seconds and fails the PR that caused it. The release assertions stay:
+      # they cover the Qt each artifact actually ships, which is not the Qt any
+      # of these jobs use.
+      #
+      # Assert on the configure output, not CMakeCache.txt: CMakeLists.txt
+      # disables the feature with a plain set(), which shadows the cache entry
+      # without rewriting it, so the cache still reads ON when it is off.
+      - name: Assert GPU spectrum rendering actually enabled
+        run: |
+          grep -q "GPU spectrum rendering enabled" configure.log || {
+            echo "ERROR: -DAETHER_GPU_SPECTRUM=ON but CMake disabled it. Relevant output:"
+            grep -iE "GPU spectrum|Qt6GuiPrivate|private headers" configure.log || true
+            exit 1
+          }
+          grep "GPU spectrum rendering enabled" configure.log
 
       - name: Build
         run: cmake --build build -j$(nproc)
@@ -326,6 +357,9 @@ jobs:
             # is fully built + linked + packaged by the windows-installer workflow,
             # so nothing is lost here.
             "-DENABLE_ASR=OFF",
+            # Stated rather than left to the CMake default so the assertion
+            # below has a request to check against.
+            "-DAETHER_GPU_SPECTRUM=ON",
             "-DCMAKE_TOOLCHAIN_FILE=$env:CMAKE_TOOLCHAIN_FILE",
             "-DVCPKG_TARGET_TRIPLET=$env:VCPKG_TARGET_TRIPLET"
           )
@@ -333,7 +367,30 @@ jobs:
             $cargs += "-DCMAKE_C_COMPILER_LAUNCHER=sccache"
             $cargs += "-DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
           }
-          & cmake @cargs
+          # Tee without `2>&1`: GitHub runs pwsh with $ErrorActionPreference=
+          # 'Stop', where merging a native command's stderr into the pipeline
+          # can promote an ordinary CMake warning to a terminating error and
+          # fail configure on a non-problem. Nothing is lost — every line the
+          # assertion reads is message(STATUS), which CMake writes to stdout.
+          # No pipefail equivalent is needed either: $LASTEXITCODE tracks the
+          # last *native* command (cmake), and Tee-Object is a cmdlet.
+          & cmake @cargs | Tee-Object -FilePath configure.log
+
+      # Same guard as the Linux build job above — see the long note there for
+      # why it reads configure output rather than CMakeCache.txt. This job is
+      # the only per-PR coverage the aqtinstall Qt layout gets: it is the layout
+      # CMakeLists.txt calls out as shipping the private QtGui headers while
+      # omitting the Qt6GuiPrivate CMake package, so it reaches the fallback
+      # path that windows-installer.yml depends on at release time.
+      - name: Assert GPU spectrum rendering actually enabled
+        shell: pwsh
+        run: |
+          if (-not (Select-String -Path configure.log -Pattern 'GPU spectrum rendering enabled' -Quiet)) {
+            Write-Host "ERROR: -DAETHER_GPU_SPECTRUM=ON but CMake disabled it. Relevant output:"
+            Select-String -Path configure.log -Pattern 'GPU spectrum|Qt6GuiPrivate|private headers'
+            exit 1
+          }
+          Select-String -Path configure.log -Pattern 'GPU spectrum rendering enabled'
 
       - name: Build Opus (RADE dependency)
         # ExternalProject dependency ordering via BUILD_BYPRODUCTS is correct,
@@ -440,12 +497,28 @@ jobs:
 
       - name: Configure
         run: |
+          # See the Linux build job: pipefail so the tee can't mask a cmake
+          # failure, and AETHER_GPU_SPECTRUM stated rather than defaulted.
+          set -o pipefail
           cmake -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_PREFIX_PATH="$(brew --prefix qt@6);$(brew --prefix)" \
-            -DMQTT_TLS=OFF
+            -DAETHER_GPU_SPECTRUM=ON \
+            -DMQTT_TLS=OFF 2>&1 | tee configure.log
+
+      # Same guard as the Linux build job above. -iE rather than the -i "a\|b"
+      # form: this runs on the macOS runner's BSD grep, which has no BRE
+      # alternation and would search for the literal "a|b".
+      - name: Assert GPU spectrum rendering actually enabled
+        run: |
+          grep -q "GPU spectrum rendering enabled" configure.log || {
+            echo "ERROR: -DAETHER_GPU_SPECTRUM=ON but CMake disabled it. Relevant output:"
+            grep -iE "GPU spectrum|Qt6GuiPrivate|private headers" configure.log || true
+            exit 1
+          }
+          grep "GPU spectrum rendering enabled" configure.log
 
       - name: Build Opus (RADE dependency)
         run: cmake --build build --target build_opus -j$(sysctl -n hw.ncpu)

--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -183,15 +183,36 @@ jobs:
       # Assert on the configure output, not CMakeCache.txt: CMakeLists.txt
       # disables the feature with a plain set(), which shadows the cache entry
       # without rewriting it, so the cache still reads ON when it is off.
+      # -iE, not the -i "a\|b" form appimage.yml uses: that file runs on GNU
+      # grep, where \| is BRE alternation. This one runs on the macOS runner's
+      # BSD grep, which has no BRE alternation and would search for the literal
+      # string "GPU spectrum|Qt6GuiPrivate|private headers" — printing nothing
+      # under the ERROR header, on the one path where this step has to explain
+      # itself. Every other multi-pattern grep in this file already uses -E.
       - name: Assert GPU spectrum rendering actually enabled
         if: matrix.label == 'apple-silicon'
         run: |
           grep -q "GPU spectrum rendering enabled" configure.log || {
             echo "ERROR: -DAETHER_GPU_SPECTRUM=ON but CMake disabled it. Relevant output:"
-            grep -i "GPU spectrum\|Qt6GuiPrivate\|private headers" configure.log || true
+            grep -iE "GPU spectrum|Qt6GuiPrivate|private headers" configure.log || true
             exit 1
           }
           grep "GPU spectrum rendering enabled" configure.log
+
+      # The mirror of the above, and cheap: the Intel leg asks for OFF because
+      # QRhiWidget misbehaves on older Metal/OpenGL hardware, so a change that
+      # quietly turned it back ON here would ship exactly the artifact that
+      # decision exists to prevent. Asserting both directions is what makes
+      # GPU_FLAG's two values a tested contract rather than a comment.
+      - name: Assert GPU spectrum rendering actually disabled
+        if: matrix.label == 'intel'
+        run: |
+          grep -q "GPU spectrum rendering disabled" configure.log || {
+            echo "ERROR: -DAETHER_GPU_SPECTRUM=OFF but CMake enabled it. Relevant output:"
+            grep -iE "GPU spectrum|Qt6GuiPrivate|private headers" configure.log || true
+            exit 1
+          }
+          grep "GPU spectrum rendering disabled" configure.log
 
       - name: Build
         # Only the .app bundle ships (+ its aether-dv-waveform helper dependency,

--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -129,6 +129,11 @@ jobs:
 
       - name: Configure
         run: |
+          # Without pipefail the step's exit status is tee's, so a cmake failure
+          # would look green. Set it in the script rather than via `shell: bash`
+          # (which also implies -eo pipefail) so the guard is self-contained and
+          # survives anyone editing the step's shell. Same as appimage.yml.
+          set -o pipefail
           if [ "${{ matrix.label }}" = "intel" ]; then
             QT_PREFIX="$PWD/qt-install"
             DEPLOY_TARGET="13.0"
@@ -137,8 +142,11 @@ jobs:
             DEPLOY_TARGET="14.0"
           fi
           # Intel Mac: disable GPU rendering — QRhiWidget has issues on
-          # older Metal/OpenGL hardware. Apple Silicon uses GPU by default.
-          GPU_FLAG=""
+          # older Metal/OpenGL hardware. Apple Silicon renders via QRhi.
+          # Both legs state the value rather than leaning on the CMake default,
+          # so the intent is readable here and the assertion below has a
+          # request to check against.
+          GPU_FLAG="-DAETHER_GPU_SPECTRUM=ON"
           if [ "${{ matrix.label }}" = "intel" ]; then
             GPU_FLAG="-DAETHER_GPU_SPECTRUM=OFF"
           fi
@@ -161,7 +169,29 @@ jobs:
             -DREQUIRE_ASR_GPU=ON \
             -DREQUIRE_ASR_SHERPA=ON \
             $ONNX_FLAG \
-            $GPU_FLAG
+            $GPU_FLAG 2>&1 | tee configure.log
+
+      # Apple Silicon only — the Intel leg asks for OFF on purpose (see above).
+      # Same reasoning as appimage.yml and windows-installer.yml: CMake turns
+      # AETHER_GPU_SPECTRUM back OFF without failing when Qt6GuiPrivate can't be
+      # located, so the DMG could ship the CPU QPainter fallback with this
+      # workflow green. Homebrew Qt is the one layout here that does provide the
+      # Qt6GuiPrivate CMake package, which is precisely why this leg has gone
+      # unguarded — but that is a property of the Qt we happen to install, not
+      # something this workflow pins, so assert it rather than assume it.
+      #
+      # Assert on the configure output, not CMakeCache.txt: CMakeLists.txt
+      # disables the feature with a plain set(), which shadows the cache entry
+      # without rewriting it, so the cache still reads ON when it is off.
+      - name: Assert GPU spectrum rendering actually enabled
+        if: matrix.label == 'apple-silicon'
+        run: |
+          grep -q "GPU spectrum rendering enabled" configure.log || {
+            echo "ERROR: -DAETHER_GPU_SPECTRUM=ON but CMake disabled it. Relevant output:"
+            grep -i "GPU spectrum\|Qt6GuiPrivate\|private headers" configure.log || true
+            exit 1
+          }
+          grep "GPU spectrum rendering enabled" configure.log
 
       - name: Build
         # Only the .app bundle ships (+ its aether-dv-waveform helper dependency,

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -21,7 +21,14 @@ jobs:
       - name: Install Qt6
         uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730
         with:
-          version: '6.8.*'
+          # Exact, not '6.8.*'. The wildcard resolved to 6.8.3 only because Qt
+          # stopped publishing open-source 6.8.x binaries after it — 6.8.4 is
+          # source-only and 6.8.5+ are absent from the open-source repo. That is
+          # a licensing accident holding the release build to the tested Qt, not
+          # a pin. ci.yml's check-windows leg already spells 6.8.3 exactly; with
+          # both exact, the per-PR build and the release build agree by
+          # construction rather than by coincidence.
+          version: '6.8.3'
           host: 'windows'
           target: 'desktop'
           # Qt 6.8 LTS dropped MSVC 2019 builds — arch must be msvc2022.
@@ -140,7 +147,44 @@ jobs:
           # only job is compiling ggml-vulkan's own shaders, which are already
           # baked into the shipped .lib). The runtime vulkan-1.dll is bundled
           # in the Deploy step.
-          cmake -B build -G "Ninja" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMQTT_TLS=OFF -DREQUIRE_KEYCHAIN=ON -DREQUIRE_SERIALPORT=ON -DREQUIRE_ASR_ONNX=ON -DREQUIRE_ASR_SHERPA=ON -DREQUIRE_ASR_GPU=ON -DASR_USE_PREBUILT_WHISPER_GPU=ON -DCMAKE_PREFIX_PATH="$env:VULKAN_SDK" -DENABLE_NVIDIA_AFX=ON -DCMAKE_TOOLCHAIN_FILE="$env:CMAKE_TOOLCHAIN_FILE" -DVCPKG_TARGET_TRIPLET="$env:VCPKG_TARGET_TRIPLET"
+          #
+          # AETHER_GPU_SPECTRUM=ON is stated explicitly even though it is the
+          # CMake default, so the request is legible next to the assertion that
+          # follows — same shape as appimage.yml.
+          #
+          # Tee without `2>&1`, unlike the bash legs: GitHub runs pwsh with
+          # $ErrorActionPreference='Stop', where merging a native command's
+          # stderr into the pipeline can turn any CMake warning into a
+          # terminating error and fail configure on a non-problem. Nothing is
+          # lost — every line the assertion reads is message(STATUS), which
+          # CMake writes to stdout, and Tee-Object still passes the console
+          # output through for a human reading a failed run.
+          #
+          # $LASTEXITCODE survives the pipe (Tee-Object is a cmdlet, not a
+          # native command), so a configure failure still fails this step —
+          # the reason the bash legs need `set -o pipefail` and this one does
+          # not.
+          cmake -B build -G "Ninja" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMQTT_TLS=OFF -DREQUIRE_KEYCHAIN=ON -DREQUIRE_SERIALPORT=ON -DREQUIRE_ASR_ONNX=ON -DREQUIRE_ASR_SHERPA=ON -DREQUIRE_ASR_GPU=ON -DASR_USE_PREBUILT_WHISPER_GPU=ON -DAETHER_GPU_SPECTRUM=ON -DCMAKE_PREFIX_PATH="$env:VULKAN_SDK" -DENABLE_NVIDIA_AFX=ON -DCMAKE_TOOLCHAIN_FILE="$env:CMAKE_TOOLCHAIN_FILE" -DVCPKG_TARGET_TRIPLET="$env:VCPKG_TARGET_TRIPLET" | Tee-Object -FilePath configure.log
+
+      # AETHER_GPU_SPECTRUM=ON is a request, not a guarantee: CMake flips it
+      # back OFF without failing when Qt6GuiPrivate can't be located, and
+      # CMakeLists.txt names aqtinstall specifically as a layout that ships the
+      # private QtGui headers on disk while omitting the Qt6GuiPrivate CMake
+      # package — which is exactly what install-qt-action lays down here. So the
+      # Windows installer could quietly ship the CPU QPainter fallback with this
+      # workflow green, the same failure mode #4000 shipped on aarch64.
+      #
+      # Assert on the configure output, not CMakeCache.txt: CMakeLists.txt
+      # disables the feature with a plain set(), which shadows the cache entry
+      # without rewriting it, so the cache still reads ON when it is off.
+      - name: Assert GPU spectrum rendering actually enabled
+        run: |
+          if (-not (Select-String -Path configure.log -Pattern 'GPU spectrum rendering enabled' -Quiet)) {
+            Write-Host "ERROR: -DAETHER_GPU_SPECTRUM=ON but CMake disabled it. Relevant output:"
+            Select-String -Path configure.log -Pattern 'GPU spectrum|Qt6GuiPrivate|private headers'
+            exit 1
+          }
+          Select-String -Path configure.log -Pattern 'GPU spectrum rendering enabled'
 
       - name: Build Opus (RADE dependency)
         # ExternalProject dependency ordering via BUILD_BYPRODUCTS is correct,


### PR DESCRIPTION
## Summary

Closes §2 and §4 of #4688 (the issue stays open for §1, §5 and §6).

**§2 — the Windows Qt was never actually pinned.** `windows-installer.yml` asked
`install-qt-action` for `'6.8.*'` while `ci.yml`'s check-windows leg pinned
`'6.8.3'`. They agree today only because Qt stopped publishing open-source 6.8.x
binaries after 6.8.3 — 6.8.4 is source-only and 6.8.5+ never reach the
open-source repo at all. A licensing accident, not the pin, is what holds the
release build to the Qt that CI tested. Spelling it exactly makes that agreement
structural.

**§4 — the GPU guard existed on one artifact of three.** `AETHER_GPU_SPECTRUM=ON`
is a request, not a guarantee: CMake flips it back OFF, without failing, when
`Qt6GuiPrivate` can't be located. So an artifact can ship the CPU `QPainter`
fallback with its workflow green — the failure #4000 shipped on aarch64.
`appimage.yml` has asserted against that since it was written; the Windows
installer and the Apple Silicon DMG never did. Both now do, and both legs state
the flag explicitly rather than leaning on the CMake default, so the request is
legible next to the assertion.

Homebrew Qt does supply the `Qt6GuiPrivate` CMake package, which is why the
macOS leg has gone unguarded without incident. But that is a property of the Qt
we happen to install, not one this workflow pins — so it is now asserted rather
than assumed. The Intel leg is untouched: it asks for `OFF` deliberately, and
the new step is gated `if: matrix.label == 'apple-silicon'`.

### Three details worth review attention

**The guard reads configure output, not `CMakeCache.txt`.** `CMakeLists.txt`
disables the feature with a plain `set(AETHER_GPU_SPECTRUM OFF)`, which shadows
the cache entry without rewriting it — the cache still reads `ON` when the
feature is off. A cache-based guard would always pass.

**The macOS Configure step gains `set -o pipefail`.** Under GitHub's default
`bash -e` a pipeline's exit status is `tee`'s, so piping configure to a log
would have masked a cmake failure. `appimage.yml` already does this and
documents why; the comment here matches it.

**The Windows tee deliberately omits `2>&1`.** GitHub runs `pwsh` with
`$ErrorActionPreference='Stop'`, where merging a native command's stderr into
the pipeline can promote an ordinary CMake warning to a terminating error and
fail configure on a non-problem. Nothing is lost: all five lines the assertion
reads are `message(STATUS)`, which CMake writes to stdout. Windows also needs no
pipefail — `$LASTEXITCODE` tracks the last *native* command (cmake), and
`Tee-Object` is a cmdlet.

## Constitution principle honored

Technology Constraints — "Cross-platform: features must build and run on Linux
x86_64, Windows 10+, macOS (current and one back), and Raspberry Pi 5." GPU
spectrum rendering is a cross-platform feature that two of four release
artifacts could silently drop; this makes the platforms verify what they claim
to ship rather than differing by accident.

## Test plan

- [ ] Local build passes — N/A, workflow-only change, no code compiled
- [ ] Behavior verified on a real radio if applicable — N/A
- [x] Existing tests pass (CI)
- [ ] Reproduction steps documented if user-reported bug — N/A

**Verification limits, stated plainly.** Both files parse as YAML and each
contains its guard step; that is all that can be confirmed without running the
jobs. The new assertions execute only in `windows-installer.yml` and
`macos-dmg.yml`, which are tag-triggered — neither runs on this PR. The
PowerShell block has been reviewed by eye, not executed. A `workflow_dispatch`
run of each is the only real pre-merge test, and is worth doing given both are
release-path workflows.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no settings touched
- [x] Code is clean-room — CI configuration only


---

## Second commit — review follow-ups (499bbf5d)

Three things came out of review; all are in `ci.yml` and `macos-dmg.yml`.

**The macOS diagnostic grep could never print.** The failure branch was copied
verbatim from `appimage.yml`, which runs on GNU grep where `\|` is BRE
alternation. `macos-dmg.yml` runs on the macOS runner's BSD grep, which has
none — it would have searched for the literal string
`GPU spectrum|Qt6GuiPrivate|private headers`, matched nothing, and been
swallowed by `|| true`. The `ERROR:` header would have printed with silence
underneath, on the one path where the step has to explain itself to someone
holding a broken release tag. `-iE` is correct on both greps and is already
what every other multi-pattern grep in that file uses.

**The Intel DMG leg asserted nothing.** It asks for `AETHER_GPU_SPECTRUM=OFF`
because QRhiWidget misbehaves on older Metal/OpenGL hardware, so a change that
quietly turned it back ON would ship exactly the artifact that decision exists
to prevent. Asserting both directions makes `GPU_FLAG`'s two values a tested
contract rather than a comment.

**Nothing checked any of this on a pull request.** All four release workflows
are tag-triggered — `appimage.yml` included — so a change that silently flipped
the feature off would sit on `main` until someone cut a release: the same shape
as #4000, just discovered later. `ci.yml`'s three build jobs already print the
line on every PR; teeing their configure and reusing the same guard moves
detection from tag time to PR time on Linux, Windows and macOS. The release
assertions stay — they cover the Qt each artifact actually ships, which is not
the Qt any CI job uses, and the `check-windows` one is the only per-PR coverage
the aqtinstall layout gets (the layout `CMakeLists.txt` calls out as omitting
the `Qt6GuiPrivate` CMake package, so it exercises the fallback
`windows-installer.yml` depends on at release time).

This third item goes beyond §2/§4 of #4688 and is not one of its numbered
sections. It is included here rather than split out because it is the only part
of this PR that CI can actually prove: unlike the tag-triggered guards, these
three steps run on this PR.

### Verification of the second commit

Empirically checked, not just read:

- Guard logic mutation-tested both directions on synthetic configure logs —
  enabled log passes; disabled log fails with exit 1 **and a populated
  diagnostic**; and the inverse for the new Intel guard.
- Strings cross-checked against real output rather than against `CMakeLists.txt`
  alone: this PR's own CI run (30730387478) for all three `ci.yml` jobs, the
  v26.7.4 Windows installer run, and the v26.7.4.1 DMG run. The last of those
  confirms both macOS assertions against real release output — Intel prints
  `GPU spectrum rendering disabled (use -DAETHER_GPU_SPECTRUM=ON to enable)`,
  Apple Silicon prints `GPU spectrum rendering enabled (QRhi, Qt 6.11.1)`.
- The v26.7.4 Windows run shows `Qt6GuiPrivate CMake package not found,
  searching for private headers directly...` followed by
  `GPU spectrum rendering enabled (QRhi, Qt 6.8.3)` — so aqtinstall really does
  omit the CMake package on Windows, the fallback really does recover it, and
  the first commit's assertion would have passed on the last release.
- All four workflow files parse as YAML with the intended step and `if:`
  structure.

Still unverified, unchanged from above: the tag-triggered assertions do not
execute on this PR. A `workflow_dispatch` run of `windows-installer.yml` and
`macos-dmg.yml` remains the only real pre-merge test of those two.
