### PR TITLE
feat(midi): manual MIDI binding entry and per-row edit in the mapping dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ MIDI, Stream Deck/StreamController plugins, and generic USB-serial adapters:
 - Icom RC-28 USB remote encoder
 - Griffin PowerMate USB knob
 - Contour ShuttleXpress and ShuttlePro v2 jog controllers
-- MIDI controllers with learn mode, profiles, and relative-encoder support
+- MIDI controllers with learn mode, manual mapping entry, profiles, and relative-encoder support
 - Elgato Stream Deck devices through the bundled macOS/Windows Stream Deck plugin
 - Stream Deck devices on Linux through the bundled StreamController plugin
 - USB-serial PTT/CW interfaces for foot switches, straight keys, iambic paddles,

--- a/resources/help/configuring-aethersdr-controls.md
+++ b/resources/help/configuring-aethersdr-controls.md
@@ -23,7 +23,7 @@ AetherSDR currently supports these control paths:
 - **Built-in keyboard shortcuts** for tuning, audio, transmit, and other common actions.
 - **Custom keyboard bindings** through the shortcut editor.
 - **FlexControl USB tuning knob** through the serial-control path.
-- **MIDI controllers** with learn mode, profiles, and relative-encoder support.
+- **MIDI controllers** with learn mode, manual mapping entry, profiles, and relative-encoder support.
 - **USB HID encoder devices** including:
   - Icom RC-28
   - Griffin PowerMate
@@ -392,6 +392,8 @@ The MIDI dialog lets you:
 - Refresh the port list
 - Turn on **Auto-connect on startup**
 - Use **Learn** mode to bind a control by moving it
+- Use **Manual…** to type in a binding yourself
+- Edit any existing binding with the **✎** button on its row
 - Save named profiles
 - Load saved profiles
 - Clear all bindings if you want to start over
@@ -437,6 +439,38 @@ For slider and knob targets, Learn ignores touch-only NoteOn messages and waits 
 For sliders, leave **Relative** off and use normal absolute mode.
 
 Use **Invert** if the control moves the opposite way from what feels natural.
+
+### Entering a binding manually
+
+Learn is the easiest path, but sometimes typing the binding in directly is better:
+
+- Some controllers send **more than one MIDI message for a single press**. Learn
+  captures whichever message arrives first, which may not be the one you want.
+- You may want to set up bindings from the controller's manual **before the
+  device is connected**.
+- A binding Learn captured may simply need a small correction.
+
+To add a binding by hand, select the parameter as usual and click **Manual…**
+instead of Learn. Enter the channel, the message type (**Note On**,
+**Control Change**, or **Pitch Bend**), and the note or CC number from your
+controller's documentation, then click **OK**. The binding behaves exactly like
+a learned one and is saved immediately.
+
+To correct an existing binding, click the **✎** button on its row. The same form
+opens with the current values filled in — change what you need and click **OK**.
+
+A few details worth knowing:
+
+- **Channel "Any"** matches the message on every MIDI channel. Learn always binds
+  the specific channel it heard, so "Any" is available only through manual entry.
+- If the source you enter is **already bound to another parameter**, AetherSDR
+  asks before replacing it. Two bindings on the same source cannot both respond,
+  so the dialog never lets one silently disable the other.
+- For key and button targets there is no separate Note Off entry: a **Note On**
+  binding automatically follows the release too.
+- **Pitch Bend** messages carry no number, so that field is disabled.
+- The **Relative** checkbox is only meaningful for Control Change bindings, and
+  it is pre-checked for you when you bind the `VFO Tune Knob` to a CC.
 
 ### CW and PTT from MIDI
 

--- a/src/core/MidiControlManager.cpp
+++ b/src/core/MidiControlManager.cpp
@@ -36,7 +36,7 @@ bool isCwMomentaryParamId(const QString& paramId)
 
 bool isVfoTuneKnobParamId(const QString& paramId)
 {
-    return paramId == QLatin1String("rx.tuneKnob");
+    return AetherSDR::MidiControlManager::isVfoTuneKnob(paramId);
 }
 
 int relativeCcDelta(int value)
@@ -45,6 +45,11 @@ int relativeCcDelta(int value)
 }
 
 } // namespace
+
+bool MidiControlManager::isVfoTuneKnob(const QString& paramId)
+{
+    return paramId == QLatin1String("rx.tuneKnob");
+}
 
 // ── MidiBinding helpers ─────────────────────────────────────────────────────
 

--- a/src/core/MidiControlManager.h
+++ b/src/core/MidiControlManager.h
@@ -77,6 +77,12 @@ public:
     const QVector<MidiParam>& params() const { return m_params; }
     const MidiParam* findParam(const QString& id) const;
 
+    // The VFO tune knob gets special handling in two places that must agree:
+    // Learn forces relative=true on its CC captures here, and the manual
+    // entry form mirrors that default (MidiMappingDialog).  One definition
+    // so the two can't drift.
+    static bool isVfoTuneKnob(const QString& paramId);
+
     // Binding management
     void addBinding(const MidiBinding& binding);
     void removeBinding(const QString& paramId);

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -47,6 +47,14 @@ static const QString kBtnSubtleStyle =
     "border: 1px solid {{color.border.strong}}; padding: 5px 14px; border-radius: 3px; }"
     "QPushButton:hover { background: {{color.background.2}}; color: {{color.text.primary}}; }";
 
+// Same palette for the fixed-size square glyph buttons in the table rows. The
+// 14 px side padding of kBtnSubtleStyle exceeds a 24 px button's width, which
+// leaves no room for the glyph and renders it blank.
+static const QString kBtnGlyphStyle =
+    "QPushButton { background: {{color.background.1}}; color: {{color.text.primary}}; "
+    "border: 1px solid {{color.border.strong}}; padding: 0; border-radius: 3px; }"
+    "QPushButton:hover { background: {{color.background.2}}; color: {{color.text.primary}}; }";
+
 MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* parent)
     : PersistentDialog("MIDI Controller Mapping", "MidiMappingDialogGeometry", parent),
       m_manager(manager)
@@ -351,7 +359,7 @@ void MidiMappingDialog::refreshBindingTable()
         // Edit button — manual correction of this binding's source (#4760)
         auto* editBtn = new QPushButton("✎");
         editBtn->setFixedSize(24, 24);
-        AetherSDR::ThemeManager::instance().applyStyleSheet(editBtn, kBtnSubtleStyle);
+        AetherSDR::ThemeManager::instance().applyStyleSheet(editBtn, kBtnGlyphStyle);
         editBtn->setToolTip("Edit this binding's channel, type and number manually");
         editBtn->setAccessibleName(QString("Edit binding for %1").arg(paramName));
         connect(editBtn, &QPushButton::clicked, this, [this, paramId = b.paramId] {

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -6,6 +6,9 @@
 #include "core/MidiControlManager.h"
 #include "core/MidiSettings.h"
 
+#include <QTimer>
+#include <memory>
+
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QGridLayout>
@@ -219,6 +222,17 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
         connect(manualBtn, &QPushButton::clicked, this, [this] {
             QString paramId = m_paramCombo->currentData().toString();
             if (paramId.isEmpty()) return;
+            // If the parameter is already bound, open as an edit — addBinding()
+            // removes by paramId first, so a blank form + accidental OK would
+            // silently replace the existing binding with defaults.  Pre-filling
+            // makes Manual… and the row ✎ behave identically.
+            for (const auto& cur : m_manager->bindings()) {
+                if (cur.paramId == paramId) {
+                    const MidiBinding copy = cur;
+                    openManualEditor(paramId, &copy);
+                    return;
+                }
+            }
             openManualEditor(paramId, nullptr);
         });
         addRow->addWidget(manualBtn);
@@ -363,16 +377,23 @@ void MidiMappingDialog::refreshBindingTable()
         editBtn->setToolTip("Edit this binding's channel, type and number manually");
         editBtn->setAccessibleName(QString("Edit binding for %1").arg(paramName));
         connect(editBtn, &QPushButton::clicked, this, [this, paramId = b.paramId] {
-            // Look the binding up fresh at click time — the captured row index
-            // could go stale after any table mutation. Copy before opening the
-            // editor: committing mutates the vector the reference points into.
-            for (const auto& cur : m_manager->bindings()) {
-                if (cur.paramId == paramId) {
-                    const MidiBinding copy = cur;
-                    openManualEditor(paramId, &copy);
-                    return;
+            // Deferred: openManualEditor() ends in refreshBindingTable(),
+            // which destroys this very button while its clicked emission is
+            // still on the stack — get off it before opening the nested
+            // modal.  (Same pattern the × button relies on implicitly.)
+            QTimer::singleShot(0, this, [this, paramId] {
+                // Look the binding up fresh at open time — the captured row
+                // index could go stale after any table mutation.  Copy before
+                // opening: committing mutates the vector the reference points
+                // into.
+                for (const auto& cur : m_manager->bindings()) {
+                    if (cur.paramId == paramId) {
+                        const MidiBinding copy = cur;
+                        openManualEditor(paramId, &copy);
+                        return;
+                    }
                 }
-            }
+            });
         });
         m_bindingTable->setCellWidget(i, 5, editBtn);
 
@@ -413,19 +434,23 @@ void MidiMappingDialog::openManualEditor(const QString& paramId, const MidiBindi
         ? QString("[%1] %2").arg(param->category, param->displayName) : paramId;
     // Learn forces relative=true on VFO CC captures (onMidiMessage); the form
     // mirrors that as a default so a typed VFO knob behaves like a learned one.
-    const bool isVfoKnob = (paramId == QLatin1String("rx.tuneKnob"));
+    const bool isVfoKnob = MidiControlManager::isVfoTuneKnob(paramId);
 
     QDialog dlg(this);
     dlg.setWindowTitle(existing ? "Edit MIDI Binding" : "Add MIDI Binding");
     dlg.setModal(true);
     dlg.setObjectName("midiManualBindingDialog");
+    // checkBoxIndicatorStyle() is the #4013 fix for invisible indicators in
+    // dark themes; it returns an unresolved template, so it must ride through
+    // applyStyleSheet (not setStyleSheet) like the dialogs it came from.
     AetherSDR::ThemeManager::instance().applyStyleSheet(&dlg,
-        "QDialog { background: {{color.background.0}}; }"
+        QString("QDialog { background: {{color.background.0}}; }"
         "QLabel { color: {{color.text.primary}}; }"
         "QCheckBox { color: {{color.text.primary}}; }"
         "QComboBox, QSpinBox { background: {{color.background.1}}; "
         "border: 1px solid {{color.border.strong}}; border-radius: 3px; "
-        "color: {{color.text.primary}}; font-size: 11px; padding: 2px 6px; }");
+        "color: {{color.text.primary}}; font-size: 11px; padding: 2px 6px; }")
+        + ThemeManager::checkBoxIndicatorStyle());
 
     auto* form = new QFormLayout(&dlg);
     form->setLabelAlignment(Qt::AlignRight);
@@ -488,15 +513,27 @@ void MidiMappingDialog::openManualEditor(const QString& paramId, const MidiBindi
         relativeCheck->setChecked(existing->relative);
     }
 
-    auto refreshFieldStates = [typeCombo, numberSpin, relativeCheck, isVfoKnob, existing] {
+    // Remember the Relative intent across type round-trips: without this, an
+    // existing binding's Relative flag (or a deliberate mid-dialog uncheck)
+    // was silently lost by flipping Type away from CC and back — the box
+    // would come back at the default instead of the user's state.
+    const auto lastCcRelative =
+        std::make_shared<bool>(existing ? existing->relative : isVfoKnob);
+    const auto prevWasCc = std::make_shared<bool>(false);
+    auto refreshFieldStates =
+        [typeCombo, numberSpin, relativeCheck, lastCcRelative, prevWasCc] {
         const auto t = MidiBinding::MsgType(typeCombo->currentData().toInt());
         numberSpin->setEnabled(t != MidiBinding::PitchBend);   // PB carries no number
-        relativeCheck->setEnabled(t == MidiBinding::CC);       // dispatch honors it for CC only
-        if (t != MidiBinding::CC)
-            relativeCheck->setChecked(false);  // non-CC never saves relative — keep the
-                                               // display equal to what OK would commit
-        else if (isVfoKnob && !existing)
-            relativeCheck->setChecked(true);
+        const bool isCc = (t == MidiBinding::CC);
+        if (*prevWasCc && !isCc)
+            *lastCcRelative = relativeCheck->isChecked();  // leaving CC — keep intent
+        relativeCheck->setEnabled(isCc);                   // dispatch honors it for CC only
+        // Non-CC never saves relative — keep the display equal to what OK
+        // would commit; back on CC, restore the remembered intent (the VFO
+        // Learn-mirror default for a fresh binding, the stored flag for an
+        // existing one, or whatever the user last set).
+        relativeCheck->setChecked(isCc ? *lastCcRelative : false);
+        *prevWasCc = isCc;
     };
     connect(typeCombo, &QComboBox::currentIndexChanged, &dlg, refreshFieldStates);
     refreshFieldStates();
@@ -521,7 +558,17 @@ void MidiMappingDialog::openManualEditor(const QString& paramId, const MidiBindi
     QStringList shadowedNames;
     QStringList shadowedIds;
     for (const auto& cur : m_manager->bindings()) {
-        if (cur.paramId != b.paramId && cur.key() == b.key()) {
+        // Overlap, not key() equality: key() folds the wildcard channel to
+        // 0xFF while dispatch probes the exact-channel key first and falls
+        // back to the wildcard — so an "Any" binding and a channel-specific
+        // one on the same type+number collide at runtime with different
+        // keys, and this form is the only UI able to create the wildcard.
+        // (A legacy NoteOff row shadowing the NoteOn pairing fallback for a
+        // Gate param is a separate, far rarer case — out of scope here.)
+        const bool sameSource = cur.msgType == b.msgType
+            && (b.msgType == MidiBinding::PitchBend || cur.number == b.number)
+            && (cur.channel < 0 || b.channel < 0 || cur.channel == b.channel);
+        if (cur.paramId != b.paramId && sameSource) {
             const MidiParam* cp = m_manager->findParam(cur.paramId);
             shadowedNames << (cp ? QString("[%1] %2").arg(cp->category, cp->displayName)
                                  : cur.paramId);
@@ -532,8 +579,9 @@ void MidiMappingDialog::openManualEditor(const QString& paramId, const MidiBindi
         const auto answer = FramelessMessageBox::question(
             this, "Source Already Bound",
             QString("%1 is already bound to:\n  %2\n\n"
-                    "Two bindings on the same source cannot both respond — "
-                    "the older one would silently stop working.\n\n"
+                    "Two bindings on the same or overlapping source cannot "
+                    "both respond on the channel they share — the older one "
+                    "would silently stop working there.\n\n"
                     "Replace the existing binding%3?")
                 .arg(b.sourceDisplayName(), shadowedNames.join("\n  "),
                      shadowedIds.size() > 1 ? QStringLiteral("s") : QString()));

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -43,7 +43,7 @@ static const QString kBtnStyle =
 // primary way to create bindings; manual entry is the bypass (#4760).
 // {{token}} template: apply via ThemeManager::applyStyleSheet, never setStyleSheet.
 static const QString kBtnSubtleStyle =
-    "QPushButton { background: {{color.background.1}}; color: {{color.text.secondary}}; "
+    "QPushButton { background: {{color.background.1}}; color: {{color.text.primary}}; "
     "border: 1px solid {{color.border.strong}}; padding: 5px 14px; border-radius: 3px; }"
     "QPushButton:hover { background: {{color.background.2}}; color: {{color.text.primary}}; }";
 

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -41,14 +41,11 @@ static const QString kBtnStyle =
 
 // Muted sibling of kBtnStyle for secondary actions — Learn stays the visually
 // primary way to create bindings; manual entry is the bypass (#4760).
+// {{token}} template: apply via ThemeManager::applyStyleSheet, never setStyleSheet.
 static const QString kBtnSubtleStyle =
-    "QPushButton { background: #1a2a3a; color: #8aa8c0; "
-    "border: 1px solid #304050; padding: 5px 14px; border-radius: 3px; }"
-    "QPushButton:hover { background: #24384c; color: #c8d8e8; }";
-
-static const QString kSpinStyle =
-    "QSpinBox { background: #1a2a3a; border: 1px solid #304050; "
-    "border-radius: 3px; color: #c8d8e8; font-size: 11px; padding: 2px 6px; }";
+    "QPushButton { background: {{color.background.1}}; color: {{color.text.secondary}}; "
+    "border: 1px solid {{color.border.strong}}; padding: 5px 14px; border-radius: 3px; }"
+    "QPushButton:hover { background: {{color.background.2}}; color: {{color.text.primary}}; }";
 
 MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* parent)
     : PersistentDialog("MIDI Controller Mapping", "MidiMappingDialogGeometry", parent),
@@ -206,7 +203,7 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
                 [learnBtn] { learnBtn->setText("Learn"); });
 
         auto* manualBtn = new QPushButton("Manual…");
-        manualBtn->setStyleSheet(kBtnSubtleStyle);
+        AetherSDR::ThemeManager::instance().applyStyleSheet(manualBtn, kBtnSubtleStyle);
         manualBtn->setObjectName("midiManualAddButton");
         manualBtn->setAccessibleName("Add MIDI binding manually");
         manualBtn->setToolTip("Add binding by typing channel, message type and number — "
@@ -354,10 +351,7 @@ void MidiMappingDialog::refreshBindingTable()
         // Edit button — manual correction of this binding's source (#4760)
         auto* editBtn = new QPushButton("✎");
         editBtn->setFixedSize(24, 24);
-        editBtn->setStyleSheet(
-            "QPushButton { background: #1a2a3a; color: #8aa8c0; "
-            "border: 1px solid #304050; border-radius: 3px; }"
-            "QPushButton:hover { background: #24384c; color: #c8d8e8; }");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(editBtn, kBtnSubtleStyle);
         editBtn->setToolTip("Edit this binding's channel, type and number manually");
         editBtn->setAccessibleName(QString("Edit binding for %1").arg(paramName));
         connect(editBtn, &QPushButton::clicked, this, [this, paramId = b.paramId] {
@@ -420,7 +414,10 @@ void MidiMappingDialog::openManualEditor(const QString& paramId, const MidiBindi
     AetherSDR::ThemeManager::instance().applyStyleSheet(&dlg,
         "QDialog { background: {{color.background.0}}; }"
         "QLabel { color: {{color.text.primary}}; }"
-        "QCheckBox { color: {{color.text.primary}}; }");
+        "QCheckBox { color: {{color.text.primary}}; }"
+        "QComboBox, QSpinBox { background: {{color.background.1}}; "
+        "border: 1px solid {{color.border.strong}}; border-radius: 3px; "
+        "color: {{color.text.primary}}; font-size: 11px; padding: 2px 6px; }");
 
     auto* form = new QFormLayout(&dlg);
     form->setLabelAlignment(Qt::AlignRight);
@@ -429,7 +426,6 @@ void MidiMappingDialog::openManualEditor(const QString& paramId, const MidiBindi
     form->addRow(new QLabel(QString("Binding for: %1").arg(paramLabel)));
 
     auto* channelCombo = new QComboBox(&dlg);
-    channelCombo->setStyleSheet(kComboStyle);
     channelCombo->setObjectName("manualChannelCombo");
     channelCombo->setAccessibleName("MIDI channel");
     channelCombo->addItem("Any", -1);
@@ -442,7 +438,6 @@ void MidiMappingDialog::openManualEditor(const QString& paramId, const MidiBindi
     form->addRow("Channel:", channelCombo);
 
     auto* typeCombo = new QComboBox(&dlg);
-    typeCombo->setStyleSheet(kComboStyle);
     typeCombo->setObjectName("manualTypeCombo");
     typeCombo->setAccessibleName("MIDI message type");
     typeCombo->addItem("Note On", int(MidiBinding::NoteOn));
@@ -458,7 +453,6 @@ void MidiMappingDialog::openManualEditor(const QString& paramId, const MidiBindi
 
     auto* numberSpin = new QSpinBox(&dlg);
     numberSpin->setRange(0, 127);
-    numberSpin->setStyleSheet(kSpinStyle);
     numberSpin->setObjectName("manualNumberSpin");
     numberSpin->setAccessibleName("Note or CC number");
     form->addRow("Number:", numberSpin);

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -2,6 +2,7 @@
 #ifdef HAVE_MIDI
 
 #include "MidiMappingDialog.h"
+#include "FramelessMessageBox.h"
 #include "core/MidiControlManager.h"
 #include "core/MidiSettings.h"
 
@@ -14,6 +15,9 @@
 #include <QLineEdit>
 #include <QInputDialog>
 #include <QMessageBox>
+#include <QSpinBox>
+#include <QFormLayout>
+#include <QDialogButtonBox>
 
 namespace AetherSDR {
 
@@ -34,6 +38,17 @@ static const QString kBtnStyle =
     "border: 1px solid #008ba8; padding: 5px 14px; border-radius: 3px; }"
     "QPushButton:hover { background: #00c8f0; }"
     "QPushButton:disabled { background: #404060; color: #808080; }";
+
+// Muted sibling of kBtnStyle for secondary actions — Learn stays the visually
+// primary way to create bindings; manual entry is the bypass (#4760).
+static const QString kBtnSubtleStyle =
+    "QPushButton { background: #1a2a3a; color: #8aa8c0; "
+    "border: 1px solid #304050; padding: 5px 14px; border-radius: 3px; }"
+    "QPushButton:hover { background: #24384c; color: #c8d8e8; }";
+
+static const QString kSpinStyle =
+    "QSpinBox { background: #1a2a3a; border: 1px solid #304050; "
+    "border-radius: 3px; color: #c8d8e8; font-size: 11px; padding: 2px 6px; }";
 
 MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* parent)
     : PersistentDialog("MIDI Controller Mapping", "MidiMappingDialogGeometry", parent),
@@ -118,8 +133,8 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
         auto* vbox = new QVBoxLayout(group);
 
         m_bindingTable = new QTableWidget;
-        m_bindingTable->setColumnCount(6);
-        m_bindingTable->setHorizontalHeaderLabels({"Parameter", "MIDI Source", "Channel", "Invert", "Relative", ""});
+        m_bindingTable->setColumnCount(7);
+        m_bindingTable->setHorizontalHeaderLabels({"Parameter", "MIDI Source", "Channel", "Invert", "Relative", "", ""});
         m_bindingTable->horizontalHeader()->setStretchLastSection(false);
         m_bindingTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
         m_bindingTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
@@ -127,6 +142,7 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
         m_bindingTable->horizontalHeader()->setSectionResizeMode(3, QHeaderView::ResizeToContents);
         m_bindingTable->horizontalHeader()->setSectionResizeMode(4, QHeaderView::ResizeToContents);
         m_bindingTable->horizontalHeader()->setSectionResizeMode(5, QHeaderView::ResizeToContents);
+        m_bindingTable->horizontalHeader()->setSectionResizeMode(6, QHeaderView::ResizeToContents);
         m_bindingTable->setSelectionBehavior(QAbstractItemView::SelectRows);
         m_bindingTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
         m_bindingTable->verticalHeader()->setVisible(false);
@@ -148,6 +164,7 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
 
         m_paramCombo = new QComboBox;
         m_paramCombo->setStyleSheet(kComboStyle);
+        m_paramCombo->setObjectName("midiParamCombo");
         m_paramCombo->setMinimumWidth(200);
         addRow->addWidget(m_paramCombo, 1);
 
@@ -187,6 +204,19 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
         });
         connect(m_manager, &MidiControlManager::learnCancelled, this,
                 [learnBtn] { learnBtn->setText("Learn"); });
+
+        auto* manualBtn = new QPushButton("Manual…");
+        manualBtn->setStyleSheet(kBtnSubtleStyle);
+        manualBtn->setObjectName("midiManualAddButton");
+        manualBtn->setAccessibleName("Add MIDI binding manually");
+        manualBtn->setToolTip("Add binding by typing channel, message type and number — "
+                              "for controllers whose messages Learn cannot capture cleanly");
+        connect(manualBtn, &QPushButton::clicked, this, [this] {
+            QString paramId = m_paramCombo->currentData().toString();
+            if (paramId.isEmpty()) return;
+            openManualEditor(paramId, nullptr);
+        });
+        addRow->addWidget(manualBtn);
 
         vbox->addLayout(addRow);
 
@@ -321,6 +351,29 @@ void MidiMappingDialog::refreshBindingTable()
         });
         m_bindingTable->setCellWidget(i, 4, relCheck);
 
+        // Edit button — manual correction of this binding's source (#4760)
+        auto* editBtn = new QPushButton("✎");
+        editBtn->setFixedSize(24, 24);
+        editBtn->setStyleSheet(
+            "QPushButton { background: #1a2a3a; color: #8aa8c0; "
+            "border: 1px solid #304050; border-radius: 3px; }"
+            "QPushButton:hover { background: #24384c; color: #c8d8e8; }");
+        editBtn->setToolTip("Edit this binding's channel, type and number manually");
+        editBtn->setAccessibleName(QString("Edit binding for %1").arg(paramName));
+        connect(editBtn, &QPushButton::clicked, this, [this, paramId = b.paramId] {
+            // Look the binding up fresh at click time — the captured row index
+            // could go stale after any table mutation. Copy before opening the
+            // editor: committing mutates the vector the reference points into.
+            for (const auto& cur : m_manager->bindings()) {
+                if (cur.paramId == paramId) {
+                    const MidiBinding copy = cur;
+                    openManualEditor(paramId, &copy);
+                    return;
+                }
+            }
+        });
+        m_bindingTable->setCellWidget(i, 5, editBtn);
+
         // Delete button
         auto* delBtn = new QPushButton("×");
         delBtn->setFixedSize(24, 24);
@@ -332,7 +385,7 @@ void MidiMappingDialog::refreshBindingTable()
             refreshBindingTable();
             MidiSettings::instance().saveBindings(m_manager->bindings());
         });
-        m_bindingTable->setCellWidget(i, 5, delBtn);
+        m_bindingTable->setCellWidget(i, 6, delBtn);
     }
 }
 
@@ -344,6 +397,153 @@ void MidiMappingDialog::refreshProfileList()
         m_profileCombo->addItem(name);
     if (!current.isEmpty())
         m_profileCombo->setCurrentText(current);
+}
+
+void MidiMappingDialog::openManualEditor(const QString& paramId, const MidiBinding* existing)
+{
+    // A stray controller touch must not complete a half-armed Learn while the
+    // operator is typing in this form.
+    if (m_manager->isLearning())
+        m_manager->cancelLearn();
+
+    const MidiParam* param = m_manager->findParam(paramId);
+    const QString paramLabel = param
+        ? QString("[%1] %2").arg(param->category, param->displayName) : paramId;
+    // Learn forces relative=true on VFO CC captures (onMidiMessage); the form
+    // mirrors that as a default so a typed VFO knob behaves like a learned one.
+    const bool isVfoKnob = (paramId == QLatin1String("rx.tuneKnob"));
+
+    QDialog dlg(this);
+    dlg.setWindowTitle(existing ? "Edit MIDI Binding" : "Add MIDI Binding");
+    dlg.setModal(true);
+    dlg.setObjectName("midiManualBindingDialog");
+    AetherSDR::ThemeManager::instance().applyStyleSheet(&dlg,
+        "QDialog { background: {{color.background.0}}; }"
+        "QLabel { color: {{color.text.primary}}; }"
+        "QCheckBox { color: {{color.text.primary}}; }");
+
+    auto* form = new QFormLayout(&dlg);
+    form->setLabelAlignment(Qt::AlignRight);
+    form->setSpacing(8);
+
+    form->addRow(new QLabel(QString("Binding for: %1").arg(paramLabel)));
+
+    auto* channelCombo = new QComboBox(&dlg);
+    channelCombo->setStyleSheet(kComboStyle);
+    channelCombo->setObjectName("manualChannelCombo");
+    channelCombo->setAccessibleName("MIDI channel");
+    channelCombo->addItem("Any", -1);
+    for (int ch = 1; ch <= 16; ++ch)
+        channelCombo->addItem(QString::number(ch), ch - 1);
+    // Default to channel 1, the overwhelmingly common case; "Any" stays one
+    // click away. (Learn can only ever produce channel-specific bindings, so
+    // this form is the first UI able to reach the supported -1 wildcard.)
+    channelCombo->setCurrentIndex(1);
+    form->addRow("Channel:", channelCombo);
+
+    auto* typeCombo = new QComboBox(&dlg);
+    typeCombo->setStyleSheet(kComboStyle);
+    typeCombo->setObjectName("manualTypeCombo");
+    typeCombo->setAccessibleName("MIDI message type");
+    typeCombo->addItem("Note On", int(MidiBinding::NoteOn));
+    typeCombo->addItem("Control Change (CC)", int(MidiBinding::CC));
+    typeCombo->addItem("Pitch Bend", int(MidiBinding::PitchBend));
+    // The menu omits Note Off: Learn never creates NoteOff bindings, and
+    // dispatch already routes NoteOff to the matching NoteOn binding for Gate
+    // params — offering it would invite dead bindings. An existing NoteOff row
+    // (possible in an old settings file) must still display truthfully, though.
+    if (existing && existing->msgType == MidiBinding::NoteOff)
+        typeCombo->addItem("Note Off", int(MidiBinding::NoteOff));
+    form->addRow("Type:", typeCombo);
+
+    auto* numberSpin = new QSpinBox(&dlg);
+    numberSpin->setRange(0, 127);
+    numberSpin->setStyleSheet(kSpinStyle);
+    numberSpin->setObjectName("manualNumberSpin");
+    numberSpin->setAccessibleName("Note or CC number");
+    form->addRow("Number:", numberSpin);
+
+    auto* invertCheck = new QCheckBox("Invert value range", &dlg);
+    invertCheck->setObjectName("manualInvertCheck");
+    form->addRow(QString(), invertCheck);
+
+    auto* relativeCheck = new QCheckBox("Relative (knob sends deltas)", &dlg);
+    relativeCheck->setObjectName("manualRelativeCheck");
+    form->addRow(QString(), relativeCheck);
+
+    auto* box = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+    connect(box, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
+    connect(box, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
+    form->addRow(box);
+
+    if (existing) {
+        const int chIdx = channelCombo->findData(existing->channel);
+        if (chIdx >= 0) channelCombo->setCurrentIndex(chIdx);
+        const int typeIdx = typeCombo->findData(int(existing->msgType));
+        if (typeIdx >= 0) typeCombo->setCurrentIndex(typeIdx);
+        numberSpin->setValue(qBound(0, existing->number, 127));
+        invertCheck->setChecked(existing->inverted);
+        relativeCheck->setChecked(existing->relative);
+    }
+
+    auto refreshFieldStates = [typeCombo, numberSpin, relativeCheck, isVfoKnob, existing] {
+        const auto t = MidiBinding::MsgType(typeCombo->currentData().toInt());
+        numberSpin->setEnabled(t != MidiBinding::PitchBend);   // PB carries no number
+        relativeCheck->setEnabled(t == MidiBinding::CC);       // dispatch honors it for CC only
+        if (t != MidiBinding::CC)
+            relativeCheck->setChecked(false);  // non-CC never saves relative — keep the
+                                               // display equal to what OK would commit
+        else if (isVfoKnob && !existing)
+            relativeCheck->setChecked(true);
+    };
+    connect(typeCombo, &QComboBox::currentIndexChanged, &dlg, refreshFieldStates);
+    refreshFieldStates();
+
+    if (dlg.exec() != QDialog::Accepted)
+        return;
+
+    MidiBinding b;
+    b.channel  = channelCombo->currentData().toInt();
+    b.msgType  = MidiBinding::MsgType(typeCombo->currentData().toInt());
+    // Learn stores -1 for Pitch Bend (the message carries no number); mirror it.
+    b.number   = (b.msgType == MidiBinding::PitchBend) ? -1 : numberSpin->value();
+    b.paramId  = paramId;
+    b.inverted = invertCheck->isChecked();
+    b.relative = relativeCheck->isChecked() && b.msgType == MidiBinding::CC;
+
+    // Duplicate-source guard. The dispatch index is keyed on (channel, type,
+    // number) without the param, so on a collision the last table row silently
+    // wins and the older binding stops responding with no indication. Learn
+    // rarely produces this; a typed form is one typo away. Never shadow
+    // silently — name the loser and ask.
+    QStringList shadowedNames;
+    QStringList shadowedIds;
+    for (const auto& cur : m_manager->bindings()) {
+        if (cur.paramId != b.paramId && cur.key() == b.key()) {
+            const MidiParam* cp = m_manager->findParam(cur.paramId);
+            shadowedNames << (cp ? QString("[%1] %2").arg(cp->category, cp->displayName)
+                                 : cur.paramId);
+            shadowedIds << cur.paramId;
+        }
+    }
+    if (!shadowedIds.isEmpty()) {
+        const auto answer = FramelessMessageBox::question(
+            this, "Source Already Bound",
+            QString("%1 is already bound to:\n  %2\n\n"
+                    "Two bindings on the same source cannot both respond — "
+                    "the older one would silently stop working.\n\n"
+                    "Replace the existing binding%3?")
+                .arg(b.sourceDisplayName(), shadowedNames.join("\n  "),
+                     shadowedIds.size() > 1 ? QStringLiteral("s") : QString()));
+        if (answer != FramelessMessageBox::Yes)
+            return;
+        for (const auto& id : shadowedIds)
+            m_manager->removeBinding(id);
+    }
+
+    m_manager->addBinding(b);
+    refreshBindingTable();
+    MidiSettings::instance().saveBindings(m_manager->bindings());
 }
 
 } // namespace AetherSDR

--- a/src/gui/MidiMappingDialog.h
+++ b/src/gui/MidiMappingDialog.h
@@ -12,6 +12,7 @@
 namespace AetherSDR {
 
 class MidiControlManager;
+struct MidiBinding;
 
 // MIDI Mapping dialog — dedicated settings window for configuring MIDI
 // controller bindings. Opened from Settings → MIDI Mapping.
@@ -27,6 +28,10 @@ private:
     void refreshPortList();
     void refreshBindingTable();
     void refreshProfileList();
+    // Manual add/edit form (#4760). One form serves both the "Manual…" button
+    // (existing == nullptr) and the per-row edit button (existing == the row's
+    // current binding). Commits through the same addBinding()/save path as Learn.
+    void openManualEditor(const QString& paramId, const MidiBinding* existing);
 
     MidiControlManager* m_manager;
 


### PR DESCRIPTION

Fixes #4760

## What

Two manual affordances in the MIDI Mapping dialog, per the v1 scope agreed in the
issue thread (existing message types only; no `MsgType` enum extension; MoMIDI out
of scope):

- A **Manual…** button beside Learn: type in a binding's channel (Any / 1–16),
  message type (Note On, Control Change, Pitch Bend), and note/CC number, plus the
  existing Invert/Relative flags, for the selected parameter.
- A **✎ edit button on each binding row**: opens the same form pre-filled, for
  correcting a binding Learn captured (the issue's precursor mis-bind case) without
  re-learning.

Learn is unchanged and remains the default flow. Manual entry is a second producer of
the same `MidiBinding` values through the same commit path as `learnCompleted`
(`addBinding()` → table refresh → `saveBindings()`). `MidiControlManager`, dispatch,
and the `midi.settings` format are untouched; a file written by this build loads in
older builds.

## Behavior details

- **Duplicate-source guard:** the dispatch index is keyed on (channel, type, number)
  without the parameter, so two bindings on one source silently leave only the last
  one working. The form detects an exact-source collision on OK and asks
  replace-or-cancel, naming the existing binding. Learn's own semantics are
  deliberately not changed.
- **VFO relative default mirrored:** Learn forces `relative=true` when the VFO knob
  is bound to a CC; the form auto-checks Relative in the same case (still
  user-editable). The checkbox clears and disables for non-CC types so the display
  always matches what OK commits (`relative` is only honored for CC in dispatch).
- **Learn exclusion:** opening the form cancels an armed Learn, so a stray
  controller event cannot complete a capture while typing.
- **Note Off** is omitted from the type menu (Learn never creates NoteOff bindings;
  dispatch pairs NoteOff with the NoteOn binding for Gate params). A legacy NoteOff
  row from an existing settings file still displays truthfully when edited.
- **Pitch Bend** disables the number field and stores number −1, as Learn does.
- Channel "Any" (−1 wildcard) was already supported by matching and persistence;
  this form is the first UI able to create it.

## Verification

- Clean worktree build of `0eaf6328` (macOS, Qt 6.8.3), embedded About SHA verified
  against HEAD before every run.
- `ctest`: full suite green except the three known environment failures
  (`s_meter_geometry`, `range_slider_a11y`, `relay_bar_a11y`) and the standing
  `crdv_quarantined` skip — identical to unmodified main on this machine.
  `midi_settings_test` and `midi_relative_cc_decoder_test` pass. One
  timing-sensitive test (`hl2_link_stats_test`, ~120 s of link-statistics
  deadlines) failed in one full-suite run and passed on isolated re-run and in
  the other full run — scheduler-load sensitivity, unrelated to this change.
- Automation-bridge drive (real dialog, real settings file): manual add of
  `Ch 1 CC #74` committed and persisted; conflict prompt fired on a deliberate
  `Ch 1 CC #100` collision with a live VFO binding and declining left the file
  byte-identical; ✎ edit round-trip persisted; Pitch Bend measured
  `numberSpin enabled:false`; Learn arm/cancel unchanged; opening the form with
  Learn armed reset the Learn button. Relative-checkbox state machine verified in
  all four transitions.
- Two follow-up commits since the first review pass: the new widget styles were routed
  through theme tokens to clear the hardcoded-colour ratchet, and the row edit glyph —
  which rendered blank because the shared button style's `padding: 5px 14px` does not fit
  a `setFixedSize(24, 24)` button — was fixed with a padding-free token template. Ratchet
  re-verified against the PR base at +0 colours / +0 references / +0 `setStyleSheet` call
  sites.

### Hardware verification — HaliKey MIDI, 2026-08-06

Run on macOS against a HaliKey MIDI (Halibut Electronics, firmware 2026-06-23) with a
paddle on the key jack. No radio was connected, so no RF was involved. Build `0eaf6328`,
verified in the About dialog, one uninterrupted session.

Against the acceptance criteria in the issue:

✅ **1 — Create a mapping manually without triggering the device.** `Ch 1 Note 21` was typed
into the form for "Trigger CW Right Paddle" and committed. The session log contains no MIDI
traffic of any kind between the preceding press and the next one, and exactly one Learn arm
in the whole session, for a different parameter.

✅ **2 — Manually-created mappings function identically to Learned ones at runtime.** The
manually entered binding and a Learned binding (`Ch 1 Note 20` → left paddle) produced
identical dispatch traces and both drove the local iambic keyer. The Note On binding tracks
press and release (`value=1.000` → `value=0.000`), so no separate Note Off binding is needed
— same as Learn.

✅ **3 — Persist across restarts and within named MIDI profiles.** The two manual bindings
saved to a named profile, survived Clear All, and returned identical after Load. Across an
app restart the settings file was byte-identical by checksum, and the restored binding keyed
in the new process.

✅ **4 — Existing Learn workflow unaffected.** On the same build, Learn captured
`Ch 1 Note 20` from the paddle exactly as before.

⬜ **5 — Verified against a controller sending precursor messages.** Not covered by this
hardware: the firmware emits no precursor messages, only Note On/Off pairs. The tip contact
does send two notes 77–98 µs apart (20 then 31, the vendor's PTT); the manual binding on 20
works and 31 is ignored, which exercises the multi-message case without being a precursor
test.

Also exercised, though not an issue criterion: the duplicate-source guard, in both
directions. Entering an already-bound source raised the prompt naming the current owner;
declining left the settings file byte-identical, and accepting transferred the source so the
same contact drove the new parameter.

Screenshots of the build SHA, dialog, the form, and the conflict prompt attached.

<img width="836" height="1434" alt="aethersdr-midi-about-sha-0eaf6328-2026-08-06" src="https://github.com/user-attachments/assets/94a353dc-5bf3-434d-8f29-698c9560e499" />

<img width="1945" height="1606" alt="aethersdr-midi-mapping-dialog-2026-08-06" src="https://github.com/user-attachments/assets/068cfde8-94aa-4ea7-aad9-afb4c75cf32f" />

<img width="719" height="495" alt="aethersdr-midi-manual-form-2026-08-06" src="https://github.com/user-attachments/assets/7368ffc2-c439-4707-b20d-d5d5482775a5" />

<img width="924" height="451" alt="aethersdr-midi-conflict-prompt-2026-08-06" src="https://github.com/user-attachments/assets/ca3ad736-26cf-479e-aaae-a111235c0dd9" />


[aethersdr-pr4790-halikey-evidence-2026-08-06.zip](https://github.com/user-attachments/files/30801320/aethersdr-pr4790-halikey-evidence-2026-08-06.zip)


— authored by agent (Claude Code) on behalf of @skerker


