### PR TITLE
feat(display): close the 3D stacked-trace wedges with offscreen spectrum

### DIFF
--- a/resources/shaders/dss_mesh.frag
+++ b/resources/shaders/dss_mesh.frag
@@ -51,7 +51,7 @@ layout(binding = 2) uniform sampler2D paletteLut;  // 256x1 RGBA8, floor(0)->pea
 
 layout(location = 0) out vec4 fragColor;
 
-vec3 applySliceShadow(vec3 surfaceColor, float depthFade, float freqUnit)
+vec3 applySliceShadow(vec3 surfaceColor, float depthFade)
 {
     if (shadowMeta.y < 0.5) {
         return surfaceColor;
@@ -60,7 +60,7 @@ vec3 applySliceShadow(vec3 surfaceColor, float depthFade, float freqUnit)
     int descriptorCount = int(clamp(shadowMeta.x, 0.0, 8.0));
     float shadowPlotWidthPx = max(shadowMeta.z, 1.0);
     float frequencyPixel =
-        max(fwidth(freqUnit), 1.0 / shadowPlotWidthPx);
+        max(fwidth(vFrequency), 1.0 / shadowPlotWidthPx);
     vec3 color = surfaceColor;
     for (int i = 0; i < 8; ++i) {
         if (i >= descriptorCount) {
@@ -70,9 +70,9 @@ vec3 applySliceShadow(vec3 surfaceColor, float depthFade, float freqUnit)
         vec4 style = shadowStyles[i];
         float edgeSoftness = frequencyPixel * 0.8;
         float insideLow = smoothstep(
-            band.x - edgeSoftness, band.x + edgeSoftness, freqUnit);
+            band.x - edgeSoftness, band.x + edgeSoftness, vFrequency);
         float insideHigh = 1.0 - smoothstep(
-            band.y - edgeSoftness, band.y + edgeSoftness, freqUnit);
+            band.y - edgeSoftness, band.y + edgeSoftness, vFrequency);
         float bandMask = insideLow * insideHigh;
 
         // Near-black with a trace of the slice hue: this darkens the existing
@@ -85,7 +85,7 @@ vec3 applySliceShadow(vec3 surfaceColor, float depthFade, float freqUnit)
         float lineHalfWidth = frequencyPixel * 1.4;
         float lineMask = 1.0 - smoothstep(
             lineHalfWidth, lineHalfWidth * 2.1,
-            abs(freqUnit - band.z));
+            abs(vFrequency - band.z));
         vec3 cueColor = mix(shadowColor, style.rgb, 0.42);
         color = mix(
             color, cueColor,
@@ -100,7 +100,6 @@ void main()
         discard;
     }
     float fade = clamp(1.0 - vDepth, 0.0, 1.0);   // 1 at front, 0 at back
-    float freqUnit = vFrequency;
     float shadowFade = pow(fade, 1.15);
 
     if (vEdge < -0.5) {
@@ -109,7 +108,7 @@ void main()
         // analytical edge coverage changes continuously as the trace moves
         // through subpixels instead of toggling whole pixels on and off.
         vec3 oc = mix(bgFill.rgb, vec3(0.92), 0.45 + 0.55 * fade);
-        oc = applySliceShadow(oc, shadowFade, freqUnit);
+        oc = applySliceShadow(oc, shadowFade);
         float flatOutline = 1.0 - smoothstep(0.0, 0.035, vLut);
         float flatOutlineScale = mix(1.0, 0.42, flatOutline);
         float ribbonCoverage =
@@ -146,7 +145,7 @@ void main()
     vec3 c = texture(paletteLut, vec2(clamp(vLut, 0.0, 1.0), 0.5)).rgb;
     c = mix(c, bgFill.rgb, clamp(vDepth * haze, 0.0, 1.0));
     c = mix(bgFill.rgb, c, vBoundaryFade);
-    c = applySliceShadow(c, shadowFade, freqUnit);
+    c = applySliceShadow(c, shadowFade);
     float sideDistancePx =
         max(vSideDistance, 0.0) * max(plotWidthPx, 1.0);
     // The curtain has the same exposed stacked endpoints as the ridge. Fade

--- a/resources/shaders/dss_mesh.frag
+++ b/resources/shaders/dss_mesh.frag
@@ -8,10 +8,11 @@ layout(location = 0) in float vLut;
 layout(location = 1) in float vDepth;
 layout(location = 2) in float vEdge;
 layout(location = 3) in float vBoundaryFade;
-layout(location = 4) in float vFrequency;
+layout(location = 4) in float vFrequency;   // viewport units; leaves [0,1] when widened
 layout(location = 5) in float vLayerAlpha;
 layout(location = 6) in float vRibbonCoord;
 layout(location = 7) flat in float vOverlayLayer;
+layout(location = 8) in float vSideDistance;  // to the row silhouette, plot units
 
 layout(std140, binding = 0) uniform U {
     float rowOffset;
@@ -34,6 +35,8 @@ layout(std140, binding = 0) uniform U {
     float visibleRows;
     float plotWidthPx;
     float plotHeightPx;
+    float rowSpanFactor;  // see dss_mesh.vert; 1.0 = classic clipped trapezoid
+    // std140 pads this 21-float scalar run out to bgFill's vec4 alignment.
     vec4  bgFill;
     vec4  shadowBands[8];
     vec4  shadowStyles[8];
@@ -47,7 +50,7 @@ layout(binding = 2) uniform sampler2D paletteLut;  // 256x1 RGBA8, floor(0)->pea
 
 layout(location = 0) out vec4 fragColor;
 
-vec3 applySliceShadow(vec3 surfaceColor, float depthFade)
+vec3 applySliceShadow(vec3 surfaceColor, float depthFade, float freqUnit)
 {
     if (shadowMeta.y < 0.5) {
         return surfaceColor;
@@ -56,7 +59,7 @@ vec3 applySliceShadow(vec3 surfaceColor, float depthFade)
     int descriptorCount = int(clamp(shadowMeta.x, 0.0, 8.0));
     float shadowPlotWidthPx = max(shadowMeta.z, 1.0);
     float frequencyPixel =
-        max(fwidth(vFrequency), 1.0 / shadowPlotWidthPx);
+        max(fwidth(freqUnit), 1.0 / shadowPlotWidthPx);
     vec3 color = surfaceColor;
     for (int i = 0; i < 8; ++i) {
         if (i >= descriptorCount) {
@@ -66,9 +69,9 @@ vec3 applySliceShadow(vec3 surfaceColor, float depthFade)
         vec4 style = shadowStyles[i];
         float edgeSoftness = frequencyPixel * 0.8;
         float insideLow = smoothstep(
-            band.x - edgeSoftness, band.x + edgeSoftness, vFrequency);
+            band.x - edgeSoftness, band.x + edgeSoftness, freqUnit);
         float insideHigh = 1.0 - smoothstep(
-            band.y - edgeSoftness, band.y + edgeSoftness, vFrequency);
+            band.y - edgeSoftness, band.y + edgeSoftness, freqUnit);
         float bandMask = insideLow * insideHigh;
 
         // Near-black with a trace of the slice hue: this darkens the existing
@@ -81,7 +84,7 @@ vec3 applySliceShadow(vec3 surfaceColor, float depthFade)
         float lineHalfWidth = frequencyPixel * 1.4;
         float lineMask = 1.0 - smoothstep(
             lineHalfWidth, lineHalfWidth * 2.1,
-            abs(vFrequency - band.z));
+            abs(freqUnit - band.z));
         vec3 cueColor = mix(shadowColor, style.rgb, 0.42);
         color = mix(
             color, cueColor,
@@ -96,6 +99,7 @@ void main()
         discard;
     }
     float fade = clamp(1.0 - vDepth, 0.0, 1.0);   // 1 at front, 0 at back
+    float freqUnit = vFrequency;
     float shadowFade = pow(fade, 1.15);
 
     if (vEdge < -0.5) {
@@ -104,16 +108,13 @@ void main()
         // analytical edge coverage changes continuously as the trace moves
         // through subpixels instead of toggling whole pixels on and off.
         vec3 oc = mix(bgFill.rgb, vec3(0.92), 0.45 + 0.55 * fade);
-        oc = applySliceShadow(oc, shadowFade);
+        oc = applySliceShadow(oc, shadowFade, freqUnit);
         float flatOutline = 1.0 - smoothstep(0.0, 0.035, vLut);
         float flatOutlineScale = mix(1.0, 0.42, flatOutline);
         float ribbonCoverage =
             1.0 - smoothstep(0.15, 1.0, abs(vRibbonCoord));
-        float perspectiveWidth =
-            mix(1.0, backWidthFrac, clamp(vDepth, 0.0, 1.0));
         float sideDistancePx =
-            max(min(vFrequency, 1.0 - vFrequency), 0.0)
-            * max(plotWidthPx, 1.0) * perspectiveWidth;
+            max(vSideDistance, 0.0) * max(plotWidthPx, 1.0);
         // The stacked endpoints form a high-contrast comb against the black
         // outside of the perspective surface. Successive exact FFT rows can
         // legitimately put those endpoints at different heights, so any
@@ -144,12 +145,9 @@ void main()
     vec3 c = texture(paletteLut, vec2(clamp(vLut, 0.0, 1.0), 0.5)).rgb;
     c = mix(c, bgFill.rgb, clamp(vDepth * haze, 0.0, 1.0));
     c = mix(bgFill.rgb, c, vBoundaryFade);
-    c = applySliceShadow(c, shadowFade);
-    float perspectiveWidth =
-        mix(1.0, backWidthFrac, clamp(vDepth, 0.0, 1.0));
+    c = applySliceShadow(c, shadowFade, freqUnit);
     float sideDistancePx =
-        max(min(vFrequency, 1.0 - vFrequency), 0.0)
-        * max(plotWidthPx, 1.0) * perspectiveWidth;
+        max(vSideDistance, 0.0) * max(plotWidthPx, 1.0);
     // The curtain has the same exposed stacked endpoints as the ridge. Fade
     // only the narrow side strip so adjacent curtain heights cannot form a
     // flashing comb against the black outside of the perspective surface.

--- a/resources/shaders/dss_mesh.frag
+++ b/resources/shaders/dss_mesh.frag
@@ -36,7 +36,8 @@ layout(std140, binding = 0) uniform U {
     float plotWidthPx;
     float plotHeightPx;
     float rowSpanFactor;  // see dss_mesh.vert; 1.0 = classic clipped trapezoid
-    // std140 pads this 21-float scalar run out to bgFill's vec4 alignment.
+    float meshCols;       // mesh columns per row (>= texCols)
+    // std140 pads this 22-float scalar run out to bgFill's vec4 alignment.
     vec4  bgFill;
     vec4  shadowBands[8];
     vec4  shadowStyles[8];

--- a/resources/shaders/dss_mesh.vert
+++ b/resources/shaders/dss_mesh.vert
@@ -250,9 +250,11 @@ void main()
     float ridge = sH * frontMaxRidgeFrac * w;          // far ridges shorter
     float topY  = baseY - ridge;                       // up = smaller y
     float plotY = edge > 0.5 ? 1.0 : topY;
-    // Half the row's on-screen width, times how far this column sits from the
-    // nearer end. Off-screen ends give a large value, so the fade correctly
-    // leaves them alone.
+    // Distance from this column to the nearer silhouette edge, in plot-width
+    // units. It reaches 0 at both mesh ends, so the side fade always applies
+    // there; on a widened row those ends sit outside the plot and the fade is
+    // clipped away with them, which is why widening shows no fade band inside
+    // the viewport.
     vSideDistance = min(u, 1.0 - u) * rowSpanFactor * w;
 
     vec2 ndc = vec2(plotX * 2.0 - 1.0, 1.0 - plotY * 2.0);

--- a/resources/shaders/dss_mesh.vert
+++ b/resources/shaders/dss_mesh.vert
@@ -32,6 +32,19 @@ layout(std140, binding = 0) uniform U {
     float visibleRows;        // perspective depth; texture also holds exit reserve
     float plotWidthPx;        // DSS viewport width in physical pixels
     float plotHeightPx;       // DSS viewport height in physical pixels
+    // Frequency span each mesh row covers, as a multiple of the on-screen
+    // viewport bandwidth. 1.0 is the classic clipped trapezoid. Above 1.0 the
+    // NEAR rows run off both edges of the plot and the existing perspective
+    // narrowing walks them back in with depth, so the flanking wedges close
+    // from the front. The projection itself is untouched — a signal still lands
+    // at 0.5 + (freq - 0.5) * depthScale — so the converging slant, the
+    // frequency ruler, and every marker stay exactly where they were.
+    // 1/backWidthFrac (1.667) is the point where the deepest row lands exactly
+    // on the plot edge and no wedge remains at any depth; the host clamps
+    // there and otherwise tapers to the overhang actually available.
+    float rowSpanFactor;
+    // std140 rounds this 21-float scalar run up to the next vec4 boundary.
+    // SpectrumWidget writes three explicit zeros to match — see kDssMeshUboFloats.
     vec4  bgFill;             // plot background colour (for haze)
     vec4  shadowBands[8];     // low u, high u, centre u, band alpha
     vec4  shadowStyles[8];    // cue rgb, centre-line alpha
@@ -55,6 +68,9 @@ layout(location = 4) out float vFrequency;
 layout(location = 5) out float vLayerAlpha;
 layout(location = 6) out float vRibbonCoord;  // -1..+1 across AA outline
 layout(location = 7) flat out float vOverlayLayer;
+// Distance to this row's silhouette in plot-width units. vFrequency can no
+// longer serve: past the plot edge it leaves [0,1] and reads as "outside".
+layout(location = 8) out float vSideDistance;
 
 vec4 sampleHistory(float texU, float sourceAge, float rows)
 {
@@ -71,7 +87,27 @@ vec4 sampleHistory(float texU, float sourceAge, float rows)
         heightTex, vec2(texU, fract(rowOffset + sourceAge / rows)));
 }
 
-float effectiveDbmAt(float geometryU, float sampleAge, float rows)
+// Perspective narrowing with depth. Unchanged, and still the ONLY thing that
+// places a frequency on screen — widening the rows must not touch it.
+float dssDepthScale(float geometryV)
+{
+    return mix(1.0, backWidthFrac, geometryV);
+}
+
+// Mesh column u (0..1 across the drawn row) -> frequency in viewport units,
+// where 0..1 spans the on-screen bandwidth. rowSpanFactor > 1 pushes the ends
+// outside that range, into the offscreen overhang served by the supplemental
+// (native waterfall tile) channel. Depth-independent: every row covers the same
+// frequency range and the perspective decides how wide it lands.
+float dssFreqUnit(float meshU)
+{
+    return 0.5 + (meshU - 0.5) * rowSpanFactor;
+}
+
+// Returns (dBm, covered). `covered` is 0 where neither the exact FFT row nor the
+// calibrated tile overhang had data for this frequency, which lets the caller
+// feather the extended wedge out instead of drawing a flat floor plateau.
+vec2 effectiveDbmAt(float geometryU, float sampleAge, float rows)
 {
     int frameAge = int(clamp(
         floor(sampleAge + 0.5), 0.0, float(103)));
@@ -91,7 +127,7 @@ float effectiveDbmAt(float geometryU, float sampleAge, float rows)
         ? vec4(floorDbm, 0.0, floorDbm, 0.0)
         : sampleHistory(texU, sampleAge, rows);
     if (historySample.g > 0.5) {
-        return historySample.r;
+        return vec2(historySample.r, 1.0);
     }
 
     float supplementalBandwidthMhz = frame.w;
@@ -109,21 +145,21 @@ float effectiveDbmAt(float geometryU, float sampleAge, float rows)
             vec4 supplementalSample =
                 sampleHistory(supplementalTexU, sampleAge, rows);
             if (supplementalSample.a > 0.5) {
-                return supplementalSample.b;
+                return vec2(supplementalSample.b, 1.0);
             }
         }
     }
-    return floorDbm;
+    return vec2(floorDbm, 0.0);
 }
 
-vec2 ridgeNdcAt(float geometryU, float dbm, float geometryV)
+vec2 ridgeNdcAt(float freqUnit, float dbm, float geometryV)
 {
     float strengthLinear = clamp(
         (dbm - floorDbm) / max(rangeDb, 1.0), 0.0, 1.0);
     float strengthHeight =
         pow(strengthLinear, max(zCurve, 0.05));
-    float width = mix(1.0, backWidthFrac, geometryV);
-    float plotX = 0.5 + (geometryU - 0.5) * width;
+    float width = dssDepthScale(geometryV);
+    float plotX = 0.5 + (freqUnit - 0.5) * width;
     float baselineY =
         mix(1.0, 1.0 - depthSpanFrac, geometryV);
     float ridge =
@@ -190,7 +226,9 @@ void main()
     // A zoom-created gap is not an amplitude measurement. Pin it to the
     // baseline before both height and colour mapping so later range changes
     // cannot recolour or lift it, while leaving row/layer visibility untouched.
-    float dbm = effectiveDbmAt(u, sampleAge, rows);
+    float freqUnit = dssFreqUnit(u);
+    vec2 sampled = effectiveDbmAt(freqUnit, sampleAge, rows);
+    float dbm = sampled.x;
     // Linear strength drives COLOUR (LUT[sLin] = dbmToRgb(floor+sLin*range),
     // matching the CPU path); the zCurve lift applies to HEIGHT only.
     float sLin = clamp((dbm - floorDbm) / max(rangeDb, 1.0), 0.0, 1.0);
@@ -199,13 +237,21 @@ void main()
         (dbm - floorDbm) / max(colorRangeDb, 1.0), 0.0, 1.0);
 
     // Receding perspective trapezoid in plot space [0,1] (0,0 = top-left).
-    float w = mix(1.0, backWidthFrac, geometryV);      // narrows with depth
-    float plotX = 0.5 + (u - 0.5) * w;
+    // Unchanged: rowSpanFactor widened the frequency range the row COVERS, not
+    // the way a frequency maps to screen. A row wider than the viewport simply
+    // has its ends fall outside [0,1] and get clipped, which is exactly the
+    // near-row overflow that closes the wedge.
+    float w = dssDepthScale(geometryV);                // narrows with depth
+    float plotX = 0.5 + (freqUnit - 0.5) * w;
     float baseY = mix(1.0, 1.0 - depthSpanFrac,
                       geometryV);                       // baseline rises with depth
     float ridge = sH * frontMaxRidgeFrac * w;          // far ridges shorter
     float topY  = baseY - ridge;                       // up = smaller y
     float plotY = edge > 0.5 ? 1.0 : topY;
+    // Half the row's on-screen width, times how far this column sits from the
+    // nearer end. Off-screen ends give a large value, so the fade correctly
+    // leaves them alone.
+    vSideDistance = min(u, 1.0 - u) * rowSpanFactor * w;
 
     vec2 ndc = vec2(plotX * 2.0 - 1.0, 1.0 - plotY * 2.0);
     if (ribbonOutline) {
@@ -216,10 +262,14 @@ void main()
         float du = 1.0 / max(texCols - 1.0, 1.0);
         float previousU = max(u - du, 0.0);
         float nextU = min(u + du, 1.0);
+        float previousFreq = dssFreqUnit(previousU);
+        float nextFreq = dssFreqUnit(nextU);
         vec2 previousNdc = ridgeNdcAt(
-            previousU, effectiveDbmAt(previousU, sampleAge, rows), geometryV);
+            previousFreq,
+            effectiveDbmAt(previousFreq, sampleAge, rows).x, geometryV);
         vec2 nextNdc = ridgeNdcAt(
-            nextU, effectiveDbmAt(nextU, sampleAge, rows), geometryV);
+            nextFreq,
+            effectiveDbmAt(nextFreq, sampleAge, rows).x, geometryV);
         vec2 viewportHalf =
             vec2(max(plotWidthPx, 1.0), max(plotHeightPx, 1.0)) * 0.5;
         vec2 tangentPx = (nextNdc - previousNdc) * viewportHalf;
@@ -246,7 +296,17 @@ void main()
     vLut = edge > 0.5 ? colorStrength * 0.6 : colorStrength;
     vDepth = clamp(geometryV, 0.0, 1.0);
     vEdge  = edge;
-    vFrequency = u;
-    vBoundaryFade = clamp(validRows - sampleAge, 0.0, 1.0);
+    // Frequency in viewport units, which is what the slice-shadow decals expect.
+    // Now leaves [0,1] on a widened row; vSideDistance carries the silhouette.
+    vFrequency = freqUnit;
+    // Feather the widened wedge where no channel had data, instead of extruding
+    // a flat floor plateau out to the plot edge. vBoundaryFade already fades the
+    // curtain toward bgFill and dims the ridge, and discards at zero, so folding
+    // coverage in here needs no fragment-shader change. Inside the on-screen
+    // viewport an uncovered bin keeps its existing floor rendering.
+    float insideViewport =
+        (freqUnit >= 0.0 && freqUnit <= 1.0) ? 1.0 : 0.0;
+    vBoundaryFade = clamp(validRows - sampleAge, 0.0, 1.0)
+        * max(insideViewport, sampled.y);
     vOverlayLayer = overlayLayer ? 1.0 : 0.0;
 }

--- a/resources/shaders/dss_mesh.vert
+++ b/resources/shaders/dss_mesh.vert
@@ -43,8 +43,10 @@ layout(std140, binding = 0) uniform U {
     // on the plot edge and no wedge remains at any depth; the host clamps
     // there and otherwise tapers to the overhang actually available.
     float rowSpanFactor;
-    // std140 rounds this 21-float scalar run up to the next vec4 boundary.
-    // SpectrumWidget writes three explicit zeros to match — see kDssMeshUboFloats.
+    float meshCols;           // mesh columns per row; >= texCols so a widened
+                              // row still samples every texel on screen
+    // std140 rounds this 22-float scalar run up to the next vec4 boundary.
+    // SpectrumWidget writes two explicit zeros to match — see kDssMeshUboFloats.
     vec4  bgFill;             // plot background colour (for haze)
     vec4  shadowBands[8];     // low u, high u, centre u, band alpha
     vec4  shadowStyles[8];    // cue rgb, centre-line alpha
@@ -259,7 +261,9 @@ void main()
         // through subpixels, producing a whole-surface strobe. Expand each
         // outline into a two-pixel screen-space ribbon; the fragment shader
         // analytically softens its edges.
-        float du = 1.0 / max(texCols - 1.0, 1.0);
+        // One MESH column, which is no longer one texel: the mesh is wider than
+        // the viewport so its column pitch is the tangent's natural step.
+        float du = 1.0 / max(meshCols - 1.0, 1.0);
         float previousU = max(u - du, 0.0);
         float nextU = min(u + du, 1.0);
         float previousFreq = dssFreqUnit(previousU);

--- a/src/gui/DssRenderer.cpp
+++ b/src/gui/DssRenderer.cpp
@@ -320,6 +320,22 @@ DssRenderer::rowAt(int age) const
     return m_rows[idx];
 }
 
+double DssRenderer::newestSupplementalBandwidthMhz(
+    double targetBandwidthMhz) const
+{
+    if (!std::isfinite(targetBandwidthMhz) || targetBandwidthMhz <= 0.0) {
+        return 0.0;
+    }
+    const int rows = visibleRowCount();
+    for (int age = 0; age < rows; ++age) {
+        const double candidate = rowSupplementalBandwidthMhzAtAge(age);
+        if (std::isfinite(candidate) && candidate > targetBandwidthMhz) {
+            return candidate;
+        }
+    }
+    return 0.0;
+}
+
 DssRenderer::RowStats DssRenderer::rowStats(int age, float epsilonDb) const
 {
     RowStats stats;

--- a/src/gui/DssRenderer.h
+++ b/src/gui/DssRenderer.h
@@ -63,6 +63,24 @@ public:
     // the surface only overhangs further without revealing more of the plot.
     static constexpr float kMaxRowSpanFactor = 1.0f / kBackWidthFrac;
 
+    // Mesh columns per row for the GPU path. The mesh spans rowSpanFactor x the
+    // viewport, while the height texture holds kCols texels ACROSS THE VIEWPORT
+    // — so a kCols-wide mesh would leave (span-1)/span of those texels unread.
+    // That is not shimmer: the mesh-column-to-frequency mapping is static, so
+    // the same texels are missed every frame and a narrow carrier landing on one
+    // is permanently invisible at a fixed screen position. Size the mesh for the
+    // widest span instead, so the on-screen region is never sparser than the
+    // texture it samples. Below the widest span it merely oversamples, which
+    // Nearest filtering absorbs by repeating texels.
+    static constexpr int kMeshCols =
+        static_cast<int>(kCols * kMaxRowSpanFactor) + 1;
+    // The invariant dss_mesh.vert's Nearest height sampler depends on: at the
+    // widest span the on-screen columns (kMeshCols / kMaxRowSpanFactor) must
+    // still be at least kCols, or bins fall between samples and vanish.
+    static_assert(static_cast<float>(kMeshCols) >= kCols * kMaxRowSpanFactor,
+                  "kMeshCols must keep the on-screen grid at texel density "
+                  "at kMaxRowSpanFactor");
+
     // Perspective narrowing with depth — the only thing that places a frequency.
     static float depthScale(float depth)
     {

--- a/src/gui/DssRenderer.h
+++ b/src/gui/DssRenderer.h
@@ -125,6 +125,33 @@ public:
         return std::min(spanFactor, kMaxRowSpanFactor);
     }
 
+    // Row span for a source whose calibrated overhang spans
+    // supplementalBandwidthMhz against a targetBandwidthMhz viewport, scaled by
+    // a 0-100 operator setting. Anything that cannot be trusted -- a
+    // non-positive or non-finite bandwidth, or an overhang no wider than the
+    // viewport -- yields 1.0, the clipped trapezoid, rather than widening into
+    // spectrum that was never captured.
+    //
+    // The percentage scales the AVAILABLE span, not the absolute maximum:
+    // against a ~1.15x tile an absolute reading would clamp everything above
+    // ~22% to the same picture, leaving most of the control's travel dead.
+    static float rowSpanFactorFor(double supplementalBandwidthMhz,
+                                  double targetBandwidthMhz,
+                                  int spanPercent)
+    {
+        if (!std::isfinite(targetBandwidthMhz) || targetBandwidthMhz <= 0.0
+            || !std::isfinite(supplementalBandwidthMhz)
+            || supplementalBandwidthMhz <= targetBandwidthMhz) {
+            return 1.0f;
+        }
+        const float available = rowSpanFactorForOverhang(
+            static_cast<float>(
+                supplementalBandwidthMhz / targetBandwidthMhz));
+        const float fraction =
+            static_cast<float>(std::clamp(spanPercent, 0, 100)) / 100.0f;
+        return 1.0f + fraction * (available - 1.0f);
+    }
+
     // Project a normalized frequency coordinate onto the same perspective
     // plane used by both DSS renderers. depth=0 is the full-width front edge;
     // depth=1 is the narrowed back edge. Slice overlays use this helper so

--- a/src/gui/DssRenderer.h
+++ b/src/gui/DssRenderer.h
@@ -285,6 +285,16 @@ public:
     double rowBandwidthMhzAtAge(int age) const;
     double rowSupplementalCenterMhzAtAge(int age) const;
     double rowSupplementalBandwidthMhzAtAge(int age) const;
+    // Bandwidth of the newest VISIBLE row carrying a calibrated overhang wider
+    // than targetBandwidthMhz, or 0 when no such row is on screen.
+    //
+    // The front row is deliberately not authoritative: the FFT-derived producer
+    // that paces rows during TX and during the RX stale-native fallback appends
+    // with no supplemental at all, so keying up would otherwise drop the
+    // overhang to nothing while 90-odd rows of it are still on screen. Once the
+    // last covered row scrolls out, returning 0 is the correct answer.
+    double newestSupplementalBandwidthMhz(double targetBandwidthMhz) const;
+
     RowStats rowStats(int age, float epsilonDb = 0.01f) const;
     quint64 rowGeneration() const { return m_rowGeneration; }
 

--- a/src/gui/DssRenderer.h
+++ b/src/gui/DssRenderer.h
@@ -50,14 +50,74 @@ public:
     // span. Otherwise a high Ref level compresses every real signal into blue.
     static constexpr float kColorSpanDb        = 45.0f;
 
+    // ── Wedge-closing row span ──────────────────────────────────────────────
+    // Because every row covers the SAME frequency span while the far rows
+    // narrow to kBackWidthFrac, the surface leaves two empty triangles beside
+    // it. Widen the span each row covers instead: the near rows then run off
+    // both edges of the plot and the existing perspective narrowing walks them
+    // back in, closing the wedge from the front. The projection below is
+    // untouched, so the converging slant, the frequency ruler and every marker
+    // stay put. dss_mesh.vert applies the SAME formulas.
+
+    // Span at which the DEEPEST row lands exactly on the plot edge. Beyond this
+    // the surface only overhangs further without revealing more of the plot.
+    static constexpr float kMaxRowSpanFactor = 1.0f / kBackWidthFrac;
+
+    // Perspective narrowing with depth — the only thing that places a frequency.
+    static float depthScale(float depth)
+    {
+        return 1.0f - std::clamp(depth, 0.0f, 1.0f) * (1.0f - kBackWidthFrac);
+    }
+
+    // Mesh column (0..1 across the drawn row) -> frequency in viewport units,
+    // where 0..1 spans the on-screen bandwidth. Depth-independent by design.
+    static float rowFrequencyUnit(float meshUnit, float rowSpanFactor)
+    {
+        return 0.5f + (meshUnit - 0.5f) * rowSpanFactor;
+    }
+
+    // Fraction of the plot width a row at `depth` covers. >= 1 means that row
+    // reaches both edges and leaves no wedge; the front row is the widest.
+    static float rowScreenCoverage(float depth, float rowSpanFactor)
+    {
+        return depthScale(depth) * rowSpanFactor;
+    }
+
+    // Shallowest depth still leaving a wedge, or 1 when the surface is closed
+    // all the way to the back. Lets the host report how much a given overhang
+    // actually bought.
+    static float wedgeFreeDepth(float rowSpanFactor)
+    {
+        if (rowSpanFactor <= 1.0f) {
+            return 0.0f;
+        }
+        if (rowSpanFactor >= kMaxRowSpanFactor) {
+            return 1.0f;
+        }
+        return (1.0f - 1.0f / rowSpanFactor) / (1.0f - kBackWidthFrac);
+    }
+
+    // Usable span for an overhang of `spanFactor` x the viewport bandwidth.
+    // Clamped at kMaxRowSpanFactor: past it the extra data is off-plot anyway.
+    static float rowSpanFactorForOverhang(float spanFactor)
+    {
+        if (!(spanFactor > 1.0f) || !std::isfinite(spanFactor)) {
+            return 1.0f;
+        }
+        return std::min(spanFactor, kMaxRowSpanFactor);
+    }
+
     // Project a normalized frequency coordinate onto the same perspective
     // plane used by both DSS renderers. depth=0 is the full-width front edge;
     // depth=1 is the narrowed back edge. Slice overlays use this helper so
     // their apparent angle cannot drift from the FFT surface.
+    //
+    // Frequency-in / screen-out, and independent of rowSpanFactor: widening a
+    // row extends the frequency range it covers, never where a frequency lands.
     static QPointF projectPerspective(float frequencyUnit, float depth)
     {
         const float d = std::clamp(depth, 0.0f, 1.0f);
-        const float width = 1.0f - d * (1.0f - kBackWidthFrac);
+        const float width = depthScale(d);
         return QPointF(0.5f + (frequencyUnit - 0.5f) * width,
                        1.0f - d * kDepthSpanFrac);
     }
@@ -69,7 +129,7 @@ public:
                                   float floorDbm, float rangeDb, float zCurve)
     {
         const float d = std::clamp(depth, 0.0f, 1.0f);
-        const float width = 1.0f - d * (1.0f - kBackWidthFrac);
+        const float width = depthScale(d);
         const float finiteDbm = std::isfinite(dbm) ? dbm : floorDbm;
         const float strengthLinear = std::clamp(
             (finiteDbm - floorDbm) / std::max(rangeDb, 1.0f),

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -1426,7 +1426,8 @@ void MainWindow::syncKiwiSdrPanadapterUiState(const QString& panId)
             spectrum->wfColorScheme(), spectrum->showGrid(),
             spectrum->fftLineWidth(), spectrum->wfAutoBlackRadioSide(),
             spectrum->spectrumRenderMode(), spectrum->dssFloorDepth(),
-            spectrum->dssGain(), spectrum->fftLineColor());
+            spectrum->dssGain(), spectrum->fftLineColor(),
+            spectrum->dssRowSpan());
     };
 
     // Capture the pre-sync display source: leaving kiwi display is the

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1424,10 +1424,10 @@ void MainWindow::wirePanLifecycle()
             // DisplaySourceTraceSettings; do not reapply legacy flat keys here.
             sw->setSpectrumRenderMode(
                 s.value(sw->settingsKey("DisplaySpectrumRenderMode"), "0").toInt());
-            sw->setDssGain(
+            // Principle V: one owned object, re-applied as a unit. The legacy
+            // flat gain key only seeds it when nothing has been written yet.
+            sw->loadDisplay3DSettings(
                 s.value(sw->settingsKey("Display3DGain"), "70").toInt());
-            sw->setDssRowSpan(
-                s.value(sw->settingsKey("Display3DSpan"), "100").toInt());
         }
     });
     // NOTE: panadapterLevelChanged → spectrum()::setDbmRange has been removed.

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1426,6 +1426,8 @@ void MainWindow::wirePanLifecycle()
                 s.value(sw->settingsKey("DisplaySpectrumRenderMode"), "0").toInt());
             sw->setDssGain(
                 s.value(sw->settingsKey("Display3DGain"), "70").toInt());
+            sw->setDssRowSpan(
+                s.value(sw->settingsKey("Display3DSpan"), "100").toInt());
         }
     });
     // NOTE: panadapterLevelChanged → spectrum()::setDbmRange has been removed.

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -3882,6 +3882,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             menu, &SpectrumOverlayMenu::syncDssFloorDepth);
     connect(menu, &SpectrumOverlayMenu::dssGainChanged,
             sw, &SpectrumWidget::setDssGain);
+    connect(menu, &SpectrumOverlayMenu::dssRowSpanChanged,
+            sw, &SpectrumWidget::setDssRowSpan);
     connect(menu, &SpectrumOverlayMenu::wfColorGainChanged,
             this, [this, applet, sw](int v) {
         if (kiwiSdrPanDisplaysKiwi(applet->panId())) {
@@ -4182,6 +4184,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         s.setValue(sw->settingsKey("DisplaySpectrumRenderMode"),  "0");
         s.setValue(sw->settingsKey("Display3DFloorDepth"),        "6");
         s.setValue(sw->settingsKey("Display3DGain"),        "70");
+        s.setValue(sw->settingsKey("Display3DSpan"),        "100");
         s.save();
 
         // Apply the render-mode + 3D-floor reset to the widget too (the keys
@@ -4189,11 +4192,13 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         sw->setSpectrumRenderMode(0);
         sw->setDssFloorDepth(6);
         sw->setDssGain(70);
+        sw->setDssRowSpan(100);
 
         // Sync all Display panel UI controls (incl. the 2D/3D combo + 3D Floor).
         menu->syncDisplaySettings(0, 25, 70, false, QColor(0x00, 0xe5, 0xff),
                                   50, 15, true, 50, 100, 75, false, true, 0,
-                                  true, 2.0f, false, 0, 6);
+                                  true, 2.0f, false, 0, 6, 70,
+                                  QColor(0x00, 0xe5, 0xff), 100);
         menu->syncExtraDisplaySettings(false, 1.15f, 80, 0,
                                        QColor(0x0a, 0x0a, 0x14));
     });

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -4183,16 +4183,16 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
                        "\"version\":1}"));
         s.setValue(sw->settingsKey("DisplaySpectrumRenderMode"),  "0");
         s.setValue(sw->settingsKey("Display3DFloorDepth"),        "6");
-        s.setValue(sw->settingsKey("Display3DGain"),        "70");
-        s.setValue(sw->settingsKey("Display3DSpan"),        "100");
         s.save();
 
         // Apply the render-mode + 3D-floor reset to the widget too (the keys
         // above only update settings, not the live SpectrumWidget).
         sw->setSpectrumRenderMode(0);
         sw->setDssFloorDepth(6);
-        sw->setDssGain(70);
-        sw->setDssRowSpan(100);
+        // Writes the whole 3D object once, and unconditionally — the setters
+        // early-return when a value already matches, which would otherwise
+        // leave a stale object behind on a partial reset.
+        sw->resetDisplay3DSettings();
 
         // Sync all Display panel UI controls (incl. the 2D/3D combo + 3D Floor).
         menu->syncDisplaySettings(0, 25, 70, false, QColor(0x00, 0xe5, 0xff),

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1922,6 +1922,11 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     makeRow("3D Span:", 0, 100, 100, m_dssRowSpanSlider, m_dssRowSpanLabel);
     if (m_dssRowSpanSlider) {
         m_dssRowSpanSlider->setObjectName("dssRowSpanSlider");
+        m_dssRowSpanSlider->setAccessibleName(tr("3D Span"));
+        m_dssRowSpanSlider->setAccessibleDescription(
+            tr("How far the nearest 3D traces overhang the plot edges, using "
+               "spectrum from outside the panadapter. 0 keeps the classic "
+               "narrowing trapezoid."));
         m_dssRowSpanSlider->setToolTip(
             "3D surface width: how far the nearest traces overhang the plot "
             "edges,\nusing spectrum the radio sends from outside the "
@@ -1930,7 +1935,9 @@ void SpectrumOverlayMenu::buildDisplayPanel()
             "how much\noffscreen spectrum the source actually provides.");
     }
     connect(m_dssRowSpanSlider, &QSlider::valueChanged, this, [this](int v) {
-        if (m_dssRowSpanLabel) m_dssRowSpanLabel->setText(QString::number(v));
+        if (m_dssRowSpanLabel) {
+            m_dssRowSpanLabel->setText(QString::number(v));
+        }
         emit dssRowSpanChanged(v);
     });
 

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1915,6 +1915,25 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         emit dssGainChanged(v);
     });
 
+    // ── 3D span — how far the near rows overhang the plot edges ───────────
+    // Caps how much of the radio's offscreen spectrum the surface may use to
+    // close the empty wedges beside it. 100 spends everything available, so a
+    // source that ships no overhang is unaffected at any setting.
+    makeRow("3D Span:", 0, 100, 100, m_dssRowSpanSlider, m_dssRowSpanLabel);
+    if (m_dssRowSpanSlider) {
+        m_dssRowSpanSlider->setObjectName("dssRowSpanSlider");
+        m_dssRowSpanSlider->setToolTip(
+            "3D surface width: how far the nearest traces overhang the plot "
+            "edges,\nusing spectrum the radio sends from outside the "
+            "panadapter.\nHigher = the empty wedges beside the surface close "
+            "from the front;\n0 = the classic narrowing trapezoid. Limited by "
+            "how much\noffscreen spectrum the source actually provides.");
+    }
+    connect(m_dssRowSpanSlider, &QSlider::valueChanged, this, [this](int v) {
+        if (m_dssRowSpanLabel) m_dssRowSpanLabel->setText(QString::number(v));
+        emit dssRowSpanChanged(v);
+    });
+
     makeHeader("SYSTEM");
 
     // ── Render GPU (multi-GPU systems only) ───────────────────────────────
@@ -2136,7 +2155,8 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
                                                int renderMode,
                                                int dssFloorDepth,
                                                int dssGain,
-                                               const QColor& lineColor)
+                                               const QColor& lineColor,
+                                               int dssRowSpan)
 {
     if (!m_avgSlider) return;  // panel not built yet
 
@@ -2211,6 +2231,13 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
         QSignalBlocker bc(m_dssGainSlider);
         m_dssGainSlider->setValue(dssGain);
         if (m_dssGainLabel) m_dssGainLabel->setText(QString::number(dssGain));
+    }
+    if (m_dssRowSpanSlider) {
+        QSignalBlocker bs(m_dssRowSpanSlider);
+        m_dssRowSpanSlider->setValue(dssRowSpan);
+        if (m_dssRowSpanLabel) {
+            m_dssRowSpanLabel->setText(QString::number(dssRowSpan));
+        }
     }
 }
 

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1919,7 +1919,8 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     // Caps how much of the radio's offscreen spectrum the surface may use to
     // close the empty wedges beside it. 100 spends everything available, so a
     // source that ships no overhang is unaffected at any setting.
-    makeRow("3D Span:", 0, 100, 100, m_dssRowSpanSlider, m_dssRowSpanLabel);
+    makeRow("3D Span:", 0, 100, 100, m_dssRowSpanSlider, m_dssRowSpanLabel,
+            &m_dssRowSpanTitle);
     if (m_dssRowSpanSlider) {
         m_dssRowSpanSlider->setObjectName("dssRowSpanSlider");
         m_dssRowSpanSlider->setAccessibleName(tr("3D Span"));
@@ -1927,12 +1928,10 @@ void SpectrumOverlayMenu::buildDisplayPanel()
             tr("How far the nearest 3D traces overhang the plot edges, using "
                "spectrum from outside the panadapter. 0 keeps the classic "
                "narrowing trapezoid."));
-        m_dssRowSpanSlider->setToolTip(
-            "3D surface width: how far the nearest traces overhang the plot "
-            "edges,\nusing spectrum the radio sends from outside the "
-            "panadapter.\nHigher = the empty wedges beside the surface close "
-            "from the front;\n0 = the classic narrowing trapezoid. Limited by "
-            "how much\noffscreen spectrum the source actually provides.");
+        // Tooltip text lives in setDssRowSpanSupported() so the enabled and
+        // unavailable wordings cannot drift apart.
+        m_dssRowSpanSupported = false;
+        setDssRowSpanSupported(true);
     }
     connect(m_dssRowSpanSlider, &QSlider::valueChanged, this, [this](int v) {
         if (m_dssRowSpanLabel) {
@@ -2246,6 +2245,33 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
             m_dssRowSpanLabel->setText(QString::number(dssRowSpan));
         }
     }
+}
+
+void SpectrumOverlayMenu::setDssRowSpanSupported(bool supported)
+{
+    if (!m_dssRowSpanSlider || m_dssRowSpanSupported == supported) {
+        return;
+    }
+    m_dssRowSpanSupported = supported;
+    m_dssRowSpanSlider->setEnabled(supported);
+    if (m_dssRowSpanLabel) {
+        m_dssRowSpanLabel->setEnabled(supported);
+    }
+    if (m_dssRowSpanTitle) {
+        m_dssRowSpanTitle->setEnabled(supported);
+    }
+    m_dssRowSpanSlider->setToolTip(supported
+        ? QStringLiteral(
+              "3D surface width: how far the nearest traces overhang the plot "
+              "edges,\nusing spectrum the radio sends from outside the "
+              "panadapter.\nHigher = the empty wedges beside the surface close "
+              "from the front;\n0 = the classic narrowing trapezoid. Limited "
+              "by how much\noffscreen spectrum the source actually provides.")
+        : QStringLiteral(
+              "Unavailable: the 3D view is on the CPU fallback, which always "
+              "draws\nthe narrowing trapezoid. The GPU mesh path this control "
+              "drives\nneeds float (RGBA16F) textures, which this system's "
+              "graphics\ndriver does not report."));
 }
 
 void SpectrumOverlayMenu::setKiwiWaterfallControlMode(bool kiwiMode)

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -59,7 +59,8 @@ public:
                              int renderMode = 0,
                              int dssFloorDepth = 6,
                              int dssGain = 70,
-                             const QColor& lineColor = QColor(0x00, 0xe5, 0xff));
+                             const QColor& lineColor = QColor(0x00, 0xe5, 0xff),
+                             int dssRowSpan = 100);
     // Update only the radio-owned pan processing controls from live status.
     // Signal blockers keep status echoes from generating commands back to the
     // radio.
@@ -184,6 +185,7 @@ signals:
     void spectrumRenderModeChanged(int mode);
     void dssFloorDepthChanged(int dB);
     void dssGainChanged(int pct);
+    void dssRowSpanChanged(int pct);
     void noiseFloorPositionChanged(int pos);
     void noiseFloorEnableChanged(bool on);
     // Emitted when user selects a band from the sub-panel.  stackKeyHint is
@@ -374,6 +376,8 @@ private:
     QLabel*      m_dssFloorLabel{nullptr};
     QSlider*     m_dssGainSlider{nullptr};  // 3DSS colour floor (0-100)
     QLabel*      m_dssGainLabel{nullptr};
+    QSlider*     m_dssRowSpanSlider{nullptr};  // 3DSS wedge close-in (0-100)
+    QLabel*      m_dssRowSpanLabel{nullptr};
     QComboBox*   m_gpuCombo{nullptr};   // render-GPU selector (multi-GPU only)
     QSlider*     m_rateSlider{nullptr};
     QLabel*      m_rateLabel{nullptr};

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -64,6 +64,11 @@ public:
     // Update only the radio-owned pan processing controls from live status.
     // Signal blockers keep status echoes from generating commands back to the
     // radio.
+    // Grey the 3D Span row out when the GPU mesh path is unavailable. The CPU
+    // image fallback ignores rowSpanFactor entirely, so the control would move,
+    // label, and persist while nothing on screen changed.
+    void setDssRowSpanSupported(bool supported);
+
     void syncPanProcessingSettings(int avg, int fps, bool weightedAvg);
     void syncWfLineDuration(int rate);
     void syncKiwiWaterfallSettings(int minDbm, int maxDbm, bool autoScale,
@@ -378,6 +383,8 @@ private:
     QLabel*      m_dssGainLabel{nullptr};
     QSlider*     m_dssRowSpanSlider{nullptr};  // 3DSS wedge close-in (0-100)
     QLabel*      m_dssRowSpanLabel{nullptr};
+    QLabel*      m_dssRowSpanTitle{nullptr};
+    bool         m_dssRowSpanSupported{true};
     QComboBox*   m_gpuCombo{nullptr};   // render-GPU selector (multi-GPU only)
     QSlider*     m_rateSlider{nullptr};
     QLabel*      m_rateLabel{nullptr};

--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -16,6 +16,20 @@ enum class DssOutlinePipelineMode {
 // QRhi's OpenGLES2 backend, which covers desktop GL as well as GLES, reuses the
 // fill program for ribbon outlines: live probes showed flat/stale outlines
 // with a separate, identically configured program.
+// Whether the "3D Span" control can actually affect the display.
+//
+// rowSpanFactor is a dss_mesh.vert uniform, so ONLY the GPU height-map mesh
+// honours it: DssRenderer::rebuild(), the CPU image fallback, ignores it and
+// always draws the narrowing trapezoid. Two independent ways to end up there --
+// a build configured with AETHER_GPU_SPECTRUM=OFF, and a runtime without
+// RGBA16F support leaving m_dssMeshReady false -- and BOTH must disable the
+// control, or it moves, labels and persists while nothing on screen changes,
+// which an operator cannot tell apart from "this source ships no overhang".
+constexpr bool dssRowSpanSupported(bool gpuSpectrumBuild, bool meshReady)
+{
+    return gpuSpectrumBuild && meshReady;
+}
+
 constexpr DssOutlinePipelineMode dssOutlinePipelineModeForBackend(
     bool openGlEs2Backend)
 {

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -130,6 +130,12 @@ bool waterfallFrameResizeFailureForced()
 }
 #endif
 
+#ifdef AETHER_GPU_SPECTRUM
+constexpr bool kGpuSpectrumBuild = true;
+#else
+constexpr bool kGpuSpectrumBuild = false;
+#endif
+
 constexpr int dssFillVerticesPerRow()
 {
     // Two exact-row crossfade layers, each with two triangles per column.
@@ -1921,6 +1927,11 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
 
     // Floating overlay menu (child widget, stays on top)
     m_overlayMenu = new SpectrumOverlayMenu(this);
+    // Start the 3D Span row disabled and let the GPU path prove itself below.
+    // A build without AETHER_GPU_SPECTRUM never reaches that code at all, so
+    // defaulting to enabled would leave the control permanently inert there.
+    m_overlayMenu->setDssRowSpanSupported(
+        AetherSDR::dssRowSpanSupported(kGpuSpectrumBuild, false));
     m_overlayMenu->raise();
 
     m_tnfHoverPopup = new QLabel(this);
@@ -2658,12 +2669,20 @@ void SpectrumWidget::loadDisplay3DSettings(int legacyGain)
 
     const QString raw = AppSettings::instance()
         .value(display3DSettingsKey(), QString()).toString();
-    if (!raw.trimmed().isEmpty()) {
+    if (raw.trimmed().isEmpty()) {
+        // No object yet: this is the one-time migration off the grandfathered
+        // flat Display3DGain key. Persist it NOW, otherwise the flat key would
+        // be re-read on every launch and "the object owns the value" would only
+        // become true once the operator happened to touch a control.
+        saveDisplay3DSettings();
+    } else {
         QJsonParseError error;
         const QJsonDocument doc =
             QJsonDocument::fromJson(raw.toUtf8(), &error);
         if (error.error != QJsonParseError::NoError || !doc.isObject()) {
-            // Keep the defaults rather than half-applying a damaged object.
+            // Keep the defaults rather than half-applying a damaged object, and
+            // deliberately do NOT write: overwriting here would destroy the
+            // evidence and whatever a future version may have stored.
             qCWarning(lcGui).noquote()
                 << "SpectrumWidget: ignoring invalid Display3DSettings"
                 << display3DSettingsKey() << error.errorString();
@@ -2679,6 +2698,8 @@ void SpectrumWidget::loadDisplay3DSettings(int legacyGain)
                     obj.value(QStringLiteral("span")).toInt(m_dssRowSpanPct),
                     0, 100);
             }
+            // An existing object is left exactly as written, including one from
+            // a newer version carrying fields this build does not know about.
         }
     }
 
@@ -12951,7 +12972,8 @@ void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
         // m_dssMeshReady is only final once every pipeline, texture and sampler
         // in initDssMeshPipeline() has succeeded, so ask after it returns
         // rather than from inside it.
-        m_overlayMenu->setDssRowSpanSupported(m_dssMeshReady);
+        m_overlayMenu->setDssRowSpanSupported(
+            AetherSDR::dssRowSpanSupported(kGpuSpectrumBuild, m_dssMeshReady));
     }
     // initDssDepthPipeline() is deliberately NOT called here — its ~458 KB VBO
     // and pipeline are only used on the CPU-image fallback, which most GPU

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2426,6 +2426,8 @@ void SpectrumWidget::loadSettings()
                    0, static_cast<int>(WfColorScheme::Count) - 1));
     m_dssGain = std::clamp(
         s.value(settingsKey("Display3DGain"), "70").toInt(), 0, 100);
+    m_dssRowSpanPct = std::clamp(
+        s.value(settingsKey("Display3DSpan"), "100").toInt(), 0, 100);
     m_spectrumRenderMode = static_cast<SpectrumRenderMode>(
         std::clamp(s.value(settingsKey("DisplaySpectrumRenderMode"), "0").toInt(),
                    0, static_cast<int>(SpectrumRenderMode::Count) - 1));
@@ -2458,7 +2460,7 @@ void SpectrumWidget::loadSettings()
             m_fftHeatMap, static_cast<int>(m_wfColorScheme), m_showGrid,
             m_fftLineWidth, m_wfAutoBlackRadioSide,
             static_cast<int>(m_spectrumRenderMode), dssFloorDepth(),
-            m_dssGain, m_fftLineColor);
+            m_dssGain, m_fftLineColor, m_dssRowSpanPct);
         m_overlayMenu->syncExtraDisplaySettings(m_wfBlankerEnabled,
             m_wfBlankerThreshold, m_bgOpacity, m_freqGridSpacingKhz, m_bgFillColor,
             m_freqScaleFontPt);
@@ -4525,6 +4527,21 @@ void SpectrumWidget::setDssGain(int pct) {
 #endif
         m_dss.invalidate();     // CPU fallback surface re-colours too
     }
+    update();
+}
+
+void SpectrumWidget::setDssRowSpan(int pct) {
+    pct = std::clamp(pct, 0, 100);
+    if (pct == m_dssRowSpanPct) {
+        return;
+    }
+    m_dssRowSpanPct = pct;
+    auto& s = AppSettings::instance();
+    s.setValue(settingsKey("Display3DSpan"), QString::number(pct));
+    s.save();
+    // Geometry only: the mesh reads it as a uniform and the row store is
+    // untouched, so nothing needs re-uploading. The eased approach in
+    // renderGpuFrame carries the change over the next few frames.
     update();
 }
 
@@ -12488,6 +12505,51 @@ void SpectrumWidget::uploadDssPaletteLut(QRhiResourceUpdateBatch* batch,
     m_dssLutToken = token;
 }
 
+float SpectrumWidget::dssRowSpanTarget(double targetBandwidthMhz) const
+{
+    // A/B override: AETHER_DSS_ROW_SPAN=1 pins today's clipped trapezoid, 1.667
+    // forces the widest useful frustum (the near rows overhang the plot and any
+    // column with no data behind it feathers out), anything between scales it.
+    if (qEnvironmentVariableIsSet("AETHER_DSS_ROW_SPAN")) {
+        bool ok = false;
+        const float forced =
+            qEnvironmentVariable("AETHER_DSS_ROW_SPAN").toFloat(&ok);
+        if (ok) {
+            // Wins over the slider: this is the A/B lever, and it must be able
+            // to demand more span than the source can fill so the coverage
+            // feather itself can be exercised.
+            return std::clamp(forced, 1.0f, DssRenderer::kMaxRowSpanFactor);
+        }
+    }
+
+    // The newest row is the live edge and the only one guaranteed to carry a
+    // calibrated tile overhang: Kiwi, the fallback producer, and anything
+    // rebuilt from retained history all drop supplemental, so driving the span
+    // off the minimum across rows would collapse it to 1.0 after every pan.
+    // dss_mesh.vert feathers those rows out per-vertex instead.
+    const double supplementalBandwidthMhz =
+        m_dss.rowSupplementalBandwidthMhzAtAge(0);
+    if (!std::isfinite(targetBandwidthMhz) || targetBandwidthMhz <= 0.0
+        || !std::isfinite(supplementalBandwidthMhz)
+        || supplementalBandwidthMhz <= targetBandwidthMhz) {
+        return 1.0f;
+    }
+
+    // Closing the wedge all the way to the back needs 1 / kBackWidthFrac
+    // (1.667x, i.e. +33% per side). A FLEX waterfall tile runs about 1.2x, which
+    // overhangs the near rows and closes the wedge for the front third.
+    const float available = DssRenderer::rowSpanFactorForOverhang(
+        static_cast<float>(supplementalBandwidthMhz / targetBandwidthMhz));
+
+    // "3D Span" scales how much of the AVAILABLE overhang to spend, not how
+    // much of the absolute maximum. Against a 1.15x tile the absolute reading
+    // would clamp everything above ~22% to the same picture, leaving most of
+    // the travel dead; this way 100 always means "all the source gives" and
+    // every step below it visibly narrows the surface.
+    return 1.0f
+        + (static_cast<float>(m_dssRowSpanPct) / 100.0f) * (available - 1.0f);
+}
+
 void SpectrumWidget::initDssMeshPipeline()
 {
     QRhi* r = rhi();
@@ -13847,7 +13909,20 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
             // UBO would swallow a short initializer list (breaking e.g. preview
             // zoom/pan) without complaint; the shadow descriptors are filled
             // separately below.
-            constexpr int kDssMeshScalarFields = 24;  // through the bgFill vec4
+            // Overhang the near rows past the plot edges by as much as the
+            // offscreen spectrum supports, easing so a zoom or a stream switch
+            // can't snap the silhouette. See dss_mesh.vert's rowSpanFactor.
+            {
+                const float target =
+                    dssRowSpanTarget(dssTargetBandwidthMhz);
+                constexpr float kRowSpanAlpha = 0.12f;
+                m_dssRowSpanFactor += kRowSpanAlpha
+                    * (target - m_dssRowSpanFactor);
+                if (std::abs(target - m_dssRowSpanFactor) < 0.002f) {
+                    m_dssRowSpanFactor = target;
+                }
+            }
+            constexpr int kDssMeshScalarFields = 28;  // through the bgFill vec4
             const float uboScalars[] = {
                 rowOffset,
                 floorDbm, rangeDb, m_dssZCurve,
@@ -13863,6 +13938,10 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                 static_cast<float>(DssRenderer::kVisibleRows),
                 static_cast<float>(specContentW * dpr),
                 static_cast<float>(specRect.height() * dpr),
+                m_dssRowSpanFactor,
+                // std140 rounds the 21-float scalar run up to bgFill's vec4
+                // alignment. These three are the hole, not fields.
+                0.0f, 0.0f, 0.0f,
                 static_cast<float>(m_bgFillColor.redF()),
                 static_cast<float>(m_bgFillColor.greenF()),
                 static_cast<float>(m_bgFillColor.blueF()),
@@ -13877,7 +13956,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
             // Slice shadows are decals evaluated by the DSS shader itself.
             // Because the mask modifies the existing curtain/ridge fragments,
             // it cannot hover above or cut through the rendered surface.
-            constexpr int kShadowBandsOffset = 24;
+            constexpr int kShadowBandsOffset = 28;
             static_assert(kShadowBandsOffset == kDssMeshScalarFields,
                 "shadow descriptors must begin right after the scalar prefix");
             constexpr int kShadowStylesOffset =
@@ -13891,6 +13970,14 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
             const double shadowEndMhz =
                 shadowCenterMhz + shadowBandwidthMhz * 0.5;
             int shadowCount = 0;
+            // A widened row covers frequencies outside the on-screen viewport,
+            // so slice decals now live on [-margin, 1+margin] in target-frame
+            // units rather than [0,1]. margin is 0 at span 1.0, which restores
+            // the old clamps exactly.
+            const float shadowUnitMargin =
+                (m_dssRowSpanFactor - 1.0f) * 0.5f;
+            const float shadowUnitLow = -shadowUnitMargin;
+            const float shadowUnitHigh = 1.0f + shadowUnitMargin;
             const auto unitForShadowMhz = [&](double mhz) {
                 return static_cast<float>(
                     (mhz - shadowStartMhz) / shadowBandwidthMhz);
@@ -13906,9 +13993,12 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                     return false;
                 }
                 const int bandBase = kShadowBandsOffset + shadowCount * 4;
-                ubo.at(bandBase) = std::clamp(low, 0.0f, 1.0f);
-                ubo.at(bandBase + 1) = std::clamp(high, 0.0f, 1.0f);
-                ubo.at(bandBase + 2) = std::clamp(cueCenter, 0.0f, 1.0f);
+                ubo.at(bandBase) =
+                    std::clamp(low, shadowUnitLow, shadowUnitHigh);
+                ubo.at(bandBase + 1) =
+                    std::clamp(high, shadowUnitLow, shadowUnitHigh);
+                ubo.at(bandBase + 2) =
+                    std::clamp(cueCenter, shadowUnitLow, shadowUnitHigh);
                 ubo.at(bandBase + 3) =
                     bandVisible ? (active ? 0.42f : 0.17f) : 0.0f;
                 const int styleBase = kShadowStylesOffset + shadowCount * 4;
@@ -13926,11 +14016,13 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
             // mark+space pair rather than a carrier cue; markerWidth == 0 draws
             // the passband with no cue at all.
             const auto appendShadow = [&](const SliceOverlay& so) {
+                const double shadowMarginMhz =
+                    static_cast<double>(shadowUnitMargin) * shadowBandwidthMhz;
                 if (shadowCount >= kDssMeshShadowSlices
                     || !std::isfinite(shadowBandwidthMhz)
                     || shadowBandwidthMhz <= 0.0
-                    || so.freqMhz < shadowStartMhz
-                    || so.freqMhz > shadowEndMhz) {
+                    || so.freqMhz < shadowStartMhz - shadowMarginMhz
+                    || so.freqMhz > shadowEndMhz + shadowMarginMhz) {
                     return;
                 }
                 float low = unitForShadowMhz(
@@ -13940,7 +14032,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                 if (low > high) {
                     std::swap(low, high);
                 }
-                const bool bandVisible = !(high < 0.0f || low > 1.0f);
+                const bool bandVisible =
+                    !(high < shadowUnitLow || low > shadowUnitHigh);
 
                 struct ShadowCue { float center; QColor color; };
                 std::array<ShadowCue, 2> cues;
@@ -13968,7 +14061,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                 std::array<ShadowCue, 2> visible;
                 int visibleCount = 0;
                 for (int i = 0; i < cueCount; ++i) {
-                    if (cues[i].center >= 0.0f && cues[i].center <= 1.0f) {
+                    if (cues[i].center >= shadowUnitLow
+                        && cues[i].center <= shadowUnitHigh) {
                         visible[visibleCount++] = cues[i];
                     }
                 }

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -12596,13 +12596,22 @@ float SpectrumWidget::dssRowSpanTarget(double targetBandwidthMhz) const
         return kForcedSpan;
     }
 
-    // Age 0 is the live edge and the only row guaranteed to carry a calibrated
-    // tile overhang: Kiwi, the fallback producer, and anything rebuilt from
-    // retained history all drop supplemental, so driving the span off the
-    // minimum across rows would collapse it to 1.0 after every pan.
-    // dss_mesh.vert feathers those rows out per-vertex instead.
+    // Age 0 is NOT authoritative. pushWaterfallRow() -- the FFT-derived producer
+    // that paces rows during TX and during the RX stale-native fallback --
+    // appends with no supplemental at all, so keying up drops age 0's overhang
+    // to zero and would walk the whole surface back to the clipped trapezoid
+    // over ~30 frames, then back out on unkey, on every single over.
+    //
+    // Take the newest row that actually carries a tile instead. dss_mesh.vert
+    // already feathers the rows that genuinely have none, so the host does not
+    // need the front row to be the one with data -- that split is the whole
+    // point of the per-vertex coverage test. Once the last such row scrolls out
+    // of the visible ring there really is no overhang left on screen, and
+    // relaxing to the trapezoid is then the correct answer rather than a
+    // flicker. Also covers Kiwi and anything rebuilt from retained history,
+    // which drop supplemental the same way.
     return DssRenderer::rowSpanFactorFor(
-        m_dss.rowSupplementalBandwidthMhzAtAge(0),
+        m_dss.newestSupplementalBandwidthMhz(targetBandwidthMhz),
         targetBandwidthMhz,
         m_dssRowSpanPct);
 }
@@ -12938,6 +12947,12 @@ void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
     initOverlayPipeline();
     initSpectrumPipeline();
     initDssMeshPipeline();
+    if (m_overlayMenu) {
+        // m_dssMeshReady is only final once every pipeline, texture and sampler
+        // in initDssMeshPipeline() has succeeded, so ask after it returns
+        // rather than from inside it.
+        m_overlayMenu->setDssRowSpanSupported(m_dssMeshReady);
+    }
     // initDssDepthPipeline() is deliberately NOT called here — its ~458 KB VBO
     // and pipeline are only used on the CPU-image fallback, which most GPU
     // systems never hit. Built lazily on first fallback use in renderGpuFrame.

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2426,10 +2426,9 @@ void SpectrumWidget::loadSettings()
     m_wfColorScheme  = static_cast<WfColorScheme>(
         std::clamp(s.value(settingsKey("DisplayWfColorScheme"), "0").toInt(),
                    0, static_cast<int>(WfColorScheme::Count) - 1));
-    m_dssGain = std::clamp(
-        s.value(settingsKey("Display3DGain"), "70").toInt(), 0, 100);
-    m_dssRowSpanPct = std::clamp(
-        s.value(settingsKey("Display3DSpan"), "100").toInt(), 0, 100);
+    // Principle V: the 3D view's controls live in one owned object. The legacy
+    // flat Display3DGain key is grandfathered and only seeds the first load.
+    loadDisplay3DSettings(s.value(settingsKey("Display3DGain"), "70").toInt());
     m_spectrumRenderMode = static_cast<SpectrumRenderMode>(
         std::clamp(s.value(settingsKey("DisplaySpectrumRenderMode"), "0").toInt(),
                    0, static_cast<int>(SpectrumRenderMode::Count) - 1));
@@ -2643,6 +2642,77 @@ void SpectrumWidget::setFftAverage(int frames) {
         m_overlayMenu->syncPanProcessingSettings(
             m_fftAverage, m_fftFps, m_fftWeightedAvg);
     }
+}
+
+QString SpectrumWidget::display3DSettingsKey() const
+{
+    return settingsKey(QStringLiteral("Display3DSettings"));
+}
+
+void SpectrumWidget::loadDisplay3DSettings(int legacyGain)
+{
+    // Defaults first, so an absent or unreadable object still leaves the
+    // feature fully configured — the "one place to default" Principle V wants.
+    m_dssGain = std::clamp(legacyGain, 0, 100);
+    m_dssRowSpanPct = 100;
+
+    const QString raw = AppSettings::instance()
+        .value(display3DSettingsKey(), QString()).toString();
+    if (!raw.trimmed().isEmpty()) {
+        QJsonParseError error;
+        const QJsonDocument doc =
+            QJsonDocument::fromJson(raw.toUtf8(), &error);
+        if (error.error != QJsonParseError::NoError || !doc.isObject()) {
+            // Keep the defaults rather than half-applying a damaged object.
+            qCWarning(lcGui).noquote()
+                << "SpectrumWidget: ignoring invalid Display3DSettings"
+                << display3DSettingsKey() << error.errorString();
+        } else {
+            const QJsonObject obj = doc.object();
+            if (obj.contains(QStringLiteral("gain"))) {
+                m_dssGain = std::clamp(
+                    obj.value(QStringLiteral("gain")).toInt(m_dssGain),
+                    0, 100);
+            }
+            if (obj.contains(QStringLiteral("span"))) {
+                m_dssRowSpanPct = std::clamp(
+                    obj.value(QStringLiteral("span")).toInt(m_dssRowSpanPct),
+                    0, 100);
+            }
+        }
+    }
+
+#ifdef AETHER_GPU_SPECTRUM
+    m_dssLutToken = ~0ull;  // gain feeds the GPU palette LUT
+#endif
+    m_dss.invalidate();     // and the CPU fallback surface colours
+}
+
+void SpectrumWidget::saveDisplay3DSettings()
+{
+    QJsonObject obj;
+    obj.insert(QStringLiteral("version"), 1);
+    obj.insert(QStringLiteral("gain"), std::clamp(m_dssGain, 0, 100));
+    obj.insert(QStringLiteral("span"), std::clamp(m_dssRowSpanPct, 0, 100));
+
+    // One setValue + save for the whole object (Principle XIV): a crash cannot
+    // leave the 3D view half-configured the way per-key writes could.
+    auto& s = AppSettings::instance();
+    s.setValue(display3DSettingsKey(), QString::fromUtf8(
+        QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+    s.save();
+}
+
+void SpectrumWidget::resetDisplay3DSettings()
+{
+    m_dssGain = 70;
+    m_dssRowSpanPct = 100;
+    saveDisplay3DSettings();
+#ifdef AETHER_GPU_SPECTRUM
+    m_dssLutToken = ~0ull;
+#endif
+    m_dss.invalidate();
+    update();
 }
 
 QString SpectrumWidget::displaySourceTraceSettingsKey() const
@@ -4521,9 +4591,7 @@ void SpectrumWidget::setDssGain(int pct) {
     pct = std::clamp(pct, 0, 100);
     if (pct != m_dssGain) {
         m_dssGain = pct;
-        auto& s = AppSettings::instance();
-        s.setValue(settingsKey("Display3DGain"), QString::number(pct));
-        s.save();
+        saveDisplay3DSettings();
 #ifdef AETHER_GPU_SPECTRUM
         m_dssLutToken = ~0ull;  // force the GPU palette LUT to re-bake next frame
 #endif
@@ -4538,9 +4606,7 @@ void SpectrumWidget::setDssRowSpan(int pct) {
         return;
     }
     m_dssRowSpanPct = pct;
-    auto& s = AppSettings::instance();
-    s.setValue(settingsKey("Display3DSpan"), QString::number(pct));
-    s.save();
+    saveDisplay3DSettings();
     // Geometry only: the mesh reads it as a uniform and the row store is
     // untouched, so nothing needs re-uploading. The eased approach in
     // renderGpuFrame carries the change over the next few frames.

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -12509,47 +12509,36 @@ void SpectrumWidget::uploadDssPaletteLut(QRhiResourceUpdateBatch* batch,
 
 float SpectrumWidget::dssRowSpanTarget(double targetBandwidthMhz) const
 {
-    // A/B override: AETHER_DSS_ROW_SPAN=1 pins today's clipped trapezoid, 1.667
-    // forces the widest useful frustum (the near rows overhang the plot and any
-    // column with no data behind it feathers out), anything between scales it.
-    if (qEnvironmentVariableIsSet("AETHER_DSS_ROW_SPAN")) {
+    // A/B override, read once: this sits in the per-frame render path, and the
+    // environment cannot change under a running process. AETHER_DSS_ROW_SPAN=1
+    // pins the classic clipped trapezoid, 1.667 forces the widest useful
+    // frustum. Negative means "unset or unparseable", so the slider decides.
+    //
+    // Unlike the slider it can demand more span than the source can fill, which
+    // is what exercises the coverage feather in dss_mesh.vert.
+    static const float kForcedSpan = [] {
+        if (!qEnvironmentVariableIsSet("AETHER_DSS_ROW_SPAN")) {
+            return -1.0f;
+        }
         bool ok = false;
         const float forced =
             qEnvironmentVariable("AETHER_DSS_ROW_SPAN").toFloat(&ok);
-        if (ok) {
-            // Wins over the slider: this is the A/B lever, and it must be able
-            // to demand more span than the source can fill so the coverage
-            // feather itself can be exercised.
-            return std::clamp(forced, 1.0f, DssRenderer::kMaxRowSpanFactor);
-        }
+        return ok ? std::clamp(forced, 1.0f, DssRenderer::kMaxRowSpanFactor)
+                  : -1.0f;
+    }();
+    if (kForcedSpan > 0.0f) {
+        return kForcedSpan;
     }
 
-    // The newest row is the live edge and the only one guaranteed to carry a
-    // calibrated tile overhang: Kiwi, the fallback producer, and anything
-    // rebuilt from retained history all drop supplemental, so driving the span
-    // off the minimum across rows would collapse it to 1.0 after every pan.
+    // Age 0 is the live edge and the only row guaranteed to carry a calibrated
+    // tile overhang: Kiwi, the fallback producer, and anything rebuilt from
+    // retained history all drop supplemental, so driving the span off the
+    // minimum across rows would collapse it to 1.0 after every pan.
     // dss_mesh.vert feathers those rows out per-vertex instead.
-    const double supplementalBandwidthMhz =
-        m_dss.rowSupplementalBandwidthMhzAtAge(0);
-    if (!std::isfinite(targetBandwidthMhz) || targetBandwidthMhz <= 0.0
-        || !std::isfinite(supplementalBandwidthMhz)
-        || supplementalBandwidthMhz <= targetBandwidthMhz) {
-        return 1.0f;
-    }
-
-    // Closing the wedge all the way to the back needs 1 / kBackWidthFrac
-    // (1.667x, i.e. +33% per side). A FLEX waterfall tile runs about 1.2x, which
-    // overhangs the near rows and closes the wedge for the front third.
-    const float available = DssRenderer::rowSpanFactorForOverhang(
-        static_cast<float>(supplementalBandwidthMhz / targetBandwidthMhz));
-
-    // "3D Span" scales how much of the AVAILABLE overhang to spend, not how
-    // much of the absolute maximum. Against a 1.15x tile the absolute reading
-    // would clamp everything above ~22% to the same picture, leaving most of
-    // the travel dead; this way 100 always means "all the source gives" and
-    // every step below it visibly narrows the surface.
-    return 1.0f
-        + (static_cast<float>(m_dssRowSpanPct) / 100.0f) * (available - 1.0f);
+    return DssRenderer::rowSpanFactorFor(
+        m_dss.rowSupplementalBandwidthMhzAtAge(0),
+        targetBandwidthMhz,
+        m_dssRowSpanPct);
 }
 
 void SpectrumWidget::initDssMeshPipeline()

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -133,15 +133,17 @@ bool waterfallFrameResizeFailureForced()
 constexpr int dssFillVerticesPerRow()
 {
     // Two exact-row crossfade layers, each with two triangles per column.
-    // Together with the matching ribbon VBO this is about 20.2 MiB of static
-    // vertex storage at 768 columns x 96 visible rows (about 7.3 MiB before
-    // fixed-grid crossfading). It is built once, never rebuilt while scrolling.
-    return (DssRenderer::kCols - 1) * 6 * 2;
+    // Together with the matching ribbon VBO this is about 33.7 MiB of static
+    // vertex storage at kMeshCols (1280) columns x 96 visible rows. It is built
+    // once, never rebuilt while scrolling. The column count is kMeshCols rather
+    // than kCols so the on-screen part of a row widened by rowSpanFactor still
+    // samples the height texture at least once per texel — see kMeshCols.
+    return (DssRenderer::kMeshCols - 1) * 6 * 2;
 }
 
 constexpr int dssLineVerticesPerRow()
 {
-    return (DssRenderer::kCols - 1) * 6 * 2;
+    return (DssRenderer::kMeshCols - 1) * 6 * 2;
 }
 
 constexpr int kMaxWaterfallRowsPerUpdate = 1;
@@ -12596,8 +12598,11 @@ void SpectrumWidget::initDssMeshPipeline()
         return;
     }
 
-    // Height sampled in the vertex stage; Nearest is enough (the grid is as dense
-    // as the texture). Palette is Linear for a smooth floor->peak gradient.
+    // Height sampled in the vertex stage; Nearest is enough because the mesh grid
+    // is never sparser than the texture — kMeshCols is sized so that even at the
+    // widest rowSpanFactor the on-screen columns still cover every texel, so no
+    // bin can fall between two samples. Palette is Linear for a smooth
+    // floor->peak gradient.
     m_dssHeightSampler = r->newSampler(QRhiSampler::Nearest, QRhiSampler::Nearest,
         QRhiSampler::None, QRhiSampler::ClampToEdge, QRhiSampler::ClampToEdge);
     m_dssPaletteSampler = r->newSampler(QRhiSampler::Linear, QRhiSampler::Linear,
@@ -12892,7 +12897,9 @@ void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
     // 3DSS mesh: build the static perspective grid once (geometry never changes —
     // height comes from the ring-buffered texture sampled per-vertex).
     if (m_dssMeshReady) {
-        const int cols = m_dss.cols();
+        // Mesh columns, NOT texture columns: the mesh is wider than the
+        // viewport so a widened row keeps texel density on screen.
+        const int cols = DssRenderer::kMeshCols;
         const int rows = DssRenderer::kVisibleRows;
         QVector<float> fill;
         QVector<float> line;
@@ -13920,6 +13927,13 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                     * (target - m_dssRowSpanFactor);
                 if (std::abs(target - m_dssRowSpanFactor) < 0.002f) {
                     m_dssRowSpanFactor = target;
+                } else {
+                    // The ease advances one step per PRESENTED frame, so it has
+                    // to keep its own frames coming. Without this it stalls
+                    // wherever the last repaint left it whenever nothing else is
+                    // driving the pane — an idle or disconnected stream leaves
+                    // the slider reading 100 over a half-widened surface.
+                    coalescedUpdate();
                 }
             }
             constexpr int kDssMeshScalarFields = 28;  // through the bgFill vec4
@@ -13939,9 +13953,10 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                 static_cast<float>(specContentW * dpr),
                 static_cast<float>(specRect.height() * dpr),
                 m_dssRowSpanFactor,
-                // std140 rounds the 21-float scalar run up to bgFill's vec4
-                // alignment. These three are the hole, not fields.
-                0.0f, 0.0f, 0.0f,
+                static_cast<float>(DssRenderer::kMeshCols),
+                // std140 rounds the 22-float scalar run up to bgFill's vec4
+                // alignment. These two are the hole, not fields.
+                0.0f, 0.0f,
                 static_cast<float>(m_bgFillColor.redF()),
                 static_cast<float>(m_bgFillColor.greenF()),
                 static_cast<float>(m_bgFillColor.blueF()),

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -517,6 +517,11 @@ public:
     // strong signals only (gamma-shapes the palette lookup). Persisted per-pan.
     void setDssGain(int pct);
     int  dssGain() const { return m_dssGain; }
+    // 3DSS row span (0-100): how far the nearest traces may overhang the plot
+    // edges to close the empty wedges beside the surface, as a fraction of the
+    // widest useful span. Capped by the offscreen spectrum the source provides.
+    void setDssRowSpan(int pct);
+    int  dssRowSpan() const { return m_dssRowSpanPct; }
     void resetWfTimeScale();
     int   wfColorGain() const          { return m_wfColorGain; }
     int   wfBlackLevel() const         { return m_wfBlackLevel; }
@@ -1448,6 +1453,7 @@ private:
     float m_flexDssFloorDepth{6.0f};
     float m_kiwiDssFloorDepth{6.0f};
     int   m_dssGain{70};   // 3DSS colour floor 0-100 (gamma of palette lookup)
+    int   m_dssRowSpanPct{100};  // 3DSS wedge close-in 0-100 (see setDssRowSpan)
     float m_dssFloorAnchorDbm{-1000.0f};
     bool  m_dssFloorAnchorValid{false};
     DssZoomFloorSyncGate m_dssZoomFloorSync;
@@ -1958,11 +1964,11 @@ private:
     QRhiBuffer* m_dssMeshLineVbo{nullptr};   // batched ridge ribbons, static
     QRhiBuffer* m_dssMeshUbo{nullptr};       // dynamic uniforms
     // std140 UBO float count — must match dss_mesh.{vert,frag}'s U block AND the
-    // ubo writer in renderGpuFrame(): five scalar vec4 groups + bgFill, eight
-    // slice band descriptors, eight slice styles, shadow metadata, and one
-    // frequency-frame vec4 for every live-ring age.
+    // ubo writer in renderGpuFrame(): 21 scalars padded out to a vec4 boundary,
+    // bgFill, eight slice band descriptors, eight slice styles, shadow metadata,
+    // and one frequency-frame vec4 for every live-ring age.
     static constexpr int kDssMeshUboFloats =
-        92 + DssRenderer::kRows * 4;
+        96 + DssRenderer::kRows * 4;
     static_assert(
         DssRenderer::kRows == 104,
         "dss_mesh.{vert,frag} declare rowFrames[104] and clamp frame ages "
@@ -1980,8 +1986,14 @@ private:
     quint64 m_dssLutToken{~0ull};            // token of the palette LUT last baked
     QByteArray m_dssRowScratch;              // reused qfloat16 row buffer (mesh upload)
     QByteArray m_dssTextureScratch;          // reused qfloat16 full texture buffer
+    // Smoothed dss_mesh rowSpanFactor. 1.0 keeps the classic clipped trapezoid,
+    // so a backend shipping no supplemental overhang renders exactly as before.
+    float m_dssRowSpanFactor{1.0f};
 
     void initDssMeshPipeline();
+    // Frequency span each mesh row should cover, as a multiple of the on-screen
+    // bandwidth. See dss_mesh.vert's rowSpanFactor.
+    float dssRowSpanTarget(double targetBandwidthMhz) const;
     void uploadDssPaletteLut(QRhiResourceUpdateBatch* batch, float floorDbm, float rangeDb);
 
     // Distance-faded slice/passband shadows painted across the completed DSS

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -1465,7 +1465,15 @@ private:
     float m_flexDssFloorDepth{6.0f};
     float m_kiwiDssFloorDepth{6.0f};
     int   m_dssGain{70};   // 3DSS colour floor 0-100 (gamma of palette lookup)
-    int   m_dssRowSpanPct{100};  // 3DSS wedge close-in 0-100 (see setDssRowSpan)
+    // 3DSS wedge close-in 0-100 (see setDssRowSpan). Defaults to 100 -- fully
+    // ON -- by deliberate product decision, not by omission: three reviewers
+    // read 0 as the safer default since it is the reference rendering. The
+    // control is buried in the Display overlay's 3D VIEW section, so shipping
+    // it off would mean most operators never discover the feature exists.
+    // Anyone who wants the classic trapezoid has a labelled slider; anyone who
+    // does not know to look gets the intended view. Do not flip this to 0
+    // without also solving the discoverability side.
+    int   m_dssRowSpanPct{100};
     float m_dssFloorAnchorDbm{-1000.0f};
     bool  m_dssFloorAnchorValid{false};
     DssZoomFloorSyncGate m_dssZoomFloorSync;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -522,6 +522,11 @@ public:
     // widest useful span. Capped by the offscreen spectrum the source provides.
     void setDssRowSpan(int pct);
     int  dssRowSpan() const { return m_dssRowSpanPct; }
+    // Re-read the owned 3D config object (profile recall re-applies it per pan).
+    // legacyGain seeds 3D Gain when no object has been written yet.
+    void loadDisplay3DSettings(int legacyGain = 70);
+    // Restore both 3D controls to defaults and persist the object as a unit.
+    void resetDisplay3DSettings();
     void resetWfTimeScale();
     int   wfColorGain() const          { return m_wfColorGain; }
     int   wfBlackLevel() const         { return m_wfBlackLevel; }
@@ -1175,6 +1180,13 @@ private:
     // can persist; startup/enable/layout refreshes only rebuild transient state.
     void refreshNoiseFloorTarget(bool captureCurrentScale = false, bool persistCapture = false);
     bool captureNoiseFloorTargetFromCurrentScale(bool notify, bool persist);
+    // ── Display3DSettings — the 3D view's owned configuration object ───────
+    // Principle V: one self-contained, versioned, atomically-written object
+    // rather than loose flat keys. Holds the 3D Gain and 3D Span controls.
+    // (3D Floor is per-source and already owned by DisplaySourceTraceSettings.)
+    QString display3DSettingsKey() const;
+    void saveDisplay3DSettings();
+
     QString displaySourceTraceSettingsKey() const;
     void loadDisplaySourceTraceSettings(int legacyNoiseFloorPosition,
                                         int legacyDssFloorDepth);

--- a/tests/dss_renderer_test.cpp
+++ b/tests/dss_renderer_test.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <limits>
 #include <utility>
 
 namespace {
@@ -556,6 +557,112 @@ int testDcEdgeSpikeFlattening()
     return 0;
 }
 
+int testRowSpanGeometry()
+{
+    constexpr float kMax = DssRenderer::kMaxRowSpanFactor;
+
+    // Span 1.0 is a strict identity: the CPU fallback and every existing caller
+    // depend on today's rendering being untouched when no overhang exists.
+    for (const float meshUnit : {0.0f, 0.25f, 0.5f, 1.0f}) {
+        if (std::abs(DssRenderer::rowFrequencyUnit(meshUnit, 1.0f) - meshUnit)
+                > 0.0001f) {
+            return fail("span 1.0 must map mesh columns to themselves");
+        }
+    }
+    for (const float depth : {0.0f, 0.5f, 1.0f}) {
+        if (std::abs(DssRenderer::rowScreenCoverage(depth, 1.0f)
+                     - DssRenderer::depthScale(depth)) > 0.0001f) {
+            return fail("span 1.0 must leave row coverage untouched");
+        }
+    }
+    if (DssRenderer::wedgeFreeDepth(1.0f) != 0.0f) {
+        return fail("span 1.0 must close no part of the wedge");
+    }
+
+    // The point of the whole change: at the widest useful span the NEAR rows
+    // overhang the plot and the DEEPEST row lands exactly on its edge, so no
+    // depth is left with a wedge.
+    if (!(DssRenderer::rowScreenCoverage(0.0f, kMax) > 1.0f)) {
+        return fail("the front row must overhang the plot edges");
+    }
+    if (std::abs(DssRenderer::rowScreenCoverage(1.0f, kMax) - 1.0f) > 0.0001f) {
+        return fail("the deepest row must land exactly on the plot edge");
+    }
+    if (std::abs(DssRenderer::wedgeFreeDepth(kMax) - 1.0f) > 0.0001f) {
+        return fail("the widest span must close the wedge at every depth");
+    }
+    // Coverage must fall monotonically front to back and never dip below the
+    // plot until the wedge-free depth is passed.
+    float previous = DssRenderer::rowScreenCoverage(0.0f, kMax);
+    for (int step = 1; step <= 20; ++step) {
+        const float depth = static_cast<float>(step) / 20.0f;
+        const float coverage = DssRenderer::rowScreenCoverage(depth, kMax);
+        if (coverage > previous + 0.0001f) {
+            return fail("row coverage must narrow with depth");
+        }
+        if (coverage < 1.0f - 0.0001f) {
+            return fail("no row may fall inside the plot at the widest span");
+        }
+        previous = coverage;
+    }
+
+    // A partial overhang closes the wedge from the FRONT, and wedgeFreeDepth
+    // must agree with where coverage actually crosses the plot edge.
+    constexpr float kFlexSpan = 1.2f;   // a FLEX tile runs about 1.2x
+    const float flexSpan = DssRenderer::rowSpanFactorForOverhang(kFlexSpan);
+    if (std::abs(flexSpan - kFlexSpan) > 0.0001f) {
+        return fail("an overhang below the cap should be used in full");
+    }
+    if (!(DssRenderer::rowScreenCoverage(0.0f, flexSpan) > 1.0f)
+        || !(DssRenderer::rowScreenCoverage(1.0f, flexSpan) < 1.0f)) {
+        return fail("a partial overhang must overhang the front and not the back");
+    }
+    const float crossing = DssRenderer::wedgeFreeDepth(flexSpan);
+    if (!(crossing > 0.0f) || !(crossing < 1.0f)) {
+        return fail("a partial overhang must close part of the wedge");
+    }
+    if (std::abs(DssRenderer::rowScreenCoverage(crossing, flexSpan) - 1.0f)
+            > 0.0001f) {
+        return fail("wedgeFreeDepth must be where coverage reaches the edge");
+    }
+
+    // Data past the cap is off-plot; taking it would only overhang further.
+    if (std::abs(DssRenderer::rowSpanFactorForOverhang(4.0f) - kMax) > 0.0001f) {
+        return fail("overhang beyond the cap must clamp");
+    }
+    // No overhang, or a degenerate one, must keep the clipped trapezoid rather
+    // than widening into spectrum that was never captured.
+    if (DssRenderer::rowSpanFactorForOverhang(1.0f) != 1.0f
+        || DssRenderer::rowSpanFactorForOverhang(0.5f) != 1.0f
+        || DssRenderer::rowSpanFactorForOverhang(
+               std::numeric_limits<float>::quiet_NaN()) != 1.0f) {
+        return fail("a missing overhang must keep the clipped trapezoid");
+    }
+
+    // The projection must be span-INDEPENDENT: widening changes what a row
+    // covers, never where a frequency lands. This is what keeps the converging
+    // slant, the frequency ruler and every marker exactly where they were.
+    for (const float span : {1.0f, 1.2f, kMax}) {
+        for (const float depth : {0.0f, 0.4f, 1.0f}) {
+            constexpr float kSignalUnit = 0.3f;
+            // Solve for the mesh column carrying this frequency, project it,
+            // and it must land on the unwidened position.
+            const float meshUnit = 0.5f + (kSignalUnit - 0.5f) / span;
+            const float freqUnit =
+                DssRenderer::rowFrequencyUnit(meshUnit, span);
+            const double screenX =
+                0.5 + (freqUnit - 0.5) * DssRenderer::depthScale(depth);
+            if (std::abs(screenX
+                         - DssRenderer::projectPerspective(
+                               kSignalUnit, depth).x()) > 0.0001) {
+                return fail("widening a row must not move an in-band signal");
+            }
+        }
+    }
+
+    return 0;
+}
+
 int testPerspectiveProjection()
 {
     const QPointF frontLeft =
@@ -701,6 +808,9 @@ int main()
         return rc;
     }
     if (int rc = testDcEdgeSpikeFlattening(); rc != 0) {
+        return rc;
+    }
+    if (int rc = testRowSpanGeometry(); rc != 0) {
         return rc;
     }
     if (int rc = testPerspectiveProjection(); rc != 0) {

--- a/tests/dss_renderer_test.cpp
+++ b/tests/dss_renderer_test.cpp
@@ -557,6 +557,64 @@ int testDcEdgeSpikeFlattening()
     return 0;
 }
 
+int testOverhangSurvivesUncoveredRows()
+{
+    // Reproduces the transmit case: the FFT-derived producer that paces rows
+    // during TX appends with NO supplemental, so the front row loses its
+    // overhang while the rest of the screen still has it. Driving the span off
+    // the front row alone collapsed the whole surface on every over.
+    constexpr double kTargetBw = 0.2;
+    constexpr double kTileBw = 0.24;
+    DssRenderer renderer;
+    QVector<float> fft(DssRenderer::kCols, -95.0f);
+    QVector<float> tile(DssRenderer::kCols, -100.0f);
+
+    for (int i = 0; i < 8; ++i) {
+        renderer.pushRowWithSupplemental(
+            fft, 14.1, kTargetBw, tile, 14.1, kTileBw);
+    }
+    if (std::abs(renderer.newestSupplementalBandwidthMhz(kTargetBw) - kTileBw)
+            > 1.0e-9) {
+        return fail("a covered front row must report its own overhang");
+    }
+
+    // Key up: several supplemental-less rows arrive on top.
+    for (int i = 0; i < 5; ++i) {
+        renderer.pushRow(fft, 14.1, kTargetBw);
+    }
+    if (renderer.rowSupplementalBandwidthMhzAtAge(0) != 0.0) {
+        return fail("the transmit-era front row should carry no overhang");
+    }
+    if (std::abs(renderer.newestSupplementalBandwidthMhz(kTargetBw) - kTileBw)
+            > 1.0e-9) {
+        return fail("overhang must survive uncovered rows at the front while "
+                    "covered rows are still on screen");
+    }
+
+    // Once every covered row has scrolled out of the VISIBLE ring there really
+    // is no overhang on screen, and reporting none is then correct.
+    for (int i = 0; i < DssRenderer::kVisibleRows; ++i) {
+        renderer.pushRow(fft, 14.1, kTargetBw);
+    }
+    if (renderer.newestSupplementalBandwidthMhz(kTargetBw) != 0.0) {
+        return fail("overhang must lapse once no covered row remains visible");
+    }
+
+    // A tile no wider than the viewport is not an overhang, and a degenerate
+    // target must not be divided by downstream.
+    DssRenderer narrow;
+    narrow.pushRowWithSupplemental(fft, 14.1, kTargetBw, tile, 14.1, kTargetBw);
+    if (narrow.newestSupplementalBandwidthMhz(kTargetBw) != 0.0) {
+        return fail("a tile no wider than the viewport is not an overhang");
+    }
+    if (renderer.newestSupplementalBandwidthMhz(0.0) != 0.0
+        || renderer.newestSupplementalBandwidthMhz(
+               std::numeric_limits<double>::quiet_NaN()) != 0.0) {
+        return fail("a degenerate viewport width must report no overhang");
+    }
+    return 0;
+}
+
 int testRowSpanTaper()
 {
     constexpr float kMax = DssRenderer::kMaxRowSpanFactor;
@@ -879,6 +937,9 @@ int main()
         return rc;
     }
     if (int rc = testDcEdgeSpikeFlattening(); rc != 0) {
+        return rc;
+    }
+    if (int rc = testOverhangSurvivesUncoveredRows(); rc != 0) {
         return rc;
     }
     if (int rc = testRowSpanTaper(); rc != 0) {

--- a/tests/dss_renderer_test.cpp
+++ b/tests/dss_renderer_test.cpp
@@ -557,6 +557,77 @@ int testDcEdgeSpikeFlattening()
     return 0;
 }
 
+int testRowSpanTaper()
+{
+    constexpr float kMax = DssRenderer::kMaxRowSpanFactor;
+    const auto span = [](double supp, double target, int pct) {
+        return DssRenderer::rowSpanFactorFor(supp, target, pct);
+    };
+
+    // A source with no usable overhang must keep the clipped trapezoid at EVERY
+    // setting — the slider must never widen into spectrum never captured.
+    for (const int pct : {0, 50, 100}) {
+        if (span(0.2, 0.2, pct) != 1.0f        // exactly the viewport
+            || span(0.1, 0.2, pct) != 1.0f     // narrower than the viewport
+            || span(0.0, 0.2, pct) != 1.0f) {
+            return fail("no overhang must keep the clipped trapezoid");
+        }
+    }
+
+    // Degenerate frames must not widen either. A zero/negative target would
+    // divide by zero and a NaN would poison the mesh uniform.
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    const double inf = std::numeric_limits<double>::infinity();
+    for (const int pct : {0, 100}) {
+        if (span(0.23, 0.0, pct) != 1.0f
+            || span(0.23, -0.2, pct) != 1.0f
+            || span(0.23, nan, pct) != 1.0f
+            || span(nan, 0.2, pct) != 1.0f
+            || span(inf, 0.2, pct) != 1.0f
+            || span(0.23, inf, pct) != 1.0f) {
+            return fail("a degenerate frequency frame must not widen the mesh");
+        }
+    }
+
+    // The percentage scales the AVAILABLE span, not the absolute maximum: with
+    // a 1.2x tile, 100 must reach exactly 1.2 and 50 exactly halfway. An
+    // absolute reading would put 50 at 1.333 and clamp it back to 1.2, which is
+    // the dead-travel bug this mapping exists to avoid.
+    if (std::abs(span(0.24, 0.2, 100) - 1.2f) > 0.0001f) {
+        return fail("100% must spend the whole available overhang");
+    }
+    if (std::abs(span(0.24, 0.2, 50) - 1.1f) > 0.0001f) {
+        return fail("50% must spend half the available overhang");
+    }
+    if (span(0.24, 0.2, 0) != 1.0f) {
+        return fail("0% must restore the clipped trapezoid");
+    }
+
+    // Monotone in the setting, so every step of the control does something.
+    float previous = span(0.24, 0.2, 0);
+    for (int pct = 10; pct <= 100; pct += 10) {
+        const float current = span(0.24, 0.2, pct);
+        if (!(current > previous)) {
+            return fail("every step of the span control must widen the surface");
+        }
+        previous = current;
+    }
+
+    // An overhang past the cap saturates rather than overhanging pointlessly.
+    if (std::abs(span(2.0, 0.2, 100) - kMax) > 0.0001f) {
+        return fail("an overhang beyond the cap must saturate");
+    }
+
+    // Out-of-range settings clamp rather than extrapolating past the cap or
+    // inverting the surface.
+    if (span(0.24, 0.2, -50) != 1.0f
+        || std::abs(span(0.24, 0.2, 500) - 1.2f) > 0.0001f) {
+        return fail("the span setting must clamp to 0..100");
+    }
+
+    return 0;
+}
+
 int testRowSpanGeometry()
 {
     constexpr float kMax = DssRenderer::kMaxRowSpanFactor;
@@ -808,6 +879,9 @@ int main()
         return rc;
     }
     if (int rc = testDcEdgeSpikeFlattening(); rc != 0) {
+        return rc;
+    }
+    if (int rc = testRowSpanTaper(); rc != 0) {
         return rc;
     }
     if (int rc = testRowSpanGeometry(); rc != 0) {

--- a/tests/spectrum_preview_logic_test.cpp
+++ b/tests/spectrum_preview_logic_test.cpp
@@ -20,6 +20,30 @@ bool nearlyEqual(double a, double b, double epsilon = 1.0e-12)
     return std::abs(a - b) <= epsilon;
 }
 
+int testDssRowSpanSupported()
+{
+    using namespace AetherSDR;
+
+    // A build without AETHER_GPU_SPECTRUM has no mesh pipeline at all, so the
+    // control can never affect the display whatever the runtime reports. This
+    // is the case that shipped enabled: the only runtime correction lived
+    // inside the GPU-only block, so the software build never corrected it and
+    // the slider moved, labelled and persisted over a fallback that ignores it.
+    if (dssRowSpanSupported(false, false) || dssRowSpanSupported(false, true)) {
+        return fail("a CPU-only build must never offer the 3D span control");
+    }
+
+    // A GPU build still has to prove the mesh came up — RGBA16F support is a
+    // runtime property, and without it the CPU image fallback draws instead.
+    if (dssRowSpanSupported(true, false)) {
+        return fail("a GPU build without the mesh must not offer the control");
+    }
+    if (!dssRowSpanSupported(true, true)) {
+        return fail("the control must be offered once the mesh is ready");
+    }
+    return 0;
+}
+
 int testCursorAnchoredZoom()
 {
     using namespace AetherSDR;
@@ -971,6 +995,9 @@ int testDssSupplementalCoverageCalibration()
 
 int main()
 {
+    if (const int result = testDssRowSpanSupported(); result != 0) {
+        return result;
+    }
     if (const int result = testCursorAnchoredZoom(); result != 0) {
         return result;
     }


### PR DESCRIPTION
Closes #4778

## What this does

In 3D Stacked Trace mode every row covers the **same** frequency span while the
far rows narrow to `kBackWidthFrac` (0.60), so the surface leaves two empty
black triangles flanking it.

This widens the span each row *covers* instead of the geometry that *places*
it. The near rows then run off both edges of the plot and the existing
perspective narrowing walks them back in with depth, so the wedge closes from
the front.

The projection is deliberately untouched — a frequency still lands at
`0.5 + (freq - 0.5) * depthScale` — so **the converging slant of a signal
through depth, the frequency ruler, and every marker stay exactly where they
were.** Only what a row *covers* changed, never where a frequency lands.

The extra spectrum was already plumbed: `buildDssSupplementalCoverage()`
calibrates the native FLEX waterfall tile (wider than the panadapter) into
per-row supplemental channels, and `dss_mesh.vert` already sampled them outside
an FFT row's captured frame. Only the geometry was clipping them away.

## What to test

There's a new **3D Span** slider under 3D Gain (Display → 3D VIEW).

- **0** restores today's rendering exactly. Please confirm it does — that is the
  regression guard for anyone who doesn't want this.
- **100** spends all the overhang the source provides.
- The slider scales the *available* span, not the absolute maximum, so 100
  always means "everything the radio gives" and every step below it visibly
  narrows the surface. (An absolute mapping left most of the travel dead
  against a ~1.15x tile.)

Worth a careful look at the **band-edge markers, the frequency ruler, and slice
passband shading** — those are what a geometry change like this breaks quietly.
A signal should sit at the same horizontal position it always did; only the
extra spectrum beyond the ruler ends is new.

Non-FLEX sources ship no overhang, so Kiwi, the fallback producer, and the CPU
image fallback render exactly as before at any slider setting.

`AETHER_DSS_ROW_SPAN=1.0..1.667` overrides the slider and, unlike the slider,
can demand more span than the source can fill — that is what exercises the
coverage feather.

## Expected rough edges

These are **known and tracked in #4778**, not regressions to file:

- Pan or zoom and the overhang collapses until fresh rows arrive. The retained
  history ring stores no supplemental and both reprojection paths wipe it.
  Same in scrollback.
- The deepest rows can show a ragged silhouette where per-row coverage runs
  out — only rows carrying supplemental extend.
- The CPU image fallback (no RGBA16F) still draws the clipped trapezoid, so it
  now visibly diverges from the GPU mesh path.

## Verification

Measured offscreen under Xvfb at a matched 0.2 MHz span against a 1.153x
overhang, driving the slider over the automation bridge. Surface left edge in
px, front to back:

| slider | left edge, front → back |
|---|---|
| 0 | 540 → 460 → 380 → 299 → 219 → 144 |
| 50 | 475 → 386 → 297 → 216 → 130 → 44 |
| 100 | 410 → 319 → 226 → 137 → 41 → **0** |

Monotone, closing from the front, with the residual at the back exactly where
`wedgeFreeDepth(1.153) = 0.33` predicts. Confirmed on a live FLEX-8600.

`237/237` tests pass, including new coverage for the span-1.0 identity, front
overhang, monotone narrowing, `wedgeFreeDepth`/coverage agreement, and that
widening never moves an in-band signal. `tools/check_shader_dialects.py` passes
— the new varying and uniform compile in all four baked GLSL slices
(130/140/150/300es).

🤖 Generated with [Claude Code](https://claude.com/claude-code)