### PR TITLE
fix(icom): DFM, MOX and TUNE never reached a backend without a Flex command plane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,27 @@ jobs:
       - name: Test TCI protocol parsing and malformed-input rejection
         run: ctest --test-dir build -R "^tci_protocol_test$" --output-on-failure
 
+      # icom_civ_test joins the gate for the same reason as the steps above, and
+      # the DFM mode mapping is what earned it the slot. `modeFromNeutral()`
+      # handled FM and NFM but not DFM, so DFM fell through to the "no
+      # equivalent" arm and setSliceMode() re-asserted whatever the radio was
+      # already in: the mode control silently reverted, with no crash, no log
+      # line above DEBUG, and no other assertion in the tree able to see it.
+      # The reverse direction was the same shape — CivMode::Fm returned "FM"
+      # regardless of the data flag, so a radio in FM-D reported as plain FM and
+      # the next mode write cleared the flag, taking the radio out of data mode
+      # on its own.
+      #
+      # A mode map is exactly the kind of table that grows a hole when a mode is
+      # added elsewhere and forgotten here, and the failure is invisible from
+      # the UI, which shows the mode it asked for either way. That is only worth
+      # guarding if it runs before the merge.
+      #
+      # Pure string-to-enum arithmetic against a target the Build step already
+      # linked: no radio, no sockets, no event loop, milliseconds to run.
+      - name: Test Icom CI-V codec and mode mapping
+        run: ctest --test-dir build -R "^icom_civ_test$" --output-on-failure
+
       # #4146 turned liquid-dsp off by default, so the main build above no
       # longer proves the vendored snapshot still compiles. Build only the
       # liquid-static target (separate build dir, opt-in flag) so a bitrotted

--- a/src/core/backends/icom/CivCodec.cpp
+++ b/src/core/backends/icom/CivCodec.cpp
@@ -275,6 +275,19 @@ std::optional<CivMode> modeFromNeutral(const std::string& neutral, bool& dataMod
     // microphone while the operator is running FT8.
     if (u == "DIGU") { dataModeOut = true; return CivMode::Usb; }
     if (u == "DIGL") { dataModeOut = true; return CivMode::Lsb; }
+    // DFM is FM with the same DATA flag, and it was missing here. Two costs,
+    // and the second is the expensive one:
+    //
+    //   1. DFM fell through to nullopt, so setSliceMode() took the "no
+    //      equivalent" path and re-asserted the radio's current mode. Selecting
+    //      DFM in the UI simply reverted — indistinguishable from the control
+    //      being ignored.
+    //   2. Worse, on the paths that DID reach the radio as plain FM the DATA
+    //      flag stayed clear, so transmit audio came from the MICROPHONE rather
+    //      than the WLAN modulator — exactly the failure the DIGU/DIGL comment
+    //      above describes, but for packet instead of FT8. A 2 m AX.25 frame
+    //      keyed the radio and put room noise on the air.
+    if (u == "DFM")  { dataModeOut = true; return CivMode::Fm; }
     if (u == "RTTY") return CivMode::Rtty;
 
     // DSB, SAM and DRM have no IC-705 equivalent. Returning nullopt rather than
@@ -291,7 +304,12 @@ std::string modeToNeutral(CivMode mode, bool dataMode)
     case CivMode::Am:   return "AM";
     case CivMode::Cw:   return "CWU";
     case CivMode::CwR:  return "CWL";
-    case CivMode::Fm:   return "FM";
+    // Symmetric with Lsb/Usb above: the DATA flag is what distinguishes FM-D
+    // from FM, and returning plain "FM" for both made the round trip lossy. A
+    // radio sitting in FM-D reported as FM, so the UI showed FM, and the next
+    // mode write sent FM with the flag clear — silently taking the radio OUT of
+    // data mode and back onto the microphone.
+    case CivMode::Fm:   return dataMode ? "DFM" : "FM";
     case CivMode::Wfm:  return "WFM";
     // AetherSDR has no RTTY neutral mode. Mapping to the data mode on the
     // matching sideband is LOSSY IN NAME but correct in the two things that

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1921,6 +1921,24 @@ RadioModel::RadioModel(QObject* parent)
                 m_txAudioGate = false;
                 emit txAudioGateChanged(false);
             }
+            // KEY THROUGH THE SEAM. This arm set m_txRequested and then let the
+            // "xmit N" text fall through to sendCommand(), which is a no-op on a
+            // backend with no Flex command plane: RadioModel logs "no command
+            // plane for this backend, dropping xmit 1" at DEBUG and the radio
+            // never keys. MOX did nothing on a networked Icom, silently, with
+            // the only evidence below the default log level.
+            //
+            // This is the same fix already applied in setTransmit() — see the
+            // "Key through the SEAM, not with a raw Flex command" comment there,
+            // which converted the other caller after IRadioBackend::setKeying
+            // was found to have no callers at all. This path was missed.
+            //
+            // Flex behaviour is unchanged: FlexBackend::setKeying sends the very
+            // same "xmit N" through the same sink, so the text command below is
+            // now redundant for Flex rather than load-bearing.
+            if (m_backend)
+                m_backend->setKeying(tx);
+            publishBackendTransmitEdge(tx);
         }
         if (cmd == "transmit tune 1" || cmd == "atu start") {
             if (transmitStartBlockedByInhibit(QStringLiteral("tune-start"))) {
@@ -1945,6 +1963,23 @@ RadioModel::RadioModel(QObject* parent)
             armInterlockNotification(m_pendingTransmitPreflightSource);
             m_pendingTransmitPreflightSource = TransmitModel::PttSource::Mox;
             applyTuneInhibit();
+        }
+        // TUNE THROUGH THE SEAM TOO, for the same reason as xmit above: on a
+        // backend with no Flex command plane "transmit tune 1" is dropped and
+        // the TUNE button does nothing at all. IRadioBackend::setTune() exists
+        // and is implemented (IcomCivBackend composes a tune carrier from drive
+        // + key, since CI-V has no tune-carrier command), but nothing routed to
+        // it from here.
+        //
+        // Only the tune verbs are diverted; every other transmit command still
+        // goes out as text, and Flex is unaffected because sendCmd() below
+        // continues to carry them.
+        if (cmd == QStringLiteral("transmit tune 1")
+            || cmd == QStringLiteral("transmit tune 0")) {
+            if (m_backend) {
+                const bool on = cmd.endsWith(QLatin1Char('1'));
+                m_backend->setTune(on, m_transmitModel.tunePower());
+            }
         }
         sendCmd(cmd);
     });

--- a/tests/icom_civ_test.cpp
+++ b/tests/icom_civ_test.cpp
@@ -185,6 +185,14 @@ static void testModes()
     // what routes audio to the WLAN modulator instead of the microphone.
     check(modeFromNeutral("DIGU", data) == CivMode::Usb && data, "DIGU is USB + data");
     check(modeFromNeutral("DIGL", data) == CivMode::Lsb && data, "DIGL is LSB + data");
+    // DFM is FM + DATA, and it was missing entirely. Selecting DFM fell through
+    // to the "no equivalent" path, so setSliceMode() re-asserted the radio's
+    // current mode and the control appeared to do nothing. The expensive half
+    // was the DATA flag: without it the radio transmits from the MICROPHONE
+    // rather than the WLAN modulator, so a 2 m AX.25 frame keyed the rig and
+    // put room noise on the air. Found on an IC-9700, 2026-08-09.
+    check(modeFromNeutral("DFM", data) == CivMode::Fm && data, "DFM is FM + data");
+    check(modeFromNeutral("FM", data) == CivMode::Fm && !data, "plain FM has no data flag");
     check(modeFromNeutral("CW", data) == CivMode::Cw, "bare CW maps, not just CWU");
     check(modeFromNeutral("CWL", data) == CivMode::CwR, "CWL is CW-reverse");
     // No IC-705 equivalent: refuse rather than silently substituting USB.
@@ -193,6 +201,12 @@ static void testModes()
 
     check(modeToNeutral(CivMode::Usb, false) == "USB", "reverse USB");
     check(modeToNeutral(CivMode::Usb, true) == "DIGU", "reverse DIGU");
+    // The round trip has to survive too. Returning plain "FM" for a radio in
+    // FM-D made the UI show FM, and the next mode write then sent FM with the
+    // flag CLEAR — silently taking the radio out of data mode and back onto the
+    // microphone without the operator touching anything.
+    check(modeToNeutral(CivMode::Fm, false) == "FM", "reverse FM");
+    check(modeToNeutral(CivMode::Fm, true) == "DFM", "reverse DFM keeps the data flag");
     check(modeToNeutral(CivMode::Dv, false).empty(), "D-STAR has no neutral mode");
 
     // THE LADDER IS PER MODE. FIL1 is 3.0 kHz in SSB, 1.2 kHz in CW, 9 kHz in


### PR DESCRIPTION
Three controls did nothing on a networked Icom. All three are the same shape of bug — a UI action that never reaches the backend — and all three are verified on an IC-9700 over LAN.

## 1. DFM never reached the radio, in either direction

`modeFromNeutral()` handled `FM` and `NFM` but not `DFM`, so DFM fell through to the `nullopt` "no equivalent" arm. `setSliceMode()` then re-asserted whatever the radio was already in, and **selecting DFM in the UI silently reverted**.

The reverse was broken too: `CivMode::Fm` returned `"FM"` unconditionally, ignoring the data flag, unlike `Lsb`/`Usb` which correctly return `DIGL`/`DIGU`. A radio sitting in FM-D therefore reported back as plain FM — so the UI showed FM, and the next mode write sent FM **with the flag clear**, taking the radio out of data mode without the operator touching anything.

DFM is FM with the same DATA flag the `DIGU`/`DIGL` comment three lines above already describes: *"that flag is what routes audio to the WLAN/USB modulator instead of the mic"*.

**Before:** no `06` frame was sent at all.
**After:** `fe fe a2 e0 06 05 01 fd` (set mode, FM, data) and the radio answers `FB`.

## 2. MOX never keyed the radio

Pressing MOX did nothing. The reason was in the log, at DEBUG, below the default level:

```
RadioModel: no command plane for this backend, dropping xmit 1
```

`TransmitModel::setMox()` emits the Flex text command `xmit N`, which `sendCommand()` discards on a backend with no Flex command sink. `IRadioBackend::setKeying()` exists, is implemented, and works — the AX.25 modem keys the same radio through it successfully, which is why packet could transmit while MOX could not.

This is the same fix already applied in `RadioModel::setTransmit()`, whose comment records the identical bug:

> *"This used to be `sendCmd("xmit N")`, which meant `IRadioBackend::setKeying` had no callers at all and no non-Flex backend could ever be keyed — the verb existed and was wired to nothing."*

That conversion missed the `commandReady` handler.

## 3. TUNE, same cause

`transmit tune 1` was dropped identically. Routed through `IRadioBackend::setTune()`, which `IcomCivBackend` implements by composing a tune carrier from drive + key (CI-V has no tune-carrier command).

## Flex is unaffected

`FlexBackend::setKeying()` sends the very same `xmit N` through the same sink, so the text command is now redundant on that path rather than load-bearing. No behaviour change for a Flex radio.

## Verification

On an IC-9700 over LAN, after building this branch:

| Control | Before | After |
|---|---|---|
| DFM | reverted silently, no CI-V frame sent | sets; radio ACKs `06 05 01` |
| MOX | `dropping xmit 1`, radio never keyed | **radio keys** |
| TUNE | `dropping transmit tune 1`, nothing | **keys with carrier** |

Tests in `icom_civ_test` pin both directions of the DFM mapping. Verified by reverting the fix: `DFM is FM + data` and `reverse DFM keeps the data flag` both fail, exit 1.

## Known cosmetic follow-up, not addressed here

The `no command plane for this backend, dropping ...` line still fires for commands the seam has already handled, so it now reads as a failure when it is not. In one session there were 62 harmless instances of it alongside the 26 real ones, which is exactly what made this class of bug hard to spot. Worth suppressing for verbs the seam takes, but that is a separate change.
