### PR TITLE
ci(macos): pin Apple Silicon to Qt 6.8.3 instead of Homebrew's rolling qt@6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,12 +483,38 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Install dependencies via Homebrew
-        # Mirrors macos-dmg.yml's apple-silicon path.  Homebrew Qt targets
-        # the current OS, which is fine for the arm64 CI check; deployment-
-        # target pinning is a release-time concern handled in macos-dmg.yml.
+        # Mirrors macos-dmg.yml's apple-silicon path — which no longer takes Qt
+        # from Homebrew, so neither does this. Leaving qt@6 here would put the
+        # per-PR macOS check on a rolling Qt (6.11.1 today) while the DMG ships
+        # 6.8.3, i.e. CI green would say nothing about the artifact.
         run: |
-          brew install ninja qt@6 qtkeychain fftw portaudio hidapi \
+          brew install ninja fftw portaudio hidapi \
             autoconf automake libtool
+
+      - name: Install Qt 6.8.3 LTS via aqtinstall
+        run: |
+          set -o pipefail
+          python3 -m venv "$RUNNER_TEMP/aqtvenv"
+          "$RUNNER_TEMP/aqtvenv/bin/pip" install -q aqtinstall
+          "$RUNNER_TEMP/aqtvenv/bin/aqt" install-qt mac desktop 6.8.3 clang_64 \
+            -m qtmultimedia qtwebsockets qtserialport qtshadertools \
+            --outputdir ${{ github.workspace }}/Qt
+          QT_ROOT="${{ github.workspace }}/Qt/6.8.3/macos"
+          if [ ! -x "$QT_ROOT/bin/qmake" ]; then
+            echo "ERROR: no qmake at $QT_ROOT — aqt layout changed"
+            ls -la "${{ github.workspace }}/Qt/6.8.3/" || true
+            exit 1
+          fi
+          # CMAKE_PREFIX_PATH and PATH matter beyond the Configure step:
+          # setup-qtkeychain.sh locates Qt via CMAKE_PREFIX_PATH, then Qt6_DIR,
+          # then qmake on PATH. Exporting only QT_ROOT would leave it with none
+          # of the three, and it would exit "Qt6 not found" before building.
+          {
+            echo "QT_ROOT=$QT_ROOT"
+            echo "CMAKE_PREFIX_PATH=$QT_ROOT"
+            echo "PATH=$QT_ROOT/bin:$PATH"
+          } >> "$GITHUB_ENV"
+          "$QT_ROOT/bin/qmake" -query QT_VERSION
 
       - name: Cache DeepFilterNet3
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -500,6 +526,22 @@ jobs:
       - name: Setup DeepFilterNet3 (DFNR)
         if: steps.cache-deepfilter.outputs.cache-hit != 'true'
         run: bash scripts/setup/setup-deepfilter.sh
+
+      - name: Cache qtkeychain
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        id: cache-qtkeychain-mac
+        with:
+          path: third_party/qtkeychain
+          key: qtkeychain-macos-arm64-qt6.8.3-${{ hashFiles('scripts/setup/setup-qtkeychain.sh') }}
+
+      # Dropping Homebrew's qtkeychain along with its Qt would have quietly
+      # removed credential-persistence compile coverage from every PR, since
+      # find_package(Qt6Keychain QUIET) just compiles it out — the #3639 shape.
+      # Build it from source against the same aqt Qt the DMG uses, and pair it
+      # with REQUIRE_KEYCHAIN=ON at configure so a regression is a red run.
+      - name: Setup qtkeychain (SmartLink credential persistence)
+        if: steps.cache-qtkeychain-mac.outputs.cache-hit != 'true'
+        run: bash scripts/setup/setup-qtkeychain.sh
 
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03
@@ -529,13 +571,19 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_PREFIX_PATH="$(brew --prefix qt@6);$(brew --prefix)" \
+            -DCMAKE_PREFIX_PATH="$QT_ROOT;$(brew --prefix)" \
             -DAETHER_GPU_SPECTRUM=ON \
+            -DREQUIRE_KEYCHAIN=ON \
             -DMQTT_TLS=OFF 2>&1 | tee configure.log
 
       # Same guard as the Linux build job above. -iE rather than the -i "a\|b"
       # form: this runs on the macOS runner's BSD grep, which has no BRE
       # alternation and would search for the literal "a|b".
+      #
+      # This assertion is the one that caught the aqt Qt having no Qt6GuiPrivate
+      # CMake package where Homebrew's had one — see the CMakeLists.txt macOS
+      # framework-layout probe. Homebrew Qt was carrying this leg; the pin
+      # exposed that, which is exactly what a guard is for.
       - name: Assert GPU spectrum rendering actually enabled
         run: |
           grep -q "GPU spectrum rendering enabled" configure.log || {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,6 +479,18 @@ jobs:
   # Apple Silicon runner only; Intel coverage remains release-time-only.
   check-macos:
     runs-on: macos-15
+
+    # One place each for the two versions this job pins, and for the deployment
+    # target. MACOS_DEPLOYMENT_TARGET is consumed by setup-qtkeychain.sh and
+    # must match macos-dmg.yml's apple-silicon DEPLOY_TARGET: the two jobs share
+    # a qtkeychain cache key, so whichever runs first produces the dylib the
+    # other ships, and a mismatch would put a minos-15 library inside a bundle
+    # that advertises 14.0.
+    env:
+      QT_VERSION: '6.8.3'
+      AQTINSTALL_VERSION: '3.3.0'
+      MACOS_DEPLOYMENT_TARGET: '14.0'
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
@@ -491,29 +503,57 @@ jobs:
           brew install ninja fftw portaudio hidapi \
             autoconf automake libtool
 
-      - name: Install Qt 6.8.3 LTS via aqtinstall
+      # ~1.3 GB downloaded on every PR otherwise, and it showed: this job went
+      # from ~6 min to ~18 min the first time it took Qt from aqt.
+      # check-windows gets caching for free from jurplel/install-qt-action; aqt
+      # has no such wrapper, so cache the tree explicitly. Keyed on everything
+      # that changes its contents — the Qt version, the module set, and the aqt
+      # version that resolved them — so the entry is written once and then just
+      # restored, which is what keeps it from churning the repo's 10 GB cache
+      # budget the way a per-run key would.
+      - name: Cache Qt
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        id: cache-qt-mac
+        with:
+          path: ${{ github.workspace }}/Qt
+          key: qt-${{ env.QT_VERSION }}-macos-clang64-aqt${{ env.AQTINSTALL_VERSION }}-mm.ws.sp.st
+
+      - name: Install Qt LTS via aqtinstall
+        if: steps.cache-qt-mac.outputs.cache-hit != 'true'
         run: |
           set -o pipefail
+          # aqt goes in a venv, and is pinned: it is the tool that decides what
+          # Qt lands here, so an unreviewed aqt upgrade is an unreviewed change
+          # to the Qt the per-PR macOS check builds against — the same argument
+          # this job exists to make about Qt itself. Matches
+          # .github/docker/Dockerfile, which pins for that reason.
           python3 -m venv "$RUNNER_TEMP/aqtvenv"
-          "$RUNNER_TEMP/aqtvenv/bin/pip" install -q aqtinstall
-          "$RUNNER_TEMP/aqtvenv/bin/aqt" install-qt mac desktop 6.8.3 clang_64 \
+          "$RUNNER_TEMP/aqtvenv/bin/pip" install -q "aqtinstall==${AQTINSTALL_VERSION}"
+          "$RUNNER_TEMP/aqtvenv/bin/aqt" install-qt mac desktop "$QT_VERSION" clang_64 \
             -m qtmultimedia qtwebsockets qtserialport qtshadertools \
-            --outputdir ${{ github.workspace }}/Qt
-          QT_ROOT="${{ github.workspace }}/Qt/6.8.3/macos"
+            --outputdir "${{ github.workspace }}/Qt"
+
+      # Separate from the install so it also runs on a cache hit.
+      - name: Export Qt environment
+        run: |
+          set -o pipefail
+          QT_ROOT="${{ github.workspace }}/Qt/$QT_VERSION/macos"
           if [ ! -x "$QT_ROOT/bin/qmake" ]; then
-            echo "ERROR: no qmake at $QT_ROOT — aqt layout changed"
-            ls -la "${{ github.workspace }}/Qt/6.8.3/" || true
+            echo "ERROR: no qmake at $QT_ROOT — aqt layout changed, or a stale cache entry"
+            ls -la "${{ github.workspace }}/Qt/$QT_VERSION/" || true
             exit 1
           fi
-          # CMAKE_PREFIX_PATH and PATH matter beyond the Configure step:
+          # CMAKE_PREFIX_PATH matters beyond the Configure step:
           # setup-qtkeychain.sh locates Qt via CMAKE_PREFIX_PATH, then Qt6_DIR,
           # then qmake on PATH. Exporting only QT_ROOT would leave it with none
           # of the three, and it would exit "Qt6 not found" before building.
+          # PATH goes through GITHUB_PATH rather than GITHUB_ENV so it prepends
+          # instead of freezing this step's PATH for every later step.
           {
             echo "QT_ROOT=$QT_ROOT"
             echo "CMAKE_PREFIX_PATH=$QT_ROOT"
-            echo "PATH=$QT_ROOT/bin:$PATH"
           } >> "$GITHUB_ENV"
+          echo "$QT_ROOT/bin" >> "$GITHUB_PATH"
           "$QT_ROOT/bin/qmake" -query QT_VERSION
 
       # Same guard as macos-dmg.yml, same history: #711 removed aqt from macOS
@@ -553,7 +593,14 @@ jobs:
         id: cache-qtkeychain-mac
         with:
           path: third_party/qtkeychain
-          key: qtkeychain-macos-arm64-qt6.8.3-${{ hashFiles('scripts/setup/setup-qtkeychain.sh') }}
+          # Deliberately identical to macos-dmg.yml's key: both jobs build the
+          # same source against the same Qt at the same deployment target, so
+          # sharing the entry is the point. That makes every input that changes
+          # the dylib part of the key — Qt version, deployment target, script
+          # hash — because this job runs on push:main and default-branch caches
+          # are visible to every ref, so the entry the *tag* build restores is
+          # normally the one this job wrote.
+          key: qtkeychain-macos-arm64-qt${{ env.QT_VERSION }}-deploy${{ env.MACOS_DEPLOYMENT_TARGET }}-${{ hashFiles('scripts/setup/setup-qtkeychain.sh') }}
 
       # Dropping Homebrew's qtkeychain along with its Qt would have quietly
       # removed credential-persistence compile coverage from every PR, since

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,6 +516,27 @@ jobs:
           } >> "$GITHUB_ENV"
           "$QT_ROOT/bin/qmake" -query QT_VERSION
 
+      # Same guard as macos-dmg.yml, same history: #711 removed aqt from macOS
+      # because two discoverable Qt trees produced Qt6GuiPrivate and linker
+      # failures, and #812 hit it again on Intel. The second Qt arrives
+      # transitively — brew's qtkeychain depends on qtbase — so "we didn't
+      # install Qt" is not sufficient. CMAKE_PREFIX_PATH below still includes
+      # $(brew --prefix) for fftw/portaudio/hidapi.
+      - name: Assert no Homebrew Qt is discoverable
+        run: |
+          set -o pipefail
+          if brew list --formula 2>/dev/null | grep -qE '^(qt|qt@[0-9]+|qtbase)$'; then
+            echo "ERROR: a Homebrew Qt is installed alongside the aqt Qt:"
+            brew list --formula | grep -E '^(qt|qt@[0-9]+|qtbase)$'
+            echo "Two discoverable Qt trees is the #711 / #812 failure mode."
+            exit 1
+          fi
+          if [ -f "$(brew --prefix)/lib/cmake/Qt6/Qt6Config.cmake" ]; then
+            echo "ERROR: a Qt6 CMake config exists under $(brew --prefix)"
+            exit 1
+          fi
+          echo "No Homebrew Qt present; the aqt tree at $QT_ROOT is the only one."
+
       - name: Cache DeepFilterNet3
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         id: cache-deepfilter

--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -26,17 +26,71 @@ jobs:
 
       - name: Install dependencies via Homebrew
         run: |
+          # No Homebrew Qt on either leg. Apple Silicon used to take qt@6 here,
+          # which is a rolling formula — it shipped 6.11.1 while every other
+          # artifact pinned 6.8.3, so the most-downloaded macOS artifact linked
+          # a Qt no other build tested and could change between tags with no PR
+          # (#4688 §1). Both legs now use a pinned Qt: aqt 6.8.3 below on Apple
+          # Silicon, the from-source/prebuilt 6.8.3 tree on Intel.
+          #
+          # qtkeychain likewise: the Homebrew formula is compiled against
+          # Homebrew Qt, so taking it here would reintroduce the exact ABI
+          # mismatch #4685 removed on Linux — and one that fails silently,
+          # because find_package(Qt6Keychain QUIET) just compiles credential
+          # persistence out (#3639). It is built from source against the aqt Qt.
           brew install ninja create-dmg autoconf automake libtool \
             fftw portaudio hidapi
-          if [ "${{ matrix.label }}" = "apple-silicon" ]; then
-            # Apple Silicon: Homebrew Qt targets current OS, fine for arm64
-            brew install qt@6 qtkeychain
-          else
-            # Intel: don't install Homebrew Qt — we build from source below.
-            # qtkeychain pulls in qt@6 as a dependency, so skip it too and
-            # build without SmartLink credential persistence on Intel.
-            brew install fftw portaudio hidapi
+
+      - name: Install Qt 6.8.3 LTS via aqtinstall (Apple Silicon)
+        if: matrix.label == 'apple-silicon'
+        run: |
+          set -o pipefail
+          # aqt goes in a venv rather than `pip3 install --user` or
+          # --break-system-packages: whether the runner's python3 is PEP 668
+          # externally-managed depends on the image and on whether a Homebrew
+          # formula pulled in its own python, and --break-system-packages is
+          # itself a pip>=23 option. A venv is correct regardless of both.
+          # Same reasoning as .github/docker/Dockerfile.
+          python3 -m venv "$RUNNER_TEMP/aqtvenv"
+          "$RUNNER_TEMP/aqtvenv/bin/pip" install -q aqtinstall
+          # Qt publishes ONE macOS desktop build, clang_64, and it is universal2
+          # (x86_64 + arm64) — there is no separate arm64 arch to choose.
+          # Verified against `aqt list-qt mac desktop --arch 6.8.3`, which
+          # returns clang_64 alone, and all four modules below are published
+          # for it.
+          "$RUNNER_TEMP/aqtvenv/bin/aqt" install-qt mac desktop 6.8.3 clang_64 \
+            -m qtmultimedia qtwebsockets qtserialport qtshadertools \
+            --outputdir ${{ github.workspace }}/Qt
+          QT_ROOT="${{ github.workspace }}/Qt/6.8.3/macos"
+          # Assert the layout rather than trusting it: a wrong QT_ROOT would
+          # sail through configure (Homebrew's Qt could satisfy find_package if
+          # it were ever reinstalled by another formula) and only surface as a
+          # subtly mis-deployed DMG. Same guard appimage.yml uses.
+          if [ ! -x "$QT_ROOT/bin/qmake" ]; then
+            echo "ERROR: no qmake at $QT_ROOT — aqt layout changed"
+            ls -la "${{ github.workspace }}/Qt/6.8.3/" || true
+            exit 1
           fi
+          {
+            echo "QT_ROOT=$QT_ROOT"
+            echo "CMAKE_PREFIX_PATH=$QT_ROOT"
+            echo "PATH=$QT_ROOT/bin:$PATH"
+          } >> "$GITHUB_ENV"
+          "$QT_ROOT/bin/qmake" -query QT_VERSION
+
+      - name: Cache qtkeychain (Apple Silicon)
+        if: matrix.label == 'apple-silicon'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        id: cache-qtkeychain-mac
+        with:
+          path: third_party/qtkeychain
+          # Keyed on the Qt version as well as the script: the library is an ABI
+          # match for one specific Qt, so a Qt bump must invalidate it.
+          key: qtkeychain-macos-arm64-qt6.8.3-${{ hashFiles('scripts/setup/setup-qtkeychain.sh') }}
+
+      - name: Setup qtkeychain (SmartLink credential persistence, Apple Silicon)
+        if: matrix.label == 'apple-silicon' && steps.cache-qtkeychain-mac.outputs.cache-hit != 'true'
+        run: bash scripts/setup/setup-qtkeychain.sh
 
       - name: Download pre-built Qt (Intel only)
         if: matrix.label == 'intel'
@@ -138,7 +192,10 @@ jobs:
             QT_PREFIX="$PWD/qt-install"
             DEPLOY_TARGET="13.0"
           else
-            QT_PREFIX="$(brew --prefix)"
+            # $QT_ROOT is the aqt 6.8.3 tree exported by the install step —
+            # not $(brew --prefix), which used to resolve to Homebrew's rolling
+            # qt@6 (#4688 §1).
+            QT_PREFIX="$QT_ROOT"
             DEPLOY_TARGET="14.0"
           fi
           # Intel Mac: disable GPU rendering — QRhiWidget has issues on
@@ -156,8 +213,16 @@ jobs:
           # compiler + the GGML_METAL_EMBED_LIBRARY fix), so a broken Metal
           # toolchain fails the build instead of silently shipping CPU-only.
           ONNX_FLAG=""
+          KEYCHAIN_FLAG=""
           if [ "${{ matrix.label }}" = "apple-silicon" ]; then
             ONNX_FLAG="-DREQUIRE_ASR_ONNX=ON"
+            # qtkeychain is now built from source against the aqt Qt rather than
+            # taken from Homebrew, so make its absence fatal. find_package(
+            # Qt6Keychain QUIET) otherwise compiles SmartLink credential
+            # persistence out without a word, which is how the AppImage shipped
+            # broken persistence for several releases (#3639). Intel stays
+            # unguarded — it deliberately ships without persistence.
+            KEYCHAIN_FLAG="-DREQUIRE_KEYCHAIN=ON"
           fi
           cmake -B build -G "Unix Makefiles" \
             -DCMAKE_BUILD_TYPE=Release \
@@ -169,16 +234,21 @@ jobs:
             -DREQUIRE_ASR_GPU=ON \
             -DREQUIRE_ASR_SHERPA=ON \
             $ONNX_FLAG \
+            $KEYCHAIN_FLAG \
             $GPU_FLAG 2>&1 | tee configure.log
 
       # Apple Silicon only — the Intel leg asks for OFF on purpose (see above).
       # Same reasoning as appimage.yml and windows-installer.yml: CMake turns
       # AETHER_GPU_SPECTRUM back OFF without failing when Qt6GuiPrivate can't be
       # located, so the DMG could ship the CPU QPainter fallback with this
-      # workflow green. Homebrew Qt is the one layout here that does provide the
-      # Qt6GuiPrivate CMake package, which is precisely why this leg has gone
-      # unguarded — but that is a property of the Qt we happen to install, not
-      # something this workflow pins, so assert it rather than assume it.
+      # workflow green.
+      #
+      # This is not hypothetical here. Homebrew Qt shipped the Qt6GuiPrivate
+      # CMake package, which is the only reason this leg went unguarded for so
+      # long; the aqt Qt above does not, and the private headers sit in a
+      # framework layout CMakeLists.txt did not probe for. Pinning the Qt
+      # without also teaching CMake that layout turned this feature off
+      # silently — this assertion is what makes that impossible to ship.
       #
       # Assert on the configure output, not CMakeCache.txt: CMakeLists.txt
       # disables the feature with a plain set(), which shadows the cache entry
@@ -253,10 +323,14 @@ jobs:
 
       - name: Bundle Qt frameworks
         run: |
+          # macdeployqt must come from the SAME Qt the app linked, or it stages
+          # frameworks from a different build than the binary resolves against.
+          # On Apple Silicon that is now the aqt 6.8.3 tree; taking it from
+          # $(brew --prefix qt@6) is what mixed Homebrew's 6.11.1 into the DMG.
           if [ "${{ matrix.label }}" = "intel" ]; then
             DEPLOYQT="$PWD/qt-install/bin/macdeployqt"
           else
-            DEPLOYQT="$(brew --prefix qt@6)/bin/macdeployqt"
+            DEPLOYQT="$QT_ROOT/bin/macdeployqt"
           fi
           "$DEPLOYQT" build/AetherSDR.app \
             -verbose=1 \

--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -19,6 +19,18 @@ jobs:
             label: intel
     runs-on: ${{ matrix.runner }}
 
+    # One place each for the versions and the deployment targets this workflow
+    # pins. MACOS_DEPLOYMENT_TARGET is the Apple Silicon value: it feeds both
+    # the app's CMAKE_OSX_DEPLOYMENT_TARGET below and setup-qtkeychain.sh, so
+    # the bundled dylib can never end up newer than the bundle carrying it.
+    # ci.yml's check-macos pins the same three values, and shares the qtkeychain
+    # cache key built from them.
+    env:
+      QT_VERSION: '6.8.3'
+      AQTINSTALL_VERSION: '3.3.0'
+      MACOS_DEPLOYMENT_TARGET: '14.0'
+      MACOS_INTEL_DEPLOYMENT_TARGET: '13.0'
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -41,7 +53,7 @@ jobs:
           brew install ninja create-dmg autoconf automake libtool \
             fftw portaudio hidapi
 
-      - name: Install Qt 6.8.3 LTS via aqtinstall (Apple Silicon)
+      - name: Install Qt LTS via aqtinstall (Apple Silicon)
         if: matrix.label == 'apple-silicon'
         run: |
           set -o pipefail
@@ -51,31 +63,40 @@ jobs:
           # formula pulled in its own python, and --break-system-packages is
           # itself a pip>=23 option. A venv is correct regardless of both.
           # Same reasoning as .github/docker/Dockerfile.
+          #
+          # aqt is pinned for the same reason Qt is: it is the tool that decides
+          # which Qt lands in the DMG, so leaving it floating would put an
+          # unreviewed dependency back on the release path this PR exists to
+          # close. .github/docker/Dockerfile pins it and says so; appimage.yml
+          # does not, and should — separate change, separate artifact.
           python3 -m venv "$RUNNER_TEMP/aqtvenv"
-          "$RUNNER_TEMP/aqtvenv/bin/pip" install -q aqtinstall
+          "$RUNNER_TEMP/aqtvenv/bin/pip" install -q "aqtinstall==${AQTINSTALL_VERSION}"
           # Qt publishes ONE macOS desktop build, clang_64, and it is universal2
           # (x86_64 + arm64) — there is no separate arm64 arch to choose.
           # Verified against `aqt list-qt mac desktop --arch 6.8.3`, which
           # returns clang_64 alone, and all four modules below are published
           # for it.
-          "$RUNNER_TEMP/aqtvenv/bin/aqt" install-qt mac desktop 6.8.3 clang_64 \
+          "$RUNNER_TEMP/aqtvenv/bin/aqt" install-qt mac desktop "$QT_VERSION" clang_64 \
             -m qtmultimedia qtwebsockets qtserialport qtshadertools \
-            --outputdir ${{ github.workspace }}/Qt
-          QT_ROOT="${{ github.workspace }}/Qt/6.8.3/macos"
+            --outputdir "${{ github.workspace }}/Qt"
+          QT_ROOT="${{ github.workspace }}/Qt/$QT_VERSION/macos"
           # Assert the layout rather than trusting it: a wrong QT_ROOT would
           # sail through configure (Homebrew's Qt could satisfy find_package if
           # it were ever reinstalled by another formula) and only surface as a
           # subtly mis-deployed DMG. Same guard appimage.yml uses.
           if [ ! -x "$QT_ROOT/bin/qmake" ]; then
             echo "ERROR: no qmake at $QT_ROOT — aqt layout changed"
-            ls -la "${{ github.workspace }}/Qt/6.8.3/" || true
+            ls -la "${{ github.workspace }}/Qt/$QT_VERSION/" || true
             exit 1
           fi
+          # PATH goes through GITHUB_PATH, not GITHUB_ENV: the latter would
+          # freeze this step's PATH verbatim for every later step, silently
+          # discarding anything a subsequent action prepends.
           {
             echo "QT_ROOT=$QT_ROOT"
             echo "CMAKE_PREFIX_PATH=$QT_ROOT"
-            echo "PATH=$QT_ROOT/bin:$PATH"
           } >> "$GITHUB_ENV"
+          echo "$QT_ROOT/bin" >> "$GITHUB_PATH"
           "$QT_ROOT/bin/qmake" -query QT_VERSION
 
       # Why this guard exists — the history is easy to lose and expensive to
@@ -118,10 +139,18 @@ jobs:
         id: cache-qtkeychain-mac
         with:
           path: third_party/qtkeychain
-          # Keyed on the Qt version as well as the script: the library is an ABI
-          # match for one specific Qt, so a Qt bump must invalidate it.
-          key: qtkeychain-macos-arm64-qt6.8.3-${{ hashFiles('scripts/setup/setup-qtkeychain.sh') }}
+          # Keyed on every input that changes the dylib, not just the script:
+          # it is an ABI match for one specific Qt, and it carries one specific
+          # LC_BUILD_VERSION. Identical to ci.yml's key on purpose — that job
+          # runs on push:main, default-branch caches are visible to every ref,
+          # so the entry restored here is normally the one check-macos wrote.
+          # Anything that would make those two builds differ has to appear here.
+          key: qtkeychain-macos-arm64-qt${{ env.QT_VERSION }}-deploy${{ env.MACOS_DEPLOYMENT_TARGET }}-${{ hashFiles('scripts/setup/setup-qtkeychain.sh') }}
 
+      # MACOS_DEPLOYMENT_TARGET is not optional here: CMake otherwise leaves the
+      # deployment target empty and clang stamps the runner's own OS (15.x) into
+      # the dylib, which CMakeLists.txt then copies into Contents/Frameworks of
+      # a bundle built for 14.0 — dyld refuses to load it on macOS 14.
       - name: Setup qtkeychain (SmartLink credential persistence, Apple Silicon)
         if: matrix.label == 'apple-silicon' && steps.cache-qtkeychain-mac.outputs.cache-hit != 'true'
         run: bash scripts/setup/setup-qtkeychain.sh
@@ -224,13 +253,15 @@ jobs:
           set -o pipefail
           if [ "${{ matrix.label }}" = "intel" ]; then
             QT_PREFIX="$PWD/qt-install"
-            DEPLOY_TARGET="13.0"
+            DEPLOY_TARGET="$MACOS_INTEL_DEPLOYMENT_TARGET"
           else
-            # $QT_ROOT is the aqt 6.8.3 tree exported by the install step —
-            # not $(brew --prefix), which used to resolve to Homebrew's rolling
-            # qt@6 (#4688 §1).
+            # $QT_ROOT is the aqt Qt tree exported by the install step — not
+            # $(brew --prefix), which used to resolve to Homebrew's rolling
+            # qt@6 (#4688 §1). DEPLOY_TARGET comes from the same job-level env
+            # setup-qtkeychain.sh was given, so the bundled dylib and the bundle
+            # cannot drift apart.
             QT_PREFIX="$QT_ROOT"
-            DEPLOY_TARGET="14.0"
+            DEPLOY_TARGET="$MACOS_DEPLOYMENT_TARGET"
           fi
           # Intel Mac: disable GPU rendering — QRhiWidget has issues on
           # older Metal/OpenGL hardware. Apple Silicon renders via QRhi.
@@ -336,9 +367,9 @@ jobs:
       - name: Build DAX audio driver
         run: |
           if [ "${{ matrix.label }}" = "intel" ]; then
-            DEPLOY_TARGET="13.0"
+            DEPLOY_TARGET="$MACOS_INTEL_DEPLOYMENT_TARGET"
           else
-            DEPLOY_TARGET="14.0"
+            DEPLOY_TARGET="$MACOS_DEPLOYMENT_TARGET"
           fi
           cmake -B driver-build hal-plugin \
             -DCMAKE_BUILD_TYPE=Release \
@@ -359,7 +390,7 @@ jobs:
         run: |
           # macdeployqt must come from the SAME Qt the app linked, or it stages
           # frameworks from a different build than the binary resolves against.
-          # On Apple Silicon that is now the aqt 6.8.3 tree; taking it from
+          # On Apple Silicon that is now the aqt Qt tree; taking it from
           # $(brew --prefix qt@6) is what mixed Homebrew's 6.11.1 into the DMG.
           if [ "${{ matrix.label }}" = "intel" ]; then
             DEPLOYQT="$PWD/qt-install/bin/macdeployqt"
@@ -369,6 +400,43 @@ jobs:
           "$DEPLOYQT" build/AetherSDR.app \
             -verbose=1 \
             -always-overwrite
+
+      # The artifact-side half of the pin. Everything upstream of here asserts
+      # what we *asked* for; this asserts what the DMG actually carries, which
+      # is the claim #4688 §1 makes and #2191 asked for directly ("verify they
+      # resolve to the same installation"). Reading it off the staged framework
+      # is the only check that survives someone changing QT_ROOT, macdeployqt,
+      # or the Homebrew guard without noticing.
+      - name: Assert the bundled Qt is the pinned Qt
+        run: |
+          set -o pipefail
+          FW="build/AetherSDR.app/Contents/Frameworks/QtCore.framework/Versions/A/QtCore"
+          if [ ! -f "$FW" ]; then
+            echo "ERROR: macdeployqt staged no QtCore framework at $FW"
+            ls -la build/AetherSDR.app/Contents/Frameworks/ || true
+            exit 1
+          fi
+          # Two independent readings, and the pin has to show up in one of them.
+          # Line 2 of `otool -L` on a dylib is its own LC_ID_DYLIB; `strings -a`
+          # finds the "Qt <ver> (...)" build string QLibraryInfo::build() returns
+          # (-a so it does not skip Mach-O sections it cannot classify). Either
+          # alone is a plausible false negative on some future Qt packaging;
+          # requiring only one to match keeps this from turning into a red
+          # release on a cosmetic change, while a genuinely wrong Qt — the 6.11.1
+          # this PR exists to keep out — fails both.
+          ID_LINE="$(otool -L "$FW" | sed -n '2p')"
+          BUILD_STR="$(strings -a "$FW" | grep -m1 -oE 'Qt [0-9]+\.[0-9]+\.[0-9]+' || true)"
+          echo "  install name: ${ID_LINE:-<none>}"
+          echo "  build string: ${BUILD_STR:-<none>}"
+          # Both legs pin the same version — aqt on Apple Silicon, the
+          # prebuilt/from-source tree on Intel — so one expectation covers both.
+          if ! printf '%s\n%s\n' "$ID_LINE" "$BUILD_STR" | grep -qF "$QT_VERSION"; then
+            echo "ERROR: the staged QtCore is not the pinned Qt $QT_VERSION."
+            echo "macdeployqt staged a different Qt than this workflow installed."
+            otool -L build/AetherSDR.app/Contents/MacOS/AetherSDR | head -20
+            exit 1
+          fi
+          echo "Bundled Qt matches the pin ($QT_VERSION)."
 
       - name: Import code signing certificate
         env:

--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -78,6 +78,40 @@ jobs:
           } >> "$GITHUB_ENV"
           "$QT_ROOT/bin/qmake" -query QT_VERSION
 
+      # Why this guard exists — the history is easy to lose and expensive to
+      # relearn. #711 ("drop aqtinstall, use Homebrew for everything") removed
+      # aqt from macOS precisely because an aqt Qt and a Homebrew Qt visible at
+      # the same time produced "Qt6GuiPrivate and linker failures", and #812 hit
+      # the same clash on Intel against the source-built Qt ("their CMake
+      # configs clash"). The real constraint is not "aqt is wrong on macOS" —
+      # it is that TWO discoverable Qt trees break the build.
+      #
+      # In both incidents the second Qt arrived transitively rather than by
+      # request: brew's qtkeychain depends on qtbase. This job installs neither
+      # qtkeychain nor any Qt formula, so there is exactly one Qt — but
+      # CMAKE_PREFIX_PATH still carries $(brew --prefix) for fftw/portaudio/
+      # hidapi, so a future formula that pulls qtbase in, or a runner image that
+      # ships Qt preinstalled, would silently recreate #711. Assert it.
+      - name: Assert no Homebrew Qt is discoverable (Apple Silicon)
+        if: matrix.label == 'apple-silicon'
+        run: |
+          set -o pipefail
+          if brew list --formula 2>/dev/null | grep -qE '^(qt|qt@[0-9]+|qtbase)$'; then
+            echo "ERROR: a Homebrew Qt is installed alongside the aqt Qt:"
+            brew list --formula | grep -E '^(qt|qt@[0-9]+|qtbase)$'
+            echo "Two discoverable Qt trees is the #711 / #812 failure mode."
+            echo "Find the formula that pulled it in (qtkeychain depends on"
+            echo "qtbase) and drop it, or this build links a mixed Qt."
+            exit 1
+          fi
+          if [ -f "$(brew --prefix)/lib/cmake/Qt6/Qt6Config.cmake" ]; then
+            echo "ERROR: a Qt6 CMake config exists under $(brew --prefix)"
+            echo "even though no Qt formula is listed — CMAKE_PREFIX_PATH"
+            echo "includes that prefix and could resolve Qt from it."
+            exit 1
+          fi
+          echo "No Homebrew Qt present; the aqt tree at $QT_ROOT is the only one."
+
       - name: Cache qtkeychain (Apple Silicon)
         if: matrix.label == 'apple-silicon'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed: the macOS build keeps GPU spectrum rendering when Qt comes from Qt (#4688, #2191)
+
+**The Apple Silicon DMG now ships the Qt it says it ships — 6.8.3, the same one
+behind every other download — and keeps drawing the spectrum on the GPU while
+doing it.**
+
+Until now that DMG took Qt from Homebrew: whatever version Homebrew happened to
+be publishing on the day a release was tagged. That was 6.11.1 while every other
+artifact was pinned to 6.8.3, so the most-downloaded macOS build was the only one
+running a Qt nobody had tested it against — and it could change between two
+releases with no code change anywhere. It is the most likely explanation for
+#2191, where the DMG's Qt behaved differently from a standard install of the
+same version.
+
+Pinning it exposed a second problem that had been hiding behind Homebrew. Qt's
+own macOS packages arrange their headers differently from every other platform,
+and AetherSDR's build did not recognise that arrangement — so the GPU spectrum
+renderer quietly switched itself off and the app fell back to CPU drawing, with
+nothing in the build saying so. Both halves are fixed here, and the release now
+refuses to produce a macOS app that has silently lost GPU rendering or that
+bundles a Qt other than the pinned one.
+
+Also on macOS: SmartLink credential persistence — staying logged in between
+launches — is now built as part of the release rather than picked up from
+Homebrew, and its absence is a build failure instead of a feature that
+disappears without a word.
+
 ### Fixed: the Linux AppImage runs natively on Wayland instead of XWayland (#1389, #1233)
 
 **On a Wayland desktop the AppImage now uses Wayland directly.** Text and the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,6 +420,30 @@ if(AETHER_GPU_SPECTRUM)
                 set(Qt6GuiPrivate_FOUND TRUE)
                 set(DEBIAN_GPU_FIX_REQUIRED TRUE) # Mark for Step 2 (manual include dirs)
             endif()
+            # macOS framework layout. Qt's own macOS builds — the official
+            # installer and aqtinstall alike — ship QtGui as a framework, so the
+            # private headers live at QtGui.framework/Headers/<ver>/QtGui, one
+            # path component short of the SDK layout probed above (which expects
+            # a further QtGui/ beneath the include root). They also ship no
+            # Qt6GuiPrivate CMake package at all, so nothing above finds them.
+            #
+            # This is not a hypothetical layout: pinning the Apple Silicon DMG
+            # to aqt Qt 6.8.3 (#4688 §1) moved that leg off Homebrew's Qt, which
+            # *does* provide Qt6GuiPrivate — and AETHER_GPU_SPECTRUM promptly
+            # turned itself OFF, with the CPU QPainter fallback compiled in and
+            # the workflow green. Only the #4690 assertion caught it. Probe the
+            # framework layout here so the gate agrees with the wiring in the
+            # AETHER_GPU_SPECTRUM block below, which has always had a branch for
+            # this shape and could never be reached.
+            if(NOT Qt6GuiPrivate_FOUND AND APPLE)
+                foreach(_inc IN LISTS _qt_gui_incs)
+                    if(EXISTS "${_inc}/${Qt6_VERSION}/QtGui/private/qhighdpiscaling_p.h")
+                        set(QT_FRAMEWORK_PRIVATE_INC "${_inc}/${Qt6_VERSION}")
+                        set(Qt6GuiPrivate_FOUND TRUE)
+                        break()
+                    endif()
+                endforeach()
+            endif()
         endif()
 
         if(Qt6GuiPrivate_FOUND)
@@ -2280,13 +2304,26 @@ if(AETHER_GPU_SPECTRUM)
             "${DEBIAN_PRIVATE_INC}/QtGui/${Qt6_VERSION}"
             "${DEBIAN_PRIVATE_INC}/QtGui/${Qt6_VERSION}/QtGui"
         )
+    elseif(QT_FRAMEWORK_PRIVATE_INC)
+        # macOS framework layout located during detection. Both dirs, matching
+        # what Qt's own Qt6::Gui generator expression adds when the private
+        # module is available: <ver>/ resolves QtGui/private/... spellings,
+        # <ver>/QtGui/ resolves the <rhi/qrhi.h> the spectrum widgets include.
+        message(STATUS "Applying framework private QtGui include paths to AetherSDR (${QT_FRAMEWORK_PRIVATE_INC})")
+        target_include_directories(AetherSDR PRIVATE
+            "${QT_FRAMEWORK_PRIVATE_INC}"
+            "${QT_FRAMEWORK_PRIVATE_INC}/QtGui"
+        )
     endif()
 
     if(TARGET Qt6::GuiPrivate)
         target_link_libraries(AetherSDR PRIVATE Qt6::GuiPrivate)
-    elseif(NOT DEBIAN_GPU_FIX_REQUIRED)
-        # No GuiPrivate target and no manual path (e.g. some macOS layouts) —
-        # locate the rhi/ headers within the Qt6::Gui include dirs.
+    elseif(NOT DEBIAN_GPU_FIX_REQUIRED AND NOT QT_FRAMEWORK_PRIVATE_INC)
+        # No GuiPrivate target and neither manual path applied — last resort:
+        # locate the rhi/ headers within the Qt6::Gui include dirs. Qt's macOS
+        # framework layout used to land here and no longer does (the branch
+        # above handles it), so this now covers only distributions that expose
+        # rhi/ directly on the Qt6::Gui include path.
         get_target_property(_qt_gui_inc Qt6::Gui INTERFACE_INCLUDE_DIRECTORIES)
         foreach(_dir IN LISTS _qt_gui_inc)
             if(EXISTS "${_dir}/rhi/qrhi.h")

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ it on Debian Trixie, Ubuntu 25.10+, Fedora 41+ and Arch. It does **not** clear
 on **Ubuntu 24.04 LTS**, which ships Qt 6.4.2 — build there against a Qt from
 [aqtinstall](https://github.com/miurahr/aqtinstall) or the Qt online installer
 and point CMake at it with `-DCMAKE_PREFIX_PATH=/path/to/Qt/6.8.3/gcc_64`.
+On **macOS** the Qt does not come from Homebrew at all — see the macOS note
+below the install commands.
 
 ```bash
 # Arch / CachyOS / Manjaro
@@ -139,10 +141,45 @@ sudo dnf install qt6-qtbase-devel qt6-qtbase-private-devel qt6-qtmultimedia-deve
   cmake ninja-build autoconf automake libtool \
   fftw3-devel portaudio-devel hidapi-devel qtkeychain-qt6-devel
 
-# macOS (Homebrew)
-brew install qt@6 ninja cmake pkgconf autoconf automake libtool \
-  fftw portaudio hidapi qtkeychain
+# macOS (Homebrew) — everything EXCEPT Qt and qtkeychain; see the note below
+brew install ninja cmake pkgconf autoconf automake libtool \
+  fftw portaudio hidapi
 ```
+
+> **macOS note — Qt and qtkeychain do not come from Homebrew.** Homebrew's `qt`
+> formula (aliased `qt6` and `qt@6`) is a *rolling* release — 6.11.1 at the time
+> of writing — while the DMG ships 6.8.3 LTS like every other artifact. Building
+> against Homebrew's Qt means testing a Qt no release ships. Install the matching
+> one and point CMake at it:
+>
+> ```bash
+> # A venv rather than a bare `pip install`: a PEP 668 python3 refuses the latter.
+> python3 -m venv ~/.venv/aqt && ~/.venv/aqt/bin/pip install aqtinstall
+> ~/.venv/aqt/bin/aqt install-qt mac desktop 6.8.3 clang_64 \
+>   -m qtmultimedia qtwebsockets qtserialport qtshadertools \
+>   --outputdir ~/Qt
+> cmake -B build -DCMAKE_PREFIX_PATH="$HOME/Qt/6.8.3/macos;$(brew --prefix)"
+> ```
+>
+> `clang_64` is the only macOS desktop build Qt publishes, and it is universal2 —
+> there is no separate arm64 archive to pick. `$(brew --prefix)` stays on the
+> path for fftw, portaudio and hidapi.
+>
+> Homebrew's `qtkeychain` is left out for a related reason: the formula depends
+> on `qtbase`, so installing it pulls a second Qt in behind your back. Build it
+> against the Qt you just installed instead — or skip it and build without
+> SmartLink credential persistence:
+>
+> ```bash
+> CMAKE_PREFIX_PATH="$HOME/Qt/6.8.3/macos" bash scripts/setup/setup-qtkeychain.sh
+> ```
+>
+> **Two Qt installations visible to CMake at once is a real failure, not a
+> theoretical one** — it is what #711 and #812 were, and `CMakeLists.txt` puts
+> `$(brew --prefix)/include` on the global include path on macOS, so a Homebrew
+> Qt is discoverable whether or not you asked for it. If you have one,
+> `brew uninstall qt` (plus whatever pulled it in) before building. The release
+> workflow asserts this; your machine will not.
 
 <details>
 <summary>What each dependency enables</summary>

--- a/scripts/setup/setup-qtkeychain.sh
+++ b/scripts/setup/setup-qtkeychain.sh
@@ -22,6 +22,15 @@
 #
 # Requires: cmake, ninja, a C++ compiler, git, and a discoverable Qt6.
 #
+# MACOS_DEPLOYMENT_TARGET (optional, macOS only) must be set to the SAME value
+# the app is built with. CMake otherwise leaves CMAKE_OSX_DEPLOYMENT_TARGET
+# empty and clang stamps the *runner's* OS into LC_BUILD_VERSION — a dylib with
+# minos 15.0 inside a bundle that advertises 14.0, which dyld refuses to load on
+# macOS 14. The library is copied into Contents/Frameworks (CMakeLists.txt,
+# APPLE branch of the Qt6Keychain block), so it ships with that stamp. The
+# `${VAR:+…}` form is safe under `set -u` and passes nothing when unset, leaving
+# Linux exactly as it was.
+#
 # Usage: ./setup-qtkeychain.sh
 
 set -euo pipefail
@@ -86,7 +95,8 @@ cmake -B "$BUILD_DIR" -S "$SRC_DIR" -G Ninja \
     -DLIBSECRET_SUPPORT=OFF \
     -DCMAKE_PREFIX_PATH="$QT_PREFIX" \
     -DCMAKE_INSTALL_PREFIX="$OUT_DIR_ABS" \
-    -DCMAKE_INSTALL_LIBDIR=lib
+    -DCMAKE_INSTALL_LIBDIR=lib \
+    ${MACOS_DEPLOYMENT_TARGET:+-DCMAKE_OSX_DEPLOYMENT_TARGET="$MACOS_DEPLOYMENT_TARGET"}
 # nproc is GNU coreutils and absent on macOS, where this script now also runs
 # (the Apple Silicon DMG builds qtkeychain against its aqt Qt for the same ABI
 # reason as Linux). sysctl is the BSD equivalent. Fall back to 1 rather than

--- a/scripts/setup/setup-qtkeychain.sh
+++ b/scripts/setup/setup-qtkeychain.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# setup-qtkeychain.sh — Build qtkeychain for Linux release packaging.
+# setup-qtkeychain.sh — Build qtkeychain for Linux and macOS release packaging.
 #
 # Downloads the qtkeychain source, builds it from source against the Qt6
 # installation in use (aqt-provided or system), and installs it into
@@ -17,7 +17,8 @@
 # LIBSECRET_SUPPORT is OFF on purpose: that selects qtkeychain's pure
 # Qt-D-Bus Secret Service backend, which talks to KDE Wallet (kwalletd) and
 # GNOME Keyring over the session bus with no extra native runtime deps to
-# bundle — only Qt6 D-Bus, which linuxdeploy already carries.
+# bundle — only Qt6 D-Bus, which linuxdeploy already carries. It has no effect
+# on macOS, where qtkeychain always uses the native Keychain backend.
 #
 # Requires: cmake, ninja, a C++ compiler, git, and a discoverable Qt6.
 #
@@ -86,7 +87,13 @@ cmake -B "$BUILD_DIR" -S "$SRC_DIR" -G Ninja \
     -DCMAKE_PREFIX_PATH="$QT_PREFIX" \
     -DCMAKE_INSTALL_PREFIX="$OUT_DIR_ABS" \
     -DCMAKE_INSTALL_LIBDIR=lib
-cmake --build "$BUILD_DIR" -j"$(nproc)"
+# nproc is GNU coreutils and absent on macOS, where this script now also runs
+# (the Apple Silicon DMG builds qtkeychain against its aqt Qt for the same ABI
+# reason as Linux). sysctl is the BSD equivalent. Fall back to 1 rather than
+# letting the substitution come out empty — a bare `-j` means "unlimited" and
+# would fork-bomb the runner.
+JOBS="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)"
+cmake --build "$BUILD_DIR" -j"$JOBS"
 cmake --install "$BUILD_DIR"
 
 # ── Cleanup ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes §1 of #4688 — the last unpinned Qt in the release matrix.

The Apple Silicon DMG took Qt from `brew install qt@6`, a **rolling** formula
currently at **6.11.1**, while the AppImage (both arches), the Windows
installer, the CI image and the Intel DMG all pin **6.8.3**. So the
most-downloaded macOS artifact linked a Qt no other build tested, three minor
versions ahead, on a dependency that can change between two tag pushes with no
PR and no review. It is the same defect #4670 fixed on aarch64, inverted.

**This was not theoretical.** The drift is already visible in the source tree:

- `src/core/AudioEngine.cpp:338` carries `#if QT_VERSION < QT_VERSION_CHECK(6, 11, 0)`
  for `QAudio::UnderrunError`. That branch exists *only* because a release
  artifact is already on 6.11.
- The `>= 6.10` `beginFilterChange()` / `endFilterChange()` paths in
  `DxClusterDialog` and `FreeDvReporterDialog` execute on macOS ARM and nowhere
  else in the same release.

It is also the likely root of #2191 (priority: high, open since May), which
reports the DMG's `libqcocoa.dylib` at Qt 6.11.0 behaving differently from
"standard Qt". Pinning removes the variable.

Both macOS legs now use a pinned Qt: **aqt 6.8.3** on Apple Silicon, the
existing from-source/prebuilt 6.8.3 tree on Intel. Qt publishes one macOS
desktop build, `clang_64`, and it is universal2.

### What moved with it, and why it had to

**qtkeychain.** The Homebrew formula is compiled against Homebrew Qt, so keeping
it would reintroduce exactly the ABI mismatch #4685 removed on Linux — and one
that fails *silently*, because `find_package(Qt6Keychain QUIET)` simply compiles
credential persistence out. That is #3639 verbatim. It is now built from source
against the aqt Qt, with `REQUIRE_KEYCHAIN=ON` making its absence fatal.

**`check-macos` in `ci.yml`.** Leaving it on Homebrew would put the per-PR macOS
check on a rolling Qt while the DMG ships 6.8.3 — a green check that says
nothing about the artifact. And dropping brew's qtkeychain alongside its Qt
would have quietly removed credential-persistence compile coverage from every
PR, the same silent-removal shape, so that job builds it from source and
configures `REQUIRE_KEYCHAIN=ON` too.

**`setup-qtkeychain.sh`** runs on macOS for the first time here and needed one
fix: `-j"$(nproc)"` is GNU coreutils and absent on macOS. It now falls back
`nproc` → `sysctl -n hw.ncpu` → `1`. The final literal matters — an empty
substitution would leave a bare `-j`, which means *unlimited* parallelism.

**aqt goes in a venv**, not `pip3 install --break-system-packages`: whether the
runner's python3 is PEP 668 externally-managed depends on the image and on
whether some formula pulled in its own python, and `--break-system-packages` is
itself a pip>=23 option. `.github/docker/Dockerfile` already uses a venv for
this reason.

## Constitution principle honored

Technology Constraints — *"Cross-platform: features must build and run on Linux
x86_64, Windows 10+, macOS (current and one back), and Raspberry Pi 5."* A
platform whose Qt is chosen by whatever Homebrew published that morning is not
meaningfully covered by that guarantee; the other four artifacts are pinned and
this one now is too.

## What review changed (rebased onto main, which now carries #4690)

**The pin turned GPU spectrum rendering off, and this branch's own green CI
proved it.** `check-macos` on the pre-review head configured with:

```
-- Qt6GuiPrivate CMake package not found, searching for private headers directly...
-- GPU spectrum rendering disabled — Qt6GuiPrivate not found
```

while the same job on `main` says `GPU spectrum rendering enabled (QRhi, Qt
6.11.1)`. Homebrew's Qt ships a `Qt6GuiPrivate` CMake package; Qt's own macOS
packages do not, and they lay the private headers out as
`QtGui.framework/Headers/<ver>/QtGui` — one component short of the SDK layout
`CMakeLists.txt` probed for. So the gate rejected the layout, set the option
`OFF`, and the DMG would have shipped the CPU `QPainter` fallback: the #4000
failure that #4688 §4 exists to prevent, arriving through §1's own fix.

The wiring for that layout already existed — the `elseif` branch below the gate
is commented *"some macOS layouts"* and its `rhi/qrhi.h` glob matches exactly.
It was unreachable because the gate and the wiring disagreed about the layout.
They now share one variable.

That also means **this is no longer a CI-only change**, and the checklist below
is corrected accordingly.

Four more, all the same shape — asserting what we asked for and never what we
got:

- **qtkeychain took the runner's deployment target,** not the bundle's: no
  `CMAKE_OSX_DEPLOYMENT_TARGET`, so clang stamps minos 15.0 into a dylib that
  `CMakeLists.txt` copies into a bundle built for 14.0, where dyld refuses to
  load it. Homebrew's bottle had the same property, so it is a carry-forward
  rather than a regression — but building it ourselves is what makes it ours.
- **The qtkeychain cache key** was byte-identical across the two workflows but
  encoded only the Qt version and the script hash. Sharing is deliberate;
  `check-macos` runs on `push: main` and default-branch caches are visible to
  every ref, so the entry the *tag* build restores is normally the one CI wrote.
  Every input that changes the dylib is now in the key — which is also what
  stops the fix above from being undone by a stale entry.
- **Nothing asserted the Qt `macdeployqt` actually staged** — this PR's central
  claim, and steps 1–2 of #2191's own suggested investigation. Now read off the
  staged `QtCore` two independent ways.
- **`aqtinstall` is pinned** to the version the Dockerfile already pins, and
  **Qt is cached** in `check-macos`, which went ~6 min → ~18 min when it started
  pulling 1.3 GB per PR.
- **The README told macOS contributors to `brew install qt@6 … qtkeychain`.**
  Pinning CI and the artifact to 6.8.3 left a developer's machine as the only
  place still on Homebrew's rolling 6.11.1 — the same "tested Qt is not the
  shipped Qt" split this PR closes, relocated rather than fixed. And Homebrew's
  `qtkeychain` depends on `qtbase` (checked against the formula API), so that
  line installed a second Qt behind your back — the #711/#812 trap, in our own
  build instructions. Both replaced with the aqt 6.8.3 invocation the workflows
  use and `setup-qtkeychain.sh`.

## Test plan

- [x] Local build passes — Linux `AetherSDR` target builds clean with the
      `CMakeLists.txt` change; the new branch is `APPLE`-gated and inert there,
      and a Linux configure still reports `GPU spectrum rendering enabled`
- [ ] Behavior verified on a real radio if applicable — N/A
- [x] Existing tests pass (CI) — and `check-macos` now proves the fix on a real
      runner: `GPU spectrum rendering enabled (QRhi, Qt 6.8.3)` with
      `Applying framework private QtGui include paths to AetherSDR
      (…/QtGui.framework/Headers/6.8.3)`, where the pre-review head said
      `disabled`. #4690's assertion passes rather than firing.
- [ ] Reproduction steps documented if user-reported bug — N/A (see #2191 for
      the likely downstream symptom)

**Verified locally**

- `aqt list-qt mac desktop --arch 6.8.3` returns `clang_64` alone, and
  `--modules 6.8.3 clang_64` lists `qtmultimedia`, `qtwebsockets`,
  `qtserialport` and `qtshadertools`. So the arch and module set in this PR are
  confirmed to exist, not assumed.
- **The macOS Qt archive itself was downloaded and inspected.**
  `aqt install-qt mac desktop 6.8.3 clang_64` ships no
  `lib/cmake/Qt6GuiPrivate`; `qhighdpiscaling_p.h` sits at
  `lib/QtGui.framework/Headers/6.8.3/QtGui/private/`; `<rhi/qrhi.h>` — the only
  private-ish include in the tree — resolves from `Headers/6.8.3/QtGui`. The old
  probe misses that tree and the new one finds it, checked by replaying both
  against the real `Qt6::Gui` include dirs read out of `Qt6GuiTargets.cmake`.
- The bundled-Qt assertion's build string is really there: `strings -a` on the
  archive's `QtCore` yields `Qt 6.8.3`.
- `setup-qtkeychain.sh` runs clean end to end after the `nproc` change, and the
  new `${MACOS_DEPLOYMENT_TARGET:+…}` argument expands to exactly one clean
  `-DCMAKE_OSX_DEPLOYMENT_TARGET=14.0` when set and to nothing when unset, under
  `set -u`.
- The job-count fallback yields `32` on Linux, the `sysctl` value on macOS, and
  `1` when neither command exists — never empty.
- Both workflows parse as YAML, and the aqt step precedes the qtkeychain step in
  each job (checked programmatically, since a wrong order would fail with
  "Qt6 not found").

**Not verifiable off a macOS runner — please weigh this before merging**

The aqt install itself, `macdeployqt` staging the aqt Qt into the `.app`, and
qtkeychain's macOS Keychain backend building under this configuration are all
untested here. This is the release path for the most-downloaded macOS artifact,
so **a `workflow_dispatch` run of both `macOS DMG` and `CI` is the real
pre-merge test** and is worth doing before a tag depends on it. Two things to
read in that run specifically: the new `Assert the bundled Qt is the pinned Qt`
step, and `otool -l` on the staged `libqt6keychain.1.dylib` to confirm its
`LC_BUILD_VERSION` now says 14.0.

## Follow-up, deliberately not in this PR

Qt's macOS build being universal2 means the **Intel leg could use the same aqt
Qt**, deleting `build-macos-qt.yml`, the prebuilt-tarball download, the ~2 h
from-source fallback and its cache. Qt 6.8 targets macOS 12+, below Intel's
13.0 deployment target, so it should just work. Left alone because it is not
§1, it changes a second release leg, and #4532 suggests that leg has history
worth reading first.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no settings touched
- [x] Code is clean-room — CI configuration, a build script, and a
      build-system fix (`CMakeLists.txt`) derived from the on-disk layout of
      Qt's own macOS packages

