### PR TITLE
fix(logging): name TCI in the aether.cat category label (#4750)

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -723,8 +723,8 @@ handoffs: `buffer_bytes_available`, `buffer_capacity_bytes`,
 capacity during TCI suppression. An Active-to-Idle transition with suppressed
 callbacks and unread bytes remains a fallback for backends that do not expose a
 useful capacity. The same evidence is written to the Audio Summary support log
-only when Help → Support's **CAT/rigctld** logging toggle (the category used by
-TCI debug logging) is enabled; TX capture-health summaries are off by default.
+only when Help → Support's **TCI / CAT / rigctld** logging toggle is enabled;
+TX capture-health summaries are off by default.
 
 ### `get cwx`
 CWX keyer state, including the **queue-drain watch** that the #3949 fix relies

--- a/src/core/LogManager.cpp
+++ b/src/core/LogManager.cpp
@@ -69,18 +69,20 @@ LogManager::LogManager()
         {"aether.dsp",        "DSP",          "NR2, RN2, CW decoder processing"},
         {"aether.rade",       "RADE",         "FreeDV Radio Autoencoder digital voice"},
         {"aether.smartlink",  "SmartLink",    "Auth0 login, TLS tunnel, WAN streaming"},
-        // Label leads with TCI because TciServer.cpp owns 53 of this category's
-        // 76 call sites — CatPort.cpp has 15 and the rest are scattered. The
-        // old "CAT/rigctld" label named only the minority user, so someone
-        // chasing a TCI problem scanned the checkbox list, saw nothing about
-        // TCI, and concluded AetherSDR had no TCI logging to turn on. It has
-        // more than any other rig-control surface; it was just filed under
-        // another name. Deliberately NOT split into a new aether.tci category:
-        // the id is what filter rules and saved settings key off, so renaming
-        // it would silently drop every user's existing preference for this
-        // category, and the two surfaces genuinely share the rig-control
-        // plumbing that the qCInfo lines report on.
-        {"aether.cat",        "TCI / CAT / rigctld",  "TCI server (slice and DAX arming, TX audio summaries), rigctld TCP servers, PTY virtual serial ports"},
+        // Label leads with TCI because TciServer.cpp owns the large majority of
+        // this category's call sites — 53 of 76 as of #4750, with CatPort.cpp
+        // next at 15 and the rest scattered. The old "CAT/rigctld" label named
+        // only the minority user, so someone chasing a TCI problem scanned the
+        // checkbox list, saw nothing about TCI, and concluded AetherSDR had no
+        // TCI logging to turn on. It has more than any other rig-control
+        // surface; it was just filed under another name. Deliberately NOT split
+        // into a new aether.tci category: the id is what filter rules and saved
+        // settings key off, so renaming it would silently drop every user's
+        // existing preference for this category, and the two surfaces genuinely
+        // share the rig-control plumbing that the qCInfo lines report on.
+        // The description names the TX-summary fields (blocks/peak/rms/clips)
+        // because those are the tokens an operator greps a support log for.
+        {"aether.cat",        "TCI / CAT / rigctld",  "TCI server (slice and DAX arming, TX audio summary: blocks, peak, rms, clips), rigctld TCP servers, PTY virtual serial ports"},
         {"aether.dax",        "DAX",          "Virtual audio bridge (PipeWire/CoreAudio)"},
         {"aether.meters",     "Meters",       "Meter definitions and value conversion"},
         {"aether.transmit",   "Transmit",     "TX state, ATU, profiles, power control"},

--- a/src/core/LogManager.cpp
+++ b/src/core/LogManager.cpp
@@ -69,7 +69,18 @@ LogManager::LogManager()
         {"aether.dsp",        "DSP",          "NR2, RN2, CW decoder processing"},
         {"aether.rade",       "RADE",         "FreeDV Radio Autoencoder digital voice"},
         {"aether.smartlink",  "SmartLink",    "Auth0 login, TLS tunnel, WAN streaming"},
-        {"aether.cat",        "CAT/rigctld",  "rigctld TCP servers, PTY virtual serial ports"},
+        // Label leads with TCI because TciServer.cpp owns 53 of this category's
+        // 76 call sites — CatPort.cpp has 15 and the rest are scattered. The
+        // old "CAT/rigctld" label named only the minority user, so someone
+        // chasing a TCI problem scanned the checkbox list, saw nothing about
+        // TCI, and concluded AetherSDR had no TCI logging to turn on. It has
+        // more than any other rig-control surface; it was just filed under
+        // another name. Deliberately NOT split into a new aether.tci category:
+        // the id is what filter rules and saved settings key off, so renaming
+        // it would silently drop every user's existing preference for this
+        // category, and the two surfaces genuinely share the rig-control
+        // plumbing that the qCInfo lines report on.
+        {"aether.cat",        "TCI / CAT / rigctld",  "TCI server (slice and DAX arming, TX audio summaries), rigctld TCP servers, PTY virtual serial ports"},
         {"aether.dax",        "DAX",          "Virtual audio bridge (PipeWire/CoreAudio)"},
         {"aether.meters",     "Meters",       "Meter definitions and value conversion"},
         {"aether.transmit",   "Transmit",     "TX state, ATU, profiles, power control"},

--- a/tests/log_manager_filter_rules_test.cpp
+++ b/tests/log_manager_filter_rules_test.cpp
@@ -91,6 +91,32 @@ int main(int argc, char** argv)
     report("audio.summary info always on", lcAudioSummary().isInfoEnabled());
     report("QtDebugMsg-declared info untouched", lcKiwiSdr().isInfoEnabled());
 
+    // #4750: the aether.cat checkbox must NAME the TCI server, which owns 53 of
+    // the category's 76 call sites. The old label said only "CAT/rigctld", so a
+    // user hunting TCI diagnostics scanned Help → Support, found no mention of
+    // TCI, and concluded there was none to enable. The label is the checkbox
+    // text and the description is its tooltip, so the label is what has to
+    // carry it — a user who has to open a tooltip to discover the category has
+    // already given up on it.
+    //
+    // Asserted on the metadata rather than by eyeballing the dialog because
+    // this is precisely the kind of drift that returns: the id is stable and
+    // the call sites moved to TCI over time while the human-readable name kept
+    // pointing at the original minority user.
+    {
+        QString catLabel, catDesc;
+        bool found = false;
+        for (const auto& c : lm.categories()) {
+            if (c.id == "aether.cat") { catLabel = c.label; catDesc = c.description; found = true; break; }
+        }
+        report("aether.cat is registered", found);
+        report("aether.cat label names TCI (#4750)", catLabel.contains("TCI", Qt::CaseInsensitive));
+        // The rename must not drop the surfaces that were already discoverable.
+        report("aether.cat label keeps CAT", catLabel.contains("CAT", Qt::CaseSensitive));
+        report("aether.cat label keeps rigctld", catLabel.contains("rigctld", Qt::CaseInsensitive));
+        report("aether.cat description mentions TCI", catDesc.contains("TCI", Qt::CaseInsensitive));
+    }
+
     // Toggling back off closes the gate again.
     lm.setEnabled("aether.cat", false);
     report("re-disabled: info off", !lcCat().isInfoEnabled());


### PR DESCRIPTION
Fixes #4750.

## Problem

`aether.cat` is registered as **"CAT/rigctld"** in the Support & Diagnostics
dialog. That label names the minority user of the category.

Counting the actual `qCDebug/qCInfo/qCWarning/qCCritical(lcCat)` call sites on
`main` @ `a061c5c3` — 76 in total:

| file | call sites | share |
|---|---|---|
| `src/core/TciServer.cpp` | **53** | 69.7% |
| `src/core/CatPort.cpp` | 15 | 19.7% |
| `SmartCatSession` / `SmartCatProtocol` / `RigctlProtocol` | 2 each | |
| `PanadapterStream` / `LogManager` | 1 each | |

The TciServer lines are unambiguously TCI — they self-identify in their own
message text (`"TCI: radio reconnected — re-arming DAX"`, `"TciServer:
listening on port"`, `"TCI: audio started for client"`, `"TCI rx:"`).

In `SupportDialog.cpp` the **label is the checkbox text** and the description
is only its tooltip. So a user chasing a TCI problem scans the checkbox grid,
sees no mention of TCI anywhere, and reasonably concludes AetherSDR has no TCI
logging to turn on. It has more TCI logging than any other rig-control surface
in the app — it was just filed under another name.

This is the same discoverability class as #4419 and #4537, which were about
this category's messages being unreachable at runtime. This one is about them
being unreachable to the person looking for them.

## Fix

Relabel to **"TCI / CAT / rigctld"** and name the TCI surfaces in the
description. Deliberately **labels-only**:

- The **id `aether.cat` is unchanged.** The id is what `applyFilterRules()`
  builds rules from and what `saveSettings()` persists, so renaming it would
  silently discard every existing user's saved preference for this category —
  and would break the documented
  `QT_LOGGING_RULES="aether.cat.info=true"` escape hatch (CHANGELOG:558) plus
  the two tests that key off it.
- **Not split into a new `aether.tci` category.** The two surfaces share the
  rig-control plumbing these lines report on, and a split would mean the same
  settings-loss problem plus a second checkbox for one logical concern.

`docs/automation-bridge.md` referred to this toggle by its old label and had to
gloss it parenthetically as "(the category used by TCI debug logging)" — which
is the bug restated in the docs. Updated to the new label; the gloss is now
redundant and is dropped.

## Testing

Extended `log_manager_filter_rules_test` — the existing home for this
category's metadata behaviour — rather than adding a new target.

The new assertions pin that the label names TCI **and** that the relabel does
not drop the two surfaces that were already discoverable (`CAT`, `rigctld`),
so a future edit cannot fix discoverability for one audience by breaking it for
another.

**Falsifiability proven, not assumed.** Windows / MSVC 19.50, Qt 6.8.3,
RelWithDebInfo, `QT_QPA_PLATFORM=offscreen`:

- **Fixed — 16/16 pass, exit 0.**
- **Deliberately reverted** `LogManager.cpp` to the old `"CAT/rigctld"` label,
  leaving the test untouched → **exit 1**, failing on exactly:

  ```
  [FAIL] aether.cat label names TCI (#4750)
  [FAIL] aether.cat description mentions TCI
  ```

  The `keeps CAT` / `keeps rigctld` assertions stayed **green** through the
  revert, which is the point — they pin a different property, so the two new
  TCI assertions are the only thing the label change moves.
- **Restored the fix → 16/16 green again.**

Not a green re-run: the red state was produced deliberately and the failing
assertions were the predicted ones.

**Verified in the running app**, not only in the unit test. Built `AetherSDR`
from this branch, launched it under `AETHER_AUTOMATION=1`, and asked the
automation bridge what the Support dialog is actually working from:

```
$ log categories
{"enabled": false, "id": "aether.cat", "label": "TCI / CAT / rigctld"}
```

That is the same `Category.label` that `SupportDialog.cpp` passes straight to
`new QCheckBox(cat.label)`, and it confirms the id is still `aether.cat` in a
live process — so saved settings and `QT_LOGGING_RULES` keep resolving.

The pre-existing assertions in the same test (the #4419 Debug/Info coupling,
the `audio.summary` always-on case, the QtDebugMsg-declared-Info case) continue
to pass, confirming the relabel does not disturb filter-rule behaviour — the
id, which those rules are built from, is untouched.

**Not exercised:** the dialog was not driven to a screenshot — the bridge's
`menu open` pops a top-level menu but cannot click an item, and this action is
a lambda with no object name for `invoke` to target. The label was read from
the live app's own metadata rather than off a rendered pixel.
