### PR TITLE
fix(hl2): hide CWX/DVK/FDX on unsupported radios

### DIFF
--- a/docs/architecture/radio-capabilities-map.md
+++ b/docs/architecture/radio-capabilities-map.md
@@ -47,6 +47,9 @@ traps and why the DAX crash guard is deliberately *not* the DAX capability.
 | `hasDaxStreams` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | DAX + DAX-IQ applets, Autostart DAX |
 | `hasRadioSideDsp` | ✅ | ❌ | ❌ | `RadioModel::hasRadioSideDsp()` | NR/NB/ANF/NRL/ANFL/ANFT, the APD row, the WNB row |
 | `hasRadioSideWaterfallAutoBlack` | ✅ | ❌ | ❌ | `MainWindow::applyRadioSideDspToPanDisplay` | The HW position of the Display ▸ Black Level button. False cycles Off ↔ SW. **Masks, never rewrites** the stored preference — see below |
+| `hasRadioSideCwKeyer` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi`, `updateKeyerAvailability` | Status-bar CWX indicator, the CWX panel, and its F1-F12 arming |
+| `hasVoiceKeyer` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi`, `updateKeyerAvailability` | Status-bar DVK indicator, the DVK panel, and its F1-F12 arming. ANDed *ahead of* the SmartSDR+ entitlement gate — see below |
+| `hasFullDuplex` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | Status-bar FDX indicator |
 | `hasWaveforms` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | File ▸ Waveforms… |
 | `hasMultiClientSessions` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | Settings ▸ multiFLEX… |
 | `hasSupplyVoltageTelemetry` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | PA supply-voltage readout in the status bar |
@@ -112,6 +115,52 @@ wrong in both directions:
 Both predicates therefore turn on whether the operator has actually moved one of
 the Flex-shaped controls in this process.
 `tests/host_voice_chain_policy_test.cpp` pins the truth table.
+
+### The status-bar row: hidden, not dimmed — and what stays
+
+`CWX`, `DVK` and `FDX` are three labels in the status bar whose entire
+implementation is a verb the radio's firmware executes: `cwx …`, `dvk …`,
+`radio set full_duplex_enabled=`. They pass the `hasRadioSideDsp` test above,
+but each got its own flag rather than riding that one — a family could plausibly
+have a voice keyer without full duplex, and merging them would make the first
+such backend a rewrite.
+
+They are **hidden**, not disabled. A greyed-out control says "not right now";
+these are "not on this radio, ever", and permanently dim labels read as a fault
+the operator can go looking for.
+
+Three things do **not** move with them:
+
+- **ASR (Copy Assist)** sits in the same row and is host-side. `AsrAudioTap`
+  subscribes to `AudioEngine::receivePresentationPostDspAudioReady` and whisper
+  runs on this machine, so it works on every family. Gating it would remove a
+  working control — the `EQ`-applet mistake above, one row over.
+- **TNF**, and its `+TNF` sibling in the pan overlay menu. `tnf create/remove/
+  set` and `sub tnf all` are Flex command-plane verbs, so by the test above TNF
+  looks like a fourth member of this group — and it was written as one before
+  being pulled back out. It stays ungated because the control is about to stop
+  being empty: a host-side notch is landing and these are the surfaces it will
+  drive. Gating it now would mean deleting the control and putting it straight
+  back, which is precisely the round trip the `EQ` applet already made. If that
+  notch does not land, reconsider this — but reconsider it as "is the control
+  still empty", not as "is this a Flex feature".
+- **CW itself.** A radio with `hasRadioSideCwKeyer = false` still transmits CW
+  from a key, a paddle or the host keying path. What it lacks is a text buffer.
+
+The **shortcuts** need the flag too, not just the buttons. The keyer F1-F12 keys
+are `ApplicationShortcut`s that stay armed whether or not their button is on
+screen, so `updateKeyerAvailability()` ANDs both capabilities into the same
+availability that drives the enabled state and the panel auto-hide. Without
+that, an HL2 in CW keeps F1-F12 firing `cwx send` into a backend with no such
+verb.
+
+`hasVoiceKeyer` is evaluated **ahead of** `DvkAvailabilityGate`'s SmartSDR+
+entitlement check, and the ordering is load-bearing. That gate fails *open* when
+the entitlement is unknown (#4210 — the radio must say no before the UI does),
+which is right for a Flex mid-handshake and would otherwise leave a live DVK
+button on every radio that never reports a license at all. "Is this radio
+licensed for the feature" is a question only a radio that *has* the feature can
+be asked.
 
 ### What `hasRadioSideWaterfallAutoBlack` must never hide
 

--- a/docs/architecture/radio-capabilities-map.md
+++ b/docs/architecture/radio-capabilities-map.md
@@ -47,8 +47,8 @@ traps and why the DAX crash guard is deliberately *not* the DAX capability.
 | `hasDaxStreams` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | DAX + DAX-IQ applets, Autostart DAX |
 | `hasRadioSideDsp` | ✅ | ❌ | ❌ | `RadioModel::hasRadioSideDsp()` | NR/NB/ANF/NRL/ANFL/ANFT, the APD row, the WNB row |
 | `hasRadioSideWaterfallAutoBlack` | ✅ | ❌ | ❌ | `MainWindow::applyRadioSideDspToPanDisplay` | The HW position of the Display ▸ Black Level button. False cycles Off ↔ SW. **Masks, never rewrites** the stored preference — see below |
-| `hasRadioSideCwKeyer` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi`, `updateKeyerAvailability` | Status-bar CWX indicator, the CWX panel, and its F1-F12 arming |
-| `hasVoiceKeyer` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi`, `updateKeyerAvailability` | Status-bar DVK indicator, the DVK panel, and its F1-F12 arming. ANDed *ahead of* the SmartSDR+ entitlement gate — see below |
+| `hasRadioSideCwKeyer` | ✅ | ❌ | ❌ | `RadioModel::hasRadioSideCwKeyer()` | Status-bar CWX indicator, the CWX panel and its F1-F12 arming, plus every other `cwx` entry point — see below |
+| `hasVoiceKeyer` | ✅ | ❌ | ❌ | `RadioModel::hasVoiceKeyer()` | Status-bar DVK indicator, the DVK panel, and its F1-F12 arming. ANDed *ahead of* the SmartSDR+ entitlement gate — see below |
 | `hasFullDuplex` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | Status-bar FDX indicator |
 | `hasWaveforms` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | File ▸ Waveforms… |
 | `hasMultiClientSessions` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | Settings ▸ multiFLEX… |
@@ -153,6 +153,21 @@ screen, so `updateKeyerAvailability()` ANDs both capabilities into the same
 availability that drives the enabled state and the panel auto-hide. Without
 that, an HL2 in CW keeps F1-F12 firing `cwx send` into a backend with no such
 verb.
+
+And the buttons are not the last of it. `cwx` has four entry points that never
+touch the status bar at all, so both keyer capabilities are read through
+`RadioModel::hasRadioSideCwKeyer()` / `hasVoiceKeyer()` — which carry the
+permissive disconnected rule themselves — rather than inline at each site:
+
+| Surface | Where | On a radio that declares false |
+|---|---|---|
+| FlexControl / Ulanzi `CwxF1`..`CwxF12` macro action | `MainWindow::applyFlexControlAction` | Ignored, logged under `aether.cw`. The binding stays assignable — it is operator-scoped and outlives any one radio |
+| MQTT `aethersdr/cw/transmit` | `MainWindow::wireSpotSubsystem` | Ignored, `qCWarning(lcMqtt)` |
+| TCI `cw_msg`, `cw_macros`, `cw_macros_stop` | `TciProtocol` | Ignored, `qCWarning(lcCat)`. Checked inside the queued lambda, on the model's thread — the TCI socket thread must not read `RadioModel` |
+| Automation bridge `cwx send\|speed\|stop` | `AutomationServer::doCwx` | Returns an error rather than `ok:true`, so a caller polling `get_state cwx` has something to blame |
+
+An `ok` for work that never happens is the same defect as a permanently dim
+button, one plane over.
 
 `hasVoiceKeyer` is evaluated **ahead of** `DvkAvailabilityGate`'s SmartSDR+
 entitlement check, and the ordering is load-bearing. That gate fails *open* when

--- a/docs/architecture/radio-capabilities-map.md
+++ b/docs/architecture/radio-capabilities-map.md
@@ -165,6 +165,13 @@ permissive disconnected rule themselves — rather than inline at each site:
 | MQTT `aethersdr/cw/transmit` | `MainWindow::wireSpotSubsystem` | Ignored, `qCWarning(lcMqtt)` |
 | TCI `cw_msg`, `cw_macros`, `cw_macros_stop` | `TciProtocol` | Ignored, `qCWarning(lcCat)`. Checked inside the queued lambda, on the model's thread — the TCI socket thread must not read `RadioModel` |
 | Automation bridge `cwx send\|speed\|stop` | `AutomationServer::doCwx` | Returns an error rather than `ok:true`, so a caller polling `get_state cwx` has something to blame |
+| rigctl `send_morse` / `b`, `stop_morse` | `RigctlProtocol` | `RPRT -11` (RIG_ENAVAIL) instead of `RPRT 0` — Not1MM/N1MM must not be told a contest exchange went out |
+| SmartCAT (Kenwood) `KY` | `SmartCatProtocol::cmdKY` | `?;` for both set and query; the query would otherwise answer `KY0;` "buffer empty" forever |
+
+The two CAT surfaces read the accessor SYNCHRONOUSLY, on their own socket
+thread — the same direct-read posture those files already take for
+`isConnected()` / `cwxActive()`, and the only way to answer a protocol that
+wants a return code. Only the mutation takes the queued hop to the model thread.
 
 An `ok` for work that never happens is the same defect as a permanently dim
 button, one plane over.

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -2773,6 +2773,18 @@ Drive the CWX CW keyer — the easy repro for post-TX FFT-floor recovery (#3804)
 Stage the slice into a CW mode first (`invoke sliceModeCombo setCurrentText CW`)
 for the radio to actually emit.
 
+Every action here emits a `cwx` verb at the radio, so on a connected backend that
+declares `hasRadioSideCwKeyer=false` (an HL2, the demo) all three return an error
+rather than `ok:true` for work the radio would silently drop:
+
+```json
+→ {"cmd":"cwx","action":"send","value":"CQ"}
+← {"ok":false,"error":"cwx unavailable: this radio has no radio-side CW keyer (no `cwx` command plane)"}
+```
+
+Disconnected it still answers, like every other capability gate here — with
+nothing attached there is nothing to be honest about.
+
 ### `txtest`
 Two-tone TX test signal (for IMD / PA / meter measurements).
 

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -6625,6 +6625,14 @@ QJsonObject AutomationServer::doCwx(const QString& action, const QString& arg)
 {
     if (!m_radioModel)
         return err(QStringLiteral("no radio model available"));
+    // All three actions below emit a `cwx` verb at the radio — `cwx send`,
+    // `cwx wpm`, `cwx clear` — so a backend with no radio-side text buffer
+    // swallows every one of them. An honest error beats an ok:true for work
+    // that never happened: a caller polling `get_state cwx` would otherwise
+    // watch a keyer that never starts with nothing to blame.
+    if (!m_radioModel->hasRadioSideCwKeyer())
+        return err(QStringLiteral("cwx unavailable: this radio has no radio-side "
+                                  "CW keyer (no `cwx` command plane)"));
     CwxModel& cwx = m_radioModel->cwxModel();
     const QString a = action.trimmed().toLower();
 

--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -1647,6 +1647,12 @@ QString RigctlProtocol::cmdSendMorse(const QString& text)
         m_pendingMorseLine = true;
         return {};
     }
+    // A radio with no radio-side CW text buffer would swallow every `cwx send`
+    // this produces, and RPRT 0 would tell Not1MM/N1MM the contest exchange
+    // went out. RIG_ENAVAIL is the file's established answer for a control this
+    // radio does not have. Direct read, on the CAT thread — the same posture as
+    // the isConnected() checks above; only the MUTATION needs the queued hop.
+    if (!m_model->hasRadioSideCwKeyer()) return rprt(-11);
     // Route through CwxModel so the local sidetone keyer (driven by
     // CwxModel::transmissionRequested) fires alongside the radio command.
     // Going through sendCmdPublic directly would silently bypass the
@@ -1660,6 +1666,10 @@ QString RigctlProtocol::cmdSendMorse(const QString& text)
 QString RigctlProtocol::cmdStopMorse()
 {
     if (!m_model) return rprt(-1);
+    // Nothing to stop on a radio that could never have been started — same
+    // RIG_ENAVAIL as send_morse, so a client that probes with stop_morse gets
+    // one consistent answer about this radio rather than two.
+    if (!m_model->hasRadioSideCwKeyer()) return rprt(-11);
     // CwxModel::clearBuffer emits transmissionCancelled, which cuts any
     // in-flight local sidetone in addition to sending "cwx clear". (#2909)
     QMetaObject::invokeMethod(m_model, [model = m_model]() {

--- a/src/core/SmartCatProtocol.cpp
+++ b/src/core/SmartCatProtocol.cpp
@@ -995,6 +995,12 @@ QString SmartCatProtocol::cmdPT(const QString& arg)
 
 QString SmartCatProtocol::cmdKY(const QString& arg)
 {
+    // A radio with no radio-side CW text buffer has no KY to answer. Both forms
+    // report the Kenwood error token rather than an honest-looking "KY0;" and a
+    // silent accept — the query would otherwise say "buffer empty" forever
+    // while every set went nowhere. Direct read on the CAT thread, the same
+    // posture as the cwxActive() read this replaces.
+    if (!m_model->hasRadioSideCwKeyer()) return "?;";
     if (arg.isEmpty())
         return QString("KY%1;").arg(m_model->cwxActive() ? 1 : 0);
     if (arg.size() < 2) return "?;";

--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -1,6 +1,7 @@
 #ifdef HAVE_WEBSOCKETS
 #include "TciProtocol.h"
 #include "AppSettings.h"
+#include "LogManager.h"
 #include "TciRoutingState.h"
 #include "TciTrxMap.h"
 #include "models/RadioModel.h"
@@ -994,6 +995,14 @@ QString TciProtocol::cmdCwMsg(const QStringList& args)
     if (text.isEmpty()) return {};
     QString cmd = QStringLiteral("cwx send \"%1\"").arg(text);
     QMetaObject::invokeMethod(m_model, [model = m_model, cmd]() {
+        // Capability check runs HERE, on the model's thread, not in the caller:
+        // this method is driven by the TCI client socket and RadioModel state is
+        // not ours to read from it.
+        if (!model->hasRadioSideCwKeyer()) {
+            qCWarning(lcCat) << "TCI: cw_msg ignored \u2014 radio has no radio-side "
+                                "CW keyer";
+            return;
+        }
         model->sendCmdPublic(cmd, nullptr);
     }, Qt::QueuedConnection);
     return {};
@@ -1431,6 +1440,11 @@ QString TciProtocol::cmdCwMacros(const QStringList& args)
     if (text.isEmpty()) return {};
     QString cmd = QStringLiteral("cwx send \"%1\"").arg(text);
     QMetaObject::invokeMethod(m_model, [model = m_model, cmd]() {
+        if (!model->hasRadioSideCwKeyer()) {
+            qCWarning(lcCat) << "TCI: cw_macros ignored \u2014 radio has no "
+                                "radio-side CW keyer";
+            return;
+        }
         model->sendCmdPublic(cmd, nullptr);
     }, Qt::QueuedConnection);
     return {};
@@ -1440,6 +1454,7 @@ QString TciProtocol::cmdCwMacrosStop()
 {
     if (!m_model) return {};
     QMetaObject::invokeMethod(m_model, [model = m_model]() {
+        if (!model->hasRadioSideCwKeyer()) return;
         model->sendCmdPublic("cwx clear", nullptr);
     }, Qt::QueuedConnection);
     return {};

--- a/src/core/backends/RadioCapabilities.h
+++ b/src/core/backends/RadioCapabilities.h
@@ -219,10 +219,12 @@ struct RadioCapabilities {
     // `cwx send` is the "silently does nothing" shape the DVK entitlement gate
     // already exists to prevent. The buttons are not the only surface: the
     // FlexControl/Ulanzi macro action, the MQTT cw/transmit topic, TCI's
-    // cw_msg / cw_macros and the automation bridge's `cwx` verb all reach
-    // CwxModel without passing the status bar, so all of them ask
-    // RadioModel::hasRadioSideCwKeyer() — read through the accessor, never
-    // inline, so the permissive disconnected rule cannot be forgotten at a site.
+    // cw_msg / cw_macros, rigctl's send_morse / stop_morse, SmartCAT's KY and
+    // the automation bridge's `cwx` verb all reach CwxModel without passing the
+    // status bar, so all of them ask RadioModel::hasRadioSideCwKeyer() — read
+    // through the accessor, never inline, so the permissive disconnected rule
+    // cannot be forgotten at a site. The three that owe a caller an answer
+    // (bridge, rigctl, SmartCAT) return an error rather than a cheerful ok.
     //
     // NOT about CW. A radio reporting false still transmits CW perfectly well
     // from a key, a paddle or the host's own keying path; what it lacks is a

--- a/src/core/backends/RadioCapabilities.h
+++ b/src/core/backends/RadioCapabilities.h
@@ -217,7 +217,12 @@ struct RadioCapabilities {
     // Gates the status-bar CWX indicator, the CWX panel and its F1-F12 macro
     // shortcuts together — leaving the keys armed on a radio that refuses every
     // `cwx send` is the "silently does nothing" shape the DVK entitlement gate
-    // already exists to prevent.
+    // already exists to prevent. The buttons are not the only surface: the
+    // FlexControl/Ulanzi macro action, the MQTT cw/transmit topic, TCI's
+    // cw_msg / cw_macros and the automation bridge's `cwx` verb all reach
+    // CwxModel without passing the status bar, so all of them ask
+    // RadioModel::hasRadioSideCwKeyer() — read through the accessor, never
+    // inline, so the permissive disconnected rule cannot be forgotten at a site.
     //
     // NOT about CW. A radio reporting false still transmits CW perfectly well
     // from a key, a paddle or the host's own keying path; what it lacks is a

--- a/src/core/backends/RadioCapabilities.h
+++ b/src/core/backends/RadioCapabilities.h
@@ -193,6 +193,58 @@ struct RadioCapabilities {
     // it is the only automatic floor the operator has.
     bool hasRadioSideWaterfallAutoBlack = false;
 
+    // NO hasTrackingNotchFilters HERE, deliberately. TNF looks like it belongs
+    // beside the three below — TnfModel's whole surface is `tnf create/remove/
+    // set` and `sub tnf all`, so it passes the "does the control only emit a
+    // verb the firmware executes" test the same way they do.
+    //
+    // It is left ungated because the CONTROL is about to stop being empty: a
+    // host-side notch is landing, and the status-bar TNF indicator and the
+    // overlay menu's +TNF button are the surfaces it will drive on a radio with
+    // no `tnf` command plane. Hiding them now would mean deleting them and
+    // putting them straight back — the exact round trip the hardware EQ already
+    // made (see hasRadioSideDsp above, and the map doc).
+    //
+    // If that host-side notch does not land, this is the first thing to
+    // reconsider — but reconsider it as "is the control still empty", not as
+    // "is this a Flex feature".
+
+    // The RADIO buffers CW text and sends it on its own keyer, driven by `cwx`
+    // verbs and reporting progress through `sub cwx all`. True for a Flex, whose
+    // firmware owns the character queue, the send index and the break-in timing;
+    // false for a backend where nothing on the far end has a text buffer.
+    //
+    // Gates the status-bar CWX indicator, the CWX panel and its F1-F12 macro
+    // shortcuts together — leaving the keys armed on a radio that refuses every
+    // `cwx send` is the "silently does nothing" shape the DVK entitlement gate
+    // already exists to prevent.
+    //
+    // NOT about CW. A radio reporting false still transmits CW perfectly well
+    // from a key, a paddle or the host's own keying path; what it lacks is a
+    // place to put the text.
+    bool hasRadioSideCwKeyer = false;
+
+    // The RADIO records and plays back voice-keyer messages from its own store
+    // (`dvk` verbs). True for a Flex; false for a backend with no recorder.
+    //
+    // Distinct from, and evaluated BEFORE, the SmartSDR+ DVK entitlement in
+    // DvkAvailabilityGate. That gate answers "is this Flex licensed for the
+    // feature", which is a question only a radio that HAS the feature can be
+    // asked — its fail-open rule for an unknown entitlement (#4210) is correct
+    // for a Flex mid-handshake and would otherwise leave a live DVK button on
+    // every radio that never reports a license at all.
+    bool hasVoiceKeyer = false;
+
+    // The radio can receive and transmit simultaneously on demand, toggled with
+    // `radio set full_duplex_enabled=`. True for a Flex; false for a backend
+    // where the T/R changeover is exclusive and no such setting exists.
+    //
+    // Gates the status-bar FDX indicator. On a radio reporting false the button
+    // could only ever produce the "FDX not available" interlock notification it
+    // already raises on a non-zero response — an error message where a control
+    // should be.
+    bool hasFullDuplex = false;
+
     // The radio accepts installable waveform/mode plugins (SmartSDR waveforms),
     // so a client can offer to manage them.
     bool hasWaveforms = false;

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -161,6 +161,14 @@ RadioCapabilities FlexBackend::capabilities() const
     // asked (`display panafall set <id> auto_black=1`), so HW is a real
     // choice on the Display panel's Black Level button.
     caps.hasRadioSideWaterfallAutoBlack = true;
+    // The CWX text keyer, the digital voice keyer and full duplex are SmartSDR
+    // command-plane features carried by this backend: `cwx …`, `dvk …`,
+    // `radio set full_duplex_enabled=`. hasVoiceKeyer says the radio HAS a
+    // voice keyer; whether this operator is licensed for it is the separate
+    // SmartSDR+ entitlement gate.
+    caps.hasRadioSideCwKeyer = true;
+    caps.hasVoiceKeyer = true;
+    caps.hasFullDuplex = true;
     caps.hasWaveforms = true;            // installable SmartSDR waveforms
     caps.hasMultiClientSessions = true;  // multiFLEX
     // GPSDO / on-board GNSS, reported through the `gps` status.

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -1304,6 +1304,15 @@ RadioCapabilities Hl2Backend::capabilities() const
     // waterfall black level, so the Black Level button's HW position would be
     // a mode that never produces one. Off <-> SW only. (#4606)
     c.hasRadioSideWaterfallAutoBlack = false;
+    // No command plane to carry any of these. The HL2 has no text buffer for a
+    // CW keyer, no voice recorder and no full-duplex setting — so the three
+    // status-bar toggles that drive them go away rather than sitting greyed
+    // out. The host-side equivalents are untouched: this radio still transmits
+    // CW, and this client's own noise modules are the only DSP it has. TNF is
+    // deliberately NOT gated — see the note in RadioCapabilities.h.
+    c.hasRadioSideCwKeyer = false;
+    c.hasVoiceKeyer = false;
+    c.hasFullDuplex = false;
     c.hasWaveforms = false;             // no installable plugin surface
     c.hasMultiClientSessions = false;   // one client owns the radio
     c.hasGpsLocation = false;           // no GNSS receiver on the board

--- a/src/core/backends/sim/SimBackend.cpp
+++ b/src/core/backends/sim/SimBackend.cpp
@@ -311,6 +311,11 @@ RadioCapabilities SimBackend::capabilities() const
     caps.hasRadioSideDsp = false;        // synthetic scene; no firmware DSP
     // No radio-side display engine either — the demo's rows carry no black level.
     caps.hasRadioSideWaterfallAutoBlack = false;
+    // No command plane at all: no radio-side CW text keyer, no voice keyer, and
+    // a simulator that cannot key has nothing to be full duplex about.
+    caps.hasRadioSideCwKeyer = false;
+    caps.hasVoiceKeyer = false;
+    caps.hasFullDuplex = false;
     caps.hasWaveforms = false;
     caps.hasMultiClientSessions = false;
     caps.hasGpsLocation = false;         // synthetic radio has no position source

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -8670,6 +8670,19 @@ void MainWindow::updateKeyerAvailability()
     static const QString kAvail    = "QLabel { color: #404858; font-weight: bold; font-size: 24px; }";
     static const QString kDisabled = "QLabel { color: #252530; font-weight: bold; font-size: 24px; }";
 
+    // QWidget::setStyleSheet() does not compare before it acts — it unpolishes
+    // and repolishes the widget every call. This function is no longer reached
+    // only on mode and connection edges: applyCapabilitiesToUi() calls it, and
+    // that slot is itself re-invoked from the gpsStatusChanged lambda, which a
+    // GPSDO Flex drives periodically because the status carries UTC time. Three
+    // labels restyled per second for no change is cheap but pointless, so the
+    // rewrite is skipped when the sheet already matches.
+    const auto setIndicatorStyle = [](QLabel* label, const QString& sheet) {
+        if (label && label->styleSheet() != sheet) {
+            label->setStyleSheet(sheet);
+        }
+    };
+
     // CWX and DVK both key the radio's TX slice, so their availability and
     // F1-F12 shortcuts follow that slice — not the selected RX slice.  FlexLib
     // scopes CWX to the TX slice (reference/FlexLib_API_v4.1.5.39794/FlexLib/
@@ -8692,14 +8705,14 @@ void MainWindow::updateKeyerAvailability()
     // does nothing, which is exactly the report the DVK entitlement gate below
     // was added for.
     //
-    // Reads through backendCapabilities() rather than a cached flag so the
-    // disconnected case answers permissively via the same struct every other
-    // gate here uses: with nothing attached the default-constructed capabilities
-    // would say false, so the connected test is explicit.
-    const RadioCapabilities keyerCaps = m_radioModel.backendCapabilities();
-    const bool radioConnected = m_radioModel.isConnected();
-    const bool hasCwKeyer = !radioConnected || keyerCaps.hasRadioSideCwKeyer;
-    const bool hasVoiceKeyer = !radioConnected || keyerCaps.hasVoiceKeyer;
+    // Through RadioModel's accessors, not a local backendCapabilities() read:
+    // the same two questions are asked by the FlexControl macro action, the MQTT
+    // CW-transmit topic, TCI's cw_msg / cw_macros and the bridge's `cwx` verb,
+    // and they carry the permissive disconnected rule with them so no caller can
+    // forget it. A default-constructed RadioCapabilities says false, so a raw
+    // read here would hide the keyers with nothing attached.
+    const bool hasCwKeyer = m_radioModel.hasRadioSideCwKeyer();
+    const bool hasVoiceKeyer = m_radioModel.hasVoiceKeyer();
 
     const bool txIsCw  = hasCwKeyer
                          && (txMode == "CW" || txMode == "CWL");
@@ -8736,11 +8749,11 @@ void MainWindow::updateKeyerAvailability()
     m_cwxIndicator->setEnabled(txIsCw);
     if (txSlice && !txIsCw && m_cwxPanel->isVisible()) {
         m_cwxPanel->hide();
-        m_cwxIndicator->setStyleSheet(kDisabled);
+        setIndicatorStyle(m_cwxIndicator, kDisabled);
     } else if (m_cwxPanel->isVisible()) {
-        m_cwxIndicator->setStyleSheet(kActive);
+        setIndicatorStyle(m_cwxIndicator, kActive);
     } else {
-        m_cwxIndicator->setStyleSheet(txIsCw ? kAvail : kDisabled);
+        setIndicatorStyle(m_cwxIndicator, txIsCw ? kAvail : kDisabled);
     }
     m_cwxIndicator->setCursor(txIsCw ? Qt::PointingHandCursor : Qt::ArrowCursor);
 
@@ -8752,11 +8765,11 @@ void MainWindow::updateKeyerAvailability()
     // transient no-TX-slice" caveat (#4173) applies only to the mode gate.
     if ((dvkUnlicensed || (txSlice && !txIsSsb)) && m_dvkPanel->isVisible()) {
         m_dvkPanel->hide();
-        m_dvkIndicator->setStyleSheet(kDisabled);
+        setIndicatorStyle(m_dvkIndicator, kDisabled);
     } else if (m_dvkPanel->isVisible()) {
-        m_dvkIndicator->setStyleSheet(kActive);
+        setIndicatorStyle(m_dvkIndicator, kActive);
     } else {
-        m_dvkIndicator->setStyleSheet(dvkAvailable ? kAvail : kDisabled);
+        setIndicatorStyle(m_dvkIndicator, dvkAvailable ? kAvail : kDisabled);
     }
     m_dvkIndicator->setCursor(dvkAvailable ? Qt::PointingHandCursor
                                            : Qt::ArrowCursor);
@@ -8775,11 +8788,11 @@ void MainWindow::updateKeyerAvailability()
             m_copyAssistApplet && m_copyAssistApplet->isCopyAssistVisible();
         if (txSlice && !txIsSsb && asrVisible) {
             m_copyAssistApplet->setCopyAssistVisible(false);
-            m_asrIndicator->setStyleSheet(kDisabled);
+            setIndicatorStyle(m_asrIndicator, kDisabled);
         } else if (asrVisible) {
-            m_asrIndicator->setStyleSheet(kActive);
+            setIndicatorStyle(m_asrIndicator, kActive);
         } else {
-            m_asrIndicator->setStyleSheet(txIsSsb ? kAvail : kDisabled);
+            setIndicatorStyle(m_asrIndicator, txIsSsb ? kAvail : kDisabled);
         }
         m_asrIndicator->setCursor(txIsSsb ? Qt::PointingHandCursor : Qt::ArrowCursor);
     }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6647,6 +6647,56 @@ void MainWindow::applyCapabilitiesToUi(bool connected, const RadioCapabilities& 
         updateStatusBarMinimumWidth();
     }
 
+    // ── The status-bar CWX / DVK / FDX toggles ──────────────────────────────
+    //
+    // HIDDEN, not disabled. Each of these three is a verb the radio's firmware
+    // executes — `cwx …`, `dvk …`, `radio set full_duplex_enabled=` — and on a
+    // backend with no command plane to carry it the control has nothing behind
+    // it at all. A greyed-out button says "not right now"; these are "not on
+    // this radio, ever", and permanently dim labels in the status bar read as a
+    // fault the operator can go looking for.
+    //
+    // TWO neighbours in this row are deliberately NOT gated:
+    //
+    //   ASR — Copy Assist is host-side. AsrAudioTap subscribes to the engine's
+    //   post-DSP RX audio and whisper runs here, so it works on every family.
+    //   Hiding it would remove a working control, the mistake the hardware EQ
+    //   gate above documents.
+    //
+    //   TNF — `tnf` is a Flex command-plane verb and by the test above it looks
+    //   like it belongs here, but a host-side notch is landing and these are
+    //   the surfaces it will drive. Gating it now would mean deleting the
+    //   control and putting it straight back. See RadioCapabilities.h.
+    //
+    // The panels are hidden with their buttons. CWX and DVK are dockable
+    // splitter children that survive a reconnect, so a panel left open from a
+    // Flex session would otherwise stay on screen next to a hidden button, its
+    // F-key rows still drawn against a radio that refuses every send.
+    const bool cwx = !connected || caps.hasRadioSideCwKeyer;
+    const bool dvk = !connected || caps.hasVoiceKeyer;
+    const bool fdx = !connected || caps.hasFullDuplex;
+
+    if (m_cwxIndicator) {
+        m_cwxIndicator->setVisible(cwx);
+    }
+    if (!cwx && m_cwxPanel) {
+        m_cwxPanel->hide();
+    }
+    if (m_dvkIndicator) {
+        m_dvkIndicator->setVisible(dvk);
+    }
+    if (!dvk && m_dvkPanel) {
+        m_dvkPanel->hide();
+    }
+    if (m_fdxIndicator) {
+        m_fdxIndicator->setVisible(fdx);
+    }
+    // updateKeyerAvailability() owns the enabled/dim state and the F1-F12 arming
+    // for the two keyers, and applies the same capabilities. Run it here so a
+    // mid-session revision disarms the shortcuts at the moment the buttons go,
+    // rather than waiting for the next TX-slice mode change.
+    updateKeyerAvailability();
+
     // ── Flex platform features that are not DSP ─────────────────────────────
     if (m_waveformsAction) {
         m_waveformsAction->setVisible(!connected || caps.hasWaveforms);
@@ -8630,7 +8680,29 @@ void MainWindow::updateKeyerAvailability()
     // activatedAmbiguously (#2464, #2582, #4173).
     SliceModel* txSlice = m_radioModel.txSlice();
     const QString txMode = txSlice ? txSlice->mode() : QString();
-    const bool txIsCw  = (txMode == "CW" || txMode == "CWL");
+    // Both keyers carry a family gate ahead of the mode gate: a radio with no
+    // text buffer and no voice recorder never gains one by switching mode, so
+    // the capability is ANDed into the availability that drives the enabled
+    // state, the panel auto-hide AND the F1-F12 arming below.
+    //
+    // The BUTTONS are hidden entirely by applyCapabilitiesToUi(); this exists
+    // because the shortcuts are ApplicationShortcuts that stay armed whether or
+    // not their button is on screen. Without it an HL2 in CW would keep F1-F12
+    // firing `cwx send` into a backend that has no such verb — a keypress that
+    // does nothing, which is exactly the report the DVK entitlement gate below
+    // was added for.
+    //
+    // Reads through backendCapabilities() rather than a cached flag so the
+    // disconnected case answers permissively via the same struct every other
+    // gate here uses: with nothing attached the default-constructed capabilities
+    // would say false, so the connected test is explicit.
+    const RadioCapabilities keyerCaps = m_radioModel.backendCapabilities();
+    const bool radioConnected = m_radioModel.isConnected();
+    const bool hasCwKeyer = !radioConnected || keyerCaps.hasRadioSideCwKeyer;
+    const bool hasVoiceKeyer = !radioConnected || keyerCaps.hasVoiceKeyer;
+
+    const bool txIsCw  = hasCwKeyer
+                         && (txMode == "CW" || txMode == "CWL");
     const bool txIsSsb = (txMode == "USB" || txMode == "LSB"
                           || txMode == "AM" || txMode == "SAM"
                           || txMode == "FM" || txMode == "NFM"
@@ -8645,7 +8717,12 @@ void MainWindow::updateKeyerAvailability()
         txIsSsb,
         m_radioModel.licenseFeatureSeen(kDvkLicenseFeature),
         m_radioModel.licenseFeatureEnabled(kDvkLicenseFeature));
-    const bool dvkAvailable = (dvkBlocker == DvkIndicatorBlocker::None);
+    // hasVoiceKeyer is ANDed in HERE rather than into txIsSsb, because txIsSsb
+    // also drives the ASR indicator further down and Copy Assist is host-side —
+    // folding a voice-keyer capability into the shared mode test would take a
+    // working transcription feature down with the keyer.
+    const bool dvkAvailable = hasVoiceKeyer
+                              && (dvkBlocker == DvkIndicatorBlocker::None);
     const bool dvkUnlicensed = (dvkBlocker == DvkIndicatorBlocker::NotLicensed);
 
     if (m_cwxPanel) m_cwxPanel->setShortcutsEnabled(txIsCw);

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -505,10 +505,20 @@ void MainWindow::handleFlexControlButton(int button, int action)
             disableSplit();
         }
     } else if (actionName.startsWith("CwxF")) {
-        bool ok = false;
-        const int idx = actionName.mid(4).toInt(&ok);
-        if (ok && idx >= 1 && idx <= 12)
-            m_radioModel.cwxModel().sendMacro(idx);
+        // Same gate the panel's own F1-F12 shortcuts carry: a radio with no CWX
+        // text buffer never gains one, and a mapped hardware button that emits
+        // `cwx send` into a backend with no such verb is the "silently does
+        // nothing" report, not a working control. The action stays assignable —
+        // the binding is operator-scoped and outlives any one radio.
+        if (!m_radioModel.hasRadioSideCwKeyer()) {
+            qCDebug(lcCw) << "CWX macro action" << actionName
+                          << "ignored: radio has no radio-side CW keyer";
+        } else {
+            bool ok = false;
+            const int idx = actionName.mid(4).toInt(&ok);
+            if (ok && idx >= 1 && idx <= 12)
+                m_radioModel.cwxModel().sendMacro(idx);
+        }
     }
 
     syncFlexControlDialog();

--- a/src/gui/MainWindow_Spots.cpp
+++ b/src/gui/MainWindow_Spots.cpp
@@ -126,6 +126,15 @@ void MainWindow::wireSpotSubsystem()
             QJsonDocument::fromJson(payload).object();
         const QString text = obj.value(QStringLiteral("text")).toString().trimmed();
         if (text.isEmpty()) return;
+        // The CWX capability gate, same as the panel's F1-F12 shortcuts and the
+        // FlexControl macro action: this ends in `cwx send`, and a radio with no
+        // text buffer swallows it. Say so in the log rather than accepting a
+        // published message that goes nowhere.
+        if (!m_radioModel.hasRadioSideCwKeyer()) {
+            qCWarning(lcMqtt) << "cw/transmit ignored:"
+                              << "radio has no radio-side CW keyer";
+            return;
+        }
         auto& tx = m_radioModel.transmitModel();
         const int wpm = obj.value(QStringLiteral("speed_wpm")).toInt(0);
         const int hz  = obj.value(QStringLiteral("pitch_hz")).toInt(0);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -3215,6 +3215,22 @@ bool RadioModel::hasRadioSideWaterfallAutoBlack() const
     return backendCapabilities().hasRadioSideWaterfallAutoBlack;
 }
 
+bool RadioModel::hasRadioSideCwKeyer() const
+{
+    if (!m_backend || !isConnected()) {
+        return true;   // nothing attached — assume present, see the header
+    }
+    return backendCapabilities().hasRadioSideCwKeyer;
+}
+
+bool RadioModel::hasVoiceKeyer() const
+{
+    if (!m_backend || !isConnected()) {
+        return true;   // nothing attached — assume present, see the header
+    }
+    return backendCapabilities().hasVoiceKeyer;
+}
+
 bool RadioModel::hasDaxStreams() const
 {
     if (!m_backend || !isConnected()) {

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -320,6 +320,24 @@ public:
     // Says nothing about auto-black itself: the client-side (SW) estimate works
     // on every family and is never gated on this.
     bool hasRadioSideWaterfallAutoBlack() const;
+    // Whether the RADIO buffers CW text and sends it on its own keyer
+    // (RadioCapabilities::hasRadioSideCwKeyer), and whether it records and
+    // plays back voice-keyer messages (RadioCapabilities::hasVoiceKeyer). Same
+    // permissive disconnected rule as hasRadioSideDsp().
+    //
+    // These are accessors rather than inline capability reads because the `cwx`
+    // and `dvk` verbs have more entry points than the status-bar buttons: the
+    // FlexControl/Ulanzi macro actions, the MQTT CW-transmit topic, the TCI
+    // cw_msg / cw_macros commands and the automation bridge's `cwx` verb all
+    // reach CwxModel without passing through MainWindow's keyer gate. Every one
+    // of them asks here, so "the radio has no such verb" is answered in one
+    // place instead of once per surface.
+    //
+    // Says nothing about CW itself: a radio reporting hasRadioSideCwKeyer=false
+    // still transmits CW from a key, a paddle or the host keying path; what it
+    // lacks is a text buffer.
+    bool hasRadioSideCwKeyer() const;
+    bool hasVoiceKeyer() const;
     // Whether this radio has DAX audio/IQ channels. Same permissive
     // disconnected rule as hasRadioSideDsp(): with nothing attached there is
     // nothing to be honest about, and blanking the controls on unplug would look

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -328,10 +328,12 @@ public:
     // These are accessors rather than inline capability reads because the `cwx`
     // and `dvk` verbs have more entry points than the status-bar buttons: the
     // FlexControl/Ulanzi macro actions, the MQTT CW-transmit topic, the TCI
-    // cw_msg / cw_macros commands and the automation bridge's `cwx` verb all
-    // reach CwxModel without passing through MainWindow's keyer gate. Every one
-    // of them asks here, so "the radio has no such verb" is answered in one
-    // place instead of once per surface.
+    // cw_msg / cw_macros commands, rigctl's send_morse / stop_morse, SmartCAT's
+    // KY and the automation bridge's `cwx` verb all reach CwxModel without
+    // passing through MainWindow's keyer gate. Every one of them asks here, so
+    // "the radio has no such verb" is answered in one place instead of once per
+    // surface — and the ones that owe a caller a return code answer with an
+    // error instead of a success for work that never happened.
     //
     // Says nothing about CW itself: a radio reporting hasRadioSideCwKeyer=false
     // still transmits CW from a key, a paddle or the host keying path; what it

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -65,7 +65,21 @@
 //                 on screen. hasVoiceKeyer is evaluated AHEAD of the SmartSDR+
 //                 entitlement gate, which fails open on an unknown license
 //                 (#4210) and would otherwise leave DVK live on every radio
-//                 that reports none at all.
+//                 that reports none at all. Both flags are read through
+//                 RadioModel::hasRadioSideCwKeyer() / hasVoiceKeyer(), because
+//                 the `cwx` verb has four more entry points than the buttons —
+//                 the FlexControl/Ulanzi macro action, the MQTT cw/transmit
+//                 topic, TCI cw_msg / cw_macros and the bridge's `cwx` verb —
+//                 and all of them ask the accessor.
+//
+// A NOTE ON WHAT THE HELPERS BELOW DO AND DO NOT PIN. This target links
+// aethercore, not the GUI (CMakeLists.txt), so nothing here can call
+// MainWindow::applyCapabilitiesToUi() or updateKeyerAvailability() directly.
+// uiWouldShow() is therefore a MIRROR of the visibility expression and pins
+// nothing on the MainWindow side — deleting a `caps.x &&` there leaves this
+// green. What IS pinned for real: every backend's declaration, and, for the two
+// keyers, the RadioModel accessor the gate is built on, which the shortcut
+// helpers call rather than paraphrase.
 //   extended DSP  hasExtendedDspFilters() resolves through the BACKEND while
 //                 connected and falls back to the model-name table when not,
 //                 with Flex's answer unchanged on both routes.
@@ -126,17 +140,25 @@ static bool uiWouldShow(bool connected, bool declared)
 // keyers' F1-F12 arming. Separate from uiWouldShow() because the BUTTON and the
 // SHORTCUT are two gates: hiding the label leaves an ApplicationShortcut armed,
 // which is how a keypress ends up silently doing nothing.
-static bool cwxShortcutsWouldArm(bool connected, bool declared, bool txModeIsCw)
+//
+// These take the MODEL rather than a bool, so the capability half is the
+// PRODUCTION accessor and not a paraphrase of it: RadioModel::hasRadioSideCwKeyer()
+// / hasVoiceKeyer() carry the permissive disconnected rule themselves, and they
+// are the same call MainWindow makes — and the same one the FlexControl macro
+// action, the MQTT cw/transmit topic, TCI's cw_msg / cw_macros and the automation
+// bridge's `cwx` verb make. Only the mode half is restated, because MainWindow is
+// not linkable from this target (it links aethercore, not the GUI).
+static bool cwxShortcutsWouldArm(const RadioModel& model, bool txModeIsCw)
 {
-    return (!connected || declared) && txModeIsCw;
+    return model.hasRadioSideCwKeyer() && txModeIsCw;
 }
 
-static bool dvkShortcutsWouldArm(bool connected, bool declared, bool txModeIsVoice)
+static bool dvkShortcutsWouldArm(const RadioModel& model, bool txModeIsVoice)
 {
     // The entitlement gate is the second input on a radio that HAS the feature;
     // with the mode true and no license reported it answers None (fails open),
     // so this expression isolates the capability, which is the new half.
-    return (!connected || declared)
+    return model.hasVoiceKeyer()
            && dvkIndicatorBlocker(txModeIsVoice, /*licenseSeen=*/false,
                                   /*licenseEnabled=*/false)
                   == DvkIndicatorBlocker::None;
@@ -219,28 +241,27 @@ int main(int argc, char** argv)
               "hasRadioSideDsp and hasExtendedDsp are independent");
         check(caps.hasRadioSideWaterfallAutoBlack,
               "Flex declares hasRadioSideWaterfallAutoBlack (per-tile auto_black)");
-        // The four status-bar toggles. Same regression shape as the supply-rail
+        // The three status-bar toggles. Same regression shape as the supply-rail
         // field above and worse in kind: these are shipping SmartSDR features
         // whose only implementation is a command-plane verb, so a field added
-        // without touching FlexBackend deletes TNF, CWX, DVK or FDX from every
-        // Flex.
+        // without touching FlexBackend deletes CWX, DVK or FDX from every Flex.
         check(caps.hasRadioSideCwKeyer,
               "Flex declares hasRadioSideCwKeyer (the `cwx` text buffer)");
         check(caps.hasVoiceKeyer,
               "Flex declares hasVoiceKeyer (the `dvk` recorder)");
         check(caps.hasFullDuplex,
               "Flex declares hasFullDuplex (radio set full_duplex_enabled=)");
-        // Four flags, not one ride on hasRadioSideDsp. All four are true on a
+        // Three flags, not one ride on hasRadioSideDsp. All three are true on a
         // Flex and false on both other backends, so the shipped set cannot
         // demonstrate that they are separable — assert it on the struct, which
         // is where a future merge would start. A family could plausibly have a
-        // voice keyer without tracking notches, or full duplex without either.
+        // voice keyer without full duplex, or full duplex without either.
         RadioCapabilities statusBar;
         statusBar.hasRadioSideDsp = true;
         check(!statusBar.hasRadioSideCwKeyer
                   && !statusBar.hasVoiceKeyer
                   && !statusBar.hasFullDuplex,
-              "hasRadioSideDsp implies none of the four status-bar capabilities");
+              "hasRadioSideDsp implies none of the three status-bar capabilities");
         // Separate from hasRadioSideDsp on purpose: one is audio DSP driven by
         // command-plane verbs, the other a display-plane computation embedded in
         // the waterfall stream. Both happen to be true on a Flex and false on an
@@ -331,9 +352,9 @@ int main(int argc, char** argv)
         // not the stack.
         check(!caps.hasSupplyVoltageTelemetry,
               "HL2 declares hasSupplyVoltageTelemetry=false (PATEMP, no +13.8A)");
-        // The four status-bar toggles. The HL2 has no tracking-notch engine, no
-        // CW text buffer, no voice recorder and no full-duplex setting, so all
-        // four labels go away entirely rather than sitting permanently dim.
+        // The three status-bar toggles. The HL2 has no CW text buffer, no voice
+        // recorder and no full-duplex setting, so all three labels go away
+        // entirely rather than sitting permanently dim.
         check(!caps.hasRadioSideCwKeyer,
               "HL2 declares hasRadioSideCwKeyer=false (no text buffer)");
         check(!caps.hasVoiceKeyer,
@@ -345,10 +366,11 @@ int main(int argc, char** argv)
         // or not their button is on screen, so hiding the labels is not enough:
         // without the capability in this expression an HL2 in CW keeps F1-F12
         // firing `cwx send` into a backend with no such verb.
-        check(!cwxShortcutsWouldArm(true, caps.hasRadioSideCwKeyer, true),
-              "connected + hasRadioSideCwKeyer=false disarms F1-F12 even in CW");
-        check(!dvkShortcutsWouldArm(true, caps.hasVoiceKeyer, true),
-              "connected + hasVoiceKeyer=false disarms F1-F12 even in a voice mode");
+        // DECLARED, on the struct. The accessors cannot be exercised here: the
+        // HL2 fixture reaches the post-swap state without hardware, so
+        // isConnected() is false and hasRadioSideCwKeyer() answers permissively
+        // whatever the backend declares. The Sim block below is genuinely
+        // connected and is where the accessor path is pinned.
         // hasVoiceKeyer is ANDed AHEAD of the SmartSDR+ entitlement gate, whose
         // unknown-entitlement rule fails OPEN (#4210 — the radio must say no
         // before the UI does). Right for a Flex mid-handshake, and exactly why
@@ -426,6 +448,22 @@ int main(int argc, char** argv)
               "Sim declares hasRadioSideCwKeyer=false");
         check(!caps.hasVoiceKeyer, "Sim declares hasVoiceKeyer=false");
         check(!caps.hasFullDuplex, "Sim declares hasFullDuplex=false");
+        // The two keyer ACCESSORS, on the one backend in this file that really
+        // connects — so this is the only place the permissive rule inside them
+        // can be shown to be off rather than assumed. Five surfaces ask through
+        // here: the status-bar gate, the FlexControl/Ulanzi CwxF1..F12 macro
+        // action, the MQTT cw/transmit topic, TCI cw_msg / cw_macros and the
+        // automation bridge's `cwx` verb. The last four reach CwxModel without
+        // passing the status bar at all, and each would otherwise emit
+        // `cwx send` at a radio with no such verb.
+        check(!model.hasRadioSideCwKeyer(),
+              "connected Sim: hasRadioSideCwKeyer() is false through the accessor");
+        check(!model.hasVoiceKeyer(),
+              "connected Sim: hasVoiceKeyer() is false through the accessor");
+        check(!cwxShortcutsWouldArm(model, /*txModeIsCw=*/true),
+              "connected + hasRadioSideCwKeyer=false disarms F1-F12 even in CW");
+        check(!dvkShortcutsWouldArm(model, /*txModeIsVoice=*/true),
+              "connected + hasVoiceKeyer=false disarms F1-F12 even in a voice mode");
         check(caps.clientSettingsDomains
                   == RadioCapabilities::ClientSettingsDomains{},
               "Sim declares clientSettingsDomains EMPTY (synthetic scene "
@@ -535,11 +573,11 @@ int main(int argc, char** argv)
         // attached, armed again with nothing attached and the TX slice in the
         // right mode — the same permissive rule, applied to the gate that is not
         // a widget.
-        check(cwxShortcutsWouldArm(model.isConnected(),
-                                   caps.hasRadioSideCwKeyer, true),
+        check(model.hasRadioSideCwKeyer() && model.hasVoiceKeyer(),
+              "disconnected: both keyer accessors go permissive");
+        check(cwxShortcutsWouldArm(model, /*txModeIsCw=*/true),
               "disconnected: F1-F12 rearm for CWX in a CW TX mode");
-        check(dvkShortcutsWouldArm(model.isConnected(),
-                                   caps.hasVoiceKeyer, true),
+        check(dvkShortcutsWouldArm(model, /*txModeIsVoice=*/true),
               "disconnected: F1-F12 rearm for DVK in a voice TX mode");
     }
 

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -1,5 +1,6 @@
 // Capability-gated UI surfaces: hasProfiles, hasDaxStreams, hasExtendedDsp,
-// hasSupplyVoltageTelemetry.
+// hasSupplyVoltageTelemetry, and the three status-bar toggles
+// (hasRadioSideCwKeyer / hasVoiceKeyer / hasFullDuplex).
 //
 // The rule these guard (RadioCapabilities.h header comment, aetherd RFC §1) is
 // that no call site asks "is this a Flex". A surface is gated on a DECLARED
@@ -49,6 +50,22 @@
 //                 on a radio reporting false, and it must go permissive on
 //                 disconnect or the mask could never restore a stashed HW
 //                 intent (docs/architecture/radio-capabilities-map.md). (#4606)
+//   status bar    the CWX / DVK / FDX labels are HIDDEN, not dimmed, on a radio
+//                 whose firmware runs none of those verbs. Three separate flags
+//                 rather than one ride on hasRadioSideDsp, because a family
+//                 could plausibly have a voice keyer without full duplex. TWO
+//                 neighbours in that row are NOT gated: ASR, because Copy
+//                 Assist runs whisper on this host off the engine's post-DSP RX
+//                 audio, and TNF, because a host-side notch is landing and the
+//                 TNF / +TNF surfaces are what it will drive — gating either
+//                 would remove a control that works or is about to (the
+//                 EQ-applet mistake, one row over). The keyer F1-F12 SHORTCUTS
+//                 carry the same two flags as their buttons: an
+//                 ApplicationShortcut stays armed whether or not its label is
+//                 on screen. hasVoiceKeyer is evaluated AHEAD of the SmartSDR+
+//                 entitlement gate, which fails open on an unknown license
+//                 (#4210) and would otherwise leave DVK live on every radio
+//                 that reports none at all.
 //   extended DSP  hasExtendedDspFilters() resolves through the BACKEND while
 //                 connected and falls back to the model-name table when not,
 //                 with Flex's answer unchanged on both routes.
@@ -67,6 +84,7 @@
 
 #include "models/RadioModel.h"
 #include "models/ModelCapabilities.h"
+#include "gui/DvkAvailabilityGate.h"
 #include "core/RadioDiscovery.h"
 #include "core/backends/flex/FlexBackend.h"
 #include "core/backends/sim/SimBackend.h"
@@ -102,6 +120,26 @@ static void check(bool ok, const char* what)
 static bool uiWouldShow(bool connected, bool declared)
 {
     return !connected || declared;
+}
+
+// The expressions MainWindow::updateKeyerAvailability() applies to the two
+// keyers' F1-F12 arming. Separate from uiWouldShow() because the BUTTON and the
+// SHORTCUT are two gates: hiding the label leaves an ApplicationShortcut armed,
+// which is how a keypress ends up silently doing nothing.
+static bool cwxShortcutsWouldArm(bool connected, bool declared, bool txModeIsCw)
+{
+    return (!connected || declared) && txModeIsCw;
+}
+
+static bool dvkShortcutsWouldArm(bool connected, bool declared, bool txModeIsVoice)
+{
+    // The entitlement gate is the second input on a radio that HAS the feature;
+    // with the mode true and no license reported it answers None (fails open),
+    // so this expression isolates the capability, which is the new half.
+    return (!connected || declared)
+           && dvkIndicatorBlocker(txModeIsVoice, /*licenseSeen=*/false,
+                                  /*licenseEnabled=*/false)
+                  == DvkIndicatorBlocker::None;
 }
 
 // GPS presence has two layers: the family must support a position source and
@@ -181,6 +219,28 @@ int main(int argc, char** argv)
               "hasRadioSideDsp and hasExtendedDsp are independent");
         check(caps.hasRadioSideWaterfallAutoBlack,
               "Flex declares hasRadioSideWaterfallAutoBlack (per-tile auto_black)");
+        // The four status-bar toggles. Same regression shape as the supply-rail
+        // field above and worse in kind: these are shipping SmartSDR features
+        // whose only implementation is a command-plane verb, so a field added
+        // without touching FlexBackend deletes TNF, CWX, DVK or FDX from every
+        // Flex.
+        check(caps.hasRadioSideCwKeyer,
+              "Flex declares hasRadioSideCwKeyer (the `cwx` text buffer)");
+        check(caps.hasVoiceKeyer,
+              "Flex declares hasVoiceKeyer (the `dvk` recorder)");
+        check(caps.hasFullDuplex,
+              "Flex declares hasFullDuplex (radio set full_duplex_enabled=)");
+        // Four flags, not one ride on hasRadioSideDsp. All four are true on a
+        // Flex and false on both other backends, so the shipped set cannot
+        // demonstrate that they are separable — assert it on the struct, which
+        // is where a future merge would start. A family could plausibly have a
+        // voice keyer without tracking notches, or full duplex without either.
+        RadioCapabilities statusBar;
+        statusBar.hasRadioSideDsp = true;
+        check(!statusBar.hasRadioSideCwKeyer
+                  && !statusBar.hasVoiceKeyer
+                  && !statusBar.hasFullDuplex,
+              "hasRadioSideDsp implies none of the four status-bar capabilities");
         // Separate from hasRadioSideDsp on purpose: one is audio DSP driven by
         // command-plane verbs, the other a display-plane computation embedded in
         // the waterfall stream. Both happen to be true on a Flex and false on an
@@ -271,6 +331,35 @@ int main(int argc, char** argv)
         // not the stack.
         check(!caps.hasSupplyVoltageTelemetry,
               "HL2 declares hasSupplyVoltageTelemetry=false (PATEMP, no +13.8A)");
+        // The four status-bar toggles. The HL2 has no tracking-notch engine, no
+        // CW text buffer, no voice recorder and no full-duplex setting, so all
+        // four labels go away entirely rather than sitting permanently dim.
+        check(!caps.hasRadioSideCwKeyer,
+              "HL2 declares hasRadioSideCwKeyer=false (no text buffer)");
+        check(!caps.hasVoiceKeyer,
+              "HL2 declares hasVoiceKeyer=false (no on-radio recorder)");
+        check(!caps.hasFullDuplex,
+              "HL2 declares hasFullDuplex=false (exclusive T/R changeover)");
+        // The keyer F1-F12 shortcuts, evaluated as updateKeyerAvailability()
+        // evaluates them. These are ApplicationShortcuts that stay armed whether
+        // or not their button is on screen, so hiding the labels is not enough:
+        // without the capability in this expression an HL2 in CW keeps F1-F12
+        // firing `cwx send` into a backend with no such verb.
+        check(!cwxShortcutsWouldArm(true, caps.hasRadioSideCwKeyer, true),
+              "connected + hasRadioSideCwKeyer=false disarms F1-F12 even in CW");
+        check(!dvkShortcutsWouldArm(true, caps.hasVoiceKeyer, true),
+              "connected + hasVoiceKeyer=false disarms F1-F12 even in a voice mode");
+        // hasVoiceKeyer is ANDed AHEAD of the SmartSDR+ entitlement gate, whose
+        // unknown-entitlement rule fails OPEN (#4210 — the radio must say no
+        // before the UI does). Right for a Flex mid-handshake, and exactly why
+        // it cannot be the only gate: an HL2 never reports a license at all, so
+        // on the entitlement alone the DVK button stays live forever.
+        check(dvkIndicatorBlocker(/*txModeIsVoice=*/true,
+                                  /*licenseSeen=*/false,
+                                  /*licenseEnabled=*/false)
+                  == DvkIndicatorBlocker::None,
+              "the DVK entitlement gate alone fails open on a radio that reports "
+              "no license — hasVoiceKeyer is what closes it");
         // RFC #4603: the HL2 persists nothing on-radio — the client is its
         // memory for exactly these declared domains (per-band drive/LNA maps
         // ride the extension document, RFC PR 3).
@@ -333,6 +422,10 @@ int main(int argc, char** argv)
         check(!caps.hasGpsLocation, "Sim declares hasGpsLocation=false");
         check(!caps.hasSupplyVoltageTelemetry,
               "Sim declares hasSupplyVoltageTelemetry=false");
+        check(!caps.hasRadioSideCwKeyer,
+              "Sim declares hasRadioSideCwKeyer=false");
+        check(!caps.hasVoiceKeyer, "Sim declares hasVoiceKeyer=false");
+        check(!caps.hasFullDuplex, "Sim declares hasFullDuplex=false");
         check(caps.clientSettingsDomains
                   == RadioCapabilities::ClientSettingsDomains{},
               "Sim declares clientSettingsDomains EMPTY (synthetic scene "
@@ -352,6 +445,19 @@ int main(int argc, char** argv)
               "connected + hasGpsLocation=false hides the GPS stack and its separator");
         check(!uiWouldShow(model.isConnected(), caps.hasSupplyVoltageTelemetry),
               "connected + hasSupplyVoltageTelemetry=false hides the volts readout");
+        check(!uiWouldShow(model.isConnected(), caps.hasRadioSideCwKeyer),
+              "connected + hasRadioSideCwKeyer=false hides CWX and its panel");
+        check(!uiWouldShow(model.isConnected(), caps.hasVoiceKeyer),
+              "connected + hasVoiceKeyer=false hides DVK and its panel");
+        check(!uiWouldShow(model.isConnected(), caps.hasFullDuplex),
+              "connected + hasFullDuplex=false hides FDX");
+        // ASR sits in the same status-bar row and is deliberately NOT in that
+        // list, which is why no assertion here hides it: AsrAudioTap feeds
+        // whisper from the engine's post-DSP RX audio on THIS host, so Copy
+        // Assist works on every family. There is no capability to gate it on,
+        // and adding one would delete a working control — the mistake the EQ
+        // applet already made and reverted
+        // (docs/architecture/radio-capabilities-map.md).
 
         // hasRadioSideDsp reaches the UI through its own accessor, which applies
         // the permissive rule itself (there is no model-name table to fall back
@@ -419,6 +525,22 @@ int main(int argc, char** argv)
         // design exists to prevent. (#4606)
         check(model.hasRadioSideWaterfallAutoBlack(),
               "disconnected: hasRadioSideWaterfallAutoBlack() goes permissive, HW back");
+        check(uiWouldShow(model.isConnected(), caps.hasRadioSideCwKeyer),
+              "disconnected: the CWX indicator is restored");
+        check(uiWouldShow(model.isConnected(), caps.hasVoiceKeyer),
+              "disconnected: the DVK indicator is restored");
+        check(uiWouldShow(model.isConnected(), caps.hasFullDuplex),
+              "disconnected: the FDX indicator is restored");
+        // The keyer shortcuts follow the buttons back. Disarmed while an HL2 was
+        // attached, armed again with nothing attached and the TX slice in the
+        // right mode — the same permissive rule, applied to the gate that is not
+        // a widget.
+        check(cwxShortcutsWouldArm(model.isConnected(),
+                                   caps.hasRadioSideCwKeyer, true),
+              "disconnected: F1-F12 rearm for CWX in a CW TX mode");
+        check(dvkShortcutsWouldArm(model.isConnected(),
+                                   caps.hasVoiceKeyer, true),
+              "disconnected: F1-F12 rearm for DVK in a voice TX mode");
     }
 
     // ---- The TX-intent callbacks are installed once too --------------------
@@ -473,6 +595,9 @@ int main(int argc, char** argv)
               "round-trip: Flex regains hasRadioSideDsp after sim -> Flex");
         check(caps.hasRadioSideWaterfallAutoBlack,
               "round-trip: Flex regains hasRadioSideWaterfallAutoBlack");
+        check(caps.hasRadioSideCwKeyer && caps.hasVoiceKeyer
+                  && caps.hasFullDuplex,
+              "round-trip: Flex regains CWX / DVK / FDX after sim -> Flex");
         check(caps.hasWaveforms,
               "round-trip: Flex regains hasWaveforms after sim -> Flex");
         check(caps.hasMultiClientSessions,

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -67,10 +67,11 @@
 //                 (#4210) and would otherwise leave DVK live on every radio
 //                 that reports none at all. Both flags are read through
 //                 RadioModel::hasRadioSideCwKeyer() / hasVoiceKeyer(), because
-//                 the `cwx` verb has four more entry points than the buttons —
+//                 the `cwx` verb has six more entry points than the buttons —
 //                 the FlexControl/Ulanzi macro action, the MQTT cw/transmit
-//                 topic, TCI cw_msg / cw_macros and the bridge's `cwx` verb —
-//                 and all of them ask the accessor.
+//                 topic, TCI cw_msg / cw_macros, rigctl send_morse / stop_morse,
+//                 SmartCAT KY and the bridge's `cwx` verb — and all of them ask
+//                 the accessor.
 //
 // A NOTE ON WHAT THE HELPERS BELOW DO AND DO NOT PIN. This target links
 // aethercore, not the GUI (CMakeLists.txt), so nothing here can call
@@ -145,8 +146,8 @@ static bool uiWouldShow(bool connected, bool declared)
 // PRODUCTION accessor and not a paraphrase of it: RadioModel::hasRadioSideCwKeyer()
 // / hasVoiceKeyer() carry the permissive disconnected rule themselves, and they
 // are the same call MainWindow makes — and the same one the FlexControl macro
-// action, the MQTT cw/transmit topic, TCI's cw_msg / cw_macros and the automation
-// bridge's `cwx` verb make. Only the mode half is restated, because MainWindow is
+// action, the MQTT cw/transmit topic, TCI's cw_msg / cw_macros, rigctl's
+// send_morse, SmartCAT's KY and the automation bridge's `cwx` verb make. Only the mode half is restated, because MainWindow is
 // not linkable from this target (it links aethercore, not the GUI).
 static bool cwxShortcutsWouldArm(const RadioModel& model, bool txModeIsCw)
 {
@@ -452,10 +453,11 @@ int main(int argc, char** argv)
         // connects — so this is the only place the permissive rule inside them
         // can be shown to be off rather than assumed. Five surfaces ask through
         // here: the status-bar gate, the FlexControl/Ulanzi CwxF1..F12 macro
-        // action, the MQTT cw/transmit topic, TCI cw_msg / cw_macros and the
-        // automation bridge's `cwx` verb. The last four reach CwxModel without
-        // passing the status bar at all, and each would otherwise emit
-        // `cwx send` at a radio with no such verb.
+        // action, the MQTT cw/transmit topic, TCI cw_msg / cw_macros, rigctl
+        // send_morse / stop_morse, SmartCAT KY and the automation bridge's
+        // `cwx` verb. All but the first reach CwxModel without passing the
+        // status bar at all, and each would otherwise emit `cwx send` at a radio
+        // with no such verb.
         check(!model.hasRadioSideCwKeyer(),
               "connected Sim: hasRadioSideCwKeyer() is false through the accessor");
         check(!model.hasVoiceKeyer(),


### PR DESCRIPTION
## The problem

On a Hermes-Lite 2 the status bar carried five Flex-shaped toggles. Three of
them are nothing but a command-plane verb — `cwx …`, `dvk …`, and
`radio set full_duplex_enabled=` — so on a backend with no command plane to
carry them the control has nothing behind it at all. They sat permanently dim,
which reads as a fault the operator can go looking for rather than as a fact
about the radio.

**Before** — HL2 connected, five dim labels:

![before](https://raw.githubusercontent.com/jensenpat/AetherSDR/fix-hl2-statusbar-assets/.pr-assets/hl2-statusbar-before.png)

**After** — same radio, same session:

![after](https://raw.githubusercontent.com/jensenpat/AetherSDR/fix-hl2-statusbar-assets/.pr-assets/hl2-statusbar-after.png)

## What changed

Three capabilities, declared explicitly in all three backends per the
`ADDING A FIELD` contract, gated in `applyCapabilitiesToUi()` — the single
fan-out point — by **visibility, not enabled state**. A greyed-out control says
"not right now"; these are "not on this radio, ever".

| Flag | Gates | Flex | HL2 | Sim |
|---|---|:--:|:--:|:--:|
| `hasRadioSideCwKeyer` | CWX indicator, panel, F1–F12 | ✅ | ❌ | ❌ |
| `hasVoiceKeyer` | DVK indicator, panel, F1–F12 | ✅ | ❌ | ❌ |
| `hasFullDuplex` | FDX indicator | ✅ | ❌ | ❌ |

Three flags rather than one ride on `hasRadioSideDsp`: a family could plausibly
have a voice keyer without full duplex, and merging them would make the first
such backend a rewrite.

### The shortcuts needed the gate too, not just the buttons

The keyer F1–F12 keys are `ApplicationShortcut`s that stay armed whether or not
their label is on screen. `updateKeyerAvailability()` therefore ANDs both keyer
capabilities into the same availability that drives the enabled state, the panel
auto-hide *and* the arming. Without it an HL2 in CW kept F1–F12 firing
`cwx send` into a backend with no such verb — a keypress that silently does
nothing, which is the report the DVK entitlement gate already exists for.

### Ordering against the SmartSDR+ entitlement gate is load-bearing

`hasVoiceKeyer` is evaluated **ahead of** `DvkAvailabilityGate`. That gate fails
*open* on an unknown license (#4210 — the radio must say no before the UI does),
which is right for a Flex mid-handshake and would otherwise leave DVK live on
every radio that reports no license at all. "Is this radio licensed for the
feature" is a question only a radio that *has* the feature can be asked.

## What is deliberately NOT gated

Two neighbours in that row stay:

- **ASR (Copy Assist)** is host-side. `AsrAudioTap` feeds whisper from
  `AudioEngine::receivePresentationPostDspAudioReady` on this machine, so it
  works on every family. Gating it would remove a working control.
- **TNF**, and its `+TNF` sibling in the pan overlay menu. `tnf` is a Flex verb
  and by the same test it looks like a fourth member of this group — it was
  written as one and then pulled back out. A host-side notch is landing in a
  follow-on PR and these are the surfaces it will drive, so gating now would
  mean deleting the control and putting it straight back.

Both are the mistake the hardware EQ applet already made and reverted (#4609).
`RadioCapabilities.h` and the capabilities map both carry a note so the next
reader does not "fix" TNF back.

## Verification

Proven on the real HL2 (`00:1C:C0:A2:13:DD`, gateware 74) over the automation
bridge, on an isolated profile, `txAllowed:false` throughout. The two results
that actually discriminate this from the pre-existing mode gates:

- **DVK in USB** — `visible:false, enabled:false`. The entitlement gate alone
  fails open there, so before this change DVK was live.
- **CWX in CW** — `visible:false, enabled:false`. CW is exactly the mode where
  the old gate enabled it and armed F1–F12.

TNF, `+TNF` and ASR all stay `visible:true, enabled:true` while connected. All
three gated labels return on disconnect (the permissive `!connected || caps.x`
rule):

![disconnected](https://raw.githubusercontent.com/jensenpat/AetherSDR/fix-hl2-statusbar-assets/.pr-assets/hl2-statusbar-disconnected.png)

`radio_capability_gating_test` gains ~25 assertions: explicit declaration per
backend, the permissive disconnect rule, shortcut arming, the entitlement-gate
ordering, and a struct-level check that the three flags are independent of
`hasRadioSideDsp`.

## Test suite

250/251 pass. The one failure, `hl2_tx_loopback_test`, is **pre-existing and
unrelated** — I stashed this branch, rebuilt it against pristine `origin/main`,
and it fails identically there (same peak bins 619 vs expected 405 and 544 vs
expected 480, same four assertions about transmit frequency and opposite-sideband
suppression). Worth its own issue; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
