### PR TITLE
[codex] Recolor retained waterfall history on palette change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed: the waterfall recolours its history when you change the palette (#4694)
+
+**Picking a new waterfall Scheme now recolours the waterfall you are already
+looking at, instead of only the rows that arrive next.** Previously the palette
+change took effect at the waterline: everything above it kept the old colours,
+so comparing two schemes meant waiting for the display to scroll clear. The 3D
+spectrum has always recoloured immediately — the 2D waterfall now matches it.
+
+Switching *themes* does the same thing, for the same reason: the theme owns the
+gradient behind every preset, so a theme change is a palette change.
+
+Nothing moves while it happens. The waterfall keeps its scroll position, its
+paused scrollback, and its place in the scroll animation — the retained rows
+were always stored as palette-independent intensity, so recolouring is a
+repaint of what is on screen, the same work a pan already does, and the
+scrollback above the viewport recolours as you scroll it back in.
+
 ### Fixed: transmit audio breaking up with RN2 enabled (#4584)
 
 **Your transmitted audio no longer breaks up when RN2 is on.** Remote transmit

--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -292,6 +292,27 @@ inline WaterfallPaletteRecolorPlan waterfallPaletteRecolorPlan(
     return WaterfallPaletteRecolorPlan{false, viewportFrame, {}};
 }
 
+// Scanline that a retained row of age `ageRows` occupies in a visible ring
+// whose newest row sits at `writeRowOrigin`. appendVisibleRow() decrements the
+// write row *before* writing, so age 0 is the origin itself and age grows
+// downward, wrapping — which is exactly the order drawWaterfall() blits from.
+//
+// The origin is the whole reason a palette recolour is not just a viewport
+// rebuild: a rebuild re-lays the ring out from scanline 0 (origin 0), which is
+// invisible only because it repaints everything at once. Recolouring in place
+// must keep the live origin, or the waterfall jumps by m_wfWriteRow rows the
+// moment the operator touches the Scheme dropdown.
+inline int waterfallVisibleRowForAge(int writeRowOrigin, int ageRows,
+                                     int height)
+{
+    if (height <= 0) {
+        return -1;
+    }
+    const int origin = ((writeRowOrigin % height) + height) % height;
+    const int age = ((ageRows % height) + height) % height;
+    return (origin + age) % height;
+}
+
 struct WaterfallRowFrameReadiness {
     bool requested{false};
     bool formatSupported{false};

--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -269,6 +269,29 @@ enum class WaterfallPipelineMode {
     RowFrequencyFrames,
 };
 
+struct WaterfallPaletteRecolorPlan {
+    bool retainNativeFrames{false};
+    FrequencyFrame primaryFrame;
+    FrequencyFrame supplementalFrame;
+};
+
+inline WaterfallPaletteRecolorPlan waterfallPaletteRecolorPlan(
+    WaterfallPipelineMode pipelineMode,
+    const FrequencyFrame& historyFrame,
+    const FrequencyFrame& supplementalHistoryFrame,
+    const FrequencyFrame& viewportFrame)
+{
+    if (pipelineMode == WaterfallPipelineMode::RowFrequencyFrames) {
+        return WaterfallPaletteRecolorPlan{
+            true,
+            historyFrame.isValid() ? historyFrame : viewportFrame,
+            supplementalHistoryFrame.isValid()
+                ? supplementalHistoryFrame : FrequencyFrame{},
+        };
+    }
+    return WaterfallPaletteRecolorPlan{false, viewportFrame, {}};
+}
+
 struct WaterfallRowFrameReadiness {
     bool requested{false};
     bool formatSupported{false};

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2122,11 +2122,10 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     connect(&SliceColorManager::instance(), &SliceColorManager::colorsChanged,
             this, [this]() { markOverlayDirty(); });
 
-    // Refresh the waterfall colormap cache when the theme changes.  Existing
-    // already-rendered rows keep their pre-switch colours (same behaviour as
-    // changing the Scheme: dropdown — recolouring history would force a full
-    // O(rows × cols) repaint we don't currently amortise).  New rows pick up
-    // the new palette on the next push.
+    // Refresh the waterfall colormap cache when the theme changes. Theme
+    // changes still affect newly-arriving rows only; the operator-facing
+    // Scheme dropdown has a separate palette-refresh path because it explicitly
+    // requests an immediate recolour of retained waterfall history.
     connect(&ThemeManager::instance(), &ThemeManager::themeChanged,
             this, [this]() {
         rebuildWfStopsCacheFromTheme();
@@ -4411,6 +4410,7 @@ void SpectrumWidget::setWfColorScheme(int scheme) {
         auto& s = AppSettings::instance();
         s.setValue(settingsKey("DisplayWfColorScheme"), QString::number(static_cast<int>(m_wfColorScheme)));
         s.save();
+        recolorWaterfallViewport();
     }
     update();
 }
@@ -5567,6 +5567,97 @@ void SpectrumWidget::rebuildDssViewportFromHistoryForFrame(double centerMhz,
     resetDssUploadState();
 }
 
+void SpectrumWidget::recolorWaterfallViewport()
+{
+    if (m_frequencyPreviewActive) {
+        m_waterfallPaletteRefreshPending = true;
+        return;
+    }
+
+    m_waterfallPaletteRefreshPending = false;
+    if (m_waterfall.isNull() || !m_waterfallHistory.isConfigured()) {
+        return;
+    }
+
+    const int height = m_waterfall.height();
+    if (height <= 0) {
+        return;
+    }
+
+    m_wfHistoryOffsetRows = std::clamp(
+        m_wfHistoryOffsetRows, 0, maxWaterfallHistoryOffsetRows());
+
+    // Rebuild only the already-visible RGB images from the retained,
+    // palette-independent intensity history. Keep the current visible ring
+    // position and scroll clock intact so a palette change cannot move the
+    // waterfall while it is live or paused.
+    const int writeRow = ((m_wfWriteRow % height) + height) % height;
+    m_waterfall.fill(Qt::black);
+    if (!m_waterfallSupplemental.isNull()) {
+        m_waterfallSupplemental.fill(Qt::black);
+    }
+    resetVisibleWaterfallFrequencyFrames(m_centerMhz, m_bandwidthMhz);
+
+    const int w = m_waterfall.width();
+    const bool haveFrames = m_wfHistoryRowCenterMhz.size()
+        == m_waterfallHistory.capacityRows();
+    const bool haveSupplementalFrames =
+        m_wfHistorySupplementalCenterMhz.size()
+            == m_waterfallHistory.capacityRows()
+        && m_wfHistorySupplementalBwMhz.size()
+            == m_waterfallHistory.capacityRows();
+    const std::array<QRgb, 256> colorLut = waterfallHistoryColorLut();
+    for (int age = 0; age < height; ++age) {
+        const int rowIndex = historyRowIndexForAge(
+            m_wfHistoryOffsetRows + age);
+        if (rowIndex < 0) {
+            break;
+        }
+
+        const quint8* src = m_waterfallHistory.row(rowIndex);
+        if (!src) {
+            continue;
+        }
+
+        const int destinationRow = (writeRow + age) % height;
+        auto* dst = reinterpret_cast<QRgb*>(
+            m_waterfall.scanLine(destinationRow));
+        const double rowCenter = haveFrames
+            ? m_wfHistoryRowCenterMhz[rowIndex] : m_centerMhz;
+        const double rowBw = haveFrames
+            ? m_wfHistoryRowBwMhz[rowIndex] : m_bandwidthMhz;
+        const quint8* supplementalSrc =
+            m_waterfallSupplementalHistory.row(rowIndex);
+        const double supplementalCenter = haveSupplementalFrames
+            ? m_wfHistorySupplementalCenterMhz[rowIndex] : 0.0;
+        const double supplementalBw = haveSupplementalFrames
+            ? m_wfHistorySupplementalBwMhz[rowIndex] : 0.0;
+        remapHistoryRowInto(dst, src, w, colorLut,
+                            rowCenter, rowBw,
+                            m_centerMhz, m_bandwidthMhz,
+                            m_kiwiSdrWaterfallActive,
+                            supplementalSrc,
+                            supplementalCenter, supplementalBw);
+
+        m_wfVisibleRowCenterMhz[destinationRow] = rowCenter;
+        m_wfVisibleRowBwMhz[destinationRow] = rowBw;
+        m_wfVisibleSupplementalCenterMhz[destinationRow] = supplementalCenter;
+        m_wfVisibleSupplementalBwMhz[destinationRow] = supplementalBw;
+    }
+
+#ifdef AETHER_GPU_SPECTRUM
+    // The image changed in every physical row, so an incremental upload would
+    // be both more complicated and slower than the existing full-upload path.
+    m_wfTexFullUpload = true;
+#endif
+    if (PerfTelemetry::instance().enabled()) {
+        PerfTelemetry::instance().recordWaterfallRebuild();
+    }
+    if (!m_wfLive) {
+        rebuildDssViewportFromHistory();
+    }
+}
+
 void SpectrumWidget::rebuildWaterfallViewportForFrame(double centerMhz,
                                                       double bandwidthMhz)
 {
@@ -5906,6 +5997,9 @@ void SpectrumWidget::commitFrequencyPreview()
 #ifdef AETHER_GPU_SPECTRUM
     m_frequencyScalePreviewNeedsUpload = false;
 #endif
+    if (m_waterfallPaletteRefreshPending) {
+        recolorWaterfallViewport();
+    }
     ++m_frequencyPreviewOverlayCommitRefreshCount;
     ++m_panStats.previewOverlayCommitRefreshes;
     markOverlayDirty("frequencyPreviewCommit", false);
@@ -6025,6 +6119,7 @@ void SpectrumWidget::clearCurrentWaterfallRows()
     m_wfHistoryWriteRow = 0;
     m_wfHistoryRowCount = 0;
     m_wfHistoryOffsetRows = 0;
+    m_waterfallPaletteRefreshPending = false;
     m_wfLive = true;
     m_wfRowsSinceRateChange = 0;
     m_prevTileLevels.clear();

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -5468,6 +5468,17 @@ static void remapHistoryRowInto(
     }
 }
 
+static void colorizeHistoryRowInto(
+    QRgb* dst,
+    const quint8* src,
+    int width,
+    const std::array<QRgb, 256>& colorLut)
+{
+    for (int x = 0; x < width; ++x) {
+        dst[x] = colorLut[src[x]];
+    }
+}
+
 void SpectrumWidget::resetVisibleWaterfallFrequencyFrames(
     double centerMhz,
     double bandwidthMhz)
@@ -5606,6 +5617,13 @@ void SpectrumWidget::recolorWaterfallViewport()
             == m_waterfallHistory.capacityRows()
         && m_wfHistorySupplementalBwMhz.size()
             == m_waterfallHistory.capacityRows();
+#ifdef AETHER_GPU_SPECTRUM
+    const WaterfallPipelineMode pipelineMode = m_wfPipelineMode;
+#else
+    constexpr WaterfallPipelineMode pipelineMode =
+        WaterfallPipelineMode::Legacy;
+#endif
+    const FrequencyFrame viewportFrame{m_centerMhz, m_bandwidthMhz};
     const std::array<QRgb, 256> colorLut = waterfallHistoryColorLut();
     for (int age = 0; age < height; ++age) {
         const int rowIndex = historyRowIndexForAge(
@@ -5632,17 +5650,42 @@ void SpectrumWidget::recolorWaterfallViewport()
             ? m_wfHistorySupplementalCenterMhz[rowIndex] : 0.0;
         const double supplementalBw = haveSupplementalFrames
             ? m_wfHistorySupplementalBwMhz[rowIndex] : 0.0;
-        remapHistoryRowInto(dst, src, w, colorLut,
-                            rowCenter, rowBw,
-                            m_centerMhz, m_bandwidthMhz,
-                            m_kiwiSdrWaterfallActive,
-                            supplementalSrc,
-                            supplementalCenter, supplementalBw);
+        const WaterfallPaletteRecolorPlan recolorPlan =
+            waterfallPaletteRecolorPlan(
+                pipelineMode,
+                FrequencyFrame{rowCenter, rowBw},
+                FrequencyFrame{supplementalCenter, supplementalBw},
+                viewportFrame);
+        // Row-frame rendering needs native primary and supplemental pixels so
+        // the shader can reproject each texture exactly once. The legacy path
+        // instead stores one flattened viewport row and labels it accordingly.
+        if (recolorPlan.retainNativeFrames) {
+            colorizeHistoryRowInto(dst, src, w, colorLut);
+            if (supplementalSrc
+                && recolorPlan.supplementalFrame.isValid()
+                && !m_waterfallSupplemental.isNull()) {
+                auto* supplementalDst = reinterpret_cast<QRgb*>(
+                    m_waterfallSupplemental.scanLine(destinationRow));
+                colorizeHistoryRowInto(
+                    supplementalDst, supplementalSrc, w, colorLut);
+            }
+        } else {
+            remapHistoryRowInto(dst, src, w, colorLut,
+                                rowCenter, rowBw,
+                                m_centerMhz, m_bandwidthMhz,
+                                m_kiwiSdrWaterfallActive,
+                                supplementalSrc,
+                                supplementalCenter, supplementalBw);
+        }
 
-        m_wfVisibleRowCenterMhz[destinationRow] = rowCenter;
-        m_wfVisibleRowBwMhz[destinationRow] = rowBw;
-        m_wfVisibleSupplementalCenterMhz[destinationRow] = supplementalCenter;
-        m_wfVisibleSupplementalBwMhz[destinationRow] = supplementalBw;
+        m_wfVisibleRowCenterMhz[destinationRow] =
+            recolorPlan.primaryFrame.centerMhz;
+        m_wfVisibleRowBwMhz[destinationRow] =
+            recolorPlan.primaryFrame.bandwidthMhz;
+        m_wfVisibleSupplementalCenterMhz[destinationRow] =
+            recolorPlan.supplementalFrame.centerMhz;
+        m_wfVisibleSupplementalBwMhz[destinationRow] =
+            recolorPlan.supplementalFrame.bandwidthMhz;
     }
 
 #ifdef AETHER_GPU_SPECTRUM

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -756,6 +756,10 @@ namespace {
 struct WfStopsCache {
     std::array<std::vector<WfGradientStop>, static_cast<int>(WfColorScheme::Count)> stops;
     bool initialized = false;
+    // Bumped whenever the theme reloads the stops. Combined with the selected
+    // scheme it identifies the exact 256-entry LUT a run of RGB rows was
+    // rendered with — see SpectrumWidget::waterfallPaletteToken().
+    quint64 generation = 0;
 };
 
 WfStopsCache& wfStopsCache()
@@ -776,10 +780,26 @@ const char* wfSchemeToken(WfColorScheme s)
     }
 }
 
+bool sameWfStops(const std::vector<WfGradientStop>& a,
+                 const std::vector<WfGradientStop>& b)
+{
+    if (a.size() != b.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < a.size(); ++i) {
+        if (a[i].pos != b[i].pos || a[i].r != b[i].r
+            || a[i].g != b[i].g || a[i].b != b[i].b) {
+            return false;
+        }
+    }
+    return true;
+}
+
 void rebuildWfStopsCacheFromTheme()
 {
     auto& c = wfStopsCache();
     auto& tm = ThemeManager::instance();
+    bool changed = !c.initialized;
     for (int i = 0; i < static_cast<int>(WfColorScheme::Count); ++i) {
         const QBrush br = tm.brush(QString::fromLatin1(
             wfSchemeToken(static_cast<WfColorScheme>(i))));
@@ -798,9 +818,23 @@ void rebuildWfStopsCacheFromTheme()
         // black→white ramp instead of a divide-by-zero on the first paint.
         if (v.size() < 2)
             v = { {0.0f, 0, 0, 0}, {1.0f, 255, 255, 255} };
+        if (!sameWfStops(v, c.stops[i])) {
+            changed = true;
+        }
         c.stops[i] = std::move(v);
     }
     c.initialized = true;
+    // Bump only on a real stop change. Every SpectrumWidget rebuilds this
+    // shared cache on themeChanged, so an unconditional bump would leave each
+    // widget's palette token stale the moment the next widget's handler ran.
+    if (changed) {
+        ++c.generation;
+    }
+}
+
+quint64 wfStopsCacheGeneration()
+{
+    return wfStopsCache().generation;
 }
 
 } // namespace
@@ -2122,13 +2156,18 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     connect(&SliceColorManager::instance(), &SliceColorManager::colorsChanged,
             this, [this]() { markOverlayDirty(); });
 
-    // Refresh the waterfall colormap cache when the theme changes. Theme
-    // changes still affect newly-arriving rows only; the operator-facing
-    // Scheme dropdown has a separate palette-refresh path because it explicitly
-    // requests an immediate recolour of retained waterfall history.
+    // Refresh the waterfall colormap cache when the theme changes, then
+    // recolour retained history through the new stops. The theme owns the
+    // gradient behind every Scheme preset (#3122), so a theme switch changes
+    // exactly the same 256-entry LUT the Scheme: dropdown does — leaving
+    // history on the old palette here would band the waterfall at the switch
+    // point. The cost is one viewport repaint, the same work a pan already
+    // does; the retained scrollback stays palette-independent intensity and
+    // recolours as it is scrolled back in.
     connect(&ThemeManager::instance(), &ThemeManager::themeChanged,
             this, [this]() {
         rebuildWfStopsCacheFromTheme();
+        recolorWaterfallViewport();
         markOverlayDirty();
         update();
     });
@@ -5578,36 +5617,45 @@ void SpectrumWidget::rebuildDssViewportFromHistoryForFrame(double centerMhz,
     resetDssUploadState();
 }
 
-void SpectrumWidget::recolorWaterfallViewport()
+quint64 SpectrumWidget::waterfallPaletteToken() const
 {
-    if (m_frequencyPreviewActive) {
-        m_waterfallPaletteRefreshPending = true;
-        return;
-    }
+    // Identifies the exact LUT waterfallHistoryColorLut() would build right
+    // now: the selected scheme plus the theme generation behind it, because a
+    // theme reload rewrites the gradient stops of every preset (#3122).
+    // Asking through wfSchemeStops() forces the lazy first fill, so a token
+    // taken before the first paint is not the pre-init generation.
+    int stopCount = 0;
+    (void)wfSchemeStops(m_wfColorScheme, stopCount);
+    return (wfStopsCacheGeneration() << 8)
+        | static_cast<quint64>(static_cast<int>(m_wfColorScheme));
+}
 
-    m_waterfallPaletteRefreshPending = false;
-    if (m_waterfall.isNull() || !m_waterfallHistory.isConfigured()) {
-        return;
-    }
-
+void SpectrumWidget::paintWaterfallRowsFromHistory(
+    double centerMhz,
+    double bandwidthMhz,
+    int writeRowOrigin,
+    WaterfallPipelineMode pipelineMode)
+{
+    // The single loop behind every "repaint the visible rows from retained
+    // intensity" caller. The two axes callers vary on:
+    //   • writeRowOrigin — which scanline holds the newest row. A pan/resize
+    //     rebuild re-lays the ring out from 0; a palette recolour passes the
+    //     live m_wfWriteRow so the waterfall cannot jump under the operator.
+    //   • pipelineMode — Legacy flattens every row into the destination frame;
+    //     RowFrequencyFrames keeps native pixels and per-row frames so the
+    //     shader reprojects each texture exactly once.
+    // Keeping them one function means the frame bookkeeping (#3578, #3668,
+    // #4081) can only ever be fixed in one place.
     const int height = m_waterfall.height();
-    if (height <= 0) {
+    if (height <= 0 || !m_waterfallHistory.isConfigured()) {
         return;
     }
-
-    m_wfHistoryOffsetRows = std::clamp(
-        m_wfHistoryOffsetRows, 0, maxWaterfallHistoryOffsetRows());
-
-    // Rebuild only the already-visible RGB images from the retained,
-    // palette-independent intensity history. Keep the current visible ring
-    // position and scroll clock intact so a palette change cannot move the
-    // waterfall while it is live or paused.
-    const int writeRow = ((m_wfWriteRow % height) + height) % height;
-    m_waterfall.fill(Qt::black);
-    if (!m_waterfallSupplemental.isNull()) {
-        m_waterfallSupplemental.fill(Qt::black);
+    if (m_wfVisibleRowCenterMhz.size() != height
+        || m_wfVisibleRowBwMhz.size() != height
+        || m_wfVisibleSupplementalCenterMhz.size() != height
+        || m_wfVisibleSupplementalBwMhz.size() != height) {
+        resetVisibleWaterfallFrequencyFrames(centerMhz, bandwidthMhz);
     }
-    resetVisibleWaterfallFrequencyFrames(m_centerMhz, m_bandwidthMhz);
 
     const int w = m_waterfall.width();
     const bool haveFrames = m_wfHistoryRowCenterMhz.size()
@@ -5617,13 +5665,13 @@ void SpectrumWidget::recolorWaterfallViewport()
             == m_waterfallHistory.capacityRows()
         && m_wfHistorySupplementalBwMhz.size()
             == m_waterfallHistory.capacityRows();
-#ifdef AETHER_GPU_SPECTRUM
-    const WaterfallPipelineMode pipelineMode = m_wfPipelineMode;
-#else
-    constexpr WaterfallPipelineMode pipelineMode =
-        WaterfallPipelineMode::Legacy;
-#endif
-    const FrequencyFrame viewportFrame{m_centerMhz, m_bandwidthMhz};
+    // Every other writer of the supplemental image requires an exact size
+    // match (appendVisibleRow, the upload path's supplementalTextureReady);
+    // scanLine() on a stale smaller image would be a heap overflow, not a
+    // wrong pixel.
+    const bool supplementalWritable =
+        m_waterfallSupplemental.size() == m_waterfall.size();
+    const FrequencyFrame viewportFrame{centerMhz, bandwidthMhz};
     const std::array<QRgb, 256> colorLut = waterfallHistoryColorLut();
     for (int age = 0; age < height; ++age) {
         const int rowIndex = historyRowIndexForAge(
@@ -5637,9 +5685,14 @@ void SpectrumWidget::recolorWaterfallViewport()
             continue;
         }
 
-        const int destinationRow = (writeRow + age) % height;
+        const int destinationRow =
+            waterfallVisibleRowForAge(writeRowOrigin, age, height);
         auto* dst = reinterpret_cast<QRgb*>(
             m_waterfall.scanLine(destinationRow));
+        // With no stamped frames the rows carry no capture information at all,
+        // so fall back to the widget's live frame — NOT the destination frame.
+        // The two differ mid-pan, and treating an unstamped row as already
+        // being in the destination frame would skip the remap it needs.
         const double rowCenter = haveFrames
             ? m_wfHistoryRowCenterMhz[rowIndex] : m_centerMhz;
         const double rowBw = haveFrames
@@ -5656,37 +5709,85 @@ void SpectrumWidget::recolorWaterfallViewport()
                 FrequencyFrame{rowCenter, rowBw},
                 FrequencyFrame{supplementalCenter, supplementalBw},
                 viewportFrame);
-        // Row-frame rendering needs native primary and supplemental pixels so
-        // the shader can reproject each texture exactly once. The legacy path
-        // instead stores one flattened viewport row and labels it accordingly.
+        bool wroteSupplemental = false;
         if (recolorPlan.retainNativeFrames) {
             colorizeHistoryRowInto(dst, src, w, colorLut);
             if (supplementalSrc
                 && recolorPlan.supplementalFrame.isValid()
-                && !m_waterfallSupplemental.isNull()) {
+                && supplementalWritable) {
                 auto* supplementalDst = reinterpret_cast<QRgb*>(
                     m_waterfallSupplemental.scanLine(destinationRow));
                 colorizeHistoryRowInto(
                     supplementalDst, supplementalSrc, w, colorLut);
+                wroteSupplemental = true;
             }
         } else {
             remapHistoryRowInto(dst, src, w, colorLut,
                                 rowCenter, rowBw,
-                                m_centerMhz, m_bandwidthMhz,
+                                centerMhz, bandwidthMhz,
                                 m_kiwiSdrWaterfallActive,
                                 supplementalSrc,
                                 supplementalCenter, supplementalBw);
         }
 
+        // Label the pixels that were actually written. Claiming supplemental
+        // coverage the image does not hold sends the shader sampling rows the
+        // fill() above left black.
         m_wfVisibleRowCenterMhz[destinationRow] =
             recolorPlan.primaryFrame.centerMhz;
         m_wfVisibleRowBwMhz[destinationRow] =
             recolorPlan.primaryFrame.bandwidthMhz;
         m_wfVisibleSupplementalCenterMhz[destinationRow] =
-            recolorPlan.supplementalFrame.centerMhz;
+            wroteSupplemental ? recolorPlan.supplementalFrame.centerMhz : 0.0;
         m_wfVisibleSupplementalBwMhz[destinationRow] =
-            recolorPlan.supplementalFrame.bandwidthMhz;
+            wroteSupplemental ? recolorPlan.supplementalFrame.bandwidthMhz
+                              : 0.0;
     }
+}
+
+void SpectrumWidget::recolorWaterfallViewport()
+{
+    if (m_frequencyPreviewActive) {
+        m_waterfallPaletteRefreshPending = true;
+        return;
+    }
+
+    // Claim the palette before the early-outs: once the refresh is serviced
+    // the visible rows are at the current palette either way — recoloured
+    // below, or empty because there is nothing to recolour. Leaving the stamp
+    // stale here would re-arm the stream-restore check on every parked row.
+    m_waterfallPaletteRefreshPending = false;
+    m_wfVisiblePaletteToken = waterfallPaletteToken();
+    if (m_waterfall.isNull() || !m_waterfallHistory.isConfigured()) {
+        return;
+    }
+
+    const int height = m_waterfall.height();
+    if (height <= 0) {
+        return;
+    }
+
+    m_wfHistoryOffsetRows = std::clamp(
+        m_wfHistoryOffsetRows, 0, maxWaterfallHistoryOffsetRows());
+
+    // Rebuild only the already-visible RGB images from the retained,
+    // palette-independent intensity history. Keep the current visible ring
+    // position and scroll clock intact so a palette change cannot move the
+    // waterfall while it is live or paused.
+    m_waterfall.fill(Qt::black);
+    if (!m_waterfallSupplemental.isNull()) {
+        m_waterfallSupplemental.fill(Qt::black);
+    }
+    resetVisibleWaterfallFrequencyFrames(m_centerMhz, m_bandwidthMhz);
+
+#ifdef AETHER_GPU_SPECTRUM
+    const WaterfallPipelineMode pipelineMode = m_wfPipelineMode;
+#else
+    constexpr WaterfallPipelineMode pipelineMode =
+        WaterfallPipelineMode::Legacy;
+#endif
+    paintWaterfallRowsFromHistory(m_centerMhz, m_bandwidthMhz,
+                                  m_wfWriteRow, pipelineMode);
 
 #ifdef AETHER_GPU_SPECTRUM
     // The image changed in every physical row, so an incremental upload would
@@ -5719,45 +5820,20 @@ void SpectrumWidget::rebuildWaterfallViewportForFrame(double centerMhz,
     }
     m_wfWriteRow = 0;
     resetVisibleWaterfallFrequencyFrames(centerMhz, bandwidthMhz);
+    m_wfVisiblePaletteToken = waterfallPaletteToken();
 
     if (!m_waterfallHistory.isConfigured()) {
         update();
         return;
     }
 
-    const int w = m_waterfall.width();
-    const bool haveFrames = m_wfHistoryRowCenterMhz.size()
-        == m_waterfallHistory.capacityRows();
-    const bool haveSupplementalFrames =
-        m_wfHistorySupplementalCenterMhz.size()
-            == m_waterfallHistory.capacityRows()
-        && m_wfHistorySupplementalBwMhz.size()
-            == m_waterfallHistory.capacityRows();
-    const std::array<QRgb, 256> colorLut = waterfallHistoryColorLut();
-    for (int y = 0; y < m_waterfall.height(); ++y) {
-        const int rowIndex = historyRowIndexForAge(m_wfHistoryOffsetRows + y);
-        if (rowIndex < 0) {
-            break;
-        }
-        const quint8* src = m_waterfallHistory.row(rowIndex);
-        if (!src) {
-            continue;
-        }
-        auto* dst = reinterpret_cast<QRgb*>(m_waterfall.scanLine(y));
-        const double rowCenter = haveFrames ? m_wfHistoryRowCenterMhz[rowIndex] : m_centerMhz;
-        const double rowBw = haveFrames ? m_wfHistoryRowBwMhz[rowIndex] : m_bandwidthMhz;
-        const quint8* supplementalSrc =
-            m_waterfallSupplementalHistory.row(rowIndex);
-        const double supplementalCenter = haveSupplementalFrames
-            ? m_wfHistorySupplementalCenterMhz[rowIndex] : 0.0;
-        const double supplementalBw = haveSupplementalFrames
-            ? m_wfHistorySupplementalBwMhz[rowIndex] : 0.0;
-        remapHistoryRowInto(dst, src, w, colorLut,
-                            rowCenter, rowBw, centerMhz, bandwidthMhz,
-                            m_kiwiSdrWaterfallActive,
-                            supplementalSrc,
-                            supplementalCenter, supplementalBw);
-    }
+    // The ring was just re-laid out from scanline 0, so there is no native row
+    // ordering left to preserve: every row is flattened into the destination
+    // frame and labelled with it (what resetVisibleWaterfallFrequencyFrames
+    // above already wrote).
+    paintWaterfallRowsFromHistory(centerMhz, bandwidthMhz,
+                                  /*writeRowOrigin=*/0,
+                                  WaterfallPipelineMode::Legacy);
 
 #ifdef AETHER_GPU_SPECTRUM
     m_wfTexFullUpload = true;
@@ -6163,6 +6239,8 @@ void SpectrumWidget::clearCurrentWaterfallRows()
     m_wfHistoryRowCount = 0;
     m_wfHistoryOffsetRows = 0;
     m_waterfallPaletteRefreshPending = false;
+    // Cleared rows carry no palette, so they are trivially current.
+    m_wfVisiblePaletteToken = waterfallPaletteToken();
     m_wfLive = true;
     m_wfRowsSinceRateChange = 0;
     m_prevTileLevels.clear();
@@ -6331,6 +6409,7 @@ void SpectrumWidget::saveCurrentWaterfallStreamState()
     updated.kiwiDisplayRangeAutoRange = m_kiwiSdrDisplayRangeAutoRange;
     updated.kiwiFftTraceFloorDbm = m_kiwiSdrFftTraceFloorDbm;
     updated.kiwiFftTraceFloorValid = m_kiwiSdrFftTraceFloorValid;
+    updated.visiblePaletteToken = m_wfVisiblePaletteToken;
     updated.valid = !updated.waterfall.isNull();
 #ifdef AETHER_GPU_SPECTRUM
     updated.wfTexFullUpload = m_wfTexFullUpload;
@@ -6463,6 +6542,7 @@ void SpectrumWidget::restoreCurrentWaterfallStreamState()
     m_kiwiSdrDisplayRangeAutoRange = restored.kiwiDisplayRangeAutoRange;
     m_kiwiSdrFftTraceFloorDbm = restored.kiwiFftTraceFloorDbm;
     m_kiwiSdrFftTraceFloorValid = restored.kiwiFftTraceFloorValid;
+    m_wfVisiblePaletteToken = restored.visiblePaletteToken;
 #ifdef AETHER_GPU_SPECTRUM
     m_wfTexFullUpload = restored.wfTexFullUpload;
     m_wfLastUploadedRow = restored.wfLastUploadedRow;
@@ -6474,6 +6554,14 @@ void SpectrumWidget::restoreCurrentWaterfallStreamState()
 #endif
     if (m_waterfallWriteVisible) {
         ensureWaterfallHistory();
+    }
+    // A parked stream keeps already-coloured RGB rows, so a Scheme or theme
+    // change made while the other source was on screen never reached them.
+    // This runs at most once per palette change per stream — begin/end
+    // WaterfallStreamWrite() swap on every hidden-source row, and the stamp
+    // matches on all of those.
+    if (m_wfVisiblePaletteToken != waterfallPaletteToken()) {
+        recolorWaterfallViewport();
     }
 }
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -5800,6 +5800,12 @@ void SpectrumWidget::recolorWaterfallViewport()
     if (!m_wfLive) {
         rebuildDssViewportFromHistory();
     }
+    // Self-sufficient, like rebuildWaterfallViewportForFrame(). Two of the
+    // four callers (the stream restore, clearFrequencyPreview()) do not
+    // repaint afterwards, and relying on the caller is how a recolour that
+    // ran silently ends up on screen a frame late — or not until the next
+    // unrelated update().
+    update();
 }
 
 void SpectrumWidget::rebuildWaterfallViewportForFrame(double centerMhz,
@@ -6127,6 +6133,7 @@ void SpectrumWidget::commitFrequencyPreview()
 
 void SpectrumWidget::clearFrequencyPreview()
 {
+    const bool paletteRefreshPending = m_waterfallPaletteRefreshPending;
     m_frequencyPreviewActive = false;
     m_frequencyPreviewBaseCenterMhz = m_centerMhz;
     m_frequencyPreviewBaseBandwidthMhz = m_bandwidthMhz;
@@ -6137,6 +6144,14 @@ void SpectrumWidget::clearFrequencyPreview()
 #ifdef AETHER_GPU_SPECTRUM
     m_frequencyScalePreviewNeedsUpload = false;
 #endif
+    // m_frequencyPreviewActive has two exits — commitFrequencyPreview() lands
+    // the preview, this abandons it — and a deferred palette refresh has to
+    // drain through both. Leaving it armed here loses a Scheme change made
+    // during a drag that ends in an automation reset or a clearDisplay(),
+    // and leaves the flag set for the next preview to inherit.
+    if (paletteRefreshPending) {
+        recolorWaterfallViewport();
+    }
 }
 
 void SpectrumWidget::requestFrequencyRangeChange(double centerMhz,

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -914,6 +914,7 @@ private:
     QRect waterfallLiveButtonRect(const QRect& wfRect) const;
     QRect waterfallTimeScaleRect(const QRect& wfRect) const;
     void ensureWaterfallHistory();
+    void recolorWaterfallViewport();
     void rebuildWaterfallViewport();
     void rebuildWaterfallViewportForFrame(double centerMhz, double bandwidthMhz);
     void rebuildDssViewportFromHistory();
@@ -1556,6 +1557,7 @@ private:
     FrequencyRangeCommandThrottle m_frequencyRangeCommandThrottle;
     quint64 m_frequencyRangeCommandCount{0};
     bool m_frequencyPreviewActive{false};
+    bool m_waterfallPaletteRefreshPending{false};
     double m_frequencyPreviewBaseCenterMhz{0.0};
     double m_frequencyPreviewBaseBandwidthMhz{0.0};
     double m_frequencyPreviewTargetCenterMhz{0.0};

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -914,6 +914,10 @@ private:
     QRect waterfallLiveButtonRect(const QRect& wfRect) const;
     QRect waterfallTimeScaleRect(const QRect& wfRect) const;
     void ensureWaterfallHistory();
+    quint64 waterfallPaletteToken() const;
+    void paintWaterfallRowsFromHistory(double centerMhz, double bandwidthMhz,
+                                       int writeRowOrigin,
+                                       WaterfallPipelineMode pipelineMode);
     void recolorWaterfallViewport();
     void rebuildWaterfallViewport();
     void rebuildWaterfallViewportForFrame(double centerMhz, double bandwidthMhz);
@@ -1021,6 +1025,11 @@ private:
         bool kiwiDisplayRangeAutoRange{false};
         float kiwiFftTraceFloorDbm{-1000.0f};
         bool kiwiFftTraceFloorValid{false};
+        // Palette the saved RGB rows were rendered with. A parked stream
+        // cannot see a Scheme or theme change, so restore compares this
+        // against the live token and recolours once instead of on every
+        // hidden-source row write.
+        quint64 visiblePaletteToken{0};
         bool valid{false};
 #ifdef AETHER_GPU_SPECTRUM
         bool wfTexFullUpload{true};
@@ -1420,6 +1429,10 @@ private:
     // effectiveWfAutoBlackRadioSide(). (#4606)
     bool  m_radioSideAutoBlackAvailable{true};
     WfColorScheme m_wfColorScheme{WfColorScheme::Default};
+    // Palette the visible RGB rows currently hold. Diverges from the live
+    // token only while a stream is parked (see WaterfallStreamState) or a
+    // palette refresh is deferred behind a frequency preview.
+    quint64 m_wfVisiblePaletteToken{0};
 
     // 3DSS — perspective stacked-trace render mode. m_dss owns the rolling
     // history + cached surface image; consumed by both the CPU and GPU paths.

--- a/tests/spectrum_preview_logic_test.cpp
+++ b/tests/spectrum_preview_logic_test.cpp
@@ -416,6 +416,65 @@ int testWaterfallPaletteRecolorPlan()
     return 0;
 }
 
+// The property a palette recolour has to hold and a viewport rebuild does not:
+// recolouring in place may not move, drop, or duplicate a single visible row.
+// A rebuild gets away with re-laying the ring out from scanline 0 only because
+// it repaints everything at once; a recolour keeps the live write row, so the
+// age → scanline map is the whole correctness argument.
+int testWaterfallVisibleRowForAge()
+{
+    using namespace AetherSDR;
+    constexpr int kHeight = 7;
+
+    // Age 0 is the newest row and sits on the origin itself — that is where
+    // appendVisibleRow() last wrote, and where drawWaterfall() starts blitting.
+    if (waterfallVisibleRowForAge(3, 0, kHeight) != 3
+        || waterfallVisibleRowForAge(0, 0, kHeight) != 0) {
+        return fail("age 0 must land on the write row");
+    }
+
+    // Older rows walk downward and wrap.
+    if (waterfallVisibleRowForAge(5, 1, kHeight) != 6
+        || waterfallVisibleRowForAge(5, 2, kHeight) != 0
+        || waterfallVisibleRowForAge(5, 3, kHeight) != 1) {
+        return fail("increasing age must walk down the ring and wrap");
+    }
+
+    // A full sweep covers every scanline exactly once, from any origin. This
+    // is what "the waterfall cannot move under a palette change" reduces to.
+    for (int origin = 0; origin < kHeight; ++origin) {
+        bool seen[kHeight] = {};
+        for (int age = 0; age < kHeight; ++age) {
+            const int row = waterfallVisibleRowForAge(origin, age, kHeight);
+            if (row < 0 || row >= kHeight || seen[row]) {
+                return fail("a full age sweep must be a permutation of rows");
+            }
+            seen[row] = true;
+        }
+    }
+
+    // Origin 0 is the rebuild path: age is the scanline, unchanged.
+    for (int age = 0; age < kHeight; ++age) {
+        if (waterfallVisibleRowForAge(0, age, kHeight) != age) {
+            return fail("origin 0 must reproduce the plain rebuild layout");
+        }
+    }
+
+    // m_wfWriteRow is decremented modulo the image height by appendVisibleRow,
+    // but a restored stream state can carry one from a differently sized image.
+    if (waterfallVisibleRowForAge(-2, 0, kHeight) != 5
+        || waterfallVisibleRowForAge(kHeight + 2, 0, kHeight) != 2
+        || waterfallVisibleRowForAge(1, -1, kHeight) != 0) {
+        return fail("out-of-range origin and age must normalise, not index OOB");
+    }
+
+    if (waterfallVisibleRowForAge(0, 0, 0) != -1
+        || waterfallVisibleRowForAge(0, 0, -4) != -1) {
+        return fail("an empty image must report no destination row");
+    }
+    return 0;
+}
+
 int testWaterfallScrollProgress()
 {
     using namespace AetherSDR;
@@ -886,6 +945,9 @@ int main()
         return result;
     }
     if (const int result = testWaterfallPaletteRecolorPlan(); result != 0) {
+        return result;
+    }
+    if (const int result = testWaterfallVisibleRowForAge(); result != 0) {
         return result;
     }
     if (const int result = testWaterfallScrollProgress(); result != 0) {

--- a/tests/spectrum_preview_logic_test.cpp
+++ b/tests/spectrum_preview_logic_test.cpp
@@ -356,6 +356,66 @@ int testWaterfallPipelineSelection()
     return 0;
 }
 
+int testWaterfallPaletteRecolorPlan()
+{
+    using namespace AetherSDR;
+    const FrequencyFrame historyFrame{14.0, 0.2};
+    const FrequencyFrame supplementalFrame{14.0, 0.8};
+    const FrequencyFrame viewportFrame{14.05, 0.1};
+
+    const WaterfallPaletteRecolorPlan nativePlan =
+        waterfallPaletteRecolorPlan(
+            WaterfallPipelineMode::RowFrequencyFrames,
+            historyFrame, supplementalFrame, viewportFrame);
+    if (!nativePlan.retainNativeFrames
+        || !nearlyEqual(nativePlan.primaryFrame.centerMhz,
+                        historyFrame.centerMhz)
+        || !nearlyEqual(nativePlan.primaryFrame.bandwidthMhz,
+                        historyFrame.bandwidthMhz)
+        || !nearlyEqual(nativePlan.supplementalFrame.centerMhz,
+                        supplementalFrame.centerMhz)
+        || !nearlyEqual(nativePlan.supplementalFrame.bandwidthMhz,
+                        supplementalFrame.bandwidthMhz)
+        || !nearlyEqual(
+            sourceUnitPosition(
+                0.5, nativePlan.primaryFrame, viewportFrame),
+            0.75)) {
+        return fail(
+            "row-frame recolor must retain matching native frame metadata");
+    }
+
+    const WaterfallPaletteRecolorPlan flattenedPlan =
+        waterfallPaletteRecolorPlan(
+            WaterfallPipelineMode::Legacy,
+            historyFrame, supplementalFrame, viewportFrame);
+    if (flattenedPlan.retainNativeFrames
+        || !nearlyEqual(flattenedPlan.primaryFrame.centerMhz,
+                        viewportFrame.centerMhz)
+        || !nearlyEqual(flattenedPlan.primaryFrame.bandwidthMhz,
+                        viewportFrame.bandwidthMhz)
+        || flattenedPlan.supplementalFrame.isValid()
+        || !nearlyEqual(
+            sourceUnitPosition(
+                0.5, flattenedPlan.primaryFrame, viewportFrame),
+            0.5)) {
+        return fail(
+            "legacy recolor must label flattened pixels as the viewport frame");
+    }
+
+    const WaterfallPaletteRecolorPlan missingSupplementalPlan =
+        waterfallPaletteRecolorPlan(
+            WaterfallPipelineMode::RowFrequencyFrames,
+            FrequencyFrame{}, FrequencyFrame{}, viewportFrame);
+    if (!missingSupplementalPlan.retainNativeFrames
+        || !nearlyEqual(missingSupplementalPlan.primaryFrame.centerMhz,
+                        viewportFrame.centerMhz)
+        || missingSupplementalPlan.supplementalFrame.isValid()) {
+        return fail(
+            "missing native frames must fall back without inventing coverage");
+    }
+    return 0;
+}
+
 int testWaterfallScrollProgress()
 {
     using namespace AetherSDR;
@@ -823,6 +883,9 @@ int main()
         return result;
     }
     if (const int result = testWaterfallPipelineSelection(); result != 0) {
+        return result;
+    }
+    if (const int result = testWaterfallPaletteRecolorPlan(); result != 0) {
         return result;
     }
     if (const int result = testWaterfallScrollProgress(); result != 0) {


### PR DESCRIPTION
## Summary

Changing the waterfall color scheme now immediately recolors the entire retained waterfall history, matching the existing 3D spectrum behavior.

The waterfall keeps palette-independent intensity history. On a scheme change, the visible RGB rows are rebuilt through the current color LUT while preserving ring-buffer position, scrollback, row frequency metadata, supplemental history, and live/paused state. Palette refreshes are deferred safely during frequency preview and applied when the preview commits.

Root cause: retained waterfall rows were stored and rendered as already-colored RGB data, so changing the palette only affected rows arriving afterward. The fix reuses the retained intensity history to regenerate the visible rows.

## Constitution principle honored

Principle VIII — Evidence Over Assertion; Principle XI — Fixes Are Demonstrated.

## Test plan

- [x] Local focused build/tests pass:
  - `cmake --build build-arm64-native --target dss_renderer_test waterfall_history_buffer_test -j4`
  - `ctest --test-dir build-arm64-native --output-on-failure -R 'dss_renderer_test|waterfall_history_buffer_test'`
- [x] Behavior verified in RX-only automation mode on a FLEX-6700: changed Purple → Fire and observed the retained waterfall history recolor; restored Purple afterward. TX remained disabled.
- [ ] Existing CI tests pass.
- [x] Reproduction steps documented:
  1. Allow waterfall history to accumulate.
  2. Open the Display panel.
  3. Change the waterfall Scheme.
  4. Confirm the existing history changes palette immediately.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls.
- [x] Code is clean-room.
- [x] No meter UI changes.
- [ ] Documentation updated if user-visible behavior changed.
- [x] No security-sensitive changes.
