### PR TITLE
refactor(qt): drop the Qt 6.5 fallbacks the 6.8 floor made unreachable

### DIFF
--- a/src/core/FreeDvClient.cpp
+++ b/src/core/FreeDvClient.cpp
@@ -37,12 +37,7 @@ void FreeDvClient::initialize()
     connect(m_ws, &QWebSocket::connected, this, &FreeDvClient::onWsConnected);
     connect(m_ws, &QWebSocket::disconnected, this, &FreeDvClient::onWsDisconnected);
     connect(m_ws, &QWebSocket::textMessageReceived, this, &FreeDvClient::onWsTextMessage);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     connect(m_ws, &QWebSocket::errorOccurred, this, &FreeDvClient::onWsError);
-#else
-    connect(m_ws, QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::error),
-            this, &FreeDvClient::onWsError);
-#endif
     connect(m_reconnectTimer, &QTimer::timeout, this, &FreeDvClient::onReconnectTimer);
     connect(m_snrTimer,       &QTimer::timeout, this, &FreeDvClient::onSnrTimer);
 

--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -884,13 +884,7 @@ void KiwiSdrClient::openWebSockets()
             }
         }
     });
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     connect(m_soundSocket, &QWebSocket::errorOccurred, this,
-#else
-    connect(m_soundSocket,
-            QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::error),
-            this,
-#endif
             [this](QAbstractSocket::SocketError) {
                 const QString error =
                     m_soundSocket ? m_soundSocket->errorString() : QString();
@@ -951,13 +945,7 @@ void KiwiSdrClient::openWebSockets()
             }
         }
     });
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     connect(m_waterfallSocket, &QWebSocket::errorOccurred, this,
-#else
-    connect(m_waterfallSocket,
-            QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::error),
-            this,
-#endif
             [this](QAbstractSocket::SocketError) {
                 const QString error = m_waterfallSocket
                     ? m_waterfallSocket->errorString()


### PR DESCRIPTION
## Summary

Follow-up to #4686. Raising the floor to Qt 6.8 left three
`#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)` blocks whose `#else` branch is
unreachable on every supported configuration. All three select between
`QWebSocket::errorOccurred` and the
`QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::error)` spelling it
replaced in 6.5 — dead since the floor moved.

The overload behind the fallback is deprecated rather than *removed*: Qt 6.11.1
still declares `QWebSocket::error` in `qwebsocket.h`, guarded by
`QT_DEPRECATED_SINCE(6, 5)`. So the `#else` would still compile if anything
reached it — nothing does, and that is the whole argument. Keeping the gates
costs more than the lines: a reader has to establish the `#else` is unreachable
before trusting the connect, and `QWebSocket::error` still appearing in the tree
implies a compatibility target the build no longer has.

17 deletions across two files. No behaviour change — every supported Qt already
took the `errorOccurred` branch.

Part of #4688 (the cleanup the floor bump unlocked); does not close it.

### The harvest is complete

Swept the whole tree outside `third_party/` — not just `src/`, but `tests/`,
`tools/`, `cmake/`, `packaging/` and `.github/` too, and for the
`QT_VERSION_MAJOR`, `QT_DEPRECATED_SINCE` and `QT_DISABLE_DEPRECATED_BEFORE`
spellings as well as `QT_VERSION_CHECK`. After this change, six `QT_VERSION`
gates remain in first-party code and **every one is live at the current floor**:

| Gate | Not taken on | Taken on |
|---|---|---|
| `AudioEngine.cpp:338` `< 6.11` | macOS 6.11.1 | trixie 6.8.2 → Ubuntu 26.04 6.10.2 |
| `DxClusterDialog.cpp:274,281` `>= 6.10` | trixie 6.8.2, CI 6.8.3 | Ubuntu 26.04 6.10.2, macOS 6.11.1 |
| `FreeDvReporterDialog.cpp:42,47,56,61` `>= 6.10` | trixie 6.8.2, CI 6.8.3 | Ubuntu 26.04 6.10.2, macOS 6.11.1 |

Both sides of all three compile somewhere real, so there is no further dead
conditional code to take. `tests/` has no Qt gates at all, and after this change
`QWebSocket::error` appears nowhere in first-party code.

### Deliberately not included

`CMakeLists.txt`'s `VERSION_LESS "6.7"` guard is unreachable at a 6.8 floor, but
#4686 kept it on purpose and documented it as "a cheap backstop so lowering the
floor again can't silently produce" a broken config. Left alone — and unlike an
`#else` branch, a CMake guard that never fires costs a reader nothing.

Separately, 66 of the tree's remaining `QOverload` sites are redundant — verified
against the Qt 6.11.1 headers, `QComboBox::currentIndexChanged`,
`QComboBox::activated`, `QSpinBox::valueChanged`, `QDoubleSpinBox::valueChanged`
and `QButtonGroup::idClicked` each have exactly one signature in Qt 6, the
`(const QString&)` overloads having been removed. That is Qt 5 → 6 legacy rather
than anything this floor bump unlocked, and it would bury a 17-line diff, so it
belongs in its own PR. (`QOverload<>::of(&QWidget::update)` is genuinely
overloaded and must stay.)

## Constitution principle honored

Technology Constraints. The letter of that rule is about Qt 5 — "Qt 5 fallback
code paths must not be introduced into new features" — and these gates are
6.2-vs-6.5, a later vintage, so the citation is by extension rather than
directly on point. What carries the change is the same principle one step on:
compatibility scaffolding for a configuration the declared floor no longer
admits can only mislead a reader. Nothing here introduces a fallback path; it
removes three.

## Test plan

- [x] Local build passes — full build against Qt 6.11.1 on the **rebased** head,
      clean link, exit 0
- [x] Local test suite on the rebased head — 238/241 pass. The three
      failures (`wdsp_channel_test`, `automation_drag_at_test`,
      `radio_capability_gating_test`) reproduce identically on unmodified
      `origin/main`, so they are pre-existing and unrelated to this diff.
      They are not gated by CI either — `ci.yml:120` runs only
      `cross_needle_meter_test|hgauge_range_test` on Linux. Filed
      separately rather than papered over here.
- [ ] Behavior verified on a real radio if applicable — N/A, no behaviour change;
      the removed branch was never compiled on any supported Qt
- [x] Existing tests pass (CI)
- [ ] Reproduction steps documented if user-reported bug — N/A

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no settings touched
- [x] Code is clean-room — deletion only
