### PR TITLE
fix(gui): cache AetherVoice EQ layers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3255,6 +3255,9 @@ add_executable(client_eq_smoothing_test
 target_include_directories(client_eq_smoothing_test PRIVATE src)
 target_link_libraries(client_eq_smoothing_test PRIVATE Qt6::Widgets)
 set_target_properties(client_eq_smoothing_test PROPERTIES AUTOMOC ON)
+add_test(NAME client_eq_smoothing_test COMMAND client_eq_smoothing_test)
+set_tests_properties(client_eq_smoothing_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_SCALE_FACTOR=2")
 
 add_executable(client_comp_test
     tests/client_comp_test.cpp

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -837,7 +837,9 @@ Use `get renderstats reset`, wait for a fixed observation interval, then read
 `get renderstats reset` again. This gives disjoint samples across pan, waterfall,
 3DSS, scheduler, and WAVE counters with one command. `measuredMainThreadMsPerSec`
 is instrumented GUI-thread work, not whole-process CPU percentage; use it for
-causal comparisons while keeping the radio/display configuration fixed.
+causal comparisons while keeping the radio/display configuration fixed. As of
+v26.8.1, the total includes Client EQ paint time; captures from older builds do
+not include that component and are not directly comparable.
 
 ### `get eqstats`
 
@@ -845,7 +847,9 @@ Per-Client-EQ-canvas paint and cache counters. The bridge finds widgets by
 `inherits("AetherSDR::ClientEqCurveWidget")`, so it includes both the base widget and the
 interactive `ClientEqEditorCanvas` subclass used by the strip/editor. The
 active strip canvas has a stable selector: `stripRxEqCanvas` or
-`stripTxEqCanvas`.
+`stripTxEqCanvas`. Those path-specific selectors name the same widget at
+different times: before a path is selected it is `stripEqCanvas`, and switching
+between RX and TX replaces its object name rather than creating another canvas.
 
 ```json
 → {"cmd":"get","model":"eqstats","selector":"stripTxEqCanvas","property":"reset"}
@@ -854,7 +858,8 @@ active strip canvas has a stable selector: `stripRxEqCanvas` or
    "dpr":2.0,"fftUpdatesPerSec":25.0,"paintsPerSec":25.0,
    "paintMsPerSec":1.1,"backgroundCacheRebuildCount":1,
    "responseCacheRebuildCount":1,"backgroundCacheHits":624,
-   "responseCacheHits":624,"cacheLayerByteLimit":33554432,
+   "responseCacheHits":624,"cacheEligible":true,
+   "cacheLayerByteLimit":33554432,
    "cacheTotalByteLimit":67108864,"cacheRetainedBytes":66355200}]}
 ```
 

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -332,6 +332,7 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 | | [`get cwx`](#get-cwx) | CWX keyer state + queue-drain watch (#3949). |
 | | [`get panstats`](#get-panstats) | Per-panadapter render-cost counters (profiling). |
 | | [`get renderstats`](#get-renderstats) | Combined 2D/3D pan, waterfall, DSS, scheduler, and WAVE profiling snapshot. |
+| | [`get eqstats`](#get-eqstats) | Client EQ analyzer paint/cache counters. |
 | | [`get tracedebug`](#get-tracedebug) | Per-panadapter Flex/Kiwi FFT and 3D trace diagnostics. |
 | | [`get clients`](#get-clients) | Radio client roster, GUI IDs + foreign-pan-write forensics (#3977/#4166). |
 | | [`get sync`](#get-sync) | Receive-Sync (Auto Assist) state. |
@@ -693,6 +694,7 @@ connects).
 | `pan` | `active` (default) / `<panId>` e.g. `0x40000000` | one pan (centerMhz, bandwidthMhz, min/maxDbm, rxAntenna, rfGain, fps, `transmitInhibited`, `transmitInhibitReason`) |
 | `flags` (or `vfoFlags`) | `all` (default) / `<sliceId>` | VFO flag attachment snapshot: each flag’s slice id, expected radio pan id, attached UI pan id/index, geometry, visibility, and `attachedToExpectedPan`; also reports `missingSlices`. |
 | `panstats` | `<panIndex>` / `<objectName>` (default: all) | per-panadapter render-cost counters — see [`get panstats`](#get-panstats) |
+| `eqstats` | Client EQ canvas objectName (default: all) | analyzer paint/cache counters — see [`get eqstats`](#get-eqstats) |
 | `tracedebug` | `<panIndex>` / `<objectName>` (default: all) | per-panadapter Flex/Kiwi FFT and 3D trace diagnostics — see [`get tracedebug`](#get-tracedebug) |
 | `wavestats` | `—` / scope objectName | waveform-scope paint/append counters — see [`get wavestats`](#get-wavestats) |
 | `clients` | — | connected-client roster, per-pan ownership, foreign dBm-write counters and evictions — see [`get clients`](#get-clients) |
@@ -810,10 +812,10 @@ generic; the bridge does not embed or preserve an old registration name.
 ### `get renderstats`
 
 Combined rendering-analysis snapshot for before/after automation. It returns
-every `panstats` entry, every WAVE/strip `wavestats` entry, the shared pan
-scheduler, and non-overlapping headline totals. The totals cover measured
+every `panstats` entry, every WAVE/strip `wavestats` entry, every Client EQ
+`eqstats` entry, the shared pan scheduler, and non-overlapping headline totals. The totals cover measured
 GUI-thread FFT ingest, native/Kiwi waterfall ingest, GPU frame preparation,
-software fallback painting, and WAVE painting. DSS timings are reported
+software fallback painting, WAVE painting, and Client EQ painting. DSS timings are reported
 separately because they are a subset of FFT/waterfall ingest.
 
 ```json
@@ -822,13 +824,13 @@ separately because they are a subset of FFT/waterfall ingest.
    "totals":{"panCount":1,"visiblePanCount":1,"waveScopeCount":1,
      "fftFramesPerSec":24.9,"gpuFramesPerSec":25.1,
      "fftIngestMsPerSec":4.2,"nativeWaterfallUpdateMsPerSec":3.8,
-     "gpuFrameMsPerSec":2.7,"wavePaintMsPerSec":0.0,
+     "gpuFrameMsPerSec":2.7,"wavePaintMsPerSec":0.0,"eqPaintMsPerSec":1.1,
      "measuredMainThreadMsPerSec":10.7,
      "hiddenWaterfallUpdatesPerSec":0.0,
      "hiddenDssHistoryRowsPerSec":0.0,
      "waterfallAllocatedBytes":583680,
      "dssAllocatedBytes":37847040},
-   "pans":[...],"scopes":[...],"renderScheduler":{...}}
+   "pans":[...],"scopes":[...],"eqCurves":[...],"renderScheduler":{...}}
 ```
 
 Use `get renderstats reset`, wait for a fixed observation interval, then read
@@ -836,6 +838,33 @@ Use `get renderstats reset`, wait for a fixed observation interval, then read
 3DSS, scheduler, and WAVE counters with one command. `measuredMainThreadMsPerSec`
 is instrumented GUI-thread work, not whole-process CPU percentage; use it for
 causal comparisons while keeping the radio/display configuration fixed.
+
+### `get eqstats`
+
+Per-Client-EQ-canvas paint and cache counters. The bridge finds widgets by
+`inherits("AetherSDR::ClientEqCurveWidget")`, so it includes both the base widget and the
+interactive `ClientEqEditorCanvas` subclass used by the strip/editor. The
+active strip canvas has a stable selector: `stripRxEqCanvas` or
+`stripTxEqCanvas`.
+
+```json
+→ {"cmd":"get","model":"eqstats","selector":"stripTxEqCanvas","property":"reset"}
+← {"ok":true,"model":"eqstats","curves":[{
+   "name":"stripTxEqCanvas","visible":true,"widthPx":1920,"heightPx":1080,
+   "dpr":2.0,"fftUpdatesPerSec":25.0,"paintsPerSec":25.0,
+   "paintMsPerSec":1.1,"backgroundCacheRebuildCount":1,
+   "responseCacheRebuildCount":1,"backgroundCacheHits":624,
+   "responseCacheHits":624,"cacheLayerByteLimit":33554432,
+   "cacheTotalByteLimit":67108864,"cacheRetainedBytes":66355200}]}
+```
+
+`get eqstats [selector] [reset]` returns then clears the selected interval
+when `reset` is supplied. FFT-only paints should increase the hit counters
+without increasing either rebuild count. Each retained layer is capped at
+33,554,432 bytes (67,108,864 bytes across both layers); ordinary physical 4K
+(3840×2160) layers remain eligible.
+Above that size, the widget paints directly and releases any prior layer once,
+instead of reallocating cache storage every paint.
 
 ### `get panstats`
 Per-panadapter (SpectrumWidget) frame-cost counters — how much GUI-thread time

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -780,6 +780,32 @@ QList<QWidget*> findWidgetsByClass(const QString& cls)
     return out;
 }
 
+// Keep findWidgetsByClass exact for existing callers. EQ canvases are
+// ClientEqEditorCanvas subclasses, so their bridge enumeration deliberately
+// uses QObject inheritance instead.
+void collectClientEqCurveWidgets(QWidget* widget, QList<QWidget*>& out)
+{
+    if (widget->inherits("AetherSDR::ClientEqCurveWidget")) {
+        out.append(widget);
+    }
+    const QObjectList children = widget->children();
+    for (QObject* child : children) {
+        if (auto* childWidget = qobject_cast<QWidget*>(child)) {
+            collectClientEqCurveWidgets(childWidget, out);
+        }
+    }
+}
+
+QList<QWidget*> findClientEqCurveWidgets()
+{
+    QList<QWidget*> out;
+    const QWidgetList tops = QApplication::topLevelWidgets();
+    for (QWidget* topLevel : tops) {
+        collectClientEqCurveWidgets(topLevel, out);
+    }
+    return out;
+}
+
 struct ObjectInventory {
     int count{0};
     QMap<QString, int> classes;
@@ -2569,7 +2595,8 @@ const QStringList& getModelNames()
         QStringLiteral("pans"),       QStringLiteral("panstats"),
         QStringLiteral("gps"),        QStringLiteral("clock"),
         QStringLiteral("renderstats"),
-        QStringLiteral("tracedebug"), QStringLiteral("waveforms"),
+        QStringLiteral("eqstats"),    QStringLiteral("tracedebug"),
+        QStringLiteral("waveforms"),
         QStringLiteral("kiwi"),
     };
     return kModels;
@@ -2875,7 +2902,7 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
                 return s.doInvoke(a.target, a.action, a.value);
             });
 
-        add("get", {}, "get <model> [selector] [property] — live model snapshot",
+        add("get", {}, "get <model> [selector] [property] — live model snapshot; get eqstats [selector] [reset] reports Client EQ paint/cache counters",
             [](const QList<QByteArray>& p, A& a) -> QJsonObject {
                 a.model = vtok(p, 1);
                 a.selector = vtok(p, 2);
@@ -4659,6 +4686,36 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
                            {QStringLiteral("model"), model},
                            {QStringLiteral("waveforms"), data}};
     }
+    if (model == QLatin1String("eqstats")) {
+        // Per Client-EQ paint/cache counters. This keeps the bridge
+        // GUI-header-free: widgets are located by class name and expose the
+        // snapshot through Q_INVOKABLE. `reset` returns then clears an interval.
+        const bool reset = selector == QLatin1String("reset")
+            || property == QLatin1String("reset");
+        const QString effectiveSelector = selector == QLatin1String("reset")
+            ? QString() : selector;
+        QJsonArray curves;
+        QSet<QWidget*> seen;
+        for (QWidget* w : findClientEqCurveWidgets()) {
+            if (seen.contains(w)) {
+                continue;
+            }
+            seen.insert(w);
+            if (!effectiveSelector.isEmpty() && w->objectName() != effectiveSelector) {
+                continue;
+            }
+            QVariantMap snap;
+            if (!QMetaObject::invokeMethod(w, "eqstatsSnapshot", Qt::DirectConnection,
+                                           Q_RETURN_ARG(QVariantMap, snap),
+                                           Q_ARG(bool, reset))) {
+                continue;
+            }
+            curves.append(QJsonObject::fromVariantMap(snap));
+        }
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("model"), model},
+                           {QStringLiteral("curves"), curves}};
+    }
     if (model == QLatin1String("renderstats")) {
         // One profiling snapshot for all panadapter, waterfall, 3DSS, shared
         // scheduler, and WAVE-scope work. This deliberately reuses the widget
@@ -4768,10 +4825,31 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
             waveAppendsPerSec += snap.value(QStringLiteral("appendsPerSec")).toDouble();
         }
 
+        seen.clear();
+        double eqPaintMsPerSec = 0.0;
+        double eqPaintsPerSec = 0.0;
+        QJsonArray eqCurves;
+        for (QWidget* w : findClientEqCurveWidgets()) {
+            if (seen.contains(w)) {
+                continue;
+            }
+            seen.insert(w);
+            QVariantMap snap;
+            if (!QMetaObject::invokeMethod(w, "eqstatsSnapshot",
+                                           Qt::DirectConnection,
+                                           Q_RETURN_ARG(QVariantMap, snap),
+                                           Q_ARG(bool, reset))) {
+                continue;
+            }
+            eqCurves.append(QJsonObject::fromVariantMap(snap));
+            eqPaintMsPerSec += snap.value(QStringLiteral("paintMsPerSec")).toDouble();
+            eqPaintsPerSec += snap.value(QStringLiteral("paintsPerSec")).toDouble();
+        }
+
         const double measuredMainThreadMsPerSec =
             fftIngestMsPerSec + nativeWaterfallUpdateMsPerSec
             + kiwiWaterfallUpdateMsPerSec + gpuFrameMsPerSec
-            + softwarePaintMsPerSec + wavePaintMsPerSec;
+            + softwarePaintMsPerSec + wavePaintMsPerSec + eqPaintMsPerSec;
         QJsonObject totals{
             {QStringLiteral("panCount"), pans.size()},
             {QStringLiteral("visiblePanCount"), visiblePanCount},
@@ -4795,6 +4873,9 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
             {QStringLiteral("wavePaintsPerSec"), wavePaintsPerSec},
             {QStringLiteral("wavePaintMsPerSec"), wavePaintMsPerSec},
             {QStringLiteral("waveAppendsPerSec"), waveAppendsPerSec},
+            {QStringLiteral("eqCurveCount"), eqCurves.size()},
+            {QStringLiteral("eqPaintsPerSec"), eqPaintsPerSec},
+            {QStringLiteral("eqPaintMsPerSec"), eqPaintMsPerSec},
             {QStringLiteral("measuredMainThreadMsPerSec"), measuredMainThreadMsPerSec},
             {QStringLiteral("waterfallAllocatedBytes"), waterfallAllocatedBytes},
             {QStringLiteral("dssAllocatedBytes"), dssAllocatedBytes},
@@ -4803,6 +4884,7 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
                         {QStringLiteral("model"), model},
                         {QStringLiteral("pans"), pans},
                         {QStringLiteral("scopes"), scopes},
+                        {QStringLiteral("eqCurves"), eqCurves},
                         {QStringLiteral("totals"), totals}};
         if (haveSchedulerStats) {
             out[QStringLiteral("renderScheduler")] =
@@ -5165,7 +5247,7 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
         data = panSnapshot(p, radio);
     } else {
         return err(QStringLiteral("unknown model: ") + model
-                   + QStringLiteral(" (use audio|dsp|sync|radio|transmit|cwx|equalizer|meters|slice|slices|pan|pans|flags|panstats|renderstats|tracedebug|clients|kiwi|wavestats|clock)"));
+                   + QStringLiteral(" (use audio|dsp|sync|radio|transmit|cwx|equalizer|meters|slice|slices|pan|pans|flags|panstats|renderstats|eqstats|tracedebug|clients|kiwi|wavestats|clock)"));
     }
 
     if (!property.isEmpty()) {

--- a/src/gui/ClientEqCurveWidget.cpp
+++ b/src/gui/ClientEqCurveWidget.cpp
@@ -7,6 +7,11 @@
 #include <QPen>
 #include <QFont>
 #include <QColor>
+#include <QElapsedTimer>
+#include <QLinearGradient>
+#include <QVariantMap>
+#include <QVector>
+#include <algorithm>
 #include <array>
 #include <cmath>
 
@@ -18,6 +23,9 @@ namespace {
 constexpr float kMinHz   = 20.0f;
 constexpr float kMaxHz   = 20000.0f;
 constexpr float kDbRange = 18.0f;   // ±18 dB vertical extent
+// A physical 3840×2160 layer is 33,177,600 bytes, so ordinary physical 4K
+// canvases remain cached while each of our two retained layers stays bounded.
+constexpr qint64 kMaxCacheLayerBytes = 32LL * 1024LL * 1024LL;
 // Bottom strip showing band-plan-style audio modulation regions
 // (E-SSB / SSB / AM-FM).  Reserved at the bottom of the drawing
 // rect; freq labels move above it; analyzer + curves clip to
@@ -69,6 +77,7 @@ ClientEqCurveWidget::ClientEqCurveWidget(QWidget* parent) : QWidget(parent)
 {
     setMinimumHeight(80);
     setAttribute(Qt::WA_OpaquePaintEvent, false);
+    m_perfSince.start();
 }
 
 void ClientEqCurveWidget::setEq(ClientEq* eq)
@@ -95,6 +104,7 @@ void ClientEqCurveWidget::setShowFilledRegions(bool on)
 void ClientEqCurveWidget::setFftBinsDb(const std::vector<float>& binsDb,
                                        double sampleRate)
 {
+    ++m_perfStats.fftUpdates;
     m_fftBinsDb = binsDb;
     m_fftSampleRate = sampleRate > 0.0 ? sampleRate : 24000.0;
 
@@ -243,6 +253,62 @@ void ClientEqCurveWidget::setReferenceCurvePreset(const QString& id)
     update();
 }
 
+ClientEqCurveWidget::BackgroundCacheKey ClientEqCurveWidget::backgroundCacheKey() const
+{
+    return {size(), devicePixelRatioF(), font(), m_filterLowCutHz, m_filterHighCutHz};
+}
+
+ClientEqCurveWidget::ResponseCacheKey ClientEqCurveWidget::responseCacheKey() const
+{
+    ResponseCacheKey key;
+    key.size = size();
+    key.devicePixelRatio = devicePixelRatioF();
+    key.font = font();
+    key.eq = m_eq;
+    key.selectedBand = m_selectedBand;
+    key.showFilled = m_showFilled;
+    key.referencePreset = m_referencePreset;
+    if (!m_eq) {
+        return key;
+    }
+
+    key.eqEnabled = m_eq->isEnabled();
+    key.filterFamily = static_cast<int>(m_eq->filterFamily());
+    key.sampleRate = m_eq->sampleRate();
+    key.activeBandCount = std::clamp(m_eq->activeBandCount(), 0,
+                                     static_cast<int>(key.bands.size()));
+    for (int i = 0; i < key.activeBandCount; ++i) {
+        const ClientEq::BandParams band = m_eq->band(i);
+        key.bands[static_cast<size_t>(i)] = {
+            band.freqHz, band.gainDb, band.q, static_cast<int>(band.type),
+            band.enabled, band.slopeDbPerOct,
+        };
+    }
+    return key;
+}
+
+bool ClientEqCurveWidget::cacheEligible(const QSize& cacheSize,
+                                        qreal devicePixelRatio) const
+{
+    // The two current-size layers are bounded rather than accumulating on
+    // resize.  Avoid retaining very large DPR pixmaps on unusually large
+    // canvases; drawing directly preserves fidelity in that rare case.
+    const qint64 pixelWidth = std::max<qint64>(0, qRound(cacheSize.width() * devicePixelRatio));
+    const qint64 pixelHeight = std::max<qint64>(0, qRound(cacheSize.height() * devicePixelRatio));
+    return pixelWidth > 0 && pixelHeight > 0
+        && pixelWidth <= kMaxCacheLayerBytes / 4 / pixelHeight;
+}
+
+QPixmap ClientEqCurveWidget::makeCachePixmap(const QSize& cacheSize,
+                                              qreal devicePixelRatio) const
+{
+    QPixmap cache(qRound(cacheSize.width() * devicePixelRatio),
+                  qRound(cacheSize.height() * devicePixelRatio));
+    cache.setDevicePixelRatio(devicePixelRatio);
+    cache.fill(Qt::transparent);
+    return cache;
+}
+
 std::vector<float> ClientEqCurveWidget::applyFractionalOctaveSmoothing(
     const std::vector<float>& binsDb, double sampleRate, int octaveFraction)
 {
@@ -332,15 +398,9 @@ float ClientEqCurveWidget::yToDb(float y) const
     return kDbRange - norm * (2.0f * kDbRange);
 }
 
-void ClientEqCurveWidget::paintEvent(QPaintEvent* /*ev*/)
+void ClientEqCurveWidget::drawBackground(QPainter& p, const QRect& r) const
 {
-    QPainter p(this);
-    p.setRenderHint(QPainter::Antialiasing, true);
-    p.setRenderHint(QPainter::TextAntialiasing, true);
-
-    const QRect r = rect();
-
-    // Background — deep navy matching our dark theme.
+    // Background/grid/filter guides/labels stay behind the live analyzer.
     p.fillRect(r, QColor("#0a0a18"));
 
     // Minor grid — dB lines at ±6, ±12 dB.
@@ -411,93 +471,15 @@ void ClientEqCurveWidget::paintEvent(QPaintEvent* /*ev*/)
         }
     }
 
-    // Live FFT analyzer — filled gradient showing what's actually flowing
-    // through the audio path post-EQ.  Drawn early so every EQ-visual
-    // layer sits on top.  Scale: -70 dB → bottom, 0 dB → top.
-    // Filled region uses fractional-octave-smoothed bins (m_fftBinsDbSmoothed)
-    // so the visual matches the user's smoothing selection.  Peak-hold trace
-    // below stays on raw bins so transient peaks aren't masked.
-    if (!m_fftBinsDb.empty()) {
-        const int bins = static_cast<int>(m_fftBinsDb.size());
-        const std::vector<float>& drawBins = (m_fftBinsDbSmoothed.size() == m_fftBinsDb.size())
-            ? m_fftBinsDbSmoothed : m_fftBinsDb;
-        const float minDb = -70.0f;
-        const float maxDb =   0.0f;
-        // Clip the analyzer to above the audio band-plan strip.
-        const float h = static_cast<float>(r.height() - kAudioBandStripH);
-        auto dbfsToY = [&](float db) {
-            const float n = (db - minDb) / (maxDb - minDb);
-            return (1.0f - std::clamp(n, 0.0f, 1.0f)) * h;
-        };
+}
 
-        QPainterPath fftPath;
-        fftPath.moveTo(0, h);
-        bool  started = false;
-        float lastX   = 0.0f;
-        for (int i = 1; i < bins; ++i) {
-            // bins.size() == fftSize/2 + 1; bin i maps to i * fs / fftSize.
-            const float f = static_cast<float>(i) *
-                            static_cast<float>(m_fftSampleRate) /
-                            static_cast<float>((bins - 1) * 2);
-            const float x = freqToX(f);
-            if (x < 0 || x > r.width()) continue;
-            const float y = dbfsToY(drawBins[i]);
-            if (!started) { fftPath.lineTo(x, h); started = true; }
-            fftPath.lineTo(x, y);
-            lastX = x;
-        }
-        // Close the filled region at the last valid bin's x, not at the
-        // canvas right edge.  Above Nyquist the FFT has no bins; drawing
-        // out to r.width() produced a misleading near-horizontal "shelf"
-        // connecting the last bin's level to the bottom-right corner.
-        if (started) {
-            fftPath.lineTo(lastX, h);
-        }
-        fftPath.closeSubpath();
-
-        QLinearGradient grad(0, 0, 0, h);
-        grad.setColorAt(0.0, QColor(88, 200, 232, 140));   // cyan top
-        grad.setColorAt(0.6, QColor(30, 110, 170,  70));
-        grad.setColorAt(1.0, QColor(12,  40,  70,   0));   // fades to clear
-        p.setPen(Qt::NoPen);
-        p.setBrush(grad);
-        p.drawPath(fftPath);
-
-        // Peak-hold line — same dBFS scale as the live spectrum.  Drawn
-        // on top so resonances and harsh peaks stand out as the user
-        // tunes.  Soft off-white reads cleanly against the cool-cyan
-        // analyzer.  Reads the smoothed peak-hold buffer so changing
-        // the Smoothing combo visibly affects the dominant trace.
-        const std::vector<float>& peakBins =
-            (m_peakHoldDbSmoothed.size() == m_peakHoldDb.size())
-                ? m_peakHoldDbSmoothed : m_peakHoldDb;
-        if (!peakBins.empty() && peakBins.size() == m_fftBinsDb.size()) {
-            QPainterPath peakPath;
-            bool peakStarted = false;
-            for (int i = 1; i < bins; ++i) {
-                const float f = static_cast<float>(i) *
-                                static_cast<float>(m_fftSampleRate) /
-                                static_cast<float>((bins - 1) * 2);
-                const float x = freqToX(f);
-                if (x < 0 || x > r.width()) continue;
-                const float y = dbfsToY(peakBins[i]);
-                if (!peakStarted) { peakPath.moveTo(x, y); peakStarted = true; }
-                else              peakPath.lineTo(x, y);
-            }
-            QPen peakPen(QColor(220, 222, 230, 210), 1.4);
-            peakPen.setJoinStyle(Qt::RoundJoin);
-            peakPen.setCapStyle(Qt::RoundCap);
-            p.setPen(peakPen);
-            p.setBrush(Qt::NoBrush);
-            p.drawPath(peakPath);
-        }
-    }
-
-    // Reference curve overlay — selected preset.  Drawn after the
-    // analyzer but before the EQ band curves so the user's adjustments
-    // sit on top of the target they're shaping toward.  Amber,
-    // semi-transparent.
-    if (const RefPreset* preset = findPreset(m_referencePreset)) {
+void ClientEqCurveWidget::drawResponse(QPainter& p, const QRect& r,
+                                       const ResponseCacheKey& key) const
+{
+    // This layer stays above the live analyzer. Its key intentionally covers
+    // every visible ClientEq value because ClientEq is not a QObject and a
+    // caller may mutate it then call update() without a signal.
+    if (const RefPreset* preset = findPreset(key.referencePreset)) {
         QPainterPath refPath;
         for (int i = 0; i < preset->count; ++i) {
             const float x = freqToX(preset->pts[i].hz);
@@ -514,21 +496,21 @@ void ClientEqCurveWidget::paintEvent(QPaintEvent* /*ev*/)
         p.drawPath(refPath);
     }
 
-    if (!m_eq || m_eq->activeBandCount() == 0) {
+    if (!key.eq || key.activeBandCount == 0) {
         p.setPen(QColor("#405060"));
         QFont f = p.font();
         f.setPointSizeF(8.0);
         p.setFont(f);
         p.drawText(r, Qt::AlignCenter,
-                   m_eq ? QString("(no bands — add one in the editor)")
+                   key.eq ? QString("(no bands — add one in the editor)")
                         : QString("(no EQ connected)"));
         return;
     }
 
-    const int   bandCount = m_eq->activeBandCount();
-    const double fs       = m_eq->sampleRate();
+    const int   bandCount = key.activeBandCount;
+    const double fs       = key.sampleRate;
     const int   W         = r.width();
-    const bool  eqOn      = m_eq->isEnabled();
+    const bool  eqOn      = key.eqEnabled;
 
     // bandMagnitudeDb evaluates analog-prototype transfer functions in
     // double precision, so the drawn response is ideal across the full
@@ -537,14 +519,20 @@ void ClientEqCurveWidget::paintEvent(QPaintEvent* /*ev*/)
     // biquads; this is the analog reference the biquad approximates.
     // HP/LP bands cascade internally based on slopeDbPerOct and the
     // globally-selected FilterFamily on the bound ClientEq.
-    const ClientEq::FilterFamily family = m_eq->filterFamily();
+    const ClientEq::FilterFamily family =
+        static_cast<ClientEq::FilterFamily>(key.filterFamily);
     QVector<float> summed(W, 0.0f);
     QVector<QVector<float>> perBand(bandCount, QVector<float>(W, 0.0f));
     for (int x = 0; x < W; ++x) {
         const float probe = xToFreq(static_cast<float>(x));
         float acc = 0.0f;
         for (int i = 0; i < bandCount; ++i) {
-            const auto bp = m_eq->band(i);
+            const BandCacheState& state = key.bands[static_cast<size_t>(i)];
+            const ClientEq::BandParams bp{
+                state.freqHz, state.gainDb, state.q,
+                static_cast<ClientEq::FilterType>(state.type), state.enabled,
+                state.slopeDbPerOct,
+            };
             const float dB = ClientEq::bandMagnitudeDb(bp, probe, fs, family);
             perBand[i][x] = dB;
             acc += dB;
@@ -555,11 +543,11 @@ void ClientEqCurveWidget::paintEvent(QPaintEvent* /*ev*/)
     // Selected-band highlight bar — vertical translucent stripe that ties
     // the icon row, canvas, and param-row column together.  Drawn before
     // the filled regions so the filled region colour still shows through.
-    if (m_selectedBand >= 0 && m_selectedBand < bandCount) {
-        const auto bp = m_eq->band(m_selectedBand);
+    if (key.selectedBand >= 0 && key.selectedBand < bandCount) {
+        const BandCacheState& bp = key.bands[static_cast<size_t>(key.selectedBand)];
         const float cx = freqToX(bp.freqHz);
         const float stripeWidth = 18.0f;
-        QColor stripe = bandColor(m_selectedBand);
+        QColor stripe = bandColor(key.selectedBand);
         stripe.setAlphaF(0.16f);
         p.fillRect(QRectF(cx - stripeWidth * 0.5f, 0.0f,
                           stripeWidth, static_cast<float>(r.height())),
@@ -570,11 +558,13 @@ void ClientEqCurveWidget::paintEvent(QPaintEvent* /*ev*/)
     // line and each band's response.  Renders the Logic-Pro-style "see
     // what each band is doing" look.  Drawn first so the per-band strokes
     // and summed curve on top stay readable.
-    if (m_showFilled) {
+    if (key.showFilled) {
         const float yZero = dbToY(0.0f);
         for (int i = 0; i < bandCount; ++i) {
-            const auto bp = m_eq->band(i);
-            if (!bp.enabled) continue;
+            const BandCacheState& bp = key.bands[static_cast<size_t>(i)];
+            if (!bp.enabled) {
+                continue;
+            }
             QColor fill = bandColor(i);
             fill.setAlphaF(eqOn ? 0.22f : 0.07f);
             p.setPen(Qt::NoPen);
@@ -631,15 +621,17 @@ void ClientEqCurveWidget::paintEvent(QPaintEvent* /*ev*/)
     // Selected band renders a halo ring to match the icon-row highlight.
     p.setRenderHint(QPainter::Antialiasing, true);
     for (int i = 0; i < bandCount; ++i) {
-        const auto bp = m_eq->band(i);
-        const bool isSlope = (bp.type == ClientEq::FilterType::LowPass
-                           || bp.type == ClientEq::FilterType::HighPass);
+        const BandCacheState& bp = key.bands[static_cast<size_t>(i)];
+        const bool isSlope = (bp.type == static_cast<int>(ClientEq::FilterType::LowPass)
+                           || bp.type == static_cast<int>(ClientEq::FilterType::HighPass));
         const float handleDb = isSlope ? 0.0f : bp.gainDb;
         const QPointF center(freqToX(bp.freqHz), dbToY(handleDb));
         QColor c = bandColor(i);
-        if (!bp.enabled || !eqOn) c.setAlphaF(0.35f);
+        if (!bp.enabled || !eqOn) {
+            c.setAlphaF(0.35f);
+        }
 
-        if (i == m_selectedBand) {
+        if (i == key.selectedBand) {
             QColor halo = c; halo.setAlphaF(0.35f);
             p.setBrush(halo);
             p.setPen(Qt::NoPen);
@@ -679,7 +671,9 @@ void ClientEqCurveWidget::paintEvent(QPaintEvent* /*ev*/)
         for (const auto& seg : segs) {
             const int x1 = static_cast<int>(freqToX(seg.lowHz));
             const int x2 = static_cast<int>(freqToX(seg.highHz));
-            if (x2 <= x1) continue;
+            if (x2 <= x1) {
+                continue;
+            }
             QColor fill(
                 static_cast<int>(seg.color.red()   * seg.blend + bg.red()   * (1.0f - seg.blend)),
                 static_cast<int>(seg.color.green() * seg.blend + bg.green() * (1.0f - seg.blend)),
@@ -695,6 +689,215 @@ void ClientEqCurveWidget::paintEvent(QPaintEvent* /*ev*/)
             }
         }
     }
+}
+
+void ClientEqCurveWidget::paintEvent(QPaintEvent* /*ev*/)
+{
+    QElapsedTimer paintTimer;
+    paintTimer.start();
+    ++m_perfStats.paints;
+
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, true);
+    p.setRenderHint(QPainter::TextAntialiasing, true);
+    const QRect r = rect();
+    const qreal dpr = devicePixelRatioF();
+    const bool cacheAllowed = cacheEligible(r.size(), dpr);
+
+    const BackgroundCacheKey backgroundKey = backgroundCacheKey();
+    if (cacheAllowed) {
+        if (!m_backgroundCacheValid || m_backgroundCacheKey != backgroundKey) {
+            m_backgroundCache = makeCachePixmap(r.size(), dpr);
+            QPainter cachePainter(&m_backgroundCache);
+            cachePainter.setRenderHint(QPainter::Antialiasing, true);
+            cachePainter.setRenderHint(QPainter::TextAntialiasing, true);
+            cachePainter.setFont(font());
+            drawBackground(cachePainter, r);
+            m_backgroundCacheKey = backgroundKey;
+            m_backgroundCacheValid = !m_backgroundCache.isNull();
+            ++m_perfStats.backgroundCacheRebuilds;
+        } else {
+            ++m_perfStats.backgroundCacheHits;
+        }
+        if (m_backgroundCacheValid) {
+            p.drawPixmap(0, 0, m_backgroundCache);
+        } else {
+            drawBackground(p, r);
+        }
+    } else {
+        if (!m_backgroundCache.isNull()) {
+            m_backgroundCache = QPixmap();
+        }
+        m_backgroundCacheValid = false;
+        drawBackground(p, r);
+    }
+
+    // The analyzer is deliberately dynamic: FFT, peak-hold and smoothing
+    // changes repaint only this section between the two cached layers.
+    if (!m_fftBinsDb.empty()) {
+        const int bins = static_cast<int>(m_fftBinsDb.size());
+        const std::vector<float>& drawBins = (m_fftBinsDbSmoothed.size() == m_fftBinsDb.size())
+            ? m_fftBinsDbSmoothed : m_fftBinsDb;
+        const float h = static_cast<float>(r.height() - kAudioBandStripH);
+        auto dbfsToY = [h](float db) {
+            const float n = (db + 70.0f) / 70.0f;
+            return (1.0f - std::clamp(n, 0.0f, 1.0f)) * h;
+        };
+        QPainterPath fftPath;
+        fftPath.moveTo(0, h);
+        bool started = false;
+        float lastX = 0.0f;
+        for (int i = 1; i < bins; ++i) {
+            const float f = static_cast<float>(i) * static_cast<float>(m_fftSampleRate)
+                / static_cast<float>((bins - 1) * 2);
+            const float x = freqToX(f);
+            if (x < 0 || x > r.width()) {
+                continue;
+            }
+            const float y = dbfsToY(drawBins[i]);
+            if (!started) {
+                fftPath.lineTo(x, h);
+                started = true;
+            }
+            fftPath.lineTo(x, y);
+            lastX = x;
+        }
+        if (started) {
+            fftPath.lineTo(lastX, h);
+        }
+        fftPath.closeSubpath();
+        QLinearGradient grad(0, 0, 0, h);
+        grad.setColorAt(0.0, QColor(88, 200, 232, 140));
+        grad.setColorAt(0.6, QColor(30, 110, 170, 70));
+        grad.setColorAt(1.0, QColor(12, 40, 70, 0));
+        p.setPen(Qt::NoPen);
+        p.setBrush(grad);
+        p.drawPath(fftPath);
+
+        const std::vector<float>& peakBins =
+            (m_peakHoldDbSmoothed.size() == m_peakHoldDb.size())
+                ? m_peakHoldDbSmoothed : m_peakHoldDb;
+        if (!peakBins.empty() && peakBins.size() == m_fftBinsDb.size()) {
+            QPainterPath peakPath;
+            bool peakStarted = false;
+            for (int i = 1; i < bins; ++i) {
+                const float f = static_cast<float>(i) * static_cast<float>(m_fftSampleRate)
+                    / static_cast<float>((bins - 1) * 2);
+                const float x = freqToX(f);
+                if (x < 0 || x > r.width()) {
+                    continue;
+                }
+                const float y = dbfsToY(peakBins[i]);
+                if (!peakStarted) {
+                    peakPath.moveTo(x, y);
+                    peakStarted = true;
+                } else {
+                    peakPath.lineTo(x, y);
+                }
+            }
+            QPen peakPen(QColor(220, 222, 230, 210), 1.4);
+            peakPen.setJoinStyle(Qt::RoundJoin);
+            peakPen.setCapStyle(Qt::RoundCap);
+            p.setPen(peakPen);
+            p.setBrush(Qt::NoBrush);
+            p.drawPath(peakPath);
+        }
+    }
+
+    const ResponseCacheKey responseKey = responseCacheKey();
+    if (cacheAllowed) {
+        if (!m_responseCacheValid || m_responseCacheKey != responseKey) {
+            m_responseCache = makeCachePixmap(r.size(), dpr);
+            QPainter cachePainter(&m_responseCache);
+            cachePainter.setRenderHint(QPainter::Antialiasing, true);
+            cachePainter.setRenderHint(QPainter::TextAntialiasing, true);
+            cachePainter.setFont(font());
+            drawResponse(cachePainter, r, responseKey);
+            m_responseCacheKey = responseKey;
+            m_responseCacheValid = !m_responseCache.isNull();
+            ++m_perfStats.responseCacheRebuilds;
+        } else {
+            ++m_perfStats.responseCacheHits;
+        }
+        if (m_responseCacheValid) {
+            p.drawPixmap(0, 0, m_responseCache);
+        } else {
+            drawResponse(p, r, responseKey);
+        }
+    } else {
+        if (!m_responseCache.isNull()) {
+            m_responseCache = QPixmap();
+        }
+        m_responseCacheValid = false;
+        drawResponse(p, r, responseKey);
+    }
+
+    const quint64 elapsedUs = static_cast<quint64>(paintTimer.nsecsElapsed() / 1000);
+    m_perfStats.paintUsTotal += elapsedUs;
+    m_perfStats.paintUsMax = std::max(m_perfStats.paintUsMax, elapsedUs);
+}
+
+void ClientEqCurveWidget::resetPerfStats()
+{
+    m_perfStats = {};
+    m_perfSince.restart();
+}
+
+QVariantMap ClientEqCurveWidget::eqstatsSnapshot(bool reset)
+{
+    const double secs = std::max(0.001, m_perfSince.elapsed() / 1000.0);
+    QVariantMap stats;
+    stats[QStringLiteral("name")] = objectName();
+    stats[QStringLiteral("className")] = QString::fromLatin1(metaObject()->className());
+    stats[QStringLiteral("windowTitle")] = window() ? window()->windowTitle() : QString();
+    stats[QStringLiteral("windowName")] = window() ? window()->objectName() : QString();
+    stats[QStringLiteral("windowClass")] = window()
+        ? QString::fromLatin1(window()->metaObject()->className()) : QString();
+    stats[QStringLiteral("visible")] = isVisible();
+    stats[QStringLiteral("x")] = x();
+    stats[QStringLiteral("y")] = y();
+    stats[QStringLiteral("widthPx")] = width();
+    stats[QStringLiteral("heightPx")] = height();
+    stats[QStringLiteral("dpr")] = devicePixelRatioF();
+    stats[QStringLiteral("sinceMs")] = static_cast<qlonglong>(m_perfSince.elapsed());
+    stats[QStringLiteral("fftUpdateCount")] = static_cast<qulonglong>(m_perfStats.fftUpdates);
+    stats[QStringLiteral("fftUpdatesPerSec")] = m_perfStats.fftUpdates / secs;
+    stats[QStringLiteral("paintCount")] = static_cast<qulonglong>(m_perfStats.paints);
+    stats[QStringLiteral("paintsPerSec")] = m_perfStats.paints / secs;
+    stats[QStringLiteral("avgPaintUs")] = m_perfStats.paints
+        ? static_cast<double>(m_perfStats.paintUsTotal) / m_perfStats.paints : 0.0;
+    stats[QStringLiteral("maxPaintUs")] = static_cast<qulonglong>(m_perfStats.paintUsMax);
+    stats[QStringLiteral("paintMsPerSec")] = (m_perfStats.paintUsTotal / 1000.0) / secs;
+    stats[QStringLiteral("backgroundCacheRebuildCount")] =
+        static_cast<qulonglong>(m_perfStats.backgroundCacheRebuilds);
+    stats[QStringLiteral("backgroundCacheRebuildsPerSec")] =
+        m_perfStats.backgroundCacheRebuilds / secs;
+    stats[QStringLiteral("responseCacheRebuildCount")] =
+        static_cast<qulonglong>(m_perfStats.responseCacheRebuilds);
+    stats[QStringLiteral("responseCacheRebuildsPerSec")] =
+        m_perfStats.responseCacheRebuilds / secs;
+    stats[QStringLiteral("backgroundCacheHits")] =
+        static_cast<qulonglong>(m_perfStats.backgroundCacheHits);
+    stats[QStringLiteral("responseCacheHits")] =
+        static_cast<qulonglong>(m_perfStats.responseCacheHits);
+    stats[QStringLiteral("cacheEligible")] = cacheEligible(size(), devicePixelRatioF());
+    stats[QStringLiteral("cacheLayerByteLimit")] =
+        static_cast<qulonglong>(kMaxCacheLayerBytes);
+    stats[QStringLiteral("cacheTotalByteLimit")] =
+        static_cast<qulonglong>(kMaxCacheLayerBytes * 2);
+    const auto cacheBytes = [](const QPixmap& cache) {
+        return static_cast<qulonglong>(cache.width())
+            * static_cast<qulonglong>(cache.height()) * 4ULL;
+    };
+    stats[QStringLiteral("backgroundCacheBytes")] = cacheBytes(m_backgroundCache);
+    stats[QStringLiteral("responseCacheBytes")] = cacheBytes(m_responseCache);
+    stats[QStringLiteral("cacheRetainedBytes")] =
+        stats.value(QStringLiteral("backgroundCacheBytes")).toULongLong()
+        + stats.value(QStringLiteral("responseCacheBytes")).toULongLong();
+    if (reset) {
+        resetPerfStats();
+    }
+    return stats;
 }
 
 } // namespace AetherSDR

--- a/src/gui/ClientEqCurveWidget.cpp
+++ b/src/gui/ClientEqCurveWidget.cpp
@@ -260,6 +260,9 @@ ClientEqCurveWidget::BackgroundCacheKey ClientEqCurveWidget::backgroundCacheKey(
 
 ClientEqCurveWidget::ResponseCacheKey ClientEqCurveWidget::responseCacheKey() const
 {
+    static_assert(std::tuple_size_v<decltype(ResponseCacheKey::bands)>
+                      == ClientEq::kMaxBands,
+                  "ResponseCacheKey::bands must cover every ClientEq band slot");
     ResponseCacheKey key;
     key.size = size();
     key.devicePixelRatio = devicePixelRatioF();
@@ -708,11 +711,13 @@ void ClientEqCurveWidget::paintEvent(QPaintEvent* /*ev*/)
     if (cacheAllowed) {
         if (!m_backgroundCacheValid || m_backgroundCacheKey != backgroundKey) {
             m_backgroundCache = makeCachePixmap(r.size(), dpr);
-            QPainter cachePainter(&m_backgroundCache);
-            cachePainter.setRenderHint(QPainter::Antialiasing, true);
-            cachePainter.setRenderHint(QPainter::TextAntialiasing, true);
-            cachePainter.setFont(font());
-            drawBackground(cachePainter, r);
+            if (!m_backgroundCache.isNull()) {
+                QPainter cachePainter(&m_backgroundCache);
+                cachePainter.setRenderHint(QPainter::Antialiasing, true);
+                cachePainter.setRenderHint(QPainter::TextAntialiasing, true);
+                cachePainter.setFont(font());
+                drawBackground(cachePainter, r);
+            }
             m_backgroundCacheKey = backgroundKey;
             m_backgroundCacheValid = !m_backgroundCache.isNull();
             ++m_perfStats.backgroundCacheRebuilds;
@@ -808,11 +813,13 @@ void ClientEqCurveWidget::paintEvent(QPaintEvent* /*ev*/)
     if (cacheAllowed) {
         if (!m_responseCacheValid || m_responseCacheKey != responseKey) {
             m_responseCache = makeCachePixmap(r.size(), dpr);
-            QPainter cachePainter(&m_responseCache);
-            cachePainter.setRenderHint(QPainter::Antialiasing, true);
-            cachePainter.setRenderHint(QPainter::TextAntialiasing, true);
-            cachePainter.setFont(font());
-            drawResponse(cachePainter, r, responseKey);
+            if (!m_responseCache.isNull()) {
+                QPainter cachePainter(&m_responseCache);
+                cachePainter.setRenderHint(QPainter::Antialiasing, true);
+                cachePainter.setRenderHint(QPainter::TextAntialiasing, true);
+                cachePainter.setFont(font());
+                drawResponse(cachePainter, r, responseKey);
+            }
             m_responseCacheKey = responseKey;
             m_responseCacheValid = !m_responseCache.isNull();
             ++m_perfStats.responseCacheRebuilds;

--- a/src/gui/ClientEqCurveWidget.h
+++ b/src/gui/ClientEqCurveWidget.h
@@ -186,6 +186,8 @@ private:
         int filterFamily{0};
         double sampleRate{0.0};
         int activeBandCount{0};
+        // Keep in sync with ClientEq::kMaxBands. responseCacheKey() pins
+        // the relationship with a static_assert where ClientEq is complete.
         std::array<BandCacheState, 16> bands{};
 
         bool operator==(const ResponseCacheKey&) const = default;

--- a/src/gui/ClientEqCurveWidget.h
+++ b/src/gui/ClientEqCurveWidget.h
@@ -1,9 +1,16 @@
 #pragma once
 
+#include <QElapsedTimer>
+#include <QFont>
+#include <QPixmap>
 #include <QString>
 #include <QStringList>
+#include <QVariantMap>
 #include <QWidget>
+#include <array>
 #include <vector>
+
+class QPainter;
 
 namespace AetherSDR {
 
@@ -101,6 +108,11 @@ public:
     // first entry is always "Off".
     static const QStringList& referenceCurveIds();
 
+    // Bridge-facing, production-light paint/cache counters. AutomationServer
+    // invokes this by class name so core code does not depend on GUI headers.
+    // `reset` returns the completed interval before beginning a fresh one.
+    Q_INVOKABLE QVariantMap eqstatsSnapshot(bool reset);
+
 signals:
     void selectedBandChanged(int idx);
     // Fired whenever band params mutate on the audio side from user
@@ -141,7 +153,73 @@ protected:
     QString            m_referencePreset;  // empty = off
 
 private:
+    struct BackgroundCacheKey {
+        QSize size;
+        qreal devicePixelRatio{1.0};
+        QFont font;
+        int filterLowCutHz{0};
+        int filterHighCutHz{0};
+
+        bool operator==(const BackgroundCacheKey&) const = default;
+    };
+
+    struct BandCacheState {
+        float freqHz{0.0f};
+        float gainDb{0.0f};
+        float q{0.0f};
+        int type{0};
+        bool enabled{false};
+        int slopeDbPerOct{0};
+
+        bool operator==(const BandCacheState&) const = default;
+    };
+
+    struct ResponseCacheKey {
+        QSize size;
+        qreal devicePixelRatio{1.0};
+        QFont font;
+        ClientEq* eq{nullptr};
+        int selectedBand{-1};
+        bool showFilled{true};
+        QString referencePreset;
+        bool eqEnabled{false};
+        int filterFamily{0};
+        double sampleRate{0.0};
+        int activeBandCount{0};
+        std::array<BandCacheState, 16> bands{};
+
+        bool operator==(const ResponseCacheKey&) const = default;
+    };
+
+    struct PerfStats {
+        quint64 fftUpdates{0};
+        quint64 paints{0};
+        quint64 paintUsTotal{0};
+        quint64 paintUsMax{0};
+        quint64 backgroundCacheRebuilds{0};
+        quint64 responseCacheRebuilds{0};
+        quint64 backgroundCacheHits{0};
+        quint64 responseCacheHits{0};
+    };
+
     void applySmoothing();
+    BackgroundCacheKey backgroundCacheKey() const;
+    ResponseCacheKey responseCacheKey() const;
+    bool cacheEligible(const QSize& size, qreal devicePixelRatio) const;
+    QPixmap makeCachePixmap(const QSize& size, qreal devicePixelRatio) const;
+    void drawBackground(QPainter& painter, const QRect& rect) const;
+    void drawResponse(QPainter& painter, const QRect& rect,
+                      const ResponseCacheKey& key) const;
+    void resetPerfStats();
+
+    QPixmap m_backgroundCache;
+    QPixmap m_responseCache;
+    BackgroundCacheKey m_backgroundCacheKey;
+    ResponseCacheKey m_responseCacheKey;
+    bool m_backgroundCacheValid{false};
+    bool m_responseCacheValid{false};
+    QElapsedTimer m_perfSince;
+    PerfStats m_perfStats;
 };
 
 } // namespace AetherSDR

--- a/src/gui/StripEqPanel.cpp
+++ b/src/gui/StripEqPanel.cpp
@@ -286,6 +286,7 @@ StripEqPanel::StripEqPanel(AudioEngine* engine, QWidget* parent)
     eqColumn->addWidget(m_iconRow);
 
     m_canvas = new ClientEqEditorCanvas;
+    m_canvas->setObjectName(QStringLiteral("stripEqCanvas"));
     m_canvas->setAudioEngine(m_audio);
     // Apply the saved smoothing fraction now that the canvas exists.
     // The combo box already shows the right value from the toolbar build,

--- a/src/gui/StripEqPanel.cpp
+++ b/src/gui/StripEqPanel.cpp
@@ -421,6 +421,12 @@ void StripEqPanel::showForPath(ClientEqApplet::Path path)
     m_path = path;
     if (!m_audio || !m_canvas) return;
 
+    // The single strip canvas changes between RX and TX paths. Give the
+    // active path a stable bridge selector so `get eqstats` can distinguish
+    // the 25 Hz live canvas from a detached editor canvas.
+    m_canvas->setObjectName(path == ClientEqApplet::Path::Rx
+        ? QStringLiteral("stripRxEqCanvas") : QStringLiteral("stripTxEqCanvas"));
+
     ClientEq* eq = (path == ClientEqApplet::Path::Rx)
         ? m_audio->clientEqRx() : m_audio->clientEqTx();
     m_canvas->setEq(eq);

--- a/tests/client_eq_smoothing_test.cpp
+++ b/tests/client_eq_smoothing_test.cpp
@@ -1,15 +1,21 @@
 // Unit tests for fractional-octave smoothing on ClientEqCurveWidget.
 //
-// The smoothing function is exposed as a free static method so this
-// harness doesn't need a QApplication / live widget.
+// The smoothing function is exposed as a free static method, and the
+// cache assertions render a real widget through Qt's offscreen platform.
 
+#include "core/ClientEq.h"
 #include "gui/ClientEqCurveWidget.h"
 
+#include <QApplication>
+#include <QImage>
+#include <QPainter>
 #include <cmath>
+#include <cstring>
 #include <cstdio>
 #include <vector>
 
 using AetherSDR::ClientEqCurveWidget;
+using AetherSDR::ClientEq;
 
 namespace {
 
@@ -29,6 +35,18 @@ bool nearlyEq(float a, float b, float tol = 0.01f)
 // 1025-bin (kFftSize/2 + 1 for kFftSize=2048) is the production size.
 constexpr int kBins = 1025;
 constexpr double kSampleRate = 24000.0;
+
+class DerivedEqCanvas final : public ClientEqCurveWidget {
+public:
+    using ClientEqCurveWidget::ClientEqCurveWidget;
+};
+
+void testDerivedCanvasIdentifiesAsBase()
+{
+    DerivedEqCanvas canvas;
+    report("derived EQ canvas inherits ClientEqCurveWidget",
+           canvas.inherits("AetherSDR::ClientEqCurveWidget"));
+}
 
 void testOffReturnsInputUnchanged()
 {
@@ -185,10 +203,163 @@ void testDbFloorPreserved()
     report("dB floor preserved on silent input", ok);
 }
 
+QImage renderWidget(ClientEqCurveWidget& widget)
+{
+    const QSize pixelSize(qRound(widget.width() * widget.devicePixelRatioF()),
+                          qRound(widget.height() * widget.devicePixelRatioF()));
+    QImage image(pixelSize,
+                 QImage::Format_ARGB32_Premultiplied);
+    image.setDevicePixelRatio(widget.devicePixelRatioF());
+    image.fill(Qt::transparent);
+    QPainter painter(&image);
+    widget.render(&painter);
+    return image;
+}
+
+bool imageIsNonblank(const QImage& image)
+{
+    for (int y = 0; y < image.height(); ++y) {
+        for (int x = 0; x < image.width(); ++x) {
+            if (image.pixelColor(x, y).alpha() != 0) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool imagesMatch(const QImage& first, const QImage& second)
+{
+    return first.size() == second.size()
+        && first.format() == second.format()
+        && first.sizeInBytes() == second.sizeInBytes()
+        && std::memcmp(first.constBits(), second.constBits(),
+                       static_cast<size_t>(first.sizeInBytes())) == 0;
+}
+
+qulonglong counter(const QVariantMap& stats, const char* key)
+{
+    return stats.value(QString::fromLatin1(key)).toULongLong();
+}
+
+void testPaintCaches()
+{
+    ClientEq eq;
+    eq.prepare(48000.0);
+    eq.setEnabled(true);
+    eq.setActiveBandCount(1);
+    ClientEq::BandParams band;
+    band.freqHz = 1200.0f;
+    band.gainDb = 4.0f;
+    band.q = 1.2f;
+    eq.setBand(0, band);
+
+    ClientEqCurveWidget widget;
+    widget.resize(480, 180);
+    widget.setEq(&eq);
+    widget.setReferenceCurvePreset(QStringLiteral("Heil DX"));
+    widget.setSelectedBand(0);
+    std::vector<float> fft(kBins, -65.0f);
+    fft[100] = -12.0f;
+    widget.setFftBinsDb(fft, kSampleRate);
+    const QImage firstImage = renderWidget(widget);
+    const QImage identicalImage = renderWidget(widget);
+    const QVariantMap first = widget.eqstatsSnapshot(false);
+    const qulonglong firstBackground = counter(first, "backgroundCacheRebuildCount");
+    const qulonglong firstResponse = counter(first, "responseCacheRebuildCount");
+    report("first paint builds background cache", firstBackground == 1);
+    report("first paint builds response cache", firstResponse == 1);
+    report("cached widget render remains nonblank", imageIsNonblank(firstImage));
+    report("identical cached composition is pixel-stable",
+           imagesMatch(firstImage, identicalImage));
+    const qreal dpr = first.value(QStringLiteral("dpr")).toReal();
+    const qulonglong expectedCacheBytes = static_cast<qulonglong>(qRound(widget.width() * dpr))
+        * static_cast<qulonglong>(qRound(widget.height() * dpr)) * 4ULL;
+    report("high-DPI cache preserves device pixels",
+           dpr >= 2.0 && counter(first, "backgroundCacheBytes") == expectedCacheBytes
+           && counter(first, "responseCacheBytes") == expectedCacheBytes);
+
+    for (int frame = 0; frame < 4; ++frame) {
+        fft[100 + frame] = -12.0f;
+        widget.setFftBinsDb(fft, kSampleRate);
+        (void)renderWidget(widget);
+    }
+    const QVariantMap fftOnly = widget.eqstatsSnapshot(false);
+    report("FFT-only paints reuse background cache",
+           counter(fftOnly, "backgroundCacheRebuildCount") == firstBackground);
+    report("FFT-only paints reuse response cache",
+           counter(fftOnly, "responseCacheRebuildCount") == firstResponse);
+    report("FFT-only cache hits are counted",
+           counter(fftOnly, "backgroundCacheHits") >= 4
+           && counter(fftOnly, "responseCacheHits") >= 4);
+
+    widget.setFilterCutoffs(200, 2800);
+    (void)renderWidget(widget);
+    const QVariantMap cutoffs = widget.eqstatsSnapshot(false);
+    report("filter cutoff rebuilds background only",
+           counter(cutoffs, "backgroundCacheRebuildCount") == firstBackground + 1
+           && counter(cutoffs, "responseCacheRebuildCount") == firstResponse);
+
+    widget.setReferenceCurvePreset(QStringLiteral("AT&T 1959"));
+    (void)renderWidget(widget);
+    const QVariantMap reference = widget.eqstatsSnapshot(false);
+    report("reference curve rebuilds response cache",
+           counter(reference, "responseCacheRebuildCount")
+           == counter(cutoffs, "responseCacheRebuildCount") + 1);
+
+    widget.setSelectedBand(-1);
+    (void)renderWidget(widget);
+    const QVariantMap selection = widget.eqstatsSnapshot(false);
+    report("band selection rebuilds response cache",
+           counter(selection, "responseCacheRebuildCount")
+           == counter(reference, "responseCacheRebuildCount") + 1);
+
+    widget.setShowFilledRegions(false);
+    (void)renderWidget(widget);
+    const QVariantMap filled = widget.eqstatsSnapshot(false);
+    report("filled-region toggle rebuilds response cache",
+           counter(filled, "responseCacheRebuildCount")
+           == counter(selection, "responseCacheRebuildCount") + 1);
+
+    band.gainDb = -3.0f;
+    eq.setBand(0, band);
+    widget.update();  // ClientEq has no QObject signal; callers may do this.
+    (void)renderWidget(widget);
+    const QVariantMap changedBand = widget.eqstatsSnapshot(false);
+    report("ClientEq band mutation rebuilds response cache",
+           counter(changedBand, "responseCacheRebuildCount")
+           == counter(filled, "responseCacheRebuildCount") + 1);
+
+    QFont changedFont = widget.font();
+    changedFont.setPointSize(13);
+    widget.setFont(changedFont);
+    (void)renderWidget(widget);
+    const QVariantMap changedFontStats = widget.eqstatsSnapshot(false);
+    report("font change rebuilds both text-bearing caches",
+           counter(changedFontStats, "backgroundCacheRebuildCount")
+           == counter(changedBand, "backgroundCacheRebuildCount") + 1
+           && counter(changedFontStats, "responseCacheRebuildCount")
+           == counter(changedBand, "responseCacheRebuildCount") + 1);
+
+    widget.resize(640, 220);
+    const QImage resizedImage = renderWidget(widget);
+    const QVariantMap resized = widget.eqstatsSnapshot(false);
+    report("resize rebuilds both caches",
+           counter(resized, "backgroundCacheRebuildCount")
+           == counter(changedFontStats, "backgroundCacheRebuildCount") + 1
+           && counter(resized, "responseCacheRebuildCount")
+           == counter(changedFontStats, "responseCacheRebuildCount") + 1);
+    report("resized widget render remains nonblank", imageIsNonblank(resizedImage));
+}
+
 }  // namespace
 
-int main()
+int main(int argc, char* argv[])
 {
+    qputenv("QT_QPA_PLATFORM", QByteArrayLiteral("offscreen"));
+    qputenv("QT_SCALE_FACTOR", QByteArrayLiteral("2"));
+    QApplication app(argc, argv);
+    testDerivedCanvasIdentifiesAsBase();
     testOffReturnsInputUnchanged();
     testFlatInputStaysFlat();
     testImpulseSpreads();
@@ -197,6 +368,7 @@ int main()
     testEmptyInputHandled();
     testIdempotentForOff();
     testDbFloorPreserved();
+    testPaintCaches();
 
     if (g_failed == 0) {
         std::printf("\nAll EQ smoothing tests passed.\n");


### PR DESCRIPTION
## Summary

Fixes #4721.

The AetherVoice EQ canvas rebuilt its full-width band response plus static grid, labels, and band-plan decoration on every analyzer frame. That work runs on the GUI thread, scales with the strip width, and remained after #4634 reduced the waveform timer rate.

This change splits the EQ rendering into DPR-aware cached background and response layers, leaving only the live FFT trace dynamic. Cache keys cover size, DPR, font, filter cutoffs, and all visible EQ state. Each layer is capped at 32 MiB and falls back to direct rendering when oversized. It also adds focused cache/render tests and read-only `eqstats` automation telemetry so this regression can be measured directly.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The unmodified and patched trees were built and measured on the same Windows 11 VM, against the same RX-only simulator and size sequence, with TX asserted false and TX power asserted zero throughout.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [ ] Behavior verified on a real radio if applicable
- [x] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

### Local and Windows evidence

- Full macOS ARM64 build completed with the required toolchain; executable verified as Mach-O arm64 and the Ninja graph contains no RNNoise x86 object rules.
- `ctest --test-dir build-codex-arm64 --output-on-failure -R '^client_eq_smoothing_test$'` — passed.
- `python3 tools/check_engine_boundary.py --strict` — 0 blocking findings (tracked legacy warnings only).
- `git diff --check` — passed.
- Windows RelWithDebInfo package built from commit base `3a1f59ea` plus this exact working-tree patch; deployed executable SHA-256 `73935FE941FBAD5DCDFD3EF549B3472B8EA0B01A05820F44AA1DA035EE99B3E3`.
- Before (unmodified current main, 30 s each): 73.1% of one core at 1280x900; 82.8% at 2200x1300. The large-window UI-lag maximum was 40.0 ms.
- After (patched, same VM/simulator and exact matching sizes, 30 s each): 37.4% of one core at 1280x900; 43.1% at 2200x1300. The large-window UI-lag maximum was 34.4 ms.
- Direct steady-state EQ telemetry at small/medium/large widths recorded 107/105/108 visible RX paints with the same 107/105/108 hits in both cached layers and zero static-layer rebuilds during each interval.
- Captures at 720x900, 1280x900, and 2200x1300 show the EQ grid, response, handles, band plan, and live trace intact.
- The physical FLEX-6700 was already at its client limit. No existing client was evicted; Windows validation used the built-in `DEMO-0001` RX-only simulator. Real-radio confirmation remains intentionally unchecked.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention; no meter UI changed)
- [x] Documentation updated if user-visible behavior changed — automation telemetry documentation updated; `CHANGELOG.md` untouched
- [x] Security-sensitive changes reference a GHSA if applicable (not applicable)

## Agent automation bridge — gaps found

- The legacy Windows discovery file can remain stale after a managed relaunch; the probe had to resolve the launch-status PID and use its per-PID discovery entry.
- Existing render telemetry did not isolate EQ paint cost or cache behavior. This PR adds `get eqstats` and includes EQ totals in `get renderstats`.
- Accessible names may include live state (for example `DSP settings (DSP active)`), so exact static-name invocation can miss an otherwise visible control.
