### PR TITLE
fix(automation): connection-path resolution + TX drive readout (#4912)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4549,6 +4549,17 @@ target_link_libraries(automation_connect_family_test PRIVATE
 )
 add_test(NAME automation_connect_family_test COMMAND automation_connect_family_test)
 
+# `connect wait` phase reporting + deferred connect-failure delivery (#4912).
+add_executable(automation_connect_wait_phase_test
+    tests/automation_connect_wait_phase_test.cpp
+)
+target_include_directories(automation_connect_wait_phase_test PRIVATE src tests)
+target_link_libraries(automation_connect_wait_phase_test PRIVATE
+    aethercore Qt6::Core Qt6::Network
+)
+add_test(NAME automation_connect_wait_phase_test
+         COMMAND automation_connect_wait_phase_test)
+
 add_executable(gui_client_identity_policy_test
     tests/gui_client_identity_policy_test.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4538,6 +4538,17 @@ target_link_libraries(automation_json_id_test PRIVATE
 )
 add_test(NAME automation_json_id_test COMMAND automation_json_id_test)
 
+# `connect ip` family resolution + the `family` field on `connect list` (#4912).
+# Pure verb-level test against a fake IConnectionAutomation — no socket, no radio.
+add_executable(automation_connect_family_test
+    tests/automation_connect_family_test.cpp
+)
+target_include_directories(automation_connect_family_test PRIVATE src tests)
+target_link_libraries(automation_connect_family_test PRIVATE
+    aethercore Qt6::Core Qt6::Network
+)
+add_test(NAME automation_connect_family_test COMMAND automation_connect_family_test)
+
 add_executable(gui_client_identity_policy_test
     tests/gui_client_identity_policy_test.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4520,6 +4520,11 @@ if(PYTHON3_EXECUTABLE)
     add_test(NAME automation_probe_field_mapping
              COMMAND ${PYTHON3_EXECUTABLE}
                      ${CMAKE_CURRENT_SOURCE_DIR}/tools/test_automation_probe.py)
+    # Argument parsing for the logwatch helper (#4912) — blind rest[0]/rest[1]
+    # indexing turned a typo into an IndexError traceback.
+    add_test(NAME automation_logwatch_arguments
+             COMMAND ${PYTHON3_EXECUTABLE}
+                     ${CMAKE_CURRENT_SOURCE_DIR}/tools/test_automation_logwatch.py)
     # Bridge docs must stay in sync with the verb registry (#4174 Phase 3):
     # fail CI if the generated verb table drifts or a detail heading is dup'd.
     add_test(NAME bridge_docs_check

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -1990,9 +1990,14 @@ routed/off-subnet radios. The response carries both `"family"` (the type
 actually used, or `"dialog"` when it was left to the selector) and
 `"familySource"`: `"argument"`, `"discovery"` or `"dialog"`. Read
 `familySource`, not `family` — `"family":"flex"` alone cannot tell a resolved
-answer from a default. An explicit type that contradicts a discovered entry is
-refused, naming both, rather than probing the wrong plane and failing where
-only the log can see it.
+answer from a default.
+
+**An explicit type always wins, including against discovery** — it is you saying you know
+what is at that address, which is the whole point of being able to pass it. When the two
+disagree the reply carries `"discoveryFamily"` (present whenever discovery had an opinion
+at all), so a caller that wants strictness compares it against `"family"` and decides for
+itself, while a caller working around a wrong discovery entry still gets through. The
+mismatch is also logged.
 
 `connect wait <timeout_ms>` holds that request's response until the radio
 connects, the connect fails, or the timeout expires — the preferred unattended
@@ -2009,8 +2014,11 @@ running out the clock.
 Because every connect verb answers `{"ok":true,"deferred":true}` before its real
 work runs, a failure afterwards used to be visible only in the log. The wait
 reply now also carries `"lastError"` and `"lastErrorAgeMs"` — the last deferred
-connect/disconnect failure and how long ago it happened, so a stale one is
-distinguishable from this attempt's.
+connect/disconnect failure and how long ago it happened. It is **scoped to the current
+attempt**: a connect that lands retires it, and so does scheduling a fresh one, so its
+presence means this attempt has a failure behind it rather than "something went wrong at
+some point since the process started". A failed `disconnect` is recorded there too, but
+never completes an in-flight `connect wait` — its message belongs to the disconnect.
 
 ### `streams`
 Radio-side display-stream inventory + leak detector (#3856). `get pans` can never

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -1968,24 +1968,49 @@ so `connect show` is safe when the dialog is already open. `connect local first`
 captures the first currently discovered local radio's serial before scheduling
 the request, so the response and deferred connect target stay consistent.
 `connect local serial <serial>` selects by discovery serial. `connect ip
-<host-or-ip> [flex|hl2]` uses the manual **Connect by IP** probe path; if the
+<host-or-ip> [flex|hl2|icom]` uses the manual **Connect by IP** probe path; if the
 probe finds a radio, the panel emits its normal `connectRequested` signal and
 `MainWindow` performs the standard Multi-Flex/client-slot checks before
 `RadioModel` connects.
 
 The optional radio type selects which wire protocol to probe, matching the
 dialog's **Radio type** dropdown: `flex` opens the TCP/4992 command plane, `hl2`
-sends a directed HPSDR Protocol 1 discovery datagram to UDP/1024. The two are
-disjoint — a Hermes-Lite 2 never answers the Flex probe and vice versa — so an
-address is only reached with the right type. Omit it and the dialog's current
-selection is used, which keeps every existing `connect ip <addr>` script
-working; the response echoes `"family"` as the requested type or `"dialog"`.
+sends a directed HPSDR Protocol 1 discovery datagram to UDP/1024, and `icom`
+uses the CI-V backend. They are disjoint — a Hermes-Lite 2 never answers the
+Flex probe and vice versa — so an address is only reached with the right type.
 A directed HL2 probe is the only way to reach a Hermes-Lite 2 that discovery
 broadcasts cannot see (VPN, routed subnet), and it is bounded at ~600 ms.
 
-`connect wait <timeout_ms>` holds that request's response until
-`RadioModel::connectionStateChanged(true)` or timeout, which is the preferred
-unattended "request then assert" flow.
+**Omit the type and discovery decides.** If the address appears in `connect
+list`, that entry's `family` is used, so `connect ip <addr>` reaches an HL2
+without the caller having to know it is one. Only an address nothing has
+advertised falls back to the connect dialog's current selection — which is what
+every pre-existing `connect ip <addr>` script relied on, and still does for
+routed/off-subnet radios. The response carries both `"family"` (the type
+actually used, or `"dialog"` when it was left to the selector) and
+`"familySource"`: `"argument"`, `"discovery"` or `"dialog"`. Read
+`familySource`, not `family` — `"family":"flex"` alone cannot tell a resolved
+answer from a default. An explicit type that contradicts a discovered entry is
+refused, naming both, rather than probing the wrong plane and failing where
+only the log can see it.
+
+`connect wait <timeout_ms>` holds that request's response until the radio
+connects, the connect fails, or the timeout expires — the preferred unattended
+"request then assert" flow.
+
+A reply that is not `connected` carries `"phase"`: `"connecting"` means an
+attempt is still in flight and waiting again is the right move, `"idle"` means
+nothing is pending and another wait will time out identically. **This matters on
+the HL2**, which queues a connect behind its DSP open and re-drives it later, so
+a wait can legitimately expire on a connect that then succeeds. A connect that
+fails outright returns immediately with the backend's own message instead of
+running out the clock.
+
+Because every connect verb answers `{"ok":true,"deferred":true}` before its real
+work runs, a failure afterwards used to be visible only in the log. The wait
+reply now also carries `"lastError"` and `"lastErrorAgeMs"` — the last deferred
+connect/disconnect failure and how long ago it happened, so a stale one is
+distinguishable from this attempt's.
 
 ### `streams`
 Radio-side display-stream inventory + leak detector (#3856). `get pans` can never

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -2540,9 +2540,29 @@ or a regression test. Read-only: it keys nothing and sets nothing.
       "label":"Mic slider (0-100, 50 = unity)","value":80},
      {"key":"micGainAppliedLinear",
       "label":"Mic gain at the modulator (linear)","value":3.98},
+     {"key":"rfPowerPercent","label":"Drive requested (0-100)","value":60},
+     {"key":"txDriveRegister","label":"Drive written (raw 0-255)","value":153},
+     {"key":"txDriveGated","label":"Drive held at 0 by the TX gate","value":false},
      {"key":"forwardPowerPeakW",
-      "label":"Forward (W, approx — peak estimate)","value":4.56}]}
+      "label":"Forward (W, approx — peak HOLD, display only)","value":4.56}]}
 ```
+
+**Assert on `forwardPowerW`, never on `forwardPowerPeakW`.** The peak row is a
+meter's display hold: a single key-edge ADC sample decays over seconds, so a
+script that asserts on it reads a transient from the start of the over as
+though it were the power now. It is reset at each key edge, which is right for
+a needle and wrong for a test.
+
+On the HL2, `rfPowerPercent` / `txDriveRegister` / `txDriveGated` are the
+requested-versus-applied pair for transmit drive. `txDriveRegister` is the raw
+value last written to the radio and is **absent until the first write** — a `0`
+there means the radio was commanded to zero drive, not that nothing has
+happened yet. `txDriveGated` is true when the transmit gate
+(`AETHER_AUTOMATION_ALLOW_TX` unset, or a TX-blocked session) forced the
+register to 0 while the requested percent stayed where the operator left it;
+without it that divergence is invisible. Note the gateware decodes only the
+drive byte's top nibble, so the raw scale moves in steps of 16 — a percent
+alone does not tell you which of the 16 drives the radio actually got.
 
 **This is deliberately not assembled from the models, and that is the whole
 point.** `get` already reports those, and a model reports what the operator

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1311,6 +1311,14 @@ QJsonObject connectionRadioToJson(const RadioInfo& radio)
     QJsonObject o{
         {QStringLiteral("name"), radio.name},
         {QStringLiteral("model"), radio.model},
+        // The wire-protocol discriminator (#4912). Without it `connect list`
+        // describes a Hermes-Lite 2 in prose only — "Hermes-Lite 2" lives in
+        // model, which is a display string — so a caller could not read the
+        // family back and pass it to `connect ip`, and could not work around a
+        // mis-resolved family either. RadioInfo has carried it since the
+        // aetherd Gap B backend split; only the serialisation was missing.
+        {QStringLiteral("family"),
+         radio.family.isEmpty() ? QStringLiteral("flex") : radio.family.toLower()},
         {QStringLiteral("serial"), radio.serial},
         {QStringLiteral("version"), radio.version},
         {QStringLiteral("nickname"), radio.nickname},
@@ -5517,10 +5525,23 @@ QJsonObject AutomationServer::doConnect(const QString& action,
     }
 
     if (a == QLatin1String("ip")) {
-        // connect ip <host-or-ip> [flex|hl2]
-        // The optional family picks which wire protocol to probe. Omitted keeps
-        // whatever the connect dialog's radio-type selector is set to, so every
-        // pre-existing `connect ip <addr>` script keeps working.
+        // connect ip <host-or-ip> [flex|hl2|icom]
+        //
+        // The optional family picks which wire protocol to probe. When it is
+        // omitted, DISCOVERY decides (#4912): an address the radio list already
+        // advertises is probed with that entry's family, so
+        // `connect ip 192.0.2.10` reaches a Hermes-Lite 2 without the caller
+        // having to know it is one. Before this, an omitted family fell through
+        // to whatever the connect dialog's radio-type selector happened to hold
+        // — Flex on a fresh instance — and the resulting failure surfaced only
+        // as a qCWarning while the reply still said ok/deferred.
+        //
+        // The dialog fallback is kept for an address nothing has advertised
+        // (a routed/off-subnet radio the caller knows about and discovery does
+        // not), so pre-existing scripts that lean on the selector still work.
+        // `familySource` in the reply says which of the three decided, because
+        // "family: flex" alone cannot distinguish a resolved answer from a
+        // default.
         static const QRegularExpression ipTokenSep(QStringLiteral("\\s+"));
         const QStringList ipTokens = arg.trimmed().split(ipTokenSep,
                                                          Qt::SkipEmptyParts);
@@ -5542,6 +5563,37 @@ QJsonObject AutomationServer::doConnect(const QString& action,
             return err(QStringLiteral("connect ip takes at most <host-or-ip> [flex|hl2|icom]"));
         }
 
+        // Match on the textual address the list itself publishes, so a caller
+        // can round-trip `connect list` → `connect ip` without reformatting.
+        QString discoveredFamily;
+        for (const RadioInfo& radio : conn->automationLocalRadios()) {
+            if (radio.address.toString().compare(target, Qt::CaseInsensitive) != 0) {
+                continue;
+            }
+            discoveredFamily = radio.family.isEmpty() ? QStringLiteral("flex")
+                                                      : radio.family.toLower();
+            break;
+        }
+
+        QString familySource;
+        if (!family.isEmpty()) {
+            // An explicit family contradicting discovery would probe the wrong
+            // plane, and that failure is invisible from here (deferred, logged,
+            // never returned). Fail fast and name both so the caller can see
+            // which of the two is wrong rather than reading a timeout.
+            if (!discoveredFamily.isEmpty() && discoveredFamily != family) {
+                return err(QStringLiteral("connect ip %1: requested radio type '%2' but "
+                                          "discovery reports '%3' at that address")
+                               .arg(target, family, discoveredFamily));
+            }
+            familySource = QStringLiteral("argument");
+        } else if (!discoveredFamily.isEmpty()) {
+            family = discoveredFamily;
+            familySource = QStringLiteral("discovery");
+        } else {
+            familySource = QStringLiteral("dialog");
+        }
+
         QPointer<QObject> guard(conn->asQObject());
         QTimer::singleShot(0, qApp, [guard, conn, target, family] {
             if (!guard) {
@@ -5558,6 +5610,7 @@ QJsonObject AutomationServer::doConnect(const QString& action,
             {QStringLiteral("connect"), QStringLiteral("ip")},
             {QStringLiteral("target"), target},
             {QStringLiteral("family"), family.isEmpty() ? QStringLiteral("dialog") : family},
+            {QStringLiteral("familySource"), familySource},
             {QStringLiteral("requested"), true},
             {QStringLiteral("deferred"), true},
         };

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -5406,6 +5406,38 @@ QJsonObject AutomationServer::doWaveform(const QString& action,
                + action + QStringLiteral("'"));
 }
 
+// Record a connect/disconnect failure that happened AFTER the verb replied.
+//
+// Every connect verb schedules its real work onto the GUI event loop and
+// answers {ok:true, deferred:true} immediately, so until now a failure existed
+// only as a qCWarning — the client that asked could not see it, and the only
+// symptom was a `connect wait` that ran its whole timeout and then reported the
+// generic "timed out waiting for radio connection" (#4912).
+//
+// Two things happen here: the message is kept for the next `connect wait` to
+// report, and any wait already in flight is answered NOW, because it is waiting
+// on precisely the thing that just failed.
+void AutomationServer::noteConnectFailure(const QString& what,
+                                          const QString& error)
+{
+    const QString detail = error.trimmed();
+    m_lastConnectError = detail.isEmpty() ? what + QStringLiteral(" failed")
+                                          : what + QStringLiteral(": ") + detail;
+    m_lastConnectErrorMs = QDateTime::currentMSecsSinceEpoch();
+    qCWarning(lcAutomation).noquote()
+        << what << "failed after scheduling:" << error;
+
+    // finishConnectWait() erases from m_connectWaits, so iterate a copy.
+    const std::vector<std::shared_ptr<ConnectWait>> pending = m_connectWaits;
+    for (const std::shared_ptr<ConnectWait>& wait : pending) {
+        if (!wait || wait->complete) {
+            continue;
+        }
+        wait->error = m_lastConnectError;
+        finishConnectWait(wait, false);
+    }
+}
+
 QJsonObject AutomationServer::doConnect(const QString& action,
                                         const QString& arg,
                                         QLocalSocket* sock)
@@ -5467,14 +5499,14 @@ QJsonObject AutomationServer::doConnect(const QString& action,
             }
 
             QPointer<QObject> guard(conn->asQObject());
-            QTimer::singleShot(0, qApp, [guard, conn, selectedSerial] {
+            QPointer<AutomationServer> self(this);
+            QTimer::singleShot(0, qApp, [guard, self, conn, selectedSerial] {
                 if (!guard) {
                     return;
                 }
                 QString error;
-                if (!conn->automationConnectLocalSerial(selectedSerial, &error)) {
-                    qCWarning(lcAutomation).noquote()
-                        << "connect local first failed after scheduling:" << error;
+                if (!conn->automationConnectLocalSerial(selectedSerial, &error) && self) {
+                    self->noteConnectFailure(QStringLiteral("connect local first"), error);
                 }
             });
             return QJsonObject{
@@ -5497,14 +5529,15 @@ QJsonObject AutomationServer::doConnect(const QString& action,
                 }
 
                 QPointer<QObject> guard(conn->asQObject());
-                QTimer::singleShot(0, qApp, [guard, conn, serial] {
+                QPointer<AutomationServer> self(this);
+                QTimer::singleShot(0, qApp, [guard, self, conn, serial] {
                     if (!guard) {
                         return;
                     }
                     QString error;
-                    if (!conn->automationConnectLocalSerial(serial, &error)) {
-                        qCWarning(lcAutomation).noquote()
-                            << "connect local serial failed after scheduling:" << error;
+                    if (!conn->automationConnectLocalSerial(serial, &error) && self) {
+                        self->noteConnectFailure(QStringLiteral("connect local serial"),
+                                                 error);
                     }
                 });
                 return QJsonObject{
@@ -5595,14 +5628,14 @@ QJsonObject AutomationServer::doConnect(const QString& action,
         }
 
         QPointer<QObject> guard(conn->asQObject());
-        QTimer::singleShot(0, qApp, [guard, conn, target, family] {
+        QPointer<AutomationServer> self(this);
+        QTimer::singleShot(0, qApp, [guard, self, conn, target, family] {
             if (!guard) {
                 return;
             }
             QString error;
-            if (!conn->automationConnectByIp(target, family, &error)) {
-                qCWarning(lcAutomation).noquote()
-                    << "connect ip failed after scheduling:" << error;
+            if (!conn->automationConnectByIp(target, family, &error) && self) {
+                self->noteConnectFailure(QStringLiteral("connect ip ") + target, error);
             }
         });
         return QJsonObject{
@@ -5674,14 +5707,14 @@ QJsonObject AutomationServer::doDisconnect()
     }
 
     QPointer<QObject> guard(conn->asQObject());
-    QTimer::singleShot(0, qApp, [guard, conn] {
+    QPointer<AutomationServer> self(this);
+    QTimer::singleShot(0, qApp, [guard, self, conn] {
         if (!guard) {
             return;
         }
         QString error;
-        if (!conn->automationDisconnect(&error)) {
-            qCWarning(lcAutomation).noquote()
-                << "disconnect failed after scheduling:" << error;
+        if (!conn->automationDisconnect(&error) && self) {
+            self->noteConnectFailure(QStringLiteral("disconnect"), error);
         }
     });
 
@@ -5862,6 +5895,17 @@ QJsonObject AutomationServer::doConnectWait(int timeoutMs, QLocalSocket* sock)
             finishConnectWait(wait, false);
         }
     });
+    // A connect that FAILS emits connectionError and never emits
+    // connectionStateChanged, so without this edge the wait had no way to hear
+    // about it and sat out the full timeout before reporting the generic
+    // "timed out" — the wrong diagnosis for a connect that already died (#4912).
+    wait->errorConnection = connect(m_radioModel, &RadioModel::connectionError,
+                                    this, [this, wait](const QString& msg) {
+        wait->error = msg.trimmed().isEmpty()
+            ? QStringLiteral("radio connection failed")
+            : msg.trimmed();
+        finishConnectWait(wait, false);
+    });
     connect(wait->timer, &QTimer::timeout, this, [this, wait] {
         finishConnectWait(wait, true);
     });
@@ -5885,6 +5929,7 @@ void AutomationServer::finishConnectWait(const std::shared_ptr<ConnectWait>& wai
         wait->timer = nullptr;
     }
     QObject::disconnect(wait->connection);
+    QObject::disconnect(wait->errorConnection);
 
     const auto newEnd = std::remove(m_connectWaits.begin(), m_connectWaits.end(), wait);
     m_connectWaits.erase(newEnd, m_connectWaits.end());
@@ -5906,13 +5951,42 @@ void AutomationServer::finishConnectWait(const std::shared_ptr<ConnectWait>& wai
     };
     if (connected) {
         response[QStringLiteral("radio")] = radioSnapshot(m_radioModel);
-    } else if (timedOut) {
-        response[QStringLiteral("timeout")] = true;
-        response[QStringLiteral("error")] =
-            QStringLiteral("timed out waiting for radio connection");
     } else {
-        response[QStringLiteral("error")] =
-            QStringLiteral("radio connection did not complete");
+        // WHAT THE CALLER ACTUALLY NEEDS TO KNOW IS "IS IT STILL WORKING?" —
+        // and until now the reply could not say (#4912). A timeout meant both
+        // "this connect died" and "this connect is still coming", and the HL2
+        // makes the second case ordinary: Hl2Backend::connectRadio() parks the
+        // request behind the DSP open and re-drives it later, emitting nothing
+        // in between, so a wait can expire mid-queue on a connect that then
+        // succeeds. Polling `get radio` was the only way to tell.
+        //
+        // `phase` splits them: "connecting" means an attempt is genuinely in
+        // flight and waiting again is the right move; "idle" means nothing is
+        // pending and waiting again will time out identically.
+        const bool inFlight = m_radioModel && m_radioModel->isConnectAttemptInFlight();
+        response[QStringLiteral("phase")] = inFlight ? QStringLiteral("connecting")
+                                                     : QStringLiteral("idle");
+        if (timedOut) {
+            response[QStringLiteral("timeout")] = true;
+            response[QStringLiteral("error")] =
+                QStringLiteral("timed out waiting for radio connection");
+        } else if (!wait->error.isEmpty()) {
+            response[QStringLiteral("error")] = wait->error;
+        } else {
+            response[QStringLiteral("error")] =
+                QStringLiteral("radio connection did not complete");
+        }
+        // The last deferred connect failure, whenever it happened. A verb that
+        // replied {ok:true, deferred:true} and then failed is otherwise
+        // unobservable from the client side; the age is what lets a caller tell
+        // this attempt's failure from a stale one.
+        if (!m_lastConnectError.isEmpty()) {
+            response[QStringLiteral("lastError")] = m_lastConnectError;
+            if (m_lastConnectErrorMs >= 0) {
+                response[QStringLiteral("lastErrorAgeMs")] = static_cast<int>(
+                    QDateTime::currentMSecsSinceEpoch() - m_lastConnectErrorMs);
+            }
+        }
     }
 
     writeJsonResponse(socket, response);

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -5417,8 +5417,19 @@ QJsonObject AutomationServer::doWaveform(const QString& action,
 // Two things happen here: the message is kept for the next `connect wait` to
 // report, and any wait already in flight is answered NOW, because it is waiting
 // on precisely the thing that just failed.
+// A landed connect retires the last deferred failure (#4918 review). Without
+// this, one failure rode along on every later non-connected `connect wait` for
+// the life of the process — and the field's mere presence reads as "something
+// went wrong with THIS attempt", which is the opposite of what it then meant.
+void AutomationServer::clearLastConnectError()
+{
+    m_lastConnectError.clear();
+    m_lastConnectErrorMs = -1;
+}
+
 void AutomationServer::noteConnectFailure(const QString& what,
-                                          const QString& error)
+                                          const QString& error,
+                                          bool answerPendingWaits)
 {
     const QString detail = error.trimmed();
     m_lastConnectError = detail.isEmpty() ? what + QStringLiteral(" failed")
@@ -5426,6 +5437,14 @@ void AutomationServer::noteConnectFailure(const QString& what,
     m_lastConnectErrorMs = QDateTime::currentMSecsSinceEpoch();
     qCWarning(lcAutomation).noquote()
         << what << "failed after scheduling:" << error;
+
+    // Only a failed CONNECT answers an outstanding `connect wait` (#4918 review).
+    // A failed disconnect is recorded the same way — it is still a deferred
+    // failure a caller should be able to see — but completing the wait with it
+    // would hand a legitimately-in-flight connect somebody else's error text.
+    if (!answerPendingWaits) {
+        return;
+    }
 
     // finishConnectWait() erases from m_connectWaits, so iterate a copy.
     const std::vector<std::shared_ptr<ConnectWait>> pending = m_connectWaits;
@@ -5482,6 +5501,12 @@ QJsonObject AutomationServer::doConnect(const QString& action,
     if (m_radioModel && m_radioModel->isConnected()) {
         return err(QStringLiteral("already connected to a radio"));
     }
+
+    // Everything below schedules a fresh attempt, and `lastError` is meant to
+    // describe THIS one — so retire the previous failure here as well as on a
+    // successful connect. A caller that wants the older failure has already had
+    // it reported once.
+    clearLastConnectError();
 
     if (a == QLatin1String("local")) {
         const QList<RadioInfo> radios = conn->automationLocalRadios();
@@ -5610,14 +5635,23 @@ QJsonObject AutomationServer::doConnect(const QString& action,
 
         QString familySource;
         if (!family.isEmpty()) {
-            // An explicit family contradicting discovery would probe the wrong
-            // plane, and that failure is invisible from here (deferred, logged,
-            // never returned). Fail fast and name both so the caller can see
-            // which of the two is wrong rather than reading a timeout.
+            // THE ARGUMENT WINS, even against discovery — it is the caller saying
+            // "I know what is at this address" (#4918 review). An earlier revision
+            // refused the contradiction, which inverted the point of the argument:
+            // it made the explicit form WEAKER than the inferred one, changed the
+            // behaviour of the already-documented `connect ip <addr> flex`, and
+            // closed the escape hatch this commit's `family` field exists to open
+            // — exactly when discovery is the thing that is wrong (stale entry, a
+            // recycled DHCP lease, a mis-parsed reply).
+            //
+            // The disagreement is still worth seeing, so it is returned as data
+            // rather than as a refusal: a strict caller compares `family` against
+            // `discoveryFamily` itself and decides.
             if (!discoveredFamily.isEmpty() && discoveredFamily != family) {
-                return err(QStringLiteral("connect ip %1: requested radio type '%2' but "
-                                          "discovery reports '%3' at that address")
-                               .arg(target, family, discoveredFamily));
+                qCWarning(lcAutomation).noquote()
+                    << "connect ip" << target << "requested family" << family
+                    << "but discovery reports" << discoveredFamily
+                    << "— honouring the argument";
             }
             familySource = QStringLiteral("argument");
         } else if (!discoveredFamily.isEmpty()) {
@@ -5638,7 +5672,7 @@ QJsonObject AutomationServer::doConnect(const QString& action,
                 self->noteConnectFailure(QStringLiteral("connect ip ") + target, error);
             }
         });
-        return QJsonObject{
+        QJsonObject reply{
             {QStringLiteral("ok"), true},
             {QStringLiteral("connect"), QStringLiteral("ip")},
             {QStringLiteral("target"), target},
@@ -5647,6 +5681,12 @@ QJsonObject AutomationServer::doConnect(const QString& action,
             {QStringLiteral("requested"), true},
             {QStringLiteral("deferred"), true},
         };
+        // What discovery believed, whenever it had an opinion — so a caller that
+        // passed an explicit family can tell whether it overrode anything.
+        if (!discoveredFamily.isEmpty()) {
+            reply[QStringLiteral("discoveryFamily")] = discoveredFamily;
+        }
+        return reply;
     }
 
     return err(QStringLiteral("unknown connect action: ") + action
@@ -5714,7 +5754,8 @@ QJsonObject AutomationServer::doDisconnect()
         }
         QString error;
         if (!conn->automationDisconnect(&error) && self) {
-            self->noteConnectFailure(QStringLiteral("disconnect"), error);
+            self->noteConnectFailure(QStringLiteral("disconnect"), error,
+                                     /*answerPendingWaits=*/false);
         }
     });
 
@@ -5870,6 +5911,7 @@ QJsonObject AutomationServer::doConnectWait(int timeoutMs, QLocalSocket* sock)
         return err(QStringLiteral("no radio model available"));
     }
     if (m_radioModel->isConnected()) {
+        clearLastConnectError();   // connected is connected — nothing is outstanding
         return QJsonObject{
             {QStringLiteral("ok"), true},
             {QStringLiteral("connected"), true},
@@ -5943,6 +5985,9 @@ void AutomationServer::finishConnectWait(const std::shared_ptr<ConnectWait>& wai
     }
 
     const bool connected = m_radioModel && m_radioModel->isConnected();
+    if (connected) {
+        clearLastConnectError();
+    }
     QJsonObject response{
         {QStringLiteral("ok"), connected},
         {QStringLiteral("connected"), connected},

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -861,7 +861,15 @@ private:
     // without the caller needing a clock of its own.
     QString m_lastConnectError;
     qint64 m_lastConnectErrorMs{-1};
-    void noteConnectFailure(const QString& what, const QString& error);
+    // answerPendingWaits: whether this failure should complete outstanding
+    // `connect wait` calls. True for the connect verbs; false for disconnect,
+    // whose error would otherwise be handed to an unrelated connect still in
+    // flight.
+    void noteConnectFailure(const QString& what, const QString& error,
+                            bool answerPendingWaits = true);
+    // A connect that lands retires the previous failure, so `lastError` describes
+    // the current state of the world rather than everything that ever went wrong.
+    void clearLastConnectError();
 
     QTimer* m_memoryTimer{nullptr};
     QElapsedTimer m_memoryClock;

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -836,11 +836,32 @@ private:
         QPointer<QLocalSocket> socket;
         QTimer* timer{nullptr};
         QMetaObject::Connection connection;
+        // Bound alongside `connection` so a connect that FAILS returns the
+        // backend's message immediately instead of burning the whole timeout
+        // and then reporting the generic "timed out" (#4912).
+        QMetaObject::Connection errorConnection;
         QElapsedTimer elapsed;
         int timeoutMs{0};
         bool complete{false};
+        // Set when finishConnectWait() runs off connectionError rather than
+        // off the timer or a successful connectionStateChanged.
+        QString error;
     };
     std::vector<std::shared_ptr<ConnectWait>> m_connectWaits;
+
+    // The last deferred connect/disconnect failure, and when it happened.
+    //
+    // Every connect verb schedules its real work onto the GUI event loop and
+    // replies {ok:true, deferred:true} before that work runs, so a failure
+    // afterwards existed only as a qCWarning — invisible to the client that
+    // asked (#4912). Keeping the last one here lets `connect wait` hand it
+    // back, which is where a caller is already looking when a connect does not
+    // land. The reply carries the error's AGE, not its timestamp, so a stale
+    // failure from a previous attempt is distinguishable from this one's
+    // without the caller needing a clock of its own.
+    QString m_lastConnectError;
+    qint64 m_lastConnectErrorMs{-1};
+    void noteConnectFailure(const QString& what, const QString& error);
 
     QTimer* m_memoryTimer{nullptr};
     QElapsedTimer m_memoryClock;

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -3134,16 +3134,9 @@ void Hl2Backend::applyDrive(int percent)
     // uncommanded in a transmit-BLOCKED session, defeating connectRadio()'s
     // deliberate drive=0 safety seed. Assert drive off instead. (#4449 review)
     if (!m_txAllowed) {
-        // Remembered so the health snapshot can SAY the gate zeroed it (#4912).
-        // Without this row the operator's commanded percent reads back intact
-        // from TransmitModel while the register is held at 0 — a readback that
-        // shares the failure it is meant to catch, in the one place where the
-        // divergence is safety-adjacent.
-        m_txDriveGated = true;
         setTxDriveLevel(0);
         return;
     }
-    m_txDriveGated = false;
     const int clamped = percent < 0 ? 0 : (percent > 100 ? 100 : percent);
     setTxDriveLevel(clamped * kTxDriveMax / 100);
 }
@@ -3454,7 +3447,14 @@ IRadioBackend::HealthSnapshot Hl2Backend::healthSnapshot() const
     // 0 here would read as "the radio was commanded to zero drive".
     put("txDriveRegister", QStringLiteral("Drive written (raw 0-255)"),
         m_txDriveRegister >= 0 ? QVariant(m_txDriveRegister) : QVariant());
-    put("txDriveGated", QStringLiteral("Drive held at 0 by the TX gate"), m_txDriveGated);
+    // Reported from the GATE, not from an observation of it acting. Latching this
+    // inside applyDrive() looked equivalent and was not: finishDspSetup() seeds the
+    // register with a direct setTxDriveLevel(0) that never goes through applyDrive(),
+    // so a TX-blocked session where nobody touched the drive slider read
+    // "rfPowerPercent: 100, txDriveRegister: 0, txDriveGated: false" — the row
+    // positively denying responsibility for the exact divergence it exists to
+    // explain. The gate is a session property, so it is always knowable.
+    put("txDriveGated", QStringLiteral("Drive held at 0 by the TX gate"), !m_txAllowed);
 
     // THE VOICE CHAIN, END TO END, AS THE MODULATOR ACTUALLY RAN IT.
     //

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -3134,9 +3134,16 @@ void Hl2Backend::applyDrive(int percent)
     // uncommanded in a transmit-BLOCKED session, defeating connectRadio()'s
     // deliberate drive=0 safety seed. Assert drive off instead. (#4449 review)
     if (!m_txAllowed) {
+        // Remembered so the health snapshot can SAY the gate zeroed it (#4912).
+        // Without this row the operator's commanded percent reads back intact
+        // from TransmitModel while the register is held at 0 — a readback that
+        // shares the failure it is meant to catch, in the one place where the
+        // divergence is safety-adjacent.
+        m_txDriveGated = true;
         setTxDriveLevel(0);
         return;
     }
+    m_txDriveGated = false;
     const int clamped = percent < 0 ? 0 : (percent > 100 ? 100 : percent);
     setTxDriveLevel(clamped * kTxDriveMax / 100);
 }
@@ -3324,6 +3331,11 @@ void Hl2Backend::setTxDriveLevel(int level)
 {
     if (!m_metis)
         return;
+    // Retained purely so the health snapshot can report what was ACTUALLY
+    // written (#4912). The value went straight out over a queued invoke and was
+    // kept nowhere, so nothing downstream could report the applied drive — only
+    // TransmitModel's requested percent, which is the operator's ask.
+    m_txDriveRegister = level;
     QMetaObject::invokeMethod(m_metis, "setTxDriveLevel", Qt::QueuedConnection,
         Q_ARG(int, level));
 }
@@ -3422,6 +3434,28 @@ IRadioBackend::HealthSnapshot Hl2Backend::healthSnapshot() const
     put("txFifoOverflow", QStringLiteral("TX FIFO overflow"),
         opt(m_telemetry.txFifoOverflow));
 
+    // DRIVE: WHAT WAS ASKED FOR, AND WHAT WAS WRITTEN (#4912).
+    //
+    // Nothing anywhere reported the APPLIED drive. `get transmit` has rfPower
+    // and `get radio` has txPower, but both read TransmitModel — the operator's
+    // request — which is exactly the readback-shares-the-failure problem this
+    // section exists to solve. Worse, applyDrive()'s transmit gate forces the
+    // register to 0 while the requested percent reads back untouched, so
+    // "commanded but never applied" was invisible to automation in the one area
+    // where it is safety-adjacent.
+    //
+    // The raw register is reported alongside the percent rather than instead of
+    // it because the gateware decodes only the drive byte's top nibble: the
+    // 0..255 scale moves in steps of 16, so 100 distinct percents land on 16
+    // distinct drives and a percent alone cannot tell you which one the radio
+    // got.
+    put("rfPowerPercent", QStringLiteral("Drive requested (0-100)"), m_rfPowerPercent);
+    // Absent until first write, per this section's "never told" convention — a
+    // 0 here would read as "the radio was commanded to zero drive".
+    put("txDriveRegister", QStringLiteral("Drive written (raw 0-255)"),
+        m_txDriveRegister >= 0 ? QVariant(m_txDriveRegister) : QVariant());
+    put("txDriveGated", QStringLiteral("Drive held at 0 by the TX gate"), m_txDriveGated);
+
     // THE VOICE CHAIN, END TO END, AS THE MODULATOR ACTUALLY RAN IT.
     //
     // Every row here is read from this backend rather than from TransmitModel.
@@ -3514,7 +3548,13 @@ IRadioBackend::HealthSnapshot Hl2Backend::healthSnapshot() const
     // a hard 0.0 before any telemetry, next to a neighbour saying "not
     // reported" — and "0 W" from a wattmeter reads as a measurement, which is
     // the one thing nothing in this section is allowed to fake.
-    put("forwardPowerPeakW", QStringLiteral("Forward (W, approx — peak estimate)"),
+    // DISPLAY HOLD — NOT AN ASSERTION TARGET (#4912). This is a meter's
+    // peak-hold: one key-edge ADC sample decays over seconds, so a script that
+    // asserts on it reads a transient from the start of the over as though it
+    // were the power now. That is correct for a needle and wrong for a test.
+    // Assert on forwardPowerW, the instantaneous row above.
+    put("forwardPowerPeakW",
+        QStringLiteral("Forward (W, approx — peak HOLD, display only)"),
         m_telemetry.forwardPowerRaw ? QVariant(m_fwdPeakWatts) : QVariant());
     put("reversePowerRaw", QStringLiteral("Reverse (raw counts)"),
         opt(m_telemetry.reversePowerRaw));

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -576,14 +576,11 @@ private:
     // restores something sane rather than 0.
     int m_rfPowerPercent = 100;
     // The APPLIED side of the pair above, for the health snapshot (#4912).
-    // m_txDriveRegister is the raw 0..kTxDriveMax value setTxDriveLevel() last
-    // handed to MetisClient — negative means never written, so the row stays
-    // absent rather than claiming a 0 the radio was never told. m_txDriveGated
-    // records that applyDrive() took the !m_txAllowed zero path, which is the
-    // one case where the commanded percent and the register legitimately
-    // disagree and nothing said so.
+    // The raw 0..kTxDriveMax value setTxDriveLevel() last handed to MetisClient —
+    // negative means never written, so the row stays absent rather than claiming a
+    // 0 the radio was never told. (Its companion "gated" row is derived from
+    // m_txAllowed at read time, not latched here — see healthSnapshot().)
     int m_txDriveRegister = -1;
-    bool m_txDriveGated = false;
     // RFC #4603 PR 3 state memory. m_restoredState is the validated snapshot
     // handed over pre-connect; the per-band maps are the working copies the
     // session reads and updates (band key -> value; see Hl2Bands.h). Defaults

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -575,6 +575,15 @@ private:
     // TransmitModel defaults rfPower to, so a TUNE before any power change
     // restores something sane rather than 0.
     int m_rfPowerPercent = 100;
+    // The APPLIED side of the pair above, for the health snapshot (#4912).
+    // m_txDriveRegister is the raw 0..kTxDriveMax value setTxDriveLevel() last
+    // handed to MetisClient — negative means never written, so the row stays
+    // absent rather than claiming a 0 the radio was never told. m_txDriveGated
+    // records that applyDrive() took the !m_txAllowed zero path, which is the
+    // one case where the commanded percent and the register legitimately
+    // disagree and nothing said so.
+    int m_txDriveRegister = -1;
+    bool m_txDriveGated = false;
     // RFC #4603 PR 3 state memory. m_restoredState is the validated snapshot
     // handed over pre-connect; the per-band maps are the working copies the
     // session reads and updates (band key -> value; see Hl2Bands.h). Defaults

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2089,6 +2089,11 @@ RadioModel::RadioModel(QObject* parent)
     connect(&m_reconnectTimer, &QTimer::timeout, this, [this]() {
         if (!m_intentionalDisconnect && !m_lastInfo.address.isNull()) {
             qCDebug(lcProtocol) << "RadioModel: auto-reconnecting to" << m_lastInfo.address.toString();
+            // A retry is an attempt too (#4912). This path does NOT go through
+            // connectToRadio() — it re-drives the connection/backend directly —
+            // so the flag has to be set here as well or an armed reconnect
+            // reads as "nothing is happening".
+            m_connectAttemptActive = true;
             clearAutomationSliceFixtures();
             if (m_connection) {
                 QMetaObject::invokeMethod(m_connection, [this] {
@@ -3050,6 +3055,12 @@ void RadioModel::connectToRadio(const RadioInfo& info)
         emit backendRebuilt();
     }
 
+    // An attempt is in flight from here until it lands, fails, or is abandoned
+    // (#4912). Set after the family switch above so a backend rebuild — which
+    // tears the old backend down and can emit a disconnect — cannot clear the
+    // flag we are about to set.
+    m_connectAttemptActive = true;
+
     clearAutomationSliceFixtures();
     m_automationGpsNtpServerAddress.clear();
 
@@ -3124,6 +3135,8 @@ void RadioModel::connectViaWan(WanConnection* wan, const QString& publicIp, quin
     qCDebug(lcProtocol) << "RadioModel: connectViaWan publicIp=" << publicIp
              << "udpPort=" << udpPort
              << "wanHandle=0x" << QString::number(wan->clientHandle(), 16);
+
+    m_connectAttemptActive = true;  // see connectToRadio() (#4912)
 
     clearAutomationSliceFixtures();
     m_automationGpsNtpServerAddress.clear();
@@ -3330,6 +3343,7 @@ void RadioModel::disconnectFromRadio()
 {
     m_intentionalDisconnect = true;
     m_rebootInProgress = false;
+    m_connectAttemptActive = false;  // the operator abandoned it (#4912)
     m_reconnectTimer.stop();
     m_pingTimer.stop();
     if (m_wanConn) {
@@ -3382,6 +3396,7 @@ void RadioModel::forceDisconnect()
 {
     // Close TCP/TLS without setting m_intentionalDisconnect so the UI can
     // start the normal unexpected-disconnect reconnect path.
+    m_connectAttemptActive = false;  // this attempt is over; the retry re-arms it (#4912)
     if (m_wanConn) {
         m_wanConn->disconnectFromRadio();
     } else if (!m_connection) {
@@ -5147,6 +5162,7 @@ void RadioModel::onBackendSpectrumFrame(int panId, const QByteArray& frame)
 void RadioModel::onConnected()
 {
     qCDebug(lcProtocol) << "RadioModel: connected (family=" << m_family << ")";
+    m_connectAttemptActive = false;  // the attempt landed (#4912)
     m_reconnectTimer.stop();
     m_rebootInProgress = false;
     // Belt-and-braces (#4122 review): the connect entry points clear fixtures,
@@ -6336,6 +6352,15 @@ void RadioModel::onDisconnected()
 void RadioModel::onConnectionError(const QString& msg)
 {
     qCWarning(lcProtocol) << "RadioModel: connection error:" << msg;
+    // The attempt ended (#4912). If the reconnect below arms, its own lambda
+    // re-arms the flag when it actually re-drives the connect — so the window
+    // between the failure and the retry reads as idle, which is what it is.
+    //
+    // Deliberately NOT cleared in onDisconnected(): a disconnect emitted while
+    // a connect is in flight is part of that connect (a family switch tears the
+    // old backend down mid-connectToRadio), and clearing there would report
+    // "idle" for a connect that is still very much running.
+    m_connectAttemptActive = false;
     if (!m_rebootInProgress) {
         emit connectionError(msg);
     }

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -159,6 +159,15 @@ public:
     // stays the unadorned token that rigctl and the bridge serve.
     QString versionLabel() const { return m_versionLabel; }
     bool isConnected() const;
+    // True from the moment a connect is requested until it lands, fails, or is
+    // abandoned. isConnected() alone cannot express "still working": it is
+    // false both before an attempt starts and while one is in flight, which is
+    // why the bridge's `connect wait` could not tell a timeout worth retrying
+    // from one that never had a chance (#4912). The HL2 makes the gap wide —
+    // Hl2Backend::connectRadio() parks the request in m_queuedConnect behind
+    // the DSP open and re-drives it from finishDspSetup(), and nothing about
+    // that queue reaches this model, so no signal fires for seconds.
+    bool isConnectAttemptInFlight() const { return m_connectAttemptActive; }
     bool fullDuplexEnabled() const { return m_fullDuplex; }
     void setFullDuplex(bool on) { m_fullDuplex = on; emit infoChanged(); }
     float paTemp()    const { return m_paTemp; }
@@ -1840,6 +1849,9 @@ private:
     SleepInhibitor m_sleepInhibitor;     // prevents OS idle sleep while connected
     RadioInfo m_lastInfo;               // stored for auto-reconnect
     bool      m_intentionalDisconnect{false};
+    // See isConnectAttemptInFlight(). Set by the connect entry points, cleared
+    // by every way an attempt can end.
+    bool      m_connectAttemptActive{false};
     bool      m_forcedDisconnectInProgress{false};
     GuiClientRegistrationState m_guiClientRegistrationState;
     // Suppress connection-error toasts between rebootRadio() and the next

--- a/tests/automation_connect_family_test.cpp
+++ b/tests/automation_connect_family_test.cpp
@@ -212,21 +212,47 @@ int main(int argc, char** argv)
               "the explicit family reaches the connection panel");
     }
 
-    // ── Explicit family contradicting discovery fails fast ──────────────────
+    // ── Explicit family OVERRIDES discovery, and the disagreement is data ───
+    //
+    // The argument is the caller saying "I know what is at this address", so it
+    // has to win — otherwise the explicit form is weaker than the inferred one and
+    // the workaround for a wrong discovery entry disappears exactly when it is
+    // needed. An earlier revision refused this case; #4918's review caught it.
     {
         conn.byIpCalls = 0;
+        conn.lastFamily = QStringLiteral("<unset>");
         const QJsonObject reply =
             AutomationServerTestAccess::connect(
                 server, QStringLiteral("ip"),
                 QString(QLatin1String(kHl2Address)) + QStringLiteral(" flex"));
         settle();
-        check(!reply.value(QStringLiteral("ok")).toBool(),
-              "connect ip <hl2 address> flex is refused");
-        const QString error = reply.value(QStringLiteral("error")).toString();
-        check(error.contains(QLatin1String("flex")) && error.contains(QLatin1String("hl2")),
-              "the refusal names both the requested and the discovered family");
-        check(conn.byIpCalls == 0,
-              "nothing is scheduled when the families contradict");
+        check(reply.value(QStringLiteral("ok")).toBool(),
+              "connect ip <hl2 address> flex is accepted, not refused");
+        check(reply.value(QStringLiteral("family")).toString() == QLatin1String("flex"),
+              "the caller's family wins over discovery");
+        check(reply.value(QStringLiteral("familySource")).toString()
+                  == QLatin1String("argument"),
+              "and is labelled as coming from the argument");
+        check(reply.value(QStringLiteral("discoveryFamily")).toString()
+                  == QLatin1String("hl2"),
+              "the disagreement is returned as data, so a strict caller can compare");
+        check(conn.lastFamily == QLatin1String("flex"),
+              "the overriding family is what reaches the connection panel");
+    }
+
+    // ── No disagreement to report when discovery agrees ─────────────────────
+    {
+        const QJsonObject reply =
+            AutomationServerTestAccess::connect(
+                server, QStringLiteral("ip"),
+                QString(QLatin1String(kHl2Address)) + QStringLiteral(" hl2"));
+        settle();
+        check(reply.value(QStringLiteral("discoveryFamily")).toString()
+                  == QLatin1String("hl2"),
+              "discoveryFamily still reports what discovery believed");
+        check(reply.value(QStringLiteral("familySource")).toString()
+                  == QLatin1String("argument"),
+              "an agreeing argument is still an argument");
     }
 
     // ── An undiscovered address still falls back to the dialog selector ─────

--- a/tests/automation_connect_family_test.cpp
+++ b/tests/automation_connect_family_test.cpp
@@ -1,0 +1,258 @@
+// `connect ip` family resolution, and the family field that makes it
+// checkable (#4912).
+//
+// The bug this pins: `connect ip <addr>` with no family argument probed with
+// whatever the connect dialog's radio-type selector held — Flex on a fresh
+// instance — so a Hermes-Lite 2 at a known address was probed on the Flex
+// plane. The reply still said {ok:true, deferred:true}; the failure existed
+// only as a qCWarning no client can read. Twenty-five minutes of a hardware
+// session went into that gap.
+//
+// Discovery already knew the answer. RadioInfo has carried `family` since the
+// aetherd Gap B backend split, and `connect list` walks that same list — it
+// just never serialised the field, so a caller could not even work around the
+// bug by reading the family and passing it explicitly.
+//
+// The tests drive AutomationServer::doConnect() directly against a fake
+// IConnectionAutomation holding a fixed discovery list. No socket, no radio:
+// the whole behaviour under test is "which family does the verb hand to the
+// connection panel, and what does it tell the caller it did".
+
+#include "TestSettingsProfile.h"
+// AutomationServer holds QPointers to both; the complete types are needed for
+// its members to instantiate, exactly as in the sibling automation tests.
+#include "core/AudioEngine.h"
+#include "core/QsoRecorder.h"
+#include "core/AutomationServer.h"
+#include "core/IConnectionAutomation.h"
+#include "core/RadioDiscovery.h"
+#include "models/RadioModel.h"
+
+#include <QCoreApplication>
+#include <QHostAddress>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QString>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace AetherSDR {
+
+// doConnect() is private; the header already befriends this name for the
+// other automation tests.
+class AutomationServerTestAccess
+{
+public:
+    static QJsonObject connect(AutomationServer& server,
+                               const QString& action,
+                               const QString& arg)
+    {
+        return server.doConnect(action, arg, nullptr);
+    }
+};
+
+} // namespace AetherSDR
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* description)
+{
+    std::printf("%s  %s\n", condition ? "PASS" : "FAIL", description);
+    if (!condition) {
+        ++failures;
+    }
+}
+
+constexpr const char* kHl2Address = "192.0.2.184";
+constexpr const char* kFlexAddress = "192.0.2.253";
+constexpr const char* kUnknownAddress = "192.0.2.99";
+
+RadioInfo makeRadio(const char* address, const QString& family, const QString& model)
+{
+    RadioInfo info;
+    info.family = family;
+    info.model = model;
+    info.name = model;
+    info.serial = QStringLiteral("SN-") + family;
+    info.address = QHostAddress(QLatin1String(address));
+    info.port = family == QLatin1String("hl2") ? 1024 : 4992;
+    info.status = QStringLiteral("Available");
+    return info;
+}
+
+// Records what the connect verbs actually asked for. Everything else is the
+// minimum the interface demands.
+class FakeConnectionAutomation : public QObject, public IConnectionAutomation
+{
+public:
+    QList<RadioInfo> automationLocalRadios() const override { return m_radios; }
+
+    bool automationConnectLocalSerial(const QString&, QString* = nullptr) override
+    {
+        return true;
+    }
+
+    bool automationConnectByIp(const QString& hostOrIp,
+                               const QString& family = QString(),
+                               QString* = nullptr) override
+    {
+        ++byIpCalls;
+        lastTarget = hostOrIp;
+        lastFamily = family;
+        return true;
+    }
+
+    bool automationDisconnect(QString* = nullptr) override { return true; }
+    bool automationDialogVisible() const override { return false; }
+    void automationSetDialogVisible(bool) override {}
+    QObject* asQObject() override { return this; }
+
+    void setRadios(QList<RadioInfo> radios) { m_radios = std::move(radios); }
+
+    int byIpCalls = 0;
+    QString lastTarget;
+    QString lastFamily;
+
+private:
+    QList<RadioInfo> m_radios;
+};
+
+// The connect is scheduled with QTimer::singleShot(0, qApp, …), so the fake
+// only sees it after the event loop turns once.
+void settle()
+{
+    QCoreApplication::processEvents();
+    QCoreApplication::sendPostedEvents();
+    QCoreApplication::processEvents();
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile settingsProfile(
+        QStringLiteral("aether-automation-connect-family-test"));
+    check(settingsProfile.isValid(), "isolated settings profile is available");
+
+    QCoreApplication app(argc, argv);
+
+    RadioModel radio;
+    AutomationServer server;
+    server.setRadioModel(&radio);
+
+    FakeConnectionAutomation conn;
+    conn.setRadios({
+        makeRadio(kFlexAddress, QStringLiteral("flex"), QStringLiteral("FLEX-6700")),
+        makeRadio(kHl2Address, QStringLiteral("hl2"), QStringLiteral("Hermes-Lite 2")),
+    });
+    server.setConnectionAutomation(&conn);
+
+    // ── `connect list` publishes the discriminator ──────────────────────────
+    {
+        const QJsonObject reply =
+            AutomationServerTestAccess::connect(server, QStringLiteral("list"),
+                                                QString());
+        check(reply.value(QStringLiteral("ok")).toBool(), "connect list succeeds");
+        const QJsonArray radios = reply.value(QStringLiteral("radios")).toArray();
+        check(radios.size() == 2, "connect list returns both discovered radios");
+
+        QString flexFamily;
+        QString hl2Family;
+        for (const QJsonValue& entry : radios) {
+            const QJsonObject o = entry.toObject();
+            const QString address = o.value(QStringLiteral("address")).toString();
+            if (address == QLatin1String(kFlexAddress)) {
+                flexFamily = o.value(QStringLiteral("family")).toString();
+            } else if (address == QLatin1String(kHl2Address)) {
+                hl2Family = o.value(QStringLiteral("family")).toString();
+            }
+        }
+        check(flexFamily == QLatin1String("flex"),
+              "connect list reports family=flex for the Flex");
+        check(hl2Family == QLatin1String("hl2"),
+              "connect list reports family=hl2 for the Hermes-Lite 2");
+    }
+
+    // ── Omitted family resolves from discovery — the actual bug ─────────────
+    {
+        conn.byIpCalls = 0;
+        conn.lastFamily = QStringLiteral("<unset>");
+        const QJsonObject reply =
+            AutomationServerTestAccess::connect(server, QStringLiteral("ip"),
+                                                QLatin1String(kHl2Address));
+        settle();
+        check(reply.value(QStringLiteral("ok")).toBool(), "connect ip <hl2> succeeds");
+        check(reply.value(QStringLiteral("family")).toString() == QLatin1String("hl2"),
+              "reply reports the resolved family hl2, not 'dialog'");
+        check(reply.value(QStringLiteral("familySource")).toString()
+                  == QLatin1String("discovery"),
+              "reply reports familySource=discovery");
+        check(conn.byIpCalls == 1, "one connect-by-ip was scheduled");
+        check(conn.lastFamily == QLatin1String("hl2"),
+              "the connection panel is handed family=hl2 (pre-fix: empty → dialog selector)");
+    }
+
+    // ── Explicit family still wins, and is labelled as such ─────────────────
+    {
+        conn.byIpCalls = 0;
+        conn.lastFamily = QStringLiteral("<unset>");
+        const QJsonObject reply =
+            AutomationServerTestAccess::connect(
+                server, QStringLiteral("ip"),
+                QString(QLatin1String(kFlexAddress)) + QStringLiteral(" flex"));
+        settle();
+        check(reply.value(QStringLiteral("familySource")).toString()
+                  == QLatin1String("argument"),
+              "an explicit family reports familySource=argument");
+        check(conn.lastFamily == QLatin1String("flex"),
+              "the explicit family reaches the connection panel");
+    }
+
+    // ── Explicit family contradicting discovery fails fast ──────────────────
+    {
+        conn.byIpCalls = 0;
+        const QJsonObject reply =
+            AutomationServerTestAccess::connect(
+                server, QStringLiteral("ip"),
+                QString(QLatin1String(kHl2Address)) + QStringLiteral(" flex"));
+        settle();
+        check(!reply.value(QStringLiteral("ok")).toBool(),
+              "connect ip <hl2 address> flex is refused");
+        const QString error = reply.value(QStringLiteral("error")).toString();
+        check(error.contains(QLatin1String("flex")) && error.contains(QLatin1String("hl2")),
+              "the refusal names both the requested and the discovered family");
+        check(conn.byIpCalls == 0,
+              "nothing is scheduled when the families contradict");
+    }
+
+    // ── An undiscovered address still falls back to the dialog selector ─────
+    {
+        conn.byIpCalls = 0;
+        conn.lastFamily = QStringLiteral("<unset>");
+        const QJsonObject reply =
+            AutomationServerTestAccess::connect(server, QStringLiteral("ip"),
+                                                QLatin1String(kUnknownAddress));
+        settle();
+        check(reply.value(QStringLiteral("ok")).toBool(),
+              "connect ip to an undiscovered address is still accepted");
+        check(reply.value(QStringLiteral("family")).toString()
+                  == QLatin1String("dialog"),
+              "an undiscovered address reports family=dialog");
+        check(reply.value(QStringLiteral("familySource")).toString()
+                  == QLatin1String("dialog"),
+              "an undiscovered address reports familySource=dialog");
+        check(conn.lastFamily.isEmpty(),
+              "the connection panel is handed an empty family, i.e. the selector");
+    }
+
+    if (failures > 0) {
+        std::printf("\n%d check(s) failed\n", failures);
+        return 1;
+    }
+    std::printf("\nall checks passed\n");
+    return 0;
+}

--- a/tests/automation_connect_wait_phase_test.cpp
+++ b/tests/automation_connect_wait_phase_test.cpp
@@ -1,0 +1,265 @@
+// `connect wait` has to be able to say "still working" — and a deferred
+// connect failure has to reach the client that asked (#4912).
+//
+// Two defects, one reply shape:
+//
+//   1. The wait bound exactly one edge, RadioModel::connectionStateChanged, so
+//      it had two outcomes: connected, or "timed out waiting for radio
+//      connection". Nothing distinguished a connect that had died from one
+//      still in flight. The HL2 makes the second case ordinary —
+//      Hl2Backend::connectRadio() parks the request behind the DSP open and
+//      re-drives it from finishDspSetup(), emitting nothing in between — so a
+//      wait can expire mid-queue on a connect that then succeeds. Polling
+//      `get radio → .radio.connected` was the only reliable route.
+//
+//   2. Every connect verb replies {ok:true, deferred:true} before its real work
+//      runs, and a failure afterwards reached only qCWarning. So a connect that
+//      was rejected outright still looked accepted, and the wait that followed
+//      burned its whole timeout before reporting a timeout — the wrong
+//      diagnosis for something that had already failed.
+//
+// The fake connection here refuses on demand, which is what makes case 2
+// deterministic: no radio, no network, no timing window.
+
+#include "TestSettingsProfile.h"
+// AutomationServer holds QPointers to both; the complete types are needed for
+// its members to instantiate, as in the sibling automation tests.
+#include "core/AudioEngine.h"
+#include "core/QsoRecorder.h"
+#include "core/AutomationServer.h"
+#include "core/IConnectionAutomation.h"
+#include "core/RadioDiscovery.h"
+#include "models/RadioModel.h"
+
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QHostAddress>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLocalSocket>
+#include <QTimer>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* description)
+{
+    std::printf("%s  %s\n", condition ? "PASS" : "FAIL", description);
+    if (!condition) {
+        ++failures;
+    }
+}
+
+// One socket per outstanding request: `connect wait` is deferred, so the socket
+// that issued it is still waiting for its reply while the next verb is sent.
+class BridgeClient
+{
+public:
+    bool connectToServer(const QString& serverName)
+    {
+        m_socket.connectToServer(serverName);
+        return m_socket.waitForConnected(1000);
+    }
+
+    void send(const QJsonObject& request)
+    {
+        QByteArray payload = QJsonDocument(request).toJson(QJsonDocument::Compact);
+        payload.append('\n');
+        m_socket.write(payload);
+        m_socket.flush();
+    }
+
+    QJsonObject readReply(int timeoutMs)
+    {
+        QEventLoop loop;
+        QTimer timeout;
+        timeout.setSingleShot(true);
+        QObject::connect(&m_socket, &QLocalSocket::readyRead, &loop, &QEventLoop::quit);
+        QObject::connect(&timeout, &QTimer::timeout, &loop, &QEventLoop::quit);
+        timeout.start(timeoutMs);
+        while (!m_socket.canReadLine() && timeout.isActive()) {
+            loop.exec();
+        }
+        if (!m_socket.canReadLine()) {
+            return {};
+        }
+        return QJsonDocument::fromJson(m_socket.readLine()).object();
+    }
+
+    QJsonObject request(const QJsonObject& r, int timeoutMs = 2000)
+    {
+        send(r);
+        return readReply(timeoutMs);
+    }
+
+private:
+    QLocalSocket m_socket;
+};
+
+QJsonObject connectVerb(const QString& action, const QString& value = QString())
+{
+    QJsonObject o{
+        {QStringLiteral("cmd"), QStringLiteral("connect")},
+        {QStringLiteral("action"), action},
+    };
+    if (!value.isEmpty()) {
+        o.insert(QStringLiteral("value"), value);
+    }
+    return o;
+}
+
+// Refuses connect-by-ip when armed, so the deferred-failure path can be driven
+// without a radio.
+class RefusingConnection : public QObject, public IConnectionAutomation
+{
+public:
+    QList<RadioInfo> automationLocalRadios() const override { return {}; }
+
+    bool automationConnectLocalSerial(const QString&, QString* = nullptr) override
+    {
+        return true;
+    }
+
+    bool automationConnectByIp(const QString&,
+                               const QString& = QString(),
+                               QString* error = nullptr) override
+    {
+        if (refuse) {
+            if (error) {
+                *error = QStringLiteral("no route to radio");
+            }
+            return false;
+        }
+        return true;
+    }
+
+    bool automationDisconnect(QString* = nullptr) override { return true; }
+    bool automationDialogVisible() const override { return false; }
+    void automationSetDialogVisible(bool) override {}
+    QObject* asQObject() override { return this; }
+
+    bool refuse = true;
+};
+
+void pump(int ms)
+{
+    QEventLoop loop;
+    QTimer::singleShot(ms, &loop, &QEventLoop::quit);
+    loop.exec();
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile settingsProfile(
+        QStringLiteral("aether-automation-connect-wait-phase-test"));
+    check(settingsProfile.isValid(), "isolated settings profile is available");
+
+    QCoreApplication app(argc, argv);
+
+    RadioModel radio;
+    AutomationServer server;
+    server.setRadioModel(&radio);
+
+    RefusingConnection conn;
+    server.setConnectionAutomation(&conn);
+
+    const QString serverName = QStringLiteral("aether-connect-wait-phase-test-%1")
+                                   .arg(QCoreApplication::applicationPid());
+    check(server.start(serverName), "automation server starts");
+
+    BridgeClient waiter;
+    BridgeClient driver;
+    check(waiter.connectToServer(serverName), "waiter client connects");
+    check(driver.connectToServer(serverName), "driver client connects");
+
+    // ── A wait with nothing in flight says so ───────────────────────────────
+    {
+        const QJsonObject reply =
+            waiter.request(connectVerb(QStringLiteral("wait"), QStringLiteral("60")),
+                           3000);
+        check(reply.value(QStringLiteral("timeout")).toBool(),
+              "an idle wait still times out");
+        check(reply.value(QStringLiteral("phase")).toString() == QLatin1String("idle"),
+              "a timeout with no attempt in flight reports phase=idle");
+    }
+
+    // ── A deferred connect failure answers the wait immediately ─────────────
+    //
+    // The wait asks for 5 s. The refused `connect ip` must cut it short well
+    // inside that, carrying the connection layer's own message — pre-fix the
+    // refusal reached only qCWarning and this wait ran the full 5 s.
+    {
+        conn.refuse = true;
+        waiter.send(connectVerb(QStringLiteral("wait"), QStringLiteral("5000")));
+        pump(50);  // let the wait register before the failure is provoked
+
+        QElapsedTimer elapsed;
+        elapsed.start();
+        const QJsonObject accepted =
+            driver.request(connectVerb(QStringLiteral("ip"),
+                                       QStringLiteral("192.0.2.99")));
+        check(accepted.value(QStringLiteral("ok")).toBool(),
+              "connect ip is still accepted up front (the failure is deferred)");
+
+        const QJsonObject reply = waiter.readReply(3000);
+        const qint64 tookMs = elapsed.elapsed();
+        check(!reply.isEmpty(), "the outstanding wait is answered");
+        check(tookMs < 2000, "the wait is answered without burning its 5 s timeout");
+        check(!reply.value(QStringLiteral("timeout")).toBool(),
+              "the answer is a failure, not a timeout");
+        check(reply.value(QStringLiteral("error")).toString()
+                  .contains(QLatin1String("no route to radio")),
+              "the connection layer's own message reaches the client");
+    }
+
+    // ── And the failure is still readable afterwards ────────────────────────
+    {
+        const QJsonObject reply =
+            waiter.request(connectVerb(QStringLiteral("wait"), QStringLiteral("60")),
+                           3000);
+        check(reply.value(QStringLiteral("lastError")).toString()
+                  .contains(QLatin1String("no route to radio")),
+              "a later wait still reports the last deferred connect failure");
+        check(reply.contains(QStringLiteral("lastErrorAgeMs")),
+              "the last failure is aged, so a stale one is distinguishable");
+    }
+
+    // ── The in-flight flag itself ───────────────────────────────────────────
+    //
+    // Last, because it leaves an attempt on the model. Read synchronously: the
+    // point is that connectToRadio() marks the attempt the moment it is asked
+    // for, which is the whole window the wait previously could not see. Family
+    // "sim" keeps this off the network entirely.
+    {
+        check(!radio.isConnectAttemptInFlight(),
+              "a fresh model reports no connect attempt in flight");
+
+        RadioInfo info;
+        info.family = QStringLiteral("sim");
+        info.name = QStringLiteral("Demo");
+        info.serial = QStringLiteral("SIM-0001");
+        info.address = QHostAddress(QStringLiteral("127.0.0.1"));
+        radio.connectToRadio(info);
+        check(radio.isConnectAttemptInFlight(),
+              "connectToRadio() marks the attempt in flight immediately");
+
+        radio.disconnectFromRadio();
+        check(!radio.isConnectAttemptInFlight(),
+              "abandoning the connect clears the in-flight mark");
+    }
+
+    if (failures > 0) {
+        std::printf("\n%d check(s) failed\n", failures);
+        return 1;
+    }
+    std::printf("\nall checks passed\n");
+    return 0;
+}

--- a/tests/automation_connect_wait_phase_test.cpp
+++ b/tests/automation_connect_wait_phase_test.cpp
@@ -44,6 +44,22 @@
 
 using namespace AetherSDR;
 
+namespace AetherSDR {
+
+// noteConnectFailure() is private; the header already befriends this name for
+// the other automation tests.
+class AutomationServerTestAccess
+{
+public:
+    static void noteFailure(AutomationServer& server, const QString& what,
+                            const QString& error, bool answerPendingWaits)
+    {
+        server.noteConnectFailure(what, error, answerPendingWaits);
+    }
+};
+
+} // namespace AetherSDR
+
 namespace {
 
 int failures = 0;
@@ -230,6 +246,56 @@ int main(int argc, char** argv)
               "a later wait still reports the last deferred connect failure");
         check(reply.contains(QStringLiteral("lastErrorAgeMs")),
               "the last failure is aged, so a stale one is distinguishable");
+    }
+
+    // ── A fresh attempt retires the previous failure ────────────────────────
+    //
+    // #4918 review: `m_lastConnectError` was set and never cleared, so one
+    // failure rode along on every later non-connected wait for the life of the
+    // process — and the field's presence reads as "this attempt failed".
+    {
+        conn.refuse = false;                       // this one is accepted
+        driver.request(connectVerb(QStringLiteral("ip"), QStringLiteral("192.0.2.98")));
+        const QJsonObject reply =
+            waiter.request(connectVerb(QStringLiteral("wait"), QStringLiteral("60")),
+                           3000);
+        check(!reply.contains(QStringLiteral("lastError")),
+              "scheduling a fresh connect retires the previous failure");
+        check(!reply.contains(QStringLiteral("lastErrorAgeMs")),
+              "and its age goes with it");
+    }
+
+    // ── A failed DISCONNECT does not answer a connect wait ──────────────────
+    //
+    // #4918 review: noteConnectFailure() completed EVERY pending wait, so a
+    // disconnect failure handed its message to an unrelated connect still
+    // legitimately in flight.
+    //
+    // Driven through the verb's failure hook rather than the `disconnect` verb
+    // itself: doDisconnect() refuses up front unless the radio is connected, so
+    // the deferred path this guards is unreachable from a socket in a test with
+    // no radio. Calling the hook directly is what makes the guard testable at
+    // all — and the guard, not the route to it, is the thing under test.
+    {
+        conn.refuse = true;
+        waiter.send(connectVerb(QStringLiteral("wait"), QStringLiteral("700")));
+        pump(80);
+
+        AutomationServerTestAccess::noteFailure(
+            server, QStringLiteral("disconnect"), QStringLiteral("port busy"),
+            /*answerPendingWaits=*/false);
+        pump(120);
+
+        const QJsonObject reply = waiter.readReply(3000);
+        check(!reply.isEmpty(), "the wait still ends, on its own timeout");
+        check(reply.value(QStringLiteral("timeout")).toBool(),
+              "a failed disconnect does not answer an in-flight connect wait");
+        check(!reply.value(QStringLiteral("error")).toString()
+                   .contains(QLatin1String("port busy")),
+              "and the disconnect's message is never reported as the wait's error");
+        check(reply.value(QStringLiteral("lastError")).toString()
+                  .contains(QLatin1String("port busy")),
+              "it is still RECORDED though — a deferred failure a caller can see");
     }
 
     // ── The in-flight flag itself ───────────────────────────────────────────

--- a/tests/hl2_backend_test.cpp
+++ b/tests/hl2_backend_test.cpp
@@ -725,6 +725,20 @@ int main(int argc, char** argv)
         spin(300);
         check(gated.isConnected(), "#4912: gated backend connects");
 
+        // BEFORE touching drive at all — the case a latched flag got wrong (#4918
+        // review). finishDspSetup() seeds the register with a direct
+        // setTxDriveLevel(0) that bypasses applyDrive(), so nothing observes the
+        // gate acting; meanwhile m_rfPowerPercent still reads its default 100.
+        // A flag set only inside applyDrive() therefore denied responsibility for
+        // the very divergence the row exists to explain.
+        {
+            const auto h0 = gated.healthSnapshot();
+            check(h0.values.value(QStringLiteral("txDriveGated")).toBool(),
+                  "#4918: the gate is reported before drive is ever commanded");
+            check(h0.values.value(QStringLiteral("rfPowerPercent")).toInt() == 100,
+                  "#4918: and the requested percent is still its default 100");
+        }
+
         gatedDrive = -1;
         gated.setTxPower(100);
         spin(200);

--- a/tests/hl2_backend_test.cpp
+++ b/tests/hl2_backend_test.cpp
@@ -649,7 +649,95 @@ int main(int argc, char** argv)
         check(lastDrive == driveFor(40),
               "#4549: the unkey restores the power set DURING the tune");
 
+        // ---- #4912: health reports the APPLIED drive, not the request ------
+        //
+        // Nothing reported the drive the radio was actually given. `get
+        // transmit` has rfPower and `get radio` has txPower, but both read
+        // TransmitModel — the operator's ask — so a drive that never reached
+        // the radio read back as though it had. That is the exact failure the
+        // HL2 health section exists to catch, in the one area where it is
+        // safety-adjacent.
+        //
+        // Asserted against `lastDrive`, the value taken off the WIRE by the
+        // same reader the checks above use. A readback that agrees only with
+        // the model would prove nothing — agreement with the wire is the claim.
+        lastDrive = -1;
+        tuner.setTxPower(60);
+        spin(200);
+        {
+            const auto h = tuner.healthSnapshot();
+            check(lastDrive == driveFor(60), "#4912: RF power 60 reaches the wire");
+            check(h.values.value(QStringLiteral("rfPowerPercent")).toInt() == 60,
+                  "#4912: health reports the requested drive percent");
+            check(h.values.contains(QStringLiteral("txDriveRegister"))
+                      && h.values.value(QStringLiteral("txDriveRegister")).toInt()
+                             == lastDrive,
+                  "#4912: health reports the raw drive register sent to the radio");
+            check(h.values.contains(QStringLiteral("txDriveGated"))
+                      && !h.values.value(QStringLiteral("txDriveGated")).toBool(),
+                  "#4912: drive is not reported as gated in a TX-capable session");
+        }
+
         tuner.disconnectRadio();
+        spin(50);
+    }
+
+    // ---- #4912: a TX-BLOCKED session says so, instead of looking normal -----
+    //
+    // applyDrive() forces the register to 0 when the transmit gate is closed
+    // while m_rfPowerPercent keeps the operator's value, so the two legitimately
+    // disagree — and until now nothing reported the disagreement. A script
+    // reading only the request would conclude the radio was driven at 100%.
+    //
+    // The gate is decided per connect from AETHER_AUTOMATION + ALLOW_TX, so a
+    // second backend connected with the bridge's variable set (and ALLOW_TX
+    // absent) exercises the blocked path without disturbing anything above.
+    {
+        const bool hadAutomation = qEnvironmentVariableIsSet("AETHER_AUTOMATION");
+        const bool hadAllowTx = qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX");
+        check(!hadAllowTx, "#4912: ALLOW_TX is absent, so the gated case is reachable");
+        qputenv("AETHER_AUTOMATION", "1");
+        const auto restoreEnv = qScopeGuard([hadAutomation] {
+            if (!hadAutomation)
+                qunsetenv("AETHER_AUTOMATION");
+        });
+
+        QUdpSocket gatedRadio;
+        check(gatedRadio.bind(QHostAddress::LocalHost, 0), "#4912: gated fake radio binds");
+        std::uint32_t gatedSeq = 0;
+        int gatedDrive = -1;
+        QObject::connect(&gatedRadio, &QUdpSocket::readyRead, &gatedRadio, [&] {
+            while (gatedRadio.hasPendingDatagrams()) {
+                const QNetworkDatagram dg = gatedRadio.receiveDatagram();
+                const int drive = ep2DriveLevel(dg.data());
+                if (drive >= 0)
+                    gatedDrive = drive;
+                gatedRadio.writeDatagram(fakeEp6(gatedSeq++), dg.senderAddress(),
+                                         dg.senderPort());
+            }
+        });
+
+        Hl2Backend gated;
+        RadioConnectRequest gatedReq;
+        gatedReq.host = QStringLiteral("127.0.0.1");
+        gatedReq.port = gatedRadio.localPort();
+        gated.connectRadio(gatedReq);
+        spin(300);
+        check(gated.isConnected(), "#4912: gated backend connects");
+
+        gatedDrive = -1;
+        gated.setTxPower(100);
+        spin(200);
+        const auto h = gated.healthSnapshot();
+        check(gatedDrive == 0, "#4912: the closed gate holds the wire drive at 0");
+        check(h.values.value(QStringLiteral("rfPowerPercent")).toInt() == 100,
+              "#4912: the operator's requested percent is still reported");
+        check(h.values.value(QStringLiteral("txDriveRegister")).toInt() == 0,
+              "#4912: the written register is reported as 0, matching the wire");
+        check(h.values.value(QStringLiteral("txDriveGated")).toBool(),
+              "#4912: the gate is named, so requested-vs-applied is explainable");
+
+        gated.disconnectRadio();
         spin(50);
     }
 

--- a/tools/automation_logwatch.py
+++ b/tools/automation_logwatch.py
@@ -7,7 +7,9 @@ exposes when launched with AETHER_AUTOMATION=1:
 
   log categories                 list logging categories + enabled state
   log get <cat>                  whether a category is enabled
-  log set <cat> <on|off>         toggle a category at runtime (no restart)
+  log set <cat> [<cat>...] <on|off>
+                                 toggle one or more categories at runtime
+  log set <cat>=<on|off>[;...]   batch form, a single shell token
   log set all <on|off>           toggle every category
   log reset                      restore the operator's persisted prefs
   log tail [n] [since=<seq>]     pull recent ring events (default newest 100);
@@ -135,6 +137,94 @@ class LogStream:
             self._thread.join(timeout=1.0)
 
 
+class UsageError(Exception):
+    """A CLI argument problem. Reported as one usage line, never a traceback."""
+
+
+_TRUE_WORDS = ("on", "true", "1", "yes", "enable", "enabled")
+_FALSE_WORDS = ("off", "false", "0", "no", "disable", "disabled")
+
+
+def parse_onoff(word):
+    w = word.strip().lower()
+    if w in _TRUE_WORDS:
+        return True
+    if w in _FALSE_WORDS:
+        return False
+    raise UsageError("expected on|off, got %r" % word)
+
+
+def parse_set_targets(rest):
+    """`set` arguments -> [(category, enabled), ...].
+
+    Two accepted forms, because both are reached for in practice (#4912):
+
+        set <cat> [<cat> ...] <on|off>   the documented form, now also taking
+                                         several categories against one state
+        set "a=true;b=false"             the batch form — ONE shell token, which
+                                         is exactly why the old blind rest[1]
+                                         raised IndexError on it, and why the
+                                         command silently did nothing even when
+                                         it did not crash
+
+    A '=' anywhere switches the whole call to pair parsing, so the two forms
+    cannot mix into an ambiguous half-state.
+    """
+    if not rest:
+        raise UsageError("set requires <cat> <on|off>, or <cat>=<on|off>[;...]")
+
+    if any("=" in tok for tok in rest):
+        pairs = []
+        for tok in rest:
+            for item in tok.split(";"):
+                item = item.strip()
+                if not item:
+                    continue
+                if "=" not in item:
+                    raise UsageError("expected <cat>=<on|off>, got %r" % item)
+                cat, _, state = item.partition("=")
+                cat = cat.strip()
+                if not cat:
+                    raise UsageError("missing category name in %r" % item)
+                pairs.append((cat, parse_onoff(state)))
+        if not pairs:
+            raise UsageError("set requires at least one <cat>=<on|off>")
+        return pairs
+
+    if len(rest) < 2:
+        raise UsageError("set requires <cat> <on|off> (got only %r)" % rest[0])
+    on = parse_onoff(rest[-1])
+    return [(cat, on) for cat in rest[:-1]]
+
+
+def parse_tail_args(rest):
+    """`tail` arguments -> (count, since). Accepts [n] [since=<seq>], any order.
+
+    The docstring has always advertised `since=<seq>`, but the old code ran
+    int(rest[0]) on whatever came first, so `tail since=42` died with a
+    ValueError traceback.
+    """
+    n = 100
+    since = None
+    seen_count = False
+    for tok in rest:
+        if tok.startswith("since="):
+            value = tok[len("since="):]
+            try:
+                since = int(value)
+            except ValueError:
+                raise UsageError("since= expects an integer sequence, got %r" % value)
+            continue
+        if seen_count:
+            raise UsageError("unexpected argument %r" % tok)
+        try:
+            n = int(tok)
+        except ValueError:
+            raise UsageError("tail expects a count, got %r" % tok)
+        seen_count = True
+    return n, since
+
+
 def main():
     ap = argparse.ArgumentParser(description="AetherSDR bridge log/observability helper")
     ap.add_argument("action", choices=["categories", "get", "set", "reset",
@@ -143,6 +233,25 @@ def main():
     ap.add_argument("--socket")
     ap.add_argument("--secs", type=float, default=3.0, help="watch duration")
     args = ap.parse_args()
+
+    # Validate arity BEFORE touching the bridge, so a typo costs a usage line
+    # rather than a socket connection and a traceback interleaved with whatever
+    # else is writing to the terminal (#4912).
+    try:
+        set_targets = parse_set_targets(args.rest) if args.action == "set" else []
+        tail_count, tail_since = (parse_tail_args(args.rest)
+                                  if args.action == "tail" else (100, None))
+        if args.action == "get":
+            if len(args.rest) != 1:
+                raise UsageError("get requires exactly one category")
+        if args.action == "mark" and not args.rest:
+            raise UsageError("mark requires the text to record")
+    except UsageError as exc:
+        sys.exit("error: %s\nusage: %s %s"
+                 % (exc, ap.prog,
+                    "categories | get <cat> | set <cat> <on|off> | "
+                    "set <cat>=<on|off>[;...] | reset | tail [n] [since=<seq>] | "
+                    "mark <text> | watch [cat ...]"))
 
     path = args.socket or discover_socket()
     if not path:
@@ -164,14 +273,14 @@ def main():
     elif args.action == "get":
         print(c.get(args.rest[0]))
     elif args.action == "set":
-        print(json.dumps(c.set(args.rest[0], args.rest[1].lower() in ("on", "true", "1"))))
+        for cat, on in set_targets:
+            print(json.dumps(c.set(cat, on)))
     elif args.action == "reset":
         print(json.dumps(c.reset()))
     elif args.action == "mark":
         print(json.dumps(c.mark(" ".join(args.rest))))
     elif args.action == "tail":
-        n = int(args.rest[0]) if args.rest else 100
-        for e in c.tail(n):
+        for e in c.tail(tail_count, tail_since):
             print(f"{e['seq']:>5} {e['mono_us']:>10} {e['lvl']} {e['cat']}: {e['msg']}")
 
 

--- a/tools/test_automation_logwatch.py
+++ b/tools/test_automation_logwatch.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Argument-parsing checks for tools/automation_logwatch.py (#4912).
+
+The bug: `main()` declared `rest` as `nargs="*"` and then indexed it blind —
+`args.rest[0]`, `args.rest[1]` — so
+
+    automation_logwatch.py set "lcConnection=true;lcHl2=true"
+
+raised `IndexError: list index out of range`, because that batch form is ONE
+shell token. Its traceback then interleaved on stderr with a concurrent `tail`
+on stdout, which is how it was found. The quieter half was worse: the
+`a=true;b=true` form was never a syntax the tool accepted, so the command did
+nothing even when it did not crash.
+
+These tests cover the parsers only. They take no socket and no bridge, which is
+the point — arity is validated before anything connects.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import automation_logwatch as lw  # noqa: E402
+
+
+def check(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_usage_error(fn, *args):
+    try:
+        fn(*args)
+    except lw.UsageError:
+        return
+    raise AssertionError("expected a UsageError from %s%r" % (fn.__name__, args))
+
+
+def test_set_documented_form():
+    check(lw.parse_set_targets(["lcAutomation", "on"]) == [("lcAutomation", True)],
+          "single category on")
+    check(lw.parse_set_targets(["lcAutomation", "off"]) == [("lcAutomation", False)],
+          "single category off")
+    check(lw.parse_set_targets(["all", "true"]) == [("all", True)],
+          "'all' is just a category name here")
+    check(lw.parse_set_targets(["lcConnection", "lcHl2", "on"])
+          == [("lcConnection", True), ("lcHl2", True)],
+          "several categories share one state")
+
+
+def test_set_batch_form():
+    # The exact invocation that produced the IndexError.
+    check(lw.parse_set_targets(["lcConnection=true;lcHl2=true;lcAutomation=true"])
+          == [("lcConnection", True), ("lcHl2", True), ("lcAutomation", True)],
+          "the one-token batch form is accepted")
+    check(lw.parse_set_targets(["lcHl2=off"]) == [("lcHl2", False)],
+          "a single pair is a batch of one")
+    check(lw.parse_set_targets(["a=true;", " b = false "])
+          == [("a", True), ("b", False)],
+          "stray separators and spacing are tolerated")
+
+
+def test_set_rejections_are_usage_not_tracebacks():
+    expect_usage_error(lw.parse_set_targets, [])
+    expect_usage_error(lw.parse_set_targets, ["lcAutomation"])      # the old IndexError
+    expect_usage_error(lw.parse_set_targets, ["lcAutomation", "maybe"])
+    expect_usage_error(lw.parse_set_targets, ["=true"])
+    expect_usage_error(lw.parse_set_targets, ["lcHl2=perhaps"])
+
+
+def test_tail_arguments():
+    check(lw.parse_tail_args([]) == (100, None), "tail defaults to the newest 100")
+    check(lw.parse_tail_args(["50"]) == (50, None), "a bare count is the count")
+    # Documented in the module docstring since day one, and a ValueError
+    # traceback before this change.
+    check(lw.parse_tail_args(["since=42"]) == (100, 42), "since= alone is accepted")
+    check(lw.parse_tail_args(["25", "since=42"]) == (25, 42), "count then since")
+    check(lw.parse_tail_args(["since=42", "25"]) == (25, 42), "since then count")
+    expect_usage_error(lw.parse_tail_args, ["everything"])
+    expect_usage_error(lw.parse_tail_args, ["since=soon"])
+    expect_usage_error(lw.parse_tail_args, ["10", "20"])
+
+
+def test_onoff_words():
+    for word in ("on", "ON", "true", "1", "yes", "enabled"):
+        check(lw.parse_onoff(word) is True, "%r should read as on" % word)
+    for word in ("off", "OFF", "false", "0", "no", "disabled"):
+        check(lw.parse_onoff(word) is False, "%r should read as off" % word)
+    expect_usage_error(lw.parse_onoff, "sometimes")
+
+
+if __name__ == "__main__":
+    test_set_documented_form()
+    test_set_batch_form()
+    test_set_rejections_are_usage_not_tracebacks()
+    test_tail_arguments()
+    test_onoff_words()
+    print("automation logwatch argument checks passed")


### PR DESCRIPTION
## Summary

Fixes the four automation-bridge gaps from #4912, plus the sixth one AetherClaude found
during triage (`connect list` never published `family`). Four commits, one per gap, so
they can be taken independently — commits 1+4 and 2+3 map onto the PR A / PR B split the
triage suggested, if you'd rather have two.

Every gap here is the same shape: **the bridge knew something and didn't say it.** The
family was in discovery; the applied drive was on its way to the radio; the connect
failure reached a log line; the CLI knew its own argument was missing. In each case the
caller got an answer that looked fine.

## Why

| # | Gap | What it cost |
|---|-----|--------------|
| 1 | `connect ip <addr>` with no family probed the connect dialog's selector — Flex on a fresh instance | ~25 min of a hardware session, with the reply saying `ok:true, deferred:true` throughout |
| 6 | `connect list` never serialised `family` | The HL2 was described in prose only, so you couldn't read the family back — or work around gap 1 by passing it explicitly |
| 2 | `connect wait` had two outcomes: connected, or "timed out" | Nothing distinguished a dead connect from one still queued behind the HL2's DSP open. Polling `get radio` was the only reliable route |
| 1b | Every connect verb replies before its real work runs; failures reached only `qCWarning` | Invisible to the client that asked |
| 3 | No applied drive anywhere — `rfPower`/`txPower` both read `TransmitModel` | The readback shared the failure it was meant to catch, in the one area that's safety-adjacent |
| 4 | `automation_logwatch.py` indexed `args.rest` blind | `set "a=true;b=true"` → `IndexError` traceback interleaved with a concurrent `tail`; the batch form was never accepted either, so it silently did nothing when it didn't crash |
| 5 | `forwardPowerPeakW` is a display hold | Documented rather than changed — it's correct for a needle and wrong for an assertion |

## Scope

- `src/core/AutomationServer.{cpp,h}` — family resolution, `familySource`, `family` on
  `connect list`, deferred-failure capture at all four sites, `connect wait` phase +
  `connectionError` binding
- `src/models/RadioModel.{cpp,h}` — connect-attempt-in-flight state
- `src/core/backends/hl2/Hl2Backend.{cpp,h}` — `rfPowerPercent` / `txDriveRegister` /
  `txDriveGated` health rows, peak-hold label
- `tools/automation_logwatch.py` + `tools/test_automation_logwatch.py` — argument parsing
- `docs/automation-bridge.md`, `CMakeLists.txt`, three test files
- **No protocol change, no persistence change, no UX change.** Two new health rows and
  three new reply fields; every existing field keeps its meaning. `connect ip <addr>` on
  an address discovery has never seen still falls back to the dialog selector, so
  pre-existing scripts are unchanged.

## Constitution principle honored

- **Principle II** (the radio is authoritative on live state) — commits 1 and 3. Discovery
  is the radio telling us what it is; a local UI default that overrides it is the client
  asserting its own state over the radio's. Same for drive: reporting the operator's
  request as though it were the applied value is the model overriding what the radio was
  actually told.
- **Principle VIII** (evidence over assertion) — commit 2. A reply that says `ok` and then
  fails silently is assertion without evidence.
- **Principle VII** (untrusted input validated at the boundary) — commit 4. Argv is input,
  and the boundary is before anything connects.

## Test plan

- [x] Local incremental `ninja -C build` clean on Linux (Nobara 43, Qt 6.10.3, gcc 16.1.1,
      cmake 3.31.11)
- [x] **Fail-first on every commit.** Each test was written and run against the unfixed
      tree first:

  | Commit | Test | Before | After |
  |---|---|---|---|
  | 1 | `automation_connect_family_test` | 10 / 19 checks fail | 19 / 19 pass |
  | 2 | `automation_connect_wait_phase_test` | 6 / 16 checks fail | 16 / 16 pass |
  | 3 | `hl2_backend_test` (extended) | 5 checks fail | all pass |
  | 4 | `automation_logwatch_arguments` | parsers absent; CLI reproduces the `IndexError` and a `ValueError` against a live socket | all pass |

- [x] `ctest` — the four new/extended tests pass, and `bridge_docs_check` still passes
      after the `docs/automation-bridge.md` edits.
- [x] CI green on this PR: Static checks, build, check-macos, check-windows.
- [x] Six tests failed in my first local `-j 8` sweep; **that sweep ran while the app was
      streaming from the real HL2**, so each was re-run individually on an idle box.
      `hl2_backend_test`, `hl2_link_stats_test`, `hl2_link_stats_model_test`,
      `hl2_receiver_churn_test` and `hl2_connect_reentrancy_test` all pass — the last of
      those being the one adjacent to this PR's `RadioModel` change, so the one that
      mattered. `eibi_client_test` turned out not to be a failure at all (see below).
- [x] **Hardware, on a real Hermes-Lite 2** (gateware 75, `172.17.0.184`), which is where
      all of this was found:

  ```
  connect list           → "family": "hl2"   (was: field absent)
  connect ip 172.17.0.184  ← no family argument
                         → "family": "hl2", "familySource": "discovery"
                            (was: "family": "dialog", probed the Flex plane)
  connect wait 300       → "phase": "connecting", timeout: true
                            (was: timeout with no way to tell it from a dead connect)
  connect wait 20000     → connected: true, model "Hermes-Lite 2"
  ```

  The family-less `connect ip` is the exact command that cost the 25 minutes; it now
  reaches the HL2 first try, and `phase: "connecting"` is the HL2's queued-connect case
  showing up live rather than in theory.

- [x] **Drive rows against the wire**, keyed into a dummy load through a KXPA100 as an
      external wattmeter (ANT2 asserted from the amp's live `^AN;` before every key-down;
      licensed control operator present):

  | Requested | `rfPowerPercent` | `txDriveRegister` | `txDriveGated` |
  |---|---|---|---|
  | 20 % | 20 | 51 | false |
  | 40 % | 40 | 102 | false |
  | 60 % | 60 | 153 | false |
  | 100 % | 100 | 255 | false |

  Exactly `pct × 255 / 100`. In a TX-blocked session the same rows read
  `rfPowerPercent: 60, txDriveRegister: 0, txDriveGated: true` — the divergence that was
  previously invisible.

  **The new rows earned their keep on their first hardware run.** Sweeping drive 20→100 %
  under `txtest twotone` produced a *flat* power curve (~1.2 W throughout), because
  `txtest` calls `startTwoToneTune()` and therefore runs at **tune power** — the register
  sat pinned at 25 the whole sweep while `rfPower` dutifully reported 20/40/60/80/100.
  Pre-change there was nothing in the snapshot to contradict the request, and the flat
  curve would have looked like a hardware problem.

## Unrelated finding, deliberately not bundled

`eibi_client_test` aborts at startup (SIGABRT, no QTest output) when the ctest process has
no usable Qt platform plugin — which is what I first read as a test failure. Under
`QT_QPA_PLATFORM=offscreen` it is **7 passed / 0 failed in 3 ms**. Its registration is

```cmake
add_test(NAME eibi_client_test COMMAND eibi_client_test)
```

with no `set_tests_properties(eibi_client_test PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")`,
unlike siblings such as `native_widget_topology_test`. Nothing in this PR touches
`EibiClient`. Left out on purpose — happy to send the one-liner separately if you want it.

## Checklist

- [x] Commits are signed (docs/COMMIT-SIGNING.md)
- [x] No new flat-key AppSettings calls (Principle V)
- [x] All meter UI uses MeterSmoother (Principle II)

## Notes for review

- Commit 2 folds in gap 1's *silent-success* half (the deferred-failure capture) rather
  than commit 1, because it's only observable through `connect wait`. If you take the
  A / B split, that half travels with B.
- `txDriveRegister` is **absent until the first write**, per the health section's existing
  "never told" convention — a `0` there means the radio was commanded to zero drive.
- I skipped the optional `forwardPowerSettled` companion from the triage — the row is
  documented as a display hold instead. Happy to add it if you want it.

Closes #4912

---

73, Ozy **K6OZY**  · cost: $46.29 · model: claude-opus-5
