### PR TITLE
fix(windows): ship vcomp140.dll app-local so the app starts without a system redist (#4781)

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -290,10 +290,21 @@ jobs:
       - name: Stage MSVC runtime for installer
         run: |
           powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\stage-msvc-runtime.ps1 -OutputDir installer-runtime
+          # Copied into deploy\ here rather than in the portable-ZIP step so the
+          # audit below sees the SAME payload all three artifacts ship (portable
+          # ZIP, Inno installer, MSIX all derive from deploy\ + this runtime).
+          Copy-Item -Path installer-runtime\*.dll -Destination deploy\ -Force
+
+      # Hard gate for the missing-runtime class (#4781: vcomp140.dll was never
+      # staged, so the app died at startup on any machine whose system-wide VC++
+      # redistributable had been removed or downgraded by another installer).
+      # Runs before any artifact is built, so a payload that isn't self-contained
+      # never reaches the ZIP, the installer, the MSIX or the release.
+      - name: Verify deploy payload is self-contained
+        run: powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\check-deploy-dependencies.ps1 -DeployDir deploy
 
       - name: Create portable ZIP
         run: |
-          # Keep portable ZIP app-local runtime behavior aligned with the installer.
           # Sanitize github.ref_name — release-tag pushes give a slash-free
           # "v26.5.3" but workflow_dispatch on a branch ref like
           # "codex/windows-store-msix" injects slashes that break the
@@ -301,7 +312,6 @@ jobs:
           # character so ad-hoc dispatch runs (e.g. validating new packaging
           # work on a branch) reach the later Inno + MSIX steps instead of
           # exiting 1 at the very first artifact-creation step.
-          Copy-Item -Path installer-runtime\*.dll -Destination deploy\ -Force
           $safeRefName = "${{ github.ref_name }}" -replace '[\\/:*?"<>|]', '_'
           Compress-Archive -Path deploy\* -DestinationPath "AetherSDR-$safeRefName-Windows-x64-portable.zip"
 

--- a/packaging/windows/check-deploy-dependencies.ps1
+++ b/packaging/windows/check-deploy-dependencies.ps1
@@ -35,6 +35,11 @@
     Override the Windows system directory used to resolve OS DLLs.
 #>
 
+# Keep this file ASCII-only -- see the note at the top of stage-msvc-runtime.ps1.
+# Both scripts are invoked with `powershell` (5.1), where a UTF-8 em-dash inside
+# a double-quoted string terminates that string under CP1252 decoding and the
+# file fails to parse.
+
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
@@ -46,7 +51,7 @@ param(
 $ErrorActionPreference = "Stop"
 
 # msvcrt.dll (no digits after the prefix) is the OS-provided legacy CRT and is
-# intentionally NOT matched — only the redistributable, versioned runtimes are.
+# intentionally NOT matched -- only the redistributable, versioned runtimes are.
 #
 # An "mfc" hit means "add the Microsoft.VC<nnn>.MFC redist directory to
 # stage-msvc-runtime.ps1", not "the payload is broken": MFC ships in a third
@@ -96,7 +101,7 @@ function Get-PeDependencies {
     # Scope ErrorActionPreference around the native call. Windows PowerShell 5.1
     # (what the CI step invokes, not pwsh 7) turns each stderr line of a native
     # command redirected with 2>&1 into an ErrorRecord, and under "Stop" that is
-    # a terminating NativeCommandError raised before $LASTEXITCODE is read — so
+    # a terminating NativeCommandError raised before $LASTEXITCODE is read -- so
     # a benign dumpbin warning (LNK4048 on a file that is not a well-formed PE)
     # would kill the job with an opaque error instead of the message below.
     $output = & {
@@ -148,7 +153,7 @@ function Test-DependencySatisfied {
         return "shipped"
     }
 
-    # Checked before the System32 probe on purpose — see the header comment.
+    # Checked before the System32 probe on purpose -- see the header comment.
     if ($Name -match $RuntimeDllPattern) {
         return "missing-runtime"
     }
@@ -181,8 +186,8 @@ if (-not $images) {
 }
 
 # Index every shipped file by bare name, including the ones in subdirectories.
-# That is deliberately more permissive than the real loader — a DLL sitting only
-# in deploy\imageformats\ would not satisfy an import from deploy\platforms\ —
+# That is deliberately more permissive than the real loader -- a DLL sitting only
+# in deploy\imageformats\ would not satisfy an import from deploy\platforms\ --
 # and it errs toward passing on purpose: a false failure blocking a release is
 # worse than missing an exotic cross-plugin case.
 $shippedFiles = @{}
@@ -199,18 +204,18 @@ foreach ($image in $images) {
     foreach ($dep in $deps.Direct) {
         $verdict = Test-DependencySatisfied -Name $dep -ShippedFiles $shippedFiles -SystemDirectory $SystemDir
         if ($verdict -eq "missing-runtime") {
-            $failures += "$($image.Name) imports $dep — MSVC runtime not staged app-local"
+            $failures += "$($image.Name) imports $dep -- MSVC runtime not staged app-local"
         } elseif ($verdict -eq "missing") {
-            $failures += "$($image.Name) imports $dep — not in the payload and not a system DLL"
+            $failures += "$($image.Name) imports $dep -- not in the payload and not a system DLL"
         }
     }
 
     foreach ($dep in $deps.Delayed) {
         $verdict = Test-DependencySatisfied -Name $dep -ShippedFiles $shippedFiles -SystemDirectory $SystemDir
         if ($verdict -eq "missing-runtime") {
-            $failures += "$($image.Name) delay-loads $dep — MSVC runtime not staged app-local"
+            $failures += "$($image.Name) delay-loads $dep -- MSVC runtime not staged app-local"
         } elseif ($verdict -eq "missing") {
-            $warnings += "$($image.Name) delay-loads $dep — not in the payload and not a system DLL"
+            $warnings += "$($image.Name) delay-loads $dep -- not in the payload and not a system DLL"
         }
     }
 }

--- a/packaging/windows/check-deploy-dependencies.ps1
+++ b/packaging/windows/check-deploy-dependencies.ps1
@@ -47,6 +47,12 @@ $ErrorActionPreference = "Stop"
 
 # msvcrt.dll (no digits after the prefix) is the OS-provided legacy CRT and is
 # intentionally NOT matched — only the redistributable, versioned runtimes are.
+#
+# An "mfc" hit means "add the Microsoft.VC<nnn>.MFC redist directory to
+# stage-msvc-runtime.ps1", not "the payload is broken": MFC ships in a third
+# sibling of the CRT/OpenMP dirs that the staging script does not copy. Very
+# unlikely for a Qt app, but the entry stays so it fails loudly rather than
+# resolving from the machine's redistributable.
 $RuntimeDllPattern = '^(msvcp|msvcr|vcruntime|vcomp|concrt|vccorlib|mfc)\d'
 $ApiSetPattern     = '^(api-ms-win-|ext-ms-)'
 
@@ -87,7 +93,16 @@ function Get-PeDependencies {
         [string]$ImagePath
     )
 
-    $output = & $Dumpbin /nologo /dependents $ImagePath 2>&1
+    # Scope ErrorActionPreference around the native call. Windows PowerShell 5.1
+    # (what the CI step invokes, not pwsh 7) turns each stderr line of a native
+    # command redirected with 2>&1 into an ErrorRecord, and under "Stop" that is
+    # a terminating NativeCommandError raised before $LASTEXITCODE is read — so
+    # a benign dumpbin warning (LNK4048 on a file that is not a well-formed PE)
+    # would kill the job with an opaque error instead of the message below.
+    $output = & {
+        $ErrorActionPreference = "Continue"
+        & $Dumpbin /nologo /dependents $ImagePath 2>&1
+    }
     if ($LASTEXITCODE -ne 0) {
         throw "dumpbin failed on ${ImagePath}: $($output -join [Environment]::NewLine)"
     }
@@ -165,8 +180,11 @@ if (-not $images) {
     throw "No .dll/.exe images found under $resolvedDeployDir."
 }
 
-# Every shipped file resolves an import, not just the ones we walk — Qt plugins
-# live in subdirectories but load from the app directory, so index by name.
+# Index every shipped file by bare name, including the ones in subdirectories.
+# That is deliberately more permissive than the real loader — a DLL sitting only
+# in deploy\imageformats\ would not satisfy an import from deploy\platforms\ —
+# and it errs toward passing on purpose: a false failure blocking a release is
+# worse than missing an exotic cross-plugin case.
 $shippedFiles = @{}
 foreach ($image in $images) {
     $shippedFiles[$image.Name.ToLowerInvariant()] = $true

--- a/packaging/windows/check-deploy-dependencies.ps1
+++ b/packaging/windows/check-deploy-dependencies.ps1
@@ -1,0 +1,211 @@
+<#
+.SYNOPSIS
+    Fail the build when the Windows payload is not self-contained.
+
+.DESCRIPTION
+    Walks the import table of every PE in the deploy directory (dumpbin
+    /dependents) and classifies each imported DLL:
+
+      * present in the deploy directory        -> ships with us, fine
+      * an MSVC runtime (vcomp/msvcp/...)      -> MUST ship with us, else FAIL
+      * a Windows system DLL or API set        -> fine, the OS provides it
+      * anything else                          -> FAIL, nothing provides it
+
+    The MSVC-runtime rule is deliberately checked BEFORE the system-DLL rule.
+    Build machines have the VC++ redistributable installed, so those DLLs do
+    resolve from System32 on the runner and a plain "does it resolve here?"
+    test passes while users' machines fail. That is exactly how #4781 shipped:
+    AetherSDR.exe imports vcomp140.dll (ggml is built with /openmp), nothing
+    staged it, and it went unnoticed through every release since ASR landed
+    because CI never inspected the payload. Same class as the OpenSSL crash in
+    #1341/#1362.
+
+    Delay-load imports are held to the runtime rule but only warned about
+    otherwise: a missing delay-load is a run-time feature failure rather than a
+    startup failure, and Qt/ONNX Runtime delay-load optional OS components.
+
+.PARAMETER DeployDir
+    Directory holding the final payload (post runtime staging).
+
+.PARAMETER DumpbinPath
+    Override the dumpbin executable. Defaults to dumpbin on PATH (MSVC dev
+    environment), then a vswhere lookup.
+
+.PARAMETER SystemDir
+    Override the Windows system directory used to resolve OS DLLs.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$DeployDir,
+    [string]$DumpbinPath,
+    [string]$SystemDir = (Join-Path $env:SystemRoot "System32")
+)
+
+$ErrorActionPreference = "Stop"
+
+# msvcrt.dll (no digits after the prefix) is the OS-provided legacy CRT and is
+# intentionally NOT matched — only the redistributable, versioned runtimes are.
+$RuntimeDllPattern = '^(msvcp|msvcr|vcruntime|vcomp|concrt|vccorlib|mfc)\d'
+$ApiSetPattern     = '^(api-ms-win-|ext-ms-)'
+
+function Resolve-Dumpbin {
+    param([string]$Explicit)
+
+    if ($Explicit) {
+        if (-not (Test-Path -LiteralPath $Explicit)) {
+            throw "dumpbin not found at $Explicit"
+        }
+        return $Explicit
+    }
+
+    $onPath = Get-Command dumpbin -ErrorAction SilentlyContinue
+    if ($onPath) {
+        return $onPath.Source
+    }
+
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+    if (Test-Path -LiteralPath $vswhere) {
+        $vsRoot = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+        if ($vsRoot) {
+            $found = Get-ChildItem -LiteralPath (Join-Path $vsRoot "VC\Tools\MSVC") -Recurse -Filter "dumpbin.exe" -ErrorAction SilentlyContinue |
+                Where-Object { $_.FullName -match "\\bin\\Hostx64\\x64\\dumpbin\.exe$" } |
+                Select-Object -First 1
+            if ($found) {
+                return $found.FullName
+            }
+        }
+    }
+
+    throw "dumpbin.exe not found. Run this from an MSVC developer environment or pass -DumpbinPath."
+}
+
+function Get-PeDependencies {
+    param(
+        [string]$Dumpbin,
+        [string]$ImagePath
+    )
+
+    $output = & $Dumpbin /nologo /dependents $ImagePath 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "dumpbin failed on ${ImagePath}: $($output -join [Environment]::NewLine)"
+    }
+
+    $direct = @()
+    $delayed = @()
+    $section = "none"
+
+    foreach ($rawLine in $output) {
+        $line = "$rawLine".Trim()
+
+        if ($line -match 'following delay load dependencies:') { $section = "delay"; continue }
+        if ($line -match 'following dependencies:')            { $section = "direct"; continue }
+        if ($line -eq "Summary")                               { $section = "none"; continue }
+        if ($section -eq "none" -or -not $line)                { continue }
+
+        # Dependency lines are bare file names; anything else ends the section.
+        if ($line -notmatch '^[^\s]+\.dll$') {
+            $section = "none"
+            continue
+        }
+
+        if ($section -eq "direct") { $direct += $line } else { $delayed += $line }
+    }
+
+    return [pscustomobject]@{
+        Direct  = $direct
+        Delayed = $delayed
+    }
+}
+
+function Test-DependencySatisfied {
+    <#
+        Returns 'shipped', 'system', 'missing-runtime' or 'missing'.
+    #>
+    param(
+        [string]$Name,
+        [hashtable]$ShippedFiles,
+        [string]$SystemDirectory
+    )
+
+    if ($ShippedFiles.ContainsKey($Name.ToLowerInvariant())) {
+        return "shipped"
+    }
+
+    # Checked before the System32 probe on purpose — see the header comment.
+    if ($Name -match $RuntimeDllPattern) {
+        return "missing-runtime"
+    }
+
+    if ($Name -match $ApiSetPattern) {
+        return "system"
+    }
+
+    if ($SystemDirectory -and (Test-Path -LiteralPath (Join-Path $SystemDirectory $Name))) {
+        return "system"
+    }
+
+    return "missing"
+}
+
+$resolvedDeployDir = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($DeployDir)
+if (-not (Test-Path -LiteralPath $resolvedDeployDir)) {
+    throw "Deploy directory not found: $resolvedDeployDir"
+}
+
+$dumpbin = Resolve-Dumpbin -Explicit $DumpbinPath
+Write-Host "Auditing $resolvedDeployDir with $dumpbin"
+
+$images = Get-ChildItem -LiteralPath $resolvedDeployDir -Recurse -File |
+    Where-Object { $_.Extension -in ".dll", ".exe" } |
+    Sort-Object FullName
+
+if (-not $images) {
+    throw "No .dll/.exe images found under $resolvedDeployDir."
+}
+
+# Every shipped file resolves an import, not just the ones we walk — Qt plugins
+# live in subdirectories but load from the app directory, so index by name.
+$shippedFiles = @{}
+foreach ($image in $images) {
+    $shippedFiles[$image.Name.ToLowerInvariant()] = $true
+}
+
+$failures = @()
+$warnings = @()
+
+foreach ($image in $images) {
+    $deps = Get-PeDependencies -Dumpbin $dumpbin -ImagePath $image.FullName
+
+    foreach ($dep in $deps.Direct) {
+        $verdict = Test-DependencySatisfied -Name $dep -ShippedFiles $shippedFiles -SystemDirectory $SystemDir
+        if ($verdict -eq "missing-runtime") {
+            $failures += "$($image.Name) imports $dep — MSVC runtime not staged app-local"
+        } elseif ($verdict -eq "missing") {
+            $failures += "$($image.Name) imports $dep — not in the payload and not a system DLL"
+        }
+    }
+
+    foreach ($dep in $deps.Delayed) {
+        $verdict = Test-DependencySatisfied -Name $dep -ShippedFiles $shippedFiles -SystemDirectory $SystemDir
+        if ($verdict -eq "missing-runtime") {
+            $failures += "$($image.Name) delay-loads $dep — MSVC runtime not staged app-local"
+        } elseif ($verdict -eq "missing") {
+            $warnings += "$($image.Name) delay-loads $dep — not in the payload and not a system DLL"
+        }
+    }
+}
+
+foreach ($warning in $warnings) {
+    Write-Warning $warning
+}
+
+if ($failures) {
+    foreach ($failure in $failures) {
+        Write-Host "MISSING: $failure"
+    }
+    throw "Windows payload is not self-contained: $($failures.Count) unresolved dependenc$(if ($failures.Count -eq 1) { 'y' } else { 'ies' })."
+}
+
+Write-Host "Payload is self-contained: $($images.Count) images audited, every import resolves app-local or to the OS."

--- a/packaging/windows/installer.iss
+++ b/packaging/windows/installer.iss
@@ -43,7 +43,7 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 
 [Files]
 #ifdef VC_RUNTIME_DIR
-Source: "..\..\deploy\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs; Excludes: "concrt140.dll,msvcp140*.dll,vccorlib140.dll,vcruntime140*.dll"
+Source: "..\..\deploy\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs; Excludes: "concrt140.dll,msvcp140*.dll,vccorlib140.dll,vcruntime140*.dll,vcomp140*.dll"
 Source: "{#VC_RUNTIME_DIR}\*.dll"; DestDir: "{app}"; Flags: ignoreversion
 #else
 Source: "..\..\deploy\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs

--- a/packaging/windows/stage-msvc-runtime.ps1
+++ b/packaging/windows/stage-msvc-runtime.ps1
@@ -7,6 +7,18 @@
     Studio/MSVC environment and copies its DLLs to a staging directory for
     Inno Setup. Prefer VCToolsRedistDir because GitHub Actions initializes it
     through ilammy/msvc-dev-cmd before packaging.
+
+    The OpenMP runtime (vcomp140.dll) ships in a SEPARATE redist directory,
+    Microsoft.VC<nnn>.OpenMP, sitting next to the CRT one — it is not in
+    Microsoft.VC*.CRT. ggml is compiled with /openmp (GGML_OPENMP defaults ON)
+    and its static libs carry /DEFAULTLIB:"VCOMP", so AetherSDR.exe imports
+    vcomp140.dll directly. Staging only the CRT left that one import to be
+    satisfied by whatever machine-wide redistributable happened to be present,
+    and any other installer repairing/downgrading/removing it produced
+    "VCOMP140.DLL was not found" on startup — unfixable by reinstalling
+    AetherSDR, because the file was never in our payload (#4781). Both
+    directories are staged here, version-matched, so the payload is
+    self-contained.
 #>
 
 [CmdletBinding()]
@@ -71,19 +83,47 @@ if (-not $runtimeDir) {
     throw "Could not find an x64 Microsoft.VC*.CRT runtime directory. Make sure the MSVC redist components are installed."
 }
 
+# Take the OpenMP redist as a SIBLING of the chosen CRT directory rather than
+# searching independently: siblings share the toolset version by construction,
+# so vcomp140.dll can never end up mismatched against the CRT it was built with.
+$redistArchRoot = Split-Path -Parent $runtimeDir.FullName
+$openMpDir = Get-ChildItem -LiteralPath $redistArchRoot -Directory -Filter "Microsoft.VC*.OpenMP" -ErrorAction SilentlyContinue |
+    Sort-Object FullName |
+    Select-Object -First 1
+
+if (-not $openMpDir) {
+    # Hard failure, not a warning. Silently omitting this DLL is precisely the
+    # bug in #4781, and a broken installer is far more expensive than a red CI
+    # run. The OpenMP redist installs with the "MSVC v143 - VS 2022 C++ x64/x86
+    # build tools" component that already provides the CRT redist next to it.
+    throw "Could not find a Microsoft.VC*.OpenMP runtime directory next to $($runtimeDir.FullName). " +
+          "AetherSDR.exe imports vcomp140.dll (ggml is built with /openmp), so it must ship app-local. " +
+          "Install the MSVC v143 C++ build tools redist component and retry."
+}
+
 $resolvedOutputDir = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($OutputDir)
 New-Item -ItemType Directory -Force -Path $resolvedOutputDir | Out-Null
 
-$runtimeDlls = Get-ChildItem -LiteralPath $runtimeDir.FullName -File -Filter "*.dll"
-if (-not $runtimeDlls) {
-    throw "No runtime DLLs found in $($runtimeDir.FullName)."
+$sourceDirs = @($runtimeDir, $openMpDir)
+foreach ($sourceDir in $sourceDirs) {
+    $runtimeDlls = Get-ChildItem -LiteralPath $sourceDir.FullName -File -Filter "*.dll"
+    if (-not $runtimeDlls) {
+        throw "No runtime DLLs found in $($sourceDir.FullName)."
+    }
+
+    foreach ($dll in $runtimeDlls) {
+        Copy-Item -LiteralPath $dll.FullName -Destination $resolvedOutputDir -Force
+    }
+
+    Write-Host "Staged MSVC runtime from $($sourceDir.FullName)"
 }
 
-foreach ($dll in $runtimeDlls) {
-    Copy-Item -LiteralPath $dll.FullName -Destination $resolvedOutputDir -Force
+# Guard the one file this whole script exists to guarantee: a future refactor
+# that loses it again must fail here, not in a user's startup dialog.
+if (-not (Test-Path -LiteralPath (Join-Path $resolvedOutputDir "vcomp140.dll"))) {
+    throw "vcomp140.dll was not staged from $($openMpDir.FullName) — the payload would fail to start on machines without a system-wide VC++ redistributable."
 }
 
-Write-Host "Staged MSVC runtime from $($runtimeDir.FullName)"
 Get-ChildItem -LiteralPath $resolvedOutputDir -File -Filter "*.dll" |
     Sort-Object Name |
     ForEach-Object { Write-Host "  $($_.Name)" }

--- a/packaging/windows/stage-msvc-runtime.ps1
+++ b/packaging/windows/stage-msvc-runtime.ps1
@@ -9,17 +9,25 @@
     through ilammy/msvc-dev-cmd before packaging.
 
     The OpenMP runtime (vcomp140.dll) ships in a SEPARATE redist directory,
-    Microsoft.VC<nnn>.OpenMP, sitting next to the CRT one — it is not in
+    Microsoft.VC<nnn>.OpenMP, sitting next to the CRT one -- it is not in
     Microsoft.VC*.CRT. ggml is compiled with /openmp (GGML_OPENMP defaults ON)
     and its static libs carry /DEFAULTLIB:"VCOMP", so AetherSDR.exe imports
     vcomp140.dll directly. Staging only the CRT left that one import to be
     satisfied by whatever machine-wide redistributable happened to be present,
     and any other installer repairing/downgrading/removing it produced
-    "VCOMP140.DLL was not found" on startup — unfixable by reinstalling
+    "VCOMP140.DLL was not found" on startup -- unfixable by reinstalling
     AetherSDR, because the file was never in our payload (#4781). Both
     directories are staged here, version-matched, so the payload is
     self-contained.
 #>
+
+# Keep this file ASCII-only. CI runs it with `powershell` (Windows PowerShell
+# 5.1), which decodes a BOM-less .ps1 as the ANSI codepage: a UTF-8 em-dash
+# becomes the three characters `a"` in CP1252, and PowerShell honours that curly
+# quote as a string delimiter. Inside a double-quoted string that ends the string
+# early and the whole file fails to PARSE -- not a cosmetic mojibake, a script
+# that never runs. The sibling scripts under scripts/setup/ do contain non-ASCII
+# and are fine only because the workflow invokes those with `pwsh` (UTF-8).
 
 [CmdletBinding()]
 param(
@@ -88,7 +96,7 @@ if (-not $runtimeDir) {
 # above sorts descending to take the newest, so an independent search with its
 # own ordering could silently pick a different toolset the moment the redist
 # layout stops being version-scoped. Deriving the name makes the version match
-# an invariant rather than a coincidence — Microsoft.VC143.CRT pairs with
+# an invariant rather than a coincidence -- Microsoft.VC143.CRT pairs with
 # Microsoft.VC143.OpenMP, and nothing else.
 $redistArchRoot = Split-Path -Parent $runtimeDir.FullName
 $openMpDirName = $runtimeDir.Name -replace '\.CRT$', '.OpenMP'
@@ -126,7 +134,7 @@ foreach ($sourceDir in $sourceDirs) {
 # Guard the one file this whole script exists to guarantee: a future refactor
 # that loses it again must fail here, not in a user's startup dialog.
 if (-not (Test-Path -LiteralPath (Join-Path $resolvedOutputDir "vcomp140.dll"))) {
-    throw "vcomp140.dll was not staged from $($openMpDir.FullName) — the payload would fail to start on machines without a system-wide VC++ redistributable."
+    throw "vcomp140.dll was not staged from $($openMpDir.FullName) -- the payload would fail to start on machines without a system-wide VC++ redistributable."
 }
 
 Get-ChildItem -LiteralPath $resolvedOutputDir -File -Filter "*.dll" |

--- a/packaging/windows/stage-msvc-runtime.ps1
+++ b/packaging/windows/stage-msvc-runtime.ps1
@@ -83,12 +83,17 @@ if (-not $runtimeDir) {
     throw "Could not find an x64 Microsoft.VC*.CRT runtime directory. Make sure the MSVC redist components are installed."
 }
 
-# Take the OpenMP redist as a SIBLING of the chosen CRT directory rather than
-# searching independently: siblings share the toolset version by construction,
-# so vcomp140.dll can never end up mismatched against the CRT it was built with.
+# Take the OpenMP redist as a SIBLING of the chosen CRT directory, deriving its
+# name from that directory instead of globbing independently: the CRT search
+# above sorts descending to take the newest, so an independent search with its
+# own ordering could silently pick a different toolset the moment the redist
+# layout stops being version-scoped. Deriving the name makes the version match
+# an invariant rather than a coincidence — Microsoft.VC143.CRT pairs with
+# Microsoft.VC143.OpenMP, and nothing else.
 $redistArchRoot = Split-Path -Parent $runtimeDir.FullName
-$openMpDir = Get-ChildItem -LiteralPath $redistArchRoot -Directory -Filter "Microsoft.VC*.OpenMP" -ErrorAction SilentlyContinue |
-    Sort-Object FullName |
+$openMpDirName = $runtimeDir.Name -replace '\.CRT$', '.OpenMP'
+$expectedOpenMpDir = Join-Path $redistArchRoot $openMpDirName
+$openMpDir = Get-ChildItem -LiteralPath $redistArchRoot -Directory -Filter $openMpDirName -ErrorAction SilentlyContinue |
     Select-Object -First 1
 
 if (-not $openMpDir) {
@@ -96,7 +101,7 @@ if (-not $openMpDir) {
     # bug in #4781, and a broken installer is far more expensive than a red CI
     # run. The OpenMP redist installs with the "MSVC v143 - VS 2022 C++ x64/x86
     # build tools" component that already provides the CRT redist next to it.
-    throw "Could not find a Microsoft.VC*.OpenMP runtime directory next to $($runtimeDir.FullName). " +
+    throw "Could not find the OpenMP runtime directory $expectedOpenMpDir (sibling of the chosen CRT redist $($runtimeDir.FullName)). " +
           "AetherSDR.exe imports vcomp140.dll (ggml is built with /openmp), so it must ship app-local. " +
           "Install the MSVC v143 C++ build tools redist component and retry."
 }

--- a/scripts/build-windows-local.ps1
+++ b/scripts/build-windows-local.ps1
@@ -4,7 +4,7 @@
 
 .DESCRIPTION
     Mirrors .github/workflows/windows-installer.yml end-to-end so a native build
-    produces the same artifact as CI — but on hardware with enough cores/RAM that
+    produces the same artifact as CI -- but on hardware with enough cores/RAM that
     the full ASR + GPU (whisper Vulkan) build finishes fast instead of hitting the
     GitHub runner's 6-hour timeout. (That timeout is a 4-core/16 GB free-runner
     resource limit, not a real build problem; a 32-core box with plenty of RAM
@@ -12,7 +12,7 @@
 
     Stages the third_party deps via the same setup-*.ps1 scripts CI uses,
     configures with the release flags (ASR ONNX + sherpa + GPU Vulkan all
-    REQUIRED — fail-loud if a runtime is missing), builds, deploys Qt + all
+    REQUIRED -- fail-loud if a runtime is missing), builds, deploys Qt + all
     runtime DLLs (ONNX Runtime, sherpa-onnx, vulkan-1), and optionally packages
     the Inno Setup installer.
 
@@ -33,7 +33,7 @@
 
 .PARAMETER Jobs
     Build parallelism. Defaults to the CPU count. Do NOT copy CI's -j2 workaround
-    here — that was only for the 4-core/16 GB runner.
+    here -- that was only for the 4-core/16 GB runner.
 
 .PARAMETER Installer
     Also build the Inno Setup installer (needs ISCC.exe). Otherwise stops after
@@ -76,7 +76,7 @@ if (-not $QtDir -or -not (Test-Path "$QtDir\bin\windeployqt.exe")) {
 Write-Host "  MSVC + CMake + Ninja OK; Qt = $QtDir; jobs = $Jobs" -ForegroundColor Green
 
 # ---------------------------------------------------------------------------
-# 1. third_party deps — the exact scripts CI runs (each is idempotent/cached).
+# 1. third_party deps -- the exact scripts CI runs (each is idempotent/cached).
 # ---------------------------------------------------------------------------
 Write-Host "== Staging third_party deps ==" -ForegroundColor Cyan
 foreach ($s in @(
@@ -97,7 +97,7 @@ if (-not $env:VULKAN_SDK) {
 Write-Host "  VULKAN_SDK = $env:VULKAN_SDK" -ForegroundColor Green
 
 # ---------------------------------------------------------------------------
-# 2. Configure — same flags as windows-installer.yml (minus the empty vcpkg
+# 2. Configure -- same flags as windows-installer.yml (minus the empty vcpkg
 #    toolchain vars; zlib is vendored). CMAKE_PREFIX_PATH points CMake at Qt and
 #    the Vulkan SDK (glslc + SPIRV-Headers) so REQUIRE_ASR_GPU can succeed.
 # ---------------------------------------------------------------------------
@@ -112,7 +112,7 @@ if ($LASTEXITCODE -ne 0) { throw "configure failed" }
 
 # ---------------------------------------------------------------------------
 # 3. Build. Opus first (ExternalProject ordering), then everything at full -j.
-#    No ggml-vulkan isolation / -j2 needed here — that was a CI-runner workaround.
+#    No ggml-vulkan isolation / -j2 needed here -- that was a CI-runner workaround.
 # ---------------------------------------------------------------------------
 Write-Host "== Build (opus, then full -j$Jobs) ==" -ForegroundColor Cyan
 cmake --build build --target build_opus -j $Jobs
@@ -121,7 +121,7 @@ cmake --build build -j $Jobs
 if ($LASTEXITCODE -ne 0) { throw "build failed" }
 
 # ---------------------------------------------------------------------------
-# 4. Deploy — mirror the workflow's "Deploy Qt" step.
+# 4. Deploy -- mirror the workflow's "Deploy Qt" step.
 # ---------------------------------------------------------------------------
 Write-Host "== Deploy ==" -ForegroundColor Cyan
 $deploy = "$repo\deploy"
@@ -152,7 +152,7 @@ Get-ChildItem build\*.dll -ErrorAction SilentlyContinue | ForEach-Object {
 }
 # Vulkan loader (whisper GPU): the exe hard-links it, so it must ship. Its
 # location varies by SDK layout (runtime\x64 on newer SDKs, Bin on older) with a
-# driver copy in System32 — take the first that exists.
+# driver copy in System32 -- take the first that exists.
 $vkCandidates = @(
     (Join-Path $env:VULKAN_SDK "runtime\x64\vulkan-1.dll"),
     (Join-Path $env:VULKAN_SDK "Bin\vulkan-1.dll"),
@@ -166,27 +166,27 @@ Write-Host "  deploy\ staged ($((Get-ChildItem $deploy).Count) items)" -Foregrou
 # Quick sanity: confirm the GPU + ASR runtimes actually landed in the payload.
 foreach ($need in @("vulkan-1.dll", "onnxruntime.dll")) {
     if (-not (Test-Path "$deploy\$need")) {
-        Write-Warning "expected $need not present in deploy\ — check the build config"
+        Write-Warning "expected $need not present in deploy\ -- check the build config"
     }
 }
 
 # ---------------------------------------------------------------------------
-# 5. (optional) Installer — Inno Setup, mirroring the workflow's packaging.
+# 5. (optional) Installer -- Inno Setup, mirroring the workflow's packaging.
 # ---------------------------------------------------------------------------
 if ($Installer) {
     Assert-Tool iscc "Install Inno Setup 6 (provides ISCC.exe) to build the installer."
     Write-Host "== Staging MSVC runtime + building installer ==" -ForegroundColor Cyan
     & powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\stage-msvc-runtime.ps1 -OutputDir installer-runtime
     # Surface the staging script's own message. Without this the common local
-    # failure — a VS install missing the OpenMP redist component — shows up as
+    # failure -- a VS install missing the OpenMP redist component -- shows up as
     # the Copy-Item below erroring on an absent directory, which reads as a path
     # problem rather than "install the MSVC v143 redist component".
-    if ($LASTEXITCODE -ne 0) { throw "MSVC runtime staging failed — see the output above." }
+    if ($LASTEXITCODE -ne 0) { throw "MSVC runtime staging failed -- see the output above." }
     Copy-Item installer-runtime\*.dll $deploy\ -Force
-    # Same gate CI runs — catch a payload that leans on the machine's own VC++
+    # Same gate CI runs -- catch a payload that leans on the machine's own VC++
     # redistributable here rather than on a user's machine (#4781).
     & powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\check-deploy-dependencies.ps1 -DeployDir $deploy
-    if ($LASTEXITCODE -ne 0) { throw "deploy\ payload is not self-contained — see the audit output above." }
+    if ($LASTEXITCODE -ne 0) { throw "deploy\ payload is not self-contained -- see the audit output above." }
     $version = (Get-Content CMakeLists.txt | Select-String -Pattern 'project\(AetherSDR VERSION (\d+\.\d+\.\d+)' | ForEach-Object { $_.Matches[0].Groups[1].Value } | Select-Object -First 1)
     if (-not $version) { $version = "0.0.0-local" }
     $runtimeDir = (Resolve-Path "installer-runtime").Path

--- a/scripts/build-windows-local.ps1
+++ b/scripts/build-windows-local.ps1
@@ -178,6 +178,10 @@ if ($Installer) {
     Write-Host "== Staging MSVC runtime + building installer ==" -ForegroundColor Cyan
     & powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\stage-msvc-runtime.ps1 -OutputDir installer-runtime
     Copy-Item installer-runtime\*.dll $deploy\ -Force
+    # Same gate CI runs — catch a payload that leans on the machine's own VC++
+    # redistributable here rather than on a user's machine (#4781).
+    & powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\check-deploy-dependencies.ps1 -DeployDir $deploy
+    if ($LASTEXITCODE -ne 0) { throw "deploy\ payload is not self-contained — see the audit output above." }
     $version = (Get-Content CMakeLists.txt | Select-String -Pattern 'project\(AetherSDR VERSION (\d+\.\d+\.\d+)' | ForEach-Object { $_.Matches[0].Groups[1].Value } | Select-Object -First 1)
     if (-not $version) { $version = "0.0.0-local" }
     $runtimeDir = (Resolve-Path "installer-runtime").Path

--- a/scripts/build-windows-local.ps1
+++ b/scripts/build-windows-local.ps1
@@ -177,6 +177,11 @@ if ($Installer) {
     Assert-Tool iscc "Install Inno Setup 6 (provides ISCC.exe) to build the installer."
     Write-Host "== Staging MSVC runtime + building installer ==" -ForegroundColor Cyan
     & powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\stage-msvc-runtime.ps1 -OutputDir installer-runtime
+    # Surface the staging script's own message. Without this the common local
+    # failure — a VS install missing the OpenMP redist component — shows up as
+    # the Copy-Item below erroring on an absent directory, which reads as a path
+    # problem rather than "install the MSVC v143 redist component".
+    if ($LASTEXITCODE -ne 0) { throw "MSVC runtime staging failed — see the output above." }
     Copy-Item installer-runtime\*.dll $deploy\ -Force
     # Same gate CI runs — catch a payload that leans on the machine's own VC++
     # redistributable here rather than on a user's machine (#4781).


### PR DESCRIPTION
Fixes #4781.

## The bug

`AetherSDR.exe` genuinely imports `VCOMP140.DLL` — the MSVC OpenMP runtime — and our Windows packaging never shipped it.

`GGML_OPENMP` defaults `ON` (`third_party/whisper.cpp/ggml/CMakeLists.txt:246`) and we never force it off, so ggml is compiled with `/openmp`. The prebuilt `whisper-gpu-1.9.1-windows-x86_64` static libs we link against confirm it:

```
ggml-base.lib:  /DEFAULTLIB:"MSVCRT" /DEFAULTLIB:"OLDNAMES" /DEFAULTLIB:"VCOMP"
                _vcomp_fork, _vcomp_barrier, _vcomp_for_dynamic_init, ...
ggml-cpu.lib:   /DEFAULTLIB:"VCOMP"
                _vcomp_fork, _vcomp_set_num_threads, _vcomp_single_begin, ...
```

Those are static libs linked straight into the exe, which is why the failure dialog names `AetherSDR.exe` rather than a plugin DLL.

`stage-msvc-runtime.ps1` only searched for `Microsoft.VC*.CRT`. That directory holds `msvcp140*.dll`, `vcruntime140*.dll`, `concrt140.dll` and `vccorlib140.dll` — **not** `vcomp140.dll`, which ships in a sibling redist directory, `Microsoft.VC143.OpenMP`. `windeployqt` didn't cover it either (invoked without `--compiler-runtime`).

So we shipped *everything else* app-local and left `vcomp140.dll` as the single machine-wide dependency in the entire payload. Any other installer that repaired, downgraded or removed the VC++ redistributable took AetherSDR down while nothing else on the machine noticed — and reinstalling AetherSDR couldn't fix it, because the file was never in our payload. All three artifacts were affected: Inno installer, portable ZIP, and MSIX.

## The fix

**Stage the OpenMP redist** as a *sibling* of the CRT directory the script already selects, deriving its name from that directory (`Microsoft.VC143.CRT` → `Microsoft.VC143.OpenMP`) rather than globbing for it independently. The two selections then cannot diverge, so `vcomp140.dll` can never be mismatched against the CRT it was built with. A missing or empty OpenMP redist is a hard failure rather than a warning — silently omitting this DLL is precisely the bug. `installer.iss` excludes `vcomp140*.dll` from `deploy\` alongside the other CRT DLLs so the staged copy stays authoritative.

**Add `check-deploy-dependencies.ps1`** as a CI gate against the whole class. It walks every PE in `deploy\` with `dumpbin /dependents` and fails when an MSVC runtime import is not app-local, or when any import resolves to neither `deploy\` nor the OS.

The runtime rule is checked **before** the System32 probe on purpose. Build machines have the redistributable installed, so a plain "does it resolve here?" test passes on the runner while users' machines fail — exactly how this shipped unnoticed through every release since ASR landed. Nothing in the release workflow inspected the payload; the OpenSSL crash in #1341/#1362 was the same class and would have been caught by this too.

Missing delay-load imports warn rather than fail (a delay-load miss is a feature failure, not a startup failure, and Qt/ONNX Runtime delay-load optional OS components).

The gate runs **before any artifact is built**, so a payload that isn't self-contained never reaches the ZIP, the installer, the MSIX or the release. `build-windows-local.ps1` runs the same check on its `-Installer` path, right after it stages the runtime into `deploy\` — that is the only local path where `deploy\` is a shippable payload, so it is the only one the audit can meaningfully hold to this standard. A plain local `deploy\` build never gets the staged runtime and is deliberately left alone.

The `installer-runtime\*.dll` copy into `deploy\` moved from the portable-ZIP step into the staging step so the audit sees the same payload all three artifacts ship.

`check-deploy-dependencies.ps1` scopes `$ErrorActionPreference` around the `dumpbin` call. CI invokes `powershell` (Windows PowerShell 5.1), where merging a native command's stderr with `2>&1` under `Stop` raises a terminating `NativeCommandError` before `$LASTEXITCODE` is read — one benign `LNK4048` on an odd file in a few-hundred-file payload would otherwise kill packaging with an opaque error instead of a real report.

## Testing

No pwsh on the Linux dev box, so both scripts were exercised under a real PowerShell runtime in `mcr.microsoft.com/powershell`, against simulated redist trees and a stub `dumpbin` emitting real-shaped `/dependents` output. 23/23 checks pass:

`stage-msvc-runtime.ps1`
- OpenMP sibling present → `vcomp140.dll` staged, CRT DLLs still staged, exactly the expected set
- OpenMP redist absent → throws, message names both `vcomp140.dll` and the exact directory it expected
- OpenMP directory present but empty → throws
- **only a version-mismatched sibling present** (`Microsoft.VC142.OpenMP` next to `Microsoft.VC143.CRT`) → throws, nothing staged. The earlier glob-and-take-first form staged the mismatched `vcomp140.dll` and exited 0 on this tree; deriving the name from the chosen CRT directory is what makes the version match an invariant rather than a coincidence.
- correct sibling present alongside an older one → picks the matching one

`check-deploy-dependencies.ps1`
- complete payload → passes, reports every import resolved
- **`vcomp140.dll` missing from `deploy\` but present in `System32`** → fails, naming `AetherSDR.exe imports VCOMP140.dll` (this reproduces the runner condition that hid the original bug, and is the check that matters most)
- missing third-party DLL (the `libssl-3-x64.dll` class) → fails, naming it
- missing non-runtime delay-load → warns, exits 0
- empty deploy directory → fails rather than passing vacuously
- stub `dumpbin` writing to stderr → still walks the payload and passes

Case-insensitive import matching is covered (`VCOMP140.dll` vs `vcomp140.dll`), as is the `vcruntime140_1.dll` suffix form.

One limit worth stating: pwsh 7 does not reproduce Windows PowerShell 5.1's `NativeCommandError`, so the stderr test proves the scoped block still parses merged output correctly — it cannot prove the 5.1 behaviour itself. That rests on the documented difference between the two runtimes, and on the dry run below.

**Dry run on the real runner.** This workflow only fires on `v*` tags, so without a dispatch its first exercise would be a release build — a false positive there blocks a release rather than a PR. Run on this branch: https://github.com/aethersdr/AetherSDR/actions/runs/31035929154

## Notes

Setting `GGML_OPENMP OFF` for MSVC would remove the dependency at the source, but the `.lib`s come from the pinned prebuilt whisper-gpu asset, so it would need that asset regenerated on a Windows box before taking effect. Shipping the DLL lands now with no rebuild, and the audit gate makes the choice moot either way.

Users hitting this today can reinstall the VC++ redistributable (<https://aka.ms/vs/17/release/vc_redist.x64.exe>) or drop a `vcomp140.dll` into the install directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

