### PR TITLE
fix(tci): retain native-rate RX buffer through frame send

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -2476,7 +2476,12 @@ void TciServer::onDaxAudioReady(int channel, const QByteArray& pcm)
             continue;
         }
 
-        const float* audioSrc = reinterpret_cast<const float*>(accumBuf.constData());
+        // Transfer ownership before taking a data pointer.  The native 24 kHz
+        // path uses this storage directly; clearing/squeezing accumBuf first
+        // left audioSrc dangling while gain conversion or frame construction
+        // still read it (#4744).
+        QByteArray accumulated = std::move(accumBuf);
+        const float* audioSrc = reinterpret_cast<const float*>(accumulated.constData());
         int audioFrames = accumFrames;
         QByteArray resampledBuf;
 
@@ -2485,13 +2490,6 @@ void TciServer::onDaxAudioReady(int channel, const QByteArray& pcm)
             audioSrc = reinterpret_cast<const float*>(resampledBuf.constData());
             audioFrames = resampledBuf.size() / (2 * static_cast<int>(sizeof(float)));
         }
-
-        // squeeze() after clear() releases the buffer's heap allocation so
-        // idle channels that were reassigned away don't hold kAccumMinFrames
-        // worth of memory indefinitely. Cost is a re-alloc on next packet —
-        // trivial next to the resampling work that just finished.
-        accumBuf.clear();
-        accumBuf.squeeze();
 
         int srcSamples = audioFrames * 2;  // stereo
 

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -2477,10 +2477,14 @@ void TciServer::onDaxAudioReady(int channel, const QByteArray& pcm)
         }
 
         // Transfer ownership before taking a data pointer.  The native 24 kHz
-        // path uses this storage directly; clearing/squeezing accumBuf first
-        // left audioSrc dangling while gain conversion or frame construction
-        // still read it (#4744).
+        // path uses this storage directly, including when it inherits staged
+        // samples across a rate change; clearing/squeezing accumBuf first left
+        // audioSrc dangling while gain conversion or frame construction still
+        // read it (#4744).
         QByteArray accumulated = std::move(accumBuf);
+        // Pin the moved-from state for the next packet's append.  The local
+        // owner releases the old allocation at the end of this iteration.
+        accumBuf.clear();
         const float* audioSrc = reinterpret_cast<const float*>(accumulated.constData());
         int audioFrames = accumFrames;
         QByteArray resampledBuf;

--- a/tests/tci_server_review_test.cpp
+++ b/tests/tci_server_review_test.cpp
@@ -1132,9 +1132,9 @@ public:
         return sent.contains(QStringLiteral("vfo:0,0,%1;").arg(parked));
     }
 
-    // #4744: native-rate TCI RX uses the accumulation buffer as its frame
-    // source.  Releasing that buffer before sendBinaryMessage() left the
-    // payload pointer dangling; an allocator reuse could corrupt audio or AV.
+    // #4744: switching from resampled TCI RX to native rate carries staged
+    // samples into the native frame source. Releasing that buffer before
+    // gain conversion or sendBinaryMessage() left the payload pointer dangling.
     static bool native24kAudioRetainsAccumulatedPayload()
     {
         RadioModel model;
@@ -1169,13 +1169,13 @@ public:
         }
 
         client.sendTextMessage(QStringLiteral(
-            "audio_samplerate:24000;audio_stream_sample_type:float32;"
+            "audio_samplerate:48000;audio_stream_sample_type:float32;"
             "audio_stream_channels:2;audio_start:0;"));
         for (int i = 0; i < 100 && !server.m_clients.first().audioEnabled; ++i) {
             spin(10);
         }
         if (!server.m_clients.first().audioEnabled
-            || server.m_clients.first().audioSampleRate != 24000) {
+            || server.m_clients.first().audioSampleRate != 48000) {
             std::printf("      audioEnabled=%d sampleRate=%d\n",
                         server.m_clients.first().audioEnabled,
                         server.m_clients.first().audioSampleRate);
@@ -1189,21 +1189,56 @@ public:
         for (int i = 0; i < kFrames * 2; ++i) {
             samples[i] = static_cast<float>(i + 1) / 1024.0f;
         }
-        server.m_rxChannelGain[0] = 1.0f;
+        constexpr float kGain = 0.5f;
+        server.m_rxChannelGain[0] = kGain;
+
+        // Seed a sub-threshold 48 kHz resampler accumulation, then switch to
+        // native 24 kHz.  The old implementation retained this staging buffer
+        // across the rate change and released it before the native-rate gain
+        // loop read it.
         server.onDaxAudioReady(1, pcm);
+        spin(20);
+        if (!receivedFrame.isEmpty()) {
+            std::printf("      48 kHz staging unexpectedly emitted a frame\n");
+            return false;
+        }
+
+        client.sendTextMessage(QStringLiteral("audio_samplerate:24000;"));
+        for (int i = 0; i < 100
+             && server.m_clients.first().audioSampleRate != 24000; ++i) {
+            spin(10);
+        }
+        if (server.m_clients.first().audioSampleRate != 24000) {
+            std::printf("      sampleRate=%d after native-rate switch\n",
+                        server.m_clients.first().audioSampleRate);
+            return false;
+        }
+
+        QByteArray nextPcm = pcm;
+        float* nextSamples = reinterpret_cast<float*>(nextPcm.data());
+        for (int i = 0; i < kFrames * 2; ++i) {
+            nextSamples[i] = -samples[i];
+        }
+        QByteArray expectedPcm = pcm + nextPcm;
+        float* expectedSamples = reinterpret_cast<float*>(expectedPcm.data());
+        for (int i = 0; i < kFrames * 4; ++i) {
+            expectedSamples[i] *= kGain;
+        }
+        server.onDaxAudioReady(1, nextPcm);
 
         for (int i = 0; i < 100 && receivedFrame.isEmpty(); ++i) {
             spin(10);
         }
         constexpr int kHeaderBytes = 64;
-        if (receivedFrame.size() != kHeaderBytes + pcm.size()) {
+        if (receivedFrame.size() != kHeaderBytes + expectedPcm.size()) {
             std::printf("      received=%lld expected=%lld\n",
                         static_cast<long long>(receivedFrame.size()),
-                        static_cast<long long>(kHeaderBytes + pcm.size()));
+                        static_cast<long long>(kHeaderBytes + expectedPcm.size()));
         }
-        return receivedFrame.size() == kHeaderBytes + pcm.size()
+        return receivedFrame.size() == kHeaderBytes + expectedPcm.size()
             && std::memcmp(receivedFrame.constData() + kHeaderBytes,
-                           pcm.constData(), static_cast<size_t>(pcm.size())) == 0;
+                           expectedPcm.constData(),
+                           static_cast<size_t>(expectedPcm.size())) == 0;
     }
 };
 

--- a/tests/tci_server_review_test.cpp
+++ b/tests/tci_server_review_test.cpp
@@ -11,14 +11,18 @@
 #include "models/TransmitModel.h"
 
 #include <QCoreApplication>
+#include <QAbstractSocket>
 #include <QEventLoop>
+#include <QHostAddress>
 #include <QJsonObject>
 #include <QLoggingCategory>
 #include <QSet>
 #include <QStringList>
 #include <QTimer>
+#include <QUrl>
 #include <QWebSocket>
 
+#include <cstring>
 #include <cstdio>
 
 namespace AetherSDR
@@ -1127,6 +1131,80 @@ public:
         server.tuneSliceAndConfirm(&client, 0, 0, 0, parked);
         return sent.contains(QStringLiteral("vfo:0,0,%1;").arg(parked));
     }
+
+    // #4744: native-rate TCI RX uses the accumulation buffer as its frame
+    // source.  Releasing that buffer before sendBinaryMessage() left the
+    // payload pointer dangling; an allocator reuse could corrupt audio or AV.
+    static bool native24kAudioRetainsAccumulatedPayload()
+    {
+        RadioModel model;
+        TciServer server(&model);
+        if (!server.start(0) || !server.m_server) {
+            std::printf("      TCI server failed to bind an ephemeral port\n");
+            return false;
+        }
+        const quint16 port = server.port();
+
+        QByteArray receivedFrame;
+        QWebSocket client;
+        QObject::connect(&client, &QWebSocket::binaryMessageReceived,
+                         [&receivedFrame](const QByteArray& frame) {
+            receivedFrame = frame;
+        });
+        client.open(QUrl(QStringLiteral("ws://127.0.0.1:%1")
+                             .arg(port)));
+
+        for (int i = 0; i < 100
+             && (client.state() != QAbstractSocket::ConnectedState
+                 || server.m_clients.isEmpty()); ++i) {
+            spin(10);
+        }
+        if (client.state() != QAbstractSocket::ConnectedState
+            || server.m_clients.isEmpty()) {
+            std::printf("      clientState=%d clients=%lld error=%s\n",
+                        static_cast<int>(client.state()),
+                        static_cast<long long>(server.m_clients.size()),
+                        client.errorString().toUtf8().constData());
+            return false;
+        }
+
+        client.sendTextMessage(QStringLiteral(
+            "audio_samplerate:24000;audio_stream_sample_type:float32;"
+            "audio_stream_channels:2;audio_start:0;"));
+        for (int i = 0; i < 100 && !server.m_clients.first().audioEnabled; ++i) {
+            spin(10);
+        }
+        if (!server.m_clients.first().audioEnabled
+            || server.m_clients.first().audioSampleRate != 24000) {
+            std::printf("      audioEnabled=%d sampleRate=%d\n",
+                        server.m_clients.first().audioEnabled,
+                        server.m_clients.first().audioSampleRate);
+            return false;
+        }
+
+        constexpr int kFrames = 128;
+        QByteArray pcm(kFrames * 2 * static_cast<int>(sizeof(float)),
+                       Qt::Uninitialized);
+        float* samples = reinterpret_cast<float*>(pcm.data());
+        for (int i = 0; i < kFrames * 2; ++i) {
+            samples[i] = static_cast<float>(i + 1) / 1024.0f;
+        }
+        server.m_rxChannelGain[0] = 1.0f;
+        server.onDaxAudioReady(1, pcm);
+
+        for (int i = 0; i < 100 && receivedFrame.isEmpty(); ++i) {
+            spin(10);
+        }
+        constexpr int kHeaderBytes = 64;
+        if (receivedFrame.size() != kHeaderBytes + pcm.size()) {
+            std::printf("      received=%lld expected=%lld\n",
+                        static_cast<long long>(receivedFrame.size()),
+                        static_cast<long long>(kHeaderBytes + pcm.size()));
+        }
+        return receivedFrame.size() == kHeaderBytes + pcm.size()
+            && std::memcmp(receivedFrame.constData() + kHeaderBytes,
+                           pcm.constData(), static_cast<size_t>(pcm.size())) == 0;
+    }
 };
 
 } // namespace AetherSDR
@@ -1181,6 +1259,8 @@ int main(int argc, char** argv)
         = AetherSDR::TciServerReviewTest::pttRouteLogSamplesCacheBeforeResolve();
     const bool routeLogSanitizes
         = AetherSDR::TciServerReviewTest::pttRouteLogSanitizesClientSource();
+    const bool native24kPayload
+        = AetherSDR::TciServerReviewTest::native24kAudioRetainsAccumulatedPayload();
 
     std::printf("%s  isolated settings profile\n",
                 validProfile ? "PASS" : "FAIL");
@@ -1230,6 +1310,8 @@ int main(int argc, char** argv)
     std::printf("%s  PTT route log neutralises a client-supplied source "
                 "(#4547)\n",
                 routeLogSanitizes ? "PASS" : "FAIL");
+    std::printf("%s  native 24 kHz TCI RX retains accumulated payload (#4744)\n",
+                native24kPayload ? "PASS" : "FAIL");
 
     return validProfile && deferredAbort && observableFailure && pttBindsReceiver
         && pttUsesStableMap
@@ -1239,5 +1321,6 @@ int main(int argc, char** argv)
         && trxDistinctReconnect && heldTrxRefuses
         && vfoConfirmsAccepted && vfoConfirmsRefusal && vfoAcksNoOp
         && routeLogStaleCache && routeLogSampleOrder && routeLogSanitizes
+        && native24kPayload
         ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Refs #4744.

The TCI DAX RX path kept a `const float*` into its accumulation `QByteArray`, then cleared and squeezed that array before gain conversion and WebSocket frame construction. The deterministic trigger is a client switching from a resampled rate such as 48 kHz to native 24 kHz while sub-threshold samples remain staged: the native path inherits the owned staging buffer, no resampling buffer replaces the pointer, and later code reads freed storage.

This change moves the accumulated bytes into a local owner before taking the pointer and explicitly clears the moved-from accumulator for the next packet. The loopback WebSocket test stages audio at 48 kHz, switches to 24 kHz, applies non-unity gain, and verifies the complete transmitted payload byte-for-byte.

This is a confirmed lifetime defect in a code path related to #4744. The supplied crash information does not include a call stack or the negotiated TCI sample-rate history, so this PR intentionally does not claim that the defect is the proven source of that particular crash.

## Constitution principle honored

Principle VIII — Evidence Over Assertion. The focused test fails at the parent implementation under ASan with `heap-use-after-free` and passes on this branch, while the relationship to the reported crash remains explicitly qualified.

## Test plan

- [x] Local build passes (`/opt/homebrew/bin/cmake --build build-codex-arm64 -j8`)
- [ ] Behavior verified on a real radio if applicable — not applicable; this is a TCI server buffer-lifetime path and no TX is involved
- [ ] Existing tests pass (CI) — rerun pending for the review-fix commit
- [x] Reproduction steps documented if user-reported bug — focused 48→24 kHz TCI loopback coverage added

Local verification:

- Parent `3a1f59ea` plus the strengthened test, ASan enabled: fails with `heap-use-after-free` during the 48→24 kHz transition
- Fixed branch, same ASan flags and test: passes with no sanitizer finding
- `./build-codex-arm64/tci_server_review_test`: all checks pass, including the native-rate accumulated-payload case
- Full clean ARM64 build succeeds with RADE enabled; `CMAKE_HOST_SYSTEM_PROCESSOR` and `CMAKE_SYSTEM_PROCESSOR` are `arm64`, no RNNoise x86 source is compiled, and the app executable is Mach-O arm64
- `python3 tools/check_engine_boundary.py --strict`: 0 blocking findings
- `git diff --check`: clean

Automation-bridge gap: the current bridge can configure TCI-facing UI state, but it cannot inject a DAX RX audio frame into `TciServer` and inspect the resulting binary WebSocket payload. The focused loopback integration test directly exercises that missing seam. A future `inject_tci_dax_rx` fixture or equivalent binary-frame capture verb would make this path bridge-verifiable.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention) — not applicable
- [x] Documentation updated if user-visible behavior changed — no user-facing documentation change is needed for this lifetime fix
- [x] Security-sensitive changes reference a GHSA if applicable — not applicable

Generated with OpenAI Codex.
