### PR TITLE
fix(gui): refresh power gauge scale on infoChanged, not just power-level edges

### DIFF
--- a/src/gui/HealthApplet.cpp
+++ b/src/gui/HealthApplet.cpp
@@ -533,6 +533,13 @@ void HealthApplet::setMeterModel(MeterModel* model)
 
 void HealthApplet::setPowerScale(int maxWatts, bool hasAmplifier)
 {
+    if (m_havePowerScale && maxWatts == m_lastMaxWatts && hasAmplifier == m_lastHasAmplifier) {
+        return;
+    }
+    m_havePowerScale = true;
+    m_lastMaxWatts = maxWatts;
+    m_lastHasAmplifier = hasAmplifier;
+
     if (hasAmplifier) {
         m_powerFullScale = 2000.0f;
     } else if (maxWatts > 100) {

--- a/src/gui/HealthApplet.h
+++ b/src/gui/HealthApplet.h
@@ -129,6 +129,14 @@ private:
     int m_activeFrames{0};
     int m_idleFrames{0};
     int m_incidentCooldownFrames{0};
+
+    // setPowerScale() no-ops when neither input moved (#4845) — called on
+    // every RadioModel::infoChanged, most of which carry no scale-relevant
+    // change; consistent with the other power gauges even though this one
+    // doesn't itself force a repaint.
+    int  m_lastMaxWatts{-1};
+    bool m_lastHasAmplifier{false};
+    bool m_havePowerScale{false};
 };
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -5886,6 +5886,14 @@ void MainWindow::wireMeters()
     };
     connect(&m_radioModel.amplifier(), &AmpModel::presenceChanged, this, updatePowerScale);
     connect(&m_radioModel.amplifier(), &AmpModel::stateChanged, this, updatePowerScale);
+    // Also refresh on infoChanged (#4813): maxPowerLevelChanged only fires when
+    // the numeric value actually changes, which it doesn't on connect if the
+    // radio's exciter limit matches TransmitModel's compiled-in default (100W —
+    // exactly the AU- case above). infoChanged fires once "info" comes back and
+    // model() is populated, so this is what actually catches the initial scale
+    // on connect instead of leaving it wrong until the next real power-level
+    // edge (e.g. a band change that happens to carry a different limit).
+    connect(&m_radioModel, &RadioModel::infoChanged, this, updatePowerScale);
 
     // TGXL indicator: two-line rich text — label on top, state smaller below.
     // Green = OPERATE, amber = BYPASS, grey = STANDBY (matches SmartSDR)

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -5868,7 +5868,10 @@ void MainWindow::wireMeters()
     // When the PGXL is in STANDBY we fall back to the barefoot scale — only the
     // radio's forward power is reaching the meter, so the 2kW arc would make
     // every reading look tiny and useless.
-    auto updatePowerScale = [this]() {
+    // lastMaxW/lastAmpActive skip redundant applies (#4845 review) — infoChanged
+    // fires far more often than the three signals this used to run on alone, and
+    // most of those emissions carry no power-scale-relevant change at all.
+    auto updatePowerScale = [this, lastMaxW = -1, lastAmpActive = false]() mutable {
         int maxW = m_radioModel.transmitModel().maxPowerLevel();
         // Aurora (AU-) radios have an integrated 600W PA (Overlord) but
         // max_power_level only reports the exciter limit (100W). Use model
@@ -5879,6 +5882,11 @@ void MainWindow::wireMeters()
         }
         const bool ampActive = m_radioModel.amplifier().present()
                             && m_radioModel.amplifier().operate();
+        if (maxW == lastMaxW && ampActive == lastAmpActive) {
+            return;
+        }
+        lastMaxW = maxW;
+        lastAmpActive = ampActive;
         m_appletPanel->txApplet()->setPowerScale(maxW, ampActive);
         m_appletPanel->tunerApplet()->setPowerScale(maxW, ampActive);
         m_appletPanel->setMeterPowerScale(maxW, ampActive);

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -5868,10 +5868,14 @@ void MainWindow::wireMeters()
     // When the PGXL is in STANDBY we fall back to the barefoot scale — only the
     // radio's forward power is reaching the meter, so the 2kW arc would make
     // every reading look tiny and useless.
-    // lastMaxW/lastAmpActive skip redundant applies (#4845 review) — infoChanged
-    // fires far more often than the three signals this used to run on alone, and
-    // most of those emissions carry no power-scale-relevant change at all.
-    auto updatePowerScale = [this, lastMaxW = -1, lastAmpActive = false]() mutable {
+    // Redundant-apply skipping (#4845 review) lives in each gauge's own
+    // setPowerScale() now, not here — a lambda-side cache doesn't know about
+    // CrossNeedleMeterApplet's direct test-fixture write to the same widget
+    // (see its "Clear test" action), so it could skip a real update that
+    // needed to overwrite a fixture value still sitting in the widget. Each
+    // widget already owns its displayed state, so that's the only place a
+    // cache can't diverge from what's actually on screen.
+    auto updatePowerScale = [this]() {
         int maxW = m_radioModel.transmitModel().maxPowerLevel();
         // Aurora (AU-) radios have an integrated 600W PA (Overlord) but
         // max_power_level only reports the exciter limit (100W). Use model
@@ -5882,11 +5886,6 @@ void MainWindow::wireMeters()
         }
         const bool ampActive = m_radioModel.amplifier().present()
                             && m_radioModel.amplifier().operate();
-        if (maxW == lastMaxW && ampActive == lastAmpActive) {
-            return;
-        }
-        lastMaxW = maxW;
-        lastAmpActive = ampActive;
         m_appletPanel->txApplet()->setPowerScale(maxW, ampActive);
         m_appletPanel->tunerApplet()->setPowerScale(maxW, ampActive);
         m_appletPanel->setMeterPowerScale(maxW, ampActive);

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -5869,12 +5869,16 @@ void MainWindow::wireMeters()
     // radio's forward power is reaching the meter, so the 2kW arc would make
     // every reading look tiny and useless.
     // Redundant-apply skipping (#4845 review) lives in each gauge's own
-    // setPowerScale() now, not here — a lambda-side cache doesn't know about
-    // CrossNeedleMeterApplet's direct test-fixture write to the same widget
-    // (see its "Clear test" action), so it could skip a real update that
-    // needed to overwrite a fixture value still sitting in the widget. Each
-    // widget already owns its displayed state, so that's the only place a
-    // cache can't diverge from what's actually on screen.
+    // setPowerScale(), not here. It is worth having because infoChanged is
+    // emitted from ordinary radio status parsing (headphone/lineout gain,
+    // TNF, filter sharpness) and not just the connect-time "info" reply, so
+    // a slider drag on the radio bursts it and every burst would otherwise
+    // re-push an unchanged scale. It has to sit in the widget because a
+    // widget is not always the sole writer of its own scale:
+    // CrossNeedleMeterApplet's "Test 100 W / 4 W reflected" automation
+    // action calls setPowerScale(200, false) straight at the widget, and a
+    // cache out here would then skip the real re-apply that has to
+    // overwrite it.
     auto updatePowerScale = [this]() {
         int maxW = m_radioModel.transmitModel().maxPowerLevel();
         // Aurora (AU-) radios have an integrated 600W PA (Overlord) but
@@ -5900,6 +5904,11 @@ void MainWindow::wireMeters()
     // model() is populated, so this is what actually catches the initial scale
     // on connect instead of leaving it wrong until the next real power-level
     // edge (e.g. a band change that happens to carry a different limit).
+    // infoChanged rather than connectionStateChanged: model() does happen to
+    // be seeded from the discovery packet before that one fires on a LAN
+    // connect (RadioModel.cpp, connectToRadio()), but infoChanged is the
+    // signal actually tied to the info data this branch reads, so it doesn't
+    // depend on that seeding holding for every connect path.
     connect(&m_radioModel, &RadioModel::infoChanged, this, updatePowerScale);
 
     // TGXL indicator: two-line rich text — label on top, state smaller below.

--- a/src/gui/SMeterWidget.cpp
+++ b/src/gui/SMeterWidget.cpp
@@ -1121,6 +1121,13 @@ void SMeterWidget::paintEvent(QPaintEvent*)
 
 void SMeterWidget::setPowerScale(int maxWatts, bool hasAmplifier)
 {
+    if (m_havePowerScale && maxWatts == m_lastMaxWatts && hasAmplifier == m_lastHasAmplifier) {
+        return;
+    }
+    m_havePowerScale = true;
+    m_lastMaxWatts = maxWatts;
+    m_lastHasAmplifier = hasAmplifier;
+
     if (hasAmplifier) {
         m_powerScaleMax = 2000.0f;
         m_powerRedStart = 1500.0f;

--- a/src/gui/SMeterWidget.h
+++ b/src/gui/SMeterWidget.h
@@ -172,6 +172,12 @@ private:
     float m_powerScaleMax{120.0f};
     float m_powerRedStart{100.0f};
 
+    // setPowerScale() no-ops when neither input moved (#4845) — it's called
+    // on every RadioModel::infoChanged, most of which carry no scale-relevant
+    // change, and this forces a needle-target recompute plus repaint.
+    int  m_lastMaxWatts{-1};
+    bool m_lastHasAmplifier{false};
+    bool m_havePowerScale{false};
 };
 
 } // namespace AetherSDR

--- a/src/gui/TunerApplet.cpp
+++ b/src/gui/TunerApplet.cpp
@@ -67,6 +67,13 @@ void TunerApplet::setAmplifierMode(bool hasAmp)
 
 void TunerApplet::setPowerScale(int maxWatts, bool hasAmplifier)
 {
+    if (m_havePowerScale && maxWatts == m_lastMaxWatts && hasAmplifier == m_lastHasAmplifier) {
+        return;
+    }
+    m_havePowerScale = true;
+    m_lastMaxWatts = maxWatts;
+    m_lastHasAmplifier = hasAmplifier;
+
     auto* gauge = static_cast<HGauge*>(m_fwdGauge);
     if (hasAmplifier) {
         // PGXL: 0–2000 W, yellow > 1000 W, red > 1500 W

--- a/src/gui/TunerApplet.h
+++ b/src/gui/TunerApplet.h
@@ -92,6 +92,13 @@ private:
     bool m_postTuneCapture{false};  // true during post-tune settling window
     float m_tuneSwr{1.0f};   // last non-1.00 SWR seen while tuning
     QTimer* m_postTuneTimer{nullptr};
+
+    // setPowerScale() no-ops when neither input moved (#4845) — it's called
+    // on every RadioModel::infoChanged, most of which carry no scale-relevant
+    // change, and gauge->setRange() forces a repaint.
+    int  m_lastMaxWatts{-1};
+    bool m_lastHasAmplifier{false};
+    bool m_havePowerScale{false};
 };
 
 } // namespace AetherSDR

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -764,8 +764,15 @@ void TxApplet::confirmAndClearAtuMemories()
 
 void TxApplet::setPowerScale(int maxWatts, bool hasAmplifier)
 {
-    Q_UNUSED(hasAmplifier);
-    // TX applet always shows exciter (barefoot) power.
+    if (m_havePowerScale && maxWatts == m_lastMaxWatts && hasAmplifier == m_lastHasAmplifier) {
+        return;
+    }
+    m_havePowerScale = true;
+    m_lastMaxWatts = maxWatts;
+    m_lastHasAmplifier = hasAmplifier;
+
+    // TX applet always shows exciter (barefoot) power regardless of
+    // hasAmplifier — cached above only so a redundant call can be detected.
     // Amplified output power is shown in the AMP applet.
     auto* gauge = static_cast<HGauge*>(m_fwdGauge);
     float gaugeFullScaleW = 0.0f;

--- a/src/gui/TxApplet.h
+++ b/src/gui/TxApplet.h
@@ -176,6 +176,13 @@ private:
     QElapsedTimer m_peakHoldTimer;
     bool m_peakHoldRunning{false};
     QTimer m_peakTick;
+
+    // setPowerScale() no-ops when neither input moved (#4845) — it's called
+    // on every RadioModel::infoChanged, most of which carry no scale-relevant
+    // change, and gauge->setRange() forces a repaint.
+    int  m_lastMaxWatts{-1};
+    bool m_lastHasAmplifier{false};
+    bool m_havePowerScale{false};
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
Closes #4813

**Symptom.** On an AU-520 the analog power meter comes up on the 120 W scale at
every connect and only corrects to the 600 W scale after a band change.
6000/8000-series owners never notice, because on those the 120 W default happens
to be the right scale.

**Root cause.** `updatePowerScale()` in `MainWindow_Wiring.cpp` is only ever
wired to signals — it is never called once at connect.
`TransmitModel::setMaxPowerLevel()` emits `maxPowerLevelChanged` only when the
value actually moves, and `m_maxPowerLevel` defaults to 100 W. An AU- radio
reports its 100 W *exciter* limit, which is a no-op against that default, so
nothing fires and the `model().startsWith("AU-")` branch that bumps the scale to
the 500 W tier never runs. The true capability only lands later, via
`max_internal_pa_power` in a slice status — i.e. on the next band change. That is
exactly the reported symptom.

**Fix.** Also run `updatePowerScale` on `RadioModel::infoChanged`, which is
emitted unconditionally once the `info` reply is parsed, so the scale is
recomputed at connect instead of waiting for an unrelated value edge.
`infoChanged` rather than `connectionStateChanged` because it is the signal tied
to the info data the AU- branch reads — `m_model` is in fact already seeded from
the discovery packet inside `connectToRadio()` before `connectionStateChanged(true)`
is emitted, so that hook would also have seen a populated `model()` on a LAN
connect; the choice is about coupling the recompute to the right data, not about
signal ordering.

`infoChanged` is also emitted from ordinary radio status parsing — headphone and
lineout gain, TNF, filter sharpness — so it can burst while a slider is being
dragged on the radio. Each power gauge's `setPowerScale()` therefore early-returns
when neither `maxWatts` nor `hasAmplifier` moved (`TxApplet`, `TunerApplet`,
`HealthApplet`, `SMeterWidget`; `CrossNeedleMeterWidget` already had an equivalent
guard on its derived range multiplier). That guard lives in each widget rather
than in the wiring lambda because a widget is not always the sole writer of its
own scale — `CrossNeedleMeterApplet`'s "Test 100 W / 4 W reflected" automation
action writes `setPowerScale(200, false)` straight at the widget — so only a guard
sitting next to the state can see every writer of it.

**Testing.** Built clean and connected to a FLEX-6600: connects normally, gauge
shows the correct 0–120 W scale immediately, no band change needed. No AU-series
radio was available to exercise the 500 W-tier branch, and a 6600's correct scale
equals `TransmitModel`'s compiled-in default, so that hardware cannot distinguish
"fix ran" from "fix didn't run" — the AU- path is verified by inspection of the
signal path plus a clean connect with no regressions. `s_meter_geometry_test` and
`cross_needle_meter_test` also pass locally against this branch.
