### PR TITLE
feat(display): add "Clone to all Pans" to the Display panel

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -696,6 +696,7 @@ connects).
 | `panstats` | `<panIndex>` / `<objectName>` (default: all) | per-panadapter render-cost counters — see [`get panstats`](#get-panstats) |
 | `eqstats` | Client EQ canvas objectName (default: all) | analyzer paint/cache counters — see [`get eqstats`](#get-eqstats) |
 | `tracedebug` | `<panIndex>` / `<objectName>` (default: all) | per-panadapter Flex/Kiwi FFT and 3D trace diagnostics — see [`get tracedebug`](#get-tracedebug) |
+| `display` | `<panIndex>` / `<objectName>` (default: all) | per-panadapter **Display panel** settings — see [`get display`](#get-display) |
 | `wavestats` | `—` / scope objectName | waveform-scope paint/append counters — see [`get wavestats`](#get-wavestats) |
 | `clients` | — | connected-client roster, per-pan ownership, foreign dBm-write counters and evictions — see [`get clients`](#get-clients) |
 | `dax` | — | DAX RX channel-ownership table — see [`get dax`](#get-dax) |
@@ -956,6 +957,69 @@ used by the stacked trace renderer.
   sources; useful for checking that hidden histories continue updating.
 - `kiwiFftTraceFloorDbm` versus `kiwiDisplayFloorDbm` — distinguishes the FFT
   trace floor used by 3D placement from the waterfall color floor.
+
+### `get display`
+Per-panadapter **Display panel** settings — every value the panel's PANADAPTER
+/ WATERFALL / BACKGROUND / APPEARANCE / 3D VIEW groups own, as one flat object
+per pan. Where `get tracedebug` is diagnostic internals, this is the operator's
+own preferences, so a display change is assertable field-by-field instead of by
+comparing screenshots.
+
+```json
+→ {"cmd":"get","model":"display","selector":"1"}
+← {"ok":true,"model":"display","pans":[{
+   "panIndex":1,"objectName":"",
+   "fftAverage":0,"fftFps":25,"fftWeightedAvg":false,
+   "fftHeatMap":true,"showGrid":true,
+   "fftLineWidth":2.0,"fftLineColor":"#00e5ff",
+   "fftFillAlpha":0.7,"fftFillColor":"#00e5ff",
+   "noiseFloorEnable":false,"noiseFloorPosition":75,
+   "wfBlankerEnabled":false,"wfBlankerThreshold":1.15,"wfBlankerMode":0,
+   "wfBlackLevel":15,"wfAutoBlack":true,"wfAutoBlackOffset":50,
+   "wfAutoBlackRadioSide":false,"effectiveWfAutoBlackRadioSide":false,
+   "wfColorGain":50,"wfLineDuration":100,
+   "backgroundImage":":/bg-default.jpg","backgroundOpacity":80,
+   "backgroundFillColor":"#0a0a14",
+   "freqGridSpacing":0,"freqScaleFontPt":8,"wfColorScheme":0,
+   "spectrumRenderMode":0,"dssFloorDepth":6,"dssGain":70,"dssRowSpan":100,
+   "kiwiWaterfallActive":false}]}
+```
+
+`selector` filters by pan index (`get display 0`) or objectName; omit it for
+every pan. A trailing **property** narrows each entry to `panIndex`,
+`objectName`, and that one field — `get display "" wfColorScheme` is the
+one-line way to diff a palette across pans.
+
+Field notes:
+
+- `wfAutoBlackRadioSide` is the operator's stored **intent**;
+  `effectiveWfAutoBlackRadioSide` is that intent masked by whether this radio
+  computes a black level at all (#4606). They differ legitimately — assert the
+  intent when checking what a preference action copied, the effective value when
+  checking what renders.
+- `backgroundImage` is `""` when the background is off entirely (the "Off"
+  button), `:/bg-default.jpg` for the bundled logo, otherwise a file path.
+- `dssFloorDepth` and `noiseFloorPosition` are stored per display source;
+  `kiwiWaterfallActive` says which one these resolved from, so a Flex-vs-Kiwi
+  mismatch reads as a labelled difference rather than a mystery failure.
+- `fftAverage`, `fftFps`, `fftWeightedAvg` and `wfLineDuration` are
+  radio-authoritative: the values here are what the widget last saw from radio
+  status, and they settle a turn or two after a command.
+
+**Proving "Clone to all Pans"** (Display panel → SYSTEM, above Reset to
+Defaults) — change something on pan 0, clone, and diff:
+
+```json
+→ {"cmd":"invoke","target":"pan 0/displayColorSchemeCombo","action":"select","value":"2"}
+→ {"cmd":"invoke","target":"pan 0/displayCloneToAllPansBtn","action":"click"}
+→ {"cmd":"get","model":"display"}
+← {"ok":true,"model":"display","pans":[
+   {"panIndex":0,"wfColorScheme":2, …},
+   {"panIndex":1,"wfColorScheme":2, …}]}
+```
+
+The radio-authoritative fields settle asynchronously, so re-poll rather than
+asserting them in the same write as the click.
 
 ### `get rhi`
 Per-panadapter `QRhiWidget` **surface geometry and native-widget topology** —

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -5001,7 +5001,10 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
         // GUI-header-free: snapshotted via meta-call, same as panstats.
         bool selectorIsIndex = false;
         const int wantIndex = selector.toInt(&selectorIsIndex);
-        QJsonArray pans;
+        // Collect first, emit second: an unknown property must be rejected
+        // once, up front, rather than after entries for the earlier pans have
+        // already been built — that is how the other models read.
+        QVector<QVariantMap> snaps;
         // A floated container is reachable from two top-level roots, so the
         // class walk can yield the same widget twice — dedupe by pointer.
         QSet<QWidget*> seen;
@@ -5026,23 +5029,28 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
                 && snap.value(QStringLiteral("panIndex")).toInt() != wantIndex) {
                 continue;
             }
-            if (!property.isEmpty()) {
-                if (!snap.contains(property)) {
-                    return err(QStringLiteral("unknown property '") + property
-                               + QStringLiteral("' for display"));
-                }
-                QJsonObject one{
-                    {QStringLiteral("panIndex"),
-                     snap.value(QStringLiteral("panIndex")).toInt()},
-                    {QStringLiteral(
-                         "objectName"),
-                     snap.value(QStringLiteral("objectName")).toString()},
-                    {property,
-                     QJsonValue::fromVariant(snap.value(property))}};
-                pans.append(one);
+            snaps.append(snap);
+        }
+        // Every pan carries the same field set, so the first is enough to
+        // validate against. With no pan matched there is nothing to check the
+        // name against, so an empty `pans` is the honest answer.
+        if (!property.isEmpty() && !snaps.isEmpty()
+            && !snaps.first().contains(property)) {
+            return err(QStringLiteral("unknown property '") + property
+                       + QStringLiteral("' for display"));
+        }
+        QJsonArray pans;
+        for (const QVariantMap& snap : snaps) {
+            if (property.isEmpty()) {
+                pans.append(QJsonObject::fromVariantMap(snap));
                 continue;
             }
-            pans.append(QJsonObject::fromVariantMap(snap));
+            pans.append(QJsonObject{
+                {QStringLiteral("panIndex"),
+                 snap.value(QStringLiteral("panIndex")).toInt()},
+                {QStringLiteral("objectName"),
+                 snap.value(QStringLiteral("objectName")).toString()},
+                {property, QJsonValue::fromVariant(snap.value(property))}});
         }
         QJsonObject out{{QStringLiteral("ok"), true},
                         {QStringLiteral("model"), model},

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -2597,6 +2597,7 @@ const QStringList& getModelNames()
         QStringLiteral("gps"),        QStringLiteral("clock"),
         QStringLiteral("renderstats"),
         QStringLiteral("eqstats"),    QStringLiteral("tracedebug"),
+        QStringLiteral("display"),
         QStringLiteral("waveforms"),
         QStringLiteral("kiwi"),
     };
@@ -4993,6 +4994,64 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
         }
         return out;
     }
+    if (model == QLatin1String("display")) {
+        // Per-panadapter Display-panel settings, so a preference change can be
+        // asserted field-by-field instead of eyeballed. "Clone to all Pans"
+        // proves itself by reading this twice and diffing the pans.
+        // GUI-header-free: snapshotted via meta-call, same as panstats.
+        bool selectorIsIndex = false;
+        const int wantIndex = selector.toInt(&selectorIsIndex);
+        QJsonArray pans;
+        // A floated container is reachable from two top-level roots, so the
+        // class walk can yield the same widget twice — dedupe by pointer.
+        QSet<QWidget*> seen;
+        const QList<QWidget*> widgets =
+            findWidgetsByClass(QStringLiteral("SpectrumWidget"));
+        for (QWidget* w : widgets) {
+            if (seen.contains(w)) {
+                continue;
+            }
+            seen.insert(w);
+            if (!selector.isEmpty() && !selectorIsIndex
+                && w->objectName() != selector) {
+                continue;
+            }
+            QVariantMap snap;
+            if (!QMetaObject::invokeMethod(
+                    w, "automationDisplaySettingsSnapshot", Qt::DirectConnection,
+                    Q_RETURN_ARG(QVariantMap, snap))) {
+                continue;
+            }
+            if (!selector.isEmpty() && selectorIsIndex
+                && snap.value(QStringLiteral("panIndex")).toInt() != wantIndex) {
+                continue;
+            }
+            if (!property.isEmpty()) {
+                if (!snap.contains(property)) {
+                    return err(QStringLiteral("unknown property '") + property
+                               + QStringLiteral("' for display"));
+                }
+                QJsonObject one{
+                    {QStringLiteral("panIndex"),
+                     snap.value(QStringLiteral("panIndex")).toInt()},
+                    {QStringLiteral(
+                         "objectName"),
+                     snap.value(QStringLiteral("objectName")).toString()},
+                    {property,
+                     QJsonValue::fromVariant(snap.value(property))}};
+                pans.append(one);
+                continue;
+            }
+            pans.append(QJsonObject::fromVariantMap(snap));
+        }
+        QJsonObject out{{QStringLiteral("ok"), true},
+                        {QStringLiteral("model"), model},
+                        {QStringLiteral("pans"), pans}};
+        if (!property.isEmpty()) {
+            out[QStringLiteral("property")] = property;
+        }
+        return out;
+    }
     if (model == QLatin1String("tracedebug")) {
         // Per-panadapter trace/floor state from SpectrumWidget. This keeps the
         // bridge GUI-header-free while exposing enough state to compare Flex
@@ -5280,7 +5339,7 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
         data = panSnapshot(p, radio);
     } else {
         return err(QStringLiteral("unknown model: ") + model
-                   + QStringLiteral(" (use audio|dsp|sync|radio|transmit|cwx|equalizer|meters|slice|slices|pan|pans|flags|panstats|renderstats|eqstats|tracedebug|clients|kiwi|wavestats|clock)"));
+                   + QStringLiteral(" (use audio|dsp|sync|radio|transmit|cwx|equalizer|meters|slice|slices|pan|pans|flags|panstats|renderstats|eqstats|tracedebug|display|clients|kiwi|wavestats|clock)"));
     }
 
     if (!property.isEmpty()) {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -676,6 +676,11 @@ private:
     void wireBackendSeam(AetherSDR::IRadioBackend* backend);
     void noteBandRecallForPan(const QString& panId);
     void wirePanadapter(PanadapterApplet* applet);
+    // Display panel → "Clone to all Pans". Copies every Display setting from
+    // `source` onto every other open panadapter (client-side appearance via the
+    // SpectrumWidget setters that persist it, radio-authoritative values via the
+    // same commands the live sliders send). Returns how many pans were written.
+    int cloneDisplaySettingsToAllPans(PanadapterApplet* source);
     void wirePanDisplayStatus(PanadapterApplet* applet, PanadapterModel* pan);
     void reassertUnmutedSliceAudioForPan(const QString& panId);
     void onMuteAllSlicesToggle();

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -3102,12 +3102,19 @@ int MainWindow::cloneDisplaySettingsToAllPans(PanadapterApplet* source)
         dst->setDssRowSpan(src->dssRowSpan());
 
         // ── Radio-authoritative values ────────────────────────────────────
-        m_radioModel.sendCommand(QString("display pan set %1 average=%2")
-                                     .arg(targetPanId)
-                                     .arg(src->fftAverage()));
-        m_radioModel.sendCommand(QString("display pan set %1 weighted_average=%2")
-                                     .arg(targetPanId)
-                                     .arg(src->fftWeightedAvg() ? 1 : 0));
+        // A pan applet exists before the radio hands back its id (setPanId()
+        // runs after creation), so a clone racing pan creation would put
+        // `display pan set  average=0` — double space, no id — on the wire.
+        // requestPanDisplayRates() already returns early on an empty id; these
+        // two raw sendCommand() calls are the exposed pair.
+        if (!targetPanId.isEmpty()) {
+            m_radioModel.sendCommand(QString("display pan set %1 average=%2")
+                                         .arg(targetPanId)
+                                         .arg(src->fftAverage()));
+            m_radioModel.sendCommand(QString("display pan set %1 weighted_average=%2")
+                                         .arg(targetPanId)
+                                         .arg(src->fftWeightedAvg() ? 1 : 0));
+        }
         dst->setFftAverage(src->fftAverage());
         dst->setFftWeightedAvg(src->fftWeightedAvg());
         // Always update the widget's restore target; only ask the radio when the
@@ -3168,15 +3175,26 @@ int MainWindow::cloneDisplaySettingsToAllPans(PanadapterApplet* source)
 
         // Repaint the target's own Display panel so an operator who opens it
         // sees the cloned values rather than the pre-clone slider positions.
-        if (targetIsKiwi) {
-            // syncDisplaySettings() opens with setKiwiWaterfallControlMode(false),
-            // which would drop a Kiwi-displaying pan's panel back to Flex
-            // control mode — relabelling WF Ceiling/Floor and resetting their
-            // ranges from the profile's dBm span to 0..100, clamping the stored
-            // dBm values on the way. This is the canonical restore: it runs the
-            // same Flex sync AND re-enters Kiwi mode.
-            syncKiwiSdrPanadapterUiState(targetPanId);
-        } else if (SpectrumOverlayMenu* dstMenu = dst->overlayMenu()) {
+        // BOTH steps run for a Kiwi target, in this order.
+        //
+        // syncKiwiSdrPanadapterUiState() alone is not enough: on a pan that is
+        // actually displaying Kiwi it falls through to the final block and
+        // calls syncKiwiWaterfallSettings() only — its internal
+        // syncFlexDisplaySettings() runs on the two EARLY-RETURN paths (no
+        // profile, or profile present but not displaying Kiwi). So a Kiwi
+        // target would get its WF Ceiling/Floor/Rate refreshed and nothing
+        // else: heat map, grid, line width/colour, fill, FFT floor, colour
+        // scheme, render mode, 3D and average would all still show the
+        // pre-clone positions, and the panel would read as if the clone had
+        // not happened.
+        //
+        // Running the Flex sync first is safe even though it opens with
+        // setKiwiWaterfallControlMode(false): syncDisplaySettings() blocks its
+        // signals, and the dBm span lives in the profile / KiwiSdrManager
+        // rather than in the menu, so syncKiwiWaterfallSettings() re-reads it
+        // (profile.waterfallMinDbm/MaxDbm) and the transient 0..100 clamp
+        // cannot destroy anything.
+        if (SpectrumOverlayMenu* dstMenu = dst->overlayMenu()) {
             dstMenu->syncDisplaySettings(
                 dst->fftAverage(), dst->fftFps(),
                 static_cast<int>(dst->fftFillAlpha() * 100.0f),
@@ -3189,8 +3207,13 @@ int MainWindow::cloneDisplaySettingsToAllPans(PanadapterApplet* source)
                 dst->spectrumRenderMode(), dst->dssFloorDepth(),
                 dst->dssGain(), dst->fftLineColor(), dst->dssRowSpan());
         }
+        if (targetIsKiwi) {
+            // Re-enter Kiwi control mode over the Flex sync above: restores the
+            // dBm labels and the profile's span on WF Ceiling / WF Floor.
+            syncKiwiSdrPanadapterUiState(targetPanId);
+        }
         // Kiwi-agnostic controls: syncKiwiSdrPanadapterUiState() does not carry
-        // these, so both branches need them.
+        // these, so they run for every target.
         if (SpectrumOverlayMenu* dstMenu = dst->overlayMenu()) {
             dstMenu->syncExtraDisplaySettings(
                 dst->wfBlankerEnabled(), dst->wfBlankerThreshold(),
@@ -3201,6 +3224,20 @@ int MainWindow::cloneDisplaySettingsToAllPans(PanadapterApplet* source)
     }
 
     if (cloned > 0) {
+        // The two radio-GLOBAL auto-black flags, asserted ONCE after the loop
+        // rather than per target. The per-target block deliberately omits them
+        // because they are not per-pan — but "the source pan's own toggle
+        // already set them" only holds if the operator toggled it THIS session:
+        // on a fresh start the source restores wfAutoBlack /
+        // wfAutoBlackRadioSide from AppSettings without ever passing through
+        // wfAutoBlackChanged / wfAutoBlackSourceChanged, so the radio-side
+        // flags can still be at their defaults. Idempotent, and one write.
+        // Radio-side INTENT, not the capability-masked value, for the same
+        // reason the per-target clone uses wfAutoBlackRadioSide().
+        if (!srcIsKiwi) {
+            m_radioModel.setWaterfallAutoBlack(src->wfAutoBlack());
+            m_radioModel.setWaterfallAutoBlackSource(src->wfAutoBlackRadioSide());
+        }
         settings.save();
     }
     return cloned;

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -3035,6 +3035,9 @@ int MainWindow::cloneDisplaySettingsToAllPans(PanadapterApplet* source)
     }
 
     auto& settings = AppSettings::instance();
+    // Whether the SOURCE pan is showing Kiwi decides what its waterfall
+    // level/rate accessors actually mean — see the waterfall block below.
+    const bool srcIsKiwi = kiwiSdrPanDisplaysKiwi(source->panId());
     int cloned = 0;
 
     for (PanadapterApplet* target : m_panStack->allApplets()) {
@@ -3055,19 +3058,24 @@ int MainWindow::cloneDisplaySettingsToAllPans(PanadapterApplet* source)
         dst->setFftLineColor(src->fftLineColor());
         dst->setFftFillAlpha(src->fftFillAlpha());
         dst->setFftFillColor(src->fftFillColor());
+        // noiseFloorPosition (and dssFloorDepth below) are stored per display
+        // source, so these setters write the target's CURRENTLY DISPLAYED
+        // source and read the source pan's. That is deliberate: the operator
+        // is cloning the look they can see, not a Flex slot and a Kiwi slot.
+        // The target's other-source value is left alone rather than
+        // overwritten with a position that was never chosen for it.
         dst->setNoiseFloorPosition(src->noiseFloorPosition());
         dst->setNoiseFloorEnable(src->noiseFloorEnabled());
 
         // ── WATERFALL (client-side) ───────────────────────────────────────
+        // The blanker is Flex/Kiwi-agnostic — it filters rows after they land,
+        // whatever produced them — so it clones unconditionally. Everything
+        // else on this group (auto-black trio, gain, black level, rate) is
+        // cloned in the waterfall block further down, which is gated: all five
+        // of those live per-control handlers bail on a Kiwi-displaying pan.
         dst->setWfBlankerEnabled(src->wfBlankerEnabled());
         dst->setWfBlankerThreshold(src->wfBlankerThreshold());
         dst->setWfBlankerMode(src->wfBlankerMode());
-        dst->setWfAutoBlack(src->wfAutoBlack());
-        dst->setWfAutoBlackOffset(src->wfAutoBlackOffset());
-        // The operator's stored INTENT, not the capability-masked value — see
-        // SpectrumWidget::wfAutoBlackRadioSide(). Cloning the masked value would
-        // quietly downgrade every other pan to SW on a radio without HW.
-        dst->setWfAutoBlackRadioSide(src->wfAutoBlackRadioSide());
 
         // ── BACKGROUND ────────────────────────────────────────────────────
         // "none" is the persisted spelling for background-off; an empty path is
@@ -3111,7 +3119,26 @@ int MainWindow::cloneDisplaySettingsToAllPans(PanadapterApplet* source)
                                                 /*wfMs=*/0);
         }
 
-        if (!targetIsKiwi) {
+        // ── Waterfall level/rate controls ─────────────────────────────────
+        // Skipped whenever EITHER end is displaying Kiwi. Target-side is the
+        // guard the five live handlers use. Source-side matters just as much:
+        // on a Kiwi-displaying pan these sliders drive the profile's dBm
+        // min/max through KiwiSdrManager, so wfColorGain()/wfBlackLevel()/
+        // wfLineDuration() still hold whatever stale Flex values the widget
+        // last had. Cloning those would push a setting the operator never made
+        // anywhere onto every Flex pan — and send `display panafall set` for it.
+        if (!srcIsKiwi && !targetIsKiwi) {
+            dst->setWfAutoBlack(src->wfAutoBlack());
+            dst->setWfAutoBlackOffset(src->wfAutoBlackOffset());
+            // The operator's stored INTENT, not the capability-masked value —
+            // see SpectrumWidget::wfAutoBlackRadioSide(). Cloning the masked
+            // value would quietly downgrade every other pan to SW on a radio
+            // without HW.
+            dst->setWfAutoBlackRadioSide(src->wfAutoBlackRadioSide());
+            // No m_radioModel.setWaterfallAutoBlack()/setWaterfallAutoBlackSource()
+            // here, unlike the live handlers: those two are radio-GLOBAL, and
+            // the source pan's own toggle already set them to these values.
+            // Re-sending them once per target would be the same write N times.
             dst->setWfColorGain(src->wfColorGain());
             dst->setWfBlackLevel(src->wfBlackLevel());
             if (auto* pan = m_radioModel.panadapter(targetPanId);
@@ -3125,16 +3152,31 @@ int MainWindow::cloneDisplaySettingsToAllPans(PanadapterApplet* source)
                         .arg(pan->waterfallId())
                         .arg(src->wfBlackLevel()));
             }
-            dst->setWfLineDuration(src->wfLineDuration());
+            // Clamp like the slider path does (applyWaterfallLineDuration).
+            // The source value came through the same clamp today, so this is
+            // belt-and-braces — but the two paths should not disagree about
+            // what a legal rate is.
+            const int wfRate = std::clamp(src->wfLineDuration(),
+                                          AetherSDR::WaterfallRate::kMin,
+                                          AetherSDR::WaterfallRate::kMax);
+            dst->setWfLineDuration(wfRate);
             if (!m_adaptiveThrottleActive) {
                 m_radioModel.requestPanDisplayRates(targetPanId, /*fps=*/0,
-                                                    src->wfLineDuration());
+                                                    wfRate);
             }
         }
 
         // Repaint the target's own Display panel so an operator who opens it
         // sees the cloned values rather than the pre-clone slider positions.
-        if (SpectrumOverlayMenu* dstMenu = dst->overlayMenu()) {
+        if (targetIsKiwi) {
+            // syncDisplaySettings() opens with setKiwiWaterfallControlMode(false),
+            // which would drop a Kiwi-displaying pan's panel back to Flex
+            // control mode — relabelling WF Ceiling/Floor and resetting their
+            // ranges from the profile's dBm span to 0..100, clamping the stored
+            // dBm values on the way. This is the canonical restore: it runs the
+            // same Flex sync AND re-enters Kiwi mode.
+            syncKiwiSdrPanadapterUiState(targetPanId);
+        } else if (SpectrumOverlayMenu* dstMenu = dst->overlayMenu()) {
             dstMenu->syncDisplaySettings(
                 dst->fftAverage(), dst->fftFps(),
                 static_cast<int>(dst->fftFillAlpha() * 100.0f),
@@ -3146,6 +3188,10 @@ int MainWindow::cloneDisplaySettingsToAllPans(PanadapterApplet* source)
                 dst->fftLineWidth(), dst->wfAutoBlackRadioSide(),
                 dst->spectrumRenderMode(), dst->dssFloorDepth(),
                 dst->dssGain(), dst->fftLineColor(), dst->dssRowSpan());
+        }
+        // Kiwi-agnostic controls: syncKiwiSdrPanadapterUiState() does not carry
+        // these, so both branches need them.
+        if (SpectrumOverlayMenu* dstMenu = dst->overlayMenu()) {
             dstMenu->syncExtraDisplaySettings(
                 dst->wfBlankerEnabled(), dst->wfBlankerThreshold(),
                 dst->backgroundOpacity(), dst->freqGridSpacing(),

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -3002,6 +3002,163 @@ void MainWindow::wirePanDisplayStatus(PanadapterApplet* applet,
     }
 }
 
+// Display panel → "Clone to all Pans" (sits above Reset to Defaults).
+//
+// Every value the Display panel can change is written onto every OTHER open
+// panadapter. Three kinds of setting live in that panel and each has to travel
+// its own way — a single "copy the settings blob" pass would get two of them
+// wrong:
+//
+//   1. Client appearance (trace colours, fill, waterfall palette/blanker,
+//      background, grid, 3D view). The SpectrumWidget setters both apply and
+//      persist under the target's own per-pan settingsKey(), so calling them is
+//      the whole job.
+//   2. Client appearance whose setter does NOT persist (background image path
+//      and opacity — MainWindow has always owned those writes, see the
+//      backgroundImage* handlers). Persisted explicitly here.
+//   3. Radio-authoritative values (FFT average / FPS / weighted average,
+//      waterfall line duration, color gain, black level). Per AGENTS.md these
+//      are never persisted client-side; they are cloned by sending the same
+//      commands the live sliders send, so the radio echoes them back as status.
+//
+// Kiwi-backed pans re-use the waterfall gain/black/rate controls for a different
+// quantity (dBm range), so those three are skipped for such a target exactly as
+// the live per-control handlers skip them.
+int MainWindow::cloneDisplaySettingsToAllPans(PanadapterApplet* source)
+{
+    if (!source || !m_panStack) {
+        return 0;
+    }
+    SpectrumWidget* src = source->spectrumWidget();
+    if (!src) {
+        return 0;
+    }
+
+    auto& settings = AppSettings::instance();
+    int cloned = 0;
+
+    for (PanadapterApplet* target : m_panStack->allApplets()) {
+        if (!target || target == source) {
+            continue;
+        }
+        SpectrumWidget* dst = target->spectrumWidget();
+        if (!dst || dst == src) {
+            continue;
+        }
+        const QString targetPanId = target->panId();
+        const bool targetIsKiwi = kiwiSdrPanDisplaysKiwi(targetPanId);
+
+        // ── PANADAPTER ────────────────────────────────────────────────────
+        dst->setFftHeatMap(src->fftHeatMap());
+        dst->setShowGrid(src->showGrid());
+        dst->setFftLineWidth(src->fftLineWidth());
+        dst->setFftLineColor(src->fftLineColor());
+        dst->setFftFillAlpha(src->fftFillAlpha());
+        dst->setFftFillColor(src->fftFillColor());
+        dst->setNoiseFloorPosition(src->noiseFloorPosition());
+        dst->setNoiseFloorEnable(src->noiseFloorEnabled());
+
+        // ── WATERFALL (client-side) ───────────────────────────────────────
+        dst->setWfBlankerEnabled(src->wfBlankerEnabled());
+        dst->setWfBlankerThreshold(src->wfBlankerThreshold());
+        dst->setWfBlankerMode(src->wfBlankerMode());
+        dst->setWfAutoBlack(src->wfAutoBlack());
+        dst->setWfAutoBlackOffset(src->wfAutoBlackOffset());
+        // The operator's stored INTENT, not the capability-masked value — see
+        // SpectrumWidget::wfAutoBlackRadioSide(). Cloning the masked value would
+        // quietly downgrade every other pan to SW on a radio without HW.
+        dst->setWfAutoBlackRadioSide(src->wfAutoBlackRadioSide());
+
+        // ── BACKGROUND ────────────────────────────────────────────────────
+        // "none" is the persisted spelling for background-off; an empty path is
+        // its in-memory form. Keep the two in step or a restart resurrects the
+        // default logo on a pan the operator turned off.
+        const QString bgPath = src->backgroundImagePath();
+        dst->setBackgroundImage(bgPath);
+        settings.setValue(dst->settingsKey("BackgroundImage"),
+                          bgPath.isEmpty() ? QStringLiteral("none") : bgPath);
+        dst->setBackgroundOpacity(src->backgroundOpacity());
+        settings.setValue(dst->settingsKey("BackgroundOpacity"),
+                          QString::number(src->backgroundOpacity()));
+        dst->setBackgroundFillColor(src->backgroundFillColor());
+
+        // ── APPEARANCE ────────────────────────────────────────────────────
+        dst->setFreqGridSpacing(src->freqGridSpacing());
+        dst->setFreqScaleFontPt(src->freqScaleFontPt());
+        dst->setWfColorScheme(src->wfColorScheme());
+
+        // ── 3D VIEW ───────────────────────────────────────────────────────
+        dst->setSpectrumRenderMode(src->spectrumRenderMode());
+        dst->setDssFloorDepth(src->dssFloorDepth());
+        dst->setDssGain(src->dssGain());
+        dst->setDssRowSpan(src->dssRowSpan());
+
+        // ── Radio-authoritative values ────────────────────────────────────
+        m_radioModel.sendCommand(QString("display pan set %1 average=%2")
+                                     .arg(targetPanId)
+                                     .arg(src->fftAverage()));
+        m_radioModel.sendCommand(QString("display pan set %1 weighted_average=%2")
+                                     .arg(targetPanId)
+                                     .arg(src->fftWeightedAvg() ? 1 : 0));
+        dst->setFftAverage(src->fftAverage());
+        dst->setFftWeightedAvg(src->fftWeightedAvg());
+        // Always update the widget's restore target; only ask the radio when the
+        // congestion-aware throttle isn't holding the rates down (same rule as
+        // the FPS slider — otherwise the clone fights the cap).
+        dst->setFftFps(src->fftFps());
+        if (!m_adaptiveThrottleActive) {
+            m_radioModel.requestPanDisplayRates(targetPanId, src->fftFps(),
+                                                /*wfMs=*/0);
+        }
+
+        if (!targetIsKiwi) {
+            dst->setWfColorGain(src->wfColorGain());
+            dst->setWfBlackLevel(src->wfBlackLevel());
+            if (auto* pan = m_radioModel.panadapter(targetPanId);
+                pan && !pan->waterfallId().isEmpty()) {
+                m_radioModel.sendCommand(
+                    QString("display panafall set %1 color_gain=%2")
+                        .arg(pan->waterfallId())
+                        .arg(src->wfColorGain()));
+                m_radioModel.sendCommand(
+                    QString("display panafall set %1 black_level=%2")
+                        .arg(pan->waterfallId())
+                        .arg(src->wfBlackLevel()));
+            }
+            dst->setWfLineDuration(src->wfLineDuration());
+            if (!m_adaptiveThrottleActive) {
+                m_radioModel.requestPanDisplayRates(targetPanId, /*fps=*/0,
+                                                    src->wfLineDuration());
+            }
+        }
+
+        // Repaint the target's own Display panel so an operator who opens it
+        // sees the cloned values rather than the pre-clone slider positions.
+        if (SpectrumOverlayMenu* dstMenu = dst->overlayMenu()) {
+            dstMenu->syncDisplaySettings(
+                dst->fftAverage(), dst->fftFps(),
+                static_cast<int>(dst->fftFillAlpha() * 100.0f),
+                dst->fftWeightedAvg(), dst->fftFillColor(), dst->wfColorGain(),
+                dst->wfBlackLevel(), dst->wfAutoBlack(),
+                dst->wfAutoBlackOffset(), dst->wfLineDuration(),
+                dst->noiseFloorPosition(), dst->noiseFloorEnabled(),
+                dst->fftHeatMap(), dst->wfColorScheme(), dst->showGrid(),
+                dst->fftLineWidth(), dst->wfAutoBlackRadioSide(),
+                dst->spectrumRenderMode(), dst->dssFloorDepth(),
+                dst->dssGain(), dst->fftLineColor(), dst->dssRowSpan());
+            dstMenu->syncExtraDisplaySettings(
+                dst->wfBlankerEnabled(), dst->wfBlankerThreshold(),
+                dst->backgroundOpacity(), dst->freqGridSpacing(),
+                dst->backgroundFillColor(), dst->freqScaleFontPt());
+        }
+        ++cloned;
+    }
+
+    if (cloned > 0) {
+        settings.save();
+    }
+    return cloned;
+}
 
 void MainWindow::wirePanadapter(PanadapterApplet* applet)
 {
@@ -4273,6 +4430,28 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
                                   QColor(0x00, 0xe5, 0xff), 100);
         menu->syncExtraDisplaySettings(false, 1.15f, 80, 0,
                                        QColor(0x0a, 0x0a, 0x14));
+    });
+    connect(menu, &SpectrumOverlayMenu::displaySettingsCloneRequested,
+            this, [this, applet, sw] {
+        const int cloned = cloneDisplaySettingsToAllPans(applet);
+
+        // Feedback on the source pan: the operator is looking at THIS panel, and
+        // with a single pan open (or every other pan floated off-screen) a silent
+        // button is indistinguishable from a broken one.
+        PanadapterOverlayMessage message;
+        message.id = QStringLiteral("display.clone-to-all-pans");
+        message.timeoutMs = 4000;
+        message.dismissible = true;
+        if (cloned > 0) {
+            message.title = tr("Display settings cloned");
+            message.detail = tr("Applied to %n other panadapter(s).", nullptr, cloned);
+            message.tone = PanadapterOverlayMessageTone::Info;
+        } else {
+            message.title = tr("Nothing to clone");
+            message.detail = tr("This is the only open panadapter.");
+            message.tone = PanadapterOverlayMessageTone::Warning;
+        }
+        sw->upsertOverlayMessage(std::move(message));
     });
 
     auto resolveClickedPanId = [this, sw]() -> QString {

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -338,17 +338,19 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
         int specialIdx;
         void (SpectrumOverlayMenu::*sig)();
     };
+    // QT_TR_NOOP marks each name for lupdate here and tr() translates it at the
+    // use site below — tr() on a non-literal extracts nothing.
     const BtnDef defs[] = {
         // 0 — handled separately (signal has panId arg)
-        {"+RX",     "panMenuAddRxBtn",    "Add receive slice",       -1, nullptr},
-        {"+TNF",    "panMenuAddTnfBtn",   "Add tracking notch filter", -1,
+        {"+RX",     "panMenuAddRxBtn",    QT_TR_NOOP("Add receive slice"),   -1, nullptr},
+        {"+TNF",    "panMenuAddTnfBtn",   QT_TR_NOOP("Add tracking notch filter"), -1,
          &SpectrumOverlayMenu::addTnfClicked},                       // 1
-        {"Band",    "panMenuBandBtn",     "Band panel",               0, nullptr},
-        {"ANT",     "panMenuAntBtn",      "Antenna panel",            1, nullptr},
-        {"Display", "panMenuDisplayBtn",  "Display panel",            4, nullptr},
-        {"Memory",  "panMenuMemoryBtn",   "Memory panel",             5, nullptr},
+        {"Band",    "panMenuBandBtn",     QT_TR_NOOP("Band panel"),           0, nullptr},
+        {"ANT",     "panMenuAntBtn",      QT_TR_NOOP("Antenna panel"),        1, nullptr},
+        {"Display", "panMenuDisplayBtn",  QT_TR_NOOP("Display panel"),        4, nullptr},
+        {"Memory",  "panMenuMemoryBtn",   QT_TR_NOOP("Memory panel"),         5, nullptr},
         // Add Memory lives at the top of MemoryBrowsePanel, outside the scrolling rows.
-        {"DAX",     "panMenuDaxBtn",      "DAX panel",                3, nullptr},
+        {"DAX",     "panMenuDaxBtn",      QT_TR_NOOP("DAX panel"),            3, nullptr},
     };
 
     for (const auto& def : defs) {

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -2154,14 +2154,18 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         });
     }
 
-    // ── Clone to all Pans ─────────────────────────────────────────────────
-    // Sits directly above Reset to Defaults: both are whole-panel actions, and
-    // this one is the constructive counterpart — it takes the look the operator
+    // ── Whole-panel actions: Clone to all Pans, then Reset to Defaults ────
+    // Clone sits directly above Reset because both act on the panel as a whole,
+    // and Clone is the constructive counterpart — it takes the look the operator
     // just built here and applies it everywhere, instead of throwing it away.
+    //
+    // Both are styled through ONE setStyleSheet() call over the pair. They are
+    // full-width action buttons sharing btnStyle exactly, so a second call site
+    // would add nothing but a place for the two to drift apart — and the
+    // hardcoded-colour ratchet counts call sites, not colours.
     {
         m_cloneToAllPansBtn = new QPushButton("Clone to all Pans");
         m_cloneToAllPansBtn->setObjectName("displayCloneToAllPansBtn");
-        m_cloneToAllPansBtn->setStyleSheet(btnStyle);
         m_cloneToAllPansBtn->setToolTip(
             "Copy every Display setting on this panadapter — trace, waterfall, "
             "background, appearance and 3D view — onto all other open "
@@ -2173,21 +2177,19 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         connect(m_cloneToAllPansBtn, &QPushButton::clicked, this, [this] {
             emit displaySettingsCloneRequested();
         });
-        grid->addWidget(m_cloneToAllPansBtn, row, 0, 1, 4);
-        ++row;
-    }
 
-    // ── Reset button ──────────────────────────────────────────────────────
-    {
         auto* resetBtn = new QPushButton("Reset to Defaults");
         resetBtn->setObjectName("displayResetBtn");
-        resetBtn->setStyleSheet(btnStyle);
         resetBtn->setToolTip("Reset all display settings to their default values");
         connect(resetBtn, &QPushButton::clicked, this, [this] {
             emit displaySettingsReset();
         });
-        grid->addWidget(resetBtn, row, 0, 1, 4);
-        ++row;
+
+        for (QPushButton* actionBtn : {m_cloneToAllPansBtn, resetBtn}) {
+            actionBtn->setStyleSheet(btnStyle);
+            grid->addWidget(actionBtn, row, 0, 1, 4);
+            ++row;
+        }
     }
 
     // Display panel tooltips

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -327,20 +327,34 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
     connect(m_toggleBtn, &QPushButton::clicked, this, &SpectrumOverlayMenu::toggle);
 
     // Menu buttons — Band, ANT, DSP handled specially (sub-panels)
-    struct BtnDef { QString text; int specialIdx; void (SpectrumOverlayMenu::*sig)(); };
+    // `objName` is the automation bridge's handle on each row. Without it the
+    // sub-panels behind these buttons (Display, Band, ANT, DAX, Memory) are
+    // unreachable from a test: their contents are addressable but nothing can
+    // open them, so every control inside reads as "not visible".
+    struct BtnDef {
+        QString text;
+        const char* objName;
+        const char* a11y;
+        int specialIdx;
+        void (SpectrumOverlayMenu::*sig)();
+    };
     const BtnDef defs[] = {
-        {"+RX",      -1, nullptr},   // 0 — handled separately (signal has panId arg)
-        {"+TNF",     -1, &SpectrumOverlayMenu::addTnfClicked},  // 1
-        {"Band",      0, nullptr},   // 2 — toggleBandPanel
-        {"ANT",       1, nullptr},   // 3 — toggleAntPanel
-        {"Display",   4, nullptr},   // 4 — toggleDisplayPanel
-        {"Memory",    5, nullptr},   // 6 — toggleMemoryPanel
+        // 0 — handled separately (signal has panId arg)
+        {"+RX",     "panMenuAddRxBtn",    "Add receive slice",       -1, nullptr},
+        {"+TNF",    "panMenuAddTnfBtn",   "Add tracking notch filter", -1,
+         &SpectrumOverlayMenu::addTnfClicked},                       // 1
+        {"Band",    "panMenuBandBtn",     "Band panel",               0, nullptr},
+        {"ANT",     "panMenuAntBtn",      "Antenna panel",            1, nullptr},
+        {"Display", "panMenuDisplayBtn",  "Display panel",            4, nullptr},
+        {"Memory",  "panMenuMemoryBtn",   "Memory panel",             5, nullptr},
         // Add Memory lives at the top of MemoryBrowsePanel, outside the scrolling rows.
-        {"DAX",       3, nullptr},   // 6 — toggleDaxPanel
+        {"DAX",     "panMenuDaxBtn",      "DAX panel",                3, nullptr},
     };
 
     for (const auto& def : defs) {
         auto* btn = makeMenuBtn(def.text, this);
+        btn->setObjectName(QString::fromLatin1(def.objName));
+        btn->setAccessibleName(tr(def.a11y));
         if (def.specialIdx == 0)
             connect(btn, &QPushButton::clicked, this, &SpectrumOverlayMenu::toggleBandPanel);
         else if (def.specialIdx == 1)
@@ -2138,6 +2152,29 @@ void SpectrumOverlayMenu::buildDisplayPanel()
             GpuSelector::saveChoiceId(m_gpuCombo->itemData(idx).toString());
             gpuNote->setVisible(true);   // surface the restart requirement once changed
         });
+    }
+
+    // ── Clone to all Pans ─────────────────────────────────────────────────
+    // Sits directly above Reset to Defaults: both are whole-panel actions, and
+    // this one is the constructive counterpart — it takes the look the operator
+    // just built here and applies it everywhere, instead of throwing it away.
+    {
+        m_cloneToAllPansBtn = new QPushButton("Clone to all Pans");
+        m_cloneToAllPansBtn->setObjectName("displayCloneToAllPansBtn");
+        m_cloneToAllPansBtn->setStyleSheet(btnStyle);
+        m_cloneToAllPansBtn->setToolTip(
+            "Copy every Display setting on this panadapter — trace, waterfall, "
+            "background, appearance and 3D view — onto all other open "
+            "panadapters.");
+        m_cloneToAllPansBtn->setAccessibleName(tr("Clone display settings to all panadapters"));
+        m_cloneToAllPansBtn->setAccessibleDescription(
+            tr("Applies this panadapter's Display panel settings to every other "
+               "open panadapter."));
+        connect(m_cloneToAllPansBtn, &QPushButton::clicked, this, [this] {
+            emit displaySettingsCloneRequested();
+        });
+        grid->addWidget(m_cloneToAllPansBtn, row, 0, 1, 4);
+        ++row;
     }
 
     // ── Reset button ──────────────────────────────────────────────────────

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -246,6 +246,11 @@ signals:
     void backgroundOpacityChanged(int pct);
     void backgroundFillColorChanged(const QColor& color);
     void displaySettingsReset();
+    // "Clone to all Pans": push every Display-panel setting on THIS pan onto
+    // every other open panadapter, so a tuned-in look is set once instead of
+    // per pan. MainWindow owns the fan-out (it is the only object that can see
+    // the other pans and the radio).
+    void displaySettingsCloneRequested();
 
 private:
     QString m_panId;
@@ -434,6 +439,7 @@ private:
     QSlider*     m_floorSlider{nullptr};
     QLabel*      m_floorLabel{nullptr};
     QPushButton* m_floorEnableBtn{nullptr};
+    QPushButton* m_cloneToAllPansBtn{nullptr};
 
     QComboBox*   m_freqGridSpacingCmb{nullptr};
     QComboBox*   m_freqScaleFontCmb{nullptr};

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1748,6 +1748,68 @@ QVariantMap SpectrumWidget::automationDssSetScrollback(bool live,
     return snap;
 }
 
+QVariantMap SpectrumWidget::automationDisplaySettingsSnapshot() const
+{
+    // Grouped in the same order as the Display panel's headers so a failing
+    // field points straight at the control that owns it. Colours are hex
+    // strings (`#rrggbb`) — the same spelling AppSettings persists, so a
+    // bridge assertion and a settings dump compare byte-for-byte.
+    QVariantMap snap;
+    snap[QStringLiteral("panIndex")] = m_panIndex;
+    snap[QStringLiteral("objectName")] = objectName();
+
+    // PANADAPTER
+    snap[QStringLiteral("fftAverage")] = m_fftAverage;
+    snap[QStringLiteral("fftFps")] = m_fftFps;
+    snap[QStringLiteral("fftWeightedAvg")] = m_fftWeightedAvg;
+    snap[QStringLiteral("fftHeatMap")] = m_fftHeatMap;
+    snap[QStringLiteral("showGrid")] = m_showGrid;
+    snap[QStringLiteral("fftLineWidth")] = m_fftLineWidth;
+    snap[QStringLiteral("fftLineColor")] = m_fftLineColor.name();
+    snap[QStringLiteral("fftFillAlpha")] = m_fftFillAlpha;
+    snap[QStringLiteral("fftFillColor")] = m_fftFillColor.name();
+    snap[QStringLiteral("noiseFloorEnable")] = m_noiseFloorEnable;
+    snap[QStringLiteral("noiseFloorPosition")] = m_noiseFloorPosition;
+
+    // WATERFALL
+    snap[QStringLiteral("wfBlankerEnabled")] = m_wfBlankerEnabled;
+    snap[QStringLiteral("wfBlankerThreshold")] = m_wfBlankerThreshold;
+    snap[QStringLiteral("wfBlankerMode")] = m_wfBlankerMode;
+    snap[QStringLiteral("wfBlackLevel")] = m_wfBlackLevel;
+    snap[QStringLiteral("wfAutoBlack")] = m_wfAutoBlack;
+    snap[QStringLiteral("wfAutoBlackOffset")] = m_wfAutoBlackOffset;
+    // Intent and effect are separate on purpose (#4606): a clone must copy the
+    // intent, while what renders is the intent masked by this radio.
+    snap[QStringLiteral("wfAutoBlackRadioSide")] = m_wfAutoBlackRadioSide;
+    snap[QStringLiteral("effectiveWfAutoBlackRadioSide")] =
+        effectiveWfAutoBlackRadioSide();
+    snap[QStringLiteral("wfColorGain")] = m_wfColorGain;
+    snap[QStringLiteral("wfLineDuration")] = m_wfLineDuration;
+
+    // BACKGROUND
+    snap[QStringLiteral("backgroundImage")] = m_bgImagePath;
+    snap[QStringLiteral("backgroundOpacity")] = m_bgOpacity;
+    snap[QStringLiteral("backgroundFillColor")] = m_bgFillColor.name();
+
+    // APPEARANCE
+    snap[QStringLiteral("freqGridSpacing")] = m_freqGridSpacingKhz;
+    snap[QStringLiteral("freqScaleFontPt")] = m_freqScaleFontPt;
+    snap[QStringLiteral("wfColorScheme")] = static_cast<int>(m_wfColorScheme);
+
+    // 3D VIEW
+    snap[QStringLiteral("spectrumRenderMode")] =
+        static_cast<int>(m_spectrumRenderMode);
+    snap[QStringLiteral("dssFloorDepth")] = dssFloorDepth();
+    snap[QStringLiteral("dssGain")] = m_dssGain;
+    snap[QStringLiteral("dssRowSpan")] = m_dssRowSpanPct;
+
+    // Which display source the per-source values above resolved from, so a
+    // Flex-vs-Kiwi mismatch reads as a labelled difference rather than a
+    // mysterious floor-depth failure.
+    snap[QStringLiteral("kiwiWaterfallActive")] = m_kiwiSdrWaterfallActive;
+    return snap;
+}
+
 QVariantMap SpectrumWidget::traceDebugSnapshot()
 {
     const auto vectorStats = [this](const QVector<float>& bins) {

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -189,6 +189,11 @@ public:
     Q_INVOKABLE QVariantMap automationDssSetScrollback(bool live,
                                                        int offsetRows);
     Q_INVOKABLE QVariantMap traceDebugSnapshot();
+    // Every value the Display panel owns, as one flat map keyed by the panel's
+    // own control names. Exists so "Clone to all Pans" (and any future
+    // display-preference change) is provable field-by-field over the automation
+    // bridge instead of by comparing screenshots. See `get display`.
+    Q_INVOKABLE QVariantMap automationDisplaySettingsSnapshot() const;
     void setConnectionAnimationVisible(bool on, const QString& label = {});
     void setKiwiSdrConnectionOverlay(bool visible,
                                      const QString& detail = {},


### PR DESCRIPTION
Closes #4882

## What

The Display panel gets a **Clone to all Pans** button in the SYSTEM group, directly above *Reset to Defaults* — the constructive counterpart to it. Tune the look on one panadapter, press it, and every other open pan matches.

Setting up a second pan previously meant re-picking every colour, fill rate, scheme, floor and 3D setting by hand, per pan.

## What travels

Everything the Display panel owns, across all five groups:

| Group | Cloned |
|---|---|
| **PANADAPTER** | Heat Map, Grid, Wt Avg, FFT AVG, FFT FPS, line width + line colour, fill colour + alpha, FFT Floor enable + position |
| **WATERFALL** | NB Blanker on/threshold/mode, Black Level, auto-black mode + offset + source, WtrFall Gain, WtrFall Rate |
| **BACKGROUND** | background image (incl. "off"), BG opacity, fill colour |
| **APPEARANCE** | grid spacing, scale text size, colour scheme |
| **3D VIEW** | render mode (2D/3D), 3D Floor, 3D Gain, 3D Span |

The GPU selector is deliberately excluded — it is global and applies on next launch, not per-pan.

## How

Three kinds of setting live in that panel and each has to travel its own way; copying one settings blob would get two of them wrong.

1. **Client appearance whose `SpectrumWidget` setter already persists** under the target's own per-pan `settingsKey()` — a plain setter call is the whole job.
2. **Client appearance whose setter does not persist** — background image path and opacity, which `MainWindow` has always owned the writes for. Those `AppSettings` writes are explicit here, including the `"none"`-means-off spelling, so a background the operator turned off stays off across a restart.
3. **Radio-authoritative values** — FFT average / FPS / weighted average, waterfall line duration, colour gain, black level. Per the settings-authority policy in `AGENTS.md` these are never persisted client-side, so they are cloned by sending the same commands the live sliders send and letting the radio echo them back. FPS and rate stay suppressed while the adaptive throttle is active, exactly as their sliders do.

Two behaviours worth calling out:

- **Auto-black clones the operator's stored INTENT**, not the capability-masked value (#4606). Cloning the masked value would quietly downgrade every other pan to SW on a radio that computes no black level of its own.
- **Kiwi-backed targets skip gain / black / rate**, which mean dBm range there — the same guard the per-control handlers already use.

The source pan shows a transient overlay message reporting how many pans were written, or "This is the only open panadapter" when there is nothing to clone.

## Automation bridge

Two additions so the feature is provable without pixels:

- **`get display`** — a per-pan snapshot of every Display-panel field (selector by pan index or objectName, optional single-property form). A clone becomes assertable field-by-field instead of by comparing screenshots. It reports auto-black intent and effective value separately, and flags which display source the per-source floor values resolved from.
- **Stable objectNames + accessible names on the overlay menu's seven row buttons** (`panMenuDisplayBtn`, `panMenuBandBtn`, …). They had none, so nothing could *open* the Display panel from a test even though every control inside it was already addressable — every one read back as "not visible". This unblocks Band / ANT / DAX / Memory panel testing too.

Both documented in `docs/automation-bridge.md`.

```json
→ {"cmd":"invoke","target":"pan 0/panMenuDisplayBtn","action":"click"}
→ {"cmd":"invoke","target":"pan 0/displayCloneToAllPansBtn","action":"click"}
→ {"cmd":"get","model":"display"}
← {"ok":true,"model":"display","pans":[
   {"panIndex":0,"wfColorScheme":5,"fftLineColor":"#00ff00", …},
   {"panIndex":1,"wfColorScheme":5,"fftLineColor":"#00ff00", …}]}
```

## Testing

- Built clean on macOS; `ctest` 280/281 (`icom_backend_test` fails only under parallel load and passes standalone — pre-existing flake, no Icom code touched).
- Verified manually on a FLEX-8400M with two panadapters: settings set on pan 0 propagate to pan 1 on click.
- Screenshot to follow.
