### PR TITLE
Fix ASR speaker-label preparation GUI freeze

### DIFF
--- a/src/asr/AsrEngine.cpp
+++ b/src/asr/AsrEngine.cpp
@@ -34,8 +34,6 @@ AsrWorker::AsrWorker(AsrBackendFactory factory, AsrSegmenter::Config segConfig,
     , m_segmenter(segConfig)
     , m_vadModelPath(segConfig.vadModelPath)
     , m_clusterer(segConfig.speakerThreshold)
-    , m_speakerModelPath(segConfig.speakerModelPath)
-    , m_speakerLabelingEnabled(!segConfig.speakerModelPath.empty())
 {
 }
 
@@ -48,9 +46,19 @@ AsrWorker::~AsrWorker()
 
 void AsrWorker::init()
 {
+    // ~AsrEngine() joins this thread, so every stage that can run long is a
+    // stage the GUI thread may end up waiting on. A stage already in flight
+    // still has to finish, but one that has not started must not begin after
+    // shutdown was requested — that is what bounds the join (#4737).
+    if (m_shuttingDown.load(std::memory_order_relaxed)) {
+        return;
+    }
     m_backend = m_factory ? m_factory() : nullptr;
     if (m_backend == nullptr) {
         emit errorOccurred(QStringLiteral("ASR backend could not be created."));
+    }
+    if (m_shuttingDown.load(std::memory_order_relaxed)) {
+        return;
     }
 
     // Build the learned VAD on the worker thread (the ONNX session must live
@@ -68,10 +76,9 @@ void AsrWorker::init()
         }
     }
 
-    // Speaker-embedding model for per-utterance A/B/C labeling (worker thread).
-    if (!m_speakerModelPath.empty()) {
-        loadSpeakerModel(QString::fromStdString(m_speakerModelPath));
-    }
+    // No speaker embedder is built here: it is a runtime property loaded via
+    // loadSpeakerModel() so the operator's labeling toggle never rebuilds the
+    // engine (#4737). AsrEngine::setSpeakerModelPath() is its only entry point.
 }
 
 void AsrWorker::loadModel(const QString& modelPath)
@@ -96,6 +103,15 @@ void AsrWorker::loadSpeakerModel(const QString& modelPath)
     if (modelPath.isEmpty()) {
         return;
     }
+    if (m_shuttingDown.load(std::memory_order_relaxed)) {
+        // Building the ~24 MB ECAPA session here would be time the destructor's
+        // join has to wait out. Report the request as unfulfilled instead; the
+        // engine is going away, so nothing is left to observe it. NOT gated on
+        // m_cancelPending — that flag is also set whenever the tap is disabled,
+        // which is exactly when a speaker load is queued.
+        emit speakerModelLoaded(modelPath, false);
+        return;
+    }
 
     std::unique_ptr<SpeakerEmbedder> embedder;
     if (m_speakerEmbedderFactory) {
@@ -116,11 +132,12 @@ void AsrWorker::loadSpeakerModel(const QString& modelPath)
         emit speakerModelLoaded(modelPath, true);
     } else {
         // A replacement that fails must not keep assigning labels through the
-        // previous model. The controller will reflect this as labeling off.
+        // previous model. Dropping the embedder is what guarantees that —
+        // m_speakerLabelingEnabled stays the operator's intent and is left
+        // alone, so the two never disagree about who owns which fact.
         m_embedder.reset();
         m_clusterer.reset();
         m_speakerModelPath.clear();
-        m_speakerLabelingEnabled = false;
         qCWarning(lcAsrEngine, "ASR: speaker embedder load failed (%s) — no labeling",
                   qPrintable(modelPath));
         emit speakerModelLoaded(modelPath, false);
@@ -262,7 +279,6 @@ AsrEngine::AsrEngine(AsrBackendFactory factory, QObject* parent)
 AsrEngine::AsrEngine(AsrBackendFactory factory, const AsrSegmenter::Config& segConfig,
                      QObject* parent, AsrSpeakerEmbedderFactory speakerEmbedderFactory)
     : QObject(parent)
-    , m_speakerLabelingEnabled(!segConfig.speakerModelPath.empty())
 {
     startThread(std::move(factory), segConfig, std::move(speakerEmbedderFactory));
 }
@@ -302,13 +318,13 @@ void AsrEngine::startThread(AsrBackendFactory factory, const AsrSegmenter::Confi
         m_ready = false;
         emit loadFailed(err);
     });
+    // Forwarded verbatim: a failed load does NOT clear m_speakerLabelingEnabled.
+    // That flag is the operator's intent and only setSpeakerLabelingEnabled()
+    // writes it; the worker having dropped its embedder is what guarantees no
+    // labels are produced. Deciding what a failure means for the UI (status,
+    // un-checking the box) belongs to the controller, which owns that intent.
     connect(m_worker, &AsrWorker::speakerModelLoaded, this,
-            [this](const QString& modelPath, bool loaded) {
-                if (!loaded) {
-                    m_speakerLabelingEnabled = false;
-                }
-                emit speakerModelLoaded(modelPath, loaded);
-            });
+            &AsrEngine::speakerModelLoaded);
     connect(m_worker, &AsrWorker::segmentText, this,
             [this](const QString& text, float confidence, int speaker) {
                 // A queued worker toggle can be behind an in-flight decode. Mask
@@ -338,6 +354,11 @@ AsrEngine::~AsrEngine()
             // whisper decode, or a remote HTTP round-trip up to its own
             // timeout) — quit()+wait() below still waits for that one.
             m_worker->setCancelPending(true);
+            // Separate from the cancel flag above, which is also raised every
+            // time the audio tap is disabled: this one is set only here, so
+            // init()/loadSpeakerModel() can skip a stage that has not started
+            // without ever refusing a legitimate load (#4737).
+            m_worker->requestShutdown();
         }
         m_thread->quit();
         m_thread->wait();

--- a/src/asr/AsrEngine.cpp
+++ b/src/asr/AsrEngine.cpp
@@ -27,12 +27,15 @@ constexpr double kResampleTransBand = 10.0;
 
 // ---- AsrWorker -------------------------------------------------------------
 
-AsrWorker::AsrWorker(AsrBackendFactory factory, AsrSegmenter::Config segConfig)
+AsrWorker::AsrWorker(AsrBackendFactory factory, AsrSegmenter::Config segConfig,
+                     AsrSpeakerEmbedderFactory speakerEmbedderFactory)
     : m_factory(std::move(factory))
+    , m_speakerEmbedderFactory(std::move(speakerEmbedderFactory))
     , m_segmenter(segConfig)
     , m_vadModelPath(segConfig.vadModelPath)
     , m_clusterer(segConfig.speakerThreshold)
     , m_speakerModelPath(segConfig.speakerModelPath)
+    , m_speakerLabelingEnabled(!segConfig.speakerModelPath.empty())
 {
 }
 
@@ -67,15 +70,7 @@ void AsrWorker::init()
 
     // Speaker-embedding model for per-utterance A/B/C labeling (worker thread).
     if (!m_speakerModelPath.empty()) {
-        auto embedder = std::make_unique<SpeakerEmbedder>();
-        if (embedder->load(m_speakerModelPath)) {
-            m_embedder = std::move(embedder);
-            qCInfo(lcAsrEngine, "ASR: speaker embedder loaded from %s",
-                   m_speakerModelPath.c_str());
-        } else {
-            qCWarning(lcAsrEngine, "ASR: speaker embedder load failed (%s) — no labeling",
-                      m_speakerModelPath.c_str());
-        }
+        loadSpeakerModel(QString::fromStdString(m_speakerModelPath));
     }
 }
 
@@ -94,6 +89,47 @@ void AsrWorker::loadModel(const QString& modelPath)
     } else {
         emit loadFailed(error);
     }
+}
+
+void AsrWorker::loadSpeakerModel(const QString& modelPath)
+{
+    if (modelPath.isEmpty()) {
+        return;
+    }
+
+    std::unique_ptr<SpeakerEmbedder> embedder;
+    if (m_speakerEmbedderFactory) {
+        embedder = m_speakerEmbedderFactory(modelPath);
+    } else {
+        auto candidate = std::make_unique<SpeakerEmbedder>();
+        if (candidate->load(modelPath.toStdString())) {
+            embedder = std::move(candidate);
+        }
+    }
+
+    if (embedder) {
+        m_embedder = std::move(embedder);
+        m_speakerModelPath = modelPath.toStdString();
+        m_clusterer.reset();
+        qCInfo(lcAsrEngine, "ASR: speaker embedder loaded from %s",
+               m_speakerModelPath.c_str());
+        emit speakerModelLoaded(modelPath, true);
+    } else {
+        // A replacement that fails must not keep assigning labels through the
+        // previous model. The controller will reflect this as labeling off.
+        m_embedder.reset();
+        m_clusterer.reset();
+        m_speakerModelPath.clear();
+        m_speakerLabelingEnabled = false;
+        qCWarning(lcAsrEngine, "ASR: speaker embedder load failed (%s) — no labeling",
+                  qPrintable(modelPath));
+        emit speakerModelLoaded(modelPath, false);
+    }
+}
+
+void AsrWorker::setSpeakerLabelingEnabled(bool on)
+{
+    m_speakerLabelingEnabled = on;
 }
 
 std::vector<float> AsrWorker::toSixteenK(const QVector<float>& monoSamples, int sampleRate)
@@ -177,7 +213,7 @@ void AsrWorker::processAudio(const QVector<float>& monoSamples, int sampleRate)
         }
         // Speaker label (A/B/C…) from the utterance's embedding, when enabled.
         int speaker = -1;
-        if (m_embedder) {
+        if (m_speakerLabelingEnabled && m_embedder) {
             speaker = m_clusterer.assign(
                 m_embedder->embed(seg.data(), static_cast<int>(seg.size())));
         }
@@ -224,16 +260,19 @@ AsrEngine::AsrEngine(AsrBackendFactory factory, QObject* parent)
 }
 
 AsrEngine::AsrEngine(AsrBackendFactory factory, const AsrSegmenter::Config& segConfig,
-                     QObject* parent)
+                     QObject* parent, AsrSpeakerEmbedderFactory speakerEmbedderFactory)
     : QObject(parent)
+    , m_speakerLabelingEnabled(!segConfig.speakerModelPath.empty())
 {
-    startThread(std::move(factory), segConfig);
+    startThread(std::move(factory), segConfig, std::move(speakerEmbedderFactory));
 }
 
-void AsrEngine::startThread(AsrBackendFactory factory, const AsrSegmenter::Config& segConfig)
+void AsrEngine::startThread(AsrBackendFactory factory, const AsrSegmenter::Config& segConfig,
+                            AsrSpeakerEmbedderFactory speakerEmbedderFactory)
 {
     m_thread = new QThread(this);
-    m_worker = new AsrWorker(std::move(factory), segConfig);
+    m_worker = new AsrWorker(std::move(factory), segConfig,
+                             std::move(speakerEmbedderFactory));
     m_worker->moveToThread(m_thread);
 
     // Worker lifecycle: create the backend once the thread is running. The
@@ -244,6 +283,9 @@ void AsrEngine::startThread(AsrBackendFactory factory, const AsrSegmenter::Confi
 
     // Engine -> worker (queued across threads).
     connect(this, &AsrEngine::requestLoad, m_worker, &AsrWorker::loadModel);
+    connect(this, &AsrEngine::requestLoadSpeakerModel, m_worker, &AsrWorker::loadSpeakerModel);
+    connect(this, &AsrEngine::requestSetSpeakerLabelingEnabled,
+            m_worker, &AsrWorker::setSpeakerLabelingEnabled);
     connect(this, &AsrEngine::requestProcess, m_worker, &AsrWorker::processAudio);
     connect(this, &AsrEngine::requestSetMaxSegmentMs, m_worker, &AsrWorker::setMaxSegmentMs);
     connect(this, &AsrEngine::requestSetSpeechRms, m_worker, &AsrWorker::setSpeechRms);
@@ -260,7 +302,20 @@ void AsrEngine::startThread(AsrBackendFactory factory, const AsrSegmenter::Confi
         m_ready = false;
         emit loadFailed(err);
     });
-    connect(m_worker, &AsrWorker::segmentText, this, &AsrEngine::finalText);
+    connect(m_worker, &AsrWorker::speakerModelLoaded, this,
+            [this](const QString& modelPath, bool loaded) {
+                if (!loaded) {
+                    m_speakerLabelingEnabled = false;
+                }
+                emit speakerModelLoaded(modelPath, loaded);
+            });
+    connect(m_worker, &AsrWorker::segmentText, this,
+            [this](const QString& text, float confidence, int speaker) {
+                // A queued worker toggle can be behind an in-flight decode. Mask
+                // its late result on the main side so the latest UI intent never
+                // appends a stale [A]/[B] label.
+                emit finalText(text, confidence, m_speakerLabelingEnabled ? speaker : -1);
+            });
     connect(m_worker, &AsrWorker::processedMs, this, [this](double ms) {
         m_processedMs += ms;
         updateBacklog();
@@ -317,6 +372,19 @@ void AsrEngine::setModelPath(const QString& modelPath)
     m_modelPath = modelPath;
     m_ready = false;
     emit requestLoad(modelPath);
+}
+
+void AsrEngine::setSpeakerModelPath(const QString& modelPath)
+{
+    if (!modelPath.isEmpty()) {
+        emit requestLoadSpeakerModel(modelPath);
+    }
+}
+
+void AsrEngine::setSpeakerLabelingEnabled(bool on)
+{
+    m_speakerLabelingEnabled = on;
+    emit requestSetSpeakerLabelingEnabled(on);
 }
 
 void AsrEngine::pushAudio(const QVector<float>& monoSamples, int sampleRate)

--- a/src/asr/AsrEngine.h
+++ b/src/asr/AsrEngine.h
@@ -48,6 +48,13 @@ public:
     // backlog of queued segments to finish (each includes a blocking transcribe).
     void setCancelPending(bool cancel) { m_cancelPending.store(cancel, std::memory_order_relaxed); }
 
+    // Thread-safe; set once by ~AsrEngine() before it joins this thread. Distinct
+    // from setCancelPending() above, which is ALSO raised on every ASR-disable
+    // (i.e. whenever the audio tap goes off) and so cannot mean "shutting down".
+    // Stages that would otherwise lengthen the join — backend/VAD creation and
+    // the ~24 MB speaker ONNX session — check this before starting (#4737).
+    void requestShutdown() { m_shuttingDown.store(true, std::memory_order_relaxed); }
+
 public slots:
     void init();                                   // create backend on this thread
     void loadModel(const QString& modelPath);
@@ -82,14 +89,15 @@ private:
     AsrSegmenter m_segmenter;
     std::unique_ptr<SileroVad> m_vad;   // built in init() when a model path is set
     std::string m_vadModelPath;         // optional Silero VAD .onnx (empty = energy)
-    std::unique_ptr<SpeakerEmbedder> m_embedder; // built in init() when a path is set
+    std::unique_ptr<SpeakerEmbedder> m_embedder; // built by loadSpeakerModel()
     SpeakerClusterer m_clusterer;       // online A/B/C… labeling
-    std::string m_speakerModelPath;     // optional speaker-embedding .onnx
-    bool m_speakerLabelingEnabled = false;
+    std::string m_speakerModelPath;     // path m_embedder was built from ("" = none)
+    bool m_speakerLabelingEnabled = false; // operator intent; embedder presence gates
     std::unique_ptr<Resampler> m_resampler;
     int m_resamplerSrcRate = 0;
     bool m_warnedNoModel = false;
     std::atomic<bool> m_cancelPending{false}; // see setCancelPending()
+    std::atomic<bool> m_shuttingDown{false};  // see requestShutdown()
 };
 
 // Engine half — main-thread facing. Accepts 16 kHz mono audio, ships it to the
@@ -122,6 +130,9 @@ public:
     // onto the worker so UI toggles never tear down a busy inference thread.
     void setSpeakerModelPath(const QString& modelPath);
     void setSpeakerLabelingEnabled(bool on);
+    // Pure operator intent: only setSpeakerLabelingEnabled() writes it, so it
+    // stays true after a failed load. Whether labels are actually produced is
+    // gated by the worker holding an embedder, which a failed load drops.
     bool isSpeakerLabelingEnabled() const { return m_speakerLabelingEnabled; }
 
     // Feed mono audio at its native sampleRate (e.g. the 24 kHz RX pipeline).

--- a/src/asr/AsrEngine.h
+++ b/src/asr/AsrEngine.h
@@ -23,6 +23,11 @@ class SpeakerEmbedder;
 // Factory that constructs an ASR backend. Invoked on the worker thread so the
 // backend (and any model context) lives entirely there.
 using AsrBackendFactory = std::function<std::unique_ptr<IAsrBackend>()>;
+// Creates a fully loaded speaker embedder on the ASR worker thread. Production
+// uses the default loader; tests may inject a deterministic slow loader to
+// prove model preparation never occupies the caller thread.
+using AsrSpeakerEmbedderFactory =
+    std::function<std::unique_ptr<SpeakerEmbedder>(const QString& modelPath)>;
 
 // Worker half of the ASR engine — runs on a dedicated thread, owns the backend
 // and the segmenter, and does all CPU-heavy work (segmentation + inference).
@@ -31,7 +36,8 @@ using AsrBackendFactory = std::function<std::unique_ptr<IAsrBackend>()>;
 class AsrWorker : public QObject {
     Q_OBJECT
 public:
-    AsrWorker(AsrBackendFactory factory, AsrSegmenter::Config segConfig);
+    AsrWorker(AsrBackendFactory factory, AsrSegmenter::Config segConfig,
+              AsrSpeakerEmbedderFactory speakerEmbedderFactory);
     ~AsrWorker() override;
 
     // Thread-safe; call directly (NOT via a queued signal — the whole point is
@@ -45,6 +51,8 @@ public:
 public slots:
     void init();                                   // create backend on this thread
     void loadModel(const QString& modelPath);
+    void loadSpeakerModel(const QString& modelPath);
+    void setSpeakerLabelingEnabled(bool on);
     // Mono float samples at sampleRate; resampled to whisper's 16 kHz on this
     // (worker) thread before segmentation — never on the audio/caller thread.
     void processAudio(const QVector<float>& monoSamples, int sampleRate);
@@ -57,6 +65,7 @@ public slots:
 signals:
     void loaded();
     void loadFailed(const QString& error);
+    void speakerModelLoaded(const QString& modelPath, bool loaded);
     // speaker: 0-based cluster index (A/B/C…), or -1 when labeling is off.
     void segmentText(const QString& text, float confidence, int speaker);
     void processedMs(double ms); // this chunk fully handled (for the backlog meter)
@@ -68,6 +77,7 @@ private:
     std::vector<float> toSixteenK(const QVector<float>& monoSamples, int sampleRate);
 
     AsrBackendFactory m_factory;
+    AsrSpeakerEmbedderFactory m_speakerEmbedderFactory;
     std::unique_ptr<IAsrBackend> m_backend;
     AsrSegmenter m_segmenter;
     std::unique_ptr<SileroVad> m_vad;   // built in init() when a model path is set
@@ -75,6 +85,7 @@ private:
     std::unique_ptr<SpeakerEmbedder> m_embedder; // built in init() when a path is set
     SpeakerClusterer m_clusterer;       // online A/B/C… labeling
     std::string m_speakerModelPath;     // optional speaker-embedding .onnx
+    bool m_speakerLabelingEnabled = false;
     std::unique_ptr<Resampler> m_resampler;
     int m_resamplerSrcRate = 0;
     bool m_warnedNoModel = false;
@@ -92,7 +103,8 @@ public:
     // whisperAsrBackendFactory(); tests pass a deterministic fake.
     explicit AsrEngine(AsrBackendFactory factory, QObject* parent = nullptr);
     AsrEngine(AsrBackendFactory factory, const AsrSegmenter::Config& segConfig,
-              QObject* parent = nullptr);
+              QObject* parent = nullptr,
+              AsrSpeakerEmbedderFactory speakerEmbedderFactory = {});
     ~AsrEngine() override;
 
     // Disabling drops any already-queued backlog (see AsrWorker::setCancelPending)
@@ -105,6 +117,12 @@ public:
     void setModelPath(const QString& modelPath);
     QString modelPath() const { return m_modelPath; }
     bool isReady() const { return m_ready; }
+
+    // Speaker labeling is independent from the ASR backend. Loading is queued
+    // onto the worker so UI toggles never tear down a busy inference thread.
+    void setSpeakerModelPath(const QString& modelPath);
+    void setSpeakerLabelingEnabled(bool on);
+    bool isSpeakerLabelingEnabled() const { return m_speakerLabelingEnabled; }
 
     // Feed mono audio at its native sampleRate (e.g. the 24 kHz RX pipeline).
     // Ignored unless enabled. Cheap — copies and posts to the worker, which
@@ -126,6 +144,7 @@ public:
 signals:
     void ready();
     void loadFailed(const QString& error);
+    void speakerModelLoaded(const QString& modelPath, bool loaded);
     // speaker: 0-based speaker index (A/B/C…), or -1 when labeling is off.
     void finalText(const QString& text, float confidence, int speaker);
     // Transcription backlog: seconds of received audio not yet handled by the
@@ -135,6 +154,8 @@ signals:
 
     // Internal: engine -> worker (queued). Not part of the public contract.
     void requestLoad(const QString& modelPath);
+    void requestLoadSpeakerModel(const QString& modelPath);
+    void requestSetSpeakerLabelingEnabled(bool on);
     void requestProcess(const QVector<float>& monoSamples, int sampleRate);
     void requestSetMaxSegmentMs(int ms);
     void requestSetSpeechRms(float rms);
@@ -143,7 +164,8 @@ signals:
     void requestReset();
 
 private:
-    void startThread(AsrBackendFactory factory, const AsrSegmenter::Config& segConfig);
+    void startThread(AsrBackendFactory factory, const AsrSegmenter::Config& segConfig,
+                     AsrSpeakerEmbedderFactory speakerEmbedderFactory);
 
     void updateBacklog(); // recompute lag = pushed − processed, emit if it moved
 
@@ -152,6 +174,7 @@ private:
     bool m_enabled = false;
     bool m_ready = false;
     QString m_modelPath;
+    bool m_speakerLabelingEnabled = false;
     double m_pushedMs = 0.0;         // audio handed to the engine (main thread)
     double m_processedMs = 0.0;      // audio the worker reports as handled
     double m_lastBacklogTenths = -1; // last emitted backlog (0.1 s units) — dedup

--- a/src/asr/AsrSegmenter.h
+++ b/src/asr/AsrSegmenter.h
@@ -32,9 +32,11 @@ public:
         // worker (not the segmenter) consumes this to build the detector; carried
         // here because Config is the worker's construction bundle.
         std::string vadModelPath;
-        // Optional speaker-embedding model (.onnx) for per-utterance speaker
-        // labeling (A/B/C…). Empty = no labeling. Also worker-consumed.
-        std::string speakerModelPath;
+        // The speaker-embedding model (.onnx) is deliberately NOT carried here:
+        // it is loaded at runtime via AsrEngine::setSpeakerModelPath() so a
+        // labeling change never has to rebuild the engine (#4737). Only the
+        // clustering threshold, which the worker's clusterer needs at
+        // construction, stays in this bundle.
         float speakerThreshold = 0.50f; // cosine threshold for the same speaker
     };
 

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -306,6 +306,9 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     // per-utterance A/B/C labeling.
     m_speakerModels = new AsrModelManager(this);
     connect(m_speakerModels, &AsrModelManager::progress, this, [this](qint64 got, qint64 total) {
+        if (!m_defaultSpeakerRequestPending) {
+            return; // labeling switched off mid-download — stop repainting progress
+        }
         m_panel->setStatus(total > 0
                                ? tr("Downloading speaker model… %1%").arg(static_cast<int>(got * 100 / total))
                                : tr("Downloading speaker model…"));
@@ -315,10 +318,16 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     connect(m_speakerModels, &AsrModelManager::finished, this,
             [this](const QString& path) { onSpeakerModelReady(path); });
     connect(m_speakerModels, &AsrModelManager::failed, this, [this](const QString& err) {
-        if (!m_defaultSpeakerRequestPending || !m_settings->labelSpeakers()) {
+        const bool stillWanted = m_defaultSpeakerRequestPending && m_settings->labelSpeakers();
+        // Always clear the intent, including on the path that swallows the
+        // error: leaving it set would make the next completion look current.
+        m_defaultSpeakerRequestPending = false;
+        if (!stillWanted) {
+            // The operator already turned labeling off. Drop the error, but
+            // don't strand the panel on the abandoned download's progress text.
+            restoreListeningStatus();
             return;
         }
-        m_defaultSpeakerRequestPending = false;
         m_panel->setStatus(tr("Speaker model download failed: %1").arg(err));
         m_settings->setLabelSpeakers(false);
     });
@@ -344,8 +353,14 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
             ensureSpeakerModel();
         } else {
             m_defaultSpeakerRequestPending = false;
-            if (!m_speakerLoad.isPending() && m_enabled && m_asr->isReady()) {
-                m_tap->setEnabled(true);
+            if (!m_speakerLoad.isPending()) {
+                if (m_enabled && m_asr->isReady()) {
+                    m_tap->setEnabled(true);
+                }
+                // A "Preparing…"/"Downloading…" message may still be on screen
+                // from the enable this cancels; a load still in flight restores
+                // it from onSpeakerModelLoaded() instead.
+                restoreListeningStatus();
             }
         }
     });
@@ -739,6 +754,15 @@ void CopyAssistController::requestEnable()
 void CopyAssistController::beginEnable()
 {
     m_panel->setBusy(true);
+    // Arm speaker labeling here rather than from buildEngine(): pressing Enable
+    // is the operator action that justifies fetching the ~24 MB model when the
+    // cache is missing it, whereas constructing an engine is not (#4737).
+    // Idempotent — a model already loaded into this engine is a no-op, and a
+    // download already in flight is left alone. Runs before the ASR-model
+    // status lines below so the headline stays the whisper/remote load.
+    if (m_settings->labelSpeakers()) {
+        ensureSpeakerModel();
+    }
     if (m_backend == AsrBackendKind::Remote) {
         // No local model to fetch — the remote endpoint is contacted per
         // utterance. load() just marks the backend ready.
@@ -1004,7 +1028,11 @@ void CopyAssistController::queueSpeakerModelLoad(const QString& path)
 
     m_speakerLoad.begin(path);
     m_panel->setStatus(tr("Preparing speaker model…"));
-    // Do not queue lossless RX audio behind ONNX session preparation. The tap
+    // Stop feeding the worker while it prepares. This is not a priority boost:
+    // loadSpeakerModel() is queued BEHIND whatever audio is already backlogged
+    // on that same thread, so on a deep backlog "Preparing speaker model…" can
+    // sit for a while either way. What it avoids is piling up further decodes
+    // that the operator's pending labeling choice may make moot. The tap
     // resumes from onSpeakerModelLoaded() on the controller thread.
     m_tap->setEnabled(false);
     m_asr->setSpeakerModelPath(path);
@@ -1016,18 +1044,36 @@ void CopyAssistController::onSpeakerModelLoaded(const QString& path, bool loaded
         return; // a superseded custom/default request is still queued behind it
     }
 
+    // Latched rather than re-derived: setLabelSpeakers(false) below flips
+    // labelSpeakers() as a side effect, so testing it again afterwards would
+    // overwrite the failure message with "Listening…".
+    bool reportedFailure = false;
     if (!loaded && m_settings->labelSpeakers()) {
         m_panel->setStatus(tr("Speaker model load failed."));
         m_settings->setLabelSpeakers(false);
+        reportedFailure = true;
     }
     m_asr->setSpeakerLabelingEnabled(m_settings->labelSpeakers());
     if (m_enabled && m_asr->isReady()) {
         m_tap->setEnabled(true);
-        if (loaded) {
-            m_panel->setStatus(m_backend == AsrBackendKind::Remote ? tr("Listening (remote)…")
-                                                                   : tr("Listening…"));
-        }
     }
+    if (!reportedFailure) {
+        restoreListeningStatus();
+    }
+}
+
+void CopyAssistController::restoreListeningStatus()
+{
+    if (!m_enabled || !m_asr->isReady()) {
+        return; // not listening — leave "Disabled"/"Loading model…" alone
+    }
+    m_panel->setStatus(m_backend == AsrBackendKind::Remote ? tr("Listening (remote)…")
+                                                           : tr("Listening…"));
+    // The ready() lambda skips its whole body while a speaker load is pending,
+    // so this resume point owes the log the same "on start" frequency header it
+    // would have written. writeFreqMarkerIfNeeded() dedups, so the ordinary
+    // "already marked" case costs nothing.
+    writeFreqMarkerIfNeeded();
 }
 
 void CopyAssistController::replaySpeakerConfiguration()
@@ -1052,9 +1098,21 @@ void CopyAssistController::replaySpeakerConfiguration()
         return;
     }
 
-    // This also preserves a busy default download across replacement: ensure()
-    // is skipped while busy, but m_defaultSpeakerRequestPending remains the
-    // current intent and its completion will load into this new engine.
+    // Building an engine must never START a download. ensure() fetches ~24 MB
+    // unprompted when the file is absent, and buildEngine() runs from the
+    // constructor and from every GPU/language/VAD/tier change — so without this
+    // guard a stale "labeling on" setting would pull the model at app launch
+    // with Copy Assist switched off. Fetching stays operator-driven (the
+    // labeling toggle); replay only re-arms what is already on disk.
+    if (!QFileInfo::exists(m_speakerModels->modelPath(speakerEmbedderTier()))) {
+        return;
+    }
+
+    // This also preserves a busy default download across replacement: the file
+    // is absent while it downloads, so the guard above returns early, but
+    // m_defaultSpeakerRequestPending survives resetForEngineReplacement() (it is
+    // controller state, not per-engine) and its completion loads into this new
+    // engine via onSpeakerModelReady().
     ensureSpeakerModel();
 }
 

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -315,6 +315,10 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     connect(m_speakerModels, &AsrModelManager::finished, this,
             [this](const QString& path) { onSpeakerModelReady(path); });
     connect(m_speakerModels, &AsrModelManager::failed, this, [this](const QString& err) {
+        if (!m_defaultSpeakerRequestPending || !m_settings->labelSpeakers()) {
+            return;
+        }
+        m_defaultSpeakerRequestPending = false;
         m_panel->setStatus(tr("Speaker model download failed: %1").arg(err));
         m_settings->setLabelSpeakers(false);
     });
@@ -335,10 +339,14 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
         if (!m_constructed) {
             return;
         }
+        m_asr->setSpeakerLabelingEnabled(on);
         if (on) {
             ensureSpeakerModel();
         } else {
-            rebuildEngine();
+            m_defaultSpeakerRequestPending = false;
+            if (!m_speakerLoad.isPending() && m_enabled && m_asr->isReady()) {
+                m_tap->setEnabled(true);
+            }
         }
     });
     connect(m_settings, &CopyAssistSettingsDialog::browseSpeakerModelRequested, this,
@@ -544,13 +552,9 @@ void CopyAssistController::buildEngine()
         segConfig.vadModelPath =
             CopyAssistSettings::value(QStringLiteral("AsrVadModelPath"), QString()).toString().toStdString();
     }
-    // Optional speaker labeling (A/B/C…): a speaker-embedding .onnx path + the
-    // cosine match threshold (stored 0–100 → 0.0–1.0).
-    if (CopyAssistSettings::value(QStringLiteral("AsrSpeakerEnabled"), QStringLiteral("False")).toString()
-        == QStringLiteral("True")) {
-        segConfig.speakerModelPath =
-            CopyAssistSettings::value(QStringLiteral("AsrSpeakerModelPath"), QString()).toString().toStdString();
-    }
+    // Speaker embedding is loaded only after the new engine's signals are
+    // connected below. This makes replacement deterministic: a GPU/VAD/backend
+    // rebuild never relies on an init-time completion from a dying engine.
     segConfig.speakerThreshold =
         CopyAssistSettings::value(QStringLiteral("AsrSpeakerThreshold"), QStringLiteral("50"))
             .toString().toInt() / 100.0f;
@@ -570,7 +574,7 @@ void CopyAssistController::buildEngine()
 
     connect(m_asr, &AsrEngine::ready, this, [this] {
         m_panel->setBusy(false);
-        if (m_enabled) {
+        if (m_enabled && !m_speakerLoad.isPending()) {
             m_tap->setEnabled(true);
             m_panel->setStatus(m_backend == AsrBackendKind::Remote ? tr("Listening (remote)…")
                                                                    : tr("Listening…"));
@@ -586,7 +590,7 @@ void CopyAssistController::buildEngine()
             [this](const QString& text, float confidence, int speaker) {
                 // Prefix a speaker label ([A], [B]…) when labeling is on.
                 const QString labeled =
-                    speaker >= 0
+                    m_settings->labelSpeakers() && speaker >= 0
                         ? QStringLiteral("[%1] %2").arg(QChar(u'A' + speaker)).arg(text)
                         : text;
                 m_panel->appendText(labeled, confidence);
@@ -594,8 +598,11 @@ void CopyAssistController::buildEngine()
             });
     connect(m_asr, &AsrEngine::error, this, [this](const QString& err) { m_panel->setStatus(err); });
     connect(m_asr, &AsrEngine::backlogChanged, m_panel, &CopyAssistPanel::setBacklog);
+    connect(m_asr, &AsrEngine::speakerModelLoaded, this,
+            &CopyAssistController::onSpeakerModelLoaded);
 
     applyTuning();
+    replaySpeakerConfiguration();
 }
 
 void CopyAssistController::applyTuning()
@@ -919,18 +926,40 @@ void CopyAssistController::ensureSpeakerModel()
     const QString custom = m_settings->speakerModelPath();
     if (!custom.isEmpty() && QFileInfo::exists(custom)
         && custom != m_speakerModels->modelPath(speakerEmbedderTier())) {
-        rebuildEngine();
+        m_defaultSpeakerRequestPending = false;
+        queueSpeakerModelLoad(custom);
         return;
     }
+    const AsrModelTier tier = speakerEmbedderTier();
+    const QString path = m_speakerModels->modelPath(tier);
+    if (m_speakerLoad.isPending(path)) {
+        m_panel->setStatus(tr("Preparing speaker model…"));
+        return; // off/on while this worker load is in flight only changes intent
+    }
+    if (m_speakerLoad.isLoaded(path) && !m_speakerLoad.isPending()) {
+        queueSpeakerModelLoad(path);
+        return;
+    }
+
     m_panel->setStatus(tr("Preparing speaker model…"));
-    m_speakerModels->ensure(speakerEmbedderTier());
+    // ensure() emits failed synchronously while verifying/downloading. Treat a
+    // second on/off/on as continued intent for the existing work instead.
+    m_desiredSpeakerModelPath = path;
+    m_defaultSpeakerRequestPending = true;
+    if (!m_speakerModels->isBusy()) {
+        m_speakerModels->ensure(tier);
+    }
 }
 
 void CopyAssistController::onSpeakerModelReady(const QString& path)
 {
+    if (!m_defaultSpeakerRequestPending || path != m_desiredSpeakerModelPath) {
+        return;
+    }
+    m_defaultSpeakerRequestPending = false;
     m_settings->setSpeakerModelPath(path);
     CopyAssistSettings::setValue(QStringLiteral("AsrSpeakerModelPath"), path);
-    rebuildEngine();
+    queueSpeakerModelLoad(path);
 }
 
 void CopyAssistController::promptSpeakerModel()
@@ -950,7 +979,83 @@ void CopyAssistController::promptSpeakerModel()
     }
     m_settings->setSpeakerModelPath(path);
     CopyAssistSettings::setValue(QStringLiteral("AsrSpeakerModelPath"), path);
-    rebuildEngine();
+    m_defaultSpeakerRequestPending = false;
+    queueSpeakerModelLoad(path);
+}
+
+void CopyAssistController::queueSpeakerModelLoad(const QString& path)
+{
+    if (path.isEmpty()) {
+        return;
+    }
+
+    m_desiredSpeakerModelPath = path;
+    m_asr->setSpeakerLabelingEnabled(m_settings->labelSpeakers());
+    if (m_speakerLoad.isPending(path)) {
+        m_panel->setStatus(tr("Preparing speaker model…"));
+        return; // applies equally to default and custom off/on sequences
+    }
+    if (m_speakerLoad.isLoaded(path) && !m_speakerLoad.isPending()) {
+        if (m_enabled && m_asr->isReady()) {
+            m_tap->setEnabled(true);
+        }
+        return;
+    }
+
+    m_speakerLoad.begin(path);
+    m_panel->setStatus(tr("Preparing speaker model…"));
+    // Do not queue lossless RX audio behind ONNX session preparation. The tap
+    // resumes from onSpeakerModelLoaded() on the controller thread.
+    m_tap->setEnabled(false);
+    m_asr->setSpeakerModelPath(path);
+}
+
+void CopyAssistController::onSpeakerModelLoaded(const QString& path, bool loaded)
+{
+    if (!m_speakerLoad.complete(path, loaded)) {
+        return; // a superseded custom/default request is still queued behind it
+    }
+
+    if (!loaded && m_settings->labelSpeakers()) {
+        m_panel->setStatus(tr("Speaker model load failed."));
+        m_settings->setLabelSpeakers(false);
+    }
+    m_asr->setSpeakerLabelingEnabled(m_settings->labelSpeakers());
+    if (m_enabled && m_asr->isReady()) {
+        m_tap->setEnabled(true);
+        if (loaded) {
+            m_panel->setStatus(m_backend == AsrBackendKind::Remote ? tr("Listening (remote)…")
+                                                                   : tr("Listening…"));
+        }
+    }
+}
+
+void CopyAssistController::replaySpeakerConfiguration()
+{
+    // This state belongs to the engine instance, unlike a model-manager
+    // download/verification request. A replacement may destroy an old worker
+    // before its queued completion reaches us, so begin the new instance with a
+    // clean per-engine state and explicitly replay the latest user intent.
+    m_speakerLoad.resetForEngineReplacement();
+    const bool labelSpeakers = m_settings->labelSpeakers();
+    m_asr->setSpeakerLabelingEnabled(labelSpeakers);
+    if (!labelSpeakers) {
+        return;
+    }
+
+    const QString requested = m_desiredSpeakerModelPath.isEmpty()
+                                  ? m_settings->speakerModelPath()
+                                  : m_desiredSpeakerModelPath;
+    if (!requested.isEmpty() && QFileInfo::exists(requested)
+        && requested != m_speakerModels->modelPath(speakerEmbedderTier())) {
+        queueSpeakerModelLoad(requested);
+        return;
+    }
+
+    // This also preserves a busy default download across replacement: ensure()
+    // is skipped while busy, but m_defaultSpeakerRequestPending remains the
+    // current intent and its completion will load into this new engine.
+    ensureSpeakerModel();
 }
 
 void CopyAssistController::rebuildEngine()

--- a/src/gui/CopyAssistController.h
+++ b/src/gui/CopyAssistController.h
@@ -122,6 +122,10 @@ private:
     void queueSpeakerModelLoad(const QString& path);
     void onSpeakerModelLoaded(const QString& path, bool loaded);
     void replaySpeakerConfiguration();
+    // Put the panel back on its steady-state text after a speaker-model step
+    // left a transient "Preparing…"/"Downloading…" message on screen, replaying
+    // the frequency marker the skipped ready() body owed the log.
+    void restoreListeningStatus();
     void rebuildEngine();  // rebuild only for backend/VAD/GPU changes
     static AsrModelTier sileroVadTier();       // default downloadable Silero VAD model
     static AsrModelTier speakerEmbedderTier(); // default downloadable speaker model

--- a/src/gui/CopyAssistController.h
+++ b/src/gui/CopyAssistController.h
@@ -28,6 +28,50 @@ enum class AsrBackendKind {
     SherpaOnnx, // sherpa-onnx offline model (a user-picked model directory)
 };
 
+// Per-engine state for a queued speaker-embedder load. Download/verification
+// intent belongs to the controller; this state is discarded when its AsrEngine
+// is replaced so a late completion can never leave the next engine muted.
+class SpeakerLoadLifecycle {
+public:
+    void resetForEngineReplacement()
+    {
+        m_loadingPath.clear();
+        m_loadedPath.clear();
+        m_pending = false;
+    }
+
+    void begin(const QString& path)
+    {
+        m_loadingPath = path;
+        m_pending = true;
+    }
+
+    bool complete(const QString& path, bool loaded)
+    {
+        if (!m_pending || path != m_loadingPath) {
+            return false;
+        }
+        m_pending = false;
+        if (loaded) {
+            m_loadedPath = path;
+        } else {
+            // The worker clears its previous embedder on failure, so this
+            // cache must not claim that an older path is still reusable.
+            m_loadedPath.clear();
+        }
+        return true;
+    }
+
+    bool isPending() const { return m_pending; }
+    bool isPending(const QString& path) const { return m_pending && m_loadingPath == path; }
+    bool isLoaded(const QString& path) const { return m_loadedPath == path; }
+
+private:
+    QString m_loadingPath;
+    QString m_loadedPath;
+    bool m_pending = false;
+};
+
 // Wires the Copy Assist panel to the ASR subsystem (RFC #4333, Phase 5). Owns
 // the AsrEngine, the model download manager, and the audio tap, and translates
 // panel intent into the enable → (download model) → load → tap-on flow, routing
@@ -74,8 +118,11 @@ private:
     void onVadModelReady(const QString& path); // cached/downloaded → persist + rebuild
     void promptSpeakerModel();   // pick + persist a custom speaker-embedding .onnx
     void ensureSpeakerModel();   // use the cached model, else auto-download it
-    void onSpeakerModelReady(const QString& path); // cached/downloaded → persist + rebuild
-    void rebuildEngine();  // rebuild the engine so the worker picks up a model change
+    void onSpeakerModelReady(const QString& path); // cached/downloaded → queue worker load
+    void queueSpeakerModelLoad(const QString& path);
+    void onSpeakerModelLoaded(const QString& path, bool loaded);
+    void replaySpeakerConfiguration();
+    void rebuildEngine();  // rebuild only for backend/VAD/GPU changes
     static AsrModelTier sileroVadTier();       // default downloadable Silero VAD model
     static AsrModelTier speakerEmbedderTier(); // default downloadable speaker model
     void writeFreqMarkerIfNeeded(); // log a "=== <freq> MHz ===" line on start/retune/day-roll
@@ -106,6 +153,9 @@ private:
     double m_currentFreqMhz = 0.0;  // active-slice frequency, for the log marker
     QString m_lastFreqMarkerKey;    // (dated-file|freq) last marked — dedups markers
     bool m_enabled = false;
+    bool m_defaultSpeakerRequestPending = false;
+    QString m_desiredSpeakerModelPath;
+    SpeakerLoadLifecycle m_speakerLoad;
     AsrBackendKind m_backend = AsrBackendKind::Whisper; // active inference backend
 };
 

--- a/tests/asr_engine_test.cpp
+++ b/tests/asr_engine_test.cpp
@@ -5,11 +5,14 @@
 
 #include "asr/AsrEngine.h"
 #include "asr/IAsrBackend.h"
+#include "asr/SpeakerEmbedder.h"
+#include "gui/CopyAssistController.h"
 
 #include <QCoreApplication>
 #include <QElapsedTimer>
 #include <QSignalSpy>
 #include <QThread>
+#include <QTimer>
 #include <QVector>
 
 #include <cmath>
@@ -100,6 +103,16 @@ AsrBackendFactory slowFactory(int delayMs)
     return [delayMs] { return std::unique_ptr<IAsrBackend>(new SlowBackend(delayMs)); };
 }
 
+AsrSpeakerEmbedderFactory slowSpeakerFactory(int delayMs)
+{
+    return [delayMs](const QString&) {
+        QThread::msleep(delayMs);
+        // No ONNX fixture is needed here: the delay models session preparation,
+        // while the null result exercises the regular failed-load completion.
+        return std::unique_ptr<SpeakerEmbedder>{};
+    };
+}
+
 // Generate at the real RX pipeline rate (24 kHz) so the engine must resample
 // 24k -> 16k on its worker before segmenting.
 constexpr int kSrcRate = 24000;
@@ -124,6 +137,38 @@ QVector<float> silence(int ms)
 int main(int argc, char** argv)
 {
     QCoreApplication app(argc, argv);
+
+    // ---- Engine replacement discards only per-engine speaker state --------
+    {
+        SpeakerLoadLifecycle lifecycle;
+        lifecycle.begin(QStringLiteral("/old-engine.onnx"));
+        expect(lifecycle.isPending(QStringLiteral("/old-engine.onnx")),
+               "matching speaker load is recognized as already pending");
+        expect(!lifecycle.isPending(QStringLiteral("/different-model.onnx")),
+               "a different speaker model is not deduplicated");
+        lifecycle.begin(QStringLiteral("/custom-speaker.onnx"));
+        expect(lifecycle.isPending(QStringLiteral("/custom-speaker.onnx")),
+               "custom speaker off/on recognizes the in-flight path for deduplication");
+        lifecycle.resetForEngineReplacement();
+        expect(!lifecycle.isPending(), "engine replacement clears pending speaker load");
+        expect(!lifecycle.isLoaded(QStringLiteral("/old-engine.onnx")),
+               "engine replacement does not carry a stale loaded model");
+
+        lifecycle.begin(QStringLiteral("/replayed-intent.onnx"));
+        expect(!lifecycle.complete(QStringLiteral("/old-engine.onnx"), true),
+               "late old-engine completion cannot settle replayed intent");
+        expect(lifecycle.isPending(), "late old-engine completion leaves replay pending");
+        expect(lifecycle.complete(QStringLiteral("/replayed-intent.onnx"), true),
+               "replayed speaker intent settles on the replacement engine");
+        expect(lifecycle.isLoaded(QStringLiteral("/replayed-intent.onnx")),
+               "replacement engine caches its own loaded speaker model");
+
+        lifecycle.begin(QStringLiteral("/failed-replacement.onnx"));
+        expect(lifecycle.complete(QStringLiteral("/failed-replacement.onnx"), false),
+               "failed replacement settles its pending load");
+        expect(!lifecycle.isLoaded(QStringLiteral("/replayed-intent.onnx")),
+               "failed replacement clears stale cached speaker state");
+    }
 
     // ---- Async load emits ready() -----------------------------------------
     {
@@ -191,6 +236,47 @@ int main(int argc, char** argv)
         delete engine; // must not block until the whole backlog finishes
         expect(timer.elapsed() < kDelayMs * 2,
                "destructor returns promptly despite a queued backlog");
+    }
+
+    // ---- Speaker preparation stays off the caller thread ------------------
+    {
+        constexpr int kDelayMs = 300;
+        AsrEngine engine(factory(true), AsrSegmenter::Config{}, nullptr,
+                         slowSpeakerFactory(kDelayMs));
+        QSignalSpy readySpy(&engine, &AsrEngine::ready);
+        engine.setModelPath(QStringLiteral("/does/not/matter"));
+        expect(readySpy.wait(5000), "speaker-load test: engine ready");
+
+        QSignalSpy speakerSpy(&engine, &AsrEngine::speakerModelLoaded);
+        QElapsedTimer timer;
+        timer.start();
+        engine.setSpeakerModelPath(QStringLiteral("/slow-speaker.onnx"));
+        expect(timer.elapsed() < 50,
+               "setSpeakerModelPath returns without waiting for speaker preparation");
+
+        engine.setSpeakerLabelingEnabled(true);
+        engine.setSpeakerLabelingEnabled(false); // latest intent wins behind the slow load
+        expect(!engine.isSpeakerLabelingEnabled(),
+               "speaker labeling disable takes effect immediately on the caller thread");
+
+        bool eventLoopTicked = false;
+        QTimer::singleShot(30, &app, [&eventLoopTicked] { eventLoopTicked = true; });
+        expect(speakerSpy.wait(5000), "slow speaker preparation completes asynchronously");
+        expect(eventLoopTicked,
+               "main event loop remains responsive while speaker preparation is in flight");
+        if (!speakerSpy.isEmpty()) {
+            const QList<QVariant> args = speakerSpy.first();
+            expect(args.at(0).toString() == QStringLiteral("/slow-speaker.onnx"),
+                   "speaker completion identifies the requested model path");
+            expect(!args.at(1).toBool(), "failed injected speaker loader is reported");
+        }
+
+        speakerSpy.clear();
+        engine.setSpeakerLabelingEnabled(true);
+        engine.setSpeakerModelPath(QStringLiteral("/failed-replacement.onnx"));
+        expect(speakerSpy.wait(5000), "failed speaker replacement completes");
+        expect(!engine.isSpeakerLabelingEnabled(),
+               "failed speaker replacement disables labeling instead of reusing stale state");
     }
 
     // ---- Disabling drops a queued backlog instead of transcribing it ------

--- a/tests/asr_engine_test.cpp
+++ b/tests/asr_engine_test.cpp
@@ -103,13 +103,19 @@ AsrBackendFactory slowFactory(int delayMs)
     return [delayMs] { return std::unique_ptr<IAsrBackend>(new SlowBackend(delayMs)); };
 }
 
-AsrSpeakerEmbedderFactory slowSpeakerFactory(int delayMs)
+// Deterministic stand-in for building the ~24 MB ECAPA session: the sleep is
+// what the caller must not wait on. `succeed` picks which completion branch of
+// AsrWorker::loadSpeakerModel() runs. The success branch hands back a default-
+// constructed SpeakerEmbedder — enough to prove the embedder is installed, the
+// clusterer reset and speakerModelLoaded(path, true) emitted, but NOT that a
+// label comes out the other end: embed() needs a real ONNX model for that, and
+// SpeakerEmbedder is concrete (no seam to fake one). Label emission stays
+// covered by the ONNX-gated fixtures, not here.
+AsrSpeakerEmbedderFactory speakerFactory(bool succeed, int delayMs)
 {
-    return [delayMs](const QString&) {
+    return [succeed, delayMs](const QString&) {
         QThread::msleep(delayMs);
-        // No ONNX fixture is needed here: the delay models session preparation,
-        // while the null result exercises the regular failed-load completion.
-        return std::unique_ptr<SpeakerEmbedder>{};
+        return succeed ? std::make_unique<SpeakerEmbedder>() : std::unique_ptr<SpeakerEmbedder>{};
     };
 }
 
@@ -242,7 +248,7 @@ int main(int argc, char** argv)
     {
         constexpr int kDelayMs = 300;
         AsrEngine engine(factory(true), AsrSegmenter::Config{}, nullptr,
-                         slowSpeakerFactory(kDelayMs));
+                         speakerFactory(false, kDelayMs));
         QSignalSpy readySpy(&engine, &AsrEngine::ready);
         engine.setModelPath(QStringLiteral("/does/not/matter"));
         expect(readySpy.wait(5000), "speaker-load test: engine ready");
@@ -251,7 +257,10 @@ int main(int argc, char** argv)
         QElapsedTimer timer;
         timer.start();
         engine.setSpeakerModelPath(QStringLiteral("/slow-speaker.onnx"));
-        expect(timer.elapsed() < 50,
+        // Half the loader delay, not a small absolute bound: the property is
+        // "did not wait for the load", and a loaded runner must make this test
+        // slower rather than red. The blocking (pre-fix) shape costs >= kDelayMs.
+        expect(timer.elapsed() < kDelayMs / 2,
                "setSpeakerModelPath returns without waiting for speaker preparation");
 
         engine.setSpeakerLabelingEnabled(true);
@@ -275,8 +284,73 @@ int main(int argc, char** argv)
         engine.setSpeakerLabelingEnabled(true);
         engine.setSpeakerModelPath(QStringLiteral("/failed-replacement.onnx"));
         expect(speakerSpy.wait(5000), "failed speaker replacement completes");
+        // The flag is operator intent and nothing but setSpeakerLabelingEnabled()
+        // writes it, so a failed load leaves it alone; the worker dropping its
+        // embedder is what stops labels. Owning that distinction is what lets the
+        // controller decide whether to un-check the box.
+        expect(engine.isSpeakerLabelingEnabled(),
+               "a failed speaker load does not silently rewrite the operator's intent");
+    }
+
+    // ---- A successful speaker load arms labeling and keeps intent ---------
+    {
+        constexpr int kDelayMs = 50;
+        AsrEngine engine(factory(true), AsrSegmenter::Config{}, nullptr,
+                         speakerFactory(true, kDelayMs));
+        QSignalSpy readySpy(&engine, &AsrEngine::ready);
+        engine.setModelPath(QStringLiteral("/does/not/matter"));
+        expect(readySpy.wait(5000), "speaker-success test: engine ready");
+
+        QSignalSpy speakerSpy(&engine, &AsrEngine::speakerModelLoaded);
+        engine.setSpeakerLabelingEnabled(true);
+        engine.setSpeakerModelPath(QStringLiteral("/good-speaker.onnx"));
+        expect(speakerSpy.wait(5000), "successful speaker preparation completes");
+        if (!speakerSpy.isEmpty()) {
+            const QList<QVariant> args = speakerSpy.first();
+            expect(args.at(0).toString() == QStringLiteral("/good-speaker.onnx"),
+                   "successful completion identifies the requested model path");
+            expect(args.at(1).toBool(), "successful speaker load is reported as loaded");
+        }
+        expect(engine.isSpeakerLabelingEnabled(),
+               "a successful speaker load leaves labeling intent on");
+
+        // Replacing a good model with another good one must not disturb intent
+        // either — the cached embedder is swapped, not the operator's choice.
+        speakerSpy.clear();
+        engine.setSpeakerModelPath(QStringLiteral("/second-speaker.onnx"));
+        expect(speakerSpy.wait(5000), "speaker model replacement completes");
+        expect(engine.isSpeakerLabelingEnabled(),
+               "replacing a loaded speaker model keeps labeling intent on");
+
+        // Toggling off keeps the loaded embedder (that is the whole point of
+        // #4737's fix) — only the intent flips, with no engine teardown.
+        engine.setSpeakerLabelingEnabled(false);
         expect(!engine.isSpeakerLabelingEnabled(),
-               "failed speaker replacement disables labeling instead of reusing stale state");
+               "toggling labeling off flips intent without a reload");
+    }
+
+    // ---- Shutdown skips speaker loads that have not started ---------------
+    // A backend/GPU/language change destroys the engine, and ~AsrEngine() joins
+    // the worker. A speaker session build cannot be aborted once running, so the
+    // bound that matters is "one in-flight stage", not "every queued stage".
+    {
+        constexpr int kDelayMs = 300;
+        auto* engine = new AsrEngine(factory(true), AsrSegmenter::Config{}, nullptr,
+                                     speakerFactory(false, kDelayMs));
+        QSignalSpy readySpy(engine, &AsrEngine::ready);
+        engine->setModelPath(QStringLiteral("/does/not/matter"));
+        expect(readySpy.wait(5000), "speaker-shutdown test: engine ready");
+
+        engine->setSpeakerModelPath(QStringLiteral("/first.onnx"));
+        engine->setSpeakerModelPath(QStringLiteral("/second.onnx"));
+        engine->setSpeakerModelPath(QStringLiteral("/third.onnx"));
+        QThread::msleep(50); // let the worker start on the first
+
+        QElapsedTimer timer;
+        timer.start();
+        delete engine; // must wait out one load, not all three (~900 ms)
+        expect(timer.elapsed() < kDelayMs * 2,
+               "destructor skips speaker loads that have not started");
     }
 
     // ---- Disabling drops a queued backlog instead of transcribing it ------


### PR DESCRIPTION
## Summary

- keep speaker-model ONNX session preparation on the existing ASR worker thread
- apply speaker-label enable/disable intent without rebuilding and synchronously joining the ASR engine
- deduplicate rapid off/on requests, mask late labels, and clear stale state after failed replacement loads
- pause only the ASR audio tap while loading, then resume it and restore the Listening status

Fixes #4737

## Root cause

The speaker toggle, model-ready, and custom-model paths rebuilt `AsrEngine` on the GUI thread. Destroying the old engine performs an unbounded worker-thread join, so ONNX/backend work already in flight blocked Qt event processing and could starve radio servicing. A repeated enable could also collide with an already-busy model manager and trigger another rebuild.

## Verification

- `asr_engine_test`: all pass, including a deterministic 300 ms speaker loader proving the caller and Qt event loop remain responsive
- arm64 macOS `AetherSDR` target: builds successfully
- strict engine-boundary check: 0 blockers
- accessibility check for `CopyAssistController.cpp`: no findings
- RX-only automation proof on a FLEX-6700: toggled Label speakers off/on while status showed Preparing speaker model; both interactions and the next bridge ping completed, the model loaded once, the panel returned to Listening, and the radio remained connected with `transmitting=false`

No screenshot is included because this is a lifecycle/timing defect; the relevant proof is event-loop response, settled state, and radio connectivity.

Generated with OpenAI Codex.
