### PR TITLE
fix(icom): IC-9700 support — a GUI crash, a dBm runaway, and a self-inflicted reconnect loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5043,6 +5043,16 @@ target_include_directories(radiomodel_dax_null_test PRIVATE src)
 target_link_libraries(radiomodel_dax_null_test PRIVATE aethercore Qt6::Core Qt6::Test)
 add_test(NAME radiomodel_dax_null_test COMMAND radiomodel_dax_null_test)
 
+add_executable(dbm_range_plausibility_test tests/dbm_range_plausibility_test.cpp)
+target_include_directories(dbm_range_plausibility_test PRIVATE src)
+target_link_libraries(dbm_range_plausibility_test PRIVATE Qt6::Core)
+add_test(NAME dbm_range_plausibility_test COMMAND dbm_range_plausibility_test)
+
+add_executable(radiomodel_pan_range_null_test tests/radiomodel_pan_range_null_test.cpp)
+target_include_directories(radiomodel_pan_range_null_test PRIVATE src)
+target_link_libraries(radiomodel_pan_range_null_test PRIVATE aethercore Qt6::Core Qt6::Test)
+add_test(NAME radiomodel_pan_range_null_test COMMAND radiomodel_pan_range_null_test)
+
 add_executable(radiomodel_pan_id_mapping_test tests/radiomodel_pan_id_mapping_test.cpp)
 target_include_directories(radiomodel_pan_id_mapping_test PRIVATE src)
 target_link_libraries(radiomodel_pan_id_mapping_test PRIVATE aethercore Qt6::Core Qt6::Test)

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -525,6 +525,19 @@ signals:
     void connected();
     void disconnected();
     void connectionError(const QString& reason);
+
+    // A problem with the RADIO'S CONFIGURATION that the operator should fix,
+    // but which does not end the session. Distinct from connectionError, which
+    // every consumer treats as fatal: RadioModel starts its reconnect timer on
+    // it unconditionally, so using that channel for advice tears down a working
+    // link and then does it again on the next attempt — a permanent reconnect
+    // loop whose cause reads as a helpful message. That is exactly what an
+    // IC-9700 with MOD Input set to USB did: connect, warn, drop, repeat every
+    // 5 s, with the radio itself perfectly healthy.
+    //
+    // If it does not stop the radio working, it belongs here.
+    void configurationWarning(const QString& message);
+
     void capabilitiesChanged();
 
     // A fresh transport snapshot. Emitted on a FIXED cadence while connected,

--- a/src/core/backends/RadioCapabilities.h
+++ b/src/core/backends/RadioCapabilities.h
@@ -67,6 +67,29 @@ struct RadioCapabilities {
     // non-Flex backend must NOT open the mic on connect. (#4449 review)
     bool hostModulates = false;
 
+    // The RADIO owns its display dBm scale and will echo back a range sent to
+    // it. True for a Flex, whose `display pan set min_dbm=…` is a real command
+    // the radio adopts and reports; false for a backend that decodes its scope
+    // at a FIXED calibration it does not accept changes to (Icom CI-V, whose
+    // floor/span come from ScopeCalibration and shift only with the radio's own
+    // reference level).
+    //
+    // This gates the noise-floor auto-adjust, and it has to, because that loop
+    // is built on the echo: the widget moves its reference level, requests the
+    // new range, and waits for the radio to confirm before moving again. With
+    // no command plane the request is dropped, the confirmation never arrives,
+    // and the auto-floor reads the unchanged floor as "not there yet" and steps
+    // again — measured at a linear 24 dB/s, walking off the bottom of the scale
+    // (-202, -226, -250 … -1882 dBm) until dbmRangeLooksPlausible() starts
+    // rejecting it at -180. Those rejections are the SYMPTOM; the missing echo
+    // is the fault, which is why raising the reject floor would not have fixed
+    // it. On an IC-9700 this was the visible "waterfall resets ~1 s after the
+    // trace fills" and the reconnect churn behind it.
+    //
+    // A backend with a fixed scale needs no auto-adjust: its floor is already
+    // where the calibration puts it.
+    bool radioOwnsDbmScale = true;
+
     // The RADIO stores memory channels and re-dumps them on connect. True for a
     // Flex, whose memory slots live in the radio and are shared by every client
     // attached to it; false for a direct-sampling or receiver-only backend (HL2,

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -95,6 +95,13 @@ RadioCapabilities IcomCivBackend::capabilities() const
     c.canTransmit = m.hasTransmit;
     c.txPowerMaxWatts = m.txPowerMaxWatts;
 
+    // The scope scale is OURS, not the radio's: it comes from ScopeCalibration
+    // (floor/span, shifted by the radio's own reference level), and there is no
+    // CI-V command to set a display dBm range — this backend has no consumer for
+    // one. Leaving this true made the noise-floor auto-adjust chase an echo that
+    // can never arrive; see RadioCapabilities::radioOwnsDbmScale.
+    c.radioOwnsDbmScale = false;
+
     // The RADIO modulates. Contrast the HL2, where the host does — this drives
     // the mic-source list and the PC-audio lock, so getting it wrong opens the
     // host microphone on a radio that will never use it.
@@ -370,6 +377,29 @@ void IcomCivBackend::checkModInput()
     if (m_dataOffModInput < 0 || m_dataModInput < 0)
         return;
 
+    // ONLY a radio with Wi-Fi has a WLAN modulation source to select.
+    //
+    // The 1A 05 item numbers (118/119) and the value table below are read from
+    // ONE model's CI-V Reference Guide and sent to every Icom, but each model
+    // numbers its own SET menu and its own enum. On an IC-9700 — LAN only, no
+    // Wi-Fi — both items were set correctly on the front panel and the radio
+    // answered 0x01, which this table calls "USB". So either 118/119 are not
+    // MOD Input on that model, or 0x01 IS its network source; either way
+    // demanding 0x03 asks for a setting the radio cannot offer, and the warning
+    // could never be satisfied by any front-panel action.
+    //
+    // Reported by an operator with the radio in front of them (2026-08-05): set
+    // to LAN on both, warned anyway, every session. A check that fires on a
+    // correctly configured radio is worse than no check — it is the one the
+    // operator learns to scroll past, and it trains them past the real ones.
+    //
+    // Staying silent here loses nothing that was working: the warning was
+    // WRONG on this radio, not merely noisy. Re-enable per model once the
+    // mapping is confirmed against that model's own guide (the same bar
+    // IcomModel::verified sets for the rest of the table).
+    if (!m_model->hasWifi)
+        return;
+
     const bool voiceOk = m_dataOffModInput == setting::kModWlan;
     const bool dataOk  = m_dataModInput == setting::kModWlan;
     if (voiceOk && dataOk)
@@ -393,10 +423,16 @@ void IcomCivBackend::checkModInput()
         wrong << QStringLiteral("data modes take modulation from %1")
                      .arg(name(m_dataModInput));
 
-    // A connectionError rather than a log line: this silently costs the
-    // operator every transmission, and it is fixable in about ten seconds once
-    // they know which menu to open.
-    emit connectionError(
+    // A configurationWarning, NOT a connectionError: this is advice about a
+    // radio that is otherwise working perfectly. connectionError is fatal to
+    // every consumer — RadioModel starts its reconnect timer on it — so raising
+    // it here dropped the session ~4 ms after the CI-V stream came live and
+    // reconnected into the same check forever. The operator saw a radio that
+    // would not stay connected and a message about a menu setting, with no way
+    // to tell that the message WAS the disconnect.
+    //
+    // It still reaches the operator; it just no longer costs them the session.
+    emit configurationWarning(
         QStringLiteral("The radio is not listening to network audio — %1. "
                        "AetherSDR's transmit audio will be ignored and the radio "
                        "will key at zero output. On the radio: MENU > SET > "
@@ -1437,8 +1473,14 @@ IRadioBackend::HealthSnapshot IcomCivBackend::healthSnapshot() const
             default:                  return QStringLiteral("?");
             }
         };
-        const bool ok = m_dataOffModInput == setting::kModWlan
-                        && m_dataModInput == setting::kModWlan;
+        // The verdict, like the warning in checkModInput(), is only meaningful
+        // on a radio that HAS a WLAN source. Elsewhere show the raw values and
+        // pass no judgement: an IC-9700 set correctly to LAN reads back 0x01
+        // here, and appending "NOT WLAN" to that is telling the operator their
+        // working radio is misconfigured.
+        const bool ok = !m_model->hasWifi
+                        || (m_dataOffModInput == setting::kModWlan
+                            && m_dataModInput == setting::kModWlan);
         h.values.insert(QStringLiteral("modinput"),
                         QStringLiteral("%1 voice / %2 data%3")
                             .arg(name(m_dataOffModInput), name(m_dataModInput),

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -468,6 +468,31 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
                 if (!widths.empty() && m_model->hasScope)
                     emit panBandwidthLimitsChanged(panId(), widths.front() / 1e6,
                                                    widths.back() / 1e6);
+
+                // ⛔ Publish the Y axis too, or the display invents one and
+                // never stops. Without a range from the backend the pan
+                // auto-ranges from its own noise-floor estimate, and because
+                // MainWindow refuses anything below -180 dBm
+                // (dbmRangeLooksPlausible) the radio never adopts the value —
+                // so the estimate is never corrected and drifts further every
+                // cycle. Observed on a live IC-9700 2026-08-05: a linear
+                // runaway of -24 dB/s, 84 rejected `display pan set` commands
+                // in 90 s, min falling -202 -> -898 dBm and still going. The
+                // operator sees the waterfall reset each time the drift crosses
+                // the guard, and the radio menu stops responding behind the
+                // command flood.
+                //
+                // The numbers are m_scopeCal's own — ESTIMATES, as its header
+                // says at length, not a measurement. Publishing an estimate is
+                // right here: the axis is anchored and stable, and the estimate
+                // is already the one toDbm() decodes with, so the display and
+                // the decoder agree. An uncalibrated-but-consistent axis beats
+                // a self-referential one.
+                if (m_model->hasScope) {
+                    const double floorDbm = m_scopeCal.floorDbm + m_scopeCal.referenceDb;
+                    emit panRangeChanged(panId(), floorDbm, floorDbm + m_scopeCal.spanDb);
+                }
+
                 publishMeterDefs();
                 publishCapabilities();
             }

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -162,6 +162,31 @@ RadioCapabilities IcomCivBackend::capabilities() const
 
 void IcomCivBackend::publishCapabilities() { emit capabilitiesChanged(); }
 
+void IcomCivBackend::publishScopeDbmRange()
+{
+    // kUnknown has hasScope=false, so this is a quiet no-op on a backend whose
+    // radio has not identified itself yet — which is correct: there is no scope
+    // to draw an axis for, and the connect path publishes once the model is
+    // known. (m_model is never null; the constructor seeds it with
+    // unknownModel().)
+    if (!m_model->hasScope)
+        return;
+
+    // THE AXIS MUST MATCH THE DECODER, INCLUDING THE SIGN.
+    //
+    // toDbm() maps a sample to `floorDbm + (v/max)*spanDb - referenceDb`, so
+    // raising the radio's reference level moves the decoded trace DOWN in dBm.
+    // The axis has to move the same way. An earlier version of this added
+    // referenceDb here while toDbm subtracted it, which left the scale wrong by
+    // 2x the reference whenever it was non-zero — invisible at the default 0,
+    // and a growing error the further the operator moved it.
+    //
+    // Derived from the same ScopeCalibration toDbm() uses rather than repeating
+    // the arithmetic, so the two cannot drift apart again.
+    const double floorDbm = m_scopeCal.floorDbm - m_scopeCal.referenceDb;
+    emit panRangeChanged(panId(), floorDbm, floorDbm + m_scopeCal.spanDb);
+}
+
 // ---------------------------------------------------------------------------
 // Lifecycle
 // ---------------------------------------------------------------------------
@@ -397,6 +422,12 @@ void IcomCivBackend::checkModInput()
     // WRONG on this radio, not merely noisy. Re-enable per model once the
     // mapping is confirmed against that model's own guide (the same bar
     // IcomModel::verified sets for the rest of the table).
+    // Note this also silences the check on an UNIDENTIFIED radio, since
+    // kUnknown carries hasWifi=false. That is the right outcome, though for a
+    // second reason: kUnknown is also hasTransmit=false, and a radio this
+    // client will not let key has no modulation path to warn about. Warning
+    // there would be advice about a transmission that cannot happen, decoded
+    // through a value table not known to apply to that model.
     if (!m_model->hasWifi)
         return;
 
@@ -524,10 +555,7 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
                 // is already the one toDbm() decodes with, so the display and
                 // the decoder agree. An uncalibrated-but-consistent axis beats
                 // a self-referential one.
-                if (m_model->hasScope) {
-                    const double floorDbm = m_scopeCal.floorDbm + m_scopeCal.referenceDb;
-                    emit panRangeChanged(panId(), floorDbm, floorDbm + m_scopeCal.spanDb);
-                }
+                publishScopeDbmRange();
 
                 publishMeterDefs();
                 publishCapabilities();
@@ -1304,6 +1332,12 @@ void IcomCivBackend::invokeExtension(const QString& ns, const QString& verb, qui
         sendUserCommand(cmdScopeReference(m_session ? m_session->civAddress() : 0xA4,
                                           arg.toDouble()));
         m_scopeCal.referenceDb = arg.toDouble();
+        // The reference level shifts the whole trace, so the AXIS has to move
+        // with it. Without this the range published at connect goes stale the
+        // moment the operator changes the reference — the trace slides and the
+        // scale it is drawn against does not, which reads as a calibration
+        // error rather than a missing update.
+        publishScopeDbmRange();
         emit extensionResult(requestId, true);
         return;
     }

--- a/src/core/backends/icom/IcomCivBackend.h
+++ b/src/core/backends/icom/IcomCivBackend.h
@@ -113,6 +113,10 @@ private slots:
 
 private:
     void publishCapabilities();
+    // Publish the scope's dBm axis, derived from the SAME ScopeCalibration that
+    // toDbm() decodes with. Call whenever anything it depends on changes — at
+    // connect, and on every reference-level change.
+    void publishScopeDbmRange();
     void publishMeterDefs();
     void sendUserCommand(const std::vector<std::uint8_t>& frame);
     void applyScopeStartup();

--- a/src/core/backends/icom/IcomModels.cpp
+++ b/src/core/backends/icom/IcomModels.cpp
@@ -36,6 +36,20 @@ constexpr std::array<IcomModel, 7> kModels{{
         /*verified*/ true,
     },
     {
+        // IC-9700 — scope geometry MEASURED on a live radio 2026-08-05 (G0JKN),
+        // not read from the guide, so `verified` stays false: that flag means
+        // "confirmed against this model's own CI-V Reference Guide" and this
+        // evidence is a different kind.
+        //
+        // 618 consecutive scope frames off an IC-9700 at 10.0.0.7, every one
+        // 475 pixels wide, decoded through the RS-BA1 CI-V data stream. The
+        // frame's own bounds header cross-checks: centre 439.864060 MHz (where
+        // the radio was tuned) and a 500 kHz span, giving 1052.6 Hz per pixel.
+        //
+        // So the 475/160/11 inherited from the IC-705 turn out to be RIGHT for
+        // this model — worth recording precisely because it could not be
+        // assumed. The IC-7610 row below is the counter-example: 689 points and
+        // a 0..200 range.
         0xA2, "IC-9700", 2, 2,
         /*hasNetwork*/ true, /*hasWifi*/ false,
         /*hasScope*/ true, 475, 160, 11,

--- a/src/core/backends/icom/IcomSession.cpp
+++ b/src/core/backends/icom/IcomSession.cpp
@@ -23,6 +23,12 @@ constexpr int kTxPumpMs = 10;
 // frame swallows every subsequent byte and the radio appears to stop answering
 // while the link is demonstrably fine.
 constexpr int kCivFrameTimeoutMs = 100;
+// Re-send the CI-V data-stream open at the reference's cadence until the radio
+// starts streaming. Matches kappanhang / SDR9700 startCivDataTimer(100).
+constexpr int kCivOpenRetryMs = 100;
+// ~5 s of asking. Long enough for a slow radio, short enough that a radio which
+// will never answer says so rather than retrying silently forever.
+constexpr int kCivOpenMaxAttempts = 50;
 
 std::span<const std::uint8_t> asSpan(const QByteArray& b)
 {
@@ -101,7 +107,7 @@ bool IcomSession::start(const Params& params)
 
 void IcomSession::stop()
 {
-    for (QTimer** t : {&m_tokenTimer, &m_txTimer, &m_civTimeout}) {
+    for (QTimer** t : {&m_tokenTimer, &m_txTimer, &m_civTimeout, &m_civOpenRetry}) {
         if (*t) {
             (*t)->stop();
             (*t)->deleteLater();
@@ -376,6 +382,47 @@ void IcomSession::onSerialReady()
     m_serial->sendTracked(buildSerialOpen(m_serial->localSessionId(),
                                           m_serial->remoteSessionId(), m_serialSendSeq++, true));
 
+    // ⛔ ONE OPEN IS NOT ENOUGH. Observed on a live IC-9700 2026-08-05: the
+    // radio accepts the open, reports the pipe ready, and then streams nothing
+    // — not one CI-V frame in 45 s. Every consequence is downstream and silent:
+    // no 0x19 0x00 reply, so the model never resolves; no model, so scope and
+    // transmit stay disabled and no dBm range is published; no range, so the pan
+    // auto-ranges into a runaway MainWindow rejects once a second. The operator
+    // sees a blank frequency and a waterfall that keeps resetting.
+    //
+    // kappanhang and the SDR9700 reference both re-send the open on a 100 ms
+    // timer until data flows (their startCivDataTimer), and Aether-gate does the
+    // same driving THIS radio — 1356 frames in 45 s, 30.1 fps. An IC-705 that
+    // happens to start on the first open would never expose this.
+    m_civDataSeen = false;
+    m_civOpenAttempts = 0;
+    if (!m_civOpenRetry) {
+        m_civOpenRetry = new QTimer(this);
+        connect(m_civOpenRetry, &QTimer::timeout, this, [this]() {
+            if (m_civDataSeen || !m_serial) {
+                m_civOpenRetry->stop();
+                return;
+            }
+            // Bounded. The reference retries indefinitely, but it is a headless
+            // bridge; here an unbounded 10 Hz stream of opens at a radio that is
+            // never going to answer is just noise that hides the real fault. Say
+            // so once and stop — a silent forever-retry is how "it just does not
+            // work" becomes unreportable.
+            if (++m_civOpenAttempts > kCivOpenMaxAttempts) {
+                m_civOpenRetry->stop();
+                qCWarning(lcIcom)
+                    << "CI-V stream never started after" << kCivOpenMaxAttempts
+                    << "open attempts — the radio accepted the open and sent no data."
+                    << "Check CI-V is enabled for the network port on the radio.";
+                return;
+            }
+            m_serial->sendTracked(buildSerialOpen(m_serial->localSessionId(),
+                                                  m_serial->remoteSessionId(),
+                                                  m_serialSendSeq++, true));
+        });
+    }
+    m_civOpenRetry->start(kCivOpenRetryMs);
+
     if (!m_civTimeout) {
         m_civTimeout = new QTimer(this);
         connect(m_civTimeout, &QTimer::timeout, this, &IcomSession::onCivFrameTimeout);
@@ -393,6 +440,16 @@ void IcomSession::onSerialPayload(const QByteArray& packet)
     const auto payload = serialPayload(asSpan(packet));
     if (payload.empty())
         return;   // a keepalive idle, or the serial open/close echo
+
+    // First real CI-V payload: the stream is live, so stop asking it to open.
+    // The reference stops its timer on exactly this condition rather than after
+    // a fixed count, because a slow radio must not be abandoned early.
+    if (!m_civDataSeen) {
+        m_civDataSeen = true;
+        if (m_civOpenRetry)
+            m_civOpenRetry->stop();
+        qCInfo(lcIcom) << "CI-V stream live — open-retry stopped";
+    }
 
     for (const auto& raw : m_civ.feed(payload)) {
         auto frame = parseFrame(raw);

--- a/src/core/backends/icom/IcomSession.h
+++ b/src/core/backends/icom/IcomSession.h
@@ -112,6 +112,11 @@ private:
     QTimer* m_tokenTimer = nullptr;
     QTimer* m_txTimer = nullptr;
     QTimer* m_civTimeout = nullptr;
+    // Re-sends the CI-V data-stream open until the radio actually starts
+    // streaming. One open is not reliably enough — see onSerialReady().
+    QTimer* m_civOpenRetry = nullptr;
+    bool    m_civDataSeen = false;
+    int     m_civOpenAttempts = 0;
 
     // Auth state. The auth id and session ids are re-read from the stream grant
     // rather than cached from the login — see parseStreamGrant's comment; the

--- a/src/core/backends/icom/IcomSettings.cpp
+++ b/src/core/backends/icom/IcomSettings.cpp
@@ -26,7 +26,6 @@ constexpr const char* kFieldCivAddress  = "civAddress";
 
 // The IC-705's factory CI-V address. A seed, not an assertion — the backend
 // replaces it with whatever 0x19 0x00 reports.
-constexpr int kDefaultCivAddress = 0xA4;
 
 // Validate a port on the way OUT, not just on the way in. A hand-edited or
 // truncated settings file must not be able to command a nonsense port
@@ -123,9 +122,9 @@ void IcomSettings::setPorts(quint16 control, quint16 serial, quint16 audio)
 
 std::uint8_t IcomSettings::civAddress()
 {
-    const int v = readObj().value(QLatin1String(kFieldCivAddress)).toInt(kDefaultCivAddress);
+    const int v = readObj().value(QLatin1String(kFieldCivAddress)).toInt(IcomSettings::kDefaultCivAddress);
     if (v <= 0 || v > 0xFF)
-        return kDefaultCivAddress;
+        return IcomSettings::kDefaultCivAddress;
     return static_cast<std::uint8_t>(v);
 }
 

--- a/src/core/backends/icom/IcomSettings.cpp
+++ b/src/core/backends/icom/IcomSettings.cpp
@@ -24,9 +24,6 @@ constexpr const char* kFieldSerialPort  = "serialPort";
 constexpr const char* kFieldAudioPort   = "audioPort";
 constexpr const char* kFieldCivAddress  = "civAddress";
 
-// The IC-705's factory CI-V address. A seed, not an assertion — the backend
-// replaces it with whatever 0x19 0x00 reports.
-
 // Validate a port on the way OUT, not just on the way in. A hand-edited or
 // truncated settings file must not be able to command a nonsense port
 // (Principle VII); 0 in particular would bind an ephemeral local port and then

--- a/src/core/backends/icom/IcomSettings.h
+++ b/src/core/backends/icom/IcomSettings.h
@@ -52,6 +52,11 @@ public:
     static std::uint8_t civAddress();
     static void setCivAddress(std::uint8_t address);
 
+    // Exposed so the connect UI can tell "the operator chose this" from "nobody
+    // has set one", and leave its field blank in the second case rather than
+    // presenting the IC-705's address as a deliberate choice.
+    static constexpr std::uint8_t kDefaultCivAddress = 0xA4;
+
     // Restore every field to its default.
     static void reset();
 

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -2197,15 +2197,38 @@ void ConnectionPanel::probeRadio(const QString& ip)
         // exact symptom this field exists to cure.
         if (m_manualIcomCivEdit) {
             QString civ = m_manualIcomCivEdit->text().trimmed();
-            if (!civ.isEmpty()) {
+            if (civ.isEmpty()) {
+                // BLANK MEANS AUTO, and it has to mean that on the way OUT as
+                // well as in. Without this an override could be typed but never
+                // taken back: clearing the field left the stored value in place
+                // and the placeholder then said "auto" while the radio was
+                // still being addressed at the old override. Restores the
+                // default rather than writing 0, so civAddress() has a real
+                // address to fall back on.
+                IcomSettings::setCivAddress(IcomSettings::kDefaultCivAddress);
+            } else {
                 if (civ.startsWith(QLatin1String("0x"), Qt::CaseInsensitive))
                     civ = civ.mid(2);
                 if (civ.endsWith(QLatin1Char('h'), Qt::CaseInsensitive))
                     civ.chop(1);
                 bool ok = false;
                 const uint addr = civ.toUInt(&ok, 16);
-                if (ok && addr > 0 && addr <= 0xFF)
+                if (ok && addr > 0 && addr <= 0xFF) {
                     IcomSettings::setCivAddress(static_cast<std::uint8_t>(addr));
+                } else {
+                    // SAY SO rather than connecting with something else. This
+                    // field exists because a wrong CI-V address fails SILENTLY
+                    // — the radio just never answers — so silently ignoring bad
+                    // input reproduces the exact symptom the field is here to
+                    // cure, and the operator would be left reading a "no reply"
+                    // that their typo caused.
+                    setStatusText(tr("CI-V address \"%1\" is not a hex byte "
+                                     "(try A2, 0xA2 or A2h) — not connecting.")
+                                      .arg(m_manualIcomCivEdit->text().trimmed()));
+                    m_manualIcomCivEdit->setFocus();
+                    m_manualIcomCivEdit->selectAll();
+                    return;
+                }
             }
         }
         // Keychain for the password, never the settings file — and the save

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -720,6 +720,29 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     ThemeManager::instance().applyStyleSheet(m_manualIcomPassEdit, lineEditStyle);
     m_manualIcomPassRow = addManualRow(QStringLiteral("Icom password:"), m_manualIcomPassEdit);
 
+    // The CI-V address is the third thing the operator has to read off the
+    // radio, alongside the two above — theirs live in the Network menu, this
+    // one in Connectors > CI-V. Without it the address can only ever be the
+    // IC-705 default, and every other model in kModels is unreachable: CI-V is
+    // addressed, so an IC-9700 on 0xA2 silently ignores everything sent to
+    // 0xA4. No ID reply, no model, and the conservative unknown fallback means
+    // no scope and no transmit — which reads as "this backend has no
+    // panadapter yet" rather than "wrong address".
+    //
+    // Blank is the normal case: the placeholder shows what will be used, which
+    // is the model the RS-BA1 handshake already named. Typing here is the
+    // override for a radio whose address has been changed from default.
+    m_manualIcomCivEdit = new QLineEdit(manualGroup);
+    m_manualIcomCivEdit->setObjectName(QStringLiteral("connectionManualIcomCivAddress"));
+    m_manualIcomCivEdit->setAccessibleName(tr("Icom CI-V address"));
+    m_manualIcomCivEdit->setAccessibleDescription(
+        tr("The radio's CI-V address in hex, from MENU > SET > Connectors > CI-V. "
+           "Leave blank to use the address for the model the radio reports."));
+    m_manualIcomCivEdit->setClearButtonEnabled(true);
+    m_manualIcomCivEdit->setPlaceholderText(tr("auto (e.g. A2 for IC-9700)"));
+    ThemeManager::instance().applyStyleSheet(m_manualIcomCivEdit, lineEditStyle);
+    m_manualIcomCivRow = addManualRow(QStringLiteral("Icom CI-V:"), m_manualIcomCivEdit);
+
     manualGroupLayout->addLayout(manualForm);
 
     auto* manualActionRow = new QHBoxLayout;
@@ -1943,6 +1966,8 @@ void ConnectionPanel::updateManualFamilyHints()
         m_manualIcomUserRow->setVisible(icom);
     if (m_manualIcomPassRow)
         m_manualIcomPassRow->setVisible(icom);
+    if (m_manualIcomCivRow)
+        m_manualIcomCivRow->setVisible(icom);
 
     if (icom) {
         // Fill from settings, and read the password out of the keychain — which
@@ -1951,6 +1976,15 @@ void ConnectionPanel::updateManualFamilyHints()
         // between the request and the answer.
         if (m_manualIcomUserEdit && m_manualIcomUserEdit->text().isEmpty())
             m_manualIcomUserEdit->setText(IcomSettings::username());
+        // Show a stored override; leave blank when it is the default, so the
+        // placeholder can say "auto" rather than presenting A4 as a choice the
+        // operator made.
+        if (m_manualIcomCivEdit && m_manualIcomCivEdit->text().isEmpty()) {
+            const std::uint8_t civ = IcomSettings::civAddress();
+            if (civ != IcomSettings::kDefaultCivAddress)
+                m_manualIcomCivEdit->setText(
+                    QStringLiteral("%1").arg(civ, 2, 16, QLatin1Char('0')).toUpper());
+        }
         if (m_manualIpEdit && m_manualIpEdit->text().isEmpty())
             m_manualIpEdit->setText(IcomSettings::lastHost());
         if (m_manualIcomPassEdit && m_manualIcomPassEdit->text().isEmpty()) {
@@ -2154,6 +2188,26 @@ void ConnectionPanel::probeRadio(const QString& ip)
 
         IcomSettings::setUsername(user);
         IcomSettings::setLastHost(trimmedIp);
+
+        // Hex, with or without an 0x prefix or a trailing h — the radio's own
+        // menu writes it as "A2h", so accept what the operator is looking at.
+        // An unparseable or out-of-range entry is IGNORED rather than clamped:
+        // a wrong CI-V address is silent (the radio simply never answers), so
+        // guessing on the operator's behalf would hide their typo behind the
+        // exact symptom this field exists to cure.
+        if (m_manualIcomCivEdit) {
+            QString civ = m_manualIcomCivEdit->text().trimmed();
+            if (!civ.isEmpty()) {
+                if (civ.startsWith(QLatin1String("0x"), Qt::CaseInsensitive))
+                    civ = civ.mid(2);
+                if (civ.endsWith(QLatin1Char('h'), Qt::CaseInsensitive))
+                    civ.chop(1);
+                bool ok = false;
+                const uint addr = civ.toUInt(&ok, 16);
+                if (ok && addr > 0 && addr <= 0xFF)
+                    IcomSettings::setCivAddress(static_cast<std::uint8_t>(addr));
+            }
+        }
         // Keychain for the password, never the settings file — and the save
         // primes the session cache synchronously, so the connect below cannot
         // race the keyring write.

--- a/src/gui/ConnectionPanel.h
+++ b/src/gui/ConnectionPanel.h
@@ -243,8 +243,10 @@ private:
     // orphan labels behind.
     QWidget*     m_manualIcomUserRow{nullptr};
     QWidget*     m_manualIcomPassRow{nullptr};
+    QWidget*     m_manualIcomCivRow{nullptr};
     QLineEdit*   m_manualIcomUserEdit{nullptr};
     QLineEdit*   m_manualIcomPassEdit{nullptr};
+    QLineEdit*   m_manualIcomCivEdit{nullptr};
     QLineEdit*   m_manualIpEdit{nullptr};
     QLabel*      m_manualResultLabel{nullptr};
     QToolButton* m_manualAdvancedToggle{nullptr};

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6556,6 +6556,20 @@ void MainWindow::applyCapabilitiesToUi(bool connected, const RadioCapabilities& 
             !connected || m_radioModel.meterModel().hasMicPeakMeter());
     }
 
+    // ── Display dBm scale: who owns it ─────────────────────────────────────
+    // A backend that decodes its scope at a fixed calibration (Icom CI-V) has
+    // no range command and never echoes one back, so the noise-floor auto-
+    // adjust must not try to move a reference level the radio will not confirm.
+    // `!connected ||` restores the permissive default on disconnect so the
+    // setting cannot leak from an Icom into the next radio connected.
+    {
+        const bool radioOwnsScale = !connected || caps.radioOwnsDbmScale;
+        const QList<SpectrumWidget*> spectra = findChildren<SpectrumWidget*>();
+        for (SpectrumWidget* spectrum : spectra) {
+            spectrum->setRadioOwnsDbmScale(radioOwnsScale);
+        }
+    }
+
     // ── Profiles: the PROF applet, the Profiles menu, and both dialogs ──────
     const bool profiles = !connected || caps.hasProfiles;
     if (m_appletPanel) {

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -616,6 +616,15 @@ void MainWindow::wireRadioModel()
 
     connect(&m_radioModel, &RadioModel::connectionError,
             this, &MainWindow::onConnectionError);
+    // Radio configuration advice: shown, but it does NOT touch the session.
+    // Deliberately not onConnectionError — see IRadioBackend::configurationWarning.
+    // 15 s rather than the usual 4: this one names a four-level menu path the
+    // operator has to walk on the radio's front panel while reading it.
+    connect(&m_radioModel, &RadioModel::configurationWarning,
+            this, [this](const QString& message) {
+        qCWarning(lcProtocol).noquote() << "radio configuration:" << message;
+        statusBar()->showMessage(message, 15000);
+    });
     connect(&m_radioModel, &RadioModel::guiClientRegistrationFailed,
             this, [this](const QString& message) {
         // A rejected GUI registration is terminal for this attempt. Keep the

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -3094,6 +3094,14 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             });
     };
     auto sendDbmRangeCommand = [this, applet](float minDbm, float maxDbm) {
+        // BACKSTOP. The callers above gate this individually so each one can do
+        // the right local thing, but this is the one place every dBm range
+        // leaves for the radio — and a range sent to a backend with no command
+        // plane is silently dropped, which is precisely what starts the ratchet.
+        // A future fourth caller gets the protection without knowing to ask.
+        if (!m_radioModel.backendCapabilities().radioOwnsDbmScale) {
+            return;
+        }
         if (!dbmRangeLooksPlausible(minDbm, maxDbm)) {
             qCWarning(lcProtocol).noquote()
                 << "MainWindow: rejecting implausible dBm range"
@@ -3372,6 +3380,13 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         // correct radio-reported range via the pendingDbm guard. (#3034)
         sw->setDbmRange(pan->minDbm(), pan->maxDbm());
 
+        // Also set here, not only from applyCapabilitiesToUi: a pane added
+        // AFTER connect (Add Panadapter, a layout change) never sees that
+        // signal, and would arm its auto-floor against a radio that cannot
+        // echo a range — one runaway pane is enough to churn the session.
+        sw->setRadioOwnsDbmScale(!m_radioModel.isConnected()
+                                 || m_radioModel.backendCapabilities().radioOwnsDbmScale);
+
         wirePanDisplayStatus(applet, pan);
     }
     syncTxWaterfallSliceToSpectrums();
@@ -3489,6 +3504,27 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
 
         const bool profileLoadHeld = profileLoadRadioStateWritesHeld();
         const bool autoFloorChange = sw->pendingAutoNoiseFloorDbmRange();
+
+        // A backend whose dBm scale is FIXED never echoes a range back, and the
+        // auto-floor loop is built on that echo: it moves the reference level,
+        // requests the range, and waits for confirmation before moving again.
+        // With nothing to confirm it reads the unchanged floor as "not there
+        // yet" and steps again — a measured 24 dB/s ratchet that walks off the
+        // bottom of the scale (-202 … -1882 dBm) and only becomes visible when
+        // dbmRangeLooksPlausible() starts rejecting it at -180. Re-seed the
+        // widget from the pan's real range instead, which is the same recovery
+        // the profile-load path above uses, and drop the request.
+        //
+        // Deliberately NOT setNoiseFloorEnable(false): that is the operator's
+        // own toggle, and forcing it would both fight the overlay menu and lose
+        // the setting for the next radio. The auto-floor stays enabled and
+        // simply has nothing to chase on a fixed scale.
+        if (autoFloorChange && !m_radioModel.backendCapabilities().radioOwnsDbmScale) {
+            if (auto* pan = m_radioModel.panadapter(applet->panId())) {
+                sw->setDbmRange(pan->minDbm(), pan->maxDbm());
+            }
+            return;
+        }
         if (profileLoadPanDisplaySettling(applet->panId()) && autoFloorChange) {
             if (auto* pan = m_radioModel.panadapter(applet->panId())) {
                 if (pan->panStreamId() && m_radioModel.panStream()) {
@@ -3533,6 +3569,16 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             || profileLoadRadioStateWritesHeld()) {
             return;
         }
+        // Headroom recovery asks the RADIO to move its scale — the clue is in
+        // the name of the signal that gets us here. A backend whose scale is
+        // fixed has nothing to ask and nothing that will answer, so the request
+        // is dropped, the handshake never completes, and the auto-floor retries
+        // it forever: this is the second source of the 24 dB/s dBm ratchet, and
+        // it survives gating the dbmRangeChangeRequested path alone (measured
+        // on an IC-9700 — the sendCommand lines stop, the rejections do not).
+        if (!m_radioModel.backendCapabilities().radioOwnsDbmScale) {
+            return;
+        }
         if (auto* pan = m_radioModel.panadapter(applet->panId());
             pan && !pan->ownedByClient(m_radioModel.ourClientHandle())) {
             return;
@@ -3565,6 +3611,18 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         // #3977: same whole-operation refusal as dbmRangeChangeRequested.
         if (auto* pan = m_radioModel.panadapter(applet->panId());
             pan && !pan->ownedByClient(m_radioModel.ourClientHandle())) {
+            return;
+        }
+
+        // A hand drag is a deliberate operator action, so it still moves the
+        // LOCAL scale on a fixed-scale backend — but there is no radio-side
+        // range to command and no echo to wait for, so skip the handshake and
+        // the command. Arming the handshake here would leave m_pendingDbmRange
+        // set until it times out, which is what blocks the next legitimate
+        // range update (SpectrumWidget::setDbmRange's early return).
+        if (!m_radioModel.backendCapabilities().radioOwnsDbmScale) {
+            sw->setDbmRange(minDbm, maxDbm);
+            setStreamDbmRange(minDbm, maxDbm, true);
             return;
         }
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -3806,6 +3806,15 @@ bool SpectrumWidget::updateNoiseFloorBaseline(const QVector<float>& bins, bool f
 
 void SpectrumWidget::applyNoiseFloorAutoAdjust(qint64 nowMs)
 {
+    // A FIXED-scale backend has no reference level to move: the floor is where
+    // its calibration puts it. Moving m_refLevel here would ratchet forever,
+    // because the loop only stops when the radio echoes the requested range
+    // back and there is nothing on the other end to echo. This is the gate that
+    // actually stops the runaway — the ones on the outbound command paths stop
+    // the traffic, but m_refLevel is local and would keep marching without this.
+    if (!m_radioOwnsDbmScale) {
+        return;
+    }
     if (noiseFloorAutoAdjustHeld(nowMs)) {
         return;
     }

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -316,6 +316,15 @@ public:
         return m_pendingDbmRangeEcho && m_pendingDbmRangeEchoFromAutoFloor;
     }
     bool noiseFloorAutoAdjustEnabled() const { return m_noiseFloorEnable; }
+    // False when the connected backend decodes its scope at a FIXED scale it
+    // does not accept range commands for (Icom CI-V). The auto-floor loop is
+    // built on the radio echoing a requested range back; with no echo it reads
+    // the unchanged floor as "not there yet" and steps the reference level
+    // again, forever. Kept separate from m_noiseFloorEnable, which is the
+    // OPERATOR's toggle — clobbering that would fight the overlay menu and
+    // persist to the next radio. See RadioCapabilities::radioOwnsDbmScale.
+    void setRadioOwnsDbmScale(bool on) { m_radioOwnsDbmScale = on; }
+    bool radioOwnsDbmScale() const { return m_radioOwnsDbmScale; }
     double centerMhz()    const { return m_centerMhz; }
     double bandwidthMhz() const { return m_bandwidthMhz; }
     // Width of the frequency canvas, in logical pixels: the widget width minus
@@ -1330,6 +1339,9 @@ private:
 
     // Noise floor auto-adjust
     bool  m_noiseFloorEnable{false};
+    // Defaults true so every existing backend is unaffected; only a backend
+    // that opts out (RadioCapabilities::radioOwnsDbmScale=false) disarms.
+    bool  m_radioOwnsDbmScale{true};
     int   m_noiseFloorPosition{75};  // 1=top, 99=bottom
     int   m_flexNoiseFloorPosition{75};
     int   m_kiwiNoiseFloorPosition{75};

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -717,7 +717,19 @@ void RadioModel::setupBackend(const QString& family)
         auto* pan = resolveBackendPan(panId);
         if (!pan) return;
         if (pan->setRange(minDbm, maxDbm)) {
-            m_panStream->setDbmRange(pan->panStreamId(), pan->minDbm(), pan->maxDbm());
+            // ⛔ m_panStream IS NULL on a backend that does not own one. It is
+            // assigned only on the Flex and Sim paths (see setupBackend), so an
+            // Icom — which decodes its scope inside the backend and never uses
+            // PanadapterStream — leaves it nullptr. Every other use in this file
+            // guards it; this one did not, and the deref crashed the GUI thread
+            // the instant the backend reported a dBm range. Four dumps, all
+            // identical: read of 0x30 in Qt6Core, reached from here.
+            //
+            // The range still reaches the model above, which is the part the
+            // display needs. The stream call is the FFT decoder's copy, and a
+            // backend with no PanadapterStream has no decoder to inform.
+            if (m_panStream)
+                m_panStream->setDbmRange(pan->panStreamId(), pan->minDbm(), pan->maxDbm());
         }
         emit panadapterLevelChanged(pan->minDbm(), pan->maxDbm());
     });
@@ -1213,6 +1225,10 @@ void RadioModel::setupBackend(const QString& family)
                 this, &RadioModel::onDisconnected);
         connect(m_backend.get(), &IRadioBackend::connectionError,
                 this, &RadioModel::onConnectionError);
+        // Advisory only — deliberately NOT routed through onConnectionError,
+        // which starts the reconnect timer. Re-emitted for the UI to surface.
+        connect(m_backend.get(), &IRadioBackend::configurationWarning,
+                this, &RadioModel::configurationWarning);
     }
 
     // Transport counters from a backend that owns its own socket. Wired

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -855,6 +855,9 @@ signals:
     void rawSliceModeListsChanged();
     void metersChanged();
     void connectionError(const QString& msg);
+    // Radio CONFIGURATION advice that does not end the session. See
+    // IRadioBackend::configurationWarning for why this is a separate channel.
+    void configurationWarning(const QString& msg);
     // Phase 2 of GHSA-wfx7-w6p8-4jr2 (#2951): forwarded from
     // WanConnection. UI is expected to prompt the operator and call
     // accept/rejectPresentedWanCert() in response.

--- a/tests/dbm_range_plausibility_test.cpp
+++ b/tests/dbm_range_plausibility_test.cpp
@@ -1,0 +1,99 @@
+// The dBm auto-floor ratchet, pinned as arithmetic.
+//
+// On a backend with no command plane the noise-floor auto-adjust requests a
+// range, the request is dropped, no echo comes back, and the loop steps the
+// reference level again. Measured against an IC-9700 at a linear 24 dB/s:
+//
+//     -154 / -64      dropped ("no command plane for this backend")
+//     -178 / -88      dropped
+//     -202 / -112     REJECTED — first one past dbmRangeLooksPlausible()
+//     ...
+//     -1882 / -1792   still going, 71 rejections in ~90 s
+//
+// The rejections are the symptom, not the fault: the run was already 48 dB
+// adrift before the first one, and raising the reject floor would only have
+// delayed it. What this file pins is the CONSEQUENCE of losing the echo, so
+// that a future change which reintroduces an unechoed request has something
+// that fails rather than a warning nobody is watching.
+//
+// dbmRangeLooksPlausible() is duplicated here rather than exported: it is a
+// file-static in MainWindow_Wiring.cpp, and linking that pulls in the whole GUI.
+// The duplication is asserted against the real constants below.
+
+#include "core/backends/RadioCapabilities.h"
+
+#include <QtGlobal>
+
+#include <cmath>
+#include <cstdio>
+
+using AetherSDR::RadioCapabilities;
+
+static int g_failures = 0;
+static void check(bool ok, const char* what)
+{
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what); ++g_failures; }
+}
+
+// Mirror of MainWindow_Wiring.cpp's dbmRangeLooksPlausible().
+static bool dbmRangeLooksPlausible(float minDbm, float maxDbm)
+{
+    constexpr float kMinAllowedDbm = -180.0f;
+    constexpr float kMaxAllowedDbm = 80.0f;
+    constexpr float kMinRangeDb = 10.0f;
+    constexpr float kMaxRangeDb = 180.0f;
+
+    if (!std::isfinite(minDbm) || !std::isfinite(maxDbm)) {
+        return false;
+    }
+    const float rangeDb = maxDbm - minDbm;
+    return minDbm >= kMinAllowedDbm
+        && maxDbm <= kMaxAllowedDbm
+        && rangeDb >= kMinRangeDb
+        && rangeDb <= kMaxRangeDb;
+}
+
+int main()
+{
+    // The observed ranges, verbatim from the IC-9700 log.
+    check(dbmRangeLooksPlausible(-154.0f, -64.0f),
+          "-154/-64 is plausible (it was DROPPED, not rejected — already adrift)");
+    check(dbmRangeLooksPlausible(-178.0f, -88.0f),
+          "-178/-88 is still plausible — the last one before the floor");
+    check(!dbmRangeLooksPlausible(-202.0f, -112.0f),
+          "-202/-112 is the first rejection");
+    check(!dbmRangeLooksPlausible(-1882.0f, -1792.0f),
+          "-1882/-1792, 71 steps later, still rejected");
+
+    // The span never changes: the loop slides refLevel and keeps dynamicRange.
+    // A drifting span would mean a different fault, so pin the shape too.
+    check(std::abs((-64.0f - -154.0f) - 90.0f) < 0.01f, "span is 90 dB at the start");
+    check(std::abs((-1792.0f - -1882.0f) - 90.0f) < 0.01f, "span is still 90 dB at the end");
+
+    // A fixed-scale backend's own calibration (ScopeCalibration: floor -140,
+    // span 80) MUST be plausible -- if it were not, the re-seed the fix falls
+    // back to would itself be rejected and the display would have no range.
+    check(dbmRangeLooksPlausible(-140.0f, -60.0f),
+          "the Icom's own calibrated range is plausible (the fix's fallback works)");
+
+    // Guard the boundary the ratchet crosses, so a change to kMinAllowedDbm is
+    // a deliberate act with a test to update rather than a silent widening.
+    check(dbmRangeLooksPlausible(-180.0f, -90.0f), "-180 is exactly on the floor");
+    check(!dbmRangeLooksPlausible(-180.01f, -90.0f), "just past the floor is rejected");
+
+    // Degenerate inputs: NaN reached this in the crash-adjacent paths.
+    check(!dbmRangeLooksPlausible(std::nanf(""), -60.0f), "NaN min is rejected");
+    check(!dbmRangeLooksPlausible(-140.0f, std::nanf("")), "NaN max is rejected");
+    check(!dbmRangeLooksPlausible(-60.0f, -140.0f), "inverted range is rejected");
+
+    // The gate defaults to "the radio owns the scale", so adding it changes
+    // NOTHING for a Flex or any other existing backend -- only a backend that
+    // opts out is affected. Pin that, because getting the default backwards
+    // would silently disable the auto-floor everywhere rather than fix one radio.
+    check(RadioCapabilities{}.radioOwnsDbmScale,
+          "radioOwnsDbmScale defaults TRUE (existing backends keep the auto-floor)");
+
+    if (g_failures == 0)
+        std::fprintf(stderr, "dbm_range_plausibility_test: all checks passed\n");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/dbm_range_plausibility_test.cpp
+++ b/tests/dbm_range_plausibility_test.cpp
@@ -16,9 +16,21 @@
 // that a future change which reintroduces an unechoed request has something
 // that fails rather than a warning nobody is watching.
 //
-// dbmRangeLooksPlausible() is duplicated here rather than exported: it is a
-// file-static in MainWindow_Wiring.cpp, and linking that pulls in the whole GUI.
-// The duplication is asserted against the real constants below.
+// ⚠ dbmRangeLooksPlausible() is DUPLICATED here rather than exported: it is a
+// file-static in MainWindow_Wiring.cpp and linking that pulls in the whole GUI.
+//
+// Be honest about what that costs: this file cannot catch a change to the real
+// constants. If someone widens kMinAllowedDbm to -400, the copy below still
+// says -180 and every check here still passes while the ratchet this exists to
+// document sails past the guard unnoticed.
+//
+// What it DOES pin is the arithmetic and the shape of the runaway, which is the
+// part that was hard to characterise and easy to misread as "just a bad number".
+// The behavioural half — that a fixed-scale backend never arms the loop at all —
+// is pinned in icom_family_test via the capability, where it can be asserted
+// against the real code. Exporting the predicate (its own small header, or a
+// namespace in a linkable TU) would let this file close the gap; worth doing if
+// a third caller ever needs it.
 
 #include "core/backends/RadioCapabilities.h"
 

--- a/tests/icom_family_test.cpp
+++ b/tests/icom_family_test.cpp
@@ -12,6 +12,7 @@
 #include "models/RadioModel.h"
 #include "core/RadioDiscovery.h"
 #include "core/backends/icom/IcomCivBackend.h"
+#include "core/backends/icom/IcomModels.h"
 
 #include <QCoreApplication>
 
@@ -61,6 +62,22 @@ int main(int argc, char** argv)
           "no IQ on any networked Icom — a true here offers a DAX-IQ path that cannot exist");
     check(caps.clientSettingsDomains == RadioCapabilities::ClientSettingsDomains{},
           "an Icom remembers its own state, so the client restores NOTHING");
+    // The MOD Input warning demands a WLAN modulation source. Only a radio with
+    // Wi-Fi has one -- and in kModels exactly ONE model does (the IC-705, whose
+    // 0xA4 is also the default CI-V address, which is almost certainly the radio
+    // the check was written against). On every other networked Icom the warning
+    // asked for a setting the radio cannot offer: an IC-9700 set correctly to
+    // LAN on the front panel reports 0x01 and was warned at it on every single
+    // session. Pin the discriminator so the gate cannot quietly come back.
+    check(!AetherSDR::icom::modelForCivAddress(0xA2)->hasWifi,
+          "the IC-9700 has no Wi-Fi — so no WLAN MOD Input to demand");
+    check(AetherSDR::icom::modelForCivAddress(0xA4)->hasWifi,
+          "the IC-705 does — the one model the WLAN check is legitimate for");
+
+    check(!caps.radioOwnsDbmScale,
+          "the scope scale is FIXED (ScopeCalibration), not the radio's to set — "
+          "true here re-arms the noise-floor auto-adjust against a radio that "
+          "never echoes a range back, and it ratchets 24 dB/s off the scale");
 
     // A pure seam backend owns no RadioConnection and no PanadapterStream, so
     // setupBackend()'s dynamic_cast chain must SKIP it — the same shape as HL2.

--- a/tests/icom_family_test.cpp
+++ b/tests/icom_family_test.cpp
@@ -79,6 +79,51 @@ int main(int argc, char** argv)
           "true here re-arms the noise-floor auto-adjust against a radio that "
           "never echoes a range back, and it ratchets 24 dB/s off the scale");
 
+    // ---- the published dBm axis tracks the reference level, WITH THE RIGHT SIGN ----
+    //
+    // toDbm() maps a sample to `floorDbm + (v/max)*spanDb - referenceDb`, so
+    // raising the radio's reference level moves the decoded trace DOWN. The axis
+    // the display draws has to move the same way, or trace and scale disagree by
+    // twice the reference — invisible at the default 0, and a growing error the
+    // further the operator moves it. The first version of this emit ADDED
+    // referenceDb where toDbm subtracts it.
+    //
+    // Driven through invokeExtension("scope.reference"), which is the real
+    // operator path AND the place the range must be re-published: before this,
+    // the range was emitted once at connect and never updated, so the trace slid
+    // and the scale stayed put.
+    {
+        auto* icomBackend = dynamic_cast<icom::IcomCivBackend*>(model.backend());
+        check(icomBackend != nullptr, "an Icom backend to drive");
+        if (icomBackend) {
+            double gotMin = 0.0, gotMax = 0.0;
+            int emits = 0;
+            QObject::connect(icomBackend, &IRadioBackend::panRangeChanged,
+                             [&](const QString&, double lo, double hi) {
+                                 gotMin = lo; gotMax = hi; ++emits;
+                             });
+
+            // An UNIDENTIFIED radio falls back to kUnknown, which has no scope,
+            // so this must publish NOTHING. Pinning the quiet case matters: the
+            // emit is on the connect path, and a version that published a range
+            // for a radio with no scope would put an axis on a pane that never
+            // gets a trace.
+            icomBackend->invokeExtension(QStringLiteral("icom"),
+                                         QStringLiteral("scope.reference"), 0, 10.0);
+            check(emits == 0,
+                  "a radio with no scope publishes no dBm range");
+
+            // The SIGN itself is pinned in icom_scope_test against toDbm(),
+            // which is the relationship that matters and can be asserted
+            // without a live radio. Reaching a scope-capable m_model needs the
+            // 0x19 0x00 reply over a real serial stream, so the emitted VALUE
+            // is exercised on hardware rather than faked here — recorded as a
+            // gap rather than papered over with a mock that proves nothing.
+            (void)gotMin;
+            (void)gotMax;
+        }
+    }
+
     // A pure seam backend owns no RadioConnection and no PanadapterStream, so
     // setupBackend()'s dynamic_cast chain must SKIP it — the same shape as HL2.
     check(model.backend()->ownsRxAudio(),

--- a/tests/icom_scope_test.cpp
+++ b/tests/icom_scope_test.cpp
@@ -286,6 +286,21 @@ static void testDbmMapping()
     auto shifted = toDbm(f, g, cal);
     check(shifted[0] < dbm[0], "a positive reference level shifts the trace down");
 
+    // THE AXIS MUST MOVE WITH THE TRACE, AND IN THE SAME DIRECTION.
+    //
+    // IcomCivBackend::publishScopeDbmRange() publishes the dBm range the display
+    // draws its scale from. It has to be derived the same way toDbm() derives
+    // the samples, or the trace and the scale disagree by twice the reference —
+    // invisible at the default 0, growing the further the operator moves it.
+    // An earlier version ADDED referenceDb where toDbm subtracts it, which is
+    // exactly that bug; this pins the relationship rather than the constant.
+    const double publishedFloor = cal.floorDbm - cal.referenceDb;
+    check(std::abs(publishedFloor - static_cast<double>(shifted[0])) < 0.05,
+          "the published floor equals what toDbm maps display 0 to");
+    const double publishedCeil = publishedFloor + cal.spanDb;
+    check(std::abs(publishedCeil - static_cast<double>(shifted[2])) < 0.05,
+          "and the published ceiling equals what it maps display max to");
+
     // A byte above the published 0..160 range must clamp, not project above the
     // top of the scale and drag the waterfall's auto-contrast with it.
     ScopeFrame over;

--- a/tests/radiomodel_pan_range_null_test.cpp
+++ b/tests/radiomodel_pan_range_null_test.cpp
@@ -1,0 +1,101 @@
+// The fifth path.
+//
+// radiomodel_dax_null_test fixed four bare m_panStream-> derefs behind the DAX
+// verbs. The panRangeChanged handler in setupBackend() was a fifth, and it is
+// worse than the DAX ones: DAX needs a user to activate something, whereas this
+// one fires by itself the moment a backend reports its dBm range -- which for an
+// Icom is during connect, from inside the CI-V frame handler.
+//
+// A backend that decodes its own scope (Icom CI-V, HL2, KiwiSDR) never gets a
+// PanadapterStream: it is assigned only on the Flex and Sim paths. So the very
+// first panRangeChanged from such a backend dereferenced null on the GUI thread.
+// Observed as an instant, repeatable crash on connecting an IC-9700 -- four
+// minidumps, all 0xC0000005 reading 0x30, all reaching PanadapterStream::
+// setDbmRange from this lambda.
+//
+// This asserts the property directly: with no stream, delivering a pan range
+// updates the model and does not dereference null.
+
+#include "models/RadioModel.h"
+#include "core/RadioDiscovery.h"
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+static void check(bool ok, const char* what)
+{
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what); ++g_failures; }
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    RadioModel model;
+
+    // As in the DAX test: the Flex default DOES own a stream, which is why the
+    // bare deref survived review.
+    check(model.panStream() != nullptr,
+          "the Flex default has a PanadapterStream (why the bare deref looked safe)");
+
+    // A self-decoding backend. HL2 stands in for the Icom here -- same property
+    // (no PanadapterStream), and it needs no radio to reach the state.
+    RadioInfo hl2;
+    hl2.family = QStringLiteral("hl2");
+    hl2.serial = QStringLiteral("00:00:00:00:00:00");
+    hl2.address = QHostAddress(QStringLiteral("192.0.2.1"));   // TEST-NET-1, unroutable
+    model.connectToRadio(hl2);
+
+    check(model.panStream() == nullptr,
+          "a self-decoding backend has no PanadapterStream");
+
+    auto* backend = model.backend();
+    check(backend != nullptr, "the backend swap happened");
+    if (!backend) return 1;
+
+    // A pan has to EXIST for this to test anything. resolveBackendPan() is a
+    // lookup, not a create, so on a bare model it returns null and the handler
+    // early-outs before the deref -- a test written without this would pass
+    // against the unfixed code while proving nothing.
+    // The backend's OWN pan id, in its own namespace -- exactly what an Icom
+    // puts on the wire. Neutral indices are allocated in first-seen order, so
+    // this id is unknown until the first signal names it. Do not substitute a
+    // model-side id: it would resolve to a different pan (or none) and stop
+    // exercising the path.
+    const QString panId = QStringLiteral("hl2-0");
+
+    // Geometry first, which is what MATERIALISES the pane -- createPanadapter()
+    // on a self-decoding backend asks the backend, not the model. This is also
+    // the real connect ordering: an Icom reports its geometry before its range.
+    emit backend->panCenterBandwidthChanged(panId, 144.300, 0.5);
+    check(!model.panadapters().isEmpty(), "a pan exists to report a range against");
+    if (model.panadapters().isEmpty()) return 1;
+
+    QSignalSpy levels(&model, &RadioModel::panadapterLevelChanged);
+
+    // THE CRASH, REPRODUCED: before the guard this dereferenced null here.
+    emit backend->panRangeChanged(panId, -140.0, -60.0);
+
+    check(levels.count() == 1,
+          "the range was delivered (the handler ran; it did not early-out)");
+
+    // And the range must actually reach the model -- the guard skips only the
+    // stream's copy, which a backend with no stream has no decoder to receive.
+    if (levels.count() == 1) {
+        const auto args = levels.takeFirst();
+        check(qFuzzyCompare(args.at(0).toDouble(), -140.0), "min dBm reached the model");
+        check(qFuzzyCompare(args.at(1).toDouble(), -60.0),  "max dBm reached the model");
+    }
+
+    // Idempotent: a second identical report is a no-op in the model, and still
+    // must not crash.
+    emit backend->panRangeChanged(panId, -140.0, -60.0);
+
+    if (g_failures == 0)
+        std::fprintf(stderr, "radiomodel_pan_range_null_test: all checks passed\n");
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Tested #4784 against a real IC-9700 the evening it merged. It connects, and RX works — but there were four faults in the way, one of which is a **crash that is live on `main` right now** and is not Icom-specific.

@jensenpat — this is the PR you asked for. Everything here is verified on the radio; the one thing that is *not* verified is transmit, and I have said so explicitly at the bottom rather than let it look tested.

Three commits: two were written while #4784 was open (they were meant as review fixes and are now fixes to shipped code), and one is tonight's work.

---

## 1. Null `PanadapterStream` — crashes the GUI thread on connect

⚠️ **This one is live on `main` and affects HL2 and Kiwi too, not just Icom.**

`RadioModel`'s `panRangeChanged` handler dereferenced `m_panStream` bare:

```cpp
if (pan->setRange(minDbm, maxDbm)) {
    m_panStream->setDbmRange(...);   // null on any self-decoding backend
}
```

`m_panStream` is assigned only on the Flex and Sim paths. Any backend that decodes its own scope leaves it null, so the **first dBm range the backend reports** kills the GUI thread. Four minidumps, all `0xC0000005` reading `0x30`, all reaching `PanadapterStream::setDbmRange` from this lambda.

This is the same defect `radiomodel_dax_null_test` already fixed four times — its own header says *"the same crash already fixed once at the `startDax()` entry, still reachable by four paths behind it."* This is the fifth path, and unlike the DAX ones it needs no user action: it fires by itself on connect.

`radiomodel_pan_range_null_test` reproduces it with no hardware. Guard removed, it exits `0xC0000005`.

## 2. dBm auto-floor runaway — the loop waits for an echo that never comes

The noise-floor auto-adjust slides the reference level, requests the new range, and waits for the radio to confirm before moving again. An Icom has no command plane for a display range, so the request is dropped, the confirmation never arrives, the unchanged floor reads as *"not there yet"*, and it steps again. Linear **24 dB/s**, span locked at 90 dB:

```
-154/-64   dropped ("no command plane for this backend")
-178/-88   dropped
-202/-112  REJECTED  <- first "implausible dBm range"
   ... 71 rejections later ...
-1882/-1792
```

The `implausible dBm range` warnings are the **symptom**. The run was already 48 dB adrift before the first one, so raising that floor would have hidden it, not fixed it.

Fix: new `RadioCapabilities::radioOwnsDbmScale`, **defaulting `true`** so every existing backend is untouched.

Worth a close look in review: gating the outbound command paths alone is **not sufficient**, and I had it wrong that way first. `m_refLevel` is local widget state, so the traffic stops while the ratchet keeps running — the `sendCommand` lines vanished from the log and the rejections carried on. The gate has to be on `applyNoiseFloorAutoAdjust` itself.

Deliberately *not* `setNoiseFloorEnable(false)` — that is the operator's own toggle, and forcing it would fight the overlay menu and persist to the next radio.

## 3. Configuration advice on a fatal channel — a self-inflicted reconnect loop

The MOD Input check emitted `connectionError`, which every consumer treats as fatal (`RadioModel` starts its reconnect timer on it unconditionally). The session came up healthy and the warning tore it down 4 ms later:

```
21:19:09.353  CI-V stream live
21:19:09.357  connection error: "The radio is not listening to network audio..."
21:19:09.357  connection error — reconnecting in 5s
```

Then again every 5 s, forever. From the operator's side that is a radio that will not stay connected, plus a message about a menu setting, with no way to tell that *the message is the disconnect*.

Added `IRadioBackend::configurationWarning` for advice that does not end the session. Status bar, 15 s rather than the usual 4 — it names a four-level menu path you have to walk on the radio's front panel while reading it.

The original intent is kept: this genuinely does cost the operator every transmission and should be visible. Just not on a channel that is fatal.

## 4. The MOD Input warning is wrong on every non-705 networked Icom

It demands `MOD Input = WLAN` (`0x03`). **The IC-9700 is LAN-only** — there is no WLAN option in its menu. Set correctly on the front panel, it reports `0x01`, and the warning fired on every session.

`kModels` already carried the discriminator:

| Model | Wi-Fi |
|---|---|
| IC-705 (`0xA4`) | **yes** |
| IC-9700, IC-7300, IC-7610, IC-7300MK2, IC-905 | no |

Exactly one model has Wi-Fi — the IC-705, whose `0xA4` is also the default CI-V address, so almost certainly the radio this was written and tested against. On every other networked Icom it asked for a modulation source the radio does not have, and no front-panel action could satisfy it.

Now gated on `hasWifi`, and the health readout no longer appends `— NOT WLAN` to a correctly configured radio. Nothing is lost: the warning was *wrong* here, not merely noisy.

**Left alone deliberately — needs your call.** The `1A 05` item numbers (118/119) and the value enum are hardcoded from one model's CI-V Reference Guide and sent to every Icom, but each model numbers its own SET menu. So on an IC-9700 either 118/119 is not MOD Input at all, or `0x01` *is* its network source. Both need that model's guide to settle, and I was not willing to guess at a TX-path setting. If you know the 9700 mapping I will wire it up per model.

## Also included (written during #4784, now fixes to merged code)

- **CI-V open retry.** One `buildSerialOpen` was not reliably enough: the radio accepted the open and sent nothing. Retries at 100 ms up to 50 attempts, stops on the first real payload, and warns with a specific cause if it never starts. Took the CI-V stream from dead (0 frames in 45 s) to live at 76 ms.
- **CI-V address field in the connection panel.** The address is user-changeable and other Icoms share this transport, so it cannot be assumed. Accepts `A2`, `0xA2`, `A2h`; unparseable input is ignored rather than clamped.
- **IC-9700 scope geometry recorded as measured** (475 points / 618 frames), deliberately keeping `verified: false` — measured on hardware is not the same as confirmed against that model's own CI-V guide.

---

## Verified on hardware — IC-9700, 2026-08-05

| | Before | After |
|---|---|---|
| implausible dBm rejections | 71 | **0** |
| connection errors | every 5 s | **0** |
| reconnects | continuous loop | **0** |
| CI-V bring-ups | one per reconnect | **1** |
| crash on connect | yes | **no** |

Each fix was falsified by breaking it deliberately and watching the test catch it, rather than by a green re-run. I re-ran the crash falsification after rebasing onto `main`, because a rebase can silently drop a hunk and a green test alone would not tell the difference.

### Tests

- `radiomodel_pan_range_null_test` — reproduces the crash with no hardware
- `dbm_range_plausibility_test` — pins the ratchet arithmetic and the defaults-`true` gate
- `icom_family_test` — extended with the capability and the `hasWifi` discriminator

### Not verified

**Transmit.** Whether TX audio actually reaches the modulator depends on the 118/119 mapping above, which is unresolved on this model. RX, scope and stability are solid; I have not keyed the radio.

Unrelated but visible in the logs: `TgxlConnection`/`PgxlConnection` retry a refused socket every ~9 s on a non-Flex radio. Harmless, pre-existing, untouched here — happy to look at it separately if you want.
