### PR TITLE
Fix missing 3D FFT history outlines on Linux/OpenGL

### DIFF
--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -8,6 +8,21 @@
 
 namespace AetherSDR {
 
+enum class DssOutlinePipelineMode {
+    DedicatedRibbonPipeline,
+    SharedFillPipeline,
+};
+
+// The OpenGL backend reuses the fill program for ribbon outlines: its separate
+// program loses the mesh resources despite the same shader/SRB configuration.
+constexpr DssOutlinePipelineMode dssOutlinePipelineModeForBackend(
+    bool openGlBackend)
+{
+    return openGlBackend
+        ? DssOutlinePipelineMode::SharedFillPipeline
+        : DssOutlinePipelineMode::DedicatedRibbonPipeline;
+}
+
 struct FrequencyFrame {
     double centerMhz{0.0};
     double bandwidthMhz{0.0};

--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -24,6 +24,23 @@ constexpr DssOutlinePipelineMode dssOutlinePipelineModeForBackend(
         : DssOutlinePipelineMode::DedicatedRibbonPipeline;
 }
 
+// The pipeline the outline draw binds, given the mode above. Templated on the
+// pipeline type purely so the selection stays testable without a QRhi device:
+// SpectrumWidget instantiates it with QRhiGraphicsPipeline*. Keeping the
+// selection here rather than as a ternary at the draw site is what lets
+// spectrum_preview_logic_test pin the mapping the renderer actually uses.
+// dedicatedPipeline is null on OpenGL — never created — so the shared-fill
+// answer must not depend on it.
+template <typename PipelineT>
+constexpr PipelineT* dssOutlinePipelineFor(DssOutlinePipelineMode mode,
+                                           PipelineT* fillPipeline,
+                                           PipelineT* dedicatedPipeline)
+{
+    return mode == DssOutlinePipelineMode::SharedFillPipeline
+        ? fillPipeline
+        : dedicatedPipeline;
+}
+
 struct FrequencyFrame {
     double centerMhz{0.0};
     double bandwidthMhz{0.0};

--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -13,12 +13,13 @@ enum class DssOutlinePipelineMode {
     SharedFillPipeline,
 };
 
-// The OpenGL backend reuses the fill program for ribbon outlines: live probes
-// showed flat/stale outlines with a separate, identically configured program.
+// QRhi's OpenGLES2 backend, which covers desktop GL as well as GLES, reuses the
+// fill program for ribbon outlines: live probes showed flat/stale outlines
+// with a separate, identically configured program.
 constexpr DssOutlinePipelineMode dssOutlinePipelineModeForBackend(
-    bool openGlBackend)
+    bool openGlEs2Backend)
 {
-    return openGlBackend
+    return openGlEs2Backend
         ? DssOutlinePipelineMode::SharedFillPipeline
         : DssOutlinePipelineMode::DedicatedRibbonPipeline;
 }

--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -13,8 +13,8 @@ enum class DssOutlinePipelineMode {
     SharedFillPipeline,
 };
 
-// The OpenGL backend reuses the fill program for ribbon outlines: its separate
-// program loses the mesh resources despite the same shader/SRB configuration.
+// The OpenGL backend reuses the fill program for ribbon outlines: live probes
+// showed flat/stale outlines with a separate, identically configured program.
 constexpr DssOutlinePipelineMode dssOutlinePipelineModeForBackend(
     bool openGlBackend)
 {

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -14305,10 +14305,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
         cb->draw(4);
     }
 
-    QRhiGraphicsPipeline* outlinePipeline =
-        m_dssOutlinePipelineMode == DssOutlinePipelineMode::SharedFillPipeline
-        ? m_dssMeshFillPipeline
-        : m_dssMeshLinePipeline;
+    QRhiGraphicsPipeline* outlinePipeline = dssOutlinePipelineFor(
+        m_dssOutlinePipelineMode, m_dssMeshFillPipeline, m_dssMeshLinePipeline);
     if (dssMeshOutlineRows > 0 && outlinePipeline && m_dssMeshSrb) {
         const QRhiViewport vp(
             static_cast<float>(specRect.x()) * dpr,

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -12498,6 +12498,8 @@ void SpectrumWidget::initDssMeshPipeline()
 {
     QRhi* r = rhi();
     m_dssMeshReady = false;
+    m_dssOutlinePipelineMode = dssOutlinePipelineModeForBackend(
+        r->backend() == QRhi::OpenGLES2);
 
     // R stores dBm and G stores captured-frequency coverage. The second channel
     // keeps zoom-created floor spans colour-stable without hiding their lines.
@@ -12584,26 +12586,32 @@ void SpectrumWidget::initDssMeshPipeline()
     m_dssMeshFillPipeline->setRenderPassDescriptor(renderTarget()->renderPassDescriptor());
     m_dssMeshFillPipeline->setTargetBlends({fillBlend});
 
-    // Outline pipeline — alpha-blended screen-space ribbons on a fixed
-    // perspective grid. The shader crossfades exact FFT shapes in place, so
-    // neither native line coverage nor translated ribbon coverage can strobe.
+    // OpenGL reuses the fill program below for this unchanged ribbon VBO. The
+    // probe proved its separate program loses mesh resource bindings, while the
+    // fill program already sees the same shader inputs correctly.
     QRhiGraphicsPipeline::TargetBlend lblend;
     lblend.enable = true;
     lblend.srcColor = QRhiGraphicsPipeline::SrcAlpha;
     lblend.dstColor = QRhiGraphicsPipeline::OneMinusSrcAlpha;
     lblend.srcAlpha = QRhiGraphicsPipeline::One;
     lblend.dstAlpha = QRhiGraphicsPipeline::OneMinusSrcAlpha;
-    m_dssMeshLinePipeline = r->newGraphicsPipeline();
-    m_dssMeshLinePipeline->setShaderStages({{QRhiShaderStage::Vertex, vs}, {QRhiShaderStage::Fragment, fs}});
-    m_dssMeshLinePipeline->setVertexInputLayout(layout);
-    m_dssMeshLinePipeline->setTopology(QRhiGraphicsPipeline::Triangles);
-    m_dssMeshLinePipeline->setShaderResourceBindings(m_dssMeshSrb);
-    m_dssMeshLinePipeline->setRenderPassDescriptor(renderTarget()->renderPassDescriptor());
-    m_dssMeshLinePipeline->setTargetBlends({lblend});
-
-    if (!m_dssMeshFillPipeline->create() || !m_dssMeshLinePipeline->create()) {
+    if (!m_dssMeshFillPipeline->create()) {
         qCWarning(lcGui) << "SpectrumWidget: dss_mesh pipeline create failed";
         return;
+    }
+    if (m_dssOutlinePipelineMode
+        == DssOutlinePipelineMode::DedicatedRibbonPipeline) {
+        m_dssMeshLinePipeline = r->newGraphicsPipeline();
+        m_dssMeshLinePipeline->setShaderStages({{QRhiShaderStage::Vertex, vs}, {QRhiShaderStage::Fragment, fs}});
+        m_dssMeshLinePipeline->setVertexInputLayout(layout);
+        m_dssMeshLinePipeline->setTopology(QRhiGraphicsPipeline::Triangles);
+        m_dssMeshLinePipeline->setShaderResourceBindings(m_dssMeshSrb);
+        m_dssMeshLinePipeline->setRenderPassDescriptor(renderTarget()->renderPassDescriptor());
+        m_dssMeshLinePipeline->setTargetBlends({lblend});
+        if (!m_dssMeshLinePipeline->create()) {
+            qCWarning(lcGui) << "SpectrumWidget: dss_mesh pipeline create failed";
+            return;
+        }
     }
 
     m_dssMeshHeadUploaded = -1;
@@ -12611,7 +12619,12 @@ void SpectrumWidget::initDssMeshPipeline()
     m_dssLutToken = ~0ull;
     m_dssMeshReady = true;
     qDebug() << "SpectrumWidget: stacked-trace mesh pipeline created"
-             << cols << "x" << textureRows;
+             << cols << "x" << textureRows
+             << "outline pipeline" << (m_dssOutlinePipelineMode
+                 == DssOutlinePipelineMode::SharedFillPipeline
+                     ? "shared-fill-pipeline" : "dedicated-ribbon-pipeline")
+             << "outline vertices/row"
+             << dssLineVerticesPerRow();
 }
 
 void SpectrumWidget::initDssDepthPipeline()
@@ -14292,13 +14305,20 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
         cb->draw(4);
     }
 
-    if (dssMeshOutlineRows > 0 && m_dssMeshLinePipeline && m_dssMeshSrb) {
+    QRhiGraphicsPipeline* outlinePipeline =
+        m_dssOutlinePipelineMode == DssOutlinePipelineMode::SharedFillPipeline
+        ? m_dssMeshFillPipeline
+        : m_dssMeshLinePipeline;
+    if (dssMeshOutlineRows > 0 && outlinePipeline && m_dssMeshSrb) {
         const QRhiViewport vp(
             static_cast<float>(specRect.x()) * dpr,
             static_cast<float>(h - specRect.bottom() - 1) * dpr,
             static_cast<float>(specContentW) * dpr,
             static_cast<float>(specRect.height()) * dpr);
-        cb->setGraphicsPipeline(m_dssMeshLinePipeline);
+        // Reuse the working OpenGL fill program for ribbon outlines. Its blend
+        // state matches the dedicated outline pipeline; only the program switch
+        // differed when the flat-probe rows exposed the binding failure.
+        cb->setGraphicsPipeline(outlinePipeline);
         cb->setShaderResources(m_dssMeshSrb);
         cb->setViewport(vp);
         const QRhiCommandBuffer::VertexInput vbuf(m_dssMeshLineVbo, 0);

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -14318,6 +14318,12 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
         // Reuse the working OpenGL fill program for ribbon outlines. Its blend
         // state matches the dedicated outline pipeline; live probes isolated
         // the flat/stale rows to the separate-program path.
+        //
+        // On the shared-fill path this rebind is deliberately a no-op: the fill
+        // draw above leaves m_dssMeshFillPipeline current, so QRhi skips the GL
+        // program switch and this draw inherits its state. Do not bind another
+        // pipeline between that draw and this one; doing so reintroduces the
+        // Linux-only flat-row failure that this path avoids.
         cb->setGraphicsPipeline(outlinePipeline);
         cb->setShaderResources(m_dssMeshSrb);
         cb->setViewport(vp);

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -12586,21 +12586,21 @@ void SpectrumWidget::initDssMeshPipeline()
     m_dssMeshFillPipeline->setRenderPassDescriptor(renderTarget()->renderPassDescriptor());
     m_dssMeshFillPipeline->setTargetBlends({fillBlend});
 
-    // OpenGL reuses the fill program below for this unchanged ribbon VBO. The
-    // probe proved its separate program loses mesh resource bindings, while the
-    // fill program already sees the same shader inputs correctly.
-    QRhiGraphicsPipeline::TargetBlend lblend;
-    lblend.enable = true;
-    lblend.srcColor = QRhiGraphicsPipeline::SrcAlpha;
-    lblend.dstColor = QRhiGraphicsPipeline::OneMinusSrcAlpha;
-    lblend.srcAlpha = QRhiGraphicsPipeline::One;
-    lblend.dstAlpha = QRhiGraphicsPipeline::OneMinusSrcAlpha;
+    // OpenGL reuses the fill program below for this unchanged ribbon VBO: live
+    // probes showed flat/stale outlines only after switching to a separate,
+    // identically configured program. Keep the proven Metal/D3D11 path intact.
     if (!m_dssMeshFillPipeline->create()) {
-        qCWarning(lcGui) << "SpectrumWidget: dss_mesh pipeline create failed";
+        qCWarning(lcGui) << "SpectrumWidget: dss_mesh fill pipeline create failed";
         return;
     }
     if (m_dssOutlinePipelineMode
         == DssOutlinePipelineMode::DedicatedRibbonPipeline) {
+        QRhiGraphicsPipeline::TargetBlend lblend;
+        lblend.enable = true;
+        lblend.srcColor = QRhiGraphicsPipeline::SrcAlpha;
+        lblend.dstColor = QRhiGraphicsPipeline::OneMinusSrcAlpha;
+        lblend.srcAlpha = QRhiGraphicsPipeline::One;
+        lblend.dstAlpha = QRhiGraphicsPipeline::OneMinusSrcAlpha;
         m_dssMeshLinePipeline = r->newGraphicsPipeline();
         m_dssMeshLinePipeline->setShaderStages({{QRhiShaderStage::Vertex, vs}, {QRhiShaderStage::Fragment, fs}});
         m_dssMeshLinePipeline->setVertexInputLayout(layout);
@@ -12609,7 +12609,7 @@ void SpectrumWidget::initDssMeshPipeline()
         m_dssMeshLinePipeline->setRenderPassDescriptor(renderTarget()->renderPassDescriptor());
         m_dssMeshLinePipeline->setTargetBlends({lblend});
         if (!m_dssMeshLinePipeline->create()) {
-            qCWarning(lcGui) << "SpectrumWidget: dss_mesh pipeline create failed";
+            qCWarning(lcGui) << "SpectrumWidget: dss_mesh outline pipeline create failed";
             return;
         }
     }
@@ -14316,8 +14316,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
             static_cast<float>(specContentW) * dpr,
             static_cast<float>(specRect.height()) * dpr);
         // Reuse the working OpenGL fill program for ribbon outlines. Its blend
-        // state matches the dedicated outline pipeline; only the program switch
-        // differed when the flat-probe rows exposed the binding failure.
+        // state matches the dedicated outline pipeline; live probes isolated
+        // the flat/stale rows to the separate-program path.
         cb->setGraphicsPipeline(outlinePipeline);
         cb->setShaderResources(m_dssMeshSrb);
         cb->setViewport(vp);

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -1951,8 +1951,8 @@ private:
     // perspective grid samples it in dss_mesh.vert. Geometry never rebuilds,
     // so pan/zoom are free. Falls back to the cached-image quad above when the
     // pipeline can't be created.
-    QRhiGraphicsPipeline* m_dssMeshFillPipeline{nullptr};  // Triangles, opaque
-    QRhiGraphicsPipeline* m_dssMeshLinePipeline{nullptr};  // dedicated ribbon triangles
+    QRhiGraphicsPipeline* m_dssMeshFillPipeline{nullptr};  // alpha-blended triangles; outlines on OpenGL
+    QRhiGraphicsPipeline* m_dssMeshLinePipeline{nullptr};  // dedicated ribbon triangles; null on OpenGL
     QRhiShaderResourceBindings* m_dssMeshSrb{nullptr};
     QRhiBuffer* m_dssMeshVbo{nullptr};       // batched curtain triangles, static
     QRhiBuffer* m_dssMeshLineVbo{nullptr};   // batched ridge ribbons, static

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -1952,7 +1952,7 @@ private:
     // so pan/zoom are free. Falls back to the cached-image quad above when the
     // pipeline can't be created.
     QRhiGraphicsPipeline* m_dssMeshFillPipeline{nullptr};  // Triangles, opaque
-    QRhiGraphicsPipeline* m_dssMeshLinePipeline{nullptr};  // AA ribbon triangles
+    QRhiGraphicsPipeline* m_dssMeshLinePipeline{nullptr};  // dedicated ribbon triangles
     QRhiShaderResourceBindings* m_dssMeshSrb{nullptr};
     QRhiBuffer* m_dssMeshVbo{nullptr};       // batched curtain triangles, static
     QRhiBuffer* m_dssMeshLineVbo{nullptr};   // batched ridge ribbons, static
@@ -1973,6 +1973,8 @@ private:
     QRhiSampler* m_dssHeightSampler{nullptr};
     QRhiSampler* m_dssPaletteSampler{nullptr};
     bool m_dssMeshReady{false};
+    DssOutlinePipelineMode m_dssOutlinePipelineMode{
+        DssOutlinePipelineMode::DedicatedRibbonPipeline};
     int  m_dssMeshHeadUploaded{-1};          // ring head last uploaded to heightTex
     quint64 m_dssMeshRowGenUploaded{~0ull};  // DssRenderer rowGeneration uploaded
     quint64 m_dssLutToken{~0ull};            // token of the palette LUT last baked

--- a/tests/spectrum_preview_logic_test.cpp
+++ b/tests/spectrum_preview_logic_test.cpp
@@ -737,6 +737,18 @@ int testDssStartupHistoryAvailability()
     return 0;
 }
 
+int testDssOutlinePipelinePolicy()
+{
+    using namespace AetherSDR;
+    if (dssOutlinePipelineModeForBackend(true)
+            != DssOutlinePipelineMode::SharedFillPipeline
+        || dssOutlinePipelineModeForBackend(false)
+            != DssOutlinePipelineMode::DedicatedRibbonPipeline) {
+        return fail("3D FFT outline pipeline policy is incorrect");
+    }
+    return 0;
+}
+
 int testObservedWaterfallCadence()
 {
     using namespace AetherSDR;
@@ -957,6 +969,9 @@ int main()
         return result;
     }
     if (const int result = testDssStartupHistoryAvailability(); result != 0) {
+        return result;
+    }
+    if (const int result = testDssOutlinePipelinePolicy(); result != 0) {
         return result;
     }
     if (const int result = testObservedWaterfallCadence(); result != 0) {

--- a/tests/spectrum_preview_logic_test.cpp
+++ b/tests/spectrum_preview_logic_test.cpp
@@ -749,6 +749,45 @@ int testDssOutlinePipelinePolicy()
     return 0;
 }
 
+// The policy above only names a mode; this pins the pipeline the outline draw
+// actually binds, which is the half that can regress on its own. Renderer proof
+// still comes from the three-backend manual verification — no headless test can
+// reach a QRhi draw — but the selection itself no longer rests on a ternary
+// duplicated at the draw site.
+int testDssOutlinePipelineSelection()
+{
+    using namespace AetherSDR;
+    struct FakePipeline {
+        int id{0};
+    };
+    FakePipeline fill{1};
+    FakePipeline dedicated{2};
+
+    // OpenGL must land on the fill pipeline. That is what makes the rebind at
+    // the outline draw a no-op, so no GL program switch separates it from the
+    // fill draw — the whole point of the Linux fix.
+    if (dssOutlinePipelineFor(dssOutlinePipelineModeForBackend(true), &fill,
+                              &dedicated)
+        != &fill) {
+        return fail("OpenGL outline draw must reuse the fill pipeline");
+    }
+    // Metal/D3D11 keep the already-validated dedicated ribbon pipeline.
+    if (dssOutlinePipelineFor(dssOutlinePipelineModeForBackend(false), &fill,
+                              &dedicated)
+        != &dedicated) {
+        return fail("non-OpenGL outline draw must use the ribbon pipeline");
+    }
+    // initDssMeshPipeline never creates the dedicated pipeline on OpenGL, so
+    // the shared-fill answer must survive a null one rather than disabling
+    // outlines the way a `m_dssMeshLinePipeline`-based guard would.
+    if (dssOutlinePipelineFor(DssOutlinePipelineMode::SharedFillPipeline, &fill,
+                              static_cast<FakePipeline*>(nullptr))
+        != &fill) {
+        return fail("shared-fill outline selection must not need a ribbon pipeline");
+    }
+    return 0;
+}
+
 int testObservedWaterfallCadence()
 {
     using namespace AetherSDR;
@@ -972,6 +1011,9 @@ int main()
         return result;
     }
     if (const int result = testDssOutlinePipelinePolicy(); result != 0) {
+        return result;
+    }
+    if (const int result = testDssOutlinePipelineSelection(); result != 0) {
         return result;
     }
     if (const int result = testObservedWaterfallCadence(); result != 0) {


### PR DESCRIPTION
## Summary

Fix missing and non-updating 3D FFT history outlines on Linux systems using the QRhi OpenGL backend.

The dedicated OpenGL outline pipeline rasterized its geometry but observed flat or stale mesh-height data, while the fill pipeline received the live FFT history correctly. OpenGL now draws the existing outline ribbon VBO through the working fill pipeline. Metal, D3D11, and other backends retain the dedicated outline pipeline unchanged.

## Reproduction

1. Run AetherSDR on Linux with the QRhi OpenGL backend.
2. Connect to a radio and select **Display → 3D Stacked Trace**.
3. Observe that the leading edge is static or absent and repeated FFT outlines are missing from the 3D history.
4. Pan horizontally and observe that the display does not update immediately.

After this change, all 96 visible history rows have shaped outlines and the pan preview updates continuously.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The renderer behavior was verified through native builds, focused tests, authenticated renderer telemetry, screenshots, and operator visual confirmation across Linux, macOS, and Windows.

## Test plan

- [x] Local build passes (`cmake --build build`)
  - Debian Linux VM, Qt/OpenGL
  - macOS arm64, Qt/Metal
  - Windows, MSVC/Qt 6.8.3/D3D11
- [x] Behavior verified on a real radio if applicable
  - Linux: 96/96 visible history rows non-flat; operator visually confirmed
  - macOS: 96/96 visible history rows non-flat; real-radio visual and live pan proof
  - Windows: 96/96 visible history rows non-flat; simulator visual and live pan proof
- [ ] Existing tests pass (CI)
  - Focused `spectrum_preview_logic_test` passes locally on Linux and macOS
- [x] Reproduction steps documented if user-reported bug
- [x] `git diff --check`
- [x] `python3 tools/check_engine_boundary.py --strict` (zero blocking findings)
- [x] No shader changes

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention) — N/A, no meter changes
- [x] Documentation updated if user-visible behavior changed — N/A, this restores existing behavior
- [x] Security-sensitive changes reference a GHSA if applicable — N/A
