### PR TITLE
fix(display): bake dss_mesh with flat-capable GLSL slices only (140/150/300es)

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -27,10 +27,13 @@ on:
     paths:
       - "src/**"
       - "resources/themes/**"
+      - "resources/shaders/**"
+      - "CMakeLists.txt"
       - "tools/audit_colours.py"
       - "tools/check_a11y.py"
       - "tools/check_engine_boundary.py"
       - "tools/check_network_timeouts.py"
+      - "tools/check_shader_dialects.py"
       - "tools/check_theme_seed.py"
       - "tools/gen_theme_seed.py"
       - ".github/workflows/static-checks.yml"
@@ -108,6 +111,23 @@ jobs:
       - name: Theme seed vs bundled JSON
         if: ${{ !cancelled() }}
         run: python tools/check_theme_seed.py --strict
+
+      # ── Shader/GLSL-dialect ratchet (#4746). qt_add_shaders bakes one slice
+      # per target dialect and QRhi picks the highest slice <= what the driver
+      # reports. A shader using an interpolation qualifier that some baked slice
+      # cannot express still BAKES — qsb emits the illegal text and exits 0 — so
+      # the build is green, the .qsb is produced, and the only symptom is a
+      # driver rejecting it at runtime. #4746 was exactly that: `flat` (#4539)
+      # baked into a GLSL 120 slice, invisible on every GL 3.2+ desktop GPU and
+      # on CI, and a dead 3D FFT on the Raspberry Pi's GL 3.1 v3d driver.
+      #
+      # This is the one class of shader bug CI structurally cannot catch by
+      # building, so it gets a source gate instead (--strict). Matches only
+      # interpolation qualifiers, which SPIRV-Cross passes through verbatim —
+      # everything else it lowers, and a gate with false positives gets ignored.
+      - name: Shader GLSL dialects
+        if: ${{ !cancelled() }}
+        run: python tools/check_shader_dialects.py --strict
 
       # ── Hardcoded-colour ratchet (#4569, RFC #3076). Counts may not rise
       # above the PR's base. The gate is a DELTA rather than a stored constant:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2382,9 +2382,27 @@ if(AETHER_GPU_SPECTRUM)
             resources/shaders/spectrum.vert
             resources/shaders/spectrum.frag
             resources/shaders/panscope.frag
+            resources/shaders/wavescope.frag
+    )
+
+    # dss_mesh (3D-FFT stacked-trace) is the only shader that uses the `flat`
+    # interpolation qualifier — added for ridge stability in #4539 — which is
+    # legal only in GLSL 130 and later. Bake it exclusively as flat-capable
+    # slices: 140 (desktop OpenGL 3.1, e.g. the Raspberry Pi's v3d driver), 150
+    # (OpenGL 3.2+), and 300es (OpenGL ES 3). The qsb default (100es, 120, 150)
+    # would offer a 120 slice, where `flat` is illegal — so on a driver that
+    # reports GLSL 1.40 (no 140 baked → falls back to 120) the shader failed to
+    # compile and the 3D FFT was disabled. Restricting the target set means QRhi
+    # never selects a slice this shader can't compile in; on an older GL<=3.0 /
+    # GLES2 context no slice matches and the pipeline is skipped cleanly (the CPU
+    # image fallback still renders the 3D FFT). No shader-source change — #4539's
+    # `flat` is preserved. Complementary to #4730 (OpenGL outline rendering).
+    qt_add_shaders(AetherSDR "aether_dss_shaders"
+        PREFIX "/shaders"
+        GLSL "140,150,300es"
+        FILES
             resources/shaders/dss_mesh.vert
             resources/shaders/dss_mesh.frag
-            resources/shaders/wavescope.frag
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2373,7 +2373,8 @@ if(AETHER_GPU_SPECTRUM)
     # Shaders in this list get qsb's default GLSL set (100es/120/150). Anything
     # using GLSL 130+ syntax (e.g. the `flat` qualifier) must NOT go here — the
     # 120 slice would bake illegal code that only the driver rejects, on-device,
-    # where CI can't see it. Put such shaders in the dss block below instead.
+    # where CI can't see it. Put such shaders in the GLSL-130+ block below;
+    # tools/check_shader_dialects.py fails the build-gate if they land here.
     qt_add_shaders(AetherSDR "aether_shaders"
         PREFIX "/shaders"
         FILES
@@ -2389,23 +2390,34 @@ if(AETHER_GPU_SPECTRUM)
             resources/shaders/wavescope.frag
     )
 
-    # dss_mesh (3D-FFT stacked-trace) is the only shader that uses the `flat`
-    # interpolation qualifier — added for ridge stability in #4539 — which is
-    # legal only in GLSL 130 and later. Bake it exclusively as flat-capable
-    # slices: 130 (OpenGL 3.0, incl. Mesa compat-profile caps and the
-    # `opengl32sw` software-GL Qt ships on Windows), 140 (desktop OpenGL 3.1,
-    # e.g. the Raspberry Pi's v3d driver), 150 (OpenGL 3.2+), and 300es
-    # (OpenGL ES 3). The qsb default (100es, 120, 150) would offer a 120 slice,
-    # where `flat` is illegal — so on a driver that reports GLSL 1.40 (no 140
-    # baked → falls back to 120) the shader failed to compile and the 3D FFT was
-    # disabled. Restricting the target set means QRhi never selects a slice this
-    # shader can't compile in; on an older GL<3.0 / GLES2 context no slice
-    # matches, so QRhi finds no GLSL code and the m_dssMeshFillPipeline->create()
-    # call in SpectrumWidget::initDssMeshPipeline fails — m_dssMeshReady stays
-    # false and the CPU image fallback still renders the 3D FFT. No shader-source
-    # change — #4539's `flat` is preserved. Complementary to #4730 (OpenGL
-    # outline rendering).
-    qt_add_shaders(AetherSDR "aether_dss_shaders"
+    # Shaders needing GLSL 130+. dss_mesh (3D-FFT stacked-trace) is the only one
+    # today: it uses the `flat` interpolation qualifier — added for ridge
+    # stability in #4539 — which is legal only in GLSL 130 / ES 300 and later.
+    # SPIRV-Cross cannot lower an interpolation qualifier the way it lowers
+    # explicit locations and UBO blocks, so `flat` reaches every baked slice
+    # verbatim; the qsb default (100es, 120, 150) therefore bakes a 120 slice
+    # containing `flat varying float …`, which is a syntax error, and a 100es
+    # slice where `flat` is a reserved word. Both still BAKE — qsb exits 0 — so
+    # the only symptom is a driver rejecting the shader at runtime.
+    #
+    # Bake instead the flat-capable slices our GL backends actually report:
+    # 130 (OpenGL 3.0, e.g. Mesa compat-profile caps), 140 (desktop OpenGL 3.1 —
+    # the Raspberry Pi's v3d driver, which is what #4746 hit: no 140 slice baked,
+    # so QRhi fell back to 120 and the 3D FFT was silently disabled), 150
+    # (OpenGL 3.2+, what desktop GPUs already selected — byte-identical to
+    # before), and 300es (OpenGL ES 3, which previously matched only the illegal
+    # 100es slice). HLSL 50 / MSL 12 / SPIR-V are untouched: only GLSL is
+    # overridden, so the D3D11, Metal and Vulkan paths bake exactly as before.
+    #
+    # On an older GL<3.0 / GLES2 context no slice matches. QShader stays valid,
+    # so this is NOT caught by the vs.isValid() guard — QRhi finds no GLSL code
+    # and the m_dssMeshFillPipeline->create() call in
+    # SpectrumWidget::initDssMeshPipeline fails, m_dssMeshReady stays false, and
+    # the CPU image fallback still renders the 3D FFT. That is no worse than
+    # before: those contexts previously selected 120/100es, which never
+    # compiled. No shader-source change — #4539's `flat` is preserved.
+    # Complementary to #4730 (OpenGL outline rendering).
+    qt_add_shaders(AetherSDR "aether_shaders_glsl130"
         PREFIX "/shaders"
         GLSL "130,140,150,300es"
         FILES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2370,6 +2370,10 @@ if(AETHER_GPU_SPECTRUM)
         endforeach()
     endif()
 
+    # Shaders in this list get qsb's default GLSL set (100es/120/150). Anything
+    # using GLSL 130+ syntax (e.g. the `flat` qualifier) must NOT go here — the
+    # 120 slice would bake illegal code that only the driver rejects, on-device,
+    # where CI can't see it. Put such shaders in the dss block below instead.
     qt_add_shaders(AetherSDR "aether_shaders"
         PREFIX "/shaders"
         FILES
@@ -2388,18 +2392,22 @@ if(AETHER_GPU_SPECTRUM)
     # dss_mesh (3D-FFT stacked-trace) is the only shader that uses the `flat`
     # interpolation qualifier — added for ridge stability in #4539 — which is
     # legal only in GLSL 130 and later. Bake it exclusively as flat-capable
-    # slices: 140 (desktop OpenGL 3.1, e.g. the Raspberry Pi's v3d driver), 150
-    # (OpenGL 3.2+), and 300es (OpenGL ES 3). The qsb default (100es, 120, 150)
-    # would offer a 120 slice, where `flat` is illegal — so on a driver that
-    # reports GLSL 1.40 (no 140 baked → falls back to 120) the shader failed to
-    # compile and the 3D FFT was disabled. Restricting the target set means QRhi
-    # never selects a slice this shader can't compile in; on an older GL<=3.0 /
-    # GLES2 context no slice matches and the pipeline is skipped cleanly (the CPU
-    # image fallback still renders the 3D FFT). No shader-source change — #4539's
-    # `flat` is preserved. Complementary to #4730 (OpenGL outline rendering).
+    # slices: 130 (OpenGL 3.0, incl. Mesa compat-profile caps and the
+    # `opengl32sw` software-GL Qt ships on Windows), 140 (desktop OpenGL 3.1,
+    # e.g. the Raspberry Pi's v3d driver), 150 (OpenGL 3.2+), and 300es
+    # (OpenGL ES 3). The qsb default (100es, 120, 150) would offer a 120 slice,
+    # where `flat` is illegal — so on a driver that reports GLSL 1.40 (no 140
+    # baked → falls back to 120) the shader failed to compile and the 3D FFT was
+    # disabled. Restricting the target set means QRhi never selects a slice this
+    # shader can't compile in; on an older GL<3.0 / GLES2 context no slice
+    # matches, so QRhi finds no GLSL code and the m_dssMeshFillPipeline->create()
+    # call in SpectrumWidget::initDssMeshPipeline fails — m_dssMeshReady stays
+    # false and the CPU image fallback still renders the 3D FFT. No shader-source
+    # change — #4539's `flat` is preserved. Complementary to #4730 (OpenGL
+    # outline rendering).
     qt_add_shaders(AetherSDR "aether_dss_shaders"
         PREFIX "/shaders"
-        GLSL "140,150,300es"
+        GLSL "130,140,150,300es"
         FILES
             resources/shaders/dss_mesh.vert
             resources/shaders/dss_mesh.frag

--- a/tools/check_shader_dialects.py
+++ b/tools/check_shader_dialects.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""
+AetherSDR shader-dialect checker.
+
+`qt_add_shaders` bakes one GLSL slice per target dialect, and at runtime QRhi
+picks the highest baked slice <= the version the driver reports. A shader whose
+source uses a construct that some baked dialect cannot express still BAKES — qsb
+emits the illegal text and exits 0. The failure surfaces only when a driver that
+selects that slice tries to compile it, on a machine that has such a driver.
+
+That is #4746: `dss_mesh.{vert,frag}` use the `flat` interpolation qualifier
+(#4539), which is legal from GLSL 130 / ES 300 onward. They were in the block
+that takes qsb's default set (100es, 120, 150), so a 120 slice was baked
+containing `flat varying float vOverlayLayer;`. Desktop GPUs report GL 3.2+ and
+select the legal 150 slice, so CI and every developer machine were fine; the
+Raspberry Pi's v3d driver reports GL 3.1 / GLSL 1.40, found no 140 slice, fell
+back to 120, and the 3D FFT silently never rendered.
+
+Note what CI could not have caught: the build was green, the .qsb files were
+produced, and the only evidence was a qCWarning on one class of hardware. Fixing
+the CMake target set (#4754) fixed that shader. This fails the NEXT one.
+
+WHY QUALIFIERS AND NOT A FULL GLSL PARSE: the shader sources are Vulkan-style
+GLSL 440, and SPIRV-Cross lowers nearly everything on the way down — explicit
+locations, UBO blocks, and modern builtins all become legal 120 constructs. The
+interpolation qualifiers are the exception: they carry semantics no lowering can
+preserve, so SPIRV-Cross emits them verbatim into every slice. Matching those and
+nothing else is what keeps this gate free of false positives; a gate that cries
+wolf gets ignored, and an ignored gate is worse than no gate.
+
+Usage:
+    python tools/check_shader_dialects.py            # report, exit 0
+    python tools/check_shader_dialects.py --strict   # exit 1 on a violation
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+CMAKELISTS = REPO / "CMakeLists.txt"
+
+# qsb's default when qt_add_shaders is given no GLSL argument. Keep in sync with
+# the Qt version in use; it has been this triple since Qt 6.0.
+QSB_DEFAULT_GLSL = "100es,120,150"
+
+# Interpolation qualifiers, and the first dialect that accepts each. `None` means
+# the qualifier does not exist in that flavour at any version.
+#   (minimum desktop GLSL, minimum GLSL ES)
+QUALIFIER_MIN = {
+    "flat": (130, 300),
+    "noperspective": (130, None),
+    "centroid": (120, 300),
+    "sample": (400, 320),
+}
+
+# `flat out float x;`, `layout(location = 7) flat out float x;`, `flat in ...`,
+# and the pre-130 `centroid varying ...` spelling. The qualifier may also trail
+# the storage keyword (`out flat float x;`), which some drivers accept.
+QUALIFIER_RE = re.compile(
+    r"\b(?:(flat|noperspective|centroid|sample)\s+(?:in|out|varying)"
+    r"|(?:in|out|varying)\s+(flat|noperspective|centroid|sample))\b"
+)
+
+BLOCK_RE = re.compile(r"qt_add_shaders\s*\(\s*(\w+)\s+\"([^\"]+)\"(.*?)\n\s*\)",
+                      re.DOTALL)
+GLSL_ARG_RE = re.compile(r"\bGLSL\s+\"([^\"]+)\"")
+FILES_RE = re.compile(r"\bFILES\b(.*)", re.DOTALL)
+DIALECT_RE = re.compile(r"^(\d+)(es)?$")
+
+
+def strip_comments(source: str) -> str:
+    """Drop // and /* */ comments so a commented-out `flat` is not a finding."""
+    source = re.sub(r"/\*.*?\*/", " ", source, flags=re.DOTALL)
+    return re.sub(r"//[^\n]*", "", source)
+
+
+def parse_dialects(spec: str) -> list[tuple[int, bool]]:
+    """"100es,120,150" -> [(100, True), (120, False), (150, False)]."""
+    dialects = []
+    for token in spec.split(","):
+        match = DIALECT_RE.match(token.strip())
+        if match:
+            dialects.append((int(match.group(1)), match.group(2) == "es"))
+    return dialects
+
+
+def parse_blocks(cmake_text: str) -> list[dict]:
+    """Every qt_add_shaders() call, with its dialect set and shader files."""
+    blocks = []
+    for match in BLOCK_RE.finditer(cmake_text):
+        body = match.group(3)
+        glsl_arg = GLSL_ARG_RE.search(body)
+        files_match = FILES_RE.search(body)
+        files = []
+        if files_match:
+            for line in files_match.group(1).splitlines():
+                line = line.split("#", 1)[0].strip()
+                if line.endswith((".vert", ".frag", ".comp")):
+                    files.append(line)
+        blocks.append({
+            "resource": match.group(2),
+            "spec": glsl_arg.group(1) if glsl_arg else QSB_DEFAULT_GLSL,
+            "explicit": glsl_arg is not None,
+            "files": files,
+        })
+    return blocks
+
+
+def dialect_name(version: int, is_es: bool) -> str:
+    return f"{version}es" if is_es else str(version)
+
+
+def check_file(path: Path, dialects: list[tuple[int, bool]]) -> list[str]:
+    """Qualifiers in `path` that at least one baked dialect cannot express."""
+    findings = []
+    source = strip_comments(path.read_text(encoding="utf-8", errors="replace"))
+    for match in QUALIFIER_RE.finditer(source):
+        qualifier = match.group(1) or match.group(2)
+        min_desktop, min_es = QUALIFIER_MIN[qualifier]
+        line_no = source.count("\n", 0, match.start()) + 1
+        for version, is_es in dialects:
+            minimum = min_es if is_es else min_desktop
+            if minimum is None:
+                findings.append(
+                    f"{path.relative_to(REPO)}:{line_no}: `{qualifier}` does not "
+                    f"exist in GLSL ES, but a {dialect_name(version, is_es)} "
+                    f"slice is baked")
+            elif version < minimum:
+                findings.append(
+                    f"{path.relative_to(REPO)}:{line_no}: `{qualifier}` needs "
+                    f"GLSL {'ES ' if is_es else ''}{minimum}+, but a "
+                    f"{dialect_name(version, is_es)} slice is baked")
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Fail when a shader uses a qualifier one of its baked GLSL "
+                    "dialects cannot express")
+    parser.add_argument("--strict", action="store_true",
+                        help="exit 1 when a shader/dialect mismatch is found")
+    args = parser.parse_args()
+
+    if not CMAKELISTS.exists():
+        print(f"FAIL: {CMAKELISTS} is missing — shader dialects cannot be "
+              f"verified.")
+        return 1
+
+    blocks = parse_blocks(CMAKELISTS.read_text(encoding="utf-8"))
+    if not blocks:
+        # Not "nothing to do": the GPU spectrum path is unconditional in the
+        # tree, so no blocks means the regexes stopped matching the file.
+        print("FAIL: no qt_add_shaders() blocks found in CMakeLists.txt — the "
+              "parser is out of date and this gate is checking nothing.")
+        return 1
+
+    findings: list[str] = []
+    checked = 0
+    for block in blocks:
+        dialects = parse_dialects(block["spec"])
+        origin = "explicit" if block["explicit"] else "qsb default"
+        print(f'qt_add_shaders "{block["resource"]}" — GLSL {block["spec"]} '
+              f'({origin}), {len(block["files"])} file(s)')
+        for rel in block["files"]:
+            path = REPO / rel
+            if not path.exists():
+                findings.append(f"{rel}: listed in CMakeLists.txt but missing "
+                                f"from the tree")
+                continue
+            checked += 1
+            findings.extend(check_file(path, dialects))
+
+    print(f"\nChecked {checked} shader source(s).")
+    if not findings:
+        print("OK: every shader compiles in all of its baked GLSL dialects.")
+        return 0
+
+    print(f"\n{len(findings)} shader/dialect mismatch(es):\n")
+    for finding in findings:
+        print(f"  {finding}")
+    print("\nA slice that cannot express the qualifier still BAKES — qsb emits "
+          "illegal text and exits 0. It fails at runtime, on the subset of "
+          "drivers that select that slice, as a log warning and a dead feature "
+          "(see #4746).\n"
+          "Fix by moving the shader into a qt_add_shaders() block whose GLSL "
+          "set omits the dialects it cannot support, not by widening this "
+          "check.")
+    return 1 if args.strict else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The `dss_mesh` (3D-FFT stacked-trace) shader is the only shader that uses the `flat` interpolation qualifier — added for ridge stability in #4539 — which is legal only in **GLSL 130 and later**. `qsb`'s default GLSL target set (`100es, 120, 150`) bakes a **120** slice, and 120 predates `flat`.

At runtime QRhi selects the highest baked slice ≤ the driver's reported GLSL version. The Raspberry Pi's **v3d** driver reports **OpenGL 3.1 = GLSL 1.40**; with no 140 slice baked, QRhi falls back to **120**, where `flat` is illegal, so `dss_mesh` fails to compile and the **3D FFT is disabled on every RPi5**. It's silent unless the 3D stacked-trace mode is selected (the pipeline is built at startup but only rendered in 3D mode). Desktop GPUs reporting GL 3.2+ selected the 150 slice and were unaffected — which is why CI / VM Linux runs never surfaced it.

Give `dss_mesh` its **own `qt_add_shaders` target** restricted to the `flat`-capable versions our GL backends report: **130** (GL 3.0), **140** (desktop GL 3.1), **150** (GL 3.2+), and **300es** (GLES 3). QRhi now selects 140 on v3d and the shader compiles. No shader-source change — #4539's `flat` is preserved.

Fixes #4746.

## What changed

`CMakeLists.txt` only — `dss_mesh.vert`/`.frag` move into a second `qt_add_shaders(... "aether_dss_shaders" GLSL "130,140,150,300es" ...)` block; every other shader keeps the default target set. No `.vert`/`.frag`/C++ changes.

## Design notes

- **Preserves #4539's `flat`.** The alternative — dropping `flat` — would make all slices compile but risk reintroducing the ridge shimmer #4539 fixed. This keeps the qualifier and simply gives QRhi a slice that can express it.
- **Surgical.** Only `dss_mesh`'s baked dialects change; the 2D panadapter shaders are byte-for-byte as shipped (still `100es/120/150`).
- **Graceful on old hardware.** On a **GL<3.0 / GLES2** context no `dss_mesh` slice matches. `QShader` stays valid, so this is *not* caught by the `vs.isValid()` guard — `m_dssMeshFillPipeline->create()` fails, `m_dssMeshReady` stays false, and the CPU image fallback still renders the 3D FFT.
- **130 slice** covers GL-3.0 contexts that report GLSL 1.30 — Mesa compat-profile caps and the `opengl32sw` software-GL Qt ships on Windows — which otherwise matched no slice at all. Additive: v3d still selects 140, so nothing about the path tested here changes. (Requested in review; both stages bake a clean 130 slice — `flat`, UBO lowered to a plain `uniform U` struct.)
- **Scope note:** the `300es` slice is bake-verified on both toolchains, but v3d hands Qt a *desktop*-GL 3.1 context, so the runtime path uses the **140** slice; the GLES-3 (`300es`) selection is not runtime-exercised here.

## Constitution principle honored

**Principle XI — Fixes Are Demonstrated.** Verified by build, `qsb --dump`, and runtime on three toolchains (below).

## Test plan

- [x] Local build passes (`cmake --build`)
  - macOS arm64, Qt **6.11**, Metal — green
  - Raspberry Pi 5, Debian trixie, Qt **6.8.2**, OpenGL/v3d — green
  - Windows 11 (i3), MSVC / D3D11 — green
- [x] `qsb --dump` confirms slice sets (in-build, Mac + RPi5)
  - `dss_mesh.vert.qsb`: SPIR-V + GLSL **130 / 140 / 150 / 300es** (no 120/100es), + HLSL 50 / MSL 12
  - `spectrum.vert.qsb` (representative other shader): unchanged default **100es / 120 / 150**
- [x] Behavior verified
  - RPi5 (Demo mode): `dss_mesh` pipeline **created** at runtime (previously `dss_mesh pipeline create failed`); 3D FFT renders with stable ridge outlines; 2D panadapter unchanged.
  - Windows 11 (i3, integrated GPU): *About AetherSDR* renderer = **GPU QRhi (D3D11, Intel(R) UHD Graphics)** — the HLSL path, unaffected by the GLSL change. Toggled 3D↔2D; log shows `stacked-trace mesh pipeline created 768x104` and no shader errors.
- [ ] Existing tests pass (CI)
  - No tests are affected (CMake/shader-bake change only); relies on CI.
- [x] Reproduction steps documented if user-reported bug — see #4746
- [x] `git diff --check` — clean
- [x] `python3 tools/check_engine_boundary.py --strict` — 0 blocking findings

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — N/A, no settings changes
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered
- [x] All meter UI uses `MeterSmoother` — N/A, no meter changes
- [x] Documentation updated if user-visible behavior changed — N/A; restores intended behavior (3D FFT on GL≤3.1 drivers)
- [x] Security-sensitive changes reference a GHSA if applicable — N/A

## Related

- **#4539** — introduced the `flat vOverlayLayer` this trips over.
- **#4730** — complementary; fixes OpenGL history-outline rendering *once* the shader compiles. This change is the prerequisite that lets `dss_mesh` build at all on v3d.

Built and smoke tested on: MacBook Air M2 / Raspberry Pi 5 Debian trixie / Win 11 i3
