### PR TITLE
test(capabilities): wait for the relay instead of spinning on an empty queue (#4693)

### DIFF
--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -72,6 +72,7 @@
 #include "core/backends/sim/SimBackend.h"
 
 #include <QCoreApplication>
+#include <QDeadlineTimer>
 #include <QSignalSpy>
 
 #include <cstdio>
@@ -82,6 +83,35 @@ static int g_failures = 0;
 static void check(bool ok, const char* what)
 {
     if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what); ++g_failures; }
+}
+
+// Wait for a queued cross-thread signal, or give up at a real deadline.
+//
+// The obvious `for (200x) processEvents(AllEvents, 10)` does NOT do this. That
+// argument is a MAXIMUM, not a wait — processEvents() strips WaitForMoreEvents
+// and returns immediately on an empty queue — so all 200 iterations drain in
+// microseconds and the loop exits having waited approximately zero. It reads as
+// a 2-second budget and is a zero-second one.
+//
+// Measured with a standalone Qt 6.10.3 probe firing a worker-thread signal
+// after N ms. The old loop exited after 0 ms and MISSED it at every N tried
+// (5, 50, 200, 1000, 3000) — it never waited at all. This form catches it at
+// each of those and returns as the signal arrives (0 ms at N=0, 201 ms at
+// N=200), timing out only past the deadline.
+//
+// So both edge assertions here passed on luck — on whether the emission
+// happened to be queued already — which is why this test failed intermittently
+// on assertions unrelated to whatever was under review (#4693).
+//
+// count() is tested FIRST because wait() waits for the NEXT emission and would
+// miss one already delivered. 5 s is a timeout, not a duration: the normal path
+// returns in well under a millisecond.
+static bool waitForSpy(QSignalSpy& spy, int timeoutMs = 5000)
+{
+    QDeadlineTimer deadline(timeoutMs);
+    while (spy.count() == 0 && !deadline.hasExpired())
+        spy.wait(static_cast<int>(qMin<qint64>(100, deadline.remainingTime())));
+    return spy.count() > 0;
 }
 
 // The exact expression MainWindow::applyCapabilitiesToUi() applies to every
@@ -287,16 +317,21 @@ int main(int argc, char** argv)
         // object lives on a worker thread and reaches Connected before its
         // queued signal has crossed to this one, so waiting on isConnected()
         // races the very emission under test.
-        for (int i = 0; i < 200 && spy.count() == 0; ++i) {
-            QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
-        }
+        //
+        // The relay is the anchor for BOTH checks below, so it is waited on and
+        // asserted first. isConnected() reads the connection's atomic state, which
+        // flips the instant the worker sets Connected — before the queued signal
+        // chain has been delivered here. Asserting it before the relay has landed
+        // means a worker that has not been scheduled at all inverts every
+        // connected-branch assertion in this block, not just this one. (#4693)
+        const bool relayFired = waitForSpy(spy);
+
+        // Without it applyCapabilitiesToUi() never runs and every gated surface
+        // keeps the previous radio's answer.
+        check(relayFired,
+              "relay: capabilitiesChanged fired on the connect edge");
         check(model.isConnected(),
               "synthetic demo connect reached the connected state");
-
-        // The relay fired for that edge. Without it applyCapabilitiesToUi()
-        // never runs and every gated surface keeps the previous radio's answer.
-        check(spy.count() > 0,
-              "relay: capabilitiesChanged fired on the connect edge");
         if (spy.count() > 0) {
             const QList<QVariant> args = spy.last();
             check(args.value(0).toBool(),
@@ -370,12 +405,11 @@ int main(int argc, char** argv)
     {
         QSignalSpy spy(&model, &RadioModel::capabilitiesChanged);
         model.disconnectFromRadio();
-        for (int i = 0; i < 200 && spy.count() == 0; ++i) {
-            QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
-        }
-        check(!model.isConnected(), "disconnected from the synthetic demo radio");
-        check(spy.count() > 0,
+        // Same ordering as the connect edge above, for the same reason. (#4693)
+        const bool relayFired = waitForSpy(spy);
+        check(relayFired,
               "relay: capabilitiesChanged fired on the disconnect edge");
+        check(!model.isConnected(), "disconnected from the synthetic demo radio");
 
         const RadioCapabilities caps = model.backendCapabilities();
         check(uiWouldShow(model.isConnected(), caps.hasProfiles),

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -106,6 +106,16 @@ static void check(bool ok, const char* what)
 // count() is tested FIRST because wait() waits for the NEXT emission and would
 // miss one already delivered. 5 s is a timeout, not a duration: the normal path
 // returns in well under a millisecond.
+//
+// Sliced rather than one wait(timeoutMs) call, deliberately. QSignalSpy exits
+// its nested loop from the EMITTING thread, so a cross-thread emission racing
+// loop entry can in principle lose the wake; the outer re-check of count() then
+// recovers it at the cost of one slice, where a single un-sliced wait() would
+// sit out the whole timeout. That race did not reproduce here (Qt 6.10.3,
+// Windows: 440 trials across four emission delays, 220 of them under 14-way CPU
+// contention, zero misses in either form) but it has been measured elsewhere on
+// Qt 6.11, and the slicing costs nothing when it does not trigger. Do not
+// collapse these into a single wait().
 static bool waitForSpy(QSignalSpy& spy, int timeoutMs = 5000)
 {
     QDeadlineTimer deadline(timeoutMs);

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -111,11 +111,23 @@ static void check(bool ok, const char* what)
 // its nested loop from the EMITTING thread, so a cross-thread emission racing
 // loop entry can in principle lose the wake; the outer re-check of count() then
 // recovers it at the cost of one slice, where a single un-sliced wait() would
-// sit out the whole timeout. That race did not reproduce here (Qt 6.10.3,
-// Windows: 440 trials across four emission delays, 220 of them under 14-way CPU
-// contention, zero misses in either form) but it has been measured elsewhere on
-// Qt 6.11, and the slicing costs nothing when it does not trigger. Do not
-// collapse these into a single wait().
+// sit out the whole timeout. That race is REPORTED on Qt 6.11 (a 0 ms emission
+// returning at 102 ms — one slice late, recovered), but it has not reproduced in
+// either attempt to measure it: Qt 6.10.3/Windows, 440 trials across four
+// emission delays with 220 under 14-way CPU contention, and Qt 6.11.1/Linux, 800
+// trials over the same delays with half under load. Both runs put the sliced and
+// un-sliced forms within a millisecond of each other at zero misses.
+//
+// The slicing stays on that asymmetry, then, not on a confirmed race: it costs
+// nothing when it does not trigger, and if the report is right an un-sliced
+// wait() turns one slice of latency into a full-timeout stall. So do not
+// collapse these into a single wait() on the strength of a probe that comes back
+// clean — that is the expected result on both versions measured so far.
+//
+// Retire this helper for AetherTest::waitForSignal() once #4699 lands. That PR
+// consolidates the spellings of this wait into tests/TestEventLoop.h but does
+// not touch this file, so until it is migrated the test that motivated the
+// shared helper is the one place still carrying a private copy of it.
 static bool waitForSpy(QSignalSpy& spy, int timeoutMs = 5000)
 {
     QDeadlineTimer deadline(timeoutMs);


### PR DESCRIPTION
Fixes #4693.

`radio_capability_gating_test` fails intermittently on assertions unrelated to whatever is under review — observed by @ten9876 failing on *both* sides of #4672's diff, which is what marks it pre-existing.

## The defect

`tests/radio_capability_gating_test.cpp:290` (and identically at `:373`):

```cpp
for (int i = 0; i < 200 && spy.count() == 0; ++i) {
    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
}
```

The comment above it states the right intent — pump until the *relay* has been seen, because the connection lives on a worker thread — but the API doesn't implement it. That ms argument is a **maximum, not a wait**: `processEvents()` strips `WaitForMoreEvents` and returns immediately on an empty queue, so all 200 iterations drain in microseconds. It reads as a 2-second budget and is a zero-second one.

Measured with a standalone Qt 6.10.3 probe firing a worker-thread signal after N ms:

| signal at | old loop | this fix |
|---|---|---|
| 0 ms | exited 0 ms — **MISSED** | 0 ms — CAUGHT |
| 5 ms | exited 0 ms — **MISSED** | 5 ms — CAUGHT |
| 50 ms | exited 0 ms — **MISSED** | 51 ms — CAUGHT |
| 200 ms | exited 0 ms — **MISSED** | 201 ms — CAUGHT |
| 1000 ms | exited 0 ms — **MISSED** | 1001 ms — CAUGHT |
| 3000 ms | exited 0 ms — MISSED | 2000 ms — MISSED *(deadline, correct)* |

It never waited at all. Both edge assertions passed on luck — on whether the emission happened to be queued already — and lost that luck on a loaded box.

## The fix

Deadline-bounded `QSignalSpy::wait()`, which blocks on a real nested event loop. `count()` is tested first because `wait()` waits for the *next* emission and would miss one already delivered. `Qt6::Test` was already linked (`CMakeLists.txt:4739`).

The relay is now asserted **before** `isConnected()`, not after. `isConnected()` reads the connection's atomic state, which flips the instant the worker sets `Connected` — before the queued chain has been delivered here. Checking it first let a worker that hadn't been scheduled at all invert every connected-branch assertion in the block.

## Verification

Reproduced and fixed on Windows/MSVC, Qt 6.10.3, offscreen. Idle it does not reproduce (0/40). Under 14-way CPU contention — same build directory, interleaved runs of both binaries so the only variable is the diff:

```
unfixed: 5 / 40 failed
fixed  : 0 / 40 failed
```

Both reported signatures appear in the unfixed runs, and collapse to this one cause:

- **1×** `relay: capabilitiesChanged fired on the connect edge` alone — the 2/5 signature
- **8×** the full connected-branch block, including `connected + hasRadioSideDsp=false hides the hardware EQ applet` — the 4/6 signature. That assertion is one line of a multi-line failure, not a distinct bug.

## Notes

The assertions stay edge-shaped, per the analysis on the issue: `capabilitiesChanged` is the only signal `applyCapabilitiesToUi()` binds to, so "fired on this transition" is the property worth pinning — accumulated state would weaken the test. The wait was wrong, not the assertion.

No product code touched. The cross-thread ordering the test trips over is the real design.

**Out of scope, worth a follow-up:** a shared `tests/TestEventLoop.h` retires the four private spellings of this wait — up as #4699, branched from `main` and touching disjoint files, so the two can land in either order.

*(An earlier revision of this section claimed roughly 15 other tests carry the same latent defect. Measured, that was wrong, and it is corrected here rather than only in a comment: the 14 `processEvents` spins in `tests/` are three shapes, and only the iteration-count one was broken — a single site, fixed by this PR. Deadline-bounded condition waits are fine without a yield, since the wall-clock bound keeps re-entering `processEvents()` until it expires. The fixed-duration pumps are deliberate — their subject IS elapsed time, so converting them would be a regression. #4699 is therefore consolidation and future-proofing, not a bug fix.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

