### PR TITLE
test(hl2): verify the loopback simulator probe and skip honestly (#4815)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5049,6 +5049,9 @@ add_executable(hl2_tx_loopback_test tests/hl2_tx_loopback_test.cpp)
 target_include_directories(hl2_tx_loopback_test PRIVATE src)
 target_link_libraries(hl2_tx_loopback_test PRIVATE aethercore Qt6::Core Qt6::Network)
 add_test(NAME hl2_tx_loopback_test COMMAND hl2_tx_loopback_test)
+# Exit 77 = no simulator verified at the target host: report as Skipped, never
+# Passed (#4815). Same convention as crdv_quarantined_test above.
+set_tests_properties(hl2_tx_loopback_test PROPERTIES SKIP_RETURN_CODE 77)
 
 add_executable(hl2_tx_gate_test tests/hl2_tx_gate_test.cpp)
 target_include_directories(hl2_tx_gate_test PRIVATE src)

--- a/tests/hl2_tx_loopback_test.cpp
+++ b/tests/hl2_tx_loopback_test.cpp
@@ -9,10 +9,14 @@
 // BYTES leave, but only the simulator can show the radio actually received them
 // and acted on them.
 //
-// SIM ONLY, deliberately. The address is hardcoded to the simulator and this
-// test keys the transmitter; pointing it at real hardware would radiate.
-// If nothing answers there, the test SKIPS rather than fails, so a machine
-// without the simulator running does not get a spurious red.
+// SIM ONLY, deliberately. This test keys the transmitter; pointing it at real
+// hardware would radiate. The target defaults to the documented simulator host
+// and can be moved with AETHER_HL2_SIM_HOST (or set empty to disable). Before
+// the TX gate opens, the probe requires a VERIFIED HL2 discovery reply from
+// exactly the host asked — an unrelated device answering must not be mistaken
+// for the simulator (#4815).
+// If no simulator is verified, the test SKIPS with exit 77 — which ctest
+// reports as Skipped, not Passed, so "did not run" can never shadow a result.
 
 #include "core/backends/hl2/Hl2Backend.h"
 #include "core/backends/hl2/MetisProtocol.h"
@@ -20,11 +24,14 @@
 #include "TestDspBuildWait.h"
 
 #include <QCoreApplication>
+#include <QDeadlineTimer>
 #include <QEventLoop>
 #include <QTimer>
 #include <QUdpSocket>
 
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <cstdio>
 #include <vector>
 
@@ -44,7 +51,11 @@ static void spin(int ms)
     loop.exec();
 }
 
-// Is the simulator actually there? A plain Metis discovery probe.
+// Is the simulator actually there? A VERIFIED Metis discovery probe: the reply
+// must come from the host we asked and must parse as an HL2-family discovery
+// response. "Some datagram arrived" is not presence — this gate opens a
+// transmit path, and an unrelated responder at that address must read as
+// absent, not as the simulator (#4815).
 static bool simPresent(const QString& host)
 {
     QUdpSocket s;
@@ -54,7 +65,28 @@ static bool simPresent(const QString& host)
     s.writeDatagram(reinterpret_cast<const char*>(req.data()),
                     static_cast<qint64>(req.size()), QHostAddress(host),
                     AetherSDR::hl2::kMetisPort);
-    return s.waitForReadyRead(1500);
+    // Drain replies until the deadline rather than trusting the first packet,
+    // so one stray datagram cannot consume the whole window.
+    QDeadlineTimer deadline(1500);
+    while (s.waitForReadyRead(static_cast<int>(deadline.remainingTime()))) {
+        while (s.hasPendingDatagrams()) {
+            QByteArray buf(static_cast<int>(s.pendingDatagramSize()), '\0');
+            QHostAddress sender;
+            if (s.readDatagram(buf.data(), buf.size(), &sender, nullptr) <= 0)
+                continue;
+            if (!sender.isEqual(QHostAddress(host),
+                                QHostAddress::TolerantConversion))
+                continue;   // answered, but not by the host we asked
+            const auto reply = AetherSDR::hl2::parseDiscoveryReply(
+                {reinterpret_cast<const std::uint8_t*>(buf.constData()),
+                 static_cast<std::size_t>(buf.size())});
+            if (reply && reply->isHermesLite2())
+                return true;
+        }
+        if (deadline.hasExpired())
+            break;
+    }
+    return false;
 }
 
 // The IQ sample rate this test runs the receiver at, and therefore the span the
@@ -67,12 +99,28 @@ int main(int argc, char** argv)
     QCoreApplication app(argc, argv);
     qRegisterMetaType<SliceDelta>();
 
-    const QString simHost = QStringLiteral("192.168.1.12");
+    // ctest maps this exit to Skipped (SKIP_RETURN_CODE 77 in CMakeLists.txt),
+    // the same convention crdv_quarantined_test uses — a skip must never be
+    // indistinguishable from a pass (#4815).
+    constexpr int kSkipExit = 77;
+
+    // Overridable target: unset -> the documented simulator host; explicitly
+    // empty -> deliberately disabled. The default is one developer's bench, so
+    // on any other network the honest outcome is a visible skip.
+    const QString simHost = qEnvironmentVariable("AETHER_HL2_SIM_HOST",
+                                                 QStringLiteral("192.168.1.12"));
+    if (simHost.trimmed().isEmpty()) {
+        std::fprintf(stderr,
+            "hl2_tx_loopback_test: SKIPPED — AETHER_HL2_SIM_HOST is set empty "
+            "(deliberately disabled)\n");
+        return kSkipExit;
+    }
     if (!simPresent(simHost)) {
         std::fprintf(stderr,
-            "hl2_tx_loopback_test: SKIPPED — no simulator answering at %s\n",
+            "hl2_tx_loopback_test: SKIPPED — no HL2 simulator verified at %s "
+            "(set AETHER_HL2_SIM_HOST to relocate it, or empty to disable)\n",
             qPrintable(simHost));
-        return 0;
+        return kSkipExit;
     }
 
     // Transmit must be permitted for this to mean anything. This process sets no


### PR DESCRIPTION
Fixes #4815.

## Root cause

`tests/hl2_tx_loopback_test.cpp` hardcoded `192.168.1.12` with no override, and `simPresent()` accepted **any** datagram arriving at its ephemeral port within 1.5 s — it never called `readDatagram()`, never compared the sender, never parsed the payload. Past that gate the test deliberately `qunsetenv("AETHER_AUTOMATION")` to open the TX gate and keys. A stray responder at that address was therefore enough to make a **transmit** test run against an unknown device.

It also returned `0` when it skipped. On any subnet other than that one bench it exited 0 having tested nothing — indistinguishable from a pass, which is what shadowed the review on #4799.

## Fix — tests-only, no production code

1. **Probe verifies.** `readDatagram()` into a buffer; require the sender to equal the host asked; require `hl2::parseDiscoveryReply()` to parse and `isHermesLite2()` (board `0x06`) to hold. Drains until the deadline so one unrelated datagram can't consume the window. Both halves already existed in `MetisProtocol.h` — the test just never called them.
2. **Skip is honest.** `return 77` + `SKIP_RETURN_CODE 77`, the convention `crdv_quarantined_test` already uses → ctest reports **Skipped**.
3. **Target configurable.** `AETHER_HL2_SIM_HOST` overrides; explicitly empty = deliberately disabled. The resolved host is named in the skip message.

Deliberately **not** done: moving the test out of the default ctest set (issue point 4). Now that it self-disables and says so, leaving it registered is defensible, and `LABELS`/`-LE` is the maintainer's call.

## Proof

aurora13 (Windows/MSVC), **fixed vs red-before binaries of this same worktree** — I reverted just the two hunks, rebuilt, and confirmed both original defects resurface. Driven by a localhost UDP responder answering either garbage or a byte-correct 60-byte Metis reply (`EF FE 02 | MAC | 0x49 | 0x06`).

| Scenario | red-before | fixed |
|---|---|---|
| nothing answers | `exit 0` → reads as **Passed** | `exit 77` → **Skipped** |
| ctest, nothing answers | `Passed 1.67 sec` | `***Skipped 1.67 sec` |
| **garbage responder** | **RAN — TX gate opened** | `exit 77`, rejected |
| verified Metis reply | ran | ran (positive path intact) |
| `AETHER_HL2_SIM_HOST=""` | n/a | `exit 77`, "deliberately disabled" |

The garbage row is the safety one: before, a device that merely answers UDP got a keyed transmit test pointed at it.

⚠ **Not addressed here:** the pre-existing non-deterministic sideband failure the triage noted (`HERMES.md:2999`) — that is what #4799 actually hit, and it deserves its own issue rather than being folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)