### PR TITLE
fix(hl2): unfreeze the first connect, and make FFTW wisdom actually persist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3095,6 +3095,13 @@ target_include_directories(hl2_receiver_churn_test PRIVATE src tests)
 target_link_libraries(hl2_receiver_churn_test PRIVATE aethercore Qt6::Core Qt6::Network Qt6::Test)
 add_test(NAME hl2_receiver_churn_test COMMAND hl2_receiver_churn_test)
 
+# HL2 connect re-entrancy — a connect or a disconnect landing while the WDSP
+# chains are still opening. Needs no radio; see the file header.
+add_executable(hl2_connect_reentrancy_test tests/hl2_connect_reentrancy_test.cpp)
+target_include_directories(hl2_connect_reentrancy_test PRIVATE src tests)
+target_link_libraries(hl2_connect_reentrancy_test PRIVATE aethercore Qt6::Core Qt6::Network Qt6::Test)
+add_test(NAME hl2_connect_reentrancy_test COMMAND hl2_connect_reentrancy_test)
+
 add_executable(client_eq_test
     tests/client_eq_test.cpp
     src/core/ClientEq.cpp

--- a/HERMES.md
+++ b/HERMES.md
@@ -463,8 +463,10 @@ AETHER_AUTOMATION=1 AETHER_AUTOMATION_SOCKET=aethersdr-hl2 \
 - Launch the app as the **foreground process of a backgrounded shell**;
   launching it with `&` inside a foreground command gets it killed with the
   shell's process group.
-- First WDSP channel open costs **~17 s** generating FFTW wisdom; subsequent
-  connects are **~110 ms**. Not a bug — don't "fix" it.
+- First WDSP channel open costs **~19 s** generating FFTW wisdom; every later
+  open — any receiver, any sample rate — is **40–175 ms**. The planning cost is
+  not a bug and cannot be optimised away, but it is now paid **off the GUI
+  thread** and reported in the connect animation; see §22.
 - The `prototypes/hl2/` Python spike defaults to broadcasting
   `255.255.255.255`, which fails on macOS with `OSError 65` when multiple
   interfaces are up. Use `--bcast <subnet>.255`. The in-app Qt sweep is fine.
@@ -532,10 +534,11 @@ cannot be starved by rendering — and `Hl2Backend.h` states plainly that Phase 
 runs the wire AND the DSP on the backend's own (GUI) thread.
 
 A GUI stall therefore stops EP2 and the radio stops streaming on its own. We
-already measured a 17-second main-thread stall on first connect (FFTW wisdom).
-That one lands before the stream starts, but it proves the class exists, and at
-384 kHz the DSP shares the same thread. Moving the DSP off the GUI thread was
-always "a later refinement"; the watchdog turns it into a correctness issue.
+measured a 21–82 second main-thread stall on first connect (FFTW wisdom) — see
+§22, which fixed that one. The wire and the DSP now live on their own I/O
+thread, so the class this warned about is narrower than it was; what remains is
+the **span-change** path, which still blocks the GUI thread on a rebuild of
+every receiver. §22.4.
 
 ### 11.4 Absent subsystems, in rough value order
 
@@ -602,10 +605,12 @@ defects that cost this session the most.
   `86a3d27b`, which we arrived at by reading RXA.c.
 - **`dsp_rate` is 48000, fixed** — §2 and the §10 reference table. Confirms
   `74f10f53`.
-- **First-run FFTW planning is slow BY DESIGN** (§9). Our measured 17-second
+- **First-run FFTW planning is slow BY DESIGN** (§9). Our measured ~19-second
   first connect is expected behaviour, not a performance bug. The oracle's
-  prescription is a progress indicator, not optimisation. That closes an open
-  question from earlier in the session.
+  prescription is a progress indicator, not optimisation — which is what §22
+  built. What the oracle does NOT excuse, and what was the actual defect, is
+  spending those 19 seconds with the GUI thread blocked and then discarding the
+  result at exit.
 
 ### 12.2 Licensing — resolved, we are fine
 
@@ -778,16 +783,18 @@ radio. See §18 for the full audit and the proposed seam.
 | Divergence | Reference does | We do | Why ours is defensible |
 |---|---|---|---|
 | `output_samplerate` | 48000 | 24000 | AudioEngine's native rate; avoids a resample. Legitimate, but it IS a divergence in the area that produced our worst bug — keep it labelled |
-| Rate change | `SetAllRates` | Rebuild the channel | Dodges the intermediate-inconsistent-state hazard entirely; heavier (re-plans FFTW). Switch if rate changes get frequent |
+| Rate change | `SetAllRates` | Rebuild the channel | Dodges the intermediate-inconsistent-state hazard entirely. Heavier, but NOT because of FFTW — a rebuild at a new rate re-plans almost nothing (§22.4). It is heavier because it is a close+open per receiver, and it still blocks the GUI thread |
 | Spectrum | WDSP analyzer (returns pixels) | Own `Hl2Spectrum` FFT | A3 §4 recommends exactly this for our architecture. **If it ever looks noisy, the lever is a detector/averaging mode, not a bigger FFT** |
-| FFTW wisdom | `WDSPwisdom(dir)` | Own `fftw_import_wisdom_from_filename` | `WDSPwisdom` is Windows-console-only. First-run slowness is expected — the fix is a progress indicator, not optimisation |
+| FFTW wisdom | `WDSPwisdom(dir)` | Own `fftw_import_wisdom_from_filename` + eager export | `WDSPwisdom` is Windows-console-only. First-run slowness is expected; the fix was a progress indicator plus getting the wisdom to actually persist (§22) |
 
 ### Settled — no action
 
 - **WDSP licensing.** GPL-2-**or-later** in 70 of 74 `.c` files, so it upgrades
   into our GPL-3. Linking is fine. (Spot-check the four before any
   redistribution question.)
-- **17-second first connect.** Expected FFTW planning, per A3 §9.
+- **~19-second first connect.** Expected FFTW planning, per A3 §9. The
+  planning itself stays; what was fixed is that it froze the whole UI and was
+  then thrown away on exit. §22.
 - **Alex manual mode** (`0x09[22]`). Not implemented in gateware — do not build
   UI for it.
 
@@ -2604,7 +2611,7 @@ second one is opened, which an operator reads as the radio going deaf.
 
 ### 20.8 Ordering: DSP chains are built BEFORE start()
 
-Opening a WDSP channel costs ~17 s on a first run (FFTW wisdom) and runs on the
+Opening a WDSP channel costs ~19 s on a first run (FFTW wisdom) and runs on the
 I/O thread — **the thread that paces EP2**. Configuring after `start()` stalls
 the pacer for all of it, and the gateware watchdog halts the stream when EP2
 stops arriving; it also stalls the EP6 reader, so the connect watchdog can time
@@ -3105,3 +3112,82 @@ disconnect edge, and the per-session reset the two scoring-session entry points
 share. Per §7 that is necessary and not sufficient — but the RTT and category
 predicates are decisions about what we *refuse* to claim, which is one of the few
 things a fixture can check honestly.
+
+---
+
+## 22. The first connect: 19 seconds of a dead application
+
+The symptom an operator reports is "the app hangs when I connect a Hermes-Lite
+for the first time." It is not a hang and it is not the radio. It is FFTW
+measuring plans, on the GUI thread, with nothing on screen to say so.
+
+### 22.1 What was actually measured
+
+Driven through the automation bridge against `hpsdrsim -hermeslite2 -P1`. The
+bridge's socket handler runs on the GUI thread, so pinging it every 100 ms from
+another thread turns "is the UI frozen" into a number: a gap between replies IS
+a frozen UI.
+
+| | Before | After |
+|---|---|---|
+| Cold-cache connect | 21–82 s (load-dependent) | 20.2 s |
+| Bridge pings answered during it | 0 of ~200 | 219 of 219 |
+| Longest unresponsive gap | 58–82 s | 0.50 s |
+| Wisdom on disk after SIGTERM | none | 9117 bytes |
+| Next launch, same profile | 21.6 s **again** | 0.57 s |
+
+### 22.2 Two defects, not one
+
+**The GUI thread waited.** `RadioModel` calls `Hl2Backend::connectRadio()`
+synchronously, and that method drove every `Hl2RxDsp::configure()` through
+`Qt::BlockingQueuedConnection`. The work was correctly on the I/O thread; the
+GUI thread simply stood there for all of it. Split into three phases now — see
+the comment above `beginDspSetup()`. The §20.8 ordering is untouched: chains
+still open before `start()`, serially, on the I/O thread.
+
+**The wisdom was never saved.** Export was a `std::atexit` handler, and
+`Hl2EmergencyStop` restores `SIG_DFL` and re-raises — so an unhandled signal,
+which is what SIGTERM, a crash and a Force Quit all become, never runs it.
+Measured: connect, kill, relaunch, connect — full cost a second time, cache file
+never created. **Anyone who had ever force-quit was paying first-run cost on
+every run**, which is why a one-time expense felt permanent. Export now happens
+at the end of `open()`, and it is write-then-rename: the direct write truncated
+a shared cache when two processes exported at once (a 48 KB cache came back as
+13 KB after a `ctest -j8` run, and FFTW rejects a short file wholesale).
+
+### 22.3 The planning cost is one-time per MACHINE, not per rate
+
+Measured cold, both orderings, with `WdspChannel` opened exactly as
+`Hl2RxDsp::configure` builds it:
+
+| Order | 1st open | 2nd | 3rd | 4th |
+|---|---|---|---|---|
+| 48 → 96 → 192 → 384 kHz | **18865 ms** | 100 ms | 71 ms | 39 ms |
+| 384 → 192 → 96 → 48 kHz | **18666 ms** | 64 ms | 99 ms | 175 ms |
+
+The first open costs ~19 s whichever rate it is; every other rate afterwards is
+40–175 ms. The plan sets overlap almost completely, so **do not reason about
+"cold wisdom for this sample rate"** — there is one cold open per machine, ever.
+
+### 22.4 Still open: the span change blocks the GUI thread
+
+`applyPanBandwidth()` has the same shape the connect used to have. Crossing one
+of the four rate boundaries rebuilds **every** receiver (the rate register is
+radio-wide) through `Qt::BlockingQueuedConnection`, and each receiver costs an
+open (40–175 ms, per §22.3) plus a close, which flushes and is bounded by WDSP's
+own 100 ms timeout. Four panadapters open is roughly **0.6–1.1 s of frozen UI
+per boundary crossing** — the "chunky zoom" operators describe, layered on top
+of two things that are not bugs:
+
+- **The span IS the sample rate.** Four rates only, snapped log-nearest, so the
+  boundaries sit near 68 / 136 / 272 kHz. Zoom within a rate is free display
+  scaling; crossing one re-spans the radio, and `emitAllPanState()` deliberately
+  snaps the widget back to the span that was actually granted.
+- **A 150 ms coalescing throttle** (`kBandwidthThrottleMs`, #4470), because a
+  drag delivers ~30 span changes a second and each one is a full rebuild.
+
+The three-phase split from §22.2 is directly reusable here, but the rate change
+has ordering constraints the connect does not: the DSP must expect the new rate
+before EP6 starts delivering at it, and a partial failure has to roll every
+receiver back to a single rate. Left as a follow-up rather than bolted onto the
+connect fix.

--- a/HERMES.md
+++ b/HERMES.md
@@ -536,9 +536,9 @@ runs the wire AND the DSP on the backend's own (GUI) thread.
 A GUI stall therefore stops EP2 and the radio stops streaming on its own. We
 measured a 21–82 second main-thread stall on first connect (FFTW wisdom) — see
 §22, which fixed that one. The wire and the DSP now live on their own I/O
-thread, so the class this warned about is narrower than it was; what remains is
-the **span-change** path, which still blocks the GUI thread on a rebuild of
-every receiver. §22.4.
+thread, so the class this warned about is narrower than it was. Two paths still
+block the GUI thread, both in §22.4: the **span change**, which rebuilds every
+receiver, and **backend teardown**, which waits out an in-flight DSP build.
 
 ### 11.4 Absent subsystems, in rough value order
 
@@ -3169,7 +3169,26 @@ The first open costs ~19 s whichever rate it is; every other rate afterwards is
 40–175 ms. The plan sets overlap almost completely, so **do not reason about
 "cold wisdom for this sample rate"** — there is one cold open per machine, ever.
 
-### 22.4 Still open: the span change blocks the GUI thread
+### 22.4 Still open: two paths that still block the GUI thread
+
+#### Backend teardown waits out an in-flight build
+
+`~Hl2Backend()` stops the wire through a `Qt::BlockingQueuedConnection` before
+joining the I/O thread, and `beginDspSetup()`'s opens are a single event on that
+thread's loop. So a teardown during a cold connect — a **family switch**
+(`RadioModel::connectToRadio` → `teardownBackend()`) or an **app quit** — blocks
+the GUI thread for whatever is left of the planning.
+
+Splitting the connect is what made this reachable, and that is not an argument
+against the split: before it, the connect itself held the UI, so nobody could
+get to the radio picker mid-connect. Now the UI is live for those twenty
+seconds, and reaching for a different radio is the obvious thing to do while
+waiting. `OpenChannel` cannot be cancelled, so the honest options are a busy
+state over the teardown or a backend that can be abandoned rather than joined —
+and the second one also has to replace the `QPointer` guard in
+`beginDspSetup()`, which is sound today *because* teardown blocks.
+
+#### The span change rebuilds every receiver
 
 `applyPanBandwidth()` has the same shape the connect used to have. Crossing one
 of the four rate boundaries rebuilds **every** receiver (the rate register is

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -19,6 +19,7 @@
 #include <QByteArray>
 #include <QHostAddress>
 #include <QLoggingCategory>
+#include <QPointer>
 
 #include <cstdint>
 #include <utility>
@@ -34,6 +35,31 @@ static_assert(AetherSDR::hl2::Hl2TxDsp::Config{}.alcHoldBelowDbfs == -45.0,
 Q_LOGGING_CATEGORY(lcHl2Tx, "aether.hl2.tx")
 
 namespace AetherSDR::hl2 {
+
+// Declared incomplete in the header so it keeps its forward declarations of
+// MetisClient/Hl2RxDsp/Hl2TxDsp; the async connect is the only thing that needs
+// their Config types by value. See beginDspSetup().
+struct Hl2Backend::PendingConnect {
+    MetisClient::Params mp;
+    Hl2RxDsp::Config dc;
+    Hl2TxDsp::Config tc;
+    int actualNumRx = 0;
+    // Which connect this is. A disconnect, or a second connect, bumps
+    // m_connectGeneration; a build whose generation is stale on completion
+    // tears itself down instead of starting a wire nobody asked for.
+    quint64 generation = 0;
+};
+
+// What the I/O thread carries back. Parallel arrays indexed by DDC rather than
+// a vector of structs so a partial build — the trim-on-failure case — reads the
+// same way as a complete one.
+struct Hl2Backend::DspSetupResult {
+    std::vector<bool> rxOk;
+    std::vector<int> rxChannelId;
+    std::vector<std::string> rxErr;
+    bool txOk = false;
+    std::string txErr;
+};
 
 namespace {
 
@@ -1341,6 +1367,24 @@ void Hl2Backend::connectRadio(const RadioConnectRequest& request)
         return;
     }
 
+    // A connect arriving while the previous one's chains are still opening.
+    // Reachable now that the build spans event-loop turns: the reconnect timer
+    // or an operator picking a different radio both land here.
+    //
+    // It cannot be served inline. buildReceivers() would destroy the very
+    // chains the I/O thread is opening, and its publishIoDsps() is a BLOCKING
+    // hop into an I/O thread busy for the rest of that open -- which is exactly
+    // the GUI stall this change removes, reintroduced through the back door.
+    // So: supersede the build, hold the request, and re-drive it from
+    // finishDspSetup() once the I/O thread is free.
+    if (m_pendingConnect) {
+        qCInfo(lcHl2) << "HL2: connect requested while the DSP was still opening"
+                      << "— queued behind it";
+        ++m_connectGeneration;
+        m_queuedConnect = std::make_unique<RadioConnectRequest>(request);
+        return;
+    }
+
     // A new connect re-derives the passband from the mode; a mid-session linkUp
     // (EP6 silence then resume) does not. See m_passbandDerivedThisConnect.
     m_passbandDerivedThisConnect = false;
@@ -1542,20 +1586,182 @@ void Hl2Backend::connectRadio(const RadioConnectRequest& request)
     Hl2RxDsp::Config dc;
     dc.inputSampleRateHz = m_sampleRateHz;
     dc.audioSampleRateHz = 24000;   // AudioEngine's native RX rate
-    std::string err;
+
+    // The transmit chain follows the TX RECEIVER's mode, not "the mode": with
+    // several receivers there is no single one. Built here, on the GUI thread,
+    // where m_rx may be read; the open itself happens with the others.
+    const Receiver* txRx = rx(m_txDdc);
+    const QString txMode = txRx ? txRx->mode : QStringLiteral("USB");
+    Hl2TxDsp::Config tc;
+    tc.inputSampleRateHz = 24000;    // AudioEngine's rate; submitTxAudio re-checks
+    tc.outputSampleRateHz = 48000;   // EP2 is fixed at 48 kHz
+    tc.mode = modeFromString(txMode);
+    // Sideband-correct from the first key, not from the first mode change. The
+    // struct default is a positive 300..2700, so connecting straight into LSB
+    // or DIGL would otherwise transmit on the upper sideband until the operator
+    // happened to change mode.
+    {
+        const auto [txLo, txHi] = effectiveTxPassband(txMode);
+        tc.filterLowHz  = txLo;
+        tc.filterHighHz = txHi;
+    }
+    // Remember the threshold the modulator is being handed, so the health
+    // snapshot and the unkey diagnostic both report what it is RUNNING rather
+    // than what a default-constructed Config would have said. Assigned from
+    // `tc` and not from the default so it stays correct the day this Config
+    // sets the field.
+    m_alcHoldBelowDbfs = tc.alcHoldBelowDbfs;
+
+    // Announce the passband the modulator is being configured with. The Config
+    // is how the modulator learns it, so this is the echo half only — but it is
+    // the half the operator sees. A restored eSSB 100..4000 reached the
+    // modulator and nothing else: the Phone applet went on showing
+    // TransmitModel's own construction default until the operator happened to
+    // press a cut button, which is a passband readout that disagrees with the
+    // transmitter.
+    //
+    // Emitted HERE rather than after the open, and that is deliberate now that
+    // the open is asynchronous. The value is already decided — waiting for the
+    // channel to finish opening would tell the operator nothing more, and would
+    // make an echo that connectRadio() used to deliver synchronously arrive tens
+    // of seconds later on a cold cache. What still holds is the ordering that
+    // matters: this precedes linkUp either way.
+    {
+        TransmitDelta delta;
+        delta.txFilterLow = tc.filterLowHz;
+        delta.txFilterHigh = tc.filterHighHz;
+        emit transmitChanged(delta);
+    }
+
+    // Hand the opens to the I/O thread and RETURN. finishDspSetup() picks the
+    // connect back up from here, on this thread, once they are done.
+    m_pendingConnect = std::make_unique<PendingConnect>();
+    m_pendingConnect->mp = mp;
+    m_pendingConnect->dc = dc;
+    m_pendingConnect->tc = tc;
+    m_pendingConnect->actualNumRx = actualNumRx;
+    m_pendingConnect->generation = ++m_connectGeneration;
+    beginDspSetup();
+}
+
+void Hl2Backend::beginDspSetup()
+{
+    if (!m_pendingConnect)
+        return;
+
+    const int actualNumRx = m_pendingConnect->actualNumRx;
+    // Receivers plus the one transmit chain — what the operator is waiting for.
+    const int total = actualNumRx + 1;
+
+    // The chains to open, snapshotted on THIS thread. m_rx is GUI-thread-only
+    // (see its declaration), so the I/O thread gets a plain vector of the
+    // pointers it may touch and never the container they came out of.
+    std::vector<Hl2RxDsp*> chains;
+    chains.reserve(static_cast<std::size_t>(actualNumRx));
+    std::vector<Hl2RxDsp::Config> configs;
+    configs.reserve(static_cast<std::size_t>(actualNumRx));
     for (int i = 0; i < actualNumRx; ++i) {
         Receiver& r = m_rx[static_cast<std::size_t>(i)];
+        Hl2RxDsp::Config dc = m_pendingConnect->dc;
         dc.mode = modeFromString(r.mode);
         dc.filterLowHz = r.filterLowHz;
         dc.filterHighHz = r.filterHighHz;
-        bool dspOk = false;
-        // Blocking: the DSP must be configured before the wire delivers samples
-        // into it. Serial rather than parallel on purpose — FFTW's planner is
-        // not thread-safe and Hl2Spectrum builds a plan in its constructor.
-        Hl2RxDsp* dsp = r.dsp;
-        QMetaObject::invokeMethod(dsp, [dsp, &dc, &err, &dspOk] {
-            dspOk = dsp->configure(dc, &err);
-        }, Qt::BlockingQueuedConnection);
+        chains.push_back(r.dsp);
+        configs.push_back(dc);
+    }
+
+    emit dspSetupProgress(tr("Preparing the receive chain…"), 0, total);
+
+    const Hl2TxDsp::Config tc = m_pendingConnect->tc;
+    Hl2TxDsp* txDsp = m_txDsp;
+    // QPointer, not `this`: the build outlives the call, and a backend
+    // destroyed mid-build (a family switch, app teardown) must not be resumed
+    // through a dangling pointer.
+    QPointer<Hl2Backend> self(this);
+
+    QMetaObject::invokeMethod(chains.empty() ? static_cast<QObject*>(txDsp)
+                                             : static_cast<QObject*>(chains.front()),
+        [self, chains, configs, tc, txDsp, total] {
+        // ---- I/O THREAD ----
+        //
+        // Serial rather than parallel on purpose, and it is not about ordering:
+        // FFTW's planner is not thread-safe, and Hl2Spectrum builds a plan in
+        // its constructor. Two of these at once corrupt the planner's state.
+        DspSetupResult result;
+        const int rxCount = static_cast<int>(chains.size());
+        result.rxOk.resize(chains.size(), false);
+        result.rxChannelId.resize(chains.size(), -1);
+        result.rxErr.resize(chains.size());
+        for (std::size_t i = 0; i < chains.size(); ++i) {
+            if (self) {
+                const int done = static_cast<int>(i);
+                const QString stage = rxCount > 1
+                    ? tr("Preparing receiver %1 of %2…").arg(i + 1).arg(rxCount)
+                    : tr("Preparing the receive chain…");
+                QMetaObject::invokeMethod(self, [self, stage, done, total] {
+                    if (self)
+                        emit self->dspSetupProgress(stage, done, total);
+                }, Qt::QueuedConnection);
+            }
+            std::string err;
+            result.rxOk[i] = chains[i]->configure(configs[i], &err);
+            result.rxErr[i] = err;
+            if (result.rxOk[i])
+                result.rxChannelId[i] = chains[i]->wdspChannelId();
+            else
+                break;   // the GUI thread trims from here; opening past it is waste
+        }
+        if (self) {
+            QMetaObject::invokeMethod(self, [self, rxCount, total] {
+                if (self) {
+                    emit self->dspSetupProgress(tr("Preparing the transmit chain…"),
+                                                rxCount, total);
+                }
+            }, Qt::QueuedConnection);
+        }
+        if (txDsp)
+            result.txOk = txDsp->configure(tc, &result.txErr);
+
+        // ---- back to the GUI thread ----
+        QMetaObject::invokeMethod(self, [self, result] {
+            if (self)
+                self->finishDspSetup(result);
+        }, Qt::QueuedConnection);
+    }, Qt::QueuedConnection);
+}
+
+void Hl2Backend::finishDspSetup(const DspSetupResult& result)
+{
+    if (!m_pendingConnect)
+        return;
+    // A disconnect, or a second connect, arrived while the chains were opening.
+    // The wire was never started, so there is nothing to stop — but the chains
+    // ARE open, and leaving them open would leak WDSP channels out of the
+    // 32-slot pool on every abandoned connect.
+    if (m_pendingConnect->generation != m_connectGeneration) {
+        qCInfo(lcHl2) << "HL2: connect superseded while the DSP was opening —"
+                      << "releasing the chains it built";
+        m_pendingConnect.reset();
+        // Safe to block inside here: the build has finished, so the I/O thread
+        // is back at its event loop and publishIoDsps() returns promptly.
+        tearDownReceivers();
+        emit dspSetupFinished();
+        // A connect that arrived mid-build has been waiting for exactly this.
+        if (m_queuedConnect) {
+            const RadioConnectRequest queued = *m_queuedConnect;
+            m_queuedConnect.reset();
+            connectRadio(queued);
+        }
+        return;
+    }
+
+    MetisClient::Params mp = m_pendingConnect->mp;
+    const int actualNumRx = m_pendingConnect->actualNumRx;
+    m_pendingConnect.reset();
+
+    for (int i = 0; i < actualNumRx; ++i) {
+        const bool dspOk = result.rxOk[static_cast<std::size_t>(i)];
+        const std::string& err = result.rxErr[static_cast<std::size_t>(i)];
         if (!dspOk) {
             // Receiver 0 failing is a failed connect. A LATER receiver failing
             // is not: the radio works, there is simply one fewer panadapter, and
@@ -1564,6 +1770,7 @@ void Hl2Backend::connectRadio(const RadioConnectRequest& request)
             if (i == 0) {
                 emit connectionError(
                     QStringLiteral("HL2 DSP: %1").arg(QString::fromStdString(err)));
+                emit dspSetupFinished();
                 return;
             }
             qCWarning(lcHl2) << "HL2: receiver" << i << "DSP failed —"
@@ -1605,65 +1812,18 @@ void Hl2Backend::connectRadio(const RadioConnectRequest& request)
             m_ids.truncate(i);
             break;
         }
-        // The WDSP channel id is knowable only NOW, and it is whatever the
-        // shared 32-slot pool had free. Recording it here rather than deriving
-        // it from i is the entire point of the index-space map.
-        int channelId = -1;
-        QMetaObject::invokeMethod(dsp, [dsp, &channelId] {
-            channelId = dsp->wdspChannelId();
-        }, Qt::BlockingQueuedConnection);
+        // The WDSP channel id is knowable only after the open, and it is
+        // whatever the shared 32-slot pool had free. Carrying it back from the
+        // I/O thread rather than deriving it from i is the entire point of the
+        // index-space map.
         if (auto* ids = m_ids.mutableByDdc(i)) {
-            ids->dspChannel = channelId;
+            ids->dspChannel = result.rxChannelId[static_cast<std::size_t>(i)];
             ids->analyzerId = i;   // Hl2Spectrum is per-receiver and owned by it
         }
     }
-    // Assert a known TX drive rather than inheriting whatever the board held.
-    // ZERO is deliberate: this backend has no drive-level control wired to the
-    // UI yet, so anything higher would be an un-commanded power level chosen by
-    // a default. An operator raising it explicitly is the only way it should go up.
-    // The transmit chain follows the TX RECEIVER's mode, not "the mode": with
-    // several receivers there is no single one.
-    const Receiver* txRx = rx(m_txDdc);
-    const QString txMode = txRx ? txRx->mode : QStringLiteral("USB");
-    Hl2TxDsp::Config tc;
-    tc.inputSampleRateHz = 24000;    // AudioEngine's rate; submitTxAudio re-checks
-    tc.outputSampleRateHz = 48000;   // EP2 is fixed at 48 kHz
-    tc.mode = modeFromString(txMode);
-    // Sideband-correct from the first key, not from the first mode change. The
-    // struct default is a positive 300..2700, so connecting straight into LSB
-    // or DIGL would otherwise transmit on the upper sideband until the operator
-    // happened to change mode.
-    {
-        const auto [txLo, txHi] = effectiveTxPassband(txMode);
-        tc.filterLowHz  = txLo;
-        tc.filterHighHz = txHi;
-    }
-    // Remember the threshold the modulator was handed, so the health snapshot
-    // and the unkey diagnostic both report what it is RUNNING rather than what
-    // a default-constructed Config would have said. Assigned from `tc` and not
-    // from the default so it stays correct the day this Config sets the field.
-    m_alcHoldBelowDbfs = tc.alcHoldBelowDbfs;
-    std::string txErr;
-    bool txOk = false;
-    QMetaObject::invokeMethod(m_txDsp, [this, &tc, &txErr, &txOk] {
-        txOk = m_txDsp->configure(tc, &txErr);
-    }, Qt::BlockingQueuedConnection);
-    if (!txOk)
+    if (!result.txOk)
         qWarning() << "Hl2Backend: TX DSP unavailable —"
-                   << QString::fromStdString(txErr) << "(receive is unaffected)";
-
-    // Announce the passband the modulator was just configured with. The Config
-    // above is how the modulator learns it, so this is the echo half only — but
-    // it is the half the operator sees. A restored eSSB 100..4000 reached the
-    // modulator and nothing else: the Phone applet went on showing TransmitModel's
-    // own construction default until the operator happened to press a cut button,
-    // which is a passband readout that disagrees with the transmitter.
-    {
-        TransmitDelta delta;
-        delta.txFilterLow = tc.filterLowHz;
-        delta.txFilterHigh = tc.filterHighHz;
-        emit transmitChanged(delta);
-    }
+                   << QString::fromStdString(result.txErr) << "(receive is unaffected)";
 
     // ---- and only now, the wire ----
     //
@@ -1681,10 +1841,12 @@ void Hl2Backend::connectRadio(const RadioConnectRequest& request)
     if (!started) {
         tearDownReceivers();   // do not leave WDSP channels open on a failed connect
         emit connectionError(QStringLiteral("HL2: could not open the UDP socket"));
+        emit dspSetupFinished();
         return;
     }
 
     setTxDriveLevel(0);
+    emit dspSetupFinished();
 
     // Initial slice/pan state is published from the linkUp handler above, once
     // connected() has fired and RadioModel has finished staging the old session.
@@ -1692,6 +1854,13 @@ void Hl2Backend::connectRadio(const RadioConnectRequest& request)
 
 void Hl2Backend::disconnectRadio()
 {
+    // Invalidate any DSP build still in flight. Without this, a disconnect
+    // during the opens would be followed by finishDspSetup() starting a wire
+    // for a session the operator has already left. The build itself cannot be
+    // cancelled — WDSP's OpenChannel does not return early — so it runs to
+    // completion on the I/O thread and finishDspSetup() releases what it built.
+    ++m_connectGeneration;
+
     if (m_metis)
         // Queued: serialises behind whatever the I/O thread is doing.
         QMetaObject::invokeMethod(m_metis, "stop");   // linkDown -> disconnected()
@@ -2156,6 +2325,21 @@ void Hl2Backend::applyPanBandwidth(double hz)
         QMetaObject::invokeMethod(m_metis, "setSampleRate", Qt::QueuedConnection,
             Q_ARG(AetherSDR::hl2::SampleRate, sampleRateEnum(rate)));
 
+    // FOLLOW-UP: this loop still BLOCKS THE GUI THREAD, which is the same defect
+    // connectRadio() had before it was split into beginDspSetup()/
+    // finishDspSetup(). Each receiver costs an open (40-175 ms) plus a close
+    // that flushes under WDSP's 100 ms timeout, and it runs for every receiver
+    // because the rate register is radio-wide — roughly 0.6-1.1 s of frozen UI
+    // per rate-boundary crossing with four panadapters open. That is the
+    // "chunky zoom" operators report. HERMES.md §22.4 has the measurements.
+    //
+    // Not fixed here on purpose: unlike the connect, this has ordering
+    // constraints that survive a partial failure — the DSP must expect the new
+    // rate BEFORE EP6 delivers at it, and a receiver that fails to reconfigure
+    // has to put the ones already rebuilt back, or the set is split across two
+    // rates with nothing reporting it. The phase split is reusable; the
+    // roll-back is what needs designing.
+    //
     // Rebuild the receive chain at the new input rate. WDSP's channel is opened
     // with a fixed input rate, so a rate change is a reconfigure, not a setter —
     // Hl2RxDsp::Config carries the operator's live mode/filter/AGC/shift so the

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -1255,6 +1255,16 @@ Hl2Backend::~Hl2Backend()
         // never run -- quit() below ends the event loop that would deliver it --
         // and tearing the socket down from this thread is the affinity bug this
         // whole change exists to avoid.
+        //
+        // THIS BLOCKS FOR AN IN-FLIGHT DSP BUILD. beginDspSetup()'s job is a
+        // single event on that thread's loop and OpenChannel cannot be cancelled,
+        // so a family switch or an app quit during a cold connect waits out the
+        // rest of the planning -- on the GUI thread. It is the one GUI stall the
+        // three-phase split does NOT remove, and splitting the connect is what
+        // made it reachable: the operator can now use the UI while the chains
+        // open, and reaching for a different radio is the obvious thing to do
+        // while waiting. HERMES.md §22.4. It is also what keeps the QPointer in
+        // beginDspSetup() sound, so a fix here has to deal with that too.
         if (m_metis)
             QMetaObject::invokeMethod(m_metis, "stop", Qt::BlockingQueuedConnection);
         m_ioThread->quit();
@@ -1560,8 +1570,9 @@ void Hl2Backend::connectRadio(const RadioConnectRequest& request)
     // ORDER IS LOAD-BEARING, and the reason is the same one that governs every
     // other ordering decision in this backend: EP2 must not stop.
     //
-    // Opening a WDSP channel is slow -- ~17 s on a first run, generating FFTW
-    // wisdom, and ~110 ms after that (HERMES.md §10) -- and it runs ON THE I/O
+    // Opening a WDSP channel is slow -- ~19 s on the FIRST open this machine
+    // ever does, generating FFTW wisdom, and 40-175 ms for every open after
+    // that, at any rate (HERMES.md §10 and §22.3) -- and it runs ON THE I/O
     // THREAD, which is the thread that paces EP2. Configuring after start()
     // therefore stalls the pacer for the whole of that, and the gateware
     // watchdog halts the stream when EP2 stops arriving. It also stalls the EP6
@@ -1650,8 +1661,13 @@ void Hl2Backend::beginDspSetup()
         return;
 
     const int actualNumRx = m_pendingConnect->actualNumRx;
-    // Receivers plus the one transmit chain — what the operator is waiting for.
-    const int total = actualNumRx + 1;
+    // The RECEIVERS, and only them. The transmit chain is not a step:
+    // Hl2TxDsp::configure() designs two FIR kernels and returns — it opens no
+    // WDSP channel and measures no FFTW plan (the class includes WdspChannel.h
+    // for the Mode enum alone). Counting it inflated the denominator with a step
+    // that completes in microseconds and put a "Preparing the transmit chain…"
+    // label on screen for work that was already over.
+    const int total = actualNumRx;
 
     // The chains to open, snapshotted on THIS thread. m_rx is GUI-thread-only
     // (see its declaration), so the I/O thread gets a plain vector of the
@@ -1677,6 +1693,15 @@ void Hl2Backend::beginDspSetup()
     // QPointer, not `this`: the build outlives the call, and a backend
     // destroyed mid-build (a family switch, app teardown) must not be resumed
     // through a dangling pointer.
+    //
+    // What makes the cross-thread reads of it SOUND is the destructor, not the
+    // QPointer: ~Hl2Backend() blocks on the I/O thread (a BlockingQueuedConnection
+    // stop, then quit()/wait()), so this lambda has always finished before the
+    // object can go away, and every `if (self)` below is a check on a pointer
+    // nothing is racing to clear. QPointer is reentrant, NOT thread-safe — the day
+    // teardown stops blocking, a check-then-use here becomes a real race and this
+    // needs a different mechanism. That blocking teardown has its own cost; see
+    // the note in ~Hl2Backend() and HERMES.md §22.4.
     QPointer<Hl2Backend> self(this);
 
     QMetaObject::invokeMethod(chains.empty() ? static_cast<QObject*>(txDsp)
@@ -1688,16 +1713,17 @@ void Hl2Backend::beginDspSetup()
         // FFTW's planner is not thread-safe, and Hl2Spectrum builds a plan in
         // its constructor. Two of these at once corrupt the planner's state.
         DspSetupResult result;
-        const int rxCount = static_cast<int>(chains.size());
         result.rxOk.resize(chains.size(), false);
         result.rxChannelId.resize(chains.size(), -1);
         result.rxErr.resize(chains.size());
         for (std::size_t i = 0; i < chains.size(); ++i) {
             if (self) {
                 const int done = static_cast<int>(i);
-                const QString stage = rxCount > 1
-                    ? tr("Preparing receiver %1 of %2…").arg(i + 1).arg(rxCount)
-                    : tr("Preparing the receive chain…");
+                // PURE STAGE TEXT — no counter. The label renders the fraction
+                // from done/total (MainWindow::wireBackendSeam), so numbering
+                // here too put two fractions over two denominators on screen:
+                // "Preparing receiver 1 of 2… (1 of 3)".
+                const QString stage = tr("Preparing the receive chain…");
                 QMetaObject::invokeMethod(self, [self, stage, done, total] {
                     if (self)
                         emit self->dspSetupProgress(stage, done, total);
@@ -1711,14 +1737,9 @@ void Hl2Backend::beginDspSetup()
             else
                 break;   // the GUI thread trims from here; opening past it is waste
         }
-        if (self) {
-            QMetaObject::invokeMethod(self, [self, rxCount, total] {
-                if (self) {
-                    emit self->dspSetupProgress(tr("Preparing the transmit chain…"),
-                                                rxCount, total);
-                }
-            }, Qt::QueuedConnection);
-        }
+        // No progress emit for the transmit chain: it designs two FIR kernels
+        // and returns. Announcing a step that is over before the label repaints
+        // is worse than saying nothing.
         if (txDsp)
             result.txOk = txDsp->configure(tc, &result.txErr);
 
@@ -1759,6 +1780,14 @@ void Hl2Backend::finishDspSetup(const DspSetupResult& result)
     const int actualNumRx = m_pendingConnect->actualNumRx;
     m_pendingConnect.reset();
 
+    // m_rx STILL HOLDS actualNumRx RECEIVERS. Worth stating, because the loop
+    // below indexes it with a count snapshotted in beginDspSetup() and the two
+    // phases no longer run back to back — event-loop turns pass between them.
+    // Nothing can resize it in that window: the only two paths that do are
+    // createPanadapter() and removePanadapter(), and both return early unless
+    // m_connected, which is set from linkUp — that is, only after the wire this
+    // function has not started yet. A connect or a disconnect landing here is
+    // the generation counter's job and is handled above.
     for (int i = 0; i < actualNumRx; ++i) {
         const bool dspOk = result.rxOk[static_cast<std::size_t>(i)];
         const std::string& err = result.rxErr[static_cast<std::size_t>(i)];
@@ -1845,6 +1874,10 @@ void Hl2Backend::finishDspSetup(const DspSetupResult& result)
         return;
     }
 
+    // Assert a known TX drive rather than inheriting whatever the board held.
+    // ZERO is deliberate: this backend has no drive-level control wired to the
+    // UI yet, so anything higher would be an un-commanded power level chosen by
+    // a default. An operator raising it explicitly is the only way it should go up.
     setTxDriveLevel(0);
     emit dspSetupFinished();
 
@@ -1860,6 +1893,12 @@ void Hl2Backend::disconnectRadio()
     // cancelled — WDSP's OpenChannel does not return early — so it runs to
     // completion on the I/O thread and finishDspSetup() releases what it built.
     ++m_connectGeneration;
+    // And a connect PARKED BEHIND that build is stale for the same reason: the
+    // operator has since asked to be disconnected. Leaving it here made
+    // finishDspSetup()'s supersede branch re-drive it — a second full build
+    // ending in MetisClient::start(), for a session nobody is in. Measured:
+    // connect, connect, disconnect gave two dspSetupFinished and a running wire.
+    m_queuedConnect.reset();
 
     if (m_metis)
         // Queued: serialises behind whatever the I/O thread is doing.

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -108,9 +108,11 @@ signals:
     // demodulates in firmware, an Icom does not use WDSP at all), so a neutral
     // signal would be one every other family had to ignore.
     //
-    // `stage` is already operator-facing text. `done`/`total` count opened
-    // channels, so a caller can render a fraction; total is receivers + 1 for
-    // the transmit chain.
+    // `stage` is already operator-facing text, and carries NO counter of its own
+    // — `done`/`total` are the counter, so the label owns how (or whether) a
+    // fraction is rendered. They count WDSP channel opens, which means receivers
+    // and only receivers: the transmit chain designs FIR kernels and opens
+    // nothing, so it is not a step and is not in `total`.
     //
     // Emitted from the GUI thread, including the terminal one, so a slot may
     // touch widgets directly.

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -14,6 +14,7 @@
 
 #include <deque>
 #include <limits>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -101,6 +102,21 @@ public:
     HealthSnapshot healthSnapshot() const override;
     LinkStats linkStats() const override;
 
+signals:
+    // Connect-time progress for the CLIENT-SIDE DSP build, and deliberately not
+    // on the IRadioBackend seam: WDSP is this backend's alone (a Flex
+    // demodulates in firmware, an Icom does not use WDSP at all), so a neutral
+    // signal would be one every other family had to ignore.
+    //
+    // `stage` is already operator-facing text. `done`/`total` count opened
+    // channels, so a caller can render a fraction; total is receivers + 1 for
+    // the transmit chain.
+    //
+    // Emitted from the GUI thread, including the terminal one, so a slot may
+    // touch widgets directly.
+    void dspSetupProgress(const QString& stage, int done, int total);
+    void dspSetupFinished();
+
 private:
     // Publish linkStats() on the fixed cadence the seam promises. Driven by a
     // timer here rather than by MetisClient's receive path so the tick survives
@@ -118,6 +134,45 @@ private:
     void applyLnaGainDb(int gainDb);   // the one true LNA application
     void rememberCurrentBandState();
     void notifyOperatingStateChanged();
+
+    // ---- the connect's three phases ----
+    //
+    // connectRadio() used to be one straight-line function that waited on the
+    // I/O thread through Qt::BlockingQueuedConnection for every WDSP open. The
+    // work was correctly OFF the GUI thread; the GUI thread simply stood there
+    // holding its breath for all of it. On a machine with no FFTW wisdom yet
+    // that is tens of seconds of an application that answers nothing at all —
+    // measured at 21-82 s here, load-dependent, with the automation bridge (a
+    // GUI-thread server) going completely silent for the whole window.
+    //
+    // So it is split. connectRadio() itself still does every member seeding
+    // SYNCHRONOUSLY — hl2_state_restore_test reads currentOperatingState()
+    // immediately after it returns, and that contract is worth keeping — and
+    // then hands the channel opens to beginDspSetup() and returns to the event
+    // loop. finishDspSetup() resumes on the GUI thread when the opens are done
+    // and starts the wire.
+    //
+    // What did NOT change is the ORDER: every DSP chain is still open and
+    // configured before MetisClient::start(), because EP2 must not stop (see
+    // the note above buildReceivers() and HERMES.md §20.8). The sequence stays
+    // serial on the I/O thread; only the GUI thread stopped waiting for it.
+    void beginDspSetup();
+
+    // Everything the async build needs to carry across event-loop turns (the
+    // wire params, the RX and TX configs, and which connect it belongs to). A
+    // local could not: connectRadio() has returned long before the I/O thread
+    // answers. Defined in the .cpp so this header keeps its forward
+    // declarations of MetisClient/Hl2RxDsp/Hl2TxDsp instead of including all
+    // three for three member types.
+    struct PendingConnect;
+    struct DspSetupResult;
+    void finishDspSetup(const DspSetupResult& result);
+
+    std::unique_ptr<PendingConnect> m_pendingConnect;
+    // A connect that arrived while m_pendingConnect was still building. Held
+    // rather than served inline — see the guard at the top of connectRadio().
+    std::unique_ptr<RadioConnectRequest> m_queuedConnect;
+    quint64 m_connectGeneration = 0;
 
     void emitSliceState(int ddc);   // sliceChanged(delta) from a receiver's state
     void emitPanState(int ddc);     // panCenterBandwidthChanged from its NCO + rate

--- a/src/core/backends/hl2/MetisClient.h
+++ b/src/core/backends/hl2/MetisClient.h
@@ -175,9 +175,10 @@ public:
     // The STATIC form answers from a Params alone, without a running client.
     // That exists because the caller must know the receiver count BEFORE
     // start(): the DSP chains have to be built and configured first, and WDSP
-    // channel setup is slow enough (~17 s on a first run, generating FFTW
-    // wisdom) that doing it after start() stalls the I/O thread's EP2 pacer --
-    // and the gateware watchdog halts the stream when EP2 stops arriving.
+    // channel setup is slow enough (~19 s on the first open a machine ever does,
+    // generating FFTW wisdom -- HERMES.md §22.3) that doing it after start()
+    // stalls the I/O thread's EP2 pacer -- and the gateware watchdog halts the
+    // stream when EP2 stops arriving.
     static int effectiveNumRx(const Params& p);
     int effectiveNumRx() const { return effectiveNumRx(m_params); }
 

--- a/src/core/dsp/WdspChannel.cpp
+++ b/src/core/dsp/WdspChannel.cpp
@@ -13,7 +13,23 @@
 #include <string>
 #include <thread>
 
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
 namespace {
+
+// Only ever used to make the wisdom cache's temp filename unique per process.
+long long currentProcessId()
+{
+#ifdef _WIN32
+    return static_cast<long long>(_getpid());
+#else
+    return static_cast<long long>(::getpid());
+#endif
+}
 
 constexpr int kWdspChannelCount = 32;
 constexpr int kRxChannelType = 0;
@@ -56,15 +72,57 @@ void loadWisdomOnce()
     std::call_once(flag, [] { fftw_import_wisdom_from_filename(wisdomPath().c_str()); });
 }
 
-// Persist wisdom at process exit so EVERY plan measured during the run — not
-// just OpenChannel's, but also the ones SetRXAMode/SetRXABandpassFreqs build when
-// the mode or filter changes — is cached for the next run to import.
+// Write the wisdom cache NOW. Called at the end of open(), under g_setupMutex,
+// where the expensive PATIENT plans have just been measured.
+//
+// EAGER, not only at exit, because at-exit persistence turned out to persist
+// almost nothing. The process dies through Hl2EmergencyStop's handler, which
+// restores SIG_DFL and re-raises so the kill looks exactly like an unhandled
+// one — and an unhandled signal does not run std::atexit. Neither does a crash
+// or a Force Quit. Measured: connect (21 s of FFTW planning), SIGTERM the app,
+// relaunch, connect again — 21 s a SECOND time, with the cache file never
+// created. Every operator who has ever force-quit was paying first-run cost on
+// every run, which is what made a genuinely one-time expense feel permanent.
+//
+// A channel open is rare (connect, add panadapter, rate change) and this writes
+// ~10-50 KB, so paying it per open is not a cost worth optimizing. It runs on
+// the I/O thread, never the GUI thread.
+//
+// WRITE-THEN-RENAME, not a direct write, because this file is shared across
+// PROCESSES and g_setupMutex only serialises threads within one of them. An
+// app instance, a second app instance and the test suite (which ctest runs
+// -j8) all export to the same path, and fftw_export_wisdom_to_filename opens
+// with "w" — it truncates first, so two concurrent exporters leave a short
+// file, and a reader importing mid-write gets a partial one that FFTW rejects
+// WHOLESALE. Observed exactly that: a 48 KB cache came back as 13 KB after a
+// parallel test run, which is a cache that silently stopped working.
+//
+// rename(2) is atomic within a filesystem, so a reader sees either the old
+// complete file or the new complete file, and concurrent writers merely race
+// to be last. The temp name carries the pid so two exporters never share it.
+void exportWisdomNow()
+{
+    namespace fs = std::filesystem;
+    const fs::path final = wisdomPath();
+    const fs::path tmp = fs::path(final).concat(
+        ".tmp." + std::to_string(currentProcessId()));
+    if (!fftw_export_wisdom_to_filename(tmp.string().c_str()))
+        return;
+    std::error_code ec;
+    fs::rename(tmp, final, ec);
+    if (ec)
+        fs::remove(tmp, ec);   // leave no debris behind a failed publish
+}
+
+// Persist at process exit as well, so plans measured OUTSIDE an open() —
+// SetRXAMode and SetRXABandpassFreqs build their own when the operator changes
+// mode or drags a filter edge — are cached too. Those are not worth a file
+// write each (a filter drag delivers them at ~30 Hz), so exit is the right
+// moment for them, on the runs where exit is reached at all.
 void armWisdomExportOnce()
 {
     static std::once_flag flag;
-    std::call_once(flag, [] {
-        std::atexit([] { fftw_export_wisdom_to_filename(wisdomPath().c_str()); });
-    });
+    std::call_once(flag, [] { std::atexit([] { exportWisdomNow(); }); });
 }
 
 int acquireChannelId()
@@ -429,7 +487,10 @@ void WdspChannel::open() noexcept
         SetTXAMode(m_channelId, wdspMode(m_config.mode));
         SetTXABandpassFreqs(m_channelId, m_config.filterLowHz, m_config.filterHighHz);
     }
-    armWisdomExportOnce();   // cache all measured wisdom (incl. later setMode) at exit
+    // Cache what this open measured, right now, while we still hold the setup
+    // lock -- a kill or a crash before exit must not throw the measurement away.
+    exportWisdomNow();
+    armWisdomExportOnce();   // and again at exit, for later setMode/setFilter plans
     // Fully configured -- now run. dmode 0: nothing to flush on the way up.
     SetChannelState(m_channelId, 1, 0);
     m_open = true;

--- a/src/core/dsp/WdspChannel.cpp
+++ b/src/core/dsp/WdspChannel.cpp
@@ -106,8 +106,16 @@ void exportWisdomNow()
     const fs::path final = wisdomPath();
     const fs::path tmp = fs::path(final).concat(
         ".tmp." + std::to_string(currentProcessId()));
-    if (!fftw_export_wisdom_to_filename(tmp.string().c_str()))
+    if (!fftw_export_wisdom_to_filename(tmp.string().c_str())) {
+        // It opens with "w", so a failure part way through still leaves a SHORT
+        // file sitting next to the real cache. The name is per-process rather
+        // than per-call, so an unwritable cache directory keeps exactly one of
+        // them rather than accumulating — but a truncated wisdom file is a trap
+        // for whoever debugs this next, so do not leave one.
+        std::error_code rmEc;
+        fs::remove(tmp, rmEc);
         return;
+    }
     std::error_code ec;
     fs::rename(tmp, final, ec);
     if (ec)
@@ -411,6 +419,11 @@ uint64_t WdspChannel::allocationSequenceForTest() noexcept
 uint64_t WdspChannel::outstandingAllocationsForTest() noexcept
 {
     return wdspPortOutstandingAllocations();
+}
+
+std::string WdspChannel::wisdomCachePathForTest()
+{
+    return wisdomPath();
 }
 
 bool WdspChannel::validateConfig(const Config& config, std::string* error) noexcept

--- a/src/core/dsp/WdspChannel.h
+++ b/src/core/dsp/WdspChannel.h
@@ -137,6 +137,13 @@ public:
     static uint64_t allocationSequenceForTest() noexcept;
     static uint64_t outstandingAllocationsForTest() noexcept;
 
+    // Where open() writes the FFTW wisdom cache. Exposed so a test can assert
+    // the file is on disk once open() has RETURNED — the defect it pins is
+    // wisdom that only ever reached disk through an atexit handler, which every
+    // signal-terminated run skipped. Reading the path instead of hardcoding it
+    // keeps the test honest about the env vars wisdomPath() actually consults.
+    static std::string wisdomCachePathForTest();
+
 private:
     explicit WdspChannel(int channelId, const Config& config) noexcept;
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -232,6 +232,7 @@
 #endif
 #include "core/PanadapterStream.h"
 #include "core/backends/IRadioBackend.h"   // seam: SimBackend::audioFrameReady wiring
+#include "core/backends/hl2/Hl2Backend.h"  // dynamic_cast for WDSP setup progress
 #include "core/backends/sim/SimBackend.h"  // dynamic_cast for demo noise controls
 #if defined(Q_OS_MAC)
 #include "core/VirtualAudioBridge.h"
@@ -6160,6 +6161,33 @@ void MainWindow::wireBackendSeam(IRadioBackend* backend)
     if (dynamic_cast<SimBackend*>(backend) != nullptr) {
         connect(backend, &IRadioBackend::audioFrameReady,
                 m_audio, &AudioEngine::feedAudioData);
+    }
+
+    // HL2 only, and deliberately: the client-side WDSP chains are this family's
+    // alone. Opening them measures FFTW plans, which on a machine with no cached
+    // wisdom takes tens of seconds — long enough that a silent connect animation
+    // reads as a hung application. Say what is happening in the label that is
+    // already on screen rather than adding a dialog for it.
+    if (auto* hl2Backend = dynamic_cast<hl2::Hl2Backend*>(backend)) {
+        connect(hl2Backend, &hl2::Hl2Backend::dspSetupProgress, this,
+                [this](const QString& stage, int done, int total) {
+            // Only while the connect animation is up. A DSP rebuild can happen
+            // mid-session (a span change), and hijacking the panadapter with a
+            // connect label for it would be a worse lie than saying nothing.
+            if (!m_panadapterConnectionAnimationVisible)
+                return;
+            const QString label = total > 1
+                ? tr("%1 (%2 of %3)").arg(stage).arg(done + 1).arg(total)
+                : stage;
+            setPanadapterConnectionAnimation(true, label);
+        });
+        // Put the label back to the generic one, so what remains of the connect
+        // — the wire coming up, the first EP6 packet — is not still described as
+        // DSP setup.
+        connect(hl2Backend, &hl2::Hl2Backend::dspSetupFinished, this, [this] {
+            if (m_panadapterConnectionAnimationVisible)
+                setPanadapterConnectionAnimation(true, tr("Connecting to radio…"));
+        });
     }
 
     // The demo delivers native 128-sample frames, which the improved 1024/4 NR2

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6169,6 +6169,11 @@ void MainWindow::wireBackendSeam(IRadioBackend* backend)
     // reads as a hung application. Say what is happening in the label that is
     // already on screen rather than adding a dialog for it.
     if (auto* hl2Backend = dynamic_cast<hl2::Hl2Backend*>(backend)) {
+        // Disconnected first, like every other lambda connect in this function:
+        // the helper promises to be idempotent for the same live backend, and
+        // Qt::UniqueConnection cannot cover a lambda.
+        disconnect(hl2Backend, &hl2::Hl2Backend::dspSetupProgress, this, nullptr);
+        disconnect(hl2Backend, &hl2::Hl2Backend::dspSetupFinished, this, nullptr);
         connect(hl2Backend, &hl2::Hl2Backend::dspSetupProgress, this,
                 [this](const QString& stage, int done, int total) {
             // Only while the connect animation is up. A DSP rebuild can happen

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -6646,6 +6646,7 @@ void SpectrumWidget::setConnectionAnimationVisible(bool on, const QString& label
     const QString nextLabel = label.trimmed().isEmpty()
         ? QStringLiteral("Connecting to radio…")
         : label.trimmed();
+    const bool becomingVisible = on && !m_connectionAnimationVisible;
     const bool changed = (m_connectionAnimationVisible != on)
         || (on && m_connectionAnimationLabel != nextLabel);
 
@@ -6656,7 +6657,12 @@ void SpectrumWidget::setConnectionAnimationVisible(bool on, const QString& label
     m_connectionAnimationVisible = on;
     if (on) {
         m_connectionAnimationLabel = nextLabel;
-        m_connectionAnimationClock.restart();
+        // The clock is the ANIMATION's phase, not the label's. Restarting it on
+        // a label change snapped the spinner back to phase zero mid-spin, which
+        // an HL2 connect now does once per receiver as the DSP build reports
+        // progress. Restart only when the overlay is actually appearing.
+        if (becomingVisible || !m_connectionAnimationClock.isValid())
+            m_connectionAnimationClock.restart();
         m_connectionAnimationTimer->start();
     } else {
         m_connectionAnimationLabel.clear();

--- a/tests/TestDspBuildWait.h
+++ b/tests/TestDspBuildWait.h
@@ -1,0 +1,64 @@
+#pragma once
+
+// Waiting out the connect's asynchronous WDSP channel opens, for the HL2 tests.
+//
+// Hl2Backend::connectRadio() hands the opens to the I/O thread and returns
+// (beginDspSetup), so the wire does not start until they finish. Every one of
+// these tests runs on an isolated HOME — TestSettingsProfile re-roots it, and
+// WdspChannel's wisdomPath() falls back to $HOME/.cache — which means an empty
+// FFTW wisdom cache and a first open that genuinely spends tens of seconds
+// measuring plans. That cost belongs to neither the radio nor anything under
+// test, so waiting a fixed number of milliseconds for it would be measuring the
+// host's CPU. The timing assertions AFTER a connect still use each test's own
+// spin(), because those ARE the assertion.
+//
+// Shared rather than pasted into each test because the number below is a
+// judgement about the slowest machine we expect to run on, and five copies of a
+// judgement drift.
+
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QTimer>
+
+#include <cstdio>
+#include <functional>
+
+namespace AetherSDR::test {
+
+// A BACKSTOP, not a budget: reaching it means something is wrong, not that the
+// machine was slow. Sized from measurement rather than taste — one cold
+// hl2_backend_test spent ~70 s of its 88 s wall time on plan measurement alone,
+// on a 32-core box under load ~26, and `ctest -j8` puts several cold-cache tests
+// through the planner at once. 120 s left too little between "slow host" and
+// "hung".
+constexpr int kDspBuildTimeoutMs = 240000;
+
+inline bool spinUntil(const std::function<bool()>& done,
+                      int timeoutMs = kDspBuildTimeoutMs)
+{
+    QElapsedTimer clock;
+    clock.start();
+    while (!done() && clock.elapsed() < timeoutMs) {
+        QEventLoop loop;
+        QTimer::singleShot(10, &loop, &QEventLoop::quit);
+        loop.exec();
+    }
+    return done();
+}
+
+// Wait for the connect to get through its DSP build, and SAY SO if it does not.
+// Without this the timeout is silent: the test carries on and fails on whatever
+// assertion comes next, which then reads as a defect in the wire or in the
+// publish cadence rather than as a build that never finished.
+inline bool awaitDspBuild(const char* testName, const std::function<bool()>& done)
+{
+    if (spinUntil(done))
+        return true;
+    std::fprintf(stderr,
+                 "%s: the connect's DSP build did not finish within %d ms — the "
+                 "checks below fail for that reason, not the one they name\n",
+                 testName, kDspBuildTimeoutMs);
+    return false;
+}
+
+} // namespace AetherSDR::test

--- a/tests/hl2_backend_test.cpp
+++ b/tests/hl2_backend_test.cpp
@@ -8,6 +8,7 @@
 
 #include "core/backends/IRadioBackend.h"
 #include "TestSettingsProfile.h"
+#include "TestDspBuildWait.h"
 
 #include "core/backends/hl2/Hl2Backend.h"
 
@@ -17,7 +18,6 @@
 #include "core/backends/hl2/MetisProtocol.h"
 
 #include <QCoreApplication>
-#include <QElapsedTimer>
 #include <QEventLoop>
 #include <QHostAddress>
 #include <QNetworkDatagram>
@@ -29,7 +29,6 @@
 
 #include <cstdint>
 #include <cstdio>
-#include <functional>
 
 using namespace AetherSDR;
 using AetherSDR::hl2::Hl2Backend;
@@ -61,24 +60,6 @@ static void spin(int ms)
     QEventLoop loop;
     QTimer::singleShot(ms, &loop, &QEventLoop::quit);
     loop.exec();
-}
-
-// Wait for a CONDITION, with a wall-clock cap that is only a backstop.
-//
-// The connect's WDSP channel opens are asynchronous (Hl2Backend::beginDspSetup),
-// so the wire does not start until they finish — and this test runs on an
-// isolated HOME, which means an empty FFTW wisdom cache and a first open that
-// genuinely takes tens of seconds of plan measurement. That cost is not a
-// property of the radio or of anything under test, so waiting a fixed number of
-// milliseconds for it would be measuring the host's CPU. The timing assertions
-// that follow a connect still use spin(), because those ARE the assertion.
-static bool spinUntil(const std::function<bool()>& done, int timeoutMs)
-{
-    QElapsedTimer clock;
-    clock.start();
-    while (!done() && clock.elapsed() < timeoutMs)
-        spin(10);
-    return done();
 }
 
 // Decode the TX drive level out of an EP2 packet, if this one happens to be
@@ -236,7 +217,8 @@ int main(int argc, char** argv)
     // than on a clock. Once EP6 flows, stay inside kSilenceTimeoutMs (2 s): the
     // fake radio stops after kCap frames and the silence watchdog legitimately
     // drops the link after it.
-    spinUntil([&] { return connectedSpy.count() >= 1; }, 120000);
+    AetherSDR::test::awaitDspBuild("hl2_backend_test",
+                                  [&] { return connectedSpy.count() >= 1; });
     spin(1200);   // capped ping-pong delivers EP6 + at least one spectrum frame
 
     check(connectedSpy.count() == 1, "connected() on the first EP6");

--- a/tests/hl2_backend_test.cpp
+++ b/tests/hl2_backend_test.cpp
@@ -17,6 +17,7 @@
 #include "core/backends/hl2/MetisProtocol.h"
 
 #include <QCoreApplication>
+#include <QElapsedTimer>
 #include <QEventLoop>
 #include <QHostAddress>
 #include <QNetworkDatagram>
@@ -28,6 +29,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <functional>
 
 using namespace AetherSDR;
 using AetherSDR::hl2::Hl2Backend;
@@ -59,6 +61,24 @@ static void spin(int ms)
     QEventLoop loop;
     QTimer::singleShot(ms, &loop, &QEventLoop::quit);
     loop.exec();
+}
+
+// Wait for a CONDITION, with a wall-clock cap that is only a backstop.
+//
+// The connect's WDSP channel opens are asynchronous (Hl2Backend::beginDspSetup),
+// so the wire does not start until they finish — and this test runs on an
+// isolated HOME, which means an empty FFTW wisdom cache and a first open that
+// genuinely takes tens of seconds of plan measurement. That cost is not a
+// property of the radio or of anything under test, so waiting a fixed number of
+// milliseconds for it would be measuring the host's CPU. The timing assertions
+// that follow a connect still use spin(), because those ARE the assertion.
+static bool spinUntil(const std::function<bool()>& done, int timeoutMs)
+{
+    QElapsedTimer clock;
+    clock.start();
+    while (!done() && clock.elapsed() < timeoutMs)
+        spin(10);
+    return done();
 }
 
 // Decode the TX drive level out of an EP2 packet, if this one happens to be
@@ -212,8 +232,11 @@ int main(int argc, char** argv)
     // session leftovers, so anything emitted before connected() is discarded.
     check(!connectedSpy.count(), "connect leaves connected() pending until the first EP6");
 
-    // Stay inside kSilenceTimeoutMs (2 s): the fake radio stops after kCap
-    // frames, and the EP6 silence watchdog legitimately drops the link after it.
+    // The DSP has to finish opening before the wire starts; wait on that rather
+    // than on a clock. Once EP6 flows, stay inside kSilenceTimeoutMs (2 s): the
+    // fake radio stops after kCap frames and the silence watchdog legitimately
+    // drops the link after it.
+    spinUntil([&] { return connectedSpy.count() >= 1; }, 120000);
     spin(1200);   // capped ping-pong delivers EP6 + at least one spectrum frame
 
     check(connectedSpy.count() == 1, "connected() on the first EP6");

--- a/tests/hl2_connect_reentrancy_test.cpp
+++ b/tests/hl2_connect_reentrancy_test.cpp
@@ -1,0 +1,136 @@
+// What happens to a connect that arrives while the previous one's WDSP chains
+// are still opening — and to that connect when the operator then disconnects.
+//
+// The connect stopped being one straight-line call: connectRadio() seeds its
+// members, hands the channel opens to the I/O thread and returns, and
+// finishDspSetup() picks the session back up an event-loop turn (or twenty
+// seconds) later. That opened a window nothing could previously land in, and
+// this test is about what lands in it.
+//
+// NO RADIO IS NEEDED. Everything under test happens before the wire matters:
+// the DSP build runs against nothing, and the socket start at the end of
+// finishDspSetup() binds locally whether or not anything answers. Each case is
+// observed through dspSetupProgress/dspSetupFinished, which bracket exactly one
+// build each.
+
+#include "core/backends/hl2/Hl2Backend.h"
+
+#include "TestSettingsProfile.h"
+#include "TestDspBuildWait.h"
+
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QTimer>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+using AetherSDR::hl2::Hl2Backend;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* what)
+{
+    std::fprintf(stderr, "[%s] %s\n", condition ? " OK " : "FAIL", what);
+    if (!condition)
+        ++failures;
+}
+
+void spin(int ms)
+{
+    QEventLoop loop;
+    QTimer::singleShot(ms, &loop, &QEventLoop::quit);
+    loop.exec();
+}
+
+RadioConnectRequest request()
+{
+    RadioConnectRequest req;
+    req.host = QStringLiteral("127.0.0.1");
+    // A port nothing is on. The connect's unicast discovery probe times out
+    // (400 ms) and the session comes up on the conservative defaults, which is
+    // all this test needs — it never asserts anything about the wire.
+    req.port = 1024;
+    return req;
+}
+
+// Counts complete DSP builds. dspSetupFinished is emitted once per build on
+// every exit from finishDspSetup(), including the superseded one.
+struct BuildCounter {
+    int finished = 0;
+    explicit BuildCounter(Hl2Backend& backend)
+    {
+        QObject::connect(&backend, &Hl2Backend::dspSetupFinished, &backend,
+                         [this] { ++finished; });
+    }
+};
+
+// A disconnect during the opens must take the QUEUED connect with it.
+//
+// The defect: disconnectRadio() bumped the generation, so the in-flight build
+// was correctly superseded and released — but the connect parked behind it in
+// m_queuedConnect survived, and the supersede branch re-drove it. The radio came
+// back up, wire and all, after the operator asked it to go down.
+void disconnectCancelsTheQueuedConnect()
+{
+    TestSettingsProfile profile(QStringLiteral("hl2-reentrancy-disconnect"));
+    Hl2Backend backend;
+    BuildCounter builds(backend);
+
+    backend.connectRadio(request());   // build 1 starts on the I/O thread
+    backend.connectRadio(request());   // cannot be served inline — queued
+    backend.disconnectRadio();         // and the operator leaves
+
+    // finishDspSetup() runs on THIS thread, so nothing above can have completed
+    // yet; the first build lands when the event loop turns.
+    test::awaitDspBuild("hl2_connect_reentrancy_test",
+                        [&] { return builds.finished >= 1; });
+    check(builds.finished == 1, "the superseded build reported once");
+
+    // A re-driven connect would start its own build here. Generous, because on
+    // a cold FFTW cache the first build has already paid the planning and a
+    // second one is fast — it would land well inside this window.
+    spin(3000);
+    check(builds.finished == 1,
+          "a connect queued before the disconnect is NOT re-driven after it");
+    check(!backend.isConnected(), "the backend stayed disconnected");
+}
+
+// The other half of the same guard: WITHOUT a disconnect, a connect that
+// arrives mid-build is still owed. It is held rather than served inline
+// (serving it inline would blocking-hop into the busy I/O thread, which is the
+// GUI stall the split exists to remove), and finishDspSetup() re-drives it.
+void aQueuedConnectIsStillHonoured()
+{
+    TestSettingsProfile profile(QStringLiteral("hl2-reentrancy-queued"));
+    Hl2Backend backend;
+    BuildCounter builds(backend);
+
+    backend.connectRadio(request());
+    backend.connectRadio(request());
+
+    test::awaitDspBuild("hl2_connect_reentrancy_test",
+                        [&] { return builds.finished >= 2; });
+    check(builds.finished == 2,
+          "the queued connect ran its own build once the first was released");
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    disconnectCancelsTheQueuedConnect();
+    aQueuedConnectIsStillHonoured();
+
+    if (failures) {
+        std::fprintf(stderr, "hl2_connect_reentrancy_test: %d check(s) failed\n",
+                     failures);
+        return 1;
+    }
+    std::fprintf(stderr, "hl2_connect_reentrancy_test: all checks passed\n");
+    return 0;
+}

--- a/tests/hl2_link_stats_model_test.cpp
+++ b/tests/hl2_link_stats_model_test.cpp
@@ -23,6 +23,7 @@
 #include "core/backends/hl2/MetisProtocol.h"
 
 #include <QCoreApplication>
+#include <QElapsedTimer>
 #include <QEventLoop>
 #include <QHostAddress>
 #include <QJsonObject>
@@ -33,6 +34,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <functional>
 
 using namespace AetherSDR;
 namespace hl2 = AetherSDR::hl2;
@@ -63,6 +65,24 @@ static void spin(int ms)
     QEventLoop loop;
     QTimer::singleShot(ms, &loop, &QEventLoop::quit);
     loop.exec();
+}
+
+// Wait for a CONDITION, with a wall-clock cap that is only a backstop.
+//
+// The connect's WDSP channel opens are asynchronous (Hl2Backend::beginDspSetup),
+// so the wire does not start until they finish — and this test runs on an
+// isolated HOME, which means an empty FFTW wisdom cache and a first open that
+// genuinely takes tens of seconds of plan measurement. That cost belongs to
+// neither the radio nor anything under test, so waiting a fixed number of
+// milliseconds for it would be measuring the host's CPU. The timing assertions
+// AFTER a connect still use spin(), because those are the assertion.
+static bool spinUntil(const std::function<bool()>& done, int timeoutMs)
+{
+    QElapsedTimer clock;
+    clock.start();
+    while (!done() && clock.elapsed() < timeoutMs)
+        spin(10);
+    return done();
 }
 
 int main(int argc, char** argv)
@@ -106,7 +126,9 @@ int main(int argc, char** argv)
     model.connectToRadio(info);
     check(model.panStream() == nullptr, "HL2 owns no PanadapterStream");
 
-    // Long enough for the connect handshake plus several 1 s publish ticks.
+    // Wait out the asynchronous DSP build first; the 3.6 s after it is the
+    // assertion (several 1 s publish ticks), not connect latency.
+    spinUntil([&] { return model.isConnected(); }, 120000);
     spin(3600);
 
     // ---- the reported symptom: the readouts are no longer structurally zero ----

--- a/tests/hl2_link_stats_model_test.cpp
+++ b/tests/hl2_link_stats_model_test.cpp
@@ -19,11 +19,11 @@
 
 #include "models/RadioModel.h"
 #include "TestSettingsProfile.h"
+#include "TestDspBuildWait.h"
 
 #include "core/backends/hl2/MetisProtocol.h"
 
 #include <QCoreApplication>
-#include <QElapsedTimer>
 #include <QEventLoop>
 #include <QHostAddress>
 #include <QJsonObject>
@@ -34,7 +34,6 @@
 
 #include <cstdint>
 #include <cstdio>
-#include <functional>
 
 using namespace AetherSDR;
 namespace hl2 = AetherSDR::hl2;
@@ -65,24 +64,6 @@ static void spin(int ms)
     QEventLoop loop;
     QTimer::singleShot(ms, &loop, &QEventLoop::quit);
     loop.exec();
-}
-
-// Wait for a CONDITION, with a wall-clock cap that is only a backstop.
-//
-// The connect's WDSP channel opens are asynchronous (Hl2Backend::beginDspSetup),
-// so the wire does not start until they finish — and this test runs on an
-// isolated HOME, which means an empty FFTW wisdom cache and a first open that
-// genuinely takes tens of seconds of plan measurement. That cost belongs to
-// neither the radio nor anything under test, so waiting a fixed number of
-// milliseconds for it would be measuring the host's CPU. The timing assertions
-// AFTER a connect still use spin(), because those are the assertion.
-static bool spinUntil(const std::function<bool()>& done, int timeoutMs)
-{
-    QElapsedTimer clock;
-    clock.start();
-    while (!done() && clock.elapsed() < timeoutMs)
-        spin(10);
-    return done();
 }
 
 int main(int argc, char** argv)
@@ -128,7 +109,8 @@ int main(int argc, char** argv)
 
     // Wait out the asynchronous DSP build first; the 3.6 s after it is the
     // assertion (several 1 s publish ticks), not connect latency.
-    spinUntil([&] { return model.isConnected(); }, 120000);
+    AetherSDR::test::awaitDspBuild("hl2_link_stats_model_test",
+                                  [&] { return model.isConnected(); });
     spin(3600);
 
     // ---- the reported symptom: the readouts are no longer structurally zero ----

--- a/tests/hl2_link_stats_test.cpp
+++ b/tests/hl2_link_stats_test.cpp
@@ -22,6 +22,7 @@
 #include "core/backends/hl2/MetisProtocol.h"
 
 #include <QCoreApplication>
+#include <QElapsedTimer>
 #include <QEventLoop>
 #include <QHostAddress>
 #include <QNetworkDatagram>
@@ -31,6 +32,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <functional>
 #include <vector>
 
 using namespace AetherSDR;
@@ -63,6 +65,24 @@ static void spin(int ms)
     QEventLoop loop;
     QTimer::singleShot(ms, &loop, &QEventLoop::quit);
     loop.exec();
+}
+
+// Wait for a CONDITION, with a wall-clock cap that is only a backstop.
+//
+// The connect's WDSP channel opens are asynchronous (Hl2Backend::beginDspSetup),
+// so the wire does not start until they finish — and this test runs on an
+// isolated HOME, which means an empty FFTW wisdom cache and a first open that
+// genuinely takes tens of seconds of plan measurement. That cost belongs to
+// neither the radio nor anything under test, so waiting a fixed number of
+// milliseconds for it would be measuring the host's CPU. The timing assertions
+// AFTER a connect still use spin(), because those are the assertion.
+static bool spinUntil(const std::function<bool()>& done, int timeoutMs)
+{
+    QElapsedTimer clock;
+    clock.start();
+    while (!done() && clock.elapsed() < timeoutMs)
+        spin(10);
+    return done();
 }
 
 int main(int argc, char** argv)
@@ -121,8 +141,10 @@ int main(int argc, char** argv)
     req.port = radioPort;
     backend.connectRadio(req);
 
-    // Long enough for the connect handshake plus at least two publish ticks
-    // (the cadence is 1 s).
+    // Wait out the asynchronous DSP build, THEN time the publish cadence: the
+    // 2.6 s below is the assertion (>= two 1 s ticks) and must not be spent
+    // waiting for FFTW to finish planning.
+    spinUntil([&] { return connectedSpy.count() >= 1; }, 120000);
     spin(2600);
     check(connectedSpy.count() == 1, "backend connected on first EP6");
 

--- a/tests/hl2_link_stats_test.cpp
+++ b/tests/hl2_link_stats_test.cpp
@@ -17,12 +17,12 @@
 
 #include "core/backends/IRadioBackend.h"
 #include "TestSettingsProfile.h"
+#include "TestDspBuildWait.h"
 
 #include "core/backends/hl2/Hl2Backend.h"
 #include "core/backends/hl2/MetisProtocol.h"
 
 #include <QCoreApplication>
-#include <QElapsedTimer>
 #include <QEventLoop>
 #include <QHostAddress>
 #include <QNetworkDatagram>
@@ -32,7 +32,6 @@
 
 #include <cstdint>
 #include <cstdio>
-#include <functional>
 #include <vector>
 
 using namespace AetherSDR;
@@ -65,24 +64,6 @@ static void spin(int ms)
     QEventLoop loop;
     QTimer::singleShot(ms, &loop, &QEventLoop::quit);
     loop.exec();
-}
-
-// Wait for a CONDITION, with a wall-clock cap that is only a backstop.
-//
-// The connect's WDSP channel opens are asynchronous (Hl2Backend::beginDspSetup),
-// so the wire does not start until they finish — and this test runs on an
-// isolated HOME, which means an empty FFTW wisdom cache and a first open that
-// genuinely takes tens of seconds of plan measurement. That cost belongs to
-// neither the radio nor anything under test, so waiting a fixed number of
-// milliseconds for it would be measuring the host's CPU. The timing assertions
-// AFTER a connect still use spin(), because those are the assertion.
-static bool spinUntil(const std::function<bool()>& done, int timeoutMs)
-{
-    QElapsedTimer clock;
-    clock.start();
-    while (!done() && clock.elapsed() < timeoutMs)
-        spin(10);
-    return done();
 }
 
 int main(int argc, char** argv)
@@ -144,7 +125,8 @@ int main(int argc, char** argv)
     // Wait out the asynchronous DSP build, THEN time the publish cadence: the
     // 2.6 s below is the assertion (>= two 1 s ticks) and must not be spent
     // waiting for FFTW to finish planning.
-    spinUntil([&] { return connectedSpy.count() >= 1; }, 120000);
+    AetherSDR::test::awaitDspBuild("hl2_link_stats_test",
+                                  [&] { return connectedSpy.count() >= 1; });
     spin(2600);
     check(connectedSpy.count() == 1, "backend connected on first EP6");
 

--- a/tests/hl2_receiver_churn_test.cpp
+++ b/tests/hl2_receiver_churn_test.cpp
@@ -31,9 +31,9 @@
 #include "core/backends/hl2/MetisProtocol.h"
 #include "core/backends/IRadioBackend.h"
 #include "TestSettingsProfile.h"
+#include "TestDspBuildWait.h"
 
 #include <QCoreApplication>
-#include <QElapsedTimer>
 #include <QEventLoop>
 #include <QHostAddress>
 #include <QNetworkDatagram>
@@ -45,7 +45,6 @@
 
 #include <cstdint>
 #include <cstdio>
-#include <functional>
 
 using namespace AetherSDR;
 using namespace AetherSDR::hl2;
@@ -76,24 +75,6 @@ static void spin(int ms)
     QEventLoop loop;
     QTimer::singleShot(ms, &loop, &QEventLoop::quit);
     loop.exec();
-}
-
-// Wait for a CONDITION, with a wall-clock cap that is only a backstop.
-//
-// The connect's WDSP channel opens are asynchronous (Hl2Backend::beginDspSetup),
-// so the wire does not start until they finish — and this test runs on an
-// isolated HOME, which means an empty FFTW wisdom cache and a first open that
-// genuinely takes tens of seconds of plan measurement. That cost belongs to
-// neither the radio nor anything under test, so waiting a fixed number of
-// milliseconds for it would be measuring the host's CPU. The timing assertions
-// AFTER a connect still use spin(), because those are the assertion.
-static bool spinUntil(const std::function<bool()>& done, int timeoutMs)
-{
-    QElapsedTimer clock;
-    clock.start();
-    while (!done() && clock.elapsed() < timeoutMs)
-        spin(10);
-    return done();
 }
 
 int main(int argc, char** argv)
@@ -152,7 +133,8 @@ int main(int argc, char** argv)
     req.host = QStringLiteral("127.0.0.1");
     req.port = radioPort;
     backend.connectRadio(req);
-    spinUntil([&] { return connectedSpy.count() >= 1; }, 120000);
+    AetherSDR::test::awaitDspBuild("hl2_receiver_churn_test",
+                                  [&] { return connectedSpy.count() >= 1; });
     spin(1200);   // unchanged settle budget; only the connect wait moved out of it
     check(connectedSpy.count() == 1, "connected() on the first EP6");
     check(backend.isConnected(), "link up before the churn starts");

--- a/tests/hl2_receiver_churn_test.cpp
+++ b/tests/hl2_receiver_churn_test.cpp
@@ -33,6 +33,7 @@
 #include "TestSettingsProfile.h"
 
 #include <QCoreApplication>
+#include <QElapsedTimer>
 #include <QEventLoop>
 #include <QHostAddress>
 #include <QNetworkDatagram>
@@ -44,6 +45,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <functional>
 
 using namespace AetherSDR;
 using namespace AetherSDR::hl2;
@@ -74,6 +76,24 @@ static void spin(int ms)
     QEventLoop loop;
     QTimer::singleShot(ms, &loop, &QEventLoop::quit);
     loop.exec();
+}
+
+// Wait for a CONDITION, with a wall-clock cap that is only a backstop.
+//
+// The connect's WDSP channel opens are asynchronous (Hl2Backend::beginDspSetup),
+// so the wire does not start until they finish — and this test runs on an
+// isolated HOME, which means an empty FFTW wisdom cache and a first open that
+// genuinely takes tens of seconds of plan measurement. That cost belongs to
+// neither the radio nor anything under test, so waiting a fixed number of
+// milliseconds for it would be measuring the host's CPU. The timing assertions
+// AFTER a connect still use spin(), because those are the assertion.
+static bool spinUntil(const std::function<bool()>& done, int timeoutMs)
+{
+    QElapsedTimer clock;
+    clock.start();
+    while (!done() && clock.elapsed() < timeoutMs)
+        spin(10);
+    return done();
 }
 
 int main(int argc, char** argv)
@@ -132,7 +152,8 @@ int main(int argc, char** argv)
     req.host = QStringLiteral("127.0.0.1");
     req.port = radioPort;
     backend.connectRadio(req);
-    spin(1200);
+    spinUntil([&] { return connectedSpy.count() >= 1; }, 120000);
+    spin(1200);   // unchanged settle budget; only the connect wait moved out of it
     check(connectedSpy.count() == 1, "connected() on the first EP6");
     check(backend.isConnected(), "link up before the churn starts");
     check(pans.size() == 1, "one pan to begin with");

--- a/tests/hl2_tx_loopback_test.cpp
+++ b/tests/hl2_tx_loopback_test.cpp
@@ -17,15 +17,15 @@
 #include "core/backends/hl2/Hl2Backend.h"
 #include "core/backends/hl2/MetisProtocol.h"
 
+#include "TestDspBuildWait.h"
+
 #include <QCoreApplication>
-#include <QElapsedTimer>
 #include <QEventLoop>
 #include <QTimer>
 #include <QUdpSocket>
 
 #include <cmath>
 #include <cstdio>
-#include <functional>
 #include <vector>
 
 using namespace AetherSDR;
@@ -42,24 +42,6 @@ static void spin(int ms)
     QEventLoop loop;
     QTimer::singleShot(ms, &loop, &QEventLoop::quit);
     loop.exec();
-}
-
-// Wait for a CONDITION, with a wall-clock cap that is only a backstop.
-//
-// The connect's WDSP channel opens are asynchronous (Hl2Backend::beginDspSetup),
-// so the wire does not start until they finish — and this test runs on an
-// isolated HOME, which means an empty FFTW wisdom cache and a first open that
-// genuinely takes tens of seconds of plan measurement. That cost belongs to
-// neither the radio nor anything under test, so waiting a fixed number of
-// milliseconds for it would be measuring the host's CPU. The timing assertions
-// AFTER a connect still use spin(), because those are the assertion.
-static bool spinUntil(const std::function<bool()>& done, int timeoutMs)
-{
-    QElapsedTimer clock;
-    clock.start();
-    while (!done() && clock.elapsed() < timeoutMs)
-        spin(10);
-    return done();
 }
 
 // Is the simulator actually there? A plain Metis discovery probe.
@@ -122,7 +104,8 @@ int main(int argc, char** argv)
     // were. kIqRateHz is the ONE place the rate appears.
     req.params[QStringLiteral("sampleRateHz")] = kIqRateHz;
     backend.connectRadio(req);
-    spinUntil([&] { return backend.isConnected(); }, 120000);
+    AetherSDR::test::awaitDspBuild("hl2_tx_loopback_test",
+                                  [&] { return backend.isConnected(); });
     spin(2500);   // unchanged settle budget; only the connect wait moved out of it
     check(backend.isConnected(), "connected to the simulator");
     if (!backend.isConnected()) {

--- a/tests/hl2_tx_loopback_test.cpp
+++ b/tests/hl2_tx_loopback_test.cpp
@@ -25,6 +25,7 @@
 
 #include <cmath>
 #include <cstdio>
+#include <functional>
 #include <vector>
 
 using namespace AetherSDR;
@@ -41,6 +42,24 @@ static void spin(int ms)
     QEventLoop loop;
     QTimer::singleShot(ms, &loop, &QEventLoop::quit);
     loop.exec();
+}
+
+// Wait for a CONDITION, with a wall-clock cap that is only a backstop.
+//
+// The connect's WDSP channel opens are asynchronous (Hl2Backend::beginDspSetup),
+// so the wire does not start until they finish — and this test runs on an
+// isolated HOME, which means an empty FFTW wisdom cache and a first open that
+// genuinely takes tens of seconds of plan measurement. That cost belongs to
+// neither the radio nor anything under test, so waiting a fixed number of
+// milliseconds for it would be measuring the host's CPU. The timing assertions
+// AFTER a connect still use spin(), because those are the assertion.
+static bool spinUntil(const std::function<bool()>& done, int timeoutMs)
+{
+    QElapsedTimer clock;
+    clock.start();
+    while (!done() && clock.elapsed() < timeoutMs)
+        spin(10);
+    return done();
 }
 
 // Is the simulator actually there? A plain Metis discovery probe.
@@ -103,7 +122,8 @@ int main(int argc, char** argv)
     // were. kIqRateHz is the ONE place the rate appears.
     req.params[QStringLiteral("sampleRateHz")] = kIqRateHz;
     backend.connectRadio(req);
-    spin(2500);
+    spinUntil([&] { return backend.isConnected(); }, 120000);
+    spin(2500);   // unchanged settle budget; only the connect wait moved out of it
     check(backend.isConnected(), "connected to the simulator");
     if (!backend.isConnected()) {
         std::fprintf(stderr, "hl2_tx_loopback_test: cannot continue unconnected\n");

--- a/tests/wdsp_channel_test.cpp
+++ b/tests/wdsp_channel_test.cpp
@@ -2,12 +2,59 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
+#include <filesystem>
 #include <iostream>
 #include <numbers>
 #include <string>
 #include <vector>
 
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
 namespace {
+
+// The env var WdspChannel's wisdomPath() reads for the cache directory.
+constexpr const char* kCacheDirVar =
+#ifdef _WIN32
+    "LOCALAPPDATA";
+#else
+    "XDG_CACHE_HOME";
+#endif
+
+void setCacheDirEnv(const std::string& value)
+{
+#ifdef _WIN32
+    _putenv_s(kCacheDirVar, value.c_str());
+#else
+    ::setenv(kCacheDirVar, value.c_str(), 1);
+#endif
+}
+
+void restoreCacheDirEnv(const char* previous)
+{
+    if (previous)
+        setCacheDirEnv(previous);
+#ifdef _WIN32
+    else
+        _putenv_s(kCacheDirVar, "");
+#else
+    else
+        ::unsetenv(kCacheDirVar);
+#endif
+}
+
+long long testProcessId()
+{
+#ifdef _WIN32
+    return static_cast<long long>(_getpid());
+#else
+    return static_cast<long long>(::getpid());
+#endif
+}
 
 bool require(bool condition, const char* message)
 {
@@ -242,6 +289,51 @@ bool runLifecycleTest()
     return true;
 }
 
+// The wisdom cache must be on disk when open() RETURNS — not at process exit.
+//
+// What this pins: export used to be a std::atexit handler alone, and the app's
+// own signal path (Hl2EmergencyStop restores SIG_DFL and re-raises) turns every
+// SIGTERM, crash and Force Quit into an exit that never runs one. The plans were
+// measured and then thrown away, so the next launch paid full first-run cost
+// again — for anyone who had ever force-quit, on every run.
+//
+// Redirects the cache directory to a fresh empty path first, so "the file is
+// there" can only be true if THIS open() wrote it. Cheap despite opening a
+// channel: by the time this runs the process has already measured wisdom for
+// these geometries, so FFTW has it in memory and the open is a warm one.
+bool runWisdomExportTest()
+{
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    const fs::path scratch = fs::temp_directory_path(ec)
+        / ("aethersdr-wisdom-export-test-" + std::to_string(testProcessId()));
+    fs::remove_all(scratch, ec);
+    fs::create_directories(scratch, ec);
+    if (ec)
+        return require(false, "could not create a scratch wisdom directory");
+
+    const char* previous = std::getenv(kCacheDirVar);
+    const std::string saved = previous ? previous : std::string();
+    setCacheDirEnv(scratch.string());
+
+    const fs::path wisdom = WdspChannel::wisdomCachePathForTest();
+    bool ok = require(!fs::exists(wisdom), "the scratch wisdom cache started empty");
+    if (ok) {
+        std::unique_ptr<WdspChannel> channel = WdspChannel::create({});
+        ok = require(channel != nullptr, "could not open a channel for the wisdom test");
+        if (ok) {
+            // Checked while the process is still very much alive: an atexit
+            // handler cannot have run, so this file exists only if open() wrote it.
+            ok = require(fs::exists(wisdom) && fs::file_size(wisdom) > 0,
+                         "open() left the FFTW wisdom cache on disk");
+        }
+    }
+
+    restoreCacheDirEnv(previous ? saved.c_str() : nullptr);
+    fs::remove_all(scratch, ec);
+    return ok;
+}
+
 } // namespace
 
 int main()
@@ -262,6 +354,7 @@ int main()
         }) ||
         !runLeakChecked("underrun test", runUnderrunTest) ||
         !runLeakChecked("reconfiguration test", runReconfigurationTest) ||
+        !runLeakChecked("wisdom export test", runWisdomExportTest) ||
         !require(WdspChannel::outstandingAllocationsForTest() == allocationBaseline,
                  "WDSP test suite left allocations outstanding")) {
         return 1;


### PR DESCRIPTION
## The symptom

Connecting a Hermes-Lite 2 for the first time froze the entire application for
**21–82 seconds** with nothing on screen to explain it. Reported as "the client
has completely hung."

It is not a hang and it is not the radio — it is FFTW measuring plans for WDSP's
`FFTW_PATIENT` channel setup, on the GUI thread, silently.

## How the freeze was measured

The automation bridge's socket handler runs on the GUI thread, so pinging it
every 100 ms from a separate thread turns "is the UI frozen" into a number: a
gap between replies **is** a frozen UI. Driven against
`hpsdrsim -hermeslite2 -P1` on a cold FFTW cache.

| | Before | After |
|---|---|---|
| Cold-cache connect | 21–82 s (load-dependent) | 20.2 s |
| Bridge pings answered during it | **0 of ~200** | **219 of 219** |
| Longest unresponsive gap | 58–82 s | **0.50 s** |
| Panadapter grabs served mid-open | n/a (impossible) | 4 of 4 |
| Wisdom on disk after SIGTERM | none | 9117 bytes |
| Next launch, same profile | 21.6 s **again** | **0.57 s** |

The connect still takes ~20 s on a cold cache — that planning cannot be
optimised away — but the application is fully live throughout, and it now
happens once per machine instead of once per launch.

## Two independent defects

### 1. The GUI thread waited on the I/O thread

`RadioModel` calls `Hl2Backend::connectRadio()` synchronously, and that method
drove every `Hl2RxDsp::configure()` (and the TX one) through
`Qt::BlockingQueuedConnection`. The work was correctly *off* the GUI thread; the
GUI thread simply stood there for all of it.

`connectRadio()` now splits into three phases: synchronous member seeding
(unchanged — `hl2_state_restore_test` reads `currentOperatingState()` right
after it returns), the channel opens posted to the I/O thread, then
`finishDspSetup()` resuming on the GUI thread to start the wire.

**The §20.8 ordering is untouched**: chains still open before
`MetisClient::start()`, serially, on the I/O thread. EP2 still is not
best-effort. What changed is only that the GUI thread stopped waiting.

Two re-entrancy cases the old blocking window structurally could not reach:

- A **disconnect** mid-build is caught by a generation counter; the build runs
  to completion (WDSP's `OpenChannel` cannot be cancelled) and `finishDspSetup`
  releases what it built instead of starting a wire nobody asked for.
- A **connect** mid-build is queued, not served inline. Serving it inline would
  call `buildReceivers()`, whose `publishIoDsps()` is a *blocking* hop into an
  I/O thread busy for the rest of that open — the same stall through the back
  door.

### 2. The wisdom was never saved

Export was a `std::atexit` handler. `Hl2EmergencyStop` restores `SIG_DFL` and
re-raises, so an unhandled signal — which is what SIGTERM, a crash and a Force
Quit all become — never ran it.

Measured: connect (21 s), `kill`, relaunch, connect → **21.6 s a second time**,
cache file never created. **Anyone who had ever force-quit was paying first-run
cost on every run**, which is why a genuinely one-time expense felt permanent.

Export now happens at the end of `open()`. It is **write-then-rename**: the
direct write truncated the shared cache when two processes exported at once —
a 48 KB cache came back as 13 KB after a `ctest -j8` run, and FFTW rejects a
short file wholesale, so the cache silently stopped working. Caught during this
work; the atexit export is kept for plans measured outside an `open()`.

## The notification

Fed into the connection animation already on screen, rather than a new dialog.
The signal stays on `Hl2Backend` rather than the `IRadioBackend` seam because
WDSP is this family's alone — a Flex demodulates in firmware and an Icom does
not use WDSP at all.

![Preparing the receive chain](https://raw.githubusercontent.com/jensenpat/AetherSDR/fix/wdsp-init-hang-assets/.pr-assets/wdsp-init-progress.png)

Captured 3.2 s into a cold open. The grab itself is the proof — the bridge
served it from the GUI thread while the chains were opening.

![Connected](https://raw.githubusercontent.com/jensenpat/AetherSDR/fix/wdsp-init-hang-assets/.pr-assets/wdsp-init-connected.png)

## A finding worth recording: planning is per MACHINE, not per rate

Measured cold, both orderings, opening `WdspChannel` exactly as
`Hl2RxDsp::configure` builds it:

| Order | 1st open | 2nd | 3rd | 4th |
|---|---|---|---|---|
| 48 → 96 → 192 → 384 kHz | **18865 ms** | 100 ms | 71 ms | 39 ms |
| 384 → 192 → 96 → 48 kHz | **18666 ms** | 64 ms | 99 ms | 175 ms |

The first open costs ~19 s whichever rate it is; every other rate afterwards is
40–175 ms. This corrects a plausible assumption I started from — there is **one**
cold open per machine, ever, not one per sample rate. HERMES.md §22.3.

## Follow-up, deliberately not in this PR

`applyPanBandwidth()` has the same shape the connect used to have. Crossing one
of the four rate boundaries rebuilds **every** receiver (the rate register is
radio-wide) through `Qt::BlockingQueuedConnection` — an open plus a close that
flushes under WDSP's 100 ms timeout, per receiver. With four panadapters open
that is roughly **0.6–1.1 s of frozen UI per boundary crossing**: the "chunky
zoom" operators describe.

The three-phase split here is directly reusable, but the rate change carries
ordering constraints the connect does not — the DSP must expect the new rate
before EP6 delivers at it, and a partial failure has to roll every receiver back
to a single rate or the set is split across two with nothing reporting it. The
roll-back is what needs designing, so it gets its own change. Recorded in
HERMES.md §22.4 and in a comment at the call site.

## Tests

23 of 24 `hl2_*` / `wdsp_*` pass headless (`QT_QPA_PLATFORM=offscreen`).

Five tests needed the connect wait moved out of their fixed spin. They run on
isolated HOMEs, so every run is a cold cache — the old spins passed only because
the blocking open finished *before* the spin started, and the async build now
lands inside it. Each test's **post-connect settle budget is unchanged**; only
the connect latency moved out of it.

`hl2_tx_loopback_test` fails, and fails **identically on unmodified `main`** in
this environment — confirmed by stashing, rebuilding and running the baseline
before attributing it. Pre-existing, worth its own look.

## Docs

HERMES.md §22 is new. §10, §11.3, §12.1, §20.8, the Tier-4 divergence table and
the "Settled — no action" list all carried the old "~17 s, not a bug, don't fix
it" framing; they now point at what was actually wrong — not the planning, but
spending it with the UI blocked and then discarding the result.
