### PR TITLE
Fix off-screen slice indicator centering

### DIFF
--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -4555,6 +4555,18 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     // ── Slice marker clicks ──────────────────────────────────────────────
     connect(sw, &SpectrumWidget::sliceClicked,
             this, &MainWindow::setActiveSlice);
+    connect(sw, &SpectrumWidget::offScreenSliceCenterRequested,
+            this, [this](int sliceId) {
+        SliceModel* slice = m_radioModel.slice(sliceId);
+        if (!slice) {
+            return;
+        }
+        const bool noCenterLock = centerLockSliceForPan(slice->panId()) < 0;
+        setActiveSliceInternal(sliceId, false);
+        if (noCenterLock) {
+            centerActiveSliceInPanadapter(true, slice->frequency());
+        }
+    });
     connect(sw, &SpectrumWidget::sliceTxRequested,
             this, [this](int sliceId) {
         if (auto* s = m_radioModel.slice(sliceId))

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -4561,10 +4561,14 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         if (!slice) {
             return;
         }
-        const bool noCenterLock = centerLockSliceForPan(slice->panId()) < 0;
+        const QString panId = slice->panId();
+        const int lockedSliceId = centerLockSliceForPan(panId);
+        const double targetMhz = slice->frequency();
         setActiveSliceInternal(sliceId, false);
-        if (noCenterLock) {
-            centerActiveSliceInPanadapter(true, slice->frequency());
+        if (lockedSliceId < 0) {
+            centerActiveSliceInPanadapter(true, targetMhz);
+        } else if (lockedSliceId == sliceId) {
+            recenterCenterLockForPan(panId);
         }
     });
     connect(sw, &SpectrumWidget::sliceTxRequested,

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -9266,6 +9266,10 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
     const auto dragStatePublisher = makeScopeExit([this] { publishPerfDragState(); });
     (void)dragStatePublisher;
 
+    // A prior off-screen-pill press is relevant only to Qt's immediately
+    // following mouseDoubleClickEvent. Any new press starts a new gesture.
+    m_offScreenSliceCenterPressPending = false;
+
     const int chromeH  = freqScaleH() + DIVIDER_H;
     const int contentH = height() - chromeH;
     const int specH = static_cast<int>(contentH * m_spectrumFrac);
@@ -9402,13 +9406,16 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
         }
     }
 
-    // Left-click on off-screen slice indicator → absorb or switch slice
+    // Left-click on an off-screen slice indicator → let MainWindow activate
+    // and center it through the canonical profile-load and Kiwi-safe path.
     if (ev->button() == Qt::LeftButton) {
         for (int oi = 0; oi < m_offScreenRects.size(); ++oi) {
             if (!m_offScreenRects[oi].isNull() &&
                 m_offScreenRects[oi].contains(QPoint(static_cast<int>(ev->position().x()), y))) {
                 const auto& so = m_sliceOverlays[oi];
-                if (!so.isActive) emit sliceClicked(so.sliceId);
+                m_offScreenSliceCenterPressPending = true;
+                m_offScreenSliceCenterPressPos = ev->position().toPoint();
+                emit offScreenSliceCenterRequested(so.sliceId);
                 m_spotClickConsumed = true;   // suppress release-to-tune (#1772)
                 ev->accept();
                 return;
@@ -11013,18 +11020,29 @@ void SpectrumWidget::mouseDoubleClickEvent(QMouseEvent* ev)
     const int mx = static_cast<int>(ev->position().x());
     const int rightStripW = (y >= wfY) ? waterfallStripWidth() : DBM_STRIP_W;
 
+    // The first press may have recentered the pan and removed its indicator
+    // before Qt delivers this double-click event. Consume the matching event
+    // so its trailing release cannot fall through to click-to-tune.
+    if (m_offScreenSliceCenterPressPending
+        && (ev->position().toPoint() - m_offScreenSliceCenterPressPos).manhattanLength()
+            <= QApplication::startDragDistance()) {
+        m_offScreenSliceCenterPressPending = false;
+        m_spotClickConsumed = true;
+        ev->accept();
+        return;
+    }
+
     // Consume double-clicks on the dBm and time strips
     if (mx >= width() - rightStripW) {
         ev->accept();
         return;
     }
 
-    // Double-click on off-screen slice indicator → recenter on that slice
+    // Preserve direct/synthetic double-click support through the same owner
+    // path as a normal off-screen indicator press.
     for (int oi = 0; oi < m_offScreenRects.size(); ++oi) {
         if (!m_offScreenRects[oi].isNull() && m_offScreenRects[oi].contains(QPoint(mx, y))) {
-            m_centerMhz = m_sliceOverlays[oi].freqMhz;
-            markOverlayDirty();
-            emit centerChangeRequested(m_centerMhz);
+            emit offScreenSliceCenterRequested(m_sliceOverlays[oi].sliceId);
             // Suppress the second mouseRelease's single-click-to-tune emit
             // (Qt fires Press → Release → DoubleClick → Release; without this
             // flag the trailing release would re-tune against the new

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -9414,7 +9414,6 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
                 m_offScreenRects[oi].contains(QPoint(static_cast<int>(ev->position().x()), y))) {
                 const auto& so = m_sliceOverlays[oi];
                 m_offScreenSliceCenterPressPending = true;
-                m_offScreenSliceCenterPressPos = ev->position().toPoint();
                 emit offScreenSliceCenterRequested(so.sliceId);
                 m_spotClickConsumed = true;   // suppress release-to-tune (#1772)
                 ev->accept();
@@ -11023,9 +11022,8 @@ void SpectrumWidget::mouseDoubleClickEvent(QMouseEvent* ev)
     // The first press may have recentered the pan and removed its indicator
     // before Qt delivers this double-click event. Consume the matching event
     // so its trailing release cannot fall through to click-to-tune.
-    if (m_offScreenSliceCenterPressPending
-        && (ev->position().toPoint() - m_offScreenSliceCenterPressPos).manhattanLength()
-            <= QApplication::startDragDistance()) {
+    if (ev->button() == Qt::LeftButton
+        && m_offScreenSliceCenterPressPending) {
         m_offScreenSliceCenterPressPending = false;
         m_spotClickConsumed = true;
         ev->accept();

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -1707,7 +1707,6 @@ private:
     QVector<QRect> m_offScreenRects;
     int  m_hoveringOffScreenIdx{-1};
     bool m_offScreenSliceCenterPressPending{false};
-    QPoint m_offScreenSliceCenterPressPos;
 
     // On-screen indicators (WNB, RF Gain)
     bool m_wnbActive{false};

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -734,6 +734,9 @@ signals:
 
     // Emitted when user clicks on an inactive slice marker.
     void sliceClicked(int sliceId);
+    // Emitted when the user clicks an off-screen slice indicator. MainWindow
+    // owns the resulting activation and canonical pan recenter request.
+    void offScreenSliceCenterRequested(int sliceId);
     // Emitted when the user requests an absolute jump in the panadapter area.
     void frequencyClicked(double mhz);
     // Emitted when the user makes an incremental tuning gesture such as
@@ -1703,6 +1706,8 @@ private:
     // Off-screen slice indicator hit rects (parallel to m_sliceOverlays)
     QVector<QRect> m_offScreenRects;
     int  m_hoveringOffScreenIdx{-1};
+    bool m_offScreenSliceCenterPressPending{false};
+    QPoint m_offScreenSliceCenterPressPos;
 
     // On-screen indicators (WNB, RF Gain)
     bool m_wnbActive{false};


### PR DESCRIPTION
## Summary

Fixes #4462.

A single click on any off-screen slice indicator now activates that slice and hard-centers its panadapter through MainWindow's canonical centering path. Previously the active indicator path emitted nothing, so the only off-screen slice ignored single-clicks; inactive indicators followed generic selection/reveal behavior instead of centering.

The dedicated signal preserves Center Lock, profile-load deferral, Kiwi/widget-local centering, cross-pan ownership, and double-click release suppression.

## Constitution principle honored

Principle XI - Fixes Are Demonstrated. The change is backed by a clean ARM64 build and RX-only bridge proof on a real FLEX-6700.

## Test plan

- [x] Local build passes (`/opt/homebrew/bin/cmake --build build-codex-arm64 -j8`)
- [x] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Bridge proof:

1. With exactly one active slice at 14.100 MHz, set its 0.200 MHz pan center to 14.300 MHz.
2. Confirm the `< A` indicator is visible and `transmitting=false`.
3. Single-click the painted indicator through `clickAt SpectrumWidget 100 30`.
4. Confirm pan center becomes 14.100 MHz, the same slice remains active, slice count remains one, and `transmitting=false` with `txPower=0`.

Focused checks:

- `pan_recenter_policy_test`
- `spectrum_overlay_wheel_guard_test`
- `tools/check_engine_boundary.py --strict`
- `tools/check_a11y.py`
- ARM64 app, Opus archive, and RNNoise object verification

## Checklist

- [x] Commits are signed (`git log --show-signature -1` shows a good ED25519 signature)
- [x] No new flat-key settings or direct `QSettings` usage
- [x] Clean-room contribution requirements preserved
- [x] Meter UI requirements are not applicable
- [x] Behavior and validation are documented here; no `CHANGELOG.md` change per repository policy
- [x] Security-sensitive requirements are not applicable

Generated with OpenAI Codex.
