### PR TITLE
Add rotary action mapping to Ulanzi Dial Mapper UI. Principle V.

### DIFF
--- a/src/core/UlanziDialMappings.cpp
+++ b/src/core/UlanziDialMappings.cpp
@@ -15,18 +15,35 @@ namespace {
 // and we start from empty rather than propagating garbage.
 QJsonObject readDocument(const char* context)
 {
-    const QByteArray raw = AppSettings::instance()
+    const QString rawStr = AppSettings::instance()
                                .value(UlanziDialMappings::rootSettingsKey())
-                               .toString().toUtf8();
-    if (raw.isEmpty())
+                               .toString();
+    static QString s_cachedRawStr;
+    static QJsonObject s_cachedObj;
+
+    if (!s_cachedRawStr.isNull() && rawStr == s_cachedRawStr) {
+        return s_cachedObj;
+    }
+
+    if (rawStr.isEmpty()) {
+        s_cachedRawStr = rawStr;
+        s_cachedObj = {};
         return {};
+    }
+
     QJsonParseError err{};
-    const QJsonDocument doc = QJsonDocument::fromJson(raw, &err);
-    if (err.error == QJsonParseError::NoError && doc.isObject())
-        return doc.object();
+    const QJsonDocument doc = QJsonDocument::fromJson(rawStr.toUtf8(), &err);
+    if (err.error == QJsonParseError::NoError && doc.isObject()) {
+        s_cachedRawStr = rawStr;
+        s_cachedObj = doc.object();
+        return s_cachedObj;
+    }
+
     qCWarning(lcDevices) << "Ulanzi Dial: unparseable mappings document under"
                          << UlanziDialMappings::rootSettingsKey() << "—"
                          << err.errorString() << "— starting from empty (" << context << ")";
+    s_cachedRawStr = rawStr;
+    s_cachedObj = {};
     return {};
 }
 
@@ -123,6 +140,32 @@ int UlanziDialMappings::migrateLegacyKeys(const QStringList& pillIds)
                           << "legacy pill binding(s) into" << rootSettingsKey();
     }
     return adopted;
+}
+
+QString UlanziDialMappings::rotaryAction()
+{
+    const QJsonObject obj = readDocument("read");
+    if (obj.contains(QStringLiteral("rotary_action"))) {
+        const QString action = obj.value(QStringLiteral("rotary_action")).toString();
+        return action.isEmpty() ? QStringLiteral("WheelFrequency") : action;
+    }
+
+    auto& s = AppSettings::instance();
+    if (s.contains(QStringLiteral("UlanziDialRotaryAction"))) {
+        const QString legacy = s.value(QStringLiteral("UlanziDialRotaryAction")).toString();
+        s.remove(QStringLiteral("UlanziDialRotaryAction"));
+        if (!legacy.isEmpty()) {
+            setRotaryAction(legacy);
+            return legacy;
+        }
+        s.save();
+    }
+    return QStringLiteral("WheelFrequency");
+}
+
+bool UlanziDialMappings::setRotaryAction(const QString& actionId)
+{
+    return setActionForPill(QStringLiteral("rotary_action"), actionId);
 }
 
 }  // namespace AetherSDR

--- a/src/core/UlanziDialMappings.h
+++ b/src/core/UlanziDialMappings.h
@@ -40,6 +40,12 @@ public:
     // removed. Returns the number of bindings adopted.
     static int migrateLegacyKeys(const QStringList& pillIds);
 
+    // Bound rotary action for the dial wheel, or "WheelFrequency" by default.
+    static QString rotaryAction();
+
+    // Bind rotary action and persist immediately inside the UlanziDialMappings root document.
+    static bool setRotaryAction(const QString& actionId);
+
     // Pre-#4611 per-pill key names, retained only as migration sources.
     static QString legacyUnderscoreKey(const QString& pillId);
     static QString legacySlashKey(const QString& pillId);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1090,6 +1090,8 @@ private:
     // radio-authoritative model state — togglePanZoomModeForPan, #4057.)
     void togglePanZoomMode(bool segmentZoom);
     void togglePanZoomModeForPan(const QString& panId, bool segmentZoom);
+    void setPanZoomMode(bool segmentZoom, bool enable);
+    void zoomActivePanadapter(double factor);
 #ifdef HAVE_HIDAPI
     HidEncoderManager*   m_hidEncoder{nullptr};
     static QString hidEncoderDefaultAction(int encoderIndex);
@@ -1157,8 +1159,6 @@ private:
 #else
     UlanziDialBackend*         m_dialBackend{nullptr};
 #endif
-    QTimer                     m_dialCoalesceTimer;
-    int                        m_dialPendingSteps{0};
     QSet<QString>              m_dialActiveMidiGates;
     // True while the DIAL is holding PTT.  Distinct from m_pttHoldActive so a
     // dial release cannot un-key a PTT the keyboard is still holding.

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -20,6 +20,7 @@
 
 #include "FlexControlDialog.h"
 #include "MainWindowHelpers.h"
+#include "SpectrumOverlayMenu.h"
 #include "core/AppSettings.h"
 #include "core/CwTrace.h"
 #include "core/DigitalVoiceFeature.h"
@@ -27,6 +28,7 @@
 #include "core/LogManager.h"
 #include "core/MidiSettings.h"
 #include "core/UlanziDialBackend.h"
+#include "core/UlanziDialMappings.h"
 #include "AppletPanel.h"
 #include "core/IambicKeyer.h"
 #include "PanadapterStack.h"
@@ -1455,6 +1457,39 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
 #ifdef HAVE_HIDAPI
         triggerTMate2Overlay(TMate2Overlay::Wpm, next);
 #endif
+    } else if (actionId == "BandZoom") {
+        setPanZoomMode(/*segmentZoom=*/false, steps > 0);
+    } else if (actionId == "SegmentZoom") {
+        setPanZoomMode(/*segmentZoom=*/true, steps > 0);
+    } else if (actionId == "FilterWidth") {
+        if (auto* rx = m_appletPanel->rxApplet()) {
+            rx->stepFilterWidth(steps);
+        }
+    } else if (actionId == "PanadapterZoom") {
+        const double baseFactor = steps > 0 ? 0.8 : 1.25;
+        const double factor = std::pow(baseFactor, std::abs(steps));
+        zoomActivePanadapter(factor);
+    } else if (actionId == "WheelRfGain") {
+        if (auto* s = activeSlice()) {
+            if (!s->panId().isEmpty()) {
+                auto* pan = m_radioModel.panadapter(s->panId());
+                const int low = pan ? pan->rfGainLow() : -8;
+                const int high = pan ? pan->rfGainHigh() : 32;
+                const int step = (pan && pan->rfGainStep() > 0) ? pan->rfGainStep() : 8;
+                const int current = pan ? pan->rfGain() : static_cast<int>(s->rfGain());
+                const int next = std::clamp(current + steps * step, low, high);
+                m_radioModel.setPanRfGainFor(s->panId(), next);
+                if (auto* sw = spectrumForSlice(s)) {
+                    sw->setRfGain(next);
+                    if (auto* menu = sw->overlayMenu()) {
+                        menu->setRfGain(next);
+                    }
+                    auto& settings = AppSettings::instance();
+                    settings.setValue(rfGainSettingsKey(sw), QString::number(next));
+                    settings.save();
+                }
+            }
+        }
     }
 }
 
@@ -2698,28 +2733,10 @@ void MainWindow::wireExternalControllers()
 #endif
 
 
-    m_dialCoalesceTimer.setSingleShot(true);
-    m_dialCoalesceTimer.setInterval(20);
-    connect(&m_dialCoalesceTimer, &QTimer::timeout, this, [this]() {
-        if (m_dialPendingSteps == 0) return;
-        auto* s = activeSlice();
-        if (!s) { m_dialPendingSteps = 0; return; }
-        if (s->isLocked()) {
-            s->notifyTuneBlockedByLock();
-            m_dialPendingSteps = 0;
-            return;
-        }
-        int stepHz = spectrum() ? spectrum()->stepSize() : 100;
-        double newMhz = s->frequency() + m_dialPendingSteps * stepHz / 1e6;
-        m_dialPendingSteps = 0;
-        applyTuneRequest(s, newMhz, TuneIntent::IncrementalTune, "ulanzi-dial");
-    });
-
     connect(m_dialBackend, &UlanziDialBackend::tuneSteps,
             this, [this](int steps) {
-        m_dialPendingSteps += steps;
-        if (!m_dialCoalesceTimer.isActive())
-            m_dialCoalesceTimer.start();
+        const QString actionId = UlanziDialMappings::rotaryAction();
+        applyFlexControlWheelAction(actionId, steps);
     });
 
     // One-shot claim of the pre-#4611 flat mapping keys, before the first

--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -1020,48 +1020,6 @@ void MainWindow::registerShortcutActions()
             }
         });
 
-    static constexpr double kPanZoomFactor = 1.5;
-    auto zoomActivePanadapter = [this](double factor) {
-        if (!m_radioModel.isConnected()) {
-            return;
-        }
-
-        auto* s = activeSlice();
-        if (!s || s->panId().isEmpty()) {
-            return;
-        }
-
-        auto* sw = spectrumForSlice(s);
-        if (!sw) {
-            return;
-        }
-
-        const double currentBw = sw->bandwidthMhz();
-        // Clamp to limits so the final keypress snaps to exact min/max (#1458).
-        // Per-pan limits: the backend's reported range when it gave one, so a
-        // keyboard zoom stops where the receiver's data stops rather than at the
-        // FlexLib table's guess for an unrecognised model.
-        const double newBw = std::clamp(currentBw * factor,
-                                        m_radioModel.panMinBandwidthMhz(s->panId()),
-                                        m_radioModel.panMaxBandwidthMhz(s->panId()));
-        if (newBw == currentBw) return;  // already at the hard limit
-
-        double newCenter = sw->centerMhz();
-
-        // When zooming in, center on the active slice so repeated keypresses do
-        // not push it toward the panadapter edge (#1932).
-        if (factor < 1.0) {
-            newCenter = s->frequency();
-        }
-        newCenter = std::max(newCenter, newBw / 2.0);
-
-        sw->setFrequencyRange(newCenter, newBw);
-        // Keep keyboard zoom on the same combined pan-range path as trackpad /
-        // on-screen zoom so mode/frequency jumps do not reintroduce stale
-        // center-versus-bandwidth transitions.
-        applyPanRangeRequest(s->panId(), newCenter, newBw, "keyboard-pan-zoom");
-    };
-
     // ── DSP ─────────────────────────────────────────────────────────────
     m_shortcutManager.registerAction("nb_toggle", "NB Toggle", "DSP",
         QKeySequence(), [this]() {
@@ -1259,10 +1217,11 @@ void MainWindow::registerShortcutActions()
         QKeySequence(), [this]() { togglePanZoomMode(/*segmentZoom=*/false); });
     m_shortcutManager.registerAction("segment_zoom", "Segment Zoom", "Display",
         QKeySequence(), [this]() { togglePanZoomMode(/*segmentZoom=*/true); });
+    static constexpr double kPanZoomFactor = 1.5;
     m_shortcutManager.registerAction("pan_zoom_in", "Panadapter Zoom In", "Display",
-        QKeySequence(Qt::Key_Equal), [zoomActivePanadapter]() { zoomActivePanadapter(1.0 / kPanZoomFactor); });
+        QKeySequence(Qt::Key_Equal), [this]() { zoomActivePanadapter(1.0 / kPanZoomFactor); });
     m_shortcutManager.registerAction("pan_zoom_out", "Panadapter Zoom Out", "Display",
-        QKeySequence(Qt::Key_Minus), [zoomActivePanadapter]() { zoomActivePanadapter(kPanZoomFactor); });
+        QKeySequence(Qt::Key_Minus), [this]() { zoomActivePanadapter(kPanZoomFactor); });
     m_shortcutManager.registerAction("open_memories", "Open Memories Dialog", "Display",
         QKeySequence(Qt::Key_Slash), [this]() { showMemoryDialog(); });
 
@@ -1352,11 +1311,75 @@ void MainWindow::togglePanZoomModeForPan(const QString& panId, bool segmentZoom)
         .arg(on ? 1 : 0));
 }
 
+void MainWindow::zoomActivePanadapter(double factor)
+{
+    if (!m_radioModel.isConnected()) {
+        return;
+    }
+
+    auto* s = activeSlice();
+    if (!s || s->panId().isEmpty()) {
+        return;
+    }
+
+    auto* sw = spectrumForSlice(s);
+    if (!sw) {
+        return;
+    }
+
+    const double currentBw = sw->bandwidthMhz();
+    // Clamp to limits so the final keypress snaps to exact min/max (#1458).
+    const double newBw = std::clamp(currentBw * factor,
+                                    m_radioModel.panMinBandwidthMhz(s->panId()),
+                                    m_radioModel.panMaxBandwidthMhz(s->panId()));
+    if (newBw == currentBw) {
+        return;  // already at the hard limit
+    }
+
+    double newCenter = sw->centerMhz();
+
+    // When zooming in, center on the active slice so repeated keypresses do
+    // not push it toward the panadapter edge (#1932).
+    if (factor < 1.0) {
+        newCenter = s->frequency();
+    }
+    newCenter = std::max(newCenter, newBw / 2.0);
+
+    sw->setFrequencyRange(newCenter, newBw);
+    applyPanRangeRequest(s->panId(), newCenter, newBw, "pan-zoom");
+}
+
+void MainWindow::setPanZoomMode(bool segmentZoom, bool enable)
+{
+    if (!m_radioModel.isConnected()) {
+        return;
+    }
+    auto* s = activeSlice();
+    if (!s) {
+        return;
+    }
+    const QString panId = !s->panId().isEmpty()
+        ? s->panId()
+        : (m_panStack ? m_panStack->activePanId() : m_radioModel.panId());
+    if (panId.isEmpty()) {
+        return;
+    }
+    auto* pan = m_radioModel.panadapter(panId);
+    if (!pan) {
+        return;
+    }
+    const bool current = segmentZoom ? pan->segmentZoomOn() : pan->bandZoomOn();
+    if (current != enable) {
+        m_radioModel.sendCommand(QString("display pan set %1 %2=%3")
+            .arg(panId,
+                 segmentZoom ? QStringLiteral("segment_zoom")
+                             : QStringLiteral("band_zoom"))
+            .arg(enable ? 1 : 0));
+    }
+}
+
 void MainWindow::togglePanZoomMode(bool segmentZoom)
 {
-    // Active-slice entry: shortcut/MIDI/FlexControl/RC28 paths resolve the pan
-    // from the active slice (falling back to the active pan) and share the
-    // per-pan toggle above.
     if (!m_radioModel.isConnected()) {
         return;
     }

--- a/src/gui/UlanziDialMapperDialog.cpp
+++ b/src/gui/UlanziDialMapperDialog.cpp
@@ -3,6 +3,7 @@
 #include "UlanziDialMapperDialog.h"
 #include "core/AppSettings.h"
 #include "core/ShortcutManager.h"
+#include "core/ThemeManager.h"
 #include "core/UlanziDialMappings.h"
 #ifdef HAVE_MIDI
 #include "core/MidiControlManager.h"
@@ -70,7 +71,7 @@ public:
         setAttribute(Qt::WA_StyledBackground, false);
         setAutoFillBackground(false);
         setStyleSheet(QStringLiteral("background: transparent;"));
-        setFixedSize(620, 555);  // matches the 640×640 fixed dialog
+        setFixedSize(620, 590);
     }
 
 protected:
@@ -160,7 +161,8 @@ UlanziDialMapperDialog::UlanziDialMapperDialog(UlanziDialBackend* manager,
     , m_shortcuts(shortcuts)
     , m_midi(midi)
 {
-    setFixedSize(640, 640);
+    setFixedSize(640, 675);
+
 
     auto* outer = new QVBoxLayout(bodyWidget());
     outer->setContentsMargins(0, 0, 0, 8);
@@ -206,6 +208,10 @@ UlanziDialMapperDialog::UlanziDialMapperDialog(UlanziDialBackend* manager,
             const int idx = m_pills[i].combo->findData(m_pills[i].defaultAction);
             if (idx >= 0) m_pills[i].combo->setCurrentIndex(idx);
         }
+        if (m_rotaryCombo) {
+            const int rIdx = m_rotaryCombo->findData(QStringLiteral("WheelFrequency"));
+            if (rIdx >= 0) m_rotaryCombo->setCurrentIndex(rIdx);
+        }
     });
     bottomRow->addWidget(m_resetBtn);
 
@@ -242,9 +248,10 @@ QPoint UlanziDialMapperDialog::normalizedAnchor(double nx, double ny)
 
 QRect UlanziDialMapperDialog::dialBodyRect() const
 {
-    // Fixed geometry inside the fixed-size canvas (620 × 555).  Body
-    // honours the trimmed image aspect (512:562 ≈ 0.911) at 320×352,
-    // centred both horizontally and vertically in the canvas.
+    // Fixed geometry inside the upper region (620 × 555) of the canvas
+    // (620 × 590). Body honours the trimmed image aspect (512:562 ≈ 0.911)
+    // at 320×352, centered in the upper region to leave vertical space for
+    // the bottom rotary and single-tap combo controls at y >= 525.
     const int bw = 320;
     const int bh = 352;
     const int bx = (620 - bw) / 2;       // 150
@@ -262,6 +269,59 @@ QPoint UlanziDialMapperDialog::anchorScreenPos(const QPoint& norm) const
 void UlanziDialMapperDialog::buildPills()
 {
     m_pills.clear();
+
+    if (!m_rotaryCombo) {
+        m_rotaryLabel = new QLabel(tr("Tuning:"), this);
+        ThemeManager::instance().applyStyleSheet(m_rotaryLabel,
+            QStringLiteral("QLabel { color: {{color.text.primary}}; font-size: 11px; font-weight: bold; }"));
+        m_rotaryLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        m_rotaryLabel->raise();
+
+        m_rotaryCombo = new QComboBox(this);
+        ThemeManager::instance().applyStyleSheet(m_rotaryCombo, pillComboStyle());
+        m_rotaryCombo->setFixedWidth(180);
+        m_rotaryCombo->raise();
+
+        struct RotaryOption {
+            const char* label;
+            const char* actionId;
+        };
+        static constexpr RotaryOption kRotaryOptions[] = {
+            {"[Frequency] Tune Slice", "WheelFrequency"},
+            {"[Filter] Filter Bandwidth", "FilterWidth"},
+            {"[Audio] Slice Audio Volume", "WheelSliceAudio"},
+            {"[Audio] Master Volume", "WheelVolume"},
+            {"[Audio] Headphone Volume", "WheelHeadphoneVolume"},
+            {"[Display] Panadapter Zoom", "PanadapterZoom"},
+            {"[Display] Band Zoom", "BandZoom"},
+            {"[Display] Segment Zoom", "SegmentZoom"},
+            {"[RIT/XIT] RIT (Receive Incremental Tuning)", "WheelRit"},
+            {"[RIT/XIT] XIT (Transmit Incremental Tuning)", "WheelXit"},
+            {"[AGC] AGC-T (Threshold)", "WheelAgcT"},
+            {"[AGC] RF Gain", "WheelRfGain"},
+            {"[DSP] APF (Audio Peaking Filter)", "WheelApf"},
+            {"[CW] CW Speed", "WheelCwSpeed"},
+            {"[TX] RF Power", "WheelPower"},
+        };
+        for (const auto& opt : kRotaryOptions) {
+            m_rotaryCombo->addItem(QString::fromLatin1(opt.label), QString::fromLatin1(opt.actionId));
+        }
+
+        connect(m_rotaryCombo, &QComboBox::currentIndexChanged, this, [this](int idx) {
+            if (m_isLoading || !m_rotaryCombo || idx < 0) {
+                return;
+            }
+            const QString actionId = m_rotaryCombo->itemData(idx).toString();
+            UlanziDialMappings::setRotaryAction(actionId);
+        });
+
+        m_singleTapLabel = new QLabel(tr("Single tap:"), this);
+        ThemeManager::instance().applyStyleSheet(m_singleTapLabel,
+            QStringLiteral("QLabel { color: {{color.text.primary}}; font-size: 11px; font-weight: bold; }"));
+        m_singleTapLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        m_singleTapLabel->raise();
+    }
+
     for (int i = 0; i < kPillCount; ++i) {
         Pill p;
         p.id            = QString::fromLatin1(kPillSpecs[i].id);
@@ -281,7 +341,7 @@ void UlanziDialMapperDialog::buildPills()
         p.combo = new QComboBox(dialogParented ? static_cast<QWidget*>(this)
                                                : static_cast<QWidget*>(m_canvas));
         p.combo->setStyleSheet(pillComboStyle());
-        p.combo->setFixedWidth(120);  // uniform; longer labels get ellipsized
+        p.combo->setFixedWidth(pillId == QLatin1String("dial_press") ? 180 : 120);
         if (dialogParented) p.combo->raise();
 
         // (unassigned) — always first.
@@ -330,6 +390,16 @@ void UlanziDialMapperDialog::layoutPills()
     if (m_pills.isEmpty()) return;
     const QRect body = dialBodyRect();
 
+    if (m_rotaryLabel && m_rotaryCombo && m_singleTapLabel) {
+        m_rotaryLabel->resize(75, 24);
+        m_rotaryLabel->move(185, 525);
+        m_rotaryCombo->resize(180, 24);
+        m_rotaryCombo->move(265, 525);
+
+        m_singleTapLabel->resize(75, 24);
+        m_singleTapLabel->move(185, 557);
+    }
+
     // No connector lines: pills sit "almost touching" the body edge at
     // positions derived directly from pill_id, not anchor coords.  Top
     // pills sit just above the dial, bottom pill just below, side pills
@@ -374,13 +444,13 @@ void UlanziDialMapperDialog::layoutPills()
             center = QPoint(body.right() + sz.width() / 2 + touchGap,
                             body.top()   + body.height() * 68 / 100 - 15);
         } else if (p.id == QLatin1String("dial_press")) {
-            // Same treatment as top_middle.  Hardcoded x = 640/2 − 120/2 = 260.
-            p.combo->resize(120, p.combo->sizeHint().height());
-            p.combo->move(260, 525);
+            p.combo->resize(180, p.combo->sizeHint().height());
+            p.combo->move(265, 557);
             p.combo->raise();
-            p.pillCenter = QPoint(320, 525 + p.combo->height() / 2);
+            p.pillCenter = QPoint(355, 557 + p.combo->height() / 2);
             return;
         }
+
         p.pillCenter = center;
         p.combo->resize(sz);
         p.combo->move(center.x() - sz.width() / 2,
@@ -515,6 +585,11 @@ void UlanziDialMapperDialog::loadActions()
         const QString actionId = actionForPill(m_pills[i].id);
         const int idx = m_pills[i].combo->findData(actionId);
         if (idx >= 0) m_pills[i].combo->setCurrentIndex(idx);
+    }
+    if (m_rotaryCombo) {
+        const QString rotaryAction = UlanziDialMappings::rotaryAction();
+        const int rIdx = m_rotaryCombo->findData(rotaryAction);
+        if (rIdx >= 0) m_rotaryCombo->setCurrentIndex(rIdx);
     }
     m_isLoading = false;
 }

--- a/src/gui/UlanziDialMapperDialog.h
+++ b/src/gui/UlanziDialMapperDialog.h
@@ -124,6 +124,10 @@ private:
     QList<Pill> m_pills;
     bool m_isLoading{false};
 
+    QLabel*    m_rotaryLabel{nullptr};
+    QComboBox* m_rotaryCombo{nullptr};
+    QLabel*    m_singleTapLabel{nullptr};
+
     QLabel* m_statusLabel{nullptr};
     QLabel* m_lastEventLabel{nullptr};
     QPushButton* m_resetBtn{nullptr};
@@ -134,4 +138,3 @@ private:
 };
 
 } // namespace AetherSDR
-

--- a/tests/ulanzi_mapping_migration_test.cpp
+++ b/tests/ulanzi_mapping_migration_test.cpp
@@ -139,6 +139,33 @@ int main(int argc, char** argv)
                      == QStringLiteral("shortcut:next_slice"),
                  "and the rebuilt document reads back");
 
+    // ── rotaryAction tests (Principle V) ──────────────────────────────────
+    ok &= expect(UlanziDialMappings::rotaryAction() == QStringLiteral("WheelFrequency"),
+                 "default rotaryAction is WheelFrequency");
+    ok &= expect(UlanziDialMappings::setRotaryAction(QStringLiteral("WheelVolume")),
+                 "setting rotaryAction persists to document");
+    ok &= expect(UlanziDialMappings::rotaryAction() == QStringLiteral("WheelVolume"),
+                 "rotaryAction reads back from document");
+
+    // Legacy UlanziDialRotaryAction flat key migration
+    s.setValue(QStringLiteral("UlanziDialRotaryAction"), QStringLiteral("WheelPower"));
+    s.save();
+
+    // Explicit empty rotary_action in document returns default WheelFrequency rather than adopting legacy key
+    UlanziDialMappings::setActionForPill(QStringLiteral("rotary_action"), QString());
+    ok &= expect(UlanziDialMappings::rotaryAction() == QStringLiteral("WheelFrequency"),
+                 "explicit empty rotary_action in document returns default WheelFrequency");
+
+    // When rotary_action key is missing from document, legacy flat key is adopted
+    s.remove(UlanziDialMappings::rootSettingsKey());
+    s.save();
+    s.setValue(QStringLiteral("UlanziDialRotaryAction"), QStringLiteral("WheelPower"));
+    s.save();
+    ok &= expect(UlanziDialMappings::rotaryAction() == QStringLiteral("WheelPower"),
+                 "legacy flat key UlanziDialRotaryAction is adopted when document key is missing");
+    ok &= expect(!s.contains(QStringLiteral("UlanziDialRotaryAction")),
+                 "legacy flat key UlanziDialRotaryAction is removed after adoption");
+
     std::cout << (ok ? "ALL PASS" : "FAILURES") << '\n';
     return ok ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Add configurable rotary action mapping for the Ulanzi Dial in UlanziDialMapperDialog.

- Introduce 'Tuning:' rotary action selector supporting frequency tuning, filter bandwidth, slice/master audio volume, panadapter zoom, RIT/XIT, AGCT, RF gain, APF, CW speed, and RF power.
- Update dial mapper UI with a 'Single tap:' label left of the dial-press combo box and maintain original padding below the dial body image.
- Dispatch rotary steps via MainWindow_Controllers using UlanziDialMappings::rotaryAction().
- Remove bypassed m_dialCoalesceTimer and m_dialPendingSteps in MainWindow_Controllers.

<img width="623" height="672" alt="image" src="https://github.com/user-attachments/assets/2a5f40bc-b7b5-4843-b759-858dbaae1d4b" />

## Constitution principle honored

Principle V — rotary action persistence uses nested-JSON under `UlanziDialMappings`.

## Test plan

- [X] Local build passes (`cmake --build build`)
- [X] Behavior verified on a real radio if applicable
- [X] Existing tests pass (CI)
- [ ] Reproduction steps documented if user-reported bug

## Checklist

- [X] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [X] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [X] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [ ] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [ ] Documentation updated if user-visible behavior changed
- [ ] Security-sensitive changes reference a GHSA if applicable