### PR TITLE
Restore the operator's slice selection across sessions. Principle III.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3532,6 +3532,14 @@ target_include_directories(band_recall_slice_selection_policy_test PRIVATE src)
 add_test(NAME band_recall_slice_selection_policy_test
     COMMAND band_recall_slice_selection_policy_test)
 
+add_executable(slice_selection_restore_policy_test
+    tests/slice_selection_restore_policy_test.cpp
+)
+target_include_directories(slice_selection_restore_policy_test PRIVATE src)
+target_link_libraries(slice_selection_restore_policy_test PRIVATE Qt6::Core)
+add_test(NAME slice_selection_restore_policy_test
+    COMMAND slice_selection_restore_policy_test)
+
 # When that policy applies — the window opened by an actually-dispatched
 # `display pan set <pan> band=` write. Header-only.
 add_executable(band_recall_selection_guard_test

--- a/src/gui/BandRecallSliceSelectionPolicy.h
+++ b/src/gui/BandRecallSliceSelectionPolicy.h
@@ -26,6 +26,7 @@ enum class RadioSliceSelectionSource {
 struct RadioSliceSelectionDecision {
     bool revealOffscreen{true};
     bool suppressActiveCommand{false};
+    bool isOperatorSelection{false};
 };
 
 inline RadioSliceSelectionDecision radioSliceSelectionDecision(
@@ -33,15 +34,21 @@ inline RadioSliceSelectionDecision radioSliceSelectionDecision(
     RadioSliceSelectionSource source)
 {
     if (bandRecallInFlight) {
-        return {false, true};
+        return {false, true, false};
     }
 
     // TopologyFallback is the only source that may assert the selection: it
     // fires when the active slice was REMOVED, so the radio has no valid active
     // slice and must be told which one takes over.
+    //
+    // However, NO radio-driven source (ActiveStatus, TopologyFallback, InitialEnumeration)
+    // is an operator selection. TopologyFallback asserts active=1 on the wire
+    // because the radio needs a replacement active slice, BUT it must NOT be
+    // persisted as the operator's preference nor cancel the post-connect restore.
     return {
         true,
         source != RadioSliceSelectionSource::TopologyFallback,
+        false,
     };
 }
 

--- a/src/gui/BandRecallSliceSelectionPolicy.h
+++ b/src/gui/BandRecallSliceSelectionPolicy.h
@@ -2,15 +2,25 @@
 
 namespace AetherSDR {
 
-// MainWindow reaches the active-slice setter from two radio-driven sources:
-// an explicit active=1 status and a topology fallback while slices are being
-// removed/recreated. Outside a band recall both retain their established
-// behavior. During a FLEX band-stack rebuild, neither may reveal the transient
-// slice or send active=1 back: either write can race the radio-authoritative
-// pan/slice reconstruction and undo the selected band.
+// MainWindow reaches the active-slice setter from three radio-driven sources:
+// an explicit active=1 status, a topology fallback while slices are being
+// removed/recreated, and the connect-time bootstrap of the first enumerated
+// slice. Outside a band recall each retains its established behavior. During a
+// FLEX band-stack rebuild, none may reveal the transient slice or send active=1
+// back: either write can race the radio-authoritative pan/slice reconstruction
+// and undo the selected band.
 enum class RadioSliceSelectionSource {
     ActiveStatus,
     TopologyFallback,
+    // The first slice to arrive on a fresh connect, selected only so the UI has
+    // a target before the enumeration finishes. It is arrival ORDER, not the
+    // operator's choice — slice 0 is simply enumerated first — so it must never
+    // write active=1 back. During connect the status burst / enumeration order
+    // can leave a different slice active (often the last one created). Asserting
+    // a selection here overwrites that live status before later slices have even
+    // been created client-side, so the first-enumerated slice always won and
+    // the operator's slice B silently became slice A on every launch.
+    InitialEnumeration,
 };
 
 struct RadioSliceSelectionDecision {
@@ -26,10 +36,26 @@ inline RadioSliceSelectionDecision radioSliceSelectionDecision(
         return {false, true};
     }
 
+    // TopologyFallback is the only source that may assert the selection: it
+    // fires when the active slice was REMOVED, so the radio has no valid active
+    // slice and must be told which one takes over.
     return {
         true,
-        source == RadioSliceSelectionSource::ActiveStatus,
+        source != RadioSliceSelectionSource::TopologyFallback,
     };
+}
+
+inline const char* radioSliceSelectionSourceName(RadioSliceSelectionSource source)
+{
+    switch (source) {
+    case RadioSliceSelectionSource::ActiveStatus:
+        return "active-status";
+    case RadioSliceSelectionSource::TopologyFallback:
+        return "topology-fallback";
+    case RadioSliceSelectionSource::InitialEnumeration:
+        return "initial-enumeration";
+    }
+    return "unknown";
 }
 
 }  // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7285,7 +7285,7 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
     }
 
     if (SliceSelectionRestorePolicy::shouldPersist(
-            m_updatingFromModel,
+            m_updatingFromModel || m_selectingFromRadioState,
             m_bandRecallSelection.isActive(s->panId(), QDateTime::currentMSecsSinceEpoch()),
             profileLoadRadioStateWritesHeld(),
             /*fromRestore=*/false)) {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3512,6 +3512,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
     // the last tune/drive edit before quit is remembered (RFC #4603 PR 3;
     // PR #4619 review).
     m_radioModel.flushPendingOperatingState();
+    captureTxSliceSelection();
 
     // Same reason as the TGXL/PGXL sockets above: the D-STAR helper is stopped
     // by the queued RadioModel::connectionStateChanged(false) handler, which
@@ -5533,6 +5534,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
         // status trickle with a wide margin. The generation it carries keeps a
         // previous connect's pending timeout from closing this window.
         m_daxRestore.onConnected();
+        m_activeSliceRestore.onConnected();
         const int daxGen = m_daxRestore.generation();
         QTimer::singleShot(10000, this, [this, daxGen]() {
             m_daxRestore.onSettleTimeout(daxGen);
@@ -5802,6 +5804,8 @@ void MainWindow::onConnectionStateChanged(bool connected)
         // reopens it for its own enumeration. Disconnect teardown does not emit
         // sliceRemoved, so without this the window would stay armed until the
         // settle timer happened to fire.
+        captureTxSliceSelection();
+        m_activeSliceRestore.onDisconnected();
         m_daxRestore.onDisconnected();
 
         // Radio disconnected: trim CAT ports back to 1 so apps on channel A
@@ -7278,6 +7282,15 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
         m_optimisticActiveEdgeSliceId = sliceId;
         s->setActive(true);
         m_optimisticActiveEdgeSliceId = previousEdgeSliceId;
+    }
+
+    if (SliceSelectionRestorePolicy::shouldPersist(
+            m_updatingFromModel,
+            m_bandRecallSelection.isActive(s->panId(), QDateTime::currentMSecsSinceEpoch()),
+            profileLoadRadioStateWritesHeld(),
+            /*fromRestore=*/false)) {
+        m_activeSliceRestore.noteOperatorSelection();
+        noteActiveSliceSelection(s);
     }
 
     // Update RX EQ filter-cutoff guides whenever the active slice swaps —

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1749,6 +1749,7 @@ private:
 #endif
     SliceSelectionRestorePolicy m_activeSliceRestore;
     SliceModel* m_pendingOperatorActiveSlice{nullptr};
+    bool m_selectingFromRadioState{false};
     QString sliceSelectionScope() const;
     bool storeSliceSelectionLetter(const QString& field, const QString& letter);
     void noteActiveSliceSelection(SliceModel* slice);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -24,6 +24,7 @@
 #include "gui/CenterLockRebindTracker.h"
 #include "gui/DaxRestorePolicy.h"       // #4558 last-session DAX restore window
 #include "gui/KiwiRebindTracker.h"      // #4158 band-recall Kiwi re-bind policy
+#include "gui/SliceSelectionRestorePolicy.h"
 #include "core/CatPort.h"
 #ifdef HAVE_WEBSOCKETS
 #include "core/TciServer.h"
@@ -1746,6 +1747,15 @@ private:
     QList<QMetaObject::Connection> m_daxSliceConns;
     QHash<int, int> m_daxSliceLastCh;  // sliceId -> last-known DAX channel
 #endif
+    SliceSelectionRestorePolicy m_activeSliceRestore;
+    SliceModel* m_pendingOperatorActiveSlice{nullptr};
+    QString sliceSelectionScope() const;
+    bool storeSliceSelectionLetter(const QString& field, const QString& letter);
+    void noteActiveSliceSelection(SliceModel* slice);
+    void captureTxSliceSelection();
+    void scheduleSliceSelectionRestore();
+    void applySliceSelectionRestore();
+    SliceModel* sliceForRestoreLetter(const QString& letter) const;
 };
 
 template <class T, class... Args>

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -328,7 +328,10 @@ void MainWindow::selectSliceFromRadioState(
     const bool wasUpdatingFromModel = m_updatingFromModel;
     m_updatingFromModel =
         wasUpdatingFromModel || decision.suppressActiveCommand;
+    const bool wasSelectingFromRadioState = m_selectingFromRadioState;
+    m_selectingFromRadioState = !decision.isOperatorSelection;
     setActiveSliceInternal(slice->sliceId(), decision.revealOffscreen);
+    m_selectingFromRadioState = wasSelectingFromRadioState;
     m_updatingFromModel = wasUpdatingFromModel;
 }
 

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -6096,7 +6096,9 @@ QString MainWindow::sliceSelectionScope() const
 {
     const bool isWan = m_radioModel.isWan();
     const QString discoverySerial = m_radioModel.lastRadioInfo().serial;
-    const QString chassisSerial = m_radioModel.chassisSerial();
+    const QString chassisSerial = !m_radioModel.chassisSerial().isEmpty()
+        ? m_radioModel.chassisSerial()
+        : m_radioModel.serial();
     const QString stationName = m_radioModel.nickname();
     return SliceSelectionRestorePolicy::radioIdForScope(
         isWan, discoverySerial, chassisSerial, stationName);

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -6108,7 +6108,7 @@ bool MainWindow::storeSliceSelectionLetter(const QString& field, const QString& 
     if (!SliceSelectionRestorePolicy::scopeCanCarrySelection(scope)) {
         return false;
     }
-    QJsonObject doc = AppSettings::instance().radioFeature(
+    QJsonObject doc = AppSettings::instance().radioFeatureExact(
         m_radioModel.family(), scope, QStringLiteral("SliceSelection"));
     doc[field] = letter;
     return AppSettings::instance().setRadioFeature(

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -6139,6 +6139,15 @@ void MainWindow::captureTxSliceSelection()
             m_radioModel.txOwnedByUs())) {
         return;
     }
+    int slicesWithLetter = 0;
+    for (auto* sl : slices) {
+        if (sl->hasLetterFromRadio()) {
+            ++slicesWithLetter;
+        }
+    }
+    if (!SliceSelectionRestorePolicy::lettersReadyForSelection(slices.size(), slicesWithLetter)) {
+        return;
+    }
     for (auto* sl : slices) {
         if (sl->isTxSlice()) {
             storeSliceSelectionLetter(QStringLiteral("txSliceLetter"), sl->letter());

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -2000,6 +2000,9 @@ void MainWindow::onSliceAdded(SliceModel* s)
     }
 
     connect(s, &SliceModel::txSliceChanged, this, [this, s](bool tx) {
+        if (tx) {
+            captureTxSliceSelection();
+        }
         // Update hasTxSlice on all spectrums for waterfall freeze logic
         if (tx) {
             for (auto* pan : m_radioModel.panadapters()) {
@@ -2218,6 +2221,19 @@ void MainWindow::onSliceAdded(SliceModel* s)
 
     refreshSliceLinkUi();
     updateAetherDspModePolicy();
+
+    connect(s, &SliceModel::letterChanged, this, [this, s]() {
+        if (s == m_pendingOperatorActiveSlice && s == activeSlice() && s->hasLetterFromRadio()) {
+            noteActiveSliceSelection(s);
+        }
+        if (m_activeSliceRestore.restoreAllowed()) {
+            scheduleSliceSelectionRestore();
+        }
+    });
+
+    if (m_activeSliceRestore.restoreAllowed()) {
+        scheduleSliceSelectionRestore();
+    }
 }
 
 void MainWindow::onSliceRemoved(int id)
@@ -6073,6 +6089,123 @@ void MainWindow::onSpectrumReadyForAdaptiveFilter(quint32 streamId,
                 emittedNs);
         }
         break;  // one pan owns this stream id
+    }
+}
+
+QString MainWindow::sliceSelectionScope() const
+{
+    const bool isWan = m_radioModel.isWan();
+    const QString discoverySerial = m_radioModel.lastRadioInfo().serial;
+    const QString chassisSerial = m_radioModel.chassisSerial();
+    const QString stationName = m_radioModel.nickname();
+    return SliceSelectionRestorePolicy::radioIdForScope(
+        isWan, discoverySerial, chassisSerial, stationName);
+}
+
+bool MainWindow::storeSliceSelectionLetter(const QString& field, const QString& letter)
+{
+    const QString scope = sliceSelectionScope();
+    if (!SliceSelectionRestorePolicy::scopeCanCarrySelection(scope)) {
+        return false;
+    }
+    QJsonObject doc = AppSettings::instance().radioFeature(
+        m_radioModel.family(), scope, QStringLiteral("SliceSelection"));
+    doc[field] = letter;
+    return AppSettings::instance().setRadioFeature(
+        m_radioModel.family(), scope, QStringLiteral("SliceSelection"), 1, doc);
+}
+
+void MainWindow::noteActiveSliceSelection(SliceModel* slice)
+{
+    if (!slice) return;
+    if (!slice->hasLetterFromRadio()) {
+        m_pendingOperatorActiveSlice = slice;
+        return;
+    }
+    if (m_pendingOperatorActiveSlice == slice) {
+        m_pendingOperatorActiveSlice = nullptr;
+    }
+    storeSliceSelectionLetter(QStringLiteral("activeSliceLetter"), slice->letter());
+}
+
+void MainWindow::captureTxSliceSelection()
+{
+    const auto slices = m_radioModel.slices();
+    if (!SliceSelectionRestorePolicy::shouldCaptureTxSlice(
+            m_radioModel.isConnected() || m_shuttingDown,
+            slices.size(),
+            m_radioModel.txOwnedByUs())) {
+        return;
+    }
+    for (auto* sl : slices) {
+        if (sl->isTxSlice()) {
+            storeSliceSelectionLetter(QStringLiteral("txSliceLetter"), sl->letter());
+            return;
+        }
+    }
+}
+
+SliceModel* MainWindow::sliceForRestoreLetter(const QString& letter) const
+{
+    if (letter.isEmpty()) return nullptr;
+    for (auto* sl : m_radioModel.slices()) {
+        if (sl->letter() == letter) {
+            return sl;
+        }
+    }
+    return nullptr;
+}
+
+void MainWindow::scheduleSliceSelectionRestore()
+{
+    if (!m_activeSliceRestore.restoreAllowed()) return;
+    const int gen = m_activeSliceRestore.generation();
+    QTimer::singleShot(600, this, [this, gen]() {
+        if (gen == m_activeSliceRestore.generation()) {
+            applySliceSelectionRestore();
+        }
+    });
+}
+
+void MainWindow::applySliceSelectionRestore()
+{
+    const QString scope = sliceSelectionScope();
+    const bool scopeReady = SliceSelectionRestorePolicy::scopeCanCarrySelection(scope);
+    const auto action = SliceSelectionRestorePolicy::restoreAction(
+        m_activeSliceRestore.restoreAllowed(),
+        profileLoadRadioStateWritesHeld(),
+        scopeReady);
+
+    if (action == SliceSelectionRestorePolicy::RestoreAction::Skip) {
+        return;
+    }
+    if (action == SliceSelectionRestorePolicy::RestoreAction::Defer) {
+        scheduleSliceSelectionRestore();
+        return;
+    }
+
+    const QJsonObject doc = AppSettings::instance().radioFeature(
+        m_radioModel.family(), scope, QStringLiteral("SliceSelection"));
+
+    const QString savedActiveLetter = doc.value(QStringLiteral("activeSliceLetter")).toString();
+    const QString savedTxLetter = doc.value(QStringLiteral("txSliceLetter")).toString();
+
+    // Which slice owns transmit — restored first so local state settles before active
+    if (!savedTxLetter.isEmpty() && SliceSelectionRestorePolicy::mayAssertTxSlice(m_radioModel.txOwnedByUs())) {
+        if (auto* targetTx = sliceForRestoreLetter(savedTxLetter)) {
+            if (!targetTx->isTxSlice()) {
+                targetTx->setTxSlice(true);
+            }
+        }
+    }
+
+    // Which slice is active
+    if (!savedActiveLetter.isEmpty()) {
+        if (auto* targetActive = sliceForRestoreLetter(savedActiveLetter)) {
+            if (targetActive->sliceId() != m_activeSliceId) {
+                setActiveSlice(targetActive->sliceId());
+            }
+        }
     }
 }
 

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -322,9 +322,7 @@ void MainWindow::selectSliceFromRadioState(
             << "MainWindow: band recall suppressing slice reveal"
             << "pan=" << slice->panId()
             << "slice=" << slice->sliceId()
-            << "source="
-            << (source == RadioSliceSelectionSource::ActiveStatus
-                    ? "active-status" : "topology-fallback");
+            << "source=" << radioSliceSelectionSourceName(source);
     }
 
     const bool wasUpdatingFromModel = m_updatingFromModel;
@@ -1628,6 +1626,8 @@ bool MainWindow::reattachSliceVisualsToPanadapter(SliceModel* s)
 }
 
 
+
+
 void MainWindow::onSliceAdded(SliceModel* s)
 {
     // During layout transition, spectrums are being destroyed/recreated — skip
@@ -1644,8 +1644,18 @@ void MainWindow::onSliceAdded(SliceModel* s)
 
     // First slice — wire everything up
     if (firstSlice) {
+        // Bootstrap only: give the UI a selection. Do NOT write active=1 —
+        // this is the first slice ENUMERATED, not the slice that should own
+        // the UI. A FLEX does not persist the operator's active-slice choice
+        // across a restart; during connect the status burst / enumeration
+        // order may end with a different slice active (often last-created),
+        // and that slice may not exist client-side yet (it arrives in a later
+        // status frame). Asserting here would clobber that live status and
+        // make first-enumerated always win. The adoption below — and the
+        // activeChanged handler / client-side restore — pick the right slice
+        // up when it arrives. (#2465 class)
         selectSliceFromRadioState(
-            s, RadioSliceSelectionSource::TopologyFallback);
+            s, RadioSliceSelectionSource::InitialEnumeration);
 
         // Detect initial band from radio's frequency
         if (m_bandSettings.currentBand().isEmpty())

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -6097,14 +6097,9 @@ void MainWindow::onSpectrumReadyForAdaptiveFilter(quint32 streamId,
 
 QString MainWindow::sliceSelectionScope() const
 {
-    const bool isWan = m_radioModel.isWan();
-    const QString discoverySerial = m_radioModel.lastRadioInfo().serial;
-    const QString chassisSerial = !m_radioModel.chassisSerial().isEmpty()
-        ? m_radioModel.chassisSerial()
-        : m_radioModel.serial();
+    const RadioSettingsScope scope = m_radioModel.settingsScope();
     const QString stationName = m_radioModel.nickname();
-    return SliceSelectionRestorePolicy::radioIdForScope(
-        isWan, discoverySerial, chassisSerial, stationName);
+    return SliceSelectionRestorePolicy::radioIdForScope(scope.radioId(), stationName);
 }
 
 bool MainWindow::storeSliceSelectionLetter(const QString& field, const QString& letter)

--- a/src/gui/SliceSelectionRestorePolicy.h
+++ b/src/gui/SliceSelectionRestorePolicy.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <QString>
+
+namespace AetherSDR {
+
+// Rules governing active/TX slice selection persistence and post-connect restore.
+//
+// FlexRadio firmware does NOT persist active or TX slice assignments across
+// client reconnects: on connect, the radio enumerates existing slices in slice
+// ID order and marks whatever slice was last created as active in the status
+// stream.
+//
+// This policy coordinates capturing the operator's live selections and
+// restoring them once enumeration quiesces on connect.
+class SliceSelectionRestorePolicy {
+public:
+    // Scope key for the SliceSelection document.
+    // Includes station name to isolate Multi-Flex client instances on the same radio.
+    static QString radioIdForScope(bool isWan,
+                                   const QString& discoverySerial,
+                                   const QString& chassisSerial,
+                                   const QString& stationName = QString())
+    {
+        QString baseId;
+        if (isWan) {
+            baseId = chassisSerial.trimmed();
+        } else {
+            baseId = !discoverySerial.trimmed().isEmpty()
+                ? discoverySerial.trimmed()
+                : chassisSerial.trimmed();
+        }
+        if (baseId.isEmpty()) {
+            return QString();
+        }
+        if (!stationName.trimmed().isEmpty()) {
+            return QStringLiteral("%1/%2").arg(baseId, stationName.trimmed());
+        }
+        return baseId;
+    }
+
+    // Guard: is the radioId non-empty so settings can be read or written?
+    static bool scopeCanCarrySelection(const QString& radioId)
+    {
+        return !radioId.trimmed().isEmpty();
+    }
+
+    // May the TX slice choice be recorded?
+    static bool shouldCaptureTxSlice(bool activeOrDisconnecting, int liveSliceCount,
+                                     bool txOwnedByUs)
+    {
+        return activeOrDisconnecting && liveSliceCount > 0 && txOwnedByUs;
+    }
+
+    // May the restore re-assert a stored TX-slice assignment?
+    static bool mayAssertTxSlice(bool txOwnedByUs) { return txOwnedByUs; }
+
+    // May this active-slice change be recorded as the operator's preference?
+    static bool shouldPersist(bool fromRadioEchoOrSystem,
+                              bool bandRecallInFlight,
+                              bool profileLoadHeld,
+                              bool fromRestore)
+    {
+        return !fromRadioEchoOrSystem && !bandRecallInFlight && !profileLoadHeld
+            && !fromRestore;
+    }
+
+    // ── The post-connect restore window ────────────────────────────────────
+
+    void onConnected()
+    {
+        m_windowOpen = true;
+        m_operatorSelected = false;
+        ++m_generation;
+    }
+
+    void onDisconnected() { m_windowOpen = false; }
+
+    int generation() const { return m_generation; }
+
+    void noteOperatorSelection() { m_operatorSelected = true; }
+
+    void onSettleTimeout(int generation)
+    {
+        if (generation == m_generation) {
+            m_windowOpen = false;
+        }
+    }
+
+    bool restoreAllowed() const { return m_windowOpen && !m_operatorSelected; }
+
+    enum class RestoreAction {
+        Skip,
+        Defer,
+        Apply,
+    };
+
+    static RestoreAction restoreAction(bool allowed,
+                                       bool profileLoadHeld,
+                                       bool scopeReady)
+    {
+        if (!allowed) {
+            return RestoreAction::Skip;
+        }
+        if (profileLoadHeld || !scopeReady) {
+            return RestoreAction::Defer;
+        }
+        return RestoreAction::Apply;
+    }
+
+    void consume() { m_windowOpen = false; }
+
+private:
+    bool m_windowOpen{false};
+    bool m_operatorSelected{false};
+    int m_generation{0};
+};
+
+}  // namespace AetherSDR

--- a/src/gui/SliceSelectionRestorePolicy.h
+++ b/src/gui/SliceSelectionRestorePolicy.h
@@ -43,7 +43,9 @@ public:
         return activeOrDisconnecting && liveSliceCount > 0 && txOwnedByUs;
     }
 
-    // May the restore re-assert a stored TX-slice assignment?
+    // TX ownership is the gate between a restored preference and a wire-level
+    // TX assignment. Unpinned, a refactor can drop the term and the regression
+    // is invisible from the client — see the test cases next to shouldPersist().
     static bool mayAssertTxSlice(bool txOwnedByUs) { return txOwnedByUs; }
 
     // May this active-slice change be recorded as the operator's preference?

--- a/src/gui/SliceSelectionRestorePolicy.h
+++ b/src/gui/SliceSelectionRestorePolicy.h
@@ -65,6 +65,19 @@ public:
             && !fromRestore;
     }
 
+    // Are slice letters ready for selection matching?
+    //
+    // On older firmware that never sends index_letter (SliceModel.h:34),
+    // slicesWithLetterFromRadio stays 0 and letter() falls back to 'A' + sliceId,
+    // so letters are immediately ready. On modern firmware, letters are ready
+    // when all enumerated slices have received index_letter status.
+    static bool lettersReadyForSelection(int enumeratedSliceCount,
+                                          int slicesWithLetterFromRadio)
+    {
+        if (enumeratedSliceCount <= 0) return false;
+        return slicesWithLetterFromRadio == 0 || slicesWithLetterFromRadio >= enumeratedSliceCount;
+    }
+
     // ── The post-connect restore window ────────────────────────────────────
 
     void onConnected()

--- a/src/gui/SliceSelectionRestorePolicy.h
+++ b/src/gui/SliceSelectionRestorePolicy.h
@@ -16,20 +16,11 @@ namespace AetherSDR {
 class SliceSelectionRestorePolicy {
 public:
     // Scope key for the SliceSelection document.
-    // Includes station name to isolate Multi-Flex client instances on the same radio.
-    static QString radioIdForScope(bool isWan,
-                                   const QString& discoverySerial,
-                                   const QString& chassisSerial,
+    // Uses RadioSettingsScope's radioId, appending station name for Multi-Flex isolation.
+    static QString radioIdForScope(const QString& scopeRadioId,
                                    const QString& stationName = QString())
     {
-        QString baseId;
-        if (isWan) {
-            baseId = chassisSerial.trimmed();
-        } else {
-            baseId = !discoverySerial.trimmed().isEmpty()
-                ? discoverySerial.trimmed()
-                : chassisSerial.trimmed();
-        }
+        const QString baseId = scopeRadioId.trimmed();
         if (baseId.isEmpty()) {
             return QString();
         }

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -6067,6 +6067,8 @@ void RadioModel::onDisconnected()
         m_staleSessionSerial = m_chassisSerial;
     m_chassisSerial.clear();
     m_callsign.clear();
+    m_txOwnedByUs = true;
+    m_txClientHandle = 0;
     // Clear the nickname here too, not just on the connectToRadio() seeding
     // path: connectViaWan() takes no RadioInfo and the LAN auto-reconnect timer
     // calls m_connection->connectToRadio(m_lastInfo) directly, both bypassing
@@ -9227,7 +9229,17 @@ void RadioModel::onStatusReceived(const QString& object,
 
 QString RadioModel::serial() const
 {
-    return m_lastInfo.serial;
+    const QString chassis = !m_chassisSerial.isEmpty()
+        ? m_chassisSerial.trimmed()
+        : m_staleSessionSerial.trimmed();
+    if (isWan()) {
+        return chassis;
+    }
+    const QString discoverySerial = m_lastInfo.serial.trimmed();
+    if (!discoverySerial.isEmpty()) {
+        return discoverySerial;
+    }
+    return chassis;
 }
 
 QString RadioModel::gpsNtpServerAddress() const

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -34,6 +34,7 @@ public:
     // *this* client (e.g. the second client's first slice is "A" even when
     // its global sliceId is 2).  Falls back to `'A' + sliceId` if the field
     // hasn't arrived yet (early in status, or older firmware).
+    bool    hasLetterFromRadio() const { return !m_letter.isEmpty(); }
     QString letter()     const { return m_letter.isEmpty()
                                      ? QString(QChar('A' + m_id))
                                      : m_letter; }

--- a/tests/band_recall_slice_selection_policy_test.cpp
+++ b/tests/band_recall_slice_selection_policy_test.cpp
@@ -112,6 +112,23 @@ int main()
     check(onlyFallbackAsserts,
           "only topology fallback asserts active=1 outside a recall");
 
+    // Verify that NO radio-driven source (ActiveStatus, TopologyFallback, InitialEnumeration)
+    // is classified as an operator selection (TopologyFallback asserts active=1 on the wire
+    // but must NOT be persisted as the operator's choice).
+    const RadioSliceSelectionSource kAllSources[] = {
+        RadioSliceSelectionSource::ActiveStatus,
+        RadioSliceSelectionSource::TopologyFallback,
+        RadioSliceSelectionSource::InitialEnumeration,
+    };
+    bool noSourceIsOperatorSelection = true;
+    for (const RadioSliceSelectionSource source : kAllSources) {
+        if (radioSliceSelectionDecision(false, source).isOperatorSelection) {
+            noSourceIsOperatorSelection = false;
+        }
+    }
+    check(noSourceIsOperatorSelection,
+          "no radio-driven source (including topology fallback) is an operator selection");
+
     if (failures == 0) {
         std::printf("\nAll band-recall slice-selection policy tests passed.\n");
         return 0;

--- a/tests/band_recall_slice_selection_policy_test.cpp
+++ b/tests/band_recall_slice_selection_policy_test.cpp
@@ -73,6 +73,45 @@ int main()
               && !ordinaryFallback.suppressActiveCommand,
           "ordinary topology fallback: existing reveal and activation remain");
 
+    // The connect-time bootstrap of the first ENUMERATED slice must never
+    // assert active=1. The radio emits active=1 status for slices as they
+    // enumerate (the last-created slice becomes active in the status stream);
+    // asserting active=1 on the first slice during enumeration overwrote the
+    // radio's active status before the remaining slices were created client-side,
+    // so an operator who left slice B active came back to slice A on every launch.
+    const RadioSliceSelectionDecision initialEnumeration =
+        radioSliceSelectionDecision(
+            false, RadioSliceSelectionSource::InitialEnumeration);
+    check(initialEnumeration.revealOffscreen
+              && initialEnumeration.suppressActiveCommand,
+          "initial enumeration: first slice is selected without asserting active=1");
+
+    // ...and it is equally suppressed during a band recall.
+    const RadioSliceSelectionDecision initialDuringRecall =
+        radioSliceSelectionDecision(
+            true, RadioSliceSelectionSource::InitialEnumeration);
+    check(!initialDuringRecall.revealOffscreen
+              && initialDuringRecall.suppressActiveCommand,
+          "initial enumeration during recall: synchronization-only");
+
+    // TopologyFallback is the ONLY source that may assert the selection — it
+    // fires when the active slice was removed and the radio needs to be told
+    // which one takes over. Guard that this stays a single exception.
+    const RadioSliceSelectionSource kSuppressingSources[] = {
+        RadioSliceSelectionSource::ActiveStatus,
+        RadioSliceSelectionSource::InitialEnumeration,
+    };
+    bool onlyFallbackAsserts =
+        !radioSliceSelectionDecision(
+             false, RadioSliceSelectionSource::TopologyFallback)
+             .suppressActiveCommand;
+    for (const RadioSliceSelectionSource source : kSuppressingSources) {
+        onlyFallbackAsserts = onlyFallbackAsserts
+            && radioSliceSelectionDecision(false, source).suppressActiveCommand;
+    }
+    check(onlyFallbackAsserts,
+          "only topology fallback asserts active=1 outside a recall");
+
     if (failures == 0) {
         std::printf("\nAll band-recall slice-selection policy tests passed.\n");
         return 0;

--- a/tests/slice_selection_restore_policy_test.cpp
+++ b/tests/slice_selection_restore_policy_test.cpp
@@ -24,16 +24,14 @@ int main()
     using AetherSDR::SliceSelectionRestorePolicy;
 
     // Radio ID scoping — client station name isolates Multi-Flex instances
-    check(SliceSelectionRestorePolicy::radioIdForScope(false, "N12345", "", "Station1") == "N12345/Station1",
-          "LAN scope includes station name");
-    check(SliceSelectionRestorePolicy::radioIdForScope(true, "", "N12345", "Station1") == "N12345/Station1",
-          "WAN scope uses chassis serial and includes station name");
+    check(SliceSelectionRestorePolicy::radioIdForScope("N12345", "Station1") == "N12345/Station1",
+          "scope includes station name");
     check(SliceSelectionRestorePolicy::scopeCanCarrySelection(
-              SliceSelectionRestorePolicy::radioIdForScope(true, "", "N12345", "Station1"))
+              SliceSelectionRestorePolicy::radioIdForScope("N12345", "Station1"))
               && SliceSelectionRestorePolicy::shouldCaptureTxSlice(true, 1, true),
           "the TX capture on an unexpected WAN drop");
-    check(SliceSelectionRestorePolicy::radioIdForScope(true, "", "") == "",
-          "WAN scope returns empty when chassis serial is unpopulated");
+    check(SliceSelectionRestorePolicy::radioIdForScope("") == "",
+          "scope returns empty when base radio ID is unpopulated");
 
     // Scope carry guard
     check(SliceSelectionRestorePolicy::scopeCanCarrySelection("N12345/Station1"),

--- a/tests/slice_selection_restore_policy_test.cpp
+++ b/tests/slice_selection_restore_policy_test.cpp
@@ -56,8 +56,15 @@ int main()
           "profile load held -> Defer");
     check(SliceSelectionRestorePolicy::restoreAction(true, false, false) == SliceSelectionRestorePolicy::RestoreAction::Defer,
           "scope not ready -> Defer");
-    check(SliceSelectionRestorePolicy::restoreAction(false, false, true) == SliceSelectionRestorePolicy::RestoreAction::Skip,
-          "disallowed -> Skip");
+    // Letters ready predicate
+    check(SliceSelectionRestorePolicy::lettersReadyForSelection(2, 2),
+          "letters ready when all enumerated slices have index_letter");
+    check(!SliceSelectionRestorePolicy::lettersReadyForSelection(2, 1),
+          "letters not ready when index_letter is pending on some slices");
+    check(SliceSelectionRestorePolicy::lettersReadyForSelection(2, 0),
+          "older firmware (no index_letter) considers letters ready via 'A' + id fallback");
+    check(!SliceSelectionRestorePolicy::lettersReadyForSelection(0, 0),
+          "un-enumerated slice list is not ready");
 
     if (failures == 0) {
         std::printf("\nAll slice selection restore policy tests passed.\n");

--- a/tests/slice_selection_restore_policy_test.cpp
+++ b/tests/slice_selection_restore_policy_test.cpp
@@ -28,6 +28,10 @@ int main()
           "LAN scope includes station name");
     check(SliceSelectionRestorePolicy::radioIdForScope(true, "", "N12345", "Station1") == "N12345/Station1",
           "WAN scope uses chassis serial and includes station name");
+    check(SliceSelectionRestorePolicy::scopeCanCarrySelection(
+              SliceSelectionRestorePolicy::radioIdForScope(true, "", "N12345", "Station1"))
+              && SliceSelectionRestorePolicy::shouldCaptureTxSlice(true, 1, true),
+          "the TX capture on an unexpected WAN drop");
     check(SliceSelectionRestorePolicy::radioIdForScope(true, "", "") == "",
           "WAN scope returns empty when chassis serial is unpopulated");
 

--- a/tests/slice_selection_restore_policy_test.cpp
+++ b/tests/slice_selection_restore_policy_test.cpp
@@ -1,0 +1,67 @@
+#include "gui/SliceSelectionRestorePolicy.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* message)
+{
+    if (!condition) {
+        std::fprintf(stderr, "[FAIL] %s\n", message);
+        ++failures;
+    } else {
+        std::printf("[PASS] %s\n", message);
+    }
+}
+
+}  // namespace
+
+int main()
+{
+    using AetherSDR::SliceSelectionRestorePolicy;
+
+    // Radio ID scoping — client station name isolates Multi-Flex instances
+    check(SliceSelectionRestorePolicy::radioIdForScope(false, "N12345", "", "Station1") == "N12345/Station1",
+          "LAN scope includes station name");
+    check(SliceSelectionRestorePolicy::radioIdForScope(true, "", "N12345", "Station1") == "N12345/Station1",
+          "WAN scope uses chassis serial and includes station name");
+    check(SliceSelectionRestorePolicy::radioIdForScope(true, "", "") == "",
+          "WAN scope returns empty when chassis serial is unpopulated");
+
+    // Scope carry guard
+    check(SliceSelectionRestorePolicy::scopeCanCarrySelection("N12345/Station1"),
+          "non-empty scope ID can carry selection");
+    check(!SliceSelectionRestorePolicy::scopeCanCarrySelection(""),
+          "empty scope ID cannot carry selection");
+
+    // Persist guard
+    check(SliceSelectionRestorePolicy::shouldPersist(false, false, false, false),
+          "operator selection is persisted");
+    check(!SliceSelectionRestorePolicy::shouldPersist(true, false, false, false),
+          "radio echo / system selection is suppressed");
+    check(!SliceSelectionRestorePolicy::shouldPersist(false, true, false, false),
+          "selection during band recall is suppressed");
+    check(!SliceSelectionRestorePolicy::shouldPersist(false, false, true, false),
+          "selection during profile load is suppressed");
+    check(!SliceSelectionRestorePolicy::shouldPersist(false, false, false, true),
+          "selection from restore path is suppressed");
+
+    // Restore action
+    check(SliceSelectionRestorePolicy::restoreAction(true, false, true) == SliceSelectionRestorePolicy::RestoreAction::Apply,
+          "allowed, unheld, ready scope -> Apply");
+    check(SliceSelectionRestorePolicy::restoreAction(true, true, true) == SliceSelectionRestorePolicy::RestoreAction::Defer,
+          "profile load held -> Defer");
+    check(SliceSelectionRestorePolicy::restoreAction(true, false, false) == SliceSelectionRestorePolicy::RestoreAction::Defer,
+          "scope not ready -> Defer");
+    check(SliceSelectionRestorePolicy::restoreAction(false, false, true) == SliceSelectionRestorePolicy::RestoreAction::Skip,
+          "disallowed -> Skip");
+
+    if (failures == 0) {
+        std::printf("\nAll slice selection restore policy tests passed.\n");
+        return 0;
+    }
+    return 1;
+}

--- a/tests/slice_selection_restore_policy_test.cpp
+++ b/tests/slice_selection_restore_policy_test.cpp
@@ -40,6 +40,10 @@ int main()
           "empty scope ID cannot carry selection");
 
     // Persist guard
+    check(SliceSelectionRestorePolicy::mayAssertTxSlice(true),
+          "TX slice may be asserted when we own transmit");
+    check(!SliceSelectionRestorePolicy::mayAssertTxSlice(false),
+          "TX slice is never asserted when another client owns transmit");
     check(SliceSelectionRestorePolicy::shouldPersist(false, false, false, false),
           "operator selection is persisted");
     check(!SliceSelectionRestorePolicy::shouldPersist(true, false, false, false),


### PR DESCRIPTION
## Summary

Fixes active and TX slice selection retention across app restarts (#4759).

On a fresh connection, Flex radios enumerate existing slices in slice ID order (`slice 0 ... active=1`, `slice 1 ... active=1`). AetherSDR's initial connect bootstrap in `onSliceAdded()` previously selected the first enumerated slice via `RadioSliceSelectionSource::TopologyFallback`, which sent `active=1` back to the radio over the wire. Because the first slice enumerated is merely the first one created—not necessarily the radio's active slice—and landed before subsequent slices were created client-side, the client's write overwrote the radio's live active slice state on every launch (causing slice B to silently revert to slice A).

This PR introduces `RadioSliceSelectionSource::InitialEnumeration`, which reveals the first enumerated slice in the UI without asserting `active=1` to the radio over the wire. Once connect slice enumeration settles (600 ms debounce), `SliceSelection` policy restores the operator's last saved active slice and TX slice choices across app restarts.

Feature document storage uses `AppSettings::radioFeatureExact(family, scope, "SliceSelection")` for RMW. Multi-Flex client instances on the same radio are isolated by client station name (`<radioSerial>/<stationName>`), and `m_txOwnedByUs` interlock state is cleanly initialized on session disconnects.

Reference FlexLib (`Slice.cs:2032`) handles incoming active status with `_UpdateActive(..., update_radio: false)`, matching this non-asserting behavior.

### Side Effect / Related Improvement

- **SmartLink/WAN Scope & BandStack Retention**: Obtaining radio identity directly from `RadioModel::settingsScope()` ensures that SmartLink/WAN sessions receive a valid chassis serial rather than an empty string. As a beneficial side effect, `BandStackSettings` (which refuses an empty `radioId`) now persists per-radio band-stack bookmarks across SmartLink/WAN sessions.

## Review Blockers Resolved

- **`InitialEnumeration` bug fix retained**: Connect-time slice bootstrap uses `RadioSliceSelectionSource::InitialEnumeration` to adopt first slice locally without sending `active=1` back over the wire.
- **Blocker 1 (`TopologyFallback` persistence separation)**: Fixed and mutation-test pinned. `TopologyFallback` asserts `active=1` on the wire (so the radio has a valid active slice when a slice is removed), but sets `m_selectingFromRadioState = true` so it is NOT persisted as an operator choice and does NOT cancel the pending restore window (`isOperatorSelection = false`).
- **Blocker 3 (Radio identity re-derivation)**: Fixed. `sliceSelectionScope()` obtains canonical radio identity directly from `RadioModel::settingsScope().radioId()`, preventing drift between settings accessors.
- **Read-Modify-Write Exact Row**: `storeSliceSelectionLetter()` uses `AppSettings::radioFeatureExact()` so family defaults are never cloned into per-radio rows during RMW.
- **Multi-Flex Document Isolation**: Keyed by `<scopeRadioId>/<stationName>` so multiple AetherSDR instances on the same radio do not clobber each other's slice selection documents.
- **`txOwnedByUs` Session Lifecycle & Restore Guard Coverage**: Added explicit reset of `m_txOwnedByUs` (`true`) and `m_txClientHandle` (`0`) in `RadioModel::onDisconnected()` ([`RadioModel.cpp:6068`](file:///usr/local/src/aethersdr-worktrees/slice-restore/src/models/RadioModel.cpp#L6068)). Pinning assertions for `mayAssertTxSlice(bool)` were added to `slice_selection_restore_policy_test.cpp`.
- **Governance Clean**: `AGENTS.md` and `RadioCapabilities.h` remain clean and untouched.
- **Unit-Tested Readiness Predicate**: `lettersReadyForSelection` is extracted into `SliceSelectionRestorePolicy` and covered by unit tests for both modern firmware (`index_letter`) and older firmware (`'A' + sliceId` fallback).

## Constitution principle honored

- **Principle II — Radio-Authoritative Live State**: `RadioModel::onDisconnected()` resets interlock TX ownership state so live session state is always initialized directly from radio-authoritative status.
- **Principle III — Radio-persistable vs. Client-owned State**: AetherSDR respects radio-authoritative active slice state during connect enumeration and avoids overwriting live radio state with client-side writes.
- **Principle V — Per-feature config ownership**: `SliceSelection` settings are stored as an atomic feature document in `AppSettings` via `radioFeatureExact`.
- **Principle VI — Evidence Over Assertion**: Gated restore predicates (`mayAssertTxSlice`) are directly tested and pinned by unit tests.

## Test plan & Verification Results

- [x] Local build passes (`cmake --build build -j$(nproc)`)
- [x] Unit tests pass (`./build/slice_selection_restore_policy_test` and `./build/band_recall_slice_selection_policy_test`)
- [x] Static engine boundary check passes (`python3 tools/check_engine_boundary.py --strict` - 0 blocking violations)
- [x] Network transfer timeouts check passes (`python3 tools/check_network_timeouts.py --strict`)
- [x] Theme seed check passes (`python3 tools/check_theme_seed.py --strict`)
- [x] Accessibility check passes (`python3 tools/check_a11y.py src/gui/MainWindow.cpp src/gui/MainWindow_Wiring.cpp` - 0 findings)

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [ ] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [ ] Documentation updated if user-visible behavior changed — `docs/` and the affected READMEs. **Not `CHANGELOG.md`**, which is a release-prep file a PR must not add to (AGENTS.md); describe it in the Summary above instead
- [ ] Security-sensitive changes reference a GHSA if applicable
