### PR TITLE
fix(gui): scope remaining SpectrumOverlayMenu panel stylesheets

### DIFF
--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -205,9 +205,16 @@ static bool isLoopSelectableRxAntenna(const QString& token)
 static constexpr int BAND_BTN_W = 48;
 static constexpr int BAND_BTN_H = 26;
 
-static const QString kPanelStyle =
-    "QWidget { background: rgba(15, 15, 26, 220); "
-    "border: 1px solid #304050; border-radius: 3px; }";
+// Scoped to the widget's own objectName rather than a bare "QWidget { … }"
+// selector — an unscoped type selector cascades into Qt's tooltip QLabel for
+// any descendant of the styled widget, stripping the tooltip's frame (#4440,
+// #4444).
+static QString panelStyleFor(const QString& objectName)
+{
+    return QStringLiteral("QWidget#%1 { background: rgba(15, 15, 26, 220); "
+                           "border: 1px solid #304050; border-radius: 3px; }")
+        .arg(objectName);
+}
 
 static const QString kLabelStyle =
     "QLabel { background: transparent; border: none; "
@@ -404,7 +411,8 @@ void SpectrumOverlayMenu::setMemories(const QMap<int, MemoryEntry>& memories)
 void SpectrumOverlayMenu::buildBandPanel()
 {
     m_bandPanel = new QWidget(parentWidget());
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_bandPanel, "QWidget { background: rgba(15, 15, 26, 220); "
+    m_bandPanel->setObjectName(QStringLiteral("bandPanel"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_bandPanel, "QWidget#bandPanel { background: rgba(15, 15, 26, 220); "
                                 "border: 1px solid {{color.background.2}}; border-radius: 3px; }");
     m_bandPanel->hide();
 
@@ -469,7 +477,8 @@ void SpectrumOverlayMenu::buildBandPanel()
 void SpectrumOverlayMenu::buildAntPanel()
 {
     m_antPanel = new QWidget(parentWidget());
-    m_antPanel->setStyleSheet(kPanelStyle);
+    m_antPanel->setObjectName(QStringLiteral("antPanel"));
+    m_antPanel->setStyleSheet(panelStyleFor(QStringLiteral("antPanel")));
     m_antPanel->hide();
 
     auto* vbox = new QVBoxLayout(m_antPanel);
@@ -533,7 +542,8 @@ void SpectrumOverlayMenu::buildAntPanel()
         "border: 1px solid #0090e0; }"
         "QPushButton:hover { border: 1px solid #0090e0; }";
     m_loopRow = new QWidget(m_antPanel);
-    m_loopRow->setStyleSheet("QWidget { background: transparent; border: none; }");
+    m_loopRow->setObjectName(QStringLiteral("loopRow"));
+    m_loopRow->setStyleSheet("QWidget#loopRow { background: transparent; border: none; }");
     auto* loopRow = new QHBoxLayout(m_loopRow);
     loopRow->setContentsMargins(0, 0, 0, 0);
     loopRow->setSpacing(4);
@@ -1040,7 +1050,8 @@ void SpectrumOverlayMenu::syncAntPanel()
 void SpectrumOverlayMenu::buildDaxPanel()
 {
     m_daxPanel = new QWidget(parentWidget());
-    m_daxPanel->setStyleSheet(kPanelStyle);
+    m_daxPanel->setObjectName(QStringLiteral("daxPanel"));
+    m_daxPanel->setStyleSheet(panelStyleFor(QStringLiteral("daxPanel")));
     m_daxPanel->hide();
 
     auto* vb = new QVBoxLayout(m_daxPanel);
@@ -2708,7 +2719,8 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     }
 
     m_bandPanel = new QWidget(parentWidget());
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_bandPanel, "QWidget { background: rgba(15, 15, 26, 220); "
+    m_bandPanel->setObjectName(QStringLiteral("bandPanel"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_bandPanel, "QWidget#bandPanel { background: rgba(15, 15, 26, 220); "
                                 "border: 1px solid {{color.background.2}}; border-radius: 3px; }");
     m_bandPanel->hide();
     m_bandPanel->installEventFilter(this);

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -208,12 +208,19 @@ static constexpr int BAND_BTN_H = 26;
 // Scoped to the widget's own objectName rather than a bare "QWidget { … }"
 // selector — an unscoped type selector cascades into Qt's tooltip QLabel for
 // any descendant of the styled widget, stripping the tooltip's frame (#4440,
-// #4444).
-static QString panelStyleFor(const QString& objectName)
+// #4444). Takes the widget and sets both the object name and the style in one
+// call so the two can't drift apart (a typo in one used to silently un-style
+// the panel with no compile error). Routed through ThemeManager so the border
+// stays theme-aware, matching the band and display panels rather than the
+// literal #304050 the un-scoped rule inherited.
+static void applyPanelStyle(QWidget* panel, const QString& objectName)
 {
-    return QStringLiteral("QWidget#%1 { background: rgba(15, 15, 26, 220); "
-                           "border: 1px solid #304050; border-radius: 3px; }")
-        .arg(objectName);
+    panel->setObjectName(objectName);
+    AetherSDR::ThemeManager::instance().applyStyleSheet(
+        panel,
+        QStringLiteral("QWidget#%1 { background: rgba(15, 15, 26, 220); "
+                       "border: 1px solid {{color.background.2}}; border-radius: 3px; }")
+            .arg(objectName));
 }
 
 static const QString kLabelStyle =
@@ -411,9 +418,7 @@ void SpectrumOverlayMenu::setMemories(const QMap<int, MemoryEntry>& memories)
 void SpectrumOverlayMenu::buildBandPanel()
 {
     m_bandPanel = new QWidget(parentWidget());
-    m_bandPanel->setObjectName(QStringLiteral("bandPanel"));
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_bandPanel, "QWidget#bandPanel { background: rgba(15, 15, 26, 220); "
-                                "border: 1px solid {{color.background.2}}; border-radius: 3px; }");
+    applyPanelStyle(m_bandPanel, QStringLiteral("bandPanel"));
     m_bandPanel->hide();
 
     auto* grid = new QGridLayout(m_bandPanel);
@@ -477,8 +482,7 @@ void SpectrumOverlayMenu::buildBandPanel()
 void SpectrumOverlayMenu::buildAntPanel()
 {
     m_antPanel = new QWidget(parentWidget());
-    m_antPanel->setObjectName(QStringLiteral("antPanel"));
-    m_antPanel->setStyleSheet(panelStyleFor(QStringLiteral("antPanel")));
+    applyPanelStyle(m_antPanel, QStringLiteral("antPanel"));
     m_antPanel->hide();
 
     auto* vbox = new QVBoxLayout(m_antPanel);
@@ -1050,8 +1054,7 @@ void SpectrumOverlayMenu::syncAntPanel()
 void SpectrumOverlayMenu::buildDaxPanel()
 {
     m_daxPanel = new QWidget(parentWidget());
-    m_daxPanel->setObjectName(QStringLiteral("daxPanel"));
-    m_daxPanel->setStyleSheet(panelStyleFor(QStringLiteral("daxPanel")));
+    applyPanelStyle(m_daxPanel, QStringLiteral("daxPanel"));
     m_daxPanel->hide();
 
     auto* vb = new QVBoxLayout(m_daxPanel);
@@ -2719,9 +2722,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     }
 
     m_bandPanel = new QWidget(parentWidget());
-    m_bandPanel->setObjectName(QStringLiteral("bandPanel"));
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_bandPanel, "QWidget#bandPanel { background: rgba(15, 15, 26, 220); "
-                                "border: 1px solid {{color.background.2}}; border-radius: 3px; }");
+    applyPanelStyle(m_bandPanel, QStringLiteral("bandPanel"));
     m_bandPanel->hide();
     m_bandPanel->installEventFilter(this);
 
@@ -2888,8 +2889,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     }
 
     m_xvtrPanel = new QWidget(parentWidget());
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_xvtrPanel, "QWidget { background: rgba(15, 15, 26, 220); "
-                                "border: 1px solid {{color.background.2}}; border-radius: 3px; }");
+    applyPanelStyle(m_xvtrPanel, QStringLiteral("xvtrPanel"));
     m_xvtrPanel->hide();
     m_xvtrPanel->installEventFilter(this);
     m_xvtrPanelVisible = false;


### PR DESCRIPTION
Closes #4444

Follow-up to #4440, which fixed the Display panel's tooltip-frame
regression: an un-scoped `QWidget { background; border }` stylesheet
cascades into Qt's tooltip `QLabel` — and into every other bare
container in the panel — because a Qt type selector matches subclasses
and propagates to descendants. The same pattern remained on the sibling
overlay panels in `SpectrumOverlayMenu.cpp`.

Every un-scoped panel sheet in the file is now scoped to the widget's
own `objectName`, through one helper:

```cpp
static void applyPanelStyle(QWidget* panel, const QString& objectName)
```

It sets the object name and the `QWidget#<name> { … }` selector in a
single call, so the two cannot drift apart, and routes through
`ThemeManager::applyStyleSheet()` so all five panels express the border
as `{{color.background.2}}` instead of two of them carrying a literal
`#304050`.

Sites covered:

| Widget | Where |
|---|---|
| `m_bandPanel` | `buildBandPanel()` |
| `m_antPanel` | `buildAntPanel()` (was `kPanelStyle`) |
| `m_loopRow` | `buildAntPanel()`, scoped inline like `toggleRow` |
| `m_daxPanel` | `buildDaxPanel()` (was `kPanelStyle`) |
| `m_bandPanel` | `setXvtrBands()` — the XVTR rebuild path |
| `m_xvtrPanel` | `setXvtrBands()` |

The last two are not in #4444's enumerated list. `setXvtrBands()`
rebuilds the band panel, so missing it would have left the bug live for
anyone running transverters; `m_xvtrPanel` is latent today (its children
are `QPushButton`s with no `setToolTip`) but is the same pattern four
lines away, and this is the third PR in this class.

After this, `SpectrumOverlayMenu.cpp` has no un-scoped `QWidget { … }`
selector left.

## Visible side effects

Dropping the cascade also removes accidental frames the un-scoped rule
was drawing on bare containers inside the Ant panel — the WNB
button+slider row, the "Limit range" checkbox, and the From/To labels
each lost a box they should never have had, and the sweep-range spin
boxes reclaim the width those frames were eating. This is the same
rationale #4440 gives for making `toggleRow` borderless. Each panel
keeps its own outer 1 px frame.

`{{color.background.2}}` resolves to `#304050` in the default dark
theme, so the ant/dax panel borders are unchanged there; the light theme
now themes them correctly instead of pinning the dark literal.
