### PR TITLE
feat(tx): TX Linearity Analyzer — Phase 1 spectral measurement (RFC #4769)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,6 +624,7 @@ set(CORE_SOURCES
     # radio-specific types) plus the FlexRadio DAX IQ capture adapter. The core
     # is the measurement half of a digital-predistortion loop, so it is kept
     # free of Flex specifics for the HPSDR adapter that follows.
+    src/core/TxLinearitySettings.cpp          # owned config object (Principle V)
     src/core/txlinearity/SpectrumWindow.cpp
     src/core/txlinearity/TxSpectrumAnalyzer.cpp
     src/core/txlinearity/ImdAnalyzer.cpp
@@ -3696,6 +3697,18 @@ add_executable(tx_linearity_imd_test
 target_include_directories(tx_linearity_imd_test PRIVATE src ${FFTW3_INCLUDE_DIRS})
 target_link_libraries(tx_linearity_imd_test PRIVATE ${FFTW3_LIBRARIES})
 add_test(NAME tx_linearity_imd_test COMMAND tx_linearity_imd_test)
+
+# The owned config object (Principle V): defaults as a unit, round-trips as a
+# unit, and a drifted document degrades field by field. The range clamp is
+# load-bearing — timeoutSec feeds a transmit interlock.
+add_executable(tx_linearity_settings_test
+    tests/tx_linearity_settings_test.cpp
+    src/core/TxLinearitySettings.cpp
+    ${AETHER_SETTINGS_SOURCES}
+)
+target_include_directories(tx_linearity_settings_test PRIVATE src)
+target_link_libraries(tx_linearity_settings_test PRIVATE aethercore Qt6::Core)
+add_test(NAME tx_linearity_settings_test COMMAND tx_linearity_settings_test)
 
 # The safety interlocks are clock-injected and Qt-free specifically so they can
 # be tested without transmitting. An interlock that can only be exercised by

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,6 +620,16 @@ set(CORE_SOURCES
     src/core/backends/hl2/Hl2Discovery.cpp   # aetherd HL2 Phase 1c (HPSDR discovery -> picker)
     src/core/backends/hl2/Hl2Settings.cpp    # owned config object, "Hl2" root key (Principle V)
     src/core/dsp/WdspChannel.cpp
+    # TX Linearity Analyzer — backend-agnostic measurement core (no Qt, no
+    # radio-specific types) plus the FlexRadio DAX IQ capture adapter. The core
+    # is the measurement half of a digital-predistortion loop, so it is kept
+    # free of Flex specifics for the HPSDR adapter that follows.
+    src/core/txlinearity/SpectrumWindow.cpp
+    src/core/txlinearity/TxSpectrumAnalyzer.cpp
+    src/core/txlinearity/ImdAnalyzer.cpp
+    src/core/txlinearity/TxLinearitySafety.cpp
+    src/core/txlinearity/FlexDaxIqCapture.cpp
+    src/core/txlinearity/TxLinearityController.cpp
     ${AETHER_SETTINGS_SOURCES}
     src/core/RadioStateMemory.cpp   # RFC #4603 client-side radio memory
     src/core/GpuSelector.cpp
@@ -841,6 +851,10 @@ set(MODEL_SOURCES
 add_subdirectory(third_party/QGeoView/lib EXCLUDE_FROM_ALL)
 
 set(GUI_SOURCES
+    # TX Linearity Analyzer — instrument window + marked spectrum plot.
+    # All DSP lives in src/core/txlinearity; these are display and wiring only.
+    src/gui/TxLinearityDialog.cpp
+    src/gui/TxLinearitySpectrumView.cpp
     src/gui/Contribute.cpp
     src/gui/MainWindow.cpp
     src/gui/MainWindowHelpers.cpp
@@ -3654,6 +3668,44 @@ add_executable(spectral_nr_test
 target_include_directories(spectral_nr_test PRIVATE src)
 target_link_libraries(spectral_nr_test PRIVATE Qt6::Core)
 add_test(NAME spectral_nr_test COMMAND spectral_nr_test)
+
+# ── TX Linearity Analyzer ────────────────────────────────────────────────────
+#
+# Hardware-free by construction: the measurement core takes no Qt and no radio
+# types, so these link FFTW3 directly and nothing else. Every expected value is
+# derived in closed form from the synthetic PA model in
+# tests/TxLinearityTestSignals.h rather than recorded from a previous run, so
+# the suite proves the instrument measures correctly rather than proving it is
+# self-consistent. Do not let these regress into needing a radio.
+add_executable(tx_linearity_spectrum_test
+    tests/tx_linearity_spectrum_test.cpp
+    src/core/txlinearity/SpectrumWindow.cpp
+    src/core/txlinearity/TxSpectrumAnalyzer.cpp
+    src/core/txlinearity/ImdAnalyzer.cpp
+)
+target_include_directories(tx_linearity_spectrum_test PRIVATE src ${FFTW3_INCLUDE_DIRS})
+target_link_libraries(tx_linearity_spectrum_test PRIVATE ${FFTW3_LIBRARIES})
+add_test(NAME tx_linearity_spectrum_test COMMAND tx_linearity_spectrum_test)
+
+add_executable(tx_linearity_imd_test
+    tests/tx_linearity_imd_test.cpp
+    src/core/txlinearity/SpectrumWindow.cpp
+    src/core/txlinearity/TxSpectrumAnalyzer.cpp
+    src/core/txlinearity/ImdAnalyzer.cpp
+)
+target_include_directories(tx_linearity_imd_test PRIVATE src ${FFTW3_INCLUDE_DIRS})
+target_link_libraries(tx_linearity_imd_test PRIVATE ${FFTW3_LIBRARIES})
+add_test(NAME tx_linearity_imd_test COMMAND tx_linearity_imd_test)
+
+# The safety interlocks are clock-injected and Qt-free specifically so they can
+# be tested without transmitting. An interlock that can only be exercised by
+# keying a radio is an interlock that never gets exercised.
+add_executable(tx_linearity_safety_test
+    tests/tx_linearity_safety_test.cpp
+    src/core/txlinearity/TxLinearitySafety.cpp
+)
+target_include_directories(tx_linearity_safety_test PRIVATE src)
+add_test(NAME tx_linearity_safety_test COMMAND tx_linearity_safety_test)
 
 add_executable(mono_dsp_stereo_adapter_test
     tests/mono_dsp_stereo_adapter_test.cpp

--- a/src/core/TxLinearitySettings.cpp
+++ b/src/core/TxLinearitySettings.cpp
@@ -1,0 +1,116 @@
+#include "core/TxLinearitySettings.h"
+
+#include "core/AppSettings.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include <algorithm>
+
+namespace AetherSDR {
+namespace {
+
+const QString kRootKey = QStringLiteral("TxLinearity");
+
+constexpr const char* kFieldDaxChannel = "daxChannel";
+constexpr const char* kFieldToneSpacing = "toneSpacingHz";
+constexpr const char* kFieldTunePower = "tunePowerW";
+constexpr const char* kFieldAverages = "averages";
+constexpr const char* kFieldTimeout = "timeoutSec";
+constexpr const char* kFieldWindow = "window";
+constexpr const char* kFieldMaxOrder = "maxOrder";
+
+// Read one field, keeping the caller's default when the key is absent OR
+// stored with the wrong JSON type. isDouble()/isString() rather than a bare
+// toInt() so a document that has drifted degrades field by field instead of
+// silently substituting zero — which for `averages` or `timeoutSec` would be a
+// meaningfully wrong configuration, not a cosmetic one.
+int readInt(const QJsonObject& obj, const char* field, int fallback)
+{
+    const QJsonValue v = obj.value(QLatin1String(field));
+    return v.isDouble() ? v.toInt(fallback) : fallback;
+}
+
+double readDouble(const QJsonObject& obj, const char* field, double fallback)
+{
+    const QJsonValue v = obj.value(QLatin1String(field));
+    return v.isDouble() ? v.toDouble(fallback) : fallback;
+}
+
+QString readString(const QJsonObject& obj, const char* field, const QString& fallback)
+{
+    const QJsonValue v = obj.value(QLatin1String(field));
+    return v.isString() ? v.toString() : fallback;
+}
+
+}  // namespace
+
+QString TxLinearitySettings::rootKey()
+{
+    return kRootKey;
+}
+
+void TxLinearitySettings::clampToValidRanges()
+{
+    daxChannel = std::clamp(daxChannel, 1, 4);
+    toneSpacingHz = std::clamp(toneSpacingHz, 200.0, 10000.0);
+    tunePowerW = std::clamp(tunePowerW, 1, 100);
+    averages = std::clamp(averages, 1, 64);
+    // Never above the 10 s ceiling §8 fixes, and never zero — "no timeout" is
+    // not a configuration that can exist.
+    timeoutSec = std::clamp(timeoutSec, 1, 10);
+    // Odd orders only, and 7 is the practical limit for a feedback path with
+    // ~80 dB of dynamic range.
+    if (maxOrder != 3 && maxOrder != 5 && maxOrder != 7) {
+        maxOrder = 7;
+    }
+    // An unrecognised window name falls back to the default rather than
+    // leaving the combo with no valid selection; windowKindFromKey() applies
+    // the same fallback on the DSP side, so the two agree.
+    if (window != QStringLiteral("blackman-harris-7")
+        && window != QStringLiteral("blackman-harris-4")
+        && window != QStringLiteral("hann") && window != QStringLiteral("flat-top")) {
+        window = QStringLiteral("blackman-harris-7");
+    }
+}
+
+TxLinearitySettings TxLinearitySettings::load()
+{
+    TxLinearitySettings out;
+
+    const QString json = AppSettings::instance().value(kRootKey, QString{}).toString();
+    if (json.isEmpty()) {
+        return out;   // never stored: the compiled-in defaults ARE the answer
+    }
+
+    const QJsonObject obj = QJsonDocument::fromJson(json.toUtf8()).object();
+    out.daxChannel = readInt(obj, kFieldDaxChannel, out.daxChannel);
+    out.toneSpacingHz = readDouble(obj, kFieldToneSpacing, out.toneSpacingHz);
+    out.tunePowerW = readInt(obj, kFieldTunePower, out.tunePowerW);
+    out.averages = readInt(obj, kFieldAverages, out.averages);
+    out.timeoutSec = readInt(obj, kFieldTimeout, out.timeoutSec);
+    out.window = readString(obj, kFieldWindow, out.window);
+    out.maxOrder = readInt(obj, kFieldMaxOrder, out.maxOrder);
+
+    out.clampToValidRanges();
+    return out;
+}
+
+void TxLinearitySettings::save() const
+{
+    QJsonObject obj;
+    obj[QLatin1String(kFieldDaxChannel)] = daxChannel;
+    obj[QLatin1String(kFieldToneSpacing)] = toneSpacingHz;
+    obj[QLatin1String(kFieldTunePower)] = tunePowerW;
+    obj[QLatin1String(kFieldAverages)] = averages;
+    obj[QLatin1String(kFieldTimeout)] = timeoutSec;
+    obj[QLatin1String(kFieldWindow)] = window;
+    obj[QLatin1String(kFieldMaxOrder)] = maxOrder;
+
+    AppSettings& settings = AppSettings::instance();
+    settings.setValue(kRootKey,
+                      QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+    settings.save();
+}
+
+}  // namespace AetherSDR

--- a/src/core/TxLinearitySettings.h
+++ b/src/core/TxLinearitySettings.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <QString>
+
+namespace AetherSDR {
+
+// Owned configuration for the TX Linearity Analyzer, per Constitution
+// Principle V: ONE nested JSON object under a single root key
+// ("TxLinearity"), defaulted, read and written as a unit — never scattered as
+// loose flat keys across the shared AppSettings namespace.
+//
+// Shape:
+//   {"daxChannel":int, "toneSpacingHz":double, "tunePowerW":int,
+//    "averages":int, "timeoutSec":int, "window":string, "maxOrder":int}
+//
+// There is no legacy-flat-key migration here because this feature has never
+// shipped: the object is the only shape its settings have ever had.
+//
+// WHAT IS DELIBERATELY ABSENT. The dummy-load / verified-clear confirmation is
+// NOT persisted and must never be added to this object. §8 requires explicit
+// confirmation before every test transmission and requires it not to be
+// remembered across runs or sessions — the antenna on the other end of the
+// coax is not a preference, it is a fact that can change between one run and
+// the next. TxLinearitySafety holds it in memory for exactly one run and
+// clears it on stop.
+//
+// The transmit timeout IS persisted, but restoring it can only ever tighten
+// the interlock: TxLinearitySafety::setLimits() refuses a value that loosens a
+// limit without an explicit override, so a corrupted or hand-edited stored
+// value cannot quietly widen the transmit window.
+struct TxLinearitySettings {
+    int daxChannel = 1;
+    double toneSpacingHz = 2000.0;
+    int tunePowerW = 10;
+    int averages = 8;
+    int timeoutSec = 10;
+    QString window = QStringLiteral("blackman-harris-7");
+    int maxOrder = 7;
+
+    // Read the whole object, falling back to the defaults above for any field
+    // the stored document is missing or has stored with the wrong type. A
+    // partially-written or hand-edited document degrades field by field rather
+    // than resetting the operator's whole setup.
+    static TxLinearitySettings load();
+
+    // Write the whole object atomically under the single root key.
+    void save() const;
+
+    // Clamp every field into the range its control accepts. Called by load(),
+    // so a stored document that is out of range — from an older build with
+    // different limits, or from a hand edit — can never drive a control past
+    // its bounds or hand the analyzer an unusable FFT configuration.
+    void clampToValidRanges();
+
+    static QString rootKey();   // "TxLinearity"
+};
+
+}  // namespace AetherSDR

--- a/src/core/txlinearity/CaptureRing.h
+++ b/src/core/txlinearity/CaptureRing.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+namespace AetherSDR::txlin {
+
+// Lock-free single-producer / single-consumer ring for handing capture frames
+// from the thread that receives IQ to the thread that transforms it.
+//
+// WHY LOCK-FREE. The producer side runs on the thread that services the radio's
+// VITA-49 stream, which is the same thread that services the GUI. If it ever
+// blocks on a mutex held by an analysis thread mid-FFT, the panadapter stutters
+// and — far worse — the stream backs up while the radio is keyed. The one
+// property that matters here is that push() cannot wait for pop(), and a
+// bounded SPSC ring with acquire/release indices gives exactly that with no
+// atomics contention beyond two cache lines.
+//
+// OVERFLOW IS DROP-NEWEST, DELIBERATELY. When the analysis thread falls behind,
+// the ring refuses the incoming frame rather than overwriting the oldest. A
+// linearity measurement Welch-averages whole frames and does not care WHICH
+// frames it gets, only that each one is internally contiguous — so dropping is
+// harmless, while overwriting a frame the consumer is mid-read on would splice
+// two different capture instants together and manufacture spectral content that
+// was never transmitted. Dropped frames are counted so the UI can report a
+// measurement that did not get the averaging it asked for.
+//
+// Capacity is rounded up to a power of two so the index wrap is a mask.
+template <typename T>
+class CaptureRing {
+public:
+    explicit CaptureRing(std::size_t capacity)
+    {
+        std::size_t cap = 2;
+        while (cap < capacity) {
+            cap <<= 1;
+        }
+        m_slots.resize(cap);
+        m_mask = cap - 1;
+    }
+
+    [[nodiscard]] std::size_t capacity() const { return m_slots.size(); }
+
+    // Producer side. Returns false when the ring is full; the caller must treat
+    // that as a dropped frame, not as a retry-later.
+    bool push(T&& value)
+    {
+        const std::size_t head = m_head.load(std::memory_order_relaxed);
+        const std::size_t next = (head + 1) & m_mask;
+        if (next == m_tail.load(std::memory_order_acquire)) {
+            m_dropped.fetch_add(1, std::memory_order_relaxed);
+            return false;
+        }
+        m_slots[head] = std::move(value);
+        m_head.store(next, std::memory_order_release);
+        return true;
+    }
+
+    // Consumer side. Returns false when empty.
+    bool pop(T& out)
+    {
+        const std::size_t tail = m_tail.load(std::memory_order_relaxed);
+        if (tail == m_head.load(std::memory_order_acquire)) {
+            return false;
+        }
+        out = std::move(m_slots[tail]);
+        m_tail.store((tail + 1) & m_mask, std::memory_order_release);
+        return true;
+    }
+
+    [[nodiscard]] bool empty() const
+    {
+        return m_head.load(std::memory_order_acquire) == m_tail.load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] std::size_t dropped() const
+    {
+        return m_dropped.load(std::memory_order_relaxed);
+    }
+
+    // Safe only when neither side is running — between runs.
+    void reset()
+    {
+        m_head.store(0, std::memory_order_relaxed);
+        m_tail.store(0, std::memory_order_relaxed);
+        m_dropped.store(0, std::memory_order_relaxed);
+    }
+
+private:
+    std::vector<T> m_slots;
+    std::size_t m_mask = 0;
+    // Separate cache lines: head is written only by the producer and tail only
+    // by the consumer, and sharing a line would put them in false contention on
+    // every single frame.
+    alignas(64) std::atomic<std::size_t> m_head{0};
+    alignas(64) std::atomic<std::size_t> m_tail{0};
+    alignas(64) std::atomic<std::size_t> m_dropped{0};
+};
+
+}  // namespace AetherSDR::txlin

--- a/src/core/txlinearity/FlexDaxIqCapture.cpp
+++ b/src/core/txlinearity/FlexDaxIqCapture.cpp
@@ -1,0 +1,178 @@
+#include "FlexDaxIqCapture.h"
+
+#include "core/LogManager.h"
+
+#include <algorithm>
+
+namespace AetherSDR::txlin {
+
+FlexDaxIqCapture::FlexDaxIqCapture(int channel, QObject* parent)
+    : QObject(parent), m_channel(std::clamp(channel, 1, kMaxChannels))
+{
+}
+
+FlexDaxIqCapture::~FlexDaxIqCapture()
+{
+    // Not a courtesy: leaving the stream up would keep a DAX IQ channel
+    // allocated on the radio after the analyzer is gone, and the radio has only
+    // four.
+    FlexDaxIqCapture::stop();
+}
+
+bool FlexDaxIqCapture::start(const CaptureConfig& config)
+{
+    if (m_running) {
+        return true;
+    }
+    m_config = config;
+    if (m_config.frameSamples < 64) {
+        emitError("Frame size is too small to analyze");
+        return false;
+    }
+
+    // Preallocate once. Nothing on the delivery path may allocate.
+    m_frame.assign(std::size_t(m_config.frameSamples), std::complex<float>(0.0f, 0.0f));
+    m_filled = 0;
+    m_saturated = 0;
+    m_gateOpen = false;
+    m_actualRate = 0.0;
+
+    const int rate = int(m_config.sampleRateHz);
+    emit streamStartRequested(m_channel, rate);
+    if (!m_panId.isEmpty()) {
+        emit commandReady(QStringLiteral("display pan set %1 daxiq_channel=%2")
+                              .arg(m_panId)
+                              .arg(m_channel));
+    }
+
+    m_running = true;
+    qCInfo(lcDax) << "FlexDaxIqCapture: started ch" << m_channel << "at" << rate
+                  << "Hz, frame" << m_config.frameSamples << "pan" << m_panId;
+    return true;
+}
+
+void FlexDaxIqCapture::stop()
+{
+    if (!m_running) {
+        return;
+    }
+    // Close the gate FIRST. Any frame still in flight must not reach a consumer
+    // that is tearing down.
+    m_gateOpen = false;
+    m_running = false;
+    m_filled = 0;
+    m_saturated = 0;
+    emit streamStopRequested(m_channel);
+    qCInfo(lcDax) << "FlexDaxIqCapture: stopped ch" << m_channel;
+}
+
+std::string FlexDaxIqCapture::describe() const
+{
+    QString text = m_radioDescription.isEmpty() ? QStringLiteral("FlexRadio")
+                                                : m_radioDescription;
+    text += QStringLiteral(" DAX IQ ch %1").arg(m_channel);
+    if (m_actualRate > 0.0) {
+        text += QStringLiteral(" @ %1 kHz").arg(m_actualRate / 1000.0, 0, 'f', 0);
+    }
+    return text.toStdString();
+}
+
+void FlexDaxIqCapture::setFrameCallback(FrameCallback callback)
+{
+    m_frameCallback = std::move(callback);
+}
+
+void FlexDaxIqCapture::setErrorCallback(ErrorCallback callback)
+{
+    m_errorCallback = std::move(callback);
+}
+
+void FlexDaxIqCapture::setGateOpen(bool open)
+{
+    if (m_gateOpen == open) {
+        return;
+    }
+    m_gateOpen = open;
+    // Discard whatever partial frame straddles the gate edge. Half a frame of
+    // key-up transient spliced onto half a frame of steady state is not a
+    // measurement of either.
+    m_filled = 0;
+    m_saturated = 0;
+}
+
+void FlexDaxIqCapture::noteStreamRemoved(int channel)
+{
+    if (channel != m_channel || !m_running) {
+        return;
+    }
+    emitError("DAX IQ stream was removed by the radio");
+}
+
+void FlexDaxIqCapture::noteStreamRate(int channel, int sampleRateHz)
+{
+    if (channel != m_channel || sampleRateHz <= 0) {
+        return;
+    }
+    m_actualRate = double(sampleRateHz);
+}
+
+void FlexDaxIqCapture::feedIqSamples(int channel, const QVector<float>& interleaved,
+                                     int sampleRateHz)
+{
+    if (!m_running || channel != m_channel || !m_gateOpen) {
+        return;
+    }
+    if (m_frameCallback == nullptr || sampleRateHz <= 0) {
+        return;
+    }
+
+    // The radio, not the request, is authoritative about the rate. Measuring a
+    // frame at the wrong assumed rate would put every frequency, and therefore
+    // every product identification, in the wrong place.
+    if (m_actualRate > 0.0 && double(sampleRateHz) != m_actualRate) {
+        // Rate changed mid-capture: the partial frame spans two sample rates
+        // and is not analyzable.
+        m_filled = 0;
+        m_saturated = 0;
+    }
+    m_actualRate = double(sampleRateHz);
+
+    const std::size_t pairs = std::size_t(interleaved.size()) / 2;
+    const float* src = interleaved.constData();
+    const std::size_t frameLen = m_frame.size();
+
+    for (std::size_t i = 0; i < pairs; ++i) {
+        const float re = src[2 * i];
+        const float im = src[2 * i + 1];
+        if (double(re) * double(re) + double(im) * double(im) >= 0.999 * 0.999) {
+            ++m_saturated;
+        }
+        m_frame[m_filled] = std::complex<float>(re, im);
+        ++m_filled;
+
+        if (m_filled == frameLen) {
+            CaptureFrame frame;
+            frame.feedback = m_frame;   // one copy, handed off to the ring
+            frame.sampleRateHz = m_actualRate;
+            frame.centerFreqHz = m_config.centerFreqHz;
+            frame.timestampNs = 0;
+            frame.clipped =
+                (double(m_saturated) / double(frameLen)) > kClippedFractionThreshold;
+            // reference stays disengaged — see the header for why that is
+            // architectural on this backend and not a gap.
+            m_frameCallback(frame);
+            m_filled = 0;
+            m_saturated = 0;
+        }
+    }
+}
+
+void FlexDaxIqCapture::emitError(const std::string& reason)
+{
+    qCWarning(lcDax) << "FlexDaxIqCapture:" << QString::fromStdString(reason);
+    if (m_errorCallback != nullptr) {
+        m_errorCallback(reason);
+    }
+}
+
+}  // namespace AetherSDR::txlin

--- a/src/core/txlinearity/FlexDaxIqCapture.h
+++ b/src/core/txlinearity/FlexDaxIqCapture.h
@@ -1,0 +1,146 @@
+#pragma once
+
+#include "ITxCaptureSource.h"
+
+#include <QObject>
+#include <QString>
+#include <QVector>
+
+namespace AetherSDR::txlin {
+
+// ITxCaptureSource over a FlexRadio DAX IQ stream.
+//
+// STREAM SETUP. The tree already has the whole DAX IQ path: DaxIqModel creates
+// and tears down streams, PanadapterStream receives the VITA-49 payload on the
+// existing UDP socket, and a worker thread does the byte-swap before the
+// samples surface as DaxIqModel::iqSamplesReady. This adapter therefore does
+// not create a socket, a stream lifecycle or a parser of its own — it consumes
+// that path, which is also the path that has been debugged against real
+// hardware.
+//
+// The published command syntax, verified against FlexLib (Radio.cs:4800,
+// DAXIQStream.cs:54, Panadapter.cs:259) per Constitution Principle I:
+//
+//     stream create type=dax_iq daxiq_channel=<n>
+//     stream set 0x<id> daxiq_rate=<24000|48000|96000|192000>
+//     display pan set <panId> daxiq_channel=<n>
+//
+// Note this differs from the syntax in the original feature brief
+// (`stream create daxiq=<ch> ip=<ip> port=<port>`) — there is no ip/port on the
+// create, because the radio streams to the client's existing VITA-49 socket.
+// FlexLib and the shipping code agree; the brief does not.
+//
+// NO MODEL DEPENDENCY, BY RULE AND ON THE MERITS. This class holds no pointer
+// to DaxIqModel and includes none of its headers: samples arrive through
+// feedIqSamples() and stream operations leave as request signals, which the
+// owning UI connects to the radio. The engine-boundary ratchet (EB3, aetherd
+// RFC §2.4) forbids new above-seam code reaching around IRadioBackend to a
+// vendor model, and the decoupling it forces is the better design anyway —
+// what is left here is exactly the frame assembler and capture gate, with none
+// of the DAX plumbing, which is what the HPSDR adapter will want to mirror.
+//
+// SAMPLE RATE. Always requests the highest rate the pan allows, 192 kHz, for
+// the reason set out in CaptureConfig: order-7 products sit three tone-spacings
+// beyond each tone, and the capture needs enough clean bandwidth beyond that
+// for the band-edge filter skirt never to reach the measurement region.
+//
+// NO REFERENCE CHANNEL, AND WHY THAT IS PERMANENT ON THIS BACKEND. DAX IQ is
+// unidirectional. There is no API to send IQ to the radio for transmission; the
+// only inbound path is the TX Audio stream, which carries audio. An SSB
+// modulator derives the analytic signal from a single real input via Hilbert
+// transform, so the complex envelope's phase is determined by its amplitude and
+// an arbitrary complex correction cannot be expressed at all. And the radio's
+// TX filter sits downstream of injected audio, so any out-of-band correction
+// product is removed while any in-band one is added distortion. This is an
+// architectural property of the radio, not a gap to be worked around later.
+//
+// THREADING. Frames are assembled on the thread that delivers the IQ — today
+// the main thread, since DaxIqModel's worker relays across. The assembly is a
+// bounded memcpy into a preallocated buffer: no allocation and no DSP, which is
+// the constraint that actually matters. The FFT work happens on
+// TxLinearityController's analysis thread, fed through a lock-free ring. A
+// third capture thread of our own would mean duplicating the VITA-49 and
+// byte-swap path that DaxIqWorker already owns, for no benefit.
+class FlexDaxIqCapture : public QObject, public ITxCaptureSource {
+    Q_OBJECT
+
+public:
+    // A FLEX offers four DAX IQ channels. Stated here rather than reached for
+    // from DaxIqModel so this file keeps no vendor-model dependency; the UI
+    // that populates the channel chooser reads the model's own constant.
+    static constexpr int kMaxChannels = 4;
+
+    explicit FlexDaxIqCapture(int channel, QObject* parent = nullptr);
+    ~FlexDaxIqCapture() override;
+
+    bool start(const CaptureConfig& config) override;
+    void stop() override;
+
+    [[nodiscard]] bool hasReferenceChannel() const override { return false; }
+    [[nodiscard]] std::string describe() const override;
+
+    void setFrameCallback(FrameCallback callback) override;
+    void setErrorCallback(ErrorCallback callback) override;
+    void setGateOpen(bool open) override;
+
+    [[nodiscard]] bool gateOpen() const { return m_gateOpen; }
+    [[nodiscard]] int channel() const { return m_channel; }
+    [[nodiscard]] double actualSampleRateHz() const { return m_actualRate; }
+
+    // Identity for export stamps, pushed down by the UI so the core never has
+    // to know about RadioModel.
+    void setRadioDescription(const QString& text) { m_radioDescription = text; }
+
+    // Panadapter watching the feedback port. Binding the DAX IQ channel to it
+    // is what centres the IQ window on the transmitted signal; without it the
+    // channel keeps whatever pan it was last assigned to and the signal can
+    // fall outside the +/-fs/2 window entirely — the same trap WfmDemodulator
+    // documents.
+    void setPanId(const QString& panId) { m_panId = panId; }
+
+public slots:
+    // Interleaved I/Q float32 for `channel`, native endian, as delivered by the
+    // radio's DAX IQ stream. Frames outside the gate are discarded here.
+    void feedIqSamples(int channel, const QVector<float>& interleaved, int sampleRateHz);
+
+    // The radio dropped the stream underneath us. Treated as a terminal capture
+    // error: a keyed radio whose measurement path has died has no reason to
+    // still be transmitting.
+    void noteStreamRemoved(int channel);
+
+    // The rate the radio actually settled on, which is authoritative over the
+    // requested one — a stream whose re-rate is still settling reports the
+    // 48 kHz default transiently.
+    void noteStreamRate(int channel, int sampleRateHz);
+
+signals:
+    void streamStartRequested(int channel, int sampleRateHz);
+    void streamStopRequested(int channel);
+    // Raw command for the pan binding, in the radio's own syntax.
+    void commandReady(const QString& command);
+
+private:
+    void emitError(const std::string& reason);
+
+    int m_channel = 1;
+    QString m_panId;
+    QString m_radioDescription;
+
+    CaptureConfig m_config;
+    bool m_running = false;
+    bool m_gateOpen = false;
+    double m_actualRate = 0.0;
+
+    // Frame assembly. Preallocated at start(); never resized while running, so
+    // the delivery path allocates nothing.
+    std::vector<std::complex<float>> m_frame;
+    std::size_t m_filled = 0;
+    // Rolling count of saturated samples in the frame being assembled, so the
+    // clipped verdict costs one comparison per sample rather than a second pass.
+    std::size_t m_saturated = 0;
+
+    FrameCallback m_frameCallback;
+    ErrorCallback m_errorCallback;
+};
+
+}  // namespace AetherSDR::txlin

--- a/src/core/txlinearity/ITxCaptureSource.h
+++ b/src/core/txlinearity/ITxCaptureSource.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include "TxLinearityTypes.h"
+
+#include <cmath>
+#include <functional>
+#include <span>
+#include <string>
+
+namespace AetherSDR::txlin {
+
+// The seam between "where the observed TX signal comes from" and "what is
+// measured on it".
+//
+// This is the most consequential design decision in the feature, because the
+// analyzer is the measurement half of a digital-predistortion loop and the
+// correction half arrives later on a different backend. Everything above this
+// interface is arithmetic on complex samples and knows nothing about
+// FlexRadio, VITA-49, DAX, Metis or Qt. Everything below it is one radio's
+// plumbing. Get the seam right and the HL2 DPD work is additive; get it wrong
+// and the DSP gets rewritten, which is the one part that must not be.
+//
+// hasReferenceChannel() is the capability that gates the whole downstream
+// pipeline:
+//
+//   false — FlexRadio. DAX IQ is unidirectional: it streams IQ from radio to
+//           host and there is no API to send IQ back. The only inbound path is
+//           the TX Audio stream, which carries audio, and an SSB modulator
+//           derives phase from amplitude via Hilbert transform, so an arbitrary
+//           complex correction cannot be expressed in it at all. Phase 1 is
+//           therefore reference-free: spectrum, IMD products, shoulders, ACPR.
+//           Phase 2 recovers an envelope by SYNTHESISING the reference from a
+//           known two-tone stimulus (valid for that stimulus only).
+//
+//   true  — HPSDR / Hermes-Lite 2. The radio supplies both the DAC reference
+//           stream and the RF feedback stream, which enables true AM-AM/AM-PM
+//           and, eventually, correction.
+//
+// Consumers must degrade — not crash, and above all not fabricate — when
+// CaptureFrame::reference is disengaged.
+class ITxCaptureSource {
+public:
+    using FrameCallback = std::function<void(const CaptureFrame&)>;
+    // Terminal failure of the capture path. The controller treats any call to
+    // this as an immediate abort, because a keyed radio whose analysis thread
+    // has stopped receiving is the exact situation §8 exists to prevent.
+    using ErrorCallback = std::function<void(const std::string& reason)>;
+
+    virtual ~ITxCaptureSource() = default;
+
+    virtual bool start(const CaptureConfig& config) = 0;
+    virtual void stop() = 0;
+
+    [[nodiscard]] virtual bool hasReferenceChannel() const = 0;
+
+    // Human-readable identity for export stamps ("FLEX-8600 DAX IQ ch 2").
+    [[nodiscard]] virtual std::string describe() const = 0;
+
+    // Frames are delivered on the capture thread. Implementations must set both
+    // callbacks before start() and must not invoke either after stop() returns.
+    virtual void setFrameCallback(FrameCallback callback) = 0;
+    virtual void setErrorCallback(ErrorCallback callback) = 0;
+
+    // Capture gate: only frames assembled while open reach the frame callback,
+    // and a partial frame straddling either edge is discarded rather than
+    // spliced. The controller opens it once the post-key settling guard has
+    // elapsed and closes it before key-down ends, so PA thermal and ALC
+    // settling never average into a steady-state distortion measurement.
+    //
+    // Defaulted to a no-op because a source that only ever produces samples
+    // during transmit — a future HPSDR feedback stream, or a file replay in a
+    // test — has nothing to gate.
+    virtual void setGateOpen(bool open) { (void)open; }
+};
+
+// ── Overload detection ──────────────────────────────────────────────────────
+
+// Fraction of samples whose magnitude sits at or above `threshold` (relative to
+// full scale 1.0).
+//
+// Clipping is judged by POPULATION, not by any single sample. On a signal whose
+// peaks are the entire point, one sample touching full scale in 16384 is a
+// statistical certainty and means nothing; a population piled against the rail
+// is the condition that flattens the envelope and manufactures the very
+// distortion the instrument is trying to measure. The caller compares this
+// against a fraction, so the verdict is "how much of the frame is saturated",
+// which is the question that matters.
+inline double saturatedFraction(std::span<const std::complex<float>> samples,
+                                double threshold = 0.999)
+{
+    if (samples.empty()) {
+        return 0.0;
+    }
+    // Compare squared magnitudes so the hot loop carries no sqrt.
+    const double t2 = threshold * threshold;
+    std::size_t hits = 0;
+    for (const std::complex<float>& s : samples) {
+        const double re = double(s.real());
+        const double im = double(s.imag());
+        if (re * re + im * im >= t2) {
+            ++hits;
+        }
+    }
+    return double(hits) / double(samples.size());
+}
+
+// Default fraction above which a frame is declared clipped. 0.1% of a 16384
+// sample frame is ~16 samples — comfortably above the handful a clean
+// peak-riding envelope produces, comfortably below the thousands a genuinely
+// overdriven path produces.
+inline constexpr double kClippedFractionThreshold = 0.001;
+
+}  // namespace AetherSDR::txlin

--- a/src/core/txlinearity/ImdAnalyzer.cpp
+++ b/src/core/txlinearity/ImdAnalyzer.cpp
@@ -1,0 +1,291 @@
+#include "ImdAnalyzer.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR::txlin {
+namespace {
+
+double dbToAmplitude(double db)
+{
+    return std::pow(10.0, db / 20.0);
+}
+
+// Median of the bins that belong to neither a fundamental nor a product skirt.
+//
+// MEDIAN, not mean: the guard set inevitably still contains the odd real
+// signal — a spur, a birdie, a stray carrier — and a mean would let one of them
+// lift the reported floor by tens of dB, which would then suppress every
+// genuine product as "limited by noise floor". The median is indifferent to a
+// minority of outliers, which is exactly the robustness this needs.
+double estimateNoiseFloorDb(const std::vector<double>& power,
+                            const std::vector<int>& excludeCentres,
+                            int excludeHalfBins)
+{
+    const int n = int(power.size());
+    std::vector<bool> masked(std::size_t(n), false);
+    for (int centre : excludeCentres) {
+        const int lo = std::max(0, centre - excludeHalfBins);
+        const int hi = std::min(n - 1, centre + excludeHalfBins);
+        for (int k = lo; k <= hi; ++k) {
+            masked[std::size_t(k)] = true;
+        }
+    }
+
+    // Trim the outer 5% of the capture band. A DAX IQ stream is decimated by
+    // the radio's own filters, whose transition band lives right at the edges;
+    // including it would measure the filter skirt and call it the noise floor.
+    const int edge = std::max(1, n / 20);
+    std::vector<double> keep;
+    keep.reserve(std::size_t(n));
+    for (int k = edge; k < n - edge; ++k) {
+        if (!masked[std::size_t(k)] && power[std::size_t(k)] > 0.0) {
+            keep.push_back(power[std::size_t(k)]);
+        }
+    }
+    if (keep.empty()) {
+        return -300.0;
+    }
+    const std::size_t mid = keep.size() / 2;
+    std::nth_element(keep.begin(), keep.begin() + std::ptrdiff_t(mid), keep.end());
+    return 10.0 * std::log10(keep[mid]);
+}
+
+}  // namespace
+
+std::optional<BandPower> integrateBand(const TxSpectrumAnalyzer& analyzer,
+                                       double sampleRateHz,
+                                       double lowHz, double highHz,
+                                       double toneRefDb, double pepDb)
+{
+    const std::vector<double>& power = analyzer.powerSpectrum();
+    const int n = int(power.size());
+    if (n < 4 || sampleRateHz <= 0.0 || highHz <= lowHz) {
+        return std::nullopt;
+    }
+
+    const double bw = TxSpectrumAnalyzer::binHz(sampleRateHz, n);
+    const double nyq = sampleRateHz / 2.0;
+    // Refuse rather than truncate. A band clipped at the capture edge
+    // integrates less energy than the caller asked for and reports it as though
+    // it were the whole band — a silently optimistic ACPR figure, which is the
+    // worst kind of wrong for this instrument.
+    if (lowHz < -nyq || highHz > nyq) {
+        return std::nullopt;
+    }
+
+    const int loBin = std::clamp(int(std::floor(lowHz / bw)) + n / 2, 0, n - 1);
+    const int hiBin = std::clamp(int(std::ceil(highHz / bw)) + n / 2, 0, n - 1);
+    if (hiBin <= loBin) {
+        return std::nullopt;
+    }
+
+    double sum = 0.0;
+    for (int k = loBin; k <= hiBin; ++k) {
+        sum += power[std::size_t(k)];
+    }
+    const double enbw = analyzer.window().enbwBins;
+    const double p = (enbw > 0.0) ? (sum / enbw) : sum;
+    if (p <= 0.0) {
+        return std::nullopt;
+    }
+
+    BandPower out;
+    out.lowHz = lowHz;
+    out.highHz = highHz;
+    out.powerDb = 10.0 * std::log10(p);
+    out.dbcPerTone = out.powerDb - toneRefDb;
+    out.dbcPep = out.powerDb - pepDb;
+    return out;
+}
+
+LinearityResult measureTwoTone(const TxSpectrumAnalyzer& analyzer,
+                               double sampleRateHz,
+                               const ImdConfig& config,
+                               bool clipped)
+{
+    LinearityResult r;
+    r.sampleRateHz = sampleRateHz;
+    r.fftSize = analyzer.fftSize();
+    r.averages = analyzer.averages();
+    r.clipped = clipped;
+
+    const std::vector<double>& power = analyzer.powerSpectrum();
+    const int n = int(power.size());
+    if (n < 16 || analyzer.averages() == 0 || sampleRateHz <= 0.0) {
+        r.invalidReason = "No averaged spectrum available";
+        return r;
+    }
+
+    r.binHz = TxSpectrumAnalyzer::binHz(sampleRateHz, n);
+    analyzer.toDb(r.spectrumDb);
+
+    const int lobe = std::max(1, analyzer.window().mainLobeHalfBins);
+    const int centre = n / 2;
+
+    // ── Fundamentals ────────────────────────────────────────────────────────
+    //
+    // Search the whole band except the DC notch, take the strongest bin, then
+    // blank its entire main lobe before searching again. Blanking the main lobe
+    // rather than a fixed span is what stops the second "tone" being the first
+    // tone's own skirt, which is the failure this loop exists to prevent.
+    std::vector<double> search = power;
+    for (int k = centre - config.dcNotchBins; k <= centre + config.dcNotchBins; ++k) {
+        if (k >= 0 && k < n) {
+            search[std::size_t(k)] = 0.0;
+        }
+    }
+
+    auto takePeak = [&](InterpolatedPeak& out) {
+        out = interpolatePeak(search, 1, n - 2, sampleRateHz);
+        if (!out.valid) {
+            return;
+        }
+        const int bin = std::clamp(int(std::lround(out.freqHz / r.binHz)) + centre, 0, n - 1);
+        for (int k = std::max(0, bin - lobe); k <= std::min(n - 1, bin + lobe); ++k) {
+            search[std::size_t(k)] = 0.0;
+        }
+    };
+
+    InterpolatedPeak p1;
+    InterpolatedPeak p2;
+    takePeak(p1);
+    takePeak(p2);
+    if (!p1.valid || !p2.valid) {
+        r.invalidReason = "Could not resolve two tones in the capture";
+        return r;
+    }
+
+    // Order them low-to-high so f1 < f2 and the product formulae below read as
+    // written rather than depending on which happened to be stronger.
+    if (p2.freqHz < p1.freqHz) {
+        std::swap(p1, p2);
+    }
+
+    r.tone1 = TonePeak{true, p1.freqHz, p1.powerDb};
+    r.tone2 = TonePeak{true, p2.freqHz, p2.powerDb};
+    r.toneSpacingHz = p2.freqHz - p1.freqHz;
+    r.toneImbalanceDb = p2.powerDb - p1.powerDb;
+
+    // Two peaks closer together than the window can separate are one tone read
+    // twice, whatever the blanking did.
+    if (r.toneSpacingHz < 2.0 * double(lobe) * r.binHz) {
+        r.invalidReason = "Tones are closer than the analysis window can resolve";
+        return r;
+    }
+
+    // ── PEP ─────────────────────────────────────────────────────────────────
+    //
+    // From the MEASURED amplitudes, not from tone power + 6.02 dB. For a
+    // balanced pair the two agree exactly (that is the §9 reference-convention
+    // test); for an imbalanced pair the envelope peak is A1 + A2 and the
+    // idealisation would be wrong in the direction that flatters the radio.
+    const double a1 = dbToAmplitude(r.tone1.powerDb);
+    const double a2 = dbToAmplitude(r.tone2.powerDb);
+    r.pepDb = 20.0 * std::log10(a1 + a2);
+
+    // The single-tone reference. With an imbalanced pair there is no one "the
+    // tone", so use the mean power of the two — it degrades to A^2 exactly when
+    // they are balanced, and it is the choice that keeps the reported
+    // per-tone/PEP pair self-consistent.
+    const double toneRefDb = 10.0 * std::log10(0.5 * (a1 * a1 + a2 * a2));
+
+    // ── Products ────────────────────────────────────────────────────────────
+    const double nyq = sampleRateHz / 2.0;
+    std::vector<int> guardCentres{
+        std::clamp(int(std::lround(r.tone1.freqHz / r.binHz)) + centre, 0, n - 1),
+        std::clamp(int(std::lround(r.tone2.freqHz / r.binHz)) + centre, 0, n - 1),
+        centre,  // DC / LO leakage is not noise either
+    };
+
+    struct Candidate {
+        int order;
+        bool upper;
+        double freqHz;
+    };
+    std::vector<Candidate> candidates;
+    for (int order = 3; order <= config.maxOrder; order += 2) {
+        // 2f1-f2 is d beyond f1; 3f1-2f2 is 2d beyond; generally
+        // ((order+1)/2)*f1 - ((order-1)/2)*f2 = f1 - ((order-1)/2)*d.
+        const double steps = double((order - 1) / 2);
+        candidates.push_back({order, false, r.tone1.freqHz - steps * r.toneSpacingHz});
+        candidates.push_back({order, true,  r.tone2.freqHz + steps * r.toneSpacingHz});
+    }
+
+    for (const Candidate& c : candidates) {
+        // A product predicted outside the capture band is not a missing
+        // measurement, it is an unmeasurable one — skip it silently rather than
+        // reporting the band-edge filter skirt as an IMD level.
+        if (std::abs(c.freqHz) > nyq - double(lobe) * r.binHz) {
+            continue;
+        }
+        const int predicted = std::clamp(
+            int(std::lround(c.freqHz / r.binHz)) + centre, 1, n - 2);
+        // Search only the main lobe around the predicted frequency. Wider would
+        // let a neighbouring spur be reported as the product; narrower would
+        // miss it when the tone estimates carry a fraction of a bin of error.
+        const InterpolatedPeak pk =
+            interpolatePeak(power, predicted - lobe, predicted + lobe, sampleRateHz);
+        if (!pk.valid) {
+            continue;
+        }
+
+        ImdProduct prod;
+        prod.order = c.order;
+        prod.upper = c.upper;
+        prod.freqHz = pk.freqHz;
+        prod.powerDb = pk.powerDb;
+        prod.dbcPerTone = pk.powerDb - toneRefDb;
+        prod.dbcPep = pk.powerDb - r.pepDb;
+        r.products.push_back(prod);
+
+        guardCentres.push_back(
+            std::clamp(int(std::lround(pk.freqHz / r.binHz)) + centre, 0, n - 1));
+    }
+
+    // ── Instrument noise floor ──────────────────────────────────────────────
+    //
+    // Computed AFTER the products are located so their skirts are excluded from
+    // the guard set. Excluding twice the main lobe leaves the window's own
+    // sidelobe structure out of the estimate too, which would otherwise make
+    // the floor look band-dependent rather than being a property of the
+    // instrument.
+    r.noiseFloorDb = estimateNoiseFloorDb(power, guardCentres, 2 * lobe);
+    for (ImdProduct& prod : r.products) {
+        prod.limitedByNoiseFloor =
+            (prod.powerDb < r.noiseFloorDb + config.noiseFloorMarginDb);
+    }
+
+    // ── Shoulder and ACPR ───────────────────────────────────────────────────
+    if (config.measureShoulder && config.shoulderBandwidthHz > 0.0) {
+        const double half = config.shoulderBandwidthHz / 2.0;
+        r.shoulderLow = integrateBand(analyzer, sampleRateHz,
+                                      r.tone1.freqHz - config.shoulderOffsetHz - half,
+                                      r.tone1.freqHz - config.shoulderOffsetHz + half,
+                                      toneRefDb, r.pepDb);
+        r.shoulderHigh = integrateBand(analyzer, sampleRateHz,
+                                       r.tone2.freqHz + config.shoulderOffsetHz - half,
+                                       r.tone2.freqHz + config.shoulderOffsetHz + half,
+                                       toneRefDb, r.pepDb);
+    }
+    if (config.measureAcpr && config.acprBandwidthHz > 0.0) {
+        // Occupied channel: the tone pair widened by half the spacing at each
+        // end, which is where an SSB two-tone's own energy stops and the
+        // distortion skirt starts.
+        const double chanLow = r.tone1.freqHz - r.toneSpacingHz / 2.0;
+        const double chanHigh = r.tone2.freqHz + r.toneSpacingHz / 2.0;
+        const double lowEdge = chanLow - config.acprGapHz;
+        const double highEdge = chanHigh + config.acprGapHz;
+        r.acprLow = integrateBand(analyzer, sampleRateHz,
+                                  lowEdge - config.acprBandwidthHz, lowEdge,
+                                  toneRefDb, r.pepDb);
+        r.acprHigh = integrateBand(analyzer, sampleRateHz,
+                                   highEdge, highEdge + config.acprBandwidthHz,
+                                   toneRefDb, r.pepDb);
+    }
+
+    r.valid = true;
+    return r;
+}
+
+}  // namespace AetherSDR::txlin

--- a/src/core/txlinearity/ImdAnalyzer.h
+++ b/src/core/txlinearity/ImdAnalyzer.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "TxLinearityTypes.h"
+#include "TxSpectrumAnalyzer.h"
+
+namespace AetherSDR::txlin {
+
+// Two-tone intermodulation measurement over an averaged spectrum.
+//
+// For two tones at f1 and f2 with spacing d = f2 - f1, the odd-order products
+// fall symmetrically outside the pair:
+//
+//   order | lower      | upper
+//   ------+------------+-----------
+//     3   | 2f1 - f2   | 2f2 - f1      (d beyond each tone)
+//     5   | 3f1 - 2f2  | 3f2 - 2f1     (2d beyond)
+//     7   | 4f1 - 3f2  | 4f2 - 3f1     (3d beyond)
+//
+// Even-order products land at DC and at 2f, far outside the capture band on a
+// baseband IQ capture of an SSB signal, so they are not measured here — their
+// absence is a property of the signal path, not an omission.
+struct ImdConfig {
+    // Highest odd order to report. 7 is the practical limit for a feedback path
+    // with ~80 dB of dynamic range; beyond that the products are below any
+    // realistic instrument floor and reporting them invites reading noise as a
+    // measurement.
+    int maxOrder = 7;
+
+    // A product peak must clear the measured instrument noise floor by this
+    // much for the number to be trusted. Below it the product is flagged
+    // limitedByNoiseFloor and the UI says so rather than printing the figure as
+    // though it were a measurement. 6 dB is the conventional "you can see it
+    // but do not quote it" threshold; the value at the floor itself is a coin
+    // flip between signal and noise.
+    double noiseFloorMarginDb = 6.0;
+
+    // Beyond this the two tones are unbalanced enough that the symmetric-IMD
+    // interpretation and the exact 6.02 dB PEP relation both stop holding.
+    double toneImbalanceWarnDb = 0.5;
+
+    // Ignore this many bins either side of exact DC when searching for the
+    // fundamentals. A direct-conversion feedback path puts an LO-leakage spike
+    // at DC that is not a tone; without this it can win the "two strongest
+    // peaks" search outright. Deliberately narrow — a genuine tone only a few
+    // bins from DC is unmeasurable anyway, since its window skirt wraps.
+    int dcNotchBins = 3;
+
+    // Shoulder measurement: a band `shoulderBandwidthHz` wide, centred
+    // `shoulderOffsetHz` outside each fundamental. The shoulder is where the
+    // IMD skirt plateaus, so it characterises the splatter an adjacent operator
+    // actually hears — which the discrete product levels do not.
+    double shoulderOffsetHz = 5000.0;
+    double shoulderBandwidthHz = 1000.0;
+
+    // ACPR: a band `acprBandwidthHz` wide, starting `acprGapHz` outside the
+    // occupied channel. The occupied channel is taken as the tone pair widened
+    // by half the tone spacing at each end.
+    double acprGapHz = 1000.0;
+    double acprBandwidthHz = 3000.0;
+
+    // Set false to skip shoulder/ACPR when the capture bandwidth cannot hold
+    // the bands (the analyzer also refuses on its own and leaves the optional
+    // results disengaged rather than reporting a truncated integration).
+    bool measureShoulder = true;
+    bool measureAcpr = true;
+};
+
+// Run the full reference-free (Phase 1) measurement.
+//
+// `clipped` is the capture path's overload verdict, carried through so the
+// result records that the numbers came from a saturated capture even though
+// the arithmetic itself cannot tell.
+//
+// Returns a result with valid == false and a populated invalidReason whenever
+// the spectrum cannot support a measurement — no averages, fewer than two
+// resolvable tones, tones too close to separate, products falling outside the
+// capture band. Refusing is a first-class outcome; this function never
+// fabricates a figure to have something to display.
+LinearityResult measureTwoTone(const TxSpectrumAnalyzer& analyzer,
+                               double sampleRateHz,
+                               const ImdConfig& config,
+                               bool clipped);
+
+// Integrated power over [lowHz, highHz] of a DC-centred power spectrum,
+// expressed against both reference conventions.
+//
+// Exposed because the UI marks these bands on the plot and must integrate
+// exactly what it draws. sum(|S[k]|^2)/enbwBins is correct for a discrete tone
+// and for a noise-like band alike — see AnalysisWindow for why.
+std::optional<BandPower> integrateBand(const TxSpectrumAnalyzer& analyzer,
+                                       double sampleRateHz,
+                                       double lowHz, double highHz,
+                                       double toneRefDb, double pepDb);
+
+}  // namespace AetherSDR::txlin

--- a/src/core/txlinearity/SpectrumWindow.cpp
+++ b/src/core/txlinearity/SpectrumWindow.cpp
@@ -1,0 +1,134 @@
+#include "SpectrumWindow.h"
+
+#include <array>
+#include <cmath>
+#include <numbers>
+
+namespace AetherSDR::txlin {
+namespace {
+
+// Cosine-sum window: w[n] = sum_j (-1)^j a_j cos(2*pi*j*n/N).
+//
+// PERIODIC form (divisor N, not N-1). For spectral analysis the periodic window
+// is the correct one — it is the sampled version of the continuous window that
+// makes the DFT's implicit periodic extension seamless. The symmetric (N-1)
+// form belongs to FIR filter design; using it here leaves a one-sample
+// discontinuity that raises the far sidelobes by tens of dB and would quietly
+// undo the entire reason for choosing a -92 dB window.
+template <std::size_t K>
+std::vector<double> cosineSum(const std::array<double, K>& a, std::size_t n)
+{
+    std::vector<double> w(n, 0.0);
+    for (std::size_t i = 0; i < n; ++i) {
+        double v = 0.0;
+        double sign = 1.0;
+        for (std::size_t j = 0; j < K; ++j) {
+            v += sign * a[j]
+                 * std::cos(2.0 * std::numbers::pi * double(j) * double(i) / double(n));
+            sign = -sign;
+        }
+        w[i] = v;
+    }
+    return w;
+}
+
+// Harris 1978, Table 1 / eq. 33: 4-term minimum-sidelobe Blackman-Harris.
+constexpr std::array<double, 4> kBh4{0.35875, 0.48829, 0.14128, 0.01168};
+
+// 7-term minimum-sidelobe extension of the same family. ~-92 dB peak sidelobe
+// with a far-sidelobe rolloff steep enough that a tone 60 dB down is not
+// contaminated by the neighbouring tone's skirt at the IMD3 offsets.
+constexpr std::array<double, 7> kBh7{0.27105140069342,
+                                     0.43329793923448,
+                                     0.21812299954311,
+                                     0.06592544638803,
+                                     0.01081174209837,
+                                     0.00077658482522,
+                                     0.00001388721735};
+
+// Hann as a 2-term cosine sum, for comparison only.
+constexpr std::array<double, 2> kHann{0.5, 0.5};
+
+// SRS/HP flat-top: amplitude-flat across a bin at the cost of a very wide main
+// lobe. Useful when the operator cares about absolute tone amplitude more than
+// about separating close products.
+constexpr std::array<double, 5> kFlatTop{0.21557895, 0.41663158, 0.277263158,
+                                         0.083578947, 0.006947368};
+
+}  // namespace
+
+AnalysisWindow makeWindow(WindowKind kind, std::size_t n)
+{
+    AnalysisWindow win;
+    if (n < 2) {
+        return win;
+    }
+
+    switch (kind) {
+    case WindowKind::BlackmanHarris7:
+        win.taps = cosineSum(kBh7, n);
+        win.nominalSidelobeDb = -92.0;
+        win.mainLobeHalfBins = int(kBh7.size());
+        break;
+    case WindowKind::BlackmanHarris4:
+        win.taps = cosineSum(kBh4, n);
+        win.nominalSidelobeDb = -92.0;
+        win.mainLobeHalfBins = int(kBh4.size());
+        break;
+    case WindowKind::Hann:
+        win.taps = cosineSum(kHann, n);
+        win.nominalSidelobeDb = -31.5;
+        win.mainLobeHalfBins = int(kHann.size());
+        break;
+    case WindowKind::FlatTop:
+        win.taps = cosineSum(kFlatTop, n);
+        win.nominalSidelobeDb = -93.6;
+        win.mainLobeHalfBins = int(kFlatTop.size());
+        break;
+    }
+
+    double sum = 0.0;
+    double sumSq = 0.0;
+    for (double t : win.taps) {
+        sum += t;
+        sumSq += t * t;
+    }
+    win.sumTaps = sum;
+    win.coherentGain = sum / double(n);
+    // Guard against a degenerate window rather than emitting inf/NaN into the
+    // measurement arithmetic: every caller divides by enbwBins.
+    win.enbwBins = (sum != 0.0) ? (double(n) * sumSq / (sum * sum)) : 1.0;
+    return win;
+}
+
+std::string windowKindKey(WindowKind kind)
+{
+    switch (kind) {
+    case WindowKind::BlackmanHarris7: return "blackman-harris-7";
+    case WindowKind::BlackmanHarris4: return "blackman-harris-4";
+    case WindowKind::Hann:            return "hann";
+    case WindowKind::FlatTop:         return "flat-top";
+    }
+    return "blackman-harris-7";
+}
+
+WindowKind windowKindFromKey(const std::string& key)
+{
+    if (key == "blackman-harris-4") { return WindowKind::BlackmanHarris4; }
+    if (key == "hann")              { return WindowKind::Hann; }
+    if (key == "flat-top")          { return WindowKind::FlatTop; }
+    return WindowKind::BlackmanHarris7;
+}
+
+std::string windowKindLabel(WindowKind kind)
+{
+    switch (kind) {
+    case WindowKind::BlackmanHarris7: return "Blackman-Harris 7";
+    case WindowKind::BlackmanHarris4: return "Blackman-Harris 4";
+    case WindowKind::Hann:            return "Hann";
+    case WindowKind::FlatTop:         return "Flat Top";
+    }
+    return "Blackman-Harris 7";
+}
+
+}  // namespace AetherSDR::txlin

--- a/src/core/txlinearity/SpectrumWindow.h
+++ b/src/core/txlinearity/SpectrumWindow.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace AetherSDR::txlin {
+
+// Analysis windows for the TX linearity analyzer, with the two correction
+// factors that make a bin magnitude mean something.
+//
+// WHY THIS IS ITS OWN FILE, AND WHY THE DEFAULT IS WHAT IT IS.
+//
+// Window choice matters more than any other single decision in this analyzer.
+// The measurement is "how far below the tones do the distortion products sit",
+// and a window's own spectral leakage puts a skirt around each tone that reads
+// exactly like a distortion product. Hann's first sidelobe is -31 dB and its
+// skirt falls at 18 dB/octave; against a -40 dBc IMD3 that is not a small
+// error, it is the entire measurement. Anything below roughly -50 dBc simply
+// cannot be seen through a Hann window no matter how many averages are taken,
+// because leakage is coherent and averaging does not reduce it.
+//
+// The default is therefore the 7-term Blackman-Harris (about -92 dB peak
+// sidelobe), which puts the window's own contribution far below the -60 to
+// -70 dBc region where a well-behaved amplifier's IMD3 actually lives. It costs
+// resolution — the main lobe is wide — but resolution is cheap here (11.7 Hz
+// bins at 192 kHz with a 16k transform) and dynamic range is not.
+//
+// The window is selectable because a wider main lobe genuinely hurts when tone
+// spacing is small, but the default exists for the reason above: nobody should
+// "optimize" it back to Hann and quietly cap the instrument at -50 dBc.
+//
+// Coefficients: Harris, "On the Use of Windows for Harmonic Analysis with the
+// Discrete Fourier Transform", Proc. IEEE 66(1), 1978, and the 7-term minimum
+// sidelobe extension tabulated in Rabiner & Gold / used throughout the SDR
+// literature. Derived here from the published cosine-sum coefficients rather
+// than copied from any implementation.
+enum class WindowKind {
+    BlackmanHarris7,  // ~-92 dB sidelobes. The default; see above.
+    BlackmanHarris4,  // ~-92 dB nominal, narrower main lobe than the 7-term
+    Hann,             // ~-31 dB. Offered for comparison, never as the default.
+    FlatTop,          // amplitude-accurate, very wide main lobe
+};
+
+// A window plus everything needed to convert bin magnitudes into physical
+// quantities.
+//
+//   coherentGain = sum(w)/N        — divide an amplitude spectrum by sum(w) to
+//                                    recover a tone's true amplitude.
+//   enbwBins     = N*sum(w^2)/sum(w)^2
+//                                  — the width, in bins, of the ideal
+//                                    rectangular filter with the same noise
+//                                    power gain. Integrated band power is
+//                                    sum(|S[k]|^2)/enbwBins; that one
+//                                    expression is correct for BOTH a discrete
+//                                    tone and a noise-like band (Parseval:
+//                                    sum_k |W(k)|^2 = N*sum_n w[n]^2), which is
+//                                    why ACPR, shoulder and tone power all go
+//                                    through it.
+struct AnalysisWindow {
+    std::vector<double> taps;
+    double sumTaps = 0.0;
+    double coherentGain = 1.0;
+    double enbwBins = 1.0;
+    // Nominal peak sidelobe level, dB. Documentation and the leakage
+    // regression's expectation — not used in any signal-path arithmetic.
+    double nominalSidelobeDb = 0.0;
+    // Half-width of the main lobe in bins. For a K-term cosine-sum window the
+    // main lobe spans exactly +/-K bins, which is why this is an integer and
+    // not a measurement. Everything that needs "how far from this tone is still
+    // this tone" uses it: separating the two fundamentals, excluding tone
+    // skirts from the noise-floor estimate, and sizing the search window around
+    // each predicted IMD frequency.
+    int mainLobeHalfBins = 1;
+};
+
+// Build a window of `n` taps. `n` must be >= 2; smaller returns an empty
+// window with unity factors, which the analyzer rejects up front.
+AnalysisWindow makeWindow(WindowKind kind, std::size_t n);
+
+// Stable identifiers for settings persistence and CSV export stamps. Round-trip
+// with windowKindFromKey(); an unknown key falls back to the default rather
+// than throwing, because a corrupt settings value must not stop the app.
+std::string windowKindKey(WindowKind kind);
+WindowKind windowKindFromKey(const std::string& key);
+
+// Display names for the UI, matching the on-screen label convention.
+std::string windowKindLabel(WindowKind kind);
+
+}  // namespace AetherSDR::txlin

--- a/src/core/txlinearity/TxLinearityController.cpp
+++ b/src/core/txlinearity/TxLinearityController.cpp
@@ -1,0 +1,318 @@
+#include "TxLinearityController.h"
+
+#include "TxSpectrumAnalyzer.h"
+#include "core/LogManager.h"
+
+#include <QStringList>
+#include <QTimer>
+
+namespace AetherSDR::txlin {
+namespace {
+
+// Interlock evaluation cadence. Fast enough that the hard timeout is honoured
+// to within a tick, slow enough to be free. Deliberately independent of the
+// telemetry arrival rate — see the header.
+constexpr int kTickMs = 100;
+
+}  // namespace
+
+// ── TxAnalysisWorker ────────────────────────────────────────────────────────
+
+TxAnalysisWorker::TxAnalysisWorker(int fftSize, WindowKind window, ImdConfig imd,
+                                   int targetAverages)
+    : m_imd(imd), m_targetAverages(targetAverages > 0 ? targetAverages : 1), m_fftSize(fftSize)
+{
+    m_analyzer = std::make_unique<TxSpectrumAnalyzer>(fftSize, window);
+}
+
+TxAnalysisWorker::~TxAnalysisWorker() = default;
+
+void TxAnalysisWorker::submit(CaptureFrame&& frame)
+{
+    // A refused push is a dropped frame, counted by the ring. Dropping is
+    // harmless for a Welch average and vastly preferable to blocking the
+    // thread that is servicing the radio's stream.
+    m_ring.push(std::move(frame));
+}
+
+void TxAnalysisWorker::resetAverages()
+{
+    m_analyzer->reset();
+    m_clippedSinceReset = false;
+    m_sampleRateHz = 0.0;
+    // The ring may still hold frames from the previous run. Draining them here
+    // would fold pre-reset samples into the new average.
+    CaptureFrame stale;
+    while (m_ring.pop(stale)) {
+    }
+}
+
+void TxAnalysisWorker::drain()
+{
+    CaptureFrame frame;
+    bool any = false;
+    while (m_ring.pop(frame)) {
+        if (int(frame.feedback.size()) != m_fftSize) {
+            continue;
+        }
+        // A rate change mid-run invalidates the accumulated average: the bins
+        // no longer mean the same frequencies.
+        if (m_sampleRateHz != 0.0 && frame.sampleRateHz != m_sampleRateHz) {
+            m_analyzer->reset();
+            m_clippedSinceReset = false;
+        }
+        m_sampleRateHz = frame.sampleRateHz;
+        m_clippedSinceReset = m_clippedSinceReset || frame.clipped;
+        if (m_analyzer->accumulate(frame.feedback)) {
+            any = true;
+        }
+    }
+    if (!any) {
+        return;
+    }
+
+    emit progress(m_analyzer->averages(), m_targetAverages);
+    if (m_analyzer->averages() < m_targetAverages) {
+        return;
+    }
+
+    const LinearityResult result =
+        measureTwoTone(*m_analyzer, m_sampleRateHz, m_imd, m_clippedSinceReset);
+    emit resultReady(result);
+}
+
+// ── TxLinearityController ───────────────────────────────────────────────────
+
+TxLinearityController::TxLinearityController(QObject* parent) : QObject(parent)
+{
+    qRegisterMetaType<AetherSDR::txlin::LinearityResult>();
+    qRegisterMetaType<AetherSDR::txlin::AbortReason>();
+    m_clock.start();
+    m_tick = new QTimer(this);
+    m_tick->setInterval(kTickMs);
+    connect(m_tick, &QTimer::timeout, this, &TxLinearityController::tick);
+}
+
+TxLinearityController::~TxLinearityController()
+{
+    // The last line of defence. If anything above unwound past stopRun(), the
+    // radio still stops transmitting here rather than staying keyed because an
+    // object went away.
+    releaseKey();
+    teardown();
+}
+
+qint64 TxLinearityController::nowMs() const
+{
+    return m_clock.elapsed();
+}
+
+void TxLinearityController::setCaptureSource(ITxCaptureSource* source)
+{
+    if (m_running) {
+        stopRun(AbortReason::OperatorStop);
+    }
+    m_source = source;
+}
+
+PreflightResult TxLinearityController::preflight(const RunRequest& request) const
+{
+    RunRequest req = request;
+    req.captureReady = req.captureReady && (m_source != nullptr);
+    return m_safety.preflight(nowMs(), req);
+}
+
+bool TxLinearityController::startRun(const RunRequest& request, const RunConfig& config)
+{
+    // Preflight is run HERE, not merely offered to the caller, so there is no
+    // code path that transmits without it.
+    const PreflightResult pre = preflight(request);
+    if (!pre.ok()) {
+        QStringList warnings;
+        for (const std::string& w : pre.warnings) {
+            warnings << QString::fromStdString(w);
+        }
+        emit refused(QString::fromStdString(pre.message), warnings);
+        return false;
+    }
+    if (m_source == nullptr || m_keyRequest == nullptr) {
+        emit refused(QStringLiteral("The analyzer is not wired to a radio"), {});
+        return false;
+    }
+
+    m_config = config;
+
+    // Analysis thread first: if it cannot be brought up, nothing has been keyed
+    // and there is nothing to unwind.
+    m_worker = new TxAnalysisWorker(config.capture.frameSamples, config.window,
+                                    config.imd, config.targetAverages);
+    m_worker->moveToThread(&m_analysisThread);
+    connect(&m_analysisThread, &QThread::finished, m_worker, &QObject::deleteLater);
+    // The run ends the moment it has the averages it asked for. Publishing the
+    // result and then continuing to transmit would be a longer emission than
+    // the measurement needs, which §8 has no interest in permitting.
+    connect(m_worker, &TxAnalysisWorker::resultReady, this,
+            [this](const LinearityResult& result) {
+                emit resultReady(result);
+                stopRun(AbortReason::None);
+            });
+    connect(m_worker, &TxAnalysisWorker::progress, this, &TxLinearityController::progress);
+    m_analysisThread.start();
+
+    m_source->setFrameCallback([this](const CaptureFrame& frame) {
+        // Runs on the thread delivering IQ. Copy into the ring and return: no
+        // DSP, no allocation beyond the frame's own buffer, no signal emission.
+        if (m_worker != nullptr) {
+            CaptureFrame copy = frame;
+            m_worker->submit(std::move(copy));
+        }
+    });
+    m_source->setErrorCallback([this](const std::string& reason) {
+        qCWarning(lcTransmit) << "TxLinearityController: capture error —"
+                              << QString::fromStdString(reason);
+        // Queued so the abort runs on the controller's thread even when the
+        // capture path reports from another one.
+        QMetaObject::invokeMethod(this, [this] { stopRun(AbortReason::CaptureLost); },
+                                  Qt::QueuedConnection);
+    });
+
+    if (!m_source->start(config.capture)) {
+        teardown();
+        emit refused(QStringLiteral("The TX capture stream could not be started"), {});
+        return false;
+    }
+
+    // Key LAST, once every non-transmitting prerequisite has succeeded. A
+    // failure after this point unkeys; a failure before it never keyed.
+    if (!m_keyRequest(true)) {
+        teardown();
+        emit refused(QStringLiteral("The radio refused the transmit request"), {});
+        return false;
+    }
+    m_keyed = true;
+    m_keyedAtMs = nowMs();
+    m_gateOpened = false;
+    m_running = true;
+    m_safety.noteRunStarted(m_keyedAtMs);
+    m_tick->start();
+
+    qCInfo(lcTransmit) << "TxLinearityController: run started, timeout"
+                       << m_safety.limits().maxTransmitMs << "ms, target averages"
+                       << config.targetAverages;
+    emit runStateChanged(true);
+    return true;
+}
+
+void TxLinearityController::stopRun(AbortReason reason)
+{
+    if (!m_running && !m_keyed) {
+        return;
+    }
+    // UNKEY FIRST. Everything below this line is bookkeeping and none of it is
+    // allowed to sit between the decision to stop and the radio actually
+    // stopping.
+    releaseKey();
+
+    const bool wasRunning = m_running;
+    m_running = false;
+    m_tick->stop();
+    m_safety.noteRunStopped(nowMs());
+    teardown();
+
+    if (wasRunning) {
+        qCInfo(lcTransmit) << "TxLinearityController: run stopped —"
+                           << QString::fromStdString(abortReasonText(reason));
+        emit runStateChanged(false);
+        // None is a completed measurement and OperatorStop is a deliberate
+        // one; neither is an abort the operator needs told about.
+        if (reason != AbortReason::None && reason != AbortReason::OperatorStop) {
+            emit aborted(reason, QString::fromStdString(abortReasonText(reason)));
+        }
+    }
+}
+
+void TxLinearityController::releaseKey()
+{
+    if (!m_keyed) {
+        return;
+    }
+    m_keyed = false;
+    if (m_keyRequest != nullptr) {
+        m_keyRequest(false);
+    }
+}
+
+void TxLinearityController::teardown()
+{
+    if (m_source != nullptr) {
+        // Clear the callbacks before stopping so a frame already in flight
+        // cannot reach a worker that is about to be deleted.
+        m_source->setFrameCallback(nullptr);
+        m_source->setErrorCallback(nullptr);
+        m_source->stop();
+    }
+    if (m_analysisThread.isRunning()) {
+        m_analysisThread.quit();
+        m_analysisThread.wait();
+    }
+    m_worker = nullptr;   // deleteLater'd by the thread's finished signal
+    m_gateOpened = false;
+}
+
+void TxLinearityController::tick()
+{
+    if (!m_running) {
+        return;
+    }
+    const qint64 now = nowMs();
+
+    // Open the capture gate once the post-key settling guard has elapsed. PA
+    // thermal and ALC settling after key-down are transients; averaging them
+    // into a steady-state distortion measurement reports the transient as
+    // distortion. The gate lives on the source; the controller only decides
+    // when, so a source with nothing to gate ignores it.
+    if (!m_gateOpened && (now - m_keyedAtMs) >= qint64(m_config.capture.settleMsAfterKey)) {
+        m_gateOpened = true;
+        if (m_worker != nullptr) {
+            QMetaObject::invokeMethod(m_worker, "resetAverages", Qt::QueuedConnection);
+        }
+        m_source->setGateOpen(true);
+        emit progress(0, m_config.targetAverages);
+    }
+
+    // Close it again before the hard timeout. A run that reaches its target
+    // averages has already stopped by now, so this only affects a run being cut
+    // short — where the last frames are taken right as the deadline arrives and
+    // are the least trustworthy in the capture.
+    if (m_gateOpened) {
+        const qint64 remaining =
+            qint64(m_safety.limits().maxTransmitMs) - (now - m_keyedAtMs);
+        if (remaining <= qint64(m_config.capture.settleMsBeforeUnkey)) {
+            m_source->setGateOpen(false);
+        }
+    }
+
+    // Interlocks. The timeout inside evaluate() depends on nothing but the
+    // clock, so it fires even with no telemetry at all.
+    TelemetrySnapshot snap;
+    if (m_telemetry != nullptr) {
+        snap = m_telemetry();
+    } else {
+        // No telemetry provider wired is not permission to transmit blind: keep
+        // the stamp current so only the timeout governs, and log it once at
+        // start rather than aborting a run the operator explicitly asked for on
+        // a radio that publishes no meters.
+        snap.lastUpdateMs = now;
+    }
+    const AbortReason reason = m_safety.evaluate(now, snap.telemetry, snap.lastUpdateMs);
+    if (reason != AbortReason::None) {
+        stopRun(reason);
+        return;
+    }
+
+    if (m_worker != nullptr && m_gateOpened) {
+        QMetaObject::invokeMethod(m_worker, "drain", Qt::QueuedConnection);
+    }
+}
+
+}  // namespace AetherSDR::txlin

--- a/src/core/txlinearity/TxLinearityController.h
+++ b/src/core/txlinearity/TxLinearityController.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#include "CaptureRing.h"
+#include "ITxCaptureSource.h"
+#include "ImdAnalyzer.h"
+#include "SpectrumWindow.h"
+#include "TxLinearitySafety.h"
+
+#include <QElapsedTimer>
+#include <QObject>
+#include <QString>
+#include <QThread>
+
+#include <functional>
+#include <memory>
+
+class QTimer;
+
+namespace AetherSDR::txlin {
+
+// Analysis worker. Lives on its own thread and does every transform.
+//
+// Separate from the controller so the FFT work is structurally incapable of
+// running on the GUI thread — a 16384-point transform every few milliseconds
+// would stall the panadapter, and a stalled GUI while the radio is keyed is
+// exactly the condition in which an operator cannot press Stop.
+class TxAnalysisWorker : public QObject {
+    Q_OBJECT
+
+public:
+    TxAnalysisWorker(int fftSize, WindowKind window, ImdConfig imd, int targetAverages);
+    ~TxAnalysisWorker() override;
+
+    // Producer side, called from the capture thread. Never blocks.
+    void submit(CaptureFrame&& frame);
+
+public slots:
+    // Drain whatever the ring holds and, once enough frames have averaged,
+    // publish a result. Invoked via a queued connection from the controller's
+    // tick so the worker owns no timer of its own.
+    void drain();
+    void resetAverages();
+
+signals:
+    void resultReady(const AetherSDR::txlin::LinearityResult& result);
+    void progress(int averages, int target);
+
+private:
+    std::unique_ptr<class TxSpectrumAnalyzer> m_analyzer;
+    ImdConfig m_imd;
+    int m_targetAverages = 8;
+    int m_fftSize = 0;
+    double m_sampleRateHz = 0.0;
+    bool m_clippedSinceReset = false;
+    CaptureRing<CaptureFrame> m_ring{16};
+};
+
+// Orchestrates one linearity measurement: preflight, key, settle, capture,
+// analyze, unkey.
+//
+// The radio-facing operations are injected as callables rather than taken as
+// model pointers. That keeps the whole of `txlinearity` free of RadioModel and
+// TransmitModel — the seam that lets the same controller drive an HPSDR
+// backend later — and it means the run logic can be exercised in a test with
+// two lambdas and no radio.
+//
+// TRANSMIT DISCIPLINE. Constitution Principle VI: every path fails closed.
+// - stopRun() releases the key as its FIRST action, before touching capture,
+//   timers, or state, and is idempotent. It is never the tail of a function
+//   that can return early.
+// - The destructor releases the key too, so an unwind that skips stopRun()
+//   still cannot leave the radio transmitting.
+// - Loss of the capture stream is an immediate abort, not a degraded mode.
+// - The transmit timeout is checked on a timer that depends on nothing except
+//   the clock, so a radio that has gone completely silent is still unkeyed.
+class TxLinearityController : public QObject {
+    Q_OBJECT
+
+public:
+    struct RunConfig {
+        CaptureConfig capture;
+        ImdConfig imd;
+        WindowKind window = WindowKind::BlackmanHarris7;
+        // Welch averages to collect before the run finishes on its own. The
+        // hard transmit timeout still wins: a run that cannot reach this count
+        // inside the timeout is cut short with however many it got, and the
+        // result says so.
+        int targetAverages = 8;
+    };
+
+    struct TelemetrySnapshot {
+        TxTelemetry telemetry;
+        qint64 lastUpdateMs = 0;
+    };
+
+    // Returns false if the radio refused; the controller then aborts the run
+    // rather than assuming the key took.
+    using KeyRequest = std::function<bool(bool key)>;
+    using TelemetryProvider = std::function<TelemetrySnapshot()>;
+
+    explicit TxLinearityController(QObject* parent = nullptr);
+    ~TxLinearityController() override;
+
+    // The controller does not own the source; the UI does, because the source
+    // needs Qt signal wiring to the radio that the controller deliberately has
+    // no access to.
+    void setCaptureSource(ITxCaptureSource* source);
+    [[nodiscard]] ITxCaptureSource* captureSource() const { return m_source; }
+
+    void setKeyRequest(KeyRequest fn) { m_keyRequest = std::move(fn); }
+    void setTelemetryProvider(TelemetryProvider fn) { m_telemetry = std::move(fn); }
+
+    [[nodiscard]] TxLinearitySafety& safety() { return m_safety; }
+    [[nodiscard]] const TxLinearitySafety& safety() const { return m_safety; }
+
+    [[nodiscard]] PreflightResult preflight(const RunRequest& request) const;
+
+    // Runs preflight itself and refuses if it does not pass — a caller cannot
+    // skip the interlocks by not calling preflight().
+    bool startRun(const RunRequest& request, const RunConfig& config);
+    void stopRun(AbortReason reason = AbortReason::OperatorStop);
+
+    [[nodiscard]] bool running() const { return m_running; }
+    [[nodiscard]] qint64 nowMs() const;
+
+signals:
+    void runStateChanged(bool running);
+    void resultReady(const AetherSDR::txlin::LinearityResult& result);
+    void progress(int averages, int target);
+    void aborted(AetherSDR::txlin::AbortReason reason, const QString& text);
+    // Emitted when preflight refuses, so the UI has one place to show refusals
+    // whether they came from the explicit call or from startRun().
+    void refused(const QString& message, const QStringList& warnings);
+
+private:
+    void tick();
+    void releaseKey();
+    void teardown();
+
+    ITxCaptureSource* m_source = nullptr;
+    KeyRequest m_keyRequest;
+    TelemetryProvider m_telemetry;
+
+    TxLinearitySafety m_safety;
+    RunConfig m_config;
+
+    bool m_running = false;
+    bool m_keyed = false;
+    bool m_gateOpened = false;
+    qint64 m_keyedAtMs = 0;
+
+    QElapsedTimer m_clock;
+    QTimer* m_tick = nullptr;
+    QThread m_analysisThread;
+    TxAnalysisWorker* m_worker = nullptr;
+};
+
+}  // namespace AetherSDR::txlin
+
+Q_DECLARE_METATYPE(AetherSDR::txlin::LinearityResult)
+Q_DECLARE_METATYPE(AetherSDR::txlin::AbortReason)

--- a/src/core/txlinearity/TxLinearitySafety.cpp
+++ b/src/core/txlinearity/TxLinearitySafety.cpp
@@ -1,0 +1,226 @@
+#include "TxLinearitySafety.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR::txlin {
+namespace {
+
+// Advisory clearance between the occupied span and the allocation edge. Below
+// this the run is still permitted — the products are inside the band — but the
+// operator is told, because the tone estimates and the radio's own filtering
+// both carry uncertainty and "just inside" is not a comfortable place to put a
+// -30 dBc product.
+constexpr double kBandEdgeWarnHz = 500.0;
+
+std::string hzText(double hz)
+{
+    // Plain kHz with three decimals: this text goes into operator-facing
+    // refusal messages, where a raw float in Hz is unreadable.
+    char buf[64];
+    std::snprintf(buf, sizeof(buf), "%.3f kHz", hz / 1000.0);
+    return std::string(buf);
+}
+
+}  // namespace
+
+std::string abortReasonText(AbortReason reason)
+{
+    switch (reason) {
+    case AbortReason::None:             return "";
+    case AbortReason::TransmitTimeout:  return "Transmit timeout reached";
+    case AbortReason::HighSwr:          return "SWR above the configured limit";
+    case AbortReason::PaOverTemp:       return "PA temperature above the configured limit";
+    case AbortReason::LowSupplyVoltage: return "Supply voltage below the configured limit";
+    case AbortReason::TelemetryStale:   return "Radio telemetry stopped updating";
+    case AbortReason::CaptureLost:      return "Capture stream lost";
+    case AbortReason::OperatorStop:     return "Stopped by the operator";
+    }
+    return "";
+}
+
+bool TxLinearitySafety::setLimits(const SafetyLimits& limits, bool allowOverride)
+{
+    if (!allowOverride) {
+        if (limits.maxTransmitMs > m_limits.maxTransmitMs) {
+            return false;
+        }
+        if (limits.minCooldownMs < m_limits.minCooldownMs) {
+            return false;
+        }
+        if (limits.maxSwr > m_limits.maxSwr || limits.maxPaTempC > m_limits.maxPaTempC) {
+            return false;
+        }
+        if (limits.minSupplyVolts < m_limits.minSupplyVolts) {
+            return false;
+        }
+    }
+    m_limits = limits;
+    // A zero or negative timeout would mean "no timeout", which is the one
+    // configuration §8 does not allow to exist.
+    m_limits.maxTransmitMs = std::max(1, m_limits.maxTransmitMs);
+    m_limits.minCooldownMs = std::max(0, m_limits.minCooldownMs);
+    return true;
+}
+
+PreflightResult TxLinearitySafety::preflight(std::int64_t nowMs,
+                                             const RunRequest& request) const
+{
+    PreflightResult out;
+
+    const double lo = std::min(request.tone1Hz, request.tone2Hz);
+    const double hi = std::max(request.tone1Hz, request.tone2Hz);
+    const double spacing = hi - lo;
+    // Occupied span including the highest odd product the test generates:
+    // order N reaches ((N-1)/2) tone spacings beyond each tone.
+    const double reach = spacing * double(std::max(1, (request.maxOrder - 1) / 2));
+    out.occupiedLowHz = lo - reach;
+    out.occupiedHighHz = hi + reach;
+
+    // Order matters: report the condition the operator can act on first. A
+    // cooldown message while the real problem is an unconfirmed dummy load
+    // wastes 30 seconds before showing the actual blocker.
+    if (m_running) {
+        out.verdict = PreflightVerdict::AlreadyRunning;
+        out.message = "A measurement is already running";
+        return out;
+    }
+    if (spacing <= 0.0) {
+        out.verdict = PreflightVerdict::InvalidToneSpacing;
+        out.message = "The two test tones must be at different frequencies";
+        return out;
+    }
+    if (!request.captureReady) {
+        out.verdict = PreflightVerdict::NoCaptureSource;
+        out.message = "No TX capture source is running";
+        return out;
+    }
+    if (!m_dummyLoadConfirmed) {
+        out.verdict = PreflightVerdict::NoDummyLoadConfirmation;
+        out.message = "Confirm a dummy load or a verified-clear frequency before transmitting";
+        return out;
+    }
+    const std::int64_t cooldown = cooldownRemainingMs(nowMs);
+    if (cooldown > 0) {
+        out.verdict = PreflightVerdict::CoolingDown;
+        out.message = "Cooling down — " + std::to_string((cooldown + 999) / 1000)
+                      + " s remaining before the next test transmission";
+        return out;
+    }
+
+    // ── Band plan ───────────────────────────────────────────────────────────
+    //
+    // The TONES must sit inside one allocation: a test that puts a carrier
+    // outside the licensed service's allocation is not a measurement, it is an
+    // out-of-band emission. The PRODUCTS crossing an edge is a warning rather
+    // than a refusal — they are real emissions and the operator must know, but
+    // they are also 30+ dB down and the radio's own TX filtering acts on them,
+    // so refusing outright would block legitimate near-edge measurements that
+    // are the very ones worth making.
+    //
+    // An empty allocation list means the band plan has not loaded. Fail closed:
+    // no data is not permission.
+    const auto containsTones = [&](const AllocationRange& r) {
+        return lo >= r.lowHz && hi <= r.highHz;
+    };
+    const auto it = std::find_if(request.allocations.begin(), request.allocations.end(),
+                                 containsTones);
+    if (it == request.allocations.end()) {
+        out.verdict = PreflightVerdict::OutsideAllocation;
+        out.message = request.allocations.empty()
+                          ? "No band plan is loaded, so the test frequency cannot be verified"
+                          : ("Test tones at " + hzText(lo) + " to " + hzText(hi)
+                             + " are outside the licensed amateur allocation");
+        return out;
+    }
+
+    if (out.occupiedLowHz < it->lowHz) {
+        out.warnings.push_back(
+            "Order-" + std::to_string(request.maxOrder) + " products reach "
+            + hzText(out.occupiedLowHz) + ", below the band edge at " + hzText(it->lowHz));
+    } else if (out.occupiedLowHz - it->lowHz < kBandEdgeWarnHz) {
+        out.warnings.push_back("Occupied bandwidth comes within "
+                               + hzText(out.occupiedLowHz - it->lowHz)
+                               + " of the lower band edge");
+    }
+    if (out.occupiedHighHz > it->highHz) {
+        out.warnings.push_back(
+            "Order-" + std::to_string(request.maxOrder) + " products reach "
+            + hzText(out.occupiedHighHz) + ", above the band edge at " + hzText(it->highHz));
+    } else if (it->highHz - out.occupiedHighHz < kBandEdgeWarnHz) {
+        out.warnings.push_back("Occupied bandwidth comes within "
+                               + hzText(it->highHz - out.occupiedHighHz)
+                               + " of the upper band edge");
+    }
+
+    out.verdict = PreflightVerdict::Ok;
+    return out;
+}
+
+void TxLinearitySafety::noteRunStarted(std::int64_t nowMs)
+{
+    m_running = true;
+    m_runStartedMs = nowMs;
+    m_everRan = true;
+}
+
+void TxLinearitySafety::noteRunStopped(std::int64_t nowMs)
+{
+    m_running = false;
+    m_runStoppedMs = nowMs;
+    // Single-use confirmation. The next run asks again — see the header.
+    m_dummyLoadConfirmed = false;
+}
+
+AbortReason TxLinearitySafety::evaluate(std::int64_t nowMs,
+                                        const TxTelemetry& telemetry,
+                                        std::int64_t lastTelemetryMs) const
+{
+    if (!m_running) {
+        return AbortReason::None;
+    }
+
+    // The timeout is checked first and unconditionally. Every other interlock
+    // depends on data arriving; this one does not, which is precisely why it is
+    // the backstop.
+    if (transmitElapsedMs(nowMs) >= std::int64_t(m_limits.maxTransmitMs)) {
+        return AbortReason::TransmitTimeout;
+    }
+
+    if (nowMs - lastTelemetryMs > std::int64_t(m_limits.telemetryMaxAgeMs)) {
+        return AbortReason::TelemetryStale;
+    }
+
+    // SWR is only meaningful with real forward power behind it — a reflected
+    // reading taken against a near-zero forward reading is a ratio of two noise
+    // samples, and tripping on it would abort every run during key-up. This
+    // mirrors MeterModel's own kMinForwardWattsForSwr gate.
+    if (telemetry.swr.has_value()
+        && (!telemetry.forwardWatts.has_value() || *telemetry.forwardWatts > 0.5)
+        && *telemetry.swr > m_limits.maxSwr) {
+        return AbortReason::HighSwr;
+    }
+    if (telemetry.paTempC.has_value() && *telemetry.paTempC > m_limits.maxPaTempC) {
+        return AbortReason::PaOverTemp;
+    }
+    if (telemetry.supplyVolts.has_value() && *telemetry.supplyVolts < m_limits.minSupplyVolts) {
+        return AbortReason::LowSupplyVoltage;
+    }
+    return AbortReason::None;
+}
+
+std::int64_t TxLinearitySafety::transmitElapsedMs(std::int64_t nowMs) const
+{
+    return m_running ? std::max<std::int64_t>(0, nowMs - m_runStartedMs) : 0;
+}
+
+std::int64_t TxLinearitySafety::cooldownRemainingMs(std::int64_t nowMs) const
+{
+    if (!m_everRan || m_running) {
+        return 0;
+    }
+    const std::int64_t elapsed = nowMs - m_runStoppedMs;
+    return std::max<std::int64_t>(0, std::int64_t(m_limits.minCooldownMs) - elapsed);
+}
+
+}  // namespace AetherSDR::txlin

--- a/src/core/txlinearity/TxLinearitySafety.h
+++ b/src/core/txlinearity/TxLinearitySafety.h
@@ -1,0 +1,178 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace AetherSDR::txlin {
+
+// Safety interlocks for the TX linearity analyzer.
+//
+// A two-tone test is a high-duty-cycle, PEP-heavy transmission deliberately
+// driven towards the region where the amplifier misbehaves — that is the whole
+// point of the measurement. It is therefore the most hardware-hostile thing
+// this application can ask a radio to do, and it happens under the operator's
+// callsign and legal responsibility.
+//
+// Everything here is Qt-free and clock-injected: every decision is a pure
+// function of (now, state, telemetry), so the timeout, the duty-cycle limiter,
+// the telemetry aborts and the band-plan refusal are all unit-testable without
+// a radio, without a GUI and without sleeping. Interlocks that can only be
+// tested by transmitting are interlocks that do not get tested.
+//
+// Constitution Principle VI — AetherSDR never transmits without operator
+// intent — is the governing constraint: every path here fails CLOSED. When
+// intent, telemetry or the capture stream is in any doubt, the answer is "do
+// not key" or "unkey now", never "carry on and see".
+
+struct TxTelemetry {
+    // All optional because a meter that has stopped updating is a different
+    // condition from a meter reading zero, and the two must not be confused.
+    // MeterModel already distinguishes them (swrIfLive(), the per-meter
+    // freshness timestamps); this type preserves that distinction across the
+    // seam instead of flattening it to 0.0.
+    std::optional<double> swr;
+    std::optional<double> paTempC;
+    std::optional<double> supplyVolts;
+    std::optional<double> forwardWatts;
+};
+
+struct SafetyLimits {
+    // Hard transmit timeout. Cut TX unconditionally on expiry — not "ask the
+    // user", not "finish the current average".
+    int maxTransmitMs = 10000;
+
+    // Minimum idle time between test transmissions. A two-tone at PEP is close
+    // to worst case for PA dissipation and the finals need the recovery time
+    // whether or not the temperature meter has noticed yet.
+    int minCooldownMs = 30000;
+
+    // Telemetry abort thresholds. Chosen to trip before the radio's own
+    // protection does, so the analyzer stops the test rather than the radio
+    // stopping the transmitter — a cleaner failure, and one the operator can
+    // see the reason for.
+    double maxSwr = 2.0;
+    double maxPaTempC = 75.0;
+    double minSupplyVolts = 11.0;
+
+    // How stale telemetry may be before the run aborts. A radio that has
+    // stopped reporting SWR during a high-power test is not a radio to keep
+    // transmitting on.
+    int telemetryMaxAgeMs = 2000;
+};
+
+// The band the test is allowed to occupy, in absolute Hz. Fed from
+// BandPlanManager by the Qt layer so this file stays free of it.
+struct AllocationRange {
+    double lowHz = 0.0;
+    double highHz = 0.0;
+};
+
+struct RunRequest {
+    // Absolute frequency of the lower and upper test tones.
+    double tone1Hz = 0.0;
+    double tone2Hz = 0.0;
+    // Highest odd IMD order the test will generate meaningfully. Order 7 puts
+    // products 3 tone-spacings beyond each tone, so the occupied bandwidth is
+    // markedly wider than the tone pair — which is exactly what a band-edge
+    // check has to account for and what an eyeball estimate always forgets.
+    int maxOrder = 7;
+    std::vector<AllocationRange> allocations;
+    bool captureReady = false;
+};
+
+enum class PreflightVerdict {
+    Ok,
+    AlreadyRunning,
+    CoolingDown,
+    NoDummyLoadConfirmation,
+    NoCaptureSource,
+    InvalidToneSpacing,
+    OutsideAllocation,
+};
+
+struct PreflightResult {
+    PreflightVerdict verdict = PreflightVerdict::Ok;
+    std::string message;
+    // Non-blocking advisories the UI must show but which do not by themselves
+    // refuse the run — band-edge proximity being the main one.
+    std::vector<std::string> warnings;
+    // The span the test will actually occupy, including IMD products, so the
+    // UI can state it rather than leaving the operator to work it out.
+    double occupiedLowHz = 0.0;
+    double occupiedHighHz = 0.0;
+
+    [[nodiscard]] bool ok() const { return verdict == PreflightVerdict::Ok; }
+};
+
+enum class AbortReason {
+    None,
+    TransmitTimeout,
+    HighSwr,
+    PaOverTemp,
+    LowSupplyVoltage,
+    TelemetryStale,
+    CaptureLost,
+    OperatorStop,
+};
+
+std::string abortReasonText(AbortReason reason);
+
+class TxLinearitySafety {
+public:
+    TxLinearitySafety() = default;
+    explicit TxLinearitySafety(const SafetyLimits& limits) : m_limits(limits) {}
+
+    [[nodiscard]] const SafetyLimits& limits() const { return m_limits; }
+
+    // Apply operator-adjusted limits.
+    //
+    // The transmit timeout is adjustable DOWNWARD only unless `allowOverride`
+    // is set: a limit that any dialog can quietly raise is not a limit. The
+    // same rule applies to the cooldown, for the same reason. Returns false
+    // (and applies nothing) when the request would loosen a limit without an
+    // override, so the caller can tell the operator why rather than silently
+    // clamping.
+    bool setLimits(const SafetyLimits& limits, bool allowOverride = false);
+
+    // ── Dummy-load confirmation ─────────────────────────────────────────────
+    //
+    // Deliberately session-scoped and single-use: cleared by noteRunStopped()
+    // and never written to AppSettings. §8 requires explicit confirmation
+    // before ANY test transmission and requires it not to be remembered across
+    // sessions — the antenna on the other end of the coax is not a preference,
+    // it is a fact that can change between one run and the next.
+    void confirmDummyLoad() { m_dummyLoadConfirmed = true; }
+    void clearDummyLoadConfirmation() { m_dummyLoadConfirmed = false; }
+    [[nodiscard]] bool dummyLoadConfirmed() const { return m_dummyLoadConfirmed; }
+
+    [[nodiscard]] PreflightResult preflight(std::int64_t nowMs,
+                                            const RunRequest& request) const;
+
+    void noteRunStarted(std::int64_t nowMs);
+    void noteRunStopped(std::int64_t nowMs);
+    [[nodiscard]] bool running() const { return m_running; }
+
+    // Evaluate the interlocks against the current telemetry. Call on every
+    // telemetry update AND on a timer, so a radio that stops reporting entirely
+    // still trips TelemetryStale rather than transmitting until the timeout.
+    //
+    // `lastTelemetryMs` is when the telemetry snapshot was last refreshed.
+    [[nodiscard]] AbortReason evaluate(std::int64_t nowMs,
+                                       const TxTelemetry& telemetry,
+                                       std::int64_t lastTelemetryMs) const;
+
+    [[nodiscard]] std::int64_t transmitElapsedMs(std::int64_t nowMs) const;
+    [[nodiscard]] std::int64_t cooldownRemainingMs(std::int64_t nowMs) const;
+
+private:
+    SafetyLimits m_limits;
+    bool m_dummyLoadConfirmed = false;
+    bool m_running = false;
+    std::int64_t m_runStartedMs = 0;
+    std::int64_t m_runStoppedMs = 0;
+    bool m_everRan = false;
+};
+
+}  // namespace AetherSDR::txlin

--- a/src/core/txlinearity/TxLinearityTypes.h
+++ b/src/core/txlinearity/TxLinearityTypes.h
@@ -1,0 +1,183 @@
+#pragma once
+
+#include <complex>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+// TX Linearity Analyzer — shared value types.
+//
+// Everything in `AetherSDR::txlin` is deliberately backend-agnostic: no Qt, no
+// FlexRadio types, no radio-model dependency. The analyzer is the measurement
+// half of a digital-predistortion loop with the correction half removed, and
+// the HL2 backend will eventually need exactly this core with a different
+// capture adapter bolted underneath. Coupling it to Flex specifics now would
+// mean rewriting the DSP later, which is the one part that must not be
+// rewritten — it is the part with the numbers in it.
+//
+// The one dependency the core does take is FFTW3, which is already a hard
+// requirement of the tree (vendored WDSP needs it) — see SpectralNR and
+// Hl2Spectrum for the existing precedent.
+namespace AetherSDR::txlin {
+
+// ── Reference conventions ───────────────────────────────────────────────────
+//
+// The single most common way to publish a wrong IMD number is to omit which
+// reference it is against, so this type exists to make the choice unskippable
+// at every boundary that carries a dBc value.
+//
+// For two equal-amplitude tones of complex-baseband amplitude A each:
+//   - one tone's average power          = A^2
+//   - envelope peak amplitude           = 2A
+//   - PEP (peak envelope power)         = (2A)^2 = 4A^2
+// so PEP sits exactly 10*log10(4) = 6.0206 dB above a single tone. Ham-radio
+// convention usually quotes IMD relative to ONE TONE; ARRL lab measurements are
+// referenced to PEP, which reads 6 dB better for the identical signal. Both are
+// correct; a bare "IMD3 = -32 dB" is not.
+enum class ImdReference {
+    PerTone,  // dBc relative to one of the two tones
+    Pep,      // dBc relative to peak envelope power (PerTone - 6.02 dB)
+};
+
+// The exact PEP-to-single-tone offset for a balanced two-tone, in dB.
+// 10*log10(4). Named rather than spelled 6.02 inline because §9's reference
+// convention test asserts on it and a literal would drift.
+inline constexpr double kPepOverToneDb = 6.020599913279624;
+
+// ── Capture ─────────────────────────────────────────────────────────────────
+
+struct CaptureConfig {
+    // Highest rate the pan bandwidth allows. For a two-tone with spacing df,
+    // IMD3 sits at +/-df beyond the tones and IMD7 at +/-3df; at df = 2 kHz that
+    // is +/-8 kHz of products, and we want considerably more than that so window
+    // leakage from the capture band edges never reaches the measurement region.
+    // 192 kHz is the top DAX IQ rate a FLEX offers, so it is the default.
+    double sampleRateHz = 192000.0;
+
+    // 16384 bins at 192 kHz is 11.7 Hz/bin — enough to resolve products with
+    // 1 kHz tone spacing with many bins of guard either side.
+    int frameSamples = 16384;
+
+    double centerFreqHz = 0.0;
+
+    // PA thermal and ALC settling after key-down, and the fall of the envelope
+    // before key-up. Samples inside these guards are not steady-state and
+    // measuring them reports a transient as distortion.
+    int settleMsAfterKey = 50;
+    int settleMsBeforeUnkey = 50;
+};
+
+// One block of aligned capture handed from the capture thread to the analyzer.
+//
+// `reference` is engaged only on a backend that can supply the radio's own
+// ideal TX signal (HL2 Phase 3). On a FLEX it is always nullopt, because DAX IQ
+// is unidirectional and there is no path by which the radio's modulator output
+// reaches the host as IQ. Every consumer must degrade gracefully rather than
+// fabricate one — see ITxCaptureSource::hasReferenceChannel().
+struct CaptureFrame {
+    std::vector<std::complex<float>> feedback;
+    std::optional<std::vector<std::complex<float>>> reference;
+    double sampleRateHz = 0.0;
+    double centerFreqHz = 0.0;
+    std::uint64_t timestampNs = 0;
+    // ADC/path overload somewhere in this frame. Judged by magnitude-histogram
+    // saturation across the frame, not by one sample touching full scale — a
+    // single clipped sample in 16384 is a statistical certainty on a signal
+    // whose peaks are the point, while a *population* piled against full scale
+    // is the thing that ruins the measurement.
+    bool clipped = false;
+};
+
+// ── Measurement results ─────────────────────────────────────────────────────
+
+// One estimated spectral tone. `powerDb` is in dB relative to the analyzer's
+// full-scale complex amplitude of 1.0, i.e. dBFS — the capture path delivers
+// normalized IQ and the analyzer never learns the antenna-side absolute power,
+// so every ratio below is a difference of these and is therefore absolute-scale
+// independent, which is exactly what a linearity measurement wants.
+struct TonePeak {
+    bool valid = false;
+    double freqHz = 0.0;
+    double powerDb = 0.0;
+};
+
+struct ImdProduct {
+    int order = 3;          // 3, 5 or 7
+    bool upper = false;     // false: 2f1-f2 side. true: 2f2-f1 side.
+    double freqHz = 0.0;
+    double powerDb = 0.0;   // dBFS, same reference as TonePeak::powerDb
+
+    // The two conventions, always both, always labelled. dbcPep is
+    // dbcPerTone - kPepOverToneDb by construction for a balanced pair; it is
+    // computed from the measured PEP rather than by subtracting the constant,
+    // so an imbalanced pair reports the truth instead of the idealisation.
+    double dbcPerTone = 0.0;
+    double dbcPep = 0.0;
+
+    // The product's peak is not far enough above the instrument's own noise
+    // floor for the number to mean anything. A measurement that is actually
+    // reading the analyzer's noise, or the feedback receiver's own IMD, is
+    // worse than no measurement, so this flag exists to let the UI say so
+    // instead of printing a confident wrong number.
+    bool limitedByNoiseFloor = false;
+};
+
+// Adjacent-channel / shoulder measurement over an explicit band, so the caller
+// can see exactly what was integrated rather than trusting an offset label.
+struct BandPower {
+    double lowHz = 0.0;   // relative to the two-tone centre
+    double highHz = 0.0;
+    double powerDb = 0.0;     // integrated power, dBFS
+    double dbcPerTone = 0.0;
+    double dbcPep = 0.0;
+};
+
+struct LinearityResult {
+    bool valid = false;
+    // Populated whenever valid == false. Human-readable and shown verbatim in
+    // the UI; the analyzer refusing to answer is a first-class result.
+    std::string invalidReason;
+
+    double sampleRateHz = 0.0;
+    double binHz = 0.0;
+    int fftSize = 0;
+    int averages = 0;
+
+    TonePeak tone1;   // lower
+    TonePeak tone2;   // upper
+    double toneSpacingHz = 0.0;
+    // tone2 - tone1 in dB. Beyond ~0.5 dB the IMD interpretation changes
+    // (products are no longer symmetric and the PEP relation stops holding),
+    // so the UI warns rather than silently reporting a number that assumes
+    // balance.
+    double toneImbalanceDb = 0.0;
+
+    double pepDb = 0.0;  // measured peak envelope power, dBFS
+
+    // Instrument noise floor, dBFS, PER ANALYSIS BIN — directly comparable
+    // against TonePeak::powerDb and ImdProduct::powerDb, which is the whole
+    // point: it is the level a product has to clear to mean anything.
+    //
+    // Note this includes the window's equivalent noise bandwidth. A bin's noise
+    // power is 2*sigma^2 * ENBW / N, not 2*sigma^2 / N; for the default
+    // Blackman-Harris 7 that is 4.2 dB higher than the naive figure. Reporting
+    // the naive one would make every product look 4 dB more trustworthy than it
+    // is.
+    double noiseFloorDb = 0.0;
+
+    std::vector<ImdProduct> products;
+    std::optional<BandPower> shoulderLow;
+    std::optional<BandPower> shoulderHigh;
+    std::optional<BandPower> acprLow;
+    std::optional<BandPower> acprHigh;
+
+    bool clipped = false;
+
+    // Welch-averaged magnitude spectrum in dBFS, DC-centred (DC at index
+    // fftSize/2) to match the convention Hl2Spectrum already uses so the plot
+    // code has one mental model, not two.
+    std::vector<float> spectrumDb;
+};
+
+}  // namespace AetherSDR::txlin

--- a/src/core/txlinearity/TxSpectrumAnalyzer.cpp
+++ b/src/core/txlinearity/TxSpectrumAnalyzer.cpp
@@ -1,0 +1,178 @@
+#include "TxSpectrumAnalyzer.h"
+
+#include <fftw3.h>
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR::txlin {
+
+TxSpectrumAnalyzer::TxSpectrumAnalyzer(int fftSize, WindowKind window)
+    : m_fftSize(fftSize > 0 ? fftSize : 0)
+{
+    if (m_fftSize < 4) {
+        m_fftSize = 0;
+        return;
+    }
+    m_window = makeWindow(window, std::size_t(m_fftSize));
+
+    auto* in = fftw_alloc_complex(std::size_t(m_fftSize));
+    auto* out = fftw_alloc_complex(std::size_t(m_fftSize));
+    m_in = in;
+    m_out = out;
+    // FFTW_MEASURE would be faster per transform but reorders and overwrites
+    // the buffers during planning and costs a noticeable pause; the analyzer
+    // runs a handful of 16k transforms per capture, so ESTIMATE is the right
+    // trade and matches Hl2Spectrum.
+    m_plan = fftw_plan_dft_1d(m_fftSize, in, out, FFTW_FORWARD, FFTW_ESTIMATE);
+    m_avg.assign(std::size_t(m_fftSize), 0.0);
+}
+
+TxSpectrumAnalyzer::~TxSpectrumAnalyzer()
+{
+    if (m_plan != nullptr) {
+        fftw_destroy_plan(static_cast<fftw_plan>(m_plan));
+    }
+    if (m_in != nullptr) {
+        fftw_free(static_cast<fftw_complex*>(m_in));
+    }
+    if (m_out != nullptr) {
+        fftw_free(static_cast<fftw_complex*>(m_out));
+    }
+}
+
+void TxSpectrumAnalyzer::reset() noexcept
+{
+    m_averages = 0;
+    std::fill(m_avg.begin(), m_avg.end(), 0.0);
+}
+
+bool TxSpectrumAnalyzer::accumulate(std::span<const std::complex<float>> frame)
+{
+    if (m_fftSize == 0 || m_plan == nullptr) {
+        return false;
+    }
+    if (frame.size() != std::size_t(m_fftSize)) {
+        return false;
+    }
+
+    auto* in = static_cast<fftw_complex*>(m_in);
+    for (int i = 0; i < m_fftSize; ++i) {
+        const double w = m_window.taps[std::size_t(i)];
+        in[i][0] = double(frame[std::size_t(i)].real()) * w;
+        in[i][1] = double(frame[std::size_t(i)].imag()) * w;
+    }
+
+    fftw_execute(static_cast<fftw_plan>(m_plan));
+
+    const auto* out = static_cast<const fftw_complex*>(m_out);
+    const double norm = (m_window.sumTaps != 0.0) ? (1.0 / m_window.sumTaps) : 1.0;
+    const int half = m_fftSize / 2;
+    const double n = double(m_averages);
+    const double invNext = 1.0 / (n + 1.0);
+
+    // Running mean, not sum-then-divide: an operator can leave the analyzer
+    // averaging for a long time and a sum of 16k-bin power spectra would drift
+    // in precision long before the count itself became implausible.
+    //
+    // fftshift folded into the same pass — DC (bin 0) lands at index half, so
+    // output index = (k + half) mod fftSize.
+    for (int k = 0; k < m_fftSize; ++k) {
+        const double re = out[k][0] * norm;
+        const double im = out[k][1] * norm;
+        const double p = re * re + im * im;
+        const int dst = (k + half) % m_fftSize;
+        m_avg[std::size_t(dst)] += (p - m_avg[std::size_t(dst)]) * invNext;
+    }
+    ++m_averages;
+    return true;
+}
+
+double TxSpectrumAnalyzer::binFreqHz(int index, double sampleRateHz) const
+{
+    if (m_fftSize == 0) {
+        return 0.0;
+    }
+    return double(index - m_fftSize / 2) * binHz(sampleRateHz, m_fftSize);
+}
+
+int TxSpectrumAnalyzer::freqToBin(double freqHz, double sampleRateHz) const
+{
+    if (m_fftSize == 0) {
+        return 0;
+    }
+    const double bw = binHz(sampleRateHz, m_fftSize);
+    if (bw <= 0.0) {
+        return 0;
+    }
+    const int idx = int(std::lround(freqHz / bw)) + m_fftSize / 2;
+    return std::clamp(idx, 0, m_fftSize - 1);
+}
+
+void TxSpectrumAnalyzer::toDb(std::vector<float>& out, float floorDb) const
+{
+    out.resize(m_avg.size());
+    const double floorLin = std::pow(10.0, double(floorDb) / 10.0);
+    for (std::size_t i = 0; i < m_avg.size(); ++i) {
+        out[i] = float(10.0 * std::log10(std::max(m_avg[i], floorLin)));
+    }
+}
+
+InterpolatedPeak interpolatePeak(const std::vector<double>& powerDcCentred,
+                                 int loBin, int hiBin,
+                                 double sampleRateHz)
+{
+    InterpolatedPeak peak;
+    const int n = int(powerDcCentred.size());
+    if (n < 4 || sampleRateHz <= 0.0) {
+        return peak;
+    }
+
+    // The interpolation needs a neighbour either side, so the search never
+    // returns an edge bin. A tone sitting against the capture-band edge is not
+    // measurable anyway — the window skirt runs off the end of the spectrum.
+    const int lo = std::max(loBin, 1);
+    const int hi = std::min(hiBin, n - 2);
+    if (lo > hi) {
+        return peak;
+    }
+
+    int best = lo;
+    for (int k = lo; k <= hi; ++k) {
+        if (powerDcCentred[std::size_t(k)] > powerDcCentred[std::size_t(best)]) {
+            best = k;
+        }
+    }
+    if (powerDcCentred[std::size_t(best)] <= 0.0) {
+        return peak;
+    }
+
+    const double alpha = 10.0 * std::log10(std::max(powerDcCentred[std::size_t(best - 1)], 1e-300));
+    const double beta  = 10.0 * std::log10(std::max(powerDcCentred[std::size_t(best)],     1e-300));
+    const double gamma = 10.0 * std::log10(std::max(powerDcCentred[std::size_t(best + 1)], 1e-300));
+
+    // Standard three-point parabolic vertex. The denominator vanishes only for
+    // three collinear points (a flat or perfectly linear neighbourhood), which
+    // is not a peak at all — fall back to the raw bin rather than dividing by
+    // something near zero and reporting a wild offset.
+    const double denom = alpha - 2.0 * beta + gamma;
+    double delta = 0.0;
+    double peakDb = beta;
+    if (std::abs(denom) > 1e-12) {
+        delta = 0.5 * (alpha - gamma) / denom;
+        if (std::abs(delta) <= 1.0) {
+            peakDb = beta - 0.25 * (alpha - gamma) * delta;
+        } else {
+            delta = 0.0;
+        }
+    }
+
+    const double bw = TxSpectrumAnalyzer::binHz(sampleRateHz, n);
+    peak.valid = true;
+    peak.deltaBins = delta;
+    peak.freqHz = (double(best - n / 2) + delta) * bw;
+    peak.powerDb = peakDb;
+    return peak;
+}
+
+}  // namespace AetherSDR::txlin

--- a/src/core/txlinearity/TxSpectrumAnalyzer.h
+++ b/src/core/txlinearity/TxSpectrumAnalyzer.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include "SpectrumWindow.h"
+
+#include <complex>
+#include <cstddef>
+#include <span>
+#include <vector>
+
+namespace AetherSDR::txlin {
+
+// Welch-averaged complex-baseband spectrum estimator for the linearity
+// analyzer.
+//
+// Distinct from Hl2Spectrum (the HL2 panadapter) on purpose. That one is a
+// display path: Hanning window, one frame at a time, float output, tuned for
+// frame rate. This one is a measurement path — low-sidelobe window, power
+// averaging across frames, double precision throughout, and it keeps the
+// linear power spectrum rather than dB so band powers can be integrated
+// correctly. Sharing them would force one of the two to compromise, and the
+// display can afford to and the instrument cannot.
+//
+// AVERAGING. Welch averaging of |X[k]|^2 across frames reduces the variance of
+// the noise estimate by ~1/sqrt(M) while leaving coherent tones untouched, so
+// it lowers the visible noise floor and lets weaker products be resolved. It
+// does NOT reduce window leakage, which is coherent — that is the window's job
+// and the reason for the default in SpectrumWindow.h.
+//
+// SCALING. accumulate() stores mean |X[k]/sum(w)|^2. With that normalisation:
+//   - a complex exponential of amplitude A peaks at |S[k]|^2 = A^2, so a tone's
+//     power reads directly off the peak bin;
+//   - integrated band power is sum_{k in band} |S[k]|^2 / enbwBins, which is
+//     correct for tones and for noise alike (see AnalysisWindow).
+// The capture path delivers IQ normalised to a full-scale magnitude of 1.0, so
+// everything downstream is dBFS and every published figure is a ratio of two of
+// them.
+//
+// THREADING. Owns an FFTW plan. Construction and destruction allocate and call
+// into FFTW's global planner, which is not thread-safe; fftw_execute itself is.
+// Construct on the analysis thread, off the capture thread, and never from two
+// threads at once — the same rule Hl2Spectrum documents.
+class TxSpectrumAnalyzer {
+public:
+    TxSpectrumAnalyzer(int fftSize, WindowKind window);
+    ~TxSpectrumAnalyzer();
+    TxSpectrumAnalyzer(const TxSpectrumAnalyzer&) = delete;
+    TxSpectrumAnalyzer& operator=(const TxSpectrumAnalyzer&) = delete;
+
+    [[nodiscard]] int fftSize() const noexcept { return m_fftSize; }
+    [[nodiscard]] const AnalysisWindow& window() const noexcept { return m_window; }
+
+    // Transform one frame of exactly fftSize samples and fold it into the
+    // running average. A short or long span is rejected (returns false) rather
+    // than silently zero-padded: zero-padding changes the effective window and
+    // therefore the leakage floor, which is the one property this instrument
+    // depends on.
+    bool accumulate(std::span<const std::complex<float>> frame);
+
+    void reset() noexcept;
+
+    [[nodiscard]] int averages() const noexcept { return m_averages; }
+
+    // Mean linear power spectrum, DC-CENTRED (DC at index fftSize/2) to match
+    // the convention already used by Hl2Spectrum. Empty until the first
+    // accumulate() succeeds.
+    [[nodiscard]] const std::vector<double>& powerSpectrum() const noexcept { return m_avg; }
+
+    // Hz per bin, given the capture sample rate.
+    [[nodiscard]] static double binHz(double sampleRateHz, int fftSize)
+    {
+        return (fftSize > 0) ? sampleRateHz / double(fftSize) : 0.0;
+    }
+
+    // Baseband frequency of a DC-centred bin index, in Hz (negative below DC).
+    [[nodiscard]] double binFreqHz(int index, double sampleRateHz) const;
+
+    // Nearest DC-centred bin index to a baseband frequency. Clamped into range;
+    // callers that care about out-of-range must check the frequency themselves.
+    [[nodiscard]] int freqToBin(double freqHz, double sampleRateHz) const;
+
+    // Convert the averaged power spectrum to dBFS for display. Values at or
+    // below the floor are clamped to `floorDb` so an all-zero capture produces
+    // a flat trace instead of -inf.
+    void toDb(std::vector<float>& out, float floorDb = -200.0f) const;
+
+private:
+    int m_fftSize = 0;
+    AnalysisWindow m_window;
+    int m_averages = 0;
+    std::vector<double> m_avg;   // DC-centred mean |S[k]|^2
+
+    void* m_in = nullptr;    // fftw_complex[m_fftSize]
+    void* m_out = nullptr;   // fftw_complex[m_fftSize]
+    void* m_plan = nullptr;  // fftw_plan
+};
+
+// ── Peak estimation ─────────────────────────────────────────────────────────
+
+struct InterpolatedPeak {
+    bool valid = false;
+    double freqHz = 0.0;
+    double powerDb = 0.0;
+    // Fractional bin offset actually applied, for diagnostics. |delta| > 0.5
+    // means the search picked the wrong bin and the caller should widen.
+    double deltaBins = 0.0;
+};
+
+// Locate the largest bin within [loBin, hiBin] of a DC-centred power spectrum
+// and refine it by parabolic interpolation on the dB magnitudes.
+//
+// Parabolic-on-log is the right estimator for a tone under a smooth cosine-sum
+// window: the main lobe of such a window is very nearly a parabola in dB near
+// its peak, so three points recover both the true frequency and the true
+// amplitude to a fraction of a dB even when the tone falls between bins.
+// Without it, a tone landing on a bin boundary reads up to ~1.4 dB low under
+// Blackman-Harris — an error that would propagate straight into every dBc
+// figure. (Jacobsen's complex three-point estimator is more accurate for
+// frequency alone but needs the complex spectrum, which averaging has already
+// discarded; amplitude is what the dBc numbers actually depend on.)
+InterpolatedPeak interpolatePeak(const std::vector<double>& powerDcCentred,
+                                 int loBin, int hiBin,
+                                 double sampleRateHz);
+
+}  // namespace AetherSDR::txlin

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -29,6 +29,7 @@
 #include "RC28MappingDialog.h"
 #include "ShortcutDialog.h"
 #include "RadioHealthDialog.h"
+#include "TxLinearityDialog.h"
 #include "SliceTroubleshootingDialog.h"
 #include "SpectrumWidget.h"
 #include "SupportDialog.h"
@@ -1209,6 +1210,22 @@ void MainWindow::buildMenuBar()
     // symptoms in that dialog turn out to have a hardware cause.
     helpMenu->addAction("Radio Health...", this, [this]() {
         auto* dlg = new RadioHealthDialog(&m_radioModel, this);
+        dlg->setAttribute(Qt::WA_DeleteOnClose);
+        trackPersistentDialog(dlg);
+        dlg->show();
+        dlg->raise();
+        dlg->activateWindow();
+    });
+    // TX Linearity Analyzer. Grouped with the other instruments because it
+    // MEASURES the radio rather than configuring it — and because the Settings
+    // menu's placeholder-connect loop would hijack any action added there.
+    //
+    // Unlike its neighbours here it transmits, so the full §8 interlock set
+    // lives inside the dialog: per-run dummy-load confirmation that is never
+    // remembered, a hard transmit timeout, a duty-cycle cooldown, band-plan
+    // refusal that fails closed, and SWR / PA-temperature / supply aborts.
+    helpMenu->addAction("TX Linearity Analyzer...", this, [this]() {
+        auto* dlg = new TxLinearityDialog(&m_radioModel, m_bandPlanMgr, this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
         trackPersistentDialog(dlg);
         dlg->show();

--- a/src/gui/TxLinearityDialog.cpp
+++ b/src/gui/TxLinearityDialog.cpp
@@ -1,0 +1,849 @@
+#include "TxLinearityDialog.h"
+
+#include "TxLinearitySpectrumView.h"
+#include "core/AppSettings.h"
+#include "core/ThemeManager.h"
+#include "core/TxKeyingMarker.h"
+#include "core/txlinearity/FlexDaxIqCapture.h"
+#include "models/BandPlanManager.h"
+#include "models/MeterModel.h"
+#include "models/PanadapterModel.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+#include "models/TransmitModel.h"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDateTime>
+#include <QDoubleSpinBox>
+#include <QFileDialog>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QLabel>
+#include <QMessageBox>
+#include <QPixmap>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QTableWidget>
+#include <QTextStream>
+#include <QVBoxLayout>
+
+#include <cmath>
+
+namespace AetherSDR {
+namespace {
+
+// Feedback level window, dBFS RMS on the DAX IQ stream.
+//
+// The lower bound is set by SNR, not by taste. To read an IMD3 product 40 dB
+// below the tones with 30 dB of margin over the instrument floor, the tones
+// themselves have to sit roughly 70 dB above it — which on a 16-bit-equivalent
+// path means the RMS cannot be down in the -50s. The upper bound is set by
+// headroom: a two-tone's envelope peak is 6 dB above its RMS, so an RMS above
+// about -9 dBFS puts the peaks against the rail and the analyzer starts
+// measuring the ADC's clipping instead of the amplifier's distortion.
+constexpr double kLevelTooLowDbfs = -35.0;
+constexpr double kLevelGoodLowDbfs = -30.0;
+constexpr double kLevelGoodHighDbfs = -12.0;
+constexpr double kLevelTooHighDbfs = -9.0;
+
+// Persisted setup choices. The dummy-load confirmation is deliberately NOT in
+// this list — see TxLinearitySafety.
+constexpr auto kKeyDaxChannel = "TxLinearityDaxChannel";
+constexpr auto kKeyToneSpacing = "TxLinearityToneSpacingHz";
+constexpr auto kKeyTunePower = "TxLinearityTunePower";
+constexpr auto kKeyAverages = "TxLinearityAverages";
+constexpr auto kKeyTimeoutSec = "TxLinearityTimeoutSec";
+constexpr auto kKeyWindow = "TxLinearityWindow";
+constexpr auto kKeyMaxOrder = "TxLinearityMaxOrder";
+
+QString refText(double perTone, double pep, bool trusted)
+{
+    if (!trusted) {
+        return TxLinearityDialog::tr("below noise floor");
+    }
+    // BOTH conventions, both labelled, every time. A bare "-32 dB" is the
+    // single most common way to publish a wrong IMD figure.
+    return QStringLiteral("%1 dBc/tone   %2 dBc/PEP")
+        .arg(QString::number(perTone, 'f', 1))
+        .arg(QString::number(pep, 'f', 1));
+}
+
+}  // namespace
+
+TxLinearityDialog::TxLinearityDialog(RadioModel* model, BandPlanManager* bandPlan,
+                                     QWidget* parent)
+    : PersistentDialog(QStringLiteral("TX Linearity Analyzer"),
+                       QStringLiteral("TxLinearityDialogGeometry"), parent)
+    , m_model(model)
+    , m_bandPlan(bandPlan)
+{
+    theme::setContainer(this, QStringLiteral("dialog/txLinearity"));
+    setMinimumSize(760, 640);
+    resize(900, 780);
+
+    auto* root = new QVBoxLayout(bodyWidget());
+    root->setSpacing(9);
+
+    buildSetupGroup(root);
+    buildTestGroup(root);
+    buildResultArea(root);
+    wireController();
+    refreshPanChoices();
+    refreshRunEnabled();
+}
+
+TxLinearityDialog::~TxLinearityDialog()
+{
+    // The controller unkeys in its own destructor, but stop it explicitly first
+    // so the capture stream is torn down while the DaxIqModel it talks to is
+    // still alive.
+    m_controller.stopRun(txlin::AbortReason::OperatorStop);
+}
+
+// ── Setup ───────────────────────────────────────────────────────────────────
+
+void TxLinearityDialog::buildSetupGroup(QVBoxLayout* root)
+{
+    auto* group = new QGroupBox(tr("1 — Feedback path"), bodyWidget());
+    auto* grid = new QGridLayout(group);
+    grid->setSpacing(6);
+
+    auto* intro = new QLabel(
+        tr("Route attenuated TX energy into a receive-only port (RX A or XVTR) and "
+           "tune a slice there to the transmit frequency, then point a panadapter at "
+           "it. Never connect the transmitter to a receive port without attenuation."));
+    intro->setWordWrap(true);
+    ThemeManager::instance().applyStyleSheet(
+        intro, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
+    grid->addWidget(intro, 0, 0, 1, 4);
+
+    grid->addWidget(new QLabel(tr("DAX IQ channel")), 1, 0);
+    m_daxChannel = new QComboBox(group);
+    for (int ch = 1; ch <= DaxIqModel::NUM_CHANNELS; ++ch) {
+        m_daxChannel->addItem(QString::number(ch), ch);
+    }
+    m_daxChannel->setAccessibleName(tr("DAX IQ channel"));
+    m_daxChannel->setAccessibleDescription(
+        tr("Which of the radio's four DAX IQ channels captures the feedback signal."));
+    m_daxChannel->setCurrentIndex(
+        AppSettings::instance().value(kKeyDaxChannel, "1").toInt() - 1);
+    grid->addWidget(m_daxChannel, 1, 1);
+
+    grid->addWidget(new QLabel(tr("Feedback panadapter")), 1, 2);
+    m_feedbackPan = new QComboBox(group);
+    m_feedbackPan->setAccessibleName(tr("Feedback panadapter"));
+    m_feedbackPan->setAccessibleDescription(
+        tr("The panadapter watching the receive-only port. The DAX IQ window follows "
+           "this panadapter's centre frequency."));
+    grid->addWidget(m_feedbackPan, 1, 3);
+
+    grid->addWidget(new QLabel(tr("Feedback level")), 2, 0);
+    m_levelBar = new QProgressBar(group);
+    m_levelBar->setRange(-60, 0);
+    m_levelBar->setValue(-60);
+    m_levelBar->setFormat(tr("%v dBFS"));
+    m_levelBar->setAccessibleName(tr("Feedback level"));
+    m_levelBar->setAccessibleDescription(
+        tr("RMS level of the captured feedback signal. Target minus 30 to minus 12 dBFS."));
+    grid->addWidget(m_levelBar, 2, 1, 1, 2);
+
+    m_levelVerdict = new QLabel(tr("No signal"), group);
+    m_levelVerdict->setAccessibleName(tr("Feedback level verdict"));
+    grid->addWidget(m_levelVerdict, 2, 3);
+
+    auto* levelHelp = new QLabel(
+        tr("Adjust the external attenuator until the level sits in the target band. "
+           "Too low and the distortion products disappear into the receiver's noise; "
+           "too high and the analyzer measures the receiver clipping rather than the "
+           "amplifier."));
+    levelHelp->setWordWrap(true);
+    ThemeManager::instance().applyStyleSheet(
+        levelHelp, "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
+    grid->addWidget(levelHelp, 3, 0, 1, 4);
+
+    m_dummyLoadConfirm = new QCheckBox(
+        tr("I confirm a dummy load is connected, or the frequency is verified clear"), group);
+    m_dummyLoadConfirm->setAccessibleName(tr("Dummy load confirmation"));
+    m_dummyLoadConfirm->setAccessibleDescription(
+        tr("Required before every test transmission. This confirmation is never "
+           "remembered between runs or between sessions."));
+    grid->addWidget(m_dummyLoadConfirm, 4, 0, 1, 4);
+
+    root->addWidget(group);
+
+    connect(m_daxChannel, &QComboBox::currentIndexChanged, this, [this] {
+        AppSettings::instance().setValue(
+            kKeyDaxChannel, QString::number(m_daxChannel->currentData().toInt()));
+        AppSettings::instance().save();
+        // A channel change invalidates the capture adapter bound to the old one.
+        m_capture.reset();
+        m_controller.setCaptureSource(nullptr);
+        m_levelSeen = false;
+        refreshRunEnabled();
+    });
+    connect(m_feedbackPan, &QComboBox::currentIndexChanged, this,
+            &TxLinearityDialog::refreshRunEnabled);
+    connect(m_dummyLoadConfirm, &QCheckBox::toggled, this, [this](bool on) {
+        if (on) {
+            m_controller.safety().confirmDummyLoad();
+        } else {
+            m_controller.safety().clearDummyLoadConfirmation();
+        }
+        refreshRunEnabled();
+    });
+}
+
+void TxLinearityDialog::buildTestGroup(QVBoxLayout* root)
+{
+    auto* group = new QGroupBox(tr("2 — Test signal"), bodyWidget());
+    auto* grid = new QGridLayout(group);
+    grid->setSpacing(6);
+
+    AppSettings& settings = AppSettings::instance();
+
+    grid->addWidget(new QLabel(tr("Tone spacing")), 0, 0);
+    m_toneSpacing = new QDoubleSpinBox(group);
+    m_toneSpacing->setRange(200.0, 10000.0);
+    m_toneSpacing->setSingleStep(100.0);
+    m_toneSpacing->setSuffix(tr(" Hz"));
+    m_toneSpacing->setValue(settings.value(kKeyToneSpacing, "2000").toDouble());
+    m_toneSpacing->setAccessibleName(tr("Tone spacing"));
+    m_toneSpacing->setAccessibleDescription(
+        tr("Separation between the two test tones. Order 7 products reach three "
+           "spacings beyond each tone."));
+    grid->addWidget(m_toneSpacing, 0, 1);
+
+    grid->addWidget(new QLabel(tr("Tune power")), 0, 2);
+    m_tunePower = new QSpinBox(group);
+    m_tunePower->setRange(1, 100);
+    m_tunePower->setSuffix(tr(" W"));
+    m_tunePower->setValue(settings.value(kKeyTunePower, "10").toInt());
+    m_tunePower->setAccessibleName(tr("Tune power"));
+    grid->addWidget(m_tunePower, 0, 3);
+
+    grid->addWidget(new QLabel(tr("Averages")), 1, 0);
+    m_averages = new QSpinBox(group);
+    m_averages->setRange(1, 64);
+    m_averages->setValue(settings.value(kKeyAverages, "8").toInt());
+    m_averages->setAccessibleName(tr("Averages"));
+    m_averages->setAccessibleDescription(
+        tr("Welch averages to collect. More averages lower the noise floor but "
+           "lengthen the transmission."));
+    grid->addWidget(m_averages, 1, 1);
+
+    grid->addWidget(new QLabel(tr("Transmit timeout")), 1, 2);
+    m_timeoutSec = new QSpinBox(group);
+    m_timeoutSec->setRange(1, 10);
+    m_timeoutSec->setSuffix(tr(" s"));
+    m_timeoutSec->setValue(settings.value(kKeyTimeoutSec, "10").toInt());
+    m_timeoutSec->setAccessibleName(tr("Transmit timeout"));
+    m_timeoutSec->setAccessibleDescription(
+        tr("Hard limit on continuous test transmission. Adjustable downward only."));
+    grid->addWidget(m_timeoutSec, 1, 3);
+
+    grid->addWidget(new QLabel(tr("Analysis window")), 2, 0);
+    m_window = new QComboBox(group);
+    for (txlin::WindowKind kind : {txlin::WindowKind::BlackmanHarris7,
+                                   txlin::WindowKind::BlackmanHarris4,
+                                   txlin::WindowKind::FlatTop, txlin::WindowKind::Hann}) {
+        m_window->addItem(QString::fromStdString(txlin::windowKindLabel(kind)),
+                          QString::fromStdString(txlin::windowKindKey(kind)));
+    }
+    m_window->setCurrentIndex(m_window->findData(
+        settings.value(kKeyWindow, "blackman-harris-7").toString()));
+    m_window->setAccessibleName(tr("Analysis window"));
+    m_window->setAccessibleDescription(
+        tr("Blackman-Harris 7 is the default because its low sidelobes are what make "
+           "products below minus 50 dBc visible at all. Hann cannot see them."));
+    grid->addWidget(m_window, 2, 1);
+
+    grid->addWidget(new QLabel(tr("Highest order")), 2, 2);
+    m_maxOrder = new QComboBox(group);
+    m_maxOrder->addItem(tr("IMD3"), 3);
+    m_maxOrder->addItem(tr("IMD3 + 5"), 5);
+    m_maxOrder->addItem(tr("IMD3 + 5 + 7"), 7);
+    m_maxOrder->setCurrentIndex(
+        m_maxOrder->findData(settings.value(kKeyMaxOrder, "7").toInt()));
+    m_maxOrder->setAccessibleName(tr("Highest intermodulation order"));
+    grid->addWidget(m_maxOrder, 2, 3);
+
+    auto* buttons = new QHBoxLayout();
+    m_runButton = new QPushButton(tr("Run Measurement"), group);
+    m_runButton->setAccessibleName(tr("Run measurement"));
+    // The automation bridge must never key a live radio by accident, and this
+    // button transmits. Marking it puts it behind AETHER_AUTOMATION_ALLOW_TX
+    // like MOX, TUNE and ATU.
+    markTxKeying(m_runButton);
+    m_stopButton = new QPushButton(tr("Stop"), group);
+    m_stopButton->setAccessibleName(tr("Stop measurement"));
+    m_stopButton->setEnabled(false);
+    m_progressLabel = new QLabel(QString(), group);
+    buttons->addWidget(m_runButton);
+    buttons->addWidget(m_stopButton);
+    buttons->addWidget(m_progressLabel, 1);
+    grid->addLayout(buttons, 3, 0, 1, 4);
+
+    m_statusLabel = new QLabel(QString(), group);
+    m_statusLabel->setWordWrap(true);
+    m_statusLabel->setAccessibleName(tr("Analyzer status"));
+    grid->addWidget(m_statusLabel, 4, 0, 1, 4);
+
+    root->addWidget(group);
+
+    connect(m_runButton, &QPushButton::clicked, this, &TxLinearityDialog::onStartClicked);
+    connect(m_stopButton, &QPushButton::clicked, this, &TxLinearityDialog::onStopClicked);
+}
+
+void TxLinearityDialog::buildResultArea(QVBoxLayout* root)
+{
+    m_plot = new TxLinearitySpectrumView(bodyWidget());
+    root->addWidget(m_plot, 1);
+
+    m_readout = new QTableWidget(0, 2, bodyWidget());
+    m_readout->setHorizontalHeaderLabels({tr("Measurement"), tr("Value")});
+    m_readout->verticalHeader()->setVisible(false);
+    m_readout->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+    m_readout->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    m_readout->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_readout->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_readout->setAlternatingRowColors(true);
+    m_readout->setShowGrid(false);
+    m_readout->setMinimumHeight(160);
+    m_readout->setAccessibleName(tr("Measurement results"));
+    ThemeManager::instance().applyStyleSheet(m_readout,
+        "QTableWidget {"
+        "  background: {{color.background.0}};"
+        "  color: {{color.text.primary}};"
+        "  border: 1px solid {{color.background.2}};"
+        "  font-size: 11px;"
+        "}"
+        "QHeaderView::section {"
+        "  background: {{color.background.1}};"
+        "  color: {{color.text.secondary}};"
+        "  border: 0px;"
+        "  padding: 4px;"
+        "}");
+    root->addWidget(m_readout);
+
+    auto* exportRow = new QHBoxLayout();
+    m_exportCsvButton = new QPushButton(tr("Export CSV…"), bodyWidget());
+    m_exportPngButton = new QPushButton(tr("Export PNG…"), bodyWidget());
+    m_exportCsvButton->setAccessibleName(tr("Export results as CSV"));
+    m_exportPngButton->setAccessibleName(tr("Export plot as PNG"));
+    m_exportCsvButton->setEnabled(false);
+    m_exportPngButton->setEnabled(false);
+    exportRow->addStretch(1);
+    exportRow->addWidget(m_exportCsvButton);
+    exportRow->addWidget(m_exportPngButton);
+    root->addLayout(exportRow);
+
+    connect(m_exportCsvButton, &QPushButton::clicked, this, &TxLinearityDialog::exportCsv);
+    connect(m_exportPngButton, &QPushButton::clicked, this, &TxLinearityDialog::exportPng);
+}
+
+// ── Wiring ──────────────────────────────────────────────────────────────────
+
+void TxLinearityDialog::wireController()
+{
+    if (m_model == nullptr) {
+        return;
+    }
+
+    // Keying goes through TransmitModel's two-tone tune, which is the radio's
+    // OWN test generator: the tones are generated in the radio, downstream of
+    // nothing this application controls, so they are exactly the stimulus a
+    // SmartSDR operator would produce by hand. Nothing here synthesizes audio.
+    m_controller.setKeyRequest([this](bool key) {
+        TransmitModel& tx = m_model->transmitModel();
+        if (key) {
+            tx.setTunePower(m_tunePower->value());
+            tx.setTuneMode(QStringLiteral("two_tone"));
+            tx.startTwoToneTune();
+        } else {
+            tx.stopTune();
+        }
+        return true;
+    });
+
+    m_controller.setTelemetryProvider([this] {
+        txlin::TxLinearityController::TelemetrySnapshot snap;
+        MeterModel& meters = m_model->meterModel();
+        if (const std::optional<float> swr = meters.swrIfLive(); swr.has_value()) {
+            snap.telemetry.swr = double(*swr);
+        }
+        snap.telemetry.paTempC = double(meters.paTemp());
+        snap.telemetry.forwardWatts = double(meters.fwdPower());
+        if (meters.hasSupplyVoltage()) {
+            snap.telemetry.supplyVolts = double(meters.supplyVolts());
+        }
+        snap.lastUpdateMs = m_controller.nowMs();
+        return snap;
+    });
+
+    connect(&m_model->daxIqModel(), &DaxIqModel::iqLevelReady,
+            this, &TxLinearityDialog::onLevelUpdate);
+    connect(m_model, &RadioModel::panadapterAdded, this,
+            &TxLinearityDialog::refreshPanChoices);
+    connect(m_model, &RadioModel::panadapterRemoved, this,
+            &TxLinearityDialog::refreshPanChoices);
+
+    connect(&m_controller, &txlin::TxLinearityController::resultReady,
+            this, &TxLinearityDialog::onResult);
+    connect(&m_controller, &txlin::TxLinearityController::aborted,
+            this, &TxLinearityDialog::onAborted);
+    connect(&m_controller, &txlin::TxLinearityController::refused,
+            this, &TxLinearityDialog::onRefused);
+    connect(&m_controller, &txlin::TxLinearityController::progress, this,
+            [this](int averages, int target) {
+                m_progressLabel->setText(tr("Averaging %1 of %2").arg(averages).arg(target));
+            });
+    connect(&m_controller, &txlin::TxLinearityController::runStateChanged, this,
+            [this](bool running) {
+                m_stopButton->setEnabled(running);
+                if (!running) {
+                    // The safety layer clears the confirmation when a run ends;
+                    // the checkbox must follow it or the UI would show a
+                    // confirmation the interlock no longer holds.
+                    m_dummyLoadConfirm->setChecked(false);
+                    m_progressLabel->clear();
+                }
+                refreshRunEnabled();
+            });
+}
+
+void TxLinearityDialog::refreshPanChoices()
+{
+    if (m_model == nullptr || m_feedbackPan == nullptr) {
+        return;
+    }
+    const QString previous = m_feedbackPan->currentData().toString();
+    m_feedbackPan->clear();
+    for (PanadapterModel* pan : m_model->panadapters()) {
+        if (pan == nullptr) {
+            continue;
+        }
+        m_feedbackPan->addItem(
+            tr("%1 — %2 MHz").arg(pan->panId()).arg(pan->centerMhz(), 0, 'f', 4),
+            pan->panId());
+    }
+    const int restored = m_feedbackPan->findData(previous);
+    if (restored >= 0) {
+        m_feedbackPan->setCurrentIndex(restored);
+    }
+    refreshRunEnabled();
+}
+
+void TxLinearityDialog::onLevelUpdate(int channel, float rms)
+{
+    if (m_daxChannel == nullptr || channel != m_daxChannel->currentData().toInt()) {
+        return;
+    }
+    m_levelSeen = true;
+    m_levelDbfs = (rms > 0.0f) ? 20.0 * std::log10(double(rms)) : -120.0;
+    m_levelBar->setValue(int(std::round(std::clamp(m_levelDbfs, -60.0, 0.0))));
+
+    QString verdict;
+    QString colorToken;
+    if (m_levelDbfs < kLevelTooLowDbfs) {
+        verdict = tr("Too low");
+        colorToken = QStringLiteral("color.accent.danger");
+    } else if (m_levelDbfs < kLevelGoodLowDbfs) {
+        verdict = tr("Low");
+        colorToken = QStringLiteral("color.accent.warning");
+    } else if (m_levelDbfs <= kLevelGoodHighDbfs) {
+        verdict = tr("Good");
+        colorToken = QStringLiteral("color.accent.success");
+    } else if (m_levelDbfs <= kLevelTooHighDbfs) {
+        verdict = tr("High");
+        colorToken = QStringLiteral("color.accent.warning");
+    } else {
+        verdict = tr("Clipping");
+        colorToken = QStringLiteral("color.accent.danger");
+    }
+    m_levelVerdict->setText(verdict);
+    ThemeManager::instance().applyStyleSheet(
+        m_levelVerdict, QStringLiteral("QLabel { color: {{%1}}; font-weight: 600; }")
+                            .arg(colorToken));
+    refreshRunEnabled();
+}
+
+void TxLinearityDialog::refreshRunEnabled()
+{
+    if (m_runButton == nullptr) {
+        return;
+    }
+    const bool running = m_controller.running();
+    const bool haveRadio = (m_model != nullptr) && m_model->isConnected();
+    const bool havePan = m_feedbackPan != nullptr && m_feedbackPan->count() > 0;
+    const bool confirmed = m_dummyLoadConfirm != nullptr && m_dummyLoadConfirm->isChecked();
+
+    m_runButton->setEnabled(!running && haveRadio && havePan && confirmed);
+    m_stopButton->setEnabled(running);
+
+    // Setup inputs lock during a run: changing the DAX channel or the tone
+    // spacing mid-transmission would invalidate the average that is being
+    // accumulated, and the operator would have no way to know.
+    const QList<QWidget*> setupInputs{m_daxChannel,  m_feedbackPan, m_toneSpacing,
+                                      m_tunePower,   m_averages,    m_timeoutSec,
+                                      m_window,      m_maxOrder,    m_dummyLoadConfirm};
+    for (QWidget* w : setupInputs) {
+        if (w != nullptr) {
+            w->setEnabled(!running);
+        }
+    }
+}
+
+// ── Run ─────────────────────────────────────────────────────────────────────
+
+bool TxLinearityDialog::buildRunRequest(txlin::RunRequest& request, QString& reason) const
+{
+    if (m_model == nullptr) {
+        reason = tr("No radio is connected.");
+        return false;
+    }
+    SliceModel* tx = m_model->txSlice();
+    if (tx == nullptr) {
+        reason = tr("No transmit slice is selected.");
+        return false;
+    }
+
+    // The two-tone generator sits in the radio and produces its tones either
+    // side of the carrier point, so the occupied span is centred on the TX
+    // slice's frequency.
+    const double centreHz = tx->frequency() * 1e6;
+    const double half = m_toneSpacing->value() / 2.0;
+    request.tone1Hz = centreHz - half;
+    request.tone2Hz = centreHz + half;
+    request.maxOrder = m_maxOrder->currentData().toInt();
+    request.captureReady = true;
+
+    if (m_bandPlan == nullptr) {
+        reason = tr("The band plan is not available, so the test frequency cannot be verified.");
+        return false;
+    }
+    // Search a generous window either side and let the plan decide which
+    // contiguous region actually contains the tones. Passing the tone pair
+    // itself would return a region clipped to the pair rather than the
+    // allocation, and the band-edge check needs the allocation's real edges.
+    const double searchLowMhz = (centreHz - 2e6) / 1e6;
+    const double searchHighMhz = (centreHz + 2e6) / 1e6;
+    for (const BandPlanManager::Region& region :
+         m_bandPlan->contiguousRegionsForBand(searchLowMhz, searchHighMhz)) {
+        request.allocations.push_back(
+            txlin::AllocationRange{region.lowMhz * 1e6, region.highMhz * 1e6});
+    }
+    return true;
+}
+
+void TxLinearityDialog::onStartClicked()
+{
+    txlin::RunRequest request;
+    QString reason;
+    if (!buildRunRequest(request, reason)) {
+        setStatus(reason, true);
+        return;
+    }
+
+    AppSettings& settings = AppSettings::instance();
+    settings.setValue(kKeyToneSpacing, QString::number(m_toneSpacing->value()));
+    settings.setValue(kKeyTunePower, QString::number(m_tunePower->value()));
+    settings.setValue(kKeyAverages, QString::number(m_averages->value()));
+    settings.setValue(kKeyTimeoutSec, QString::number(m_timeoutSec->value()));
+    settings.setValue(kKeyWindow, m_window->currentData().toString());
+    settings.setValue(kKeyMaxOrder, QString::number(m_maxOrder->currentData().toInt()));
+    settings.save();
+
+    // Bring up the capture adapter for the selected channel if it is not
+    // already bound. Doing this here rather than on every combo change keeps a
+    // DAX IQ channel allocated on the radio only while it is actually wanted.
+    const int channel = m_daxChannel->currentData().toInt();
+    if (m_capture == nullptr) {
+        m_capture = std::make_unique<txlin::FlexDaxIqCapture>(channel);
+        // The capture adapter holds no model pointer — it asks, and this dialog
+        // (which legitimately owns the radio wiring) does. That keeps the
+        // engine-boundary ratchet satisfied and, more usefully, leaves the
+        // adapter as pure frame assembly for the HPSDR one to mirror.
+        DaxIqModel& dax = m_model->daxIqModel();
+        connect(m_capture.get(), &txlin::FlexDaxIqCapture::streamStartRequested, &dax,
+                [&dax](int ch, int rateHz) {
+                    dax.createStream(ch);
+                    dax.setSampleRate(ch, rateHz);
+                });
+        connect(m_capture.get(), &txlin::FlexDaxIqCapture::streamStopRequested, &dax,
+                [&dax](int ch) { dax.removeStream(ch); });
+        connect(m_capture.get(), &txlin::FlexDaxIqCapture::commandReady, m_model,
+                [this](const QString& cmd) { m_model->sendCommand(cmd); });
+        connect(&dax, &DaxIqModel::iqSamplesReady, m_capture.get(),
+                [this](int ch, const QVector<float>& iq, int rateHz) {
+                    m_capture->feedIqSamples(ch, iq, rateHz);
+                });
+        connect(&dax, &DaxIqModel::streamChanged, m_capture.get(), [this, &dax](int ch) {
+            const DaxIqModel::IqStream& stream = dax.stream(ch);
+            if (!stream.exists) {
+                m_capture->noteStreamRemoved(ch);
+            } else if (!stream.rateSettling) {
+                m_capture->noteStreamRate(ch, stream.sampleRate);
+            }
+        });
+        m_capture->setRadioDescription(m_model->model());
+        m_controller.setCaptureSource(m_capture.get());
+    }
+    m_capture->setPanId(m_feedbackPan->currentData().toString());
+
+    // The timeout is adjustable downward only; setLimits enforces that and
+    // refuses an increase without an override, so a stale persisted value can
+    // never quietly loosen the interlock.
+    txlin::SafetyLimits limits = m_controller.safety().limits();
+    limits.maxTransmitMs = m_timeoutSec->value() * 1000;
+    m_controller.safety().setLimits(limits);
+
+    txlin::TxLinearityController::RunConfig config;
+    config.capture.sampleRateHz = 192000.0;
+    config.capture.frameSamples = 16384;
+    config.window = txlin::windowKindFromKey(m_window->currentData().toString().toStdString());
+    config.imd.maxOrder = request.maxOrder;
+    config.targetAverages = m_averages->value();
+
+    m_plot->clear();
+    m_hasResult = false;
+    m_exportCsvButton->setEnabled(false);
+    m_exportPngButton->setEnabled(false);
+    setStatus(tr("Transmitting…"), false);
+    m_controller.startRun(request, config);
+    refreshRunEnabled();
+}
+
+void TxLinearityDialog::onStopClicked()
+{
+    m_controller.stopRun(txlin::AbortReason::OperatorStop);
+    setStatus(tr("Stopped."), false);
+}
+
+void TxLinearityDialog::onAborted(txlin::AbortReason reason, const QString& text)
+{
+    Q_UNUSED(reason);
+    setStatus(tr("Measurement aborted: %1").arg(text), true);
+}
+
+void TxLinearityDialog::onRefused(const QString& message, const QStringList& warnings)
+{
+    QString text = message;
+    for (const QString& warning : warnings) {
+        text += QStringLiteral("\n• ") + warning;
+    }
+    setStatus(text, true);
+}
+
+void TxLinearityDialog::setStatus(const QString& text, bool warning)
+{
+    m_statusLabel->setText(text);
+    ThemeManager::instance().applyStyleSheet(
+        m_statusLabel, warning
+                           ? "QLabel { color: {{color.accent.warning}}; font-size: 11px; }"
+                           : "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
+}
+
+void TxLinearityDialog::onResult(const txlin::LinearityResult& result)
+{
+    m_lastResult = result;
+    m_hasResult = result.valid;
+    m_plot->setResult(result);
+    populateReadout(result);
+    m_exportCsvButton->setEnabled(result.valid);
+    m_exportPngButton->setEnabled(result.valid);
+
+    if (!result.valid) {
+        setStatus(tr("No measurement: %1").arg(QString::fromStdString(result.invalidReason)),
+                  true);
+        return;
+    }
+
+    QStringList caveats;
+    if (result.clipped) {
+        caveats << tr("the capture clipped — reduce the feedback level and re-run");
+    }
+    if (std::abs(result.toneImbalanceDb) > 0.5) {
+        caveats << tr("the two tones differ by %1 dB, so the symmetric-IMD reading is "
+                      "approximate")
+                       .arg(QString::number(result.toneImbalanceDb, 'f', 2));
+    }
+    int noiseLimited = 0;
+    for (const txlin::ImdProduct& p : result.products) {
+        if (p.limitedByNoiseFloor) {
+            ++noiseLimited;
+        }
+    }
+    if (noiseLimited > 0) {
+        caveats << tr("%1 product(s) sit at the instrument's own noise floor and are not "
+                      "quoted").arg(noiseLimited);
+    }
+
+    setStatus(caveats.isEmpty()
+                  ? tr("Measurement complete — %1 averages.").arg(result.averages)
+                  : tr("Measurement complete — %1.").arg(caveats.join(tr("; "))),
+              !caveats.isEmpty());
+}
+
+void TxLinearityDialog::populateReadout(const txlin::LinearityResult& result)
+{
+    m_readout->setRowCount(0);
+    if (!result.valid) {
+        return;
+    }
+
+    const auto addRow = [this](const QString& name, const QString& value) {
+        const int row = m_readout->rowCount();
+        m_readout->insertRow(row);
+        m_readout->setItem(row, 0, new QTableWidgetItem(name));
+        m_readout->setItem(row, 1, new QTableWidgetItem(value));
+    };
+
+    addRow(tr("Tone spacing"), tr("%1 Hz").arg(QString::number(result.toneSpacingHz, 'f', 1)));
+    addRow(tr("Tone imbalance"),
+           tr("%1 dB").arg(QString::number(result.toneImbalanceDb, 'f', 2)));
+    addRow(tr("Measured PEP"), tr("%1 dBFS").arg(QString::number(result.pepDb, 'f', 2)));
+    addRow(tr("Instrument noise floor"),
+           tr("%1 dBFS per bin").arg(QString::number(result.noiseFloorDb, 'f', 1)));
+    addRow(tr("Averages"), QString::number(result.averages));
+    addRow(tr("Resolution"), tr("%1 Hz/bin").arg(QString::number(result.binHz, 'f', 2)));
+
+    for (int order : {3, 5, 7}) {
+        for (const txlin::ImdProduct& p : result.products) {
+            if (p.order != order) {
+                continue;
+            }
+            addRow(tr("IMD%1 %2").arg(order).arg(p.upper ? tr("upper") : tr("lower")),
+                   refText(p.dbcPerTone, p.dbcPep, !p.limitedByNoiseFloor));
+        }
+    }
+
+    const auto addBand = [&](const QString& name, const std::optional<txlin::BandPower>& band) {
+        if (!band.has_value()) {
+            // An absent band is stated, not omitted: "the capture was too narrow
+            // to integrate this" and "this measured zero" are different facts.
+            addRow(name, tr("not measurable in the capture bandwidth"));
+            return;
+        }
+        addRow(name, QStringLiteral("%1   (%2 to %3 Hz)")
+                         .arg(refText(band->dbcPerTone, band->dbcPep, true))
+                         .arg(QString::number(band->lowHz, 'f', 0))
+                         .arg(QString::number(band->highHz, 'f', 0)));
+    };
+    addBand(tr("Shoulder, lower"), result.shoulderLow);
+    addBand(tr("Shoulder, upper"), result.shoulderHigh);
+    addBand(tr("ACPR, lower"), result.acprLow);
+    addBand(tr("ACPR, upper"), result.acprHigh);
+
+    addRow(tr("Capture clipped"), result.clipped ? tr("YES") : tr("no"));
+}
+
+// ── Export ──────────────────────────────────────────────────────────────────
+
+QString TxLinearityDialog::provenanceStamp() const
+{
+    if (m_model == nullptr) {
+        return QString();
+    }
+    SliceModel* tx = m_model->txSlice();
+    const TransmitModel& transmit = m_model->transmitModel();
+    return tr("radio=%1, frequency=%2 MHz, mode=%3, tune power=%4 W, APD=%5, window=%6, "
+              "averages=%7, capture=%8")
+        .arg(m_model->model())
+        .arg(tx != nullptr ? QString::number(tx->frequency(), 'f', 6) : tr("unknown"))
+        .arg(tx != nullptr ? tx->mode() : tr("unknown"))
+        .arg(m_tunePower->value())
+        .arg(transmit.apdEnabled() ? tr("on") : tr("off"))
+        .arg(m_window->currentText())
+        .arg(m_lastResult.averages)
+        .arg(m_capture != nullptr ? QString::fromStdString(m_capture->describe())
+                                  : tr("unknown"));
+}
+
+void TxLinearityDialog::exportCsv()
+{
+    if (!m_hasResult) {
+        return;
+    }
+    const QString suggested =
+        QStringLiteral("tx_linearity_%1.csv")
+            .arg(QDateTime::currentDateTime().toString(QStringLiteral("yyyyMMdd_HHmmss")));
+    const QString path = QFileDialog::getSaveFileName(
+        this, tr("Export Measurement"), suggested, tr("CSV files (*.csv)"));
+    if (path.isEmpty()) {
+        return;
+    }
+    QFile file(path);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        QMessageBox::warning(this, tr("TX Linearity Analyzer"),
+                             tr("Could not write %1").arg(path));
+        return;
+    }
+    QTextStream out(&file);
+    out << "# AetherSDR TX Linearity Analyzer\n";
+    out << "# " << QDateTime::currentDateTime().toString(Qt::ISODate) << "\n";
+    out << "# " << provenanceStamp() << "\n";
+    // Both reference conventions in the header, so a CSV read six months later
+    // cannot be misinterpreted.
+    out << "Measurement,Value,Unit,Reference\n";
+    out << "Tone spacing," << QString::number(m_lastResult.toneSpacingHz, 'f', 2) << ",Hz,\n";
+    out << "Tone imbalance," << QString::number(m_lastResult.toneImbalanceDb, 'f', 3) << ",dB,\n";
+    out << "Measured PEP," << QString::number(m_lastResult.pepDb, 'f', 3) << ",dBFS,\n";
+    out << "Instrument noise floor," << QString::number(m_lastResult.noiseFloorDb, 'f', 2)
+        << ",dBFS,per analysis bin\n";
+    out << "Averages," << m_lastResult.averages << ",,\n";
+    for (const txlin::ImdProduct& p : m_lastResult.products) {
+        const QString side = p.upper ? QStringLiteral("upper") : QStringLiteral("lower");
+        if (p.limitedByNoiseFloor) {
+            out << "IMD" << p.order << " " << side << ",,dBc,below instrument noise floor\n";
+            continue;
+        }
+        out << "IMD" << p.order << " " << side << "," << QString::number(p.dbcPerTone, 'f', 2)
+            << ",dBc,one tone\n";
+        out << "IMD" << p.order << " " << side << "," << QString::number(p.dbcPep, 'f', 2)
+            << ",dBc,PEP\n";
+    }
+    const auto writeBand = [&out](const char* name, const std::optional<txlin::BandPower>& b) {
+        if (!b.has_value()) {
+            out << name << ",,dBc,not measurable in the capture bandwidth\n";
+            return;
+        }
+        out << name << "," << QString::number(b->dbcPerTone, 'f', 2) << ",dBc,one tone ("
+            << QString::number(b->lowHz, 'f', 0) << " to " << QString::number(b->highHz, 'f', 0)
+            << " Hz)\n";
+        out << name << "," << QString::number(b->dbcPep, 'f', 2) << ",dBc,PEP\n";
+    };
+    writeBand("Shoulder lower", m_lastResult.shoulderLow);
+    writeBand("Shoulder upper", m_lastResult.shoulderHigh);
+    writeBand("ACPR lower", m_lastResult.acprLow);
+    writeBand("ACPR upper", m_lastResult.acprHigh);
+    out << "Capture clipped," << (m_lastResult.clipped ? "yes" : "no") << ",,\n";
+
+    setStatus(tr("Exported %1").arg(path), false);
+}
+
+void TxLinearityDialog::exportPng()
+{
+    if (!m_hasResult || m_plot == nullptr) {
+        return;
+    }
+    const QString suggested =
+        QStringLiteral("tx_linearity_%1.png")
+            .arg(QDateTime::currentDateTime().toString(QStringLiteral("yyyyMMdd_HHmmss")));
+    const QString path = QFileDialog::getSaveFileName(
+        this, tr("Export Plot"), suggested, tr("PNG images (*.png)"));
+    if (path.isEmpty()) {
+        return;
+    }
+    if (!m_plot->grab().save(path, "PNG")) {
+        QMessageBox::warning(this, tr("TX Linearity Analyzer"),
+                             tr("Could not write %1").arg(path));
+        return;
+    }
+    setStatus(tr("Exported %1").arg(path), false);
+}
+
+}  // namespace AetherSDR

--- a/src/gui/TxLinearityDialog.cpp
+++ b/src/gui/TxLinearityDialog.cpp
@@ -1,8 +1,8 @@
 #include "TxLinearityDialog.h"
 
 #include "TxLinearitySpectrumView.h"
-#include "core/AppSettings.h"
 #include "core/ThemeManager.h"
+#include "core/TxLinearitySettings.h"
 #include "core/TxKeyingMarker.h"
 #include "core/txlinearity/FlexDaxIqCapture.h"
 #include "models/BandPlanManager.h"
@@ -50,16 +50,6 @@ constexpr double kLevelGoodLowDbfs = -30.0;
 constexpr double kLevelGoodHighDbfs = -12.0;
 constexpr double kLevelTooHighDbfs = -9.0;
 
-// Persisted setup choices. The dummy-load confirmation is deliberately NOT in
-// this list — see TxLinearitySafety.
-constexpr auto kKeyDaxChannel = "TxLinearityDaxChannel";
-constexpr auto kKeyToneSpacing = "TxLinearityToneSpacingHz";
-constexpr auto kKeyTunePower = "TxLinearityTunePower";
-constexpr auto kKeyAverages = "TxLinearityAverages";
-constexpr auto kKeyTimeoutSec = "TxLinearityTimeoutSec";
-constexpr auto kKeyWindow = "TxLinearityWindow";
-constexpr auto kKeyMaxOrder = "TxLinearityMaxOrder";
-
 QString refText(double perTone, double pep, bool trusted)
 {
     if (!trusted) {
@@ -87,6 +77,11 @@ TxLinearityDialog::TxLinearityDialog(RadioModel* model, BandPlanManager* bandPla
 
     auto* root = new QVBoxLayout(bodyWidget());
     root->setSpacing(9);
+
+    // One read of the owned config object, then every control seeds from it
+    // (Principle V). load() has already defaulted and range-clamped, so no
+    // control below has to second-guess what came back.
+    m_settings = TxLinearitySettings::load();
 
     buildSetupGroup(root);
     buildTestGroup(root);
@@ -129,8 +124,7 @@ void TxLinearityDialog::buildSetupGroup(QVBoxLayout* root)
     m_daxChannel->setAccessibleName(tr("DAX IQ channel"));
     m_daxChannel->setAccessibleDescription(
         tr("Which of the radio's four DAX IQ channels captures the feedback signal."));
-    m_daxChannel->setCurrentIndex(
-        AppSettings::instance().value(kKeyDaxChannel, "1").toInt() - 1);
+    m_daxChannel->setCurrentIndex(m_settings.daxChannel - 1);
     grid->addWidget(m_daxChannel, 1, 1);
 
     grid->addWidget(new QLabel(tr("Feedback panadapter")), 1, 2);
@@ -176,9 +170,8 @@ void TxLinearityDialog::buildSetupGroup(QVBoxLayout* root)
     root->addWidget(group);
 
     connect(m_daxChannel, &QComboBox::currentIndexChanged, this, [this] {
-        AppSettings::instance().setValue(
-            kKeyDaxChannel, QString::number(m_daxChannel->currentData().toInt()));
-        AppSettings::instance().save();
+        m_settings.daxChannel = m_daxChannel->currentData().toInt();
+        m_settings.save();
         // A channel change invalidates the capture adapter bound to the old one.
         m_capture.reset();
         m_controller.setCaptureSource(nullptr);
@@ -203,14 +196,12 @@ void TxLinearityDialog::buildTestGroup(QVBoxLayout* root)
     auto* grid = new QGridLayout(group);
     grid->setSpacing(6);
 
-    AppSettings& settings = AppSettings::instance();
-
     grid->addWidget(new QLabel(tr("Tone spacing")), 0, 0);
     m_toneSpacing = new QDoubleSpinBox(group);
     m_toneSpacing->setRange(200.0, 10000.0);
     m_toneSpacing->setSingleStep(100.0);
     m_toneSpacing->setSuffix(tr(" Hz"));
-    m_toneSpacing->setValue(settings.value(kKeyToneSpacing, "2000").toDouble());
+    m_toneSpacing->setValue(m_settings.toneSpacingHz);
     m_toneSpacing->setAccessibleName(tr("Tone spacing"));
     m_toneSpacing->setAccessibleDescription(
         tr("Separation between the two test tones. Order 7 products reach three "
@@ -221,14 +212,14 @@ void TxLinearityDialog::buildTestGroup(QVBoxLayout* root)
     m_tunePower = new QSpinBox(group);
     m_tunePower->setRange(1, 100);
     m_tunePower->setSuffix(tr(" W"));
-    m_tunePower->setValue(settings.value(kKeyTunePower, "10").toInt());
+    m_tunePower->setValue(m_settings.tunePowerW);
     m_tunePower->setAccessibleName(tr("Tune power"));
     grid->addWidget(m_tunePower, 0, 3);
 
     grid->addWidget(new QLabel(tr("Averages")), 1, 0);
     m_averages = new QSpinBox(group);
     m_averages->setRange(1, 64);
-    m_averages->setValue(settings.value(kKeyAverages, "8").toInt());
+    m_averages->setValue(m_settings.averages);
     m_averages->setAccessibleName(tr("Averages"));
     m_averages->setAccessibleDescription(
         tr("Welch averages to collect. More averages lower the noise floor but "
@@ -239,7 +230,7 @@ void TxLinearityDialog::buildTestGroup(QVBoxLayout* root)
     m_timeoutSec = new QSpinBox(group);
     m_timeoutSec->setRange(1, 10);
     m_timeoutSec->setSuffix(tr(" s"));
-    m_timeoutSec->setValue(settings.value(kKeyTimeoutSec, "10").toInt());
+    m_timeoutSec->setValue(m_settings.timeoutSec);
     m_timeoutSec->setAccessibleName(tr("Transmit timeout"));
     m_timeoutSec->setAccessibleDescription(
         tr("Hard limit on continuous test transmission. Adjustable downward only."));
@@ -253,8 +244,7 @@ void TxLinearityDialog::buildTestGroup(QVBoxLayout* root)
         m_window->addItem(QString::fromStdString(txlin::windowKindLabel(kind)),
                           QString::fromStdString(txlin::windowKindKey(kind)));
     }
-    m_window->setCurrentIndex(m_window->findData(
-        settings.value(kKeyWindow, "blackman-harris-7").toString()));
+    m_window->setCurrentIndex(m_window->findData(m_settings.window));
     m_window->setAccessibleName(tr("Analysis window"));
     m_window->setAccessibleDescription(
         tr("Blackman-Harris 7 is the default because its low sidelobes are what make "
@@ -266,8 +256,7 @@ void TxLinearityDialog::buildTestGroup(QVBoxLayout* root)
     m_maxOrder->addItem(tr("IMD3"), 3);
     m_maxOrder->addItem(tr("IMD3 + 5"), 5);
     m_maxOrder->addItem(tr("IMD3 + 5 + 7"), 7);
-    m_maxOrder->setCurrentIndex(
-        m_maxOrder->findData(settings.value(kKeyMaxOrder, "7").toInt()));
+    m_maxOrder->setCurrentIndex(m_maxOrder->findData(m_settings.maxOrder));
     m_maxOrder->setAccessibleName(tr("Highest intermodulation order"));
     grid->addWidget(m_maxOrder, 2, 3);
 
@@ -548,14 +537,15 @@ void TxLinearityDialog::onStartClicked()
         return;
     }
 
-    AppSettings& settings = AppSettings::instance();
-    settings.setValue(kKeyToneSpacing, QString::number(m_toneSpacing->value()));
-    settings.setValue(kKeyTunePower, QString::number(m_tunePower->value()));
-    settings.setValue(kKeyAverages, QString::number(m_averages->value()));
-    settings.setValue(kKeyTimeoutSec, QString::number(m_timeoutSec->value()));
-    settings.setValue(kKeyWindow, m_window->currentData().toString());
-    settings.setValue(kKeyMaxOrder, QString::number(m_maxOrder->currentData().toInt()));
-    settings.save();
+    // One atomic write of the whole object, not six independent keys.
+    m_settings.daxChannel = m_daxChannel->currentData().toInt();
+    m_settings.toneSpacingHz = m_toneSpacing->value();
+    m_settings.tunePowerW = m_tunePower->value();
+    m_settings.averages = m_averages->value();
+    m_settings.timeoutSec = m_timeoutSec->value();
+    m_settings.window = m_window->currentData().toString();
+    m_settings.maxOrder = m_maxOrder->currentData().toInt();
+    m_settings.save();
 
     // Bring up the capture adapter for the selected channel if it is not
     // already bound. Doing this here rather than on every combo change keeps a

--- a/src/gui/TxLinearityDialog.h
+++ b/src/gui/TxLinearityDialog.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "PersistentDialog.h"
+#include "core/TxLinearitySettings.h"
 #include "core/txlinearity/TxLinearityController.h"
 
 #include <QString>
@@ -87,6 +88,10 @@ private:
 
     RadioModel* m_model{nullptr};
     BandPlanManager* m_bandPlan{nullptr};
+
+    // The feature's owned configuration object (Principle V) — loaded once,
+    // written as a unit. The dummy-load confirmation is deliberately not in it.
+    TxLinearitySettings m_settings;
 
     txlin::TxLinearityController m_controller;
     std::unique_ptr<txlin::FlexDaxIqCapture> m_capture;

--- a/src/gui/TxLinearityDialog.h
+++ b/src/gui/TxLinearityDialog.h
@@ -1,0 +1,128 @@
+#pragma once
+
+#include "PersistentDialog.h"
+#include "core/txlinearity/TxLinearityController.h"
+
+#include <QString>
+
+#include <memory>
+
+class QCheckBox;
+class QComboBox;
+class QDoubleSpinBox;
+class QLabel;
+class QProgressBar;
+class QPushButton;
+class QSpinBox;
+class QTableWidget;
+class QTimer;
+class QVBoxLayout;
+
+namespace AetherSDR {
+
+class BandPlanManager;
+class RadioModel;
+class TxLinearitySpectrumView;
+namespace txlin {
+class FlexDaxIqCapture;
+}
+
+// TX Linearity Analyzer — the instrument window.
+//
+// Puts numbers on transmitter and amplifier linearity using hardware the
+// operator already owns: the radio transmits a two-tone, attenuated TX energy
+// is routed back into a receive-only port, and a DAX IQ stream on a panadapter
+// watching that port becomes the measurement. Today a Flex owner can turn
+// SmartSignal on and look at a picture; this answers "is it actually helping,
+// on this band, at this power, into this amplifier" — which otherwise needs a
+// spectrum analyzer.
+//
+// The dialog owns the run: it drives the guided setup, gates the Run button on
+// every §8 interlock, and holds the controller and the capture adapter. It does
+// NOT do DSP — every number on screen comes from `core/txlinearity`, which
+// knows nothing about Qt or FlexRadio and is unit-tested without either.
+//
+// A NOTE ON THE SETUP FLOW. The brief calls for a wizard. This is a guided
+// setup SECTION rather than a modal multi-page QWizard, because a wizard would
+// be a new interaction pattern in an application that has none, and because the
+// operator needs to watch the live feedback level while adjusting a physical
+// attenuator — which a page-at-a-time wizard actively obstructs. The steps, the
+// order, and the refusal to run until each one validates are unchanged.
+class TxLinearityDialog : public PersistentDialog {
+    Q_OBJECT
+
+public:
+    TxLinearityDialog(RadioModel* model, BandPlanManager* bandPlan,
+                      QWidget* parent = nullptr);
+    ~TxLinearityDialog() override;
+
+private:
+    void buildSetupGroup(QVBoxLayout* root);
+    void buildTestGroup(QVBoxLayout* root);
+    void buildResultArea(QVBoxLayout* root);
+
+    void wireController();
+    void refreshPanChoices();
+    void refreshRunEnabled();
+    void onLevelUpdate(int channel, float rms);
+    void onStartClicked();
+    void onStopClicked();
+    void onResult(const txlin::LinearityResult& result);
+    void onAborted(txlin::AbortReason reason, const QString& text);
+    void onRefused(const QString& message, const QStringList& warnings);
+    void populateReadout(const txlin::LinearityResult& result);
+    void exportCsv();
+    void exportPng();
+    void setStatus(const QString& text, bool warning);
+
+    // Build the run request from the current UI state and radio state. Returns
+    // false with a reason when the radio cannot currently be measured — no TX
+    // slice, no band plan, and so on.
+    bool buildRunRequest(txlin::RunRequest& request, QString& reason) const;
+
+    // Everything that stamps an exported file: band, power, mode, APD state,
+    // radio model, window, averages. A measurement without this context is
+    // an anecdote.
+    [[nodiscard]] QString provenanceStamp() const;
+
+    RadioModel* m_model{nullptr};
+    BandPlanManager* m_bandPlan{nullptr};
+
+    txlin::TxLinearityController m_controller;
+    std::unique_ptr<txlin::FlexDaxIqCapture> m_capture;
+
+    // Setup
+    QComboBox* m_daxChannel{nullptr};
+    QComboBox* m_feedbackPan{nullptr};
+    QProgressBar* m_levelBar{nullptr};
+    QLabel* m_levelVerdict{nullptr};
+    QCheckBox* m_dummyLoadConfirm{nullptr};
+
+    // Test parameters
+    QDoubleSpinBox* m_toneSpacing{nullptr};
+    QSpinBox* m_tunePower{nullptr};
+    QSpinBox* m_averages{nullptr};
+    QSpinBox* m_timeoutSec{nullptr};
+    QComboBox* m_window{nullptr};
+    QComboBox* m_maxOrder{nullptr};
+
+    QPushButton* m_runButton{nullptr};
+    QPushButton* m_stopButton{nullptr};
+    QPushButton* m_exportCsvButton{nullptr};
+    QPushButton* m_exportPngButton{nullptr};
+    QLabel* m_statusLabel{nullptr};
+    QLabel* m_progressLabel{nullptr};
+
+    TxLinearitySpectrumView* m_plot{nullptr};
+    QTableWidget* m_readout{nullptr};
+
+    txlin::LinearityResult m_lastResult;
+    bool m_hasResult{false};
+    // Feedback level in dBFS, updated from the DAX IQ RMS meter. Held here
+    // rather than read back off the progress bar so the run gate reasons about
+    // the measurement, not about a widget's rounding.
+    double m_levelDbfs{-120.0};
+    bool m_levelSeen{false};
+};
+
+}  // namespace AetherSDR

--- a/src/gui/TxLinearitySpectrumView.cpp
+++ b/src/gui/TxLinearitySpectrumView.cpp
@@ -1,0 +1,355 @@
+#include "TxLinearitySpectrumView.h"
+
+#include "core/ThemeManager.h"
+
+#include <QFontMetricsF>
+#include <QPaintEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPolygonF>
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+namespace {
+
+constexpr int kLeftGutter = 52;    // dB axis labels
+constexpr int kBottomGutter = 26;  // frequency axis labels
+constexpr int kTopMargin = 26;     // product labels need headroom
+constexpr int kRightMargin = 12;
+
+QString dbcText(double dbc)
+{
+    return QString::number(dbc, 'f', 1) + QStringLiteral(" dBc");
+}
+
+}  // namespace
+
+TxLinearitySpectrumView::TxLinearitySpectrumView(QWidget* parent) : QWidget(parent)
+{
+    theme::setContainer(this, QStringLiteral("dialog/txLinearity/spectrum"));
+    setMinimumSize(420, 240);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    setAccessibleName(tr("TX linearity spectrum"));
+    setAccessibleDescription(tr("No measurement yet."));
+}
+
+void TxLinearitySpectrumView::setDbRange(double topDb, double bottomDb)
+{
+    if (bottomDb >= topDb) {
+        return;
+    }
+    m_topDb = topDb;
+    m_bottomDb = bottomDb;
+    update();
+}
+
+void TxLinearitySpectrumView::clear()
+{
+    m_hasResult = false;
+    m_result = txlin::LinearityResult{};
+    updateAccessibleSummary();
+    update();
+}
+
+void TxLinearitySpectrumView::clearReferenceResult()
+{
+    m_hasReference = false;
+    m_reference = txlin::LinearityResult{};
+    update();
+}
+
+void TxLinearitySpectrumView::setReferenceResult(const txlin::LinearityResult& result)
+{
+    m_reference = result;
+    m_hasReference = result.valid;
+    update();
+}
+
+void TxLinearitySpectrumView::setResult(const txlin::LinearityResult& result)
+{
+    m_result = result;
+    m_hasResult = result.valid;
+
+    if (m_hasResult) {
+        m_centreHz = 0.5 * (result.tone1.freqHz + result.tone2.freqHz);
+        // Fit the widest product with a margin of one more tone spacing, so an
+        // order-7 measurement is never cropped and the operator can see that
+        // there is nothing beyond it.
+        double reach = result.toneSpacingHz * 1.5;
+        for (const txlin::ImdProduct& p : result.products) {
+            reach = std::max(reach, std::abs(p.freqHz - m_centreHz) + result.toneSpacingHz);
+        }
+        m_spanHz = std::min(reach, result.sampleRateHz / 2.0);
+
+        // Autoscale the vertical span to the measurement: top just above the
+        // tones, bottom a little below the noise floor. A fixed range either
+        // wastes half the plot or crops the products, and the products are the
+        // point.
+        const double top = std::max(result.tone1.powerDb, result.tone2.powerDb) + 8.0;
+        const double bottom = std::min(result.noiseFloorDb - 12.0, top - 40.0);
+        m_topDb = top;
+        m_bottomDb = bottom;
+    }
+    updateAccessibleSummary();
+    update();
+}
+
+void TxLinearitySpectrumView::updateAccessibleSummary()
+{
+    // Custom-painted content is opaque to a screen reader, so the plot carries a
+    // spoken summary of what it draws. Every number here is also in the readout
+    // table — this is the plot's own description, not a substitute for it.
+    if (!m_hasResult) {
+        setAccessibleDescription(m_result.invalidReason.empty()
+                                     ? tr("No measurement yet.")
+                                     : QString::fromStdString(m_result.invalidReason));
+        return;
+    }
+    QString text = tr("Two tones %1 hertz apart. ")
+                       .arg(QString::number(m_result.toneSpacingHz, 'f', 0));
+    for (const txlin::ImdProduct& p : m_result.products) {
+        if (p.order != 3) {
+            continue;
+        }
+        text += p.limitedByNoiseFloor
+                    ? tr("%1 IMD3 below the noise floor. ")
+                          .arg(p.upper ? tr("Upper") : tr("Lower"))
+                    : tr("%1 IMD3 %2 dB below one tone. ")
+                          .arg(p.upper ? tr("Upper") : tr("Lower"))
+                          .arg(QString::number(-p.dbcPerTone, 'f', 1));
+    }
+    text += tr("Instrument noise floor %1 dBFS.")
+                .arg(QString::number(m_result.noiseFloorDb, 'f', 1));
+    setAccessibleDescription(text);
+}
+
+double TxLinearitySpectrumView::freqToX(double hz, const QRectF& plot) const
+{
+    const double lo = m_centreHz - m_spanHz;
+    const double hi = m_centreHz + m_spanHz;
+    if (hi <= lo) {
+        return plot.left();
+    }
+    return plot.left() + plot.width() * (hz - lo) / (hi - lo);
+}
+
+double TxLinearitySpectrumView::dbToY(double db, const QRectF& plot) const
+{
+    const double clamped = std::clamp(db, m_bottomDb, m_topDb);
+    return plot.top() + plot.height() * (m_topDb - clamped) / (m_topDb - m_bottomDb);
+}
+
+void TxLinearitySpectrumView::drawGrid(QPainter& painter, const QRectF& plot) const
+{
+    ThemeManager& theme = ThemeManager::instance();
+    const QColor gridColor = theme.color(this, QStringLiteral("color.background.2"));
+    const QColor textColor = theme.color(this, QStringLiteral("color.text.secondary"));
+
+    painter.setPen(QPen(gridColor, 1.0));
+    painter.drawRect(plot);
+
+    QFont small = font();
+    small.setPointSizeF(std::max(7.0, small.pointSizeF() - 2.0));
+    painter.setFont(small);
+    const QFontMetricsF metrics(small);
+
+    // dB gridlines every 10 dB, labelled every 20 so the axis stays readable on
+    // a short plot.
+    const double firstLine = std::ceil(m_bottomDb / 10.0) * 10.0;
+    for (double db = firstLine; db <= m_topDb; db += 10.0) {
+        const double y = dbToY(db, plot);
+        painter.setPen(QPen(gridColor, 1.0, Qt::DotLine));
+        painter.drawLine(QPointF(plot.left(), y), QPointF(plot.right(), y));
+        if (std::fmod(std::abs(db), 20.0) < 0.01) {
+            painter.setPen(textColor);
+            const QString label = QString::number(db, 'f', 0);
+            painter.drawText(QPointF(plot.left() - metrics.horizontalAdvance(label) - 6.0,
+                                     y + metrics.height() / 3.0),
+                             label);
+        }
+    }
+
+    // Frequency gridlines relative to the two-tone centre — the operator thinks
+    // in offsets from the transmission, not in absolute baseband bins.
+    const double step = (m_spanHz > 12000.0) ? 5000.0 : ((m_spanHz > 4000.0) ? 2000.0 : 1000.0);
+    for (double off = -std::floor(m_spanHz / step) * step; off <= m_spanHz; off += step) {
+        const double x = freqToX(m_centreHz + off, plot);
+        painter.setPen(QPen(gridColor, 1.0, Qt::DotLine));
+        painter.drawLine(QPointF(x, plot.top()), QPointF(x, plot.bottom()));
+        painter.setPen(textColor);
+        const QString label = QString::number(off / 1000.0, 'f', off == 0.0 ? 0 : 1);
+        painter.drawText(QPointF(x - metrics.horizontalAdvance(label) / 2.0,
+                                 plot.bottom() + metrics.height() + 2.0),
+                         label);
+    }
+    painter.setPen(textColor);
+    painter.drawText(QPointF(plot.left(), plot.bottom() + 2.0 * metrics.height() + 2.0),
+                     tr("kHz from centre"));
+}
+
+void TxLinearitySpectrumView::drawTrace(QPainter& painter, const QRectF& plot,
+                                        const txlin::LinearityResult& result,
+                                        bool dimmed) const
+{
+    if (result.spectrumDb.empty() || result.binHz <= 0.0) {
+        return;
+    }
+    ThemeManager& theme = ThemeManager::instance();
+    QColor traceColor = dimmed ? theme.color(this, QStringLiteral("color.text.secondary"))
+                               : theme.color(this, QStringLiteral("color.accent"));
+    if (dimmed) {
+        traceColor.setAlpha(140);
+    }
+
+    const int n = int(result.spectrumDb.size());
+    const int centre = n / 2;
+    const double loHz = m_centreHz - m_spanHz;
+    const double hiHz = m_centreHz + m_spanHz;
+    const int loBin = std::clamp(int(std::floor(loHz / result.binHz)) + centre, 0, n - 1);
+    const int hiBin = std::clamp(int(std::ceil(hiHz / result.binHz)) + centre, 0, n - 1);
+
+    // More bins than pixels: draw the per-pixel MAXIMUM rather than sampling.
+    // Sampling would alias a narrow product straight out of the picture, which
+    // for this instrument means the operator sees a clean signal that is not.
+    const int columns = std::max(1, int(plot.width()));
+    std::vector<double> peak(std::size_t(columns), -1e30);
+    for (int k = loBin; k <= hiBin; ++k) {
+        const double hz = double(k - centre) * result.binHz;
+        const int col = std::clamp(int(freqToX(hz, plot) - plot.left()), 0, columns - 1);
+        peak[std::size_t(col)] = std::max(peak[std::size_t(col)],
+                                          double(result.spectrumDb[std::size_t(k)]));
+    }
+
+    QPolygonF poly;
+    poly.reserve(columns);
+    for (int c = 0; c < columns; ++c) {
+        if (peak[std::size_t(c)] < -1e29) {
+            continue;
+        }
+        poly << QPointF(plot.left() + c, dbToY(peak[std::size_t(c)], plot));
+    }
+    painter.setPen(QPen(traceColor, dimmed ? 1.0 : 1.4));
+    painter.setBrush(Qt::NoBrush);
+    painter.drawPolyline(poly);
+}
+
+void TxLinearitySpectrumView::drawBands(QPainter& painter, const QRectF& plot) const
+{
+    ThemeManager& theme = ThemeManager::instance();
+    QColor shade = theme.color(this, QStringLiteral("color.text.secondary"));
+    shade.setAlpha(38);
+
+    const auto shadeBand = [&](const std::optional<txlin::BandPower>& band,
+                               const QString& label) {
+        if (!band.has_value()) {
+            return;
+        }
+        const double x0 = freqToX(band->lowHz, plot);
+        const double x1 = freqToX(band->highHz, plot);
+        const QRectF rect(QPointF(x0, plot.top()), QPointF(x1, plot.bottom()));
+        painter.fillRect(rect.intersected(plot), shade);
+        painter.setPen(theme.color(this, QStringLiteral("color.text.secondary")));
+        painter.drawText(QPointF(x0 + 2.0, plot.bottom() - 4.0), label);
+    };
+
+    shadeBand(m_result.acprLow, tr("ACPR"));
+    shadeBand(m_result.acprHigh, tr("ACPR"));
+    shadeBand(m_result.shoulderLow, tr("Shoulder"));
+    shadeBand(m_result.shoulderHigh, tr("Shoulder"));
+}
+
+void TxLinearitySpectrumView::drawMarkers(QPainter& painter, const QRectF& plot) const
+{
+    ThemeManager& theme = ThemeManager::instance();
+    const QColor toneColor = theme.color(this, QStringLiteral("color.accent"));
+    const QColor productColor = theme.color(this, QStringLiteral("color.text.primary"));
+    const QColor mutedColor = theme.color(this, QStringLiteral("color.text.secondary"));
+    const QColor floorColor = theme.color(this, QStringLiteral("color.accent.warning"));
+
+    QFont small = font();
+    small.setPointSizeF(std::max(7.0, small.pointSizeF() - 2.0));
+    painter.setFont(small);
+    const QFontMetricsF metrics(small);
+
+    // Instrument noise floor. Drawn across the whole plot because it is the
+    // line every product has to clear to mean anything — the operator should
+    // be able to see at a glance which products are above it.
+    const double floorY = dbToY(m_result.noiseFloorDb, plot);
+    painter.setPen(QPen(floorColor, 1.0, Qt::DashLine));
+    painter.drawLine(QPointF(plot.left(), floorY), QPointF(plot.right(), floorY));
+    painter.setPen(floorColor);
+    painter.drawText(QPointF(plot.left() + 4.0, floorY - 3.0), tr("noise floor"));
+
+    const auto markTone = [&](const txlin::TonePeak& tone, const QString& label) {
+        if (!tone.valid) {
+            return;
+        }
+        const double x = freqToX(tone.freqHz, plot);
+        const double y = dbToY(tone.powerDb, plot);
+        painter.setPen(QPen(toneColor, 1.0, Qt::DashLine));
+        painter.drawLine(QPointF(x, y), QPointF(x, plot.top()));
+        painter.setPen(toneColor);
+        painter.drawText(QPointF(x - metrics.horizontalAdvance(label) / 2.0,
+                                 plot.top() - 4.0),
+                         label);
+    };
+    markTone(m_result.tone1, QStringLiteral("f1"));
+    markTone(m_result.tone2, QStringLiteral("f2"));
+
+    for (const txlin::ImdProduct& product : m_result.products) {
+        const double x = freqToX(product.freqHz, plot);
+        if (x < plot.left() || x > plot.right()) {
+            continue;
+        }
+        const double y = dbToY(product.powerDb, plot);
+        // A noise-limited product is drawn muted and labelled with its order
+        // only. Printing "-31.4 dBc" beside a peak that is actually the
+        // instrument's own noise is the specific mistake this whole feature
+        // exists to stop an operator making.
+        const bool trusted = !product.limitedByNoiseFloor;
+        painter.setPen(QPen(trusted ? productColor : mutedColor, 1.0));
+        painter.drawLine(QPointF(x, y), QPointF(x, y - 10.0));
+
+        const QString label =
+            trusted ? QStringLiteral("IMD%1  %2").arg(product.order).arg(dbcText(product.dbcPerTone))
+                    : tr("IMD%1  (noise)").arg(product.order);
+        const double tx = std::clamp(x - metrics.horizontalAdvance(label) / 2.0,
+                                     plot.left(), plot.right() - metrics.horizontalAdvance(label));
+        painter.drawText(QPointF(tx, y - 13.0), label);
+    }
+}
+
+void TxLinearitySpectrumView::paintEvent(QPaintEvent* event)
+{
+    Q_UNUSED(event);
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+
+    ThemeManager& theme = ThemeManager::instance();
+    painter.fillRect(rect(), theme.color(this, QStringLiteral("color.background.0")));
+
+    const QRectF plot(kLeftGutter, kTopMargin,
+                      std::max(10, width() - kLeftGutter - kRightMargin),
+                      std::max(10, height() - kTopMargin - kBottomGutter));
+
+    if (!m_hasResult) {
+        painter.setPen(theme.color(this, QStringLiteral("color.text.secondary")));
+        const QString message = m_result.invalidReason.empty()
+                                    ? tr("Run a measurement to see the TX spectrum.")
+                                    : QString::fromStdString(m_result.invalidReason);
+        painter.drawText(rect(), Qt::AlignCenter, message);
+        return;
+    }
+
+    drawGrid(painter, plot);
+    drawBands(painter, plot);
+    if (m_hasReference) {
+        drawTrace(painter, plot, m_reference, true);
+    }
+    drawTrace(painter, plot, m_result, false);
+    drawMarkers(painter, plot);
+}
+
+}  // namespace AetherSDR

--- a/src/gui/TxLinearitySpectrumView.h
+++ b/src/gui/TxLinearitySpectrumView.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "core/txlinearity/TxLinearityTypes.h"
+
+#include <QWidget>
+
+class QPaintEvent;
+
+namespace AetherSDR {
+
+// The marked TX spectrum — the core of the linearity analyzer's display.
+//
+// A raw spectrum picture is what SmartSDR already gives an operator. What it
+// does not give is which peak is which: this view labels f1 and f2, marks every
+// computed IMD product with its order and its level in dBc, draws the measured
+// instrument noise floor as a line, and shades the shoulder and ACPR
+// integration bands so the operator can see exactly what was integrated rather
+// than trusting an offset label in a table. A marked spectrum beats a raw
+// picture, and it is the difference between a display and an instrument.
+//
+// Deliberately a plain QWidget with a paintEvent, not a QRhiWidget like
+// SpectrumWidget. That one is a display path drawing tens of thousands of bins
+// at frame rate and needs the GPU; this draws one static averaged trace when a
+// measurement completes. Reaching for the GPU path here would inherit its
+// context-loss and readback machinery for a plot that repaints a few times a
+// minute.
+class TxLinearitySpectrumView : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit TxLinearitySpectrumView(QWidget* parent = nullptr);
+
+    // Show a completed measurement. An invalid result clears the plot and
+    // displays the refusal reason, because a stale trace next to a failed
+    // measurement is how an operator ends up reading last run's numbers.
+    void setResult(const txlin::LinearityResult& result);
+    void clear();
+
+    // Overlay a second, dimmed trace for A/B comparison (SmartSignal off vs
+    // on). Phase 2 drives this; the view supports it now so the Phase 2 change
+    // is a call site rather than a rewrite of the paint code.
+    void setReferenceResult(const txlin::LinearityResult& result);
+    void clearReferenceResult();
+
+    // Vertical span, dBFS. Defaults cover a full-scale tone down to below any
+    // realistic instrument floor.
+    void setDbRange(double topDb, double bottomDb);
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+
+private:
+    // Baseband Hz -> x pixel, dBFS -> y pixel, over the plot rect.
+    [[nodiscard]] double freqToX(double hz, const QRectF& plot) const;
+    [[nodiscard]] double dbToY(double db, const QRectF& plot) const;
+
+    void drawGrid(QPainter& painter, const QRectF& plot) const;
+    void drawTrace(QPainter& painter, const QRectF& plot,
+                   const txlin::LinearityResult& result, bool dimmed) const;
+    void drawBands(QPainter& painter, const QRectF& plot) const;
+    void drawMarkers(QPainter& painter, const QRectF& plot) const;
+    void updateAccessibleSummary();
+
+    txlin::LinearityResult m_result;
+    txlin::LinearityResult m_reference;
+    bool m_hasResult = false;
+    bool m_hasReference = false;
+
+    double m_topDb = 0.0;
+    double m_bottomDb = -140.0;
+    // Horizontal span, Hz either side of the two-tone centre. Recomputed from
+    // the result so the products always fit with margin, rather than being a
+    // fixed span the operator has to zoom.
+    double m_spanHz = 20000.0;
+    double m_centreHz = 0.0;
+};
+
+}  // namespace AetherSDR

--- a/tests/TxLinearityTestSignals.h
+++ b/tests/TxLinearityTestSignals.h
@@ -1,0 +1,173 @@
+#pragma once
+
+// Deterministic synthetic signal generators for the TX linearity analyzer
+// tests.
+//
+// These ARE the golden test vectors. They are checked in as a generator rather
+// than as captured sample files on purpose: a generator is reviewable (a
+// reviewer can see that the two-tone really is two tones and that the PA model
+// really has the coefficients the assertions claim), it is exactly reproducible
+// on every platform because every random draw comes from a seeded std::mt19937
+// with no floating-point-order dependence, and it lets a test state its
+// expected answer as a closed-form expression instead of a magic number nobody
+// can re-derive. Nothing here needs a radio, so all of it runs in CI.
+//
+// The analytic IMD levels below are derived from the standard two-tone
+// expansion of a memoryless odd-order polynomial, not taken from any
+// implementation. For x = A(e1 + e2) with e_i = exp(j w_i t):
+//
+//   |x|^2 x = A^3 [ 3e1 + 3e2 + e1^2 e2* + e2^2 e1* ]
+//   |x|^4 x = A^5 [ 10e1 + 10e2 + 5 e1^2 e2* + 5 e2^2 e1*
+//                   + e1^3 e2*^2 + e2^3 e1*^2 ]
+//
+// so for y = a1 x + a3 |x|^2 x + a5 |x|^4 x:
+//
+//   fundamental amplitude = a1 A + 3 a3 A^3 + 10 a5 A^5
+//   IMD3 amplitude        =        a3 A^3 +  5 a5 A^5
+//   IMD5 amplitude        =                     a5 A^5
+//
+// (Standard result; see e.g. Cripps, "RF Power Amplifiers for Wireless
+// Communications", ch. 9, or Ding et al. on memory-polynomial predistortion for
+// the general form.)
+
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <numbers>
+#include <optional>
+#include <random>
+#include <vector>
+
+namespace txlin_test {
+
+// Memory polynomial y[n] = sum_{k odd} sum_{m} a[k][m] x[n-m] |x[n-m]|^(k-1).
+//
+// `coeff[i][m]` is the coefficient for order 2i+1 at memory tap m. Depth 1
+// (m == 0 only) is the memoryless case, which is the only one with the closed
+// form above — deeper memory is supported so the generator can exercise the
+// Phase 3 model fit, but its IMD levels are frequency-dependent and are not
+// asserted analytically.
+class MemoryPolynomialPa {
+public:
+    MemoryPolynomialPa(double a1, double a3, double a5)
+        : m_coeff{{a1, 0.0, 0.0}, {a3, 0.0, 0.0}, {a5, 0.0, 0.0}}, m_depth(1)
+    {
+    }
+
+    void setMemoryTap(int order, int tap, double value)
+    {
+        const std::size_t i = std::size_t((order - 1) / 2);
+        m_coeff[i][std::size_t(tap)] = value;
+        m_depth = std::max(m_depth, tap + 1);
+    }
+
+    [[nodiscard]] int depth() const { return m_depth; }
+
+    [[nodiscard]] std::vector<std::complex<double>>
+    apply(const std::vector<std::complex<double>>& x) const
+    {
+        std::vector<std::complex<double>> y(x.size(), {0.0, 0.0});
+        for (std::size_t n = 0; n < x.size(); ++n) {
+            for (int m = 0; m < m_depth; ++m) {
+                if (n < std::size_t(m)) {
+                    continue;
+                }
+                const std::complex<double> xm = x[n - std::size_t(m)];
+                const double mag2 = std::norm(xm);
+                double magPow = 1.0;
+                for (std::size_t i = 0; i < 3; ++i) {
+                    y[n] += m_coeff[i][std::size_t(m)] * xm * magPow;
+                    magPow *= mag2;
+                }
+            }
+        }
+        return y;
+    }
+
+    // Closed-form levels for a balanced two-tone of per-tone amplitude A.
+    // Disengaged when the model has memory, where no closed form exists.
+    struct AnalyticLevels {
+        double toneAmplitude;
+        double imd3Amplitude;
+        double imd5Amplitude;
+        [[nodiscard]] double imd3DbcPerTone() const
+        {
+            return 20.0 * std::log10(std::abs(imd3Amplitude) / std::abs(toneAmplitude));
+        }
+        [[nodiscard]] double imd5DbcPerTone() const
+        {
+            return 20.0 * std::log10(std::abs(imd5Amplitude) / std::abs(toneAmplitude));
+        }
+    };
+
+    [[nodiscard]] std::optional<AnalyticLevels> analytic(double a) const
+    {
+        if (m_depth != 1) {
+            return std::nullopt;
+        }
+        const double a1 = m_coeff[0][0];
+        const double a3 = m_coeff[1][0];
+        const double a5 = m_coeff[2][0];
+        const double a3p = a * a * a;
+        const double a5p = a * a * a * a * a;
+        AnalyticLevels out;
+        out.toneAmplitude = a1 * a + 3.0 * a3 * a3p + 10.0 * a5 * a5p;
+        out.imd3Amplitude = a3 * a3p + 5.0 * a5 * a5p;
+        out.imd5Amplitude = a5 * a5p;
+        return out;
+    }
+
+private:
+    // [order index 0..2][memory tap 0..3]
+    double m_coeff[3][4]{};
+    int m_depth = 1;
+};
+
+// Two complex baseband tones of equal amplitude `amp`, at f1 and f2 Hz.
+//
+// Frequencies are NOT snapped to bin centres and callers are encouraged to keep
+// them off-bin: an on-bin tone is the easy case for both the peak interpolator
+// and the leakage floor, so a test that only ever uses on-bin tones passes
+// while the instrument is wrong about every real signal.
+inline std::vector<std::complex<double>> twoTone(std::size_t n, double sampleRate,
+                                                 double f1, double f2,
+                                                 double amp, double amp2 = -1.0,
+                                                 double phase2 = 0.0)
+{
+    const double a2 = (amp2 < 0.0) ? amp : amp2;
+    std::vector<std::complex<double>> x(n);
+    const double w1 = 2.0 * std::numbers::pi * f1 / sampleRate;
+    const double w2 = 2.0 * std::numbers::pi * f2 / sampleRate;
+    for (std::size_t i = 0; i < n; ++i) {
+        const double t = double(i);
+        x[i] = amp * std::complex<double>(std::cos(w1 * t), std::sin(w1 * t))
+               + a2 * std::complex<double>(std::cos(w2 * t + phase2),
+                                           std::sin(w2 * t + phase2));
+    }
+    return x;
+}
+
+// Additive complex white Gaussian noise, `sigma` being the standard deviation
+// of EACH quadrature — so the total noise power is 2*sigma^2 and, spread over
+// N bins, the per-bin floor is 2*sigma^2/N. Seeded, so the "measurement is
+// limited by the noise floor" test is reproducible rather than flaky.
+inline void addNoise(std::vector<std::complex<double>>& x, double sigma, unsigned seed)
+{
+    std::mt19937 rng(seed);
+    std::normal_distribution<double> dist(0.0, sigma);
+    for (std::complex<double>& s : x) {
+        s += std::complex<double>(dist(rng), dist(rng));
+    }
+}
+
+inline std::vector<std::complex<float>>
+toFloat(const std::vector<std::complex<double>>& x, std::size_t offset, std::size_t count)
+{
+    std::vector<std::complex<float>> out(count);
+    for (std::size_t i = 0; i < count; ++i) {
+        out[i] = std::complex<float>(float(x[offset + i].real()), float(x[offset + i].imag()));
+    }
+    return out;
+}
+
+}  // namespace txlin_test

--- a/tests/tx_linearity_imd_test.cpp
+++ b/tests/tx_linearity_imd_test.cpp
@@ -1,0 +1,277 @@
+// TX Linearity Analyzer — IMD measurement tests against a synthetic PA.
+//
+// Every assertion here compares the analyzer's answer against a CLOSED-FORM
+// expectation derived from the polynomial's coefficients (see
+// TxLinearityTestSignals.h), not against a previously recorded output. That
+// distinction is the difference between a test that proves the instrument
+// measures correctly and a test that proves it still does whatever it did last
+// week.
+
+#include "core/txlinearity/ITxCaptureSource.h"
+#include "core/txlinearity/ImdAnalyzer.h"
+#include "core/txlinearity/TxSpectrumAnalyzer.h"
+
+#include "TxLinearityTestSignals.h"
+
+#include <cmath>
+#include <cstdio>
+#include <optional>
+
+using namespace AetherSDR::txlin;
+using namespace txlin_test;
+
+static int g_failures = 0;
+
+static void check(bool cond, const char* what)
+{
+    if (!cond) {
+        std::fprintf(stderr, "FAIL: %s\n", what);
+        ++g_failures;
+    }
+}
+
+static void checkNear(double got, double want, double tol, const char* what)
+{
+    if (!(std::abs(got - want) <= tol)) {
+        std::fprintf(stderr, "FAIL: %s (got %.4f, want %.4f +/- %.4f)\n",
+                     what, got, want, tol);
+        ++g_failures;
+    }
+}
+
+namespace {
+
+constexpr double kSampleRate = 192000.0;
+constexpr int kFftSize = 16384;
+constexpr int kFrames = 8;
+
+const ImdProduct* findProduct(const LinearityResult& r, int order, bool upper)
+{
+    for (const ImdProduct& p : r.products) {
+        if (p.order == order && p.upper == upper) {
+            return &p;
+        }
+    }
+    return nullptr;
+}
+
+LinearityResult analyze(const std::vector<std::complex<double>>& x,
+                        const ImdConfig& cfg = {})
+{
+    TxSpectrumAnalyzer an(kFftSize, WindowKind::BlackmanHarris7);
+    for (int f = 0; f < kFrames; ++f) {
+        an.accumulate(toFloat(x, std::size_t(f) * std::size_t(kFftSize),
+                              std::size_t(kFftSize)));
+    }
+    return measureTwoTone(an, kSampleRate, cfg, false);
+}
+
+// Off-bin on purpose — see the leakage discussion in the spectrum test.
+double toneF1()
+{
+    return -1000.0 + 0.29 * TxSpectrumAnalyzer::binHz(kSampleRate, kFftSize);
+}
+
+}  // namespace
+
+int main()
+{
+    const double f1 = toneF1();
+    const double spacing = 2000.0;
+    const double f2 = f1 + spacing;
+    const std::size_t nSamples = std::size_t(kFftSize) * std::size_t(kFrames);
+
+    // ── Known-coefficient PA, analytic IMD3/IMD5 ────────────────────────────
+    {
+        // Compressive third order (a3 negative, as a real PA is) plus a small
+        // fifth. Chosen so IMD3 lands near -35 dBc and IMD5 near -60 dBc —
+        // realistic levels, both comfortably above the synthetic noise floor,
+        // and far enough apart that a bug swapping the two is visible.
+        const double amp = 0.30;
+        const MemoryPolynomialPa pa(1.0, -0.55, 0.12);
+        const std::optional<MemoryPolynomialPa::AnalyticLevels> want = pa.analytic(amp);
+        check(want.has_value(), "memoryless model has a closed form");
+
+        std::vector<std::complex<double>> x =
+            twoTone(nSamples, kSampleRate, f1, f2, amp);
+        x = pa.apply(x);
+
+        const LinearityResult r = analyze(x);
+        check(r.valid, "distorted two-tone measures successfully");
+        checkNear(r.toneSpacingHz, spacing, 0.5, "tone spacing recovered");
+        checkNear(r.toneImbalanceDb, 0.0, 0.05, "balanced tones report no imbalance");
+
+        const double toneDb = 20.0 * std::log10(std::abs(want->toneAmplitude));
+        checkNear(r.tone1.powerDb, toneDb, 0.1, "lower tone amplitude matches the model");
+        checkNear(r.tone2.powerDb, toneDb, 0.1, "upper tone amplitude matches the model");
+
+        // The target from the spec: +/-0.5 dB for products at least 20 dB above
+        // the synthetic noise floor. The analyzer does considerably better than
+        // that on a noiseless synthetic, so hold it to 0.3 dB — a regression
+        // that merely stays inside 0.5 dB should still be visible.
+        for (bool upper : {false, true}) {
+            const ImdProduct* p3 = findProduct(r, 3, upper);
+            check(p3 != nullptr, "IMD3 product located");
+            if (p3 != nullptr) {
+                checkNear(p3->dbcPerTone, want->imd3DbcPerTone(), 0.3,
+                          "IMD3 dBc/tone matches the analytic value");
+                check(!p3->limitedByNoiseFloor, "IMD3 is not noise-limited here");
+                checkNear(p3->freqHz, upper ? f2 + spacing : f1 - spacing, 2.0,
+                          "IMD3 lands at the predicted frequency");
+            }
+            const ImdProduct* p5 = findProduct(r, 5, upper);
+            check(p5 != nullptr, "IMD5 product located");
+            if (p5 != nullptr) {
+                checkNear(p5->dbcPerTone, want->imd5DbcPerTone(), 0.3,
+                          "IMD5 dBc/tone matches the analytic value");
+            }
+        }
+
+        // ── Reference convention ────────────────────────────────────────────
+        //
+        // The trap this feature must not fall into. For a balanced pair the
+        // PEP-referenced and tone-referenced numbers differ by exactly
+        // 10*log10(4) = 6.0206 dB, and both are reported, always labelled.
+        checkNear(r.pepDb - r.tone1.powerDb, kPepOverToneDb, 0.02,
+                  "measured PEP sits 6.02 dB above one tone");
+        const ImdProduct* p3 = findProduct(r, 3, false);
+        if (p3 != nullptr) {
+            checkNear(p3->dbcPerTone - p3->dbcPep, kPepOverToneDb, 0.02,
+                      "per-tone and PEP dBc differ by exactly 6.02 dB");
+        }
+
+        // Shoulder and ACPR are engaged and sit below the tones. Their absolute
+        // level depends on the whole skirt, so assert the ordering and the
+        // reference consistency rather than a value the model does not predict
+        // in closed form.
+        check(r.shoulderLow.has_value() && r.shoulderHigh.has_value(),
+              "shoulder levels measured");
+        check(r.acprLow.has_value() && r.acprHigh.has_value(), "ACPR measured");
+        if (r.acprLow.has_value()) {
+            check(r.acprLow->dbcPerTone < 0.0, "lower ACPR sits below the tone level");
+            checkNear(r.acprLow->dbcPerTone - r.acprLow->dbcPep, kPepOverToneDb, 0.02,
+                      "ACPR carries both reference conventions consistently");
+        }
+    }
+
+    // ── Imbalanced tones ────────────────────────────────────────────────────
+    //
+    // With unequal tones the exact 6.02 dB PEP relation stops holding, and the
+    // analyzer must report the measured envelope rather than the idealisation —
+    // the idealisation is wrong in the direction that flatters the radio.
+    {
+        const double a1 = 0.30;
+        const double a2 = a1 * std::pow(10.0, -1.5 / 20.0);   // 1.5 dB down
+        std::vector<std::complex<double>> x =
+            twoTone(nSamples, kSampleRate, f1, f2, a1, a2);
+        x = MemoryPolynomialPa(1.0, -0.55, 0.0).apply(x);
+
+        const LinearityResult r = analyze(x);
+        check(r.valid, "imbalanced two-tone measures successfully");
+
+        // The OUTPUT imbalance is not the input imbalance. Expanding
+        // y = a1 x + a3|x|^2 x for x = A1 e1 + A2 e2 gives fundamental
+        // coefficients
+        //     e1: a1 A1 + a3 (A1^3 + 2 A1 A2^2)
+        //     e2: a1 A2 + a3 (A2^3 + 2 A1^2 A2)
+        // — each tone is compressed by its own amplitude AND cross-modulated by
+        // the other's, and the two effects do not cancel. A compressive a3
+        // therefore WIDENS a 1.5 dB input imbalance to about 1.64 dB at the
+        // output. Asserting the input figure here would have been asserting
+        // that the analyzer fails to see real cross-modulation.
+        const double a3 = -0.55;
+        const double out1 = a1 + a3 * (a1 * a1 * a1 + 2.0 * a1 * a2 * a2);
+        const double out2 = a2 + a3 * (a2 * a2 * a2 + 2.0 * a1 * a1 * a2);
+        const double expectedImbalance = 20.0 * std::log10(out2 / out1);
+        checkNear(r.toneImbalanceDb, expectedImbalance, 0.05,
+                  "tone imbalance matches the model's output imbalance");
+        check(expectedImbalance < -1.5,
+              "and the compressive PA has widened the input imbalance, not narrowed it");
+
+        // Envelope peak is A1 + A2, so PEP sits strictly below the balanced
+        // idealisation of one tone + 6.02 dB. Reporting the idealisation would
+        // be wrong in the direction that flatters the radio.
+        check(r.pepDb - r.tone1.powerDb < kPepOverToneDb,
+              "an imbalanced pair reports less PEP headroom than 6.02 dB");
+        checkNear(r.pepDb, 20.0 * std::log10(out1 + out2), 0.1,
+                  "measured PEP matches the model's envelope peak");
+    }
+
+    // ── Noise floor honesty ─────────────────────────────────────────────────
+    //
+    // The instrument must say "I cannot measure this" rather than emit a
+    // confident wrong number. A measurement that is actually reading the
+    // analyzer's own noise is worse than no measurement at all.
+    {
+        // Very nearly linear: IMD3 around -85 dBc, buried under the noise added
+        // below.
+        const double amp = 0.30;
+        std::vector<std::complex<double>> x =
+            twoTone(nSamples, kSampleRate, f1, f2, amp);
+        x = MemoryPolynomialPa(1.0, -1.5e-4, 0.0).apply(x);
+        addNoise(x, 3e-4, 0x5EEDu);
+
+        const LinearityResult r = analyze(x);
+        check(r.valid, "a noisy capture still measures the fundamentals");
+
+        // Per-quadrature sigma s gives total noise power 2s^2. The reported
+        // floor is PER ANALYSIS BIN, and a bin's noise power is not simply
+        // 2s^2/N — the window's equivalent noise bandwidth comes into it:
+        //
+        //   E|S[k]|^2 = 2 s^2 * sum(w^2)/sum(w)^2 = 2 s^2 * ENBW / N
+        //
+        // For the 7-term Blackman-Harris, ENBW is about 2.63 bins, so the floor
+        // sits about 4.2 dB above the naive 2s^2/N figure. Getting this wrong in
+        // the other direction — reporting the naive number — would make every
+        // product look 4 dB more trustworthy than it is. Welch averaging reduces
+        // the VARIANCE of this estimate, not its mean.
+        const double enbw = makeWindow(WindowKind::BlackmanHarris7,
+                                       std::size_t(kFftSize)).enbwBins;
+        const double expectedFloorDb =
+            10.0 * std::log10(2.0 * 3e-4 * 3e-4 * enbw / double(kFftSize));
+        checkNear(r.noiseFloorDb, expectedFloorDb, 1.0,
+                  "reported noise floor matches the injected noise through the window ENBW");
+
+        const ImdProduct* p3 = findProduct(r, 3, false);
+        check(p3 != nullptr, "a product is still located in noise");
+        if (p3 != nullptr) {
+            check(p3->limitedByNoiseFloor,
+                  "a product buried in noise is flagged rather than quoted");
+        }
+    }
+
+    // ── Refusals ────────────────────────────────────────────────────────────
+    {
+        // Nothing accumulated at all.
+        TxSpectrumAnalyzer empty(kFftSize, WindowKind::BlackmanHarris7);
+        const LinearityResult r = measureTwoTone(empty, kSampleRate, ImdConfig{}, false);
+        check(!r.valid, "an empty analyzer refuses to measure");
+        check(!r.invalidReason.empty(), "the refusal carries a reason");
+
+        // Two tones closer together than the window can separate must be
+        // refused, not reported as one tone twice with a nonsense spacing.
+        const double tooClose = 3.0 * TxSpectrumAnalyzer::binHz(kSampleRate, kFftSize);
+        const std::vector<std::complex<double>> x =
+            twoTone(nSamples, kSampleRate, f1, f1 + tooClose, 0.3);
+        const LinearityResult rc = analyze(x);
+        check(!rc.valid, "unresolvable tone spacing is refused");
+    }
+
+    // ── Clip detection is a population, not a sample ─────────────────────────
+    {
+        std::vector<std::complex<float>> frame(4096, std::complex<float>(0.1f, 0.0f));
+        frame[7] = std::complex<float>(1.0f, 0.0f);
+        check(saturatedFraction(frame) < kClippedFractionThreshold,
+              "one full-scale sample in 4096 is not clipping");
+        for (std::size_t i = 0; i < 512; ++i) {
+            frame[i] = std::complex<float>(1.0f, 0.0f);
+        }
+        check(saturatedFraction(frame) > kClippedFractionThreshold,
+              "a saturated population is clipping");
+    }
+
+    if (g_failures == 0) {
+        std::printf("tx_linearity_imd_test: all checks passed\n");
+    }
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/tx_linearity_safety_test.cpp
+++ b/tests/tx_linearity_safety_test.cpp
@@ -1,0 +1,229 @@
+// TX Linearity Analyzer — safety interlock tests.
+//
+// Section 8 of the design is labelled non-negotiable, and an interlock that can
+// only be exercised by transmitting is an interlock that never gets exercised.
+// TxLinearitySafety is therefore clock-injected and Qt-free so every rule here
+// runs in CI with no radio, no GUI and no sleeping.
+//
+// Constitution Principle VI is the standard being enforced: every path fails
+// CLOSED. Where a test below asserts a refusal, the interesting property is not
+// that the refusal happens but that it happens when data is MISSING — no band
+// plan, no telemetry, no confirmation — rather than only when data says "no".
+
+#include "core/txlinearity/TxLinearitySafety.h"
+
+#include <cstdio>
+
+using namespace AetherSDR::txlin;
+
+static int g_failures = 0;
+
+static void check(bool cond, const char* what)
+{
+    if (!cond) {
+        std::fprintf(stderr, "FAIL: %s\n", what);
+        ++g_failures;
+    }
+}
+
+namespace {
+
+// 20 m, IARU/FCC general segment boundaries in Hz. Only used as plausible
+// numbers — the real values come from BandPlanManager at runtime.
+constexpr double kBandLow = 14000000.0;
+constexpr double kBandHigh = 14350000.0;
+
+RunRequest makeRequest(double tone1Hz, double tone2Hz)
+{
+    RunRequest req;
+    req.tone1Hz = tone1Hz;
+    req.tone2Hz = tone2Hz;
+    req.maxOrder = 7;
+    req.captureReady = true;
+    req.allocations.push_back(AllocationRange{kBandLow, kBandHigh});
+    return req;
+}
+
+}  // namespace
+
+int main()
+{
+    // ── Dummy-load confirmation is required and is never remembered ─────────
+    {
+        TxLinearitySafety safety;
+        const RunRequest req = makeRequest(14200000.0, 14202000.0);
+
+        check(safety.preflight(0, req).verdict == PreflightVerdict::NoDummyLoadConfirmation,
+              "preflight refuses without a dummy-load confirmation");
+
+        safety.confirmDummyLoad();
+        check(safety.preflight(0, req).ok(), "preflight passes once confirmed");
+
+        safety.noteRunStarted(0);
+        safety.noteRunStopped(1000);
+        check(!safety.dummyLoadConfirmed(),
+              "the confirmation is cleared when the run stops, so the next run asks again");
+    }
+
+    // ── Hard transmit timeout ───────────────────────────────────────────────
+    {
+        SafetyLimits limits;
+        limits.maxTransmitMs = 10000;
+        TxLinearitySafety safety(limits);
+        safety.confirmDummyLoad();
+        safety.noteRunStarted(100000);
+
+        const TxTelemetry good{1.2, 40.0, 13.8, 100.0};
+        check(safety.evaluate(105000, good, 105000) == AbortReason::None,
+              "a healthy run partway through the window does not abort");
+        check(safety.evaluate(109999, good, 109999) == AbortReason::None,
+              "the timeout has not tripped one millisecond early");
+        check(safety.evaluate(110000, good, 110000) == AbortReason::TransmitTimeout,
+              "the timeout trips exactly at the limit");
+        // The timeout must not depend on telemetry arriving. A radio that has
+        // gone silent must still be unkeyed at the deadline.
+        check(safety.evaluate(120000, TxTelemetry{}, 0) == AbortReason::TransmitTimeout,
+              "the timeout trips even with no telemetry at all");
+    }
+
+    // ── Duty-cycle limiter ──────────────────────────────────────────────────
+    {
+        SafetyLimits limits;
+        limits.minCooldownMs = 30000;
+        TxLinearitySafety safety(limits);
+        const RunRequest req = makeRequest(14200000.0, 14202000.0);
+
+        safety.confirmDummyLoad();
+        safety.noteRunStarted(0);
+        safety.noteRunStopped(5000);
+
+        check(safety.cooldownRemainingMs(5000) == 30000, "cooldown starts at the full period");
+        check(safety.cooldownRemainingMs(20000) == 15000, "cooldown counts down");
+
+        safety.confirmDummyLoad();
+        check(safety.preflight(20000, req).verdict == PreflightVerdict::CoolingDown,
+              "preflight refuses during the cooldown");
+        check(safety.cooldownRemainingMs(35000) == 0, "cooldown expires");
+        check(safety.preflight(35000, req).ok(), "preflight passes after the cooldown");
+    }
+
+    // ── Limits are adjustable downward only ─────────────────────────────────
+    {
+        TxLinearitySafety safety;
+        SafetyLimits tighter = safety.limits();
+        tighter.maxTransmitMs = 5000;
+        check(safety.setLimits(tighter), "tightening the timeout is allowed");
+        check(safety.limits().maxTransmitMs == 5000, "the tightened timeout applied");
+
+        SafetyLimits looser = safety.limits();
+        looser.maxTransmitMs = 60000;
+        check(!safety.setLimits(looser), "loosening the timeout needs an explicit override");
+        check(safety.limits().maxTransmitMs == 5000,
+              "a rejected limit change applies nothing at all");
+        check(safety.setLimits(looser, true), "an explicit override loosens the timeout");
+        check(safety.limits().maxTransmitMs == 60000, "the override applied");
+
+        SafetyLimits shortCooldown = safety.limits();
+        shortCooldown.minCooldownMs = 0;
+        check(!safety.setLimits(shortCooldown), "shortening the cooldown needs an override too");
+
+        SafetyLimits zeroTimeout = safety.limits();
+        zeroTimeout.maxTransmitMs = 0;
+        check(safety.setLimits(zeroTimeout), "a zero timeout is accepted as a tightening");
+        check(safety.limits().maxTransmitMs >= 1,
+              "but 'no timeout' is not a configuration that can exist");
+    }
+
+    // ── Telemetry aborts ────────────────────────────────────────────────────
+    {
+        TxLinearitySafety safety;
+        safety.confirmDummyLoad();
+        safety.noteRunStarted(0);
+
+        check(safety.evaluate(1000, TxTelemetry{3.5, 40.0, 13.8, 100.0}, 1000)
+                  == AbortReason::HighSwr,
+              "high SWR with real forward power aborts");
+        // The same SWR reading with no power behind it is a ratio of two noise
+        // samples, and tripping on it would abort every run during key-up.
+        check(safety.evaluate(1000, TxTelemetry{3.5, 40.0, 13.8, 0.01}, 1000)
+                  == AbortReason::None,
+              "high SWR with no forward power does not abort");
+        check(safety.evaluate(1000, TxTelemetry{1.2, 95.0, 13.8, 100.0}, 1000)
+                  == AbortReason::PaOverTemp,
+              "PA over-temperature aborts");
+        check(safety.evaluate(1000, TxTelemetry{1.2, 40.0, 9.5, 100.0}, 1000)
+                  == AbortReason::LowSupplyVoltage,
+              "low supply voltage aborts");
+        check(safety.evaluate(5000, TxTelemetry{1.2, 40.0, 13.8, 100.0}, 1000)
+                  == AbortReason::TelemetryStale,
+              "telemetry that has stopped updating aborts even when the last values were fine");
+
+        safety.noteRunStopped(6000);
+        check(safety.evaluate(7000, TxTelemetry{3.5, 95.0, 9.5, 100.0}, 7000)
+                  == AbortReason::None,
+              "a stopped run has nothing to abort");
+    }
+
+    // ── Band plan ───────────────────────────────────────────────────────────
+    {
+        TxLinearitySafety safety;
+        safety.confirmDummyLoad();
+
+        // No band plan loaded is not permission to transmit.
+        RunRequest noPlan = makeRequest(14200000.0, 14202000.0);
+        noPlan.allocations.clear();
+        check(safety.preflight(0, noPlan).verdict == PreflightVerdict::OutsideAllocation,
+              "an unloaded band plan fails closed");
+
+        check(safety.preflight(0, makeRequest(13900000.0, 13902000.0)).verdict
+                  == PreflightVerdict::OutsideAllocation,
+              "tones outside the allocation are refused");
+
+        // Mid-band: inside, and far enough from both edges that nothing warns.
+        const PreflightResult mid = safety.preflight(0, makeRequest(14200000.0, 14202000.0));
+        check(mid.ok(), "a mid-band run is permitted");
+        check(mid.warnings.empty(), "a mid-band run raises no warnings");
+        // Order 7 reaches three tone-spacings beyond each tone: 2 kHz spacing
+        // means 6 kHz of products either side, so 14.194–14.208 MHz.
+        check(std::abs(mid.occupiedLowHz - 14194000.0) < 1.0,
+              "occupied span accounts for order-7 products below");
+        check(std::abs(mid.occupiedHighHz - 14208000.0) < 1.0,
+              "occupied span accounts for order-7 products above");
+
+        // Tones inside the band but products spilling over the edge: permitted,
+        // with an explicit warning. Refusing outright would block exactly the
+        // near-edge measurements worth making, but the operator must be told.
+        const PreflightResult edge = safety.preflight(0, makeRequest(14001000.0, 14003000.0));
+        check(edge.ok(), "a near-edge run with spilling products is still permitted");
+        check(!edge.warnings.empty(), "but it warns about the band edge");
+
+        // Just inside with clearance under the advisory threshold.
+        const PreflightResult tight = safety.preflight(0, makeRequest(14006200.0, 14008200.0));
+        check(tight.ok(), "a run with small but positive clearance is permitted");
+        check(!tight.warnings.empty(), "and warns about the proximity");
+    }
+
+    // ── Ordering and prerequisites ──────────────────────────────────────────
+    {
+        TxLinearitySafety safety;
+        RunRequest noCapture = makeRequest(14200000.0, 14202000.0);
+        noCapture.captureReady = false;
+        check(safety.preflight(0, noCapture).verdict == PreflightVerdict::NoCaptureSource,
+              "a missing capture source is reported before the dummy-load prompt");
+
+        safety.confirmDummyLoad();
+        RunRequest sameFreq = makeRequest(14200000.0, 14200000.0);
+        check(safety.preflight(0, sameFreq).verdict == PreflightVerdict::InvalidToneSpacing,
+              "two tones at the same frequency are refused");
+
+        safety.noteRunStarted(0);
+        check(safety.preflight(0, makeRequest(14200000.0, 14202000.0)).verdict
+                  == PreflightVerdict::AlreadyRunning,
+              "a second run cannot start while one is in progress");
+    }
+
+    if (g_failures == 0) {
+        std::printf("tx_linearity_safety_test: all checks passed\n");
+    }
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/tx_linearity_settings_test.cpp
+++ b/tests/tx_linearity_settings_test.cpp
@@ -1,0 +1,173 @@
+// TX Linearity Analyzer — owned-config-object tests (Constitution Principle V).
+//
+// The analyzer's settings are one nested JSON object under a single root key,
+// so this proves the three properties that shape buys you and a flat namespace
+// does not: it defaults as a unit when absent, it round-trips as a unit, and a
+// document that has drifted — a missing field, a wrong type, a value outside
+// the range its control accepts — degrades field by field instead of resetting
+// the operator's whole setup or driving a control out of bounds.
+//
+// The range clamp is load-bearing beyond tidiness: `timeoutSec` feeds a
+// transmit interlock, so a stored value that is zero, negative or larger than
+// the §8 ceiling must not survive being read back.
+
+#include "TestSettingsProfile.h"
+
+#include "core/AppSettings.h"
+#include "core/TxLinearitySettings.h"
+
+#include <QCoreApplication>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include <cmath>
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+
+static void check(bool cond, const char* what)
+{
+    if (!cond) {
+        std::fprintf(stderr, "FAIL: %s\n", what);
+        ++g_failures;
+    }
+}
+
+namespace {
+
+void storeRaw(const QJsonObject& obj)
+{
+    AppSettings& settings = AppSettings::instance();
+    settings.setValue(TxLinearitySettings::rootKey(),
+                      QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+    settings.save();
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    // Must precede QCoreApplication and the first AppSettings touch.
+    TestSettingsProfile profile(QStringLiteral("tx-linearity-settings-test"));
+    QCoreApplication app(argc, argv);
+
+    // ── Absent: the compiled-in defaults ARE the answer ─────────────────────
+    {
+        const TxLinearitySettings s = TxLinearitySettings::load();
+        check(s.daxChannel == 1, "default DAX channel");
+        check(std::abs(s.toneSpacingHz - 2000.0) < 1e-9, "default tone spacing");
+        check(s.tunePowerW == 10, "default tune power");
+        check(s.averages == 8, "default averages");
+        check(s.timeoutSec == 10, "default transmit timeout");
+        check(s.maxOrder == 7, "default highest order");
+        check(s.window == QStringLiteral("blackman-harris-7"),
+              "default window is the low-sidelobe one");
+    }
+
+    // ── Round-trip as a unit ────────────────────────────────────────────────
+    {
+        TxLinearitySettings out;
+        out.daxChannel = 3;
+        out.toneSpacingHz = 1500.0;
+        out.tunePowerW = 25;
+        out.averages = 16;
+        out.timeoutSec = 4;
+        out.window = QStringLiteral("blackman-harris-4");
+        out.maxOrder = 5;
+        out.save();
+
+        const TxLinearitySettings back = TxLinearitySettings::load();
+        check(back.daxChannel == 3, "DAX channel round-trips");
+        check(std::abs(back.toneSpacingHz - 1500.0) < 1e-9, "tone spacing round-trips");
+        check(back.tunePowerW == 25, "tune power round-trips");
+        check(back.averages == 16, "averages round-trip");
+        check(back.timeoutSec == 4, "timeout round-trips");
+        check(back.window == QStringLiteral("blackman-harris-4"), "window round-trips");
+        check(back.maxOrder == 5, "highest order round-trips");
+
+        // ONE key, not seven. This is the property Principle V is actually
+        // about — asserting it here stops a later change quietly re-scattering
+        // the config back across the shared namespace.
+        check(!AppSettings::instance()
+                   .value(TxLinearitySettings::rootKey(), QString{})
+                   .toString()
+                   .isEmpty(),
+              "the whole object lives under one root key");
+        check(AppSettings::instance().value("TxLinearityAverages", QString{}).toString().isEmpty(),
+              "no loose flat key is written alongside it");
+    }
+
+    // ── A partial document degrades field by field ──────────────────────────
+    {
+        QJsonObject partial;
+        partial["averages"] = 12;   // the only field present
+        storeRaw(partial);
+
+        const TxLinearitySettings s = TxLinearitySettings::load();
+        check(s.averages == 12, "a present field is read");
+        check(s.timeoutSec == 10, "an absent field falls back to its default");
+        check(s.window == QStringLiteral("blackman-harris-7"),
+              "an absent string field falls back to its default");
+    }
+
+    // ── Wrong types fall back rather than coercing to zero ──────────────────
+    //
+    // A bare toInt() on a string would yield 0, and 0 averages or a 0 s
+    // timeout is a meaningfully broken configuration, not a cosmetic one.
+    {
+        QJsonObject wrong;
+        wrong["averages"] = QStringLiteral("lots");
+        wrong["timeoutSec"] = QStringLiteral("forever");
+        wrong["window"] = 42;
+        storeRaw(wrong);
+
+        const TxLinearitySettings s = TxLinearitySettings::load();
+        check(s.averages == 8, "a string in an int field falls back, not to zero");
+        check(s.timeoutSec == 10, "a string in the timeout field falls back, not to zero");
+        check(s.window == QStringLiteral("blackman-harris-7"),
+              "a number in the window field falls back to the default");
+    }
+
+    // ── Out-of-range values are clamped on the way in ───────────────────────
+    {
+        QJsonObject wild;
+        wild["daxChannel"] = 99;
+        wild["toneSpacingHz"] = 1.0e9;
+        wild["tunePowerW"] = -5;
+        wild["averages"] = 100000;
+        wild["timeoutSec"] = 3600;   // an hour of continuous two-tone
+        wild["maxOrder"] = 4;        // even orders are not measured here
+        wild["window"] = QStringLiteral("no-such-window");
+        storeRaw(wild);
+
+        const TxLinearitySettings s = TxLinearitySettings::load();
+        check(s.daxChannel >= 1 && s.daxChannel <= 4, "DAX channel is clamped to the radio's four");
+        check(s.toneSpacingHz <= 10000.0, "tone spacing is clamped");
+        check(s.tunePowerW >= 1, "tune power is clamped above zero");
+        check(s.averages <= 64, "averages are clamped");
+        // The one that matters: a stored timeout can never widen the interlock.
+        check(s.timeoutSec >= 1 && s.timeoutSec <= 10,
+              "a stored transmit timeout cannot exceed the safety ceiling");
+        check(s.maxOrder == 7, "an even IMD order falls back to a valid odd one");
+        check(s.window == QStringLiteral("blackman-harris-7"),
+              "an unknown window name falls back to the default");
+    }
+
+    // ── Corrupt JSON is not fatal ───────────────────────────────────────────
+    {
+        AppSettings& settings = AppSettings::instance();
+        settings.setValue(TxLinearitySettings::rootKey(), QStringLiteral("{not json at all"));
+        settings.save();
+
+        const TxLinearitySettings s = TxLinearitySettings::load();
+        check(s.averages == 8 && s.timeoutSec == 10,
+              "a corrupt document yields the defaults rather than breaking the dialog");
+    }
+
+    if (g_failures == 0) {
+        std::printf("tx_linearity_settings_test: all checks passed\n");
+    }
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/tx_linearity_spectrum_test.cpp
+++ b/tests/tx_linearity_spectrum_test.cpp
@@ -1,0 +1,220 @@
+// TX Linearity Analyzer — window and spectrum-estimator tests.
+//
+// The headline case here is the WINDOW LEAKAGE REGRESSION: synthesize a
+// two-tone with NO distortion whatsoever and assert the analyzer reports IMD
+// products down at the window's own sidelobe floor. This catches the single
+// most likely class of bug in the whole feature — an analyzer that measures its
+// own window skirt and calls it the amplifier's IMD3 looks completely
+// plausible, produces confident numbers, and is wrong about every radio it is
+// ever pointed at.
+//
+// The same test is run through a Hann window as a control. Hann is expected to
+// FAIL to see a clean signal as clean; asserting that keeps the reason for the
+// Blackman-Harris default in executable form, so a future "optimization" back
+// to Hann trips a test instead of quietly capping the instrument's dynamic
+// range at about -50 dBc.
+
+#include "core/txlinearity/ImdAnalyzer.h"
+#include "core/txlinearity/SpectrumWindow.h"
+#include "core/txlinearity/TxSpectrumAnalyzer.h"
+
+#include "TxLinearityTestSignals.h"
+
+#include <cmath>
+#include <cstdio>
+
+using namespace AetherSDR::txlin;
+using namespace txlin_test;
+
+static int g_failures = 0;
+
+static void check(bool cond, const char* what)
+{
+    if (!cond) {
+        std::fprintf(stderr, "FAIL: %s\n", what);
+        ++g_failures;
+    }
+}
+
+static void checkNear(double got, double want, double tol, const char* what)
+{
+    if (!(std::abs(got - want) <= tol)) {
+        std::fprintf(stderr, "FAIL: %s (got %.4f, want %.4f +/- %.4f)\n",
+                     what, got, want, tol);
+        ++g_failures;
+    }
+}
+
+namespace {
+
+constexpr double kSampleRate = 192000.0;
+constexpr int kFftSize = 16384;
+
+// Feed `frames` consecutive blocks of a signal into an analyzer.
+void feed(TxSpectrumAnalyzer& an, const std::vector<std::complex<double>>& x, int frames)
+{
+    for (int f = 0; f < frames; ++f) {
+        const std::vector<std::complex<float>> block =
+            toFloat(x, std::size_t(f) * std::size_t(kFftSize), std::size_t(kFftSize));
+        check(an.accumulate(block), "accumulate accepted a full frame");
+    }
+}
+
+}  // namespace
+
+int main()
+{
+    // ── Window factors ──────────────────────────────────────────────────────
+    //
+    // Published values for the periodic form. Hann's ENBW is exactly 1.5 bins
+    // and its coherent gain exactly 0.5, which makes it the arithmetic anchor:
+    // if those two are right the general cosine-sum machinery is right.
+    {
+        const AnalysisWindow hann = makeWindow(WindowKind::Hann, 4096);
+        checkNear(hann.coherentGain, 0.5, 1e-9, "Hann coherent gain is 0.5");
+        checkNear(hann.enbwBins, 1.5, 1e-6, "Hann ENBW is 1.5 bins");
+
+        const AnalysisWindow bh4 = makeWindow(WindowKind::BlackmanHarris4, 4096);
+        checkNear(bh4.coherentGain, 0.35875, 1e-6, "BH4 coherent gain is a0");
+        checkNear(bh4.enbwBins, 2.0044, 2e-3, "BH4 ENBW is ~2.0044 bins");
+
+        const AnalysisWindow bh7 = makeWindow(WindowKind::BlackmanHarris7, 4096);
+        checkNear(bh7.coherentGain, 0.27105140069342, 1e-6, "BH7 coherent gain is a0");
+        // The 7-term window trades main-lobe width for sidelobe depth, so its
+        // ENBW is correspondingly larger than the 4-term's.
+        check(bh7.enbwBins > 2.5 && bh7.enbwBins < 2.8, "BH7 ENBW is ~2.63 bins");
+        check(bh7.mainLobeHalfBins == 7, "BH7 main lobe is +/-7 bins");
+
+        // A degenerate request must not produce NaN factors that would poison
+        // every division downstream.
+        const AnalysisWindow tiny = makeWindow(WindowKind::BlackmanHarris7, 1);
+        check(tiny.taps.empty(), "a 1-tap window request yields no taps");
+        check(tiny.enbwBins == 1.0, "a degenerate window keeps unity ENBW");
+
+        check(windowKindFromKey(windowKindKey(WindowKind::FlatTop)) == WindowKind::FlatTop,
+              "window kind key round-trips");
+        check(windowKindFromKey("nonsense") == WindowKind::BlackmanHarris7,
+              "an unknown window key falls back to the default");
+    }
+
+    // ── Tone amplitude recovery, on-bin and off-bin ─────────────────────────
+    //
+    // A tone parked exactly half a bin between two bins is the worst case for
+    // the peak interpolator. Without interpolation a Blackman-Harris window
+    // reads such a tone more than a dB low, and that error would land directly
+    // in every dBc figure the instrument publishes.
+    {
+        const double binHz = TxSpectrumAnalyzer::binHz(kSampleRate, kFftSize);
+        const double amp = 0.25;
+        const double expectedDb = 20.0 * std::log10(amp);
+
+        for (double offsetBins : {0.0, 0.25, 0.5}) {
+            TxSpectrumAnalyzer an(kFftSize, WindowKind::BlackmanHarris7);
+            const double f = (1000.0 + offsetBins) * binHz;
+            const std::vector<std::complex<double>> x =
+                twoTone(std::size_t(kFftSize) * 4, kSampleRate, f, f + 2000.0, amp);
+            feed(an, x, 4);
+
+            const int centre = kFftSize / 2;
+            const int predicted = an.freqToBin(f, kSampleRate);
+            const InterpolatedPeak pk = interpolatePeak(an.powerSpectrum(),
+                                                        predicted - 8, predicted + 8,
+                                                        kSampleRate);
+            check(pk.valid, "peak interpolation succeeded");
+            checkNear(pk.powerDb, expectedDb, 0.05,
+                      "interpolated tone amplitude is within 0.05 dB");
+            checkNear(pk.freqHz, f, binHz * 0.05,
+                      "interpolated tone frequency is within 0.05 bins");
+            (void)centre;
+        }
+    }
+
+    // ── Window leakage regression ───────────────────────────────────────────
+    //
+    // A perfectly linear "amplifier": the two-tone passes through untouched, so
+    // every IMD product the analyzer reports is leakage, not distortion. Tones
+    // are deliberately off-bin, which is the leakage-worst case.
+    {
+        const double binHz = TxSpectrumAnalyzer::binHz(kSampleRate, kFftSize);
+        const double f1 = (-100.0 + 0.37) * binHz;   // ~-1.17 kHz
+        const double f2 = f1 + 2000.0;               // 2 kHz spacing
+        const std::vector<std::complex<double>> x =
+            twoTone(std::size_t(kFftSize) * 8, kSampleRate, f1, f2, 0.35);
+
+        TxSpectrumAnalyzer bh(kFftSize, WindowKind::BlackmanHarris7);
+        feed(bh, x, 8);
+        ImdConfig cfg;
+        const LinearityResult r = measureTwoTone(bh, kSampleRate, cfg, false);
+        check(r.valid, "a clean two-tone measures successfully");
+        check(!r.products.empty(), "products were located");
+
+        double worstDbc = -1000.0;
+        for (const ImdProduct& p : r.products) {
+            if (p.dbcPerTone > worstDbc) {
+                worstDbc = p.dbcPerTone;
+            }
+            // The whole point: every product on an undistorted signal must be
+            // reported as unmeasurable, not as a number.
+            check(p.limitedByNoiseFloor,
+                  "products of an undistorted signal are flagged noise-limited");
+        }
+        // -80 dBc is a deliberately conservative bar against the window's
+        // nominal -92 dB: floating-point synthesis, the 0.37-bin offset and the
+        // averaging all contribute a little. Anywhere near -50 means the window
+        // has been changed and the instrument's dynamic range with it.
+        check(worstDbc < -80.0, "clean two-tone reports no product above -80 dBc");
+
+        // The control. Hann is expected to fail this — it is here so that the
+        // reason the default is Blackman-Harris is asserted, not just written
+        // in a comment.
+        TxSpectrumAnalyzer hn(kFftSize, WindowKind::Hann);
+        feed(hn, x, 8);
+        const LinearityResult rh = measureTwoTone(hn, kSampleRate, cfg, false);
+        check(rh.valid, "the Hann control measures successfully");
+        double hannWorst = -1000.0;
+        for (const ImdProduct& p : rh.products) {
+            if (p.dbcPerTone > hannWorst) {
+                hannWorst = p.dbcPerTone;
+            }
+        }
+        check(hannWorst > worstDbc + 20.0,
+              "Hann leaks at least 20 dB more than Blackman-Harris 7 "
+              "(this is why the default is what it is)");
+    }
+
+    // ── Band integration ────────────────────────────────────────────────────
+    //
+    // sum(|S|^2)/ENBW must recover a tone's power exactly, and must recover a
+    // noise band's power too. One expression, both signal classes — if this is
+    // wrong then ACPR and the shoulder levels are wrong in a way no amount of
+    // eyeballing the plot would reveal.
+    {
+        TxSpectrumAnalyzer an(kFftSize, WindowKind::BlackmanHarris7);
+        const double amp = 0.3;
+        const double f1 = -20000.0 + 0.31 * TxSpectrumAnalyzer::binHz(kSampleRate, kFftSize);
+        const std::vector<std::complex<double>> x =
+            twoTone(std::size_t(kFftSize) * 4, kSampleRate, f1, f1 + 2000.0, amp);
+        feed(an, x, 4);
+
+        // A band containing exactly one of the two tones, wide enough to hold
+        // its whole main lobe.
+        const std::optional<BandPower> bp =
+            integrateBand(an, kSampleRate, f1 - 500.0, f1 + 500.0, 0.0, 0.0);
+        check(bp.has_value(), "band integration over a tone succeeded");
+        if (bp.has_value()) {
+            checkNear(bp->powerDb, 20.0 * std::log10(amp), 0.05,
+                      "integrated tone power matches the tone amplitude");
+        }
+
+        // A band running past the capture edge must be refused, not truncated:
+        // a truncated integration under-reports and would flatter the radio.
+        check(!integrateBand(an, kSampleRate, kSampleRate / 2.0 - 100.0,
+                             kSampleRate / 2.0 + 100.0, 0.0, 0.0).has_value(),
+              "a band crossing the capture edge is refused, not truncated");
+    }
+
+    if (g_failures == 0) {
+        std::printf("tx_linearity_spectrum_test: all checks passed\n");
+    }
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Implements **#4769 (RFC)** — Phase 1 of the TX Linearity Analyzer. **Draft: the
RFC is not approved yet**, and `GOVERNANCE.md` says a PR waits for that. This is
up early so the proposal can be reviewed against real code and real measurements
rather than a sketch; it should not merge before #4769 is decided.

A Flex owner can enable SmartSignal today and look at a panadapter picture of
their own transmission. There is no number anywhere in it — no IMD3/IMD5 in dBc,
no shoulder, no ACPR — so "is APD helping on *this* band, at *this* power, into
*this* amplifier?" currently needs a spectrum analyzer. This answers it from a DAX
IQ capture of the radio's own two-tone, using hardware the operator already owns.

Phase 1 is the instrument and the reference-free spectral measurements. Phases 2
(synthesized-reference AM-AM/AM-PM + SmartSignal A/B) and 3 (HPSDR dual-stream,
memory-polynomial fit) are **not** scaffolded — the RFC deliberately delivers
Phase 1 complete first.

The DSP core is the measurement half of a digital-predistortion loop with the
correction half removed, kept free of Qt and of radio types so the HL2
predistorter (#78) is a new capture adapter rather than a DSP rewrite.

### Three decisions that determine whether the numbers are right

**Window** — 7-term Blackman-Harris default (~-92 dB sidelobes). Hann's -31 dB
skirt buries anything below about -50 dBc and leakage is coherent, so averaging
cannot remove it: the window sets the instrument's dynamic range outright. It is
selectable, but the default is pinned by a regression test with a Hann control
asserted to leak ≥20 dB more, so it cannot be quietly "optimized" back.

**Reference convention** — for two equal tones, PEP sits exactly 6.02 dB above one
tone. Ham convention quotes IMD against one tone; ARRL lab figures are against
PEP, which reads 6 dB better for the identical signal. **Every dBc value in the
UI, the table and the CSV carries both, labelled.** PEP is computed from the
measured envelope rather than by subtracting the constant, so an imbalanced pair
reports the truth instead of the flattering idealisation.

**Noise floor** — reported alongside every result, and any product that does not
clear it by a margin is flagged as unmeasurable rather than quoted. A measurement
silently reading the analyzer's own noise, or the feedback receiver's own IMD, is
worse than no measurement.

### Safety (§8 of the RFC)

Interlocks are a Qt-free, clock-injected policy object so all of them are tested
without a radio, a GUI, or sleeping — an interlock that can only be exercised by
transmitting is one that never gets exercised.

- Dummy-load / verified-clear confirmation before **every** run, never persisted,
  cleared on stop.
- Hard transmit timeout (10 s default, **downward-adjustable only**) that depends
  on nothing but the clock, so a radio that has gone silent is still unkeyed.
- Duty-cycle cooldown; SWR / PA-temp / supply aborts, with SWR gated on real
  forward power; telemetry-stale abort; capture-loss abort.
- Band-plan refusal that **fails closed** — no plan loaded is not permission —
  with the occupied span computed *including order-7 products*.
- `stopRun()` unkeys as its first action and is idempotent; the destructor unkeys
  too.
- Run button is `markTxKeying()`, so the automation bridge refuses it without
  `AETHER_AUTOMATION_ALLOW_TX`.

### Notable review points

- **The brief's DAX IQ syntax was wrong.** `stream create daxiq=<ch> ip=<ip>
  port=<port>` does not exist. FlexLib (`Radio.cs:4800`, `DAXIQStream.cs:54`) and
  the shipping code agree on `stream create type=dax_iq daxiq_channel=<n>` with no
  ip/port — the radio streams to the client's existing VITA-49 socket. Repo wins
  (Principle I).
- **No new vendor coupling.** `FlexDaxIqCapture` holds no `DaxIqModel` pointer and
  includes none of its headers — it emits stream requests and receives samples via
  slots, with the dialog doing the wiring. The EB3 ratchet forced this and it is
  the better design: what is left is pure frame assembly for the HPSDR adapter to
  mirror. `check_engine_boundary.py --strict`: **0 blocking findings.**
- **Two of my own test expectations were wrong and the analyzer was right**, which
  is worth a reviewer's attention because both are derived in the test comments: a
  compressive PA *widens* a 1.5 dB tone imbalance to 1.64 dB through
  cross-modulation, and the noise floor sits 4.2 dB above the naive `2σ²/N` because
  of the window's ENBW.
- **Deliberate deviation from the brief:** golden vectors are a checked-in
  deterministic *generator* (seeded `std::mt19937`) rather than capture files. A
  generator is reviewable and lets each test state its expected answer in closed
  form instead of a magic number nobody can re-derive. Still hardware-free, still
  runs in CI.
- **Deliberate deviation from the brief:** setup is a guided section, not a modal
  wizard — the operator must watch the live feedback level while adjusting a
  physical attenuator, which a page-at-a-time wizard obstructs. Steps, order and
  the refusal to run until each validates are unchanged.
- **Menu placement is a judgement call** (RFC question b): grouped with Radio
  Health and Slice Troubleshooting, because it measures the radio rather than
  configuring it, and the Settings menu's placeholder-connect loop would hijack an
  action added there. Happy to move it to the TX applet like ATU Pre-Tune.

## Constitution principle honored

- **Principle I — FlexLib is the protocol authority.** Every DAX IQ command was
  verified against `reference/FlexLib_API_v4.1.5.39794/` rather than the brief,
  which is how the syntax error above was caught.
- **Principle IV — clean-room.** No decompiled or disassembled sources. WDSP
  (GPLv2-or-later, compatible with our GPLv3) was read as an open-source
  reference, which Principle IV names explicitly as a clean input; its PureSignal
  `calcc.c` is **not** ported — it is reserved as an independent oracle for Phase
  3. I checked for public docs claiming provenance with no PowerSDR/Thetis lineage
  and found none (`docs/` already cites Thetis openly), so no rescoping is needed.
- **Principle V — one owned config object.** `TxLinearitySettings` is a single
  nested JSON document under the root key `TxLinearity`, defaulted, range-clamped
  and written atomically. The second commit exists because the first version got
  this wrong with seven flat keys.
- **Principle VI — never transmits without operator intent.** Every path fails
  closed; see Safety above.
- **Principle XIV — atomic persistence.** The config object is one value written
  in one go.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [ ] **Behavior verified on a real radio — NOT DONE, and this gates merge.** See
      "Blocking" below.
- [x] Existing tests pass — **252/252** locally, offscreen (`ctest -j4`)
- [x] Reproduction steps documented if user-reported bug — n/a, new feature

### What is actually covered

Four new suites, all hardware-free, every expectation closed-form from the
synthetic PA model rather than recorded output:

| Suite | Covers |
|---|---|
| `tx_linearity_spectrum_test` | window coherent gain + ENBW against published values; tone amplitude recovery on- and off-bin to 0.05 dB; **window leakage regression** (undistorted two-tone must report no product above -80 dBc) with the Hann control; band integration; refusal to truncate a band at the capture edge |
| `tx_linearity_imd_test` | IMD3/IMD5 against analytic levels within 0.3 dB; reference convention (exactly 6.02 dB); imbalanced-pair cross-modulation; noise-floor honesty; refusals; clip detection as a population |
| `tx_linearity_safety_test` | every interlock — timeout (including with no telemetry at all), cooldown, downward-only limits, SWR gating on forward power, telemetry staleness, band-plan fail-closed, band-edge warnings, ordering |
| `tx_linearity_settings_test` | defaults, round-trip, partial documents, wrong types, out-of-range clamping, corrupt JSON, and that exactly one root key is written |

### Verified in the running app

Launched offscreen in an isolated `HOME` and driven through the automation
bridge: menu action present, dialog opens, all controls carry accessible
names, plot renders, and the Run button reports `keying: true` and is correctly
refused by the bridge.

### Blocking — do not merge on this

**The assumption the whole feature rests on is unverified against hardware:**
whether DAX IQ actually flows during TX for a slice on a receive-only port, or
whether the receiver is muted. Confirming it needs a deliberate on-air two-tone
into a dummy load, which has not been run. If it does not work, the DSP core and
safety layer still stand but the Flex capture path needs rethinking. RFC question
(c) asks whether this should gate the PR; my view is that it should.

Secondary: the feedback-level "too low / good / clipping" band is derived from SNR
and headroom reasoning, not measured on a real feedback path — expect to tune it
once the above is answered.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`) — both, as
      `kk7gwy@aethersdr.com`
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V) — fixed in `2b723cde`; the first commit had seven
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered
      from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` — n/a; this reads `MeterModel` for
      interlocks and displays no meter
- [ ] Documentation updated if user-visible behavior changed — **not yet.**
      `docs/` and the help text want a page on the feedback-path setup, but that
      is worth writing after the hardware probe settles what the setup actually
      is. No `CHANGELOG.md` entry, per AGENTS.md.
- [x] Security-sensitive changes reference a GHSA if applicable — n/a

---

**Diff:** 27 files, ~5,000 lines — roughly half of it the measurement core and its
tests. `src/core/txlinearity/` is backend-agnostic; `src/gui/` is display and
wiring only; the one line of existing-code change is a menu action.
