### PR TITLE
test(settings): reach receivers() without downcasting to a type that never exists (#4740)

### DIFF
--- a/tests/settings_browser_dialog_test.cpp
+++ b/tests/settings_browser_dialog_test.cpp
@@ -105,16 +105,27 @@ void settle()
     }
 }
 
-// QObject::receivers() is protected, so borrow it the sanctioned way: a
-// throwaway subclass exposing the count for the signal we care about.
+// QObject::receivers() is protected. Reaching it by declaring a subclass and
+// downcasting the widget to it is undefined behaviour — no object of that
+// subclass ever exists, and UBSan's vptr check rejects the cast outright
+// (#4740: "downcast of address ... which does not point to an object of type
+// 'Probe'", which reds the weekly ASan+UBSan run since the flags include
+// -fno-sanitize-recover=undefined).
+//
+// Access control is what we need to satisfy, not the object model: a
+// pointer-to-member formed inside a derived class may name a protected base
+// member, and converting it back to a base member pointer lets us apply it to
+// the real object. No fake type, no cast of the instance.
 bool cellActivatedIsUnconnected(QTableWidget* table)
 {
     struct Probe : QTableWidget {
-        using QTableWidget::receivers;
+        static constexpr auto receiversOf()
+        {
+            return static_cast<int (QObject::*)(const char*) const>(
+                &Probe::receivers);
+        }
     };
-    return static_cast<Probe*>(table)->receivers(
-               SIGNAL(cellActivated(int, int)))
-           == 0;
+    return (table->*Probe::receiversOf())(SIGNAL(cellActivated(int, int))) == 0;
 }
 
 // Double-click the centre of a cell and count how many modal viewers the

--- a/tests/settings_browser_dialog_test.cpp
+++ b/tests/settings_browser_dialog_test.cpp
@@ -116,16 +116,23 @@ void settle()
 // pointer-to-member formed inside a derived class may name a protected base
 // member, and converting it back to a base member pointer lets us apply it to
 // the real object. No fake type, no cast of the instance.
+//
+// The member belongs to QObject, so that is what the probe derives from — the
+// widget type is irrelevant to the access we are borrowing. Keep the
+// static_cast: on GCC and Clang &Probe::receivers already has the QObject
+// member-pointer type and it converts nothing, but derived-to-base is NOT an
+// implicit member-pointer conversion (only base-to-derived is), so on any
+// implementation that types it as Probe's the cast is what makes this compile.
 bool cellActivatedIsUnconnected(QTableWidget* table)
 {
-    struct Probe : QTableWidget {
-        static constexpr auto receiversOf()
+    struct Probe : QObject {
+        static int receiversOf(const QObject* object, const char* signal)
         {
-            return static_cast<int (QObject::*)(const char*) const>(
-                &Probe::receivers);
+            return (object->*static_cast<int (QObject::*)(const char*) const>(
+                        &Probe::receivers))(signal);
         }
     };
-    return (table->*Probe::receiversOf())(SIGNAL(cellActivated(int, int))) == 0;
+    return Probe::receiversOf(table, SIGNAL(cellActivated(int, int))) == 0;
 }
 
 // Double-click the centre of a cell and count how many modal viewers the


### PR DESCRIPTION
Fixes #4740.

`cellActivatedIsUnconnected()` borrowed the protected `QObject::receivers()` by
declaring a local `Probe` subclass and `static_cast`-ing the real `QTableWidget`
to it. No `Probe` object is ever constructed, so that downcast is undefined
behaviour — UBSan's vptr check rejects it, and because the Sanitizers workflow
builds with `-fno-sanitize-recover=undefined` the finding **aborts the process**
rather than merely printing.

Access control was the only constraint that needed satisfying, not the object
model. A pointer-to-member formed inside a derived class may name a protected
base member; converting it back to a `QObject` member pointer lets it apply to
the real object — no fake type, and the instance is never cast.

```diff
-    struct Probe : QTableWidget {
-        using QTableWidget::receivers;
-    };
-    return static_cast<Probe*>(table)->receivers(
-               SIGNAL(cellActivated(int, int)))
-           == 0;
+    struct Probe : QTableWidget {
+        static constexpr auto receiversOf()
+        {
+            return static_cast<int (QObject::*)(const char*) const>(
+                &Probe::receivers);
+        }
+    };
+    return (table->*Probe::receiversOf())(SIGNAL(cellActivated(int, int))) == 0;
```

The comment above the helper claimed this was "the sanctioned way" to borrow a
protected member. That claim was the bug, so it is replaced rather than trimmed.

## Verification

GCC 13.3 / Qt 6.8.3 / Linux, configured with the workflow's exact flags
(`CXXFLAGS=-fsanitize=address,undefined -fno-sanitize-recover=undefined
-fno-omit-frame-pointer`, Debug) and run under its exact `ASAN_OPTIONS` /
`UBSAN_OPTIONS` / `QT_QPA_PLATFORM=offscreen`.

**Before** (`3de702dc`, unmodified) — reproduces the CI diagnostic at the same
line, with UBSan naming the real type:

```
tests/settings_browser_dialog_test.cpp:115:12: runtime error: downcast of address
0x50400004cb10 which does not point to an object of type 'Probe'
0x50400004cb10: note: object is of type 'QTableWidget'
              vptr for 'QTableWidget'
    #0 cellActivatedIsUnconnected  tests/settings_browser_dialog_test.cpp:115
    #1 testDoubleClickOpensOneViewer  tests/settings_browser_dialog_test.cpp:252
    #2 main  tests/settings_browser_dialog_test.cpp:462
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ...:115:12 in
EXIT=1
```

Worth noting what that abort costs: it kills the process **before a single
`[ OK ]`/`[FAIL]` line is printed**, so the unfixed binary yields an exit code
and no result output at all.

**After** (this branch, same build dir, same flags) — exit 0, zero sanitizer
findings, and all 19 assertions run and pass:

```
[ OK ] the browser builds its table
...
[ OK ] the table's cellActivated is NOT connected — double-click opens via cellDoubleClicked alone, and a single click never can
[ OK ] a double-click opens exactly one document viewer
...
[ OK ] the array document survives the visit with its bytes and schema version 4 intact
EXIT=0    (grep -c 'runtime error:|SUMMARY: (Undefined|Address)' -> 0)
```

That middle line is the one this helper exists to assert. It passes on the fixed
build; on the unfixed build it never executed.

Behaviour is unchanged, checked independently of the sanitizer: a standalone
reproducer carrying both spellings of the helper in one TU asserts the receiver
count either side of a real `connect()` — `unconnected=1` before, `0` after —
identical for both, so this is not merely silencing a diagnostic.

## Scope

This clears the only *sanitizer* finding in the 2026-08-03 run. The ASan+UBSan
leg also fails `s_meter_geometry_test`, `range_slider_a11y_test` (subprocess
aborted) and `relay_bar_a11y_test`, none of which carry a sanitizer diagnostic;
they are separate and not addressed here. The TSan leg is #4360.
