### PR TITLE
fix(radiocert): stop the meters phase reporting five stale or unsupportable findings on healthy hardware

### DIFF
--- a/docs/radio-certification.md
+++ b/docs/radio-certification.md
@@ -37,10 +37,10 @@ Hermes-Lite 2 can physically produce it.
 | `TX:MICPEAK` | dBFS | yes | tracks input | inject −20 dBFS tone → reads −20 | **±1 dB** |
 | `TX:SWR` | SWR | yes | 1.0–1.5 into a dummy load | key with audio | **±0.3** |
 | `TX:SWR` idle | SWR | yes | **absent** | key with no audio | present-while-idle means the ratio saturated |
-| `TX:FWDPWR` | dBm | yes | rises with drive | halve RF power → drops ≈6 dB | ±3 dB |
+| `TX:FWDPWR` | dBm | yes | rises with drive | raise the drive **one nibble** → rises | see the note below on halving |
 | `TX:REFPWR` | dBm | yes | ≪ forward into a load | key into a dummy load | ≥15 dB below forward |
-| `TX:ALC` | dBFS | **host-side** | post-ALC transmit peak | inject a tone → tracks the envelope | ±3 dB |
-| `TX:COMPPEAK` | dB | host-side | compression applied | PROC on → reads the gain reduction | reads 0 with PROC off |
+| `TX:ALC` | dBFS | **host-side** | post-ALC transmit peak | sweep the input 20 dB → reading does **not** move | **±1 dB across the sweep** |
+| `TX:COMPPEAK` | dB | host-side | compression applied | PROC on → rises above 0 | reads 0 with PROC off |
 | `TX:MIC` | dBFS | host-side | pre-gain mic level | — | not yet wired |
 | `TX:HWALC` | dBFS | **no** | — | Flex RCA jack; no HL2 equivalent | — |
 
@@ -50,6 +50,30 @@ estimate, not a measurement, and the meter descriptions say so. Uncalibrated is
 not the same as absent, and this table said "counts only" long after they were
 being published; a stale not-fed claim is what switches off the check that
 would notice the meter regressing (CERTIFICATION.md 1.32).
+
+**Why `TX:FWDPWR`'s stimulus is a nibble step and not a halving.** The obvious
+check — halve the drive, expect −6.02 dB — cannot be run on this radio, for two
+independent reasons, neither of which is a fault in the control:
+
+1. The gateware decodes only the drive register's **top nibble**, so a slider
+   halving is not a drive halving: 100 → 50 → 25 % is nibble 15 → 7 → 3, and
+   sliders 44 % and 50 % both land on nibble 7 (`HERMES.md` 17.7).
+2. The reference curve is nonlinear as well as uncalibrated, so the scale does
+   not cancel out of a ratio taken across a wide span (`HERMES.md` 17.5).
+
+Measured live: **−4.44 dB** (100→50 %) and **−2.33 dB** (50→25 %) against the
+−6.02 dB a true halving would give — the second is outside even a ±3 dB
+tolerance, on a radio that is working correctly. A failing delta therefore
+cannot be attributed to the control rather than to the curve, so `radiocert`
+must not report one as a control defect. Monotonicity under a one-nibble step is
+what this control can honestly certify by effect.
+
+Likewise `TX:ALC`'s stimulus is a **20 dB input sweep with no movement**, not
+envelope tracking. A post-ALC peak meter has a known answer available with no
+calibration at all: it must stay constant while its input does not. Swept
+−10 → −30 dBFS it read −1.41 dBFS at every level while `TX:MICPEAK` tracked the
+same sweep to within 0.02 dB. A check written to "tracks the envelope" would
+fail a correct meter by roughly 17 dB.
 
 ### Radio / hardware
 
@@ -236,11 +260,11 @@ this table, which is the same rule the report itself follows.
 
 | Control | Range | HL2 path | Observable effect | Tolerance | Certified |
 |---|---|---|---|---|---|
-| `TransmitModel::setRfPower` | 0–100 | drive `0x09[31:28]` + PA enable | halve → `TX:FWDPWR` drops ≈6 dB | ±3 dB | **no — unrunnable** |
-| `TransmitModel::setRfPower(0)` | — | disables the PA | forward power to the floor | — | **no — unrunnable** |
+| `TransmitModel::setRfPower` | 0–100 | drive register, **top nibble only** | one nibble up → `TX:FWDPWR` rises | monotonic; ≈6 dB not applicable | **partly — monotonic proved by hand** |
+| `TransmitModel::setRfPower(0)` | — | disables the PA | forward power to the floor | — | **yes — 0 % reads the 0.001 W floor** |
 | `AudioEngine::setPcMicGain` | 0–100 | host-side, pre-modulator | halve → `TX:MICPEAK` drops ≈6 dB | ±1 dB | **yes — 6.023 dB measured** |
 | `SliceModel::setAgcThreshold` | 0–100 | WDSP `SetRXAAGCTop` | raise → audio floor rises | ±3 dB | no |
-| RF Gain slider | dB | AD9866 LNA `0x0a[5:0]` | step the gain → S-meter must **not** move (the display reference tracks it) | ±3 dB of 0 | yes — `meters` phase |
+| RF Gain slider | dB | AD9866 LNA `0x0a[5:0]` | step the gain → the pan echoes the value the hardware took | echo must equal the request | **yes — `control-effect` phase** |
 | `SliceModel::setRfGain` | dB | **dead end** | Flex wire text; the slider does not call it — see below | — | n/a |
 | `TransmitModel::setTunePower` | 0–100 | **NOT WIRED** | tune uses full drive | — | n/a |
 | `SliceModel::setSquelch` | on/off | **NOT WIRED** | — | — | n/a |
@@ -249,12 +273,14 @@ this table, which is the same rule the report itself follows.
 
 ### Gaps this table makes visible
 
-- **The RF power rows are unimplemented, not unrunnable.** Certifying them by
-  effect needs `TX:FWDPWR`, which IS published now (in dBm, through the
-  uncalibrated reference curve). A halving is a ratio, so the missing
-  calibration cancels and the check is available as soon as someone writes it;
-  until then `radiocert` reports `rfPowerExercised: false` rather than implying
-  a sweep happened.
+- **The RF power rows are runnable but not conclusive.** They were listed as
+  unrunnable because `TX:FWDPWR` was defined-but-never-fed. It is fed, and a
+  sweep runs — but neither premise of the ≈6 dB criterion holds on this radio
+  (the control is 16-step, the instrument is another board's calibration), so a
+  failing delta cannot separate a control fault from a curve error. See the note
+  under the transmit table. `radiocert` still reports `rfPowerExercised: false`,
+  which remains the right answer: the verb does not drive the slider, and the
+  sweep that produced these numbers was manual.
 - **`SliceModel::setRfGain` is a dead end, and the RF Gain slider does not use
   it.** The setter's whole body is `slice set N rfgain=X`, Flex wire text no
   seam backend can receive — but `SpectrumOverlayMenu` emits `rfGainChanged`
@@ -265,6 +291,22 @@ this table, which is the same rule the report itself follows.
   `0x0a[5:0]` at runtime. `radiocert` used to assert the opposite as a
   hardcoded, family-gated finding on every HL2 run; it now MEASURES the
   control instead, which is what let the gate go (CERTIFICATION.md 1.14, 1.35).
+- **The RF gain check's verdict rests on the echo, and its S-meter delta is
+  evidence only.** The tempting expectation — an 8 dB LNA step must move
+  `SLC:LEVEL` by 8 dB — is wrong twice over. `Hl2DbReference` is moved in the
+  same call as the gain and both the spectrum and the S-meter render through it,
+  precisely so a gain change does **not** slide the display (`HERMES.md` 17.4),
+  so the expected delta is **0 dB**, not the step size. And a reading near
+  −step has two causes this measurement cannot separate: the register never took
+  the value, or the reading is dominated by converter noise that does not rise
+  with the gain. Measured on a quiet 20 m, an 8 dB step moved `SLC:LEVEL` by
+  −6.3 dB — within 2 dB of the defect signature — while the raw dBFS behind it
+  *rose* 1.74 dB, proving the register **had** been written. So the stage
+  publishes both hypotheses (`sLevelExpectedDeltaDb`,
+  `sLevelDeltaIfRegisterNotWrittenDb`), marks the delta
+  `sLevelDeltaIsConclusive: false`, and raises its one concern on a missing
+  echo. Closing the effect half needs the raw pre-reference dBFS, which the seam
+  does not expose (CERTIFICATION.md 2.4).
 - **`TX:FWDPWR` and `TX:REFPWR` are published and uncalibrated**, not absent.
   They read in dBm through a reference curve for a different board. The gap is
   a per-unit calibration, not a missing meter.

--- a/docs/radio-certification.md
+++ b/docs/radio-certification.md
@@ -37,12 +37,19 @@ Hermes-Lite 2 can physically produce it.
 | `TX:MICPEAK` | dBFS | yes | tracks input | inject −20 dBFS tone → reads −20 | **±1 dB** |
 | `TX:SWR` | SWR | yes | 1.0–1.5 into a dummy load | key with audio | **±0.3** |
 | `TX:SWR` idle | SWR | yes | **absent** | key with no audio | present-while-idle means the ratio saturated |
-| `TX:FWDPWR` | dBm | counts only | rises with drive | halve RF power → drops ≈6 dB | ±3 dB |
-| `TX:REFPWR` | dBm | counts only | ≪ forward into a load | key into a dummy load | ≥15 dB below forward |
-| `TX:ALC` | dB | **host-side** | gain the ALC applies | quiet input → gain rises | ±3 dB |
-| `TX:COMPPEAK` | dB | host-side | compression applied | — | not yet wired |
+| `TX:FWDPWR` | dBm | yes | rises with drive | halve RF power → drops ≈6 dB | ±3 dB |
+| `TX:REFPWR` | dBm | yes | ≪ forward into a load | key into a dummy load | ≥15 dB below forward |
+| `TX:ALC` | dBFS | **host-side** | post-ALC transmit peak | inject a tone → tracks the envelope | ±3 dB |
+| `TX:COMPPEAK` | dB | host-side | compression applied | PROC on → reads the gain reduction | reads 0 with PROC off |
 | `TX:MIC` | dBFS | host-side | pre-gain mic level | — | not yet wired |
 | `TX:HWALC` | dBFS | **no** | — | Flex RCA jack; no HL2 equivalent | — |
+
+`TX:FWDPWR` and `TX:REFPWR` are published in dBm through the reference curve in
+`Hl2Backend::directionalWatts()`, which is **uncalibrated** — the value is an
+estimate, not a measurement, and the meter descriptions say so. Uncalibrated is
+not the same as absent, and this table said "counts only" long after they were
+being published; a stale not-fed claim is what switches off the check that
+would notice the meter regressing (CERTIFICATION.md 1.32).
 
 ### Radio / hardware
 
@@ -233,7 +240,8 @@ this table, which is the same rule the report itself follows.
 | `TransmitModel::setRfPower(0)` | — | disables the PA | forward power to the floor | — | **no — unrunnable** |
 | `AudioEngine::setPcMicGain` | 0–100 | host-side, pre-modulator | halve → `TX:MICPEAK` drops ≈6 dB | ±1 dB | **yes — 6.023 dB measured** |
 | `SliceModel::setAgcThreshold` | 0–100 | WDSP `SetRXAAGCTop` | raise → audio floor rises | ±3 dB | no |
-| `SliceModel::setRfGain` | dB | **NOT WIRED** | LNA gain is connect-params only on HL2 | — | n/a |
+| RF Gain slider | dB | AD9866 LNA `0x0a[5:0]` | step the gain → S-meter must **not** move (the display reference tracks it) | ±3 dB of 0 | yes — `meters` phase |
+| `SliceModel::setRfGain` | dB | **dead end** | Flex wire text; the slider does not call it — see below | — | n/a |
 | `TransmitModel::setTunePower` | 0–100 | **NOT WIRED** | tune uses full drive | — | n/a |
 | `SliceModel::setSquelch` | on/off | **NOT WIRED** | — | — | n/a |
 | `setFilter(low, high)` | Hz | WDSP passband | tone outside the passband is rejected | ≥30 dB | no |
@@ -241,24 +249,28 @@ this table, which is the same rule the report itself follows.
 
 ### Gaps this table makes visible
 
-- **The RF power rows are unrunnable, not unimplemented.** Certifying them by
-  effect needs `TX:FWDPWR`, which is defined-but-never-fed on this backend (see
-  below). Until a power meter is published with a documented scale, the drive
-  control cannot be certified by effect on the HL2 at all — so `radiocert`
-  reports `rfPowerExercised: false` rather than implying a sweep happened.
-- **`SliceModel::setRfGain` has no runtime path.** The AD9866 LNA gain is sent
-  once in the connect parameters and never again, so the preamp/attenuator
-  control does nothing after connect. It is also the control an operator reaches
-  for first when the ADC overloads. `radiocert` only reports this on a radio
-  whose `family()` is `hl2` — asserting it generically told Flex operators a
-  working control was broken.
-- **`TX:FWDPWR` and `TX:REFPWR` are defined but never fed.** The counts are
-  uncalibrated, so they are deliberately not published — which leaves two power
-  meters on screen that can never move. Either publish with a documented scale
-  or stop defining them.
-- **`TX:ALC` is computed and thrown away.** `Hl2TxDsp` emits `alcGain` and
-  nothing consumes it, while an ALC meter is exactly what tells an operator
-  whether their mic gain is sane.
+- **The RF power rows are unimplemented, not unrunnable.** Certifying them by
+  effect needs `TX:FWDPWR`, which IS published now (in dBm, through the
+  uncalibrated reference curve). A halving is a ratio, so the missing
+  calibration cancels and the check is available as soon as someone writes it;
+  until then `radiocert` reports `rfPowerExercised: false` rather than implying
+  a sweep happened.
+- **`SliceModel::setRfGain` is a dead end, and the RF Gain slider does not use
+  it.** The setter's whole body is `slice set N rfgain=X`, Flex wire text no
+  seam backend can receive — but `SpectrumOverlayMenu` emits `rfGainChanged`
+  unconditionally and only falls back to the slice setter when there is no
+  radio model or no pan id. On the HL2 the slider therefore routes
+  `rfGainChanged` → `RadioModel::setPanRfGainFor` → `Hl2Backend::setPanRfGain`
+  → `applyLnaGainDb` → `MetisClient::setLnaGainDb`, writing AD9866
+  `0x0a[5:0]` at runtime. `radiocert` used to assert the opposite as a
+  hardcoded, family-gated finding on every HL2 run; it now MEASURES the
+  control instead, which is what let the gate go (CERTIFICATION.md 1.14, 1.35).
+- **`TX:FWDPWR` and `TX:REFPWR` are published and uncalibrated**, not absent.
+  They read in dBm through a reference curve for a different board. The gap is
+  a per-unit calibration, not a missing meter.
+- **`TX:ALC` is consumed.** `MeterModel::swAlc()` carries it to the Phone/CW
+  applet's ALC gauges. It was computed and discarded for a while, and the note
+  saying so outlived the wiring.
 - **Tune power is not separable from transmit power.** TUNE keys at whatever
   drive is set, which on a fresh connect is the operator's full RF power.
 

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -7024,17 +7024,10 @@ QJsonObject AutomationServer::doLiveness()
         const QString accepted = QString::fromLatin1(surf.acceptedUnits);
         // SET MEMBERSHIP, not equality — the consumer may legitimately handle
         // several units, and asking "are these the same string" reported a
-        // healthy meter as broken forever. See MeterSurfaces.h.
-        const QStringList acceptedList =
-            accepted.split(QLatin1Char(','), Qt::SkipEmptyParts);
-        bool understood = acceptedList.isEmpty();
-        for (const QString& u : acceptedList) {
-            if (declared.compare(u.trimmed(), Qt::CaseInsensitive) == 0) {
-                understood = true;
-                break;
-            }
-        }
-        const bool disagrees = def && !declared.isEmpty() && !understood;
+        // healthy meter as broken forever. Through the shared predicate in
+        // MeterSurfaces.h, because a private copy of it here is how the
+        // `radiocert` table went on emitting the old answer (§1.33).
+        const bool disagrees = def && !meterUnitAccepted(accepted, declared);
         if (disagrees) {
             unitDisagreements
                 << QStringLiteral("%1 (backend declares %2; the consumer handles only %3)")
@@ -7061,7 +7054,7 @@ QJsonObject AutomationServer::doLiveness()
         if (!def)
             continue;
         const QString key = def->source + QLatin1Char(':') + def->name;
-        if (meterSurfaceFor(QLatin1String(key.toLatin1().constData())))
+        if (meterSurfaceFor(key))
             continue;
         publishedNowhere << key;
     }

--- a/src/core/MeterSurfaces.h
+++ b/src/core/MeterSurfaces.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <QLatin1String>
+#include <QString>
+#include <QStringList>
+#include <QStringView>
 
 #include <array>
 
@@ -108,13 +111,44 @@ inline constexpr std::array<MeterSurface, 9> kMeterSurfaces{{
 // Look up a meter's surfaces. Returns nullptr for a key nothing renders, which
 // is the answer the caller wants: a backend publishing "RAD:PACURRENT" and
 // "RAD:OVF" is doing nothing wrong, but no gauge anywhere will move.
-[[nodiscard]] inline const MeterSurface* meterSurfaceFor(QLatin1String key)
+[[nodiscard]] inline const MeterSurface* meterSurfaceFor(QStringView key)
 {
     for (const auto& s : kMeterSurfaces) {
         if (key == QLatin1String(s.key))
             return &s;
     }
     return nullptr;
+}
+
+// Does the consumer understand what the backend declared?
+//
+// THE one implementation of this question, and it is a function rather than
+// three copies of a split-and-compare loop because §1.33 is precisely what
+// happens when two places answer it differently. `acceptedUnits` was widened
+// from a single value to a set here, the automation `meters` join was updated,
+// and `kMeterTable` in RadioCertification.cpp was not — so `radiocert meters`
+// reported UNIT MISMATCH on a healthy TX:ALC on every run, and ranked it above
+// every real finding. There is now nowhere left to hold the old form.
+//
+// An empty declaration is NOT a mismatch: a backend that declares no unit has
+// made no claim to disagree with, and reporting one would invent a defect out
+// of missing metadata. An empty accepted set is not a mismatch either — it
+// means nobody has written down what the consumer handles, which is a gap in
+// this table and not a fault in the radio.
+[[nodiscard]] inline bool meterUnitAccepted(QStringView acceptedUnits,
+                                            QStringView declaredUnit)
+{
+    if (declaredUnit.isEmpty())
+        return true;
+    const QList<QStringView> accepted =
+        acceptedUnits.split(QLatin1Char(','), Qt::SkipEmptyParts);
+    if (accepted.isEmpty())
+        return true;
+    for (QStringView u : accepted) {
+        if (declaredUnit.compare(u.trimmed(), Qt::CaseInsensitive) == 0)
+            return true;
+    }
+    return false;
 }
 
 }  // namespace AetherSDR

--- a/src/core/RadioCertification.cpp
+++ b/src/core/RadioCertification.cpp
@@ -6,18 +6,23 @@
 #include "core/ClientQuindarTone.h"
 #include "core/LogManager.h"
 #include "core/ClientTxTestTone.h"
+#include "core/MeterSurfaces.h"
 #include "models/MeterModel.h"
+#include "models/PanadapterModel.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
 
 #include <QByteArray>
+#include <QDateTime>
 #include <QEventLoop>
 #include <QScopeGuard>
 #include <QTimer>
 
+#include <algorithm>
 #include <cmath>
 #include <complex>
+#include <optional>
 #include <vector>
 
 namespace AetherSDR {
@@ -35,24 +40,68 @@ namespace {
 // radio means adding rows, and so the documentation and the tool cannot drift
 // apart — anything here that a backend does not publish shows up as "defined
 // but never fed" or as absent, which are different findings and both useful.
+//
+// THERE IS NO UNIT COLUMN HERE, deliberately. It used to hold one expected unit
+// compared by equality, and MeterSurfaces.h's `acceptedUnits` — a SET — was
+// introduced precisely because that form reports a permanent false positive on
+// a healthy meter. Only one of the two tables was updated, so every HL2 run
+// went on reporting `UNIT MISMATCH … TX:ALC (declared dBFS, expected dB)` on a
+// correct meter, and ranked it above every real concern (CERTIFICATION.md
+// 1.33). The unit expectation now has exactly one home: kMeterSurfaces, joined
+// by key. A row here whose key has no surface entry gets no unit verdict, which
+// is the honest answer rather than a comparison against a value nobody wrote.
 struct MeterSpec {
     const char* source;
     const char* name;
-    const char* unit;
     bool expectedOnHl2;      // physically producible by this radio class
+
+    // Cannot carry a value unless the transmitter was keyed at all.
+    //
+    // TX:MICPEAK, TX:ALC and TX:COMPPEAK are computed host-side from the audio
+    // heading for the modulator, so a key with the drive slider at zero feeds
+    // all three — but a key the radio REFUSED feeds none of them, and the run
+    // that exposed all of this had three refusals and reported the resulting
+    // silence as three meters that are never fed.
+    bool needsKey;
+
+    // Cannot carry a value unless the PA actually produced forward power.
+    //
+    // A strictly stronger condition than needsKey, and the distinction is the
+    // point: TX:SWR, TX:FWDPWR and TX:REFPWR measure RF that did not happen
+    // even when the key went down cleanly. Reporting them as "defined but never
+    // fed" after a silent key is the false finding CERTIFICATION.md 1.32
+    // records — and its own concern text recommends deleting the meter.
+    bool needsForwardPower;
+
     const char* note;
 };
 
+// `note` is factual as of 2026-08-10, checked against Hl2Backend rather than
+// remembered. Four rows previously described meters as unpublished or unwired
+// that are both defined and fed, and were marked expectedOnHl2 = false while
+// being present — which switched off the one check (`expectedButMissing`) that
+// could notice them regressing.
+//                              hl2   key    rf
 constexpr MeterSpec kMeterTable[] = {
-    {"SLC", "LEVEL",    "dBm",  true,  "receive signal level"},
-    {"TX",  "MICPEAK",  "dBFS", true,  "pre-ALC microphone peak"},
-    {"TX",  "SWR",      "SWR",  true,  "ratio — meaningful uncalibrated"},
-    {"TX",  "FWDPWR",   "dBm",  false, "counts available but uncalibrated; not published"},
-    {"TX",  "REFPWR",   "dBm",  false, "counts available but uncalibrated; not published"},
-    {"TX",  "ALC",      "dB",   false, "host ALC computes this and nothing consumes it"},
-    {"TX",  "COMPPEAK", "dB",   false, "host-side compressor; not wired"},
-    {"RAD", "PATEMP",   "degC", true,  "rise under key is the check, not the value"},
-    {"RAD", "+13.8A",   "Volts",false, "no supply telemetry on this radio"},
+    {"SLC", "LEVEL",    true,  false, false, "receive signal level"},
+    {"TX",  "MICPEAK",  true,  true,  false, "pre-ALC microphone peak; host-side, so a "
+                                             "zero-drive key still feeds it"},
+    {"TX",  "SWR",      true,  true,  true,  "ratio - meaningful uncalibrated, but only "
+                                             "published above the forward-power floor"},
+    {"TX",  "FWDPWR",   true,  true,  true,  "published in dBm as wattsToDbm(directional"
+                                             "Watts(raw)) through the peak hold; the "
+                                             "reference curve is uncalibrated, the meter "
+                                             "is not absent"},
+    {"TX",  "REFPWR",   true,  true,  true,  "published in dBm as wattsToDbm(directional"
+                                             "Watts(raw)); same uncalibrated curve as "
+                                             "FWDPWR"},
+    {"TX",  "ALC",      true,  true,  false, "host ALC; MeterModel::swAlc() consumes it "
+                                             "and the Phone/CW ALC gauges render it"},
+    {"TX",  "COMPPEAK", true,  true,  false, "host speech processor, polled onto the "
+                                             "meter at 20 Hz; reads 0 with PROC off, "
+                                             "which is a value and not a silence"},
+    {"RAD", "PATEMP",   true,  false, false, "rise under key is the check, not the value"},
+    {"RAD", "+13.8A",   false, false, false, "no supply telemetry on this radio"},
 };
 
 }  // namespace
@@ -186,6 +235,83 @@ QJsonObject RadioCertification::meterSnapshot() const
     return out;
 }
 
+QJsonObject RadioCertification::renderedSnapshot() const
+{
+    QJsonObject out;
+    if (!m_radio)
+        return out;
+    const auto& meters = m_radio->meterModel();
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    auto ageOf = [now](qint64 stamp) { return stamp > 0 ? now - stamp : qint64(-1); };
+
+    // FORWARD POWER, gated the way RigctlProtocol gates RFPOWER_METER_WATTS:
+    // suppress a cached last-transmit value rather than presenting it as
+    // current. The value reported is fwdPowerInstant(), which is what the TX
+    // Controls power gauge binds to, so this is the gauge's number and not the
+    // seam's dBm.
+    const qint64 fwdAge = ageOf(meters.fwdPowerUpdatedAtMs());
+    const bool fwdLive = fwdAge >= 0 && fwdAge <= MeterModel::kTxMeterStaleMs;
+    out[QStringLiteral("fwdPowerWatts")] =
+        fwdLive ? QJsonValue(static_cast<double>(meters.fwdPowerInstant())) : QJsonValue();
+    out[QStringLiteral("fwdPowerAgeMs")] = static_cast<double>(fwdAge);
+    out[QStringLiteral("fwdPowerLive")] = fwdLive;
+
+    // SWR through swrIfLive(), which is THE liveness predicate — the same one
+    // behind the signals' swrValid flag, both snapshot arrays and the bridge
+    // scalar. Reading swr() raw returns m_swr's 1.0f initialiser, so a meter
+    // that has never been fed and a perfect match are indistinguishable, and
+    // this probe reported "1.0" in the same object that reported "never fed".
+    const std::optional<float> liveSwr = meters.swrIfLive();
+    out[QStringLiteral("swr")] =
+        liveSwr ? QJsonValue(static_cast<double>(*liveSwr)) : QJsonValue();
+    out[QStringLiteral("swrAgeMs")] = static_cast<double>(ageOf(meters.swrUpdatedAtMs()));
+    out[QStringLiteral("swrLive")] = liveSwr.has_value();
+
+    // ALC has no liveness predicate on the model — the Phone/CW gauges are
+    // signal-driven and simply keep displaying the last value they were sent.
+    // That is exactly §1.11's stale reading, so age it from the meter's own
+    // timestamp here rather than reporting a bare float. Reported unaged, an
+    // ALC value left over from the previous key reads as a live one.
+    const int alcIdx = meters.findMeter(QStringLiteral("TX"), QStringLiteral("ALC"));
+    const qint64 alcAge = alcIdx >= 0 ? meters.valueAgeMs(alcIdx) : -1;
+    const bool alcLive = alcAge >= 0 && alcAge <= MeterModel::kTxMeterStaleMs;
+    out[QStringLiteral("alcDbfs")] =
+        alcLive ? QJsonValue(static_cast<double>(meters.swAlc())) : QJsonValue();
+    out[QStringLiteral("alcAgeMs")] = static_cast<double>(alcAge);
+    out[QStringLiteral("alcLive")] = alcLive;
+    return out;
+}
+
+void RadioCertification::observeKeyedRf()
+{
+    if (!m_radio)
+        return;
+    const auto& meters = m_radio->meterModel();
+    ++m_keyedWindows;
+
+    // A radio that defines no forward-power meter cannot answer the question,
+    // and that is a different state from one that answered zero. Recorded so
+    // the verdict can say WHICH.
+    if (meters.findMeter(QStringLiteral("TX"), QStringLiteral("FWDPWR")) < 0)
+        return;
+    m_fwdPowerMeterDefined = true;
+
+    const qint64 stamp = meters.fwdPowerUpdatedAtMs();
+    if (stamp <= 0)
+        return;
+    const qint64 age = QDateTime::currentMSecsSinceEpoch() - stamp;
+    if (age > MeterModel::kTxMeterStaleMs)
+        return;   // a reading from a previous key proves nothing about this one
+    ++m_keyedRfSamples;
+    m_keyedFwdWattsMax = std::max(m_keyedFwdWattsMax,
+                                  static_cast<double>(meters.fwdPowerInstant()));
+}
+
+bool RadioCertification::keyedRfConfirmed() const
+{
+    return m_keyedRfSamples > 0 && m_keyedFwdWattsMax > kKeyedRfFloorWatts;
+}
+
 // ---------------------------------------------------------------------------
 // Receive stages. Every one of these is a transcription of HERMES.md 15.
 // ---------------------------------------------------------------------------
@@ -214,6 +340,12 @@ void RadioCertification::stageControlEffect(const Options& o)
         const bool keyed = keyViaOperatorPath(true);
         spin(o.settleMs);
         const QJsonObject s2 = meterSnapshot();
+        // Evidence for the keyed-RF precondition, taken while the key is still
+        // down. Every keyed window in the run contributes, because one silent
+        // key does not prove the PA never enabled and one loud one is enough to
+        // prove it did.
+        if (keyed)
+            observeKeyedRf();
         keyViaOperatorPath(false);
         // A STALE OR REFUSED READING IS NOT A MEASUREMENT. A frozen TX:MICPEAK
         // returns the same number at both gain settings, so the delta is 0 dB
@@ -241,9 +373,12 @@ void RadioCertification::stageControlEffect(const Options& o)
     // to. It previously reported `rfPowerRestoredTo`, which named a restore that
     // never happened — in a report whose entire value is that it does not
     // overstate what it verified. The power row in docs/radio-certification.md
-    // is certified by TX:FWDPWR dropping ~6 dB on a halving, and FWDPWR is
-    // defined-but-never-fed on this backend, so that row is currently unrunnable
-    // rather than unimplemented.
+    // is certified by TX:FWDPWR dropping ~6 dB on a halving; FWDPWR IS published
+    // on this backend now (in dBm, through an uncalibrated reference curve), so
+    // that row is unimplemented rather than unrunnable. A halving is a RATIO, so
+    // the uncalibrated scale cancels and the check is available as soon as
+    // someone writes it — the reason it is still absent is that the sweep has to
+    // run inside the automation power ceiling without ever raising drive.
     QJsonObject m{
         {QStringLiteral("micGain100Dbfs"), micFull},
         {QStringLiteral("micGain50Dbfs"), micHalf},
@@ -262,24 +397,145 @@ void RadioCertification::stageControlEffect(const Options& o)
             "about what the gain is")
             .arg(micDelta, 0, 'f', 1);
 
-    // RF gain has no runtime path ON THE HERMES-LITE 2: the LNA value is sent
-    // once in the connect parameters. Report it rather than silently skipping,
-    // because it is the control an operator reaches for first when the ADC
-    // overloads, and a UI that offers it is making a promise.
+    // RF GAIN, CERTIFIED BY EFFECT — AND THE FAMILY GATE GOES WITH IT.
     //
-    // GATED ON THE FAMILY, because this is the one radio-specific fact in an
-    // otherwise backend-generic tool. Emitted unconditionally it told a Flex
-    // operator their working preamp was broken — a hardcoded false finding is
-    // worse than a missing one, since nothing distinguishes it from a real
-    // result. Properly this belongs in the capability seam or the per-backend
-    // radio profile (docs/CERTIFICATION.md 2.1); the family gate is the
-    // stopgap that stops it lying in the meantime.
-    if (m_radio->family().compare(QStringLiteral("hl2"), Qt::CaseInsensitive) == 0) {
-        m[QStringLiteral("rfGainRuntimePath")] = false;
-        problems << QStringLiteral(
-            "SliceModel::setRfGain has no runtime path on this backend — LNA gain is "
-            "connect-parameters only, so the preamp/attenuator control does nothing "
-            "after connect");
+    // This used to hardcode, behind `if (family == "hl2")`, the finding
+    // "SliceModel::setRfGain has no runtime path on this backend". The first
+    // clause is still true: SliceModel::setRfGain's whole body is
+    // `slice set N rfgain=X`, Flex wire text no seam backend can receive. The
+    // CONCLUSION was false, and printed on every Hermes-Lite 2 run. The
+    // operator's slider does not call it — SpectrumOverlayMenu emits
+    // rfGainChanged unconditionally and only falls back to the slice setter
+    // when there is no radio model or no pan id — so on the HL2 the slider
+    // routes rfGainChanged → RadioModel::setPanRfGainFor →
+    // Hl2Backend::setPanRfGain → applyLnaGainDb → MetisClient::setLnaGainDb,
+    // which writes AD9866 0x0a[5:0] at runtime and remembers it per band.
+    //
+    // Replacing the assertion with a measurement removes the reason for the
+    // family gate (§1.14). A stage that DRIVES the control and reports what
+    // happened cannot tell a Flex operator their working preamp is broken,
+    // because it is no longer telling anybody anything it did not observe.
+    //
+    // THE EXPECTED DELTA IS ZERO, NOT THE STEP SIZE. Hl2DbReference is moved in
+    // the same call as the gain and both the spectrum and the S-meter render
+    // through it, specifically so a gain change does NOT slide the display
+    // (HERMES.md 17.4; the class header states it as an invariant — "a gain
+    // change provably cannot move a reported dBm value"). On healthy hardware
+    // an 8 dB LNA step moves SLC:LEVEL by 0 dB. Asserting 8 dB would have
+    // replaced one permanent false positive with another.
+    //
+    // AND THE DELTA STILL DOES NOT RENDER A VERDICT, because it cannot. Two
+    // different states produce the identical −step reading:
+    //
+    //   * the reference moved and the LNA register did not — the real defect;
+    //   * the register moved and the RECEIVED NOISE FLOOR did not, because the
+    //     reading is dominated by the converter's own noise rather than by
+    //     anything coming down the feedline. Raising the LNA lifts antenna
+    //     noise and leaves ADC noise where it is, so on a quiet band the raw
+    //     dBFS barely moves and the display subtracts the full step anyway.
+    //
+    // That is not a hypothetical. Measured on the live Hermes-Lite 2 on a quiet
+    // 20 m: an 8 dB step moved SLC:LEVEL by −6.3 dB, which is within 2 dB of
+    // the defect signature — while the raw dBFS behind it ROSE 1.74 dB, proving
+    // the register HAD been written. A threshold tight enough to catch the
+    // defect fires on healthy hardware every time the band is quiet, and this
+    // stage exists to stop printing findings like that.
+    //
+    // So the delta is reported as evidence with its two readings named, and the
+    // VERDICT rests on the echo. applyLnaGainDb echoes the value the hardware
+    // actually took to every pan, so an echo landing on
+    // PanadapterModel::rfGain() is evidence the seam was crossed — and it is
+    // not §1.6's readback of our own setpoint, because an out-of-range request
+    // comes back clamped rather than repeated. What is still missing to close
+    // the effect half is the raw pre-reference dBFS, which the seam does not
+    // expose (docs/CERTIFICATION.md 2.4 — the meters join).
+    auto settledSLevel = [&]() -> double {
+        // LET THE EMA CATCH UP. HERMES.md 17.6: every WDSP sample is smoothed
+        // (decay alpha 0.15 at ~47 samples/s, so ~0.7 s to settle) and one is
+        // published per 100 ms gate. A reading taken straight after the step is
+        // a blend of both gain settings, which halves the delta and lands it
+        // exactly between the two hypotheses this check distinguishes.
+        spin(1200);
+        const QJsonObject s = meterSnapshot();
+        if (s.value(QStringLiteral("sLevelDbmStale")).toBool())
+            return -999.0;
+        return s.value(QStringLiteral("sLevelDbm")).toDouble(-999.0);
+    };
+
+    const QString panId = m_radio->panId();
+    PanadapterModel* pan = panId.isEmpty() ? nullptr : m_radio->panadapter(panId);
+    if (!pan) {
+        m[QStringLiteral("rfGainExercised")] = false;
+        m[QStringLiteral("rfGainNotExercised")] = QStringLiteral(
+            "no active panadapter, so the route the operator's RF Gain slider "
+            "actually uses does not exist to be driven");
+    } else {
+        const int startGain = pan->rfGain();
+        const int low = pan->rfGainLow();
+        const int high = pan->rfGainHigh();
+        // 8 dB: large enough to clear S-meter noise, small enough to leave the
+        // front end somewhere ordinary. Bounded by the range the BACKEND
+        // published rather than a constant pasted from one radio — the HL2
+        // reports -12..+48 in 1 dB steps against the model's Flex-shaped default.
+        constexpr int kProbeStepDb = 8;
+        int target = startGain + kProbeStepDb;
+        if (target > high)
+            target = startGain - kProbeStepDb;
+        target = qBound(low, target, high);
+        const int stepDb = target - startGain;
+
+        const double before = settledSLevel();
+        m_radio->setPanRfGainFor(panId, target);
+        const double after = settledSLevel();
+        const int echoed = pan->rfGain();
+        m_radio->setPanRfGainFor(panId, startGain);   // leave it where we found it
+        spin(400);
+
+        const bool haveLevels = before > -998.0 && after > -998.0;
+        const double delta = after - before;
+        m[QStringLiteral("rfGainExercised")] = stepDb != 0;
+        m[QStringLiteral("rfGainStartDb")] = startGain;
+        m[QStringLiteral("rfGainRequestedDb")] = target;
+        m[QStringLiteral("rfGainEchoedDb")] = echoed;
+        m[QStringLiteral("rfGainReachedBackend")] = echoed == target;
+        m[QStringLiteral("rfGainStepDb")] = stepDb;
+        m[QStringLiteral("sLevelBeforeDbm")] = before > -998.0 ? QJsonValue(before) : QJsonValue();
+        m[QStringLiteral("sLevelAfterDbm")] = after > -998.0 ? QJsonValue(after) : QJsonValue();
+        m[QStringLiteral("sLevelDeltaDb")] = haveLevels ? QJsonValue(delta) : QJsonValue();
+        // Zero, and see above for why it is not the step size — and for why a
+        // reading near sLevelDeltaIfRegisterNotWrittenDb is NOT reported as a
+        // defect. Both numbers are published so a reader can place the measured
+        // delta between them instead of being handed a verdict the measurement
+        // cannot support.
+        m[QStringLiteral("sLevelExpectedDeltaDb")] = 0.0;
+        m[QStringLiteral("sLevelDeltaIfRegisterNotWrittenDb")] = -stepDb;
+        m[QStringLiteral("sLevelDeltaIsConclusive")] = false;
+        m[QStringLiteral("sLevelDeltaCaveat")] = QStringLiteral(
+            "a delta near %1 dB has two causes that this measurement cannot "
+            "separate: the LNA register never took the value, or the reading is "
+            "dominated by converter noise that does not rise with the gain. Only "
+            "the raw pre-reference dBFS distinguishes them and the seam does not "
+            "expose it").arg(-stepDb);
+
+        if (stepDb == 0) {
+            m[QStringLiteral("rfGainNotExercised")] = QStringLiteral(
+                "the published gain range %1..%2 dB leaves no room for a probe "
+                "step from %3 dB").arg(low).arg(high).arg(startGain);
+        } else if (echoed != target) {
+            // THE ONE CONCERN THIS CHECK EARNS. The echo carries the value the
+            // hardware clamped to, so its absence means the command did not
+            // reach the backend at all — which is the claim the deleted
+            // hardcoded assertion used to make without ever testing it.
+            problems << QStringLiteral(
+                "the RF Gain control did not reach the backend: asked for %1 dB "
+                "and the pan reports %2 dB. This route echoes the value the "
+                "hardware took, so a missing echo means the command went nowhere")
+                .arg(target).arg(echoed);
+        } else if (!haveLevels) {
+            problems << QStringLiteral(
+                "no S-meter reading either side of the RF gain step — the gain "
+                "reached the backend but its effect could not be measured");
+        }
     }
 
     record(QStringLiteral("control-effect"),
@@ -288,7 +544,11 @@ void RadioCertification::stageControlEffect(const Options& o)
            QStringLiteral(
                "Halving a linear gain is -6.02 dB. That is arithmetic rather than "
                "a property of this radio, which is what makes it a threshold that "
-               "transfers to hardware nobody has characterised yet."),
+               "transfers to hardware nobody has characterised yet. The RF gain "
+               "check is the same idea against a different invariant: the display "
+               "reference tracks the commanded gain, so the S-meter must not move "
+               "at all, and the amount it moves if the register was never written "
+               "is known exactly."),
            problems.join(QStringLiteral("; ")),
            QStringLiteral("docs/radio-certification.md — Controls"));
 }
@@ -304,11 +564,38 @@ void RadioCertification::stageMeterInventory()
         return;
     const auto& meters = m_radio->meterModel();
     QJsonObject m;
-    QStringList definedNeverFed, expectedButMissing, unitMismatches;
+    QStringList definedNeverFed, expectedButMissing, unitMismatches, inconclusive;
 
     // kMeterTable's `expectedOnHl2` column is a fact about ONE radio class.
     const bool tableAppliesToThisRadio =
         m_radio->family().compare(QStringLiteral("hl2"), Qt::CaseInsensitive) == 0;
+
+    // DID THIS RUN ACTUALLY TRANSMIT? Established from forward power observed
+    // inside a keyed window — a quantity independent of the meters being judged
+    // — because with the operator's drive slider at zero every keyed stage
+    // succeeded, keyRefusals was 0, every precondition passed, and the radio
+    // radiated nothing. The report then blamed TX:SWR and recommended deleting
+    // it (CERTIFICATION.md 1.32).
+    const bool rfConfirmed = keyedRfConfirmed();
+    const bool anyKeyedWindow = m_keyedWindows > 0;
+    // ASK THE MODEL, do not report the observation flag. m_fwdPowerMeterDefined
+    // is only set when a keyed window actually looked, so on a run where every
+    // key was refused it reads false — which states as a fact about the radio
+    // ("it defines no forward-power meter") something that is really a fact
+    // about the run ("nothing ever looked"). The distinction is the whole
+    // subject of this stage.
+    const bool fwdMeterDefined =
+        meters.findMeter(QStringLiteral("TX"), QStringLiteral("FWDPWR")) >= 0;
+    m[QStringLiteral("keyedRf")] = QJsonObject{
+        {QStringLiteral("confirmed"), rfConfirmed},
+        {QStringLiteral("keyedWindows"), m_keyedWindows},
+        {QStringLiteral("freshForwardPowerSamples"), m_keyedRfSamples},
+        {QStringLiteral("maxWattsWhileKeyed"),
+         m_keyedRfSamples > 0 ? QJsonValue(m_keyedFwdWattsMax) : QJsonValue()},
+        {QStringLiteral("floorWatts"), static_cast<double>(kKeyedRfFloorWatts)},
+        {QStringLiteral("forwardPowerMeterDefined"), fwdMeterDefined},
+        {QStringLiteral("keyRefusals"), m_keyRefusals},
+    };
 
     for (const MeterSpec& spec : kMeterTable) {
         const QString key = QString::fromLatin1(spec.source) + QLatin1Char(':')
@@ -316,41 +603,89 @@ void RadioCertification::stageMeterInventory()
         const int idx = meters.findMeter(QString::fromLatin1(spec.source),
                                          QString::fromLatin1(spec.name));
         const qint64 age = idx >= 0 ? meters.valueAgeMs(idx) : -1;
-        // THE UNIT, TWICE. `unit` is what this table EXPECTS; `declaredUnit` is
-        // what the backend actually published. When they disagree the meter is
+        // THE UNIT, TWICE. `acceptedUnits` is every unit the CONSUMER can
+        // correctly handle; `declaredUnit` is what the backend actually
+        // published. When the declaration is outside the set the meter is
         // already being misread and no amount of freshness will show it — an
         // IC-705 declaring FWDPWR in Watts against a consumer assuming dBm
         // rendered 5 W as 0.003 W while this stage reported it fed and healthy.
+        //
+        // The set comes from kMeterSurfaces, the one table that owns it, and
+        // the membership test from the one predicate that answers it. This used
+        // to be a private single-value column compared by equality, which
+        // flagged a correct TX:ALC on every HL2 run (CERTIFICATION.md 1.33).
         const MeterDef* def = idx >= 0 ? meters.meterDef(idx) : nullptr;
         const QString declared = def ? def->unit : QString();
-        const bool unitDisagrees =
-            def && !declared.isEmpty()
-            && declared.compare(QLatin1String(spec.unit), Qt::CaseInsensitive) != 0;
+        const MeterSurface* surface = meterSurfaceFor(key);
+        const QString accepted =
+            surface ? QString::fromLatin1(surface->acceptedUnits) : QString();
+        const bool unitDisagrees = def && surface
+            && !meterUnitAccepted(accepted, declared);
         if (unitDisagrees)
-            unitMismatches << QStringLiteral("%1 (declared %2, expected %3)")
-                                  .arg(key, declared, QString::fromLatin1(spec.unit));
+            unitMismatches << QStringLiteral("%1 (declared %2, consumer handles %3)")
+                                  .arg(key, declared, accepted);
 
-        m[key] = QJsonObject{
-            {QStringLiteral("unit"), QString::fromLatin1(spec.unit)},
+        // INCONCLUSIVE, not "never fed". A meter cannot be judged by a run that
+        // never produced the thing it measures, and NOT-TESTED is already a
+        // first-class outcome in the control scrub (§1.29). Two rungs: a key
+        // that never went down leaves even the host-side transmit meters
+        // unexercised; a key that went down silently additionally leaves the RF
+        // ones unexercised.
+        QString untestedBecause;
+        if (spec.needsKey && !anyKeyedWindow) {
+            untestedBecause = m_keyRefusals > 0
+                ? QStringLiteral("the radio refused every key this run (%1 refusals), "
+                                 "so nothing was ever transmitted for this meter to "
+                                 "measure").arg(m_keyRefusals)
+                : QStringLiteral("no stage in this run keyed the transmitter, so "
+                                 "nothing was ever transmitted for this meter to "
+                                 "measure");
+        } else if (spec.needsForwardPower && !rfConfirmed) {
+            untestedBecause = QStringLiteral(
+                "no keyed stage in this run produced forward power above %1 W, so "
+                "this meter had nothing to report")
+                .arg(static_cast<double>(kKeyedRfFloorWatts), 0, 'g', 3);
+        }
+
+        QJsonObject row{
+            {QStringLiteral("acceptedUnits"), accepted},
             {QStringLiteral("declaredUnit"), declared},
             {QStringLiteral("unitDisagrees"), unitDisagrees},
             {QStringLiteral("defined"), idx >= 0},
             {QStringLiteral("everFed"), age >= 0},
             {QStringLiteral("ageMs"), static_cast<double>(age)},
+            {QStringLiteral("needsKey"), spec.needsKey},
+            {QStringLiteral("needsForwardPower"), spec.needsForwardPower},
             // Named for the radio class it describes, not "this radio" — the
             // old key claimed the table had been evaluated against whatever
             // backend happened to be connected.
             {QStringLiteral("expectedOnHl2Class"), spec.expectedOnHl2},
-            {QStringLiteral("note"), QString::fromLatin1(spec.note)},
+            // fromUtf8, not fromLatin1: these notes are UTF-8 source literals
+            // and Latin-1 decoding mangled the one em dash in the table into
+            // three characters in the report.
+            {QStringLiteral("note"), QString::fromUtf8(spec.note)},
         };
+        const bool untested = !untestedBecause.isEmpty();
+        if (untested && idx >= 0 && age < 0) {
+            row[QStringLiteral("verdict")] = QStringLiteral("INCONCLUSIVE");
+            row[QStringLiteral("inconclusiveReason")] = untestedBecause;
+        }
+        m[key] = row;
+
         // Defined but never fed renders as a real instrument reading nothing,
         // which is worse than an absent one: the operator has no way to tell it
         // apart from a quiet band.
         // By the time this runs, the stages above have keyed and injected
         // audio, so a meter with no value has genuinely never been fed rather
-        // than merely not exercised.
-        if (idx >= 0 && age < 0)
-            definedNeverFed << key;
+        // than merely not exercised — PROVIDED those stages transmitted. When
+        // they did not, the silence says nothing about the meter and this is an
+        // inconclusive result, not a negative one.
+        if (idx >= 0 && age < 0) {
+            if (untested)
+                inconclusive << key;
+            else
+                definedNeverFed << key;
+        }
         if (tableAppliesToThisRadio && spec.expectedOnHl2 && idx < 0)
             expectedButMissing << key;
     }
@@ -385,6 +720,50 @@ void RadioCertification::stageMeterInventory()
             + QStringLiteral(". Either publish them with a documented scale or "
                              "stop defining them");
     }
+    // INCONCLUSIVE COMES BEFORE THE NEGATIVE FINDINGS, and is worded as a
+    // statement about the RUN rather than about the meters. A reader who skims
+    // must not come away with "TX:SWR is broken" from a run that never keyed
+    // the PA, because the remedy the negative form recommends is deleting a
+    // working meter.
+    if (!inconclusive.isEmpty()) {
+        QString why;
+        if (m_keyRefusals > 0 && !anyKeyedWindow) {
+            // §1.17: a refused action reads as a broken subject. Name the
+            // refusal, because it is the actionable fact and the meters are
+            // not the subject of it.
+            why = QStringLiteral(
+                "the radio refused every key this run (%1 refusals) — enable TX "
+                "automation, or check band limits and interlocks")
+                .arg(m_keyRefusals);
+        } else if (!anyKeyedWindow) {
+            why = QStringLiteral("no stage in this run keyed the transmitter");
+        } else if (!fwdMeterDefined) {
+            why = QStringLiteral(
+                "this radio defines no TX:FWDPWR meter, so there is no quantity "
+                "independent of the meters below that can confirm a transmission");
+        } else if (m_keyedRfSamples == 0) {
+            why = QStringLiteral(
+                "forward power was never fresh inside a keyed window across %1 "
+                "keyed stage(s)").arg(m_keyedWindows);
+        } else {
+            why = QStringLiteral(
+                "forward power peaked at %1 W across %2 keyed stage(s), below the "
+                "%3 W floor an SWR reading needs behind it — the RF power slider "
+                "at 0 does this, and so do an interlock, a band limit and a PA "
+                "that never enabled")
+                .arg(m_keyedFwdWattsMax, 0, 'g', 3)
+                .arg(m_keyedWindows)
+                .arg(static_cast<double>(kKeyedRfFloorWatts), 0, 'g', 3);
+        }
+        const QString lead = QStringLiteral(
+            "INCONCLUSIVE — this run produced no confirmed RF, so nothing here is "
+            "a verdict on these meters: ")
+            + inconclusive.join(QStringLiteral(", "))
+            + QStringLiteral(". ") + why
+            + QStringLiteral(". Re-run with drive up and into a load before "
+                             "concluding anything about them");
+        concern = concern.isEmpty() ? lead : lead + QStringLiteral(". ") + concern;
+    }
 
     // A UNIT MISMATCH OUTRANKS EVERYTHING ELSE HERE, so it goes first. Every
     // other concern in this stage describes a meter that is not there; this one
@@ -403,11 +782,21 @@ void RadioCertification::stageMeterInventory()
     // these three are read back through the consumer that converts, because
     // "a value arrived" and "the face moved" turned out to be different
     // questions (CERTIFICATION.md 1.27).
-    m[QStringLiteral("asRendered")] = QJsonObject{
-        {QStringLiteral("fwdPowerWatts"), meters.fwdPowerInstant()},
-        {QStringLiteral("swr"), meters.swr()},
-        {QStringLiteral("alcDbfs"), meters.swAlc()},
-    };
+    //
+    // TAKEN WHILE KEYED, by stageMeterScale, and behind each consumer's own
+    // liveness gate. Sampled here instead — after stageControlEffect unkeyed
+    // and settled 700 ms — every transmit quantity is absent by construction,
+    // and read raw the SWR accessor returns its 1.0f initialiser, so the probe
+    // reported a confident perfect match beside its own "never fed" (1.34).
+    // The unkeyed reading is kept alongside because the pair is the evidence
+    // that the gauge falls back correctly when transmission stops.
+    QJsonObject rendered = m_renderedWhileKeyed;
+    const bool haveKeyedSample = !rendered.isEmpty();
+    if (!haveKeyedSample)
+        rendered = renderedSnapshot();
+    rendered[QStringLiteral("sampledWhileKeyed")] = haveKeyedSample;
+    m[QStringLiteral("asRendered")] = rendered;
+    m[QStringLiteral("asRenderedUnkeyed")] = renderedSnapshot();
 
     record(QStringLiteral("meter-inventory"),
            QStringLiteral("Meters exist and actually receive values"),
@@ -415,7 +804,10 @@ void RadioCertification::stageMeterInventory()
            QStringLiteral(
                "Definition and delivery are separate wires and were connected "
                "separately. A defined meter that never updates is indistinguish"
-               "able from a real reading of nothing."),
+               "able from a real reading of nothing — and from a meter that was "
+               "never given anything to measure, which is why the RF-dependent "
+               "rows are only judged once a keyed stage has been confirmed to "
+               "produce forward power."),
            concern,
            QStringLiteral("HERMES.md 14.4 — the orphaned meter seam"));
 }
@@ -438,9 +830,19 @@ void RadioCertification::stageMeterScale(const Options& o)
         tone->setLevelDb(-20.0f);
         tone->setEnabled(true);
     }
-    keyViaOperatorPath(true);
+    const bool keyedOk = keyViaOperatorPath(true);
     spin(o.settleMs);
     const QJsonObject keyed = meterSnapshot();
+    // SAMPLE THE CONSUMER HERE, WHILE THE KEY IS DOWN. This is the only moment
+    // in the meters phase when a transmit-only quantity can exist, and the
+    // inventory stage that reports it runs after stageControlEffect has unkeyed
+    // and settled 700 ms — so it was reading the one instant the value is
+    // guaranteed absent, and reported 0.001 W in a run that measured 2.0 W
+    // (CERTIFICATION.md 1.34).
+    if (keyedOk) {
+        m_renderedWhileKeyed = renderedSnapshot();
+        observeKeyedRf();
+    }
     keyViaOperatorPath(false);
     if (auto* tone = m_audio->clientTxTestTone())
         tone->setEnabled(false);
@@ -454,6 +856,12 @@ void RadioCertification::stageMeterScale(const Options& o)
         {QStringLiteral("micPeakErrorDb"), micPeak + 20.0},
         {QStringLiteral("swr"), swr},
         {QStringLiteral("swrStale"), keyed.contains(QStringLiteral("swrStale"))},
+        // The SWR row above is only a measurement of anything if RF happened.
+        // `swr: -1` at zero drive is the absence of a transmission, not the
+        // absence of a meter, and this is where a reader finds out which.
+        {QStringLiteral("keyedRfConfirmed"), keyedRfConfirmed()},
+        {QStringLiteral("maxFwdWattsWhileKeyed"),
+         m_keyedRfSamples > 0 ? QJsonValue(m_keyedFwdWattsMax) : QJsonValue()},
     };
 
     QStringList problems;
@@ -931,9 +1339,16 @@ void RadioCertification::stageRf(const Options& o)
         tone->setLevelDb(-20.0f);
         tone->setEnabled(true);
     }
-    keyViaOperatorPath(true);
+    const bool keyedOk = keyViaOperatorPath(true);
     spin(o.settleMs);
     const QJsonObject keyed = meterSnapshot();
+    // This stage transmits a tone, so its keyed window is evidence for the
+    // meters phase's keyed-RF precondition in an `all` run. The carrier-
+    // suppression stage deliberately keys into silence and is NOT instrumented
+    // for the same reason: a window that is supposed to produce no RF must not
+    // be counted as one that failed to.
+    if (keyedOk)
+        observeKeyedRf();
     keyViaOperatorPath(false);
     if (auto* tone = m_audio->clientTxTestTone())
         tone->setEnabled(false);
@@ -1375,6 +1790,15 @@ void RadioCertification::stageLifecycle(const Options&)
 QJsonObject RadioCertification::run(const Options& o)
 {
     m_stages = QJsonArray{};
+    // Per-run evidence, cleared with the stages it is reported beside. Carrying
+    // a previous run's keyed-RF confirmation forward would make the second run
+    // of a session inherit the first one's transmission.
+    m_keyedFwdWattsMax = -1.0;
+    m_keyedRfSamples = 0;
+    m_keyedWindows = 0;
+    m_fwdPowerMeterDefined = false;
+    m_renderedWhileKeyed = QJsonObject{};
+    m_keyRefusals = 0;
 
     // LEAVE THE RADIO WHERE WE FOUND IT.
     //
@@ -1622,6 +2046,23 @@ QJsonObject RadioCertification::run(const Options& o)
         // non-zero count here invalidates the transmit stages rather than
         // merely annotating them.
         {QStringLiteral("keyRefusals"), m_keyRefusals},
+        // DID ANY OF IT ACTUALLY RADIATE. Reported at the top level, not only
+        // inside the meters phase, because a run that keyed cleanly and put out
+        // no RF invalidates every transmit measurement in it in exactly the way
+        // keyRefusals above invalidates a run the radio declined to key — and
+        // that case is harder to notice, since nothing refused anything.
+        {QStringLiteral("keyedRf"), QJsonObject{
+            {QStringLiteral("confirmed"), keyedRfConfirmed()},
+            {QStringLiteral("keyedWindows"), m_keyedWindows},
+            {QStringLiteral("maxWattsWhileKeyed"),
+             m_keyedRfSamples > 0 ? QJsonValue(m_keyedFwdWattsMax) : QJsonValue()},
+            {QStringLiteral("floorWatts"), static_cast<double>(kKeyedRfFloorWatts)},
+            // Asked of the model, not of the observation flag — see the same
+            // field in stageMeterInventory for why the two differ on a run
+            // where no keyed window ever looked.
+            {QStringLiteral("forwardPowerMeterDefined"),
+             m_radio && m_radio->meterModel().findMeter(
+                 QStringLiteral("TX"), QStringLiteral("FWDPWR")) >= 0}}},
         {QStringLiteral("stages"), m_stages},
         {QStringLiteral("manualChecks"), manual},
     };

--- a/src/core/RadioCertification.cpp
+++ b/src/core/RadioCertification.cpp
@@ -373,12 +373,26 @@ void RadioCertification::stageControlEffect(const Options& o)
     // to. It previously reported `rfPowerRestoredTo`, which named a restore that
     // never happened — in a report whose entire value is that it does not
     // overstate what it verified. The power row in docs/radio-certification.md
-    // is certified by TX:FWDPWR dropping ~6 dB on a halving; FWDPWR IS published
-    // on this backend now (in dBm, through an uncalibrated reference curve), so
-    // that row is unimplemented rather than unrunnable. A halving is a RATIO, so
-    // the uncalibrated scale cancels and the check is available as soon as
-    // someone writes it — the reason it is still absent is that the sweep has to
-    // run inside the automation power ceiling without ever raising drive.
+    // used to be certified by TX:FWDPWR dropping ~6 dB on a halving. FWDPWR IS
+    // published on this backend now (in dBm, through an uncalibrated reference
+    // curve), so that row is no longer blocked on a missing meter — but the
+    // HALVING STIMULUS ITSELF IS NOT USABLE ON THIS RADIO, and the ratio does
+    // not rescue it. Two independent reasons, both measured:
+    //
+    //   * The gateware decodes only the drive register's TOP NIBBLE, so a
+    //     slider halving is not a drive halving. Slider 44 % and 50 % both land
+    //     on nibble 7 (1.984 W vs 2.001 W — six points of travel doing
+    //     nothing), and 51 % jumps +1.25 dB. 100→50→25 % is nibble 15→7→3.
+    //   * HL2FilterE3 is nonlinear as well as uncalibrated, so the scale does
+    //     not cancel out of a ratio taken across a wide span.
+    //
+    // Measured live: −4.44 dB (100→50 %) and −2.33 dB (50→25 %) against the
+    // −6.02 dB a true halving would give. If the scale cancelled, both would
+    // read −6.02. So a failing delta cannot be attributed to the control rather
+    // than to the curve, and radiocert must not report one as a control defect.
+    // What this control CAN certify by effect is monotonicity — one nibble up,
+    // FWDPWR rises — which is the stimulus docs/radio-certification.md now
+    // carries. See HERMES.md 17.5 and 17.7 for both measurements.
     QJsonObject m{
         {QStringLiteral("micGain100Dbfs"), micFull},
         {QStringLiteral("micGain50Dbfs"), micHalf},

--- a/src/core/RadioCertification.h
+++ b/src/core/RadioCertification.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "models/MeterModel.h"   // kMinForwardWattsForSwr — the keyed-RF floor
+
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QPointer>
@@ -195,6 +197,43 @@ private:
     void spin(int ms);
     QJsonObject meterSnapshot() const;
 
+    // WHAT THE OPERATOR'S GAUGE WILL SHOW, read the way the gauge reads it.
+    //
+    // meterSnapshot() above measures the SEAM — the value that crossed from the
+    // backend, by meter index. This measures the CONSUMER: the typed accessors
+    // the applets bind to, each behind the liveness gate its real consumer
+    // applies. The two answer different questions and a probe that mixes them
+    // becomes a third convention that agrees with neither (CERTIFICATION.md
+    // 1.34): reading MeterModel::swr() raw reported a confident 1.0:1 in the
+    // same stage that reported TX:SWR had never been fed, because an unfed SWR
+    // and a perfect match are the same float.
+    QJsonObject renderedSnapshot() const;
+
+    // Record forward power seen INSIDE a keyed window. Called from every stage
+    // that keys, because "did this radio actually radiate" is a precondition of
+    // every transmit-meter verdict and cannot be answered from the meter whose
+    // silence is being judged (CERTIFICATION.md 1.32).
+    void observeKeyedRf();
+
+    // Was a transmission ever CONFIRMED to have produced RF during this run?
+    //
+    // Judged on observed forward power, never on requested drive. A drive floor
+    // would catch the slider-at-zero case that exposed this and nothing else:
+    // an interlock, a band limit or a PA that never enabled are all silent at
+    // any slider setting, and all produce the identical "meter never fed".
+    bool keyedRfConfirmed() const;
+
+    // The floor forward power must clear for a keyed window to count as RF.
+    //
+    // Deliberately MeterModel's own SWR-qualifying floor rather than a number
+    // chosen here. The finding this precondition exists to suppress is "TX:SWR
+    // defined but never fed", and SWR is fed exactly when forward power clears
+    // that floor — so any other constant would make the precondition answer a
+    // slightly different question from the gate it is reasoning about, which is
+    // §1.1 one level up. Zero drive on the HL2 reads 0.001 W; a real key at
+    // 50 % read 2.0 W.
+    static constexpr double kKeyedRfFloorWatts = MeterModel::kMinForwardWattsForSwr;
+
     // QPointer, not raw: run() holds these across nested event loops for minutes
     // at a time. If the session tears down mid-run — a disconnect, an app quit —
     // raw pointers would have the remaining stages resume against freed objects.
@@ -204,6 +243,22 @@ private:
     std::function<void(bool)> m_onKey;
     int m_keyRefusals = 0;   // keys the radio refused; reported, never ignored
     QJsonArray m_stages;
+
+    // ---- keyed-RF evidence, accumulated across every stage that keys ----
+    //
+    // Negative means "never sampled": no keyed window found a fresh forward
+    // power reading, which is a DIFFERENT state from one that read zero and
+    // must not collapse into it.
+    double m_keyedFwdWattsMax = -1.0;
+    int m_keyedRfSamples = 0;        // fresh forward-power reads inside a key
+    int m_keyedWindows = 0;          // keyed windows that reached a measurement
+    bool m_fwdPowerMeterDefined = false;
+
+    // The consumer-side reading taken while the radio was actually keyed.
+    // stageMeterInventory runs after stageControlEffect has unkeyed and settled
+    // 700 ms, so sampling there is sampling the one moment a transmit-only
+    // quantity is guaranteed absent (CERTIFICATION.md 1.34).
+    QJsonObject m_renderedWhileKeyed;
 };
 
 }  // namespace AetherSDR

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -22,15 +22,11 @@ namespace {
 // exactly, while any genuine reading (0 dBm is already 30 dB below a 1 W
 // carrier) stays on the smoothed path.
 constexpr float kNoCarrierWatts = 0.0011f;
-// Minimum instantaneous forward power for an SWR ratio to mean anything.
+// MeterModel::kMinForwardWattsForSwr — the SWR power floor — now lives in the
+// header, because `radiocert`'s keyed-RF precondition has to reason about the
+// same number: the finding it suppresses is "TX:SWR never fed", and SWR is fed
+// exactly when forward power clears this floor.
 //
-// A radio with no carrier reports 0 dBm on FWDPWR, which is 10^(0/10)/1000 =
-// 0.001 W — small but not zero. SWR is computed from forward and reflected
-// power, so below this there is no power behind the ratio and it saturates:
-// an HL2 published 255.99 and held it. The threshold sits a hair above that
-// floor, and 0 dBm is already 30 dB below a 1 W carrier, so nothing real
-// lives underneath it. (#4533)
-constexpr float kMinForwardWattsForSwr = 0.0011f;
 // NOTE: kNoCarrierWatts (#4540) and kMinForwardWattsForSwr (#4533) share the
 // same numeric floor but answer different questions -- "is a carrier present"
 // versus "is there power behind this ratio" -- and are kept separate so a

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -114,6 +114,21 @@ public:
     // conflicting one.)
     static constexpr qint64 kTxMeterStaleMs = 2000;
 
+    // Minimum instantaneous forward power for an SWR ratio to mean anything.
+    //
+    // A radio with no carrier reports 0 dBm on FWDPWR, which is 10^(0/10)/1000
+    // = 0.001 W — small but not zero. SWR is computed from forward and
+    // reflected power, so below this there is no power behind the ratio and it
+    // saturates: an HL2 published 255.99 and held it. The threshold sits a hair
+    // above that floor, and 0 dBm is already 30 dB below a 1 W carrier, so
+    // nothing real lives underneath it. (#4533)
+    //
+    // PUBLIC because it is also the floor `radiocert` uses to decide whether a
+    // keyed stage actually radiated. Anything that reasons about "could SWR
+    // have been fed" must use this exact number rather than a second literal
+    // that happens to be near it.
+    static constexpr float kMinForwardWattsForSwr = 0.0011f;
+
     // Convenience: SWR.
     // ⚠ May be a stale reading from a previous transmit. Callers that display
     // it must gate on swrIfLive(); `allMeters()` and `metersForSource()`


### PR DESCRIPTION
Every `radiocert meters` run against a **working** Hermes-Lite 2 printed concerns that were wrong, and ranked two of them above the real ones. This fixes the five defects that hardware run exposed — the four in CERTIFICATION.md §1.32–1.34 plus the list closing §2.3, and §1.35's stale RF-gain assertion.

Evidence lives in #4916 (branch `test/hl2-radiocert-meters`), which is still open; this branch is off `main` and carries only the code fix.

## The five

**1. A keyed stage that produces no RF now reports INCONCLUSIVE, not a defect.** With the operator's drive slider at 0, every key succeeded, `keyRefusals` was 0, every precondition passed, and the radio radiated nothing — so `TX:SWR` came back *"DEFINED BUT NEVER FED … Either publish them with a documented scale or stop defining them"*. That advice would have deleted a working meter. The precondition is **observed forward power inside a keyed window**, never requested drive: an interlock, a band limit or a PA that never enabled are silent at any slider setting. Two rungs, because a key the radio *refused* leaves even the host-side transmit meters unexercised.

**2. `kMeterTable`'s unit column is gone; the check reads the `acceptedUnits` SET from `kMeterSurfaces`.** The set form exists *because* single-value equality reports a permanent false positive on a healthy meter — and only one of the two tables got the fix, so a correct `TX:ALC` was flagged `declared dBFS, expected dB` on every run, ranked first. There is now one table holding the expectation and one shared predicate answering it; `AutomationServer`'s third private copy of the same split-and-compare loop calls it too.

**3. `asRendered` is sampled while keyed and read through each consumer's liveness gate.** It ran after `stageControlEffect` had unkeyed and settled 700 ms — the one moment a transmit quantity is guaranteed absent — and reading `MeterModel::swr()` raw returns the `1.0f` initialiser, so it reported a confident perfect match *beside its own "never fed"*. SWR now goes through `swrIfLive()`, the predicate `RigctlProtocol` and the SWR sweep already use; ALC is aged instead of reported bare.

**4. `kMeterTable`'s notes and `expectedOnHl2` refreshed against the backend.** `TX:FWDPWR`, `TX:REFPWR`, `TX:ALC` and `TX:COMPPEAK` are all defined **and** fed — confirmed live at 66 ms age — while being described as unpublished or unwired and marked not-expected, which switched off the one check (`expectedButMissing`) that could notice them regressing.

**5. §1.35 — the hardcoded RF-gain assertion is replaced by a measurement.** `SliceModel::setRfGain` really is a dead end, but the operator's slider does not call it: it routes `rfGainChanged` → `setPanRfGainFor` → `Hl2Backend::applyLnaGainDb` → AD9866 `0x0a[5:0]` at runtime. Measuring instead of asserting is what let the family gate go (§1.14).

## One deliberate deviation, and the measurement that forced it

§1.35 asks for "an 8 dB LNA step must move SLC:LEVEL by 8 dB". **It must move it by 0 dB.** `Hl2DbReference` moves in lockstep with the commanded gain — the class header states it as an invariant, *"a gain change provably cannot move a reported dBm value"* (HERMES.md 17.4). Asserting 8 dB would have replaced one permanent false positive with another.

The verdict therefore rests on the backend's **clamped echo**, not on the S-meter delta — because a `−step` reading has two causes this measurement cannot separate:

- the LNA register never took the value (the real defect), or
- the reading is dominated by converter noise, which does not rise with the gain.

That is not hypothetical. Measured live on a quiet 20 m:

| | value |
|---|---|
| commanded step | +8 dB (20 → 28) |
| echoed back by the backend | 28 dB — seam crossed |
| SLC:LEVEL delta | **−6.3 dB** (within 2 dB of the defect signature) |
| raw dBFS behind it | **+1.74 dB** — the register *had* been written |

A threshold tight enough to catch the defect fires every time the band is quiet. The delta is reported with both reference points and `sLevelDeltaIsConclusive: false`; the missing piece is the raw pre-reference dBFS, which the seam does not expose (§2.4).

## Verification — live Hermes-Lite 2, gateware v74, drive at 0

Receive-only, no transmission, no dummy load needed. Before → after on the same radio:

- `UNIT MISMATCH … TX:ALC (declared dBFS, expected dB)` → **gone** (`unitDisagrees: false`)
- rfGain concern on every run → **gone** (`rfGainReachedBackend: true`)
- `TX:SWR` "NEVER FED … stop defining them" → `verdict: INCONCLUSIVE` naming the refusals
- `asRendered.swr: 1.0` → `null`, `swrLive: false`
- `asRendered.alcDbfs: -1.43` unaged → `null`, `alcAgeMs`, `alcLive: false`
- `TX:FWDPWR`/`TX:REFPWR` → `everFed: true`, `ageMs: 66`, `expectedOnHl2Class: true`

**Not re-verified on hardware:** the refinements the first live run itself prompted — the refused-key rung, the refusal-aware wording, `forwardPowerMeterDefined` read from the model rather than the observation flag, and removing the S-meter verdict. The radio dropped off the network mid-session (`arp` shows `(incomplete)` — powered down, not locked) before a second run. Everything else above is from a real run against the real radio.

282/282 tests pass headless. `icom_backend_test` flaked once under `-j22` parallel load, passes in isolation and on a clean re-run, and touches none of the changed code.
