### PR TITLE
fix(test): the Icom scrub TX-safety check matched a PTT read, so it failed ~1 run in 2

### DIFF
--- a/tests/icom_backend_test.cpp
+++ b/tests/icom_backend_test.cpp
@@ -39,6 +39,29 @@ static void check(bool cond, const char* what)
     }
 }
 
+// A frame that can MOVE the transmitter or the antenna tuner, as opposed to one
+// that merely asks about them.
+//
+// 1C 00 and 1C 01 each have two forms and only one of them does anything. The
+// payload-bearing form is the command — cmdSetPtt writes one byte (00 receive,
+// 01 transmit) and cmdSetTuner writes one byte (00 off, 01 on, 02 start a
+// matching cycle). The empty form is a READ, which the register answers and
+// never acts on. The backend polls exactly that read on a 250 ms cadence from
+// onMeterTick, deliberately: m_keyed was set only by our own setKeying() and by
+// an unsolicited status frame, so a radio keyed from its own front-panel PTT
+// left every transmit meter suppressed and reading "never fed".
+//
+// Matching on cmd+sub alone cannot tell those two forms apart, and a check that
+// cannot tell them apart is not a TX-safety check. It fires on the poll — which
+// keys nothing — and it would go on firing at whoever silenced it, until it got
+// silenced the easy way.
+static bool movesPttOrTuner(const CivFrame& f)
+{
+    return f.cmd == cmd::kControl && f.hasSub
+        && (f.sub == control::kPtt || f.sub == control::kTuner)
+        && !f.data.empty();
+}
+
 int main(int argc, char** argv)
 {
     QCoreApplication app(argc, argv);
@@ -269,12 +292,25 @@ int main(int argc, char** argv)
               "transmit audio is DROPPED while unkeyed");
 
         // KEYED: the same buffers must arrive.
+        radio.clearCivLog();
         backend.setKeying(true);
         for (int i = 0; i < 20; ++i)
             backend.submitTxAudio(pcm, 24000);
         QTest::qWait(200);
         const int keyed = radio.audioPacketsFromClient();
         check(keyed > before, "and flows once keyed");
+
+        // THE TX-SAFETY PREDICATE HAS TEETH. The scrub check further down is a
+        // negative — "no frame like this was sent" — and a negative passes for
+        // free the moment it stops recognising the thing it forbids. Here a
+        // transmitter really was keyed over the same wire and through the same
+        // capture, so the predicate is proven to catch it before it is trusted
+        // to say the scrub never did.
+        check(std::any_of(radio.civCommands().begin(), radio.civCommands().end(),
+                          movesPttOrTuner),
+              "and a real key IS caught by the TX-safety predicate, so the "
+              "scrub's 'never keys' check is not vacuous");
+
         backend.setKeying(false);
 
         // ...and stops again on unkey, rather than draining a backlog into the
@@ -558,10 +594,14 @@ int main(int argc, char** argv)
               "does not claim coverage it does not have");
 
         // 3. PTT, the ATU and power-off are never scrubbed (Principle VI).
-        const bool keyed = std::any_of(sent.begin(), sent.end(), [](const CivFrame& f) {
-            return f.cmd == cmd::kControl && f.hasSub
-                && (f.sub == control::kPtt || f.sub == control::kTuner);
-        });
+        //
+        // Payload-bearing frames only — see movesPttOrTuner. The window this
+        // reads spans the qWait above, so it also catches the backend's own
+        // 250 ms PTT-state READ, which is not a scrub frame and keys nothing.
+        // Matching that read made this assertion fail on roughly half of all
+        // runs purely on timer phase, on a check whose whole job is to be
+        // believed when it fires.
+        const bool keyed = std::any_of(sent.begin(), sent.end(), movesPttOrTuner);
         check(!keyed, "and the scrub never touches PTT or the antenna tuner");
     }
 


### PR DESCRIPTION
`tests/icom_backend_test.cpp` fails

```
FAIL: and the scrub never touches PTT or the antenna tuner
```

on roughly half of all runs — **14/30 on a clean `f6f56865` build**, macOS, `QT_QPA_PLATFORM=offscreen`. This is the Principle VI check that proves `controls scrub` cannot key the transmitter, so an intermittent failure is worse than a cosmetic flake. Either the scrub genuinely emits a PTT/tuner frame under some ordering, or the capture races it. This settles which.

## It is the test, not the backend

Instrumenting the offending frame shows it is **always the same frame**:

```
DIAG offender cmd=1c sub=00 dataLen=0 data= | index=33 of 34
```

Zero-length payload, at index 33 of 34 — *after* every one of the scrub's own frames. That is a CI-V **read** of the PTT register, emitted by `IcomCivBackend::onMeterTick` ([IcomCivBackend.cpp:2393](../blob/main/src/core/backends/icom/IcomCivBackend.cpp#L2393)) on its 250 ms cadence, landing inside the test's 200 ms observation window purely on timer phase. It reads state; it keys nothing.

The scrub is clean. `kNeverScrub` excludes `ptt`/`tuner`/`power` by id before `scrubDrive` is reached, and no `scrubDrive` branch emits a `cmd::kControl` frame at all. **No ordering hole, no backend change.**

## The actual defect

The capture predicate matched on cmd+sub only:

```cpp
return f.cmd == cmd::kControl && f.hasSub
    && (f.sub == control::kPtt || f.sub == control::kTuner);
```

`1C 00` and `1C 01` each have two forms and only one of them does anything. `cmdSetPtt` writes one payload byte (00 receive / 01 transmit) and `cmdSetTuner` writes one (00 off / 01 on / 02 start a matching cycle); the empty form is a read the register answers and never acts on.

A check that cannot tell those apart is not a TX-safety check. It fires on a poll that keys nothing, and it goes on firing at whoever it wakes up — until it gets silenced the easy way. The predicate now requires a payload, which is exactly *"can move the transmitter or the ATU"*, and the reasoning sits next to it instead of in a commit message.

## The missing positive

A negative assertion passes for free the moment it stops recognising what it forbids. The existing keying block now checks that a real `setKeying(true)` **is** caught by the same predicate, over the same wire and the same capture — so the safety check is proven to have teeth before it is trusted to say the scrub never keys.

## Proof, both directions

| | result |
|---|---|
| Before the fix | **14/30 failing** |
| After the fix | **60/60 clean** |
| Mutation test — `cmdSetPtt(true)` + `cmdSetTuner(0x02)` injected into `controlScrub` | **caught 6/6**, deterministically |
| Full suite | **282/282** (2 pre-existing skips) |

The mutation test is the load-bearing one: it shows the flake was removed by making the check *more* precise, not by weakening it.