### PR TITLE
fix(linux): prefer xcb on a headless Wayland session (no GL window surface)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5065,6 +5065,11 @@ target_link_libraries(location_address_resolver_test PRIVATE
 set_target_properties(location_address_resolver_test PROPERTIES AUTOMOC ON)
 add_test(NAME location_address_resolver_test COMMAND location_address_resolver_test)
 
+add_executable(display_presence_test tests/display_presence_test.cpp)
+target_include_directories(display_presence_test PRIVATE src)
+target_link_libraries(display_presence_test PRIVATE Qt6::Core)
+add_test(NAME display_presence_test COMMAND display_presence_test)
+
 add_executable(amp_model_test tests/amp_model_test.cpp)
 target_include_directories(amp_model_test PRIVATE src)
 target_link_libraries(amp_model_test PRIVATE aethercore Qt6::Core Qt6::Test)

--- a/README.md
+++ b/README.md
@@ -279,20 +279,32 @@ That is the escape hatch if a GPU or driver renders the spectrum incorrectly —
 
 ### Wayland and XWayland
 
-On a Wayland session AetherSDR asks Qt for `wayland;xcb` — native Wayland when
-the platform plugin is available, XWayland otherwise. Native Wayland avoids the
-GLX `BadAccess` crash that XWayland can produce when opening child dialogs on
-some compositors, and renders correctly under fractional scaling instead of
-being bitmap-scaled by the compositor.
+On a Wayland session AetherSDR chooses the Qt platform based on whether a
+display is attached:
 
-If a compositor misbehaves under native Wayland, force XWayland:
+- **A display is connected** → `wayland;xcb` (native Wayland when the platform
+  plugin is available, XWayland otherwise). Native Wayland avoids the GLX
+  `BadAccess` crash that XWayland can produce when opening child dialogs on some
+  compositors, and renders correctly under fractional scaling instead of being
+  bitmap-scaled by the compositor.
+- **Headless** — no connected display, e.g. a remote Raspberry Pi reached over
+  VNC — → `xcb;wayland`. With no DRM scanout, native-Wayland hardware GL cannot
+  allocate a window surface and the spectrum renders black under an
+  `EGL_BAD_MATCH` error storm; XWayland allocates its buffers through the X
+  server and works. AetherSDR detects this from the DRM connector status and
+  flips the order automatically; the chosen platform is recorded at startup in
+  the log (`Platform: Wayland session, display presence …`).
+
+Setting `QT_QPA_PLATFORM` yourself always wins — override in either direction:
 
 ```bash
-QT_QPA_PLATFORM=xcb ./AetherSDR-*.AppImage
+QT_QPA_PLATFORM=xcb ./AetherSDR-*.AppImage            # force XWayland
+QT_QPA_PLATFORM='wayland;xcb' ./AetherSDR-*.AppImage  # force native Wayland
 ```
 
-Setting `QT_QPA_PLATFORM` yourself always wins — AetherSDR only supplies a
-default when the variable is unset.
+The second form is the way back to native Wayland on a headless session whose
+XWayland mishandles child dialogs (the GLX `BadAccess` above) — the automatic
+choice there is `xcb;wayland`, so you would otherwise be on XWayland.
 
 On a distribution whose Qt is older than the required 6.8 (notably Ubuntu 24.04 LTS at 6.4.2), install a newer Qt manually:
 

--- a/src/core/DisplayPresence.h
+++ b/src/core/DisplayPresence.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QByteArray>
 #include <QDir>
 #include <QFile>
 #include <QIODevice>
@@ -16,19 +17,24 @@ namespace AetherSDR {
 // main.cpp).
 enum class DisplayPresence {
     Connected,  // at least one DRM connector reports "connected"
-    Headless,   // DRM connectors exist, but none is "connected"
-    Unknown     // no DRM connectors found — we cannot tell
+    Headless,   // at least one connector is "disconnected", and none "connected"
+    Unknown     // no connectors, or every connector reports "unknown"
 };
 
 // Scan the DRM connector status files under `drmRoot`. Returns:
 //   Connected — some connector's status is exactly "connected";
-//   Headless  — connectors exist but none is connected (e.g. a Pi over wayvnc);
+//   Headless  — at least one connector is "disconnected" and none is connected
+//               (e.g. a Pi over wayvnc with HDMI unplugged);
 //   Unknown   — no connector directories were found (no /sys/class/drm, an
-//               unusual driver, a container) — the caller should not assume
-//               headless in that case.
-// Writeback / virtual connectors report "unknown" and so never count as
-// connected. `drmRoot` is a parameter (not hard-coded) so the logic is testable
-// against a fake sysfs tree; it defaults to the real path.
+//               unusual driver, a container), OR every connector reports
+//               "unknown" — the caller should not assume headless in that case.
+// "unknown" is not only writeback/virtual connectors: a connector that cannot do
+// hotplug detection (DPI, composite TV-out, some fixed DSI panels) also reports
+// "unknown" while a panel is physically attached. Requiring an explicit
+// "disconnected" before claiming Headless keeps such a display off XWayland,
+// matching the tri-state rule: do not assume headless when we cannot tell.
+// `drmRoot` is a parameter (not hard-coded) so the logic is testable against a
+// fake sysfs tree; it defaults to the real path.
 inline DisplayPresence detectDisplayPresence(
     const QString& drmRoot = QStringLiteral("/sys/class/drm"))
 {
@@ -39,15 +45,25 @@ inline DisplayPresence detectDisplayPresence(
     if (connectors.isEmpty()) {
         return DisplayPresence::Unknown;
     }
+    bool sawDisconnected = false;
     for (const QString& c : connectors) {
         QFile status(drmRoot + QLatin1Char('/') + c + QStringLiteral("/status"));
         // status is a single short word; bound the read.
-        if (status.open(QIODevice::ReadOnly)
-            && status.readLine(64).trimmed() == "connected") {
+        if (!status.open(QIODevice::ReadOnly)) {
+            continue;
+        }
+        const QByteArray s = status.readLine(64).trimmed();
+        if (s == "connected") {
             return DisplayPresence::Connected;
         }
+        if (s == "disconnected") {
+            sawDisconnected = true;
+        }
     }
-    return DisplayPresence::Headless;
+    // No connector said "connected". Only claim Headless if at least one said
+    // "disconnected"; an all-"unknown" set (writeback/virtual, or a panel that
+    // can't hotplug-detect) means we cannot tell.
+    return sawDisconnected ? DisplayPresence::Headless : DisplayPresence::Unknown;
 }
 
 }  // namespace AetherSDR

--- a/src/core/DisplayPresence.h
+++ b/src/core/DisplayPresence.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <QDir>
+#include <QFile>
+#include <QIODevice>
+#include <QLatin1Char>
+#include <QString>
+#include <QStringList>
+
+namespace AetherSDR {
+
+// Whether a physical display is attached, as reported by the Linux DRM
+// subsystem. Used to choose the Qt platform on a Wayland session: a headless
+// session has no scanout, so native-Wayland hardware GL cannot allocate a
+// window surface and we prefer XWayland (see detectDisplayPresence use in
+// main.cpp).
+enum class DisplayPresence {
+    Connected,  // at least one DRM connector reports "connected"
+    Headless,   // DRM connectors exist, but none is "connected"
+    Unknown     // no DRM connectors found — we cannot tell
+};
+
+// Scan the DRM connector status files under `drmRoot`. Returns:
+//   Connected — some connector's status is exactly "connected";
+//   Headless  — connectors exist but none is connected (e.g. a Pi over wayvnc);
+//   Unknown   — no connector directories were found (no /sys/class/drm, an
+//               unusual driver, a container) — the caller should not assume
+//               headless in that case.
+// Writeback / virtual connectors report "unknown" and so never count as
+// connected. `drmRoot` is a parameter (not hard-coded) so the logic is testable
+// against a fake sysfs tree; it defaults to the real path.
+inline DisplayPresence detectDisplayPresence(
+    const QString& drmRoot = QStringLiteral("/sys/class/drm"))
+{
+    QDir drm(drmRoot);
+    const QStringList connectors = drm.entryList(
+        QStringList{QStringLiteral("card*-*")},
+        QDir::Dirs | QDir::NoDotAndDotDot);
+    if (connectors.isEmpty()) {
+        return DisplayPresence::Unknown;
+    }
+    for (const QString& c : connectors) {
+        QFile status(drmRoot + QLatin1Char('/') + c + QStringLiteral("/status"));
+        // status is a single short word; bound the read.
+        if (status.open(QIODevice::ReadOnly)
+            && status.readLine(64).trimmed() == "connected") {
+            return DisplayPresence::Connected;
+        }
+    }
+    return DisplayPresence::Headless;
+}
+
+}  // namespace AetherSDR

--- a/src/core/DisplayPresence.h
+++ b/src/core/DisplayPresence.h
@@ -63,7 +63,26 @@ inline DisplayPresence detectDisplayPresence(
     // No connector said "connected". Only claim Headless if at least one said
     // "disconnected"; an all-"unknown" set (writeback/virtual, or a panel that
     // can't hotplug-detect) means we cannot tell.
+    //
+    // Caveat: this is a host-level probe standing in for a session-level fact.
+    // A compositor on a headless backend running on a host that does have a
+    // monitor attached elsewhere (second seat, VM guest) reports Connected and
+    // keeps native Wayland. Detecting that needs a wl_output roundtrip, which
+    // is not available this early; the startup log line makes it diagnosable.
     return sawDisconnected ? DisplayPresence::Headless : DisplayPresence::Unknown;
 }
+
+// The display presence detected at startup, recorded so code that runs later —
+// e.g. SpectrumWidget's XWayland warning — can tell a deliberate headless->xcb
+// platform choice from a genuine Wayland-plugin failure or a user override.
+// Set once in main() before QApplication; read anywhere after. The static lives
+// in an inline function, so every translation unit shares the one instance.
+inline DisplayPresence& detectedDisplayPresenceRef()
+{
+    static DisplayPresence presence = DisplayPresence::Unknown;
+    return presence;
+}
+inline void setDetectedDisplayPresence(DisplayPresence p) { detectedDisplayPresenceRef() = p; }
+inline DisplayPresence detectedDisplayPresence() { return detectedDisplayPresenceRef(); }
 
 }  // namespace AetherSDR

--- a/src/core/GpuSelector.cpp
+++ b/src/core/GpuSelector.cpp
@@ -127,17 +127,23 @@ QVector<GpuInfo> enumeratePlatform() { return {}; }
 QString s_appliedSummary = QStringLiteral("not run");
 
 #if defined(Q_OS_LINUX)
-// Will the app run on a Wayland (EGL) platform rather than X11 (GLX)?  Mirrors
-// main.cpp's Wayland-preference logic; applyAtStartup() runs before QApplication
-// so we read the environment directly.  GLX vendor selection only applies under
-// X11 — under Wayland it is useless and __GLX_VENDOR_LIBRARY_NAME=nvidia can even
-// raise a GLX BadValue.
+// Will the app run on a Wayland (EGL) platform rather than X11 (GLX)?  main.cpp
+// sets QT_QPA_PLATFORM (including the headless->xcb case) before applyAtStartup()
+// runs, so we read that decision directly, falling back to the session type only
+// when it is unset.  GLX vendor selection only applies under X11 — under Wayland
+// it is useless and __GLX_VENDOR_LIBRARY_NAME=nvidia can even raise a GLX
+// BadValue.
 bool willUseWayland()
 {
     const QByteArray plat = qgetenv("QT_QPA_PLATFORM");
     if (!plat.isEmpty()) {
-        if (plat.contains("wayland")) return true;
-        if (plat.contains("xcb"))     return false;
+        // QT_QPA_PLATFORM is an ordered list ("wayland;xcb" / "xcb;wayland"); Qt
+        // loads the first entry it can, so only the first decides. Match it, not
+        // a substring of the whole value — "xcb;wayland" contains "wayland" but
+        // runs on xcb.
+        const QByteArray first = plat.split(';').constFirst().trimmed();
+        if (first.contains("wayland")) return true;
+        if (first.contains("xcb"))     return false;
     }
     return qEnvironmentVariableIsSet("WAYLAND_DISPLAY")
         || qgetenv("XDG_SESSION_TYPE") == QByteArrayLiteral("wayland");

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -58,6 +58,7 @@
 #include <QStringList>
 #include <QUrl>
 #include "core/AppSettings.h"
+#include "core/DisplayPresence.h"
 #include "core/KiwiSdrProtocol.h"
 #include "InteractionSettings.h"
 #include "models/BandPlanManager.h"
@@ -1900,17 +1901,35 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     // main.cpp normally forces native Wayland, but log it if we ended up here.
     if (QGuiApplication::platformName() == QLatin1String("xcb")
         && qEnvironmentVariable("XDG_SESSION_TYPE") == QLatin1String("wayland")) {
-        // Don't advise "set QT_QPA_PLATFORM=wayland" here. Reaching this line on
-        // a Wayland session means either main.cpp already asked for
-        // "wayland;xcb" and the Wayland plugin would not load, or the user
-        // forced xcb — so the old advice was a no-op in the first case and a
-        // startup abort in the second, which is how #1389 happened. Name the
-        // workaround that always applies, and the override only where it helps.
-        qWarning() << "SpectrumWidget: running under XWayland with OpenGL — "
-                      "GLX context issues may occur. The Wayland platform plugin "
-                      "is unavailable or overridden; set AETHER_NO_GPU=1 to work "
-                      "around, or QT_QPA_PLATFORM='wayland;xcb' if you forced "
-                      "xcb yourself (#1233)";
+        if (AetherSDR::detectedDisplayPresence()
+            == AetherSDR::DisplayPresence::Headless) {
+            // main.cpp deliberately prefers xcb on a headless Wayland session
+            // (#4747) — with no DRM scanout, native-Wayland GL cannot allocate a
+            // window surface (the panadapter renders black under an
+            // EGL_BAD_MATCH storm). This is the intended, working path, NOT a
+            // plugin failure — so don't tell this user their Wayland plugin is
+            // missing, and above all don't send them to "wayland;xcb", which is
+            // the #4747 bug. #1233 (GLX child-dialog BadAccess) can still bite
+            // under XWayland but was verified clean on labwc.
+            qInfo() << "SpectrumWidget: headless Wayland session — using XWayland "
+                       "by design (#4747; no DRM scanout for a native-Wayland GL "
+                       "surface). If a real display is attached and you want "
+                       "native Wayland, set QT_QPA_PLATFORM='wayland;xcb' (#1233).";
+        } else {
+            // Display present (or user-forced xcb). Don't advise "set
+            // QT_QPA_PLATFORM=wayland" here: reaching this line means either
+            // main.cpp asked for "wayland;xcb" and the Wayland plugin would not
+            // load, or the user forced xcb — so the old advice was a no-op in the
+            // first case and a startup abort in the second, which is how #1389
+            // happened. Name the workaround that always applies, and the override
+            // only where it helps.
+            qWarning() << "SpectrumWidget: running under XWayland with OpenGL — "
+                          "GLX context issues may occur. The Wayland platform "
+                          "plugin is unavailable or overridden; set "
+                          "AETHER_NO_GPU=1 to work around, or "
+                          "QT_QPA_PLATFORM='wayland;xcb' if you forced xcb "
+                          "yourself (#1233)";
+        }
     }
 #  endif
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -231,10 +231,9 @@ static int runConfigCli(int argc, char* argv[])
 // logging is up — so a Support bundle shows why we chose xcb vs wayland (the
 // first "why am I on XWayland / why did fractional scaling change" question).
 // nullptr choice = no override applied (not a Wayland session, or the user set
-// QT_QPA_PLATFORM already).
+// QT_QPA_PLATFORM already). The presence itself lives in DisplayPresence.h's
+// accessor (setDetectedDisplayPresence) so SpectrumWidget can read it too.
 static const char* g_qpaPlatformChoice = nullptr;
-static AetherSDR::DisplayPresence g_displayPresence =
-    AetherSDR::DisplayPresence::Unknown;
 
 static const char* displayPresenceName(AetherSDR::DisplayPresence p)
 {
@@ -261,10 +260,14 @@ int main(int argc, char* argv[])
         qputenv("QT_OPENGL", "software");
     }
 
-    // Render-adapter selection on multi-GPU systems.  Must run before the GL/D3D
-    // context is created (i.e. before QApplication): sets PRIME offload (Linux)
-    // or QT_D3D_ADAPTER_INDEX (Windows) from the persisted Display-menu choice.
-    AetherSDR::GpuSelector::applyAtStartup();
+    // NOTE ON ORDER: the QT_QPA_PLATFORM block runs BEFORE
+    // GpuSelector::applyAtStartup() below. GpuSelector::willUseWayland() reads
+    // QT_QPA_PLATFORM to decide whether to apply the X11/GLX NVIDIA vendor hint
+    // (__GLX_VENDOR_LIBRARY_NAME), so our platform choice must be in the
+    // environment before it runs — otherwise a headless box that we route to
+    // XWayland/GLX would be mistaken for EGL/Wayland and lose PRIME offload.
+    // applyAtStartup() is otherwise independent (pure sysfs reads + PRIME-var
+    // qputenv, no Qt/GL dependency), so nothing here needs it to go first.
 
     // Prefer native Wayland when running under a Wayland session (#1233).
     // Without this, Qt may fall back to XWayland (xcb platform) where GLX
@@ -320,7 +323,7 @@ int main(int argc, char* argv[])
                 AetherSDR::detectDisplayPresence();
             const bool headless =
                 presence == AetherSDR::DisplayPresence::Headless;
-            g_displayPresence = presence;
+            AetherSDR::setDetectedDisplayPresence(presence);
 #else
             constexpr bool headless = false;
 #endif
@@ -329,6 +332,13 @@ int main(int argc, char* argv[])
             g_qpaPlatformChoice = platform;  // re-emitted once logging is up
         }
     }
+
+    // Render-adapter selection on multi-GPU systems.  Must run before the GL/D3D
+    // context is created (i.e. before QApplication): sets PRIME offload (Linux)
+    // or QT_D3D_ADAPTER_INDEX (Windows) from the persisted Display-menu choice.
+    // Runs AFTER the QT_QPA_PLATFORM block above so GpuSelector::willUseWayland()
+    // reads the platform we actually chose (see the ORDER note above).
+    AetherSDR::GpuSelector::applyAtStartup();
 
 #ifdef __linux__
     // Install a tolerant X11 error handler before QApplication and before any
@@ -641,8 +651,8 @@ int main(int argc, char* argv[])
         if (g_qpaPlatformChoice) {
             qInfo().noquote()
                 << "Platform: Wayland session, display presence"
-                << displayPresenceName(g_displayPresence) << "-> QT_QPA_PLATFORM"
-                << g_qpaPlatformChoice;
+                << displayPresenceName(AetherSDR::detectedDisplayPresence())
+                << "-> QT_QPA_PLATFORM" << g_qpaPlatformChoice;
         }
 
         // Symlink aethersdr.log → latest timestamped file (for Support dialog)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 #include "core/SettingsSanitizer.h"
 #include "models/Nr2SettingsModel.h"
 #include "core/AutomationBridgeSettings.h"
+#include "core/DisplayPresence.h"
 #include "core/GpuSelector.h"
 #include "core/LogManager.h"
 #include "core/MacMicPermission.h"
@@ -279,7 +280,26 @@ int main(int argc, char* argv[])
     if (!qEnvironmentVariableIsSet("QT_QPA_PLATFORM")) {
         const QByteArray session = qgetenv("XDG_SESSION_TYPE");
         if (session == "wayland" && qEnvironmentVariableIsSet("WAYLAND_DISPLAY")) {
-            qputenv("QT_QPA_PLATFORM", "wayland;xcb");
+#ifdef __linux__
+            // Only override to xcb when we AFFIRMATIVELY detect a headless
+            // session — DRM connectors present, none connected (e.g. a Pi 5
+            // reached over wayvnc). Native-Wayland hardware GL cannot allocate a
+            // window surface with no DRM scanout, so the panadapter renders
+            // black under an EGL_BAD_MATCH storm (QT_OPENGL=software does NOT
+            // help — the failure is the wayland-egl surface, not the renderer).
+            // XWayland renders fine; "xcb;wayland" still falls back to wayland if
+            // the xcb plugin is absent. If we cannot tell (no DRM connectors
+            // found — a container, an unusual driver), keep the native-Wayland
+            // default rather than assume headless. A physical display restores
+            // it too.
+            if (AetherSDR::detectDisplayPresence()
+                == AetherSDR::DisplayPresence::Headless) {
+                qputenv("QT_QPA_PLATFORM", "xcb;wayland");
+            } else
+#endif
+            {
+                qputenv("QT_QPA_PLATFORM", "wayland;xcb");
+            }
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -226,6 +226,26 @@ static int runConfigCli(int argc, char* argv[])
     return usage();
 }
 
+// The Qt platform-selection decision made on a Wayland session, recorded before
+// the log handler exists and re-emitted next to the GpuSelector summary once
+// logging is up — so a Support bundle shows why we chose xcb vs wayland (the
+// first "why am I on XWayland / why did fractional scaling change" question).
+// nullptr choice = no override applied (not a Wayland session, or the user set
+// QT_QPA_PLATFORM already).
+static const char* g_qpaPlatformChoice = nullptr;
+static AetherSDR::DisplayPresence g_displayPresence =
+    AetherSDR::DisplayPresence::Unknown;
+
+static const char* displayPresenceName(AetherSDR::DisplayPresence p)
+{
+    switch (p) {
+        case AetherSDR::DisplayPresence::Connected: return "connected";
+        case AetherSDR::DisplayPresence::Headless:  return "headless";
+        case AetherSDR::DisplayPresence::Unknown:   return "unknown";
+    }
+    return "unknown";
+}
+
 int main(int argc, char* argv[])
 {
     if (argc >= 2 && qstrcmp(argv[1], "--config") == 0) {
@@ -280,26 +300,33 @@ int main(int argc, char* argv[])
     if (!qEnvironmentVariableIsSet("QT_QPA_PLATFORM")) {
         const QByteArray session = qgetenv("XDG_SESSION_TYPE");
         if (session == "wayland" && qEnvironmentVariableIsSet("WAYLAND_DISPLAY")) {
-#ifdef __linux__
             // Only override to xcb when we AFFIRMATIVELY detect a headless
-            // session — DRM connectors present, none connected (e.g. a Pi 5
-            // reached over wayvnc). Native-Wayland hardware GL cannot allocate a
-            // window surface with no DRM scanout, so the panadapter renders
-            // black under an EGL_BAD_MATCH storm (QT_OPENGL=software does NOT
-            // help — the failure is the wayland-egl surface, not the renderer).
-            // XWayland renders fine; "xcb;wayland" still falls back to wayland if
-            // the xcb plugin is absent. If we cannot tell (no DRM connectors
-            // found — a container, an unusual driver), keep the native-Wayland
-            // default rather than assume headless. A physical display restores
-            // it too.
-            if (AetherSDR::detectDisplayPresence()
-                == AetherSDR::DisplayPresence::Headless) {
-                qputenv("QT_QPA_PLATFORM", "xcb;wayland");
-            } else
+            // session — DRM connectors present, at least one "disconnected",
+            // none connected (e.g. a Pi 5 reached over wayvnc). Native-Wayland
+            // hardware GL cannot allocate a window surface with no DRM scanout,
+            // so the panadapter renders black under an EGL_BAD_MATCH storm
+            // (QT_OPENGL=software does NOT help — the failure is the wayland-egl
+            // surface, not the renderer). XWayland renders fine; "xcb;wayland"
+            // still falls back to wayland if the xcb plugin is absent. If we
+            // cannot tell (no DRM connectors, or every connector reports
+            // "unknown"), keep the native-Wayland default rather than assume
+            // headless. A physical display restores it too.
+            //
+            // Detect on Linux only; a bool with an #else arm keeps the branch
+            // below preprocessor-safe (an added branch can't silently rebind
+            // the non-Linux case).
+#ifdef __linux__
+            const AetherSDR::DisplayPresence presence =
+                AetherSDR::detectDisplayPresence();
+            const bool headless =
+                presence == AetherSDR::DisplayPresence::Headless;
+            g_displayPresence = presence;
+#else
+            constexpr bool headless = false;
 #endif
-            {
-                qputenv("QT_QPA_PLATFORM", "wayland;xcb");
-            }
+            const char* platform = headless ? "xcb;wayland" : "wayland;xcb";
+            qputenv("QT_QPA_PLATFORM", platform);
+            g_qpaPlatformChoice = platform;  // re-emitted once logging is up
         }
     }
 
@@ -609,6 +636,14 @@ int main(int argc, char* argv[])
         // (GpuSelector::applyAtStartup() ran before logging was available).
         qInfo().noquote() << "GpuSelector: render GPU ->"
                           << AetherSDR::GpuSelector::appliedSummary();
+
+        // Likewise the Wayland platform choice (decided before logging existed).
+        if (g_qpaPlatformChoice) {
+            qInfo().noquote()
+                << "Platform: Wayland session, display presence"
+                << displayPresenceName(g_displayPresence) << "-> QT_QPA_PLATFORM"
+                << g_qpaPlatformChoice;
+        }
 
         // Symlink aethersdr.log → latest timestamped file (for Support dialog)
         const QString symlink = logDir + "/aethersdr.log";

--- a/tests/display_presence_test.cpp
+++ b/tests/display_presence_test.cpp
@@ -99,6 +99,18 @@ int main(int argc, char** argv)
               == DisplayPresence::Unknown);
     }
 
+    // 9. Every connector reports "unknown" (all writeback/virtual, or a panel
+    //    that can't hotplug-detect: DPI, composite, some DSI) -> Unknown, NOT
+    //    Headless — we cannot tell, so don't push such a display onto XWayland.
+    {
+        QTemporaryDir dir;
+        makeConnector(dir.path(), QStringLiteral("card1-DSI-1"),
+                      QStringLiteral("unknown"));
+        makeConnector(dir.path(), QStringLiteral("card1-Writeback-1"),
+                      QStringLiteral("unknown"));
+        CHECK(detectDisplayPresence(dir.path()) == DisplayPresence::Unknown);
+    }
+
     if (g_failures == 0) {
         std::fprintf(stderr, "display_presence_test: all checks passed\n");
     }

--- a/tests/display_presence_test.cpp
+++ b/tests/display_presence_test.cpp
@@ -1,0 +1,106 @@
+#include "core/DisplayPresence.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QIODevice>
+#include <QTemporaryDir>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+    ++g_failures; \
+} } while (0)
+
+// Build a fake /sys/class/drm connector: <root>/<name>/status = <status>\n.
+static void makeConnector(const QString& root, const QString& name,
+                          const QString& status)
+{
+    QDir().mkpath(root + QStringLiteral("/") + name);
+    QFile f(root + QStringLiteral("/") + name + QStringLiteral("/status"));
+    if (f.open(QIODevice::WriteOnly)) {
+        f.write(status.toUtf8() + '\n');
+        f.close();
+    }
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    // 1. A connected display -> Connected.
+    {
+        QTemporaryDir dir;
+        makeConnector(dir.path(), QStringLiteral("card1-HDMI-A-1"),
+                      QStringLiteral("connected"));
+        makeConnector(dir.path(), QStringLiteral("card1-HDMI-A-2"),
+                      QStringLiteral("disconnected"));
+        CHECK(detectDisplayPresence(dir.path()) == DisplayPresence::Connected);
+    }
+
+    // 2. Connectors present, none connected -> Headless (the wayvnc case).
+    {
+        QTemporaryDir dir;
+        makeConnector(dir.path(), QStringLiteral("card1-HDMI-A-1"),
+                      QStringLiteral("disconnected"));
+        makeConnector(dir.path(), QStringLiteral("card1-HDMI-A-2"),
+                      QStringLiteral("disconnected"));
+        CHECK(detectDisplayPresence(dir.path()) == DisplayPresence::Headless);
+    }
+
+    // 3. Writeback / virtual connectors ("unknown") never count as connected.
+    {
+        QTemporaryDir dir;
+        makeConnector(dir.path(), QStringLiteral("card1-HDMI-A-1"),
+                      QStringLiteral("disconnected"));
+        makeConnector(dir.path(), QStringLiteral("card1-Writeback-1"),
+                      QStringLiteral("unknown"));
+        CHECK(detectDisplayPresence(dir.path()) == DisplayPresence::Headless);
+    }
+
+    // 4. No connector directories at all -> Unknown (do NOT assume headless).
+    {
+        QTemporaryDir dir;  // empty
+        CHECK(detectDisplayPresence(dir.path()) == DisplayPresence::Unknown);
+    }
+
+    // 5. Only non-connector entries (no "card*-*" dash form) -> Unknown.
+    {
+        QTemporaryDir dir;
+        QDir().mkpath(dir.path() + QStringLiteral("/card1"));       // no dash suffix
+        QDir().mkpath(dir.path() + QStringLiteral("/renderD128"));  // not a card
+        CHECK(detectDisplayPresence(dir.path()) == DisplayPresence::Unknown);
+    }
+
+    // 6. A connector directory without a status file is skipped, not counted.
+    {
+        QTemporaryDir dir;
+        QDir().mkpath(dir.path() + QStringLiteral("/card1-HDMI-A-1"));  // no status
+        makeConnector(dir.path(), QStringLiteral("card1-HDMI-A-2"),
+                      QStringLiteral("disconnected"));
+        CHECK(detectDisplayPresence(dir.path()) == DisplayPresence::Headless);
+    }
+
+    // 7. Trailing newline is trimmed; a second card's connector counts too.
+    {
+        QTemporaryDir dir;
+        makeConnector(dir.path(), QStringLiteral("card0-DP-1"),
+                      QStringLiteral("connected"));
+        CHECK(detectDisplayPresence(dir.path()) == DisplayPresence::Connected);
+    }
+
+    // 8. A nonexistent root -> Unknown (no crash).
+    {
+        CHECK(detectDisplayPresence(QStringLiteral("/nonexistent/path/xyz"))
+              == DisplayPresence::Unknown);
+    }
+
+    if (g_failures == 0) {
+        std::fprintf(stderr, "display_presence_test: all checks passed\n");
+    }
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

When AetherSDR runs under a **headless Wayland** session — no physical monitor, as is typical for remote access via **VNC (wayvnc)** — the GPU panadapter/waterfall render **black** under a continuous `QWaylandGLContext::makeCurrent: EGL_BAD_MATCH` storm. With no DRM scanout, the driver cannot allocate a GL **window surface**, so every frame's `makeCurrent` fails. `AETHER_NO_GPU=1` (software GL) does **not** help — the failure is the wayland-egl *surface*, not the renderer. XWayland allocates its window buffers through the X server and renders fine, which is why `QT_QPA_PLATFORM=xcb` is the current manual workaround.

Detect a **headless** session at startup and prefer `xcb` automatically, so a remote/headless user gets a working GPU window with no env-var knowledge.

Fixes #4747.

## Update 2026-08-06 — round-2 review addressed + rebased onto `main`

Rebased onto current `main` now that #4754 (the `dss_mesh` GLSL shader fix) merged, so it's in the base — which let the *combined* behaviour be validated end-to-end (below). Addressed @ten9876's two blockers + nit:

- **`GpuSelector` ordering + `willUseWayland()` (Blocker 1).** The `QT_QPA_PLATFORM` block now runs *before* `GpuSelector::applyAtStartup()` (which is pure sysfs + PRIME-var `qputenv`, no Qt/GL dependency), and `willUseWayland()` reads the **first** entry of the ordered `QT_QPA_PLATFORM` list (`"xcb;wayland"` → `false`, not a substring match). Together these keep the X11/GLX NVIDIA vendor hint (`__GLX_VENDOR_LIBRARY_NAME`) in place when a headless box actually runs on XWayland/GLX — no lost PRIME offload — and fix the pre-existing manual `QT_QPA_PLATFORM=xcb` case too.
- **`SpectrumWidget` XWayland warning (Blocker 2).** It now branches on the detected presence: a deliberate headless→xcb choice logs an informational "using XWayland by design (#4747)" line instead of the false "Wayland plugin unavailable / try `wayland;xcb`" that would have sent exactly the fixed cohort back to the black panadapter. The display-present / user-forced-xcb case keeps the original #1389-safe warning. The presence result moved from a `main.cpp` file-static into a small `DisplayPresence.h` accessor (`setDetectedDisplayPresence`/`detectedDisplayPresence`) so `SpectrumWidget` can read it.
- **Host-vs-session nit.** `DisplayPresence.h` now documents that the DRM probe is a host-level stand-in for a session-level fact (headless compositor on a host with a monitor elsewhere / a VM guest → false `Connected`), diagnosable via the startup log line.

**Three-platform validation** (rebased tip `b691c057`; CI green on all four checks incl. check-macos / check-windows):
- **Headless RPi5** (wayvnc + labwc, Qt 6.8.2, v3d): headless→xcb auto-selected, **0** `makeCurrent` failures, `dss_mesh` builds on the GPU, and **3D FFT renders without the CPU-fallback main-thread freeze** it hit before the shader fix landed in the base. Startup log: `SpectrumWidget: headless Wayland session — using XWayland by design (#4747; …)`.
- **macOS** (Qt 6.11, Metal) and **Windows 11** (MSVC, D3D11): build clean, run, 3D FFT works; the Linux-only platform path is a compile-time no-op there.

## What changed

- New `src/core/DisplayPresence.h` — a small header-only `detectDisplayPresence(drmRoot)` that scans `/sys/class/drm/*/status` and returns a tri-state: **Connected** (some connector `connected`), **Headless** (at least one connector `disconnected`, none connected), or **Unknown** (no connectors found, **or every connector reports `unknown`**).
- `src/main.cpp` — in the existing pre-`QApplication` platform-selection block, when under a Wayland session, prefer `xcb;wayland` **only when affirmatively `Headless`**; otherwise keep `wayland;xcb`. The decision (display presence + chosen list) is **logged** at startup next to the `GpuSelector` summary, using the same deferred-emit pattern — the platform is chosen before the log handler exists. The Linux/non-Linux split is a `bool headless` with an `#else` arm (rather than an `if`/`else` straddling `#endif`), so a later-added branch can't silently rebind the non-Linux case.
- `tests/display_presence_test.cpp` — unit-tests the detection against a fake sysfs tree (9 cases).
- `README.md` — documents the now-conditional Wayland platform default and how to force either direction.

## Design notes

- **Tri-state, not a boolean.** xcb is forced only when we *affirmatively* detect headless: at least one connector reports `disconnected` and none `connected`. `unknown` is **not** only writeback/virtual connectors — DPI, composite TV-out, and some fixed DSI panels report `unknown` while a panel is physically attached. So an all-`unknown` set (or no connectors at all — a container, an unusual driver) returns `Unknown` and keeps the native-Wayland default. We don't assume headless when we can't tell.
- **A connected display keeps native Wayland** — even a dummy HDMI plug, which provides a scanout. A user-set `QT_QPA_PLATFORM` still wins.
- **The decision is logged.** A silent platform switch would leave the first "why am I on XWayland / why did fractional scaling change" support thread with nothing to go on. The chosen platform + presence are recorded at startup: `Platform: Wayland session, display presence <presence> -> QT_QPA_PLATFORM <list>` — diagnosable from a Support bundle alone.
- **`#1233` was checked.** Routing headless sessions through XWayland could in principle re-expose the #1233 GLX child-dialog crash (the reason native Wayland is otherwise preferred). Verified **clean on labwc**: repeatedly opening Radio Setup plus switching the display 3D↔2D produced no crash and no X11/GLX errors (not even a suppressed one). This has not been exercised on other compositors' XWayland; the `xcb;wayland` fallback still degrades to wayland if xcb is unavailable.

## Constitution principle honored

**Principle XI — Fixes Are Demonstrated.** Verified by build, unit test, and runtime on three toolchains, plus the #1233 dialog check (below).

## Test plan

- [x] Local build passes (`cmake --build`)
  - macOS arm64, Qt **6.11** — green
  - Raspberry Pi 5, Debian trixie, Qt **6.8.2** — green
  - Windows 11, MSVC — green (the Linux-only path is a compile-time no-op there)
- [x] New unit test passes — `display_presence_test` (9 cases: connected / headless / unknown, writeback ignored, **all-`unknown` → Unknown**, missing status file, non-connector entries, missing root) on macOS and the Pi.
- [x] Behavior verified
  - Headless RPi5 (wayvnc + labwc), Wayland session, no `QT_QPA_PLATFORM`: app **auto-selects xcb**, logs `Platform: Wayland session, display presence headless -> QT_QPA_PLATFORM xcb;wayland`, **0** makeCurrent failures, GPU panadapter renders (previously black under an EGL_BAD_MATCH storm). The Pi's two `Writeback` connectors report `unknown` and correctly do **not** prevent the two `disconnected` HDMIs from yielding `Headless` — exercises the all-`unknown` refinement against real sysfs.
  - #1233 XWayland child-dialog check: clean on labwc (no crash, no X11/GLX errors).
  - Windows 11 (MSVC): builds and launches; the platform-selection path is `#ifdef __linux__`, a no-op there.
- [ ] Existing tests pass (CI) — relies on CI; only an additive test here.
- [x] Reproduction steps documented if user-reported bug — see #4747
- [x] `git diff --check` — clean
- [x] `python3 tools/check_engine_boundary.py --strict` — 0 blocking findings

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — N/A, no settings changes
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered
- [x] All meter UI uses `MeterSmoother` — N/A, no meter changes
- [x] Documentation updated if user-visible behavior changed — README's *Wayland and XWayland* section now documents the conditional default and both override directions.
- [x] Security-sensitive changes reference a GHSA if applicable — N/A

## Related

- **#1233** — the XWayland GLX child-dialog crash that motivates preferring native Wayland; verified clean on labwc here.
- **#4746** — a separate `dss_mesh` GLSL shader bug; independent root cause, but both surface together on a headless RPi5.

Built and smoke tested on: MacBook Air M2 / Raspberry Pi 5 Debian trixie / Win 11 i3

