### PR TITLE
fix(audio): mirror mute commands into the model, clear them on disconnect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4906,6 +4906,12 @@ target_include_directories(radiomodel_pan_id_mapping_test PRIVATE src)
 target_link_libraries(radiomodel_pan_id_mapping_test PRIVATE aethercore Qt6::Core Qt6::Test)
 add_test(NAME radiomodel_pan_id_mapping_test COMMAND radiomodel_pan_id_mapping_test)
 
+# RadioModel audio-mute model-state contract (#4771).
+add_executable(radiomodel_audio_mute_test tests/radiomodel_audio_mute_test.cpp)
+target_include_directories(radiomodel_audio_mute_test PRIVATE src)
+target_link_libraries(radiomodel_audio_mute_test PRIVATE aethercore Qt6::Core Qt6::Test)
+add_test(NAME radiomodel_audio_mute_test COMMAND radiomodel_audio_mute_test)
+
 add_executable(demo_backend_swap_test tests/demo_backend_swap_test.cpp)
 target_include_directories(demo_backend_swap_test PRIVATE src)
 target_link_libraries(demo_backend_swap_test PRIVATE aethercore Qt6::Core Qt6::Test)

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -5907,6 +5907,13 @@ void RadioModel::onDisconnected()
     m_netCwLastSendMs = -1;
     m_lineoutGain = 50;
     m_headphoneGain = 50;
+    // The mutes are the previous radio's state just as much as the gains are.
+    // Leaving them set meant a reconnect asserted the OLD radio's mute state
+    // until the new one's first `audio` status arrived — the same staleness the
+    // nickname clearing above exists to prevent. (#4771)
+    m_lineoutMute = false;
+    m_headphoneMute = false;
+    m_frontSpeakerMute = false;
 
     stopNetworkMonitor();
     // stop() must run on the network thread (socket lives there). (#561)
@@ -9195,10 +9202,32 @@ void RadioModel::setLineoutGain(int v)
     emit audioOutputChanged();
 }
 
+// The three mute setters below mirror the command into the model the way the
+// gain setters already do. Principle II allows the optimistic write — the
+// radio's own `audio` status supersedes it on the next echo — and Flex echoes
+// gain and mute alike (FlexBackend.cpp:942-946), so this is the same bargain
+// setLineoutGain()/setHeadphoneGain() have always made, not a new one.
+//
+// Without it these flags are written ONLY by a Flex status, and Flex is their
+// only parser. On every other backend they stay pinned to their `false`
+// initialisers for the life of the session, so a reconciler reading them
+// contradicts what the operator just asked for: mute from the title bar, nudge
+// the headphone slider, and setHeadphoneGain()'s audioOutputChanged drives the
+// glyph back to unmuted with no command sent to undo it (#4771).
+//
+// Where these differ from the gain setters: the command is sent
+// unconditionally rather than short-circuited on an unchanged value. A mute is
+// a request, and suppressing it because the model already believes the radio is
+// muted would leave a model that has drifted from the radio unrecoverable from
+// the UI — and that drift is precisely what this fixes.
 void RadioModel::setLineoutMute(bool m)
 {
     qCDebug(lcAudio) << "setLineoutMute:" << m;
     sendCmd(QString("mixer lineout mute %1").arg(m ? 1 : 0));
+    if (m_lineoutMute != m) {
+        m_lineoutMute = m;
+        emit audioOutputChanged();
+    }
 }
 
 void RadioModel::setHeadphoneGain(int v)
@@ -9213,16 +9242,26 @@ void RadioModel::setHeadphoneGain(int v)
     emit audioOutputChanged();
 }
 
+// Optimistic mirror — see the rationale on setLineoutMute() above.
 void RadioModel::setHeadphoneMute(bool m)
 {
     qCDebug(lcAudio) << "setHeadphoneMute:" << m;
     sendCmd(QString("mixer headphone mute %1").arg(m ? 1 : 0));
+    if (m_headphoneMute != m) {
+        m_headphoneMute = m;
+        emit audioOutputChanged();
+    }
 }
 
+// Optimistic mirror — see the rationale on setLineoutMute() above.
 void RadioModel::setFrontSpeakerMute(bool m)
 {
     qCDebug(lcAudio) << "setFrontSpeakerMute:" << m;
     sendCmd(QString("mixer front_speaker mute %1").arg(m ? 1 : 0));
+    if (m_frontSpeakerMute != m) {
+        m_frontSpeakerMute = m;
+        emit audioOutputChanged();
+    }
 }
 
 void RadioModel::handleSliceStatus(int id,

--- a/tests/radiomodel_audio_mute_test.cpp
+++ b/tests/radiomodel_audio_mute_test.cpp
@@ -1,0 +1,177 @@
+// RadioModel's audio-mute setters must mirror the command into the model (#4771).
+//
+// Before this test, setLineoutMute() / setHeadphoneMute() / setFrontSpeakerMute()
+// sent the command and returned -- they never assigned, never emitted. Their
+// neighbours setLineoutGain() / setHeadphoneGain() did both. The asymmetry was
+// invisible on a Flex, whose `audio` status echo writes the flags a beat later,
+// and permanent everywhere else: FlexBackend is the ONLY parser of lineout_mute
+// / headphone_mute / front_speaker_mute, so on hl2 or sim the flags sat at their
+// `false` initialisers for the whole session.
+//
+// What that cost, once #4733 made the title bar reconcile from them: mute the
+// headphones, nudge the headphone volume slider, and setHeadphoneGain()'s
+// audioOutputChanged drove the glyph back to unmuted from the stale flag --
+// under a QSignalBlocker, so no command was sent to undo it and nothing was
+// logged. The control and the radio disagreed silently.
+//
+// The assertions below are the contract, not the implementation: a mute request
+// always reaches the wire, the model mirrors it, the mirror is idempotent, and
+// -- the Principle II half -- a radio status still supersedes the optimistic
+// value. That last one is why this is safe to do at all.
+
+#include "models/RadioModel.h"
+#include "core/backends/IRadioBackend.h"
+#include "core/backends/RadioDelta.h"
+#include "core/backends/sim/SimBackend.h"
+#include "core/RadioDiscovery.h"
+
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QSignalSpy>
+#include <QTimer>
+
+#include <QHostAddress>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+static void check(bool ok, const char* what)
+{
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what); ++g_failures; }
+}
+
+static void spin(int ms)
+{
+    QEventLoop loop;
+    QTimer::singleShot(ms, &loop, &QEventLoop::quit);
+    loop.exec();
+}
+
+// The demo entry exactly as ConnectionPanel::addDemoRadio() builds it.
+static RadioInfo demoInfo()
+{
+    RadioInfo i;
+    i.name    = QStringLiteral("FLEX-6700");
+    i.model   = SimBackend::demoModelName();
+    i.serial  = SimBackend::demoSerial();
+    i.family  = SimBackend::familyName();
+    i.address = QHostAddress(QHostAddress::LocalHost);   // synthetic; never dialed
+    i.port    = 4992;
+    return i;
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    RadioModel model;
+    QSignalSpy audio(&model, &RadioModel::audioOutputChanged);
+
+    // --- Headphone -----------------------------------------------------------
+    check(!model.headphoneMute(), "precondition: headphone mute starts false");
+
+    model.setHeadphoneMute(true);
+    check(model.headphoneMute(),
+          "setHeadphoneMute(true) mirrors into the model");
+    check(audio.count() == 1,
+          "setHeadphoneMute(true) raises audioOutputChanged once");
+
+    // Idempotence: Flex re-sends `audio` on every mixer change, and the UI
+    // reconciles on each one. A no-op setter call must not add churn.
+    model.setHeadphoneMute(true);
+    check(model.headphoneMute() && audio.count() == 1,
+          "repeating setHeadphoneMute(true) does not re-emit");
+
+    model.setHeadphoneMute(false);
+    check(!model.headphoneMute() && audio.count() == 2,
+          "setHeadphoneMute(false) mirrors and emits");
+
+    // --- Line out ------------------------------------------------------------
+    audio.clear();
+    model.setLineoutMute(true);
+    check(model.lineoutMute(), "setLineoutMute(true) mirrors into the model");
+    check(audio.count() == 1, "setLineoutMute(true) raises audioOutputChanged once");
+
+    model.setLineoutMute(true);
+    check(audio.count() == 1, "repeating setLineoutMute(true) does not re-emit");
+
+    // --- Front speaker -------------------------------------------------------
+    audio.clear();
+    model.setFrontSpeakerMute(true);
+    check(model.frontSpeakerMute(),
+          "setFrontSpeakerMute(true) mirrors into the model");
+    check(audio.count() == 1,
+          "setFrontSpeakerMute(true) raises audioOutputChanged once");
+
+    // --- The reported failure, end to end ------------------------------------
+    // This is the exact sequence from #4771: mute, then move the volume. The
+    // gain setter raises audioOutputChanged, which is what the title bar
+    // reconciles the glyph from -- so the mute flag it reads there must still
+    // say muted.
+    model.setHeadphoneMute(true);
+    model.setHeadphoneGain(60);
+    check(model.headphoneMute(),
+          "a headphone volume change does not clear the mute the operator set");
+    check(model.headphoneGain() == 60,
+          "the volume change itself still lands");
+
+    // --- Principle II: the radio still wins ----------------------------------
+    // The optimistic mirror is only defensible because a status echo overrides
+    // it. Feed a radio-authoritative delta through the backend seam and confirm
+    // it beats the value the setter just wrote.
+    if (IRadioBackend* backend = model.backend()) {
+        model.setHeadphoneMute(true);
+        check(model.headphoneMute(), "precondition: optimistic value is set");
+
+        RadioDelta d;
+        d.headphoneMute = false;      // the radio says otherwise
+        emit backend->radioChanged(d);
+
+        check(!model.headphoneMute(),
+              "a radio status supersedes the optimistic mute (Principle II)");
+    } else {
+        std::fprintf(stderr,
+                     "NOTE: no backend on a bare RadioModel; supersede leg not "
+                     "exercised here (applyRadioChanges assigns unconditionally "
+                     "at RadioModel.cpp:9139)\n");
+    }
+
+    // --- Disconnect clears the mutes -----------------------------------------
+    // onDisconnected() resets the audio GAINS to 50 so a reconnect cannot render
+    // the previous radio's state while the new radio's status is in flight. The
+    // mutes were missed by that block, so they survived a disconnect holding the
+    // old rig's values (#4771 item 2).
+    // Reached through a real lifecycle: onDisconnected() only runs for a model
+    // that actually connected, so drive the in-process demo backend rather than
+    // calling disconnectFromRadio() on a model that never connected.
+    model.connectToRadio(demoInfo());
+    for (int i = 0; i < 40 && !model.isConnected(); ++i)
+        spin(50);
+    check(model.isConnected(), "precondition: connected to the demo backend");
+
+    model.setHeadphoneMute(true);
+    model.setLineoutMute(true);
+    model.setFrontSpeakerMute(true);
+    model.setHeadphoneGain(70);
+    check(model.headphoneMute() && model.lineoutMute() && model.frontSpeakerMute(),
+          "precondition: all three mutes set before disconnect");
+
+    model.disconnectFromRadio();
+    // isConnected() goes false BEFORE onDisconnected() runs its state reset, so
+    // waiting on the connection flag alone races the thing under test. Wait for
+    // the reset itself to land, bounded at 2 s.
+    for (int i = 0; i < 40 && model.headphoneGain() != 50; ++i)
+        spin(50);
+    check(!model.isConnected(), "precondition: model reports disconnected");
+    check(!model.headphoneMute(), "disconnect clears headphone mute");
+    check(!model.lineoutMute(),   "disconnect clears line out mute");
+    check(!model.frontSpeakerMute(), "disconnect clears front speaker mute");
+    check(model.headphoneGain() == 50,
+          "disconnect still resets the gains it always did");
+
+    if (g_failures == 0)
+        std::fprintf(stderr, "radiomodel_audio_mute_test: PASS\n");
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

`RadioModel`'s three audio-mute setters sent their command and returned — they never assigned, never emitted — while their immediate neighbours `setLineoutGain()` / `setHeadphoneGain()` did both. `FlexBackend` is the only parser of `lineout_mute` / `headphone_mute` / `front_speaker_mute`, so on every other backend the three flags sat at their `false` initialisers for the life of the session.

That was invisible until #4733 made the title bar reconcile from them. The reported sequence: mute the headphones, nudge the headphone volume, and `setHeadphoneGain()`'s `audioOutputChanged` drives the glyph back to unmuted from the stale flag — under a `QSignalBlocker`, so no command is sent to undo it and nothing is logged. The control and the radio disagree silently.

- Mirror the command into the model in all three mute setters, as the gain setters already do
- Clear the three mutes in `onDisconnected()`, alongside the gain resets that were already there
- Add `tests/radiomodel_audio_mute_test.cpp`

Fixes #4771

## The design call I took, and the one I didn't

#4771 offered two options and carries `maintainer-review`. **This PR is Option A only.**

**Option A — optimistic mirror.** Taken. It is not a new bargain: Flex echoes `lineout_gain` and `headphone_gain` just as it echoes the mutes (`FlexBackend.cpp:942-946`), and the gain setters have always assigned optimistically anyway. Principle II explicitly permits it — *"the client may update optimistically, but the radio's subsequent status is the truth and supersedes the optimistic value"* — and the test pins that supersede leg rather than assuming it.

**Option B — capability-gate the controls.** Deliberately **not** here. Adding a radio-audio-mixer capability means the full `RadioCapabilities.h` ADDING-A-FIELD contract (field + caps-map doc + gating test), and it would take the headphone control away from HL2 operators entirely. That is a product decision, not a bug fix, and #4771 stays open for it.

One deviation from the gain setters worth flagging in review: the command is sent **unconditionally** rather than short-circuited on an unchanged value. A mute is a request; suppressing it because the model already believes the radio is muted would leave a drifted model unrecoverable from the UI — and that drift is exactly what this fixes. Only the assign-and-emit is guarded.

## Verification

Every claim below was run, not reasoned.

**The reported failure, before and after.** A throwaway probe on unfixed `main` ([posted to #4771](https://github.com/aethersdr/AetherSDR/issues/4771#issuecomment-5190812728)) showed `setHeadphoneMute(true)` leaving `headphoneMute()` false and the subsequent `setHeadphoneGain(60)` raising `audioOutputChanged` with the flag still false. The new test asserts that exact sequence and now passes.

**Mutation-tested — all five changes, each reverted in turn:**

| Mutation | Assertions that fail |
|---|---|
| `setHeadphoneMute` back to send-only | 7 |
| `setLineoutMute` back to send-only | 4 |
| `setFrontSpeakerMute` back to send-only | 3 |
| drop the `onDisconnected()` mute reset | 3 |
| drop the idempotence guard (emit every call) | 2 |

**Build and suite:** full build of all 2323 targets, then the complete `ctest` suite (not the CI `-R` subset) — **250/250 pass**, one deliberate skip. Details in the comment below.

## A note for whoever touches `onDisconnected()` next

`isConnected()` goes false **before** `onDisconnected()` runs its state reset, so a test that waits on the connection flag races the reset. The test here waits on the reset itself (bounded at 2 s) rather than on `isConnected()`. Worth knowing — waiting on the flag looked correct and silently asserted against pre-reset state.

## Test plan

- [x] `ctest -R radiomodel_audio_mute_test` passes; fails under all five mutations above
- [x] `libaethercore` builds and links with the change
- [x] Full build of all targets (2323) + full `ctest` suite — **250/250 pass**, see comment below
- [ ] Behaviour on a real FLEX-8600 — unverified; the Flex path is the one case that already worked (its status echo masked the bug), so this is regression risk rather than fix confirmation
