### PR TITLE
fix(gui): scope the last un-scoped QWidget sheet in SpectrumOverlayMenu

### DIFF
--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -226,13 +226,19 @@ static void applyPanelStyle(QWidget* panel, const QString& objectName)
 
 // The same object-name scoping for the bare containers INSIDE a panel: rows
 // that group a label with its control so the pair can be shown or hidden as a
-// unit, and the Display panel's scroll viewport and content widget. Being real
-// QWidgets rather than layouts, they have to declare that they paint nothing —
-// and they have to declare it scoped, because an unscoped "QWidget { … }"
-// opt-out makes the container a cascade source in its own right, pushing its
-// rule onto its children and onto their tooltip labels, which is exactly what
-// the panel scoping above exists to stop. No ThemeManager here: the rule names
-// no token, so there is nothing to re-resolve on a theme change.
+// unit, and the Display panel's scroll area, viewport and content widget. Being
+// real QWidgets rather than layouts, they have to declare that they paint
+// nothing — and they have to declare it scoped, because an unscoped
+// "QWidget { … }" opt-out makes the container a cascade source in its own
+// right, pushing its rule onto its children and onto their tooltip labels,
+// which is exactly what the panel scoping above exists to stop. No ThemeManager
+// here: the rule names no token, so there is nothing to re-resolve on a theme
+// change.
+//
+// The selector is QWidget# even for the QScrollArea: a type selector matches
+// subclasses, and the object name already pins the rule to exactly one widget,
+// so spelling the concrete class would narrow nothing — it would only keep that
+// one site out of this helper and back on a hand-rolled literal.
 static void applyTransparentStyle(QWidget* widget, const QString& objectName)
 {
     widget->setObjectName(objectName);
@@ -690,11 +696,14 @@ void SpectrumOverlayMenu::buildAntPanel()
         auto* rowWidget = new QWidget;
         // NO BOX AROUND THE ROW. The rows above are bare QHBoxLayouts added
         // straight to the panel's vbox; these two need real containers so each
-        // can hide independently, which is exactly what makes them a surface
-        // the panel's frame can land on. Scoped to the row's own name for the
-        // reason applyTransparentStyle documents — the opt-out this replaced
-        // was itself unscoped, so it cancelled the panel's box by broadcasting
-        // a rule at every descendant, tooltip labels included.
+        // can hide independently, which is what made them a surface the ANT
+        // panel's frame landed on while that sheet was an unscoped
+        // "QWidget { … }". It is QWidget#antPanel now and reaches nothing below
+        // itself, so this rule no longer cancels a live cascade — it keeps the
+        // row inert if the panel is ever un-scoped again. Scoped to the row's
+        // own name for the reason applyTransparentStyle documents: the opt-out
+        // this replaced was itself unscoped, so it cancelled the panel's box by
+        // broadcasting a rule at every descendant, tooltip labels included.
         applyTransparentStyle(rowWidget, objectName + QStringLiteral("Row"));
         auto* row = new QHBoxLayout(rowWidget);
         row->setContentsMargins(0, 0, 0, 0);
@@ -1409,15 +1418,13 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     auto* panelLayout = new QVBoxLayout(m_displayPanel);
     panelLayout->setContentsMargins(1, 1, 1, 1);  // keep the 1px panel border visible
     m_displayScroll = new QScrollArea;
-    m_displayScroll->setObjectName(QStringLiteral("displayPanelScroll"));
+    applyTransparentStyle(m_displayScroll, QStringLiteral("displayPanelScroll"));
     m_displayScroll->verticalScrollBar()->setObjectName(
         QStringLiteral("displayPanelScrollBar"));
     m_displayScroll->setWidgetResizable(true);
     m_displayScroll->setFrameShape(QFrame::NoFrame);
     m_displayScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_displayScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-    m_displayScroll->setStyleSheet(
-        "QScrollArea#displayPanelScroll { background: transparent; border: none; }");
     applyTransparentStyle(m_displayScroll->viewport(),
                           QStringLiteral("displayPanelViewport"));
     auto* displayContent = new QWidget;
@@ -1537,19 +1544,18 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     makeHeader("PANADAPTER");
     {
         auto* toggleRow = new QWidget;
-        toggleRow->setObjectName(QStringLiteral("displayPanelToggleRow"));
-        toggleRow->setStyleSheet(
-            "QWidget#displayPanelToggleRow { border: none; background: transparent; }");
+        applyTransparentStyle(toggleRow, QStringLiteral("displayPanelToggleRow"));
         auto* toggleLayout = new QHBoxLayout(toggleRow);
         toggleLayout->setContentsMargins(0, 2, 0, 2);
         toggleLayout->setSpacing(3);
 
         // Use the shared btnStyle so Heat Map / Grid / Wt Avg get the same
         // 1 px frame (blue unchecked, green checked) as the FFT Floor "Auto"
-        // button and the other row-end action buttons.  The toggleRow
-        // QWidget container itself is borderless (see setStyleSheet above)
-        // so the panel's cascading frame doesn't draw a box around the
-        // whole row.
+        // button and the other row-end action buttons. The toggleRow container
+        // declares itself borderless above for the same reason the Ant panel's
+        // front-end rows do — a real widget inside a panel is a surface a
+        // cascading panel frame can land on. #4440 scoped this panel, so
+        // nothing cascades here today and the rule is defensive.
         auto makeToggle = [&](const QString& text, QPushButton*& btn, bool checked = false) {
             btn = new QPushButton(text);
             btn->setCheckable(true);

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -205,14 +205,15 @@ static bool isLoopSelectableRxAntenna(const QString& token)
 static constexpr int BAND_BTN_W = 48;
 static constexpr int BAND_BTN_H = 26;
 
-// Scoped to the widget's own objectName rather than a bare "QWidget { … }"
-// selector — an unscoped type selector cascades into Qt's tooltip QLabel for
-// any descendant of the styled widget, stripping the tooltip's frame (#4440,
-// #4444). Takes the widget and sets both the object name and the style in one
-// call so the two can't drift apart (a typo in one used to silently un-style
-// the panel with no compile error). Routed through ThemeManager so the border
-// stays theme-aware, matching the band and display panels rather than the
-// literal #304050 the un-scoped rule inherited.
+// Every overlay panel's frame, scoped to the widget's own objectName rather
+// than a bare "QWidget { … }" selector. A Qt type selector matches subclasses
+// AND descendants, so an unscoped panel sheet paints its own frame onto every
+// bare container inside it, and reaches Qt's tooltip QLabel for the panel's
+// descendants (#4440, #4444). Takes the widget and sets both the object name
+// and the style in one call so the two can't drift apart (a typo in one used
+// to silently un-style the panel with no compile error). Routed through
+// ThemeManager so the border stays theme-aware instead of pinning the dark
+// theme's #304050 literal.
 static void applyPanelStyle(QWidget* panel, const QString& objectName)
 {
     panel->setObjectName(objectName);
@@ -220,6 +221,23 @@ static void applyPanelStyle(QWidget* panel, const QString& objectName)
         panel,
         QStringLiteral("QWidget#%1 { background: rgba(15, 15, 26, 220); "
                        "border: 1px solid {{color.background.2}}; border-radius: 3px; }")
+            .arg(objectName));
+}
+
+// The same object-name scoping for the bare containers INSIDE a panel: rows
+// that group a label with its control so the pair can be shown or hidden as a
+// unit, and the Display panel's scroll viewport and content widget. Being real
+// QWidgets rather than layouts, they have to declare that they paint nothing —
+// and they have to declare it scoped, because an unscoped "QWidget { … }"
+// opt-out makes the container a cascade source in its own right, pushing its
+// rule onto its children and onto their tooltip labels, which is exactly what
+// the panel scoping above exists to stop. No ThemeManager here: the rule names
+// no token, so there is nothing to re-resolve on a theme change.
+static void applyTransparentStyle(QWidget* widget, const QString& objectName)
+{
+    widget->setObjectName(objectName);
+    widget->setStyleSheet(
+        QStringLiteral("QWidget#%1 { background: transparent; border: none; }")
             .arg(objectName));
 }
 
@@ -546,8 +564,7 @@ void SpectrumOverlayMenu::buildAntPanel()
         "border: 1px solid #0090e0; }"
         "QPushButton:hover { border: 1px solid #0090e0; }";
     m_loopRow = new QWidget(m_antPanel);
-    m_loopRow->setObjectName(QStringLiteral("loopRow"));
-    m_loopRow->setStyleSheet("QWidget#loopRow { background: transparent; border: none; }");
+    applyTransparentStyle(m_loopRow, QStringLiteral("loopRow"));
     auto* loopRow = new QHBoxLayout(m_loopRow);
     loopRow->setContentsMargins(0, 0, 0, 0);
     loopRow->setSpacing(4);
@@ -671,15 +688,14 @@ void SpectrumOverlayMenu::buildAntPanel()
                                      const QString& a11yName,
                                      QPushButton** btnOut) -> QWidget* {
         auto* rowWidget = new QWidget;
-        // NO BOX AROUND THE ROW. kPanelStyle sets "QWidget { border: 1px solid
-        // ...; background: ... }" on the ANT panel, and Qt descendant-matches a
-        // bare type selector onto every child QWidget — so a row that is a real
-        // widget draws the panel's own frame around itself. The rows above are
-        // bare QHBoxLayouts added straight to the panel's vbox and have no
-        // container to catch it; these two need containers so each can hide
-        // independently, and therefore have to opt out explicitly.
-        rowWidget->setStyleSheet(
-            QStringLiteral("QWidget { border: none; background: transparent; }"));
+        // NO BOX AROUND THE ROW. The rows above are bare QHBoxLayouts added
+        // straight to the panel's vbox; these two need real containers so each
+        // can hide independently, which is exactly what makes them a surface
+        // the panel's frame can land on. Scoped to the row's own name for the
+        // reason applyTransparentStyle documents — the opt-out this replaced
+        // was itself unscoped, so it cancelled the panel's box by broadcasting
+        // a rule at every descendant, tooltip labels included.
+        applyTransparentStyle(rowWidget, objectName + QStringLiteral("Row"));
         auto* row = new QHBoxLayout(rowWidget);
         row->setContentsMargins(0, 0, 0, 0);
         row->setSpacing(4);
@@ -1380,19 +1396,16 @@ void SpectrumOverlayMenu::updateLayout()
 void SpectrumOverlayMenu::buildDisplayPanel()
 {
     m_displayPanel = new QWidget(parentWidget());
-    m_displayPanel->setObjectName(QStringLiteral("displayPanel"));
-    AetherSDR::ThemeManager::instance().applyStyleSheet(
-        m_displayPanel,
-        "QWidget#displayPanel { background: rgba(15, 15, 26, 220); "
-        "border: 1px solid {{color.background.2}}; border-radius: 3px; }");
+    applyPanelStyle(m_displayPanel, QStringLiteral("displayPanel"));
     m_displayPanel->hide();
 
     // #3969: the panel's ~24 rows exceed a short window's height, so the grid
     // lives on a content widget inside a scroll area (same pattern as
     // RadioSetupDialog::wrapTabInScrollArea) and toggleDisplayPanel() clamps
-    // the shown height. The explicit transparent styles stop the panel-level
-    // QWidget stylesheet above from cascading a second background/border onto
-    // the scroll machinery.
+    // the shown height. The scroll area, its viewport and the content widget
+    // each declare themselves transparent so the panel's own background shows
+    // through the scroll machinery — a QScrollArea viewport otherwise fills
+    // itself with the palette's base colour and hides it.
     auto* panelLayout = new QVBoxLayout(m_displayPanel);
     panelLayout->setContentsMargins(1, 1, 1, 1);  // keep the 1px panel border visible
     m_displayScroll = new QScrollArea;
@@ -1405,14 +1418,10 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     m_displayScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     m_displayScroll->setStyleSheet(
         "QScrollArea#displayPanelScroll { background: transparent; border: none; }");
-    m_displayScroll->viewport()->setObjectName(
-        QStringLiteral("displayPanelViewport"));
-    m_displayScroll->viewport()->setStyleSheet(
-        "QWidget#displayPanelViewport { background: transparent; border: none; }");
+    applyTransparentStyle(m_displayScroll->viewport(),
+                          QStringLiteral("displayPanelViewport"));
     auto* displayContent = new QWidget;
-    displayContent->setObjectName(QStringLiteral("displayPanelContent"));
-    displayContent->setStyleSheet(
-        "QWidget#displayPanelContent { background: transparent; border: none; }");
+    applyTransparentStyle(displayContent, QStringLiteral("displayPanelContent"));
     m_displayScroll->setWidget(displayContent);
     panelLayout->addWidget(m_displayScroll);
 


### PR DESCRIPTION
Follow-up to #4847 — the sweep that issue #4444 asked for. Found while reviewing that PR after it merged.

#4847 scoped all five overlay **panels** to their own `objectName`, and its description closes with "After this, `SpectrumOverlayMenu.cpp` has no un-scoped `QWidget { … }` selector left." That is one site short. The fix stopped at the panel boundary, and an un-scoped sheet survived *inside* the Ant panel, on the container rows `makeFrontEndRow()` builds for the preamp and attenuator controls:

```cpp
rowWidget->setStyleSheet(
    QStringLiteral("QWidget { border: none; background: transparent; }"));
```

That rule exists to cancel the box the old un-scoped `kPanelStyle` cascaded onto the row — and it cancels it *the same way the bug worked*, by broadcasting a bare type selector at every descendant, tooltip labels included. So the file still carried the pattern the sweep exists to remove, four hundred lines from the panel it had just fixed, and the two sibling opt-out rows in `buildAntPanel()` ended up scoped inconsistently: `m_loopRow` named and scoped, these two not.

The comment above it cited `kPanelStyle`, which #4847 deleted — the only surviving reference to that symbol anywhere in the tree — and the mechanism it described (the Ant panel descendant-matching onto the row) stopped existing the moment the panel sheet became `QWidget#antPanel`.

## What this does

A second helper alongside `applyPanelStyle()`, for the bare containers *inside* a panel rather than the panel itself:

```cpp
static void applyTransparentStyle(QWidget* widget, const QString& objectName)
```

Same anti-drift property as its sibling — object name and selector set in one call. Applied to the two front-end rows, and folded over the five sites that already hand-rolled the identical string:

| Widget | Where | Was |
|---|---|---|
| preamp / attenuator rows | `makeFrontEndRow()` | **un-scoped `QWidget { … }`** |
| `m_loopRow` | `buildAntPanel()` | hand-rolled scoped literal |
| Display scroll area | `buildDisplayPanel()` | hand-rolled `QScrollArea#…` literal, name set 8 lines away |
| Display scroll viewport | `buildDisplayPanel()` | hand-rolled scoped literal |
| Display content widget | `buildDisplayPanel()` | hand-rolled scoped literal |
| `displayPanelToggleRow` | `buildDisplayPanel()` | hand-rolled scoped literal |
| `m_displayPanel` | `buildDisplayPanel()` | hand-rolled — now `applyPanelStyle()` |

`m_displayPanel`'s string was byte-for-byte what `applyPanelStyle()` produces and was the last copy of that literal, so the helper now covers all six `applyPanelStyle()` call sites (five distinct panels — `m_bandPanel` is built on both the initial and the rebuild path).

**Every stylesheet on a container widget in this file now goes through one of the two helpers**, so there is no site left where an object name and its selector are written in two places and can drift apart. The scroll area is styled `QWidget#displayPanelScroll` rather than `QScrollArea#…`: a Qt type selector matches subclasses, and the object name already pins the rule to exactly one widget, so naming the concrete class bought nothing and cost that call site its place in the helper.

Three stale comments corrected: the dangling `kPanelStyle` reference; #3969's claim that the Display panel's transparent styles defend against a panel-level cascade (they don't since #4440 scoped it — they're there because a `QScrollArea` viewport fills itself with the palette base colour); and `displayPanelToggleRow`'s "so the panel's cascading frame doesn't draw a box around the whole row", which is the same dead mechanism. The front-end row comment says outright that its own rule is now defensive rather than cancelling a live cascade.

`SpectrumOverlayMenu.cpp` now genuinely has no un-scoped `QWidget { … }` selector. The only remaining occurrences of that text are the two helper comments that quote the pattern in order to explain it, and one comment that names the historical sheet it replaced.

## Verification

- Built clean, no new warnings.
- 12 overlay / theme / a11y / CI-gated tests pass.
- All five static checks pass locally, run against current `main` as the ratchet base rather than the merge base; the hardcoded-colour ratchet moves the right way (`setstylesheet` 1107 → 1102, unique colours and total references unchanged).
- **Rendering no-op, measured.** Built the merge base and this head side by side, ran both offscreen, and grabbed the Display, Ant, Band and DAX panels plus `panPreampBtn` from each — **byte-identical PNGs** in every case. `panPreampBtnRow` / `panAttenuatorBtnRow` appear in the head's widget tree and not the base's, confirming the new names land and collide with nothing.
- Not captured: the front-end rows themselves, which only become visible on an Icom radio. Their sheet is unchanged apart from the scope, and their child button renders identically.

## Not in scope

The pattern is repo-wide, not file-local: 24 un-scoped `QWidget { … }` sheets across 16 files under `src/` (`CatControlApplet`, nine `Client*Applet`s, `CwxPanel`, `PanadapterApplet`, others). Worth its own issue plus a Static-checks gate, per the closing note on #4847 — a gate can't land until the sweep does.

Refs #4444, #4440, #4847
