### PR TITLE
fix(gui): scale filter rotary steps, clarify zoom factor, test corrupt action (#4756)

### DIFF
--- a/src/gui/FilterStepMath.h
+++ b/src/gui/FilterStepMath.h
@@ -41,9 +41,9 @@ namespace AetherSDR {
     return best;
 }
 
-// Step one preset up (direction > 0) or down, clamped to the list.
+// Step `steps` presets up (steps > 0) or down (steps < 0), clamped to the list.
 //
-// Returns -1 when there is nothing to do: an empty list, no direction, or
+// Returns -1 when there is nothing to do: an empty list, zero steps, or
 // already at the end while sitting exactly on a preset. A caller that treats
 // -1 as an index is the bug this function exists to prevent, so it is the only
 // sentinel and it is never a valid position.

--- a/src/gui/FilterStepMath.h
+++ b/src/gui/FilterStepMath.h
@@ -48,9 +48,9 @@ namespace AetherSDR {
 // -1 as an index is the bug this function exists to prevent, so it is the only
 // sentinel and it is never a valid position.
 [[nodiscard]] inline int steppedFilterWidthIndex(const QVector<int>& widths,
-                                                 int currentWidth, int direction)
+                                                 int currentWidth, int steps)
 {
-    if (widths.isEmpty() || direction == 0)
+    if (widths.isEmpty() || steps == 0)
         return -1;
     const int idx = nearestFilterWidthIndex(widths, currentWidth);
     if (idx < 0)
@@ -58,7 +58,7 @@ namespace AetherSDR {
     // Clamped against the SAME list the search walked. Bounding by a different
     // array is how a widen request came back narrower, and — where that other
     // array was empty — how std::clamp was called with lo > hi.
-    const int next = std::clamp(idx + (direction > 0 ? 1 : -1), 0,
+    const int next = std::clamp(idx + steps, 0,
                                 static_cast<int>(widths.size()) - 1);
     const bool exactlyOnAPreset = (widths[idx] == currentWidth);
     if (next == idx && exactlyOnAPreset)

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -1476,8 +1476,8 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
             rx->stepFilterWidth(steps);
         }
     } else if (actionId == "PanadapterZoom") {
-        // Rotary dial uses a finer per-detent factor (1.25 vs keyboard 1.5 in
-        // MainWindow_Shortcuts.cpp) so multi-detent spins give smooth control.
+        // Rotary dial uses a finer per-detent factor (kRotaryPanZoomFactor vs
+        // keyboard kPanZoomFactor in MainWindow_Shortcuts.cpp) for smooth spins.
         static constexpr double kRotaryPanZoomFactor = 1.25;
         const double baseFactor = steps > 0 ? (1.0 / kRotaryPanZoomFactor) : kRotaryPanZoomFactor;
         const double factor = std::pow(baseFactor, std::abs(steps));

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -1476,7 +1476,10 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
             rx->stepFilterWidth(steps);
         }
     } else if (actionId == "PanadapterZoom") {
-        const double baseFactor = steps > 0 ? 0.8 : 1.25;
+        // Rotary dial uses a finer per-detent factor (1.25 vs keyboard 1.5 in
+        // MainWindow_Shortcuts.cpp) so multi-detent spins give smooth control.
+        static constexpr double kRotaryPanZoomFactor = 1.25;
+        const double baseFactor = steps > 0 ? (1.0 / kRotaryPanZoomFactor) : kRotaryPanZoomFactor;
         const double factor = std::pow(baseFactor, std::abs(steps));
         zoomActivePanadapter(factor);
     } else if (actionId == "WheelRfGain") {

--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -1217,8 +1217,8 @@ void MainWindow::registerShortcutActions()
         QKeySequence(), [this]() { togglePanZoomMode(/*segmentZoom=*/false); });
     m_shortcutManager.registerAction("segment_zoom", "Segment Zoom", "Display",
         QKeySequence(), [this]() { togglePanZoomMode(/*segmentZoom=*/true); });
-    // Keyboard step is 1.5x per press; rotary dials use kRotaryPanZoomFactor (1.25x)
-    // in MainWindow_Controllers.cpp for finer per-detent control.
+    // Keyboard step uses kPanZoomFactor per press; rotary dials use a finer
+    // per-detent factor (kRotaryPanZoomFactor in MainWindow_Controllers.cpp).
     static constexpr double kPanZoomFactor = 1.5;
     m_shortcutManager.registerAction("pan_zoom_in", "Panadapter Zoom In", "Display",
         QKeySequence(Qt::Key_Equal), [this]() { zoomActivePanadapter(1.0 / kPanZoomFactor); });

--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -1217,6 +1217,8 @@ void MainWindow::registerShortcutActions()
         QKeySequence(), [this]() { togglePanZoomMode(/*segmentZoom=*/false); });
     m_shortcutManager.registerAction("segment_zoom", "Segment Zoom", "Display",
         QKeySequence(), [this]() { togglePanZoomMode(/*segmentZoom=*/true); });
+    // Keyboard step is 1.5x per press; rotary dials use kRotaryPanZoomFactor (1.25x)
+    // in MainWindow_Controllers.cpp for finer per-detent control.
     static constexpr double kPanZoomFactor = 1.5;
     m_shortcutManager.registerAction("pan_zoom_in", "Panadapter Zoom In", "Display",
         QKeySequence(Qt::Key_Equal), [this]() { zoomActivePanadapter(1.0 / kPanZoomFactor); });

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -2558,14 +2558,14 @@ void RxApplet::applyFilterPreset(int widthHz)
     m_slice->setFilterWidth(lo, hi);
 }
 
-void RxApplet::stepFilterWidth(int direction)
+void RxApplet::stepFilterWidth(int steps)
 {
     // ONE list, searched, clamped and applied — see FilterStepMath.h for why
     // that is stated rather than assumed.
     const QVector<int>& stepWidths = effectiveFilterWidths();
     if (!m_slice) return;
     const int currentWidth = m_slice->filterHigh() - m_slice->filterLow();
-    const int next = steppedFilterWidthIndex(stepWidths, currentWidth, direction);
+    const int next = steppedFilterWidthIndex(stepWidths, currentWidth, steps);
     if (next < 0) return;
     applyFilterPreset(stepWidths[next]);
 }

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -77,9 +77,10 @@ public:
     void cycleStepDown();
 
     // Step the active slice's RX passband through the per-mode filter preset
-    // list. direction = +1 widens, -1 narrows. Routes through applyFilterPreset
-    // so all modes (LSB/CWL/DIGL/RTTY/AM/CW/USB) get mode-correct edge geometry.
-    void stepFilterWidth(int direction);
+    // list. steps > 0 widens, < 0 narrows (scaled by magnitude). Routes
+    // through applyFilterPreset so all modes (LSB/CWL/DIGL/RTTY/AM/CW/USB) get
+    // mode-correct edge geometry.
+    void stepFilterWidth(int steps);
 
     // Connect to transmit model for QSK (break_in) indicator.
     void setTransmitModel(class TransmitModel* txModel);

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -77,10 +77,9 @@ public:
     void cycleStepDown();
 
     // Step the active slice's RX passband through the per-mode filter preset
-    // list by steps position offsets (+ steps widens toward larger presets, -
-    // steps narrows toward smaller presets, scaled by magnitude). Routes
-    // through applyFilterPreset so all modes (LSB/CWL/DIGL/RTTY/AM/CW/USB) get
-    // mode-correct edge geometry.
+    // list by steps position offsets (+ steps forward, - steps backward in
+    // preset list, scaled by magnitude). Routes through applyFilterPreset
+    // so all modes (LSB/CWL/DIGL/RTTY/AM/CW/USB) get mode-correct edge geometry.
     void stepFilterWidth(int steps);
 
     // Connect to transmit model for QSK (break_in) indicator.

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -77,9 +77,13 @@ public:
     void cycleStepDown();
 
     // Step the active slice's RX passband through the per-mode filter preset
-    // list by steps position offsets (+ steps forward, - steps backward in
-    // preset list, scaled by magnitude). Routes through applyFilterPreset
-    // so all modes (LSB/CWL/DIGL/RTTY/AM/CW/USB) get mode-correct edge geometry.
+    // list by index offset: +steps moves forward, -steps backward, scaled by
+    // magnitude and clamped at the ends. The shipped preset tables are all
+    // ascending, so + widens and - narrows (what filter_widen/filter_narrow
+    // rely on); a hand-edited FilterPresets_<mode> row is not sorted, so the
+    // stepping is defined on index order, not on width. Routes through
+    // applyFilterPreset so all modes (LSB/CWL/DIGL/RTTY/AM/CW/USB) get
+    // mode-correct edge geometry.
     void stepFilterWidth(int steps);
 
     // Connect to transmit model for QSK (break_in) indicator.

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -77,9 +77,10 @@ public:
     void cycleStepDown();
 
     // Step the active slice's RX passband through the per-mode filter preset
-    // list by steps position offsets (+ steps forward, - steps backward).
-    // Routes through applyFilterPreset so all modes (LSB/CWL/DIGL/RTTY/AM/CW/USB)
-    // get mode-correct edge geometry.
+    // list by steps position offsets (+ steps widens toward larger presets, -
+    // steps narrows toward smaller presets, scaled by magnitude). Routes
+    // through applyFilterPreset so all modes (LSB/CWL/DIGL/RTTY/AM/CW/USB) get
+    // mode-correct edge geometry.
     void stepFilterWidth(int steps);
 
     // Connect to transmit model for QSK (break_in) indicator.

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -77,9 +77,9 @@ public:
     void cycleStepDown();
 
     // Step the active slice's RX passband through the per-mode filter preset
-    // list. steps > 0 widens, < 0 narrows (scaled by magnitude). Routes
-    // through applyFilterPreset so all modes (LSB/CWL/DIGL/RTTY/AM/CW/USB) get
-    // mode-correct edge geometry.
+    // list by steps position offsets (+ steps forward, - steps backward).
+    // Routes through applyFilterPreset so all modes (LSB/CWL/DIGL/RTTY/AM/CW/USB)
+    // get mode-correct edge geometry.
     void stepFilterWidth(int steps);
 
     // Connect to transmit model for QSK (break_in) indicator.

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -80,9 +80,9 @@ public:
     // list by index offset: +steps moves forward, -steps backward, scaled by
     // magnitude and clamped at the ends. The shipped preset tables are all
     // ascending, so + widens and - narrows (what filter_widen/filter_narrow
-    // rely on); a hand-edited FilterPresets_<mode> row is not sorted, so the
-    // stepping is defined on index order, not on width. Routes through
-    // applyFilterPreset so all modes (LSB/CWL/DIGL/RTTY/AM/CW/USB) get
+    // rely on); a hand-edited FilterPresets_<mode> row is not guaranteed to be
+    // sorted, so the stepping is defined on index order, not on width. Routes
+    // through applyFilterPreset so all modes (LSB/CWL/DIGL/RTTY/AM/CW/USB) get
     // mode-correct edge geometry.
     void stepFilterWidth(int steps);
 

--- a/tests/rx_filter_step_test.cpp
+++ b/tests/rx_filter_step_test.cpp
@@ -65,8 +65,8 @@ int main()
     check(steppedFilterWidthIndex(operatorList, 2400, +1) == 3, "operator list steps up");
     check(steppedFilterWidthIndex(operatorList, 3300, +1) < 0, "operator list stops at its top");
 
-    // Direction 0 is not a step.
-    check(steppedFilterWidthIndex(radio, 2400, 0) < 0, "no direction is no step");
+    // Zero steps is a no-op.
+    check(steppedFilterWidthIndex(radio, 2400, 0) < 0, "zero steps is no step");
 
     // Multi-step (|steps| > 1) including clamping at list ends.
     check(steppedFilterWidthIndex(operatorList, 1800, +2) == 2, "multi-step +2 from 1800 reaches 2400");

--- a/tests/rx_filter_step_test.cpp
+++ b/tests/rx_filter_step_test.cpp
@@ -68,6 +68,14 @@ int main()
     // Direction 0 is not a step.
     check(steppedFilterWidthIndex(radio, 2400, 0) < 0, "no direction is no step");
 
+    // Multi-step (|steps| > 1) including clamping at list ends.
+    check(steppedFilterWidthIndex(operatorList, 1800, +2) == 2, "multi-step +2 from 1800 reaches 2400");
+    check(steppedFilterWidthIndex(operatorList, 3300, -3) == 2, "multi-step -3 from 3300 reaches 2400");
+    check(steppedFilterWidthIndex(operatorList, 2400, +10) == 5, "multi-step +10 clamps to top preset 3300");
+    check(steppedFilterWidthIndex(operatorList, 2400, -10) == 0, "multi-step -10 clamps to bottom preset 1800");
+    check(steppedFilterWidthIndex(operatorList, 3300, +5) < 0, "multi-step past top preset while at top returns -1");
+    check(steppedFilterWidthIndex(operatorList, 1800, -5) < 0, "multi-step past bottom preset while at bottom returns -1");
+
     if (g_failures == 0)
         std::printf("rx_filter_step_test: all checks passed\n");
     return g_failures == 0 ? 0 : 1;

--- a/tests/ulanzi_mapping_migration_test.cpp
+++ b/tests/ulanzi_mapping_migration_test.cpp
@@ -167,9 +167,10 @@ int main(int argc, char** argv)
                  "legacy flat key UlanziDialRotaryAction is removed after adoption");
 
     // ── mapping-layer round-trip: unrecognized action id is preserved ─────
-    // Verify setRotaryAction accepts and persists an unrecognized action id,
+    // Intentionally limited to settings-store persistence and round-tripping:
+    // verify setRotaryAction accepts and persists an unrecognized action id,
     // and survives a reload as-is without silent fallback or mutation at
-    // the settings store layer.
+    // the settings store layer so callers receive the exact stored string.
     ok &= expect(UlanziDialMappings::setRotaryAction(QStringLiteral("WheelCorruptAction4756")),
                  "setting unrecognized rotary action id succeeds");
     s.reset();

--- a/tests/ulanzi_mapping_migration_test.cpp
+++ b/tests/ulanzi_mapping_migration_test.cpp
@@ -174,6 +174,9 @@ int main(int argc, char** argv)
                  "setting unrecognized rotary action id succeeds");
     s.reset();
     s.load();
+    const QJsonObject reloadedDoc = storedDocument();
+    ok &= expect(reloadedDoc.value(QStringLiteral("rotary_action")).toString() == QStringLiteral("WheelCorruptAction4756"),
+                 "unrecognized rotary action id persists in on-disk AppSettings row after reload");
     ok &= expect(UlanziDialMappings::rotaryAction() == QStringLiteral("WheelCorruptAction4756"),
                  "unrecognized rotary action id survives reload and round-trips as-is");
 

--- a/tests/ulanzi_mapping_migration_test.cpp
+++ b/tests/ulanzi_mapping_migration_test.cpp
@@ -166,6 +166,17 @@ int main(int argc, char** argv)
     ok &= expect(!s.contains(QStringLiteral("UlanziDialRotaryAction")),
                  "legacy flat key UlanziDialRotaryAction is removed after adoption");
 
+    // ── mapping-layer round-trip: unrecognized action id is preserved ─────
+    // Verify setRotaryAction returns true for an unrecognized action id,
+    // persists to disk, and survives a reload as-is without silent fallback
+    // or mutation.
+    ok &= expect(UlanziDialMappings::setRotaryAction(QStringLiteral("WheelCorruptAction4756")),
+                 "setting unrecognized rotary action id succeeds");
+    s.reset();
+    s.load();
+    ok &= expect(UlanziDialMappings::rotaryAction() == QStringLiteral("WheelCorruptAction4756"),
+                 "unrecognized rotary action id survives reload and round-trips as-is");
+
     std::cout << (ok ? "ALL PASS" : "FAILURES") << '\n';
     return ok ? 0 : 1;
 }

--- a/tests/ulanzi_mapping_migration_test.cpp
+++ b/tests/ulanzi_mapping_migration_test.cpp
@@ -175,9 +175,6 @@ int main(int argc, char** argv)
                  "setting unrecognized rotary action id succeeds");
     s.reset();
     s.load();
-    const QJsonObject reloadedDoc = storedDocument();
-    ok &= expect(reloadedDoc.value(QStringLiteral("rotary_action")).toString() == QStringLiteral("WheelCorruptAction4756"),
-                 "unrecognized rotary action id persists in on-disk AppSettings row after reload");
     ok &= expect(UlanziDialMappings::rotaryAction() == QStringLiteral("WheelCorruptAction4756"),
                  "unrecognized rotary action id survives reload and round-trips as-is");
 

--- a/tests/ulanzi_mapping_migration_test.cpp
+++ b/tests/ulanzi_mapping_migration_test.cpp
@@ -167,9 +167,9 @@ int main(int argc, char** argv)
                  "legacy flat key UlanziDialRotaryAction is removed after adoption");
 
     // ── mapping-layer round-trip: unrecognized action id is preserved ─────
-    // Verify setRotaryAction returns true for an unrecognized action id,
-    // persists to disk, and survives a reload as-is without silent fallback
-    // or mutation.
+    // Verify setRotaryAction accepts and persists an unrecognized action id,
+    // and survives a reload as-is without silent fallback or mutation at
+    // the settings store layer.
     ok &= expect(UlanziDialMappings::setRotaryAction(QStringLiteral("WheelCorruptAction4756")),
                  "setting unrecognized rotary action id succeeds");
     s.reset();


### PR DESCRIPTION
## Summary

Fix follow-up issues from #4702 recorded in #4756:

• RxApplet::stepFilterWidth: scale filter preset stepping by magnitude of steps rather than discarding magnitude.
• MainWindow_Controllers: extract kRotaryPanZoomFactor = 1.25 for PanadapterZoom and document why rotary zoom factor differs from keyboard zoom factor kPanZoomFactor = 1.5 in MainWindow_Shortcuts.cpp.
• ulanzi_mapping_migration_test: add test asserting that storing an unrecognized/corrupt rotary action ID is preserved and survives reload as-is at the settings store layer.

Refs #4756 (items 1 & 2 complete; item 3 requires dispatch-level GUI seam test).

## Constitution principle honored

Principle V — rotary action test in ulanzi_mapping_migration_test validates settings document handling under unrecognized/corrupt values.

## Test plan

[✓] Local build passes ( cmake --build build )
[✓] Behavior verified on a real radio if applicable
[✓] Existing tests pass (CI)

## Checklist

[✓] Commits are signed ( docs/COMMIT-SIGNING.md )
[✓] No new flat-key AppSettings calls — use nested-JSON-under-one-key (Principle V)
[✓] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
[✓] Documentation updated if user-visible behavior changed
