### PR TITLE
fix(gui): surface QRhi spectrum failures

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -951,7 +951,7 @@ alignment and upload-size invariants exercised by pop-out reparenting (#4091,
 | field | meaning |
 |---|---|
 | `dpr` | effective device-pixel ratio (fractional when `QT_SCALE_FACTOR` ≠ integer) |
-| `rendererFailed` / `rendererFailureReason` | whether this panadapter's QRhi renderer failed and its recorded reason; a failed renderer reports `QRhi failed: ...` in `renderer` too |
+| `rendererFailed` / `rendererFailureReason` | whether this panadapter's QRhi renderer failed and its recorded reason; a failed renderer reports `QRhi failed: ...` in `renderer` too. GPU builds only — omitted alongside the buffer fields when `gpu` is `false` |
 | `colorBufferAutoSized` | `true` when the widget lets QRhiWidget auto-size (`fixedColorBufferSize` unset); `false` when pinned |
 | `colorBufferW` / `colorBufferH` | the pinned device-pixel color buffer, or the unset sentinel `-1,-1` when auto-sized |
 | `expectedEvenW` / `expectedEvenH` | what an even-aligned pin should be for the current size — assert `colorBufferW/H` matches without recomputing the formula |

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -936,6 +936,7 @@ alignment and upload-size invariants exercised by pop-out reparenting (#4091,
 ← {"ok":true,"model":"rhi","pans":[{
    "panIndex":0,"name":"","visible":true,"widthPx":1100,"heightPx":455,"dpr":0.85,
    "gpu":true,"renderer":"GPU QRhi (D3D11; Intel(R) HD Graphics 520)",
+   "rendererFailed":false,"rendererFailureReason":"",
    "colorBufferAutoSized":false,"colorBufferW":936,"colorBufferH":388,
    "expectedEvenW":936,"expectedEvenH":388,"evenAligned":true,
    "overlayTextureW":936,"overlayTextureH":388,
@@ -950,6 +951,7 @@ alignment and upload-size invariants exercised by pop-out reparenting (#4091,
 | field | meaning |
 |---|---|
 | `dpr` | effective device-pixel ratio (fractional when `QT_SCALE_FACTOR` ≠ integer) |
+| `rendererFailed` / `rendererFailureReason` | whether this panadapter's QRhi renderer failed and its recorded reason; a failed renderer reports `QRhi failed: ...` in `renderer` too |
 | `colorBufferAutoSized` | `true` when the widget lets QRhiWidget auto-size (`fixedColorBufferSize` unset); `false` when pinned |
 | `colorBufferW` / `colorBufferH` | the pinned device-pixel color buffer, or the unset sentinel `-1,-1` when auto-sized |
 | `expectedEvenW` / `expectedEvenH` | what an even-aligned pin should be for the current size — assert `colorBufferW/H` matches without recomputing the formula |
@@ -966,6 +968,15 @@ alignment and upload-size invariants exercised by pop-out reparenting (#4091,
 `selector` filters by pan index (`get rhi 0`) or objectName. On non-GPU builds
 each entry reports `gpu:false` and omits the buffer fields. The three native
 topology fields are emitted only on macOS; other platforms omit them.
+
+For an automation-only QRhi failure check, launch with both
+`AETHER_AUTOMATION=1` and `AETHER_AUTOMATION_FORCE_RHI_FAILURE=1`. The latter
+keeps the platform's production QRhi API, presents only a blank clear pass, and
+exercises AetherSDR's failure-reporting path; it has no effect unless automation
+is enabled. Assert the per-pan `rendererFailed` state and the
+`rhi.render-failed` panadapter message, then capture the composite pan surface
+to confirm the warning card remains visible over the blank renderer. Production
+QRhi failures enter the same reporting path through `QRhiWidget::renderFailed()`.
 
 ### `get clients`
 Multi-session forensics (#3977/#3951): every client connected to the radio,

--- a/src/gui/SpectrumRhiFailureState.h
+++ b/src/gui/SpectrumRhiFailureState.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "PanadapterMessageOverlay.h"
+
+#include <QString>
+
+namespace AetherSDR {
+
+// Small value object for the latched QRhi failure contract. Keeping the state
+// independent from SpectrumWidget makes the first-failure and recovery rules
+// testable without constructing the full GPU widget.
+class SpectrumRhiFailureState
+{
+public:
+    bool report(const QString& reason)
+    {
+        if (m_failed) {
+            return false;
+        }
+        m_failed = true;
+        m_reason = reason;
+        return true;
+    }
+
+    bool clear()
+    {
+        if (!m_failed) {
+            return false;
+        }
+        m_failed = false;
+        m_reason.clear();
+        return true;
+    }
+
+    bool failed() const { return m_failed; }
+    const QString& reason() const { return m_reason; }
+
+    QString rendererDescription() const
+    {
+        return m_failed
+            ? QStringLiteral("QRhi failed: %1").arg(m_reason)
+            : QString();
+    }
+
+    PanadapterOverlayMessage warningMessage(const QString& title,
+                                             const QString& detail) const
+    {
+        PanadapterOverlayMessage message;
+        message.id = QStringLiteral("rhi.render-failed");
+        message.title = title;
+        message.detail = detail;
+        message.timeoutMs = 0;
+        message.dismissible = false;
+        message.collapsible = true;
+        message.tone = PanadapterOverlayMessageTone::Warning;
+        return message;
+    }
+
+private:
+    bool m_failed{false};
+    QString m_reason;
+};
+
+} // namespace AetherSDR

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -128,6 +128,13 @@ bool waterfallFrameResizeFailureForced()
         && qEnvironmentVariableIntValue(
                "AETHER_AUTOMATION_FORCE_WF_FRAME_RESIZE_FAILURE") != 0;
 }
+
+bool rhiFailureForcedForAutomation()
+{
+    return qEnvironmentVariableIsSet("AETHER_AUTOMATION")
+        && qEnvironmentVariableIntValue(
+               "AETHER_AUTOMATION_FORCE_RHI_FAILURE") != 0;
+}
 #endif
 
 constexpr int dssFillVerticesPerRow()
@@ -890,6 +897,10 @@ static bool qrhiDeviceNameLooksSoftware(const QString& deviceName)
 QString SpectrumWidget::rendererDescription() const
 {
 #ifdef AETHER_GPU_SPECTRUM
+    if (m_rhiFailureReported) {
+        return QStringLiteral("QRhi failed: %1").arg(m_rhiFailureReason);
+    }
+
     QRhi* currentRhi = rhi();
     if (!currentRhi) {
         return QStringLiteral("QRhi initializing");
@@ -948,6 +959,8 @@ QVariantMap SpectrumWidget::automationRhiSnapshot() const
 #ifdef AETHER_GPU_SPECTRUM
     m[QStringLiteral("gpu")] = true;
     m[QStringLiteral("renderer")] = rendererDescription();
+    m[QStringLiteral("rendererFailed")] = m_rhiFailureReported;
+    m[QStringLiteral("rendererFailureReason")] = m_rhiFailureReason;
     const QSize fixed = fixedColorBufferSize();
     // Unset fixedColorBufferSize() is the null QSize(-1,-1) — isEmpty()
     // covers it (and any degenerate size) → QRhiWidget auto-sizes.
@@ -1869,6 +1882,10 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     setAttribute(Qt::WA_OpaquePaintEvent);
     setAccessibleName(tr("Panadapter spectrum display"));
 #ifdef AETHER_GPU_SPECTRUM
+    connect(this, &QRhiWidget::renderFailed, this, [this]() {
+        reportRhiFailure(tr("Qt could not create or present the spectrum renderer."));
+    });
+
     // Explicitly request Metal on macOS.
 #  ifdef Q_OS_MAC
     setApi(QRhiWidget::Api::Metal);
@@ -12231,6 +12248,49 @@ bool SpectrumWidget::initWaterfallPipeline()
     return true;
 }
 
+void SpectrumWidget::reportRhiFailure(const QString& reason)
+{
+    if (m_rhiFailureReported) {
+        return;
+    }
+
+    const QString detail = reason.trimmed().isEmpty()
+        ? tr("The spectrum renderer failed.")
+        : reason.trimmed();
+    m_rhiFailureReported = true;
+    m_rhiFailureReason = detail;
+
+    qCWarning(lcGui) << "SpectrumWidget: QRhi failure:" << detail;
+
+    PanadapterOverlayMessage message;
+    message.id = QStringLiteral("rhi.render-failed");
+    message.title = tr("Spectrum renderer unavailable");
+#ifdef Q_OS_MAC
+    message.detail = tr("%1 Rebuild with -DAETHER_GPU_SPECTRUM=OFF.")
+                         .arg(detail);
+#else
+    message.detail = tr("%1 Try launching with AETHER_NO_GPU=1, or rebuild with "
+                        "-DAETHER_GPU_SPECTRUM=OFF.")
+                         .arg(detail);
+#endif
+    message.timeoutMs = 0;
+    message.dismissible = false;
+    message.collapsible = true;
+    message.tone = PanadapterOverlayMessageTone::Warning;
+    upsertOverlayMessage(std::move(message));
+}
+
+void SpectrumWidget::clearRhiFailure()
+{
+    if (!m_rhiFailureReported) {
+        return;
+    }
+
+    m_rhiFailureReported = false;
+    m_rhiFailureReason.clear();
+    removeOverlayMessage(QStringLiteral("rhi.render-failed"));
+}
+
 void SpectrumWidget::initOverlayPipeline()
 {
     QRhi* r = rhi();
@@ -12810,13 +12870,14 @@ void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
 
     QRhi* r = rhi();
     if (!r) {
-        qWarning() << "SpectrumWidget: QRhi initialization failed — no GPU backend";
+        reportRhiFailure(tr("No QRhi graphics backend is available."));
         return;
     }
 
     qDebug() << "SpectrumWidget: QRhi initialized, backend:" << r->backendName();
 
     if (!initWaterfallPipeline()) {
+        reportRhiFailure(tr("The waterfall rendering pipeline could not be created."));
         return;
     }
     initOverlayPipeline();
@@ -12916,6 +12977,12 @@ void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
     m_wfTexFullUpload = false;
     m_wfLastUploadedRow = m_wfWriteRow;
     m_rhiInitialized = true;
+    if (rhiFailureForcedForAutomation()) {
+        reportRhiFailure(
+            tr("A blank QRhi surface was forced for automation verification."));
+    } else {
+        clearRhiFailure();
+    }
 
     // Force full overlay repaint + upload — the new GPU texture is empty.
     // Without this, m_overlayStaticDirty and m_overlayNeedsUpload may be
@@ -14419,6 +14486,14 @@ void SpectrumWidget::render(QRhiCommandBuffer* cb)
         initialize(cb);
         if (!m_rhiInitialized) return;
     }
+    if (rhiFailureForcedForAutomation()) {
+        // Keep the widget on its production QRhi API. Mixing Null with Metal or
+        // D3D11 in one top-level window can crash Qt's backing-store compositor.
+        cb->beginPass(renderTarget(), Qt::black, {1.0f, 0});
+        cb->endPass();
+        raisePanadapterMessageOverlay();
+        return;
+    }
     if (m_resizeBufferSettleTimer && m_resizeBufferSettleTimer->isActive()) {
         // Keep presenting fresh FFT/waterfall data into the last settled render
         // target while QRhiWidget stretches it to the live geometry. This
@@ -14515,18 +14590,7 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
 {
     if (width() <= 0 || height() <= freqScaleH() + DIVIDER_H + 2) return;
 
-#ifdef AETHER_GPU_SPECTRUM
-    // GPU mode: render() handles everything via QRhi. Skip the full
-    // QPainter path to avoid redundant rendering + compositing overhead.
-    // This is the single biggest CPU optimization on macOS (100% → 20%).
-    if (m_rhiInitialized) {
-        SPECTRUM_BASE_CLASS::paintEvent(ev);
-        return;
-    }
-#endif
-
-    // panstats: software-path paint cost (GPU builds only reach here before
-    // QRhi init or after GPU teardown).
+    // panstats: software-path paint cost.
     m_panStats.paintEvents++;
     struct PaintCost {
         quint64& acc;

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -897,8 +897,8 @@ static bool qrhiDeviceNameLooksSoftware(const QString& deviceName)
 QString SpectrumWidget::rendererDescription() const
 {
 #ifdef AETHER_GPU_SPECTRUM
-    if (m_rhiFailureReported) {
-        return QStringLiteral("QRhi failed: %1").arg(m_rhiFailureReason);
+    if (m_rhiFailure.failed()) {
+        return m_rhiFailure.rendererDescription();
     }
 
     QRhi* currentRhi = rhi();
@@ -959,8 +959,8 @@ QVariantMap SpectrumWidget::automationRhiSnapshot() const
 #ifdef AETHER_GPU_SPECTRUM
     m[QStringLiteral("gpu")] = true;
     m[QStringLiteral("renderer")] = rendererDescription();
-    m[QStringLiteral("rendererFailed")] = m_rhiFailureReported;
-    m[QStringLiteral("rendererFailureReason")] = m_rhiFailureReason;
+    m[QStringLiteral("rendererFailed")] = m_rhiFailure.failed();
+    m[QStringLiteral("rendererFailureReason")] = m_rhiFailure.reason();
     const QSize fixed = fixedColorBufferSize();
     // Unset fixedColorBufferSize() is the null QSize(-1,-1) — isEmpty()
     // covers it (and any degenerate size) → QRhiWidget auto-sizes.
@@ -1882,6 +1882,7 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     setAttribute(Qt::WA_OpaquePaintEvent);
     setAccessibleName(tr("Panadapter spectrum display"));
 #ifdef AETHER_GPU_SPECTRUM
+    m_rhiFailureForcedForAutomation = rhiFailureForcedForAutomation();
     connect(this, &QRhiWidget::renderFailed, this, [this]() {
         reportRhiFailure(tr("Qt could not create or present the spectrum renderer."));
     });
@@ -12250,44 +12251,33 @@ bool SpectrumWidget::initWaterfallPipeline()
 
 void SpectrumWidget::reportRhiFailure(const QString& reason)
 {
-    if (m_rhiFailureReported) {
-        return;
-    }
-
     const QString detail = reason.trimmed().isEmpty()
         ? tr("The spectrum renderer failed.")
         : reason.trimmed();
-    m_rhiFailureReported = true;
-    m_rhiFailureReason = detail;
+    if (!m_rhiFailure.report(detail)) {
+        return;
+    }
 
     qCWarning(lcGui) << "SpectrumWidget: QRhi failure:" << detail;
 
-    PanadapterOverlayMessage message;
-    message.id = QStringLiteral("rhi.render-failed");
-    message.title = tr("Spectrum renderer unavailable");
 #ifdef Q_OS_MAC
-    message.detail = tr("%1 Rebuild with -DAETHER_GPU_SPECTRUM=OFF.")
-                         .arg(detail);
+    const QString messageDetail =
+        tr("%1 Rebuild with -DAETHER_GPU_SPECTRUM=OFF.").arg(detail);
 #else
-    message.detail = tr("%1 Try launching with AETHER_NO_GPU=1, or rebuild with "
-                        "-DAETHER_GPU_SPECTRUM=OFF.")
-                         .arg(detail);
+    const QString messageDetail =
+        tr("%1 Try launching with AETHER_NO_GPU=1, or rebuild with "
+           "-DAETHER_GPU_SPECTRUM=OFF.")
+            .arg(detail);
 #endif
-    message.timeoutMs = 0;
-    message.dismissible = false;
-    message.collapsible = true;
-    message.tone = PanadapterOverlayMessageTone::Warning;
-    upsertOverlayMessage(std::move(message));
+    upsertOverlayMessage(m_rhiFailure.warningMessage(
+        tr("Spectrum renderer unavailable"), messageDetail));
 }
 
 void SpectrumWidget::clearRhiFailure()
 {
-    if (!m_rhiFailureReported) {
+    if (!m_rhiFailure.clear()) {
         return;
     }
-
-    m_rhiFailureReported = false;
-    m_rhiFailureReason.clear();
     removeOverlayMessage(QStringLiteral("rhi.render-failed"));
 }
 
@@ -12977,7 +12967,7 @@ void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
     m_wfTexFullUpload = false;
     m_wfLastUploadedRow = m_wfWriteRow;
     m_rhiInitialized = true;
-    if (rhiFailureForcedForAutomation()) {
+    if (m_rhiFailureForcedForAutomation) {
         reportRhiFailure(
             tr("A blank QRhi surface was forced for automation verification."));
     } else {
@@ -14486,12 +14476,11 @@ void SpectrumWidget::render(QRhiCommandBuffer* cb)
         initialize(cb);
         if (!m_rhiInitialized) return;
     }
-    if (rhiFailureForcedForAutomation()) {
+    if (m_rhiFailureForcedForAutomation) {
         // Keep the widget on its production QRhi API. Mixing Null with Metal or
         // D3D11 in one top-level window can crash Qt's backing-store compositor.
         cb->beginPass(renderTarget(), Qt::black, {1.0f, 0});
         cb->endPass();
-        raisePanadapterMessageOverlay();
         return;
     }
     if (m_resizeBufferSettleTimer && m_resizeBufferSettleTimer->isActive()) {
@@ -14590,7 +14579,9 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
 {
     if (width() <= 0 || height() <= freqScaleH() + DIVIDER_H + 2) return;
 
-    // panstats: software-path paint cost.
+    // panstats: software-path paint cost. These counters are written only here,
+    // so they are meaningful only in an AETHER_GPU_SPECTRUM=OFF build — a GPU
+    // build never compiles this function and reports 0.
     m_panStats.paintEvents++;
     struct PaintCost {
         quint64& acc;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -1878,6 +1878,8 @@ private:
 
 #ifdef AETHER_GPU_SPECTRUM
     bool m_rhiInitialized{false};
+    bool m_rhiFailureReported{false};
+    QString m_rhiFailureReason;
 
     // Waterfall GPU resources
     QRhiGraphicsPipeline* m_wfPipeline{nullptr};
@@ -2000,6 +2002,8 @@ private:
 
     bool initWaterfallPipeline();
     void releaseWaterfallFramePipelineResources();
+    void reportRhiFailure(const QString& reason);
+    void clearRhiFailure();
     void initOverlayPipeline();
     void initSpectrumPipeline();
     void renderGpuFrame(QRhiCommandBuffer* cb, const QSize& logicalSize,

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -31,6 +31,7 @@ class QVariantAnimation;
 class QSoundEffect;
 
 #ifdef AETHER_GPU_SPECTRUM
+#include "SpectrumRhiFailureState.h"
 #include <QRhiWidget>
 #include <rhi/qrhi.h>
 #define SPECTRUM_BASE_CLASS QRhiWidget
@@ -1878,8 +1879,8 @@ private:
 
 #ifdef AETHER_GPU_SPECTRUM
     bool m_rhiInitialized{false};
-    bool m_rhiFailureReported{false};
-    QString m_rhiFailureReason;
+    bool m_rhiFailureForcedForAutomation{false};
+    SpectrumRhiFailureState m_rhiFailure;
 
     // Waterfall GPU resources
     QRhiGraphicsPipeline* m_wfPipeline{nullptr};

--- a/tests/panadapter_message_overlay_test.cpp
+++ b/tests/panadapter_message_overlay_test.cpp
@@ -10,6 +10,7 @@
 // out of the way across owner re-assertion, and never disappear entirely while
 // its condition holds.
 #include "gui/PanadapterMessageOverlay.h"
+#include "gui/SpectrumRhiFailureState.h"
 
 #include <QApplication>
 #include <QElapsedTimer>
@@ -21,6 +22,7 @@
 
 using AetherSDR::PanadapterMessageOverlay;
 using AetherSDR::PanadapterOverlayMessage;
+using AetherSDR::SpectrumRhiFailureState;
 
 namespace {
 
@@ -88,6 +90,20 @@ QVariantMap settledMessage(const PanadapterMessageOverlay& overlay,
         }
     }
     return previous;
+}
+
+bool waitForMessageRemoval(const PanadapterMessageOverlay& overlay,
+                           const QString& id)
+{
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < 2000) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+        if (findMessage(overlay, id).isEmpty()) {
+            return true;
+        }
+    }
+    return false;
 }
 
 // The card is never dismissible, so the owner stays the only thing that can
@@ -291,6 +307,47 @@ void testNonCollapsibleCardRejectsCollapse()
           "an unknown id is refused");
 }
 
+void testRhiFailureStateAndWarningContract()
+{
+    SpectrumRhiFailureState state;
+    check(!state.failed(), "QRhi failure state starts clear");
+    check(state.report(QStringLiteral("boom")),
+          "the first QRhi failure is accepted");
+    check(!state.report(QStringLiteral("later failure")),
+          "a repeated QRhi failure is deduplicated");
+    check(state.reason() == QStringLiteral("boom"),
+          "the first QRhi failure reason remains authoritative");
+    check(state.rendererDescription() == QStringLiteral("QRhi failed: boom"),
+          "renderer diagnostics expose the latched failure");
+
+    PanadapterMessageOverlay overlay;
+    overlay.resize(900, 500);
+    overlay.upsertMessage(state.warningMessage(
+        QStringLiteral("Spectrum renderer unavailable"),
+        QStringLiteral("boom")));
+
+    const QVariantMap message =
+        findMessage(overlay, QStringLiteral("rhi.render-failed"));
+    check(!message.isEmpty(), "the QRhi failure warning is present");
+    check(message.value(QStringLiteral("timeoutMs")).toInt() == 0,
+          "the QRhi failure warning is persistent");
+    check(!message.value(QStringLiteral("dismissible")).toBool(),
+          "the QRhi failure warning is not dismissible");
+    check(message.value(QStringLiteral("collapsible")).toBool(),
+          "the QRhi failure warning is collapsible");
+    check(message.value(QStringLiteral("tone")).toString()
+              == QStringLiteral("warning"),
+          "the QRhi failure warning uses warning tone");
+
+    check(state.clear(), "QRhi recovery clears the latched failure");
+    overlay.removeMessage(QStringLiteral("rhi.render-failed"));
+    check(!state.failed() && state.reason().isEmpty(),
+          "QRhi recovery clears the diagnostic state");
+    check(waitForMessageRemoval(overlay, QStringLiteral("rhi.render-failed")),
+          "QRhi recovery removes the warning");
+    check(!state.clear(), "clearing an already-clear failure is idempotent");
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -307,6 +364,7 @@ int main(int argc, char** argv)
     testExpandRestoresTheFullCard();
     testCollapsedCardStillPaints();
     testNonCollapsibleCardRejectsCollapse();
+    testRhiFailureStateAndWarningContract();
     if (failures == 0) {
         std::puts("Panadapter message overlay tests passed");
     }


### PR DESCRIPTION
## Summary

Fixes #4709.

Connects each GPU `SpectrumWidget` to `QRhiWidget::renderFailed()` and surfaces a stable, persistent warning card over the affected panadapter. The same state now updates renderer diagnostics, covers early QRhi/waterfall-pipeline failures, and is exposed through `get rhi` for automation. The unreachable GPU branch inside the software-only `paintEvent()` is removed and its paint-stat comment is corrected.

The automation-only failure hook retains the platform's production QRhi API and submits a blank clear pass. An earlier local proof attempt selected QRhi Null beside Metal and reproduced a Qt backing-store compositor crash; that approach was discarded before this commit.

## Constitution principle honored

Principle VIII — Evidence Over Assertion. The failure path is directly observable through the native UI, bridge state, persistent overlay state, renderer diagnostics, and a composite screenshot.

## Test plan

- [x] Native arm64 local build passes (`cmake --build build-native --target AetherSDR -j16`)
- [x] Failure behavior verified with the built-in `DEMO-0001` simulator; bridge TX permission disabled and `mox`, `transmitting`, and `tuning` remained false
- [x] Focused tests pass: `panadapter_message_overlay_test`, `software_opengl_request_test`, `native_widget_topology_test`
- [ ] Existing tests pass (CI)
- [x] Reproduction/proof steps documented in `docs/automation-bridge.md`
- [x] `tools/check_engine_boundary.py --strict` reports 0 blockers
- [x] Accessibility and generated bridge-doc checks pass

### Native bridge proof

Launched the arm64 app with isolated settings and:

```bash
AETHER_SETTINGS_DIR=/tmp/fb-4709/settings-safe \
AETHER_AUTOMATION=1 \
AETHER_AUTOMATION_NO_TX=1 \
AETHER_AUTOMATION_IDENTITY=issue-4709-safe \
AETHER_AUTOMATION_SOCKET=issue-4709-safe \
AETHER_AUTOMATION_FORCE_RHI_FAILURE=1 \
./build-native/AetherSDR.app/Contents/MacOS/AetherSDR
```

Then connected only to simulator serial `DEMO-0001`.

- `get rhi`: `rendererFailed: true`, renderer `QRhi failed: A blank QRhi surface was forced for automation verification.`
- `panmessage list 0`: one `rhi.render-failed` warning, `timeoutMs: 0`, `dismissible: false`, `collapsible: true`
- Follow-up `ping` remained healthy after the screenshot on the production Metal API
- Final `get transmit`: `mox: false`, `transmitting: false`, `tuning: false`

![QRhi failure warning over the blank panadapter](https://raw.githubusercontent.com/rfoust/AetherSDR/fix-4709-assets/.pr-assets/4709-after.png)

## Checklist

- [x] Commit is signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] No meter UI changes
- [x] User-visible automation diagnostics documented; `CHANGELOG.md` untouched
- [x] No security-sensitive changes

Generated with OpenAI Codex.
