### PR TITLE
feat(kiwisdr): import/export the saved receiver list as CSV (#4586)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3741,6 +3741,15 @@ set_target_properties(kiwi_sdr_manager_password_test PROPERTIES AUTOMOC ON)
 add_test(NAME kiwi_sdr_manager_password_test
          COMMAND kiwi_sdr_manager_password_test)
 
+add_executable(kiwi_sdr_manager_csv_test
+    tests/kiwi_sdr_manager_csv_test.cpp
+)
+target_include_directories(kiwi_sdr_manager_csv_test PRIVATE src)
+target_link_libraries(kiwi_sdr_manager_csv_test PRIVATE
+    aethercore Qt6::Core Qt6::Test)
+set_target_properties(kiwi_sdr_manager_csv_test PROPERTIES AUTOMOC ON)
+add_test(NAME kiwi_sdr_manager_csv_test COMMAND kiwi_sdr_manager_csv_test)
+
 add_executable(kiwi_sdr_trace_math_test
     tests/kiwi_sdr_trace_math_test.cpp
 )

--- a/src/core/KiwiSdrManager.cpp
+++ b/src/core/KiwiSdrManager.cpp
@@ -3,11 +3,15 @@
 #include "AppSettings.h"
 #include "LogManager.h"
 
+#include <QDir>
+#include <QFile>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QMetaObject>
 #include <QMetaType>
+#include <QSaveFile>
+#include <QStringConverter>
 #include <QThread>
 #include <QTimer>
 #include <QUuid>
@@ -31,6 +35,310 @@ constexpr int kKiwiSdrDefaultWaterfallMaxDbm = -10;
 QString normalizedProfileEndpoint(const QString& endpoint)
 {
     return KiwiSdrClient::normalizeEndpoint(endpoint);
+}
+
+// ── Receiver-list CSV (#4586) ────────────────────────────────────────────
+// A deliberately small, self-contained CSV reader/writer rather than reusing
+// MemoryCsvCompat (multi-dialect memory channels) or ShortcutManager's parser
+// (keybinding collision semantics) — neither is a good fit for a flat list
+// of receiver profiles, and this repo's existing CSV consumers each own a
+// parser tailored to their own schema rather than sharing one.
+
+constexpr qsizetype kMaxKiwiCsvBytes = 256 * 1024;
+constexpr int kMaxKiwiCsvRows = 2000;
+constexpr int kMaxKiwiCsvFieldLength = 512;
+constexpr int kKiwiSdrCsvSchemaVersion = 1;
+
+// Only FORMAT_VERSION/NAME/ENDPOINT are required. The remaining columns
+// (AUTO_CONNECT, KEEP_AUDIO_DURING_TX, RESUME_AUDIO_AFTER_TX_DELAY,
+// WATERFALL_AUTO_SCALE, WATERFALL_MIN_DBM, WATERFALL_MAX_DBM,
+// WATERFALL_RATE) are optional on the way in: an absent one falls back to
+// the struct's own default, so an older export or a hand-trimmed CSV still
+// imports cleanly.
+const QStringList kKiwiSdrCsvHeader{
+    QStringLiteral("FORMAT_VERSION"),
+    QStringLiteral("NAME"),
+    QStringLiteral("ENDPOINT"),
+};
+
+struct KiwiCsvRow {
+    int lineNumber{0};
+    QStringList fields;
+};
+
+struct ParsedKiwiCsvRow {
+    int lineNumber{0};
+    QString name;
+    QString endpoint;
+    bool autoConnect{false};
+    bool keepAudioDuringTx{false};
+    bool resumeAudioAfterTxDelay{false};
+    bool waterfallAutoScale{true};
+    int waterfallMinDbm{kKiwiSdrDefaultWaterfallMinDbm};
+    int waterfallMaxDbm{kKiwiSdrDefaultWaterfallMaxDbm};
+    int waterfallRate{0};
+};
+
+QString kiwiCsvEscape(QString value)
+{
+    if (value.contains(QLatin1Char(',')) || value.contains(QLatin1Char('"'))
+        || value.contains(QLatin1Char('\n')) || value.contains(QLatin1Char('\r'))) {
+        value.replace(QLatin1Char('"'), QStringLiteral("\"\""));
+        return QLatin1Char('"') + value + QLatin1Char('"');
+    }
+    return value;
+}
+
+QString kiwiCsvBool(bool value)
+{
+    return value ? QStringLiteral("True") : QStringLiteral("False");
+}
+
+bool appendKiwiCsvField(KiwiCsvRow& row, QString& field, QStringList& errors)
+{
+    if (field.size() > kMaxKiwiCsvFieldLength) {
+        errors << QStringLiteral("Line %1: a field exceeds %2 characters.")
+                      .arg(row.lineNumber)
+                      .arg(kMaxKiwiCsvFieldLength);
+        return false;
+    }
+    row.fields << field;
+    field.clear();
+    return true;
+}
+
+// RFC4180-style tokenizer (quotes, embedded commas/newlines) — the same
+// mechanics as ShortcutManager's parseCsvRows, sized down for a much smaller
+// file (receiver lists run to dozens of rows, not thousands).
+QList<KiwiCsvRow> parseKiwiCsvRows(const QByteArray& bytes, QStringList& errors)
+{
+    QList<KiwiCsvRow> rows;
+    if (bytes.size() > kMaxKiwiCsvBytes) {
+        errors << QStringLiteral("KiwiSDR receiver CSV exceeds the 256 KiB size limit.");
+        return rows;
+    }
+
+    QStringDecoder decoder(QStringDecoder::Utf8);
+    QString text = decoder.decode(bytes);
+    if (decoder.hasError()) {
+        errors << QStringLiteral("KiwiSDR receiver CSV is not valid UTF-8.");
+        return rows;
+    }
+    if (!text.isEmpty() && text.front() == QChar(0xfeff)) {
+        text.remove(0, 1);
+    }
+
+    KiwiCsvRow row;
+    row.lineNumber = 1;
+    QString field;
+    bool inQuotes = false;
+    bool afterQuote = false;
+    int lineNumber = 1;
+    int quoteOpenedLine = 0;
+
+    auto finishRow = [&]() -> bool {
+        if (!appendKiwiCsvField(row, field, errors)) {
+            return false;
+        }
+        const bool blank = row.fields.size() == 1 && row.fields.constFirst().isEmpty();
+        if (!blank) {
+            rows << row;
+            if (rows.size() > kMaxKiwiCsvRows + 1) {
+                errors << QStringLiteral("KiwiSDR receiver CSV exceeds the %1-row limit.")
+                              .arg(kMaxKiwiCsvRows);
+                return false;
+            }
+        }
+        row = KiwiCsvRow{};
+        afterQuote = false;
+        return true;
+    };
+
+    for (int i = 0; i < text.size(); ++i) {
+        const QChar ch = text.at(i);
+        if (inQuotes) {
+            if (ch == QLatin1Char('"')) {
+                if (i + 1 < text.size() && text.at(i + 1) == QLatin1Char('"')) {
+                    field += QLatin1Char('"');
+                    ++i;
+                } else {
+                    inQuotes = false;
+                    afterQuote = true;
+                }
+            } else {
+                field += ch;
+                if (ch == QLatin1Char('\n')) {
+                    ++lineNumber;
+                } else if (ch == QLatin1Char('\r')
+                           && (i + 1 >= text.size()
+                               || text.at(i + 1) != QLatin1Char('\n'))) {
+                    ++lineNumber;
+                }
+            }
+            continue;
+        }
+
+        if (afterQuote && ch != QLatin1Char(',') && ch != QLatin1Char('\r')
+            && ch != QLatin1Char('\n')) {
+            errors << QStringLiteral("Line %1: unexpected character after a quoted field.")
+                          .arg(lineNumber);
+            return {};
+        }
+        if (ch == QLatin1Char('"')) {
+            if (!field.isEmpty() || afterQuote) {
+                errors << QStringLiteral("Line %1: unexpected quote in an unquoted field.")
+                              .arg(lineNumber);
+                return {};
+            }
+            inQuotes = true;
+            quoteOpenedLine = lineNumber;
+            continue;
+        }
+        if (ch == QLatin1Char(',')) {
+            if (!appendKiwiCsvField(row, field, errors)) {
+                return {};
+            }
+            afterQuote = false;
+            continue;
+        }
+        if (ch == QLatin1Char('\r') || ch == QLatin1Char('\n')) {
+            if (!finishRow()) {
+                return {};
+            }
+            if (ch == QLatin1Char('\r') && i + 1 < text.size()
+                && text.at(i + 1) == QLatin1Char('\n')) {
+                ++i;
+            }
+            ++lineNumber;
+            row.lineNumber = lineNumber;
+            continue;
+        }
+        field += ch;
+    }
+
+    if (inQuotes) {
+        errors << QStringLiteral("Line %1: unterminated quoted field.").arg(quoteOpenedLine);
+        return {};
+    }
+    if (!field.isEmpty() || !row.fields.isEmpty()) {
+        if (!finishRow()) {
+            return {};
+        }
+    }
+    return rows;
+}
+
+// Accepts True/False/1/0/Yes/No case-insensitively; anything else is invalid.
+bool parseKiwiCsvBool(const QString& text, bool defaultValue, bool& valid)
+{
+    const QString lower = text.trimmed().toLower();
+    if (lower.isEmpty()) {
+        valid = true;
+        return defaultValue;
+    }
+    if (lower == QLatin1String("true") || lower == QLatin1String("1")
+        || lower == QLatin1String("yes")) {
+        valid = true;
+        return true;
+    }
+    if (lower == QLatin1String("false") || lower == QLatin1String("0")
+        || lower == QLatin1String("no")) {
+        valid = true;
+        return false;
+    }
+    valid = false;
+    return defaultValue;
+}
+
+QList<ParsedKiwiCsvRow> parseKiwiSdrCsv(const QByteArray& bytes, QStringList& errors)
+{
+    const QList<KiwiCsvRow> rows = parseKiwiCsvRows(bytes, errors);
+    if (!errors.isEmpty()) {
+        return {};
+    }
+    if (rows.isEmpty()) {
+        errors << QStringLiteral("KiwiSDR receiver CSV is empty.");
+        return {};
+    }
+
+    QHash<QString, int> columns;
+    for (int i = 0; i < rows.constFirst().fields.size(); ++i) {
+        const QString name = rows.constFirst().fields.at(i).trimmed().toUpper();
+        if (name.isEmpty() || columns.contains(name)) {
+            errors << QStringLiteral("Line 1: empty or duplicate column name '%1'.").arg(name);
+            return {};
+        }
+        columns.insert(name, i);
+    }
+    for (const QString& required : kKiwiSdrCsvHeader) {
+        if (!columns.contains(required)) {
+            errors << QStringLiteral("Line 1: missing required column %1.").arg(required);
+        }
+    }
+    if (!errors.isEmpty()) {
+        return {};
+    }
+
+    QList<ParsedKiwiCsvRow> parsed;
+    for (int i = 1; i < rows.size(); ++i) {
+        const KiwiCsvRow& row = rows.at(i);
+        const auto value = [&row, &columns](const QString& name) {
+            const int index = columns.value(name, -1);
+            return index >= 0 && index < row.fields.size() ? row.fields.at(index).trimmed()
+                                                           : QString();
+        };
+
+        ParsedKiwiCsvRow parsedRow;
+        parsedRow.lineNumber = row.lineNumber;
+        parsedRow.name = value(QStringLiteral("NAME"));
+        parsedRow.endpoint = value(QStringLiteral("ENDPOINT"));
+        if (parsedRow.name.isEmpty()) {
+            errors << QStringLiteral("Line %1: NAME is required.").arg(row.lineNumber);
+        }
+        if (parsedRow.endpoint.isEmpty()) {
+            errors << QStringLiteral("Line %1: ENDPOINT is required.").arg(row.lineNumber);
+        }
+
+        auto boolField = [&](const QString& column, bool defaultValue) {
+            bool fieldOk = true;
+            const bool result = parseKiwiCsvBool(value(column), defaultValue, fieldOk);
+            if (!fieldOk) {
+                errors << QStringLiteral("Line %1: %2 must be True or False.")
+                              .arg(row.lineNumber).arg(column);
+            }
+            return result;
+        };
+        parsedRow.autoConnect = boolField(QStringLiteral("AUTO_CONNECT"), false);
+        parsedRow.keepAudioDuringTx = boolField(QStringLiteral("KEEP_AUDIO_DURING_TX"), false);
+        parsedRow.resumeAudioAfterTxDelay =
+            boolField(QStringLiteral("RESUME_AUDIO_AFTER_TX_DELAY"), false);
+        parsedRow.waterfallAutoScale = boolField(QStringLiteral("WATERFALL_AUTO_SCALE"), true);
+
+        // Out-of-range values are not an error here — updateProfile() clamps
+        // them once the row is applied, same as a value typed into the UI
+        // dialog would be. Only a non-numeric field fails the import.
+        auto intField = [&](const QString& column, int defaultValue) {
+            const QString text = value(column);
+            if (text.isEmpty()) {
+                return defaultValue;
+            }
+            bool fieldOk = false;
+            const int result = text.toInt(&fieldOk);
+            if (!fieldOk) {
+                errors << QStringLiteral("Line %1: %2 must be an integer.")
+                              .arg(row.lineNumber).arg(column);
+            }
+            return result;
+        };
+        parsedRow.waterfallMinDbm =
+            intField(QStringLiteral("WATERFALL_MIN_DBM"), kKiwiSdrDefaultWaterfallMinDbm);
+        parsedRow.waterfallMaxDbm =
+            intField(QStringLiteral("WATERFALL_MAX_DBM"), kKiwiSdrDefaultWaterfallMaxDbm);
+        parsedRow.waterfallRate = intField(QStringLiteral("WATERFALL_RATE"), 0);
+
+        parsed << parsedRow;
+    }
+    return parsed;
 }
 
 } // namespace
@@ -319,6 +627,147 @@ void KiwiSdrManager::updateProfile(const KiwiSdrAntennaProfile& profile)
     }
 
     emit profilesChanged();
+}
+
+QByteArray KiwiSdrManager::exportProfilesCsv() const
+{
+    QStringList lines;
+    lines << QStringLiteral(
+        "FORMAT_VERSION,NAME,ENDPOINT,AUTO_CONNECT,KEEP_AUDIO_DURING_TX,"
+        "RESUME_AUDIO_AFTER_TX_DELAY,WATERFALL_AUTO_SCALE,WATERFALL_MIN_DBM,"
+        "WATERFALL_MAX_DBM,WATERFALL_RATE");
+    for (const KiwiSdrAntennaProfile& p : m_profiles) {
+        const QStringList fields{
+            QString::number(kKiwiSdrCsvSchemaVersion),
+            kiwiCsvEscape(p.name),
+            kiwiCsvEscape(p.endpoint),
+            kiwiCsvBool(p.autoConnect),
+            kiwiCsvBool(p.keepAudioDuringTx),
+            kiwiCsvBool(p.resumeAudioAfterTxDelay),
+            kiwiCsvBool(p.waterfallAutoScale),
+            QString::number(p.waterfallMinDbm),
+            QString::number(p.waterfallMaxDbm),
+            QString::number(p.waterfallRate),
+        };
+        lines << fields.join(QLatin1Char(','));
+    }
+    return lines.join(QStringLiteral("\r\n")).toUtf8() + QByteArray("\r\n");
+}
+
+KiwiSdrCsvImportResult KiwiSdrManager::importProfilesCsv(const QByteArray& bytes)
+{
+    KiwiSdrCsvImportResult result;
+    const QList<ParsedKiwiCsvRow> rows = parseKiwiSdrCsv(bytes, result.errors);
+    if (!result.ok()) {
+        return result;
+    }
+
+    for (const ParsedKiwiCsvRow& row : rows) {
+        const QString normalizedEndpoint = normalizedProfileEndpoint(row.endpoint);
+        if (normalizedEndpoint.isEmpty() || row.name.trimmed().isEmpty()) {
+            result.errors << QStringLiteral(
+                "Line %1: NAME and ENDPOINT are required.").arg(row.lineNumber);
+            continue;
+        }
+
+        int existingIdx = -1;
+        for (int i = 0; i < m_profiles.size(); ++i) {
+            if (m_profiles.at(i).endpoint == normalizedEndpoint) {
+                existingIdx = i;
+                break;
+            }
+        }
+
+        // Merge on a matching endpoint (#4586): update the existing profile
+        // in place (keeping its id and password) instead of creating a
+        // duplicate, so re-importing the same file — e.g. after syncing
+        // between machines — is idempotent. A brand-new id is always minted
+        // for a new row via the same addProfile() path the UI's "Add
+        // receiver" button uses, so validation/truncation/logging match.
+        QString id;
+        if (existingIdx >= 0) {
+            id = m_profiles.at(existingIdx).id;
+        } else {
+            id = addProfile(row.name, row.endpoint);
+            if (id.isEmpty()) {
+                result.errors << QStringLiteral(
+                    "Line %1: '%2' has no usable name/endpoint.")
+                    .arg(row.lineNumber).arg(row.name);
+                continue;
+            }
+        }
+
+        KiwiSdrAntennaProfile updated = profile(id);
+        updated.name = row.name;
+        updated.endpoint = row.endpoint;
+        updated.autoConnect = row.autoConnect;
+        updated.keepAudioDuringTx = row.keepAudioDuringTx;
+        updated.resumeAudioAfterTxDelay = row.resumeAudioAfterTxDelay;
+        updated.waterfallAutoScale = row.waterfallAutoScale;
+        updated.waterfallMinDbm = row.waterfallMinDbm;
+        updated.waterfallMaxDbm = row.waterfallMaxDbm;
+        updated.waterfallRate = row.waterfallRate;
+        updateProfile(updated); // clamps waterfall fields, persists, emits
+
+        if (existingIdx >= 0) {
+            ++result.mergedCount;
+        } else {
+            ++result.addedCount;
+        }
+    }
+    return result;
+}
+
+KiwiSdrCsvExportResult KiwiSdrManager::exportToFile(const QString& path) const
+{
+    KiwiSdrCsvExportResult result;
+    if (path.trimmed().isEmpty()) {
+        result.error = QStringLiteral("No export path was provided.");
+        return result;
+    }
+
+    const QByteArray csv = exportProfilesCsv();
+    QSaveFile file(path);
+    // Some network mounts (SMB, WSL DrvFs) can't create the sidecar temp file
+    // QSaveFile normally uses — fall back to a direct write so export
+    // succeeds where a plain write would (matches ShortcutManager).
+    file.setDirectWriteFallback(true);
+    if (!file.open(QIODevice::WriteOnly)) {
+        result.error = QStringLiteral("Couldn't open %1 for writing (%2).")
+                           .arg(QDir::toNativeSeparators(path), file.errorString());
+        return result;
+    }
+    if (file.write(csv) != csv.size()) {
+        const QString reason = file.errorString();
+        file.cancelWriting();
+        result.error = QStringLiteral("Couldn't write the receiver list to %1 (%2).")
+                           .arg(QDir::toNativeSeparators(path), reason);
+        return result;
+    }
+    if (!file.commit()) {
+        result.error = QStringLiteral("Couldn't save %1 (%2).")
+                           .arg(QDir::toNativeSeparators(path), file.errorString());
+        return result;
+    }
+    result.exportedCount = m_profiles.size();
+    return result;
+}
+
+KiwiSdrCsvImportResult KiwiSdrManager::importFromFile(const QString& path)
+{
+    KiwiSdrCsvImportResult result;
+    if (path.trimmed().isEmpty()) {
+        result.errors << QStringLiteral("No import path was provided.");
+        return result;
+    }
+
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        result.errors << QStringLiteral("Couldn't open %1 for reading (%2).")
+                             .arg(QDir::toNativeSeparators(path), file.errorString());
+        return result;
+    }
+    return importProfilesCsv(file.readAll());
 }
 
 void KiwiSdrManager::setProfilePassword(const QString& id,

--- a/src/core/KiwiSdrManager.h
+++ b/src/core/KiwiSdrManager.h
@@ -3,10 +3,12 @@
 #include "KiwiSdrClient.h"
 #include "KiwiSdrCredentialStore.h"
 
+#include <QByteArray>
 #include <QHash>
 #include <QObject>
 #include <QSet>
 #include <QString>
+#include <QStringList>
 #include <QVector>
 
 #include <functional>
@@ -44,6 +46,19 @@ struct KiwiSdrWaterfallDisplayRange {
     bool valid{false};
 };
 
+struct KiwiSdrCsvImportResult {
+    int addedCount{0};
+    int mergedCount{0};
+    QStringList errors;
+    bool ok() const { return errors.isEmpty(); }
+};
+
+struct KiwiSdrCsvExportResult {
+    int exportedCount{0};
+    QString error;
+    bool ok() const { return error.isEmpty(); }
+};
+
 enum class KiwiSdrPasswordPersistenceState {
     Loading,
     NoPassword,
@@ -65,6 +80,16 @@ public:
     QVector<KiwiSdrAntennaProfile> profiles() const { return m_profiles; }
     KiwiSdrAntennaProfile profile(const QString& id) const;
     bool hasProfile(const QString& id) const;
+
+    // CSV import/export of the saved receiver list (#4586), scoped to the
+    // profile fields only — passwords stay in IKiwiSdrCredentialStore and
+    // are never written to a plaintext file. Import merges: a row whose
+    // endpoint matches an existing profile updates that profile in place
+    // (keeping its id and password) rather than creating a duplicate.
+    QByteArray exportProfilesCsv() const;
+    KiwiSdrCsvImportResult importProfilesCsv(const QByteArray& bytes);
+    KiwiSdrCsvExportResult exportToFile(const QString& path) const;
+    KiwiSdrCsvImportResult importFromFile(const QString& path);
     QString displayName(const QString& id) const;
     QString virtualAntennaToken(const QString& id) const;
     QString profileIdForVirtualAntennaToken(const QString& token) const;

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -3618,6 +3618,7 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
     vbox->addWidget(group, 1);
 
     QVBoxLayout* kiwiRowsLayout = nullptr;
+    QVBoxLayout* kiwiLayout = nullptr;
 
 #ifdef HAVE_KEYCHAIN
     const QString kiwiPasswordHelpText =
@@ -3642,7 +3643,7 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
     if (m_kiwiSdrManager) {
         auto* kiwiGroup = new QGroupBox("KiwiSDR RX Antennas");
         kiwiGroup->setStyleSheet(kGroupStyle);
-        auto* kiwiLayout = new QVBoxLayout(kiwiGroup);
+        kiwiLayout = new QVBoxLayout(kiwiGroup);
         kiwiLayout->setSpacing(6);
 
         auto* kiwiHelp = new QLabel(
@@ -3704,129 +3705,6 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
         kiwiRowsLayout->setAlignment(Qt::AlignTop);
         kiwiScroll->setWidget(kiwiRowsWidget);
         kiwiLayout->addWidget(kiwiScroll);
-
-        // Import/export the receiver list as a CSV (#4586) — passwords are
-        // never included (they live in the OS credential store), so a
-        // password-protected receiver needs its password re-entered after
-        // import. Remembers its own last-used folder, independent of any
-        // other CSV import/export elsewhere in the app (mirrors
-        // ShortcutDialog's pattern).
-        auto kiwiTransferDirectory = [] {
-            const QString saved = AppSettings::instance()
-                .value(QStringLiteral("KiwiSdrImportExportPath"), QString())
-                .toString();
-            if (!saved.isEmpty() && QDir(saved).exists()) {
-                return saved;
-            }
-            const QString docs = QStandardPaths::writableLocation(
-                QStandardPaths::DocumentsLocation);
-            return docs.isEmpty() ? QDir::homePath() : docs;
-        };
-        auto rememberKiwiTransferDirectory = [](const QString& path) {
-            const QFileInfo info(path);
-            if (!info.absolutePath().isEmpty()) {
-                AppSettings::instance().setValue(
-                    QStringLiteral("KiwiSdrImportExportPath"), info.absolutePath());
-            }
-        };
-
-        auto* kiwiTransferRow = new QHBoxLayout;
-        kiwiTransferRow->addStretch(1);
-
-        auto* kiwiImportBtn = new QPushButton("Import...");
-        kiwiImportBtn->setObjectName(QStringLiteral("kiwiImportButton"));
-        kiwiImportBtn->setAutoDefault(false);
-        kiwiImportBtn->setAccessibleName("Import KiwiSDR receivers");
-        kiwiImportBtn->setAccessibleDescription(
-            "Import KiwiSDR receivers from a CSV file. A receiver whose "
-            "endpoint matches one already saved is updated in place.");
-        kiwiImportBtn->setStyleSheet(kKiwiActionButtonStyle);
-        kiwiImportBtn->setMinimumWidth(96);
-        connect(kiwiImportBtn, &QPushButton::clicked, this,
-                [this, kiwiTransferDirectory, rememberKiwiTransferDirectory] {
-            QFileDialog dialog(this, QStringLiteral("Import KiwiSDR Receivers"),
-                               kiwiTransferDirectory(),
-                               QStringLiteral("CSV Files (*.csv)"));
-            dialog.setAcceptMode(QFileDialog::AcceptOpen);
-            dialog.setFileMode(QFileDialog::ExistingFile);
-            dialog.setDefaultSuffix(QStringLiteral("csv"));
-            if (dialog.exec() != QDialog::Accepted || dialog.selectedFiles().isEmpty()) {
-                return;
-            }
-            const QString path = dialog.selectedFiles().first();
-            rememberKiwiTransferDirectory(path);
-
-            const KiwiSdrCsvImportResult result =
-                m_kiwiSdrManager->importFromFile(path);
-            if (!result.ok() && result.addedCount == 0 && result.mergedCount == 0) {
-                QMessageBox box(QMessageBox::Warning,
-                                QStringLiteral("Import KiwiSDR Receivers"),
-                                QStringLiteral("No receivers were imported from %1.")
-                                    .arg(QFileInfo(path).fileName()),
-                                QMessageBox::Ok, this);
-                box.setDetailedText(result.errors.join(QLatin1Char('\n')));
-                box.exec();
-                return;
-            }
-
-            QMessageBox box(result.errors.isEmpty()
-                                ? QMessageBox::Information : QMessageBox::Warning,
-                            QStringLiteral("Import KiwiSDR Receivers"),
-                            QStringLiteral("Added %1 and updated %2 receiver(s) from %3.")
-                                .arg(result.addedCount)
-                                .arg(result.mergedCount)
-                                .arg(QFileInfo(path).fileName()),
-                            QMessageBox::Ok, this);
-            if (!result.errors.isEmpty()) {
-                box.setInformativeText(
-                    QStringLiteral("%1 row(s) could not be imported.")
-                        .arg(result.errors.size()));
-                box.setDetailedText(result.errors.join(QLatin1Char('\n')));
-            }
-            box.exec();
-        });
-        kiwiTransferRow->addWidget(kiwiImportBtn);
-
-        auto* kiwiExportBtn = new QPushButton("Export...");
-        kiwiExportBtn->setObjectName(QStringLiteral("kiwiExportButton"));
-        kiwiExportBtn->setAutoDefault(false);
-        kiwiExportBtn->setAccessibleName("Export KiwiSDR receivers");
-        kiwiExportBtn->setAccessibleDescription(
-            "Export the saved KiwiSDR receivers to a CSV file. Passwords "
-            "are not included.");
-        kiwiExportBtn->setStyleSheet(kKiwiActionButtonStyle);
-        kiwiExportBtn->setMinimumWidth(96);
-        connect(kiwiExportBtn, &QPushButton::clicked, this,
-                [this, kiwiTransferDirectory, rememberKiwiTransferDirectory] {
-            const QString fileName = QStringLiteral("AetherSDR_KiwiSDR_Receivers_%1.csv")
-                                         .arg(QDateTime::currentDateTime().toString(
-                                             QStringLiteral("yyyyMMdd_HHmmss")));
-            QFileDialog dialog(this, QStringLiteral("Export KiwiSDR Receivers"),
-                               QDir(kiwiTransferDirectory()).filePath(fileName),
-                               QStringLiteral("CSV Files (*.csv)"));
-            dialog.setAcceptMode(QFileDialog::AcceptSave);
-            dialog.setDefaultSuffix(QStringLiteral("csv"));
-            if (dialog.exec() != QDialog::Accepted || dialog.selectedFiles().isEmpty()) {
-                return;
-            }
-            const QString path = dialog.selectedFiles().first();
-            rememberKiwiTransferDirectory(path);
-
-            const KiwiSdrCsvExportResult result = m_kiwiSdrManager->exportToFile(path);
-            if (!result.ok()) {
-                QMessageBox::warning(this, QStringLiteral("Export KiwiSDR Receivers"),
-                                     result.error);
-                return;
-            }
-            QMessageBox::information(
-                this, QStringLiteral("Export KiwiSDR Receivers"),
-                QStringLiteral("Exported %1 receiver(s) to %2. Passwords are not "
-                               "included; re-enter them after importing elsewhere.")
-                    .arg(result.exportedCount)
-                    .arg(QFileInfo(path).fileName()));
-        });
-        kiwiTransferRow->addWidget(kiwiExportBtn);
-        kiwiLayout->addLayout(kiwiTransferRow);
 
         vbox->addWidget(kiwiGroup, 0);
     }
@@ -4478,6 +4356,127 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
                 kiwiTelemetryRefreshTimer->start();
             }
         });
+
+        // Import/export the receiver list as a CSV (#4586) — passwords are
+        // never included (they live in the OS credential store), so a
+        // password-protected receiver needs its password re-entered after
+        // import. Remembers its own last-used folder, independent of any
+        // other CSV import/export elsewhere in the app (mirrors
+        // ShortcutDialog's pattern). Reuses styleKiwiButton (declared above
+        // for the per-row Connect/Add-receiver buttons) instead of adding a
+        // fresh setStyleSheet() call site the colour-audit ratchet counts.
+        auto kiwiTransferDirectory = [] {
+            const QString saved = AppSettings::instance()
+                .value(QStringLiteral("KiwiSdrImportExportPath"), QString())
+                .toString();
+            if (!saved.isEmpty() && QDir(saved).exists()) {
+                return saved;
+            }
+            const QString docs = QStandardPaths::writableLocation(
+                QStandardPaths::DocumentsLocation);
+            return docs.isEmpty() ? QDir::homePath() : docs;
+        };
+        auto rememberKiwiTransferDirectory = [](const QString& path) {
+            const QFileInfo info(path);
+            if (!info.absolutePath().isEmpty()) {
+                AppSettings::instance().setValue(
+                    QStringLiteral("KiwiSdrImportExportPath"), info.absolutePath());
+            }
+        };
+
+        auto* kiwiTransferRow = new QHBoxLayout;
+        kiwiTransferRow->addStretch(1);
+
+        auto* kiwiImportBtn = new QPushButton("Import...");
+        kiwiImportBtn->setObjectName(QStringLiteral("kiwiImportButton"));
+        kiwiImportBtn->setAccessibleName("Import KiwiSDR receivers");
+        kiwiImportBtn->setAccessibleDescription(
+            "Import KiwiSDR receivers from a CSV file. A receiver whose "
+            "endpoint matches one already saved is updated in place.");
+        styleKiwiButton(kiwiImportBtn);
+        connect(kiwiImportBtn, &QPushButton::clicked, this,
+                [this, kiwiTransferDirectory, rememberKiwiTransferDirectory] {
+            QFileDialog dialog(this, QStringLiteral("Import KiwiSDR Receivers"),
+                               kiwiTransferDirectory(),
+                               QStringLiteral("CSV Files (*.csv)"));
+            dialog.setAcceptMode(QFileDialog::AcceptOpen);
+            dialog.setFileMode(QFileDialog::ExistingFile);
+            dialog.setDefaultSuffix(QStringLiteral("csv"));
+            if (dialog.exec() != QDialog::Accepted || dialog.selectedFiles().isEmpty()) {
+                return;
+            }
+            const QString path = dialog.selectedFiles().first();
+            rememberKiwiTransferDirectory(path);
+
+            const KiwiSdrCsvImportResult result =
+                m_kiwiSdrManager->importFromFile(path);
+            if (!result.ok() && result.addedCount == 0 && result.mergedCount == 0) {
+                QMessageBox box(QMessageBox::Warning,
+                                QStringLiteral("Import KiwiSDR Receivers"),
+                                QStringLiteral("No receivers were imported from %1.")
+                                    .arg(QFileInfo(path).fileName()),
+                                QMessageBox::Ok, this);
+                box.setDetailedText(result.errors.join(QLatin1Char('\n')));
+                box.exec();
+                return;
+            }
+
+            QMessageBox box(result.errors.isEmpty()
+                                ? QMessageBox::Information : QMessageBox::Warning,
+                            QStringLiteral("Import KiwiSDR Receivers"),
+                            QStringLiteral("Added %1 and updated %2 receiver(s) from %3.")
+                                .arg(result.addedCount)
+                                .arg(result.mergedCount)
+                                .arg(QFileInfo(path).fileName()),
+                            QMessageBox::Ok, this);
+            if (!result.errors.isEmpty()) {
+                box.setInformativeText(
+                    QStringLiteral("%1 row(s) could not be imported.")
+                        .arg(result.errors.size()));
+                box.setDetailedText(result.errors.join(QLatin1Char('\n')));
+            }
+            box.exec();
+        });
+        kiwiTransferRow->addWidget(kiwiImportBtn);
+
+        auto* kiwiExportBtn = new QPushButton("Export...");
+        kiwiExportBtn->setObjectName(QStringLiteral("kiwiExportButton"));
+        kiwiExportBtn->setAccessibleName("Export KiwiSDR receivers");
+        kiwiExportBtn->setAccessibleDescription(
+            "Export the saved KiwiSDR receivers to a CSV file. Passwords "
+            "are not included.");
+        styleKiwiButton(kiwiExportBtn);
+        connect(kiwiExportBtn, &QPushButton::clicked, this,
+                [this, kiwiTransferDirectory, rememberKiwiTransferDirectory] {
+            const QString fileName = QStringLiteral("AetherSDR_KiwiSDR_Receivers_%1.csv")
+                                         .arg(QDateTime::currentDateTime().toString(
+                                             QStringLiteral("yyyyMMdd_HHmmss")));
+            QFileDialog dialog(this, QStringLiteral("Export KiwiSDR Receivers"),
+                               QDir(kiwiTransferDirectory()).filePath(fileName),
+                               QStringLiteral("CSV Files (*.csv)"));
+            dialog.setAcceptMode(QFileDialog::AcceptSave);
+            dialog.setDefaultSuffix(QStringLiteral("csv"));
+            if (dialog.exec() != QDialog::Accepted || dialog.selectedFiles().isEmpty()) {
+                return;
+            }
+            const QString path = dialog.selectedFiles().first();
+            rememberKiwiTransferDirectory(path);
+
+            const KiwiSdrCsvExportResult result = m_kiwiSdrManager->exportToFile(path);
+            if (!result.ok()) {
+                QMessageBox::warning(this, QStringLiteral("Export KiwiSDR Receivers"),
+                                     result.error);
+                return;
+            }
+            QMessageBox::information(
+                this, QStringLiteral("Export KiwiSDR Receivers"),
+                QStringLiteral("Exported %1 receiver(s) to %2. Passwords are not "
+                               "included; re-enter them after importing elsewhere.")
+                    .arg(result.exportedCount)
+                    .arg(QFileInfo(path).fileName()));
+        });
+        kiwiTransferRow->addWidget(kiwiExportBtn);
+        kiwiLayout->addLayout(kiwiTransferRow);
     }
 
     (*refresh)();

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -58,6 +58,8 @@
 #include <QUrl>
 #include <QMediaDevices>
 #include <QAudioDevice>
+#include <QDateTime>
+#include <QDir>
 #include <QFileDialog>
 #include <QStandardPaths>
 #include <QFileInfo>
@@ -3702,6 +3704,130 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
         kiwiRowsLayout->setAlignment(Qt::AlignTop);
         kiwiScroll->setWidget(kiwiRowsWidget);
         kiwiLayout->addWidget(kiwiScroll);
+
+        // Import/export the receiver list as a CSV (#4586) — passwords are
+        // never included (they live in the OS credential store), so a
+        // password-protected receiver needs its password re-entered after
+        // import. Remembers its own last-used folder, independent of any
+        // other CSV import/export elsewhere in the app (mirrors
+        // ShortcutDialog's pattern).
+        auto kiwiTransferDirectory = [] {
+            const QString saved = AppSettings::instance()
+                .value(QStringLiteral("KiwiSdrImportExportPath"), QString())
+                .toString();
+            if (!saved.isEmpty() && QDir(saved).exists()) {
+                return saved;
+            }
+            const QString docs = QStandardPaths::writableLocation(
+                QStandardPaths::DocumentsLocation);
+            return docs.isEmpty() ? QDir::homePath() : docs;
+        };
+        auto rememberKiwiTransferDirectory = [](const QString& path) {
+            const QFileInfo info(path);
+            if (!info.absolutePath().isEmpty()) {
+                AppSettings::instance().setValue(
+                    QStringLiteral("KiwiSdrImportExportPath"), info.absolutePath());
+            }
+        };
+
+        auto* kiwiTransferRow = new QHBoxLayout;
+        kiwiTransferRow->addStretch(1);
+
+        auto* kiwiImportBtn = new QPushButton("Import...");
+        kiwiImportBtn->setObjectName(QStringLiteral("kiwiImportButton"));
+        kiwiImportBtn->setAutoDefault(false);
+        kiwiImportBtn->setAccessibleName("Import KiwiSDR receivers");
+        kiwiImportBtn->setAccessibleDescription(
+            "Import KiwiSDR receivers from a CSV file. A receiver whose "
+            "endpoint matches one already saved is updated in place.");
+        kiwiImportBtn->setStyleSheet(kKiwiActionButtonStyle);
+        kiwiImportBtn->setMinimumWidth(96);
+        connect(kiwiImportBtn, &QPushButton::clicked, this,
+                [this, kiwiTransferDirectory, rememberKiwiTransferDirectory] {
+            QFileDialog dialog(this, QStringLiteral("Import KiwiSDR Receivers"),
+                               kiwiTransferDirectory(),
+                               QStringLiteral("CSV Files (*.csv)"));
+            dialog.setAcceptMode(QFileDialog::AcceptOpen);
+            dialog.setFileMode(QFileDialog::ExistingFile);
+            dialog.setDefaultSuffix(QStringLiteral("csv"));
+            if (dialog.exec() != QDialog::Accepted || dialog.selectedFiles().isEmpty()) {
+                return;
+            }
+            const QString path = dialog.selectedFiles().first();
+            rememberKiwiTransferDirectory(path);
+
+            const KiwiSdrCsvImportResult result =
+                m_kiwiSdrManager->importFromFile(path);
+            if (!result.ok() && result.addedCount == 0 && result.mergedCount == 0) {
+                QMessageBox box(QMessageBox::Warning,
+                                QStringLiteral("Import KiwiSDR Receivers"),
+                                QStringLiteral("No receivers were imported from %1.")
+                                    .arg(QFileInfo(path).fileName()),
+                                QMessageBox::Ok, this);
+                box.setDetailedText(result.errors.join(QLatin1Char('\n')));
+                box.exec();
+                return;
+            }
+
+            QMessageBox box(result.errors.isEmpty()
+                                ? QMessageBox::Information : QMessageBox::Warning,
+                            QStringLiteral("Import KiwiSDR Receivers"),
+                            QStringLiteral("Added %1 and updated %2 receiver(s) from %3.")
+                                .arg(result.addedCount)
+                                .arg(result.mergedCount)
+                                .arg(QFileInfo(path).fileName()),
+                            QMessageBox::Ok, this);
+            if (!result.errors.isEmpty()) {
+                box.setInformativeText(
+                    QStringLiteral("%1 row(s) could not be imported.")
+                        .arg(result.errors.size()));
+                box.setDetailedText(result.errors.join(QLatin1Char('\n')));
+            }
+            box.exec();
+        });
+        kiwiTransferRow->addWidget(kiwiImportBtn);
+
+        auto* kiwiExportBtn = new QPushButton("Export...");
+        kiwiExportBtn->setObjectName(QStringLiteral("kiwiExportButton"));
+        kiwiExportBtn->setAutoDefault(false);
+        kiwiExportBtn->setAccessibleName("Export KiwiSDR receivers");
+        kiwiExportBtn->setAccessibleDescription(
+            "Export the saved KiwiSDR receivers to a CSV file. Passwords "
+            "are not included.");
+        kiwiExportBtn->setStyleSheet(kKiwiActionButtonStyle);
+        kiwiExportBtn->setMinimumWidth(96);
+        connect(kiwiExportBtn, &QPushButton::clicked, this,
+                [this, kiwiTransferDirectory, rememberKiwiTransferDirectory] {
+            const QString fileName = QStringLiteral("AetherSDR_KiwiSDR_Receivers_%1.csv")
+                                         .arg(QDateTime::currentDateTime().toString(
+                                             QStringLiteral("yyyyMMdd_HHmmss")));
+            QFileDialog dialog(this, QStringLiteral("Export KiwiSDR Receivers"),
+                               QDir(kiwiTransferDirectory()).filePath(fileName),
+                               QStringLiteral("CSV Files (*.csv)"));
+            dialog.setAcceptMode(QFileDialog::AcceptSave);
+            dialog.setDefaultSuffix(QStringLiteral("csv"));
+            if (dialog.exec() != QDialog::Accepted || dialog.selectedFiles().isEmpty()) {
+                return;
+            }
+            const QString path = dialog.selectedFiles().first();
+            rememberKiwiTransferDirectory(path);
+
+            const KiwiSdrCsvExportResult result = m_kiwiSdrManager->exportToFile(path);
+            if (!result.ok()) {
+                QMessageBox::warning(this, QStringLiteral("Export KiwiSDR Receivers"),
+                                     result.error);
+                return;
+            }
+            QMessageBox::information(
+                this, QStringLiteral("Export KiwiSDR Receivers"),
+                QStringLiteral("Exported %1 receiver(s) to %2. Passwords are not "
+                               "included; re-enter them after importing elsewhere.")
+                    .arg(result.exportedCount)
+                    .arg(QFileInfo(path).fileName()));
+        });
+        kiwiTransferRow->addWidget(kiwiExportBtn);
+        kiwiLayout->addLayout(kiwiTransferRow);
+
         vbox->addWidget(kiwiGroup, 0);
     }
 

--- a/tests/kiwi_sdr_manager_csv_test.cpp
+++ b/tests/kiwi_sdr_manager_csv_test.cpp
@@ -1,0 +1,173 @@
+#include "TestSettingsProfile.h"
+#include "core/AppSettings.h"
+#include "core/KiwiSdrManager.h"
+
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QDebug>
+
+#include <cstdio>
+#include <memory>
+
+using namespace AetherSDR;
+
+namespace {
+
+constexpr const char* kProfilesKey = "KiwiSdrRxAntennas";
+
+// CSV import/export never touches passwords, so a fully no-op store is
+// enough here (unlike kiwi_sdr_manager_password_test.cpp, which exercises
+// the store's async read/write/remove machinery directly).
+class NullCredentialStore final : public IKiwiSdrCredentialStore {
+public:
+    bool isPersistent() const override { return false; }
+    void read(const QString&, QObject*, Callback) override {}
+    void write(const QString&, const QString&, QObject*, Callback) override {}
+    void remove(const QString&, QObject*, Callback) override {}
+};
+
+std::shared_ptr<IKiwiSdrCredentialStore> makeStore()
+{
+    return std::make_shared<NullCredentialStore>();
+}
+
+int fail(const QString& message)
+{
+    qCritical().noquote() << message;
+    return 1;
+}
+
+void clearProfiles()
+{
+    AppSettings::instance().remove(QString::fromLatin1(kProfilesKey));
+    AppSettings::instance().save();
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile settingsProfile(QStringLiteral("aether-kiwi-csv-test"));
+    if (!settingsProfile.isValid()) {
+        return fail("could not create isolated settings home");
+    }
+    QCoreApplication app(argc, argv);
+    AppSettings::instance().load();
+    clearProfiles();
+
+    // Round trip: export then import into a fresh manager reproduces every
+    // visible field, minting a brand-new id rather than reusing the
+    // exported one (#4586 — the CSV never carries an id).
+    {
+        KiwiSdrManager exporter(nullptr, makeStore());
+        const QString sourceId =
+            exporter.addProfile("Test RX", "kiwi.example.test:8073");
+        KiwiSdrAntennaProfile p = exporter.profile(sourceId);
+        p.autoConnect = true;
+        p.keepAudioDuringTx = true;
+        p.waterfallAutoScale = false;
+        p.waterfallMinDbm = -120;
+        p.waterfallMaxDbm = -20;
+        p.waterfallRate = 2;
+        exporter.updateProfile(p);
+        const QByteArray csv = exporter.exportProfilesCsv();
+
+        clearProfiles();
+        KiwiSdrManager importer(nullptr, makeStore());
+        const KiwiSdrCsvImportResult result = importer.importProfilesCsv(csv);
+        if (!result.ok() || result.addedCount != 1 || result.mergedCount != 0) {
+            return fail("round-trip import did not add exactly one new profile");
+        }
+        const QVector<KiwiSdrAntennaProfile> profiles = importer.profiles();
+        if (profiles.size() != 1) {
+            return fail("round-trip import produced the wrong profile count");
+        }
+        const KiwiSdrAntennaProfile& imported = profiles.constFirst();
+        if (imported.id == sourceId) {
+            return fail("import reused the exported id instead of minting a fresh one");
+        }
+        if (imported.name != QStringLiteral("Test RX")
+            || imported.endpoint != QStringLiteral("kiwi.example.test:8073")
+            || !imported.autoConnect || !imported.keepAudioDuringTx
+            || imported.waterfallAutoScale || imported.waterfallMinDbm != -120
+            || imported.waterfallMaxDbm != -20 || imported.waterfallRate != 2) {
+            return fail("round-trip import did not preserve the profile's fields");
+        }
+    }
+
+    // Merge: a row whose endpoint matches an existing profile updates that
+    // profile in place — keeping its id — instead of creating a duplicate.
+    {
+        clearProfiles();
+        KiwiSdrManager manager(nullptr, makeStore());
+        const QString id =
+            manager.addProfile("Old Name", "merge.example.test:8073");
+
+        const QByteArray csv = QByteArrayLiteral(
+            "FORMAT_VERSION,NAME,ENDPOINT,AUTO_CONNECT\r\n"
+            "1,New Name,merge.example.test:8073,True\r\n");
+        const KiwiSdrCsvImportResult result = manager.importProfilesCsv(csv);
+        if (!result.ok() || result.addedCount != 0 || result.mergedCount != 1) {
+            return fail("importing a matching endpoint did not merge in place");
+        }
+        if (manager.profiles().size() != 1) {
+            return fail("merge created a duplicate instead of updating in place");
+        }
+        const KiwiSdrAntennaProfile updated = manager.profile(id);
+        if (updated.id != id) {
+            return fail("merge did not preserve the existing profile's id");
+        }
+        if (updated.name != QStringLiteral("New Name") || !updated.autoConnect) {
+            return fail("merge did not apply the imported fields");
+        }
+    }
+
+    // Out-of-range waterfall values in a hand-edited CSV are clamped, not
+    // rejected — the same behaviour as typing them into the UI dialog.
+    {
+        clearProfiles();
+        KiwiSdrManager manager(nullptr, makeStore());
+        const QByteArray csv = QByteArrayLiteral(
+            "FORMAT_VERSION,NAME,ENDPOINT,WATERFALL_MIN_DBM,WATERFALL_MAX_DBM,WATERFALL_RATE\r\n"
+            "1,Clamped,clamp.example.test:8073,-9999,9999,99\r\n");
+        const KiwiSdrCsvImportResult result = manager.importProfilesCsv(csv);
+        if (!result.ok() || result.addedCount != 1) {
+            return fail("a valid row with out-of-range numeric fields was rejected");
+        }
+        const KiwiSdrAntennaProfile p = manager.profiles().constFirst();
+        if (p.waterfallMinDbm < -260 || p.waterfallMaxDbm > 30
+            || p.waterfallRate > 4 || p.waterfallRate < 0) {
+            return fail("out-of-range waterfall values were not clamped on import");
+        }
+    }
+
+    // A row missing a required field fails with a line-numbered error and
+    // does not add a partial profile.
+    {
+        clearProfiles();
+        KiwiSdrManager manager(nullptr, makeStore());
+        const QByteArray csv = QByteArrayLiteral(
+            "FORMAT_VERSION,NAME,ENDPOINT\r\n"
+            "1,,missing-name.example.test:8073\r\n");
+        const KiwiSdrCsvImportResult result = manager.importProfilesCsv(csv);
+        if (result.ok() || !manager.profiles().isEmpty()) {
+            return fail("a row missing NAME should fail without adding a profile");
+        }
+    }
+
+    // Passwords live in IKiwiSdrCredentialStore, never in the exported CSV.
+    {
+        clearProfiles();
+        KiwiSdrManager manager(nullptr, makeStore());
+        const QString id =
+            manager.addProfile("Secret", "secret.example.test:8073");
+        manager.setProfilePassword(id, "hunter2");
+        const QByteArray csv = manager.exportProfilesCsv();
+        if (csv.contains("hunter2")) {
+            return fail("exported CSV leaked a receiver password");
+        }
+    }
+
+    std::printf("All tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #4586 (part 1, per the scoping agreed in the issue thread with
@jortiz77 — the broader "export all client config" ask stays on #4168).

## What
Adds Import.../Export... buttons to the KiwiSDR section of the
Antennas tab, so the saved receiver list can move between machines/OSes
without hand-copying entries one at a time.

## Design (per @aethersdr-agent's triage on the issue)
- CSV columns mirror `KiwiSdrAntennaProfile` — name, endpoint,
  auto-connect, keep-audio-during-TX, resume-audio-after-TX-delay, and
  the three waterfall display fields. `id` is deliberately never
  exported; on import a new UUID is minted via the same `addProfile()`
  path the "Add receiver" button uses.
- **Passwords are never included.** They live in
  `IKiwiSdrCredentialStore` (the OS keychain), keyed by profile id —
  exporting them to a plaintext CSV would be a real regression in
  handling. A password-protected receiver needs its password re-entered
  after import (noted in the export confirmation dialog).
- **Import merges on a normalized-endpoint match** (per the maintainer
  call on the issue): a row whose endpoint matches an existing profile
  updates it in place — keeping its id and password — rather than
  creating a duplicate. Re-importing the same file (e.g. after syncing
  between machines) is idempotent.
- Out-of-range waterfall values in a hand-edited CSV are clamped via
  the existing `updateProfile()` logic rather than rejected, matching
  what typing them into the UI dialog would do.

## Testing
- New `tests/kiwi_sdr_manager_csv_test.cpp`: round-trip export→import
  (fresh id minted, fields preserved), merge-on-matching-endpoint
  (id/existing profile preserved, no duplicate), out-of-range values
  clamped not rejected, a row missing a required field fails cleanly,
  and passwords never appear in exported CSV bytes.
- Full app build succeeds.
- Manually verified against my own live KiwiSDR receiver list (5 real
  saved receivers): exported to CSV, inspected the file, then
  re-imported it — got "Added 0 and updated 5 receiver(s)", confirmed
  via the settings DB that all 5 ids were unchanged (pure merge, no
  duplicates, no data loss).