### PR TITLE
fix(hl2): mic gain reached nothing, and the wattmeter read voice ~3.5 dB low

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,53 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **Hermes-Lite 2: the MIC slider reached nothing, and the wattmeter read voice
+  ~3.5 dB low (#4696).** Reported from the bench as 6 W out on FT8 and WSPR but
+  never more than 1 W on SSB voice, at every mic and RF level, with and without
+  the compressor. Three faults, and the first is why the other two were
+  invisible.
+
+  *The wattmeter was measuring the wrong thing on voice.* Forward power was
+  published as the raw instantaneous sample from the HL2's directional coupler
+  — one 12-bit conversion from the `slow_adc` I2C converter, round-robined with
+  reverse power, temperature and bias current, with no peak detector and no
+  averaging anywhere in the gateware, reaching us at 10 Hz. Speech peaks last
+  tens of milliseconds, so sampling that envelope at 10 Hz lands on a peak
+  essentially never, while a constant-envelope FT8 or WSPR transmission — where
+  every instant *is* the peak — read full scale. The same transmitter making the
+  same power read very differently depending on what was modulating it. It is
+  now published through a peak hold (instant attack, ~2 s release, in watts
+  because the calibration curve is markedly non-linear). This does not recover
+  an instantaneous PEP reading — no filter can recover a peak that was never
+  sampled — it accumulates the maximum across a transmission, so the reading
+  climbs toward PEP as the over goes on; the meter is labelled "peak estimate"
+  rather than claiming to be a measurement. Measured on a live HL2 into a dummy
+  load, voice peaks now read **4.6 W where they read 1.7 W before**, and a
+  constant carrier is unchanged (2.642 W held against 2.637 W instantaneous),
+  which is the control case a hold must not inflate. `MeterModel`'s own
+  ballistics are untouched, so no Flex behaviour changes.
+
+  *Mic gain was wired to nothing.* The Phone applet's MIC slider emits a Flex
+  `transmit set miclevel=` verb, which a backend with no command plane drops,
+  and nothing bridged it to the host modulator — so sweeping the slider end to
+  end changed nothing on the air. The client-side fallback could not fire
+  either, being gated on a `mic_selection` an HL2 never reports. The slider now
+  reaches the modulator's pre-ALC gain through the same seam the TX passband
+  uses, with 50 as unity so an untouched slider leaves every existing install
+  exactly where it was. This is what carries a quiet microphone over the ALC's
+  hold threshold, which is what the "raise mic gain" diagnostic has been
+  advising since it shipped — at a control that did nothing on this backend.
+
+  *And the readback agreed with the failure.* Every readback available while mic
+  gain was dead reported the requesting side, so all of them agreed the control
+  worked. A confirmation sourced from the requester cannot detect a request that
+  never arrived. The modulator now echoes its own gain, and the Radio Health
+  dialog gained a **Transmit voice chain** section reporting both the operator's
+  request and what the modulator is actually running — mic level and applied
+  gain, mic peak for the current over, the ALC hold threshold, ALC gain and
+  post-ALC peak, the passband in use, and both instantaneous and held forward
+  power.
+
 - **Amplifier bar gauges no longer keep painting the old scale after the range
   changes (#4636).** When a gauge's scale is re-derived from live telemetry —
   the ACOM auto-range as forward power outgrows its tier, an SPE LOW/MID/HIGH
@@ -51,6 +98,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   with no cause at all.
 
 ### Added
+
+- **`health` automation-bridge verb (#4696).** Returns the backend's own health
+  snapshot — the rows the Radio Health dialog shows, which until now reached
+  nothing else and so were unavailable to any script or regression test.
+  Deliberately *not* assembled from the models: `get` already reports those, and
+  a model reports what the operator **asked for**, which is why a control whose
+  command was dropped on the way to the radio could read back as working. Every
+  row here comes from the backend instead, so the two can be compared and the
+  comparison is the diagnosis. Read-only and TX-safe — it keys nothing and sets
+  nothing. A `null` value means the radio never reported that row, kept distinct
+  from a zero because "the FIFO is empty" and "we were never told" are different
+  answers.
 
 - **The aarch64 (Raspberry Pi / ARM) AppImage now ships Qt 6.8.3 LTS and
   GPU spectrum rendering (#4670).** It was the only release artifact still

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5195,6 +5195,11 @@ add_executable(host_voice_chain_policy_test
 )
 target_include_directories(host_voice_chain_policy_test PRIVATE src)
 add_test(NAME host_voice_chain_policy_test COMMAND host_voice_chain_policy_test)
+add_executable(hl2_tx_level_policy_test
+    tests/hl2_tx_level_policy_test.cpp
+)
+target_include_directories(hl2_tx_level_policy_test PRIVATE src)
+add_test(NAME hl2_tx_level_policy_test COMMAND hl2_tx_level_policy_test)
 add_executable(slice_link_policy_test
     tests/slice_link_policy_test.cpp
 )

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -2894,7 +2894,7 @@ lands.
 The complete registry, generated from the `add(...)` table in `AutomationServer.cpp` by `tools/gen_bridge_docs.py`. CI fails if this drifts from the code.
 
 <!-- BEGIN GENERATED VERB TABLE (tools/gen_bridge_docs.py) -->
-<!-- Do not edit by hand — run tools/gen_bridge_docs.py. 57 verbs. -->
+<!-- Do not edit by hand — run tools/gen_bridge_docs.py. 58 verbs. -->
 
 | Verb | Aliases | Description |
 |---|---|---|
@@ -2952,6 +2952,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `midi` | — | midi cc <0-127> — inject a learned VFO Tune Knob CC event |
 | `menu` | — | menu list \| open <name> — menu-bar menus |
 | `whoami` | — | bridge instance info: pid, socket, label, station, txAllowed |
+| `health` | — | backend health snapshot — what the RADIO reports, not what was asked for |
 | `log` | — | log <categories\|get\|set\|reset\|tail\|subscribe\|unsubscribe> [args] |
 | `mark` | — | mark <text> — timestamped annotation in the log ring |
 | `qrz` | — | qrz <status\|cached\|lookup\|spottext> [args] |

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -306,6 +306,7 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 | | [`grab pan-visible <index> [path]`](#grab) | Pan applet incl. VFO/flag overlays (alias `pan-composite`). |
 | | [`floors`](#floors) | Per-pan measured noise + display floor (dBm). |
 | | [`whoami`](#whoami) | This bridge instance: pid, socket, label, station, `txAllowed`, `readOnly`. |
+| | [`health`](#health) | Backend health snapshot — what the **radio** reports, not what was asked for. |
 | **Drive** | [`invoke <target> <action> [v]`](#invoke) | Click/toggle/set/selectRow/submit/trigger a control (TX-guarded). |
 | | [`close <target>`](#close) | Close the target's top-level window. |
 | | [`drag <target> "<dx> <dy>"`](#drag-alias-mouse) | Synthesize press→move→release (alias `mouse`). |
@@ -2407,6 +2408,38 @@ its own per-pid socket + discovery entry).
 `txAllowed` reports whether `AETHER_AUTOMATION_ALLOW_TX` is set for this process —
 check it before assuming a keying verb will work. `label` is
 `AETHER_AUTOMATION_LABEL` (a human tag for the instance).
+
+### `health`
+The **backend's** view of the radio — the same rows the Radio Health dialog
+shows, which until now reached nothing else and so were unavailable to a script
+or a regression test. Read-only: it keys nothing and sets nothing.
+
+```json
+→ {"cmd":"health"}
+← {"ok":true,"connected":true,"rows":[
+     {"key":"micLevel","section":"Transmit voice chain",
+      "label":"Mic slider (0-100, 50 = unity)","value":80},
+     {"key":"micGainAppliedLinear",
+      "label":"Mic gain at the modulator (linear)","value":3.98},
+     {"key":"forwardPowerPeakW",
+      "label":"Forward (W, approx — peak estimate)","value":4.56}]}
+```
+
+**This is deliberately not assembled from the models, and that is the whole
+point.** `get` already reports those, and a model reports what the operator
+**asked for** — so a control whose command was dropped on the way to the radio
+reads back as though it worked. Every row here comes from the backend instead,
+so the two can be compared and the comparison is the diagnosis. The HL2's mic
+gain was exactly that failure: the slider moved, every readback agreed, and the
+modulator never heard about it.
+
+`rows` is ordered as the dialog renders it; `section` appears on the first row
+of each group and is absent on the rest. A `value` of `null` means **the radio
+never reported this**, which is distinct from a zero — "the FIFO is empty" and
+"we were never told" are different answers, and collapsing them is what makes a
+readout unable to detect its own failure. An empty `rows` array with
+`"ok":true` is a real state too: no radio connected, or a family that publishes
+no health rows. Check `connected` to tell those apart.
 
 ### `mark`
 Drop a **sequenced timeline marker** into the log ring, then bracket a sequence

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -2490,6 +2490,8 @@ bool isReadOnlyRequest(const QString& name, const QString& action)
         QStringLiteral("whoami"),   QStringLiteral("dumpTree"),
         QStringLiteral("grab"),     QStringLiteral("get"),
         QStringLiteral("floors"),   QStringLiteral("hitTest"),
+        // Reads backend telemetry; keys nothing and sets nothing.
+        QStringLiteral("health"),
     };
     if (kSafe.contains(name)) {
         return true;
@@ -3212,6 +3214,10 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
         add("whoami", {}, "bridge instance info: pid, socket, label, station, txAllowed",
             parseTargetPath,
             [](AutomationServer& s, A&, QLocalSocket*) { return s.doWhoami(); });
+
+        add("health", {}, "backend health snapshot — what the RADIO reports, not what was asked for",
+            parseTargetPath,
+            [](AutomationServer& s, A&, QLocalSocket*) { return s.doHealth(); });
 
         add("log", {}, "log <categories|get|set|reset|tail|subscribe|unsubscribe> [args]",
             parseActionRest,
@@ -5692,6 +5698,57 @@ void AutomationServer::finishConnectWait(const std::shared_ptr<ConnectWait>& wai
     }
 
     writeJsonResponse(socket, response);
+}
+
+// ── Backend health snapshot ─────────────────────────────────────────────────
+// The backend's own view of the radio, surfaced over the bridge. Until now this
+// reached only the Radio Health dialog, so anything it knew was unavailable to a
+// script and therefore unavailable to a regression test.
+//
+// This is deliberately NOT assembled from the models. `get` already reports
+// those, and a model reports what the operator ASKED for — which is why a
+// control whose command was dropped could read back as working. Everything here
+// comes from the backend, so the two can be compared and the comparison is the
+// diagnosis.
+//
+// Read-only and TX-safe: it keys nothing and changes nothing.
+QJsonObject AutomationServer::doHealth()
+{
+    if (!m_radioModel)
+        return err(QStringLiteral("no radio model available"));
+
+    const IRadioBackend::HealthSnapshot snap = m_radioModel->backendHealthSnapshot();
+    if (snap.isEmpty()) {
+        // Not an error: a backend with nothing to report is a real state (no
+        // radio connected, or a family that publishes no health rows). Say which
+        // rather than returning an empty object the caller has to guess about.
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("connected"), m_radioModel->isConnected()},
+                           {QStringLiteral("rows"), QJsonArray{}}};
+    }
+
+    QJsonArray rows;
+    for (const QString& key : snap.order) {
+        QJsonObject row;
+        row[QStringLiteral("key")] = key;
+        if (const auto label = snap.labels.constFind(key); label != snap.labels.constEnd())
+            row[QStringLiteral("label")] = *label;
+        if (const auto sect = snap.sections.constFind(key); sect != snap.sections.constEnd())
+            row[QStringLiteral("section")] = *sect;
+        // A key absent from `values` means "the radio never reported this",
+        // which the dialog renders as "not reported". Preserve that as JSON
+        // null rather than coercing to 0 or "" — the difference between "the
+        // FIFO is empty" and "we were never told" is the whole value of the row.
+        const auto v = snap.values.constFind(key);
+        row[QStringLiteral("value")] = v != snap.values.constEnd()
+            ? QJsonValue::fromVariant(*v)
+            : QJsonValue(QJsonValue::Null);
+        rows.append(row);
+    }
+
+    return QJsonObject{{QStringLiteral("ok"), true},
+                       {QStringLiteral("connected"), m_radioModel->isConnected()},
+                       {QStringLiteral("rows"), rows}};
 }
 
 // ── TX test-signal control (#3646) ──────────────────────────────────────────

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -596,6 +596,9 @@ private:
     // TX test-signal control (two-tone) and ATU control. Both gated by
     // AETHER_AUTOMATION_ALLOW_TX where they key the transmitter.
     QJsonObject doTxTest(const QString& action);
+    // Backend-sourced radio health. Read-only; see the definition for why it is
+    // deliberately not assembled from the models.
+    QJsonObject doHealth();
     QJsonObject doAtu(const QString& action);
 
     void forceUnkey(const char* reason);  // emergency all-stop (tune/mox/two-tone)

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -310,6 +310,22 @@ public:
         Q_UNUSED(highHz);
     }
 
+    // Microphone gain, 0..100, as the Phone applet's MIC slider means it.
+    //
+    // Same seam and same reason as setTxFilter() above: on a Flex the slider's
+    // `transmit set miclevel=` reaches the radio's own preamp, but a backend
+    // that modulates on this host has no command plane to receive it and the
+    // verb is dropped. Without this the slider was inert on the HL2 — moving it
+    // end to end changed nothing on the air, which reads as a dead control
+    // rather than as a control aimed at hardware that is not there.
+    //
+    // A backend that takes this owns the gain: nothing else scales the mic on
+    // its behalf, so ignoring the call means the operator has no mic gain at all.
+    virtual void setMicGain(int level)
+    {
+        Q_UNUSED(level);
+    }
+
     // Processed transmit audio, int16 interleaved stereo at sampleRateHz.
     //
     // For backends that modulate on the host (HL2). A Flex radio does its own

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -23,6 +23,14 @@
 #include <cstdint>
 #include <utility>
 
+// Hl2Backend.h seeds m_alcHoldBelowDbfs with a literal because it can only
+// forward-declare Hl2TxDsp. This is what stops the two drifting: the seed has
+// to keep meaning "the modulator's own default" for a pre-connect snapshot to
+// be honest, and a silent divergence is exactly the class of readout error this
+// backend's health section exists to eliminate.
+static_assert(AetherSDR::hl2::Hl2TxDsp::Config{}.alcHoldBelowDbfs == -45.0,
+              "Hl2Backend.h seeds m_alcHoldBelowDbfs with this value — keep them equal");
+
 Q_LOGGING_CATEGORY(lcHl2Tx, "aether.hl2.tx")
 
 namespace AetherSDR::hl2 {
@@ -1630,6 +1638,11 @@ void Hl2Backend::connectRadio(const RadioConnectRequest& request)
         tc.filterLowHz  = txLo;
         tc.filterHighHz = txHi;
     }
+    // Remember the threshold the modulator was handed, so the health snapshot
+    // and the unkey diagnostic both report what it is RUNNING rather than what
+    // a default-constructed Config would have said. Assigned from `tc` and not
+    // from the default so it stays correct the day this Config sets the field.
+    m_alcHoldBelowDbfs = tc.alcHoldBelowDbfs;
     std::string txErr;
     bool txOk = false;
     QMetaObject::invokeMethod(m_txDsp, [this, &tc, &txErr, &txOk] {
@@ -2288,7 +2301,7 @@ void Hl2Backend::setKeying(bool key)
     // not log per block, and a per-block test would fire on every normal
     // transmission because the pauses between words are what the hold is for.
     if (m_keyed && !key) {
-        constexpr double kHoldDbfs = Hl2TxDsp::Config{}.alcHoldBelowDbfs;
+        const double kHoldDbfs = m_alcHoldBelowDbfs;
         if (m_txMicPeakMaxDbfs > -139.0f
             && m_txMicPeakMaxDbfs < static_cast<float>(kHoldDbfs)) {
             qCInfo(lcHl2) << "HL2 TX: microphone peaked at" << m_txMicPeakMaxDbfs
@@ -2781,9 +2794,18 @@ IRadioBackend::HealthSnapshot Hl2Backend::healthSnapshot() const
     // side, and a diagnosis is one comparison rather than a source dive.
     section("micLevel", QStringLiteral("Transmit voice chain"));
     put("micLevel", QStringLiteral("Mic slider (0-100, 50 = unity)"), m_micLevel);
-    put("micGainDb", QStringLiteral("Mic gain requested (dB)"),
-        m_micLevel == 0 ? QVariant(QStringLiteral("muted"))
-                        : QVariant(micSliderToGainDb(m_micLevel)));
+    // NUMERIC ON EVERY PATH. An earlier revision reported the string "muted"
+    // here at slider 0 and a number everywhere else, which reads fine in the
+    // dialog and breaks the bridge: `health` serialises this row straight to
+    // JSON, so any script comparing it changes type underneath itself at
+    // exactly the value most likely to be under a microscope. The mute is a
+    // separate FACT, not a gain — micSliderToLinear() short-circuits to 0.0
+    // rather than resolving the -20 dB this mapping would otherwise give it —
+    // so it is reported as its own row rather than smuggled into this one's
+    // type.
+    put("micGainDb", QStringLiteral("Mic gain requested (dB, continuous mapping)"),
+        micSliderToGainDb(m_micLevel));
+    put("micMuted", QStringLiteral("Mic muted (slider at 0)"), m_micLevel == 0);
     // THE ROW THAT WOULD HAVE CAUGHT THE ORIGINAL BUG. Echoed by the modulator,
     // so it stays absent — "not reported" — if the push never arrived, however
     // confidently the row above claims a value.
@@ -2796,8 +2818,14 @@ IRadioBackend::HealthSnapshot Hl2Backend::healthSnapshot() const
     // to lift it and the answer is mic gain.
     put("txMicPeakDbfs", QStringLiteral("Mic peak this over (dBFS)"),
         m_txMicPeakMaxDbfs > -139.0f ? QVariant(m_txMicPeakMaxDbfs) : QVariant());
+    // The threshold the modulator was actually CONFIGURED with, not the one a
+    // default-constructed Config would have. The two agree today because the
+    // Config built in connectRadio() never touches this field — but this row sits
+    // in a section whose thesis is "report what the modulator is running",
+    // and a constant that silently stops matching the modulator is the row
+    // nobody would think to suspect.
     put("alcHoldBelowDbfs", QStringLiteral("ALC hold threshold (dBFS)"),
-        Hl2TxDsp::Config{}.alcHoldBelowDbfs);
+        m_alcHoldBelowDbfs);
     put("alcGainDb", QStringLiteral("ALC gain applied (dB)"),
         std::isnan(m_alcGainDb) ? QVariant() : QVariant(m_alcGainDb));
     put("alcPeakDbfs", QStringLiteral("Post-ALC peak (dBFS)"),
@@ -2838,8 +2866,14 @@ IRadioBackend::HealthSnapshot Hl2Backend::healthSnapshot() const
     // On a constant-envelope carrier the two should very nearly agree, and a
     // held value ABOVE the instantaneous on TUNE would mean the release is
     // inflating the reading rather than holding it.
+    //
+    // Gated on the same optional as the instantaneous row above, so the pair
+    // says "never told" or "told" TOGETHER. Reported unconditionally this read
+    // a hard 0.0 before any telemetry, next to a neighbour saying "not
+    // reported" — and "0 W" from a wattmeter reads as a measurement, which is
+    // the one thing nothing in this section is allowed to fake.
     put("forwardPowerPeakW", QStringLiteral("Forward (W, approx — peak estimate)"),
-        m_fwdPeakWatts);
+        m_telemetry.forwardPowerRaw ? QVariant(m_fwdPeakWatts) : QVariant());
     put("reversePowerRaw", QStringLiteral("Reverse (raw counts)"),
         opt(m_telemetry.reversePowerRaw));
     put("reversePowerW", QStringLiteral("Reverse (W, approx)"),
@@ -2942,6 +2976,25 @@ void Hl2Backend::applyRestoredState(const RestoredRadioState& state)
     m_txFilterFromOperator = false;
     m_txFilterLowHz = 300;
     m_txFilterHighHz = 2700;
+    // Everything the voice chain OBSERVED goes back to "never reported". These
+    // rows answer "what was the chain doing on that over?", and carrying radio
+    // A's last ALC figures and held power under radio B's identity is worse
+    // than a blank row: it answers a question about this radio with a confident
+    // number measured on a different one.
+    m_alcGainDb = std::numeric_limits<double>::quiet_NaN();
+    m_alcPeakDbfs = std::numeric_limits<double>::quiet_NaN();
+    m_fwdPeakWatts = 0.0;
+    m_txMicPeakMaxDbfs = -140.0f;
+    // DELIBERATELY NOT RESET: m_micLevel and m_appliedMicGainLinear.
+    //
+    // Those two are not observations and not radio state — they are the
+    // operator's setting on a modulator that lives on THIS HOST, and a
+    // same-family swap does not rebuild it, so Hl2TxDsp genuinely still holds
+    // that gain. Blanking the mirror here would make the snapshot report "not
+    // reported" for a gain the modulator demonstrably has, which is the same
+    // class of lie in the opposite direction — and this section exists to make
+    // the applied gain checkable, not plausible. A swap that DOES rebuild the
+    // backend gets a fresh pair, re-asserted by RadioModel::setupBackend().
 
     RestoredRadioState valid;
     if (state.rfFrequencyHz >= 100'000.0 && state.rfFrequencyHz <= 38'400'000.0)

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -2828,9 +2828,18 @@ IRadioBackend::HealthSnapshot Hl2Backend::healthSnapshot() const
     section("forwardPowerRaw", QStringLiteral("Directional coupler (uncalibrated)"));
     put("forwardPowerRaw", QStringLiteral("Forward (raw counts)"),
         opt(m_telemetry.forwardPowerRaw));
-    put("forwardPowerW", QStringLiteral("Forward (W, approx)"),
+    put("forwardPowerW", QStringLiteral("Forward (W, approx — instantaneous)"),
         m_telemetry.forwardPowerRaw
             ? QVariant(directionalWatts(*m_telemetry.forwardPowerRaw)) : QVariant());
+    // The value the FWDPWR meter is actually driven from, next to the raw
+    // instantaneous sample it is derived from. Both, because the difference
+    // between them IS the diagnosis on SSB: a wide gap means the envelope is
+    // being sampled off its peaks, which is the whole reason the hold exists.
+    // On a constant-envelope carrier the two should very nearly agree, and a
+    // held value ABOVE the instantaneous on TUNE would mean the release is
+    // inflating the reading rather than holding it.
+    put("forwardPowerPeakW", QStringLiteral("Forward (W, approx — peak estimate)"),
+        m_fwdPeakWatts);
     put("reversePowerRaw", QStringLiteral("Reverse (raw counts)"),
         opt(m_telemetry.reversePowerRaw));
     put("reversePowerW", QStringLiteral("Reverse (W, approx)"),

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -8,6 +8,7 @@
 
 #include "core/backends/hl2/Hl2RxDsp.h"
 #include "core/backends/hl2/Hl2TxDsp.h"
+#include "core/backends/hl2/Hl2TxLevelPolicy.h"
 #include "core/backends/hl2/MetisClient.h"
 #include "core/backends/hl2/MetisProtocol.h"
 
@@ -419,8 +420,23 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
     // alcGain answers "how hard is the ALC working"; the gauge asks "how close
     // to full modulation am I", and on a chain whose ALC targets 0.85 those two
     // move in opposite directions.
-    connect(m_txDsp, &Hl2TxDsp::alcPeak, this,
-            [this](float dbfs) { emit meterUpdate(QStringLiteral("TX:ALC"), dbfs); });
+    connect(m_txDsp, &Hl2TxDsp::alcPeak, this, [this](float dbfs) {
+        m_alcPeakDbfs = dbfs;
+        emit meterUpdate(QStringLiteral("TX:ALC"), dbfs);
+    });
+    // alcGain drives no meter — TX:ALC is fed from alcPeak above, for the reason
+    // given there — but it is the number that answers "is the ALC holding?", so
+    // it is mirrored for healthSnapshot() and the bridge. Before this it was
+    // emitted into nothing, which is why a chain that was quietly refusing to
+    // lift a quiet mic could only be diagnosed by reading the source.
+    connect(m_txDsp, &Hl2TxDsp::alcGain, this,
+            [this](float db) { m_alcGainDb = db; });
+    // The modulator's own copy of the mic gain, for healthSnapshot(). Reported
+    // ALONGSIDE m_micLevel rather than instead of it: the operator's request and
+    // the modulator's state are different facts, and a diagnosis needs to see
+    // them disagree. See Hl2TxDsp::micGainChanged.
+    connect(m_txDsp, &Hl2TxDsp::micGainChanged, this,
+            [this](double linear) { m_appliedMicGainLinear = linear; });
 
     connect(m_metis, &MetisClient::telemetryUpdated, this,
             [this](const Hl2Telemetry& t) { publishTelemetry(t); });
@@ -2282,8 +2298,15 @@ void Hl2Backend::setKeying(bool key)
                              " audio went out quiet. Raise mic gain.";
         }
     }
-    if (key)
+    if (key) {
         m_txMicPeakMaxDbfs = -140.0f;
+        // Start each transmission's peak hold from nothing, rather than trusting
+        // the unkeyed branch in publishTelemetry() to have already walked it
+        // down. Telemetry is 10 Hz, so a key inside 100 ms of the previous unkey
+        // can arrive before any no-carrier sample does, and the new over would
+        // open displaying the old one's peak.
+        m_fwdPeakWatts = 0.0;
+    }
 
     m_keyed = key;
     // MUTE RECEIVE AUDIO WHILE TRANSMITTING.
@@ -2597,6 +2620,45 @@ void Hl2Backend::setTxFilter(int lowHz, int highHz)
     notifyOperatingStateChanged();
 }
 
+// The Phone applet's MIC slider, 0..100, onto the modulator's linear pre-ALC gain.
+//
+// 50 IS UNITY, and that is load-bearing rather than cosmetic. TransmitModel
+// constructs m_micLevel at 50 and nothing restores it at startup, so a session
+// where the operator never touches the slider must leave the modulator exactly
+// where its own default (m_micGain = 1.0) puts it. A mapping with unity anywhere
+// else would silently change the transmit level of every existing HL2 install
+// the first time this code shipped.
+//
+// Above and below that, +/-20 dB linear in dB — 0.4 dB per slider step, which is
+// fine enough to set by ear and wide enough to cover the range between a headset
+// boom mic and a built-in laptop microphone.
+//
+// WHAT THIS DOES AND DOES NOT BUY, because the ALC sits right behind it:
+// Hl2TxDsp's ALC normalizes each block's peak to alcTargetPeak, so raising mic
+// gain on already-loud speech is largely given back and PEP barely moves. Where
+// it MATTERS is the ALC's hold threshold (alcHoldBelowDbfs, -45 dBFS): below
+// that the ALC deliberately stops lifting, so a microphone quiet enough to sit
+// under it gets no makeup at all and goes out weak. This slider is what carries
+// such a mic over the threshold — which is exactly what setKeying()'s "raise mic
+// gain" diagnostic tells the operator to do, and until now that advice pointed
+// at a control that did nothing on this backend.
+//
+// Level 0 mutes outright rather than resolving to -20 dB. A slider at the bottom
+// of its travel means off, and a mic that is merely 20 dB down would still be
+// hauled back up by the ALC's 40 dB of makeup — so without the special case,
+// "0" would sound barely different from "50".
+void Hl2Backend::setMicGain(int level)
+{
+    level = std::clamp(level, 0, 100);
+    m_micLevel = level;
+
+    const double linear = micSliderToLinear(level);
+
+    if (m_txDsp)
+        QMetaObject::invokeMethod(m_txDsp, "setMicGain", Qt::QueuedConnection,
+            Q_ARG(double, linear));
+}
+
 void Hl2Backend::setTxPower(int percent)
 {
     // The operator's 0..100 maps onto the HL2's 0..255 drive field. The gateware
@@ -2704,6 +2766,56 @@ IRadioBackend::HealthSnapshot Hl2Backend::healthSnapshot() const
         opt(m_telemetry.txFifoUnderflow));
     put("txFifoOverflow", QStringLiteral("TX FIFO overflow"),
         opt(m_telemetry.txFifoOverflow));
+
+    // THE VOICE CHAIN, END TO END, AS THE MODULATOR ACTUALLY RAN IT.
+    //
+    // Every row here is read from this backend rather than from TransmitModel.
+    // That distinction is the entire reason the section exists: the bridge's
+    // transmit snapshot reports the operator's REQUEST, so a control whose verb
+    // was dropped on the floor read back as though it had worked. Mic gain was
+    // exactly that — the slider moved, the snapshot agreed, and the modulator
+    // never heard about it. A readback that shares the failure it is meant to
+    // catch is worse than none, because it manufactures confidence.
+    //
+    // So: what the operator asked for AND what the modulator is running, side by
+    // side, and a diagnosis is one comparison rather than a source dive.
+    section("micLevel", QStringLiteral("Transmit voice chain"));
+    put("micLevel", QStringLiteral("Mic slider (0-100, 50 = unity)"), m_micLevel);
+    put("micGainDb", QStringLiteral("Mic gain requested (dB)"),
+        m_micLevel == 0 ? QVariant(QStringLiteral("muted"))
+                        : QVariant(micSliderToGainDb(m_micLevel)));
+    // THE ROW THAT WOULD HAVE CAUGHT THE ORIGINAL BUG. Echoed by the modulator,
+    // so it stays absent — "not reported" — if the push never arrived, however
+    // confidently the row above claims a value.
+    put("micGainAppliedLinear", QStringLiteral("Mic gain at the modulator (linear)"),
+        std::isnan(m_appliedMicGainLinear) ? QVariant()
+                                           : QVariant(m_appliedMicGainLinear));
+    // Peak mic level for the CURRENT transmission, reset at each key. Compared
+    // against the hold threshold below, these two rows are the whole "why did I
+    // go out quiet" diagnosis: a peak under the threshold means the ALC declined
+    // to lift it and the answer is mic gain.
+    put("txMicPeakDbfs", QStringLiteral("Mic peak this over (dBFS)"),
+        m_txMicPeakMaxDbfs > -139.0f ? QVariant(m_txMicPeakMaxDbfs) : QVariant());
+    put("alcHoldBelowDbfs", QStringLiteral("ALC hold threshold (dBFS)"),
+        Hl2TxDsp::Config{}.alcHoldBelowDbfs);
+    put("alcGainDb", QStringLiteral("ALC gain applied (dB)"),
+        std::isnan(m_alcGainDb) ? QVariant() : QVariant(m_alcGainDb));
+    put("alcPeakDbfs", QStringLiteral("Post-ALC peak (dBFS)"),
+        std::isnan(m_alcPeakDbfs) ? QVariant() : QVariant(m_alcPeakDbfs));
+    // The passband the modulator is running RIGHT NOW, which on any mode other
+    // than SSB voice is NOT the operator's stored pair — effectiveTxPassband()
+    // deliberately declines to apply a voice setting to CW or the digital modes.
+    // Reporting the stored pair here would explain nothing on exactly the modes
+    // where the two disagree.
+    {
+        const Receiver* txRx = rx(m_txDdc);
+        const QString txMode = txRx ? txRx->mode : QStringLiteral("USB");
+        const auto [lo, hi] = effectiveTxPassband(txMode);
+        put("txPassbandHz", QStringLiteral("TX passband in use (Hz)"),
+            QStringLiteral("%1 .. %2").arg(lo).arg(hi));
+        put("txPassbandFromOperator", QStringLiteral("TX passband is an operator override"),
+            m_txFilterFromOperator);
+    }
 
     section("temperatureC", QStringLiteral("Analog / thermal"));
     put("temperatureC", QStringLiteral("PA temperature (°C)"),
@@ -3243,7 +3355,7 @@ void Hl2Backend::defineMeters()
     // little above the top of the reference curve. A 50 dBm (100 W) scale would
     // leave every real HL2 reading in the bottom tenth of the meter.
     def(2, QStringLiteral("TX"),  QStringLiteral("FWDPWR"),  QStringLiteral("dBm"),
-        0.0, 41.0,     QStringLiteral("Forward power (uncalibrated)"));
+        0.0, 41.0,     QStringLiteral("Forward power, peak estimate (uncalibrated)"));
     def(3, QStringLiteral("TX"),  QStringLiteral("REFPWR"),  QStringLiteral("dBm"),
         0.0, 41.0,     QStringLiteral("Reflected power (uncalibrated)"));
     def(4, QStringLiteral("TX"),  QStringLiteral("SWR"),     QStringLiteral("SWR"),
@@ -3308,9 +3420,21 @@ void Hl2Backend::publishTelemetry(const Hl2Telemetry& t)
     // Arrives at the 10 Hz MetisClient already paces telemetry at
     // (kTelemetryMinIntervalMs), so no further rate gate is needed here;
     // MeterModel applies its own forward-power ballistics on top.
-    if (t.forwardPowerRaw)
-        emit meterUpdate(QStringLiteral("TX:FWDPWR"),
-                         wattsToDbm(directionalWatts(*t.forwardPowerRaw)));
+    //
+    // Published through the peak hold, not raw. See kFwdPeakReleaseAlpha for
+    // why a 10 Hz instantaneous sample of a speech envelope reads ~10 dB low
+    // and what the hold does and does not recover.
+    if (t.forwardPowerRaw) {
+        const double instantW = directionalWatts(*t.forwardPowerRaw);
+        // The hold applies only while keyed. Unkeyed, the reading must fall to
+        // zero on the same schedule REFPWR does — MeterModel snaps its own
+        // forward-power filter to zero the moment a no-carrier sample arrives,
+        // and a hold that outlived the transmission would keep re-arming it,
+        // leaving the gauge claiming power out of a radio that has stopped.
+        m_fwdPeakWatts = fwdPeakHoldStep(m_fwdPeakWatts, instantW, m_keyed,
+                                         kFwdPeakReleaseAlpha);
+        emit meterUpdate(QStringLiteral("TX:FWDPWR"), wattsToDbm(m_fwdPeakWatts));
+    }
     if (t.reversePowerRaw)
         emit meterUpdate(QStringLiteral("TX:REFPWR"),
                          wattsToDbm(directionalWatts(*t.reversePowerRaw)));

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -13,6 +13,7 @@
 #include "core/backends/hl2/MetisProtocol.h"   // Hl2Telemetry
 
 #include <deque>
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -83,6 +84,7 @@ public:
     void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz) override;
     void setTxPower(int percent) override;
     void setTxFilter(int lowHz, int highHz) override;
+    void setMicGain(int level) override;
     // No default argument here on purpose: defaults on virtuals bind statically,
     // so repeating the base's is how the two quietly diverge later. The sole
     // call site passes it explicitly.
@@ -523,6 +525,76 @@ private:
     static constexpr double kPaTempAlpha = 0.2;
     double m_paTempC = 0.0;
     bool   m_havePaTemp = false;
+
+    // ---- Forward-power peak hold ----
+    //
+    // WHY THE SHARED BALLISTICS ABOVE ARE NOT ENOUGH HERE, and why this is a
+    // peak ESTIMATE rather than a peak measurement.
+    //
+    // A Flex reports FWDPWR from a detector the radio itself peak-reads, so
+    // MeterModel's fast-attack EMA is smoothing an already-peak-tracking
+    // signal. The HL2 has nothing of the kind: forward power is one 12-bit
+    // conversion from the `slow_adc` I2C converter, round-robined with reverse
+    // power, temperature and bias current, with no peak detector and no
+    // averaging anywhere in the gateware (rtl/slow_adc.v, rtl/control.v ~L262 —
+    // tier 1 on the source-precedence ladder). Each reading is the RF envelope
+    // at whatever instant the I2C transaction happened to land, and we see one
+    // every kTelemetryMinIntervalMs.
+    //
+    // Speech peaks last tens of milliseconds. Sampling that envelope at 10 Hz
+    // lands on a peak essentially never, so an SSB reading sat 8-12 dB below
+    // PEP while a constant-envelope FT8 or WSPR transmission — where every
+    // instant IS the peak — read full scale. That is the whole of the reported
+    // "6 W on FT8, 1 W on voice": both were making the same PEP.
+    //
+    // No host-side filter can recover a peak that was never sampled. What a
+    // hold CAN do is accumulate the maximum across a transmission: ~30
+    // independent samples in a 3 s over lands within a few dB of true PEP, and
+    // converges further the longer the operator talks. So this is honest as an
+    // estimate that settles, and dishonest as an instantaneous reading — which
+    // is why the meter description says so and why the raw counts keep being
+    // logged and published for the bridge alongside it.
+    //
+    // Instant attack, slow release, in WATTS rather than counts because the
+    // calibration curve is markedly non-linear and a peak held in counts would
+    // decay at a rate that changed with level.
+    //
+    // 0.05 per 10 Hz sample is a ~2 s release, matching what an outboard PEP
+    // wattmeter does. Slower would keep a peak past the end of the over; faster
+    // would decay between syllables and give the reading back to the average,
+    // which is exactly the failure this exists to fix.
+    static constexpr double kFwdPeakReleaseAlpha = 0.05;
+    double m_fwdPeakWatts = 0.0;
+
+    // Operator's MIC slider position, 0..100. Kept alongside the value pushed
+    // into the modulator so the automation bridge and any diagnostic can report
+    // what the operator asked for, not just the linear gain it became — the two
+    // are related by a mapping that is easy to get backwards when reading a log.
+    // 50 is unity; see setMicGain().
+    int m_micLevel = 50;
+
+    // ---- Voice-chain mirrors, for healthSnapshot() ----
+    //
+    // Same reason as m_drops and m_linkCounters above: these originate on the
+    // DSP worker, and healthSnapshot() is called from the GUI thread. Mirroring
+    // on signal delivery means the readout is a plain read of a value that
+    // already lives on the reading thread, instead of reaching across for it.
+    //
+    // Both are published as meters too. They are ALSO kept here because a meter
+    // is a stream nobody can query after the fact, and the whole point of
+    // exposing these is answering "what was the chain doing on that over?" — a
+    // question the operator asks once the over is finished.
+    //
+    // NaN, not 0, for "never reported": the ALC applying 0 dB is a real and
+    // common state, so a zero default would be indistinguishable from a
+    // modulator that has never run.
+    double m_alcGainDb = std::numeric_limits<double>::quiet_NaN();
+    double m_alcPeakDbfs = std::numeric_limits<double>::quiet_NaN();
+    // The linear gain the MODULATOR holds, echoed back by Hl2TxDsp rather than
+    // computed here. NaN until the modulator has confirmed one, so "the push
+    // never landed" is distinguishable from "it landed at unity" — which is the
+    // exact pair that was indistinguishable while this control was dead.
+    double m_appliedMicGainLinear = std::numeric_limits<double>::quiet_NaN();
 
     // Fraction of the half-span the slice may occupy before the NCO re-centres.
     // 0.8 leaves the outer 20% of each side for filter roll-off.

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -563,6 +563,16 @@ private:
     // wattmeter does. Slower would keep a peak past the end of the over; faster
     // would decay between syllables and give the reading back to the average,
     // which is exactly the failure this exists to fix.
+    //
+    // ONE DOWNSTREAM CONSEQUENCE, stated because it is not obvious: TxApplet
+    // runs its own ~2 s PEP hold + linear decay on the FWDPWR gauge (#2561),
+    // fed from MeterModel::txPeakChanged and documented there as taking the
+    // "pre-smoothed" sample. On this backend that sample is now itself held, so
+    // the applet's PEP tick and the gauge fill converge on the same number
+    // where they diverge on a Flex. That is the honest outcome rather than a
+    // defect — the fill is a peak estimate here BECAUSE the hardware gives us
+    // nothing to smooth — but the applet's tick carries no extra information on
+    // an HL2, and anyone reading the two as independent would be wrong.
     static constexpr double kFwdPeakReleaseAlpha = 0.05;
     double m_fwdPeakWatts = 0.0;
 
@@ -595,6 +605,19 @@ private:
     // never landed" is distinguishable from "it landed at unity" — which is the
     // exact pair that was indistinguishable while this control was dead.
     double m_appliedMicGainLinear = std::numeric_limits<double>::quiet_NaN();
+
+    // The ALC hold threshold the modulator was CONFIGURED with, captured from
+    // the Config that connectRadio() hands it. Read by healthSnapshot() and by
+    // setKeying()'s "raise mic gain" diagnostic, both of which previously
+    // re-derived it from a default-constructed Config and so would have gone on
+    // reporting -45 dBFS the day connectRadio() set the field to anything else.
+    //
+    // Seeded with Config's own default so a snapshot taken before the first
+    // connect still reports what the modulator would use. The literal is spelt
+    // out because Hl2TxDsp is only forward-declared in this header — a
+    // static_assert in Hl2Backend.cpp pins it to Config's default, so the two
+    // cannot drift silently.
+    double m_alcHoldBelowDbfs = -45.0;
 
     // Fraction of the half-span the slice may occupy before the NCO re-centres.
     // 0.8 leaves the outer 20% of each side for filter roll-off.

--- a/src/core/backends/hl2/Hl2TxDsp.cpp
+++ b/src/core/backends/hl2/Hl2TxDsp.cpp
@@ -138,6 +138,9 @@ void Hl2TxDsp::setFilter(double lowHz, double highHz)
 void Hl2TxDsp::setMicGain(double linear)
 {
     m_micGain = linear < 0.0 ? 0.0 : linear;
+    // Echo what was actually stored, not the argument — the clamp above is
+    // exactly the sort of thing a readout needs to see rather than assume.
+    emit micGainChanged(m_micGain);
 }
 
 double Hl2TxDsp::alcGainDb() const noexcept

--- a/src/core/backends/hl2/Hl2TxDsp.h
+++ b/src/core/backends/hl2/Hl2TxDsp.h
@@ -109,6 +109,16 @@ signals:
     // moves opposite to alcGain (the harder the ALC works on a quiet mic, the
     // closer to full scale this sits).
     void alcPeak(float dbfs);
+    // Echoed back from setMicGain, so a readout can report the gain THIS OBJECT
+    // holds rather than the caller's copy of what it asked for.
+    //
+    // That distinction is the whole reason this signal exists. Mic gain was
+    // dead on this backend for a release because the slider's Flex verb was
+    // dropped and nothing bridged it here — and every readback available at the
+    // time reported the requesting side, so all of them agreed the control
+    // worked. A confirmation sourced from the requester cannot detect a request
+    // that never arrived.
+    void micGainChanged(double linear);
 
 private:
     void designFilters();

--- a/src/core/backends/hl2/Hl2TxLevelPolicy.h
+++ b/src/core/backends/hl2/Hl2TxLevelPolicy.h
@@ -1,0 +1,88 @@
+#pragma once
+
+// The two level calculations on the HL2's transmit path, as pure functions.
+//
+// Both were live bugs rather than refinements, and both are the kind that a
+// running radio reports as "the control does nothing" — which is the hardest
+// symptom to act on, because it is indistinguishable from the operator having
+// misunderstood the control.
+//
+// They live in a header, evaluated by Hl2Backend rather than copied into it, so
+// the suite exercises the SAME expressions the backend runs. A test against a
+// re-typed copy of a mapping proves only that two copies agree; the convention
+// error it is meant to catch would sit in both.
+//
+// See Hl2Backend::setMicGain and Hl2Backend::publishTelemetry for the reasoning
+// about WHY each is shaped this way; this header is the arithmetic only.
+
+#include <cmath>
+
+namespace AetherSDR::hl2 {
+
+// ---- Microphone gain -------------------------------------------------------
+
+// The Phone applet's MIC slider (0..100) as dB of gain.
+//
+// 50 is unity, because TransmitModel constructs m_micLevel at 50 and nothing
+// restores it at startup: a session where the operator never touches the slider
+// must leave the modulator exactly at its own 1.0 default. +/-20 dB across the
+// travel, linear in dB.
+//
+// Level 0 is NOT -20 dB — see micSliderToLinear, which handles it as a mute.
+// This function is the continuous part of the mapping only.
+[[nodiscard]] constexpr double micSliderToGainDb(int level) noexcept
+{
+    const int clamped = level < 0 ? 0 : (level > 100 ? 100 : level);
+    return (static_cast<double>(clamped) - 50.0) * 0.4;
+}
+
+// The same slider as the linear multiplier the modulator takes.
+//
+// Level 0 mutes outright rather than resolving to the -20 dB the line above
+// would give it. A slider at the bottom of its travel means off — and a mic
+// merely 20 dB down would be hauled back up by the ALC's 40 dB of makeup
+// anyway, so without the special case "0" would sound barely different from
+// "50", which is the sort of control that teaches an operator to distrust every
+// other one on the panel.
+[[nodiscard]] inline double micSliderToLinear(int level) noexcept
+{
+    if (level <= 0)
+        return 0.0;
+    return std::pow(10.0, micSliderToGainDb(level) / 20.0);
+}
+
+// ---- Forward-power peak hold -----------------------------------------------
+
+// One step of the transmit forward-power peak hold, in watts.
+//
+// The HL2's forward power is a single 12-bit conversion from an I2C
+// instrumentation ADC with no peak detector and no averaging in the gateware
+// (rtl/slow_adc.v), reaching us at 10 Hz. Speech peaks last tens of
+// milliseconds, so sampling that envelope at 10 Hz lands on a peak essentially
+// never: an SSB reading sat 8-12 dB below PEP while constant-envelope FT8 —
+// where every instant IS the peak — read full scale. Both were making the same
+// power.
+//
+// Instant attack, exponential release. What this recovers is NOT an
+// instantaneous PEP reading; no filter can recover a peak that was never
+// sampled. What it does is accumulate the maximum ACROSS a transmission, so the
+// displayed value climbs toward PEP as the over goes on and settles within a
+// few dB of it.
+//
+// `keyed` is a real term, not a guard: unkeyed, the reading must follow the
+// instantaneous sample straight down, or a hold outliving the transmission
+// keeps re-arming MeterModel's filter and the gauge claims power out of a radio
+// that has stopped.
+[[nodiscard]] constexpr double fwdPeakHoldStep(double previousPeakW,
+                                               double instantW,
+                                               bool keyed,
+                                               double releaseAlpha) noexcept
+{
+    if (!keyed)
+        return instantW;
+    if (instantW >= previousPeakW)
+        return instantW;
+    return previousPeakW + releaseAlpha * (instantW - previousPeakW);
+}
+
+}  // namespace AetherSDR::hl2

--- a/src/core/backends/hl2/Hl2TxLevelPolicy.h
+++ b/src/core/backends/hl2/Hl2TxLevelPolicy.h
@@ -44,6 +44,18 @@ namespace AetherSDR::hl2 {
 // anyway, so without the special case "0" would sound barely different from
 // "50", which is the sort of control that teaches an operator to distrust every
 // other one on the panel.
+//
+// SCOPE, because "mic" undersells it: this multiplier is applied to everything
+// entering Hl2TxDsp::processAudioBlock, and on a host-modulating backend that
+// includes digital-mode and WSPR-beacon audio arriving through submitTxAudio,
+// not only voice. Above the ALC's hold threshold that is very nearly a no-op —
+// the ALC normalizes each block's peak to alcTargetPeak and hands the gain
+// straight back. At 0 it is not: the block is silent, silence sits below the
+// hold threshold so the ALC declines to lift it, and the beacon goes out muted
+// along with the microphone. That is the honest reading of a slider at the
+// bottom of its travel on a host modulator — there is one modulator and it is
+// off — but it is worth knowing before parking the control at 0 between voice
+// sessions.
 [[nodiscard]] inline double micSliderToLinear(int level) noexcept
 {
     if (level <= 0)

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -878,9 +878,17 @@ void MainWindow::wireRadioModel()
     // micSelection() is "MIC" until a radio reports otherwise, and an HL2 has no
     // command plane to report it, so neither branch of the old condition ever
     // ran and neither did the modulator's — the slider reached nothing at all.
+    //
+    // Through hostModulatesTxAudio() rather than reading caps.hostModulates
+    // bare: that helper is `hostModulates && canTransmit`, which is the form
+    // every other site in this file uses (see the connection-edge handler
+    // above) and the one QsoRecordStartPolicy.h names as canonical. A backend
+    // declaring hostModulates without canTransmit would otherwise lose the PC
+    // path here and get nothing back, since RadioModel's seam would be pushing
+    // gain into a modulator that can never key.
     connect(m_appletPanel->phoneCwApplet(), &PhoneCwApplet::micLevelChanged,
             this, [this](int level) {
-        if (m_radioModel.backendCapabilities().hostModulates)
+        if (hostModulatesTxAudio())
             return;
         if (m_radioModel.transmitModel().micSelection() == "PC" || m_audio->isRadeMode()) {
             m_audio->setPcMicGain(level);

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -864,8 +864,24 @@ void MainWindow::wireRadioModel()
 #endif
     // Sync PC mic gain directly from slider. In RADE mode, the radio's mic input
     // is unused — the slider controls client-side gain regardless of mic_selection.
+    //
+    // EXCEPT on a backend that modulates on this host, where the SAME slider
+    // already reaches Hl2TxDsp's pre-ALC gain through TransmitModel::setMicLevel
+    // and the seam bridge in RadioModel. Letting both run would apply the
+    // operator's gain TWICE, in series, which is not what a slider labelled once
+    // can mean. The modulator's is the one to keep: setPcMicGain only ever
+    // attenuates (0..100 maps to 0.0..1.0, and AudioEngine skips it entirely at
+    // unity), while the ALC behind the modulator needs the mic pushed UP past
+    // its hold threshold — see Hl2Backend::setMicGain.
+    //
+    // This gate is also why the control was dead rather than doubled before now:
+    // micSelection() is "MIC" until a radio reports otherwise, and an HL2 has no
+    // command plane to report it, so neither branch of the old condition ever
+    // ran and neither did the modulator's — the slider reached nothing at all.
     connect(m_appletPanel->phoneCwApplet(), &PhoneCwApplet::micLevelChanged,
             this, [this](int level) {
+        if (m_radioModel.backendCapabilities().hostModulates)
+            return;
         if (m_radioModel.transmitModel().micSelection() == "PC" || m_audio->isRadeMode()) {
             m_audio->setPcMicGain(level);
             auto& s = AppSettings::instance();

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1569,6 +1569,14 @@ RadioModel::RadioModel(QObject* parent)
             m_backend->setTxFilter(lowHz, highHz);
     });
 
+    // Mic gain reaches a host-modulating backend the same way and under the same
+    // rule: operator intent only, and only where the Flex verb cannot land.
+    connect(&m_transmitModel, &TransmitModel::micLevelCommandIssued, this,
+            [this](int level) {
+        if (m_backend && !usesFlexCommandPlane())
+            m_backend->setMicGain(level);
+    });
+
     // Forward transmit model commands to the radio
     connect(&m_transmitModel, &TransmitModel::commandReady, this, [this](const QString& cmd){
         const QString trimmed = cmd.trimmed();

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1163,6 +1163,32 @@ void RadioModel::setupBackend(const QString& family)
     if (m_panStream)
     connect(m_panStream, &PanadapterStream::meterDataReady,
             &m_meterModel, &MeterModel::updateValues);
+
+    // HAND THE FRESH BACKEND THE MIC GAIN THE MODEL ALREADY HOLDS.
+    //
+    // The seam wired in the constructor carries operator INTENT — it fires when
+    // the slider moves, and a backend rebuild is not the slider moving. So
+    // without this, a family swap silently parts the two: the new modulator is
+    // constructed at its own 1.0 default (Hl2TxDsp::m_micGain) while
+    // TransmitModel::m_micLevel still holds the operator's position, because
+    // nothing resets that model and micLevel is not persisted for
+    // applyRestoredState() to restore. Connect an HL2, set MIC to 80, visit the
+    // demo or a Flex, come back: the slider reads 80, the snapshot's micLevel
+    // reads 80, and the radio is transmitting at unity.
+    //
+    // That is the readback-agreeing-with-the-failure shape this whole change
+    // exists to eliminate, so it cannot be left standing one seam over. Pushing
+    // here rather than in the connect path because the disagreement is created
+    // by CONSTRUCTION, not by connecting — the modulator is wrong the moment it
+    // exists, and a backend that is never connected should still answer
+    // healthSnapshot() honestly.
+    //
+    // Free on the constructor's own call, where TransmitModel is at its 50 and
+    // 50 maps to the 1.0 the modulator already holds. Same Flex gate as the
+    // seam: on a Flex the slider's `transmit set miclevel=` reaches the radio's
+    // own preamp and this must not double it.
+    if (m_backend && !usesFlexCommandPlane())
+        m_backend->setMicGain(m_transmitModel.micLevel());
 }
 
 void RadioModel::applyBackendLinkStats(const IRadioBackend::LinkStats& stats)

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -460,6 +460,12 @@ void TransmitModel::setMicLevel(int level)
         m_micLevel = level;
         emit micStateChanged();  // PhoneCwApplet's mic slider binds to this
     }
+    // Unconditional, like commandReady below and deliberately NOT inside the
+    // changed test: a host-modulating backend is the authority on its own gain
+    // and may have been reset (reconnect, radio swap) while m_micLevel stood
+    // still. Re-asserting a value the seam already holds is free; failing to
+    // re-assert one it has lost leaves the operator's slider lying.
+    emit micLevelCommandIssued(level);
     emit commandReady(QString("transmit set miclevel=%1").arg(level));
 }
 

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -320,6 +320,11 @@ signals:
     // (Principle II). Distinct from txFilterCutoffChanged, which also fires when
     // a Flex's own status moves the value.
     void txFilterCommandIssued(int lowHz, int highHz);
+    // The operator moved the MIC slider. OPERATOR INTENT ONLY, for exactly the
+    // reason txFilterCommandIssued carries above: applyStatus() must never emit
+    // this, or a Flex's own `transmit set miclevel=` echo would be handed
+    // straight back to the seam as a fresh command.
+    void micLevelCommandIssued(int level);
     // The operator moved PROC or its NOR/DX/DX+ level. OPERATOR INTENT ONLY,
     // for the same reason as txFilterCommandIssued — and here the distinction is
     // what protects the operator's own work: the client compressor these drive is

--- a/tests/hl2_family_transition_test.cpp
+++ b/tests/hl2_family_transition_test.cpp
@@ -202,6 +202,49 @@ int main(int argc, char** argv)
     check(model.slices().isEmpty(),
           "F1: no slice models carried across the family switches");
 
+    // ── Mic gain survives the backend rebuild ───────────────────────────────
+    //
+    // THE FAILURE THIS PINS. A family switch destroys the backend and builds a
+    // fresh one, so the new Hl2TxDsp starts at its own 1.0 default. But the
+    // seam carrying mic gain to a host-modulating backend fires on operator
+    // INTENT — the slider moving — and a rebuild is not the slider moving.
+    // TransmitModel is never reset and micLevel is not persisted, so without an
+    // explicit re-assert the slider goes on reading the operator's value while
+    // the modulator sits at unity, and the radio transmits several dB below
+    // what every readout claims.
+    //
+    // That is exactly the readback-agrees-with-the-failure shape the mic-gain
+    // fix exists to eliminate, displaced one seam over, so it gets its own pin.
+    // Break it by deleting the re-assert at the end of
+    // RadioModel::setupBackend() and this check fails with micLevel still at
+    // its 50 default.
+    //
+    // Asserted on micLevel rather than on micGainAppliedLinear because the
+    // latter is echoed back from the DSP worker thread and would need a running
+    // event loop to arrive; the modulator-side half is covered by
+    // hl2_txdsp_test and the loopback test. What is proved here is that the
+    // fresh backend was told at all.
+    model.transmitModel().setMicLevel(80);
+    model.connectToRadio(hl2Info());
+    {
+        const auto snap = model.backendHealthSnapshot();
+        check(snap.values.value(QStringLiteral("micLevel")).toInt() == 80,
+              "mic gain is re-asserted into a rebuilt backend (slider and "
+              "modulator cannot silently part on a family switch)");
+    }
+
+    // And the operator's own default is carried just as faithfully: 50 maps to
+    // the modulator's 1.0, so the re-assert itself must not nudge a session
+    // that never touched the slider off unity.
+    model.connectToRadio(flexInfo());
+    model.transmitModel().setMicLevel(50);
+    model.connectToRadio(hl2Info());
+    {
+        const auto snap = model.backendHealthSnapshot();
+        check(snap.values.value(QStringLiteral("micLevel")).toInt() == 50,
+              "an untouched slider still lands on the modulator's unity point");
+    }
+
     if (g_failures == 0)
         std::fprintf(stderr, "hl2_family_transition_test: all checks passed\n");
     return g_failures == 0 ? 0 : 1;

--- a/tests/hl2_tx_level_policy_test.cpp
+++ b/tests/hl2_tx_level_policy_test.cpp
@@ -1,0 +1,132 @@
+// The HL2 transmit level calculations: mic gain, and the forward-power peak hold.
+//
+// Both fixed controls that were DEAD rather than wrong, which is why the cases
+// below lean on the boundaries rather than the middle of the range:
+//
+//   - Hl2TxDsp::setMicGain had no production caller at all. The Phone applet's
+//     MIC slider emitted `transmit set miclevel=`, which a backend with no
+//     command plane drops, and nothing bridged it to the modulator. Moving the
+//     slider end to end changed nothing on the air.
+//   - Forward power was published as the raw instantaneous sample from a 10 Hz
+//     I2C instrumentation ADC. On constant-envelope FT8 that reads PEP; on
+//     speech it reads ~10 dB low, so the same transmitter measured 6 W on FT8
+//     and 1 W on voice and the operator had no way to tell those apart.
+//
+// Hl2Backend evaluates these same functions rather than its own copy, so what
+// passes here is what the radio runs (core/backends/hl2/Hl2TxLevelPolicy.h).
+
+#include "core/backends/hl2/Hl2TxLevelPolicy.h"
+
+#include <cmath>
+#include <cstdio>
+
+using AetherSDR::hl2::fwdPeakHoldStep;
+using AetherSDR::hl2::micSliderToGainDb;
+using AetherSDR::hl2::micSliderToLinear;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool ok, const char* what)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", what);
+    if (!ok) ++g_failures;
+}
+
+bool near(double a, double b, double tol = 1e-9)
+{
+    return std::fabs(a - b) <= tol;
+}
+
+// The release constant Hl2Backend ships. Duplicated deliberately: if the
+// backend's value changes, the convergence case below should be re-reasoned
+// rather than silently tracking it.
+constexpr double kRelease = 0.05;
+
+}  // namespace
+
+int main()
+{
+    // ---- Mic gain ----------------------------------------------------------
+
+    // THE ONE THAT PROTECTS EXISTING INSTALLS. TransmitModel constructs
+    // m_micLevel at 50 and no startup path restores it, so 50 must land exactly
+    // on the modulator's own 1.0 default. Any other unity point would silently
+    // change the transmit level of every HL2 station the first time this shipped.
+    check(near(micSliderToGainDb(50), 0.0), "slider 50 is unity gain (0 dB)");
+    check(near(micSliderToLinear(50), 1.0), "slider 50 is unity linear (1.0)");
+
+    check(near(micSliderToGainDb(100), 20.0), "slider 100 is +20 dB");
+    check(near(micSliderToGainDb(1), -19.6), "slider 1 is -19.6 dB");
+
+    // A slider at the bottom means OFF. Without the special case it would be
+    // -20 dB, which the ALC's 40 dB of makeup would haul straight back up —
+    // making "0" sound much like "50".
+    check(near(micSliderToLinear(0), 0.0), "slider 0 mutes rather than attenuating");
+    check(micSliderToLinear(1) > 0.0, "slider 1 is quiet but not muted");
+
+    // Monotonic across the travel, so no slider position is louder than one
+    // above it.
+    {
+        bool monotonic = true;
+        for (int lvl = 1; lvl < 100; ++lvl) {
+            if (micSliderToLinear(lvl + 1) <= micSliderToLinear(lvl))
+                monotonic = false;
+        }
+        check(monotonic, "gain rises monotonically from slider 1 to 100");
+    }
+
+    // Out-of-range input is clamped, not extrapolated: a CAT client or a bridge
+    // verb can pass anything, and 200 must not become +60 dB on the air.
+    check(near(micSliderToGainDb(200), 20.0), "over-range level clamps to +20 dB");
+    check(near(micSliderToGainDb(-50), -20.0), "under-range level clamps to -20 dB");
+    check(near(micSliderToLinear(-50), 0.0), "negative level mutes");
+
+    // ---- Forward-power peak hold -------------------------------------------
+
+    // Attack is instant, so a peak that IS sampled is never averaged away —
+    // which is the whole failure being fixed.
+    check(near(fwdPeakHoldStep(1.0, 6.0, /*keyed=*/true, kRelease), 6.0),
+          "a higher sample is taken immediately");
+
+    // Release is gradual, so the reading does not fall back to the average
+    // between syllables.
+    {
+        const double held = fwdPeakHoldStep(6.0, 1.0, /*keyed=*/true, kRelease);
+        check(held > 5.7 && held < 6.0, "a lower sample releases slowly, not instantly");
+    }
+
+    // THE BEHAVIOUR THE FIX EXISTS FOR: speech sampled at 10 Hz lands mostly on
+    // the troughs. Feed a run of low samples with occasional peaks — the shape
+    // of a real over — and the reading must converge UP toward the peak rather
+    // than settling near the average of the samples.
+    {
+        double peak = 0.0;
+        const double kPeakW = 6.0;
+        const double kTroughW = 0.7;
+        // 3 seconds at 10 Hz. Every fifth sample catches a syllable.
+        for (int i = 0; i < 30; ++i) {
+            const double sample = (i % 5 == 0) ? kPeakW : kTroughW;
+            peak = fwdPeakHoldStep(peak, sample, /*keyed=*/true, kRelease);
+        }
+        check(peak > 5.0,
+              "over a 3 s speech-shaped run the hold converges toward PEP, not the average");
+        // And it is bounded by the real peak — a hold must never invent power
+        // that was not measured.
+        check(peak <= kPeakW, "the hold never exceeds the largest sample seen");
+    }
+
+    // Unkeyed, the reading follows the sample straight down. A hold that
+    // outlived the transmission would keep re-arming MeterModel's filter and
+    // leave the gauge claiming power out of a radio that has stopped.
+    check(near(fwdPeakHoldStep(6.0, 0.0, /*keyed=*/false, kRelease), 0.0),
+          "unkeyed, the reading drops to the instantaneous sample at once");
+
+    if (g_failures == 0) {
+        std::printf("\nALL PASS\n");
+        return 0;
+    }
+    std::printf("\nFAILURES PRESENT\n");
+    return 1;
+}

--- a/tests/transmit_model_test.cpp
+++ b/tests/transmit_model_test.cpp
@@ -249,6 +249,53 @@ int main(int argc, char** argv)
                      "applying radio status does not emit operator intent");
     }
 
+    // ── Mic level: the same operator-intent contract ────────────────────────
+    //
+    // Hl2TxDsp::setMicGain had no production caller: the slider's `transmit set
+    // miclevel=` is dropped by a backend with no command plane, so mic gain did
+    // nothing at all on the HL2 and an operator sweeping it end to end saw no
+    // change on the air. micLevelCommandIssued is the seam's route in.
+    //
+    // The applyChanges half is the one that bites if it is wrong. A Flex echoes
+    // miclevel back in transmit status, and if that echo looked like intent it
+    // would be handed straight back to the seam as a fresh command.
+    {
+        QList<int> micIntents;
+        QObject::connect(&tx, &TransmitModel::micLevelCommandIssued,
+                         [&micIntents](int level) { micIntents.append(level); });
+
+        micIntents.clear();
+        tx.setMicLevel(80);
+        ok &= expect(tx.micLevel() == 80, "setMicLevel adopts the level");
+        ok &= expect(micIntents == QList<int>({80}),
+                     "setMicLevel announces operator intent for the seam");
+
+        // Re-asserting the SAME level must still reach the seam. A
+        // host-modulating backend can have been reset underneath the model — a
+        // reconnect, a radio swap — while m_micLevel never moved, and gating on
+        // "changed" would leave the modulator at its default with the slider
+        // insisting otherwise.
+        micIntents.clear();
+        tx.setMicLevel(80);
+        ok &= expect(micIntents == QList<int>({80}),
+                     "re-setting an unchanged mic level still re-asserts to the seam");
+
+        // Out of range is clamped before it is announced, so the seam never has
+        // to defend itself against a CAT client's arithmetic.
+        micIntents.clear();
+        tx.setMicLevel(150);
+        ok &= expect(tx.micLevel() == 100 && micIntents == QList<int>({100}),
+                     "an over-range mic level is clamped before it reaches the seam");
+
+        micIntents.clear();
+        TransmitDelta micEcho;
+        micEcho.micLevel = 42;
+        tx.applyChanges(micEcho);
+        ok &= expect(tx.micLevel() == 42, "radio status still updates the mic level");
+        ok &= expect(micIntents.isEmpty(),
+                     "applying radio status does not emit mic operator intent");
+    }
+
     ClientQuindarTone quindar;
     quindar.prepare(24000.0);
     quindar.setEnabled(true);


### PR DESCRIPTION
Field report on a Hermes-Lite 2: 6 W out on FT8 and WSPR, never more than 1 W on
SSB voice, with and without the compressor and at every mic and RF level.

Three faults. The first is why the other two were invisible.

## The wattmeter was reading the wrong thing on voice

`TX:FWDPWR` was published as the raw instantaneous sample from the directional
coupler. That coupler is one 12-bit conversion from the `slow_adc` I2C
converter, round-robined with reverse power, temperature and bias current, with
no peak detector and no averaging anywhere in the gateware (`rtl/slow_adc.v`,
`rtl/control.v` ~L262 — tier 1 on the source-precedence ladder). It reaches us
at 10 Hz.

Speech peaks last tens of milliseconds, so sampling that envelope at 10 Hz lands
on a peak essentially never. A constant-envelope FT8 or WSPR transmission, where
every instant *is* the peak, read full scale. The same transmitter making the
same power read very differently depending on what was modulating it.

Now published through a peak hold: instant attack, ~2 s release, in watts rather
than counts because the calibration curve is markedly non-linear. This does not
recover an instantaneous PEP reading — no filter can recover a peak that was
never sampled. It accumulates the maximum across a transmission, so the reading
climbs toward PEP as the over goes on. The meter description says "peak
estimate" rather than claiming to be a measurement.

The hold applies only while keyed and resets at each key. Unkeyed it must follow
the sample straight down, or it keeps re-arming `MeterModel`'s filter and the
gauge claims power out of a radio that has stopped.

`MeterModel`'s own ballistics are untouched, so Flex behaviour does not change.

## Mic gain was wired to nothing

`Hl2TxDsp::setMicGain()` had no production caller — only the unit test. The Phone
applet's slider emits `transmit set miclevel=`, which a backend with no command
plane drops, and unlike `setTxFilter` there was no seam bridge. `m_micGain`
stayed at 1.0 and sweeping the slider end to end changed nothing on the air.

The client-side fallback could not fire either: `setPcMicGain` is gated on
`micSelection() == "PC"`, and an HL2 never reports `mic_selection`, so the model
sits at its `"MIC"` default. Both paths dead.

Fixed with the same seam shape `setTxFilter` uses. `micLevelCommandIssued`
carries operator intent only — `applyStatus()` never emits it — so a Flex's own
`miclevel` echo cannot loop back out as a fresh command.

50 is unity, and that is load-bearing: `TransmitModel` constructs `m_micLevel` at
50 and nothing restores it at startup, so an untouched slider must leave the
modulator at its own 1.0 default rather than changing the transmit level of every
existing install.

The client-side path is now explicitly stood down on a host-modulating backend
rather than un-gated. Enabling both would apply the operator's gain twice in
series, and `setPcMicGain` only ever attenuates, while what the ALC behind the
modulator needs is the mic pushed *up* past its hold threshold.

## The readback agreed with the failure

Every readback available while mic gain was dead reported the requesting side, so
all of them agreed the control worked. A confirmation sourced from the requester
cannot detect a request that never arrived.

`Hl2TxDsp` now echoes `micGainChanged`, `Hl2Backend` mirrors it, and
`healthSnapshot()` reports the modulator's own gain alongside the operator's
request. A new `health` bridge verb surfaces that snapshot, which previously
reached only the Radio Health dialog and so was unavailable to any script or
regression test. The snapshot gained a "Transmit voice chain" section: mic level
and applied gain, mic peak for the current over, the ALC hold threshold, ALC gain
and post-ALC peak, the passband actually in use, and both the instantaneous and
held forward power.

## Hardware measurements

Live Hermes-Lite 2 into a dummy load. SWR 1.00 median (max 1.27), PA temperature
peaked at 44.1 C.

Constant carrier, 7.200 LSB at 60% drive — the control case, where a hold must
not inflate a reading that has no peaks to recover:

| | instantaneous | held |
|---|---|---|
| median | 2.637 W | 2.642 W |
| max | 2.651 W | 2.651 W |

Voice, 14.250 USB at 100% drive, four overs cycling PROC. Both columns have
`MeterModel`'s filter applied, so this is what the gauge actually displayed
rather than a raw-sample comparison:

| Setting | before (med/max) | after (med/max) | median | peak |
|---|---|---|---|---|
| PROC OFF | 0.641 / 1.742 W | 1.307 / 2.568 W | +3.1 dB | +1.7 dB |
| PROC NOR | 0.495 / 1.446 W | 1.129 / 1.976 W | +3.6 dB | +1.4 dB |
| PROC DX | 0.604 / 1.794 W | 1.293 / 2.494 W | +3.3 dB | +1.4 dB |
| PROC DX+ | 0.449 / 2.692 W | 1.085 / 4.558 W | +3.8 dB | +2.3 dB |

Raw held peaks reached 5.18 W on voice, against 2.65 W from the 60% constant
carrier. The transmitter was making full PEP throughout; the gauge was not
showing it.

Two things this does **not** establish, stated plainly:

- Metering does not close the whole 6 W / 1 W gap. Even after the fix the typical
  voice reading sits ~6 dB below a constant-envelope FT8 reading, which is SSB
  crest factor rather than a fault. What changed is that peaks now read 4.6 W
  instead of 1.7 W.
- Whether PROC is working. Held peak barely moved across the four settings, which
  is consistent with the ALC pinning peaks at 0.85 FS — but the overs were not
  controlled (mic peak varied 3.4 dB, durations 14.5–38 s), and compression's job
  is raising average relative to peak. Answering it needs the same audio through
  each setting. Tracked separately.

## Testing

- `hl2_tx_level_policy_test` (new) — the mic mapping and the peak hold as pure
  functions that `Hl2Backend` evaluates rather than re-implements, so what passes
  here is what the radio runs. Unity at 50, mute at 0, clamping, monotonicity,
  and that a 3 s speech-shaped run converges toward PEP rather than the average
  of its samples.
- `transmit_model_test` — mic level announces operator intent, re-asserts an
  unchanged level (a backend can be reset underneath the model), clamps before
  announcing, and radio status does not emit intent.
- `hl2_tx_loopback_test` unchanged and passing, which is what rules out the
  modulation path: audio reaching `submitTxAudio` still lands on the correct
  sideband above the unkeyed floor.
- Bridge against `hpsdrsim -hermeslite2 -P1` on an isolated profile: the GUI
  slider drives the modulator end to end (100 → 10.0 linear, 50 → 1.0, 0 →
  muted), and `micGainAppliedLinear` reads "not reported" before the slider is
  first touched — confirming the readout can detect the failure it exists to
  catch.
- Full suite 239/240 headless. The one failure, `connection_panel_size_test`, was
  verified failing identically on clean `upstream/main` and is unrelated.

## Follow-ups not in this PR

- The WSPR beacon calls `tx.setTxFilter(1200, 1800)`, which since #4609 latches
  `m_txFilterFromOperator` on the HL2 and persists. `stopBeacon()` restores it,
  but a crash mid-beacon leaves a 600 Hz passband that `applyRestoredState()`
  re-arms as operator intent on the next session. The flag is observably set in a
  real operator profile today.
- The WAVE meter shows post-DSP mic audio during TUNE, when the modulator is
  transmitting a carrier instead. Audio is discarded rather than radiated
  (`MetisClient` prefers the tone, and the queue is flushed on unkey), but the
  display is wrong and `submitTxAudio` gates only on `m_keyed`, so the mic is
  captured and modulated throughout a tune.
- `txtest twotone` produces a single carrier on this backend: `tune_mode=two_tone`
  is a Flex verb that gets dropped, and `setTune()` raises one tone. A real
  two-tone plus a mic-audio source is what PROC needs to become measurable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
