### PR TITLE
fix(gui): AsrTapPolicy::toMono() takes an explicit channel count, not a parity guess

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -4488,11 +4488,13 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
             externalSource ? externalSource->id : QString(),
             *output, scopeSampleRate, 2);
         if (!txPresentationGated) {
+            // Same literal captureAutomationAudio() already uses two lines up —
+            // this path always produces interleaved stereo.
             emit receivePresentationPostDspAudioReady(
                 source == RxDspSource::KiwiSdr ? QStringLiteral("kiwi")
                                                : QStringLiteral("flex"),
                 externalSource ? externalSource->id : QString(),
-                *output, scopeSampleRate);
+                *output, scopeSampleRate, 2);
         }
         outputBuffer.append(*output);
         if (!txPresentationGated) {

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -4488,8 +4488,9 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
             externalSource ? externalSource->id : QString(),
             *output, scopeSampleRate, 2);
         if (!txPresentationGated) {
-            // Same literal captureAutomationAudio() already uses two lines up —
-            // this path always produces interleaved stereo.
+            // Same literal the captureAutomationAudio() call just above passes
+            // for this same buffer — this path always produces interleaved
+            // stereo. A mono RX source changes both, together.
             emit receivePresentationPostDspAudioReady(
                 source == RxDspSource::KiwiSdr ? QStringLiteral("kiwi")
                                                : QStringLiteral("flex"),

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -634,10 +634,15 @@ signals:
     // RX panStream::audioDataReady() path so CwDecoder::feedAudio()
     // accepts it without a separate adapter.
     void txDecodeAudioReady(const QByteArray& pcm24kStereoFloat);
+    // `channels` is carried explicitly (#4489) rather than left for a consumer
+    // to infer from the block's byte count — every current emit site passes 2
+    // (interleaved stereo, see writeAudio()), but a consumer must not assume
+    // that stays true; it must read this argument.
     void receivePresentationPostDspAudioReady(const QString& source,
                                               const QString& sourceId,
-                                              const QByteArray& pcmStereoFloat,
-                                              int sampleRate);
+                                              const QByteArray& pcmFloat,
+                                              int sampleRate,
+                                              int channels);
     void receivePresentationOutputAudioReady(const QString& source,
                                              const QString& sourceId,
                                              const QByteArray& pcmStereoFloat,

--- a/src/gui/AsrAudioTap.cpp
+++ b/src/gui/AsrAudioTap.cpp
@@ -50,8 +50,9 @@ void AsrAudioTap::setEnabled(bool on)
 
 void AsrAudioTap::onRxAudio(const QString& source,
                             const QString& sourceId,
-                            const QByteArray& stereoFloat32Pcm,
-                            int sampleRate)
+                            const QByteArray& pcmFloat,
+                            int sampleRate,
+                            int channels)
 {
     if (!m_enabled || m_asr == nullptr) {
         return;
@@ -60,14 +61,11 @@ void AsrAudioTap::onRxAudio(const QString& source,
                           m_clock.isValid() ? m_clock.elapsed() : 0)) {
         return;
     }
-    // receivePresentationPostDspAudioReady has exactly one emit site
-    // (AudioEngine.cpp:4491), and the captureAutomationAudio call right
-    // above it tags that same buffer as 2 channels — so 2 is correct here
-    // today. Passed explicitly rather than inferred from the block's byte
-    // count (#4489); the contract lives only in this parameter, not in a
-    // formal doc comment on the signal, so it's worth re-checking here if
-    // that emit site ever changes.
-    const QVector<float> mono = AsrTapPolicy::toMono(stereoFloat32Pcm, 2);
+    // channels comes straight off the signal (#4489) instead of being
+    // assumed here — a future mono RX source is then a one-line change at
+    // AudioEngine's emit site, and toMono() rejects a caller that gets it
+    // wrong instead of silently mis-decoding.
+    const QVector<float> mono = AsrTapPolicy::toMono(pcmFloat, channels);
     if (mono.isEmpty()) {
         return;
     }

--- a/src/gui/AsrAudioTap.cpp
+++ b/src/gui/AsrAudioTap.cpp
@@ -60,9 +60,13 @@ void AsrAudioTap::onRxAudio(const QString& source,
                           m_clock.isValid() ? m_clock.elapsed() : 0)) {
         return;
     }
-    // receivePresentationPostDspAudioReady is documented (and, at every emit
-    // site, actually) fixed at 2 channels — see AudioEngine.h's doc comment
-    // on the signal. Passed explicitly rather than inferred (#4489).
+    // receivePresentationPostDspAudioReady has exactly one emit site
+    // (AudioEngine.cpp:4491), and the captureAutomationAudio call right
+    // above it tags that same buffer as 2 channels — so 2 is correct here
+    // today. Passed explicitly rather than inferred from the block's byte
+    // count (#4489); the contract lives only in this parameter, not in a
+    // formal doc comment on the signal, so it's worth re-checking here if
+    // that emit site ever changes.
     const QVector<float> mono = AsrTapPolicy::toMono(stereoFloat32Pcm, 2);
     if (mono.isEmpty()) {
         return;

--- a/src/gui/AsrAudioTap.cpp
+++ b/src/gui/AsrAudioTap.cpp
@@ -4,9 +4,12 @@
 #include "core/AudioEngine.h"
 
 #include <QByteArray>
+#include <QLoggingCategory>
 #include <QVector>
 
 namespace AetherSDR {
+
+Q_LOGGING_CATEGORY(lcAsrTap, "aether.asr.tap")
 
 AsrAudioTap::AsrAudioTap(AudioEngine* audio, AsrEngine* asr, QObject* parent)
     : QObject(parent)
@@ -31,6 +34,7 @@ void AsrAudioTap::setEnabled(bool on)
         // the release window before anything was transcribed.
         m_policy.reset();
         m_clock.start();
+        m_warnedUndecodable = false;
         if (m_audio != nullptr) {
             // Queued so the audio-thread emit lands on this (main) thread; the
             // heavy resample+inference then happens on the ASR worker thread.
@@ -64,9 +68,28 @@ void AsrAudioTap::onRxAudio(const QString& source,
     // channels comes straight off the signal (#4489) instead of being
     // assumed here — a future mono RX source is then a one-line change at
     // AudioEngine's emit site, and toMono() rejects a caller that gets it
-    // wrong instead of silently mis-decoding.
+    // wrong (and says so below) instead of silently mis-decoding.
     const QVector<float> mono = AsrTapPolicy::toMono(pcmFloat, channels);
     if (mono.isEmpty()) {
+        // Rejecting a block toMono() cannot decode is right, but it is also
+        // invisible: Copy Assist simply produces nothing, which looks exactly
+        // like a model that failed to load or a tap that never connected. The
+        // guard exists to catch a FUTURE emit site stating the wrong channel
+        // count, so the one person who needs this message is the one who has
+        // no reason to suspect this code at all — say it out loud.
+        //
+        // Once per enable, not per block: this runs on every audio block
+        // (~5 ms apart on a Flex LAN stream), and a mis-stated channel count
+        // is permanent for a given emit site, so the first block says
+        // everything the log needs. setEnabled() clears the latch so a later
+        // session reports again.
+        if (!m_warnedUndecodable) {
+            m_warnedUndecodable = true;
+            qCWarning(lcAsrTap) << "dropping undecodable RX audio from" << source
+                                << "id" << sourceId << "- bytes" << pcmFloat.size()
+                                << "channels" << channels
+                                << "(expected 1 or 2, a whole number of frames)";
+        }
         return;
     }
     m_asr->pushAudio(mono, sampleRate);

--- a/src/gui/AsrAudioTap.cpp
+++ b/src/gui/AsrAudioTap.cpp
@@ -60,7 +60,10 @@ void AsrAudioTap::onRxAudio(const QString& source,
                           m_clock.isValid() ? m_clock.elapsed() : 0)) {
         return;
     }
-    const QVector<float> mono = AsrTapPolicy::toMono(stereoFloat32Pcm);
+    // receivePresentationPostDspAudioReady is documented (and, at every emit
+    // site, actually) fixed at 2 channels — see AudioEngine.h's doc comment
+    // on the signal. Passed explicitly rather than inferred (#4489).
+    const QVector<float> mono = AsrTapPolicy::toMono(stereoFloat32Pcm, 2);
     if (mono.isEmpty()) {
         return;
     }

--- a/src/gui/AsrAudioTap.h
+++ b/src/gui/AsrAudioTap.h
@@ -68,6 +68,9 @@ private:
     bool m_enabled = false;
     AsrTapPolicy m_policy;
     QElapsedTimer m_clock;   // monotonic source for the policy's release window
+    // Latch so a block toMono() cannot decode warns once per enable rather
+    // than once per audio block. Cleared in setEnabled(true).
+    bool m_warnedUndecodable = false;
 };
 
 } // namespace AetherSDR

--- a/src/gui/AsrAudioTap.h
+++ b/src/gui/AsrAudioTap.h
@@ -58,8 +58,9 @@ public:
 private:
     void onRxAudio(const QString& source,
                    const QString& sourceId,
-                   const QByteArray& stereoFloat32Pcm,
-                   int sampleRate);
+                   const QByteArray& pcmFloat,
+                   int sampleRate,
+                   int channels);
 
     AudioEngine* m_audio = nullptr;
     AsrEngine* m_asr = nullptr;

--- a/src/gui/AsrTapPolicy.h
+++ b/src/gui/AsrTapPolicy.h
@@ -80,26 +80,39 @@ public:
     QString lockedSource() const { return m_source; }
     QString lockedSourceId() const { return m_sourceId; }
 
-    // Collapse interleaved float32 stereo to mono, matching what
+    // Collapse interleaved float32 audio to mono, matching what
     // AudioEngine::emitRxPostChainScopeFromFloat32Stereo used to hand us —
     // INCLUDING the non-finite guard. AsrEngine does not sanitise its input, and
     // a single NaN reaching the resampler poisons every sample after it, so
     // dropping that clamp when moving off the engine-side tap would trade a
     // known bug for a worse one.
-    static QVector<float> toMono(const QByteArray& stereoFloat32)
+    //
+    // `channels` is the caller's actual channel count (1 or 2), not a guess —
+    // receivePresentationPostDspAudioReady is documented stereo today, but
+    // inferring channel layout from the byte count's parity (#4489) silently
+    // mis-decodes the moment that stops being true: a mono block with an even
+    // sample count would be averaged pairwise into half as many frames while
+    // the caller kept treating it as full-rate audio. A block that isn't a
+    // whole number of frames for the given channel count is malformed, not a
+    // shape to guess at, so it is rejected rather than reinterpreted.
+    static QVector<float> toMono(const QByteArray& pcmFloat32, int channels)
     {
-        const int floatSamples =
-            static_cast<int>(stereoFloat32.size() / static_cast<int>(sizeof(float)));
-        if (floatSamples <= 0) {
+        if (channels != 1 && channels != 2) {
             return {};
         }
-        const bool stereo = (floatSamples % 2) == 0;
-        const int monoSamples = stereo ? floatSamples / 2 : floatSamples;
+        const int totalFloats =
+            static_cast<int>(pcmFloat32.size() / static_cast<int>(sizeof(float)));
+        if (totalFloats <= 0 || totalFloats % channels != 0) {
+            return {};
+        }
+        const int monoSamples = totalFloats / channels;
 
         QVector<float> mono(monoSamples);
-        const auto* src = reinterpret_cast<const float*>(stereoFloat32.constData());
+        const auto* src = reinterpret_cast<const float*>(pcmFloat32.constData());
         for (int i = 0; i < monoSamples; ++i) {
-            const float v = stereo ? (src[2 * i] + src[2 * i + 1]) * 0.5f : src[i];
+            const float v = (channels == 2)
+                ? (src[2 * i] + src[2 * i + 1]) * 0.5f
+                : src[i];
             mono[i] = std::clamp(std::isfinite(v) ? v : 0.0f, -1.0f, 1.0f);
         }
         return mono;

--- a/src/gui/AsrTapPolicy.h
+++ b/src/gui/AsrTapPolicy.h
@@ -100,6 +100,13 @@ public:
         if (channels != 1 && channels != 2) {
             return {};
         }
+        // A byte count that isn't a whole number of floats truncates below —
+        // a block malformed at the sample level, not just the frame level. A
+        // 9-byte block claimed as stereo would otherwise become 2 floats,
+        // pass the frame check below, and silently drop its trailing byte.
+        if (pcmFloat32.size() % static_cast<int>(sizeof(float)) != 0) {
+            return {};
+        }
         const int totalFloats =
             static_cast<int>(pcmFloat32.size() / static_cast<int>(sizeof(float)));
         if (totalFloats <= 0 || totalFloats % channels != 0) {

--- a/tests/asr_tap_policy_test.cpp
+++ b/tests/asr_tap_policy_test.cpp
@@ -129,7 +129,7 @@ static void testMonoCollapse()
     // over before the tap moved. Asymmetric channels prove it is an average and
     // not a channel pick.
     const QByteArray in = stereoBlock({{1.0f, 0.0f}, {-0.5f, -0.5f}, {0.25f, 0.75f}});
-    const QVector<float> mono = AsrTapPolicy::toMono(in);
+    const QVector<float> mono = AsrTapPolicy::toMono(in, 2);
 
     check(mono.size() == 3, "one mono sample per stereo frame");
     if (mono.size() != 3) return;
@@ -146,7 +146,7 @@ static void testMonoCollapseGuardsAgainstNonFiniteAndClipping()
     const float nan = std::numeric_limits<float>::quiet_NaN();
     const float inf = std::numeric_limits<float>::infinity();
     const QByteArray in = stereoBlock({{nan, 0.0f}, {inf, inf}, {5.0f, 5.0f}, {-9.0f, -9.0f}});
-    const QVector<float> mono = AsrTapPolicy::toMono(in);
+    const QVector<float> mono = AsrTapPolicy::toMono(in, 2);
 
     check(mono.size() == 4, "non-finite input still yields one sample per frame");
     if (mono.size() != 4) return;
@@ -158,11 +158,46 @@ static void testMonoCollapseGuardsAgainstNonFiniteAndClipping()
 
 static void testMonoCollapseEdgeCases()
 {
-    check(AsrTapPolicy::toMono(QByteArray()).isEmpty(),
+    check(AsrTapPolicy::toMono(QByteArray(), 2).isEmpty(),
           "an empty block produces no samples");
     // Shorter than one float: must not read past the end.
-    check(AsrTapPolicy::toMono(QByteArray(3, '\0')).isEmpty(),
+    check(AsrTapPolicy::toMono(QByteArray(3, '\0'), 2).isEmpty(),
           "a sub-sample block produces no samples");
+}
+
+// #4489: the caller states the channel count instead of toMono() inferring it
+// from the byte count's parity. A genuinely mono block with an even sample
+// count used to be misread as stereo and averaged pairwise — silent
+// corruption, not a crash, which is why it needed a caller-supplied count
+// rather than a better heuristic.
+static void testMonoPassthroughForMonoChannelCount()
+{
+    QByteArray in(4 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
+    auto* f = reinterpret_cast<float*>(in.data());
+    f[0] = 1.0f; f[1] = -1.0f; f[2] = 0.25f; f[3] = -0.25f;
+
+    const QVector<float> mono = AsrTapPolicy::toMono(in, 1);
+    check(mono.size() == 4, "mono in, mono out — one sample per float, none paired off");
+    if (mono.size() != 4) return;
+    check(std::fabs(mono[0] - 1.0f) < 1e-6f && std::fabs(mono[1] + 1.0f) < 1e-6f,
+          "mono samples pass through individually rather than being averaged in pairs");
+}
+
+// A block that is not a whole number of frames for the stated channel count is
+// malformed. The old parity heuristic would have silently reinterpreted it
+// (an odd stereo block read as mono); the fix rejects it instead.
+static void testMalformedLengthIsRejectedNotReinterpreted()
+{
+    // 3 floats claimed as stereo: not a whole number of stereo frames.
+    QByteArray in(3 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
+    auto* f = reinterpret_cast<float*>(in.data());
+    f[0] = 1.0f; f[1] = 1.0f; f[2] = 1.0f;
+    check(AsrTapPolicy::toMono(in, 2).isEmpty(),
+          "an odd-length block claimed as stereo is rejected, not read as mono");
+
+    check(AsrTapPolicy::toMono(in, 0).isEmpty(), "a zero channel count is rejected");
+    check(AsrTapPolicy::toMono(in, 3).isEmpty(),
+          "an unsupported channel count is rejected rather than guessed at");
 }
 
 // The property the whole change exists to protect: EVERY sample handed to the
@@ -185,7 +220,7 @@ static void testNoSamplesAreDropped()
     int delivered = 0;
     for (int n = 0; n < 10; ++n) {
         if (p.accepts(QStringLiteral("flex"), QString(), 0)) {
-            delivered += AsrTapPolicy::toMono(packet).size();
+            delivered += AsrTapPolicy::toMono(packet, 2).size();
         }
     }
     check(delivered == 10 * kFramesPerPacket,
@@ -205,6 +240,8 @@ int main(int argc, char** argv)
     AetherSDR::testMonoCollapse();
     AetherSDR::testMonoCollapseGuardsAgainstNonFiniteAndClipping();
     AetherSDR::testMonoCollapseEdgeCases();
+    AetherSDR::testMonoPassthroughForMonoChannelCount();
+    AetherSDR::testMalformedLengthIsRejectedNotReinterpreted();
     AetherSDR::testNoSamplesAreDropped();
 
     if (AetherSDR::g_failures == 0)

--- a/tests/asr_tap_policy_test.cpp
+++ b/tests/asr_tap_policy_test.cpp
@@ -198,6 +198,15 @@ static void testMalformedLengthIsRejectedNotReinterpreted()
     check(AsrTapPolicy::toMono(in, 0).isEmpty(), "a zero channel count is rejected");
     check(AsrTapPolicy::toMono(in, 3).isEmpty(),
           "an unsupported channel count is rejected rather than guessed at");
+
+    // A byte count that isn't a whole number of floats truncates on the way
+    // to totalFloats, so it can pass the frame check on a shorter, silently
+    // wrong count. 9 bytes claimed as stereo would truncate to 2 floats (one
+    // frame, accepted) with the trailing byte dropped without a word — this
+    // must be caught before the frame check ever sees it.
+    QByteArray partial(9, '\0');
+    check(AsrTapPolicy::toMono(partial, 2).isEmpty(),
+          "a byte count that isn't a whole number of floats is rejected, not truncated");
 }
 
 // The property the whole change exists to protect: EVERY sample handed to the


### PR DESCRIPTION
Closes #4489

toMono() decided stereo-vs-mono by testing whether the float count was
even — a heuristic standing in for a channel count the caller actually
knows. Failure mode as described in the issue: a genuinely mono
post-DSP block with an even float count gets treated as stereo and
averaged pairwise, handing AsrEngine half as many samples at the wrong
duration; an odd-length stereo block is read as mono. Latent today
because receivePresentationPostDspAudioReady only ever emits real
stereo (confirmed at its one emit site in AudioEngine.cpp), but live
the moment any RX source emits mono on that signal.

Fix: `toMono()` now takes an explicit `channels` argument instead of
guessing. Its sole caller (AsrAudioTap.cpp) passes 2, matching the
signal's documented contract. A block that isn't a whole number of
frames for the stated channel count is now rejected outright rather
than silently reinterpreted — malformed input shouldn't get a shape
guessed for it.

Testing: extended `tests/asr_tap_policy_test.cpp` (updated all existing
call sites for the new signature, added coverage for mono passthrough
and for malformed-length/invalid-channel-count rejection) and ran it —
all checks pass. `AsrTapPolicy.h` is header-only by design specifically
so this logic is unit-testable without a live AudioEngine.

I could not locally build-verify the one-line call-site change in
AsrAudioTap.cpp itself — this machine's Homebrew ggml install shadows
the vendored whisper.cpp headers ENABLE_ASR pulls in (a pre-existing,
documented local-environment issue, not a repo bug), so ENABLE_ASR=OFF
is required for a full local build and AsrAudioTap.cpp is compiled out
under that config. The change there is a single added argument
(`toMono(stereoFloat32Pcm, 2)`) matching the new signature exactly; CI
should compile it cleanly.