### PR TITLE
feat(asr): segment-overlap for Copy Assist — boundary-word recovery (RFC #4821)

### DIFF
--- a/docs/asr-copy-assist.md
+++ b/docs/asr-copy-assist.md
@@ -62,6 +62,23 @@ more options. It floats over the app and can stay open while you operate.
   splits), lower = looser (fewer, merged speakers). RF caveats: narrowband/noise
   and propagation drift can split or merge a voice, so expect to tune it.
   Requires an ONNX-Runtime-enabled build.
+- **Boundary overlap** (slider, 0–2000 ms; **0 = Off, the default**) — recovers a
+  word chopped in half by the **Buffer** cap. A long "over" that never pauses is
+  force-closed at the buffer limit, and that cut can land mid-word; because each
+  segment is decoded on its own, the straddling word comes out mangled or
+  missing. With overlap set, the last N ms of a *cap-forced* segment are carried
+  into the front of the next one so the word is decoded whole, and the repeated
+  boundary words are then stripped from the transcript. Applied live, no model
+  reload, and it works on every backend (whisper, sherpa-onnx, remote).
+  - Costs a little extra decoding — the carried audio is transcribed twice — so
+    the practical setting is a few hundred ms, not the maximum. The carry is
+    internally capped at half the Buffer, so no combination of the two sliders
+    can run away.
+  - Only fires on a **buffer-cap** close. A normal close on a silence gap has no
+    split word to recover, and is left alone.
+  - The de-duplication is word-based, so it does nothing for languages whisper
+    transcribes without spaces (Chinese, Japanese, Thai) — on those, leave it
+    Off or expect the overlapping words to appear twice.
 
 ### Tuning (the control row)
 

--- a/src/asr/AsrEngine.cpp
+++ b/src/asr/AsrEngine.cpp
@@ -301,6 +301,10 @@ void AsrWorker::processAudio(const QVector<float>& monoSamples, int sampleRate)
         const AsrTranscript result = m_backend->transcribe(seg.samples, &error);
         if (!error.isEmpty()) {
             emit errorOccurred(error);
+            // A failed decode yields no tail — same as an empty one below: drop
+            // the reference so the next continuation doesn't de-dup against a
+            // stale, pre-failure segment.
+            m_prevSegmentText.clear();
             continue;
         }
         if (result.text.isEmpty()) {
@@ -316,7 +320,9 @@ void AsrWorker::processAudio(const QVector<float>& monoSamples, int sampleRate)
         // that segment's tail — strip them so nothing is emitted twice.
         QString emitText = result.text;
         if (seg.continuesPrevious && !m_prevSegmentText.isEmpty()) {
-            emitText = stripOverlapWords(m_prevSegmentText, result.text, m_segmenter.overlapMs());
+            // Use the window captured when THIS segment closed, not the live
+            // slider — a mid-backlog slider move must not re-scope a queued strip.
+            emitText = stripOverlapWords(m_prevSegmentText, result.text, seg.overlapMs);
         }
         m_prevSegmentText = result.text; // full decode is the tail source for the next continuation
         if (emitText.isEmpty()) {

--- a/src/asr/AsrEngine.cpp
+++ b/src/asr/AsrEngine.cpp
@@ -98,7 +98,24 @@ QString stripOverlapWords(const QString& prev, const QString& next, int overlapM
     if (best == 0) {
         return next;
     }
-    return nextWords.mid(best).join(QLatin1Char(' '));
+    // Return the ORIGINAL text sliced at the best-th word, not a rejoin of the
+    // split tokens. split("\\s+")+join(' ') would collapse internal whitespace
+    // runs, flatten tabs/non-breaking spaces, and drop whisper's leading space —
+    // but only on segments that happened to match, so de-dup'd continuations
+    // would be formatted differently from untouched ones (return next; above).
+    // Find where the best-th word starts and slice there (robust to a leading
+    // space; best == nextWords.size() slices to "" — a fully-overlapped segment).
+    static const QRegularExpression word(QStringLiteral("\\S+"));
+    QRegularExpressionMatchIterator it = word.globalMatch(next);
+    qsizetype offset = next.size();
+    for (int i = 0; it.hasNext(); ++i) {
+        const QRegularExpressionMatch m = it.next();
+        if (i == best) {
+            offset = m.capturedStart();
+            break;
+        }
+    }
+    return next.mid(offset);
 }
 } // namespace
 

--- a/src/asr/AsrEngine.cpp
+++ b/src/asr/AsrEngine.cpp
@@ -5,6 +5,8 @@
 #include "core/Resampler.h"
 
 #include <QLoggingCategory>
+#include <QRegularExpression>
+#include <QStringList>
 #include <QThread>
 
 #include <algorithm>
@@ -23,6 +25,57 @@ constexpr int kResampleBlock = 4096; // max samples per r8brain process() call
 // resampler's group delay small (important for live copy and for prompt segment
 // close-out).
 constexpr double kResampleTransBand = 10.0;
+
+// Segment-overlap de-dup (RFC #4821, Approach A). A cap-forced segment carries a
+// little trailing audio into the next one, so the next decode re-transcribes the
+// tail of the previous segment as its own leading words. We strip that repeated
+// prefix at the text level — backend-agnostic, no whisper-param change, and it
+// keeps the byte-safe segment text (no per-token UTF-8 reconstruction).
+
+// Normalize a word for boundary comparison: drop leading/trailing non-alnum
+// (punctuation whisper may add on one side of the cut but not the other) and
+// lowercase, so "fox." and "Fox" match across the boundary.
+QString normWord(const QString& w)
+{
+    int a = 0;
+    int b = static_cast<int>(w.size());
+    while (a < b && !w.at(a).isLetterOrNumber()) ++a;
+    while (b > a && !w.at(b - 1).isLetterOrNumber()) --b;
+    return w.mid(a, b - a).toLower();
+}
+
+// An overlap is at most a second or two of speech — a handful of words. Cap the
+// compared window so a coincidental long repeat can't swallow genuine new text.
+constexpr int kMaxOverlapWords = 12;
+
+// Strip from `next` the longest run of leading words that duplicates the tail of
+// `prev` (word-level, normalized); return the remaining text. No match → `next`
+// unchanged.
+QString stripOverlapWords(const QString& prev, const QString& next)
+{
+    static const QRegularExpression ws(QStringLiteral("\\s+"));
+    const QStringList prevWords = prev.split(ws, Qt::SkipEmptyParts);
+    const QStringList nextWords = next.split(ws, Qt::SkipEmptyParts);
+    const int cap = std::min({kMaxOverlapWords, static_cast<int>(prevWords.size()),
+                              static_cast<int>(nextWords.size())});
+    int best = 0;
+    for (int k = 1; k <= cap; ++k) {
+        bool match = true;
+        for (int j = 0; j < k; ++j) {
+            if (normWord(prevWords.at(prevWords.size() - k + j)) != normWord(nextWords.at(j))) {
+                match = false;
+                break;
+            }
+        }
+        if (match) {
+            best = k; // keep the longest k that fully matches
+        }
+    }
+    if (best == 0) {
+        return next;
+    }
+    return nextWords.mid(best).join(QLatin1Char(' '));
+}
 } // namespace
 
 // ---- AsrWorker -------------------------------------------------------------
@@ -92,6 +145,7 @@ void AsrWorker::loadModel(const QString& modelPath)
         m_warnedNoModel = false;
         m_segmenter.reset();
         m_clusterer.reset();
+        m_prevSegmentText.clear();
         emit loaded();
     } else {
         emit loadFailed(error);
@@ -204,7 +258,7 @@ void AsrWorker::processAudio(const QVector<float>& monoSamples, int sampleRate)
         return;
     }
 
-    std::vector<std::vector<float>> segments =
+    std::vector<AsrSegmenter::ClosedSegment> segments =
         m_segmenter.feed(pcm16k.data(), static_cast<int>(pcm16k.size()));
     if (segments.empty()) {
         return;
@@ -218,23 +272,36 @@ void AsrWorker::processAudio(const QVector<float>& monoSamples, int sampleRate)
         return;
     }
 
-    for (std::vector<float>& seg : segments) {
+    for (AsrSegmenter::ClosedSegment& seg : segments) {
         QString error;
-        const AsrTranscript result = m_backend->transcribe(seg, &error);
+        const AsrTranscript result = m_backend->transcribe(seg.samples, &error);
         if (!error.isEmpty()) {
             emit errorOccurred(error);
             continue;
         }
         if (result.text.isEmpty()) {
+            // Nothing decoded — leave m_prevSegmentText as the last real tail so a
+            // following continuation still de-dups against actual spoken words.
             continue;
+        }
+        // Segment overlap (RFC #4821): when this segment was seeded with audio
+        // carried across the previous cap-forced close, its leading words repeat
+        // that segment's tail — strip them so nothing is emitted twice.
+        QString emitText = result.text;
+        if (seg.continuesPrevious && !m_prevSegmentText.isEmpty()) {
+            emitText = stripOverlapWords(m_prevSegmentText, result.text);
+        }
+        m_prevSegmentText = result.text; // full decode is the tail source for the next continuation
+        if (emitText.isEmpty()) {
+            continue; // the whole segment was overlap (rare) — nothing new to emit
         }
         // Speaker label (A/B/C…) from the utterance's embedding, when enabled.
         int speaker = -1;
         if (m_speakerLabelingEnabled && m_embedder) {
             speaker = m_clusterer.assign(
-                m_embedder->embed(seg.data(), static_cast<int>(seg.size())));
+                m_embedder->embed(seg.samples.data(), static_cast<int>(seg.samples.size())));
         }
-        emit segmentText(result.text, result.confidence, speaker);
+        emit segmentText(emitText, result.confidence, speaker);
     }
     }();
 
@@ -256,6 +323,11 @@ void AsrWorker::setHangoverMs(int ms)
     m_segmenter.setHangoverMs(ms);
 }
 
+void AsrWorker::setOverlapMs(int ms)
+{
+    m_segmenter.setOverlapMs(ms);
+}
+
 void AsrWorker::setSpeakerThreshold(float t)
 {
     m_clusterer.setThreshold(t);
@@ -265,6 +337,7 @@ void AsrWorker::reset()
 {
     m_segmenter.reset();
     m_clusterer.reset(); // new session/frequency → relabel speakers from A
+    m_prevSegmentText.clear(); // a Clear/retune must not de-dup against stale text
     m_resampler.reset();
     m_resamplerSrcRate = 0;
 }
@@ -306,6 +379,7 @@ void AsrEngine::startThread(AsrBackendFactory factory, const AsrSegmenter::Confi
     connect(this, &AsrEngine::requestSetMaxSegmentMs, m_worker, &AsrWorker::setMaxSegmentMs);
     connect(this, &AsrEngine::requestSetSpeechRms, m_worker, &AsrWorker::setSpeechRms);
     connect(this, &AsrEngine::requestSetHangoverMs, m_worker, &AsrWorker::setHangoverMs);
+    connect(this, &AsrEngine::requestSetOverlapMs, m_worker, &AsrWorker::setOverlapMs);
     connect(this, &AsrEngine::requestSetSpeakerThreshold, m_worker, &AsrWorker::setSpeakerThreshold);
     connect(this, &AsrEngine::requestReset, m_worker, &AsrWorker::reset);
 
@@ -442,6 +516,11 @@ void AsrEngine::setSpeechRms(float rms)
 void AsrEngine::setSilenceDurationMs(int ms)
 {
     emit requestSetHangoverMs(ms);
+}
+
+void AsrEngine::setOverlapMs(int ms)
+{
+    emit requestSetOverlapMs(ms);
 }
 
 void AsrEngine::setSpeakerThreshold(float threshold)

--- a/src/asr/AsrEngine.cpp
+++ b/src/asr/AsrEngine.cpp
@@ -44,25 +44,49 @@ QString normWord(const QString& w)
     return w.mid(a, b - a).toLower();
 }
 
-// An overlap is at most a second or two of speech — a handful of words. Cap the
-// compared window so a coincidental long repeat can't swallow genuine new text.
+// Hard ceiling on the compared window regardless of overlapMs — a coincidental
+// long repeat must never swallow genuine new text.
 constexpr int kMaxOverlapWords = 12;
+// Rough shortest-plausible word length; overlapMs / this + a margin bounds how
+// many leading words the carried window could actually duplicate. Keeping the
+// strip near the real overlap (rather than the unconstrained longest match)
+// limits over-stripping genuine repeated speech at the boundary (Approach A is
+// deliberately lossy only at the margins — see RFC #4821).
+constexpr int kMinWordMs = 200;
 
 // Strip from `next` the longest run of leading words that duplicates the tail of
-// `prev` (word-level, normalized); return the remaining text. No match → `next`
-// unchanged.
-QString stripOverlapWords(const QString& prev, const QString& next)
+// `prev` (word-level, normalized); return the remaining text. `overlapMs` is the
+// configured carry window — the comparison is bounded to about that many words.
+// No match → `next` unchanged.
+QString stripOverlapWords(const QString& prev, const QString& next, int overlapMs)
 {
     static const QRegularExpression ws(QStringLiteral("\\s+"));
     const QStringList prevWords = prev.split(ws, Qt::SkipEmptyParts);
     const QStringList nextWords = next.split(ws, Qt::SkipEmptyParts);
-    const int cap = std::min({kMaxOverlapWords, static_cast<int>(prevWords.size()),
+    // Bound the window by the carry duration (words the overlap could hold),
+    // then by the hard ceiling and the two token counts.
+    const int overlapWordBudget = overlapMs > 0 ? overlapMs / kMinWordMs + 1 : 0;
+    const int cap = std::min({overlapWordBudget, kMaxOverlapWords,
+                              static_cast<int>(prevWords.size()),
                               static_cast<int>(nextWords.size())});
+    // Pre-normalize only the tokens in range: prev's last `cap`, next's first `cap`.
+    std::vector<QString> prevTail;
+    std::vector<QString> nextHead;
+    prevTail.reserve(cap);
+    nextHead.reserve(cap);
+    for (int i = 0; i < cap; ++i) {
+        prevTail.push_back(normWord(prevWords.at(prevWords.size() - cap + i)));
+        nextHead.push_back(normWord(nextWords.at(i)));
+    }
     int best = 0;
     for (int k = 1; k <= cap; ++k) {
         bool match = true;
         for (int j = 0; j < k; ++j) {
-            if (normWord(prevWords.at(prevWords.size() - k + j)) != normWord(nextWords.at(j))) {
+            const QString& p = prevTail.at(cap - k + j);
+            const QString& n = nextHead.at(j);
+            // A punctuation-only token normalizes to "" — never let "" == ""
+            // count as a boundary-word match (it isn't a real repeated word).
+            if (p.isEmpty() || n.isEmpty() || p != n) {
                 match = false;
                 break;
             }
@@ -280,8 +304,11 @@ void AsrWorker::processAudio(const QVector<float>& monoSamples, int sampleRate)
             continue;
         }
         if (result.text.isEmpty()) {
-            // Nothing decoded — leave m_prevSegmentText as the last real tail so a
-            // following continuation still de-dups against actual spoken words.
+            // Nothing decoded. Clear the tail so the NEXT continuation (whose
+            // carried audio overlaps THIS segment, not the one before it) doesn't
+            // de-dup against a two-segments-old tail — m_prevSegmentText must
+            // always mirror the immediately-preceding segment.
+            m_prevSegmentText.clear();
             continue;
         }
         // Segment overlap (RFC #4821): when this segment was seeded with audio
@@ -289,13 +316,19 @@ void AsrWorker::processAudio(const QVector<float>& monoSamples, int sampleRate)
         // that segment's tail — strip them so nothing is emitted twice.
         QString emitText = result.text;
         if (seg.continuesPrevious && !m_prevSegmentText.isEmpty()) {
-            emitText = stripOverlapWords(m_prevSegmentText, result.text);
+            emitText = stripOverlapWords(m_prevSegmentText, result.text, m_segmenter.overlapMs());
         }
         m_prevSegmentText = result.text; // full decode is the tail source for the next continuation
         if (emitText.isEmpty()) {
             continue; // the whole segment was overlap (rare) — nothing new to emit
         }
         // Speaker label (A/B/C…) from the utterance's embedding, when enabled.
+        // Known limitation (RFC #4821): for a continuation segment this embeds the
+        // whole buffer, including the carried overlap prefix that also fed the
+        // previous segment's embedding — a small same-speaker weighting bias
+        // (never a different voice), only material when speaker labeling AND
+        // overlap are both on with a small decode buffer. Not corrected here; a
+        // fix would thread the carried-sample count through to skip the prefix.
         int speaker = -1;
         if (m_speakerLabelingEnabled && m_embedder) {
             speaker = m_clusterer.assign(

--- a/src/asr/AsrEngine.h
+++ b/src/asr/AsrEngine.h
@@ -66,6 +66,7 @@ public slots:
     void setMaxSegmentMs(int ms);
     void setSpeechRms(float rms);
     void setHangoverMs(int ms);
+    void setOverlapMs(int ms);
     void setSpeakerThreshold(float t);
     void reset();
 
@@ -93,6 +94,7 @@ private:
     SpeakerClusterer m_clusterer;       // online A/B/C… labeling
     std::string m_speakerModelPath;     // path m_embedder was built from ("" = none)
     bool m_speakerLabelingEnabled = false; // operator intent; embedder presence gates
+    QString m_prevSegmentText;          // last decode's text — tail source for overlap de-dup (#4821)
     std::unique_ptr<Resampler> m_resampler;
     int m_resamplerSrcRate = 0;
     bool m_warnedNoModel = false;
@@ -147,6 +149,9 @@ public:
     void setDecodeBufferMs(int ms);
     void setSpeechRms(float rms);
     void setSilenceDurationMs(int ms);
+    //  - overlap: boundary-word recovery window (ms) carried across a cap-forced
+    //    segment close so a word split at the cut isn't lost (RFC #4821). 0 = off.
+    void setOverlapMs(int ms);
     //  - speaker threshold: cosine match threshold for A/B/C clustering (0..1)
     void setSpeakerThreshold(float threshold);
 
@@ -171,6 +176,7 @@ signals:
     void requestSetMaxSegmentMs(int ms);
     void requestSetSpeechRms(float rms);
     void requestSetHangoverMs(int ms);
+    void requestSetOverlapMs(int ms);
     void requestSetSpeakerThreshold(float threshold);
     void requestReset();
 

--- a/src/asr/AsrSegmenter.cpp
+++ b/src/asr/AsrSegmenter.cpp
@@ -32,6 +32,7 @@ void AsrSegmenter::reset()
     m_trailingSilence = 0;
     m_speechSamples = 0;
     m_pendingContinues = false;
+    m_pendingOverlapMs = 0;
     if (m_vad != nullptr) {
         m_vad->reset();
     }
@@ -76,15 +77,22 @@ void AsrSegmenter::closeSegment(std::vector<ClosedSegment>& out, bool forceCap)
 
     // Snapshot the trailing window BEFORE m_segment is moved out below.
     std::vector<float> carry;
+    int carryMs = 0;
     if (continueUtterance) {
         int overlapSamples =
             std::min(framesToSamples(m_config.overlapMs), static_cast<int>(m_segment.size()));
-        // Never carry so much that the reseeded segment re-hits the cap without
-        // any forward progress (overlapMs ≥ maxSegmentMs) — always leave room for
-        // at least one new frame before the next cap could fire.
-        overlapSamples = std::min(overlapSamples, std::max(0, m_maxSegmentSamples - m_frameSamples));
+        // Bound the carry to HALF the segment budget so the reseeded segment is
+        // always at least half fresh audio before the next cap. Without this a
+        // large overlap (≥ maxSegmentMs — both are user sliders) would carry
+        // nearly the whole segment forward every cap, force-decoding the same
+        // audio over and over (a runaway backlog through the backpressure-free
+        // pushAudio path). Half-budget caps the intrinsic overlap cost at ~2×
+        // realtime for every slider combination.
+        overlapSamples = std::min(overlapSamples, m_maxSegmentSamples / 2);
         if (overlapSamples > 0) {
             carry.assign(m_segment.end() - overlapSamples, m_segment.end());
+            carryMs = static_cast<int>(static_cast<long long>(overlapSamples) * 1000
+                                       / m_config.sampleRate);
         }
     }
 
@@ -92,6 +100,7 @@ void AsrSegmenter::closeSegment(std::vector<ClosedSegment>& out, bool forceCap)
         ClosedSegment cs;
         cs.samples = std::move(m_segment);
         cs.continuesPrevious = m_pendingContinues; // this segment itself began with carried audio
+        cs.overlapMs = m_pendingContinues ? m_pendingOverlapMs : 0; // window carried into THIS segment
         out.push_back(std::move(cs));
     }
 
@@ -99,13 +108,16 @@ void AsrSegmenter::closeSegment(std::vector<ClosedSegment>& out, bool forceCap)
     m_trailingSilence = 0;
     m_speechSamples = 0;
     m_pendingContinues = false;
+    m_pendingOverlapMs = 0;
 
     if (!carry.empty()) {
         // Still mid-utterance: seed the next segment with the carried audio
-        // instead of starting from silence, and mark it so the worker de-dups
-        // the repeated leading words. m_inSpeech stays true.
+        // instead of starting from silence, and mark it (with the window size in
+        // force now) so the worker de-dups the repeated leading words against the
+        // right budget. m_inSpeech stays true.
         m_speechSamples = static_cast<int>(carry.size());
         m_pendingContinues = true;
+        m_pendingOverlapMs = carryMs;
         m_segment = std::move(carry);
     } else {
         m_inSpeech = false;

--- a/src/asr/AsrSegmenter.cpp
+++ b/src/asr/AsrSegmenter.cpp
@@ -115,6 +115,17 @@ void AsrSegmenter::closeSegment(std::vector<ClosedSegment>& out, bool forceCap)
         // instead of starting from silence, and mark it (with the window size in
         // force now) so the worker de-dups the repeated leading words against the
         // right budget. m_inSpeech stays true.
+        //
+        // The carry counts toward m_speechSamples deliberately, reversing the
+        // hazard note in #4821's triage (maintainer-ruled on the RFC before this
+        // landed). Not counting it would mean a continuation carrying less than
+        // minSpeechMs of NEW speech never qualifies — and the second half of the
+        // word split at the cap is exactly that case, so the floor would discard
+        // the fragment this whole feature exists to recover. The price is the
+        // documented Approach-A margin: if the speaker stops immediately after
+        // the cap, the continuation clears the floor on carried audio alone and
+        // emits one decode that is entirely the previous tail, recovered only
+        // when the worker's de-dup strips it back to empty.
         m_speechSamples = static_cast<int>(carry.size());
         m_pendingContinues = true;
         m_pendingOverlapMs = carryMs;

--- a/src/asr/AsrSegmenter.cpp
+++ b/src/asr/AsrSegmenter.cpp
@@ -66,9 +66,13 @@ void AsrSegmenter::closeSegment(std::vector<ClosedSegment>& out, bool forceCap)
 
     // Continue the same utterance across this close only when it's the
     // maxSegmentMs cap firing (speech still ongoing, not real silence), overlap
-    // is configured, and the segment closing now actually qualifies (an
-    // unqualified segment's audio is discarded, not emitted — nothing to carry).
-    const bool continueUtterance = forceCap && m_config.overlapMs > 0 && qualifies;
+    // is configured, the segment closing now actually qualifies (an unqualified
+    // segment's audio is discarded, not emitted — nothing to carry), AND the cut
+    // lands mid-speech (m_trailingSilence == 0). If the cap fires during the
+    // hangover, the trailing window is silence: there is no split word to
+    // recover, and carrying it would wrongly count that silence as speech.
+    const bool continueUtterance =
+        forceCap && m_config.overlapMs > 0 && qualifies && m_trailingSilence == 0;
 
     // Snapshot the trailing window BEFORE m_segment is moved out below.
     std::vector<float> carry;

--- a/src/asr/AsrSegmenter.cpp
+++ b/src/asr/AsrSegmenter.cpp
@@ -31,6 +31,7 @@ void AsrSegmenter::reset()
     m_inSpeech = false;
     m_trailingSilence = 0;
     m_speechSamples = 0;
+    m_pendingContinues = false;
     if (m_vad != nullptr) {
         m_vad->reset();
     }
@@ -57,22 +58,59 @@ void AsrSegmenter::setHangoverMs(int ms)
     m_hangoverSamples = framesToSamples(ms);
 }
 
-void AsrSegmenter::closeSegment(std::vector<std::vector<float>>& out)
+void AsrSegmenter::closeSegment(std::vector<ClosedSegment>& out, bool forceCap)
 {
     // Gate on speech content, not total length: the segment also carries the
     // hangover silence, which must not count toward the minimum-speech floor.
-    if (m_speechSamples >= m_minSpeechSamples) {
-        out.push_back(std::move(m_segment));
+    const bool qualifies = m_speechSamples >= m_minSpeechSamples;
+
+    // Continue the same utterance across this close only when it's the
+    // maxSegmentMs cap firing (speech still ongoing, not real silence), overlap
+    // is configured, and the segment closing now actually qualifies (an
+    // unqualified segment's audio is discarded, not emitted — nothing to carry).
+    const bool continueUtterance = forceCap && m_config.overlapMs > 0 && qualifies;
+
+    // Snapshot the trailing window BEFORE m_segment is moved out below.
+    std::vector<float> carry;
+    if (continueUtterance) {
+        int overlapSamples =
+            std::min(framesToSamples(m_config.overlapMs), static_cast<int>(m_segment.size()));
+        // Never carry so much that the reseeded segment re-hits the cap without
+        // any forward progress (overlapMs ≥ maxSegmentMs) — always leave room for
+        // at least one new frame before the next cap could fire.
+        overlapSamples = std::min(overlapSamples, std::max(0, m_maxSegmentSamples - m_frameSamples));
+        if (overlapSamples > 0) {
+            carry.assign(m_segment.end() - overlapSamples, m_segment.end());
+        }
     }
+
+    if (qualifies) {
+        ClosedSegment cs;
+        cs.samples = std::move(m_segment);
+        cs.continuesPrevious = m_pendingContinues; // this segment itself began with carried audio
+        out.push_back(std::move(cs));
+    }
+
     m_segment.clear();
-    m_inSpeech = false;
     m_trailingSilence = 0;
     m_speechSamples = 0;
+    m_pendingContinues = false;
+
+    if (!carry.empty()) {
+        // Still mid-utterance: seed the next segment with the carried audio
+        // instead of starting from silence, and mark it so the worker de-dups
+        // the repeated leading words. m_inSpeech stays true.
+        m_speechSamples = static_cast<int>(carry.size());
+        m_pendingContinues = true;
+        m_segment = std::move(carry);
+    } else {
+        m_inSpeech = false;
+    }
 }
 
-std::vector<std::vector<float>> AsrSegmenter::feed(const float* samples, int count)
+std::vector<AsrSegmenter::ClosedSegment> AsrSegmenter::feed(const float* samples, int count)
 {
-    std::vector<std::vector<float>> out;
+    std::vector<ClosedSegment> out;
 
     for (int i = 0; i < count; ++i) {
         m_frame.push_back(samples[i]);
@@ -108,14 +146,14 @@ std::vector<std::vector<float>> AsrSegmenter::feed(const float* samples, int cou
             m_segment.insert(m_segment.end(), m_frame.begin(), m_frame.end());
             m_trailingSilence += static_cast<int>(m_frame.size());
             if (m_trailingSilence >= m_hangoverSamples) {
-                closeSegment(out);
+                closeSegment(out, /*forceCap=*/false);
             }
         }
         // else: silence outside speech — ignored.
 
         // Hard cap on a single utterance.
         if (m_inSpeech && static_cast<int>(m_segment.size()) >= m_maxSegmentSamples) {
-            closeSegment(out);
+            closeSegment(out, /*forceCap=*/true);
         }
 
         m_frame.clear();
@@ -124,16 +162,18 @@ std::vector<std::vector<float>> AsrSegmenter::feed(const float* samples, int cou
     return out;
 }
 
-std::vector<std::vector<float>> AsrSegmenter::flush()
+std::vector<AsrSegmenter::ClosedSegment> AsrSegmenter::flush()
 {
-    std::vector<std::vector<float>> out;
+    std::vector<ClosedSegment> out;
     // Fold any partial frame into the segment before closing.
     if (m_inSpeech && !m_frame.empty()) {
         m_segment.insert(m_segment.end(), m_frame.begin(), m_frame.end());
     }
     m_frame.clear();
     if (m_inSpeech) {
-        closeSegment(out);
+        // End of stream: never a candidate to continue via overlap (there's no
+        // next segment to carry into).
+        closeSegment(out, /*forceCap=*/false);
     }
     return out;
 }

--- a/src/asr/AsrSegmenter.h
+++ b/src/asr/AsrSegmenter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -38,18 +39,38 @@ public:
         // clustering threshold, which the worker's clusterer needs at
         // construction, stays in this bundle.
         float speakerThreshold = 0.50f; // cosine threshold for the same speaker
+        // Boundary-word recovery / segment-overlap (RFC #4821, opt-in, 0 =
+        // disabled). When a segment is force-closed by maxSegmentMs (speech still
+        // ongoing, not a real silence gap), carry this many ms of trailing audio
+        // forward as the start of the next segment so a word split at the cut
+        // isn't lost. Never applied on a hangover-based close, where speech had
+        // already stopped (nothing to recover). The worker de-duplicates the
+        // repeated leading words at the text level (Approach A) using the
+        // continuesPrevious flag below.
+        int overlapMs = 0;
+    };
+
+    // One closed utterance. `continuesPrevious` is true when this segment was
+    // seeded with trailing audio carried across the PREVIOUS segment's cap-forced
+    // close (segment overlap) — its leading words re-transcribe the tail of that
+    // segment, so the consumer must de-duplicate them. false for an ordinary
+    // (non-overlapping) segment.
+    struct ClosedSegment {
+        std::vector<float> samples;
+        bool continuesPrevious = false;
     };
 
     AsrSegmenter() : AsrSegmenter(Config{}) {}
     explicit AsrSegmenter(const Config& config);
 
     // Feed mono float samples in [-1, 1]. Returns any utterances that closed as
-    // a result of this input (each a contiguous sample buffer). Usually empty.
-    std::vector<std::vector<float>> feed(const float* samples, int count);
+    // a result of this input. Usually empty.
+    std::vector<ClosedSegment> feed(const float* samples, int count);
 
     // Close any in-progress utterance (end of stream / mode change). Returns it
-    // if it qualifies as speech, otherwise empty.
-    std::vector<std::vector<float>> flush();
+    // if it qualifies as speech, otherwise empty. Never carries overlap forward
+    // (there's no "next segment" at end of stream).
+    std::vector<ClosedSegment> flush();
 
     // Discard all buffered state without emitting.
     void reset();
@@ -68,15 +89,22 @@ public:
     void setMaxSegmentMs(int ms);
     void setSpeechRms(float rms);
     void setHangoverMs(int ms);
+    // Boundary-word recovery window (RFC #4821); see Config::overlapMs. Takes
+    // effect on the next cap-forced close. 0 disables.
+    void setOverlapMs(int ms) { m_config.overlapMs = std::max(0, ms); }
     int maxSegmentMs() const { return m_config.maxSegmentMs; }
     float speechRms() const { return m_config.speechRms; }
     int hangoverMs() const { return m_config.hangoverMs; }
+    int overlapMs() const { return m_config.overlapMs; }
 
     bool inSpeech() const { return m_inSpeech; }
 
 private:
     int framesToSamples(int ms) const;
-    void closeSegment(std::vector<std::vector<float>>& out);
+    // forceCap: true when this close is the maxSegmentMs cap firing mid-speech
+    // (a candidate to continue via overlap), false for a real hangover / end-of-
+    // stream close (the utterance actually ended; never carries overlap forward).
+    void closeSegment(std::vector<ClosedSegment>& out, bool forceCap);
 
     Config m_config;
     int m_frameSamples = 160;
@@ -90,6 +118,7 @@ private:
     bool m_inSpeech = false;
     int m_trailingSilence = 0;      // samples of silence since last speech frame
     int m_speechSamples = 0;        // speech-only samples (excludes hangover), gates minSpeech
+    bool m_pendingContinues = false; // next emitted segment was seeded with carried overlap audio
 };
 
 } // namespace AetherSDR

--- a/src/asr/AsrSegmenter.h
+++ b/src/asr/AsrSegmenter.h
@@ -54,10 +54,14 @@ public:
     // seeded with trailing audio carried across the PREVIOUS segment's cap-forced
     // close (segment overlap) — its leading words re-transcribe the tail of that
     // segment, so the consumer must de-duplicate them. false for an ordinary
-    // (non-overlapping) segment.
+    // (non-overlapping) segment. `overlapMs` records how much audio was actually
+    // carried into this segment (0 when continuesPrevious is false); it is
+    // captured at close time so de-dup uses the window in force when the segment
+    // closed, not whatever the slider reads later.
     struct ClosedSegment {
         std::vector<float> samples;
         bool continuesPrevious = false;
+        int overlapMs = 0;
     };
 
     AsrSegmenter() : AsrSegmenter(Config{}) {}
@@ -119,6 +123,7 @@ private:
     int m_trailingSilence = 0;      // samples of silence since last speech frame
     int m_speechSamples = 0;        // speech-only samples (excludes hangover), gates minSpeech
     bool m_pendingContinues = false; // next emitted segment was seeded with carried overlap audio
+    int m_pendingOverlapMs = 0;      // ms of audio carried into that next segment (for its overlapMs)
 };
 
 } // namespace AetherSDR

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -343,6 +343,17 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
         saveInt("AsrSpeakerThreshold", pct);
         m_asr->setSpeakerThreshold(pct / 100.0f); // live, no engine rebuild
     });
+    // Boundary-word recovery / segment overlap (RFC #4821). Set the value before
+    // connecting so this init doesn't fire the slot; applied live afterward.
+    m_settings->setBoundaryOverlapMs(
+        CopyAssistSettings::value(QStringLiteral("AsrBoundaryOverlapMs"), QStringLiteral("0"))
+            .toString().toInt());
+    connect(m_settings, &CopyAssistSettingsDialog::boundaryOverlapChanged, this, [this](int ms) {
+        saveInt("AsrBoundaryOverlapMs", ms);
+        if (m_asr) {
+            m_asr->setOverlapMs(ms); // live, no engine rebuild
+        }
+    });
     connect(m_settings, &CopyAssistSettingsDialog::labelSpeakersToggled, this, [this](bool on) {
         CopyAssistSettings::setValue(QStringLiteral("AsrSpeakerEnabled"), on ? QStringLiteral("True") : QStringLiteral("False"));
         if (!m_constructed) {
@@ -626,6 +637,7 @@ void CopyAssistController::applyTuning()
     m_asr->setSpeechRms(sensitivityToRms(
         CopyAssistSettings::value(QStringLiteral("AsrSensitivity"), QStringLiteral("80")).toString().toInt()));
     m_asr->setSilenceDurationMs(CopyAssistSettings::value(QStringLiteral("AsrSilenceMs"), QStringLiteral("300")).toString().toInt());
+    m_asr->setOverlapMs(CopyAssistSettings::value(QStringLiteral("AsrBoundaryOverlapMs"), QStringLiteral("0")).toString().toInt());
 }
 
 void CopyAssistController::onEnableToggled(bool on)

--- a/src/gui/CopyAssistSettingsDialog.cpp
+++ b/src/gui/CopyAssistSettingsDialog.cpp
@@ -7,6 +7,7 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QSignalBlocker>
 #include <QSlider>
 #include <QVBoxLayout>
 
@@ -168,6 +169,7 @@ CopyAssistSettingsDialog::CopyAssistSettingsDialog(QWidget* parent)
     auto* ovRow = new QHBoxLayout;
     m_overlap = new QSlider(Qt::Horizontal, this);
     m_overlap->setObjectName(QStringLiteral("CopyAssistOverlapSlider"));
+    m_overlap->setAccessibleName(tr("Copy Assist boundary overlap"));
     m_overlap->setRange(0, 2000);      // ms of trailing audio carried forward
     m_overlap->setSingleStep(250);
     m_overlap->setPageStep(250);
@@ -177,6 +179,7 @@ CopyAssistSettingsDialog::CopyAssistSettingsDialog(QWidget* parent)
     m_overlap->setToolTip(tr("Carry this much trailing audio across a forced segment "
                              "cut to recover a word split at the boundary (0 = off)"));
     m_overlapValue = new QLabel(tr("Off"), this);
+    m_overlapValue->setAccessibleName(tr("Boundary overlap value"));
     m_overlapValue->setMinimumWidth(48);
     m_overlapValue->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     connect(m_overlap, &QSlider::valueChanged, this, [this](int v) {
@@ -353,7 +356,14 @@ int CopyAssistSettingsDialog::speakerThreshold() const
 
 void CopyAssistSettingsDialog::setBoundaryOverlapMs(int ms)
 {
-    m_overlap->setValue(ms); // fires valueChanged → updates label + emits
+    // Programmatic set: don't echo back out as an operator edit. Without this,
+    // any post-construction call (settings reload, reset-to-defaults, a future
+    // profile switch) would round-trip straight into saveInt("AsrBoundaryOverlapMs")
+    // and re-write what it just read. The label — normally driven by valueChanged
+    // — is updated explicitly here since that signal is suppressed.
+    const QSignalBlocker block(m_overlap);
+    m_overlap->setValue(ms);
+    m_overlapValue->setText(ms > 0 ? tr("%1 ms").arg(ms) : tr("Off"));
 }
 
 int CopyAssistSettingsDialog::boundaryOverlapMs() const

--- a/src/gui/CopyAssistSettingsDialog.cpp
+++ b/src/gui/CopyAssistSettingsDialog.cpp
@@ -162,6 +162,31 @@ CopyAssistSettingsDialog::CopyAssistSettingsDialog(QWidget* parent)
     thrRow->addWidget(m_spkThresholdValue);
     form->addRow(tr("Match threshold:"), thrRow);
 
+    // Boundary-word recovery / segment overlap (RFC #4821): carry a little
+    // trailing audio across a forced segment cut so a word split at the boundary
+    // isn't lost. 0 = off (default); opt-in. Applied live, no engine rebuild.
+    auto* ovRow = new QHBoxLayout;
+    m_overlap = new QSlider(Qt::Horizontal, this);
+    m_overlap->setObjectName(QStringLiteral("CopyAssistOverlapSlider"));
+    m_overlap->setRange(0, 2000);      // ms of trailing audio carried forward
+    m_overlap->setSingleStep(250);
+    m_overlap->setPageStep(250);
+    m_overlap->setTickInterval(250);
+    m_overlap->setTickPosition(QSlider::TicksBelow);
+    m_overlap->setValue(0);
+    m_overlap->setToolTip(tr("Carry this much trailing audio across a forced segment "
+                             "cut to recover a word split at the boundary (0 = off)"));
+    m_overlapValue = new QLabel(tr("Off"), this);
+    m_overlapValue->setMinimumWidth(48);
+    m_overlapValue->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    connect(m_overlap, &QSlider::valueChanged, this, [this](int v) {
+        m_overlapValue->setText(v > 0 ? tr("%1 ms").arg(v) : tr("Off"));
+        emit boundaryOverlapChanged(v);
+    });
+    ovRow->addWidget(m_overlap, 1);
+    ovRow->addWidget(m_overlapValue);
+    form->addRow(tr("Boundary overlap:"), ovRow);
+
     root->addLayout(form);
     root->addStretch(1); // headroom for further options added here later
 }
@@ -324,6 +349,16 @@ void CopyAssistSettingsDialog::setSpeakerThreshold(int percent)
 int CopyAssistSettingsDialog::speakerThreshold() const
 {
     return m_spkThreshold->value();
+}
+
+void CopyAssistSettingsDialog::setBoundaryOverlapMs(int ms)
+{
+    m_overlap->setValue(ms); // fires valueChanged → updates label + emits
+}
+
+int CopyAssistSettingsDialog::boundaryOverlapMs() const
+{
+    return m_overlap->value();
 }
 
 } // namespace AetherSDR

--- a/src/gui/CopyAssistSettingsDialog.h
+++ b/src/gui/CopyAssistSettingsDialog.h
@@ -76,6 +76,12 @@ public:
     void setSpeakerThreshold(int percent);
     int speakerThreshold() const;
 
+    // Boundary-word recovery / segment overlap (RFC #4821): milliseconds of
+    // trailing audio carried across a forced segment cut so a word split at the
+    // boundary isn't lost. 0 = off (the default). Opt-in.
+    void setBoundaryOverlapMs(int ms);
+    int boundaryOverlapMs() const;
+
 signals:
     void tierChanged(const QString& tierId);
     void gpuChanged(int index);
@@ -87,6 +93,7 @@ signals:
     void labelSpeakersToggled(bool on);
     void browseSpeakerModelRequested();
     void speakerThresholdChanged(int percent);
+    void boundaryOverlapChanged(int ms);
 
 private:
     QComboBox* m_tier = nullptr;
@@ -105,6 +112,8 @@ private:
     QPushButton* m_spkBrowse = nullptr;
     QSlider* m_spkThreshold = nullptr;
     QLabel* m_spkThresholdValue = nullptr;
+    QSlider* m_overlap = nullptr;
+    QLabel* m_overlapValue = nullptr;
 };
 
 } // namespace AetherSDR

--- a/tests/asr_engine_test.cpp
+++ b/tests/asr_engine_test.cpp
@@ -69,6 +69,40 @@ AsrBackendFactory factory(bool loadOk)
     return [loadOk] { return std::unique_ptr<IAsrBackend>(new FakeBackend(loadOk)); };
 }
 
+// Returns a scripted phrase per successive transcribe() call (the last phrase
+// repeats once the script runs out). Lets the segment-overlap de-dup test drive
+// deterministic boundary words across consecutive segments (RFC #4821).
+class ScriptedBackend : public IAsrBackend {
+public:
+    explicit ScriptedBackend(std::vector<QString> lines) : m_lines(std::move(lines)) {}
+    bool load(const QString&, QString*) override
+    {
+        m_loaded = true;
+        return true;
+    }
+    bool isLoaded() const override { return m_loaded; }
+    AsrTranscript transcribe(const std::vector<float>& pcm, QString*) override
+    {
+        if (pcm.empty() || m_lines.empty()) {
+            return {};
+        }
+        const QString text = m_next < m_lines.size() ? m_lines[m_next] : m_lines.back();
+        ++m_next;
+        return AsrTranscript{text, 0.9f};
+    }
+    void unload() override { m_loaded = false; }
+
+private:
+    std::vector<QString> m_lines;
+    std::size_t m_next = 0;
+    bool m_loaded = false;
+};
+
+AsrBackendFactory scriptedFactory(std::vector<QString> lines)
+{
+    return [lines] { return std::unique_ptr<IAsrBackend>(new ScriptedBackend(lines)); };
+}
+
 // Backend whose transcribe() blocks for a fixed delay — stands in for a real
 // whisper decode or remote HTTP round-trip, so tests can build an actual
 // backlog of queued (not-yet-dequeued) processAudio() calls and verify
@@ -210,6 +244,45 @@ int main(int argc, char** argv)
         QSignalSpy idle(&engine, &AsrEngine::finalText);
         idle.wait(400); // give the worker a chance; expect nothing
         expect(textSpy.count() == before, "disabled engine emits no finalText");
+    }
+
+    // ---- Segment overlap: boundary-word de-dup (RFC #4821) -----------------
+    // A small decode-buffer cap force-closes continuous speech into consecutive
+    // segments; with overlap on, each continuation re-transcribes the previous
+    // segment's tail word, which the worker must strip. The scripted backend
+    // makes that duplicated boundary word deterministic (…charlie | charlie…).
+    {
+        const std::vector<QString> lines = {
+            QStringLiteral("alpha bravo charlie"),
+            QStringLiteral("charlie delta echo"),
+            QStringLiteral("echo foxtrot golf"),
+            QStringLiteral("golf hotel india"),
+            QStringLiteral("india juliet kilo"),
+            QStringLiteral("kilo lima mike"),
+        };
+        AsrEngine engine(scriptedFactory(lines));
+        QSignalSpy readySpy(&engine, &AsrEngine::ready);
+        engine.setModelPath(QStringLiteral("/does/not/matter"));
+        expect(readySpy.wait(5000), "overlap dedup: engine ready");
+
+        engine.setEnabled(true);
+        engine.setDecodeBufferMs(300); // small cap → continuous speech force-closes
+        engine.setOverlapMs(100);      // carry 100 ms across the cut
+
+        QSignalSpy textSpy(&engine, &AsrEngine::finalText);
+        engine.pushAudio(tone(1000), kSrcRate);   // continuous → repeated cap closes
+        engine.pushAudio(silence(400), kSrcRate);  // hangover closes the tail
+        expect(textSpy.wait(5000), "overlap dedup: first finalText emitted");
+        while (textSpy.wait(500)) {
+            // drain the remaining queued segment transcriptions
+        }
+        expect(textSpy.count() >= 2, "overlap dedup: continuous speech split into >=2 segments");
+        if (textSpy.count() >= 2) {
+            expect(textSpy.at(0).at(0).toString() == QStringLiteral("alpha bravo charlie"),
+                   "overlap dedup: first segment is emitted whole");
+            expect(textSpy.at(1).at(0).toString() == QStringLiteral("delta echo"),
+                   "overlap dedup: continuation drops the duplicated boundary word");
+        }
     }
 
     // ---- Destructor returns promptly with a queued backlog ----------------

--- a/tests/asr_engine_test.cpp
+++ b/tests/asr_engine_test.cpp
@@ -69,6 +69,10 @@ AsrBackendFactory factory(bool loadOk)
     return [loadOk] { return std::unique_ptr<IAsrBackend>(new FakeBackend(loadOk)); };
 }
 
+// A scripted line equal to this reports a decode FAILURE instead of text — the
+// error out-param path, which is distinct from an empty decode (RFC #4821).
+const QString kScriptedFailure = QStringLiteral("!fail");
+
 // Returns a scripted phrase per successive transcribe() call (the last phrase
 // repeats once the script runs out). Lets the segment-overlap de-dup test drive
 // deterministic boundary words across consecutive segments (RFC #4821).
@@ -81,13 +85,19 @@ public:
         return true;
     }
     bool isLoaded() const override { return m_loaded; }
-    AsrTranscript transcribe(const std::vector<float>& pcm, QString*) override
+    AsrTranscript transcribe(const std::vector<float>& pcm, QString* error) override
     {
         if (pcm.empty() || m_lines.empty()) {
             return {};
         }
         const QString text = m_next < m_lines.size() ? m_lines[m_next] : m_lines.back();
         ++m_next;
+        if (text == kScriptedFailure) {
+            if (error != nullptr) {
+                *error = QStringLiteral("scripted decode failure");
+            }
+            return {};
+        }
         return AsrTranscript{text, 0.9f};
     }
     void unload() override { m_loaded = false; }
@@ -322,6 +332,123 @@ int main(int argc, char** argv)
                    "overlap empty-continuation: first segment whole");
             expect(textSpy.at(1).at(0).toString() == QStringLiteral("charlie hotel india"),
                    "overlap empty-continuation: word after an empty decode is not stripped");
+        }
+    }
+
+    // ---- Segment overlap: a FAILED continuation clears the de-dup tail ------
+    // The error out-param path, not the empty-text one: a backend that reports a
+    // decode failure also leaves no tail, so the reference must be dropped for
+    // exactly the same reason. Without the clear, the 3rd segment would de-dup
+    // against the 1st — two segments back — and lose a genuine leading word.
+    // Mutation check: delete the m_prevSegmentText.clear() on the error path and
+    // this case emits "hotel india" instead.
+    {
+        const std::vector<QString> lines = {
+            QStringLiteral("alpha bravo charlie"),
+            kScriptedFailure,                       // decode error (clears the tail)
+            QStringLiteral("charlie hotel india"),  // leading "charlie" must NOT be stripped
+            QStringLiteral("india juliet kilo"),
+            QStringLiteral("kilo lima mike"),
+        };
+        AsrEngine engine(scriptedFactory(lines));
+        QSignalSpy readySpy(&engine, &AsrEngine::ready);
+        engine.setModelPath(QStringLiteral("/does/not/matter"));
+        expect(readySpy.wait(5000), "overlap failed-continuation: engine ready");
+
+        engine.setEnabled(true);
+        engine.setDecodeBufferMs(300);
+        engine.setOverlapMs(100);
+
+        QSignalSpy errSpy(&engine, &AsrEngine::error);
+        QSignalSpy textSpy(&engine, &AsrEngine::finalText);
+        engine.pushAudio(tone(1000), kSrcRate);
+        engine.pushAudio(silence(400), kSrcRate);
+        expect(textSpy.wait(5000), "overlap failed-continuation: first finalText emitted");
+        while (textSpy.wait(500)) {
+            // drain
+        }
+        expect(errSpy.count() >= 1, "overlap failed-continuation: the decode failure is reported");
+        expect(textSpy.count() >= 2, "overlap failed-continuation: >=2 non-empty emissions");
+        if (textSpy.count() >= 2) {
+            expect(textSpy.at(0).at(0).toString() == QStringLiteral("alpha bravo charlie"),
+                   "overlap failed-continuation: first segment whole");
+            expect(textSpy.at(1).at(0).toString() == QStringLiteral("charlie hotel india"),
+                   "overlap failed-continuation: word after a failed decode is not stripped");
+        }
+    }
+
+    // ---- Segment overlap: a punctuation-only token is not a boundary match ---
+    // normWord() strips edge punctuation, so a token that is ALL punctuation
+    // normalizes to "". Two such tokens must not compare equal — "" == "" is not
+    // a repeated word, and treating it as one silently eats the continuation's
+    // real first token. Mutation check: drop the isEmpty() guards from the
+    // comparison and this case emits "delta echo".
+    {
+        const std::vector<QString> lines = {
+            QStringLiteral("alpha bravo ..."),
+            QStringLiteral("... delta echo"), // the "..." must survive, not match
+            QStringLiteral("echo foxtrot golf"),
+            QStringLiteral("golf hotel india"),
+        };
+        AsrEngine engine(scriptedFactory(lines));
+        QSignalSpy readySpy(&engine, &AsrEngine::ready);
+        engine.setModelPath(QStringLiteral("/does/not/matter"));
+        expect(readySpy.wait(5000), "overlap punctuation: engine ready");
+
+        engine.setEnabled(true);
+        engine.setDecodeBufferMs(300);
+        engine.setOverlapMs(100);
+
+        QSignalSpy textSpy(&engine, &AsrEngine::finalText);
+        engine.pushAudio(tone(1000), kSrcRate);
+        engine.pushAudio(silence(400), kSrcRate);
+        expect(textSpy.wait(5000), "overlap punctuation: first finalText emitted");
+        while (textSpy.wait(500)) {
+            // drain
+        }
+        expect(textSpy.count() >= 2, "overlap punctuation: >=2 emissions");
+        if (textSpy.count() >= 2) {
+            expect(textSpy.at(1).at(0).toString() == QStringLiteral("... delta echo"),
+                   "overlap punctuation: a punctuation-only token is not a boundary match");
+        }
+    }
+
+    // ---- Segment overlap: the strip is bounded by the carried window ---------
+    // The de-dup must not strip the longest match it can find — only about as
+    // many words as the carried audio could actually hold (overlapWordBudget).
+    // Here the boundary is a genuine triple repeat ("one one one" | "one one one
+    // two") but only 100 ms was carried, so exactly ONE word may go; the other
+    // two are real speech the operator said. Mutation check: remove
+    // overlapWordBudget from the cap (or pass a live/large overlapMs instead of
+    // the value captured at close time) and this case emits "two".
+    {
+        const std::vector<QString> lines = {
+            QStringLiteral("bravo one one one"),
+            QStringLiteral("one one one two"), // only the first "one" is overlap
+            QStringLiteral("two three four"),
+            QStringLiteral("four five six"),
+        };
+        AsrEngine engine(scriptedFactory(lines));
+        QSignalSpy readySpy(&engine, &AsrEngine::ready);
+        engine.setModelPath(QStringLiteral("/does/not/matter"));
+        expect(readySpy.wait(5000), "overlap budget: engine ready");
+
+        engine.setEnabled(true);
+        engine.setDecodeBufferMs(300);
+        engine.setOverlapMs(100); // 100 ms -> a one-word budget
+
+        QSignalSpy textSpy(&engine, &AsrEngine::finalText);
+        engine.pushAudio(tone(1000), kSrcRate);
+        engine.pushAudio(silence(400), kSrcRate);
+        expect(textSpy.wait(5000), "overlap budget: first finalText emitted");
+        while (textSpy.wait(500)) {
+            // drain
+        }
+        expect(textSpy.count() >= 2, "overlap budget: >=2 emissions");
+        if (textSpy.count() >= 2) {
+            expect(textSpy.at(1).at(0).toString() == QStringLiteral("one one two"),
+                   "overlap budget: the strip is bounded by the carried window, "
+                   "not the longest match");
         }
     }
 

--- a/tests/asr_engine_test.cpp
+++ b/tests/asr_engine_test.cpp
@@ -285,6 +285,46 @@ int main(int argc, char** argv)
         }
     }
 
+    // ---- Segment overlap: an empty continuation clears the de-dup tail --------
+    // If a continuation decodes empty (marginal SNR), the tail it would have been
+    // compared against is gone; the NEXT continuation must de-dup against *that*
+    // (now empty) reference, not the segment before it — otherwise a leading word
+    // that coincidentally matches the older tail is wrongly stripped. Here the
+    // 2nd decode is empty and the 3rd begins with "charlie", which also ends the
+    // 1st: it must survive, not be de-dup'd away.
+    {
+        const std::vector<QString> lines = {
+            QStringLiteral("alpha bravo charlie"),
+            QString(),                              // empty decode (skipped, clears tail)
+            QStringLiteral("charlie hotel india"),  // leading "charlie" must NOT be stripped
+            QStringLiteral("india juliet kilo"),
+            QStringLiteral("kilo lima mike"),
+        };
+        AsrEngine engine(scriptedFactory(lines));
+        QSignalSpy readySpy(&engine, &AsrEngine::ready);
+        engine.setModelPath(QStringLiteral("/does/not/matter"));
+        expect(readySpy.wait(5000), "overlap empty-continuation: engine ready");
+
+        engine.setEnabled(true);
+        engine.setDecodeBufferMs(300);
+        engine.setOverlapMs(100);
+
+        QSignalSpy textSpy(&engine, &AsrEngine::finalText);
+        engine.pushAudio(tone(1000), kSrcRate);
+        engine.pushAudio(silence(400), kSrcRate);
+        expect(textSpy.wait(5000), "overlap empty-continuation: first finalText emitted");
+        while (textSpy.wait(500)) {
+            // drain
+        }
+        expect(textSpy.count() >= 2, "overlap empty-continuation: >=2 non-empty emissions");
+        if (textSpy.count() >= 2) {
+            expect(textSpy.at(0).at(0).toString() == QStringLiteral("alpha bravo charlie"),
+                   "overlap empty-continuation: first segment whole");
+            expect(textSpy.at(1).at(0).toString() == QStringLiteral("charlie hotel india"),
+                   "overlap empty-continuation: word after an empty decode is not stripped");
+        }
+    }
+
     // ---- Destructor returns promptly with a queued backlog ----------------
     // Note: Qt's own QThread::quit() already stops the worker from starting
     // any FURTHER queued processAudio() calls once the current one returns —

--- a/tests/asr_segmenter_test.cpp
+++ b/tests/asr_segmenter_test.cpp
@@ -209,6 +209,30 @@ int main()
                "overlap: a hangover close is not a continuation");
     }
 
+    // Overlap must NOT carry when the cap fires DURING the hangover silence (the
+    // trailing window is silence — no split word to recover). Here the cap (400
+    // ms) fires ~150 ms into the hangover, so the close must not spawn a spurious
+    // silence-only continuation segment.
+    {
+        AsrSegmenter seg;
+        seg.setMaxSegmentMs(400);
+        seg.setOverlapMs(200);
+        std::vector<float> audio;
+        appendTone(audio, 250);    // speech, then...
+        appendSilence(audio, 400); // ...silence; cap fires mid-hangover at 400 ms total
+        auto out = seg.feed(audio.data(), static_cast<int>(audio.size()));
+        auto tail = seg.flush();
+        out.insert(out.end(), tail.begin(), tail.end());
+        expect(out.size() == 1, "overlap: cap during hangover does not spawn a silence continuation");
+        bool anyContinue = false;
+        for (const auto& s : out) {
+            if (s.continuesPrevious) {
+                anyContinue = true;
+            }
+        }
+        expect(!anyContinue, "overlap: a silence-tail cap close is not flagged a continuation");
+    }
+
     std::printf(g_failures == 0 ? "\nASR segmenter: ALL PASS\n"
                                 : "\nASR segmenter: %d FAILURE(S)\n",
                 g_failures);

--- a/tests/asr_segmenter_test.cpp
+++ b/tests/asr_segmenter_test.cpp
@@ -178,12 +178,20 @@ int main()
         expect(!ovOut.empty() && !ovOut.front().continuesPrevious,
                "overlap: first segment is not a continuation");
         bool laterAllContinue = ovOut.size() >= 2;
+        bool laterWindowRecorded = ovOut.size() >= 2;
         for (std::size_t i = 1; i < ovOut.size(); ++i) {
             if (!ovOut[i].continuesPrevious) {
                 laterAllContinue = false;
             }
+            // 200 ms carried (< half of the 500 ms budget, so unclamped here).
+            if (ovOut[i].overlapMs != 200) {
+                laterWindowRecorded = false;
+            }
         }
         expect(laterAllContinue, "overlap: later segments are flagged as continuations");
+        expect(laterWindowRecorded, "overlap: continuations record the carried window (200 ms)");
+        expect(!ovOut.empty() && ovOut.front().overlapMs == 0,
+               "overlap: a non-continuation segment records no carried window");
         // No segment in the plain run is ever flagged a continuation.
         bool plainNoneContinue = true;
         for (const auto& s : plainOut) {
@@ -231,6 +239,24 @@ int main()
             }
         }
         expect(!anyContinue, "overlap: a silence-tail cap close is not flagged a continuation");
+    }
+
+    // Overlap ≥ maxSegmentMs must stay bounded: the carry is clamped to half the
+    // segment budget, so each reseeded segment is ≥ half fresh audio and the
+    // decode count stays near ~2× realtime instead of exploding (a runaway
+    // "decode every frame" backlog). 2 s of continuous speech at a 300 ms cap
+    // yields ~13 segments here; without the clamp it would be ~170.
+    {
+        AsrSegmenter seg;
+        seg.setMaxSegmentMs(300);
+        seg.setOverlapMs(1000); // >> the 300 ms cap
+        std::vector<float> audio;
+        appendTone(audio, 2000); // continuous speech
+        auto out = seg.feed(audio.data(), static_cast<int>(audio.size()));
+        // ~2× realtime bound: 2000 ms / (300/2 ms fresh per segment) ≈ 13, well
+        // under 30; the pre-clamp bug produced ~170.
+        expect(out.size() < 30, "overlap: overlap >= cap stays bounded (carry clamped to half budget)");
+        expect(out.size() >= 2, "overlap: overlap >= cap still splits into segments");
     }
 
     std::printf(g_failures == 0 ? "\nASR segmenter: ALL PASS\n"

--- a/tests/asr_segmenter_test.cpp
+++ b/tests/asr_segmenter_test.cpp
@@ -45,11 +45,11 @@ void appendTone(std::vector<float>& buf, int ms, float amp = 0.3f, float freq = 
     }
 }
 
-int totalSamples(const std::vector<std::vector<float>>& segs)
+int totalSamples(const std::vector<AsrSegmenter::ClosedSegment>& segs)
 {
     int n = 0;
     for (const auto& s : segs) {
-        n += static_cast<int>(s.size());
+        n += static_cast<int>(s.samples.size());
     }
     return n;
 }
@@ -79,7 +79,7 @@ int main()
         auto out = seg.feed(audio.data(), static_cast<int>(audio.size()));
         expect(out.size() == 1, "one tone burst -> one segment");
         if (out.size() == 1) {
-            const int len = static_cast<int>(out[0].size());
+            const int len = static_cast<int>(out[0].samples.size());
             const int lo = 700 * kRate / 1000; // >= tone + most of hangover
             const int hi = 900 * kRate / 1000; // <= tone + hangover + slop
             expect(len >= lo && len <= hi, "segment length is tone + hangover");
@@ -155,6 +155,58 @@ int main()
         appendSilence(audio, 150); // 150 ms > 100 ms hangover -> closes
         auto out = seg.feed(audio.data(), static_cast<int>(audio.size()));
         expect(out.size() == 1, "shorter hangover closes the utterance sooner");
+    }
+
+    // Segment overlap (RFC #4821): a cap-forced close carries trailing audio into
+    // the next segment and flags it as a continuation; consecutive segments then
+    // share that audio, so the emitted total exceeds a no-overlap run of the same
+    // input. Overlap fires only on the cap path, never on a hangover close.
+    {
+        std::vector<float> audio;
+        appendTone(audio, 1600); // continuous speech — forces repeated cap closes
+
+        AsrSegmenter plain;
+        plain.setMaxSegmentMs(500);
+        auto plainOut = plain.feed(audio.data(), static_cast<int>(audio.size()));
+
+        AsrSegmenter ov;
+        ov.setMaxSegmentMs(500);
+        ov.setOverlapMs(200);
+        auto ovOut = ov.feed(audio.data(), static_cast<int>(audio.size()));
+
+        expect(ovOut.size() >= 2, "overlap: long over still splits into segments");
+        expect(!ovOut.empty() && !ovOut.front().continuesPrevious,
+               "overlap: first segment is not a continuation");
+        bool laterAllContinue = ovOut.size() >= 2;
+        for (std::size_t i = 1; i < ovOut.size(); ++i) {
+            if (!ovOut[i].continuesPrevious) {
+                laterAllContinue = false;
+            }
+        }
+        expect(laterAllContinue, "overlap: later segments are flagged as continuations");
+        // No segment in the plain run is ever flagged a continuation.
+        bool plainNoneContinue = true;
+        for (const auto& s : plainOut) {
+            if (s.continuesPrevious) {
+                plainNoneContinue = false;
+            }
+        }
+        expect(plainNoneContinue, "no-overlap: no segment is flagged as a continuation");
+        expect(totalSamples(ovOut) > totalSamples(plainOut),
+               "overlap: carried audio duplicates across the cut (more total samples)");
+    }
+
+    // Overlap must NOT trigger on a hangover-based close (speech already stopped).
+    {
+        AsrSegmenter seg;
+        seg.setOverlapMs(200); // default 20 s cap won't fire on this short over
+        std::vector<float> audio;
+        appendSilence(audio, 100);
+        appendTone(audio, 500);
+        appendSilence(audio, 400); // closes by hangover
+        auto out = seg.feed(audio.data(), static_cast<int>(audio.size()));
+        expect(out.size() == 1 && !out[0].continuesPrevious,
+               "overlap: a hangover close is not a continuation");
     }
 
     std::printf(g_failures == 0 ? "\nASR segmenter: ALL PASS\n"

--- a/tests/copy_assist_settings_dialog_test.cpp
+++ b/tests/copy_assist_settings_dialog_test.cpp
@@ -17,6 +17,7 @@
 #include <QComboBox>
 #include <QLabel>
 #include <QSignalSpy>
+#include <QSlider>
 
 #include <cstdio>
 
@@ -278,6 +279,33 @@ int main(int argc, char** argv)
         expect(dlg.speakerThreshold() == 65, "setSpeakerThreshold round-trips");
         expect(!thrSpy.isEmpty() && thrSpy.last().at(0).toInt() == 65,
                "speakerThresholdChanged emits percent");
+    }
+
+    // ---- Boundary overlap slider: round-trip, no echo, operator edit ------
+    // Unlike setSpeakerThreshold() above, setBoundaryOverlapMs() must NOT emit:
+    // the controller calls it to seed the widget from the store, and an echo
+    // would round-trip straight back into saveInt("AsrBoundaryOverlapMs") and
+    // re-write what it just read (RFC #4821). The QSignalBlocker in that setter
+    // is the only thing preventing it, so pin both halves — the programmatic
+    // set stays silent, a real operator edit still reaches the controller.
+    {
+        QSignalSpy ovSpy(&dlg, &CopyAssistSettingsDialog::boundaryOverlapChanged);
+        dlg.setBoundaryOverlapMs(750);
+        expect(dlg.boundaryOverlapMs() == 750, "setBoundaryOverlapMs round-trips");
+        expect(ovSpy.isEmpty(),
+               "a programmatic overlap set does not echo back as an operator edit");
+
+        auto* ov = dlg.findChild<QSlider*>(QStringLiteral("CopyAssistOverlapSlider"));
+        expect(ov != nullptr, "boundary overlap slider is findable by object name");
+        if (ov != nullptr) {
+            expect(ov->minimum() == 0 && ov->maximum() == 2000,
+                   "boundary overlap slider spans 0-2000 ms");
+            ov->setValue(1250); // a real operator edit
+            expect(!ovSpy.isEmpty() && ovSpy.last().at(0).toInt() == 1250,
+                   "boundaryOverlapChanged carries the operator's value in ms");
+        }
+
+        dlg.setBoundaryOverlapMs(0); // restore the default (off)
     }
 
     dlg.resize(520, 360);


### PR DESCRIPTION
## Summary

An **opt-in, off-by-default** segment-overlap mode for Copy Assist (on-device ASR). When an utterance is force-closed by the max-length cap — speech still ongoing, not a real pause — the cut can fall mid-word, and because each segment is decoded independently the straddling word is mangled or dropped. Overlap carries a small window of trailing audio into the next segment so that word isn't lost, then de-duplicates the repeated boundary words. Independent of and complementary to context-carry (#4818).

## Approach A (text-level de-dup), per the RFC

Of the RFC's two designs I implemented **Approach A** (recommended-first): overlap the audio, decode normally, and strip the longest normalized word-prefix of the new segment that matches the previous segment's tail. Chosen over the DTW/token-timestamp prototype (Approach B, preserved on `feat/asr-segment-overlap`) because it:

- adds **zero inference cost** and needs **no whisper-param change**;
- works **uniformly across whisper / sherpa-onnx / remote** backends (`transcribe()` stays unchanged);
- keeps the byte-safe segment text — **no per-token UTF-8 reconstruction** (Approach B risks U+FFFD on byte-fallback tokens);
- carries **no dependency** on the context-carry work.

## What changed

- **`AsrSegmenter`** — `feed()`/`flush()` return `ClosedSegment{samples, continuesPrevious}`. On a cap-forced close of a qualifying, *mid-speech* segment, snapshot the last `overlapMs` of audio and seed the next segment with it, flagged as a continuation. The carry is clamped to leave room for a new frame (no cap loop), and never happens on a hangover/end-of-stream close. `overlapMs` is a runtime setter (0 = off).
- **`AsrEngine`/`AsrWorker`** — de-dup lives in the worker (backend-agnostic). `stripOverlapWords()` removes the longest normalized word-prefix of a continuation matching the previous decode's tail, bounded by the configured overlap window. `m_prevSegmentText` is the tail source; cleared on Clear/retune/model-load and on an empty decode.
- **Copy Assist settings** — a "Boundary overlap" slider (0–2000 ms, **0 = Off, default**), persisted, applied live and on engine rebuild.

## Review

Ran an adversarial pass before submitting; it surfaced 5 non-blocking edge cases in the de-dup heuristic. Fixed 4 (punctuation-only token match, unbounded over-strip, stale de-dup tail after an empty decode, silence-tail cap close), and documented 1 known limitation at the call site (a continuation's speaker embedding includes the carried prefix — a small *same-speaker* weighting bias, only with speaker-labeling + overlap both on at a small decode buffer).

## Testing

New unit coverage: segmenter carry-forward / continuation flags / cap-vs-hangover / silence-tail; engine ScriptedBackend de-dup + empty-continuation. **Unit tests pass on all three platforms (0 fail).**

**Live copy:** verified on Mac (M2) and Windows (i3, whisper **base** model) — boundary words that previously dropped or garbled at the cap cut are recovered. On the **RPi 5** the unit tests pass, but live decode there runs the **tiny** model, which already struggles with noisy speech independent of this feature — so live overlap quality couldn't be meaningfully judged on that host.

Built and smoke tested on: MacBook Air M2 (live copy + unit tests) / Win 11 i3 (live copy, base model + unit tests) / RPi 5 Debian trixie (unit tests; tiny model too weak for a live noisy-speech read)

Resolves #4821

🤖 Generated with [Claude Code](https://claude.com/claude-code)
