### PR TITLE
Add experimental receive-only RTL-SDR backend (#4797)

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get install -y \
     libgl1-mesa-dev \
     libasound2-dev \
     libfftw3-dev \
+    librtlsdr-dev \
     libhidapi-dev \
     portaudio19-dev \
     libpipewire-0.3-dev \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,12 @@ jobs:
       - name: Ensure ccache is present
         run: command -v ccache || (apt-get update && apt-get install -y ccache)
 
+      # Keep the PR gate honest while the rolling CI image catches up with a
+      # Dockerfile dependency change. This is a no-op once the image contains
+      # librtlsdr-dev, and ensures rtl_backend_test exists on this exact head.
+      - name: Ensure RTL-SDR build dependency is present
+        run: dpkg -s librtlsdr-dev >/dev/null 2>&1 || (apt-get update && apt-get install -y librtlsdr-dev)
+
       # RESTORE on every run, SAVE only on main — see "Compiler-cache strategy"
       # at the bottom of this file for the measurements behind the split.
       - name: Restore ccache objects
@@ -309,6 +315,14 @@ jobs:
       # exercising six four-second AM/SAM audio bursts through the real HL2 DSP.
       - name: Test HL2 AM/SAM DC blocker
         run: ctest --test-dir build -R "^hl2_am_dcblock_test$" --no-tests=error --output-on-failure
+
+      # rtl_backend_test exercises the RTL-SDR backend's gain reset, state
+      # validation, sample-rate clamping, DDC output, and discovery stub — things that
+      # can regress silently because the backend is an optional dependency.
+      # The CI image carries librtlsdr-dev, so the backend and its test are
+      # always built here. ~0.1 s, no hardware or event loop.
+      - name: Test RTL-SDR backend
+        run: ctest --test-dir build -R "^rtl_backend_test$" --no-tests=error --output-on-failure
 
       # ulanzi_mapping_migration_test was on this gate (added by #4834) and is
       # not any more. Unlike hl2_am_dcblock_test above it was not costing
@@ -755,7 +769,7 @@ jobs:
         # per-PR macOS check on a rolling Qt (6.11.1 today) while the DMG ships
         # 6.8.3, i.e. CI green would say nothing about the artifact.
         run: |
-          brew install ninja fftw portaudio hidapi \
+          brew install ninja fftw portaudio hidapi librtlsdr \
             autoconf automake libtool
 
       # ~1.3 GB downloaded on every PR otherwise, and it showed: this job went

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ option(ENABLE_ASR "Enable on-device speech-to-text (ASR) via vendored whisper.cp
 option(ASR_USE_PREBUILT_WHISPER_GPU
     "Windows CI: consume prebuilt whisper-gpu asset instead of building from source" OFF)
 option(ENABLE_MQTT "Enable MQTT client support" ON)
+option(ENABLE_RTL "Enable the experimental receive-only RTL-SDR backend" ON)
 option(MQTT_TLS "Enable MQTT TLS via OpenSSL (disable for AppImage)" ON)
 option(LOWER_CASE_BINARY_NAME "Make the output binary lower case. Only affects Linux" OFF)
 if(WIN32)
@@ -2254,11 +2255,73 @@ else()
         endif()
     endif()
 endif()
+
+# RTL-SDR hardware backend — IRadioBackend implementor (family "rtl")
+if(PkgConfig_FOUND)
+    pkg_check_modules(RTLSDR IMPORTED_TARGET librtlsdr)
+    pkg_check_modules(RTL_FFTW3F IMPORTED_TARGET fftw3f)
+endif()
+
+# vcpkg / Homebrew / hand-built installs ship no .pc file. Fall back to a
+# plain header+library probe so the switch below is reachable on every
+# platform, not only the pkg-config ones.
+if(ENABLE_RTL AND NOT RTLSDR_FOUND)
+    find_path(RTLSDR_INCLUDE_DIR rtl-sdr.h)
+    find_library(RTLSDR_LIBRARY NAMES rtlsdr librtlsdr)
+    if(RTLSDR_INCLUDE_DIR AND RTLSDR_LIBRARY)
+        add_library(RtlSdr::RtlSdr UNKNOWN IMPORTED)
+        set_target_properties(RtlSdr::RtlSdr PROPERTIES
+            IMPORTED_LOCATION "${RTLSDR_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${RTLSDR_INCLUDE_DIR}")
+        set(RTLSDR_FOUND TRUE)
+        set(RTLSDR_TARGET RtlSdr::RtlSdr)
+    endif()
+else()
+    set(RTLSDR_TARGET PkgConfig::RTLSDR)
+endif()
+
+if(ENABLE_RTL AND NOT RTL_FFTW3F_FOUND)
+    find_path(RTL_FFTW3F_INCLUDE_DIR fftw3.h)
+    find_library(RTL_FFTW3F_LIBRARY NAMES fftw3f libfftw3f libfftw3f-3)
+    if(RTL_FFTW3F_INCLUDE_DIR AND RTL_FFTW3F_LIBRARY)
+        add_library(RtlFftw3f::RtlFftw3f UNKNOWN IMPORTED)
+        set_target_properties(RtlFftw3f::RtlFftw3f PROPERTIES
+            IMPORTED_LOCATION "${RTL_FFTW3F_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${RTL_FFTW3F_INCLUDE_DIR}")
+        set(RTL_FFTW3F_FOUND TRUE)
+        set(RTL_FFTW3F_TARGET RtlFftw3f::RtlFftw3f)
+    endif()
+else()
+    set(RTL_FFTW3F_TARGET PkgConfig::RTL_FFTW3F)
+endif()
+
+if(NOT ENABLE_RTL)
+    message(STATUS "RTL-SDR ... disabled by ENABLE_RTL=OFF")
+elseif(RTLSDR_FOUND AND RTL_FFTW3F_FOUND)
+    message(STATUS "RTL-SDR ... found with fftw3f — RtlSdrBackend enabled")
+    set(AETHER_BACKEND_RTL ON)
+    target_compile_definitions(aethercore PUBLIC AETHER_BACKEND_RTL)
+    target_link_libraries(aethercore PRIVATE ${RTLSDR_TARGET} ${RTL_FFTW3F_TARGET})
+    target_sources(aethercore PRIVATE
+        src/core/backends/rtl/RtlSdrBackend.cpp
+        src/core/backends/rtl/RtlSdrBackend.h
+        src/core/backends/rtl/RtlSdrWorker.cpp
+        src/core/backends/rtl/RtlSdrWorker.h
+        src/core/backends/rtl/RtlSdrDdc.cpp
+        src/core/backends/rtl/RtlSdrDdc.h)
+elseif(RTLSDR_FOUND AND NOT RTL_FFTW3F_FOUND)
+    message(STATUS "RTL-SDR ... disabled — librtlsdr found but fftw3f missing. Install fftw3f (e.g. libfftw3-dev), or configure with -DENABLE_RTL=OFF.")
+else()
+    message(STATUS "RTL-SDR ... disabled — librtlsdr not found")
+endif()
+
 # Ulanzi Dial backend — one per platform.  All three implementations
 # expose the same Qt signal contract (see UlanziDialBackend.h); the
 # mapper dialog and MainWindow dispatcher are unchanged across
 # platforms.  See #3232 for the design.
 target_sources(aethercore PRIVATE
+    src/core/RtlSdrDiscovery.cpp    # RTL-SDR discovery — compiled unconditionally, stubbed internally when librtlsdr absent
+    src/core/RtlSdrDiscovery.h
     src/core/UlanziDialBackend.h    # header-only Q_OBJECT — listed so AUTOMOC mocs it in the engine
     src/core/UlanziChordDecoder.cpp # chord decode shared by all three backends (ulanzi_chord_decoder_test)
     src/core/UlanziChordDecoder.h
@@ -2849,6 +2912,11 @@ else()
                 DESTINATION lib/udev/rules.d
             )
         endif()
+    endif()
+    if(LINUX AND AETHER_BACKEND_RTL)
+        install(FILES packaging/linux/70-rtl-sdr.rules
+            DESTINATION lib/udev/rules.d
+        )
     endif()
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/packaging/linux/AetherSDR.desktop
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ is a supported family yet, and FlexRadio remains the supported target:
   one. Only the IC-705 and IC-7300MK2 are verified against their own CI-V guides
   — an unrecognised model gets no scope and no transmit rather than optimistic
   defaults.
+- **RTL-SDR** — **experimental, receive-only**. Discovers supported USB dongles
+  through `librtlsdr` and provides one panadapter and one host-demodulated slice.
 
 No radio at all? **Demo mode** runs the full UI against a synthetic backend
 that generates its own audio and spectrum.
@@ -143,14 +145,14 @@ below the install commands.
 # Arch / CachyOS / Manjaro
 sudo pacman -S qt6-base qt6-multimedia qt6-websockets qt6-serialport \
   qt6-shadertools cmake ninja pkgconf autoconf automake libtool \
-  fftw portaudio hidapi qtkeychain-qt6
+  fftw rtl-sdr portaudio hidapi qtkeychain-qt6
 
 # Debian Trixie / Ubuntu 25.10+ / Linux Mint 23+
 # (Ubuntu 24.04's Qt is 6.4.2 — below the floor; see the note above.)
 sudo apt install qt6-base-dev qt6-base-private-dev qt6-multimedia-dev \
   qt6-websockets-dev qt6-serialport-dev qt6-shader-baker qt6-shadertools-dev \
   cmake ninja-build pkg-config autoconf automake libtool \
-  libfftw3-dev portaudio19-dev libhidapi-dev qtkeychain-qt6-dev \
+  libfftw3-dev librtlsdr-dev portaudio19-dev libhidapi-dev qtkeychain-qt6-dev \
   libxkbcommon-dev libopengl0 \
   gstreamer1.0-pulseaudio gstreamer1.0-plugins-base
 
@@ -158,11 +160,11 @@ sudo apt install qt6-base-dev qt6-base-private-dev qt6-multimedia-dev \
 sudo dnf install qt6-qtbase-devel qt6-qtbase-private-devel qt6-qtmultimedia-devel \
   qt6-qtwebsockets-devel qt6-qtserialport-devel qt6-qtshadertools-devel \
   cmake ninja-build autoconf automake libtool \
-  fftw3-devel portaudio-devel hidapi-devel qtkeychain-qt6-devel
+  fftw3-devel rtl-sdr-devel portaudio-devel hidapi-devel qtkeychain-qt6-devel
 
 # macOS (Homebrew) — everything EXCEPT Qt and qtkeychain; see the note below
 brew install ninja cmake pkgconf autoconf automake libtool \
-  fftw portaudio hidapi
+  fftw librtlsdr portaudio hidapi
 ```
 
 > **macOS note — Qt and qtkeychain do not come from Homebrew.** Homebrew's `qt`
@@ -182,7 +184,7 @@ brew install ninja cmake pkgconf autoconf automake libtool \
 >
 > `clang_64` is the only macOS desktop build Qt publishes, and it is universal2 —
 > there is no separate arm64 archive to pick. `$(brew --prefix)` stays on the
-> path for fftw, portaudio and hidapi.
+> path for fftw, librtlsdr, portaudio and hidapi.
 >
 > Homebrew's `qtkeychain` is left out for a related reason: the formula depends
 > on `qtbase`, so installing it pulls a second Qt in behind your back. Build it
@@ -211,6 +213,7 @@ brew install ninja cmake pkgconf autoconf automake libtool \
 | qt6-websockets-dev | TCI server, FreeDV Reporter spots |
 | qt6-serialport-dev | FlexControl, serial PTT/CW, MIDI controllers |
 | libfftw3-dev | NR2 spectral noise reduction |
+| librtlsdr-dev | RTL-SDR USB receiver backend (optional) |
 | portaudio19-dev | PortAudio audio backend |
 | libhidapi-dev | USB HID encoders (RC-28, PowerMate, FlexControl) |
 | qtkeychain-qt6-dev | SmartLink credential persistence |

--- a/docs/architecture/aetherd-rtl-sdr-backend-design.md
+++ b/docs/architecture/aetherd-rtl-sdr-backend-design.md
@@ -1,0 +1,88 @@
+# RTL-SDR backend
+
+**Status:** Experimental implementation for issue #4797
+**Family:** `rtl`
+**Transport:** local USB through `librtlsdr`
+
+## Scope
+
+The RTL-SDR backend is a receive-only `IRadioBackend` implementation. It
+provides one panadapter and one slice, discovers local USB dongles, converts
+unsigned 8-bit IQ on a worker thread, and emits spectrum, waterfall, and
+24 kHz stereo audio through the existing backend seam.
+
+`librtlsdr` and its float-precision FFTW dependency are optional. The
+`ENABLE_RTL` option permits an explicit opt-out; otherwise CMake defines
+`AETHER_BACKEND_RTL` only when both libraries are present. Discovery compiles
+as an unavailable stub when the backend is disabled so normal builds retain
+the same source graph.
+
+## Components
+
+- `RtlSdrDiscovery` enumerates USB devices off the GUI thread and feeds the
+  existing discovered-radio list. Duplicate or blank USB serials fall back to
+  a stable scan index for that connection attempt.
+- `RtlSdrBackend` owns radio state, validates requests, translates seam verbs,
+  and advertises a strictly receive-only capability set.
+- `RtlSdrWorker` owns the opened device handle. It runs
+  `rtlsdr_read_async`, performs control transfers only between async-read
+  sessions, and closes the handle only after the read loop exits.
+- `RtlSdrDdc` performs frequency translation, decimation, basic analog-mode
+  demodulation, FFTW spectrum generation, display pacing, and slice audio
+  mute/gain/pan.
+
+There is no intermediate ring buffer: each librtlsdr callback converts and
+processes its block on the reader thread. This bounds memory use but means DSP
+must keep pace with USB input.
+
+## Connection and state
+
+RTL-SDR is discovered as a local device; it is deliberately not accepted by
+the automation bridge's `connect ip` verb. A future USB-specific bridge verb
+should identify a dongle by enumerated serial or index.
+
+The client owns tuning, passband, sample rate, and RF gain. Universal values
+use `RestoredRadioState` fields; tuner gain is stored under the schema's
+`rfGain` extension domain. PPM and explicit direct-sampling overrides are
+runtime extension controls and are not persisted by the current generic state
+schema. Direct sampling is selected automatically when tuning below 24 MHz.
+
+Supported sample-rate detents are 225001, 250000, 300000, 1000000,
+1536000, 1843200, 2000000, 2400000, and 3000000 Hz. Requests snap to the
+nearest detent, and the resulting span is echoed through
+`panCenterBandwidthChanged`.
+
+## Threading and shutdown
+
+The GUI thread never performs a USB control transfer after streaming starts.
+A control setter stores its latest value atomically and cancels the async read.
+The worker consumes the retune flag before applying pending values, preserving
+any request that arrives during that application window, then restarts the
+read.
+
+Shutdown repeatedly cancels while waiting for the reader. If a broken USB
+stack does not acknowledge cancellation within the bounded wait, the backend
+detaches the worker until it finishes rather than destroying a running
+`QThread` or closing a device handle still in use.
+
+## Current limitations
+
+- No transmit, radio-side meters, memories, or multi-slice operation.
+- Demodulation is intentionally basic; passband values are state/UI controls,
+  not yet a sharp selectable DSP filter.
+- PPM, direct-sampling override, and offset tuning are extension verbs rather
+  than first-class controls.
+- Live hardware validation depends on an attached RTL-SDR dongle. The unit
+  test covers seam declarations, state validation/reset, discovery build
+  availability, DDC output, and sample-rate snapping without opening hardware.
+
+## Dependencies
+
+- Arch: `rtl-sdr`
+- Debian/Ubuntu: `librtlsdr-dev`
+- Fedora: `rtl-sdr-devel`
+- macOS: `librtlsdr`
+- FFTW float library and pkg-config module: `fftw3f`
+
+Windows and AppImage builds currently compile the feature out unless their
+dependency bundles supply `librtlsdr` through the same CMake contract.

--- a/docs/architecture/radio-capabilities-map.md
+++ b/docs/architecture/radio-capabilities-map.md
@@ -104,6 +104,23 @@ traps and why the DAX crash guard is deliberately *not* the DAX capability.
 | `notchHasDepth` | ✅ | ❌ | ❌ | `SpectrumWidget::setNotchCapabilities` | The depth submenu on a notch's right-click menu. A WDSP notch is a full null with no depth to set |
 | `notchMinWidthHz` / `notchMaxWidthHz` | 10 / 6000 | 50 / 6000 | 0 / 0 | `SpectrumWidget::setNotchCapabilities` | Clamps drag-resize and the width presets. HL2's floor is set by the RX filter length and WDSP **silently widens** anything narrower, so a UI offering less draws a notch narrower than the one being heard |
 
+### RTL-SDR experimental profile
+
+RTL-SDR is receive-only and mostly inherits the false/empty capability
+defaults. Its non-default declarations are kept separately so adding the
+experimental family does not duplicate or stale the main cross-family table.
+
+| Field | RTL-SDR value | Effect |
+|---|---|---|
+| `family` / `model` / `manufacturer` | `"rtl"` / USB product / USB vendor (fallback `"Realtek"`) | Identifies the local device in the shared radio model and status bar |
+| `tuningMinHz` / `tuningMaxHz` | 24 kHz / 1.766 GHz | Bounds tune requests; frequencies below 24 MHz select Q-branch direct sampling |
+| `sampleRatesHz` | 225001, 250000, 300000, 1000000, 1536000, 1843200, 2000000, 2400000, 3000000 | Publishes only legal `librtlsdr` detents |
+| `canTransmit` / `txPowerMaxWatts` / `hostModulates` | false / 0 / false | Fails closed on every transmit path and never opens the microphone |
+| `maxSlices` / `maxPanadapters` | 1 / 1 | Matches the single in-process DDC |
+| `persistsMemories` / `hasSupplyVoltageTelemetry` / `hasMultiClientSessions` | false / false / false | Avoids fabricating radio-side services or telemetry |
+| `clientSettingsDomains` | Tuning\|Passband\|SpanRate\|RfGain\|Memories | Restores only state the USB receiver cannot persist itself |
+| `extensionNamespaces` | `["rtl"]` | Declares gain, PPM, direct-sampling, offset-tuning, and sample-rate controls |
+
 `MainWindow::applyCapabilitiesToUi()` is the single fan-out for UI visibility. It
 is bound to `RadioModel::capabilitiesChanged`, which fires on both connection
 edges and on any mid-session revision by the backend. Add a capability by adding

--- a/packaging/linux/70-rtl-sdr.rules
+++ b/packaging/linux/70-rtl-sdr.rules
@@ -1,0 +1,8 @@
+# AetherSDR - RTL-SDR (RTL2832U) USB access for the active local user.
+# uaccess hands the node to whoever owns the active local session, so no
+# static group membership is required. Covers the Realtek reference IDs and
+# the common rebrands; see librtlsdr's own rtl-sdr.rules for the full list.
+ACTION!="remove", SUBSYSTEM=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2832", TAG+="uaccess"
+ACTION!="remove", SUBSYSTEM=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2838", TAG+="uaccess"
+ACTION!="remove", SUBSYSTEM=="usb", ATTRS{idVendor}=="0ccd", ATTRS{idProduct}=="00a9", TAG+="uaccess"
+ACTION!="remove", SUBSYSTEM=="usb", ATTRS{idVendor}=="1f4d", ATTRS{idProduct}=="b803", TAG+="uaccess"

--- a/src/core/RtlSdrDiscovery.cpp
+++ b/src/core/RtlSdrDiscovery.cpp
@@ -1,0 +1,166 @@
+#include "RtlSdrDiscovery.h"
+
+#include <QtConcurrent/QtConcurrentRun>
+#include <QtGlobal>
+#include <QSet>
+
+#ifdef AETHER_BACKEND_RTL
+#include <rtl-sdr.h>
+#endif
+
+namespace AetherSDR {
+
+// ---------------------------------------------------------------------------
+// RtlSdrDiscovery  —  pattern-matches Hl2Discovery for ConnectionPanel
+// ---------------------------------------------------------------------------
+
+RtlSdrDiscovery::RtlSdrDiscovery(QObject* parent)
+    : QObject(parent)
+    , m_timer(new QTimer(this))
+{
+    connect(m_timer, &QTimer::timeout, this, &RtlSdrDiscovery::onScanTimer);
+    connect(&m_watcher, &QFutureWatcher<QVector<RadioInfo>>::finished,
+            this, &RtlSdrDiscovery::onScanFinished);
+}
+
+RtlSdrDiscovery::~RtlSdrDiscovery()
+{
+    stop();
+    m_watcher.waitForFinished();
+}
+
+bool RtlSdrDiscovery::isRunning() const noexcept
+{
+    return m_timer->isActive() || m_scanning;
+}
+
+bool RtlSdrDiscovery::isAvailable()
+{
+#ifdef AETHER_BACKEND_RTL
+    return true;
+#else
+    return false;
+#endif
+}
+
+void RtlSdrDiscovery::start(int intervalMs)
+{
+    if (!isAvailable()) {
+        return;
+    }
+    m_timer->start(intervalMs);
+    onScanTimer(); // immediate first scan
+}
+
+void RtlSdrDiscovery::stop()
+{
+    m_timer->stop();
+}
+
+// ---------------------------------------------------------------------------
+// Scan logic: enumerate USB devices in a background worker thread via QtConcurrent
+// ---------------------------------------------------------------------------
+
+void RtlSdrDiscovery::onScanTimer()
+{
+    if (!isAvailable() || m_scanning) {
+        return; // Background scan still in progress or backend disabled
+    }
+
+    m_scanning = true;
+    m_watcher.setFuture(QtConcurrent::run([]() -> QVector<RadioInfo> {
+        QVector<RadioInfo> current;
+
+#ifdef AETHER_BACKEND_RTL
+        QSet<QString> usedSerials;
+        int count = rtlsdr_get_device_count();
+        for (int i = 0; i < count; ++i) {
+            char manufactBuf[256] = {0};
+            char productBuf[256] = {0};
+            char serialBuf[256] = {0};
+            rtlsdr_get_device_usb_strings(i, manufactBuf, productBuf, serialBuf);
+
+            RadioInfo info;
+            info.family = QStringLiteral("rtl");
+
+            QString usbSerial = QString::fromUtf8(serialBuf).trimmed();
+            if (!usbSerial.isEmpty() && !usedSerials.contains(usbSerial)) {
+                info.serial = usbSerial;
+            } else {
+                info.serial = QStringLiteral("rtl:%1").arg(i);
+            }
+            usedSerials.insert(info.serial);
+
+            QString vendor = QString::fromUtf8(manufactBuf).trimmed();
+            QString product = QString::fromUtf8(productBuf).trimmed();
+
+            info.name = vendor.isEmpty()
+                           ? product
+                           : QStringLiteral("%1 %2").arg(vendor, product);
+            if (info.name.trimmed().isEmpty()) {
+                info.name = QStringLiteral("RTL-SDR");
+            }
+
+            info.model = product.isEmpty() ? QStringLiteral("RTL2832U") : product;
+            info.status = QStringLiteral("Available");
+            info.inUse = false;
+
+            current.append(info);
+        }
+#endif
+        return current;
+    }));
+}
+
+void RtlSdrDiscovery::onScanFinished()
+{
+    m_scanning = false;
+    const QVector<RadioInfo> current = m_watcher.result();
+
+    if (!m_timer->isActive()) {
+        return;
+    }
+
+    // Track which devices are still present; report lost ones
+    QStringList lostSerials;
+    for (auto it = m_seen.begin(); it != m_seen.end(); ++it) {
+        const QString& serial = it.key();
+        bool found = false;
+        for (const auto& cur : current) {
+            if (cur.serial == serial) {
+                found = true;
+                it.value().missedScans = 0;
+                break;
+            }
+        }
+        if (!found) {
+            ++it.value().missedScans;
+            if (it.value().missedScans >= kMissedScansBeforeLost) {
+                lostSerials.append(serial);
+            }
+        }
+    }
+
+    // Remove lost entries
+    for (const auto& serial : lostSerials) {
+        emit radioLost(serial);
+        m_seen.remove(serial);
+    }
+
+    // Report newly discovered or updated devices
+    for (const auto& info : current) {
+        if (!m_seen.contains(info.serial)) {
+            m_seen[info.serial] = Seen{info, 0};
+            emit radioDiscovered(info);
+        } else {
+            // Check if anything changed (name, model, etc.)
+            if (m_seen[info.serial].info.name != info.name ||
+                m_seen[info.serial].info.model != info.model) {
+                m_seen[info.serial].info = info;
+                emit radioUpdated(info);
+            }
+        }
+    }
+}
+
+}  // namespace AetherSDR

--- a/src/core/RtlSdrDiscovery.h
+++ b/src/core/RtlSdrDiscovery.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "core/RadioDiscovery.h"   // RadioInfo
+
+#include <QFutureWatcher>
+#include <QHash>
+#include <QObject>
+#include <QString>
+#include <QVector>
+
+class QTimer;
+
+namespace AetherSDR {
+
+/**
+ * @brief Discovers RTL-SDR USB dongles via librtlsdr on a background worker thread.
+ *
+ * Emits RadioInfo with family="rtl" so ConnectionPanel's existing
+ * onRadioDiscovered/onRadioUpdated/onRadioLost slots consume it unchanged.
+ * Pattern-matches Hl2Discovery for consistent multi-backend discovery.
+ */
+class RtlSdrDiscovery : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit RtlSdrDiscovery(QObject* parent = nullptr);
+    ~RtlSdrDiscovery() override;
+
+    // Start/stop periodic USB scans
+    void start(int intervalMs = 5000);
+    void stop();
+
+    [[nodiscard]] bool isRunning() const noexcept;
+
+    // True when this build includes librtlsdr support.
+    static bool isAvailable();
+
+signals:
+    void radioDiscovered(const RadioInfo& info);
+    void radioUpdated(const RadioInfo& info);
+    void radioLost(const QString& serial);
+
+private slots:
+    void onScanTimer();
+    void onScanFinished();
+
+private:
+    struct Seen {
+        RadioInfo info;
+        int missedScans = 0;
+    };
+
+    QTimer* m_timer = nullptr;
+    QFutureWatcher<QVector<RadioInfo>> m_watcher;
+    bool m_scanning = false;
+    QHash<QString, Seen> m_seen;  // keyed by serial (USB serial or index)
+    static constexpr int kMissedScansBeforeLost = 3;
+};
+
+}  // namespace AetherSDR

--- a/src/core/backends/rtl/RtlSdrBackend.cpp
+++ b/src/core/backends/rtl/RtlSdrBackend.cpp
@@ -1,0 +1,898 @@
+#include "core/backends/rtl/RtlSdrBackend.h"
+#include "core/backends/rtl/RtlSdrWorker.h"
+#include "core/backends/rtl/RtlSdrDdc.h"
+#include "core/backends/RadioDelta.h"
+#include "core/backends/SliceDelta.h"
+
+#include <QDebug>
+
+#include <rtl-sdr.h>
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR::rtl {
+
+namespace {
+
+constexpr double kMinTuneHz = 24'000.0;
+constexpr double kMaxTuneHz = 1'766'000'000.0;
+
+double clampFrequency(double hz)
+{
+    return std::clamp(hz, kMinTuneHz, kMaxTuneHz);
+}
+
+bool isKnownMode(const QString& mode)
+{
+    static const QStringList modes{QStringLiteral("AM"), QStringLiteral("SAM"),
+                                   QStringLiteral("FM"), QStringLiteral("FMN"),
+                                   QStringLiteral("WFM"), QStringLiteral("USB"),
+                                   QStringLiteral("LSB"), QStringLiteral("CW"),
+                                   QStringLiteral("CWR")};
+    return modes.contains(mode.trimmed().toUpper());
+}
+
+int nearestGainTenths(const QVector<int>& gains, int requested)
+{
+    if (gains.isEmpty()) {
+        return requested;
+    }
+    return *std::min_element(gains.cbegin(), gains.cend(), [requested](int a, int b) {
+        return std::abs(a - requested) < std::abs(b - requested);
+    });
+}
+
+} // namespace
+
+// Static convenience — returns the family string used by RadioModel::makeBackend().
+QString RtlSdrBackend::familyName() { return QStringLiteral("rtl"); }
+
+uint32_t RtlSdrBackend::clampSampleRate(uint32_t requestedHz)
+{
+    static const QVector<uint32_t> kSupportedRates = {
+        225'001u, 250'000u, 300'000u, 1'000'000u,
+        1'536'000u, 1'843'200u, 2'000'000u, 2'400'000u, 3'000'000u
+    };
+
+    uint32_t bestRate = kSupportedRates.front();
+    int64_t minDiff = std::abs(static_cast<int64_t>(requestedHz) - static_cast<int64_t>(bestRate));
+
+    for (uint32_t rate : kSupportedRates) {
+        int64_t diff = std::abs(static_cast<int64_t>(requestedHz) - static_cast<int64_t>(rate));
+        if (diff < minDiff) {
+            minDiff = diff;
+            bestRate = rate;
+        }
+    }
+
+    return bestRate;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Lifecycle
+// ──────────────────────────────────────────────────────────────────────────────
+
+RtlSdrBackend::RtlSdrBackend(QObject* parent)
+    : IRadioBackend(parent)
+{
+}
+
+RtlSdrBackend::~RtlSdrBackend()
+{
+    if (m_connected) {
+        disconnectRadio();
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// IRadioBackend::capabilities
+// ──────────────────────────────────────────────────────────────────────────────
+
+RadioCapabilities RtlSdrBackend::capabilities() const
+{
+    RadioCapabilities c;
+    c.family = QStringLiteral("rtl");
+    c.model  = m_modelName;
+    c.manufacturer = m_vendor.isEmpty() ? QStringLiteral("Realtek") : m_vendor;
+
+    // TX — receive-only (Principle VI)
+    c.canTransmit = false;
+    c.txPowerMaxWatts = 0.0;
+    c.hostModulates = false;  // CRITICAL: must not open mic on connect (#4449)
+
+    // Receiver limits
+    c.maxSlices = 1;
+    c.maxPanadapters = 1;
+
+    // Tuning range — R820T: 24 MHz – 1.766 GHz (HF via direct sampling)
+    c.tuningMinHz = 24'000;
+    c.tuningMaxHz = 1'766'000'000;
+
+    // Sample rates — non-contiguous legal windows for R820T
+    c.sampleRatesHz = {
+        225'001, 250'000, 300'000, 1'000'000,
+        1'536'000, 1'843'200, 2'000'000, 2'400'000, 3'000'000
+    };
+
+    // Persistence — RTL-SDR has no radio-side memory
+    c.persistsMemories = false;
+    c.hasSupplyVoltageTelemetry = false;
+    c.hasMultiClientSessions = false;
+
+    // Client owns all state (RTL-SDR persists nothing)
+    c.clientSettingsDomains = RadioCapabilities::ClientSettingsDomain::Tuning
+                            | RadioCapabilities::ClientSettingsDomain::Passband
+                            | RadioCapabilities::ClientSettingsDomain::SpanRate
+                            | RadioCapabilities::ClientSettingsDomain::RfGain
+                            | RadioCapabilities::ClientSettingsDomain::Memories;
+
+    // Vendor extensions
+    c.extensions["rtl"] = QVariantMap{{"serial", m_serial}};
+    c.extensionNamespaces = {"rtl"};
+
+    return c;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// IRadioBackend::connectRadio / disconnectRadio
+// ──────────────────────────────────────────────────────────────────────────────
+
+void RtlSdrBackend::connectRadio(const RadioConnectRequest& request)
+{
+    if (m_connected) {
+        disconnectRadio();
+    }
+
+    const auto params = request.params;
+    const int deviceIdx = deviceIndexFromParams(params);
+    QString targetSerial = request.serial.trimmed();
+    if (targetSerial.isEmpty()) {
+        targetSerial = serialFromParams(params);
+    }
+
+    // ── Discover the target device ──────────────────────────────────────────
+    int count = rtlsdr_get_device_count();
+    if (count == 0) {
+        emit connectionError(tr("No RTL-SDR devices found"));
+        return;
+    }
+
+    int idx = -1;
+    if (!targetSerial.isEmpty()) {
+        if (targetSerial.startsWith(QLatin1String("rtl:"))) {
+            bool ok = false;
+            int parsedIdx = targetSerial.mid(4).toInt(&ok);
+            if (ok && parsedIdx >= 0 && parsedIdx < count) {
+                idx = parsedIdx;
+            }
+        }
+        if (idx < 0) {
+            for (int i = 0; i < count; ++i) {
+                char vendor[256] = {0};
+                char product[256] = {0};
+                char serial[256] = {0};
+                if (rtlsdr_get_device_usb_strings(i, vendor, product, serial) == 0) {
+                    QString s = QString::fromUtf8(serial).trimmed();
+                    if (s == targetSerial || (s.isEmpty() && targetSerial == QStringLiteral("rtl:%1").arg(i))) {
+                        idx = i;
+                        break;
+                    }
+                }
+            }
+        }
+        if (idx < 0) {
+            emit connectionError(tr("RTL-SDR device with serial %1 not found").arg(targetSerial));
+            return;
+        }
+    } else {
+        idx = deviceIdx;
+    }
+
+    if (idx < 0 || idx >= count) {
+        emit connectionError(tr("RTL-SDR device index %1 out of range (0-%2)").arg(idx).arg(count - 1));
+        return;
+    }
+
+    // ── Open device ─────────────────────────────────────────────────────────
+    rtlsdr_dev_t* devHandle = nullptr;
+    int rc = rtlsdr_open(&devHandle, idx);
+    if (rc < 0 || !devHandle) {
+        // The two failures that actually happen in the field, named so the
+        // operator can fix them without searching.  LIBUSB_ERROR_ACCESS is a
+        // missing udev rule; LIBUSB_ERROR_BUSY is another process (or the
+        // DVB-T kernel driver) still holding the device.
+        QString hint;
+        if (rc == -3) {
+            hint = tr(" — no permission to open the USB device. Install the "
+                      "udev rule (packaging/linux/70-rtl-sdr.rules) and "
+                      "replug the dongle.");
+        } else if (rc == -6) {
+            hint = tr(" — the device is in use. Close any other SDR program, "
+                      "or blacklist the dvb_usb_rtl28xxu kernel driver.");
+        }
+        emit connectionError(tr("Failed to open RTL-SDR device: error %1%2")
+                                 .arg(rc).arg(hint));
+        return;
+    }
+    m_device = devHandle;
+
+    const auto failConfiguration = [this, devHandle](const QString& message) {
+        rtlsdr_close(devHandle);
+        m_device = nullptr;
+        m_modelName.clear();
+        m_vendor.clear();
+        m_product.clear();
+        m_serial.clear();
+        m_tunerGainsTenths.clear();
+        emit connectionError(message);
+    };
+
+    char vendorBuf[256] = {0};
+    char productBuf[256] = {0};
+    char serialBuf[256] = {0};
+    if (rtlsdr_get_device_usb_strings(idx, vendorBuf, productBuf, serialBuf) == 0) {
+        m_vendor  = QString::fromUtf8(vendorBuf);
+        m_product = QString::fromUtf8(productBuf);
+        m_serial  = QString::fromUtf8(serialBuf);
+    } else {
+        m_vendor  = tr("Realtek");
+        m_product = tr("RTL2832U");
+        m_serial  = QString::number(idx);
+    }
+
+    // ── Configure initial frequency, direct sampling, and gain ───────────────
+    if (request.params.contains("initialFrequencyHz")) {
+        m_panCenterHz = clampFrequency(request.params["initialFrequencyHz"].toDouble());
+    } else if (m_panCenterHz <= 0) {
+        m_panCenterHz = 101'700'000.0;
+    }
+    m_sliceFreqHz = m_panCenterHz;
+
+    // Direct sampling mode MUST be configured before tuning center frequency,
+    // because HF (< 24 MHz) requires direct sampling mode 2 before setting frequency.
+    m_directSampling = m_panCenterHz < 24'000'000.0 ? 2 : 0;
+    rc = rtlsdr_set_direct_sampling(devHandle, m_directSampling);
+    if (rc < 0) {
+        failConfiguration(tr("Failed to configure RTL-SDR direct sampling: error %1").arg(rc));
+        return;
+    }
+
+    rc = rtlsdr_set_center_freq(devHandle, static_cast<uint32_t>(m_panCenterHz));
+    if (rc < 0) {
+        failConfiguration(tr("Failed to tune RTL-SDR to %1 Hz: error %2")
+                              .arg(m_panCenterHz, 0, 'f', 0).arg(rc));
+        return;
+    }
+
+    // Apply tuner gain (from request params or restored state)
+    if (request.params.contains("gainDb")) {
+        m_panRfGainDb = request.params["gainDb"].toInt();
+    }
+    m_tunerGainsTenths.clear();
+    const int gainCount = rtlsdr_get_tuner_gains(devHandle, nullptr);
+    if (gainCount > 0) {
+        m_tunerGainsTenths.resize(gainCount);
+        if (rtlsdr_get_tuner_gains(devHandle, m_tunerGainsTenths.data()) < 0) {
+            m_tunerGainsTenths.clear();
+        }
+    }
+    const int gainTenths = nearestGainTenths(m_tunerGainsTenths, m_panRfGainDb * 10);
+    m_panRfGainDb = qRound(gainTenths / 10.0);
+    rc = rtlsdr_set_tuner_gain_mode(devHandle, 1);
+    if (rc < 0) {
+        failConfiguration(tr("Failed to enable manual RTL-SDR tuner gain: error %1").arg(rc));
+        return;
+    }
+    rc = rtlsdr_set_tuner_gain(devHandle, gainTenths);
+    if (rc < 0) {
+        failConfiguration(tr("Failed to configure RTL-SDR tuner gain: error %1").arg(rc));
+        return;
+    }
+    // The RTL2832 digital AGC is independent of the tuner's gain mode. Keep it
+    // disabled so it cannot ride on top of the operator's manual RF gain.
+    rc = rtlsdr_set_agc_mode(devHandle, 0);
+    if (rc < 0) {
+        failConfiguration(tr("Failed to disable RTL-SDR digital AGC: error %1").arg(rc));
+        return;
+    }
+
+    // ── Set sample rate (default 2.4 MSPS) ──────────────────────────────────
+    uint32_t sampleRate = m_sampleRateHz;
+    if (request.params.contains("sampleRateHz")) {
+        sampleRate = request.params["sampleRateHz"].toUInt();
+    }
+    sampleRate = clampSampleRate(sampleRate);
+    rc = rtlsdr_set_sample_rate(devHandle, sampleRate);
+    if (rc < 0) {
+        failConfiguration(tr("Failed to set RTL-SDR sample rate to %1 Hz: error %2")
+                              .arg(sampleRate).arg(rc));
+        return;
+    }
+    m_sampleRateHz = rtlsdr_get_sample_rate(devHandle);
+    if (m_sampleRateHz == 0) {
+        failConfiguration(tr("Failed to read back the applied RTL-SDR sample rate"));
+        return;
+    }
+
+    // ── Set PPM frequency correction ────────────────────────────────────────
+    if (m_ppmCorrection != 0) {
+        rc = rtlsdr_set_freq_correction(devHandle, m_ppmCorrection);
+        if (rc < 0) {
+            failConfiguration(tr("Failed to set RTL-SDR frequency correction: error %1").arg(rc));
+            return;
+        }
+    }
+
+    // ── Identify tuner IC for model name ────────────────────────────────────
+    m_modelName = m_product;
+
+    // ── Instantiate Worker (owns RtlSdrDdc processing engine) ─────────────
+    m_worker = std::make_unique<RtlSdrWorker>(m_device);
+
+    if (RtlSdrDdc* ddcEngine = m_worker->ddc()) {
+        ddcEngine->setSampleRate(m_sampleRateHz);
+        ddcEngine->setCenterFrequency(m_panCenterHz);
+        ddcEngine->setSliceFrequency(m_sliceFreqHz);
+        ddcEngine->setSliceMode(m_sliceMode);
+        ddcEngine->setSliceFilter(m_sliceFilterLow, m_sliceFilterHigh);
+    }
+
+    // Relay worker/DDC signals to IRadioBackend outputs via cross-thread queued connection
+    connect(m_worker.get(), &RtlSdrWorker::spectrumFrameReady,
+            this, &IRadioBackend::spectrumFrameReady);
+    connect(m_worker.get(), &RtlSdrWorker::waterfallRowReady,
+            this, &IRadioBackend::waterfallRowReady);
+    connect(m_worker.get(), &RtlSdrWorker::audioFrameReady,
+            this, [this](const QByteArray& pcm) {
+                emit audioFrameReady(pcm);
+                emit sliceAudioFrameReady(0, pcm);
+            });
+    connect(m_worker.get(), &RtlSdrWorker::readError,
+            this, [this](const QString& err) {
+                emit connectionError(err);
+                disconnectRadio();
+            });
+    connect(m_worker.get(), &RtlSdrWorker::controlApplied,
+            this, &RtlSdrBackend::handleControlApplied);
+    connect(m_worker.get(), &RtlSdrWorker::controlFailed,
+            this, &RtlSdrBackend::handleControlFailed);
+
+    m_worker->startReading();
+
+    // ── Mark connected, emit signals ────────────────────────────────────────
+    m_connected = true;
+    emit connected();
+    emitInitialState();
+}
+
+void RtlSdrBackend::disconnectRadio()
+{
+    if (!m_connected) {
+        return;
+    }
+
+    for (auto it = m_pendingExtensionRequests.cbegin();
+         it != m_pendingExtensionRequests.cend(); ++it) {
+        for (quint64 requestId : it.value()) {
+            emit extensionError(requestId, tr("RTL-SDR disconnected before the control completed"));
+        }
+    }
+    m_pendingExtensionRequests.clear();
+
+    // The worker owns the device handle and closes it only after read_async has
+    // exited. If a broken USB stack ignores cancellation, leave the worker
+    // alive until QThread::finished rather than destroying a live QThread or
+    // closing a handle underneath libusb.
+    if (m_worker) {
+        if (m_worker->stopReading()) {
+            m_worker.reset();
+        } else {
+            RtlSdrWorker* stranded = m_worker.release();
+            connect(stranded, &QThread::finished, stranded, &QObject::deleteLater);
+        }
+        m_device = nullptr;
+    }
+
+    m_connected = false;
+    m_modelName.clear();
+    m_vendor.clear();
+    m_product.clear();
+    m_serial.clear();
+    m_tunerGainsTenths.clear();
+
+    emit disconnected();
+}
+
+bool RtlSdrBackend::isConnected() const
+{
+    return m_connected;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// IRadioBackend — slice control
+// ──────────────────────────────────────────────────────────────────────────────
+
+void RtlSdrBackend::setSliceFrequency(int sliceId, double hz)
+{
+    Q_UNUSED(sliceId);  // Single slice
+
+    if (!m_connected) {
+        return;
+    }
+
+    m_sliceFreqHz = clampFrequency(hz);
+
+    // Check if the requested slice frequency is outside the current 2.4 MHz panadapter window (±1.0 MHz)
+    const double spanMarginHz = m_sampleRateHz * 0.45;
+    if (std::abs(m_sliceFreqHz - m_panCenterHz) > spanMarginHz) {
+        m_panCenterHz = m_sliceFreqHz;
+        if (m_worker) {
+            const int requiredDs = (m_panCenterHz < 24'000'000.0) ? 2 : 0;
+            if (m_directSampling != requiredDs) {
+                m_directSampling = requiredDs;
+                m_worker->setDirectSampling(requiredDs);
+            }
+            m_worker->setCenterFrequency(static_cast<uint32_t>(m_panCenterHz));
+        }
+        if (RtlSdrDdc* ddcEngine = ddc()) {
+            ddcEngine->setCenterFrequency(m_panCenterHz);
+        }
+        emit panCenterBandwidthChanged(QStringLiteral("0xe1000000"), m_panCenterHz / 1e6,
+                                       m_sampleRateHz / 1e6);
+    }
+
+    if (RtlSdrDdc* ddcEngine = ddc()) {
+        ddcEngine->setSliceFrequency(m_sliceFreqHz);
+    }
+
+    SliceDelta delta;
+    delta.frequency = m_sliceFreqHz / 1e6;
+    delta.mode = m_sliceMode;
+    emit sliceChanged(0, delta);
+    emit operatingStateChanged();
+}
+
+void RtlSdrBackend::setSliceMode(int sliceId, const QString& mode)
+{
+    Q_UNUSED(sliceId);
+
+    if (!m_connected) {
+        return;
+    }
+
+    const QString canonicalMode = mode.trimmed().toUpper();
+    if (!isKnownMode(canonicalMode)) {
+        return;
+    }
+    m_sliceMode = canonicalMode;
+    if (RtlSdrDdc* ddcEngine = ddc()) {
+        ddcEngine->setSliceMode(canonicalMode);
+    }
+
+    SliceDelta delta;
+    delta.frequency = m_sliceFreqHz / 1e6;
+    delta.mode = canonicalMode;
+    emit sliceChanged(0, delta);
+    emit operatingStateChanged();
+}
+
+void RtlSdrBackend::setSliceFilter(int sliceId, int lowHz, int highHz)
+{
+    Q_UNUSED(sliceId);
+
+    if (!m_connected) {
+        return;
+    }
+
+    if (lowHz >= highHz || lowHz < -100'000 || highHz > 100'000) {
+        return;
+    }
+    m_sliceFilterLow = lowHz;
+    m_sliceFilterHigh = highHz;
+    if (RtlSdrDdc* ddcEngine = ddc()) {
+        ddcEngine->setSliceFilter(lowHz, highHz);
+    }
+
+    SliceDelta delta;
+    delta.frequency = m_sliceFreqHz / 1e6;
+    delta.mode = m_sliceMode;
+    delta.filterLow = lowHz;
+    delta.filterHigh = highHz;
+    emit sliceChanged(0, delta);
+    emit operatingStateChanged();
+}
+
+void RtlSdrBackend::setSliceAgc(int sliceId, const QString& mode, int thresholdDb)
+{
+    Q_UNUSED(sliceId);
+    Q_UNUSED(mode);
+    Q_UNUSED(thresholdDb);
+    // Phase 1: AGC is engine-side DSP, not hardware.
+    // The DDC will apply AGC in Phase 2.
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// IRadioBackend — pan control
+// ──────────────────────────────────────────────────────────────────────────────
+
+void RtlSdrBackend::setPanCenter(const QString& panId, double hz,
+                                  PanCenterIntent intent)
+{
+    Q_UNUSED(intent);
+    if (!m_connected) {
+        return;
+    }
+
+    hz = clampFrequency(hz);
+    m_panCenterHz = hz;
+    if (RtlSdrDdc* ddcEngine = ddc()) {
+        ddcEngine->setCenterFrequency(hz);
+    }
+
+    // Dispatch blocking USB control transfer to worker thread (§ Hazards #2)
+    if (m_worker) {
+        const int requiredDs = (hz < 24'000'000.0) ? 2 : 0;
+        if (m_directSampling != requiredDs) {
+            m_directSampling = requiredDs;
+            m_worker->setDirectSampling(requiredDs);
+        }
+        m_worker->setCenterFrequency(static_cast<uint32_t>(hz));
+    }
+
+    const QString effectivePanId = panId.isEmpty() ? QStringLiteral("0xe1000000") : panId;
+    emit panCenterBandwidthChanged(effectivePanId, hz / 1e6, m_sampleRateHz / 1e6);
+    // Update slice frequency to track pan center (single-slice design)
+    m_sliceFreqHz = hz;
+    if (RtlSdrDdc* ddcEngine = ddc()) {
+        ddcEngine->setSliceFrequency(hz);
+    }
+
+    SliceDelta delta;
+    delta.frequency = hz / 1e6;
+    delta.mode = m_sliceMode;
+    emit sliceChanged(0, delta);
+    emit operatingStateChanged();
+}
+
+void RtlSdrBackend::setPanBandwidth(const QString& panId, double hz)
+{
+    if (!m_connected || !m_worker) {
+        return;
+    }
+    const uint32_t rate = clampSampleRate(
+        static_cast<uint32_t>(std::clamp(hz, 1.0, static_cast<double>(UINT32_MAX))));
+    m_pendingPanId = panId.isEmpty() ? QStringLiteral("0xe1000000") : panId;
+    m_worker->setSampleRate(rate);
+}
+
+void RtlSdrBackend::setPanFrameRate(const QString& panId, int fps)
+{
+    Q_UNUSED(panId);
+    if (RtlSdrDdc* ddcEngine = ddc()) {
+        ddcEngine->setSpectrumRateFps(fps);
+    }
+}
+
+void RtlSdrBackend::setSliceAudioMute(int sliceId, bool mute)
+{
+    if (sliceId == 0) {
+        if (RtlSdrDdc* ddcEngine = ddc()) {
+            ddcEngine->setAudioMute(mute);
+        }
+    }
+}
+
+void RtlSdrBackend::setSliceAudioGain(int sliceId, int gainPercent)
+{
+    if (sliceId == 0) {
+        if (RtlSdrDdc* ddcEngine = ddc()) {
+            ddcEngine->setAudioGain(gainPercent);
+        }
+    }
+}
+
+void RtlSdrBackend::setSliceAudioPan(int sliceId, int panPercent)
+{
+    if (sliceId == 0) {
+        if (RtlSdrDdc* ddcEngine = ddc()) {
+            ddcEngine->setAudioPan(panPercent);
+        }
+    }
+}
+
+void RtlSdrBackend::setPanRfGain(const QString& panId, int gainDb)
+{
+    if (!m_connected) {
+        return;
+    }
+
+    const int gainTenths = nearestGainTenths(m_tunerGainsTenths, gainDb * 10);
+    m_pendingPanId = panId.isEmpty() ? QStringLiteral("0xe1000000") : panId;
+
+    // Dispatch blocking USB control transfer to worker thread (§ Hazards #2)
+    if (m_worker) {
+        m_worker->setTunerGain(gainTenths);
+    }
+
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// IRadioBackend — transmit (guarded — RX-only)
+// ──────────────────────────────────────────────────────────────────────────────
+
+void RtlSdrBackend::setKeying(bool key)
+{
+    Q_UNUSED(key);
+    // RTL-SDR is receive-only. This is a no-op.
+    // The bridge TX gate (AETHER_AUTOMATION_ALLOW_TX) is the real guard.
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// IRadioBackend — vendor extensions
+// ──────────────────────────────────────────────────────────────────────────────
+
+void RtlSdrBackend::invokeExtension(const QString& ns, const QString& verb,
+                                    quint64 requestId, const QVariant& arg)
+{
+    if (ns != "rtl") {
+        emit extensionError(requestId, tr("Unknown namespace %1").arg(ns));
+        return;
+    }
+
+    if (!m_connected || !m_device) {
+        emit extensionError(requestId, tr("Not connected"));
+        return;
+    }
+
+    if (verb == "gain.set") {
+        bool ok = false;
+        const int gain = arg.toInt(&ok);
+        if (!ok) {
+            emit extensionError(requestId, tr("gain.set requires an integer dB value"));
+            return;
+        }
+        queueExtensionRequest(QStringLiteral("gain"), requestId);
+        setPanRfGain(QStringLiteral("0xe1000000"), gain);
+
+    } else if (verb == "gain.list") {
+        emit extensionResult(requestId, QVariant::fromValue(m_tunerGainsTenths));
+
+    } else if (verb == "ppm.set") {
+        bool ok = false;
+        int ppm = arg.toInt(&ok);
+        if (!ok || ppm < -1000 || ppm > 1000) {
+            emit extensionError(requestId, tr("ppm.set requires an integer from -1000 to 1000"));
+            return;
+        }
+        queueExtensionRequest(QStringLiteral("ppm"), requestId);
+        if (m_worker) {
+            m_worker->setPpmCorrection(ppm);
+        }
+
+    } else if (verb == "direct_sampling.set") {
+        // Mode 0 = Off (tuner), Mode 1 = I-branch, Mode 2 = Q-branch (HF direct)
+        bool ok = false;
+        int mode = arg.toInt(&ok);
+        if (!ok || mode < 0 || mode > 2) {
+            emit extensionError(requestId, tr("direct_sampling.set requires 0, 1, or 2"));
+            return;
+        }
+        queueExtensionRequest(QStringLiteral("direct_sampling"), requestId);
+        if (m_worker) {
+            m_worker->setDirectSampling(mode);
+        }
+
+    } else if (verb == "offset_tuning.set") {
+        bool ok = false;
+        int enable = arg.toInt(&ok);
+        if (!ok || (enable != 0 && enable != 1)) {
+            emit extensionError(requestId, tr("offset_tuning.set requires 0 or 1"));
+            return;
+        }
+        queueExtensionRequest(QStringLiteral("offset_tuning"), requestId);
+        if (m_worker) {
+            m_worker->setOffsetTuning(enable);
+        }
+
+    } else if (verb == "sample_rate.set") {
+        bool ok = false;
+        uint32_t rate = clampSampleRate(arg.toUInt(&ok));
+        if (!ok) {
+            emit extensionError(requestId, tr("sample_rate.set requires an integer Hz value"));
+            return;
+        }
+        queueExtensionRequest(QStringLiteral("sample_rate"), requestId);
+        if (m_worker) {
+            m_worker->setSampleRate(rate);
+        }
+
+    } else {
+        emit extensionError(requestId, tr("Unknown RTL extension %1").arg(verb));
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// IRadioBackend — client-side state memory
+// ──────────────────────────────────────────────────────────────────────────────
+
+void RtlSdrBackend::applyRestoredState(const RestoredRadioState& state)
+{
+    // Restore is applied during connectRadio for RTL-SDR because the device
+    // has no persistent state — frequency, gain, PPM are applied as setpoints
+    // after rtlsdr_open(). The RadioModel calls applyRestoredState before
+    // connectRadio, so we stash the values and use them in connectRadio.
+    //
+    // NOTE: restore never keys transmit (Principle VI).
+    // Reset first: RadioModel can reuse this backend object for another dongle,
+    // and an empty snapshot must not inherit the previous radio's settings.
+    m_panCenterHz = 95'200'000.0;
+    m_sliceFreqHz = m_panCenterHz;
+    m_sliceMode = QStringLiteral("WFM");
+    m_sliceFilterLow = -100'000;
+    m_sliceFilterHigh = 100'000;
+    m_sampleRateHz = 2'400'000;
+    m_panRfGainDb = kDefaultRfGainDb;
+    m_ppmCorrection = 0;
+    m_directSampling = 0;
+
+    if (state.rfFrequencyHz > 0) {
+        const double clampedHz = clampFrequency(state.rfFrequencyHz);
+        m_panCenterHz = clampedHz;
+        m_sliceFreqHz = clampedHz;
+    }
+    if (isKnownMode(state.mode)) {
+        m_sliceMode = state.mode.trimmed().toUpper();
+    }
+    if (state.filterLowHz < state.filterHighHz
+        && state.filterLowHz >= -100'000.0 && state.filterHighHz <= 100'000.0) {
+        m_sliceFilterLow = qRound(state.filterLowHz);
+        m_sliceFilterHigh = qRound(state.filterHighHz);
+    }
+    if (state.sampleRateHz > 0) {
+        m_sampleRateHz = clampSampleRate(static_cast<uint32_t>(state.sampleRateHz));
+    }
+
+    const QJsonObject rfGain =
+        state.extension.value(QStringLiteral("rfGain")).toObject();
+    if (rfGain.contains(QStringLiteral("gainDb"))) {
+        m_panRfGainDb = std::clamp(rfGain.value(QStringLiteral("gainDb")).toInt(),
+                                   -100, 100);
+    }
+}
+
+RestoredRadioState RtlSdrBackend::currentOperatingState() const
+{
+    RestoredRadioState state;
+    state.rfFrequencyHz = m_panCenterHz;
+    state.mode = m_sliceMode;
+    state.filterLowHz = m_sliceFilterLow;
+    state.filterHighHz = m_sliceFilterHigh;
+    state.sampleRateHz = static_cast<int>(m_sampleRateHz);
+    state.extensionSchemaVersion = 1;
+
+    state.extension[QStringLiteral("rfGain")] =
+        QJsonObject{{QStringLiteral("gainDb"), m_panRfGainDb}};
+    return state;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Private helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+void RtlSdrBackend::queueExtensionRequest(const QString& control, quint64 requestId)
+{
+    m_pendingExtensionRequests[control].append(requestId);
+}
+
+void RtlSdrBackend::handleControlApplied(const QString& control, qint64 value)
+{
+    if (!m_connected) {
+        return;
+    }
+
+    QVariant result = value;
+    if (control == QLatin1String("gain")) {
+        m_panRfGainDb = qRound(value / 10.0);
+        result = m_panRfGainDb;
+        emit panRfGainChanged(m_pendingPanId, m_panRfGainDb);
+        emit operatingStateChanged();
+    } else if (control == QLatin1String("sample_rate")) {
+        m_sampleRateHz = static_cast<uint32_t>(value);
+        result = m_sampleRateHz;
+        emit panCenterBandwidthChanged(m_pendingPanId, m_panCenterHz / 1e6,
+                                       m_sampleRateHz / 1e6);
+        emit operatingStateChanged();
+    } else if (control == QLatin1String("center_frequency")) {
+        m_panCenterHz = static_cast<double>(value);
+        if (RtlSdrDdc* ddcEngine = ddc()) {
+            ddcEngine->setCenterFrequency(m_panCenterHz);
+        }
+        emit panCenterBandwidthChanged(m_pendingPanId, m_panCenterHz / 1e6,
+                                       m_sampleRateHz / 1e6);
+        emit operatingStateChanged();
+    } else if (control == QLatin1String("direct_sampling")) {
+        m_directSampling = static_cast<int>(value);
+    } else if (control == QLatin1String("ppm")) {
+        m_ppmCorrection = static_cast<int>(value);
+    }
+
+    const QVector<quint64> requests = m_pendingExtensionRequests.take(control);
+    for (quint64 requestId : requests) {
+        emit extensionResult(requestId, result);
+    }
+}
+
+void RtlSdrBackend::handleControlFailed(const QString& control, const QString& message)
+{
+    if (!m_connected) {
+        return;
+    }
+
+    const QVector<quint64> requests = m_pendingExtensionRequests.take(control);
+    for (quint64 requestId : requests) {
+        emit extensionError(requestId, message);
+    }
+    if (requests.isEmpty()) {
+        emit connectionError(message);
+    }
+}
+
+void RtlSdrBackend::emitInitialState()
+{
+    // Emit the signals the UI expects from a freshly-connected radio.
+    // Mirrors what the Flex backend does with initial status echoes.
+    RadioDelta rDelta;
+    rDelta.model = m_modelName;
+    rDelta.nickname = m_product;
+    emit radioChanged(rDelta);
+
+    const QString kPanId = QStringLiteral("0xe1000000");
+
+    // Pan 0 FIRST — center frequency and bandwidth limits so PanadapterModel materialises
+    emit panCenterBandwidthChanged(kPanId, m_panCenterHz / 1e6, m_sampleRateHz / 1e6);
+    emit panBandwidthLimitsChanged(kPanId, 0.225001, 3.0);
+
+    // Tuner RF gain info
+    if (!m_tunerGainsTenths.isEmpty()) {
+        const auto [minIt, maxIt] = std::minmax_element(m_tunerGainsTenths.cbegin(),
+                                                        m_tunerGainsTenths.cend());
+        emit panRfGainInfoChanged(kPanId, qFloor(*minIt / 10.0), qCeil(*maxIt / 10.0), 1);
+    }
+
+    // RF gain
+    emit panRfGainChanged(kPanId, m_panRfGainDb);
+
+    // Slice 0 — initial frequency, mode, and filters
+    SliceDelta sDelta;
+    sDelta.frequency = m_sliceFreqHz / 1e6;
+    sDelta.mode = m_sliceMode;
+    sDelta.filterLow = m_sliceFilterLow;
+    sDelta.filterHigh = m_sliceFilterHigh;
+    // No txAntenna or rxAntenna list on hardware without software antenna switches (Constitution Principle II & VI)
+    sDelta.modeList = QStringList{QStringLiteral("AM"), QStringLiteral("SAM"),
+                                  QStringLiteral("FM"), QStringLiteral("FMN"),
+                                  QStringLiteral("WFM"), QStringLiteral("USB"),
+                                  QStringLiteral("LSB"), QStringLiteral("CW"),
+                                  QStringLiteral("CWR")};
+    sDelta.active = true;
+    sDelta.panId = kPanId;
+    emit sliceChanged(0, sDelta);
+}
+
+RtlSdrDdc* RtlSdrBackend::ddc()
+{
+    return m_worker ? m_worker->ddc() : nullptr;
+}
+
+int RtlSdrBackend::deviceIndexFromParams(const QVariantMap& params) const
+{
+    return params.value("rtl.deviceIndex", 0).toInt();
+}
+
+QString RtlSdrBackend::serialFromParams(const QVariantMap& params) const
+{
+    return params.value("rtl.serialNumber").toString();
+}
+
+}  // namespace AetherSDR::rtl

--- a/src/core/backends/rtl/RtlSdrBackend.h
+++ b/src/core/backends/rtl/RtlSdrBackend.h
@@ -1,0 +1,133 @@
+#pragma once
+
+#include "core/backends/IRadioBackend.h"
+#include "core/backends/RestoredRadioState.h"
+
+#include <QObject>
+#include <QHash>
+#include <QString>
+#include <QTimer>
+#include <QVector>
+
+// librtlsdr forward
+struct rtlsdr_dev;
+
+namespace AetherSDR::rtl {
+
+class RtlSdrWorker;
+class RtlSdrDdc;
+
+// IRadioBackend implementation for RTL-SDR USB dongles.
+//
+// Receive-only (Principle VI): capabilities().canTransmit = false,
+// hostModulates = false. Single DDC, single panadapter.
+//
+// The worker owns the librtlsdr device handle and runs
+// rtlsdr_read_async → IQ conversion → DDC. Backend relays are delivered to
+// the main thread through queued connections.
+class RtlSdrBackend : public IRadioBackend {
+    Q_OBJECT
+
+public:
+    explicit RtlSdrBackend(QObject* parent = nullptr);
+    ~RtlSdrBackend() override;
+
+    // ---- IRadioBackend ----
+    RadioCapabilities capabilities() const override;
+
+    // Demodulates in-process (DDC); there is no VITA-49 stream.
+    bool ownsRxAudio() const override { return true; }
+
+    // RTL-SDR has no radio-side memory; the client owns frequency, mode,
+    // passband, gain, PPM, etc.
+    void applyRestoredState(const RestoredRadioState& state) override;
+    RestoredRadioState currentOperatingState() const override;
+
+    void connectRadio(const RadioConnectRequest& request) override;
+    void disconnectRadio() override;
+    bool isConnected() const override;
+
+    void setSliceFrequency(int sliceId, double hz) override;
+    void setSliceMode(int sliceId, const QString& mode) override;
+    void setSliceFilter(int sliceId, int lowHz, int highHz) override;
+    void setSliceAgc(int sliceId, const QString& mode, int thresholdDb) override;
+    void setPanCenter(const QString& panId, double hz,
+                      PanCenterIntent intent) override;
+    void setPanBandwidth(const QString& panId, double hz) override;
+    void setPanFrameRate(const QString& panId, int fps) override;
+    void setSliceAudioMute(int sliceId, bool mute) override;
+    void setSliceAudioGain(int sliceId, int gainPercent) override;
+    void setSliceAudioPan(int sliceId, int panPercent) override;
+    void setKeying(bool key) override;
+    void invokeExtension(const QString& ns, const QString& verb,
+                         quint64 requestId, const QVariant& arg = {}) override;
+
+    // Gain control — rtl-specific.
+    void setPanRfGain(const QString& panId, int gainDb) override;
+
+    // ---- Identity ----
+    // The backend family string ("rtl"), used by RadioModel::makeBackend().
+    static QString familyName();
+
+    // Sample rate validation & clamping against hardware / capabilities constraints
+    static uint32_t clampSampleRate(uint32_t requestedHz);
+
+    // Tuner gain an unconfigured dongle comes up at.
+    //
+    // NOT ZERO, and the distinction is the whole point: rtlsdr_set_tuner_gain_mode(dev, 1)
+    // hands the operator manual control of the tuner, and nearestGainTenths() then snaps
+    // the request onto the tuner's own discrete table. Both the R820T and the R828D start
+    // that table at exactly 0.0 dB, so a 0 default did not mean "unset" -- it programmed
+    // the LOWEST gain the hardware offers, and the receiver came up deaf on a strong local
+    // signal. Measured on an RTL-SDR Blog V4 (R828D): 24 snaps to the table's 22.9 dB entry
+    // and a nearby WFM broadcast is clearly audible; at 0.0 dB the same station is
+    // inaudible. Mid-table rather than max: the top of the R828D table (49.6 dB) overloads
+    // the front end on the same signal.
+    static constexpr int kDefaultRfGainDb = 24;
+
+private:
+    // Emit the initial snapshot a freshly-connected device would report.
+    void emitInitialState();
+
+    // Parse device index or serial from connect request params.
+    int deviceIndexFromParams(const QVariantMap& params) const;
+    QString serialFromParams(const QVariantMap& params) const;
+    void handleControlApplied(const QString& control, qint64 value);
+    void handleControlFailed(const QString& control, const QString& message);
+    void queueExtensionRequest(const QString& control, quint64 requestId);
+
+    // ---- State ----
+    bool m_connected{false};
+
+    // Device identity (filled on connect)
+    QString m_modelName;
+    QString m_serial;
+    QString m_vendor;
+    QString m_product;
+
+    // Slice 0 state — default to 95.2 MHz FM Wide
+    double m_sliceFreqHz{95'200'000.0};
+    QString m_sliceMode{"WFM"};
+    int m_sliceFilterLow{-100000};
+    int m_sliceFilterHigh{100000};
+
+    // Pan & Hardware state — default to 95.2 MHz
+    double m_panCenterHz{95'200'000.0};
+    uint32_t m_sampleRateHz{2'400'000};
+    int m_panRfGainDb{kDefaultRfGainDb};
+    int m_ppmCorrection{0};
+    int m_directSampling{0};
+    QVector<int> m_tunerGainsTenths;
+    QHash<QString, QVector<quint64>> m_pendingExtensionRequests;
+    QString m_pendingPanId{QStringLiteral("0xe1000000")};
+
+    // Non-owning while connected; RtlSdrWorker closes the handle after its
+    // async read loop has exited.
+    struct rtlsdr_dev* m_device{nullptr};   // rtlsdr_dev_t*
+
+    // Worker thread (owns async USB reader & RtlSdrDdc engine)
+    std::unique_ptr<RtlSdrWorker> m_worker;
+    RtlSdrDdc* ddc();
+};
+
+}  // namespace AetherSDR::rtl

--- a/src/core/backends/rtl/RtlSdrDdc.cpp
+++ b/src/core/backends/rtl/RtlSdrDdc.cpp
@@ -1,0 +1,310 @@
+#include "core/backends/rtl/RtlSdrDdc.h"
+
+#include <cmath>
+#include <numbers>
+#include <algorithm>
+#include <QDebug>
+
+namespace AetherSDR::rtl {
+
+RtlSdrDdc::RtlSdrDdc(QObject* parent)
+    : QObject(parent)
+{
+    m_fftAccumulator.reserve(kFftSize);
+
+    // Initialize Blackman-Harris window for FFT spectrum
+    m_fftWindow.resize(kFftSize);
+    for (size_t i = 0; i < kFftSize; ++i) {
+        const double n = static_cast<double>(i);
+        const double N = static_cast<double>(kFftSize);
+        m_fftWindow[i] = static_cast<float>(0.35875 - 0.48829 * std::cos(2.0 * std::numbers::pi * n / (N - 1.0))
+                                                    + 0.14128 * std::cos(4.0 * std::numbers::pi * n / (N - 1.0))
+                                                    - 0.01168 * std::cos(6.0 * std::numbers::pi * n / (N - 1.0)));
+    }
+
+    // Allocate FFTW buffers and plan
+    m_fftIn  = static_cast<fftwf_complex*>(fftwf_malloc(sizeof(fftwf_complex) * kFftSize));
+    m_fftOut = static_cast<fftwf_complex*>(fftwf_malloc(sizeof(fftwf_complex) * kFftSize));
+    if (m_fftIn && m_fftOut) {
+        m_fftPlan = fftwf_plan_dft_1d(static_cast<int>(kFftSize), m_fftIn, m_fftOut, FFTW_FORWARD, FFTW_ESTIMATE);
+    }
+}
+
+RtlSdrDdc::~RtlSdrDdc()
+{
+    if (m_fftPlan) {
+        fftwf_destroy_plan(m_fftPlan);
+        m_fftPlan = nullptr;
+    }
+    if (m_fftIn) {
+        fftwf_free(m_fftIn);
+        m_fftIn = nullptr;
+    }
+    if (m_fftOut) {
+        fftwf_free(m_fftOut);
+        m_fftOut = nullptr;
+    }
+}
+
+void RtlSdrDdc::setSampleRate(double sampleRateHz)
+{
+    if (sampleRateHz > 0) {
+        m_sampleRateHz.store(sampleRateHz, std::memory_order_relaxed);
+        const int spectrumFps = m_spectrumFps.load(std::memory_order_relaxed);
+        m_spectrumSampleStride.store(
+            std::max<size_t>(1, static_cast<size_t>(sampleRateHz / spectrumFps)),
+            std::memory_order_relaxed);
+    }
+}
+
+void RtlSdrDdc::setCenterFrequency(double centerHz)
+{
+    m_centerHz.store(centerHz, std::memory_order_relaxed);
+}
+
+void RtlSdrDdc::setSliceFrequency(double sliceHz)
+{
+    m_sliceHz.store(sliceHz, std::memory_order_relaxed);
+}
+
+void RtlSdrDdc::setSliceMode(const QString& mode)
+{
+    const QString canonical = mode.trimmed().toUpper();
+    DemodMode demodMode = DemodMode::Usb;
+    if (canonical == QLatin1String("AM")) {
+        demodMode = DemodMode::Am;
+    } else if (canonical == QLatin1String("SAM")) {
+        demodMode = DemodMode::Sam;
+    } else if (canonical == QLatin1String("FM")) {
+        demodMode = DemodMode::Fm;
+    } else if (canonical == QLatin1String("FMN")) {
+        demodMode = DemodMode::Fmn;
+    } else if (canonical == QLatin1String("WFM")) {
+        demodMode = DemodMode::Wfm;
+    } else if (canonical == QLatin1String("LSB")) {
+        demodMode = DemodMode::Lsb;
+    } else if (canonical == QLatin1String("CW")) {
+        demodMode = DemodMode::Cw;
+    } else if (canonical == QLatin1String("CWR")) {
+        demodMode = DemodMode::Cwr;
+    }
+    m_mode.store(demodMode, std::memory_order_relaxed);
+}
+
+void RtlSdrDdc::setSliceFilter(int lowHz, int highHz)
+{
+    m_filterLowHz.store(lowHz, std::memory_order_relaxed);
+    m_filterHighHz.store(highHz, std::memory_order_relaxed);
+}
+
+void RtlSdrDdc::setSpectrumRateFps(int fps)
+{
+    const int clampedFps = std::clamp(fps, 1, 60);
+    m_spectrumFps.store(clampedFps, std::memory_order_relaxed);
+    m_spectrumSampleStride.store(
+        std::max<size_t>(1, static_cast<size_t>(
+            m_sampleRateHz.load(std::memory_order_relaxed) / clampedFps)),
+        std::memory_order_relaxed);
+}
+
+void RtlSdrDdc::setAudioMute(bool mute)
+{
+    m_audioMuted.store(mute, std::memory_order_relaxed);
+}
+
+void RtlSdrDdc::setAudioGain(int gainPercent)
+{
+    m_audioGain.store(std::clamp(gainPercent, 0, 100) / 100.0f,
+                      std::memory_order_relaxed);
+}
+
+void RtlSdrDdc::setAudioPan(int panPercent)
+{
+    m_audioPanPercent.store(std::clamp(panPercent, 0, 100),
+                            std::memory_order_relaxed);
+}
+
+void RtlSdrDdc::processIqData(const QVector<std::complex<float>>& samples)
+{
+    if (samples.isEmpty()) {
+        return;
+    }
+
+    processSpectrum(samples);
+    processAudio(samples);
+}
+
+void RtlSdrDdc::processSpectrum(const QVector<std::complex<float>>& samples)
+{
+    if (!m_fftPlan || !m_fftIn || !m_fftOut) {
+        return;
+    }
+
+    m_spectrumCounter += samples.size();
+    if (m_spectrumCounter < m_spectrumSampleStride.load(std::memory_order_relaxed)
+        && m_firstSpectrumEmitted) {
+        return;
+    }
+
+    m_spectrumCounter = 0;
+    m_firstSpectrumEmitted = true;
+
+    const size_t numToCopy = std::min(static_cast<size_t>(samples.size()), kFftSize);
+    for (size_t i = 0; i < numToCopy; ++i) {
+        const float w = m_fftWindow[i];
+        m_fftIn[i][0] = samples[i].real() * w;
+        m_fftIn[i][1] = samples[i].imag() * w;
+    }
+    for (size_t i = numToCopy; i < kFftSize; ++i) {
+        m_fftIn[i][0] = 0.0f;
+        m_fftIn[i][1] = 0.0f;
+    }
+
+    // Run FFTW 1D forward transform
+    fftwf_execute(m_fftPlan);
+
+    QByteArray frame;
+    frame.resize(static_cast<int>(kFftSize * sizeof(float)));
+    float* magOut = reinterpret_cast<float*>(frame.data());
+
+    for (size_t k = 0; k < kFftSize; ++k) {
+        const float re = m_fftOut[k][0];
+        const float im = m_fftOut[k][1];
+        const float mag = std::sqrt(re * re + im * im) / static_cast<float>(kFftSize);
+        const float db = 20.0f * std::log10(std::max(mag, 1e-6f));
+        // Shift zero-frequency component to center
+        size_t outIdx = (k + kFftSize / 2) % kFftSize;
+        magOut[outIdx] = db;
+    }
+
+    emit spectrumFrameReady(0, frame);
+    emit waterfallRowReady(0, frame);
+}
+
+void RtlSdrDdc::processAudio(const QVector<std::complex<float>>& samples)
+{
+    double sampleRateHz = 2'400'000.0;
+    double centerHz = 95'200'000.0;
+    double sliceHz = 95'200'000.0;
+    DemodMode mode = DemodMode::Wfm;
+    bool audioMuted = false;
+    float audioGain = 1.0f;
+    int audioPanPercent = 50;
+
+    sampleRateHz = m_sampleRateHz.load(std::memory_order_relaxed);
+    centerHz = m_centerHz.load(std::memory_order_relaxed);
+    sliceHz = m_sliceHz.load(std::memory_order_relaxed);
+    mode = m_mode.load(std::memory_order_relaxed);
+    audioMuted = m_audioMuted.load(std::memory_order_relaxed);
+    audioGain = m_audioGain.load(std::memory_order_relaxed);
+    audioPanPercent = m_audioPanPercent.load(std::memory_order_relaxed);
+
+    if (audioMuted) {
+        return;
+    }
+
+    const double ncoStep = 2.0 * std::numbers::pi * (sliceHz - centerHz) / sampleRateHz;
+    const std::complex<float> ncoStepPhasor(
+        static_cast<float>(std::cos(-ncoStep)),
+        static_cast<float>(std::sin(-ncoStep))
+    );
+
+    QByteArray pcm;
+    pcm.reserve(static_cast<int>((samples.size() / 100 + 1) * sizeof(float) * 2));
+
+    // Target ~240 kSPS intermediate IQ sample rate for Stage 1 decimation
+    const int stage1Decim = std::max(1, static_cast<int>(std::round(sampleRateHz / 240'000.0)));
+    const double stage1Fs = sampleRateHz / static_cast<double>(stage1Decim);
+    const float deemphAlpha = 1.0f - std::exp(-1.0f / (75e-6f * static_cast<float>(stage1Fs)));
+
+    for (const auto& sample : samples) {
+        // NCO phasor shift (shifts target slice frequency to DC)
+        m_ncoPhasor *= ncoStepPhasor;
+        const std::complex<float> shifted = sample * m_ncoPhasor;
+
+        if (++m_ncoNormalizeCounter >= 1000) {
+            m_ncoNormalizeCounter = 0;
+            const float mag = std::abs(m_ncoPhasor);
+            if (mag > 0.0f) {
+                m_ncoPhasor /= mag;
+            }
+        }
+
+        // Anti-aliasing boxcar accumulator
+        m_decimAcc += shifted;
+        ++m_decimCount;
+
+        if (m_decimCount >= stage1Decim) {
+            const std::complex<float> decimIq = m_decimAcc / static_cast<float>(m_decimCount);
+            m_decimAcc = {0.0f, 0.0f};
+            m_decimCount = 0;
+
+            float audioLeft = 0.0f;
+
+            if (mode == DemodMode::Fm || mode == DemodMode::Fmn
+                || mode == DemodMode::Wfm) {
+                // Demodulate FM: phase difference angle(Z_n * conj(Z_n-1))
+                const std::complex<float> prod = decimIq * std::conj(m_prevDecimIq);
+                m_prevDecimIq = decimIq;
+
+                float dphi = std::atan2(prod.imag(), prod.real());
+                if (mode == DemodMode::Wfm) {
+                    // WFM (±75 kHz deviation)
+                    audioLeft = dphi / std::numbers::pi_v<float>;
+                    // 75µs de-emphasis lowpass filter
+                    m_deemphState += deemphAlpha * (audioLeft - m_deemphState);
+                    audioLeft = m_deemphState;
+                } else {
+                    // NFM (±5 kHz deviation)
+                    audioLeft = (dphi / std::numbers::pi_v<float>) * 4.0f;
+                }
+            } else if (mode == DemodMode::Am || mode == DemodMode::Sam) {
+                audioLeft = (std::abs(decimIq) - 0.3f) * 1.5f;
+                m_prevDecimIq = decimIq;
+            } else if (mode == DemodMode::Lsb) {
+                audioLeft = (decimIq.real() - decimIq.imag()) * 1.5f;
+                m_prevDecimIq = decimIq;
+            } else if (mode == DemodMode::Cw || mode == DemodMode::Cwr) {
+                audioLeft = decimIq.real() * 1.5f;
+                m_prevDecimIq = decimIq;
+            } else {
+                // USB
+                audioLeft = (decimIq.real() + decimIq.imag()) * 1.5f;
+                m_prevDecimIq = decimIq;
+            }
+
+            // Stage 2: fractional boxcar resampling to exactly 24 kSPS on
+            // average. A rounded integer divisor drifts for rates such as
+            // 225001 and 1.8432 MSPS and eventually starves/overruns audio.
+            ++m_audioDecimCounter;
+            m_audioDecimAcc += audioLeft;
+            m_audioResamplePhase += 24'000.0;
+            if (m_audioResamplePhase >= stage1Fs) {
+                m_audioResamplePhase -= stage1Fs;
+                float finalAudio = m_audioDecimAcc / static_cast<float>(m_audioDecimCounter);
+                m_audioDecimAcc = 0.0f;
+                m_audioDecimCounter = 0;
+
+                finalAudio = std::clamp(finalAudio * audioGain, -1.0f, 1.0f);
+                const float pan = audioPanPercent / 100.0f;
+                float audioLeftOut = finalAudio * std::min(1.0f, 2.0f * (1.0f - pan));
+                float audioRight = finalAudio * std::min(1.0f, 2.0f * pan);
+
+                pcm.append(reinterpret_cast<const char*>(&audioLeftOut), sizeof(float));
+                pcm.append(reinterpret_cast<const char*>(&audioRight), sizeof(float));
+            }
+        }
+    }
+
+    if (!pcm.isEmpty()) {
+        m_audioBuffer.append(pcm);
+        // Batch audio dispatches to ~50 ms chunks (9600 bytes = 1200 stereo float samples @ 24kHz).
+        if (!m_firstAudioEmitted || m_audioBuffer.size() >= 9600) {
+            m_firstAudioEmitted = true;
+            emit audioFrameReady(m_audioBuffer);
+            m_audioBuffer.clear();
+        }
+    }
+}
+
+}  // namespace AetherSDR::rtl

--- a/src/core/backends/rtl/RtlSdrDdc.h
+++ b/src/core/backends/rtl/RtlSdrDdc.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <QObject>
+#include <QByteArray>
+#include <QVector>
+#include <QString>
+#include <complex>
+#include <vector>
+#include <atomic>
+#include <fftw3.h>
+
+namespace AetherSDR::rtl {
+
+// Digital Down-Converter (DDC) and Demodulation engine for RtlSdrBackend.
+// Executes on the RtlSdrWorker thread:
+// 1. Computes 2048-point FFT magnitude spectrum at ~30 FPS using FFTW float32
+// 2. Performs NCO frequency shifting, decimation, and FM/AM/SSB demodulation for AudioEngine
+class RtlSdrDdc : public QObject {
+    Q_OBJECT
+
+public:
+    explicit RtlSdrDdc(QObject* parent = nullptr);
+    ~RtlSdrDdc() override;
+
+    // Parameter configuration (thread-safe setters called from main thread)
+    void setSampleRate(double sampleRateHz);
+    void setCenterFrequency(double centerHz);
+    void setSliceFrequency(double sliceHz);
+    void setSliceMode(const QString& mode);
+    void setSliceFilter(int lowHz, int highHz);
+    void setSpectrumRateFps(int fps);
+    void setAudioMute(bool mute);
+    void setAudioGain(int gainPercent);
+    void setAudioPan(int panPercent);
+
+public slots:
+    // Process incoming complex float IQ samples (runs on worker thread)
+    void processIqData(const QVector<std::complex<float>>& samples);
+
+signals:
+    // Emits raw spectrum FFT magnitude data for PanadapterWidget (~30 FPS)
+    void spectrumFrameReady(int panId, const QByteArray& frame);
+
+    // Emits raw waterfall row FFT magnitude data for WaterfallWidget (~30 FPS)
+    void waterfallRowReady(int panId, const QByteArray& row);
+
+    // Emits 24 kHz float32 PCM audio data for AudioEngine
+    void audioFrameReady(const QByteArray& pcm);
+
+private:
+    enum class DemodMode {
+        Am,
+        Sam,
+        Fm,
+        Fmn,
+        Wfm,
+        Usb,
+        Lsb,
+        Cw,
+        Cwr,
+    };
+
+    void processSpectrum(const QVector<std::complex<float>>& samples);
+    void processAudio(const QVector<std::complex<float>>& samples);
+
+    // Written by the main thread and sampled inside the USB callback. These
+    // must stay lock-free at the DSP boundary; the audio callback never waits
+    // on a GUI-thread mutex.
+    std::atomic<double> m_sampleRateHz{2'400'000.0};
+    std::atomic<double> m_centerHz{95'200'000.0};
+    std::atomic<double> m_sliceHz{95'200'000.0};
+    std::atomic<DemodMode> m_mode{DemodMode::Wfm};
+    std::atomic<int> m_filterLowHz{-100000};
+    std::atomic<int> m_filterHighHz{100000};
+    std::atomic<int> m_spectrumFps{30};
+    std::atomic<bool> m_audioMuted{false};
+    std::atomic<float> m_audioGain{1.0f};
+    std::atomic<int> m_audioPanPercent{50};
+
+    // FFT state & rate limiter
+    static constexpr size_t kFftSize = 2048;
+    std::vector<std::complex<float>> m_fftAccumulator;
+    std::vector<float> m_fftWindow;
+    fftwf_complex* m_fftIn{nullptr};
+    fftwf_complex* m_fftOut{nullptr};
+    fftwf_plan m_fftPlan{nullptr};
+    std::atomic<size_t> m_spectrumSampleStride{80'000};  // 2.4 MSPS / 30 FPS = 80,000 samples
+    size_t m_spectrumCounter{0};
+    bool m_firstSpectrumEmitted{false};
+
+    // NCO & Decimation state
+    double m_ncoPhase{0.0};
+    std::complex<float> m_ncoPhasor{1.0f, 0.0f};
+    uint32_t m_ncoNormalizeCounter{0};
+    std::complex<float> m_decimAcc{0.0f, 0.0f};
+    int m_decimCount{0};
+    std::complex<float> m_prevDecimIq{0.0f, 0.0f};
+    float m_deemphState{0.0f};
+    float m_audioDecimAcc{0.0f};
+    int m_audioDecimCounter{0};
+    double m_audioResamplePhase{0.0};
+    QByteArray m_audioBuffer;
+    bool m_firstAudioEmitted{false};
+};
+
+}  // namespace AetherSDR::rtl

--- a/src/core/backends/rtl/RtlSdrWorker.cpp
+++ b/src/core/backends/rtl/RtlSdrWorker.cpp
@@ -1,0 +1,353 @@
+#include "core/backends/rtl/RtlSdrWorker.h"
+#include "core/backends/rtl/RtlSdrBackend.h"
+
+#include <QDebug>
+#include <rtl-sdr.h>
+#include <climits>
+
+namespace AetherSDR::rtl {
+
+static constexpr uint32_t kRtlBufLength = 16384;   // 16KB per USB transfer
+static constexpr uint32_t kRtlBufNum    = 15;      // 15 buffers
+
+RtlSdrWorker::RtlSdrWorker(struct rtlsdr_dev* dev, QObject* parent)
+    : QThread(parent)
+    , m_dev(dev)
+{
+    // Relay DDC signals across thread boundary to main thread
+    connect(&m_ddc, &RtlSdrDdc::spectrumFrameReady,
+            this, &RtlSdrWorker::spectrumFrameReady);
+    connect(&m_ddc, &RtlSdrDdc::waterfallRowReady,
+            this, &RtlSdrWorker::waterfallRowReady);
+    connect(&m_ddc, &RtlSdrDdc::audioFrameReady,
+            this, &RtlSdrWorker::audioFrameReady);
+}
+
+RtlSdrWorker::~RtlSdrWorker()
+{
+    if (!stopReading()) {
+        qFatal("RtlSdrWorker destroyed while its USB reader is still running");
+    }
+    if (m_dev) {
+        rtlsdr_close(static_cast<rtlsdr_dev_t*>(m_dev));
+        m_dev = nullptr;
+    }
+}
+
+void RtlSdrWorker::startReading()
+{
+    if (isRunning()) {
+        return;
+    }
+
+    m_stopRequested = false;
+    m_readerRunning = false;
+    start();
+}
+
+bool RtlSdrWorker::stopReading()
+{
+    m_stopRequested = true;
+
+    // Cancellation issued just before librtlsdr enters read_async can be lost.
+    // Repeat it while waiting so that narrow startup race cannot leave a
+    // QThread alive at destruction or tempt the backend to close a live handle.
+    for (int attempt = 0; isRunning() && attempt < 50; ++attempt) {
+        if (m_dev) {
+            rtlsdr_cancel_async(static_cast<rtlsdr_dev_t*>(m_dev));
+        }
+        if (wait(100)) {
+            break;
+        }
+    }
+
+    m_readerRunning = false;
+    if (isRunning()) {
+        qWarning() << "RtlSdrWorker: USB reader did not stop after repeated cancellation";
+        return false;
+    }
+    return true;
+}
+
+// ── Async USB control transfer dispatch ─────────────────────────────────────
+// These methods are called from the main thread. They store the requested
+// value in an atomic, then signal the callback to cancel read_async so the
+// run() loop can apply the USB control transfer outside the callback context.
+//
+// Why: rtlsdr_set_center_freq / rtlsdr_set_direct_sampling / rtlsdr_set_tuner_gain
+// are USB control transfers that silently fail or deadlock when called from
+// within the rtlsdr_read_async callback (the USB handle is busy with bulk IQ
+// transfers). The standard librtlsdr pattern is: cancel → retune → restart.
+
+void RtlSdrWorker::setCenterFrequency(uint32_t hz)
+{
+    m_pendingCenterHz.store(static_cast<int64_t>(hz), std::memory_order_relaxed);
+    m_retuneRequested.store(true, std::memory_order_release);
+    if (m_readerRunning.load() && m_dev) {
+        rtlsdr_cancel_async(static_cast<rtlsdr_dev_t*>(m_dev));
+    }
+}
+
+void RtlSdrWorker::setTunerGain(int gainTenths)
+{
+    m_pendingGainTenths.store(gainTenths, std::memory_order_relaxed);
+    m_retuneRequested.store(true, std::memory_order_release);
+    if (m_readerRunning.load() && m_dev) {
+        rtlsdr_cancel_async(static_cast<rtlsdr_dev_t*>(m_dev));
+    }
+}
+
+void RtlSdrWorker::setDirectSampling(int mode)
+{
+    m_pendingDirectSampling.store(mode, std::memory_order_relaxed);
+    m_retuneRequested.store(true, std::memory_order_release);
+    if (m_readerRunning.load() && m_dev) {
+        rtlsdr_cancel_async(static_cast<rtlsdr_dev_t*>(m_dev));
+    }
+}
+
+void RtlSdrWorker::setPpmCorrection(int ppm)
+{
+    m_pendingPpm.store(ppm, std::memory_order_relaxed);
+    m_retuneRequested.store(true, std::memory_order_release);
+    if (m_readerRunning.load() && m_dev) {
+        rtlsdr_cancel_async(static_cast<rtlsdr_dev_t*>(m_dev));
+    }
+}
+
+void RtlSdrWorker::setSampleRate(uint32_t rate)
+{
+    const uint32_t clampedRate = RtlSdrBackend::clampSampleRate(rate);
+    m_pendingSampleRate.store(static_cast<int64_t>(clampedRate), std::memory_order_relaxed);
+    m_retuneRequested.store(true, std::memory_order_release);
+    if (m_readerRunning.load() && m_dev) {
+        rtlsdr_cancel_async(static_cast<rtlsdr_dev_t*>(m_dev));
+    }
+}
+
+void RtlSdrWorker::setOffsetTuning(int enable)
+{
+    m_pendingOffsetTuning.store(enable, std::memory_order_relaxed);
+    m_retuneRequested.store(true, std::memory_order_release);
+    if (m_readerRunning.load() && m_dev) {
+        rtlsdr_cancel_async(static_cast<rtlsdr_dev_t*>(m_dev));
+    }
+}
+
+void RtlSdrWorker::run()
+{
+    if (!m_dev) {
+        emit readError(QStringLiteral("Device handle is null"));
+        return;
+    }
+
+    rtlsdr_dev_t* dev = static_cast<rtlsdr_dev_t*>(m_dev);
+
+    // ── Cancel / retune / restart loop ──────────────────────────────────────
+    // rtlsdr_read_async blocks until rtlsdr_cancel_async() is called.
+    // USB control transfers (frequency, gain, direct sampling) CANNOT be
+    // issued from within the read_async callback — the USB handle is busy.
+    // Instead, the setters call cancel_async to break out, we apply the
+    // control transfers here (outside the callback), then restart read_async.
+    while (!m_stopRequested.load()) {
+        const int resetRc = rtlsdr_reset_buffer(dev);
+        if (resetRc < 0) {
+            emit readError(QStringLiteral("rtlsdr_reset_buffer failed with error %1")
+                               .arg(resetRc));
+            break;
+        }
+
+        // Publish this before entering read_async, not from its first callback:
+        // an empty or stalled device may never deliver a callback, but stop and
+        // retune still have to cancel the blocking call.
+        m_readerRunning.store(true, std::memory_order_release);
+        if (m_stopRequested.load(std::memory_order_acquire)) {
+            m_readerRunning.store(false, std::memory_order_release);
+            break;
+        }
+
+        int rc = rtlsdr_read_async(dev,
+                                   &RtlSdrWorker::rtlsdrCallback,
+                                   this,
+                                   kRtlBufNum,
+                                   kRtlBufLength);
+
+        m_readerRunning = false;
+
+        if (m_stopRequested.load()) {
+            break;
+        }
+
+        // read_async returned because of a retune request — apply controls
+        if (m_retuneRequested.exchange(false, std::memory_order_acq_rel)) {
+            applyPendingControls();
+            continue;  // restart read_async with new settings
+        }
+
+        // Unexpected return — real error
+        if (rc < 0) {
+            emit readError(QStringLiteral("rtlsdr_read_async failed with error %1").arg(rc));
+            break;
+        }
+    }
+}
+
+void RtlSdrWorker::rtlsdrCallback(unsigned char* buf, uint32_t len, void* ctx)
+{
+    auto* worker = static_cast<RtlSdrWorker*>(ctx);
+    if (!worker) {
+        return;
+    }
+
+    if (worker->m_stopRequested.load()) {
+        if (worker->m_dev) {
+            rtlsdr_cancel_async(static_cast<rtlsdr_dev_t*>(worker->m_dev));
+        }
+        return;
+    }
+
+    // If a retune was requested, cancel read_async so the run() loop can
+    // apply USB control transfers outside this callback context.
+    if (worker->m_retuneRequested.load(std::memory_order_acquire)) {
+        if (worker->m_dev) {
+            rtlsdr_cancel_async(static_cast<rtlsdr_dev_t*>(worker->m_dev));
+        }
+        return;  // Don't process this buffer — stale frequency data
+    }
+
+    worker->handleCallback(buf, len);
+}
+
+void RtlSdrWorker::handleCallback(unsigned char* buf, uint32_t len)
+{
+    if (!buf || len == 0) {
+        return;
+    }
+
+    // ── No USB control transfers here ───────────────────────────────────────
+    // USB control transfers (rtlsdr_set_center_freq, etc.) MUST NOT be called
+    // from within the rtlsdr_read_async callback — they silently fail because
+    // the USB handle is busy with bulk IQ transfers. All control transfers are
+    // applied in applyPendingControls(), called from run() after read_async
+    // returns.
+
+    // ── Convert IQ and process ──────────────────────────────────────────────
+    const uint32_t numSamples = len / 2;
+    if (static_cast<uint32_t>(m_iqBuffer.size()) != numSamples) {
+        m_iqBuffer.resize(numSamples);
+    }
+
+    // Convert unsigned 8-bit [0..255] interleaved [I, Q] to float complex [-1.0..+1.0]
+    for (uint32_t i = 0; i < numSamples; ++i) {
+        const float real = (static_cast<float>(buf[2 * i])     - 127.5f) / 127.5f;
+        const float imag = (static_cast<float>(buf[2 * i + 1]) - 127.5f) / 127.5f;
+        m_iqBuffer[i] = std::complex<float>(real, imag);
+    }
+
+    // Process DDC (FFT spectrum & demodulation) on this worker thread
+    m_ddc.processIqData(m_iqBuffer);
+}
+
+// ── USB control transfer application ────────────────────────────────────────
+// Called from run() OUTSIDE the rtlsdr_read_async callback context, after
+// read_async has returned. This is the only safe place to issue USB control
+// transfers on the RTL-SDR device handle.
+
+void RtlSdrWorker::applyPendingControls()
+{
+    rtlsdr_dev_t* dev = static_cast<rtlsdr_dev_t*>(m_dev);
+    if (!dev) {
+        return;
+    }
+
+    // Direct sampling MUST be applied BEFORE center frequency, because tuning
+    // to HF (< 24 MHz) requires direct sampling mode 2 before setting frequency,
+    // and tuning to VHF/UHF (>= 24 MHz) requires direct sampling mode 0 before
+    // the tuner PLL can be programmed.
+    int pendingDs = m_pendingDirectSampling.exchange(-1, std::memory_order_relaxed);
+    if (pendingDs >= 0) {
+        int rc = rtlsdr_set_direct_sampling(dev, pendingDs);
+        if (rc < 0) {
+            qWarning() << "RtlSdrWorker: rtlsdr_set_direct_sampling failed, rc =" << rc;
+            emit controlFailed(QStringLiteral("direct_sampling"),
+                               QStringLiteral("rtlsdr_set_direct_sampling failed: %1").arg(rc));
+        } else {
+            qDebug() << "RtlSdrWorker: direct sampling set to" << pendingDs;
+            emit controlApplied(QStringLiteral("direct_sampling"),
+                                rtlsdr_get_direct_sampling(dev));
+        }
+    }
+
+    int64_t pendingHz = m_pendingCenterHz.exchange(-1, std::memory_order_relaxed);
+    if (pendingHz >= 0) {
+        int rc = rtlsdr_set_center_freq(dev, static_cast<uint32_t>(pendingHz));
+        if (rc < 0) {
+            qWarning() << "RtlSdrWorker: rtlsdr_set_center_freq failed, rc =" << rc
+                       << "requested" << pendingHz << "Hz";
+            emit controlFailed(QStringLiteral("center_frequency"),
+                               QStringLiteral("rtlsdr_set_center_freq failed: %1").arg(rc));
+        } else {
+            qDebug() << "RtlSdrWorker: center freq set to" << pendingHz << "Hz";
+            emit controlApplied(QStringLiteral("center_frequency"),
+                                rtlsdr_get_center_freq(dev));
+        }
+    }
+
+    int pendingGain = m_pendingGainTenths.exchange(INT_MIN, std::memory_order_relaxed);
+    if (pendingGain != INT_MIN) {
+        rtlsdr_set_tuner_gain_mode(dev, 1);
+        int rc = rtlsdr_set_tuner_gain(dev, pendingGain);
+        if (rc < 0) {
+            qWarning() << "RtlSdrWorker: rtlsdr_set_tuner_gain failed, rc =" << rc;
+            emit controlFailed(QStringLiteral("gain"),
+                               QStringLiteral("rtlsdr_set_tuner_gain failed: %1").arg(rc));
+        } else {
+            qDebug() << "RtlSdrWorker: tuner gain set to" << pendingGain << "tenths dB";
+            emit controlApplied(QStringLiteral("gain"), rtlsdr_get_tuner_gain(dev));
+        }
+    }
+
+    int pendingPpm = m_pendingPpm.exchange(INT_MIN, std::memory_order_relaxed);
+    if (pendingPpm != INT_MIN) {
+        int rc = rtlsdr_set_freq_correction(dev, pendingPpm);
+        if (rc < 0) {
+            qWarning() << "RtlSdrWorker: rtlsdr_set_freq_correction failed, rc =" << rc;
+            emit controlFailed(QStringLiteral("ppm"),
+                               QStringLiteral("rtlsdr_set_freq_correction failed: %1").arg(rc));
+        } else {
+            qDebug() << "RtlSdrWorker: freq correction set to" << pendingPpm << "ppm";
+            emit controlApplied(QStringLiteral("ppm"), rtlsdr_get_freq_correction(dev));
+        }
+    }
+
+    int64_t pendingRate = m_pendingSampleRate.exchange(-1, std::memory_order_relaxed);
+    if (pendingRate > 0) {
+        int rc = rtlsdr_set_sample_rate(dev, static_cast<uint32_t>(pendingRate));
+        if (rc < 0) {
+            qWarning() << "RtlSdrWorker: rtlsdr_set_sample_rate failed, rc =" << rc;
+            emit controlFailed(QStringLiteral("sample_rate"),
+                               QStringLiteral("rtlsdr_set_sample_rate failed: %1").arg(rc));
+        } else {
+            const uint32_t actualRate = rtlsdr_get_sample_rate(dev);
+            qDebug() << "RtlSdrWorker: sample rate set to" << actualRate << "Hz";
+            m_ddc.setSampleRate(static_cast<double>(actualRate));
+            emit controlApplied(QStringLiteral("sample_rate"), actualRate);
+        }
+    }
+
+    int pendingOffset = m_pendingOffsetTuning.exchange(-1, std::memory_order_relaxed);
+    if (pendingOffset >= 0) {
+        int rc = rtlsdr_set_offset_tuning(dev, pendingOffset);
+        if (rc < 0) {
+            qWarning() << "RtlSdrWorker: rtlsdr_set_offset_tuning failed, rc =" << rc;
+            emit controlFailed(QStringLiteral("offset_tuning"),
+                               QStringLiteral("rtlsdr_set_offset_tuning failed: %1").arg(rc));
+        } else {
+            qDebug() << "RtlSdrWorker: offset tuning set to" << pendingOffset;
+            emit controlApplied(QStringLiteral("offset_tuning"),
+                                rtlsdr_get_offset_tuning(dev));
+        }
+    }
+}
+
+}  // namespace AetherSDR::rtl

--- a/src/core/backends/rtl/RtlSdrWorker.h
+++ b/src/core/backends/rtl/RtlSdrWorker.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "core/backends/rtl/RtlSdrDdc.h"
+
+#include <QObject>
+#include <QThread>
+#include <QVector>
+#include <climits>
+#include <complex>
+#include <atomic>
+
+struct rtlsdr_dev;
+
+namespace AetherSDR::rtl {
+
+// Worker thread that manages the asynchronous USB read loop via rtlsdr_read_async().
+// Converts 8-bit unsigned USB I/Q samples to float complex samples and runs RtlSdrDdc
+// processing off the main thread.
+//
+// Deadlock Prevention (§ Hazards #1):
+// rtlsdr_read_async() blocks until rtlsdr_cancel_async() is called.
+// Calling cancel before the callback loop starts causes a deadlock.
+// This class tracks m_readerRunning and uses a bounded QThread::wait(5000) on stop.
+//
+// Thread Safety (§ Hazards #2):
+// rtlsdr_set_center_freq(), rtlsdr_set_tuner_gain(), and rtlsdr_set_direct_sampling()
+// are USB control transfers that block for ~100-300ms. They MUST NOT be called on the
+// main thread. Use the setCenterFrequency/setTunerGain/setDirectSampling slots which
+// are dispatched via QMetaObject::invokeMethod(Qt::QueuedConnection) from the backend.
+// The librtlsdr callbacks serialize with read_async, so there is no USB contention.
+class RtlSdrWorker : public QThread {
+    Q_OBJECT
+
+public:
+    explicit RtlSdrWorker(struct rtlsdr_dev* dev, QObject* parent = nullptr);
+    ~RtlSdrWorker() override;
+
+    // Start async USB reading loop on this thread
+    void startReading();
+
+    // Safely stop reading and wait for worker thread exit. Returns false only
+    // when the USB read thread did not acknowledge repeated cancellation.
+    bool stopReading();
+
+    bool isReading() const { return m_readerRunning.load(); }
+
+    RtlSdrDdc* ddc() { return &m_ddc; }
+
+    // Dispatch blocking USB control transfers to the worker thread.
+    // Setters store requested values in atomic variables and trigger a cancel/restart
+    // loop on the worker thread so control transfers are executed safely outside callback.
+    void setCenterFrequency(uint32_t hz);
+    void setTunerGain(int gainTenths);
+    void setDirectSampling(int mode);
+    void setPpmCorrection(int ppm);
+    void setSampleRate(uint32_t rate);
+    void setOffsetTuning(int enable);
+
+signals:
+    // Emitted on USB read error or unexpected disconnect
+    void readError(const QString& message);
+
+    // Relayed from RtlSdrDdc (cross-thread queued connection to main thread)
+    void spectrumFrameReady(int panId, const QByteArray& frame);
+    void waterfallRowReady(int panId, const QByteArray& row);
+    void audioFrameReady(const QByteArray& pcm);
+
+    // USB control completion, emitted only after the transfer has run between
+    // async-read sessions. value is read back from librtlsdr where available.
+    void controlApplied(const QString& control, qint64 value);
+    void controlFailed(const QString& control, const QString& message);
+
+protected:
+    void run() override;
+
+private:
+    static void rtlsdrCallback(unsigned char* buf, uint32_t len, void* ctx);
+    void handleCallback(unsigned char* buf, uint32_t len);
+
+    // Owned by this worker. The run loop closes it only after read_async exits,
+    // so the backend can never close a handle still used by libusb.
+    struct rtlsdr_dev* m_dev{nullptr};
+    std::atomic<bool> m_readerRunning{false};
+    std::atomic<bool> m_stopRequested{false};
+    RtlSdrDdc m_ddc;
+
+    // Pre-allocated IQ buffer to prevent per-callback heap allocations
+    QVector<std::complex<float>> m_iqBuffer;
+
+    // Pending USB control requests (set from any thread, applied between
+    // read_async sessions in the run() loop — never inside the callback)
+    std::atomic<int64_t> m_pendingCenterHz{-1};
+    std::atomic<int> m_pendingGainTenths{INT_MIN};
+    std::atomic<int> m_pendingDirectSampling{-1};
+    std::atomic<int> m_pendingPpm{INT_MIN};
+    std::atomic<int64_t> m_pendingSampleRate{-1};
+    std::atomic<int> m_pendingOffsetTuning{-1};
+
+    // Set by setters to signal the callback to cancel read_async so the
+    // run() loop can apply USB control transfers outside the callback.
+    std::atomic<bool> m_retuneRequested{false};
+
+    // Apply all pending USB control transfers. Called from run() OUTSIDE
+    // the rtlsdr_read_async callback context.
+    void applyPendingControls();
+};
+
+}  // namespace AetherSDR::rtl

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -187,6 +187,8 @@ QString familyFromProfile(const QJsonObject& profile)
         return QString::fromLatin1(ConnectionPanel::kFamilyAnan);
     if (family == QLatin1String(ConnectionPanel::kFamilyIcom))
         return QString::fromLatin1(ConnectionPanel::kFamilyIcom);
+    if (family == QLatin1String(ConnectionPanel::kFamilyRtl))
+        return QString::fromLatin1(ConnectionPanel::kFamilyRtl);
     return QString::fromLatin1(ConnectionPanel::kFamilyFlex);
 }
 
@@ -720,6 +722,9 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     m_manualRadioTypeCombo->addItem(tr("Hermes-Lite 2"), QString::fromLatin1(kFamilyHl2));
     m_manualRadioTypeCombo->addItem(tr("ANAN-G2"), QString::fromLatin1(kFamilyAnan));
     m_manualRadioTypeCombo->addItem(tr("Icom (network)"), QString::fromLatin1(kFamilyIcom));
+#ifdef AETHER_BACKEND_RTL
+    m_manualRadioTypeCombo->addItem(tr("RTL-SDR (USB)"), QString::fromLatin1(kFamilyRtl));
+#endif
     addManualRow(QStringLiteral("Radio type:"), m_manualRadioTypeCombo);
 
     m_manualIpCombo = new QComboBox(manualGroup);
@@ -2316,6 +2321,7 @@ void ConnectionPanel::setManualFamily(const QString& family)
         lowered == QLatin1String(kFamilyHl2)  ? QString::fromLatin1(kFamilyHl2)
       : lowered == QLatin1String(kFamilyAnan) ? QString::fromLatin1(kFamilyAnan)
       : lowered == QLatin1String(kFamilyIcom) ? QString::fromLatin1(kFamilyIcom)
+      : lowered == QLatin1String(kFamilyRtl)  ? QString::fromLatin1(kFamilyRtl)
                                               : QString::fromLatin1(kFamilyFlex);
     const int index = m_manualRadioTypeCombo->findData(wanted);
     if (index < 0 || index == m_manualRadioTypeCombo->currentIndex()) {

--- a/src/gui/ConnectionPanel.h
+++ b/src/gui/ConnectionPanel.h
@@ -70,6 +70,9 @@ public:
     // handshake needs a username and password before the radio will answer with
     // anything useful, which is why the manual page grows credential fields.
     static constexpr const char* kFamilyIcom = "icom";
+    // RTL-SDR USB dongles (RTL2832U / R820T). USB-addressed (device index +
+    // serial), not network. Receive-only (Principle VI).
+    static constexpr const char* kFamilyRtl  = "rtl";
 
     // IConnectionAutomation — engine-facing connect/disconnect/dialog hook.
     QList<RadioInfo> automationLocalRadios() const override;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -10,6 +10,7 @@
 
 #include "core/backends/anan/AnanDiscovery.h"
 #include "core/backends/hl2/Hl2Discovery.h"
+#include "core/RtlSdrDiscovery.h"
 #include "models/RadioModel.h"
 #include "models/BandSettings.h"
 #include "models/AntennaGeniusModel.h"
@@ -1012,6 +1013,8 @@ private:
     // openHPSDR Protocol 2 discovery for the ANAN-G2. Feeds the same
     // ConnectionPanel slots as m_discovery, tagged family="anan".
     anan::AnanDiscovery m_ananDiscovery;
+    // Local USB discovery for RTL-SDR devices, tagged family="rtl".
+    RtlSdrDiscovery m_rtlDiscovery;
     // Radio sessions (#3445 Camp B / #3351). Each session owns the full
     // per-radio aggregate; today there is exactly one. The vector sits at
     // the old `RadioModel m_radioModel` member position so destruction

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -279,6 +279,15 @@ void MainWindow::wireDiscovery()
             this, &MainWindow::maybeAutoConnectToDiscoveredRadio);
     m_ananDiscovery.start();
 
+    connect(&m_rtlDiscovery, &RtlSdrDiscovery::radioDiscovered,
+            m_connPanel, &ConnectionPanel::onRadioDiscovered);
+    connect(&m_rtlDiscovery, &RtlSdrDiscovery::radioUpdated,
+            m_connPanel, &ConnectionPanel::onRadioUpdated);
+    connect(&m_rtlDiscovery, &RtlSdrDiscovery::radioLost,
+            m_connPanel, &ConnectionPanel::onRadioLost);
+    if (RtlSdrDiscovery::isAvailable()) {
+        m_rtlDiscovery.start();
+    }
     connect(&m_discovery, &RadioDiscovery::radioUpdated,
             m_connPanel, &ConnectionPanel::onRadioUpdated);
     connect(&m_discovery, &RadioDiscovery::radioUpdated,
@@ -303,10 +312,16 @@ void MainWindow::wireDiscovery()
                     m_autoConnectSerial.clear();
             });
     connect(m_connPanel, &ConnectionPanel::retryDiscoveryRequested, this, [this] {
-        m_connPanel->setStatusText("Searching your local network…");
+        m_connPanel->setStatusText(RtlSdrDiscovery::isAvailable()
+                                       ? "Searching local network & USB devices…"
+                                       : "Searching your local network…");
         if (m_titleBar) m_titleBar->setDiscovering(true);
         m_discovery.stopListening();
         m_discovery.startListening();
+        if (RtlSdrDiscovery::isAvailable()) {
+            m_rtlDiscovery.stop();
+            m_rtlDiscovery.start();
+        }
     });
     connect(m_connPanel, &ConnectionPanel::networkDiagnosticsRequested,
             this, &MainWindow::showNetworkDiagnosticsDialog);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -13,6 +13,9 @@
 #include "core/backends/icom/IcomCivBackend.h"  // Icom networked radios (family "icom")
 #include "core/backends/icom/IcomCredentials.h"  // password: keychain, never settings
 #include "core/backends/icom/IcomSettings.h"     // host/user/ports (Principle V)
+#ifdef AETHER_BACKEND_RTL
+#include "core/backends/rtl/RtlSdrBackend.h"    // RTL-SDR backend (family "rtl")
+#endif
 #include "core/AppSettings.h"
 #include "core/RadioStateMemory.h"  // RFC #4603 typed restore handoff
 #include "core/ShutdownTrace.h"
@@ -713,6 +716,14 @@ std::unique_ptr<IRadioBackend> RadioModel::makeBackend(const QString& family)
     // same way it does for Flex (see the dynamic_cast below).
     if (family.compare(QLatin1String("sim"), Qt::CaseInsensitive) == 0)
         return std::make_unique<SimBackend>();
+    if (family.compare(QLatin1String("rtl"), Qt::CaseInsensitive) == 0) {
+#ifdef AETHER_BACKEND_RTL
+        return std::make_unique<rtl::RtlSdrBackend>();
+#else
+        qWarning() << "RadioModel: RTL-SDR backend requested but RTL support is disabled";
+        return nullptr;
+#endif
+    }
     return std::make_unique<FlexBackend>();
 }
 
@@ -751,6 +762,12 @@ void RadioModel::setupBackend(const QString& family)
         // guarded by a dynamic_cast so the Flex path stays byte-identical and a
         // non-Flex backend simply skips it (it owns its own wire objects).
         m_backend = makeBackend(m_family);
+        if (!m_backend) {
+            emit connectionError(
+                tr("This build has no RTL-SDR support — librtlsdr or fftw3f "
+                   "was unavailable when AetherSDR was compiled."));
+            return;
+        }
         if (auto* flex = dynamic_cast<FlexBackend*>(m_backend.get())) {
             flex->setCommandSink([this](const QString& cmd){ sendCommand(cmd); });
             // Slice verbs route through the TX-inhibit-guarded slice sink (§6), so
@@ -3401,7 +3418,7 @@ void RadioModel::connectToRadio(const RadioInfo& info)
     // family for the whole process. Same-family reconnects rebuild nothing.
     const QString wantFamily = info.family.isEmpty() ? QStringLiteral("flex")
                                                      : info.family.toLower();
-    if (wantFamily != m_family) {
+    if (wantFamily != m_family || !m_backend) {
         qCInfo(lcProtocol) << "RadioModel: switching backend family" << m_family
                            << "->" << wantFamily << "for" << info.address.toString();
         // F1 (#4448): a family switch is a hard radio change — drop every live and
@@ -3411,6 +3428,9 @@ void RadioModel::connectToRadio(const RadioInfo& info)
         teardownBackend();
         setupBackend(wantFamily);
         emit backendRebuilt();
+        if (!m_backend) {
+            return;
+        }
     }
 
     // An attempt is in flight from here until it lands, fails, or is abandoned

--- a/tests/rtl_backend_test.cpp
+++ b/tests/rtl_backend_test.cpp
@@ -1,0 +1,165 @@
+// Unit test for RtlSdrBackend and RtlSdrDiscovery (Issue #4797).
+// Verifies capabilities declaration, state restore contract, signal deltas,
+// and discovery availability.
+
+#include "core/backends/rtl/RtlSdrBackend.h"
+#include "core/backends/rtl/RtlSdrDdc.h"
+#include "core/backends/rtl/RtlSdrWorker.h"
+#include "core/RtlSdrDiscovery.h"
+
+#include <QCoreApplication>
+#include <QJsonObject>
+#include <cstdio>
+#include <memory>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+static void check(bool cond, const char* what)
+{
+    if (!cond) {
+        std::fprintf(stderr, "FAIL: %s\n", what);
+        ++g_failures;
+    }
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+#ifdef AETHER_BACKEND_RTL
+    auto backend = std::make_unique<rtl::RtlSdrBackend>();
+    check(backend != nullptr, "RtlSdrBackend instantiation");
+
+    // 1. Check capabilities declaration (Principle VI: receive-only)
+    const auto caps = backend->capabilities();
+    check(caps.family == "rtl", "capabilities.family is rtl");
+    check(!caps.canTransmit, "RTL-SDR cannot transmit");
+    check(caps.txPowerMaxWatts == 0.0, "RTL-SDR max TX power is 0");
+    check(!caps.hostModulates, "RTL-SDR does not modulate on host");
+    check(caps.maxSlices == 1, "RTL-SDR maxSlices is 1");
+    check(caps.maxPanadapters == 1, "RTL-SDR maxPanadapters is 1");
+    check(!caps.persistsMemories, "RTL-SDR does not persist memories on device");
+
+    // Check ClientSettingsDomains
+    check(caps.clientSettingsDomains.testFlag(RadioCapabilities::ClientSettingsDomain::Tuning),
+          "ClientSettingsDomain::Tuning declared");
+    check(caps.clientSettingsDomains.testFlag(RadioCapabilities::ClientSettingsDomain::RfGain),
+          "ClientSettingsDomain::RfGain declared");
+
+    // 2. Test state restoration (RFC #4603 typed restore contract)
+    RestoredRadioState restoredState;
+    restoredState.rfFrequencyHz = 144'200'000.0;
+    restoredState.mode = QStringLiteral("USB");
+    restoredState.filterLowHz = 300;
+    restoredState.filterHighHz = 2'700;
+    restoredState.sampleRateHz = 1'843'200;
+    restoredState.extension[QStringLiteral("rfGain")] =
+        QJsonObject{{QStringLiteral("gainDb"), 28}};
+
+    backend->applyRestoredState(restoredState);
+
+    // Save state back out and verify
+    const auto savedState = backend->currentOperatingState();
+    check(savedState.rfFrequencyHz == 144'200'000.0, "restored rfFrequencyHz");
+    check(savedState.mode == QStringLiteral("USB"), "restored mode");
+    check(savedState.sampleRateHz == 1'843'200, "restored sampleRateHz");
+    check(savedState.filterLowHz == 300 && savedState.filterHighHz == 2'700,
+          "restored passband");
+    check(savedState.extension.contains("rfGain"), "saved state contains rfGain extension");
+    const auto savedExt = savedState.extension.value("rfGain").toObject();
+    check(savedExt.value("gainDb").toInt() == 28, "restored gainDb");
+
+    // 3. Test RtlSdrDiscovery static check
+    check(RtlSdrDiscovery::isAvailable(), "RtlSdrDiscovery::isAvailable() is true when built with librtlsdr");
+
+    // 4. Test RtlSdrDdc processing & signal emissions
+    rtl::RtlSdrDdc ddc;
+    ddc.setSampleRate(2'400'000.0);
+    ddc.setCenterFrequency(144'200'000.0);
+    ddc.setSliceFrequency(144'200'000.0);
+    ddc.setSliceMode(QStringLiteral("FM"));
+
+    bool spectrumEmitted = false;
+    bool waterfallEmitted = false;
+    bool audioEmitted = false;
+
+    QObject::connect(&ddc, &rtl::RtlSdrDdc::spectrumFrameReady, [&spectrumEmitted](int panId, const QByteArray& frame) {
+        Q_UNUSED(panId);
+        if (!frame.isEmpty()) {
+            spectrumEmitted = true;
+        }
+    });
+
+    QObject::connect(&ddc, &rtl::RtlSdrDdc::waterfallRowReady, [&waterfallEmitted](int panId, const QByteArray& row) {
+        Q_UNUSED(panId);
+        if (!row.isEmpty()) {
+            waterfallEmitted = true;
+        }
+    });
+
+    QObject::connect(&ddc, &rtl::RtlSdrDdc::audioFrameReady, [&audioEmitted](const QByteArray& pcm) {
+        if (!pcm.isEmpty()) {
+            audioEmitted = true;
+        }
+    });
+
+    // Feed 4096 synthetic complex float IQ samples
+    QVector<std::complex<float>> syntheticSamples(4096, std::complex<float>(0.5f, 0.5f));
+    ddc.processIqData(syntheticSamples);
+
+    check(spectrumEmitted, "RtlSdrDdc emitted spectrumFrameReady");
+    check(waterfallEmitted, "RtlSdrDdc emitted waterfallRowReady");
+    check(audioEmitted, "RtlSdrDdc emitted audioFrameReady");
+
+    // 5. Test direct sampling mode persistence contract
+    RestoredRadioState hfState;
+    hfState.rfFrequencyHz = 14'100'000.0;
+    hfState.mode = QStringLiteral("USB");
+    backend->applyRestoredState(hfState);
+    const auto hfSaved = backend->currentOperatingState();
+    check(hfSaved.rfFrequencyHz == 14'100'000.0, "HF state restored frequency");
+
+    // Empty restore is a real reset, not a same-family state leak.
+    backend->applyRestoredState({});
+    const auto resetState = backend->currentOperatingState();
+    check(resetState.rfFrequencyHz == 95'200'000.0, "empty restore resets frequency");
+    check(resetState.mode == QStringLiteral("WFM"), "empty restore resets mode");
+    check(resetState.sampleRateHz == 2'400'000, "empty restore resets sample rate");
+    // The reset gain is the DEFAULT, and the default is deliberately not zero.
+    //
+    // 0 was the shipped value and it is the one number that must never come back:
+    // both tuner families start their discrete gain table at exactly 0.0 dB, so
+    // nearestGainTenths() snapped a 0 default onto the LOWEST gain the hardware has
+    // and an unconfigured dongle came up deaf. Pinned as a literal rather than
+    // written against the constant, so moving the constant to 0 fails here instead
+    // of silently agreeing with itself.
+    static_assert(rtl::RtlSdrBackend::kDefaultRfGainDb != 0,
+                  "a 0 dB default programs the tuner's lowest gain, not 'unset'");
+    check(resetState.extension.value("rfGain").toObject().value("gainDb").toInt()
+              == rtl::RtlSdrBackend::kDefaultRfGainDb,
+          "empty restore resets gain to the default");
+    check(resetState.extension.value("rfGain").toObject().value("gainDb").toInt() != 0,
+          "the reset gain is not the deaf-on-connect 0 dB the backend shipped with");
+
+    // 6. Test sample rate validation & clamping (Priority 4)
+    check(rtl::RtlSdrBackend::clampSampleRate(0) == 225'001u, "clampSampleRate(0) -> 225001");
+    check(rtl::RtlSdrBackend::clampSampleRate(500'000u) == 300'000u, "forbidden-gap 500k -> 300k");
+    check(rtl::RtlSdrBackend::clampSampleRate(768'000u) == 1'000'000u, "forbidden-gap 768k -> 1M");
+    check(rtl::RtlSdrBackend::clampSampleRate(10'000'000u) == 3'000'000u, "clampSampleRate(10M) -> 3000000");
+    check(rtl::RtlSdrBackend::clampSampleRate(2'400'000u) == 2'400'000u, "clampSampleRate(2.4M) -> 2400000");
+    check(rtl::RtlSdrBackend::clampSampleRate(2'500'000u) == 2'400'000u, "clampSampleRate(2.5M) -> 2400000");
+#else
+
+    std::fprintf(stderr, "rtl_backend_test: SKIPPED (librtlsdr support disabled)\n");
+    return 0;
+#endif
+
+    if (g_failures > 0) {
+        std::fprintf(stderr, "rtl_backend_test: %d checks failed\n", g_failures);
+        return 1;
+    }
+
+    std::fprintf(stderr, "rtl_backend_test: all checks passed\n");
+    return 0;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -724,6 +724,14 @@ target_link_libraries(hl2_link_stats_model_test PRIVATE aethercore Qt6::Core Qt6
 add_test(NAME hl2_link_stats_model_test COMMAND hl2_link_stats_model_test)
 ]==]
 
+if(AETHER_BACKEND_RTL)
+    # Socket-free RTL-SDR backend seam, DSP, and discovery contract.
+    add_executable(rtl_backend_test tests/rtl_backend_test.cpp)
+    target_include_directories(rtl_backend_test PRIVATE src)
+    target_link_libraries(rtl_backend_test PRIVATE aethercore Qt6::Core Qt6::Network Qt6::Test)
+    add_test(NAME rtl_backend_test COMMAND rtl_backend_test)
+endif()
+
 # HL2 receiver churn — add/close receivers against a LIVE EP6 stream. The only
 # test that puts the m_rx reshape and the I/O-thread fan-out in contention, which
 # is what lets the weekly TSan job (.github/workflows/sanitizers.yml) exercise the


### PR DESCRIPTION
## Summary

Closes #4797.

Adds an experimental, receive-only RTL-SDR backend for local RTL2832U-class USB dongles. The implementation stays below the neutral radio seam and provides one panadapter, one slice, spectrum/waterfall frames, and 24 kHz host-demodulated audio.

## What changed

- Added optional `librtlsdr` + FFTW3f discovery, build integration, and local USB enumeration.
- Added a worker-owned async USB lifecycle with bounded cancellation and control transfers between read sessions.
- Added tuning, legal sample-rate detents, tuner gain, PPM/direct-sampling/offset controls, and hardware-readback acknowledgements.
- Added basic AM/SAM/FM/WFM/SSB/CW demodulation, fractional 24 kHz resampling, display pacing, and audio mute/gain/pan.
- Added neutral state restore/reset, strictly receive-only capabilities, documentation, and a socket-free `rtl_backend_test`.
- Added Linux and macOS CI dependencies so the backend and its test compile where supported. Windows and AppImage continue to compile the feature out unless their dependency bundles provide `librtlsdr` and FFTW3f.

The earlier unrelated ConnectionPanel lifecycle, QRhi device-loss, HL2 discovery, automation `connect ip`, and AppImage workflow changes are not part of this PR.

## Rebase and review repairs

- Squash-rebased as one signed contributor-authored commit onto upstream `main` at `13a315f3`.
- Made the optional dependency path explicit with `ENABLE_RTL` and kept missing FFTW3f non-fatal.
- Ensured Linux CI installs `librtlsdr-dev` before configuring and made a missing test fail with `--no-tests=error`.
- Moved `rtl_backend_test` out of a retired-test comment block so it is actually registered.
- Kept PortAudio probing independent from the RTL option.
- Removed a mutex from the real-time USB/DSP callback path and made live DDC parameters atomic.
- Added a safe, operator-visible refusal for a saved RTL profile on builds without RTL support.
- Clamped tune requests before recentering and restored the advertised SAM/FMN/CWR mode coverage.

## Exact-head validation (`fea6ae9b`)

- GitHub verifies the commit's SSH signature.
- Conflict-free merge-tree against upstream `main`; the branch is exactly one commit ahead.
- Full macOS application compile passed with RTL enabled (`librtlsdr 2.0.3`, `fftw3f 3.3.11`). This host's `iconutil` rejected generated PNGs carrying local provenance metadata, so the build reused the repository checkout's already-valid ICNS artifact; no CMake workaround is committed.
- `rtl_backend_test`: 1/1 passed, socket-free.
- `ENABLE_RTL=OFF`: `aethercore` compiled successfully, including the discovery stub and unavailable-backend path.
- Engine-boundary strict check: 0 blockers. Test-registration check: passed.
- The broad local suite was not fully clean in this restricted host: 329/338 passed with one intentional skip; nine existing non-RTL tests failed, mostly because legacy socket fixtures could not bind. The focused RTL test did not fail. Required GitHub CI is the authoritative merge gate.

No RTL-SDR dongle was attached for this exact-head pass, so live USB/audio behavior was not re-proved here. The contributor previously reported live Linux/X11 validation with RTL2832U/R820T hardware at 2.4 MS/s, including spectrum/waterfall, tuning, and audio.

## Current limitations

- No transmit, radio-side meters, radio-owned memories, or multi-slice support.
- Passband values are exposed as state/UI controls but do not yet drive a sharp selectable DSP filter.
- Demodulation is intentionally basic.
- PPM, direct-sampling override, and offset tuning remain extension controls rather than first-class UI controls.
- A USB-specific automation verb is still needed for bridge-driven RTL hardware certification; the network-oriented `connect ip` verb deliberately does not accept this family.

Generated with OpenAI Codex (Daybreak Blue)
