### PR TITLE
fix(asr): the Metal 2.x standard is spelled macos-metal2.4, not metal2.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1517,13 +1517,21 @@ if (ENABLE_ASR)
             #    2.4 build plausible but NOT proven: ggml may still use unguarded
             #    Metal-3 intrinsics. REQUIRE_ASR_GPU=ON on the DMG job means a wrong
             #    answer is a loud build failure rather than a silently CPU-only
-            #    artifact, so this is safe to discover in CI — but it does need a
-            #    macOS run to confirm, and it has not had one.
+            #    artifact, so this is safe to discover in CI.
+            #
+            #    Note the 2.x tier is spelled `macos-metal2.4`, NOT `metal2.4`.
+            #    Metal 3 unified the platforms and dropped the prefix, so 3.0/3.1
+            #    below are correct unqualified while everything at 2.x needs it.
+            #    The unqualified 2.4 spelling is not a legacy alias — the compiler
+            #    rejects it outright ("invalid value 'metal2.4' in '-std=metal2.4'")
+            #    and lists ios-metal2.4 / macos-metal2.4 / metal3.0 / metal3.1 /
+            #    metal3.2 as the accepted set. That killed the first Intel DMG
+            #    build to reach this tier, at 32%, in run 30764239938.
             if (CMAKE_OSX_DEPLOYMENT_TARGET AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 13.0)
-                set(GGML_METAL_STD "metal2.4" CACHE STRING "" FORCE)
+                set(GGML_METAL_STD "macos-metal2.4" CACHE STRING "" FORCE)
                 set(GGML_METAL_EMBED_LIBRARY_NO_BF16 ON CACHE BOOL "" FORCE)
                 message(STATUS "ASR: Metal kernels precompiled for macOS ${CMAKE_OSX_DEPLOYMENT_TARGET} "
-                    "(metal2.4, no bf16 — props.has_bfloat clamped to match)")
+                    "(macos-metal2.4, no bf16 — props.has_bfloat clamped to match)")
             elseif (CMAKE_OSX_DEPLOYMENT_TARGET AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 14.0)
                 set(GGML_METAL_STD "metal3.0" CACHE STRING "" FORCE)
                 set(GGML_METAL_EMBED_LIBRARY_NO_BF16 ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
## Summary

The Intel DMG build dies at 32%, the first time any build has reached this tier:

```
[ 32%] Compiling Metal kernels for embedding
error: invalid value 'metal2.4' in '-std=metal2.4'
LLVM ERROR: Invalid bitcode file!
```

Metal 3 unified the platforms and dropped the platform prefix; Metal 2 and
earlier did not. The compiler's own accepted set, printed in that error, is:

```
ios-metal1.0 … ios-metal2.4
macos-metal2.1 … macos-metal2.4
metal3.0, metal3.1, metal3.2
```

So the 2.x tier must be platform-qualified and the 3.x tiers must not. The
unqualified `metal2.4` is not a legacy alias — it is rejected outright.

### What changes

One string at `CMakeLists.txt:1523`: `metal2.4` → `macos-metal2.4`.

`metal3.0` and `metal3.1` are **deliberately left alone**. The same accepted-set
list is the evidence that they are already correct, and the Apple Silicon leg
(deployment target 14.0, `metal3.1`) builds green today — qualifying them would
have broken the one leg that works.

The comment above the block is rewritten. It previously said the 2.4 build was
"plausible but NOT proven… it does need a macOS run to confirm, and it has not
had one." That run has now happened, so the comment records what it found and
why 2.x and 3.x are spelled differently — the detail most likely to be "tidied"
back out otherwise.

### Why it surfaced now

This tier only became reachable when #4706 dropped the Intel deployment target
from 13.0 to 12.0, moving that leg out of the `metal3.0` branch for the first
time. It is the fifth defect from that PR found by dispatching `macos-dmg.yml`,
after the four in #4714.

## Test plan

- [x] `cmake` configure clean on Linux — proves only that the CMake parses; the
      whole block is inside an `APPLE` guard, so Linux never evaluates it
- [ ] `workflow_dispatch` of **macOS DMG** — the real test

Dispatch in flight: run 30765103344.

**This gets past the flag, not necessarily past the compile.** The original
comment's actual concern was that ggml's shaders may use unguarded Metal-3
intrinsics that will not compile at 2.4 at all; the build died on the `-std`
argument before it could find out. If that concern holds, the next failure is
real shader errors, and the answer becomes a policy call — raise the Intel floor
back to 13.0, or drop Metal ASR on Intel — rather than a spelling fix.
`REQUIRE_ASR_GPU=ON` makes that loud rather than a silent CPU-only artifact.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no settings touched
- [x] Code is clean-room
