### PR TITLE
Fix DFNR stereo pumping

### DIFF
--- a/src/core/MonoDspStereoAdapter.cpp
+++ b/src/core/MonoDspStereoAdapter.cpp
@@ -12,25 +12,22 @@ constexpr int kMaxBufferedFrames = kSampleRate * 5;
 constexpr int kFrameBytes = kChannels * static_cast<int>(sizeof(float));
 constexpr int kMaxBufferedBytes = kMaxBufferedFrames * kFrameBytes;
 constexpr int kCompactThresholdBytes = kSampleRate * kFrameBytes;
-constexpr float kEnvelopeCoeff = 0.006f;
-constexpr float kAttackCoeff = 0.22f;
-constexpr float kReleaseCoeff = 0.035f;
+// Keep balance changes well below the audio envelope rate. The mono DSP owns
+// the program waveform; this estimate only distributes it between channels.
+constexpr float kBalanceEnvelopeCoeff = 4.0e-5f;
+constexpr float kMonoObservabilityEnvelopeCoeff = 0.006f;
 constexpr float kPowerFloor = 1.0e-10f;
 constexpr float kMonoObservabilityRatio = 0.01f;
-constexpr float kMinObservableGain = 0.035f;
-constexpr float kMaxGain = 1.0f;
-constexpr float kStereoDetectionRatio = 1.0e-4f;
-constexpr float kProcessedMixAttackCoeff = 0.05f;
-constexpr float kProcessedMixReleaseCoeff = 0.01f;
+constexpr float kMaxBalanceGain = 2.0f;
 
 float clampSample(float sample)
 {
     return std::clamp(sample, -1.0f, 1.0f);
 }
 
-float updatePowerEnvelope(float current, float samplePower)
+float updatePowerEnvelope(float current, float samplePower, float coefficient)
 {
-    current += kEnvelopeCoeff * (samplePower - current);
+    current += coefficient * (samplePower - current);
     return current < kPowerFloor ? 0.0f : current;
 }
 
@@ -58,11 +55,11 @@ void MonoDspStereoAdapter::setProcessingLatencyFrames(int frames)
 void MonoDspStereoAdapter::resetEnvelopeState()
 {
     m_dryMonoPower = 0.0f;
+    m_leftPower = 0.0f;
+    m_rightPower = 0.0f;
     m_dryStereoPower = 0.0f;
-    m_sidePower = 0.0f;
-    m_processedPower = 0.0f;
-    m_gain = 1.0f;
-    m_processedMix = 1.0f;
+    m_leftBalance = 1.0f;
+    m_rightBalance = 1.0f;
 }
 
 int MonoDspStereoAdapter::readableDryStereoBytes() const
@@ -148,45 +145,39 @@ QByteArray MonoDspStereoAdapter::takeProcessedMono(const float* processedMono, i
         const float left = dry[dryFrames * kChannels];
         const float right = dry[dryFrames * kChannels + 1];
         const float dryMono = 0.5f * (left + right);
-        const float side = 0.5f * (left - right);
         const float dryStereoPower = 0.5f * (left * left + right * right);
 
-        m_dryMonoPower = updatePowerEnvelope(m_dryMonoPower, dryMono * dryMono);
-        m_dryStereoPower = updatePowerEnvelope(m_dryStereoPower, dryStereoPower);
-        m_sidePower = updatePowerEnvelope(m_sidePower, side * side);
-        m_processedPower = updatePowerEnvelope(m_processedPower, processed * processed);
+        m_dryMonoPower = updatePowerEnvelope(
+            m_dryMonoPower, dryMono * dryMono, kMonoObservabilityEnvelopeCoeff);
+        m_dryStereoPower = updatePowerEnvelope(
+            m_dryStereoPower, dryStereoPower, kMonoObservabilityEnvelopeCoeff);
 
-        float targetGain = kMaxGain;
         const float observableMonoFloor =
             std::max(kPowerFloor, m_dryStereoPower * kMonoObservabilityRatio);
-        // If stereo energy is present but the mono sum cancels, the mono DSP
-        // path has no trustworthy gain estimate. Preserve the dry stereo level.
-        if (m_dryMonoPower >= observableMonoFloor) {
-            targetGain = std::clamp(
-                std::sqrt(std::max(m_processedPower, 0.0f) / m_dryMonoPower),
-                kMinObservableGain,
-                kMaxGain);
+        const float instantObservableMonoFloor =
+            std::max(kPowerFloor, dryStereoPower * kMonoObservabilityRatio);
+        // If stereo energy is present but the mono sum cancels, there is no
+        // trustworthy denominator for a balance estimate. Keep the last valid
+        // balance instead of reintroducing dry audio or amplifying noise
+        // through an unstable ratio.
+        if (dryMono * dryMono >= instantObservableMonoFloor
+            && m_dryMonoPower >= observableMonoFloor) {
+            m_leftPower = updatePowerEnvelope(
+                m_leftPower, left * left, kBalanceEnvelopeCoeff);
+            m_rightPower = updatePowerEnvelope(
+                m_rightPower, right * right, kBalanceEnvelopeCoeff);
+            const float leftLevel = std::sqrt(std::max(m_leftPower, 0.0f));
+            const float rightLevel = std::sqrt(std::max(m_rightPower, 0.0f));
+            const float totalLevel = leftLevel + rightLevel;
+            if (totalLevel > 0.0f) {
+                m_leftBalance = std::clamp(
+                    2.0f * leftLevel / totalLevel, 0.0f, kMaxBalanceGain);
+                m_rightBalance = std::clamp(
+                    2.0f * rightLevel / totalLevel, 0.0f, kMaxBalanceGain);
+            }
         }
-        const float smoothCoeff = targetGain < m_gain ? kAttackCoeff : kReleaseCoeff;
-        m_gain += smoothCoeff * (targetGain - m_gain);
-
-        const float stereoRatio = m_sidePower
-            / std::max(m_dryStereoPower, kPowerFloor);
-        const float targetProcessedMix =
-            stereoRatio <= kStereoDetectionRatio ? 1.0f : 0.0f;
-        const float mixCoeff = targetProcessedMix < m_processedMix
-            ? kProcessedMixAttackCoeff
-            : kProcessedMixReleaseCoeff;
-        m_processedMix += mixCoeff * (targetProcessedMix - m_processedMix);
-        if (std::fabs(m_processedMix - targetProcessedMix) < 1.0e-6f) {
-            m_processedMix = targetProcessedMix;
-        }
-
-        const float envelopeMix = 1.0f - m_processedMix;
-        dst[i * kChannels] = clampSample(
-            m_processedMix * processed + envelopeMix * left * m_gain);
-        dst[i * kChannels + 1] = clampSample(
-            m_processedMix * processed + envelopeMix * right * m_gain);
+        dst[i * kChannels] = clampSample(processed * m_leftBalance);
+        dst[i * kChannels + 1] = clampSample(processed * m_rightBalance);
         ++dryFrames;
     }
 

--- a/src/core/MonoDspStereoAdapter.cpp
+++ b/src/core/MonoDspStereoAdapter.cpp
@@ -17,18 +17,21 @@ constexpr int kCompactThresholdBytes = kSampleRate * kFrameBytes;
 constexpr float kBalanceEnvelopeCoeff = 4.0e-5f;
 constexpr float kMonoObservabilityEnvelopeCoeff = 0.006f;
 constexpr float kPowerFloor = 1.0e-10f;
+// Keep the same effective input threshold when the envelope coefficient changes.
+constexpr float kBalancePowerFloor =
+    kPowerFloor * (kBalanceEnvelopeCoeff / kMonoObservabilityEnvelopeCoeff);
 constexpr float kMonoObservabilityRatio = 0.01f;
-constexpr float kMaxBalanceGain = 2.0f;
 
 float clampSample(float sample)
 {
     return std::clamp(sample, -1.0f, 1.0f);
 }
 
-float updatePowerEnvelope(float current, float samplePower, float coefficient)
+float updatePowerEnvelope(
+    float current, float samplePower, float coefficient, float floor)
 {
     current += coefficient * (samplePower - current);
-    return current < kPowerFloor ? 0.0f : current;
+    return current < floor ? 0.0f : current;
 }
 
 } // namespace
@@ -130,15 +133,15 @@ QByteArray MonoDspStereoAdapter::takeProcessedMono(const float* processedMono, i
         if (m_latencyFramesRemaining > 0) {
             // Preserve the engine's own startup output while retaining dry
             // samples until the processed stream reaches the same timeline.
-            dst[i * kChannels] = clampSample(processed);
-            dst[i * kChannels + 1] = clampSample(processed);
+            dst[i * kChannels] = clampSample(processed * m_leftBalance);
+            dst[i * kChannels + 1] = clampSample(processed * m_rightBalance);
             --m_latencyFramesRemaining;
             continue;
         }
 
         if (dryFrames >= availableFrames) {
-            dst[i * kChannels] = clampSample(processed);
-            dst[i * kChannels + 1] = clampSample(processed);
+            dst[i * kChannels] = clampSample(processed * m_leftBalance);
+            dst[i * kChannels + 1] = clampSample(processed * m_rightBalance);
             continue;
         }
 
@@ -148,9 +151,15 @@ QByteArray MonoDspStereoAdapter::takeProcessedMono(const float* processedMono, i
         const float dryStereoPower = 0.5f * (left * left + right * right);
 
         m_dryMonoPower = updatePowerEnvelope(
-            m_dryMonoPower, dryMono * dryMono, kMonoObservabilityEnvelopeCoeff);
+            m_dryMonoPower,
+            dryMono * dryMono,
+            kMonoObservabilityEnvelopeCoeff,
+            kPowerFloor);
         m_dryStereoPower = updatePowerEnvelope(
-            m_dryStereoPower, dryStereoPower, kMonoObservabilityEnvelopeCoeff);
+            m_dryStereoPower,
+            dryStereoPower,
+            kMonoObservabilityEnvelopeCoeff,
+            kPowerFloor);
 
         const float observableMonoFloor =
             std::max(kPowerFloor, m_dryStereoPower * kMonoObservabilityRatio);
@@ -163,17 +172,21 @@ QByteArray MonoDspStereoAdapter::takeProcessedMono(const float* processedMono, i
         if (dryMono * dryMono >= instantObservableMonoFloor
             && m_dryMonoPower >= observableMonoFloor) {
             m_leftPower = updatePowerEnvelope(
-                m_leftPower, left * left, kBalanceEnvelopeCoeff);
+                m_leftPower,
+                left * left,
+                kBalanceEnvelopeCoeff,
+                kBalancePowerFloor);
             m_rightPower = updatePowerEnvelope(
-                m_rightPower, right * right, kBalanceEnvelopeCoeff);
+                m_rightPower,
+                right * right,
+                kBalanceEnvelopeCoeff,
+                kBalancePowerFloor);
             const float leftLevel = std::sqrt(std::max(m_leftPower, 0.0f));
             const float rightLevel = std::sqrt(std::max(m_rightPower, 0.0f));
             const float totalLevel = leftLevel + rightLevel;
             if (totalLevel > 0.0f) {
-                m_leftBalance = std::clamp(
-                    2.0f * leftLevel / totalLevel, 0.0f, kMaxBalanceGain);
-                m_rightBalance = std::clamp(
-                    2.0f * rightLevel / totalLevel, 0.0f, kMaxBalanceGain);
+                m_leftBalance = 2.0f * leftLevel / totalLevel;
+                m_rightBalance = 2.0f * rightLevel / totalLevel;
             }
         }
         dst[i * kChannels] = clampSample(processed * m_leftBalance);

--- a/src/core/MonoDspStereoAdapter.h
+++ b/src/core/MonoDspStereoAdapter.h
@@ -4,8 +4,9 @@
 
 namespace AetherSDR {
 
-// Re-applies a mono DSP path's gain envelope to the delayed dry stereo signal.
-// This keeps a single mono noise analysis while preserving RX left/right balance.
+// Applies a delayed dry stereo balance to a mono DSP waveform. This keeps a
+// single mono noise analysis while preserving RX left/right balance without
+// feeding dry program material back into the processed output.
 class MonoDspStereoAdapter {
 public:
     explicit MonoDspStereoAdapter(int processingLatencyFrames = 0);
@@ -28,11 +29,11 @@ private:
     int m_processingLatencyFrames{0};
     int m_latencyFramesRemaining{0};
     float m_dryMonoPower{0.0f};
+    float m_leftPower{0.0f};
+    float m_rightPower{0.0f};
     float m_dryStereoPower{0.0f};
-    float m_sidePower{0.0f};
-    float m_processedPower{0.0f};
-    float m_gain{1.0f};
-    float m_processedMix{1.0f};
+    float m_leftBalance{1.0f};
+    float m_rightBalance{1.0f};
 };
 
 } // namespace AetherSDR

--- a/src/core/MonoDspStereoAdapter.h
+++ b/src/core/MonoDspStereoAdapter.h
@@ -5,8 +5,9 @@
 namespace AetherSDR {
 
 // Applies a delayed dry stereo balance to a mono DSP waveform. This keeps a
-// single mono noise analysis while preserving RX left/right balance without
-// feeding dry program material back into the processed output.
+// single mono noise analysis while preserving RX left/right levels without
+// feeding dry program material back into the processed output. Independent
+// stereo content cannot survive a mono DSP path; only its level balance does.
 class MonoDspStereoAdapter {
 public:
     explicit MonoDspStereoAdapter(int processingLatencyFrames = 0);

--- a/tests/mono_dsp_stereo_adapter_test.cpp
+++ b/tests/mono_dsp_stereo_adapter_test.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <utility>
 #include <vector>
@@ -46,6 +47,23 @@ QByteArray makeOppositePhaseStereoBlock(int frames, float scale)
     return block;
 }
 
+QByteArray makePannedNoisyStereoBlock(int frames, float leftScale, float rightScale)
+{
+    QByteArray block(frames * 2 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
+    auto* samples = reinterpret_cast<float*>(block.data());
+    std::uint32_t state = 0x4d595df4U;
+    for (int i = 0; i < frames; ++i) {
+        state = state * 1664525U + 1013904223U;
+        const float noise = static_cast<float>((state >> 8) & 0xffffU) / 32767.5f - 1.0f;
+        const float dry = 0.22f * std::sin(
+            2.0f * kPi * 733.0f * static_cast<float>(i) / kSampleRate)
+            + 0.12f * noise;
+        samples[i * 2] = leftScale * dry;
+        samples[i * 2 + 1] = rightScale * dry;
+    }
+    return block;
+}
+
 QByteArray makeConstantStereoBlock(int frames, float left, float right)
 {
     QByteArray block(frames * 2 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
@@ -66,6 +84,16 @@ std::vector<float> makeProcessedMono(const QByteArray& stereoBlock, float gain)
         mono[i] = gain * 0.5f * (samples[i * 2] + samples[i * 2 + 1]);
     }
     return mono;
+}
+
+std::vector<float> makeProcessedWaveform(int frames)
+{
+    std::vector<float> processed(frames);
+    for (int i = 0; i < frames; ++i) {
+        processed[i] = 0.28f * std::sin(
+            2.0f * kPi * 1379.0f * static_cast<float>(i) / kSampleRate);
+    }
+    return processed;
 }
 
 Rms measureRms(const QByteArray& stereoBlock, int discardFrames)
@@ -146,32 +174,28 @@ bool testBuffersDryUntilProcessedArrives()
     return true;
 }
 
-bool testOppositePhaseStereoDoesNotFadeOut()
+bool testOppositePhaseStereoUsesCenteredProcessedFallback()
 {
     MonoDspStereoAdapter adapter;
     const QByteArray dry = makeOppositePhaseStereoBlock(kSampleRate, 0.6f);
-    const std::vector<float> processedMono = makeProcessedMono(dry, 0.42f);
+    const std::vector<float> processedMono = makeProcessedWaveform(kSampleRate);
 
     adapter.pushDryStereo(dry);
     const QByteArray out = adapter.takeProcessedMono(
         processedMono.data(), static_cast<int>(processedMono.size()));
 
-    const Rms rms = measureRms(out, kSampleRate / 4);
-    const double ratio = rms.left / std::max(rms.right, 1.0e-12);
-    if (!nearlyEqual(ratio, 1.0, 0.05)) {
-        std::printf("opposite-phase ratio failed: got %.6f expected 1.0\n", ratio);
-        return false;
-    }
-    if (rms.left < 0.35 || rms.right < 0.35) {
-        std::printf("opposite-phase stereo faded out: L %.6f R %.6f\n",
-                    rms.left,
-                    rms.right);
-        return false;
+    const auto* samples = reinterpret_cast<const float*>(out.constData());
+    for (int i = 0; i < kSampleRate; ++i) {
+        if (!nearlyEqual(samples[i * 2], processedMono[i], 1.0e-6)
+            || !nearlyEqual(samples[i * 2 + 1], processedMono[i], 1.0e-6)) {
+            std::printf("opposite-phase fallback lost processed waveform at frame %d\n", i);
+            return false;
+        }
     }
     return true;
 }
 
-bool testProcessedSilenceKeepsMinimumStereoFloor()
+bool testProcessedSilenceRemainsSilent()
 {
     MonoDspStereoAdapter adapter;
     const QByteArray dry = makeStereoBlock(kSampleRate * 2, 0.8f, 0.2f);
@@ -182,17 +206,12 @@ bool testProcessedSilenceKeepsMinimumStereoFloor()
     const QByteArray out = adapter.takeProcessedMono(
         processedMono.data(), static_cast<int>(processedMono.size()));
 
-    const Rms rms = measureRms(out, kSampleRate);
-    const double ratio = rms.left / std::max(rms.right, 1.0e-12);
-    if (!nearlyEqual(ratio, 4.0, 0.05)) {
-        std::printf("minimum-floor ratio failed: got %.6f expected 4.0\n", ratio);
-        return false;
-    }
-    if (rms.left < 0.012 || rms.right < 0.003) {
-        std::printf("minimum-floor output too quiet: L %.6f R %.6f\n",
-                    rms.left,
-                    rms.right);
-        return false;
+    const auto* samples = reinterpret_cast<const float*>(out.constData());
+    for (int i = 0; i < frames * 2; ++i) {
+        if (samples[i] != 0.0f) {
+            std::printf("processed silence leaked dry audio at sample %d\n", i);
+            return false;
+        }
     }
     return true;
 }
@@ -251,6 +270,65 @@ bool testDuplicatedMonoUsesProcessedWaveform()
     return true;
 }
 
+bool testPannedDryDoesNotReplaceProcessedWaveform()
+{
+    MonoDspStereoAdapter adapter;
+    const int frames = kSampleRate;
+    const QByteArray dry = makePannedNoisyStereoBlock(frames, 0.8f, 0.2f);
+    const std::vector<float> processed = makeProcessedWaveform(frames);
+
+    adapter.pushDryStereo(dry);
+    const QByteArray out = adapter.takeProcessedMono(processed.data(), frames);
+    const auto* samples = reinterpret_cast<const float*>(out.constData());
+    for (int i = frames / 4; i < frames; ++i) {
+        const float expectedLeft = processed[i] * 1.6f;
+        const float expectedRight = processed[i] * 0.4f;
+        if (!nearlyEqual(samples[i * 2], expectedLeft, 1.0e-5)
+            || !nearlyEqual(samples[i * 2 + 1], expectedRight, 1.0e-5)) {
+            std::printf("panned dry replaced or modulated processed waveform at frame %d\n", i);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool testMonoCancellationHoldsLastBalance()
+{
+    MonoDspStereoAdapter adapter;
+    const QByteArray panned = makePannedNoisyStereoBlock(kSampleRate, 0.8f, 0.2f);
+    const QByteArray cancelled = makeOppositePhaseStereoBlock(kSampleRate, 0.6f);
+    const std::vector<float> processed = makeProcessedWaveform(kSampleRate);
+
+    adapter.pushDryStereo(panned);
+    adapter.takeProcessedMono(processed.data(), kSampleRate);
+    adapter.pushDryStereo(cancelled);
+    const QByteArray out = adapter.takeProcessedMono(processed.data(), kSampleRate);
+    const auto* samples = reinterpret_cast<const float*>(out.constData());
+    for (int i = kSampleRate / 4; i < kSampleRate; ++i) {
+        const float expectedLeft = processed[i] * 1.6f;
+        const float expectedRight = processed[i] * 0.4f;
+        if (!nearlyEqual(samples[i * 2], expectedLeft, 2.0e-3)
+            || !nearlyEqual(samples[i * 2 + 1], expectedRight, 2.0e-3)) {
+            std::printf("mono-cancellation fallback changed the established balance at frame %d\n", i);
+            return false;
+        }
+    }
+
+    adapter.pushDryStereo(panned);
+    const QByteArray recovered = adapter.takeProcessedMono(processed.data(), kSampleRate);
+    const auto* recoveredSamples = reinterpret_cast<const float*>(recovered.constData());
+    for (int i = 0; i < kSampleRate / 4; ++i) {
+        const float expectedLeft = processed[i] * 1.6f;
+        const float expectedRight = processed[i] * 0.4f;
+        if (!nearlyEqual(recoveredSamples[i * 2], expectedLeft, 2.0e-3)
+            || !nearlyEqual(recoveredSamples[i * 2 + 1], expectedRight, 2.0e-3)) {
+            std::printf("mono-cancellation recovery changed the established balance at frame %d\n", i);
+            return false;
+        }
+    }
+    return true;
+}
+
 bool testProcessingLatencyRetainsDryTimeline()
 {
     constexpr int latencyFrames = 4;
@@ -298,16 +376,22 @@ int main()
     if (!testBuffersDryUntilProcessedArrives()) {
         return 1;
     }
-    if (!testOppositePhaseStereoDoesNotFadeOut()) {
+    if (!testPannedDryDoesNotReplaceProcessedWaveform()) {
         return 1;
     }
-    if (!testProcessedSilenceKeepsMinimumStereoFloor()) {
+    if (!testOppositePhaseStereoUsesCenteredProcessedFallback()) {
+        return 1;
+    }
+    if (!testProcessedSilenceRemainsSilent()) {
         return 1;
     }
     if (!testIndependentAdaptersDoNotDrainOtherSource()) {
         return 1;
     }
     if (!testDuplicatedMonoUsesProcessedWaveform()) {
+        return 1;
+    }
+    if (!testMonoCancellationHoldsLastBalance()) {
         return 1;
     }
     if (!testProcessingLatencyRetainsDryTimeline()) {

--- a/tests/mono_dsp_stereo_adapter_test.cpp
+++ b/tests/mono_dsp_stereo_adapter_test.cpp
@@ -64,6 +64,32 @@ QByteArray makePannedNoisyStereoBlock(int frames, float leftScale, float rightSc
     return block;
 }
 
+QByteArray makeDecorrelatedPannedStereoBlock(
+    int frames, float leftScale, float rightScale)
+{
+    QByteArray block(frames * 2 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
+    auto* samples = reinterpret_cast<float*>(block.data());
+    std::uint32_t leftState = 0x4d595df4U;
+    std::uint32_t rightState = 0x8f7011eeU;
+    for (int i = 0; i < frames; ++i) {
+        leftState = leftState * 1664525U + 1013904223U;
+        rightState = rightState * 22695477U + 1U;
+        const float leftNoise =
+            static_cast<float>((leftState >> 8) & 0xffffU) / 32767.5f - 1.0f;
+        const float rightNoise =
+            static_cast<float>((rightState >> 8) & 0xffffU) / 32767.5f - 1.0f;
+        const float leftDry = 0.22f * std::sin(
+            2.0f * kPi * 733.0f * static_cast<float>(i) / kSampleRate)
+            + 0.12f * leftNoise;
+        const float rightDry = 0.22f * std::sin(
+            2.0f * kPi * 997.0f * static_cast<float>(i) / kSampleRate)
+            + 0.12f * rightNoise;
+        samples[i * 2] = leftScale * leftDry;
+        samples[i * 2 + 1] = rightScale * rightDry;
+    }
+    return block;
+}
+
 QByteArray makeConstantStereoBlock(int frames, float left, float right)
 {
     QByteArray block(frames * 2 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
@@ -292,6 +318,92 @@ bool testPannedDryDoesNotReplaceProcessedWaveform()
     return true;
 }
 
+bool testQuietChannelDoesNotLatchMuted()
+{
+    MonoDspStereoAdapter adapter;
+    const int frames = kSampleRate;
+    const QByteArray dry = makeStereoBlock(frames, 0.02f, 0.001f);
+    const std::vector<float> processed(frames, 0.1f);
+
+    adapter.pushDryStereo(dry);
+    const QByteArray out = adapter.takeProcessedMono(processed.data(), frames);
+    const auto* samples = reinterpret_cast<const float*>(out.constData());
+    const float expectedLeft = 2.0f * 0.02f / 0.021f;
+    const float expectedRight = 2.0f * 0.001f / 0.021f;
+    for (int i = frames / 2; i < frames; ++i) {
+        if (!nearlyEqual(samples[i * 2], 0.1f * expectedLeft, 1.0e-4)
+            || !nearlyEqual(samples[i * 2 + 1], 0.1f * expectedRight, 1.0e-4)) {
+            std::printf("quiet balance latched a channel at frame %d: L %.6f R %.6f\n",
+                        i,
+                        samples[i * 2],
+                        samples[i * 2 + 1]);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool testBalanceTransitionUsesSlowEnvelope()
+{
+    MonoDspStereoAdapter adapter;
+    const int settleFrames = kSampleRate * 3;
+    const int transitionFrames = kSampleRate * 2;
+    const QByteArray initial =
+        makeDecorrelatedPannedStereoBlock(settleFrames, 0.8f, 0.2f);
+    const QByteArray swapped =
+        makeDecorrelatedPannedStereoBlock(transitionFrames, 0.2f, 0.8f);
+    const std::vector<float> settleProcessed(settleFrames, 0.1f);
+    const std::vector<float> transitionProcessed(transitionFrames, 0.1f);
+
+    adapter.pushDryStereo(initial);
+    adapter.takeProcessedMono(settleProcessed.data(), settleFrames);
+    adapter.pushDryStereo(swapped);
+    const QByteArray out = adapter.takeProcessedMono(
+        transitionProcessed.data(), transitionFrames);
+    const auto* samples = reinterpret_cast<const float*>(out.constData());
+
+    constexpr int kEarlyFrame = 1000;
+    const float earlyLeftBalance = samples[kEarlyFrame * 2] / 0.1f;
+    const float earlyRightBalance = samples[kEarlyFrame * 2 + 1] / 0.1f;
+    if (earlyLeftBalance < 1.35f || earlyRightBalance > 0.65f) {
+        std::printf("balance transition tracked too quickly: L %.6f R %.6f\n",
+                    earlyLeftBalance,
+                    earlyRightBalance);
+        return false;
+    }
+
+    const int finalFrame = transitionFrames - 1;
+    const float finalLeftBalance = samples[finalFrame * 2] / 0.1f;
+    const float finalRightBalance = samples[finalFrame * 2 + 1] / 0.1f;
+    if (finalLeftBalance > 0.8f || finalRightBalance < 1.2f) {
+        std::printf("balance transition tracked too slowly: L %.6f R %.6f\n",
+                    finalLeftBalance,
+                    finalRightBalance);
+        return false;
+    }
+    return true;
+}
+
+bool testDryUnderrunHoldsLastBalance()
+{
+    MonoDspStereoAdapter adapter;
+    const QByteArray panned = makePannedNoisyStereoBlock(kSampleRate, 0.8f, 0.2f);
+    const std::vector<float> processed(kSampleRate, 0.1f);
+
+    adapter.pushDryStereo(panned);
+    adapter.takeProcessedMono(processed.data(), kSampleRate);
+    const QByteArray out = adapter.takeProcessedMono(processed.data(), kSampleRate);
+    const auto* samples = reinterpret_cast<const float*>(out.constData());
+    for (int i = 0; i < kSampleRate; ++i) {
+        if (!nearlyEqual(samples[i * 2], 0.16f, 1.0e-5)
+            || !nearlyEqual(samples[i * 2 + 1], 0.04f, 1.0e-5)) {
+            std::printf("dry underrun centered the held balance at frame %d\n", i);
+            return false;
+        }
+    }
+    return true;
+}
+
 bool testMonoCancellationHoldsLastBalance()
 {
     MonoDspStereoAdapter adapter;
@@ -377,6 +489,15 @@ int main()
         return 1;
     }
     if (!testPannedDryDoesNotReplaceProcessedWaveform()) {
+        return 1;
+    }
+    if (!testQuietChannelDoesNotLatchMuted()) {
+        return 1;
+    }
+    if (!testBalanceTransitionUsesSlowEnvelope()) {
+        return 1;
+    }
+    if (!testDryUnderrunHoldsLastBalance()) {
         return 1;
     }
     if (!testOppositePhaseStereoUsesCenteredProcessedFallback()) {


### PR DESCRIPTION
## Summary

Fixes #4766.

DFNR still routed its mono denoised waveform through `MonoDspStereoAdapter`, which switched to delayed dry stereo whenever the input channels were not effectively identical. It then drove that dry signal with a fast processed-to-dry power envelope, producing the same speech-dependent pumping family previously fixed in RN2.

Keep the processed mono waveform authoritative and use the delayed dry stereo only to estimate a slow normalized left/right balance. Mono-cancelling input holds the last trustworthy balance rather than leaking dry audio or destabilizing the estimator. Latency preroll and dry-buffer underruns also retain that held balance instead of briefly snapping to center.

The balance estimator now scales its numerical floor with its slower coefficient so a quiet but valid channel does not latch at zero. The normalization is intrinsically bounded to `[0, 2]`, so the unreachable output clamps were removed.

Regression coverage proves that panned/noisy dry input cannot replace or modulate an unrelated processed waveform, processed silence remains silent, quiet channels remain represented, the balance transition stays intentionally slow, dry underruns retain the established balance, and mono cancellation preserves and cleanly recovers it.

## Shared-adapter scope

`MonoDspStereoAdapter` is shared by `DeepFilterFilter` (DFNR), `NvidiaAfxFilter` (BNR), and `SpecbleachFilter`. The class-level contract and regression tests therefore cover the common adapter behavior for all three call sites. Because each processor supplies a mono waveform, genuinely independent stereo content cannot survive this path; the adapter preserves only the dry input's slow left/right level balance while keeping the processed mono waveform authoritative.

Hardware A/B listening for this PR was performed with DFNR. NVIDIA BNR is unavailable in this macOS/arm64 build, so no local BNR listening claim is made.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The targeted regression fails against the pre-fix adapter (`panned dry replaced or modulated processed waveform at frame 6000`) and passes with this change; the fix was also built, bridge-probed, and listened to on a real radio before publication.

## Test plan

- [x] Full macOS arm64 build completed with the repository-mandated toolchain (`/opt/homebrew/bin/cmake --build build-codex-arm64 -j8`)
- [x] Behavior verified on a real FLEX-6700 with DFNR active; reporter-equivalent A/B listening was substantially improved
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented: compare a voice signal with DFNR off/on, especially on non-identical stereo output

Additional local proof:

- `ctest --test-dir build-codex-arm64 -R '^(mono_dsp_stereo_adapter_test|rnnoise_filter_test|spectral_nr_test)$' --output-on-failure` — 3/3 passed
- `python3 tools/check_engine_boundary.py --strict` — 0 blocking findings
- CMake host/system processors and final executable verified arm64; no RNNoise x86 source compile edges are present. The repository's unconditional RNNoise x86 include-directory metadata still makes the newer exact `build.ninja` zero-match guard fail; that pre-existing CMake issue is unchanged by this PR.
- Strict automation bridge `audioCapture probeDspStereo DFNR strict` — full coverage, audible output, intended 4:1 stereo balance preserved with zero ratio error
- RX-only bridge run: connected FLEX-6700, DFNR available and active, radio not transmitting, `txAllowed=false`
- Manual A/B acceptance: “this sounds much better”

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no settings changes
- [x] Code is clean-room — not derived from proprietary binary inspection
- [x] All meter UI uses `MeterSmoother` — no meter UI changes
- [x] Documentation reviewed; no documentation or `CHANGELOG.md` change is needed for this focused bug fix
- [x] Security-sensitive changes reference a GHSA if applicable — not applicable
