### PR TITLE
fix(crash): stop a panadapter pop-out crash from becoming a boot loop (Microsoft Store) (#4617)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3994,6 +3994,14 @@ target_include_directories(spectrum_preview_logic_test PRIVATE src)
 target_link_libraries(spectrum_preview_logic_test PRIVATE Qt6::Core)
 add_test(NAME spectrum_preview_logic_test COMMAND spectrum_preview_logic_test)
 
+# Floating-panadapter crash-loop guard (#4617) — pins that a session which died
+# inside floatPanadapter() comes up docked instead of replaying the crash.
+add_executable(floating_restore_policy_test
+    tests/floating_restore_policy_test.cpp
+)
+target_include_directories(floating_restore_policy_test PRIVATE src)
+add_test(NAME floating_restore_policy_test COMMAND floating_restore_policy_test)
+
 add_executable(software_opengl_request_test
     tests/software_opengl_request_test.cpp
 )

--- a/src/gui/FloatingRestorePolicy.h
+++ b/src/gui/FloatingRestorePolicy.h
@@ -1,0 +1,53 @@
+#pragma once
+
+namespace AetherSDR {
+
+// Settings keys backing the floating-panadapter crash-loop guard (#4617).
+//
+// "FloatingPanIds" is the list of pans that were floated when the session
+// ended; the post-connect layout restore replays it. "FloatingPanRestorePending"
+// is armed immediately before every float — interactive or replayed — and
+// cleared once the new window has survived kFloatingRestoreSettleMs, so finding
+// it armed at startup means the previous process died inside the float.
+inline constexpr char kFloatingPanIdsKey[] = "FloatingPanIds";
+inline constexpr char kFloatingRestorePendingKey[] = "FloatingPanRestorePending";
+
+enum class FloatingRestoreAction {
+    // No evidence of a previous failure — replay the saved IDs as before.
+    Replay,
+    // The previous process armed the marker and never cleared it, and it left
+    // pan IDs behind. Those IDs are what it was floating when it died, so
+    // replaying them reproduces the crash. Forget them and come up docked.
+    DropSavedIds,
+    // Marker armed but nothing saved to replay (the previous process died
+    // after the float had already been undone, or the IDs were cleared by
+    // hand). Nothing to protect the user from; just retire the marker.
+    ClearStaleMarker,
+};
+
+// Decide what a starting session should do with the persisted float state.
+//
+// This exists because a crash inside floatPanadapter() used to be terminal
+// rather than merely annoying: saveFloatingState() commits the pan ID *before*
+// the reparent + GPU re-initialize that historically took the process down on
+// marginal D3D11 drivers (#4319, #4091, #4617), and restoreFloatingState()
+// replayed the saved list unconditionally on every connect. The result was a
+// boot loop with no in-app escape — the user had to hand-edit the settings
+// store to get their radio back. One armed-across-the-crash marker turns that
+// into a single lost pop-out.
+//
+// Deliberately conservative: it only discards state when a *previous* process
+// left the marker armed. A session that is merely slow to settle keeps its
+// layout, because the marker is evaluated once at construction, before this
+// session's own floats can arm it.
+constexpr FloatingRestoreAction evaluateFloatingRestore(bool haveSavedIds,
+                                                        bool restorePending)
+{
+    if (!restorePending) {
+        return FloatingRestoreAction::Replay;
+    }
+    return haveSavedIds ? FloatingRestoreAction::DropSavedIds
+                        : FloatingRestoreAction::ClearStaleMarker;
+}
+
+} // namespace AetherSDR

--- a/src/gui/FloatingRestorePolicy.h
+++ b/src/gui/FloatingRestorePolicy.h
@@ -6,18 +6,39 @@ namespace AetherSDR {
 //
 // "FloatingPanIds" is the list of pans that were floated when the session
 // ended; the post-connect layout restore replays it. "FloatingPanRestorePending"
-// is armed immediately before every float — interactive or replayed — and
-// cleared once the new window has survived kFloatingRestoreSettleMs, so finding
-// it armed at startup means the previous process died inside the float.
+// is armed and committed to disk immediately before every float — interactive
+// or replayed, and before the GPU teardown/reparent, not after — then cleared
+// once the new window has survived kFloatingRestoreSettleMs, so finding it
+// armed at startup means the previous process died inside the float.
 inline constexpr char kFloatingPanIdsKey[] = "FloatingPanIds";
 inline constexpr char kFloatingRestorePendingKey[] = "FloatingPanRestorePending";
+
+// The settings store's boolean spelling (AGENTS.md, "Settings Persistence":
+// booleans are stored as the strings "True"/"False"). Named here rather than
+// written inline so the marker cannot drift back to a C++ bool, which
+// AppSettings stringifies as "true" — that round-trips through .toBool(), but
+// reads as false to the documented
+// `value(k, "False").toString() == "True"` idiom, and silent-false is the
+// wrong direction for a crash-loop guard to fail in.
+inline constexpr char kSettingsTrue[] = "True";
+inline constexpr char kSettingsFalse[] = "False";
 
 enum class FloatingRestoreAction {
     // No evidence of a previous failure — replay the saved IDs as before.
     Replay,
     // The previous process armed the marker and never cleared it, and it left
-    // pan IDs behind. Those IDs are what it was floating when it died, so
-    // replaying them reproduces the crash. Forget them and come up docked.
+    // pan IDs behind. One of those IDs is what it was floating when it died,
+    // so replaying the list reproduces the crash. Forget them and come up
+    // docked.
+    //
+    // The drop is deliberately coarse: the marker is a bare flag, so *all*
+    // saved IDs go, not just the one in flight. Floating a second pan inside
+    // the settle window therefore puts the first one at risk too, and a crash
+    // from an unrelated cause within that window costs the whole pop-out
+    // layout. Both are one pop-out's worth of loss on a guard that is
+    // single-use by construction, and narrowing it would mean persisting the
+    // in-flight ID — more state to keep consistent across the exact code path
+    // that is known to die mid-write.
     DropSavedIds,
     // Marker armed but nothing saved to replay (the previous process died
     // after the float had already been undone, or the IDs were cleared by
@@ -48,6 +69,35 @@ constexpr FloatingRestoreAction evaluateFloatingRestore(bool haveSavedIds,
     }
     return haveSavedIds ? FloatingRestoreAction::DropSavedIds
                         : FloatingRestoreAction::ClearStaleMarker;
+}
+
+// What the starting session must persist for a given action.
+//
+// Split out of the caller's switch so the *writes* are pinned by the test, not
+// only the decision. The mutation that matters is deleting the marker-clearing
+// write: the guard would then stay armed forever and every subsequent launch
+// would drop the layout — a worse bug than the one it fixes — while
+// evaluateFloatingRestore() still returned the right answer and the suite
+// still passed. Routing the writes through a pure function makes that mutation
+// fail a test instead of merely contradicting a comment.
+struct FloatingRestoreWrites {
+    bool clearSavedIds;  // blank kFloatingPanIdsKey
+    bool clearMarker;    // write kFloatingRestorePendingKey = kSettingsFalse
+};
+
+constexpr FloatingRestoreWrites floatingRestoreWrites(FloatingRestoreAction action)
+{
+    switch (action) {
+    case FloatingRestoreAction::DropSavedIds:
+        return {true, true};
+    case FloatingRestoreAction::ClearStaleMarker:
+        return {false, true};
+    case FloatingRestoreAction::Replay:
+        break;
+    }
+    // Replay is the untouched-state case: a healthy session must not write to
+    // the store just because it looked at it.
+    return {false, false};
 }
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -25,6 +25,7 @@
 #include "AppletPanel.h"
 #include "ConnectedStationsDialog.h"
 #include "ConnectionPanel.h"
+#include "FloatingRestorePolicy.h"
 #include "PhoneCwApplet.h"
 #include "SpectrumOverlayMenu.h"
 #include "core/backends/sim/SimBackend.h"   // demo owns its audio — see wirePanStreamRxAudioSinks
@@ -1638,9 +1639,9 @@ void MainWindow::wirePanLifecycle()
                         ? saved
                         : defaultPanLayoutForCount(panCount);
                     const QString floatingPanIds = AppSettings::instance()
-                        .value("FloatingPanIds", "").toString();
+                        .value(kFloatingPanIdsKey, "").toString();
                     m_panStack->rearrangeLayout(layoutId);
-                    AppSettings::instance().setValue("FloatingPanIds", floatingPanIds);
+                    AppSettings::instance().setValue(kFloatingPanIdsKey, floatingPanIds);
 
                     // Defensive re-push xpixels for all pans after layout settles.
                     // Covers race where radio hadn't finished pan init when first push arrived.
@@ -1744,11 +1745,14 @@ void MainWindow::wirePanLifecycle()
     // docked rather than replaying the crash (#4617). Say so — otherwise the
     // pop-out silently fails to return and looks like a second bug.
     connect(m_panStack, &PanadapterStack::floatingRestoreAbandoned,
-            this, [this](const QString& abandonedPanIds) {
+            this, [this](int abandonedPanCount) {
+        // %n carries the count purely for plural agreement — phrased without a
+        // verb that has to agree, so the untranslated English reads correctly
+        // at 1 as well as at 2+.
         statusBar()->showMessage(
-            tr("Panadapter %1 was popped out when AetherSDR last closed "
-               "unexpectedly — it has been restored docked. Pop it out again "
-               "to retry.").arg(abandonedPanIds),
+            tr("%n panadapter(s) restored docked — AetherSDR last closed "
+               "unexpectedly while popping out. Pop out again to retry.",
+               nullptr, abandonedPanCount),
             15000);
     });
 

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1740,6 +1740,18 @@ void MainWindow::wirePanLifecycle()
             this, [repushPanDimensions](const QString&) { repushPanDimensions(); });
 #endif
 
+    // The previous session died floating a panadapter, so this one came up
+    // docked rather than replaying the crash (#4617). Say so — otherwise the
+    // pop-out silently fails to return and looks like a second bug.
+    connect(m_panStack, &PanadapterStack::floatingRestoreAbandoned,
+            this, [this](const QString& abandonedPanIds) {
+        statusBar()->showMessage(
+            tr("Panadapter %1 was popped out when AetherSDR last closed "
+               "unexpectedly — it has been restored docked. Pop it out again "
+               "to retry.").arg(abandonedPanIds),
+            15000);
+    });
+
     connect(&m_radioModel, &RadioModel::panadapterRemoved,
             this, [this](const QString& panId) {
         clearKiwiSdrPanDisplaySourceOverride(panId);

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -1,10 +1,12 @@
 #include "PanadapterStack.h"
 #include "BandStackPanel.h"
+#include "FloatingRestorePolicy.h"
 #include "PanFloatingWindow.h"
 #include "PanadapterApplet.h"
 #include "PanadapterRenderScheduler.h"
 #include "SpectrumWidget.h"
 #include "core/AppSettings.h"
+#include "core/LogManager.h"
 
 #include <QHBoxLayout>
 #include <QLayout>
@@ -86,6 +88,62 @@ PanadapterStack::PanadapterStack(QWidget* parent)
     m_splitter->setHandleWidth(3);
     m_splitter->setChildrenCollapsible(false);
     hbox->addWidget(m_splitter, 1);
+
+    // Crash-loop guard (#4617). Evaluated here, at construction, and nowhere
+    // else: this is the last point at which the marker on disk can only have
+    // been written by a *previous* process. Deferring the check to
+    // restoreFloatingState() would race a pop-out performed during this
+    // session's own settle window and throw away a layout that never crashed.
+    auto& settings = AppSettings::instance();
+    const QString savedIds = settings.value(kFloatingPanIdsKey, "").toString();
+    const bool restorePending =
+        settings.value(kFloatingRestorePendingKey, false).toBool();
+    switch (evaluateFloatingRestore(!savedIds.isEmpty(), restorePending)) {
+    case FloatingRestoreAction::DropSavedIds:
+        qCWarning(lcGui)
+            << "PanadapterStack: the previous session did not survive floating"
+            << savedIds
+            << "— starting docked and forgetting the saved float state (#4617)";
+        m_floatingRestoreAbandonedIds = savedIds;
+        settings.setValue(kFloatingPanIdsKey, QString());
+        settings.setValue(kFloatingRestorePendingKey, false);
+        settings.save();
+        break;
+    case FloatingRestoreAction::ClearStaleMarker:
+        settings.setValue(kFloatingRestorePendingKey, false);
+        settings.save();
+        break;
+    case FloatingRestoreAction::Replay:
+        break;
+    }
+}
+
+void PanadapterStack::armFloatingRestoreMarker()
+{
+    // Caller commits this with the pan ID in one settings write, so the marker
+    // can never reach disk later than the ID it protects.
+    AppSettings::instance().setValue(kFloatingRestorePendingKey, true);
+
+    if (!m_floatingRestoreSettleTimer) {
+        m_floatingRestoreSettleTimer = new QTimer(this);
+        m_floatingRestoreSettleTimer->setSingleShot(true);
+        m_floatingRestoreSettleTimer->setInterval(kFloatingRestoreSettleMs);
+        connect(m_floatingRestoreSettleTimer, &QTimer::timeout,
+                this, &PanadapterStack::clearFloatingRestoreMarker);
+    }
+    // Restart rather than start: a restore that replays several pans settles
+    // once, after the last of them has held up.
+    m_floatingRestoreSettleTimer->start();
+}
+
+void PanadapterStack::clearFloatingRestoreMarker()
+{
+    auto& settings = AppSettings::instance();
+    if (!settings.value(kFloatingRestorePendingKey, false).toBool()) {
+        return;
+    }
+    settings.setValue(kFloatingRestorePendingKey, false);
+    settings.save();
 }
 
 void PanadapterStack::setBandStackVisible(bool visible)
@@ -814,6 +872,13 @@ void PanadapterStack::floatPanadapter(const QString& panId)
     fw->restoreWindowGeometry();
     fw->show();
     fw->raise();
+    // Everything from here to the first frame in the new window — the deferred
+    // GPU reset, the show, and the resize it triggers — is the code that has
+    // taken the process down on marginal D3D11 drivers (#4319/#4091). Arm the
+    // marker first so saveFloatingState()'s save() commits it in the same
+    // transaction as the pan ID: if we die below, the next launch sees both
+    // and starts docked instead of replaying straight back into it (#4617).
+    armFloatingRestoreMarker();
     saveFloatingState();
     emit panFloated(panId);
 
@@ -929,6 +994,10 @@ void PanadapterStack::prepareShutdown()
 
     setShuttingDown(true);
     saveFloatingState();
+    // Reaching an orderly shutdown proves the floats held up, even if the
+    // settle timer has not fired yet. Without this, quitting inside the settle
+    // window would cost the user their pop-out on the next launch (#4617).
+    clearFloatingRestoreMarker();
 
     // Explicitly delete floating windows rather than calling close().
     // close() without WA_DeleteOnClose only hides the window, leaving it alive
@@ -975,7 +1044,7 @@ void PanadapterStack::saveFloatingState() const
 {
     QStringList ids;
     const QString saved =
-        AppSettings::instance().value("FloatingPanIds", "").toString();
+        AppSettings::instance().value(kFloatingPanIdsKey, "").toString();
     for (const QString& id : saved.split(',', Qt::SkipEmptyParts)) {
         if (!m_seenPanIds.contains(id) && !ids.contains(id)) {
             ids << id;
@@ -986,15 +1055,24 @@ void PanadapterStack::saveFloatingState() const
             ids << id;
         }
     }
-    AppSettings::instance().setValue("FloatingPanIds", ids.join(','));
+    AppSettings::instance().setValue(kFloatingPanIdsKey, ids.join(','));
     AppSettings::instance().save();
 }
 
 void PanadapterStack::restoreFloatingState()
 {
+    // The constructor already dropped the saved IDs if the previous session
+    // died floating them; report that here, where a window is listening.
+    if (!m_floatingRestoreAbandonedIds.isEmpty()) {
+        emit floatingRestoreAbandoned(m_floatingRestoreAbandonedIds);
+        m_floatingRestoreAbandonedIds.clear();
+    }
+
     const QString saved =
-        AppSettings::instance().value("FloatingPanIds", "").toString();
+        AppSettings::instance().value(kFloatingPanIdsKey, "").toString();
     if (saved.isEmpty()) return;
+    // Each floatPanadapter() re-arms the crash-loop marker, so the replay is
+    // covered by the same guard as an interactive pop-out.
     for (const QString& id : saved.split(',', Qt::SkipEmptyParts)) {
         if (m_pans.contains(id) && !m_floatingWindows.contains(id)) {
             floatPanadapter(id);

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -97,32 +97,58 @@ PanadapterStack::PanadapterStack(QWidget* parent)
     auto& settings = AppSettings::instance();
     const QString savedIds = settings.value(kFloatingPanIdsKey, "").toString();
     const bool restorePending =
-        settings.value(kFloatingRestorePendingKey, false).toBool();
-    switch (evaluateFloatingRestore(!savedIds.isEmpty(), restorePending)) {
-    case FloatingRestoreAction::DropSavedIds:
+        settings.value(kFloatingRestorePendingKey, kSettingsFalse).toBool();
+    const FloatingRestoreAction action =
+        evaluateFloatingRestore(!savedIds.isEmpty(), restorePending);
+    if (action == FloatingRestoreAction::DropSavedIds) {
         qCWarning(lcGui)
             << "PanadapterStack: the previous session did not survive floating"
             << savedIds
             << "— starting docked and forgetting the saved float state (#4617)";
-        m_floatingRestoreAbandonedIds = savedIds;
-        settings.setValue(kFloatingPanIdsKey, QString());
-        settings.setValue(kFloatingRestorePendingKey, false);
-        settings.save();
-        break;
-    case FloatingRestoreAction::ClearStaleMarker:
-        settings.setValue(kFloatingRestorePendingKey, false);
-        settings.save();
-        break;
-    case FloatingRestoreAction::Replay:
-        break;
+        m_floatingRestoreAbandonedCount =
+            static_cast<int>(savedIds.split(',', Qt::SkipEmptyParts).size());
+        // Tell the operator at launch, not only if they get as far as a
+        // successful connect — the #4617 case is precisely the one where
+        // connecting is the act the user has learnt to fear. A zero-timer is
+        // late enough that MainWindow::wirePanLifecycle() has connected to us
+        // (the event loop has not started yet at construction) and early
+        // enough that the notice describes *this* launch.
+        QTimer::singleShot(0, this,
+                           &PanadapterStack::announceAbandonedFloatingRestore);
     }
+
+    // The writes come from the policy header too, so that dropping the
+    // marker-clearing write — which would leave the guard armed forever and
+    // cost the layout on every launch — fails floating_restore_policy_test
+    // rather than passing it.
+    const FloatingRestoreWrites writes = floatingRestoreWrites(action);
+    if (writes.clearSavedIds) {
+        settings.setValue(kFloatingPanIdsKey, QString());
+    }
+    if (writes.clearMarker) {
+        settings.setValue(kFloatingRestorePendingKey, kSettingsFalse);
+    }
+    if (writes.clearSavedIds || writes.clearMarker) {
+        settings.save();
+    }
+}
+
+void PanadapterStack::announceAbandonedFloatingRestore()
+{
+    if (m_floatingRestoreAbandonedCount <= 0) return;
+    emit floatingRestoreAbandoned(m_floatingRestoreAbandonedCount);
 }
 
 void PanadapterStack::armFloatingRestoreMarker()
 {
-    // Caller commits this with the pan ID in one settings write, so the marker
-    // can never reach disk later than the ID it protects.
-    AppSettings::instance().setValue(kFloatingRestorePendingKey, true);
+    // Persisted here rather than left to the caller's save(): on the replay
+    // path the pan ID is *already* on disk, so the marker has to reach disk
+    // before the float work begins or a crash inside it is indistinguishable
+    // from a clean session. One extra transaction per pop-out buys that
+    // ordering, and it keeps the argument local to this function.
+    auto& settings = AppSettings::instance();
+    settings.setValue(kFloatingRestorePendingKey, kSettingsTrue);
+    settings.save();
 
     if (!m_floatingRestoreSettleTimer) {
         m_floatingRestoreSettleTimer = new QTimer(this);
@@ -139,10 +165,10 @@ void PanadapterStack::armFloatingRestoreMarker()
 void PanadapterStack::clearFloatingRestoreMarker()
 {
     auto& settings = AppSettings::instance();
-    if (!settings.value(kFloatingRestorePendingKey, false).toBool()) {
+    if (!settings.value(kFloatingRestorePendingKey, kSettingsFalse).toBool()) {
         return;
     }
-    settings.setValue(kFloatingRestorePendingKey, false);
+    settings.setValue(kFloatingRestorePendingKey, kSettingsFalse);
     settings.save();
 }
 
@@ -845,6 +871,20 @@ void PanadapterStack::floatPanadapter(const QString& panId)
     PanadapterApplet* applet = m_pans.value(panId, nullptr);
     if (!applet || m_floatingWindows.contains(panId)) return;
 
+    // Everything below — the GPU teardown, the reparent into a new top-level
+    // window, the rebuildDockedSplitter() that resizes every remaining sibling
+    // QRhiWidget, fw->show(), and the deferred reset/first frame — is the code
+    // that has taken the process down on marginal D3D11 drivers (#4319/#4091).
+    // Arm *and persist* the marker before any of it: on the replay path the
+    // pan ID is already on disk (restoreFloatingState() read it from there), so
+    // a marker committed after this work would leave a crash here looking
+    // exactly like a clean session, and the next launch would replay straight
+    // back into it — the #4617 boot loop. Arming before saveFloatingState()
+    // also means the marker can never reach disk *later* than the ID it
+    // protects; the cost is that a crash in between drops the previously saved
+    // IDs too, which is the single-use price this guard already accepts.
+    armFloatingRestoreMarker();
+
     // Hide the SpectrumWidget and release GPU resources *before* reparenting.
     // On macOS, QRhiWidget with WA_NativeWindow has a native NSView; orphaning
     // the widget to nullptr creates a transient top-level NSWindow whose
@@ -872,13 +912,6 @@ void PanadapterStack::floatPanadapter(const QString& panId)
     fw->restoreWindowGeometry();
     fw->show();
     fw->raise();
-    // Everything from here to the first frame in the new window — the deferred
-    // GPU reset, the show, and the resize it triggers — is the code that has
-    // taken the process down on marginal D3D11 drivers (#4319/#4091). Arm the
-    // marker first so saveFloatingState()'s save() commits it in the same
-    // transaction as the pan ID: if we die below, the next launch sees both
-    // and starts docked instead of replaying straight back into it (#4617).
-    armFloatingRestoreMarker();
     saveFloatingState();
     emit panFloated(panId);
 
@@ -1062,11 +1095,13 @@ void PanadapterStack::saveFloatingState() const
 void PanadapterStack::restoreFloatingState()
 {
     // The constructor already dropped the saved IDs if the previous session
-    // died floating them; report that here, where a window is listening.
-    if (!m_floatingRestoreAbandonedIds.isEmpty()) {
-        emit floatingRestoreAbandoned(m_floatingRestoreAbandonedIds);
-        m_floatingRestoreAbandonedIds.clear();
-    }
+    // died floating them, and already announced it on a zero-timer at launch.
+    // Say it once more here: the launch notice competes with the connect
+    // sequence's own status messages, and this is the moment the pop-out
+    // visibly fails to come back. Consumed after this, so a later reconnect
+    // does not resurrect a stale explanation.
+    announceAbandonedFloatingRestore();
+    m_floatingRestoreAbandonedCount = 0;
 
     const QString saved =
         AppSettings::instance().value(kFloatingPanIdsKey, "").toString();

--- a/src/gui/PanadapterStack.h
+++ b/src/gui/PanadapterStack.h
@@ -91,16 +91,19 @@ signals:
     void activePanChanged(const QString& panId);
     void panFloated(const QString& panId);
     void panDocked(const QString& panId);
-    // The previous session died while floating these pans, so they were
-    // dropped and this one came up docked. Carries the abandoned ID list so
-    // the window can tell the operator why their pop-out did not come back.
-    void floatingRestoreAbandoned(const QString& abandonedPanIds);
+    // The previous session died while floating panadapters, so they were
+    // dropped and this one came up docked. Carries how many were dropped —
+    // enough for plural agreement in the operator notice, and nothing more:
+    // the internal 0x4000… pan IDs appear nowhere else in the UI, so they
+    // would give the operator no action they could take.
+    void floatingRestoreAbandoned(int abandonedPanCount);
 
 private:
     void rebuildDockedSplitter();
     // Arm / retire the persisted "a float is in flight" marker (#4617).
     void armFloatingRestoreMarker();
     void clearFloatingRestoreMarker();
+    void announceAbandonedFloatingRestore();
 
     PanadapterRenderScheduler* m_renderScheduler{nullptr};
     BandStackPanel* m_bandStackPanel{nullptr};
@@ -111,10 +114,11 @@ private:
     QSet<QString> m_seenPanIds;
     QString m_activePanId;
     bool m_shutdownPrepared{false};
-    // Pan IDs the constructor discarded because the previous process never
-    // survived floating them. Held until restoreFloatingState() so the notice
-    // reaches a window that has had time to connect to us.
-    QString m_floatingRestoreAbandonedIds;
+    // How many pans the constructor discarded because the previous process
+    // never survived floating them. Announced on a zero-timer at launch (once
+    // wirePanLifecycle() has connected to us) and again from
+    // restoreFloatingState(), which consumes it.
+    int m_floatingRestoreAbandonedCount{0};
     QTimer* m_floatingRestoreSettleTimer{nullptr};
 };
 

--- a/src/gui/PanadapterStack.h
+++ b/src/gui/PanadapterStack.h
@@ -5,6 +5,8 @@
 #include <QSet>
 #include <QSplitter>
 
+class QTimer;
+
 namespace AetherSDR {
 
 class BandStackPanel;
@@ -76,15 +78,29 @@ public:
     void saveFloatingState() const;
     void restoreFloatingState();
 
+    // How long a freshly floated panadapter must stay alive before the
+    // crash-loop marker is retired (#4617). The float path's failure mode is
+    // immediate — the reparent, the GPU re-initialize and the first frame in
+    // the new window all land within one event-loop turn — so this only has to
+    // outlast that turn plus the deferred refreshAfterReparent().
+    static constexpr int kFloatingRestoreSettleMs = 5000;
+
     void prepareShutdown();
 
 signals:
     void activePanChanged(const QString& panId);
     void panFloated(const QString& panId);
     void panDocked(const QString& panId);
+    // The previous session died while floating these pans, so they were
+    // dropped and this one came up docked. Carries the abandoned ID list so
+    // the window can tell the operator why their pop-out did not come back.
+    void floatingRestoreAbandoned(const QString& abandonedPanIds);
 
 private:
     void rebuildDockedSplitter();
+    // Arm / retire the persisted "a float is in flight" marker (#4617).
+    void armFloatingRestoreMarker();
+    void clearFloatingRestoreMarker();
 
     PanadapterRenderScheduler* m_renderScheduler{nullptr};
     BandStackPanel* m_bandStackPanel{nullptr};
@@ -95,6 +111,11 @@ private:
     QSet<QString> m_seenPanIds;
     QString m_activePanId;
     bool m_shutdownPrepared{false};
+    // Pan IDs the constructor discarded because the previous process never
+    // survived floating them. Held until restoreFloatingState() so the notice
+    // reaches a window that has had time to connect to us.
+    QString m_floatingRestoreAbandonedIds;
+    QTimer* m_floatingRestoreSettleTimer{nullptr};
 };
 
 } // namespace AetherSDR

--- a/tests/floating_restore_policy_test.cpp
+++ b/tests/floating_restore_policy_test.cpp
@@ -81,6 +81,44 @@ int testGuardIsSingleUse()
     if (evaluateFloatingRestore(true, false) != FloatingRestoreAction::Replay) {
         return fail("the guard must not persist past the run that consumed it");
     }
+
+    // The two checks above only pin the *decision*. What actually makes the
+    // guard single-use is the write that retires the marker: drop it and the
+    // marker stays armed forever, so every launch from then on evaluates
+    // DropSavedIds and throws the layout away. Pinning the writes is what
+    // makes that mutation fail here instead of shipping.
+    if (!floatingRestoreWrites(FloatingRestoreAction::DropSavedIds).clearMarker) {
+        return fail("dropping the saved IDs must also retire the marker");
+    }
+    if (!floatingRestoreWrites(FloatingRestoreAction::ClearStaleMarker).clearMarker) {
+        return fail("a stale marker must be retired, or it re-fires every launch");
+    }
+    return 0;
+}
+
+int testWritesMatchTheDecision()
+{
+    using namespace AetherSDR;
+
+    // Replay is the untouched-state case. A healthy session that merely looked
+    // at the store must not write to it — a stray clear here would silently
+    // delete a layout that had nothing wrong with it.
+    const auto replay = floatingRestoreWrites(FloatingRestoreAction::Replay);
+    if (replay.clearSavedIds || replay.clearMarker) {
+        return fail("Replay must leave the persisted float state alone");
+    }
+
+    // Retiring a stale marker must not take the saved IDs with it: by
+    // definition there were none to protect, and clearing regardless would
+    // turn the benign case into data loss.
+    if (floatingRestoreWrites(FloatingRestoreAction::ClearStaleMarker).clearSavedIds) {
+        return fail("retiring a stale marker must not discard saved IDs");
+    }
+
+    // The crash case is the only one allowed to discard the layout.
+    if (!floatingRestoreWrites(FloatingRestoreAction::DropSavedIds).clearSavedIds) {
+        return fail("DropSavedIds must actually blank the saved IDs");
+    }
     return 0;
 }
 
@@ -92,6 +130,7 @@ int main()
     if (const int rc = testCrashedSessionStartsDocked()) return rc;
     if (const int rc = testStaleMarkerIsRetiredNotEscalated()) return rc;
     if (const int rc = testGuardIsSingleUse()) return rc;
+    if (const int rc = testWritesMatchTheDecision()) return rc;
     std::printf("floating_restore_policy_test: all cases passed\n");
     return 0;
 }

--- a/tests/floating_restore_policy_test.cpp
+++ b/tests/floating_restore_policy_test.cpp
@@ -1,0 +1,97 @@
+// Pins the floating-panadapter crash-loop guard (#4617).
+//
+// Popping out a panadapter commits the pan ID to "FloatingPanIds" before the
+// reparent + GPU re-initialize that has historically killed the process on
+// marginal D3D11 drivers (#4319 / #4091). The post-connect restore then
+// replayed that list unconditionally, so a single pop-out crash became a boot
+// loop with no in-app escape. evaluateFloatingRestore() is the decision that
+// breaks it: one marker armed across the crash, one discarded pop-out.
+
+#include "gui/FloatingRestorePolicy.h"
+
+#include <cstdio>
+
+namespace {
+
+int fail(const char* message)
+{
+    std::fprintf(stderr, "floating_restore_policy_test: %s\n", message);
+    return 1;
+}
+
+int testHealthySessionReplays()
+{
+    using namespace AetherSDR;
+
+    // The overwhelmingly common case: pans were floated, the session that
+    // floated them shut down cleanly and retired the marker. Restoring the
+    // layout is the whole point of persisting it, so nothing may interfere.
+    if (evaluateFloatingRestore(true, false) != FloatingRestoreAction::Replay) {
+        return fail("a cleanly closed session must get its floating pans back");
+    }
+
+    // Nothing saved and no marker — restoreFloatingState() has nothing to do,
+    // and must not be told to clear state it never wrote.
+    if (evaluateFloatingRestore(false, false) != FloatingRestoreAction::Replay) {
+        return fail("an empty saved list is not evidence of a failure");
+    }
+    return 0;
+}
+
+int testCrashedSessionStartsDocked()
+{
+    using namespace AetherSDR;
+
+    // The #4617 case. The marker survived, and so did the pan IDs the previous
+    // process was floating when it died — those exact IDs are what the replay
+    // would feed straight back into floatPanadapter(). Drop them.
+    if (evaluateFloatingRestore(true, true) != FloatingRestoreAction::DropSavedIds) {
+        return fail("a session that died floating must not replay the same IDs");
+    }
+    return 0;
+}
+
+int testStaleMarkerIsRetiredNotEscalated()
+{
+    using namespace AetherSDR;
+
+    // Marker armed but nothing left to replay — e.g. the pan was docked again
+    // before the process died, or the IDs were cleared by hand as the #4617
+    // workaround. There is no crash to protect anyone from here, and treating
+    // it as one would leave the marker armed forever, so this must retire the
+    // marker WITHOUT being confused for the drop case.
+    if (evaluateFloatingRestore(false, true)
+        != FloatingRestoreAction::ClearStaleMarker) {
+        return fail("an armed marker with nothing saved must just be retired");
+    }
+    return 0;
+}
+
+int testGuardIsSingleUse()
+{
+    using namespace AetherSDR;
+
+    // Once the marker is retired, the very next evaluation of the same saved
+    // IDs must replay them. The guard costs the user one pop-out, not their
+    // ability to ever pop out again — a sticky guard would be a worse bug than
+    // the one it fixes.
+    if (evaluateFloatingRestore(true, true) != FloatingRestoreAction::DropSavedIds) {
+        return fail("first evaluation after a crash must drop");
+    }
+    if (evaluateFloatingRestore(true, false) != FloatingRestoreAction::Replay) {
+        return fail("the guard must not persist past the run that consumed it");
+    }
+    return 0;
+}
+
+} // namespace
+
+int main()
+{
+    if (const int rc = testHealthySessionReplays()) return rc;
+    if (const int rc = testCrashedSessionStartsDocked()) return rc;
+    if (const int rc = testStaleMarkerIsRetiredNotEscalated()) return rc;
+    if (const int rc = testGuardIsSingleUse()) return rc;
+    std::printf("floating_restore_policy_test: all cases passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Why

A Microsoft Store crash report (Dell Latitude 5424 Rugged, **26.7.2.0, 2026-07-17**) landed in the panadapter pop-out path. Decoding the stack:

| Frames | What |
|---|---|
| 43–33 | `main` → `QCoreApplication::exec` → Windows dispatcher → `sendPostedEvents` |
| 32–28 | notify chain delivering a queued `QMetaCallEvent` |
| 27–20 | `PanadapterStack::floatPanadapter`'s deferred `QTimer::singleShot(0, …)` lambda (`PanadapterStack.cpp:884`) |
| 19–13 | `show()` / layout → notify chain delivering a `QResizeEvent` |
| 12 | `SpectrumWidget::resizeEvent` **+0x18** — the first call in the body, `QRhiWidget::resizeEvent(ev)` |
| 11–5 | synchronous paint event → `QRhiWidget::paintEvent` |
| 4–2 | Qt6Gui — QRhiD3D11 flushing the frame's resource-update batch |
| 1–0 | `ID3D11DeviceContext::UpdateSubresource` → **access violation in `atidxx64.dll`** |

Note that `SpectrumWidget::render()` is absent even though it must have run: QRhi records resource updates and only executes them when the frame ends, so the stack can prove a bad `UpdateSubresource` was submitted but structurally cannot say which upload submitted it.

**That crash itself is already fixed.** It is #4319, fixed by #4329 (`aaf313ac`) — `git merge-base --is-ancestor` puts that commit outside v26.7.2 and v26.7.3 and inside v26.7.4. I re-verified all three fixes in the lineage are present on current `main`: waterfall texture sized from the retained CPU image (`SpectrumWidget.cpp:12338`), overlay/frequency/bg/dss textures and their QImages all sized from `fullFrameTextureSize()` (`:12569`, `:13736`) with recreate and upload behind the same `!resizePreview` gate, and sub-splitters attached before being filled (`PanadapterStack.cpp:563`).

One thing the new report does add: every previously confirmed case of this class died in the 2016 Intel HD 520 UMD (`igd10iumd64.dll`), which left open the reading that #4091/#4329's extent alignment was an Intel driver quirk. An AMD UMD dying on the identical path is independent corroboration that we really were handing D3D11 a source that did not match the destination extent.

**What is not fixed is the blast radius**, and that is what this PR addresses.

## The actual defect

`saveFloatingState()` commits the pan ID to `FloatingPanIds` *before* the reparent and GPU re-initialize that follow — exactly the code that has historically taken the process down. `restoreFloatingState()` (`PanadapterStack.cpp:993`) then replayed the saved list unconditionally on every post-connect layout restore, with no guard.

So any crash inside the float path was self-perpetuating: crash → ID still saved → reconnect → re-float → crash. #4617's reporter described it precisely — *"as soon as the radio connects the pop out appears then the application crashes"* — and had to be told to hand-edit the settings store to get his radio back. There is no in-app escape.

The #4617 triage flagged this as a live defect and recommended an attempt-flag; the issue was then closed COMPLETED, but no guard was ever implemented. It is still live on `main` today.

## What this does

Arm a `FloatingPanRestorePending` marker immediately before every float — interactive or replayed — committed in the **same settings transaction** as the pan ID, so the marker can never reach disk later than the ID it protects. Retire it once the new window has survived 5 s, or on orderly shutdown. Finding it still armed at construction means the previous process died mid-float, so drop the saved IDs, come up docked, and say why in the status bar.

Two decisions worth reviewing:

- **The check runs in the `PanadapterStack` constructor, not in `restoreFloatingState()`.** That is the last point at which an armed marker can only have been written by a *previous* process. Evaluating it lazily would race a pop-out performed during this session's own settle window and discard a layout that never crashed.
- **`prepareShutdown()` clears the marker.** Reaching an orderly shutdown proves the floats held up even if the settle timer has not fired; without this, quitting inside the 5 s window would cost the user their pop-out.

The guard is deliberately single-use: it costs one pop-out, not the ability to ever pop out again.

The decision itself is a pure function in the new `src/gui/FloatingRestorePolicy.h`, so `tests/floating_restore_policy_test.cpp` pins it without constructing widgets (same pattern as `SpectrumPreviewLogic.h`).

**This fixes no pop-out crash.** #4329 did that for the reported one. This makes the next one cost a pop-out instead of the application.

## Proof — agent automation bridge, live FLEX-8400M

Run against an isolated settings store (`AETHER_SETTINGS_DIR`), 2 pans, RX only, TX gated off. Pat's real settings store was verified untouched afterwards.

1. **Marker arms and retires.** Pop out via `panFloatToggle`, read the SQLite store directly:
   - `t+1s` → `FloatingPanIds=0x40000001`, `FloatingPanRestorePending=true` (both committed together)
   - `t+8s` → `FloatingPanIds=0x40000001`, `FloatingPanRestorePending=false`
2. **Crash simulation.** Dock (`FloatingPanIds` empties, marker false), re-float, `kill -9` at t+2s — inside the settle window. On-disk state left behind: `FloatingPanIds=0x40000001`, `FloatingPanRestorePending=true`. That is precisely the state that used to boot-loop.
3. **Recovery.** Relaunch → before connect, `FloatingPanIds` is empty and the marker retired. After connect, 2 pans, `PanFloatingWindow` absent from `dumpTree` — docked, no crash, no loop.
4. **Operator notice** (screenshot below): the status bar explains why the pop-out did not come back.

Build clean, `ctest` 279/280. The one failure is `hl2_tx_loopback_test`, the known stale-expected-sideband failure addressed by #4800 — this diff touches no HL2 code.

## Bridge gap found while proving this

There is **no verb that can float or dock a panadapter.** `panFloatToggle` is hidden in single-pan mode and the context-menu "↗ Pop out" is a transient `QMenu` that `dumpTree`/`invoke` cannot reach, so proving this needed a real multi-pan radio — the demo simulator caps at one pan and cannot exercise the path at all. Given that float/dock is the subject of #4319, #4617 and the #4091 family, a `pan float <id>` / `pan dock <id>` verb would make this whole crash lineage testable in CI. Filing separately rather than widening this PR.

Second, smaller gap: `dumpTree` does not expose a `QStatusBar` temporary message, so the operator notice above had to be verified by screenshot rather than by assertion.

## Related

- #4617 — the boot-loop report this fixes (closed COMPLETED with the guard unimplemented)
- #4319 / #4329 — the pop-out crash itself, fixed in v26.7.4
- #4091 / #4120 — sibling add-pan resize crash, same D3D11 class
- #4133 — hardening follow-ups; **item 1 is now obsolete**, #4329 incidentally fixed the truncating `w*dpr` sites it lists. Item 2 (CMakeLists.txt:375 still declares a Qt 6.7 floor while the GPU path calls the 6.8-only `setFixedColorBufferSize`) is still real.
