### PR TITLE
feat(midi): import/export binding profiles — native XML and SmartSDR .map (#4888)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ MIDI, Stream Deck/StreamController plugins, and generic USB-serial adapters:
 - Icom RC-28 USB remote encoder
 - Griffin PowerMate USB knob
 - Contour ShuttleXpress and ShuttlePro v2 jog controllers
-- MIDI controllers with learn mode, manual mapping entry, profiles, and relative-encoder support
+- MIDI controllers with learn mode, manual mapping entry, importable/exportable profiles (including vendor-supplied SmartSDR `.map` files), and relative-encoder support
 - Elgato Stream Deck devices through the bundled macOS/Windows Stream Deck plugin
 - Stream Deck devices on Linux through the bundled StreamController plugin
 - USB-serial PTT/CW interfaces for foot switches, straight keys, iambic paddles,

--- a/resources/help/configuring-aethersdr-controls.md
+++ b/resources/help/configuring-aethersdr-controls.md
@@ -23,7 +23,7 @@ AetherSDR currently supports these control paths:
 - **Built-in keyboard shortcuts** for tuning, audio, transmit, and other common actions.
 - **Custom keyboard bindings** through the shortcut editor.
 - **FlexControl USB tuning knob** through the serial-control path.
-- **MIDI controllers** with learn mode, manual mapping entry, profiles, and relative-encoder support.
+- **MIDI controllers** with learn mode, manual mapping entry, profiles you can import and export, and relative-encoder support.
 - **USB HID encoder devices** including:
   - Icom RC-28
   - Griffin PowerMate
@@ -396,6 +396,8 @@ The MIDI dialog lets you:
 - Edit any existing binding with the **✎** button on its row
 - Save named profiles
 - Load saved profiles
+- Use **Import…** to bring in a profile file, including a mapping supplied by your controller's vendor
+- Use **Export…** to write the current bindings out as a file you can keep or share
 - Clear all bindings if you want to start over
 
 ### What kinds of parameters you can control
@@ -492,6 +494,37 @@ Profiles are useful when you want one controller for different jobs. For example
 - A CW profile
 
 Save the profile after you finish a layout so you can return to it quickly later.
+
+### Importing and exporting profiles
+
+Profiles are ordinary files, so a finished mapping can move between machines —
+or come ready-made from the people who built your controller.
+
+**Import…** reads a profile file and stores it under the file's name. Two kinds
+of file are accepted, and AetherSDR works out which one it is by looking inside:
+
+- An **AetherSDR profile** written by **Export…** on this or another machine.
+- A **SmartSDR ".map" file**, the mapping format the SmartSDR iOS and Mac apps
+  use. Controller vendors publish these for their own devices, so a supported
+  controller can be set up by importing the vendor's file instead of binding
+  every control by hand.
+
+Importing never overwrites a profile you already have: a name that is already
+taken gets a numbered suffix. Importing also does not change your current
+bindings — the imported profile is stored and selected in the list, and you
+click **Load** to actually apply it.
+
+A vendor file usually describes more controls than AetherSDR has parameters
+for. Nothing is dropped quietly: the summary after an import tells you how many
+bindings came in, and lists by name every control that was skipped — controls
+with no AetherSDR equivalent, rows with values out of range, and duplicates
+where two controls asked for the same parameter. Expand the details to see the
+individual names.
+
+**Export…** writes your current bindings to a file you choose. That file
+imports back into AetherSDR unchanged, which makes it a convenient backup
+before you rework a layout, and an easy way to hand a working setup to someone
+running the same controller.
 
 ## Stream Deck integration
 

--- a/src/core/MidiSettings.cpp
+++ b/src/core/MidiSettings.cpp
@@ -562,6 +562,16 @@ MidiImportResult MidiSettings::importProfile(
                                   file.errorString());
         return result;
     }
+    // A profile is kilobytes — the vendor CTR2-Quad map is a few. Refuse
+    // anything absurd before readAll() allocates it, so pointing the dialog at
+    // the wrong file is a message rather than an allocation failure.
+    constexpr qint64 kMaxProfileBytes = 1 << 20;
+    if (file.size() > kMaxProfileBytes) {
+        result.errors << QStringLiteral("%1 is too large to be a MIDI profile (%2 bytes).")
+                             .arg(QDir::toNativeSeparators(filePath))
+                             .arg(file.size());
+        return result;
+    }
     const QByteArray bytes = file.readAll();
     file.close();
 
@@ -595,6 +605,13 @@ MidiImportResult MidiSettings::importProfile(
     // suffix is the reversible default. Dots are replaced because the store
     // round-trips names through QFileInfo::baseName(), which cuts at the
     // first dot — a dotted name would list, load, and collide wrongly.
+    //
+    // completeBaseName() operates on fileName(), so any directory component of
+    // the chosen path is already stripped: "../../evil.map" yields "evil". That
+    // is what keeps this call site safe, because saveProfile() — and its load
+    // and delete siblings — concatenate the name straight into profileDir()
+    // with no sanitizing. Do not swap this for a name taken from the document
+    // body or from filePath without stripping separators first.
     QString name = QFileInfo(filePath).completeBaseName().trimmed();
     name.replace(QLatin1Char('.'), QLatin1Char('_'));
     if (name.isEmpty())

--- a/src/core/MidiSettings.cpp
+++ b/src/core/MidiSettings.cpp
@@ -5,6 +5,7 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QSaveFile>
 #include <QSet>
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
@@ -24,6 +25,27 @@ QString normalizedMidiParamId(const QString& paramId)
     if (paramId == QLatin1String("cw.dah"))
         return QStringLiteral("cwdah");
     return paramId;
+}
+
+// One serializer for the <MidiProfile> document, shared by the store's
+// profile writer and the user-facing export so the two can never drift.
+void writeProfileDocument(QXmlStreamWriter& xml, const QVector<MidiBinding>& bindings)
+{
+    xml.setAutoFormatting(true);
+    xml.writeStartDocument();
+    xml.writeStartElement("MidiProfile");
+    for (const auto& b : bindings) {
+        xml.writeStartElement("Binding");
+        xml.writeAttribute("param", normalizedMidiParamId(b.paramId));
+        xml.writeAttribute("channel", QString::number(b.channel));
+        xml.writeAttribute("type", QString::number(static_cast<int>(b.msgType)));
+        xml.writeAttribute("number", QString::number(b.number));
+        xml.writeAttribute("inverted", b.inverted ? "True" : "False");
+        if (b.relative) xml.writeAttribute("relative", "True");
+        xml.writeEndElement();
+    }
+    xml.writeEndElement();
+    xml.writeEndDocument();
 }
 
 // ── SmartSDR iOS/Mac ".map" import ──────────────────────────────────────────
@@ -420,21 +442,7 @@ void MidiSettings::writeBindingsToXml(const QString& filePath,
     if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) return;
 
     QXmlStreamWriter xml(&file);
-    xml.setAutoFormatting(true);
-    xml.writeStartDocument();
-    xml.writeStartElement("MidiProfile");
-    for (const auto& b : bindings) {
-        xml.writeStartElement("Binding");
-        xml.writeAttribute("param", normalizedMidiParamId(b.paramId));
-        xml.writeAttribute("channel", QString::number(b.channel));
-        xml.writeAttribute("type", QString::number(static_cast<int>(b.msgType)));
-        xml.writeAttribute("number", QString::number(b.number));
-        xml.writeAttribute("inverted", b.inverted ? "True" : "False");
-        if (b.relative) xml.writeAttribute("relative", "True");
-        xml.writeEndElement();
-    }
-    xml.writeEndElement();
-    xml.writeEndDocument();
+    writeProfileDocument(xml, bindings);
 }
 
 // ── Profiles ────────────────────────────────────────────────────────────────
@@ -534,6 +542,48 @@ MidiImportResult MidiSettings::importProfile(
         return result;
     }
     result.profileName = unique;
+    return result;
+}
+
+MidiExportResult MidiSettings::exportProfile(const QString& filePath,
+                                             const QVector<MidiBinding>& bindings) const
+{
+    MidiExportResult result;
+    if (filePath.trimmed().isEmpty()) {
+        result.error = QStringLiteral("No export path was provided.");
+        return result;
+    }
+
+    QByteArray xmlBytes;
+    {
+        QXmlStreamWriter xml(&xmlBytes);
+        writeProfileDocument(xml, bindings);
+    }
+
+    QSaveFile file(filePath);
+    // Some network mounts (SMB, WSL DrvFs) can't create the sidecar temp
+    // file QSaveFile normally uses — fall back to a direct write so export
+    // succeeds where a plain write would (matches ShortcutManager and
+    // KiwiSdrManager).
+    file.setDirectWriteFallback(true);
+    if (!file.open(QIODevice::WriteOnly)) {
+        result.error = QStringLiteral("Couldn't open %1 for writing (%2).")
+                           .arg(QDir::toNativeSeparators(filePath), file.errorString());
+        return result;
+    }
+    if (file.write(xmlBytes) != xmlBytes.size()) {
+        const QString reason = file.errorString();
+        file.cancelWriting();
+        result.error = QStringLiteral("Couldn't write the profile to %1 (%2).")
+                           .arg(QDir::toNativeSeparators(filePath), reason);
+        return result;
+    }
+    if (!file.commit()) {
+        result.error = QStringLiteral("Couldn't save %1 (%2).")
+                           .arg(QDir::toNativeSeparators(filePath), file.errorString());
+        return result;
+    }
+    result.exportedCount = bindings.size();
     return result;
 }
 

--- a/src/core/MidiSettings.cpp
+++ b/src/core/MidiSettings.cpp
@@ -165,6 +165,16 @@ QVector<MidiBinding> parseSmartSdrMap(const QByteArray& bytes,
 
         sawAssignment = true;
 
+        // Section first: rows in a section we never bind from are not ours to
+        // key-validate. Vendors key their feedback sections in their own
+        // dialect ("L1=", "LED1="), and judging those by the control/button
+        // key format would fail the whole file instead of naming the skip.
+        if (section == Section::Other) {
+            // e.g. the LEDs section: device feedback, not a binding.
+            result.skippedUnknownParam << function + QStringLiteral(" (not a control/button row)");
+            continue;
+        }
+
         const QChar kind = key.isEmpty() ? QChar() : key.at(0).toUpper();
         bool numberOk = false;
         const int number = key.mid(1).toInt(&numberOk);
@@ -172,12 +182,6 @@ QVector<MidiBinding> parseSmartSdrMap(const QByteArray& bytes,
             || !numberOk || number < 0 || number > 127) {
             result.errors << QStringLiteral("Line %1: bad assignment key \"%2\"")
                                  .arg(i + 1).arg(key);
-            continue;
-        }
-
-        if (section == Section::Other) {
-            // e.g. the LEDs section: device feedback, not a binding.
-            result.skippedUnknownParam << function + QStringLiteral(" (not a control/button row)");
             continue;
         }
 
@@ -263,14 +267,24 @@ QVector<MidiBinding> parseProfileXml(const QByteArray& bytes,
                 << param + QStringLiteral(" (type \"%1\")").arg(attrs.value("type").toString());
             continue;
         }
-        const int channel = attrs.value("channel").toInt();
-        if (channel < -1 || channel > 15) {
-            result.skippedBadType << param + QStringLiteral(" (channel %1)").arg(channel);
+        // Absent attributes keep their defaults (our writer always emits both,
+        // hand-written files may not); a present-but-non-numeric value is a
+        // named skip, never a silent 0 — channel 0 is MIDI channel 1, not the
+        // any-channel wildcard, so accepting it would bind the row wrongly.
+        const auto channelAttr = attrs.value("channel");
+        bool channelOk = true;
+        const int channel = channelAttr.isNull() ? 0 : channelAttr.toInt(&channelOk);
+        if (!channelOk || channel < -1 || channel > 15) {
+            result.skippedBadType
+                << param + QStringLiteral(" (channel \"%1\")").arg(channelAttr.toString());
             continue;
         }
-        const int number = attrs.value("number").toInt();
-        if (type != MidiBinding::PitchBend && (number < 0 || number > 127)) {
-            result.skippedBadType << param + QStringLiteral(" (number %1)").arg(number);
+        const auto numberAttr = attrs.value("number");
+        bool numberOk = true;
+        const int number = numberAttr.isNull() ? 0 : numberAttr.toInt(&numberOk);
+        if (!numberOk || (type != MidiBinding::PitchBend && (number < 0 || number > 127))) {
+            result.skippedBadType
+                << param + QStringLiteral(" (number \"%1\")").arg(numberAttr.toString());
             continue;
         }
 
@@ -509,6 +523,10 @@ MidiImportResult MidiSettings::importProfile(
     // Sniff the dialect: native XML leads with '<'; a SmartSDR ".map" leads
     // with a "#"-headed section. Anything else is not a profile.
     QVector<MidiBinding> bindings;
+    // A leading UTF-8 BOM (any file round-tripped through a Windows editor)
+    // never reaches this comparison: QString::fromUtf8() consumes it. The
+    // import test pins that, so a toolchain that ever stops doing it fails
+    // loudly here rather than reporting a valid profile as unrecognized.
     const QString head = QString::fromUtf8(bytes.left(256)).trimmed();
     if (head.startsWith(QLatin1Char('<')))
         bindings = parseProfileXml(bytes, paramValidator, result);

--- a/src/core/MidiSettings.cpp
+++ b/src/core/MidiSettings.cpp
@@ -5,6 +5,7 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QMap>
 #include <QSaveFile>
 #include <QSet>
 #include <QXmlStreamReader>
@@ -27,6 +28,23 @@ QString normalizedMidiParamId(const QString& paramId)
     return paramId;
 }
 
+// One writer for a <Binding> element, shared by all three documents that
+// contain one: the profile store, the user-facing export, and midi.settings.
+// A new attribute added here reaches every file that should carry it, which
+// is the whole point — three hand-kept copies is how a field ends up in the
+// profile a user exports but not in the settings the app reloads.
+void writeBindingElement(QXmlStreamWriter& xml, const MidiBinding& b)
+{
+    xml.writeStartElement("Binding");
+    xml.writeAttribute("param", normalizedMidiParamId(b.paramId));
+    xml.writeAttribute("channel", QString::number(b.channel));
+    xml.writeAttribute("type", QString::number(static_cast<int>(b.msgType)));
+    xml.writeAttribute("number", QString::number(b.number));
+    xml.writeAttribute("inverted", b.inverted ? "True" : "False");
+    if (b.relative) xml.writeAttribute("relative", "True");
+    xml.writeEndElement();
+}
+
 // One serializer for the <MidiProfile> document, shared by the store's
 // profile writer and the user-facing export so the two can never drift.
 void writeProfileDocument(QXmlStreamWriter& xml, const QVector<MidiBinding>& bindings)
@@ -37,16 +55,8 @@ void writeProfileDocument(QXmlStreamWriter& xml, const QVector<MidiBinding>& bin
     // Schema hook for files in circulation, cheap now and painful to
     // retrofit — the .map's FORMAT_VERSION analogue.
     xml.writeAttribute("version", "1");
-    for (const auto& b : bindings) {
-        xml.writeStartElement("Binding");
-        xml.writeAttribute("param", normalizedMidiParamId(b.paramId));
-        xml.writeAttribute("channel", QString::number(b.channel));
-        xml.writeAttribute("type", QString::number(static_cast<int>(b.msgType)));
-        xml.writeAttribute("number", QString::number(b.number));
-        xml.writeAttribute("inverted", b.inverted ? "True" : "False");
-        if (b.relative) xml.writeAttribute("relative", "True");
-        xml.writeEndElement();
-    }
+    for (const auto& b : bindings)
+        writeBindingElement(xml, b);
     xml.writeEndElement();
     xml.writeEndDocument();
 }
@@ -143,8 +153,17 @@ QVector<MidiBinding> parseSmartSdrMap(const QByteArray& bytes,
     QSet<quint32> importedKeys;
     bool sawAssignment = false;
 
-    enum class Section { None, Controls, Buttons, Other };
+    // NonBinding (a section we know carries device feedback) is kept distinct
+    // from Unrecognized (a header we couldn't read, which may well be a
+    // comment) because the two justify different handling: rows under a known
+    // feedback header are never bindings, while rows under an unreadable one
+    // still deserve a try. Reporting one as the other sends the operator
+    // looking at the wrong line.
+    enum class Section { None, Controls, Buttons, NonBinding, Unrecognized };
     Section section = Section::None;
+    QString sectionLabel;
+    // section label -> rows skipped under it, summarized once after the loop.
+    QMap<QString, int> nonBindingRows;
 
     const QStringList lines = QString::fromUtf8(bytes).split(QLatin1Char('\n'));
     for (int i = 0; i < lines.size(); ++i) {
@@ -153,13 +172,25 @@ QVector<MidiBinding> parseSmartSdrMap(const QByteArray& bytes,
             continue;
 
         if (line.startsWith(QLatin1Char('#'))) {
-            const QString name = line.mid(1).trimmed().toLower();
-            if (name == QLatin1String("controls"))
+            // Match the header's FIRST WORD, not the whole line: vendors
+            // decorate headers ("# Controls (16 knobs)"), and matching the
+            // whole line demotes a decorated header to "not a binding
+            // section", losing every row under it.
+            sectionLabel = line.mid(1).trimmed();
+            QString first;
+            for (const QChar& c : sectionLabel) {
+                if (!c.isLetter()) break;
+                first.append(c.toLower());
+            }
+            if (first == QLatin1String("controls")) {
                 section = Section::Controls;
-            else if (name == QLatin1String("buttons"))
+            } else if (first == QLatin1String("buttons")) {
                 section = Section::Buttons;
-            else
-                section = Section::Other;
+            } else if (first == QLatin1String("leds")) {
+                section = Section::NonBinding;
+            } else {
+                section = Section::Unrecognized;
+            }
             continue;
         }
 
@@ -171,37 +202,66 @@ QVector<MidiBinding> parseSmartSdrMap(const QByteArray& bytes,
         }
 
         const QString key = line.left(eq).trimmed();
-        // Everything after the first ';' is a flag ("active" in vendor
-        // files); flags decorate rows we otherwise fully understand, so
-        // they are ignored.
+        // Everything after the first ';' is a flag; flags decorate rows we
+        // otherwise fully understand, so they are ignored. Observed in
+        // published vendor files: "active" (most rows) and "f"
+        // (CTR2-Max B12). No flag has been shown to change what a row binds
+        // to, and dropping them round-trips every vendor row correctly — but
+        // this is an observation, not a documented guarantee. If a flag ever
+        // turns out to mean "assignment disabled", this is the line to fix.
         const QString function = line.mid(eq + 1).section(QLatin1Char(';'), 0, 0).trimmed();
         if (function.isEmpty())
             continue; // unassigned slot ("C0="): no content to import or report
 
         sawAssignment = true;
 
-        // Section first: rows in a section we never bind from are not ours to
-        // key-validate. Vendors key their feedback sections in their own
-        // dialect ("L1=", "LED1="), and judging those by the control/button
-        // key format would fail the whole file instead of naming the skip.
-        if (section == Section::Other) {
-            // e.g. the LEDs section: device feedback, not a binding.  Named
-            // once, not once per row — a real device has one row per LED.
-            const QString note = function + QStringLiteral(" (not a control/button row)");
+        // Named skips carry the whole row, not just its value. A metadata row
+        // reads as "1" on its own; "FORMAT_VERSION=1" tells the operator what
+        // was skipped, and keeps two different rows that happen to share a
+        // value from collapsing into one entry.
+        const auto nameSkip = [&](const QString& suffix) {
+            const QString note = key + QLatin1Char('=') + function + suffix;
             if (!result.skippedUnknownParam.contains(note))
                 result.skippedUnknownParam << note;
+        };
+
+        // A section we know carries device feedback is never a binding, and
+        // vendors key those in their own dialect ("L1=", "LED1="), so they are
+        // not ours to key-validate — reporting them beats failing the file.
+        //
+        // Counted per section rather than named per row: every row under a
+        // known feedback header is the same kind of thing and none of them can
+        // ever bind, so a device with sixty LEDs would otherwise put sixty
+        // lines in the details list saying nothing the first one didn't. Rows
+        // under a header we *couldn't read* get named individually below,
+        // because there the operator does need to see which row it was.
+        if (section == Section::NonBinding) {
+            ++nonBindingRows[sectionLabel];
             continue;
         }
 
         const QChar kind = key.isEmpty() ? QChar() : key.at(0).toUpper();
         bool numberOk = false;
         const int number = key.mid(1).toInt(&numberOk);
-        if ((kind != QLatin1Char('C') && kind != QLatin1Char('B'))
-            || !numberOk || number < 0 || number > 127) {
-            result.errors << QStringLiteral("Line %1: bad assignment key \"%2\"")
-                                 .arg(i + 1).arg(key);
+        const bool keyIsBindable = (kind == QLatin1Char('C') || kind == QLatin1Char('B'))
+                                   && numberOk && number >= 0 && number <= 127;
+        if (!keyIsBindable) {
+            // Under a header we couldn't read, a key we can't use is a named
+            // skip rather than a file-level error: the header may be a comment
+            // or a section this build doesn't know, and neither is a corrupt
+            // file. Under Controls/Buttons the file really is malformed.
+            if (section == Section::Controls || section == Section::Buttons) {
+                result.errors << QStringLiteral("Line %1: bad assignment key \"%2\"")
+                                     .arg(i + 1).arg(key);
+            } else {
+                nameSkip(QStringLiteral(" (not a control or button row)"));
+            }
             continue;
         }
+        // A bindable row still binds under an unreadable header — that is what
+        // keeps a stray comment line mid-file from swallowing the rows after
+        // it, which is how a decorated header or a vendor note used to cost
+        // real bindings.
 
         const MapFunctionEntry* entry = findMapFunction(function);
         if (!entry) {
@@ -242,6 +302,13 @@ QVector<MidiBinding> parseSmartSdrMap(const QByteArray& bytes,
         bindings.append(b);
         importedParams.insert(paramId);
         importedKeys.insert(b.key());
+    }
+
+    for (auto it = nonBindingRows.cbegin(); it != nonBindingRows.cend(); ++it) {
+        result.skippedUnknownParam
+            << QStringLiteral("%1 section (%2 row(s)) — device feedback, not bindings")
+                   .arg(it.key())
+                   .arg(it.value());
     }
 
     if (!sawAssignment)
@@ -291,11 +358,18 @@ QVector<MidiBinding> parseProfileXml(const QByteArray& bytes,
             continue;
         }
 
-        bool typeOk = false;
-        const int type = attrs.value("type").toInt(&typeOk);
+        // `type` follows the same absent-vs-non-numeric rule as its
+        // neighbours below: absent keeps MidiBinding's own default (CC),
+        // present-but-unreadable is a named skip. Treating absent as a bad
+        // value made it the one attribute a hand-written row could not omit,
+        // while omitting channel and number was fine — an inconsistency with
+        // nothing behind it.
+        const auto typeAttr = attrs.value("type");
+        bool typeOk = true;
+        const int type = typeAttr.isNull() ? int(MidiBinding::CC) : typeAttr.toInt(&typeOk);
         if (!typeOk || type < MidiBinding::CC || type > MidiBinding::PitchBend) {
             result.skippedBadType
-                << param + QStringLiteral(" (type \"%1\")").arg(attrs.value("type").toString());
+                << param + QStringLiteral(" (type \"%1\")").arg(typeAttr.toString());
             continue;
         }
         // Absent attributes keep their defaults (our writer always emits both,
@@ -310,10 +384,17 @@ QVector<MidiBinding> parseProfileXml(const QByteArray& bytes,
                 << param + QStringLiteral(" (channel \"%1\")").arg(channelAttr.toString());
             continue;
         }
+        // Range-checked for every type, Pitch Bend included. Pitch Bend
+        // ignores `number` at dispatch (key() substitutes 0xFF and
+        // sourceDisplayName() omits it), so an out-of-range value there is
+        // inert rather than dangerous — but storing and re-exporting a number
+        // no MIDI message can carry leaves a file that says something untrue,
+        // and Principle VII asks the boundary to validate ranges, not just
+        // the ranges that currently matter.
         const auto numberAttr = attrs.value("number");
         bool numberOk = true;
         const int number = numberAttr.isNull() ? 0 : numberAttr.toInt(&numberOk);
-        if (!numberOk || (type != MidiBinding::PitchBend && (number < 0 || number > 127))) {
+        if (!numberOk || number < 0 || number > 127) {
             result.skippedBadType
                 << param + QStringLiteral(" (number \"%1\")").arg(numberAttr.toString());
             continue;
@@ -427,16 +508,8 @@ void MidiSettings::save()
 
     // Write bindings inline in the main settings file
     xml.writeStartElement("Bindings");
-    for (const auto& b : bindings) {
-        xml.writeStartElement("Binding");
-        xml.writeAttribute("param", normalizedMidiParamId(b.paramId));
-        xml.writeAttribute("channel", QString::number(b.channel));
-        xml.writeAttribute("type", QString::number(static_cast<int>(b.msgType)));
-        xml.writeAttribute("number", QString::number(b.number));
-        xml.writeAttribute("inverted", b.inverted ? "True" : "False");
-        if (b.relative) xml.writeAttribute("relative", "True");
-        xml.writeEndElement();
-    }
+    for (const auto& b : bindings)
+        writeBindingElement(xml, b);
     xml.writeEndElement(); // Bindings
 
     xml.writeEndElement(); // MidiSettings
@@ -468,16 +541,8 @@ void MidiSettings::saveBindings(const QVector<MidiBinding>& bindings)
     xml.writeTextElement("AutoConnect", m_autoConnect ? "True" : "False");
 
     xml.writeStartElement("Bindings");
-    for (const auto& b : bindings) {
-        xml.writeStartElement("Binding");
-        xml.writeAttribute("param", normalizedMidiParamId(b.paramId));
-        xml.writeAttribute("channel", QString::number(b.channel));
-        xml.writeAttribute("type", QString::number(static_cast<int>(b.msgType)));
-        xml.writeAttribute("number", QString::number(b.number));
-        xml.writeAttribute("inverted", b.inverted ? "True" : "False");
-        if (b.relative) xml.writeAttribute("relative", "True");
-        xml.writeEndElement();
-    }
+    for (const auto& b : bindings)
+        writeBindingElement(xml, b);
     xml.writeEndElement();
 
     xml.writeEndElement();
@@ -555,6 +620,25 @@ MidiImportResult MidiSettings::importProfile(
 {
     MidiImportResult result;
 
+    // A profile is kilobytes — the vendor CTR2-Quad map is a few. Two guards,
+    // because they cover different failures and neither covers the other:
+    //
+    //  1. Regular files only. QFile::size() reports 0 for character devices,
+    //     FIFOs and most /proc entries, so a size check alone lets exactly the
+    //     files with no end through. Pointing the picker at /dev/zero used to
+    //     read until the kernel OOM-killed the app (74 GB VM, no dialog, no log
+    //     line); a FIFO hung in the read forever. Principle VII: a parser must
+    //     not crash, hang, or over-allocate on the input it is handed.
+    //  2. A bounded read of one byte past the cap. This is what enforces the
+    //     size limit — checking size() first would re-trust the same number
+    //     guard 1 exists because we cannot trust.
+    const QFileInfo info(filePath);
+    if (!info.isFile()) {
+        result.errors << QStringLiteral("%1 is not a regular file.")
+                             .arg(QDir::toNativeSeparators(filePath));
+        return result;
+    }
+
     QFile file(filePath);
     if (!file.open(QIODevice::ReadOnly)) {
         result.errors << QStringLiteral("Couldn't open %1 for reading (%2).")
@@ -562,32 +646,42 @@ MidiImportResult MidiSettings::importProfile(
                                   file.errorString());
         return result;
     }
-    // A profile is kilobytes — the vendor CTR2-Quad map is a few. Refuse
-    // anything absurd before readAll() allocates it, so pointing the dialog at
-    // the wrong file is a message rather than an allocation failure.
     constexpr qint64 kMaxProfileBytes = 1 << 20;
-    if (file.size() > kMaxProfileBytes) {
-        result.errors << QStringLiteral("%1 is too large to be a MIDI profile (%2 bytes).")
+    const QByteArray bytes = file.read(kMaxProfileBytes + 1);
+    file.close();
+    if (bytes.size() > kMaxProfileBytes) {
+        result.errors << QStringLiteral("%1 is too large to be a MIDI profile (over %2 bytes).")
                              .arg(QDir::toNativeSeparators(filePath))
-                             .arg(file.size());
+                             .arg(kMaxProfileBytes);
         return result;
     }
-    const QByteArray bytes = file.readAll();
-    file.close();
 
-    // Sniff the dialect: native XML leads with '<'; a SmartSDR ".map" leads
-    // with a "#"-headed section. Anything else is not a profile.
+    // Sniff the dialect: native XML leads with '<'; a SmartSDR ".map" is
+    // recognized by a "#"-headed section appearing in its first few lines,
+    // not merely by its first character — a file that opens with a
+    // "FORMAT_VERSION=1"-style preamble is still a map, and rejecting it
+    // wholesale sends the operator an error naming a header the file
+    // contains three lines further down. Anything else is not a profile.
     QVector<MidiBinding> bindings;
     // A leading UTF-8 BOM (any file round-tripped through a Windows editor)
     // never reaches this comparison: QString::fromUtf8() consumes it. The
     // import test pins that, so a toolchain that ever stops doing it fails
     // loudly here rather than reporting a valid profile as unrecognized.
-    const QString head = QString::fromUtf8(bytes.left(256)).trimmed();
-    if (head.startsWith(QLatin1Char('<')))
+    const QString head = QString::fromUtf8(bytes.left(1024)).trimmed();
+    constexpr int kSniffLines = 8;
+    bool looksLikeMap = false;
+    const QStringList headLines = head.split(QLatin1Char('\n'));
+    for (int i = 0; i < headLines.size() && i < kSniffLines; ++i) {
+        if (headLines.at(i).trimmed().startsWith(QLatin1Char('#'))) {
+            looksLikeMap = true;
+            break;
+        }
+    }
+    if (head.startsWith(QLatin1Char('<'))) {
         bindings = parseProfileXml(bytes, paramValidator, result);
-    else if (head.startsWith(QLatin1Char('#')))
+    } else if (looksLikeMap) {
         bindings = parseSmartSdrMap(bytes, paramValidator, result);
-    else {
+    } else {
         result.errors << QStringLiteral(
             "Unrecognized file: expected <MidiProfile> XML or a SmartSDR \"# Controls\" map.");
         return result;
@@ -647,6 +741,16 @@ MidiExportResult MidiSettings::exportProfile(const QString& filePath,
     MidiExportResult result;
     if (filePath.trimmed().isEmpty()) {
         result.error = QStringLiteral("No export path was provided.");
+        return result;
+    }
+    // Refused here, not only in the dialog. An empty set serializes to a
+    // childless <MidiProfile/>, which importProfile() then rejects with
+    // "File contains no <Binding> elements" — so reporting success would
+    // hand the caller a file that cannot come back, and the round-trip
+    // contract this API documents lives here, not in the GUI that happens
+    // to guard it today.
+    if (bindings.isEmpty()) {
+        result.error = QStringLiteral("There are no bindings to export.");
         return result;
     }
 

--- a/src/core/MidiSettings.cpp
+++ b/src/core/MidiSettings.cpp
@@ -107,6 +107,20 @@ constexpr MapFunctionEntry kSmartSdrMapFunctions[] = {
     { "zoomout",       "global.panZoomOut", false },
 };
 
+// Message-type name for skip/duplicate reports.  Spelled out here rather than
+// calling MidiBinding::sourceDisplayName(), which lives in
+// MidiControlManager.cpp — midi_settings_test links this file alone.
+QString midiMsgTypeName(MidiBinding::MsgType type)
+{
+    switch (type) {
+    case MidiBinding::CC:        return QStringLiteral("CC");
+    case MidiBinding::NoteOn:    return QStringLiteral("Note On");
+    case MidiBinding::NoteOff:   return QStringLiteral("Note Off");
+    case MidiBinding::PitchBend: return QStringLiteral("Pitch Bend");
+    }
+    return QStringLiteral("message");
+}
+
 const MapFunctionEntry* findMapFunction(const QString& function)
 {
     for (const auto& entry : kSmartSdrMapFunctions) {
@@ -126,6 +140,7 @@ QVector<MidiBinding> parseSmartSdrMap(const QByteArray& bytes,
 {
     QVector<MidiBinding> bindings;
     QSet<QString> importedParams;
+    QSet<quint32> importedKeys;
     bool sawAssignment = false;
 
     enum class Section { None, Controls, Buttons, Other };
@@ -170,8 +185,11 @@ QVector<MidiBinding> parseSmartSdrMap(const QByteArray& bytes,
         // dialect ("L1=", "LED1="), and judging those by the control/button
         // key format would fail the whole file instead of naming the skip.
         if (section == Section::Other) {
-            // e.g. the LEDs section: device feedback, not a binding.
-            result.skippedUnknownParam << function + QStringLiteral(" (not a control/button row)");
+            // e.g. the LEDs section: device feedback, not a binding.  Named
+            // once, not once per row — a real device has one row per LED.
+            const QString note = function + QStringLiteral(" (not a control/button row)");
+            if (!result.skippedUnknownParam.contains(note))
+                result.skippedUnknownParam << note;
             continue;
         }
 
@@ -194,8 +212,10 @@ QVector<MidiBinding> parseSmartSdrMap(const QByteArray& bytes,
 
         const QString paramId = QLatin1String(entry->paramId);
         if (paramValidator && !paramValidator(paramId)) {
-            result.skippedUnknownParam
-                << function + QStringLiteral(" (param %1 not registered)").arg(paramId);
+            const QString note =
+                function + QStringLiteral(" (param %1 not registered)").arg(paramId);
+            if (!result.skippedUnknownParam.contains(note))
+                result.skippedUnknownParam << note;
             continue;
         }
         if (importedParams.contains(paramId)) {
@@ -210,8 +230,18 @@ QVector<MidiBinding> parseSmartSdrMap(const QByteArray& bytes,
         b.paramId = paramId;
         b.inverted = false;
         b.relative = (b.msgType == MidiBinding::CC) && entry->relativeCc;
+        // Two rows on one MIDI source is the other way a binding disappears:
+        // MidiControlManager indexes by MidiBinding::key(), one entry per
+        // key, so the later row would make the earlier one unreachable after
+        // Load while both still show in the table. Name it instead.
+        if (importedKeys.contains(b.key())) {
+            result.duplicates
+                << function + QStringLiteral(" (%1 already bound)").arg(key);
+            continue;
+        }
         bindings.append(b);
         importedParams.insert(paramId);
+        importedKeys.insert(b.key());
     }
 
     if (!sawAssignment)
@@ -231,6 +261,7 @@ QVector<MidiBinding> parseProfileXml(const QByteArray& bytes,
 {
     QVector<MidiBinding> bindings;
     QSet<QString> importedParams;
+    QSet<quint32> importedKeys;
     bool sawRoot = false;
     bool sawBindingElement = false;
 
@@ -304,8 +335,22 @@ QVector<MidiBinding> parseProfileXml(const QByteArray& bytes,
         b.number = number;
         b.inverted = (attrs.value("inverted") == u"True");
         b.relative = (attrs.value("relative") == u"True");
+        // Same MIDI-source collision as the .map path, and likelier here:
+        // addBinding() dedups by param only, so our own export can carry two
+        // bindings on one source. The later one would win the index after
+        // Load and the earlier would go quiet with nothing reporting it.
+        if (importedKeys.contains(b.key())) {
+            result.duplicates
+                << param + QStringLiteral(" (%1 %2 on channel %3 already bound)")
+                               .arg(midiMsgTypeName(b.msgType))
+                               .arg(number)
+                               .arg(channel < 0 ? QStringLiteral("any")
+                                                : QString::number(channel + 1));
+            continue;
+        }
         bindings.append(b);
         importedParams.insert(param);
+        importedKeys.insert(b.key());
     }
 
     if (xml.hasError()) {

--- a/src/core/MidiSettings.cpp
+++ b/src/core/MidiSettings.cpp
@@ -34,6 +34,9 @@ void writeProfileDocument(QXmlStreamWriter& xml, const QVector<MidiBinding>& bin
     xml.setAutoFormatting(true);
     xml.writeStartDocument();
     xml.writeStartElement("MidiProfile");
+    // Schema hook for files in circulation, cheap now and painful to
+    // retrofit — the .map's FORMAT_VERSION analogue.
+    xml.writeAttribute("version", "1");
     for (const auto& b : bindings) {
         xml.writeStartElement("Binding");
         xml.writeAttribute("param", normalizedMidiParamId(b.paramId));

--- a/src/core/MidiSettings.cpp
+++ b/src/core/MidiSettings.cpp
@@ -62,9 +62,10 @@ void writeProfileDocument(QXmlStreamWriter& xml, const QVector<MidiBinding>& bin
 //     # LEDs                    (device feedback — not bindings)
 //
 // The function vocabulary is SmartSDR's; this table carries the verified
-// CTR2-MIDI subset. Functions absent here are reported as named skips, so
-// growing coverage is a data change only. relativeCc marks functions whose
-// CC values are relative steps (the VFO knob) rather than absolute levels.
+// CTR2-MIDI + CTR2-Quad vocabulary. Functions absent here are reported as
+// named skips, so growing coverage is a data change only. relativeCc marks
+// functions whose CC values are relative steps (the VFO knob) rather than
+// absolute levels.
 struct MapFunctionEntry {
     const char* function;
     const char* paramId;
@@ -72,23 +73,35 @@ struct MapFunctionEntry {
 };
 
 constexpr MapFunctionEntry kSmartSdrMapFunctions[] = {
-    { "agct",        "rx.agcThreshold",   false },
-    { "atu",         "tx.atuStart",       false },
-    { "banddown",    "global.bandDown",   false },
-    { "bandup",      "global.bandUp",     false },
-    { "freq",        "rx.tuneKnob",       true  },
-    { "leftpaddle",  "cwdit",             false },
-    { "mainmute",    "global.masterMute", false },
-    { "modenext",    "global.modeUp",     false },
-    { "nr",          "rx.nrEnable",       false },
-    { "power",       "tx.rfPower",        false },
-    { "ptt",         "cw.ptt",            false },
-    { "rightpaddle", "cwdah",             false },
-    { "slicevolume", "rx.afGain",         false },
-    { "straightkey", "cwkey",             false },
-    { "tunestep",    "rx.stepUp",         false },
-    { "zoomin",      "global.panZoomIn",  false },
-    { "zoomout",     "global.panZoomOut", false },
+    { "agct",          "rx.agcThreshold",   false },
+    { "anf",           "rx.anfEnable",      false },
+    { "atu",           "tx.atuStart",       false },
+    { "balanceslice",  "rx.audioPan",       false },
+    { "banddown",      "global.bandDown",   false },
+    { "bandup",        "global.bandUp",     false },
+    { "cwspeed",       "cw.speed",          false },
+    { "freq",          "rx.tuneKnob",       true  },
+    { "leftpaddle",    "cwdit",             false },
+    { "mainmute",      "global.masterMute", false },
+    { "micgain",       "phone.micLevel",    false },
+    { "modenext",      "global.modeUp",     false },
+    { "modeprev",      "global.modeDown",   false },
+    { "nb",            "rx.nbEnable",       false },
+    { "nr",            "rx.nrEnable",       false },
+    { "power",         "tx.rfPower",        false },
+    { "ptt",           "cw.ptt",            false },
+    { "rightpaddle",   "cwdah",             false },
+    { "rit",           "rx.ritEnable",      false },
+    { "slicevolume",   "rx.afGain",         false },
+    { "straightkey",   "cwkey",             false },
+    { "togglebandzoom","global.bandZoom",   false },
+    { "tune",          "tx.tune",           false },
+    { "tunestep",      "rx.stepUp",         false },
+    { "tunestepprev",  "rx.stepDown",       false },
+    { "vox",           "phone.voxEnable",   false },
+    { "xit",           "rx.xitEnable",      false },
+    { "zoomin",        "global.panZoomIn",  false },
+    { "zoomout",       "global.panZoomOut", false },
 };
 
 const MapFunctionEntry* findMapFunction(const QString& function)

--- a/src/core/MidiSettings.cpp
+++ b/src/core/MidiSettings.cpp
@@ -4,6 +4,8 @@
 
 #include <QDir>
 #include <QFile>
+#include <QFileInfo>
+#include <QSet>
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
 #include <QStandardPaths>
@@ -22,6 +24,248 @@ QString normalizedMidiParamId(const QString& paramId)
     if (paramId == QLatin1String("cw.dah"))
         return QStringLiteral("cwdah");
     return paramId;
+}
+
+// ── SmartSDR iOS/Mac ".map" import ──────────────────────────────────────────
+//
+// The ".map" is the mapping file consumed by the SmartSDR iOS/Mac family's
+// own Import-map tool and published per device by controller vendors
+// (e.g. Lynovation's CTR2 config packages). Plain ASCII, "#"-headed
+// sections, one assignment per line:
+//
+//     # Controls
+//     C100=freq;active          C<CC#> = <function>[;flags]
+//     # Buttons
+//     B20=leftpaddle            B<note#> = <function>[;flags]
+//     # LEDs                    (device feedback — not bindings)
+//
+// The function vocabulary is SmartSDR's; this table carries the verified
+// CTR2-MIDI subset. Functions absent here are reported as named skips, so
+// growing coverage is a data change only. relativeCc marks functions whose
+// CC values are relative steps (the VFO knob) rather than absolute levels.
+struct MapFunctionEntry {
+    const char* function;
+    const char* paramId;
+    bool relativeCc;
+};
+
+constexpr MapFunctionEntry kSmartSdrMapFunctions[] = {
+    { "agct",        "rx.agcThreshold",   false },
+    { "atu",         "tx.atuStart",       false },
+    { "banddown",    "global.bandDown",   false },
+    { "bandup",      "global.bandUp",     false },
+    { "freq",        "rx.tuneKnob",       true  },
+    { "leftpaddle",  "cwdit",             false },
+    { "mainmute",    "global.masterMute", false },
+    { "modenext",    "global.modeUp",     false },
+    { "nr",          "rx.nrEnable",       false },
+    { "power",       "tx.rfPower",        false },
+    { "ptt",         "cw.ptt",            false },
+    { "rightpaddle", "cwdah",             false },
+    { "slicevolume", "rx.afGain",         false },
+    { "straightkey", "cwkey",             false },
+    { "tunestep",    "rx.stepUp",         false },
+    { "zoomin",      "global.panZoomIn",  false },
+    { "zoomout",     "global.panZoomOut", false },
+};
+
+const MapFunctionEntry* findMapFunction(const QString& function)
+{
+    for (const auto& entry : kSmartSdrMapFunctions) {
+        if (function.compare(QLatin1String(entry.function), Qt::CaseInsensitive) == 0)
+            return &entry;
+    }
+    return nullptr;
+}
+
+// Parse a ".map". Structural problems (a line that isn't a section header,
+// an assignment, or blank) are file-level errors — vendor files are
+// machine-generated, so a malformed one is a wrong or corrupt file, not
+// something to import half of. Unknown functions are named skips.
+QVector<MidiBinding> parseSmartSdrMap(const QByteArray& bytes,
+                                      const std::function<bool(const QString&)>& paramValidator,
+                                      MidiImportResult& result)
+{
+    QVector<MidiBinding> bindings;
+    QSet<QString> importedParams;
+    bool sawAssignment = false;
+
+    enum class Section { None, Controls, Buttons, Other };
+    Section section = Section::None;
+
+    const QStringList lines = QString::fromUtf8(bytes).split(QLatin1Char('\n'));
+    for (int i = 0; i < lines.size(); ++i) {
+        const QString line = lines.at(i).trimmed();
+        if (line.isEmpty())
+            continue;
+
+        if (line.startsWith(QLatin1Char('#'))) {
+            const QString name = line.mid(1).trimmed().toLower();
+            if (name == QLatin1String("controls"))
+                section = Section::Controls;
+            else if (name == QLatin1String("buttons"))
+                section = Section::Buttons;
+            else
+                section = Section::Other;
+            continue;
+        }
+
+        const int eq = line.indexOf(QLatin1Char('='));
+        if (eq <= 0) {
+            result.errors << QStringLiteral("Line %1: not a section header or assignment: \"%2\"")
+                                 .arg(i + 1).arg(line);
+            continue;
+        }
+
+        const QString key = line.left(eq).trimmed();
+        // Everything after the first ';' is a flag ("active" in vendor
+        // files); flags decorate rows we otherwise fully understand, so
+        // they are ignored.
+        const QString function = line.mid(eq + 1).section(QLatin1Char(';'), 0, 0).trimmed();
+        if (function.isEmpty())
+            continue; // unassigned slot ("C0="): no content to import or report
+
+        sawAssignment = true;
+
+        const QChar kind = key.isEmpty() ? QChar() : key.at(0).toUpper();
+        bool numberOk = false;
+        const int number = key.mid(1).toInt(&numberOk);
+        if ((kind != QLatin1Char('C') && kind != QLatin1Char('B'))
+            || !numberOk || number < 0 || number > 127) {
+            result.errors << QStringLiteral("Line %1: bad assignment key \"%2\"")
+                                 .arg(i + 1).arg(key);
+            continue;
+        }
+
+        if (section == Section::Other) {
+            // e.g. the LEDs section: device feedback, not a binding.
+            result.skippedUnknownParam << function + QStringLiteral(" (not a control/button row)");
+            continue;
+        }
+
+        const MapFunctionEntry* entry = findMapFunction(function);
+        if (!entry) {
+            if (!result.skippedUnknownParam.contains(function))
+                result.skippedUnknownParam << function;
+            continue;
+        }
+
+        const QString paramId = QLatin1String(entry->paramId);
+        if (paramValidator && !paramValidator(paramId)) {
+            result.skippedUnknownParam
+                << function + QStringLiteral(" (param %1 not registered)").arg(paramId);
+            continue;
+        }
+        if (importedParams.contains(paramId)) {
+            result.duplicates << function;
+            continue;
+        }
+
+        MidiBinding b;
+        b.channel = -1; // the .map carries no channel — accept any
+        b.msgType = (kind == QLatin1Char('C')) ? MidiBinding::CC : MidiBinding::NoteOn;
+        b.number = number;
+        b.paramId = paramId;
+        b.inverted = false;
+        b.relative = (b.msgType == MidiBinding::CC) && entry->relativeCc;
+        bindings.append(b);
+        importedParams.insert(paramId);
+    }
+
+    if (!sawAssignment)
+        result.errors << QStringLiteral("File contains no assignments.");
+    if (!result.errors.isEmpty())
+        return {};
+    return bindings;
+}
+
+// Parse native <MidiProfile> XML with the validation the store's own
+// parser never needed: reader errors are surfaced, the root element is
+// required (so importing midi.settings itself is an error, not a
+// surprise), and per-row problems become named skips.
+QVector<MidiBinding> parseProfileXml(const QByteArray& bytes,
+                                     const std::function<bool(const QString&)>& paramValidator,
+                                     MidiImportResult& result)
+{
+    QVector<MidiBinding> bindings;
+    QSet<QString> importedParams;
+    bool sawRoot = false;
+    bool sawBindingElement = false;
+
+    QXmlStreamReader xml(bytes);
+    while (!xml.atEnd()) {
+        xml.readNext();
+        if (!xml.isStartElement())
+            continue;
+
+        if (!sawRoot) {
+            sawRoot = true;
+            if (xml.name() != u"MidiProfile") {
+                result.errors << QStringLiteral("Root element is <%1>; expected <MidiProfile>.")
+                                     .arg(xml.name().toString());
+                return {};
+            }
+            continue;
+        }
+        if (xml.name() != u"Binding")
+            continue;
+
+        sawBindingElement = true;
+        const auto attrs = xml.attributes();
+        const QString param = normalizedMidiParamId(attrs.value("param").toString());
+        if (param.isEmpty()) {
+            result.skippedUnknownParam << QStringLiteral("(empty param)");
+            continue;
+        }
+
+        bool typeOk = false;
+        const int type = attrs.value("type").toInt(&typeOk);
+        if (!typeOk || type < MidiBinding::CC || type > MidiBinding::PitchBend) {
+            result.skippedBadType
+                << param + QStringLiteral(" (type \"%1\")").arg(attrs.value("type").toString());
+            continue;
+        }
+        const int channel = attrs.value("channel").toInt();
+        if (channel < -1 || channel > 15) {
+            result.skippedBadType << param + QStringLiteral(" (channel %1)").arg(channel);
+            continue;
+        }
+        const int number = attrs.value("number").toInt();
+        if (type != MidiBinding::PitchBend && (number < 0 || number > 127)) {
+            result.skippedBadType << param + QStringLiteral(" (number %1)").arg(number);
+            continue;
+        }
+
+        if (paramValidator && !paramValidator(param)) {
+            result.skippedUnknownParam << param;
+            continue;
+        }
+        if (importedParams.contains(param)) {
+            result.duplicates << param;
+            continue;
+        }
+
+        MidiBinding b;
+        b.paramId = param;
+        b.channel = channel;
+        b.msgType = static_cast<MidiBinding::MsgType>(type);
+        b.number = number;
+        b.inverted = (attrs.value("inverted") == u"True");
+        b.relative = (attrs.value("relative") == u"True");
+        bindings.append(b);
+        importedParams.insert(param);
+    }
+
+    if (xml.hasError()) {
+        result.errors << QStringLiteral("XML error at line %1: %2")
+                             .arg(xml.lineNumber()).arg(xml.errorString());
+        return {};
+    }
+    if (!sawBindingElement) {
+        result.errors << QStringLiteral("File contains no <Binding> elements.");
+        return {};
+    }
+    return bindings;
 }
 
 } // namespace
@@ -218,6 +462,79 @@ QVector<MidiBinding> MidiSettings::loadProfile(const QString& name) const
 void MidiSettings::deleteProfile(const QString& name)
 {
     QFile::remove(profileDir() + "/" + name + ".xml");
+}
+
+// ── Import ──────────────────────────────────────────────────────────────────
+
+MidiImportResult MidiSettings::importProfile(
+    const QString& filePath,
+    const std::function<bool(const QString&)>& paramValidator)
+{
+    MidiImportResult result;
+
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        result.errors << QStringLiteral("Couldn't open %1 for reading (%2).")
+                             .arg(QDir::toNativeSeparators(filePath),
+                                  file.errorString());
+        return result;
+    }
+    const QByteArray bytes = file.readAll();
+    file.close();
+
+    // Sniff the dialect: native XML leads with '<'; a SmartSDR ".map" leads
+    // with a "#"-headed section. Anything else is not a profile.
+    QVector<MidiBinding> bindings;
+    const QString head = QString::fromUtf8(bytes.left(256)).trimmed();
+    if (head.startsWith(QLatin1Char('<')))
+        bindings = parseProfileXml(bytes, paramValidator, result);
+    else if (head.startsWith(QLatin1Char('#')))
+        bindings = parseSmartSdrMap(bytes, paramValidator, result);
+    else {
+        result.errors << QStringLiteral(
+            "Unrecognized file: expected <MidiProfile> XML or a SmartSDR \"# Controls\" map.");
+        return result;
+    }
+
+    if (!result.ok())
+        return result;
+
+    result.importedCount = bindings.size();
+    if (bindings.isEmpty())
+        return result; // parsed, but every row was a named skip — nothing to store
+
+    // Store name = file base name; never overwrite an existing profile. The
+    // prompt-vs-suffix collision policy is an open maintainer call, and a
+    // suffix is the reversible default. Dots are replaced because the store
+    // round-trips names through QFileInfo::baseName(), which cuts at the
+    // first dot — a dotted name would list, load, and collide wrongly.
+    QString name = QFileInfo(filePath).completeBaseName().trimmed();
+    name.replace(QLatin1Char('.'), QLatin1Char('_'));
+    if (name.isEmpty())
+        name = QStringLiteral("Imported profile");
+    const QStringList existing = availableProfiles();
+    const auto taken = [&existing](const QString& candidate) {
+        for (const auto& p : existing)
+            if (p.compare(candidate, Qt::CaseInsensitive) == 0)
+                return true;
+        return false;
+    };
+    QString unique = name;
+    for (int n = 2; taken(unique); ++n)
+        unique = name + QStringLiteral(" (%1)").arg(n);
+
+    saveProfile(unique, bindings);
+
+    // The write path returns void, so prove the store took it before
+    // reporting success.
+    if (loadProfile(unique).size() != bindings.size()) {
+        result.errors << QStringLiteral("Couldn't write the profile into %1.")
+                             .arg(QDir::toNativeSeparators(profileDir()));
+        result.importedCount = 0;
+        return result;
+    }
+    result.profileName = unique;
+    return result;
 }
 
 } // namespace AetherSDR

--- a/src/core/MidiSettings.h
+++ b/src/core/MidiSettings.h
@@ -24,6 +24,12 @@ struct MidiImportResult {
     bool ok() const { return errors.isEmpty(); }
 };
 
+struct MidiExportResult {
+    int exportedCount{0};
+    QString error;
+    bool ok() const { return error.isEmpty(); }
+};
+
 // Dedicated settings file for MIDI controller configuration.
 // Stored at ~/.config/AetherSDR/midi.settings (XML format).
 // Keeps MIDI bindings, device preferences, and profiles separate
@@ -62,6 +68,11 @@ public:
     MidiImportResult importProfile(
         const QString& filePath,
         const std::function<bool(const QString&)>& paramValidator = {});
+
+    // Export bindings as a shareable <MidiProfile> XML — the same document
+    // importProfile() reads back, so Export → Import round-trips.
+    MidiExportResult exportProfile(const QString& filePath,
+                                   const QVector<MidiBinding>& bindings) const;
 
 private:
     MidiSettings() = default;

--- a/src/core/MidiSettings.h
+++ b/src/core/MidiSettings.h
@@ -3,10 +3,26 @@
 #ifdef HAVE_MIDI
 
 #include <QString>
+#include <QStringList>
 #include <QVector>
+#include <functional>
 #include "MidiControlManager.h"
 
 namespace AetherSDR {
+
+// Result of importing a profile file. Import policy: import what maps,
+// name what doesn't, never silently drop — every row that cannot become a
+// binding is either a named skip (the file parsed, that row has no target
+// here) or a file-level error (nothing was written).
+struct MidiImportResult {
+    int importedCount{0};
+    QString profileName;             // store name the profile was saved under
+    QStringList skippedUnknownParam; // functions/params with no target here
+    QStringList skippedBadType;      // out-of-range type/channel/number rows
+    QStringList duplicates;          // rows dropped as later duplicates
+    QStringList errors;              // file-level problems; nothing written
+    bool ok() const { return errors.isEmpty(); }
+};
 
 // Dedicated settings file for MIDI controller configuration.
 // Stored at ~/.config/AetherSDR/midi.settings (XML format).
@@ -36,6 +52,16 @@ public:
     void saveProfile(const QString& name, const QVector<MidiBinding>& bindings);
     QVector<MidiBinding> loadProfile(const QString& name) const;
     void deleteProfile(const QString& name);
+
+    // Import a profile file into the store. Accepts the native <MidiProfile>
+    // XML or a SmartSDR iOS/Mac ".map" (auto-detected by content). The store
+    // name derives from the file name; an existing name gets a " (2)" style
+    // suffix rather than being overwritten. paramValidator returns true when
+    // the action registry knows the id (the GUI passes a findParam() check;
+    // tests inject a fixed set); an empty validator accepts every id.
+    MidiImportResult importProfile(
+        const QString& filePath,
+        const std::function<bool(const QString&)>& paramValidator = {});
 
 private:
     MidiSettings() = default;

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -92,6 +92,15 @@ static const QString kBtnGlyphStyle =
     "border: 1px solid {{color.border.strong}}; padding: 0; border-radius: 3px; }"
     "QPushButton:hover { background: {{color.background.2}}; color: {{color.text.primary}}; }";
 
+// One apply site for the shared primary-button sheet — the colour ratchet
+// counts setStyleSheet() call sites, not colours (tools/audit_colours.py).
+static QPushButton* makeStyledButton(const QString& text)
+{
+    auto* btn = new QPushButton(text);
+    btn->setStyleSheet(kBtnStyle);
+    return btn;
+}
+
 MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* parent)
     : PersistentDialog("MIDI Controller Mapping", "MidiMappingDialogGeometry", parent),
       m_manager(manager)
@@ -116,13 +125,11 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
         m_portCombo->setMinimumWidth(250);
         grid->addWidget(m_portCombo, 0, 1);
 
-        auto* refreshBtn = new QPushButton("Refresh");
-        refreshBtn->setStyleSheet(kBtnStyle);
+        auto* refreshBtn = makeStyledButton("Refresh");
         connect(refreshBtn, &QPushButton::clicked, this, &MidiMappingDialog::refreshPortList);
         grid->addWidget(refreshBtn, 0, 2);
 
-        m_connectBtn = new QPushButton("Connect");
-        m_connectBtn->setStyleSheet(kBtnStyle);
+        m_connectBtn = makeStyledButton("Connect");
         connect(m_connectBtn, &QPushButton::clicked, this, [this] {
             if (m_manager->isOpen()) {
                 m_manager->closePort();
@@ -221,8 +228,7 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
         connect(m_categoryCombo, &QComboBox::currentTextChanged, this, populateParams);
         populateParams();
 
-        auto* learnBtn = new QPushButton("Learn");
-        learnBtn->setStyleSheet(kBtnStyle);
+        auto* learnBtn = makeStyledButton("Learn");
         learnBtn->setToolTip("Add binding: select a parameter, click Learn, then move a knob on your controller");
         connect(learnBtn, &QPushButton::clicked, this, [this, learnBtn] {
             if (m_manager->isLearning()) {
@@ -275,8 +281,7 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
 
         // Button row
         auto* btnRow = new QHBoxLayout;
-        auto* clearAllBtn = new QPushButton("Clear All");
-        clearAllBtn->setStyleSheet(kBtnStyle);
+        auto* clearAllBtn = makeStyledButton("Clear All");
         connect(clearAllBtn, &QPushButton::clicked, this, [this] {
             m_manager->clearBindings();
             refreshBindingTable();
@@ -294,8 +299,7 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
         btnRow->addWidget(new QLabel("Profile:"));
         btnRow->addWidget(m_profileCombo);
 
-        auto* saveProfileBtn = new QPushButton("Save");
-        saveProfileBtn->setStyleSheet(kBtnStyle);
+        auto* saveProfileBtn = makeStyledButton("Save");
         saveProfileBtn->setToolTip(
             QStringLiteral("Save the current bindings as a named profile"));
         connect(saveProfileBtn, &QPushButton::clicked, this, [this] {
@@ -306,8 +310,7 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
         });
         btnRow->addWidget(saveProfileBtn);
 
-        auto* loadProfileBtn = new QPushButton("Load");
-        loadProfileBtn->setStyleSheet(kBtnStyle);
+        auto* loadProfileBtn = makeStyledButton("Load");
         loadProfileBtn->setToolTip(
             QStringLiteral("Apply the selected profile to the current bindings"));
         connect(loadProfileBtn, &QPushButton::clicked, this, [this] {
@@ -330,8 +333,7 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
         });
         btnRow->addWidget(loadProfileBtn);
 
-        auto* importProfileBtn = new QPushButton("Import...");
-        importProfileBtn->setStyleSheet(kBtnStyle);
+        auto* importProfileBtn = makeStyledButton("Import...");
         importProfileBtn->setObjectName(QStringLiteral("midiProfileImportButton"));
         importProfileBtn->setAccessibleName(QStringLiteral("Import MIDI profile"));
         importProfileBtn->setToolTip(QStringLiteral(
@@ -340,8 +342,7 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
                 &MidiMappingDialog::importProfileFromFile);
         btnRow->addWidget(importProfileBtn);
 
-        auto* exportProfileBtn = new QPushButton("Export...");
-        exportProfileBtn->setStyleSheet(kBtnStyle);
+        auto* exportProfileBtn = makeStyledButton("Export...");
         exportProfileBtn->setObjectName(QStringLiteral("midiProfileExportButton"));
         exportProfileBtn->setAccessibleName(QStringLiteral("Export MIDI profile"));
         exportProfileBtn->setToolTip(
@@ -357,8 +358,7 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
     // ── Close button ────────────────────────────────────────────────────
     auto* closeRow = new QHBoxLayout;
     closeRow->addStretch();
-    auto* closeBtn = new QPushButton("Close");
-    closeBtn->setStyleSheet(kBtnStyle);
+    auto* closeBtn = makeStyledButton("Close");
     connect(closeBtn, &QPushButton::clicked, this, &QDialog::accept);
     closeRow->addWidget(closeBtn);
     root->addLayout(closeRow);

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -1,8 +1,8 @@
-#include "core/AppSettings.h"
 #include "core/ThemeManager.h"
 #ifdef HAVE_MIDI
 
 #include "MidiMappingDialog.h"
+#include "core/AppSettings.h"
 #include "FramelessMessageBox.h"
 #include "core/MidiControlManager.h"
 #include "core/MidiSettings.h"
@@ -296,6 +296,8 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
 
         auto* saveProfileBtn = new QPushButton("Save");
         saveProfileBtn->setStyleSheet(kBtnStyle);
+        saveProfileBtn->setToolTip(
+            QStringLiteral("Save the current bindings as a named profile"));
         connect(saveProfileBtn, &QPushButton::clicked, this, [this] {
             QString name = m_profileCombo->currentText().trimmed();
             if (name.isEmpty()) return;
@@ -306,6 +308,8 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
 
         auto* loadProfileBtn = new QPushButton("Load");
         loadProfileBtn->setStyleSheet(kBtnStyle);
+        loadProfileBtn->setToolTip(
+            QStringLiteral("Apply the selected profile to the current bindings"));
         connect(loadProfileBtn, &QPushButton::clicked, this, [this] {
             QString name = m_profileCombo->currentText().trimmed();
             if (name.isEmpty()) return;
@@ -331,7 +335,7 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
         importProfileBtn->setObjectName(QStringLiteral("midiProfileImportButton"));
         importProfileBtn->setAccessibleName(QStringLiteral("Import MIDI profile"));
         importProfileBtn->setToolTip(QStringLiteral(
-            "Import a profile file — an AetherSDR profile XML or a SmartSDR \".map\""));
+            "Import a profile file into the store — AetherSDR profile XML or SmartSDR \".map\""));
         connect(importProfileBtn, &QPushButton::clicked, this,
                 &MidiMappingDialog::importProfileFromFile);
         btnRow->addWidget(importProfileBtn);
@@ -341,7 +345,7 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
         exportProfileBtn->setObjectName(QStringLiteral("midiProfileExportButton"));
         exportProfileBtn->setAccessibleName(QStringLiteral("Export MIDI profile"));
         exportProfileBtn->setToolTip(
-            QStringLiteral("Export the current bindings as a shareable profile file"));
+            QStringLiteral("Export the current bindings as an AetherSDR profile XML"));
         connect(exportProfileBtn, &QPushButton::clicked, this,
                 &MidiMappingDialog::exportProfileToFile);
         btnRow->addWidget(exportProfileBtn);

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -310,7 +310,14 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
             QString name = m_profileCombo->currentText().trimmed();
             if (name.isEmpty()) return;
             auto bindings = MidiSettings::instance().loadProfile(name);
-            if (bindings.isEmpty()) return;
+            if (bindings.isEmpty()) {
+                // A missing or empty profile silently doing nothing is the
+                // same failure class the importer refuses — say so instead.
+                FramelessMessageBox::warning(
+                    this, QStringLiteral("Load Profile"),
+                    QStringLiteral("Profile \"%1\" is empty or missing.").arg(name));
+                return;
+            }
             m_manager->clearBindings();
             for (const auto& b : bindings)
                 m_manager->addBinding(b);
@@ -441,7 +448,9 @@ void MidiMappingDialog::importProfileFromFile()
     box.setIcon(informativeLines.isEmpty() ? QMessageBox::Information
                                            : QMessageBox::Warning);
     box.setWindowTitle(QStringLiteral("Import MIDI Profile"));
-    box.setText(QStringLiteral("Imported %1 binding(s) from %2 as profile \"%3\".")
+    box.setText(QStringLiteral(
+                    "Imported %1 binding(s) from %2 as profile \"%3\". "
+                    "Click Load to apply it.")
                     .arg(result.importedCount)
                     .arg(fileName, result.profileName));
     if (!informativeLines.isEmpty())

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -404,6 +404,7 @@ void MidiMappingDialog::importProfileFromFile()
         box.setIcon(QMessageBox::Warning);
         box.setWindowTitle(QStringLiteral("Import MIDI Profile"));
         box.setText(QStringLiteral("No bindings were imported from %1.").arg(fileName));
+        box.setStandardButtons(QMessageBox::Ok);
         box.setDetailedText(result.errors.join(QLatin1Char('\n')));
         box.exec();
         return;
@@ -437,6 +438,7 @@ void MidiMappingDialog::importProfileFromFile()
         box.setIcon(QMessageBox::Warning);
         box.setWindowTitle(QStringLiteral("Import MIDI Profile"));
         box.setText(QStringLiteral("No usable bindings in %1.").arg(fileName));
+        box.setStandardButtons(QMessageBox::Ok);
         if (!informativeLines.isEmpty())
             box.setInformativeText(informativeLines.join(QLatin1Char('\n')));
         if (!detailLines.isEmpty())
@@ -457,6 +459,7 @@ void MidiMappingDialog::importProfileFromFile()
                     "Click Load to apply it.")
                     .arg(result.importedCount)
                     .arg(fileName, result.profileName));
+    box.setStandardButtons(QMessageBox::Ok);
     if (!informativeLines.isEmpty())
         box.setInformativeText(informativeLines.join(QLatin1Char('\n')));
     if (!detailLines.isEmpty())
@@ -466,7 +469,7 @@ void MidiMappingDialog::importProfileFromFile()
 
 void MidiMappingDialog::exportProfileToFile()
 {
-    const auto bindings = m_manager->bindings();
+    const auto& bindings = m_manager->bindings();
     if (bindings.isEmpty()) {
         FramelessMessageBox::information(this, QStringLiteral("Export MIDI Profile"),
                                          QStringLiteral("There are no bindings to export."));

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -1,3 +1,4 @@
+#include "core/AppSettings.h"
 #include "core/ThemeManager.h"
 #ifdef HAVE_MIDI
 
@@ -21,8 +22,41 @@
 #include <QSpinBox>
 #include <QFormLayout>
 #include <QDialogButtonBox>
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QDir>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QStandardPaths>
 
 namespace AetherSDR {
+
+namespace {
+
+// Remembered directory for profile Import/Export (mirrors the shortcut
+// dialog's transfer-directory helpers).
+QString midiTransferDirectory()
+{
+    const QString saved = AppSettings::instance()
+                              .value(QStringLiteral("MidiImportExportPath"), QString())
+                              .toString();
+    if (!saved.isEmpty() && QDir(saved).exists())
+        return saved;
+    const QString docs =
+        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+    return docs.isEmpty() ? QDir::homePath() : docs;
+}
+
+void rememberMidiTransferDirectory(const QString& path)
+{
+    const QFileInfo info(path);
+    if (!info.absolutePath().isEmpty()) {
+        AppSettings::instance().setValue(QStringLiteral("MidiImportExportPath"),
+                                         info.absolutePath());
+    }
+}
+
+} // namespace
 
 static const QString kGroupStyle =
     "QGroupBox { border: 1px solid #304050; border-radius: 4px; "
@@ -285,6 +319,26 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
         });
         btnRow->addWidget(loadProfileBtn);
 
+        auto* importProfileBtn = new QPushButton("Import...");
+        importProfileBtn->setStyleSheet(kBtnStyle);
+        importProfileBtn->setObjectName(QStringLiteral("midiProfileImportButton"));
+        importProfileBtn->setAccessibleName(QStringLiteral("Import MIDI profile"));
+        importProfileBtn->setToolTip(QStringLiteral(
+            "Import a profile file — an AetherSDR profile XML or a SmartSDR \".map\""));
+        connect(importProfileBtn, &QPushButton::clicked, this,
+                &MidiMappingDialog::importProfileFromFile);
+        btnRow->addWidget(importProfileBtn);
+
+        auto* exportProfileBtn = new QPushButton("Export...");
+        exportProfileBtn->setStyleSheet(kBtnStyle);
+        exportProfileBtn->setObjectName(QStringLiteral("midiProfileExportButton"));
+        exportProfileBtn->setAccessibleName(QStringLiteral("Export MIDI profile"));
+        exportProfileBtn->setToolTip(
+            QStringLiteral("Export the current bindings as a shareable profile file"));
+        connect(exportProfileBtn, &QPushButton::clicked, this,
+                &MidiMappingDialog::exportProfileToFile);
+        btnRow->addWidget(exportProfileBtn);
+
         vbox->addLayout(btnRow);
         root->addWidget(group, 1);
     }
@@ -315,6 +369,124 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
     if (m_manager->isOpen()) {
         m_connectBtn->setText("Disconnect");
     }
+}
+
+void MidiMappingDialog::importProfileFromFile()
+{
+    QFileDialog dialog(this, QStringLiteral("Import MIDI Profile"),
+                       midiTransferDirectory(),
+                       QStringLiteral("MIDI profiles (*.xml *.map);;All files (*)"));
+    dialog.setAcceptMode(QFileDialog::AcceptOpen);
+    dialog.setFileMode(QFileDialog::ExistingFile);
+    if (dialog.exec() != QDialog::Accepted || dialog.selectedFiles().isEmpty())
+        return;
+    const QString path = dialog.selectedFiles().first();
+    rememberMidiTransferDirectory(path);
+
+    const MidiImportResult result = MidiSettings::instance().importProfile(
+        path,
+        [this](const QString& id) { return m_manager->findParam(id) != nullptr; });
+
+    const QString fileName = QFileInfo(path).fileName();
+    if (!result.ok()) {
+        FramelessMessageBox box(this);
+        box.setIcon(QMessageBox::Warning);
+        box.setWindowTitle(QStringLiteral("Import MIDI Profile"));
+        box.setText(QStringLiteral("No bindings were imported from %1.").arg(fileName));
+        box.setDetailedText(result.errors.join(QLatin1Char('\n')));
+        box.exec();
+        return;
+    }
+
+    // Layered report, like the shortcut importer: headline count up front,
+    // per-category counts as informative text, every skipped name in the
+    // expandable details — import what maps, name what doesn't.
+    QStringList informativeLines;
+    QStringList detailLines;
+    const auto addSection = [&](const QString& header, const QStringList& names,
+                                const QString& summary) {
+        if (names.isEmpty())
+            return;
+        informativeLines << summary.arg(names.size());
+        if (!detailLines.isEmpty())
+            detailLines << QString();
+        detailLines << header;
+        detailLines << names;
+    };
+    addSection(QStringLiteral("Skipped (no matching AetherSDR control):"),
+               result.skippedUnknownParam,
+               QStringLiteral("%1 control(s) have no AetherSDR equivalent and were skipped."));
+    addSection(QStringLiteral("Skipped (invalid values):"), result.skippedBadType,
+               QStringLiteral("%1 row(s) had out-of-range values and were skipped."));
+    addSection(QStringLiteral("Dropped duplicates:"), result.duplicates,
+               QStringLiteral("%1 duplicate row(s) were dropped."));
+
+    if (result.importedCount == 0) {
+        FramelessMessageBox box(this);
+        box.setIcon(QMessageBox::Warning);
+        box.setWindowTitle(QStringLiteral("Import MIDI Profile"));
+        box.setText(QStringLiteral("No usable bindings in %1.").arg(fileName));
+        if (!informativeLines.isEmpty())
+            box.setInformativeText(informativeLines.join(QLatin1Char('\n')));
+        if (!detailLines.isEmpty())
+            box.setDetailedText(detailLines.join(QLatin1Char('\n')));
+        box.exec();
+        return;
+    }
+
+    refreshProfileList();
+    m_profileCombo->setCurrentText(result.profileName);
+
+    FramelessMessageBox box(this);
+    box.setIcon(informativeLines.isEmpty() ? QMessageBox::Information
+                                           : QMessageBox::Warning);
+    box.setWindowTitle(QStringLiteral("Import MIDI Profile"));
+    box.setText(QStringLiteral("Imported %1 binding(s) from %2 as profile \"%3\".")
+                    .arg(result.importedCount)
+                    .arg(fileName, result.profileName));
+    if (!informativeLines.isEmpty())
+        box.setInformativeText(informativeLines.join(QLatin1Char('\n')));
+    if (!detailLines.isEmpty())
+        box.setDetailedText(detailLines.join(QLatin1Char('\n')));
+    box.exec();
+}
+
+void MidiMappingDialog::exportProfileToFile()
+{
+    const auto bindings = m_manager->bindings();
+    if (bindings.isEmpty()) {
+        FramelessMessageBox::information(this, QStringLiteral("Export MIDI Profile"),
+                                         QStringLiteral("There are no bindings to export."));
+        return;
+    }
+
+    // yyyyMMdd_HHmmss so two exports the same day don't suggest the identical
+    // filename (matches the shortcut exporter).
+    const QString fileName = QStringLiteral("AetherSDR_MidiProfile_%1_v%2.xml")
+                                 .arg(QDateTime::currentDateTime().toString(
+                                          QStringLiteral("yyyyMMdd_HHmmss")),
+                                      QCoreApplication::applicationVersion());
+    QFileDialog dialog(this, QStringLiteral("Export MIDI Profile"),
+                       QDir(midiTransferDirectory()).filePath(fileName),
+                       QStringLiteral("MIDI profile XML (*.xml)"));
+    dialog.setAcceptMode(QFileDialog::AcceptSave);
+    dialog.setDefaultSuffix(QStringLiteral("xml"));
+    if (dialog.exec() != QDialog::Accepted || dialog.selectedFiles().isEmpty())
+        return;
+    const QString path = dialog.selectedFiles().first();
+    rememberMidiTransferDirectory(path);
+
+    const MidiExportResult result = MidiSettings::instance().exportProfile(path, bindings);
+    if (!result.ok()) {
+        FramelessMessageBox::warning(this, QStringLiteral("Export MIDI Profile"),
+                                     result.error);
+        return;
+    }
+    FramelessMessageBox::information(
+        this, QStringLiteral("Export MIDI Profile"),
+        QStringLiteral("Exported %1 binding(s) to %2.")
+            .arg(result.exportedCount)
+            .arg(QFileInfo(path).fileName()));
 }
 
 void MidiMappingDialog::refreshPortList()

--- a/src/gui/MidiMappingDialog.h
+++ b/src/gui/MidiMappingDialog.h
@@ -32,6 +32,12 @@ private:
     // (existing == nullptr) and the per-row edit button (existing == the row's
     // current binding). Commits through the same addBinding()/save path as Learn.
     void openManualEditor(const QString& paramId, const MidiBinding* existing);
+    // Profile file import/export (#4888). Import accepts the native
+    // <MidiProfile> XML or a SmartSDR iOS/Mac ".map" (auto-detected), stores
+    // a new profile (suffix on name collision) and selects it in the combo;
+    // Export writes the current bindings as a shareable profile XML.
+    void importProfileFromFile();
+    void exportProfileToFile();
 
     MidiControlManager* m_manager;
 

--- a/tests/midi_settings_test.cpp
+++ b/tests/midi_settings_test.cpp
@@ -196,6 +196,58 @@ int main(int argc, char** argv)
     ok &= expect(rLeds.skippedUnknownParam.size() == 2,
                  "LEDs rows are named skips, not file-level errors");
 
+    // A real device has one row per LED; the details list should name the
+    // target once rather than once per row.
+    const auto rLedsMany = settings.importProfile(
+        writeImportFile("many-leds.map",
+                        "# Controls\n"
+                        "C100=freq\n"
+                        "# LEDs\n"
+                        "L1=txled\n"
+                        "L2=txled\n"
+                        "L3=txled\n"
+                        "L4=txled\n"),
+        validator);
+    ok &= expect(rLedsMany.ok() && rLedsMany.skippedUnknownParam.size() == 1,
+                 "repeated LEDs rows collapse to one named skip");
+
+    // Two functions on ONE MIDI source: MidiControlManager indexes by
+    // MidiBinding::key(), so importing both would leave the earlier one
+    // unreachable after Load with nothing reporting it.
+    const auto rKeyClash = settings.importProfile(
+        writeImportFile("keyclash.map",
+                        "# Buttons\n"
+                        "B13=nr\n"
+                        "B13=banddown\n"),
+        validator);
+    ok &= expect(rKeyClash.ok() && rKeyClash.importedCount == 1,
+                 "two functions on one key import as one binding");
+    ok &= expect(rKeyClash.duplicates.size() == 1
+                     && rKeyClash.duplicates.first().contains("B13"),
+                 "the losing row is named as a duplicate, not dropped silently");
+    {
+        const auto stored = settings.loadProfile(rKeyClash.profileName);
+        QSet<quint32> keys;
+        for (const auto& b : stored) keys.insert(b.key());
+        ok &= expect(stored.size() == static_cast<int>(keys.size()),
+                     "no stored profile binds one MIDI source twice");
+    }
+
+    // Same collision in the native XML — likelier there, since addBinding()
+    // dedups by param only and our own export can carry it.
+    const auto rXmlKeyClash = settings.importProfile(
+        writeImportFile("keyclash.xml",
+                        "<MidiProfile>"
+                        "<Binding param=\"rx.afGain\" channel=\"0\" type=\"0\" number=\"7\"/>"
+                        "<Binding param=\"tx.rfPower\" channel=\"0\" type=\"0\" number=\"7\"/>"
+                        "</MidiProfile>\n"),
+        validator);
+    ok &= expect(rXmlKeyClash.ok() && rXmlKeyClash.importedCount == 1,
+                 "XML: two bindings on one source import as one");
+    ok &= expect(rXmlKeyClash.duplicates.size() == 1
+                     && rXmlKeyClash.duplicates.first().contains("CC"),
+                 "XML: the losing binding is named with its source");
+
     const auto r3 = settings.importProfile(writeImportFile("garbage.map", "hello world\n"),
                                            validator);
     ok &= expect(!r3.ok() && r3.importedCount == 0, "unrecognized content fails loudly");

--- a/tests/midi_settings_test.cpp
+++ b/tests/midi_settings_test.cpp
@@ -193,8 +193,14 @@ int main(int argc, char** argv)
         validator);
     ok &= expect(rLeds.ok() && rLeds.importedCount == 1,
                  "a vendor-dialect LEDs section doesn't fail the import");
-    ok &= expect(rLeds.skippedUnknownParam.size() == 2,
-                 "LEDs rows are named skips, not file-level errors");
+    // Reported as one summary per feedback section rather than one line per
+    // row: every row under a known non-binding header is the same kind of
+    // thing, so naming each would flood the details list on a real device
+    // without telling the operator anything the first line didn't.
+    ok &= expect(rLeds.skippedUnknownParam.size() == 1
+                     && rLeds.skippedUnknownParam.first().contains("LEDs section")
+                     && rLeds.skippedUnknownParam.first().contains("2 row"),
+                 "a LEDs section is summarized once, with its row count");
 
     // A real device has one row per LED; the details list should name the
     // target once rather than once per row.
@@ -208,8 +214,9 @@ int main(int argc, char** argv)
                         "L3=txled\n"
                         "L4=txled\n"),
         validator);
-    ok &= expect(rLedsMany.ok() && rLedsMany.skippedUnknownParam.size() == 1,
-                 "repeated LEDs rows collapse to one named skip");
+    ok &= expect(rLedsMany.ok() && rLedsMany.skippedUnknownParam.size() == 1
+                     && rLedsMany.skippedUnknownParam.first().contains("4 row"),
+                 "repeated LEDs rows collapse to one skip that counts them");
 
     // Two functions on ONE MIDI source: MidiControlManager indexes by
     // MidiBinding::key(), so importing both would leave the earlier one
@@ -360,6 +367,184 @@ int main(int argc, char** argv)
         fakeHome.path() + "/no-such-dir/out.xml",
         settings.loadProfile("CTR2-Test_v1_0"));
     ok &= expect(!exportFail.ok(), "export to an unwritable path reports an error");
+
+    // An empty set must not report success: it serializes to a childless
+    // <MidiProfile/> that importProfile() rejects, so "exported OK" would
+    // hand the caller a file that cannot come back.
+    const auto exportEmpty =
+        settings.exportProfile(fakeHome.path() + "/empty.xml", QVector<MidiBinding>{});
+    ok &= expect(!exportEmpty.ok() && exportEmpty.exportedCount == 0,
+                 "exporting an empty binding set is refused, not written as a stub");
+
+    // ── Non-regular files: the size cap cannot see them ─────────────────────
+    //
+    // QFile::size() reports 0 for character devices, FIFOs and most /proc
+    // entries, so a size-based cap lets exactly the files with no end through.
+    // /dev/null is the safe representative: a character device that reads EOF
+    // immediately, so this pins the guard with no chance of hanging the suite
+    // the way /dev/zero or a FIFO would. Asserting the *specific* message
+    // matters — a bare !ok() check would also pass on "couldn't open".
+#ifdef Q_OS_UNIX
+    if (QFile::exists(QStringLiteral("/dev/null"))) {
+        const auto rDev = settings.importProfile(QStringLiteral("/dev/null"), validator);
+        ok &= expect(!rDev.ok() && rDev.importedCount == 0,
+                     "a character device is refused, not read");
+        ok &= expect(rDev.errors.size() == 1
+                         && rDev.errors.first().contains("not a regular file"),
+                     "the non-regular-file refusal names the reason");
+    }
+#endif
+    const auto rDir = settings.importProfile(fakeHome.path(), validator);
+    ok &= expect(!rDir.ok() && rDir.errors.size() == 1
+                     && rDir.errors.first().contains("not a regular file"),
+                 "a directory is refused before any read");
+
+    // ── ".map" section headers: decorated, commented, unknown ───────────────
+
+    // Vendors decorate headers. Matching the whole header line demoted these
+    // rows to "not a binding row" and lost both bindings.
+    const auto rDecorated = settings.importProfile(
+        writeImportFile("decorated.map",
+                        "# Controls (16 knobs)\n"
+                        "C100=freq;active\n"
+                        "C110=cwspeed;active\n"),
+        validator);
+    ok &= expect(rDecorated.ok() && rDecorated.importedCount == 2,
+                 "a decorated section header still binds its rows");
+    ok &= expect(rDecorated.skippedUnknownParam.isEmpty(),
+                 "a decorated header produces no bogus skips");
+
+    // First-word matching also has to keep recognizing a decorated *feedback*
+    // header. Bindable rows survive an unreadable header on their own (that is
+    // the per-row rule below), so this is the case that actually depends on the
+    // header being parsed: "# LEDs (8 indicators)" must still be understood as
+    // the LEDs section and summarized, not reported as an unknown row.
+    const auto rDecoratedLeds = settings.importProfile(
+        writeImportFile("decorated-leds.map",
+                        "# Controls\n"
+                        "C100=freq\n"
+                        "# LEDs (8 indicators)\n"
+                        "L1=on\n"
+                        "L2=on\n"),
+        validator);
+    ok &= expect(rDecoratedLeds.ok() && rDecoratedLeds.importedCount == 1,
+                 "a decorated LEDs header still imports the controls above it");
+    ok &= expect(rDecoratedLeds.skippedUnknownParam.size() == 1
+                     && rDecoratedLeds.skippedUnknownParam.first().contains("LEDs")
+                     && rDecoratedLeds.skippedUnknownParam.first().contains("2 row"),
+                 "a decorated LEDs header is still recognized as a feedback section");
+
+    // A comment line mid-section must not swallow the rows after it: the row
+    // still looks like a control row, so it still binds.
+    const auto rComment = settings.importProfile(
+        writeImportFile("comment.map",
+                        "# Controls\n"
+                        "C100=freq;active\n"
+                        "# the VFO knob sends relative steps\n"
+                        "C110=cwspeed;active\n"),
+        validator);
+    ok &= expect(rComment.ok() && rComment.importedCount == 2,
+                 "a comment between control rows doesn't drop the rows after it");
+
+    // A section this build doesn't know, keyed in a dialect we can't use, is a
+    // named skip — not a file-level error that loses the bindings around it.
+    const auto rUnknownSection = settings.importProfile(
+        writeImportFile("unknown-section.map",
+                        "# Controls\n"
+                        "C100=freq\n"
+                        "# Encoders\n"
+                        "E1=turn\n"),
+        validator);
+    ok &= expect(rUnknownSection.ok() && rUnknownSection.importedCount == 1,
+                 "an unknown section doesn't fail the file");
+    ok &= expect(rUnknownSection.skippedUnknownParam.size() == 1
+                     && rUnknownSection.skippedUnknownParam.first().contains("E1=turn"),
+                 "an unusable row under an unknown header is named with its key");
+
+    // Under an unreadable header the naming is per row, so two rows that share
+    // a value stay distinct — the case that made "FORMAT_VERSION=1" and a
+    // dozen other metadata rows all report as the same unreadable "1".
+    const auto rDistinct = settings.importProfile(
+        writeImportFile("distinct.map",
+                        "# Controls\n"
+                        "C100=freq\n"
+                        "# Metadata\n"
+                        "FORMAT_VERSION=1\n"
+                        "REVISION=1\n"),
+        validator);
+    ok &= expect(rDistinct.ok() && rDistinct.skippedUnknownParam.size() == 2
+                     && rDistinct.skippedUnknownParam.first().contains("FORMAT_VERSION=1")
+                     && rDistinct.skippedUnknownParam.at(1).contains("REVISION=1"),
+                 "metadata rows sharing a value are named separately, by key");
+
+    // Skips carry the whole row. "on" alone is unreadable; "L1=on" says what
+    // was skipped, and two rows sharing a value stay distinct.
+    const auto rSkipNames = settings.importProfile(
+        writeImportFile("skipnames.map",
+                        "# Controls\n"
+                        "C100=freq\n"
+                        "# LEDs\n"
+                        "L1=on\n"
+                        "L2=on\n"),
+        validator);
+    ok &= expect(rSkipNames.ok() && rSkipNames.importedCount == 1,
+                 "a LEDs section still lets the controls import");
+    ok &= expect(rSkipNames.skippedUnknownParam.size() == 1
+                     && rSkipNames.skippedUnknownParam.first().contains("2 row"),
+                 "same-valued LED rows are counted, not collapsed into one name");
+
+    // The sniff scans the first lines for a header rather than testing only
+    // the first character, so a preamble doesn't reject the whole file.
+    const auto rPreamble = settings.importProfile(
+        writeImportFile("preamble.map",
+                        "FORMAT_VERSION=1\n"
+                        "DEVICE=CTR2-Max\n"
+                        "# Controls\n"
+                        "C100=freq;active\n"),
+        validator);
+    ok &= expect(rPreamble.ok() && rPreamble.importedCount == 1,
+                 "a KEY=value preamble still sniffs as a map");
+
+    // ── XML attribute handling ──────────────────────────────────────────────
+
+    // Absent `type` now follows the same rule as absent channel/number.
+    const auto rNoType = settings.importProfile(
+        writeImportFile("notype.xml",
+                        "<MidiProfile>"
+                        "<Binding param=\"rx.afGain\" channel=\"0\" number=\"7\"/>"
+                        "</MidiProfile>\n"),
+        validator);
+    ok &= expect(rNoType.ok() && rNoType.importedCount == 1,
+                 "XML: an absent type attribute defaults to CC and still imports");
+    {
+        const auto stored = settings.loadProfile(rNoType.profileName);
+        ok &= expect(stored.size() == 1 && stored.first().msgType == MidiBinding::CC,
+                     "XML: the defaulted type really is CC");
+    }
+    // A present-but-unreadable type is still a named skip.
+    const auto rBadType = settings.importProfile(
+        writeImportFile("badtype.xml",
+                        "<MidiProfile>"
+                        "<Binding param=\"rx.afGain\" channel=\"0\" type=\"zz\" number=\"7\"/>"
+                        "</MidiProfile>\n"),
+        validator);
+    ok &= expect(rBadType.importedCount == 0 && rBadType.skippedBadType.size() == 1,
+                 "XML: a non-numeric type is still a named skip, not a default");
+
+    // Pitch Bend ignores `number` at dispatch, but an out-of-range value would
+    // be stored and re-exported as a number no MIDI message can carry.
+    const auto rPitch = settings.importProfile(
+        writeImportFile("pitch.xml",
+                        "<MidiProfile>"
+                        "<Binding param=\"rx.afGain\" channel=\"0\" type=\"3\" number=\"99999\"/>"
+                        "<Binding param=\"tx.rfPower\" channel=\"0\" type=\"3\" number=\"5\"/>"
+                        "</MidiProfile>\n"),
+        validator);
+    ok &= expect(rPitch.ok() && rPitch.importedCount == 1,
+                 "XML: an out-of-range Pitch Bend number is skipped, not stored");
+    ok &= expect(rPitch.skippedBadType.size() == 1
+                     && rPitch.skippedBadType.first().contains("number"),
+                 "XML: the out-of-range Pitch Bend row is named");
 
     QFile::remove(configRoot + "/AetherSDR/midi.settings");
     QDir(configRoot + "/AetherSDR").removeRecursively();

--- a/tests/midi_settings_test.cpp
+++ b/tests/midi_settings_test.cpp
@@ -3,6 +3,7 @@
 #include <QCoreApplication>
 #include <QDir>
 #include <QFile>
+#include <QSet>
 #include <QStandardPaths>
 #include <QTemporaryDir>
 
@@ -113,6 +114,109 @@ int main(int argc, char** argv)
                  "preference-only save updates last device");
     ok &= expect(!settings.autoConnect(),
                  "preference-only save updates auto-connect");
+
+    // ── importProfile: native XML + SmartSDR ".map", auto-detected ──────────
+
+    const QSet<QString> registry = {
+        "rx.tuneKnob", "rx.afGain", "rx.agcThreshold", "tx.rfPower",
+        "rx.nrEnable", "global.bandUp", "global.bandDown", "global.masterMute",
+        "global.modeUp", "global.panZoomIn", "global.panZoomOut", "rx.stepUp",
+        "tx.atuStart", "cwdit", "cwdah", "cwkey", "cw.ptt",
+    };
+    const auto validator = [&registry](const QString& id) { return registry.contains(id); };
+
+    const auto writeImportFile = [&fakeHome](const QString& name, const QByteArray& content) {
+        QFile f(fakeHome.path() + "/" + name);
+        if (!f.open(QIODevice::WriteOnly))
+            return QString();
+        f.write(content);
+        f.close();
+        return f.fileName();
+    };
+
+    // Shaped like the vendor CTR2-MIDI file: known + unknown functions, an
+    // unassigned slot, flags, a duplicate function, and an LEDs section.
+    const QByteArray mapContent =
+        "# Controls\n"
+        "C100=freq\n"
+        "C103=bwset;active\n"
+        "C0=\n"
+        "# Buttons\n"
+        "B20=leftpaddle\n"
+        "B21=rightpaddle;active\n"
+        "B13=nr\n"
+        "B4=nr\n"
+        "B53=openft8\n"
+        "B31=ptt\n"
+        "# LEDs\n";
+    const QString mapPath = writeImportFile("CTR2-Test_v1.0.map", mapContent);
+
+    const auto r1 = settings.importProfile(mapPath, validator);
+    ok &= expect(r1.ok(), "map import succeeds");
+    ok &= expect(r1.importedCount == 5, "map import count (freq, paddles, nr, ptt)");
+    ok &= expect(r1.profileName == "CTR2-Test_v1_0", "map import names profile from file name");
+    ok &= expect(r1.skippedUnknownParam.contains("bwset")
+                     && r1.skippedUnknownParam.contains("openft8"),
+                 "unknown map functions are skipped by name");
+    ok &= expect(r1.duplicates == QStringList{"nr"}, "duplicate map function reported by name");
+    {
+        const auto imported = settings.loadProfile(r1.profileName);
+        ok &= expect(imported.size() == 5, "imported map profile loads from the store");
+        bool foundFreq = false;
+        bool foundDit = false;
+        for (const auto& b : imported) {
+            if (b.paramId == "rx.tuneKnob")
+                foundFreq = b.msgType == MidiBinding::CC && b.number == 100
+                            && b.relative && b.channel == -1 && !b.inverted;
+            if (b.paramId == "cwdit")
+                foundDit = b.msgType == MidiBinding::NoteOn && b.number == 20 && !b.relative;
+        }
+        ok &= expect(foundFreq, "freq row becomes a relative CC 100 VFO binding");
+        ok &= expect(foundDit, "leftpaddle row becomes a NoteOn 20 cwdit binding");
+    }
+
+    const auto r2 = settings.importProfile(mapPath, validator);
+    ok &= expect(r2.ok() && r2.profileName == "CTR2-Test_v1_0 (2)",
+                 "a name collision gets a suffix, never an overwrite");
+
+    const auto r3 = settings.importProfile(writeImportFile("garbage.map", "hello world\n"),
+                                           validator);
+    ok &= expect(!r3.ok() && r3.importedCount == 0, "unrecognized content fails loudly");
+
+    {
+        // Native XML round trip: the profile the map import just stored.
+        const auto r4 = settings.importProfile(
+            configRoot + "/AetherSDR/midi/CTR2-Test_v1_0.xml", validator);
+        ok &= expect(r4.ok() && r4.importedCount == 5, "native XML profile re-imports");
+        ok &= expect(r4.profileName == "CTR2-Test_v1_0 (3)", "XML re-import takes the next suffix");
+        const auto again = settings.loadProfile(r4.profileName);
+        const auto first = settings.loadProfile("CTR2-Test_v1_0");
+        bool same = again.size() == first.size();
+        for (int i = 0; same && i < again.size(); ++i)
+            same = sameBinding(again[i], first[i]);
+        ok &= expect(same, "XML round trip preserves every binding field");
+    }
+
+    const auto r5 = settings.importProfile(configRoot + "/AetherSDR/midi.settings", validator);
+    ok &= expect(!r5.ok(), "midi.settings itself is rejected (wrong root element)");
+
+    const auto r6 = settings.importProfile(
+        writeImportFile("mixed.xml",
+                        "<MidiProfile>"
+                        "<Binding param=\"rx.afGain\" channel=\"0\" type=\"9\" number=\"10\"/>"
+                        "<Binding param=\"no.such\" channel=\"0\" type=\"0\" number=\"11\"/>"
+                        "<Binding param=\"rx.afGain\" channel=\"0\" type=\"0\" number=\"12\"/>"
+                        "</MidiProfile>\n"),
+        validator);
+    ok &= expect(r6.ok() && r6.importedCount == 1, "XML: the one good row imports");
+    ok &= expect(r6.skippedBadType.size() == 1 && r6.skippedBadType.first().contains("type"),
+                 "XML: out-of-range type is skipped by name");
+    ok &= expect(r6.skippedUnknownParam == QStringList{"no.such"},
+                 "XML: unregistered param is skipped by name");
+
+    const auto r7 = settings.importProfile(
+        writeImportFile("trunc.xml", "<MidiProfile><Binding param=\"x\""), validator);
+    ok &= expect(!r7.ok(), "truncated XML fails loudly");
 
     QFile::remove(configRoot + "/AetherSDR/midi.settings");
     QDir(configRoot + "/AetherSDR").removeRecursively();

--- a/tests/midi_settings_test.cpp
+++ b/tests/midi_settings_test.cpp
@@ -218,6 +218,18 @@ int main(int argc, char** argv)
         writeImportFile("trunc.xml", "<MidiProfile><Binding param=\"x\""), validator);
     ok &= expect(!r7.ok(), "truncated XML fails loudly");
 
+    // Export → Import round trip through the user-facing export path.
+    const auto exported = settings.exportProfile(
+        fakeHome.path() + "/exported.xml", settings.loadProfile("CTR2-Test_v1_0"));
+    ok &= expect(exported.ok() && exported.exportedCount == 5,
+                 "export writes the current profile");
+    const auto r8 = settings.importProfile(fakeHome.path() + "/exported.xml", validator);
+    ok &= expect(r8.ok() && r8.importedCount == 5, "exported file re-imports cleanly");
+    const auto exportFail = settings.exportProfile(
+        fakeHome.path() + "/no-such-dir/out.xml",
+        settings.loadProfile("CTR2-Test_v1_0"));
+    ok &= expect(!exportFail.ok(), "export to an unwritable path reports an error");
+
     QFile::remove(configRoot + "/AetherSDR/midi.settings");
     QDir(configRoot + "/AetherSDR").removeRecursively();
 

--- a/tests/midi_settings_test.cpp
+++ b/tests/midi_settings_test.cpp
@@ -121,7 +121,7 @@ int main(int argc, char** argv)
         "rx.tuneKnob", "rx.afGain", "rx.agcThreshold", "tx.rfPower",
         "rx.nrEnable", "global.bandUp", "global.bandDown", "global.masterMute",
         "global.modeUp", "global.panZoomIn", "global.panZoomOut", "rx.stepUp",
-        "tx.atuStart", "cwdit", "cwdah", "cwkey", "cw.ptt",
+        "tx.atuStart", "cwdit", "cwdah", "cwkey", "cw.ptt", "cw.speed",
     };
     const auto validator = [&registry](const QString& id) { return registry.contains(id); };
 
@@ -140,6 +140,7 @@ int main(int argc, char** argv)
         "# Controls\n"
         "C100=freq\n"
         "C103=bwset;active\n"
+        "C110=cwspeed;active\n"
         "C0=\n"
         "# Buttons\n"
         "B20=leftpaddle\n"
@@ -153,7 +154,7 @@ int main(int argc, char** argv)
 
     const auto r1 = settings.importProfile(mapPath, validator);
     ok &= expect(r1.ok(), "map import succeeds");
-    ok &= expect(r1.importedCount == 5, "map import count (freq, paddles, nr, ptt)");
+    ok &= expect(r1.importedCount == 6, "map import count (freq, cwspeed, paddles, nr, ptt)");
     ok &= expect(r1.profileName == "CTR2-Test_v1_0", "map import names profile from file name");
     ok &= expect(r1.skippedUnknownParam.contains("bwset")
                      && r1.skippedUnknownParam.contains("openft8"),
@@ -161,7 +162,7 @@ int main(int argc, char** argv)
     ok &= expect(r1.duplicates == QStringList{"nr"}, "duplicate map function reported by name");
     {
         const auto imported = settings.loadProfile(r1.profileName);
-        ok &= expect(imported.size() == 5, "imported map profile loads from the store");
+        ok &= expect(imported.size() == 6, "imported map profile loads from the store");
         bool foundFreq = false;
         bool foundDit = false;
         for (const auto& b : imported) {
@@ -187,7 +188,7 @@ int main(int argc, char** argv)
         // Native XML round trip: the profile the map import just stored.
         const auto r4 = settings.importProfile(
             configRoot + "/AetherSDR/midi/CTR2-Test_v1_0.xml", validator);
-        ok &= expect(r4.ok() && r4.importedCount == 5, "native XML profile re-imports");
+        ok &= expect(r4.ok() && r4.importedCount == 6, "native XML profile re-imports");
         ok &= expect(r4.profileName == "CTR2-Test_v1_0 (3)", "XML re-import takes the next suffix");
         const auto again = settings.loadProfile(r4.profileName);
         const auto first = settings.loadProfile("CTR2-Test_v1_0");
@@ -221,10 +222,10 @@ int main(int argc, char** argv)
     // Export → Import round trip through the user-facing export path.
     const auto exported = settings.exportProfile(
         fakeHome.path() + "/exported.xml", settings.loadProfile("CTR2-Test_v1_0"));
-    ok &= expect(exported.ok() && exported.exportedCount == 5,
+    ok &= expect(exported.ok() && exported.exportedCount == 6,
                  "export writes the current profile");
     const auto r8 = settings.importProfile(fakeHome.path() + "/exported.xml", validator);
-    ok &= expect(r8.ok() && r8.importedCount == 5, "exported file re-imports cleanly");
+    ok &= expect(r8.ok() && r8.importedCount == 6, "exported file re-imports cleanly");
     const auto exportFail = settings.exportProfile(
         fakeHome.path() + "/no-such-dir/out.xml",
         settings.loadProfile("CTR2-Test_v1_0"));

--- a/tests/midi_settings_test.cpp
+++ b/tests/midi_settings_test.cpp
@@ -287,6 +287,21 @@ int main(int argc, char** argv)
         writeImportFile("trunc.xml", "<MidiProfile><Binding param=\"x\""), validator);
     ok &= expect(!r7.ok(), "truncated XML fails loudly");
 
+    // Oversized files are refused before the read allocates them. The content
+    // is valid profile XML followed by padding, so the only thing that can
+    // reject it is the size cap — not the dialect sniff or the parser.
+    {
+        QByteArray huge = "<MidiProfile>"
+                          "<Binding param=\"rx.afGain\" channel=\"0\" type=\"0\" number=\"7\"/>"
+                          "</MidiProfile>\n";
+        huge.append(QByteArray((1 << 20) + 1 - huge.size(), ' '));
+        const auto rBig = settings.importProfile(writeImportFile("huge.xml", huge), validator);
+        ok &= expect(!rBig.ok() && rBig.importedCount == 0,
+                     "an oversized file is refused, not imported");
+        ok &= expect(rBig.errors.size() == 1 && rBig.errors.first().contains("too large"),
+                     "the oversize refusal is a named error");
+    }
+
     // A row whose value is present but not a number must be a named skip, not
     // a silent 0: channel 0 is MIDI channel 1, not the any-channel wildcard,
     // and number 0 is CC 0 — either would bind the row to the wrong control.

--- a/tests/midi_settings_test.cpp
+++ b/tests/midi_settings_test.cpp
@@ -180,6 +180,22 @@ int main(int argc, char** argv)
     ok &= expect(r2.ok() && r2.profileName == "CTR2-Test_v1_0 (2)",
                  "a name collision gets a suffix, never an overwrite");
 
+    // Sections we never bind from carry the vendor's own key dialect. Judging
+    // those rows by the control/button key format would fail the whole file;
+    // they are named skips, and the bindings around them still import.
+    const auto rLeds = settings.importProfile(
+        writeImportFile("with-leds.map",
+                        "# Controls\n"
+                        "C100=freq\n"
+                        "# LEDs\n"
+                        "L1=txled\n"
+                        "LED2=rxled;active\n"),
+        validator);
+    ok &= expect(rLeds.ok() && rLeds.importedCount == 1,
+                 "a vendor-dialect LEDs section doesn't fail the import");
+    ok &= expect(rLeds.skippedUnknownParam.size() == 2,
+                 "LEDs rows are named skips, not file-level errors");
+
     const auto r3 = settings.importProfile(writeImportFile("garbage.map", "hello world\n"),
                                            validator);
     ok &= expect(!r3.ok() && r3.importedCount == 0, "unrecognized content fails loudly");
@@ -218,6 +234,53 @@ int main(int argc, char** argv)
     const auto r7 = settings.importProfile(
         writeImportFile("trunc.xml", "<MidiProfile><Binding param=\"x\""), validator);
     ok &= expect(!r7.ok(), "truncated XML fails loudly");
+
+    // A row whose value is present but not a number must be a named skip, not
+    // a silent 0: channel 0 is MIDI channel 1, not the any-channel wildcard,
+    // and number 0 is CC 0 — either would bind the row to the wrong control.
+    const auto r9 = settings.importProfile(
+        writeImportFile("badnumbers.xml",
+                        "<MidiProfile>"
+                        "<Binding param=\"rx.afGain\" channel=\"abc\" type=\"0\" number=\"10\"/>"
+                        "<Binding param=\"rx.nrEnable\" channel=\"0\" type=\"0\" number=\"xyz\"/>"
+                        "<Binding param=\"tx.rfPower\" channel=\"0\" type=\"0\" number=\"12\"/>"
+                        "</MidiProfile>\n"),
+        validator);
+    ok &= expect(r9.ok() && r9.importedCount == 1,
+                 "XML: non-numeric channel/number rows don't become bindings");
+    ok &= expect(r9.skippedBadType.size() == 2, "XML: both bad-value rows are skipped by name");
+    {
+        const auto imported = settings.loadProfile(r9.profileName);
+        bool wrongBinding = false;
+        for (const auto& b : imported)
+            if (b.paramId == "rx.afGain" || b.paramId == "rx.nrEnable")
+                wrongBinding = true;
+        ok &= expect(!wrongBinding, "XML: no wrong binding is stored from a bad-value row");
+    }
+
+    // Absent attributes are not the same as bad ones — hand-written files omit
+    // them and must still import.
+    const auto r10 = settings.importProfile(
+        writeImportFile("sparse.xml",
+                        "<MidiProfile>"
+                        "<Binding param=\"rx.afGain\" type=\"0\" number=\"7\"/>"
+                        "</MidiProfile>\n"),
+        validator);
+    ok &= expect(r10.ok() && r10.importedCount == 1,
+                 "XML: an absent attribute keeps its default and still imports");
+
+    // A UTF-8 BOM (any file round-tripped through a Windows editor) must not
+    // defeat the dialect sniff. QString::fromUtf8() consumes the BOM, so this
+    // holds without a guard in the sniff — pinned here so a toolchain that
+    // stops consuming it is caught by this test rather than by a user.
+    const auto r11 = settings.importProfile(
+        writeImportFile("bom.xml",
+                        QByteArray("\xEF\xBB\xBF")
+                            + "<MidiProfile>"
+                              "<Binding param=\"rx.afGain\" channel=\"0\" type=\"0\" number=\"9\"/>"
+                              "</MidiProfile>\n"),
+        validator);
+    ok &= expect(r11.ok() && r11.importedCount == 1, "a UTF-8 BOM still sniffs as profile XML");
 
     // Export → Import round trip through the user-facing export path.
     const auto exported = settings.exportProfile(


### PR DESCRIPTION
Fixes #4888.

## What

Import… and Export… in the MIDI Mapping dialog's profile row. Import ingests
a profile file into the store, auto-detecting the dialect by content: the
native `<MidiProfile>` XML, or the SmartSDR iOS/Mac `.map` that controller
vendors publish per device (per maintainer direction). Export writes the
current bindings as a shareable `<MidiProfile>` XML — the same document
Import reads back. Learn and manual entry (#4790) are untouched.

**Three deliberate changes to existing dialog behaviour**, listed here rather
than left to the diff, since #4888's Non-goals said Save/Load would work
exactly as today:

- **Load now reports an empty or missing profile** instead of silently doing
  nothing (`ec4d8746`). A silent no-op is the same failure class the importer
  refuses, so leaving it silent next to a loud importer read as an oversight.
- **Save and Load gained tooltips** teaching the store-vs-file split
  (`b87897d6`) — the profile row now has four buttons and needed to say which
  two touch files.
- **Five pre-existing buttons** (Refresh, Connect, Learn, Clear All, Close)
  moved to a shared `makeStyledButton()` helper (`c4471f03`). Behaviour-neutral
  and mechanically required: the colour ratchet counts `setStyleSheet()` call
  sites, so adding two buttons meant removing two applications elsewhere.

## Design

- **Import policy: import what maps, name what doesn't, never silently
  drop.** `MidiImportResult` carries imported count, named skips (unknown
  function/param, out-of-range type/channel/number), named duplicates, and
  file-level errors. Unparseable or empty input fails loudly — the
  triage-noted `hasError()` gap and the root-element check are both closed,
  so importing `midi.settings` itself is an error, not a surprise.
- **Native XML stays canonical** (per triage recommendation); `.map` is an
  accepted foreign dialect via content auto-detection — the
  `MemoryCsvCompat::parse()` SmartSDR/CHIRP pattern. The translation table
  carries the verified CTR2 vocabulary (29 functions); unmapped functions
  surface as named skips, so widening coverage is a data change.
- **Never overwrite:** an existing profile name gets a " (2)" suffix
  (prompt-vs-suffix remains the maintainer's call per the issue; the suffix
  is the reversible default). Import-derived names are dot-sanitized —
  the store round-trips names through `QFileInfo::baseName()`, which cuts at
  the first dot (pre-existing quirk, surfaced by the collision test).
- Export uses `QSaveFile` with the direct-write fallback (matches
  `ShortcutManager`/`KiwiSdrManager`) and a timestamped default filename.
  The store's profile writer and the exporter share one serializer.
- GUI adapts the shipped `ShortcutDialog` convention: remembered transfer
  directory, layered result dialog (headline count, per-category counts,
  every skipped name in the details).

## Verification

- `midi_settings_test`: **67 checks, 0 failures** — map happy path (flags,
  unassigned slots, LEDs section), skip-by-name, duplicate report, collision
  suffix, XML round trip preserving every field, wrong-root/truncated/
  garbage inputs fail loudly, bad type/channel rows skip by name, export
  round trip, unwritable-path error, and the review round at `45c7bde2`
  (non-regular-file refusal, decorated and commented section headers,
  unknown sections, per-row skip naming, preamble sniff, absent `type`,
  Pitch Bend range, empty export). Every guard is mutation-checked: reverting
  any one of them fails a named check and only that check.
- **Radio-free hardware pass (macOS, real vendor artifacts):** importing
  Lynovation's published `CTR2-MIDI_SmartSDR_v1.0.map` produced exactly the
  predicted result — 17 bindings imported, 6 skipped by name (`bwset`,
  `nrlevel`, `zoom`, `ritfreq`, `modecw`, `sliceset`), 1 duplicate dropped
  (the vendor file assigns `nr` to two buttons). Load applied all 17;
  the VFO row survived translation exactly
  (`rx.tuneKnob channel=-1 type=CC number=100 relative=True`, verified in
  `midi.settings`); Export produced a 17-binding `<MidiProfile>`; a live
  CTR2-MIDI knob detent showed `CC #100` against the imported binding.
- **CTR2-Quad vendor map import — predicted 27 / 53 / 1, measured 27 / 53 /
  1** (`SmartSDR_CTR2-Dial_v2.0.map`; the duplicate is `tune`, which the
  vendor file assigns to two buttons). Load applied all 27; persisted set
  measured in `midi.settings` (27 rows, `cw.speed` = CC 110 exact). Live
  CTR2-Quad connected: VFO function selected on the device → knob detent →
  `CC #100` activity against the imported binding, and paddle-jack contacts
  (notes 96/97 per the vendor map) triggered the imported `cwdit`/`cwdah`
  Gate bindings.
- **In-app Export → Import round trip** of the loaded 27-binding set: clean —
  27 imported, zero skips, zero duplicates (acceptance criterion 3 at the
  GUI level).

## Test boundary

Radio-free layers (parse, translate, store, load, persist, export, live
MIDI activity on both CTR2 devices) are verified above; hardware readings
were captured at `4119660b`/`a7f5b536`. Everything since — `ec4d8746`,
`0a9c8395`, `8f1a11da`, `9e3cc1ca`, `17f6dce0` and the review round at
`45c7bde2` — is covered by the unit suite and, for the GUI half, by an
offscreen bridge session against the demo simulator (Import → real file
picker → vendor `.map` → result dialog → Load → 27 rows persisted → Export
→ byte-identical to the stored profile → clean re-import).

That session also ran a **third** vendor device the hardware pass above did
not cover: Lynovation's `CTR2-Max_SmartSDR_v1.0.map` from the public
`CTR2-Max_Configuration_Files_v100.zip` (2026-08-10) imports 27 bindings,
48 named skips, 1 duplicate (`tune`, assigned to both B48 and B98), 0
errors, 27 unique MIDI keys — matching a hand-count of the file exactly.

Not yet verified: each binding driving its radio action (bridge bench
pending); the relative-decode interaction between the imported
`relative=True` VFO binding and the CTR2 device-side "SmartSDR" dial-map
wheel type; and whether any `.map` row flag is semantic — published vendor
files carry both `;active` and `;f` (CTR2-Max `B12`), all flags are
dropped, and no flag has been shown to change what a row binds to.

## Relations

- #4888 (this feature request; triage's proposed shape followed incl. the
  result struct and validation list)
- #419 → PR #4226 — the import/export convention this adapts
- #4790 — same dialog, untouched
- RFC #4603 — orthogonal (interchange, not storage)

— authored by agent (Claude Code) on behalf of @skerker

