### PR TITLE
fix(hl2): fix hl2_tx_loopback_test coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5028,6 +5028,12 @@ add_executable(hl2_tx_loopback_test tests/hl2_tx_loopback_test.cpp)
 target_include_directories(hl2_tx_loopback_test PRIVATE src)
 target_link_libraries(hl2_tx_loopback_test PRIVATE aethercore Qt6::Core Qt6::Network)
 add_test(NAME hl2_tx_loopback_test COMMAND hl2_tx_loopback_test)
+# This test is a no-op without an hpsdrsim answering discovery, which is the
+# normal state of every machine that has not deliberately started one. Without
+# this property that no-op reports as Passed, which is indistinguishable from a
+# run that actually keyed and measured — the exact silent-green this test was
+# fixed to stop. Same convention as crdv_quarantined_test above.
+set_tests_properties(hl2_tx_loopback_test PROPERTIES SKIP_RETURN_CODE 77)
 
 add_executable(hl2_tx_gate_test tests/hl2_tx_gate_test.cpp)
 target_include_directories(hl2_tx_gate_test PRIVATE src)

--- a/HERMES.md
+++ b/HERMES.md
@@ -1017,6 +1017,23 @@ Related: this is why TUNE always worked and voice never did. A tune carrier sits
 at ZERO offset, where handedness has no effect — the one signal that could not
 have exposed the bug was the one that always looked fine.
 
+**Why the loopback could not have caught it, and what changed.** The second row
+above is worth being precise about. `hl2_tx_loopback_test` measures a loop that
+conjugates twice — `Hl2TxDsp` for the wire on the way out, `Hl2RxDsp` for the
+panadapter on the way back — so a handedness error present at BOTH ends cancels
+exactly. Whichever sign that test asserted, it was blind to a global flip; it
+was another instrument sharing the convention. The test now takes an
+**independent bearing on the receive end first**: hpsdrsim generates its own
+scene tones at 800 Hz and 4 kHz with a fixed handedness, and those reach the
+spectrum without passing through the transmitter. Anchoring on them pins the
+receive end on its own, which is what makes the transmit assertions load-bearing
+instead of self-satisfying. Verified by injecting each fault separately —
+mirroring the display trips the anchor and names the receive end; flipping only
+the modulator leaves the anchor green and trips just the mic-path checks.
+
+It is still inside the machine, and the lesson above still stands: the operator's
+second receiver remains the only check that comes from outside it.
+
 ### 14.7 Process failures worth not repeating
 
 - **`0x39` wedged the radio.** The filter-pipeline reset was validated with 7
@@ -2983,7 +3000,8 @@ and one `active` slice; `slice tx` and `slice select` each clearing the previous
 holder; RF gain on one pan moving all pans; WSJT-X's TCI split creating a second
 DDC and moving transmit to it; and two TCI clients on RX1/RX2 both receiving
 per-slice audio, including with one slice speaker-muted. 196/196 tests green
-(`hl2_tx_loopback_test` excluded — see below).
+(`hl2_tx_loopback_test` was excluded at the time; it has since been fixed and no
+longer needs excluding — see below).
 
 **Proven on real hardware.** The operator has since exercised this end to end on
 a Hermes-Lite 2, transmit included. That closes the gap the simulator
@@ -2999,12 +3017,21 @@ confirming it (§7, and the wrong-sideband account in §14.6).
 
 **Still open:**
 
-- **`hl2_tx_loopback_test` fails against the simulator** on transmit-sideband
-  checks, non-deterministically. Commit `256142a6` — the pre-multi-DDC base —
-  fails identically, so it is pre-existing rather than caused by this work, and
-  it is tracked separately. Note a dev host at `192.168.1.12` is the address that
-  test probes, so a locally-running `hpsdrsim` makes it execute when it was
-  written to skip, and collide with any app already driving that simulator.
+- ~~**`hl2_tx_loopback_test` fails against the simulator** on transmit-sideband
+  checks, non-deterministically.~~ **FIXED.** Correctly diagnosed as pre-existing
+  — commit `256142a6` failed identically — but it was never a transmit fault at
+  all. The test asserted that the fed-back tone appears BELOW centre, which was
+  right against the pre-#4471 panadapter, when the display carried the raw wire.
+  #4471 added the receive-side conjugation that fixed the mirrored panadapter,
+  and from then on the same tone correctly read ABOVE centre while the test went
+  on expecting the old sign. Two supposed symptoms are also explained: the
+  "non-determinism" was the hardcoded `192.168.1.12` reaching a simulator on a
+  *different* machine, so results tracked whatever that machine was doing; and
+  the check that "passed sometimes" did so only when that other simulator was in
+  a different state. The test now defaults to loopback, refuses to key anything
+  whose discovery MAC is not hpsdrsim's synthetic `AA:BB:CC:DD:xx:FF`, asserts
+  the analytic sign, and anchors the receive end on the simulator's own scene
+  tones first (§14.6).
 - **The link-budget ceiling is derived, not measured.** 70% of 100BASE-T is a
   working figure. Where the drop counter actually starts moving is still a
   number nobody has written down, and it is the one that would justify or move

--- a/HERMES.md
+++ b/HERMES.md
@@ -3031,7 +3031,9 @@ confirming it (§7, and the wrong-sideband account in §14.6).
   a different state. The test now defaults to loopback, refuses to key anything
   whose discovery MAC is not hpsdrsim's synthetic `AA:BB:CC:DD:xx:FF`, asserts
   the analytic sign, and anchors the receive end on the simulator's own scene
-  tones first (§14.6).
+  tones first (§14.6). Its skip paths exit 77 with `SKIP_RETURN_CODE` set, so the
+  ordinary machine — no simulator running — reports `Skipped` rather than a
+  `Passed` that measured nothing.
 - **The link-budget ceiling is derived, not measured.** 70% of 100BASE-T is a
   working figure. Where the drop counter actually starts moving is still a
   number nobody has written down, and it is the one that would justify or move

--- a/HERMES.md
+++ b/HERMES.md
@@ -3031,9 +3031,11 @@ confirming it (§7, and the wrong-sideband account in §14.6).
   a different state. The test now defaults to loopback, refuses to key anything
   whose discovery MAC is not hpsdrsim's synthetic `AA:BB:CC:DD:xx:FF`, asserts
   the analytic sign, and anchors the receive end on the simulator's own scene
-  tones first (§14.6). Its skip paths exit 77 with `SKIP_RETURN_CODE` set, so the
-  ordinary machine — no simulator running — reports `Skipped` rather than a
-  `Passed` that measured nothing.
+  tones first (§14.6). It also skips when the simulator reports it is already
+  streaming to somebody else (discovery status `0x03`), which is the collision
+  clause above finally fixed in code rather than in a warning. Its skip paths
+  exit 77 with `SKIP_RETURN_CODE` set, so the ordinary machine — no simulator
+  running — reports `Skipped` rather than a `Passed` that measured nothing.
 - **The link-budget ceiling is derived, not measured.** 70% of 100BASE-T is a
   working figure. Where the drop counter actually starts moving is still a
   number nobody has written down, and it is the one that would justify or move

--- a/docs/hl2-multi-ddc-test-matrix.md
+++ b/docs/hl2-multi-ddc-test-matrix.md
@@ -232,4 +232,7 @@ QT_QPA_PLATFORM=offscreen ctest --test-dir build -j22
 ```
 
 It SKIPS cleanly when no simulator is running, so it is safe in CI and on a
-machine connected to real hardware.
+machine connected to real hardware — and the skip is honest rather than silent:
+it exits 77, and `SKIP_RETURN_CODE` on the `add_test` makes ctest report
+`***Skipped`. A run that measured nothing cannot be mistaken for one that keyed
+and passed.

--- a/docs/hl2-multi-ddc-test-matrix.md
+++ b/docs/hl2-multi-ddc-test-matrix.md
@@ -35,9 +35,13 @@ open /Users/patj/aether/AetherSDR/.worktrees/feat-hl2-multi-rx/build/AetherSDR.a
   `Hl2Settings::receiverCount` is retired. If you previously set it, it is
   ignored.
 - Radio: HL2 at `192.168.1.21`. Simulator: `./hpsdrsim -hermeslite2 -P1`.
-- **Do not run the simulator on this Mac while testing the real radio** — this
-  machine is `192.168.1.12`, which is the address `hl2_tx_loopback_test` probes,
-  and a local simulator makes that test run when it should skip.
+- Running the simulator on this Mac alongside the real radio is now safe.
+  `hl2_tx_loopback_test` used to probe a hardcoded `192.168.1.12` — this
+  machine — so a local simulator made it run when it should have skipped. It now
+  defaults to loopback and refuses to key anything that does not answer discovery
+  with hpsdrsim's synthetic `AA:BB:CC:DD:xx:FF` MAC, so it cannot reach the
+  radio. Point it elsewhere with `AETHER_HL2_SIM_HOST` if the simulator is on
+  another box.
 - Only one client per radio. Check nothing else is connected first.
 - Turn on the HL2 log: `QT_LOGGING_RULES="aether.hl2*=true"`. Most rows below
   are confirmed from a log line, not from the screen.
@@ -211,12 +215,21 @@ audio gap there is correct behaviour, not a fault.
 
 ---
 
-## Known-failing, not caused by this work
+## Known-failing, not caused by this work — now fixed
 
-`hl2_tx_loopback_test` fails against the simulator on transmit-sideband checks.
-Commit `256142a6` (pre-multi-DDC) fails **identically**, and the failure count
-varies run to run. Tracked separately. Exclude it when running the suite:
+`hl2_tx_loopback_test` used to fail against the simulator on transmit-sideband
+checks, and commit `256142a6` (pre-multi-DDC) failed identically, so the "not
+caused by this work" call was right. It was not a transmit fault: the test
+expected the fed-back tone BELOW centre, which was correct only against the
+pre-#4471 panadapter that drew the raw wire. #4471 added the receive-side
+conjugation and the expectation went stale. The run-to-run variation was the
+hardcoded `192.168.1.12` reaching a simulator on another machine.
+
+No exclusion is needed any more — run the whole suite:
 
 ```bash
-ctest -j8 -E hl2_tx_loopback_test
+QT_QPA_PLATFORM=offscreen ctest --test-dir build -j22
 ```
+
+It SKIPS cleanly when no simulator is running, so it is safe in CI and on a
+machine connected to real hardware.

--- a/docs/hl2-multi-ddc-test-matrix.md
+++ b/docs/hl2-multi-ddc-test-matrix.md
@@ -40,8 +40,10 @@ open /Users/patj/aether/AetherSDR/.worktrees/feat-hl2-multi-rx/build/AetherSDR.a
   machine — so a local simulator made it run when it should have skipped. It now
   defaults to loopback and refuses to key anything that does not answer discovery
   with hpsdrsim's synthetic `AA:BB:CC:DD:xx:FF` MAC, so it cannot reach the
-  radio. Point it elsewhere with `AETHER_HL2_SIM_HOST` if the simulator is on
-  another box.
+  radio. It also skips a simulator that is already streaming to another client,
+  so running the suite cannot take a session out from under an app you have
+  driving it. Point it elsewhere with `AETHER_HL2_SIM_HOST` (an IP literal —
+  names are not resolved) if the simulator is on another box.
 - Only one client per radio. Check nothing else is connected first.
 - Turn on the HL2 log: `QT_LOGGING_RULES="aether.hl2*=true"`. Most rows below
   are confirmed from a log line, not from the screen.

--- a/tests/hl2_tx_loopback_test.cpp
+++ b/tests/hl2_tx_loopback_test.cpp
@@ -9,10 +9,36 @@
 // BYTES leave, but only the simulator can show the radio actually received them
 // and acted on them.
 //
-// SIM ONLY, deliberately. The address is hardcoded to the simulator and this
-// test keys the transmitter; pointing it at real hardware would radiate.
-// If nothing answers there, the test SKIPS rather than fails, so a machine
-// without the simulator running does not get a spurious red.
+// SIM ONLY, deliberately — and now ENFORCED rather than asserted. This test keys
+// the transmitter, so pointing it at real hardware would radiate. It used to
+// trust a hardcoded LAN address to BE the simulator; findSimulator() below
+// checks the responder's identity instead, and the default host is loopback.
+// If nothing answers, the test SKIPS rather than fails, so a machine without the
+// simulator running does not get a spurious red.
+//
+// WHICH SIDE OF CENTRE A TONE LANDS ON. The loop conjugates TWICE. Hl2TxDsp
+// conjugates the modulator output for the wire (the HPSDR wire has the opposite
+// handedness to the analytic convention); the simulator feeds that IQ back
+// verbatim; Hl2RxDsp conjugates the receive stream back before it reaches the
+// panadapter FFT. Two conjugations cancel, so the spectrum this test reads is in
+// the ANALYTIC convention: a tone transmitted 5 kHz above the carrier appears
+// 5 kHz ABOVE centre.
+//
+// It did not always. The receive-side conjugation arrived in #4471, to fix a
+// panadapter that drew every signal mirrored — on 40 m it put FT8 below a
+// correctly-drawn DIGU cursor. Before that the display carried the raw wire and
+// the fed-back tone read BELOW centre. This test was written against that older
+// display in #4466 and went on asserting the negative offset afterwards. That
+// staleness — not transmit — is the whole of the "fails on transmit-sideband
+// checks" that HERMES.md carried as pre-existing.
+//
+// BUT cancelling conjugations mean this loopback ALONE cannot prove absolute
+// sideband: a handedness error at BOTH ends still cancels. That is exactly how a
+// wrong-sideband transmitter once passed its own tests, and it took an operator
+// with a second receiver to catch it. So before believing anything the
+// transmitter puts in the spectrum, we pin the RECEIVE end against a signal that
+// never went through the transmitter — the simulator's own synthetic scene. See
+// the scene anchor below.
 
 #include "core/backends/hl2/Hl2Backend.h"
 #include "core/backends/hl2/MetisProtocol.h"
@@ -24,8 +50,11 @@
 #include <QTimer>
 #include <QUdpSocket>
 
+#include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
+#include <span>
 #include <vector>
 
 using namespace AetherSDR;
@@ -44,17 +73,49 @@ static void spin(int ms)
     loop.exec();
 }
 
-// Is the simulator actually there? A plain Metis discovery probe.
-static bool simPresent(const QString& host)
+enum class Probe { NoReply, NotSimulator, Simulator };
+
+// hpsdrsim builds its discovery reply with a synthetic MAC written byte by byte
+// in its source: AA BB CC DD <radio-type> FF. No HPSDR board ships an
+// AA:BB:CC:DD OUI, so this is a dependable "simulator, not a radio" fingerprint
+// — and it is the gate that keeps a test which KEYS A TRANSMITTER off real
+// hardware.
+//
+// It replaces a bare "did anything answer at 192.168.1.12". That address is not
+// the simulator's by construction; it is only where one happened to run once. On
+// another network it is somebody's actual radio. It was also, on the author's
+// LAN, silently reaching a simulator on a DIFFERENT machine — which is where the
+// "fails non-deterministically" reputation came from, since the answers depended
+// on what that other machine was doing at the time.
+static Probe findSimulator(const QString& host, AetherSDR::hl2::DiscoveryReply* out)
 {
     QUdpSocket s;
     if (!s.bind(QHostAddress(QHostAddress::AnyIPv4), 0))
-        return false;
+        return Probe::NoReply;
     const auto req = AetherSDR::hl2::discoveryRequest();
     s.writeDatagram(reinterpret_cast<const char*>(req.data()),
                     static_cast<qint64>(req.size()), QHostAddress(host),
                     AetherSDR::hl2::kMetisPort);
-    return s.waitForReadyRead(1500);
+    if (!s.waitForReadyRead(1500))
+        return Probe::NoReply;
+
+    QByteArray dg(2048, 0);
+    const qint64 got = s.readDatagram(dg.data(), dg.size());
+    if (got <= 0)
+        return Probe::NoReply;
+    const auto reply = AetherSDR::hl2::parseDiscoveryReply(
+        std::span<const std::uint8_t>(
+            reinterpret_cast<const std::uint8_t*>(dg.constData()),
+            static_cast<std::size_t>(got)));
+    if (!reply)
+        return Probe::NotSimulator;
+    if (out)
+        *out = *reply;
+
+    const auto& mac = reply->mac;
+    const bool synthetic = mac[0] == 0xAA && mac[1] == 0xBB && mac[2] == 0xCC
+                        && mac[3] == 0xDD && mac[5] == 0xFF;
+    return synthetic ? Probe::Simulator : Probe::NotSimulator;
 }
 
 // The IQ sample rate this test runs the receiver at, and therefore the span the
@@ -62,17 +123,76 @@ static bool simPresent(const QString& host)
 // derives from it.
 constexpr int kIqRateHz = 48000;
 
+// hpsdrsim's synthetic receive scene: two tones it generates itself into
+// toneItab/toneQtab, at offsets fixed relative to the ADC rather than the NCO,
+// present whether or not we are keyed.
+//
+// It builds them as I = sin(theta), Q = cos(theta) — so I + jQ = j*exp(-j*theta),
+// a NEGATIVE frequency on the wire, and a receive path that conjugates correctly
+// draws them ABOVE centre. That is the anchor: these tones reach the spectrum
+// without passing through the transmitter, so their side of centre pins the
+// RECEIVE end's handedness on its own. With it pinned, the transmit assertions
+// below can no longer be satisfied by a matched pair of errors.
+constexpr double kSceneToneLowHz = 800.0;
+constexpr double kSceneToneHighHz = 4000.0;
+
+// Bin of a baseband offset in the displayed spectrum, which is fftshifted (DC at
+// the centre bin) and in the analytic convention (above the carrier is above
+// centre). The ONE place that sign convention is written down.
+static int binForOffset(double offsetHz, int n)
+{
+    return n / 2 + static_cast<int>(
+        std::lround(offsetHz * n / static_cast<double>(kIqRateHz)));
+}
+
+// Strongest level within +/-halfWidth bins of centreBin. Offsets rarely land on
+// an exact bin — 800 Hz is 17.07 bins at this rate — so a bare lookup reads the
+// shoulder of the tone rather than its peak.
+static float peakNear(const std::vector<float>& spec, int centreBin, int halfWidth)
+{
+    const int n = static_cast<int>(spec.size());
+    const int lo = std::max(0, centreBin - halfWidth);
+    const int hi = std::min(n - 1, centreBin + halfWidth);
+    float best = -300.0f;
+    for (int i = lo; i <= hi; ++i)
+        best = std::max(best, spec[static_cast<std::size_t>(i)]);
+    return best;
+}
+
 int main(int argc, char** argv)
 {
     QCoreApplication app(argc, argv);
     qRegisterMetaType<SliceDelta>();
 
-    const QString simHost = QStringLiteral("192.168.1.12");
-    if (!simPresent(simHost)) {
+    // Loopback by default: a simulator on this machine is the normal case, and
+    // 127.0.0.1 cannot be somebody's radio. Override to reach a simulator on
+    // another box — the fingerprint check still applies there.
+    const QString simHost = qEnvironmentVariableIsSet("AETHER_HL2_SIM_HOST")
+        ? qEnvironmentVariable("AETHER_HL2_SIM_HOST")
+        : QStringLiteral("127.0.0.1");
+
+    AetherSDR::hl2::DiscoveryReply reply;
+    switch (findSimulator(simHost, &reply)) {
+    case Probe::NoReply:
         std::fprintf(stderr,
-            "hl2_tx_loopback_test: SKIPPED — no simulator answering at %s\n",
+            "hl2_tx_loopback_test: SKIPPED — nothing answering discovery at %s. "
+            "Start hpsdrsim (-hermeslite2 -P1), or set AETHER_HL2_SIM_HOST.\n",
             qPrintable(simHost));
         return 0;
+    case Probe::NotSimulator:
+        // Deliberately a SKIP and not a failure: the responder is somebody's
+        // radio or another board, and the correct outcome is to leave it alone,
+        // not to key it and not to redden a suite over it.
+        std::fprintf(stderr,
+            "hl2_tx_loopback_test: SKIPPED — %s answered with MAC "
+            "%02X:%02X:%02X:%02X:%02X:%02X, which is not hpsdrsim's synthetic "
+            "AA:BB:CC:DD:xx:FF. This test keys the transmitter, so it refuses to "
+            "run against anything that might be a real radio.\n",
+            qPrintable(simHost), reply.mac[0], reply.mac[1], reply.mac[2],
+            reply.mac[3], reply.mac[4], reply.mac[5]);
+        return 0;
+    case Probe::Simulator:
+        break;
     }
 
     // Transmit must be permitted for this to mean anything. This process sets no
@@ -125,6 +245,30 @@ int main(int argc, char** argv)
     const std::vector<float> baseline = lastSpectrum;
     check(!baseline.empty(), "receiving spectrum before keying");
 
+    // ---- scene anchor: pin the RECEIVE end before trusting the transmit end ----
+    //
+    // Unkeyed, so nothing here has been through the modulator. If these fail, the
+    // receive/display handedness is wrong and EVERY transmit assertion below is
+    // measuring through a broken ruler — fix this first and do not read the
+    // transmit results as a sideband verdict.
+    if (!baseline.empty()) {
+        const int n = static_cast<int>(baseline.size());
+        const float lowUp = peakNear(baseline, binForOffset(kSceneToneLowHz, n), 2);
+        const float lowDown = peakNear(baseline, binForOffset(-kSceneToneLowHz, n), 2);
+        const float highUp = peakNear(baseline, binForOffset(kSceneToneHighHz, n), 2);
+        const float highDown = peakNear(baseline, binForOffset(-kSceneToneHighHz, n), 2);
+
+        std::fprintf(stderr,
+            "scene anchor: %.0f Hz above %.1f dB / below %.1f dB, "
+            "%.0f Hz above %.1f dB / below %.1f dB\n",
+            kSceneToneLowHz, lowUp, lowDown, kSceneToneHighHz, highUp, highDown);
+
+        check(lowUp - lowDown > 20.0f,
+              "receive handedness: the simulator's 800 Hz scene tone is ABOVE centre");
+        check(highUp - highDown > 20.0f,
+              "receive handedness: the simulator's 4 kHz scene tone is ABOVE centre");
+    }
+
     // ---- transmit a tone ----
     constexpr double kToneOffsetHz = 5000.0;
     backend.setTxTestTone(kToneOffsetHz, 0.5);
@@ -143,11 +287,13 @@ int main(int argc, char** argv)
         const int n = static_cast<int>(keyed.size());
         const int centre = n / 2;
         const double binHz = static_cast<double>(kIqRateHz) / n;
-        // NEGATIVE offset: hpsdrsim feeds the TX IQ back in WIRE order, and the
-        // wire is the conjugate of the standard analytic convention (see
-        // Hl2TxDsp). On the air this same IQ becomes +5 kHz; here we are looking
-        // at the wire, so it reads -5 kHz.
-        const int expected = centre - static_cast<int>(std::lround(kToneOffsetHz / binHz));
+        // POSITIVE offset, and the scene anchor above is what earns the right to
+        // say so. Hl2TxDsp conjugates for the wire and Hl2RxDsp conjugates back
+        // for the panadapter, so the spectrum reads in the analytic convention
+        // and a tone sent 5 kHz up comes back 5 kHz up. The old negative
+        // expectation was correct against the pre-#4471 display, which showed
+        // the raw wire; it has been stale since.
+        const int expected = binForOffset(kToneOffsetHz, n);
 
         // Find the strongest bin while keyed.
         int peak = 0;
@@ -213,13 +359,16 @@ int main(int argc, char** argv)
             const int n = static_cast<int>(voice.size());
             const int centre = n / 2;
             const double binHz = static_cast<double>(kIqRateHz) / n;
-            // Same wire-order reasoning as above: USB audio leaves the
-            // modulator BELOW centre in wire order and is transmitted above the
-            // carrier. Asserting the textbook sign here is precisely what let a
-            // wrong-sideband transmitter pass its own tests — it took an
-            // operator with a second receiver to catch it.
-            const int expected = centre - static_cast<int>(std::lround(kAudioHz / binHz));
-            const int mirrored = centre + static_cast<int>(std::lround(kAudioHz / binHz));
+            // USB: 1.5 kHz of audio is transmitted 1.5 kHz ABOVE the carrier and,
+            // through the twice-conjugating loop, reads 1.5 kHz above centre.
+            //
+            // Asserting the textbook sign is what let a wrong-sideband
+            // transmitter pass its own tests once — but the defence against that
+            // is the scene anchor, which fixes the receive end independently, not
+            // a sign flip here. Flipping the sign only made this fail always,
+            // which is not the same as having teeth.
+            const int expected = binForOffset(kAudioHz, n);
+            const int mirrored = binForOffset(-kAudioHz, n);
 
             int peak = 0;
             for (int i = 1; i < n; ++i)

--- a/tests/hl2_tx_loopback_test.cpp
+++ b/tests/hl2_tx_loopback_test.cpp
@@ -14,7 +14,9 @@
 // trust a hardcoded LAN address to BE the simulator; findSimulator() below
 // checks the responder's identity instead, and the default host is loopback.
 // If nothing answers, the test SKIPS rather than fails, so a machine without the
-// simulator running does not get a spurious red.
+// simulator running does not get a spurious red — exiting 77, which the
+// SKIP_RETURN_CODE on its add_test turns into an honest ctest "Skipped" rather
+// than a "Passed" that measured nothing.
 //
 // WHICH SIDE OF CENTRE A TONE LANDS ON. The loop conjugates TWICE. Hl2TxDsp
 // conjugates the modulator output for the wire (the HPSDR wire has the opposite
@@ -72,6 +74,12 @@ static void spin(int ms)
     QTimer::singleShot(ms, &loop, &QEventLoop::quit);
     loop.exec();
 }
+
+// ctest's skip convention, declared as SKIP_RETURN_CODE on the add_test. Exiting
+// 0 on a skip is what let this test read as Passed to every automated consumer
+// while having measured nothing — and with the loopback default below, the
+// no-simulator case is the ordinary one, not the exception.
+constexpr int kSkipExit = 77;
 
 enum class Probe { NoReply, NotSimulator, Simulator };
 
@@ -178,7 +186,7 @@ int main(int argc, char** argv)
             "hl2_tx_loopback_test: SKIPPED — nothing answering discovery at %s. "
             "Start hpsdrsim (-hermeslite2 -P1), or set AETHER_HL2_SIM_HOST.\n",
             qPrintable(simHost));
-        return 0;
+        return kSkipExit;
     case Probe::NotSimulator:
         // Deliberately a SKIP and not a failure: the responder is somebody's
         // radio or another board, and the correct outcome is to leave it alone,
@@ -190,7 +198,7 @@ int main(int argc, char** argv)
             "run against anything that might be a real radio.\n",
             qPrintable(simHost), reply.mac[0], reply.mac[1], reply.mac[2],
             reply.mac[3], reply.mac[4], reply.mac[5]);
-        return 0;
+        return kSkipExit;
     case Probe::Simulator:
         break;
     }

--- a/tests/hl2_tx_loopback_test.cpp
+++ b/tests/hl2_tx_loopback_test.cpp
@@ -48,6 +48,7 @@
 #include "TestDspBuildWait.h"
 
 #include <QCoreApplication>
+#include <QElapsedTimer>
 #include <QEventLoop>
 #include <QTimer>
 #include <QUdpSocket>
@@ -81,7 +82,7 @@ static void spin(int ms)
 // no-simulator case is the ordinary one, not the exception.
 constexpr int kSkipExit = 77;
 
-enum class Probe { NoReply, NotSimulator, Simulator };
+enum class Probe { NoReply, Unreadable, NotSimulator, Simulator };
 
 // hpsdrsim builds its discovery reply with a synthetic MAC written byte by byte
 // in its source: AA BB CC DD <radio-type> FF. No HPSDR board ships an
@@ -95,35 +96,64 @@ enum class Probe { NoReply, NotSimulator, Simulator };
 // LAN, silently reaching a simulator on a DIFFERENT machine — which is where the
 // "fails non-deterministically" reputation came from, since the answers depended
 // on what that other machine was doing at the time.
+//
+// Which hpsdrsim: the g0orx/pihpsdr build HERMES.md §7 pins as the fixture. It
+// writes those bytes at hpsdrsim.c:628-633. Current upstream (dl1ycf/pihpsdr)
+// uses a different synthetic MAC, so a simulator built from that one reads as
+// NotSimulator and this test skips rather than running against it.
 static Probe findSimulator(const QString& host, AetherSDR::hl2::DiscoveryReply* out)
 {
+    const QHostAddress target(host);
     QUdpSocket s;
     if (!s.bind(QHostAddress(QHostAddress::AnyIPv4), 0))
         return Probe::NoReply;
     const auto req = AetherSDR::hl2::discoveryRequest();
     s.writeDatagram(reinterpret_cast<const char*>(req.data()),
-                    static_cast<qint64>(req.size()), QHostAddress(host),
+                    static_cast<qint64>(req.size()), target,
                     AetherSDR::hl2::kMetisPort);
-    if (!s.waitForReadyRead(1500))
-        return Probe::NoReply;
 
-    QByteArray dg(2048, 0);
-    const qint64 got = s.readDatagram(dg.data(), dg.size());
-    if (got <= 0)
-        return Probe::NoReply;
-    const auto reply = AetherSDR::hl2::parseDiscoveryReply(
-        std::span<const std::uint8_t>(
-            reinterpret_cast<const std::uint8_t*>(dg.constData()),
-            static_cast<std::size_t>(got)));
-    if (!reply)
-        return Probe::NotSimulator;
-    if (out)
-        *out = *reply;
+    // Read until the deadline instead of believing the first datagram, and
+    // ignore anything that did not come from the host we probed. Taking the
+    // first packet is a narrow version of this test's own root cause: one stray
+    // sender consumes the window, and the answer that decides whether we may key
+    // never gets looked at.
+    QElapsedTimer clock;
+    clock.start();
+    bool answeredUnparseable = false;
+    while (true) {
+        const qint64 remaining = 1500 - clock.elapsed();
+        if (remaining <= 0 || !s.waitForReadyRead(static_cast<int>(remaining)))
+            break;
+        while (s.hasPendingDatagrams()) {
+            QByteArray dg(2048, 0);
+            QHostAddress from;
+            const qint64 got = s.readDatagram(dg.data(), dg.size(), &from);
+            if (got <= 0)
+                continue;
+            if (!from.isEqual(target, QHostAddress::TolerantConversion))
+                continue;
+            const auto reply = AetherSDR::hl2::parseDiscoveryReply(
+                std::span<const std::uint8_t>(
+                    reinterpret_cast<const std::uint8_t*>(dg.constData()),
+                    static_cast<std::size_t>(got)));
+            // Answered, but not as a discovery reply. Kept distinct from the
+            // MAC mismatch below so the skip message can say which it was —
+            // reporting an all-zero MAC for a packet that never parsed sends
+            // whoever reads it looking for a device that does not exist.
+            if (!reply) {
+                answeredUnparseable = true;
+                continue;
+            }
+            if (out)
+                *out = *reply;
 
-    const auto& mac = reply->mac;
-    const bool synthetic = mac[0] == 0xAA && mac[1] == 0xBB && mac[2] == 0xCC
-                        && mac[3] == 0xDD && mac[5] == 0xFF;
-    return synthetic ? Probe::Simulator : Probe::NotSimulator;
+            const auto& mac = reply->mac;
+            const bool synthetic = mac[0] == 0xAA && mac[1] == 0xBB && mac[2] == 0xCC
+                                && mac[3] == 0xDD && mac[5] == 0xFF;
+            return synthetic ? Probe::Simulator : Probe::NotSimulator;
+        }
+    }
+    return answeredUnparseable ? Probe::Unreadable : Probe::NoReply;
 }
 
 // The IQ sample rate this test runs the receiver at, and therefore the span the
@@ -178,6 +208,17 @@ int main(int argc, char** argv)
     const QString simHost = qEnvironmentVariableIsSet("AETHER_HL2_SIM_HOST")
         ? qEnvironmentVariable("AETHER_HL2_SIM_HOST")
         : QStringLiteral("127.0.0.1");
+    // QHostAddress parses IP literals only — it does not resolve names. A
+    // hostname silently becomes a null address, the probe goes nowhere, and the
+    // result is a skip that reads exactly like "the simulator is down". Say so
+    // instead of leaving somebody to debug a simulator that was running fine.
+    if (QHostAddress(simHost).isNull()) {
+        std::fprintf(stderr,
+            "hl2_tx_loopback_test: SKIPPED — AETHER_HL2_SIM_HOST=\"%s\" is not an "
+            "IP literal. Give the simulator's address; names are not resolved.\n",
+            qPrintable(simHost));
+        return kSkipExit;
+    }
 
     AetherSDR::hl2::DiscoveryReply reply;
     switch (findSimulator(simHost, &reply)) {
@@ -185,6 +226,14 @@ int main(int argc, char** argv)
         std::fprintf(stderr,
             "hl2_tx_loopback_test: SKIPPED — nothing answering discovery at %s. "
             "Start hpsdrsim (-hermeslite2 -P1), or set AETHER_HL2_SIM_HOST.\n",
+            qPrintable(simHost));
+        return kSkipExit;
+    case Probe::Unreadable:
+        std::fprintf(stderr,
+            "hl2_tx_loopback_test: SKIPPED — %s answered the discovery probe, but "
+            "the reply did not parse as a Metis discovery response. This test keys "
+            "the transmitter, so it refuses to run against an unidentified "
+            "responder.\n",
             qPrintable(simHost));
         return kSkipExit;
     case Probe::NotSimulator:
@@ -200,6 +249,20 @@ int main(int argc, char** argv)
             reply.mac[3], reply.mac[4], reply.mac[5]);
         return kSkipExit;
     case Probe::Simulator:
+        // Somebody else's session. hpsdrsim serves one client: connecting tears
+        // down its EP6 handler and re-points it at us, and this test then keys
+        // PTT. Leaving it alone is the same call as the NotSimulator arm — and
+        // it is the collision HERMES.md used to warn about, now that the local
+        // simulator is the default target rather than an accident.
+        if (reply.streaming) {
+            std::fprintf(stderr,
+                "hl2_tx_loopback_test: SKIPPED — the simulator at %s reports it is "
+                "already streaming to another client (discovery status 0x03). "
+                "Taking its session over would break that client, and this test "
+                "then keys PTT.\n",
+                qPrintable(simHost));
+            return kSkipExit;
+        }
         break;
     }
 
@@ -362,6 +425,13 @@ int main(int argc, char** argv)
                 voice = lastSpectrum;
         }
         backend.setKeying(false);
+
+        // Assert the capture happened. Without this the three checks below are
+        // skipped in silence when `voice` never arrived, and the test still
+        // prints "all checks passed" — the same silent-green shape as a skip
+        // that exits 0, one level down.
+        check(voice.size() == baseline.size() && !voice.empty(),
+              "spectrum still flowing during the mic-path transmission");
 
         if (voice.size() == baseline.size() && !voice.empty()) {
             const int n = static_cast<int>(voice.size());


### PR DESCRIPTION
## What was wrong

`hl2_tx_loopback_test` has been failing on its transmit-sideband checks, carried
in `HERMES.md` and `docs/hl2-multi-ddc-test-matrix.md` as "pre-existing, not
caused by this work, fails non-deterministically, exclude it from the suite".

The "pre-existing" call was right. Everything else was a misdiagnosis, and it was
never a transmit fault.

**The sign went stale.** The test asserts that the tone hpsdrsim feeds back
appears BELOW centre. That was correct when it was written in #4466: the
panadapter then carried the raw HPSDR wire, which is the conjugate of the
analytic convention. #4471 added the receive-side conjugation in `Hl2RxDsp` — the
fix for a panadapter that drew every signal mirrored, putting FT8 on 40 m left of
a correctly-drawn DIGU cursor — and from that commit the same tone correctly
reads ABOVE centre. The test kept expecting the old sign.

The loop conjugates twice, `Hl2TxDsp` on the way out and `Hl2RxDsp` on the way
back, and the two cancel. So the spectrum reads in the analytic convention.

**The "non-determinism" was the hardcoded address.** `192.168.1.12` was never the
simulator by construction, only where one happened to run once. On this LAN it
belongs to a different machine, and the test was silently driving *that* box's
simulator — so results tracked whatever it was doing at the time. Against a local
simulator the old failure is perfectly deterministic.

## What this changes

**1. Assert the analytic sign.** A tone sent 5 kHz up comes back 5 kHz up.

**2. Anchor the receive end first — the part that matters.** Flipping the sign
alone would be a poor fix. Because the loop conjugates twice, a handedness error
at *both* ends cancels exactly, so this loopback could never prove absolute
sideband on its own. It was another instrument sharing the convention, which is
precisely how a wrong-sideband transmitter once passed its own tests and needed
an operator with a second receiver to catch it (§14.6).

So the test now takes an independent bearing on the receive end before believing
anything the transmitter puts in the spectrum. hpsdrsim generates its own scene
tones at 800 Hz and 4 kHz as `I = sin(θ)`, `Q = cos(θ)` — i.e. `j·e^{-jθ}`, a
negative frequency on the wire — and they reach the spectrum without passing
through the transmitter. A correctly conjugating receive path must therefore draw
them above centre.

**3. Refuse to key anything that is not the simulator.** The header always said
"SIM ONLY", but nothing enforced it — it trusted a hardcoded LAN address. It now
defaults to loopback (which cannot be somebody's radio) and checks the
responder's identity: hpsdrsim writes a synthetic `AA:BB:CC:DD:<type>:FF` MAC
byte by byte in its source, and no HPSDR board ships that OUI. Anything else is a
skip, not a failure — the right outcome for a stranger's radio is to leave it
alone. `AETHER_HL2_SIM_HOST` reaches a simulator on another box, fingerprint
check still applied.

## Proof

Against a local `./hpsdrsim -hermeslite2 -P1`:

```
scene anchor: 800 Hz above -61.0 dB / below -108.8 dB, 4000 Hz above -61.6 dB / below -109.2 dB
loopback: peak bin 619 (5016 Hz), expected ~619 (5000 Hz), level -6.8 dB (baseline at that bin -121.9 dB)
mic path: peak bin 544 (1500 Hz), expected 544; wanted -1.0 dB, mirror -112.5 dB, floor -121.2 dB
hl2_tx_loopback_test: all checks passed
```

Deterministic across repeated runs, with 48 dB of anchor margin and 111 dB of
opposite-sideband suppression — nothing here is marginal.

**The anchor discriminates.** Each fault injected separately:

| Injected fault | Scene anchor | Built-in tone | Mic path |
|---|---|---|---|
| none | pass | pass | pass |
| receive conjugation removed (recreates pre-#4471 display) | **FAIL** — names the receive end | fail | fail |
| modulator conjugation removed (TX-only sideband flip) | pass | pass¹ | **FAIL** |

¹ correctly — the built-in tone is synthesised in `MetisClient` and bypasses the
modulator entirely, so it is unaffected by a modulator flip.

The middle row reproduces the original failure signature exactly (peak bin 405 /
480), confirming the root cause. The bottom row is the one that matters: a
transmit-only sideband flip is now caught, on the path an operator actually uses,
and the diagnostics say which end broke instead of leaving all three transmit
checks red with no way to tell.

**Safety gate.** Against a responder carrying a genuine `00:1c:c0:a2:12:34`
Hermes-Lite MAC, the test skips — and the fake radio logged exactly one inbound
packet, the discovery probe, proving it never proceeded to key. With nothing
listening it skips too, so CI and machines attached to real hardware stay clean.

**Suite:** `QT_QPA_PLATFORM=offscreen ctest --test-dir build -j22` → **265/265
passed**, with `hl2_tx_loopback_test` running (not skipping). The exclusion the
docs carried is retired.

## Docs

- `HERMES.md` §14.6 — why the loopback structurally could not have caught the
  wrong-sideband bug, and what the anchor changes. The "measuring harder inside
  the loop cannot substitute" lesson stands; this is still inside the machine.
- `HERMES.md` "Still open" — bullet resolved, with the real root cause recorded.
- `docs/hl2-multi-ddc-test-matrix.md` — exclusion removed; the "do not run the
  simulator on this Mac" warning is obsolete now that the test cannot reach the
  radio.

No screenshots: this is a headless test fix with no UI surface.


---

## Added in review

**4. Pin the IQ rate.** `req.params["sampleRateHz"] = kIqRateHz` is a fourth root
cause, recorded here because it belongs in the merge commit: the test hardcoded
48000 in its bin arithmetic while silently depending on the backend default
happening to be 48 kHz, so raising that default moved every expected bin and
failed three assertions for a reason unrelated to transmit.

**5. The skip is honest to ctest.** Both skip paths exit 77 with
`SKIP_RETURN_CODE` set, matching `crdv_quarantined_test`. A run that measured
nothing now reports `***Skipped`, not `Passed` — #4815 point 3, and the
mechanism by which this test shadowed the #4799 review.

**6. The gate closes the rest of the way.** It skips a simulator already
streaming to another client (discovery status `0x03`), reads until the probe
deadline and ignores datagrams from any other sender, distinguishes an
unparseable answer from a wrong-MAC one instead of printing an invented
`00:00:00:00:00:00`, and rejects an `AETHER_HL2_SIM_HOST` that is not an IP
literal. The mic-path block also asserts its own capture happened, rather than
skipping three checks in silence and still printing "all checks passed".

Each branch of the gate exercised against a scripted Metis responder, all
exiting 77: nothing listening; unparseable reply; real HL2 MAC
(`00:1C:C0:A2:13:DD`); synthetic MAC with status `0x03`; a stray packet ahead of
that reply; and a hostname override.
