### PR TITLE
Fix title bar headphone mute reconcile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5485,6 +5485,33 @@ add_test(NAME hl2_pc_audio_lock_test COMMAND hl2_pc_audio_lock_test)
 set_tests_properties(hl2_pc_audio_lock_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
+# Title-bar headphone mute reconcile contract (#4722) — needs QApplication +
+# Widgets, same dependency set as hl2_pc_audio_lock_test above.
+add_executable(titlebar_headphone_mute_test
+    tests/titlebar_headphone_mute_test.cpp
+    src/gui/TitleBar.cpp
+    # TitleBar's dialogs are frameless, so the resizer + frameless title bar
+    # come along; ThemeManager pulls its logging deps.
+    src/gui/FramelessMessageBox.cpp
+    src/gui/PersistentDialog.cpp
+    src/gui/FramelessResizer.cpp
+    src/gui/FramelessWindowTitleBar.cpp
+    src/gui/DragValuePopup.cpp
+    ${AETHER_SETTINGS_SOURCES}
+    src/core/ThemeManager.cpp
+    src/core/ThemeSeedGenerated.cpp
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+)
+target_include_directories(titlebar_headphone_mute_test PRIVATE src tests)
+target_link_libraries(titlebar_headphone_mute_test PRIVATE
+    Qt6::Core Qt6::Widgets Qt6::Network Qt6::Test
+)
+set_target_properties(titlebar_headphone_mute_test PROPERTIES AUTOMOC ON)
+add_test(NAME titlebar_headphone_mute_test COMMAND titlebar_headphone_mute_test)
+set_tests_properties(titlebar_headphone_mute_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 add_executable(amp_applet_test
     tests/amp_applet_test.cpp
     src/gui/AmpApplet.cpp
@@ -5692,6 +5719,7 @@ set(AETHER_SETTINGS_CONSUMERS
     transmit_model_test
     container_widget_test
     hl2_pc_audio_lock_test
+    titlebar_headphone_mute_test
     amp_applet_test
     container_manager_test
     container_nesting_test

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1936,11 +1936,11 @@ MainWindow::MainWindow(QWidget* parent)
     // (MainWindow_DspApplets.cpp, #3351 Phase 2d).
     wirePooDooTiles();
 
-    connect(m_titleBar, &TitleBar::headphoneMuteChanged, this, [this](bool muted) {
-        m_radioModel.sendCommand(QString("mixer headphone mute %1").arg(muted ? 1 : 0));
-    });
+    connect(m_titleBar, &TitleBar::headphoneMuteChanged,
+            &m_radioModel, &RadioModel::setHeadphoneMute);
     connect(&m_radioModel, &RadioModel::audioOutputChanged, this, [this]() {
         m_titleBar->setHeadphoneVolume(m_radioModel.headphoneGain());
+        m_titleBar->setHeadphoneMuted(m_radioModel.headphoneMute());
     });
 
     // Multi-Flex: show when another client is transmitting

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -866,6 +866,13 @@ void TitleBar::setLineoutMuted(bool muted)
     m_speakerBtn->setText(muted ? "\xF0\x9F\x94\x87" : "\xF0\x9F\x94\x8A");  // 🔇 / 🔊
 }
 
+void TitleBar::setHeadphoneMuted(bool muted)
+{
+    QSignalBlocker b(m_headphoneBtn);
+    m_headphoneBtn->setChecked(muted);
+    m_headphoneBtn->setText(muted ? "\xF0\x9F\x94\x87" : "\xF0\x9F\x8E\xA7");  // 🔇 / 🎧
+}
+
 void TitleBar::setMasterVolume(int pct)
 {
     QSignalBlocker b(m_masterSlider);

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -37,6 +37,7 @@ public:
     void setPcAudioLocked(bool locked);
     void setPcAudioDevices(const QString& inputDevice, const QString& outputDevice);
     void setLineoutMuted(bool muted);
+    void setHeadphoneMuted(bool muted);
     void setMasterVolume(int pct);
     void setHeadphoneVolume(int pct);
     void setOtherClientTx(bool transmitting, const QString& station);

--- a/tests/titlebar_headphone_mute_test.cpp
+++ b/tests/titlebar_headphone_mute_test.cpp
@@ -1,0 +1,115 @@
+// Title-bar headphone mute must be reconcilable from radio status (#4722).
+//
+// The truth path is radio -> RadioModel::applyDelta -> audioOutputChanged ->
+// TitleBar::setHeadphoneMuted. Two details of that setter are load-bearing and
+// invisible, which is why they get a test rather than a comment:
+//
+//   1. setHeadphoneMuted() runs under a QSignalBlocker, so the `toggled`
+//      lambda in the constructor -- which is what normally swaps the glyph --
+//      does NOT run. The explicit setText() in the setter is therefore
+//      required, not redundant: drop it and the button's checked state and its
+//      glyph disagree with each other.
+//   2. That same blocker is what stops the reconcile from re-emitting
+//      headphoneMuteChanged and echoing the radio's own status back at it as a
+//      fresh command -- the Constitution Principle II feedback loop ("the
+//      command path runs client -> radio; the truth path runs radio ->
+//      client; the two must never form a feedback loop").
+//
+// Neither failure surfaces on a single client. Both show up the moment a
+// second Multi-Flex client, Radio Setup, or the rig's own front panel changes
+// headphone mute -- exactly the case #4722 was filed for.
+
+#include "TestSettingsProfile.h"
+
+#include "gui/TitleBar.h"
+
+#include <QApplication>
+#include <QPushButton>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+static void check(bool ok, const char* what)
+{
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what); ++g_failures; }
+}
+
+static const char* kMuted   = "\xF0\x9F\x94\x87";  // 🔇
+static const char* kUnmuted = "\xF0\x9F\x8E\xA7";  // 🎧
+
+// The button is private; the automation bridge finds it the same way.
+static QPushButton* headphoneButton(TitleBar& bar)
+{
+    const auto buttons = bar.findChildren<QPushButton*>();
+    for (QPushButton* b : buttons) {
+        if (b->accessibleName() == QLatin1String("Headphone mute"))
+            return b;
+    }
+    return nullptr;
+}
+
+int main(int argc, char** argv)
+{
+    // TitleBar pulls ThemeManager, which reads AppSettings. Sandbox the store
+    // before QApplication so the test never touches the operator's profile.
+    TestSettingsProfile settingsProfile(
+        QStringLiteral("aether-titlebar-headphone-mute-test"));
+
+    QApplication app(argc, argv);
+
+    TitleBar bar;
+    QPushButton* hp = headphoneButton(bar);
+    check(hp != nullptr, "headphone button is discoverable by accessibleName");
+    if (!hp) {
+        std::fprintf(stderr, "cannot continue without the button\n");
+        return 1;
+    }
+
+    int emitted = 0;
+    bool lastEmitted = false;
+    QObject::connect(&bar, &TitleBar::headphoneMuteChanged, &bar,
+                     [&](bool m) { ++emitted; lastEmitted = m; });
+
+    check(!hp->isChecked(), "precondition: starts unmuted");
+    check(hp->text() == QString::fromUtf8(kUnmuted),
+          "precondition: starts on the headphone glyph");
+
+    // Command leg -- an operator click is still a request to the radio, and is
+    // reported exactly once.
+    hp->click();
+    check(emitted == 1 && lastEmitted,
+          "clicking the button emits headphoneMuteChanged(true) once");
+    check(hp->text() == QString::fromUtf8(kMuted),
+          "clicking swaps the glyph to muted");
+
+    // Truth leg -- reconciling from radio status moves the control WITHOUT
+    // emitting. If this ever emits, the radio's status echo becomes a fresh
+    // command back to the radio.
+    emitted = 0;
+    bar.setHeadphoneMuted(false);
+    check(emitted == 0,
+          "setHeadphoneMuted() emits nothing -- reconcile is not a command");
+    check(!hp->isChecked(), "setHeadphoneMuted(false) unchecks the button");
+    check(hp->text() == QString::fromUtf8(kUnmuted),
+          "setHeadphoneMuted(false) restores the headphone glyph "
+          "(the explicit setText, since the blocker suppressed toggled)");
+
+    bar.setHeadphoneMuted(true);
+    check(emitted == 0, "setHeadphoneMuted(true) also emits nothing");
+    check(hp->isChecked(), "setHeadphoneMuted(true) checks the button");
+    check(hp->text() == QString::fromUtf8(kMuted),
+          "setHeadphoneMuted(true) shows the muted glyph");
+
+    // A repeated status echo -- Flex re-sends `audio` on every mixer change --
+    // must not thrash the control.
+    bar.setHeadphoneMuted(true);
+    check(emitted == 0 && hp->isChecked() &&
+          hp->text() == QString::fromUtf8(kMuted),
+          "a repeated reconcile to the same value is a no-op");
+
+    if (g_failures == 0)
+        std::fprintf(stderr, "titlebar_headphone_mute_test: PASS\n");
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
Title bar headphone mute was sending a hand-written mixer command and never updating from radio status.

- Add `TitleBar::setHeadphoneMuted`, mirroring `setLineoutMuted`
- Wire `headphoneMuteChanged` to `RadioModel::setHeadphoneMute`
- Reconcile mute state on `audioOutputChanged` next to headphone volume

Fixes #4722

## Test plan
- [x] Mute headphones from Radio Setup → title bar icon flips muted
- [x] Mute from title bar → Radio Setup mute button matches
- [x] Second Multi-Flex client changes headphone mute → title bar follows