### PR TITLE
fix(hl2): bypass the TX ALC for client-leveled TCI/DAX audio (#4796)

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -8742,8 +8742,10 @@ void AudioEngine::feedDaxTxAudioInternal(const QByteArray& inPcm,
         // markExternalSource is the source split this tap needs (#4796): true
         // for TCI/DAX client audio, whose sender owns its level and must not
         // get ALC makeup gain; false for the engine's own pre-shaped audio
-        // (WSPR pump, AX.25 modem), which is generated below full scale and
-        // keeps the ALC so its on-air level does not change.
+        // (WSPR pump, AX.25 modem, RADE modem waveform — all reaching here
+        // via sendModemTxAudio or the WSPR pump with markExternalSource
+        // false), which the engine generates at a known level and which keeps
+        // the ALC so its on-air level does not change.
         emit txFinalMonitorPcmReady(out, /*clientLeveled=*/markExternalSource);
         return;
     }

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -8251,7 +8251,9 @@ void AudioEngine::onTxAudioReady()
     // Expose the post-limiter int16 stream so the QSO recorder captures voice TX
     // for Client-Side recording (#3556). Emitted unconditionally; the recorder
     // slot fast-returns when not recording / not transmitting, so this is cheap.
-    emit txFinalMonitorPcmReady(data);
+    // Mic-chain audio: the level is ours to manage, so the backend's ALC stays
+    // in play.
+    emit txFinalMonitorPcmReady(data, /*clientLeveled=*/false);
 
     // ── TX post-final-limiter scope tap ─────────────────────────
     // Sampled here, AFTER everything the strip can do to the audio
@@ -8737,7 +8739,12 @@ void AudioEngine::feedDaxTxAudioInternal(const QByteArray& inPcm,
             dst[i] = static_cast<qint16>(
                 std::clamp(v * 32768.0f, -32768.0f, 32767.0f));
         }
-        emit txFinalMonitorPcmReady(out);
+        // markExternalSource is the source split this tap needs (#4796): true
+        // for TCI/DAX client audio, whose sender owns its level and must not
+        // get ALC makeup gain; false for the engine's own pre-shaped audio
+        // (WSPR pump, AX.25 modem), which is generated below full scale and
+        // keeps the ALC so its on-air level does not change.
+        emit txFinalMonitorPcmReady(out, /*clientLeveled=*/markExternalSource);
         return;
     }
 

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -616,7 +616,15 @@ signals:
     // which is RADE-only), so it is the source for Client-Side TX recording:
     // connect to QsoRecorder::feedTxAudio (#3556). Emitted from the audio thread;
     // receivers connect via Qt::AutoConnection (queued across threads).
-    void txFinalMonitorPcmReady(const QByteArray& int16Stereo);
+    //
+    // `clientLeveled` is true when the frames came from an external TCI/DAX
+    // client (feedDaxTxAudio's markExternalSource) rather than the mic chain or
+    // the engine's own tone generators. Such a client owns its level — WSJT-X's
+    // Pwr slider attenuates the audio it streams — and a host-modulating
+    // backend must not run makeup gain over it (#4796). Slots that only record
+    // or meter the stream can ignore the flag (Qt permits connecting to a slot
+    // with fewer arguments).
+    void txFinalMonitorPcmReady(const QByteArray& int16Stereo, bool clientLeveled);
     // Local CW/CWX sidetone for the Client-Side QSO recorder (#2539), 24 kHz
     // stereo int16 — the recorder's native WAV format. Pumped on the audio
     // thread while the radio is keyed for CW (no mic-driven onTxAudioReady in

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -550,10 +550,19 @@ public:
     // compressor and EQ before this point. That is deliberate — the TONE button,
     // the microphone and any future source all reach the air through ONE path,
     // so what the operator monitors is what gets transmitted.
-    virtual void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz)
+    //
+    // `clientLeveled` is true when the audio came from an external TCI/DAX
+    // client rather than the mic chain or the engine's own generators. The
+    // sender of such audio has already applied its own level control, so a
+    // host-modulating backend must not run makeup gain (ALC) over it (#4796).
+    // No default argument — defaults on virtuals bind statically, and the
+    // override a caller actually reaches would quietly diverge from it.
+    virtual void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz,
+                               bool clientLeveled)
     {
         Q_UNUSED(int16Stereo);
         Q_UNUSED(sampleRateHz);
+        Q_UNUSED(clientLeveled);
     }
 
     // ---- diagnostics ----

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -3277,15 +3277,26 @@ void Hl2Backend::setTxFilter(int lowHz, int highHz)
 // fine enough to set by ear and wide enough to cover the range between a headset
 // boom mic and a built-in laptop microphone.
 //
-// WHAT THIS DOES AND DOES NOT BUY, because the ALC sits right behind it:
-// Hl2TxDsp's ALC normalizes each block's peak to alcTargetPeak, so raising mic
-// gain on already-loud speech is largely given back and PEP barely moves. Where
-// it MATTERS is the ALC's hold threshold (alcHoldBelowDbfs, -45 dBFS): below
-// that the ALC deliberately stops lifting, so a microphone quiet enough to sit
-// under it gets no makeup at all and goes out weak. This slider is what carries
-// such a mic over the threshold — which is exactly what setKeying()'s "raise mic
-// gain" diagnostic tells the operator to do, and until now that advice pointed
-// at a control that did nothing on this backend.
+// WHAT THIS DOES AND DOES NOT BUY depends on which path the audio took, because
+// the ALC sits right behind this and is one-sided for client-leveled audio
+// (#4796).
+//
+// MIC PATH: the ALC normalizes each block's peak to alcTargetPeak, so raising
+// mic gain on already-loud speech is largely given back and PEP barely moves.
+// Where it MATTERS is the ALC's hold threshold (alcHoldBelowDbfs, -45 dBFS):
+// below that the ALC deliberately stops lifting, so a microphone quiet enough to
+// sit under it gets no makeup at all and goes out weak. This slider is what
+// carries such a mic over the threshold — which is exactly what setKeying()'s
+// "raise mic gain" diagnostic tells the operator to do, and until that
+// diagnostic existed the advice pointed at a control that did nothing here.
+//
+// CLIENT-LEVELED PATH (TCI/DAX): nothing is given back. The ALC may only reduce,
+// never lift, so this is a straight proportional attenuator all the way up to
+// alcTargetPeak — TX gain 5 is a real -18 dB on the air. The hold threshold does
+// not apply, and neither does the "raise mic gain" diagnostic, which setKeying()
+// gates off for such transmissions. Past the target the ALC limits rather than
+// letting the modulator's clamp flat-top the signal, so the last stretch of
+// travel buys reduced headroom rather than more power.
 //
 // Level 0 mutes outright rather than resolving to -20 dB. A slider at the bottom
 // of its travel means off, and a mic that is merely 20 dB down would still be
@@ -3489,7 +3500,14 @@ IRadioBackend::HealthSnapshot Hl2Backend::healthSnapshot() const
     // in a section whose thesis is "report what the modulator is running",
     // and a constant that silently stops matching the modulator is the row
     // nobody would think to suspect.
-    put("alcHoldBelowDbfs", QStringLiteral("ALC hold threshold (dBFS)"),
+    //
+    // Labelled as mic-path-only since #4796: the hold governs the ALC's MAKEUP
+    // half, and client-leveled (TCI/DAX) audio has no makeup half to hold — its
+    // gain is ceilinged at unity and released freely. A reader debugging a
+    // WSJT-X level problem against this row would otherwise chase a threshold
+    // that was never in their path.
+    put("alcHoldBelowDbfs",
+        QStringLiteral("ALC hold threshold (dBFS, mic path only)"),
         m_alcHoldBelowDbfs);
     put("alcGainDb", QStringLiteral("ALC gain applied (dB)"),
         std::isnan(m_alcGainDb) ? QVariant() : QVariant(m_alcGainDb));

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -3034,6 +3034,15 @@ void Hl2Backend::submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz,
     // Remember whether THIS transmission carried client-leveled audio, so the
     // unkey diagnostic knows a below-threshold peak was the client's own choice
     // of level rather than a microphone the ALC declined to lift.
+    //
+    // The sticky OR — and the per-block flag it forwards — lean on mic and
+    // client audio never interleaving inside one transmission: AudioEngine
+    // steps local mic capture aside while a TCI/DAX source is actively
+    // feeding (onTxAudioReady's tciAudioFresh() gate). If that mutual
+    // exclusion is ever relaxed, Hl2TxDsp would flip its ALC per block and
+    // process m_inBuffer residue under the newest block's flag — no crash,
+    // just a level that depends on block alignment. Whoever touches the
+    // mic-capture gate owns re-checking this.
     m_txAudioClientLeveled = m_txAudioClientLeveled || clientLeveled;
     if (sampleRateHz != 24000) {
         // Stated rather than silently resampled: the modulator's upsampler

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -2813,7 +2813,12 @@ void Hl2Backend::setKeying(bool key)
     // transmission because the pauses between words are what the hold is for.
     if (m_keyed && !key) {
         const double kHoldDbfs = m_alcHoldBelowDbfs;
-        if (m_txMicPeakMaxDbfs > -139.0f
+        // Not for client-leveled transmissions: the ALC is bypassed there
+        // (#4796), so a below-threshold peak is the client's own attenuation
+        // doing exactly what it asked for, and "raise mic gain" would send an
+        // operator chasing a control that was never in the path.
+        if (!m_txAudioClientLeveled
+            && m_txMicPeakMaxDbfs > -139.0f
             && m_txMicPeakMaxDbfs < static_cast<float>(kHoldDbfs)) {
             qCInfo(lcHl2) << "HL2 TX: microphone peaked at" << m_txMicPeakMaxDbfs
                           << "dBFS for the whole transmission, below the ALC hold"
@@ -2824,6 +2829,9 @@ void Hl2Backend::setKeying(bool key)
     }
     if (key) {
         m_txMicPeakMaxDbfs = -140.0f;
+        // A new transmission decides afresh whether it is client-leveled; the
+        // first submitTxAudio() block of the over re-marks it.
+        m_txAudioClientLeveled = false;
         // Start each transmission's peak hold from nothing, rather than trusting
         // the unkeyed branch in publishTelemetry() to have already walked it
         // down. Telemetry is 10 Hz, so a key inside 100 ms of the previous unkey
@@ -3014,7 +3022,8 @@ void Hl2Backend::applyFreqCalPpb(int ppb, bool persist)
     repushAllFrequencies();
 }
 
-void Hl2Backend::submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz)
+void Hl2Backend::submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz,
+                               bool clientLeveled)
 {
     // Only modulate while actually keyed. Feeding the modulator unkeyed would
     // fill the transmit queue with audio that goes out the instant MOX asserts —
@@ -3022,6 +3031,10 @@ void Hl2Backend::submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz)
     // syllable.
     if (!m_txDsp || !m_keyed || int16Stereo.isEmpty())
         return;
+    // Remember whether THIS transmission carried client-leveled audio, so the
+    // unkey diagnostic knows a below-threshold peak was the client's own choice
+    // of level rather than a microphone the ALC declined to lift.
+    m_txAudioClientLeveled = m_txAudioClientLeveled || clientLeveled;
     if (sampleRateHz != 24000) {
         // Stated rather than silently resampled: the modulator's upsampler
         // assumes this rate, and a mismatch transmits at the wrong pitch.
@@ -3044,8 +3057,9 @@ void Hl2Backend::submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz)
         const float r = static_cast<float>(pcm[2 * n + 1]) / 32768.0f;
         mono[static_cast<std::size_t>(n)] = 0.5f * (l + r);
     }
-    QMetaObject::invokeMethod(m_txDsp, [this, mono = std::move(mono)] {
-        m_txDsp->processAudioBlock(mono);
+    QMetaObject::invokeMethod(m_txDsp,
+                              [this, mono = std::move(mono), clientLeveled] {
+        m_txDsp->processAudioBlock(mono, clientLeveled);
     }, Qt::QueuedConnection);
 }
 

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -87,7 +87,8 @@ public:
     void removeNotch(int notchId) override;
     void setNotchesEnabled(bool on) override;
     void setKeying(bool key) override;
-    void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz) override;
+    void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz,
+                       bool clientLeveled) override;
     void setTxPower(int percent) override;
     void setTxFilter(int lowHz, int highHz) override;
     void setMicGain(int level) override;
@@ -612,6 +613,12 @@ private:
     // rather than merely stopping the stage pumping. -140 is the floor
     // Hl2TxDsp::micPeak reports for silence, and means "nothing measured yet".
     float m_txMicPeakMaxDbfs = -140.0f;
+
+    // True once the current transmission has carried client-leveled (TCI/DAX)
+    // audio, for which the ALC is bypassed (#4796). Gates the unkey "raise mic
+    // gain" diagnostic, whose advice only applies to the microphone path.
+    // Cleared on each key edge in setKeying().
+    bool m_txAudioClientLeveled = false;
 
     // The passband to push at the modulator for `mode`: the operator's if they
     // have chosen one, otherwise that mode's default.

--- a/src/core/backends/hl2/Hl2TxDsp.cpp
+++ b/src/core/backends/hl2/Hl2TxDsp.cpp
@@ -255,7 +255,9 @@ void Hl2TxDsp::processAudioBlock(const std::vector<float>& mono, bool clientLeve
             // there is no makeup gain to chase with, and holding would be
             // actively harmful — it is exactly the mechanism that would strand
             // a client-leveled transmission at the reduction its loudest block
-            // called for.
+            // called for. hl2_txdsp_test's limiter-release case pins this: its
+            // quiet leg sits below alcHoldBelowDbfs on purpose, and dropping
+            // the !clientLeveled term here latches that leg at -21.41 dB.
             const double holdThreshold =
                 std::pow(10.0, m_config.alcHoldBelowDbfs / 20.0);
             const bool held = !reducing && !clientLeveled

--- a/src/core/backends/hl2/Hl2TxDsp.cpp
+++ b/src/core/backends/hl2/Hl2TxDsp.cpp
@@ -197,26 +197,51 @@ void Hl2TxDsp::processAudioBlock(const std::vector<float>& mono, bool clientLeve
     // hiss, and the result is hard-limited below full scale afterwards, because
     // an ALC that can overshoot is a splatter generator.
     //
-    // Client-leveled audio bypasses the ALC entirely (#4796). A TCI/DAX client
-    // that attenuates its own tone — WSJT-X's Pwr slider is a digital
+    // Client-leveled audio is never given MAKEUP gain (#4796). A TCI/DAX
+    // client that attenuates its own tone — WSJT-X's Pwr slider is a digital
     // attenuator on the audio it streams, not a rig command — must see output
-    // proportional to what it sent. Through the ALC it saw two other things
-    // instead: above the hold threshold its level control was normalized away
-    // to alcTargetPeak, and below it the gain froze at whatever history left
-    // behind, so the same slider position produced RF or none depending on the
-    // path taken to it. Pinning unity here (not just skipping the update)
-    // keeps the reset()-on-unkey contract: the next mic transmission starts
-    // from unity either way.
-    if (m_config.alcEnabled && !clientLeveled) {
+    // proportional to what it sent. Through the ALC's makeup half it saw two
+    // other things instead: above the hold threshold its level control was
+    // normalized away to alcTargetPeak, and below it the gain froze at
+    // whatever history left behind, so the same slider position produced RF or
+    // none depending on the path taken to it.
+    //
+    // It still gets REDUCTION, because that half was never the bug. m_micGain
+    // reaches 10x (+20 dB, Hl2TxLevelPolicy.h) and is applied BEFORE this
+    // block, so a full-scale client with the TX gain slider up arrives ~17 dB
+    // into the hard clamp below — and flat-topping an SSB modulator input is a
+    // splatter generator, which is the one failure mode that harms other
+    // operators rather than the operator who caused it. The clamp is a
+    // backstop, not a level control; it must not become the only thing
+    // standing between a hot client and the band.
+    //
+    // So the bypass is one-sided, expressed as a CEILING on the gain rather
+    // than a branch around the loop: mic audio may be lifted to alcMaxGainDb,
+    // client-leveled audio may not be lifted past unity. Below alcTargetPeak
+    // the ceiling binds, the gain sits at exactly 1.0, and output is
+    // proportional — the whole reported range. Above it the ALC reduces on its
+    // normal 5 ms attack, so the response degrades to smooth limiting instead
+    // of clipping.
+    //
+    // Gating the INCREASE branch instead would have been the smaller edit and
+    // is wrong: once a loud block pulled the gain down, nothing could ever
+    // raise it again within the over, so a client sliding back down would stay
+    // attenuated at whatever the loudest block called for. That is
+    // path-dependent gain — the same class of defect as #4796, mirrored — and
+    // hl2_txdsp_test's recovery case pins it.
+    if (m_config.alcEnabled) {
         float blockPeak = 0.0f;
         for (std::size_t s = 0; s < consumed; ++s)
             blockPeak = std::max(blockPeak, std::fabs(
                 static_cast<float>(m_inBuffer[s] * m_micGain)));
 
         if (blockPeak > 1e-6f) {
+            // The ceiling is the whole of the client-leveled special case.
+            const double ceiling = clientLeveled
+                ? 1.0
+                : std::pow(10.0, m_config.alcMaxGainDb / 20.0);
             const double wanted = m_config.alcTargetPeak / blockPeak;
-            const double maxGain = std::pow(10.0, m_config.alcMaxGainDb / 20.0);
-            const double target = std::min(wanted, maxGain);
+            const double target = std::min(wanted, ceiling);
             // Per-block time constants. Attack when we need LESS gain (the
             // signal got louder) so overshoot is corrected immediately.
             const double blockSec = static_cast<double>(consumed)
@@ -224,9 +249,18 @@ void Hl2TxDsp::processAudioBlock(const std::vector<float>& mono, bool clientLeve
             const bool reducing = target < m_alcGain;
             // Hold the gain through pauses rather than winding it up on room
             // noise. Reduction is never held — see alcHoldBelowDbfs.
+            //
+            // The hold is a MIC-path concern only. It exists to stop makeup
+            // gain chasing room noise between syllables; under a unity ceiling
+            // there is no makeup gain to chase with, and holding would be
+            // actively harmful — it is exactly the mechanism that would strand
+            // a client-leveled transmission at the reduction its loudest block
+            // called for.
             const double holdThreshold =
                 std::pow(10.0, m_config.alcHoldBelowDbfs / 20.0);
-            if (reducing || blockPeak >= holdThreshold) {
+            const bool held = !reducing && !clientLeveled
+                           && blockPeak < holdThreshold;
+            if (!held) {
                 const double tau = reducing ? m_config.alcAttackSec
                                             : m_config.alcReleaseSec;
                 const double a = 1.0 - std::exp(-blockSec / std::max(1e-6, tau));
@@ -234,6 +268,9 @@ void Hl2TxDsp::processAudioBlock(const std::vector<float>& mono, bool clientLeve
             }
         }
     } else {
+        // ALC configured off: unity for every path. The clamp below is then the
+        // only over-level backstop on BOTH the mic and client paths, which is
+        // pre-existing behaviour for an operator who has turned the ALC off.
         m_alcGain = 1.0;
     }
     // Published unconditionally, including when the ALC is off and the answer

--- a/src/core/backends/hl2/Hl2TxDsp.cpp
+++ b/src/core/backends/hl2/Hl2TxDsp.cpp
@@ -168,7 +168,7 @@ bool Hl2TxDsp::isLowerSideband() const
     }
 }
 
-void Hl2TxDsp::processAudioBlock(const std::vector<float>& mono)
+void Hl2TxDsp::processAudioBlock(const std::vector<float>& mono, bool clientLeveled)
 {
     if (m_bandpass.empty() || mono.empty())
         return;
@@ -196,7 +196,18 @@ void Hl2TxDsp::processAudioBlock(const std::vector<float>& mono)
     // between words. The gain is capped so a quiet room is not amplified into
     // hiss, and the result is hard-limited below full scale afterwards, because
     // an ALC that can overshoot is a splatter generator.
-    if (m_config.alcEnabled) {
+    //
+    // Client-leveled audio bypasses the ALC entirely (#4796). A TCI/DAX client
+    // that attenuates its own tone — WSJT-X's Pwr slider is a digital
+    // attenuator on the audio it streams, not a rig command — must see output
+    // proportional to what it sent. Through the ALC it saw two other things
+    // instead: above the hold threshold its level control was normalized away
+    // to alcTargetPeak, and below it the gain froze at whatever history left
+    // behind, so the same slider position produced RF or none depending on the
+    // path taken to it. Pinning unity here (not just skipping the update)
+    // keeps the reset()-on-unkey contract: the next mic transmission starts
+    // from unity either way.
+    if (m_config.alcEnabled && !clientLeveled) {
         float blockPeak = 0.0f;
         for (std::size_t s = 0; s < consumed; ++s)
             blockPeak = std::max(blockPeak, std::fabs(

--- a/src/core/backends/hl2/Hl2TxDsp.h
+++ b/src/core/backends/hl2/Hl2TxDsp.h
@@ -98,14 +98,33 @@ public slots:
     //
     // `clientLeveled` marks audio whose level is owned by an external client —
     // TCI or DAX TX audio (WSJT-X, fldigi, the PipeWire bridge), where the
-    // sender has already applied its own power/attenuation control. The ALC is
-    // bypassed for such blocks: an ALC exists to close the 20-30 dB gap between
-    // a microphone and full modulation, and applied to a client that sets its
-    // own level it does the opposite of what either party wants — it normalizes
-    // the client's level control away above the hold threshold, and freezes
-    // into a path-dependent gain below it (#4796). The engine's own generated
-    // audio (WSPR beacon, AX.25 modem tones) arrives with this false and keeps
-    // the ALC, matching its on-air level to date.
+    // sender has already applied its own power/attenuation control.
+    //
+    // THE CONTRACT IS ONE-SIDED, and its two halves are different claims:
+    //
+    //   * The CLIENT owns its level upward. Nothing here adds gain it did not
+    //     ask for — the ALC's makeup half is ceilinged at unity for such
+    //     blocks. That half is #4796: an ALC exists to close the 20-30 dB gap
+    //     between a microphone and full modulation, and applied to a client
+    //     that sets its own level it does the opposite of what either party
+    //     wants — it normalizes the client's level control away above the hold
+    //     threshold, and freezes into a path-dependent gain below it.
+    //   * The MODULATOR owns its own ceiling. Reduction still applies, because
+    //     that half was never the bug. m_micGain reaches 10x (+20 dB), so a
+    //     full-scale client with the TX gain slider up arrives well inside the
+    //     hard clamp in processAudioBlock, and flat-topping an SSB modulator
+    //     input splatters across the band. That clamp is a backstop, not a
+    //     level control, and must not become the only thing standing between a
+    //     hot client and the air.
+    //
+    // The hold (alcHoldBelowDbfs) belongs to the makeup half and so applies to
+    // the mic path only. Leaving it on this path would strand a client-leveled
+    // over at whatever reduction its loudest block called for — #4796
+    // mirrored. hl2_txdsp_test pins all three of these claims.
+    //
+    // The engine's own generated audio (WSPR beacon, AX.25 modem tones, the
+    // RADE modem waveform) arrives with this false and keeps the whole ALC,
+    // matching its on-air level to date.
     void processAudioBlock(const std::vector<float>& mono, bool clientLeveled);
     // Drop anything buffered — on unkey, so the next transmission does not
     // start with the tail of the previous one.

--- a/src/core/backends/hl2/Hl2TxDsp.h
+++ b/src/core/backends/hl2/Hl2TxDsp.h
@@ -95,7 +95,18 @@ public:
 
 public slots:
     // Mono TX audio at inputSampleRateHz.
-    void processAudioBlock(const std::vector<float>& mono);
+    //
+    // `clientLeveled` marks audio whose level is owned by an external client —
+    // TCI or DAX TX audio (WSJT-X, fldigi, the PipeWire bridge), where the
+    // sender has already applied its own power/attenuation control. The ALC is
+    // bypassed for such blocks: an ALC exists to close the 20-30 dB gap between
+    // a microphone and full modulation, and applied to a client that sets its
+    // own level it does the opposite of what either party wants — it normalizes
+    // the client's level control away above the hold threshold, and freezes
+    // into a path-dependent gain below it (#4796). The engine's own generated
+    // audio (WSPR beacon, AX.25 modem tones) arrives with this false and keeps
+    // the ALC, matching its on-air level to date.
+    void processAudioBlock(const std::vector<float>& mono, bool clientLeveled);
     // Drop anything buffered — on unkey, so the next transmission does not
     // start with the tail of the previous one.
     void reset();

--- a/src/core/backends/hl2/Hl2TxLevelPolicy.h
+++ b/src/core/backends/hl2/Hl2TxLevelPolicy.h
@@ -48,14 +48,17 @@ namespace AetherSDR::hl2 {
 // SCOPE, because "mic" undersells it: this multiplier is applied to everything
 // entering Hl2TxDsp::processAudioBlock, and on a host-modulating backend that
 // includes digital-mode and WSPR-beacon audio arriving through submitTxAudio,
-// not only voice. Above the ALC's hold threshold that is very nearly a no-op —
-// the ALC normalizes each block's peak to alcTargetPeak and hands the gain
-// straight back. At 0 it is not: the block is silent, silence sits below the
-// hold threshold so the ALC declines to lift it, and the beacon goes out muted
-// along with the microphone. That is the honest reading of a slider at the
-// bottom of its travel on a host modulator — there is one modulator and it is
-// off — but it is worth knowing before parking the control at 0 between voice
-// sessions.
+// not only voice. For MIC-path audio, above the ALC's hold threshold it is
+// very nearly a no-op — the ALC normalizes each block's peak to alcTargetPeak
+// and hands the gain straight back. For CLIENT-LEVELED audio (TCI/DAX) the ALC
+// is bypassed (#4796), so there is no handing back: this slider is a straight
+// proportional attenuator on that path, and TX gain 5 (-18 dB) is a real
+// -18 dB on the air. At 0 neither path transmits: the mic path because silence
+// sits below the hold threshold so the ALC declines to lift it, the
+// client-leveled path as a plain 0.0x multiply. That is the honest reading of
+// a slider at the bottom of its travel on a host modulator — there is one
+// modulator and it is off — but it is worth knowing before parking the control
+// at 0 between voice sessions.
 [[nodiscard]] inline double micSliderToLinear(int level) noexcept
 {
     if (level <= 0)

--- a/src/core/backends/hl2/Hl2TxLevelPolicy.h
+++ b/src/core/backends/hl2/Hl2TxLevelPolicy.h
@@ -51,9 +51,13 @@ namespace AetherSDR::hl2 {
 // not only voice. For MIC-path audio, above the ALC's hold threshold it is
 // very nearly a no-op — the ALC normalizes each block's peak to alcTargetPeak
 // and hands the gain straight back. For CLIENT-LEVELED audio (TCI/DAX) the ALC
-// is bypassed (#4796), so there is no handing back: this slider is a straight
-// proportional attenuator on that path, and TX gain 5 (-18 dB) is a real
-// -18 dB on the air. At 0 neither path transmits: the mic path because silence
+// may only reduce, never lift (#4796), so below its target there is no handing
+// back: this slider is a straight proportional attenuator on that path, and
+// TX gain 5 (-18 dB) is a real -18 dB on the air. It stops being straight only
+// where it has to — drive a full-scale client through the top of this slider's
+// +20 dB and the ALC limits, rather than letting the modulator's hard clamp
+// flat-top it, so the last stretch of travel buys reduced headroom rather than
+// more power. At 0 neither path transmits: the mic path because silence
 // sits below the hold threshold so the ALC declines to lift it, the
 // client-leveled path as a plain 0.0x multiply. That is the honest reading of
 // a slider at the bottom of its travel on a host modulator — there is one

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -1116,8 +1116,12 @@ void IcomCivBackend::onAudio(const std::vector<float>& mono)
     emit sliceAudioFrameReady(sliceId(), stereo24k);
 }
 
-void IcomCivBackend::submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz)
+void IcomCivBackend::submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz,
+                                   bool clientLeveled)
 {
+    // The flag is the HL2's concern: this backend ships PCM to a radio that
+    // runs its own transmit processing, so there is no host ALC here to bypass.
+    Q_UNUSED(clientLeveled);
     if (!m_session || !m_connected)
         return;
 

--- a/src/core/backends/icom/IcomCivBackend.h
+++ b/src/core/backends/icom/IcomCivBackend.h
@@ -95,7 +95,8 @@ public:
     void setRitEnabled(bool on) override;
     void setXitEnabled(bool on) override;
     void setRitOffset(int hz) override;
-    void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz) override;
+    void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz,
+                       bool clientLeveled) override;
     void invokeExtension(const QString& ns, const QString& verb, quint64 requestId,
                          const QVariant& arg = {}) override;
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1674,8 +1674,9 @@ MainWindow::MainWindow(QWidget* parent)
     // agree with what actually goes on the air. A Flex radio modulates on the
     // radio side and ignores this.
     connect(m_audio, &AudioEngine::txFinalMonitorPcmReady,
-            this, [this](const QByteArray& pcm) {
-        m_radioModel.submitTxAudio(pcm, AudioEngine::DEFAULT_SAMPLE_RATE);
+            this, [this](const QByteArray& pcm, bool clientLeveled) {
+        m_radioModel.submitTxAudio(pcm, AudioEngine::DEFAULT_SAMPLE_RATE,
+                                   clientLeveled);
     });
     connect(&m_radioModel.transmitModel(), &TransmitModel::moxChanged,
             m_qsoRecorder, &QsoRecorder::onMoxChanged);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -7296,10 +7296,11 @@ void RadioModel::setTxAudioMonitor(bool on)
         m_backend->setTxAudioMonitor(on);
 }
 
-void RadioModel::submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz)
+void RadioModel::submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz,
+                               bool clientLeveled)
 {
     if (m_backend)
-        m_backend->submitTxAudio(int16Stereo, sampleRateHz);
+        m_backend->submitTxAudio(int16Stereo, sampleRateHz, clientLeveled);
 }
 
 bool RadioModel::sendCommand(const QString& cmd)

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1164,8 +1164,11 @@ public:
         return m_backend != nullptr && m_flexBackend == nullptr;
     }
     // Forward processed transmit audio to a host-modulating backend. No-op when
-    // the backend modulates on the radio side.
-    void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz);
+    // the backend modulates on the radio side. `clientLeveled` carries
+    // AudioEngine's source decision through: true for external TCI/DAX client
+    // audio, whose level the sender owns (#4796).
+    void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz,
+                       bool clientLeveled);
     // Let receive audio through while transmitting. Diagnostic use only — see
     // IRadioBackend::setTxAudioMonitor.
     void setTxAudioMonitor(bool on);

--- a/tests/hl2_tci_signaling_test.cpp
+++ b/tests/hl2_tci_signaling_test.cpp
@@ -465,6 +465,13 @@ static void testHostModulatedTxAudio()
     if (monitor.isEmpty())
         return;
 
+    // TCI audio must arrive marked client-leveled: the sender owns its level
+    // (WSJT-X's Pwr slider is a digital attenuator on this very stream), so
+    // the HL2 modulator bypasses its ALC for it (#4796). The mic chain emits
+    // this flag false; feedDaxTxAudio is the external-client path.
+    check(monitor.first().size() >= 2 && monitor.first().at(1).toBool(),
+          "host modulation: TCI audio is marked client-leveled at the tap");
+
     // MainWindow routes that tap to RadioModel::submitTxAudio(), whose HL2
     // implementation requires int16 interleaved stereo at 24 kHz and averages
     // L/R. Stereo must survive, or the averaging halves every sample.

--- a/tests/hl2_tx_loopback_test.cpp
+++ b/tests/hl2_tx_loopback_test.cpp
@@ -415,7 +415,7 @@ int main(int argc, char** argv)
                 out[2 * n] = v;
                 out[2 * n + 1] = v;      // AudioEngine duplicates across channels
             }
-            backend.submitTxAudio(pcm, kRate);
+            backend.submitTxAudio(pcm, kRate, /*clientLeveled=*/false);
             spin(20);
             // Capture WHILE transmitting. Sampling after the loop would read
             // silence: the queue drains in well under a second once audio stops,

--- a/tests/hl2_txdsp_test.cpp
+++ b/tests/hl2_txdsp_test.cpp
@@ -56,7 +56,8 @@ static std::vector<std::complex<float>> modulate(WdspChannel::Mode mode,
                                                  double micGain, double seconds,
                                                  float* lastMicPeak = nullptr,
                                                  bool alc = false,
-                                                 const double* passband = nullptr)
+                                                 const double* passband = nullptr,
+                                                 bool clientLeveled = false)
 {
     Hl2TxDsp tx;
     Hl2TxDsp::Config cfg;
@@ -102,7 +103,8 @@ static std::vector<std::complex<float>> modulate(WdspChannel::Mode mode,
     for (std::size_t off = 0; off < audio.size(); off += kChunk) {
         const std::size_t n = std::min(kChunk, audio.size() - off);
         tx.processAudioBlock(std::vector<float>(audio.begin() + static_cast<std::ptrdiff_t>(off),
-                                                audio.begin() + static_cast<std::ptrdiff_t>(off + n)));
+                                                audio.begin() + static_cast<std::ptrdiff_t>(off + n)),
+                             clientLeveled);
     }
     return out;
 }
@@ -323,7 +325,7 @@ int main(int argc, char** argv)
                         amplitude * std::sin(2.0 * M_PI * 1000.0
                                              * (off + static_cast<int>(n)) / fs));
                 }
-                tx.processAudioBlock(chunk);
+                tx.processAudioBlock(chunk, /*clientLeveled=*/false);
             }
             return lastGainDb;
         };
@@ -344,6 +346,108 @@ int main(int argc, char** argv)
               "ALC still lifts audio at speech level");
         check(speechGainDb > quietGainDb + 20.0,
               "ALC distinguishes speech from room noise");
+    }
+
+    // ── #4796: client-leveled audio bypasses the ALC entirely ──────────────
+    //
+    // A TCI/DAX client's level control is a digital attenuator on the audio it
+    // streams (WSJT-X's Pwr slider). Through the ALC that control was either
+    // normalized away (above the hold threshold) or frozen into a
+    // path-dependent gain (below it). With the bypass, output must simply be
+    // proportional to input — even 5 dB BELOW the hold threshold, where the
+    // ALC used to freeze.
+    {
+        // -50 dBFS and -30 dBFS, both with the ALC configured ON, both marked
+        // client-leveled. 20 dB apart in, 20 dB apart out.
+        const auto quiet = modulate(WdspChannel::Mode::Usb, kTone, 0.00316, 1.0,
+                                    1.0, nullptr, true, nullptr,
+                                    /*clientLeveled=*/true);
+        const auto loud  = modulate(WdspChannel::Mode::Usb, kTone, 0.0316, 1.0,
+                                    1.0, nullptr, true, nullptr,
+                                    /*clientLeveled=*/true);
+        if (!quiet.empty() && !loud.empty()) {
+            const double a = binPower(quiet, kTone, kFsOut);
+            const double b = binPower(loud, kTone, kFsOut);
+            const double ratioDb = 20.0 * std::log10((b + 1e-12) / (a + 1e-12));
+            std::fprintf(stderr,
+                         "client-leveled: -50 dBFS %.6f, -30 dBFS %.6f, ratio %.1f dB\n",
+                         a, b, ratioDb);
+            check(ratioDb > 18.0 && ratioDb < 22.0,
+                  "client-leveled output is proportional to input (no ALC)");
+            // And the quiet tone was NOT hauled up toward the ALC target.
+            double mx = 0.0;
+            for (const auto& v : quiet) mx = std::max(mx, static_cast<double>(std::abs(v)));
+            check(mx < 0.05,
+                  "a -50 dBFS client tone stays near -50 dBFS on the wire");
+        }
+    }
+
+    // ── #4796: the reported hysteresis, as an assertion ─────────────────────
+    //
+    // One continuous transmission, level swept down-up-down across the hold
+    // threshold: -50 dBFS -> -30 dBFS -> -50 dBFS. This is the report's "slide
+    // the Pwr slider up, RF appears; slide it back, RF stays" — with the ALC in
+    // the path, the third segment came out ~26 dB hotter than the first,
+    // because the gain wound up during the loud segment was frozen (not
+    // reducing, input below hold) instead of released. Client-leveled audio
+    // must be path-independent: equal inputs, equal outputs, whatever came
+    // between.
+    {
+        Hl2TxDsp tx;
+        Hl2TxDsp::Config cfg;
+        cfg.mode = WdspChannel::Mode::Usb;
+        cfg.alcEnabled = true;   // configured ON — the bypass is per-block
+        std::string err;
+        if (!tx.configure(cfg, &err)) {
+            std::fprintf(stderr, "FAIL: hysteresis configure: %s\n", err.c_str());
+            ++g_failures;
+        } else {
+            std::vector<std::complex<float>> out;
+            QObject::connect(&tx, &Hl2TxDsp::iqReady, &tx,
+                             [&](const std::vector<std::complex<float>>& iq) {
+                out.insert(out.end(), iq.begin(), iq.end());
+            });
+
+            const int fs = cfg.inputSampleRateHz;
+            const double levels[] = {0.00316, 0.0316, 0.00316};
+            std::size_t marks[4] = {0, 0, 0, 0};
+            constexpr std::size_t kChunk = 240;
+            std::vector<float> chunk(kChunk);
+            int sample = 0;
+            for (int stage = 0; stage < 3; ++stage) {
+                for (int off = 0; off < fs; off += static_cast<int>(kChunk)) {
+                    for (std::size_t n = 0; n < kChunk; ++n, ++sample) {
+                        chunk[n] = static_cast<float>(
+                            levels[stage]
+                            * std::sin(2.0 * M_PI * 1000.0 * sample / fs));
+                    }
+                    tx.processAudioBlock(chunk, /*clientLeveled=*/true);
+                }
+                marks[stage + 1] = out.size();
+            }
+
+            // Compare the settled tail of each quiet segment (its second half).
+            auto tailPeak = [&](std::size_t from, std::size_t to) {
+                double mx = 0.0;
+                for (std::size_t i = from + (to - from) / 2; i < to; ++i)
+                    mx = std::max(mx, static_cast<double>(std::abs(out[i])));
+                return mx;
+            };
+            const double firstQuiet = tailPeak(marks[0], marks[1]);
+            const double loud       = tailPeak(marks[1], marks[2]);
+            const double lastQuiet  = tailPeak(marks[2], marks[3]);
+            const double reGainDb =
+                20.0 * std::log10((lastQuiet + 1e-12) / (firstQuiet + 1e-12));
+            std::fprintf(stderr,
+                         "hysteresis: quiet %.6f -> loud %.6f -> quiet %.6f "
+                         "(re-gain %.2f dB)\n",
+                         firstQuiet, loud, lastQuiet, reGainDb);
+            check(std::fabs(reGainDb) < 1.0,
+                  "equal client levels produce equal output before and after a "
+                  "loud excursion (no ALC hysteresis)");
+            check(loud > firstQuiet * 5.0,
+                  "the loud segment is genuinely louder (sweep is real)");
+        }
     }
 
     if (g_failures == 0)

--- a/tests/hl2_txdsp_test.cpp
+++ b/tests/hl2_txdsp_test.cpp
@@ -450,6 +450,160 @@ int main(int argc, char** argv)
         }
     }
 
+    // ── #4796 review: the bypass is ONE-SIDED — an over-level client is ────
+    //    limited, not clipped.
+    //
+    // Removing the ALC's makeup half is the #4796 fix. Removing its REDUCTION
+    // half would leave the modulator's hard clamp as the only thing between a
+    // hot client and the band, and m_micGain reaches 10x (+20 dB — the TX gain
+    // slider at 100, Hl2TxLevelPolicy.h), so a full-scale client arrives ~17 dB
+    // into that clamp. Flat-topping an SSB modulator input is a splatter
+    // generator: the one failure mode here that harms other operators rather
+    // than the operator who caused it.
+    //
+    // Distortion is measured as the CREST FACTOR of the analytic magnitude,
+    // not as a harmonic bin. For a single tone |IQ| is constant, so peak/mean
+    // is 1.0 however the tone is scaled; clipping ripples it. A DFT bin ratio
+    // was tried first and rejected: binPower's absolute output is dominated by
+    // frequency-dependent cancellation, so it read the same -5.8 dBc on a tone
+    // that provably could not be clipping. It is a same-frequency comparator
+    // (which is all the proportionality case above asks of it), not a
+    // distortion meter. The clean control below stays in the test so the
+    // instrument is validated on every run rather than on the day it was
+    // written.
+    {
+        constexpr double kSlider100 = 10.0;   // micSliderToLinear(100) = +20 dB
+        constexpr double kHarmTone  = 700.0;
+        auto crest = [](const std::vector<std::complex<float>>& v) {
+            double mx = 0.0, sum = 0.0;
+            for (const auto& x : v) {
+                const double m = std::abs(x);
+                mx = std::max(mx, m);
+                sum += m;
+            }
+            return mx / (sum / static_cast<double>(v.size()) + 1e-12);
+        };
+        auto settledTail = [](const std::vector<std::complex<float>>& v) {
+            return std::vector<std::complex<float>>(
+                v.begin() + static_cast<std::ptrdiff_t>(v.size() / 2), v.end());
+        };
+
+        const auto hot = modulate(WdspChannel::Mode::Usb, kHarmTone, 1.0,
+                                  kSlider100, 1.5, nullptr, true, nullptr,
+                                  /*clientLeveled=*/true);
+        // 24 dB below the ALC target at unity mic gain: the limiter cannot
+        // engage, so this is what "undistorted" reads on this instrument.
+        const auto clean = modulate(WdspChannel::Mode::Usb, kHarmTone, 0.05,
+                                    1.0, 1.5, nullptr, true, nullptr,
+                                    /*clientLeveled=*/true);
+        if (!hot.empty() && !clean.empty()) {
+            const auto tail  = settledTail(hot);     // skips the 5 ms attack
+            const auto ctail = settledTail(clean);
+            double mx = 0.0;
+            for (const auto& v : tail)
+                mx = std::max(mx, static_cast<double>(std::abs(v)));
+            const double hotCrest   = crest(tail);
+            const double cleanCrest = crest(ctail);
+            std::fprintf(stderr,
+                         "over-level client: settled |IQ| peak %.3f, crest %.4f "
+                         "(undistorted control %.4f)\n",
+                         mx, hotCrest, cleanCrest);
+            check(cleanCrest < 1.05,
+                  "crest-factor instrument reads ~1.0 on an undistorted tone");
+            check(mx < 0.95,
+                  "a full-scale client at TX gain 100 is limited below the "
+                  "clamp, not flat-topped by it");
+            check(mx > 0.5,
+                  "the limited transmission is still on the air (case is real)");
+            check(hotCrest < 1.05,
+                  "an over-level client is limited cleanly, with no clipping "
+                  "distortion on the wire");
+        }
+    }
+
+    // ── #4796 review: the reduction half must RELEASE — it may not latch ────
+    //
+    // Gating only the ALC's INCREASE branch (leaving `reducing` free to act) is
+    // the smaller edit and is wrong: once a loud block pulls the gain down,
+    // nothing can raise it again within the over, so a client sliding back down
+    // stays attenuated at whatever the loudest block called for. That is
+    // path-dependent gain — #4796's own defect class, mirrored. Expressing the
+    // bypass as a unity CEILING instead leaves the gain free to release.
+    //
+    // This case is the discriminator between those two shapes. It passes on a
+    // total bypass and on the ceiling; it fails ~21 dB wide on an
+    // increase-gated ALC.
+    //
+    // One continuous transmission: full scale, then -50 dBFS held for four
+    // release time constants. The tail must match the same level keyed fresh.
+    {
+        constexpr double kSlider100 = 10.0;
+        const auto fresh = modulate(WdspChannel::Mode::Usb, kTone, 0.00316,
+                                    kSlider100, 1.5, nullptr, true, nullptr,
+                                    /*clientLeveled=*/true);
+
+        Hl2TxDsp tx;
+        Hl2TxDsp::Config cfg;
+        cfg.mode = WdspChannel::Mode::Usb;
+        cfg.alcEnabled = true;
+        std::string err;
+        if (!tx.configure(cfg, &err)) {
+            std::fprintf(stderr, "FAIL: limiter release configure: %s\n",
+                         err.c_str());
+            ++g_failures;
+        } else if (!fresh.empty()) {
+            tx.setMicGain(kSlider100);
+            std::vector<std::complex<float>> out;
+            QObject::connect(&tx, &Hl2TxDsp::iqReady, &tx,
+                             [&](const std::vector<std::complex<float>>& iq) {
+                out.insert(out.end(), iq.begin(), iq.end());
+            });
+            double lastGainDb = 0.0;
+            QObject::connect(&tx, &Hl2TxDsp::alcGain, &tx,
+                             [&lastGainDb](float db) { lastGainDb = db; });
+
+            const int fs = cfg.inputSampleRateHz;
+            constexpr std::size_t kChunk = 240;
+            std::vector<float> chunk(kChunk);
+            const double levels[]  = {1.0, 0.00316};
+            const int    stageSec[] = {1, 2};
+            int sample = 0;
+            std::size_t afterLoud = 0;
+            for (int stage = 0; stage < 2; ++stage) {
+                for (int off = 0; off < fs * stageSec[stage];
+                     off += static_cast<int>(kChunk)) {
+                    for (std::size_t n = 0; n < kChunk; ++n, ++sample) {
+                        chunk[n] = static_cast<float>(
+                            levels[stage]
+                            * std::sin(2.0 * M_PI * 1000.0 * sample / fs));
+                    }
+                    tx.processAudioBlock(chunk, /*clientLeveled=*/true);
+                }
+                if (stage == 0)
+                    afterLoud = out.size();
+            }
+
+            double swept = 0.0;
+            for (std::size_t i = afterLoud + (out.size() - afterLoud) / 2;
+                 i < out.size(); ++i)
+                swept = std::max(swept, static_cast<double>(std::abs(out[i])));
+            double ref = 0.0;
+            for (std::size_t i = fresh.size() / 2; i < fresh.size(); ++i)
+                ref = std::max(ref, static_cast<double>(std::abs(fresh[i])));
+            const double deltaDb =
+                20.0 * std::log10((swept + 1e-12) / (ref + 1e-12));
+            std::fprintf(stderr,
+                         "limiter release: swept %.6f vs fresh-key %.6f "
+                         "(delta %.2f dB, settled ALC %.2f dB)\n",
+                         swept, ref, deltaDb, lastGainDb);
+            check(std::fabs(deltaDb) < 1.0,
+                  "the limiter releases to unity after an over-level excursion "
+                  "(reduction does not latch)");
+            check(std::fabs(lastGainDb) < 1.0,
+                  "ALC gain is back at 0 dB once the client is quiet again");
+        }
+    }
+
     if (g_failures == 0)
         std::fprintf(stderr, "hl2_txdsp_test: all checks passed\n");
     return g_failures == 0 ? 0 : 1;

--- a/tests/hl2_txdsp_test.cpp
+++ b/tests/hl2_txdsp_test.cpp
@@ -534,11 +534,21 @@ int main(int argc, char** argv)
     // total bypass and on the ceiling; it fails ~21 dB wide on an
     // increase-gated ALC.
     //
-    // One continuous transmission: full scale, then -50 dBFS held for four
+    // It is ALSO the discriminator for the other half of the change — the hold
+    // being made mic-path-only (`!clientLeveled` in processAudioBlock's `held`).
+    // THE QUIET LEG IS DELIBERATELY BELOW alcHoldBelowDbfs: -70 dBFS times this
+    // case's 10x mic gain is -50 dBFS at the ALC's measurement point, under the
+    // -45 dBFS hold threshold. Do not raise it. If the hold is left applying to
+    // client-leveled audio, the gain the loud leg pulled down can never be
+    // released again — the transmission strands at -21.41 dB — and with the
+    // quiet leg anywhere above the threshold this case cannot see that at all.
+    // Both wrong shapes fail here and nowhere else in this file.
+    //
+    // One continuous transmission: full scale, then -70 dBFS held for four
     // release time constants. The tail must match the same level keyed fresh.
     {
         constexpr double kSlider100 = 10.0;
-        const auto fresh = modulate(WdspChannel::Mode::Usb, kTone, 0.00316,
+        const auto fresh = modulate(WdspChannel::Mode::Usb, kTone, 0.000316,
                                     kSlider100, 1.5, nullptr, true, nullptr,
                                     /*clientLeveled=*/true);
 
@@ -565,7 +575,7 @@ int main(int argc, char** argv)
             const int fs = cfg.inputSampleRateHz;
             constexpr std::size_t kChunk = 240;
             std::vector<float> chunk(kChunk);
-            const double levels[]  = {1.0, 0.00316};
+            const double levels[]  = {1.0, 0.000316};
             const int    stageSec[] = {1, 2};
             int sample = 0;
             std::size_t afterLoud = 0;

--- a/tests/icom_backend_test.cpp
+++ b/tests/icom_backend_test.cpp
@@ -263,7 +263,7 @@ int main(int argc, char** argv)
 
         // UNKEYED: nothing may reach the radio.
         for (int i = 0; i < 20; ++i)
-            backend.submitTxAudio(pcm, 24000);
+            backend.submitTxAudio(pcm, 24000, /*clientLeveled=*/false);
         QTest::qWait(120);
         check(radio.audioPacketsFromClient() == before,
               "transmit audio is DROPPED while unkeyed");
@@ -271,7 +271,7 @@ int main(int argc, char** argv)
         // KEYED: the same buffers must arrive.
         backend.setKeying(true);
         for (int i = 0; i < 20; ++i)
-            backend.submitTxAudio(pcm, 24000);
+            backend.submitTxAudio(pcm, 24000, /*clientLeveled=*/false);
         QTest::qWait(200);
         const int keyed = radio.audioPacketsFromClient();
         check(keyed > before, "and flows once keyed");
@@ -282,7 +282,7 @@ int main(int argc, char** argv)
         QTest::qWait(120);
         const int afterUnkey = radio.audioPacketsFromClient();
         for (int i = 0; i < 20; ++i)
-            backend.submitTxAudio(pcm, 24000);
+            backend.submitTxAudio(pcm, 24000, /*clientLeveled=*/false);
         QTest::qWait(120);
         check(radio.audioPacketsFromClient() == afterUnkey,
               "and stops again on unkey");


### PR DESCRIPTION
## Summary

WSJT-X's `Pwr` slider is not a rig command — it is a digital attenuator on the audio the client streams over TCI. The HL2 host modulator ran its speech ALC over that audio, so the client's level control was either normalized away (above the −45 dBFS hold threshold) or frozen into a path-dependent gain (below it). That is every behaviour in the report: TUNE at a low Pwr setting makes no RF, sliding up mid-key winds the gain up, sliding back retains it, and re-keying resets to nothing. The 1–2 s power ramp-up @eicket added in the comments is the same ALC's 0.5 s release normalizing his tone.

The fix carries AudioEngine's existing source decision through to the modulator: `feedDaxTxAudio` already marks external client audio (`markExternalSource`) and already bypasses the voice compressor/EQ for it — "digital modes carry pre-shaped tones that would be destroyed by a voice-tuned compressor or EQ" (`AudioEngine.cpp`). This change propagates that one bit through the final-monitor tap (`txFinalMonitorPcmReady` → `RadioModel::submitTxAudio` → `IRadioBackend::submitTxAudio`) so `Hl2TxDsp` caps the ALC gain at unity for client-leveled blocks. Output is now proportional to what the client sent, both directions, path-independent.

**Revised after review** (@ten9876, 2026-08-11): the bypass is **one-sided**, not total. Client-leveled audio may never be *lifted*, but it is still *reduced*. The makeup half was the bug; the reduction half was the overdrive protection, and removing it left the modulator's hard clamp as the only thing between a hot client and the band — measured at twice full scale (settled |IQ| peak **1.687**, crest factor **1.3003** vs 1.0001 undistorted) with a full-scale client at TX gain 100, where `micSliderToLinear` reaches 10×. It is now expressed as a ceiling on the ALC gain: unity for client-leveled audio, `alcMaxGainDb` for mic audio.

## Why

- **The client owns its level.** A TCI/DAX client that attenuates its own tone must see output proportional to its input. Through the ALC it saw two other things: a control that does nothing (every level ≥ −45 dBFS normalized to `alcTargetPeak`), and a control that is path-dependent (gain frozen below the hold threshold at whatever history left behind).
- **Safety.** The old behaviour hands up to +40 dB of uncommanded makeup gain to a signal the operator deliberately set low — a station driving a linear gets full modulation from a control they believe is near zero. An emission at a level nobody commanded is an emission without operator intent.
- **DAX clients get the same fix.** `markExternalSource` is true for every external client, not only TCI: `DaxBridge::txAudioReady` → `feedDaxTxAudio` marks DAX TX audio too. So `TciTxGain` / `DaxTxGain` also stop being normalized away on this backend and become real proportional attenuators — `TciTxGain` defaults to 0.5, a real −6 dB where it used to be handed straight back. Same defect, same bit, worth knowing if you drive the HL2 through DAX rather than TCI.
- **Scoped to clients only.** The mic path keeps the ALC (speech genuinely arrives 20–30 dB low — the measurements in `Hl2TxDsp::Config` still hold). The engine's own generated audio — the WSPR beacon (generated at −20 dBFS) and AX.25 modem tones — arrives with the flag false and keeps today's on-air level. Audio routed in through a **PC mic/VAC device** still takes the voice chain including ALC, by design: at that boundary it is indistinguishable from a microphone.

## Root cause

`src/core/backends/hl2/Hl2TxDsp.cpp` (ALC block): gain increase is held below `alcHoldBelowDbfs = −45 dBFS` (`if (reducing || blockPeak >= holdThreshold)`), reduction always allowed, `reset()` restores unity on unkey. TX gain 5 = −18 dB (`Hl2TxLevelPolicy.h`) is applied *before* the ALC measures the block peak, so the reporter's levels straddled the threshold. Confirmed against every observation in the report; the mechanism analysis posted earlier in the issue thread is correct (with these citations now verified against `main`).

## Scope

- `AudioEngine`: `txFinalMonitorPcmReady(pcm)` → `(pcm, clientLeveled)`; mic-chain emit passes `false`, the host-modulation DAX/TCI emit passes `markExternalSource`.
- `RadioModel` / `IRadioBackend` / `IcomCivBackend`: signature plumb (Icom accepts and ignores — no host ALC there). No default argument on the virtual.
- `Hl2Backend`: forwards the flag per block; the unkey "raise mic gain" diagnostic is gated off for client-leveled transmissions (that advice points at a control that was never in the path).
- `Hl2TxDsp`: `processAudioBlock(mono, clientLeveled)` — the ALC runs whenever `alcEnabled`, with `ceiling = clientLeveled ? 1.0 : alcMaxGainDb` and the hold made mic-path-only. For `!clientLeveled` this reduces to byte-identical logic, so the mic path is untouched. The TX:ALC meter is fed unconditionally as before: it reads 0 dB for client-leveled audio below the target, and honestly shows the reduction when limiting.
- No protocol change, no persistence change, no UI change.

## Constitution principle honored

**Principle VI — AetherSDR never transmits without operator intent.** The ALC was re-deciding the transmit level after the operator (via their client) had already decided it: up to +40 dB of makeup gain on a deliberately-quiet signal, and RF that appears or persists depending on slider history rather than slider position. Pinning unity for client-leveled audio makes the emitted level trace back to exactly what the operator's client commanded. (Principle VIII's evidence standard is served by the fail-first regression tests and the hardware A/B below.)

## Test plan

- [x] Full `ninja` build clean on Linux (Nobara, Qt 6.10.3, gcc 16.1.1)
- [x] Full `ctest` suite green — 279 tests, 2 skipped by design (`crdv_quarantined_test`, `hl2_tx_loopback_test`). Five `hl2_*` tests time out under `-j 8` and pass serially; none of them reference `Hl2TxDsp`, `submitTxAudio` or `clientLeveled`.
- [x] `hl2_txdsp_test` — four regressions, all **fail-first verified** with controls in both directions:
  - *Proportionality:* −50 dBFS vs −30 dBFS client tones, ALC configured on → output ratio **20.0 dB** (old code: 48.4 dB — freeze below threshold + wind-up above). 
  - *Hysteresis:* one continuous transmission, −50 → −30 → −50 dBFS staircase → re-gain **0.00 dB** (old code: **+27.44 dB** — the report's "RF is still there", as an assertion).
  - *Over-level protection (review blocker):* full-scale client at TX gain 100 → settled |IQ| peak **0.844** (≤ `alcTargetPeak`) and crest factor **1.0001**, against **1.687** / **1.3003** on the total bypass. Distortion is measured as the crest factor of the analytic magnitude, which is 1.0 for any single tone at any scale and ripples under clipping. A third-harmonic bin ratio was tried first and discarded: it read the same −5.8 dBc on a tone that provably could not be clipping, so the helper is a same-frequency comparator rather than a distortion meter. The undistorted control stays inside the test so the instrument is validated on every run.
  - *Limiter release:* one continuous transmission, full scale → −50 dBFS held four release constants → **−0.15 dB** against the same level keyed fresh. This is the case that distinguishes a unity ceiling from gating only the gain-increase branch: the latter fixes the over-level case but latches at **−21.41 dB**, since nothing can raise the gain again within the over. That variant passes every other test here, including the hysteresis case, because that sweep stays below the ALC target and never engages reduction.
  - All pre-existing ALC assertions (speech lift 32.5 dB, hold-below-threshold 0.0 dB, no-overshoot) still pass — the mic path is unchanged.
- [x] `hl2_tci_signaling_test` — asserts TCI audio arrives at the final-monitor tap marked client-leveled; existing conversion assertions unchanged.
- [x] `icom_backend_test` — keying-gate behaviour unchanged with the new signature.
- [ ] `hl2_tx_loopback_test` — signature change compiles; the test self-skips without a local `hpsdrsim`, so it did not execute here (the real-radio A/B below covers that path).
- [x] **Hardware A/B on a real Hermes-Lite 2 (gateware 75)**, driven end-to-end over TCI by a scripted client emulating WSJT-X (48 kHz float32 duplicated-stereo TX audio + `trx`), RF into a dummy load (SWR 1.1 measured at the inline wattmeter), external power cross-check via an Elecraft KXPA100 (PA bypass) in the line. TX was operator-authorized for this run (control operator present).

## Hardware proof

Same radio, same drive (60 %), same scripted sweeps, same dummy-load path (SWR 1.1); the only variable is this patch. HL2 power is the radio's own forward-power telemetry (steady-state, transmit settled); KXPA is the external wattmeter, 0.1 W resolution.

**Fresh key per level ("TUNE at N steps"):**

| Client level | baseline `alcGainDb` | baseline RF (HL2 / KXPA) | fixed `alcGainDb` | fixed RF (HL2 / KXPA) |
|---|---|---|---|---|
| −50 dBFS | 0 (frozen) | 0.000 W / 0.0 | 0 | 0.000 W / 0.0 |
| −40 dBFS | **+40.0** (cap) | 1.59 W / 1.0 | 0 | 0.000 W / 0.0 |
| −30 dBFS | **+31.6** | 2.46 W / 1.7 | 0 | 0.0009 W / 0.0 |
| −20 dBFS | **+21.6** | 2.46 W / 1.8 | 0 | 0.0104 W / 0.0 |
| −10 dBFS | **+11.6** | 2.47 W / 1.7 | 0 | 0.127 W / 0.0 |
| 0 dBFS | +1.6 | 2.48 W / 1.7 | 0 | **1.63 W / 1.0** |

Baseline: **40 dB of input range lands on the same ~2.46 W** — the client's control is normalized away — and the wattmeter time-series shows the 1–2 s ramp-up the reporter described as the release winds toward +40 dB. Fixed: one clean decade of power per 10 dB step across four decades.

**One continuous key, level swept −50 → −30 → −10 → −30 → −50 dBFS ("slide the slider"):**

- Baseline: returning to −50 dBFS, the wound-up gain is **retained** (`alcGainDb` +31.5, post-ALC −21.5 dBFS and ~16 mW still emitted, vs −53.0 dBFS and 0 W for the identical level at key-start) — RF persists where the same input made none.
- Fixed: byte-identical up-leg and down-leg (post-ALC −33.0 / −53.0 dBFS both directions, 0.9/1.0 mW and 0.1/0.2 mW), `alcGainDb` 0 throughout.

**The hardware table above is unaffected by the one-sided revision** — but with less margin than first stated. *(Corrected by @ten9876 in review: the original text said every point ran at TX gain 5 = `micSliderToLinear(5)` = 0.126. That does not reconcile with the table's own `alcGainDb` column, which pins the effective pre-ALC gain at **0.707** to 0.1 dB on four independent rows — 0.85/10^(31.6/20) = 0.0224 = 0.707×0.0316 at −30 dBFS, and likewise at −20, −10 and 0 dBFS. At 0.126 the −30 dBFS row would have railed at the +40 dB cap rather than landing on +31.6. The two figures below agree with 0.707 and not with 0.126.)*

The hottest published sample therefore reaches **0.707** against an `alcTargetPeak` of 0.85 — still below it, so the limiter is idle at every row in both columns and the one-sided revision really is a no-op against this table. Limiting first engages around slider 54 for a full-scale client (0.85 / `micSliderToLinear(54)` = 0.707), reaching 18.4 dB of reduction at slider 100. **The margin is 1.6 dB, not 19.6 dB**, which is worth stating plainly: no hardware point in this PR exercised the limiter, so the reduction half — the half added after review — is verified by unit test only. That is acceptable because it is the long-standing mic-path reduction with an unchanged time constant, driven by the same code, but it should not read as though the hardware run covered it.

On the "two ALC components" question: with the host ALC bypassed, measured output tracked the commanded level cleanly across four decades on both power meters — no residual leveling behaviour was observed from the gateware at these power levels. The entire reported mechanism was the host ALC.

**One honest trade at the top of the range:** full-scale client audio peaks at −3 dBFS in the modulator (a fixed pipeline factor), where the ALC used to force −1.4 dBFS — so maximum output for a full-scale digital client sits ~1.8 dB below the old ALC-saturated level (1.63 W vs 2.48 W at drive 60 here). RF Power compensates directly, and the level now actually belongs to the operator. This trade is also unchanged by the one-sided revision: at the default TX gain 50 a full-scale client sits at 0.708, still below the 0.85 target, so the limiter does not engage there either.

**Operating note for @eicket:** with this fix, leave WSJT-X's Pwr slider near the top and set your 100 mW drive with AetherSDR's RF Power control (or back the slider off — it now attenuates proportionally instead of doing nothing). The HL2 TX gain slider still applies before the modulator as before.

Fixed build mid-key at full scale (MOX, TCI server 1 client, HL2 gateware 75):

![fixed build transmitting at full-scale client level](https://raw.githubusercontent.com/Ozy311/AetherSDR/fix-4796-assets/.pr-assets/4796-fix-fullscale-tx.png)

## Checklist

- [x] Commits are signed (docs/COMMIT-SIGNING.md)
- [x] No new flat-key AppSettings calls (Principle V)
- [x] All meter UI uses MeterSmoother (Principle II) — no meter UI touched; the TX:ALC meter reads 0 dB for client-leveled audio below the target and honestly shows the reduction when limiting

Closes #4796

---

73, Ozy **K6OZY**

