### PR TITLE
feat(asr): context-carry for Copy Assist via explicit prompt (RFC #4818)

### DIFF
--- a/docs/asr-copy-assist.md
+++ b/docs/asr-copy-assist.md
@@ -18,6 +18,14 @@ Design + decision record: RFC **#4333** (accepted). Engine: **whisper.cpp**
   of the audio you're hearing streams into the panel.
 - Text is **color-coded by recognition confidence**: green (high) → yellow →
   orange → red (low), mirroring the CW decoder.
+- **Context** (header toggle, off by default) — carries context across segment
+  boundaries: each decode is conditioned on the *previous confident segment's*
+  own text (via whisper's `initial_prompt`), for continuity of names, callsigns,
+  and topic. Applied live (no model reload) so it can be A/B'd on the fly. It's
+  self-protecting: a low-confidence decode is **not** carried (so a garbled over
+  can't poison the next), and a real pause, **Clear**, or a retune starts fresh.
+  Whisper-only — greyed out on the sherpa-onnx and remote backends, which don't
+  implement it.
 - Hiding the panel (the status-bar **ASR** toggle / leaving voice mode) turns
   ASR off.
 - The status line shows a **`Queue: N s`** backlog — seconds of received audio not

--- a/src/asr/AsrEngine.cpp
+++ b/src/asr/AsrEngine.cpp
@@ -301,6 +301,14 @@ void AsrWorker::processAudio(const QVector<float>& monoSamples, int sampleRate)
 
     std::vector<AsrSegmenter::ClosedSegment> segments =
         m_segmenter.feed(pcm16k.data(), static_cast<int>(pcm16k.size()));
+
+    // A real pause (long idle silence) flushes any carried ASR context so a
+    // noisy/garbled prior can't keep conditioning later utterances and never
+    // recover. Checked every feed (fires during the gap, not just on a segment).
+    if (m_segmenter.consumeLongGap() && m_backend != nullptr) {
+        m_backend->resetContext();
+    }
+
     if (segments.empty()) {
         return;
     }
@@ -389,9 +397,31 @@ void AsrWorker::setSpeakerThreshold(float t)
     m_clusterer.setThreshold(t);
 }
 
+void AsrWorker::setContextCarryEnabled(bool on)
+{
+    if (m_backend) {
+        m_backend->setContextCarryEnabled(on);
+    }
+}
+
+void AsrWorker::clearContext()
+{
+    // Explicit flush (the panel's Clear button): drop the carried prompt so the
+    // next utterance starts clean, matching the cleared display.
+    if (m_backend) {
+        m_backend->resetContext();
+    }
+}
+
 void AsrWorker::reset()
 {
     m_segmenter.reset();
+    // A retune/clear is a new context — don't prime the next decode with the
+    // previous QSO's carried prompt (retune is the one boundary where the
+    // operator has explicitly signalled a fresh start). Mirrors clearContext().
+    if (m_backend) {
+        m_backend->resetContext();
+    }
     m_clusterer.reset(); // new session/frequency → relabel speakers from A
     m_prevSegmentText.clear(); // a Clear/retune must not de-dup against stale text
     m_resampler.reset();
@@ -437,6 +467,8 @@ void AsrEngine::startThread(AsrBackendFactory factory, const AsrSegmenter::Confi
     connect(this, &AsrEngine::requestSetHangoverMs, m_worker, &AsrWorker::setHangoverMs);
     connect(this, &AsrEngine::requestSetOverlapMs, m_worker, &AsrWorker::setOverlapMs);
     connect(this, &AsrEngine::requestSetSpeakerThreshold, m_worker, &AsrWorker::setSpeakerThreshold);
+    connect(this, &AsrEngine::requestSetContextCarryEnabled, m_worker, &AsrWorker::setContextCarryEnabled);
+    connect(this, &AsrEngine::requestClearContext, m_worker, &AsrWorker::clearContext);
     connect(this, &AsrEngine::requestReset, m_worker, &AsrWorker::reset);
 
     // Worker -> engine (queued back to the main thread).
@@ -582,6 +614,16 @@ void AsrEngine::setOverlapMs(int ms)
 void AsrEngine::setSpeakerThreshold(float threshold)
 {
     emit requestSetSpeakerThreshold(threshold);
+}
+
+void AsrEngine::clearContext()
+{
+    emit requestClearContext();
+}
+
+void AsrEngine::setContextCarryEnabled(bool on)
+{
+    emit requestSetContextCarryEnabled(on);
 }
 
 void AsrEngine::reset()

--- a/src/asr/AsrEngine.cpp
+++ b/src/asr/AsrEngine.cpp
@@ -304,12 +304,22 @@ void AsrWorker::processAudio(const QVector<float>& monoSamples, int sampleRate)
 
     // A real pause (long idle silence) flushes any carried ASR context so a
     // noisy/garbled prior can't keep conditioning later utterances and never
-    // recover. Checked every feed (fires during the gap, not just on a segment).
-    if (m_segmenter.consumeLongGap() && m_backend != nullptr) {
-        m_backend->resetContext();
-    }
+    // recover. Consume the one-shot now (it must clear even on a feed that
+    // produced no segment, so a gap spanning several silent buffers isn't held
+    // pending), but apply the flush AFTER decoding this feed's own segments
+    // below: a segment that closed BEFORE the gap should still be decoded with
+    // the previous context — the flush protects only what comes after the pause.
+    //
+    // Caller constraint: this relies on a single feed() never both closing an
+    // utterance and crossing longGapMs of idle silence. AsrAudioTap delivers
+    // chunks far shorter than longGapMs (2.5 s), so a close and a long gap never
+    // share one feed; a much larger buffer would break that and want revisiting.
+    const bool longGap = m_segmenter.consumeLongGap();
 
     if (segments.empty()) {
+        if (longGap && m_backend != nullptr) {
+            m_backend->resetContext();
+        }
         return;
     }
 
@@ -366,6 +376,13 @@ void AsrWorker::processAudio(const QVector<float>& monoSamples, int sampleRate)
                 m_embedder->embed(seg.samples.data(), static_cast<int>(seg.samples.size())));
         }
         emit segmentText(emitText, result.confidence, speaker);
+    }
+
+    // Apply the long-gap flush now, after this feed's own (pre-gap) segments have
+    // been decoded with the context they should have had — so the pause only
+    // affects the next utterance. (Guard kept though m_backend is non-null here.)
+    if (longGap && m_backend != nullptr) {
+        m_backend->resetContext();
     }
     }();
 

--- a/src/asr/AsrEngine.h
+++ b/src/asr/AsrEngine.h
@@ -68,6 +68,9 @@ public slots:
     void setHangoverMs(int ms);
     void setOverlapMs(int ms);
     void setSpeakerThreshold(float t);
+    // Opt-in (RFC #4818), see IAsrBackend::setContextCarryEnabled.
+    void setContextCarryEnabled(bool on);
+    void clearContext();   // flush carried context (long gap / Clear button)
     void reset();
 
 signals:
@@ -155,6 +158,15 @@ public:
     //  - speaker threshold: cosine match threshold for A/B/C clustering (0..1)
     void setSpeakerThreshold(float threshold);
 
+    // Opt-in (RFC #4818), applied live, no engine rebuild:
+    //  - context carry: condition each decode on the backend's own previous
+    //    confident output, for continuity across segment boundaries (off =
+    //    independent decodes, the historical default)
+    void setContextCarryEnabled(bool on);
+    // Flush any carried decode context (Copy Assist Clear button); the display
+    // and the context reset together for a clean fresh start.
+    void clearContext();
+
     void reset();
 
 signals:
@@ -178,6 +190,8 @@ signals:
     void requestSetHangoverMs(int ms);
     void requestSetOverlapMs(int ms);
     void requestSetSpeakerThreshold(float threshold);
+    void requestSetContextCarryEnabled(bool on);
+    void requestClearContext();
     void requestReset();
 
 private:

--- a/src/asr/AsrSegmenter.cpp
+++ b/src/asr/AsrSegmenter.cpp
@@ -16,6 +16,7 @@ AsrSegmenter::AsrSegmenter(const Config& config)
     m_minSpeechSamples = framesToSamples(m_config.minSpeechMs);
     m_hangoverSamples = framesToSamples(m_config.hangoverMs);
     m_maxSegmentSamples = framesToSamples(m_config.maxSegmentMs);
+    m_longGapSamples = framesToSamples(m_config.longGapMs);
     m_frame.reserve(m_frameSamples);
 }
 
@@ -33,9 +34,19 @@ void AsrSegmenter::reset()
     m_speechSamples = 0;
     m_pendingContinues = false;
     m_pendingOverlapMs = 0;
+    m_idleSilence = 0;
+    m_longGapFired = false;
+    m_longGapPending = false;
     if (m_vad != nullptr) {
         m_vad->reset();
     }
+}
+
+bool AsrSegmenter::consumeLongGap()
+{
+    const bool r = m_longGapPending;
+    m_longGapPending = false;
+    return r;
 }
 
 void AsrSegmenter::setMaxSegmentMs(int ms)
@@ -165,6 +176,9 @@ std::vector<AsrSegmenter::ClosedSegment> AsrSegmenter::feed(const float* samples
                 m_segment.clear();
             }
             m_trailingSilence = 0;
+            // Speech resumed: the idle gap (if any) is over; re-arm for the next.
+            m_idleSilence = 0;
+            m_longGapFired = false;
             m_segment.insert(m_segment.end(), m_frame.begin(), m_frame.end());
             m_speechSamples += static_cast<int>(m_frame.size());
         } else if (m_inSpeech) {
@@ -175,8 +189,18 @@ std::vector<AsrSegmenter::ClosedSegment> AsrSegmenter::feed(const float* samples
             if (m_trailingSilence >= m_hangoverSamples) {
                 closeSegment(out, /*forceCap=*/false);
             }
+        } else {
+            // Silence outside speech: accumulate the idle gap. When it first
+            // reaches longGapMs, latch a one-shot the worker consumes to flush
+            // carried context (fires once per gap; re-armed when speech resumes).
+            if (m_longGapSamples > 0 && !m_longGapFired) {
+                m_idleSilence += static_cast<int>(m_frame.size());
+                if (m_idleSilence >= m_longGapSamples) {
+                    m_longGapFired = true;
+                    m_longGapPending = true;
+                }
+            }
         }
-        // else: silence outside speech — ignored.
 
         // Hard cap on a single utterance.
         if (m_inSpeech && static_cast<int>(m_segment.size()) >= m_maxSegmentSamples) {

--- a/src/asr/AsrSegmenter.h
+++ b/src/asr/AsrSegmenter.h
@@ -48,6 +48,14 @@ public:
         // repeated leading words at the text level (Approach A) using the
         // continuesPrevious flag below.
         int overlapMs = 0;
+        // Idle silence AFTER an utterance's hangover close counts toward this;
+        // once it reaches longGapMs the run is a real pause and consumeLongGap()
+        // reports it so the worker can flush any carried ASR context and start
+        // the next utterance clean. The hangover silence itself is part of the
+        // utterance and is NOT counted, so the effective wall-clock pause before
+        // a flush is hangoverMs + longGapMs (~2.8 s at the defaults). Fixed, not
+        // UI-exposed. 0 disables.
+        int longGapMs = 2500;
     };
 
     // One closed utterance. `continuesPrevious` is true when this segment was
@@ -103,6 +111,11 @@ public:
 
     bool inSpeech() const { return m_inSpeech; }
 
+    // True once per idle-silence gap that reaches Config::longGapMs; clears on
+    // read. The worker polls this each feed() and, when set, flushes the
+    // backend's carried context so a real pause starts the next utterance clean.
+    bool consumeLongGap();
+
 private:
     int framesToSamples(int ms) const;
     // forceCap: true when this close is the maxSegmentMs cap firing mid-speech
@@ -124,6 +137,10 @@ private:
     int m_speechSamples = 0;        // speech-only samples (excludes hangover), gates minSpeech
     bool m_pendingContinues = false; // next emitted segment was seeded with carried overlap audio
     int m_pendingOverlapMs = 0;      // ms of audio carried into that next segment (for its overlapMs)
+    int m_longGapSamples = 0;       // Config::longGapMs in samples (0 = disabled)
+    int m_idleSilence = 0;          // contiguous silence samples while NOT in speech
+    bool m_longGapFired = false;    // latched when the current idle gap crossed the threshold
+    bool m_longGapPending = false;  // consumable one-shot for consumeLongGap()
 };
 
 } // namespace AetherSDR

--- a/src/asr/IAsrBackend.h
+++ b/src/asr/IAsrBackend.h
@@ -39,6 +39,21 @@ public:
 
     // Release the loaded model. Called before destruction; idempotent.
     virtual void unload() = 0;
+
+    // Opt-in: when true, condition each decode on the text the backend
+    // itself produced on its last confident segment, for continuity across
+    // segment boundaries. The whisper backend does this by passing the carried
+    // text as an explicit decode prompt (not by reusing whisper's own internal
+    // prompt state), so the confidence gate and resetContext() fully control what
+    // conditions the next decode. Default is off (independent decodes) — the
+    // historical behavior. No-op for backends that don't support it.
+    virtual void setContextCarryEnabled(bool) {}
+
+    // Drop any carried context so the next decode starts clean.
+    // The engine calls this on a long silence gap and on an explicit Clear, so a
+    // noisy/garbled prior can't keep conditioning later utterances. No-op for
+    // backends that don't carry context.
+    virtual void resetContext() {}
 };
 
 } // namespace AetherSDR

--- a/src/asr/WhisperAsrBackend.cpp
+++ b/src/asr/WhisperAsrBackend.cpp
@@ -113,14 +113,6 @@ whisper_context* initWhisperContext(const QByteArray& pathUtf8,
     }
     return nullptr;
 }
-
-// Below this confidence, don't let a segment's text seed the next decode's
-// prompt — a garbled/low-confidence result is more likely to compound into a
-// worse one downstream (a known whisper hallucination-propagation failure mode)
-// than to help continuity. 0.65 aligns with CopyAssistPanel's "yellow" band
-// (colorForConfidence): text the UI paints sub-yellow is exactly what we don't
-// want to carry. Not exposed in the UI — kept deliberately simple.
-constexpr float kContextCarryMinConfidence = 0.65f;
 } // namespace
 
 WhisperAsrBackend::WhisperAsrBackend()
@@ -361,9 +353,13 @@ AsrTranscript WhisperAsrBackend::transcribe(const std::vector<float>& pcm16k, QS
     // Only a confident segment becomes the next decode's prompt; a marginal one
     // leaves the last good prompt in place rather than replacing it with garbage.
     // (A real pause or Clear drops it entirely via resetContext().)
-    if (m_contextCarryEnabled && !result.text.isEmpty()
-        && result.confidence >= kContextCarryMinConfidence) {
-        m_carriedPrompt = result.text;
+    if (m_contextCarryEnabled && asrShouldCarryContext(result.text, result.confidence)) {
+        // whisper consumes at most the LAST min(n_max_text_ctx, n_text_ctx/2)-1
+        // ≈ 223 prompt tokens (whisper.cpp max_prompt_ctx), and a decode can echo
+        // initial_prompt back into its own text — so keep only the tail, or an
+        // echo would compound the carried string run over run.
+        constexpr int kMaxCarriedChars = 1000;
+        m_carriedPrompt = result.text.right(kMaxCarriedChars);
     }
 
     return result;

--- a/src/asr/WhisperAsrBackend.cpp
+++ b/src/asr/WhisperAsrBackend.cpp
@@ -113,6 +113,14 @@ whisper_context* initWhisperContext(const QByteArray& pathUtf8,
     }
     return nullptr;
 }
+
+// Below this confidence, don't let a segment's text seed the next decode's
+// prompt — a garbled/low-confidence result is more likely to compound into a
+// worse one downstream (a known whisper hallucination-propagation failure mode)
+// than to help continuity. 0.65 aligns with CopyAssistPanel's "yellow" band
+// (colorForConfidence): text the UI paints sub-yellow is exactly what we don't
+// want to carry. Not exposed in the UI — kept deliberately simple.
+constexpr float kContextCarryMinConfidence = 0.65f;
 } // namespace
 
 WhisperAsrBackend::WhisperAsrBackend()
@@ -247,7 +255,12 @@ AsrTranscript WhisperAsrBackend::transcribe(const std::vector<float>& pcm16k, QS
     whisper_full_params wparams = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
     wparams.n_threads = m_threads;
     wparams.translate = false;
-    wparams.no_context = true;    // each over is independent
+    // Never reuse whisper's INTERNAL cross-call prompt (prompt_past): it is
+    // rebuilt from every decode's output unconditionally, so the confidence gate
+    // can't reach it — that was the "kept re-seeding and couldn't recover" bug.
+    // Instead we condition explicitly via initial_prompt below, which the gate
+    // and resetContext() fully control.
+    wparams.no_context = true;
     wparams.single_segment = true; // one utterance -> one segment
     wparams.no_timestamps = true;
     wparams.print_progress = false;
@@ -255,6 +268,16 @@ AsrTranscript WhisperAsrBackend::transcribe(const std::vector<float>& pcm16k, QS
     wparams.print_timestamps = false;
     wparams.print_special = false;
     wparams.suppress_blank = true;
+
+    // Context carry (opt-in): condition this decode on the last confident
+    // segment's text by passing it as an explicit prompt. promptUtf8 must outlive
+    // whisper_full() (it holds the buffer initial_prompt points at); whisper
+    // tokenizes it synchronously during the call.
+    QByteArray promptUtf8;
+    if (m_contextCarryEnabled && !m_carriedPrompt.isEmpty()) {
+        promptUtf8 = m_carriedPrompt.toUtf8();
+        wparams.initial_prompt = promptUtf8.constData();
+    }
 
     // "auto" (or empty) → let whisper detect the language from the audio and
     // then transcribe it; any other value pins decoding to that language.
@@ -302,9 +325,9 @@ AsrTranscript WhisperAsrBackend::transcribe(const std::vector<float>& pcm16k, QS
         return {};
     }
 
-    // Confidence = mean probability over the real (non-special) tokens. Special
-    // tokens (timestamps, <eot>, etc.) have ids >= the end-of-text token and are
-    // excluded so punctuation/formatting doesn't skew the score.
+    // Special tokens (timestamps, <eot>, etc.) have ids >= the end-of-text token;
+    // they're excluded from the confidence mean below so punctuation/formatting
+    // doesn't skew the score.
     const whisper_token specialFloor = whisper_token_eot(m_ctx);
 
     QString text;
@@ -312,10 +335,15 @@ AsrTranscript WhisperAsrBackend::transcribe(const std::vector<float>& pcm16k, QS
     int probCount = 0;
     const int segments = whisper_full_n_segments(m_ctx);
     for (int i = 0; i < segments; ++i) {
+        // Text via whisper's own byte-safe assembly — NOT rebuilt token-by-token:
+        // whisper can split one multi-byte UTF-8 character across token
+        // boundaries (BPE / byte-fallback), and QString::fromUtf8 on each partial
+        // fragment would yield U+FFFD, corrupting non-ASCII text (#4399 languages).
         const char* seg = whisper_full_get_segment_text(m_ctx, i);
         if (seg != nullptr) {
             text += QString::fromUtf8(seg);
         }
+        // Confidence = mean probability over the real (non-special) tokens.
         const int nTokens = whisper_full_n_tokens(m_ctx, i);
         for (int t = 0; t < nTokens; ++t) {
             if (whisper_full_get_token_id(m_ctx, i, t) >= specialFloor) {
@@ -329,7 +357,31 @@ AsrTranscript WhisperAsrBackend::transcribe(const std::vector<float>& pcm16k, QS
     AsrTranscript result;
     result.text = text.trimmed();
     result.confidence = probCount > 0 ? static_cast<float>(probSum / probCount) : 0.0f;
+
+    // Only a confident segment becomes the next decode's prompt; a marginal one
+    // leaves the last good prompt in place rather than replacing it with garbage.
+    // (A real pause or Clear drops it entirely via resetContext().)
+    if (m_contextCarryEnabled && !result.text.isEmpty()
+        && result.confidence >= kContextCarryMinConfidence) {
+        m_carriedPrompt = result.text;
+    }
+
     return result;
+}
+
+void WhisperAsrBackend::setContextCarryEnabled(bool on)
+{
+    m_contextCarryEnabled = on;
+    if (!on) {
+        m_carriedPrompt.clear(); // start clean when re-enabled
+    }
+}
+
+void WhisperAsrBackend::resetContext()
+{
+    // Drop the carried prompt so the next decode starts clean. Lets the engine
+    // recover after a long silence or an explicit Clear.
+    m_carriedPrompt.clear();
 }
 
 void WhisperAsrBackend::unload()
@@ -339,6 +391,9 @@ void WhisperAsrBackend::unload()
         m_ctx = nullptr;
     }
     m_ctxOnGpu = false;
+    // A new/different model has no relationship to whatever text the old one
+    // produced — don't carry a stale prompt into its first decode.
+    m_carriedPrompt.clear();
 }
 
 std::function<std::unique_ptr<IAsrBackend>()> whisperAsrBackendFactory(const QString& language,

--- a/src/asr/WhisperAsrBackend.h
+++ b/src/asr/WhisperAsrBackend.h
@@ -12,6 +12,24 @@ struct whisper_context;
 
 namespace AetherSDR {
 
+// Below this confidence, don't let a segment's text seed the next decode's
+// prompt — a garbled/low-confidence result is more likely to compound into a
+// worse one downstream (a known whisper hallucination-propagation failure mode)
+// than to help continuity. 0.65 aligns with CopyAssistPanel's "yellow" band
+// (colorForConfidence): text the UI paints sub-yellow is exactly what we don't
+// want to carry. Not exposed in the UI — kept deliberately simple.
+inline constexpr float kContextCarryMinConfidence = 0.65f;
+
+// Whether a decoded segment should become the next decode's carried context
+// prompt (RFC #4818). Free + inline so it is unit-testable without a loaded
+// whisper_context: carry only confident, non-empty text — a marginal or empty
+// decode returns false, which the caller honours by leaving the previous prompt
+// in place rather than replacing it with garbage.
+inline bool asrShouldCarryContext(const QString& text, float confidence)
+{
+    return !text.isEmpty() && confidence >= kContextCarryMinConfidence;
+}
+
 // whisper.cpp implementation of IAsrBackend. CPU inference (the vendored ggml
 // is CPU-only for now); language defaults to English but is configurable.
 // Lives entirely on AsrEngine's worker thread.

--- a/src/asr/WhisperAsrBackend.h
+++ b/src/asr/WhisperAsrBackend.h
@@ -27,6 +27,15 @@ public:
     bool isLoaded() const override { return m_ctx != nullptr; }
     AsrTranscript transcribe(const std::vector<float>& pcm16k, QString* error) override;
     void unload() override;
+    // Opt-in (RFC #4818): see IAsrBackend::setContextCarryEnabled. The
+    // carried text is passed as an explicit decode prompt (whisper's
+    // initial_prompt), and only a segment whose confidence clears the gate (see
+    // .cpp) is stored as the next call's prompt, so a garbled decode can't poison
+    // it.
+    void setContextCarryEnabled(bool on) override;
+    // Drop the carried prompt so the next decode starts clean (long silence gap
+    // or explicit Clear). See IAsrBackend::resetContext.
+    void resetContext() override;
 
 private:
     whisper_context* m_ctx = nullptr;
@@ -37,6 +46,11 @@ private:
     // load(), so a decode-time throw never latches a device that was not
     // involved.
     bool m_ctxOnGpu = false;
+    bool m_contextCarryEnabled = false;
+    // The last confident segment's text, carried forward as the next decode's
+    // explicit prompt when context-carry is on. Empty = start clean (right after
+    // load(), a reset, or while no segment has cleared the confidence gate).
+    QString m_carriedPrompt;
 };
 
 // A selectable GPU: `index` is the value to pass as gpuDevice (its position among

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -172,6 +172,7 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
         " color: {{color.text.primary}}; border: 1px solid {{color.accent.bright}}; }");
     ThemeManager::instance().applyStyleSheet(m_panel->enableButton(), appletToggleStyle);
     ThemeManager::instance().applyStyleSheet(m_panel->newlineButton(), appletToggleStyle);
+    ThemeManager::instance().applyStyleSheet(m_panel->contextCarryButton(), appletToggleStyle);
 
     // ⚙ settings button — modeled on the band-stack gear button but themed and
     // sized (via the shared toggle padding) to sit flush with this row's buttons.
@@ -212,9 +213,9 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     // language from the model, so hide it when sherpa is the active backend.
     m_settings->setLanguageSelectorVisible(m_backend != AsrBackendKind::SherpaOnnx);
     // Context-carry is implemented only on the whisper backend (sherpa/remote
-    // inherit the IAsrBackend no-ops), so disable the control on those tiers so
-    // it can't promise behavior the active backend won't deliver.
-    m_settings->setContextCarryAvailable(m_backend == AsrBackendKind::Whisper);
+    // inherit the IAsrBackend no-ops), so disable the header toggle on those
+    // tiers so it can't promise behavior the active backend won't deliver.
+    m_panel->setContextCarryAvailable(m_backend == AsrBackendKind::Whisper);
 
     // Panel intent. The ⚙ button toggles the modeless settings dialog; model/GPU
     // changes come from the dialog itself.
@@ -391,11 +392,13 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     connect(m_settings, &CopyAssistSettingsDialog::browseSpeakerModelRequested, this,
             [this] { promptSpeakerModel(); });
 
-    // Context-carry (RFC #4818), live — no engine rebuild needed.
-    m_settings->setContextCarryEnabled(
+    // Context-carry (RFC #4818), live — no engine rebuild needed. The toggle
+    // lives on the panel header (not the ⚙ dialog) so it can be flipped without
+    // opening settings; reflect the persisted state into it without re-emitting.
+    m_panel->setContextCarryChecked(
         CopyAssistSettings::value(QStringLiteral("AsrContextCarryEnabled"), QStringLiteral("False"))
             .toString() == QStringLiteral("True"));
-    connect(m_settings, &CopyAssistSettingsDialog::contextCarryToggled, this, [this](bool on) {
+    connect(m_panel, &CopyAssistPanel::contextCarryToggled, this, [this](bool on) {
         CopyAssistSettings::setValue(QStringLiteral("AsrContextCarryEnabled"),
                                      on ? QStringLiteral("True") : QStringLiteral("False"));
         if (m_asr) {
@@ -905,8 +908,8 @@ void CopyAssistController::setBackend(AsrBackendKind kind, const QString& tierId
     // Language applies to whisper/remote only; sherpa-onnx picks it from the
     // model. Keep the selector's visibility in sync with the active backend.
     m_settings->setLanguageSelectorVisible(kind != AsrBackendKind::SherpaOnnx);
-    // Context-carry is whisper-only; keep the control enabled only there.
-    m_settings->setContextCarryAvailable(kind == AsrBackendKind::Whisper);
+    // Context-carry is whisper-only; keep the header toggle enabled only there.
+    m_panel->setContextCarryAvailable(kind == AsrBackendKind::Whisper);
 
     // Leaving the remote backend clears the persisted auto-connect flag so the
     // next launch starts on the local engine.

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -211,6 +211,10 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     // The language selector only affects whisper/remote; sherpa-onnx takes its
     // language from the model, so hide it when sherpa is the active backend.
     m_settings->setLanguageSelectorVisible(m_backend != AsrBackendKind::SherpaOnnx);
+    // Context-carry is implemented only on the whisper backend (sherpa/remote
+    // inherit the IAsrBackend no-ops), so disable the control on those tiers so
+    // it can't promise behavior the active backend won't deliver.
+    m_settings->setContextCarryAvailable(m_backend == AsrBackendKind::Whisper);
 
     // Panel intent. The ⚙ button toggles the modeless settings dialog; model/GPU
     // changes come from the dialog itself.
@@ -222,6 +226,13 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
             m_settings->show();
             m_settings->raise();
             m_settings->activateWindow();
+        }
+    });
+    // Clear button: the panel already wiped its own text; also flush the carried
+    // decode context so the fresh display starts from a clean prompt (#4333).
+    connect(m_panel, &CopyAssistPanel::clearRequested, this, [this] {
+        if (m_asr) {
+            m_asr->clearContext();
         }
     });
     connect(m_settings, &CopyAssistSettingsDialog::tierChanged, this, &CopyAssistController::onTierChanged);
@@ -379,6 +390,18 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     });
     connect(m_settings, &CopyAssistSettingsDialog::browseSpeakerModelRequested, this,
             [this] { promptSpeakerModel(); });
+
+    // Context-carry (RFC #4818), live — no engine rebuild needed.
+    m_settings->setContextCarryEnabled(
+        CopyAssistSettings::value(QStringLiteral("AsrContextCarryEnabled"), QStringLiteral("False"))
+            .toString() == QStringLiteral("True"));
+    connect(m_settings, &CopyAssistSettingsDialog::contextCarryToggled, this, [this](bool on) {
+        CopyAssistSettings::setValue(QStringLiteral("AsrContextCarryEnabled"),
+                                     on ? QStringLiteral("True") : QStringLiteral("False"));
+        if (m_asr) {
+            m_asr->setContextCarryEnabled(on);
+        }
+    });
 
     // Model download → engine load (the handlers read m_asr at call time, so they
     // survive an engine rebuild on backend switch).
@@ -773,6 +796,14 @@ void CopyAssistController::applyTuning()
         CopyAssistSettings::value(QStringLiteral("AsrSensitivity"), QStringLiteral("80")).toString().toInt()));
     m_asr->setSilenceDurationMs(CopyAssistSettings::value(QStringLiteral("AsrSilenceMs"), QStringLiteral("300")).toString().toInt());
     m_asr->setOverlapMs(CopyAssistSettings::value(QStringLiteral("AsrBoundaryOverlapMs"), QStringLiteral("0")).toString().toInt());
+
+    // Context-carry (RFC #4818) — a fresh engine (backend switch, model change)
+    // starts with this off by default; re-apply the persisted state so it
+    // survives a rebuild, same as the tuning above.
+    const bool contextCarry =
+        CopyAssistSettings::value(QStringLiteral("AsrContextCarryEnabled"), QStringLiteral("False")).toString()
+        == QStringLiteral("True");
+    m_asr->setContextCarryEnabled(contextCarry);
 }
 
 void CopyAssistController::onEnableToggled(bool on)
@@ -874,6 +905,8 @@ void CopyAssistController::setBackend(AsrBackendKind kind, const QString& tierId
     // Language applies to whisper/remote only; sherpa-onnx picks it from the
     // model. Keep the selector's visibility in sync with the active backend.
     m_settings->setLanguageSelectorVisible(kind != AsrBackendKind::SherpaOnnx);
+    // Context-carry is whisper-only; keep the control enabled only there.
+    m_settings->setContextCarryAvailable(kind == AsrBackendKind::Whisper);
 
     // Leaving the remote backend clears the persisted auto-connect flag so the
     // next launch starts on the local engine.

--- a/src/gui/CopyAssistPanel.cpp
+++ b/src/gui/CopyAssistPanel.cpp
@@ -6,6 +6,7 @@
 #include <QMenu>
 #include <QProgressBar>
 #include <QPushButton>
+#include <QSignalBlocker>
 #include <QSlider>
 #include <QTextCharFormat>
 #include <QTextCursor>
@@ -115,6 +116,20 @@ CopyAssistPanel::CopyAssistPanel(QWidget* parent)
         emit newlineOnSilenceChanged(on);
     });
     controls->addWidget(m_newline);
+
+    // Context-carry toggle (RFC #4818). When on, each decode is conditioned on the
+    // previous confident segment's text for continuity across boundaries. Here on
+    // the header (not buried in ⚙ settings) so it can be A/B'd on the fly; the
+    // controller greys it out on the non-whisper tiers that can't honor it.
+    m_contextCarry = new QPushButton(tr("Context"), this);
+    m_contextCarry->setCheckable(true);
+    m_contextCarry->setToolTip(tr("Condition each decode on the previous confident segment's own "
+                                  "text, for continuity across segment boundaries. Gated internally "
+                                  "by that segment's confidence, so a garbled decode doesn't poison "
+                                  "the next one; a pause or Clear starts fresh. (whisper model only)"));
+    m_contextCarry->setAccessibleName(tr("Carry context across segments"));
+    connect(m_contextCarry, &QPushButton::toggled, this, &CopyAssistPanel::contextCarryToggled);
+    controls->addWidget(m_contextCarry);
 
     m_clear = new QPushButton(tr("Clear"), this);
     m_clear->setAccessibleName(tr("Clear transcript"));
@@ -345,6 +360,22 @@ void CopyAssistPanel::appendText(const QString& text, float confidence)
 void CopyAssistPanel::setNewlineOnSilence(bool on)
 {
     m_newline->setChecked(on); // fires toggled → updates m_newlineOnSilence + emits
+}
+
+void CopyAssistPanel::setContextCarryChecked(bool on)
+{
+    // Reflect persisted/programmatic state without echoing back out as an
+    // operator toggle (which would re-persist and re-apply what we just read).
+    const QSignalBlocker block(m_contextCarry);
+    m_contextCarry->setChecked(on);
+}
+
+void CopyAssistPanel::setContextCarryAvailable(bool available)
+{
+    // Whisper-only: greyed out on backends that inherit IAsrBackend's no-op
+    // context hooks. The checked state is preserved so it re-applies if the
+    // operator switches back to whisper.
+    m_contextCarry->setEnabled(available);
 }
 
 void CopyAssistPanel::clearText()

--- a/src/gui/CopyAssistPanel.h
+++ b/src/gui/CopyAssistPanel.h
@@ -46,10 +46,19 @@ public:
     // The ↵ newline-on-silence toggle — exposed so the controller can apply the
     // themed applet-toggle style (panel stays ThemeManager-free).
     QPushButton* newlineButton() const { return m_newline; }
+    // The "Context" context-carry toggle (RFC #4818) — exposed so the controller
+    // can apply the themed applet-toggle style (panel stays ThemeManager-free).
+    QPushButton* contextCarryButton() const { return m_contextCarry; }
 
     // When on, each utterance (VAD end-of-speech) begins on a new line.
     void setNewlineOnSilence(bool on);
     bool newlineOnSilence() const { return m_newlineOnSilence; }
+
+    // Context-carry (RFC #4818) header toggle. setContextCarryChecked reflects the
+    // persisted state without re-emitting; setContextCarryAvailable greys it out
+    // on the non-whisper tiers whose backends can't honor it (with a tooltip).
+    void setContextCarryChecked(bool on);
+    void setContextCarryAvailable(bool available);
 
     // Decode-buffer size in milliseconds (1000–20000). The slider works in
     // whole seconds; setBufferMs rounds/clamps into range.
@@ -82,6 +91,7 @@ signals:
     void silenceMsChanged(int ms);
     void fontPxChanged(int px);
     void newlineOnSilenceChanged(bool on);
+    void contextCarryToggled(bool on);
 
 private:
     static QString colorForConfidence(float confidence);
@@ -96,6 +106,7 @@ private:
     QTextEdit* m_text = nullptr;
     QPushButton* m_enable = nullptr;   // checkable: "Enable" / "Disable"
     QPushButton* m_newline = nullptr;  // checkable ↵: newline on each silence
+    QPushButton* m_contextCarry = nullptr; // checkable: carry context across segments
     QPushButton* m_settings = nullptr; // ⚙: opens the modeless settings dialog
     QLabel* m_status = nullptr;
     QLabel* m_backlog = nullptr; // always-visible transcription backlog (seconds)

--- a/src/gui/CopyAssistSettingsDialog.cpp
+++ b/src/gui/CopyAssistSettingsDialog.cpp
@@ -190,16 +190,6 @@ CopyAssistSettingsDialog::CopyAssistSettingsDialog(QWidget* parent)
     ovRow->addWidget(m_overlapValue);
     form->addRow(tr("Boundary overlap:"), ovRow);
 
-    // Context-carry (RFC #4818): opt-in, off by default; applies live (no engine
-    // rebuild) so the effect can be A/B'd on the fly.
-    m_contextCarry = new QCheckBox(tr("Carry context across segments"), this);
-    m_contextCarry->setToolTip(tr("Condition each decode on the previous confident segment's own "
-                                  "text, for continuity across segment boundaries. Gated internally "
-                                  "by that segment's confidence, so a garbled decode doesn't poison "
-                                  "the next one; a pause or Clear starts fresh."));
-    connect(m_contextCarry, &QCheckBox::toggled, this, &CopyAssistSettingsDialog::contextCarryToggled);
-    form->addRow(m_contextCarry);
-
     root->addLayout(form);
     root->addStretch(1); // headroom for further options added here later
 }
@@ -379,24 +369,6 @@ void CopyAssistSettingsDialog::setBoundaryOverlapMs(int ms)
 int CopyAssistSettingsDialog::boundaryOverlapMs() const
 {
     return m_overlap->value();
-}
-
-void CopyAssistSettingsDialog::setContextCarryEnabled(bool on)
-{
-    m_contextCarry->setChecked(on);
-}
-
-void CopyAssistSettingsDialog::setContextCarryAvailable(bool available)
-{
-    // Whisper-only: greyed out (but its persisted checked state preserved) on
-    // backends that inherit IAsrBackend's no-op context hooks.
-    m_contextCarry->setEnabled(available);
-    m_contextCarry->setToolTip(available
-        ? tr("Condition each decode on the previous confident segment's own "
-             "text, for continuity across segment boundaries. Gated internally "
-             "by that segment's confidence, so a garbled decode doesn't poison "
-             "the next one; a pause or Clear starts fresh.")
-        : tr("Context-carry is available only with the on-device whisper model."));
 }
 
 } // namespace AetherSDR

--- a/src/gui/CopyAssistSettingsDialog.cpp
+++ b/src/gui/CopyAssistSettingsDialog.cpp
@@ -190,6 +190,16 @@ CopyAssistSettingsDialog::CopyAssistSettingsDialog(QWidget* parent)
     ovRow->addWidget(m_overlapValue);
     form->addRow(tr("Boundary overlap:"), ovRow);
 
+    // Context-carry (RFC #4818): opt-in, off by default; applies live (no engine
+    // rebuild) so the effect can be A/B'd on the fly.
+    m_contextCarry = new QCheckBox(tr("Carry context across segments"), this);
+    m_contextCarry->setToolTip(tr("Condition each decode on the previous confident segment's own "
+                                  "text, for continuity across segment boundaries. Gated internally "
+                                  "by that segment's confidence, so a garbled decode doesn't poison "
+                                  "the next one; a pause or Clear starts fresh."));
+    connect(m_contextCarry, &QCheckBox::toggled, this, &CopyAssistSettingsDialog::contextCarryToggled);
+    form->addRow(m_contextCarry);
+
     root->addLayout(form);
     root->addStretch(1); // headroom for further options added here later
 }
@@ -369,6 +379,24 @@ void CopyAssistSettingsDialog::setBoundaryOverlapMs(int ms)
 int CopyAssistSettingsDialog::boundaryOverlapMs() const
 {
     return m_overlap->value();
+}
+
+void CopyAssistSettingsDialog::setContextCarryEnabled(bool on)
+{
+    m_contextCarry->setChecked(on);
+}
+
+void CopyAssistSettingsDialog::setContextCarryAvailable(bool available)
+{
+    // Whisper-only: greyed out (but its persisted checked state preserved) on
+    // backends that inherit IAsrBackend's no-op context hooks.
+    m_contextCarry->setEnabled(available);
+    m_contextCarry->setToolTip(available
+        ? tr("Condition each decode on the previous confident segment's own "
+             "text, for continuity across segment boundaries. Gated internally "
+             "by that segment's confidence, so a garbled decode doesn't poison "
+             "the next one; a pause or Clear starts fresh.")
+        : tr("Context-carry is available only with the on-device whisper model."));
 }
 
 } // namespace AetherSDR

--- a/src/gui/CopyAssistSettingsDialog.h
+++ b/src/gui/CopyAssistSettingsDialog.h
@@ -81,13 +81,9 @@ public:
     // boundary isn't lost. 0 = off (the default). Opt-in.
     void setBoundaryOverlapMs(int ms);
     int boundaryOverlapMs() const;
-    // Context-carry (RFC #4818): opt-in, off by default. See
-    // AsrEngine::setContextCarryEnabled for what it does.
-    void setContextCarryEnabled(bool on);
-    // Enable/disable the checkbox itself: context-carry is whisper-only, so the
-    // controller greys it out on the sherpa-onnx / remote tiers where the backend
-    // can't honor it.
-    void setContextCarryAvailable(bool available);
+    // Context-carry (RFC #4818) has no control here — it lives on the panel
+    // header (CopyAssistPanel::contextCarryButton) so it can be toggled without
+    // opening this dialog.
 
 signals:
     void tierChanged(const QString& tierId);
@@ -101,7 +97,6 @@ signals:
     void browseSpeakerModelRequested();
     void speakerThresholdChanged(int percent);
     void boundaryOverlapChanged(int ms);
-    void contextCarryToggled(bool on);
 
 private:
     QComboBox* m_tier = nullptr;
@@ -122,7 +117,6 @@ private:
     QLabel* m_spkThresholdValue = nullptr;
     QSlider* m_overlap = nullptr;
     QLabel* m_overlapValue = nullptr;
-    QCheckBox* m_contextCarry = nullptr;
 };
 
 } // namespace AetherSDR

--- a/src/gui/CopyAssistSettingsDialog.h
+++ b/src/gui/CopyAssistSettingsDialog.h
@@ -81,6 +81,13 @@ public:
     // boundary isn't lost. 0 = off (the default). Opt-in.
     void setBoundaryOverlapMs(int ms);
     int boundaryOverlapMs() const;
+    // Context-carry (RFC #4818): opt-in, off by default. See
+    // AsrEngine::setContextCarryEnabled for what it does.
+    void setContextCarryEnabled(bool on);
+    // Enable/disable the checkbox itself: context-carry is whisper-only, so the
+    // controller greys it out on the sherpa-onnx / remote tiers where the backend
+    // can't honor it.
+    void setContextCarryAvailable(bool available);
 
 signals:
     void tierChanged(const QString& tierId);
@@ -94,6 +101,7 @@ signals:
     void browseSpeakerModelRequested();
     void speakerThresholdChanged(int percent);
     void boundaryOverlapChanged(int ms);
+    void contextCarryToggled(bool on);
 
 private:
     QComboBox* m_tier = nullptr;
@@ -114,6 +122,7 @@ private:
     QLabel* m_spkThresholdValue = nullptr;
     QSlider* m_overlap = nullptr;
     QLabel* m_overlapValue = nullptr;
+    QCheckBox* m_contextCarry = nullptr;
 };
 
 } // namespace AetherSDR

--- a/tests/asr_engine_test.cpp
+++ b/tests/asr_engine_test.cpp
@@ -10,11 +10,13 @@
 
 #include <QCoreApplication>
 #include <QElapsedTimer>
+#include <QEventLoop>
 #include <QSignalSpy>
 #include <QThread>
 #include <QTimer>
 #include <QVector>
 
+#include <atomic>
 #include <cmath>
 #include <cstdio>
 #include <memory>
@@ -145,6 +147,55 @@ private:
 AsrBackendFactory slowFactory(int delayMs)
 {
     return [delayMs] { return std::unique_ptr<IAsrBackend>(new SlowBackend(delayMs)); };
+}
+
+// Records the context-carry control calls so the engine's wiring can be checked
+// from the test thread. Counters are atomic (the backend lives on the worker).
+class ContextFake : public IAsrBackend {
+public:
+    bool load(const QString&, QString*) override { m_loaded = true; return true; }
+    bool isLoaded() const override { return m_loaded; }
+    AsrTranscript transcribe(const std::vector<float>& pcm, QString*) override
+    {
+        if (pcm.empty()) {
+            return {};
+        }
+        return AsrTranscript{QStringLiteral("OVER"), 0.9f};
+    }
+    void unload() override { m_loaded = false; }
+    void setContextCarryEnabled(bool on) override { carryEnabled.store(on); }
+    void resetContext() override { resets.fetch_add(1); }
+
+    std::atomic<bool> carryEnabled{false};
+    std::atomic<int> resets{0};
+
+private:
+    bool m_loaded = false;
+};
+
+// Factory that also publishes the constructed backend pointer so the test can
+// read its counters. The engine owns the instance; the sink is a non-owning view
+// valid until the engine is destroyed.
+AsrBackendFactory contextFactory(std::atomic<ContextFake*>* sink)
+{
+    return [sink] {
+        auto* b = new ContextFake();
+        sink->store(b, std::memory_order_release);
+        return std::unique_ptr<IAsrBackend>(b);
+    };
+}
+
+// Spin the event loop until pred() holds or the timeout elapses.
+template <typename Pred>
+bool waitUntil(Pred pred, int timeoutMs)
+{
+    QElapsedTimer t;
+    t.start();
+    while (!pred() && t.elapsed() < timeoutMs) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+        QThread::msleep(5);
+    }
+    return pred();
 }
 
 // Deterministic stand-in for building the ~24 MB ECAPA session: the sleep is
@@ -620,6 +671,40 @@ int main(int argc, char** argv)
         // may complete — the rest of the backlog must be dropped.
         expect(textSpy.count() <= 1,
                "disabling drops the backlog instead of transcribing all of it");
+    }
+
+    // ---- Context-carry control reaches the backend (RFC #4818) ------------
+    // The engine must marshal setContextCarryEnabled() to the backend, flush its
+    // context on a long idle-silence gap, and flush again on clearContext()
+    // (the Copy Assist Clear button). Verified via a fake that counts the calls.
+    {
+        std::atomic<ContextFake*> sink{nullptr};
+        AsrEngine engine(contextFactory(&sink));
+        QSignalSpy readySpy(&engine, &AsrEngine::ready);
+        engine.setModelPath(QStringLiteral("/does/not/matter"));
+        expect(readySpy.wait(5000), "context test: engine ready");
+        expect(waitUntil([&] { return sink.load() != nullptr; }, 2000),
+               "fake backend was constructed on the worker");
+        ContextFake* backend = sink.load();
+
+        engine.setEnabled(true);
+        engine.setContextCarryEnabled(true);
+        expect(waitUntil([&] { return backend->carryEnabled.load(); }, 2000),
+               "setContextCarryEnabled reaches the backend");
+
+        // A real pause (idle silence past longGapMs = 2500) flushes the context.
+        const int resetsBeforeGap = backend->resets.load();
+        engine.pushAudio(tone(400), kSrcRate);
+        engine.pushAudio(silence(400), kSrcRate);   // hangover closes the utterance
+        engine.pushAudio(silence(3000), kSrcRate);  // > 2500 ms idle -> long gap
+        expect(waitUntil([&] { return backend->resets.load() > resetsBeforeGap; }, 5000),
+               "a long silence gap flushes the carried context");
+
+        // The Clear button flushes it too.
+        const int resetsBeforeClear = backend->resets.load();
+        engine.clearContext();
+        expect(waitUntil([&] { return backend->resets.load() > resetsBeforeClear; }, 5000),
+               "clearContext() flushes the carried context");
     }
 
     // ---- Load failure surfaces loadFailed(), not ready() ------------------

--- a/tests/asr_engine_test.cpp
+++ b/tests/asr_engine_test.cpp
@@ -6,6 +6,7 @@
 #include "asr/AsrEngine.h"
 #include "asr/IAsrBackend.h"
 #include "asr/SpeakerEmbedder.h"
+#include "asr/WhisperAsrBackend.h"
 #include "gui/CopyAssistController.h"
 
 #include <QCoreApplication>
@@ -238,6 +239,25 @@ QVector<float> silence(int ms)
 int main(int argc, char** argv)
 {
     QCoreApplication app(argc, argv);
+
+    // ---- Context-carry confidence gate (RFC #4818) ------------------------
+    // The gate is the whole recovery story: it decides whether a decode's text
+    // seeds the next decode's prompt. Pinned here as a pure function so the three
+    // cases can't regress silently (an inverted comparison or a 0.0 threshold).
+    {
+        expect(asrShouldCarryContext(QStringLiteral("CQ DE K5PTB"), 0.90f),
+               "gate: confident non-empty text carries");
+        expect(!asrShouldCarryContext(QStringLiteral("garbled"), 0.40f),
+               "gate: sub-threshold confidence does not carry (prev prompt stays)");
+        expect(!asrShouldCarryContext(QString(), 0.99f),
+               "gate: empty text never carries, regardless of confidence");
+        // Boundary: kContextCarryMinConfidence itself carries; just under does not.
+        expect(asrShouldCarryContext(QStringLiteral("x"), kContextCarryMinConfidence),
+               "gate: confidence exactly at the floor carries");
+        expect(!asrShouldCarryContext(QStringLiteral("x"),
+                                      kContextCarryMinConfidence - 0.01f),
+               "gate: just below the floor does not carry");
+    }
 
     // ---- Engine replacement discards only per-engine speaker state --------
     {

--- a/tests/asr_segmenter_test.cpp
+++ b/tests/asr_segmenter_test.cpp
@@ -259,6 +259,43 @@ int main()
         expect(out.size() >= 2, "overlap: overlap >= cap still splits into segments");
     }
 
+    // Long idle-gap detection (context-carry recovery, RFC #4818): a run of idle
+    // silence at least Config::longGapMs long latches consumeLongGap() exactly
+    // once, and re-arms after speech resumes. Default longGapMs is 2500.
+    {
+        AsrSegmenter seg; // default longGapMs = 2500
+        std::vector<float> lead;
+        appendTone(lead, 300);      // an utterance so we're past the initial state
+        appendSilence(lead, 400);   // hangover closes it; idle gap starts after
+        seg.feed(lead.data(), static_cast<int>(lead.size()));
+        expect(!seg.consumeLongGap(), "no long gap yet after a short pause");
+
+        std::vector<float> gap;
+        appendSilence(gap, 2600);   // > 2500 ms of idle silence
+        seg.feed(gap.data(), static_cast<int>(gap.size()));
+        expect(seg.consumeLongGap(), "idle silence past longGapMs latches a long gap");
+        expect(!seg.consumeLongGap(), "consumeLongGap is a one-shot (cleared on read)");
+
+        // Speech re-arms it: another long idle gap fires again.
+        std::vector<float> more;
+        appendTone(more, 300);
+        appendSilence(more, 400);
+        appendSilence(more, 2600);
+        seg.feed(more.data(), static_cast<int>(more.size()));
+        expect(seg.consumeLongGap(), "long gap re-arms after speech resumes");
+    }
+
+    // longGapMs = 0 disables the detector entirely.
+    {
+        AsrSegmenter::Config cfg;
+        cfg.longGapMs = 0;
+        AsrSegmenter seg(cfg);
+        std::vector<float> audio;
+        appendSilence(audio, 5000); // long silence, but detection is off
+        seg.feed(audio.data(), static_cast<int>(audio.size()));
+        expect(!seg.consumeLongGap(), "longGapMs = 0 never reports a gap");
+    }
+
     std::printf(g_failures == 0 ? "\nASR segmenter: ALL PASS\n"
                                 : "\nASR segmenter: %d FAILURE(S)\n",
                 g_failures);


### PR DESCRIPTION
Implements **RFC #4818** (context-carry for Copy Assist). Opt-in, **off by default**.

## What it does

Conditions each Copy Assist decode on the text the backend produced on its **last confident segment**, for continuity across utterance boundaries (names, callsigns, topic). Independent per-segment decoding stays the default.

## Mechanism (per #4818 triage)

Context is carried via whisper's explicit **`initial_prompt`** — **not** by enabling whisper's internal cross-call prompt (`no_context` stays `true`). whisper rebuilds that internal prompt from every decode unconditionally, so the confidence gate could never reach it — that was the "kept re-seeding and couldn't recover" behavior on noisy audio. With an explicit prompt, the gate and reset paths fully control what conditions the next decode, and it's unit-testable against a fake backend with no model. (Thanks to triage for catching this.)

## Recovery — ways a garbled prior stops compounding

- **Confidence gate** — only a segment ≥ `kContextCarryMinConfidence` (**0.65**, aligned with the panel's yellow band) becomes the next prompt; a marginal decode leaves the last good prompt in place. Extracted to a free, inline `asrShouldCarryContext(text, confidence)` so it's unit-tested directly.
- **Silence-gap flush** — a real pause (`longGapMs = 2500`, fixed) drops the carried prompt via a one-shot `consumeLongGap()`. Applied *after* the current feed's own segments are decoded, so a segment that closed before the gap still gets the prior context.
- **Clear / retune flush** — `CopyAssistPanel::clearRequested` was previously **unconnected** (a pre-existing bug — Clear wiped only the text box); now wired to `AsrEngine::clearContext()`. `AsrWorker::reset()` (the retune path) also flushes, so Clear and a frequency change both start clean.
- **Bounded prompt** — the carried text is kept to its tail (`right(1000)`), since whisper consumes only its last ~223 prompt tokens and can echo `initial_prompt` back into its output (which would otherwise compound run over run).

## Interface / UI

`IAsrBackend` gains `setContextCarryEnabled()` / `resetContext()` (no-op defaults; whisper implements them); `transcribe()` keeps its 2-arg signature. The control is a checkable **"Context"** toggle on the **Copy Assist panel header** (next to ↵ and Clear) — so it can be flipped without opening ⚙ settings, matching how the DeepCW DSP/Neural selector lives on its decode-panel header. Persisted (`AsrContextCarryEnabled`), applied live (no engine rebuild), and greyed out on the sherpa-onnx / remote tiers whose backends can't honor it.

## Tests

New segmenter coverage (long-gap one-shot: latch / one-shot read / re-arm / disabled at 0); engine coverage (a fake backend confirms `setContextCarryEnabled`, the long-gap flush, and `clearContext()` all reach the backend); and direct coverage of the confidence gate (`asrShouldCarryContext`: confident non-empty carries, sub-threshold does not, empty never does, and the exact floor boundary).

## Testing

Built + tested on: **MacBook Air M2** (full app + `asr_segmenter_test` + `asr_engine_test` pass). Rebased onto current `main` after #4837 (segment-overlap) and #4767 (whisper GPU exception guard) landed — keep-both on the adjacent `WhisperAsrBackend` / `AsrSegmenter` hunks; the context-carry × overlap integration is byte-identical to the pre-rebase branch.

---

**Revision note (addressing review):** dropped an inaccurate "UTF-8 fix" claim from an earlier body/commit message — `whisper_full_get_segment_text()` already predates this PR (#4338), so there was no per-token concatenation to fix. Long-gap flush ordering corrected, carried prompt bounded, confidence gate lifted to a tested free function, the no-op `closeSegment()` reorder dropped, `docs/asr-copy-assist.md` updated, and the enable control moved from the ⚙ dialog to the panel header (one control, one place).
