### PR TITLE
fix(rigctld): report split per-client, not from the global TX slice

### DIFF
--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -307,8 +307,12 @@ SliceModel* RigctlProtocol::sliceForVfo(const QString& vfo) const
         // promote=false: this is a read-only resolver (get_freq/get_mode VFOB and
         // the set_freq/set_mode VFOB prefix path). It must not drive the deferred
         // split-promotion state machine — that belongs to the split commands.
-        auto* tx = const_cast<RigctlProtocol*>(this)->findTxSlice(/*promote=*/false);
-        // findTxSlice returns currentSlice() when no split exists; distinguish that.
+        // VFOB exists only when THIS client engaged split (same predicate as
+        // get_split_vfo). Otherwise -8, so a port reporting simplex never hands
+        // out another client's TX slice as its VFOB (#4853 review).
+        if (!clientSplitActive())
+            return nullptr;
+        auto* tx = currentTxSlice();
         auto* rx = currentSlice();
         return (tx && tx != rx) ? tx : nullptr;
     }
@@ -540,9 +544,10 @@ QString RigctlProtocol::processCommand(const QString& cmd)
 
         // VFO / mode discovery
         if (name == "get_vfo_list") {
-            // Report VFOB only when a distinct TX slice exists (split active).
-            auto* tx = findTxSlice();
-            const bool hasSplit = (tx && tx != currentSlice());
+            // Report VFOB only when THIS client engaged split (same predicate as
+            // get_split_vfo); a simplex-reporting port must not advertise another
+            // client's slice as VFOB (#4853 review).
+            const bool hasSplit = clientSplitActive();
             const QString vfoList = hasSplit ? QStringLiteral("VFOA VFOB")
                                              : QStringLiteral("VFOA");
             if (m_extended)
@@ -891,6 +896,17 @@ QString RigctlProtocol::cmdGetPtt()
     return QStringLiteral("%1\n").arg(ptt);
 }
 
+bool RigctlProtocol::clientSplitActive(bool includePending) const
+{
+    if (m_lastSplitEnable != 1)
+        return false;
+    if (includePending && m_pendingSplitEnable)
+        return true;  // create-on-demand TX slice not landed yet (keying path only)
+    auto* rx = currentSlice();
+    auto* tx = currentTxSlice();
+    return (rx && tx && rx != tx);
+}
+
 QString RigctlProtocol::cmdSetPtt(const QString& arg)
 {
     if (!m_model) return rprt(-8);
@@ -911,14 +927,11 @@ QString RigctlProtocol::cmdSetPtt(const QString& arg)
     // Without this gate the seize below moves TX to VFOA on every key, so the radio
     // transmits on the RX VFO — the WSJT-X "Rig" split symptom. Resolve split on
     // the CAT thread (same direct-read pattern as cmdGetSplitVfo).
-    auto* txSlice = findTxSlice(/*promote=*/false);
-    auto* rx      = currentSlice();
-    // Split is "active" if a distinct TX slice exists OR a create-on-demand is
-    // still in flight (m_pendingTxSlice not resolvable yet). Covering the pending
-    // window stops a key that arrives before the slice lands from seizing TX back
-    // to the RX slice (transmitting on VFOA — the very symptom this gate prevents).
-    const bool splitActive = (m_lastSplitEnable == 1)
-                             && (m_pendingSplitEnable || (txSlice && rx && txSlice != rx));
+    // "Active" only when THIS client engaged split (shared predicate so this and
+    // the getters cannot drift): keying must then transmit on the split TX slice
+    // (VFOB), not seize TX back to this port's RX slice. Covers the pending
+    // create-on-demand window too.
+    const bool splitActive = clientSplitActive(/*includePending=*/true);
 
     QMetaObject::invokeMethod(m_model, [model = m_model, sliceId = m_sliceIndex, tx, splitActive]() {
         // Non-split: ensure this protocol's bound slice is the TX slice so the
@@ -949,14 +962,9 @@ QString RigctlProtocol::cmdGetInfo()
 }
 
 // Find the TX slice (may differ from the RX slice in split mode)
-SliceModel* RigctlProtocol::findTxSlice(bool promote)
+SliceModel* RigctlProtocol::currentTxSlice() const
 {
     if (!m_model) return nullptr;
-    // Promote the new slice if it has appeared since the last check, and apply
-    // any stashed split freq/mode from the command burst that preceded it.
-    // Skipped on read-only resolution (promote=false) so a query has no side effects.
-    if (promote)
-        tryPromoteTxSlice();
     // Prefer the pending pointer: setTxSlice(true) may have been queued but not
     // yet processed by the event loop, so isTxSlice() on the target slice is
     // still stale-false.  Returning the intended slice here avoids set_split_freq
@@ -965,6 +973,16 @@ SliceModel* RigctlProtocol::findTxSlice(bool promote)
     for (auto* s : m_model->slices())
         if (s->isTxSlice()) return s;
     return nullptr;
+}
+
+SliceModel* RigctlProtocol::findTxSlice(bool promote)
+{
+    // Promote the new slice if it has appeared since the last check, and apply
+    // any stashed split freq/mode from the command burst that preceded it.
+    // Skipped on read-only resolution (promote=false) so a query has no side effects.
+    if (promote)
+        tryPromoteTxSlice();
+    return currentTxSlice();
 }
 
 // If set_split_vfo 1 arrived when only one slice existed, addSlice() was called
@@ -1011,9 +1029,12 @@ void RigctlProtocol::tryPromoteTxSlice()
 QString RigctlProtocol::cmdGetSplitVfo()
 {
     tryPromoteTxSlice();
-    auto* rxSlice = currentSlice();
-    auto* txSlice = findTxSlice();
-    bool split = (rxSlice && txSlice && rxSlice != txSlice);
+    // Report split only when THIS client engaged it, never merely because the
+    // radio's single TX flag sits on another slice — otherwise every per-slice
+    // port except the one owning TX reads as split and WSJT-X refuses emulated
+    // split (Fake It). SmartSDR CAT does not conflate the two; matches the TCI
+    // fix for #4085/#4086.
+    const bool split = clientSplitActive();
     // Report TX VFO as VFOB when split (TX on a different slice), VFOA otherwise.
     // The actual slice is resolved internally — the VFO label is only for the client.
     const QString txVfo = split ? "VFOB" : "VFOA";
@@ -2082,9 +2103,9 @@ QString RigctlProtocol::cmdGetVfoInfo(const QString& arg)
     const QString hamlibMode = smartsdrToHamlib(slice->mode());
     const int passband      = qAbs(slice->filterHigh() - slice->filterLow());
 
-    auto* rxSlice = currentSlice();
-    auto* txSlice = findTxSlice();
-    const bool split = (rxSlice && txSlice && rxSlice != txSlice);
+    // Split only when THIS client engaged it (see clientSplitActive), keeping
+    // independent per-slice ports simplex for multi-instance WSJT-X (#4851).
+    const bool split = clientSplitActive();
 
     if (m_extended) {
         // Echo line must include the VFO argument ("get_vfo_info: VFOA").

--- a/src/core/RigctlProtocol.h
+++ b/src/core/RigctlProtocol.h
@@ -99,6 +99,22 @@ private:
     // serving get_freq/get_mode VFOB) pass promote=false so a query never
     // mutates radio state as a side effect.
     SliceModel* findTxSlice(bool promote = true);
+    // Read-only lookup of the current TX slice (pending pointer, else the
+    // isTxSlice() slice); no promotion side effect, so it is callable from const.
+    SliceModel* currentTxSlice() const;
+
+    // True only when THIS connection engaged split (set_split_vfo 1 or an
+    // implicit VFOB set), regardless of where the radio's single transmitter
+    // sits. Split reporting over rigctld is therefore per-CONNECTION state, not
+    // rig state: split engaged in the AetherSDR GUI, or by another CAT client, is
+    // intentionally NOT surfaced here — matching SmartSDR CAT and the TCI fix
+    // (#4085/#4086), which is what lets N per-slice ports each behave as an
+    // independent single-VFO rig (#4851/#4853). includePending covers the
+    // create-on-demand window and is for the keying path (cmdSetPtt) only; the
+    // getters and the VFOB resolver pass false so they never advertise split
+    // before the TX slice exists. One source of truth for cmdGetSplitVfo,
+    // cmdGetVfoInfo, sliceForVfo, get_vfo_list and cmdSetPtt so it cannot drift.
+    bool clientSplitActive(bool includePending = false) const;
     // If a split-enable arrived when only one slice existed, this promotes the
     // newly-created second slice to TX as soon as it appears in the model,
     // then applies any stashed split freq/mode from the burst that preceded it.

--- a/tests/rigctld_test.cpp
+++ b/tests/rigctld_test.cpp
@@ -740,6 +740,57 @@ void section4(RigctlClient& c, Runner& r)
 // Section 5 — Split VFO
 // ═════════════════════════════════════════════════════════════════════════════
 
+// section 5b - Multi-connection split isolation (#4851 / #4853)
+// Reported bug: with one CAT port per slice, a port whose slice is NOT the
+// radio's single TX slice reported Split: 1 purely because the transmitter sat
+// elsewhere, so WSJT-X refused Fake It on every instance but one. Needs a SECOND
+// rigctld port bound to a different slice; skips cleanly if that port (this
+// port + 1) isn't configured. Live-radio, like the rest of section 5.
+void section5b(RigctlClient& c, Runner& r, const QString& host, quint16 port)
+{
+    RigctlClient c2;
+    if (!c2.connectToServer(host, static_cast<quint16>(port + 1))) {
+        r.skip(QStringLiteral("5b   multi-connection split isolation"),
+               QStringLiteral("no 2nd CAT port at %1 (bind a second rigctld port to a "
+                              "different slice to run this)").arg(port + 1));
+        return;
+    }
+    auto splitOf = [](RigctlClient& cl) {
+        return cl.field(cl.send(QStringLiteral("\\get_split_vfo")),
+                        QStringLiteral("Split"));
+    };
+
+    // c2's port engages split -> a TX slice now exists that is NOT c's slice.
+    c2.send(QStringLiteral("\\set_split_vfo 1 VFOB"));
+    QString c2split;
+    QElapsedTimer t; t.start();
+    do {
+        c2split = splitOf(c2);
+        if (c2split == QLatin1String("1") || t.elapsed() >= 5000) break;
+        QThread::msleep(150);
+    } while (true);
+
+    // 5b.1  the port that never engaged split reports simplex even though another
+    //       slice holds TX - the exact #4851 bug (fails on pre-#4853 main).
+    const QString cSplit = splitOf(c);
+    r.check(QStringLiteral("5b.1 non-split port reports Split: 0 while another slice holds TX"),
+            cSplit == QLatin1String("0"), QStringLiteral("Split=%1").arg(cSplit));
+
+    // 5b.2  and it must not advertise that foreign TX slice as its own VFOB.
+    const QString vfoList = c.field(c.send(QStringLiteral("\\get_vfo_list")),
+                                    QStringLiteral("VFO List"));
+    r.check(QStringLiteral("5b.2 non-split port lists VFOA only (no foreign VFOB)"),
+            vfoList.trimmed() == QLatin1String("VFOA"), vfoList);
+
+    // 5b.3  the port that DID engage split still reports Split: 1 (fix isn't "always 0").
+    r.check(QStringLiteral("5b.3 split-enabled port still reports Split: 1"),
+            c2split == QLatin1String("1"), QStringLiteral("Split=%1").arg(c2split));
+
+    // teardown: let the on-demand TX slice settle before removing it (mirrors section 5).
+    QThread::msleep(300);
+    c2.send(QStringLiteral("\\set_split_vfo 0 VFOA"));
+}
+
 void section5(RigctlClient& c, Runner& r, qint64 origFreq)
 {
     r.section(QStringLiteral("Section 5 — Split VFO"));
@@ -2313,6 +2364,7 @@ int main(int argc, char** argv)
     section3(c, r, origMode, origPb);
     section4(c, r);
     section5(c, r, origFreq);
+    section5b(c, r, host, port);
 
     if (doPtt) section6Ptt(c, r);
     else        section6Skip(r);


### PR DESCRIPTION
## Summary

Fixes #4851.

`RigctlProtocol::cmdGetSplitVfo()` and `cmdGetVfoInfo()` reported `split=1` whenever the
radio's transmit slice differed from the slice a CAT port controls. With N independent
single-VFO CAT ports (one slice per WSJT-X instance), only one slice holds the TX flag at
a time, so every *other* port read as "in split" — and WSJT-X refused emulated split
(Fake It) on all but one instance with "Emulated split mode requires rig to be in simplex
mode." SmartSDR CAT does not conflate the two, and the TCI transport already fixed the
same class of bug (#4085 / #4086); this is the rigctld twin.

The fix gates the split determination on this client's own split state
(`m_lastSplitEnable`), mirroring the `splitActive` check already used in `cmdSetPtt()`. A
port that never enabled split now reports simplex even when the transmitter is on another
slice, so multiple WSJT-X instances can each run Fake It.

## Constitution principle honored

**Principle XI (Demonstrated Fixes)** — backed by a live before/after reproduction on a
real FLEX-6700, not assertion.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio — two WSJT-X instances on separate slices both
      accept Fake It simultaneously (FLEX-6700, fw 4.1.3.39644, Linux Mint 22.3)
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented in #4851

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls (protocol-only change)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered
- [x] No meter UI touched
- [ ] Documentation updated — N/A (protocol-conformance fix; no user-visible UI/docs surface)
- [x] Security-sensitive changes reference a GHSA if applicable — N/A
