### PR TITLE
feat(gui): thumbnail view for the Choose Background Image dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1034,6 +1034,7 @@ set(GUI_SOURCES
     src/gui/GradientEditorDialog.cpp
     src/gui/TokenEditorWidget.cpp
     src/gui/CompactColorPicker.cpp
+    src/gui/ImageFileDialog.cpp
 )
 
 # Bundled RNNoise (Mozilla/Xiph BSD-3) — client-side neural noise suppression

--- a/src/gui/ImageFileDialog.cpp
+++ b/src/gui/ImageFileDialog.cpp
@@ -190,16 +190,21 @@ QString getBackgroundImagePath(QWidget* parent, const QString& caption)
     if (grid && listView) {
         // Deliberately not touching QFileDialog's own view/flow/layout
         // (setViewMode, setFlow, setWrapping, setResizeMode,
-        // setUniformItemSizes): reconfiguring the internal listView into a
-        // wrapped icon grid broke double-click activation on the "Computer"
-        // root (drive entries stopped responding to clicks). Real machine
-        // testing on Windows caught this. Sticking to icon-size-only keeps
-        // native navigation (List and Detail both) completely untouched.
+        // setUniformItemSizes) — that was ruled out on real hardware as the
+        // cause of broken drive/folder navigation.
+        //
+        // The actual cause: QFileDialogPrivate's own navigation slots
+        // (_q_enterDirectory and friends) map a clicked view index back to
+        // the real QFileSystemModel via a private `proxyModel` pointer that
+        // is only populated by QFileDialog::setProxyModel(). Setting
+        // listView/treeView's model directly (as this used to do) leaves
+        // that private pointer null, so the dialog resolves proxy-model
+        // indices against the raw model and silently fails to navigate —
+        // clicking anything did nothing. setProxyModel() is the sanctioned
+        // API for exactly this (augmenting the model backing the dialog's
+        // views) and wires both listView and treeView itself.
         auto* proxy = new ImageThumbnailProxyModel(&dlg);
-        proxy->setSourceModel(listView->model());
-        listView->setModel(proxy);
-        if (treeView && treeView->model() == proxy->sourceModel())
-            treeView->setModel(proxy);
+        dlg.setProxyModel(proxy);
 
         const QSize defaultIconSize = listView->iconSize();
 

--- a/src/gui/ImageFileDialog.cpp
+++ b/src/gui/ImageFileDialog.cpp
@@ -114,13 +114,28 @@ public:
     {
     }
 
+    // Gates real-thumbnail decoration on/off. False returns the untouched
+    // generic file icon (QIdentityProxyModel::data() passthrough) — the
+    // normal small-icon list. True supplies the real decoded photo instead.
+    // Kept as an explicit switch rather than relying on icon-size alone:
+    // whether the delegate visibly scales a raw QPixmap decoration to a
+    // changed view iconSize() is not reliable, so "off" must mean a
+    // genuinely different (generic-icon) decoration value, not just a
+    // smaller copy of the same thumbnail.
+    void setShowThumbnails(bool on)
+    {
+        if (m_showThumbnails == on)
+            return;
+        m_showThumbnails = on;
+    }
+
     QVariant data(const QModelIndex& index, int role) const override
     {
         // Name is column 0; Size/Type/Date Modified are separate indexes on
         // the same row. Without this check every column got the same
         // thumbnail for Qt::DecorationRole (the path lookup is column-
         // agnostic), crowding the attribute columns' text out entirely.
-        if (role != Qt::DecorationRole || index.column() != 0)
+        if (role != Qt::DecorationRole || index.column() != 0 || !m_showThumbnails)
             return QIdentityProxyModel::data(index, role);
 
         const QString path = pathForIndex(index);
@@ -172,6 +187,7 @@ private:
     }
 
     QSet<QString> m_pending;
+    bool m_showThumbnails = false;
 };
 
 } // namespace
@@ -234,15 +250,19 @@ QString getBackgroundImagePath(QWidget* parent, const QString& caption)
         const int previewRowSpan = std::max(1, grid->rowCount() - 1);
         grid->addWidget(previewLabel, 1, grid->columnCount(), previewRowSpan, 1, Qt::AlignTop);
 
-        auto applyThumbnailSize = [listView, treeView, defaultIconSize](bool large) {
+        auto applyThumbnailMode = [listView, treeView, proxy, defaultIconSize](bool large) {
+            proxy->setShowThumbnails(large);
             const QSize size = large ? kThumbnailDecodeSize : defaultIconSize;
             listView->setIconSize(size);
-            if (treeView)
+            listView->viewport()->update();
+            if (treeView) {
                 treeView->setIconSize(size);
+                treeView->viewport()->update();
+            }
         };
 
-        QObject::connect(thumbButton, &QToolButton::toggled, &dlg, [applyThumbnailSize](bool on) {
-            applyThumbnailSize(on);
+        QObject::connect(thumbButton, &QToolButton::toggled, &dlg, [applyThumbnailMode](bool on) {
+            applyThumbnailMode(on);
             auto& s = AppSettings::instance();
             s.setValue(QStringLiteral("ImageFileDialog/ThumbnailView"),
                        on ? QStringLiteral("True") : QStringLiteral("False"));

--- a/src/gui/ImageFileDialog.cpp
+++ b/src/gui/ImageFileDialog.cpp
@@ -84,8 +84,18 @@ QImage decodeThumbnail(const QString& path, const QSize& targetSize)
     if (dim.isValid() && (dim.width() > kMaxDecodeDimension || dim.height() > kMaxDecodeDimension))
         return {};
     reader.setAutoTransform(true);
-    reader.setScaledSize(targetSize.expandedTo(QSize(1, 1)));
-    return reader.read();
+    // Preserve aspect ratio rather than stretching into a square: when the
+    // reader can report the source size up front, scale to the largest size
+    // that fits targetSize (cheap, since e.g. JPEG decodes DCT-scaled at the
+    // computed size); otherwise fall back to scaling after the full decode.
+    if (dim.isValid()) {
+        reader.setScaledSize(dim.scaled(targetSize.expandedTo(QSize(1, 1)), Qt::KeepAspectRatio));
+        return reader.read();
+    }
+    const QImage img = reader.read();
+    return img.isNull() ? img
+                         : img.scaled(targetSize.expandedTo(QSize(1, 1)), Qt::KeepAspectRatio,
+                                      Qt::SmoothTransformation);
 }
 
 void updatePreview(QLabel* label, const QString& path)
@@ -299,7 +309,7 @@ QString getBackgroundImagePath(QWidget* parent, const QString& caption)
         auto selectMode = [applyThumbnailMode](bool large) {
             applyThumbnailMode(large);
             auto& s = AppSettings::instance();
-            s.setValue(QStringLiteral("ImageFileDialog/ThumbnailView"),
+            s.setValue(QStringLiteral("ImageFileDialogThumbnailView"),
                        large ? QStringLiteral("True") : QStringLiteral("False"));
             s.save();
         };
@@ -316,7 +326,7 @@ QString getBackgroundImagePath(QWidget* parent, const QString& caption)
         });
 
         auto& s = AppSettings::instance();
-        const bool persisted = s.value(QStringLiteral("ImageFileDialog/ThumbnailView"),
+        const bool persisted = s.value(QStringLiteral("ImageFileDialogThumbnailView"),
                                         QStringLiteral("False")).toString()
             == QStringLiteral("True");
         // Exactly one of these fires toggled(true), applying the persisted

--- a/src/gui/ImageFileDialog.cpp
+++ b/src/gui/ImageFileDialog.cpp
@@ -178,6 +178,12 @@ QString getBackgroundImagePath(QWidget* parent, const QString& caption)
     dlg.setFileMode(QFileDialog::ExistingFile);
     dlg.setOption(QFileDialog::DontUseNativeDialog, true);
     dlg.setAcceptMode(QFileDialog::AcceptOpen);
+    // Detail (name/date modified/type/size columns, small icons) instead of
+    // the default, which shows the "Computer" root's drives as large icons —
+    // distracting, and inconsistent with how the rest of the list renders.
+    // Qt's own view, not the native shell's (DontUseNativeDialog above), so
+    // this is identical across Windows/Linux/macOS.
+    dlg.setViewMode(QFileDialog::Detail);
 
     // Best-effort augmentation: if QFileDialog's internal layout/widget
     // names ever change under us, fall back to the plain (wider-filter)

--- a/src/gui/ImageFileDialog.cpp
+++ b/src/gui/ImageFileDialog.cpp
@@ -37,6 +37,9 @@ namespace {
 // (CallsignCard::setPhotoPath) — a small file can still claim a huge pixel
 // count, which would freeze/OOM the GUI on decode.
 constexpr int kMaxDecodeDimension = 4096;
+// 4096 x 4096 x 4 bytes (ARGB32), i.e. the same worst case the dimension
+// guard above already allows through when size() is known.
+constexpr int kMaxDecodeAllocationMiB = 64;
 const QSize kThumbnailDecodeSize(96, 96);
 // Caps the preview decode target: the preview label grows with the dialog
 // (Expanding size policy), so decoding at its raw size could mean decoding
@@ -95,17 +98,22 @@ QImage decodeThumbnail(const QString& path, const QSize& targetSize)
     // Preserve aspect ratio rather than stretching into a square: when the
     // reader can report the source size up front, scale to the largest size
     // that fits targetSize (cheap, since e.g. JPEG decodes DCT-scaled at the
-    // computed size). When it can't, we still always set a scaled decode
-    // target before read() -- capped at kMaxDecodeDimension, mirroring the
-    // guard above that this path skips because dim is invalid -- so a huge
-    // or hostile source image can't force a full-resolution decode; the
-    // aspect ratio is then fixed up on the (already bounded) returned image.
-    reader.setScaledSize(dim.isValid() ? dim.scaled(cap, Qt::KeepAspectRatio)
-                                        : QSize(kMaxDecodeDimension, kMaxDecodeDimension));
+    // computed size).
+    if (dim.isValid()) {
+        reader.setScaledSize(dim.scaled(cap, Qt::KeepAspectRatio));
+        return reader.read();
+    }
+    // dim invalid: we can't precompute an aspect-correct scaled size, and
+    // requesting an arbitrary scaled decode target here wouldn't bound the
+    // expensive part anyway -- only JPEG's DCT scaling decodes directly at
+    // the requested size; every other format handler still fully decodes at
+    // native resolution first and downscales afterward. setAllocationLimit()
+    // aborts the decode (returning a null image) once it would exceed this
+    // budget, which is what actually guards against a decompression bomb
+    // when the pre-decode dimension check above can't run.
+    reader.setAllocationLimit(kMaxDecodeAllocationMiB);
     const QImage img = reader.read();
-    if (img.isNull() || dim.isValid())
-        return img;
-    return img.scaled(cap, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    return img.isNull() ? img : img.scaled(cap, Qt::KeepAspectRatio, Qt::SmoothTransformation);
 }
 
 void updatePreview(QLabel* label, const QString& path)

--- a/src/gui/ImageFileDialog.cpp
+++ b/src/gui/ImageFileDialog.cpp
@@ -21,6 +21,7 @@
 #include <QStringList>
 #include <QStyle>
 #include <QToolButton>
+#include <QTreeView>
 #include <QtConcurrent/QtConcurrentRun>
 #include <QFutureWatcher>
 
@@ -102,10 +103,9 @@ void updatePreview(QLabel* label, const QString& path)
 
 // Wraps QFileDialog's internal QFileSystemModel to supply real image
 // thumbnails for Qt::DecorationRole instead of the generic per-filetype
-// icon. QFileDialog::ViewMode has no native thumbnail mode (#4717) — this
-// proxy is what makes IconMode on the internal list view show anything
-// useful. Decoding happens off the GUI thread; results land in a bounded,
-// mtime-keyed QPixmapCache.
+// icon (#4717). Shared between the dialog's listView and treeView so both
+// List and Detail mode show real thumbnails. Decoding happens off the GUI
+// thread; results land in a bounded, mtime-keyed QPixmapCache.
 class ImageThumbnailProxyModel : public QIdentityProxyModel
 {
 public:
@@ -184,17 +184,29 @@ QString getBackgroundImagePath(QWidget* parent, const QString& caption)
     // dialog rather than crashing.
     auto* grid = qobject_cast<QGridLayout*>(dlg.layout());
     auto* listView = dlg.findChild<QListView*>(QStringLiteral("listView"));
+    auto* treeView = dlg.findChild<QTreeView*>(QStringLiteral("treeView"));
     QLabel* previewLabel = nullptr;
 
     if (grid && listView) {
+        // Deliberately not touching QFileDialog's own view/flow/layout
+        // (setViewMode, setFlow, setWrapping, setResizeMode,
+        // setUniformItemSizes): reconfiguring the internal listView into a
+        // wrapped icon grid broke double-click activation on the "Computer"
+        // root (drive entries stopped responding to clicks). Real machine
+        // testing on Windows caught this. Sticking to icon-size-only keeps
+        // native navigation (List and Detail both) completely untouched.
         auto* proxy = new ImageThumbnailProxyModel(&dlg);
         proxy->setSourceModel(listView->model());
         listView->setModel(proxy);
+        if (treeView && treeView->model() == proxy->sourceModel())
+            treeView->setModel(proxy);
+
+        const QSize defaultIconSize = listView->iconSize();
 
         auto* thumbButton = new QToolButton(&dlg);
         thumbButton->setObjectName(QStringLiteral("imageDialogThumbnailToggle"));
         thumbButton->setCheckable(true);
-        thumbButton->setToolTip(QStringLiteral("Thumbnail view"));
+        thumbButton->setToolTip(QStringLiteral("Large thumbnails"));
         thumbButton->setIcon(dlg.style()->standardIcon(QStyle::SP_FileDialogContentsView));
         grid->addWidget(thumbButton, 0, grid->columnCount());
 
@@ -207,26 +219,15 @@ QString getBackgroundImagePath(QWidget* parent, const QString& caption)
         const int previewRowSpan = std::max(1, grid->rowCount() - 1);
         grid->addWidget(previewLabel, 1, grid->columnCount(), previewRowSpan, 1, Qt::AlignTop);
 
-        auto applyViewMode = [&dlg, listView](bool thumbnails) {
-            if (thumbnails) {
-                dlg.setViewMode(QFileDialog::List);
-                listView->setViewMode(QListView::IconMode);
-                listView->setIconSize(kThumbnailDecodeSize);
-                listView->setGridSize(kThumbnailDecodeSize + QSize(16, 16));
-                listView->setWrapping(true);
-                listView->setResizeMode(QListView::Adjust);
-                listView->setFlow(QListView::LeftToRight);
-                listView->setUniformItemSizes(true);
-            } else {
-                listView->setViewMode(QListView::ListMode);
-                listView->setFlow(QListView::TopToBottom);
-                listView->setWrapping(false);
-                listView->setGridSize(QSize());
-            }
+        auto applyThumbnailSize = [listView, treeView, defaultIconSize](bool large) {
+            const QSize size = large ? kThumbnailDecodeSize : defaultIconSize;
+            listView->setIconSize(size);
+            if (treeView)
+                treeView->setIconSize(size);
         };
 
-        QObject::connect(thumbButton, &QToolButton::toggled, &dlg, [applyViewMode](bool on) {
-            applyViewMode(on);
+        QObject::connect(thumbButton, &QToolButton::toggled, &dlg, [applyThumbnailSize](bool on) {
+            applyThumbnailSize(on);
             auto& s = AppSettings::instance();
             s.setValue(QStringLiteral("ImageFileDialog/ThumbnailView"),
                        on ? QStringLiteral("True") : QStringLiteral("False"));

--- a/src/gui/ImageFileDialog.cpp
+++ b/src/gui/ImageFileDialog.cpp
@@ -15,10 +15,13 @@
 #include <QPersistentModelIndex>
 #include <QPixmap>
 #include <QPixmapCache>
+#include <QResizeEvent>
 #include <QSet>
 #include <QSize>
+#include <QSizePolicy>
 #include <QStringList>
 #include <QStyle>
+#include <QTimer>
 #include <QToolButton>
 #include <QTreeView>
 #include <QtConcurrent/QtConcurrentRun>
@@ -109,6 +112,42 @@ void updatePreview(QLabel* label, const QString& path)
     }
     label->setPixmap(QPixmap::fromImage(img));
 }
+
+// Preview pane (#4717): grows with the dialog instead of staying pinned at
+// its initial size, matching the platform file picker's resizable preview.
+// Re-decoding at the new size on every intermediate frame of a live resize
+// drag would stutter, so resizeEvent debounces via a timer rather than
+// refreshing immediately; setPreviewPath() (a selection change, not a
+// resize) still refreshes right away.
+class PreviewLabel : public QLabel
+{
+public:
+    explicit PreviewLabel(QWidget* parent)
+        : QLabel(parent)
+    {
+        m_refreshTimer.setSingleShot(true);
+        m_refreshTimer.setInterval(50);
+        connect(&m_refreshTimer, &QTimer::timeout, this, [this] { updatePreview(this, m_path); });
+    }
+
+    void setPreviewPath(const QString& path)
+    {
+        m_path = path;
+        updatePreview(this, m_path);
+    }
+
+protected:
+    void resizeEvent(QResizeEvent* event) override
+    {
+        QLabel::resizeEvent(event);
+        if (!m_path.isEmpty())
+            m_refreshTimer.start();
+    }
+
+private:
+    QString m_path;
+    QTimer m_refreshTimer;
+};
 
 // Wraps QFileDialog's internal QFileSystemModel to supply real image
 // thumbnails for Qt::DecorationRole instead of the generic per-filetype
@@ -220,7 +259,7 @@ QString getBackgroundImagePath(QWidget* parent, const QString& caption)
     auto* grid = qobject_cast<QGridLayout*>(dlg.layout());
     auto* listView = dlg.findChild<QListView*>(QStringLiteral("listView"));
     auto* treeView = dlg.findChild<QTreeView*>(QStringLiteral("treeView"));
-    QLabel* previewLabel = nullptr;
+    PreviewLabel* previewLabel = nullptr;
 
     if (grid && listView) {
         // Deliberately not touching QFileDialog's own view/flow/layout
@@ -284,14 +323,21 @@ QString getBackgroundImagePath(QWidget* parent, const QString& caption)
         viewButtons->addButton(smallIconsButton);
         viewButtons->addButton(thumbButton);
 
-        previewLabel = new QLabel(&dlg);
+        previewLabel = new PreviewLabel(&dlg);
         previewLabel->setObjectName(QStringLiteral("imageDialogPreviewLabel"));
-        previewLabel->setFixedSize(180, 180);
+        previewLabel->setMinimumSize(180, 180);
+        previewLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
         previewLabel->setAlignment(Qt::AlignCenter);
         previewLabel->setFrameShape(QFrame::StyledPanel);
         previewLabel->setScaledContents(false);
+        const int previewColumn = grid->columnCount();
         const int previewRowSpan = std::max(1, grid->rowCount() - 1);
-        grid->addWidget(previewLabel, 1, grid->columnCount(), previewRowSpan, 1, Qt::AlignTop);
+        // No alignment argument: passing one (e.g. the old Qt::AlignTop)
+        // pins the widget to its size hint within the cell instead of
+        // stretching it to fill the cell, which is what let the dialog grow
+        // around it without the preview itself growing.
+        grid->addWidget(previewLabel, 1, previewColumn, previewRowSpan, 1);
+        grid->setColumnStretch(previewColumn, 1);
 
         auto applyThumbnailMode = [listView, treeView, proxy, defaultIconSize](bool large) {
             proxy->setShowThumbnails(large);
@@ -324,7 +370,7 @@ QString getBackgroundImagePath(QWidget* parent, const QString& caption)
 
     if (previewLabel) {
         QObject::connect(&dlg, &QFileDialog::currentChanged, &dlg,
-                          [previewLabel](const QString& path) { updatePreview(previewLabel, path); });
+                          [previewLabel](const QString& path) { previewLabel->setPreviewPath(path); });
     }
 
     if (dlg.exec() != QDialog::Accepted)

--- a/src/gui/ImageFileDialog.cpp
+++ b/src/gui/ImageFileDialog.cpp
@@ -116,7 +116,11 @@ public:
 
     QVariant data(const QModelIndex& index, int role) const override
     {
-        if (role != Qt::DecorationRole)
+        // Name is column 0; Size/Type/Date Modified are separate indexes on
+        // the same row. Without this check every column got the same
+        // thumbnail for Qt::DecorationRole (the path lookup is column-
+        // agnostic), crowding the attribute columns' text out entirely.
+        if (role != Qt::DecorationRole || index.column() != 0)
             return QIdentityProxyModel::data(index, role);
 
         const QString path = pathForIndex(index);

--- a/src/gui/ImageFileDialog.cpp
+++ b/src/gui/ImageFileDialog.cpp
@@ -1,7 +1,5 @@
 #include "ImageFileDialog.h"
 
-#include "core/AppSettings.h"
-
 #include <QButtonGroup>
 #include <QDialog>
 #include <QFileDialog>
@@ -306,35 +304,22 @@ QString getBackgroundImagePath(QWidget* parent, const QString& caption)
             }
         };
 
-        auto selectMode = [applyThumbnailMode](bool large) {
-            applyThumbnailMode(large);
-            auto& s = AppSettings::instance();
-            s.setValue(QStringLiteral("ImageFileDialogThumbnailView"),
-                       large ? QStringLiteral("True") : QStringLiteral("False"));
-            s.save();
-        };
         // Both buttons' toggled(true) fires exactly once per user click (the
         // group's exclusivity fires toggled(false) on the other button too,
         // ignored here) — each branch only acts on becoming the active one.
-        QObject::connect(thumbButton, &QToolButton::toggled, &dlg, [selectMode](bool on) {
+        QObject::connect(thumbButton, &QToolButton::toggled, &dlg, [applyThumbnailMode](bool on) {
             if (on)
-                selectMode(true);
+                applyThumbnailMode(true);
         });
-        QObject::connect(smallIconsButton, &QToolButton::toggled, &dlg, [selectMode](bool on) {
+        QObject::connect(smallIconsButton, &QToolButton::toggled, &dlg, [applyThumbnailMode](bool on) {
             if (on)
-                selectMode(false);
+                applyThumbnailMode(false);
         });
 
-        auto& s = AppSettings::instance();
-        const bool persisted = s.value(QStringLiteral("ImageFileDialogThumbnailView"),
-                                        QStringLiteral("False")).toString()
-            == QStringLiteral("True");
-        // Exactly one of these fires toggled(true), applying the persisted
-        // mode above.
-        if (persisted)
-            thumbButton->setChecked(true);
-        else
-            smallIconsButton->setChecked(true);
+        // Always open in Detail + small icons, matching the dialog's
+        // pre-#4717 behavior; the view mode isn't persisted across opens,
+        // only within the current dialog session via the toggle above.
+        smallIconsButton->setChecked(true);
     }
 
     if (previewLabel) {

--- a/src/gui/ImageFileDialog.cpp
+++ b/src/gui/ImageFileDialog.cpp
@@ -91,18 +91,21 @@ QImage decodeThumbnail(const QString& path, const QSize& targetSize)
     if (dim.isValid() && (dim.width() > kMaxDecodeDimension || dim.height() > kMaxDecodeDimension))
         return {};
     reader.setAutoTransform(true);
+    const QSize cap = targetSize.expandedTo(QSize(1, 1));
     // Preserve aspect ratio rather than stretching into a square: when the
     // reader can report the source size up front, scale to the largest size
     // that fits targetSize (cheap, since e.g. JPEG decodes DCT-scaled at the
-    // computed size); otherwise fall back to scaling after the full decode.
-    if (dim.isValid()) {
-        reader.setScaledSize(dim.scaled(targetSize.expandedTo(QSize(1, 1)), Qt::KeepAspectRatio));
-        return reader.read();
-    }
+    // computed size). When it can't, we still always set a scaled decode
+    // target before read() -- capped at kMaxDecodeDimension, mirroring the
+    // guard above that this path skips because dim is invalid -- so a huge
+    // or hostile source image can't force a full-resolution decode; the
+    // aspect ratio is then fixed up on the (already bounded) returned image.
+    reader.setScaledSize(dim.isValid() ? dim.scaled(cap, Qt::KeepAspectRatio)
+                                        : QSize(kMaxDecodeDimension, kMaxDecodeDimension));
     const QImage img = reader.read();
-    return img.isNull() ? img
-                         : img.scaled(targetSize.expandedTo(QSize(1, 1)), Qt::KeepAspectRatio,
-                                      Qt::SmoothTransformation);
+    if (img.isNull() || dim.isValid())
+        return img;
+    return img.scaled(cap, Qt::KeepAspectRatio, Qt::SmoothTransformation);
 }
 
 void updatePreview(QLabel* label, const QString& path)

--- a/src/gui/ImageFileDialog.cpp
+++ b/src/gui/ImageFileDialog.cpp
@@ -2,6 +2,7 @@
 
 #include "core/AppSettings.h"
 
+#include <QButtonGroup>
 #include <QDialog>
 #include <QFileDialog>
 #include <QFileInfo>
@@ -232,7 +233,36 @@ QString getBackgroundImagePath(QWidget* parent, const QString& caption)
         auto* proxy = new ImageThumbnailProxyModel(&dlg);
         dlg.setProxyModel(proxy);
 
+        // QFileSystemModel populates a directory's rows asynchronously —
+        // rowCount() reads 0 until its background scan finishes and
+        // directoryLoaded() fires. An already-scanned (cached) directory
+        // resolves before the view ever paints, so it looks instant; a
+        // fresh one can leave the view showing zero rows against a root
+        // index that is otherwise perfectly valid, until something else
+        // happens to force a re-layout. Re-applying rootIndex is a public,
+        // idempotent way to force that re-layout (QAbstractItemView
+        // doesn't skip it just because the index value is unchanged).
+        if (auto* fsModel = qobject_cast<QFileSystemModel*>(proxy->sourceModel())) {
+            QObject::connect(fsModel, &QFileSystemModel::directoryLoaded, &dlg,
+                              [listView, treeView](const QString&) {
+                                  listView->setRootIndex(listView->rootIndex());
+                                  if (treeView)
+                                      treeView->setRootIndex(treeView->rootIndex());
+                              });
+        }
+
         const QSize defaultIconSize = listView->iconSize();
+
+        // Two mutually-exclusive view buttons (Explorer-style view switcher)
+        // rather than one checkable toggle: clicking a button always selects
+        // it; clicking the already-active one is a no-op (QButtonGroup
+        // exclusivity), so neither button un-selects itself.
+        auto* smallIconsButton = new QToolButton(&dlg);
+        smallIconsButton->setObjectName(QStringLiteral("imageDialogSmallIconsButton"));
+        smallIconsButton->setCheckable(true);
+        smallIconsButton->setToolTip(QStringLiteral("Small icons"));
+        smallIconsButton->setIcon(dlg.style()->standardIcon(QStyle::SP_FileDialogListView));
+        grid->addWidget(smallIconsButton, 0, grid->columnCount());
 
         auto* thumbButton = new QToolButton(&dlg);
         thumbButton->setObjectName(QStringLiteral("imageDialogThumbnailToggle"));
@@ -240,6 +270,11 @@ QString getBackgroundImagePath(QWidget* parent, const QString& caption)
         thumbButton->setToolTip(QStringLiteral("Large thumbnails"));
         thumbButton->setIcon(dlg.style()->standardIcon(QStyle::SP_FileDialogContentsView));
         grid->addWidget(thumbButton, 0, grid->columnCount());
+
+        auto* viewButtons = new QButtonGroup(&dlg);
+        viewButtons->setExclusive(true);
+        viewButtons->addButton(smallIconsButton);
+        viewButtons->addButton(thumbButton);
 
         previewLabel = new QLabel(&dlg);
         previewLabel->setObjectName(QStringLiteral("imageDialogPreviewLabel"));
@@ -261,19 +296,35 @@ QString getBackgroundImagePath(QWidget* parent, const QString& caption)
             }
         };
 
-        QObject::connect(thumbButton, &QToolButton::toggled, &dlg, [applyThumbnailMode](bool on) {
-            applyThumbnailMode(on);
+        auto selectMode = [applyThumbnailMode](bool large) {
+            applyThumbnailMode(large);
             auto& s = AppSettings::instance();
             s.setValue(QStringLiteral("ImageFileDialog/ThumbnailView"),
-                       on ? QStringLiteral("True") : QStringLiteral("False"));
+                       large ? QStringLiteral("True") : QStringLiteral("False"));
             s.save();
+        };
+        // Both buttons' toggled(true) fires exactly once per user click (the
+        // group's exclusivity fires toggled(false) on the other button too,
+        // ignored here) — each branch only acts on becoming the active one.
+        QObject::connect(thumbButton, &QToolButton::toggled, &dlg, [selectMode](bool on) {
+            if (on)
+                selectMode(true);
+        });
+        QObject::connect(smallIconsButton, &QToolButton::toggled, &dlg, [selectMode](bool on) {
+            if (on)
+                selectMode(false);
         });
 
         auto& s = AppSettings::instance();
         const bool persisted = s.value(QStringLiteral("ImageFileDialog/ThumbnailView"),
                                         QStringLiteral("False")).toString()
             == QStringLiteral("True");
-        thumbButton->setChecked(persisted); // fires toggled() above when true
+        // Exactly one of these fires toggled(true), applying the persisted
+        // mode above.
+        if (persisted)
+            thumbButton->setChecked(true);
+        else
+            smallIconsButton->setChecked(true);
     }
 
     if (previewLabel) {

--- a/src/gui/ImageFileDialog.cpp
+++ b/src/gui/ImageFileDialog.cpp
@@ -38,6 +38,12 @@ namespace {
 // count, which would freeze/OOM the GUI on decode.
 constexpr int kMaxDecodeDimension = 4096;
 const QSize kThumbnailDecodeSize(96, 96);
+// Caps the preview decode target: the preview label grows with the dialog
+// (Expanding size policy), so decoding at its raw size could mean decoding
+// at whatever huge size the user resizes the dialog to. QLabel centers the
+// (unscaled) pixmap within the available space, so capping here doesn't
+// change what's visible for any label smaller than this.
+const QSize kPreviewMaxDecodeSize(512, 512);
 
 const QSet<QByteArray>& supportedImageFormats()
 {
@@ -105,7 +111,7 @@ void updatePreview(QLabel* label, const QString& path)
         label->clear();
         return;
     }
-    const QImage img = decodeThumbnail(path, label->size());
+    const QImage img = decodeThumbnail(path, label->size().boundedTo(kPreviewMaxDecodeSize));
     if (img.isNull()) {
         label->clear();
         return;
@@ -309,6 +315,11 @@ QString getBackgroundImagePath(QWidget* parent, const QString& caption)
         smallIconsButton->setCheckable(true);
         smallIconsButton->setToolTip(QStringLiteral("Small icons"));
         smallIconsButton->setIcon(dlg.style()->standardIcon(QStyle::SP_FileDialogListView));
+        // Tooltips aren't reliably exposed to assistive tech on icon-only
+        // buttons; set the accessible name/description explicitly.
+        smallIconsButton->setAccessibleName(QStringLiteral("Small icons"));
+        smallIconsButton->setAccessibleDescription(
+            QStringLiteral("Show the file list with small icons"));
         grid->addWidget(smallIconsButton, 0, grid->columnCount());
 
         auto* thumbButton = new QToolButton(&dlg);
@@ -316,6 +327,9 @@ QString getBackgroundImagePath(QWidget* parent, const QString& caption)
         thumbButton->setCheckable(true);
         thumbButton->setToolTip(QStringLiteral("Large thumbnails"));
         thumbButton->setIcon(dlg.style()->standardIcon(QStyle::SP_FileDialogContentsView));
+        thumbButton->setAccessibleName(QStringLiteral("Large thumbnails"));
+        thumbButton->setAccessibleDescription(
+            QStringLiteral("Show the file list with large image thumbnails"));
         grid->addWidget(thumbButton, 0, grid->columnCount());
 
         auto* viewButtons = new QButtonGroup(&dlg);
@@ -330,6 +344,9 @@ QString getBackgroundImagePath(QWidget* parent, const QString& caption)
         previewLabel->setAlignment(Qt::AlignCenter);
         previewLabel->setFrameShape(QFrame::StyledPanel);
         previewLabel->setScaledContents(false);
+        previewLabel->setAccessibleName(QStringLiteral("Image preview"));
+        previewLabel->setAccessibleDescription(
+            QStringLiteral("Preview of the currently selected image file"));
         const int previewColumn = grid->columnCount();
         const int previewRowSpan = std::max(1, grid->rowCount() - 1);
         // No alignment argument: passing one (e.g. the old Qt::AlignTop)

--- a/src/gui/ImageFileDialog.cpp
+++ b/src/gui/ImageFileDialog.cpp
@@ -1,0 +1,253 @@
+#include "ImageFileDialog.h"
+
+#include "core/AppSettings.h"
+
+#include <QDialog>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QFileSystemModel>
+#include <QFrame>
+#include <QGridLayout>
+#include <QIdentityProxyModel>
+#include <QImage>
+#include <QImageReader>
+#include <QLabel>
+#include <QListView>
+#include <QPersistentModelIndex>
+#include <QPixmap>
+#include <QPixmapCache>
+#include <QSet>
+#include <QSize>
+#include <QStringList>
+#include <QStyle>
+#include <QToolButton>
+#include <QtConcurrent/QtConcurrentRun>
+#include <QFutureWatcher>
+
+#include <algorithm>
+
+namespace AetherSDR {
+
+namespace {
+
+// Mirrors the decompression-bomb guard added for #3990
+// (CallsignCard::setPhotoPath) — a small file can still claim a huge pixel
+// count, which would freeze/OOM the GUI on decode.
+constexpr int kMaxDecodeDimension = 4096;
+const QSize kThumbnailDecodeSize(96, 96);
+
+const QSet<QByteArray>& supportedImageFormats()
+{
+    static const QSet<QByteArray> formats = [] {
+        QSet<QByteArray> s;
+        for (const QByteArray& f : QImageReader::supportedImageFormats())
+            s.insert(f.toLower());
+        return s;
+    }();
+    return formats;
+}
+
+bool isSupportedImage(const QString& path)
+{
+    const QString suffix = QFileInfo(path).suffix().toLower();
+    return !suffix.isEmpty() && supportedImageFormats().contains(suffix.toUtf8());
+}
+
+QString buildImageFilter()
+{
+    const QSet<QByteArray>& formats = supportedImageFormats();
+    if (formats.isEmpty())
+        return QStringLiteral("Images (*.png *.jpg *.jpeg *.bmp)");
+    QStringList patterns;
+    patterns.reserve(formats.size());
+    for (const QByteArray& f : formats)
+        patterns << QStringLiteral("*.%1").arg(QString::fromLatin1(f));
+    patterns.sort();
+    return QStringLiteral("Images (%1)").arg(patterns.join(QLatin1Char(' ')));
+}
+
+QString cacheKey(const QString& path)
+{
+    const QFileInfo info(path);
+    return QStringLiteral("bgimg:%1:%2")
+        .arg(path, QString::number(info.lastModified().toMSecsSinceEpoch()));
+}
+
+// Decodes DCT-scaled where the format supports it (e.g. JPEG), so scaling
+// down to targetSize keeps this cheap even for large source images.
+QImage decodeThumbnail(const QString& path, const QSize& targetSize)
+{
+    QImageReader reader(path);
+    const QSize dim = reader.size();
+    if (dim.isValid() && (dim.width() > kMaxDecodeDimension || dim.height() > kMaxDecodeDimension))
+        return {};
+    reader.setAutoTransform(true);
+    reader.setScaledSize(targetSize.expandedTo(QSize(1, 1)));
+    return reader.read();
+}
+
+void updatePreview(QLabel* label, const QString& path)
+{
+    if (path.isEmpty() || !isSupportedImage(path)) {
+        label->clear();
+        return;
+    }
+    const QImage img = decodeThumbnail(path, label->size());
+    if (img.isNull()) {
+        label->clear();
+        return;
+    }
+    label->setPixmap(QPixmap::fromImage(img));
+}
+
+// Wraps QFileDialog's internal QFileSystemModel to supply real image
+// thumbnails for Qt::DecorationRole instead of the generic per-filetype
+// icon. QFileDialog::ViewMode has no native thumbnail mode (#4717) — this
+// proxy is what makes IconMode on the internal list view show anything
+// useful. Decoding happens off the GUI thread; results land in a bounded,
+// mtime-keyed QPixmapCache.
+class ImageThumbnailProxyModel : public QIdentityProxyModel
+{
+public:
+    explicit ImageThumbnailProxyModel(QObject* parent)
+        : QIdentityProxyModel(parent)
+    {
+    }
+
+    QVariant data(const QModelIndex& index, int role) const override
+    {
+        if (role != Qt::DecorationRole)
+            return QIdentityProxyModel::data(index, role);
+
+        const QString path = pathForIndex(index);
+        if (path.isEmpty())
+            return QIdentityProxyModel::data(index, role);
+
+        QPixmap cached;
+        if (QPixmapCache::find(cacheKey(path), &cached))
+            return cached;
+
+        const_cast<ImageThumbnailProxyModel*>(this)->scheduleDecode(
+            path, QPersistentModelIndex(mapToSource(index)));
+        return QIdentityProxyModel::data(index, role);
+    }
+
+private:
+    QString pathForIndex(const QModelIndex& index) const
+    {
+        const auto* fsModel = qobject_cast<const QFileSystemModel*>(sourceModel());
+        if (!fsModel)
+            return {};
+        const QModelIndex srcIdx = mapToSource(index);
+        if (!srcIdx.isValid() || fsModel->isDir(srcIdx))
+            return {};
+        const QString path = fsModel->filePath(srcIdx);
+        return isSupportedImage(path) ? path : QString();
+    }
+
+    void scheduleDecode(const QString& path, const QPersistentModelIndex& srcIdx)
+    {
+        if (m_pending.contains(path))
+            return;
+        m_pending.insert(path);
+
+        auto* watcher = new QFutureWatcher<QImage>(this);
+        connect(watcher, &QFutureWatcher<QImage>::finished, this, [this, watcher, path, srcIdx] {
+            m_pending.remove(path);
+            const QImage img = watcher->result();
+            watcher->deleteLater();
+            if (img.isNull() || !srcIdx.isValid())
+                return;
+            QPixmapCache::insert(cacheKey(path), QPixmap::fromImage(img));
+            const QModelIndex proxyIdx = mapFromSource(srcIdx);
+            if (proxyIdx.isValid())
+                emit dataChanged(proxyIdx, proxyIdx, {Qt::DecorationRole});
+        });
+        watcher->setFuture(QtConcurrent::run(
+            [path] { return decodeThumbnail(path, kThumbnailDecodeSize); }));
+    }
+
+    QSet<QString> m_pending;
+};
+
+} // namespace
+
+QString getBackgroundImagePath(QWidget* parent, const QString& caption)
+{
+    QFileDialog dlg(parent, caption, QString(), buildImageFilter());
+    dlg.setFileMode(QFileDialog::ExistingFile);
+    dlg.setOption(QFileDialog::DontUseNativeDialog, true);
+    dlg.setAcceptMode(QFileDialog::AcceptOpen);
+
+    // Best-effort augmentation: if QFileDialog's internal layout/widget
+    // names ever change under us, fall back to the plain (wider-filter)
+    // dialog rather than crashing.
+    auto* grid = qobject_cast<QGridLayout*>(dlg.layout());
+    auto* listView = dlg.findChild<QListView*>(QStringLiteral("listView"));
+    QLabel* previewLabel = nullptr;
+
+    if (grid && listView) {
+        auto* proxy = new ImageThumbnailProxyModel(&dlg);
+        proxy->setSourceModel(listView->model());
+        listView->setModel(proxy);
+
+        auto* thumbButton = new QToolButton(&dlg);
+        thumbButton->setObjectName(QStringLiteral("imageDialogThumbnailToggle"));
+        thumbButton->setCheckable(true);
+        thumbButton->setToolTip(QStringLiteral("Thumbnail view"));
+        thumbButton->setIcon(dlg.style()->standardIcon(QStyle::SP_FileDialogContentsView));
+        grid->addWidget(thumbButton, 0, grid->columnCount());
+
+        previewLabel = new QLabel(&dlg);
+        previewLabel->setObjectName(QStringLiteral("imageDialogPreviewLabel"));
+        previewLabel->setFixedSize(180, 180);
+        previewLabel->setAlignment(Qt::AlignCenter);
+        previewLabel->setFrameShape(QFrame::StyledPanel);
+        previewLabel->setScaledContents(false);
+        const int previewRowSpan = std::max(1, grid->rowCount() - 1);
+        grid->addWidget(previewLabel, 1, grid->columnCount(), previewRowSpan, 1, Qt::AlignTop);
+
+        auto applyViewMode = [&dlg, listView](bool thumbnails) {
+            if (thumbnails) {
+                dlg.setViewMode(QFileDialog::List);
+                listView->setViewMode(QListView::IconMode);
+                listView->setIconSize(kThumbnailDecodeSize);
+                listView->setGridSize(kThumbnailDecodeSize + QSize(16, 16));
+                listView->setWrapping(true);
+                listView->setResizeMode(QListView::Adjust);
+                listView->setFlow(QListView::LeftToRight);
+                listView->setUniformItemSizes(true);
+            } else {
+                listView->setViewMode(QListView::ListMode);
+                listView->setFlow(QListView::TopToBottom);
+                listView->setWrapping(false);
+                listView->setGridSize(QSize());
+            }
+        };
+
+        QObject::connect(thumbButton, &QToolButton::toggled, &dlg, [applyViewMode](bool on) {
+            applyViewMode(on);
+            auto& s = AppSettings::instance();
+            s.setValue(QStringLiteral("ImageFileDialog/ThumbnailView"),
+                       on ? QStringLiteral("True") : QStringLiteral("False"));
+            s.save();
+        });
+
+        auto& s = AppSettings::instance();
+        const bool persisted = s.value(QStringLiteral("ImageFileDialog/ThumbnailView"),
+                                        QStringLiteral("False")).toString()
+            == QStringLiteral("True");
+        thumbButton->setChecked(persisted); // fires toggled() above when true
+    }
+
+    if (previewLabel) {
+        QObject::connect(&dlg, &QFileDialog::currentChanged, &dlg,
+                          [previewLabel](const QString& path) { updatePreview(previewLabel, path); });
+    }
+
+    if (dlg.exec() != QDialog::Accepted)
+        return {};
+    return dlg.selectedFiles().value(0, QString());
+}
+
+} // namespace AetherSDR

--- a/src/gui/ImageFileDialog.h
+++ b/src/gui/ImageFileDialog.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <QString>
+
+class QWidget;
+
+namespace AetherSDR {
+
+// Drop-in replacement for QFileDialog::getOpenFileName() for picking a
+// background image (#4717). Adds a thumbnail/grid view toggle, an image
+// preview pane, and widens the filter to every format QImageReader can
+// decode. Returns an empty string if the user cancels.
+QString getBackgroundImagePath(QWidget* parent, const QString& caption);
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -36,6 +36,7 @@
 #include "AmpApplet.h"
 #include "AcomApplet.h"
 #include "HealthApplet.h"
+#include "ImageFileDialog.h"
 #include "MeterApplet.h"
 #include "ProfileSwitcherApplet.h"
 #include "SMeterWidget.h"
@@ -66,7 +67,6 @@
 
 #include <QDateTime>
 #include <QElapsedTimer>
-#include <QFileDialog>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonParseError>
@@ -4059,13 +4059,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             sw, &SpectrumWidget::setWfBlankerThreshold);
     connect(menu, &SpectrumOverlayMenu::backgroundImageRequested,
             this, [sw] {
-        QString path = QFileDialog::getOpenFileName(
-            sw->window(),
-            "Choose Background Image",
-            QString(),
-            "Images (*.png *.jpg *.jpeg *.bmp)",
-            nullptr,
-            QFileDialog::DontUseNativeDialog);
+        const QString path = getBackgroundImagePath(sw->window(), "Choose Background Image");
         if (path.isEmpty()) return;
         sw->setBackgroundImage(path);
         auto& s = AppSettings::instance();


### PR DESCRIPTION
## Summary

- Adds a thumbnail/preview experience to the "Choose Background Image" dialog, which previously used `QFileDialog::getOpenFileName(..., DontUseNativeDialog)` and showed only generic per-filetype icons (`DontUseNativeDialog` is required for this app's custom theming and has no native thumbnail view mode).
- Two mutually exclusive view buttons ("Small icons" / "Large thumbnails", Explorer-style switcher) let the user pick between the dialog's normal small icons and larger real, decoded image thumbnails.
- Adds a preview pane showing a larger decode of the currently selected file. The pane grows with the dialog (Expanding size policy + column stretch) instead of staying pinned at a fixed size, matching the platform picker's resizable preview; re-decoding on resize is debounced so a live resize drag doesn't stutter.
- Widens the file filter to every format `QImageReader` can decode, rather than a hardcoded `*.png *.jpg *.jpeg *.bmp` list (`SpectrumWidget::setBackgroundImage()` already accepts anything `QImage` can load).
- The dialog always opens in Detail view with small icons (matching the pre-#4717 default); the thumbnail toggle applies only for the current dialog session and is not persisted across opens.

Thumbnail decoding happens off the GUI thread (`QtConcurrent`/`QFutureWatcher`) with the same decompression-bomb guard used in `CallsignCard::setPhotoPath` (#3990), and results are cached in a bounded, mtime-keyed `QPixmapCache`.

Fixes #4717

## Test plan

- [x] Manual testing on Windows 11: open dialog, navigate drives/folders, switch view modes, verify real thumbnails decode and the preview pane updates
- [x] Verify Detail view shows correct Size/Type/Date Modified text (not thumbnails) alongside the Name column's icon
- [x] Built and manually tested on Windows and Linux Mint 22.1: dialog navigation, view-mode switching, thumbnail decoding, and preview-pane resize/growth all confirmed on both platforms