### PR TITLE
docs(gui): correct TCI audio guidance

### DIFF
--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1984,8 +1984,10 @@ void MainWindow::wireCatPorts()
     // TCI client count changes no longer auto-create/remove the audio stream.
     // Control-only TCI clients (StreamDeck) don't need audio, and auto-creating
     // the stream overrode the user's explicit PC Audio toggle. TCI audio does
-    // not need PC Audio either: it uses DAX channels acquired by
-    // TciServer::ensureDaxForTci(), independently of remote_audio_rx. (#1071, #1331)
+    // not need PC Audio either: on Flex it uses DAX channels acquired by
+    // TciServer::ensureDaxForTci(), and on a host-modulating backend it arrives
+    // over the seam via backendSliceAudioFrameReady — neither path consults
+    // PcAudioEnabled, which gates only remote_audio_rx. (#1071, #1331)
 #endif
 
 }

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1967,8 +1967,9 @@ void MainWindow::wireCatPorts()
 
     // TCI client count changes no longer auto-create/remove the audio stream.
     // Control-only TCI clients (StreamDeck) don't need audio, and auto-creating
-    // the stream overrode the user's explicit PC Audio toggle. Users who need
-    // TCI audio (WSJT-X) should enable PC Audio manually. (#1071)
+    // the stream overrode the user's explicit PC Audio toggle. TCI audio does
+    // not need PC Audio either: it uses DAX channels acquired by
+    // TciServer::ensureDaxForTci(), independently of remote_audio_rx. (#1071, #1331)
 #endif
 
 }


### PR DESCRIPTION
## Summary

Fixes #4894.

Replaces only the stale instruction that WSJT-X users should enable PC Audio. On Flex, the current receive path uses DAX channels acquired by `TciServer::ensureDaxForTci()`; host-modulating backends relay per-slice TCI audio through `backendSliceAudioFrameReady`. Neither path consults `PcAudioEnabled`, which gates only the separate `remote_audio_rx` stream. The valid #1071 rationale about not auto-creating the PC Audio stream remains unchanged.

## Constitution principle honored

Principle VIII — Evidence Over Assertion. The correction was traced on current `main` through `wirePanStreamTciSinks()`, `TciServer::ensureDaxForTci()`, the DAX stream-create path in `RadioModel`, `backendSliceAudioFrameReady`, and the separate `PcAudioEnabled` gate in `scheduleRxAudioStreamEnsure()`.

## Test plan

- [x] `git diff --check`
- [x] Confirmed all remote commits are GitHub-verified
- [x] Verified that the diff changes comments only; no code or preprocessor tokens changed
- [x] Re-checked the Flex DAX path and the host-modulating backend seam path on current `main`
- [ ] Existing CI passes

A local application build and real-radio run were not performed because this is a comment-only correction with no behavior change.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — not applicable; no code changed
- [x] Code is clean-room — evidence comes only from the current open-source tree
- [x] All meter UI uses `MeterSmoother` — not applicable; no UI code changed
- [x] Documentation updated if user-visible behavior changed — no user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable — not applicable

AI assistance: prepared with OpenAI Codex; the source trace and final diff were verified directly against current `main`.