### PR TITLE
fix(hl2): DC-block AM/SAM demodulated audio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,21 @@ jobs:
       - name: Test band edges and band-plan voice labels
         run: ctest --test-dir build -R "band_edges_test|bandplan_voice_labels_test" --output-on-failure
 
+      # hl2_am_dcblock_test joins the gate on the same test as the two steps
+      # above — it pins a defect nothing else in the tree could see. The AM/SAM
+      # carrier arrived in the demodulated audio as a DC pedestal 79% past full
+      # scale, and every existing HL2 assertion stayed green through it, because
+      # they all measure things a constant offset does not move. It is an offline
+      # burst feed with blockForOutput, so no wall clock and no event loop, and
+      # it runs in well under a second against a target the Build step already
+      # linked.
+      #
+      # The rest of the HL2 suite is deliberately NOT here: hl2_backend_test and
+      # friends run tens of seconds apiece against timers and sockets, which is
+      # what the weekly full-suite sanitizers job is for.
+      - name: Test HL2 AM/SAM DC blocker
+        run: ctest --test-dir build -R "hl2_am_dcblock_test" --output-on-failure
+
       # #4146 turned liquid-dsp off by default, so the main build above no
       # longer proves the vendored snapshot still compiles. Build only the
       # liquid-static target (separate build dir, opt-in flag) so a bitrotted

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3079,12 +3079,16 @@ target_include_directories(hl2_rxdsp_test PRIVATE src)
 target_link_libraries(hl2_rxdsp_test PRIVATE aethercore Qt6::Core Qt6::Test)
 add_test(NAME hl2_rxdsp_test COMMAND hl2_rxdsp_test)
 
-# The RX DSP must demodulate at every IQ rate the operator can select by zooming.
+# AM/SAM come back from WDSP's envelope detector with the carrier as a DC
+# pedestal; the blocker on the audio output must strip it without touching the
+# modes that were already zero-mean, and without its corner creeping up into
+# the audio band.
 add_executable(hl2_am_dcblock_test tests/hl2_am_dcblock_test.cpp)
 target_include_directories(hl2_am_dcblock_test PRIVATE src)
 target_link_libraries(hl2_am_dcblock_test PRIVATE aethercore Qt6::Core Qt6::Test)
 add_test(NAME hl2_am_dcblock_test COMMAND hl2_am_dcblock_test)
 
+# The RX DSP must demodulate at every IQ rate the operator can select by zooming.
 add_executable(hl2_rxdsp_rate_test tests/hl2_rxdsp_rate_test.cpp)
 target_include_directories(hl2_rxdsp_rate_test PRIVATE src)
 target_link_libraries(hl2_rxdsp_rate_test PRIVATE aethercore Qt6::Core Qt6::Test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3080,6 +3080,11 @@ target_link_libraries(hl2_rxdsp_test PRIVATE aethercore Qt6::Core Qt6::Test)
 add_test(NAME hl2_rxdsp_test COMMAND hl2_rxdsp_test)
 
 # The RX DSP must demodulate at every IQ rate the operator can select by zooming.
+add_executable(hl2_am_dcblock_test tests/hl2_am_dcblock_test.cpp)
+target_include_directories(hl2_am_dcblock_test PRIVATE src)
+target_link_libraries(hl2_am_dcblock_test PRIVATE aethercore Qt6::Core Qt6::Test)
+add_test(NAME hl2_am_dcblock_test COMMAND hl2_am_dcblock_test)
+
 add_executable(hl2_rxdsp_rate_test tests/hl2_rxdsp_rate_test.cpp)
 target_include_directories(hl2_rxdsp_rate_test PRIVATE src)
 target_link_libraries(hl2_rxdsp_rate_test PRIVATE aethercore Qt6::Core Qt6::Test)

--- a/HERMES.md
+++ b/HERMES.md
@@ -203,6 +203,50 @@ the modes.
 - Mode vocabulary: `off/slow/med/fast` → WDSP RXA 0/2/3/4. WDSP's "long" (1)
   has no representation in the four-way UI control.
 
+### AM/SAM hand back a DC pedestal, and nothing upstream removes it
+
+WDSP's AM/SAM detector is an **envelope** detector — `amd.c` emits
+`sqrt(I² + Q²)`, which is strictly non-negative — so the carrier arrives in the
+demodulated audio as DC. Three things that each look like they would remove it,
+and do not:
+
+- **`levelfade` is not a DC blocker.** On by default (`RXA.c`). It computes
+  `audio += dc_insert - dc` from an 8 Hz-corner average and a 0.11 Hz-corner
+  average. Those cancel *fading*; they deliberately **hold** the pedestal at the
+  long-term carrier level. That is the entire point of the stage.
+- **The AM/SAM passband cannot strip it.** `defaultPassbandForMode` gives AM and
+  SAM `{-4000, +4000}` — symmetric about the carrier, because both detectors
+  need it that way — which puts 0 Hz mid-band.
+- **AetherSDR had no RX DC blocker.** The only other `setDcBlockEnabled` in the
+  tree is on the **TX** final limiter.
+
+Measured on a 50%-modulated carrier, unfixed: settled audio mean **1.79** on a
+±1.0 float scale, AC RMS 0.70 — measured at the `WdspChannel` output, so that is
+*after* AGC. The pedestal alone is 79% past full scale, so AM audio clipped hard
+against the rails everywhere downstream.
+
+Every zero-referenced consumer downstream inherits the offset. The visible
+symptom was the **WAVE applet drawing two waveforms, the lower one inverted**:
+it renders `peak` and `rms` — both magnitudes — mirrored about a hard
+centreline, so a DC-shifted trace draws a phantom upside-down copy of itself in
+the bottom half. SSB looked fine throughout because it is already zero-mean, and
+that asymmetry is the tell.
+
+`Hl2RxDsp` now applies a 20 Hz one-pole DC blocker per channel to the
+`WdspChannel` output, **unconditionally for every mode** — SSB/CW are already
+zero-mean so it is a no-op there, FM wants it for the same reason AM does, and
+an unconditional filter has no mode-change state to get wrong. Guarded by
+`hl2_am_dcblock_test`, which measures the *settled tail* (`dc_insert` is a 1.4 s
+pole, so a short burst shows almost no DC even unfixed) and asserts a DC/AC
+**ratio** rather than a level, since AGC scales both equally.
+
+**What this does not fix.** The blocker is downstream of the entire RXA chain,
+so `wcpAGC` — which sits after `amd` *inside* RXA — still rides the pedestal.
+Its gain decisions on AM/SAM remain biased by the carrier. Correcting that needs
+DC removal between `amd` and the AGC, and WDSP exposes no hook there;
+`SetRXAAMDFadeLevel(0)` is not one, since it only drops the fade correction and
+leaves `sqrt(I² + Q²)` just as non-negative. Left as a known residual.
+
 ---
 
 ## 6. Seam gaps found (the reusable checklist)

--- a/HERMES.md
+++ b/HERMES.md
@@ -217,8 +217,12 @@ and do not:
 - **The AM/SAM passband cannot strip it.** `defaultPassbandForMode` gives AM and
   SAM `{-4000, +4000}` — symmetric about the carrier, because both detectors
   need it that way — which puts 0 Hz mid-band.
-- **AetherSDR had no RX DC blocker.** The only other `setDcBlockEnabled` in the
-  tree is on the **TX** final limiter.
+- **AetherSDR had no DC blocker on the RX demodulated-audio path.** The only
+  `setDcBlockEnabled` in the tree is on the **TX** final limiter
+  (`ClientFinalLimiter`). `ClientPudu` has a one-pole DC block too, but it is
+  internal to the opt-in Aphex HF path and exists to remove the offset that
+  path's own one-sided clipping introduces — it is not in the chain unless the
+  operator switched that effect on, and it is downstream of the applet anyway.
 
 Measured on a 50%-modulated carrier, unfixed: settled audio mean **1.79** on a
 ±1.0 float scale, AC RMS 0.70 — measured at the `WdspChannel` output, so that is
@@ -239,6 +243,22 @@ an unconditional filter has no mode-change state to get wrong. Guarded by
 `hl2_am_dcblock_test`, which measures the *settled tail* (`dc_insert` is a 1.4 s
 pole, so a short burst shows almost no DC even unfixed) and asserts a DC/AC
 **ratio** rather than a level, since AGC scales both equally.
+
+That test also pins the corner, which is the half of the property that is easy
+to satisfy by accident: a blocker whose corner has crept up into the audio band
+removes the pedestal just as thoroughly while eating the bass out of every mode,
+and every DC measurement stays green through it. So it checks a 60 Hz vs 400 Hz
+modulation ratio through the real chain, the closed-form `|H(f)|` at three audio
+rates, and the unconfigured bypass. It is one of the few HL2 tests in the
+per-PR CI gate; the rest of the suite runs weekly under the sanitizers job.
+
+**Why on `Hl2RxDsp` and not on `WdspChannel`.** The root cause is `amd`'s
+envelope detector, which belongs to WDSP, so a blocker on `WdspChannel`'s own RX
+output would fix it once for every future consumer rather than per caller.
+`Hl2RxDsp` is the only WDSP **receive** consumer in the tree today — `Hl2TxDsp`
+is the one other user and is transmit-only — so per-caller costs nothing yet.
+The next WDSP RX path added will not inherit it: push the blocker down into
+`WdspChannel` at that point rather than repeating it.
 
 **What this does not fix.** The blocker is downstream of the entire RXA chain,
 so `wcpAGC` — which sits after `amd` *inside* RXA — still rides the pedestal.

--- a/src/core/backends/hl2/Hl2RxDsp.cpp
+++ b/src/core/backends/hl2/Hl2RxDsp.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <numbers>
 
 namespace AetherSDR::hl2 {
 
@@ -79,6 +80,16 @@ bool Hl2RxDsp::configure(const Config& config, std::string* error)
     m_left.assign(outN, 0.0f);
     m_right.assign(outN, 0.0f);
     m_stereo.assign(outN * 2, 0.0f);
+    // DC blocker pole for the AUDIO rate — the blocker runs on WdspChannel's
+    // output, not on its 48 kHz internal rate. Recomputed here so a rate change
+    // keeps the same corner frequency instead of moving it.
+    const float pole = static_cast<float>(
+        std::exp(-2.0 * std::numbers::pi * kDcBlockerCornerHz /
+                 static_cast<double>(config.audioSampleRateHz)));
+    m_dcBlockL.r = pole;
+    m_dcBlockR.r = pole;
+    m_dcBlockL.reset();
+    m_dcBlockR.reset();
     // A rebuild (rate change) creates a fresh channel; restore the operator's
     // current slice offset rather than silently snapping the slice to centre.
     if (m_shiftHz != 0.0)
@@ -246,8 +257,12 @@ void Hl2RxDsp::processIqBlock(const std::vector<std::complex<float>>& iq)
 
         const std::size_t outN = m_left.size();
         for (std::size_t k = 0; k < outN; ++k) {
-            m_stereo[2 * k] = m_left[k];
-            m_stereo[2 * k + 1] = m_right[k];
+            // DC-block on the way out. AM/SAM arrive with the carrier as a DC
+            // pedestal that nothing upstream removes — see DcBlocker in the
+            // header for why WDSP's levelfade and the symmetric AM passband
+            // both leave it in place.
+            m_stereo[2 * k] = m_dcBlockL.process(m_left[k]);
+            m_stereo[2 * k + 1] = m_dcBlockR.process(m_right[k]);
         }
         emit audioReady(m_stereo);
         // S-meter from WDSP's own signal-strength meter, NOT from the RMS of

--- a/src/core/backends/hl2/Hl2RxDsp.cpp
+++ b/src/core/backends/hl2/Hl2RxDsp.cpp
@@ -4,7 +4,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <numbers>
 
 namespace AetherSDR::hl2 {
 
@@ -83,9 +82,8 @@ bool Hl2RxDsp::configure(const Config& config, std::string* error)
     // DC blocker pole for the AUDIO rate — the blocker runs on WdspChannel's
     // output, not on its 48 kHz internal rate. Recomputed here so a rate change
     // keeps the same corner frequency instead of moving it.
-    const float pole = static_cast<float>(
-        std::exp(-2.0 * std::numbers::pi * kDcBlockerCornerHz /
-                 static_cast<double>(config.audioSampleRateHz)));
+    const float pole = dcBlockerPole(kDcBlockerCornerHz,
+                                     static_cast<double>(config.audioSampleRateHz));
     m_dcBlockL.r = pole;
     m_dcBlockR.r = pole;
     m_dcBlockL.reset();

--- a/src/core/backends/hl2/Hl2RxDsp.h
+++ b/src/core/backends/hl2/Hl2RxDsp.h
@@ -3,6 +3,7 @@
 #include <QElapsedTimer>
 #include <QObject>
 
+#include <cmath>
 #include <complex>
 #include <memory>
 #include <vector>
@@ -146,8 +147,70 @@ private:
     // the demodulator takes the raw wire. A member rather than a local: this
     // runs per IQ block on the I/O thread.
     std::vector<std::complex<float>> m_conjugated;
+    // Demodulated-audio DC blocker, one pole per channel.
+    //
+    // WDSP's AM/SAM detector is an ENVELOPE detector — amd.c emits
+    // sqrt(I^2 + Q^2), which is strictly non-negative — so the carrier arrives
+    // as a DC pedestal. Nothing upstream removes it:
+    //
+    //   * `levelfade` (ON by default, RXA.c) computes
+    //     `audio += dc_insert - dc` from an 8 Hz-corner and a 0.11 Hz-corner
+    //     average. That cancels FADING and deliberately holds the pedestal at
+    //     the long-term carrier level; it is not a DC blocker.
+    //   * The AM/SAM passband is symmetric about the carrier ({-4000, +4000}
+    //     in Hl2Backend::defaultPassbandForMode) because both detectors need
+    //     it that way, which puts 0 Hz mid-band.
+    //
+    // Left in, the pedestal eats output headroom and skews every
+    // zero-referenced consumer downstream — the WAVE applet draws `peak` and
+    // `rms`, both magnitudes, mirrored about a hard centreline, so a DC-shifted
+    // trace renders as a second inverted phantom copy of itself in the lower
+    // half.
+    //
+    // SCOPE: this runs on WdspChannel's OUTPUT, downstream of the whole RXA
+    // chain, so it fixes the audio we deliver but NOT what WDSP itself saw.
+    // wcpAGC sits after amd INSIDE RXA and still rides the pedestal; correcting
+    // that would need DC removal between the two, which WDSP exposes no hook
+    // for. Turning `levelfade` off does not help either — it only stops the
+    // fade correction, leaving sqrt(I^2+Q^2) just as non-negative.
+    //
+    // Applied to EVERY mode rather than switched on for AM/SAM: SSB, CW and
+    // the digital modes are already zero-mean so it is a no-op there, FM wants
+    // it for the same reason AM does, and an unconditional filter has no
+    // mode-change state that can be got wrong.
+    struct DcBlocker {
+        float r = 0.0f;    // pole radius, set by configure(); <= 0 bypasses
+        float x1 = 0.0f;
+        float y1 = 0.0f;
+
+        [[nodiscard]] float process(float x) noexcept
+        {
+            // Bypass rather than filter when unconfigured. `y = x - x1 + r*y1`
+            // at r = 0 is a DIFFERENTIATOR, not a passthrough, so a missed
+            // configure() would otherwise gut the low end of the audio.
+            if (!(r > 0.0f))
+                return x;
+            float y = x - x1 + r * y1;
+            // Flush to zero. During silence y1 decays geometrically toward
+            // denormal, and denormal arithmetic is punitively slow on x86.
+            if (!(std::fabs(y) > 1e-20f))
+                y = 0.0f;
+            x1 = x;
+            y1 = y;
+            return y;
+        }
+
+        void reset() noexcept { x1 = 0.0f; y1 = 0.0f; }
+    };
+
+    // -3 dB corner, Hz. Well below the 100 Hz that even a wide AM passband
+    // carries as audio, and far below the CW pitch, so it removes the pedestal
+    // without touching program material.
+    static constexpr double kDcBlockerCornerHz = 20.0;
+
     std::vector<float> m_i, m_q;                    // deinterleaved input scratch
     std::vector<float> m_left, m_right;             // WdspChannel output scratch
+    DcBlocker m_dcBlockL, m_dcBlockR;               // applied to m_left/m_right
     std::vector<float> m_stereo;                    // interleaved audio out
     std::vector<float> m_bins;                      // spectrum scratch
 };

--- a/src/core/backends/hl2/Hl2RxDsp.h
+++ b/src/core/backends/hl2/Hl2RxDsp.h
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <complex>
 #include <memory>
+#include <numbers>
 #include <vector>
 
 #include "core/backends/hl2/Hl2Spectrum.h"
@@ -116,6 +117,91 @@ public:
         return m_channel ? m_channel->channelIdForTest() : -1;
     }
 
+    // Demodulated-audio DC blocker, one pole per channel.
+    //
+    // WDSP's AM/SAM detector is an ENVELOPE detector — amd.c emits
+    // sqrt(I^2 + Q^2), which is strictly non-negative — so the carrier arrives
+    // as a DC pedestal. Nothing upstream removes it:
+    //
+    //   * `levelfade` (ON by default, RXA.c) computes
+    //     `audio += dc_insert - dc` from an 8 Hz-corner and a 0.11 Hz-corner
+    //     average. That cancels FADING and deliberately holds the pedestal at
+    //     the long-term carrier level; it is not a DC blocker.
+    //   * The AM/SAM passband is symmetric about the carrier ({-4000, +4000}
+    //     in Hl2Backend::defaultPassbandForMode) because both detectors need
+    //     it that way, which puts 0 Hz mid-band.
+    //
+    // Left in, the pedestal eats output headroom and skews every
+    // zero-referenced consumer downstream — the WAVE applet draws `peak` and
+    // `rms`, both magnitudes, mirrored about a hard centreline, so a DC-shifted
+    // trace renders as a second inverted phantom copy of itself in the lower
+    // half.
+    //
+    // SCOPE: this runs on WdspChannel's OUTPUT, downstream of the whole RXA
+    // chain, so it fixes the audio we deliver but NOT what WDSP itself saw.
+    // wcpAGC sits after amd INSIDE RXA and still rides the pedestal; correcting
+    // that would need DC removal between the two, which WDSP exposes no hook
+    // for. Turning `levelfade` off does not help either — it only stops the
+    // fade correction, leaving sqrt(I^2+Q^2) just as non-negative.
+    //
+    // WHY HERE AND NOT IN WdspChannel: the root cause is amd's envelope
+    // detector, which belongs to WDSP, so a blocker on WdspChannel's own RX
+    // output would fix it once for every future consumer instead of per caller.
+    // Hl2RxDsp is the only WDSP RECEIVE consumer in the tree today — Hl2TxDsp is
+    // the one other user and is transmit-only — so per-caller costs nothing yet.
+    // It does mean the next WDSP RX path added will NOT inherit this: whoever
+    // adds one should push the blocker down into WdspChannel rather than repeat
+    // it here.
+    //
+    // Applied to EVERY mode rather than switched on for AM/SAM: SSB, CW and
+    // the digital modes are already zero-mean so it is a no-op there, FM wants
+    // it for the same reason AM does, and an unconditional filter has no
+    // mode-change state that can be got wrong.
+    //
+    // Public, with the pole helper below, so hl2_am_dcblock_test can pin the
+    // unconfigured bypass and the rate-dependent corner directly. Neither is
+    // reachable through configure(), which only ever hands it a valid rate.
+    struct DcBlocker {
+        float r = 0.0f;    // pole radius, set by configure(); <= 0 bypasses
+        float x1 = 0.0f;
+        float y1 = 0.0f;
+
+        [[nodiscard]] float process(float x) noexcept
+        {
+            // Bypass rather than filter when unconfigured. `y = x - x1 + r*y1`
+            // at r = 0 is a DIFFERENTIATOR, not a passthrough, so a missed
+            // configure() would otherwise gut the low end of the audio.
+            if (!(r > 0.0f))
+                return x;
+            float y = x - x1 + r * y1;
+            // Flush to zero. During silence y1 decays geometrically toward
+            // denormal, and denormal arithmetic is punitively slow on x86.
+            if (!(std::fabs(y) > 1e-20f))
+                y = 0.0f;
+            x1 = x;
+            y1 = y;
+            return y;
+        }
+
+        void reset() noexcept { x1 = 0.0f; y1 = 0.0f; }
+    };
+
+    // -3 dB corner, Hz. Well below the 100 Hz that even a wide AM passband
+    // carries as audio, and far below the CW pitch, so it removes the pedestal
+    // without touching program material.
+    static constexpr double kDcBlockerCornerHz = 20.0;
+
+    // Pole radius placing DcBlocker's -3 dB corner at `cornerHz`. Split out of
+    // configure() so the corner can be asserted at more than one audio rate:
+    // hardcoding the pole for one rate leaves the filter working and the corner
+    // silently wrong, which no end-to-end DC measurement notices.
+    [[nodiscard]] static float dcBlockerPole(double cornerHz,
+                                             double sampleRateHz) noexcept
+    {
+        return static_cast<float>(
+            std::exp(-2.0 * std::numbers::pi * cornerHz / sampleRateHz));
+    }
+
 public slots:
     // Feed one IQ block (normalized complex<float>). Emits spectrumReady per FFT
     // frame and audioReady/meterUpdate per completed WdspChannel block.
@@ -147,70 +233,11 @@ private:
     // the demodulator takes the raw wire. A member rather than a local: this
     // runs per IQ block on the I/O thread.
     std::vector<std::complex<float>> m_conjugated;
-    // Demodulated-audio DC blocker, one pole per channel.
-    //
-    // WDSP's AM/SAM detector is an ENVELOPE detector — amd.c emits
-    // sqrt(I^2 + Q^2), which is strictly non-negative — so the carrier arrives
-    // as a DC pedestal. Nothing upstream removes it:
-    //
-    //   * `levelfade` (ON by default, RXA.c) computes
-    //     `audio += dc_insert - dc` from an 8 Hz-corner and a 0.11 Hz-corner
-    //     average. That cancels FADING and deliberately holds the pedestal at
-    //     the long-term carrier level; it is not a DC blocker.
-    //   * The AM/SAM passband is symmetric about the carrier ({-4000, +4000}
-    //     in Hl2Backend::defaultPassbandForMode) because both detectors need
-    //     it that way, which puts 0 Hz mid-band.
-    //
-    // Left in, the pedestal eats output headroom and skews every
-    // zero-referenced consumer downstream — the WAVE applet draws `peak` and
-    // `rms`, both magnitudes, mirrored about a hard centreline, so a DC-shifted
-    // trace renders as a second inverted phantom copy of itself in the lower
-    // half.
-    //
-    // SCOPE: this runs on WdspChannel's OUTPUT, downstream of the whole RXA
-    // chain, so it fixes the audio we deliver but NOT what WDSP itself saw.
-    // wcpAGC sits after amd INSIDE RXA and still rides the pedestal; correcting
-    // that would need DC removal between the two, which WDSP exposes no hook
-    // for. Turning `levelfade` off does not help either — it only stops the
-    // fade correction, leaving sqrt(I^2+Q^2) just as non-negative.
-    //
-    // Applied to EVERY mode rather than switched on for AM/SAM: SSB, CW and
-    // the digital modes are already zero-mean so it is a no-op there, FM wants
-    // it for the same reason AM does, and an unconditional filter has no
-    // mode-change state that can be got wrong.
-    struct DcBlocker {
-        float r = 0.0f;    // pole radius, set by configure(); <= 0 bypasses
-        float x1 = 0.0f;
-        float y1 = 0.0f;
-
-        [[nodiscard]] float process(float x) noexcept
-        {
-            // Bypass rather than filter when unconfigured. `y = x - x1 + r*y1`
-            // at r = 0 is a DIFFERENTIATOR, not a passthrough, so a missed
-            // configure() would otherwise gut the low end of the audio.
-            if (!(r > 0.0f))
-                return x;
-            float y = x - x1 + r * y1;
-            // Flush to zero. During silence y1 decays geometrically toward
-            // denormal, and denormal arithmetic is punitively slow on x86.
-            if (!(std::fabs(y) > 1e-20f))
-                y = 0.0f;
-            x1 = x;
-            y1 = y;
-            return y;
-        }
-
-        void reset() noexcept { x1 = 0.0f; y1 = 0.0f; }
-    };
-
-    // -3 dB corner, Hz. Well below the 100 Hz that even a wide AM passband
-    // carries as audio, and far below the CW pitch, so it removes the pedestal
-    // without touching program material.
-    static constexpr double kDcBlockerCornerHz = 20.0;
-
     std::vector<float> m_i, m_q;                    // deinterleaved input scratch
     std::vector<float> m_left, m_right;             // WdspChannel output scratch
-    DcBlocker m_dcBlockL, m_dcBlockR;               // applied to m_left/m_right
+    // Applied to m_left/m_right on the way into m_stereo. See DcBlocker above
+    // for why AM/SAM need it, and for what it deliberately does not fix.
+    DcBlocker m_dcBlockL, m_dcBlockR;
     std::vector<float> m_stereo;                    // interleaved audio out
     std::vector<float> m_bins;                      // spectrum scratch
 };

--- a/tests/hl2_am_dcblock_test.cpp
+++ b/tests/hl2_am_dcblock_test.cpp
@@ -1,0 +1,216 @@
+// HL2 AM/SAM DC-pedestal regression test.
+//
+// WDSP's AM/SAM detector is an ENVELOPE detector — amd.c emits
+// sqrt(I^2 + Q^2), strictly non-negative — so the carrier lands in the
+// demodulated audio as a DC pedestal. Neither `levelfade` (which cancels
+// fading and deliberately HOLDS that pedestal) nor the symmetric {-4000,+4000}
+// AM passband removes it, and AetherSDR has no other RX DC blocker. Left in,
+// the pedestal eats headroom, biases wcpAGC, and offsets every zero-referenced
+// consumer — the WAVE applet mirrors `peak`/`rms` about a hard centreline, so a
+// DC-shifted trace draws a second, INVERTED phantom copy of itself.
+//
+// Two things make this test able to fail against the unfixed chain:
+//
+//   1. It feeds a REAL amplitude-modulated carrier, A*(1 + m*cos(wm.t)), in
+//      WIRE ORDER (the HPSDR wire is the conjugate of the analytic convention,
+//      so a carrier above the NCO is exp(-j.w.t)). A textbook constant-envelope
+//      tone has no modulation to distinguish from its own DC.
+//   2. It measures the SETTLED tail. `dc_insert` is a 1.4 s one-pole (RXA.c
+//      tauI), so the pedestal ramps in from zero — a short burst shows almost
+//      no DC even with the blocker removed, and would pass either way.
+//
+// The assertion is a RATIO of DC to AC, not an absolute level, because
+// wcpAGC applies the same gain to both and the absolute scale is arbitrary.
+
+#include "core/backends/hl2/Hl2RxDsp.h"
+#include "core/backends/hl2/MetisProtocol.h"   // kEp6BlockSamples
+
+#include <QCoreApplication>
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstdio>
+#include <numbers>
+#include <span>
+#include <vector>
+
+using namespace AetherSDR::hl2;
+
+static int g_failures = 0;
+static void check(bool cond, const char* what)
+{
+    if (!cond) {
+        std::fprintf(stderr, "FAIL: %s\n", what);
+        ++g_failures;
+    }
+}
+
+namespace {
+
+struct AudioStats {
+    double mean = 0.0;    // DC pedestal
+    double acRms = 0.0;   // RMS about that mean — the actual program material
+};
+
+// Drive `dsp` with `seconds` of amplitude-modulated carrier and return the
+// statistics of the settled TAIL of the demodulated audio.
+AudioStats runAm(Hl2RxDsp& dsp,
+                 int inputRateHz,
+                 double seconds,
+                 double tailSeconds,
+                 double carrierOffsetHz,
+                 double modHz,
+                 double modDepth)
+{
+    std::vector<float> audio;
+    const auto conn = QObject::connect(
+        &dsp, &Hl2RxDsp::audioReady, &dsp,
+        [&](const std::vector<float>& pcm) {
+            // Left channel only; AM writes both channels identically.
+            for (std::size_t k = 0; k < pcm.size(); k += 2)
+                audio.push_back(pcm[k]);
+        });
+
+    const auto total = static_cast<int>(seconds * inputRateHz);
+    std::vector<std::complex<float>> stream(static_cast<std::size_t>(total));
+    for (int n = 0; n < total; ++n) {
+        const double t = static_cast<double>(n) / inputRateHz;
+        const double env = 0.3 * (1.0 + modDepth * std::cos(2.0 * std::numbers::pi * modHz * t));
+        // WIRE ORDER: negative sine puts the carrier ABOVE the NCO.
+        const double ph = 2.0 * std::numbers::pi * carrierOffsetHz * t;
+        stream[static_cast<std::size_t>(n)] =
+            std::complex<float>(static_cast<float>(env * std::cos(ph)),
+                                static_cast<float>(-env * std::sin(ph)));
+    }
+
+    std::span<const std::complex<float>> s(stream);
+    for (std::size_t off = 0; off < s.size(); off += kEp6BlockSamples) {
+        const std::size_t n = std::min<std::size_t>(kEp6BlockSamples, s.size() - off);
+        const auto sub = s.subspan(off, n);
+        dsp.processIqBlock(std::vector<std::complex<float>>(sub.begin(), sub.end()));
+    }
+    QObject::disconnect(conn);
+
+    AudioStats st;
+    if (audio.empty())
+        return st;
+
+    // Settled tail only — see the dc_insert note in the file header.
+    const auto tail = std::min<std::size_t>(
+        audio.size(),
+        static_cast<std::size_t>(tailSeconds * audio.size() / seconds));
+    const std::size_t start = audio.size() - tail;
+
+    double sum = 0.0;
+    for (std::size_t i = start; i < audio.size(); ++i)
+        sum += audio[i];
+    st.mean = sum / static_cast<double>(tail);
+
+    double sumSq = 0.0;
+    for (std::size_t i = start; i < audio.size(); ++i) {
+        const double d = audio[i] - st.mean;
+        sumSq += d * d;
+    }
+    st.acRms = std::sqrt(sumSq / static_cast<double>(tail));
+    return st;
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    constexpr int kInputRate = 48000;
+    constexpr double kSeconds = 4.0;      // > 2x the 1.4 s dc_insert time constant
+    constexpr double kTail = 1.0;         // measure only the settled last second
+    constexpr double kModHz = 400.0;
+    constexpr double kModDepth = 0.5;
+
+    Hl2RxDsp::Config cfg;
+    cfg.inputSampleRateHz = kInputRate;
+    cfg.audioSampleRateHz = 24000;        // the shipping audio rate
+    cfg.dspBlockSize = 1024;
+    cfg.fftSize = 256;
+    cfg.blockForOutput = true;            // deterministic for an offline burst feed
+
+    // ---- AM: the mode that carries the pedestal ----
+    {
+        Hl2RxDsp dsp;
+        Hl2RxDsp::Config c = cfg;
+        c.mode = WdspChannel::Mode::Am;
+        c.filterLowHz = -4000.0;          // symmetric, as defaultPassbandForMode gives AM
+        c.filterHighHz = 4000.0;
+        std::string err;
+        check(dsp.configure(c, &err), err.empty() ? "AM configures" : err.c_str());
+
+        const AudioStats st = runAm(dsp, kInputRate, kSeconds, kTail,
+                                    /*carrierOffsetHz=*/1000.0, kModHz, kModDepth);
+
+        check(st.acRms > 1e-4,
+              "AM demod produced non-silent modulation (the blocker did not eat the audio)");
+
+        // The discriminator. With m = 0.5 the envelope is A*(1 + 0.5cos), so
+        // undetected DC gives mean/acRms = A / (0.5A/sqrt2) = 2.83. The blocker
+        // must drive that ratio to roughly zero. 0.10 sits an order of magnitude
+        // below the unfixed value, so this cannot pass on a pedestal.
+        const double ratio = st.acRms > 0.0 ? std::fabs(st.mean) / st.acRms : 1e9;
+        static_assert(kModDepth == 0.5, "the 2.83 unfixed ratio below assumes m = 0.5");
+        check(ratio < 0.10,
+              "AM audio is zero-mean: no carrier DC pedestal survives to the audio");
+        if (ratio >= 0.10) {
+            std::fprintf(stderr, "  DC/AC ratio = %.3f (mean %.6f, acRms %.6f);"
+                                 " unfixed chain measures ~2.83\n",
+                         ratio, st.mean, st.acRms);
+        }
+    }
+
+    // ---- SAM: same detector family, same pedestal ----
+    {
+        Hl2RxDsp dsp;
+        Hl2RxDsp::Config c = cfg;
+        c.mode = WdspChannel::Mode::Sam;
+        c.filterLowHz = -4000.0;
+        c.filterHighHz = 4000.0;
+        std::string err;
+        check(dsp.configure(c, &err), err.empty() ? "SAM configures" : err.c_str());
+
+        const AudioStats st = runAm(dsp, kInputRate, kSeconds, kTail,
+                                    /*carrierOffsetHz=*/1000.0, kModHz, kModDepth);
+
+        check(st.acRms > 1e-4, "SAM demod produced non-silent modulation");
+        const double ratio = st.acRms > 0.0 ? std::fabs(st.mean) / st.acRms : 1e9;
+        check(ratio < 0.10, "SAM audio is zero-mean: no carrier DC pedestal");
+        if (ratio >= 0.10) {
+            std::fprintf(stderr, "  SAM DC/AC ratio = %.3f (mean %.6f, acRms %.6f)\n",
+                         ratio, st.mean, st.acRms);
+        }
+    }
+
+    // ---- USB: the blocker must be a no-op on a mode that was already correct ----
+    //
+    // The reported symptom was AM/SAM-only, so the fix has to leave SSB
+    // untouched. A 20 Hz corner is far below the 100 Hz the USB passband starts
+    // at, so the modulation must survive at full strength.
+    {
+        Hl2RxDsp dsp;
+        Hl2RxDsp::Config c = cfg;
+        c.mode = WdspChannel::Mode::Usb;
+        c.filterLowHz = 100.0;
+        c.filterHighHz = 2900.0;
+        std::string err;
+        check(dsp.configure(c, &err), err.empty() ? "USB configures" : err.c_str());
+
+        const AudioStats st = runAm(dsp, kInputRate, kSeconds, kTail,
+                                    /*carrierOffsetHz=*/1000.0, kModHz, kModDepth);
+
+        check(st.acRms > 1e-4, "USB demod still produces audio through the DC blocker");
+        const double ratio = st.acRms > 0.0 ? std::fabs(st.mean) / st.acRms : 1e9;
+        check(ratio < 0.10, "USB audio remains zero-mean (it always was)");
+    }
+
+    if (g_failures == 0)
+        std::fprintf(stderr, "hl2_am_dcblock_test: all checks passed\n");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/hl2_am_dcblock_test.cpp
+++ b/tests/hl2_am_dcblock_test.cpp
@@ -21,6 +21,14 @@
 //
 // The assertion is a RATIO of DC to AC, not an absolute level, because
 // wcpAGC applies the same gain to both and the absolute scale is arbitrary.
+//
+// "The pedestal is gone" is only half the property, though, and it is the half
+// that is easy to satisfy by accident: a blocker with its corner up in the audio
+// band removes DC just as thoroughly while eating the bass out of every mode. So
+// the file also pins the corner from three directions — a 60 Hz vs 400 Hz
+// modulation ratio through the real chain, the closed-form |H(f)| at three audio
+// rates, and the unconfigured bypass that keeps a missed configure() from
+// turning the filter into a differentiator.
 
 #include "core/backends/hl2/Hl2RxDsp.h"
 #include "core/backends/hl2/MetisProtocol.h"   // kEp6BlockSamples
@@ -152,18 +160,137 @@ int main(int argc, char** argv)
               "AM demod produced non-silent modulation (the blocker did not eat the audio)");
 
         // The discriminator. With m = 0.5 the envelope is A*(1 + 0.5cos), so
-        // undetected DC gives mean/acRms = A / (0.5A/sqrt2) = 2.83. The blocker
-        // must drive that ratio to roughly zero. 0.10 sits an order of magnitude
-        // below the unfixed value, so this cannot pass on a pedestal.
+        // undetected DC gives mean/acRms = A / (0.5A/sqrt2) = 2.83 in the ideal
+        // case. The measured unfixed chain lands a little under that — 2.57 here,
+        // 2.53 in SAM — because levelfade and the AGC are not ideal. Either way
+        // the blocker must drive the ratio to roughly zero, and 0.10 sits more
+        // than an order of magnitude below the measured value.
         const double ratio = st.acRms > 0.0 ? std::fabs(st.mean) / st.acRms : 1e9;
-        static_assert(kModDepth == 0.5, "the 2.83 unfixed ratio below assumes m = 0.5");
+        static_assert(kModDepth == 0.5, "the 2.83 ideal ratio above assumes m = 0.5");
         check(ratio < 0.10,
               "AM audio is zero-mean: no carrier DC pedestal survives to the audio");
         if (ratio >= 0.10) {
             std::fprintf(stderr, "  DC/AC ratio = %.3f (mean %.6f, acRms %.6f);"
-                                 " unfixed chain measures ~2.83\n",
+                                 " unfixed chain MEASURES ~2.57 (ideal envelope"
+                                 " derivation is 2.83)\n",
                          ratio, st.mean, st.acRms);
         }
+    }
+
+    // ---- The corner must stay LOW ----
+    //
+    // Every assertion above is one-sided: they check that DC is GONE, never that
+    // the program material survived. A blocker whose corner has crept up into the
+    // audio band passes all of them — at 500 Hz instead of 20 Hz the 400 Hz tone
+    // still clears the `acRms > 1e-4` floor by four orders of magnitude, and AM,
+    // SAM and USB all stay zero-mean.
+    //
+    // A second modulation frequency pins it, because the RATIO between the two is
+    // what a too-high corner destroys: a 60 Hz tone is 0.94 of a 400 Hz one
+    // through a 20 Hz corner, but only 0.19 through a 500 Hz one.
+    {
+        double acAt400 = 0.0, acAt60 = 0.0;
+        for (double mod : {400.0, 60.0}) {
+            Hl2RxDsp dsp;
+            Hl2RxDsp::Config c = cfg;
+            c.mode = WdspChannel::Mode::Am;
+            c.filterLowHz = -4000.0;
+            c.filterHighHz = 4000.0;
+            std::string err;
+            check(dsp.configure(c, &err), err.empty() ? "AM configures" : err.c_str());
+            const AudioStats st = runAm(dsp, kInputRate, kSeconds, kTail,
+                                        /*carrierOffsetHz=*/1000.0, mod, kModDepth);
+            (mod == 400.0 ? acAt400 : acAt60) = st.acRms;
+        }
+        const double keep = acAt400 > 0.0 ? acAt60 / acAt400 : 0.0;
+        check(keep > 0.70,
+              "60 Hz modulation survives: the blocker's corner is not in the audio band");
+        if (!(keep > 0.70)) {
+            std::fprintf(stderr, "  60/400 Hz AC ratio = %.3f (ac60 %.6f, ac400 %.6f)\n",
+                         keep, acAt60, acAt400);
+        }
+    }
+
+    // ---- The corner must follow the AUDIO rate, not a hardcoded 24 kHz ----
+    //
+    // configure() recomputes the pole from audioSampleRateHz precisely so a rate
+    // change leaves the corner frequency where it was. Nothing end-to-end can see
+    // that: hardcode the 24 kHz pole and run at 48 kHz and the corner merely
+    // halves to 10 Hz, which still removes DC and still passes every measurement
+    // above. So assert the transfer function directly.
+    //
+    // |H(f)| for y = x - x1 + r*y1 is |1 - e^-jw| / |1 - r.e^-jw|; at the -3 dB
+    // corner it is 1/sqrt(2). A pole frozen at 24 kHz would read 0.89 at 48 kHz,
+    // well outside the tolerance here.
+    //
+    // Second thing this catches, for free: `r = exp(-2.pi.fc/fs)` is only the
+    // corner for fc << fs, and it drifts off by 6% by the time fc reaches
+    // 500 Hz at 24 kHz. So raising kDcBlockerCornerHz far enough to matter fails
+    // here too — which is the right answer, since at that point the constant no
+    // longer means what its comment says it does.
+    {
+        for (const double rateHz : {24000.0, 48000.0, 96000.0}) {
+            const double r = Hl2RxDsp::dcBlockerPole(Hl2RxDsp::kDcBlockerCornerHz, rateHz);
+            const double w = 2.0 * std::numbers::pi * Hl2RxDsp::kDcBlockerCornerHz / rateHz;
+            const std::complex<double> z = std::polar(1.0, -w);
+            const double mag = std::abs(1.0 - z) / std::abs(1.0 - r * z);
+            const bool ok = std::fabs(mag - 0.70710678) < 0.01;
+            check(ok, "DC blocker -3 dB corner stays at kDcBlockerCornerHz at this audio rate");
+            if (!ok) {
+                std::fprintf(stderr, "  rate %.0f Hz: |H(%.1f Hz)| = %.4f, want 0.7071 (r = %.6f)\n",
+                             rateHz, Hl2RxDsp::kDcBlockerCornerHz, mag, r);
+            }
+        }
+    }
+
+    // ---- ...and the whole chain still works at that other rate ----
+    //
+    // The transfer-function check above pins the pole arithmetic; this pins that
+    // configure() actually reaches it on a rate other than the shipping one.
+    {
+        Hl2RxDsp dsp;
+        Hl2RxDsp::Config c = cfg;
+        c.audioSampleRateHz = 48000;
+        c.mode = WdspChannel::Mode::Am;
+        c.filterLowHz = -4000.0;
+        c.filterHighHz = 4000.0;
+        std::string err;
+        check(dsp.configure(c, &err), err.empty() ? "AM configures at 48 kHz" : err.c_str());
+
+        const AudioStats st = runAm(dsp, kInputRate, kSeconds, kTail,
+                                    /*carrierOffsetHz=*/1000.0, kModHz, kModDepth);
+        check(st.acRms > 1e-4, "AM demod produces audio at a 48 kHz audio rate");
+        const double ratio = st.acRms > 0.0 ? std::fabs(st.mean) / st.acRms : 1e9;
+        check(ratio < 0.10, "AM audio is zero-mean at a 48 kHz audio rate too");
+        if (ratio >= 0.10) {
+            std::fprintf(stderr, "  48 kHz DC/AC ratio = %.3f (mean %.6f, acRms %.6f)\n",
+                         ratio, st.mean, st.acRms);
+        }
+    }
+
+    // ---- An unconfigured blocker must PASS audio, not differentiate it ----
+    //
+    // `y = x - x1 + r*y1` at r = 0 is a differentiator, so a missed configure()
+    // would gut the low end rather than do nothing. The bypass is unreachable
+    // through configure() — it rejects a non-positive rate before it gets there —
+    // so drive the struct directly.
+    {
+        Hl2RxDsp::DcBlocker idle;   // r defaults to 0: never configured
+        bool passthrough = true;
+        for (int n = 0; n < 256; ++n) {
+            const auto x = static_cast<float>(std::cos(2.0 * std::numbers::pi * n / 64.0));
+            if (idle.process(x) != x)
+                passthrough = false;
+        }
+        check(passthrough, "an unconfigured DC blocker passes its input through untouched");
+
+        Hl2RxDsp::DcBlocker configured;
+        configured.r = Hl2RxDsp::dcBlockerPole(Hl2RxDsp::kDcBlockerCornerHz, 24000.0);
+        double settled = 0.0;
+        for (int n = 0; n < 24000; ++n)
+            settled = configured.process(1.0f);   // pure DC in
+        check(std::fabs(settled) < 0.02,
+              "a configured DC blocker drives a pure DC input to zero");
     }
 
     // ---- SAM: same detector family, same pedestal ----


### PR DESCRIPTION
## Symptom

On a Hermes-Lite 2, the WAVE meter applet draws **two waveforms instead of one, with the lower one upside down**, in AM and SAM on the MW band. USB and LSB look correct.

## Root cause

Not stereo downmixing — in AM/SAM the two channels are bit-identical, so `(L+R)*0.5` is a no-op there.

WDSP's AM/SAM detector is an **envelope** detector. `amd.c` emits `sqrt(I² + Q²)`, which is strictly non-negative, so the carrier lands in the demodulated audio as a **DC pedestal**. Three things that each look like they would remove it, and do not:

- **`levelfade` is not a DC blocker.** On by default (`RXA.c`). It computes `audio += dc_insert - dc` from an 8 Hz-corner and a 0.11 Hz-corner average. That cancels *fading* and deliberately holds the pedestal at the long-term carrier level.
- **The AM/SAM passband cannot strip it.** `defaultPassbandForMode` gives AM/SAM `{-4000, +4000}` — symmetric about the carrier, because both detectors need it that way — which puts 0 Hz mid-band.
- **AetherSDR had no RX DC blocker at all.** The only other `setDcBlockEnabled` in the tree is on the TX final limiter.

Every zero-referenced consumer downstream inherits the offset. `WaveformWidget` renders `peak` and `rms` — both *magnitudes* — mirrored about a hard centreline:

```cpp
m_peakTopPts[x]    = QPointF(px, centerY - peak * halfHeight);
m_peakBottomPts[x] = QPointF(px, centerY + peak * halfHeight);   // the phantom
```

With zero-mean audio the two halves meet at the centreline and read as one symmetric waveform. With a DC pedestal they separate, and the lower one is a literal inverted mirror image. **SSB looked correct throughout because it is already zero-mean — that asymmetry is the tell.**

## This was not only cosmetic

Measured on a 50%-modulated carrier, unfixed: settled audio mean **1.79** on a ±1.0 float scale, AC RMS 0.70 — taken at the `WdspChannel` output, so *after* AGC. The pedestal alone is 79% past full scale, so AM audio was clipping hard against the rails everywhere downstream, and skewing the applet's `CLIP` counter and `PK dBFS` readout.

## Fix

`Hl2RxDsp` applies a 20 Hz one-pole DC blocker per channel to the `WdspChannel` output, **unconditionally for every mode** — SSB/CW are already zero-mean so it is a no-op there, FM wants it for the same reason AM does, and an unconditional filter has no mode-change state to get wrong. The pole is recomputed in `configure()` from `audioSampleRateHz`, so a rate change keeps the corner frequency put.

`r <= 0` is an explicit bypass: `y = x - x1 + r*y1` at `r = 0` is a **differentiator**, not a passthrough, so a missed `configure()` would otherwise gut the low end.

## Scope — one residual, at the DSP level

The blocker sits downstream of the whole RXA chain, so at the DSP level **`wcpAGC` — which is after `amd` *inside* RXA — still rides the pedestal**, and its AM/SAM gain decisions are still computed from a DC-offset input. Correcting that would need DC removal between `amd` and the AGC, and WDSP exposes no hook there; `SetRXAAMDFadeLevel(0)` is not one, since it only drops the fade correction and leaves `sqrt(I² + Q²)` just as non-negative. Recorded as a known residual in `HERMES.md`.

Note this is narrower than it sounds, and on-air results bear that out (below). The audible AGC misbehaviour came from the output railing — unfixed, the audio sat 79% past full scale before any AGC setting could matter, so AGC changes had little audible effect. Removing the pedestal restores that headroom and AGC behaves as expected on air. What remains is only that WDSP's internal gain computation still sees the offset.

## Testing

New `hl2_am_dcblock_test` feeds a **real amplitude-modulated carrier in wire order** and measures the **settled tail** — `dc_insert` is a 1.4 s pole, so a short burst shows almost no DC even unfixed and would pass either way. It asserts a DC/AC **ratio** rather than a level, since AGC scales both equally.

Verified to fail against the unfixed chain by forcing the pole to zero and rebuilding:

| Mode | Unfixed | Fixed | Threshold |
|---|---|---|---|
| AM | **2.569** ❌ | ~0 ✅ | 0.10 |
| SAM | **2.530** ❌ | ~0 ✅ | 0.10 |
| USB | pass ✅ | pass ✅ | 0.10 |

USB passing in *both* runs is the part that matters: it confirms the blocker is a genuine no-op on the modes that were already correct.

Full HL2 suite: **23/24 pass**. `hl2_tx_loopback_test` fails, but **pre-existing on `main`** — confirmed by reverting only `Hl2RxDsp.{h,cpp}` to the parent commit and reproducing the identical failure. It is a TX sideband/bin-mapping failure, untouched by this RX-only change.

## On-air verification

**Verified on live hardware against a MW AM signal** — the case the bug was originally reported on:

- **WAVE meter** — a single, right-side-up trace. The inverted phantom copy in the lower half is gone.
- **AGC** — behaves correctly on AM/SAM now that the output is no longer railed.

This is the check that matters: a convention error is invisible to any test that shares the convention, so the unit test above is necessary but was never sufficient on its own.

## Docs

`HERMES.md` §5 gains a subsection covering the pedestal, why each candidate removal path fails, the fix, and the `wcpAGC` residual.
