### PR TITLE
fix(display): clamp waterfall interpolation at history boundaries

### DIFF
--- a/resources/shaders/texturedquad.frag
+++ b/resources/shaders/texturedquad.frag
@@ -12,7 +12,7 @@ layout(std140, binding = 0) uniform Uniforms {
     float padding3;
     float scrollSampleOffsetUnit;
     float texelHeightUnit;
-    float padding6;
+    float waterfallRows;
     float padding7;
 };
 
@@ -28,12 +28,12 @@ void main()
     // rowOffset advances as soon as a row arrives. The residual one-row sample
     // offset starts at the prior ring position and closes to zero over the row
     // interval, preserving the previous frame at the handoff.
-    float physicalY = fract(
-        v_uv.y + rowOffset + scrollSampleOffsetUnit);
     float unit = max(texelHeightUnit, 0.000001);
-    float texel = physicalY / unit - 0.5;
-    float base = floor(texel);
-    float f = fract(texel);
+    float rows = max(waterfallRows, 1.0);
+    float logicalTexel =
+        (v_uv.y + scrollSampleOffsetUnit) / unit - 0.5;
+    float base = floor(logicalTexel);
+    float f = fract(logicalTexel);
     float f2 = f * f;
     float f3 = f2 * f;
 
@@ -44,10 +44,14 @@ void main()
     float w1 = (4.0 - 6.0 * f2 + 3.0 * f3) / 6.0;
     float w2 = (1.0 + 3.0 * f + 3.0 * f2 - 3.0 * f3) / 6.0;
     float w3 = f3 / 6.0;
-    float y0 = fract((base - 0.5) * unit);
-    float y1 = fract((base + 0.5) * unit);
-    float y2 = fract((base + 1.5) * unit);
-    float y3 = fract((base + 2.5) * unit);
+    float y0 = fract(rowOffset
+        + (clamp(base - 1.0, 0.0, rows - 1.0) + 0.5) * unit);
+    float y1 = fract(rowOffset
+        + (clamp(base,       0.0, rows - 1.0) + 0.5) * unit);
+    float y2 = fract(rowOffset
+        + (clamp(base + 1.0, 0.0, rows - 1.0) + 0.5) * unit);
+    float y3 = fract(rowOffset
+        + (clamp(base + 2.0, 0.0, rows - 1.0) + 0.5) * unit);
     fragColor =
           texture(tex, vec2(v_uv.x, y0)) * w0
         + texture(tex, vec2(v_uv.x, y1)) * w1

--- a/resources/shaders/texturedquad_rowframes.frag
+++ b/resources/shaders/texturedquad_rowframes.frag
@@ -18,9 +18,13 @@ layout(std140, binding = 0) uniform Uniforms {
     float padding7;
 };
 
-vec4 sampleWaterfallRow(float rowIndex, float unit)
+vec4 sampleWaterfallSourceAge(float sourceAge, float unit, float rows)
 {
-    float rowY = fract((rowIndex + 0.5) * unit);
+    // The source age is logical waterfall history, not a physical ring row.
+    // Clamp it before applying the write-row origin so the cubic kernel cannot
+    // alias the opposite end of the ring at either history boundary.
+    float clampedAge = clamp(sourceAge, 0.0, rows - 1.0);
+    float rowY = fract(rowOffset + (clampedAge + 0.5) * unit);
     vec4 rowFrame = texture(rowFrequencyFrame, vec2(0.5, rowY));
     if (rowFrame.y <= 0.0) {
         return vec4(0.0, 0.0, 0.0, 1.0);
@@ -54,12 +58,12 @@ void main()
     // rasterized. Reconstruct four adjacent rows independently so each sample
     // is remapped through its own frame while the vertical motion remains
     // phase-stable instead of alternating sharp/blurred.
-    float physicalY = fract(
-        v_uv.y + rowOffset + scrollSampleOffsetUnit);
     float unit = max(texelHeightUnit, 0.000001);
-    float texel = physicalY / unit - 0.5;
-    float base = floor(texel);
-    float f = fract(texel);
+    float rows = max(floor(1.0 / unit + 0.5), 1.0);
+    float logicalTexel =
+        (v_uv.y + scrollSampleOffsetUnit) / unit - 0.5;
+    float base = floor(logicalTexel);
+    float f = fract(logicalTexel);
     float f2 = f * f;
     float f3 = f2 * f;
     float w0 = (1.0 - 3.0 * f + 3.0 * f2 - f3) / 6.0;
@@ -67,8 +71,8 @@ void main()
     float w2 = (1.0 + 3.0 * f + 3.0 * f2 - 3.0 * f3) / 6.0;
     float w3 = f3 / 6.0;
     fragColor =
-          sampleWaterfallRow(base - 1.0, unit) * w0
-        + sampleWaterfallRow(base,       unit) * w1
-        + sampleWaterfallRow(base + 1.0, unit) * w2
-        + sampleWaterfallRow(base + 2.0, unit) * w3;
+          sampleWaterfallSourceAge(base - 1.0, unit, rows) * w0
+        + sampleWaterfallSourceAge(base,       unit, rows) * w1
+        + sampleWaterfallSourceAge(base + 1.0, unit, rows) * w2
+        + sampleWaterfallSourceAge(base + 2.0, unit, rows) * w3;
 }

--- a/resources/shaders/texturedquad_rowframes.frag
+++ b/resources/shaders/texturedquad_rowframes.frag
@@ -14,7 +14,7 @@ layout(std140, binding = 0) uniform Uniforms {
     float rowFrequencyFrames;
     float scrollSampleOffsetUnit;
     float texelHeightUnit;
-    float padding6;
+    float waterfallRows;
     float padding7;
 };
 
@@ -59,7 +59,7 @@ void main()
     // is remapped through its own frame while the vertical motion remains
     // phase-stable instead of alternating sharp/blurred.
     float unit = max(texelHeightUnit, 0.000001);
-    float rows = max(floor(1.0 / unit + 0.5), 1.0);
+    float rows = max(waterfallRows, 1.0);
     float logicalTexel =
         (v_uv.y + scrollSampleOffsetUnit) / unit - 0.5;
     float base = floor(logicalTexel);

--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -360,9 +360,10 @@ inline int waterfallVisibleRowForAge(int writeRowOrigin, int ageRows,
     return (origin + age) % height;
 }
 
-// The cubic waterfall shader must clamp source ages in logical history before
-// mapping them into the physical ring. Wrapping an out-of-range tap directly
-// would blend the newest and oldest rows across the visible history boundary.
+// Mirror of texturedquad.frag and texturedquad_rowframes.frag: both cubic
+// shaders clamp source ages in logical history before mapping them into the
+// physical ring. Wrapping an out-of-range tap directly would blend the newest
+// and oldest rows across the visible history boundary.
 inline int waterfallCubicPhysicalRowForSourceAge(int writeRowOrigin,
                                                  int sourceAge, int height)
 {

--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -360,6 +360,19 @@ inline int waterfallVisibleRowForAge(int writeRowOrigin, int ageRows,
     return (origin + age) % height;
 }
 
+// The cubic waterfall shader must clamp source ages in logical history before
+// mapping them into the physical ring. Wrapping an out-of-range tap directly
+// would blend the newest and oldest rows across the visible history boundary.
+inline int waterfallCubicPhysicalRowForSourceAge(int writeRowOrigin,
+                                                 int sourceAge, int height)
+{
+    if (height <= 0) {
+        return -1;
+    }
+    return waterfallVisibleRowForAge(
+        writeRowOrigin, std::clamp(sourceAge, 0, height - 1), height);
+}
+
 struct WaterfallRowFrameReadiness {
     bool requested{false};
     bool formatSupported{false};

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -13441,7 +13441,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
         waterfallRowFrequencyFrames,
         scrollSampleOffsetUnit,
         m_wfGpuTexH > 0 ? 1.0f / static_cast<float>(m_wfGpuTexH) : 0.0f,
-        0.0f,
+        static_cast<float>(m_wfGpuTexH),
         0.0f,
     };
     static_assert(sizeof(uniforms) == kWaterfallUboFloats * sizeof(float),

--- a/tests/spectrum_preview_logic_test.cpp
+++ b/tests/spectrum_preview_logic_test.cpp
@@ -499,6 +499,38 @@ int testWaterfallVisibleRowForAge()
     return 0;
 }
 
+int testWaterfallCubicSourceAgeBoundary()
+{
+    using namespace AetherSDR;
+    constexpr int kHeight = 7;
+    constexpr int kOrigin = 5;
+
+    // The newest edge's leading cubic tap must duplicate age 0, not wrap to
+    // age kHeight - 1 at the opposite end of the retained history.
+    if (waterfallCubicPhysicalRowForSourceAge(kOrigin, -1, kHeight) != 5
+        || waterfallCubicPhysicalRowForSourceAge(kOrigin, 0, kHeight) != 5
+        || waterfallCubicPhysicalRowForSourceAge(kOrigin, 1, kHeight) != 6
+        || waterfallCubicPhysicalRowForSourceAge(kOrigin, 2, kHeight) != 0) {
+        return fail("waterfall cubic newest-edge taps must clamp logically");
+    }
+
+    // Likewise, the oldest edge's trailing taps duplicate the oldest row
+    // instead of wrapping into the newest history.
+    if (waterfallCubicPhysicalRowForSourceAge(kOrigin, kHeight - 2, kHeight)
+            != 3
+        || waterfallCubicPhysicalRowForSourceAge(kOrigin, kHeight - 1, kHeight)
+               != 4
+        || waterfallCubicPhysicalRowForSourceAge(kOrigin, kHeight, kHeight)
+               != 4
+        || waterfallCubicPhysicalRowForSourceAge(
+               kOrigin, kHeight + 1, kHeight)
+               != 4
+        || waterfallCubicPhysicalRowForSourceAge(kOrigin, 0, 0) != -1) {
+        return fail("waterfall cubic oldest-edge taps must clamp logically");
+    }
+    return 0;
+}
+
 int testWaterfallScrollProgress()
 {
     using namespace AetherSDR;
@@ -1026,6 +1058,9 @@ int main()
         return result;
     }
     if (const int result = testWaterfallVisibleRowForAge(); result != 0) {
+        return result;
+    }
+    if (const int result = testWaterfallCubicSourceAgeBoundary(); result != 0) {
         return result;
     }
     if (const int result = testWaterfallScrollProgress(); result != 0) {


### PR DESCRIPTION
## Summary

Fixes #4793.

Fractional waterfall scrolling reconstructs each visible sample from four neighboring retained rows. Both GPU waterfall shaders previously derived those taps in wrapped physical texture coordinates, so taps just beyond the newest or oldest logical history boundary could alias the opposite end of the circular texture and blend an unrelated row. That appeared as an occasional bright, dark, or scrambled horizontal row during rapid pan or zoom activity.

This change computes the cubic taps as logical source ages in both the row-frequency and legacy fallback shaders, clamps each age to the valid retained-history range, and only then maps it through the circular write-row origin. The renderer now also passes the exact texture height through the shared uniform block instead of reconstructing it from a reciprocal in each fragment. A deliberately named C++ mirror and focused regression test cover the newest edge, oldest edge, a wrapping write origin, and zero-height input. No radio stream, pan/zoom control, brightness, blanking, or no-data behavior changes.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The boundary contract is captured in a focused deterministic test, both shader variants bake successfully, the complete ARM64 application builds, and the row-frequency GPU path was exercised through the agent automation bridge against a FLEX-6700.

## Test plan

- [x] Local build passes (`/opt/homebrew/bin/cmake --build build-codex-arm64 -j8`)
- [x] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Focused validation:

- `spectrum_preview_logic_test`
- `waterfall_history_buffer_test`
- `dss_renderer_test`
- both waterfall `.qsb` shader packs regenerated; reflection confirms the shared 32-byte UBO and exact row count at byte offset 24
- `tools/check_engine_boundary.py --strict` — zero blocking findings
- `tools/check_a11y.py src/gui/SpectrumWidget.cpp src/gui/SpectrumPreviewLogic.h` — zero findings
- `git diff --check`
- ARM64 verification: `AetherSDR.app/Contents/MacOS/AetherSDR` is a Mach-O arm64 executable

## Proof

The agent automation bridge launched the exact ARM64 build in RX-only, read-only mode. `ping` returned AetherSDR 26.8.1 with `readOnly: true`; `get pans` returned the owned live 14.1 MHz pan at 25 FPS; and `grab SpectrumWidget` captured the 1336 x 842 Metal framebuffer after the changed row-frame shader initialized. The deterministic regression test supplies the exact newest/oldest boundary assertion that a framebuffer screenshot cannot evaluate pixel-by-pixel. The legacy fallback shader is covered by shader compilation and the same logical-age boundary contract, not by this live capture.

![Live post-fix waterfall framebuffer](https://raw.githubusercontent.com/rfoust/AetherSDR/fix-4793-assets/.pr-assets/4793-after.png)

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (no meter UI changed)
- [x] Documentation updated if user-visible behavior changed — N/A; no user-facing documentation describes the internal cubic sampling contract
- [x] Security-sensitive changes reference a GHSA if applicable — N/A; no security-sensitive behavior changed

Related: #4425 introduced fractional waterfall motion and the four-row interpolation path. #4539 contains later retained-history stabilization work but does not address this logical-boundary aliasing case.

Generated with OpenAI Codex.
