### PR TITLE
fix(gui): make the SpotHub Time column sortable (#4749)

### DIFF
--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -182,9 +182,14 @@ QVariant SpotTableModel::data(const QModelIndex& index, int role) const
         if (index.column() == ColFreq)
             return QColor(0xe0, 0xd0, 0x60);  // yellow-ish
     }
-    // Store freq in UserRole for sorting
+    // Store freq/time in UserRole so QSortFilterProxyModel can sort on them
+    // (#4749: Time was the only always-visible column with no sortable
+    // value, so clicking it did nothing and there was no way back to
+    // newest-first order once Freq had been sorted).
     if (role == Qt::UserRole && index.column() == ColFreq)
         return spot.freqMhz;
+    if (role == Qt::UserRole && index.column() == ColTime)
+        return spot.utcTime;
 
     return {};
 }


### PR DESCRIPTION
Fixes #4749.

## Problem
SpotHub's Spot List lets you sort by Freq (click header to toggle
lowest/highest) but Time was not sortable — clicking it did nothing.

## Root cause
`SpotTableModel::data()` only returned a `Qt::UserRole` value for
`ColFreq`. The proxy model's `setSortRole(Qt::UserRole)` had nothing
to compare for any other column, so clicking Time was a no-op. New
spots are prepended (newest-first) by default, which is why this only
bit once a user had already sorted by Freq — there was then no way
back to time order.

## Fix
Return `spot.utcTime` under `Qt::UserRole` for `ColTime`, matching the
existing Freq pattern. Time is now sortable ascending/descending like
Freq.

## Testing
Built and manually verified against a live DX cluster + RBN feed in
SpotHub → Spot List: clicking Time now sorts correctly (verified
against real spot timestamps spanning several hours), and Freq sort
still works as before (no regression).

Note: `DxSpot::utcTime` is a `QTime` with no date component, so
sorting purely by time-of-day could misorder spots across a UTC
midnight rollover — a pre-existing limitation of the field, not
something this fix changes.