### PR TITLE
Guard wheel action dispatch chain with isKnownWheelAction predicate. Principle VII.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,21 @@ jobs:
       - name: Test HL2 AM/SAM DC blocker
         run: ctest --test-dir build -R "hl2_am_dcblock_test" --output-on-failure
 
+      # ulanzi_mapping_migration_test joins the gate for the same reason as the
+      # steps above, and #4834 is what made it earn the slot. Guarding wheel
+      # dispatch on UlanziDialMappings::knownWheelActions() turned an
+      # unrecognised action id from a harmless fall-through into an early
+      # return, so an action added to the else-if chain and forgotten in the
+      # registry is now a control that silently does nothing — no log, no
+      # crash, nothing any other assertion in the tree can see. The test parses
+      # the chain out of the source and asserts the two are the same set, which
+      # is only worth having if it runs before the merge rather than on the
+      # weekly sanitizers job. Pure string and settings work against a target
+      # the Build step already linked: no widgets, no event loop, no wall
+      # clock, milliseconds to run.
+      - name: Test Ulanzi dial mappings and wheel-action registry drift
+        run: ctest --test-dir build -R "ulanzi_mapping_migration_test" --output-on-failure
+
       # #4146 turned liquid-dsp off by default, so the main build above no
       # longer proves the vendored snapshot still compiles. Build only the
       # liquid-static target (separate build dir, opt-in flag) so a bitrotted

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5635,6 +5635,11 @@ add_executable(ulanzi_mapping_migration_test
     ${AETHER_SETTINGS_SOURCES}
 )
 target_include_directories(ulanzi_mapping_migration_test PRIVATE src tests)
+# The drift assertion parses the wheel-action else-if chain out of
+# MainWindow_Controllers.cpp at run time, so it needs to find the source tree
+# from wherever ctest runs it.
+target_compile_definitions(ulanzi_mapping_migration_test PRIVATE
+    AETHER_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(ulanzi_mapping_migration_test PRIVATE Qt6::Core)
 add_test(NAME ulanzi_mapping_migration_test COMMAND ulanzi_mapping_migration_test)
 

--- a/src/core/UlanziDialMappings.cpp
+++ b/src/core/UlanziDialMappings.cpp
@@ -168,7 +168,7 @@ bool UlanziDialMappings::setRotaryAction(const QString& actionId)
     return setActionForPill(QStringLiteral("rotary_action"), actionId);
 }
 
-bool UlanziDialMappings::isKnownWheelAction(const QString& actionId)
+const QStringList& UlanziDialMappings::knownWheelActions()
 {
     // Mirrors the else-if chain in MainWindow::applyFlexControlWheelAction
     // (MainWindow_Controllers.cpp) — a new wheel action must be added to BOTH.
@@ -192,7 +192,12 @@ bool UlanziDialMappings::isKnownWheelAction(const QString& actionId)
         QStringLiteral("PanadapterZoom"),
         QStringLiteral("WheelRfGain")
     };
-    return kKnownWheelActions.contains(actionId);
+    return kKnownWheelActions;
+}
+
+bool UlanziDialMappings::isKnownWheelAction(const QString& actionId)
+{
+    return knownWheelActions().contains(actionId);
 }
 
 }  // namespace AetherSDR

--- a/src/core/UlanziDialMappings.cpp
+++ b/src/core/UlanziDialMappings.cpp
@@ -172,6 +172,11 @@ const QStringList& UlanziDialMappings::knownWheelActions()
 {
     // Mirrors the else-if chain in MainWindow::applyFlexControlWheelAction
     // (MainWindow_Controllers.cpp) — a new wheel action must be added to BOTH.
+    // That is enforced, not just asked for: ulanzi_mapping_migration_test
+    // parses the chain out of the source and asserts the two are the same set
+    // in both directions. Since applyFlexControlWheelAction now returns early
+    // on an id missing from this list, drift here is a silently dead control
+    // rather than a harmless fall-through.
     static const QStringList kKnownWheelActions = {
         QStringLiteral("WheelFrequency"),
         QStringLiteral("WheelRit"),

--- a/src/core/UlanziDialMappings.cpp
+++ b/src/core/UlanziDialMappings.cpp
@@ -168,4 +168,31 @@ bool UlanziDialMappings::setRotaryAction(const QString& actionId)
     return setActionForPill(QStringLiteral("rotary_action"), actionId);
 }
 
+bool UlanziDialMappings::isKnownWheelAction(const QString& actionId)
+{
+    // Mirrors the else-if chain in MainWindow::applyFlexControlWheelAction
+    // (MainWindow_Controllers.cpp) — a new wheel action must be added to BOTH.
+    static const QStringList kKnownWheelActions = {
+        QStringLiteral("WheelFrequency"),
+        QStringLiteral("WheelRit"),
+        QStringLiteral("WheelXit"),
+        QStringLiteral("WheelVolume"),
+        QStringLiteral("WheelMasterAf"),
+        QStringLiteral("WheelSliceAudio"),
+        QStringLiteral("WheelHeadphoneVolume"),
+        QStringLiteral("WheelAgcT"),
+        QStringLiteral("WheelApf"),
+        QStringLiteral("NextSlice"),
+        QStringLiteral("PrevSlice"),
+        QStringLiteral("WheelPower"),
+        QStringLiteral("WheelCwSpeed"),
+        QStringLiteral("BandZoom"),
+        QStringLiteral("SegmentZoom"),
+        QStringLiteral("FilterWidth"),
+        QStringLiteral("PanadapterZoom"),
+        QStringLiteral("WheelRfGain")
+    };
+    return kKnownWheelActions.contains(actionId);
+}
+
 }  // namespace AetherSDR

--- a/src/core/UlanziDialMappings.h
+++ b/src/core/UlanziDialMappings.h
@@ -46,6 +46,9 @@ public:
     // Bind rotary action and persist immediately inside the UlanziDialMappings root document.
     static bool setRotaryAction(const QString& actionId);
 
+    // True if actionId is a recognized wheel action handled by the wheel dispatch chain.
+    static bool isKnownWheelAction(const QString& actionId);
+
     // Pre-#4611 per-pill key names, retained only as migration sources.
     static QString legacyUnderscoreKey(const QString& pillId);
     static QString legacySlashKey(const QString& pillId);

--- a/src/core/UlanziDialMappings.h
+++ b/src/core/UlanziDialMappings.h
@@ -46,6 +46,9 @@ public:
     // Bind rotary action and persist immediately inside the UlanziDialMappings root document.
     static bool setRotaryAction(const QString& actionId);
 
+    // Returns the complete list of wheel action IDs handled by the wheel dispatch chain.
+    static const QStringList& knownWheelActions();
+
     // True if actionId is a recognized wheel action handled by the wheel dispatch chain.
     static bool isKnownWheelAction(const QString& actionId);
 

--- a/src/gui/MainWindowHelpers.h
+++ b/src/gui/MainWindowHelpers.h
@@ -123,6 +123,14 @@ inline constexpr int kSwrSweepMaxPoints = 260;
 inline constexpr qint64 kPanLayoutRestoreWaitingForFirstPan = -1;
 inline constexpr int kPanLayoutRestoreWindowMs = 30000;
 
+// ─── Panadapter zoom step factors ──────────────────────────────────────────
+//
+// Keyboard step uses kPanZoomFactor per press; rotary dials use a finer
+// per-detent factor (kRotaryPanZoomFactor) for smooth spins.
+
+inline constexpr double kPanZoomFactor = 1.5;
+inline constexpr double kRotaryPanZoomFactor = 1.25;
+
 // ─── Pan layout ──────────────────────────────────────────────────────────────
 
 // Pan count for a saved layout id (e.g. "2x2" → 4); 1 for unknown ids.

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -1477,8 +1477,7 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
         }
     } else if (actionId == "PanadapterZoom") {
         // Rotary dial uses a finer per-detent factor (kRotaryPanZoomFactor vs
-        // keyboard kPanZoomFactor in MainWindow_Shortcuts.cpp) for smooth spins.
-        static constexpr double kRotaryPanZoomFactor = 1.25;
+        // keyboard kPanZoomFactor in MainWindowHelpers.h) for smooth spins.
         const double baseFactor = steps > 0 ? (1.0 / kRotaryPanZoomFactor) : kRotaryPanZoomFactor;
         const double factor = std::pow(baseFactor, std::abs(steps));
         zoomActivePanadapter(factor);

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -1340,7 +1340,7 @@ int MainWindow::injectMidiVfoCcForAutomation(int value)
 
 void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
 {
-    if (steps == 0)
+    if (steps == 0 || !UlanziDialMappings::isKnownWheelAction(actionId))
         return;
 
     if (actionId == "WheelFrequency") {

--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -1218,8 +1218,7 @@ void MainWindow::registerShortcutActions()
     m_shortcutManager.registerAction("segment_zoom", "Segment Zoom", "Display",
         QKeySequence(), [this]() { togglePanZoomMode(/*segmentZoom=*/true); });
     // Keyboard step uses kPanZoomFactor per press; rotary dials use a finer
-    // per-detent factor (kRotaryPanZoomFactor in MainWindow_Controllers.cpp).
-    static constexpr double kPanZoomFactor = 1.5;
+    // per-detent factor (kRotaryPanZoomFactor in MainWindowHelpers.h).
     m_shortcutManager.registerAction("pan_zoom_in", "Panadapter Zoom In", "Display",
         QKeySequence(Qt::Key_Equal), [this]() { zoomActivePanadapter(1.0 / kPanZoomFactor); });
     m_shortcutManager.registerAction("pan_zoom_out", "Panadapter Zoom Out", "Display",

--- a/tests/ulanzi_mapping_migration_test.cpp
+++ b/tests/ulanzi_mapping_migration_test.cpp
@@ -178,6 +178,16 @@ int main(int argc, char** argv)
     ok &= expect(UlanziDialMappings::rotaryAction() == QStringLiteral("WheelCorruptAction4756"),
                  "unrecognized rotary action id survives reload and round-trips as-is");
 
+    // ── dispatch seam: unrecognized action id is not a known wheel action ─
+    ok &= expect(!UlanziDialMappings::isKnownWheelAction(UlanziDialMappings::rotaryAction()),
+                 "stored unrecognized rotary action is not a known wheel action");
+    ok &= expect(!UlanziDialMappings::isKnownWheelAction(QStringLiteral("NotAnAction")),
+                 "'NotAnAction' is not a known wheel action");
+    ok &= expect(UlanziDialMappings::isKnownWheelAction(QStringLiteral("WheelFrequency")),
+                 "'WheelFrequency' is a known wheel action");
+    ok &= expect(UlanziDialMappings::isKnownWheelAction(QStringLiteral("WheelVolume")),
+                 "'WheelVolume' is a known wheel action");
+
     std::cout << (ok ? "ALL PASS" : "FAILURES") << '\n';
     return ok ? 0 : 1;
 }

--- a/tests/ulanzi_mapping_migration_test.cpp
+++ b/tests/ulanzi_mapping_migration_test.cpp
@@ -16,8 +16,10 @@
 #include "core/UlanziDialMappings.h"
 
 #include <QCoreApplication>
+#include <QFile>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QRegularExpression>
 #include <QStringList>
 
 #include <iostream>
@@ -193,6 +195,51 @@ int main(int argc, char** argv)
         }
     }
     ok &= expect(allKnown, "every action in knownWheelActions registry is recognized by isKnownWheelAction");
+
+    // ── drift detection: assert every actionId handled by applyFlexControlWheelAction is registered ─
+    auto extractDispatchActions = []() -> QStringList {
+        QStringList candidates = {
+            QStringLiteral("src/gui/MainWindow_Controllers.cpp"),
+            QStringLiteral("../src/gui/MainWindow_Controllers.cpp"),
+            QStringLiteral("../../src/gui/MainWindow_Controllers.cpp")
+        };
+        QFile file;
+        for (const QString& cand : candidates) {
+            file.setFileName(cand);
+            if (file.exists()) break;
+        }
+        if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+            return {};
+        const QString content = QString::fromUtf8(file.readAll());
+        file.close();
+
+        const int start = content.indexOf(QStringLiteral("applyFlexControlWheelAction("));
+        if (start < 0) return {};
+        const int end = content.indexOf(QStringLiteral("QJsonObject MainWindow::buildControlDevicesSnapshot"), start);
+        const QString fnBody = end > start ? content.mid(start, end - start) : content.mid(start, 2500);
+
+        static const QRegularExpression rx(QStringLiteral("actionId\\s*==\\s*\"([^\"]+)\""));
+        QRegularExpressionMatchIterator it = rx.globalMatch(fnBody);
+        QStringList list;
+        while (it.hasNext()) {
+            list.append(it.next().captured(1));
+        }
+        return list;
+    };
+
+    const QStringList dispatchActions = extractDispatchActions();
+    ok &= expect(!dispatchActions.isEmpty(),
+                 "extracted dispatch action IDs from MainWindow_Controllers.cpp applyFlexControlWheelAction");
+    bool allDispatchRegistered = true;
+    for (const QString& act : dispatchActions) {
+        if (!UlanziDialMappings::isKnownWheelAction(act)) {
+            std::cout << "[FAIL] Action '" << act.toStdString()
+                      << "' in applyFlexControlWheelAction is missing from UlanziDialMappings::knownWheelActions()\n";
+            allDispatchRegistered = false;
+        }
+    }
+    ok &= expect(allDispatchRegistered,
+                 "every actionId handled in applyFlexControlWheelAction is registered in UlanziDialMappings::knownWheelActions()");
 
     std::cout << (ok ? "ALL PASS" : "FAILURES") << '\n';
     return ok ? 0 : 1;

--- a/tests/ulanzi_mapping_migration_test.cpp
+++ b/tests/ulanzi_mapping_migration_test.cpp
@@ -183,10 +183,16 @@ int main(int argc, char** argv)
                  "stored unrecognized rotary action is not a known wheel action");
     ok &= expect(!UlanziDialMappings::isKnownWheelAction(QStringLiteral("NotAnAction")),
                  "'NotAnAction' is not a known wheel action");
-    ok &= expect(UlanziDialMappings::isKnownWheelAction(QStringLiteral("WheelFrequency")),
-                 "'WheelFrequency' is a known wheel action");
-    ok &= expect(UlanziDialMappings::isKnownWheelAction(QStringLiteral("WheelVolume")),
-                 "'WheelVolume' is a known wheel action");
+    const QStringList& known = UlanziDialMappings::knownWheelActions();
+    ok &= expect(known.size() == 18, "knownWheelActions registry contains exactly 18 dispatch actions");
+    bool allKnown = true;
+    for (const QString& action : known) {
+        if (!UlanziDialMappings::isKnownWheelAction(action)) {
+            allKnown = false;
+            break;
+        }
+    }
+    ok &= expect(allKnown, "every action in knownWheelActions registry is recognized by isKnownWheelAction");
 
     std::cout << (ok ? "ALL PASS" : "FAILURES") << '\n';
     return ok ? 0 : 1;

--- a/tests/ulanzi_mapping_migration_test.cpp
+++ b/tests/ulanzi_mapping_migration_test.cpp
@@ -186,7 +186,6 @@ int main(int argc, char** argv)
     ok &= expect(!UlanziDialMappings::isKnownWheelAction(QStringLiteral("NotAnAction")),
                  "'NotAnAction' is not a known wheel action");
     const QStringList& known = UlanziDialMappings::knownWheelActions();
-    ok &= expect(known.size() == 18, "knownWheelActions registry contains exactly 18 dispatch actions");
     bool allKnown = true;
     for (const QString& action : known) {
         if (!UlanziDialMappings::isKnownWheelAction(action)) {
@@ -198,7 +197,11 @@ int main(int argc, char** argv)
 
     // ── drift detection: assert every actionId handled by applyFlexControlWheelAction is registered ─
     auto extractDispatchActions = []() -> QStringList {
+        // AETHER_SOURCE_DIR comes from CMake so this works for an
+        // out-of-source build too; the relative forms are the fallback for a
+        // hand-compiled run from the source root or a build directory.
         QStringList candidates = {
+            QStringLiteral(AETHER_SOURCE_DIR "/src/gui/MainWindow_Controllers.cpp"),
             QStringLiteral("src/gui/MainWindow_Controllers.cpp"),
             QStringLiteral("../src/gui/MainWindow_Controllers.cpp"),
             QStringLiteral("../../src/gui/MainWindow_Controllers.cpp")
@@ -213,12 +216,28 @@ int main(int argc, char** argv)
         const QString content = QString::fromUtf8(file.readAll());
         file.close();
 
-        const int start = content.indexOf(QStringLiteral("applyFlexControlWheelAction("));
+        // Anchor on the DEFINITION, not the first mention: the name also
+        // appears at ~:370 as a call inside handleFlexControlTuneSteps, and
+        // anchoring there would sweep a thousand lines of unrelated functions
+        // into the window and attribute their action-id comparisons to this
+        // one.
+        const int start = content.indexOf(
+            QStringLiteral("void MainWindow::applyFlexControlWheelAction("));
         if (start < 0) return {};
-        const int end = content.indexOf(QStringLiteral("QJsonObject MainWindow::buildControlDevicesSnapshot"), start);
-        const QString fnBody = end > start ? content.mid(start, end - start) : content.mid(start, 2500);
+        // Bound on the closing brace in column 0, or give up. A fixed-size
+        // window would silently cover part of the chain and still report a
+        // pass, which is worse than no check at all.
+        const int end = content.indexOf(QStringLiteral("\n}\n"), start);
+        if (end < 0) return {};
+        const QString fnBody = content.mid(start, end - start);
 
-        static const QRegularExpression rx(QStringLiteral("actionId\\s*==\\s*\"([^\"]+)\""));
+        // The optional wrapper matters: `actionId == QLatin1String("...")` is
+        // used in this very file at ~:2549 and is the dominant form in
+        // FlexControlDialog.cpp and HidEncoderManager.cpp. Matching only bare
+        // literals would let a branch written that way escape both the
+        // registry and this check, and the guard would then drop it silently.
+        static const QRegularExpression rx(QStringLiteral(
+            "actionId\\s*==\\s*(?:QLatin1String\\(|QStringLiteral\\()?\"([^\"]+)\""));
         QRegularExpressionMatchIterator it = rx.globalMatch(fnBody);
         QStringList list;
         while (it.hasNext()) {
@@ -240,6 +259,21 @@ int main(int argc, char** argv)
     }
     ok &= expect(allDispatchRegistered,
                  "every actionId handled in applyFlexControlWheelAction is registered in UlanziDialMappings::knownWheelActions()");
+
+    // And the other direction, so the two are one set rather than one subset.
+    // A registry entry with no branch left behind by a removal is a dead id
+    // the guard would wave through; it also replaces a hand-counted size
+    // assertion that had to be edited every time an action was added.
+    bool allRegisteredDispatched = true;
+    for (const QString& action : known) {
+        if (!dispatchActions.contains(action)) {
+            std::cout << "[FAIL] Action '" << action.toStdString()
+                      << "' in UlanziDialMappings::knownWheelActions() has no branch in applyFlexControlWheelAction\n";
+            allRegisteredDispatched = false;
+        }
+    }
+    ok &= expect(allRegisteredDispatched,
+                 "every action in UlanziDialMappings::knownWheelActions() is handled in applyFlexControlWheelAction");
 
     std::cout << (ok ? "ALL PASS" : "FAILURES") << '\n';
     return ok ? 0 : 1;


### PR DESCRIPTION
## Summary

Extract wheel action ID verification into UlanziDialMappings::isKnownWheelAction predicate and guard MainWindow::applyFlexControlWheelAction against unrecognized action IDs, ensuring fall-through wheel actions short-circuit as a harmless no-op.

Add unit test assertions in ulanzi_mapping_migration_test ensuring unrecognized rotary action IDs match no known wheel action. Consolidate kPanZoomFactor and kRotaryPanZoomFactor constants in MainWindowHelpers.h.

Closes #4756

## Constitution principle honored

Principle VII — Boundary Input Validation. Unrecognized rotary action IDs from hand-edited settings documents or external controllers are validated before dispatching wheel actions.

Principle XI — Fixes Are Demonstrated. The dispatch predicate seam is verified by unit test assertions in `ulanzi_mapping_migration_test`.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [X] Behavior verified on a real radio if applicable
- [x] Existing tests pass (`./build/ulanzi_mapping_migration_test`)
- [ ] Reproduction steps documented if user-reported bug

Focused checks:
- `ninja -C build ulanzi_mapping_migration_test` (ALL PASS)
- `ninja -C build AetherSDR`
- `python3 tools/check_engine_boundary.py --strict` (0 findings)

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [ ] Documentation updated if user-visible behavior changed — `docs/` and the
      affected READMEs. **Not `CHANGELOG.md`**, which is a release-prep file a
      PR must not add to (AGENTS.md); describe it in the Summary above instead
- [ ] Security-sensitive changes reference a GHSA if applicable