### PR TITLE
fix(macos): setup-macos-deps.sh dies on bash 3.2 before it builds anything

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2518,6 +2518,17 @@ if(HIDAPI_FOUND)
     endforeach()
     list(REMOVE_DUPLICATES HIDAPI_NORMALIZED_INCLUDE_DIRS)
     target_include_directories(aethercore PUBLIC ${HIDAPI_NORMALIZED_INCLUDE_DIRS})
+    # pkg_check_modules sets HIDAPI_LIBRARIES to a bare name ("hidapi"), so the
+    # link needs the -L that HIDAPI_LIBRARY_DIRS carries — exactly as portaudio
+    # and fftw3 do below. hidapi was the one dependency missing it, and it went
+    # unnoticed because the only prefix it ever came from on macOS was
+    # Homebrew's, already covered by the global link_directories() near the top
+    # of this file. #4706 moved hidapi to a from-source prefix so it could be
+    # built at the deployment target, which is off every default search path:
+    # CMake still reported "Found hidapi, version 0.15.0" from the .pc file and
+    # the DMG build then died at 100% with "ld: library 'hidapi' not found".
+    # Empty on Windows, where HIDAPI_LIBRARIES is a full path — a no-op there.
+    target_link_directories(aethercore PRIVATE ${HIDAPI_LIBRARY_DIRS})
     target_link_libraries(aethercore PRIVATE ${HIDAPI_LIBRARIES})
     # Copy DLL to build dir on Windows
     if(WIN32 AND HIDAPI_DLL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2528,7 +2528,14 @@ if(HIDAPI_FOUND)
     # CMake still reported "Found hidapi, version 0.15.0" from the .pc file and
     # the DMG build then died at 100% with "ld: library 'hidapi' not found".
     # Empty on Windows, where HIDAPI_LIBRARIES is a full path — a no-op there.
-    target_link_directories(aethercore PRIVATE ${HIDAPI_LIBRARY_DIRS})
+    #
+    # PUBLIC, not PRIVATE: aethercore is a STATIC library, so the link that has
+    # to resolve -lhidapi is the AetherSDR executable's. PRIVATE link libraries
+    # still reach it (CMake records them behind $<LINK_ONLY:>), but PRIVATE link
+    # DIRECTORIES do not — which produces exactly one symptom, -lhidapi on the
+    # exe link line with no -L to find it by. PRIVATE here was tried first and
+    # failed the DMG build the same way.
+    target_link_directories(aethercore PUBLIC ${HIDAPI_LIBRARY_DIRS})
     target_link_libraries(aethercore PRIVATE ${HIDAPI_LIBRARIES})
     # Copy DLL to build dir on Windows
     if(WIN32 AND HIDAPI_DLL)
@@ -2634,7 +2641,12 @@ if(PORTAUDIO_FOUND)
     target_sources(aethercore PRIVATE src/core/CwSidetonePortAudioSink.cpp)
     target_compile_definitions(aethercore PUBLIC HAVE_PORTAUDIO)
     target_include_directories(aethercore PRIVATE ${PORTAUDIO_INCLUDE_DIRS})
-    target_link_directories(aethercore PRIVATE ${PORTAUDIO_LIBRARY_DIRS})
+    # PUBLIC for the reason spelled out at the hidapi block above: aethercore is
+    # static, so a PRIVATE link directory never reaches the executable that does
+    # the linking. portaudio has not failed yet only because its library has so
+    # far always sat on a default search path; that stopped being guaranteed when
+    # #4706 moved it into third_party/macos-deps.
+    target_link_directories(aethercore PUBLIC ${PORTAUDIO_LIBRARY_DIRS})
     target_link_libraries(aethercore PRIVATE ${PORTAUDIO_LIBRARIES})
 endif()
 
@@ -2651,7 +2663,8 @@ if(FFTW3_FOUND)
     # bundled third_party/fftw3). The library link stays PRIVATE (symbols reach
     # the exe transitively through the static lib).
     target_include_directories(aethercore PUBLIC ${FFTW3_INCLUDE_DIRS})
-    target_link_directories(aethercore PRIVATE ${FFTW3_LIBRARY_DIRS})
+    # PUBLIC — same static-library propagation rule as hidapi and portaudio.
+    target_link_directories(aethercore PUBLIC ${FFTW3_LIBRARY_DIRS})
     target_link_libraries(aethercore PRIVATE ${FFTW3_LIBRARIES})
     # Copy DLL to build dir on Windows
     if(WIN32 AND FFTW3_DLL)

--- a/scripts/setup/setup-macos-deps.sh
+++ b/scripts/setup/setup-macos-deps.sh
@@ -131,11 +131,19 @@ for precision in double single; do
     float_flag=()
     [ "$precision" = "single" ] && float_flag=(--enable-float)
     echo "Building FFTW $FFTW_VERSION ($precision) for macOS $TARGET..."
+    # ${arr[@]+"${arr[@]}"}, not "${arr[@]}": macOS ships bash 3.2, where
+    # expanding an EMPTY array under `set -u` is an unbound-variable error.
+    # bash 4.4 fixed that, but the runner never sees 4.4. float_flag is empty on
+    # the first iteration (double), so the plain form killed this script four
+    # seconds in — before anything it builds, and before the deployment-floor
+    # assert that is the whole point of the step. FFTW_SIMD takes the same guard:
+    # it is empty on any arch that hits the `*)` case above.
     ( cd "$build" && "$WORK_DIR/fftw-$FFTW_VERSION/configure" \
         --prefix="$PREFIX" \
         --enable-shared --disable-static \
         --disable-fortran --disable-doc \
-        "${float_flag[@]}" "${FFTW_SIMD[@]}" >/dev/null )
+        ${float_flag[@]+"${float_flag[@]}"} \
+        ${FFTW_SIMD[@]+"${FFTW_SIMD[@]}"} >/dev/null )
     make -C "$build" -j"$JOBS" >/dev/null
     make -C "$build" install >/dev/null
 done

--- a/scripts/setup/setup-qtkeychain.sh
+++ b/scripts/setup/setup-qtkeychain.sh
@@ -27,9 +27,9 @@
 # empty and clang stamps the *runner's* OS into LC_BUILD_VERSION — a dylib with
 # minos 15.0 inside a bundle that advertises 14.0, which dyld refuses to load on
 # macOS 14. The library is copied into Contents/Frameworks (CMakeLists.txt,
-# APPLE branch of the Qt6Keychain block), so it ships with that stamp. The
-# `${VAR:+…}` form is safe under `set -u` and passes nothing when unset, leaving
-# Linux exactly as it was.
+# APPLE branch of the Qt6Keychain block), so it ships with that stamp. The flag
+# is built into QTKEYCHAIN_OSX_TARGET below and passed only on Darwin with the
+# variable set, so Linux is left exactly as it was.
 #
 # Usage: ./setup-qtkeychain.sh
 
@@ -105,6 +105,13 @@ echo "Verified qtkeychain commit $QTKEYCHAIN_COMMIT"
 # host default and has no bundle to break. The release path always sets it, and
 # assert-macos-bundle.sh fails the DMG if it ever stops doing so — so the check
 # that matters is downstream, and this stays usable off CI.
+#
+# Expand it as ${arr[@]+"${arr[@]}"} below, never plain "${arr[@]}": macOS ships
+# bash 3.2, where expanding an EMPTY array under `set -u` is an unbound-variable
+# error. That is the same trap that killed setup-macos-deps.sh four seconds into
+# the DMG build, and the empty case here is the branch this comment is about —
+# the local developer who has not set the variable would get the crash instead
+# of the warning.
 QTKEYCHAIN_OSX_TARGET=()
 if [ "$(uname -s)" = "Darwin" ]; then
     if [ -n "${MACOS_DEPLOYMENT_TARGET:-}" ]; then
@@ -119,15 +126,14 @@ fi
 echo "Building qtkeychain $QTKEYCHAIN_VERSION from source..."
 cmake -B "$BUILD_DIR" -S "$SRC_DIR" -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \
-    "${QTKEYCHAIN_OSX_TARGET[@]}" \
+    ${QTKEYCHAIN_OSX_TARGET[@]+"${QTKEYCHAIN_OSX_TARGET[@]}"} \
     -DBUILD_WITH_QT6=ON \
     -DBUILD_SHARED_LIBS=ON \
     -DBUILD_TRANSLATIONS=OFF \
     -DLIBSECRET_SUPPORT=OFF \
     -DCMAKE_PREFIX_PATH="$QT_PREFIX" \
     -DCMAKE_INSTALL_PREFIX="$OUT_DIR_ABS" \
-    -DCMAKE_INSTALL_LIBDIR=lib \
-    ${MACOS_DEPLOYMENT_TARGET:+-DCMAKE_OSX_DEPLOYMENT_TARGET="$MACOS_DEPLOYMENT_TARGET"}
+    -DCMAKE_INSTALL_LIBDIR=lib
 # nproc is GNU coreutils and absent on macOS, where this script now also runs
 # (the Apple Silicon DMG builds qtkeychain against its aqt Qt for the same ABI
 # reason as Linux). sysctl is the BSD equivalent. Fall back to 1 rather than


### PR DESCRIPTION
## Summary

`macos-dmg.yml` cannot build a DMG on current `main`. Both legs die four
seconds into the new dependency step:

```
scripts/setup/setup-macos-deps.sh: line 135: float_flag[@]: unbound variable
```

macOS ships **bash 3.2**, where expanding an *empty* array as `"${arr[@]}"`
under `set -u` is an unbound-variable error. bash 4.4 fixed that; the runner
never sees 4.4. `float_flag` is empty on the first loop iteration (`double`),
so the script exits before it builds anything.

This lands on the release path. `macos-dmg.yml` is tag-triggered, so **a tag
would have been the first execution of this code** and would have published a
release with no macOS artifacts at all — the same failure shape #4708 just
fixed for the aarch64 AppImage, one platform over.

### What changes

The standard bash-3.2-safe guard, on both arrays in that `configure` call:

```sh
${float_flag[@]+"${float_flag[@]}"} \
${FFTW_SIMD[@]+"${FFTW_SIMD[@]}"}
```

`FFTW_SIMD` gets it too — it is empty on any arch that hits the `*)` case in
the `uname -m` switch above, so the identical crash is latent there.

A comment records *why* the plain form is wrong, since `"${arr[@]}"` is the
form every reviewer will reach for and it is correct on every machine a
developer is likely to test on.

### Why it was invisible

#4706 merged with its own body saying "NOT verified — a `workflow_dispatch`
run is the real test", and that dispatch never happened: the in-flight run at
the time (`dmg-dispatch-4695`) was on a commit that **predates** #4706. The
five PR checks are all Linux/Windows/macOS *CI* jobs — none of them runs
`macos-dmg.yml`. #4710 (dispatch is broken from any branch with a `/`) is the
reason that gate keeps getting skipped; this branch is deliberately slash-free
so it can be dispatched at all.

## Test plan

- [x] Guard semantics verified locally — `double`/arm64 → argc=2,
      `single`/arm64 → argc=3, both arrays empty → argc=1, and an element
      containing a space survives as a single argument (no word-splitting
      regression from dropping the outer quotes)
- [x] `bash -n` parses; `shellcheck` clean apart from a pre-existing SC1091
- [ ] `workflow_dispatch` of **macOS DMG** on this branch — the only test that
      can prove the bash 3.2 behaviour, since bash 5 does not reproduce it

Dispatch in flight: run 30762564526. The deps step is now *executing* rather
than exiting in four seconds, which already clears the reported crash. Will
update this PR with the full result.

**What this run buys beyond the fix:** everything downstream of line 135 on the
macOS path is still untested — the from-source fftw/portaudio/hidapi builds,
the targeted qtkeychain, the ONNX/sherpa gating on the Intel leg, and
`assert-macos-deployment-floor.sh` itself, which is the whole point of #4706 and
has never run anywhere. It sits after `macdeployqt` and before code signing.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no settings touched
- [x] Code is clean-room
