### PR TITLE
ci(macos): drop ASR from the Intel DMG rather than keep repairing it

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -244,9 +244,10 @@ jobs:
         run: bash scripts/setup/setup-deepfilter.sh
 
       - name: Setup ONNX Runtime (Silero VAD + speaker labeling + signal classifier)
-        # ONNX Runtime 1.27 ships no Intel-macOS prebuilt (Apple-Silicon only), so
-        # the Intel DMG builds without the ONNX ASR features (CPU whisper + Metal
-        # still ship). Apple Silicon requires them (below).
+        # ONNX Runtime 1.27 ships no Intel-macOS prebuilt (Apple-Silicon only).
+        # That was the first reason the Intel DMG went without the ONNX ASR
+        # features; it now ships no ASR at all (ENABLE_ASR=OFF, see Configure).
+        # Apple Silicon requires them.
         if: matrix.label == 'apple-silicon'
         run: bash scripts/setup/setup-onnxruntime.sh
 
@@ -260,12 +261,13 @@ jobs:
         # advertise macOS 15.5 to be honest about what it ships, which is
         # useless on hardware that mostly stops at 13.
         #
-        # Intel therefore ships whisper.cpp ASR (built from source here, so it
-        # takes the deployment target) without the sherpa backend or the
-        # ONNX-based extras. setup-sherpa-onnx.sh drops sherpa's bundled ORT on
-        # macOS so the Apple Silicon leg carries exactly one runtime — the
-        # upstream 14.0 build staged above — instead of silently preferring the
-        # 15.5 copy.
+        # That left Intel on whisper.cpp alone, and it no longer ships even that:
+        # ENABLE_ASR=OFF on that leg (see Configure for the reasoning). This step
+        # and the ONNX one above are Apple-Silicon-only for both reasons now.
+        #
+        # setup-sherpa-onnx.sh drops sherpa's bundled ORT on macOS so the Apple
+        # Silicon leg carries exactly one runtime — the upstream 14.0 build
+        # staged above — instead of silently preferring the 15.5 copy.
         if: matrix.label == 'apple-silicon'
         run: bash scripts/setup/setup-sherpa-onnx.sh
 
@@ -282,6 +284,10 @@ jobs:
         # runtime-compile path. Xcode 16 bundles the component (probe succeeds,
         # step is a no-op); Xcode 26 ships it as a separate download, so this is
         # what keeps a runner-image bump from breaking a release tag build.
+        #
+        # Apple Silicon only: the Intel leg builds ENABLE_ASR=OFF, so it compiles
+        # no Metal kernels and has no use for the toolchain.
+        if: matrix.label == 'apple-silicon'
         run: |
           xcrun -sdk macosx metal --version >/dev/null 2>&1 || \
             sudo xcodebuild -downloadComponent MetalToolchain
@@ -314,21 +320,32 @@ jobs:
           if [ "${{ matrix.label }}" = "intel" ]; then
             GPU_FLAG="-DAETHER_GPU_SPECTRUM=OFF"
           fi
-          # Require the ONNX ASR features only on Apple Silicon (ONNX Runtime 1.27
-          # has no Intel-macOS prebuilt). REQUIRE_ASR_GPU=ON on both: the Metal
-          # backend must build (the macOS runners have full Xcode with the metal
-          # compiler + the GGML_METAL_EMBED_LIBRARY fix), so a broken Metal
-          # toolchain fails the build instead of silently shipping CPU-only.
-          # ONNX and sherpa are Apple-Silicon-only, both for the ORT deployment
-          # floor explained on the sherpa setup step above. Requiring them where
-          # they are staged keeps a silent compile-out from shipping; not
-          # requiring them on Intel is the deliberate feature split, not an
-          # oversight.
-          ONNX_FLAG=""
-          SHERPA_FLAG=""
+          # ASR is an Apple-Silicon-only feature of the macOS DMGs, and the split
+          # is now total rather than partial. Apple Silicon requires all three
+          # pieces — the Metal GPU backend, the ONNX extras and the sherpa
+          # backend — so that a silent compile-out cannot ship. Requiring them
+          # where they are staged is what keeps that honest.
+          #
+          # Intel builds ENABLE_ASR=OFF outright. #4706 had already stripped it
+          # to CPU whisper alone (no ONNX, no sherpa: their ONNX Runtime carries
+          # a minos 15.5 floor no prebuilt can lower, and the Intel DMG exists to
+          # serve hardware that mostly stops at 13). What remained then broke on
+          # its own: dropping the Intel floor to 12.0 moved that leg onto the
+          # metal2.x shader tier for the first time, which #4718 found to be
+          # misspelled and which is unproven beyond that — ggml's kernels may use
+          # unguarded Metal-3 intrinsics that cannot compile at 2.4 at all.
+          #
+          # Rather than keep discovering that a release-day workflow at a time,
+          # the Intel artifact drops speech-to-text. It is a deliberate product
+          # call on fewer than 30 Intel-Mac users in the download figures, not a
+          # build workaround: an Intel Mac has no GPU worth running ASR on, and
+          # CPU-only whisper on that hardware is not a feature worth the release
+          # risk. REQUIRE_ASR_GPU therefore is NOT passed on Intel — with ASR off
+          # there is no GPU backend to require, and asking for one would fail
+          # configure.
+          ASR_FLAGS="-DENABLE_ASR=OFF"
           if [ "${{ matrix.label }}" = "apple-silicon" ]; then
-            ONNX_FLAG="-DREQUIRE_ASR_ONNX=ON"
-            SHERPA_FLAG="-DREQUIRE_ASR_SHERPA=ON"
+            ASR_FLAGS="-DREQUIRE_ASR_GPU=ON -DREQUIRE_ASR_ONNX=ON -DREQUIRE_ASR_SHERPA=ON"
           fi
           # Both legs: qtkeychain is built from source against the aqt Qt, so
           # make its absence fatal. find_package(Qt6Keychain QUIET) otherwise
@@ -344,9 +361,7 @@ jobs:
             -DCMAKE_OSX_DEPLOYMENT_TARGET="${{ matrix.deploy_target }}" \
             -DCMAKE_PREFIX_PATH="$QT_PREFIX;$DEPS_PREFIX;$(brew --prefix)" \
             -DMQTT_TLS=OFF \
-            -DREQUIRE_ASR_GPU=ON \
-            $SHERPA_FLAG \
-            $ONNX_FLAG \
+            $ASR_FLAGS \
             $KEYCHAIN_FLAG \
             $GPU_FLAG 2>&1 | tee configure.log
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ AetherSDR brings full FlexRadio operation to Linux, macOS, and Windows — each 
 - **AetherSweep** — in-panadapter SWR analyzer with log scale, threshold-band shading, and interpolated bandwidth at SWR ≤ 1.5 / 2.0
 - **SpotHub** — DX Cluster, RBN, WSJT-X, POTA, and FreeDV Reporter spots with auto-mode switch
 - **CW operator suite** — real-time Morse decoder, MIDI/keyboard straight-key & iambic paddles with full QSK, optional Quindar tones
-- **Copy Assist (speech-to-text)** — on-device transcription of received voice via whisper.cpp, docked under the waterfall with confidence color-coding; CPU or GPU (Vulkan/Metal, auto-detected), download-on-demand models, and an optional remote OpenAI-compatible endpoint (see [`docs/asr-copy-assist.md`](docs/asr-copy-assist.md))
+- **Copy Assist (speech-to-text)** — on-device transcription of received voice via whisper.cpp, docked under the waterfall with confidence color-coding; CPU or GPU (Vulkan/Metal, auto-detected), download-on-demand models, and an optional remote OpenAI-compatible endpoint. Not in the Intel macOS build — it would force a macOS 15.5 floor on hardware that mostly cannot reach it (see [`docs/asr-copy-assist.md`](docs/asr-copy-assist.md))
 - **FreeDV RADE** — AI digital-voice codec with a client-side neural encoder/decoder
 - **SmartLink remote + TCI v2.0 server** — Auth0/TLS WAN operation, and CAT + audio + IQ + CW + spots over a single TCI WebSocket
 - **Broad hardware control** — rigctld + virtual-serial CAT, MIDI mapping, the FlexControl knob, serial PTT/CW keying, and Multi-Flex operation alongside SmartSDR/Maestro

--- a/docs/asr-copy-assist.md
+++ b/docs/asr-copy-assist.md
@@ -115,6 +115,23 @@ The selected model runs on the **GPU when one is available**, else CPU
 Without the toolchain the build is CPU-only, unchanged. A GPU-enabled binary
 still runs on GPU-less hosts.
 
+### Not shipped on the Intel macOS DMG
+
+The **Intel macOS release build has no ASR at all** (`ENABLE_ASR=OFF`, #4719).
+Building it from source on an Intel Mac still works; this is about the shipped
+artifact.
+
+The reason is reach, not the feature. The ASR stack pulls in an ONNX Runtime
+built at `minos 15.5`, and dyld enforces that floor on every Mach-O it loads —
+so a DMG carrying it requires macOS 15.5 no matter what it advertises, which
+excludes most of the older Intel hardware that artifact exists for (#4713,
+#4532). Dropping ASR is what lets the Intel DMG hold a 12.0 floor. Intel Macs
+also have no GPU worth running ASR on, so what was left there after the ONNX
+and sherpa backends came out was CPU-only whisper.
+
+Apple Silicon is unaffected: Metal 3.1 with bf16, plus the ONNX and sherpa
+backends, all required at configure time.
+
 ## sherpa-onnx models (non-whisper engines)
 
 The model picker's **"sherpa-onnx model…"** entry (shown when sherpa-onnx is


### PR DESCRIPTION
## Summary

The Intel DMG ships no speech-to-text: `ENABLE_ASR=OFF` on that leg. Apple
Silicon is untouched — Metal 3.1 with bf16, ONNX and sherpa, all three required.

**The point is hardware reach, not trimming a feature.** ASR is what made the
Intel artifact unusable on the machines it exists to serve. The ONNX Runtime
that the ASR stack pulls in (bundled inside the sherpa-onnx prebuilt) is built
at `minos 15.5` on both slices, and dyld enforces that floor on every Mach-O it
loads — so the shipped Intel DMG, advertising 13.0, actually required **macOS
15.5**. That excludes every Intel Mac Sequoia dropped, which is most of the
older hardware this artifact is for: the 2017 iMac in #4532 tops out at Ventura
13.7 and could never have launched it. That is #4713, and it is the direct cause
of #4532.

So the trade is not "Intel users lose ASR." It is: **ASR on Intel, reachable by
a sliver of Intel Macs — or no ASR on Intel, reachable by all of them.** With
fewer than 30 Intel-Mac users in the download figures to begin with, an
artifact most of them cannot launch is the worse half of that trade.

### How this finishes the job #4706 started

#4706 removed the 15.5 sources — sherpa and the ONNX extras — and rebuilt the
Homebrew-bottle dependencies from source at the target, taking Intel from an
effective 15.5 down to a declared and real 12.0. That left CPU whisper.cpp as
the last ASR remnant, and it promptly broke at the new floor: 12.0 moved that
leg onto the `metal2.x` shader tier for the first time, where #4718 found the
`-std` spelling wrong and where nothing past the flag has ever been proven —
ggml's kernels may use unguarded Metal-3 intrinsics that cannot compile at 2.4
at all.

Rather than keep repairing a feature that only existed on Intel in a degraded,
CPU-only form — on hardware with no GPU worth running ASR on anyway — this drops
it and keeps the 12.0 floor that actually lets old Intel Macs run the app.

### What changes

Dropping the feature has consequences beyond one flag, so this is four changes:

- **`ENABLE_ASR=OFF` on Intel**, via a single `ASR_FLAGS` variable.
- **`REQUIRE_ASR_GPU` is no longer passed on Intel.** With ASR off there is no
  GPU backend to require and asking for one fails configure — the naive
  one-line version of this change breaks the build a different way. Apple
  Silicon's three requirements (GPU, ONNX, sherpa) now go through that same
  variable instead of two flags plus a hardcoded third, so the split reads in
  one place.
- **`Ensure offline Metal toolchain` is Apple-Silicon-only.** Intel compiles no
  Metal kernels and has no use for it.
- **Two stale comments corrected.** The ONNX and sherpa setup steps both still
  claimed Intel shipped "CPU whisper + Metal". A wrong comment about which
  features a release artifact carries is worse than no comment.

## Test plan

- [x] `-DENABLE_ASR=OFF` configures (`-- ASR: disabled (-DENABLE_ASR=OFF)`) and
      builds a **complete `AetherSDR` executable** on Linux — the OFF path is
      sound, not merely nominally supported. This is the part testable without
      a Mac, and it is platform-agnostic.
- [ ] `workflow_dispatch` of **macOS DMG** — the real test for both legs

Dispatch in flight: run 30765546421. No PR check touches `macos-dmg.yml`; it is
tag-triggered, which is how #4706 merged with five defects in it (four fixed in
#4714, one in #4718).

The floor assert added by #4706 is what will confirm the 12.0 claim on the Intel
leg — `assert-macos-deployment-floor.sh`, step 25. It has passed on Apple
Silicon (`OK — 37 Mach-O files, all load on macOS 14.0`) and has never run on
Intel.

### What this does not settle

The `macos-metal2.4` spelling from #4718 becomes unexercised — no shipping
artifact has a floor below 13.0 any more. Tracked in #4720 along with the
vendored bf16 patch that exists to serve it.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no settings touched
- [x] Code is clean-room
