### PR TITLE
fix(gui): mini-pan centres on the passband, not the carrier. Principle XI.

### DIFF
--- a/docs/minipan-implementation.md
+++ b/docs/minipan-implementation.md
@@ -12,7 +12,7 @@ panadapter is hidden (Minimal Mode) or alongside contest-logging software.
 
 The mini-pan **creates nothing on the radio**. It re-slices the FFT frames the
 active slice's panadapter is already streaming down to a ±5 or ±10 kHz window
-around that slice.
+around that slice's passband.
 
 No dedicated panadapter, no slice. That is the whole architecture, and it is
 what makes the feature free to open: no pan slot consumed against
@@ -27,6 +27,34 @@ sub-range around the VFO into a fixed-width output, interpolating between
 source bins (so a narrow main pan upsamples smoothly rather than stair-stepping)
 and padding with the frame's own floor outside the pan's edges (so the
 frequency axis stays honest instead of smearing edge data across the gap).
+
+### It centres on the passband, not the carrier
+
+The window is centred on the middle of the receive filter —
+`MiniPan::passbandCenterOffsetHz(filterLow, filterHigh)` above the carrier.
+
+On a single-sideband mode the carrier sits at the *edge* of the passband (USB
+100..2800 Hz), so a carrier-centred view pushed everything the operator is
+listening to into one half of an already narrow scope and spent the other half
+on the sideband the filter throws away. Symmetric filters — AM, FM, and CW
+filters that straddle the carrier — give an offset of 0 and are unchanged.
+
+Two consumers share that one helper, which is why it lives next to the re-slice
+rather than in either of them:
+
+| Consumer | Uses it for |
+|---|---|
+| `MainWindow::feedMiniPanFromPanFrame` | the centre of the window it cuts out of the frame |
+| `MiniPanScope::paintEvent` | placing the passband wash and the carrier hairline |
+
+Two copies would let the trace and the chrome disagree about which frequency is
+in the middle.
+
+The hairline still marks the **carrier**, and the readout still shows it — so on
+SSB the hairline sits off to one side against the edge of the wash, exactly as
+it reads on the main pan. A filter wider than the span can push the carrier out
+of view; the hairline is then not drawn at all, rather than clamped to the edge
+where it would name a frequency it is not on.
 
 ### The trade: resolution follows the main pan
 
@@ -145,9 +173,12 @@ button, float, dock, layout apply — and MainWindow starts or stops consuming
 frames on it. A hidden applet costs nothing per frame, and because nothing
 radio-side is created or destroyed there is no state to get out of sync.
 
-Centre and passband come from the active slice (`frequencyChanged`,
-`filterChanged`), rebound on active-slice change. All of it is local: nothing is
-sent to the radio, so tuning needs no debounce.
+Carrier and passband come from the active slice (`frequencyChanged`,
+`filterChanged`), rebound on active-slice change. Because the view is centred on
+the passband, a filter change moves the window as well as the shading — the feed
+re-derives the centre from the same slice on the next frame, so the trace and the
+chrome cannot disagree. All of it is local: nothing is sent to the radio, so
+tuning needs no debounce.
 
 ---
 
@@ -174,6 +205,10 @@ Nothing the radio owns is persisted (Principle III).
   here would put a signal at a frequency it is not on), a window outside the
   pan reads as floor rather than clamped edge data, a straddling window pads
   the outside half, and degenerate inputs return empty;
+- the passband centring — the offset itself (SSB either way, symmetric filters
+  unchanged, hidden passband falls back to the carrier) and the render it drives
+  (the wash lands symmetric about the middle, the hairline leaves the middle to
+  stay on the carrier);
 - the scope render API against synthetic and empty frames;
 - the show/hide feed lifecycle, exact edges;
 - span persistence, including that the radio-echo path does not overwrite the

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -793,8 +793,10 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // Mini-Pan — the K4-style narrow scope. Deliberately an applet and NOT a
     // View-menu item: the menu bar does not exist in Minimal Mode, which is
     // exactly when the operator wants this. The tray button below is the only
-    // entry point reachable there. Off by default (it costs a radio pan slot);
-    // float it out via the container title bar to keep it over a logging app.
+    // entry point reachable there. Off by default because it is a specialist
+    // view, not because it is expensive — it creates nothing on the radio, it
+    // just re-slices the main pan's frames. Float it out via the container
+    // title bar to keep it over a logging app.
     m_miniPanApplet = new MiniPanApplet;
     m_appletOrder.append(makeEntry("MPAN", "Mini-Pan", m_miniPanApplet, false, m_drawer, m_drawerLayout, "MINI"));
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7673,7 +7673,9 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
 // ── Mini-pan glue ─────────────────────────────────────────────────────────────
 // The mini-pan applet is pure presentation, and it is a VIEW — it creates no
 // radio objects at all. It re-slices the FFT bins of the pan the active slice
-// already lives on down to a +/-5 or +/-10 kHz window around that slice.
+// already lives on down to a +/-5 or +/-10 kHz window centred on that slice's
+// PASSBAND (MiniPan::passbandCenterOffsetHz — on SSB the carrier sits at the
+// edge of the filter, so centring on it wasted half the view).
 //
 // That is the whole architecture: no dedicated pan (no slot consumed, nothing
 // to leak on quit, no reconnect zombie, no active-pan hijack) and no slice
@@ -7695,7 +7697,7 @@ void MainWindow::refreshMiniPanFollow()
 
     auto* s = activeSlice();
     if (!s) {
-        applet->setCenterMhz(0.0);
+        applet->setVfoMhz(0.0);
         applet->setPassbandHz(0, 0);
         applet->scope()->updateSpectrum(QVector<float>{});
         return;
@@ -7705,9 +7707,13 @@ void MainWindow::refreshMiniPanFollow()
     // already streaming. Nothing is sent to the radio, so tuning needs no
     // debounce -- the old "display pan set ... center=" push is gone with the
     // dedicated pan.
+    //
+    // A filter change moves the VIEW as well as the shading, because the window
+    // is centred on the passband -- feedMiniPanFromPanFrame re-derives that from
+    // the same slice on the next frame, so the two cannot disagree.
     m_miniPanFreqConn = connect(s, &SliceModel::frequencyChanged, this,
                                 [this](double mhz) {
-        if (auto* a = miniPanApplet()) a->setCenterMhz(mhz);
+        if (auto* a = miniPanApplet()) a->setVfoMhz(mhz);
     });
     m_miniPanFiltConn = connect(s, &SliceModel::filterChanged, this,
                                 [this]() {
@@ -7715,7 +7721,7 @@ void MainWindow::refreshMiniPanFollow()
             if (auto* a = miniPanApplet())
                 a->setPassbandHz(cur->filterLow(), cur->filterHigh());
     });
-    applet->setCenterMhz(s->frequency());
+    applet->setVfoMhz(s->frequency());
     applet->setPassbandHz(s->filterLow(), s->filterHigh());
 }
 
@@ -7774,11 +7780,22 @@ void MainWindow::feedMiniPanFromPanFrame(const PanadapterModel* pan,
         scope->setDbmRange(pan->minDbm(), pan->maxDbm());
     }
 
+    // Centre the window on the PASSBAND centre, not the carrier: on SSB the
+    // carrier sits at the edge of the filter, so a carrier-centred cut spent
+    // half of an already narrow view on the rejected sideband. Re-derived from
+    // the slice here rather than read back off the applet, so the trace is cut
+    // from this frame's actual filter state; MiniPanScope places the hairline
+    // and the passband wash with the same helper.
+    const double centerMhz =
+        s->frequency()
+        + AetherSDR::MiniPan::passbandCenterOffsetHz(s->filterLow(),
+                                                     s->filterHigh()) / 1.0e6;
+
     scope->updateSpectrum(
         AetherSDR::MiniPan::resliceWindow(
             bins,
             pan->centerMhz() - panBw / 2.0, panBw,
-            s->frequency() - span / 2.0, span,
+            centerMhz - span / 2.0, span,
             AetherSDR::MiniPan::kResliceOutputBins, floorDbm));
 }
 

--- a/src/gui/MiniPanApplet.cpp
+++ b/src/gui/MiniPanApplet.cpp
@@ -20,7 +20,7 @@ MiniPanApplet::MiniPanApplet(QWidget* parent)
     setObjectName("miniPanApplet");   // addressable for automation/tests
     setAccessibleName(tr("Mini-pan"));
     setAccessibleDescription(
-        tr("Narrow-span scope centred on the active VFO. "
+        tr("Narrow-span scope centred on the active VFO's receive passband. "
            "Right-click to choose ±5 or ±10 kHz."));
 
     // The scope fills the tile. The frequency readout is drawn INSIDE it, on
@@ -49,10 +49,10 @@ QSize MiniPanApplet::sizeHint() const
     return {260, 150};
 }
 
-void MiniPanApplet::setCenterMhz(double mhz)
+void MiniPanApplet::setVfoMhz(double mhz)
 {
-    m_centerMhz = mhz;
-    if (m_scope) m_scope->setCenterMhz(mhz);
+    m_vfoMhz = mhz;
+    if (m_scope) m_scope->setVfoMhz(mhz);
 }
 
 void MiniPanApplet::setSpanKHz(double kHz)

--- a/src/gui/MiniPanApplet.h
+++ b/src/gui/MiniPanApplet.h
@@ -18,9 +18,13 @@
 //
 // The mini-pan is a VIEW, not a radio object: it creates no panadapter and no
 // slice. MainWindow re-slices the FFT frames the active slice's pan is already
-// streaming down to this window's +/-5 or +/-10 kHz, and drives centre/passband
+// streaming down to this window's +/-5 or +/-10 kHz, and drives carrier/passband
 // from the followed VFO through the setters below. So the applet costs a radio
 // nothing to open — no pan slot, nothing to leak, no phantom slice.
+//
+// The window is centred on the PASSBAND centre rather than the carrier, so on
+// SSB the received signal sits in the middle instead of hard against one edge.
+// MainWindow and MiniPanScope share MiniPan::passbandCenterOffsetHz for that.
 //
 // This widget holds NO radio/slice references (so it links into a light
 // offscreen test). It reports two intents back up: feedWanted() (shown/hidden)
@@ -43,9 +47,10 @@ public:
     QSize sizeHint() const override;
 
     // Driven by MainWindow from the followed VFO slice.
-    void setCenterMhz(double mhz);        // 0 → placeholder readout
+    void setVfoMhz(double mhz);           // carrier: readout + hairline. 0 → placeholder
     void setSpanKHz(double kHz);
-    void setPassbandHz(int lowHz, int highHz);
+    void setPassbandHz(int lowHz, int highHz);   // Hz from the carrier; its centre
+                                                 // is what the view centres on
 
     MiniPanScope* scope() const { return m_scope; }
     double spanKHz() const { return m_spanKHz; }
@@ -68,7 +73,7 @@ private:
 
     MiniPanScope* m_scope{nullptr};
 
-    double  m_centerMhz{0.0};
+    double  m_vfoMhz{0.0};
     double  m_spanKHz{10.0};   // ±5 kHz default (10 kHz total span)
 };
 

--- a/src/gui/MiniPanReslice.h
+++ b/src/gui/MiniPanReslice.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // Mini-pan re-slice: take one main-pan FFT frame and cut a narrow window out of
-// it around the followed VFO.
+// it around the followed VFO's passband (see passbandCenterOffsetHz below).
 //
 // This is the whole mini-pan data path. There is no dedicated radio pan and no
 // slice — the applet is a VIEW of bins the main pan is already streaming, so
@@ -59,5 +59,28 @@ inline QVector<float> resliceWindow(const QVector<float>& bins,
 // Output width for the re-sliced trace. Enough to render smoothly at any applet
 // width; a wide main pan simply repeats its few in-range bins across it.
 inline constexpr int kResliceOutputBins = 512;
+
+// Offset of the passband centre from the VFO carrier, in Hz, given the slice's
+// filter edges (Hz offsets from the carrier, e.g. USB 100..2800 → +1450).
+//
+// The mini-pan centres its window HERE, not on the carrier. On a single-sideband
+// mode the carrier sits at the edge of the passband, so a carrier-centred view
+// pushed the whole received signal into one half of an already narrow scope and
+// wasted the other half on the sideband that is filtered out. Centring on the
+// passband puts what the operator is actually listening to in the middle, which
+// is what a tuning aid is for. Symmetric modes (AM/FM, and CW filters that
+// straddle the carrier) give 0 and are unaffected.
+//
+// A hidden passband (hi <= lo — no slice, or filter edges not yet known) falls
+// back to 0, i.e. the carrier, rather than inventing an offset.
+//
+// This lives here, next to the re-slice, because MainWindow uses it to pick the
+// window it cuts and MiniPanScope uses it to place the carrier hairline and the
+// passband wash. Two copies of this arithmetic would mean the trace and the
+// chrome disagreeing about which frequency is in the middle.
+inline double passbandCenterOffsetHz(int lowHz, int highHz)
+{
+    return highHz > lowHz ? (lowHz + highHz) / 2.0 : 0.0;
+}
 
 } // namespace AetherSDR::MiniPan

--- a/src/gui/MiniPanScope.cpp
+++ b/src/gui/MiniPanScope.cpp
@@ -1,6 +1,7 @@
 #include "gui/MiniPanScope.h"
 
 #include "gui/FftHeatMap.h"
+#include "gui/MiniPanReslice.h"   // passbandCenterOffsetHz — shared with the re-slice
 #include "gui/SpectrumGrid.h"
 
 #include "core/ThemeManager.h"
@@ -33,8 +34,8 @@ MiniPanScope::MiniPanScope(QWidget* parent)
     setMinimumHeight(90);
     setAccessibleName(tr("Mini-pan spectrum scope"));
     setAccessibleDescription(
-        tr("Narrow spectrum trace centred on the active VFO, with the "
-           "receive passband shaded."));
+        tr("Narrow spectrum trace centred on the active VFO's receive passband, "
+           "which is shaded, with a hairline on the carrier frequency."));
 
     // The render paints through raw QPainter keyed off ThemeManager::color(),
     // so applyStyleSheet's reverse-map never sees these. Declare them so an
@@ -107,17 +108,17 @@ void MiniPanScope::setSpanKHz(double kHz)
     update();
 }
 
-void MiniPanScope::setCenterMhz(double mhz)
+void MiniPanScope::setVfoMhz(double mhz)
 {
-    if (qFuzzyCompare(m_centerMhz, mhz)) return;
-    m_centerMhz = mhz;
+    if (qFuzzyCompare(m_vfoMhz, mhz)) return;
+    m_vfoMhz = mhz;
     update();
 }
 
 QString MiniPanScope::readoutText() const
 {
-    return m_centerMhz > 0.0 ? QString::number(m_centerMhz, 'f', 6)
-                             : QStringLiteral("—.———");
+    return m_vfoMhz > 0.0 ? QString::number(m_vfoMhz, 'f', 6)
+                          : QStringLiteral("—.———");
 }
 
 void MiniPanScope::setPassbandHz(int lowHz, int highHz)
@@ -141,16 +142,28 @@ void MiniPanScope::paintEvent(QPaintEvent*)
     p.fillRect(rect(), tm.color(this, QStringLiteral("color.background.spectrum")));
 
     const double halfHz = m_spanKHz * 1000.0 / 2.0;   // e.g. 5000 Hz for ±5 kHz
-    const auto xOf = [&](double offHz) {
-        return w * 0.5 + (offHz / halfHz) * (w * 0.5);
+
+    // The view is centred on the PASSBAND centre, so a carrier-relative offset
+    // (which is what SliceModel reports, and what MainWindow re-slices around)
+    // has to be shifted by the carrier's own position before it can be drawn.
+    // Same helper MainWindow picks the re-slice window with — one definition, so
+    // the trace and this chrome cannot end up centred on different frequencies.
+    const double carrierOffHz =
+        -MiniPan::passbandCenterOffsetHz(m_pbLoHz, m_pbHiHz);
+    const auto xOf = [&](double offHzFromCentre) {
+        return w * 0.5 + (offHzFromCentre / halfHz) * (w * 0.5);
+    };
+    const auto xOfCarrierRel = [&](double offHzFromCarrier) {
+        return xOf(offHzFromCarrier + carrierOffHz);
     };
 
     // Passband band (translucent, brighter than the field). color.slice.a is
     // the same token the main panadapter shades slice A's passband with, so
-    // the two views read as one system.
+    // the two views read as one system. It lands symmetrically about the middle
+    // by construction — that is what centring on the passband means.
     if (m_pbHiHz > m_pbLoHz) {
-        const double x0 = std::clamp(xOf(m_pbLoHz), 0.0, w);
-        const double x1 = std::clamp(xOf(m_pbHiHz), 0.0, w);
+        const double x0 = std::clamp(xOfCarrierRel(m_pbLoHz), 0.0, w);
+        const double x1 = std::clamp(xOfCarrierRel(m_pbHiHz), 0.0, w);
         p.fillRect(QRectF(x0, 0, x1 - x0, h),
                    tinted("color.slice.a", kPassbandAlpha));
     }
@@ -162,7 +175,7 @@ void MiniPanScope::paintEvent(QPaintEvent*)
     //
     // No VERTICAL rules: the main pan's frequency spacing is chosen for its own
     // span (tens of kHz and up), so inside a 10 kHz window it yields one line or
-    // none. The centre hairline already marks the only frequency of interest.
+    // none. The carrier hairline already marks the only frequency of interest.
     if (m_showGrid) {
         const float range = m_maxDbm - m_minDbm;
         if (range > 0.0f) {
@@ -177,9 +190,18 @@ void MiniPanScope::paintEvent(QPaintEvent*)
         }
     }
 
-    // Centre hairline.
-    p.setPen(tinted("color.accent", kHairlineAlpha));
-    p.drawLine(QPointF(w * 0.5, 0), QPointF(w * 0.5, h));
+    // Carrier hairline — the VFO the readout above it shows. It sits dead centre
+    // only on a symmetric passband; on SSB it marks the sideband's edge, which is
+    // the point of centring on the passband instead.
+    //
+    // Skipped entirely when the carrier falls outside the span (a filter wider
+    // than the view can push it out): clamping it to the edge would plant the
+    // dial frequency on a frequency it is not on, and this is a tuning aid.
+    if (std::abs(carrierOffHz) <= halfHz) {
+        p.setPen(tinted("color.accent", kHairlineAlpha));
+        const double xc = xOf(carrierOffHz);
+        p.drawLine(QPointF(xc, 0), QPointF(xc, h));
+    }
 
     // FFT trace: filled polygon + bright line, in the source pan's own colours
     // and dBm window so the two views agree.

--- a/src/gui/MiniPanScope.h
+++ b/src/gui/MiniPanScope.h
@@ -3,10 +3,16 @@
 // MiniPanScope — the slim K4-style spectrum trace at the heart of the mini-pan.
 //
 // A deliberately bare tuning-aid render: dark field, a translucent passband band,
-// a centre hairline, a filled FFT trace, and ±span corner labels. NO overlay menu,
+// a carrier hairline, a filled FFT trace, and ±span corner labels. NO overlay menu,
 // dBm strip, waterfall or time axis — everything SpectrumWidget carries that a
 // tuning aid does not want (which is why the mini-pan does not reuse it; see
 // docs/minipan-implementation.md §3).
+//
+// The view is centred on the PASSBAND centre, not on the carrier — so on SSB the
+// received audio sits in the middle of the scope and the hairline marking the
+// carrier sits off to one side (MiniPan::passbandCenterOffsetHz). Everything the
+// paint draws is an offset from that centre, which is also the centre of the
+// window MainWindow re-slices, so the trace and the chrome agree.
 //
 // Appearance MIRRORS the main pan rather than inventing its own: MainWindow
 // pushes the source pan's FFT line/fill colours and its dBm window every frame,
@@ -35,14 +41,21 @@ public:
     void setDbmRange(float minDbm, float maxDbm);
     // Total visible span in kHz (e.g. 10.0 for a ±5 kHz view).
     void setSpanKHz(double kHz);
-    // Centre (VFO) frequency for the readout drawn in the top row, between the
-    // ±span labels. 0 renders the placeholder. Drawn here rather than in a
-    // QLabel above the scope so the trace gets the full height of the tile.
-    void setCenterMhz(double mhz);
+    // VFO (carrier) frequency: the readout drawn in the top row between the
+    // ±span labels, and the frequency the hairline marks. 0 renders the
+    // placeholder. Drawn here rather than in a QLabel above the scope so the
+    // trace gets the full height of the tile.
+    //
+    // NOT the centre of the view — that is the passband centre, which this and
+    // setPassbandHz() together determine.
+    void setVfoMhz(double mhz);
     // The readout exactly as drawn — for tests and automation, which have no
     // QLabel to read now.
     QString readoutText() const;
-    // Passband band as Hz offsets from centre (e.g. USB 100..2800). lo>=hi hides it.
+    // Passband as Hz offsets from the CARRIER (e.g. USB 100..2800), exactly as
+    // SliceModel reports them. lo>=hi hides the band and falls the view back to
+    // carrier-centred. Its midpoint is what the view centres on, so the band
+    // itself always renders symmetrically about the middle of the widget.
     void setPassbandHz(int lowHz, int highHz);
     // Mirror the source pan's FFT trace appearance (FFT Line / FFT Fill).
     // An invalid line or fill colour falls back to the theme's spectrum token,
@@ -60,7 +73,7 @@ protected:
 
 private:
     QVector<float> m_bins;
-    double m_centerMhz{0.0};
+    double m_vfoMhz{0.0};
     float  m_minDbm{-130.0f};
     float  m_maxDbm{-40.0f};
     double m_spanKHz{10.0};

--- a/tests/mini_pan_widget_test.cpp
+++ b/tests/mini_pan_widget_test.cpp
@@ -89,11 +89,15 @@ void testAppletBasics()
     // that row was dead space above an already-short trace.
     report("no separate readout label above the scope",
            a.findChild<QLabel*>("miniPanFreq") == nullptr);
-    a.setCenterMhz(14.074);
-    report("frequency readout follows setCenterMhz",
+    // The readout shows the CARRIER, not the passband centre the view is built
+    // around — the operator's dial frequency is the number they need, and it is
+    // the frequency the hairline marks.
+    a.setVfoMhz(14.074);
+    a.setPassbandHz(100, 2800);          // USB: view centre is 1.45 kHz higher
+    report("frequency readout follows the carrier, not the view centre",
            a.scope()->readoutText() == "14.074000",
            a.scope()->readoutText().toStdString());
-    a.setCenterMhz(0.0);
+    a.setVfoMhz(0.0);
     report("no active slice → placeholder readout",
            a.scope()->readoutText() == QString::fromUtf8("—.———"));
 
@@ -286,6 +290,67 @@ void testHeatMapAndGrid()
     scope.setShowGrid(true);
 }
 
+// Which frequency ends up in the middle. On SSB the carrier sits at the edge of
+// the filter, so centring on it spent half of an already narrow view on the
+// sideband the filter throws away — the window centres on the passband instead.
+// MainWindow cuts the re-slice around this offset and MiniPanScope places the
+// hairline and the wash with it, so a regression here desynchronises the trace
+// from the chrome as well as mis-centring both.
+void testPassbandCentreOffset()
+{
+    using AetherSDR::MiniPan::passbandCenterOffsetHz;
+
+    report("USB 100..2800 centres 1450 Hz above the carrier",
+           qFuzzyCompare(passbandCenterOffsetHz(100, 2800), 1450.0),
+           std::to_string(passbandCenterOffsetHz(100, 2800)));
+    report("LSB -2800..-100 centres 1450 Hz below the carrier",
+           qFuzzyCompare(passbandCenterOffsetHz(-2800, -100), -1450.0),
+           std::to_string(passbandCenterOffsetHz(-2800, -100)));
+
+    // A filter that straddles the carrier (AM/FM, and CW filters centred on the
+    // pitch) is unaffected — the view stays exactly where it was before.
+    report("symmetric passband still centres on the carrier",
+           qFuzzyIsNull(passbandCenterOffsetHz(-3000, 3000)));
+    // No slice, or filter edges not known yet: fall back to the carrier rather
+    // than inventing an offset from nonsense.
+    report("hidden passband falls back to the carrier",
+           qFuzzyIsNull(passbandCenterOffsetHz(0, 0))
+               && qFuzzyIsNull(passbandCenterOffsetHz(2800, 100)));
+}
+
+// The render side of the same rule: the wash must land symmetrically about the
+// middle of the widget, and the hairline must leave the middle to stay on the
+// carrier. Both are drawn from carrier-relative offsets, so an unshifted one
+// would put the band off-centre or the hairline on the wrong frequency.
+void testPassbandCentredRender()
+{
+    MiniPanScope scope;
+    scope.resize(300, 160);
+    scope.setDbmRange(-120.0f, -40.0f);
+    scope.setSpanKHz(10.0);              // ±5 kHz across 300 px → 30 px per kHz
+    scope.setShowGrid(false);            // keep the field plain to sample against
+    scope.setPassbandHz(100, 2800);      // USB: 2.7 kHz wide, centred 1450 Hz up
+    const QImage usb = scope.grab().toImage();
+
+    // Band half-width 1350 Hz → x 109.5..190.5 about the centre at 150. Sample
+    // well inside and well outside, clear of both edges and of the carrier
+    // hairline (1450 Hz below centre → x ≈ 106).
+    const int y = scope.height() - 5;    // below the top label row
+    const QRgb field = usb.pixel(30, y);
+    report("passband wash is centred on the widget",
+           usb.pixel(130, y) != field && usb.pixel(130, y) == usb.pixel(170, y));
+    report("outside the passband is plain field",
+           usb.pixel(70, y) == field && usb.pixel(230, y) == field);
+
+    // Same filter WIDTH, straddling the carrier: the wash is identical geometry,
+    // so the only thing that can differ is where the hairline is — which is the
+    // assertion. If the hairline were still pinned to the middle these would
+    // compare equal.
+    scope.setPassbandHz(-1350, 1350);
+    report("carrier hairline moves off centre on a sideband filter",
+           scope.grab().toImage() != usb);
+}
+
 // The whole mini-pan data path: cut a narrow window out of a main-pan frame.
 // No radio object is created, so this mapping is the feature.
 void testReslice()
@@ -354,6 +419,8 @@ int main(int argc, char** argv)
     testDbmWindowIsAuthoritative();
     testTraceAppearanceMirrors();
     testHeatMapAndGrid();
+    testPassbandCentreOffset();
+    testPassbandCentredRender();
     testReslice();
     testAppletBasics();
     testFeedLifecycle();


### PR DESCRIPTION
## The problem

On a single-sideband mode the carrier sits at the **edge** of the receive filter (USB `100..2800` Hz), so the carrier-centred mini-pan window spent half of an already narrow ±5 kHz scope on the sideband the filter throws away, and pushed everything the operator is actually listening to hard against one side of the tile.

The view now centres on the middle of the passband.

| | USB, ±5 kHz |
|---|---|
| Before | signal occupies the right half; left half is rejected sideband |
| After | signal centred; carrier hairline at the left edge of the wash |

## How

One shared helper, `MiniPan::passbandCenterOffsetHz()`, living next to the re-slice it parameterises, with exactly two consumers:

- `MainWindow::feedMiniPanFromPanFrame` — the centre of the window it cuts out of each frame. Re-derived from the slice per frame rather than read back off the applet, so the trace follows *this* frame's actual filter state.
- `MiniPanScope::paintEvent` — placing the passband wash and the carrier hairline, which are drawn from carrier-relative offsets and so need the same shift.

Two copies of that arithmetic would let the trace and the chrome end up centred on different frequencies, which is the one thing a tuning aid must never do.

Symmetric filters — AM, FM, and CW filters that straddle the carrier — give an offset of 0 and render exactly as before.

## Two judgement calls

**The hairline still marks the carrier**, so on SSB it sits at the edge of the wash rather than in the middle. It is the frequency the readout above it shows, and it matches how the main pan draws a slice; moving it to the passband centre would have it marking a frequency displayed nowhere. A filter wider than the span can push the carrier out of view — the hairline is then dropped rather than clamped to the edge, since clamping would plant the dial frequency on a frequency it is not on.

**The readout stays the dial frequency**, not the view centre.

`setCenterMhz` is renamed `setVfoMhz` on the applet and the scope, because "center" is now actively wrong — the carrier is not the centre of the view.

## Also

Drops a stale claim in `AppletPanel.cpp` that the mini-pan is off by default because *"it costs a radio pan slot"* — left over from the dedicated-pan architecture that was rejected in review on #4562. It creates nothing on the radio; it is off by default because it is a specialist view.

## Verification

Principle XI — Fixes Are Demonstrated. `mini_pan_widget_test` gains:

- the offset itself — SSB both ways, symmetric filters unchanged, hidden passband falls back to the carrier;
- the render it drives — the wash lands symmetric about the middle of the widget, and a same-width filter straddling the carrier renders differently, which can only be the hairline having left the centre.

44/44 offscreen. Full RelWithDebInfo build clean (2,951 targets). Rendered offscreen against a synthetic USB voice signal to confirm the geometry by eye.

Design record updated: `docs/minipan-implementation.md` §1.