### PR TITLE
fix(net): give every HTTP client a transfer timeout

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -30,6 +30,7 @@ on:
       - "tools/audit_colours.py"
       - "tools/check_a11y.py"
       - "tools/check_engine_boundary.py"
+      - "tools/check_network_timeouts.py"
       - "tools/check_theme_seed.py"
       - "tools/gen_theme_seed.py"
       - ".github/workflows/static-checks.yml"
@@ -79,6 +80,21 @@ jobs:
       # shrink. Full-tree scan, stdlib-only.
       - name: Engine/UI dependency direction
         run: python tools/check_engine_boundary.py --strict
+
+      # ── Network transfer-timeout ratchet (#4688 §6). A QNetworkAccessManager
+      # with no transfer timeout turns a half-open connection into a reply that
+      # never finishes and never errors — the surface that issued it just stops,
+      # with no error and no way to tell "slow" from "gone". #4698 swept the
+      # eleven clients that had drifted, but the sweep is not the durable part:
+      # seven call sites had set a per-request timeout for years while eleven
+      # more never got the memo, which is what an unenforced convention looks
+      # like after enough merges. This fails the NEXT one instead (--strict).
+      #
+      # `!cancelled()` so a failure above still lets this one report — seeing
+      # every gate's verdict in one run is the point of sharing a job.
+      - name: Network transfer timeouts
+        if: ${{ !cancelled() }}
+        run: python tools/check_network_timeouts.py --strict
 
       # ── ThemeManager::seedBuiltinDefaults() compiles a copy of the default
       # theme into the binary. It is GENERATED (tools/gen_theme_seed.py emits

--- a/src/asr/AsrModelManager.cpp
+++ b/src/asr/AsrModelManager.cpp
@@ -13,17 +13,16 @@
 #include <QUrl>
 #include <QtConcurrent>
 
-// Stall timeout for model downloads (#4688 §6). 30 s rather than 15: models
-// run to hundreds of MB and this clock resets on every byte, so it only fires
-// on a genuinely dead transfer, not a slow one.
-constexpr int kTransferTimeoutMs = 30000;
-
 namespace AetherSDR {
 
 Q_LOGGING_CATEGORY(lcAsrModel, "aether.asr.model")
 
 namespace {
 constexpr qint64 kHashChunkBytes = 1 << 20; // 1 MiB
+// Stall timeout for model downloads (#4688 §6). 30 s rather than 15: models
+// run to hundreds of MB and this clock resets on every byte, so it only fires
+// on a genuinely dead transfer, not a slow one.
+constexpr int kTransferTimeoutMs = 30000;
 } // namespace
 
 QString AsrModelManager::defaultModelsDir()

--- a/src/asr/AsrModelManager.cpp
+++ b/src/asr/AsrModelManager.cpp
@@ -13,6 +13,11 @@
 #include <QUrl>
 #include <QtConcurrent>
 
+// Stall timeout for model downloads (#4688 §6). 30 s rather than 15: models
+// run to hundreds of MB and this clock resets on every byte, so it only fires
+// on a genuinely dead transfer, not a slow one.
+constexpr int kTransferTimeoutMs = 30000;
+
 namespace AetherSDR {
 
 Q_LOGGING_CATEGORY(lcAsrModel, "aether.asr.model")
@@ -47,6 +52,7 @@ AsrModelManager::AsrModelManager(QString cacheDir, QNetworkAccessManager* nam, Q
 {
     if (m_nam == nullptr) {
         m_nam = new QNetworkAccessManager(this);
+        m_nam->setTransferTimeout(kTransferTimeoutMs);
         m_ownsNam = true;
     }
 }

--- a/src/core/FirmwareStager.cpp
+++ b/src/core/FirmwareStager.cpp
@@ -13,11 +13,17 @@
 #include <QStandardPaths>
 #include <QUrl>
 
+// Stall timeout for the software-page, MD5 and installer requests (#4688 §6).
+// 30 s rather than 15: the installer is a large download and this clock resets
+// on every byte, so it only fires on a genuinely dead transfer.
+constexpr int kTransferTimeoutMs = 30000;
+
 namespace AetherSDR {
 
 FirmwareStager::FirmwareStager(QObject* parent)
     : QObject(parent)
 {
+    m_nam.setTransferTimeout(kTransferTimeoutMs);
 }
 
 QString FirmwareStager::stagingDir()

--- a/src/core/FirmwareStager.cpp
+++ b/src/core/FirmwareStager.cpp
@@ -13,12 +13,14 @@
 #include <QStandardPaths>
 #include <QUrl>
 
+namespace AetherSDR {
+
+namespace {
 // Stall timeout for the software-page, MD5 and installer requests (#4688 §6).
 // 30 s rather than 15: the installer is a large download and this clock resets
 // on every byte, so it only fires on a genuinely dead transfer.
 constexpr int kTransferTimeoutMs = 30000;
-
-namespace AetherSDR {
+} // namespace
 
 FirmwareStager::FirmwareStager(QObject* parent)
     : QObject(parent)

--- a/src/core/NvidiaAfxPack.cpp
+++ b/src/core/NvidiaAfxPack.cpp
@@ -22,6 +22,11 @@
 #include <QNetworkRequest>
 #include <QUrl>
 
+// Stall timeout for the AFX pack manifest and archive downloads (#4688 §6).
+// 30 s rather than 15: the archive is large and this clock resets on every
+// byte, so it only fires on a genuinely dead transfer.
+constexpr int kTransferTimeoutMs = 30000;
+
 namespace AetherSDR {
 
 // ─── Platform layout ─────────────────────────────────────────────────────────
@@ -319,7 +324,10 @@ QList<NvidiaAfxPack::Component> NvidiaAfxPack::manifest(const QString& arch) con
 
 // ─── Lifecycle ───────────────────────────────────────────────────────────────
 NvidiaAfxPack::NvidiaAfxPack(QObject* parent)
-    : QObject(parent), m_nam(new QNetworkAccessManager(this)) {}
+    : QObject(parent), m_nam(new QNetworkAccessManager(this))
+{
+    m_nam->setTransferTimeout(kTransferTimeoutMs);
+}
 
 NvidiaAfxPack::~NvidiaAfxPack() { cancel(); }
 

--- a/src/core/NvidiaAfxPack.cpp
+++ b/src/core/NvidiaAfxPack.cpp
@@ -22,11 +22,6 @@
 #include <QNetworkRequest>
 #include <QUrl>
 
-// Stall timeout for the AFX pack manifest and archive downloads (#4688 §6).
-// 30 s rather than 15: the archive is large and this clock resets on every
-// byte, so it only fires on a genuinely dead transfer.
-constexpr int kTransferTimeoutMs = 30000;
-
 namespace AetherSDR {
 
 // ─── Platform layout ─────────────────────────────────────────────────────────
@@ -41,6 +36,10 @@ namespace AetherSDR {
 //     bin/, which the loader searches via LOAD_WITH_ALTERED_SEARCH_PATH (so no
 //     symlink step). Hosting the slim AFX zip keeps it a ~33 MB release asset.
 namespace {
+// Stall timeout for the AFX pack manifest and archive downloads (#4688 §6).
+// 30 s rather than 15: the archive is large and this clock resets on every
+// byte, so it only fires on a genuinely dead transfer.
+constexpr int kTransferTimeoutMs = 30000;
 #if defined(_WIN32)
 constexpr char kCoreRelPath[] = "bin/NVAudioEffects.dll";
 constexpr char kPlatformTag[] = "windows-x86_64";

--- a/src/core/PotaClient.cpp
+++ b/src/core/PotaClient.cpp
@@ -11,6 +11,9 @@
 #include <QDir>
 #include <QFileInfo>
 
+// Stall timeout for POTA spot queries (#4688 §6).
+constexpr int kTransferTimeoutMs = 15000;
+
 namespace AetherSDR {
 
 PotaClient::PotaClient(QObject* parent)
@@ -23,6 +26,7 @@ void PotaClient::initialize()
 {
     if (m_nam) return;
     m_nam = new QNetworkAccessManager(this);
+    m_nam->setTransferTimeout(kTransferTimeoutMs);
     m_pollTimer = new QTimer(this);
     m_pollTimer->setSingleShot(false);
     connect(m_pollTimer, &QTimer::timeout, this, &PotaClient::onPollTimer);

--- a/src/core/PotaClient.cpp
+++ b/src/core/PotaClient.cpp
@@ -11,10 +11,12 @@
 #include <QDir>
 #include <QFileInfo>
 
+namespace AetherSDR {
+
+namespace {
 // Stall timeout for POTA spot queries (#4688 §6).
 constexpr int kTransferTimeoutMs = 15000;
-
-namespace AetherSDR {
+} // namespace
 
 PotaClient::PotaClient(QObject* parent)
     : QObject(parent)

--- a/src/core/PropForecastClient.cpp
+++ b/src/core/PropForecastClient.cpp
@@ -14,12 +14,14 @@
 
 Q_LOGGING_CATEGORY(lcPropForecast, "aether.propforecast")
 
+namespace AetherSDR {
+
+namespace {
 // Stall timeout for every request this client issues (#4688 §6). Without one a
 // half-open connection to any of the four space-weather hosts leaves its reply
 // pending forever — the fetch neither completes nor errors.
 constexpr int kTransferTimeoutMs = 15000;
-
-namespace AetherSDR {
+} // namespace
 
 PropForecastClient::PropForecastClient(QObject* parent)
     : QObject(parent)

--- a/src/core/PropForecastClient.cpp
+++ b/src/core/PropForecastClient.cpp
@@ -14,11 +14,23 @@
 
 Q_LOGGING_CATEGORY(lcPropForecast, "aether.propforecast")
 
+// Stall timeout for every request this client issues (#4688 §6). Without one a
+// half-open connection to any of the four space-weather hosts leaves its reply
+// pending forever — the fetch neither completes nor errors.
+constexpr int kTransferTimeoutMs = 15000;
+
 namespace AetherSDR {
 
 PropForecastClient::PropForecastClient(QObject* parent)
     : QObject(parent)
 {
+    // Set on the manager rather than per request. A timeout that must be
+    // remembered at every call site is one a later call site forgets — which is
+    // how all five requests here ended up without one — and manager-level
+    // covers any request added later for free. It is a stall timeout: the clock
+    // resets on every byte received, so it bounds a dead connection without
+    // capping a slow one.
+    m_nam.setTransferTimeout(kTransferTimeoutMs);
     m_timer.setSingleShot(false);
     m_timer.setInterval(kIntervalMs);
     connect(&m_timer, &QTimer::timeout, this, &PropForecastClient::onTimer);

--- a/src/core/PskReporterClient.cpp
+++ b/src/core/PskReporterClient.cpp
@@ -23,11 +23,15 @@
 
 Q_LOGGING_CATEGORY(lcPskReporter, "aether.pskreporter")
 
+// Stall timeout for PSK Reporter queries (#4688 §6).
+constexpr int kTransferTimeoutMs = 15000;
+
 namespace AetherSDR {
 
 PskReporterClient::PskReporterClient(QObject* parent)
     : QObject(parent)
 {
+    m_nam.setTransferTimeout(kTransferTimeoutMs);
     connect(&m_timer, &QTimer::timeout, this, &PskReporterClient::poll);
 
     // Five-minute MQTT health summary — enough to spot a dead or flapping

--- a/src/core/PskReporterClient.cpp
+++ b/src/core/PskReporterClient.cpp
@@ -23,10 +23,17 @@
 
 Q_LOGGING_CATEGORY(lcPskReporter, "aether.pskreporter")
 
-// Stall timeout for PSK Reporter queries (#4688 §6).
-constexpr int kTransferTimeoutMs = 15000;
-
 namespace AetherSDR {
+
+namespace {
+// Stall timeout for PSK Reporter queries (#4688 §6). 30 s rather than the 15 s
+// the other interactive clients use: Qt's clock also covers the wait for the
+// FIRST byte, and the initial backfill can ask for the full 24 h window
+// (kMaxLookbackSec), which retrieve.pskreporter.info spends real server-side
+// time assembling before it writes anything. The polling floor is already five
+// minutes (kMinPollMs) for the same reason.
+constexpr int kTransferTimeoutMs = 30000;
+} // namespace
 
 PskReporterClient::PskReporterClient(QObject* parent)
     : QObject(parent)

--- a/src/core/SmartLinkClient.cpp
+++ b/src/core/SmartLinkClient.cpp
@@ -13,6 +13,9 @@
 #include <qt6keychain/keychain.h>
 #endif
 
+// Stall timeout for SmartLink auth/API requests (#4688 §6).
+constexpr int kTransferTimeoutMs = 15000;
+
 namespace AetherSDR {
 
 // Cap the line-assembly buffer.  A buggy or hostile SmartLink discovery/auth
@@ -27,6 +30,7 @@ static constexpr int kMaxReadBuffer = 16 * 1024 * 1024;
 SmartLinkClient::SmartLinkClient(QObject* parent)
     : QObject(parent)
 {
+    m_nam.setTransferTimeout(kTransferTimeoutMs);
     // Report credential-persistence availability up front so a build that
     // shipped without QtKeychain is diagnosable from the SmartLink support
     // log instead of failing silently (#3639). The disabled case is a

--- a/src/core/SmartLinkClient.cpp
+++ b/src/core/SmartLinkClient.cpp
@@ -13,10 +13,12 @@
 #include <qt6keychain/keychain.h>
 #endif
 
+namespace AetherSDR {
+
+namespace {
 // Stall timeout for SmartLink auth/API requests (#4688 §6).
 constexpr int kTransferTimeoutMs = 15000;
-
-namespace AetherSDR {
+} // namespace
 
 // Cap the line-assembly buffer.  A buggy or hostile SmartLink discovery/auth
 // peer that dribbles bytes without ever sending '\n' would otherwise grow

--- a/src/gui/Contribute.cpp
+++ b/src/gui/Contribute.cpp
@@ -563,6 +563,9 @@ void fetchOpenCollectiveSupporters(QDialog* owner, CommunityCreditsCanvas* canva
     }
 
     auto* manager = new QNetworkAccessManager(owner);
+    // Bound the Open Collective query (#4688 §6) — without it a half-open
+    // connection leaves the credits panel waiting indefinitely with no error.
+    manager->setTransferTimeout(15000);
     QNetworkRequest request{QUrl(QStringLiteral("https://api.opencollective.com/graphql/v2"))};
     request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/json"));
     request.setRawHeader("User-Agent", "AetherSDR-community-credits");

--- a/src/gui/Contribute.cpp
+++ b/src/gui/Contribute.cpp
@@ -44,6 +44,9 @@
 
 namespace {
 
+// Stall timeout for the Open Collective supporters query (#4688 §6).
+constexpr int kTransferTimeoutMs = 15000;
+
 struct CommunityStar {
     qreal x{0.0};
     qreal y{0.0};
@@ -565,7 +568,7 @@ void fetchOpenCollectiveSupporters(QDialog* owner, CommunityCreditsCanvas* canva
     auto* manager = new QNetworkAccessManager(owner);
     // Bound the Open Collective query (#4688 §6) — without it a half-open
     // connection leaves the credits panel waiting indefinitely with no error.
-    manager->setTransferTimeout(15000);
+    manager->setTransferTimeout(kTransferTimeoutMs);
     QNetworkRequest request{QUrl(QStringLiteral("https://api.opencollective.com/graphql/v2"))};
     request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/json"));
     request.setRawHeader("User-Agent", "AetherSDR-community-credits");

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -76,6 +76,11 @@
 
 namespace AetherSDR {
 
+namespace {
+// Stall timeout for the About dialog's GitHub contributor fetch (#4688 §6).
+constexpr int kTransferTimeoutMs = 15000;
+} // namespace
+
 void MainWindow::buildMenuBar()
 {
     auto* fileMenu = menuBar()->addMenu("&File");
@@ -1383,7 +1388,7 @@ void MainWindow::buildMenuBar()
         auto* nam = new QNetworkAccessManager(dlg);
         // Bound the contributor fetch (#4688 §6) — without it a half-open
         // connection leaves the About dialog's list pending with no error.
-        nam->setTransferTimeout(15000);
+        nam->setTransferTimeout(kTransferTimeoutMs);
         auto* reply = nam->get(QNetworkRequest(
             QUrl("https://api.github.com/repos/aethersdr/AetherSDR/contributors")));
         connect(reply, &QNetworkReply::finished, dlg, [contribLabel, reply] {

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -1381,6 +1381,9 @@ void MainWindow::buildMenuBar()
 
         // Fetch live contributor list from GitHub API
         auto* nam = new QNetworkAccessManager(dlg);
+        // Bound the contributor fetch (#4688 §6) — without it a half-open
+        // connection leaves the About dialog's list pending with no error.
+        nam->setTransferTimeout(15000);
         auto* reply = nam->get(QNetworkRequest(
             QUrl("https://api.github.com/repos/aethersdr/AetherSDR/contributors")));
         connect(reply, &QNetworkReply::finished, dlg, [contribLabel, reply] {

--- a/src/gui/PropDashboardDialog.cpp
+++ b/src/gui/PropDashboardDialog.cpp
@@ -22,6 +22,9 @@
 #include <QVBoxLayout>
 #include "core/ThemeManager.h"
 
+// Stall timeout for the dashboard's space-weather fetches (#4688 §6).
+constexpr int kTransferTimeoutMs = 15000;
+
 namespace AetherSDR {
 
 namespace {
@@ -385,6 +388,7 @@ PropDashboardDialog::PropDashboardDialog(PropForecastClient* client, QWidget* pa
     resize(initialWidth, initialHeight);
 
     m_nam = new QNetworkAccessManager(this);
+    m_nam->setTransferTimeout(kTransferTimeoutMs);
 
     auto* root = new QVBoxLayout(bodyWidget());
     root->setContentsMargins(10, 10, 10, 10);

--- a/src/gui/PropDashboardDialog.cpp
+++ b/src/gui/PropDashboardDialog.cpp
@@ -22,12 +22,12 @@
 #include <QVBoxLayout>
 #include "core/ThemeManager.h"
 
-// Stall timeout for the dashboard's space-weather fetches (#4688 §6).
-constexpr int kTransferTimeoutMs = 15000;
-
 namespace AetherSDR {
 
 namespace {
+
+// Stall timeout for the dashboard's space-weather fetches (#4688 §6).
+constexpr int kTransferTimeoutMs = 15000;
 
 constexpr int kMetricKIndex = 0;
 constexpr int kMetricAIndex = 1;

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -47,6 +47,9 @@ namespace AetherSDR {
 namespace {
 constexpr const char* kTitleDragHandleProperty = "aetherTitleDragHandle";
 
+// Stall timeout for the GitHub latest-release version check (#4688 §6).
+constexpr int kTransferTimeoutMs = 15000;
+
 // Build a 16×18 dock-side indicator: hollow rectangle (the main window)
 // with a thin shaded strip flush against one inner wall, representing
 // the applet panel docked on that side.  Visual language matches the
@@ -982,7 +985,7 @@ void TitleBar::showFeatureRequestDialog()
     // Bound the version check (#4688 §6). Without it a half-open connection to
     // api.github.com leaves the reply pending for the lifetime of the window,
     // holding the manager and the lambda's captures with it.
-    nam->setTransferTimeout(15000);
+    nam->setTransferTimeout(kTransferTimeoutMs);
     auto* reply = nam->get(QNetworkRequest(
         QUrl("https://api.github.com/repos/aethersdr/AetherSDR/releases/latest")));
     connect(reply, &QNetworkReply::finished, this, [this, reply, nam] {

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -979,6 +979,10 @@ void TitleBar::showFeatureRequestDialog()
 {
     // Version check guard (#486) — warn if not on latest release
     auto* nam = new QNetworkAccessManager(this);
+    // Bound the version check (#4688 §6). Without it a half-open connection to
+    // api.github.com leaves the reply pending for the lifetime of the window,
+    // holding the manager and the lambda's captures with it.
+    nam->setTransferTimeout(15000);
     auto* reply = nam->get(QNetworkRequest(
         QUrl("https://api.github.com/repos/aethersdr/AetherSDR/releases/latest")));
     connect(reply, &QNetworkReply::finished, this, [this, reply, nam] {

--- a/src/gui/map/MapView.cpp
+++ b/src/gui/map/MapView.cpp
@@ -39,6 +39,12 @@ const QGV::GeoRect kWorldRect{ 70.0, -170.0, -60.0, 170.0 };
 constexpr double kPanFraction = 0.25;   // arrow-key pan, fraction of viewport
 constexpr double kZoomStep = 2.0;       // +/- key zoom factor
 constexpr qint64 kTileCacheBytes = 256LL * 1024 * 1024;
+// Stall timeout for OSM tile fetches (#4688 §6). A stalled tile is milder than
+// a stalled panel — QGVLayerTiles marks a pending tile as present, so it is not
+// re-requested until the camera moves off it, and QGVLayerTilesOnline::cancel()
+// aborts the reply at that point — but until then the tile stays blank with the
+// socket held open and nothing logged.
+constexpr int kTransferTimeoutMs = 15000;
 } // namespace
 
 void MapView::ensureTileNetworkManager()
@@ -51,6 +57,7 @@ void MapView::ensureTileNetworkManager()
     // policy — and the User-Agent uniquely identifies AetherSDR (library
     // defaults and browser impersonation are documented blocking causes).
     auto* nam = new QNetworkAccessManager(QCoreApplication::instance());
+    nam->setTransferTimeout(kTransferTimeoutMs);
     auto* cache = new QNetworkDiskCache(nam);
     cache->setCacheDirectory(
         QStandardPaths::writableLocation(QStandardPaths::CacheLocation)

--- a/tools/check_network_timeouts.py
+++ b/tools/check_network_timeouts.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+AetherSDR network transfer-timeout ratchet (#4688 §6, PR #4698).
+
+WHY THIS EXISTS
+
+A QNetworkAccessManager with no transfer timeout turns a half-open TCP
+connection into a reply that never emits finished() and never emits
+errorOccurred(). The surface that issued it simply stops: no error, no retry,
+no way for the user to tell "slow" from "gone". #4698 swept every existing
+client, but the sweep is not the durable part — the convention is. Seven call
+sites set a per-request timeout for years and eleven more never got the memo,
+which is exactly what a convention with no enforcement looks like after enough
+merges.
+
+So this gate is the point of that PR, not an accessory to it: it fails a new
+HTTP client that forgets, rather than waiting for the next audit to find it.
+
+WHAT IT CHECKS
+
+A file under src/ that CONSTRUCTS a QNetworkAccessManager (news one up, wraps
+one in a smart pointer, or declares one by value) must bound its transfers.
+Header and implementation are treated as one unit — the member is declared in
+the .h and the timeout is set in the .cpp — so evidence from either satisfies
+the other.
+
+Either form counts as bounding:
+
+  * QNetworkAccessManager::setTransferTimeout  — covers every request the
+    manager will ever issue, including ones added years from now. Preferred,
+    and the reason #4698 moved off the per-request form.
+  * QNetworkRequest::setTransferTimeout        — per request. Accepted because
+    several long-standing clients (QrzClient, KiwiPublicDirectory,
+    LocationAddressResolver, CallsignLookupService, UpdateChecker,
+    WhatsNewDialog, KiwiSdrClient) are bounded that way and are not wrong,
+    only easier to forget at the NEXT call site.
+
+Merely mentioning or including the type is not construction, so a stale
+#include does not trip the gate.
+
+This is a text scanner, not a compiler. It is deliberately blunt: it asks
+whether a file that owns a manager talks about transfer timeouts at all. A
+false pass is possible (a second manager added to a file that already bounds a
+first one); a silent, permanently-hung request is not, which is the failure
+being designed out.
+
+Usage:
+    python tools/check_network_timeouts.py           # report, exit 0
+    python tools/check_network_timeouts.py --strict  # exit 1 on any violation
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = REPO / "src"
+
+# Ways a file takes ownership of a manager. Each is (regex, description).
+CONSTRUCTION_PATTERNS = [
+    (re.compile(r"\bnew\s+QNetworkAccessManager\b"),
+     "new QNetworkAccessManager"),
+    (re.compile(r"\b(?:make_unique|make_shared|unique_ptr|shared_ptr)\s*<\s*"
+                r"QNetworkAccessManager\s*>"),
+     "smart-pointer QNetworkAccessManager"),
+    # Value member or local: "QNetworkAccessManager m_nam;" / "... nam{...};".
+    # Excludes pointer and reference declarations (those are caught at the
+    # site that actually constructs the object) and function parameters.
+    (re.compile(r"^\s*(?:static\s+|mutable\s+|inline\s+)*"
+                r"QNetworkAccessManager\s+\w+\s*[;{=]", re.MULTILINE),
+     "QNetworkAccessManager by value"),
+]
+
+BOUNDING_PATTERN = re.compile(r"\bsetTransferTimeout\s*\(")
+
+# Units exempt from the gate. Keep this list SHORT and each entry justified —
+# an entry is a promise that the requests are bounded some other way, not that
+# the timeout does not matter.
+ALLOWLIST = {
+    "src/asr/RemoteAsrBackend":
+        "runs its own QTimer + QEventLoop on a user-configurable "
+        "m_config.timeoutMs; a transfer timeout could abort a legitimate "
+        "remote inference before the user's own limit (#4698)",
+}
+
+
+def unit_key(path: Path) -> str:
+    """Header and implementation of the same class share one key."""
+    return str(path.relative_to(REPO).with_suffix("")).replace("\\", "/")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Fail when a src/ file owns a QNetworkAccessManager "
+                    "without bounding its transfers")
+    parser.add_argument("--strict", action="store_true",
+                        help="exit 1 when a violation is found")
+    args = parser.parse_args()
+
+    if not SRC.is_dir():
+        print(f"FAIL: {SRC} not found — run from the repository.")
+        return 1
+
+    # unit -> {"constructs": [(path, line, why)], "bounded": bool}
+    units: dict[str, dict] = {}
+
+    for path in sorted(SRC.rglob("*")):
+        if path.suffix not in (".cpp", ".h", ".hpp", ".cc", ".mm"):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:  # unreadable file is a real problem, not a skip
+            print(f"FAIL: cannot read {path}: {exc}")
+            return 1
+
+        if "QNetworkAccessManager" not in text and "setTransferTimeout" not in text:
+            continue
+
+        key = unit_key(path)
+        entry = units.setdefault(key, {"constructs": [], "bounded": False})
+
+        if BOUNDING_PATTERN.search(text):
+            entry["bounded"] = True
+
+        for pattern, why in CONSTRUCTION_PATTERNS:
+            for match in pattern.finditer(text):
+                line = text.count("\n", 0, match.start()) + 1
+                entry["constructs"].append((path, line, why))
+
+    violations = []
+    exempt = []
+    checked = 0
+
+    for key, entry in sorted(units.items()):
+        if not entry["constructs"]:
+            continue
+        if key in ALLOWLIST:
+            exempt.append(key)
+            continue
+        checked += 1
+        if not entry["bounded"]:
+            violations.append((key, entry["constructs"][0]))
+
+    print(f"Network transfer-timeout ratchet: {checked} manager-owning unit(s) "
+          f"checked, {len(exempt)} allow-listed, {len(violations)} violation(s).")
+
+    for key in exempt:
+        print(f"  allow-listed: {key} — {ALLOWLIST[key]}")
+
+    for key, (path, line, why) in violations:
+        rel = path.relative_to(REPO)
+        print(f"::error file={rel},line={line}::"
+              f"{why} here, but neither {key}.h nor {key}.cpp calls "
+              f"setTransferTimeout(). An unbounded manager turns a half-open "
+              f"connection into a reply that never finishes and never errors "
+              f"(#4688 §6).")
+
+    if violations:
+        print(
+            "\nSet the timeout on the MANAGER, not the request:\n"
+            "\n"
+            "    namespace {\n"
+            "    // Stall timeout for <what this client fetches> (#4688 §6).\n"
+            "    constexpr int kTransferTimeoutMs = 15000;  // 30000 for large downloads\n"
+            "    } // namespace\n"
+            "    ...\n"
+            "    m_nam->setTransferTimeout(kTransferTimeoutMs);\n"
+            "\n"
+            "It is a STALL timeout: the clock resets on every byte received, so "
+            "it bounds a dead\nconnection without capping a slow one — safe even "
+            "on a multi-hundred-MB download.\nNote it also covers the wait for "
+            "the first byte, so allow headroom where the server\nhas real "
+            "think time before it starts writing.\n"
+            "\n"
+            "If the requests are genuinely bounded some other way, add the unit "
+            "to ALLOWLIST in\nthis script with the reason.")
+        return 1 if args.strict else 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes §6 of #4688 — the last item, and the only source-behaviour one.

Most of the app's HTTP clients set no transfer timeout, so a half-open TCP
connection leaves the `QNetworkReply` pending forever: no `finished()`, no
`errorOccurred()`, no user-visible failure. The affected surfaces just never
update — space-weather panels, POTA spots, PSK Reporter, SmartLink auth, the
About dialog's contributor list, the version check, the credits panel, OSM map
tiles — and the large downloads (ASR models, NVIDIA AFX packs, firmware) sit at
a dead progress bar with no way to distinguish "slow" from "gone".

`setTransferTimeout` is a Qt 5.15 API and is not gated on the recent floor bump;
this is a plain robustness gap that the Qt review happened to surface.

The sweep is half the change. The other half is
`tools/check_network_timeouts.py`, which makes the convention enforceable so
the gap cannot reopen — see below.

### Correcting the count in the issue

#4688 §6 said "~23 `QNetworkAccessManager` clients". That counted files
*mentioning* the type, including headers. Re-counted properly, and now verified
mechanically by the new gate: **20 units own a manager. 7 already bounded their
transfers, 1 is exempt, 12 needed one across ~23 call sites.** So "~23" was
accidentally right as a count of sites and wrong as a count of clients.

### One file deliberately excluded

- **`RemoteAsrBackend`** already implements its own timeout — a `QTimer` +
  `QEventLoop` on a configurable `m_config.timeoutMs`. A transfer timeout there
  would be redundant and could abort a legitimate remote inference *before* the
  user's configured limit. It is allow-listed in the gate, with that reason
  recorded in the script rather than in a commit message.

`MainWindow.cpp:9590` was a false positive in the original survey: `cit->get()`
on a smart pointer, not a network call.

### `MapView` — added in review

The first revision skipped `MapView`, which #4688 §6 names alongside the other
eight. That was an oversight, not a decision, and it is fixed here:
`ensureTileNetworkManager()` installs a process-wide manager via
`QGV::setNetworkManager()` for OSM tiles, and it was the last request-issuing
manager left in `src/`.

Worth recording that a stalled tile is *milder* than a stalled panel, which is
why it reads as low-stakes. `QGVLayerTiles::addTile` stores
`mIndex[zoom][tilePos] = nullptr` before calling `request()`, so a tile with a
pending reply counts as present and is not re-requested — but `removeTile()` →
`cancel()` → `QGVLayerTilesOnline::removeReply()` aborts the reply when the
camera moves off it, and it is re-requested on the way back. So the failure is
a blank tile that self-heals on the next pan, not a permanent leak. Until that
pan it is still a held-open socket and a silently missing tile.

### Manager-level, not per-request

The existing seven call sites set the timeout on the `QNetworkRequest`. That is
precisely why this gap exists — a timeout that must be remembered at every call
site is one a later call site forgets. `QNetworkAccessManager::setTransferTimeout`
applies to every request the manager issues, including ones added years from now,
so the fix cannot rot the way the original convention did. A request that sets
its own value still overrides the manager's, so the seven existing sites are
unaffected.

Verified against the local Qt headers that the `int` overload is
`QT_NETWORK_INLINE_SINCE(6, 8)` — safe on the floor #4686 set.

### The gate is the durable half

"Manager-level cannot rot" is true of the managers that exist. A *new* client
that news up its own `QNetworkAccessManager` and forgets the call is the same
failure, and nothing caught it — which is the actual reason eleven clients
drifted while seven did not.

`tools/check_network_timeouts.py` fails any unit under `src/` that constructs a
manager without bounding its transfers, accepting either the manager-level or
the per-request form (the seven long-standing clients are not wrong, only
easier to forget at the next call site). Header and `.cpp` are treated as one
unit, since the member is declared in one and the timeout set in the other. A
stale `#include` is not construction and does not trip it.

It rides `static-checks.yml` as a `run:` step, per that workflow's own
instruction that "adding a gate here is a `run:` step, not a new file".

Run against the **pre-PR** tree it reports exactly the twelve clients this PR
fixes — `AsrModelManager`, `FirmwareStager`, `NvidiaAfxPack`, `PotaClient`,
`PropForecastClient`, `PskReporterClient`, `SmartLinkClient`, `Contribute`,
`MainWindow_Menus`, `PropDashboardDialog`, `TitleBar`, `MapView` — so it
reproduces, independently, the gap it exists to prevent.

### Values chosen per client, not uniformly

| Tier | Clients | Value |
|---|---|---|
| Interactive / API | PropForecastClient, PropDashboardDialog, PotaClient, SmartLinkClient, TitleBar, Contribute, MainWindow_Menus, MapView | 15 s |
| Slow first byte / large download | PskReporterClient, AsrModelManager, NvidiaAfxPack, FirmwareStager | 30 s |

15 s matches the existing `UpdateChecker` and `WhatsNewDialog`. The 30 s tier is
for transfers where a slow CDN is normal — plus PSK Reporter, which is there for
a different reason: Qt's clock also covers the wait for the **first** byte, and
the initial backfill can ask for the full 24 h window (`kMaxLookbackSec`), which
`retrieve.pskreporter.info` spends real server-side time assembling before it
writes anything. Its polling floor is already five minutes (`kMinPollMs`) for
the same reason. That one is headroom, not a defect fix — it failed visibly
either way.

**This is a stall timeout, not a deadline** — the clock resets on every byte
received. Neither tier caps a slow transfer; both fire only on a dead one. That
is what makes it safe on a multi-hundred-MB model download.

Constants live in an anonymous namespace inside `namespace AetherSDR`, matching
`QrzClient`, `KiwiPublicDirectory`, `LocationAddressResolver` and
`CallsignLookupService`. (The first revision put them at global scope. Harmless
— `constexpr` implies internal linkage and there is no unity build in this tree
— but it was the opposite of the precedent this section claimed to follow, so a
reviewer met two placements for one idiom.)

## Constitution principle honored

Principle XIV (atomic/robust behaviour) in spirit: a request that can never
complete or fail is the network equivalent of the "worked yesterday, hangs
today" class this codebase keeps designing against. Nothing here changes
persistence or settings.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [ ] Behavior verified on a real radio if applicable — N/A, none of these
      clients talk to the radio; they are all internet HTTP endpoints
- [x] Existing tests pass (CI)
- [ ] Reproduction steps documented if user-reported bug — N/A, found by audit

**Verified**

- Full local build of the branch, including the constants' move into
  `namespace AetherSDR`'s anonymous namespace.
- The gate is green on this tree (19 checked, 1 allow-listed, 0 violations) and
  reports 12 violations on the pre-PR tree — the same twelve files this PR
  touches, derived independently of the diff.
- The gate was mutation-tested: removing `PotaClient`'s timeout makes it fail
  with the right file, line and remedy, rather than passing quietly.
- Every file checked to define its constant *and* use it. The three GUI sites
  that inlined a bare `15000` in the first revision now use the named constant,
  so this is true of all twelve.

**Not verified**

The timeouts themselves do not fire in any automated test — exercising them
needs a black-holed TCP connection. The change is uniform and the failure mode
of a wrong value is a spuriously aborted request, which would show up as a
visible error rather than a silent hang, so it fails safe relative to today.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no settings touched
- [x] Code is clean-room
