### PR TITLE
fix(gui): fit the PGXL fan-mode dropdown to its widest item (#4731)

### DIFF
--- a/src/gui/AmpApplet.cpp
+++ b/src/gui/AmpApplet.cpp
@@ -3,6 +3,7 @@
 #include "GuardedSlider.h"
 #include "core/AppSettings.h"
 
+#include <QAbstractItemView>
 #include <QAccessible>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -200,13 +201,19 @@ AmpApplet::AmpApplet(QWidget* parent)
     // fanModeChanged contract ("uppercase, ready for sendCommand") is
     // unchanged. Hidden until a direct PGXL connection delivers the first
     // fanmode status.
+    // The popup view is a separate top-level (Qt::Popup) window, so it
+    // doesn't inherit the combo's font — it must be set explicitly here or
+    // the popup paints at the app's default UI font while the combo's own
+    // width (and elision) is computed from the 10px rule below. On a
+    // larger-than-default UI font that mismatch elides "Fan: Contest", the
+    // longest item, into a garbled label (#4731).
     static const char* kComboStyle =
         "QComboBox { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
         "border-radius: 3px; padding: 1px 4px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }"
         "QComboBox:hover { background: {{color.background.1}}; }"
-        "QComboBox::drop-down { border: none; }"
+        "QComboBox::drop-down { border: none; width: 14px; }"
         "QComboBox QAbstractItemView { background: {{color.background.2}}; color: {{color.text.primary}}; "
-        "selection-background-color: {{color.background.1}}; }";
+        "selection-background-color: {{color.background.1}}; font-size: 10px; font-weight: bold; }";
     // GuardedComboBox (not plain QComboBox): this is a hardware control, so
     // an accidental mouse-wheel scroll while just hovering over it must not
     // silently change fan mode and send a command to the amp — it only
@@ -215,6 +222,15 @@ AmpApplet::AmpApplet(QWidget* parent)
     m_fanCombo->setObjectName(QStringLiteral("ampFanModeCombo"));
     for (const QString& mode : {QStringLiteral("STANDARD"), QStringLiteral("CONTEST"), QStringLiteral("BROADCAST")})
         m_fanCombo->addItem(fanModeLabel(mode), mode);
+    // Let the widest item ("Fan: Contest") drive the combo's width instead
+    // of leaving it pinned to whatever the stylesheet happens to compute
+    // (#4731) — matches the pattern used by every other combo in the app,
+    // e.g. ProfileSwitcherApplet, AdaptiveFilterControls.
+    m_fanCombo->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
+    m_fanCombo->setMinimumContentsLength(12);
+    // Belt-and-braces: if a future label ever outgrows the combo anyway,
+    // fail visibly (clipped) rather than silently mislabelling the mode.
+    m_fanCombo->view()->setTextElideMode(Qt::ElideNone);
     m_fanCombo->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
     m_fanCombo->setFocusPolicy(Qt::TabFocus);
     AetherSDR::ThemeManager::instance().applyStyleSheet(m_fanCombo, kComboStyle);

--- a/tests/amp_applet_test.cpp
+++ b/tests/amp_applet_test.cpp
@@ -2,6 +2,7 @@
 #include "core/AppSettings.h"
 #include "gui/AmpApplet.h"
 
+#include <QAbstractItemView>
 #include <QApplication>
 #include <QByteArray>
 #include <QComboBox>
@@ -183,6 +184,23 @@ void testFanModePulldown()
     report("unknown fanmode leaves combo selection unchanged",
            combo->currentData().toString() == before,
            combo->currentData().toString());
+
+    // #4731: on a large-enough default UI font, the popup's fixed pixel
+    // width (sized off the combo's own hardcoded 10px stylesheet font)
+    // couldn't fit "Fan: Contest" — the longest item — so Qt's default
+    // ElideMiddle silently mangled it. Widths/fonts aren't trustworthy to
+    // assert on directly in this offscreen, unlaid-out harness (the combo
+    // is never shown, so its geometry never reflects a real style pass),
+    // so guard the three properties the fix actually sets instead: let the
+    // widest item drive the combo's width rather than pinning it, and fail
+    // any future overflow visibly (clipped) instead of mid-eliding it.
+    report("fan combo sizes to its widest item, not a pinned width",
+           combo->sizeAdjustPolicy() == QComboBox::AdjustToMinimumContentsLengthWithIcon);
+    report("fan combo reserves room for \"Fan: Contest\"",
+           combo->minimumContentsLength() >= static_cast<int>(QStringLiteral("Fan: Contest").length()),
+           QString::number(combo->minimumContentsLength()));
+    report("fan combo popup does not silently mid-elide overflow",
+           combo->view()->textElideMode() == Qt::ElideNone);
 }
 
 } // namespace


### PR DESCRIPTION
Fixes #4731.

## Credit
Root cause and fix were fully worked out by @aethersdr-agent's triage
comment on the issue — this PR applies that proposal essentially as
written. Thanks!

## Root cause
`AmpApplet`'s fan-mode combo (`ampFanModeCombo`, added in #4459) has a
hand-rolled stylesheet that sets `font-size: 10px` on the `QComboBox`
itself but not on its popup (`QComboBox QAbstractItemView`). The popup
is a separate top-level (`Qt::Popup`) window, so it doesn't inherit
the combo's font — it painted at the application's default UI font
instead. Meanwhile nothing (`setSizeAdjustPolicy` /
`setMinimumContentsLength`) let the combo's own width grow to fit its
widest item, so on a big enough default font the fixed-width popup
elided "Fan: Contest" (the longest of the three items) via Qt's
default `Qt::ElideMiddle`.

## Fix (`src/gui/AmpApplet.cpp`)
- Give the popup the same 10px/bold font the combo's width is computed
  from, and reserve the drop-down arrow's width explicitly.
- `setSizeAdjustPolicy(AdjustToMinimumContentsLengthWithIcon)` +
  `setMinimumContentsLength(12)` so the widest item ("Fan: Contest")
  drives the combo's width, matching the pattern already used by
  `ProfileSwitcherApplet` and `AdaptiveFilterControls`.
- `view()->setTextElideMode(Qt::ElideNone)` as a belt-and-braces: any
  future label that outgrows the combo fails visibly (clipped) rather
  than silently mislabelling the fan mode.

## Testing
- Extended `testFanModePulldown()` in `tests/amp_applet_test.cpp`.
  Note: I couldn't use the exact assertion suggested in the triage
  comment (`view()->sizeHintForColumn(0) <= combo->width()`) — in this
  offscreen, never-shown test harness `combo->width()` doesn't reflect
  a real style/layout pass and the assertion passed even with the bug
  reverted, which would've been a false-positive regression guard.
  Instead the test asserts directly on the three properties the fix
  sets (`sizeAdjustPolicy`, `minimumContentsLength`, popup
  `textElideMode`). Verified this version fails on the pre-fix code
  and passes with the fix.
- Full app build succeeds.

I don't have a PGXL to reproduce the actual pixel-level rendering (and
the trigger is Windows/large-font-specific, so it wouldn't reproduce
on macOS anyway), so this leans on the test plus the code-level
correctness for verification.