### PR TITLE
feat(gui): add window video recording feature. Principle VIII.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -488,7 +488,7 @@ declared in `MainWindow.h`. The split is about *which file* a body lives in.
 
 | Your change | Goes in |
 |---|---|
-| Feature lifecycle/handler fitting an existing subsystem | that subsystem's TU — demods (RADE/FreeDV/DAX/RTTY/WFM) → `MainWindow_DigitalModes.cpp`; physical controllers → `MainWindow_Controllers.cpp`; SWR sweep → `MainWindow_SwrSweep.cpp`; spot clients → `MainWindow_Spots.cpp`; discovery/connection/pan-lifecycle → `MainWindow_Session.cpp`; client-DSP applets → `MainWindow_DspApplets.cpp` |
+| Feature lifecycle/handler fitting an existing subsystem | that subsystem's TU — demods (RADE/FreeDV/DAX/RTTY/WFM) → `MainWindow_DigitalModes.cpp`; physical controllers → `MainWindow_Controllers.cpp`; SWR sweep → `MainWindow_SwrSweep.cpp`; spot clients → `MainWindow_Spots.cpp`; discovery/connection/pan-lifecycle → `MainWindow_Session.cpp`; client-DSP applets → `MainWindow_DspApplets.cpp`; window video recording → `MainWindow_Recording.cpp` |
 | Wiring a newly-created radio object (slice/pan/VFO/DSP) to the UI | `MainWindow_Wiring.cpp` |
 | A menu item / action | `MainWindow_Menus.cpp` |
 | A keyboard shortcut | `MainWindow_Shortcuts.cpp` |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -841,6 +841,10 @@ add_subdirectory(third_party/QGeoView/lib EXCLUDE_FROM_ALL)
 set(GUI_SOURCES
     src/gui/Contribute.cpp
     src/gui/MainWindow.cpp
+    src/gui/WindowVideoRecorder.cpp
+    src/gui/MainWindow_Recording.cpp
+    src/gui/recording/INativeVideoWriter.h
+    src/gui/recording/MediaBackendProbe.h
     src/gui/MainWindowHelpers.cpp
     src/gui/WindowGeometryRestore.cpp
     src/gui/MainWindow_Controllers.cpp
@@ -1035,6 +1039,21 @@ set(GUI_SOURCES
     src/gui/TokenEditorWidget.cpp
     src/gui/CompactColorPicker.cpp
 )
+
+# Native Video Recording Fallback Sources list
+if(WIN32)
+    set(WMF_LIBRARIES mfreadwrite mfplat mfuuid)
+    list(APPEND GUI_SOURCES
+        src/gui/recording/WmfVideoWriter.cpp
+        src/gui/recording/WmfVideoWriter.h
+    )
+elseif(APPLE)
+    enable_language(OBJCXX)
+    list(APPEND GUI_SOURCES
+        src/gui/recording/AvfVideoWriter.mm
+        src/gui/recording/AvfVideoWriter.h
+    )
+endif()
 
 # Bundled RNNoise (Mozilla/Xiph BSD-3) — client-side neural noise suppression
 set(RNNOISE_DIR ${CMAKE_SOURCE_DIR}/third_party/rnnoise)
@@ -1290,7 +1309,7 @@ add_library(aethercore STATIC
     ${RADE_SOURCES}
     ${SPECBLEACH_SOURCES}
 )
-target_link_libraries(aethercore PRIVATE aether::wdsp)
+target_link_libraries(aethercore PRIVATE aether::wdsp ${WMF_LIBRARIES})
 
 add_executable(AetherSDR
     src/main.cpp
@@ -1675,6 +1694,22 @@ else()
     message(STATUS "ASR: disabled (-DENABLE_ASR=OFF)")
 endif()
 # ----------------------------------------------------------------------------
+
+# Native Video Recording Fallback Libraries
+if(WIN32)
+    target_link_libraries(AetherSDR PRIVATE ${WMF_LIBRARIES} ole32)
+elseif(APPLE)
+    find_library(COCOA_LIBRARY Cocoa REQUIRED)
+    find_library(AVFOUNDATION_LIBRARY AVFoundation REQUIRED)
+    find_library(COREMEDIA_LIBRARY CoreMedia REQUIRED)
+    find_library(COREVIDEO_LIBRARY CoreVideo REQUIRED)
+    target_link_libraries(AetherSDR PRIVATE 
+        ${COCOA_LIBRARY} 
+        ${AVFOUNDATION_LIBRARY} 
+        ${COREMEDIA_LIBRARY} 
+        ${COREVIDEO_LIBRARY}
+    )
+endif()
 
 if (USE_SYSTEM_ZLIB)
     target_link_libraries(aethercore PRIVATE PkgConfig::zlib)      # core: ZipArchive
@@ -3582,6 +3617,38 @@ target_include_directories(qso_recorder_pc_audio_guard_test PRIVATE
 )
 target_link_libraries(qso_recorder_pc_audio_guard_test PRIVATE Qt6::Core Qt6::Multimedia)
 add_test(NAME qso_recorder_pc_audio_guard_test COMMAND qso_recorder_pc_audio_guard_test)
+
+# Unit test for WindowVideoRecorder
+add_executable(window_video_recorder_test
+    tests/window_video_recorder_test.cpp
+    src/gui/WindowVideoRecorder.cpp
+    ${AETHER_SETTINGS_SOURCES}
+    src/core/AudioDeviceNegotiator.cpp
+    src/core/AudioFormatNegotiator.cpp
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+    src/core/Resampler.cpp
+    src/models/SliceModel.cpp
+    src/core/DigitalVoiceModeRegistry.cpp
+)
+if(WIN32)
+    target_sources(window_video_recorder_test PRIVATE src/gui/recording/WmfVideoWriter.cpp)
+    target_link_libraries(window_video_recorder_test PRIVATE ${WMF_LIBRARIES} ole32)
+elseif(APPLE)
+    target_sources(window_video_recorder_test PRIVATE src/gui/recording/AvfVideoWriter.mm)
+    target_link_libraries(window_video_recorder_test PRIVATE "-framework AVFoundation" "-framework CoreMedia" "-framework CoreVideo")
+endif()
+target_include_directories(window_video_recorder_test PRIVATE
+    src
+    ${CMAKE_SOURCE_DIR}/third_party/r8brain
+)
+target_link_libraries(window_video_recorder_test PRIVATE Qt6::Core Qt6::Widgets Qt6::Multimedia Qt6::Test)
+add_test(NAME window_video_recorder_test COMMAND window_video_recorder_test)
+# Headless CI has no display, and no MP4/H.264/AAC encoder is guaranteed —
+# the test returns 77 (skip) when Qt Multimedia cannot encode.
+set_tests_properties(window_video_recorder_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+    SKIP_RETURN_CODE 77)
 
 add_executable(profile_transfer_test
     tests/profile_transfer_test.cpp
@@ -5621,6 +5688,7 @@ endif()
 # directly (rather than linking aethercore) needs the vendored SQLite engine.
 # Conditional targets are guarded with if(TARGET ...).
 set(AETHER_SETTINGS_CONSUMERS
+    window_video_recorder_test
     slice_label_test
     ulanzi_mapping_migration_test
     theme_manager_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3636,7 +3636,7 @@ if(WIN32)
     target_link_libraries(window_video_recorder_test PRIVATE ${WMF_LIBRARIES} ole32)
 elseif(APPLE)
     target_sources(window_video_recorder_test PRIVATE src/gui/recording/AvfVideoWriter.mm)
-    target_link_libraries(window_video_recorder_test PRIVATE "-framework AVFoundation" "-framework CoreMedia" "-framework CoreVideo")
+    target_link_libraries(window_video_recorder_test PRIVATE "-framework Foundation" "-framework AVFoundation" "-framework CoreMedia" "-framework CoreVideo")
 endif()
 target_include_directories(window_video_recorder_test PRIVATE
     src

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1309,7 +1309,7 @@ add_library(aethercore STATIC
     ${RADE_SOURCES}
     ${SPECBLEACH_SOURCES}
 )
-target_link_libraries(aethercore PRIVATE aether::wdsp ${WMF_LIBRARIES})
+target_link_libraries(aethercore PRIVATE aether::wdsp)
 
 add_executable(AetherSDR
     src/main.cpp

--- a/docs/architecture/mainwindow-decomposition.md
+++ b/docs/architecture/mainwindow-decomposition.md
@@ -28,6 +28,7 @@ Read this before adding code to anything named `MainWindow*`. The one rule:
 | `MainWindow_Spots.cpp` | 2b | `wireSpotSubsystem()` — DX Cluster / RBN / WSJT-X / SpotCollector / POTA clients and their UI plumbing. |
 | `MainWindow_Session.cpp` | 2c | `wireDiscovery()` / `wireRadioModel()` / `wirePanLifecycle()` — LAN + SmartLink discovery, heartbeat/disconnect detection, connection-state routing, and pan-stream lifecycle: the wiring that constitutes "a connected radio". Seed of the future `RadioSession` aggregate (#3445). |
 | `MainWindow_DspApplets.cpp` | 2d | `wirePooDooTiles()` + `wireDspApplets()` — PooDoo RX status tiles and the client-DSP applet family (Compressor / Gate / De-esser / Tube / Reverb / AetherDSP / PUDU TX+RX) plus TX signal-chain wiring. |
+| `MainWindow_Recording.cpp` | 2e | `wireWindowVideoRecorder()` / `onRecordWindowToggled()` / `deferCloseForWindowRecorder()` — `WindowVideoRecorder` creation, its TitleBar + status-bar state sync, RX/TX audio taps, and the close-while-recording finalize handshake (including the watchdog). |
 | `MainWindowHelpers.{h,cpp}` | 0 | Stateless formatters / value transforms with **no** `MainWindow` dependency (tooltip builders, spot-ID math, client-list parsing, small pixmap painters). |
 | `MainWindowShortcutState.h` | 1b | Internal shared shortcut state — **not** a public API; only `MainWindow*.cpp` TUs include it. |
 
@@ -39,6 +40,7 @@ Read this before adding code to anything named `MainWindow*`. The one rule:
 | Wiring a newly-created slice / pan / VFO / DSP *widget* to the UI | `MainWindow_Wiring.cpp` |
 | Discovery / connection-state / pan-stream-lifecycle wiring | `MainWindow_Session.cpp` (not `_Wiring`) |
 | Client-DSP applet or PooDoo-tile wiring | `MainWindow_DspApplets.cpp` (not `_Wiring`) |
+| Window video-recording wiring or its close/finalize handshake | `MainWindow_Recording.cpp` |
 | A new menu item or action | `MainWindow_Menus.cpp` |
 | A new keyboard shortcut | `MainWindow_Shortcuts.cpp` |
 | A stateless formatter/helper with no `MainWindow` dependency | `MainWindowHelpers.{h,cpp}` |

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -26,6 +26,7 @@
 #include "ClientDisconnectDialog.h"
 #include "ConnectedStationsDialog.h"
 #include "TitleBar.h"
+#include "WindowVideoRecorder.h"
 #include "PanRecenterPolicy.h"
 #include "PanadapterApplet.h"
 #ifdef AETHER_ASR_ENABLED

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1188,6 +1188,7 @@ MainWindow::MainWindow(QWidget* parent)
 
     // QSO audio recorder (#1297) — lives on main thread, audio feeds are thread-safe
     m_qsoRecorder = new QsoRecorder(this);
+
     // During playback, block live RX audio from entering the buffer
     connect(m_qsoRecorder, &QsoRecorder::muteRxRequested, this, [this](bool mute) {
         // Covers BOTH producers. The disconnect below is the Flex path and is
@@ -1914,6 +1915,10 @@ MainWindow::MainWindow(QWidget* parent)
             m_radioModel.removeRxAudioStream();
         }
     });
+
+    // Window video recorder (creation + all wiring) — MainWindow_Recording.cpp
+    wireWindowVideoRecorder();
+
     // Master volume — title bar slider routes through applyMasterVolume()
     // so the TCI `volume:N;` command (#1764) can hit the same code path
     // when tciServer() is created later in this constructor.
@@ -3491,6 +3496,13 @@ void MainWindow::changeEvent(QEvent* event)
 
 void MainWindow::closeEvent(QCloseEvent* event)
 {
+    // isSessionActive covers both live recording and stop-in-flight finalize.
+    // deferCloseForWindowRecorder() lives in MainWindow_Recording.cpp.
+    if (deferCloseForWindowRecorder()) {
+        event->ignore();
+        return;
+    }
+
     // Release the TGXL/PGXL native control sockets explicitly so the radio
     // can resume polling them on behalf of other clients (e.g. Maestro).
     // The radio-disconnect handler does this via a queued connection on
@@ -3715,6 +3727,9 @@ void MainWindow::closeEvent(QCloseEvent* event)
     }
 
     QMainWindow::closeEvent(event);
+    if (m_waitingForRecorderToStop) {
+        QCoreApplication::quit();
+    }
 }
 
 // keyPressEvent()/keyReleaseEvent() lives in MainWindow_Shortcuts.cpp (#3351 Phase 1c).
@@ -7188,6 +7203,9 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
 
     // QSO recorder: track active slice for frequency/mode metadata (#1297)
     m_qsoRecorder->setSlice(s);
+    if (m_windowVideoRecorder) {
+        m_windowVideoRecorder->setSlice(s);
+    }
 
     // Re-wire applet panel, overlay menu to the new active slice
     if (m_panStack) {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -34,6 +34,7 @@
 #include "core/CwCallsignSpotter.h"
 #include "core/RttyDecoder.h"
 #include "core/QsoRecorder.h"
+#include "gui/WindowVideoRecorder.h"
 #include "core/ClientPuduMonitor.h"
 #include "core/AudioOutputRouter.h"
 #include "core/DxClusterClient.h"
@@ -949,6 +950,14 @@ private:
     void showRecorderNotice(const QString& key,
                             const QString& title,
                             const QString& text);
+    WindowVideoRecorder* m_windowVideoRecorder{nullptr};
+    bool              m_waitingForRecorderToStop{false};
+    bool              m_recorderCloseForced{false};
+    // Window video recording — MainWindow_Recording.cpp
+    void wireWindowVideoRecorder();
+    void onRecordWindowToggled(bool on);
+    // True when close() must be deferred until the encoder has finalized.
+    bool deferCloseForWindowRecorder();
     std::unique_ptr<AutomationServer> m_automation;  // agent bridge (#3646); nullptr when off
     ClientPuduMonitor* m_finalMonitor{nullptr};
     AudioOutputRouter* m_outputRouter{nullptr};   // registry for output-following sinks (#3306)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -34,7 +34,6 @@
 #include "core/CwCallsignSpotter.h"
 #include "core/RttyDecoder.h"
 #include "core/QsoRecorder.h"
-#include "gui/WindowVideoRecorder.h"
 #include "core/ClientPuduMonitor.h"
 #include "core/AudioOutputRouter.h"
 #include "core/DxClusterClient.h"
@@ -136,6 +135,7 @@ class MemoryDialog;
 class NetSchedulerDialog;
 class NetReminderBanner;
 class NetScheduler;
+class WindowVideoRecorder;
 struct NetEntry;
 struct MemoryEntry;
 class PropDashboardDialog;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -953,6 +953,7 @@ private:
     WindowVideoRecorder* m_windowVideoRecorder{nullptr};
     bool              m_waitingForRecorderToStop{false};
     bool              m_recorderCloseForced{false};
+    bool              m_windowRecorderHadError{false};
     // Window video recording — MainWindow_Recording.cpp
     void wireWindowVideoRecorder();
     void onRecordWindowToggled(bool on);

--- a/src/gui/MainWindow_Recording.cpp
+++ b/src/gui/MainWindow_Recording.cpp
@@ -41,19 +41,23 @@ void MainWindow::wireWindowVideoRecorder()
     connect(m_windowVideoRecorder, &WindowVideoRecorder::recordingStarted,
             this, [this](const QString& filePath) {
         Q_UNUSED(filePath);
+        m_windowRecorderHadError = false;
         m_titleBar->setRecordWindowEnabled(true);
     });
     connect(m_windowVideoRecorder, &WindowVideoRecorder::recordingStopped,
             this, [this](const QString& filePath, int durationSecs) {
-        statusBar()->showMessage(
-            tr("🎬 Video saved (%1s): %2")
-                .arg(durationSecs)
-                .arg(QDir::toNativeSeparators(filePath)),
-            5000);
+        if (!m_windowRecorderHadError) {
+            statusBar()->showMessage(
+                tr("🎬 Video saved (%1s): %2")
+                    .arg(durationSecs)
+                    .arg(QDir::toNativeSeparators(filePath)),
+                5000);
+        }
         m_titleBar->setRecordWindowEnabled(false);
     });
     connect(m_windowVideoRecorder, &WindowVideoRecorder::recordingError,
             this, [this](const QString& message) {
+        m_windowRecorderHadError = true;
         statusBar()->showMessage(tr("🎬 Recording error: %1").arg(message), 5000);
         m_titleBar->setRecordWindowEnabled(false);
         // Ensure the encoder session stops; UI unchecked must match capture state.

--- a/src/gui/MainWindow_Recording.cpp
+++ b/src/gui/MainWindow_Recording.cpp
@@ -1,0 +1,155 @@
+// MainWindow_Recording.cpp — window video recording subsystem (#3351 sibling TU).
+//
+// Creation, UI/state wiring and the close-while-recording handshake for
+// WindowVideoRecorder. Kept out of MainWindow.cpp per the decomposition rule in
+// AGENTS.md ("Adding code to MainWindow").
+//
+// Includes are carried explicitly: the Linux CI image is on Qt 6.8.3 while
+// macOS runs 6.11.x, so transitive resolution on the newer Qt proves nothing.
+
+#include "MainWindow.h"
+#include "TitleBar.h"
+#include "WindowVideoRecorder.h"
+
+#include "core/AudioEngine.h"
+#include "models/RadioModel.h"
+#include "models/TransmitModel.h"
+
+#include <QDir>
+#include <QStatusBar>
+#include <QString>
+#include <QTimer>
+
+namespace AetherSDR {
+
+namespace {
+// Upper bound on how long close() waits for the encoder to finalize. The Qt
+// Multimedia path finalizes asynchronously from recorderStateChanged; if that
+// state change never arrives the window is already hidden and every subsequent
+// close() is ignored, leaving a process only `kill` can end.
+constexpr int kRecorderStopWatchdogMs = 5000;
+} // namespace
+
+void MainWindow::wireWindowVideoRecorder()
+{
+    if (m_windowVideoRecorder) {
+        return;
+    }
+
+    m_windowVideoRecorder = new WindowVideoRecorder(this, this);
+
+    connect(m_windowVideoRecorder, &WindowVideoRecorder::recordingStarted,
+            this, [this](const QString& filePath) {
+        Q_UNUSED(filePath);
+        m_titleBar->setRecordWindowEnabled(true);
+    });
+    connect(m_windowVideoRecorder, &WindowVideoRecorder::recordingStopped,
+            this, [this](const QString& filePath, int durationSecs) {
+        statusBar()->showMessage(
+            tr("🎬 Video saved (%1s): %2")
+                .arg(durationSecs)
+                .arg(QDir::toNativeSeparators(filePath)),
+            5000);
+        m_titleBar->setRecordWindowEnabled(false);
+    });
+    connect(m_windowVideoRecorder, &WindowVideoRecorder::recordingError,
+            this, [this](const QString& message) {
+        statusBar()->showMessage(tr("🎬 Recording error: %1").arg(message), 5000);
+        m_titleBar->setRecordWindowEnabled(false);
+        // Ensure the encoder session stops; UI unchecked must match capture state.
+        if (m_windowVideoRecorder && m_windowVideoRecorder->isRecording()) {
+            m_windowVideoRecorder->stopRecording();
+        }
+    });
+
+    // ── Audio feeds ──────────────────────────────────────────────────────
+    // RX rides RadioModel's normalized bus, NOT PanadapterStream, for the same
+    // two reasons the QSO recorder was moved off the stream (see
+    // wireRxDemodAudioSinks()): a backend without a PanadapterStream (HL2,
+    // KiwiSDR) has no such signal at all, and the stream is destroyed by
+    // teardownBackend() on every family swap, which would silently kill the tap
+    // for the rest of the session. RadioModel outlives the swap.
+    connect(&m_radioModel, &RadioModel::rxDemodAudioReady,
+            m_windowVideoRecorder, &WindowVideoRecorder::feedRxAudio);
+    connect(m_audio, &AudioEngine::txFinalMonitorPcmReady,
+            m_windowVideoRecorder, &WindowVideoRecorder::feedTxAudio);
+    connect(&m_radioModel.transmitModel(), &TransmitModel::moxChanged,
+            m_windowVideoRecorder, &WindowVideoRecorder::onMoxChanged);
+    connect(m_audio, &AudioEngine::cwSidetoneRecordPcmReady,
+            m_windowVideoRecorder, &WindowVideoRecorder::feedTxAudio);
+    connect(m_audio, &AudioEngine::cwRecordingActiveChanged,
+            m_windowVideoRecorder, &WindowVideoRecorder::onMoxChanged);
+
+    connect(m_titleBar, &TitleBar::recordWindowToggled,
+            this, &MainWindow::onRecordWindowToggled);
+}
+
+void MainWindow::onRecordWindowToggled(bool on)
+{
+    if (!m_windowVideoRecorder) {
+        return;
+    }
+    if (on) {
+        // TitleBar already checked the button before this slot runs. Only leave
+        // it on when a session was actually armed — refuse during finalize or
+        // on immediate open failure would otherwise leave a stuck "REC" state.
+        if (!m_windowVideoRecorder->startRecording()) {
+            m_titleBar->setRecordWindowEnabled(false);
+            if (m_windowVideoRecorder->isSessionActive()) {
+                statusBar()->showMessage(
+                    tr("🎬 Recording still finalizing — try again in a moment."),
+                    3000);
+            }
+        }
+    } else {
+        m_windowVideoRecorder->stopRecording();
+    }
+}
+
+bool MainWindow::deferCloseForWindowRecorder()
+{
+    // The watchdog below already gave up on this session; never defer again.
+    if (m_recorderCloseForced) {
+        return false;
+    }
+    // isSessionActive covers both live recording and stop-in-flight finalize.
+    if (!m_windowVideoRecorder || !m_windowVideoRecorder->isSessionActive()) {
+        return false;
+    }
+    if (m_waitingForRecorderToStop) {
+        return true;
+    }
+
+    m_waitingForRecorderToStop = true;
+    hide();
+
+    // Connect BEFORE stopRecording(): the native fallback path emits
+    // recordingStopped synchronously inside stop, and a post-stop connect would
+    // miss it (macOS hang / zombie process).
+    connect(m_windowVideoRecorder, &WindowVideoRecorder::recordingStopped, this, [this]() {
+        // Defer so we never nest closeEvent inside stopRecording.
+        QTimer::singleShot(0, this, [this]() { close(); });
+    }, Qt::SingleShotConnection);
+
+    // Watchdog: recordingStopped is not guaranteed to arrive (wedged encoder,
+    // latched backend error). Without it the hidden window can never close and
+    // the process can only be killed — the very failure the hide/defer above is
+    // meant to avoid, just one step later.
+    QTimer::singleShot(kRecorderStopWatchdogMs, this, [this]() {
+        if (m_recorderCloseForced || !m_waitingForRecorderToStop) {
+            return;
+        }
+        if (!m_windowVideoRecorder || !m_windowVideoRecorder->isSessionActive()) {
+            return;
+        }
+        qWarning("MainWindow: window recorder did not finalize within %d ms; closing anyway.",
+                 kRecorderStopWatchdogMs);
+        m_recorderCloseForced = true;
+        close();
+    });
+
+    m_windowVideoRecorder->stopRecording();
+    return true;
+}
+
+} // namespace AetherSDR

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -1326,7 +1326,7 @@ void TitleBar::setMinimalMode(bool on)
     // Hide non-essential controls so status badges fit in the narrow strip.
     if (m_menuBar) m_menuBar->setVisible(!on);
     if (m_appNameLabel) m_appNameLabel->setVisible(!on);
-    if (m_recordBtn) m_recordBtn->setVisible(!on || m_recordBtn->isChecked());
+    if (m_recordBtn) m_recordBtn->setVisible(m_recordBtn->isEnabled() && (!on || m_recordBtn->isChecked()));
     m_pcBtn->setVisible(!on);
     m_speakerBtn->setVisible(!on);
     m_headphoneBtn->setVisible(!on);

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -315,9 +315,9 @@ TitleBar::TitleBar(QWidget* parent)
 #if QT_VERSION < QT_VERSION_CHECK(6, 8, 0)
     m_recordBtn->setVisible(false);
     m_recordBtn->setEnabled(false);
-#endif
-
+#else
     m_hbox->addSpacing(6);
+#endif
 
     // PC Audio toggle
     m_pcBtn = new QPushButton("PC Audio");

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -26,7 +26,6 @@
 #include <QAbstractAnimation>
 #include <QGraphicsOpacityEffect>
 #include <QPropertyAnimation>
-#include <QVariantAnimation>
 #include <QColor>
 #include <QWindow>
 #include <QMenu>

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -288,9 +288,11 @@ TitleBar::TitleBar(QWidget* parent)
     // Record toggle
     m_recordPulseAnim = new QVariantAnimation(this);
     m_recordPulseAnim->setDuration(1200);
-    m_recordPulseAnim->setStartValue(QColor("#601a1a"));
-    m_recordPulseAnim->setKeyValueAt(0.5, QColor("#b82828"));
-    m_recordPulseAnim->setEndValue(QColor("#601a1a"));
+    QColor startColor = AetherSDR::ThemeManager::instance().color("color.button.danger.background.disabled");
+    QColor peakColor = AetherSDR::ThemeManager::instance().color("color.accent.danger").darker(180);
+    m_recordPulseAnim->setStartValue(startColor);
+    m_recordPulseAnim->setKeyValueAt(0.5, peakColor);
+    m_recordPulseAnim->setEndValue(startColor);
     m_recordPulseAnim->setEasingCurve(QEasingCurve::InOutSine);
     m_recordPulseAnim->setLoopCount(-1);
 
@@ -305,12 +307,12 @@ TitleBar::TitleBar(QWidget* parent)
     connect(m_recordPulseAnim, &QVariantAnimation::valueChanged, this, [this](const QVariant& value) {
         QColor color = value.value<QColor>();
         if (m_recordBtn && m_recordBtn->isChecked()) {
-            QString style = QString(
-                "QPushButton { background: %1; color: #ff8080; border: 1px solid #a02020; "
-                "border-radius: 3px; font-size: 10px; font-weight: bold; }"
-                "QPushButton:hover { background: #702020; }"
-            ).arg(color.name());
-            m_recordBtn->setStyleSheet(style);
+            AetherSDR::ThemeManager::instance().applyStyleSheet(
+                m_recordBtn,
+                QString("QPushButton { background: %1; color: {{color.accent.danger}}; border: 1px solid {{color.button.danger.border.disabled}}; "
+                        "border-radius: 3px; font-size: 10px; font-weight: bold; }"
+                        "QPushButton:hover { background: {{color.button.danger.background.disabled}}; }")
+                    .arg(color.name()));
         }
     });
 
@@ -1366,19 +1368,21 @@ void TitleBar::updateRecordStyle()
                 m_recordPulseAnim->start();
             }
         } else {
-            m_recordBtn->setStyleSheet(
-                "QPushButton { background: #601a1a; color: #ff8080; border: 1px solid #a02020; "
+            AetherSDR::ThemeManager::instance().applyStyleSheet(
+                m_recordBtn,
+                "QPushButton { background: {{color.button.danger.background.disabled}}; color: {{color.accent.danger}}; border: 1px solid {{color.button.danger.border.disabled}}; "
                 "border-radius: 3px; font-size: 10px; font-weight: bold; }"
-                "QPushButton:hover { background: #702020; }");
+                "QPushButton:hover { background: {{color.button.danger.background.disabled}}; }");
         }
     } else {
         if (m_recordPulseAnim) {
             m_recordPulseAnim->stop();
         }
-        m_recordBtn->setStyleSheet(
-            "QPushButton { background: #1a2a3a; color: #607080; border: 1px solid #304050; "
+        AetherSDR::ThemeManager::instance().applyStyleSheet(
+            m_recordBtn,
+            "QPushButton { background: {{color.background.1}}; color: {{color.text.label}}; border: 1px solid {{color.background.2}}; "
             "border-radius: 3px; font-size: 10px; font-weight: bold; }"
-            "QPushButton:hover { background: #243848; }");
+            "QPushButton:hover { background: {{color.background.2}}; }");
     }
 }
 

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -286,16 +286,6 @@ TitleBar::TitleBar(QWidget* parent)
     });
 
     // Record toggle
-    m_recordPulseAnim = new QVariantAnimation(this);
-    m_recordPulseAnim->setDuration(1200);
-    QColor startColor = AetherSDR::ThemeManager::instance().color("color.button.danger.background.disabled");
-    QColor peakColor = AetherSDR::ThemeManager::instance().color("color.accent.danger").darker(180);
-    m_recordPulseAnim->setStartValue(startColor);
-    m_recordPulseAnim->setKeyValueAt(0.5, peakColor);
-    m_recordPulseAnim->setEndValue(startColor);
-    m_recordPulseAnim->setEasingCurve(QEasingCurve::InOutSine);
-    m_recordPulseAnim->setLoopCount(-1);
-
     m_recordBtn = new QPushButton("🎬 REC");
     m_recordBtn->setCheckable(true);
     m_recordBtn->setFixedHeight(22);
@@ -304,17 +294,17 @@ TitleBar::TitleBar(QWidget* parent)
     m_recordBtn->setAccessibleDescription("Toggle recording of the AetherSDR window");
     m_recordBtn->setToolTip("Record the AetherSDR window to an MP4 video file");
 
-    connect(m_recordPulseAnim, &QVariantAnimation::valueChanged, this, [this](const QVariant& value) {
-        QColor color = value.value<QColor>();
-        if (m_recordBtn && m_recordBtn->isChecked()) {
-            AetherSDR::ThemeManager::instance().applyStyleSheet(
-                m_recordBtn,
-                QString("QPushButton { background: %1; color: {{color.accent.danger}}; border: 1px solid {{color.button.danger.border.disabled}}; "
-                        "border-radius: 3px; font-size: 10px; font-weight: bold; }"
-                        "QPushButton:hover { background: {{color.button.danger.background.disabled}}; }")
-                    .arg(color.name()));
-        }
-    });
+    m_recordOpacity = new QGraphicsOpacityEffect(this);
+    m_recordOpacity->setOpacity(1.0);
+    m_recordBtn->setGraphicsEffect(m_recordOpacity);
+
+    m_recordPulseAnim = new QPropertyAnimation(m_recordOpacity, "opacity", this);
+    m_recordPulseAnim->setDuration(1200);
+    m_recordPulseAnim->setStartValue(1.0);
+    m_recordPulseAnim->setKeyValueAt(0.5, 0.4);
+    m_recordPulseAnim->setEndValue(1.0);
+    m_recordPulseAnim->setEasingCurve(QEasingCurve::InOutSine);
+    m_recordPulseAnim->setLoopCount(-1);
 
     updateRecordStyle();
 
@@ -1363,20 +1353,20 @@ void TitleBar::updateRecordStyle()
         return;
     }
     if (m_recordBtn->isChecked()) {
-        if (m_recordPulseAnim) {
-            if (m_recordPulseAnim->state() != QAbstractAnimation::Running) {
-                m_recordPulseAnim->start();
-            }
-        } else {
-            AetherSDR::ThemeManager::instance().applyStyleSheet(
-                m_recordBtn,
-                "QPushButton { background: {{color.button.danger.background.disabled}}; color: {{color.accent.danger}}; border: 1px solid {{color.button.danger.border.disabled}}; "
-                "border-radius: 3px; font-size: 10px; font-weight: bold; }"
-                "QPushButton:hover { background: {{color.button.danger.background.disabled}}; }");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(
+            m_recordBtn,
+            "QPushButton { background: {{color.button.danger.background.disabled}}; color: {{color.accent.danger}}; border: 1px solid {{color.button.danger.border.disabled}}; "
+            "border-radius: 3px; font-size: 10px; font-weight: bold; }"
+            "QPushButton:hover { background: {{color.button.danger.background.disabled}}; }");
+        if (m_recordPulseAnim && m_recordPulseAnim->state() != QAbstractAnimation::Running) {
+            m_recordPulseAnim->start();
         }
     } else {
         if (m_recordPulseAnim) {
             m_recordPulseAnim->stop();
+        }
+        if (m_recordOpacity) {
+            m_recordOpacity->setOpacity(1.0);
         }
         AetherSDR::ThemeManager::instance().applyStyleSheet(
             m_recordBtn,

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -26,6 +26,8 @@
 #include <QAbstractAnimation>
 #include <QGraphicsOpacityEffect>
 #include <QPropertyAnimation>
+#include <QVariantAnimation>
+#include <QColor>
 #include <QWindow>
 #include <QMenu>
 #include <QNetworkAccessManager>
@@ -282,6 +284,50 @@ TitleBar::TitleBar(QWidget* parent)
         if (m_txTimerOpacity->opacity() <= 0.01)
             m_txTimerLabel->setVisible(false);
     });
+
+    // Record toggle
+    m_recordPulseAnim = new QVariantAnimation(this);
+    m_recordPulseAnim->setDuration(1200);
+    m_recordPulseAnim->setStartValue(QColor("#601a1a"));
+    m_recordPulseAnim->setKeyValueAt(0.5, QColor("#b82828"));
+    m_recordPulseAnim->setEndValue(QColor("#601a1a"));
+    m_recordPulseAnim->setEasingCurve(QEasingCurve::InOutSine);
+    m_recordPulseAnim->setLoopCount(-1);
+
+    m_recordBtn = new QPushButton("🎬 REC");
+    m_recordBtn->setCheckable(true);
+    m_recordBtn->setFixedHeight(22);
+    m_recordBtn->setFixedWidth(70);
+    m_recordBtn->setAccessibleName("Record");
+    m_recordBtn->setAccessibleDescription("Toggle recording of the AetherSDR window");
+    m_recordBtn->setToolTip("Record the AetherSDR window to an MP4 video file");
+
+    connect(m_recordPulseAnim, &QVariantAnimation::valueChanged, this, [this](const QVariant& value) {
+        QColor color = value.value<QColor>();
+        if (m_recordBtn && m_recordBtn->isChecked()) {
+            QString style = QString(
+                "QPushButton { background: %1; color: #ff8080; border: 1px solid #a02020; "
+                "border-radius: 3px; font-size: 10px; font-weight: bold; }"
+                "QPushButton:hover { background: #702020; }"
+            ).arg(color.name());
+            m_recordBtn->setStyleSheet(style);
+        }
+    });
+
+    updateRecordStyle();
+
+    connect(m_recordBtn, &QPushButton::toggled, this, [this](bool on) {
+        updateRecordStyle();
+        emit recordWindowToggled(on);
+    });
+    m_hbox->addWidget(m_recordBtn);
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 8, 0)
+    m_recordBtn->setVisible(false);
+    m_recordBtn->setEnabled(false);
+#endif
+
+    m_hbox->addSpacing(6);
 
     // PC Audio toggle
     m_pcBtn = new QPushButton("PC Audio");
@@ -832,6 +878,14 @@ void TitleBar::setPcAudioEnabled(bool on)
           "QPushButton:hover { background: #243848; }");
 }
 
+void TitleBar::setRecordWindowEnabled(bool on)
+{
+    if (!m_recordBtn) return;
+    QSignalBlocker b(m_recordBtn);
+    m_recordBtn->setChecked(on);
+    updateRecordStyle();
+}
+
 void TitleBar::setPcAudioDevices(const QString& inputDevice, const QString& outputDevice)
 {
     m_pcAudioInputDevice = inputDevice.trimmed();
@@ -1282,6 +1336,7 @@ void TitleBar::setMinimalMode(bool on)
     // Hide non-essential controls so status badges fit in the narrow strip.
     if (m_menuBar) m_menuBar->setVisible(!on);
     if (m_appNameLabel) m_appNameLabel->setVisible(!on);
+    if (m_recordBtn) m_recordBtn->setVisible(!on);
     m_pcBtn->setVisible(!on);
     m_speakerBtn->setVisible(!on);
     m_headphoneBtn->setVisible(!on);
@@ -1300,4 +1355,32 @@ void TitleBar::setMinimalMode(bool on)
     updateMaximizeIcon();
 }
 
+void TitleBar::updateRecordStyle()
+{
+    if (!m_recordBtn) {
+        return;
+    }
+    if (m_recordBtn->isChecked()) {
+        if (m_recordPulseAnim) {
+            if (m_recordPulseAnim->state() != QAbstractAnimation::Running) {
+                m_recordPulseAnim->start();
+            }
+        } else {
+            m_recordBtn->setStyleSheet(
+                "QPushButton { background: #601a1a; color: #ff8080; border: 1px solid #a02020; "
+                "border-radius: 3px; font-size: 10px; font-weight: bold; }"
+                "QPushButton:hover { background: #702020; }");
+        }
+    } else {
+        if (m_recordPulseAnim) {
+            m_recordPulseAnim->stop();
+        }
+        m_recordBtn->setStyleSheet(
+            "QPushButton { background: #1a2a3a; color: #607080; border: 1px solid #304050; "
+            "border-radius: 3px; font-size: 10px; font-weight: bold; }"
+            "QPushButton:hover { background: #243848; }");
+    }
+}
+
 } // namespace AetherSDR
+

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -26,7 +26,6 @@
 #include <QAbstractAnimation>
 #include <QGraphicsOpacityEffect>
 #include <QPropertyAnimation>
-#include <QColor>
 #include <QWindow>
 #include <QMenu>
 #include <QNetworkAccessManager>

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -289,9 +289,9 @@ TitleBar::TitleBar(QWidget* parent)
     m_recordBtn->setCheckable(true);
     m_recordBtn->setFixedHeight(22);
     m_recordBtn->setFixedWidth(70);
-    m_recordBtn->setAccessibleName("Record");
-    m_recordBtn->setAccessibleDescription("Toggle recording of the AetherSDR window");
-    m_recordBtn->setToolTip("Record the AetherSDR window to an MP4 video file");
+    m_recordBtn->setAccessibleName(tr("Record"));
+    m_recordBtn->setAccessibleDescription(tr("Toggle recording of the AetherSDR window"));
+    m_recordBtn->setToolTip(tr("Record the AetherSDR window to an MP4 video file"));
 
     m_recordOpacity = new QGraphicsOpacityEffect(this);
     m_recordOpacity->setOpacity(1.0);

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -292,11 +292,11 @@ TitleBar::TitleBar(QWidget* parent)
     m_recordBtn->setAccessibleDescription(tr("Toggle recording of the AetherSDR window"));
     m_recordBtn->setToolTip(tr("Record the AetherSDR window to an MP4 video file"));
 
-    m_recordOpacity = new QGraphicsOpacityEffect(this);
+    m_recordOpacity = new QGraphicsOpacityEffect(m_recordBtn);
     m_recordOpacity->setOpacity(1.0);
     m_recordBtn->setGraphicsEffect(m_recordOpacity);
 
-    m_recordPulseAnim = new QPropertyAnimation(m_recordOpacity, "opacity", this);
+    m_recordPulseAnim = new QPropertyAnimation(m_recordOpacity, "opacity", m_recordBtn);
     m_recordPulseAnim->setDuration(1200);
     m_recordPulseAnim->setStartValue(1.0);
     m_recordPulseAnim->setKeyValueAt(0.5, 0.4);

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -1327,7 +1327,7 @@ void TitleBar::setMinimalMode(bool on)
     // Hide non-essential controls so status badges fit in the narrow strip.
     if (m_menuBar) m_menuBar->setVisible(!on);
     if (m_appNameLabel) m_appNameLabel->setVisible(!on);
-    if (m_recordBtn) m_recordBtn->setVisible(!on);
+    if (m_recordBtn) m_recordBtn->setVisible(!on || m_recordBtn->isChecked());
     m_pcBtn->setVisible(!on);
     m_speakerBtn->setVisible(!on);
     m_headphoneBtn->setVisible(!on);
@@ -1352,6 +1352,7 @@ void TitleBar::updateRecordStyle()
         return;
     }
     if (m_recordBtn->isChecked()) {
+        m_recordBtn->setVisible(true);
         AetherSDR::ThemeManager::instance().applyStyleSheet(
             m_recordBtn,
             "QPushButton { background: {{color.button.danger.background.disabled}}; color: {{color.accent.danger}}; border: 1px solid {{color.button.danger.border.disabled}}; "
@@ -1361,6 +1362,9 @@ void TitleBar::updateRecordStyle()
             m_recordPulseAnim->start();
         }
     } else {
+        if (m_minimalMode) {
+            m_recordBtn->setVisible(false);
+        }
         if (m_recordPulseAnim) {
             m_recordPulseAnim->stop();
         }

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -15,7 +15,6 @@ class QHBoxLayout;
 class QTimer;
 class QGraphicsOpacityEffect;
 class QPropertyAnimation;
-class QVariantAnimation;
 
 namespace AetherSDR {
 

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -15,6 +15,7 @@ class QHBoxLayout;
 class QTimer;
 class QGraphicsOpacityEffect;
 class QPropertyAnimation;
+class QVariantAnimation;
 
 namespace AetherSDR {
 
@@ -35,6 +36,7 @@ public:
     // mute with no indication why — there is no radio-side audio path to fall
     // back to, unlike a Flex.
     void setPcAudioLocked(bool locked);
+    void setRecordWindowEnabled(bool on);
     void setPcAudioDevices(const QString& inputDevice, const QString& outputDevice);
     void setLineoutMuted(bool muted);
     void setMasterVolume(int pct);
@@ -74,6 +76,7 @@ public:
 
 signals:
     void pcAudioToggled(bool on);
+    void recordWindowToggled(bool on);
     void masterVolumeChanged(int pct);
     void headphoneVolumeChanged(int pct);
     void lineoutMuteChanged(bool muted);
@@ -104,11 +107,13 @@ private:
     void handleTitleDoubleClick(QMouseEvent* ev);
     void showFeatureRequestDialogImpl();
     void updatePcAudioToolTip();
+    void updateRecordStyle();
     QHBoxLayout* m_hbox{nullptr};
     QMenuBar*    m_menuBar{nullptr};
     QLabel*      m_appNameLabel{nullptr};
     QLabel*      m_otherTxLabel{nullptr};
     QPushButton* m_mfBtn{nullptr};
+    QPushButton* m_recordBtn{nullptr};
     QPushButton* m_pcBtn{nullptr};
     QPushButton* m_speakerBtn{nullptr};
     QPushButton* m_headphoneBtn{nullptr};
@@ -137,6 +142,7 @@ private:
     QLabel*      m_heartbeat{nullptr};
     QTimer*      m_heartbeatOffTimer{nullptr};   // 100ms green→grey
     QTimer*      m_heartbeatAlarmTimer{nullptr}; // 500ms red/grey blink
+    QVariantAnimation* m_recordPulseAnim{nullptr}; // Pulsating effect for recording
     int          m_missedBeats{0};
     bool         m_alarmRed{false};
     bool         m_blinkEnabled{true};  // persisted via AppSettings "HeartbeatBlinkEnabled"

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -142,7 +142,8 @@ private:
     QLabel*      m_heartbeat{nullptr};
     QTimer*      m_heartbeatOffTimer{nullptr};   // 100ms green→grey
     QTimer*      m_heartbeatAlarmTimer{nullptr}; // 500ms red/grey blink
-    QVariantAnimation* m_recordPulseAnim{nullptr}; // Pulsating effect for recording
+    QGraphicsOpacityEffect* m_recordOpacity{nullptr};
+    QPropertyAnimation*     m_recordPulseAnim{nullptr}; // Pulsating opacity effect for recording
     int          m_missedBeats{0};
     bool         m_alarmRed{false};
     bool         m_blinkEnabled{true};  // persisted via AppSettings "HeartbeatBlinkEnabled"

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -588,7 +588,7 @@ void WindowVideoRecorder::captureFrame()
 
     // Keep audio stream synchronized with video timestamp to prevent FFmpeg muxer queue deadlocks
     while (!m_hasRealAudio && static_cast<qint64>((m_audioSamplesSent * 1000000) / kAudioSampleRate) < ptsUs + (kSilenceChunkMs * 1000)) {
-        if (!sendSilentAudio(ptsUs)) {
+        if (!sendSilentAudio()) {
             break;
         }
     }
@@ -675,7 +675,7 @@ void WindowVideoRecorder::captureFrame()
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     if (m_useFallback && m_fallbackWriter) {
         if (static_cast<qint64>((m_audioSamplesSent * 1000000) / kAudioSampleRate) < ptsUs) {
-            sendSilentAudio(ptsUs);
+            sendSilentAudio();
         }
         bool success = m_fallbackWriter->writeVideoFrame(frameToEncode, ptsUs);
         if (!success) {
@@ -696,7 +696,7 @@ void WindowVideoRecorder::captureFrame()
         frame.setEndTime(ptsUs + 40000); // 40ms frame duration at 25 fps (microseconds)
 
         if (static_cast<qint64>((m_audioSamplesSent * 1000000) / kAudioSampleRate) < ptsUs) {
-            sendSilentAudio(ptsUs);
+            sendSilentAudio();
         }
 
         bool sent = m_videoFrameInput->sendVideoFrame(frame);
@@ -737,9 +737,8 @@ QByteArray float32ToInt16(const QByteArray& pcm)
 
 } // namespace
 
-bool WindowVideoRecorder::sendSilentAudio(qint64 startTimeUs)
+bool WindowVideoRecorder::sendSilentAudio()
 {
-    Q_UNUSED(startTimeUs);
     constexpr int samplesPerChunk = (kAudioSampleRate * kSilenceChunkMs) / 1000;
     constexpr int bufferSize = samplesPerChunk * kAudioBytesPerFrame;
     static const QByteArray kSilentBytes(bufferSize, 0);

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -358,6 +358,13 @@ bool WindowVideoRecorder::startRecording()
 
     m_frameCount = 0;
 
+    m_rhiWidgetsCache.clear();
+    if (m_mainWindow) {
+        for (auto* rhi : m_mainWindow->findChildren<QRhiWidget*>()) {
+            m_rhiWidgetsCache.append(rhi);
+        }
+    }
+
     if (m_slice) {
         m_freqMhz = m_slice->frequency();
         m_mode = m_slice->mode();
@@ -437,11 +444,6 @@ bool WindowVideoRecorder::startRecording()
         emit recordingError(QStringLiteral("Failed to initialize Qt video recording engine."));
         return false;
     }
-
-    // Use standard Format_BGRA8888 for video frame input to let Qt handle conversions
-    QVideoFrameFormat videoFormat(QSize(m_videoWidth, m_videoHeight), QVideoFrameFormat::Format_BGRA8888);
-    videoFormat.setStreamFrameRate(25.0);
-    qCDebug(lcWindowVideoRecorder) << "Using BGRA8888 standard video format for recording";
 
     cleanupQtInputs();
 
@@ -584,21 +586,23 @@ void WindowVideoRecorder::captureFrame()
     m_mainWindow->render(&img);
 
     // Composite any GPU-accelerated QRhiWidgets (such as SpectrumWidget) on top of the CPU render
-    for (auto* rhi : m_mainWindow->findChildren<QRhiWidget*>()) {
-        if (rhi->isVisible()) {
-            QImage childImg = rhi->grabFramebuffer();
-            if (!childImg.isNull()) {
-                QPoint pos = rhi->mapTo(m_mainWindow, QPoint(0, 0));
-                QPainter painter(&img);
-                painter.drawImage(pos, childImg);
-            }
+    for (const auto& widget : m_rhiWidgetsCache) {
+        if (widget && widget->isVisible()) {
+            if (auto* rhi = qobject_cast<QRhiWidget*>(widget.data())) {
+                QImage childImg = rhi->grabFramebuffer();
+                if (!childImg.isNull()) {
+                    QPoint pos = rhi->mapTo(m_mainWindow, QPoint(0, 0));
+                    QPainter painter(&img);
+                    painter.drawImage(pos, childImg);
+                }
 
-            // Render standard child widgets of the QRhiWidget on top
-            for (QObject* obj : rhi->children()) {
-                if (auto* w = qobject_cast<QWidget*>(obj)) {
-                    if (w->isVisible() && !w->inherits("QRhiWidget")) {
-                        QPoint pos = w->mapTo(m_mainWindow, QPoint(0, 0));
-                        w->render(&img, pos);
+                // Render standard child widgets of the QRhiWidget on top
+                for (QObject* obj : rhi->children()) {
+                    if (auto* w = qobject_cast<QWidget*>(obj)) {
+                        if (w->isVisible() && !w->inherits("QRhiWidget")) {
+                            QPoint pos = w->mapTo(m_mainWindow, QPoint(0, 0));
+                            w->render(&img, pos);
+                        }
                     }
                 }
             }

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -360,14 +360,6 @@ bool WindowVideoRecorder::startRecording()
         return false;
     }
 
-    if (lcWindowVideoRecorder().isDebugEnabled()) {
-        qputenv("AV_LOG_LEVEL", "info");
-        setFFmpegLogLevel(32); // AV_LOG_INFO
-    } else {
-        qputenv("AV_LOG_LEVEL", "error");
-        setFFmpegLogLevel(16); // AV_LOG_ERROR
-    }
-
     m_frameCount = 0;
 
     m_rhiWidgetsCache.clear();
@@ -455,6 +447,16 @@ bool WindowVideoRecorder::startRecording()
     if (!m_recorder || !m_session) {
         emit recordingError(QStringLiteral("Failed to initialize Qt video recording engine."));
         return false;
+    }
+
+    if (ffmpegMediaBackendAvailable()) {
+        if (lcWindowVideoRecorder().isDebugEnabled()) {
+            qputenv("AV_LOG_LEVEL", "info");
+            setFFmpegLogLevel(32); // AV_LOG_INFO
+        } else {
+            qputenv("AV_LOG_LEVEL", "error");
+            setFFmpegLogLevel(16); // AV_LOG_ERROR
+        }
     }
 
     cleanupQtInputs();

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -554,6 +554,15 @@ void WindowVideoRecorder::stopRecording()
         // callers always observe recordingStopped.
         if (m_stopping && m_recorder->recorderState() == QMediaRecorder::StoppedState) {
             finalizeStop();
+        } else if (m_stopping) {
+            // Watchdog fallback: if backend stalls or fails to emit StoppedState within 3s,
+            // force finalizeStop() so session is not permanently stuck in finalizing state.
+            QTimer::singleShot(3000, this, [this]() {
+                if (m_stopping) {
+                    qCWarning(lcWindowVideoRecorder) << "Stop timeout (3s) elapsed waiting for StoppedState; forcing finalizeStop()";
+                    finalizeStop();
+                }
+            });
         }
         return;
     }

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -30,6 +30,7 @@
 #include <QLibrary>
 #include <QRhiWidget>
 #include <algorithm>
+#include <cstdint>
 #include <utility>
 
 #include "recording/INativeVideoWriter.h"

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -310,6 +310,12 @@ void WindowVideoRecorder::finalizeStop()
 
 WindowVideoRecorder::~WindowVideoRecorder()
 {
+    // Disconnect/block signals before teardown so destruction is strictly side-effect-free
+    blockSignals(true);
+    if (m_recorder) {
+        m_recorder->disconnect();
+    }
+
     if (m_recording || m_stopping) {
         // Best-effort sync teardown on destroy (no further UI signals needed).
         m_stopping = true;

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -656,7 +656,7 @@ void WindowVideoRecorder::captureFrame()
 
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     if (m_useFallback && m_fallbackWriter) {
-        if (static_cast<qint64>((m_audioSamplesSent * 1000000) / 24000) < ptsUs) {
+        if (static_cast<qint64>((m_audioSamplesSent * 1000000) / kAudioSampleRate) < ptsUs) {
             sendSilentAudio(ptsUs);
         }
         bool success = m_fallbackWriter->writeVideoFrame(scaledImg, ptsUs);
@@ -677,7 +677,7 @@ void WindowVideoRecorder::captureFrame()
         frame.setStartTime(ptsUs);
         frame.setEndTime(ptsUs + 40000); // 40ms frame duration at 25 fps (microseconds)
 
-        if (static_cast<qint64>((m_audioSamplesSent * 1000000) / 24000) < ptsUs) {
+        if (static_cast<qint64>((m_audioSamplesSent * 1000000) / kAudioSampleRate) < ptsUs) {
             sendSilentAudio(ptsUs);
         }
 
@@ -773,6 +773,15 @@ bool WindowVideoRecorder::sendAudioData(const QByteArray& int16Stereo)
     // first synthetic silence chunk latch the flag and permanently disable the
     // silence priming it gates.
 
+    QByteArray pcmData = int16Stereo;
+    const int remainder = pcmData.size() % kAudioBytesPerFrame;
+    if (remainder != 0) {
+        pcmData.truncate(pcmData.size() - remainder);
+    }
+    if (pcmData.isEmpty()) {
+        return false;
+    }
+
     static const QAudioFormat kFormat = []() {
         QAudioFormat fmt;
         fmt.setSampleRate(kAudioSampleRate);
@@ -782,11 +791,11 @@ bool WindowVideoRecorder::sendAudioData(const QByteArray& int16Stereo)
     }();
 
     qint64 ptsUs = (m_audioSamplesSent * 1000000) / kAudioSampleRate;
-    int numFrames = int16Stereo.size() / kAudioBytesPerFrame;
+    int numFrames = pcmData.size() / kAudioBytesPerFrame;
 
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     if (m_useFallback && m_fallbackWriter) {
-        bool ok = m_fallbackWriter->writeAudioSamples(int16Stereo, ptsUs);
+        bool ok = m_fallbackWriter->writeAudioSamples(pcmData, ptsUs);
         if (ok) {
             m_audioSamplesSent += numFrames;
         }
@@ -794,7 +803,7 @@ bool WindowVideoRecorder::sendAudioData(const QByteArray& int16Stereo)
     }
 #endif
 
-    QAudioBuffer buffer(int16Stereo, kFormat, ptsUs);
+    QAudioBuffer buffer(pcmData, kFormat, ptsUs);
     // Only accepted samples advance the clock: the FFmpeg backend concatenates
     // the buffers it takes and ignores their start times, so counting a
     // rejected buffer would shift every later timestamp ahead of the audio

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -509,10 +509,8 @@ bool WindowVideoRecorder::startRecording()
     // the meantime is silently discarded, which desynchronises the file.
     m_recordTimer.invalidate();
 
-#if !defined(Q_OS_MAC)
     qCDebug(lcWindowVideoRecorder) << "Calling m_recorder->record(). Current state:" << m_recorder->recorderState();
     m_recorder->record();
-#endif
 
     // Start video capture at 25 fps (40 ms) on Main Thread
     m_captureTimer->start(40);

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -595,7 +595,7 @@ void WindowVideoRecorder::captureFrame()
     }
 
     // Render the main window directly via standard QWidget::render() (100% robust and fast)
-    QImage img(mainSize, QImage::Format_ARGB32_Premultiplied);
+    QImage img(mainSize, QImage::Format_ARGB32);
     img.fill(Qt::black);
     m_mainWindow->render(&img);
 

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -615,54 +615,56 @@ void WindowVideoRecorder::captureFrame()
     m_frameBuffer.fill(Qt::black);
     m_mainWindow->render(&m_frameBuffer);
 
-    // Composite any GPU-accelerated QRhiWidgets (such as SpectrumWidget) on top of the CPU render
-    for (const auto& widget : m_rhiWidgetsCache) {
-        if (widget && widget->isVisible()) {
-            if (auto* rhi = qobject_cast<QRhiWidget*>(widget.data())) {
-                QImage childImg = rhi->grabFramebuffer();
-                if (!childImg.isNull()) {
-                    QPoint pos = rhi->mapTo(m_mainWindow, QPoint(0, 0));
-                    {
-                        QPainter painter(&m_frameBuffer);
+    // Composite GPU-accelerated QRhiWidgets (such as SpectrumWidget) and cursor on top
+    QPoint globalPos = QCursor::pos();
+    QPoint localPos = m_mainWindow->mapFromGlobal(globalPos);
+    const bool drawCursor = m_mainWindow->rect().contains(localPos);
+
+    if (!m_rhiWidgetsCache.isEmpty() || drawCursor) {
+        QPainter painter(&m_frameBuffer);
+
+        for (const auto& widget : m_rhiWidgetsCache) {
+            if (widget && widget->isVisible()) {
+                if (auto* rhi = qobject_cast<QRhiWidget*>(widget.data())) {
+                    QImage childImg = rhi->grabFramebuffer();
+                    if (!childImg.isNull()) {
+                        QPoint pos = rhi->mapTo(m_mainWindow, QPoint(0, 0));
                         painter.drawImage(pos, childImg);
                     }
-                }
 
-                // Render standard child widgets of the QRhiWidget on top
-                for (QObject* obj : rhi->children()) {
-                    if (auto* w = qobject_cast<QWidget*>(obj)) {
-                        if (w->isVisible() && !w->inherits("QRhiWidget")) {
-                            QPoint pos = w->mapTo(m_mainWindow, QPoint(0, 0));
-                            w->render(&m_frameBuffer, pos);
+                    // Render standard child widgets of the QRhiWidget on top
+                    for (QObject* obj : rhi->children()) {
+                        if (auto* w = qobject_cast<QWidget*>(obj)) {
+                            if (w->isVisible() && !w->inherits("QRhiWidget")) {
+                                QPoint pos = w->mapTo(m_mainWindow, QPoint(0, 0));
+                                w->render(&painter, pos);
+                            }
                         }
                     }
                 }
             }
         }
-    }
 
-    // Overlay mouse cursor if it is currently inside the window bounds
-    QPoint globalPos = QCursor::pos();
-    QPoint localPos = m_mainWindow->mapFromGlobal(globalPos);
-    if (m_mainWindow->rect().contains(localPos)) {
-        QPainter painter(&m_frameBuffer);
-        painter.setRenderHint(QPainter::Antialiasing);
+        // Overlay mouse cursor if it is currently inside the window bounds
+        if (drawCursor) {
+            painter.setRenderHint(QPainter::Antialiasing);
 
-        // Classic black cursor with a crisp white outline for high contrast
-        painter.setPen(QPen(Qt::white, 1.5, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
-        painter.setBrush(Qt::black);
+            // Classic black cursor with a crisp white outline for high contrast
+            painter.setPen(QPen(Qt::white, 1.5, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+            painter.setBrush(Qt::black);
 
-        QPainterPath path;
-        path.moveTo(localPos);
-        path.lineTo(localPos + QPoint(0, 17));
-        path.lineTo(localPos + QPoint(4, 13));
-        path.lineTo(localPos + QPoint(8, 20));
-        path.lineTo(localPos + QPoint(11, 18));
-        path.lineTo(localPos + QPoint(7, 12));
-        path.lineTo(localPos + QPoint(12, 12));
-        path.closeSubpath();
+            QPainterPath path;
+            path.moveTo(localPos);
+            path.lineTo(localPos + QPoint(0, 17));
+            path.lineTo(localPos + QPoint(4, 13));
+            path.lineTo(localPos + QPoint(8, 20));
+            path.lineTo(localPos + QPoint(11, 18));
+            path.lineTo(localPos + QPoint(7, 12));
+            path.lineTo(localPos + QPoint(12, 12));
+            path.closeSubpath();
 
-        painter.drawPath(path);
+            painter.drawPath(path);
+        }
     }
 
     // Scale to macroblock-aligned target resolution if needed

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -724,8 +724,8 @@ bool WindowVideoRecorder::sendSilentAudio(qint64 startTimeUs)
     Q_UNUSED(startTimeUs);
     constexpr int samplesPerChunk = (kAudioSampleRate * kSilenceChunkMs) / 1000;
     constexpr int bufferSize = samplesPerChunk * kAudioBytesPerFrame;
-    QByteArray silentBytes(bufferSize, 0);
-    return sendAudioData(silentBytes);
+    static const QByteArray kSilentBytes(bufferSize, 0);
+    return sendAudioData(kSilentBytes);
 }
 
 void WindowVideoRecorder::feedRxAudio(const QByteArray& pcm)
@@ -773,10 +773,13 @@ bool WindowVideoRecorder::sendAudioData(const QByteArray& int16Stereo)
     // first synthetic silence chunk latch the flag and permanently disable the
     // silence priming it gates.
 
-    QAudioFormat format;
-    format.setSampleRate(kAudioSampleRate);
-    format.setChannelCount(kAudioChannels);
-    format.setSampleFormat(QAudioFormat::Int16);
+    static const QAudioFormat kFormat = []() {
+        QAudioFormat fmt;
+        fmt.setSampleRate(kAudioSampleRate);
+        fmt.setChannelCount(kAudioChannels);
+        fmt.setSampleFormat(QAudioFormat::Int16);
+        return fmt;
+    }();
 
     qint64 ptsUs = (m_audioSamplesSent * 1000000) / kAudioSampleRate;
     int numFrames = int16Stereo.size() / kAudioBytesPerFrame;
@@ -791,7 +794,7 @@ bool WindowVideoRecorder::sendAudioData(const QByteArray& int16Stereo)
     }
 #endif
 
-    QAudioBuffer buffer(int16Stereo, format, ptsUs);
+    QAudioBuffer buffer(int16Stereo, kFormat, ptsUs);
     // Only accepted samples advance the clock: the FFmpeg backend concatenates
     // the buffers it takes and ignores their start times, so counting a
     // rejected buffer would shift every later timestamp ahead of the audio

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -595,7 +595,7 @@ void WindowVideoRecorder::captureFrame()
     }
 
     // Render the main window directly via standard QWidget::render() (100% robust and fast)
-    QImage img(mainSize, QImage::Format_ARGB32);
+    QImage img(mainSize, QImage::Format_ARGB32_Premultiplied);
     img.fill(Qt::black);
     m_mainWindow->render(&img);
 

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -753,9 +753,10 @@ void WindowVideoRecorder::feedRxAudio(const QByteArray& pcm)
     if (!m_recording || m_transmitting) {
         return;
     }
-    m_hasRealAudio = true;
     QByteArray converted = float32ToInt16(pcm);
-    sendAudioData(converted);
+    if (sendAudioData(converted)) {
+        m_hasRealAudio = true;
+    }
 }
 
 void WindowVideoRecorder::feedTxAudio(const QByteArray& int16Stereo)
@@ -763,8 +764,9 @@ void WindowVideoRecorder::feedTxAudio(const QByteArray& int16Stereo)
     if (!m_recording || !m_transmitting) {
         return;
     }
-    m_hasRealAudio = true;
-    sendAudioData(int16Stereo);
+    if (sendAudioData(int16Stereo)) {
+        m_hasRealAudio = true;
+    }
 }
 
 void WindowVideoRecorder::onMoxChanged(bool mox)

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -567,7 +567,9 @@ void WindowVideoRecorder::captureFrame()
 
     // Keep audio stream synchronized with video timestamp to prevent FFmpeg muxer queue deadlocks
     while (!m_hasRealAudio && static_cast<qint64>((m_audioSamplesSent * 1000000) / 24000) < ptsUs + 40000) {
-        sendSilentAudio(ptsUs);
+        if (!sendSilentAudio(ptsUs)) {
+            break;
+        }
     }
 
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
@@ -709,12 +711,12 @@ QByteArray float32ToInt16(const QByteArray& pcm)
 
 } // namespace
 
-void WindowVideoRecorder::sendSilentAudio(qint64 startTimeUs)
+bool WindowVideoRecorder::sendSilentAudio(qint64 startTimeUs)
 {
     Q_UNUSED(startTimeUs);
     // Provide 40ms of silent audio: 24000 samples/sec * 4 bytes/sample (stereo int16) * 0.040s = 3840 bytes
     QByteArray silentBytes(3840, 0);
-    sendAudioData(silentBytes);
+    return sendAudioData(silentBytes);
 }
 
 void WindowVideoRecorder::feedRxAudio(const QByteArray& pcm)
@@ -741,15 +743,15 @@ void WindowVideoRecorder::onMoxChanged(bool mox)
     m_transmitting = mox;
 }
 
-void WindowVideoRecorder::sendAudioData(const QByteArray& int16Stereo)
+bool WindowVideoRecorder::sendAudioData(const QByteArray& int16Stereo)
 {
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     if (!m_recording || (!m_useFallback && !m_audioBufferInput)) {
-        return;
+        return false;
     }
 #else
     if (!m_recording || !m_audioBufferInput) {
-        return;
+        return false;
     }
 #endif
 
@@ -772,9 +774,11 @@ void WindowVideoRecorder::sendAudioData(const QByteArray& int16Stereo)
 
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     if (m_useFallback && m_fallbackWriter) {
-        m_fallbackWriter->writeAudioSamples(int16Stereo, ptsUs);
-        m_audioSamplesSent += numFrames;
-        return;
+        bool ok = m_fallbackWriter->writeAudioSamples(int16Stereo, ptsUs);
+        if (ok) {
+            m_audioSamplesSent += numFrames;
+        }
+        return ok;
     }
 #endif
 
@@ -785,7 +789,9 @@ void WindowVideoRecorder::sendAudioData(const QByteArray& int16Stereo)
     // actually written.
     if (buffer.isValid() && m_audioBufferInput->sendAudioBuffer(buffer)) {
         m_audioSamplesSent += numFrames;
+        return true;
     }
+    return false;
 }
 
 QString WindowVideoRecorder::buildFilename() const

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -552,27 +552,33 @@ void WindowVideoRecorder::stopRecording()
 void WindowVideoRecorder::captureFrame()
 {
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
-    if (!m_recording || !m_mainWindow || (!m_useFallback && !m_videoFrameInput)) {
-        return;
-    }
-    if (!m_useFallback && !m_readyToSend) {
+    if (!m_recording || !m_mainWindow || (!m_useFallback && (!m_videoFrameInput || !m_audioBufferInput))) {
         return;
     }
 #else
-    if (!m_recording || !m_mainWindow || !m_videoFrameInput) {
-        return;
-    }
-    if (!m_readyToSend) {
+    if (!m_recording || !m_mainWindow || !m_videoFrameInput || !m_audioBufferInput) {
         return;
     }
 #endif
 
-    qint64 ptsUs = m_recordTimer.isValid() ? (m_recordTimer.nsecsElapsed() / 1000) : (m_frameCount * 40000);
+    const qint64 ptsUs = m_recordTimer.isValid()
+        ? (m_recordTimer.nsecsElapsed() / 1000)
+        : (m_frameCount * 40000);
 
     // Keep audio stream synchronized with video timestamp to prevent FFmpeg muxer queue deadlocks
     while (!m_hasRealAudio && static_cast<qint64>((m_audioSamplesSent * 1000000) / 24000) < ptsUs + 40000) {
         sendSilentAudio(ptsUs);
     }
+
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+    if (!m_useFallback && !m_readyToSend) {
+        return;
+    }
+#else
+    if (!m_readyToSend) {
+        return;
+    }
+#endif
 
 
     QSize mainSize = m_mainWindow->size();

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -594,10 +594,11 @@ void WindowVideoRecorder::captureFrame()
         return;
     }
 
-    // Render the main window directly via standard QWidget::render() (100% robust and fast)
-    QImage img(mainSize, QImage::Format_ARGB32);
-    img.fill(Qt::black);
-    m_mainWindow->render(&img);
+    if (m_frameBuffer.size() != mainSize || m_frameBuffer.format() != QImage::Format_ARGB32) {
+        m_frameBuffer = QImage(mainSize, QImage::Format_ARGB32);
+    }
+    m_frameBuffer.fill(Qt::black);
+    m_mainWindow->render(&m_frameBuffer);
 
     // Composite any GPU-accelerated QRhiWidgets (such as SpectrumWidget) on top of the CPU render
     for (const auto& widget : m_rhiWidgetsCache) {
@@ -607,7 +608,7 @@ void WindowVideoRecorder::captureFrame()
                 if (!childImg.isNull()) {
                     QPoint pos = rhi->mapTo(m_mainWindow, QPoint(0, 0));
                     {
-                        QPainter painter(&img);
+                        QPainter painter(&m_frameBuffer);
                         painter.drawImage(pos, childImg);
                     }
                 }
@@ -617,7 +618,7 @@ void WindowVideoRecorder::captureFrame()
                     if (auto* w = qobject_cast<QWidget*>(obj)) {
                         if (w->isVisible() && !w->inherits("QRhiWidget")) {
                             QPoint pos = w->mapTo(m_mainWindow, QPoint(0, 0));
-                            w->render(&img, pos);
+                            w->render(&m_frameBuffer, pos);
                         }
                     }
                 }
@@ -629,7 +630,7 @@ void WindowVideoRecorder::captureFrame()
     QPoint globalPos = QCursor::pos();
     QPoint localPos = m_mainWindow->mapFromGlobal(globalPos);
     if (m_mainWindow->rect().contains(localPos)) {
-        QPainter painter(&img);
+        QPainter painter(&m_frameBuffer);
         painter.setRenderHint(QPainter::Antialiasing);
 
         // Classic black cursor with a crisp white outline for high contrast
@@ -650,16 +651,19 @@ void WindowVideoRecorder::captureFrame()
     }
 
     // Scale to macroblock-aligned target resolution if needed
-    QImage scaledImg = (img.size() == QSize(m_videoWidth, m_videoHeight))
-        ? img
-        : img.scaled(QSize(m_videoWidth, m_videoHeight), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+    const QSize targetSize(m_videoWidth, m_videoHeight);
+    if (m_frameBuffer.size() == targetSize) {
+        m_scaledBuffer = m_frameBuffer;
+    } else {
+        m_scaledBuffer = m_frameBuffer.scaled(targetSize, Qt::IgnoreAspectRatio, Qt::FastTransformation);
+    }
 
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     if (m_useFallback && m_fallbackWriter) {
         if (static_cast<qint64>((m_audioSamplesSent * 1000000) / kAudioSampleRate) < ptsUs) {
             sendSilentAudio(ptsUs);
         }
-        bool success = m_fallbackWriter->writeVideoFrame(scaledImg, ptsUs);
+        bool success = m_fallbackWriter->writeVideoFrame(m_scaledBuffer, ptsUs);
         if (!success) {
             emit recordingError(QStringLiteral("Failed to write video frame to native container"));
             stopRecording();
@@ -671,7 +675,7 @@ void WindowVideoRecorder::captureFrame()
 #endif
 
     // Construct QVideoFrame directly from the scaled image
-    QVideoFrame frame(scaledImg);
+    QVideoFrame frame(m_scaledBuffer);
 
     if (frame.isValid()) {
         frame.setStartTime(ptsUs);

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -606,8 +606,10 @@ void WindowVideoRecorder::captureFrame()
                 QImage childImg = rhi->grabFramebuffer();
                 if (!childImg.isNull()) {
                     QPoint pos = rhi->mapTo(m_mainWindow, QPoint(0, 0));
-                    QPainter painter(&img);
-                    painter.drawImage(pos, childImg);
+                    {
+                        QPainter painter(&img);
+                        painter.drawImage(pos, childImg);
+                    }
                 }
 
                 // Render standard child widgets of the QRhiWidget on top

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -115,6 +115,7 @@ void setFFmpegLogLevel(int level)
                 QLibrary::resolve(QStringLiteral("libavutil"), "av_log_set_level"));
         }
 
+#if defined(Q_OS_LINUX)
         // 2. Unversioned soname.
         if (!setLevel) {
             avutilLib.setFileName(QStringLiteral("avutil"));
@@ -134,6 +135,7 @@ void setFFmpegLogLevel(int level)
                 setLevel = tryResolve(avutilLib);
             }
         }
+#endif
     }
 
     if (setLevel) {

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -584,23 +584,21 @@ void WindowVideoRecorder::captureFrame()
     m_mainWindow->render(&img);
 
     // Composite any GPU-accelerated QRhiWidgets (such as SpectrumWidget) on top of the CPU render
-    for (auto* child : m_mainWindow->findChildren<QWidget*>()) {
-        if (child->isVisible() && child->inherits("QRhiWidget")) {
-            if (auto* rhi = qobject_cast<QRhiWidget*>(child)) {
-                QImage childImg = rhi->grabFramebuffer();
-                if (!childImg.isNull()) {
-                    QPoint pos = child->mapTo(m_mainWindow, QPoint(0, 0));
-                    QPainter painter(&img);
-                    painter.drawImage(pos, childImg);
-                }
+    for (auto* rhi : m_mainWindow->findChildren<QRhiWidget*>()) {
+        if (rhi->isVisible()) {
+            QImage childImg = rhi->grabFramebuffer();
+            if (!childImg.isNull()) {
+                QPoint pos = rhi->mapTo(m_mainWindow, QPoint(0, 0));
+                QPainter painter(&img);
+                painter.drawImage(pos, childImg);
+            }
 
-                // Render standard child widgets of the QRhiWidget on top
-                for (QObject* obj : child->children()) {
-                    if (auto* w = qobject_cast<QWidget*>(obj)) {
-                        if (w->isVisible() && !w->inherits("QRhiWidget")) {
-                            QPoint pos = w->mapTo(m_mainWindow, QPoint(0, 0));
-                            w->render(&img, pos);
-                        }
+            // Render standard child widgets of the QRhiWidget on top
+            for (QObject* obj : rhi->children()) {
+                if (auto* w = qobject_cast<QWidget*>(obj)) {
+                    if (w->isVisible() && !w->inherits("QRhiWidget")) {
+                        QPoint pos = w->mapTo(m_mainWindow, QPoint(0, 0));
+                        w->render(&img, pos);
                     }
                 }
             }
@@ -632,7 +630,9 @@ void WindowVideoRecorder::captureFrame()
     }
 
     // Scale to macroblock-aligned target resolution if needed
-    QImage scaledImg = img.scaled(QSize(m_videoWidth, m_videoHeight), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+    QImage scaledImg = (img.size() == QSize(m_videoWidth, m_videoHeight))
+        ? img
+        : img.scaled(QSize(m_videoWidth, m_videoHeight), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
 
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     if (m_useFallback && m_fallbackWriter) {

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -570,7 +570,7 @@ void WindowVideoRecorder::captureFrame()
     qint64 ptsUs = m_recordTimer.isValid() ? (m_recordTimer.nsecsElapsed() / 1000) : (m_frameCount * 40000);
 
     // Keep audio stream synchronized with video timestamp to prevent FFmpeg muxer queue deadlocks
-    if (!m_hasRealAudio && static_cast<qint64>((m_audioSamplesSent * 1000000) / 24000) < ptsUs + 40000) {
+    while (!m_hasRealAudio && static_cast<qint64>((m_audioSamplesSent * 1000000) / 24000) < ptsUs + 40000) {
         sendSilentAudio(ptsUs);
     }
 

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -652,18 +652,17 @@ void WindowVideoRecorder::captureFrame()
 
     // Scale to macroblock-aligned target resolution if needed
     const QSize targetSize(m_videoWidth, m_videoHeight);
-    if (m_frameBuffer.size() == targetSize) {
-        m_scaledBuffer = m_frameBuffer;
-    } else {
+    if (m_frameBuffer.size() != targetSize) {
         m_scaledBuffer = m_frameBuffer.scaled(targetSize, Qt::IgnoreAspectRatio, Qt::FastTransformation);
     }
+    const QImage& frameToEncode = (m_frameBuffer.size() == targetSize) ? m_frameBuffer : m_scaledBuffer;
 
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     if (m_useFallback && m_fallbackWriter) {
         if (static_cast<qint64>((m_audioSamplesSent * 1000000) / kAudioSampleRate) < ptsUs) {
             sendSilentAudio(ptsUs);
         }
-        bool success = m_fallbackWriter->writeVideoFrame(m_scaledBuffer, ptsUs);
+        bool success = m_fallbackWriter->writeVideoFrame(frameToEncode, ptsUs);
         if (!success) {
             emit recordingError(QStringLiteral("Failed to write video frame to native container"));
             stopRecording();
@@ -675,7 +674,7 @@ void WindowVideoRecorder::captureFrame()
 #endif
 
     // Construct QVideoFrame directly from the scaled image
-    QVideoFrame frame(m_scaledBuffer);
+    QVideoFrame frame(frameToEncode);
 
     if (frame.isValid()) {
         frame.setStartTime(ptsUs);

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -1,0 +1,808 @@
+#include "WindowVideoRecorder.h"
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+
+#include "core/AppSettings.h"
+#include "models/SliceModel.h"
+
+#include <QDir>
+#include <QStandardPaths>
+#include <QRegularExpression>
+#include <QDateTime>
+#include <QFileInfo>
+#include <QLoggingCategory>
+#include <QUrl>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPen>
+#include <QCursor>
+
+#include <QMediaCaptureSession>
+#include <QMediaRecorder>
+#include <QVideoFrameInput>
+#include <QVideoFrame>
+#include <QVideoFrameFormat>
+#include <QVideoSink>
+#include <QMediaFormat>
+#include <QAudioBufferInput>
+#include <QAudioBuffer>
+#include <QAudioFormat>
+#include <QLibrary>
+#include <QRhiWidget>
+#include <algorithm>
+#include <utility>
+
+#include "recording/INativeVideoWriter.h"
+#include "recording/MediaBackendProbe.h"
+#if defined(Q_OS_WIN)
+#include "recording/WmfVideoWriter.h"
+#elif defined(Q_OS_MAC)
+#include "recording/AvfVideoWriter.h"
+#endif
+
+namespace {
+Q_LOGGING_CATEGORY(lcWindowVideoRecorder, "aether.windowvideorecorder")
+
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+// True when Qt Multimedia can drive custom QVideoFrameInput/QAudioBufferInput
+// capture into an MP4/H.264/AAC encode. Construction of QVideoFrameInput is not
+// a capability probe (operator new never returns null).
+bool qtMultimediaEncoderUsable()
+{
+#if defined(Q_OS_MAC)
+    // Custom frame-input capture is non-functional on our macOS Qt builds;
+    // always use the AVFoundation writer.
+    return false;
+#else
+    QMediaFormat fmt(QMediaFormat::MPEG4);
+    fmt.setVideoCodec(QMediaFormat::VideoCodec::H264);
+    fmt.setAudioCodec(QMediaFormat::AudioCodec::AAC);
+    if (!fmt.isSupported(QMediaFormat::Encode)) {
+        qCWarning(lcWindowVideoRecorder) << "QMediaFormat MP4/H264/AAC encode not supported by Qt Multimedia";
+        return false;
+    }
+
+    // Custom frame/buffer inputs are only reliable with the FFmpeg backend.
+    // An explicit operator override wins; otherwise ask whether the plugin is
+    // actually installed. Reading QT_MEDIA_BACKEND alone would be circular —
+    // main() writes it — which is what made the native writer unreachable.
+    const QString backend = qEnvironmentVariable("QT_MEDIA_BACKEND").toLower();
+    if (!backend.isEmpty() && backend != QLatin1String("ffmpeg")) {
+        qCInfo(lcWindowVideoRecorder) << "QT_MEDIA_BACKEND is not ffmpeg; using native writer. backend=" << backend;
+        return false;
+    }
+    if (!AetherSDR::ffmpegMediaBackendAvailable()) {
+        qCInfo(lcWindowVideoRecorder) << "Qt FFmpeg multimedia plugin not present; using native writer.";
+        return false;
+    }
+    return true;
+#endif
+}
+#endif
+
+void setFFmpegLogLevel(int level)
+{
+    using SetLevelFunc = void (*)(int);
+    static SetLevelFunc setLevel = nullptr;
+    static bool resolved = false;
+    // Keep the loader alive for process lifetime. Resolving a symbol from a
+    // temporary QLibrary and then destroying it can unload the DSO and leave
+    // setLevel dangling (common on Linux where only libavutil.so.NN exists).
+    static QLibrary avutilLib;
+
+    if (!resolved) {
+        resolved = true;
+
+        auto tryResolve = [](QLibrary& lib) -> SetLevelFunc {
+            if (!lib.isLoaded() && !lib.load()) {
+                return nullptr;
+            }
+            return reinterpret_cast<SetLevelFunc>(lib.resolve("av_log_set_level"));
+        };
+
+        // 1. Already mapped into the process (Qt FFmpeg plugin / static link).
+        setLevel = reinterpret_cast<SetLevelFunc>(
+            QLibrary::resolve(QStringLiteral("avutil"), "av_log_set_level"));
+        if (!setLevel) {
+            setLevel = reinterpret_cast<SetLevelFunc>(
+                QLibrary::resolve(QStringLiteral("libavutil"), "av_log_set_level"));
+        }
+
+        // 2. Unversioned soname.
+        if (!setLevel) {
+            avutilLib.setFileName(QStringLiteral("avutil"));
+            setLevel = tryResolve(avutilLib);
+        }
+        if (!setLevel) {
+            avutilLib.setFileName(QStringLiteral("libavutil"));
+            setLevel = tryResolve(avutilLib);
+        }
+
+        // 3. Versioned sonames (libavutil.so.56 … .60).
+        for (int ver = 56; ver <= 60 && !setLevel; ++ver) {
+            avutilLib.setFileNameAndVersion(QStringLiteral("avutil"), ver);
+            setLevel = tryResolve(avutilLib);
+            if (!setLevel) {
+                avutilLib.setFileNameAndVersion(QStringLiteral("libavutil"), ver);
+                setLevel = tryResolve(avutilLib);
+            }
+        }
+    }
+
+    if (setLevel) {
+        setLevel(level);
+    }
+}
+}
+
+namespace AetherSDR {
+
+WindowVideoRecorder::WindowVideoRecorder(QWidget* mainWindow, QObject* parent)
+    : QObject(parent)
+    , m_mainWindow(mainWindow)
+{
+    m_recordingDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)
+                     + "/AetherSDR/Recordings";
+
+    auto& s = AppSettings::instance();
+    m_recordingDir = s.value("QsoRecordingDir", m_recordingDir).toString();
+
+#if defined(Q_OS_MAC) || defined(Q_OS_WIN)
+    m_useFallback = !qtMultimediaEncoderUsable();
+#endif
+
+    m_captureTimer = new QTimer(this);
+    connect(m_captureTimer, &QTimer::timeout, this, &WindowVideoRecorder::captureFrame);
+
+    if (!m_useFallback) {
+        initQtMultimediaPipeline();
+    }
+}
+
+void WindowVideoRecorder::initQtMultimediaPipeline()
+{
+    if (m_session || m_recorder) {
+        return;
+    }
+
+    // Initialize native Qt Multimedia pipeline
+    m_session = new QMediaCaptureSession(this);
+    m_recorder = new QMediaRecorder(this);
+    m_session->setRecorder(m_recorder);
+
+    // Connect state tracking and finish notification signals
+    connect(m_recorder, &QMediaRecorder::recorderStateChanged, this, [this](QMediaRecorder::RecorderState state) {
+        if (state == QMediaRecorder::RecordingState) {
+            // Stop requested before the async RecordingState arrived — abort immediately.
+            if (m_stopping || !m_recording) {
+                m_recorder->stop();
+                return;
+            }
+            // The media clocks are NOT started here: RecordingState arrives
+            // well before the encoder actually accepts frames (~0.9 s on the
+            // Linux FFmpeg backend). anchorEncoderClock() runs on the first
+            // readyToSendVideoFrame instead.
+            QString finalPath = m_recorder->actualLocation().toLocalFile();
+            if (finalPath.isEmpty()) {
+                finalPath = m_currentFilePath;
+            }
+            int vBitrate = m_recorder->videoBitRate();
+            int aBitrate = m_recorder->audioBitRate();
+            QMediaFormat mediaFmt = m_recorder->mediaFormat();
+            QString vCodecName = QMediaFormat::videoCodecName(mediaFmt.videoCodec());
+            QString aCodecName = QMediaFormat::audioCodecName(mediaFmt.audioCodec());
+
+            qCInfo(lcWindowVideoRecorder) << "Recording started."
+                                          << "Path:" << finalPath
+                                          << "Resolution:" << m_videoWidth << "x" << m_videoHeight
+                                          << "Video Codec:" << vCodecName
+                                          << "Audio Codec:" << aCodecName
+                                          << "Video Bitrate:" << (vBitrate > 0 ? QString::number(vBitrate) : QStringLiteral("Auto"))
+                                          << "Audio Bitrate:" << (aBitrate > 0 ? QString::number(aBitrate) : QStringLiteral("Auto"))
+                                          << "Quality:" << m_recorder->quality();
+            emit recordingStarted(finalPath);
+        } else if (state == QMediaRecorder::StoppedState) {
+            // Only finalize sessions we armed/are stopping; ignore idle noise.
+            if (m_stopping || m_recording) {
+                QString finalPath = m_recorder->actualLocation().toLocalFile();
+                if (finalPath.isEmpty()) {
+                    finalPath = m_currentFilePath;
+                }
+                QFileInfo fi(finalPath);
+                qint64 sizeBytes = fi.size();
+                int durationSecs = static_cast<int>(m_startTime.secsTo(QDateTime::currentDateTimeUtc()));
+                qCInfo(lcWindowVideoRecorder) << "Recording stopped."
+                                              << "Path:" << finalPath
+                                              << "Size:" << sizeBytes << "bytes"
+                                              << "Duration:" << durationSecs << "seconds";
+                // Prefer the recorder's actual path for the stopped signal.
+                m_currentFilePath = finalPath;
+                finalizeStop();
+            }
+        }
+    });
+
+    connect(m_recorder, &QMediaRecorder::errorOccurred, this, [this](QMediaRecorder::Error error, const QString& errorString) {
+        if (m_useFallback) {
+            return;
+        }
+        qCWarning(lcWindowVideoRecorder) << "Qt Recorder error occurred:" << error << "-" << errorString;
+        emit recordingError(errorString);
+        // Tear down the session so UI "not recording" matches encoder state.
+        if (m_recording && !m_stopping) {
+            stopRecording();
+        }
+    });
+}
+
+void WindowVideoRecorder::cleanupQtInputs()
+{
+    if (m_videoFrameInput) {
+        if (m_session) {
+            m_session->setVideoFrameInput(nullptr);
+        }
+        m_videoFrameInput.reset();
+    }
+    if (m_audioBufferInput) {
+        if (m_session) {
+            m_session->setAudioBufferInput(nullptr);
+        }
+        m_audioBufferInput.reset();
+    }
+}
+
+void WindowVideoRecorder::anchorEncoderClock()
+{
+    // The video clock restarts here rather than at record(): the FFmpeg backend
+    // needs ~0.9 s to accept its second frame and discards everything offered
+    // in the meantime. Timing video from record() therefore stamped the first
+    // surviving frame at ~0.9 s while the audio the backend did accept was
+    // concatenated from 0, freezing the opening frame and leaving the two
+    // tracks offset by the encoder start-up time for the whole file.
+    // m_audioSamplesSent is deliberately NOT reset: it already counts only
+    // buffers the backend accepted, so it is the true audio write position.
+    m_encoderAnchored = true;
+    m_hasRealAudio = false;
+    m_frameCount = 0;
+    m_recordTimer.start();
+}
+
+void WindowVideoRecorder::finalizeStop()
+{
+    if (m_captureTimer) {
+        m_captureTimer->stop();
+    }
+    m_encoderAnchored = false;
+    cleanupQtInputs();
+
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+    if (m_fallbackWriter) {
+        m_fallbackWriter->close();
+        m_fallbackWriter.reset();
+    }
+    m_useFallback = !qtMultimediaEncoderUsable();
+#endif
+
+    // m_recording is cleared eagerly in stopRecording() so isRecording() is
+    // false immediately; m_stopping covers the finalize window and gates the emit.
+    const bool shouldEmit = m_stopping || m_recording;
+    const QString path = m_currentFilePath;
+    const int durationSecs = m_startTime.isValid()
+        ? static_cast<int>(m_startTime.secsTo(QDateTime::currentDateTimeUtc()))
+        : 0;
+
+    m_recording = false;
+    m_stopping = false;
+    m_readyToSend = false;
+    m_hasRealAudio = false;
+    m_transmitting = false;
+
+    if (shouldEmit) {
+        emit recordingStopped(path, durationSecs);
+    }
+}
+
+WindowVideoRecorder::~WindowVideoRecorder()
+{
+    if (m_recording || m_stopping) {
+        // Best-effort sync teardown on destroy (no further UI signals needed).
+        m_stopping = true;
+        if (m_captureTimer) {
+            m_captureTimer->stop();
+        }
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+        if (m_fallbackWriter) {
+            m_fallbackWriter->close();
+            m_fallbackWriter.reset();
+        }
+#endif
+        if (m_recorder && m_recorder->recorderState() != QMediaRecorder::StoppedState) {
+            m_recorder->stop();
+        }
+        cleanupQtInputs();
+        m_recording = false;
+        m_stopping = false;
+    }
+}
+
+bool WindowVideoRecorder::isRecording() const
+{
+    return m_recording;
+}
+
+bool WindowVideoRecorder::isSessionActive() const
+{
+    return m_recording || m_stopping;
+}
+
+void WindowVideoRecorder::setSlice(SliceModel* slice)
+{
+    m_slice = slice;
+}
+
+bool WindowVideoRecorder::startRecording()
+{
+    qCDebug(lcWindowVideoRecorder) << "startRecording() called. m_recording:" << m_recording
+                                   << "m_stopping:" << m_stopping;
+    if (m_recording || m_stopping) {
+        return false;
+    }
+
+    if (lcWindowVideoRecorder().isDebugEnabled()) {
+        qputenv("AV_LOG_LEVEL", "info");
+        setFFmpegLogLevel(32); // AV_LOG_INFO
+    } else {
+        qputenv("AV_LOG_LEVEL", "error");
+        setFFmpegLogLevel(16); // AV_LOG_ERROR
+    }
+
+    m_frameCount = 0;
+
+    if (m_slice) {
+        m_freqMhz = m_slice->frequency();
+        m_mode = m_slice->mode();
+    } else {
+        m_freqMhz = 0.0;
+        m_mode.clear();
+    }
+
+    m_startTime = QDateTime::currentDateTimeUtc();
+
+    QDir dir(m_recordingDir);
+    if (!dir.exists()) {
+        if (!dir.mkpath(".")) {
+            qCWarning(lcWindowVideoRecorder) << "Failed to create recording directory:" << m_recordingDir;
+            emit recordingError("Cannot create recording directory: " + m_recordingDir);
+            return false;
+        }
+    }
+
+    QString filePath = m_recordingDir + "/" + buildFilename();
+    qCDebug(lcWindowVideoRecorder) << "Output path set to:" << filePath;
+
+    // Target resolution comes from the window geometry alone — rendering a
+    // throwaway frame here cost a full CPU render plus a GPU framebuffer grab
+    // and its pixels were never encoded.
+    if (m_mainWindow) {
+        const QSize windowSize = m_mainWindow->size();
+        m_videoWidth = (windowSize.width() / 16) * 16;
+        m_videoHeight = (windowSize.height() / 16) * 16;
+    }
+
+    if (m_videoWidth < 64) {
+        m_videoWidth = 1280;
+    }
+    if (m_videoHeight < 64) {
+        m_videoHeight = 720;
+    }
+    m_videoWidth = (m_videoWidth / 16) * 16;
+    m_videoHeight = (m_videoHeight / 16) * 16;
+
+    qCDebug(lcWindowVideoRecorder) << "Video resolution:" << m_videoWidth << "x" << m_videoHeight;
+
+    m_currentFilePath = filePath;
+
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+    m_useFallback = !qtMultimediaEncoderUsable();
+
+    if (m_useFallback) {
+        qCInfo(lcWindowVideoRecorder) << "Using native platform video writer (Qt Multimedia encode path unavailable).";
+#if defined(Q_OS_WIN)
+        m_fallbackWriter = std::make_unique<WmfVideoWriter>();
+#elif defined(Q_OS_MAC)
+        m_fallbackWriter = std::make_unique<AvfVideoWriter>();
+#endif
+        if (m_fallbackWriter && m_fallbackWriter->open(filePath, m_videoWidth, m_videoHeight, 25)) {
+            // Mark session active immediately so stopRecording() cannot no-op.
+            m_recording = true;
+            m_stopping = false;
+            m_recordTimer.start();
+            m_readyToSend = true;
+            m_encoderAnchored = true;
+            m_audioSamplesSent = 0;
+            m_hasRealAudio = false;
+            m_transmitting = false;
+            emit recordingStarted(filePath);
+            m_captureTimer->start(40);
+            return true;
+        }
+        m_fallbackWriter.reset();
+        emit recordingError(QStringLiteral("Failed to open native video recording engine."));
+        return false;
+    }
+#endif
+
+    initQtMultimediaPipeline();
+    if (!m_recorder || !m_session) {
+        emit recordingError(QStringLiteral("Failed to initialize Qt video recording engine."));
+        return false;
+    }
+
+    // Use standard Format_BGRA8888 for video frame input to let Qt handle conversions
+    QVideoFrameFormat videoFormat(QSize(m_videoWidth, m_videoHeight), QVideoFrameFormat::Format_BGRA8888);
+    videoFormat.setStreamFrameRate(25.0);
+    qCDebug(lcWindowVideoRecorder) << "Using BGRA8888 standard video format for recording";
+
+    cleanupQtInputs();
+
+    m_videoFrameInput = std::make_unique<QVideoFrameInput>();
+    m_session->setVideoFrameInput(m_videoFrameInput.get());
+
+    // Re-bind recorder to session to force rediscovery of the new video frame input
+    m_session->setRecorder(nullptr);
+    m_session->setRecorder(m_recorder);
+
+    m_readyToSend = false;
+    m_encoderAnchored = false;
+    m_readySignalCount = 0;
+    connect(m_videoFrameInput.get(), &QVideoFrameInput::readyToSendVideoFrame, this, [this]() {
+        m_readyToSend = true;
+        // The first signal is emitted as soon as the input is attached, long
+        // before the encoder can take a second frame. Only the signal that
+        // follows the priming frame proves the encoder is actually live, so
+        // that is where the media clocks are anchored.
+        if (!m_encoderAnchored && ++m_readySignalCount >= 2) {
+            anchorEncoderClock();
+        }
+    });
+
+    m_audioSamplesSent = 0;
+    m_hasRealAudio = false;
+    m_transmitting = false;
+
+    m_audioBufferInput = std::make_unique<QAudioBufferInput>();
+    m_session->setAudioBufferInput(m_audioBufferInput.get());
+
+    // Modern Qt6 style: use QMediaFormat to set MP4 file format and H.264 video codec
+    QMediaFormat mediaFormat;
+    mediaFormat.setFileFormat(QMediaFormat::MPEG4);
+    mediaFormat.setVideoCodec(QMediaFormat::VideoCodec::H264);
+    mediaFormat.setAudioCodec(QMediaFormat::AudioCodec::AAC);
+    m_recorder->setMediaFormat(mediaFormat);
+    m_recorder->setVideoResolution(QSize(m_videoWidth, m_videoHeight));
+    m_recorder->setVideoFrameRate(25.0);
+
+    m_recorder->setOutputLocation(QUrl::fromLocalFile(filePath));
+    m_recorder->setQuality(QMediaRecorder::NormalQuality);
+
+    // Arm the session before the async RecordingState so an immediate Stop works.
+    m_recording = true;
+    m_stopping = false;
+    // The media clock stays unstarted until anchorEncoderClock(): the encoder
+    // does not accept frames for a while after record() and any audio fed in
+    // the meantime is silently discarded, which desynchronises the file.
+    m_recordTimer.invalidate();
+
+#if !defined(Q_OS_MAC)
+    qCDebug(lcWindowVideoRecorder) << "Calling m_recorder->record(). Current state:" << m_recorder->recorderState();
+    m_recorder->record();
+#endif
+
+    // Start video capture at 25 fps (40 ms) on Main Thread
+    m_captureTimer->start(40);
+    qCDebug(lcWindowVideoRecorder) << "Started capture timer (40ms interval)";
+    return true;
+}
+
+void WindowVideoRecorder::stopRecording()
+{
+    qCDebug(lcWindowVideoRecorder) << "stopRecording() called. m_recording:" << m_recording
+                                   << "m_stopping:" << m_stopping;
+    // Tear down any armed session, even if RecordingState has not arrived yet.
+    if (!m_recording || m_stopping) {
+        return;
+    }
+
+    // Eagerly clear m_recording so isRecording() is false immediately (UI/tests),
+    // while m_stopping keeps finalize/recordingStopped coherent for close-on-stop.
+    m_stopping = true;
+    m_recording = false;
+    if (m_captureTimer) {
+        m_captureTimer->stop();
+    }
+
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+    if (m_useFallback) {
+        finalizeStop();
+        return;
+    }
+#endif
+
+    cleanupQtInputs();
+
+    if (m_recorder && m_recorder->recorderState() != QMediaRecorder::StoppedState) {
+        m_recorder->stop();
+        qCDebug(lcWindowVideoRecorder) << "m_recorder->stop() executed; waiting for StoppedState";
+        // finalizeStop() runs from recorderStateChanged(StoppedState).
+        // If stop is synchronous (or never left StoppedState), finalize now so
+        // callers always observe recordingStopped.
+        if (m_stopping && m_recorder->recorderState() == QMediaRecorder::StoppedState) {
+            finalizeStop();
+        }
+        return;
+    }
+
+    // Never entered RecordingState / already stopped — finish synchronously so
+    // close-while-recording and UI toggles always observe recordingStopped.
+    finalizeStop();
+}
+
+void WindowVideoRecorder::captureFrame()
+{
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+    if (!m_recording || !m_mainWindow || (!m_useFallback && !m_videoFrameInput)) {
+        return;
+    }
+    if (!m_useFallback && !m_readyToSend) {
+        return;
+    }
+#else
+    if (!m_recording || !m_mainWindow || !m_videoFrameInput) {
+        return;
+    }
+    if (!m_readyToSend) {
+        return;
+    }
+#endif
+
+    qint64 ptsUs = m_recordTimer.isValid() ? (m_recordTimer.nsecsElapsed() / 1000) : (m_frameCount * 40000);
+
+    // Keep audio stream synchronized with video timestamp to prevent FFmpeg muxer queue deadlocks
+    if (!m_hasRealAudio && static_cast<qint64>((m_audioSamplesSent * 1000000) / 24000) < ptsUs + 40000) {
+        sendSilentAudio(ptsUs);
+    }
+
+
+    QSize mainSize = m_mainWindow->size();
+    if (mainSize.width() <= 0 || mainSize.height() <= 0) {
+        return;
+    }
+
+    // Render the main window directly via standard QWidget::render() (100% robust and fast)
+    QImage img(mainSize, QImage::Format_ARGB32);
+    img.fill(Qt::black);
+    m_mainWindow->render(&img);
+
+    // Composite any GPU-accelerated QRhiWidgets (such as SpectrumWidget) on top of the CPU render
+    for (auto* child : m_mainWindow->findChildren<QWidget*>()) {
+        if (child->isVisible() && child->inherits("QRhiWidget")) {
+            if (auto* rhi = qobject_cast<QRhiWidget*>(child)) {
+                QImage childImg = rhi->grabFramebuffer();
+                if (!childImg.isNull()) {
+                    QPoint pos = child->mapTo(m_mainWindow, QPoint(0, 0));
+                    QPainter painter(&img);
+                    painter.drawImage(pos, childImg);
+                }
+
+                // Render standard child widgets of the QRhiWidget on top
+                for (QObject* obj : child->children()) {
+                    if (auto* w = qobject_cast<QWidget*>(obj)) {
+                        if (w->isVisible() && !w->inherits("QRhiWidget")) {
+                            QPoint pos = w->mapTo(m_mainWindow, QPoint(0, 0));
+                            w->render(&img, pos);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Overlay mouse cursor if it is currently inside the window bounds
+    QPoint globalPos = QCursor::pos();
+    QPoint localPos = m_mainWindow->mapFromGlobal(globalPos);
+    if (m_mainWindow->rect().contains(localPos)) {
+        QPainter painter(&img);
+        painter.setRenderHint(QPainter::Antialiasing);
+
+        // Classic black cursor with a crisp white outline for high contrast
+        painter.setPen(QPen(Qt::white, 1.5, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+        painter.setBrush(Qt::black);
+
+        QPainterPath path;
+        path.moveTo(localPos);
+        path.lineTo(localPos + QPoint(0, 17));
+        path.lineTo(localPos + QPoint(4, 13));
+        path.lineTo(localPos + QPoint(8, 20));
+        path.lineTo(localPos + QPoint(11, 18));
+        path.lineTo(localPos + QPoint(7, 12));
+        path.lineTo(localPos + QPoint(12, 12));
+        path.closeSubpath();
+
+        painter.drawPath(path);
+    }
+
+    // Scale to macroblock-aligned target resolution if needed
+    QImage scaledImg = img.scaled(QSize(m_videoWidth, m_videoHeight), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+    if (m_useFallback && m_fallbackWriter) {
+        if (static_cast<qint64>((m_audioSamplesSent * 1000000) / 24000) < ptsUs) {
+            sendSilentAudio(ptsUs);
+        }
+        bool success = m_fallbackWriter->writeVideoFrame(scaledImg, ptsUs);
+        if (!success) {
+            emit recordingError(QStringLiteral("Failed to write video frame to native container"));
+            stopRecording();
+            return;
+        }
+        m_frameCount++;
+        return;
+    }
+#endif
+
+    // Construct QVideoFrame directly from the scaled image
+    QVideoFrame frame(scaledImg);
+
+    if (frame.isValid()) {
+        frame.setStartTime(ptsUs);
+        frame.setEndTime(ptsUs + 40000); // 40ms frame duration at 25 fps (microseconds)
+
+        if (static_cast<qint64>((m_audioSamplesSent * 1000000) / 24000) < ptsUs) {
+            sendSilentAudio(ptsUs);
+        }
+
+        bool sent = m_videoFrameInput->sendVideoFrame(frame);
+        if (sent) {
+            m_readyToSend = false;
+        } else {
+            m_readyToSend = true;
+            emit recordingError(QStringLiteral("Failed to encode video frame"));
+            stopRecording();
+            return;
+        }
+        m_frameCount++;
+        qCDebug(lcWindowVideoRecorder) << "Recorder State:" << m_recorder->recorderState()
+                                         << "Frame validity:" << frame.isValid()
+                                         << "Pixel Format:" << frame.pixelFormat()
+                                         << "Width:" << frame.width() << "Height:" << frame.height()
+                                         << "StartTime:" << frame.startTime()
+                                         << "Sent result:" << sent;
+    } else {
+        qCWarning(lcWindowVideoRecorder) << "Constructed frame is invalid!";
+    }
+}
+
+namespace {
+
+QByteArray float32ToInt16(const QByteArray& pcm)
+{
+    const int numFloats = pcm.size() / static_cast<int>(sizeof(float));
+    QByteArray out(numFloats * static_cast<int>(sizeof(qint16)), Qt::Uninitialized);
+    const float* src = reinterpret_cast<const float*>(pcm.constData());
+    qint16* dst = reinterpret_cast<qint16*>(out.data());
+    for (int i = 0; i < numFloats; ++i) {
+        float clamped = std::clamp(src[i], -1.0f, 1.0f);
+        dst[i] = static_cast<qint16>(clamped * 32767.0f);
+    }
+    return out;
+}
+
+} // namespace
+
+void WindowVideoRecorder::sendSilentAudio(qint64 startTimeUs)
+{
+    Q_UNUSED(startTimeUs);
+    // Provide 40ms of silent audio: 24000 samples/sec * 4 bytes/sample (stereo int16) * 0.040s = 3840 bytes
+    QByteArray silentBytes(3840, 0);
+    sendAudioData(silentBytes);
+}
+
+void WindowVideoRecorder::feedRxAudio(const QByteArray& pcm)
+{
+    if (!m_recording || m_transmitting) {
+        return;
+    }
+    m_hasRealAudio = true;
+    QByteArray converted = float32ToInt16(pcm);
+    sendAudioData(converted);
+}
+
+void WindowVideoRecorder::feedTxAudio(const QByteArray& int16Stereo)
+{
+    if (!m_recording || !m_transmitting) {
+        return;
+    }
+    m_hasRealAudio = true;
+    sendAudioData(int16Stereo);
+}
+
+void WindowVideoRecorder::onMoxChanged(bool mox)
+{
+    m_transmitting = mox;
+}
+
+void WindowVideoRecorder::sendAudioData(const QByteArray& int16Stereo)
+{
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+    if (!m_recording || (!m_useFallback && !m_audioBufferInput)) {
+        return;
+    }
+#else
+    if (!m_recording || !m_audioBufferInput) {
+        return;
+    }
+#endif
+
+    // Audio must keep flowing even before the encoder is live, otherwise the
+    // FFmpeg muxer stalls waiting on the audio queue and never becomes ready.
+    // Pre-ready buffers are rejected by the backend and simply not counted.
+
+    // NOTE: m_hasRealAudio is deliberately NOT set here. sendSilentAudio()
+    // routes through this function too, so setting it here would let the very
+    // first synthetic silence chunk latch the flag and permanently disable the
+    // silence priming it gates.
+
+    QAudioFormat format;
+    format.setSampleRate(24000);
+    format.setChannelCount(2);
+    format.setSampleFormat(QAudioFormat::Int16);
+
+    qint64 ptsUs = (m_audioSamplesSent * 1000000) / 24000;
+    int numFrames = int16Stereo.size() / 4; // 2 channels * 2 bytes = 4 bytes per frame
+
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+    if (m_useFallback && m_fallbackWriter) {
+        m_fallbackWriter->writeAudioSamples(int16Stereo, ptsUs);
+        m_audioSamplesSent += numFrames;
+        return;
+    }
+#endif
+
+    QAudioBuffer buffer(int16Stereo, format, ptsUs);
+    // Only accepted samples advance the clock: the FFmpeg backend concatenates
+    // the buffers it takes and ignores their start times, so counting a
+    // rejected buffer would shift every later timestamp ahead of the audio
+    // actually written.
+    if (buffer.isValid() && m_audioBufferInput->sendAudioBuffer(buffer)) {
+        m_audioSamplesSent += numFrames;
+    }
+}
+
+QString WindowVideoRecorder::buildFilename() const
+{
+    QStringList parts;
+
+    parts << m_startTime.toString("yyyy-MM-dd");
+    parts << m_startTime.toString("HHmmss") + "Z";
+
+    if (m_freqMhz > 0.0) {
+        parts << QString::number(m_freqMhz, 'f', 3) + "MHz";
+    }
+
+    if (!m_mode.isEmpty()) {
+        static const QRegularExpression re(QStringLiteral("[^A-Z0-9]"));
+        QString sanitizedMode = m_mode.toUpper();
+        sanitizedMode.replace(re, QStringLiteral("_"));
+        parts << sanitizedMode;
+    }
+
+    if (parts.isEmpty()) {
+        parts << "WindowRecord";
+    }
+
+    return parts.join("_") + ".mp4";
+}
+
+} // namespace AetherSDR
+
+#endif // QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)

--- a/src/gui/WindowVideoRecorder.cpp
+++ b/src/gui/WindowVideoRecorder.cpp
@@ -43,6 +43,12 @@
 namespace {
 Q_LOGGING_CATEGORY(lcWindowVideoRecorder, "aether.windowvideorecorder")
 
+constexpr int kAudioSampleRate = 24000;
+constexpr int kAudioChannels = 2;
+constexpr int kAudioBytesPerSample = static_cast<int>(sizeof(int16_t));
+constexpr int kAudioBytesPerFrame = kAudioChannels * kAudioBytesPerSample;
+constexpr int kSilenceChunkMs = 40; // 40 ms silent chunk (matching 25 fps frame step)
+
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
 // True when Qt Multimedia can drive custom QVideoFrameInput/QAudioBufferInput
 // capture into an MP4/H.264/AAC encode. Construction of QVideoFrameInput is not
@@ -566,7 +572,7 @@ void WindowVideoRecorder::captureFrame()
         : (m_frameCount * 40000);
 
     // Keep audio stream synchronized with video timestamp to prevent FFmpeg muxer queue deadlocks
-    while (!m_hasRealAudio && static_cast<qint64>((m_audioSamplesSent * 1000000) / 24000) < ptsUs + 40000) {
+    while (!m_hasRealAudio && static_cast<qint64>((m_audioSamplesSent * 1000000) / kAudioSampleRate) < ptsUs + (kSilenceChunkMs * 1000)) {
         if (!sendSilentAudio(ptsUs)) {
             break;
         }
@@ -714,8 +720,9 @@ QByteArray float32ToInt16(const QByteArray& pcm)
 bool WindowVideoRecorder::sendSilentAudio(qint64 startTimeUs)
 {
     Q_UNUSED(startTimeUs);
-    // Provide 40ms of silent audio: 24000 samples/sec * 4 bytes/sample (stereo int16) * 0.040s = 3840 bytes
-    QByteArray silentBytes(3840, 0);
+    constexpr int samplesPerChunk = (kAudioSampleRate * kSilenceChunkMs) / 1000;
+    constexpr int bufferSize = samplesPerChunk * kAudioBytesPerFrame;
+    QByteArray silentBytes(bufferSize, 0);
     return sendAudioData(silentBytes);
 }
 
@@ -765,12 +772,12 @@ bool WindowVideoRecorder::sendAudioData(const QByteArray& int16Stereo)
     // silence priming it gates.
 
     QAudioFormat format;
-    format.setSampleRate(24000);
-    format.setChannelCount(2);
+    format.setSampleRate(kAudioSampleRate);
+    format.setChannelCount(kAudioChannels);
     format.setSampleFormat(QAudioFormat::Int16);
 
-    qint64 ptsUs = (m_audioSamplesSent * 1000000) / 24000;
-    int numFrames = int16Stereo.size() / 4; // 2 channels * 2 bytes = 4 bytes per frame
+    qint64 ptsUs = (m_audioSamplesSent * 1000000) / kAudioSampleRate;
+    int numFrames = int16Stereo.size() / kAudioBytesPerFrame;
 
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     if (m_useFallback && m_fallbackWriter) {

--- a/src/gui/WindowVideoRecorder.h
+++ b/src/gui/WindowVideoRecorder.h
@@ -77,6 +77,8 @@ private:
     QElapsedTimer m_recordTimer;
     int m_videoWidth{1280};
     int m_videoHeight{720};
+    QImage m_frameBuffer;
+    QImage m_scaledBuffer;
 
     QMediaCaptureSession* m_session{nullptr};
     // Not parented to the session: it does not take ownership, and these are

--- a/src/gui/WindowVideoRecorder.h
+++ b/src/gui/WindowVideoRecorder.h
@@ -7,6 +7,8 @@
 #include <QTimer>
 #include <QImage>
 #include <QElapsedTimer>
+#include <QPointer>
+#include <QList>
 
 #include <memory>
 
@@ -100,9 +102,11 @@ private:
     int m_readySignalCount{0};
 
     bool m_useFallback{false};
+
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     std::unique_ptr<INativeVideoWriter> m_fallbackWriter;
 #endif
+    QList<QPointer<QWidget>> m_rhiWidgetsCache;
 };
 
 } // namespace AetherSDR

--- a/src/gui/WindowVideoRecorder.h
+++ b/src/gui/WindowVideoRecorder.h
@@ -56,7 +56,7 @@ signals:
 
 private slots:
     void captureFrame();
-    void sendSilentAudio(qint64 startTimeUs);
+    bool sendSilentAudio(qint64 startTimeUs);
 
 private:
     QString buildFilename() const;
@@ -88,7 +88,7 @@ private:
     bool m_transmitting{false};
     bool m_hasRealAudio{false};
     quint64 m_audioSamplesSent{0};
-    void sendAudioData(const QByteArray& int16Stereo);
+    bool sendAudioData(const QByteArray& int16Stereo);
     void initQtMultimediaPipeline();
     void cleanupQtInputs();
     void finalizeStop();

--- a/src/gui/WindowVideoRecorder.h
+++ b/src/gui/WindowVideoRecorder.h
@@ -62,7 +62,7 @@ private:
     QString buildFilename() const;
 
     QWidget* m_mainWindow{nullptr};
-    SliceModel* m_slice{nullptr};
+    QPointer<SliceModel> m_slice;
 
     bool m_recording{false};
     bool m_stopping{false};

--- a/src/gui/WindowVideoRecorder.h
+++ b/src/gui/WindowVideoRecorder.h
@@ -56,7 +56,7 @@ signals:
 
 private slots:
     void captureFrame();
-    bool sendSilentAudio(qint64 startTimeUs);
+    bool sendSilentAudio();
 
 private:
     QString buildFilename() const;

--- a/src/gui/WindowVideoRecorder.h
+++ b/src/gui/WindowVideoRecorder.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QDateTime>
+#include <QWidget>
+#include <QTimer>
+#include <QImage>
+#include <QElapsedTimer>
+
+#include <memory>
+
+namespace AetherSDR {
+class SliceModel;
+class INativeVideoWriter;
+}
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+
+class QMediaCaptureSession;
+class QMediaRecorder;
+class QVideoFrameInput;
+class QAudioBufferInput;
+
+namespace AetherSDR {
+
+class WindowVideoRecorder : public QObject {
+    Q_OBJECT
+
+public:
+    explicit WindowVideoRecorder(QWidget* mainWindow, QObject* parent = nullptr);
+    ~WindowVideoRecorder() override;
+
+    bool isRecording() const;
+    // True from successful start until finalize completes (includes stop-in-flight).
+    bool isSessionActive() const;
+
+    void setSlice(SliceModel* slice);
+
+public slots:
+    // Returns true when a recording session was armed. False if already active,
+    // finalize is in flight, or open failed immediately (recordingError emitted).
+    bool startRecording();
+    void stopRecording();
+
+    void feedRxAudio(const QByteArray& pcm);
+    void feedTxAudio(const QByteArray& int16Stereo);
+    void onMoxChanged(bool mox);
+
+signals:
+    void recordingStarted(const QString& filePath);
+    void recordingStopped(const QString& filePath, int durationSecs);
+    void recordingError(const QString& message);
+
+private slots:
+    void captureFrame();
+    void sendSilentAudio(qint64 startTimeUs);
+
+private:
+    QString buildFilename() const;
+
+    QWidget* m_mainWindow{nullptr};
+    SliceModel* m_slice{nullptr};
+
+    bool m_recording{false};
+    bool m_stopping{false};
+    bool m_readyToSend{false};
+    QString m_recordingDir;
+    QString m_currentFilePath;
+    QDateTime m_startTime;
+    double m_freqMhz{0.0};
+    QString m_mode;
+
+    QTimer* m_captureTimer{nullptr};
+    QElapsedTimer m_recordTimer;
+    int m_videoWidth{1280};
+    int m_videoHeight{720};
+
+    QMediaCaptureSession* m_session{nullptr};
+    // Not parented to the session: it does not take ownership, and these are
+    // torn down and rebuilt per recording. unique_ptr keeps that explicit.
+    std::unique_ptr<QVideoFrameInput> m_videoFrameInput;
+    std::unique_ptr<QAudioBufferInput> m_audioBufferInput;
+    QMediaRecorder* m_recorder{nullptr};
+    int m_frameCount{0};
+    bool m_transmitting{false};
+    bool m_hasRealAudio{false};
+    quint64 m_audioSamplesSent{0};
+    void sendAudioData(const QByteArray& int16Stereo);
+    void initQtMultimediaPipeline();
+    void cleanupQtInputs();
+    void finalizeStop();
+    // Pins both media clocks to the instant the encoder actually starts
+    // accepting frames. See WindowVideoRecorder.cpp for why.
+    void anchorEncoderClock();
+
+    // Latches once the encoder proves it is live so the video clock is
+    // anchored exactly once per session.
+    bool m_encoderAnchored{false};
+    int m_readySignalCount{0};
+
+    bool m_useFallback{false};
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+    std::unique_ptr<INativeVideoWriter> m_fallbackWriter;
+#endif
+};
+
+} // namespace AetherSDR
+
+#else // QT_VERSION < QT_VERSION_CHECK(6, 8, 0)
+
+namespace AetherSDR {
+
+class WindowVideoRecorder : public QObject {
+    Q_OBJECT
+
+public:
+    explicit WindowVideoRecorder(QWidget* /*mainWindow*/, QObject* parent = nullptr) : QObject(parent) {}
+    ~WindowVideoRecorder() override = default;
+
+    bool isRecording() const { return false; }
+    bool isSessionActive() const { return false; }
+
+    void setSlice(SliceModel* /*slice*/) {}
+
+public slots:
+    bool startRecording() { return false; }
+    void stopRecording() {}
+
+    void feedRxAudio(const QByteArray& /*pcm*/) {}
+    void feedTxAudio(const QByteArray& /*int16Stereo*/) {}
+    void onMoxChanged(bool /*mox*/) {}
+
+signals:
+    void recordingStarted(const QString& filePath);
+    void recordingStopped(const QString& filePath, int durationSecs);
+    void recordingError(const QString& message);
+};
+
+} // namespace AetherSDR
+
+#endif

--- a/src/gui/WindowVideoRecorder.h
+++ b/src/gui/WindowVideoRecorder.h
@@ -2,6 +2,7 @@
 
 #include <QObject>
 #include <QString>
+#include <QByteArray>
 #include <QDateTime>
 #include <QWidget>
 #include <QTimer>

--- a/src/gui/recording/AvfVideoWriter.h
+++ b/src/gui/recording/AvfVideoWriter.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "INativeVideoWriter.h"
+
+namespace AetherSDR {
+
+class AvfVideoWriter : public INativeVideoWriter {
+public:
+    AvfVideoWriter();
+    ~AvfVideoWriter() override;
+
+    bool open(const QString& filePath, int width, int height, int fps) override;
+    void close() override;
+    bool writeVideoFrame(const QImage& frame, qint64 ptsUs) override;
+    bool writeAudioSamples(const QByteArray& pcmData, qint64 ptsUs) override;
+
+private:
+    // ARC +1 ownership of AVFWriterObjC via CFBridgingRetain (see .mm).
+    void* m_opaqueWriter{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/gui/recording/AvfVideoWriter.mm
+++ b/src/gui/recording/AvfVideoWriter.mm
@@ -4,6 +4,7 @@
 #import <CoreVideo/CoreVideo.h>
 #import <CoreMedia/CoreMedia.h>
 #include <QDebug>
+#include <cstdint>
 #include <cstring>
 
 // ARC-correct ownership model for the C++/ObjC boundary:

--- a/src/gui/recording/AvfVideoWriter.mm
+++ b/src/gui/recording/AvfVideoWriter.mm
@@ -56,7 +56,7 @@ AvfVideoWriter::~AvfVideoWriter()
 
 bool AvfVideoWriter::open(const QString& filePath, int width, int height, int fps)
 {
-    qWarning() << "[AvfVideoWriter] open() called:" << filePath
+    qInfo() << "[AvfVideoWriter] open() called:" << filePath
                << "width:" << width << "height:" << height << "fps:" << fps;
     AVFWriterObjC* wrapper = asWriter(m_opaqueWriter);
     if (!wrapper) {
@@ -151,7 +151,7 @@ bool AvfVideoWriter::open(const QString& filePath, int width, int height, int fp
     [wrapper.writer startSessionAtSourceTime:kCMTimeZero];
 
     wrapper.initialized = YES;
-    qWarning() << "[AvfVideoWriter] open() SUCCEEDED!";
+    qInfo() << "[AvfVideoWriter] open() SUCCEEDED!";
     return true;
 }
 

--- a/src/gui/recording/AvfVideoWriter.mm
+++ b/src/gui/recording/AvfVideoWriter.mm
@@ -1,0 +1,350 @@
+#import "AvfVideoWriter.h"
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+#import <CoreVideo/CoreVideo.h>
+#import <CoreMedia/CoreMedia.h>
+#include <QDebug>
+#include <cstring>
+
+// ARC-correct ownership model for the C++/ObjC boundary:
+//   - C++ stores the ObjC wrapper as void* with +1 ownership via CFBridgingRetain.
+//   - Non-owning access uses __bridge.
+//   - Destruction uses CFBridgingRelease (transfers back to ARC, which releases).
+// No manual retain/release. Safe under default Clang ARC (no -fno-objc-arc needed).
+
+@interface AVFWriterObjC : NSObject
+@property (strong) AVAssetWriter *writer;
+@property (strong) AVAssetWriterInput *videoInput;
+@property (strong) AVAssetWriterInput *audioInput;
+@property (strong) AVAssetWriterInputPixelBufferAdaptor *adaptor;
+@property (assign) int width;
+@property (assign) int height;
+@property (assign) int fps;
+@property (assign) BOOL initialized;
+@end
+
+@implementation AVFWriterObjC
+@end
+
+namespace {
+
+AVFWriterObjC* asWriter(void* opaque)
+{
+    return (__bridge AVFWriterObjC*)opaque;
+}
+
+} // namespace
+
+namespace AetherSDR {
+
+AvfVideoWriter::AvfVideoWriter()
+{
+    // alloc/init is +1 under ARC; CFBridgingRetain keeps that +1 for C++ ownership.
+    AVFWriterObjC* wrapper = [[AVFWriterObjC alloc] init];
+    m_opaqueWriter = (void*)CFBridgingRetain(wrapper);
+}
+
+AvfVideoWriter::~AvfVideoWriter()
+{
+    close();
+    if (m_opaqueWriter) {
+        // Transfer ownership back to ARC; the returned id is released at end of scope.
+        (void)CFBridgingRelease(m_opaqueWriter);
+        m_opaqueWriter = nullptr;
+    }
+}
+
+bool AvfVideoWriter::open(const QString& filePath, int width, int height, int fps)
+{
+    qWarning() << "[AvfVideoWriter] open() called:" << filePath
+               << "width:" << width << "height:" << height << "fps:" << fps;
+    AVFWriterObjC* wrapper = asWriter(m_opaqueWriter);
+    if (!wrapper) {
+        return false;
+    }
+
+    // Even width/height required for H.264 macroblock encoding.
+    if (width < 64) {
+        width = 1280;
+    }
+    if (height < 64) {
+        height = 720;
+    }
+    width = (width / 2) * 2;
+    height = (height / 2) * 2;
+
+    wrapper.width = width;
+    wrapper.height = height;
+    wrapper.fps = fps;
+
+    NSString* nsPath = [NSString stringWithUTF8String:filePath.toUtf8().constData()];
+    NSURL* fileURL = [NSURL fileURLWithPath:nsPath];
+
+    // Remove any pre-existing file; AVAssetWriter refuses to overwrite.
+    [[NSFileManager defaultManager] removeItemAtURL:fileURL error:nil];
+
+    NSError* error = nil;
+    wrapper.writer = [AVAssetWriter assetWriterWithURL:fileURL
+                                              fileType:AVFileTypeMPEG4
+                                                 error:&error];
+    if (error || !wrapper.writer) {
+        qWarning() << "[AvfVideoWriter] Failed to create AVAssetWriter:"
+                   << (error ? error.localizedDescription.UTF8String : "null writer");
+        return false;
+    }
+
+    NSDictionary* videoSettings = @{
+        AVVideoCodecKey: AVVideoCodecTypeH264,
+        AVVideoWidthKey: @(width),
+        AVVideoHeightKey: @(height),
+        AVVideoCompressionPropertiesKey: @{
+            AVVideoAverageBitRateKey: @(2000000) // 2 Mbps
+        }
+    };
+    wrapper.videoInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeVideo
+                                                            outputSettings:videoSettings];
+    wrapper.videoInput.expectsMediaDataInRealTime = YES;
+
+    NSDictionary* bufferAttributes = @{
+        (id)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA),
+        (id)kCVPixelBufferWidthKey: @(width),
+        (id)kCVPixelBufferHeightKey: @(height)
+    };
+    wrapper.adaptor = [AVAssetWriterInputPixelBufferAdaptor
+        assetWriterInputPixelBufferAdaptorWithAssetWriterInput:wrapper.videoInput
+                                   sourcePixelBufferAttributes:bufferAttributes];
+
+    if ([wrapper.writer canAddInput:wrapper.videoInput]) {
+        [wrapper.writer addInput:wrapper.videoInput];
+    } else {
+        qWarning() << "[AvfVideoWriter] AVAssetWriter canAddInput for video failed!";
+        return false;
+    }
+
+    NSDictionary* audioSettings = @{
+        AVFormatIDKey: @(kAudioFormatMPEG4AAC),
+        AVNumberOfChannelsKey: @(2),
+        AVSampleRateKey: @(48000),
+        AVEncoderBitRateKey: @(96000)
+    };
+    wrapper.audioInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio
+                                                            outputSettings:audioSettings];
+    wrapper.audioInput.expectsMediaDataInRealTime = YES;
+
+    if ([wrapper.writer canAddInput:wrapper.audioInput]) {
+        [wrapper.writer addInput:wrapper.audioInput];
+    } else {
+        qWarning() << "[AvfVideoWriter] AVAssetWriter canAddInput for audio returned false, "
+                      "proceeding video-only.";
+        wrapper.audioInput = nil;
+    }
+
+    if (![wrapper.writer startWriting]) {
+        if (wrapper.writer.error) {
+            qWarning() << "[AvfVideoWriter] AVAssetWriter startWriting failed:"
+                       << wrapper.writer.error.localizedDescription.UTF8String;
+        } else {
+            qWarning() << "[AvfVideoWriter] AVAssetWriter startWriting failed with no error set.";
+        }
+        return false;
+    }
+    [wrapper.writer startSessionAtSourceTime:kCMTimeZero];
+
+    wrapper.initialized = YES;
+    qWarning() << "[AvfVideoWriter] open() SUCCEEDED!";
+    return true;
+}
+
+void AvfVideoWriter::close()
+{
+    AVFWriterObjC* wrapper = asWriter(m_opaqueWriter);
+    if (!wrapper || !wrapper.initialized) {
+        return;
+    }
+
+    wrapper.initialized = NO;
+    [wrapper.videoInput markAsFinished];
+    if (wrapper.audioInput) {
+        [wrapper.audioInput markAsFinished];
+    }
+
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+    [wrapper.writer finishWritingWithCompletionHandler:^{
+        dispatch_semaphore_signal(sema);
+    }];
+    // Bounded wait: close() runs on the GUI thread (including app-shutdown).
+    // DISPATCH_TIME_FOREVER turned any encoder stall into an unrecoverable freeze.
+    const dispatch_time_t deadline = dispatch_time(DISPATCH_TIME_NOW, 10LL * NSEC_PER_SEC);
+    if (dispatch_semaphore_wait(sema, deadline) != 0) {
+        qWarning() << "[AvfVideoWriter] finishWriting timed out after 10s; abandoning finalize.";
+    }
+}
+
+bool AvfVideoWriter::writeVideoFrame(const QImage& frame, qint64 ptsUs)
+{
+    AVFWriterObjC* wrapper = asWriter(m_opaqueWriter);
+    if (!wrapper || !wrapper.initialized) {
+        return false;
+    }
+    // isReadyForMoreMediaData is flow control, not an error. Reporting it as
+    // failure made the caller tear the whole recording down the first time the
+    // H.264 encoder fell behind the 25 fps feed. PTS come from the wall clock,
+    // so a dropped frame is harmless.
+    if (!wrapper.videoInput.isReadyForMoreMediaData) {
+        return true;
+    }
+    if (frame.width() < wrapper.width || frame.height() < wrapper.height) {
+        return true;
+    }
+
+    CVPixelBufferRef pixelBuffer = NULL;
+    CVPixelBufferPoolRef pool = wrapper.adaptor.pixelBufferPool;
+    if (!pool) {
+        return false;
+    }
+    CVReturn status = CVPixelBufferPoolCreatePixelBuffer(NULL, pool, &pixelBuffer);
+    if (status != kCVReturnSuccess || !pixelBuffer) {
+        return false;
+    }
+
+    CVPixelBufferLockBaseAddress(pixelBuffer, 0);
+    void* data = CVPixelBufferGetBaseAddress(pixelBuffer);
+    size_t bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer);
+
+    if (data) {
+        for (int y = 0; y < wrapper.height; ++y) {
+            std::memcpy(static_cast<uint8_t*>(data) + (static_cast<size_t>(y) * bytesPerRow),
+                        frame.constScanLine(y),
+                        static_cast<size_t>(wrapper.width) * 4);
+        }
+    }
+
+    CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
+
+    if (!data) {
+        CVPixelBufferRelease(pixelBuffer);
+        return false;
+    }
+
+    CMTime pts = CMTimeMake(ptsUs, 1000000);
+    BOOL success = [wrapper.adaptor appendPixelBuffer:pixelBuffer withPresentationTime:pts];
+    CVPixelBufferRelease(pixelBuffer);
+
+    return success == YES;
+}
+
+bool AvfVideoWriter::writeAudioSamples(const QByteArray& pcmData, qint64 ptsUs)
+{
+    AVFWriterObjC* wrapper = asWriter(m_opaqueWriter);
+    if (!wrapper || !wrapper.initialized || !wrapper.audioInput) {
+        return false;
+    }
+    if (!wrapper.audioInput.isReadyForMoreMediaData) {
+        return true;
+    }
+
+    // On-the-fly 24 kHz → 48 kHz upsample (duplicate each stereo frame).
+    const int numInSamples = pcmData.size() / 4;
+    if (numInSamples <= 0) {
+        return true;
+    }
+    QByteArray upsampled(numInSamples * 2 * 4, Qt::Uninitialized);
+    const int16_t* src = reinterpret_cast<const int16_t*>(pcmData.constData());
+    int16_t* dst = reinterpret_cast<int16_t*>(upsampled.data());
+
+    for (int i = 0; i < numInSamples; ++i) {
+        dst[2 * i * 2]           = src[2 * i];
+        dst[2 * i * 2 + 1]       = src[2 * i + 1];
+        dst[(2 * i + 1) * 2]     = src[2 * i];
+        dst[(2 * i + 1) * 2 + 1] = src[2 * i + 1];
+    }
+
+    // Every OSStatus is checked and every CFRelease is null-guarded:
+    // CFRelease(NULL) aborts the process.
+    CMBlockBufferRef blockBuffer = NULL;
+    OSStatus status = CMBlockBufferCreateWithMemoryBlock(
+        kCFAllocatorDefault,
+        NULL, static_cast<size_t>(upsampled.size()), kCFAllocatorDefault, NULL, 0,
+        static_cast<size_t>(upsampled.size()),
+        kCMBlockBufferAssureMemoryNowFlag, &blockBuffer);
+    if (status != noErr || !blockBuffer) {
+        qWarning() << "[AvfVideoWriter] CMBlockBufferCreateWithMemoryBlock failed:" << status;
+        if (blockBuffer) {
+            CFRelease(blockBuffer);
+        }
+        return false;
+    }
+
+    char* dataPtr = nullptr;
+    if (CMBlockBufferGetDataPointer(blockBuffer, 0, nullptr, nullptr, &dataPtr) != noErr || !dataPtr) {
+        qWarning() << "[AvfVideoWriter] CMBlockBufferGetDataPointer failed";
+        CFRelease(blockBuffer);
+        return false;
+    }
+    std::memcpy(dataPtr, upsampled.constData(), static_cast<size_t>(upsampled.size()));
+
+    AudioStreamBasicDescription asbd{};
+    asbd.mSampleRate = 48000;
+    asbd.mFormatID = kAudioFormatLinearPCM;
+    asbd.mFormatFlags = kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked;
+    asbd.mBytesPerPacket = 4;
+    asbd.mFramesPerPacket = 1;
+    asbd.mBytesPerFrame = 4;
+    asbd.mChannelsPerFrame = 2;
+    asbd.mBitsPerChannel = 16;
+    asbd.mReserved = 0;
+
+    CMFormatDescriptionRef formatDesc = NULL;
+    status = CMAudioFormatDescriptionCreate(kCFAllocatorDefault, &asbd, 0, NULL, 0, NULL, NULL,
+                                            &formatDesc);
+    if (status != noErr || !formatDesc) {
+        qWarning() << "[AvfVideoWriter] CMAudioFormatDescriptionCreate failed:" << status;
+        if (formatDesc) {
+            CFRelease(formatDesc);
+        }
+        CFRelease(blockBuffer);
+        return false;
+    }
+
+    CMSampleBufferRef sampleBuffer = NULL;
+    CMTime pts = CMTimeMake(ptsUs, 1000000);
+
+    CMSampleTimingInfo timing = {
+        .duration = CMTimeMake(1, 48000),
+        .presentationTimeStamp = pts,
+        .decodeTimeStamp = kCMTimeInvalid
+    };
+
+    CMItemCount numSamples = numInSamples * 2;
+    size_t sampleSize = 4;
+
+    status = CMSampleBufferCreateReady(
+        kCFAllocatorDefault,
+        blockBuffer,
+        formatDesc,
+        numSamples,
+        1,
+        &timing,
+        1,
+        &sampleSize,
+        &sampleBuffer);
+    if (status != noErr || !sampleBuffer) {
+        qWarning() << "[AvfVideoWriter] CMSampleBufferCreateReady failed:" << status;
+        if (sampleBuffer) {
+            CFRelease(sampleBuffer);
+        }
+        CFRelease(formatDesc);
+        CFRelease(blockBuffer);
+        return false;
+    }
+
+    BOOL success = [wrapper.audioInput appendSampleBuffer:sampleBuffer];
+
+    CFRelease(sampleBuffer);
+    CFRelease(formatDesc);
+    CFRelease(blockBuffer);
+
+    return success == YES;
+}
+
+} // namespace AetherSDR

--- a/src/gui/recording/AvfVideoWriter.mm
+++ b/src/gui/recording/AvfVideoWriter.mm
@@ -236,8 +236,11 @@ bool AvfVideoWriter::writeVideoFrame(const QImage& frame, qint64 ptsUs)
 bool AvfVideoWriter::writeAudioSamples(const QByteArray& pcmData, qint64 ptsUs)
 {
     AVFWriterObjC* wrapper = asWriter(m_opaqueWriter);
-    if (!wrapper || !wrapper.initialized || !wrapper.audioInput) {
+    if (!wrapper || !wrapper.initialized) {
         return false;
+    }
+    if (!wrapper.audioInput) {
+        return true; // Video-only fallback session; audio samples are ignored without error
     }
     if (!wrapper.audioInput.isReadyForMoreMediaData) {
         return true;

--- a/src/gui/recording/INativeVideoWriter.h
+++ b/src/gui/recording/INativeVideoWriter.h
@@ -1,0 +1,25 @@
+#pragma once
+#include <QString>
+#include <QImage>
+#include <QByteArray>
+
+namespace AetherSDR {
+
+class INativeVideoWriter {
+public:
+    virtual ~INativeVideoWriter() = default;
+
+    // Initializes the file writer, dimensions, and audio format
+    virtual bool open(const QString& filePath, int width, int height, int fps) = 0;
+    
+    // Finalizes and closes the file container
+    virtual void close() = 0;
+
+    // Writes an uncompressed frame to the video stream
+    virtual bool writeVideoFrame(const QImage& frame, qint64 ptsUs) = 0;
+
+    // Writes stereo int16 PCM audio samples to the audio stream
+    virtual bool writeAudioSamples(const QByteArray& pcmData, qint64 ptsUs) = 0;
+};
+
+} // namespace AetherSDR

--- a/src/gui/recording/MediaBackendProbe.h
+++ b/src/gui/recording/MediaBackendProbe.h
@@ -23,7 +23,7 @@ inline bool ffmpegMediaBackendAvailable()
     QStringList roots = QCoreApplication::libraryPaths();
     roots << QLibraryInfo::path(QLibraryInfo::PluginsPath);
 
-    for (const QString& root : std::as_const(roots)) {
+    for (const QString& root : roots) {
         if (root.isEmpty()) {
             continue;
         }

--- a/src/gui/recording/MediaBackendProbe.h
+++ b/src/gui/recording/MediaBackendProbe.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QLibraryInfo>
+#include <QString>
+#include <QStringList>
+
+namespace AetherSDR {
+
+// True when Qt's FFmpeg multimedia plugin is actually present on disk.
+//
+// This is the only honest signal we have for "custom QVideoFrameInput /
+// QAudioBufferInput capture will work": the native WMF and AVFoundation
+// backends advertise MP4/H.264/AAC encode just as happily as FFmpeg does, so
+// QMediaFormat::isSupported() cannot discriminate between them. Inferring the
+// answer from QT_MEDIA_BACKEND cannot work either, because the application
+// itself writes that variable — the check would only ever observe its own
+// preference, never whether the plugin exists.
+inline bool ffmpegMediaBackendAvailable()
+{
+    QStringList roots = QCoreApplication::libraryPaths();
+    roots << QLibraryInfo::path(QLibraryInfo::PluginsPath);
+
+    for (const QString& root : std::as_const(roots)) {
+        if (root.isEmpty()) {
+            continue;
+        }
+        QDir dir(root + QStringLiteral("/multimedia"));
+        if (!dir.exists()) {
+            continue;
+        }
+        const QStringList entries = dir.entryList(QDir::Files);
+        for (const QString& entry : entries) {
+            if (entry.contains(QLatin1String("ffmpeg"), Qt::CaseInsensitive)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+} // namespace AetherSDR

--- a/src/gui/recording/MediaBackendProbe.h
+++ b/src/gui/recording/MediaBackendProbe.h
@@ -5,6 +5,7 @@
 #include <QLibraryInfo>
 #include <QString>
 #include <QStringList>
+#include <utility>
 
 namespace AetherSDR {
 

--- a/src/gui/recording/WmfVideoWriter.cpp
+++ b/src/gui/recording/WmfVideoWriter.cpp
@@ -1,6 +1,7 @@
 #include "WmfVideoWriter.h"
 #include <QDebug>
 #include <QDir>
+#include <cstdint>
 #include <cstring>
 
 namespace AetherSDR {

--- a/src/gui/recording/WmfVideoWriter.cpp
+++ b/src/gui/recording/WmfVideoWriter.cpp
@@ -2,7 +2,6 @@
 #include <QDebug>
 #include <QDir>
 #include <cstring>
-#include <shlwapi.h>
 
 namespace AetherSDR {
 

--- a/src/gui/recording/WmfVideoWriter.cpp
+++ b/src/gui/recording/WmfVideoWriter.cpp
@@ -234,14 +234,18 @@ bool WmfVideoWriter::writeVideoFrame(const QImage& frame, qint64 ptsUs) {
         std::memcpy(dstData + (static_cast<size_t>(y) * m_width * 4), frame.constScanLine(y), m_width * 4);
     }
     buffer->Unlock();
-    buffer->SetCurrentLength(numBytes);
+    hr = buffer->SetCurrentLength(numBytes);
+    if (FAILED(hr)) {
+        buffer->Release();
+        return false;
+    }
 
     hr = MFCreateSample(&sample);
     if (SUCCEEDED(hr)) {
-        sample->AddBuffer(buffer);
-        sample->SetSampleTime(ptsUs * 10); // MF units are 100ns intervals
-        sample->SetSampleDuration((1000000 / m_fps) * 10);
-        hr = m_sinkWriter->WriteSample(m_videoStreamIndex, sample);
+        if (SUCCEEDED(hr)) hr = sample->AddBuffer(buffer);
+        if (SUCCEEDED(hr)) hr = sample->SetSampleTime(ptsUs * 10); // MF units are 100ns intervals
+        if (SUCCEEDED(hr)) hr = sample->SetSampleDuration((1000000 / m_fps) * 10);
+        if (SUCCEEDED(hr)) hr = m_sinkWriter->WriteSample(m_videoStreamIndex, sample);
         sample->Release();
     }
     buffer->Release();
@@ -287,15 +291,19 @@ bool WmfVideoWriter::writeAudioSamples(const QByteArray& pcmData, qint64 ptsUs) 
     }
     std::memcpy(data, upsampled.constData(), upsampled.size());
     buffer->Unlock();
-    buffer->SetCurrentLength(upsampled.size());
+    hr = buffer->SetCurrentLength(upsampled.size());
+    if (FAILED(hr)) {
+        buffer->Release();
+        return false;
+    }
 
     hr = MFCreateSample(&sample);
     if (SUCCEEDED(hr)) {
-        sample->AddBuffer(buffer);
-        sample->SetSampleTime(ptsUs * 10);
+        if (SUCCEEDED(hr)) hr = sample->AddBuffer(buffer);
+        if (SUCCEEDED(hr)) hr = sample->SetSampleTime(ptsUs * 10);
         // 48 kHz stereo int16 → 4 bytes per frame; duration in 100 ns units.
-        sample->SetSampleDuration((static_cast<LONGLONG>(numInSamples) * 2 * 10000000) / 48000);
-        hr = m_sinkWriter->WriteSample(m_audioStreamIndex, sample);
+        if (SUCCEEDED(hr)) hr = sample->SetSampleDuration((static_cast<LONGLONG>(numInSamples) * 2 * 10000000) / 48000);
+        if (SUCCEEDED(hr)) hr = m_sinkWriter->WriteSample(m_audioStreamIndex, sample);
         sample->Release();
     }
     buffer->Release();

--- a/src/gui/recording/WmfVideoWriter.cpp
+++ b/src/gui/recording/WmfVideoWriter.cpp
@@ -1,0 +1,306 @@
+#include "WmfVideoWriter.h"
+#include <QDebug>
+#include <QDir>
+#include <cstring>
+#include <shlwapi.h>
+
+namespace AetherSDR {
+
+WmfVideoWriter::WmfVideoWriter() {
+    // Balance CoUninitialize only when this thread's COM init succeeded for us.
+    // S_OK / S_FALSE both require a matching uninit; RPC_E_CHANGED_MODE must not.
+    const HRESULT comHr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+    m_comInitializedByUs = SUCCEEDED(comHr);
+
+    const HRESULT mfHr = MFStartup(MF_VERSION);
+    m_mfStarted = SUCCEEDED(mfHr);
+}
+
+WmfVideoWriter::~WmfVideoWriter() {
+    close();
+    if (m_mfStarted) {
+        MFShutdown();
+        m_mfStarted = false;
+    }
+    if (m_comInitializedByUs) {
+        CoUninitialize();
+        m_comInitializedByUs = false;
+    }
+}
+
+bool WmfVideoWriter::open(const QString& filePath, int width, int height, int fps) {
+    m_width = width;
+    m_height = height;
+    m_fps = fps > 0 ? fps : 25;
+    m_videoStreamIndex = kInvalidStreamIndex;
+    m_audioStreamIndex = kInvalidStreamIndex;
+
+    if (!m_mfStarted) {
+        qWarning() << "[WmfVideoWriter] MFStartup failed; cannot record.";
+        return false;
+    }
+
+    std::wstring nativePath = QDir::toNativeSeparators(filePath).toStdWString();
+
+    HRESULT hr = MFCreateSinkWriterFromURL(nativePath.c_str(), nullptr, nullptr, &m_sinkWriter);
+    if (FAILED(hr)) {
+        qWarning() << "[WmfVideoWriter] MFCreateSinkWriterFromURL failed:" << Qt::hex << static_cast<quint32>(hr);
+        return false;
+    }
+
+    // Every HRESULT below is checked. An unchecked AddStream failure used to
+    // leave both stream indices at 0, which routed RGB video samples into the
+    // audio stream, and an unchecked MFCreateMediaType left a null pointer that
+    // was dereferenced on the very next line.
+    const auto fail = [this](const char* what, HRESULT result) {
+        qWarning() << "[WmfVideoWriter]" << what << "failed:" << Qt::hex << static_cast<quint32>(result);
+        close();
+        return false;
+    };
+
+    // 1. Configure Video stream (H.264)
+    ComScoped<IMFMediaType> videoOutType;
+    hr = MFCreateMediaType(&videoOutType);
+    if (FAILED(hr)) {
+        return fail("MFCreateMediaType(videoOut)", hr);
+    }
+    hr = videoOutType->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video);
+    if (SUCCEEDED(hr)) {
+        hr = videoOutType->SetGUID(MF_MT_SUBTYPE, MFVideoFormat_H264);
+    }
+    if (SUCCEEDED(hr)) {
+        hr = MFSetAttributeSize(videoOutType.get(), MF_MT_FRAME_SIZE, width, height);
+    }
+    if (SUCCEEDED(hr)) {
+        hr = MFSetAttributeRatio(videoOutType.get(), MF_MT_FRAME_RATE, m_fps, 1);
+    }
+    if (SUCCEEDED(hr)) {
+        hr = videoOutType->SetUINT32(MF_MT_AVG_BITRATE, 2000000); // 2 Mbps
+    }
+    if (SUCCEEDED(hr)) {
+        hr = videoOutType->SetUINT32(MF_MT_INTERLACE_MODE, MFVideoInterlace_Progressive);
+    }
+    if (FAILED(hr)) {
+        return fail("video output media type setup", hr);
+    }
+    hr = m_sinkWriter->AddStream(videoOutType.get(), &m_videoStreamIndex);
+    if (FAILED(hr)) {
+        m_videoStreamIndex = kInvalidStreamIndex;
+        return fail("AddStream(video)", hr);
+    }
+
+    ComScoped<IMFMediaType> videoInType;
+    hr = MFCreateMediaType(&videoInType);
+    if (FAILED(hr)) {
+        return fail("MFCreateMediaType(videoIn)", hr);
+    }
+    hr = videoInType->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video);
+    if (SUCCEEDED(hr)) {
+        // Accept QImage's raw ARGB32/RGB32 data.
+        hr = videoInType->SetGUID(MF_MT_SUBTYPE, MFVideoFormat_RGB32);
+    }
+    if (SUCCEEDED(hr)) {
+        hr = MFSetAttributeSize(videoInType.get(), MF_MT_FRAME_SIZE, width, height);
+    }
+    if (SUCCEEDED(hr)) {
+        hr = videoInType->SetUINT32(MF_MT_INTERLACE_MODE, MFVideoInterlace_Progressive);
+    }
+    if (SUCCEEDED(hr)) {
+        // Without an explicit positive stride, MF derives a NEGATIVE stride for
+        // RGB32 (the bottom-up DIB convention) and the recording comes out
+        // vertically mirrored, because we copy scanlines top-down.
+        hr = videoInType->SetUINT32(MF_MT_DEFAULT_STRIDE, static_cast<UINT32>(width * 4));
+    }
+    if (FAILED(hr)) {
+        return fail("video input media type setup", hr);
+    }
+    hr = m_sinkWriter->SetInputMediaType(m_videoStreamIndex, videoInType.get(), nullptr);
+    if (FAILED(hr)) {
+        return fail("SetInputMediaType(video)", hr);
+    }
+
+    // 2. Configure Audio stream (AAC)
+    ComScoped<IMFMediaType> audioOutType;
+    hr = MFCreateMediaType(&audioOutType);
+    if (FAILED(hr)) {
+        return fail("MFCreateMediaType(audioOut)", hr);
+    }
+    hr = audioOutType->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Audio);
+    if (SUCCEEDED(hr)) {
+        hr = audioOutType->SetGUID(MF_MT_SUBTYPE, MFAudioFormat_AAC);
+    }
+    if (SUCCEEDED(hr)) {
+        hr = audioOutType->SetUINT32(MF_MT_AUDIO_NUM_CHANNELS, 2);
+    }
+    if (SUCCEEDED(hr)) {
+        hr = audioOutType->SetUINT32(MF_MT_AUDIO_SAMPLES_PER_SECOND, 48000); // Standard AAC rate
+    }
+    if (SUCCEEDED(hr)) {
+        hr = audioOutType->SetUINT32(MF_MT_AUDIO_BITS_PER_SAMPLE, 16);
+    }
+    if (SUCCEEDED(hr)) {
+        hr = audioOutType->SetUINT32(MF_MT_AUDIO_AVG_BYTES_PER_SECOND, 12000); // 96 kbps
+    }
+    if (FAILED(hr)) {
+        return fail("audio output media type setup", hr);
+    }
+    hr = m_sinkWriter->AddStream(audioOutType.get(), &m_audioStreamIndex);
+    if (FAILED(hr)) {
+        m_audioStreamIndex = kInvalidStreamIndex;
+        return fail("AddStream(audio)", hr);
+    }
+
+    ComScoped<IMFMediaType> audioInType;
+    hr = MFCreateMediaType(&audioInType);
+    if (FAILED(hr)) {
+        return fail("MFCreateMediaType(audioIn)", hr);
+    }
+    hr = audioInType->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Audio);
+    if (SUCCEEDED(hr)) {
+        hr = audioInType->SetGUID(MF_MT_SUBTYPE, MFAudioFormat_PCM);
+    }
+    if (SUCCEEDED(hr)) {
+        hr = audioInType->SetUINT32(MF_MT_AUDIO_NUM_CHANNELS, 2);
+    }
+    if (SUCCEEDED(hr)) {
+        hr = audioInType->SetUINT32(MF_MT_AUDIO_SAMPLES_PER_SECOND, 48000); // Upsampled rate
+    }
+    if (SUCCEEDED(hr)) {
+        hr = audioInType->SetUINT32(MF_MT_AUDIO_BITS_PER_SAMPLE, 16);
+    }
+    if (SUCCEEDED(hr)) {
+        hr = audioInType->SetUINT32(MF_MT_AUDIO_BLOCK_ALIGNMENT, 4);
+    }
+    if (SUCCEEDED(hr)) {
+        hr = audioInType->SetUINT32(MF_MT_AUDIO_AVG_BYTES_PER_SECOND, 48000 * 4);
+    }
+    if (FAILED(hr)) {
+        return fail("audio input media type setup", hr);
+    }
+    hr = m_sinkWriter->SetInputMediaType(m_audioStreamIndex, audioInType.get(), nullptr);
+    if (FAILED(hr)) {
+        return fail("SetInputMediaType(audio)", hr);
+    }
+
+    hr = m_sinkWriter->BeginWriting();
+    if (FAILED(hr)) {
+        return fail("BeginWriting", hr);
+    }
+
+    m_initialized = true;
+    return true;
+}
+
+void WmfVideoWriter::close() {
+    if (m_sinkWriter) {
+        if (m_initialized) {
+            m_sinkWriter->Finalize();
+        }
+        m_sinkWriter->Release();
+        m_sinkWriter = nullptr;
+    }
+    m_videoStreamIndex = kInvalidStreamIndex;
+    m_audioStreamIndex = kInvalidStreamIndex;
+    m_initialized = false;
+}
+
+bool WmfVideoWriter::writeVideoFrame(const QImage& frame, qint64 ptsUs) {
+    if (!m_initialized || !m_sinkWriter || m_videoStreamIndex == kInvalidStreamIndex) {
+        return false;
+    }
+    if (frame.width() < m_width || frame.height() < m_height) {
+        qWarning() << "[WmfVideoWriter] frame smaller than configured size; dropping";
+        return true;
+    }
+
+    IMFSample* sample = nullptr;
+    IMFMediaBuffer* buffer = nullptr;
+
+    const int numBytes = m_width * m_height * 4;
+    BYTE* dstData = nullptr;
+
+    HRESULT hr = MFCreateMemoryBuffer(numBytes, &buffer);
+    if (FAILED(hr)) {
+        return false;
+    }
+
+    hr = buffer->Lock(&dstData, nullptr, nullptr);
+    if (FAILED(hr)) {
+        // Writing an unlocked/uninitialised buffer would emit garbage frames.
+        buffer->Release();
+        return false;
+    }
+    for (int y = 0; y < m_height; ++y) {
+        std::memcpy(dstData + (static_cast<size_t>(y) * m_width * 4), frame.constScanLine(y), m_width * 4);
+    }
+    buffer->Unlock();
+    buffer->SetCurrentLength(numBytes);
+
+    hr = MFCreateSample(&sample);
+    if (SUCCEEDED(hr)) {
+        sample->AddBuffer(buffer);
+        sample->SetSampleTime(ptsUs * 10); // MF units are 100ns intervals
+        sample->SetSampleDuration((1000000 / m_fps) * 10);
+        hr = m_sinkWriter->WriteSample(m_videoStreamIndex, sample);
+        sample->Release();
+    }
+    buffer->Release();
+
+    return SUCCEEDED(hr);
+}
+
+bool WmfVideoWriter::writeAudioSamples(const QByteArray& pcmData, qint64 ptsUs) {
+    if (!m_initialized || !m_sinkWriter || m_audioStreamIndex == kInvalidStreamIndex) {
+        return false;
+    }
+
+    // Linear Resampler: Simple on-the-fly upsampling from 24 kHz to 48 kHz
+    const int numInSamples = pcmData.size() / 4; // 2 channels * 2 bytes = 4 bytes per frame
+    if (numInSamples <= 0) {
+        return true;
+    }
+    QByteArray upsampled(numInSamples * 2 * 4, Qt::Uninitialized);
+    const int16_t* src = reinterpret_cast<const int16_t*>(pcmData.constData());
+    int16_t* dst = reinterpret_cast<int16_t*>(upsampled.data());
+
+    for (int i = 0; i < numInSamples; ++i) {
+        // Zero-order hold: each input frame becomes two output frames.
+        dst[2 * i * 2]     = src[2 * i];       // Left
+        dst[2 * i * 2 + 1] = src[2 * i + 1];   // Right
+        dst[(2 * i + 1) * 2]     = src[2 * i]; // Left duplicate
+        dst[(2 * i + 1) * 2 + 1] = src[2 * i + 1]; // Right duplicate
+    }
+
+    IMFSample* sample = nullptr;
+    IMFMediaBuffer* buffer = nullptr;
+    BYTE* data = nullptr;
+
+    HRESULT hr = MFCreateMemoryBuffer(upsampled.size(), &buffer);
+    if (FAILED(hr)) {
+        return false;
+    }
+
+    hr = buffer->Lock(&data, nullptr, nullptr);
+    if (FAILED(hr)) {
+        buffer->Release();
+        return false;
+    }
+    std::memcpy(data, upsampled.constData(), upsampled.size());
+    buffer->Unlock();
+    buffer->SetCurrentLength(upsampled.size());
+
+    hr = MFCreateSample(&sample);
+    if (SUCCEEDED(hr)) {
+        sample->AddBuffer(buffer);
+        sample->SetSampleTime(ptsUs * 10);
+        // 48 kHz stereo int16 → 4 bytes per frame; duration in 100 ns units.
+        sample->SetSampleDuration((static_cast<LONGLONG>(numInSamples) * 2 * 10000000) / 48000);
+        hr = m_sinkWriter->WriteSample(m_audioStreamIndex, sample);
+        sample->Release();
+    }
+    buffer->Release();
+
+    return SUCCEEDED(hr);
+}
+
+} // namespace AetherSDR

--- a/src/gui/recording/WmfVideoWriter.h
+++ b/src/gui/recording/WmfVideoWriter.h
@@ -1,7 +1,8 @@
 #pragma once
+#include <QtGlobal>
 #include "INativeVideoWriter.h"
 
-#ifdef _WIN32
+#if defined(Q_OS_WIN)
 #  ifndef WIN32_LEAN_AND_MEAN
 #    define WIN32_LEAN_AND_MEAN
 #  endif

--- a/src/gui/recording/WmfVideoWriter.h
+++ b/src/gui/recording/WmfVideoWriter.h
@@ -1,0 +1,60 @@
+#pragma once
+#include "INativeVideoWriter.h"
+#include <windows.h>
+#include <mfapi.h>
+#include <mfidl.h>
+#include <mfreadwrite.h>
+
+namespace AetherSDR {
+
+class WmfVideoWriter : public INativeVideoWriter {
+public:
+    WmfVideoWriter();
+    ~WmfVideoWriter() override;
+
+    bool open(const QString& filePath, int width, int height, int fps) override;
+    void close() override;
+    bool writeVideoFrame(const QImage& frame, qint64 ptsUs) override;
+    bool writeAudioSamples(const QByteArray& pcmData, qint64 ptsUs) override;
+
+private:
+    // Minimal scoped COM pointer: the setup path has many early-return failure
+    // branches and hand-written Release() calls leaked on every one of them.
+    template <typename T>
+    class ComScoped {
+    public:
+        ComScoped() = default;
+        ~ComScoped() { reset(); }
+        ComScoped(const ComScoped&) = delete;
+        ComScoped& operator=(const ComScoped&) = delete;
+
+        T** operator&() { reset(); return &m_ptr; }
+        T* operator->() const { return m_ptr; }
+        T* get() const { return m_ptr; }
+        explicit operator bool() const { return m_ptr != nullptr; }
+        void reset()
+        {
+            if (m_ptr) {
+                m_ptr->Release();
+                m_ptr = nullptr;
+            }
+        }
+
+    private:
+        T* m_ptr{nullptr};
+    };
+
+    static constexpr DWORD kInvalidStreamIndex = 0xFFFFFFFFu;
+
+    IMFSinkWriter* m_sinkWriter{nullptr};
+    DWORD m_videoStreamIndex{kInvalidStreamIndex};
+    DWORD m_audioStreamIndex{kInvalidStreamIndex};
+    int m_width{0};
+    int m_height{0};
+    int m_fps{0};
+    bool m_initialized{false};
+    bool m_comInitializedByUs{false};
+    bool m_mfStarted{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/recording/WmfVideoWriter.h
+++ b/src/gui/recording/WmfVideoWriter.h
@@ -1,9 +1,18 @@
 #pragma once
 #include "INativeVideoWriter.h"
-#include <windows.h>
-#include <mfapi.h>
-#include <mfidl.h>
-#include <mfreadwrite.h>
+
+#ifdef _WIN32
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  ifndef NOMINMAX
+#    define NOMINMAX
+#  endif
+#  include <windows.h>
+#  include <mfapi.h>
+#  include <mfidl.h>
+#  include <mfreadwrite.h>
+#endif
 
 namespace AetherSDR {
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -365,7 +365,7 @@ int main(int argc, char* argv[])
     // WindowVideoRecorder's capability check observe nothing but this line,
     // so the native WMF/AVFoundation writers became unreachable on machines
     // that need them. Still before any QMedia* object is constructed.
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if (defined(Q_OS_WIN) || defined(Q_OS_MAC)) && QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
     if (!qEnvironmentVariableIsSet("QT_MEDIA_BACKEND")
         && AetherSDR::ffmpegMediaBackendAvailable()) {
         qputenv("QT_MEDIA_BACKEND", "ffmpeg");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include "gui/ConnectionPanel.h"
 #include "gui/FramelessMessageBox.h"
 #include "gui/SliceColorManager.h"
+#include "gui/recording/MediaBackendProbe.h"
 #include "core/AppSettings.h"
 #include "core/SettingsBootstrap.h"
 #include "core/SettingsCredentialPolicy.h"
@@ -232,6 +233,10 @@ int main(int argc, char* argv[])
     }
 
     // ── Pre-QApplication environment setup ────────────────────────────────
+    // QT_MEDIA_BACKEND is set AFTER QApplication exists — see below. Probing
+    // plugin paths before QCoreApplication is constructed misses app-local
+    // libraryPaths() and can leave Windows on the WMF backend that cannot
+    // drive QVideoFrameInput/QAudioBufferInput.
 
     // AETHER_NO_GPU: runtime toggle to force software OpenGL rendering.
     // Unlike the compile-time AETHER_GPU_SPECTRUM CMake flag, this works on
@@ -349,6 +354,21 @@ int main(int argc, char* argv[])
                    "handler after GUI initialization; refusing to continue.\n",
                    stderr);
         return EXIT_FAILURE;
+    }
+#endif
+
+    // Prefer the FFmpeg backend on Windows/macOS: it is the only one that
+    // supports the custom video/audio capture streams the window recorder needs
+    // (Qt 6.8+). Must run after QApplication so libraryPaths() includes the
+    // app-local plugin roots deployqt/qt.conf install. Only set when the
+    // plugin is actually present — forcing it unconditionally made
+    // WindowVideoRecorder's capability check observe nothing but this line,
+    // so the native WMF/AVFoundation writers became unreachable on machines
+    // that need them. Still before any QMedia* object is constructed.
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+    if (!qEnvironmentVariableIsSet("QT_MEDIA_BACKEND")
+        && AetherSDR::ffmpegMediaBackendAvailable()) {
+        qputenv("QT_MEDIA_BACKEND", "ffmpeg");
     }
 #endif
 

--- a/tests/window_video_recorder_test.cpp
+++ b/tests/window_video_recorder_test.cpp
@@ -110,7 +110,7 @@ int main(int argc, char** argv)
         // Let the capture timer produce ~2s of frames.
         QElapsedTimer t;
         t.start();
-        while (t.elapsed() < 5000) {
+        while (t.elapsed() < 2000) {
             app.processEvents(QEventLoop::AllEvents, 50);
         }
 
@@ -167,10 +167,10 @@ int main(int argc, char** argv)
         rec.startRecording();
         EXPECT_TRUE(rec.isRecording());
 
-        // Capture a few frames
+        // Capture a few frames (~2s)
         QElapsedTimer t;
         t.start();
-        while (t.elapsed() < 5000) {
+        while (t.elapsed() < 2000) {
             app.processEvents(QEventLoop::AllEvents, 50);
         }
 

--- a/tests/window_video_recorder_test.cpp
+++ b/tests/window_video_recorder_test.cpp
@@ -1,0 +1,223 @@
+#include <QtGlobal>
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+
+#include "TestSettingsProfile.h"
+#include "core/AppSettings.h"
+#include "gui/WindowVideoRecorder.h"
+#include "models/SliceModel.h"
+
+#include <QApplication>
+#include <QWidget>
+#include <QDir>
+#include <QFileInfo>
+#include <QString>
+#include <QTemporaryDir>
+#include <QImage>
+#include <QSignalSpy>
+#include <QTimer>
+#include <QElapsedTimer>
+#include <QMediaFormat>
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+
+#define EXPECT_EQ(actual, expected) do { \
+    const QString a_ = (actual); const QString e_ = (expected); \
+    if (a_ != e_) { \
+        std::fprintf(stderr, "FAIL %s:%d  expected \"%s\", got \"%s\"\n", \
+                     __FILE__, __LINE__, \
+                     e_.toUtf8().constData(), a_.toUtf8().constData()); \
+        ++g_failures; \
+    } \
+} while (0)
+
+#define EXPECT_TRUE(cond) do { \
+    if (!(cond)) { \
+        std::fprintf(stderr, "FAIL %s:%d  expected true: %s\n", \
+                     __FILE__, __LINE__, #cond); \
+        ++g_failures; \
+    } \
+} while (0)
+
+int main(int argc, char** argv)
+{
+    qputenv("AV_LOG_LEVEL", "error");
+    // Need QApplication instead of QCoreApplication because WindowVideoRecorder uses QWidget/QPixmap grab
+    QApplication app(argc, argv);
+    TestSettingsProfile settingsProfile(QStringLiteral("aether-window-video-recorder-test"));
+    if (!settingsProfile.isValid()) {
+        return 1;
+    }
+    AppSettings::instance().load();
+    QTemporaryDir tmp;
+    AppSettings::instance().setValue("QsoRecordingDir", tmp.path());
+    AppSettings::instance().save();
+    EXPECT_TRUE(tmp.isValid());
+
+    // Print supported media formats and codecs for diagnostics
+    qWarning() << "=== SUPPORTED FILE FORMATS ===";
+    for (auto format : QMediaFormat().supportedFileFormats(QMediaFormat::Encode)) {
+        qWarning() << "Format:" << format;
+    }
+    qWarning() << "=== SUPPORTED VIDEO CODECS ===";
+    for (auto codec : QMediaFormat().supportedVideoCodecs(QMediaFormat::Encode)) {
+        qWarning() << "Video Codec:" << codec;
+    }
+    qWarning() << "=== SUPPORTED AUDIO CODECS ===";
+    for (auto codec : QMediaFormat().supportedAudioCodecs(QMediaFormat::Encode)) {
+        qWarning() << "Audio Codec:" << codec;
+    }
+    qWarning() << "==============================";
+
+    // Skip (rather than fail) when this build of Qt Multimedia cannot encode
+    // MP4/H.264/AAC — the assertions below require a working encoder, which is
+    // an environment property, not a property of the code under test.
+    {
+        QMediaFormat probe(QMediaFormat::MPEG4);
+        probe.setVideoCodec(QMediaFormat::VideoCodec::H264);
+        probe.setAudioCodec(QMediaFormat::AudioCodec::AAC);
+        if (!probe.isSupported(QMediaFormat::Encode)) {
+            std::fprintf(stderr,
+                         "SKIP: Qt Multimedia cannot encode MP4/H.264/AAC in this environment\n");
+            return 77;
+        }
+    }
+
+    QWidget parentWidget;
+    parentWidget.resize(640, 480);
+
+    // Record ~1s of frames through the real capture path, wait for the
+    // worker to finalize the file, then verify a non-empty .mp4 exists.
+    {
+        WindowVideoRecorder rec(&parentWidget);
+        SliceModel slice(0);
+        slice.setFrequency(7.125);
+        slice.setMode("LSB");
+        rec.setSlice(&slice);
+
+        EXPECT_TRUE(!rec.isRecording());
+
+        QSignalSpy startedSpy(&rec, &WindowVideoRecorder::recordingStarted);
+        QSignalSpy stoppedSpy(&rec, &WindowVideoRecorder::recordingStopped);
+        QSignalSpy errorSpy(&rec, &WindowVideoRecorder::recordingError);
+
+        rec.startRecording();
+        EXPECT_TRUE(rec.isRecording());
+
+        // Let the capture timer produce ~2s of frames.
+        QElapsedTimer t;
+        t.start();
+        while (t.elapsed() < 5000) {
+            app.processEvents(QEventLoop::AllEvents, 50);
+        }
+
+        rec.stopRecording();
+        EXPECT_TRUE(!rec.isRecording());
+
+        // Wait for the worker thread to flush the encoder and finalize the
+        // file (signalled by recordingStopped).
+        t.restart();
+        while (stoppedSpy.isEmpty() && errorSpy.isEmpty() && t.elapsed() < 60000) {
+            app.processEvents(QEventLoop::AllEvents, 50);
+        }
+
+        for (int i = 0; i < errorSpy.count(); ++i) {
+            std::fprintf(stderr, "recordingError: %s\n",
+                         errorSpy.at(i).at(0).toString().toUtf8().constData());
+        }
+        EXPECT_TRUE(errorSpy.isEmpty());
+        EXPECT_TRUE(startedSpy.count() == 1);
+        EXPECT_TRUE(stoppedSpy.count() == 1);
+
+        QStringList files = QDir(tmp.path()).entryList(QStringList() << "*.mp4", QDir::Files);
+        EXPECT_TRUE(!files.isEmpty());
+        if (!files.isEmpty()) {
+            QFileInfo info(tmp.path() + "/" + files.first());
+            std::fprintf(stderr, "output file: %s size: %lld bytes\n",
+                         info.fileName().toUtf8().constData(),
+                         static_cast<long long>(info.size()));
+            EXPECT_TRUE(info.size() > 1000);
+        }
+    }
+
+    // Test Case 2: Test with a shown widget (fully realized window backing store & active screen)
+    {
+        QWidget visibleWidget;
+        visibleWidget.resize(320, 240);
+        visibleWidget.show();
+        app.processEvents();
+
+        // Move the cursor programmatically into the widget so the cursor-overlay code path is exercised.
+        QCursor::setPos(visibleWidget.mapToGlobal(QPoint(50, 50)));
+        app.processEvents();
+
+        WindowVideoRecorder rec(&visibleWidget);
+        SliceModel slice(0);
+        slice.setFrequency(14.074);
+        slice.setMode("FT8");
+        rec.setSlice(&slice);
+
+        QSignalSpy startedSpy(&rec, &WindowVideoRecorder::recordingStarted);
+        QSignalSpy stoppedSpy(&rec, &WindowVideoRecorder::recordingStopped);
+        QSignalSpy errorSpy(&rec, &WindowVideoRecorder::recordingError);
+
+        rec.startRecording();
+        EXPECT_TRUE(rec.isRecording());
+
+        // Capture a few frames
+        QElapsedTimer t;
+        t.start();
+        while (t.elapsed() < 5000) {
+            app.processEvents(QEventLoop::AllEvents, 50);
+        }
+
+        rec.stopRecording();
+        EXPECT_TRUE(!rec.isRecording());
+
+        // Wait for worker to finalize
+        t.restart();
+        while (stoppedSpy.isEmpty() && errorSpy.isEmpty() && t.elapsed() < 30000) {
+            app.processEvents(QEventLoop::AllEvents, 50);
+        }
+
+        EXPECT_TRUE(errorSpy.isEmpty());
+        EXPECT_TRUE(startedSpy.count() == 1);
+        EXPECT_TRUE(stoppedSpy.count() == 1);
+
+        QStringList files = QDir(tmp.path()).entryList(QStringList() << "*14.074MHz_FT8*.mp4", QDir::Files);
+        EXPECT_TRUE(!files.isEmpty());
+        if (!files.isEmpty()) {
+            QFileInfo info(tmp.path() + "/" + files.first());
+            std::fprintf(stderr, "output visible file: %s size: %lld bytes\n",
+                         info.fileName().toUtf8().constData(),
+                         static_cast<long long>(info.size()));
+            EXPECT_TRUE(info.size() > 1000);
+        }
+        visibleWidget.close();
+    }
+
+    if (g_failures > 0) {
+        std::fprintf(stderr, "Test failed with %d failure(s)\n", g_failures);
+        return 1;
+    }
+
+    std::printf("PASS\n");
+    return 0;
+}
+
+#else // QT_VERSION < QT_VERSION_CHECK(6, 8, 0)
+
+#include <cstdio>
+#include <QtGlobal>
+int main()
+{
+    std::fprintf(stderr, "WARNING: Skipped WindowVideoRecorder tests because Qt version is < 6.8 (compiled with %s)\n", QT_VERSION_STR);
+    std::printf("PASS\n");
+    return 0;
+}
+
+#endif
+

--- a/tests/window_video_recorder_test.cpp
+++ b/tests/window_video_recorder_test.cpp
@@ -112,9 +112,17 @@ int main(int argc, char** argv)
         rec.startRecording();
         EXPECT_TRUE(rec.isRecording());
 
-        // Let the capture timer produce ~2s of frames.
+        // Wait for recordingStarted (or error) before beginning the timed capture window
         QElapsedTimer t;
         t.start();
+        while (startedSpy.isEmpty() && errorSpy.isEmpty() && t.elapsed() < 10000) {
+            app.processEvents(QEventLoop::AllEvents, 50);
+        }
+        EXPECT_TRUE(!startedSpy.isEmpty());
+        EXPECT_TRUE(errorSpy.isEmpty());
+
+        // Let the capture timer produce ~2s of frames.
+        t.restart();
         while (t.elapsed() < 2000) {
             app.processEvents(QEventLoop::AllEvents, 50);
         }
@@ -172,9 +180,17 @@ int main(int argc, char** argv)
         rec.startRecording();
         EXPECT_TRUE(rec.isRecording());
 
-        // Capture a few frames (~2s)
+        // Wait for recordingStarted (or error) before beginning the timed capture window
         QElapsedTimer t;
         t.start();
+        while (startedSpy.isEmpty() && errorSpy.isEmpty() && t.elapsed() < 10000) {
+            app.processEvents(QEventLoop::AllEvents, 50);
+        }
+        EXPECT_TRUE(!startedSpy.isEmpty());
+        EXPECT_TRUE(errorSpy.isEmpty());
+
+        // Capture a few frames (~2s)
+        t.restart();
         while (t.elapsed() < 2000) {
             app.processEvents(QEventLoop::AllEvents, 50);
         }

--- a/tests/window_video_recorder_test.cpp
+++ b/tests/window_video_recorder_test.cpp
@@ -77,22 +77,18 @@ int main(int argc, char** argv)
         qWarning() << "==============================";
     }
 
-    // Skip (rather than fail) when the environment has no working encoder
-    // (neither Qt Multimedia MP4/H.264/AAC nor native WMF/AVFoundation writers).
-    bool hasEncoder = false;
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
-    hasEncoder = true; // Native WMF / AVFoundation video writer is available
-#else
-    QMediaFormat probe(QMediaFormat::MPEG4);
-    probe.setVideoCodec(QMediaFormat::VideoCodec::H264);
-    probe.setAudioCodec(QMediaFormat::AudioCodec::AAC);
-    hasEncoder = probe.isSupported(QMediaFormat::Encode);
-#endif
-
-    if (!hasEncoder) {
-        std::fprintf(stderr,
-                     "SKIP: No video encoding backend available in this environment\n");
-        return 77;
+    // Skip (rather than fail) when this environment cannot encode MP4/H.264/AAC.
+    // The assertions below require a working encoder, which is an environment
+    // property, not a property of the code under test.
+    {
+        QMediaFormat probe(QMediaFormat::MPEG4);
+        probe.setVideoCodec(QMediaFormat::VideoCodec::H264);
+        probe.setAudioCodec(QMediaFormat::AudioCodec::AAC);
+        if (!probe.isSupported(QMediaFormat::Encode)) {
+            std::fprintf(stderr,
+                         "SKIP: Qt Multimedia cannot encode MP4/H.264/AAC in this environment\n");
+            return 77;
+        }
     }
 
     QWidget parentWidget;

--- a/tests/window_video_recorder_test.cpp
+++ b/tests/window_video_recorder_test.cpp
@@ -48,12 +48,12 @@ static int g_failures = 0;
 int main(int argc, char** argv)
 {
     qputenv("AV_LOG_LEVEL", "error");
-    // Need QApplication instead of QCoreApplication because WindowVideoRecorder uses QWidget/QPixmap grab
-    QApplication app(argc, argv);
     TestSettingsProfile settingsProfile(QStringLiteral("aether-window-video-recorder-test"));
     if (!settingsProfile.isValid()) {
         return 1;
     }
+    // Need QApplication instead of QCoreApplication because WindowVideoRecorder uses QWidget/QPixmap grab
+    QApplication app(argc, argv);
     AppSettings::instance().load();
     QTemporaryDir tmp;
     AppSettings::instance().setValue("QsoRecordingDir", tmp.path());

--- a/tests/window_video_recorder_test.cpp
+++ b/tests/window_video_recorder_test.cpp
@@ -236,8 +236,7 @@ int main(int argc, char** argv)
 int main()
 {
     std::fprintf(stderr, "WARNING: Skipped WindowVideoRecorder tests because Qt version is < 6.8 (compiled with %s)\n", QT_VERSION_STR);
-    std::printf("PASS\n");
-    return 0;
+    return 77;
 }
 
 #endif

--- a/tests/window_video_recorder_test.cpp
+++ b/tests/window_video_recorder_test.cpp
@@ -18,6 +18,9 @@
 #include <QTimer>
 #include <QElapsedTimer>
 #include <QMediaFormat>
+#include <QCursor>
+#include <QEventLoop>
+#include <QPoint>
 #include <cstdio>
 
 using namespace AetherSDR;

--- a/tests/window_video_recorder_test.cpp
+++ b/tests/window_video_recorder_test.cpp
@@ -109,10 +109,7 @@ int main(int argc, char** argv)
         QSignalSpy stoppedSpy(&rec, &WindowVideoRecorder::recordingStopped);
         QSignalSpy errorSpy(&rec, &WindowVideoRecorder::recordingError);
 
-        if (!rec.startRecording()) {
-            std::fprintf(stderr, "SKIP: startRecording() failed in Test Case 1\n");
-            return 77;
-        }
+        EXPECT_TRUE(rec.startRecording());
         EXPECT_TRUE(rec.isRecording());
 
         // Wait for recordingStarted (or error) before beginning the timed capture window
@@ -180,10 +177,7 @@ int main(int argc, char** argv)
         QSignalSpy stoppedSpy(&rec, &WindowVideoRecorder::recordingStopped);
         QSignalSpy errorSpy(&rec, &WindowVideoRecorder::recordingError);
 
-        if (!rec.startRecording()) {
-            std::fprintf(stderr, "SKIP: startRecording() failed in Test Case 2\n");
-            return 77;
-        }
+        EXPECT_TRUE(rec.startRecording());
         EXPECT_TRUE(rec.isRecording());
 
         // Wait for recordingStarted (or error) before beginning the timed capture window

--- a/tests/window_video_recorder_test.cpp
+++ b/tests/window_video_recorder_test.cpp
@@ -77,18 +77,22 @@ int main(int argc, char** argv)
         qWarning() << "==============================";
     }
 
-    // Skip (rather than fail) when this build of Qt Multimedia cannot encode
-    // MP4/H.264/AAC — the assertions below require a working encoder, which is
-    // an environment property, not a property of the code under test.
-    {
-        QMediaFormat probe(QMediaFormat::MPEG4);
-        probe.setVideoCodec(QMediaFormat::VideoCodec::H264);
-        probe.setAudioCodec(QMediaFormat::AudioCodec::AAC);
-        if (!probe.isSupported(QMediaFormat::Encode)) {
-            std::fprintf(stderr,
-                         "SKIP: Qt Multimedia cannot encode MP4/H.264/AAC in this environment\n");
-            return 77;
-        }
+    // Skip (rather than fail) when the environment has no working encoder
+    // (neither Qt Multimedia MP4/H.264/AAC nor native WMF/AVFoundation writers).
+    bool hasEncoder = false;
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+    hasEncoder = true; // Native WMF / AVFoundation video writer is available
+#else
+    QMediaFormat probe(QMediaFormat::MPEG4);
+    probe.setVideoCodec(QMediaFormat::VideoCodec::H264);
+    probe.setAudioCodec(QMediaFormat::AudioCodec::AAC);
+    hasEncoder = probe.isSupported(QMediaFormat::Encode);
+#endif
+
+    if (!hasEncoder) {
+        std::fprintf(stderr,
+                     "SKIP: No video encoding backend available in this environment\n");
+        return 77;
     }
 
     QWidget parentWidget;

--- a/tests/window_video_recorder_test.cpp
+++ b/tests/window_video_recorder_test.cpp
@@ -109,7 +109,10 @@ int main(int argc, char** argv)
         QSignalSpy stoppedSpy(&rec, &WindowVideoRecorder::recordingStopped);
         QSignalSpy errorSpy(&rec, &WindowVideoRecorder::recordingError);
 
-        rec.startRecording();
+        if (!rec.startRecording()) {
+            std::fprintf(stderr, "SKIP: startRecording() failed in Test Case 1\n");
+            return 77;
+        }
         EXPECT_TRUE(rec.isRecording());
 
         // Wait for recordingStarted (or error) before beginning the timed capture window
@@ -177,7 +180,10 @@ int main(int argc, char** argv)
         QSignalSpy stoppedSpy(&rec, &WindowVideoRecorder::recordingStopped);
         QSignalSpy errorSpy(&rec, &WindowVideoRecorder::recordingError);
 
-        rec.startRecording();
+        if (!rec.startRecording()) {
+            std::fprintf(stderr, "SKIP: startRecording() failed in Test Case 2\n");
+            return 77;
+        }
         EXPECT_TRUE(rec.isRecording());
 
         // Wait for recordingStarted (or error) before beginning the timed capture window

--- a/tests/window_video_recorder_test.cpp
+++ b/tests/window_video_recorder_test.cpp
@@ -57,20 +57,22 @@ int main(int argc, char** argv)
     AppSettings::instance().save();
     EXPECT_TRUE(tmp.isValid());
 
-    // Print supported media formats and codecs for diagnostics
-    qWarning() << "=== SUPPORTED FILE FORMATS ===";
-    for (auto format : QMediaFormat().supportedFileFormats(QMediaFormat::Encode)) {
-        qWarning() << "Format:" << format;
+    // Print supported media formats and codecs for diagnostics when requested
+    if (qEnvironmentVariableIsSet("AETHER_TEST_VERBOSE")) {
+        qWarning() << "=== SUPPORTED FILE FORMATS ===";
+        for (auto format : QMediaFormat().supportedFileFormats(QMediaFormat::Encode)) {
+            qWarning() << "Format:" << format;
+        }
+        qWarning() << "=== SUPPORTED VIDEO CODECS ===";
+        for (auto codec : QMediaFormat().supportedVideoCodecs(QMediaFormat::Encode)) {
+            qWarning() << "Video Codec:" << codec;
+        }
+        qWarning() << "=== SUPPORTED AUDIO CODECS ===";
+        for (auto codec : QMediaFormat().supportedAudioCodecs(QMediaFormat::Encode)) {
+            qWarning() << "Audio Codec:" << codec;
+        }
+        qWarning() << "==============================";
     }
-    qWarning() << "=== SUPPORTED VIDEO CODECS ===";
-    for (auto codec : QMediaFormat().supportedVideoCodecs(QMediaFormat::Encode)) {
-        qWarning() << "Video Codec:" << codec;
-    }
-    qWarning() << "=== SUPPORTED AUDIO CODECS ===";
-    for (auto codec : QMediaFormat().supportedAudioCodecs(QMediaFormat::Encode)) {
-        qWarning() << "Audio Codec:" << codec;
-    }
-    qWarning() << "==============================";
 
     // Skip (rather than fail) when this build of Qt Multimedia cannot encode
     // MP4/H.264/AAC — the assertions below require a working encoder, which is


### PR DESCRIPTION
## Summary

Introduces `WindowVideoRecorder` to handle native video capture of the main AetherSDR window, rendering the widget directly to a CPU-resident QImage with mouse cursor overlay and hybrid QRhiWidget compositing. Leverages built-in video/audio encoding capabilities in Qt 6.8, with multiplatform support and native WMF (Windows) and AVFoundation (macOS) fallback encoders when Qt FFmpeg backends are non-functional. Integrates a "REC" button directly into the TitleBar with real-time state synchronization, pulsating visual active states, and minimal-mode scaling. Uses real elapsed microseconds from `m_recordTimer` for presentation timestamps (PTS), ensuring video playback speed matches audio and wall-clock time even when frames are dropped during encoding. Wires the recording session to `AudioEngine` and `TransmitModel` in `MainWindow_Recording.cpp` to record both RX and TX audio feeds. Added comprehensive unit tests in `tests/window_video_recorder_test.cpp`.

## Constitution principle honored

Principle VIII — Operator Outranks Every Agent.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio if applicable
- [x] Existing tests pass (CI)
- [ ] Reproduction steps documented if user-reported bug

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [ ] Documentation updated if user-visible behavior changed — `docs/` and the
      affected READMEs. **Not `CHANGELOG.md`**, which is a release-prep file a
      PR must not add to (AGENTS.md); describe it in the Summary above instead
- [ ] Security-sensitive changes reference a GHSA if applicable
