### PR TITLE
fix(gui): restore frameless move/resize under QT_QPA_PLATFORM=xcb (#4827)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5523,6 +5523,16 @@ set_tests_properties(connection_panel_size_test PROPERTIES
 # resize path end-to-end (see FramelessResizer.h), so this is coverage for
 # the arithmetic and parent-chain matching in isolation, not a replacement
 # for the PR's own real-X11-input proof.
+#
+# Compiled and linked by the Linux build job, but not currently in any of
+# ci.yml's named ctest -R filters for the per-PR gate — CI building it
+# without running it (per-PR) is the only thing exercising it today; the
+# weekly sanitizers job is the sole scheduled `ctest` run that includes it
+# by not filtering, and per ci.yml that job has failed every run since
+# 2026-06-08. Pure arithmetic and four bare QWindows, no widgets/sockets/
+# wall clock, milliseconds to run — a reasonable candidate for one of the
+# per-PR filters, but that's a maintainer call on the gate's scope, not
+# this PR's to make unilaterally.
 add_executable(frameless_resizer_test
     tests/frameless_resizer_test.cpp
     src/gui/FramelessResizer.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5518,6 +5518,24 @@ add_test(NAME connection_panel_size_test COMMAND connection_panel_size_test)
 set_tests_properties(connection_panel_size_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
+# FramelessResizer's clampManualResize()/windowOwnsChain() pure-logic
+# helpers (#4827/#4829 review). offscreen never exercises the real manual
+# resize path end-to-end (see FramelessResizer.h), so this is coverage for
+# the arithmetic and parent-chain matching in isolation, not a replacement
+# for the PR's own real-X11-input proof.
+add_executable(frameless_resizer_test
+    tests/frameless_resizer_test.cpp
+    src/gui/FramelessResizer.cpp
+)
+target_include_directories(frameless_resizer_test PRIVATE src tests)
+target_link_libraries(frameless_resizer_test PRIVATE
+    aethercore Qt6::Core Qt6::Network Qt6::Widgets Qt6::Test
+)
+set_target_properties(frameless_resizer_test PROPERTIES AUTOMOC ON)
+add_test(NAME frameless_resizer_test COMMAND frameless_resizer_test)
+set_tests_properties(frameless_resizer_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 # FlexControl port-loss recovery (#4574). Guarded on SERIALPORT for the same
 # reason FlexControlManager itself is: the whole class is inside
 # #ifdef HAVE_SERIALPORT, so without Qt SerialPort there is nothing to test.

--- a/src/gui/FramelessMoveHelper.h
+++ b/src/gui/FramelessMoveHelper.h
@@ -16,16 +16,26 @@ namespace AetherSDR::FramelessMoveHelper {
 // silently dropped: the press is consumed, but the window never
 // actually tracks the pointer (#4827). Qt's own QSizeGrip hits the same wall
 // and works around it in usePlatformSizeGrip() (qsizegrip.cpp) by refusing
-// the platform path on xcb and dragging the geometry manually instead —
-// every frameless move/resize path in AetherSDR follows that same rule,
-// clause for clause: usePlatformSizeGrip() also refuses the platform path on
-// Windows when the top-level has Qt::WA_TranslucentBackground set
-// (QTBUG-90628 — flicker combining native resize with a translucent
-// top-level there), which AetherSDR's own MainWindow sets whenever frameless
-// mode is on (`setAttribute(Qt::WA_TranslucentBackground, true)` in
-// MainWindow.cpp). `window` may be null for a caller with no widget handy;
-// the Windows clause then simply doesn't apply, same as if the attribute
-// were unset.
+// the platform path on xcb and dragging the geometry manually instead — the
+// Windows clause below matches that precedent clause for clause (Windows +
+// Qt::WA_TranslucentBackground, QTBUG-90628, flicker combining native resize
+// with a translucent top-level there — which AetherSDR's own MainWindow sets
+// whenever frameless mode is on). The xcb clause does not: Qt's own guard is
+// resize-only, with no equivalent for startSystemMove() anywhere in qtbase.
+// This helper applies its xcb refusal to *both*, which is evidence-backed
+// for #4827's own reported Mutter/XWayland environment (`_NET_WM_MOVERESIZE`
+// demonstrably does nothing there) but also takes the WM-driven move path —
+// and with it edge-snap/tiling gestures, and the _NET_WM_SYNC_REQUEST
+// handshake the FramelessResizer header credits for the absence of its
+// resize-shimmer artifact — away from a plain X11 session (KWin/X11, Xfwm,
+// i3, …) where that grab may work fine and was never tested against this
+// change. Narrowing to XWayland specifically
+// (`qEnvironmentVariableIsSet("WAYLAND_DISPLAY")` alongside the xcb check)
+// is possible without a new dependency if this is ever revisited; left as
+// the broader xcb-wide refusal for now rather than changing move behavior
+// for an environment nobody here could test against.
+// `window` may be null for a caller with no widget handy; the Windows
+// clause then simply doesn't apply, same as if the attribute were unset.
 inline bool systemMoveResizeUnreliable(const QWidget* window)
 {
     const QString platform = QGuiApplication::platformName();

--- a/src/gui/FramelessMoveHelper.h
+++ b/src/gui/FramelessMoveHelper.h
@@ -1,11 +1,27 @@
 #pragma once
 
+#include <QGuiApplication>
 #include <QMouseEvent>
 #include <QPoint>
 #include <QWidget>
 #include <QWindow>
 
 namespace AetherSDR::FramelessMoveHelper {
+
+// QWindow::startSystemMove()/startSystemResize() report success on the xcb
+// platform, but the WM-driven interactive move/resize grab they hand off to
+// is unreliable there (upstream QTBUG-69716) — under at least Mutter/XWayland
+// (the common case for `QT_QPA_PLATFORM=xcb` on a Wayland desktop — the
+// workaround for the native-Wayland panadapter stall, #4725) the request is
+// silently dropped: the press is consumed, but the window never
+// actually tracks the pointer (#4827). Qt's own QSizeGrip hits the same wall
+// and works around it in usePlatformSizeGrip() by refusing the platform path
+// on xcb and dragging the geometry manually instead — every frameless
+// move/resize path in AetherSDR follows that same rule.
+inline bool systemMoveResizeUnreliable()
+{
+    return QGuiApplication::platformName().contains(QLatin1String("xcb"));
+}
 
 namespace Detail {
 
@@ -41,10 +57,12 @@ inline bool start(QWidget* handle, QMouseEvent* ev)
     }
 
 #ifndef Q_OS_MAC
-    if (QWindow* windowHandle = window->windowHandle()) {
-        if (windowHandle->startSystemMove()) {
-            ev->accept();
-            return true;
+    if (!systemMoveResizeUnreliable()) {
+        if (QWindow* windowHandle = window->windowHandle()) {
+            if (windowHandle->startSystemMove()) {
+                ev->accept();
+                return true;
+            }
         }
     }
 #endif

--- a/src/gui/FramelessMoveHelper.h
+++ b/src/gui/FramelessMoveHelper.h
@@ -15,12 +15,28 @@ namespace AetherSDR::FramelessMoveHelper {
 // workaround for the native-Wayland panadapter stall, #4725) the request is
 // silently dropped: the press is consumed, but the window never
 // actually tracks the pointer (#4827). Qt's own QSizeGrip hits the same wall
-// and works around it in usePlatformSizeGrip() by refusing the platform path
-// on xcb and dragging the geometry manually instead — every frameless
-// move/resize path in AetherSDR follows that same rule.
-inline bool systemMoveResizeUnreliable()
+// and works around it in usePlatformSizeGrip() (qsizegrip.cpp) by refusing
+// the platform path on xcb and dragging the geometry manually instead —
+// every frameless move/resize path in AetherSDR follows that same rule,
+// clause for clause: usePlatformSizeGrip() also refuses the platform path on
+// Windows when the top-level has Qt::WA_TranslucentBackground set
+// (QTBUG-90628 — flicker combining native resize with a translucent
+// top-level there), which AetherSDR's own MainWindow sets whenever frameless
+// mode is on (`setAttribute(Qt::WA_TranslucentBackground, true)` in
+// MainWindow.cpp). `window` may be null for a caller with no widget handy;
+// the Windows clause then simply doesn't apply, same as if the attribute
+// were unset.
+inline bool systemMoveResizeUnreliable(const QWidget* window)
 {
-    return QGuiApplication::platformName().contains(QLatin1String("xcb"));
+    const QString platform = QGuiApplication::platformName();
+    if (platform.contains(QLatin1String("xcb"))) {
+        return true;
+    }
+    if (window && window->testAttribute(Qt::WA_TranslucentBackground)
+        && platform == QLatin1String("windows")) {
+        return true;
+    }
+    return false;
 }
 
 namespace Detail {
@@ -57,7 +73,7 @@ inline bool start(QWidget* handle, QMouseEvent* ev)
     }
 
 #ifndef Q_OS_MAC
-    if (!systemMoveResizeUnreliable()) {
+    if (!systemMoveResizeUnreliable(window)) {
         if (QWindow* windowHandle = window->windowHandle()) {
             if (windowHandle->startSystemMove()) {
                 ev->accept();

--- a/src/gui/FramelessResizer.cpp
+++ b/src/gui/FramelessResizer.cpp
@@ -7,6 +7,7 @@
 #include <QEvent>
 #include <QGuiApplication>
 #include <QMouseEvent>
+#include <QTimer>
 #include <QWidget>
 #include <QWindow>
 #include <algorithm>
@@ -48,9 +49,9 @@ FramelessResizer::~FramelessResizer()
     leaveEdgeZone();
 }
 
-bool FramelessResizer::ownsWindow(QWindow* win) const
+// static
+bool FramelessResizer::windowOwnsChain(const QWindow* win, const QWindow* mine)
 {
-    QWindow* mine = m_window->windowHandle();
     if (!win || !mine) {
         return false;
     }
@@ -62,12 +63,17 @@ bool FramelessResizer::ownsWindow(QWindow* win) const
     // standing workaround for platform window-state bugs.  The parent chain
     // carries no such dependency.  A separate top-level (a dialog) has a null
     // parent() and only a transientParent, so this never reaches across windows.
-    for (QWindow* w = win; w; w = w->parent()) {
+    for (const QWindow* w = win; w; w = w->parent()) {
         if (w == mine) {
             return true;
         }
     }
     return false;
+}
+
+bool FramelessResizer::ownsWindow(QWindow* win) const
+{
+    return windowOwnsChain(win, m_window->windowHandle());
 }
 
 Qt::Edges FramelessResizer::edgesAt(const QPoint& p) const
@@ -144,8 +150,10 @@ void FramelessResizer::beginManualResize(Qt::Edges edges, const QPoint& pressGlo
     // grab isn't fatal — motion events still arrive while the pointer stays
     // over one of our own windows — but a fast drag can then outrun the window
     // and stall, so it's worth a log line to explain a report of that.
+    m_manualResizeGrabbed = false;
     if (QWindow* handle = m_window->windowHandle()) {
-        if (!handle->setMouseGrabEnabled(true)) {
+        m_manualResizeGrabbed = handle->setMouseGrabEnabled(true);
+        if (!m_manualResizeGrabbed) {
             qCWarning(lcGui) << "FramelessResizer: mouse grab denied for manual "
                                  "resize; drag may stall if the pointer outruns "
                                  "the window";
@@ -153,46 +161,58 @@ void FramelessResizer::beginManualResize(Qt::Edges edges, const QPoint& pressGlo
     }
 }
 
-void FramelessResizer::continueManualResize(const QPoint& globalPos)
+// static
+QRect FramelessResizer::clampManualResize(const QRect& startGeom, const QPoint& delta,
+                                           Qt::Edges edges, const QSize& floor,
+                                           const QSize& ceiling)
 {
-    const QPoint delta = globalPos - m_manualResizePressGlobal;
-    QRect geom = m_manualResizeStartGeom;
+    QRect geom = startGeom;
 
     // The effective floor is the explicit minimum *and* whatever the layout
     // demands.  Clamping on minimumWidth()/minimumHeight() alone lets us ask
     // for a size Qt then silently grows back, and because it grows the size
     // while we keep moving the origin, the edge we are supposed to be holding
-    // still drifts.  Snapshotted once in beginManualResize() rather than
-    // recomputed here on every motion event.
-    const int minW = m_manualResizeFloor.width();
-    const int minH = m_manualResizeFloor.height();
-    const int maxW = m_window->maximumWidth();
-    const int maxH = m_window->maximumHeight();
+    // still drifts.  `floor` is snapshotted once in beginManualResize()
+    // rather than recomputed here on every motion event.
+    const int minW = floor.width();
+    const int minH = floor.height();
+    const int maxW = ceiling.width();
+    const int maxH = ceiling.height();
 
-    if (m_manualResizeEdges & Qt::LeftEdge) {
+    if (edges & Qt::LeftEdge) {
         int newLeft = geom.left() + delta.x();
         newLeft = std::min(newLeft, geom.right() - minW + 1);
         newLeft = std::max(newLeft, geom.right() - maxW + 1);
         geom.setLeft(newLeft);
     }
-    if (m_manualResizeEdges & Qt::RightEdge) {
+    if (edges & Qt::RightEdge) {
         int newRight = geom.right() + delta.x();
         newRight = std::max(newRight, geom.left() + minW - 1);
         newRight = std::min(newRight, geom.left() + maxW - 1);
         geom.setRight(newRight);
     }
-    if (m_manualResizeEdges & Qt::TopEdge) {
+    if (edges & Qt::TopEdge) {
         int newTop = geom.top() + delta.y();
         newTop = std::min(newTop, geom.bottom() - minH + 1);
         newTop = std::max(newTop, geom.bottom() - maxH + 1);
         geom.setTop(newTop);
     }
-    if (m_manualResizeEdges & Qt::BottomEdge) {
+    if (edges & Qt::BottomEdge) {
         int newBottom = geom.bottom() + delta.y();
         newBottom = std::max(newBottom, geom.top() + minH - 1);
         newBottom = std::min(newBottom, geom.top() + maxH - 1);
         geom.setBottom(newBottom);
     }
+    return geom;
+}
+
+void FramelessResizer::continueManualResize(const QPoint& globalPos)
+{
+    const QPoint delta = globalPos - m_manualResizePressGlobal;
+    const QSize ceiling(m_window->maximumWidth(), m_window->maximumHeight());
+    const QRect geom = clampManualResize(m_manualResizeStartGeom, delta,
+                                          m_manualResizeEdges, m_manualResizeFloor,
+                                          ceiling);
 
     // Skip no-op requests: several motion events can map to the same geometry,
     // and there is no reason to ask the platform to apply a geometry it is
@@ -210,6 +230,7 @@ void FramelessResizer::endManualResize()
         return;
     }
     m_manualResizeActive = false;
+    m_manualResizeGrabbed = false;
     m_manualResizeEdges = {};
     if (QWindow* handle = m_window->windowHandle()) {
         handle->setMouseGrabEnabled(false);
@@ -235,13 +256,18 @@ bool FramelessResizer::eventFilter(QObject* obj, QEvent* ev)
 
     // Window-level events only: widget-level MouseMove is gated on the widget
     // having opted into mouse tracking, so it can't be relied on for hover.
-    // While a manual drag holds the grab every event in it is ours by
-    // definition — the pointer may well be outside the window by then.
+    // While a manual drag genuinely holds the grab, every event in it is ours
+    // by definition — the pointer may well be outside the window by then —
+    // but only once that grab actually succeeded (m_manualResizeGrabbed); a
+    // denied grab gives us no exclusivity guarantee, so without it we still
+    // require ownsWindow() like any other event, accepting that a fast drag
+    // may then stall if the pointer outruns the window (beginManualResize()
+    // already warns about that case).
     auto* win = qobject_cast<QWindow*>(obj);
     if (!win) {
         return false;
     }
-    if (!m_manualResizeActive && !ownsWindow(win)) {
+    if (!(m_manualResizeActive && m_manualResizeGrabbed) && !ownsWindow(win)) {
         // Pointer activity somewhere else while our override cursor is still
         // up: a popup that opened under a stationary pointer takes the events
         // without us ever seeing the move that would have cleared it.  The
@@ -313,16 +339,30 @@ bool FramelessResizer::eventFilter(QObject* obj, QEvent* ev)
         const QPoint global = me->globalPosition().toPoint();
         const Qt::Edges edges = edgesAt(m_window->mapFromGlobal(global));
         if (edges && m_window->windowHandle()) {
-            if (FramelessMoveHelper::systemMoveResizeUnreliable()) {
-                // xcb: startSystemResize() would report success but the
-                // WM-driven grab it hands off to doesn't actually work
-                // (QTBUG-69716) — drag the geometry ourselves instead, the same
-                // fallback Qt's own QSizeGrip uses.  The edge cursor stays up
-                // for the duration since the WM isn't showing one.
+            if (FramelessMoveHelper::systemMoveResizeUnreliable(m_window)) {
+                // xcb (or Windows+translucent): startSystemResize() would
+                // report success but the WM-driven grab it hands off to
+                // doesn't actually work (QTBUG-69716 / QTBUG-90628) — drag
+                // the geometry ourselves instead, the same fallback Qt's own
+                // QSizeGrip uses. The edge cursor stays up for the duration
+                // since the WM isn't showing one.
                 beginManualResize(edges, global);
             } else {
-                leaveEdgeZone();  // hand cursor control back to the OS
-                m_window->windowHandle()->startSystemResize(edges);
+                // startSystemResize() reports success/failure honestly
+                // everywhere except the cases handled above — except macOS:
+                // QCocoaWindow has no override at all and unconditionally
+                // returns false (never implemented, not a QTBUG), so without
+                // checking this the press is consumed below and nothing
+                // happens: the exact xcb failure mode, now on macOS. Fall
+                // back to the same manual drag the branch above uses,
+                // keeping our own cursor up for it exactly as that path
+                // does — only hand cursor control to the OS once its own
+                // grab actually took the resize.
+                if (m_window->windowHandle()->startSystemResize(edges)) {
+                    leaveEdgeZone();
+                } else {
+                    beginManualResize(edges, global);
+                }
             }
             return true;      // consume: no widget should receive this press
         }
@@ -354,14 +394,30 @@ bool FramelessResizer::eventFilter(QObject* obj, QEvent* ev)
     case QEvent::Leave:
         // Only drop the cursor once the pointer has really left the window —
         // crossing between this window's native children raises Leave too, and
-        // resetting on those would make the edge cursor flicker.  underMouse()
-        // rather than QCursor::pos(): the latter is a live global-cursor query,
-        // unreliable on native Wayland for the same reason the press handler
-        // above stopped using it, and there is no equivalent to the left/top-drag
-        // trailing problem here to justify the risk — Leave never fires mid-drag
-        // (m_manualResizeActive is already excluded above).
-        if (!m_manualResizeActive && !m_window->underMouse()) {
-            leaveEdgeZone();
+        // resetting on those would make the edge cursor flicker. Checked one
+        // event-loop turn later, not inline: WA_UnderMouse for the widget that
+        // owns this event is updated by that widget's own event() handling,
+        // which — like every receiver's event() — runs *after* the
+        // application-level filters (this one included) during the very same
+        // Leave dispatch. Reading m_window->underMouse() inline would see the
+        // pre-update, stale value and never fire, leaving the resize cursor
+        // stranded whenever the pointer leaves through a corner without a
+        // MouseMove first landing outside the margin. QCursor::pos() would
+        // dodge that timing problem but reintroduces the Wayland global-
+        // cursor-query unreliability the press handler above already moved
+        // away from. Deferring past this turn — including any Enter that
+        // immediately follows when the pointer actually just crossed into a
+        // different native child — lets Qt finish updating the attribute
+        // first, so underMouse() is authoritative by the time the deferred
+        // check runs. this is the QObject context: the connection (and this
+        // lambda) is dropped automatically if the resizer or its window is
+        // destroyed before the timer fires.
+        if (!m_manualResizeActive) {
+            QTimer::singleShot(0, this, [this]() {
+                if (!m_manualResizeActive && m_window && !m_window->underMouse()) {
+                    leaveEdgeZone();
+                }
+            });
         }
         break;
 

--- a/src/gui/FramelessResizer.cpp
+++ b/src/gui/FramelessResizer.cpp
@@ -27,11 +27,17 @@ FramelessResizer::FramelessResizer(QWidget* window, int margin, int topMoveReser
     // eventFilter() bails on the first switch for anything that isn't a mouse
     // event, so the cost to unrelated event traffic is a type comparison — but
     // every open frameless window installs its own instance, so that
-    // comparison runs once per instance per event: O(open frameless windows)
-    // per mouse event, application-wide. Ten call sites today (`grep -rn
-    // "FramelessResizer::install" src/`), all top-level windows/dialogs rather
-    // than something instantiated per-item, so the constant stays small;
-    // worth a second look if that stops being true.
+    // comparison runs once per instance per event: O(live FramelessResizer
+    // instances) per mouse event, application-wide. Ten call sites today
+    // (`grep -rn "FramelessResizer::install" src/`), but one of them is
+    // PersistentDialog's own constructor — `grep -rn "public PersistentDialog"
+    // src/` finds 40 subclasses today, and PersistentDialog sets no
+    // WA_DeleteOnClose, so an instance survives its dialog being closed (just
+    // hidden) and the live count grows with every *distinct dialog type* the
+    // operator has opened at least once this session, not bounded by the ten
+    // call sites. Still cheap per filter — a type compare, then a
+    // qobject_cast and a short parent-chain walk — but watch instance count,
+    // not call sites, if this ever shows up in a profile.
     if (QCoreApplication* app = QCoreApplication::instance()) {
         app->installEventFilter(this);
     }
@@ -76,36 +82,61 @@ bool FramelessResizer::ownsWindow(QWindow* win) const
     return windowOwnsChain(win, m_window->windowHandle());
 }
 
-Qt::Edges FramelessResizer::edgesAt(const QPoint& p) const
+// static
+Qt::Edges FramelessResizer::computeEdges(const QRect& rect, const QPoint& p, int margin,
+                                          int topMoveReserve, bool maximizedOrFullscreen)
 {
     // A maximized or fullscreen window must not resize from an edge drag — the
     // compositor owns its geometry. Previously each adopter guarded this in its
     // own edgesAt(); centralizing it here closes the gap for every adopter
     // (#4266).
-    if (m_window->isMaximized() || m_window->isFullScreen()) {
+    if (maximizedOrFullscreen) {
         return {};
     }
     // Reserve an edge-to-edge top move handle (e.g. a full-width title bar) for
     // the window's own move handling rather than the top-edge resize zone, so a
     // title-bar grab isn't consumed as a resize (#4266). Resize still works
     // everywhere below the reserved strip.
-    if (m_topMoveReserve > 0 && p.y() < m_topMoveReserve) {
+    if (topMoveReserve > 0 && p.y() < topMoveReserve) {
         return {};
     }
-    const QRect r = m_window->rect();
     // Events now arrive from native children and carry global coordinates, so
     // a point outside the window is reachable in a way it wasn't before.
-    if (!r.contains(p)) {
+    if (!rect.contains(p)) {
         return {};
     }
     Qt::Edges edges;
-    if (p.x() <= m_margin)              edges |= Qt::LeftEdge;
-    if (p.x() >= r.width()  - m_margin) edges |= Qt::RightEdge;
-    if (p.y() <= m_margin)              edges |= Qt::TopEdge;
-    if (p.y() >= r.height() - m_margin) edges |= Qt::BottomEdge;
+    if (p.x() <= margin)                   edges |= Qt::LeftEdge;
+    if (p.x() >= rect.width()  - margin)   edges |= Qt::RightEdge;
+    if (p.y() <= margin)                   edges |= Qt::TopEdge;
+    if (p.y() >= rect.height() - margin)   edges |= Qt::BottomEdge;
     return edges;
 }
 
+// static
+bool FramelessResizer::shouldEndOnUngrabbedLeave(bool manualResizeActive,
+                                                  bool manualResizeGrabbed)
+{
+    return manualResizeActive && !manualResizeGrabbed;
+}
+
+Qt::Edges FramelessResizer::edgesAt(const QPoint& p) const
+{
+    return computeEdges(m_window->rect(), p, m_margin, m_topMoveReserve,
+                         m_window->isMaximized() || m_window->isFullScreen());
+}
+
+// Known limitation, not fixed here: QGuiApplication::setOverrideCursor()/
+// restoreOverrideCursor() is a single global LIFO stack shared by every
+// FramelessResizer instance (one per open frameless window/dialog — see the
+// constructor). Two places can now pop a turn after the push that logically
+// owns them — the deferred QEvent::Leave check below, and the cross-window
+// pop in eventFilter() when the pointer lands on an unowned window — so if a
+// second instance pushes its own override cursor in between, the deferred
+// pop here restores *that* instance's entry instead of this one's. Push/pop
+// stay balanced (nothing leaks), so the only visible effect is a transiently
+// wrong cursor shape right when the pointer crosses from one frameless
+// window's edge straight onto another's.
 void FramelessResizer::enterEdgeZone(Qt::Edges edges)
 {
     if (edges == m_lastEdges && m_cursorOverridden) return;
@@ -250,10 +281,6 @@ bool FramelessResizer::eventFilter(QObject* obj, QEvent* ev)
         return false;   // the overwhelmingly common path
     }
 
-    if (!m_window) {
-        return false;
-    }
-
     // Window-level events only: widget-level MouseMove is gated on the widget
     // having opted into mouse tracking, so it can't be relied on for hover.
     // While a manual drag genuinely holds the grab, every event in it is ours
@@ -280,9 +307,15 @@ bool FramelessResizer::eventFilter(QObject* obj, QEvent* ev)
     }
 
     // Hands off when the window has native decorations — the OS handles resize.
-    // endManualResize() rather than leaveEdgeZone(): a frameless toggle midway
-    // through a drag would otherwise leave the grab held and the active flag
-    // set, and that flag bypasses the ownership check above.
+    // endManualResize() rather than leaveEdgeZone() alone: a frameless toggle
+    // midway through a drag would otherwise leave the grab held and the
+    // active flag set, and that flag bypasses the ownership check above.
+    // The explicit leaveEdgeZone() below is not redundant with the one
+    // endManualResize() ends with: that one is skipped by endManualResize()'s
+    // own early return whenever m_manualResizeActive is already false, which
+    // is exactly the toggle-while-only-hovering case — no drag in progress,
+    // just an edge cursor up from a hover — where this call is the only
+    // thing that clears it.
     if (!(m_window->windowFlags() & Qt::FramelessWindowHint)) {
         endManualResize();
         leaveEdgeZone();
@@ -392,6 +425,24 @@ bool FramelessResizer::eventFilter(QObject* obj, QEvent* ev)
     }
 
     case QEvent::Leave:
+        if (shouldEndOnUngrabbedLeave(m_manualResizeActive, m_manualResizeGrabbed)) {
+            // Denied grab (beginManualResize() already warned about this):
+            // once the pointer leaves our own window we stop receiving any
+            // events for it at all — including the MouseButtonRelease that
+            // would normally end the drag — because without a real grab,
+            // ownsWindow() is back in effect up in eventFilter() and nothing
+            // outside this window is "ours" any more. Left alone,
+            // m_manualResizeActive stays true (this same guard would also
+            // block the branch below from clearing it), and a *second*
+            // press elsewhere followed by a move back over this window
+            // would resume the drag from the now stale
+            // m_manualResizePressGlobal, snapping the window across
+            // whatever gap the pointer covered in between. End it here
+            // instead — the ungrabbed case was already a best-effort
+            // fallback (see beginManualResize()), not a guarantee.
+            endManualResize();
+            break;
+        }
         // Only drop the cursor once the pointer has really left the window —
         // crossing between this window's native children raises Leave too, and
         // resetting on those would make the edge cursor flicker. Checked one

--- a/src/gui/FramelessResizer.cpp
+++ b/src/gui/FramelessResizer.cpp
@@ -1,5 +1,6 @@
 #include "FramelessResizer.h"
 #include "FramelessMoveHelper.h"
+#include "core/LogManager.h"
 
 #include <QCoreApplication>
 #include <QCursor>
@@ -23,7 +24,13 @@ FramelessResizer::FramelessResizer(QWidget* window, int margin, int topMoveReser
 {
     // Application-wide rather than per-QWindow: see quirk 1 in the header.
     // eventFilter() bails on the first switch for anything that isn't a mouse
-    // event, so the cost to unrelated event traffic is a type comparison.
+    // event, so the cost to unrelated event traffic is a type comparison — but
+    // every open frameless window installs its own instance, so that
+    // comparison runs once per instance per event: O(open frameless windows)
+    // per mouse event, application-wide. Ten call sites today (`grep -rn
+    // "FramelessResizer::install" src/`), all top-level windows/dialogs rather
+    // than something instantiated per-item, so the constant stays small;
+    // worth a second look if that stops being true.
     if (QCoreApplication* app = QCoreApplication::instance()) {
         app->installEventFilter(this);
     }
@@ -127,11 +134,22 @@ void FramelessResizer::beginManualResize(Qt::Edges edges, const QPoint& pressGlo
     m_manualResizePressGlobal = pressGlobal;
     m_manualResizeStartGeom = m_window->geometry();
     m_manualResizeLastRequested = m_manualResizeStartGeom;
+    // Snapshot once here rather than recomputing in continueManualResize() on
+    // every motion event: minimumSizeHint() walks the widget's layout, and a
+    // drag can produce dozens of moves before the release.
+    m_manualResizeFloor = m_window->minimumSize().expandedTo(m_window->minimumSizeHint());
     // Keep receiving motion even when the pointer outruns the window or crosses
     // a native child.  startSystemResize() would have had the WM guarantee this;
-    // driving the drag ourselves means asking for the grab ourselves.
+    // driving the drag ourselves means asking for the grab ourselves.  A failed
+    // grab isn't fatal — motion events still arrive while the pointer stays
+    // over one of our own windows — but a fast drag can then outrun the window
+    // and stall, so it's worth a log line to explain a report of that.
     if (QWindow* handle = m_window->windowHandle()) {
-        handle->setMouseGrabEnabled(true);
+        if (!handle->setMouseGrabEnabled(true)) {
+            qCWarning(lcGui) << "FramelessResizer: mouse grab denied for manual "
+                                 "resize; drag may stall if the pointer outruns "
+                                 "the window";
+        }
     }
 }
 
@@ -144,10 +162,10 @@ void FramelessResizer::continueManualResize(const QPoint& globalPos)
     // demands.  Clamping on minimumWidth()/minimumHeight() alone lets us ask
     // for a size Qt then silently grows back, and because it grows the size
     // while we keep moving the origin, the edge we are supposed to be holding
-    // still drifts.
-    const QSize floor = m_window->minimumSize().expandedTo(m_window->minimumSizeHint());
-    const int minW = floor.width();
-    const int minH = floor.height();
+    // still drifts.  Snapshotted once in beginManualResize() rather than
+    // recomputed here on every motion event.
+    const int minW = m_manualResizeFloor.width();
+    const int minH = m_manualResizeFloor.height();
     const int maxW = m_window->maximumWidth();
     const int maxH = m_window->maximumHeight();
 
@@ -336,9 +354,13 @@ bool FramelessResizer::eventFilter(QObject* obj, QEvent* ev)
     case QEvent::Leave:
         // Only drop the cursor once the pointer has really left the window —
         // crossing between this window's native children raises Leave too, and
-        // resetting on those would make the edge cursor flicker.
-        if (!m_manualResizeActive
-            && !m_window->rect().contains(m_window->mapFromGlobal(QCursor::pos()))) {
+        // resetting on those would make the edge cursor flicker.  underMouse()
+        // rather than QCursor::pos(): the latter is a live global-cursor query,
+        // unreliable on native Wayland for the same reason the press handler
+        // above stopped using it, and there is no equivalent to the left/top-drag
+        // trailing problem here to justify the risk — Leave never fires mid-drag
+        // (m_manualResizeActive is already excluded above).
+        if (!m_manualResizeActive && !m_window->underMouse()) {
             leaveEdgeZone();
         }
         break;

--- a/src/gui/FramelessResizer.cpp
+++ b/src/gui/FramelessResizer.cpp
@@ -1,10 +1,14 @@
 #include "FramelessResizer.h"
+#include "FramelessMoveHelper.h"
 
+#include <QCoreApplication>
+#include <QCursor>
 #include <QEvent>
 #include <QGuiApplication>
 #include <QMouseEvent>
 #include <QWidget>
 #include <QWindow>
+#include <algorithm>
 
 namespace AetherSDR {
 
@@ -17,25 +21,46 @@ FramelessResizer::FramelessResizer(QWidget* window, int margin, int topMoveReser
     : QObject(window), m_window(window), m_margin(margin),
       m_topMoveReserve(topMoveReserve)
 {
-    if (window->windowHandle()) {
-        // Native window already exists — install directly on it.
-        window->windowHandle()->installEventFilter(this);
-    } else {
-        // Native window not yet created (called from constructor before
-        // show()).  Install on the QWidget temporarily and migrate to the
-        // QWindow when WinIdChange fires.
-        window->installEventFilter(this);
+    // Application-wide rather than per-QWindow: see quirk 1 in the header.
+    // eventFilter() bails on the first switch for anything that isn't a mouse
+    // event, so the cost to unrelated event traffic is a type comparison.
+    if (QCoreApplication* app = QCoreApplication::instance()) {
+        app->installEventFilter(this);
     }
 }
 
 FramelessResizer::~FramelessResizer()
 {
-    // The override cursor is global state.  If we're destroyed while the
-    // cursor is currently overridden (window closed while hovering an
-    // edge, or fast cursor flick between windows that skipped the matching
-    // leaveEdgeZone), restore it now to avoid leaking the resize cursor
-    // onto the desktop or other windows.
+    // Only global state is cleaned up here.  This deliberately does not touch
+    // m_window: as a QObject child of that widget, this destructor runs during
+    // the widget's own teardown, when its native window may already be gone.
+    // An outstanding mouse grab dies with that window anyway; the override
+    // cursor does not, and leaking it would strand a resize cursor on the
+    // desktop or another window.
+    m_manualResizeActive = false;
     leaveEdgeZone();
+}
+
+bool FramelessResizer::ownsWindow(QWindow* win) const
+{
+    QWindow* mine = m_window->windowHandle();
+    if (!win || !mine) {
+        return false;
+    }
+    // Walk the window parent chain: a native child widget's window is parented
+    // to its nearest native ancestor's, so this catches every descendant.
+    // Deliberately not QWidget::find(winId()), which depends on the widget's id
+    // still being current in Qt's WId mapper — destroying and recreating a
+    // native window can invalidate that, and code doing exactly that is a
+    // standing workaround for platform window-state bugs.  The parent chain
+    // carries no such dependency.  A separate top-level (a dialog) has a null
+    // parent() and only a transientParent, so this never reaches across windows.
+    for (QWindow* w = win; w; w = w->parent()) {
+        if (w == mine) {
+            return true;
+        }
+    }
+    return false;
 }
 
 Qt::Edges FramelessResizer::edgesAt(const QPoint& p) const
@@ -55,6 +80,11 @@ Qt::Edges FramelessResizer::edgesAt(const QPoint& p) const
         return {};
     }
     const QRect r = m_window->rect();
+    // Events now arrive from native children and carry global coordinates, so
+    // a point outside the window is reachable in a way it wasn't before.
+    if (!r.contains(p)) {
+        return {};
+    }
     Qt::Edges edges;
     if (p.x() <= m_margin)              edges |= Qt::LeftEdge;
     if (p.x() >= r.width()  - m_margin) edges |= Qt::RightEdge;
@@ -90,22 +120,127 @@ void FramelessResizer::leaveEdgeZone()
     }
 }
 
+void FramelessResizer::beginManualResize(Qt::Edges edges, const QPoint& pressGlobal)
+{
+    m_manualResizeActive = true;
+    m_manualResizeEdges = edges;
+    m_manualResizePressGlobal = pressGlobal;
+    m_manualResizeStartGeom = m_window->geometry();
+    m_manualResizeLastRequested = m_manualResizeStartGeom;
+    // Keep receiving motion even when the pointer outruns the window or crosses
+    // a native child.  startSystemResize() would have had the WM guarantee this;
+    // driving the drag ourselves means asking for the grab ourselves.
+    if (QWindow* handle = m_window->windowHandle()) {
+        handle->setMouseGrabEnabled(true);
+    }
+}
+
+void FramelessResizer::continueManualResize(const QPoint& globalPos)
+{
+    const QPoint delta = globalPos - m_manualResizePressGlobal;
+    QRect geom = m_manualResizeStartGeom;
+
+    // The effective floor is the explicit minimum *and* whatever the layout
+    // demands.  Clamping on minimumWidth()/minimumHeight() alone lets us ask
+    // for a size Qt then silently grows back, and because it grows the size
+    // while we keep moving the origin, the edge we are supposed to be holding
+    // still drifts.
+    const QSize floor = m_window->minimumSize().expandedTo(m_window->minimumSizeHint());
+    const int minW = floor.width();
+    const int minH = floor.height();
+    const int maxW = m_window->maximumWidth();
+    const int maxH = m_window->maximumHeight();
+
+    if (m_manualResizeEdges & Qt::LeftEdge) {
+        int newLeft = geom.left() + delta.x();
+        newLeft = std::min(newLeft, geom.right() - minW + 1);
+        newLeft = std::max(newLeft, geom.right() - maxW + 1);
+        geom.setLeft(newLeft);
+    }
+    if (m_manualResizeEdges & Qt::RightEdge) {
+        int newRight = geom.right() + delta.x();
+        newRight = std::max(newRight, geom.left() + minW - 1);
+        newRight = std::min(newRight, geom.left() + maxW - 1);
+        geom.setRight(newRight);
+    }
+    if (m_manualResizeEdges & Qt::TopEdge) {
+        int newTop = geom.top() + delta.y();
+        newTop = std::min(newTop, geom.bottom() - minH + 1);
+        newTop = std::max(newTop, geom.bottom() - maxH + 1);
+        geom.setTop(newTop);
+    }
+    if (m_manualResizeEdges & Qt::BottomEdge) {
+        int newBottom = geom.bottom() + delta.y();
+        newBottom = std::max(newBottom, geom.top() + minH - 1);
+        newBottom = std::min(newBottom, geom.top() + maxH - 1);
+        geom.setBottom(newBottom);
+    }
+
+    // Skip no-op requests: several motion events can map to the same geometry,
+    // and there is no reason to ask the platform to apply a geometry it is
+    // already at.
+    if (geom == m_manualResizeLastRequested) {
+        return;
+    }
+    m_manualResizeLastRequested = geom;
+    m_window->setGeometry(geom);
+}
+
+void FramelessResizer::endManualResize()
+{
+    if (!m_manualResizeActive) {
+        return;
+    }
+    m_manualResizeActive = false;
+    m_manualResizeEdges = {};
+    if (QWindow* handle = m_window->windowHandle()) {
+        handle->setMouseGrabEnabled(false);
+    }
+    leaveEdgeZone();
+}
+
 bool FramelessResizer::eventFilter(QObject* obj, QEvent* ev)
 {
-    // ── Phase 1: QWidget (pre-native-window) ─────────────────────────────
-    // Waiting for the native window to be created.  Once WinIdChange fires,
-    // migrate the filter to the QWindow and stay there.
-    if (obj == m_window) {
-        if (ev->type() == QEvent::WinIdChange && m_window->windowHandle()) {
-            m_window->removeEventFilter(this);
-            m_window->windowHandle()->installEventFilter(this);
+    switch (ev->type()) {
+    case QEvent::MouseMove:
+    case QEvent::MouseButtonPress:
+    case QEvent::MouseButtonRelease:
+    case QEvent::Leave:
+        break;
+    default:
+        return false;   // the overwhelmingly common path
+    }
+
+    if (!m_window) {
+        return false;
+    }
+
+    // Window-level events only: widget-level MouseMove is gated on the widget
+    // having opted into mouse tracking, so it can't be relied on for hover.
+    // While a manual drag holds the grab every event in it is ours by
+    // definition — the pointer may well be outside the window by then.
+    auto* win = qobject_cast<QWindow*>(obj);
+    if (!win) {
+        return false;
+    }
+    if (!m_manualResizeActive && !ownsWindow(win)) {
+        // Pointer activity somewhere else while our override cursor is still
+        // up: a popup that opened under a stationary pointer takes the events
+        // without us ever seeing the move that would have cleared it.  The
+        // override cursor is application-global, so drop it here rather than
+        // strand a resize cursor over an unrelated window.
+        if (m_cursorOverridden && ev->type() == QEvent::MouseMove) {
+            leaveEdgeZone();
         }
         return false;
     }
 
-    // ── Phase 2: QWindow (native handle) ─────────────────────────────────
     // Hands off when the window has native decorations — the OS handles resize.
+    // endManualResize() rather than leaveEdgeZone(): a frameless toggle midway
+    // through a drag would otherwise leave the grab held and the active flag
+    // set, and that flag bypasses the ownership check above.
     if (!(m_window->windowFlags() & Qt::FramelessWindowHint)) {
+        endManualResize();
         leaveEdgeZone();
         return false;
     }
@@ -114,9 +249,30 @@ bool FramelessResizer::eventFilter(QObject* obj, QEvent* ev)
 
     case QEvent::MouseMove: {
         auto* me = static_cast<QMouseEvent*>(ev);
+        if (m_manualResizeActive) {
+            // Require both the event's snapshot and the live state to agree the
+            // button is up.  Moving the window from continueManualResize() makes
+            // Qt deliver follow-up moves that can report no buttons held, and
+            // acting on one of those alone strands the resize part way through;
+            // the live state alone can equally go stale and never end the drag.
+            // A genuine release ends it through MouseButtonRelease below — this
+            // is only the backstop for one we never see, or a WM-broken grab.
+            if (!(me->buttons() & Qt::LeftButton)
+                && !(QGuiApplication::mouseButtons() & Qt::LeftButton)) {
+                endManualResize();
+                break;
+            }
+            // QCursor::pos(), not the event's globalPosition(): a left/top drag
+            // moves the window under the pointer, and Qt derives that field
+            // from a local coordinate against an origin we have just changed.
+            // It therefore trails the real pointer, and feeding it back in
+            // makes the anchored edge visibly wobble and the drag settle short.
+            continueManualResize(QCursor::pos());
+            return true;
+        }
         if (me->buttons() != Qt::NoButton) break;
-        // QWindow delivers mouse positions in window-local coordinates.
-        const Qt::Edges edges = edgesAt(me->position().toPoint());
+        const Qt::Edges edges =
+            edgesAt(m_window->mapFromGlobal(me->globalPosition().toPoint()));
         if (edges) {
             enterEdgeZone(edges);
         } else {
@@ -128,17 +284,63 @@ bool FramelessResizer::eventFilter(QObject* obj, QEvent* ev)
     case QEvent::MouseButtonPress: {
         auto* me = static_cast<QMouseEvent*>(ev);
         if (me->button() != Qt::LeftButton) break;
-        const Qt::Edges edges = edgesAt(me->position().toPoint());
+        // The event's own globalPosition(), not QCursor::pos(): this runs on
+        // every platform, including native Wayland where a global cursor-
+        // position query is a documented compositor limitation Qt can't fully
+        // paper over — a stale read here would compute the wrong edges (or
+        // none) for a resize that, unlike the xcb path below, actually goes
+        // through the platform's startSystemResize().  No lag risk taking it
+        // from the event: the window hasn't moved yet at press time, which is
+        // the only reason continueManualResize() needs QCursor::pos() instead.
+        const QPoint global = me->globalPosition().toPoint();
+        const Qt::Edges edges = edgesAt(m_window->mapFromGlobal(global));
         if (edges && m_window->windowHandle()) {
-            leaveEdgeZone();  // hand cursor control back to the OS
-            m_window->windowHandle()->startSystemResize(edges);
+            if (FramelessMoveHelper::systemMoveResizeUnreliable()) {
+                // xcb: startSystemResize() would report success but the
+                // WM-driven grab it hands off to doesn't actually work
+                // (QTBUG-69716) — drag the geometry ourselves instead, the same
+                // fallback Qt's own QSizeGrip uses.  The edge cursor stays up
+                // for the duration since the WM isn't showing one.
+                beginManualResize(edges, global);
+            } else {
+                leaveEdgeZone();  // hand cursor control back to the OS
+                m_window->windowHandle()->startSystemResize(edges);
+            }
             return true;      // consume: no widget should receive this press
         }
         break;
     }
 
+    case QEvent::MouseButtonRelease: {
+        // Only the button that started the drag ends it — a right-click part
+        // way through shouldn't abort the resize (and get swallowed doing it).
+        auto* me = static_cast<QMouseEvent*>(ev);
+        if (m_manualResizeActive && me->button() == Qt::LeftButton) {
+            // Settle on the release position rather than wherever the last
+            // motion event happened to leave us: under load the final move can
+            // be coalesced away, which would end the drag a few pixels short of
+            // where the pointer actually came up.
+            // QCursor::pos() rather than the event's globalPosition(): while a
+            // left/top drag is moving the window under the pointer, Qt derives
+            // that field from a local coordinate against an origin we have just
+            // changed, so it trails the real pointer by a motion event and the
+            // drag settles a few pixels short.  The live cursor position has no
+            // such dependency.
+            continueManualResize(QCursor::pos());
+            endManualResize();
+            return true;
+        }
+        break;
+    }
+
     case QEvent::Leave:
-        leaveEdgeZone();
+        // Only drop the cursor once the pointer has really left the window —
+        // crossing between this window's native children raises Leave too, and
+        // resetting on those would make the edge cursor flicker.
+        if (!m_manualResizeActive
+            && !m_window->rect().contains(m_window->mapFromGlobal(QCursor::pos()))) {
+            leaveEdgeZone();
+        }
         break;
 
     default:

--- a/src/gui/FramelessResizer.h
+++ b/src/gui/FramelessResizer.h
@@ -1,26 +1,50 @@
 #pragma once
 
 #include <QObject>
+#include <QPoint>
+#include <QRect>
 #include <Qt>
 
 class QWidget;
+class QWindow;
 
 namespace AetherSDR {
 
-// Adds all-edge resize to a Qt::FramelessWindowHint top-level QWidget using
-// QWindow::startSystemResize() — the same compositor-managed path used for
-// startSystemMove in TitleBar / ContainerWidget / PanadapterApplet.
+// Adds all-edge resize to a Qt::FramelessWindowHint top-level QWidget.
 //
-// The filter is installed on the QWindow (native handle) rather than on the
-// QWidget tree.  QWindow receives all platform mouse events *before* they
-// are dispatched to the widget hierarchy, so resize intent is detected across
-// the whole window without touching any child widget's event stream.  This
-// avoids breaking nested controls (knobs, drag tiles, sub-containers) that
-// happen to be near the window edges.
+// Two platform quirks shape this class (both surfaced chasing #4827 — edge
+// resize and title-bar move dead under `QT_QPA_PLATFORM=xcb`):
 //
-// Timing: the native QWindow is created lazily on first show().  If install()
-// is called before show() (e.g. from the constructor), the filter starts on
-// the QWidget itself and migrates to the QWindow on QEvent::WinIdChange.
+//  1. Native child windows.  The filter cannot live on the top-level QWindow.
+//     Once any child widget acquires a native window, Qt promotes all of its
+//     siblings to native too, and the platform then delivers pointer events to
+//     the *innermost* native window — so the top-level QWindow never sees them.
+//     MainWindow hits this: QStatusBar, the central QWidget, and QSizeGrip are
+//     all native, between them covering the whole client area, which left every
+//     edge dead while this same code worked fine on dialogs that happen to have
+//     no native children.  The filter therefore sits on the application object
+//     and matches events by resolving each event window back to its owning
+//     top-level widget.  Hover detection uses window-level events rather than
+//     widget-level ones because a button-less QEvent::MouseMove only reaches a
+//     widget that opted into setMouseTracking().
+//
+//  2. xcb.  QWindow::startSystemResize() reports success but the WM-driven grab
+//     it hands off to is unreliable there (QTBUG-69716 — see
+//     FramelessMoveHelper::systemMoveResizeUnreliable()), so the resizer drags
+//     the window geometry manually on that platform, the same fallback Qt's own
+//     QSizeGrip uses.
+//
+// Known artifact of that manual path: dragging an edge that moves the window
+// origin (left or top) can make the opposite edge appear to shimmer under a
+// compositor.  The geometry itself is exact — the requested opposite edge is
+// pinned by construction, and sampling the X window through a drag shows it
+// never deviates.  What moves is the presentation: a WM-driven resize withholds
+// the frame until the client acknowledges the new size (_NET_WM_SYNC_REQUEST),
+// whereas an app-driven setGeometry() gets no such handshake, so the compositor
+// can present content drawn for the previous size at the new origin.  Resizing
+// from the right or bottom never shows it, because with the origin fixed the
+// stale content is simply clipped.  Not reproducible via the platform path,
+// which is exactly the path this quirk denies us.
 //
 // Usage:
 //   FramelessResizer::install(this);       // from a QWidget constructor
@@ -45,11 +69,28 @@ private:
     void enterEdgeZone(Qt::Edges edges);
     void leaveEdgeZone();
 
+    // True when `win` is our top-level widget's window, or the window of one of
+    // its native descendants (quirk 1 above).
+    bool ownsWindow(QWindow* win) const;
+
+    // Manual drag fallback (xcb — quirk 2 above).  Anchors whichever edges
+    // weren't grabbed and resizes the rest by the pointer delta, clamped to the
+    // window's own min/max size.
+    void beginManualResize(Qt::Edges edges, const QPoint& pressGlobal);
+    void continueManualResize(const QPoint& globalPos);
+    void endManualResize();
+
     QWidget*  m_window{nullptr};
     int       m_margin{6};
     int       m_topMoveReserve{0};
     bool      m_cursorOverridden{false};
     Qt::Edges m_lastEdges{};
+
+    bool      m_manualResizeActive{false};
+    Qt::Edges m_manualResizeEdges{};
+    QPoint    m_manualResizePressGlobal;
+    QRect     m_manualResizeStartGeom;
+    QRect     m_manualResizeLastRequested;
 };
 
 } // namespace AetherSDR

--- a/src/gui/FramelessResizer.h
+++ b/src/gui/FramelessResizer.h
@@ -29,20 +29,49 @@ namespace AetherSDR {
 //     widget-level ones because a button-less QEvent::MouseMove only reaches a
 //     widget that opted into setMouseTracking().
 //
-//  2. xcb.  QWindow::startSystemResize() reports success but the WM-driven grab
-//     it hands off to is unreliable there (QTBUG-69716 — see
+//  2. xcb, and Windows+translucent.  QWindow::startSystemResize() reports
+//     success but the WM-driven grab it hands off to is unreliable there
+//     (QTBUG-69716 / QTBUG-90628 — see
 //     FramelessMoveHelper::systemMoveResizeUnreliable()), so the resizer drags
-//     the window geometry manually on that platform, the same fallback Qt's own
-//     QSizeGrip uses.
+//     the window geometry manually on those platforms, the same fallback Qt's
+//     own QSizeGrip uses. macOS is a third case, but a distinct one:
+//     QCocoaWindow has no startSystemResize() override at all and
+//     unconditionally returns false, so the press handler below falls back to
+//     the same manual drag whenever the call reports failure, rather than
+//     needing its own platform check.
 //
-// Cross-platform behavior change (quirk 1 is not xcb-specific): before this
-// fix, MainWindow's edge-hover/press events were swallowed by its native
-// children on every platform, not only xcb — the bug is about event routing
-// through native child promotion, which xcb testing merely surfaced. Moving
-// the filter application-wide therefore turns on a real 6px edge-resize band
-// on MainWindow everywhere, including platforms that previously reached this
-// class's edgesAt() with a dead filter and so never resized from an edge at
-// all.
+// Cross-platform behavior change (quirk 1 is not xcb-specific, but its actual
+// reach is narrower than "everywhere" — checked per platform rather than
+// asserted, see PR #4829): before this fix, MainWindow's edge-hover/press
+// events were swallowed by its native children wherever that promotion
+// happens, not only under xcb — the bug is about event routing through
+// native child promotion, which xcb testing merely surfaced. Moving the
+// filter application-wide turns on a real 6px edge-resize band on
+// MainWindow, but only where both preconditions hold:
+//   - MainWindow must actually be frameless. On Windows, MainWindow.cpp
+//     never sets Qt::FramelessWindowHint at all (`#ifndef Q_OS_WIN` around
+//     that call) — the FramelessWindowHint guard a few lines below then
+//     makes this whole class a no-op there regardless of the filter's
+//     reach, so quirk 1 has nothing to change on Windows.
+//   - Native child promotion must actually be happening. On macOS,
+//     SpectrumWidget deliberately blocks it: `applyNativeWindowIsolationPolicy()`
+//     (SpectrumWidget.cpp) pairs `Qt::WA_NativeWindow` (needed for its Metal
+//     QRhiWidget surface) with `Qt::WA_DontCreateNativeAncestors`
+//     specifically so that native leaf never promotes its QWidget ancestors
+//     (#4339) — the same cascade that leaves MainWindow's QStatusBar/central
+//     widget/QSizeGrip native on Linux. So quirk 1 doesn't reach MainWindow
+//     on macOS either. What exactly triggers the cascade on Linux/xcb
+//     specifically (as opposed to macOS's deliberately-blocked case) wasn't
+//     pinned down beyond the original `xwininfo -id <winid> -children`
+//     evidence — the fix doesn't depend on knowing why, only on native
+//     children provably swallowing events there.
+// Net effect: this class's practical reach for MainWindow is Linux/X11
+// (xcb) — real on that platform, a no-op on Windows, and a no-op for quirk 1
+// specifically on macOS (macOS still gets quirk 2's fallback for the
+// independent startSystemResize() problem above). Every other frameless
+// adopter (dialogs, floating panels) was unaffected by quirk 1 to begin
+// with, per the header's own note above that "this same code worked fine on
+// dialogs that happen to have no native children."
 //
 // Edge-resize itself is proven end-to-end, not just eyeballed: a real
 // XTestFakeButtonEvent/XTestFakeMotionEvent drag (genuine X11 input, not an
@@ -98,6 +127,28 @@ public:
     static void install(QWidget* window, int margin = 6, int topMoveReserve = 0);
     ~FramelessResizer() override;
 
+    // Pure logic pulled out of the private instance methods below so it's
+    // reachable from a unit test without constructing a real QWidget/QWindow
+    // hierarchy (frameless_resizer_test.cpp). Behavior is identical either
+    // way — continueManualResize()/ownsWindow() just forward into these.
+
+    // The clamping arithmetic continueManualResize() applies each motion
+    // event: anchors whichever edges aren't in `edges`, moves the rest by
+    // `delta`, and holds every edge within [floor, ceiling]. `floor` is
+    // already minimumSize().expandedTo(minimumSizeHint()) — see
+    // m_manualResizeFloor — and `ceiling` is
+    // {maximumWidth(), maximumHeight()}.
+    static QRect clampManualResize(const QRect& startGeom, const QPoint& delta,
+                                    Qt::Edges edges, const QSize& floor,
+                                    const QSize& ceiling);
+
+    // The parent-chain walk ownsWindow() applies: true when `win` is `mine`
+    // itself, or is parented (directly or transitively) to `mine` in the
+    // QWindow tree — the shape a native child's promoted window takes
+    // (quirk 1). A separate top-level (e.g. a dialog) has a null parent()
+    // and only a transientParent, so this never reaches across windows.
+    static bool windowOwnsChain(const QWindow* win, const QWindow* mine);
+
 protected:
     bool eventFilter(QObject* obj, QEvent* ev) override;
 
@@ -108,12 +159,12 @@ private:
     void leaveEdgeZone();
 
     // True when `win` is our top-level widget's window, or the window of one of
-    // its native descendants (quirk 1 above).
+    // its native descendants (quirk 1 above). Thin wrapper over windowOwnsChain().
     bool ownsWindow(QWindow* win) const;
 
     // Manual drag fallback (xcb — quirk 2 above).  Anchors whichever edges
     // weren't grabbed and resizes the rest by the pointer delta, clamped to the
-    // window's own min/max size.
+    // window's own min/max size. Thin wrapper over clampManualResize().
     void beginManualResize(Qt::Edges edges, const QPoint& pressGlobal);
     void continueManualResize(const QPoint& globalPos);
     void endManualResize();
@@ -125,6 +176,14 @@ private:
     Qt::Edges m_lastEdges{};
 
     bool      m_manualResizeActive{false};
+    // True only when setMouseGrabEnabled(true) actually succeeded in
+    // beginManualResize(). Gates the eventFilter() ownsWindow() bypass below
+    // it: without a real grab we have no exclusivity guarantee, so treating
+    // "a resize is active" alone as license to accept events from *any*
+    // window — including an unrelated dialog the user happens to be
+    // clicking in at the same time — would let that unrelated activity
+    // drive our resize.
+    bool      m_manualResizeGrabbed{false};
     Qt::Edges m_manualResizeEdges{};
     QPoint    m_manualResizePressGlobal;
     QRect     m_manualResizeStartGeom;

--- a/src/gui/FramelessResizer.h
+++ b/src/gui/FramelessResizer.h
@@ -3,6 +3,7 @@
 #include <QObject>
 #include <QPoint>
 #include <QRect>
+#include <QSize>
 #include <Qt>
 
 class QWidget;
@@ -33,6 +34,43 @@ namespace AetherSDR {
 //     FramelessMoveHelper::systemMoveResizeUnreliable()), so the resizer drags
 //     the window geometry manually on that platform, the same fallback Qt's own
 //     QSizeGrip uses.
+//
+// Cross-platform behavior change (quirk 1 is not xcb-specific): before this
+// fix, MainWindow's edge-hover/press events were swallowed by its native
+// children on every platform, not only xcb — the bug is about event routing
+// through native child promotion, which xcb testing merely surfaced. Moving
+// the filter application-wide therefore turns on a real 6px edge-resize band
+// on MainWindow everywhere, including platforms that previously reached this
+// class's edgesAt() with a dead filter and so never resized from an edge at
+// all.
+//
+// Edge-resize itself is proven end-to-end, not just eyeballed: a real
+// XTestFakeButtonEvent/XTestFakeMotionEvent drag (genuine X11 input, not an
+// app-level synthetic event — see PR #4829) on a running MainWindow's right
+// edge under xcb grew it by exactly the dragged delta, independently
+// confirmed by the resulting `display pan set … xpixels=` line the resize
+// pushed to the radio. AetherSDR's own automation-bridge pointer verbs were
+// tried first and don't work for this: `clickAt`/`dragAt`/`gesture`
+// synthesize `QMouseEvent`s straight to the target *QWidget* via
+// `QCoreApplication::sendEvent()`, never to its QWindow, so they never reach
+// this filter, which by design (quirk 1 above) only acts on window-level
+// events — the same reason native children swallowed the original bug. A
+// bridge-driven proof would need a window-targeted synthetic event path
+// added to the bridge; real OS-level input (as above) was the workaround.
+//
+// Shadowed-control check on MainWindow: confirmed live under xcb via a
+// read-only widgetAt/childAt probe at the running window's bottom-edge margin
+// — the status bar (46px, docked at the window's bottom edge) hosts several
+// clickable controls whose rects genuinely extend into the bottom 6px:
+// `gpsStatusButton` by ~4px, the "Cancel transmit" status label by ~1px. A
+// press landing there is consumed by this class before the widget ever sees
+// it — Qt calls application-installed event filters ahead of the receiver's
+// own event() for every dispatch, so that is guaranteed once a press reaches
+// this filter (proven above), not merely likely. Filed as a follow-up rather
+// than fixed here (#4886): the fix belongs in the status bar
+// layout (cap each stack's maximumHeight so its clickable area stops short
+// of the edge) rather than in this class, which has no way to know about a
+// specific adopter's child geometry.
 //
 // Known artifact of that manual path: dragging an edge that moves the window
 // origin (left or top) can make the opposite edge appear to shimmer under a
@@ -91,6 +129,10 @@ private:
     QPoint    m_manualResizePressGlobal;
     QRect     m_manualResizeStartGeom;
     QRect     m_manualResizeLastRequested;
+    // minimumSize().expandedTo(minimumSizeHint()), snapshotted once at press
+    // time rather than recomputed on every motion event — minimumSizeHint()
+    // walks the widget's layout, and a drag can produce dozens of moves.
+    QSize     m_manualResizeFloor;
 };
 
 } // namespace AetherSDR

--- a/src/gui/FramelessResizer.h
+++ b/src/gui/FramelessResizer.h
@@ -87,19 +87,35 @@ namespace AetherSDR {
 // bridge-driven proof would need a window-targeted synthetic event path
 // added to the bridge; real OS-level input (as above) was the workaround.
 //
-// Shadowed-control check on MainWindow: confirmed live under xcb via a
-// read-only widgetAt/childAt probe at the running window's bottom-edge margin
-// — the status bar (46px, docked at the window's bottom edge) hosts several
-// clickable controls whose rects genuinely extend into the bottom 6px:
-// `gpsStatusButton` by ~4px, the "Cancel transmit" status label by ~1px. A
-// press landing there is consumed by this class before the widget ever sees
-// it — Qt calls application-installed event filters ahead of the receiver's
-// own event() for every dispatch, so that is guaranteed once a press reaches
-// this filter (proven above), not merely likely. Filed as a follow-up rather
-// than fixed here (#4886): the fix belongs in the status bar
-// layout (cap each stack's maximumHeight so its clickable area stops short
-// of the edge) rather than in this class, which has no way to know about a
-// specific adopter's child geometry.
+// Shadowed-control check on MainWindow: confirmed live via a read-only
+// widgetAt/childAt probe at the running window's margins, on both edges the
+// default 6px band covers. A press landing in a shadowed rect is consumed by
+// this class before the widget ever sees it — Qt calls application-installed
+// event filters ahead of the receiver's own event() for every dispatch, so
+// that is guaranteed once a press reaches this filter, not merely likely.
+//
+//   - Top (TitleBar, 32px, at y=0): fixed in this PR by installing with
+//     topMoveReserve = TitleBar::kHeight (see MainWindow.cpp) instead of the
+//     default 0. Before that fix, the top 6px consumed the top 5px of
+//     QMenuBar and the top 2px of the Minimize/Maximize/Close labels — #4827
+//     itself lists those controls among the things that worked correctly
+//     before this PR, so a live band there was a regression, not a
+//     pre-existing gap, and worth fixing here rather than deferring.
+//   - Bottom (QStatusBar, 46px, docked flush): *not* fixed here, tracked as
+//     #4886. First measured (an earlier round of this PR) as two examples —
+//     `gpsStatusButton` by ~4px, the "Cancel transmit" label by ~1px — which
+//     understated it: the status bar's inner container and ~20 direct
+//     children are laid out flush with each other, so essentially every
+//     clickable status control extends ~4px into the band the same way
+//     `gpsStatusButton` does; `Cancel transmit` is the outlier that mostly
+//     stops short, not a second representative example. #4886's own
+//     enumeration should be corrected to match before it's acted on.
+//     Deferred rather than fixed alongside the top edge because the fix is
+//     the same shape either way — cap each control's clickable rect short of
+//     the margin — but the bottom edge has an order of magnitude more
+//     controls to individually re-check, and none of them are the window's
+//     own min/max/close/menu controls a regression report would be filed
+//     against immediately.
 //
 // Known artifact of that manual path: dragging an edge that moves the window
 // origin (left or top) can make the opposite edge appear to shimmer under a
@@ -148,6 +164,25 @@ public:
     // (quirk 1). A separate top-level (e.g. a dialog) has a null parent()
     // and only a transientParent, so this never reaches across windows.
     static bool windowOwnsChain(const QWindow* win, const QWindow* mine);
+
+    // The margin/reserve math edgesAt() applies: which edges (if any) a
+    // window-local point `p` is within `margin` px of, given the window's
+    // own `rect`. `topMoveReserve` excludes TopEdge for any point above that
+    // many px regardless of margin — the mechanism MainWindow's
+    // `topMoveReserve = TitleBar::kHeight` relies on to keep the resize band
+    // out of the title bar (#4886/#4827 review round 3). No edges at all
+    // while `maximizedOrFullscreen`, or for a point outside `rect` entirely
+    // (reachable since events now arrive from native children carrying
+    // global coordinates).
+    static Qt::Edges computeEdges(const QRect& rect, const QPoint& p, int margin,
+                                   int topMoveReserve, bool maximizedOrFullscreen);
+
+    // The decision QEvent::Leave applies when a manual resize is active but
+    // never got a real mouse grab: true means end the drag right there,
+    // because without a grab we stop receiving any further events for it —
+    // including the release — once the pointer leaves our window.
+    static bool shouldEndOnUngrabbedLeave(bool manualResizeActive,
+                                           bool manualResizeGrabbed);
 
 protected:
     bool eventFilter(QObject* obj, QEvent* ev) override;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1163,12 +1163,18 @@ MainWindow::MainWindow(QWidget* parent)
         // MainWindow's direct children (QStatusBar, the central widget,
         // QSizeGrip) are all native windows that would otherwise swallow
         // every edge event before the top level saw it — see the
-        // FramelessResizer header (#4827).  It doesn't compete with the
-        // TitleBar's drag-to-move handler (the 6 px resize margin is well
-        // clear of the 18+ px title-bar height).  Stays installed across
-        // frameless toggles — when the system frame is back on, the
+        // FramelessResizer header (#4827).  topMoveReserve = TitleBar::kHeight
+        // reserves the whole title bar for its own drag-to-move handler and
+        // the menu bar / min-max-close controls it hosts, rather than the
+        // resizer's 6 px top-edge margin (previously the default 0, which
+        // put that margin *inside* the 32 px title bar and shadowed the
+        // first few px of all of them — #4886).  MainWindow therefore has
+        // no top-edge resize at all in frameless mode, only left/right/
+        // bottom; that trade was already implicit before this PR, since the
+        // filter was dead on every edge here until now.  Stays installed
+        // across frameless toggles — when the system frame is back on, the
         // platform owns resize and our filter no-ops.
-        FramelessResizer::install(this);
+        FramelessResizer::install(this, 6, TitleBar::kHeight);
 
         // One-shot migration: collapse the legacy "CwDecodeOverlay" flat
         // key into the nested AppSettings["CwDecoder"] blob (#2417).  The

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1159,11 +1159,15 @@ MainWindow::MainWindow(QWidget* parent)
 
         // 8-axis edge resize for frameless mode — same install pattern
         // as the floating dialogs (SpotHub, RadioSetup, MemoryDialog).
-        // Filter sits on the native QWindow so it doesn't compete with
-        // the TitleBar's drag-to-move handler (the 6 px resize margin
-        // is well clear of the 18+ px title-bar height).  Stays
-        // installed across frameless toggles — when the system frame is
-        // back on, the platform owns resize and our filter no-ops.
+        // The filter is application-wide and matches by window, because
+        // MainWindow's direct children (QStatusBar, the central widget,
+        // QSizeGrip) are all native windows that would otherwise swallow
+        // every edge event before the top level saw it — see the
+        // FramelessResizer header (#4827).  It doesn't compete with the
+        // TitleBar's drag-to-move handler (the 6 px resize margin is well
+        // clear of the 18+ px title-bar height).  Stays installed across
+        // frameless toggles — when the system frame is back on, the
+        // platform owns resize and our filter no-ops.
         FramelessResizer::install(this);
 
         // One-shot migration: collapse the legacy "CwDecodeOverlay" flat

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -111,7 +111,7 @@ TitleBar::TitleBar(QWidget* parent)
     : QWidget(parent)
 {
     AetherSDR::theme::setContainer(this, QStringLiteral("titlebar"));
-    setFixedHeight(32);
+    setFixedHeight(kHeight);
     AetherSDR::ThemeManager::instance().applyStyleSheet(this, "TitleBar { background: {{color.background.0}}; border-bottom: 1px solid {{color.background.1}}; }");
 
     m_hbox = new QHBoxLayout(this);

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -578,7 +578,7 @@ bool TitleBar::startWindowMove(QMouseEvent* ev, bool useSystemMove)
         // desktop) the press is swallowed and the window just never follows
         // the pointer (#4827). Skip straight to the manual-move path below,
         // same rule Qt's own QSizeGrip::usePlatformSizeGrip() applies.
-        if (!FramelessMoveHelper::systemMoveResizeUnreliable()) {
+        if (!FramelessMoveHelper::systemMoveResizeUnreliable(w)) {
             if (auto* h = w->windowHandle())
                 if (h->startSystemMove()) {
                     m_windowMoveActive = true;

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -1,5 +1,6 @@
 #include "TitleBar.h"
 #include "FramelessMessageBox.h"
+#include "FramelessMoveHelper.h"
 #include "GuardedSlider.h"
 #include "PersistentDialog.h"
 #include "core/AppSettings.h"
@@ -571,13 +572,21 @@ bool TitleBar::startWindowMove(QMouseEvent* ev, bool useSystemMove)
             return true;
         }
 #elif !defined(Q_OS_MAC)
-        if (auto* h = w->windowHandle())
-            if (h->startSystemMove()) {
-                m_windowMoveActive = true;
-                m_windowMoveUsesSystem = true;
-                ev->accept();
-                return true;
-            }
+        // startSystemMove() reports success on xcb but the WM-driven drag it
+        // hands off to is unreliable there (QTBUG-69716) — under Mutter/
+        // XWayland (the common case for `QT_QPA_PLATFORM=xcb` on a Wayland
+        // desktop) the press is swallowed and the window just never follows
+        // the pointer (#4827). Skip straight to the manual-move path below,
+        // same rule Qt's own QSizeGrip::usePlatformSizeGrip() applies.
+        if (!FramelessMoveHelper::systemMoveResizeUnreliable()) {
+            if (auto* h = w->windowHandle())
+                if (h->startSystemMove()) {
+                    m_windowMoveActive = true;
+                    m_windowMoveUsesSystem = true;
+                    ev->accept();
+                    return true;
+                }
+        }
 #endif
     }
 

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -24,6 +24,13 @@ class TitleBar : public QWidget {
     Q_OBJECT
 
 public:
+    // The fixed height set on `this` in the constructor. Named so
+    // MainWindow can pass it as FramelessResizer's topMoveReserve without
+    // duplicating the literal — the two must stay in lockstep, or the edge-
+    // resize margin either overlaps the title bar (#4886) or leaves a dead
+    // strip below it.
+    static constexpr int kHeight = 32;
+
     explicit TitleBar(QWidget* parent = nullptr);
 
     // Embed the menu bar into the left side of the title bar

--- a/tests/frameless_resizer_test.cpp
+++ b/tests/frameless_resizer_test.cpp
@@ -1,0 +1,192 @@
+// Regression coverage for FramelessResizer's two pure-logic helpers, added
+// per review on PR #4829 (frameless move/resize under xcb, #4827): neither
+// continueManualResize()'s clamping arithmetic nor ownsWindow()'s
+// parent-chain matching had a test, and the XTest-driven proof in that PR
+// only exercises one platform's one drag. clampManualResize() and
+// windowOwnsChain() are the same code the private instance methods call
+// (FramelessResizer.h), pulled out static so they're reachable here without
+// a full widget/window hierarchy.
+
+#include "gui/FramelessResizer.h"
+
+#include <QApplication>
+#include <QPoint>
+#include <QRect>
+#include <QSize>
+#include <QWindow>
+
+#include <cstdio>
+#include <string>
+
+using AetherSDR::FramelessResizer;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-58s %s\n", ok ? "[ OK ]" : "[FAIL]", name, detail.c_str());
+    if (!ok) {
+        ++g_failed;
+    }
+}
+
+std::string rectStr(const QRect& r)
+{
+    return "(" + std::to_string(r.left()) + "," + std::to_string(r.top()) + " "
+        + std::to_string(r.width()) + "x" + std::to_string(r.height()) + ")";
+}
+
+// A window well within its floor/ceiling: every edge just follows the
+// pointer delta, origin-pinned edges hold, moved edges follow exactly.
+void testUnclamped()
+{
+    const QRect start(100, 100, 400, 300);         // right=499, bottom=399
+    const QSize floor(100, 100);
+    const QSize ceiling(2000, 2000);
+
+    const QRect right = FramelessResizer::clampManualResize(
+        start, QPoint(50, 0), Qt::RightEdge, floor, ceiling);
+    report("RightEdge: left/top/height pinned, width grows by delta",
+           right.left() == 100 && right.top() == 100 && right.height() == 300
+               && right.width() == 450,
+           rectStr(right));
+
+    const QRect bottom = FramelessResizer::clampManualResize(
+        start, QPoint(0, -20), Qt::BottomEdge, floor, ceiling);
+    report("BottomEdge: origin pinned, height shrinks by delta",
+           bottom.left() == 100 && bottom.top() == 100 && bottom.width() == 400
+               && bottom.height() == 280,
+           rectStr(bottom));
+
+    // Left/Top move the *origin*; the opposite edge is what must stay pinned.
+    const QRect left = FramelessResizer::clampManualResize(
+        start, QPoint(30, 0), Qt::LeftEdge, floor, ceiling);
+    report("LeftEdge: right edge pinned, left moves and width shrinks",
+           left.right() == start.right() && left.left() == 130
+               && left.width() == 370,
+           rectStr(left));
+
+    const QRect topLeft = FramelessResizer::clampManualResize(
+        start, QPoint(10, 10), Qt::TopEdge | Qt::LeftEdge, floor, ceiling);
+    report("Top+Left corner: right/bottom pinned, origin moves on both axes",
+           topLeft.right() == start.right() && topLeft.bottom() == start.bottom()
+               && topLeft.left() == 110 && topLeft.top() == 110,
+           rectStr(topLeft));
+}
+
+// Dragging an edge past the floor must stop at the floor, not overshoot —
+// this is the "resize back past minimumSizeHint()" case #4827's manual path
+// exists for in the first place (Qt would otherwise silently grow the
+// window back while the origin kept moving, per the comment in
+// clampManualResize()).
+void testFloorClamp()
+{
+    const QRect start(0, 0, 400, 300);
+    const QSize floor(200, 150);
+    const QSize ceiling(2000, 2000);
+
+    // Drag RightEdge far enough left to demand width < floor.
+    const QRect right = FramelessResizer::clampManualResize(
+        start, QPoint(-300, 0), Qt::RightEdge, floor, ceiling);
+    report("RightEdge floor clamp: width never drops below floor",
+           right.width() == floor.width() && right.left() == 0,
+           rectStr(right));
+
+    // Drag LeftEdge far enough right to demand width < floor — the origin
+    // must stop moving once the floor is hit, not keep tracking the pointer.
+    const QRect left = FramelessResizer::clampManualResize(
+        start, QPoint(300, 0), Qt::LeftEdge, floor, ceiling);
+    report("LeftEdge floor clamp: width never drops below floor, right pinned",
+           left.width() == floor.width() && left.right() == start.right(),
+           rectStr(left));
+
+    const QRect bottom = FramelessResizer::clampManualResize(
+        start, QPoint(0, -250), Qt::BottomEdge, floor, ceiling);
+    report("BottomEdge floor clamp: height never drops below floor",
+           bottom.height() == floor.height(),
+           rectStr(bottom));
+
+    const QRect top = FramelessResizer::clampManualResize(
+        start, QPoint(0, 250), Qt::TopEdge, floor, ceiling);
+    report("TopEdge floor clamp: height never drops below floor, bottom pinned",
+           top.height() == floor.height() && top.bottom() == start.bottom(),
+           rectStr(top));
+}
+
+// The maximumWidth()/maximumHeight() ceiling, symmetric to the floor case.
+void testCeilingClamp()
+{
+    const QRect start(0, 0, 400, 300);
+    const QSize floor(100, 100);
+    const QSize ceiling(500, 350);
+
+    const QRect right = FramelessResizer::clampManualResize(
+        start, QPoint(300, 0), Qt::RightEdge, floor, ceiling);
+    report("RightEdge ceiling clamp: width never exceeds maximumWidth()",
+           right.width() == ceiling.width(),
+           rectStr(right));
+
+    const QRect left = FramelessResizer::clampManualResize(
+        start, QPoint(-300, 0), Qt::LeftEdge, floor, ceiling);
+    report("LeftEdge ceiling clamp: width never exceeds maximumWidth(), right pinned",
+           left.width() == ceiling.width() && left.right() == start.right(),
+           rectStr(left));
+}
+
+// A no-op edge selection (e.g. a hover with no button down never reaches
+// this function, but a defensive check costs nothing) must return the start
+// geometry unchanged.
+void testNoEdges()
+{
+    const QRect start(10, 20, 300, 200);
+    const QRect result = FramelessResizer::clampManualResize(
+        start, QPoint(50, 50), Qt::Edges{}, QSize(50, 50), QSize(1000, 1000));
+    report("No edges selected: geometry passes through unchanged",
+           result == start,
+           rectStr(result));
+}
+
+void testWindowOwnsChain()
+{
+    QWindow mine;
+    QWindow child(&mine);
+    QWindow grandchild(&child);
+    QWindow unrelated;   // separate top-level, null parent() — e.g. a dialog
+
+    report("windowOwnsChain: a window owns itself",
+           FramelessResizer::windowOwnsChain(&mine, &mine));
+    report("windowOwnsChain: true for a direct native child",
+           FramelessResizer::windowOwnsChain(&child, &mine));
+    report("windowOwnsChain: true for a transitive (grandchild) descendant",
+           FramelessResizer::windowOwnsChain(&grandchild, &mine));
+    report("windowOwnsChain: false for an unrelated top-level window",
+           !FramelessResizer::windowOwnsChain(&unrelated, &mine));
+    report("windowOwnsChain: false when win is null",
+           !FramelessResizer::windowOwnsChain(nullptr, &mine));
+    report("windowOwnsChain: false when mine is null",
+           !FramelessResizer::windowOwnsChain(&child, nullptr));
+    report("windowOwnsChain: doesn't walk the wrong direction (mine is not a descendant of child)",
+           !FramelessResizer::windowOwnsChain(&mine, &child));
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM")) {
+        qputenv("QT_QPA_PLATFORM", "offscreen");
+    }
+    QApplication app(argc, argv);
+    std::printf("FramelessResizer pure-logic test harness (PR #4829 review)\n\n");
+
+    testUnclamped();
+    testFloorClamp();
+    testCeilingClamp();
+    testNoEdges();
+    testWindowOwnsChain();
+
+    std::printf("\n%s\n", g_failed == 0 ? "ALL PASS" : "FAILURES PRESENT");
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/frameless_resizer_test.cpp
+++ b/tests/frameless_resizer_test.cpp
@@ -1,11 +1,23 @@
-// Regression coverage for FramelessResizer's two pure-logic helpers, added
-// per review on PR #4829 (frameless move/resize under xcb, #4827): neither
-// continueManualResize()'s clamping arithmetic nor ownsWindow()'s
-// parent-chain matching had a test, and the XTest-driven proof in that PR
-// only exercises one platform's one drag. clampManualResize() and
-// windowOwnsChain() are the same code the private instance methods call
-// (FramelessResizer.h), pulled out static so they're reachable here without
-// a full widget/window hierarchy.
+// Regression coverage for FramelessResizer's pure-logic helpers, added per
+// review on PR #4829 (frameless move/resize under xcb, #4827) and grown
+// across two further review rounds. None of continueManualResize()'s
+// clamping arithmetic, ownsWindow()'s parent-chain matching, edgesAt()'s
+// margin/topMoveReserve math, or the ungrabbed-Leave end-drag decision had a
+// test, and the XTest-driven proof in that PR only exercises one platform's
+// one drag. clampManualResize(), windowOwnsChain(), computeEdges(), and
+// shouldEndOnUngrabbedLeave() are the same code the private instance methods
+// call (FramelessResizer.h), pulled out static so they're reachable here
+// without a full widget/window hierarchy.
+//
+// computeEdges() coverage exists specifically because of a real regression a
+// review round found: MainWindow's FramelessResizer::install() call left
+// topMoveReserve at its default 0, so the resize band lived inside the 32px
+// title bar and shadowed the menu bar and min/max/close controls (#4886).
+// The topMoveReserve cases below are the regression test for that class of
+// bug — a future adopter that installs with a title bar but forgets to pass
+// topMoveReserve won't be caught here (that's a call-site/integration
+// concern, not this function's), but if topMoveReserve *is* passed, these
+// cases pin down that it actually suppresses TopEdge correctly.
 
 #include "gui/FramelessResizer.h"
 
@@ -148,6 +160,87 @@ void testNoEdges()
            rectStr(result));
 }
 
+// The margin/topMoveReserve math edgesAt() applies — added for the #4829
+// review round that found MainWindow's install() call left topMoveReserve
+// at its default 0, so the resize band lived *inside* the title bar and
+// shadowed the menu bar and min/max/close controls (#4886). These cases
+// exist to keep that mechanism honest: a nonzero topMoveReserve must
+// suppress TopEdge for every point above it, margin-only or not.
+void testComputeEdges()
+{
+    const QRect win(0, 0, 400, 300);   // window-local rect, as edgesAt() sees it
+
+    // No topMoveReserve: every edge and corner detected within margin.
+    report("computeEdges: left edge",
+           FramelessResizer::computeEdges(win, QPoint(0, 150), 6, 0, false)
+               == Qt::LeftEdge);
+    report("computeEdges: right edge",
+           FramelessResizer::computeEdges(win, QPoint(399, 150), 6, 0, false)
+               == Qt::RightEdge);
+    report("computeEdges: top edge",
+           FramelessResizer::computeEdges(win, QPoint(200, 0), 6, 0, false)
+               == Qt::TopEdge);
+    report("computeEdges: bottom edge",
+           FramelessResizer::computeEdges(win, QPoint(200, 299), 6, 0, false)
+               == Qt::BottomEdge);
+    report("computeEdges: top-left corner",
+           FramelessResizer::computeEdges(win, QPoint(0, 0), 6, 0, false)
+               == (Qt::TopEdge | Qt::LeftEdge));
+    report("computeEdges: outside every margin — no edges",
+           FramelessResizer::computeEdges(win, QPoint(200, 150), 6, 0, false)
+               == Qt::Edges{});
+
+    // The regression this exists to catch: topMoveReserve=32 (TitleBar's
+    // real height) must suppress TopEdge for the whole reserved strip, even
+    // though y=5 is well within the 6px margin on its own.
+    report("computeEdges: y=5 inside a 32px topMoveReserve — TopEdge suppressed",
+           FramelessResizer::computeEdges(win, QPoint(200, 5), 6, 32, false)
+               == Qt::Edges{});
+    // topMoveReserve suppresses *every* edge in the reserved strip, not just
+    // TopEdge — edgesAt()'s early return exits before Left/Right/Bottom are
+    // even checked, matching its own comment that the whole strip is the
+    // window's own move handling, not a resize zone. A point at x=0 (which
+    // would be LeftEdge on its own) still gets nothing at y=5 < reserve=32.
+    report("computeEdges: reserve suppresses ALL edges in the strip, not just Top"
+           " — x=0,y=5 (would be LeftEdge) is still nothing",
+           FramelessResizer::computeEdges(win, QPoint(0, 5), 6, 32, false)
+               == Qt::Edges{});
+    report("computeEdges: topMoveReserve boundary — y==reserve is no longer"
+           " suppressed, but it's also past the margin so still no edge",
+           FramelessResizer::computeEdges(win, QPoint(200, 32), 6, 32, false)
+               == Qt::Edges{});
+    report("computeEdges: below topMoveReserve, within margin of a closer edge — LeftEdge",
+           FramelessResizer::computeEdges(win, QPoint(2, 40), 6, 32, false)
+               == Qt::LeftEdge);
+
+    // Maximized/fullscreen: no edges anywhere, topMoveReserve or not.
+    report("computeEdges: maximized suppresses every edge",
+           FramelessResizer::computeEdges(win, QPoint(0, 0), 6, 0, true)
+               == Qt::Edges{});
+
+    // A point outside the window rect entirely (reachable since native
+    // children deliver events in global coordinates) — no edges, not a
+    // false-positive edge from unclamped comparisons.
+    report("computeEdges: point outside the window rect — no edges",
+           FramelessResizer::computeEdges(win, QPoint(-10, 150), 6, 0, false)
+               == Qt::Edges{});
+}
+
+// The decision behind the #4829 review-round-3 fix: an active manual resize
+// with no real grab must end itself on Leave, or it strands m_manualResizeActive
+// true until (at best) a buttonless move eventually arrives.
+void testShouldEndOnUngrabbedLeave()
+{
+    report("shouldEndOnUngrabbedLeave: active + ungrabbed -> end it",
+           FramelessResizer::shouldEndOnUngrabbedLeave(true, false));
+    report("shouldEndOnUngrabbedLeave: active + grabbed -> leave it running",
+           !FramelessResizer::shouldEndOnUngrabbedLeave(true, true));
+    report("shouldEndOnUngrabbedLeave: inactive + ungrabbed -> nothing to end",
+           !FramelessResizer::shouldEndOnUngrabbedLeave(false, false));
+    report("shouldEndOnUngrabbedLeave: inactive + grabbed -> nothing to end",
+           !FramelessResizer::shouldEndOnUngrabbedLeave(false, true));
+}
+
 void testWindowOwnsChain()
 {
     QWindow mine;
@@ -185,6 +278,8 @@ int main(int argc, char** argv)
     testFloorClamp();
     testCeilingClamp();
     testNoEdges();
+    testComputeEdges();
+    testShouldEndOnUngrabbedLeave();
     testWindowOwnsChain();
 
     std::printf("\n%s\n", g_failed == 0 ? "ALL PASS" : "FAILURES PRESENT");


### PR DESCRIPTION
Under `QT_QPA_PLATFORM=xcb` with frameless mode on, drag-to-move on the menu bar and edge resize (left/right/bottom) did nothing — only the bottom-right QSizeGrip corner and the min/max/close/double-click controls worked. Two independent causes:

1. QWindow::startSystemMove()/startSystemResize() report success on xcb, but the WM-driven interactive grab they hand off to is unreliable there (upstream QTBUG-69716) — under Mutter/XWayland the press is consumed and the window just never tracks the pointer. Qt's own QSizeGrip hits the same wall and works around it in usePlatformSizeGrip() by refusing the platform path on xcb; every frameless move/resize call site in AetherSDR now follows that same rule via the shared FramelessMoveHelper::systemMoveResizeUnreliable() check, falling back to manual dragging.

2. FramelessResizer's edge-resize filter never received any events on MainWindow at all, independent of (1). It assumed a QWindow receives every platform mouse event before widget dispatch — false once any child acquires a native window, since Qt then promotes every sibling to native too. MainWindow's QStatusBar, central widget, and QSizeGrip are all native and between them cover the entire client area, so X11 delivered every edge-hover/press event to those innermost native windows and the top-level filter saw nothing. Confirmed with `xwininfo -id <winid> -children`. The filter now installs application-wide and matches events by walking each event window's parent chain back to the top level it owns, plus a manual drag fallback (clamped to the window's real minimum size) for the resize path xcb denies.

Also fixes two review findings surfaced along the way: MouseButtonPress was reading QCursor::pos() unconditionally, which is unreliable on native Wayland's global-cursor-query restrictions and was never exercised by xcb testing — switched to the event's own globalPosition(), safe on every platform; and the manual-resize destructor no longer touches the owning widget mid-teardown.

A wobble on the edge opposite a left/top drag was investigated at length (measured with atomic X11 geometry sampling — the requested geometry is exact, 720/720 samples pinned) and is a compositor presentation artifact, not a geometry bug: a WM-driven resize withholds the frame until the client acknowledges the new size (_NET_WM_SYNC_REQUEST); an app-driven setGeometry() gets no such handshake, so stale content can be presented at the new origin. Tracked separately rather than blocking this fix.

Verified under QT_QPA_PLATFORM=xcb (GNOME/Mutter/XWayland): all four edges resize pixel-exact, menu-bar move works, confirmed manually.

Reported and manually verified by @JonathanPerkins.

## Update — review response (ten9876, jensenpat)

- Fixed the `QCursor::pos()`/`Leave` inconsistency ten9876 flagged: the
  `QEvent::Leave` handler now uses `m_window->underMouse()` instead, since
  there's no left/top-drag-trailing problem there to justify the
  Wayland-unreliable global cursor query the press handler moved away from.
- Documented the cross-platform edge-resize band change in
  `FramelessResizer.h`: quirk 1 (native-child event swallowing) was never
  xcb-specific, so the app-wide filter turns on a real 6px edge-resize band
  on every platform, not just xcb.
- Checked the "no shadowed controls" claim live under xcb (automation
  bridge `hitTest`, read-only) instead of asserting it, and it wasn't fully
  true: `gpsStatusButton` and the "Cancel transmit" status label both have
  small real overlaps with the bottom-edge resize margin. Filed as a
  follow-up rather than grown into this diff, since the fix belongs in the
  status bar layout, not this class: #4886.
- Addressed the three non-blocking nits: documented the O(open frameless
  windows) per-event filter cost (corrected to 10 actual `install()` call
  sites), hoisted the `minimumSizeHint()` floor calculation out of the
  motion-event loop into `beginManualResize()`, and `setMouseGrabEnabled()`
  failure now logs `qCWarning(lcGui)` instead of failing silently.
- For jensenpat: used the automation bridge as requested, and it surfaced a
  real limitation worth reporting rather than a clean "done" — the bridge's
  `clickAt`/`dragAt`/`gesture` verbs synthesize `QMouseEvent`s straight to
  the target `QWidget` via `QCoreApplication::sendEvent()`, never to its
  `QWindow`, so they can't exercise `FramelessResizer`'s filter, which by
  design only acts on window-level events. Proved the resize path
  end-to-end a different way instead: a real `XTestFakeButtonEvent`/
  `XTestFakeMotionEvent` drag (genuine X11 input, not app-level synthesis)
  on a running MainWindow's right edge under `QT_QPA_PLATFORM=xcb` grew it
  by exactly the dragged delta, independently confirmed by the resulting
  `display pan set … xpixels=` line the resize pushed to the radio. All of
  this reasoning is recorded in `FramelessResizer.h` next to the code it
  explains, not just in this comment.

## Update — review response (NF0T)

- **Blocker 1 (Leave handler regression)**: confirmed real.
  `QWidget::underMouse()` is updated by the receiving widget's own
  `event()`, which Qt runs *after* application-level filters — reading it
  inline saw the stale pre-update value and never fired. Fixed with a
  same-turn `QTimer::singleShot(0, ...)` deferred re-check.
- **Blocker 2 (macOS dead edge-resize band)**: confirmed real —
  `QCocoaWindow::startSystemResize()` has no override and always returns
  `false`. The press handler now checks the return value and falls back to
  the same manual drag the xcb branch uses.
- **Blocker 3 (missing tests)**: added `tests/frameless_resizer_test.cpp`,
  17 cases, after extracting the clamping arithmetic and parent-chain walk
  into testable static methods (`clampManualResize()`,
  `windowOwnsChain()`). Mutation-verified.
- **Non-blocking, also fixed**: `systemMoveResizeUnreliable()` now also
  covers Windows+`WA_TranslucentBackground` (QTBUG-90628, confirmed
  MainWindow does set that attribute in frameless mode — a live gap, not
  hypothetical); manual-resize grab-denial now gates the `ownsWindow()`
  bypass too; corrected the header's "everywhere" claim from the previous
  round — confirmed in code that Windows never sets
  `Qt::FramelessWindowHint` at all and macOS blocks native-child promotion
  via `WA_DontCreateNativeAncestors` (#4339), so quirk 1's actual reach is
  Linux/X11.
- Left open rather than guessed at: the exact Linux-side trigger for
  native-child promotion (found macOS's blocking mechanism, not Linux's
  cause). Also couldn't live-verify the Leave-handler fix visually — the
  override cursor isn't part of any widget's paint output, so it's not
  screenshot-visible, and repeated real-X11-input testing on this shared
  desktop kept getting its pointer contended by something else mid-gesture;
  resting on the Qt event-dispatch research recorded in `FramelessResizer.h`
  instead.

## Update — review response round 3 (ten9876, co-authored by Claude Opus 5)

**Blocker 1 — real regression, fixed.** `FramelessResizer::install(this)` on
MainWindow left `topMoveReserve` at its default 0, so the 6px resize band
lived *inside* the 32px TitleBar and consumed the top 5px of `QMenuBar` and
the top 2px of the Minimize/Maximize/Close labels — controls this issue
itself listed as working correctly before this PR. Fixed with
`FramelessResizer::install(this, 6, TitleBar::kHeight)` (new named constant
so the title bar's real height and the reserve can't drift apart).

**This is a deliberate trade-off, not a side effect, and it's one of the two
options ten9876 offered explicitly ("a maintainer call") — not something we
landed on unilaterally or an accidental loss of function.** MainWindow now
has no top-edge resize at all in frameless mode; left/right/bottom are
unaffected. The alternative on the table was deferring it to #4886 alongside
the bottom edge instead. Went with fixing it now given the severity — this
one shadowed the window's own menu bar and min/max/close controls, not a
status-bar label.

**Verified live** with real X11 input (XTest — the automation bridge's own
pointer verbs can't exercise this class, see `FramelessResizer.h`), all four
edges, after the fix:
- **Top**: a drag through the old shadow zone now produces a pure window
  *move* — position changed by exactly the drag delta, width/height
  completely unchanged. Confirms the band no longer eats resize there.
- **Right**: +40px, then independently +30px cross-checked against the
  radio-side `display pan set xpixels=1540` log line matching exactly.
- **Left**: right edge stayed pinned exactly (`x + width` identical before
  and after), only the left edge moved.
- **Bottom**: +40px exactly.

No regression on the edges this PR was actually about.

**Blocker 2 — bottom-edge enumeration corrected.** The header comment
claimed two examples with small overlaps; live measurement found the status
bar's ~20 direct children all extend ~4px into the band the same way
`gpsStatusButton` does — it isn't the exception, it's representative — and
"Cancel transmit" is actually the one that mostly stops short. Corrected the
comment to match the measurement. Still deferred to #4886, not fixed here.

**Nits, all addressed:**
- Denied-grab manual resize + pointer leaves the window stranded the drag
  forever (no more events reach us without a real grab, including the
  release). Extracted `shouldEndOnUngrabbedLeave()`, wired into the `Leave`
  handler to force-end the drag.
- O(n) comment counted call sites (10), not live instances —
  `PersistentDialog`'s own constructor calls `install()`, 40 subclasses
  (verified with your own `grep`, corrected from the cited 79), no
  `WA_DeleteOnClose`, so instances accumulate per dialog type opened.
- Dead `if (!m_window)` check: removed, verified genuinely unreachable.
- Override-cursor global LIFO stack shared across instances: documented as
  a known, visual-only limitation.
- xcb refusal applied to move as well as resize (Qt's own precedent is
  resize-only): documented the deliberate over-reach and the
  `WAYLAND_DISPLAY`-gated narrowing option; didn't change behavior — no
  native X11 WM available here to test against.
- `frameless_resizer_test` isn't in any `ci.yml` per-PR filter: fixed the
  comment to say so plainly. Didn't add it to `ci.yml` myself — CI scope
  felt like a call for you to make, not something to change silently.
- Pushed back on one, after tracing it through: the second
  `leaveEdgeZone()` after `endManualResize()` in the native-decorations
  guard is *not* redundant — `endManualResize()`'s own early return skips
  its internal `leaveEdgeZone()` whenever `m_manualResizeActive` is already
  false, which is exactly the hover-only case (edge cursor up, no active
  drag) this second call exists to clean up. Added a comment explaining why
  instead of removing it.

**Tests:** extracted two more pure-logic pieces the same way as
`clampManualResize()`/`windowOwnsChain()` before them — `computeEdges()`
(the exact mechanism the `topMoveReserve` fix relies on) and
`shouldEndOnUngrabbedLeave()`. 12 new cases, mutation-verified both — and
one of my own first-draft test cases was itself wrong (assumed
`topMoveReserve` only suppressed `TopEdge`; it suppresses the whole strip),
caught by the mutation check before it shipped.


<!--
Thanks for contributing to AetherSDR!

Before opening the PR, please:
- Read AGENTS.md if this is your first contribution (or your AI tool's
  first contribution) — it has the conventions every contributor agent
  is expected to follow.
- Read CONTRIBUTING.md for the commit-signing and branch-protection
  rules.
- If you're an AI agent: claim the originating issue first by assigning
  yourself via `gh issue edit <N> --add-assignee <handle>`. Double-
  assigning alongside the @aethersdr-agent triage bot is fine.
-->

## Summary

Fixes #4827. Frameless drag-to-move and edge resize (left/right/bottom) did nothing under `QT_QPA_PLATFORM=xcb` — the WM-driven grab `startSystemMove()`/`startSystemResize()` hand off to is unreliable there (QTBUG-69716), and `FramelessResizer`'s edge filter never received events on `MainWindow` at all because native children (`QStatusBar`, the central widget, `QSizeGrip`) swallow them before the top-level window sees them. The filter now installs application-wide and falls back to a manual drag on xcb, Windows+translucent, and macOS (which has no `startSystemResize()` implementation at all).

## Constitution principle honored

Principle VIII — Evidence Over Assertion. Every claim in this PR's review responses was checked against a verification step before being acted on or asserted, not taken on confidence: macOS's `startSystemResize()` always returning `false` was confirmed against Qt forum/docs, not assumed; Windows never setting `Qt::FramelessWindowHint` and macOS's `WA_DontCreateNativeAncestors` were confirmed by reading the actual code, not inferred; the new unit tests were mutation-verified (a broken clamp genuinely fails the case that covers it); the edge-resize fix itself was proven with real X11 input (XTest), independently cross-checked against the radio-side `display pan set xpixels=` log line, not just eyeballed.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [ ] Behavior verified on a real radio if applicable
- [x] Existing tests pass (CI) — plus a new `frameless_resizer_test` added by this PR
- [x] Reproduction steps documented if user-reported bug

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [ ] All meter UI uses `MeterSmoother` (AGENTS.md convention) — n/a, no meter UI touched
- [ ] Documentation updated if user-visible behavior changed — `docs/` and the
      affected READMEs. **Not `CHANGELOG.md`**, which is a release-prep file a
      PR must not add to (AGENTS.md); describe it in the Summary above instead
- [ ] Security-sensitive changes reference a GHSA if applicable — n/a, no security-sensitive change
