### PR TITLE
fix(modem): AetherModem TX never keys on a backend that takes audio over the seam

### DIFF
--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -2136,7 +2136,7 @@ void Ax25HfPacketDecodeDialog::beginTransmission(const Ax25TransmitResult& tx, b
     // PTT never keyed, 181 audio chunks never sent, and the 11 frames queued
     // behind it were dropped when the window closed. Same lesson the WSPR
     // beacon learned in RadioModel::prepareWsprTransmit().
-    if (!hostModulatesTx() && m_audio->txStreamId() == 0) {
+    if (!txAudioBypassesDax() && m_audio->txStreamId() == 0) {
         m_txPendingStream = true;
         refreshTransmitControls();
         appendSystemLine(QStringLiteral("Requesting DAX TX stream for AetherModem TX."));
@@ -2155,9 +2155,32 @@ void Ax25HfPacketDecodeDialog::beginTransmission(const Ax25TransmitResult& tx, b
     beginTransmitWhenReady();
 }
 
-bool Ax25HfPacketDecodeDialog::hostModulatesTx() const
+bool Ax25HfPacketDecodeDialog::txAudioBypassesDax() const
 {
-    return m_radio && m_radio->backendCapabilities().hostModulates;
+    if (!m_radio)
+        return false;
+    const RadioCapabilities caps = m_radio->backendCapabilities();
+
+    // THE QUESTION IS "DOES TX AUDIO NEED A DAX STREAM", NOT "WHO RUNS THE
+    // MODULATOR" — and those came apart when takesTxAudioOverSeam was added.
+    //
+    // hostModulates is FALSE on an Icom, correctly: the RADIO modulates. So
+    // this returned false, the caller asked for a DAX TX stream, and an Icom
+    // has none. ensureDaxTxStream() answers TRUE for a seam backend — "there
+    // IS a route, it just isn't DAX" — so the caller's failure path never fires
+    // either. m_txPendingStream is left set, waiting on a stream that cannot
+    // arrive, until the timeout: PTT never keys and every queued frame dies
+    // with it.
+    //
+    // That is the same outage the call site records for the HL2 on 2026-07-31
+    // ("PTT never keyed, 181 audio chunks never sent"), reached from the
+    // opposite direction — the HL2 was excluded because it host-modulates, and
+    // a seam backend needs excluding because its transmit audio does not go
+    // through DAX at all.
+    //
+    // Both take the direct path, so this is ORed here rather than at each call
+    // site: both callers are asking this same question.
+    return caps.hostModulates || caps.takesTxAudioOverSeam;
 }
 
 void Ax25HfPacketDecodeDialog::armTxStreamWaitTimeout()
@@ -2233,8 +2256,8 @@ void Ax25HfPacketDecodeDialog::beginTransmitWhenReady()
         finishTransmit(true, QStringLiteral("audio engine or radio model disappeared before TX"));
         return;
     }
-    const bool hostModulated = hostModulatesTx();
-    if (!hostModulated && m_audio->txStreamId() == 0) {
+    const bool bypassesDax = txAudioBypassesDax();
+    if (!bypassesDax && m_audio->txStreamId() == 0) {
         m_txPendingStream = true;
         refreshTransmitControls();
         return;
@@ -2259,20 +2282,20 @@ void Ax25HfPacketDecodeDialog::beginTransmitWhenReady()
     // command plane anyway, and latching the restore flag for a setting we
     // never changed would hand back a stale value on unkey.
     m_audio->setDaxTxMode(true);
-    if (!hostModulated) {
+    if (!bypassesDax) {
         m_txPreviousTransmitDax = txModel.daxOn();
         m_txRestoreTransmitDax = true;
         txModel.setDax(true);
     }
 
-    const QString route = hostModulated
+    const QString route = bypassesDax
         ? QStringLiteral("host-modulated (no DAX stream)")
         : QStringLiteral("DAX TX stream 0x%1").arg(m_audio->txStreamId(), 0, 16);
     appendSystemLine(QStringLiteral("Keying transmitter for AX.25 TX on %1; %2.")
         .arg(transmitSliceSummary(), route));
     qCInfo(lcAx25).noquote()
         << QStringLiteral("AX.25 TX start route=%1 %2 chunks=%3 daxSettleMs=%4 leadMs=%5 tailMs=%6")
-            .arg(hostModulated ? QStringLiteral("hostModulated")
+            .arg(bypassesDax ? QStringLiteral("seam/host")
                                : QStringLiteral("dax:0x%1").arg(m_audio->txStreamId(), 0, 16))
             .arg(transmitSliceSummary())
             .arg(m_txChunkCount)

--- a/src/gui/Ax25HfPacketDecodeDialog.h
+++ b/src/gui/Ax25HfPacketDecodeDialog.h
@@ -154,7 +154,10 @@ private:
     // True when the backend runs the modulator on this host (HL2) rather than
     // taking modulator input from a Flex DAX stream. Such a radio has no DAX
     // TX stream to wait for and no `transmit dax` setting to change.
-    bool hostModulatesTx() const;
+    // True when transmit audio reaches the radio WITHOUT a DAX stream —
+    // either the host modulates (HL2) or the audio leaves over the seam
+    // (Icom). Both skip the DAX-stream wait; see the definition.
+    bool txAudioBypassesDax() const;
     // Fail a TX that is waiting on a DAX stream which never arrives. The
     // `stream create` reply is asynchronous and its failure path only logs, so
     // without this a backend that drops the command leaves the TX — and every


### PR DESCRIPTION
**Live on `main`.** The built-in AX.25 modem cannot transmit at all on a backend that declares `takesTxAudioOverSeam` — Icom today. PTT never keys, no audio is sent, and nothing logs an error.

Found operating packet on an IC-9700 this evening.

## What happens

The modem gates its transmit path on `hostModulates`, which asks **who runs the modulator**. The question it needs to ask is **whether transmit audio needs a DAX stream** — and those came apart when `takesTxAudioOverSeam` was added.

On an Icom `hostModulates` is `false`, and correctly so: the *radio* modulates. So:

1. The modem takes the DAX branch and asks for a stream a networked Icom has never had
2. `RadioModel::ensureDaxTxStream()` returns **true** for a seam backend — *"there IS a route for transmit audio, it just isn't DAX"*
3. So the modem's failure path never fires either. `m_txPendingStream` stays set, waiting on a stream that cannot arrive, until the wait times out

Every layer behaves correctly by its own lights, which is why it is silent. From the operator's side the modem simply does nothing.

## Why it looks familiar

The call site already documents this outage for the HL2 (2026-07-31: *"PTT never keyed, 181 audio chunks never sent"*). This is the same failure reached from the opposite direction — the HL2 was excluded because it **host-modulates**, and a seam backend needs excluding because its audio **does not go through DAX at all**.

## The change

`hostModulatesTx()` → `txAudioBypassesDax()`, returning `hostModulates || takesTxAudioOverSeam`.

Renamed because the name no longer described what it answers, and both of its callers are asking the DAX question rather than the modulator one. It is private to this dialog — nothing else reads it.

## Verified on hardware — IC-9700 over LAN, 2026-08-06

| | Before | After |
|---|---|---|
| DAX stream requests | 1 per frame, never satisfied | **0** |
| PTT | never keyed | **keys** |
| AX.25 T1 retry ladder | never started | **runs 8/8** — frames going out and being timed |
| TX meters (FWDPWR / SWR / ALC) | stale | **LIVE at 0.9 s** |

Confirmed **modulating**, not a bare carrier — a beacon and a connect attempt to a live station both went out with audio.

The T1 timeouts are expected here: the station did not answer. What matters is that the ladder runs at all, which it could not do before.

## Scope

Affects any backend declaring `takesTxAudioOverSeam`, so Icom today and the same shape for anything added later. No change for Flex or the sim, which declare it false, or for the HL2, which was already excluded by `hostModulates`.

Related: #4799 introduces `takesTxAudioOverSeam` and wires it into `ensureDaxTxStream`; this caller was left on the old flag. The capability and the Icom's declaration are already on `main`, so this stands alone and does not depend on that PR.