### PR TITLE
docs(hid): note that reportSize() bounds a write into a 64-byte buffer

### DIFF
--- a/src/core/HidDeviceParser.h
+++ b/src/core/HidDeviceParser.h
@@ -26,6 +26,20 @@ class HidDeviceParser {
 public:
     virtual ~HidDeviceParser() = default;
     virtual HidEvent parse(const uint8_t* buf, size_t len) = 0;
+    // ⚠ KEEP THIS <= 64. It is not just a description of the device: it is
+    // passed straight to hid_read() as the length bound on a write into
+    // HidEncoderManager::m_buf, which is a fixed uint8_t[64]. A parser that
+    // returns more than 64 overflows that buffer on the first report it
+    // receives, and nothing between here and there will catch it.
+    //
+    // Every parser below satisfies this, but TMate2 returns exactly 64, so
+    // there is no headroom left. If a new device genuinely needs a larger
+    // report, grow m_buf (or clamp at the hid_read call) in the same change —
+    // do not just return the bigger number.
+    //
+    // Returning LESS than the device's real report size is fine and is already
+    // done deliberately: StreamDeck+ advertises 512 in its HID descriptor and
+    // returns 14 here, because only the first 14 bytes carry data we decode.
     virtual size_t reportSize() const = 0;
     virtual int encoderCount() const { return 1; }
 

--- a/src/core/HidDeviceParser.h
+++ b/src/core/HidDeviceParser.h
@@ -29,8 +29,8 @@ public:
     // ⚠ KEEP THIS <= 64. It is not just a description of the device: it is
     // passed straight to hid_read() as the length bound on a write into
     // HidEncoderManager::m_buf, which is a fixed uint8_t[64]. A parser that
-    // returns more than 64 overflows that buffer on the first report it
-    // receives, and nothing between here and there will catch it.
+    // returns more than 64 overflows that buffer as soon as the device sends a
+    // report that long, and nothing between here and there will catch it.
     //
     // Every parser below satisfies this, but TMate2 returns exactly 64, so
     // there is no headroom left. If a new device genuinely needs a larger

--- a/src/core/HidEncoderManager.cpp
+++ b/src/core/HidEncoderManager.cpp
@@ -586,7 +586,10 @@ void HidEncoderManager::poll()
 {
     if (!m_device || !m_parser) return;
 
-    // Read all pending reports
+    // Read all pending reports. reportSize() is the write bound into m_buf and
+    // is deliberately not clamped here — the "<= 64" invariant is stated and
+    // argued at HidDeviceParser::reportSize(); do not add a silent std::min
+    // without reading it.
     while (true) {
         int res = hid_read(m_device, m_buf, m_parser->reportSize());
         if (res < 0) {

--- a/src/core/HidEncoderManager.h
+++ b/src/core/HidEncoderManager.h
@@ -184,6 +184,11 @@ private:
 
     QTimer* m_pollTimer{nullptr};
     QTimer* m_hotplugTimer{nullptr};
+
+    // Input report scratch. This 64 is the other end of the invariant written
+    // up at HidDeviceParser::reportSize(): poll() hands that value to
+    // hid_read() as the write bound into here, unclamped. Changing this size
+    // means auditing every parser's reportSize() in the same change.
     uint8_t m_buf[64]{};
 
     static constexpr int POLL_INTERVAL_MS = 5;


### PR DESCRIPTION
Comment only — 14 lines, no code change.

`HidEncoderManager::poll()` passes `m_parser->reportSize()` straight to `hid_read()` as the length bound on a write into `m_buf`, a fixed `uint8_t[64]`:

```cpp
uint8_t m_buf[64]{};                                          // HidEncoderManager.h:187
int res = hid_read(m_device, m_buf, m_parser->reportSize());  // .cpp:591
```

So overriding this virtual is quietly a memory-safety decision, and its declaration said nothing about that. This adds the note at the declaration, where someone adding a parser will actually read it.

**Nothing to fix today.** All six parsers return ≤ 64 (32, 6, 5, 5, 14, 64), so no overflow exists on the tree. The one thing worth flagging is that `TMate2Parser` returns *exactly* 64 — the headroom is zero, not comfortable.

The note also records the opposite direction, because it looks like a bug and isn't: `StreamDeckPlusParser` returns 14 while its device's HID descriptor advertises 512, deliberately, since only the first 14 bytes carry data we decode. Returning *less* than the real report size is fine and intended.

## Why a comment rather than a clamp

I originally opened #4819 to add `std::min(reportSize(), sizeof(m_buf))` with a regression test. I've closed it. The clamp guarded against a *future* parser returning a larger value — speculative hardening for a hazard nobody has hit, and untestable on any hardware I own. The StreamDeck+ case I cited as supporting evidence actually cuts the other way: that parser already handles a 512-byte descriptor correctly.

What's genuinely missing is the *documentation*, not the runtime check. If a device ever does need a bigger report, the note says to grow `m_buf` or clamp at the call site in the same change — which is the moment to make that decision, with a real device in hand.

Happy to revisit the clamp if a reviewer would rather have the belt as well as the braces.

## Provenance

Came out of the Antares scanner comment on #4786. Its stated mechanism was wrong — `hid_read`'s return **is** checked (`<0` disconnect, `==0` break) and the parse is bounded by `res`, so the short-read overflow it described doesn't exist. The unclamped *length* argument is a different thing one step across from what it flagged.
