### PR TITLE
feat(freedv): status message entry in the FreeDV Reporter panel (#4231)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5213,6 +5213,30 @@ target_link_libraries(help_dialog_test PRIVATE
 )
 set_target_properties(help_dialog_test PROPERTIES AUTOMOC ON)
 
+# FreeDV Reporter status-message row (#4231). Guarded like the dialog
+# itself — FreeDvReporterDialog only exists when WebSockets are available.
+# Dialog-side only: the test never reaches qso.freedv.org.
+if(Qt6WebSockets_FOUND)
+    # src/gui/ sources belong to the AetherSDR executable rather than
+    # aethercore, so the dialog's GUI dependencies are listed explicitly;
+    # SliceModel/ThemeManager/settings come in via aethercore.
+    add_executable(freedv_reporter_message_test
+        tests/freedv_reporter_message_test.cpp
+        src/gui/FreeDvReporterDialog.cpp
+        src/gui/FreeDvReporterModel.cpp
+        src/gui/PersistentDialog.cpp
+        src/gui/FramelessResizer.cpp
+        src/gui/FramelessWindowTitleBar.cpp
+    )
+    target_include_directories(freedv_reporter_message_test PRIVATE src)
+    target_link_libraries(freedv_reporter_message_test PRIVATE
+        aethercore Qt6::Core Qt6::Widgets Qt6::Test
+    )
+    set_target_properties(freedv_reporter_message_test PROPERTIES AUTOMOC ON)
+    add_test(NAME freedv_reporter_message_test
+             COMMAND freedv_reporter_message_test)
+endif()
+
 # Regression guard for #3662: the AetherControl window must never demand a
 # minimum height taller than the screen (auto-engages compact when it would).
 add_executable(flex_control_dialog_size_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5235,6 +5235,8 @@ if(Qt6WebSockets_FOUND)
     set_target_properties(freedv_reporter_message_test PROPERTIES AUTOMOC ON)
     add_test(NAME freedv_reporter_message_test
              COMMAND freedv_reporter_message_test)
+    set_tests_properties(freedv_reporter_message_test PROPERTIES
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 endif()
 
 # Regression guard for #3662: the AetherControl window must never demand a

--- a/src/core/FreeDvClient.cpp
+++ b/src/core/FreeDvClient.cpp
@@ -523,6 +523,7 @@ void FreeDvClient::enableReporting(const QString& callsign, const QString& grid,
 
     qCDebug(lcDxCluster) << "FreeDvClient: reporting enabled for" << callsign
                           << "grid" << grid << "freq" << freqMhz << "MHz";
+    emit reportingStateChanged(true);
 
     if (m_connected.load() &&
         m_ws->state() != QAbstractSocket::ClosingState) {
@@ -543,6 +544,7 @@ void FreeDvClient::disableReporting()
     m_lastSnr    = -99.0f;
 
     qCDebug(lcDxCluster) << "FreeDvClient: reporting disabled";
+    emit reportingStateChanged(false);
 
     if (m_connected.load() &&
         m_ws->state() != QAbstractSocket::ClosingState) {
@@ -604,7 +606,7 @@ void FreeDvClient::updateRxSynced(bool synced)
 void FreeDvClient::updateRxCallsign(const QString& callsign)
 {
     qCDebug(lcDxCluster) << "FreeDvClient: EOO callsign received:" << callsign
-                        << "reporting=" << m_reportingEnabled
+                        << "reporting=" << m_reportingEnabled.load()
                         << "connected=" << m_connected.load()
                         << "synced=" << m_radeSynced
                         << "snr=" << m_lastSnr;

--- a/src/core/FreeDvClient.h
+++ b/src/core/FreeDvClient.h
@@ -49,6 +49,10 @@ public:
     void startConnection();
     void stopConnection();
     bool isConnected() const { return m_connected.load(); }
+    // Atomic like m_connected: written on the client's worker thread, read
+    // from the GUI thread (the reporter dialog gates its message field on
+    // it — #4231).
+    bool isReportingEnabled() const { return m_reportingEnabled.load(); }
     QString myGrid() const { return m_myGrid; }
     QHash<QString, StationInfo> stations() const { return m_stations; }
 
@@ -63,6 +67,10 @@ signals:
     void stationsCleared();
     void stationUpdated(const QString& sid, const AetherSDR::FreeDvClient::StationInfo& info);
     void stationRemoved(const QString& sid);
+    // Full-participant reporting turned on/off. The reporter dialog uses this
+    // to enable its message field, since updateMessage() only reaches the
+    // server while reporting is active (#4231).
+    void reportingStateChanged(bool enabled);
 
 public slots:
     // Defer QWebSocket + timer construction to the worker thread (#1929) —
@@ -120,7 +128,7 @@ private:
     QHash<QString, StationInfo> m_stations;  // sid → station info
 
     // Station reporting state
-    bool    m_reportingEnabled{false};
+    std::atomic<bool> m_reportingEnabled{false};
     bool    m_authNeedsRefresh{false};  // reconnect in progress for auth change
     QString m_myCallsign;
     QString m_myGrid;

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -1,6 +1,9 @@
 #include "DxClusterDialog.h"
 #include "DxClusterStartupCommandsDialog.h"
 #include "FlowLayout.h"
+// For MessageMaxLength — the two surfaces share FreeDvMyMessage, so they
+// must share its cap too. Header self-guards on HAVE_WEBSOCKETS.
+#include "FreeDvReporterDialog.h"
 #include "GuardedSlider.h"
 #include "core/DxClusterClient.h"
 #include "core/AppSettings.h"
@@ -1830,9 +1833,22 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
     reportLayout->addWidget(new QLabel("Station Msg:"), frow, 0);
     m_fdvMessageEdit = new QLineEdit;
     m_fdvMessageEdit->setPlaceholderText("Optional message shown on reporter map");
+    // Same cap as the FreeDV Reporter panel's field, so the bound is real at
+    // both entry points — otherwise a long message set here would sail past
+    // it, and the panel's reloadMessage() would then silently truncate what
+    // it displays relative to what is actually being broadcast (#4231 review).
+    m_fdvMessageEdit->setMaxLength(FreeDvReporterDialog::MessageMaxLength);
     m_fdvMessageEdit->setText(s.value("FreeDvMyMessage", "").toString());
     AetherSDR::ThemeManager::instance().applyStyleSheet(m_fdvMessageEdit, "QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}}; border: 1px solid {{color.background.1}}; padding: 3px; }");
     connect(m_fdvMessageEdit, &QLineEdit::editingFinished, this, [this] {
+        // Focus-out without an edit must not write: this dialog is a
+        // persistent singleton whose copy of FreeDvMyMessage can be stale
+        // (the FreeDV Reporter panel writes the same setting), and
+        // re-emitting it would silently revert a message sent there.
+        // setText() clears the flag, so reloadFreedvMessage() composes with
+        // this (#4231 review).
+        if (!m_fdvMessageEdit->isModified()) return;
+        m_fdvMessageEdit->setModified(false);
         auto& as = AppSettings::instance();
         QString msg = m_fdvMessageEdit->text().trimmed();
         as.setValue("FreeDvMyMessage", msg);
@@ -2818,8 +2834,11 @@ void DxClusterDialog::reloadFreedvMessage()
 
     const QString stored = AppSettings::instance()
                                .value("FreeDvMyMessage", "").toString();
-    // Don't clobber an in-progress edit the operator hasn't sent yet.
-    if (!m_fdvMessageEdit->hasFocus() && m_fdvMessageEdit->text() != stored)
+    // isModified(), not hasFocus() — same reasoning as the reporter panel's
+    // reloadMessage(): focus has already left by the time the menu action
+    // fires. setText() clears the flag, which is also what keeps this from
+    // arming the editingFinished guard above (#4231 review).
+    if (!m_fdvMessageEdit->isModified() && m_fdvMessageEdit->text() != stored)
         m_fdvMessageEdit->setText(stored);
 }
 #endif

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -2811,6 +2811,19 @@ void DxClusterDialog::setTotalSpots(int count)
         m_totalSpotsLabel->setText(QString::number(count));
 }
 
+#ifdef HAVE_WEBSOCKETS
+void DxClusterDialog::reloadFreedvMessage()
+{
+    if (!m_fdvMessageEdit) return;
+
+    const QString stored = AppSettings::instance()
+                               .value("FreeDvMyMessage", "").toString();
+    // Don't clobber an in-progress edit the operator hasn't sent yet.
+    if (!m_fdvMessageEdit->hasFocus() && m_fdvMessageEdit->text() != stored)
+        m_fdvMessageEdit->setText(stored);
+}
+#endif
+
 void DxClusterDialog::flushSpotBatch()
 {
     if (m_spotListFrozen) {

--- a/src/gui/DxClusterDialog.h
+++ b/src/gui/DxClusterDialog.h
@@ -94,6 +94,14 @@ public:
 
     void updateStatus();
     void setTotalSpots(int count);
+#ifdef HAVE_WEBSOCKETS
+    // Re-reads FreeDvMyMessage from AppSettings. Called on each SpotHub open
+    // so an edit made in the FreeDV Reporter panel (same setting) is
+    // reflected here — this dialog is a persistent singleton
+    // (showOrRaisePersistent), so without this the field would only ever
+    // show whatever it was at first construction (#4231 review).
+    void reloadFreedvMessage();
+#endif
 
 signals:
     void connectRequested(const QString& host, quint16 port, const QString& callsign);

--- a/src/gui/FreeDvReporterDialog.cpp
+++ b/src/gui/FreeDvReporterDialog.cpp
@@ -13,6 +13,8 @@
 #include <QTableView>
 #include <QHeaderView>
 #include <QCheckBox>
+#include <QLabel>
+#include <QLineEdit>
 #include <QRadioButton>
 #include <QPushButton>
 #include <QButtonGroup>
@@ -145,6 +147,68 @@ void FreeDvReporterDialog::buildBody()
     auto* root = new QVBoxLayout(bodyWidget());
     root->setContentsMargins(6, 6, 6, 6);
     root->setSpacing(4);
+
+    // ── Status message ─────────────────────────────────────────────────────
+    // Shares the FreeDvMyMessage setting with SpotHub's FreeDV tab, so the
+    // two surfaces stay in sync (#4231). Starts disabled; setReportingActive()
+    // from MainWindow opens it once full-participant reporting is on.
+    // Qt does not deliver tooltips to disabled widgets, so the "why is this
+    // off?" tooltip lives on an always-enabled container instead of on the
+    // field/button themselves — otherwise it would be unreachable in exactly
+    // the state that needs explaining.
+    m_msgRowWidget = new QWidget;
+    auto* msgRow = new QHBoxLayout(m_msgRowWidget);
+    msgRow->setContentsMargins(0, 0, 0, 0);
+    msgRow->setSpacing(6);
+
+    m_msgLabel = new QLabel("Message");
+    ThemeManager::instance().applyStyleSheet(m_msgLabel,
+        "QLabel { color: {{color.text.primary}}; }");
+    msgRow->addWidget(m_msgLabel);
+    // Set after m_msgEdit exists — see below.
+
+    m_msgEdit = new QLineEdit;
+    m_msgEdit->setObjectName(QStringLiteral("fdvReporterMessageEdit"));
+    m_msgEdit->setMaxLength(MessageMaxLength);
+    m_msgEdit->setAccessibleName("FreeDV Reporter status message");
+    m_msgEdit->setText(AppSettings::instance()
+                           .value("FreeDvMyMessage", "").toString());
+    ThemeManager::instance().applyStyleSheet(m_msgEdit,
+        "QLineEdit {"
+        "  background-color: {{color.background.0}};"
+        "  color: {{color.text.primary}};"
+        "  border: 1px solid {{color.background.2}};"
+        "  padding: 2px 4px;"
+        "}"
+        "QLineEdit:disabled { color: {{color.text.secondary}}; }"
+    );
+    m_msgLabel->setBuddy(m_msgEdit);
+    msgRow->addWidget(m_msgEdit, 1);
+
+    m_msgSendBtn = new QPushButton("Send");
+    m_msgSendBtn->setObjectName(QStringLiteral("fdvReporterMessageSendButton"));
+    m_msgSendBtn->setAutoDefault(false);
+    m_msgSendBtn->setAccessibleName("Send FreeDV Reporter status message");
+    ThemeManager::instance().applyStyleSheet(m_msgSendBtn,
+        "QPushButton {"
+        "  background-color: {{color.background.2}};"
+        "  color: {{color.text.primary}};"
+        "  border: 1px solid {{color.background.2}};"
+        "  padding: 2px 10px;"
+        "}"
+        "QPushButton:hover { background-color: {{color.background.2}}; }"
+        "QPushButton:disabled { color: {{color.text.secondary}}; }"
+    );
+    msgRow->addWidget(m_msgSendBtn);
+
+    root->addWidget(m_msgRowWidget);
+
+    connect(m_msgSendBtn, &QPushButton::clicked,
+            this, &FreeDvReporterDialog::commitMessage);
+    connect(m_msgEdit, &QLineEdit::returnPressed,
+            this, &FreeDvReporterDialog::commitMessage);
+
+    setReportingActive(false);
 
     // ── Table ──────────────────────────────────────────────────────────────
     m_table = new QTableView;
@@ -327,6 +391,54 @@ void FreeDvReporterDialog::onStationRemoved(const QString& sid)
 void FreeDvReporterDialog::setMyGrid(const QString& grid)
 {
     m_model->setMyGrid(grid);
+}
+
+void FreeDvReporterDialog::reloadMessage()
+{
+    const QString stored = AppSettings::instance()
+                               .value("FreeDvMyMessage", "").toString();
+    // Don't clobber an in-progress edit the operator hasn't sent yet.
+    if (!m_msgEdit->hasFocus() && m_msgEdit->text() != stored)
+        m_msgEdit->setText(stored);
+}
+
+void FreeDvReporterDialog::setReportingActive(bool active)
+{
+    m_msgEdit->setEnabled(active);
+    m_msgSendBtn->setEnabled(active);
+
+    // Say why it's off rather than leaving a dead field the operator has to
+    // guess about — updateMessage() would silently no-op here (#4231).
+    const QString tip = active
+        ? QStringLiteral("Status message broadcast to the FreeDV Reporter map "
+                         "alongside your callsign (max %1 characters).")
+              .arg(MessageMaxLength)
+        : QStringLiteral("Available when FreeDV reporting is active — enable it "
+                         "in SpotHub → FreeDV, or start RADE on a slice.");
+    // On the container, not the children: disabled widgets get no tooltip.
+    m_msgRowWidget->setToolTip(tip);
+    // The placeholder carries the reason too, so it's readable without
+    // hovering — the field is greyed but its placeholder still paints.
+    m_msgEdit->setPlaceholderText(
+        active ? QStringLiteral("Optional status shown on the reporter map")
+               : QStringLiteral("Enable FreeDV reporting to send a status message"));
+    // Same explanation for screen readers, not just hover.
+    m_msgEdit->setAccessibleDescription(tip);
+    m_msgSendBtn->setAccessibleDescription(tip);
+}
+
+void FreeDvReporterDialog::commitMessage()
+{
+    const QString msg = m_msgEdit->text().trimmed();
+    // Write back the trimmed form so what's stored is what was sent.
+    if (m_msgEdit->text() != msg)
+        m_msgEdit->setText(msg);
+
+    auto& s = AppSettings::instance();
+    s.setValue("FreeDvMyMessage", msg);
+    s.save();
+
+    emit messageChanged(msg);
 }
 
 // ── Slot implementations ───────────────────────────────────────────────────

--- a/src/gui/FreeDvReporterDialog.cpp
+++ b/src/gui/FreeDvReporterDialog.cpp
@@ -196,7 +196,10 @@ void FreeDvReporterDialog::buildBody()
         "  border: 1px solid {{color.background.2}};"
         "  padding: 2px 10px;"
         "}"
-        "QPushButton:hover { background-color: {{color.background.2}}; }"
+        // background.1, not background.2 again — the existing Close button
+        // below has this same-as-base no-op already (pre-existing, out of
+        // scope here); this button shouldn't repeat it (#4231 review).
+        "QPushButton:hover { background-color: {{color.background.1}}; }"
         "QPushButton:disabled { color: {{color.text.secondary}}; }"
     );
     msgRow->addWidget(m_msgSendBtn);

--- a/src/gui/FreeDvReporterDialog.cpp
+++ b/src/gui/FreeDvReporterDialog.cpp
@@ -200,7 +200,15 @@ void FreeDvReporterDialog::buildBody()
         // below has this same-as-base no-op already (pre-existing, out of
         // scope here); this button shouldn't repeat it (#4231 review).
         "QPushButton:hover { background-color: {{color.background.1}}; }"
-        "QPushButton:disabled { color: {{color.text.secondary}}; }"
+        // Widget×state tokens rather than generic chrome (docs/a11y.md):
+        // dimming the text alone left the disabled button reading as absent
+        // rather than greyed-out, which undercuts the row's own gating
+        // (#4231 review).
+        "QPushButton:disabled {"
+        "  background-color: {{color.button.background.disabled}};"
+        "  color: {{color.button.foreground.disabled}};"
+        "  border: 1px solid {{color.button.border.disabled}};"
+        "}"
     );
     msgRow->addWidget(m_msgSendBtn);
 
@@ -400,8 +408,12 @@ void FreeDvReporterDialog::reloadMessage()
 {
     const QString stored = AppSettings::instance()
                                .value("FreeDvMyMessage", "").toString();
-    // Don't clobber an in-progress edit the operator hasn't sent yet.
-    if (!m_msgEdit->hasFocus() && m_msgEdit->text() != stored)
+    // isModified(), not hasFocus(): the point is to protect an unsent draft,
+    // and focus has already moved away by the time the operator clicks the
+    // menu to re-show this dialog — so a focus test would let the draft be
+    // silently replaced in exactly the case it exists to cover. setText()
+    // clears the flag, so this composes with commitMessage() (#4231 review).
+    if (!m_msgEdit->isModified() && m_msgEdit->text() != stored)
         m_msgEdit->setText(stored);
 }
 
@@ -420,8 +432,13 @@ void FreeDvReporterDialog::setReportingActive(bool active)
                          "in SpotHub → FreeDV, or start RADE on a slice.");
     // On the container, not the children: disabled widgets get no tooltip.
     m_msgRowWidget->setToolTip(tip);
-    // The placeholder carries the reason too, so it's readable without
-    // hovering — the field is greyed but its placeholder still paints.
+    // The label carries the state, not just the placeholder: Qt only paints a
+    // placeholder on an *empty* field, and this one is seeded from
+    // FreeDvMyMessage — so for anyone who has ever set a message (i.e. the
+    // people this feature is for) the placeholder never shows and the tooltip
+    // would be the only remedy (#4231 review).
+    m_msgLabel->setText(active ? QStringLiteral("Message")
+                               : QStringLiteral("Message (reporting off)"));
     m_msgEdit->setPlaceholderText(
         active ? QStringLiteral("Optional status shown on the reporter map")
                : QStringLiteral("Enable FreeDV reporting to send a status message"));
@@ -436,6 +453,9 @@ void FreeDvReporterDialog::commitMessage()
     // Write back the trimmed form so what's stored is what was sent.
     if (m_msgEdit->text() != msg)
         m_msgEdit->setText(msg);
+    // Sent, so no longer an unsent draft — lets reloadMessage() track the
+    // setting again.
+    m_msgEdit->setModified(false);
 
     auto& s = AppSettings::instance();
     s.setValue("FreeDvMyMessage", msg);

--- a/src/gui/FreeDvReporterDialog.h
+++ b/src/gui/FreeDvReporterDialog.h
@@ -12,6 +12,8 @@
 
 class QTableView;
 class QCheckBox;
+class QLabel;
+class QLineEdit;
 class QRadioButton;
 class QPushButton;
 class QButtonGroup;
@@ -34,6 +36,19 @@ public slots:
     void onStationUpdated(const QString& sid, const AetherSDR::FreeDvClient::StationInfo& info);
     void onStationRemoved(const QString& sid);
     void setMyGrid(const QString& grid);
+    // Re-reads FreeDvMyMessage from AppSettings. Called on each open so an
+    // edit made in SpotHub's FreeDV tab is reflected here (#4231).
+    void reloadMessage();
+    // Enables the message row. updateMessage() only reaches the server while
+    // full-participant reporting is active, so while it's off the field is
+    // disabled with a tooltip saying why rather than silently doing nothing
+    // (#4231).
+    void setReportingActive(bool active);
+
+signals:
+    // Emitted when the operator commits a new status message. MainWindow
+    // forwards it to FreeDvClient::updateMessage() on the client's thread.
+    void messageChanged(const QString& message);
 
 private slots:
     void onSliceFrequencyChanged(double mhz);
@@ -48,6 +63,7 @@ private:
     void syncButtonStates();
     void persistSettings() const;
     void restoreSettings();
+    void commitMessage();
 
 public:
     // Total number of band filter buttons (10 named bands + "All").
@@ -55,12 +71,22 @@ public:
     // The "All" button is always at index BandCount-1 = 10.
     static constexpr int BandCount = 11;
 
+    // Client-side cap on the status message. qso.freedv.org publishes no
+    // documented limit and FreeDV-GUI does not cap client-side, so this is a
+    // conservative bound that keeps the reporter grid's Msg column readable
+    // rather than a protocol constraint (#4231).
+    static constexpr int MessageMaxLength = 100;
+
 private:
 
     FreeDvReporterModel*     m_model{nullptr};
     QSortFilterProxyModel*   m_proxy{nullptr};
 
     QTableView*    m_table{nullptr};
+    QWidget*       m_msgRowWidget{nullptr};
+    QLabel*        m_msgLabel{nullptr};
+    QLineEdit*     m_msgEdit{nullptr};
+    QPushButton*   m_msgSendBtn{nullptr};
     QCheckBox*     m_trackCheck{nullptr};
     QRadioButton*  m_bandRadio{nullptr};
     QRadioButton*  m_freqRadio{nullptr};

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -962,6 +962,21 @@ void MainWindow::showFreeDvReporter()
         connect(m_freedvClient, &FreeDvClient::stationRemoved,
                 m_freedvReporterDialog, &FreeDvReporterDialog::onStationRemoved,
                 Qt::QueuedConnection);
+        // Status message (#4231) — the client lives on m_spotThread, so the
+        // send hops threads via invokeMethod (mirrors the SpotHub wiring in
+        // MainWindow_Menus.cpp), and the enable/disable state comes back over
+        // a queued connection.
+        connect(m_freedvReporterDialog, &FreeDvReporterDialog::messageChanged,
+                this, [this](const QString& msg) {
+            QMetaObject::invokeMethod(m_freedvClient,
+                                      [this, msg] { m_freedvClient->updateMessage(msg); });
+        });
+        connect(m_freedvClient, &FreeDvClient::reportingStateChanged,
+                m_freedvReporterDialog, &FreeDvReporterDialog::setReportingActive,
+                Qt::QueuedConnection);
+        // Seed: reporting may already be on when the dialog is first opened.
+        m_freedvReporterDialog->setReportingActive(
+            m_freedvClient->isReportingEnabled());
         if (auto* s = activeSlice())
             m_freedvReporterDialog->setActiveSlice(s);
         // Seed with current state — bulk_update fires at connect time, before the
@@ -985,6 +1000,9 @@ void MainWindow::showFreeDvReporter()
             grid = m_freedvClient->myGrid();
         m_freedvReporterDialog->setMyGrid(grid);
     }
+    // Re-read the message every open so an edit made in SpotHub's FreeDV tab
+    // (same FreeDvMyMessage setting) doesn't leave this field stale (#4231).
+    m_freedvReporterDialog->reloadMessage();
     m_freedvReporterDialog->show();
     m_freedvReporterDialog->raise();
     m_freedvReporterDialog->activateWindow();

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -370,6 +370,15 @@ void MainWindow::buildMenuBar()
                               m_freedvClient,
 #endif
                               &m_radioModel, &m_dxccProvider);
+#ifdef HAVE_WEBSOCKETS
+        // Every open, not just the first: this dialog is a persistent
+        // singleton, so without this the field would only ever show
+        // whatever FreeDvMyMessage was at first construction, silently
+        // reverting anything sent from the FreeDV Reporter panel since
+        // (#4231 review).
+        if (m_spotHubDialog)
+            m_spotHubDialog->reloadFreedvMessage();
+#endif
         if (!wasFresh || !m_spotHubDialog) return;
         auto* dlg = m_spotHubDialog.data();
         dlg->setTotalSpots(m_radioModel.spotModel().spots().size());

--- a/tests/freedv_reporter_message_test.cpp
+++ b/tests/freedv_reporter_message_test.cpp
@@ -180,23 +180,31 @@ void testReloadFromSettings()
     report("reload picks up an external edit",
            edit->text() == QStringLiteral("set from SpotHub"), edit->text());
 
-    // An unfocused field tracks the setting; a focused one is left alone so
-    // a half-typed message survives the dialog being reopened.
-    edit->setText("half-typed, not sent");
-    edit->setFocus();
-    const bool focused = edit->hasFocus();
+    // An untouched field tracks the setting; a typed-but-unsent draft is
+    // left alone. The guard is the modified flag rather than focus — focus
+    // has already moved away by the time the operator re-opens the dialog,
+    // so a focus test would never fire in the case it exists to cover (and,
+    // being unreachable offscreen, would never be tested either).
+    // insert() rather than setText(): setText() clears the modified flag,
+    // which is exactly the distinction under test here.
+    edit->clear();
+    edit->insert(QStringLiteral("half-typed, not sent"));
+    report("typing marks the field modified", edit->isModified());
+
     s.setValue("FreeDvMyMessage", "changed underneath");
     s.save();
     dlg.reloadMessage();
-    if (focused) {
-        report("reload does not clobber a focused in-progress edit",
-               edit->text() == QStringLiteral("half-typed, not sent"), edit->text());
-    } else {
-        // Offscreen platforms may refuse focus; the unfocused path is the
-        // one being exercised then, so assert that instead.
-        report("reload refreshes an unfocused field",
-               edit->text() == QStringLiteral("changed underneath"), edit->text());
-    }
+    report("reload does not clobber an unsent draft",
+           edit->text() == QStringLiteral("half-typed, not sent"), edit->text());
+
+    // Sending clears the draft state, so the field tracks the setting again.
+    msgSendBtn(dlg)->click();
+    report("send clears the modified flag", !edit->isModified());
+    s.setValue("FreeDvMyMessage", "changed again");
+    s.save();
+    dlg.reloadMessage();
+    report("reload refreshes once the draft has been sent",
+           edit->text() == QStringLiteral("changed again"), edit->text());
 }
 
 } // namespace

--- a/tests/freedv_reporter_message_test.cpp
+++ b/tests/freedv_reporter_message_test.cpp
@@ -1,0 +1,230 @@
+// FreeDV Reporter status-message row (#4231).
+//
+// Covers the dialog-side logic only — no network. The send path stops at
+// the messageChanged() signal; MainWindow is what forwards it to
+// FreeDvClient::updateMessage() on the client thread, so nothing here can
+// reach qso.freedv.org.
+
+#include "TestSettingsProfile.h"
+#include "core/AppSettings.h"
+#include "gui/FreeDvReporterDialog.h"
+
+#include <QApplication>
+#include <QFile>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QSignalSpy>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const QString& detail = QString())
+{
+    std::printf("%s %-56s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                qPrintable(detail));
+    if (!ok) ++g_failed;
+}
+
+QLineEdit* msgEdit(FreeDvReporterDialog& dlg)
+{
+    return dlg.findChild<QLineEdit*>(QStringLiteral("fdvReporterMessageEdit"));
+}
+
+QPushButton* msgSendBtn(FreeDvReporterDialog& dlg)
+{
+    return dlg.findChild<QPushButton*>(
+        QStringLiteral("fdvReporterMessageSendButton"));
+}
+
+void resetSettings()
+{
+    auto& settings = AppSettings::instance();
+    const QString path = settings.filePath();
+    settings.reset();
+    QFile::remove(path);
+    QFile::remove(path + QStringLiteral(".bak"));
+    QFile::remove(path + QStringLiteral(".tmp"));
+    settings.load();
+}
+
+// The row is gated on full-participant reporting, because
+// FreeDvClient::updateMessage() silently no-ops when reporting is off.
+// Rather than leave a dead field, the row disables itself and says why.
+void testReportingGate()
+{
+    resetSettings();
+
+    FreeDvReporterDialog dlg;
+    auto* edit = msgEdit(dlg);
+    auto* send = msgSendBtn(dlg);
+    report("message edit exists", edit != nullptr);
+    report("send button exists", send != nullptr);
+    if (!edit || !send) return;
+
+    report("row starts disabled while reporting is off", !edit->isEnabled());
+    report("send starts disabled while reporting is off", !send->isEnabled());
+    const QString offPlaceholder = edit->placeholderText();
+    report("disabled placeholder explains why",
+           offPlaceholder.contains("Enable FreeDV reporting"), offPlaceholder);
+
+    dlg.setReportingActive(true);
+    report("edit enables when reporting starts", edit->isEnabled());
+    report("send enables when reporting starts", send->isEnabled());
+    report("enabled placeholder changes",
+           edit->placeholderText() != offPlaceholder, edit->placeholderText());
+
+    dlg.setReportingActive(false);
+    report("edit disables again when reporting stops", !edit->isEnabled());
+    report("placeholder explains again",
+           edit->placeholderText() == offPlaceholder, edit->placeholderText());
+}
+
+// Qt does not deliver tooltips to disabled widgets, so the "why is this
+// off?" text has to live on an enabled ancestor or it is unreachable in
+// exactly the state that needs explaining.
+void testDisabledStateStillExplains()
+{
+    resetSettings();
+
+    FreeDvReporterDialog dlg;
+    auto* edit = msgEdit(dlg);
+    if (!edit) { report("message edit exists", false); return; }
+
+    QWidget* row = edit->parentWidget();
+    report("message row container exists", row != nullptr);
+    if (!row) return;
+
+    report("tooltip lives on an enabled ancestor, not the disabled field",
+           edit->toolTip().isEmpty() && !row->toolTip().isEmpty(),
+           QStringLiteral("edit='%1' row='%2'")
+               .arg(edit->toolTip(), row->toolTip()));
+    report("container stays enabled so the tooltip is reachable",
+           row->isEnabled());
+    report("disabled-state tooltip names the remedy",
+           row->toolTip().contains("SpotHub") || row->toolTip().contains("RADE"),
+           row->toolTip());
+}
+
+// Send trims, persists to the shared FreeDvMyMessage setting, and emits.
+void testSendCommitsMessage()
+{
+    resetSettings();
+
+    FreeDvReporterDialog dlg;
+    auto* edit = msgEdit(dlg);
+    auto* send = msgSendBtn(dlg);
+    if (!edit || !send) { report("message widgets exist", false); return; }
+
+    dlg.setReportingActive(true);
+    QSignalSpy spy(&dlg, &FreeDvReporterDialog::messageChanged);
+
+    edit->setText("  QRT in 10 mins  ");
+    send->click();
+
+    report("send emits messageChanged once", spy.count() == 1,
+           QString::number(spy.count()));
+    if (!spy.isEmpty()) {
+        report("emitted message is trimmed",
+               spy.takeFirst().at(0).toString() == QStringLiteral("QRT in 10 mins"));
+    }
+    report("field shows the trimmed text",
+           edit->text() == QStringLiteral("QRT in 10 mins"), edit->text());
+    report("message persisted to FreeDvMyMessage",
+           AppSettings::instance().value("FreeDvMyMessage", "").toString()
+               == QStringLiteral("QRT in 10 mins"));
+}
+
+// Bounds checking per the issue's acceptance criteria — the field refuses
+// overlong input rather than letting it reach the network layer.
+void testLengthCap()
+{
+    resetSettings();
+
+    FreeDvReporterDialog dlg;
+    auto* edit = msgEdit(dlg);
+    if (!edit) { report("message edit exists", false); return; }
+
+    report("max length is capped", edit->maxLength() == FreeDvReporterDialog::MessageMaxLength,
+           QString::number(edit->maxLength()));
+
+    dlg.setReportingActive(true);
+    edit->setText(QString(FreeDvReporterDialog::MessageMaxLength + 50, QLatin1Char('x')));
+    report("overlong input is truncated to the cap",
+           edit->text().length() == FreeDvReporterDialog::MessageMaxLength,
+           QString::number(edit->text().length()));
+}
+
+// SpotHub's FreeDV tab writes the same setting, so the dialog re-reads it
+// on open — but must not clobber an edit the operator has not sent yet.
+void testReloadFromSettings()
+{
+    resetSettings();
+
+    FreeDvReporterDialog dlg;
+    auto* edit = msgEdit(dlg);
+    if (!edit) { report("message edit exists", false); return; }
+    dlg.setReportingActive(true);
+
+    auto& s = AppSettings::instance();
+    s.setValue("FreeDvMyMessage", "set from SpotHub");
+    s.save();
+
+    dlg.reloadMessage();
+    report("reload picks up an external edit",
+           edit->text() == QStringLiteral("set from SpotHub"), edit->text());
+
+    // An unfocused field tracks the setting; a focused one is left alone so
+    // a half-typed message survives the dialog being reopened.
+    edit->setText("half-typed, not sent");
+    edit->setFocus();
+    const bool focused = edit->hasFocus();
+    s.setValue("FreeDvMyMessage", "changed underneath");
+    s.save();
+    dlg.reloadMessage();
+    if (focused) {
+        report("reload does not clobber a focused in-progress edit",
+               edit->text() == QStringLiteral("half-typed, not sent"), edit->text());
+    } else {
+        // Offscreen platforms may refuse focus; the unfocused path is the
+        // one being exercised then, so assert that instead.
+        report("reload refreshes an unfocused field",
+               edit->text() == QStringLiteral("changed underneath"), edit->text());
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile settingsProfile(QStringLiteral("aether-fdv-reporter-msg-test"));
+    if (!settingsProfile.isValid()) {
+        std::printf("[FAIL] create temporary home\n");
+        return 1;
+    }
+    if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM")) {
+        qputenv("QT_QPA_PLATFORM", "offscreen");
+    }
+
+    QApplication app(argc, argv);
+
+    std::printf("FreeDV Reporter status-message test harness\n\n");
+
+    testReportingGate();
+    testDisabledStateStillExplains();
+    testSendCommitsMessage();
+    testLengthCap();
+    testReloadFromSettings();
+
+    std::printf("\n%s\n",
+                g_failed == 0
+                    ? "All tests passed."
+                    : qPrintable(QStringLiteral("%1 test(s) failed.").arg(g_failed)));
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Fixes #4231.

## Credit
@aethersdr-agent's triage did the legwork here — it correctly identified
that the protocol half already existed and this reduces to GUI wiring.
I re-verified every citation against current main before starting; all
still hold (line numbers had drifted ~80 lines).

## What
The reporter panel was read-only, so changing your status message meant
a trip to SpotHub → FreeDV. This adds a `Message` field + `Send` button
to the panel itself. Both surfaces read/write the same `FreeDvMyMessage`
setting, and the panel re-reads it on every open, so they stay in sync.

## The two open questions, and what I picked
The triage flagged two product decisions. I took the conservative
option on both; happy to change either.

**1. UX when reporting is off.** `FreeDvClient::updateMessage()` no-ops
unless `m_reportingEnabled && m_connected && !m_myCallsign.isEmpty()`,
so a naive Send would look broken. The row now disables itself and says
why, in two places:
- the placeholder ("Enable FreeDV reporting to send a status message"),
  readable at a glance;
- a tooltip naming the remedy (SpotHub → FreeDV, or start RADE).

The tooltip lives on an always-enabled container widget, not on the
field/button — **Qt does not deliver tooltips to disabled widgets**, so
putting it on the children would have hidden the explanation in exactly
the state that needs explaining. I hit this during live testing: the
first version's tooltip never appeared. There's a regression test for it.

**2. Length cap.** 100 characters, client-side. qso.freedv.org publishes
no documented limit and FreeDV-GUI doesn't cap client-side, so I've
commented this as a readability bound rather than a protocol constraint.

## Note on the one core-side change
`m_reportingEnabled` becomes `std::atomic<bool>`, mirroring `m_connected`
right next to it. The GUI thread now reads it (via a new
`isReportingEnabled()`) to seed the field when the dialog is first opened;
the client lives on `m_spotThread`, so a plain `bool` there would be a
data race. Live state changes come over a new `reportingStateChanged`
signal on a queued connection; sends hop threads via `invokeMethod`,
mirroring the existing SpotHub wiring.

## Testing
- New `tests/freedv_reporter_message_test.cpp` (22 assertions): the
  reporting gate, the disabled-state explanation being reachable,
  trim/persist/emit on Send, the length cap, and reload-vs-in-progress-edit.
- Verified the test catches regressions: reintroduced the tooltip-on-
  disabled-widget bug and dropped the trim, confirmed 5 assertions fail,
  restored.
- **Live end-to-end against qso.freedv.org**, real station: connected the
  FLEX-6600 under M7HNF/IO83UB, enabled reporting, activated RADE, sent
  "Testing AetherSDR reporter msg field" from the new panel field. It
  round-tripped through the server into our own row's Msg column exactly
  as trimmed. Disabling RADE correctly removed the station from the map
  and disabled the field again with the explanatory placeholder — proving
  `reportingStateChanged(false)` propagates too. Cleaned up afterward
  (blanked the message, took the station off the map).
- Full app build clean. All static checks pass locally: colour ratchet
  (+0 on all three counters), a11y (0 findings), engine boundary, network
  timeouts, theme seed.