### PR TITLE
Fix blank Windows panadapters under software OpenGL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3763,6 +3763,13 @@ target_include_directories(spectrum_preview_logic_test PRIVATE src)
 target_link_libraries(spectrum_preview_logic_test PRIVATE Qt6::Core)
 add_test(NAME spectrum_preview_logic_test COMMAND spectrum_preview_logic_test)
 
+add_executable(software_opengl_request_test
+    tests/software_opengl_request_test.cpp
+)
+target_include_directories(software_opengl_request_test PRIVATE src)
+target_link_libraries(software_opengl_request_test PRIVATE Qt6::Core)
+add_test(NAME software_opengl_request_test COMMAND software_opengl_request_test)
+
 # Kiwi-display recenter write policy — pins that tune-driven recenters on a
 # kiwi-display pan stay widget-local (never pairing a new center with the
 # frozen PanadapterModel bandwidth, which snapped the zoom back to the

--- a/src/gui/SoftwareOpenGlRequest.h
+++ b/src/gui/SoftwareOpenGlRequest.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <QString>
+
+namespace AetherSDR {
+
+// AETHER_NO_GPU is the documented runtime escape hatch. QT_OPENGL=software
+// may also be inherited from the launcher, so every QRhiWidget in a top-level
+// window must make the same backend choice for either request.
+inline bool softwareOpenGlRequested()
+{
+    return qEnvironmentVariableIsSet("AETHER_NO_GPU")
+        || qEnvironmentVariable("QT_OPENGL").compare(
+               QStringLiteral("software"), Qt::CaseInsensitive) == 0;
+}
+
+} // namespace AetherSDR

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -6,6 +6,7 @@
 #include "NativeWidgetTopology.h"
 #include "PanadapterRenderScheduler.h"
 #include "PanadapterMessageOverlay.h"
+#include "SoftwareOpenGlRequest.h"
 #include "SpectrumOverlayMenu.h"
 #include "VfoWidget.h"
 #include "DisplaySettings.h"
@@ -874,13 +875,6 @@ static QRgb interpolateGradient(float t, const WfGradientStop* stops, int n)
 }
 
 #ifdef AETHER_GPU_SPECTRUM
-static bool qtSoftwareOpenGlRequested()
-{
-    return qEnvironmentVariableIsSet("AETHER_NO_GPU")
-        || qEnvironmentVariable("QT_OPENGL").compare(
-            QStringLiteral("software"), Qt::CaseInsensitive) == 0;
-}
-
 static bool qrhiDeviceNameLooksSoftware(const QString& deviceName)
 {
     const QString lower = deviceName.toLower();
@@ -905,7 +899,7 @@ QString SpectrumWidget::rendererDescription() const
     const QRhiDriverInfo driverInfo = currentRhi->driverInfo();
     const QString deviceName = QString::fromUtf8(driverInfo.deviceName).trimmed();
     const bool softwareOpenGl = currentRhi->backend() == QRhi::OpenGLES2
-        && qtSoftwareOpenGlRequested();
+        && softwareOpenGlRequested();
     const bool cpuDevice = driverInfo.deviceType == QRhiDriverInfo::CpuDevice
         || softwareOpenGl
         || qrhiDeviceNameLooksSoftware(deviceName);
@@ -1896,7 +1890,7 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     // QT_OPENGL entirely, making the flag a silent no-op there (#3597). On Linux
     // the default backend is already OpenGL, so this is a harmless explicit
     // restatement that keeps the two platforms on the same code path.
-    if (qtSoftwareOpenGlRequested()) {
+    if (softwareOpenGlRequested()) {
         setApi(QRhiWidget::Api::OpenGL);
         qInfo() << "SpectrumWidget: AETHER_NO_GPU/QT_OPENGL=software — forcing "
                    "OpenGL QRhi backend (software rasterizer) instead of D3D11";

--- a/src/gui/WaveformWidget.cpp
+++ b/src/gui/WaveformWidget.cpp
@@ -2,6 +2,7 @@
 
 #include "InteractionSettings.h"
 #include "NativeWidgetTopology.h"
+#include "SoftwareOpenGlRequest.h"
 #include "core/AppSettings.h"
 
 #include <QApplication>
@@ -111,6 +112,10 @@ WaveformWidget::WaveformWidget(Profile profile, QWidget* parent)
     // the waveform composited into its ancestor backing store so resize,
     // scrolling, and clipping remain QWidget-owned.
     setApi(QRhiWidget::Api::Metal);
+#elif defined(AETHER_GPU_SPECTRUM)
+    if (softwareOpenGlRequested()) {
+        setApi(QRhiWidget::Api::OpenGL);
+    }
 #endif
     setToolTip("Click to pause/resume waveform capture; double-click for WAVE settings");
     setObjectName(profile == Profile::Strip ? QStringLiteral("stripWaveformScope")

--- a/tests/software_opengl_request_test.cpp
+++ b/tests/software_opengl_request_test.cpp
@@ -1,0 +1,73 @@
+#include "gui/SoftwareOpenGlRequest.h"
+
+#include <QByteArray>
+
+#include <cstdio>
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* message)
+{
+    std::printf("[%s] %s\n", condition ? " OK " : "FAIL", message);
+    if (!condition) {
+        ++g_failures;
+    }
+}
+
+class EnvironmentRestore {
+public:
+    explicit EnvironmentRestore(const char* name)
+        : m_name(name)
+        , m_wasSet(qEnvironmentVariableIsSet(name))
+        , m_value(qgetenv(name))
+    {
+    }
+
+    ~EnvironmentRestore()
+    {
+        if (m_wasSet) {
+            qputenv(m_name, m_value);
+        } else {
+            qunsetenv(m_name);
+        }
+    }
+
+private:
+    const char* m_name;
+    bool m_wasSet;
+    QByteArray m_value;
+};
+
+} // namespace
+
+int main()
+{
+    EnvironmentRestore restoreNoGpu("AETHER_NO_GPU");
+    EnvironmentRestore restoreQtOpenGl("QT_OPENGL");
+
+    qunsetenv("AETHER_NO_GPU");
+    qunsetenv("QT_OPENGL");
+    check(!AetherSDR::softwareOpenGlRequested(),
+          "unset environment keeps the default renderer");
+
+    qputenv("AETHER_NO_GPU", "1");
+    check(AetherSDR::softwareOpenGlRequested(),
+          "AETHER_NO_GPU requests software OpenGL");
+
+    qunsetenv("AETHER_NO_GPU");
+    qputenv("QT_OPENGL", "software");
+    check(AetherSDR::softwareOpenGlRequested(),
+          "QT_OPENGL=software requests software OpenGL");
+
+    qputenv("QT_OPENGL", "SoFtWaRe");
+    check(AetherSDR::softwareOpenGlRequested(),
+          "QT_OPENGL software comparison is case-insensitive");
+
+    qputenv("QT_OPENGL", "desktop");
+    check(!AetherSDR::softwareOpenGlRequested(),
+          "other QT_OPENGL values keep the default renderer");
+
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- make every `QRhiWidget` in the main window honor the same software-OpenGL request
- share the `AETHER_NO_GPU` / `QT_OPENGL=software` predicate between the spectrum and WAVE renderers
- add a focused regression test for the environment policy

Fixes #4745.

## Root cause

The reporter's v26.8.1 support log shows the panadapter selecting OpenGL because `AETHER_NO_GPU` or `QT_OPENGL=software` was present, while the hidden WAVE scope had already selected D3D11 for the same top-level window. Qt rejects mixed QRhi APIs in one backing store, producing 13,804 `QRhiWidget: No QRhi` messages and leaving every panadapter transparent.

The reporter had previously been instructed in #3944 to persist `AETHER_NO_GPU=1` with `setx` while diagnosing an unrelated multi-pan startup crash. That explains why the override was present; it does not mean the system lacked functioning graphics hardware (the earlier v26.7.1 log initialized D3D11 successfully).

The interaction began when #3955 converted the always-constructed WAVE scope to `QRhiWidget`; #3987 later forced only `SpectrumWidget` to OpenGL for the software-rendering escape hatch. #3987 is therefore the proximate regression, with #3955 as the prerequisite. #4709 is related observability work, not the cause; #4705 is documentation-only.

The fix keeps the default D3D11 path unchanged. It only aligns WAVE with the existing spectrum override when software OpenGL was explicitly requested.

## Verification

- macOS ARM64 Qt 6.11.1: complete `AetherSDR` target builds
- focused CTest: `software_opengl_request_test`, `waveform_scope_model_test`, and `spectrum_preview_logic_test` pass (3/3)
- `tools/check_engine_boundary.py --strict`: 0 blocking findings
- `tools/check_a11y.py src/gui/SpectrumWidget.cpp src/gui/WaveformWidget.cpp`: 0 findings
- Windows 11 / MSVC / Qt 6.8.3: complete native build succeeded
- Windows executable SHA-256: `3d0bd40e4de2b0b31e904ac26fad178b6121130981de109269e0cfe9f6975ec5`

## Live proof

With `AETHER_NO_GPU=1` on the Windows test machine, the automation bridge reported a live FLEX-6700 panadapter using:

`CPU QRhi (OpenGL; VMware, Inc. Gallium 0.4 on llvmpipe (LLVM 3.6, 128 bits) 3.0 Mesa 11.2.2; software OpenGL)`

The live framebuffer was 1732x948 with valid matching textures and a rendered spectrum/waterfall. The fixed log contains:

- `SpectrumWidget: QRhi initialized, backend: OpenGL`
- 0 mixed-graphics-API errors
- 0 `QRhiWidget: No QRhi` errors

The radio remained RX-only throughout (`mox=false`, `transmitting=false`, `tuning=false`), was disconnected after proof, and the temporary environment override was removed.

## Proof

Forced-software Windows run after the fix: the panadapter and waterfall render normally through the live OpenGL QRhi path.

![Windows software-OpenGL proof](https://raw.githubusercontent.com/rfoust/AetherSDR/fix-4745-assets/.pr-assets/4745-after.png)

Generated with OpenAI Codex.
