### PR TITLE
fix(protocol): route every TCI argument through a checked parse

### DIFF
--- a/docs/architecture/tci-receivers.md
+++ b/docs/architecture/tci-receivers.md
@@ -73,6 +73,43 @@ The receiver-index policy is only one half of the routing contract. Channel
    The route uses stable Flex slice IDs internally even if public TRX indexes
    shift after topology changes.
 
+6. **Eight commands carry no receiver index at all.**
+   `cw_macros_speed`, `cw_keyer_speed`, `cw_macros_delay`, `mon_volume`,
+   `mon_enable`, `cw_terminal`, `digl_offset` and `digu_offset` are global —
+   the value is the *first* argument, not the second. So is `volume`, and
+   `mic_level` / `tx_gain` are the AetherSDR extensions with the same shape.
+
+   This matters because the dispatcher derives GET-versus-SET from the
+   argument count (`isSet = args.size() >= 2`), which is the *trx-prefixed*
+   shape every per-slice verb uses. On a global verb that derivation is wrong
+   in both directions, and all eight carried the bug until #4867: the spec
+   form `mon_volume:50;` was read as a GET and the value silently discarded,
+   while `mon_volume:0,50;` was taken as a SET whose value was read from the
+   trx slot, setting the monitor gain to `0`. Both broadcast a well-formed
+   notification, so neither the sender nor a second client could tell.
+
+   These handlers therefore re-derive GET/SET from the argument list
+   themselves — **empty args = GET, otherwise SET reading the last
+   argument** — and both wire forms are accepted, the spec one and the legacy
+   trx-prefixed one.
+
+   **`mon_volume:0;` is a SET of 0, not a read.** A client written against
+   the trx-prefixed shape of the neighbouring verbs may send it meaning "read
+   receiver 0's monitor gain"; it will instead zero the monitor and the
+   operator will hear it. This is deliberate: silently refusing a legitimate
+   `0` — an ordinary thing for an operator to ask for — would be the same
+   undetectable-from-the-wire failure pointed the other way, and the client
+   can always read the value back. Send the bare `mon_volume;` to read.
+
+7. **Booleans are spelled `true` and `false`, and nothing else is accepted.**
+   Unparseable boolean arguments are dropped, exactly as unparseable numeric
+   ones are: `mute:0,yes;` used to become `false` and *unmute* the slice.
+
+   The two exceptions are `tune` and `keyer`, which key the transmitter.
+   There, anything that is not the word `true` still means **stop / key up**,
+   because dropping an unparseable stop would leave a keyed transmitter keyed.
+   Those two fail closed rather than fail silent (Constitution VI).
+
 ## Spot Click Notifications
 
 When a visible spot is clicked, AetherSDR broadcasts the click to every

--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -103,6 +103,70 @@ QString TciProtocol::tciToSmartSDR(const QString& mode, bool* ok)
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
+// Argument parsing, in one place (#4867).
+//
+// QString::toInt() returns 0 on a parse failure, so an unchecked conversion
+// does not fail — it turns malformed client input into a valid-looking 0 and
+// the command proceeds as if the client had asked for it. That is the hard
+// part of this defect class: it does not fail quietly, it *succeeds
+// convincingly*. The command applies, a well-formed notification goes out,
+// and neither the sender nor a second client watching the wire can tell
+// anything went wrong. No crash, no log line, no assertion anywhere in the
+// tree that moves. Three separate defects shipped that way and each was
+// found by a human noticing odd radio behaviour: a DRIVE read applied as a
+// power SET (#4345), `volume:` applied as 100% and `tx_gain:` as a mute
+// (#4523).
+//
+// The trx index is the sharpest case. sliceForTrx() resolves positionally, so
+// a malformed trx does not fail to resolve — it resolves to slice 0 and the
+// command lands on the wrong slice while broadcasting a notification that
+// names slice 0 as though the client had asked for it.
+//
+// Contract: `out` is left untouched when the argument is missing or
+// unparseable, so a caller that pre-seeds a default keeps it. Callers drop
+// the command on false — the "ignore silently per TCI spec" posture the
+// parser already takes for unrecognised commands, and the remedy #4345 and
+// #4523 both settled on. This rejects *unparseable* input only: range clamps
+// and the deliberately lenient forms (cmdVolume's non-spec percent branch,
+// which three bundled plugins depend on) are the caller's business and are
+// unchanged.
+static bool argToInt(const QStringList& args, int idx, int& out)
+{
+    if (idx < 0 || idx >= args.size()) return false;
+    bool ok = false;
+    const int parsed = args[idx].toInt(&ok);
+    if (!ok) return false;
+    out = parsed;
+    return true;
+}
+
+static bool argToLongLong(const QStringList& args, int idx, long long& out)
+{
+    if (idx < 0 || idx >= args.size()) return false;
+    bool ok = false;
+    const long long parsed = args[idx].toLongLong(&ok);
+    if (!ok) return false;
+    out = parsed;
+    return true;
+}
+
+// std::isfinite is part of the check, not extra paranoia: Qt's toDouble()
+// parses the literals "inf"/"-inf"/"nan" and reports ok, so the ok flag alone
+// lets them through to the arithmetic. That is how `volume:inf` muted the
+// radio until #4848 — lround(+inf) is out of long's range and the narrowing
+// cast landed on 0. Overflow ("1e400") already clears ok; the literal
+// spellings do not, which is exactly why this belongs in the shared helper
+// rather than in each caller that remembers.
+static bool argToDouble(const QStringList& args, int idx, double& out)
+{
+    if (idx < 0 || idx >= args.size()) return false;
+    bool ok = false;
+    const double parsed = args[idx].toDouble(&ok);
+    if (!ok || !std::isfinite(parsed)) return false;
+    out = parsed;
+    return true;
+}
+
 SliceModel* TciProtocol::sliceForTrx(int trx) const
 {
     if (m_trxMap)
@@ -580,14 +644,14 @@ QString TciProtocol::cmdStop()
 QString TciProtocol::cmdVfo(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    bool trxOk = false;
-    const int trx = args[0].toInt(&trxOk);
-    if (!trxOk || trx < 0)
+    int trx = 0;
+    if (!argToInt(args, 0, trx) || trx < 0)
         return {};
 
-    bool channelOk = args.size() < 2;
-    const int channel = args.size() >= 2 ? args[1].toInt(&channelOk) : 0;
-    if (!channelOk || channel < 0 || channel > 1)
+    int channel = 0;
+    if (args.size() >= 2 && !argToInt(args, 1, channel))
+        return {};
+    if (channel < 0 || channel > 1)
         return {};
     auto* s = sliceForVfo(trx, channel);
 
@@ -600,9 +664,8 @@ QString TciProtocol::cmdVfo(const QStringList& args, bool isSet)
 
     // Set: vfo:trx,channel,freq_hz
     if (args.size() < 3) return {};
-    bool ok;
-    long long hz = args[2].toLongLong(&ok);
-    if (!ok || hz < 0) return {};
+    long long hz = 0;
+    if (!argToLongLong(args, 2, hz) || hz < 0) return {};
     m_vfoRequest = VfoRequest { trx, channel, hz };
     return {};
 }
@@ -612,7 +675,8 @@ QString TciProtocol::cmdVfo(const QStringList& args, bool isSet)
 QString TciProtocol::cmdModulation(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -650,9 +714,8 @@ QString TciProtocol::cmdModulation(const QStringList& args, bool isSet)
 QString TciProtocol::cmdTrx(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    bool trxOk = false;
-    const int trx = args[0].toInt(&trxOk);
-    if (!trxOk || trx < 0)
+    int trx = 0;
+    if (!argToInt(args, 0, trx) || trx < 0)
         return {};
 
     if (!isSet) {
@@ -684,8 +747,8 @@ QString TciProtocol::cmdTxEnable(const QStringList& args)
 QString TciProtocol::cmdTune(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
-    (void)trx;
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
 
     if (!isSet) {
         bool tuning = m_model && m_model->transmitModel().isTuning();
@@ -717,20 +780,16 @@ QString TciProtocol::cmdDrive(const QStringList& args, bool /*isSet*/)
     int trx = txTrx();
     if (args.size() <= 1) {
         if (!args.isEmpty()) {
-            bool trxOk = false;
-            trx = args[0].toInt(&trxOk);
-            if (!trxOk || trx < 0) return {};
+            if (!argToInt(args, 0, trx) || trx < 0) return {};
         }
         const int pwr = m_model ? m_model->transmitModel().rfPower() : 0;
         return QStringLiteral("drive:%1,%2;").arg(trx).arg(pwr);
     }
     if (args.size() != 2) return {};
 
-    bool trxOk = false;
-    bool powerOk = false;
-    trx = args[0].toInt(&trxOk);
-    const int pwr = args[1].toInt(&powerOk);
-    if (!trxOk || trx < 0 || !powerOk || pwr < 0 || pwr > 100) return {};
+    int pwr = 0;
+    if (!argToInt(args, 0, trx) || trx < 0
+        || !argToInt(args, 1, pwr) || pwr < 0 || pwr > 100) return {};
     if (m_model) {
         QMetaObject::invokeMethod(m_model, [model = m_model, pwr]() {
             model->transmitModel().setRfPower(pwr);
@@ -748,20 +807,16 @@ QString TciProtocol::cmdTuneDrive(const QStringList& args, bool /*isSet*/)
     int trx = txTrx();
     if (args.size() <= 1) {
         if (!args.isEmpty()) {
-            bool trxOk = false;
-            trx = args[0].toInt(&trxOk);
-            if (!trxOk || trx < 0) return {};
+            if (!argToInt(args, 0, trx) || trx < 0) return {};
         }
         const int pwr = m_model ? m_model->transmitModel().tunePower() : 0;
         return QStringLiteral("tune_drive:%1,%2;").arg(trx).arg(pwr);
     }
     if (args.size() != 2) return {};
 
-    bool trxOk = false;
-    bool powerOk = false;
-    trx = args[0].toInt(&trxOk);
-    const int pwr = args[1].toInt(&powerOk);
-    if (!trxOk || trx < 0 || !powerOk || pwr < 0 || pwr > 100) return {};
+    int pwr = 0;
+    if (!argToInt(args, 0, trx) || trx < 0
+        || !argToInt(args, 1, pwr) || pwr < 0 || pwr > 100) return {};
     if (m_model) {
         QMetaObject::invokeMethod(m_model, [model = m_model, pwr]() {
             model->transmitModel().setTunePower(pwr);
@@ -790,9 +845,8 @@ QString TciProtocol::cmdMicLevel(const QStringList& args, bool /*isSet*/)
         int lvl = m_model ? m_model->transmitModel().micLevel() : 0;
         return QStringLiteral("mic_level:%1;").arg(lvl);
     }
-    bool ok;
-    int lvl = args[args.size() == 1 ? 0 : 1].toInt(&ok);
-    if (!ok) return {};
+    int lvl = 0;
+    if (!argToInt(args, args.size() == 1 ? 0 : 1, lvl)) return {};
     QMetaObject::invokeMethod(m_model, [model = m_model, lvl]() {
         model->transmitModel().setMicLevel(lvl);
     }, Qt::QueuedConnection);
@@ -826,9 +880,8 @@ QString TciProtocol::cmdTxGain(const QStringList& args, bool /*isSet*/)
     // Listed as item 2 of #4523's triage plan alongside cmdVolume; dropped
     // rather than guessed, matching the "ignore silently" posture the parser
     // already takes for unrecognised commands.
-    bool gainOk = false;
-    const int raw = args[args.size() == 1 ? 0 : 1].toInt(&gainOk);
-    if (!gainOk) {
+    int raw = 0;
+    if (!argToInt(args, args.size() == 1 ? 0 : 1, raw)) {
         return {};
     }
     const int pct = qBound(0, raw, 100);
@@ -842,7 +895,8 @@ QString TciProtocol::cmdTxGain(const QStringList& args, bool /*isSet*/)
 QString TciProtocol::cmdRitEnable(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -865,7 +919,8 @@ QString TciProtocol::cmdRitEnable(const QStringList& args, bool isSet)
 QString TciProtocol::cmdRitOffset(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -875,7 +930,8 @@ QString TciProtocol::cmdRitOffset(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 2) return {};
-    int offset = args[1].toInt();
+    int offset = 0;
+    if (!argToInt(args, 1, offset)) return {};
     bool on = s->ritOn();
     QMetaObject::invokeMethod(s, [s, on, offset]() {
         s->setRit(on, offset);
@@ -891,7 +947,8 @@ QString TciProtocol::cmdRitOffset(const QStringList& args, bool isSet)
 QString TciProtocol::cmdXitEnable(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -914,7 +971,8 @@ QString TciProtocol::cmdXitEnable(const QStringList& args, bool isSet)
 QString TciProtocol::cmdXitOffset(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -924,7 +982,8 @@ QString TciProtocol::cmdXitOffset(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 2) return {};
-    int offset = args[1].toInt();
+    int offset = 0;
+    if (!argToInt(args, 1, offset)) return {};
     bool on = s->xitOn();
     QMetaObject::invokeMethod(s, [s, on, offset]() {
         s->setXit(on, offset);
@@ -940,9 +999,8 @@ QString TciProtocol::cmdXitOffset(const QStringList& args, bool isSet)
 QString TciProtocol::cmdSplitEnable(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    bool trxOk = false;
-    const int trx = args[0].toInt(&trxOk);
-    if (!trxOk || trx < 0)
+    int trx = 0;
+    if (!argToInt(args, 0, trx) || trx < 0)
         return {};
     auto* s = sliceForTrx(trx);
     if (!isSet) {
@@ -974,7 +1032,8 @@ QString TciProtocol::cmdSplitEnable(const QStringList& args, bool isSet)
 QString TciProtocol::cmdRxFilterBand(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -984,8 +1043,9 @@ QString TciProtocol::cmdRxFilterBand(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 3) return {};
-    int lo = args[1].toInt();
-    int hi = args[2].toInt();
+    int lo = 0;
+    int hi = 0;
+    if (!argToInt(args, 1, lo) || !argToInt(args, 2, hi)) return {};
     QMetaObject::invokeMethod(s, [s, lo, hi]() {
         s->setFilterWidth(lo, hi);
     }, Qt::QueuedConnection);
@@ -1005,7 +1065,8 @@ QString TciProtocol::cmdCwMacrosSpeed(const QStringList& args, bool isSet)
     }
 
     if (args.isEmpty()) return {};
-    int wpm = args[0].toInt();
+    int wpm = 0;
+    if (!argToInt(args, 0, wpm)) return {};
     if (wpm < 5 || wpm > 100) return {};
     QString cmd = QStringLiteral("cw wpm %1").arg(wpm);
     QMetaObject::invokeMethod(m_model, [model = m_model, cmd]() {
@@ -1042,7 +1103,8 @@ QString TciProtocol::cmdCwMsg(const QStringList& args)
 QString TciProtocol::cmdLock(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -1066,7 +1128,8 @@ QString TciProtocol::cmdLock(const QStringList& args, bool isSet)
 QString TciProtocol::cmdSqlEnable(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -1090,7 +1153,8 @@ QString TciProtocol::cmdSqlEnable(const QStringList& args, bool isSet)
 QString TciProtocol::cmdSqlLevel(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -1100,7 +1164,8 @@ QString TciProtocol::cmdSqlLevel(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 2) return {};
-    int level = args[1].toInt();
+    int level = 0;
+    if (!argToInt(args, 1, level)) return {};
     bool on = s->receiveSquelchOn();
     QMetaObject::invokeMethod(s, [s, on, level]() { s->setSquelch(on, level); },
                               Qt::QueuedConnection);
@@ -1184,18 +1249,12 @@ QString TciProtocol::cmdVolume(const QStringList& args, bool /*isSet*/)
     // commands; this also catches the same shape for the legacy 2-arg form
     // (e.g. "volume:0,").
     //
-    // std::isfinite is part of the same check, not a separate paranoia: Qt's
-    // toDouble() accepts the literals "inf"/"-inf"/"nan" and reports ok, so
-    // they reach the arithmetic below with the ok flag satisfied. "inf" takes
-    // the val >= 1.0 percent branch, std::lround(+inf) is out of long's range
-    // (unspecified), and the narrowing cast lands on 0 — i.e. "volume:inf"
-    // would MUTE the radio and broadcast a well-formed "volume:-60;", the
-    // same undetectable-from-the-wire failure as the empty-argument case, at
-    // the other end of the range. ("1e400" is already rejected: overflow
-    // clears ok, unlike the literal spellings.)
-    bool volOk = false;
-    const double val = args[args.size() == 1 ? 0 : 1].toDouble(&volOk);
-    if (!volOk || !std::isfinite(val)) {
+    // argToDouble rejects the empty string AND the non-finite literals
+    // ("inf"/"nan", which Qt parses and reports ok for) — see its definition
+    // for why the second half is not optional. The percent branch below is
+    // deliberately NOT tightened: it is what three bundled plugins send.
+    double val = 0.0;
+    if (!argToDouble(args, args.size() == 1 ? 0 : 1, val)) {
         return {};
     }
     const int pct = (val >= 1.0)
@@ -1213,8 +1272,8 @@ QString TciProtocol::cmdVolume(const QStringList& args, bool /*isSet*/)
 QString TciProtocol::cmdMute(const QStringList& args, bool isSet)
 {
     if (!isSet) {
-        if (!args.isEmpty()) {
-            int trx = args[0].toInt();
+        int trx = 0;
+        if (argToInt(args, 0, trx)) {
             auto* s = sliceForTrx(trx);
             if (s) return QStringLiteral("mute:%1,%2;")
                               .arg(trx).arg(s->audioMute() ? "true" : "false");
@@ -1223,7 +1282,8 @@ QString TciProtocol::cmdMute(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 2) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     bool mute = (args[1].toLower() == "true");
     auto* s = sliceForTrx(trx);
     if (s) {
@@ -1241,7 +1301,8 @@ QString TciProtocol::cmdMute(const QStringList& args, bool isSet)
 QString TciProtocol::cmdAgcMode(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -1264,7 +1325,8 @@ QString TciProtocol::cmdAgcMode(const QStringList& args, bool isSet)
 QString TciProtocol::cmdAgcGain(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -1274,7 +1336,8 @@ QString TciProtocol::cmdAgcGain(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 2) return {};
-    int gain = args[1].toInt();
+    int gain = 0;
+    if (!argToInt(args, 1, gain)) return {};
     QMetaObject::invokeMethod(s, [s, gain]() { s->setAgcThreshold(gain); },
                               Qt::QueuedConnection);
 
@@ -1288,7 +1351,8 @@ QString TciProtocol::cmdAgcGain(const QStringList& args, bool isSet)
 QString TciProtocol::cmdRxNbEnable(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -1310,7 +1374,8 @@ QString TciProtocol::cmdRxNbEnable(const QStringList& args, bool isSet)
 QString TciProtocol::cmdRxNrEnable(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -1332,7 +1397,8 @@ QString TciProtocol::cmdRxNrEnable(const QStringList& args, bool isSet)
 QString TciProtocol::cmdRxAnfEnable(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -1354,7 +1420,8 @@ QString TciProtocol::cmdRxAnfEnable(const QStringList& args, bool isSet)
 QString TciProtocol::cmdRxApfEnable(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -1378,7 +1445,8 @@ QString TciProtocol::cmdRxApfEnable(const QStringList& args, bool isSet)
 QString TciProtocol::cmdRxRecord(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -1400,7 +1468,8 @@ QString TciProtocol::cmdRxRecord(const QStringList& args, bool isSet)
 QString TciProtocol::cmdRxPlay(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -1428,9 +1497,8 @@ QString TciProtocol::cmdSpot(const QStringList& args)
 
     QString callsign = args[0].trimmed();
     QString mode = args[1].trimmed();
-    bool ok;
-    double freqHz = args[2].toDouble(&ok);
-    if (!ok || callsign.isEmpty()) return {};
+    double freqHz = 0.0;
+    if (!argToDouble(args, 2, freqHz) || callsign.isEmpty()) return {};
 
     QString color = (args.size() > 3) ? args[3].trimmed() : QString();
     QString comment = (args.size() > 4) ? args[4].trimmed() : QString();
@@ -1456,9 +1524,8 @@ QString TciProtocol::cmdSpotDelete(const QStringList& args)
 {
     if (!m_model || args.size() < 2) return {};
     QString callsign = args[0].trimmed();
-    bool ok;
-    double freqHz = args[1].toDouble(&ok);
-    if (!ok) return {};
+    double freqHz = 0.0;
+    if (!argToDouble(args, 1, freqHz)) return {};
     double freqMhz = freqHz / 1e6;
 
     QMetaObject::invokeMethod(m_model, [model = m_model, callsign, freqMhz]() {
@@ -1518,7 +1585,8 @@ QString TciProtocol::cmdCwMacrosStop()
 QString TciProtocol::cmdIqStart(const QStringList& args)
 {
     if (!m_model || args.isEmpty()) return {};
-    const int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     const int channel = trx + 1;  // TRX 0 → DAX IQ channel 1
     if (channel < 1 || channel > 4) return {};
     // Creating the dax_iq stream is not enough to make IQ flow: on FlexRadio
@@ -1543,7 +1611,9 @@ QString TciProtocol::cmdIqStart(const QStringList& args)
 QString TciProtocol::cmdIqStop(const QStringList& args)
 {
     if (!m_model || args.isEmpty()) return {};
-    int channel = args[0].toInt() + 1;
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
+    const int channel = trx + 1;
     if (channel < 1 || channel > 4) return {};
     QMetaObject::invokeMethod(m_model, [model = m_model, channel]() {
         model->daxIqModel().removeStream(channel);
@@ -1562,8 +1632,16 @@ QString TciProtocol::cmdIqSampleRate(const QStringList& args, bool isSet)
     }
 
     if (args.isEmpty()) return {};
-    const int rate = args[0].toInt();
-    if (rate != 24000 && rate != 48000 && rate != 96000 && rate != 192000) {
+    // Deliberately NOT the drop-on-unparseable posture the rest of this file
+    // uses: an unparseable rate joins the unsupported-rate branch below rather
+    // than returning {}. #3913 made this command reply to a rejection on
+    // purpose, because a skimmer (CW Skimmer / SDC) blocks waiting for the
+    // confirmation and silence would hang it. Rejecting is still rejecting —
+    // it just says so out loud, which is strictly better than dropping here.
+    int rate = 0;
+    const bool rateParsed = argToInt(args, 0, rate);
+    if (!rateParsed
+        || (rate != 24000 && rate != 48000 && rate != 96000 && rate != 192000)) {
         // Reject without hanging the requester: report the rate that remains
         // in force. No pending notification is set because other clients saw
         // no state change (#3913 review).
@@ -1608,7 +1686,8 @@ QString TciProtocol::cmdCwKeyerSpeed(const QStringList& args, bool isSet)
         return QStringLiteral("cw_keyer_speed:%1;").arg(wpm);
     }
     if (args.isEmpty()) return {};
-    int wpm = args[0].toInt();
+    int wpm = 0;
+    if (!argToInt(args, 0, wpm)) return {};
     if (wpm < 5 || wpm > 100) return {};
     QString cmd = QStringLiteral("cw wpm %1").arg(wpm);
     QMetaObject::invokeMethod(m_model, [model = m_model, cmd]() {
@@ -1625,7 +1704,7 @@ QString TciProtocol::cmdCwMacrosDelay(const QStringList& args, bool isSet)
     if (!isSet)
         return QStringLiteral("cw_macros_delay:%1;").arg(delay);
     if (args.isEmpty()) return {};
-    delay = args[0].toInt();
+    if (!argToInt(args, 0, delay)) return {};
     if (m_model) {
         QString cmd = QStringLiteral("cw delay %1").arg(delay);
         QMetaObject::invokeMethod(m_model, [model = m_model, cmd]() {
@@ -1652,7 +1731,8 @@ QString TciProtocol::cmdDds(const QStringList& args, bool isSet)
 {
     // DDS = center frequency of the receiver (panadapter center, not the VFO).
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -1669,7 +1749,8 @@ QString TciProtocol::cmdIf(const QStringList& args, bool isSet)
 {
     // IF offset — RIT equivalent in TCI
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -1679,8 +1760,9 @@ QString TciProtocol::cmdIf(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 3) return {};
-    int offset = args[2].toInt();
-    bool on = (offset != 0);
+    int offset = 0;
+    if (!argToInt(args, 2, offset)) return {};
+    const bool on = (offset != 0);
     QMetaObject::invokeMethod(s, [s, on, offset]() { s->setRit(on, offset); },
                               Qt::QueuedConnection);
     return {};
@@ -1691,7 +1773,8 @@ QString TciProtocol::cmdIf(const QStringList& args, bool isSet)
 QString TciProtocol::cmdRxChannelEnable(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     if (!isSet)
         return QStringLiteral("rx_channel_enable:%1,true;").arg(trx);
     // Always enabled — FlexRadio slices are always active
@@ -1702,7 +1785,8 @@ QString TciProtocol::cmdRxVolume(const QStringList& args, bool isSet)
 {
     // Per-receiver volume — maps to slice audioGain
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -1712,7 +1796,9 @@ QString TciProtocol::cmdRxVolume(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 2) return {};
-    float gain = static_cast<float>(args[1].toInt());
+    int gainPct = 0;
+    if (!argToInt(args, 1, gainPct)) return {};
+    const float gain = static_cast<float>(gainPct);
     QMetaObject::invokeMethod(s, [s, gain]() { s->setAudioGain(gain); },
                               Qt::QueuedConnection);
     m_pendingNotification = QStringLiteral("rx_volume:%1,%2;")
@@ -1723,7 +1809,8 @@ QString TciProtocol::cmdRxVolume(const QStringList& args, bool isSet)
 QString TciProtocol::cmdRxMute(const QStringList& args, bool isSet)
 {
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -1745,7 +1832,8 @@ QString TciProtocol::cmdRxBalance(const QStringList& args, bool isSet)
 {
     // RX audio balance — maps to slice audioPan (0=left, 50=center, 100=right)
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -1757,7 +1845,8 @@ QString TciProtocol::cmdRxBalance(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 2) return {};
-    int tciBalance = args[1].toInt();  // -40 to +40
+    int tciBalance = 0;  // -40 to +40
+    if (!argToInt(args, 1, tciBalance)) return {};
     int flexPan = qBound(0, tciBalance + 50, 100);
     QMetaObject::invokeMethod(s, [s, flexPan]() { s->setAudioPan(flexPan); },
                               Qt::QueuedConnection);
@@ -1793,7 +1882,8 @@ QString TciProtocol::cmdMonVolume(const QStringList& args, bool isSet)
                    .arg(m_model->transmitModel().monGainSb());
     }
     if (args.isEmpty()) return {};
-    int vol = args[0].toInt();
+    int vol = 0;
+    if (!argToInt(args, 0, vol)) return {};
     QMetaObject::invokeMethod(m_model, [model = m_model, vol]() {
         model->transmitModel().setMonGainSb(vol);
     }, Qt::QueuedConnection);
@@ -1807,7 +1897,8 @@ QString TciProtocol::cmdRxNbParam(const QStringList& args, bool isSet)
 {
     // NB parameter — maps to slice nbLevel (0–100)
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     auto* s = sliceForTrx(trx);
     if (!s) return {};
 
@@ -1817,7 +1908,8 @@ QString TciProtocol::cmdRxNbParam(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 3) return {};
-    int level = args[2].toInt();
+    int level = 0;
+    if (!argToInt(args, 2, level)) return {};
     QMetaObject::invokeMethod(s, [s, level]() { s->setNbLevel(level); },
                               Qt::QueuedConnection);
     m_pendingNotification = QStringLiteral("rx_nb_param:%1,0,%2;")
@@ -1830,7 +1922,8 @@ QString TciProtocol::cmdRxBinEnable(const QStringList& args, bool isSet)
     // Binaural — no direct FlexRadio equivalent, acknowledge only
     static bool binEnabled = false;
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     if (!isSet)
         return QStringLiteral("rx_bin_enable:%1,%2;")
                    .arg(trx).arg(binEnabled ? "true" : "false");
@@ -1844,7 +1937,8 @@ QString TciProtocol::cmdRxAncEnable(const QStringList& args, bool isSet)
     // Adaptive Noise Cancellation — no direct FlexRadio equivalent
     static bool ancEnabled = false;
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     if (!isSet)
         return QStringLiteral("rx_anc_enable:%1,%2;")
                    .arg(trx).arg(ancEnabled ? "true" : "false");
@@ -1858,7 +1952,8 @@ QString TciProtocol::cmdRxDseEnable(const QStringList& args, bool isSet)
     // Digital Surround Effect — no direct FlexRadio equivalent
     static bool dseEnabled = false;
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     if (!isSet)
         return QStringLiteral("rx_dse_enable:%1,%2;")
                    .arg(trx).arg(dseEnabled ? "true" : "false");
@@ -1874,7 +1969,8 @@ QString TciProtocol::cmdRxNfEnable(const QStringList& args, bool isSet)
     // same way)
     static bool nfEnabled = true;
     if (args.isEmpty()) return {};
-    int trx = args[0].toInt();
+    int trx = 0;
+    if (!argToInt(args, 0, trx)) return {};
     if (!isSet)
         return QStringLiteral("rx_nf_enable:%1,%2;")
                    .arg(trx).arg(nfEnabled ? "true" : "false");
@@ -1895,7 +1991,8 @@ QString TciProtocol::cmdDiglOffset(const QStringList& args, bool isSet)
         return QStringLiteral("digl_offset:%1;").arg(s->diglOffset());
 
     if (args.isEmpty()) return {};
-    int hz = args[0].toInt();
+    int hz = 0;
+    if (!argToInt(args, 0, hz)) return {};
     QMetaObject::invokeMethod(s, [s, hz]() { s->setDiglOffset(hz); },
                               Qt::QueuedConnection);
     m_pendingNotification = QStringLiteral("digl_offset:%1;").arg(hz);
@@ -1912,7 +2009,8 @@ QString TciProtocol::cmdDiguOffset(const QStringList& args, bool isSet)
         return QStringLiteral("digu_offset:%1;").arg(s->diguOffset());
 
     if (args.isEmpty()) return {};
-    int hz = args[0].toInt();
+    int hz = 0;
+    if (!argToInt(args, 0, hz)) return {};
     QMetaObject::invokeMethod(s, [s, hz]() { s->setDiguOffset(hz); },
                               Qt::QueuedConnection);
     m_pendingNotification = QStringLiteral("digu_offset:%1;").arg(hz);

--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -1057,16 +1057,25 @@ QString TciProtocol::cmdRxFilterBand(const QStringList& args, bool isSet)
 
 // ── CW ─────────────────────────────────────────────────────────────────────
 
-QString TciProtocol::cmdCwMacrosSpeed(const QStringList& args, bool isSet)
+// GLOBAL commands (no trx) re-derive GET/SET from the argument list rather
+// than trusting the dispatcher's `isSet`, and read the value from the last
+// argument. handleCommand() computes `isSet = (args.size() >= 2)` from the
+// trx-prefixed shape every per-slice verb uses, which is wrong for a global
+// one: it makes the spec form `cw_macros_speed:25;` a READ that silently
+// discards the value, and leaves the 2-arg form reading the trx position as
+// the value (`cw_macros_speed:0,25;` set the speed to 0). cmdVolume,
+// cmdMicLevel and cmdTxGain already do it this way — these four verbs were
+// simply missed. Found while adding #4867's tests; no bundled plugin sends
+// any of them, so nothing shipped depended on the broken shape.
+QString TciProtocol::cmdCwMacrosSpeed(const QStringList& args, bool /*isSet*/)
 {
-    if (!isSet) {
+    if (args.isEmpty()) {
         int wpm = m_model ? m_model->transmitModel().cwSpeed() : 25;
         return QStringLiteral("cw_macros_speed:%1;").arg(wpm);
     }
 
-    if (args.isEmpty()) return {};
     int wpm = 0;
-    if (!argToInt(args, 0, wpm)) return {};
+    if (!argToInt(args, args.size() == 1 ? 0 : 1, wpm)) return {};
     if (wpm < 5 || wpm > 100) return {};
     QString cmd = QStringLiteral("cw wpm %1").arg(wpm);
     QMetaObject::invokeMethod(m_model, [model = m_model, cmd]() {
@@ -1679,15 +1688,15 @@ QString TciProtocol::cmdKeyer(const QStringList& args)
     return {};
 }
 
-QString TciProtocol::cmdCwKeyerSpeed(const QStringList& args, bool isSet)
+// Global command — see the note above cmdCwMacrosSpeed.
+QString TciProtocol::cmdCwKeyerSpeed(const QStringList& args, bool /*isSet*/)
 {
-    if (!isSet) {
+    if (args.isEmpty()) {
         int wpm = m_model ? m_model->transmitModel().cwSpeed() : 20;
         return QStringLiteral("cw_keyer_speed:%1;").arg(wpm);
     }
-    if (args.isEmpty()) return {};
     int wpm = 0;
-    if (!argToInt(args, 0, wpm)) return {};
+    if (!argToInt(args, args.size() == 1 ? 0 : 1, wpm)) return {};
     if (wpm < 5 || wpm > 100) return {};
     QString cmd = QStringLiteral("cw wpm %1").arg(wpm);
     QMetaObject::invokeMethod(m_model, [model = m_model, cmd]() {
@@ -1697,14 +1706,14 @@ QString TciProtocol::cmdCwKeyerSpeed(const QStringList& args, bool isSet)
     return {};
 }
 
-QString TciProtocol::cmdCwMacrosDelay(const QStringList& args, bool isSet)
+// Global command — see the note above cmdCwMacrosSpeed.
+QString TciProtocol::cmdCwMacrosDelay(const QStringList& args, bool /*isSet*/)
 {
     // Delay before CW TX starts (ms). FlexRadio has cw_delay.
     static int delay = 0;
-    if (!isSet)
+    if (args.isEmpty())
         return QStringLiteral("cw_macros_delay:%1;").arg(delay);
-    if (args.isEmpty()) return {};
-    if (!argToInt(args, 0, delay)) return {};
+    if (!argToInt(args, args.size() == 1 ? 0 : 1, delay)) return {};
     if (m_model) {
         QString cmd = QStringLiteral("cw delay %1").arg(delay);
         QMetaObject::invokeMethod(m_model, [model = m_model, cmd]() {
@@ -1874,16 +1883,16 @@ QString TciProtocol::cmdMonEnable(const QStringList& args, bool isSet)
     return {};
 }
 
-QString TciProtocol::cmdMonVolume(const QStringList& args, bool isSet)
+// Global command — see the note above cmdCwMacrosSpeed.
+QString TciProtocol::cmdMonVolume(const QStringList& args, bool /*isSet*/)
 {
     if (!m_model) return {};
-    if (!isSet) {
+    if (args.isEmpty()) {
         return QStringLiteral("mon_volume:%1;")
                    .arg(m_model->transmitModel().monGainSb());
     }
-    if (args.isEmpty()) return {};
     int vol = 0;
-    if (!argToInt(args, 0, vol)) return {};
+    if (!argToInt(args, args.size() == 1 ? 0 : 1, vol)) return {};
     QMetaObject::invokeMethod(m_model, [model = m_model, vol]() {
         model->transmitModel().setMonGainSb(vol);
     }, Qt::QueuedConnection);

--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -130,6 +130,12 @@ QString TciProtocol::tciToSmartSDR(const QString& mode, bool* ok)
 // and the deliberately lenient forms (cmdVolume's non-spec percent branch,
 // which three bundled plugins depend on) are the caller's business and are
 // unchanged.
+//
+// Base 10 only, and it must stay that way. QString::toInt()'s base argument
+// defaults to 10, which is the only reason "0x1" is rejected rather than
+// resolving to slice 1 — pass 0 here for "helpful" auto-base detection and
+// `mute:0x1,false` silently starts landing on a slice the client never named.
+// The test asserts the hex case; this sentence is why the assertion holds.
 static bool argToInt(const QStringList& args, int idx, int& out)
 {
     if (idx < 0 || idx >= args.size()) return false;
@@ -138,6 +144,32 @@ static bool argToInt(const QStringList& args, int idx, int& out)
     if (!ok) return false;
     out = parsed;
     return true;
+}
+
+// Booleans are the same defect with a different literal, and there are 20 of
+// them: `args[1].toLower() == "true"` turns *everything that is not the word
+// "true"* into false, so `mute:0,yes` UNMUTED slice 0 and broadcast a
+// well-formed "mute:0,false;" — #4867's signature exactly, with no number
+// involved. TCI spells booleans "true"/"false"; this accepts those two
+// (case-insensitively, as the old expression did) and reports failure for
+// anything else so the caller can drop the command. Every bundled plugin
+// sends Python's `str(bool).lower()` or JS's `${bool}`, i.e. exactly these
+// two spellings, so nothing shipped is affected.
+//
+// DELIBERATELY NOT used by the two verbs that key the transmitter. `cmdTune`
+// and `cmdKeyer` must fail CLOSED rather than fail silent: dropping an
+// unparseable `tune:0,<junk>` would leave a tuning carrier up, and dropping
+// `keyer:0,<junk>` would leave the key down. For those two, "not the word
+// true" continuing to mean *stop* is the safe reading, and Constitution VI
+// makes it the required one. They keep the bare comparison, with a comment
+// at each site saying so.
+static bool argToBool(const QStringList& args, int idx, bool& out)
+{
+    if (idx < 0 || idx >= args.size()) return false;
+    const QString v = args[idx].trimmed().toLower();
+    if (v == QLatin1String("true"))  { out = true;  return true; }
+    if (v == QLatin1String("false")) { out = false; return true; }
+    return false;
 }
 
 static bool argToLongLong(const QStringList& args, int idx, long long& out)
@@ -756,7 +788,12 @@ QString TciProtocol::cmdTune(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 2) return {};
-    bool tune = (args[1].toLower() == "true");
+    // Deliberately NOT argToBool, and deliberately not the drop posture the
+    // rest of this file uses: this verb keys the transmitter. Dropping an
+    // unparseable `tune:0,<junk>` would leave a tuning carrier on the air,
+    // so "anything that is not the word true" has to keep meaning STOP.
+    // Fail closed, not silent — Constitution VI. (#4867 review)
+    const bool tune = (args[1].trimmed().toLower() == QLatin1String("true"));
     QMetaObject::invokeMethod(m_model, [model = m_model, tune]() {
         if (tune)
             model->transmitModel().startTune(TransmitModel::PttSource::Dax);
@@ -845,6 +882,7 @@ QString TciProtocol::cmdMicLevel(const QStringList& args, bool /*isSet*/)
         int lvl = m_model ? m_model->transmitModel().micLevel() : 0;
         return QStringLiteral("mic_level:%1;").arg(lvl);
     }
+    if (!m_model) return {};
     int lvl = 0;
     if (!argToInt(args, args.size() == 1 ? 0 : 1, lvl)) return {};
     QMetaObject::invokeMethod(m_model, [model = m_model, lvl]() {
@@ -906,7 +944,8 @@ QString TciProtocol::cmdRitEnable(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 2) return {};
-    bool on = (args[1].toLower() == "true");
+    bool on = false;
+    if (!argToBool(args, 1, on)) return {};
     int hz = s->ritFreq();
     QMetaObject::invokeMethod(s, [s, on, hz]() { s->setRit(on, hz); },
                               Qt::QueuedConnection);
@@ -958,7 +997,8 @@ QString TciProtocol::cmdXitEnable(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 2) return {};
-    bool on = (args[1].toLower() == "true");
+    bool on = false;
+    if (!argToBool(args, 1, on)) return {};
     int hz = s->xitFreq();
     QMetaObject::invokeMethod(s, [s, on, hz]() { s->setXit(on, hz); },
                               Qt::QueuedConnection);
@@ -1074,6 +1114,7 @@ QString TciProtocol::cmdCwMacrosSpeed(const QStringList& args, bool /*isSet*/)
         return QStringLiteral("cw_macros_speed:%1;").arg(wpm);
     }
 
+    if (!m_model) return {};
     int wpm = 0;
     if (!argToInt(args, args.size() == 1 ? 0 : 1, wpm)) return {};
     if (wpm < 5 || wpm > 100) return {};
@@ -1123,7 +1164,8 @@ QString TciProtocol::cmdLock(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 2) return {};
-    bool on = (args[1].toLower() == "true");
+    bool on = false;
+    if (!argToBool(args, 1, on)) return {};
     QMetaObject::invokeMethod(s, [s, on]() { s->setLocked(on); },
                               Qt::QueuedConnection);
 
@@ -1149,7 +1191,8 @@ QString TciProtocol::cmdSqlEnable(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 2) return {};
-    bool on = (args[1].toLower() == "true");
+    bool on = false;
+    if (!argToBool(args, 1, on)) return {};
     int level = s->receiveSquelchLevel();
     QMetaObject::invokeMethod(s, [s, on, level]() { s->setSquelch(on, level); },
                               Qt::QueuedConnection);
@@ -1293,7 +1336,8 @@ QString TciProtocol::cmdMute(const QStringList& args, bool isSet)
     if (args.size() < 2) return {};
     int trx = 0;
     if (!argToInt(args, 0, trx)) return {};
-    bool mute = (args[1].toLower() == "true");
+    bool mute = false;
+    if (!argToBool(args, 1, mute)) return {};
     auto* s = sliceForTrx(trx);
     if (s) {
         QMetaObject::invokeMethod(s, [s, mute]() { s->setAudioMute(mute); },
@@ -1371,7 +1415,8 @@ QString TciProtocol::cmdRxNbEnable(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 2) return {};
-    bool on = (args[1].toLower() == "true");
+    bool on = false;
+    if (!argToBool(args, 1, on)) return {};
     QMetaObject::invokeMethod(s, [s, on]() { s->setNb(on); },
                               Qt::QueuedConnection);
 
@@ -1394,7 +1439,8 @@ QString TciProtocol::cmdRxNrEnable(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 2) return {};
-    bool on = (args[1].toLower() == "true");
+    bool on = false;
+    if (!argToBool(args, 1, on)) return {};
     QMetaObject::invokeMethod(s, [s, on]() { s->setNr(on); },
                               Qt::QueuedConnection);
 
@@ -1417,7 +1463,8 @@ QString TciProtocol::cmdRxAnfEnable(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 2) return {};
-    bool on = (args[1].toLower() == "true");
+    bool on = false;
+    if (!argToBool(args, 1, on)) return {};
     QMetaObject::invokeMethod(s, [s, on]() { s->setAnf(on); },
                               Qt::QueuedConnection);
 
@@ -1440,7 +1487,8 @@ QString TciProtocol::cmdRxApfEnable(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 2) return {};
-    bool on = (args[1].toLower() == "true");
+    bool on = false;
+    if (!argToBool(args, 1, on)) return {};
     QMetaObject::invokeMethod(s, [s, on]() { s->setApf(on); },
                               Qt::QueuedConnection);
 
@@ -1465,7 +1513,8 @@ QString TciProtocol::cmdRxRecord(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 2) return {};
-    bool on = (args[1].toLower() == "true");
+    bool on = false;
+    if (!argToBool(args, 1, on)) return {};
     QMetaObject::invokeMethod(s, [s, on]() { s->setRecordOn(on); },
                               Qt::QueuedConnection);
 
@@ -1488,7 +1537,8 @@ QString TciProtocol::cmdRxPlay(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 2) return {};
-    bool on = (args[1].toLower() == "true");
+    bool on = false;
+    if (!argToBool(args, 1, on)) return {};
     QMetaObject::invokeMethod(s, [s, on]() { s->setPlayOn(on); },
                               Qt::QueuedConnection);
 
@@ -1594,10 +1644,21 @@ QString TciProtocol::cmdCwMacrosStop()
 QString TciProtocol::cmdIqStart(const QStringList& args)
 {
     if (!m_model || args.isEmpty()) return {};
+    // Bound the index BEFORE the arithmetic: argToInt accepts INT_MAX (it
+    // parses cleanly — it is "99999999999" that clears ok), and `trx + 1`
+    // would then be signed overflow, i.e. UB reachable from any TCI client on
+    // the one PR whose whole subject is boundary validation. Checking the
+    // index rather than the result also subsumes the old channel range test.
+    //
+    // No observable behaviour changes: DaxIqModel::createStream() already
+    // rejects an out-of-range channel, so this is strictly about keeping the
+    // arithmetic defined for the weekly UBSan job. There is deliberately no
+    // test asserting the rejection — there would be nothing to observe — only
+    // a positive control that an in-range index still creates its stream.
     int trx = 0;
     if (!argToInt(args, 0, trx)) return {};
+    if (trx < 0 || trx > 3) return {};       // DAX IQ channels are 1-4
     const int channel = trx + 1;  // TRX 0 → DAX IQ channel 1
-    if (channel < 1 || channel > 4) return {};
     // Creating the dax_iq stream is not enough to make IQ flow: on FlexRadio
     // `daxiq_channel` is a Panadapter property, so the radio streams nothing
     // (or a stale pan's IQ) until a panadapter is routed to this channel with
@@ -1620,10 +1681,11 @@ QString TciProtocol::cmdIqStart(const QStringList& args)
 QString TciProtocol::cmdIqStop(const QStringList& args)
 {
     if (!m_model || args.isEmpty()) return {};
+    // Bounded before the addition, same as cmdIqStart above.
     int trx = 0;
     if (!argToInt(args, 0, trx)) return {};
+    if (trx < 0 || trx > 3) return {};       // DAX IQ channels are 1-4
     const int channel = trx + 1;
-    if (channel < 1 || channel > 4) return {};
     QMetaObject::invokeMethod(m_model, [model = m_model, channel]() {
         model->daxIqModel().removeStream(channel);
     }, Qt::QueuedConnection);
@@ -1681,7 +1743,9 @@ QString TciProtocol::cmdKeyer(const QStringList& args)
     // keyer:trx,state[,duration_ms]
     // state: true=key down, false=key up
     if (!m_model || args.size() < 2) return {};
-    bool down = (args[1].toLower() == "true");
+    // Same fail-closed exemption as cmdTune: an unparseable state must mean
+    // KEY UP, never "ignore and leave the key down" (Constitution VI).
+    const bool down = (args[1].trimmed().toLower() == QLatin1String("true"));
     QMetaObject::invokeMethod(m_model, [model = m_model, down]() {
         model->sendCwKey(down);
     }, Qt::QueuedConnection);
@@ -1695,6 +1759,7 @@ QString TciProtocol::cmdCwKeyerSpeed(const QStringList& args, bool /*isSet*/)
         int wpm = m_model ? m_model->transmitModel().cwSpeed() : 20;
         return QStringLiteral("cw_keyer_speed:%1;").arg(wpm);
     }
+    if (!m_model) return {};
     int wpm = 0;
     if (!argToInt(args, args.size() == 1 ? 0 : 1, wpm)) return {};
     if (wpm < 5 || wpm > 100) return {};
@@ -1724,13 +1789,15 @@ QString TciProtocol::cmdCwMacrosDelay(const QStringList& args, bool /*isSet*/)
     return {};
 }
 
-QString TciProtocol::cmdCwTerminal(const QStringList& args, bool isSet)
+// Global command — see the note above cmdMonEnable. Same boolean shape.
+QString TciProtocol::cmdCwTerminal(const QStringList& args, bool /*isSet*/)
 {
     static bool terminal = false;
-    if (!isSet)
+    if (args.isEmpty())
         return QStringLiteral("cw_terminal:%1;").arg(terminal ? "true" : "false");
-    if (!args.isEmpty())
-        terminal = (args[0].toLower() == "true");
+    // argToBool leaves `terminal` untouched when the argument is unparseable,
+    // so a dropped SET keeps the last good value rather than resetting it.
+    if (!argToBool(args, args.size() == 1 ? 0 : 1, terminal)) return {};
     return {};
 }
 
@@ -1829,7 +1896,8 @@ QString TciProtocol::cmdRxMute(const QStringList& args, bool isSet)
     }
 
     if (args.size() < 2) return {};
-    bool mute = (args[1].toLower() == "true");
+    bool mute = false;
+    if (!argToBool(args, 1, mute)) return {};
     QMetaObject::invokeMethod(s, [s, mute]() { s->setAudioMute(mute); },
                               Qt::QueuedConnection);
     m_pendingNotification = QStringLiteral("rx_mute:%1,%2;")
@@ -1866,15 +1934,20 @@ QString TciProtocol::cmdRxBalance(const QStringList& args, bool isSet)
 
 // ── Monitor ────────────────────────────────────────────────────────────────
 
-QString TciProtocol::cmdMonEnable(const QStringList& args, bool isSet)
+// Global command — see the note above cmdCwMacrosSpeed. This is the boolean
+// half of the same defect: `mon_enable:true;` is one argument, so the
+// trx-shaped `isSet` read it as a GET and the enable was silently discarded,
+// while `mon_enable:0,true;` took the SET branch and read args[0] — the trx
+// slot, "0" — as the state, so it DISABLED the monitor.
+QString TciProtocol::cmdMonEnable(const QStringList& args, bool /*isSet*/)
 {
     if (!m_model) return {};
-    if (!isSet) {
+    if (args.isEmpty()) {
         return QStringLiteral("mon_enable:%1;")
                    .arg(m_model->transmitModel().sbMonitor() ? "true" : "false");
     }
-    if (args.isEmpty()) return {};
-    bool on = (args[0].toLower() == "true");
+    bool on = false;
+    if (!argToBool(args, args.size() == 1 ? 0 : 1, on)) return {};
     QMetaObject::invokeMethod(m_model, [model = m_model, on]() {
         model->transmitModel().setSbMonitor(on);
     }, Qt::QueuedConnection);
@@ -1937,7 +2010,7 @@ QString TciProtocol::cmdRxBinEnable(const QStringList& args, bool isSet)
         return QStringLiteral("rx_bin_enable:%1,%2;")
                    .arg(trx).arg(binEnabled ? "true" : "false");
     if (args.size() < 2) return {};
-    binEnabled = (args[1].toLower() == "true");
+    if (!argToBool(args, 1, binEnabled)) return {};
     return {};
 }
 
@@ -1952,7 +2025,7 @@ QString TciProtocol::cmdRxAncEnable(const QStringList& args, bool isSet)
         return QStringLiteral("rx_anc_enable:%1,%2;")
                    .arg(trx).arg(ancEnabled ? "true" : "false");
     if (args.size() < 2) return {};
-    ancEnabled = (args[1].toLower() == "true");
+    if (!argToBool(args, 1, ancEnabled)) return {};
     return {};
 }
 
@@ -1967,7 +2040,7 @@ QString TciProtocol::cmdRxDseEnable(const QStringList& args, bool isSet)
         return QStringLiteral("rx_dse_enable:%1,%2;")
                    .arg(trx).arg(dseEnabled ? "true" : "false");
     if (args.size() < 2) return {};
-    dseEnabled = (args[1].toLower() == "true");
+    if (!argToBool(args, 1, dseEnabled)) return {};
     return {};
 }
 
@@ -1984,42 +2057,47 @@ QString TciProtocol::cmdRxNfEnable(const QStringList& args, bool isSet)
         return QStringLiteral("rx_nf_enable:%1,%2;")
                    .arg(trx).arg(nfEnabled ? "true" : "false");
     if (args.size() < 2) return {};
-    nfEnabled = (args[1].toLower() == "true");
+    if (!argToBool(args, 1, nfEnabled)) return {};
     return {};
 }
 
 // ── Digital mode offsets ───────────────────────────────────────────────────
 
-QString TciProtocol::cmdDiglOffset(const QStringList& args, bool isSet)
+// Global command — see the note above cmdCwMacrosSpeed. digl_offset takes no
+// trx (it hardcodes sliceForTrx(0)), so the dispatcher's trx-shaped `isSet`
+// was wrong in both directions here too: `digl_offset:500;` read as a GET and
+// discarded the 500, and `digl_offset:0,500;` set the offset to the trx slot
+// and broadcast "digl_offset:0;". Fifth and sixth instances of the same
+// defect, found in the #4867 review.
+QString TciProtocol::cmdDiglOffset(const QStringList& args, bool /*isSet*/)
 {
     if (!m_model) return {};
     auto* s = sliceForTrx(0);
     if (!s) return {};
 
-    if (!isSet)
+    if (args.isEmpty())
         return QStringLiteral("digl_offset:%1;").arg(s->diglOffset());
 
-    if (args.isEmpty()) return {};
     int hz = 0;
-    if (!argToInt(args, 0, hz)) return {};
+    if (!argToInt(args, args.size() == 1 ? 0 : 1, hz)) return {};
     QMetaObject::invokeMethod(s, [s, hz]() { s->setDiglOffset(hz); },
                               Qt::QueuedConnection);
     m_pendingNotification = QStringLiteral("digl_offset:%1;").arg(hz);
     return {};
 }
 
-QString TciProtocol::cmdDiguOffset(const QStringList& args, bool isSet)
+// Global command — see the note above cmdDiglOffset.
+QString TciProtocol::cmdDiguOffset(const QStringList& args, bool /*isSet*/)
 {
     if (!m_model) return {};
     auto* s = sliceForTrx(0);
     if (!s) return {};
 
-    if (!isSet)
+    if (args.isEmpty())
         return QStringLiteral("digu_offset:%1;").arg(s->diguOffset());
 
-    if (args.isEmpty()) return {};
     int hz = 0;
-    if (!argToInt(args, 0, hz)) return {};
+    if (!argToInt(args, args.size() == 1 ? 0 : 1, hz)) return {};
     QMetaObject::invokeMethod(s, [s, hz]() { s->setDiguOffset(hz); },
                               Qt::QueuedConnection);
     m_pendingNotification = QStringLiteral("digu_offset:%1;").arg(hz);

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -1049,10 +1049,25 @@ void TciServer::onTextMessage(const QString& msg)
             continue;
         }
 
-        // IQ start/stop — track per-client IQ state, then forward to protocol
+        // IQ start/stop — track per-client IQ state, then forward to protocol.
+        //
+        // The trx is parsed with the ok flag checked for the same reason
+        // TciProtocol's argToInt exists (#4867): an unchecked toInt() turns
+        // `iq_start:abc;` into trx 0. That used to be merely wrong in the same
+        // way on both sides — the protocol also resolved it to 0 and created
+        // DAX IQ channel 1, so server bookkeeping and radio state agreed. Now
+        // that cmdIqStart rejects it, an unchecked parse here would leave the
+        // two DISAGREEING: this client registered as a subscriber on trx 0
+        // with no stream ever created for it, receiving another client's
+        // channel-1 IQ frames (onIqDataReady) and eligible to tear that
+        // client's stream down on disconnect. Drop the command instead, which
+        // is also what the protocol does with it half a dozen lines later.
         if (trimmed.startsWith("iq_start:")) {
-            int colonIdx2 = trimmed.indexOf(':');
-            int trx = trimmed.mid(colonIdx2 + 1).trimmed().toInt();
+            const int colonIdx2 = trimmed.indexOf(':');
+            bool trxOk = false;
+            const int trx = trimmed.mid(colonIdx2 + 1).trimmed().toInt(&trxOk);
+            if (!trxOk || trx < 0 || trx > 3)
+                continue;
             client.iqEnabled = true;
             client.iqChannel = trx;
             qCInfo(lcCat) << "TCI: IQ started for client"
@@ -1066,8 +1081,15 @@ void TciServer::onTextMessage(const QString& msg)
             continue;
         }
         if (trimmed.startsWith("iq_stop:")) {
-            int colonIdx2 = trimmed.indexOf(':');
-            int trx = trimmed.mid(colonIdx2 + 1).trimmed().toInt();
+            // Checked for the same reason as iq_start above: an unchecked
+            // parse would clear iqEnabled for a client whose channel really
+            // is 0 whenever any garbage arrived, while the protocol declined
+            // to remove the stream.
+            const int colonIdx2 = trimmed.indexOf(':');
+            bool trxOk = false;
+            const int trx = trimmed.mid(colonIdx2 + 1).trimmed().toInt(&trxOk);
+            if (!trxOk || trx < 0 || trx > 3)
+                continue;
             if (client.iqChannel == trx)
                 client.iqEnabled = false;
             qCInfo(lcCat) << "TCI: IQ stopped for client"

--- a/tests/tci_protocol_test.cpp
+++ b/tests/tci_protocol_test.cpp
@@ -793,27 +793,41 @@ bool testMalformedValueArgsAreDropped()
 {
     TciProtocol protocol(nullptr);
 
-    // The two-argument shape is not decoration: handleCommand derives
-    // GET-vs-SET purely from argument count (`isSet = args.size() >= 2`), so
-    // a one-argument `cw_macros_delay:250` is a READ and never reaches the
-    // SET path at all. These global verbs then read args[0] as the value —
-    // an off-by-one against the trx-prefixed shape that cmdMicLevel and
-    // cmdVolume handle with `args[args.size() == 1 ? 0 : 1]`. That index
-    // quirk is a separate defect from this one and is deliberately NOT
-    // changed here; the tests below drive the shape the code actually has,
-    // so they keep passing when it is fixed on its own terms.
-    protocol.handleCommand(QStringLiteral("cw_macros_delay:250,0"));
+    // The GLOBAL verbs re-derive GET/SET from the argument list instead of
+    // trusting the dispatcher's `isSet = (args.size() >= 2)`, which is
+    // computed from the trx-prefixed shape the per-slice verbs use. Both
+    // forms must set: the spec form (one argument, the value) and the legacy
+    // trx-prefixed one (two arguments, value last). Before this change the
+    // first was a READ that discarded the value and the second read the trx
+    // position as the value, so `cw_macros_delay:0,250;` set the delay to 0.
+    protocol.handleCommand(QStringLiteral("cw_macros_delay:250"));
     if (!check(protocol.pendingNotification()
                    == QStringLiteral("cw_macros_delay:250;"),
-            "a well-formed cw_macros_delay SET must still take effect")) {
+            "the spec-form global SET must take effect, not be read as a GET")) {
+        return false;
+    }
+    protocol.handleCommand(QStringLiteral("cw_macros_delay:0,180"));
+    if (!check(protocol.pendingNotification()
+                   == QStringLiteral("cw_macros_delay:180;"),
+            "the legacy trx-prefixed global SET must read the VALUE, not the trx")) {
+        return false;
+    }
+    // Bare — no colon at all — is the read, and must not disturb the value.
+    if (!check(protocol.handleCommand(QStringLiteral("cw_macros_delay"))
+                   == QStringLiteral("cw_macros_delay:180;"),
+            "bare \"cw_macros_delay\" must read back the last value set")) {
         return false;
     }
 
     static const char* kMalformed[] = {
-        "cw_macros_delay:,0",       // the reported shape: empty argument
-        "cw_macros_delay:abc,0",
-        "cw_keyer_speed:abc,0",
-        "cw_macros_speed:abc,0",
+        "cw_macros_delay:",         // the reported shape: colon, nothing after
+        "cw_macros_delay:abc",
+        "cw_macros_delay:0,",       // legacy shape, empty value
+        "cw_macros_delay:0,abc",
+        "cw_keyer_speed:abc",
+        "cw_keyer_speed:0,abc",
+        "cw_macros_speed:abc",
+        "cw_macros_speed:0,abc",
     };
     for (const char* cmd : kMalformed) {
         protocol.handleCommand(QString::fromLatin1(cmd));
@@ -829,7 +843,7 @@ bool testMalformedValueArgsAreDropped()
     // silently resetting it to 0 — which is what the unchecked toInt() did.
     const QString readBack =
         protocol.handleCommand(QStringLiteral("cw_macros_delay"));
-    if (!check(readBack == QStringLiteral("cw_macros_delay:250;"),
+    if (!check(readBack == QStringLiteral("cw_macros_delay:180;"),
             "a dropped cw_macros_delay SET must not have clobbered the stored value")) {
         return false;
     }

--- a/tests/tci_protocol_test.cpp
+++ b/tests/tci_protocol_test.cpp
@@ -4,8 +4,10 @@
 #include "core/TciProtocol.h"
 #include "core/TciRoutingState.h"
 #include "core/backends/sim/SimBackend.h"
+#include "models/DaxIqModel.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
+#include "models/TransmitModel.h"
 
 #include <QCoreApplication>
 #include <QEventLoop>
@@ -819,15 +821,41 @@ bool testMalformedValueArgsAreDropped()
         return false;
     }
 
+    // cw_terminal is the BOOLEAN global verb, and modelless-reachable, so the
+    // argToBool half of the contract gets its positive controls here: both
+    // wire forms must set, and the value comes from the last argument.
+    protocol.handleCommand(QStringLiteral("cw_terminal:true"));
+    if (!check(protocol.handleCommand(QStringLiteral("cw_terminal"))
+                   == QStringLiteral("cw_terminal:true;"),
+            "the spec-form boolean global SET must take effect, not be read as a GET")) {
+        return false;
+    }
+    protocol.handleCommand(QStringLiteral("cw_terminal:0,false"));
+    if (!check(protocol.handleCommand(QStringLiteral("cw_terminal"))
+                   == QStringLiteral("cw_terminal:false;"),
+            "the legacy trx-prefixed boolean SET must read the VALUE, not the trx")) {
+        return false;
+    }
+    // Case-insensitivity is preserved from the expression argToBool replaced.
+    protocol.handleCommand(QStringLiteral("cw_terminal:TRUE"));
+    if (!check(protocol.handleCommand(QStringLiteral("cw_terminal"))
+                   == QStringLiteral("cw_terminal:true;"),
+            "argToBool must stay case-insensitive, as the old comparison was")) {
+        return false;
+    }
+
     static const char* kMalformed[] = {
         "cw_macros_delay:",         // the reported shape: colon, nothing after
         "cw_macros_delay:abc",
         "cw_macros_delay:0,",       // legacy shape, empty value
         "cw_macros_delay:0,abc",
-        "cw_keyer_speed:abc",
-        "cw_keyer_speed:0,abc",
-        "cw_macros_speed:abc",
-        "cw_macros_speed:0,abc",
+        // The boolean half of the same class (#4867 review): everything that
+        // was not the word "true" used to become false and apply, so these
+        // used to be indistinguishable from a deliberate `cw_terminal:false`.
+        "cw_terminal:",
+        "cw_terminal:yes",
+        "cw_terminal:1",
+        "cw_terminal:0,yes",
     };
     for (const char* cmd : kMalformed) {
         protocol.handleCommand(QString::fromLatin1(cmd));
@@ -847,6 +875,14 @@ bool testMalformedValueArgsAreDropped()
             "a dropped cw_macros_delay SET must not have clobbered the stored value")) {
         return false;
     }
+    // Same property for the boolean helper: argToBool leaves `out` untouched
+    // on failure, so the malformed cw_terminal SETs above must have left the
+    // last good value (true) rather than flipping it to false.
+    if (!check(protocol.handleCommand(QStringLiteral("cw_terminal"))
+                   == QStringLiteral("cw_terminal:true;"),
+            "a dropped boolean SET must not have clobbered the stored value")) {
+        return false;
+    }
 
     // iq_samplerate is the deliberate exception to the drop-on-malformed
     // posture: #3913 made it REPLY to a rejection because a blocked skimmer
@@ -860,6 +896,225 @@ bool testMalformedValueArgsAreDropped()
     }
     if (!check(protocol.pendingNotification().isEmpty(),
             "a rejected iq_samplerate must not notify other clients")) {
+        return false;
+    }
+    return true;
+}
+
+// #4867 review: the rest of the global-verb class, plus the boolean helper.
+// The first commit ended the numeric half; these are the sites that needed a
+// real connected model to observe, and the two the second commit missed.
+bool testGlobalVerbsAndBooleansEndToEnd()
+{
+    constexpr int kSettleTries = 100;   // × 50 ms = 5 s ceiling
+    RadioModel model;
+    model.connectToRadio(demoInfo());
+    for (int i = 0; i < kSettleTries && !model.isConnected(); ++i)
+        spin(50);
+    if (!check(model.isConnected(), "precondition: connected to the demo backend")) {
+        return false;
+    }
+    for (int i = 0; i < kSettleTries && model.slices().isEmpty(); ++i)
+        spin(50);
+    SliceModel* slice = model.slices().value(0);
+    if (!check(slice != nullptr, "precondition: the demo backend announced a slice")) {
+        return false;
+    }
+
+    TciProtocol protocol(&model);
+    auto settle = [] { QCoreApplication::processEvents(); };
+
+    // ── digl_offset / digu_offset: instances five and six ──────────────────
+    // Both take no trx (they hardcode sliceForTrx(0)), so the dispatcher's
+    // trx-shaped isSet was wrong in both directions: the spec form read as a
+    // GET and discarded the value, the legacy form set the offset to the trx
+    // slot and broadcast "digl_offset:0;".
+    protocol.handleCommand(QStringLiteral("digl_offset:500"));
+    settle();
+    if (!check(slice->diglOffset() == 500,
+            "the spec-form digl_offset SET must take effect, not be read as a GET")) {
+        return false;
+    }
+    protocol.handleCommand(QStringLiteral("digu_offset:0,650"));
+    settle();
+    if (!check(slice->diguOffset() == 650,
+            "the legacy trx-prefixed digu_offset SET must read the VALUE, not the trx")) {
+        return false;
+    }
+    for (const auto& cmd : { QStringLiteral("digl_offset:abc"),
+                             QStringLiteral("digl_offset:"),
+                             QStringLiteral("digl_offset:0,abc") }) {
+        protocol.handleCommand(cmd);
+        settle();
+        if (!check(slice->diglOffset() == 500,
+                qPrintable(QStringLiteral("\"%1\" must not clobber the stored offset")
+                               .arg(cmd)))) {
+            return false;
+        }
+        if (!check(protocol.pendingNotification().isEmpty(),
+                qPrintable(QStringLiteral("\"%1\" must not notify other clients")
+                               .arg(cmd)))) {
+            return false;
+        }
+    }
+    // A bare read must still answer, and must report what was actually set.
+    if (!check(protocol.handleCommand(QStringLiteral("digl_offset"))
+                   == QStringLiteral("digl_offset:500;"),
+            "bare \"digl_offset\" must read back the last value set")) {
+        return false;
+    }
+
+    // ── mon_enable: the boolean half of the same defect ────────────────────
+    model.transmitModel().setSbMonitor(false);
+    settle();
+    protocol.handleCommand(QStringLiteral("mon_enable:true"));
+    settle();
+    if (!check(model.transmitModel().sbMonitor(),
+            "the spec-form mon_enable SET must take effect, not be read as a GET")) {
+        return false;
+    }
+    protocol.handleCommand(QStringLiteral("mon_enable:0,false"));
+    settle();
+    if (!check(!model.transmitModel().sbMonitor(),
+            "the legacy trx-prefixed mon_enable SET must read the VALUE, not the trx")) {
+        return false;
+    }
+
+    // ── mon_volume: the verb whose ambiguous form the operator can hear ────
+    protocol.handleCommand(QStringLiteral("mon_volume:37"));
+    settle();
+    if (!check(model.transmitModel().monGainSb() == 37,
+            "the spec-form mon_volume SET must take effect, not be read as a GET")) {
+        return false;
+    }
+    // Per the #4867 review ruling: mon_volume:0 IS a SET of 0 per spec and is
+    // deliberately NOT special-cased — silently refusing a legitimate 0 would
+    // be the same undetectable-from-the-wire failure in the other direction.
+    protocol.handleCommand(QStringLiteral("mon_volume:0"));
+    settle();
+    if (!check(model.transmitModel().monGainSb() == 0,
+            "mon_volume:0 must be honoured as a SET of 0, not refused as ambiguous")) {
+        return false;
+    }
+    protocol.handleCommand(QStringLiteral("mon_volume:0,44"));
+    settle();
+    if (!check(model.transmitModel().monGainSb() == 44,
+            "the legacy trx-prefixed mon_volume SET must read the VALUE, not the trx")) {
+        return false;
+    }
+    protocol.handleCommand(QStringLiteral("mon_volume:abc"));
+    settle();
+    if (!check(protocol.pendingNotification().isEmpty(),
+            "an unparseable mon_volume must not notify other clients")) {
+        return false;
+    }
+    if (!check(model.transmitModel().monGainSb() == 44,
+            "a dropped mon_volume SET must not have clobbered the stored value")) {
+        return false;
+    }
+
+    // ── the two CW speed globals, which need a model since #4867's review ──
+    protocol.handleCommand(QStringLiteral("cw_keyer_speed:25"));
+    if (!check(protocol.pendingNotification()
+                   == QStringLiteral("cw_keyer_speed:25;"),
+            "the spec-form cw_keyer_speed SET must take effect, not be read as a GET")) {
+        return false;
+    }
+    protocol.handleCommand(QStringLiteral("cw_macros_speed:0,30"));
+    if (!check(protocol.pendingNotification()
+                   == QStringLiteral("cw_macros_speed:30;"),
+            "the legacy trx-prefixed cw_macros_speed SET must read the VALUE, not the trx")) {
+        return false;
+    }
+    for (const auto& cmd : { QStringLiteral("cw_keyer_speed:abc"),
+                             QStringLiteral("cw_keyer_speed:0,abc"),
+                             QStringLiteral("cw_macros_speed:abc"),
+                             QStringLiteral("cw_macros_speed:0,abc") }) {
+        protocol.handleCommand(cmd);
+        if (!check(protocol.pendingNotification().isEmpty(),
+                qPrintable(QStringLiteral("\"%1\" must not notify other clients")
+                               .arg(cmd)))) {
+            return false;
+        }
+    }
+
+    // ── argToBool on the per-slice verbs ───────────────────────────────────
+    // Positive control first: "true"/"false" still work, in either case.
+    slice->setAudioMute(false);
+    settle();
+    protocol.handleCommand(QStringLiteral("mute:0,TRUE"));
+    settle();
+    if (!check(slice->audioMute(),
+            "a well-formed boolean must still apply, case-insensitively")) {
+        return false;
+    }
+    // Then the defect: anything that is not the word "true" used to become
+    // false and UNMUTE slice 0, broadcasting a well-formed "mute:0,false;"
+    // that no second client could tell from a deliberate unmute.
+    for (const auto& cmd : { QStringLiteral("mute:0,yes"),
+                             QStringLiteral("mute:0,1"),
+                             QStringLiteral("mute:0,"),
+                             QStringLiteral("rx_mute:0,off") }) {
+        protocol.handleCommand(cmd);
+        settle();
+        if (!check(slice->audioMute(),
+                qPrintable(QStringLiteral("\"%1\" must not unmute slice 0")
+                               .arg(cmd)))) {
+            return false;
+        }
+        if (!check(protocol.pendingNotification().isEmpty(),
+                qPrintable(QStringLiteral("\"%1\" must not notify other clients")
+                               .arg(cmd)))) {
+            return false;
+        }
+    }
+    // The same on a non-mute boolean, so the assertion is not mute-specific.
+    protocol.handleCommand(QStringLiteral("rx_nb_enable:0,true"));
+    settle();
+    protocol.handleCommand(QStringLiteral("rx_nb_enable:0,nope"));
+    settle();
+    if (!check(slice->nbOn(),
+            "an unparseable rx_nb_enable must not turn the blanker off")) {
+        return false;
+    }
+
+    // ── the TX-keying verbs are deliberately NOT argToBool ─────────────────
+    // cmdTune and cmdKeyer must fail CLOSED, not silent: "not the word true"
+    // has to keep meaning stop/up, because dropping an unparseable stop would
+    // leave a keyed transmitter keyed (Constitution VI).
+    //
+    // Only the safe direction is asserted, and it is a smoke check rather
+    // than a mutation-proof one: proving the fail-closed property properly
+    // would mean starting a tune and then stopping it with malformed input,
+    // and a test must not drive the keyed direction. The property is held by
+    // the comment at the call site and by rule 7 of tci-receivers.md.
+    if (!check(!model.transmitModel().isTuning(),
+            "precondition: the demo backend is not tuning")) {
+        return false;
+    }
+    protocol.handleCommand(QStringLiteral("tune:0,garbage"));
+    settle();
+    if (!check(!model.transmitModel().isTuning(),
+            "a malformed tune state must never START a tune")) {
+        return false;
+    }
+
+    // ── iq_start/iq_stop bound the index before the addition ───────────────
+    // `trx + 1` on an INT_MAX index was signed overflow (argToInt accepts
+    // INT_MAX — it is "99999999999" that clears ok). Bounding trx first makes
+    // the arithmetic defined, but it changes NO observable behaviour:
+    // DaxIqModel::createStream() already rejects an out-of-range channel, so
+    // the mutation that removes the bound is caught by UBSan, not by a test.
+    // Asserting a rejection here would be a test that pins nothing, so the
+    // only assertion is the one with something to observe — that the bound
+    // did not over-tighten and an in-range index still creates its stream.
+    QStringList daxCommands;
+    QObject::connect(&model.daxIqModel(), &DaxIqModel::commandReady,
+                     [&daxCommands](const QString& c) { daxCommands << c; });
+    protocol.handleCommand(QStringLiteral("iq_start:0"));
+    settle();
+    if (!check(!daxCommands.isEmpty(),
+            "a well-formed iq_start must still create the DAX IQ stream")) {
         return false;
     }
     return true;
@@ -928,7 +1183,8 @@ int main(int argc, char** argv)
         || !testTciToSmartSdrReportsUnrecognisedNames()
         || !testModulationEndToEndRejectsUnknownName()
         || !testMalformedValueArgsAreDropped()
-        || !testMalformedTrxDoesNotLandOnSliceZero()) {
+        || !testMalformedTrxDoesNotLandOnSliceZero()
+        || !testGlobalVerbsAndBooleansEndToEnd()) {
         return 1;
     }
 

--- a/tests/tci_protocol_test.cpp
+++ b/tests/tci_protocol_test.cpp
@@ -647,6 +647,210 @@ bool testModulationEndToEndRejectsUnknownName()
     return true;
 }
 
+// #4867: the sharpest form of the malformed-argument class. Every verb that
+// takes a trx used to do `int trx = args[0].toInt();` unchecked, and
+// sliceForTrx() resolves positionally — so a malformed trx did not fail to
+// resolve, it resolved to slice 0 and the command landed on the WRONG SLICE,
+// broadcasting a notification naming slice 0 as though the client had asked
+// for it. This is the assertion none of the three previous fixes in this
+// class (#4345, #4523's two) ever made, which is why the class survived them.
+bool testMalformedTrxDoesNotLandOnSliceZero()
+{
+    constexpr int kSettleTries = 100;   // × 50 ms = 5 s ceiling; see above
+    RadioModel model;
+    model.connectToRadio(demoInfo());
+    for (int i = 0; i < kSettleTries && !model.isConnected(); ++i)
+        spin(50);
+    if (!check(model.isConnected(), "precondition: connected to the demo backend")) {
+        return false;
+    }
+    for (int i = 0; i < kSettleTries && model.slices().isEmpty(); ++i)
+        spin(50);
+    SliceModel* slice = model.slices().value(0);
+    if (!check(slice != nullptr, "precondition: the demo backend announced a slice")) {
+        return false;
+    }
+
+    TciProtocol protocol(&model);
+
+    // Positive control first, so "the fix refuses everything" cannot pass as
+    // success: a well-formed trx still reaches slice 0.
+    slice->setAudioMute(false);
+    protocol.handleCommand(QStringLiteral("mute:0,true"));
+    QCoreApplication::processEvents();
+    if (!check(slice->audioMute() && !protocol.pendingNotification().isEmpty(),
+            "a well-formed trx must still apply to the addressed slice")) {
+        return false;
+    }
+
+    // Each of these used to become trx=0 and mutate slice 0 while emitting a
+    // well-formed "…:0,…;" notification — indistinguishable, on the wire,
+    // from the client having addressed slice 0 deliberately.
+    struct Case { const char* cmd; const char* what; };
+    static const Case kCases[] = {
+        { "mute:abc,false",            "mute with a non-numeric trx" },
+        { "mute:,false",               "mute with an empty trx" },
+        { "mute:0x1,false",            "mute with a hex trx" },
+        { "rx_mute:zz,false",          "rx_mute with a non-numeric trx" },
+    };
+    for (const auto& c : kCases) {
+        slice->setAudioMute(true);
+        QCoreApplication::processEvents();
+        protocol.handleCommand(QString::fromLatin1(c.cmd));
+        QCoreApplication::processEvents();
+        if (!check(slice->audioMute(),
+                qPrintable(QStringLiteral("%1 must not unmute slice 0")
+                               .arg(QString::fromLatin1(c.what))))) {
+            return false;
+        }
+        if (!check(protocol.pendingNotification().isEmpty(),
+                qPrintable(QStringLiteral("%1 must not notify other clients")
+                               .arg(QString::fromLatin1(c.what))))) {
+            return false;
+        }
+    }
+
+    // A per-slice verb with NO trx at all must not answer for slice 0 either.
+    // This is the argument-missing half of the helper's contract, as distinct
+    // from the argument-present-but-unparseable half above: without it, a
+    // helper that treated an out-of-range index as "0" would pass every other
+    // assertion in this file. (Verified by mutation: it does.)
+    if (!check(protocol.handleCommand(QStringLiteral("mute")).isEmpty(),
+            "bare \"mute\" must not answer for slice 0")) {
+        return false;
+    }
+    if (!check(protocol.handleCommand(QStringLiteral("rx_volume")).isEmpty(),
+            "bare \"rx_volume\" must not answer for slice 0")) {
+        return false;
+    }
+
+    // Same defect on a different verb and a different observable: a malformed
+    // trx must not reach setMode() on slice 0 either.
+    slice->setMode(QStringLiteral("USB"));
+    QCoreApplication::processEvents();
+    protocol.handleCommand(QStringLiteral("modulation:abc,lsb"));
+    QCoreApplication::processEvents();
+    if (!check(slice->mode() == QStringLiteral("USB"),
+            "a malformed trx must not change slice 0's mode")) {
+        return false;
+    }
+
+    // And on the filter pair, where the old behaviour was a zero-width filter:
+    // the malformed VALUE arguments must be rejected too, not just the trx.
+    // Both edges are checked, so rejecting only the first would still fail.
+    for (const auto& cmd : { QStringLiteral("rx_filter_band:0,abc,2800"),
+                             QStringLiteral("rx_filter_band:0,100,abc"),
+                             QStringLiteral("rx_filter_band:0,,2800") }) {
+        const int lowBefore = slice->filterLow();
+        const int highBefore = slice->filterHigh();
+        protocol.handleCommand(cmd);
+        QCoreApplication::processEvents();
+        if (!check(slice->filterLow() == lowBefore
+                       && slice->filterHigh() == highBefore,
+                qPrintable(QStringLiteral("\"%1\" must not collapse the passband")
+                               .arg(cmd)))) {
+            return false;
+        }
+        if (!check(protocol.pendingNotification().isEmpty(),
+                qPrintable(QStringLiteral("\"%1\" must not notify other clients")
+                               .arg(cmd)))) {
+            return false;
+        }
+    }
+
+    // The remaining per-slice value arguments, each of which used to land on
+    // 0 — a legitimate value in every one of these ranges, which is exactly
+    // what made the defect undetectable downstream.
+    protocol.handleCommand(QStringLiteral("agc_gain:0,40"));
+    QCoreApplication::processEvents();
+    if (!check(!protocol.pendingNotification().isEmpty(),
+            "a well-formed agc_gain SET must still take effect")) {
+        return false;
+    }
+    for (const auto& cmd : { QStringLiteral("agc_gain:0,abc"),
+                             QStringLiteral("agc_gain:0,"),
+                             QStringLiteral("sql_level:0,abc"),
+                             QStringLiteral("rx_balance:0,abc"),
+                             QStringLiteral("rx_volume:0,abc"),
+                             QStringLiteral("rx_nb_param:0,0,abc"),
+                             QStringLiteral("rit_offset:0,abc"),
+                             QStringLiteral("xit_offset:0,abc") }) {
+        protocol.handleCommand(cmd);
+        QCoreApplication::processEvents();
+        if (!check(protocol.pendingNotification().isEmpty(),
+                qPrintable(QStringLiteral("\"%1\" must not notify other clients")
+                               .arg(cmd)))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// #4867: the value-argument half of the class, on the verbs that need no
+// slice. Each of these used to turn unparseable input into 0 and broadcast
+// it as a well-formed change.
+bool testMalformedValueArgsAreDropped()
+{
+    TciProtocol protocol(nullptr);
+
+    // The two-argument shape is not decoration: handleCommand derives
+    // GET-vs-SET purely from argument count (`isSet = args.size() >= 2`), so
+    // a one-argument `cw_macros_delay:250` is a READ and never reaches the
+    // SET path at all. These global verbs then read args[0] as the value —
+    // an off-by-one against the trx-prefixed shape that cmdMicLevel and
+    // cmdVolume handle with `args[args.size() == 1 ? 0 : 1]`. That index
+    // quirk is a separate defect from this one and is deliberately NOT
+    // changed here; the tests below drive the shape the code actually has,
+    // so they keep passing when it is fixed on its own terms.
+    protocol.handleCommand(QStringLiteral("cw_macros_delay:250,0"));
+    if (!check(protocol.pendingNotification()
+                   == QStringLiteral("cw_macros_delay:250;"),
+            "a well-formed cw_macros_delay SET must still take effect")) {
+        return false;
+    }
+
+    static const char* kMalformed[] = {
+        "cw_macros_delay:,0",       // the reported shape: empty argument
+        "cw_macros_delay:abc,0",
+        "cw_keyer_speed:abc,0",
+        "cw_macros_speed:abc,0",
+    };
+    for (const char* cmd : kMalformed) {
+        protocol.handleCommand(QString::fromLatin1(cmd));
+        if (!check(protocol.pendingNotification().isEmpty(),
+                qPrintable(QStringLiteral("\"%1\" must not notify other clients")
+                               .arg(QString::fromLatin1(cmd))))) {
+            return false;
+        }
+    }
+
+    // cw_macros_delay keeps its value across commands (it is a static), so a
+    // dropped malformed SET must leave the last good one in place rather than
+    // silently resetting it to 0 — which is what the unchecked toInt() did.
+    const QString readBack =
+        protocol.handleCommand(QStringLiteral("cw_macros_delay"));
+    if (!check(readBack == QStringLiteral("cw_macros_delay:250;"),
+            "a dropped cw_macros_delay SET must not have clobbered the stored value")) {
+        return false;
+    }
+
+    // iq_samplerate is the deliberate exception to the drop-on-malformed
+    // posture: #3913 made it REPLY to a rejection because a blocked skimmer
+    // would otherwise hang, so an unparseable rate must report the rate still
+    // in force rather than returning nothing.
+    const QString rateReply =
+        protocol.handleCommand(QStringLiteral("iq_samplerate:abc"));
+    if (!check(rateReply == QStringLiteral("iq_samplerate:48000;"),
+            "an unparseable iq_samplerate must report the rate still in force")) {
+        return false;
+    }
+    if (!check(protocol.pendingNotification().isEmpty(),
+            "a rejected iq_samplerate must not notify other clients")) {
+        return false;
+    }
+    return true;
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -708,7 +912,9 @@ int main(int argc, char** argv)
         || !testVolumeMalformedInputIsDropped()
         || !testTxGainMalformedInputIsDropped()
         || !testTciToSmartSdrReportsUnrecognisedNames()
-        || !testModulationEndToEndRejectsUnknownName()) {
+        || !testModulationEndToEndRejectsUnknownName()
+        || !testMalformedValueArgsAreDropped()
+        || !testMalformedTrxDoesNotLandOnSliceZero()) {
         return 1;
     }
 


### PR DESCRIPTION
Closes #4867.

`TciProtocol.cpp` converted client-supplied arguments to numbers with unchecked
`QString::toInt()` in **50 places across 39 command handlers**. Qt returns `0`
on a parse failure, so malformed input did not fail — it became a valid-looking
`0` and the command proceeded as if the client had asked for it.

The hard part of this class is that it does not fail quietly, it **succeeds
convincingly**: the command applies, a well-formed notification goes out, and
neither the sender nor a second client watching the wire can tell. No crash, no
log line, no assertion in the tree that moves. That is why it was fixed three
times one instance at a time — #4345 (a `DRIVE` read applied as a power SET),
then #4523/#4848 (`volume:` applied as 100 %, `tx_gain:` as a mute) — and
survived all three.

## The sharpest case: 30 of the 50 sites were the trx index

`sliceForTrx()` resolves positionally, so a malformed trx never failed to
resolve — it resolved to **slice 0** and the command landed on the wrong slice,
broadcasting a notification naming slice 0 as though the client had addressed it
deliberately. At the parent commit:

```
mute:abc,true     →  trx = 0  →  slice 0 muted, "mute:0,true;" broadcast
agc_gain:x,80     →  trx = 0  →  slice 0's AGC changed
rx_volume:,50     →  trx = 0  →  slice 0's volume changed
```

## The fix

Three helpers — `argToInt`, `argToLongLong`, `argToDouble` — with one contract:
`out` is untouched unless the argument is present **and** parses, and the caller
drops the command on `false`, matching the *"ignore silently per TCI spec"*
posture the parser already takes for unrecognised commands.

All **66** argument conversions in the file now go through them. The only
remaining raw `toInt`/`toDouble`/`toLongLong` calls are the three helper bodies:

```
$ grep -nE 'args\[[^]]+\]\.to(Int|Double|LongLong|Float)\(' src/core/TciProtocol.cpp
137:    const int parsed = args[idx].toInt(&ok);
147:    const long long parsed = args[idx].toLongLong(&ok);
164:    const double parsed = args[idx].toDouble(&ok);
```

`argToDouble` folds in `std::isfinite`, because the ok flag alone does not cover
it: Qt parses the literals `"inf"`/`"nan"` and reports ok, which is how
`volume:inf` muted the radio until #4848. Overflow (`"1e400"`) clears ok; the
literal spellings do not. Putting it in the helper is the point — it stops being
something each caller has to remember.

The seven handlers already hardened by #4345/#4523/#4848 are converted too, so
the file has one spelling rather than two. Their range checks (`trx < 0`,
`pwr < 0 || pwr > 100`) are preserved exactly.

## Third commit: the boolean half, the last two global verbs, and TciServer

Three gaps found in review, all the same defect wearing a different hat.

**Booleans — 20 sites.** `args[i].toLower() == "true"` turned *everything that
was not the word "true"* into `false` and applied it:

```
mute:0,yes   →  mute = false  →  slice 0 UNMUTED, "mute:0,false;" broadcast
```

That is #4867's signature verbatim with no number involved. A fourth helper,
`argToBool`, accepts `true`/`false` (still case-insensitively) and reports
failure otherwise. Every bundled plugin sends Python's `str(bool).lower()` or
JS's `${bool}`, i.e. exactly those two spellings, so nothing shipped changes.

> **`cmdTune` and `cmdKeyer` are deliberately exempt.** They key the
> transmitter, so they must fail **closed**, not silent: dropping an
> unparseable `tune:0,<junk>` would leave a tuning carrier on the air and
> dropping `keyer:0,<junk>` would leave the key down. There, "not the word
> true" keeps meaning stop/up — Constitution VI. Commented at both sites.

**The global-verb fix was four of six.** `digl_offset` and `digu_offset` take
no trx either, so the trx-shaped `isSet` was wrong on them in both directions
as well; `mon_enable` and `cw_terminal` are the boolean half of the same
shape. Reproduced on the wire at the previous head, against the demo backend:

```
digl_offset:500;     → read as a GET, the 500 discarded (offset stayed 2210)
digl_offset:0,500;   → offset set to 0, "digl_offset:0;" broadcast
mon_enable:true;     → read as a GET, monitor stayed off
```

All four now re-derive GET/SET from the argument list like the other four.

**`TciServer` had its own copy of the parse.** `iq_start:`/`iq_stop:` parsed
the trx with an unchecked `toInt()` one layer above the protocol. That used to
be wrong *symmetrically* — both sides resolved `iq_start:abc;` to 0 — but once
`cmdIqStart` rejects it the two **disagree**: the client stays registered as an
IQ subscriber on trx 0 with no stream created for it, receiving another
client's channel-1 frames and eligible to tear that stream down on disconnect.
Both sites are now checked and bounded.

## Deliberately unchanged

- **The lenient forms.** `cmdVolume`'s non-spec percent branch (`val >= 1.0`) is
  what Elgato, Ulanzi and StreamController all send. This rejects *unparseable*
  input only, never *unexpected* input — the existing `volume:79` regression
  test still passes untouched.
- **`iq_samplerate` still replies to a rejection.** #3913 made it report the
  rate still in force on purpose, because a skimmer (CW Skimmer / SDC) blocks
  waiting for the confirmation and silence would hang it. An unparseable rate
  now joins that branch rather than returning `{}` — the one place where the
  drop posture would be a regression, so it is called out at the call site and
  pinned by a test.
- **`mon_volume:0;` is a SET of 0.** The spec form is a SET, so this now sets
  the monitor gain to 0 where it used to be read as a GET. It is deliberately
  *not* special-cased: silently refusing a legitimate `0` — an ordinary thing
  for an operator to ask for — would be the same undetectable-from-the-wire
  failure pointed the other way, and the client can read the value back. The
  whole global-verb and boolean contract is now written down as rules 6 and 7
  of `docs/architecture/tci-receivers.md` instead, which is the doc a
  third-party client author would actually consult.
- **The trailing-colon read.** `mon_volume:;` and friends change from "reply
  with the current value" to silence, because `"".split(',', KeepEmptyParts)`
  yields `[""]` rather than an empty list. Consistent with the `volume:` /
  `tx_gain:` ruling in #4523/#4848. Send the bare `mon_volume;` to read.
- **Negative trx.** `resolveSliceForTrx()` falls back to the first slice for an
  unresolvable index, which is documented behaviour for read paths
  (tci-receivers.md rule 3). Only the handlers that already rejected `trx < 0`
  still do. Changing that fallback is a separate decision, not a parse fix.

## Second commit: the global-verb index bug, folded in

Found while writing these tests. Four global (non-trx) verbs —
`cw_macros_speed`, `cw_keyer_speed`, `cw_macros_delay`, `mon_volume` — trusted
the dispatcher's `isSet = (args.size() >= 2)`, which is derived from the
trx-prefixed shape every *per-slice* verb uses. On a global verb that is wrong
in both directions:

```
mon_volume:50;      1 arg  → isSet=false → treated as a READ, value discarded.
                             Setting it over TCI was impossible.
mon_volume:0,50;    2 args → SET, but the handler read args[0] — the trx slot —
                             so the volume was set to 0.
```

The spec form silently did nothing; the legacy form silently did the wrong
thing. Well-formed notification either way, which is the same
undetectable-from-the-wire signature as the rest of this class.

`cmdVolume`, `cmdMicLevel` and `cmdTxGain` already re-derive GET/SET from the
argument list and read `args[args.size() == 1 ? 0 : 1]` — these four were simply
missed. Fixed to that same shape: empty args = GET, otherwise SET reading the
last argument, bare (no colon) still reads.

No bundled plugin sends any of the four (checked Elgato, Ulanzi and
StreamController) and no doc describes their wire shape, so nothing shipped
depended on the broken behaviour.

## Deliberately still unchanged: negative trx

`resolveSliceForTrx()` falls back to the first slice for an unresolvable index,
which is documented behaviour for read paths (tci-receivers.md rule 3), so
`mute:-5,true` still reaches slice 0. Only the handlers that already rejected
`trx < 0` still do. Changing that fallback is a behaviour decision, not a parse
fix, and stays out of scope here.

## Testing

Two new tests in `tests/tci_protocol_test.cpp`, which gates merges as of #4848:

- **`testMalformedTrxDoesNotLandOnSliceZero`** — driven end to end through a
  real connected `RadioModel` on the demo backend. Asserts a malformed trx
  leaves slice 0's mute state and mode untouched and emits no notification,
  that a per-slice verb with *no* trx does not answer for slice 0, that **both**
  `rx_filter_band` edges are checked rather than just the first, and that the
  per-slice value arguments are dropped. This is the assertion none of the three
  previous fixes made, which is why the class survived them.
- **`testMalformedValueArgsAreDropped`** — the modelless value-argument half,
  including that a dropped `cw_macros_delay` SET leaves the stored value intact
  rather than resetting it to `0`, and that `iq_samplerate` still replies rather
  than hanging the requester.

Both open with positive controls, so "the fix refuses everything" cannot pass as
success.

**Mutation-tested — nine mutations, each caught by its own distinct
assertion:**

| neutered | assertion that fails |
|---|---|
| `argToInt`'s ok check | `"tx_gain:" must not be recorded as a tx_gain SET` |
| `argToInt`'s bounds check | `bare "mute" must not answer for slice 0` |
| `argToDouble`'s `isfinite` | `"volume:inf" must not be recorded as a master-volume SET` |
| `cmdMute`'s trx guard | `mute with a non-numeric trx must not unmute slice 0` |
| `rx_filter_band`'s **second** edge | `"rx_filter_band:0,100,abc" must not collapse the passband` |
| `cw_macros_delay`'s guard | `"cw_macros_delay:" must not notify other clients` |
| `iq_samplerate`'s reply-on-reject | `an unparseable iq_samplerate must report the rate still in force` |
| global verbs' value index (2nd commit) | `the legacy trx-prefixed global SET must read the VALUE, not the trx` |
| global verbs' GET/SET derivation (2nd commit) | `the spec-form global SET must take effect, not be read as a GET` |

The bounds-check assertion exists *because* of that pass: the first run of it
survived every other test in the file, so the `bare "mute"` case was added to
pin it.

**Third commit adds `testGlobalVerbsAndBooleansEndToEnd`** — driven through the
demo backend, covering all six newly-fixed verbs, `argToBool`'s positive and
negative sides, and the stored-value-survives-a-dropped-SET property for
booleans. Six further mutations, each caught by its own distinct assertion:

| neutered | assertion that fails |
|---|---|
| `argToBool`'s reject branch | `a dropped boolean SET must not have clobbered the stored value` |
| `digl`/`digu` value index | `the legacy trx-prefixed digu_offset SET must read the VALUE, not the trx` |
| `mon_enable`'s GET/SET derivation | `the spec-form mon_enable SET must take effect, not be read as a GET` |
| `cw_terminal`'s GET/SET derivation | `the spec-form boolean global SET must take effect, not be read as a GET` |
| `cw_macros_speed`'s value index | `the legacy trx-prefixed cw_macros_speed SET must read the VALUE, not the trx` |
| `mon_volume`'s value index | `the legacy trx-prefixed mon_volume SET must read the VALUE, not the trx` |

Two things are honestly *not* pinned by a test, and say so in the code: the
`iq_start` index bound changes no observable behaviour (`DaxIqModel::createStream`
already rejects an out-of-range channel — it is a UBSan fix), and the
`cmdTune`/`cmdKeyer` fail-closed property is asserted only in the safe
direction, because a test must not drive the keyed one.

Also: `tci_protocol_test` 20/20 runs pass; full `ctest -R tci` **5/5**
(`tci_protocol_test`, `tci_trxmap_test`, `tci_automation_test`,
`tci_server_review_test`, `hl2_tci_signaling_test`); `AetherSDR` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

