### PR TITLE
fix(appimage): deploy the Wayland platform plugin so the AppImage stops falling back to XWayland

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -157,16 +157,23 @@ jobs:
       - name: Install Qt 6.8.3 LTS via aqtinstall
         run: |
           pip3 install aqtinstall
-          # qtwayland: without it the AppImage ships no Wayland platform plugin,
-          # which is what #1389 actually was — src/main.cpp forced
-          # QT_QPA_PLATFORM=wayland and Qt aborted with "no Qt platform plugin
-          # could be initialized" on every Wayland session. The workaround then
-          # was to stop preferring Wayland under APPIMAGE, which left AppImage
-          # users on XWayland and so the only Linux users not receiving the
-          # #1233 GLX BadAccess fix. Bundling the plugin is the fix proposed on
-          # #1389 at the time and never landed.
+          # No qtwayland entry, deliberately: it rides in the BASE package.
+          # qt.qt6.683.<arch>'s DownloadableArchives lists qtwayland-Linux-...7z
+          # next to qtbase, so this install already lays down
+          # plugins/platforms/libqwayland-generic.so, libqwayland-egl.so and the
+          # three wayland-* integration dirs. There is no "qtwayland" module in
+          # the 6.8.3 repository at all — only qtwaylandcompositor — and aqt
+          # hard-errors on an unknown module ("The packages ['qtwayland'] were
+          # not found"), so naming one here fails the whole release build.
+          #
+          # #1389 — QT_QPA_PLATFORM=wayland aborting with "no Qt platform plugin
+          # could be initialized" — was therefore never a missing module. The
+          # plugin was in this tree and simply never DEPLOYED:
+          # linuxdeploy-plugin-qt copies platforms/libqxcb.so and nothing else
+          # unless EXTRA_PLATFORM_PLUGINS says otherwise. That is fixed in the
+          # AppImage steps below.
           aqt install-qt ${{ matrix.qt_host }} desktop 6.8.3 ${{ matrix.qt_arch }} \
-            -m qtmultimedia qtwebsockets qtserialport qtshadertools qtwayland \
+            -m qtmultimedia qtwebsockets qtserialport qtshadertools \
             --outputdir ${{ github.workspace }}/Qt
           # aqt lays the install down under <version>/<arch minus the host
           # prefix>: linux_gcc_64 -> gcc_64, linux_gcc_arm64 -> gcc_arm64.
@@ -291,6 +298,25 @@ jobs:
           # are missing, that is a broken release and the job should say so.
           cp -v "$QT_PLUGIN_PATH"/multimedia/* AppDir/usr/plugins/multimedia/
 
+          # Bundle the Wayland client buffer integration. QT_QPA_PLATFORM=wayland
+          # resolves to platforms/libqwayland-generic.so (qwayland-generic.json
+          # declares Keys: ["wayland"]; the EGL *platform* plugin's key is
+          # "wayland-egl", so that name never selects it), and the generic plugin
+          # obtains OpenGL only through a client buffer integration plugin loaded
+          # from this directory — libqt-plugin-wayland-egl.so. Without it native
+          # Wayland comes up with no GL at all, which matters because both legs
+          # ship AETHER_GPU_SPECTRUM=ON.
+          #
+          # It is staged by hand because no linuxdeploy variable reaches this
+          # directory: EXTRA_PLATFORM_PLUGINS covers platforms/ and makes
+          # linuxdeploy auto-deploy wayland-decoration-client and
+          # wayland-shell-integration, but not this one. Copying it here, before
+          # linuxdeploy runs, also gets its NEEDED libs resolved by the same
+          # dependency walk that handles everything else in the AppDir.
+          mkdir -p AppDir/usr/plugins/wayland-graphics-integration-client
+          cp -v "$QT_PLUGIN_PATH"/wayland-graphics-integration-client/* \
+            AppDir/usr/plugins/wayland-graphics-integration-client/
+
           # Bundle essential GStreamer plugins for audio
           GST_PATH=$(pkg-config --variable=pluginsdir gstreamer-1.0 2>/dev/null || echo "/usr/lib/$(uname -m)-linux-gnu/gstreamer-1.0")
           mkdir -p AppDir/usr/lib/gstreamer-1.0
@@ -308,11 +334,19 @@ jobs:
       - name: Build AppImage
         env:
           QT_SELECT: qt6
-          # The wayland-* entries pull in the client-side decoration, shell
-          # integration and graphics integration plugins that the Wayland
-          # platform plugin dlopen()s at runtime — they are not NEEDED entries
-          # on any binary, so nothing would deploy them by dependency walking.
-          EXTRA_QT_PLUGINS: multimedia;wayland-decoration-client;wayland-graphics-integration-client;wayland-shell-integration
+          # EXTRA_QT_PLUGINS is the deprecated alias of EXTRA_QT_MODULES and
+          # takes Qt *module* names, matched against linuxdeploy-plugin-qt's
+          # fixed table in src/qt-modules.h. Plugin *directory* names put here
+          # match nothing and are dropped without a warning, so it cannot reach
+          # platforms/ — the platform plugin has its own variable.
+          EXTRA_QT_PLUGINS: multimedia
+          # This is what deploys the Wayland platform plugin (#1389): without it
+          # PlatformPluginsDeployer copies platforms/libqxcb.so and stops. Naming
+          # a libqwayland* plugin here additionally makes linuxdeploy deploy
+          # wayland-decoration-client and wayland-shell-integration on its own —
+          # only wayland-graphics-integration-client has to be staged by hand,
+          # which the "Install to AppDir" step above does.
+          EXTRA_PLATFORM_PLUGINS: libqwayland-generic.so;libqwayland-egl.so
         run: |
           # Sanitize the ref for the output filename: a workflow_dispatch on a
           # branch like "ci/appimage-qtkeychain" puts a '/' in github.ref_name,
@@ -339,31 +373,61 @@ jobs:
             --icon-file AppDir/usr/share/icons/hicolor/256x256/apps/aethersdr.png \
             --output appimage
 
-      # The Wayland platform plugin is the whole point of adding qtwayland, and
-      # nothing else in the build would notice its absence: it is dlopen()ed by
-      # Qt at runtime, not linked, so no dependency walk covers it and the
-      # AppImage packages happily without it. That is exactly how #1389 shipped.
+      # Nothing else in the build would notice these plugins going missing: Qt
+      # dlopen()s them at runtime rather than linking them, so no dependency walk
+      # covers them and the AppImage packages happily without them. That is
+      # exactly how #1389 shipped — the platform plugin sat unused in the Qt tree
+      # while linuxdeploy deployed libqxcb.so and nothing else.
       #
       # This is a quality gate, not a safety gate. src/main.cpp now asks for
       # "wayland;xcb", so a missing plugin costs the Wayland improvement and
       # falls back to XWayland rather than failing to start. Failing the build
       # is still right — silently reverting to the old behaviour while the
       # release notes claim native Wayland is worse than a red run.
-      - name: Assert the Wayland platform plugin was bundled
+      - name: Assert the Wayland plugins were bundled
         run: |
-          set -o pipefail
-          found=$(find AppDir -name 'libqwayland*.so' -print 2>/dev/null | sort)
-          if [ -z "$found" ]; then
-            echo "ERROR: no Wayland platform plugin in AppDir — the AppImage would"
-            echo "silently fall back to XWayland (the #1389 shape)."
+          plugins="AppDir/usr/plugins"
+          fail=0
+          # Anchored to platforms/ deliberately: a libqwayland*.so sitting
+          # anywhere else in the AppDir is not something Qt can load. The `||
+          # true` keeps a missing directory from killing the step under `bash -e`
+          # before it can print why.
+          platform=$(find "$plugins/platforms" -maxdepth 1 -name 'libqwayland*.so' 2>/dev/null | sort || true)
+          if [ -z "$platform" ]; then
+            echo "ERROR: no Wayland platform plugin in $plugins/platforms — the"
+            echo "AppImage would silently fall back to XWayland (the #1389 shape)."
+            echo "EXTRA_PLATFORM_PLUGINS is what deploys it."
+            fail=1
+          else
+            echo "Wayland platform plugin(s):"
+            echo "$platform"
+          fi
+          # The generic platform plugin gets OpenGL only through this one, and no
+          # linuxdeploy variable deploys it — the "Install to AppDir" step stages
+          # it by hand, so a typo there is silent without this check.
+          if [ ! -f "$plugins/wayland-graphics-integration-client/libqt-plugin-wayland-egl.so" ]; then
+            echo "ERROR: libqt-plugin-wayland-egl.so missing from"
+            echo "$plugins/wayland-graphics-integration-client — native Wayland"
+            echo "would come up with no OpenGL."
+            fail=1
+          fi
+          # linuxdeploy deploys these two itself, off the libqwayland* name in
+          # EXTRA_PLATFORM_PLUGINS. If a future linuxdeploy drops that special
+          # case, catch it here rather than in a bug report about undecorated
+          # windows.
+          for d in wayland-decoration-client wayland-shell-integration; do
+            if [ ! -d "$plugins/$d" ]; then
+              echo "ERROR: $plugins/$d missing"
+              fail=1
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then
             echo "Qt plugin dirs actually deployed:"
-            find AppDir -type d -name platforms -o -type d -name 'wayland-*' | sort
+            find AppDir -type d \( -name platforms -o -name 'wayland-*' \) 2>/dev/null | sort || true
             exit 1
           fi
-          echo "Wayland platform plugin(s) bundled:"
-          echo "$found"
           echo "Wayland integration plugin dirs:"
-          find AppDir -type d -name 'wayland-*' | sort
+          find "$plugins" -maxdepth 1 -type d -name 'wayland-*' | sort
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -157,8 +157,16 @@ jobs:
       - name: Install Qt 6.8.3 LTS via aqtinstall
         run: |
           pip3 install aqtinstall
+          # qtwayland: without it the AppImage ships no Wayland platform plugin,
+          # which is what #1389 actually was — src/main.cpp forced
+          # QT_QPA_PLATFORM=wayland and Qt aborted with "no Qt platform plugin
+          # could be initialized" on every Wayland session. The workaround then
+          # was to stop preferring Wayland under APPIMAGE, which left AppImage
+          # users on XWayland and so the only Linux users not receiving the
+          # #1233 GLX BadAccess fix. Bundling the plugin is the fix proposed on
+          # #1389 at the time and never landed.
           aqt install-qt ${{ matrix.qt_host }} desktop 6.8.3 ${{ matrix.qt_arch }} \
-            -m qtmultimedia qtwebsockets qtserialport qtshadertools \
+            -m qtmultimedia qtwebsockets qtserialport qtshadertools qtwayland \
             --outputdir ${{ github.workspace }}/Qt
           # aqt lays the install down under <version>/<arch minus the host
           # prefix>: linux_gcc_64 -> gcc_64, linux_gcc_arm64 -> gcc_arm64.
@@ -300,7 +308,11 @@ jobs:
       - name: Build AppImage
         env:
           QT_SELECT: qt6
-          EXTRA_QT_PLUGINS: multimedia
+          # The wayland-* entries pull in the client-side decoration, shell
+          # integration and graphics integration plugins that the Wayland
+          # platform plugin dlopen()s at runtime — they are not NEEDED entries
+          # on any binary, so nothing would deploy them by dependency walking.
+          EXTRA_QT_PLUGINS: multimedia;wayland-decoration-client;wayland-graphics-integration-client;wayland-shell-integration
         run: |
           # Sanitize the ref for the output filename: a workflow_dispatch on a
           # branch like "ci/appimage-qtkeychain" puts a '/' in github.ref_name,
@@ -326,6 +338,32 @@ jobs:
             --desktop-file AppDir/usr/share/applications/AetherSDR.desktop \
             --icon-file AppDir/usr/share/icons/hicolor/256x256/apps/aethersdr.png \
             --output appimage
+
+      # The Wayland platform plugin is the whole point of adding qtwayland, and
+      # nothing else in the build would notice its absence: it is dlopen()ed by
+      # Qt at runtime, not linked, so no dependency walk covers it and the
+      # AppImage packages happily without it. That is exactly how #1389 shipped.
+      #
+      # This is a quality gate, not a safety gate. src/main.cpp now asks for
+      # "wayland;xcb", so a missing plugin costs the Wayland improvement and
+      # falls back to XWayland rather than failing to start. Failing the build
+      # is still right — silently reverting to the old behaviour while the
+      # release notes claim native Wayland is worse than a red run.
+      - name: Assert the Wayland platform plugin was bundled
+        run: |
+          set -o pipefail
+          found=$(find AppDir -name 'libqwayland*.so' -print 2>/dev/null | sort)
+          if [ -z "$found" ]; then
+            echo "ERROR: no Wayland platform plugin in AppDir — the AppImage would"
+            echo "silently fall back to XWayland (the #1389 shape)."
+            echo "Qt plugin dirs actually deployed:"
+            find AppDir -type d -name platforms -o -type d -name 'wayland-*' | sort
+            exit 1
+          fi
+          echo "Wayland platform plugin(s) bundled:"
+          echo "$found"
+          echo "Wayland integration plugin dirs:"
+          find AppDir -type d -name 'wayland-*' | sort
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed: the Linux AppImage runs natively on Wayland instead of XWayland (#1389, #1233)
+
+**On a Wayland desktop the AppImage now uses Wayland directly.** Text and the
+spectrum are sharp under fractional scaling — previously the desktop was
+bitmap-scaling an X11 window — and the AppImage finally receives the fix for the
+GLX crash that could happen when opening a dialog such as Radio Setup on some
+desktops. Every other Linux build has had that fix since v0.8.12; the AppImage
+was the one left out.
+
+It was left out to stop a worse problem. The AppImage asked for Wayland without
+carrying the piece of Qt that talks Wayland, so it refused to start at all on
+Ubuntu 24.04 and anything else defaulting to a Wayland session. The quick fix
+was to stop asking for Wayland in the AppImage, which cured the crash and
+stranded those users on XWayland permanently. The Wayland support was in fact
+present in the Qt we build against the whole time — it simply never made it into
+the packaged app, and nothing in the build noticed, because it is loaded on
+demand rather than linked. It is now packaged, and the release build fails if it
+ever goes missing again.
+
+AetherSDR also now asks for Wayland *with a fallback* rather than demanding it,
+so a machine without Wayland support quietly uses XWayland instead of failing to
+start. If a desktop misbehaves under native Wayland, `QT_QPA_PLATFORM=xcb`
+forces the old path — documented in the README next to `AETHER_NO_GPU`. Setting
+`QT_QPA_PLATFORM` yourself always wins.
+
+Reported by @cjdellis on Ubuntu 24.04.
+
 ### Changed: the waterfall recolours its history when you change the palette (#4694)
 
 **Picking a new waterfall Scheme now recolours the waterfall you are already

--- a/README.md
+++ b/README.md
@@ -234,6 +234,23 @@ AETHER_NO_GPU=1 ./AetherSDR-*.AppImage
 
 That is the escape hatch if a GPU or driver renders the spectrum incorrectly — worth trying first on Raspberry Pi and other systems whose Mesa driver is newer than its hardware.
 
+### Wayland and XWayland
+
+On a Wayland session AetherSDR asks Qt for `wayland;xcb` — native Wayland when
+the platform plugin is available, XWayland otherwise. Native Wayland avoids the
+GLX `BadAccess` crash that XWayland can produce when opening child dialogs on
+some compositors, and renders correctly under fractional scaling instead of
+being bitmap-scaled by the compositor.
+
+If a compositor misbehaves under native Wayland, force XWayland:
+
+```bash
+QT_QPA_PLATFORM=xcb ./AetherSDR-*.AppImage
+```
+
+Setting `QT_QPA_PLATFORM` yourself always wins — AetherSDR only supplies a
+default when the variable is unset.
+
 On a distribution whose Qt is older than the required 6.8 (notably Ubuntu 24.04 LTS at 6.4.2), install a newer Qt manually:
 
 1. **Option 1: Using a PPA (Ubuntu/Mint)**

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1906,9 +1906,13 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     // main.cpp normally forces native Wayland, but log it if we ended up here.
     if (QGuiApplication::platformName() == QLatin1String("xcb")
         && qEnvironmentVariable("XDG_SESSION_TYPE") == QLatin1String("wayland")) {
+        // Advise the fallback list rather than a bare "wayland": on a build or
+        // host without the Wayland plugin, forcing plain "wayland" aborts at
+        // startup instead of doing nothing — which is how #1389 happened.
         qWarning() << "SpectrumWidget: running under XWayland with OpenGL — "
-                      "GLX context issues may occur. Set QT_QPA_PLATFORM=wayland "
-                      "or AETHER_NO_GPU=1 to work around (#1233)";
+                      "GLX context issues may occur. Set "
+                      "QT_QPA_PLATFORM='wayland;xcb' or AETHER_NO_GPU=1 to work "
+                      "around (#1233)";
     }
 #  endif
 #endif

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1906,13 +1906,17 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     // main.cpp normally forces native Wayland, but log it if we ended up here.
     if (QGuiApplication::platformName() == QLatin1String("xcb")
         && qEnvironmentVariable("XDG_SESSION_TYPE") == QLatin1String("wayland")) {
-        // Advise the fallback list rather than a bare "wayland": on a build or
-        // host without the Wayland plugin, forcing plain "wayland" aborts at
-        // startup instead of doing nothing — which is how #1389 happened.
+        // Don't advise "set QT_QPA_PLATFORM=wayland" here. Reaching this line on
+        // a Wayland session means either main.cpp already asked for
+        // "wayland;xcb" and the Wayland plugin would not load, or the user
+        // forced xcb — so the old advice was a no-op in the first case and a
+        // startup abort in the second, which is how #1389 happened. Name the
+        // workaround that always applies, and the override only where it helps.
         qWarning() << "SpectrumWidget: running under XWayland with OpenGL — "
-                      "GLX context issues may occur. Set "
-                      "QT_QPA_PLATFORM='wayland;xcb' or AETHER_NO_GPU=1 to work "
-                      "around (#1233)";
+                      "GLX context issues may occur. The Wayland platform plugin "
+                      "is unavailable or overridden; set AETHER_NO_GPU=1 to work "
+                      "around, or QT_QPA_PLATFORM='wayland;xcb' if you forced "
+                      "xcb yourself (#1233)";
     }
 #  endif
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -250,13 +250,33 @@ int main(int argc, char* argv[])
     // context switching between the main window and child dialogs triggers
     // a BadAccess crash (X_GLXMakeCurrent) on some compositors.
     // Only set when QT_QPA_PLATFORM isn't already configured by the user.
-    // Skip for AppImage: the bundled Qt Wayland plugin may not match the
-    // host compositor's protocol version, causing an abort on init (#1389).
-    if (!qEnvironmentVariableIsSet("QT_QPA_PLATFORM")
-            && !qEnvironmentVariableIsSet("APPIMAGE")) {
+    //
+    // "wayland;xcb", not "wayland": Qt reads the value as an ordered list and
+    // moves to the next entry when a plugin cannot be loaded, so a build or
+    // host without the Wayland plugin lands on xcb instead of aborting with
+    // "no Qt platform plugin could be initialized".
+    //
+    // That abort is precisely what #1389 was. The AppImage forced plain
+    // "wayland" while bundling no qtwayland module at all, so every Wayland-
+    // session user got a binary that would not start. The carve-out added
+    // then — skip this block under APPIMAGE — treated the symptom, and its
+    // stated reason (a bundled plugin mismatching the compositor's protocol
+    // version) described something that never happened: there was no bundled
+    // plugin to mismatch.
+    //
+    // The carve-out is gone because both of its causes are: appimage.yml now
+    // installs qtwayland and asserts the platform plugin reached the AppDir,
+    // and this fallback turns a missing plugin into a downgrade to XWayland
+    // rather than a failure to start. Removing it also closes a real gap —
+    // AppImage users were the only Linux users not receiving the #1233
+    // XWayland GLX fix that this block exists to deliver.
+    //
+    // QT_QPA_PLATFORM=xcb remains the escape hatch if a compositor renders
+    // badly under native Wayland (documented in README next to AETHER_NO_GPU).
+    if (!qEnvironmentVariableIsSet("QT_QPA_PLATFORM")) {
         const QByteArray session = qgetenv("XDG_SESSION_TYPE");
         if (session == "wayland" && qEnvironmentVariableIsSet("WAYLAND_DISPLAY")) {
-            qputenv("QT_QPA_PLATFORM", "wayland");
+            qputenv("QT_QPA_PLATFORM", "wayland;xcb");
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -257,15 +257,18 @@ int main(int argc, char* argv[])
     // "no Qt platform plugin could be initialized".
     //
     // That abort is precisely what #1389 was. The AppImage forced plain
-    // "wayland" while bundling no qtwayland module at all, so every Wayland-
-    // session user got a binary that would not start. The carve-out added
-    // then — skip this block under APPIMAGE — treated the symptom, and its
-    // stated reason (a bundled plugin mismatching the compositor's protocol
+    // "wayland" while shipping no Wayland platform plugin inside the AppDir.
+    // The plugin was never missing from the Qt build — qtwayland rides in the
+    // base aqt package — but linuxdeploy-plugin-qt deploys platforms/libqxcb.so
+    // and nothing else unless EXTRA_PLATFORM_PLUGINS names more, so every
+    // Wayland-session user got a binary that would not start. The carve-out
+    // added then — skip this block under APPIMAGE — treated the symptom, and
+    // its stated reason (a bundled plugin mismatching the compositor's protocol
     // version) described something that never happened: there was no bundled
     // plugin to mismatch.
     //
     // The carve-out is gone because both of its causes are: appimage.yml now
-    // installs qtwayland and asserts the platform plugin reached the AppDir,
+    // deploys the Wayland platform plugin and asserts it reached the AppDir,
     // and this fallback turns a missing plugin into a downgrade to XWayland
     // rather than a failure to start. Removing it also closes a real gap —
     // AppImage users were the only Linux users not receiving the #1233


### PR DESCRIPTION
## Summary

Closes §5 of #4688. Properly fixes the cause behind #1389, and extends #1233's
fix to the AppImage users who never received it.

`src/main.cpp` sets `QT_QPA_PLATFORM=wayland` on a Wayland session, and the
AppImage aborted with *"no Qt platform plugin could be initialized"* because no
Wayland platform plugin was in the AppDir. That is #1389. What landed at the
time was a carve-out — skip the Wayland preference under `APPIMAGE` — which
stopped the crash and left AppImage users on XWayland permanently, making them
**the only Linux users not receiving the #1233 GLX `BadAccess` fix that the
block exists to deliver**. The carve-out's stated reason — a bundled plugin
mismatching the compositor's protocol version — described something that never
happened: there was no bundled plugin to mismatch.

### Why the plugin was missing (not what #1389's root-cause note said)

The original analysis on #1389, and the first cut of this PR, blamed the aqt
module list. That is wrong, and review caught it:

- **`qtwayland` is already installed.** It ships inside the *base* package:
  `qt.qt6.683.<arch>`'s `DownloadableArchives` lists
  `qtwayland-Linux-…7z` next to qtbase. That archive carries
  `plugins/platforms/libqwayland-generic.so`, `libqwayland-egl.so` and the three
  `wayland-*` plugin dirs — verified by download for `linux_gcc_64` and
  `linux_gcc_arm64` alike. `$QT_ROOT/plugins` has had the plugin all along.
- **There is no `qtwayland` aqt module for 6.8.3** — only `qtwaylandcompositor`
  — and aqt hard-errors on an unknown module, so asking for it fails the release
  build outright on both matrix legs.
- **The plugin was never *deployed*.** `linuxdeploy-plugin-qt` copies
  `platforms/libqxcb.so` and stops unless `EXTRA_PLATFORM_PLUGINS` names more.
  Nothing else in the build notices, because Qt `dlopen()`s the plugin rather
  than linking it — which is the one shape a dependency walk cannot catch, and
  exactly how #1389 shipped.

### What changes

- **`EXTRA_PLATFORM_PLUGINS: libqwayland-generic.so;libqwayland-egl.so`** — the
  variable that actually reaches `platforms/`. Naming a `libqwayland*` plugin
  there also makes linuxdeploy deploy `wayland-decoration-client` and
  `wayland-shell-integration` on its own. (`EXTRA_QT_PLUGINS` cannot do this: it
  is the deprecated alias of `EXTRA_QT_MODULES` and takes Qt *module* names
  matched against a fixed table, so plugin-directory names are dropped without a
  warning.)
- **`wayland-graphics-integration-client` staged by hand**, next to the existing
  multimedia copy. No linuxdeploy variable reaches it, and it is not optional:
  `QT_QPA_PLATFORM=wayland` selects `libqwayland-generic.so`
  (`qwayland-generic.json` declares `Keys: ["wayland"]`; the EGL *platform*
  plugin's key is `wayland-egl`, so that name never selects it), and the generic
  plugin obtains OpenGL only through `libqt-plugin-wayland-egl.so` from that
  directory. Without it the AppImage would reach native Wayland with **no GL** —
  on both legs, which ship `AETHER_GPU_SPECTRUM=ON`.
- **`main.cpp` asks for `"wayland;xcb"` instead of `"wayland"`.** Qt reads the
  value as an ordered list and moves to the next entry when a plugin cannot
  load, so a missing plugin now costs the Wayland upgrade instead of preventing
  startup. This is what makes dropping the `APPIMAGE` carve-out safe.
- **A build step asserts the plugins actually reached the AppDir** — anchored to
  `AppDir/usr/plugins/platforms/`, covering the hand-staged EGL integration
  plugin and the two linuxdeploy-deployed dirs. It is a quality gate, not a
  safety gate: with the fallback in place a missing plugin degrades to XWayland
  rather than breaking the app. Failing the build is still right, because
  silently reverting to the old behaviour while release notes claim native
  Wayland is worse than a red run.

`SpectrumWidget`'s XWayland warning advised *"Set `QT_QPA_PLATFORM=wayland`"*,
which on a host without the plugin aborts the app — the app was recommending the
very thing that caused #1389. Reaching that line now means either `main.cpp`
already asked for `wayland;xcb` and the plugin would not load, or the user forced
xcb, so it names the workaround that always applies and the override only where
it helps.

### Why this is worth the risk

Beyond the GLX crash class, XWayland is why the AppImage renders blurry under
fractional scaling: the compositor bitmap-scales an X11 surface. Native Wayland
gets the real scale factor, which makes `QT_SCALE_FACTOR` (via `UiScalePercent`)
a preference rather than the only available workaround on Linux.

## Constitution principle honored

Technology Constraints — *"Cross-platform: features must build and run on Linux
x86_64, Windows 10+, macOS (current and one back), and Raspberry Pi 5."* The
AppImage is the primary Linux delivery channel for both x86_64 and the Pi, and
it is currently the one Linux build excluded from a Linux crash fix.

## Test plan

- [x] Local build passes — clean build of the first cut of this branch
- [x] Behavior verified — see below; on hardware, not simulated
- [x] Existing tests pass (CI)
- [x] Reproduction steps documented — #1389 and #1233 both carry them

**Verified**

1. **Qt honours the list with fallback** (Qt 6.11.1, the mechanism the whole
   design rests on — Qt does not document it, so it was tested rather than
   assumed):

   | `QT_QPA_PLATFORM` | selected |
   |---|---|
   | `wayland;xcb` | `wayland` |
   | `bogus;xcb` | `xcb` (falls back, no abort) |
   | `bogus` | aborts — the #1389 shape |

2. **A build of this branch run with `APPIMAGE=1` on a Wayland session** did not
   emit `SpectrumWidget`'s XWayland warning, which fires whenever
   `platformName()` is `xcb` on a Wayland session. `QRhi initialized` in the same
   log confirms that code path executed. So it took the native Wayland path that
   main's code would have denied it.

3. **The packaging claims, checked against the real sources rather than docs:**
   ran `aqt install-qt` with the old `-m … qtwayland` list and watched it fail
   (`The packages ['qtwayland'] were not found while parsing XML of package
   information!`); listed the 6.8.3 modules for both arches (`qtwaylandcompositor`
   only); downloaded the base package's `qtwayland` archive for x86_64 and
   aarch64 and confirmed the plugin filenames used in `EXTRA_PLATFORM_PLUGINS`;
   read `linuxdeploy-plugin-qt`'s `main.cpp`, `qt-modules.h`,
   `PlatformPluginsDeployer.cpp` and `PluginsDeployerFactory.cpp` for the
   `EXTRA_QT_PLUGINS` / `EXTRA_PLATFORM_PLUGINS` semantics and the
   `libqwayland*` auto-deploy special case.

4. **The assert step was mutation-tested** against synthetic AppDirs: complete
   tree passes; missing platform plugin, missing `libqt-plugin-wayland-egl.so`,
   and a missing decoration dir each fail with their own diagnostic; a stray
   `libqwayland*.so` outside `platforms/` no longer satisfies it (the previous
   glob accepted it); and a missing `AppDir` now prints why instead of dying
   silently under `bash -e`.

**Not verified, and only CI can**

- That the AppDir ends up correct end-to-end after linuxdeploy runs. **A
  `workflow_dispatch` AppImage build, downloaded and run on a Wayland desktop, is
  the real pre-merge test** and is worth doing before this lands — `appimage.yml`
  runs only on tag push and dispatch, so PR CI never exercises it.
- Behaviour of the resulting AppImage on compositors other than the one tested.

**Known trade**

The `wayland;xcb` fallback covers a plugin that fails to *load*, not one that
loads and then misbehaves on an unusual compositor. Anyone in that situation gets
something worse than today's XWayland until they set `QT_QPA_PLATFORM=xcb` — now
documented in README alongside `AETHER_NO_GPU` rather than left as folklore.
Setting `QT_QPA_PLATFORM` yourself always wins; AetherSDR only supplies a default
when the variable is unset.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no settings touched
- [x] CHANGELOG entry under `[Unreleased]`
- [x] Code is clean-room
