### PR TITLE
fix(cw): iambic sidetone timing — absolute-grid element scheduling and sample-accurate edge rendering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4687,6 +4687,7 @@ add_executable(cw_sidetone_test
 )
 target_include_directories(cw_sidetone_test PRIVATE src)
 target_link_libraries(cw_sidetone_test PRIVATE Qt6::Core)
+add_test(NAME cw_sidetone_test COMMAND cw_sidetone_test)
 
 add_executable(cwx_local_keyer_drift_test
     tests/cwx_local_keyer_drift_test.cpp

--- a/src/core/CwSidetoneGenerator.cpp
+++ b/src/core/CwSidetoneGenerator.cpp
@@ -70,6 +70,18 @@ void CwSidetoneGenerator::setPan(float p) noexcept
 
 void CwSidetoneGenerator::setKeyDown(bool down) noexcept
 {
+    // Timestamp on entry — this is the keyer thread's edge time, taken
+    // before any queue mechanics, so it carries the keyer's precision.
+    const auto now = std::chrono::steady_clock::now();
+    const uint32_t head = m_edgeHead.load(std::memory_order_relaxed);
+    const uint32_t tail = m_edgeTail.load(std::memory_order_acquire);
+    if (head - tail < kEdgeQueueSize) {
+        m_edgeQueue[head % kEdgeQueueSize] = {now, down};
+        m_edgeHead.store(head + 1, std::memory_order_release);
+    }
+    // Always mirror the latest state: on queue overflow (pathological)
+    // process() falls back to applying this at the next block start —
+    // the pre-#4809 behavior — so the final key-up can never be lost.
     m_keyDown.store(down, std::memory_order_relaxed);
 }
 
@@ -78,6 +90,12 @@ void CwSidetoneGenerator::reset() noexcept
     m_state = State::Idle;
     m_rampSample = 0;
     m_phase = 0.0;
+    m_gateDown = false;
+    m_haveAnchor = false;
+    m_streamPos = 0;
+    // Drop queued edges (consumer-side drain: only the tail moves).
+    m_edgeTail.store(m_edgeHead.load(std::memory_order_acquire),
+                     std::memory_order_release);
 }
 
 void CwSidetoneGenerator::setSampleRateHz(int hz) noexcept
@@ -88,15 +106,58 @@ void CwSidetoneGenerator::setSampleRateHz(int hz) noexcept
     reset();
 }
 
+// The state-machine edge transitions, factored out of process() so they
+// can fire at an exact sample offset mid-block rather than only at the
+// block start (#4809).  The re-entrant ramp mirroring is unchanged.
+void CwSidetoneGenerator::applyKeyEdge(bool down) noexcept
+{
+    m_gateDown = down;
+    switch (m_state) {
+    case State::Idle:
+        if (down) {
+            m_state = State::RampUp;
+            m_rampSample = 0;
+        }
+        break;
+    case State::RampUp:
+        if (!down) {
+            m_state = State::RampDown;
+            // Continue from the current envelope position so a quick
+            // dot doesn't audibly click — start ramp-down from where
+            // ramp-up left off, scaled to the same envelope value.
+            m_rampSample = m_rampLength - m_rampSample;
+        }
+        break;
+    case State::Sustain:
+        if (!down) {
+            m_state = State::RampDown;
+            m_rampSample = 0;
+        }
+        break;
+    case State::RampDown:
+        if (down) {
+            // Mirror image of RampUp→RampDown: re-enter from current
+            // envelope position.
+            m_state = State::RampUp;
+            m_rampSample = m_rampLength - m_rampSample;
+        }
+        break;
+    }
+}
+
 bool CwSidetoneGenerator::process(float* out, int frames) noexcept
 {
     const bool tapSet = static_cast<bool>(m_sampleTap);
 
     if (!m_enabled.load(std::memory_order_relaxed)) {
         // Disabled — bring state back to idle on next block so a flip-on
-        // mid-keying starts cleanly from silence.
-        if (m_state != State::Idle)
+        // mid-keying starts cleanly from silence.  reset() also drops
+        // queued edges, so stale timestamps can't fire on re-enable.
+        if (m_state != State::Idle || m_haveAnchor)
             reset();
+        else
+            m_edgeTail.store(m_edgeHead.load(std::memory_order_acquire),
+                             std::memory_order_release);
         if (tapSet) {
             // Mirror silence to the TX-decode tap so the downstream
             // decoder's timeline doesn't jump forward across the gap.
@@ -107,7 +168,6 @@ bool CwSidetoneGenerator::process(float* out, int frames) noexcept
         return false;
     }
 
-    const bool keyDown = m_keyDown.load(std::memory_order_relaxed);
     const float pitch  = m_pitchHz.load(std::memory_order_relaxed);
     const float vol    = m_volume.load(std::memory_order_relaxed);
     const float shapingMs = m_shapingMs.load(std::memory_order_relaxed);
@@ -123,40 +183,49 @@ bool CwSidetoneGenerator::process(float* out, int frames) noexcept
         m_rampLength = newRampLen;
     }
 
-    // Edge transitions: drive the state machine off the current key state.
-    switch (m_state) {
-    case State::Idle:
-        if (keyDown) {
-            m_state = State::RampUp;
-            m_rampSample = 0;
+    // ── Collect this block's key edges at exact sample offsets ────────
+    // Map each queued edge's timestamp into the sample stream via the
+    // burst anchor.  Edges that fall beyond this block stay queued.
+    const int64_t blockStart = m_streamPos;
+    const int64_t blockEnd   = blockStart + frames;
+    QVarLengthArray<std::pair<int, bool>, 8> blockEdges;
+    for (;;) {
+        const uint32_t tail = m_edgeTail.load(std::memory_order_relaxed);
+        if (tail == m_edgeHead.load(std::memory_order_acquire))
+            break;
+        const KeyEdge e = m_edgeQueue[tail % kEdgeQueueSize];
+        if (!m_haveAnchor) {
+            // First edge of a burst plays at this block's start — the
+            // same onset latency as the old block-polling gate; every
+            // later edge lands relative to it, sample-exact.
+            m_anchorTime = e.t;
+            m_anchorPos  = blockStart;
+            m_haveAnchor = true;
         }
-        break;
-    case State::RampUp:
-        if (!keyDown) {
-            m_state = State::RampDown;
-            // Continue from the current envelope position so a quick
-            // dot doesn't audibly click — start ramp-down from where
-            // ramp-up left off, scaled to the same envelope value.
-            m_rampSample = m_rampLength - m_rampSample;
-        }
-        break;
-    case State::Sustain:
-        if (!keyDown) {
-            m_state = State::RampDown;
-            m_rampSample = 0;
-        }
-        break;
-    case State::RampDown:
-        if (keyDown) {
-            // Mirror image of RampUp→RampDown: re-enter from current
-            // envelope position.
-            m_state = State::RampUp;
-            m_rampSample = m_rampLength - m_rampSample;
-        }
-        break;
+        const int64_t target = m_anchorPos +
+            std::chrono::duration_cast<std::chrono::nanoseconds>(
+                e.t - m_anchorTime).count() * m_sampleRateHz / 1'000'000'000LL;
+        if (target >= blockEnd)
+            break;  // future block — edges are time-ordered, stop here
+        const int off = static_cast<int>(
+            std::max<int64_t>(target, blockStart) - blockStart);
+        blockEdges.append({off, e.down});
+        m_edgeTail.store(tail + 1, std::memory_order_release);
+    }
+    // Overflow / missed-edge fallback: nothing queued but the last-known
+    // state disagrees with the gate — apply it at the block start (the
+    // pre-#4809 behavior), so the final key-up can never be lost.
+    if (blockEdges.isEmpty()
+        && m_edgeTail.load(std::memory_order_relaxed)
+               == m_edgeHead.load(std::memory_order_acquire)
+        && m_keyDown.load(std::memory_order_relaxed) != m_gateDown) {
+        blockEdges.append({0, m_keyDown.load(std::memory_order_relaxed)});
     }
 
-    if (m_state == State::Idle && !keyDown) {
+    if (m_state == State::Idle && blockEdges.isEmpty()) {
+        m_streamPos = blockEnd;
+        if (!m_gateDown)
+            m_haveAnchor = false;  // burst over — re-anchor next time
         if (tapSet) {
             QVarLengthArray<float, 1024> silence(frames);
             std::memset(silence.data(), 0, frames * sizeof(float));
@@ -177,7 +246,13 @@ bool CwSidetoneGenerator::process(float* out, int frames) noexcept
     QVarLengthArray<float, 1024> tapBuf;
     if (tapSet) tapBuf.resize(frames);
 
+    int edgeIdx = 0;
     for (int i = 0; i < frames; ++i) {
+        // Fire any edges scheduled for this exact sample.
+        while (edgeIdx < blockEdges.size() && blockEdges[edgeIdx].first == i) {
+            applyKeyEdge(blockEdges[edgeIdx].second);
+            ++edgeIdx;
+        }
         float env = 0.0f;
         switch (m_state) {
         case State::Idle:
@@ -215,6 +290,13 @@ bool CwSidetoneGenerator::process(float* out, int frames) noexcept
     }
 
     if (tapSet) m_sampleTap(tapBuf.data(), frames, m_sampleRateHz);
+
+    m_streamPos = blockEnd;
+    if (m_state == State::Idle && !m_gateDown
+        && m_edgeTail.load(std::memory_order_relaxed)
+               == m_edgeHead.load(std::memory_order_acquire)) {
+        m_haveAnchor = false;  // burst over — re-anchor on the next edge
+    }
 
     m_lastPitchHz = pitch;
     return wroteAny;

--- a/src/core/CwSidetoneGenerator.cpp
+++ b/src/core/CwSidetoneGenerator.cpp
@@ -90,16 +90,20 @@ void CwSidetoneGenerator::setKeyDown(bool down) noexcept
     const auto now = std::chrono::steady_clock::now();
     const uint32_t head = m_edgeHead.load(std::memory_order_relaxed);
     const uint32_t tail = m_edgeTail.load(std::memory_order_acquire);
+    // Mirror the latest state BEFORE publishing the head.  The lock excludes
+    // other producers but not the audio thread, so a producer descheduled
+    // mid-section is observable either way — this order makes it harmless.
+    // Mirror ahead of the queue: process() applies it at the next block start
+    // (the pre-#4809 behavior, and what rescues the final key-up on queue
+    // overflow) and the queued edge is then a no-op through applyKeyEdge().
+    // The reverse order lets the consumer advance m_gateDown past a stale
+    // mirror, and the same fallback then injects an inverted edge — a dropout
+    // mid-element, plus a second phantom edge undoing it.
+    m_keyDown.store(down, std::memory_order_relaxed);
     if (head - tail < kEdgeQueueSize) {
         m_edgeQueue[head % kEdgeQueueSize] = {now, down};
         m_edgeHead.store(head + 1, std::memory_order_release);
     }
-    // Mirror the latest state inside the same critical section so it can
-    // never disagree with the last queued edge: on queue overflow
-    // (pathological) process() falls back to applying this at the next
-    // block start — the pre-#4809 behavior — so the final key-up can
-    // never be lost.
-    m_keyDown.store(down, std::memory_order_relaxed);
     m_edgeLock.clear(std::memory_order_release);
 }
 
@@ -210,6 +214,59 @@ bool CwSidetoneGenerator::process(float* out, int frames) noexcept
     // Prealloc covers a full ring drain after a scheduler stall, so the
     // audio callback never heap-allocates here.
     QVarLengthArray<std::pair<int, bool>, kEdgeQueueSize> blockEdges;
+
+    // ── Keep the mapping honest about real time ───────────────────────
+    // Everything below assumes process() is pumped in real time, so that
+    // m_streamPos and the anchor's wall clock advance together.  Not every
+    // consumer is: the recorder's sidetone generator renders only while the
+    // radio is transmitting a CW over (AudioEngine::onCwRecordPump), while
+    // setKeyDown() keeps queueing from every paddle edge regardless.  Left
+    // alone, that generator anchors on keying from seconds or minutes ago
+    // and replays it into the next over, and — when the pump stops with the
+    // gate still down — never reaches the Idle branch below that would have
+    // released the anchor, so it renders one unbroken tone instead.
+    //
+    // Two guards, both bounded by the same idle threshold that governs a
+    // normal re-anchor.  One clock read per block, and only while there is
+    // an anchor or something queued.
+    const bool haveQueued = m_edgeTail.load(std::memory_order_relaxed)
+                            != m_edgeHead.load(std::memory_order_acquire);
+    if (m_haveAnchor || haveQueued) {
+        const auto nowTp = std::chrono::steady_clock::now();
+        const int64_t idleLimit =
+            static_cast<int64_t>(m_sampleRateHz) * kReanchorIdleMs / 1000;
+        auto toSamples = [this](std::chrono::steady_clock::duration d) {
+            return std::chrono::duration_cast<std::chrono::nanoseconds>(d).count()
+                   * m_sampleRateHz / 1'000'000'000LL;
+        };
+        // (1) The mapping itself has gone stale — wall clock has run ahead of
+        // the samples we have rendered by more than a re-anchor's worth,
+        // which only happens when process() stopped being called.  Tested
+        // one-sided on purpose: a stream position ahead of wall clock is
+        // ordinary prefill (the QAudioSink path fills a 50 ms buffer up
+        // front) and must not re-anchor.
+        if (m_haveAnchor) {
+            const int64_t expected = m_anchorPos + toSamples(nowTp - m_anchorTime);
+            if (expected - blockStart > idleLimit)
+                m_haveAnchor = false;
+        }
+        // (2) About to anchor afresh: drop edges old enough to belong to a
+        // previous keying sequence rather than replaying them here.  The
+        // retained m_keyDown mirror still delivers the true current state
+        // through the fallback below, so nothing that matters is lost.
+        if (!m_haveAnchor) {
+            for (;;) {
+                const uint32_t tail = m_edgeTail.load(std::memory_order_relaxed);
+                if (tail == m_edgeHead.load(std::memory_order_acquire))
+                    break;
+                if (toSamples(nowTp - m_edgeQueue[tail % kEdgeQueueSize].t)
+                        <= idleLimit)
+                    break;
+                m_edgeTail.store(tail + 1, std::memory_order_release);
+            }
+        }
+    }
+
     for (;;) {
         const uint32_t tail = m_edgeTail.load(std::memory_order_relaxed);
         if (tail == m_edgeHead.load(std::memory_order_acquire))

--- a/src/core/CwSidetoneGenerator.cpp
+++ b/src/core/CwSidetoneGenerator.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <utility>
 
 #include <QVarLengthArray>
 
@@ -70,8 +71,16 @@ void CwSidetoneGenerator::setPan(float p) noexcept
 
 void CwSidetoneGenerator::setKeyDown(bool down) noexcept
 {
-    // Timestamp on entry — this is the keyer thread's edge time, taken
-    // before any queue mechanics, so it carries the keyer's precision.
+    // Several threads legitimately produce edges — the iambic and CWX
+    // workers call in directly, and the GUI thread echoes every
+    // radio-bound edge via RadioModel::cwKeyDownChanged — so slot write
+    // and head publish must be exclusive among producers.  A short spin
+    // is cheaper than any blocking primitive at tens of edges per
+    // second; process() only consumes the tail and never takes this
+    // lock, so the audio thread stays wait-free.  The timestamp is taken
+    // inside the lock so queue order equals timestamp order — process()
+    // relies on that for its edges-are-time-ordered early-out.
+    while (m_edgeLock.test_and_set(std::memory_order_acquire)) { /* spin */ }
     const auto now = std::chrono::steady_clock::now();
     const uint32_t head = m_edgeHead.load(std::memory_order_relaxed);
     const uint32_t tail = m_edgeTail.load(std::memory_order_acquire);
@@ -79,10 +88,13 @@ void CwSidetoneGenerator::setKeyDown(bool down) noexcept
         m_edgeQueue[head % kEdgeQueueSize] = {now, down};
         m_edgeHead.store(head + 1, std::memory_order_release);
     }
-    // Always mirror the latest state: on queue overflow (pathological)
-    // process() falls back to applying this at the next block start —
-    // the pre-#4809 behavior — so the final key-up can never be lost.
+    // Mirror the latest state inside the same critical section so it can
+    // never disagree with the last queued edge: on queue overflow
+    // (pathological) process() falls back to applying this at the next
+    // block start — the pre-#4809 behavior — so the final key-up can
+    // never be lost.
     m_keyDown.store(down, std::memory_order_relaxed);
+    m_edgeLock.clear(std::memory_order_release);
 }
 
 void CwSidetoneGenerator::reset() noexcept
@@ -93,6 +105,7 @@ void CwSidetoneGenerator::reset() noexcept
     m_gateDown = false;
     m_haveAnchor = false;
     m_streamPos = 0;
+    m_idleSamples = 0;
     // Drop queued edges (consumer-side drain: only the tail moves).
     m_edgeTail.store(m_edgeHead.load(std::memory_order_acquire),
                      std::memory_order_release);
@@ -188,7 +201,9 @@ bool CwSidetoneGenerator::process(float* out, int frames) noexcept
     // burst anchor.  Edges that fall beyond this block stay queued.
     const int64_t blockStart = m_streamPos;
     const int64_t blockEnd   = blockStart + frames;
-    QVarLengthArray<std::pair<int, bool>, 8> blockEdges;
+    // Prealloc covers a full ring drain after a scheduler stall, so the
+    // audio callback never heap-allocates here.
+    QVarLengthArray<std::pair<int, bool>, kEdgeQueueSize> blockEdges;
     for (;;) {
         const uint32_t tail = m_edgeTail.load(std::memory_order_relaxed);
         if (tail == m_edgeHead.load(std::memory_order_acquire))
@@ -221,11 +236,22 @@ bool CwSidetoneGenerator::process(float* out, int frames) noexcept
         && m_keyDown.load(std::memory_order_relaxed) != m_gateDown) {
         blockEdges.append({0, m_keyDown.load(std::memory_order_relaxed)});
     }
+    if (!blockEdges.isEmpty())
+        m_idleSamples = 0;
 
     if (m_state == State::Idle && blockEdges.isEmpty()) {
         m_streamPos = blockEnd;
-        if (!m_gateDown)
-            m_haveAnchor = false;  // burst over — re-anchor next time
+        if (m_haveAnchor && !m_gateDown) {
+            // Keep the anchor across ordinary inter-element and
+            // inter-character gaps — dropping it per-gap would snap the
+            // next element's onset back to a block boundary, leaving the
+            // rhythm block-quantized while only element lengths were
+            // exact.  Only a genuine pause releases the mapping.
+            m_idleSamples += frames;
+            if (m_idleSamples >=
+                static_cast<int64_t>(m_sampleRateHz) * kReanchorIdleMs / 1000)
+                m_haveAnchor = false;
+        }
         if (tapSet) {
             QVarLengthArray<float, 1024> silence(frames);
             std::memset(silence.data(), 0, frames * sizeof(float));
@@ -292,12 +318,6 @@ bool CwSidetoneGenerator::process(float* out, int frames) noexcept
     if (tapSet) m_sampleTap(tapBuf.data(), frames, m_sampleRateHz);
 
     m_streamPos = blockEnd;
-    if (m_state == State::Idle && !m_gateDown
-        && m_edgeTail.load(std::memory_order_relaxed)
-               == m_edgeHead.load(std::memory_order_acquire)) {
-        m_haveAnchor = false;  // burst over — re-anchor on the next edge
-    }
-
     m_lastPitchHz = pitch;
     return wroteAny;
 }

--- a/src/core/CwSidetoneGenerator.cpp
+++ b/src/core/CwSidetoneGenerator.cpp
@@ -80,6 +80,12 @@ void CwSidetoneGenerator::setKeyDown(bool down) noexcept
     // lock, so the audio thread stays wait-free.  The timestamp is taken
     // inside the lock so queue order equals timestamp order — process()
     // relies on that for its edges-are-time-ordered early-out.
+    // Worst case among producers: the GUI thread descheduled inside the
+    // section leaves a keying worker spinning until the holder resumes.
+    // The section is ~20 instructions, so the window is vanishingly
+    // small, and the cost is one edge timestamped late by the wait —
+    // the same per-edge epsilon class as wake latency, and never a
+    // correctness concern.
     while (m_edgeLock.test_and_set(std::memory_order_acquire)) { /* spin */ }
     const auto now = std::chrono::steady_clock::now();
     const uint32_t head = m_edgeHead.load(std::memory_order_relaxed);

--- a/src/core/CwSidetoneGenerator.h
+++ b/src/core/CwSidetoneGenerator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <functional>
 
@@ -38,8 +39,13 @@ public:
     int  sampleRateHz() const noexcept { return m_sampleRateHz; }
 
     // Key state — called from any thread when RadioModel emits
-    // cwKeyDownChanged.  The audio thread polls m_keyDown each block
-    // and transitions state machine accordingly.
+    // cwKeyDownChanged.  Each call is timestamped on entry and queued;
+    // process() applies the transition at the exact sample offset the
+    // timestamp maps to, so key edges are no longer quantized to audio
+    // block boundaries (#4809 — up to one whole block of jitter per
+    // edge, and far more on the push-model QAudioSink sink).  On queue
+    // overflow the last-known state still lands at the next block start
+    // (the pre-#4809 behavior) via m_keyDown.
     void setKeyDown(bool down) noexcept;
 
     bool  isEnabled() const noexcept { return m_enabled.load(std::memory_order_relaxed); }
@@ -72,9 +78,25 @@ public:
 private:
     enum class State : uint8_t { Idle, RampUp, Sustain, RampDown };
 
+    // One timestamped key transition from setKeyDown().  The queue is a
+    // fixed-size SPSC ring: producer = the keyer thread (head), consumer
+    // = the audio thread (tail).  Size 64 is ~32 elements of headroom —
+    // far beyond what fits in one audio block even at 60 WPM.
+    struct KeyEdge {
+        std::chrono::steady_clock::time_point t;
+        bool down;
+    };
+    static constexpr uint32_t kEdgeQueueSize = 64;  // power of two
+
+    void applyKeyEdge(bool down) noexcept;  // state-machine transition
+
     int                m_sampleRateHz;
     std::atomic<bool>  m_enabled{false};
     std::atomic<bool>  m_keyDown{false};
+
+    KeyEdge                m_edgeQueue[kEdgeQueueSize];
+    std::atomic<uint32_t>  m_edgeHead{0};
+    std::atomic<uint32_t>  m_edgeTail{0};
     std::atomic<float> m_pitchHz{600.0f};
     std::atomic<float> m_volume{0.5f};
     std::atomic<float> m_pan{0.5f};
@@ -86,6 +108,18 @@ private:
     int      m_rampLength{240};     // recomputed from m_shapingMs
     double   m_phase{0.0};          // sine phase accumulator
     float    m_lastPitchHz{600.0f}; // for change detection (smooth transitions)
+    bool     m_gateDown{false};     // audio-thread view of the key state
+
+    // Timestamp→sample mapping for the current keying burst.  Anchored
+    // on the first edge of a burst (which plays at that block's start,
+    // preserving the pre-#4809 onset latency); later edges land at
+    // anchor + Δt·rate, so their *relative* spacing — the thing the ear
+    // hears as rhythm — is sample-exact.  Re-anchored every burst so
+    // steady_clock vs audio-clock drift can't accumulate.
+    int64_t  m_streamPos{0};        // samples rendered since reset()
+    bool     m_haveAnchor{false};
+    std::chrono::steady_clock::time_point m_anchorTime;
+    int64_t  m_anchorPos{0};
 
     // Mirror sink for the TX decode path (#2417).  Holds null until
     // AudioEngine plugs in its TX-decoder feeder.  When non-null, every

--- a/src/core/CwSidetoneGenerator.h
+++ b/src/core/CwSidetoneGenerator.h
@@ -95,8 +95,14 @@ private:
 
     // Release the timestamp→sample anchor only after this much continuous
     // idle: longer than any inter-element or inter-character gap at
-    // paddle speeds (180 ms at 20 WPM), short enough to bound
-    // steady_clock vs audio-clock drift between keying sequences.
+    // typical paddle speeds (180 ms inter-character at 20 WPM), short
+    // enough to bound steady_clock vs audio-clock drift between keying
+    // sequences.  Below 15 WPM an inter-character gap (3 units of
+    // 1200/wpm ms) exceeds this and the anchor is released between
+    // characters — harmless, since at those speeds a unit is >=85 ms and
+    // block quantization of the next onset is inaudible; element lengths
+    // stay exact either way, because they come from the keyer's grid,
+    // not the anchor.
     static constexpr int kReanchorIdleMs = 250;
 
     void applyKeyEdge(bool down) noexcept;  // state-machine transition

--- a/src/core/CwSidetoneGenerator.h
+++ b/src/core/CwSidetoneGenerator.h
@@ -84,9 +84,10 @@ private:
     // One timestamped key transition from setKeyDown().  The queue is a
     // fixed-size MPSC ring: producers = the keying threads (head,
     // serialized by m_edgeLock), consumer = the audio thread (tail).
-    // Size 64 is ~32 elements of headroom — far beyond what fits in one
-    // audio block even at 60 WPM, and every element arrives twice
-    // (worker-direct plus the GUI cwKeyDownChanged echo).
+    // Size 64 is ~16 elements of headroom: 2 slots per element (down + up),
+    // doubled again because every element arrives twice (worker-direct plus
+    // the GUI cwKeyDownChanged echo).  Still far beyond what fits in one
+    // audio block even at 60 WPM.
     struct KeyEdge {
         std::chrono::steady_clock::time_point t;
         bool down;
@@ -103,6 +104,11 @@ private:
     // block quantization of the next onset is inaudible; element lengths
     // stay exact either way, because they come from the keyer's grid,
     // not the anchor.
+    //
+    // process() reuses this same threshold for the two guards that keep the
+    // mapping honest when it is NOT pumped in real time: how far the anchor
+    // may drift from wall clock before it is dropped, and how old a queued
+    // edge may be before a fresh anchor discards it instead of replaying it.
     static constexpr int kReanchorIdleMs = 250;
 
     void applyKeyEdge(bool down) noexcept;  // state-machine transition

--- a/src/core/CwSidetoneGenerator.h
+++ b/src/core/CwSidetoneGenerator.h
@@ -38,14 +38,17 @@ public:
     void setSampleRateHz(int hz) noexcept;
     int  sampleRateHz() const noexcept { return m_sampleRateHz; }
 
-    // Key state — called from any thread when RadioModel emits
-    // cwKeyDownChanged.  Each call is timestamped on entry and queued;
-    // process() applies the transition at the exact sample offset the
-    // timestamp maps to, so key edges are no longer quantized to audio
-    // block boundaries (#4809 — up to one whole block of jitter per
-    // edge, and far more on the push-model QAudioSink sink).  On queue
-    // overflow the last-known state still lands at the next block start
-    // (the pre-#4809 behavior) via m_keyDown.
+    // Key state — called from any thread, and concurrently from several
+    // in practice (iambic worker, CWX worker, GUI-thread handlers of
+    // RadioModel::cwKeyDownChanged); producers serialize on a short
+    // spinlock the audio thread never touches.  Each call is timestamped
+    // inside the lock and queued; process() applies the transition at
+    // the exact sample offset the timestamp maps to, so key edges are no
+    // longer quantized to audio block boundaries (#4809 — up to one
+    // whole block of jitter per edge, and far more on the push-model
+    // QAudioSink sink).  On queue overflow the last-known state still
+    // lands at the next block start (the pre-#4809 behavior) via
+    // m_keyDown.
     void setKeyDown(bool down) noexcept;
 
     bool  isEnabled() const noexcept { return m_enabled.load(std::memory_order_relaxed); }
@@ -79,14 +82,22 @@ private:
     enum class State : uint8_t { Idle, RampUp, Sustain, RampDown };
 
     // One timestamped key transition from setKeyDown().  The queue is a
-    // fixed-size SPSC ring: producer = the keyer thread (head), consumer
-    // = the audio thread (tail).  Size 64 is ~32 elements of headroom —
-    // far beyond what fits in one audio block even at 60 WPM.
+    // fixed-size MPSC ring: producers = the keying threads (head,
+    // serialized by m_edgeLock), consumer = the audio thread (tail).
+    // Size 64 is ~32 elements of headroom — far beyond what fits in one
+    // audio block even at 60 WPM, and every element arrives twice
+    // (worker-direct plus the GUI cwKeyDownChanged echo).
     struct KeyEdge {
         std::chrono::steady_clock::time_point t;
         bool down;
     };
     static constexpr uint32_t kEdgeQueueSize = 64;  // power of two
+
+    // Release the timestamp→sample anchor only after this much continuous
+    // idle: longer than any inter-element or inter-character gap at
+    // paddle speeds (180 ms at 20 WPM), short enough to bound
+    // steady_clock vs audio-clock drift between keying sequences.
+    static constexpr int kReanchorIdleMs = 250;
 
     void applyKeyEdge(bool down) noexcept;  // state-machine transition
 
@@ -97,6 +108,7 @@ private:
     KeyEdge                m_edgeQueue[kEdgeQueueSize];
     std::atomic<uint32_t>  m_edgeHead{0};
     std::atomic<uint32_t>  m_edgeTail{0};
+    std::atomic_flag       m_edgeLock;   // producer-only; audio thread never takes it
     std::atomic<float> m_pitchHz{600.0f};
     std::atomic<float> m_volume{0.5f};
     std::atomic<float> m_pan{0.5f};
@@ -110,16 +122,20 @@ private:
     float    m_lastPitchHz{600.0f}; // for change detection (smooth transitions)
     bool     m_gateDown{false};     // audio-thread view of the key state
 
-    // Timestamp→sample mapping for the current keying burst.  Anchored
-    // on the first edge of a burst (which plays at that block's start,
-    // preserving the pre-#4809 onset latency); later edges land at
-    // anchor + Δt·rate, so their *relative* spacing — the thing the ear
-    // hears as rhythm — is sample-exact.  Re-anchored every burst so
-    // steady_clock vs audio-clock drift can't accumulate.
+    // Timestamp→sample mapping for the current keying sequence.  Anchored
+    // on the first edge after an idle period (that edge plays at the
+    // block's start, preserving the pre-#4809 onset latency); every later
+    // edge lands at anchor + Δt·rate, so relative spacing — the thing the
+    // ear hears as rhythm — is sample-exact.  The anchor survives
+    // inter-element and inter-character gaps (dropping it per-gap would
+    // re-quantize element onsets to block boundaries) and is released
+    // only after kReanchorIdleMs of continuous idle, which bounds
+    // steady_clock vs audio-clock drift between keying sequences.
     int64_t  m_streamPos{0};        // samples rendered since reset()
     bool     m_haveAnchor{false};
     std::chrono::steady_clock::time_point m_anchorTime;
     int64_t  m_anchorPos{0};
+    int64_t  m_idleSamples{0};      // contiguous idle samples since the last edge
 
     // Mirror sink for the TX decode path (#2417).  Holds null until
     // AudioEngine plugs in its TX-decoder feeder.  When non-null, every

--- a/src/core/IambicKeyer.cpp
+++ b/src/core/IambicKeyer.cpp
@@ -232,6 +232,16 @@ void IambicKeyer::workerLoop()
             // Deadline armed BEFORE the key-down callback, so the
             // callback's cost (sidetone gate flip, per-edge trace log,
             // queued radio post) cannot push the edge out.
+            // Catch-up limiter: a stall longer than one element leaves every
+            // following deadline already past, so both wait loops fall
+            // straight through and the worker emits zero-length elements —
+            // and zero-length `cw key` edges on air — until the grid catches
+            // up.  Re-anchor instead.  Ordinary wake latency is orders of
+            // magnitude inside one element, so the self-correcting property
+            // this whole change exists for is untouched; only a stall that
+            // already lost an element stops trying to win the time back.
+            const auto markNow = std::chrono::steady_clock::now();
+            if (grid + onDuration < markNow) grid = markNow;
             const auto onDeadline = grid + onDuration;
             emitKeyDown(true);
             {
@@ -248,6 +258,10 @@ void IambicKeyer::workerLoop()
             grid = onDeadline;
 
             // ── Inter-element gap ──────────────────────────────────────
+            // Same limiter for the gap: without it the element that absorbed
+            // the stall is followed by a zero-length space.
+            const auto gapNow = std::chrono::steady_clock::now();
+            if (grid + offDuration < gapNow) grid = gapNow;
             const auto offDeadline = grid + offDuration;
             emitKeyDown(false);
             if (m_stopRequested.load(std::memory_order_acquire)) break;

--- a/src/core/IambicKeyer.cpp
+++ b/src/core/IambicKeyer.cpp
@@ -101,10 +101,13 @@ void IambicKeyer::reset() noexcept
     m_cv.notify_all();
 }
 
-int IambicKeyer::unitMs() const noexcept
+std::chrono::nanoseconds IambicKeyer::unitNs() const noexcept
 {
     const int wpm = std::clamp(m_wpm.load(std::memory_order_relaxed), kMinWpm, kMaxWpm);
-    return 1200 / wpm;
+    // Nanosecond unit math: integer 1200/wpm ms truncates (52 ms vs
+    // 52.17 ms at 23 WPM — a permanent 0.3% speed error); dividing in
+    // ns leaves sub-ppm error at any legal WPM (#4809).
+    return std::chrono::nanoseconds(1'200'000'000LL / wpm);
 }
 
 IambicKeyer::Element IambicKeyer::nextElementChoice(bool ditWanted,
@@ -173,30 +176,40 @@ void IambicKeyer::workerLoop()
             if (cur == Element::Dah && m_ditPressed) m_ditMemory = true;
         };
 
+        // Element edges advance on an absolute grid anchored here, when
+        // the active phase begins — the CwxLocalKeyer pattern from #3644.
+        // Each deadline is grid + duration and the grid advances by the
+        // nominal duration, so thread wake latency and callback cost eat
+        // into the following wait instead of stretching every element.
+        // The old per-element `now() + duration` anchoring made element
+        // length `nominal + wake latency + callback cost` with a fresh,
+        // strictly positive error term each element (#4809: measured
+        // +4 ms mean on the reporter's machine, one-sided).
+        auto grid = std::chrono::steady_clock::now();
+
         while (!m_stopRequested.load(std::memory_order_acquire)
-               && (wantDit || wantDah || m_ditMemory || m_dahMemory)) {
+               && (wantDit || wantDah
+                   || m_ditMemory.load() || m_dahMemory.load())) {
 
             // Pick next element.
             Element next;
             if (firstInSqueeze) {
                 next = wantDit ? Element::Dit : Element::Dah;
                 firstInSqueeze = false;
-            } else if (m_ditMemory || m_dahMemory) {
+            } else if (m_ditMemory.load() || m_dahMemory.load()) {
                 // Memory bits force the opposite element.
-                next = m_ditMemory ? Element::Dit : Element::Dah;
-                {
-                    std::lock_guard<std::mutex> lk(m_mu);
-                    m_ditMemory = false;
-                    m_dahMemory = false;
-                }
+                next = m_ditMemory.load() ? Element::Dit : Element::Dah;
+                m_ditMemory.store(false);
+                m_dahMemory.store(false);
             } else {
                 next = nextElementChoice(wantDit, wantDah, lastSent);
             }
             lastSent = next;
 
-            const int unit = unitMs();
-            const int onDuration = (next == Element::Dit) ? unit : unit * kDitsPerDah;
-            const int offDuration = unit;
+            const std::chrono::nanoseconds unit = unitNs();
+            const std::chrono::nanoseconds onDuration =
+                (next == Element::Dit) ? unit : unit * kDitsPerDah;
+            const std::chrono::nanoseconds offDuration = unit;
             const Mode currentMode =
                 static_cast<Mode>(m_mode.load(std::memory_order_relaxed));
 
@@ -216,9 +229,11 @@ void IambicKeyer::workerLoop()
             }
 
             // ── Element on ─────────────────────────────────────────────
+            // Deadline armed BEFORE the key-down callback, so the
+            // callback's cost (sidetone gate flip, per-edge trace log,
+            // queued radio post) cannot push the edge out.
+            const auto onDeadline = grid + onDuration;
             emitKeyDown(true);
-            const auto onDeadline =
-                std::chrono::steady_clock::now() + std::chrono::milliseconds(onDuration);
             {
                 std::unique_lock<std::mutex> lk(m_mu);
                 while (std::chrono::steady_clock::now() < onDeadline
@@ -230,12 +245,12 @@ void IambicKeyer::workerLoop()
                         latchOppositeLocked(next);
                 }
             }
-            emitKeyDown(false);
-            if (m_stopRequested.load(std::memory_order_acquire)) break;
+            grid = onDeadline;
 
             // ── Inter-element gap ──────────────────────────────────────
-            const auto offDeadline =
-                std::chrono::steady_clock::now() + std::chrono::milliseconds(offDuration);
+            const auto offDeadline = grid + offDuration;
+            emitKeyDown(false);
+            if (m_stopRequested.load(std::memory_order_acquire)) break;
             {
                 std::unique_lock<std::mutex> lk(m_mu);
                 while (std::chrono::steady_clock::now() < offDeadline
@@ -245,6 +260,7 @@ void IambicKeyer::workerLoop()
                         latchOppositeLocked(next);
                 }
             }
+            grid = offDeadline;
 
             // Re-read paddle state for the next iteration's decision.
             // Always forward to the radio so it sees release events.

--- a/src/core/IambicKeyer.h
+++ b/src/core/IambicKeyer.h
@@ -93,7 +93,7 @@ private:
     enum class Element : int { Dit = 1, Dah = 2 };
 
     void workerLoop();
-    int  unitMs() const noexcept;          // 1200 / WPM, clamped
+    std::chrono::nanoseconds unitNs() const noexcept;  // 1.2e9 ns / WPM, clamped
     Element nextElementChoice(bool ditWanted, bool dahWanted, Element justSent) const noexcept;
     void emitKeyDown(bool down);
     void emitPaddleEvent(bool dit, bool dah);
@@ -114,9 +114,11 @@ private:
     bool                    m_paddleStateDirty{false};
 
     // Iambic mode B "memory" bits — set when the opposite paddle is
-    // pressed mid-element, cleared when consumed.
-    bool                    m_ditMemory{false};
-    bool                    m_dahMemory{false};
+    // pressed mid-element, cleared when consumed.  Atomic because the
+    // worker's between-element checks read them without holding m_mu
+    // while the latch sites store under it (#4809 review find).
+    std::atomic<bool>       m_ditMemory{false};
+    std::atomic<bool>       m_dahMemory{false};
 
     std::atomic<int>        m_mode{static_cast<int>(Mode::IambicB)};
     std::atomic<int>        m_wpm{20};

--- a/tests/cw_sidetone_test.cpp
+++ b/tests/cw_sidetone_test.cpp
@@ -1,6 +1,7 @@
 #include "core/CwSidetoneGenerator.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -39,6 +40,44 @@ std::vector<float> runFrames(CwSidetoneGenerator& gen, int frames)
     std::vector<float> mono(frames);
     for (int i = 0; i < frames; ++i) mono[i] = stereo[2 * i];
     return mono;
+}
+
+// 48 kHz samples spanned by a measured wall-clock interval, plus margin.
+// The placement cases size their render window from the interval they
+// actually measured rather than a fixed constant: a scheduler stall inside
+// one of their spin loops then lengthens the window instead of pushing the
+// edge past the end of it and failing.
+int samplesFor(std::chrono::steady_clock::duration d, int marginFrames = 960)
+{
+    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(d).count();
+    return static_cast<int>(ns * 48000 / 1'000'000'000LL) + marginFrames;
+}
+
+// Count contiguous runs of audible 8-sample windows.
+int toneBursts(const std::vector<float>& buf)
+{
+    int bursts = 0;
+    bool loudRun = false;
+    for (int i = 0; i + 8 <= static_cast<int>(buf.size()); i += 8) {
+        const float peak = maxAbs(std::vector<float>(
+            buf.begin() + i, buf.begin() + i + 8));
+        const bool loud = peak > 0.1f;
+        if (loud && !loudRun) ++bursts;
+        loudRun = loud;
+    }
+    return bursts;
+}
+
+// Key one element of `ms` on, `ms` off, spinning on the real clock.
+void keyElement(CwSidetoneGenerator& gen, int ms)
+{
+    using clock = std::chrono::steady_clock;
+    gen.setKeyDown(true);
+    auto t = clock::now();
+    while (clock::now() - t < std::chrono::milliseconds(ms)) { /* spin */ }
+    gen.setKeyDown(false);
+    t = clock::now();
+    while (clock::now() - t < std::chrono::milliseconds(ms)) { /* spin */ }
 }
 
 } // namespace
@@ -191,12 +230,14 @@ int main()
         gen.setKeyDown(false);
         const auto b1 = clock::now();
 
-        auto mono = runFrames(gen, 1440);  // one 30 ms block covers both edges
+        // One block covering both edges, sized from the interval measured
+        // above so a stall in the spin loop can't push the key-up past it.
+        auto mono = runFrames(gen, std::max(1440, samplesFor(b1 - a0)));
 
         // Envelope edge: last 8-sample window whose peak clears threshold
         // (single samples of a sine pass through zero mid-tone).
         int lastLoud = -1;
-        for (int i = 0; i + 8 <= 1440; i += 8) {
+        for (int i = 0; i + 8 <= static_cast<int>(mono.size()); i += 8) {
             const float peak = maxAbs(std::vector<float>(
                 mono.begin() + i, mono.begin() + i + 8));
             if (peak > 0.1f) lastLoud = i + 8;
@@ -223,7 +264,8 @@ int main()
         gen2.setKeyDown(false);
         const auto d1 = clock::now();
         std::vector<float> cat;
-        for (int b = 0; b < 12; ++b) {
+        const int blocks2 = std::max(12, (samplesFor(d1 - c0) + 127) / 128);
+        for (int b = 0; b < blocks2; ++b) {
             auto blk = runFrames(gen2, 128);
             cat.insert(cat.end(), blk.begin(), blk.end());
         }
@@ -270,7 +312,8 @@ int main()
         gen.setKeyDown(false);
 
         std::vector<float> cat;
-        for (int b = 0; b < 30; ++b) {
+        const int blocks = std::max(30, (samplesFor(c1 - a0) + 127) / 128);
+        for (int b = 0; b < blocks; ++b) {
             auto blk = runFrames(gen, 128);
             cat.insert(cat.end(), blk.begin(), blk.end());
         }
@@ -314,6 +357,71 @@ int main()
         auto third = runFrames(gen, 480);
         ok &= expect(maxAbs(third) == 0.0f,
                      "true final key-up survives queue overflow via fallback");
+    }
+
+    // ── 10. Edges queued while process() is not being called must not replay
+    // into the next burst.  Not every consumer is pumped continuously: the
+    // recorder's sidetone generator renders only while the radio is
+    // transmitting a CW over (AudioEngine::onCwRecordPump), while
+    // setKeyDown() keeps queueing from every paddle edge regardless.  Without
+    // the staleness guard the next over anchors on keying from seconds ago
+    // and plays it back ahead of the real elements.
+    {
+        using clock = std::chrono::steady_clock;
+        CwSidetoneGenerator gen(48000);
+        gen.setEnabled(true);
+        gen.setVolume(1.0f);
+        gen.setShapingMs(0.0f);
+
+        // Three elements keyed with the consumer stopped — nothing rendered.
+        for (int k = 0; k < 3; ++k) keyElement(gen, 10);
+        // Age them past the re-anchor threshold, still unpumped.
+        const auto q = clock::now();
+        while (clock::now() - q < std::chrono::milliseconds(300)) { /* spin */ }
+
+        // The consumer starts again, and one real element is keyed.
+        const auto e0 = clock::now();
+        keyElement(gen, 10);
+
+        std::vector<float> cat;
+        const int blocks = std::max(40, (samplesFor(clock::now() - e0) + 127) / 128);
+        for (int b = 0; b < blocks; ++b) {
+            auto blk = runFrames(gen, 128);
+            cat.insert(cat.end(), blk.begin(), blk.end());
+        }
+        ok &= expect(toneBursts(cat) == 1,
+                     "stale queued edges are dropped, not replayed into the"
+                     " next burst");
+    }
+
+    // ── 11. A consumer that pauses long enough for the anchor's wall clock to
+    // outrun its stream position re-anchors instead of deferring every edge
+    // past the end of the block forever (the same pause, seen from the other
+    // side: here the queue is empty across the gap, so only the mapping is
+    // stale).
+    {
+        using clock = std::chrono::steady_clock;
+        CwSidetoneGenerator gen(48000);
+        gen.setEnabled(true);
+        gen.setVolume(1.0f);
+        gen.setShapingMs(0.0f);
+
+        keyElement(gen, 10);                       // establishes the anchor
+        for (int b = 0; b < 20; ++b) runFrames(gen, 128);
+
+        const auto q = clock::now();               // consumer stops rendering
+        while (clock::now() - q < std::chrono::milliseconds(400)) { /* spin */ }
+
+        const auto e0 = clock::now();
+        keyElement(gen, 10);
+        std::vector<float> cat;
+        const int blocks = std::max(40, (samplesFor(clock::now() - e0) + 127) / 128);
+        for (int b = 0; b < blocks; ++b) {
+            auto blk = runFrames(gen, 128);
+            cat.insert(cat.end(), blk.begin(), blk.end());
+        }
+        ok &= expect(toneBursts(cat) == 1,
+                     "element after a consumer pause still sounds, once");
     }
 
     return ok ? 0 : 1;

--- a/tests/cw_sidetone_test.cpp
+++ b/tests/cw_sidetone_test.cpp
@@ -241,6 +241,61 @@ int main()
                      "128-frame blocks: edge placed mid-block by timestamp");
     }
 
+    // ── 8b. The anchor survives an inter-element gap ───────────────────────
+    // A second element after a real gap must onset at its timestamp-mapped
+    // sample.  With a per-gap re-anchor the queued second key-down snaps to
+    // the next block's start instead — element lengths stay exact but the
+    // rhythm (onset-to-onset spacing) stays block-quantized, which is the
+    // irregularity #4809 is about.
+    {
+        using clock = std::chrono::steady_clock;
+        CwSidetoneGenerator gen(48000);
+        gen.setEnabled(true);
+        gen.setVolume(1.0f);
+        gen.setShapingMs(0.0f);
+
+        const auto a0 = clock::now();
+        gen.setKeyDown(true);
+        const auto a1 = clock::now();
+        while (clock::now() - a1 < std::chrono::milliseconds(10)) { /* spin */ }
+        gen.setKeyDown(false);
+        const auto b1 = clock::now();
+        // Inter-element gap: long enough for the ramp to finish and many
+        // Idle blocks to elapse, far below the idle re-anchor timeout.
+        while (clock::now() - b1 < std::chrono::milliseconds(40)) { /* spin */ }
+        const auto c0 = clock::now();
+        gen.setKeyDown(true);
+        const auto c1 = clock::now();
+        while (clock::now() - c1 < std::chrono::milliseconds(10)) { /* spin */ }
+        gen.setKeyDown(false);
+
+        std::vector<float> cat;
+        for (int b = 0; b < 30; ++b) {
+            auto blk = runFrames(gen, 128);
+            cat.insert(cat.end(), blk.begin(), blk.end());
+        }
+        // Second element's onset: first loud window after the quiet gap
+        // that follows the first loud run.
+        int onset2 = -1;
+        bool sawLoud = false, sawGap = false;
+        for (int i = 0; i + 8 <= static_cast<int>(cat.size()); i += 8) {
+            const float peak = maxAbs(std::vector<float>(
+                cat.begin() + i, cat.begin() + i + 8));
+            const bool loud = peak > 0.1f;
+            if (loud && !sawLoud && sawGap) { onset2 = i; break; }
+            if (!loud && sawLoud) sawGap = true;
+            sawLoud = loud;
+        }
+        const auto loNs = std::chrono::duration_cast<std::chrono::nanoseconds>(c0 - a1).count();
+        const auto hiNs = std::chrono::duration_cast<std::chrono::nanoseconds>(c1 - a0).count();
+        const int lo = static_cast<int>(loNs * 48000 / 1'000'000'000LL) - 16;
+        const int hi = static_cast<int>(hiNs * 48000 / 1'000'000'000LL) + 16;
+        ok &= expect(onset2 > 0, "cross-element: second element sounds at all");
+        ok &= expect(onset2 >= lo && onset2 <= hi,
+                     "cross-element: onset lands at the timestamp-mapped sample,"
+                     " anchor survives the gap");
+    }
+
     // ── 9. Queue-overflow fallback: the true final state still lands ───────
     // 201 toggles overflow the 64-slot ring; the last edge the ring caught
     // is a key-DOWN, but the true final state is key-UP — only the

--- a/tests/cw_sidetone_test.cpp
+++ b/tests/cw_sidetone_test.cpp
@@ -171,5 +171,95 @@ int main()
         ok &= expect(maxAbs(silent) == 0.0f, "reset + key-up produces silence");
     }
 
+    // ── 8. Timestamped edges: a sub-block down/up pair is rendered at the
+    // exact sample spacing, not lost or snapped to a block boundary (#4809).
+    // On the pre-#4809 block-polling gate this exact sequence produced
+    // total silence: both transitions landed before the first process()
+    // call, so the single bool already read `false` again.
+    {
+        using clock = std::chrono::steady_clock;
+        CwSidetoneGenerator gen(48000);
+        gen.setEnabled(true);
+        gen.setVolume(1.0f);
+        gen.setShapingMs(0.0f);  // 1-sample ramp — near-hard keying
+
+        const auto a0 = clock::now();
+        gen.setKeyDown(true);
+        const auto a1 = clock::now();
+        while (clock::now() - a1 < std::chrono::milliseconds(10)) { /* spin */ }
+        const auto b0 = clock::now();
+        gen.setKeyDown(false);
+        const auto b1 = clock::now();
+
+        auto mono = runFrames(gen, 1440);  // one 30 ms block covers both edges
+
+        // Envelope edge: last 8-sample window whose peak clears threshold
+        // (single samples of a sine pass through zero mid-tone).
+        int lastLoud = -1;
+        for (int i = 0; i + 8 <= 1440; i += 8) {
+            const float peak = maxAbs(std::vector<float>(
+                mono.begin() + i, mono.begin() + i + 8));
+            if (peak > 0.1f) lastLoud = i + 8;
+        }
+        const auto loNs = std::chrono::duration_cast<std::chrono::nanoseconds>(b0 - a1).count();
+        const auto hiNs = std::chrono::duration_cast<std::chrono::nanoseconds>(b1 - a0).count();
+        const int lo = static_cast<int>(loNs * 48000 / 1'000'000'000LL) - 16;
+        const int hi = static_cast<int>(hiNs * 48000 / 1'000'000'000LL) + 16;
+        ok &= expect(lastLoud > 0, "sub-block down/up pair produces a tone at all");
+        ok &= expect(lastLoud >= lo && lastLoud <= hi,
+                     "key-up lands at the timestamp-mapped sample, not a block edge");
+
+        // Same pair pumped through 128-frame blocks must place the edge
+        // mid-block (~480), not quantize it to a 128-sample boundary.
+        CwSidetoneGenerator gen2(48000);
+        gen2.setEnabled(true);
+        gen2.setVolume(1.0f);
+        gen2.setShapingMs(0.0f);
+        const auto c0 = clock::now();
+        gen2.setKeyDown(true);
+        const auto c1 = clock::now();
+        while (clock::now() - c1 < std::chrono::milliseconds(10)) { /* spin */ }
+        const auto d0 = clock::now();
+        gen2.setKeyDown(false);
+        const auto d1 = clock::now();
+        std::vector<float> cat;
+        for (int b = 0; b < 12; ++b) {
+            auto blk = runFrames(gen2, 128);
+            cat.insert(cat.end(), blk.begin(), blk.end());
+        }
+        int lastLoud2 = -1;
+        for (int i = 0; i + 8 <= static_cast<int>(cat.size()); i += 8) {
+            const float peak = maxAbs(std::vector<float>(
+                cat.begin() + i, cat.begin() + i + 8));
+            if (peak > 0.1f) lastLoud2 = i + 8;
+        }
+        const auto lo2Ns = std::chrono::duration_cast<std::chrono::nanoseconds>(d0 - c1).count();
+        const auto hi2Ns = std::chrono::duration_cast<std::chrono::nanoseconds>(d1 - c0).count();
+        const int lo2 = static_cast<int>(lo2Ns * 48000 / 1'000'000'000LL) - 16;
+        const int hi2 = static_cast<int>(hi2Ns * 48000 / 1'000'000'000LL) + 16;
+        ok &= expect(lastLoud2 >= lo2 && lastLoud2 <= hi2,
+                     "128-frame blocks: edge placed mid-block by timestamp");
+    }
+
+    // ── 9. Queue-overflow fallback: the true final state still lands ───────
+    // 201 toggles overflow the 64-slot ring; the last edge the ring caught
+    // is a key-DOWN, but the true final state is key-UP — only the
+    // m_keyDown fallback can deliver it.  The gate must not stick down.
+    {
+        CwSidetoneGenerator gen(48000);
+        gen.setEnabled(true);
+        gen.setVolume(1.0f);
+        gen.setShapingMs(0.0f);
+        for (int i = 0; i <= 200; ++i)          // i=200 (even) ends key-UP
+            gen.setKeyDown((i % 2) == 1);
+        auto first = runFrames(gen, 480);        // replays the 64 queued edges
+        ok &= expect(maxAbs(first) > 0.0f,
+                     "overflow replay leaves the stale key-down sounding");
+        runFrames(gen, 480);                     // fallback fires at this block
+        auto third = runFrames(gen, 480);
+        ok &= expect(maxAbs(third) == 0.0f,
+                     "true final key-up survives queue overflow via fallback");
+    }
+
     return ok ? 0 : 1;
 }


### PR DESCRIPTION
Fixes #4809

> **⚠ Stacked on #4810 — reviewers please read this first.** This branch is
> deliberately based on #4810's head (`98643cf9`), not main, because both
> changes rewrite the same region of `IambicKeyer::workerLoop()` — basing on
> main would guarantee a conflict and force one review to happen through
> merge damage. Until #4810 merges, this PR's diff therefore shows two
> commits; **only the top commit (`3455551b`) is this PR** — the other is
> #4810, reviewed there. When #4810 lands I'll rebase onto main immediately
> and the diff collapses to this change alone. The two fixes are independent
> in mechanism (latch logic vs. timing) but live in the same loop.

### The bug — two independent halves, both measured

@williamscody's held-paddle reduction is reproducible from his own
attachments. Parsing his CW debug log's key-edge timeline (all numbers in
the issue thread):

| element | n | mean | sd | range | nominal |
|---|---|---|---|---|---|
| dits | 107 | 43.8 ms | 1.7 | 40–46 | 40 |
| dahs | 45 | 124.2 ms | 1.5 | 120–125 | 120 |
| gaps | 150 | 44.0 ms | 1.4 | 40–46 | 40 |

Every element runs long, **never short** — a one-sided +4 ms mean. That is
the signature of the first half:

**Half 1 — element scheduling.** `workerLoop()` armed every deadline as
`now() + duration`, with `now()` read *after* the previous wait returned and
after the key-edge callback ran. Element length is therefore
`nominal + thread wake latency + callback cost`, a fresh strictly-positive
error each element that never self-corrects (~10% slow at 30 WPM on the
reporter's M2; the same signature is measurable but small — +0.17 ms — on an
idle Linux box, so macOS wake behavior is the amplifier, matching the
report's platform). `CwxLocalKeyer` had this exact defect fixed in #3644
with an absolute epoch + cumulative offset; `IambicKeyer` never got that
treatment. Also in this half: integer `1200/wpm` ms truncation (23 WPM runs
0.3% fast of spec permanently) and a data race on the Mode B memory flags
(read outside the mutex they're written under).

**Half 2 — edge rendering.** `CwSidetoneGenerator::process()` read its key
gate **once per audio block** and applied it to the whole buffer, so every
precisely-timed edge was quantized to a block boundary: ±2.67 ms on the
default PortAudio sink (128 @ 48 k), and much larger, variable amounts on
the `QAudioSink` fallback (50 ms buffer, 2 ms tick). #3644 explicitly left
this as the follow-up ("advancing the gate by sample count inside
`process()`"), and the reporter's support bundle confirms he was on the
PortAudio sink — so his audible irregularity is dominated by half 1, while
the Qt-sink fallback path (which the Linux bench box takes after a PortAudio
open failure) is dominated by half 2. Both halves are needed for
SmartSDR-grade regularity; fixing either alone leaves an audible remainder.

### The fix

**`IambicKeyer`** — element deadlines advance on an absolute
`steady_clock` grid anchored at squeeze start (the #3644 pattern): each
deadline is `grid + duration` computed **before** `emitKeyDown()`, and the
grid advances by the nominal duration, so wake latency and callback cost
eat into the following wait instead of stretching every element. The unit
is tracked in nanoseconds (`1'200'000'000 / wpm`). The memory flags become
atomics.

**`CwSidetoneGenerator`** — `setKeyDown()` timestamps each transition on
entry into a fixed-size lock-free SPSC ring; `process()` maps timestamps to
exact sample offsets and splits the block there, applying the existing
raised-cosine state machine mid-block (it already ramps cleanly from any
offset). The first edge of a keying burst plays at that block's start —
identical onset latency to before — and every subsequent edge lands
sample-exact *relative* to it, which is what the ear hears as rhythm. The
mapping re-anchors every burst so steady-clock-vs-audio-clock drift cannot
accumulate. On ring overflow the retained atomic still applies the
last-known state at the next block start (the old behavior), so a final
key-up can never be lost. Covers both sinks — they share `process()`. No
caller changes anywhere; the public API is unchanged.

### Tests

- `cw_sidetone_test` gains three discriminating cases: a down/up pair
  arriving within one block period must render at its timestamp-mapped
  spacing — on the old gate that pair produced **total silence** (both
  transitions landed before the next block poll; the audio-thread cousin
  of #4032's merged-release bug) — plus a 128-frame-block placement case
  and a forced ring-overflow case proving the fallback delivers the true
  final key state.
- Harness find, fixed here: `cw_sidetone_test` was built but never
  `add_test`-registered — the suite has never run it (same gap #4810 found
  and fixed for `iambic_keyer_test`). Registered; it now runs and passes.
- All 12 existing `iambic_keyer_test` cases (including #4810's Mode B
  latch cases) pass unchanged on the new timing.

### Verification status — measured so far, runtime proof PENDING

Done (Linux, RelWithDebInfo, clean build at `3455551b`, embedded SHA
verified):
- ✅ Full suite: identical to the same-day stock baseline (3 known
  environment fails + 1 quarantined skip; zero new failures) — now with
  `cw_sidetone_test` included for the first time.
- ✅ New + existing unit coverage as above.
- ✅ "Before" baselines banked: the reporter's macOS log/WAV (above) and a
  same-protocol Linux stock baseline (n=336 held dits @30 WPM,
  mean 40.17 sd 0.38).

Done since opening:
- ✅ **Linux held-dit after-arm** — measured and posted in [the readings comment](https://github.com/aethersdr/AetherSDR/pull/4823#issuecomment-5221570556): idle mean 39.996 ms sd 0.06 (vs stock 40.17/0.38), exact 30.000 WPM cumulative; plus a labeled compile-load stress arm and a HaliKey MIDI transport-equivalence pass.

- ✅ macOS before/after on real hardware (Intel MBP 2019, HaliKey Serial v1.3,
  dummy load): stock 3a1f59ea = 45.70 ms/unit → 26.26 WPM at a 30 WPM setting;
  fixed e1233704 = 40.002 ms/unit → 29.998 WPM. Readings + evidence bundle:
  https://github.com/aethersdr/AetherSDR/pull/4823#issuecomment-5222310007
- The issue thread carries @williamscody's offer to re-test on his M2 and
  @nigelfenton's offer to bench the Windows/PortAudio side.

### Known limitations

- On just-in-time pull sinks (PortAudio), an edge whose timestamp precedes
  the callback clamps to the block start, so sub-block placement there is
  bounded by callback cadence; removing that residual needs the sink's
  reported output latency plumbed into the mapping — noted as a possible
  follow-up, not attempted here.
- After an extreme scheduler stall mid-burst (e.g. system suspend), the
  grid emits compressed catch-up elements — the same exposure the #3644
  `CwxLocalKeyer` pattern accepted.

— authored by agent (Claude Code) on behalf of @skerker

