### PR TITLE
docs: CHANGELOG.md is release-prep only; PRs must not add entries

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,5 +41,5 @@ See CONSTITUTION.md for the full list. -->
 - [ ] All meter UI uses `MeterSmoother` (AGENTS.md convention)
 - [ ] Documentation updated if user-visible behavior changed — `docs/` and the
       affected READMEs. **Not `CHANGELOG.md`**, which is a release-prep file a
-      PR must not add to (AGENTS.md); describe the change here instead
+      PR must not add to (AGENTS.md); describe it in the Summary above instead
 - [ ] Security-sensitive changes reference a GHSA if applicable

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,5 +39,7 @@ See CONSTITUTION.md for the full list. -->
 - [ ] Code is clean-room — not decompiled, disassembled, or
       reverse-engineered from a proprietary binary (Principle IV)
 - [ ] All meter UI uses `MeterSmoother` (AGENTS.md convention)
-- [ ] Documentation updated if user-visible behavior changed
+- [ ] Documentation updated if user-visible behavior changed — `docs/` and the
+      affected READMEs. **Not `CHANGELOG.md`**, which is a release-prep file a
+      PR must not add to (AGENTS.md); describe the change here instead
 - [ ] Security-sensitive changes reference a GHSA if applicable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,29 @@ Leave every *historical* mention alone. "shipped v26.7.4" and "(v26.7.4)" are
 statements about when something landed and stay true forever, so a blanket
 find-and-replace across a version bump silently corrupts them.
 
+### `CHANGELOG.md` is a release-prep file. Do not touch it in a feature PR.
+
+The table above is the **only** reason to edit `CHANGELOG.md`: a new version
+section, at release prep. An ordinary PR — a fix, a feature, a refactor —
+**must not add an entry**, however user-visible the change is. Describe it in
+the PR body and the commit message instead; those are where the reasoning
+belongs and neither one conflicts with anything.
+
+This is a mechanical rule, not a stylistic preference. Every entry is prepended
+to the top of the same `## [Unreleased]` list, so **any two PRs that both add
+one conflict with each other**, and every PR still open when one of them merges
+goes stale and needs a manual resolution. With a queue of concurrent agent PRs
+that is not an occasional annoyance — it is a conflict on essentially every
+pair. The file is append-mostly by nature and merges terribly by construction,
+so the fix is to stop writing to it outside the one moment that needs it.
+
+Reviewers: do not ask for a `CHANGELOG.md` entry, and flag one as a change to
+remove if a PR adds it. There has never been a written rule requiring per-PR
+entries — `CONTRIBUTING.md` has never mentioned the file at all — but the habit
+propagated anyway, by agents reading `git log` and copying what they saw. About
+45% of recent merges carry an entry, which is the worst of both worlds: not a
+convention anyone can rely on, and enough churn to conflict constantly.
+
 ---
 
 ## CI/CD Workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,9 @@ The table above is the **only** reason to edit `CHANGELOG.md`: a new version
 section, at release prep. An ordinary PR — a fix, a feature, a refactor —
 **must not add an entry**, however user-visible the change is. Describe it in
 the PR body and the commit message instead; those are where the reasoning
-belongs and neither one conflicts with anything.
+belongs and neither one conflicts with anything. At release prep, the section
+is written *from* those PR bodies — `gh pr list --state merged --search
+'merged:>=<last-tag-date>'` is the source of truth for what shipped.
 
 This is a mechanical rule, not a stylistic preference. Every entry is prepended
 to the top of the same `## [Unreleased]` list, so **any two PRs that both add
@@ -224,9 +226,10 @@ so the fix is to stop writing to it outside the one moment that needs it.
 Reviewers: do not ask for a `CHANGELOG.md` entry, and flag one as a change to
 remove if a PR adds it. There has never been a written rule requiring per-PR
 entries — `CONTRIBUTING.md` has never mentioned the file at all — but the habit
-propagated anyway, by agents reading `git log` and copying what they saw. About
-45% of recent merges carry an entry, which is the worst of both worlds: not a
-convention anyone can rely on, and enough churn to conflict constantly.
+propagated anyway, by agents reading `git log` and copying what they saw. When
+this rule landed it sat at 45% of recent merges (18 of the last 40, measured
+2026-08-02), which is the worst of both worlds: not a convention anyone can
+rely on, and enough churn to conflict constantly.
 
 ---
 


### PR DESCRIPTION
## Summary

Agents have been adding a `CHANGELOG.md` entry to every user-visible PR, and it conflicts constantly. This writes down the rule that stops it: **`CHANGELOG.md` is a release-prep file, and an ordinary PR must not add an entry to it.**

The mechanism is what makes this worth a rule rather than a preference. Every entry is prepended to the top of the same `## [Unreleased]` list, so *any two PRs that both add one conflict with each other*, and every PR still open when one of them merges goes stale and needs a manual resolution. With a queue of concurrent agent PRs that is not an occasional annoyance — it is a conflict on essentially every pair. #4696 hit it **twice in one afternoon**, and neither conflict was over anything but the CHANGELOG; both times the resolution was "keep both entries," which is exactly the merge a human should never have been asked to perform.

## There was never a rule requiring this

Worth stating plainly, because the habit is well established and looks like policy:

- `CONTRIBUTING.md` has **never mentioned `CHANGELOG.md`** — zero occurrences.
- `AGENTS.md`'s only reference is the five-places version table, which is a **release** step: add a new version section at the top when prepping a release. Nothing about per-PR entries.
- `CONSTITUTION.md`, `GOVERNANCE.md`, `GEMINI.md`, `.github/copilot-instructions.md` and the PR template: no mention either.

The habit propagated by agents reading `git log`, seeing entries, and copying what they saw — which is why it sits at roughly **45% of recent merges** (18 of the last 40). That is the worst of both worlds: not a convention anyone can rely on, and enough churn to conflict anyway.

So this lands as an explicit prohibition rather than being left to inference, since inference is what produced the problem.

## Changes

- **`AGENTS.md`** — new subsection under the version table: *"`CHANGELOG.md` is a release-prep file. Do not touch it in a feature PR."* Gives the mechanical reason, points authors at the PR body and commit message instead (neither of which conflicts with anything), and tells reviewers not to ask for entries and to flag one as a change to remove.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — the "Documentation updated" checkbox now scopes itself to `docs/` and the affected READMEs, and says **not** `CHANGELOG.md`. That checkbox is the exact place an author decides to add one.

`AGENTS.md` is the load-bearing file: `CLAUDE.md`, `GEMINI.md`, `CONVENTIONS.md` and `.github/copilot-instructions.md` are all pointers to it, and the @aethersdr-agent bot reads it from the repo — so this one change reaches every tool.

## Constitution principle honored

None directly — this is a workflow convention, not a governance invariant. Closest in spirit is **Principle XIII** (the operator outranks every agent): the practice being removed was agent-propagated rather than operator-chosen, and this records the operator's actual ruling.

## Test plan

- [x] Docs only — no code, no tests, no behavior. Nothing to build or run.
- [x] Verified this branch touches no `CHANGELOG.md` itself.
- [x] Confirmed the claims above by grep across `CONTRIBUTING.md`, `AGENTS.md`, `CONSTITUTION.md`, `GOVERNANCE.md`, `GEMINI.md`, `CLAUDE.md`, `.github/copilot-instructions.md` and the PR template.
- [x] The 18/40 figure measured over `git log -40 origin/main`, checking each commit for a `CHANGELOG.md` path.

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls — n/a, docs only
- [x] Code is clean-room — n/a, docs only
- [x] All meter UI uses `MeterSmoother` — n/a, docs only
- [x] Documentation updated — this PR *is* the documentation change
- [x] Security-sensitive changes reference a GHSA if applicable — n/a
