### PR TITLE
fix(gui): release momentary keying when the radio disconnects

### DIFF
--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -562,6 +562,17 @@ void MainWindow::wireRadioModel()
             this, [this](bool connected) {
         dissolveAllSliceLinks(connected ? "radio connected" : "radio disconnected");
     });
+    // A momentary-keying release that arrives while disconnected is discarded
+    // by the per-path isConnected() gates before their flag bookkeeping runs,
+    // so a key held across a disconnect strands its flag and eats the first
+    // press after reconnect (#4638). Release the whole family here instead of
+    // weakening those gates: the fail-safe no-ops when nothing is keyed, and
+    // its un-key requests are harmless on a radio that is already gone.
+    connect(&m_radioModel, &RadioModel::connectionStateChanged,
+            this, [this](bool connected) {
+        if (!connected)
+            failSafeMomentaryKeyingToRx("radio-disconnect");
+    });
     // Local microphone capture for a backend that MODULATES ON THE HOST.
     //
     // Capture is otherwise started only from the Flex DAX signals


### PR DESCRIPTION
Fixes #4638

### The bug

A momentary-keying release that arrives while the radio is disconnected is
discarded before any flag bookkeeping runs, so a key held across a disconnect
strands its flag, and the first press after reconnect is silently consumed.
Exactly as the issue describes: one dead press per disconnect-while-held —
the kind of glitch that gets reported as "PTT stopped working after reconnect."

Confirmed at `3a1f59ea` by source walk:

- Keyboard PTT: `MainWindow_Shortcuts.cpp:242` gates on
  `!m_radioModel.isConnected()` **above** the `m_pttHoldActive` bookkeeping at
  `:252-261`, so the KeyRelease is dropped and the flag stays true. After
  reconnect the next KeyPress hits `!m_pttHoldActive == false` and does
  nothing (still consumed at `:262`).
- The triage bot's scope correction (2026-07-31, tree `137c3779`) — "PTT-hold
  only; the CW flags self-heal" — was correct **then**, but #4611 has since
  merged (2026-08-01): the Ulanzi dial paths gate on `isConnected()` before
  bookkeeping for **both** PTT (`MainWindow_Controllers.cpp:2791`) and CW keys
  (`:2812`), and `setCw*State()` early-returns when the flag already matches
  (`MainWindow.cpp:3773`), so a radio disconnect can now strand the CW flags
  too, via the dial. The central release covers the whole family either way.
- `failSafeMomentaryKeyingToRx()` (`MainWindow_Shortcuts.cpp:281`) already
  releases exactly this family through the real un-key paths and no-ops when
  idle. It has three callers — window-deactivate, app-deactivate, and dial
  ("ulanzi") disconnect — but nothing on **radio** disconnect; no
  `connectionStateChanged` handler touches the flags
  (`onConnectionStateChanged` at `MainWindow.cpp:5482`, and the three wires in
  `wireRadioModel()` at `MainWindow_Session.cpp:541/:557/:575`).

### The fix

One `connect()` in `MainWindow::wireRadioModel()`, alongside the existing
disconnect-teardown lambdas, calling
`failSafeMomentaryKeyingToRx("radio-disconnect")` on `connected == false` —
the missing fourth caller the issue proposed. The per-path `isConnected()`
gates stay exactly as they are (they exist so keystrokes can't key a radio
that isn't there); the fail-safe's un-key requests on a just-disconnected
radio terminate harmlessly.

### Tests

No unit test accompanies this change, stated plainly: no fixture in the tree
instantiates `MainWindow` (the flags and the wiring under test are private to
it), and the momentary CW/PTT actions register with no default key sequence,
so a first-ever MainWindow keyboard fixture would be a substantially larger
change than the fix. Verification is a live before/after bench run instead
(below).

### Verification status — COMPLETE (2026-08-11)

The runtime before/after ran 2026-08-11 on the live radio (agent-driven bench; method and full readings in [the results comment](https://github.com/aethersdr/AetherSDR/pull/4811#issuecomment-5262390188)). The branch was rebased onto `a136f8f2` the same evening — patch unchanged (`git range-diff` identical) — and the fixed-build proof re-run at the new head `34828ad6` with the same results.

- [x] Static confirmation at `3a1f59ea`: gate order, flag lifecycle, all
      three existing fail-safe callers, absence of any disconnect-side caller
      (fix byte-identical after the rebase)
- [x] Clean build of the fix branch (Linux, RelWithDebInfo) — `052c15d9`,
      then rebased `34828ad6`, binary SHA verified both times
- [x] Bench pass, un-fixed current-main tree (`c4471f03`, 2 runs): release
      while disconnected is ignored — `Fail-safe to RX on app-deactivate …
      ptt=true` catches the surviving flag afterward (bug mechanism
      demonstrated in the log)
- [x] Bench pass, fixed build: `Fail-safe to RX on radio-disconnect …
      ptt=true` fires at the disconnect itself, before the release lands
      (proven at `052c15d9`, re-proven at `34828ad6`)
- [x] OTA pass (FLEX-8400, dummy load): fixed — first PTT press after
      reconnect keys and releases cleanly. The stock dead press could **not**
      be staged: current main's disconnect flow blips the app-active state,
      so the old deactivate fail-safe rescues the stuck flag
      nondeterministically first (stated plainly in the results comment)
- [x] Full ctest vs this box's stock baseline — run 2026-08-11 at `34828ad6`:
      **282/285 passed**; the 3 failures (`s_meter_geometry_test`,
      `range_slider_a11y_test` SEGFAULT, `relay_bar_a11y_test`) are this
      box's known environment set, verified same-day identical on a stock
      build (none touch this fix's area); 2 skipped by design
      (quarantined + TX loopback)

— authored by agent (Claude Code) on behalf of @skerker


