### PR TITLE
docs: the QPainter path is a build-time alternative, not a runtime fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,13 +224,13 @@ cmake --build build --target AetherSDR
 
 ### GPU Spectrum Rendering
 
-GPU-accelerated spectrum/waterfall rendering requires Qt 6.7 or greater (`QRhiWidget`). Since the build now requires Qt 6.8 as a minimum, every build — source or release binary, the aarch64 AppImage included — clears that floor and renders via QRhi.
+GPU-accelerated spectrum/waterfall rendering requires Qt 6.7 or greater (`QRhiWidget`). Since the build now requires Qt 6.8 as a minimum, no build is held back by the Qt version any more — the aarch64 AppImage included. What decides whether a given binary renders via QRhi is the `AETHER_GPU_SPECTRUM` build option, and for a source build whether Qt's private GUI headers are installed: CMake turns the option off with `GPU spectrum rendering disabled — Qt6GuiPrivate not found` when they are missing (install `qt6-base-private-dev` / `qt6-qtbase-private-devel`).
 
-The CPU `QPainter` path is a **build-time alternative, not a runtime fallback**. `AETHER_GPU_SPECTRUM` selects `SpectrumWidget`'s base class — `QRhiWidget` or `QWidget` — so a GPU-enabled binary does not contain the `QPainter` path at all; its `paintEvent()` is never compiled. Of the shipped artifacts only the Intel macOS DMG is built the other way, and deliberately: `QRhiWidget` misbehaves on older Metal/OpenGL hardware.
+The CPU `QPainter` path is a **build-time alternative, not a runtime fallback**. `AETHER_GPU_SPECTRUM` selects `SpectrumWidget`'s base class — `QRhiWidget` or `QWidget` — and `SpectrumWidget::paintEvent()`, which is what draws the spectrum on the CPU, is compiled only into the `QWidget` build. (A GPU build still uses `QPainter`, but only to rasterise overlays into textures QRhi then composites.) Of the shipped artifacts only the Intel macOS DMG is built the other way, and deliberately: `QRhiWidget` misbehaves on older Metal/OpenGL hardware.
 
 Having no GPU is usually a non-event, because in practice "no GPU" means a software rasterizer rather than nothing. QRhi comes up on whatever the platform provides — llvmpipe or softpipe (Mesa), WARP or Microsoft Basic Render (D3D11), SwiftShader — and the app detects it and says so: **Help ▸ About** shows a `Renderer:` line reading `CPU QRhi (…)` rather than `GPU QRhi (…)`, naming the backend and device. Rendering is correct, just slow.
 
-If QRhi cannot initialise at all — no usable GL/D3D/Metal, as on a headless host, in some VMs, or behind a broken driver — there is nothing to fall back to. The spectrum does not draw, and the log records `SpectrumWidget: QRhi initialization failed — no GPU backend`. The rest of the app (controls, audio, radio I/O) is unaffected.
+If QRhi cannot initialise at all — no usable GL/D3D/Metal, as on a headless host, in some VMs, or behind a broken driver — there is nothing to fall back to. The spectrum does not draw, and the failure is reported by Qt rather than by AetherSDR: the log records `QRhiWidget: QRhi is not supported on this platform.` or `QRhiWidget: No QRhi`, and `QRhiWidget::renderFailed()` fires with nothing listening, so there is no notice in the UI. The rest of the app (controls, audio, radio I/O) is unaffected.
 
 `AETHER_NO_GPU=1` forces software OpenGL on an already-built binary, without a rebuild:
 

--- a/README.md
+++ b/README.md
@@ -224,9 +224,15 @@ cmake --build build --target AetherSDR
 
 ### GPU Spectrum Rendering
 
-GPU-accelerated spectrum/waterfall rendering requires Qt 6.7 or greater (`QRhiWidget`). Since the build now requires Qt 6.8 as a minimum, every build — source or release binary, the aarch64 AppImage included — clears that floor and renders via QRhi. The CPU-based `QPainter` path remains as a runtime fallback for machines where GPU initialisation fails, not as a Qt-version fallback.
+GPU-accelerated spectrum/waterfall rendering requires Qt 6.7 or greater (`QRhiWidget`). Since the build now requires Qt 6.8 as a minimum, every build — source or release binary, the aarch64 AppImage included — clears that floor and renders via QRhi.
 
-Going the other way, `AETHER_NO_GPU=1` forces software OpenGL on an already-built binary, without a rebuild:
+The CPU `QPainter` path is a **build-time alternative, not a runtime fallback**. `AETHER_GPU_SPECTRUM` selects `SpectrumWidget`'s base class — `QRhiWidget` or `QWidget` — so a GPU-enabled binary does not contain the `QPainter` path at all; its `paintEvent()` is never compiled. Of the shipped artifacts only the Intel macOS DMG is built the other way, and deliberately: `QRhiWidget` misbehaves on older Metal/OpenGL hardware.
+
+Having no GPU is usually a non-event, because in practice "no GPU" means a software rasterizer rather than nothing. QRhi comes up on whatever the platform provides — llvmpipe or softpipe (Mesa), WARP or Microsoft Basic Render (D3D11), SwiftShader — and the app detects it and says so: **Help ▸ About** shows a `Renderer:` line reading `CPU QRhi (…)` rather than `GPU QRhi (…)`, naming the backend and device. Rendering is correct, just slow.
+
+If QRhi cannot initialise at all — no usable GL/D3D/Metal, as on a headless host, in some VMs, or behind a broken driver — there is nothing to fall back to. The spectrum does not draw, and the log records `SpectrumWidget: QRhi initialization failed — no GPU backend`. The rest of the app (controls, audio, radio I/O) is unaffected.
+
+`AETHER_NO_GPU=1` forces software OpenGL on an already-built binary, without a rebuild:
 
 ```bash
 AETHER_NO_GPU=1 ./AetherSDR-*.AppImage

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -873,7 +873,7 @@ cost a few integer adds per frame.
 | `waterfallVisibleRows*` / `waterfallHistoryRows*` | viewport and retained compact-intensity-history write rates/cost (history is written only for the visible source) |
 | `dssLiveRows*` / `dssHistoryRows*` | 96-row live 3D surface work versus deep retained scrollback work; `dssHiddenLiveRowsPerSec` exposes the hidden-Flex live-ring warming (#4081) — hidden sources retain no deep history |
 | `waterfallAllocatedBytes` / `dssAllocatedBytes` | current plus cached Flex/Kiwi/profile storage; waterfall history is counted by actually allocated lazy chunks, not logical capacity |
-| `paintsPerSec` / `paintMsPerSec` | software-QPainter path (non-zero only before QRhi init or in non-GPU builds) |
+| `paintsPerSec` / `paintMsPerSec` | software-QPainter path — always 0 in a GPU build, where `SpectrumWidget::paintEvent()` is not compiled at all (see README ▸ GPU Spectrum Rendering); non-zero only in a build configured `-DAETHER_GPU_SPECTRUM=OFF` |
 | `renderScheduler` | shared panadapter repaint scheduler counters; `coalescedRequests` and `avgWidgetsPerFlush` show cross-pan request coalescing |
 
 `selector` filters by pan index (`get panstats 0`) or objectName. `property`


### PR DESCRIPTION
## Summary

README told users that "the CPU-based `QPainter` path remains as a runtime
fallback for machines where GPU initialisation fails." It does not, and the
machines that sentence was written for are exactly the ones it misleads: they
are told a fallback will catch them, and instead the spectrum goes blank.

`AETHER_GPU_SPECTRUM` selects `SpectrumWidget`'s base class, so the choice is
made at compile time. `src/gui/SpectrumWidget.cpp:14488` puts `paintEvent()` inside
`#else // !AETHER_GPU_SPECTRUM`; it is not compiled into a GPU-enabled binary at
all. (The `#ifdef AETHER_GPU_SPECTRUM` early-return nested inside that function
is unreachable for the same reason — noted below, not touched here.) Of the five
shipped artifacts only the Intel macOS DMG is built the other way, deliberately,
because `QRhiWidget` misbehaves on older Metal/OpenGL hardware.

The section now states what actually happens without a GPU, which is the
question the old sentence was trying to answer:

- **Usually nothing**, because "no GPU" means a software rasterizer rather than
  nothing at all — llvmpipe/softpipe (Mesa), WARP or Microsoft Basic Render
  (D3D11), SwiftShader. The app already detects this
  (`qrhiDeviceNameLooksSoftware()` plus `QRhiDriverInfo::CpuDevice`) and
  `rendererDescription()` reports `CPU QRhi (…)` rather than `GPU QRhi (…)` in
  **Help ▸ About**. Correct output, slow.
- **If QRhi cannot initialise at all**, there is nothing to fall back to: the
  spectrum never draws, Qt logs `QRhiWidget: QRhi is not supported on this
  platform.` (or `QRhiWidget: No QRhi`) and emits `renderFailed()`, which
  nothing connects — so there is no notice in the UI. The rest of the app is
  unaffected.

That ordering also makes the `AETHER_NO_GPU=1` paragraph that follows coherent
for the first time: it works because it changes what QRhi runs *on*, not whether
QRhi is used — which only reads correctly once the paragraph above it is true.

`docs/automation-bridge.md` carried the same error in one cell: panstats
`paintsPerSec` was described as non-zero "before QRhi init or in non-GPU builds."
The first half cannot happen — with no `paintEvent` compiled, the counters at
`src/gui/SpectrumWidget.cpp:14506` and `:14512` can never increment in a GPU
build, so both `paintsPerSec` and `paintMsPerSec` are always 0 there.

**Deliberately not changed:** the `wavestats` table is correct as written.
`WaveformWidget` is GPU-gated the same way, but increments its paint counter
from the QRhi render path (`WaveformWidget.cpp:1322`) as well as from
`paintEvent`, so its `paintsPerSec` is meaningful in both builds — which is why
the worked example there shows 59.5 rather than 0.

Found while reviewing #4690, whose guards assert that GPU spectrum rendering is
*compiled in* on every artifact. That is a statement about artifact parity, not
about any user's hardware, and this documentation conflated the two.

## Constitution principle honored

None specifically — documentation accuracy. Adjacent to Technology Constraints
(cross-platform), in that the corrected text is what tells a user on a GPU-less
or software-rasterizer machine what to expect and what to do about it.

## Test plan

- [ ] Local build passes — N/A, documentation only, no code compiled
- [ ] Behavior verified on a real radio if applicable — N/A
- [x] Existing tests pass (CI)
- [ ] Reproduction steps documented if user-reported bug — N/A

**How the claims were verified.** Every assertion in the new text was checked
against the tree at `origin/main`, not against the old docs:

- `paintEvent` is inside `#else // !AETHER_GPU_SPECTRUM` (`src/gui/SpectrumWidget.cpp:14488`),
  and the panstats counters it increments are at `:14506` / `:14512` — the only
  write sites for either. The GPU path does time `QPainter` overlay rebuilds
  (`:13384`), but into separate overlay counters, so it cannot muddy those two.
- The software-device detection list and the `CPU QRhi (…)` / `GPU QRhi (…)`
  output format are read from `rendererDescription()` (`src/gui/SpectrumWidget.cpp:876-926`).
- The `Renderer:` line is surfaced in Help ▸ About (`src/gui/MainWindow_Menus.cpp:1278`).
- The failure strings are read out of the shipped Qt library
  (`strings /usr/lib/libQt6Widgets.so.6 | grep -i rhi`). AetherSDR's own
  `qWarning` at `src/gui/SpectrumWidget.cpp:12800` is **not** what fires:
  `initialize()` is the `QRhiWidget::initialize` override
  (`SpectrumWidget.h:805`) and its only other caller is the `render()` override
  at `:14395`, neither of which Qt invokes while `rhi` is null.
- `WaveformWidget`'s second increment site is `src/gui/WaveformWidget.cpp:1322`,
  inside the GPU section (`:1085-1619`), alongside `:447` in the `#ifndef` — which is why the wavestats table stays as-is.
- Only the Intel macOS DMG builds `-DAETHER_GPU_SPECTRUM=OFF`
  (`.github/workflows/macos-dmg.yml:151`); both AppImage legs, the Windows
  installer and the Apple Silicon DMG are ON.
- CMake turns the option off on its own when `Qt6GuiPrivate` is missing
  (`CMakeLists.txt:425-431`) — the one way a *source* build lands on the
  QPainter path, now stated in the section.

No CHANGELOG entry: no shipped behaviour changes, and `[Unreleased]` entries in
this repo are user-facing behaviour narratives.

## Follow-ups this does not do

- The blank-spectrum case degrades to a `qWarning` with no user-facing notice.
  Arguably it should say something in the UI; that is a code change and wants
  its own issue.
- The unreachable `#ifdef AETHER_GPU_SPECTRUM` block nested inside the
  `#else`-only `paintEvent` (`src/gui/SpectrumWidget.cpp:14494-14501`) is dead
  code, and the comment right below it at `:14504-14505` (“GPU builds only reach
  here before QRhi init or after GPU teardown”) states the very claim this PR is
  correcting.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no settings touched
- [x] Code is clean-room — documentation only
- [x] All meter UI uses `MeterSmoother` — N/A
- [x] Documentation updated if user-visible behavior changed — this IS the
      documentation change; no behaviour changed
- [x] Security-sensitive changes reference a GHSA if applicable — N/A

