### PR TITLE
docs(hl2): certify the meter surface on real hardware, and record three radiocert defects it exposed

### DIFF
--- a/HERMES.md
+++ b/HERMES.md
@@ -945,6 +945,14 @@ The pattern: a seam verb with no consumer looks identical to a working one from
 below. Grep for callers of every verb a new backend implements, before trusting
 that implementing it does anything.
 
+**Closed on hardware, 2026-08-10.** `radiocert meters` against the live radio
+reports all eight defined meters `everFed: true` — `SLC:LEVEL`, `TX:MICPEAK`,
+`TX:SWR`, `TX:FWDPWR`, `TX:REFPWR`, `TX:ALC`, `TX:COMPPEAK` and `RAD:PATEMP`.
+The seam this section opened is fed end to end, and four of those meters were
+still described in `docs/radio-certification.md` as computed-and-discarded when
+the run was made. The measurements are in that file under
+*Certified by effect, 2026-08-10 (Hermes-Lite 2)*.
+
 ### 14.5 Testing UX: exercise BOTH RadioModel and TransmitModel
 
 **The automation bridge is not a test of the user interface.** The two drive
@@ -1866,6 +1874,38 @@ smoothing would alias.
 100 ms is the cadence `MetisClient` already paces telemetry at, and the
 attack/decay constants (0.5/0.15) are the ones `MeterModel` uses for Flex
 forward power — reused so meters behave the same across families.
+
+### 17.7 The RF power slider has 101 positions and the radio has 16
+
+`Hl2Backend::applyDrive` maps the operator's 0–100 onto the drive field's
+0–255 (`kTxDriveMax`), and `setTxPower` already says the gateware decodes only
+the **top nibble**. That comment is right, and the consequence is bigger than it
+sounds: the slider offers 101 settings and the radio can hold **16**. Six
+percentage points of travel do nothing at all, and the next single point is a
+step of over a decibel.
+
+Measured on the live radio (14.200 MHz USB, 1 kHz tone at −10 dBFS, dummy load,
+gateware v74), reading `TX:FWDPWR` through the §17.5 reference curve:
+
+| Slider | Drive register | Top nibble | Forward |
+|---|---|---|---|
+| 44 % | 112 | 7 | 1.984 W |
+| 50 % | 127 | 7 | 2.001 W |
+| 51 % | 130 | 8 | 2.312 W |
+| 56 % | 142 | 8 | 2.319 W |
+
+44 % and 50 % differ by 0.04 dB — the same nibble, so the same radio state, and
+the difference is measurement noise. 50 % to 51 % is +1.25 dB. The quantisation
+is a **hardware fact, not a defect**: nothing in `applyDrive` is wrong, and
+rounding differently would only move the step edges. What is worth fixing is the
+UI's implied precision, because an operator nudging 44 → 50 to "come down a
+little" changes nothing and has no way to find that out.
+
+This also bounds what §17.5's uncalibrated curve can be asked to prove. Halving
+the slider is **not** halving the drive code — 100 % → 50 % is nibble 15 → 7,
+and 50 % → 25 % is 7 → 3 — so the "halve the control, expect −6.02 dB"
+certification stimulus does not describe this radio's control at all. See
+`docs/radio-certification.md` for what that does and does not certify here.
 
 ---
 

--- a/docs/CERTIFICATION.md
+++ b/docs/CERTIFICATION.md
@@ -689,6 +689,21 @@ string. And when a defect is fixed, grep the certification tool for its
 description — the tool is the last place anyone looks for a stale claim about a
 bug they just repaired.
 
+**The rule, stated so it can be enforced at review time.** Everything above is
+the cautionary tale; this is the thing to check against the next `problems <<`
+string:
+
+> A certification finding must either be **produced by a measurement taken
+> during the run**, or **carry the date and the tree it was verified against**.
+
+A finding expressed as a measurement re-derives its own truth on every run and
+cannot go stale. A finding expressed as a literal behind a family gate is only
+ever as current as the day someone typed it — and nothing in the output
+distinguishes the two, which is what makes the second kind so expensive. §1.14
+retired the *spatial* form of this failure (a gate asserting something about the
+wrong radio); this is the *temporal* form, and it is harder to catch precisely
+because the assertion was true when it was written and is about the right radio.
+
 ## 2. Next steps
 
 ### 2.1 The radio profile — highest leverage
@@ -793,6 +808,12 @@ small and all in `RadioCertification.cpp`:
 4. **Refresh `kMeterTable`'s notes and `expectedOnHl2` column.** Four HL2 meters
    are marked not-expected while being defined and fed, so a regression in any
    of them cannot be reported by `expectedButMissing`.
+
+**All four are implemented in #4917**, which lands directly on top of this
+document. Naming it here is not bookkeeping — it is §1.35's rule applied to this
+file: a list of open work is a finding like any other, and one that outlives its
+fix is exactly the failure §1.32–1.35 exist to record. If a fifth item is ever
+added here, it needs the same treatment when it closes.
 
 ### 2.4 What the bridge needs for any of this to be automatable
 

--- a/docs/CERTIFICATION.md
+++ b/docs/CERTIFICATION.md
@@ -6,6 +6,15 @@ after the fact — which is the point of the tool, and a useful check on it: som
 of what follows is a defect radiocert found, and some is a gap in radiocert
 itself that only a second radio could expose.
 
+**1.32–1.34 came from returning to the Hermes-Lite 2** on 2026-08-10 and running
+`radiocert meters` against it after the Icom work had reshaped the tool. All
+three are defects in the *tool*, not the radio, and all three are the shapes
+this document already warns about, aimed back at the instrument: a negative
+finding from a stage that never transmitted, a false positive that a sibling
+table had already been fixed to prevent, and a staleness probe reading a stale
+value. Turning the tool on a radio it has already certified is cheap, and it is
+the only way these were ever going to surface.
+
 Why `radiocert` is shaped the way it is, and what it still cannot do.
 
 The reference tables live in [`radio-certification.md`](radio-certification.md);
@@ -539,6 +548,102 @@ that matters. And a certification stage should assert the SEQUENCE a control
 produces, not the set: correct commands in the wrong order are a defect that
 set-membership cannot see.
 
+### 1.32 A stage that transmits must check that it transmitted
+
+`radiocert meters` was run twice against the same Hermes-Lite 2, minutes apart,
+with one difference: the operator's RF power slider sat at **0** for the first
+run. It reported
+
+> DEFINED BUT NEVER FED … `TX:SWR` … Either publish them with a documented scale
+> or stop defining them
+
+and `meter-scale` recorded `swr: -1` beside it. The second run, at 50 % drive,
+read `TX:SWR` = 1.0 with an age of 531 ms. Nothing had been fixed in between.
+
+The verb keyed correctly, the audio reached the modulator, `keyRefusals` was 0
+and every precondition passed — the radio simply radiated nothing, because zero
+drive is zero drive. `run()` clamps RF power **down** to the automation ceiling
+and has no floor, and no keyed stage asks whether forward power actually
+appeared before reporting on the meters that depend on it.
+
+This is §1.8 arriving from the other side. That lesson says a transmit stage
+must not infer "no RF" from a missing meter reading; this one says a **meter**
+stage must not infer "no meter" from missing RF. Both are the same confusion
+between the instrument and its subject, and the meters phase is where it is most
+dangerous — a false `NEVER FED` is a standing invitation to delete a working
+meter, which is precisely what the concern text recommends.
+
+**Consequence.** Any stage whose measurement requires a transmission must
+establish that the transmission happened, from a quantity independent of the
+thing being measured, and downgrade to **inconclusive** rather than negative
+when it did not. A drive floor would help and is not sufficient: an interlock, a
+band limit or a PA that never enabled produce the same silence at any slider
+setting. `NOT-TESTED` is already a first-class outcome in the control scrub
+(§1.29); the meters phase needs it too.
+
+### 1.33 A lesson learned in one table is not learned in its sibling
+
+Every HL2 meters run reports
+
+> UNIT MISMATCH — these are defined, fed and MISREAD … `TX:ALC` (declared dBFS,
+> expected dB)
+
+on a meter that is correct. `MeterSurfaces.h` holds `TX:ALC` as accepting
+`"dBFS,Percent"` — a **set** — and its comment says exactly why:
+
+> The first version of this field held the one unit the consumer applied, and
+> running it against a live radio flagged both FWDPWR and ALC as mismatched —
+> after they had been fixed.
+
+`kMeterTable` in `RadioCertification.cpp` is still the first version: one
+expected unit, compared by equality. So the fix was made, written down, and
+applied to one of the two tables that needed it — and the tool that reads the
+other one has emitted a permanent false positive on healthy hardware ever since.
+
+It ranks the finding first, too, above every real concern, because §1.28's
+ordering puts a fed-and-misread meter ahead of an absent one. The one class of
+finding designed to be impossible to overlook is the one that is always wrong.
+
+**Consequence.** When a check is duplicated — a document and its executable
+copy, two tables over the same domain — fixing one and not the other is worse
+than never having fixed either, because the surviving copy now contradicts a
+correction someone made deliberately. Grep for the other copy at the moment of
+the fix. And a concern that fires on every run of healthy hardware must be
+treated as a defect in the checker with the same urgency as a missed
+detection: §1.28 warns that a concern which never goes away stops being read,
+and this one is loud enough to take the real findings with it.
+
+### 1.34 The "is it rendered" probe needs the same guards as the gauge
+
+§1.27 added `asRendered` so a stage could report what the operator's gauge will
+actually show, rather than only what crossed the seam. On the HL2 it reports:
+
+```json
+"asRendered": { "fwdPowerWatts": 0.001, "swr": 1.0, "alcDbfs": -1.43 }
+```
+
+All three numbers are wrong in a different way, and the meters are fine:
+
+- **`fwdPowerWatts: 0.001`** in a run whose own keyed stage measured 2.0 W.
+  `stageMeterInventory` runs after `stageControlEffect` has unkeyed and settled
+  for 700 ms, so for a transmit-only quantity it samples the one moment the
+  value is guaranteed absent. It can never show a keyed reading.
+- **`swr: 1.0`** in the same run that reported `TX:SWR everFed: false` — a
+  stage contradicting itself inside one JSON object. `MeterModel::swr()` returns
+  `m_swr{1.0f}` with no measured companion, so "never fed" and "a perfect match"
+  are the same float. Reflected power has `reflectedPowerMeasured`; SWR has
+  `swrSampleLive()`, which `RigctlProtocol` and the SWR sweep both use and
+  `asRendered` does not.
+- **`alcDbfs: -1.43`** is a real value from the previous key, reported unlabelled
+  and unaged — §1.11's stale reading, in the probe added to catch staleness.
+
+**Consequence.** A probe that reads a consumer must read it the way the consumer
+does, including its freshness gate, and must sample it when the quantity can
+exist. Reading a typed accessor raw makes the probe a *third* convention
+alongside the seam and the gauge, and §1.1 applies to it as much as to anything
+else: it will agree with nothing and be believed anyway. Where the model already
+exposes a liveness predicate, the probe's failure to call it is the bug.
+
 ## 2. Next steps
 
 ### 2.1 The radio profile — highest leverage
@@ -625,6 +730,24 @@ must name its gate rather than reporting as merely stale.
 not an HL2 (§2.1). Until that lands, every per-meter reading is measured and
 valid and NOTHING renders a verdict on it — which is how a run can be green and
 useless at the same time.
+
+**Confirmed on hardware, 2026-08-10.** The 2026-08-10 Hermes-Lite 2 run turned
+three of the items above from anticipated into observed, and the "forward power
+must be non-zero while keyed" check is now the highest-priority one: it is the
+single check that would have caught §1.32. Four concrete changes fall out, all
+small and all in `RadioCertification.cpp`:
+
+1. **A keyed-RF precondition on the meters phase.** If no keyed stage produced
+   forward power, every transmit-meter verdict in that run is `INCONCLUSIVE`,
+   not `NEVER FED` (§1.32). This must not be a drive floor alone — an interlock
+   or a disabled PA is silent at any slider setting.
+2. **`acceptedUnits` as a set in `kMeterTable`,** matching `kMeterSurfaces`,
+   which ends a permanent false positive on healthy hardware (§1.33).
+3. **`asRendered` through the liveness gates and sampled while keyed** —
+   `swrSampleLive()` already exists and two other consumers call it (§1.34).
+4. **Refresh `kMeterTable`'s notes and `expectedOnHl2` column.** Four HL2 meters
+   are marked not-expected while being defined and fed, so a regression in any
+   of them cannot be reported by `expectedButMissing`.
 
 ### 2.4 What the bridge needs for any of this to be automatable
 

--- a/docs/CERTIFICATION.md
+++ b/docs/CERTIFICATION.md
@@ -6,14 +6,16 @@ after the fact — which is the point of the tool, and a useful check on it: som
 of what follows is a defect radiocert found, and some is a gap in radiocert
 itself that only a second radio could expose.
 
-**1.32–1.34 came from returning to the Hermes-Lite 2** on 2026-08-10 and running
+**1.32–1.35 came from returning to the Hermes-Lite 2** on 2026-08-10 and running
 `radiocert meters` against it after the Icom work had reshaped the tool. All
-three are defects in the *tool*, not the radio, and all three are the shapes
-this document already warns about, aimed back at the instrument: a negative
-finding from a stage that never transmitted, a false positive that a sibling
-table had already been fixed to prevent, and a staleness probe reading a stale
-value. Turning the tool on a radio it has already certified is cheap, and it is
-the only way these were ever going to surface.
+four are defects in the *tool*, not the radio, and all four are shapes this
+document already warns about, aimed back at the instrument: a negative finding
+from a stage that never transmitted, a false positive that a sibling table had
+already been fixed to prevent, a staleness probe reading a stale value, and a
+hardcoded finding that outlived the bug it described. **Two of the concerns in
+that run were wrong and none of the meters were** — which is the ratio at which
+an operator stops reading concerns. Turning the tool on a radio it has already
+certified is cheap, and it is the only way these were ever going to surface.
 
 Why `radiocert` is shaped the way it is, and what it still cannot do.
 
@@ -643,6 +645,49 @@ exist. Reading a typed accessor raw makes the probe a *third* convention
 alongside the seam and the gauge, and §1.1 applies to it as much as to anything
 else: it will agree with nothing and be believed anyway. Where the model already
 exposes a liveness predicate, the probe's failure to call it is the bug.
+
+### 1.35 A hardcoded finding outlives the bug it describes
+
+`stageControlEffect` emits, on every Hermes-Lite 2 run:
+
+> `SliceModel::setRfGain` has no runtime path on this backend — LNA gain is
+> connect-parameters only, so the preamp/attenuator control does nothing after
+> connect
+
+The first clause is true and the conclusion is false. `SliceModel::setRfGain` is
+a dead end — its body is `sendCommand("slice set N rfgain=X")`, Flex wire text
+no seam backend can receive — but the operator's RF Gain slider does not call
+it. It routes through `RadioModel::setPanRfGainFor` to
+`Hl2Backend::setPanRfGain`, which writes the AD9866 LNA register at runtime.
+`setPanRfGainFor` exists *because of this bug* and says so:
+
+> Without this the HL2's RF Gain slider moved, persisted, and changed nothing:
+> `lnaGainDb` was applied once at connect and never again.
+
+The fix landed, the control works, and the finding stayed — because it is not a
+measurement. It is a `problems <<` string behind an `if (family == "hl2")`,
+asserted rather than observed, so nothing about the repair could reach it.
+
+§1.14 is the spatial version of this: a hardcoded fact about one radio, reported
+against another. This is the temporal version, and it is worse in one specific
+way — §1.14's false finding is visibly about the wrong radio, while this one is
+about the right radio and was simply true last year. Nothing distinguishes it
+from a live result, which is the same complaint §1.28 makes about a concern that
+never clears.
+
+It is also the **second** permanent false positive `radiocert` emits on healthy
+HL2 hardware, next to §1.33's unit mismatch. Two of the concerns in a clean run
+are wrong, which is the ratio at which an operator stops reading them.
+
+**Consequence.** A hardcoded finding needs an expiry mechanism, and the cheapest
+one is to stop hardcoding: assert the wiring the way the tool asserts everything
+else, by effect. RF gain has an unusually good one available — an 8 dB LNA step
+must move `SLC:LEVEL` by 8 dB, a known answer that needs no calibration and no
+transmission. Where a finding genuinely cannot be measured, it belongs in the
+radio profile (§2.1) as declared data with a date on it, not in a stage as a
+string. And when a defect is fixed, grep the certification tool for its
+description — the tool is the last place anyone looks for a stale claim about a
+bug they just repaired.
 
 ## 2. Next steps
 

--- a/docs/radio-certification.md
+++ b/docs/radio-certification.md
@@ -37,12 +37,21 @@ Hermes-Lite 2 can physically produce it.
 | `TX:MICPEAK` | dBFS | yes | tracks input | inject −20 dBFS tone → reads −20 | **±1 dB** |
 | `TX:SWR` | SWR | yes | 1.0–1.5 into a dummy load | key with audio | **±0.3** |
 | `TX:SWR` idle | SWR | yes | **absent** | key with no audio | present-while-idle means the ratio saturated |
-| `TX:FWDPWR` | dBm | counts only | rises with drive | halve RF power → drops ≈6 dB | ±3 dB |
-| `TX:REFPWR` | dBm | counts only | ≪ forward into a load | key into a dummy load | ≥15 dB below forward |
-| `TX:ALC` | dB | **host-side** | gain the ALC applies | quiet input → gain rises | ±3 dB |
-| `TX:COMPPEAK` | dB | host-side | compression applied | — | not yet wired |
+| `TX:FWDPWR` | dBm | yes | rises with drive | raise the drive **one nibble** → rises | see the note below on halving |
+| `TX:REFPWR` | dBm | yes | ≪ forward into a load | key into a dummy load | ≥15 dB below forward |
+| `TX:ALC` | dBFS | **host-side** | post-ALC transmit peak | sweep the input 20 dB → reading does **not** move | **±1 dB across the sweep** |
+| `TX:COMPPEAK` | dB | host-side | compression applied | PROC on → rises above 0 | reads 0 with PROC off |
 | `TX:MIC` | dBFS | host-side | pre-gain mic level | — | not yet wired |
 | `TX:HWALC` | dBFS | **no** | — | Flex RCA jack; no HL2 equivalent | — |
+
+Four of those rows read "counts only", "not yet wired" or "gain the ALC applies"
+until 2026-08-10, when a live run showed all four meters defined and fed. The
+stimulus column is the part that stayed wrong longest, and it is the part that
+matters: **`TX:ALC` is the post-ALC transmit PEAK in dBFS, not the gain the ALC
+applied.** That is what `Hl2Backend::defineMeters` publishes and what
+`MeterModel::swAlc()` binds to, so the old "quiet input → gain rises, ±3 dB"
+asked for a quantity this radio never produced — and would have been recorded as
+a failure by anyone who ran it, on a meter that turns out to be exact.
 
 ### Radio / hardware
 
@@ -51,6 +60,74 @@ Hermes-Lite 2 can physically produce it.
 | `RAD:PATEMP` | degC | yes | 20–60 idle | key 10 s → **rises ≥0.5 °C** | rise is the check, not the value |
 | `RAD:+13.8A` | Volts | **no** | — | HL2 reports no supply voltage | — |
 | `AMP:*`, `TGXL:*` | — | **no** | — | external amp / tuner only | — |
+
+### Certified by effect, 2026-08-10 (Hermes-Lite 2, 14.200 MHz USB, dummy load)
+
+Gateware v74, `radiocert meters 14.200` plus a manual drive sweep, host-side
+1 kHz test tone as the stimulus. Every row below is an **observed effect**, not
+a readback.
+
+| meter | stimulus | observed | verdict |
+|---|---|---|---|
+| `TX:MICPEAK` | −20 dBFS tone | **−19.977 dBFS** (+0.023 dB) | **CERTIFIED** — and again at −10 dBFS: −9.969 |
+| `TX:SWR` | tone into a dummy load | **1.0**, age 43–531 ms | **CERTIFIED** — a flat load reads flat |
+| `TX:SWR` idle | unkeyed | **absent** (null, age −1) | **CERTIFIED** — the `kMinForwardCountsForSwr` gate does its job; no 255.99:1 |
+| `TX:REFPWR` | 5.57 W forward into a dummy load | **0.001 W**, ≈37 dB below forward | **CERTIFIED** — requirement is ≥15 dB |
+| `RAD:PATEMP` | 10 s key | 32.70 → **43.06 °C** (+10.36) | **CERTIFIED** — requirement is a ≥0.5 °C rise |
+| `TX:ALC` | tone swept −10 → −30 dBFS | **−1.41 dBFS at every level** | **CERTIFIED** — see the normalisation check below |
+| `TX:COMPPEAK` | PROC off | **0 dB**, age 0–28 ms | **LIVE** — reads zero with the compressor off, which is correct |
+| `SLC:LEVEL` | receiving | −105.7 dBm, age 15–78 ms | **LIVE** |
+| `RAD:+13.8A` | — | not defined | **correct** — the HL2 reports no supply voltage |
+| mic gain control | 100 → 50 | **6.023 dB** | **CERTIFIED** — arithmetic says 6.02 |
+
+**The ALC normalisation check, and why it certifies the whole host TX chain.**
+A post-ALC peak meter has a known answer available without any calibration: it
+must be **constant** while its input is not. Sweeping the injected tone over
+20 dB, at fixed drive:
+
+| Injected tone | `TX:MICPEAK` | `TX:ALC` | `TX:FWDPWR` |
+|---|---|---|---|
+| −10 dBFS | −9.98 dBFS | **−1.41 dBFS** | 1.988 W |
+| −20 dBFS | −19.98 dBFS | **−1.41 dBFS** | 1.999 W |
+| −30 dBFS | −30.00 dBFS | **−1.41 dBFS** | 2.000 W |
+
+The pre-ALC meter tracks the input to within 0.02 dB and the post-ALC meter does
+not move at all — which is the ALC doing its job, measured rather than assumed.
+Constant forward power across the same sweep says the transmitted level is
+**drive-limited, not audio-limited** on this radio, so an operator's mic gain
+cannot change their output power; only the drive control can.
+
+Because these two meters sit on opposite sides of the ALC, agreeing with each
+other in opposite directions, they certify the host transmit path between them:
+test tone → mic gain → ALC → modulator → IQ on the wire → PA → 2 W into a load.
+This is the HL2 analogue of the IC-705's live-voice run below, with a synthetic
+stimulus instead of speech — weaker as an audio-quality check and stronger as a
+level check, since the tone's amplitude is exactly known.
+
+`TX:FWDPWR` is **live and uncertified**, and the distinction is the point.
+It reads 5.57 W at full drive and 1.17 W at 25 %, so it plainly tracks drive.
+But the certification stimulus in the table above — halve the control, expect
+−6.02 dB — cannot be run on this radio:
+
+| Change | Expected | Measured |
+|---|---|---|
+| 100 % → 50 % | −6.02 dB | **−4.44 dB** |
+| 50 % → 25 % | −6.02 dB | **−2.33 dB** |
+
+Two independent reasons, and neither is a fault in the control:
+
+1. **Halving the slider does not halve the drive.** The gateware decodes only
+   the drive register's top nibble, so the slider's 101 positions are 16 radio
+   states and 100→50→25 % is nibble 15→7→3 (`HERMES.md` 17.7).
+2. **The instrument is uncalibrated by construction.** Forward power comes from
+   Quisk's `HL2FilterE3` *reference* curve, which is a different board's
+   calibration (`HERMES.md` 17.5).
+
+So a failing delta here cannot be attributed to the control rather than to the
+curve, and **`radiocert` must not report one as a control defect.** Certifying
+drive by effect on this radio needs either a per-unit power calibration or an
+external power meter; until then the honest claim is "monotonic in drive",
+which is what the nibble sweep in `HERMES.md` 17.7 shows.
 
 ### Icom (IC-705) — measured with `controls meters`, radio idle on 20 m
 
@@ -229,8 +306,8 @@ this table, which is the same rule the report itself follows.
 
 | Control | Range | HL2 path | Observable effect | Tolerance | Certified |
 |---|---|---|---|---|---|
-| `TransmitModel::setRfPower` | 0–100 | drive `0x09[31:28]` + PA enable | halve → `TX:FWDPWR` drops ≈6 dB | ±3 dB | **no — unrunnable** |
-| `TransmitModel::setRfPower(0)` | — | disables the PA | forward power to the floor | — | **no — unrunnable** |
+| `TransmitModel::setRfPower` | 0–100 | drive register, **top nibble only** | one nibble up → `TX:FWDPWR` rises | monotonic; see below | **partly — monotonic proved, ≈6 dB not applicable** |
+| `TransmitModel::setRfPower(0)` | — | disables the PA | forward power to the floor | — | **yes — 0 % reads the 0.001 W floor** |
 | `AudioEngine::setPcMicGain` | 0–100 | host-side, pre-modulator | halve → `TX:MICPEAK` drops ≈6 dB | ±1 dB | **yes — 6.023 dB measured** |
 | `SliceModel::setAgcThreshold` | 0–100 | WDSP `SetRXAAGCTop` | raise → audio floor rises | ±3 dB | no |
 | `SliceModel::setRfGain` | dB | **NOT WIRED** | LNA gain is connect-params only on HL2 | — | n/a |
@@ -241,24 +318,30 @@ this table, which is the same rule the report itself follows.
 
 ### Gaps this table makes visible
 
-- **The RF power rows are unrunnable, not unimplemented.** Certifying them by
-  effect needs `TX:FWDPWR`, which is defined-but-never-fed on this backend (see
-  below). Until a power meter is published with a documented scale, the drive
-  control cannot be certified by effect on the HL2 at all — so `radiocert`
-  reports `rfPowerExercised: false` rather than implying a sweep happened.
+- **The RF power rows are runnable but not conclusive.** They were listed as
+  unrunnable because `TX:FWDPWR` was defined-but-never-fed. It is fed, and the
+  sweep runs — but neither of its two premises holds on this radio (the control
+  is 16-step, the instrument is a different board's calibration), so the ≈6 dB
+  criterion cannot separate a control fault from a curve error. `radiocert`
+  still reports `rfPowerExercised: false`, which remains the right answer: the
+  verb does not drive the slider, and the sweep above was manual.
 - **`SliceModel::setRfGain` has no runtime path.** The AD9866 LNA gain is sent
   once in the connect parameters and never again, so the preamp/attenuator
   control does nothing after connect. It is also the control an operator reaches
   for first when the ADC overloads. `radiocert` only reports this on a radio
   whose `family()` is `hl2` — asserting it generically told Flex operators a
-  working control was broken.
-- **`TX:FWDPWR` and `TX:REFPWR` are defined but never fed.** The counts are
-  uncalibrated, so they are deliberately not published — which leaves two power
-  meters on screen that can never move. Either publish with a documented scale
-  or stop defining them.
-- **`TX:ALC` is computed and thrown away.** `Hl2TxDsp` emits `alcGain` and
-  nothing consumes it, while an ALC meter is exactly what tells an operator
-  whether their mic gain is sane.
+  working control was broken. **Still true as of 2026-08-10**, and it is the one
+  concern in the meters run that is a real, open defect.
+- **`TX:FWDPWR`, `TX:REFPWR`, `TX:ALC` and `TX:COMPPEAK` are all fed** as of
+  2026-08-10, and were described here as unpublished, computed-and-discarded or
+  unwired long after they were wired. Directional power is published through the
+  §17.5 reference curve and labelled uncalibrated in its own `MeterDef`; the ALC
+  meter carries the post-ALC peak and the Phone/CW gauges read it.
+  `kMeterTable` in `RadioCertification.cpp` still carries all four of the stale
+  notes **and** marks all four `expectedOnHl2 = false`, which means the
+  inventory's `expectedButMissing` check can never notice if one of them
+  regresses. That table is the executable copy of this one; fixing this section
+  without fixing it leaves the tool disagreeing with the document.
 - **Tune power is not separable from transmit power.** TUNE keys at whatever
   drive is set, which on a fresh connect is the operator's full RF power.
 

--- a/docs/radio-certification.md
+++ b/docs/radio-certification.md
@@ -310,7 +310,8 @@ this table, which is the same rule the report itself follows.
 | `TransmitModel::setRfPower(0)` | — | disables the PA | forward power to the floor | — | **yes — 0 % reads the 0.001 W floor** |
 | `AudioEngine::setPcMicGain` | 0–100 | host-side, pre-modulator | halve → `TX:MICPEAK` drops ≈6 dB | ±1 dB | **yes — 6.023 dB measured** |
 | `SliceModel::setAgcThreshold` | 0–100 | WDSP `SetRXAAGCTop` | raise → audio floor rises | ±3 dB | no |
-| `SliceModel::setRfGain` | dB | **NOT WIRED** | LNA gain is connect-params only on HL2 | — | n/a |
+| `SliceModel::setRfGain` | dB | **dead — Flex wire text** | none; nothing on a non-Flex backend receives it | — | n/a — the operator's slider does not use it |
+| `IRadioBackend::setPanRfGain` | −8…+32 dB | AD9866 LNA `0x0a[5:0]`, at runtime | LNA gain changes; echoed to every pan | — | no — needs an S-meter delta check |
 | `TransmitModel::setTunePower` | 0–100 | **NOT WIRED** | tune uses full drive | — | n/a |
 | `SliceModel::setSquelch` | on/off | **NOT WIRED** | — | — | n/a |
 | `setFilter(low, high)` | Hz | WDSP passband | tone outside the passband is rejected | ≥30 dB | no |
@@ -325,13 +326,33 @@ this table, which is the same rule the report itself follows.
   criterion cannot separate a control fault from a curve error. `radiocert`
   still reports `rfPowerExercised: false`, which remains the right answer: the
   verb does not drive the slider, and the sweep above was manual.
-- **`SliceModel::setRfGain` has no runtime path.** The AD9866 LNA gain is sent
-  once in the connect parameters and never again, so the preamp/attenuator
-  control does nothing after connect. It is also the control an operator reaches
-  for first when the ADC overloads. `radiocert` only reports this on a radio
-  whose `family()` is `hl2` — asserting it generically told Flex operators a
-  working control was broken. **Still true as of 2026-08-10**, and it is the one
-  concern in the meters run that is a real, open defect.
+- **`SliceModel::setRfGain` has no runtime path — and that no longer means the
+  RF gain control is dead.** The symbol really is a dead end: its whole body is
+  `sendCommand("slice set N rfgain=X")`, raw Flex wire text, which no non-Flex
+  backend can receive. But the operator's RF Gain slider **does not use it.**
+  `SpectrumOverlayMenu` emits `rfGainChanged` unconditionally and only falls back
+  to the slice setter when there is no radio model or no pan id; on the HL2 both
+  exist, so the slider routes `rfGainChanged` → `RadioModel::setPanRfGainFor` →
+  `Hl2Backend::setPanRfGain` → `applyLnaGainDb` → `MetisClient::setLnaGainDb`,
+  which writes the AD9866 LNA register **at runtime**, remembers the value per
+  band, and echoes it to every pan.
+
+  `RadioModel::setPanRfGainFor` says so in its own comment: *"Without this the
+  HL2's RF Gain slider moved, persisted, and changed nothing: lnaGainDb was
+  applied once at connect and never again."* That is the defect this bullet used
+  to describe, and it was fixed.
+
+  **`radiocert` still reports it on every HL2 run**, because
+  `stageControlEffect` hardcodes `rfGainRuntimePath: false` behind a family
+  check. So it is a stale finding, not an open defect — the second one this
+  document's own tool emits on healthy hardware, alongside the `TX:ALC` unit
+  mismatch. See `CERTIFICATION.md` 1.35.
+
+  What is genuinely **uncertified** is the pan-level control's *effect*: nothing
+  has measured that changing the LNA gain moves the noise floor by the amount
+  asked for. That is a real gap and a runnable one — an 8 dB step should move
+  `SLC:LEVEL` by 8 dB, which is a known answer needing no calibration and no
+  transmission.
 - **`TX:FWDPWR`, `TX:REFPWR`, `TX:ALC` and `TX:COMPPEAK` are all fed** as of
   2026-08-10, and were described here as unpublished, computed-and-discarded or
   unwired long after they were wired. Directional power is published through the


### PR DESCRIPTION
Ran `radiocert meters 14.200` against the **physical Hermes-Lite 2** (gateware v74, MAC `00:1C:C0:A2:13:DD`) into a dummy load, plus manual drive and ALC sweeps. **Docs only — no code changes.**

Headline: **every meter on this radio is correct, and two of the concerns `radiocert` reports on a clean run are not.**

## Certified by effect

| meter | stimulus | observed | verdict |
|---|---|---|---|
| `TX:MICPEAK` | −20 dBFS tone | **−19.977 dBFS** (+0.023 dB) | CERTIFIED |
| `TX:ALC` | tone swept −10 → −30 dBFS | **−1.41 dBFS at every level** | CERTIFIED |
| `TX:SWR` | tone into a dummy load | **1.0**, age 43–531 ms | CERTIFIED |
| `TX:SWR` idle | unkeyed | **absent** | CERTIFIED — no 255.99:1 |
| `TX:REFPWR` | 5.57 W forward | **0.001 W**, ≈37 dB below | CERTIFIED (≥15 dB) |
| `RAD:PATEMP` | 10 s key | 32.70 → **43.06 °C** | CERTIFIED (≥0.5 °C) |
| mic gain | 100 → 50 | **6.023 dB** | CERTIFIED (6.02 is arithmetic) |

The ALC result is the strongest. `TX:MICPEAK` tracks the input to 0.02 dB across a 20 dB sweep while `TX:ALC` does not move at all — the ALC normalising, measured rather than assumed. Because the two meters sit on opposite sides of it and agree in opposite directions, they certify the host TX path between them: tone → mic gain → ALC → modulator → IQ on the wire → PA → 2 W into a load.

Four meters (`FWDPWR`, `REFPWR`, `ALC`, `COMPPEAK`) were documented as unpublished, computed-and-discarded or unwired long after they were wired. `TX:ALC`'s documented stimulus asked for the *gain the ALC applies*; the meter carries the post-ALC *peak*, so anyone who ran it would have logged a failure against a meter that turns out to be exact.

## `HERMES.md` 17.7 — the RF power slider has 101 positions and the radio has 16

The gateware decodes only the drive register's top nibble. Proved on hardware:

| Slider | Register | Top nibble | Forward |
|---|---|---|---|
| 44 % | 112 | 7 | 1.984 W |
| 50 % | 127 | 7 | 2.001 W |
| 51 % | 130 | 8 | 2.312 W |
| 56 % | 142 | 8 | 2.319 W |

Six points of travel do nothing; the next single point is +1.25 dB. Not a defect — `applyDrive` is correct and its comment already said so — but it is why "halve the drive, expect −6 dB" cannot certify this control, and the uncalibrated `HL2FilterE3` curve is an independent second reason. Measured deltas were −4.44 dB (100→50 %) and −2.33 dB (50→25 %), so a failing delta cannot be attributed to the control rather than to the curve.

## Four new lessons — all defects in the *tool*, not the radio

- **1.32 A stage that transmits must check that it transmitted.** With the operator's drive at **0**, the run reported `TX:SWR` *"DEFINED BUT NEVER FED … stop defining them"*. At 50 % drive minutes later it read 1.0. Nothing had changed but the slider. `run()` clamps RF power *down* to the automation ceiling and has no floor, and no keyed stage asks whether forward power appeared. That is §1.8 arriving from the other side — and a false `NEVER FED` is a standing invitation to delete a working meter, which is exactly what the concern text recommends.
- **1.33 A lesson learned in one table is not learned in its sibling.** `MeterSurfaces.h` holds accepted units as a **set** precisely to stop a false positive that *had already been fixed*; `kMeterTable` is still the single-value version. So every HL2 run reports `UNIT MISMATCH` on a correct meter — and ranks it **first**, above every real concern.
- **1.34 The "is it rendered" probe needs the same guards as the gauge.** `asRendered` reads three typed accessors raw and unkeyed. Forward power can never show a keyed value (0.001 W in a run that measured 2.0 W), and `swr()` returns a confident `1.0` in the same stage that reports the meter never fed — `MeterModel::swr()` has no measured companion, though `swrSampleLive()` exists and two other consumers call it.
- **1.35 A hardcoded finding outlives the bug it describes.** Every HL2 run reports *"`SliceModel::setRfGain` has no runtime path … the preamp/attenuator control does nothing after connect"*. The first clause is true — that symbol's body is `sendCommand("slice set N rfgain=X")`, Flex wire text — but the operator's slider **does not call it**. It routes `rfGainChanged` → `RadioModel::setPanRfGainFor` → `Hl2Backend::setPanRfGain` → `applyLnaGainDb`, writing the AD9866 LNA register at runtime with per-band memory. `setPanRfGainFor` exists *because of* that bug and says so: *"Without this the HL2's RF Gain slider moved, persisted, and changed nothing."* The fix landed; the finding stayed, because it is a `problems <<` string behind a family gate rather than a measurement. §1.14 is the spatial version of this; 1.35 is the temporal one, and harder to spot because the finding is about the right radio and was simply true last year.

## Follow-up

Queued in `CERTIFICATION.md` §2.3 and §1.35, none in this PR: a keyed-RF precondition that downgrades to `INCONCLUSIVE`; `acceptedUnits` as a set in `kMeterTable`; `asRendered` through the liveness gates and sampled while keyed; a refresh of `kMeterTable`'s notes and `expectedOnHl2` column; and replacing the hardcoded RF-gain finding with a measurement — an 8 dB LNA step must move `SLC:LEVEL` by 8 dB, a known answer needing no calibration and no transmission.

## Testing

Live hardware, transmitting on 14.200 MHz USB into a dummy load with the operator present and clearance given. Radio left unkeyed at drive 0 and disconnected cleanly.