### PR TITLE
fix(asr): fall back to CPU instead of crashing when the GPU cannot be used (Linux/Windows)

### DIFF
--- a/src/asr/WhisperAsrBackend.cpp
+++ b/src/asr/WhisperAsrBackend.cpp
@@ -188,6 +188,11 @@ bool WhisperAsrBackend::load(const QString& modelPath, QString* error)
         }
         cparams.use_gpu = false;
         cparams.gpu_device = 0;
+        // Clear the GPU attempt's message first: initWhisperContext() writes
+        // `failure` only when it catches, so a CPU retry that simply returns
+        // null would otherwise be reported with the GPU's Vulkan exception
+        // text — blaming the driver for, say, a truncated model file.
+        failure.clear();
         m_ctx = initWhisperContext(pathUtf8, cparams, &failure);
     }
     if (m_ctx == nullptr) {
@@ -199,10 +204,14 @@ bool WhisperAsrBackend::load(const QString& modelPath, QString* error)
         return false;
     }
 
-    // Remember where this context actually lives: after the CPU retry above,
-    // cparams.use_gpu is false even though m_gpuDevice still names the GPU.
-    // transcribe() consults this so a decode-time throw latches the device
-    // only when the GPU was really involved.
+    // Whether a GPU was asked for on the attempt that actually produced this
+    // context: false after the CPU retry above, even though m_gpuDevice still
+    // names the GPU. transcribe() consults it so a decode-time throw latches
+    // the device only when the GPU was in the picture. It records the request,
+    // not proof of placement — whisper falls back to CPU internally if
+    // whisper_backend_init_gpu() yields nothing — so the flag errs toward
+    // latching. That is the safe direction: an over-latch costs a session of
+    // GPU speed, an under-latch costs the process (#4502).
     m_ctxOnGpu = cparams.use_gpu;
 
     qCInfo(lcAsrWhisper) << "Loaded model" << modelPath << "(" << m_threads << "threads )";

--- a/src/asr/WhisperAsrBackend.cpp
+++ b/src/asr/WhisperAsrBackend.cpp
@@ -6,6 +6,8 @@
 
 #include <algorithm>
 #include <exception>
+#include <mutex>
+#include <set>
 
 #include <ggml-backend.h>
 #include <whisper.h>
@@ -145,7 +147,11 @@ bool WhisperAsrBackend::load(const QString& modelPath, QString* error)
     // gpu_device selects the GPU (index among GPU devices; see asrGpuDevices), or
     // -1 to force CPU. Otherwise use a GPU backend (Vulkan/Metal) when one is
     // compiled in and present; ggml falls back to CPU automatically when not.
-    const bool useGpu = m_gpuDevice >= 0 && asrGpuAvailable();
+    // A device that failed a load earlier this session is never re-entered:
+    // ggml's GPU instance state is sticky, and a second attempt against it can
+    // fault below the level any caller can guard (#4502).
+    const bool useGpu =
+        m_gpuDevice >= 0 && asrGpuAvailable() && !asrGpuDeviceFailed(m_gpuDevice);
     cparams.use_gpu = useGpu;
     cparams.gpu_device = useGpu ? m_gpuDevice : 0;
 
@@ -160,6 +166,7 @@ bool WhisperAsrBackend::load(const QString& modelPath, QString* error)
         qCWarning(lcAsrWhisper) << "GPU model load failed"
                                 << (failure.isEmpty() ? QStringLiteral("(null context)") : failure)
                                 << "- retrying on CPU";
+        asrMarkGpuDeviceFailed(m_gpuDevice);
         cparams.use_gpu = false;
         cparams.gpu_device = 0;
         m_ctx = initWhisperContext(pathUtf8, cparams, &failure);
@@ -281,6 +288,96 @@ std::function<std::unique_ptr<IAsrBackend>()> whisperAsrBackendFactory(const QSt
     };
 }
 
+namespace {
+
+// Devices whose model load failed this run. Whisper loads happen on the ASR
+// worker thread while enumeration runs on a QtConcurrent pool thread, so the
+// set is mutex-guarded. Never cleared: see asrMarkGpuDeviceFailed's contract.
+std::mutex& asrFailedGpuMutex()
+{
+    static std::mutex m;
+    return m;
+}
+
+std::set<int>& asrFailedGpuDevices()
+{
+    static std::set<int> failed;
+    return failed;
+}
+
+// Whether `dev` can run the kernels whisper's heavy path schedules on the GPU.
+// Probed through the public ggml_backend_dev_supports_op with synthetic ops — a
+// contiguous F32 soft-max, an F16 mat-mul, and a flash-attention op (whisper
+// enables flash attention unconditionally) — rather than by reading
+// backend-internal device properties, so one probe serves every GPU backend.
+// supports_op only consults device properties: nothing is compiled or allocated
+// (no_alloc context, freed before returning).
+//
+// On the Vulkan backends this is deliberately the FIRST touch of the device:
+// ggml_backend_vk_device_supports_op resolves ggml_vk_get_device, which creates
+// the logical device. A driver stack that cannot create one fails here — once,
+// early, and survivably — instead of at model-load time, where a repeat attempt
+// against ggml's already-initialised instance state is no longer recoverable.
+bool asrDeviceUsableForDecode(ggml_backend_dev_t dev)
+{
+    ggml_init_params params = {};
+    params.mem_size = 16 * 1024;
+    params.no_alloc = true;
+    ggml_context* ctx = ggml_init(params);
+    if (ctx == nullptr) {
+        return false;
+    }
+    ggml_tensor* act = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 64, 64);
+    ggml_tensor* softMax = ggml_soft_max(ctx, act);
+    ggml_tensor* weights = ggml_new_tensor_2d(ctx, GGML_TYPE_F16, 64, 64);
+    ggml_tensor* mulMat = ggml_mul_mat(ctx, weights, act);
+    // Head dim 64 + F16 K/V mirrors whisper's encoder.
+    ggml_tensor* q = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, 64, 4, 8);
+    ggml_tensor* k = ggml_new_tensor_3d(ctx, GGML_TYPE_F16, 64, 4, 8);
+    ggml_tensor* v = ggml_new_tensor_3d(ctx, GGML_TYPE_F16, 64, 4, 8);
+    ggml_tensor* flashAttn =
+        ggml_flash_attn_ext(ctx, q, k, v, nullptr, 1.0f, 0.0f, 0.0f);
+    const bool usable = ggml_backend_dev_supports_op(dev, softMax)
+        && ggml_backend_dev_supports_op(dev, mulMat)
+        && ggml_backend_dev_supports_op(dev, flashAttn);
+    ggml_free(ctx);
+    return usable;
+}
+
+} // namespace
+
+void asrMarkGpuDeviceFailed(int index)
+{
+    if (index < 0) {
+        return; // CPU is the fallback; it is never latched out
+    }
+    const std::lock_guard<std::mutex> lock(asrFailedGpuMutex());
+    if (asrFailedGpuDevices().insert(index).second) {
+        qCWarning(lcAsrWhisper)
+            << "GPU device" << index
+            << "marked unusable for the rest of this session after a failed load";
+    }
+}
+
+bool asrGpuDeviceFailed(int index)
+{
+    if (index < 0) {
+        return false;
+    }
+    const std::lock_guard<std::mutex> lock(asrFailedGpuMutex());
+    return asrFailedGpuDevices().count(index) > 0;
+}
+
+int asrResolveDefaultGpuIndex(const std::vector<AsrGpuDevice>& devices)
+{
+    for (const AsrGpuDevice& d : devices) {
+        if (d.usable) {
+            return d.index;
+        }
+    }
+    return -1; // CPU
+}
+
 std::vector<AsrGpuDevice> asrGpuDevices()
 {
     if (!asrMetalUsableHost()) {
@@ -307,6 +404,50 @@ std::vector<AsrGpuDevice> asrGpuDevices()
                 AsrGpuDevice d;
                 d.index = index++;
                 d.name = QString::fromUtf8(ggml_backend_dev_description(dev));
+                // A device that already failed a load this session stays
+                // unusable no matter what the probe would now say — and is not
+                // re-probed, since probing is itself a device-creation attempt.
+                if (asrGpuDeviceFailed(d.index)) {
+                    d.usable = false;
+                } else {
+                    // Probe each device inside its own guard: on the Vulkan
+                    // backends this creates the logical device, so a broken
+                    // driver throws here. That verdict belongs to this device
+                    // alone — a second, healthy GPU in the same box must stay
+                    // usable. The device is kept in the list either way, so
+                    // the indices whisper's gpu_device refers to never shift.
+                    try {
+                        d.usable = asrDeviceUsableForDecode(dev);
+                        if (!d.usable) {
+                            qCInfo(lcAsrWhisper)
+                                << "GPU device" << d.index << d.name
+                                << "fails the decode capability probe - not offered as default";
+                        }
+                    } catch (const std::exception& e) {
+                        // A THROW here means device creation itself failed, so
+                        // ggml's instance state is now half-initialised for
+                        // this device. Latch it out: a later attempt — an
+                        // explicit pick, or a restored preference — would be
+                        // the second creation attempt, which can fault below
+                        // any guard (#4502). A probe that merely returns false
+                        // is not latched: that device was created fine, it
+                        // just cannot run the decode, and staying selectable
+                        // for diagnostics is harmless.
+                        d.usable = false;
+                        asrMarkGpuDeviceFailed(d.index);
+                        qCWarning(lcAsrWhisper)
+                            << "GPU device" << d.index << d.name
+                            << "failed the capability probe:" << e.what()
+                            << "- not offered, and not retried this session";
+                    } catch (...) {
+                        d.usable = false;
+                        asrMarkGpuDeviceFailed(d.index);
+                        qCWarning(lcAsrWhisper)
+                            << "GPU device" << d.index << d.name
+                            << "failed the capability probe (unknown exception)"
+                            << "- not offered, and not retried this session";
+                    }
+                }
                 devices.push_back(std::move(d));
             }
         }

--- a/src/asr/WhisperAsrBackend.cpp
+++ b/src/asr/WhisperAsrBackend.cpp
@@ -353,9 +353,11 @@ void asrMarkGpuDeviceFailed(int index)
     }
     const std::lock_guard<std::mutex> lock(asrFailedGpuMutex());
     if (asrFailedGpuDevices().insert(index).second) {
+        // Reached from both the probe and the model load, so the reason is not
+        // named here — the caller logs it.
         qCWarning(lcAsrWhisper)
             << "GPU device" << index
-            << "marked unusable for the rest of this session after a failed load";
+            << "marked unusable for the rest of this session; it will not be tried again";
     }
 }
 

--- a/src/asr/WhisperAsrBackend.cpp
+++ b/src/asr/WhisperAsrBackend.cpp
@@ -180,6 +180,12 @@ bool WhisperAsrBackend::load(const QString& modelPath, QString* error)
         return false;
     }
 
+    // Remember where this context actually lives: after the CPU retry above,
+    // cparams.use_gpu is false even though m_gpuDevice still names the GPU.
+    // transcribe() consults this so a decode-time throw latches the device
+    // only when the GPU was really involved.
+    m_ctxOnGpu = cparams.use_gpu;
+
     qCInfo(lcAsrWhisper) << "Loaded model" << modelPath << "(" << m_threads << "threads )";
     return true;
 }
@@ -220,16 +226,28 @@ AsrTranscript WhisperAsrBackend::transcribe(const std::vector<float>& pcm16k, QS
     wparams.detect_language = false;
 
     // Same guard as the load path: inference reaches the GPU backend too, and
-    // an exception escaping the worker thread would terminate the app.
+    // an exception escaping the worker thread would terminate the app. A GPU
+    // that loaded the model fine can still fail here — and the session contract
+    // is the same as for a failed load: never hand this device another attempt
+    // (a repeat touch of the now-poisoned backend state is the class of #4502).
+    // Latch only when the context actually lives on the GPU; a CPU-side throw
+    // (e.g. an allocation failure) says nothing about the GPU. The GUI rebuilds
+    // the engine off the failed device when the error signal arrives.
     int status = -1;
     try {
         status = whisper_full(m_ctx, wparams, pcm16k.data(), static_cast<int>(pcm16k.size()));
     } catch (const std::exception& e) {
+        if (m_ctxOnGpu) {
+            asrMarkGpuDeviceFailed(m_gpuDevice);
+        }
         if (error != nullptr) {
             *error = QStringLiteral("whisper_full() failed: %1").arg(QString::fromUtf8(e.what()));
         }
         return {};
     } catch (...) {
+        if (m_ctxOnGpu) {
+            asrMarkGpuDeviceFailed(m_gpuDevice);
+        }
         if (error != nullptr) {
             *error = QStringLiteral("whisper_full() failed: unknown exception");
         }
@@ -278,6 +296,7 @@ void WhisperAsrBackend::unload()
         whisper_free(m_ctx);
         m_ctx = nullptr;
     }
+    m_ctxOnGpu = false;
 }
 
 std::function<std::unique_ptr<IAsrBackend>()> whisperAsrBackendFactory(const QString& language,

--- a/src/asr/WhisperAsrBackend.cpp
+++ b/src/asr/WhisperAsrBackend.cpp
@@ -163,10 +163,29 @@ bool WhisperAsrBackend::load(const QString& modelPath, QString* error)
         // ggml-vulkan's instance state is sticky per process — a second GPU
         // attempt re-enters the half-built state (the fail-then-crash pattern
         // of #4502). Retry once on CPU, which never touches the GPU backend.
+        //
+        // Only blame the GPU when the model itself is sound: an empty or
+        // unreadable file yields the same null context, and latching the
+        // device for that reports broken hardware for a bad download — and
+        // costs the GPU until restart, since the latch is one-way. The latch
+        // itself stays wide (`failure` is empty in exactly the dangerous
+        // case: whisper's internal catch swallows the vk::SystemError and
+        // returns null, so there is no discriminator on the exception side),
+        // and it stays BEFORE the CPU retry so a retry that fails for its own
+        // reasons — say, out of memory — cannot leave a poisoned device
+        // unlatched.
+        const QFileInfo modelInfo(modelPath);
+        const bool modelPlausible = modelInfo.isReadable() && modelInfo.size() > 0;
         qCWarning(lcAsrWhisper) << "GPU model load failed"
                                 << (failure.isEmpty() ? QStringLiteral("(null context)") : failure)
                                 << "- retrying on CPU";
-        asrMarkGpuDeviceFailed(m_gpuDevice);
+        if (modelPlausible) {
+            asrMarkGpuDeviceFailed(m_gpuDevice);
+        } else {
+            qCWarning(lcAsrWhisper)
+                << "model file is empty or unreadable - not latching device"
+                << m_gpuDevice << "; the file is the fault, not the GPU";
+        }
         cparams.use_gpu = false;
         cparams.gpu_device = 0;
         m_ctx = initWhisperContext(pathUtf8, cparams, &failure);
@@ -195,6 +214,20 @@ AsrTranscript WhisperAsrBackend::transcribe(const std::vector<float>& pcm16k, QS
     if (m_ctx == nullptr) {
         if (error != nullptr) {
             *error = QStringLiteral("no model loaded");
+        }
+        return {};
+    }
+    if (m_ctxOnGpu && asrGpuDeviceFailed(m_gpuDevice)) {
+        // The device this context lives on has been latched since the load —
+        // decoding on it again is exactly the second attempt the session
+        // contract forbids (#4502), and without this guard it stays possible
+        // in the window between the latch and the queued engine rebuild that
+        // retires this context. Refuse instead; the error keeps nudging the
+        // GUI's rebuild path, whose reconcile entry guard makes repeats
+        // harmless.
+        if (error != nullptr) {
+            *error = QStringLiteral("GPU device is latched out after a failure; "
+                                    "decode refused until the engine rebuilds off it");
         }
         return {};
     }
@@ -329,6 +362,11 @@ std::set<int>& asrFailedGpuDevices()
 // contiguous F32 soft-max, an F16 mat-mul, and a flash-attention op (whisper
 // enables flash attention unconditionally) — rather than by reading
 // backend-internal device properties, so one probe serves every GPU backend.
+// The op shapes model the decode of the vendored whisper.cpp (1.9.1 at this
+// writing): head dim 64, F16 K/V, unconditional flash attention. They are a
+// prediction, not a contract — a whisper.cpp bump that changes any of that
+// quietly changes what this probe should be asking, so re-derive the shapes
+// whenever the vendored copy moves.
 // supports_op only consults device properties: nothing is compiled or allocated
 // (no_alloc context, freed before returning).
 //
@@ -346,6 +384,13 @@ bool asrDeviceUsableForDecode(ggml_backend_dev_t dev)
     if (ctx == nullptr) {
         return false;
     }
+    // supports_op can throw on a hostile Vulkan stack — that path is caught
+    // (and latched) by the caller, so the context must free on it too, not
+    // only on the straight-line return.
+    struct CtxFree {
+        ggml_context* c;
+        ~CtxFree() { ggml_free(c); }
+    } ctxFree{ctx};
     ggml_tensor* act = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 64, 64);
     ggml_tensor* softMax = ggml_soft_max(ctx, act);
     ggml_tensor* weights = ggml_new_tensor_2d(ctx, GGML_TYPE_F16, 64, 64);
@@ -356,11 +401,9 @@ bool asrDeviceUsableForDecode(ggml_backend_dev_t dev)
     ggml_tensor* v = ggml_new_tensor_3d(ctx, GGML_TYPE_F16, 64, 4, 8);
     ggml_tensor* flashAttn =
         ggml_flash_attn_ext(ctx, q, k, v, nullptr, 1.0f, 0.0f, 0.0f);
-    const bool usable = ggml_backend_dev_supports_op(dev, softMax)
+    return ggml_backend_dev_supports_op(dev, softMax)
         && ggml_backend_dev_supports_op(dev, mulMat)
         && ggml_backend_dev_supports_op(dev, flashAttn);
-    ggml_free(ctx);
-    return usable;
 }
 
 } // namespace

--- a/src/asr/WhisperAsrBackend.cpp
+++ b/src/asr/WhisperAsrBackend.cpp
@@ -5,6 +5,7 @@
 #include <QThread>
 
 #include <algorithm>
+#include <exception>
 
 #include <ggml-backend.h>
 #include <whisper.h>
@@ -83,6 +84,33 @@ bool asrMetalUsableHost()
     return true;
 #endif
 }
+
+// whisper_init_from_file_with_params() reaches real GPU device and context
+// creation inside ggml (Vulkan on Linux/Windows, Metal on Apple Silicon). A
+// broken driver stack there surfaces as a thrown exception — e.g. vulkan-hpp's
+// vk::SystemError escaping ggml_vk_instance_init()/ggml_vk_get_device(), which
+// unlike ggml_backend_vk_reg() have no internal guard. Unguarded, that
+// exception unwinds out of the ASR worker's slot and terminates the whole app
+// (#4502). Catch it and report through the backend's error path, mirroring the
+// ONNX backends (SileroVad/SpeakerEmbedder). ggml's GGML_ABORT paths call
+// abort() and cannot be caught; this covers the throwing half only.
+whisper_context* initWhisperContext(const QByteArray& pathUtf8,
+                                    const whisper_context_params& cparams,
+                                    QString* failure)
+{
+    try {
+        return whisper_init_from_file_with_params(pathUtf8.constData(), cparams);
+    } catch (const std::exception& e) {
+        if (failure != nullptr) {
+            *failure = QString::fromUtf8(e.what());
+        }
+    } catch (...) {
+        if (failure != nullptr) {
+            *failure = QStringLiteral("unknown exception");
+        }
+    }
+    return nullptr;
+}
 } // namespace
 
 WhisperAsrBackend::WhisperAsrBackend()
@@ -122,10 +150,25 @@ bool WhisperAsrBackend::load(const QString& modelPath, QString* error)
     cparams.gpu_device = useGpu ? m_gpuDevice : 0;
 
     const QByteArray pathUtf8 = modelPath.toUtf8();
-    m_ctx = whisper_init_from_file_with_params(pathUtf8.constData(), cparams);
+    QString failure;
+    m_ctx = initWhisperContext(pathUtf8, cparams, &failure);
+    if (m_ctx == nullptr && useGpu) {
+        // A GPU that enumerates can still be unusable at load time, and
+        // ggml-vulkan's instance state is sticky per process — a second GPU
+        // attempt re-enters the half-built state (the fail-then-crash pattern
+        // of #4502). Retry once on CPU, which never touches the GPU backend.
+        qCWarning(lcAsrWhisper) << "GPU model load failed"
+                                << (failure.isEmpty() ? QStringLiteral("(null context)") : failure)
+                                << "- retrying on CPU";
+        cparams.use_gpu = false;
+        cparams.gpu_device = 0;
+        m_ctx = initWhisperContext(pathUtf8, cparams, &failure);
+    }
     if (m_ctx == nullptr) {
         if (error != nullptr) {
-            *error = QStringLiteral("whisper failed to load model: %1").arg(modelPath);
+            *error = failure.isEmpty()
+                ? QStringLiteral("whisper failed to load model: %1").arg(modelPath)
+                : QStringLiteral("whisper failed to load model: %1 (%2)").arg(modelPath, failure);
         }
         return false;
     }
@@ -169,7 +212,23 @@ AsrTranscript WhisperAsrBackend::transcribe(const std::vector<float>& pcm16k, QS
     wparams.language = autoDetect ? "auto" : langUtf8.constData();
     wparams.detect_language = false;
 
-    if (whisper_full(m_ctx, wparams, pcm16k.data(), static_cast<int>(pcm16k.size())) != 0) {
+    // Same guard as the load path: inference reaches the GPU backend too, and
+    // an exception escaping the worker thread would terminate the app.
+    int status = -1;
+    try {
+        status = whisper_full(m_ctx, wparams, pcm16k.data(), static_cast<int>(pcm16k.size()));
+    } catch (const std::exception& e) {
+        if (error != nullptr) {
+            *error = QStringLiteral("whisper_full() failed: %1").arg(QString::fromUtf8(e.what()));
+        }
+        return {};
+    } catch (...) {
+        if (error != nullptr) {
+            *error = QStringLiteral("whisper_full() failed: unknown exception");
+        }
+        return {};
+    }
+    if (status != 0) {
         if (error != nullptr) {
             *error = QStringLiteral("whisper_full() failed");
         }
@@ -230,17 +289,33 @@ std::vector<AsrGpuDevice> asrGpuDevices()
 
     // Enumerate GPU + integrated-GPU devices in the same order whisper's
     // gpu_device indexes them (see whisper_backend_init_gpu).
+    //
+    // The first call in the process constructs ggml's backend registry, and
+    // the Vulkan per-device queries sit beyond ggml_backend_vk_reg()'s
+    // internal guard — on a hostile driver stack they throw (#4509 analysis),
+    // which from here would terminate the process. Degrade to "no devices"
+    // (CPU-only) instead; a partial enumeration is discarded rather than
+    // returned, so an index never points at a device other than the one
+    // whisper would pick.
     std::vector<AsrGpuDevice> devices;
-    int index = 0;
-    for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
-        ggml_backend_dev_t dev = ggml_backend_dev_get(i);
-        const auto type = ggml_backend_dev_type(dev);
-        if (type == GGML_BACKEND_DEVICE_TYPE_GPU || type == GGML_BACKEND_DEVICE_TYPE_IGPU) {
-            AsrGpuDevice d;
-            d.index = index++;
-            d.name = QString::fromUtf8(ggml_backend_dev_description(dev));
-            devices.push_back(std::move(d));
+    try {
+        int index = 0;
+        for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
+            ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+            const auto type = ggml_backend_dev_type(dev);
+            if (type == GGML_BACKEND_DEVICE_TYPE_GPU || type == GGML_BACKEND_DEVICE_TYPE_IGPU) {
+                AsrGpuDevice d;
+                d.index = index++;
+                d.name = QString::fromUtf8(ggml_backend_dev_description(dev));
+                devices.push_back(std::move(d));
+            }
         }
+    } catch (const std::exception& e) {
+        qCWarning(lcAsrWhisper) << "GPU device enumeration failed:" << e.what();
+        devices.clear();
+    } catch (...) {
+        qCWarning(lcAsrWhisper) << "GPU device enumeration failed: unknown exception";
+        devices.clear();
     }
     return devices;
 }

--- a/src/asr/WhisperAsrBackend.h
+++ b/src/asr/WhisperAsrBackend.h
@@ -37,9 +37,12 @@ private:
 
 // A selectable GPU: `index` is the value to pass as gpuDevice (its position among
 // GPU/IGPU devices in ggml's enumeration order); `name` is a human description.
+// `usable` is the session verdict: false when the device failed the decode
+// capability probe, or when a model load on it failed earlier this run.
 struct AsrGpuDevice {
     int index = 0;
     QString name;
+    bool usable = true;
 };
 
 // Factory for wiring AsrEngine to the production whisper backend. Kept here so
@@ -55,6 +58,17 @@ bool asrGpuAvailable();
 // All selectable GPU devices (discrete + integrated), in the order whisper's
 // gpu_device indexes them. Empty on CPU-only builds / GPU-less hosts.
 std::vector<AsrGpuDevice> asrGpuDevices();
+
+// The device index to default to: the first usable device, or -1 (CPU) when none
+// is. An unusable device stays selectable — it is simply never chosen for you.
+int asrResolveDefaultGpuIndex(const std::vector<AsrGpuDevice>& devices);
+
+// Session failure latch. A GPU whose model load failed once must never be tried
+// again in this process: ggml's Vulkan instance state is sticky, so the first
+// failure is survivable but a second attempt on the poisoned state can fault
+// somewhere no caller can catch. Marking is one-way and lives until restart.
+void asrMarkGpuDeviceFailed(int index);
+bool asrGpuDeviceFailed(int index);
 
 // A selectable transcription language: `code` is the ISO code passed to the
 // backend (e.g. "en", "es"); `name` is the English display name ("English").

--- a/src/asr/WhisperAsrBackend.h
+++ b/src/asr/WhisperAsrBackend.h
@@ -33,6 +33,10 @@ private:
     QString m_language;
     int m_threads = 0;
     int m_gpuDevice = 0;
+    // Whether m_ctx was created on the GPU. False after the CPU retry in
+    // load(), so a decode-time throw never latches a device that was not
+    // involved.
+    bool m_ctxOnGpu = false;
 };
 
 // A selectable GPU: `index` is the value to pass as gpuDevice (its position among

--- a/src/asr/WhisperAsrBackend.h
+++ b/src/asr/WhisperAsrBackend.h
@@ -74,6 +74,44 @@ int asrResolveDefaultGpuIndex(const std::vector<AsrGpuDevice>& devices);
 void asrMarkGpuDeviceFailed(int index);
 bool asrGpuDeviceFailed(int index);
 
+// After compute-device resolution, which model tier should be running. The
+// GPU-default tier is heavy enough that it only makes sense on a usable GPU:
+//  - raise to it only while the GPU default is wanted (no explicit operator
+//    model choice yet) AND resolution landed on a usable GPU;
+//  - walk it back to the base default when it is selected only because an
+//    earlier resolution auto-raised it (`gpuDefaultActive`) and resolution has
+//    since fallen off the GPU — the heaviest model cannot keep up on CPU,
+//    which is the "backlog climbing, no text" shape of #4502;
+//  - never touch a tier the operator picked explicitly.
+// Returns the tier to run plus the updated auto-raise state. Header-inline and
+// whisper-free for the same reason as asrLanguageOrDefault below: unit
+// testable without linking the vendored library.
+struct AsrTierResolution {
+    QString tierId;
+    bool gpuDefaultActive = false;
+};
+
+inline AsrTierResolution asrReconcileDefaultTier(const QString& currentTier,
+                                                 bool wantGpuDefault,
+                                                 bool gpuDefaultActive,
+                                                 bool resolvedGpuUsable,
+                                                 const QString& gpuDefaultTier,
+                                                 const QString& baseDefaultTier)
+{
+    if (resolvedGpuUsable) {
+        if (wantGpuDefault) {
+            return {gpuDefaultTier, true};
+        }
+        return {currentTier, gpuDefaultActive};
+    }
+    if (gpuDefaultActive && currentTier == gpuDefaultTier) {
+        return {baseDefaultTier, false};
+    }
+    // Off the GPU the auto-raise state is meaningless — drop it so a stale
+    // flag can never walk back a tier the operator has since chosen.
+    return {currentTier, false};
+}
+
 // A selectable transcription language: `code` is the ISO code passed to the
 // backend (e.g. "en", "es"); `name` is the English display name ("English").
 struct AsrLanguage {

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -155,7 +155,8 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     const QString savedGpu =
         CopyAssistSettings::value(QStringLiteral("AsrGpuDevice"), QString()).toString();
     if (!savedGpu.isEmpty()) {
-        m_gpuDevice = savedGpu.toInt(); // an explicit compute-device choice always wins
+        m_gpuDevice = savedGpu.toInt(); // an explicit compute-device choice wins, unless it is known bad
+        m_gpuDeviceExplicit = true;
     }
     m_settings->setCurrentTier(m_tierId);
 
@@ -229,6 +230,7 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
             return;
         }
         m_gpuDevice = index;
+        m_gpuDeviceExplicit = true;
         saveInt("AsrGpuDevice", index);
         if (m_backend != AsrBackendKind::Remote) {
             m_tap->setEnabled(false);
@@ -462,11 +464,42 @@ void CopyAssistController::startGpuDiscovery()
     });
 }
 
+void CopyAssistController::reconcileAfterGpuFallback()
+{
+    // The backend already retried on CPU and is running; this only brings the
+    // UI and the stored resolution in line with what actually happened, so the
+    // next load does not aim at the failed device again.
+    const int failedDevice = m_gpuDevice;
+    for (AsrGpuDevice& d : m_gpuDevices) {
+        if (d.index == failedDevice) {
+            d.usable = false;
+        }
+    }
+    const QString failedName = [&] {
+        for (const AsrGpuDevice& d : m_gpuDevices) {
+            if (d.index == failedDevice) {
+                return d.name;
+            }
+        }
+        return tr("The selected GPU");
+    }();
+
+    // A device known bad must be overridden even when explicitly chosen.
+    m_gpuDeviceExplicit = false;
+    applyGpuDevices(m_gpuDevices);
+
+    const bool onCpu = m_gpuDevice < 0;
+    m_panel->setStatus(onCpu
+        ? tr("%1 is unavailable — running on CPU. Transcription will be slower.")
+              .arg(failedName)
+        : tr("%1 is unavailable — switched to another GPU.").arg(failedName));
+}
+
 void CopyAssistController::applyGpuDevices(const std::vector<AsrGpuDevice>& gpus)
 {
+    m_gpuDevices = gpus;
     const int previousDevice = m_gpuDevice;
     int resolvedDevice = previousDevice;
-    bool persistResolvedDevice = false;
 
     // Adding or clearing combo items changes its current index. Suppress the
     // dialog's outward gpuChanged/tierChanged signals while discovery state is
@@ -478,23 +511,52 @@ void CopyAssistController::applyGpuDevices(const std::vector<AsrGpuDevice>& gpus
 
         if (!gpus.empty()) {
             for (const AsrGpuDevice& gpu : gpus) {
-                m_settings->addGpuDevice(gpu.index, gpu.name);
+                // An unusable device stays selectable for diagnostics, but the
+                // combo says why it is not the default — whether it failed the
+                // capability probe or a load attempt this session.
+                m_settings->addGpuDevice(gpu.index,
+                                         gpu.usable ? gpu.name
+                                                    : tr("%1 (unavailable)").arg(gpu.name));
             }
             m_settings->addGpuDevice(-1, tr("CPU")); // explicit force-CPU option
 
-            if (resolvedDevice != -1
-                && (resolvedDevice < 0
-                    || resolvedDevice >= static_cast<int>(gpus.size()))) {
-                resolvedDevice = 0;
-                persistResolvedDevice = true;
+            const bool outOfRange = resolvedDevice != -1
+                && (resolvedDevice < 0 || resolvedDevice >= static_cast<int>(gpus.size()));
+            const bool resolvedUnusable = [&] {
+                for (const AsrGpuDevice& g : gpus) {
+                    if (g.index == resolvedDevice) {
+                        return !g.usable;
+                    }
+                }
+                return false;
+            }();
+            // Fall back to the first usable device (else CPU) when the choice
+            // was never explicit, has gone out of range, or names a device that
+            // cannot run the decode. A device the operator picked explicitly is
+            // still overridden once it is known-bad — leaving it selected would
+            // re-enter the failure on the next load.
+            // Not persisted: an unusable device can become usable again after a
+            // driver fix or reboot, and writing a computed value over the saved
+            // preference would pin that computation permanently.
+            if (!m_gpuDeviceExplicit || outOfRange || resolvedUnusable) {
+                resolvedDevice = asrResolveDefaultGpuIndex(gpus);
             }
             m_settings->setCurrentGpu(resolvedDevice);
             m_settings->setGpuSelectorVisible(true);
             m_settings->setGpuSelectorEnabled(true);
 
-            // Preserve the existing GPU-host default, but only while the
-            // operator has not made an explicit model choice during the probe.
-            if (m_useGpuDefaultIfAvailable) {
+            // Preserve the GPU-host default tier, but only while the operator
+            // has not made an explicit model choice, and only when the decode
+            // will actually run on a usable GPU — a CPU resolution must not
+            // select the heaviest model, which cannot keep up off a GPU.
+            const AsrGpuDevice* resolved = nullptr;
+            for (const AsrGpuDevice& g : gpus) {
+                if (g.index == resolvedDevice) {
+                    resolved = &g;
+                    break;
+                }
+            }
+            if (m_useGpuDefaultIfAvailable && resolved != nullptr && resolved->usable) {
                 m_tierId = QStringLiteral("large-v3-turbo");
                 m_settings->setCurrentTier(m_tierId);
             }
@@ -510,9 +572,6 @@ void CopyAssistController::applyGpuDevices(const std::vector<AsrGpuDevice>& gpus
     }
 
     m_gpuDevice = resolvedDevice;
-    if (persistResolvedDevice) {
-        saveInt("AsrGpuDevice", resolvedDevice);
-    }
     if (resolvedDevice != previousDevice && m_backend == AsrBackendKind::Whisper) {
         m_tap->setEnabled(false);
         buildEngine();
@@ -575,6 +634,15 @@ void CopyAssistController::buildEngine()
             m_panel->setStatus(m_backend == AsrBackendKind::Remote ? tr("Listening (remote)…")
                                                                    : tr("Listening…"));
             writeFreqMarkerIfNeeded(); // "on start": head the log with the frequency
+        }
+        // The model loaded, but the backend may have got there by falling back
+        // to CPU after the chosen GPU failed. The latch is the only signal —
+        // a successful fallback still reports ready() — so ask it, then make
+        // the selectors tell the truth instead of naming a device that is not
+        // running the decode (#4502).
+        if (m_backend == AsrBackendKind::Whisper && m_gpuDevice >= 0
+            && asrGpuDeviceFailed(m_gpuDevice)) {
+            reconcileAfterGpuFallback();
         }
     });
     connect(m_asr, &AsrEngine::loadFailed, this, [this](const QString& err) {

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -499,15 +499,28 @@ void CopyAssistController::reconcileAfterGpuFallback()
     applyGpuDevices(m_gpuDevices);
 
     const bool onCpu = m_gpuDevice < 0;
-    m_panel->setStatus(onCpu
+    const QString notice = onCpu
         ? tr("%1 is unavailable — running on CPU. Transcription will be slower.")
               .arg(failedName)
-        : tr("%1 is unavailable — switched to another GPU.").arg(failedName));
+        : tr("%1 is unavailable — switched to another GPU.").arg(failedName);
+
+    // applyGpuDevices() moved the resolution off the latched device, which
+    // rebuilt the engine — model-less, tap off. Left there, the panel looks
+    // live while the pipeline decodes nothing until the operator toggles
+    // Enable. Reload so the fallback ends in a running engine; the notice is
+    // parked for the rebuilt engine's ready() handler, which would otherwise
+    // overwrite it with "Listening…" the moment the reload lands.
+    if (m_enabled && m_backend == AsrBackendKind::Whisper) {
+        m_gpuFallbackNotice = notice;
+        beginEnable();
+    } else {
+        m_panel->setStatus(notice);
+    }
 }
 
-void CopyAssistController::applyGpuDevices(const std::vector<AsrGpuDevice>& gpus)
+void CopyAssistController::applyGpuDevices(std::vector<AsrGpuDevice> gpus)
 {
-    m_gpuDevices = gpus;
+    m_gpuDevices = std::move(gpus);
     const int previousDevice = m_gpuDevice;
     int resolvedDevice = previousDevice;
 
@@ -519,8 +532,8 @@ void CopyAssistController::applyGpuDevices(const std::vector<AsrGpuDevice>& gpus
         const QSignalBlocker blocker(m_settings);
         m_settings->clearGpuDevices();
 
-        if (!gpus.empty()) {
-            for (const AsrGpuDevice& gpu : gpus) {
+        if (!m_gpuDevices.empty()) {
+            for (const AsrGpuDevice& gpu : m_gpuDevices) {
                 // An unusable device stays selectable for diagnostics, but the
                 // combo says why it is not the default — whether it failed the
                 // capability probe or a load attempt this session.
@@ -531,9 +544,9 @@ void CopyAssistController::applyGpuDevices(const std::vector<AsrGpuDevice>& gpus
             m_settings->addGpuDevice(-1, tr("CPU")); // explicit force-CPU option
 
             const bool outOfRange = resolvedDevice != -1
-                && (resolvedDevice < 0 || resolvedDevice >= static_cast<int>(gpus.size()));
+                && (resolvedDevice < 0 || resolvedDevice >= static_cast<int>(m_gpuDevices.size()));
             const bool resolvedUnusable = [&] {
-                for (const AsrGpuDevice& g : gpus) {
+                for (const AsrGpuDevice& g : m_gpuDevices) {
                     if (g.index == resolvedDevice) {
                         return !g.usable;
                     }
@@ -549,27 +562,11 @@ void CopyAssistController::applyGpuDevices(const std::vector<AsrGpuDevice>& gpus
             // driver fix or reboot, and writing a computed value over the saved
             // preference would pin that computation permanently.
             if (!m_gpuDeviceExplicit || outOfRange || resolvedUnusable) {
-                resolvedDevice = asrResolveDefaultGpuIndex(gpus);
+                resolvedDevice = asrResolveDefaultGpuIndex(m_gpuDevices);
             }
             m_settings->setCurrentGpu(resolvedDevice);
             m_settings->setGpuSelectorVisible(true);
             m_settings->setGpuSelectorEnabled(true);
-
-            // Preserve the GPU-host default tier, but only while the operator
-            // has not made an explicit model choice, and only when the decode
-            // will actually run on a usable GPU — a CPU resolution must not
-            // select the heaviest model, which cannot keep up off a GPU.
-            const AsrGpuDevice* resolved = nullptr;
-            for (const AsrGpuDevice& g : gpus) {
-                if (g.index == resolvedDevice) {
-                    resolved = &g;
-                    break;
-                }
-            }
-            if (m_useGpuDefaultIfAvailable && resolved != nullptr && resolved->usable) {
-                m_tierId = QStringLiteral("large-v3-turbo");
-                m_settings->setCurrentTier(m_tierId);
-            }
         } else {
             // A failed, timed-out, or CPU-only probe must not trigger the same
             // registry initialization again from Whisper's worker. Force CPU
@@ -578,6 +575,32 @@ void CopyAssistController::applyGpuDevices(const std::vector<AsrGpuDevice>& gpus
             resolvedDevice = -1;
             m_settings->setGpuSelectorEnabled(false);
             m_settings->setGpuSelectorVisible(false);
+        }
+
+        // Tier follows the device resolution (asrReconcileDefaultTier): the
+        // GPU-host default is preserved only while the operator has not made
+        // an explicit model choice AND the decode will actually run on a
+        // usable GPU — and an earlier auto-raise is walked back to the base
+        // default the moment resolution falls off the GPU. Without the
+        // walk-back, the load-time fallback arm kept large-v3-turbo running
+        // on CPU: the "backlog climbing, no text" symptom this PR opens with
+        // (#4767 review). An explicitly chosen tier is never changed.
+        const bool resolvedGpuUsable = resolvedDevice >= 0 && [&] {
+            for (const AsrGpuDevice& g : m_gpuDevices) {
+                if (g.index == resolvedDevice) {
+                    return g.usable;
+                }
+            }
+            return false;
+        }();
+        const AsrTierResolution tier = asrReconcileDefaultTier(
+            m_tierId, m_useGpuDefaultIfAvailable, m_gpuDefaultTierActive,
+            resolvedGpuUsable, QStringLiteral("large-v3-turbo"),
+            AsrModelCatalog::defaultTierId());
+        m_gpuDefaultTierActive = tier.gpuDefaultActive;
+        if (tier.tierId != m_tierId) {
+            m_tierId = tier.tierId;
+            m_settings->setCurrentTier(m_tierId);
         }
     }
 
@@ -641,8 +664,17 @@ void CopyAssistController::buildEngine()
         m_panel->setBusy(false);
         if (m_enabled) {
             m_tap->setEnabled(true);
-            m_panel->setStatus(m_backend == AsrBackendKind::Remote ? tr("Listening (remote)…")
-                                                                   : tr("Listening…"));
+            if (!m_gpuFallbackNotice.isEmpty()) {
+                // This ready() is the reload after a GPU fallback: keep the
+                // explanation on screen instead of a bare "Listening…", so
+                // the operator learns why the decode moved (and why it may
+                // now be slower) rather than seeing business as usual.
+                m_panel->setStatus(m_gpuFallbackNotice);
+                m_gpuFallbackNotice.clear();
+            } else {
+                m_panel->setStatus(m_backend == AsrBackendKind::Remote ? tr("Listening (remote)…")
+                                                                       : tr("Listening…"));
+            }
             writeFreqMarkerIfNeeded(); // "on start": head the log with the frequency
         }
         // The model loaded, but the backend may have got there by falling back
@@ -663,6 +695,7 @@ void CopyAssistController::buildEngine()
     });
     connect(m_asr, &AsrEngine::loadFailed, this, [this](const QString& err) {
         m_panel->setBusy(false);
+        m_gpuFallbackNotice.clear(); // failed reload: this message wins instead
         m_panel->setStatus(tr("Model load failed: %1").arg(err));
         m_panel->setAsrEnabled(false);
     });
@@ -711,6 +744,7 @@ void CopyAssistController::onEnableToggled(bool on)
         requestEnable();
     } else {
         m_enableAfterGpuDiscovery = false;
+        m_gpuFallbackNotice.clear(); // a pending fallback reload no longer matters
         m_tap->setEnabled(false);
         m_panel->setBusy(false);
         m_panel->setStatus(tr("Disabled"));
@@ -723,6 +757,9 @@ void CopyAssistController::onTierChanged(const QString& tierId)
         return;
     }
     m_useGpuDefaultIfAvailable = false;
+    // An explicit choice, even of the GPU-default tier itself, must never be
+    // walked back by a later fallback.
+    m_gpuDefaultTierActive = false;
     m_enableAfterGpuDiscovery = false;
 
     if (tierId == QString::fromLatin1(kRemoteTierId)) {

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -466,6 +466,13 @@ void CopyAssistController::startGpuDiscovery()
 
 void CopyAssistController::reconcileAfterGpuFallback()
 {
+    // Reached from the event loop, so re-check the condition the caller saw:
+    // between queueing and running, the operator may have picked another device
+    // or an earlier fallback may already have reconciled this one.
+    if (m_gpuDevice < 0 || !asrGpuDeviceFailed(m_gpuDevice)) {
+        return;
+    }
+
     // The backend already retried on CPU and is running; this only brings the
     // UI and the stored resolution in line with what actually happened, so the
     // next load does not aim at the failed device again.
@@ -640,9 +647,15 @@ void CopyAssistController::buildEngine()
         // a successful fallback still reports ready() — so ask it, then make
         // the selectors tell the truth instead of naming a device that is not
         // running the decode (#4502).
+        //
+        // Queued, not direct: reconciling can change the resolved device, and
+        // that rebuilds the engine — which deletes the AsrEngine whose ready()
+        // emission this lambda is running inside. Deferring to the event loop
+        // lets that emission unwind before its sender is destroyed.
         if (m_backend == AsrBackendKind::Whisper && m_gpuDevice >= 0
             && asrGpuDeviceFailed(m_gpuDevice)) {
-            reconcileAfterGpuFallback();
+            QMetaObject::invokeMethod(
+                this, [this] { reconcileAfterGpuFallback(); }, Qt::QueuedConnection);
         }
     });
     connect(m_asr, &AsrEngine::loadFailed, this, [this](const QString& err) {

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -473,9 +473,12 @@ void CopyAssistController::reconcileAfterGpuFallback()
         return;
     }
 
-    // The backend already retried on CPU and is running; this only brings the
-    // UI and the stored resolution in line with what actually happened, so the
-    // next load does not aim at the failed device again.
+    // Reached queued from either signal: after a load-time fallback (the
+    // backend already retried on CPU and is running) or after a decode-time
+    // failure (the engine is still aimed at the latched device). Relabel the
+    // device and move the resolution off it — applyGpuDevices() rebuilds the
+    // engine when that changes the resolved device, which is what actually
+    // retires a decode-poisoned engine — then say so in the panel.
     const int failedDevice = m_gpuDevice;
     for (AsrGpuDevice& d : m_gpuDevices) {
         if (d.index == failedDevice) {
@@ -673,7 +676,20 @@ void CopyAssistController::buildEngine()
                 m_panel->appendText(labeled, confidence);
                 appendToLogFile(labeled);
             });
-    connect(m_asr, &AsrEngine::error, this, [this](const QString& err) { m_panel->setStatus(err); });
+    connect(m_asr, &AsrEngine::error, this, [this](const QString& err) {
+        m_panel->setStatus(err);
+        // A decode-time GPU failure latches the device in
+        // WhisperAsrBackend::transcribe(); the engine itself is still aimed at
+        // it and would throw again on every utterance. Reconcile off the error
+        // signal exactly as the ready() path does — queued, because the
+        // reconcile rebuilds the engine this handler's sender belongs to. The
+        // entry guard in reconcileAfterGpuFallback() makes repeats harmless.
+        if (m_backend == AsrBackendKind::Whisper && m_gpuDevice >= 0
+            && asrGpuDeviceFailed(m_gpuDevice)) {
+            QMetaObject::invokeMethod(
+                this, [this] { reconcileAfterGpuFallback(); }, Qt::QueuedConnection);
+        }
+    });
     connect(m_asr, &AsrEngine::backlogChanged, m_panel, &CopyAssistPanel::setBacklog);
 
     applyTuning();

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -365,6 +365,7 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     });
     connect(m_models, &AsrModelManager::failed, this, [this](const QString& err) {
         m_panel->setBusy(false);
+        m_gpuFallbackNotice.clear(); // the fallback reload never got a model
         m_panel->setStatus(tr("Model download failed: %1").arg(err));
         m_panel->setAsrEnabled(false);
     });
@@ -466,10 +467,14 @@ void CopyAssistController::startGpuDiscovery()
 
 void CopyAssistController::reconcileAfterGpuFallback()
 {
-    // Reached from the event loop, so re-check the condition the caller saw:
-    // between queueing and running, the operator may have picked another device
-    // or an earlier fallback may already have reconciled this one.
-    if (m_gpuDevice < 0 || !asrGpuDeviceFailed(m_gpuDevice)) {
+    // Reached from the event loop, so re-check every condition the caller saw:
+    // between queueing and running, the operator may have picked another device,
+    // switched to a backend that has no GPU of its own (remote/sherpa), or an
+    // earlier fallback may already have reconciled this one. Without the backend
+    // check a stale queued reconcile would stamp a GPU notice over the status of
+    // a backend the GPU has nothing to do with.
+    if (m_backend != AsrBackendKind::Whisper || m_gpuDevice < 0
+        || !asrGpuDeviceFailed(m_gpuDevice)) {
         return;
     }
 
@@ -757,9 +762,6 @@ void CopyAssistController::onTierChanged(const QString& tierId)
         return;
     }
     m_useGpuDefaultIfAvailable = false;
-    // An explicit choice, even of the GPU-default tier itself, must never be
-    // walked back by a later fallback.
-    m_gpuDefaultTierActive = false;
     m_enableAfterGpuDiscovery = false;
 
     if (tierId == QString::fromLatin1(kRemoteTierId)) {
@@ -826,6 +828,14 @@ void CopyAssistController::setBackend(AsrBackendKind kind, const QString& tierId
     const AsrBackendKind prev = m_backend;
     m_backend = kind;
     m_tierId = tierId;
+    // The tier is now an explicit operator choice — even if it is the GPU-default
+    // tier itself — so a later fallback must never walk it back. Cleared here
+    // rather than at the top of onTierChanged() because the three prompting
+    // branches (remote / custom / sherpa) can still be cancelled, and a cancel
+    // leaves the auto-raised tier in place: clearing the flag early would strand
+    // Large v3 Turbo on CPU after a fallback, the exact regression the flag exists
+    // to prevent. setBackend() is reached only once the change is committed.
+    m_gpuDefaultTierActive = false;
 
     // Language applies to whisper/remote only; sherpa-onnx picks it from the
     // model. Keep the selector's visibility in sync with the active backend.
@@ -876,6 +886,7 @@ void CopyAssistController::beginEnable()
         // catalog download + SHA verification (we don't know its checksum).
         if (m_customModelPath.isEmpty() || !QFileInfo::exists(m_customModelPath)) {
             m_panel->setBusy(false);
+            m_gpuFallbackNotice.clear(); // no reload will arrive to show it
             m_panel->setStatus(tr("Custom model file not found — pick it again."));
             m_panel->setAsrEnabled(false);
             return;
@@ -887,6 +898,7 @@ void CopyAssistController::beginEnable()
         // discovers the bundle's files). No download/verify.
         if (m_sherpaModelDir.isEmpty() || !QDir(m_sherpaModelDir).exists()) {
             m_panel->setBusy(false);
+            m_gpuFallbackNotice.clear(); // no reload will arrive to show it
             m_panel->setStatus(tr("sherpa-onnx model folder not found — pick it again."));
             m_panel->setAsrEnabled(false);
             return;

--- a/src/gui/CopyAssistController.h
+++ b/src/gui/CopyAssistController.h
@@ -59,6 +59,10 @@ private slots:
 private:
     void startGpuDiscovery();
     void applyGpuDevices(const std::vector<AsrGpuDevice>& gpus);
+    // Reconcile the selectors after a GPU model load failed and the backend
+    // silently continued on CPU: relabel the device, move the selection off it,
+    // drop a GPU-only tier, and say so in the panel status.
+    void reconcileAfterGpuFallback();
     void buildEngine();  // (re)create the engine+tap for the current backend
     void applyTuning();  // push saved VAD tuning into the engine
     void requestEnable(); // defer local Whisper until async GPU discovery finishes
@@ -99,7 +103,11 @@ private:
     bool m_useGpuDefaultIfAvailable = false; // cleared by any explicit tier choice
     bool m_gpuDiscoveryPending = true;
     bool m_enableAfterGpuDiscovery = false;
+    bool m_gpuDeviceExplicit = false; // the operator picked this device themselves
     int m_gpuDevice = 0; // resolved default or explicit setting; -1 forces CPU
+    // Last device list from discovery, kept so a runtime GPU failure can be
+    // reconciled into the selectors without re-running (and re-probing) it.
+    std::vector<AsrGpuDevice> m_gpuDevices;
     QString m_tierId;
     QString m_customModelPath; // user-picked local model (for the "Custom model…" tier)
     QString m_sherpaModelDir;  // user-picked sherpa-onnx model directory

--- a/src/gui/CopyAssistController.h
+++ b/src/gui/CopyAssistController.h
@@ -58,10 +58,13 @@ private slots:
 
 private:
     void startGpuDiscovery();
-    void applyGpuDevices(const std::vector<AsrGpuDevice>& gpus);
-    // Reconcile the selectors after a GPU model load failed and the backend
-    // silently continued on CPU: relabel the device, move the selection off it,
-    // drop a GPU-only tier, and say so in the panel status.
+    // By value: reconcileAfterGpuFallback() passes m_gpuDevices back in, and
+    // the first thing this function does is reassign that member — a
+    // reference parameter would alias it.
+    void applyGpuDevices(std::vector<AsrGpuDevice> gpus);
+    // Reconcile after a GPU failed and was latched: relabel the device, move
+    // the resolution off it, walk back an auto-raised GPU-only tier, reload
+    // the model into the rebuilt engine, and say so in the panel status.
     void reconcileAfterGpuFallback();
     void buildEngine();  // (re)create the engine+tap for the current backend
     void applyTuning();  // push saved VAD tuning into the engine
@@ -101,6 +104,16 @@ private:
     AsrAudioTap* m_tap = nullptr;
     bool m_constructed = false; // true after the initial buildEngine (guards restore)
     bool m_useGpuDefaultIfAvailable = false; // cleared by any explicit tier choice
+    // True while m_tierId is the GPU-default tier because device resolution
+    // auto-raised it (not an operator choice). What licenses the walk-back to
+    // the base tier when resolution later falls off the GPU: by then
+    // m_useGpuDefaultIfAvailable is already consumed, so it alone cannot tell
+    // an auto-raised Turbo from an explicitly chosen one.
+    bool m_gpuDefaultTierActive = false;
+    // Fallback explanation parked for the rebuilt engine's ready() handler —
+    // set when reconcileAfterGpuFallback() reloads the model, so the reload's
+    // "Listening…" does not overwrite the reason the decode moved.
+    QString m_gpuFallbackNotice;
     bool m_gpuDiscoveryPending = true;
     bool m_enableAfterGpuDiscovery = false;
     bool m_gpuDeviceExplicit = false; // the operator picked this device themselves

--- a/tests/asr_gpu_probe_test.cpp
+++ b/tests/asr_gpu_probe_test.cpp
@@ -146,6 +146,62 @@ int main()
         std::printf("[ok] #4502 session failure latch (one-way, idempotent, CPU exempt)\n");
     }
 
+    // GPU-default tier reconciliation: raising to the GPU default must require
+    // a usable GPU, and an AUTO-raised GPU default must walk back to the base
+    // default when resolution falls off the GPU — running the heaviest tier
+    // on CPU is the "backlog climbing, no text" symptom the load-time
+    // fallback arm produced (#4767 review; the drill that verified the PR ran
+    // the probe-throw arm, where the tier was never raised, so only a pinned
+    // contract catches this). An explicit operator choice is never touched.
+    {
+        const QString turbo = QStringLiteral("large-v3-turbo");
+        const QString base = QStringLiteral("base.en");
+        const QString small = QStringLiteral("small.en");
+
+        // Startup on a usable GPU: raise, and remember it was automatic.
+        AsrTierResolution r = asrReconcileDefaultTier(base, true, false, true, turbo, base);
+        if (r.tierId != turbo || !r.gpuDefaultActive) {
+            std::fprintf(stderr, "[FAIL] usable GPU + default wanted did not raise "
+                                 "to the GPU tier (#4767)\n");
+            return 1;
+        }
+        // Load-time fallback (the want-flag is already consumed by then): an
+        // auto-raised Turbo must walk back once resolution is CPU. This is
+        // the regression the review found — the arm where the raise had
+        // already happened and only the walk-back can undo it.
+        r = asrReconcileDefaultTier(turbo, false, true, false, turbo, base);
+        if (r.tierId != base || r.gpuDefaultActive) {
+            std::fprintf(stderr, "[FAIL] auto-raised GPU tier survived a CPU "
+                                 "resolution - Turbo keeps running on CPU (#4767)\n");
+            return 1;
+        }
+        // Explicitly chosen Turbo (never auto-raised) on CPU: untouched.
+        r = asrReconcileDefaultTier(turbo, false, false, false, turbo, base);
+        if (r.tierId != turbo || r.gpuDefaultActive) {
+            std::fprintf(stderr, "[FAIL] an explicit Turbo choice was walked back "
+                                 "(#4767)\n");
+            return 1;
+        }
+        // Explicit non-default tier while a usable GPU resolves: untouched.
+        r = asrReconcileDefaultTier(small, false, false, true, turbo, base);
+        if (r.tierId != small) {
+            std::fprintf(stderr, "[FAIL] an explicit tier was overridden by the "
+                                 "GPU default (#4767)\n");
+            return 1;
+        }
+        // Auto-raised Turbo re-resolved onto ANOTHER usable GPU: stays raised,
+        // stays automatic (a later CPU fallback must still walk it back).
+        r = asrReconcileDefaultTier(turbo, false, true, true, turbo, base);
+        if (r.tierId != turbo || !r.gpuDefaultActive) {
+            std::fprintf(stderr, "[FAIL] auto-raised GPU tier did not survive a "
+                                 "move to another usable GPU (#4767)\n");
+            return 1;
+        }
+        std::printf("[ok] #4767 GPU-default tier reconciliation "
+                    "(raise gated on usable GPU, auto-raise walks back, "
+                    "explicit choices untouched)\n");
+    }
+
     QElapsedTimer timer;
 
 #ifdef Q_OS_MACOS

--- a/tests/asr_gpu_probe_test.cpp
+++ b/tests/asr_gpu_probe_test.cpp
@@ -36,11 +36,13 @@
 #include <QElapsedTimer>
 #include <QtGlobal>
 
+#include <algorithm>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <string>
 #include <thread>
+#include <vector>
 
 #ifdef Q_OS_MACOS
 #include <sys/sysctl.h>
@@ -83,6 +85,66 @@ int main()
     }).detach();
 
     ggml_log_set(captureGgmlLog, nullptr);
+
+    // ---- #4502 pure contracts -------------------------------------------------
+    // Host-independent, and run before anything touches ggml so a GPU-less or
+    // hostile-driver machine still exercises them.
+    //
+    // Default resolution: the first usable device wins; no usable device means
+    // CPU (-1). Selecting a device that cannot run the decode is the failure
+    // these pin — it yields wrong output at every tier, and on a driver that
+    // cannot create a device at all it is the crash path of #4502.
+    {
+        const std::vector<AsrGpuDevice> noneUsable = {
+            {0, QStringLiteral("dGPU"), false}, {1, QStringLiteral("iGPU"), false}};
+        const std::vector<AsrGpuDevice> secondUsable = {
+            {0, QStringLiteral("dGPU"), false}, {1, QStringLiteral("iGPU"), true}};
+        const std::vector<AsrGpuDevice> bothUsable = {
+            {0, QStringLiteral("dGPU"), true}, {1, QStringLiteral("iGPU"), true}};
+        if (asrResolveDefaultGpuIndex({}) != -1
+            || asrResolveDefaultGpuIndex(noneUsable) != -1
+            || asrResolveDefaultGpuIndex(secondUsable) != 1
+            || asrResolveDefaultGpuIndex(bothUsable) != 0) {
+            std::fprintf(stderr, "[FAIL] asrResolveDefaultGpuIndex contract broken "
+                                 "(empty/none-usable/second-usable/first-usable) "
+                                 "(#4502)\n");
+            return 1;
+        }
+        std::printf("[ok] #4502 default-resolution contract\n");
+    }
+
+    // Session failure latch: one-way, and it must survive being asked twice.
+    // A device latched here is never handed to whisper again this process —
+    // that is what stops the second device-creation attempt, which is the
+    // attempt that faults below any catchable level (#4502).
+    {
+        // A high index no real enumeration reaches, so latching it cannot
+        // change what the hardware cases below are allowed to resolve to.
+        constexpr int kSyntheticDevice = 4502;
+        if (asrGpuDeviceFailed(kSyntheticDevice)) {
+            std::fprintf(stderr, "[FAIL] latch reports a device failed before "
+                                 "anything marked it (#4502)\n");
+            return 1;
+        }
+        asrMarkGpuDeviceFailed(kSyntheticDevice);
+        if (!asrGpuDeviceFailed(kSyntheticDevice)) {
+            std::fprintf(stderr, "[FAIL] latch did not hold after marking (#4502)\n");
+            return 1;
+        }
+        asrMarkGpuDeviceFailed(kSyntheticDevice); // idempotent
+        if (!asrGpuDeviceFailed(kSyntheticDevice)) {
+            std::fprintf(stderr, "[FAIL] latch cleared on a second mark (#4502)\n");
+            return 1;
+        }
+        // CPU (-1) is the fallback target and must never be latched out.
+        asrMarkGpuDeviceFailed(-1);
+        if (asrGpuDeviceFailed(-1)) {
+            std::fprintf(stderr, "[FAIL] CPU was latched out - the fallback target "
+                                 "must always stay available (#4502)\n");
+            return 1;
+        }
+        std::printf("[ok] #4502 session failure latch (one-way, idempotent, CPU exempt)\n");
+    }
 
     QElapsedTimer timer;
 
@@ -143,8 +205,39 @@ int main()
     std::printf("[ok] full GPU probe returned: %zu device(s) in %lld ms\n",
                 devices.size(), static_cast<long long>(probeMs));
     for (const AsrGpuDevice& d : devices) {
-        std::printf("     device %d: %s\n", d.index, qPrintable(d.name));
+        std::printf("     device %d: %s (usable=%s)\n", d.index, qPrintable(d.name),
+                    d.usable ? "true" : "false");
     }
+
+    // #4502 default-selection contract, on the real enumeration this time: the
+    // resolved default is either CPU (-1) or a device that actually passed the
+    // probe. Never a device we already know cannot run the decode.
+    {
+        const int def = asrResolveDefaultGpuIndex(devices);
+        if (def != -1) {
+            const auto it = std::find_if(devices.begin(), devices.end(),
+                                         [def](const AsrGpuDevice& d) { return d.index == def; });
+            if (it == devices.end() || !it->usable) {
+                std::fprintf(stderr, "[FAIL] default resolved to device %d, which is not "
+                                     "a usable enumerated device (#4502)\n", def);
+                return 1;
+            }
+        }
+        std::printf("[ok] #4502 default resolution on this host: %d\n", def);
+    }
+
+    // A device the probe rejected must also be latched, so a later explicit
+    // pick or a restored preference cannot walk back into it. (A probe that
+    // merely reports unusable without throwing does not latch — that device
+    // was created fine — so this only asserts the implication one way.)
+    for (const AsrGpuDevice& d : devices) {
+        if (asrGpuDeviceFailed(d.index) && d.usable) {
+            std::fprintf(stderr, "[FAIL] device %d is latched as failed but still "
+                                 "reported usable (#4502)\n", d.index);
+            return 1;
+        }
+    }
+    std::printf("[ok] #4502 latched devices are never reported usable\n");
 
 #ifdef Q_OS_MACOS
     // Everything below is about the embedded-metallib load path, which only


### PR DESCRIPTION
Refs #4502, #4677

**What is proven vs. what is inferred.** The reporter's logs have not yet arrived, so his
machine's exact failure is unconfirmed. What this PR fixes is a crash class demonstrated
on current `main`: a second GPU attempt after a failed device creation faults
uncatchably, and under fault injection a stock build reproduces the report's two-step
signature exactly — first Enable fails harmlessly, the next attempt kills the process,
and forcing CPU avoids it, the same workaround the reporter confirmed. Whether his
machine hits precisely this class awaits his logs — hence *Refs* rather than *Fixes*.
If it turns out to be something else, this class is still real and still needs fixing.

## What happens today

On a machine whose Vulkan stack enumerates GPUs but cannot create a logical device,
Copy Assist takes the application down — silently, with no dialog and nothing in the app
log. The reported shape is two-step: one attempt fails harmlessly, and the next one kills
the process. That is exactly what the code does, and it reproduces on current `main`.

A second, quieter problem sits behind it: where the app does survive a GPU failure, it
never says so. The compute-device selector goes on naming a GPU that is not running
anything, and the model tier stays on Large v3 Turbo, which cannot keep up off a GPU — so
the backlog grows with no explanation offered. Measured here: 7.6 s → 22.5 s of queue
while the settings dialog still read "Intel(R) Graphics (RPL-S)".

## Root cause

**It is the *second* GPU attempt that kills the process, not the first.**

The first attempt is safe: `whisper_init_from_file_with_params()` wraps
`whisper_model_load()` in its own try/catch (`whisper.cpp:3728-3740`), so a
`vk::SystemError` thrown from `ggml_vk_get_device()` →
`physical_device.createDevice()` (`ggml-vulkan.cpp:6466`) is caught inside whisper and
reported as a null context. The app stays up and the panel says the load failed. That is
the first half of the reported symptom.

What is not safe is trying again. ggml-vulkan's instance state is sticky:
`vk_instance_initialized` (`ggml-vulkan.cpp:2293`) is set at instance creation (`:6887`)
and short-circuits every later init (`:6828`) — including one that got no further than a
failed device creation. A second attempt therefore runs against a half-initialised
instance and **faults through a null dispatch pointer** — `SIGSEGV`, `ip 0x0`, on the ASR
worker thread. Nothing in `try`/`catch` can intercept that, so the only defence is to
never make the second attempt.

Today nothing prevents one. `WhisperAsrBackend::load()` reads the stored device
preference every time, so any of these re-enters the poisoned path: pressing Enable
again, changing the model tier, or simply restarting with the same device saved. This is
also why the crash looks intermittent — the trigger is not the first Enable, it is
whatever comes next.

Two call sites are also genuinely unguarded, and both matter:

- **`asrGpuDevices()`** enumerates and probes devices directly, outside any whisper
  guard — a throw here would terminate the process.
- **`whisper_full()`** has no equivalent internal try/catch (whisper.cpp guards model
  load, `:5385` and `:6721`, but not the inference entry point), so a GPU that fails
  during decode rather than load can still throw into `AsrWorker`'s slot.

## The fix

`src/asr/WhisperAsrBackend.{h,cpp}`, `src/gui/CopyAssistController.{h,cpp}`. UI and
backend only; no protocol, no radio path.

1. **Guards on the three ggml entry points** — `asrGpuDevices()`, `transcribe()` and
   `load()` — mirroring the ONNX backends (`SileroVad::load()`,
   `SpeakerEmbedder::load()`), which have carried this pattern from the start. The first
   two are the ones with no upstream guard behind them; the third is defence in depth,
   since whisper's own handler is an implementation detail we should not depend on.
2. **One-shot CPU retry** on a failed GPU load. The CPU backend never touches the GPU
   stack, so it cannot re-enter the poisoned state — and forcing CPU is the workaround the
   reporter confirmed works on his machine.
3. **A one-way, per-session failure latch** (`asrMarkGpuDeviceFailed()` /
   `asrGpuDeviceFailed()`). A device is latched when a load on it fails, **when the
   capability probe throws** — on the Vulkan backends `ggml_backend_vk_device_supports_op`
   resolves `ggml_vk_get_device` (`ggml-vulkan.cpp:17158`), so a throwing probe *is* a
   failed device creation and everything after it is a second attempt — **and when
   inference on it throws**: a GPU that loads the model fine and then fails mid-decode is
   retired the same way (the engine is rebuilt off it when the error surfaces), so no
   path hands a failed device a repeat attempt. A decode-time throw latches only when the
   context actually lives on the GPU; a CPU-side exception says nothing about the GPU.
   Latched devices are never selected for a load, however they are chosen. A probe that
   merely returns false is **not** latched: that device was created fine and simply
   cannot run the decode, so it stays selectable for diagnostics.
4. **Per-device probe guard.** One unusable GPU no longer discards the whole enumeration.
   Devices stay in the list either way, so the indices `whisper`'s `gpu_device` refers to
   never shift, and a healthy second GPU in the same machine stays usable.
5. **Selector reconciliation.** `AsrGpuDevice::usable` + `asrResolveDefaultGpuIndex()`
   default to the first usable device, else CPU; unusable devices are labelled
   "(unavailable)"; a GPU-only tier is not selected for a CPU resolution; and after a
   runtime fallback the panel says so in plain language. Computed resolutions are **not**
   persisted — a device can come back after a driver fix, and writing the computed value
   over the saved preference would pin it permanently. The reconciliation is deferred to
   the event loop (queued off `AsrEngine::ready()` for a load-time fallback, and off
   `AsrEngine::error` for a decode-time failure) rather than run inside the emission:
   reconciling can rebuild the engine, and doing that synchronously would destroy the
   `AsrEngine` whose emission is still on the stack.

### Relation to #4676 / #4677

Points 4 and 5 are not new work. I wrote the capability probe, the "(unsupported)"
labelling and the usable-device default in **#4677**, for the Intel-Mac case in **#4676**
(still open). It was reviewed there — @ten9876 built and ran `asr_gpu_probe_test` on his
own Linux/Vulkan box and mapped the change against #4676's requirements, @nigelfenton
checked it on an M4, and the triage bot reviewed it as well. Both of the blockers raised
were fixed at `eee59032`; notably the flash-attention op in the probe below is there
*because* of @ten9876's blocker 1 (the original probe read neither
`has_simdgroup_mm` nor anything gated on it, so a whole hardware class slipped through).
I closed that PR myself when v26.8.1 removed Copy Assist from the Intel macOS DMG — that
deleted its premise, not its mechanism.

This PR carries the hardware-neutral half of that work over to the Vulkan hosts, where it
turns out to matter more: there the probe is not merely advisory, it is what makes a
broken device detectable **before** anything tries to load a model on it. The Intel-Mac
vendor gating is not carried over, and #4676 is unaffected — it remains an Apple-side
issue for whoever picks it up.

On Apple Silicon the probe always passes — `has_simdgroup_reduction` /
`has_simdgroup_mm` gate on `MTLGPUFamilyApple7` (`ggml-metal-device.m:722/725`) and every
M-series meets it — so nothing changes there beyond inheriting the latch.

## Verification

Built and run on Linux (Ubuntu 24.04, Qt 6.8.3, Vulkan 1.3.275; Intel RPL-S iGPU +
NVIDIA RTX 5060). Since whisper cannot be made to fail on demand, the failure was
injected with a **Vulkan layer that returns the spec-legal
`VK_ERROR_INITIALIZATION_FAILED` from every `vkCreateDevice`**. Instance creation and
physical-device enumeration are left untouched, so the app sees a normal, selectable GPU
that simply cannot be used — the same shape as a broken driver, and the same place the
report puts the failure. (Environment tricks such as hiding the ICD are not equivalent:
they fail earlier, before a device is ever attempted.) The layer wraps a **stock binary**;
no instrumentation was added to the application. The layer is about a hundred lines of C
against the public Vulkan headers; I will attach it with the full evidence bundle (per-arm
logs, screenshots, binary SHAs) when this leaves draft.

Fresh settings store on both sides; About SHA verified (stock `ecd10440`; fixed
`2810e962`, with the two-press drill re-run at `a1f38685` after the queued-reconcile
change).

| observation (fresh store, layer active) | stock `ecd10440` | this PR |
|---|---|---|
| 1st Enable | load fails, app survives | model loads on CPU in 0.93 s |
| **2nd GPU attempt** (2nd Enable / tier change / explicit pick) | **`SIGSEGV`, exit 139** — `segfault at 0 ip 0x0` | **no GPU attempt made**; app alive |
| GPU touched at all after first failure | yes, every time | no — device latched out |
| `CopyAssistGpuCombo` value | Intel(R) Graphics (RPL-S) † | **CPU** |
| `CopyAssistGpuCombo` items | "Intel(R) Graphics (RPL-S)", "NVIDIA GeForce RTX 5060 Laptop GPU", "CPU" † | same + **(unavailable)** on both GPUs |
| `CopyAssistModelCombo` value | Large v3 Turbo † | **Base** |
| panel status after a fallback | unchanged — still names the GPU | **"Intel(R) Graphics (RPL-S) is unavailable — running on CPU. Transcription will be slower."** |
| transcription backlog | 7.6 s → 22.5 s and climbing, no text ‡ | 0.0 s |

† Derived from stock source (device resolution and tier defaulting at `ecd10440`), not
captured from a live stock dialog — the stock build was rebuilt over before its settings
dialog was opened under the layer. Every "this PR" cell is a live capture.
‡ Measured on the narrower first revision of this fix (`bc9dab46`), which for this row
behaves as stock does (no reconciliation existed yet).

Log lines, stock (stderr) — the two-press signature:

```
[layer] vkCreateDevice intercepted -> VK_ERROR_INITIALIZATION_FAILED
whisper_init_with_params_no_state: exception during model load: vk::PhysicalDevice::createDevice: ErrorInitializationFailed
whisper_init_with_params_no_state: failed to load model
# ...second Enable: no further output. exit 139.
```

Log lines, this PR (app category log) — each device judged on its own:

```
WRN aether.asr.whisper: GPU device 0 "Intel(R) Graphics (RPL-S)" failed the capability probe:
    vk::PhysicalDevice::createDevice: ErrorInitializationFailed - not offered, and not retried this session
WRN aether.asr.whisper: GPU device 1 "NVIDIA GeForce RTX 5060 Laptop GPU" failed the capability probe: ...
INF aether.asr.whisper: Loaded model ".../ggml-base.bin" ( 4 threads )
```

With the layer off, GPU load and transcription are unchanged.

**Tests:** `tests/asr_gpu_probe_test.cpp` now pins the contracts this fix rests on:
`asrResolveDefaultGpuIndex()` (empty list / none usable / second usable / all usable),
the failure latch (one-way, idempotent, CPU never latched), and two invariants checked
against the real enumeration — the resolved default is CPU or a device that passed the
probe, and a latched device is never reported usable. Each case was proven falsifiable
against deliberately broken implementations before being trusted. The test already runs
in CI on macOS (`check-macos` executes `ctest -R asr_gpu_probe_test`). Full suite:
`ctest` 245/248 with 1 skip, identical on the fixed build and on unmodified `ecd10440`
built the same way — the three failures (`s_meter_geometry_test`,
`range_slider_a11y_test`, `relay_bar_a11y_test`) are pre-existing on this machine and are
GUI geometry/a11y tests untouched by this diff.

The decode-time latch is implemented and suite-verified; the fault-injection drill above
exercises the probe and load paths, not the decode path — injecting a decode-time GPU
failure needs a layer variant that fails *after* device creation, which has not been run
yet.

**Test boundary** (per review): the pure contracts pin the latch's behaviour and the tier decision; nothing pins that `load()` consults the latch, nor that `transcribe()` refuses on it — those sit one refactor (injecting the latch predicate) away from pure testability and are covered here by review and the fault-injection drill only.

The branch merges clean against current `main` (`57c2eb94`, which includes #4739's rework
of the other half of `CopyAssistController`); `asr_gpu_probe_test` passes on the merged
tree.

## Known limitation

After a probe throw the application runs normally for the whole session but **can abort
during teardown**: ggml's destructor for the half-built device calls `vkDestroyFence` on a
device that was never created (`VUID-vkDestroyFence-device-parameter`, then SIGABRT).
Reproduced twice here. That is inside vendored ggml, below anything this change can guard,
and it happens only after quit has been requested — but it is real, and it may be worth an
upstream ggml report.

## Scope

- `GGML_ABORT` paths call `abort()` and remain uncatchable by design; this change covers
  the throwing failures and, more importantly, removes the repeat attempts that turn a
  recoverable failure into an unrecoverable one.
- **Not a fix for #4509.** That crash is `0xc000001d` (illegal instruction) on a no-AVX
  Phenom II — the prebuilt Windows pack executing AVX machine code the CPU lacks. It is a
  hardware signal no app-side guard can intercept, and the AVX code is in ggml's CPU
  kernels too, so avoiding the GPU would only move it. Its vehicle is #4397.
- **Not addressed here:** which usable GPU should be preferred when a machine has more
  than one (today: the first that passes the probe, which on a laptop is typically the
  integrated one). That is a defaults question rather than a crash, so it is better handled
  separately.

## Platform coverage

- **Linux — verified**, as above.
- **Windows — same path, not separately verified.** It runs the same ggml-Vulkan path
  this change is about, so the same failure shape and the same fix apply; nothing in the
  diff is Linux-specific. `check-windows` CI confirms the change compiles and links there,
  but (by design) it runs only a small test allow-list, which does not include
  `asr_gpu_probe_test` — that runs in `check-macos`. This PR presents Linux evidence;
  I have a Windows machine with the same dual-GPU hardware and can run the same
  fault-injection verification there if review wants it.
- **macOS — does not apply.** Apple Silicon uses the Metal backend, which reports
  failures rather than throwing, and every M-series GPU passes the capability probe
  (`has_simdgroup_reduction`/`has_simdgroup_mm` gate on `MTLGPUFamilyApple7`,
  `ggml-metal-device.m:722/725`), so the resolution logic changes nothing there — it
  inherits the failure latch and is otherwise unaffected. Intel Macs ship no ASR in
  v26.8.1, so they are out of scope entirely; `asr_gpu_probe_test` does pass on an
  Intel Mac here (AMD Radeon Pro 560X: the device enumerates, fails the capability
  probe without throwing, and the default resolves to CPU — the non-throwing branch
  exercised on real Metal hardware).

— authored by agent (Claude Code) on behalf of @skerker


