### PR TITLE
feat(workspace): canvas core, persistence and Classic migration (RFC #4887 phases 1-2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,30 @@ jobs:
       - name: Test band edges and band-plan voice labels
         run: ctest --test-dir build -R "band_edges_test|bandplan_voice_labels_test" --output-on-failure
 
+      # The workspace-canvas suites (RFC #4887) join the gate on the same
+      # rationale, and for a specific reason: their whole value proposition is
+      # "pure logic, pinned headless on every platform", and until this step
+      # existed none of the six ran in any job. Linux compiles `all`, so they
+      # linked and nobody noticed they were never executed — which by
+      # Principle VIII demotes every assertion they carry from evidence to
+      # hypothesis (PR #4900 review, H2).
+      #
+      # What they pin is the class of defect that does not announce itself:
+      # pixel-edge rounding that only grows seams at particular canvas widths,
+      # a z invariant whose breakage makes raise/lower quietly stop working
+      # after enough operations, and a newer-schema guard whose failure mode is
+      # silently destroying a document a later build wrote. All of it is
+      # arithmetic plus one offscreen widget test — no radio, no network, no
+      # wall clock — so it is deterministic everywhere and gating on Linux
+      # alone is enough.
+      #
+      # Measured, not assumed: 244/250/243 ms for all six, against targets the
+      # Build step already linked.
+      - name: Test workspace canvas
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: ctest --test-dir build -R "^workspace_" --output-on-failure
+
       # hl2_am_dcblock_test is deliberately NOT on this gate, and re-adding it
       # needs a measurement first. #4774 added it here on the "milliseconds
       # against an already-linked target" rationale every other step above

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1001,6 +1001,9 @@ set(GUI_SOURCES
     src/gui/containers/ContainerTitleBar.cpp
     src/gui/containers/ContainerWidget.cpp
     src/gui/containers/FloatingContainerWindow.cpp
+    src/gui/workspace/CanvasLayout.cpp
+    src/gui/workspace/WorkspaceCanvas.cpp
+    src/gui/workspace/WorkspaceGeometry.cpp
     src/gui/ClientCompApplet.cpp
     src/gui/ClientCompCurveWidget.cpp
     src/gui/ClientCompKnob.cpp
@@ -3449,6 +3452,44 @@ target_include_directories(window_geometry_restore_test PRIVATE src)
 target_link_libraries(window_geometry_restore_test PRIVATE Qt6::Widgets)
 add_test(NAME window_geometry_restore_test COMMAND window_geometry_restore_test)
 set_tests_properties(window_geometry_restore_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
+# Workspace canvas (RFC #4887) phase 1 — normalized geometry.  Pure logic, no
+# widgets: the edge-rounding rule that keeps tiled items seam-free, and the
+# resolution independence the whole RFC rests on, are pinned on every platform.
+add_executable(workspace_geometry_test
+    tests/workspace_geometry_test.cpp
+    src/gui/workspace/WorkspaceGeometry.cpp
+)
+target_include_directories(workspace_geometry_test PRIVATE src)
+target_link_libraries(workspace_geometry_test PRIVATE Qt6::Core)
+add_test(NAME workspace_geometry_test COMMAND workspace_geometry_test)
+
+# Workspace canvas (RFC #4887) phase 1 — the canvas model: membership,
+# placement clamping, hit testing, and the dense-contiguous z invariant that
+# keeps raise/lower working after arbitrarily many operations.
+add_executable(workspace_layout_test
+    tests/workspace_layout_test.cpp
+    src/gui/workspace/CanvasLayout.cpp
+    src/gui/workspace/WorkspaceGeometry.cpp
+)
+target_include_directories(workspace_layout_test PRIVATE src)
+target_link_libraries(workspace_layout_test PRIVATE Qt6::Core)
+add_test(NAME workspace_layout_test COMMAND workspace_layout_test)
+
+# Workspace canvas (RFC #4887) phase 1 — the widget half, offscreen: model
+# answers applied to real geometry and real Qt stacking, plus the take-vs-remove
+# ownership contract phase 3 depends on.
+add_executable(workspace_canvas_widget_test
+    tests/workspace_canvas_widget_test.cpp
+    src/gui/workspace/WorkspaceCanvas.cpp
+    src/gui/workspace/CanvasLayout.cpp
+    src/gui/workspace/WorkspaceGeometry.cpp
+)
+target_include_directories(workspace_canvas_widget_test PRIVATE src)
+target_link_libraries(workspace_canvas_widget_test PRIVATE Qt6::Widgets)
+add_test(NAME workspace_canvas_widget_test COMMAND workspace_canvas_widget_test)
+set_tests_properties(workspace_canvas_widget_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
 # KiwiSDR band-recall re-bind policy (#4158) — header-only, pure logic.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3491,7 +3491,7 @@ add_executable(workspace_canvas_widget_test
     src/gui/workspace/WorkspaceGeometry.cpp
 )
 target_include_directories(workspace_canvas_widget_test PRIVATE src)
-target_link_libraries(workspace_canvas_widget_test PRIVATE Qt6::Widgets)
+target_link_libraries(workspace_canvas_widget_test PRIVATE Qt6::Widgets Qt6::Test)
 add_test(NAME workspace_canvas_widget_test COMMAND workspace_canvas_widget_test)
 set_tests_properties(workspace_canvas_widget_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1002,8 +1002,12 @@ set(GUI_SOURCES
     src/gui/containers/ContainerWidget.cpp
     src/gui/containers/FloatingContainerWindow.cpp
     src/gui/workspace/CanvasLayout.cpp
+    src/gui/workspace/ClassicLayout.cpp
     src/gui/workspace/WorkspaceCanvas.cpp
+    src/gui/workspace/WorkspaceDocument.cpp
     src/gui/workspace/WorkspaceGeometry.cpp
+    src/gui/workspace/WorkspaceMigration.cpp
+    src/gui/workspace/WorkspaceStore.cpp
     src/gui/ClientCompApplet.cpp
     src/gui/ClientCompCurveWidget.cpp
     src/gui/ClientCompKnob.cpp
@@ -3491,6 +3495,51 @@ target_link_libraries(workspace_canvas_widget_test PRIVATE Qt6::Widgets)
 add_test(NAME workspace_canvas_widget_test COMMAND workspace_canvas_widget_test)
 set_tests_properties(workspace_canvas_widget_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
+# Workspace canvas (RFC #4887) phase 2 — the document schema.  Pure logic: the
+# newer-schema guard that refuses to re-write what a later build wrote, and the
+# boundary validation that repairs what it can and reports every repair.
+add_executable(workspace_document_test
+    tests/workspace_document_test.cpp
+    src/gui/workspace/WorkspaceDocument.cpp
+    src/gui/workspace/WorkspaceGeometry.cpp
+)
+target_include_directories(workspace_document_test PRIVATE src)
+target_link_libraries(workspace_document_test PRIVATE Qt6::Core)
+add_test(NAME workspace_document_test COMMAND workspace_document_test)
+
+# Workspace canvas (RFC #4887) phase 2 — Classic geometry and the one-way
+# migration off the legacy layout keys, against a real AppSettings in a
+# temporary home.  Pins that every pan layout id tiles the surface exactly, and
+# that migration leaves floating pans and applets alone (RFC decision 1).
+add_executable(workspace_migration_test
+    tests/workspace_migration_test.cpp
+    src/gui/workspace/ClassicLayout.cpp
+    src/gui/workspace/WorkspaceDocument.cpp
+    src/gui/workspace/WorkspaceGeometry.cpp
+    src/gui/workspace/WorkspaceMigration.cpp
+)
+target_include_directories(workspace_migration_test PRIVATE src tests)
+target_link_libraries(workspace_migration_test PRIVATE aethercore Qt6::Core Qt6::Test)
+set_target_properties(workspace_migration_test PROPERTIES AUTOMOC ON)
+add_test(NAME workspace_migration_test COMMAND workspace_migration_test)
+
+# Workspace canvas (RFC #4887) phase 2 — persistence and the auto-commit
+# contract (decision 7): gestures coalesce into one whole-document write, the
+# write is verified against the FILE rather than the settings cache, and a
+# restore replay never writes back what it is reading (#4427).
+add_executable(workspace_store_test
+    tests/workspace_store_test.cpp
+    src/gui/workspace/ClassicLayout.cpp
+    src/gui/workspace/WorkspaceDocument.cpp
+    src/gui/workspace/WorkspaceGeometry.cpp
+    src/gui/workspace/WorkspaceMigration.cpp
+    src/gui/workspace/WorkspaceStore.cpp
+)
+target_include_directories(workspace_store_test PRIVATE src tests)
+target_link_libraries(workspace_store_test PRIVATE aethercore Qt6::Core Qt6::Test)
+set_target_properties(workspace_store_test PROPERTIES AUTOMOC ON)
+add_test(NAME workspace_store_test COMMAND workspace_store_test)
 
 # KiwiSDR band-recall re-bind policy (#4158) — header-only, pure logic.
 add_executable(kiwi_rebind_tracker_test tests/kiwi_rebind_tracker_test.cpp)

--- a/src/gui/workspace/CanvasItem.h
+++ b/src/gui/workspace/CanvasItem.h
@@ -1,0 +1,50 @@
+#pragma once
+
+// One placed thing on a workspace canvas (RFC #4887, phase 1).
+//
+// Pure data, deliberately: the canvas model has to be reasoned about and
+// tested without a QWidget in sight, and the same struct is what phase 2
+// serialises into the workspace document.  There is no .cpp — this carries no
+// behaviour beyond its members, matching the other pure-logic headers in
+// src/gui (SpectrumPreviewLogic.h, CenterLockRebindTracker.h).
+
+#include "gui/workspace/WorkspaceGeometry.h"
+
+#include <QSize>
+#include <QString>
+
+namespace AetherSDR {
+
+struct CanvasItem {
+    // Stable identity, unique within one CanvasLayout.  The canvas never
+    // invents these: they come from whatever is being placed, so a pan is
+    // "pan:0x40000000" and an applet is "applet:RX" (phase 3+).
+    QString id;
+
+    // ContainerManager content-factory key, carried so phase 2 can rehydrate
+    // this item's widget on restore.  Phase 1 stores it and does nothing with
+    // it — the factory lookup arrives with the applets.
+    QString contentType;
+
+    // Placement, as a fraction of the canvas.  Always kept inside the surface
+    // by CanvasLayout; see clampToCanvas().
+    NormRect rect;
+
+    // Stacking order.  CanvasLayout keeps these dense and contiguous over
+    // [0, count-1], so "z + 1" is always the item directly above.
+    int z = 0;
+
+    // Smallest the item may be drawn, in pixels.  Enforced on every geometry
+    // change so a panadapter cannot be squeezed to unreadability, and so an
+    // item can never round down to a zero-size widget that still answers hit
+    // tests.  The default is a floor, not a design opinion; real content
+    // overrides it.
+    QSize minimumSize{160, 90};
+
+    // Collapsed to its title bar.  Phase 1 records the flag and leaves the
+    // rect alone; the collapse animation and the height override belong with
+    // the container work in phase 3.
+    bool collapsed = false;
+};
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/CanvasLayout.cpp
+++ b/src/gui/workspace/CanvasLayout.cpp
@@ -180,17 +180,16 @@ bool CanvasLayout::raise(const QString& id)
     }
 
     // Dense z means the neighbour above is exactly z + 1; swapping with it is
-    // the whole operation.  Already-topmost is a no-op, not a failure — the
-    // caller asked for a state that already holds.
+    // the whole operation.
     const int target = it->z + 1;
     for (CanvasItem& other : m_items) {
         if (other.z == target) {
             other.z = it->z;
             it->z   = target;
-            break;
+            return true;
         }
     }
-    return true;
+    return false;   // already topmost — nothing changed
 }
 
 bool CanvasLayout::lower(const QString& id)
@@ -205,10 +204,10 @@ bool CanvasLayout::lower(const QString& id)
         if (other.z == target) {
             other.z = it->z;
             it->z   = target;
-            break;
+            return true;
         }
     }
-    return true;
+    return false;   // already backmost — nothing changed
 }
 
 bool CanvasLayout::bringToFront(const QString& id)
@@ -216,6 +215,9 @@ bool CanvasLayout::bringToFront(const QString& id)
     CanvasItem* it = find(id);
     if (!it) {
         return false;
+    }
+    if (it->z == m_items.size() - 1) {
+        return false;   // already frontmost — nothing changed
     }
 
     // Park it above everything, then re-densify.  Doing it this way rather
@@ -231,6 +233,9 @@ bool CanvasLayout::sendToBack(const QString& id)
     CanvasItem* it = find(id);
     if (!it) {
         return false;
+    }
+    if (it->z == 0) {
+        return false;   // already backmost — nothing changed
     }
 
     it->z = -1;

--- a/src/gui/workspace/CanvasLayout.cpp
+++ b/src/gui/workspace/CanvasLayout.cpp
@@ -1,0 +1,220 @@
+#include "gui/workspace/CanvasLayout.h"
+
+#include <algorithm>
+
+namespace AetherSDR {
+
+CanvasItem* CanvasLayout::find(const QString& id)
+{
+    for (CanvasItem& it : m_items) {
+        if (it.id == id) {
+            return &it;
+        }
+    }
+    return nullptr;
+}
+
+const CanvasItem* CanvasLayout::find(const QString& id) const
+{
+    for (const CanvasItem& it : m_items) {
+        if (it.id == id) {
+            return &it;
+        }
+    }
+    return nullptr;
+}
+
+void CanvasLayout::normalizeZ()
+{
+    // Sort a view of the items by (z, insertion index) and hand out 0..n-1.
+    // The insertion-index tie-break is what makes this deterministic when two
+    // items arrive holding the same z — otherwise the result would depend on
+    // std::sort's unspecified handling of equal keys.
+    QList<int> order;
+    order.reserve(m_items.size());
+    for (int i = 0; i < m_items.size(); ++i) {
+        order.append(i);
+    }
+
+    std::stable_sort(order.begin(), order.end(), [this](int a, int b) {
+        return m_items[a].z < m_items[b].z;
+    });
+
+    for (int rank = 0; rank < order.size(); ++rank) {
+        m_items[order[rank]].z = rank;
+    }
+}
+
+bool CanvasLayout::addItem(CanvasItem item, const QSize& canvas)
+{
+    if (item.id.isEmpty() || contains(item.id)) {
+        return false;
+    }
+
+    // A new item lands on top and inside.  Assigning z here rather than
+    // trusting the caller keeps the dense-contiguous invariant true from the
+    // first insert.
+    item.z    = static_cast<int>(m_items.size());
+    item.rect = clampToCanvas(item.rect, item.minimumSize, canvas);
+
+    m_items.append(item);
+    return true;
+}
+
+bool CanvasLayout::removeItem(const QString& id)
+{
+    for (int i = 0; i < m_items.size(); ++i) {
+        if (m_items[i].id == id) {
+            m_items.removeAt(i);
+            normalizeZ();   // close the hole the removal left in z
+            return true;
+        }
+    }
+    return false;
+}
+
+void CanvasLayout::clear()
+{
+    m_items.clear();
+}
+
+bool CanvasLayout::contains(const QString& id) const
+{
+    return find(id) != nullptr;
+}
+
+const CanvasItem* CanvasLayout::item(const QString& id) const
+{
+    return find(id);
+}
+
+QStringList CanvasLayout::ids() const
+{
+    QStringList out;
+    out.reserve(m_items.size());
+    for (const CanvasItem& it : m_items) {
+        out.append(it.id);
+    }
+    return out;
+}
+
+QList<CanvasItem> CanvasLayout::itemsByZ() const
+{
+    QList<CanvasItem> out = m_items;
+    std::stable_sort(out.begin(), out.end(),
+                     [](const CanvasItem& a, const CanvasItem& b) {
+                         return a.z < b.z;
+                     });
+    return out;
+}
+
+bool CanvasLayout::setRect(const QString& id, const NormRect& rect, const QSize& canvas)
+{
+    CanvasItem* it = find(id);
+    if (!it) {
+        return false;
+    }
+    it->rect = clampToCanvas(rect, it->minimumSize, canvas);
+    return true;
+}
+
+QStringList CanvasLayout::reclampAll(const QSize& canvas)
+{
+    QStringList moved;
+    for (CanvasItem& it : m_items) {
+        const NormRect before = it.rect;
+        it.rect = clampToCanvas(it.rect, it.minimumSize, canvas);
+        if (!(it.rect == before)) {
+            moved.append(it.id);
+        }
+    }
+    return moved;
+}
+
+QString CanvasLayout::hitTest(const QPointF& normPoint) const
+{
+    const CanvasItem* best = nullptr;
+    for (const CanvasItem& it : m_items) {
+        if (!it.rect.contains(normPoint.x(), normPoint.y())) {
+            continue;
+        }
+        if (!best || it.z > best->z) {
+            best = &it;
+        }
+    }
+    return best ? best->id : QString();
+}
+
+int CanvasLayout::zOf(const QString& id) const
+{
+    const CanvasItem* it = find(id);
+    return it ? it->z : -1;
+}
+
+bool CanvasLayout::raise(const QString& id)
+{
+    CanvasItem* it = find(id);
+    if (!it) {
+        return false;
+    }
+
+    // Dense z means the neighbour above is exactly z + 1; swapping with it is
+    // the whole operation.  Already-topmost is a no-op, not a failure — the
+    // caller asked for a state that already holds.
+    const int target = it->z + 1;
+    for (CanvasItem& other : m_items) {
+        if (other.z == target) {
+            other.z = it->z;
+            it->z   = target;
+            break;
+        }
+    }
+    return true;
+}
+
+bool CanvasLayout::lower(const QString& id)
+{
+    CanvasItem* it = find(id);
+    if (!it) {
+        return false;
+    }
+
+    const int target = it->z - 1;
+    for (CanvasItem& other : m_items) {
+        if (other.z == target) {
+            other.z = it->z;
+            it->z   = target;
+            break;
+        }
+    }
+    return true;
+}
+
+bool CanvasLayout::bringToFront(const QString& id)
+{
+    CanvasItem* it = find(id);
+    if (!it) {
+        return false;
+    }
+
+    // Park it above everything, then re-densify.  Doing it this way rather
+    // than shuffling each item down keeps the relative order of everything
+    // else exactly as it was.
+    it->z = m_items.size();
+    normalizeZ();
+    return true;
+}
+
+bool CanvasLayout::sendToBack(const QString& id)
+{
+    CanvasItem* it = find(id);
+    if (!it) {
+        return false;
+    }
+
+    it->z = -1;
+    normalizeZ();
+    return true;
+}
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/CanvasLayout.cpp
+++ b/src/gui/workspace/CanvasLayout.cpp
@@ -53,12 +53,33 @@ bool CanvasLayout::addItem(CanvasItem item, const QSize& canvas)
 
     // A new item lands on top and inside.  Assigning z here rather than
     // trusting the caller keeps the dense-contiguous invariant true from the
-    // first insert.
+    // first insert, with no normalize pass needed.
     item.z    = static_cast<int>(m_items.size());
     item.rect = clampToCanvas(item.rect, item.minimumSize, canvas);
 
     m_items.append(item);
     return true;
+}
+
+int CanvasLayout::restoreItems(const QList<CanvasItem>& items, const QSize& canvas)
+{
+    // Sort by stored z FIRST, then insert bottom-to-top, so each insert's
+    // assigned rank matches the saved order.  Doing it the other way — insert
+    // then normalise — loses the ordering, because normalising collapses the
+    // stored z values that the next insert would have been compared against.
+    QList<CanvasItem> ordered = items;
+    std::stable_sort(ordered.begin(), ordered.end(),
+                     [](const CanvasItem& a, const CanvasItem& b) {
+                         return a.z < b.z;
+                     });
+
+    int inserted = 0;
+    for (CanvasItem& item : ordered) {
+        if (addItem(item, canvas)) {
+            ++inserted;
+        }
+    }
+    return inserted;
 }
 
 bool CanvasLayout::removeItem(const QString& id)

--- a/src/gui/workspace/CanvasLayout.h
+++ b/src/gui/workspace/CanvasLayout.h
@@ -97,6 +97,13 @@ public:
     // these.  Sparse or duplicated z is the bug that makes "raise" stop doing
     // anything after enough operations, so the invariant is restored eagerly
     // rather than checked for.
+    //
+    // Each returns TRUE ONLY IF THE STACKING ACTUALLY CHANGED — false for an
+    // unknown id, and false for an item already at that end.  Callers turn
+    // these into change notifications, and under auto-commit a notification
+    // is a whole-document write: raising an already-frontmost item on every
+    // mouse press would write the document on every click (PR #4900 review,
+    // M2).  Use contains() if you need to tell "no such item" from "no-op".
     bool raise(const QString& id);          // one step toward the front
     bool lower(const QString& id);          // one step toward the back
     bool bringToFront(const QString& id);

--- a/src/gui/workspace/CanvasLayout.h
+++ b/src/gui/workspace/CanvasLayout.h
@@ -32,7 +32,30 @@ public:
     // make every later lookup ambiguous rather than merely wrong.  The item's
     // z is assigned on insert (topmost) and its rect clamped, so a caller
     // cannot introduce an off-canvas or buried item by construction.
+    //
+    // For a NEW item this is what you want — it belongs where the operator can
+    // see it.  To rehydrate a SAVED arrangement, use restoreItems(): the
+    // stored z is meaningful there and this call would discard it.
     bool addItem(CanvasItem item, const QSize& canvas);
+
+    // Rehydrate a whole saved surface at once.
+    //
+    // WorkspaceDocument persists z per item, and once an operator has raised
+    // anything, z no longer matches array order — so feeding stored items to
+    // addItem() would silently restore the arrangement with its stacking
+    // scrambled (PR #4900 review).  This sorts by stored z, inserts
+    // bottom-to-top, and densifies once at the end.
+    //
+    // It takes the whole set rather than offering a per-item "preserve z"
+    // flag because densifying after each insert would flatten the very
+    // ordering it was given: two items whose stored z differ by 2 both
+    // normalise to adjacent ranks, and the next insert can no longer tell
+    // which was on top.  The batch is the only shape that cannot get that
+    // wrong.
+    //
+    // Items with an empty or duplicate id are skipped.  Returns how many
+    // were inserted.
+    int restoreItems(const QList<CanvasItem>& items, const QSize& canvas);
     bool removeItem(const QString& id);
     void clear();
 

--- a/src/gui/workspace/CanvasLayout.h
+++ b/src/gui/workspace/CanvasLayout.h
@@ -1,0 +1,95 @@
+#pragma once
+
+// The set of items on one canvas surface, and the rules that keep it coherent
+// (RFC #4887, phase 1).
+//
+// Widget-free by design.  Everything a canvas does that can be got wrong —
+// clamping placement, deciding what is under the cursor, keeping stacking
+// order sane — lives here so it is testable headless, leaving WorkspaceCanvas
+// as a thin widget that only applies the answers.  See
+// tests/workspace_layout_test.cpp.
+//
+// Item counts are in the tens (26 applets + up to 8 pans), so lookup is a
+// linear scan over a QList.  A hash keyed by id would win nothing measurable
+// and would cost the stable insertion order that makes the tests readable.
+
+#include "gui/workspace/CanvasItem.h"
+
+#include <QList>
+#include <QPointF>
+#include <QSize>
+#include <QString>
+#include <QStringList>
+
+namespace AetherSDR {
+
+class CanvasLayout {
+public:
+    // ── Membership ───────────────────────────────────────────────────────
+    //
+    // Rejects an empty or duplicate id: identity is what every other call
+    // here takes as an argument, so letting a second "applet:RX" in would
+    // make every later lookup ambiguous rather than merely wrong.  The item's
+    // z is assigned on insert (topmost) and its rect clamped, so a caller
+    // cannot introduce an off-canvas or buried item by construction.
+    bool addItem(CanvasItem item, const QSize& canvas);
+    bool removeItem(const QString& id);
+    void clear();
+
+    bool contains(const QString& id) const;
+    const CanvasItem* item(const QString& id) const;
+    int count() const { return static_cast<int>(m_items.size()); }
+    bool isEmpty() const { return m_items.isEmpty(); }
+
+    // Insertion order — stable, and independent of stacking.
+    QStringList ids() const;
+
+    // Bottom-to-top.  This is the order to apply stacking in, and the reverse
+    // of the order to hit-test in.
+    QList<CanvasItem> itemsByZ() const;
+
+    // ── Placement ────────────────────────────────────────────────────────
+    //
+    // The rect is clamped against the canvas before it is stored, so the
+    // layout never holds a placement the operator cannot see.  Returns false
+    // for an unknown id only — a clamped-away rect is still a successful set.
+    bool setRect(const QString& id, const NormRect& rect, const QSize& canvas);
+
+    // Re-clamp every item, for when the canvas itself changed size.  Returns
+    // the ids whose rects actually moved, so a caller can persist just those
+    // (phase 2) rather than rewriting the whole document on every resize.
+    QStringList reclampAll(const QSize& canvas);
+
+    // ── Hit testing ──────────────────────────────────────────────────────
+    //
+    // Topmost item containing the point, in canvas fractions; empty when the
+    // point is over bare canvas.  Overlap is legal (items layer), so "topmost"
+    // is the whole answer: the highest z wins, which is what the operator sees
+    // and therefore what they expect to click.
+    QString hitTest(const QPointF& normPoint) const;
+
+    // ── Stacking ─────────────────────────────────────────────────────────
+    //
+    // z values stay dense and contiguous over [0, count-1] after every one of
+    // these.  Sparse or duplicated z is the bug that makes "raise" stop doing
+    // anything after enough operations, so the invariant is restored eagerly
+    // rather than checked for.
+    bool raise(const QString& id);          // one step toward the front
+    bool lower(const QString& id);          // one step toward the back
+    bool bringToFront(const QString& id);
+    bool sendToBack(const QString& id);
+
+    int zOf(const QString& id) const;       // -1 when absent
+
+private:
+    CanvasItem* find(const QString& id);
+    const CanvasItem* find(const QString& id) const;
+
+    // Reassign z over [0, count-1] preserving current relative order, with
+    // insertion order as the tie-break so the result is deterministic.
+    void normalizeZ();
+
+    QList<CanvasItem> m_items;   // insertion order
+};
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/ClassicLayout.cpp
+++ b/src/gui/workspace/ClassicLayout.cpp
@@ -1,0 +1,149 @@
+#include "gui/workspace/ClassicLayout.h"
+
+#include <QVector>
+
+namespace AetherSDR {
+
+namespace {
+
+// The pan layout table, mirroring kAllLayouts in PanLayoutDialog.cpp: each
+// entry is rows of equal-width cells, rows of equal height.  Kept as data
+// rather than as the dialog's widget code so the geometry is testable without
+// a GUI — and so a thirteenth layout id is one line here, not a new branch.
+//
+// If PanLayoutDialog's table changes, this one has to change with it; the
+// migration test asserts the id set matches what PanadapterStack accepts.
+struct LayoutRows {
+    const char* id;
+    QVector<int> rows;   // cells per row, top to bottom
+};
+
+const QVector<LayoutRows>& layoutTable()
+{
+    static const QVector<LayoutRows> kTable = {
+        {"2v",  {1, 1}},
+        {"2h",  {2}},
+        {"2h1", {2, 1}},
+        {"12h", {1, 2}},
+        {"3v",  {1, 1, 1}},
+        {"2x2", {2, 2}},
+        {"4v",  {1, 1, 1, 1}},
+        {"3h2", {3, 2}},
+        {"2x3", {2, 2, 2}},
+        {"4h3", {4, 3}},
+        {"2x4", {2, 2, 2, 2}},
+        {"1",   {1}},
+    };
+    return kTable;
+}
+
+const LayoutRows* findLayout(const QString& layoutId)
+{
+    for (const LayoutRows& entry : layoutTable()) {
+        if (layoutId == QLatin1String(entry.id)) {
+            return &entry;
+        }
+    }
+    return nullptr;
+}
+
+}  // namespace
+
+QList<NormRect> panCellsForLayout(const QString& layoutId)
+{
+    const LayoutRows* entry = findLayout(layoutId);
+    if (!entry) {
+        return {};
+    }
+
+    QList<NormRect> cells;
+    const int rowCount = entry->rows.size();
+    const double rowHeight = 1.0 / rowCount;
+
+    for (int row = 0; row < rowCount; ++row) {
+        const int cellCount = entry->rows.at(row);
+        const double cellWidth = 1.0 / cellCount;
+        for (int col = 0; col < cellCount; ++col) {
+            NormRect r;
+            r.x = col * cellWidth;
+            r.y = row * rowHeight;
+            r.w = cellWidth;
+            r.h = rowHeight;
+            cells.append(r);
+        }
+    }
+    return cells;
+}
+
+QStringList knownPanLayoutIds()
+{
+    QStringList ids;
+    for (const LayoutRows& entry : layoutTable()) {
+        ids.append(QString::fromLatin1(entry.id));
+    }
+    return ids;
+}
+
+int panCountForLayout(const QString& layoutId)
+{
+    return static_cast<int>(panCellsForLayout(layoutId).size());
+}
+
+QList<CanvasItem> composeClassic(const QStringList& panIds,
+                                 const QStringList& appletIds,
+                                 const QString& layoutId,
+                                 bool appletsLeft)
+{
+    QList<CanvasItem> items;
+
+    // The column takes its width only if there is something to put in it —
+    // an empty applet column would leave a band of dead canvas that the
+    // operator never asked for.
+    const bool haveApplets = !appletIds.isEmpty();
+    const double columnWidth = haveApplets ? kClassicAppletColumnWidth : 0.0;
+    const double panWidth = 1.0 - columnWidth;
+    const double panOriginX = appletsLeft ? columnWidth : 0.0;
+    const double columnOriginX = appletsLeft ? 0.0 : panWidth;
+
+    // ── Pans, in their layout's cells, scaled into the pan region ────────
+    QList<NormRect> cells = panCellsForLayout(layoutId);
+    if (cells.isEmpty()) {
+        cells = panCellsForLayout(QStringLiteral("1"));
+    }
+
+    const int placeable = qMin(static_cast<int>(panIds.size()),
+                               static_cast<int>(cells.size()));
+    for (int i = 0; i < placeable; ++i) {
+        const NormRect& cell = cells.at(i);
+
+        CanvasItem item;
+        item.id          = QStringLiteral("pan:") + panIds.at(i);
+        item.contentType = QStringLiteral("panadapter");
+        item.z           = static_cast<int>(items.size());
+        item.rect.x = panOriginX + cell.x * panWidth;
+        item.rect.y = cell.y;
+        item.rect.w = cell.w * panWidth;
+        item.rect.h = cell.h;
+        items.append(item);
+    }
+
+    // ── Applets, stacked down the column ─────────────────────────────────
+    if (haveApplets) {
+        const double slotHeight = 1.0 / appletIds.size();
+        for (int i = 0; i < appletIds.size(); ++i) {
+            CanvasItem item;
+            item.id          = QStringLiteral("applet:") + appletIds.at(i);
+            item.contentType = QStringLiteral("applet");
+            item.z           = static_cast<int>(items.size());
+            item.rect.x = columnOriginX;
+            item.rect.y = i * slotHeight;
+            item.rect.w = columnWidth;
+            item.rect.h = slotHeight;
+            items.append(item);
+        }
+    }
+
+    return items;
+}
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/ClassicLayout.cpp
+++ b/src/gui/workspace/ClassicLayout.cpp
@@ -18,6 +18,13 @@ namespace {
 // expected id/cell-count pairs, so a change HERE fails immediately; a change
 // to either of the other two still has to be mirrored by hand.  Phase 3 puts
 // this in reach of a GUI-linked test and should close the gap properly.
+//
+// AND NOTE THE SHAPE IS NOT IDENTICAL.  kAllLayouts stores per-cell WEIGHTS
+// (`{{1,1},{1}}`); this stores per-row CELL COUNTS.  Today every weight is 1,
+// so the two agree exactly — but a future non-uniform layout, say a 2:1 split
+// written `{{2,1}}`, is not representable here at all and would silently come
+// out as equal halves rather than failing.  Adding one means changing this
+// vector to carry weights, not just adding a row (PR #4900 review, L1).
 struct LayoutRows {
     const char* id;
     QVector<int> rows;   // cells per row, top to bottom
@@ -133,6 +140,14 @@ QList<CanvasItem> composeClassic(const QStringList& panIds,
     }
 
     // ── Applets, stacked down the column ─────────────────────────────────
+    //
+    // Each applet gets 1/n of the column.  Past roughly a dozen open applets
+    // on a 1080 px canvas that falls under CanvasItem's 90 px floor and the
+    // clamp makes them overlap, where the real panel scrolls instead.  Nothing
+    // consumes this yet, so it is not reachable in phase 2 — but it is a real
+    // gap against "an operator who never opens the editor sees exactly what
+    // they see today", and phase 3 owes it either a scrolling column or a
+    // sensible overflow (PR #4900 review, L3).
     if (haveApplets) {
         const double slotHeight = 1.0 / appletIds.size();
         for (int i = 0; i < appletIds.size(); ++i) {

--- a/src/gui/workspace/ClassicLayout.cpp
+++ b/src/gui/workspace/ClassicLayout.cpp
@@ -11,8 +11,13 @@ namespace {
 // rather than as the dialog's widget code so the geometry is testable without
 // a GUI — and so a thirteenth layout id is one line here, not a new branch.
 //
-// If PanLayoutDialog's table changes, this one has to change with it; the
-// migration test asserts the id set matches what PanadapterStack accepts.
+// DRIFT WARNING: this is a third copy of the same knowledge.  The other two —
+// PanLayoutDialog::kAllLayouts and PanadapterStack's kLayoutPanCounts — live
+// in the GUI target, which the headless migration test does not link, so
+// nothing compares them automatically.  What the test does do is duplicate the
+// expected id/cell-count pairs, so a change HERE fails immediately; a change
+// to either of the other two still has to be mirrored by hand.  Phase 3 puts
+// this in reach of a GUI-linked test and should close the gap properly.
 struct LayoutRows {
     const char* id;
     QVector<int> rows;   // cells per row, top to bottom

--- a/src/gui/workspace/ClassicLayout.h
+++ b/src/gui/workspace/ClassicLayout.h
@@ -1,0 +1,66 @@
+#pragma once
+
+// "Classic" — today's two-region shell, expressed as canvas placement
+// (RFC #4887, phase 2).
+//
+// The default workspace has to reproduce the application as it ships now: a
+// panadapter region subdivided by one of the twelve hard-coded layout ids,
+// and the applet column beside it.  An operator who never opens the workspace
+// editor must see exactly what they see today, so this is the preset that
+// migration produces and the one phase 6 offers as "reset to Classic".
+//
+// Pure: layout id in, normalized rects out.  No settings, no widgets, no
+// radio — so every id's geometry is pinned headless, which matters because
+// there are twelve of them and nobody is going to eyeball all twelve.
+
+#include "gui/workspace/CanvasItem.h"
+#include "gui/workspace/WorkspaceGeometry.h"
+
+#include <QList>
+#include <QString>
+#include <QStringList>
+
+namespace AetherSDR {
+
+// Fraction of the canvas width taken by the applet column in Classic.
+//
+// The real panel is a fixed-width widget (~260 px), not a fraction, so no
+// single number is right at every window size; this approximates it at a
+// typical 1440-1600 px window and is a starting point the operator can drag.
+// Phase 3 can refine it from the panel's real width hint once the canvas
+// actually hosts the panel.
+inline constexpr double kClassicAppletColumnWidth = 0.18;
+
+// The panadapter cells for a layout id, in the order the stack assigns pans
+// (A, B, C, ...), covering the whole unit square.
+//
+// Mirrors the kAllLayouts table in PanLayoutDialog.cpp — rows of equal-width
+// cells, rows of equal height.  Returns an empty list for an unknown id
+// rather than guessing: a caller that cannot place pans should fall back to
+// single-pan, not invent a grid.
+QList<NormRect> panCellsForLayout(const QString& layoutId);
+
+// Every layout id this build understands, in the table's own order.
+QStringList knownPanLayoutIds();
+
+// How many pans a layout id describes (0 for an unknown id).
+int panCountForLayout(const QString& layoutId);
+
+// Compose the Classic arrangement.
+//
+//   panIds      pans to place, in stack order; extras beyond the layout's
+//               cell count are dropped (the layout is what the operator
+//               chose, and inventing a thirteenth cell is worse than
+//               honouring it).
+//   appletIds   open applets, top to bottom, sharing the column.
+//   layoutId    pan layout id; an unknown or empty id falls back to "1".
+//   appletsLeft the column on the left instead of the right.
+//
+// Item ids are namespaced by kind ("pan:" / "applet:") so a pan and an applet
+// can never collide in one CanvasLayout.
+QList<CanvasItem> composeClassic(const QStringList& panIds,
+                                 const QStringList& appletIds,
+                                 const QString& layoutId,
+                                 bool appletsLeft);
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/WorkspaceCanvas.cpp
+++ b/src/gui/workspace/WorkspaceCanvas.cpp
@@ -15,6 +15,24 @@ WorkspaceCanvas::WorkspaceCanvas(QWidget* parent)
     setMouseTracking(true);
 }
 
+WorkspaceCanvas::~WorkspaceCanvas()
+{
+    // Destruction order is the trap here.  C++ destroys this class's members
+    // (m_layout, m_widgets) before the ~QWidget base runs, and ~QWidget is
+    // what deletes the child widgets — each of which emits destroyed().  A
+    // still-connected watch would therefore run its lambda against a
+    // CanvasLayout that no longer exists.  Qt's usual context-object
+    // protection does not save us: it disconnects in ~QObject, which is
+    // further down the chain than ~QWidget.
+    //
+    // So sever them here, while everything is still alive.
+    for (const auto& widget : m_widgets) {
+        if (QWidget* w = widget.data()) {
+            disconnect(w, &QObject::destroyed, this, nullptr);
+        }
+    }
+}
+
 bool WorkspaceCanvas::addItem(const QString& id,
                               QWidget* content,
                               const NormRect& rect,
@@ -38,6 +56,23 @@ bool WorkspaceCanvas::addItem(const QString& id,
     content->setParent(this);
     content->installEventFilter(this);
     m_widgets.insert(id, content);
+
+    // If the widget dies without going through takeItem()/removeItem() — a
+    // parent destroyed out from under us, or content someone else owns — the
+    // QPointer nulls but the model entry would survive as a ghost: contains()
+    // and itemCount() would still report it, hitTest() would still return its
+    // id over dead space, and addItem() with that id would fail forever.
+    // Phase 3 moves applets between canvases and containers, which is exactly
+    // where that happens (PR #4900 review).
+    connect(content, &QObject::destroyed, this, [this, id] {
+        if (!m_layout.contains(id)) {
+            return;
+        }
+        m_widgets.remove(id);
+        m_layout.removeItem(id);
+        applyStacking();
+        emit itemRemoved(id);
+    });
 
     applyGeometryFor(id);
     content->show();
@@ -69,6 +104,10 @@ QWidget* WorkspaceCanvas::takeItem(const QString& id)
 
     if (w) {
         w->removeEventFilter(this);
+        // Drop the destroyed-watch with the widget, or a later destruction
+        // would fire a lambda still holding this id — and if something else
+        // has since taken the id, it would evict the wrong item.
+        disconnect(w, &QObject::destroyed, this, nullptr);
         w->hide();
         w->setParent(nullptr);
     }

--- a/src/gui/workspace/WorkspaceCanvas.cpp
+++ b/src/gui/workspace/WorkspaceCanvas.cpp
@@ -4,6 +4,8 @@
 #include <QMouseEvent>
 #include <QResizeEvent>
 
+#include <algorithm>
+
 namespace AetherSDR {
 
 WorkspaceCanvas::WorkspaceCanvas(QWidget* parent)
@@ -81,6 +83,32 @@ bool WorkspaceCanvas::addItem(const QString& id,
     emit itemAdded(id);
     emit itemRectChanged(id, itemRect(id));
     return true;
+}
+
+int WorkspaceCanvas::restoreItems(const QList<CanvasItem>& items,
+                                  const QHash<QString, QWidget*>& widgets)
+{
+    // Sort by stored z and place bottom-to-top, which is what makes the saved
+    // stacking survive — see CanvasLayout::restoreItems() for why the batch
+    // shape is the only one that cannot get this wrong.
+    QList<CanvasItem> ordered = items;
+    std::stable_sort(ordered.begin(), ordered.end(),
+                     [](const CanvasItem& a, const CanvasItem& b) {
+                         return a.z < b.z;
+                     });
+
+    int placed = 0;
+    for (const CanvasItem& item : ordered) {
+        QWidget* content = widgets.value(item.id);
+        if (!content) {
+            continue;   // nothing to show for this id; skip rather than guess
+        }
+        if (addItem(item.id, content, item.rect, item.contentType,
+                    item.minimumSize)) {
+            ++placed;
+        }
+    }
+    return placed;
 }
 
 bool WorkspaceCanvas::removeItem(const QString& id)
@@ -204,18 +232,16 @@ void WorkspaceCanvas::resizeEvent(QResizeEvent* ev)
     }
 }
 
-void WorkspaceCanvas::mousePressEvent(QMouseEvent* ev)
-{
-    // Only reached for presses on bare canvas: anything over an item goes to
-    // that item's widget, and comes back through eventFilter().
-    QWidget::mousePressEvent(ev);
-}
-
 bool WorkspaceCanvas::eventFilter(QObject* watched, QEvent* ev)
 {
     if (ev->type() == QEvent::MouseButtonPress) {
         for (auto it = m_widgets.constBegin(); it != m_widgets.constEnd(); ++it) {
             if (it.value().data() == watched) {
+                // bringItemToFront() is false when the item was already
+                // frontmost, and then nothing is emitted.  Without that, every
+                // click anywhere on the canvas would look like an edit and
+                // cost a whole-document write after the debounce — the same
+                // rule resizeEvent() follows (PR #4900 review, M2).
                 bringItemToFront(it.key());
                 break;
             }

--- a/src/gui/workspace/WorkspaceCanvas.cpp
+++ b/src/gui/workspace/WorkspaceCanvas.cpp
@@ -1,0 +1,217 @@
+#include "gui/workspace/WorkspaceCanvas.h"
+
+#include <QEvent>
+#include <QMouseEvent>
+#include <QResizeEvent>
+
+namespace AetherSDR {
+
+WorkspaceCanvas::WorkspaceCanvas(QWidget* parent)
+    : QWidget(parent)
+{
+    // Children are positioned absolutely from the model, so the canvas must
+    // have no layout manager: one would fight applyGeometry() on every
+    // resize and win.
+    setMouseTracking(true);
+}
+
+bool WorkspaceCanvas::addItem(const QString& id,
+                              QWidget* content,
+                              const NormRect& rect,
+                              const QString& contentType,
+                              const QSize& minimumSize)
+{
+    if (!content || id.isEmpty() || m_layout.contains(id)) {
+        return false;
+    }
+
+    CanvasItem item;
+    item.id          = id;
+    item.contentType = contentType;
+    item.rect        = rect;
+    item.minimumSize = minimumSize;
+
+    if (!m_layout.addItem(item, size())) {
+        return false;
+    }
+
+    content->setParent(this);
+    content->installEventFilter(this);
+    m_widgets.insert(id, content);
+
+    applyGeometryFor(id);
+    content->show();
+    applyStacking();
+
+    emit itemAdded(id);
+    emit itemRectChanged(id, itemRect(id));
+    return true;
+}
+
+bool WorkspaceCanvas::removeItem(const QString& id)
+{
+    QWidget* w = takeItem(id);
+    if (!w) {
+        return false;
+    }
+    w->deleteLater();
+    return true;
+}
+
+QWidget* WorkspaceCanvas::takeItem(const QString& id)
+{
+    if (!m_layout.contains(id)) {
+        return nullptr;
+    }
+
+    QWidget* w = m_widgets.take(id).data();
+    m_layout.removeItem(id);
+
+    if (w) {
+        w->removeEventFilter(this);
+        w->hide();
+        w->setParent(nullptr);
+    }
+
+    // Removal renumbers z, so the surviving items' stacking has to be redone.
+    applyStacking();
+    emit itemRemoved(id);
+    return w;
+}
+
+QWidget* WorkspaceCanvas::itemWidget(const QString& id) const
+{
+    return m_widgets.value(id).data();
+}
+
+bool WorkspaceCanvas::setItemRect(const QString& id, const NormRect& rect)
+{
+    if (!m_layout.setRect(id, rect, size())) {
+        return false;
+    }
+    applyGeometryFor(id);
+    emit itemRectChanged(id, itemRect(id));
+    return true;
+}
+
+NormRect WorkspaceCanvas::itemRect(const QString& id) const
+{
+    const CanvasItem* it = m_layout.item(id);
+    return it ? it->rect : NormRect{};
+}
+
+QString WorkspaceCanvas::hitTest(const QPoint& pos) const
+{
+    if (width() <= 0 || height() <= 0) {
+        return {};
+    }
+    return m_layout.hitTest(QPointF(pos.x() / static_cast<double>(width()),
+                                    pos.y() / static_cast<double>(height())));
+}
+
+bool WorkspaceCanvas::raiseItem(const QString& id)
+{
+    if (!m_layout.raise(id)) {
+        return false;
+    }
+    applyStacking();
+    emit itemStackingChanged(id);
+    return true;
+}
+
+bool WorkspaceCanvas::lowerItem(const QString& id)
+{
+    if (!m_layout.lower(id)) {
+        return false;
+    }
+    applyStacking();
+    emit itemStackingChanged(id);
+    return true;
+}
+
+bool WorkspaceCanvas::bringItemToFront(const QString& id)
+{
+    if (!m_layout.bringToFront(id)) {
+        return false;
+    }
+    applyStacking();
+    emit itemStackingChanged(id);
+    return true;
+}
+
+bool WorkspaceCanvas::sendItemToBack(const QString& id)
+{
+    if (!m_layout.sendToBack(id)) {
+        return false;
+    }
+    applyStacking();
+    emit itemStackingChanged(id);
+    return true;
+}
+
+void WorkspaceCanvas::resizeEvent(QResizeEvent* ev)
+{
+    QWidget::resizeEvent(ev);
+
+    // A smaller canvas can push items out or below their minimum, so the
+    // model is re-clamped first and the pixels follow.  Only the items that
+    // actually moved are announced — a resize that changes nothing must not
+    // look like an edit (this is what keeps phase 2's auto-commit from
+    // writing the document on every frame of a window drag).
+    const QStringList moved = m_layout.reclampAll(size());
+    applyGeometry();
+    for (const QString& id : moved) {
+        emit itemRectChanged(id, itemRect(id));
+    }
+}
+
+void WorkspaceCanvas::mousePressEvent(QMouseEvent* ev)
+{
+    // Only reached for presses on bare canvas: anything over an item goes to
+    // that item's widget, and comes back through eventFilter().
+    QWidget::mousePressEvent(ev);
+}
+
+bool WorkspaceCanvas::eventFilter(QObject* watched, QEvent* ev)
+{
+    if (ev->type() == QEvent::MouseButtonPress) {
+        for (auto it = m_widgets.constBegin(); it != m_widgets.constEnd(); ++it) {
+            if (it.value().data() == watched) {
+                bringItemToFront(it.key());
+                break;
+            }
+        }
+    }
+    // Never consumed: raising is incidental to whatever the press was for.
+    return QWidget::eventFilter(watched, ev);
+}
+
+void WorkspaceCanvas::applyGeometryFor(const QString& id)
+{
+    QWidget* w = m_widgets.value(id).data();
+    const CanvasItem* it = m_layout.item(id);
+    if (!w || !it) {
+        return;
+    }
+    w->setGeometry(toPixels(it->rect, size()));
+}
+
+void WorkspaceCanvas::applyGeometry()
+{
+    for (const CanvasItem& it : m_layout.itemsByZ()) {
+        applyGeometryFor(it.id);
+    }
+}
+
+void WorkspaceCanvas::applyStacking()
+{
+    // Bottom-to-top: each raise() puts that widget above everything raised so
+    // far, so the last one — the highest z — ends up on top.
+    for (const CanvasItem& it : m_layout.itemsByZ()) {
+        if (QWidget* w = m_widgets.value(it.id).data()) {
+            w->raise();
+        }
+    }
+}
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/WorkspaceCanvas.h
+++ b/src/gui/workspace/WorkspaceCanvas.h
@@ -35,6 +35,12 @@ class WorkspaceCanvas : public QWidget {
 public:
     explicit WorkspaceCanvas(QWidget* parent = nullptr);
 
+    // Drops the per-item destroyed-watches.  Not optional: ~QWidget deletes
+    // the canvas's children AFTER this class's members are gone, so a watch
+    // left connected would fire into a lambda touching a destroyed
+    // CanvasLayout. See the destructor.
+    ~WorkspaceCanvas() override;
+
     // Place `content` on the canvas at `rect`.  The canvas reparents it and
     // owns its geometry from then on — callers must not setGeometry() it
     // afterwards, or the next resize will silently undo them.

--- a/src/gui/workspace/WorkspaceCanvas.h
+++ b/src/gui/workspace/WorkspaceCanvas.h
@@ -1,0 +1,113 @@
+#pragma once
+
+// The workspace canvas surface (RFC #4887, phase 1).
+//
+// A QWidget that hosts freely-placed child widgets, positioned from a
+// CanvasLayout.  Deliberately thin: every decision that can be got wrong
+// (clamping, hit testing, stacking) lives in the widget-free model, and this
+// class only applies the answers to real geometry.  If a change here needs a
+// new rule rather than a new call, the rule belongs in CanvasLayout where it
+// can be tested headless.
+//
+// PHASE 1 SCOPE — what is deliberately absent, and where it lands:
+//   * snapping, alignment guides, resize handles, tidy, keyboard nudge — phase 5
+//   * persistence and the workspace document                          — phase 2
+//   * mounting into MainWindow, and any theme tokens for item chrome   — phase 3
+//   * automation bridge verbs                                          — phase 4
+//
+// Nothing in this file touches MainWindow, TitleBar, AutomationServer or the
+// theme seed: those are RFC #4764's files, and phase 1 runs in parallel with
+// it precisely because it stays out of them.
+
+#include "gui/workspace/CanvasLayout.h"
+
+#include <QHash>
+#include <QPointer>
+#include <QSize>
+#include <QString>
+#include <QWidget>
+
+namespace AetherSDR {
+
+class WorkspaceCanvas : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit WorkspaceCanvas(QWidget* parent = nullptr);
+
+    // Place `content` on the canvas at `rect`.  The canvas reparents it and
+    // owns its geometry from then on — callers must not setGeometry() it
+    // afterwards, or the next resize will silently undo them.
+    //
+    // Returns false for an empty or duplicate id, or a null widget; on
+    // failure `content` is left entirely alone, not deleted, so a caller that
+    // hit a duplicate id still owns something it can place elsewhere.
+    bool addItem(const QString& id,
+                 QWidget* content,
+                 const NormRect& rect,
+                 const QString& contentType = {},
+                 const QSize& minimumSize = QSize(160, 90));
+
+    // Removes the item and deletes its widget.  Use takeItem() to keep it.
+    bool removeItem(const QString& id);
+
+    // Removes the item and hands the widget back, reparented to nullptr and
+    // hidden.  This is the call phase 3 needs to move an applet between a
+    // canvas and a container without destroying it.
+    QWidget* takeItem(const QString& id);
+
+    QWidget* itemWidget(const QString& id) const;
+    bool contains(const QString& id) const { return m_layout.contains(id); }
+    int itemCount() const { return m_layout.count(); }
+
+    // Placement.  The rect is clamped against the current canvas size, so the
+    // value read back may differ from the one passed in.
+    bool setItemRect(const QString& id, const NormRect& rect);
+    NormRect itemRect(const QString& id) const;
+
+    // Item under a point in this widget's coordinates; empty over bare canvas.
+    QString hitTest(const QPoint& pos) const;
+
+    bool raiseItem(const QString& id);
+    bool lowerItem(const QString& id);
+    bool bringItemToFront(const QString& id);
+    bool sendItemToBack(const QString& id);
+
+    // Read-only view of the model, for tests and for phase 2's serializer.
+    const CanvasLayout& layout() const { return m_layout; }
+
+signals:
+    // Emitted whenever an item's stored rect changes — including the clamps
+    // applied on a canvas resize, which is why the rect is carried in the
+    // signal rather than left for the receiver to read back.
+    void itemRectChanged(const QString& id, const NormRect& rect);
+    void itemStackingChanged(const QString& id);
+    void itemAdded(const QString& id);
+    void itemRemoved(const QString& id);
+
+protected:
+    void resizeEvent(QResizeEvent* ev) override;
+    void mousePressEvent(QMouseEvent* ev) override;
+
+    // Raises an item when its widget is pressed.  Installed on the item widget
+    // itself, so a press landing on a deeper descendant does not raise — real
+    // content drives that from its own title bar once containers arrive in
+    // phase 3, rather than this class filtering the whole application.
+    bool eventFilter(QObject* watched, QEvent* ev) override;
+
+private:
+    // Model -> pixels, for every item.
+    void applyGeometry();
+
+    // Model -> Qt stacking.  Raising bottom-to-top leaves the highest z on
+    // top; Qt has no "set stacking index", so the order of these calls IS the
+    // result.
+    void applyStacking();
+
+    void applyGeometryFor(const QString& id);
+
+    CanvasLayout m_layout;
+    QHash<QString, QPointer<QWidget>> m_widgets;
+};
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/WorkspaceCanvas.h
+++ b/src/gui/workspace/WorkspaceCanvas.h
@@ -54,6 +54,18 @@ public:
                  const QString& contentType = {},
                  const QSize& minimumSize = QSize(160, 90));
 
+    // Rehydrate a saved surface: place `widgets` (keyed by item id) according
+    // to `items`, honouring their stored z.
+    //
+    // This exists because addItem() deliberately ignores a caller's z, and
+    // WorkspaceCanvas is the ONLY public way onto a canvas — so without it a
+    // restore through the widget layer would scramble stacking unless it
+    // happened to feed items in ascending z, which nothing made true
+    // (PR #4900 review, M3).  Items with no matching widget are skipped.
+    // Returns how many were placed.
+    int restoreItems(const QList<CanvasItem>& items,
+                     const QHash<QString, QWidget*>& widgets);
+
     // Removes the item and deletes its widget.  Use takeItem() to keep it.
     bool removeItem(const QString& id);
 
@@ -86,6 +98,11 @@ signals:
     // Emitted whenever an item's stored rect changes — including the clamps
     // applied on a canvas resize, which is why the rect is carried in the
     // signal rather than left for the receiver to read back.
+    //
+    // Both of these are edits: phase 2's auto-commit turns each into a
+    // whole-document write, so neither fires for an operation that changed
+    // nothing.  A resize that clamps no item is silent, and so is raising an
+    // item that was already frontmost.
     void itemRectChanged(const QString& id, const NormRect& rect);
     void itemStackingChanged(const QString& id);
     void itemAdded(const QString& id);
@@ -93,7 +110,6 @@ signals:
 
 protected:
     void resizeEvent(QResizeEvent* ev) override;
-    void mousePressEvent(QMouseEvent* ev) override;
 
     // Raises an item when its widget is pressed.  Installed on the item widget
     // itself, so a press landing on a deeper descendant does not raise — real

--- a/src/gui/workspace/WorkspaceDocument.cpp
+++ b/src/gui/workspace/WorkspaceDocument.cpp
@@ -238,7 +238,24 @@ bool WorkspaceDocument::fromJson(const QJsonObject& root,
             const QString geometry =
                 so.value(QStringLiteral("windowGeometry")).toString();
             if (!geometry.isEmpty()) {
-                surface.windowGeometry = QByteArray::fromBase64(geometry.toLatin1());
+                // Decode strictly.  The default fromBase64() silently ignores
+                // invalid characters and returns whatever it managed, so
+                // mangled input would become plausible-looking garbage that
+                // QWidget::restoreGeometry() rejects later without a word.
+                // This is a hint either way — dropping it costs one drag; the
+                // value is that it lands in warnings() instead of nowhere.
+                const auto decoded = QByteArray::fromBase64Encoding(
+                    geometry.toLatin1(),
+                    QByteArray::Base64Encoding
+                        | QByteArray::AbortOnBase64DecodingErrors);
+                if (decoded.decodingStatus == QByteArray::Base64DecodingStatus::Ok) {
+                    surface.windowGeometry = *decoded;
+                } else {
+                    appendWarning(warnings,
+                                  QStringLiteral("dropped an unreadable window "
+                                                 "geometry hint on '%1/%2'")
+                                      .arg(ws.id, surface.id));
+                }
             }
 
             QSet<QString> seenItemIds;

--- a/src/gui/workspace/WorkspaceDocument.cpp
+++ b/src/gui/workspace/WorkspaceDocument.cpp
@@ -213,8 +213,17 @@ bool WorkspaceDocument::fromJson(const QJsonObject& root,
             continue;
         }
 
+        if (wo.contains(QStringLiteral("surfaces"))
+            && !wo.value(QStringLiteral("surfaces")).isArray()) {
+            appendWarning(warnings,
+                          QStringLiteral("workspace '%1' has a non-array surfaces field")
+                              .arg(ws.id));
+        }
         for (const QJsonValue& sValue : wo.value(QStringLiteral("surfaces")).toArray()) {
             if (!sValue.isObject()) {
+                appendWarning(warnings,
+                              QStringLiteral("dropped a non-object surface in '%1'")
+                                  .arg(ws.id));
                 continue;
             }
             const QJsonObject so = sValue.toObject();
@@ -258,9 +267,19 @@ bool WorkspaceDocument::fromJson(const QJsonObject& root,
                 }
             }
 
+            if (so.contains(QStringLiteral("items"))
+                && !so.value(QStringLiteral("items")).isArray()) {
+                appendWarning(warnings,
+                              QStringLiteral("surface '%1/%2' has a non-array items field")
+                                  .arg(ws.id, surface.id));
+            }
+
             QSet<QString> seenItemIds;
             for (const QJsonValue& iValue : so.value(QStringLiteral("items")).toArray()) {
                 if (!iValue.isObject()) {
+                    appendWarning(warnings,
+                                  QStringLiteral("dropped a non-object item in '%1/%2'")
+                                      .arg(ws.id, surface.id));
                     continue;
                 }
                 const QJsonObject io = iValue.toObject();

--- a/src/gui/workspace/WorkspaceDocument.cpp
+++ b/src/gui/workspace/WorkspaceDocument.cpp
@@ -1,0 +1,354 @@
+#include "gui/workspace/WorkspaceDocument.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonValue>
+#include <QSet>
+
+namespace AetherSDR {
+
+const QString WorkspaceSurface::kMainId = QStringLiteral("main");
+
+namespace {
+
+QJsonArray rectToJson(const NormRect& r)
+{
+    return QJsonArray{r.x, r.y, r.w, r.h};
+}
+
+// A rect is four finite numbers.  Anything else is not "a rect we can fix" —
+// it is a rect we never wrote, so the item carrying it is dropped.
+bool rectFromJson(const QJsonValue& v, NormRect* out)
+{
+    if (!v.isArray()) {
+        return false;
+    }
+    const QJsonArray a = v.toArray();
+    if (a.size() != 4) {
+        return false;
+    }
+    for (const QJsonValue& n : a) {
+        if (!n.isDouble()) {
+            return false;
+        }
+    }
+    NormRect r;
+    r.x = a.at(0).toDouble();
+    r.y = a.at(1).toDouble();
+    r.w = a.at(2).toDouble();
+    r.h = a.at(3).toDouble();
+    if (!r.isValid()) {
+        return false;
+    }
+    *out = r;
+    return true;
+}
+
+QJsonObject itemToJson(const CanvasItem& it)
+{
+    QJsonObject o;
+    o[QStringLiteral("id")]   = it.id;
+    o[QStringLiteral("rect")] = rectToJson(it.rect);
+    o[QStringLiteral("z")]    = it.z;
+    if (!it.contentType.isEmpty()) {
+        o[QStringLiteral("type")] = it.contentType;
+    }
+    if (it.collapsed) {
+        o[QStringLiteral("collapsed")] = true;
+    }
+    // minimumSize is deliberately NOT persisted: it is a property of the
+    // content, not of the operator's arrangement.  Whatever rehydrates the
+    // widget re-declares it, so a content change ships a new floor instead of
+    // being overridden by a stale one saved months ago.
+    return o;
+}
+
+void appendWarning(QStringList* warnings, const QString& text)
+{
+    if (warnings) {
+        warnings->append(text);
+    }
+}
+
+}  // namespace
+
+const WorkspaceSurface* Workspace::surface(const QString& surfaceId) const
+{
+    for (const WorkspaceSurface& s : surfaces) {
+        if (s.id == surfaceId) {
+            return &s;
+        }
+    }
+    return nullptr;
+}
+
+const Workspace* WorkspaceDocument::workspace(const QString& id) const
+{
+    for (const Workspace& w : workspaces) {
+        if (w.id == id) {
+            return &w;
+        }
+    }
+    return nullptr;
+}
+
+QStringList WorkspaceDocument::workspaceIds() const
+{
+    QStringList out;
+    out.reserve(workspaces.size());
+    for (const Workspace& w : workspaces) {
+        out.append(w.id);
+    }
+    return out;
+}
+
+QString WorkspaceDocument::boundWorkspace(const QString& radioProfile) const
+{
+    const QString id = bindings.value(radioProfile);
+    return contains(id) ? id : QString();
+}
+
+QJsonObject WorkspaceDocument::toJson() const
+{
+    QJsonArray wsArray;
+    for (const Workspace& w : workspaces) {
+        QJsonArray surfaceArray;
+        for (const WorkspaceSurface& s : w.surfaces) {
+            QJsonArray itemArray;
+            for (const CanvasItem& it : s.items) {
+                itemArray.append(itemToJson(it));
+            }
+
+            QJsonObject so;
+            so[QStringLiteral("id")]    = s.id;
+            so[QStringLiteral("items")] = itemArray;
+            if (!s.label.isEmpty()) {
+                so[QStringLiteral("label")] = s.label;
+            }
+            if (!s.windowGeometry.isEmpty()) {
+                so[QStringLiteral("windowGeometry")] =
+                    QString::fromLatin1(s.windowGeometry.toBase64());
+            }
+            surfaceArray.append(so);
+        }
+
+        QJsonObject wo;
+        wo[QStringLiteral("id")]       = w.id;
+        wo[QStringLiteral("surfaces")] = surfaceArray;
+        if (!w.label.isEmpty()) {
+            wo[QStringLiteral("label")] = w.label;
+        }
+        wsArray.append(wo);
+    }
+
+    QJsonObject bindingsObj;
+    for (auto it = bindings.constBegin(); it != bindings.constEnd(); ++it) {
+        bindingsObj[it.key()] = it.value();
+    }
+
+    QJsonObject root;
+    root[QStringLiteral("version")]         = kSchemaVersion;
+    root[QStringLiteral("activeWorkspace")] = activeWorkspace;
+    root[QStringLiteral("workspaces")]      = wsArray;
+    if (!bindingsObj.isEmpty()) {
+        root[QStringLiteral("bindings")] = bindingsObj;
+    }
+    return root;
+}
+
+bool WorkspaceDocument::fromJson(const QJsonObject& root,
+                                 WorkspaceDocument* out,
+                                 QString* error,
+                                 QStringList* warnings)
+{
+    if (!out) {
+        return false;
+    }
+
+    const auto fail = [error](const QString& why) {
+        if (error) {
+            *error = why;
+        }
+        return false;
+    };
+
+    const QJsonValue versionValue = root.value(QStringLiteral("version"));
+    if (!versionValue.isDouble()) {
+        return fail(QStringLiteral("no schema version"));
+    }
+    const int version = versionValue.toInt();
+    if (version < 1) {
+        return fail(QStringLiteral("invalid schema version %1").arg(version));
+    }
+    if (version > kSchemaVersion) {
+        // A newer build wrote this.  Rewriting it from our understanding
+        // would silently drop whatever it knows that we do not.
+        return fail(QStringLiteral("schema version %1 is newer than %2")
+                        .arg(version)
+                        .arg(kSchemaVersion));
+    }
+    if (!root.value(QStringLiteral("workspaces")).isArray()) {
+        return fail(QStringLiteral("no workspaces array"));
+    }
+
+    WorkspaceDocument doc;
+
+    for (const QJsonValue& wsValue : root.value(QStringLiteral("workspaces")).toArray()) {
+        if (!wsValue.isObject()) {
+            appendWarning(warnings, QStringLiteral("dropped a non-object workspace"));
+            continue;
+        }
+        const QJsonObject wo = wsValue.toObject();
+
+        Workspace ws;
+        ws.id    = wo.value(QStringLiteral("id")).toString();
+        ws.label = wo.value(QStringLiteral("label")).toString();
+        if (ws.id.isEmpty()) {
+            appendWarning(warnings, QStringLiteral("dropped a workspace with no id"));
+            continue;
+        }
+        if (doc.contains(ws.id)) {
+            appendWarning(warnings,
+                          QStringLiteral("dropped duplicate workspace '%1'").arg(ws.id));
+            continue;
+        }
+
+        for (const QJsonValue& sValue : wo.value(QStringLiteral("surfaces")).toArray()) {
+            if (!sValue.isObject()) {
+                continue;
+            }
+            const QJsonObject so = sValue.toObject();
+
+            WorkspaceSurface surface;
+            surface.id    = so.value(QStringLiteral("id")).toString();
+            surface.label = so.value(QStringLiteral("label")).toString();
+            if (surface.id.isEmpty()) {
+                appendWarning(warnings,
+                              QStringLiteral("dropped a surface with no id in '%1'")
+                                  .arg(ws.id));
+                continue;
+            }
+            if (ws.surface(surface.id)) {
+                appendWarning(warnings,
+                              QStringLiteral("dropped duplicate surface '%1' in '%2'")
+                                  .arg(surface.id, ws.id));
+                continue;
+            }
+
+            const QString geometry =
+                so.value(QStringLiteral("windowGeometry")).toString();
+            if (!geometry.isEmpty()) {
+                surface.windowGeometry = QByteArray::fromBase64(geometry.toLatin1());
+            }
+
+            QSet<QString> seenItemIds;
+            for (const QJsonValue& iValue : so.value(QStringLiteral("items")).toArray()) {
+                if (!iValue.isObject()) {
+                    continue;
+                }
+                const QJsonObject io = iValue.toObject();
+
+                CanvasItem item;
+                item.id = io.value(QStringLiteral("id")).toString();
+                if (item.id.isEmpty()) {
+                    appendWarning(warnings,
+                                  QStringLiteral("dropped an item with no id in '%1/%2'")
+                                      .arg(ws.id, surface.id));
+                    continue;
+                }
+                if (seenItemIds.contains(item.id)) {
+                    appendWarning(warnings,
+                                  QStringLiteral("dropped duplicate item '%1' in '%2/%3'")
+                                      .arg(item.id, ws.id, surface.id));
+                    continue;
+                }
+                if (!rectFromJson(io.value(QStringLiteral("rect")), &item.rect)) {
+                    appendWarning(warnings,
+                                  QStringLiteral("dropped item '%1' with an invalid rect")
+                                      .arg(item.id));
+                    continue;
+                }
+
+                item.contentType = io.value(QStringLiteral("type")).toString();
+                item.z           = io.value(QStringLiteral("z")).toInt();
+                item.collapsed   = io.value(QStringLiteral("collapsed")).toBool();
+
+                seenItemIds.insert(item.id);
+                surface.items.append(item);
+            }
+
+            ws.surfaces.append(surface);
+        }
+
+        // Every workspace has a main surface, even if the stored document
+        // forgot one: the main window always has a canvas, so a document that
+        // cannot describe it is not usable.
+        if (!ws.surface(WorkspaceSurface::kMainId)) {
+            WorkspaceSurface main;
+            main.id = WorkspaceSurface::kMainId;
+            ws.surfaces.prepend(main);
+            appendWarning(warnings,
+                          QStringLiteral("workspace '%1' had no main surface").arg(ws.id));
+        }
+
+        doc.workspaces.append(ws);
+    }
+
+    const QJsonObject bindingsObj = root.value(QStringLiteral("bindings")).toObject();
+    for (auto it = bindingsObj.constBegin(); it != bindingsObj.constEnd(); ++it) {
+        const QString target = it.value().toString();
+        if (target.isEmpty() || !doc.contains(target)) {
+            appendWarning(warnings,
+                          QStringLiteral("dropped binding '%1' -> '%2' (no such workspace)")
+                              .arg(it.key(), target));
+            continue;
+        }
+        doc.bindings.insert(it.key(), target);
+    }
+
+    doc.activeWorkspace = root.value(QStringLiteral("activeWorkspace")).toString();
+    if (!doc.activeWorkspace.isEmpty() && !doc.contains(doc.activeWorkspace)) {
+        appendWarning(warnings,
+                      QStringLiteral("active workspace '%1' does not exist")
+                          .arg(doc.activeWorkspace));
+        doc.activeWorkspace.clear();
+    }
+    if (doc.activeWorkspace.isEmpty() && !doc.workspaces.isEmpty()) {
+        doc.activeWorkspace = doc.workspaces.first().id;
+    }
+
+    *out = doc;
+    return true;
+}
+
+bool WorkspaceDocument::fromStoredJson(const QByteArray& blob,
+                                       WorkspaceDocument* out,
+                                       QString* error,
+                                       QStringList* warnings)
+{
+    if (blob.isEmpty()) {
+        if (error) {
+            *error = QStringLiteral("empty document");
+        }
+        return false;
+    }
+
+    QJsonParseError parseError{};
+    const QJsonDocument parsed = QJsonDocument::fromJson(blob, &parseError);
+    if (parseError.error != QJsonParseError::NoError || !parsed.isObject()) {
+        if (error) {
+            *error = parseError.error != QJsonParseError::NoError
+                         ? parseError.errorString()
+                         : QStringLiteral("document root is not an object");
+        }
+        return false;
+    }
+    return fromJson(parsed.object(), out, error, warnings);
+}
+
+QByteArray WorkspaceDocument::toStoredJson() const
+{
+    return QJsonDocument(toJson()).toJson(QJsonDocument::Compact);
+}
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/WorkspaceDocument.h
+++ b/src/gui/workspace/WorkspaceDocument.h
@@ -1,0 +1,123 @@
+#pragma once
+
+// The workspace document — every workspace profile, the active selection, and
+// the radio-profile bindings, as one versioned object (RFC #4887, phase 2).
+//
+// One document, one owner, one atomic write: Constitution Principle V (a
+// feature owns its configuration as a single object) and Principle XIV
+// (persist atomically).  That is the whole point of this type existing.  The
+// arrangement it replaces is spread across a dozen independent settings keys
+// with three different schemas and no single writer, so a shutdown path that
+// skips one of them restores a MIXTURE of two layouts — which is what "the
+// window rules never work" feels like from the operator's chair.
+//
+// Two things this schema deliberately separates:
+//
+//   * item rects are AUTHORITATIVE — fractions of their surface, restored
+//     exactly, on every platform, every launch;
+//   * `windowGeometry` on an extra canvas window is a HINT, and named like
+//     one — the desktop may decline it, and always does on Wayland for
+//     position.  A hint that is ignored costs one drag and loses no layout.
+//
+// Parsing is strict (Principle VII — untrusted input is validated at the
+// boundary): the settings store is a file on disk that a user can edit, a
+// backup can restore, and a future build can write a newer schema into.
+//
+// Widget-free, so the whole schema is unit-tested headless — see
+// tests/workspace_document_test.cpp.
+
+#include "gui/workspace/CanvasItem.h"
+
+#include <QByteArray>
+#include <QJsonObject>
+#include <QList>
+#include <QMap>
+#include <QString>
+
+namespace AetherSDR {
+
+// One canvas surface: the main window's, or one extra canvas window.
+struct WorkspaceSurface {
+    // "main" is reserved for the main window's canvas and must be present.
+    static const QString kMainId;
+
+    QString id;
+    QString label;
+
+    // Placement hint for an extra canvas window, as QWidget::saveGeometry()
+    // wrote it.  Empty for "main", whose geometry is the main window's own
+    // business.  Never authoritative — see the file comment.
+    QByteArray windowGeometry;
+
+    QList<CanvasItem> items;
+};
+
+// One named arrangement — a workspace profile.  NOT a radio profile: those
+// live on the radio and know nothing about layout (Principle III does not
+// reach a window arrangement).  See the RFC for the full distinction.
+struct Workspace {
+    QString id;
+    QString label;
+    QList<WorkspaceSurface> surfaces;
+
+    const WorkspaceSurface* surface(const QString& surfaceId) const;
+};
+
+class WorkspaceDocument {
+public:
+    // Bumped only for a change this build cannot read back compatibly.
+    static constexpr int kSchemaVersion = 1;
+
+    // Workspaces are an ORDERED array rather than the object the RFC sketched:
+    // QJsonObject sorts its keys, which would silently reorder the operator's
+    // switcher every time the document round-tripped.
+    QList<Workspace> workspaces;
+
+    // Radio global profile name -> workspace id.  Client-side, because the
+    // radio has nowhere to put it and no concept of what it points at.
+    QMap<QString, QString> bindings;
+
+    QString activeWorkspace;
+
+    // ── Queries ──────────────────────────────────────────────────────────
+    const Workspace* workspace(const QString& id) const;
+    bool contains(const QString& id) const { return workspace(id) != nullptr; }
+    QStringList workspaceIds() const;
+    bool isEmpty() const { return workspaces.isEmpty(); }
+
+    // The workspace bound to a radio global profile, or empty when unbound.
+    // An unbound recall must leave the workspace alone (RFC decision 8), so
+    // "no binding" is a normal answer, not a failure.
+    QString boundWorkspace(const QString& radioProfile) const;
+
+    // ── Serialisation ────────────────────────────────────────────────────
+    QJsonObject toJson() const;
+
+    // Strict parse.  Returns false and leaves `out` untouched for anything
+    // this build must not act on:
+    //   * a missing or non-integer version,
+    //   * a version NEWER than kSchemaVersion — a later build wrote it, and
+    //     re-writing it from this one's understanding would destroy whatever
+    //     it knew that we do not (AppSettings takes the same stance),
+    //   * a root that is not an object, or carries no workspaces array.
+    //
+    // Recoverable damage inside a valid document is repaired rather than
+    // rejected, and reported through `warnings` so it is visible instead of
+    // silent: items with no id or an invalid rect are dropped, duplicate item
+    // ids within a surface are dropped, a workspace with no "main" surface
+    // gains an empty one, a binding pointing at a missing workspace is
+    // dropped, and an activeWorkspace naming nothing falls back to the first.
+    static bool fromJson(const QJsonObject& root,
+                         WorkspaceDocument* out,
+                         QString* error = nullptr,
+                         QStringList* warnings = nullptr);
+
+    // Convenience for the settings round-trip: parse a stored UTF-8 blob.
+    static bool fromStoredJson(const QByteArray& blob,
+                               WorkspaceDocument* out,
+                               QString* error = nullptr,
+                               QStringList* warnings = nullptr);
+    QByteArray toStoredJson() const;
+};
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/WorkspaceGeometry.cpp
+++ b/src/gui/workspace/WorkspaceGeometry.cpp
@@ -1,0 +1,127 @@
+#include "gui/workspace/WorkspaceGeometry.h"
+
+#include <QtGlobal>
+
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+// Fraction-space slack.  Placement is authored by dragging, stored as a
+// double, and compared after a pixel round-trip, so exact equality is the
+// wrong test.  1e-9 is far below one pixel on any canvas we will ever have
+// (1e-9 of 3840 px is 4e-6 px) and far above double's rounding noise.
+constexpr double kEpsilon = 1e-9;
+
+bool finite(double v)
+{
+    return std::isfinite(v);
+}
+
+double clampDouble(double v, double lo, double hi)
+{
+    return v < lo ? lo : (v > hi ? hi : v);
+}
+
+bool canvasUsable(const QSize& canvas)
+{
+    return canvas.width() > 0 && canvas.height() > 0;
+}
+
+}  // namespace
+
+bool NormRect::isValid() const
+{
+    return finite(x) && finite(y) && finite(w) && finite(h)
+           && w > 0.0 && h > 0.0;
+}
+
+bool NormRect::contains(double px, double py) const
+{
+    return px >= x && px < right() && py >= y && py < bottom();
+}
+
+bool NormRect::operator==(const NormRect& o) const
+{
+    return std::fabs(x - o.x) <= kEpsilon
+           && std::fabs(y - o.y) <= kEpsilon
+           && std::fabs(w - o.w) <= kEpsilon
+           && std::fabs(h - o.h) <= kEpsilon;
+}
+
+QRect toPixels(const NormRect& r, const QSize& canvas)
+{
+    if (!canvasUsable(canvas) || !finite(r.x) || !finite(r.y)
+        || !finite(r.w) || !finite(r.h)) {
+        return {};
+    }
+
+    const double cw = canvas.width();
+    const double ch = canvas.height();
+
+    // Round the edges, not the origin and the size — see the header.
+    const int left   = qRound(r.x * cw);
+    const int top    = qRound(r.y * ch);
+    const int right  = qRound(r.right() * cw);
+    const int bottom = qRound(r.bottom() * ch);
+
+    return QRect(left, top, right - left, bottom - top);
+}
+
+NormRect fromPixels(const QRect& px, const QSize& canvas)
+{
+    if (!canvasUsable(canvas)) {
+        return {};
+    }
+
+    const double cw = canvas.width();
+    const double ch = canvas.height();
+
+    NormRect r;
+    r.x = px.x() / cw;
+    r.y = px.y() / ch;
+    r.w = px.width() / cw;
+    r.h = px.height() / ch;
+    return r;
+}
+
+QSizeF minimumNormSize(const QSize& minPx, const QSize& canvas)
+{
+    if (!canvasUsable(canvas)) {
+        return {};
+    }
+
+    const double w = qMax(0, minPx.width())  / static_cast<double>(canvas.width());
+    const double h = qMax(0, minPx.height()) / static_cast<double>(canvas.height());
+    return QSizeF(qMin(w, 1.0), qMin(h, 1.0));
+}
+
+NormRect clampToCanvas(const NormRect& r, const QSize& minPx, const QSize& canvas)
+{
+    if (!canvasUsable(canvas)) {
+        return r;
+    }
+    if (!finite(r.x) || !finite(r.y) || !finite(r.w) || !finite(r.h)) {
+        return {};
+    }
+
+    const QSizeF minimum = minimumNormSize(minPx, canvas);
+
+    NormRect out = r;
+
+    // 1. Grow to the minimum, then cap at the canvas.  The cap IS the
+    //    shrink case: an item larger than the surface, or a minimum that a
+    //    tiny canvas cannot honour, ends up exactly canvas-sized.
+    out.w = clampDouble(qMax(out.w, minimum.width()),  0.0, 1.0);
+    out.h = clampDouble(qMax(out.h, minimum.height()), 0.0, 1.0);
+
+    // 2. Translate back inside.  Step 1 leaves w/h in [0,1], so the upper
+    //    bound here is never negative.
+    out.x = clampDouble(out.x, 0.0, 1.0 - out.w);
+    out.y = clampDouble(out.y, 0.0, 1.0 - out.h);
+
+    return out;
+}
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/WorkspaceGeometry.h
+++ b/src/gui/workspace/WorkspaceGeometry.h
@@ -1,0 +1,84 @@
+#pragma once
+
+// Normalized canvas geometry — the pure half of the workspace canvas
+// (RFC #4887, phase 1).
+//
+// Canvas items store their placement as fractions of the surface they sit on,
+// never as pixels.  A layout built on a 3840x1600 display therefore restores
+// correctly on a 1920x1080 laptop: only the cell pitch changes.  Pixel
+// geometry cannot do that, and is half of why pop-out window restore feels
+// random today (see the RFC's Problem section).
+//
+// Nothing here knows what a QWidget is, so all of it is unit-tested headless
+// on every platform — see tests/workspace_geometry_test.cpp.
+
+#include <QRect>
+#include <QSize>
+#include <QSizeF>
+
+namespace AetherSDR {
+
+// A rectangle in canvas-relative coordinates: x/y is the top-left corner as a
+// fraction of the canvas, w/h the size as a fraction of it.  A rect fully
+// inside its canvas satisfies 0 <= x, x + w <= 1 (and likewise for y/h), but
+// the type itself does not enforce that — clampToCanvas() does, because a
+// caller mid-drag legitimately holds a rect that is briefly outside.
+struct NormRect {
+    double x = 0.0;
+    double y = 0.0;
+    double w = 0.0;
+    double h = 0.0;
+
+    double right()  const { return x + w; }
+    double bottom() const { return y + h; }
+
+    // Finite, and with a strictly positive size.  A zero-area rect is not
+    // valid: it would map to an invisible item that still answers hit tests.
+    bool isValid() const;
+
+    // Fraction-space containment, half-open on the far edges so two items
+    // sharing an edge do not both claim a point on it.
+    bool contains(double px, double py) const;
+
+    bool operator==(const NormRect& o) const;
+    bool operator!=(const NormRect& o) const { return !(*this == o); }
+};
+
+// Map a normalized rect onto a pixel canvas.
+//
+// Each EDGE is rounded independently rather than rounding the origin and the
+// size: two items that share a normalized edge then land on the same pixel
+// column at every canvas size, so a tiled arrangement neither gaps nor
+// overlaps by a pixel.  Rounding origin+size instead lets the shared edge fall
+// on two different pixels, which shows up as a hairline seam that moves as the
+// window is resized.
+//
+// Sub-pixel rects can round to a zero-width or zero-height QRect; this
+// function does not silently inflate them.  Callers keep items measurable by
+// clamping through clampToCanvas() with a minimum pixel size.
+QRect toPixels(const NormRect& r, const QSize& canvas);
+
+// Inverse of toPixels().  Returns a default-constructed NormRect for a
+// degenerate canvas rather than dividing by zero.
+NormRect fromPixels(const QRect& px, const QSize& canvas);
+
+// The smallest normalized size that still measures at least `minPx` on this
+// canvas, capped at the full canvas.  On a canvas smaller than the minimum the
+// cap wins and the item fills the surface — a too-small item is a worse
+// outcome than one that overflows a tiny window.
+QSizeF minimumNormSize(const QSize& minPx, const QSize& canvas);
+
+// Bring `r` inside the canvas, preserving its size wherever possible.
+//
+// Order matters, and is chosen so a drag that overshoots an edge slides the
+// item back rather than resizing it under the operator's cursor:
+//   1. grow to the minimum size, then cap at the canvas — the cap is also the
+//      shrink case, for an item bigger than the surface,
+//   2. translate back inside.
+//
+// A degenerate canvas returns `r` untouched: with no surface to clamp against
+// there is no correct answer, and mangling the stored layout because a widget
+// has not been shown yet would lose real state.
+NormRect clampToCanvas(const NormRect& r, const QSize& minPx, const QSize& canvas);
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/WorkspaceMigration.cpp
+++ b/src/gui/workspace/WorkspaceMigration.cpp
@@ -1,0 +1,155 @@
+#include "gui/workspace/WorkspaceMigration.h"
+
+#include "core/AppSettings.h"
+#include "gui/workspace/ClassicLayout.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSet>
+
+namespace AetherSDR {
+
+namespace {
+
+// AppSettings stores booleans as the strings "True"/"False" throughout the
+// legacy layout keys.  Anything else is treated as absent and falls back to
+// the caller's default, rather than being coerced to false — an unreadable
+// value must not silently mean "off".
+bool legacyBool(const QString& key, bool fallback)
+{
+    const QString raw = AppSettings::instance().value(key).toString();
+    if (raw.compare(QLatin1String("True"), Qt::CaseInsensitive) == 0) {
+        return true;
+    }
+    if (raw.compare(QLatin1String("False"), Qt::CaseInsensitive) == 0) {
+        return false;
+    }
+    return fallback;
+}
+
+// Container ids that ContainerTree says are floating right now.  These are
+// the applets migration must leave alone.
+QSet<QString> floatingContainerIds()
+{
+    QSet<QString> floating;
+
+    const QString raw =
+        AppSettings::instance().value(QStringLiteral("ContainerTree")).toString();
+    if (raw.isEmpty()) {
+        return floating;
+    }
+
+    QJsonParseError err{};
+    const QJsonDocument doc = QJsonDocument::fromJson(raw.toUtf8(), &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject()) {
+        // A corrupt container tree is not a reason to fail the migration:
+        // Classic without float information is still a usable Classic, and
+        // the legacy keys are untouched either way.
+        return floating;
+    }
+
+    const QJsonObject containers =
+        doc.object().value(QStringLiteral("containers")).toObject();
+    for (auto it = containers.constBegin(); it != containers.constEnd(); ++it) {
+        if (it.value().toObject().value(QStringLiteral("mode")).toString()
+            == QLatin1String("floating")) {
+            floating.insert(it.key());
+        }
+    }
+    return floating;
+}
+
+}  // namespace
+
+QString classicWorkspaceId()
+{
+    return QStringLiteral("classic");
+}
+
+LegacyLayoutState readLegacyLayoutState(const QStringList& knownAppletIds)
+{
+    auto& settings = AppSettings::instance();
+
+    LegacyLayoutState state;
+
+    const QString layoutId =
+        settings.value(QStringLiteral("PanadapterLayout")).toString().trimmed();
+    if (!layoutId.isEmpty() && panCountForLayout(layoutId) > 0) {
+        state.panLayoutId = layoutId;
+    }
+
+    state.floatingPanIds =
+        settings.value(QStringLiteral("FloatingPanIds")).toString()
+            .split(QLatin1Char(','), Qt::SkipEmptyParts);
+
+    state.appletsLeft = legacyBool(QStringLiteral("AppletPanelDockedLeft"), false);
+    state.appletPanelVisible = legacyBool(QStringLiteral("AppletPanelVisible"), true);
+
+    // Column order: AppletOrder first, then anything the operator has never
+    // reordered, in the caller's canonical order.  A saved order that names
+    // an applet this build no longer has is skipped rather than trusted.
+    const QStringList savedOrder =
+        settings.value(QStringLiteral("AppletOrder")).toString()
+            .split(QLatin1Char(','), Qt::SkipEmptyParts);
+
+    QStringList ordered;
+    for (const QString& id : savedOrder) {
+        if (knownAppletIds.contains(id) && !ordered.contains(id)) {
+            ordered.append(id);
+        }
+    }
+    for (const QString& id : knownAppletIds) {
+        if (!ordered.contains(id)) {
+            ordered.append(id);
+        }
+    }
+
+    const QSet<QString> floating = floatingContainerIds();
+
+    for (const QString& id : ordered) {
+        // Applet_<ID> is absent until the operator toggles that applet, and
+        // its default differs per applet.  AppletPanel owns those defaults,
+        // so an unset key here means "not known to be open" and the applet is
+        // simply not placed — Classic under-populating is recoverable, and
+        // guessing wrong would put windows on screen nobody asked for.
+        if (!settings.contains(QStringLiteral("Applet_") + id)) {
+            continue;
+        }
+        if (!legacyBool(QStringLiteral("Applet_") + id, false)) {
+            continue;
+        }
+        if (floating.contains(id)) {
+            state.floatingAppletIds.append(id);   // pop-out stays; not placed
+            continue;
+        }
+        state.openAppletIds.append(id);
+    }
+
+    return state;
+}
+
+WorkspaceDocument buildClassicDocument(const LegacyLayoutState& legacy,
+                                       const QStringList& panIds)
+{
+    // A hidden applet panel means Classic has no column — the pans take the
+    // whole surface, which is exactly what the operator sees today.
+    const QStringList appletIds =
+        legacy.appletPanelVisible ? legacy.openAppletIds : QStringList{};
+
+    WorkspaceSurface main;
+    main.id    = WorkspaceSurface::kMainId;
+    main.items = composeClassic(panIds, appletIds, legacy.panLayoutId,
+                                legacy.appletsLeft);
+
+    Workspace classic;
+    classic.id    = classicWorkspaceId();
+    classic.label = QStringLiteral("Classic");
+    classic.surfaces.append(main);
+
+    WorkspaceDocument doc;
+    doc.workspaces.append(classic);
+    doc.activeWorkspace = classic.id;
+    return doc;
+}
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/WorkspaceMigration.h
+++ b/src/gui/workspace/WorkspaceMigration.h
@@ -1,0 +1,70 @@
+#pragma once
+
+// One-way migration from the legacy layout keys to a workspace document
+// (RFC #4887, phase 2).
+//
+// Today's arrangement is spread across a dozen independent AppSettings keys
+// with three different schemas and no single writer.  This reads them once,
+// builds the "Classic" workspace, and hands it back.  It does not delete
+// anything: the legacy keys keep being written by their current owners for a
+// release (dual-write), so a downgrade still finds the state it expects.
+//
+// THE KEYS, as they actually exist in the code today — the RFC's table was
+// written from a grep and is looser than this:
+//
+//   Applet_<ID>               "True"/"False"     AppletPanel   (26 of them)
+//   AppletOrder               comma-joined ids   AppletPanel
+//   ButtonBarLayout           {"order":[],"hidden":[]}         AppletPanel
+//   AppletPanelDockedLeft     "True"/"False"     MainWindow
+//   AppletPanelVisible        "True"/"False"     MainWindow
+//   AppletPanelFloatGeometry  base64             MainWindow
+//   PanadapterLayout          layout id          MainWindow_Shortcuts
+//   FloatingPanIds            comma-joined ids   PanadapterStack
+//   ContainerTree             {version,containers{}}           ContainerManager
+//   ContainerGeometry_<id>    base64             ContainerManager (per container)
+//   ContainerAlwaysOnTop_<id> bool               ContainerManager (per container)
+//
+// WHAT MIGRATION DELIBERATELY DOES NOT DO: it does not pull floating things
+// onto the canvas.  Pop-out stays (RFC decision 1), so a pan or container the
+// operator floated is left floating and is not placed in Classic.  Dragging
+// someone's pop-outs into a canvas they have not opted into would be a
+// user-visible change in a phase whose whole contract is that there is none.
+// Phase 6's "import current pop-out arrangement" is the opt-in that does it.
+
+#include "gui/workspace/WorkspaceDocument.h"
+
+#include <QString>
+#include <QStringList>
+
+namespace AetherSDR {
+
+// What the legacy keys said, gathered in one place so the reading and the
+// composing can be tested apart.
+struct LegacyLayoutState {
+    QString     panLayoutId{QStringLiteral("1")};
+    QStringList floatingPanIds;     // left floating, not placed
+    QStringList openAppletIds;      // in column order, floats excluded
+    QStringList floatingAppletIds;  // left floating, not placed
+    bool        appletsLeft{false};
+    bool        appletPanelVisible{true};
+};
+
+// Read the legacy keys out of AppSettings.
+//
+// `knownAppletIds` is the applet id set to consider — AppletPanel owns the
+// canonical list, and this stays out of that business rather than duplicating
+// 26 string literals that would rot the first time an applet is added.
+LegacyLayoutState readLegacyLayoutState(const QStringList& knownAppletIds);
+
+// Build the Classic workspace document from gathered legacy state.  Pure.
+//
+// `panIds` are the pans that exist right now; migration runs at startup
+// before a radio is connected, so this is usually empty and Classic carries
+// only the applet column until phase 3 places pans as they arrive.
+WorkspaceDocument buildClassicDocument(const LegacyLayoutState& legacy,
+                                       const QStringList& panIds);
+
+// The workspace id and label the migration produces.
+QString classicWorkspaceId();
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/WorkspaceStore.cpp
+++ b/src/gui/workspace/WorkspaceStore.cpp
@@ -1,0 +1,144 @@
+#include "gui/workspace/WorkspaceStore.h"
+
+#include "core/AppSettings.h"
+#include "gui/workspace/WorkspaceMigration.h"
+
+#include <QTimer>
+
+namespace AetherSDR {
+
+const QString WorkspaceStore::kSettingsKey = QStringLiteral("Workspaces");
+
+WorkspaceStore::WorkspaceStore(QObject* parent)
+    : QObject(parent)
+    , m_debounce(new QTimer(this))
+{
+    m_debounce->setSingleShot(true);
+    m_debounce->setInterval(m_debounceMs);
+    connect(m_debounce, &QTimer::timeout, this, [this] { flush(); });
+}
+
+WorkspaceStore::~WorkspaceStore()
+{
+    // A pending debounce at teardown is unsaved operator work.  Auto-commit
+    // promises there is no such thing, so the last thing this object does is
+    // make that true.
+    if (m_dirty && !m_restoring) {
+        writeNow();
+    }
+}
+
+bool WorkspaceStore::load()
+{
+    m_warnings.clear();
+    m_lastError.clear();
+
+    const QByteArray blob =
+        AppSettings::instance().stationValue(kSettingsKey).toString().toUtf8();
+
+    WorkspaceDocument doc;
+    if (!WorkspaceDocument::fromStoredJson(blob, &doc, &m_lastError, &m_warnings)) {
+        m_loaded = false;
+        return false;
+    }
+
+    m_document = doc;
+    m_loaded   = true;
+    m_dirty    = false;
+    emit documentChanged();
+    return true;
+}
+
+bool WorkspaceStore::loadOrMigrate(const QStringList& knownAppletIds,
+                                   const QStringList& panIds,
+                                   bool* migrated)
+{
+    if (load()) {
+        if (migrated) {
+            *migrated = false;
+        }
+        return true;
+    }
+
+    // Nothing usable stored.  Build Classic from whatever the legacy keys
+    // say and write it once.  The legacy keys are left in place: their
+    // current owners keep writing them for a release, so a downgrade still
+    // finds the state it expects.
+    const LegacyLayoutState legacy = readLegacyLayoutState(knownAppletIds);
+    m_document = buildClassicDocument(legacy, panIds);
+    m_loaded   = true;
+    m_dirty    = true;
+
+    emit documentChanged();
+    flush();
+
+    if (migrated) {
+        *migrated = true;
+    }
+    return true;
+}
+
+void WorkspaceStore::setDocument(const WorkspaceDocument& doc)
+{
+    m_document = doc;
+    m_loaded   = true;
+    emit documentChanged();
+    touch();
+}
+
+void WorkspaceStore::touch()
+{
+    m_dirty = true;
+    if (m_restoring) {
+        return;   // no timer while replaying — flush() would refuse anyway
+    }
+    m_debounce->start(m_debounceMs);
+}
+
+bool WorkspaceStore::flush()
+{
+    m_debounce->stop();
+
+    if (m_restoring || !m_dirty) {
+        return false;
+    }
+    return writeNow();
+}
+
+bool WorkspaceStore::writeNow()
+{
+    auto& settings = AppSettings::instance();
+
+    // One whole-document write IS the atomic update (Principle XIV): there is
+    // no partial state a crash between two calls could leave behind, because
+    // there is only ever one call.
+    settings.setStationValue(kSettingsKey,
+                             QString::fromUtf8(m_document.toStoredJson()));
+
+    // setStationValue only mutates the in-memory map; a genuine commit has to
+    // reach disk or an abnormal exit loses it — the same reasoning as
+    // ContainerManager's flush point (#4427).
+    settings.save();
+
+    m_dirty = false;
+    emit flushed();
+    return true;
+}
+
+void WorkspaceStore::setRestoring(bool restoring)
+{
+    m_restoring = restoring;
+    if (restoring) {
+        m_debounce->stop();
+    }
+    // Deliberately no flush on the way out: restore must leave the store
+    // exactly as clean — or as dirty — as it found it.
+}
+
+void WorkspaceStore::setDebounceMs(int ms)
+{
+    m_debounceMs = ms < 0 ? 0 : ms;
+    m_debounce->setInterval(m_debounceMs);
+}
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/WorkspaceStore.cpp
+++ b/src/gui/workspace/WorkspaceStore.cpp
@@ -28,7 +28,7 @@ WorkspaceStore::~WorkspaceStore()
     }
 }
 
-bool WorkspaceStore::load()
+WorkspaceStore::LoadResult WorkspaceStore::loadWithStatus()
 {
     m_warnings.clear();
     m_lastError.clear();
@@ -36,38 +36,58 @@ bool WorkspaceStore::load()
     const QByteArray blob =
         AppSettings::instance().stationValue(kSettingsKey).toString().toUtf8();
 
+    if (blob.trimmed().isEmpty()) {
+        m_loaded    = false;
+        m_lastError = QStringLiteral("no workspace document stored");
+        return LoadResult::Absent;
+    }
+
     WorkspaceDocument doc;
     if (!WorkspaceDocument::fromStoredJson(blob, &doc, &m_lastError, &m_warnings)) {
+        // Present and refused.  The caller must not overwrite this.
         m_loaded = false;
-        return false;
+        return LoadResult::Unusable;
     }
 
     m_document = doc;
     m_loaded   = true;
     m_dirty    = false;
     emit documentChanged();
-    return true;
+    return LoadResult::Loaded;
 }
 
 bool WorkspaceStore::loadOrMigrate(const QStringList& knownAppletIds,
                                    const QStringList& panIds,
                                    bool* migrated)
 {
-    if (load()) {
-        if (migrated) {
-            *migrated = false;
-        }
-        return true;
+    if (migrated) {
+        *migrated = false;
     }
 
-    // Nothing usable stored.  Build Classic from whatever the legacy keys
-    // say and write it once.  The legacy keys are left in place: their
+    const LoadResult result = loadWithStatus();
+    if (result == LoadResult::Loaded) {
+        return true;
+    }
+    if (result == LoadResult::Unusable) {
+        // Present but refused — a newer schema, or damage this build cannot
+        // read.  Writing Classic here would destroy it, and for the
+        // newer-schema case that is precisely the loss WorkspaceDocument's
+        // guard exists to prevent: downgrade once and every workspace the
+        // newer build held would be gone (PR #4900 review).  Leave the
+        // document alone and report; the caller decides what to tell the
+        // operator.
+        return false;
+    }
+
+    // The key is genuinely absent.  Build Classic from whatever the legacy
+    // keys say and write it once.  The legacy keys are left in place: their
     // current owners keep writing them for a release, so a downgrade still
     // finds the state it expects.
     const LegacyLayoutState legacy = readLegacyLayoutState(knownAppletIds);
-    m_document = buildClassicDocument(legacy, panIds);
-    m_loaded   = true;
-    m_dirty    = true;
+    m_document  = buildClassicDocument(legacy, panIds);
+    m_loaded    = true;
+    m_dirty     = true;
+    m_lastError.clear();
 
     emit documentChanged();
     flush();
@@ -130,9 +150,15 @@ void WorkspaceStore::setRestoring(bool restoring)
     m_restoring = restoring;
     if (restoring) {
         m_debounce->stop();
+    } else if (m_dirty) {
+        // Deliberately no flush on the way out: restore leaves the store
+        // exactly as dirty as it found it.  But the debounce HAS to resume —
+        // touch() starts no timer while suppressed, so without this a change
+        // made during the replay would wait for the next unrelated touch(),
+        // an explicit flush(), or the destructor, and a crash skips the
+        // destructor entirely (PR #4900 review).
+        m_debounce->start(m_debounceMs);
     }
-    // Deliberately no flush on the way out: restore must leave the store
-    // exactly as clean — or as dirty — as it found it.
 }
 
 void WorkspaceStore::setDebounceMs(int ms)

--- a/src/gui/workspace/WorkspaceStore.cpp
+++ b/src/gui/workspace/WorkspaceStore.cpp
@@ -23,7 +23,7 @@ WorkspaceStore::~WorkspaceStore()
     // A pending debounce at teardown is unsaved operator work.  Auto-commit
     // promises there is no such thing, so the last thing this object does is
     // make that true.
-    if (m_dirty && !m_restoring) {
+    if (m_dirty && !m_restoring && !m_writeBlocked) {
         writeNow();
     }
 }
@@ -37,21 +37,37 @@ WorkspaceStore::LoadResult WorkspaceStore::loadWithStatus()
         AppSettings::instance().stationValue(kSettingsKey).toString().toUtf8();
 
     if (blob.trimmed().isEmpty()) {
-        m_loaded    = false;
-        m_lastError = QStringLiteral("no workspace document stored");
+        m_loaded       = false;
+        m_writeBlocked = false;
+        m_lastError    = QStringLiteral("no workspace document stored");
         return LoadResult::Absent;
     }
 
     WorkspaceDocument doc;
     if (!WorkspaceDocument::fromStoredJson(blob, &doc, &m_lastError, &m_warnings)) {
-        // Present and refused.  The caller must not overwrite this.
-        m_loaded = false;
+        // Present and refused.  Arm the write block so nothing downstream can
+        // commit over a document this build could not read — including one a
+        // newer build wrote.
+        m_loaded       = false;
+        m_writeBlocked = true;
         return LoadResult::Unusable;
     }
 
-    m_document = doc;
-    m_loaded   = true;
-    m_dirty    = false;
+    if (doc.isEmpty()) {
+        // Structurally valid but carrying no workspace: equivalent to nothing
+        // stored, and there is no operator state in it to lose.  Reporting it
+        // as Loaded would leave loadOrMigrate() succeeding with no workspace
+        // at all and never migrating (PR #4900 review, L4).
+        m_loaded       = false;
+        m_writeBlocked = false;
+        m_lastError    = QStringLiteral("stored document contains no workspaces");
+        return LoadResult::Absent;
+    }
+
+    m_document     = doc;
+    m_loaded       = true;
+    m_dirty        = false;
+    m_writeBlocked = false;
     emit documentChanged();
     return LoadResult::Loaded;
 }
@@ -98,6 +114,11 @@ bool WorkspaceStore::loadOrMigrate(const QStringList& knownAppletIds,
     return true;
 }
 
+void WorkspaceStore::allowOverwrite()
+{
+    m_writeBlocked = false;
+}
+
 void WorkspaceStore::setDocument(const WorkspaceDocument& doc)
 {
     m_document = doc;
@@ -115,19 +136,35 @@ void WorkspaceStore::touch()
     m_debounce->start(m_debounceMs);
 }
 
-bool WorkspaceStore::flush()
+WorkspaceStore::FlushResult WorkspaceStore::flushWithStatus()
 {
     m_debounce->stop();
 
-    if (m_restoring || !m_dirty) {
-        return false;
+    // Order matters: "suppressed" outranks "clean" so a caller cannot read a
+    // refusal as nothing-to-do (PR #4900 review, L5).
+    if (m_restoring || m_writeBlocked) {
+        return FlushResult::Suppressed;
+    }
+    if (!m_dirty) {
+        return FlushResult::Clean;
     }
     return writeNow();
 }
 
-bool WorkspaceStore::writeNow()
+WorkspaceStore::FlushResult WorkspaceStore::writeNow()
 {
     auto& settings = AppSettings::instance();
+
+    // AppSettings::save() returns void and silently declines in a read-only
+    // session (a settings DB written by a newer build), during a
+    // reset-triggered shutdown, and before load().  Clearing m_dirty and
+    // reporting success there would make this store's durability promise
+    // false — and m_dirty/flushed() are what phase 3 will build on, so the
+    // lie would propagate (PR #4900 review, M1).
+    if (!settings.storeWritable()) {
+        m_lastError = QStringLiteral("settings store is not accepting writes");
+        return FlushResult::Failed;   // stays dirty, for a later retry
+    }
 
     // One whole-document write IS the atomic update (Principle XIV): there is
     // no partial state a crash between two calls could leave behind, because
@@ -141,8 +178,9 @@ bool WorkspaceStore::writeNow()
     settings.save();
 
     m_dirty = false;
+    m_lastError.clear();
     emit flushed();
-    return true;
+    return FlushResult::Wrote;
 }
 
 void WorkspaceStore::setRestoring(bool restoring)

--- a/src/gui/workspace/WorkspaceStore.h
+++ b/src/gui/workspace/WorkspaceStore.h
@@ -1,0 +1,117 @@
+#pragma once
+
+// Persistence for the workspace document (RFC #4887, phase 2).
+//
+// One key, one writer, one atomic whole-document write — Principle V and
+// Principle XIV.  The document is station-scoped rather than radio-scoped: a
+// workspace profile is the operator's arrangement, not a property of a radio.
+// An operator who wants a different layout per rig makes a workspace per rig
+// and binds it, which is a choice they get to make instead of one the storage
+// layer makes for them.
+//
+// ── The auto-commit contract (RFC decision 7) ────────────────────────────
+//
+// There is no "save layout" step: placement changes commit as they happen, so
+// an automatic workspace switch can never discard unsaved work, because there
+// is none.  The cost is write volume — one drag is hundreds of geometry
+// changes and every commit is a whole-document write by construction — so:
+//
+//   * touch() marks the document dirty and (re)starts a debounce timer;
+//   * flush() writes immediately, and is called at the END of a gesture
+//     (drag/resize release, add/remove/raise, workspace switch, shutdown);
+//   * flushes are SUPPRESSED while restoring, because replaying saved state
+//     would otherwise re-write exactly what it is reading.
+//
+// That is the contract ContainerManager already established for the same
+// reason (ContainerManager.h:142-144, #4427); this follows it rather than
+// inventing a second discipline for the same problem.
+
+#include "gui/workspace/WorkspaceDocument.h"
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+
+class QTimer;
+
+namespace AetherSDR {
+
+class WorkspaceStore : public QObject {
+    Q_OBJECT
+
+public:
+    // The AppSettings station key holding the whole document.
+    static const QString kSettingsKey;
+
+    // Debounce window for touch().  Long enough that a drag coalesces into
+    // one write, short enough that an abnormal exit loses at most this much.
+    static constexpr int kDefaultDebounceMs = 750;
+
+    explicit WorkspaceStore(QObject* parent = nullptr);
+    ~WorkspaceStore() override;
+
+    // ── Loading ──────────────────────────────────────────────────────────
+    //
+    // Reads the stored document.  Returns false when there is nothing stored
+    // or what is stored cannot be used; `error` says which, and parse
+    // warnings (repaired damage) come back through warnings().
+    bool load();
+
+    // Reads the stored document, and if there is none, builds "Classic" from
+    // the legacy keys and writes it.  Returns true when a document is in hand
+    // either way.  `migrated` reports which path was taken.
+    //
+    // NOTE: nothing calls this yet.  Phase 2 ships the migration tested but
+    // not wired — the first caller is phase 3, when there is a canvas to
+    // consume the result.  Running it earlier would write a new key on every
+    // install for a document nothing reads.
+    bool loadOrMigrate(const QStringList& knownAppletIds,
+                       const QStringList& panIds,
+                       bool* migrated = nullptr);
+
+    // True when the store held a usable document at the last load.
+    bool isLoaded() const { return m_loaded; }
+    QString lastError() const { return m_lastError; }
+    QStringList warnings() const { return m_warnings; }
+
+    // ── The document ─────────────────────────────────────────────────────
+    const WorkspaceDocument& document() const { return m_document; }
+
+    // Replace the document and mark it dirty.  Does not write on its own —
+    // the caller ends the gesture with flush(), or lets the debounce fire.
+    void setDocument(const WorkspaceDocument& doc);
+
+    // ── Auto-commit ──────────────────────────────────────────────────────
+    void touch();                 // dirty + (re)start the debounce
+    bool flush();                 // write now; false if suppressed or clean
+    bool isDirty() const { return m_dirty; }
+
+    // Suppress flushes while saved state is being replayed.  Setting it back
+    // to false does NOT flush: restore must leave the store exactly as clean
+    // as it found it.
+    void setRestoring(bool restoring);
+    bool isRestoring() const { return m_restoring; }
+
+    int debounceMs() const { return m_debounceMs; }
+    void setDebounceMs(int ms);
+
+signals:
+    // Emitted after a write actually reached AppSettings.
+    void flushed();
+    // Emitted when the in-memory document is replaced (load, migrate, set).
+    void documentChanged();
+
+private:
+    bool writeNow();
+
+    WorkspaceDocument m_document;
+    QTimer*     m_debounce{nullptr};
+    QString     m_lastError;
+    QStringList m_warnings;
+    int         m_debounceMs{kDefaultDebounceMs};
+    bool        m_dirty{false};
+    bool        m_restoring{false};
+    bool        m_loaded{false};
+};
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/WorkspaceStore.h
+++ b/src/gui/workspace/WorkspaceStore.h
@@ -98,9 +98,54 @@ public:
     // the caller ends the gesture with flush(), or lets the debounce fire.
     void setDocument(const WorkspaceDocument& doc);
 
+    // ── Overwrite protection ─────────────────────────────────────────────
+    //
+    // Refusing to PARSE a newer document is only half a guard: something has
+    // to refuse to WRITE over it too.  Without this, one setDocument() or
+    // touch() from phase 3 — a canvas resize while the error is still on
+    // screen is enough — would commit an empty default document over the row
+    // this build could not read, which is the exact loss the read-side guard
+    // exists to prevent (PR #4900 review, H1).
+    //
+    // So a LoadResult::Unusable arms a write block, and only an explicit
+    // caller decision clears it.  This mirrors the contract on
+    // AppSettings::setRadioFeature(), whose write-side guard must judge the
+    // row it is about to overwrite (AppSettings.h:71-74, from the #4614
+    // review) — this store implemented the read side of that and owed the
+    // other half.
+    bool isWriteBlocked() const { return m_writeBlocked; }
+
+    // Deliberately discard the unreadable stored document and allow writes
+    // again.  For a caller that has told the operator what is about to happen
+    // and had it confirmed — never a default, and never automatic.
+    void allowOverwrite();
+
     // ── Auto-commit ──────────────────────────────────────────────────────
+    //
+    // Write volume, concretely: a drag emits a placement change per mouse
+    // move — order 100/s — and every commit is a whole-document write by
+    // construction (Principle XIV).  The debounce is what makes that
+    // sustainable against a SQLite store: at kDefaultDebounceMs a continuous
+    // drag costs at most ~1.3 writes/s regardless of how long it lasts, and a
+    // gesture that ends costs exactly one.  A document with 8 pans and 26
+    // applets serialises to a few KB, so the worst case is a few KB/s during
+    // sustained dragging and nothing at rest.
     void touch();                 // dirty + (re)start the debounce
-    bool flush();                 // write now; false if suppressed or clean
+
+    enum class FlushResult {
+        Wrote,        // committed to AppSettings
+        Clean,        // nothing pending
+        Suppressed,   // restoring, or the write block is armed
+        Failed,       // the settings store refused the write
+    };
+
+    // Write now, reporting which of the four happened.  Callers that only
+    // care whether a write landed can use flush().
+    FlushResult flushWithStatus();
+
+    // True only for FlushResult::Wrote.
+    bool flush() { return flushWithStatus() == FlushResult::Wrote; }
+
     bool isDirty() const { return m_dirty; }
 
     // Suppress flushes while saved state is being replayed.  Setting it back
@@ -119,7 +164,7 @@ signals:
     void documentChanged();
 
 private:
-    bool writeNow();
+    FlushResult writeNow();
 
     WorkspaceDocument m_document;
     QTimer*     m_debounce{nullptr};
@@ -129,6 +174,7 @@ private:
     bool        m_dirty{false};
     bool        m_restoring{false};
     bool        m_loaded{false};
+    bool        m_writeBlocked{false};
 };
 
 }  // namespace AetherSDR

--- a/src/gui/workspace/WorkspaceStore.h
+++ b/src/gui/workspace/WorkspaceStore.h
@@ -52,14 +52,31 @@ public:
 
     // ── Loading ──────────────────────────────────────────────────────────
     //
-    // Reads the stored document.  Returns false when there is nothing stored
-    // or what is stored cannot be used; `error` says which, and parse
-    // warnings (repaired damage) come back through warnings().
-    bool load();
+    // Why this is three outcomes and not a bool: "nothing stored" and "stored
+    // but unusable" must never be confused.  Migrating over the second one
+    // would rewrite a document this build refused to parse — including one a
+    // NEWER build wrote — which turns the schema guard into a data-loss path
+    // on a downgrade (PR #4900 review).
+    enum class LoadResult {
+        Loaded,     // a usable document is in hand
+        Absent,     // the key is genuinely empty — safe to migrate into
+        Unusable,   // present but refused: newer schema, corrupt, truncated
+    };
 
-    // Reads the stored document, and if there is none, builds "Classic" from
-    // the legacy keys and writes it.  Returns true when a document is in hand
-    // either way.  `migrated` reports which path was taken.
+    // Reads the stored document.  `error` says why on a non-Loaded result,
+    // and parse warnings (repaired damage) come back through warnings().
+    LoadResult loadWithStatus();
+
+    // Convenience wrapper: true only for LoadResult::Loaded.
+    bool load() { return loadWithStatus() == LoadResult::Loaded; }
+
+    // Reads the stored document, and ONLY IF THE KEY IS ABSENT builds
+    // "Classic" from the legacy keys and writes it.
+    //
+    // A present-but-unusable document is left exactly as it is: this returns
+    // false with lastError() set and writes nothing, so the newer document
+    // survives for the build that understands it.  Phase 3 surfaces that
+    // rather than silently starting from Classic.
     //
     // NOTE: nothing calls this yet.  Phase 2 ships the migration tested but
     // not wired — the first caller is phase 3, when there is a canvas to

--- a/tests/workspace_canvas_widget_test.cpp
+++ b/tests/workspace_canvas_widget_test.cpp
@@ -17,6 +17,8 @@
 #include <QApplication>
 #include <QEvent>
 #include <QPointer>
+#include <QHash>
+#include <QMouseEvent>
 #include <QRect>
 #include <QSignalSpy>
 #include <QStringList>
@@ -273,6 +275,97 @@ int main(int argc, char** argv)
         delete taken;
         report("destroying a taken widget does not evict the id's new owner",
                canvas.contains("bystander"));
+    }
+
+    // ── A press raises, but a press on the frontmost is not an edit ──────
+    //
+    // eventFilter() runs bringItemToFront() on every press. Under auto-commit
+    // every stacking notification is a whole-document write, so clicking the
+    // item that is already on top must be silent — the same rule resizeEvent()
+    // follows for a resize that clamps nothing.
+    {
+        WorkspaceCanvas canvas;
+        canvas.resize(1000, 1000);
+        canvas.show();
+
+        auto* under = new QWidget;
+        auto* over  = new QWidget;
+        canvas.addItem("under", under, NormRect{0.1, 0.1, 0.4, 0.4});
+        canvas.addItem("over",  over,  NormRect{0.5, 0.5, 0.4, 0.4});
+
+        QSignalSpy stackSpy(&canvas, &WorkspaceCanvas::itemStackingChanged);
+
+        const auto press = [](QWidget* w) {
+            QMouseEvent ev(QEvent::MouseButtonPress, QPointF(5, 5),
+                           w->mapToGlobal(QPointF(5, 5)),
+                           Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+            QCoreApplication::sendEvent(w, &ev);
+        };
+
+        // "over" is already frontmost — pressing it changes nothing.
+        press(over);
+        report("pressing the frontmost item emits nothing", stackSpy.count() == 0);
+        report("...and it is still frontmost",
+               childIndex(&canvas, under) < childIndex(&canvas, over));
+
+        // Pressing the one underneath is a real change.
+        press(under);
+        report("pressing a lower item raises it", stackSpy.count() == 1);
+        report("...and Qt stacking followed",
+               childIndex(&canvas, over) < childIndex(&canvas, under));
+
+        // Pressing it again is now a no-op.
+        press(under);
+        report("pressing it again emits nothing", stackSpy.count() == 1);
+    }
+
+    // ── Restoring a saved surface through the widget ─────────────────────
+    //
+    // addItem() ignores a caller's z by design, and this is the only public
+    // way onto a canvas — so without restoreItems() a phase-3 restore would
+    // scramble stacking unless it happened to feed items in ascending z.
+    {
+        WorkspaceCanvas canvas;
+        canvas.resize(1000, 1000);
+        canvas.show();
+
+        // Saved order deliberately disagrees with array order.
+        AetherSDR::CanvasItem a;
+        a.id   = QStringLiteral("a");
+        a.rect = NormRect{0.0, 0.0, 0.3, 0.3};
+        a.z    = 2;
+        AetherSDR::CanvasItem b;
+        b.id   = QStringLiteral("b");
+        b.rect = NormRect{0.1, 0.1, 0.3, 0.3};
+        b.z    = 0;
+        AetherSDR::CanvasItem c;
+        c.id   = QStringLiteral("c");
+        c.rect = NormRect{0.2, 0.2, 0.3, 0.3};
+        c.z    = 1;
+
+        auto* wa = new QWidget;
+        auto* wb = new QWidget;
+        auto* wc = new QWidget;
+        const QHash<QString, QWidget*> widgets{{"a", wa}, {"b", wb}, {"c", wc}};
+
+        report("every item with a widget is placed",
+               canvas.restoreItems({a, b, c}, widgets) == 3);
+        report("the saved stacking is restored, not array order",
+               canvas.layout().zOf("b") == 0 && canvas.layout().zOf("c") == 1
+                   && canvas.layout().zOf("a") == 2);
+        report("...and real Qt stacking matches",
+               childIndex(&canvas, wb) < childIndex(&canvas, wc)
+                   && childIndex(&canvas, wc) < childIndex(&canvas, wa));
+        report("geometry came from the stored rects",
+               wa->geometry() == QRect(0, 0, 300, 300));
+
+        // An item with no widget is skipped rather than guessed at.
+        AetherSDR::CanvasItem orphan;
+        orphan.id   = QStringLiteral("ghost");
+        orphan.rect = NormRect{0.5, 0.5, 0.2, 0.2};
+        report("an item with no widget is skipped",
+               canvas.restoreItems({orphan}, {}) == 0
+                   && !canvas.contains("ghost"));
     }
 
     std::printf("\n%s\n", g_failures == 0 ? "All checks passed." : "FAILURES present.");

--- a/tests/workspace_canvas_widget_test.cpp
+++ b/tests/workspace_canvas_widget_test.cpp
@@ -18,6 +18,7 @@
 #include <QEvent>
 #include <QPointer>
 #include <QRect>
+#include <QSignalSpy>
 #include <QStringList>
 #include <QWidget>
 
@@ -231,6 +232,47 @@ int main(int argc, char** argv)
         report("z closes up after a removal",
                canvas.layout().zOf("a") == 0 && canvas.layout().zOf("c") == 1);
         report("stacking survives the removal", childIndex(&canvas, a) < childIndex(&canvas, c));
+    }
+
+    // ── A widget destroyed behind the canvas's back leaves no ghost ──────
+    //
+    // Phase 3 moves applets between canvases and containers, which is exactly
+    // where a widget can die out from under the model.  Without the
+    // destroyed-watch the layout entry survives: contains() still reports it,
+    // hitTest() still returns its id over dead space, and addItem() with that
+    // id fails forever.
+    {
+        WorkspaceCanvas canvas;
+        canvas.resize(1000, 1000);
+        canvas.show();
+
+        auto* victim = new QWidget;
+        canvas.addItem("victim", victim, NormRect{0.0, 0.0, 0.4, 0.4});
+        canvas.addItem("bystander", new QWidget, NormRect{0.5, 0.5, 0.4, 0.4});
+
+        QSignalSpy removedSpy(&canvas, &WorkspaceCanvas::itemRemoved);
+
+        delete victim;   // not through removeItem() / takeItem()
+
+        report("the model drops an externally destroyed item",
+               !canvas.contains("victim"));
+        report("...and the count follows",  canvas.itemCount() == 1);
+        report("...and it is announced",    removedSpy.count() == 1);
+        report("...and it no longer answers hit tests",
+               canvas.hitTest(QPoint(100, 100)).isEmpty());
+        report("...leaving the other item alone", canvas.contains("bystander"));
+
+        // The id is reusable, which it would not be if the entry had survived.
+        report("the freed id can be used again",
+               canvas.addItem("victim", new QWidget, NormRect{0.0, 0.0, 0.3, 0.3}));
+
+        // A widget handed back by takeItem() is no longer watched: destroying
+        // it must not evict whatever holds its old id now.
+        QWidget* taken = canvas.takeItem("bystander");
+        canvas.addItem("bystander", new QWidget, NormRect{0.6, 0.6, 0.3, 0.3});
+        delete taken;
+        report("destroying a taken widget does not evict the id's new owner",
+               canvas.contains("bystander"));
     }
 
     std::printf("\n%s\n", g_failures == 0 ? "All checks passed." : "FAILURES present.");

--- a/tests/workspace_canvas_widget_test.cpp
+++ b/tests/workspace_canvas_widget_test.cpp
@@ -1,0 +1,238 @@
+// Offscreen tests for WorkspaceCanvas — the thin widget half of RFC #4887
+// phase 1.
+//
+// CanvasLayout's rules are pinned in workspace_layout_test; what is checked
+// here is only that the widget faithfully applies them to real geometry and
+// real Qt stacking.  The two that matter most:
+//
+//   * takeItem() must hand a widget back ALIVE.  It is the call phase 3 needs
+//     to move an applet between a canvas and a container, and a canvas that
+//     destroys widgets on removal cannot be part of that path.
+//   * a canvas resize must announce only the items that actually moved, or
+//     phase 2's auto-commit would write the workspace document on every frame
+//     of a window drag.
+
+#include "gui/workspace/WorkspaceCanvas.h"
+
+#include <QApplication>
+#include <QEvent>
+#include <QPointer>
+#include <QRect>
+#include <QStringList>
+#include <QWidget>
+
+#include <cstdio>
+
+using AetherSDR::NormRect;
+using AetherSDR::WorkspaceCanvas;
+
+namespace {
+
+int g_failures = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) {
+        ++g_failures;
+    }
+}
+
+// Position of a child in its parent's child list.  Qt's stacking order IS
+// this order — raise() moves a widget to the end — so it is how "on top" is
+// observed without a screen.
+int childIndex(const QWidget* parent, QWidget* child)
+{
+    return parent->children().indexOf(child);
+}
+
+void flushDeferredDeletes()
+{
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+}
+
+// Resize and let the resize event actually land.  Qt may post rather than
+// send QResizeEvent depending on platform and visibility, and the whole point
+// of the resize cases is what the event handler does.
+void resizeAndSettle(QWidget* w, int width, int height)
+{
+    w->resize(width, height);
+    QCoreApplication::processEvents();
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    QApplication app(argc, argv);
+
+    // ── Placement ────────────────────────────────────────────────────────
+    {
+        WorkspaceCanvas canvas;
+        canvas.resize(1000, 800);
+        canvas.show();
+
+        auto* pan = new QWidget;
+        report("an item can be placed",
+               canvas.addItem("pan", pan, NormRect{0.0, 0.0, 0.72, 0.55}));
+        report("the canvas adopted the widget", pan->parentWidget() == &canvas);
+        report("the widget got the mapped pixels",
+               pan->geometry() == QRect(0, 0, 720, 440));
+        report("itemWidget() finds it",  canvas.itemWidget("pan") == pan);
+        report("contains() finds it",    canvas.contains("pan"));
+        report("itemCount() counts it",  canvas.itemCount() == 1);
+
+        // A refused add must leave the caller's widget completely alone —
+        // not reparent it, and above all not delete it.
+        auto* orphan = new QWidget;
+        report("a duplicate id is refused",
+               !canvas.addItem("pan", orphan, NormRect{0.1, 0.1, 0.2, 0.2}));
+        report("the refused widget is untouched",
+               orphan->parentWidget() == nullptr);
+        report("a null widget is refused",
+               !canvas.addItem("other", nullptr, NormRect{0.1, 0.1, 0.2, 0.2}));
+        report("an empty id is refused",
+               !canvas.addItem("", orphan, NormRect{0.1, 0.1, 0.2, 0.2}));
+        delete orphan;
+
+        // Placement is clamped by the model, so what is read back is what is
+        // stored, not what was asked for.
+        canvas.setItemRect("pan", NormRect{0.9, 0.9, 0.5, 0.5});
+        report("setItemRect clamps and applies",
+               canvas.itemRect("pan") == NormRect{0.5, 0.5, 0.5, 0.5}
+                   && pan->geometry() == QRect(500, 400, 500, 400));
+        report("setItemRect on an unknown id fails",
+               !canvas.setItemRect("nope", NormRect{0.0, 0.0, 0.2, 0.2}));
+    }
+
+    // ── Resize ───────────────────────────────────────────────────────────
+    {
+        WorkspaceCanvas canvas;
+        canvas.resize(1000, 1000);
+        canvas.show();
+
+        canvas.addItem("a", new QWidget, NormRect{0.0, 0.0, 0.5, 0.5});
+        canvas.addItem("b", new QWidget, NormRect{0.5, 0.5, 0.5, 0.5});
+
+        int rectChanges = 0;
+        QObject::connect(&canvas, &WorkspaceCanvas::itemRectChanged,
+                         [&rectChanges](const QString&, const NormRect&) {
+                             ++rectChanges;
+                         });
+
+        resizeAndSettle(&canvas, 400, 200);
+        report("children follow the canvas down",
+               canvas.itemWidget("a")->geometry() == QRect(0, 0, 200, 100)
+                   && canvas.itemWidget("b")->geometry() == QRect(200, 100, 200, 100));
+
+        resizeAndSettle(&canvas, 1920, 1080);
+        report("children follow the canvas back up",
+               canvas.itemWidget("a")->geometry() == QRect(0, 0, 960, 540)
+                   && canvas.itemWidget("b")->geometry() == QRect(960, 540, 960, 540));
+
+        // Both items fit at every size used above, so nothing was clamped and
+        // nothing should have been announced as an edit.
+        report("a resize that clamps nothing announces nothing",
+               rectChanges == 0);
+
+        // Shrinking below the default minimum DOES move things, and must say so.
+        resizeAndSettle(&canvas, 100, 100);
+        report("a resize that forces a clamp announces it", rectChanges > 0);
+    }
+
+    // ── Stacking ─────────────────────────────────────────────────────────
+    {
+        WorkspaceCanvas canvas;
+        canvas.resize(1000, 1000);
+        canvas.show();
+
+        auto* under = new QWidget;
+        auto* over  = new QWidget;
+        canvas.addItem("under", under, NormRect{0.1, 0.1, 0.4, 0.4});
+        canvas.addItem("over",  over,  NormRect{0.3, 0.3, 0.4, 0.4});
+
+        report("the later item stacks above",
+               childIndex(&canvas, under) < childIndex(&canvas, over));
+
+        report("bringItemToFront reorders real Qt stacking",
+               canvas.bringItemToFront("under")
+                   && childIndex(&canvas, over) < childIndex(&canvas, under));
+
+        report("sendItemToBack reorders it back",
+               canvas.sendItemToBack("under")
+                   && childIndex(&canvas, under) < childIndex(&canvas, over));
+
+        report("stacking an unknown id fails",
+               !canvas.raiseItem("nope") && !canvas.bringItemToFront("nope"));
+    }
+
+    // ── Hit testing, in widget coordinates ───────────────────────────────
+    {
+        WorkspaceCanvas canvas;
+        canvas.resize(1000, 1000);
+        canvas.show();
+
+        canvas.addItem("under", new QWidget, NormRect{0.1, 0.1, 0.4, 0.4});
+        canvas.addItem("over",  new QWidget, NormRect{0.3, 0.3, 0.4, 0.4});
+
+        report("a pixel over one item resolves to it",
+               canvas.hitTest(QPoint(150, 150)) == "under");
+        report("a pixel in the overlap resolves to the topmost",
+               canvas.hitTest(QPoint(350, 350)) == "over");
+        report("a pixel over bare canvas resolves to nothing",
+               canvas.hitTest(QPoint(950, 950)).isEmpty());
+    }
+
+    // ── Removal: take keeps, remove destroys ─────────────────────────────
+    {
+        WorkspaceCanvas canvas;
+        canvas.resize(1000, 1000);
+        canvas.show();
+
+        auto* kept = new QWidget;
+        canvas.addItem("kept", kept, NormRect{0.0, 0.0, 0.3, 0.3});
+
+        QPointer<QWidget> keptGuard(kept);
+        QWidget* handedBack = canvas.takeItem("kept");
+        report("takeItem hands the same widget back", handedBack == kept);
+        report("takeItem keeps it alive",             !keptGuard.isNull());
+        report("takeItem detaches it",                kept->parentWidget() == nullptr);
+        report("takeItem hides it",                   !kept->isVisible());
+        report("takeItem drops it from the layout",   !canvas.contains("kept"));
+        report("takeItem on an unknown id returns null",
+               canvas.takeItem("nope") == nullptr);
+        delete kept;
+
+        auto* doomed = new QWidget;
+        canvas.addItem("doomed", doomed, NormRect{0.0, 0.0, 0.3, 0.3});
+        QPointer<QWidget> doomedGuard(doomed);
+        report("removeItem reports success",  canvas.removeItem("doomed"));
+        report("removeItem drops it from the layout", !canvas.contains("doomed"));
+        flushDeferredDeletes();
+        report("removeItem destroys the widget", doomedGuard.isNull());
+        report("removeItem on an unknown id fails", !canvas.removeItem("nope"));
+    }
+
+    // ── Removal renumbers z, and the widget stacking follows ─────────────
+    {
+        WorkspaceCanvas canvas;
+        canvas.resize(1000, 1000);
+        canvas.show();
+
+        auto* a = new QWidget;
+        auto* c = new QWidget;
+        canvas.addItem("a", a,           NormRect{0.0, 0.0, 0.2, 0.2});
+        canvas.addItem("b", new QWidget, NormRect{0.2, 0.2, 0.2, 0.2});
+        canvas.addItem("c", c,           NormRect{0.4, 0.4, 0.2, 0.2});
+
+        canvas.removeItem("b");
+        flushDeferredDeletes();
+
+        report("z closes up after a removal",
+               canvas.layout().zOf("a") == 0 && canvas.layout().zOf("c") == 1);
+        report("stacking survives the removal", childIndex(&canvas, a) < childIndex(&canvas, c));
+    }
+
+    std::printf("\n%s\n", g_failures == 0 ? "All checks passed." : "FAILURES present.");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/workspace_document_test.cpp
+++ b/tests/workspace_document_test.cpp
@@ -1,0 +1,290 @@
+// Unit tests for the workspace document schema (RFC #4887, phase 2).
+//
+// Two things are being defended here.
+//
+// The SCHEMA GUARD: a document written by a newer build must be refused, not
+// re-written from this build's understanding — doing so would silently
+// destroy whatever the newer build knew that this one does not.  AppSettings
+// takes the same stance for the same reason.
+//
+// The BOUNDARY (Principle VII): the settings store is a file a user can edit,
+// a backup can restore, and a partial write can truncate.  Damage that can be
+// repaired is repaired and REPORTED; damage that cannot be is refused.  What
+// must never happen is a half-understood document being written back.
+//
+// Pure logic, no widgets, no settings store.
+
+#include "gui/workspace/WorkspaceDocument.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include <cstdio>
+
+using AetherSDR::CanvasItem;
+using AetherSDR::NormRect;
+using AetherSDR::Workspace;
+using AetherSDR::WorkspaceDocument;
+using AetherSDR::WorkspaceSurface;
+
+namespace {
+
+int g_failures = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) {
+        ++g_failures;
+    }
+}
+
+CanvasItem item(const QString& id, const NormRect& rect, int z)
+{
+    CanvasItem it;
+    it.id   = id;
+    it.rect = rect;
+    it.z    = z;
+    return it;
+}
+
+// A document with everything populated, so the round trip has something to
+// lose if a field is forgotten.
+WorkspaceDocument sample()
+{
+    WorkspaceSurface main;
+    main.id = WorkspaceSurface::kMainId;
+    main.items.append(item(QStringLiteral("pan:0x40000000"),
+                           NormRect{0.0, 0.0, 0.72, 0.55}, 0));
+    main.items.last().contentType = QStringLiteral("panadapter");
+    main.items.append(item(QStringLiteral("applet:RX"),
+                           NormRect{0.72, 0.0, 0.28, 0.40}, 1));
+    main.items.last().collapsed = true;
+
+    WorkspaceSurface aux;
+    aux.id             = QStringLiteral("canvas2");
+    aux.label          = QStringLiteral("Right monitor");
+    aux.windowGeometry = QByteArray("not-a-real-blob-but-round-trips");
+    aux.items.append(item(QStringLiteral("applet:WAVE"),
+                          NormRect{0.0, 0.0, 1.0, 0.5}, 0));
+
+    Workspace contest;
+    contest.id    = QStringLiteral("contest");
+    contest.label = QStringLiteral("Contest");
+    contest.surfaces = {main, aux};
+
+    Workspace casual;
+    casual.id    = QStringLiteral("casual");
+    casual.label = QStringLiteral("Casual");
+    WorkspaceSurface casualMain;
+    casualMain.id = WorkspaceSurface::kMainId;
+    casual.surfaces.append(casualMain);
+
+    WorkspaceDocument doc;
+    doc.workspaces      = {contest, casual};
+    doc.activeWorkspace = QStringLiteral("contest");
+    doc.bindings.insert(QStringLiteral("Contest CW"), QStringLiteral("contest"));
+    doc.bindings.insert(QStringLiteral("Ragchew"),    QStringLiteral("casual"));
+    return doc;
+}
+
+QJsonObject minimalRoot()
+{
+    QJsonObject ws;
+    ws[QStringLiteral("id")] = QStringLiteral("classic");
+    ws[QStringLiteral("surfaces")] = QJsonArray{};
+
+    QJsonObject root;
+    root[QStringLiteral("version")]    = WorkspaceDocument::kSchemaVersion;
+    root[QStringLiteral("workspaces")] = QJsonArray{ws};
+    return root;
+}
+
+}  // namespace
+
+int main()
+{
+    // ── Round trip ───────────────────────────────────────────────────────
+    {
+        const WorkspaceDocument original = sample();
+
+        WorkspaceDocument parsed;
+        QString error;
+        QStringList warnings;
+        const bool ok = WorkspaceDocument::fromStoredJson(original.toStoredJson(),
+                                                          &parsed, &error, &warnings);
+        report("a written document parses back", ok);
+        report("a clean round trip warns about nothing", warnings.isEmpty());
+
+        report("workspace order survives",
+               parsed.workspaceIds() == QStringList({"contest", "casual"}));
+        report("the active workspace survives",
+               parsed.activeWorkspace == QStringLiteral("contest"));
+        report("labels survive",
+               parsed.workspace("contest")->label == QStringLiteral("Contest"));
+        report("bindings survive",
+               parsed.bindings.value("Contest CW") == QStringLiteral("contest")
+                   && parsed.bindings.value("Ragchew") == QStringLiteral("casual"));
+
+        const Workspace* contest = parsed.workspace("contest");
+        report("surfaces survive in order",
+               contest->surfaces.size() == 2
+                   && contest->surfaces.at(0).id == WorkspaceSurface::kMainId
+                   && contest->surfaces.at(1).id == QStringLiteral("canvas2"));
+        report("the window geometry hint survives",
+               contest->surfaces.at(1).windowGeometry
+                   == QByteArray("not-a-real-blob-but-round-trips"));
+
+        const CanvasItem& pan = contest->surfaces.at(0).items.at(0);
+        report("item id, rect and z survive",
+               pan.id == QStringLiteral("pan:0x40000000")
+                   && pan.rect == NormRect{0.0, 0.0, 0.72, 0.55}
+                   && pan.z == 0);
+        report("item content type survives",
+               pan.contentType == QStringLiteral("panadapter"));
+        report("item collapsed flag survives",
+               contest->surfaces.at(0).items.at(1).collapsed);
+
+        // minimumSize is content-declared, not operator state, so it is not
+        // persisted and comes back as the default.
+        report("minimum size is not persisted", pan.minimumSize == CanvasItem{}.minimumSize);
+    }
+
+    // ── The schema guard ─────────────────────────────────────────────────
+    {
+        WorkspaceDocument parsed;
+        QString error;
+
+        QJsonObject newer = minimalRoot();
+        newer[QStringLiteral("version")] = WorkspaceDocument::kSchemaVersion + 1;
+        report("a newer schema version is refused",
+               !WorkspaceDocument::fromJson(newer, &parsed, &error));
+        report("...and says why", error.contains(QStringLiteral("newer")));
+
+        QJsonObject noVersion = minimalRoot();
+        noVersion.remove(QStringLiteral("version"));
+        report("a document with no version is refused",
+               !WorkspaceDocument::fromJson(noVersion, &parsed, &error));
+
+        QJsonObject badVersion = minimalRoot();
+        badVersion[QStringLiteral("version")] = 0;
+        report("version zero is refused",
+               !WorkspaceDocument::fromJson(badVersion, &parsed, &error));
+
+        QJsonObject noWorkspaces = minimalRoot();
+        noWorkspaces.remove(QStringLiteral("workspaces"));
+        report("a document with no workspaces array is refused",
+               !WorkspaceDocument::fromJson(noWorkspaces, &parsed, &error));
+
+        report("an empty blob is refused",
+               !WorkspaceDocument::fromStoredJson(QByteArray(), &parsed, &error));
+        report("malformed JSON is refused",
+               !WorkspaceDocument::fromStoredJson(QByteArray("{not json"), &parsed, &error));
+        report("a JSON array root is refused",
+               !WorkspaceDocument::fromStoredJson(QByteArray("[]"), &parsed, &error));
+
+        // A refusal must not leave a half-parsed document behind.
+        WorkspaceDocument untouched = sample();
+        WorkspaceDocument before    = untouched;
+        WorkspaceDocument::fromJson(newer, &untouched, &error);
+        report("a refused parse leaves the target untouched",
+               untouched.workspaceIds() == before.workspaceIds());
+    }
+
+    // ── Repairable damage is repaired, and reported ──────────────────────
+    {
+        QJsonObject itemNoId;
+        itemNoId[QStringLiteral("rect")] = QJsonArray{0.0, 0.0, 0.5, 0.5};
+
+        QJsonObject itemBadRect;
+        itemBadRect[QStringLiteral("id")]   = QStringLiteral("applet:BAD");
+        itemBadRect[QStringLiteral("rect")] = QJsonArray{0.0, 0.0, 0.0, 0.5};  // zero width
+
+        QJsonObject itemShortRect;
+        itemShortRect[QStringLiteral("id")]   = QStringLiteral("applet:SHORT");
+        itemShortRect[QStringLiteral("rect")] = QJsonArray{0.0, 0.0, 0.5};
+
+        QJsonObject itemGood;
+        itemGood[QStringLiteral("id")]   = QStringLiteral("applet:RX");
+        itemGood[QStringLiteral("rect")] = QJsonArray{0.0, 0.0, 0.5, 0.5};
+
+        QJsonObject itemDuplicate = itemGood;
+
+        QJsonObject surface;
+        surface[QStringLiteral("id")] = WorkspaceSurface::kMainId;
+        surface[QStringLiteral("items")] =
+            QJsonArray{itemNoId, itemBadRect, itemShortRect, itemGood, itemDuplicate};
+
+        QJsonObject ws;
+        ws[QStringLiteral("id")]       = QStringLiteral("classic");
+        ws[QStringLiteral("surfaces")] = QJsonArray{surface};
+
+        QJsonObject bindings;
+        bindings[QStringLiteral("Contest CW")] = QStringLiteral("nonexistent");
+
+        QJsonObject root;
+        root[QStringLiteral("version")]         = WorkspaceDocument::kSchemaVersion;
+        root[QStringLiteral("workspaces")]      = QJsonArray{ws};
+        root[QStringLiteral("bindings")]        = bindings;
+        root[QStringLiteral("activeWorkspace")] = QStringLiteral("ghost");
+
+        WorkspaceDocument parsed;
+        QString error;
+        QStringList warnings;
+        report("a damaged but valid document still parses",
+               WorkspaceDocument::fromJson(root, &parsed, &error, &warnings));
+
+        const WorkspaceSurface* main =
+            parsed.workspace("classic")->surface(WorkspaceSurface::kMainId);
+        report("only the sound item survives",
+               main->items.size() == 1
+                   && main->items.at(0).id == QStringLiteral("applet:RX"));
+        report("a binding to a missing workspace is dropped",
+               parsed.bindings.isEmpty());
+        report("an active workspace naming nothing falls back to the first",
+               parsed.activeWorkspace == QStringLiteral("classic"));
+        report("every repair was reported", warnings.size() >= 5);
+
+        // An unbound profile must resolve to nothing, not to a guess:
+        // decision 8 says an unbound recall leaves the workspace alone.
+        report("an unbound radio profile resolves to nothing",
+               parsed.boundWorkspace(QStringLiteral("Contest CW")).isEmpty());
+    }
+
+    // ── A workspace with no main surface gains one ───────────────────────
+    {
+        QJsonObject surface;
+        surface[QStringLiteral("id")]    = QStringLiteral("canvas2");
+        surface[QStringLiteral("items")] = QJsonArray{};
+
+        QJsonObject ws;
+        ws[QStringLiteral("id")]       = QStringLiteral("odd");
+        ws[QStringLiteral("surfaces")] = QJsonArray{surface};
+
+        QJsonObject root;
+        root[QStringLiteral("version")]    = WorkspaceDocument::kSchemaVersion;
+        root[QStringLiteral("workspaces")] = QJsonArray{ws};
+
+        WorkspaceDocument parsed;
+        QStringList warnings;
+        report("a workspace with no main surface still parses",
+               WorkspaceDocument::fromJson(root, &parsed, nullptr, &warnings));
+        report("...and gains an empty main surface",
+               parsed.workspace("odd")->surface(WorkspaceSurface::kMainId) != nullptr);
+        report("...and says so", !warnings.isEmpty());
+    }
+
+    // ── Binding lookup ───────────────────────────────────────────────────
+    {
+        const WorkspaceDocument doc = sample();
+        report("a bound radio profile resolves to its workspace",
+               doc.boundWorkspace(QStringLiteral("Contest CW"))
+                   == QStringLiteral("contest"));
+        report("an unknown radio profile resolves to nothing",
+               doc.boundWorkspace(QStringLiteral("Never Seen")).isEmpty());
+    }
+
+    std::printf("\n%s\n", g_failures == 0 ? "All checks passed." : "FAILURES present.");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/workspace_document_test.cpp
+++ b/tests/workspace_document_test.cpp
@@ -246,6 +246,34 @@ int main()
                parsed.activeWorkspace == QStringLiteral("classic"));
         report("every repair was reported", warnings.size() >= 5);
 
+        // Malformed CONTAINERS are reported too, not just malformed leaves —
+        // the parser claims "repaired and reported", and a silently skipped
+        // surface is the shape most likely to lose an operator's arrangement
+        // without a word (PR #4900 review, L2).
+        QJsonObject badShapes;
+        badShapes[QStringLiteral("version")] = WorkspaceDocument::kSchemaVersion;
+        QJsonObject wsBad;
+        wsBad[QStringLiteral("id")] = QStringLiteral("shapes");
+        wsBad[QStringLiteral("surfaces")] =
+            QJsonArray{QStringLiteral("not an object"), QJsonObject{
+                {QStringLiteral("id"), WorkspaceSurface::kMainId},
+                {QStringLiteral("items"), QJsonArray{QStringLiteral("also not an object")}}}};
+        badShapes[QStringLiteral("workspaces")] = QJsonArray{wsBad};
+
+        WorkspaceDocument shapes;
+        QStringList shapeWarnings;
+        report("a document with malformed containers still parses",
+               WorkspaceDocument::fromJson(badShapes, &shapes, nullptr, &shapeWarnings));
+
+        bool surfaceReported = false;
+        bool itemReported    = false;
+        for (const QString& w : shapeWarnings) {
+            if (w.contains(QStringLiteral("non-object surface"))) surfaceReported = true;
+            if (w.contains(QStringLiteral("non-object item")))    itemReported    = true;
+        }
+        report("a non-object surface is reported", surfaceReported);
+        report("a non-object item is reported",    itemReported);
+
         // An unbound profile must resolve to nothing, not to a guess:
         // decision 8 says an unbound recall leaves the workspace alone.
         report("an unbound radio profile resolves to nothing",

--- a/tests/workspace_document_test.cpp
+++ b/tests/workspace_document_test.cpp
@@ -252,6 +252,56 @@ int main()
                parsed.boundWorkspace(QStringLiteral("Contest CW")).isEmpty());
     }
 
+    // ── A mangled window-geometry hint is dropped and reported ───────────
+    //
+    // The default QByteArray::fromBase64() ignores invalid characters and
+    // returns whatever it managed, so mangled input would become
+    // plausible-looking garbage that QWidget::restoreGeometry() rejects later
+    // without a word. It is a hint either way — the value of catching it is
+    // that it lands in warnings() instead of nowhere.
+    {
+        QJsonObject surface;
+        surface[QStringLiteral("id")]             = QStringLiteral("canvas2");
+        surface[QStringLiteral("items")]          = QJsonArray{};
+        surface[QStringLiteral("windowGeometry")] = QStringLiteral("!!!not base64!!!");
+
+        QJsonObject main;
+        main[QStringLiteral("id")]    = WorkspaceSurface::kMainId;
+        main[QStringLiteral("items")] = QJsonArray{};
+
+        QJsonObject ws;
+        ws[QStringLiteral("id")]       = QStringLiteral("classic");
+        ws[QStringLiteral("surfaces")] = QJsonArray{main, surface};
+
+        QJsonObject root;
+        root[QStringLiteral("version")]    = WorkspaceDocument::kSchemaVersion;
+        root[QStringLiteral("workspaces")] = QJsonArray{ws};
+
+        WorkspaceDocument parsed;
+        QStringList warnings;
+        report("a document with a mangled geometry hint still parses",
+               WorkspaceDocument::fromJson(root, &parsed, nullptr, &warnings));
+
+        const WorkspaceSurface* aux =
+            parsed.workspace("classic")->surface(QStringLiteral("canvas2"));
+        report("the surface survives", aux != nullptr);
+        report("...but the unreadable hint is dropped, not half-decoded",
+               aux && aux->windowGeometry.isEmpty());
+
+        bool reported = false;
+        for (const QString& w : warnings) {
+            if (w.contains(QStringLiteral("geometry"))) {
+                reported = true;
+            }
+        }
+        report("...and the drop is reported", reported);
+
+        // A well-formed hint still round-trips untouched.
+        report("a valid geometry hint survives a round trip",
+               sample().workspace("contest")->surface(QStringLiteral("canvas2"))
+                   != nullptr);
+    }
+
     // ── A workspace with no main surface gains one ───────────────────────
     {
         QJsonObject surface;

--- a/tests/workspace_geometry_test.cpp
+++ b/tests/workspace_geometry_test.cpp
@@ -1,0 +1,222 @@
+// Unit tests for the normalized canvas geometry of RFC #4887 phase 1.
+//
+// The load-bearing cases are 2 and 5.  Case 2 pins the edge-rounding rule:
+// two items sharing a normalized edge must land on the same pixel column at
+// EVERY canvas size, or a tiled arrangement grows hairline seams that move as
+// the window is resized.  Case 5 pins the property the whole RFC rests on —
+// a layout authored on a big display restores in proportion on a small one,
+// which is the thing pixel geometry cannot do.
+//
+// Pure logic, no widgets: this runs headless on all three platforms.
+
+#include "gui/workspace/WorkspaceGeometry.h"
+
+#include <QRect>
+#include <QSize>
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+
+using AetherSDR::NormRect;
+using AetherSDR::clampToCanvas;
+using AetherSDR::fromPixels;
+using AetherSDR::minimumNormSize;
+using AetherSDR::toPixels;
+
+namespace {
+
+int g_failures = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) {
+        ++g_failures;
+    }
+}
+
+bool nearly(double a, double b, double tol = 1e-9)
+{
+    return std::fabs(a - b) <= tol;
+}
+
+}  // namespace
+
+int main()
+{
+    // ── Case 1: the basic mapping ────────────────────────────────────────
+    {
+        const QSize canvas(800, 600);
+
+        report("full-canvas rect maps to the whole canvas",
+               toPixels(NormRect{0.0, 0.0, 1.0, 1.0}, canvas) == QRect(0, 0, 800, 600));
+
+        report("quarter rect maps to the expected pixels",
+               toPixels(NormRect{0.5, 0.5, 0.5, 0.5}, canvas) == QRect(400, 300, 400, 300));
+
+        report("fromPixels inverts toPixels",
+               fromPixels(QRect(400, 300, 400, 300), canvas)
+                   == NormRect{0.5, 0.5, 0.5, 0.5});
+    }
+
+    // ── Case 2: shared edges land on one pixel (the anti-seam rule) ──────
+    //
+    // Odd canvas sizes are where rounding origin+size instead of the edges
+    // goes wrong, so they are the ones tested.
+    {
+        const NormRect left {0.0, 0.0, 0.5, 1.0};
+        const NormRect right{0.5, 0.0, 0.5, 1.0};
+
+        bool adjacentEverywhere = true;
+        bool coversEverywhere   = true;
+        for (int w : {1001, 1023, 777, 1920, 3841}) {
+            const QSize canvas(w, 500);
+            const QRect a = toPixels(left,  canvas);
+            const QRect b = toPixels(right, canvas);
+
+            // No gap and no overlap: b starts exactly where a ends.
+            if (a.x() + a.width() != b.x()) {
+                adjacentEverywhere = false;
+            }
+            // And between them they cover the canvas exactly.
+            if (a.width() + b.width() != w) {
+                coversEverywhere = false;
+            }
+        }
+        report("split items stay pixel-adjacent at any canvas width", adjacentEverywhere);
+        report("split items cover the canvas exactly at any width", coversEverywhere);
+
+        // Three-way split on a width divisible by nothing convenient.
+        const QSize canvas(1000, 1000);
+        const QRect a = toPixels(NormRect{0.0,       0.0, 1.0 / 3.0, 1.0}, canvas);
+        const QRect b = toPixels(NormRect{1.0 / 3.0, 0.0, 1.0 / 3.0, 1.0}, canvas);
+        const QRect c = toPixels(NormRect{2.0 / 3.0, 0.0, 1.0 / 3.0, 1.0}, canvas);
+        report("three-way split leaves no seam",
+               a.x() + a.width() == b.x() && b.x() + b.width() == c.x()
+                   && a.width() + b.width() + c.width() == 1000);
+    }
+
+    // ── Case 3: round-trip stability ─────────────────────────────────────
+    {
+        const QSize canvas(1920, 1080);
+        const NormRect original{0.137, 0.271, 0.463, 0.219};
+        const NormRect back = fromPixels(toPixels(original, canvas), canvas);
+
+        // A round trip through integer pixels cannot be exact; it must be
+        // within one pixel, which is the resolution the operator can see.
+        report("round trip stays within one pixel",
+               nearly(back.x, original.x, 1.0 / 1920.0)
+                   && nearly(back.y, original.y, 1.0 / 1080.0)
+                   && nearly(back.w, original.w, 1.0 / 1920.0)
+                   && nearly(back.h, original.h, 1.0 / 1080.0));
+
+        // And a second trip must not drift further — otherwise repeated
+        // resizes would walk a layout across the screen.
+        const NormRect twice = fromPixels(toPixels(back, canvas), canvas);
+        report("a second round trip does not drift", twice == back);
+    }
+
+    // ── Case 4: degenerate inputs are refused, not mangled ───────────────
+    {
+        report("zero canvas yields a null rect",
+               toPixels(NormRect{0.0, 0.0, 1.0, 1.0}, QSize(0, 0)).isNull());
+        report("zero canvas inverts to a default rect",
+               fromPixels(QRect(0, 0, 10, 10), QSize(0, 0)) == NormRect{});
+
+        // A canvas that has not been shown yet must not rewrite stored
+        // placement — losing real layout to a transient size is worse than
+        // doing nothing.
+        const NormRect stored{0.25, 0.25, 0.5, 0.5};
+        report("clamp leaves placement alone on a zero canvas",
+               clampToCanvas(stored, QSize(160, 90), QSize(0, 0)) == stored);
+
+        const double nan = std::numeric_limits<double>::quiet_NaN();
+        report("clamp rejects a non-finite rect",
+               clampToCanvas(NormRect{nan, 0.0, 0.5, 0.5}, QSize(0, 0), QSize(800, 600))
+                   == NormRect{});
+
+        report("zero-area rect is not valid", !NormRect{0.1, 0.1, 0.0, 0.5}.isValid());
+        report("a normal rect is valid", NormRect{0.1, 0.1, 0.5, 0.5}.isValid());
+    }
+
+    // ── Case 5: a layout survives a change of display ────────────────────
+    {
+        // Authored on a 3840x1600 ultrawide...
+        const QSize big(3840, 1600);
+        const NormRect pan{0.0, 0.0, 0.72, 0.55};
+        const QRect onBig = toPixels(pan, big);
+        report("authored rect is correct on the big canvas",
+               onBig == QRect(0, 0, 2765, 880));
+
+        // ...restored on a 1920x1080 laptop: same proportions, different pitch.
+        const QSize small(1920, 1080);
+        const QRect onSmall = toPixels(pan, small);
+        report("same rect keeps its proportions on a smaller canvas",
+               nearly(onSmall.width()  / static_cast<double>(small.width()),
+                      onBig.width()    / static_cast<double>(big.width()),   1e-3)
+                   && nearly(onSmall.height() / static_cast<double>(small.height()),
+                             onBig.height()   / static_cast<double>(big.height()), 1e-3));
+        report("restored rect stays inside the smaller canvas",
+               onSmall.right() < small.width() && onSmall.bottom() < small.height());
+    }
+
+    // ── Case 6: clamping keeps items reachable ───────────────────────────
+    {
+        const QSize canvas(1000, 1000);
+        const QSize minPx(0, 0);
+
+        // Overshooting the right edge slides the item back; it does not
+        // resize under the cursor.
+        const NormRect out = clampToCanvas(NormRect{0.9, 0.0, 0.3, 0.3}, minPx, canvas);
+        report("an item pushed past the edge slides back, keeping its size",
+               nearly(out.x, 0.7) && nearly(out.w, 0.3));
+
+        const NormRect neg = clampToCanvas(NormRect{-0.5, -0.5, 0.4, 0.4}, minPx, canvas);
+        report("an item pushed past the origin slides back",
+               nearly(neg.x, 0.0) && nearly(neg.y, 0.0)
+                   && nearly(neg.w, 0.4) && nearly(neg.h, 0.4));
+    }
+
+    // ── Case 7: minimum size ─────────────────────────────────────────────
+    {
+        const QSize canvas(1000, 1000);
+
+        report("minimum maps into fractions",
+               nearly(minimumNormSize(QSize(200, 100), canvas).width(),  0.2)
+                   && nearly(minimumNormSize(QSize(200, 100), canvas).height(), 0.1));
+
+        const NormRect grown =
+            clampToCanvas(NormRect{0.0, 0.0, 0.05, 0.05}, QSize(200, 200), canvas);
+        report("a too-small item is grown to the minimum",
+               nearly(grown.w, 0.2) && nearly(grown.h, 0.2));
+
+        // A canvas smaller than the minimum: the cap wins and the item fills
+        // the surface.  An item that overflows a tiny window is recoverable;
+        // one rounded to nothing is not.
+        const NormRect capped =
+            clampToCanvas(NormRect{0.3, 0.3, 0.1, 0.1}, QSize(200, 200), QSize(100, 100));
+        report("a canvas smaller than the minimum caps at full size",
+               nearly(capped.w, 1.0) && nearly(capped.h, 1.0)
+                   && nearly(capped.x, 0.0) && nearly(capped.y, 0.0));
+    }
+
+    // ── Case 8: half-open containment ────────────────────────────────────
+    {
+        const NormRect r{0.25, 0.25, 0.5, 0.5};
+        report("contains its top-left corner",        r.contains(0.25, 0.25));
+        report("contains an interior point",          r.contains(0.5, 0.5));
+        report("excludes its far edge",              !r.contains(0.75, 0.5));
+        report("excludes a point outside",           !r.contains(0.1, 0.5));
+
+        // Two items sharing an edge must not both claim a point on it, or a
+        // click there would depend on iteration order.
+        const NormRect left {0.0, 0.0, 0.5, 1.0};
+        const NormRect right{0.5, 0.0, 0.5, 1.0};
+        report("a point on a shared edge belongs to exactly one item",
+               left.contains(0.5, 0.5) != right.contains(0.5, 0.5));
+    }
+
+    std::printf("\n%s\n", g_failures == 0 ? "All checks passed." : "FAILURES present.");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/workspace_layout_test.cpp
+++ b/tests/workspace_layout_test.cpp
@@ -131,9 +131,9 @@ int main()
     // ── Rehydrating a saved stacking order ───────────────────────────────
     //
     // WorkspaceDocument persists z per item, and once an operator has raised
-    // anything, z no longer matches array order.  Inserting stored items with
-    // the default AssignTop would silently restore the arrangement with its
-    // stacking scrambled, so a restore path has to say PreserveGiven.
+    // anything, z no longer matches array order.  Feeding stored items to
+    // addItem() would silently restore the arrangement with its stacking
+    // scrambled, so a restore path has to use restoreItems().
     {
         CanvasLayout layout;
 
@@ -199,12 +199,18 @@ int main()
         report("lower moves one step back",
                layout.lower("a") && zOrder(layout) == QStringList({"a", "b", "c", "d"}));
 
-        // Already at an extreme: a no-op, and reported as success — the
-        // caller asked for a state that already holds.
-        report("lower at the bottom is a successful no-op",
-               layout.lower("a") && zOrder(layout) == QStringList({"a", "b", "c", "d"}));
-        report("raise at the top is a successful no-op",
-               layout.raise("d") && zOrder(layout) == QStringList({"a", "b", "c", "d"}));
+        // Already at an extreme: nothing changes, and that is reported as
+        // FALSE.  Callers turn these into change notifications, and under
+        // auto-commit a notification is a whole-document write — so "already
+        // frontmost" must not look like an edit.
+        report("lower at the bottom reports no change",
+               !layout.lower("a") && zOrder(layout) == QStringList({"a", "b", "c", "d"}));
+        report("raise at the top reports no change",
+               !layout.raise("d") && zOrder(layout) == QStringList({"a", "b", "c", "d"}));
+        report("bringToFront on the frontmost reports no change",
+               !layout.bringToFront("d") && zOrder(layout) == QStringList({"a", "b", "c", "d"}));
+        report("sendToBack on the backmost reports no change",
+               !layout.sendToBack("a") && zOrder(layout) == QStringList({"a", "b", "c", "d"}));
         report("z survives the no-ops", zIsDense(layout));
 
         report("bringToFront jumps to the top, others keep their order",

--- a/tests/workspace_layout_test.cpp
+++ b/tests/workspace_layout_test.cpp
@@ -128,6 +128,61 @@ int main()
         report("z is dense after removal", zIsDense(layout));
     }
 
+    // ── Rehydrating a saved stacking order ───────────────────────────────
+    //
+    // WorkspaceDocument persists z per item, and once an operator has raised
+    // anything, z no longer matches array order.  Inserting stored items with
+    // the default AssignTop would silently restore the arrangement with its
+    // stacking scrambled, so a restore path has to say PreserveGiven.
+    {
+        CanvasLayout layout;
+
+        // A saved set whose z deliberately disagrees with array order —
+        // exactly what "operator raised the bottom item" produces.
+        CanvasItem a = make("a", NormRect{0.0, 0.0, 0.3, 0.3});
+        CanvasItem b = make("b", NormRect{0.1, 0.1, 0.3, 0.3});
+        CanvasItem c = make("c", NormRect{0.2, 0.2, 0.3, 0.3});
+        a.z = 2;
+        b.z = 0;
+        c.z = 1;
+
+        report("every stored item is restored",
+               layout.restoreItems({a, b, c}, kCanvas) == 3);
+        report("a restored arrangement keeps its saved stacking",
+               zOrder(layout) == QStringList({"b", "c", "a"}));
+        report("...and z is dense afterwards", zIsDense(layout));
+
+        // Sparse saved z (an older document, or one hand-edited) restores in
+        // the same relative order rather than being rejected.
+        CanvasLayout sparse;
+        CanvasItem x = make("x", NormRect{0.0, 0.0, 0.2, 0.2});
+        CanvasItem y = make("y", NormRect{0.2, 0.2, 0.2, 0.2});
+        x.z = 40;
+        y.z = 10;
+        sparse.restoreItems({x, y}, kCanvas);
+        report("sparse saved z is densified, preserving order",
+               zOrder(sparse) == QStringList({"y", "x"}) && zIsDense(sparse));
+
+        // Restore skips what it cannot place, and says how many it took.
+        CanvasLayout guarded;
+        CanvasItem dup1 = make("dup", NormRect{0.0, 0.0, 0.2, 0.2});
+        CanvasItem dup2 = make("dup", NormRect{0.3, 0.3, 0.2, 0.2});
+        CanvasItem anon = make("", NormRect{0.5, 0.5, 0.2, 0.2});
+        report("restore skips duplicate and anonymous items",
+               guarded.restoreItems({dup1, dup2, anon}, kCanvas) == 1
+                   && guarded.count() == 1);
+
+        // A plain add still puts a NEW item where the operator can see it,
+        // whatever z it happens to carry.
+        CanvasLayout fresh;
+        CanvasItem buried = make("buried", NormRect{0.0, 0.0, 0.2, 0.2});
+        buried.z = -99;
+        fresh.addItem(make("first", NormRect{0.3, 0.3, 0.2, 0.2}), kCanvas);
+        fresh.addItem(buried, kCanvas);
+        report("addItem ignores the caller's z and lands on top",
+               zOrder(fresh) == QStringList({"first", "buried"}));
+    }
+
     // ── Stacking operations ──────────────────────────────────────────────
     {
         CanvasLayout layout;

--- a/tests/workspace_layout_test.cpp
+++ b/tests/workspace_layout_test.cpp
@@ -1,0 +1,229 @@
+// Unit tests for CanvasLayout — the widget-free rules of the workspace canvas
+// (RFC #4887, phase 1).
+//
+// The invariant under test throughout is that z stays dense and contiguous
+// over [0, count-1].  Sparse or duplicated z is the bug that makes "raise"
+// quietly stop doing anything after enough operations, and it is invisible
+// until an operator has been rearranging for a while — so it is asserted after
+// every mutation here, not just at the end.
+
+#include "gui/workspace/CanvasLayout.h"
+
+#include <QPointF>
+#include <QSize>
+#include <QStringList>
+
+#include <cmath>
+#include <cstdio>
+
+using AetherSDR::CanvasItem;
+using AetherSDR::CanvasLayout;
+using AetherSDR::NormRect;
+
+namespace {
+
+int g_failures = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) {
+        ++g_failures;
+    }
+}
+
+const QSize kCanvas(1000, 1000);
+
+CanvasItem make(const QString& id, const NormRect& rect)
+{
+    CanvasItem it;
+    it.id          = id;
+    it.rect        = rect;
+    it.minimumSize = QSize(0, 0);   // most cases are about placement, not floors
+    return it;
+}
+
+// Every z value present exactly once, over [0, count-1].
+bool zIsDense(const CanvasLayout& layout)
+{
+    const int n = layout.count();
+    QList<bool> seen(n, false);
+    for (const QString& id : layout.ids()) {
+        const int z = layout.zOf(id);
+        if (z < 0 || z >= n || seen[z]) {
+            return false;
+        }
+        seen[z] = true;
+    }
+    return true;
+}
+
+QStringList zOrder(const CanvasLayout& layout)
+{
+    QStringList out;
+    for (const CanvasItem& it : layout.itemsByZ()) {
+        out.append(it.id);
+    }
+    return out;
+}
+
+}  // namespace
+
+int main()
+{
+    // ── Membership ───────────────────────────────────────────────────────
+    {
+        CanvasLayout layout;
+
+        report("empty layout has no items", layout.isEmpty() && layout.count() == 0);
+
+        report("an item can be added",
+               layout.addItem(make("a", NormRect{0.0, 0.0, 0.4, 0.4}), kCanvas));
+        report("a duplicate id is refused",
+               !layout.addItem(make("a", NormRect{0.5, 0.5, 0.2, 0.2}), kCanvas));
+        report("an empty id is refused",
+               !layout.addItem(make("", NormRect{0.5, 0.5, 0.2, 0.2}), kCanvas));
+        report("the refusals did not change the layout", layout.count() == 1);
+
+        report("contains() finds it",        layout.contains("a"));
+        report("contains() misses a stranger", !layout.contains("nope"));
+        report("item() returns the record",  layout.item("a") != nullptr);
+        report("item() returns null for a stranger", layout.item("nope") == nullptr);
+
+        report("removing an absent id fails", !layout.removeItem("nope"));
+        report("removing a present id works", layout.removeItem("a"));
+        report("layout is empty again",       layout.isEmpty());
+    }
+
+    // ── Insert clamps placement ──────────────────────────────────────────
+    {
+        CanvasLayout layout;
+        CanvasItem it = make("wide", NormRect{0.8, 0.8, 0.5, 0.5});
+        it.minimumSize = QSize(100, 100);
+        layout.addItem(it, kCanvas);
+
+        const NormRect stored = layout.item("wide")->rect;
+        report("an item added off-canvas is clamped on the way in",
+               std::fabs(stored.x - 0.5) < 1e-9 && std::fabs(stored.y - 0.5) < 1e-9);
+    }
+
+    // ── z assignment and density ─────────────────────────────────────────
+    {
+        CanvasLayout layout;
+        layout.addItem(make("a", NormRect{0.0, 0.0, 0.3, 0.3}), kCanvas);
+        layout.addItem(make("b", NormRect{0.1, 0.1, 0.3, 0.3}), kCanvas);
+        layout.addItem(make("c", NormRect{0.2, 0.2, 0.3, 0.3}), kCanvas);
+
+        report("each new item lands on top",
+               layout.zOf("a") == 0 && layout.zOf("b") == 1 && layout.zOf("c") == 2);
+        report("z is dense after inserts", zIsDense(layout));
+        report("ids() keeps insertion order",
+               layout.ids() == QStringList({"a", "b", "c"}));
+        report("itemsByZ() is bottom-to-top",
+               zOrder(layout) == QStringList({"a", "b", "c"}));
+
+        // Removing from the middle must close the hole, not leave z = {0, 2}.
+        layout.removeItem("b");
+        report("removal renumbers z", layout.zOf("a") == 0 && layout.zOf("c") == 1);
+        report("z is dense after removal", zIsDense(layout));
+    }
+
+    // ── Stacking operations ──────────────────────────────────────────────
+    {
+        CanvasLayout layout;
+        layout.addItem(make("a", NormRect{0.0, 0.0, 0.3, 0.3}), kCanvas);
+        layout.addItem(make("b", NormRect{0.1, 0.1, 0.3, 0.3}), kCanvas);
+        layout.addItem(make("c", NormRect{0.2, 0.2, 0.3, 0.3}), kCanvas);
+        layout.addItem(make("d", NormRect{0.3, 0.3, 0.3, 0.3}), kCanvas);
+        // bottom -> top: a b c d
+
+        report("raise moves one step",
+               layout.raise("a") && zOrder(layout) == QStringList({"b", "a", "c", "d"}));
+        report("z is dense after raise", zIsDense(layout));
+
+        report("lower moves one step back",
+               layout.lower("a") && zOrder(layout) == QStringList({"a", "b", "c", "d"}));
+
+        // Already at an extreme: a no-op, and reported as success — the
+        // caller asked for a state that already holds.
+        report("lower at the bottom is a successful no-op",
+               layout.lower("a") && zOrder(layout) == QStringList({"a", "b", "c", "d"}));
+        report("raise at the top is a successful no-op",
+               layout.raise("d") && zOrder(layout) == QStringList({"a", "b", "c", "d"}));
+        report("z survives the no-ops", zIsDense(layout));
+
+        report("bringToFront jumps to the top, others keep their order",
+               layout.bringToFront("a")
+                   && zOrder(layout) == QStringList({"b", "c", "d", "a"}));
+        report("z is dense after bringToFront", zIsDense(layout));
+
+        report("sendToBack jumps to the bottom, others keep their order",
+               layout.sendToBack("d")
+                   && zOrder(layout) == QStringList({"d", "b", "c", "a"}));
+        report("z is dense after sendToBack", zIsDense(layout));
+
+        report("stacking an unknown id fails",
+               !layout.raise("nope") && !layout.lower("nope")
+                   && !layout.bringToFront("nope") && !layout.sendToBack("nope"));
+        report("zOf reports -1 for an unknown id", layout.zOf("nope") == -1);
+    }
+
+    // ── Hit testing ──────────────────────────────────────────────────────
+    {
+        CanvasLayout layout;
+        // Two items that overlap in the middle of the canvas.
+        layout.addItem(make("under", NormRect{0.10, 0.10, 0.40, 0.40}), kCanvas);
+        layout.addItem(make("over",  NormRect{0.30, 0.30, 0.40, 0.40}), kCanvas);
+
+        report("a point over only the lower item hits it",
+               layout.hitTest(QPointF(0.15, 0.15)) == "under");
+        report("a point over only the upper item hits it",
+               layout.hitTest(QPointF(0.65, 0.65)) == "over");
+        report("in the overlap, the topmost item wins",
+               layout.hitTest(QPointF(0.35, 0.35)) == "over");
+
+        // ...and it follows stacking, not insertion order.
+        layout.bringToFront("under");
+        report("the hit follows stacking after a raise",
+               layout.hitTest(QPointF(0.35, 0.35)) == "under");
+
+        report("bare canvas hits nothing",
+               layout.hitTest(QPointF(0.95, 0.95)).isEmpty());
+        report("outside the canvas hits nothing",
+               layout.hitTest(QPointF(-0.5, 0.5)).isEmpty());
+    }
+
+    // ── setRect and reclampAll ───────────────────────────────────────────
+    {
+        CanvasLayout layout;
+        layout.addItem(make("a", NormRect{0.0, 0.0, 0.4, 0.4}), kCanvas);
+
+        report("setRect on an unknown id fails",
+               !layout.setRect("nope", NormRect{0.0, 0.0, 0.2, 0.2}, kCanvas));
+
+        report("setRect stores the new placement",
+               layout.setRect("a", NormRect{0.5, 0.5, 0.25, 0.25}, kCanvas)
+                   && layout.item("a")->rect == NormRect{0.5, 0.5, 0.25, 0.25});
+
+        report("setRect clamps an off-canvas request",
+               layout.setRect("a", NormRect{0.9, 0.9, 0.5, 0.5}, kCanvas)
+                   && layout.item("a")->rect == NormRect{0.5, 0.5, 0.5, 0.5});
+
+        // A resize that changes nothing must report nothing changed: this is
+        // what stops phase 2's auto-commit writing the document on every frame
+        // of a window drag.
+        CanvasLayout stable;
+        CanvasItem fits = make("fits", NormRect{0.1, 0.1, 0.2, 0.2});
+        fits.minimumSize = QSize(10, 10);
+        stable.addItem(fits, kCanvas);
+        report("a resize that changes nothing reports nothing",
+               stable.reclampAll(QSize(2000, 2000)).isEmpty());
+
+        // A canvas too small for the minimum does move it, and says so.
+        report("a resize that forces a clamp reports the moved item",
+               stable.reclampAll(QSize(20, 20)) == QStringList({"fits"}));
+    }
+
+    std::printf("\n%s\n", g_failures == 0 ? "All checks passed." : "FAILURES present.");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/workspace_migration_test.cpp
+++ b/tests/workspace_migration_test.cpp
@@ -1,0 +1,393 @@
+// Migration from the legacy layout keys to a Classic workspace, and the
+// Classic geometry itself (RFC #4887, phase 2).
+//
+// Runs against a REAL AppSettings in a temporary home (TestSettingsProfile),
+// with legacy keys written in exactly the shape the current owners write
+// them — the same approach bandstack_scoped_test uses.  A migration tested
+// against a mock of the keys would prove nothing about the keys.
+//
+// The case that matters most is the last one: migration must NOT drag a
+// floating pan or a floating applet onto the canvas.  Pop-out stays (RFC
+// decision 1), and phase 2's contract is that there is no user-visible
+// change — yanking someone's pop-outs into a canvas they have not opted into
+// would be about the largest user-visible change available.
+
+#include "TestSettingsProfile.h"
+
+#include "core/AppSettings.h"
+#include "gui/workspace/ClassicLayout.h"
+#include "gui/workspace/WorkspaceMigration.h"
+
+#include <QCoreApplication>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QStringList>
+
+#include <cmath>
+#include <cstdio>
+#include <iostream>
+
+using AetherSDR::AppSettings;
+using AetherSDR::CanvasItem;
+using AetherSDR::LegacyLayoutState;
+using AetherSDR::NormRect;
+using AetherSDR::WorkspaceDocument;
+using AetherSDR::WorkspaceSurface;
+using AetherSDR::buildClassicDocument;
+using AetherSDR::classicWorkspaceId;
+using AetherSDR::composeClassic;
+using AetherSDR::knownPanLayoutIds;
+using AetherSDR::panCellsForLayout;
+using AetherSDR::panCountForLayout;
+using AetherSDR::readLegacyLayoutState;
+
+namespace {
+
+int g_failures = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) {
+        ++g_failures;
+    }
+}
+
+bool nearly(double a, double b, double tol = 1e-9)
+{
+    return std::fabs(a - b) <= tol;
+}
+
+const QStringList kApplets = {"RX", "TX", "PWR", "WAVE", "CAT"};
+
+void setKey(const QString& key, const QString& value)
+{
+    AppSettings::instance().setValue(key, value);
+}
+
+void clearLegacyKeys()
+{
+    auto& s = AppSettings::instance();
+    for (const QString& id : kApplets) {
+        s.remove(QStringLiteral("Applet_") + id);
+    }
+    s.remove(QStringLiteral("AppletOrder"));
+    s.remove(QStringLiteral("PanadapterLayout"));
+    s.remove(QStringLiteral("FloatingPanIds"));
+    s.remove(QStringLiteral("AppletPanelDockedLeft"));
+    s.remove(QStringLiteral("AppletPanelVisible"));
+    s.remove(QStringLiteral("ContainerTree"));
+}
+
+// A ContainerTree blob in the shape ContainerManager::saveState() writes.
+QString containerTreeWith(const QStringList& floatingIds)
+{
+    QJsonObject containers;
+    for (const QString& id : floatingIds) {
+        QJsonObject entry;
+        entry[QStringLiteral("mode")]        = QStringLiteral("floating");
+        entry[QStringLiteral("visible")]     = true;
+        entry[QStringLiteral("contentType")] = QString();
+        entry[QStringLiteral("parent")]      = QString();
+        containers[id] = entry;
+    }
+    QJsonObject root;
+    root[QStringLiteral("version")]    = 1;
+    root[QStringLiteral("containers")] = containers;
+    return QString::fromUtf8(QJsonDocument(root).toJson(QJsonDocument::Compact));
+}
+
+const CanvasItem* findItem(const QList<CanvasItem>& items, const QString& id)
+{
+    for (const CanvasItem& it : items) {
+        if (it.id == id) {
+            return &it;
+        }
+    }
+    return nullptr;
+}
+
+double totalArea(const QList<NormRect>& cells)
+{
+    double area = 0.0;
+    for (const NormRect& r : cells) {
+        area += r.w * r.h;
+    }
+    return area;
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile profile(QStringLiteral("aether-workspace-migration-test"));
+    if (!profile.isValid()) {
+        std::cerr << "[FAIL] create temporary home\n";
+        return 1;
+    }
+    QCoreApplication app(argc, argv);
+    AppSettings::instance().load();
+
+    // ── The pan layout table ─────────────────────────────────────────────
+    {
+        // All twelve ids the dialog offers.  (The RFC's problem statement said
+        // eleven and listed ten — the real table has twelve.)
+        report("every layout id is known",
+               knownPanLayoutIds().size() == 12);
+
+        report("single is one full cell",
+               panCellsForLayout(QStringLiteral("1"))
+                   == QList<NormRect>{NormRect{0.0, 0.0, 1.0, 1.0}});
+
+        report("2h is two columns",
+               panCellsForLayout(QStringLiteral("2h"))
+                   == QList<NormRect>({NormRect{0.0, 0.0, 0.5, 1.0},
+                                       NormRect{0.5, 0.0, 0.5, 1.0}}));
+
+        report("2v is two rows",
+               panCellsForLayout(QStringLiteral("2v"))
+                   == QList<NormRect>({NormRect{0.0, 0.0, 1.0, 0.5},
+                                       NormRect{0.0, 0.5, 1.0, 0.5}}));
+
+        // The asymmetric ones are where a hand-written table goes wrong.
+        const QList<NormRect> mixed = panCellsForLayout(QStringLiteral("2h1"));
+        report("2h1 is two on top and one below",
+               mixed.size() == 3
+                   && mixed.at(0) == NormRect{0.0, 0.0, 0.5, 0.5}
+                   && mixed.at(1) == NormRect{0.5, 0.0, 0.5, 0.5}
+                   && mixed.at(2) == NormRect{0.0, 0.5, 1.0, 0.5});
+
+        const QList<NormRect> fourThree = panCellsForLayout(QStringLiteral("4h3"));
+        report("4h3 is four on top and three below",
+               fourThree.size() == 7
+                   && nearly(fourThree.at(0).w, 0.25)
+                   && nearly(fourThree.at(4).w, 1.0 / 3.0)
+                   && nearly(fourThree.at(4).y, 0.5));
+
+        // Every layout must tile the surface exactly — no dead strips, no
+        // overlap.  This is the property that would silently rot if a new id
+        // were added with a typo in its row counts.
+        bool allTile = true;
+        for (const QString& id : knownPanLayoutIds()) {
+            if (!nearly(totalArea(panCellsForLayout(id)), 1.0, 1e-9)) {
+                allTile = false;
+                std::printf("       layout '%s' covers %.6f\n",
+                            qPrintable(id), totalArea(panCellsForLayout(id)));
+            }
+        }
+        report("every layout tiles the surface exactly", allTile);
+
+        report("pan counts match the layout ids",
+               panCountForLayout(QStringLiteral("2x4")) == 8
+                   && panCountForLayout(QStringLiteral("3h2")) == 5
+                   && panCountForLayout(QStringLiteral("1")) == 1);
+
+        report("an unknown layout id yields nothing",
+               panCellsForLayout(QStringLiteral("nope")).isEmpty()
+                   && panCountForLayout(QStringLiteral("nope")) == 0);
+    }
+
+    // ── Classic composition ──────────────────────────────────────────────
+    {
+        const QList<CanvasItem> items =
+            composeClassic({"0x40000000", "0x40000001"}, {"RX", "TX"},
+                           QStringLiteral("2v"), /*appletsLeft=*/false);
+
+        report("classic places every pan and applet", items.size() == 4);
+
+        const CanvasItem* panA = findItem(items, QStringLiteral("pan:0x40000000"));
+        const CanvasItem* rx   = findItem(items, QStringLiteral("applet:RX"));
+        report("ids are namespaced by kind", panA && rx);
+
+        report("pans take the surface minus the applet column",
+               nearly(panA->rect.x, 0.0)
+                   && nearly(panA->rect.w, 1.0 - AetherSDR::kClassicAppletColumnWidth));
+        report("the applet column sits on the right",
+               nearly(rx->rect.x, 1.0 - AetherSDR::kClassicAppletColumnWidth)
+                   && nearly(rx->rect.w, AetherSDR::kClassicAppletColumnWidth));
+        report("applets share the column height",
+               nearly(rx->rect.h, 0.5));
+        report("content types are set",
+               panA->contentType == QStringLiteral("panadapter")
+                   && rx->contentType == QStringLiteral("applet"));
+
+        // Docked left: the mirror image.
+        const QList<CanvasItem> left =
+            composeClassic({"0x40000000"}, {"RX"}, QStringLiteral("1"), true);
+        report("docked left mirrors the arrangement",
+               nearly(findItem(left, "applet:RX")->rect.x, 0.0)
+                   && nearly(findItem(left, "pan:0x40000000")->rect.x,
+                             AetherSDR::kClassicAppletColumnWidth));
+
+        // No applets: the pans take everything, rather than leaving a band of
+        // dead canvas where the column would have been.
+        const QList<CanvasItem> noApplets =
+            composeClassic({"0x40000000"}, {}, QStringLiteral("1"), false);
+        report("with no applets the pans take the whole surface",
+               noApplets.size() == 1
+                   && nearly(noApplets.at(0).rect.w, 1.0));
+
+        // More pans than the layout has cells: the operator's chosen layout
+        // wins, extras are dropped rather than a cell being invented.
+        const QList<CanvasItem> tooMany =
+            composeClassic({"a", "b", "c"}, {}, QStringLiteral("2h"), false);
+        report("pans beyond the layout's cells are dropped", tooMany.size() == 2);
+
+        // Unknown layout id falls back to single rather than placing nothing.
+        const QList<CanvasItem> fallback =
+            composeClassic({"a"}, {}, QStringLiteral("bogus"), false);
+        report("an unknown layout falls back to single", fallback.size() == 1);
+
+        // z is assigned, dense and ascending, so the document arrives with a
+        // stacking order CanvasLayout will accept unchanged.
+        bool zAscending = true;
+        for (int i = 0; i < items.size(); ++i) {
+            if (items.at(i).z != i) {
+                zAscending = false;
+            }
+        }
+        report("composed items carry dense ascending z", zAscending);
+    }
+
+    // ── Reading the legacy keys ──────────────────────────────────────────
+    {
+        clearLegacyKeys();
+        setKey(QStringLiteral("PanadapterLayout"), QStringLiteral("2x2"));
+        setKey(QStringLiteral("AppletOrder"), QStringLiteral("TX,RX,PWR"));
+        setKey(QStringLiteral("Applet_RX"), QStringLiteral("True"));
+        setKey(QStringLiteral("Applet_TX"), QStringLiteral("True"));
+        setKey(QStringLiteral("Applet_PWR"), QStringLiteral("False"));
+        setKey(QStringLiteral("AppletPanelDockedLeft"), QStringLiteral("True"));
+
+        const LegacyLayoutState state = readLegacyLayoutState(kApplets);
+
+        report("the pan layout id is read", state.panLayoutId == QStringLiteral("2x2"));
+        report("the saved applet order is honoured",
+               state.openAppletIds == QStringList({"TX", "RX"}));
+        report("an applet switched off is not placed",
+               !state.openAppletIds.contains(QStringLiteral("PWR")));
+        report("the dock side is read", state.appletsLeft);
+        report("panel visibility defaults to true", state.appletPanelVisible);
+
+        // An applet the operator has never touched has no key at all, and its
+        // default lives in AppletPanel — so it is simply not placed rather
+        // than guessed at.
+        report("an applet with no key is not placed",
+               !state.openAppletIds.contains(QStringLiteral("WAVE"))
+                   && !state.openAppletIds.contains(QStringLiteral("CAT")));
+    }
+
+    // ── An unreadable boolean falls back, it does not mean "off" ─────────
+    {
+        clearLegacyKeys();
+        setKey(QStringLiteral("Applet_RX"), QStringLiteral("yes-ish"));
+        setKey(QStringLiteral("AppletPanelVisible"), QStringLiteral("garbage"));
+
+        const LegacyLayoutState state = readLegacyLayoutState(kApplets);
+        report("an unreadable applet flag is treated as not-open",
+               !state.openAppletIds.contains(QStringLiteral("RX")));
+        report("an unreadable panel-visible flag falls back to visible",
+               state.appletPanelVisible);
+    }
+
+    // ── An unknown pan layout id falls back to single ────────────────────
+    {
+        clearLegacyKeys();
+        setKey(QStringLiteral("PanadapterLayout"), QStringLiteral("17x42"));
+        report("an unknown stored layout id falls back to single",
+               readLegacyLayoutState(kApplets).panLayoutId == QStringLiteral("1"));
+    }
+
+    // ── Floating things are left alone (RFC decision 1) ──────────────────
+    {
+        clearLegacyKeys();
+        setKey(QStringLiteral("PanadapterLayout"), QStringLiteral("2h"));
+        setKey(QStringLiteral("AppletOrder"), QStringLiteral("RX,TX,WAVE"));
+        setKey(QStringLiteral("Applet_RX"), QStringLiteral("True"));
+        setKey(QStringLiteral("Applet_TX"), QStringLiteral("True"));
+        setKey(QStringLiteral("Applet_WAVE"), QStringLiteral("True"));
+        setKey(QStringLiteral("FloatingPanIds"), QStringLiteral("0x40000001"));
+        setKey(QStringLiteral("ContainerTree"), containerTreeWith({"WAVE"}));
+
+        const LegacyLayoutState state = readLegacyLayoutState(kApplets);
+
+        report("a floated applet is recorded as floating",
+               state.floatingAppletIds == QStringList({"WAVE"}));
+        report("a floated applet is NOT placed on the canvas",
+               state.openAppletIds == QStringList({"RX", "TX"}));
+        report("floating pan ids are recorded",
+               state.floatingPanIds == QStringList({"0x40000001"}));
+
+        const WorkspaceDocument doc =
+            buildClassicDocument(state, {"0x40000000", "0x40000001"});
+        const WorkspaceSurface* main =
+            doc.workspace(classicWorkspaceId())->surface(WorkspaceSurface::kMainId);
+
+        report("the floated applet is absent from the document",
+               findItem(main->items, QStringLiteral("applet:WAVE")) == nullptr);
+        report("the docked applets are present",
+               findItem(main->items, QStringLiteral("applet:RX")) != nullptr
+                   && findItem(main->items, QStringLiteral("applet:TX")) != nullptr);
+    }
+
+    // ── A corrupt ContainerTree does not fail the migration ──────────────
+    {
+        clearLegacyKeys();
+        setKey(QStringLiteral("Applet_RX"), QStringLiteral("True"));
+        setKey(QStringLiteral("ContainerTree"), QStringLiteral("{ this is not json"));
+
+        const LegacyLayoutState state = readLegacyLayoutState(kApplets);
+        report("a corrupt container tree still yields a usable Classic",
+               state.openAppletIds == QStringList({"RX"})
+                   && state.floatingAppletIds.isEmpty());
+    }
+
+    // ── The document migration produces ──────────────────────────────────
+    {
+        clearLegacyKeys();
+        setKey(QStringLiteral("PanadapterLayout"), QStringLiteral("2v"));
+        setKey(QStringLiteral("Applet_RX"), QStringLiteral("True"));
+
+        const WorkspaceDocument doc =
+            buildClassicDocument(readLegacyLayoutState(kApplets), {"0x40000000"});
+
+        report("exactly one workspace is produced", doc.workspaces.size() == 1);
+        report("it is Classic, and active",
+               doc.activeWorkspace == classicWorkspaceId()
+                   && doc.workspace(classicWorkspaceId())->label == QStringLiteral("Classic"));
+        report("it has exactly one main surface",
+               doc.workspace(classicWorkspaceId())->surfaces.size() == 1
+                   && doc.workspace(classicWorkspaceId())->surfaces.at(0).id
+                          == WorkspaceSurface::kMainId);
+        report("migration creates no bindings", doc.bindings.isEmpty());
+
+        // And it survives the schema it will be stored in.
+        WorkspaceDocument reparsed;
+        QStringList warnings;
+        report("the migrated document round-trips through the schema",
+               WorkspaceDocument::fromStoredJson(doc.toStoredJson(), &reparsed,
+                                                 nullptr, &warnings)
+                   && warnings.isEmpty()
+                   && reparsed.workspaceIds() == doc.workspaceIds());
+    }
+
+    // ── A hidden applet panel means no column ────────────────────────────
+    {
+        clearLegacyKeys();
+        setKey(QStringLiteral("Applet_RX"), QStringLiteral("True"));
+        setKey(QStringLiteral("AppletPanelVisible"), QStringLiteral("False"));
+
+        const WorkspaceDocument doc =
+            buildClassicDocument(readLegacyLayoutState(kApplets), {"0x40000000"});
+        const WorkspaceSurface* main =
+            doc.workspace(classicWorkspaceId())->surface(WorkspaceSurface::kMainId);
+
+        report("a hidden panel places no applets",
+               findItem(main->items, QStringLiteral("applet:RX")) == nullptr);
+        report("...and the pan takes the whole surface",
+               nearly(findItem(main->items, QStringLiteral("pan:0x40000000"))->rect.w, 1.0));
+    }
+
+    std::printf("\n%s\n", g_failures == 0 ? "All checks passed." : "FAILURES present.");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/workspace_migration_test.cpp
+++ b/tests/workspace_migration_test.cpp
@@ -164,23 +164,70 @@ int main(int argc, char** argv)
                    && nearly(fourThree.at(4).w, 1.0 / 3.0)
                    && nearly(fourThree.at(4).y, 0.5));
 
-        // Every layout must tile the surface exactly — no dead strips, no
-        // overlap.  This is the property that would silently rot if a new id
-        // were added with a typo in its row counts.
-        bool allTile = true;
-        for (const QString& id : knownPanLayoutIds()) {
-            if (!nearly(totalArea(panCellsForLayout(id)), 1.0, 1e-9)) {
-                allTile = false;
-                std::printf("       layout '%s' covers %.6f\n",
-                            qPrintable(id), totalArea(panCellsForLayout(id)));
+        // The id -> cell-count expectations, duplicated here on purpose.
+        //
+        // These are the same numbers as PanadapterStack's kLayoutPanCounts and
+        // PanLayoutDialog's kAllLayouts, but those live in the GUI target this
+        // headless test does not link, so nothing compares them automatically.
+        // Spelling them out means a change to ClassicLayout's table fails HERE
+        // rather than drifting silently; a change to either GUI table still
+        // has to be mirrored by hand (see the DRIFT WARNING in ClassicLayout.cpp).
+        const QList<QPair<QString, int>> kExpectedCounts = {
+            {QStringLiteral("1"),   1}, {QStringLiteral("2v"),  2},
+            {QStringLiteral("2h"),  2}, {QStringLiteral("2h1"), 3},
+            {QStringLiteral("12h"), 3}, {QStringLiteral("3v"),  3},
+            {QStringLiteral("2x2"), 4}, {QStringLiteral("4v"),  4},
+            {QStringLiteral("3h2"), 5}, {QStringLiteral("2x3"), 6},
+            {QStringLiteral("4h3"), 7}, {QStringLiteral("2x4"), 8},
+        };
+
+        bool countsMatch = true;
+        for (const auto& expected : kExpectedCounts) {
+            const int actual = panCountForLayout(expected.first);
+            if (actual != expected.second) {
+                countsMatch = false;
+                std::printf("       layout '%s': expected %d cells, got %d\n",
+                            qPrintable(expected.first), expected.second, actual);
             }
         }
-        report("every layout tiles the surface exactly", allTile);
+        report("every layout id has the expected cell count", countsMatch);
+        report("the table holds exactly the expected ids",
+               knownPanLayoutIds().size() == kExpectedCounts.size());
 
-        report("pan counts match the layout ids",
-               panCountForLayout(QStringLiteral("2x4")) == 8
-                   && panCountForLayout(QStringLiteral("3h2")) == 5
-                   && panCountForLayout(QStringLiteral("1")) == 1);
+        // Cells must not overlap and must leave no gap.  Area alone cannot
+        // see either — equal rows of equal cells always sum to 1.0, typo or
+        // not — so this walks the actual rectangles: every probe point in the
+        // unit square must land in exactly one cell.
+        bool partitions = true;
+        for (const QString& id : knownPanLayoutIds()) {
+            const QList<NormRect> cells = panCellsForLayout(id);
+            if (!nearly(totalArea(cells), 1.0, 1e-9)) {
+                partitions = false;
+                std::printf("       layout '%s' covers %.6f\n",
+                            qPrintable(id), totalArea(cells));
+                continue;
+            }
+            for (int px = 0; px < 20 && partitions; ++px) {
+                for (int py = 0; py < 20 && partitions; ++py) {
+                    const double x = (px + 0.5) / 20.0;
+                    const double y = (py + 0.5) / 20.0;
+                    int hits = 0;
+                    for (const NormRect& cell : cells) {
+                        if (cell.contains(x, y)) {
+                            ++hits;
+                        }
+                    }
+                    if (hits != 1) {
+                        partitions = false;
+                        std::printf("       layout '%s': point (%.3f, %.3f) "
+                                    "is in %d cells\n",
+                                    qPrintable(id), x, y, hits);
+                    }
+                }
+            }
+        }
+        report("every layout partitions the surface — no gap, no overlap",
+               partitions);
 
         report("an unknown layout id yields nothing",
                panCellsForLayout(QStringLiteral("nope")).isEmpty()

--- a/tests/workspace_store_test.cpp
+++ b/tests/workspace_store_test.cpp
@@ -350,6 +350,108 @@ int main(int argc, char** argv)
                    && !migratedAgain);
     }
 
+    // ── The write block: refusing to parse is only half a guard ──────────
+    //
+    // The first round closed the overwrite at loadOrMigrate(). It was still
+    // open one call further along: nothing consulted the failed load on the
+    // WRITE path, so a single setDocument() or touch() from phase 3 — a canvas
+    // resize while the error is on screen is enough — would commit an empty
+    // default document over the row this build could not read.
+    {
+        const QString newerDocument = QStringLiteral(
+            R"({"version":99,"activeWorkspace":"from-the-future",)"
+            R"("workspaces":[{"id":"from-the-future","surfaces":[]}]})");
+
+        AppSettings::instance().setStationValue(WorkspaceStore::kSettingsKey,
+                                                newerDocument);
+        AppSettings::instance().save();
+
+        WorkspaceStore store;
+        store.loadWithStatus();
+        report("a refused load arms the write block", store.isWriteBlocked());
+
+        QSignalSpy flushSpy(&store, &WorkspaceStore::flushed);
+
+        // Exactly the phase-3 accident: an ordinary edit after a failed load.
+        store.setDocument(docWith(QStringLiteral("accident"),
+                                  QStringLiteral("applet:OOPS")));
+        report("an explicit flush is suppressed",
+               store.flushWithStatus() == WorkspaceStore::FlushResult::Suppressed);
+        report("no write was emitted", flushSpy.count() == 0);
+
+        // And the debounce must not sneak one through either.
+        store.setDebounceMs(20);
+        store.touch();
+        waitFor([&flushSpy] { return flushSpy.count() > 0; }, 300);
+        report("the debounce cannot bypass the write block", flushSpy.count() == 0);
+
+        report("the newer document is still intact", storedOnDisk() == newerDocument);
+
+        // Only an explicit decision clears it.
+        store.allowOverwrite();
+        report("allowOverwrite clears the block", !store.isWriteBlocked());
+        report("...and then the write lands", store.flush());
+        report("...over the old document", storedOnDisk().contains("applet:OOPS"));
+    }
+
+    // ── A dirty write-blocked store does not commit at teardown either ───
+    {
+        AppSettings::instance().setStationValue(WorkspaceStore::kSettingsKey,
+                                                QStringLiteral("{ corrupt"));
+        AppSettings::instance().save();
+        {
+            WorkspaceStore store;
+            store.loadWithStatus();
+            store.setDocument(docWith(QStringLiteral("teardown-blocked"),
+                                      QStringLiteral("applet:NOPE")));
+        }
+        report("teardown respects the write block",
+               storedOnDisk() == QStringLiteral("{ corrupt"));
+    }
+
+    // ── flush() distinguishes suppressed from clean ──────────────────────
+    {
+        AppSettings::instance().removeStationValue(WorkspaceStore::kSettingsKey);
+        AppSettings::instance().save();
+
+        WorkspaceStore store;
+        store.setDocument(docWith(QStringLiteral("tri"), QStringLiteral("applet:RX")));
+        store.flush();
+
+        report("a clean store reports Clean",
+               store.flushWithStatus() == WorkspaceStore::FlushResult::Clean);
+
+        store.touch();
+        store.setRestoring(true);
+        report("a restoring store reports Suppressed",
+               store.flushWithStatus() == WorkspaceStore::FlushResult::Suppressed);
+        store.setRestoring(false);
+        report("and a pending change reports Wrote",
+               store.flushWithStatus() == WorkspaceStore::FlushResult::Wrote);
+    }
+
+    // ── An empty-but-valid document is Absent, not Loaded ────────────────
+    //
+    // Otherwise loadOrMigrate() succeeds holding no workspace at all and never
+    // migrates, leaving phase 3 with nothing to show and no way to get it.
+    {
+        AppSettings::instance().setStationValue(
+            WorkspaceStore::kSettingsKey,
+            QStringLiteral(R"({"version":1,"activeWorkspace":"","workspaces":[]})"));
+        AppSettings::instance().save();
+
+        WorkspaceStore store;
+        report("a document with no workspaces reads as Absent",
+               store.loadWithStatus() == WorkspaceStore::LoadResult::Absent);
+        report("...so it is not write-blocked", !store.isWriteBlocked());
+
+        bool migrated = false;
+        report("...and loadOrMigrate migrates into it",
+               store.loadOrMigrate({"RX"}, {"0x40000000"}, &migrated) && migrated);
+        report("...producing a real workspace",
+               store.document().workspaceIds() == QStringList({"classic"}));
+    }
+
     std::printf("\n%s\n", g_failures == 0 ? "All checks passed." : "FAILURES present.");
     return g_failures == 0 ? 0 : 1;
 }

--- a/tests/workspace_store_test.cpp
+++ b/tests/workspace_store_test.cpp
@@ -1,0 +1,281 @@
+// WorkspaceStore — persistence and the auto-commit contract (RFC #4887,
+// phase 2), against a real AppSettings in a temporary home.
+//
+// The contract under test is RFC decision 7: placement changes commit as they
+// happen, so an automatic workspace switch can never discard unsaved work.
+// That is only true if three things hold, and each is asserted here:
+//
+//   1. a flush actually reaches DISK — not just the in-memory settings map.
+//      AppSettings deliberately keeps a failed save in memory for retry, so a
+//      cache re-read would pass even when nothing was committed; the store
+//      test therefore reads the row back from the FILE (Principle VIII, and
+//      the pattern AppSettings::readStationRowFromDisk exists for).
+//   2. a gesture COALESCES — one drag must not produce hundreds of
+//      whole-document writes.
+//   3. replaying saved state does NOT write back what it is reading — the
+//      #4427 rule, inherited from ContainerManager rather than reinvented.
+
+#include "TestSettingsProfile.h"
+
+#include "core/AppSettings.h"
+#include "gui/workspace/WorkspaceStore.h"
+
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QSignalSpy>
+#include <QStringList>
+
+#include <cstdio>
+#include <iostream>
+
+using AetherSDR::AppSettings;
+using AetherSDR::CanvasItem;
+using AetherSDR::NormRect;
+using AetherSDR::Workspace;
+using AetherSDR::WorkspaceDocument;
+using AetherSDR::WorkspaceStore;
+using AetherSDR::WorkspaceSurface;
+
+namespace {
+
+int g_failures = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) {
+        ++g_failures;
+    }
+}
+
+WorkspaceDocument docWith(const QString& workspaceId, const QString& itemId)
+{
+    CanvasItem item;
+    item.id   = itemId;
+    item.rect = NormRect{0.0, 0.0, 0.5, 0.5};
+
+    WorkspaceSurface main;
+    main.id = WorkspaceSurface::kMainId;
+    main.items.append(item);
+
+    Workspace ws;
+    ws.id    = workspaceId;
+    ws.label = workspaceId;
+    ws.surfaces.append(main);
+
+    WorkspaceDocument doc;
+    doc.workspaces.append(ws);
+    doc.activeWorkspace = workspaceId;
+    return doc;
+}
+
+// What is actually on disk, not what the settings cache believes.
+QString storedOnDisk()
+{
+    QString value;
+    if (!AppSettings::instance().readStationRowFromDisk(WorkspaceStore::kSettingsKey,
+                                                        value)) {
+        return {};
+    }
+    return value;
+}
+
+// Spin the event loop until `predicate` holds or the budget runs out, so the
+// debounce cases neither sleep blindly nor hang a CI run.
+bool waitFor(const std::function<bool()>& predicate, int budgetMs)
+{
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < budgetMs) {
+        if (predicate()) {
+            return true;
+        }
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    }
+    return predicate();
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile profile(QStringLiteral("aether-workspace-store-test"));
+    if (!profile.isValid()) {
+        std::cerr << "[FAIL] create temporary home\n";
+        return 1;
+    }
+    QCoreApplication app(argc, argv);
+    AppSettings::instance().load();
+
+    // ── An empty store ───────────────────────────────────────────────────
+    {
+        WorkspaceStore store;
+        report("loading an empty store fails cleanly", !store.load());
+        report("...and is not marked loaded", !store.isLoaded());
+        report("...and says why", !store.lastError().isEmpty());
+    }
+
+    // ── Write, and prove it reached disk ─────────────────────────────────
+    {
+        WorkspaceStore store;
+        store.setDocument(docWith(QStringLiteral("classic"), QStringLiteral("applet:RX")));
+        report("setDocument marks the store dirty", store.isDirty());
+
+        QSignalSpy flushSpy(&store, &WorkspaceStore::flushed);
+        report("flush reports that it wrote", store.flush());
+        report("...and is clean afterwards", !store.isDirty());
+        report("...and emitted flushed once", flushSpy.count() == 1);
+
+        // The load-bearing assertion: the row is on the FILE, not merely in
+        // the settings cache.
+        report("the document reached disk", storedOnDisk().contains("applet:RX"));
+
+        report("flushing a clean store is a no-op", !store.flush());
+    }
+
+    // ── Read back in a fresh store ───────────────────────────────────────
+    {
+        WorkspaceStore store;
+        report("a stored document loads", store.load());
+        report("...and is marked loaded", store.isLoaded());
+        report("...with no warnings", store.warnings().isEmpty());
+        report("...and carries its content",
+               store.document().activeWorkspace == QStringLiteral("classic")
+                   && store.document()
+                              .workspace(QStringLiteral("classic"))
+                              ->surface(WorkspaceSurface::kMainId)
+                              ->items.size() == 1);
+        report("a freshly loaded store is clean", !store.isDirty());
+    }
+
+    // ── A gesture coalesces into one write ───────────────────────────────
+    {
+        WorkspaceStore store;
+        store.load();
+        store.setDebounceMs(30);
+
+        QSignalSpy flushSpy(&store, &WorkspaceStore::flushed);
+
+        // Stand in for a drag: many placement changes in quick succession.
+        for (int i = 0; i < 200; ++i) {
+            store.touch();
+        }
+        report("a gesture in progress has not written yet", flushSpy.count() == 0);
+
+        report("the debounce eventually fires",
+               waitFor([&flushSpy] { return flushSpy.count() > 0; }, 2000));
+        report("200 changes produced exactly one write", flushSpy.count() == 1);
+        report("...and the store is clean again", !store.isDirty());
+    }
+
+    // ── Ending a gesture flushes immediately ─────────────────────────────
+    {
+        WorkspaceStore store;
+        store.load();
+        store.setDebounceMs(60'000);   // long enough that only an explicit flush can win
+
+        QSignalSpy flushSpy(&store, &WorkspaceStore::flushed);
+        store.setDocument(docWith(QStringLiteral("contest"), QStringLiteral("applet:TX")));
+        report("a pending change has not written", flushSpy.count() == 0);
+
+        store.flush();
+        report("the end of a gesture writes immediately", flushSpy.count() == 1);
+        report("...and it reached disk", storedOnDisk().contains("applet:TX"));
+    }
+
+    // ── Restoring must not write back what it is reading (#4427) ─────────
+    {
+        WorkspaceStore store;
+        store.load();
+        store.setDebounceMs(10);
+
+        QSignalSpy flushSpy(&store, &WorkspaceStore::flushed);
+
+        store.setRestoring(true);
+        store.setDocument(docWith(QStringLiteral("replayed"), QStringLiteral("applet:VU")));
+        store.touch();
+        report("a flush during restore is refused", !store.flush());
+
+        // Give the debounce every chance to fire behind our back.
+        waitFor([] { return false; }, 100);
+        report("no write happened while restoring", flushSpy.count() == 0);
+        report("the change is still pending", store.isDirty());
+        report("nothing was written to disk",
+               !storedOnDisk().contains("applet:VU"));
+
+        // Leaving restore must not flush by itself — it leaves the store as
+        // dirty as it found it, for the caller to decide.
+        store.setRestoring(false);
+        report("leaving restore does not write on its own", flushSpy.count() == 0);
+        report("...and the change is still pending", store.isDirty());
+
+        report("an explicit flush after restore works", store.flush());
+        report("...and reaches disk", storedOnDisk().contains("applet:VU"));
+    }
+
+    // ── A dirty store commits at destruction ─────────────────────────────
+    //
+    // Auto-commit promises there is no unsaved work; a store torn down with a
+    // pending debounce would be exactly that.
+    {
+        {
+            WorkspaceStore store;
+            store.load();
+            store.setDebounceMs(60'000);
+            store.setDocument(docWith(QStringLiteral("teardown"),
+                                      QStringLiteral("applet:CAT")));
+            report("the change is pending at teardown", store.isDirty());
+        }
+        report("teardown committed the pending change",
+               storedOnDisk().contains("applet:CAT"));
+    }
+
+    // ── A corrupt stored document is refused, not half-adopted ───────────
+    {
+        AppSettings::instance().setStationValue(WorkspaceStore::kSettingsKey,
+                                                QStringLiteral("{ not json"));
+        AppSettings::instance().save();
+
+        WorkspaceStore store;
+        report("a corrupt document fails to load", !store.load());
+        report("...and the store is not marked loaded", !store.isLoaded());
+        report("...and reports the parse error", !store.lastError().isEmpty());
+    }
+
+    // ── loadOrMigrate falls back to Classic, once ────────────────────────
+    {
+        AppSettings::instance().removeStationValue(WorkspaceStore::kSettingsKey);
+        AppSettings::instance().save();
+
+        AppSettings::instance().setValue(QStringLiteral("Applet_RX"),
+                                         QStringLiteral("True"));
+        AppSettings::instance().setValue(QStringLiteral("PanadapterLayout"),
+                                         QStringLiteral("2v"));
+
+        WorkspaceStore store;
+        bool migrated = false;
+        report("loadOrMigrate succeeds with nothing stored",
+               store.loadOrMigrate({"RX", "TX"}, {"0x40000000"}, &migrated));
+        report("...and reports that it migrated", migrated);
+        report("...producing Classic",
+               store.document().activeWorkspace == QStringLiteral("classic"));
+        report("...which it wrote to disk", storedOnDisk().contains("classic"));
+
+        // The legacy keys are left in place: dual-write for a release means a
+        // downgrade still finds the state it expects.
+        report("migration does not delete the legacy keys",
+               AppSettings::instance().contains(QStringLiteral("Applet_RX"))
+                   && AppSettings::instance().contains(QStringLiteral("PanadapterLayout")));
+
+        // Second time around there IS a document, so migration must not run
+        // again and overwrite whatever the operator has since arranged.
+        WorkspaceStore second;
+        bool migratedAgain = true;
+        report("a second loadOrMigrate loads instead of migrating",
+               second.loadOrMigrate({"RX", "TX"}, {"0x40000000"}, &migratedAgain)
+                   && !migratedAgain);
+    }
+
+    std::printf("\n%s\n", g_failures == 0 ? "All checks passed." : "FAILURES present.");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/workspace_store_test.cpp
+++ b/tests/workspace_store_test.cpp
@@ -240,6 +240,80 @@ int main(int argc, char** argv)
         report("a corrupt document fails to load", !store.load());
         report("...and the store is not marked loaded", !store.isLoaded());
         report("...and reports the parse error", !store.lastError().isEmpty());
+        report("...and is reported as unusable, not absent",
+               store.loadWithStatus() == WorkspaceStore::LoadResult::Unusable);
+    }
+
+    // ── A present-but-unusable document is NEVER migrated over ───────────
+    //
+    // The failure this closes: an operator runs a build whose schema is newer,
+    // hits a bug, downgrades. If loadOrMigrate() treated "refused" the same as
+    // "absent", it would write a v1 Classic over the v2 document and every
+    // workspace, binding and surface the newer build held would be gone — the
+    // exact loss WorkspaceDocument's newer-schema guard exists to prevent.
+    {
+        const QString newerDocument = QStringLiteral(
+            R"({"version":99,"activeWorkspace":"from-the-future",)"
+            R"("workspaces":[{"id":"from-the-future","surfaces":[]}]})");
+
+        AppSettings::instance().setStationValue(WorkspaceStore::kSettingsKey,
+                                                newerDocument);
+        AppSettings::instance().save();
+
+        WorkspaceStore store;
+        report("a newer-schema document is refused",
+               store.loadWithStatus() == WorkspaceStore::LoadResult::Unusable);
+
+        bool migrated = true;
+        report("loadOrMigrate refuses rather than migrating over it",
+               !store.loadOrMigrate({"RX"}, {"0x40000000"}, &migrated));
+        report("...and reports that it did not migrate", !migrated);
+        report("...and says why", store.lastError().contains(QStringLiteral("newer")));
+
+        // The load-bearing assertion: the newer document is still on disk,
+        // byte for byte, for the build that understands it.
+        report("the newer document survives untouched",
+               storedOnDisk() == newerDocument);
+
+        // Same for damage that is merely corrupt.
+        AppSettings::instance().setStationValue(WorkspaceStore::kSettingsKey,
+                                                QStringLiteral("{ truncated"));
+        AppSettings::instance().save();
+
+        WorkspaceStore corrupt;
+        report("a corrupt document is not migrated over either",
+               !corrupt.loadOrMigrate({"RX"}, {"0x40000000"}));
+        report("...and it also survives", storedOnDisk() == QStringLiteral("{ truncated"));
+    }
+
+    // ── A change made during restore still gets its debounce ─────────────
+    //
+    // touch() starts no timer while suppressed, so leaving restore has to
+    // rearm it — otherwise the change waits for the next unrelated touch(),
+    // an explicit flush(), or the destructor, and a crash skips the last one.
+    {
+        AppSettings::instance().removeStationValue(WorkspaceStore::kSettingsKey);
+        AppSettings::instance().save();
+
+        WorkspaceStore store;
+        store.setDocument(docWith(QStringLiteral("base"), QStringLiteral("applet:RX")));
+        store.flush();
+        store.setDebounceMs(30);
+
+        QSignalSpy flushSpy(&store, &WorkspaceStore::flushed);
+
+        store.setRestoring(true);
+        store.setDocument(docWith(QStringLiteral("during"),
+                                  QStringLiteral("applet:DURING")));
+        report("nothing is written while restoring", flushSpy.count() == 0);
+
+        store.setRestoring(false);
+        report("leaving restore still does not write immediately",
+               flushSpy.count() == 0);
+        report("...but the debounce is rearmed and fires on its own",
+               waitFor([&flushSpy] { return flushSpy.count() > 0; }, 2000));
+        report("...and the change reached disk",
+               storedOnDisk().contains("applet:DURING"));
     }
 
     // ── loadOrMigrate falls back to Classic, once ────────────────────────


### PR DESCRIPTION
## Summary

Phases 1 and 2 of the workspace canvas (RFC #4887, [approved](https://github.com/aethersdr/AetherSDR/issues/4887#issuecomment-5255588764)
including all eight decisions): the canvas core and its persistence layer. **No behaviour changes.**
Nothing is mounted, nothing is migrated at runtime, and no new settings key is
written on any install — the first caller of all of this is phase 3.

Shipping the two phases together because phase 1 alone has no consumer and phase 2
alone has nothing to persist.

**Phase 1 — canvas core.** Placement is stored as *fractions of the canvas*, never
pixels, so a layout authored on a 3840×1600 display restores in proportion on a
1920×1080 laptop. Rect edges are rounded independently rather than origin+size, so
two items sharing a normalized edge land on the same pixel column at every canvas
size — round the other way and a tiled arrangement grows hairline seams that move
as the window is resized.

- `WorkspaceGeometry` — `NormRect`, pixel↔fraction mapping, clamping
- `CanvasItem` — one placed item (pure data, header-only)
- `CanvasLayout` — membership, placement clamping, hit testing, z-order. z is kept
  dense and contiguous after every mutation: sparse or duplicated z is the bug that
  makes raise/lower quietly stop working after enough operations
- `WorkspaceCanvas` — thin `QWidget` over the model. `takeItem()` hands a widget
  back **alive**, which is the call phase 3 needs to move an applet between a canvas
  and a container

**Phase 2 — persistence and migration.** One station-scoped key, one writer, one
atomic whole-document write. The arrangement this replaces is spread across a dozen
independent settings keys with three schemas and no single writer, so a shutdown
path that skips one restores a *mixture* of two layouts.

- `WorkspaceDocument` — workspaces, surfaces, items, radio-profile bindings as one
  versioned object. A **newer** schema is refused rather than re-written from this
  build's understanding; repairable damage is repaired *and reported*
- `ClassicLayout` — today's two-region shell as canvas placement, plus the pan
  layout table as data (all twelve ids, each asserted to tile the surface exactly)
- `WorkspaceMigration` — the real legacy keys → a Classic workspace
- `WorkspaceStore` — persistence plus the auto-commit contract

Two behaviours worth calling out explicitly:

**Migration does not pull floating things onto the canvas.** Pop-out stays (RFC
decision 1), so a floated pan or applet is recorded as floating and left exactly
where it is. Phase 6's "import current pop-out arrangement" is the opt-in that does
otherwise.

**Auto-commit implies write volume** — one drag is hundreds of geometry changes and
every commit is a whole-document write by construction. Writes debounce during a
gesture and flush at its end, a dirty store commits at destruction, and flushes are
suppressed while a restore replays saved state.

## Constitution principle honored

- **Principle V** — the workspace document is one feature-owned, versioned object
  under a single key, replacing a dozen scattered flat keys. No new flat-key
  `AppSettings` calls are added; the legacy ones are only *read*, by the migration.
- **Principle XIV** — one whole-document write *is* the atomic update: there is no
  partial state a crash between two calls could leave, because there is only ever
  one call.
- **Principle VII** — the settings store is a file a user can edit and a backup can
  restore, so document parsing validates at the boundary: refuse what cannot be
  trusted, repair and report what can.
- **Principle VIII** — the store test verifies writes by reading the row back from
  the **file**, not the settings cache. `AppSettings` deliberately keeps a failed
  save in memory for retry, so a cache re-read would pass even when nothing was
  committed.
- **Principle XI** — the contract each phase claims is asserted, not described:
  seam-free edges swept across five canvas widths, the z invariant re-checked after
  every mutation, and the #4427 restore-suppression rule pinned.

## Test plan

- [x] Local build passes (`cmake --build build`) — full app target links clean, no
      new warnings
- [ ] Behavior verified on a real radio if applicable — **n/a**, no runtime path
      reaches this code yet
- [x] Existing tests pass (CI)
- [x] **The six new suites now run in CI** — they did not when this PR was opened
      (see H2 below); a gate step on the Linux job runs them at a measured
      244/250/243 ms
- [ ] Reproduction steps documented if user-reported bug — n/a

**280 checks across six new suites, all passing:**

| Suite | Checks | Covers |
|---|---|---|
| `workspace_geometry_test` | 27 | seam-free edges, round-trip stability, resolution independence, degenerate input |
| `workspace_layout_test` | 50 | membership, clamping, hit testing, z invariant after every mutation |
| `workspace_canvas_widget_test` | 52 | offscreen: real geometry, real Qt stacking, take-vs-remove ownership |
| `workspace_document_test` | 40 | round trip, newer-schema guard, boundary repairs |
| `workspace_migration_test` | 43 | every layout id tiles exactly, legacy key reading, floats left alone, corrupt `ContainerTree` |
| `workspace_store_test` | 68 | disk-verified writes, gesture coalescing, restore suppression, migrate-once |

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — the document is one JSON object under
      one station key (Principle V)
- [x] Code is clean-room
- [x] All meter UI uses `MeterSmoother` — n/a, no meters
- [x] Documentation updated if user-visible behavior changed — n/a, no user-visible
      change; the legacy key inventory is documented in `WorkspaceMigration.h`
- [x] Security-sensitive changes reference a GHSA if applicable — n/a

## Review rounds

Two rounds landed after opening, both worth reading for anyone reviewing this:

- **34a1ca49** — six findings from the automated pass, including a
  `loadOrMigrate()` path that rewrote a newer-schema document.
- **37e37df5** — @NF0T's red-team pass and @ten9876's review. The headline is
  **H1**: the newer-schema guard was *read-side only*, so the same total loss was
  still reachable one call further along — any `setDocument()` or `touch()` after
  a failed load. A refused load now arms a write block that only an explicit
  `allowOverwrite()` clears. **H2**: none of the six suites ran in any CI job, so
  by Principle VIII every assertion in the table below was a hypothesis; there is
  now a gate step for them.

## Notes for review

- **Sequencing:** the canvas is the trunk. RFC decision 4 now has it landing first
  with other work rebasing onto it, including the frameless retrofit (#4764 /
  #4906) — so phase 3 is unblocked rather than waiting on that PR. This one is
  easy either way: phases 1–2 touch no shared file at all (new files plus
  `CMakeLists.txt`), so it conflicts with nothing currently open.
- **`loadOrMigrate()` is deliberately uncalled.** Wiring it now would write a
  `Workspaces` key on every install for a document nothing reads. Phase 3 is its
  first caller, which is also when "dual-write for one release" starts.
- **`kClassicAppletColumnWidth = 0.18`** approximates the real fixed-width applet
  panel at a typical window size. Phase 3 can refine it from the panel's own width
  hint once the canvas hosts it.
- The RFC's key table in Problem §4 was written from a grep and is looser than the
  code; the precise inventory is in `src/gui/workspace/WorkspaceMigration.h`, and
  the RFC has been corrected in place.

Refs #4887

🤖 Generated with [Claude Code](https://claude.com/claude-code)
