### PR TITLE
test(cat): gate keyerless-dependent CW tests (TS-2000 §12.13, rigctld E6)

### DIFF
--- a/tests/CAT_TS-2000_test.cpp
+++ b/tests/CAT_TS-2000_test.cpp
@@ -720,12 +720,12 @@ void section11(CatClient& c, Runner& r)
 }
 
 // ═════════════════════════════════════════════════════════════════════════════
-// Section 12 — Tier-2 Commands (AG, GT, PC, NB, KS, PT, KY, RT, RG, RC, RD, RU, XT)
+// Section 12 — Tier-2 Commands (AG, GT, PC, NB, KS, PT, KY [--cw], RT, RG, RC, RD, RU, XT)
 // ═════════════════════════════════════════════════════════════════════════════
 
 void section12(CatClient& c, Runner& r, bool doCw)
 {
-    r.section(QStringLiteral("Section 12 — Tier-2 Commands (AG, GT, PC, NB, KS, PT, KY, RT, RG, XT)"));
+    r.section(QStringLiteral("Section 12 — Tier-2 Commands (AG, GT, PC, NB, KS, PT, KY [--cw], RT, RG, XT)"));
 
     // ── AG: VFO A audio gain (0-100, 3-digit) ──────────────────────────────
     QString origAg = c.query(QStringLiteral("AG"));

--- a/tests/CAT_TS-2000_test.cpp
+++ b/tests/CAT_TS-2000_test.cpp
@@ -720,12 +720,12 @@ void section11(CatClient& c, Runner& r)
 }
 
 // ═════════════════════════════════════════════════════════════════════════════
-// Section 12 — Tier-2 Commands (AG, GT, PC, NB, KS, PT, KY, RT, RG, RC, RD, RU, XT)
+// Section 12 — Tier-2 Commands (AG, GT, PC, NB, KS, PT, RT, RG, RC, RD, RU, XT)
 // ═════════════════════════════════════════════════════════════════════════════
 
 void section12(CatClient& c, Runner& r)
 {
-    r.section(QStringLiteral("Section 12 — Tier-2 Commands (AG, GT, PC, NB, KS, PT, KY, RT, RG, XT)"));
+    r.section(QStringLiteral("Section 12 — Tier-2 Commands (AG, GT, PC, NB, KS, PT, RT, RG, XT)"));
 
     // ── AG: VFO A audio gain (0-100, 3-digit) ──────────────────────────────
     QString origAg = c.query(QStringLiteral("AG"));
@@ -807,10 +807,10 @@ void section12(CatClient& c, Runner& r)
 
     if (origPt.startsWith(QLatin1String("PT"))) { c.send(origPt); QThread::msleep(50); }
 
-    // ── KY: CW send / busy query ─────────────────────────────────────────────
-    resp = c.query(QStringLiteral("KY"));
-    r.check(QStringLiteral("12.13 KY; (query) → KY0 (not busy) or KY1 (busy)"),
-            resp == QLatin1String("KY0") || resp == QLatin1String("KY1"), repr(resp));
+    // KY (CW keyer busy query) is exercised in section 13, which is --cw-gated:
+    // it only answers KY0/KY1 on a rig with a radio-side keyer, so a keyerless
+    // target (e.g. the built-in demo) correctly returns "?;". It has no place in
+    // this ungated Tier-2 section.
 
     // ── RT: RIT state (0/1) ──────────────────────────────────────────────────
     resp = c.query(QStringLiteral("RT"));

--- a/tests/CAT_TS-2000_test.cpp
+++ b/tests/CAT_TS-2000_test.cpp
@@ -720,12 +720,12 @@ void section11(CatClient& c, Runner& r)
 }
 
 // ═════════════════════════════════════════════════════════════════════════════
-// Section 12 — Tier-2 Commands (AG, GT, PC, NB, KS, PT, RT, RG, RC, RD, RU, XT)
+// Section 12 — Tier-2 Commands (AG, GT, PC, NB, KS, PT, KY, RT, RG, RC, RD, RU, XT)
 // ═════════════════════════════════════════════════════════════════════════════
 
-void section12(CatClient& c, Runner& r)
+void section12(CatClient& c, Runner& r, bool doCw)
 {
-    r.section(QStringLiteral("Section 12 — Tier-2 Commands (AG, GT, PC, NB, KS, PT, RT, RG, XT)"));
+    r.section(QStringLiteral("Section 12 — Tier-2 Commands (AG, GT, PC, NB, KS, PT, KY, RT, RG, XT)"));
 
     // ── AG: VFO A audio gain (0-100, 3-digit) ──────────────────────────────
     QString origAg = c.query(QStringLiteral("AG"));
@@ -807,10 +807,20 @@ void section12(CatClient& c, Runner& r)
 
     if (origPt.startsWith(QLatin1String("PT"))) { c.send(origPt); QThread::msleep(50); }
 
-    // KY (CW keyer busy query) is exercised in section 13, which is --cw-gated:
-    // it only answers KY0/KY1 on a rig with a radio-side keyer, so a keyerless
-    // target (e.g. the built-in demo) correctly returns "?;". It has no place in
-    // this ungated Tier-2 section.
+    // ── KY: CW keyer busy query (0=idle, 1=sending) ────────────────────────
+    // The KY; *query* is read-only (it reports keyer-busy state, it never keys —
+    // that's KY<text>;), but the whole KY family is refused with "?;" on a rig
+    // without a radio-side keyer (hasRadioSideCwKeyer()==false, e.g. the built-in
+    // demo). Gate it behind --cw like section 13 so a keyerless/ungated run SKIPs
+    // instead of failing, while keyered rigs (any Flex) keep the coverage.
+    if (doCw) {
+        resp = c.query(QStringLiteral("KY"));
+        r.check(QStringLiteral("12.13 KY; (query) → KY0 (idle) or KY1 (sending)"),
+                resp == QLatin1String("KY0") || resp == QLatin1String("KY1"), repr(resp));
+    } else {
+        r.skip(QStringLiteral("12.13 KY; (query) → KY0 or KY1"),
+               QStringLiteral("--cw not set — keyerless targets answer '?;'"));
+    }
 
     // ── RT: RIT state (0/1) ──────────────────────────────────────────────────
     resp = c.query(QStringLiteral("RT"));
@@ -1304,7 +1314,7 @@ int main(int argc, char* argv[])
     if (doPtt) { section9ptt(c, r); } else { section9skip(r); }
     section10(c, r);
     section11(c, r);
-    section12(c, r);
+    section12(c, r, doCw);
     if (doCw) { section13cw(c, r); } else { section13skip(r); }
     if (doPty) { section14pty(r, parser.value(QStringLiteral("pty"))); } else { section14ptySkip(r); }
     section15(c, r);

--- a/tests/CAT_TS-2000_test.cpp
+++ b/tests/CAT_TS-2000_test.cpp
@@ -813,6 +813,11 @@ void section12(CatClient& c, Runner& r, bool doCw)
     // without a radio-side keyer (hasRadioSideCwKeyer()==false, e.g. the built-in
     // demo). Gate it behind --cw like section 13 so a keyerless/ungated run SKIPs
     // instead of failing, while keyered rigs (any Flex) keep the coverage.
+    //
+    // Section 13's 13.1 queries KY; too — deliberately, not as a leftover. They
+    // ask different questions: 12.13 is the Tier-2 *presence* check (KY0 *or*
+    // KY1 — the command answers at all), 13.1 is the pre-send *state* baseline
+    // (strictly == "KY0" — the buffer is idle before section 13 keys).
     if (doCw) {
         resp = c.query(QStringLiteral("KY"));
         r.check(QStringLiteral("12.13 KY; (query) → KY0 (idle) or KY1 (sending)"),
@@ -900,6 +905,8 @@ void section13cw(CatClient& c, Runner& r)
     c.send(QStringLiteral("MD3"));  // CW mode required for keying
     QThread::msleep(200);
 
+    // Stricter than 12.13's presence check (KY0 or KY1) on purpose: this is the
+    // pre-send baseline, so the buffer must be *idle* before we key below.
     QString resp = c.query(QStringLiteral("KY"));
     r.check(QStringLiteral("13.1 KY; → KY0 (buffer idle before send)"),
             resp == QLatin1String("KY0"), repr(resp));

--- a/tests/rigctld_test.cpp
+++ b/tests/rigctld_test.cpp
@@ -2042,7 +2042,7 @@ void section15(RigctlClient& c, Runner& r)
 // Edge cases
 // ═════════════════════════════════════════════════════════════════════════════
 
-void sectionEdge(RigctlClient& c, Runner& r)
+void sectionEdge(RigctlClient& c, Runner& r, bool doCw)
 {
     r.section(QStringLiteral("Edge Cases"));
 
@@ -2074,12 +2074,18 @@ void sectionEdge(RigctlClient& c, Runner& r)
     lines = c.send(QStringLiteral("\\set_trn 1"));
     r.check(QStringLiteral("E5  set_trn 1 accepted silently (RPRT 0)"), c.ok(lines));
 
-    // E6  send_morse smoke test — verify protocol accepts it without --cw flag
-    //     Does not verify radio keying; just that the command parses and queues
-    lines = c.send(QStringLiteral("\\send_morse TEST"));
-    r.check(QStringLiteral("E6  send_morse \"TEST\" accepted (RPRT 0, no --cw required)"),
-            c.ok(lines), lines.join(QStringLiteral(" | ")));
-    c.send(QStringLiteral("\\stop_morse"));
+    // E6  send_morse smoke test — verify the protocol accepts/queues the command.
+    //     GATED behind --cw: send_morse routes through CwxModel → "cwx", which
+    //     KEYS CW on real hardware, so it must not run on a plain (no-TX) pass.
+    if (doCw) {
+        lines = c.send(QStringLiteral("\\send_morse TEST"));
+        r.check(QStringLiteral("E6  send_morse \"TEST\" accepted (RPRT 0)"),
+                c.ok(lines), lines.join(QStringLiteral(" | ")));
+        c.send(QStringLiteral("\\stop_morse"));
+    } else {
+        r.skip(QStringLiteral("E6  send_morse \"TEST\" accepted (RPRT 0)"),
+               QStringLiteral("--cw not set — send_morse keys CW on real hardware"));
+    }
 
     // E7  q (short-form quit) — must return RPRT 0 so Hamlib closes cleanly
     //     without triggering its 20-second command timeout
@@ -2329,7 +2335,7 @@ int main(int argc, char** argv)
     section13(host, port, timeout, r, origFreq, origMode, origPb);
     section14(c, r);
     section15(c, r);
-    sectionEdge(c, r);
+    sectionEdge(c, r, doCw);
     sectionPty(r, ptyPath);
 
     // Best-effort state restore.


### PR DESCRIPTION
Fixes #4855.

Two CAT integration tests asserted a CW-keyer command succeeds unconditionally, but those commands only work on a rig with a *radio-side* keyer — a keyerless target (including the built-in demo / `SimBackend`) correctly refuses them, so the tests fail on every no-TX / demo run, and E6 would key CW on real hardware. The fix mirrors the suite's existing `--cw` / `--ptt` safety gating.

## Changes (one test file each, no production code)

**`CAT_TS-2000_test.cpp` — gate the §12.13 `KY;` query behind `--cw`.** `section12` (ungated Tier-2) asserted `KY;` → `KY0`/`KY1`, but `SmartCatProtocol::cmdKY` answers `?;` when `hasRadioSideCwKeyer()` is false, so it failed on every keyerless / demo run. §12.13 now runs under `if (doCw)` and `r.skip()`s otherwise (`doCw` threaded into `section12`), mirroring the suite's own `section13skip` convention — the check stays visible as a SKIP on ungated runs while keyered rigs (any Flex) keep the coverage. `KY` remains listed in section 12's two command-list strings. Note the `KY;` **query** is read-only (it reports keyer-busy state; `KY<text>;` is the form that keys), so unlike E6 it was never a transmit hazard — only its ungated `== KY0/KY1` assertion was wrong.

> **Note (updated after review):** an earlier revision of this body said §12.13 was *removed* and `KY` *dropped* from the section header. That's not what shipped — it's **gated**, and `KY` stays in the header. Gating keeps the Tier-2 command visible (a Tier-2 section that silently loses a Tier-2 command is worse than one that skips it). The redundancy #4855 flagged therefore survives, deliberately: on a keyered `--cw` run `KY;` is queried twice — §12.13 is the Tier-2 **presence** check (accepts `KY0` **or** `KY1`), §13.1 is the pre-send **state** baseline (stricter `== "KY0"`). Distinct roles, kept on purpose.

**`rigctld_test.cpp` — gate E6 `send_morse` behind `--cw`.** E6 ran `send_morse "TEST"` in the ungated Edge-Cases block asserting `RPRT 0`, but `cmdSendMorse` routes `send_morse` → `CwxModel` → `"cwx"`, which returns `RPRT -11` (`RIG_ENAVAIL`) on a keyerless rig **and keys CW on a real radio** — so a plain no-TX run transmitted on the operator's licence. `sectionEdge` now takes `doCw` and skips E6 with a clear reason when `--cw` isn't set, exactly like §11. This is the safety half of the fix.

**FlexCAT — no change needed.** Its `KY` tests already live in the `--cw`-gated `section14`.

## Testing (built-in demo, no `--cw`, Mac)
- **TS-2000:** 89/89, 0 failed, §12.13 `SKIP`s (was 89/90 — the one failure being §12.13). Verified live against the sim.
- **rigctld:** E6 now `SKIP`s — no keying, no spurious failure. (The suite's §5 split failures against the single-slice demo are the separate `--no-split` matter, untouched here.)

Built and smoke tested on: MacBook Air M2 (test-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
