### PR TITLE
feat(colibri): a ColibriNANO backend (family "colibri")

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,6 +630,13 @@ set(CORE_SOURCES
     src/core/backends/icom/IcomCivBackend.cpp # IcomCIV (IRadioBackend impl)
     src/core/backends/icom/IcomSettings.cpp  # owned config, "Icom" root key (Principle V)
     src/core/backends/icom/IcomCredentials.cpp # password -> keychain, NEVER settings
+    src/core/backends/colibri/ColibriLib.cpp        # ColibriNANO — vendor DLL loader (protocol authority)
+    src/core/backends/colibri/ColibriDevice.cpp     # ColibriNANO — descriptor + IQ stream on the I/O thread
+    src/core/backends/colibri/ColibriSpectrum.cpp   # ColibriNANO — FFT panadapter (FFTW)
+    src/core/backends/colibri/ColibriRxDsp.cpp      # ColibriNANO — IQ -> WdspChannel demod + spectrum
+    src/core/backends/colibri/ColibriBackend.cpp    # ColibriNANO — IRadioBackend impl (RX-only)
+    src/core/backends/colibri/ColibriDiscovery.cpp  # ColibriNANO — USB enumeration -> picker
+    src/core/backends/colibri/ColibriSettings.cpp   # owned config object, "Colibri" root key (Principle V)
     src/core/dsp/WdspChannel.cpp
     ${AETHER_SETTINGS_SOURCES}
     src/core/RadioStateMemory.cpp   # RFC #4603 client-side radio memory

--- a/docs/architecture/aetherd-colibri-backend-design.md
+++ b/docs/architecture/aetherd-colibri-backend-design.md
@@ -1,0 +1,100 @@
+# aetherd — ColibriNANO backend design
+
+Status: implemented (first cut, RX-only)
+Family id: `colibri`
+Protocol authority: the ColibriNANO USB receiver is driven exclusively through
+Expert Electronics' own `colibrinano_lib` dynamic library. The authority for
+every call signature, sample-rate table, preamp range and tuning bound in this
+backend is the library's published C API header set (`common.h`, `LibLoader.h`
+in <https://github.com/maksimus1210/ColibriNANO_lib>), which is the vendor's
+reference client for the device. No USB traffic is spoken directly: the DLL owns
+the FTDI transport, and this backend never reaches below its API.
+
+## What the device is
+
+A direct-sampling USB receiver: 122.88 MHz ADC, one DDC, IQ delivered to a
+process callback as normalized `float` pairs at one of nine rates
+(48 k … 3.072 MHz). Controls: tuning frequency (`setFrequency`, Hz, uint32),
+preamp/attenuator (`setPream`, −31.5…+6 dB), sample rate (chosen at `start`).
+RX only — there is no transmitter, no keying line, and no telemetry beyond an
+ADC-overload flag piggybacked on every IQ callback.
+
+## Shape of the backend
+
+The Hermes-Lite 2 backend is the template: raw IQ in, host-side DSP chain below
+the seam (RFC §5.5 — "DSP location is invisible here"). The differences all
+subtract:
+
+- ONE receiver, fixed. `maxSlices = maxPanadapters = 1`; `createPanadapter()`
+  stays `false`. The pan id is `colibri-0`, the slice id is 0, and the four-way
+  index map HL2 needs collapses to constants.
+- RX-only: `canTransmit=false`, `hostModulates=false`, `setKeying()` a no-op.
+  The engine TX guard (RFC §6) sits above the seam and refuses keying on the
+  capability alone.
+- The pan SPAN is the sample rate, exactly as on the HL2 — but rate changes
+  restart the stream (`stop` → `start(newRate)`) instead of poking a register.
+- No wire protocol object: `ColibriDevice` wraps the DLL and stands where
+  `MetisClient` stands, on the same one-I/O-thread model.
+
+## Threading
+
+Identical discipline to `Hl2Backend`, with one extra hop the DLL forces on us:
+
+- The backend owns a `QThread` (`colibri-io`). `ColibriDevice` and
+  `ColibriRxDsp` are created parentless and moved onto it.
+- The DLL invokes the RX callback from ITS OWN internal thread. That thread is
+  not ours and `ColibriRxDsp` is not thread-safe against the control path, so
+  the callback only copies the block and emits a queued signal
+  (`iqBlockReady`) whose receiver context is the device object — the block is
+  therefore processed on the I/O thread. This is the one place the Colibri path
+  is one queue deeper than HL2's DirectConnection fan-out, and it is not
+  optional.
+- Counters the GUI thread reads (`linkStats()`, `healthSnapshot()`) are
+  atomics in the device, never reads into I/O-thread state.
+- Control verbs travel GUI → I/O via queued `invokeMethod`, blocking only for
+  the rate-change reconfigure (same order rule as HL2: the DSP must expect the
+  new rate before the stream delivers it — here trivially satisfied because
+  `stop` precedes the reconfigure and `start` follows it, on one event loop).
+
+## IQ handedness
+
+`ColibriRxDsp` carries `Config::wireAnalytic`. The HPSDR wire is the conjugate
+of the analytic convention and WDSP's RXA selects the opposite sign to its
+passband bounds (both measured — see `Hl2RxDsp::processIqBlock`), so:
+
+- `wireAnalytic=true` (default, expected for this library): spectrum takes the
+  wire RAW, demodulator takes the CONJUGATE. Conjugating an analytic wire
+  reproduces the HPSDR wire byte-for-byte, so the demod path and the
+  slice-shift sign (`shift = slice − NCO`) are inherited from HL2 unchanged.
+- `wireAnalytic=false`: the HL2 arrangement verbatim (spectrum conjugated,
+  demod raw).
+
+The flag is persisted in `ColibriSettings` so live calibration against a known
+signal is one settings flip, not a rebuild.
+
+## Persistence
+
+`ColibriSettings`, one root key `"Colibri"` (Principle V): remembered span,
+optional DLL path override, `wireAnalytic`. Per-radio operating state (RFC
+#4603) declares `Tuning | Passband | SpanRate | RfGain`; the preamp rides the
+`rfGain` extension sub-object. The device reports no serial through the API, so
+identity is `colibrinano-<index>`.
+
+## Discovery
+
+`ColibriDiscovery` polls `ColibriLib::deviceCount()` on a timer and emits the
+same `RadioInfo` signals the Flex and HL2 sweeps emit (`family="colibri"`,
+`address=LocalHost` — synthetic, never dialed, per the sim precedent). Polling
+is suspended while a device is open: enumerating the FTDI bus under a running
+stream is not documented safe by the authority, so we do not do it.
+
+## Boundary notes
+
+- The DLL header vocabulary appears only under `src/core/backends/colibri/`
+  (EB3).
+- `ownsRxAudio()` is true; `MainWindow::backendFeedsEngineDirectly()` stays
+  false — audio reaches the engine through the RadioModel relay, exactly like
+  HL2 (see the #4537 comment block before changing either).
+- `finalize()` is deliberately never called: the library wants it "before
+  program close", but a static-destruction-order call into a DLL that owns
+  live FTDI handles is a worse risk than letting process teardown reclaim it.

--- a/docs/architecture/radio-capabilities-map.md
+++ b/docs/architecture/radio-capabilities-map.md
@@ -33,6 +33,15 @@ traps and why the DAX crash guard is deliberately *not* the DAX capability.
 
 ## Wired and consumed
 
+**ColibriNANO (family `colibri`)** — a USB direct-sampling receiver driven
+through the vendor's `colibrinano_lib`. `model` `"ColibriNANO"`,
+`tuningMinHz/MaxHz` 9 kHz–55 MHz, `sampleRatesHz` nine rates
+(48 k…3.072 MHz), `canTransmit` ❌ (constant — it is a receiver, so
+`hostModulates` is ❌ too: RX-only must not open the mic),
+`clientSettingsDomains` Tuning|Passband|SpanRate|RfGain|Memories,
+everything else ❌/empty. Declared in `ColibriBackend::capabilities()`;
+design doc `aetherd-colibri-backend-design.md`.
+
 | Field | Flex | HL2 | Sim | Read at | Effect |
 |---|:--:|:--:|:--:|---|---|
 | `family` | `"flex"` | `"hl2"` | `"sim"` | `MainWindow::rfGainSettingsKey` | Scopes the persisted RF-gain key per family |

--- a/src/core/backends/colibri/ColibriBackend.cpp
+++ b/src/core/backends/colibri/ColibriBackend.cpp
@@ -1,0 +1,932 @@
+#include "core/backends/colibri/ColibriBackend.h"
+
+#include <QJsonObject>
+#include <QLoggingCategory>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <utility>
+
+#include "core/backends/colibri/ColibriDevice.h"
+#include "core/backends/colibri/ColibriLib.h"
+#include "core/backends/colibri/ColibriRxDsp.h"
+#include "core/backends/colibri/ColibriSettings.h"
+
+Q_LOGGING_CATEGORY(lcColibri, "aether.colibri")
+
+namespace AetherSDR::colibri {
+
+namespace {
+
+// Snap a requested span (Hz) to the nearest deliverable rate, in the LOG
+// domain — the rates are octave-ish spaced and zoom is a multiplicative
+// gesture, so ratio-nearest is what makes a wheel step land on the
+// neighbouring rate instead of skipping one (same reasoning as HL2).
+int nearestSampleRateHz(double requestedHz) noexcept
+{
+    if (!(requestedHz > 0.0))
+        return kColibriSampleRatesHz[0];
+    int best = kColibriSampleRatesHz[0];
+    double bestDistance = std::numeric_limits<double>::infinity();
+    for (const int rate : kColibriSampleRatesHz) {
+        const double distance =
+            std::abs(std::log(requestedHz / static_cast<double>(rate)));
+        if (distance < bestDistance) {
+            bestDistance = distance;
+            best = rate;
+        }
+    }
+    return best;
+}
+
+// Neutral AGC vocabulary -> WDSP RXA AGC mode (same table as the HL2 chain).
+int wdspAgcMode(const QString& mode) noexcept
+{
+    const QString m = mode.trimmed().toLower();
+    if (m == QLatin1String("off"))  return 0;
+    if (m == QLatin1String("slow")) return 2;
+    if (m == QLatin1String("fast")) return 4;
+    return 3;                                  // medium: WDSP's own default
+}
+
+WdspChannel::Mode modeFromString(const QString& mode) noexcept
+{
+    const QString u = mode.toUpper();
+    if (u == QLatin1String("LSB"))  return WdspChannel::Mode::Lsb;
+    if (u == QLatin1String("USB"))  return WdspChannel::Mode::Usb;
+    if (u == QLatin1String("DSB"))  return WdspChannel::Mode::Dsb;
+    if (u == QLatin1String("CWL"))  return WdspChannel::Mode::Cwl;
+    if (u == QLatin1String("CWU") || u == QLatin1String("CW"))
+        return WdspChannel::Mode::Cwu;
+    if (u == QLatin1String("FM") || u == QLatin1String("NFM"))
+        return WdspChannel::Mode::Fm;
+    if (u == QLatin1String("AM"))   return WdspChannel::Mode::Am;
+    if (u == QLatin1String("DIGU")) return WdspChannel::Mode::Digu;
+    if (u == QLatin1String("DIGL")) return WdspChannel::Mode::Digl;
+    if (u == QLatin1String("SAM"))  return WdspChannel::Mode::Sam;
+    if (u == QLatin1String("DRM"))  return WdspChannel::Mode::Drm;
+    if (u == QLatin1String("WBFM") || u == QLatin1String("WFM"))
+        return WdspChannel::Mode::Wbfm;
+    return WdspChannel::Mode::Usb;
+}
+
+bool isKnownModeString(const QString& mode) noexcept
+{
+    static const QStringList kKnown = {
+        QStringLiteral("LSB"), QStringLiteral("USB"), QStringLiteral("DSB"),
+        QStringLiteral("CWL"), QStringLiteral("CWU"), QStringLiteral("CW"),
+        QStringLiteral("FM"),  QStringLiteral("NFM"), QStringLiteral("AM"),
+        QStringLiteral("DIGU"), QStringLiteral("DIGL"), QStringLiteral("SAM"),
+        QStringLiteral("DRM"), QStringLiteral("WBFM"), QStringLiteral("WFM"),
+    };
+    return kKnown.contains(mode.toUpper());
+}
+
+// Default RX passband per mode (Hz, sign carries the sideband — SliceModel's
+// convention). Same table as the HL2 backend, for the same reasons.
+std::pair<int, int> defaultPassbandForMode(const QString& mode) noexcept
+{
+    const QString u = mode.toUpper();
+    if (u == QLatin1String("USB"))  return {100, 2900};
+    if (u == QLatin1String("LSB"))  return {-2900, -100};
+    if (u == QLatin1String("DIGU")) return {150, 3000};
+    if (u == QLatin1String("DIGL")) return {-3000, -150};
+    if (u == QLatin1String("CWU") || u == QLatin1String("CW")) return {350, 850};
+    if (u == QLatin1String("CWL"))  return {-850, -350};
+    if (u == QLatin1String("AM") || u == QLatin1String("SAM")) return {-4000, 4000};
+    if (u == QLatin1String("DSB")) return {-3000, 3000};
+    if (u == QLatin1String("FM") || u == QLatin1String("NFM")) return {-8000, 8000};
+    if (u == QLatin1String("WBFM") || u == QLatin1String("WFM")) return {-40000, 40000};
+    if (u == QLatin1String("DRM")) return {-5000, 5000};
+    return {150, 3000};   // matches modeFromString's USB fallback
+}
+
+// Phase-1 data-plane payload: a raw little-endian float32 array.
+QByteArray floatBytes(const std::vector<float>& v)
+{
+    return {reinterpret_cast<const char*>(v.data()),
+            static_cast<qsizetype>(v.size() * sizeof(float))};
+}
+
+}  // namespace
+
+ColibriBackend::ColibriBackend(QObject* parent) : IRadioBackend(parent)
+{
+    // No parent: moveToThread() refuses an object that has one. Destroyed
+    // explicitly in the destructor after the thread is joined.
+    m_device = new ColibriDevice(nullptr);
+
+    m_ioThread = new QThread(this);
+    m_ioThread->setObjectName(QStringLiteral("colibri-io"));
+    m_device->moveToThread(m_ioThread);
+    m_ioThread->start();
+
+    // Raw IQ -> the DSP chain. The signal is emitted from the LIBRARY's
+    // thread; the receiver context is m_device (I/O thread), so this is a
+    // QUEUED delivery and the lambda body runs on the I/O thread — where
+    // m_ioDsp lives. Never DirectConnection here: that would run WDSP on the
+    // library's own thread, unsynchronized against every control verb.
+    connect(m_device, &ColibriDevice::iqBlockReady, m_device,
+            [this](const std::vector<std::complex<float>>& iq) {
+        if (m_ioDsp)
+            m_ioDsp->processIqBlock(iq);
+    }, Qt::QueuedConnection);
+
+    connect(m_device, &ColibriDevice::opened, this, [this] {
+        m_connected = true;
+        m_linkBlocksAtLastTick = 0;
+        m_linkStatsTimer->start();
+        emit connected();
+        // Publish initial pan/slice state AFTER connected() — RadioModel's
+        // onConnected() stages existing models as previous-session leftovers,
+        // so anything emitted earlier is wiped before the UI sees it. Pan
+        // FIRST: the pan must exist before anything (zoom limits, slice)
+        // describes it, or those reports are dropped (#4470 shape).
+        emitPanState();
+        emit panBandwidthLimitsChanged(
+            panId(),
+            static_cast<double>(kColibriSampleRatesHz[0]) / 1.0e6,
+            static_cast<double>(
+                kColibriSampleRatesHz[std::size(kColibriSampleRatesHz) - 1]) / 1.0e6);
+        emit panRfGainInfoChanged(panId(), kPreampMinDb, kPreampMaxDb, kPreampStepDb);
+        emit panRfGainChanged(panId(), static_cast<int>(std::lround(m_preampDb)));
+        pushInitialState();
+        emitSliceState();
+        defineMeters();
+    });
+    connect(m_device, &ColibriDevice::openFailed, this, [this](const QString& reason) {
+        m_connected = false;
+        m_linkStatsTimer->stop();
+        emit connectionError(QStringLiteral("ColibriNANO: %1").arg(reason));
+    });
+    connect(m_device, &ColibriDevice::adcOverloadChanged, this, [this](bool overload) {
+        // Surfaced as vendor status rather than a core field: nothing in the
+        // core profile models converter overload yet.
+        emit extensionStatus(familyName(), QStringLiteral("adcOverload"),
+                             {{QStringLiteral("overload"), overload}});
+        if (overload)
+            qCWarning(lcColibri) << "ADC overload — reduce preamp gain";
+    });
+
+    m_linkStatsTimer = new QTimer(this);
+    m_linkStatsTimer->setInterval(kLinkStatsIntervalMs);
+    connect(m_linkStatsTimer, &QTimer::timeout, this,
+            &ColibriBackend::publishLinkStats);
+}
+
+ColibriBackend::~ColibriBackend()
+{
+    if (m_ioThread) {
+        // Stop the device ON its own thread and WAIT for it: quit() below
+        // ends the event loop that a queued stop would need, and tearing the
+        // descriptor down from this thread is an affinity bug.
+        QMetaObject::invokeMethod(m_device, &ColibriDevice::closeDevice,
+                                  Qt::BlockingQueuedConnection);
+        m_ioThread->quit();
+        m_ioThread->wait();
+    }
+    // The thread is joined; nothing can be running in either of these.
+    delete m_rxDsp;
+    m_rxDsp = nullptr;
+    m_ioDsp = nullptr;
+    delete m_device;
+}
+
+RadioCapabilities ColibriBackend::capabilities() const
+{
+    RadioCapabilities c;
+    c.family = familyName();
+    c.model = QStringLiteral("ColibriNANO");
+    c.maxSlices = 1;          // one DDC in the hardware; not a policy choice
+    c.maxPanadapters = 1;
+    for (const int rate : kColibriSampleRatesHz)
+        c.sampleRatesHz.append(rate);
+    c.tuningMinHz = kTuningMinHz;
+    c.tuningMaxHz = kTuningMaxHz;
+    // RECEIVER. Constant false rather than a gate: there is no transmitter to
+    // gate, and the engine TX guard refuses keying on this alone.
+    c.canTransmit = false;
+    c.txPowerMaxWatts = 0.0;
+    // RX-only must NOT open the mic on connect (#4449 review).
+    c.hostModulates = false;
+    c.persistsMemories = false;   // client-side memory bank engages
+    c.canReboot = false;
+    c.hasTuner = false;
+    c.hasAmplifier = false;
+    c.hasExtendedDsp = false;
+    c.hasProfiles = false;        // no on-device configuration store
+    c.hasDaxStreams = false;      // one raw IQ feed, demodulated here
+    c.hasRadioSideDsp = false;    // every noise module runs on this host
+    c.hasRadioSideWaterfallAutoBlack = false;
+    c.hasWaveforms = false;
+    c.hasMultiClientSessions = false;   // the DLL owns the device exclusively
+    c.hasGpsLocation = false;
+    c.hasSupplyVoltageTelemetry = false;
+    // The device persists NOTHING across unplugs — the client is its memory
+    // (RFC #4603). No TxSetpoints: there is no transmitter to have setpoints.
+    c.clientSettingsDomains = RadioCapabilities::ClientSettingsDomain::Tuning
+                            | RadioCapabilities::ClientSettingsDomain::Passband
+                            | RadioCapabilities::ClientSettingsDomain::SpanRate
+                            | RadioCapabilities::ClientSettingsDomain::RfGain
+                            | RadioCapabilities::ClientSettingsDomain::Memories;
+    return c;
+}
+
+void ColibriBackend::applyRestoredState(const RestoredRadioState& state)
+{
+    // Validated at this boundary (Principle VII): a corrupt document must not
+    // reach the UI and re-persist itself through capture.
+    m_restoredState = RestoredRadioState{};
+    m_haveRestoredState = !state.isEmpty();
+    if (!m_haveRestoredState)
+        return;
+
+    RestoredRadioState& s = m_restoredState;
+    if (state.rfFrequencyHz >= kTuningMinHz && state.rfFrequencyHz <= kTuningMaxHz)
+        s.rfFrequencyHz = state.rfFrequencyHz;
+    if (isKnownModeString(state.mode))
+        s.mode = state.mode;
+    // The passband pair is only meaningful together and bounded by what the
+    // audio chain can pass.
+    if (state.filterLowHz != 0.0 && state.filterHighHz != 0.0
+        && state.filterLowHz < state.filterHighHz
+        && std::abs(state.filterLowHz) <= 45000.0
+        && std::abs(state.filterHighHz) <= 45000.0) {
+        s.filterLowHz = state.filterLowHz;
+        s.filterHighHz = state.filterHighHz;
+    }
+    if (colibriSampleRateIndex(state.sampleRateHz) >= 0)
+        s.sampleRateHz = state.sampleRateHz;
+    // rfGain extension: {"preampDb": double} — ours to write, ours to check.
+    const QJsonObject rfGain =
+        state.extension.value(QStringLiteral("rfGain")).toObject();
+    if (rfGain.contains(QStringLiteral("preampDb"))) {
+        const double db = rfGain.value(QStringLiteral("preampDb")).toDouble();
+        if (db >= kPreampMinDb - 0.5 && db <= kPreampMaxDb) {
+            QJsonObject mine;
+            mine.insert(QStringLiteral("preampDb"), db);
+            s.extension.insert(QStringLiteral("rfGain"), mine);
+        }
+    }
+}
+
+RestoredRadioState ColibriBackend::currentOperatingState() const
+{
+    RestoredRadioState s;
+    s.rfFrequencyHz = m_sliceFreqHz;
+    s.mode = m_mode;
+    s.filterLowHz = m_filterLowHz;
+    s.filterHighHz = m_filterHighHz;
+    s.sampleRateHz = m_sampleRateHz;
+    QJsonObject rfGain;
+    rfGain.insert(QStringLiteral("preampDb"), m_preampDb);
+    s.extension.insert(QStringLiteral("rfGain"), rfGain);
+    s.extensionSchemaVersion = 1;
+    return s;
+}
+
+void ColibriBackend::connectRadio(const RadioConnectRequest& request)
+{
+    m_passbandDerivedThisConnect = false;
+
+    // The span the operator last chose (family-wide fallback), then the
+    // per-radio restored rate, then the explicit automation/test param —
+    // same precedence ladder as HL2.
+    if (const double remembered = ColibriSettings::spanMhz(); remembered > 0.0)
+        m_sampleRateHz = nearestSampleRateHz(remembered * 1.0e6);
+    if (m_haveRestoredState && m_restoredState.sampleRateHz > 0)
+        m_sampleRateHz = m_restoredState.sampleRateHz;
+    if (request.params.contains(QStringLiteral("sampleRateHz"))) {
+        const int hz = request.params.value(QStringLiteral("sampleRateHz")).toInt();
+        if (colibriSampleRateIndex(hz) >= 0)
+            m_sampleRateHz = hz;
+    }
+
+    if (m_haveRestoredState) {
+        if (m_restoredState.rfFrequencyHz > 0.0) {
+            m_sliceFreqHz = m_restoredState.rfFrequencyHz;
+            m_ncoHz = m_sliceFreqHz;
+        }
+        if (!m_restoredState.mode.isEmpty())
+            m_mode = m_restoredState.mode;
+        if (m_restoredState.filterLowHz != 0.0 || m_restoredState.filterHighHz != 0.0) {
+            m_filterLowHz = static_cast<int>(m_restoredState.filterLowHz);
+            m_filterHighHz = static_cast<int>(m_restoredState.filterHighHz);
+            // The restored passband IS this connect's passband; the per-mode
+            // derivation must not overwrite it (#4484 shape).
+            m_passbandDerivedThisConnect = true;
+        }
+        const QJsonObject rfGain =
+            m_restoredState.extension.value(QStringLiteral("rfGain")).toObject();
+        if (rfGain.contains(QStringLiteral("preampDb")))
+            m_preampDb = rfGain.value(QStringLiteral("preampDb")).toDouble();
+    }
+    if (request.params.contains(QStringLiteral("rxFrequencyHz"))) {
+        m_sliceFreqHz =
+            request.params.value(QStringLiteral("rxFrequencyHz")).toDouble();
+        m_ncoHz = m_sliceFreqHz;
+    }
+    if (request.params.contains(QStringLiteral("preampDb")))
+        m_preampDb = request.params.value(QStringLiteral("preampDb")).toDouble();
+    m_preampDb = std::clamp(m_preampDb,
+                            static_cast<double>(kPreampMinDb),
+                            static_cast<double>(kPreampMaxDb));
+
+    // ---- build the DSP BEFORE the stream starts ----
+    //
+    // Same order rule as HL2: opening a WDSP channel can be slow (first-run
+    // FFTW wisdom), and the DSP must already expect the stream's rate before
+    // blocks arrive. Configure blocking on the I/O thread, publish to the
+    // sample path, THEN open the device.
+    if (m_rxDsp) {
+        // A reconnect without a teardown: withdraw from the sample path and
+        // replace, never reconfigure a chain that might still be fed.
+        publishIoDsp(nullptr);
+        m_rxDsp->deleteLater();
+        m_rxDsp = nullptr;
+    }
+    auto* dsp = new ColibriRxDsp(nullptr);   // no parent: moveToThread refuses one
+    dsp->moveToThread(m_ioThread);
+
+    connect(dsp, &ColibriRxDsp::spectrumReady, this,
+            [this](const std::vector<float>& bins) {
+        // dBFS -> displayed dBm: one constant offset minus the preamp, so a
+        // gain change cannot move the trace (the signals did not move).
+        const double off = kFullScaleDbm - m_preampDb;
+        std::vector<float> dbm(bins.size());
+        for (std::size_t i = 0; i < bins.size(); ++i)
+            dbm[i] = static_cast<float>(bins[i] + off);
+        // The seam's spectrum feed is keyed by the slice/pan NUMBER (0), the
+        // same convention Hl2Backend uses for its first receiver.
+        emit spectrumFrameReady(0, floatBytes(dbm));
+    });
+    connect(dsp, &ColibriRxDsp::audioReady, this,
+            [this](const std::vector<float>& pcm) { routeAudio(pcm); });
+    connect(dsp, &ColibriRxDsp::meterUpdate, this, [this](float dbfs) {
+        const double dbm = dbfsToDbm(dbfs);
+        // Smooth EVERY sample, publish only on the tick — the published value
+        // then represents the whole interval rather than one instant, and the
+        // widget is not repainted ~47 times a second.
+        if (!m_haveSMeter) {
+            m_sMeterDbm = dbm;
+            m_haveSMeter = true;
+        } else {
+            const double alpha = (dbm > m_sMeterDbm) ? kMeterAttackAlpha
+                                                     : kMeterDecayAlpha;
+            m_sMeterDbm = alpha * dbm + (1.0 - alpha) * m_sMeterDbm;
+        }
+        if (m_sMeterClock.isValid()
+            && m_sMeterClock.elapsed() < kMeterPublishIntervalMs)
+            return;
+        m_sMeterClock.restart();
+        emit meterUpdate(QStringLiteral("SLC:LEVEL"), m_sMeterDbm);
+    });
+
+    ColibriRxDsp::Config dc;
+    dc.inputSampleRateHz = m_sampleRateHz;
+    dc.audioSampleRateHz = 24000;   // AudioEngine's native RX rate
+    dc.mode = modeFromString(m_mode);
+    dc.filterLowHz = m_filterLowHz;
+    dc.filterHighHz = m_filterHighHz;
+    dc.agcMode = wdspAgcMode(m_agcMode);
+    dc.maximumAgcGainDb = m_agcThresholdDb * kAgcCeilingDbPerUnit;
+    dc.wireAnalytic = ColibriSettings::wireAnalytic();
+
+    std::string err;
+    bool ok = false;
+    QMetaObject::invokeMethod(dsp, [dsp, &dc, &err, &ok] {
+        ok = dsp->configure(dc, &err);
+    }, Qt::BlockingQueuedConnection);
+    if (!ok) {
+        dsp->deleteLater();
+        emit connectionError(QStringLiteral("ColibriNANO: DSP chain failed — %1")
+                                 .arg(QString::fromStdString(err)));
+        return;
+    }
+    m_rxDsp = dsp;
+    publishIoDsp(dsp);
+
+    // The slice starts wherever the NCO starts; no shift until the operator
+    // tunes off-centre.
+    QMetaObject::invokeMethod(dsp, "setShift", Qt::QueuedConnection,
+        Q_ARG(double, m_sliceFreqHz - m_ncoHz));
+
+    ColibriDevice::Params p;
+    p.dllPath = ColibriSettings::dllPath();
+    if (request.params.contains(QStringLiteral("dllPath")))
+        p.dllPath = request.params.value(QStringLiteral("dllPath")).toString();
+    // "colibrinano-<n>" from discovery; a malformed serial falls back to 0.
+    const QString serial = request.serial;
+    const qsizetype dash = serial.lastIndexOf(QLatin1Char('-'));
+    if (dash >= 0)
+        p.deviceIndex = serial.mid(dash + 1).toUInt();
+    p.sampleRateHz = m_sampleRateHz;
+    p.frequencyHz = m_ncoHz;
+    p.preampDb = m_preampDb;
+
+    qCInfo(lcColibri) << "connecting: device" << p.deviceIndex << "rate"
+                      << p.sampleRateHz << "Hz, NCO" << p.frequencyHz << "Hz";
+    QMetaObject::invokeMethod(m_device, [dev = m_device, p] {
+        dev->openDevice(p);
+    }, Qt::QueuedConnection);
+}
+
+void ColibriBackend::disconnectRadio()
+{
+    QMetaObject::invokeMethod(m_device, &ColibriDevice::closeDevice,
+                              Qt::BlockingQueuedConnection);
+    publishIoDsp(nullptr);
+    if (m_rxDsp) {
+        m_rxDsp->deleteLater();   // lives on the I/O thread; its loop is running
+        m_rxDsp = nullptr;
+    }
+    if (m_connected) {
+        m_connected = false;
+        m_linkStatsTimer->stop();
+        emit disconnected();
+    }
+}
+
+bool ColibriBackend::isConnected() const
+{
+    return m_connected;
+}
+
+bool ColibriBackend::isOurPan(const QString& id) const
+{
+    // An EMPTY pan id addresses the (only) receiver — some seam callers omit
+    // it for a single-pan radio.
+    return id.isEmpty() || id == panId();
+}
+
+void ColibriBackend::publishIoDsp(ColibriRxDsp* dsp)
+{
+    if (m_device && m_ioThread && m_ioThread->isRunning()
+        && QThread::currentThread() != m_ioThread) {
+        // m_device is the handle onto the I/O thread's event loop. BLOCKS so
+        // the caller may destroy the chain that was previously published.
+        QMetaObject::invokeMethod(m_device, [this, dsp] { m_ioDsp = dsp; },
+                                  Qt::BlockingQueuedConnection);
+        return;
+    }
+    // Before the thread starts, after it is joined, or on it: nothing is
+    // reading m_ioDsp concurrently in any of those.
+    m_ioDsp = dsp;
+}
+
+void ColibriBackend::setSliceFrequency(int sliceId, double hz)
+{
+    if (sliceId != 0)
+        return;
+    m_sliceFreqHz = hz;
+
+    // Keep the NCO — and therefore the panadapter centre — where it is, and
+    // put the slice at an offset inside the passband. Only when the target
+    // would fall outside the usable window does the NCO move (and then it
+    // re-centres on the target). Same decoupling as HL2: without it the whole
+    // display slides under the cursor on every click.
+    const double halfSpanHz = static_cast<double>(m_sampleRateHz) / 2.0;
+    const double usableHz = halfSpanHz * kUsablePassbandFraction;
+    if (std::abs(hz - m_ncoHz) > usableHz) {
+        m_ncoHz = hz;
+        QMetaObject::invokeMethod(m_device, [dev = m_device, hz] {
+            dev->setFrequencyHz(hz);
+        }, Qt::QueuedConnection);
+    }
+
+    if (m_rxDsp)
+        QMetaObject::invokeMethod(m_rxDsp, "setShift", Qt::QueuedConnection,
+            Q_ARG(double, m_sliceFreqHz - m_ncoHz));
+
+    emitSliceState();
+    emitPanState();
+    notifyOperatingStateChanged();
+}
+
+void ColibriBackend::setSliceMode(int sliceId, const QString& mode)
+{
+    if (sliceId != 0)
+        return;
+    const QString previous = m_mode;
+    m_mode = mode;
+    const WdspChannel::Mode wdsp = modeFromString(mode);
+
+    // The passband belongs to the mode; we own the DSP, so nothing heals a
+    // stale filter for us. Adopted on CHANGE only, so an operator's own edit
+    // survives until they change mode again.
+    if (!previous.isEmpty() && previous.compare(mode, Qt::CaseInsensitive) != 0) {
+        const auto [lo, hi] = defaultPassbandForMode(mode);
+        m_filterLowHz = lo;
+        m_filterHighHz = hi;
+    }
+
+    // ORDER IS LOAD-BEARING: mode FIRST, then passband, re-pushed on EVERY
+    // mode set — SetRXAMode rebuilds the bandpass from its own per-mode
+    // notion, discarding any filter applied before it (see Hl2Backend for the
+    // USB->DIGU failure this prevents).
+    if (m_rxDsp) {
+        QMetaObject::invokeMethod(m_rxDsp, "setMode", Qt::QueuedConnection,
+            Q_ARG(WdspChannel::Mode, wdsp));
+        QMetaObject::invokeMethod(m_rxDsp, "setFilter", Qt::QueuedConnection,
+            Q_ARG(double, static_cast<double>(m_filterLowHz)),
+            Q_ARG(double, static_cast<double>(m_filterHighHz)));
+    }
+    emitSliceState();
+    notifyOperatingStateChanged();
+}
+
+void ColibriBackend::setSliceFilter(int sliceId, int lowHz, int highHz)
+{
+    if (sliceId != 0)
+        return;
+    m_filterLowHz = lowHz;
+    m_filterHighHz = highHz;
+    if (m_rxDsp)
+        QMetaObject::invokeMethod(m_rxDsp, "setFilter", Qt::QueuedConnection,
+            Q_ARG(double, static_cast<double>(lowHz)),
+            Q_ARG(double, static_cast<double>(highHz)));
+    emitSliceState();
+    notifyOperatingStateChanged();
+}
+
+void ColibriBackend::setSliceAgc(int sliceId, const QString& mode, int thresholdDb)
+{
+    if (sliceId != 0)
+        return;
+    m_agcMode = mode;
+    m_agcThresholdDb = thresholdDb;
+    if (m_rxDsp)
+        QMetaObject::invokeMethod(m_rxDsp, "setAgc", Qt::QueuedConnection,
+            Q_ARG(int, wdspAgcMode(mode)),
+            Q_ARG(double, thresholdDb * kAgcCeilingDbPerUnit));
+    emitSliceState();
+}
+
+void ColibriBackend::setSliceAudioMute(int sliceId, bool mute)
+{
+    if (sliceId != 0)
+        return;
+    m_audioMuted = mute;
+    emitSliceState();
+}
+
+void ColibriBackend::setSliceAudioGain(int sliceId, int gainPercent)
+{
+    if (sliceId != 0)
+        return;
+    // 0..100 -> linear, unity at 100 — the fader's whole travel attenuates,
+    // matching what SliceModel's control means for a host-mixed backend.
+    m_audioGain = static_cast<float>(std::clamp(gainPercent, 0, 100)) / 100.0f;
+    emitSliceState();
+}
+
+void ColibriBackend::setSliceAudioPan(int sliceId, int panPercent)
+{
+    if (sliceId != 0)
+        return;
+    m_audioPanPercent = std::clamp(panPercent, 0, 100);
+    emitSliceState();
+}
+
+void ColibriBackend::setActiveSlice(int sliceId)
+{
+    // One slice; it is always the active one. Nothing to clear.
+    Q_UNUSED(sliceId);
+}
+
+void ColibriBackend::setPanCenter(const QString& id, double hz,
+                                  PanCenterIntent intent)
+{
+    // This receiver's window is its DDC, genuinely independent of the slice,
+    // so a drag and a zoom-carried centre mean the same thing here.
+    Q_UNUSED(intent);
+    if (!isOurPan(id) || hz <= 0.0 || hz == m_ncoHz)
+        return;
+    // Moving the window means moving the NCO. The slice does NOT move with it
+    // — its offset from the new centre is recomputed and re-applied.
+    m_ncoHz = hz;
+    QMetaObject::invokeMethod(m_device, [dev = m_device, hz] {
+        dev->setFrequencyHz(hz);
+    }, Qt::QueuedConnection);
+    if (m_rxDsp)
+        QMetaObject::invokeMethod(m_rxDsp, "setShift", Qt::QueuedConnection,
+            Q_ARG(double, m_sliceFreqHz - m_ncoHz));
+    emitPanState();
+}
+
+void ColibriBackend::setPanBandwidth(const QString& id, double hz)
+{
+    if (!isOurPan(id) || hz <= 0.0)
+        return;
+
+    // Coalesce a zoom sweep (#4470 shape): each span change is a stream
+    // stop/start plus a blocking WDSP rebuild. Leading edge applies now so a
+    // discrete step responds at once.
+    if (!m_bandwidthThrottle) {
+        m_bandwidthThrottle = new QTimer(this);
+        m_bandwidthThrottle->setSingleShot(true);
+        m_bandwidthThrottle->setInterval(kBandwidthThrottleMs);
+        connect(m_bandwidthThrottle, &QTimer::timeout, this, [this] {
+            if (m_pendingBandwidthHz <= 0.0)
+                return;              // cooldown expired with nothing waiting
+            const double pending = m_pendingBandwidthHz;
+            m_pendingBandwidthHz = 0.0;
+            applyPanBandwidth(pending);
+            m_bandwidthThrottle->start();   // a sweep in progress keeps coalescing
+        });
+    }
+    if (m_bandwidthThrottle->isActive()) {
+        m_pendingBandwidthHz = hz;   // superseded by any later request
+        return;
+    }
+    applyPanBandwidth(hz);
+    m_bandwidthThrottle->start();
+}
+
+void ColibriBackend::applyPanBandwidth(double hz)
+{
+    const int rate = nearestSampleRateHz(hz);
+    if (rate == m_sampleRateHz) {
+        // Still re-publish: a zoom the hardware cannot honour must not leave
+        // the display on the requested span — re-emitting the unchanged span
+        // is how the widget snaps back to what is real (#4470).
+        emitPanState();
+        return;
+    }
+    if (!m_connected || !m_rxDsp) {
+        m_sampleRateHz = rate;   // pre-connect: just adopt it for connect time
+        emitPanState();
+        return;
+    }
+
+    const int previousRate = m_sampleRateHz;
+    m_sampleRateHz = rate;
+
+    // ORDER: stop the stream, reconfigure the DSP, restart at the new rate —
+    // all three serialized on the I/O thread's event loop, so blocks already
+    // queued at the old rate drain into the old configuration first, and the
+    // first block at the new rate meets a chain already expecting it.
+    bool streamOk = false;
+    QMetaObject::invokeMethod(m_device, [dev = m_device, rate, &streamOk] {
+        streamOk = dev->restart(rate);
+    }, Qt::BlockingQueuedConnection);
+
+    ColibriRxDsp::Config dc;
+    dc.inputSampleRateHz = m_sampleRateHz;
+    dc.audioSampleRateHz = 24000;
+    dc.mode = modeFromString(m_mode);
+    dc.filterLowHz = m_filterLowHz;
+    dc.filterHighHz = m_filterHighHz;
+    // Carried through the rebuild rather than reapplied afterwards — a
+    // reconfigured channel opens on Config defaults otherwise.
+    dc.agcMode = wdspAgcMode(m_agcMode);
+    dc.maximumAgcGainDb = m_agcThresholdDb * kAgcCeilingDbPerUnit;
+    dc.wireAnalytic = ColibriSettings::wireAnalytic();
+    std::string err;
+    bool dspOk = false;
+    ColibriRxDsp* dsp = m_rxDsp;
+    QMetaObject::invokeMethod(dsp, [dsp, &dc, &err, &dspOk] {
+        dspOk = dsp->configure(dc, &err);
+    }, Qt::BlockingQueuedConnection);
+
+    if (!streamOk || !dspOk) {
+        // Fail back to the old rate so the wire and the DSP keep agreeing —
+        // a rate split is silent wrong audio, not an error anything reports.
+        qCWarning(lcColibri) << "span change to" << rate << "Hz failed"
+                             << (streamOk ? "" : "(stream)")
+                             << (dspOk ? "" : QString::fromStdString(err))
+                             << "— staying at" << previousRate << "Hz";
+        m_sampleRateHz = previousRate;
+        QMetaObject::invokeMethod(m_device, [dev = m_device, previousRate] {
+            dev->restart(previousRate);
+        }, Qt::BlockingQueuedConnection);
+        dc.inputSampleRateHz = previousRate;
+        QMetaObject::invokeMethod(dsp, [dsp, &dc, &err] {
+            std::string e;
+            dsp->configure(dc, &e);
+        }, Qt::BlockingQueuedConnection);
+    } else {
+        ColibriSettings::setSpanMhz(m_sampleRateHz / 1.0e6);
+        qCInfo(lcColibri) << "span:" << m_sampleRateHz << "Hz";
+    }
+    emitPanState();
+    notifyOperatingStateChanged();
+}
+
+void ColibriBackend::setPanRfGain(const QString& id, int gainDb)
+{
+    if (!isOurPan(id))
+        return;
+    applyPreampDb(std::clamp(gainDb, kPreampMinDb, kPreampMaxDb));
+    notifyOperatingStateChanged();
+}
+
+void ColibriBackend::applyPreampDb(double db)
+{
+    if (db == m_preampDb)
+        return;
+    m_preampDb = db;
+    QMetaObject::invokeMethod(m_device, [dev = m_device, db] {
+        dev->setPreampDb(db);
+    }, Qt::QueuedConnection);
+    emit panRfGainChanged(panId(), static_cast<int>(std::lround(m_preampDb)));
+}
+
+void ColibriBackend::setPanFrameRate(const QString& id, int fps)
+{
+    if (!isOurPan(id) || !m_rxDsp)
+        return;
+    QMetaObject::invokeMethod(m_rxDsp, "setSpectrumRateFps", Qt::QueuedConnection,
+        Q_ARG(int, fps));
+}
+
+void ColibriBackend::setKeying(bool key)
+{
+    // RX-only (RFC §5.5 Q3): the capability already made the engine guard
+    // refuse this; getting here at all is a caller ignoring it.
+    if (key)
+        qCWarning(lcColibri) << "keying refused: the ColibriNANO is a receiver";
+}
+
+void ColibriBackend::invokeExtension(const QString& ns, const QString& verb,
+                                     quint64 requestId, const QVariant& arg)
+{
+    Q_UNUSED(arg);
+    if (requestId == 0)
+        return;
+    emit extensionError(requestId,
+                        QStringLiteral("unknown extension %1.%2").arg(ns, verb));
+}
+
+void ColibriBackend::routeAudio(const std::vector<float>& pcm)
+{
+    // THIS SLICE's audio, pre-mute and pre-gain — a decoder consumer must not
+    // stop decoding because the operator muted the speaker.
+    emit sliceAudioFrameReady(0, floatBytes(pcm));
+
+    if (m_audioMuted)
+        return;
+    if (m_audioGain == 1.0f && m_audioPanPercent == kAudioPanCentre) {
+        emit audioFrameReady(floatBytes(pcm));   // steady state: no copy
+        return;
+    }
+    // Balance is a BALANCE, not a constant-power pan: centre leaves both
+    // channels at unity rather than dipping them 3 dB.
+    const float left = m_audioPanPercent > kAudioPanCentre
+        ? static_cast<float>(100 - m_audioPanPercent) / 50.0f : 1.0f;
+    const float right = m_audioPanPercent < kAudioPanCentre
+        ? static_cast<float>(m_audioPanPercent) / 50.0f : 1.0f;
+    m_audioScratch.resize(pcm.size());
+    for (std::size_t i = 0; i + 1 < pcm.size(); i += 2) {
+        m_audioScratch[i] = pcm[i] * m_audioGain * left;
+        m_audioScratch[i + 1] = pcm[i + 1] * m_audioGain * right;
+    }
+    emit audioFrameReady(floatBytes(m_audioScratch));
+}
+
+double ColibriBackend::dbfsToDbm(double dbfs) const
+{
+    return dbfs + kFullScaleDbm - m_preampDb;
+}
+
+void ColibriBackend::emitSliceState()
+{
+    SliceDelta d;
+    d.panId = panId();
+    d.frequency = m_sliceFreqHz / 1.0e6;   // MHz
+    d.mode = m_mode;
+    d.filterLow = m_filterLowHz;
+    d.filterHigh = m_filterHighHz;
+    d.agcMode = m_agcMode;
+    d.agcThreshold = m_agcThresholdDb;
+    d.audioMute = m_audioMuted;
+    d.audioPan = m_audioPanPercent;
+    // ONE slice: always active, never the TX slice — there is no transmitter
+    // for an interlock to find. Explicit false rather than unset, so nothing
+    // upstream is left resolving an absent answer.
+    d.active = true;
+    d.txSlice = false;
+    emit sliceChanged(0, d);
+}
+
+void ColibriBackend::emitPanState()
+{
+    // The pan centre is the NCO, NOT the slice — the display describes where
+    // the receiver's window is, and the slice moves inside it.
+    emit panCenterBandwidthChanged(panId(), m_ncoHz / 1.0e6,
+                                   static_cast<double>(m_sampleRateHz) / 1.0e6);
+}
+
+void ColibriBackend::pushInitialState()
+{
+    // Derive the passband from the mode ONCE per connect (#4484): a fresh
+    // connect must not come up with another mode's filter, and a restored
+    // passband must not be overwritten by the derivation.
+    if (!m_passbandDerivedThisConnect) {
+        m_passbandDerivedThisConnect = true;
+        const auto [lo, hi] = defaultPassbandForMode(m_mode);
+        m_filterLowHz = lo;
+        m_filterHighHz = hi;
+    }
+    if (m_rxDsp) {
+        QMetaObject::invokeMethod(m_rxDsp, "setMode", Qt::QueuedConnection,
+            Q_ARG(WdspChannel::Mode, modeFromString(m_mode)));
+        QMetaObject::invokeMethod(m_rxDsp, "setFilter", Qt::QueuedConnection,
+            Q_ARG(double, static_cast<double>(m_filterLowHz)),
+            Q_ARG(double, static_cast<double>(m_filterHighHz)));
+    }
+}
+
+void ColibriBackend::defineMeters()
+{
+    // Indices are ours to choose — nothing on the device assigns meter ids.
+    MeterDef d;
+    d.index = 1;
+    d.source = QStringLiteral("SLC");
+    d.name = QStringLiteral("LEVEL");
+    d.unit = QStringLiteral("dBm");
+    d.low = -140.0;
+    d.high = 0.0;
+    d.description = QStringLiteral("Receive signal level (uncalibrated)");
+    emit meterDefined(d);
+}
+
+void ColibriBackend::publishLinkStats()
+{
+    LinkStats s = linkStats();
+    // Fresh blocks since the last tick — the transport proof-of-life the
+    // heartbeat runs on. Computed HERE rather than in linkStats() because the
+    // comparison CONSUMES the previous value, and linkStats() is a const
+    // getter any caller may poll at any rate.
+    const quint64 blocks = m_device ? m_device->blocksReceived() : 0;
+    s.alive = m_connected && blocks != m_linkBlocksAtLastTick;
+    m_linkBlocksAtLastTick = blocks;
+    emit linkStatsUpdated(s);
+}
+
+IRadioBackend::LinkStats ColibriBackend::linkStats() const
+{
+    LinkStats s;
+    s.reported = m_connected;
+    if (!m_connected || !m_device)
+        return s;
+    s.rxPackets = m_device->blocksReceived();
+    s.rxBytes = static_cast<qint64>(m_device->samplesReceived() * sizeof(float) * 2);
+    s.txBytes = 0;
+    // No request/response exchange to time on a one-way USB stream: NOT
+    // MEASURED, which must not render as zero.
+    s.rttMs = -1;
+    s.jitterMs = -1;
+    s.localEndpoint = QStringLiteral("usb");
+    return s;
+}
+
+IRadioBackend::HealthSnapshot ColibriBackend::healthSnapshot() const
+{
+    HealthSnapshot h;
+    auto put = [&h](const QString& key, const QVariant& value, const QString& label) {
+        h.values.insert(key, value);
+        h.order.append(key);
+        h.labels.insert(key, label);
+    };
+    auto& lib = ColibriLib::instance();
+    if (lib.isLoaded()) {
+        std::uint32_t maj = 0, min = 0, pat = 0;
+        lib.version(maj, min, pat);
+        put(QStringLiteral("libVersion"),
+            QStringLiteral("%1.%2.%3").arg(maj).arg(min).arg(pat),
+            QStringLiteral("Library version"));
+        put(QStringLiteral("libPath"), lib.libraryPath(),
+            QStringLiteral("Library path"));
+    }
+    put(QStringLiteral("sampleRate"),
+        QStringLiteral("%1 kHz").arg(m_sampleRateHz / 1000),
+        QStringLiteral("IQ sample rate"));
+    put(QStringLiteral("preamp"), QStringLiteral("%1 dB").arg(m_preampDb),
+        QStringLiteral("Preamp"));
+    if (m_device) {
+        put(QStringLiteral("samples"),
+            static_cast<qulonglong>(m_device->samplesReceived()),
+            QStringLiteral("IQ samples received"));
+        // "0" and "we never heard" differ on a health readout; the flag rides
+        // every block, so while connected it is always current.
+        if (m_connected)
+            put(QStringLiteral("adcOverload"),
+                m_device->adcOverload() ? QStringLiteral("OVERLOAD")
+                                        : QStringLiteral("ok"),
+                QStringLiteral("ADC"));
+    }
+    h.sections.insert(h.order.isEmpty() ? QString{} : h.order.first(),
+                      QStringLiteral("ColibriNANO"));
+    return h;
+}
+
+void ColibriBackend::notifyOperatingStateChanged()
+{
+    emit operatingStateChanged();
+}
+
+}  // namespace AetherSDR::colibri

--- a/src/core/backends/colibri/ColibriBackend.h
+++ b/src/core/backends/colibri/ColibriBackend.h
@@ -1,0 +1,209 @@
+#pragma once
+
+#include "core/backends/IRadioBackend.h"
+#include "core/dsp/WdspChannel.h"
+
+#include <QElapsedTimer>
+#include <QString>
+#include <QThread>
+#include <QTimer>
+
+#include <vector>
+
+namespace AetherSDR::colibri {
+
+class ColibriDevice;
+class ColibriRxDsp;
+
+// IRadioBackend implementation for the Expert Electronics ColibriNANO
+// (USB direct-sampling receiver, raw IQ via colibrinano_lib). Owns a
+// ColibriDevice (the DLL wire) and a ColibriRxDsp (demod + panadapter) and
+// maps the neutral seam verbs/signals onto them — the second backend after
+// HL2 that owns an engine-side DSP chain (RFC §5.5), and the first that is
+// RECEIVE-ONLY: capabilities().canTransmit is a constant false, setKeying()
+// is a guarded no-op, and the engine TX guard above the seam refuses keying
+// on the capability alone.
+//
+// ONE receiver, fixed: the device has a single DDC, so maxSlices and
+// maxPanadapters are 1, the pan id is kPanId, the slice id is 0, and HL2's
+// four-space index map collapses to constants.
+//
+// The wire and the DSP run on a dedicated I/O thread. The DLL's RX callback
+// arrives on the LIBRARY's own thread and is queued onto the I/O thread at
+// the ColibriDevice boundary — see that header for why the extra hop is not
+// optional.
+class ColibriBackend : public IRadioBackend {
+    Q_OBJECT
+
+public:
+    explicit ColibriBackend(QObject* parent = nullptr);
+    ~ColibriBackend() override;
+
+    RadioCapabilities capabilities() const override;
+    // Demodulates in-process (ColibriRxDsp); there is no VITA-49 stream at all.
+    // Like HL2, audio reaches the engine through the RadioModel relay — see
+    // MainWindow::backendFeedsEngineDirectly() before "simplifying" either.
+    bool ownsRxAudio() const override { return true; }
+
+    void connectRadio(const RadioConnectRequest& request) override;
+    void applyRestoredState(const RestoredRadioState& state) override;
+    RestoredRadioState currentOperatingState() const override;
+    void disconnectRadio() override;
+    bool isConnected() const override;
+
+    void setSliceFrequency(int sliceId, double hz) override;
+    void setSliceMode(int sliceId, const QString& mode) override;
+    void setSliceFilter(int sliceId, int lowHz, int highHz) override;
+    void setSliceAgc(int sliceId, const QString& mode, int thresholdDb) override;
+    void setSliceAudioMute(int sliceId, bool mute) override;
+    void setSliceAudioGain(int sliceId, int gainPercent) override;
+    void setSliceAudioPan(int sliceId, int panPercent) override;
+    void setActiveSlice(int sliceId) override;
+    void setPanCenter(const QString& panId, double hz,
+                      PanCenterIntent intent) override;
+    void setPanBandwidth(const QString& panId, double hz) override;
+    void setPanRfGain(const QString& panId, int gainDb) override;
+    void setPanFrameRate(const QString& panId, int fps) override;
+    // RX-only: keying is refused above the seam (canTransmit=false); this is
+    // the RFC §5.5 Q3 guarded no-op.
+    void setKeying(bool key) override;
+    void invokeExtension(const QString& ns, const QString& verb, quint64 requestId,
+                         const QVariant& arg) override;
+
+    HealthSnapshot healthSnapshot() const override;
+    LinkStats linkStats() const override;
+
+    static QString familyName() { return QStringLiteral("colibri"); }
+
+private:
+    // The seam's pan identifier for the one receiver.
+    static QString panId() { return QStringLiteral("colibri-0"); }
+    [[nodiscard]] bool isOurPan(const QString& id) const;
+
+    // The actual span change, after the throttle has settled: stop the
+    // stream, reconfigure the DSP at the new rate, restart the stream.
+    void applyPanBandwidth(double hz);
+    void applyPreampDb(double db);
+
+    void emitSliceState();
+    void emitPanState();
+    void pushInitialState();
+    void defineMeters();
+    // Publish linkStats() on the fixed cadence the seam promises — a timer
+    // here rather than the receive path, so the tick survives the device
+    // going silent (which is the case the heartbeat has to detect).
+    void publishLinkStats();
+    void notifyOperatingStateChanged();
+    // Route one demodulated block to the seam: per-slice feed raw, speaker
+    // feed with the operator's mute/gain/balance applied.
+    void routeAudio(const std::vector<float>& pcm);
+    // dBFS -> displayed dBm. Uncalibrated: a constant full-scale estimate
+    // minus the preamp gain, which is exactly right in the one way that
+    // matters — the trace and meter hold still across a gain change.
+    [[nodiscard]] double dbfsToDbm(double dbfs) const;
+
+    // Hand the I/O thread the DSP pointer (or null). Same ownership split as
+    // HL2's publishIoDsps: m_rxDsp is GUI-thread state, m_ioDsp is read only
+    // on the I/O thread, and the copy is what keeps the sample path lock-free.
+    // BLOCKS until the I/O thread has taken the new value.
+    void publishIoDsp(ColibriRxDsp* dsp);
+
+    // ---- objects on the I/O thread ----
+    ColibriDevice* m_device = nullptr;
+    ColibriRxDsp* m_rxDsp = nullptr;    // GUI-thread handle; created per connect
+    ColibriRxDsp* m_ioDsp = nullptr;    // I/O THREAD ONLY — the chain the wire feeds
+    QThread* m_ioThread = nullptr;
+
+    // ---- authoritative RX state (no status wire echoes anything back) ----
+    bool m_connected = false;
+    double m_sliceFreqHz = 7'074'000.0;   // slice — FT8 on 40 m, this station's habit
+    double m_ncoHz = 7'074'000.0;         // DDC / pan centre
+    QString m_mode = QStringLiteral("USB");
+    int m_filterLowHz = 150;
+    int m_filterHighHz = 3000;
+    QString m_agcMode = QStringLiteral("med");
+    int m_agcThresholdDb = 65;
+    bool m_audioMuted = false;
+    float m_audioGain = 1.0f;
+    int m_audioPanPercent = 50;
+    int m_sampleRateHz = 48000;
+    double m_preampDb = 0.0;
+    bool m_passbandDerivedThisConnect = false;
+
+    // S-meter ballistics: smooth every sample, publish on the tick (same
+    // attack/decay as Flex's MeterModel so the needle behaves the same way).
+    QElapsedTimer m_sMeterClock;
+    double m_sMeterDbm = 0.0;
+    bool m_haveSMeter = false;
+
+    // Audio scratch for the speaker path (gain/balance applied).
+    std::vector<float> m_audioScratch;
+
+    // Link stats, published on a fixed cadence.
+    QTimer* m_linkStatsTimer = nullptr;
+    quint64 m_linkBlocksAtLastTick = 0;
+    static constexpr int kLinkStatsIntervalMs = 1000;
+
+    // Zoom-sweep throttle (same shape as HL2 #4470): a span change here is a
+    // stream stop/start plus a blocking WDSP rebuild, and a drag delivers
+    // requests every ~33 ms.
+    static constexpr int kBandwidthThrottleMs = 150;
+    QTimer* m_bandwidthThrottle = nullptr;
+    double m_pendingBandwidthHz = 0.0;   // 0 = nothing coalesced
+
+    // RFC #4603 restored state.
+    bool m_haveRestoredState = false;
+    RestoredRadioState m_restoredState;
+
+    // Preamp range, from the library's own documentation (setPream):
+    // -31.5..+6 dB in 0.5 dB steps. The seam's gain verb is integer dB, so
+    // the advertised range is the integer subset.
+    static constexpr int kPreampMinDb = -31;
+    static constexpr int kPreampMaxDb = 6;
+    static constexpr int kPreampStepDb = 1;
+
+    // Displayed full-scale estimate, dBm at 0 dB preamp. UNCALIBRATED — the
+    // honest part is that it is one constant, so gain changes cannot move the
+    // trace; the absolute number is an estimate for a direct-sampling ADC
+    // with a full-scale input around a few hundred millivolts.
+    static constexpr double kFullScaleDbm = -10.0;
+
+    // Meter pacing/ballistics — shared numbers with HL2/Flex so an operator
+    // moving between radios sees meters that behave the same way.
+    static constexpr qint64 kMeterPublishIntervalMs = 100;
+    static constexpr double kMeterAttackAlpha = 0.5;
+    static constexpr double kMeterDecayAlpha = 0.15;
+
+    // Fraction of the half-span the slice may occupy before the NCO
+    // re-centres; the outer 20% is filter roll-off.
+    static constexpr double kUsablePassbandFraction = 0.8;
+    // Slice AGC threshold (0..100) -> WDSP gain ceiling in dB (0..90).
+    //
+    // NOT the HL2's 0.6 (a 0..60 dB span). This receiver delivers IQ tens of
+    // dB below an HL2's, so its AGC runs AT the ceiling rather than regulating
+    // below it — which makes this constant, not the AGC loop, what sets the
+    // audio level. Both ends were measured on 20 m with the preamp at +6 dB,
+    // reading the demodulated level off a decoder that reports it:
+    //
+    //   ceiling 78 dB -> rms 0.61, peak 1.0, samples CLIPPING. A clipped FT8
+    //                    slot decodes nothing at all ("zero raw FT rows while
+    //                    RX audio is overdriven, clipped=20/240").
+    //   ceiling 39 dB -> rms 0.0011, peak 0.004. Inaudible, and equally
+    //                    undecodable — 55 dB below the level above.
+    //
+    // 0.9 puts the slice default of 65 at ~58 dB, landing near rms 0.06
+    // (about -24 dBFS), which is the level FT8 decoders are happiest with and
+    // roughly the midpoint of the two measurements. The operator's AGC-T
+    // slider then spans 0..90 dB, with usable travel either side of that.
+    static constexpr double kAgcCeilingDbPerUnit = 0.9;
+    static constexpr int kAudioPanCentre = 50;
+
+    // What the library can be tuned to, from its own documentation: DC-ish to
+    // 500 MHz through Nyquist zones. The first zone (ADC clock 122.88 MHz) is
+    // what the hardware hears without an external filter, and its LPF corner
+    // is what we advertise as the honest ceiling.
+    static constexpr double kTuningMinHz = 9'000.0;
+    static constexpr double kTuningMaxHz = 55'000'000.0;
+};
+
+}  // namespace AetherSDR::colibri

--- a/src/core/backends/colibri/ColibriDevice.cpp
+++ b/src/core/backends/colibri/ColibriDevice.cpp
@@ -1,0 +1,168 @@
+#include "core/backends/colibri/ColibriDevice.h"
+
+#include <QLoggingCategory>
+#include <QMetaType>
+
+#include <algorithm>
+
+Q_LOGGING_CATEGORY(lcColibriDev, "aether.colibri.device")
+
+namespace AetherSDR::colibri {
+
+ColibriDevice::ColibriDevice(QObject* parent) : QObject(parent)
+{
+    // iqBlockReady crosses from the library's thread to the I/O thread as a
+    // queued connection; without the registration Qt drops the emission with
+    // only a warning.
+    qRegisterMetaType<std::vector<std::complex<float>>>(
+        "std::vector<std::complex<float>>");
+    qRegisterMetaType<ColibriDevice::Params>(
+        "AetherSDR::colibri::ColibriDevice::Params");
+}
+
+ColibriDevice::~ColibriDevice()
+{
+    closeDevice();
+}
+
+bool COLIBRI_CALL ColibriDevice::onRx(ColibriComplex* iq, std::uint32_t len,
+                                      bool adcOverload, void* user)
+{
+    auto* self = static_cast<ColibriDevice*>(user);
+    if (!self || !self->m_acceptBlocks.load(std::memory_order_acquire))
+        return false;   // stop delivering; the stream is being torn down
+
+    self->m_samples.fetch_add(len, std::memory_order_relaxed);
+    self->m_blocks.fetch_add(1, std::memory_order_relaxed);
+    if (self->m_adcOverload.exchange(adcOverload, std::memory_order_relaxed)
+        != adcOverload) {
+        emit self->adcOverloadChanged(adcOverload);
+    }
+
+    // ColibriComplex and std::complex<float> are layout-identical (two floats,
+    // re then im), so this is one copy into the signal payload and nothing
+    // else on the library's thread.
+    std::vector<std::complex<float>> block(len);
+    if (len > 0)
+        std::copy_n(reinterpret_cast<const std::complex<float>*>(iq), len,
+                    block.begin());
+    emit self->iqBlockReady(block);
+    return true;
+}
+
+void ColibriDevice::openDevice(const Params& params)
+{
+    if (m_dev) {
+        emit openFailed(QStringLiteral("ColibriNANO already open"));
+        return;
+    }
+
+    auto& lib = ColibriLib::instance();
+    QString error;
+    if (!lib.ensureLoaded(params.dllPath, &error)) {
+        emit openFailed(error);
+        return;
+    }
+
+    const int srIndex = colibriSampleRateIndex(params.sampleRateHz);
+    if (srIndex < 0) {
+        emit openFailed(QStringLiteral("unsupported sample rate %1 Hz")
+                            .arg(params.sampleRateHz));
+        return;
+    }
+
+    if (!lib.open(&m_dev, params.deviceIndex) || !m_dev) {
+        m_dev = nullptr;
+        emit openFailed(QStringLiteral("could not open ColibriNANO #%1 "
+                                       "(unplugged, or in use by another program?)")
+                            .arg(params.deviceIndex));
+        return;
+    }
+    // Latched for the whole open lifetime, so the discovery poll never
+    // enumerates the FTDI bus under our running stream.
+    lib.setDeviceInUse(true);
+
+    m_frequencyHz = params.frequencyHz;
+    m_preampDb = params.preampDb;
+    lib.setFrequency(m_dev, static_cast<std::uint32_t>(std::max(0.0, m_frequencyHz)));
+    lib.setPreamp(m_dev, static_cast<float>(m_preampDb));
+
+    m_samples.store(0);
+    m_blocks.store(0);
+    m_adcOverload.store(false);
+    m_acceptBlocks.store(true, std::memory_order_release);
+    if (!lib.start(m_dev, srIndex, &ColibriDevice::onRx, this)) {
+        m_acceptBlocks.store(false, std::memory_order_release);
+        lib.close(m_dev);
+        m_dev = nullptr;
+        lib.setDeviceInUse(false);
+        emit openFailed(QStringLiteral("ColibriNANO opened but the IQ stream "
+                                       "would not start"));
+        return;
+    }
+    m_streaming = true;
+    qCInfo(lcColibriDev) << "streaming at" << params.sampleRateHz << "Hz, NCO"
+                         << m_frequencyHz << "Hz, preamp" << m_preampDb << "dB";
+    emit opened();
+}
+
+void ColibriDevice::closeDevice()
+{
+    if (!m_dev)
+        return;
+    auto& lib = ColibriLib::instance();
+    // Refuse further blocks BEFORE stop(): the library may already be inside
+    // the callback on its own thread, and the flag is what makes that final
+    // delivery a no-op instead of an emit into a dying stream.
+    m_acceptBlocks.store(false, std::memory_order_release);
+    if (m_streaming) {
+        lib.stop(m_dev);
+        m_streaming = false;
+    }
+    lib.close(m_dev);
+    m_dev = nullptr;
+    lib.setDeviceInUse(false);
+    qCInfo(lcColibriDev) << "closed";
+}
+
+bool ColibriDevice::restart(int sampleRateHz)
+{
+    if (!m_dev)
+        return false;
+    const int srIndex = colibriSampleRateIndex(sampleRateHz);
+    if (srIndex < 0)
+        return false;
+
+    auto& lib = ColibriLib::instance();
+    if (m_streaming) {
+        m_acceptBlocks.store(false, std::memory_order_release);
+        lib.stop(m_dev);
+        m_streaming = false;
+    }
+    m_acceptBlocks.store(true, std::memory_order_release);
+    if (!lib.start(m_dev, srIndex, &ColibriDevice::onRx, this)) {
+        m_acceptBlocks.store(false, std::memory_order_release);
+        qCWarning(lcColibriDev) << "restart at" << sampleRateHz << "Hz failed";
+        return false;
+    }
+    m_streaming = true;
+    qCInfo(lcColibriDev) << "restarted at" << sampleRateHz << "Hz";
+    return true;
+}
+
+void ColibriDevice::setFrequencyHz(double hz)
+{
+    m_frequencyHz = hz;
+    if (m_dev)
+        ColibriLib::instance().setFrequency(
+            m_dev, static_cast<std::uint32_t>(std::max(0.0, hz)));
+}
+
+void ColibriDevice::setPreampDb(double db)
+{
+    m_preampDb = db;
+    if (m_dev)
+        ColibriLib::instance().setPreamp(m_dev, static_cast<float>(db));
+}
+
+}  // namespace AetherSDR::colibri

--- a/src/core/backends/colibri/ColibriDevice.h
+++ b/src/core/backends/colibri/ColibriDevice.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+
+#include <atomic>
+#include <complex>
+#include <cstdint>
+#include <vector>
+
+#include "core/backends/colibri/ColibriLib.h"
+
+namespace AetherSDR::colibri {
+
+// The device half of the Colibri backend: owns the open descriptor and the
+// running IQ stream, standing where MetisClient stands for the HL2. Lives on
+// the backend's I/O thread (created parentless, moveToThread'd).
+//
+// The DLL calls the RX callback from ITS OWN internal thread — not ours. The
+// callback therefore only copies the block and emits iqBlockReady; the
+// connection that feeds the DSP is queued onto this object's (I/O) thread.
+// That single queue hop is the whole thread-safety story of the sample path:
+// nothing downstream of it ever runs on the library's thread.
+class ColibriDevice : public QObject {
+    Q_OBJECT
+
+public:
+    explicit ColibriDevice(QObject* parent = nullptr);
+    ~ColibriDevice() override;
+
+    struct Params {
+        QString dllPath;          // optional override; empty = search defaults
+        std::uint32_t deviceIndex = 0;
+        int sampleRateHz = 48000;
+        double frequencyHz = 7'100'000.0;
+        double preampDb = 0.0;
+    };
+
+    // ---- counters, read by the GUI thread (linkStats/healthSnapshot) ----
+    // Atomics rather than mirrors because they are single values with no
+    // invariant between them; a torn multi-field snapshot is not possible here.
+    [[nodiscard]] std::uint64_t samplesReceived() const { return m_samples.load(); }
+    [[nodiscard]] std::uint64_t blocksReceived() const { return m_blocks.load(); }
+    [[nodiscard]] bool adcOverload() const { return m_adcOverload.load(); }
+
+public slots:
+    // Load the library if needed, open the descriptor, start the stream.
+    // Emits opened() or openFailed(reason).
+    void openDevice(const AetherSDR::colibri::ColibriDevice::Params& params);
+    // Stop + close + release the in-use latch. Idempotent.
+    void closeDevice();
+    // Stop the stream and restart it at a new rate, keeping the descriptor,
+    // frequency and preamp. Returns false (stream stopped, device still open)
+    // if the new rate could not be started — the caller decides whether to
+    // retry the old rate. Invoked blocking from the backend so the caller
+    // knows the stream is already delivering the new rate on return.
+    bool restart(int sampleRateHz);
+
+    void setFrequencyHz(double hz);
+    void setPreampDb(double db);
+
+signals:
+    void opened();
+    void openFailed(const QString& reason);
+    // One IQ block, normalized complex<float>, still in the DLL's wire order.
+    // Emitted from the LIBRARY's thread; every receiver must connect queued
+    // (the default for the cross-thread case) — never DirectConnection.
+    void iqBlockReady(const std::vector<std::complex<float>>& iq);
+    // Change-gated: the flag rides every callback, but only transitions are
+    // worth a cross-thread signal.
+    void adcOverloadChanged(bool overload);
+
+private:
+    static bool COLIBRI_CALL onRx(ColibriComplex* iq, std::uint32_t len,
+                                  bool adcOverload, void* user);
+
+    ColibriDescriptor m_dev = nullptr;
+    bool m_streaming = false;
+    double m_frequencyHz = 7'100'000.0;
+    double m_preampDb = 0.0;
+
+    std::atomic<std::uint64_t> m_samples{0};
+    std::atomic<std::uint64_t> m_blocks{0};
+    std::atomic<bool> m_adcOverload{false};
+    // The callback keeps delivering into a stopped/destroyed object unless the
+    // stream is stopped first, so this latch is belt-and-braces: a false makes
+    // the callback drop the block AND tell the library to stop.
+    std::atomic<bool> m_acceptBlocks{false};
+};
+
+}  // namespace AetherSDR::colibri
+
+Q_DECLARE_METATYPE(AetherSDR::colibri::ColibriDevice::Params)

--- a/src/core/backends/colibri/ColibriDiscovery.cpp
+++ b/src/core/backends/colibri/ColibriDiscovery.cpp
@@ -1,0 +1,101 @@
+#include "core/backends/colibri/ColibriDiscovery.h"
+
+#include "core/backends/colibri/ColibriLib.h"
+#include "core/backends/colibri/ColibriSettings.h"
+
+#include <QHostAddress>
+#include <QLoggingCategory>
+#include <QTimer>
+
+Q_LOGGING_CATEGORY(lcColibriDisc, "aether.colibri.discovery")
+
+namespace AetherSDR::colibri {
+
+ColibriDiscovery::ColibriDiscovery(QObject* parent) : QObject(parent)
+{
+    m_timer = new QTimer(this);
+    connect(m_timer, &QTimer::timeout, this, &ColibriDiscovery::pollNow);
+}
+
+ColibriDiscovery::~ColibriDiscovery() = default;
+
+QString ColibriDiscovery::serialForIndex(int index)
+{
+    return QStringLiteral("colibrinano-%1").arg(index);
+}
+
+void ColibriDiscovery::start(int intervalMs)
+{
+    m_timer->start(intervalMs);
+    pollNow();
+}
+
+void ColibriDiscovery::stop()
+{
+    m_timer->stop();
+}
+
+void ColibriDiscovery::pollNow()
+{
+    auto& lib = ColibriLib::instance();
+
+    // Never enumerate under a running stream — keep what we last saw. The
+    // open device is, by definition, still present.
+    if (lib.deviceInUse())
+        return;
+
+    if (!lib.isLoaded()) {
+        QString error;
+        if (!lib.ensureLoaded(ColibriSettings::dllPath(), &error)) {
+            if (!m_libUnavailableLogged) {
+                // Once, at info rather than warning: a PC without the vendor
+                // library is the normal case for everyone without the device.
+                qCInfo(lcColibriDisc) << "colibrinano_lib unavailable —"
+                                      << error;
+                m_libUnavailableLogged = true;
+            }
+            return;
+        }
+    }
+
+    const int count = static_cast<int>(lib.deviceCount());
+
+    QHash<QString, RadioInfo> now;
+    for (int i = 0; i < count; ++i) {
+        RadioInfo info;
+        info.family = QStringLiteral("colibri");
+        info.name = QStringLiteral("ColibriNANO");
+        info.model = QStringLiteral("ColibriNANO");
+        info.serial = serialForIndex(i);
+        std::uint32_t maj = 0, min = 0, pat = 0;
+        lib.version(maj, min, pat);
+        info.version = QStringLiteral("%1.%2.%3").arg(maj).arg(min).arg(pat);
+        info.versionLabel = QStringLiteral("lib");
+        info.nickname = QStringLiteral("ColibriNANO (USB)");
+        info.address = QHostAddress(QHostAddress::LocalHost);   // synthetic; never dialed
+        info.port = 0;
+        info.status = QStringLiteral("Available");
+        info.inUse = false;
+        info.multiFlexEnabled = false;
+        info.isSystemModel = false;
+        now.insert(info.serial, info);
+    }
+
+    for (auto it = now.cbegin(); it != now.cend(); ++it) {
+        if (m_seen.contains(it.key()))
+            emit radioUpdated(it.value());
+        else {
+            qCInfo(lcColibriDisc) << "found" << it.key();
+            emit radioDiscovered(it.value());
+        }
+    }
+    for (auto it = m_seen.cbegin(); it != m_seen.cend(); ++it) {
+        if (!now.contains(it.key())) {
+            qCInfo(lcColibriDisc) << "lost" << it.key();
+            emit radioLost(it.key());
+        }
+    }
+    m_seen = now;
+}
+
+}  // namespace AetherSDR::colibri

--- a/src/core/backends/colibri/ColibriDiscovery.h
+++ b/src/core/backends/colibri/ColibriDiscovery.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "core/RadioDiscovery.h"   // RadioInfo
+
+#include <QHash>
+#include <QObject>
+#include <QString>
+
+class QTimer;
+
+namespace AetherSDR::colibri {
+
+// ColibriNANO enumeration, shaped to feed the same picker as Flex and HL2
+// discovery: it emits RadioInfo with family="colibri" so ConnectionPanel's
+// existing onRadioDiscovered/onRadioUpdated/onRadioLost slots consume it
+// unchanged. The "address" is LocalHost — synthetic, never dialed, exactly
+// like the sim's demo entry: a USB device has no endpoint to dial.
+//
+// Polling is SUSPENDED while a device is open (ColibriLib::deviceInUse): the
+// vendor library does not document FTDI bus enumeration as safe under a
+// running stream, so the last-seen entries are simply kept until the device
+// is released.
+//
+// The library reports no per-device serial, so identity is the enumeration
+// index: "colibrinano-<n>". Stable enough for one receiver on one PC, which
+// is this device's actual deployment shape.
+class ColibriDiscovery : public QObject {
+    Q_OBJECT
+
+public:
+    explicit ColibriDiscovery(QObject* parent = nullptr);
+    ~ColibriDiscovery() override;
+
+    // Begin periodic polls. Safe to call twice; restarts the cadence. The
+    // library is loaded lazily on the first poll — a PC with no DLL installed
+    // just discovers nothing, once, quietly.
+    void start(int intervalMs = 5000);
+    void stop();
+    void pollNow();
+
+    static QString serialForIndex(int index);
+
+signals:
+    void radioDiscovered(const RadioInfo& info);
+    void radioUpdated(const RadioInfo& info);
+    void radioLost(const QString& serial);
+
+private:
+    QTimer* m_timer = nullptr;
+    QHash<QString, RadioInfo> m_seen;   // keyed by serial
+    bool m_libUnavailableLogged = false;
+};
+
+}  // namespace AetherSDR::colibri

--- a/src/core/backends/colibri/ColibriLib.cpp
+++ b/src/core/backends/colibri/ColibriLib.cpp
@@ -1,0 +1,170 @@
+#include "core/backends/colibri/ColibriLib.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFileInfo>
+#include <QLoggingCategory>
+#include <QMutexLocker>
+
+Q_LOGGING_CATEGORY(lcColibriLib, "aether.colibri.lib")
+
+namespace AetherSDR::colibri {
+
+int colibriSampleRateIndex(int hz) noexcept
+{
+    int i = 0;
+    for (const int rate : kColibriSampleRatesHz) {
+        if (rate == hz)
+            return i;
+        ++i;
+    }
+    return -1;
+}
+
+ColibriLib& ColibriLib::instance()
+{
+    static ColibriLib lib;
+    return lib;
+}
+
+QStringList ColibriLib::candidatePaths(const QString& explicitPath)
+{
+    QStringList paths;
+    if (!explicitPath.isEmpty())
+        paths << explicitPath;
+    // The deployed location: next to the executable, like every other
+    // runtime-loaded DLL this application ships (see NvidiaAfxFilter).
+    const QString appDir = QCoreApplication::applicationDirPath();
+#ifdef Q_OS_WIN
+    const QString base = QStringLiteral("colibrinano_lib.dll");
+#else
+    const QString base = QStringLiteral("libcolibrinano_lib.so");
+#endif
+    paths << QDir(appDir).filePath(base);
+    // Bare name last: lets the OS loader search PATH / LD_LIBRARY_PATH, which
+    // is how a system-wide vendor install is found without us guessing at it.
+    paths << base;
+    return paths;
+}
+
+bool ColibriLib::ensureLoaded(const QString& explicitPath, QString* error)
+{
+    QMutexLocker lock(&m_mutex);
+    if (m_initialized)
+        return true;
+
+    for (const QString& candidate : candidatePaths(explicitPath)) {
+        m_lib.setFileName(candidate);
+        if (m_lib.load()) {
+            m_path = candidate;
+            break;
+        }
+    }
+    if (!m_lib.isLoaded()) {
+        if (error)
+            *error = QStringLiteral("colibrinano_lib not found (tried: %1)")
+                         .arg(candidatePaths(explicitPath).join(QStringLiteral("; ")));
+        return false;
+    }
+
+    auto resolve = [this](const char* name) { return m_lib.resolve(name); };
+    m_initialize = reinterpret_cast<FnVoid>(resolve("initialize"));
+    m_finalize = reinterpret_cast<FnVoid>(resolve("finalize"));
+    m_version = reinterpret_cast<FnVersion>(resolve("version"));
+    m_information = reinterpret_cast<FnInformation>(resolve("information"));
+    m_devices = reinterpret_cast<FnDevices>(resolve("devices"));
+    m_open = reinterpret_cast<FnOpen>(resolve("open"));
+    m_close = reinterpret_cast<FnClose>(resolve("close"));
+    m_start = reinterpret_cast<FnStart>(resolve("start"));
+    m_stop = reinterpret_cast<FnStop>(resolve("stop"));
+    m_setPreamp = reinterpret_cast<FnSetPreamp>(resolve("setPream"));
+    m_setFrequency = reinterpret_cast<FnSetFrequency>(resolve("setFrequency"));
+
+    if (!m_initialize || !m_finalize || !m_version || !m_information || !m_devices
+        || !m_open || !m_close || !m_start || !m_stop || !m_setPreamp
+        || !m_setFrequency) {
+        if (error)
+            *error = QStringLiteral("%1 is not a colibrinano_lib (missing exports)")
+                         .arg(m_path);
+        m_lib.unload();
+        m_path.clear();
+        return false;
+    }
+
+    m_initialize();
+    m_initialized = true;
+
+    std::uint32_t maj = 0, min = 0, pat = 0;
+    m_version(maj, min, pat);
+    qCInfo(lcColibriLib) << "loaded" << m_path
+                         << QStringLiteral("v%1.%2.%3").arg(maj).arg(min).arg(pat);
+    return true;
+}
+
+void ColibriLib::version(std::uint32_t& major, std::uint32_t& minor, std::uint32_t& patch)
+{
+    QMutexLocker lock(&m_mutex);
+    major = minor = patch = 0;
+    if (m_version)
+        m_version(major, minor, patch);
+}
+
+QString ColibriLib::information()
+{
+    QMutexLocker lock(&m_mutex);
+    if (!m_information)
+        return {};
+    char* s = nullptr;
+    m_information(&s);
+    return s ? QString::fromLatin1(s) : QString{};
+}
+
+std::uint32_t ColibriLib::deviceCount()
+{
+    QMutexLocker lock(&m_mutex);
+    if (!m_devices)
+        return 0;
+    std::uint32_t n = 0;
+    m_devices(n);
+    return n;
+}
+
+bool ColibriLib::open(ColibriDescriptor* out, std::uint32_t index)
+{
+    QMutexLocker lock(&m_mutex);
+    return m_open ? m_open(out, index) : false;
+}
+
+void ColibriLib::close(ColibriDescriptor dev)
+{
+    QMutexLocker lock(&m_mutex);
+    if (m_close)
+        m_close(dev);
+}
+
+bool ColibriLib::start(ColibriDescriptor dev, int sampleRateIndex, ColibriRxCallback cb,
+                       void* user)
+{
+    QMutexLocker lock(&m_mutex);
+    return m_start ? m_start(dev, sampleRateIndex, cb, user) : false;
+}
+
+bool ColibriLib::stop(ColibriDescriptor dev)
+{
+    QMutexLocker lock(&m_mutex);
+    return m_stop ? m_stop(dev) : false;
+}
+
+bool ColibriLib::setPreamp(ColibriDescriptor dev, float db)
+{
+    QMutexLocker lock(&m_mutex);
+    return m_setPreamp ? m_setPreamp(dev, db) : false;
+}
+
+bool ColibriLib::setFrequency(ColibriDescriptor dev, std::uint32_t hz)
+{
+    QMutexLocker lock(&m_mutex);
+    return m_setFrequency ? m_setFrequency(dev, hz) : false;
+}
+
+}  // namespace AetherSDR::colibri

--- a/src/core/backends/colibri/ColibriLib.h
+++ b/src/core/backends/colibri/ColibriLib.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <QLibrary>
+#include <QMutex>
+#include <QString>
+#include <QStringList>
+
+#include <atomic>
+#include <cstdint>
+
+namespace AetherSDR::colibri {
+
+// The C ABI of Expert Electronics' colibrinano_lib, verbatim from the vendor's
+// LibLoader.h / common.h (the protocol authority — see
+// docs/architecture/aetherd-colibri-backend-design.md). These types appear only
+// under src/core/backends/colibri/ (EB3).
+struct ColibriComplex {
+    float re;
+    float im;
+};
+using ColibriDescriptor = void*;
+
+#ifdef Q_OS_WIN
+#define COLIBRI_CALL __stdcall
+#else
+#define COLIBRI_CALL
+#endif
+
+// bool return: false tells the library to stop delivering. adcOverload rides
+// every block rather than being a separate status call.
+using ColibriRxCallback = bool (COLIBRI_CALL*)(ColibriComplex* iq, std::uint32_t len,
+                                               bool adcOverload, void* user);
+
+// The nine rates the receiver offers, by the index start() takes. ONE list —
+// it is simultaneously the capability advertisement, the pan zoom limits and
+// the set a zoom request snaps to, for the same reason HL2 keeps one list: the
+// pan span IS the sample rate on this radio.
+inline constexpr int kColibriSampleRatesHz[] = {
+    48000, 96000, 192000, 384000, 768000, 1536000, 1920000, 2560000, 3072000,
+};
+
+// start()'s SampleRateIndex for a rate from the list above, or -1.
+int colibriSampleRateIndex(int hz) noexcept;
+
+// Process-wide handle onto colibrinano_lib. A singleton because the library
+// itself is process-global state: initialize() must run exactly once, and the
+// discovery poll (GUI thread) and the device (I/O thread) must share the one
+// loaded instance rather than racing two LoadLibrary calls.
+//
+// Control calls are serialized by a mutex. The RX callback does NOT pass
+// through this class at all — the library invokes it directly on its own
+// thread — so the lock never sits on the sample path.
+class ColibriLib {
+public:
+    static ColibriLib& instance();
+
+    // Load + initialize, idempotent. `explicitPath` (from settings/params)
+    // is tried first, then the executable directory, then the vendor's
+    // default install locations. Returns false with `error` set when no
+    // loadable library was found.
+    bool ensureLoaded(const QString& explicitPath, QString* error);
+    [[nodiscard]] bool isLoaded() const { return m_initialized; }
+    [[nodiscard]] QString libraryPath() const { return m_path; }
+
+    void version(std::uint32_t& major, std::uint32_t& minor, std::uint32_t& patch);
+    QString information();
+    std::uint32_t deviceCount();
+    bool open(ColibriDescriptor* out, std::uint32_t index);
+    void close(ColibriDescriptor dev);
+    bool start(ColibriDescriptor dev, int sampleRateIndex, ColibriRxCallback cb, void* user);
+    bool stop(ColibriDescriptor dev);
+    bool setPreamp(ColibriDescriptor dev, float db);
+    bool setFrequency(ColibriDescriptor dev, std::uint32_t hz);
+
+    // True while any ColibriDevice holds an open descriptor. The discovery
+    // poll checks this and SKIPS enumerating: the authority does not document
+    // FTDI bus enumeration as safe under a running stream, so we do not find
+    // out on the operator's receiver.
+    void setDeviceInUse(bool inUse) { m_deviceInUse.store(inUse); }
+    [[nodiscard]] bool deviceInUse() const { return m_deviceInUse.load(); }
+
+private:
+    ColibriLib() = default;
+
+    using FnVoid = void (COLIBRI_CALL*)();
+    using FnVersion = void (COLIBRI_CALL*)(std::uint32_t&, std::uint32_t&, std::uint32_t&);
+    using FnInformation = void (COLIBRI_CALL*)(char**);
+    using FnDevices = void (COLIBRI_CALL*)(std::uint32_t&);
+    using FnOpen = bool (COLIBRI_CALL*)(ColibriDescriptor*, std::uint32_t);
+    using FnClose = void (COLIBRI_CALL*)(ColibriDescriptor);
+    using FnStart = bool (COLIBRI_CALL*)(ColibriDescriptor, int, ColibriRxCallback, void*);
+    using FnStop = bool (COLIBRI_CALL*)(ColibriDescriptor);
+    using FnSetPreamp = bool (COLIBRI_CALL*)(ColibriDescriptor, float);
+    using FnSetFrequency = bool (COLIBRI_CALL*)(ColibriDescriptor, std::uint32_t);
+
+    static QStringList candidatePaths(const QString& explicitPath);
+
+    QLibrary m_lib;
+    QString m_path;
+    QMutex m_mutex;
+    bool m_initialized = false;
+    std::atomic<bool> m_deviceInUse{false};
+
+    FnVoid m_initialize = nullptr;
+    FnVoid m_finalize = nullptr;          // resolved but never called — see design doc
+    FnVersion m_version = nullptr;
+    FnInformation m_information = nullptr;
+    FnDevices m_devices = nullptr;
+    FnOpen m_open = nullptr;
+    FnClose m_close = nullptr;
+    FnStart m_start = nullptr;
+    FnStop m_stop = nullptr;
+    FnSetPreamp m_setPreamp = nullptr;
+    FnSetFrequency m_setFrequency = nullptr;
+};
+
+}  // namespace AetherSDR::colibri

--- a/src/core/backends/colibri/ColibriRxDsp.cpp
+++ b/src/core/backends/colibri/ColibriRxDsp.cpp
@@ -1,0 +1,209 @@
+#include "core/backends/colibri/ColibriRxDsp.h"
+
+#include <QMetaType>
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR::colibri {
+
+ColibriRxDsp::ColibriRxDsp(QObject* parent) : QObject(parent)
+{
+    // Registered so audioReady/spectrumReady can cross the thread boundary
+    // (queued connections), and so control verbs arriving as queued
+    // invokeMethod calls do not get dropped for an unregistered Mode argument.
+    qRegisterMetaType<std::vector<float>>("std::vector<float>");
+    qRegisterMetaType<WdspChannel::Mode>("WdspChannel::Mode");
+}
+
+ColibriRxDsp::~ColibriRxDsp() = default;
+
+bool ColibriRxDsp::configure(const Config& config, std::string* error)
+{
+    // Guard the rate/block inputs before the block-size division below —
+    // these can come straight from a RadioConnectRequest params override,
+    // where a malformed value decodes to 0 (Principle VII: reject at the
+    // boundary rather than divide by zero).
+    if (config.inputSampleRateHz <= 0 || config.audioSampleRateHz <= 0
+        || config.dspBlockSize <= 0) {
+        if (error) {
+            *error = "ColibriRxDsp: input/audio sample rate and DSP block size "
+                     "must all be positive";
+        }
+        return false;
+    }
+
+    m_config = config;
+
+    WdspChannel::Config wc;
+    wc.direction = WdspChannel::Direction::Receive;
+    wc.inputBlockSize = static_cast<std::size_t>(config.dspBlockSize);
+    // dsp_size describes the same span of time as in_size, but at dsp_rate
+    // (WDSP channel.c) — so WDSP consumes exactly one of our input blocks per
+    // DSP pass. Guard against the widest rates flooring this to zero.
+    std::size_t dspBlock = static_cast<std::size_t>(config.dspBlockSize) *
+                           static_cast<std::size_t>(kWdspDspSampleRateHz) /
+                           static_cast<std::size_t>(config.inputSampleRateHz);
+    if (dspBlock == 0)
+        dspBlock = 16;   // 3.072 MHz input: 1024 * 48000 / 3072000 = 16
+    wc.dspBlockSize = dspBlock;
+    wc.inputSampleRate = config.inputSampleRateHz;
+    // The WDSP DSP rate is 48 kHz and is NOT the audio rate — WDSP's RXA
+    // stages are built around a 48 kHz internal rate (both reference clients
+    // hold it there; see Hl2RxDsp for the receipts).
+    wc.dspSampleRate = kWdspDspSampleRateHz;
+    wc.outputSampleRate = config.audioSampleRateHz;
+    wc.mode = config.mode;
+    wc.filterLowHz = config.filterLowHz;
+    wc.filterHighHz = config.filterHighHz;
+    wc.agcMode = config.agcMode;
+    wc.maximumAgcGainDb = config.maximumAgcGainDb;
+    wc.blockForOutput = config.blockForOutput;
+
+    auto channel = WdspChannel::create(wc, error);
+    if (!channel)
+        return false;
+    m_channel = std::move(channel);
+    m_spectrum = std::make_unique<ColibriSpectrum>(config.fftSize);
+
+    m_iqBuffer.clear();
+    m_i.assign(static_cast<std::size_t>(config.dspBlockSize), 0.0f);
+    m_q.assign(static_cast<std::size_t>(config.dspBlockSize), 0.0f);
+    const std::size_t outN = m_channel->outputBlockSize();
+    m_left.assign(outN, 0.0f);
+    m_right.assign(outN, 0.0f);
+    m_stereo.assign(outN * 2, 0.0f);
+    // A rebuild (rate change) creates a fresh channel; restore the operator's
+    // current slice offset rather than silently snapping the slice to centre.
+    if (m_shiftHz != 0.0)
+        m_channel->setShift(m_shiftHz);
+    return true;
+}
+
+void ColibriRxDsp::setMode(WdspChannel::Mode mode)
+{
+    m_config.mode = mode;
+    if (m_channel)
+        m_channel->setMode(mode);
+}
+
+void ColibriRxDsp::setFilter(double lowHz, double highHz)
+{
+    m_config.filterLowHz = lowHz;
+    m_config.filterHighHz = highHz;
+    if (m_channel)
+        m_channel->setFilter(lowHz, highHz);
+}
+
+void ColibriRxDsp::setAgc(int agcMode, double maximumGainDb)
+{
+    m_config.agcMode = agcMode;
+    m_config.maximumAgcGainDb = maximumGainDb;
+    if (m_channel)
+        m_channel->setAgc(agcMode, maximumGainDb);
+}
+
+void ColibriRxDsp::setSpectrumRateFps(int fps)
+{
+    m_spectrumIntervalMs = fps > 0 ? (1000 / fps) : 0;
+    // Do NOT reset the clock or the last-emit stamp: a rate change mid-stream
+    // takes effect on the next frame that comes due, not an immediate extra one.
+}
+
+void ColibriRxDsp::setShift(double shiftHz)
+{
+    m_shiftHz = shiftHz;
+    if (m_channel)
+        m_channel->setShift(shiftHz);
+}
+
+bool ColibriRxDsp::spectrumFrameDue()
+{
+    if (m_spectrumIntervalMs <= 0)
+        return true;                       // uncapped
+    if (!m_spectrumClock.isValid()) {
+        m_spectrumClock.start();
+        m_lastSpectrumMs = 0;
+        return true;                       // paint the first frame immediately
+    }
+    return (m_spectrumClock.elapsed() - m_lastSpectrumMs) >= m_spectrumIntervalMs;
+}
+
+void ColibriRxDsp::processIqBlock(const std::vector<std::complex<float>>& iq)
+{
+    if (!m_channel)
+        return;
+
+    // The two consumers need OPPOSITE handedness (measured on the HL2 — see
+    // Hl2RxDsp::processIqBlock for the two facts: the HPSDR wire is the
+    // conjugate of the analytic convention, and WDSP's RXA selects the
+    // opposite sign to its passband bounds).
+    //
+    //   wireAnalytic (this library's expected convention):
+    //       spectrum <- RAW      (already analytic, fftshift is honest)
+    //       demod    <- CONJ     (conjugating an analytic wire reproduces the
+    //                             HPSDR wire, which is what WDSP's quirk wants)
+    //   !wireAnalytic (HPSDR handedness):
+    //       spectrum <- CONJ, demod <- RAW — the HL2 arrangement verbatim.
+    //
+    // Either way the slice shift stays `slice - NCO` (design doc §IQ
+    // handedness), so the flag flips only which buffer feeds which consumer.
+    m_conjugated.resize(iq.size());
+    for (std::size_t n = 0; n < iq.size(); ++n)
+        m_conjugated[n] = std::conj(iq[n]);
+
+    const std::vector<std::complex<float>>& forSpectrum =
+        m_config.wireAnalytic ? iq : m_conjugated;
+    const std::vector<std::complex<float>>& forDemod =
+        m_config.wireAnalytic ? m_conjugated : iq;
+
+    // Panadapter: fed on BOTH paths so a skipped interval advances the window
+    // rather than emptying it; the FFT itself is skipped when a frame is not
+    // due, which is the whole saving at a wide span (see setSpectrumRateFps).
+    if (spectrumFrameDue()) {
+        // "Due" STAYS true until a frame actually completes: a callback block
+        // can be smaller than the FFT frame, so the boundary can be several
+        // blocks away even with a full window behind it.
+        if (m_spectrum->process(forSpectrum, m_bins) > 0) {
+            emit spectrumReady(m_bins);
+            m_lastSpectrumMs = m_spectrumClock.elapsed();
+        }
+    } else {
+        // Keep the window fed without paying for a transform.
+        m_spectrum->accumulate(forSpectrum);
+    }
+
+    // Audio path: buffer to WdspChannel's fixed block.
+    m_iqBuffer.insert(m_iqBuffer.end(), forDemod.begin(), forDemod.end());
+    const std::size_t block = static_cast<std::size_t>(m_config.dspBlockSize);
+    std::size_t consumed = 0;
+    while (m_iqBuffer.size() - consumed >= block) {
+        for (std::size_t n = 0; n < block; ++n) {
+            m_i[n] = m_iqBuffer[consumed + n].real();
+            m_q[n] = m_iqBuffer[consumed + n].imag();
+        }
+        consumed += block;
+
+        const auto res = m_channel->processIq(m_i, m_q, m_left, m_right);
+        if (res != WdspChannel::ProcessResult::Ok)
+            continue;   // Underrun while the pipeline fills, etc. — no output yet
+
+        const std::size_t outN = m_left.size();
+        for (std::size_t k = 0; k < outN; ++k) {
+            m_stereo[2 * k] = m_left[k];
+            m_stereo[2 * k + 1] = m_right[k];
+        }
+        emit audioReady(m_stereo);
+        // S-meter from WDSP's own signal-strength meter, NOT from the RMS of
+        // the demodulated audio — holding that constant is precisely what the
+        // AGC does.
+        emit meterUpdate(static_cast<float>(
+            m_channel->meter(WdspChannel::Meter::SignalPeak)));
+    }
+
+    if (consumed > 0)
+        m_iqBuffer.erase(m_iqBuffer.begin(),
+                         m_iqBuffer.begin() + static_cast<std::ptrdiff_t>(consumed));
+}
+
+}  // namespace AetherSDR::colibri

--- a/src/core/backends/colibri/ColibriRxDsp.h
+++ b/src/core/backends/colibri/ColibriRxDsp.h
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <QElapsedTimer>
+#include <QObject>
+
+#include <complex>
+#include <memory>
+#include <vector>
+
+#include "core/backends/colibri/ColibriSpectrum.h"
+#include "core/dsp/WdspChannel.h"
+
+namespace AetherSDR::colibri {
+
+// The ColibriNANO receive DSP stage: turns raw IQ blocks (from
+// ColibriDevice::iqBlockReady) into demodulated audio (WdspChannel), a
+// panadapter spectrum (ColibriSpectrum), and an S-meter. Buffers the DLL's
+// arbitrary-length callback blocks into WdspChannel's fixed processing block.
+// Below the seam; ColibriBackend owns one and runs it on the backend's I/O
+// thread. Receive-only — this radio has no transmitter.
+//
+// Modeled on hl2::Hl2RxDsp, with the wire handedness made explicit
+// (Config::wireAnalytic) instead of hardwired to the HPSDR convention — see
+// processIqBlock() for the two arrangements and the design doc for why the
+// slice-shift sign is the same in both.
+class ColibriRxDsp : public QObject {
+    Q_OBJECT
+
+public:
+    explicit ColibriRxDsp(QObject* parent = nullptr);
+    ~ColibriRxDsp() override;
+
+    // WDSP's internal DSP rate. Constant at 48 kHz and independent of both the
+    // IQ rate and the audio rate — see the note in configure().
+    static constexpr int kWdspDspSampleRateHz = 48000;
+
+    struct Config {
+        int inputSampleRateHz = 48000;   // ColibriNANO IQ sample rate
+        // Demodulated-audio rate. 24 kHz because that is AudioEngine's native
+        // RX rate — emitting it directly hands the engine byte-compatible
+        // float32 stereo with no resampling. WDSP does the IF->audio
+        // decimation, and every Colibri IQ rate divides evenly into it.
+        int audioSampleRateHz = 24000;
+        int dspBlockSize = 1024;         // WdspChannel input/processing block
+        int fftSize = 1024;              // panadapter FFT size
+        WdspChannel::Mode mode = WdspChannel::Mode::Usb;
+        double filterLowHz = 150.0;
+        double filterHighHz = 3000.0;
+        // RX AGC. 58.5 dB is the slice default threshold of 65 through the
+        // backend's 0..100 -> 0..90 dB map, measured on the air as the level
+        // FT8 decodes at: too high clips the audio, too low buries it, and on
+        // this receiver the AGC sits AT the ceiling rather than regulating
+        // below it (see ColibriBackend::kAgcCeilingDbPerUnit for both
+        // measurements).
+        int agcMode = 3;
+        double maximumAgcGainDb = 58.5;
+        // True (expected for this library): the wire is the ANALYTIC
+        // convention — a signal above the NCO arrives at a positive frequency.
+        // False: the wire is the HPSDR handedness (the conjugate). See
+        // processIqBlock() for what each arrangement conjugates.
+        bool wireAnalytic = true;
+        // false (live): processIq is non-blocking. true: wait for each output
+        // block (deterministic for a burst/offline feed).
+        bool blockForOutput = false;
+    };
+
+    // (Re)build the WdspChannel + ColibriSpectrum for this config. Returns
+    // false (and sets error, if given) when the WDSP channel cannot be created.
+    Q_INVOKABLE bool configure(const Config& config, std::string* error = nullptr);
+    Q_INVOKABLE void setMode(WdspChannel::Mode mode);
+    Q_INVOKABLE void setFilter(double lowHz, double highHz);
+    Q_INVOKABLE void setAgc(int agcMode, double maximumGainDb);
+    // RX frequency shift in Hz relative to the NCO — how the backend tunes the
+    // slice inside the passband without moving the DDC.
+    Q_INVOKABLE void setShift(double shiftHz);
+    // Cap how often a panadapter frame is produced, in frames per second.
+    // The FFT is SKIPPED entirely when a frame is not due — at 3.072 MHz the
+    // natural rate would be 3000 fps, so limiting at the source is what makes
+    // a wide span affordable. fps <= 0 removes the cap.
+    Q_INVOKABLE void setSpectrumRateFps(int fps);
+
+    [[nodiscard]] bool isConfigured() const noexcept { return m_channel != nullptr; }
+
+public slots:
+    // Feed one IQ block (normalized complex<float>, wire order). Emits
+    // spectrumReady per FFT frame and audioReady/meterUpdate per completed
+    // WdspChannel block.
+    void processIqBlock(const std::vector<std::complex<float>>& iq);
+
+signals:
+    void audioReady(const std::vector<float>& stereoPcm);   // interleaved L,R
+    void spectrumReady(const std::vector<float>& binsDbfs); // DC-centred dBFS
+    void meterUpdate(float dbfs);                           // WDSP signal meter
+
+private:
+    // True when the next panadapter frame may be computed. Stays true until
+    // one actually completes (a frame spans several callback blocks).
+    bool spectrumFrameDue();
+
+    std::unique_ptr<WdspChannel> m_channel;
+    std::unique_ptr<ColibriSpectrum> m_spectrum;
+    double m_shiftHz = 0.0;   // current slice offset from the NCO, Hz
+    Config m_config;
+
+    // Panadapter frame-rate cap. 0 = uncapped. m_spectrumClock is started on
+    // the first block and only read/written on the DSP thread.
+    int m_spectrumIntervalMs = 0;
+    QElapsedTimer m_spectrumClock;
+    qint64 m_lastSpectrumMs = 0;
+    std::vector<std::complex<float>> m_iqBuffer;   // IQ awaiting a full DSP block
+    // The conjugated copy of the block, for whichever consumer needs the
+    // opposite handedness to the wire. A member rather than a local: this runs
+    // per IQ block on the I/O thread.
+    std::vector<std::complex<float>> m_conjugated;
+    std::vector<float> m_i, m_q;                    // deinterleaved input scratch
+    std::vector<float> m_left, m_right;             // WdspChannel output scratch
+    std::vector<float> m_stereo;                    // interleaved audio out
+    std::vector<float> m_bins;                      // spectrum scratch
+};
+
+}  // namespace AetherSDR::colibri

--- a/src/core/backends/colibri/ColibriSettings.cpp
+++ b/src/core/backends/colibri/ColibriSettings.cpp
@@ -1,0 +1,75 @@
+#include "core/backends/colibri/ColibriSettings.h"
+
+#include "core/AppSettings.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QString>
+
+namespace AetherSDR {
+
+namespace {
+// Single nested-JSON key holding this backend's config (Principle V).
+// Shape: {"spanMhz":double, "dllPath":string, "wireAnalytic":bool}.
+const QString kRootKey = QStringLiteral("Colibri");
+
+constexpr const char* kFieldSpanMhz = "spanMhz";
+constexpr const char* kFieldDllPath = "dllPath";
+constexpr const char* kFieldWireAnalytic = "wireAnalytic";
+}  // namespace
+
+QJsonObject ColibriSettings::readObj()
+{
+    const QString json =
+        AppSettings::instance().value(kRootKey, QString{}).toString();
+    if (json.isEmpty())
+        return {};
+    return QJsonDocument::fromJson(json.toUtf8()).object();
+}
+
+void ColibriSettings::writeObj(const QJsonObject& obj)
+{
+    // Read-modify-write the whole object so it is always persisted as a unit
+    // (Principle XIV) — never half a config after a crash mid-write.
+    auto& s = AppSettings::instance();
+    s.setValue(kRootKey,
+               QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+    s.save();
+}
+
+double ColibriSettings::spanMhz()
+{
+    // 0.0 both when absent and when unparseable: no remembered span, apply
+    // the default. Validating here keeps a hand-edited settings file from
+    // commanding a nonsense sample rate (Principle VII).
+    const double v = readObj().value(QLatin1String(kFieldSpanMhz)).toDouble(0.0);
+    return v > 0.0 ? v : 0.0;
+}
+
+void ColibriSettings::setSpanMhz(double mhz)
+{
+    if (!(mhz > 0.0))
+        return;
+    QJsonObject o = readObj();
+    o[QLatin1String(kFieldSpanMhz)] = mhz;
+    writeObj(o);
+}
+
+QString ColibriSettings::dllPath()
+{
+    return readObj().value(QLatin1String(kFieldDllPath)).toString();
+}
+
+bool ColibriSettings::wireAnalytic()
+{
+    return readObj().value(QLatin1String(kFieldWireAnalytic)).toBool(true);
+}
+
+void ColibriSettings::setWireAnalytic(bool analytic)
+{
+    QJsonObject o = readObj();
+    o[QLatin1String(kFieldWireAnalytic)] = analytic;
+    writeObj(o);
+}
+
+}  // namespace AetherSDR

--- a/src/core/backends/colibri/ColibriSettings.h
+++ b/src/core/backends/colibri/ColibriSettings.h
@@ -1,0 +1,39 @@
+#pragma once
+
+class QJsonObject;
+class QString;
+
+namespace AetherSDR {
+
+// Owned configuration for the ColibriNANO backend, per Constitution
+// Principle V: one nested JSON object under a single root key ("Colibri"),
+// read and written atomically, with one place to default.
+//
+//   spanMhz      — the panadapter span the operator last chose, in MHz. On
+//                  this radio the span IS the USB sample rate (48 kHz costs
+//                  ~3 Mbit/s over USB, 3.072 MHz costs ~200), so it is opted
+//                  into once and remembered, never imposed at connect.
+//   dllPath      — optional explicit path to colibrinano_lib; empty means the
+//                  default search (exe directory, then the OS loader path).
+//   wireAnalytic — the IQ handedness the library delivers (design doc §IQ
+//                  handedness). Persisted so live calibration against a known
+//                  signal is one settings flip, not a rebuild.
+class ColibriSettings {
+public:
+    // The operator's remembered span in MHz, or 0.0 when they have never
+    // chosen one — distinct from any real span, so the backend can apply its
+    // own conservative default (48 kHz).
+    static double spanMhz();
+    static void setSpanMhz(double mhz);
+
+    static QString dllPath();
+
+    static bool wireAnalytic();
+    static void setWireAnalytic(bool analytic);
+
+private:
+    static QJsonObject readObj();
+    static void writeObj(const QJsonObject& obj);
+};
+
+}  // namespace AetherSDR

--- a/src/core/backends/colibri/ColibriSpectrum.cpp
+++ b/src/core/backends/colibri/ColibriSpectrum.cpp
@@ -1,0 +1,102 @@
+#include "core/backends/colibri/ColibriSpectrum.h"
+
+#include <fftw3.h>
+
+#include <cmath>
+
+namespace AetherSDR::colibri {
+
+namespace {
+constexpr double kPi = 3.14159265358979323846;
+}
+
+ColibriSpectrum::ColibriSpectrum(int fftSize) : m_fftSize(fftSize < 2 ? 2 : fftSize)
+{
+    m_acc.reserve(static_cast<std::size_t>(m_fftSize));
+    m_window.resize(static_cast<std::size_t>(m_fftSize));
+    double sum = 0.0;
+    for (int n = 0; n < m_fftSize; ++n) {
+        m_window[static_cast<std::size_t>(n)] =
+            0.5 * (1.0 - std::cos(2.0 * kPi * n / (m_fftSize - 1)));   // Hanning
+        sum += m_window[static_cast<std::size_t>(n)];
+    }
+    m_coherentGain = sum / 2.0;
+    // Guard the per-bin normalization divisor: a degenerate window sums to 0
+    // (a length-2 Hanning), which would make the magnitude divide produce inf.
+    if (m_coherentGain < 1e-9)
+        m_coherentGain = 1.0;
+
+    m_in = fftw_malloc(sizeof(fftw_complex) * static_cast<std::size_t>(m_fftSize));
+    m_out = fftw_malloc(sizeof(fftw_complex) * static_cast<std::size_t>(m_fftSize));
+    m_plan = fftw_plan_dft_1d(m_fftSize, static_cast<fftw_complex*>(m_in),
+                              static_cast<fftw_complex*>(m_out), FFTW_FORWARD,
+                              FFTW_ESTIMATE);
+}
+
+ColibriSpectrum::~ColibriSpectrum()
+{
+    if (m_plan) fftw_destroy_plan(static_cast<fftw_plan>(m_plan));
+    if (m_in) fftw_free(m_in);
+    if (m_out) fftw_free(m_out);
+}
+
+int ColibriSpectrum::process(std::span<const std::complex<float>> iq,
+                             std::vector<float>& binsDbfs)
+{
+    int frames = 0;
+    for (const auto& s : iq) {
+        m_acc.push_back(s);
+        if (static_cast<int>(m_acc.size()) == m_fftSize) {
+            computeFrame(binsDbfs);
+            m_acc.clear();
+            ++frames;
+        }
+    }
+    return frames;
+}
+
+void ColibriSpectrum::accumulate(std::span<const std::complex<float>> iq)
+{
+    m_acc.insert(m_acc.end(), iq.begin(), iq.end());
+    // Hold at most fftSize - 1: exactly-full would wedge process()'s boundary
+    // check (it fires on == fftSize after a push_back).
+    const std::size_t keep = static_cast<std::size_t>(m_fftSize) - 1;
+    if (m_acc.size() > keep) {
+        m_acc.erase(m_acc.begin(),
+                    m_acc.end() - static_cast<std::ptrdiff_t>(keep));
+    }
+}
+
+void ColibriSpectrum::computeFrame(std::vector<float>& binsDbfs)
+{
+    // Remove the frame's DC offset (the direct-sampling ADC offset), then
+    // apply the window.
+    double meanRe = 0.0, meanIm = 0.0;
+    for (const auto& s : m_acc) { meanRe += s.real(); meanIm += s.imag(); }
+    meanRe /= m_fftSize;
+    meanIm /= m_fftSize;
+
+    auto* in = static_cast<fftw_complex*>(m_in);
+    for (int n = 0; n < m_fftSize; ++n) {
+        const double w = m_window[static_cast<std::size_t>(n)];
+        in[n][0] = (static_cast<double>(m_acc[static_cast<std::size_t>(n)].real()) - meanRe) * w;
+        in[n][1] = (static_cast<double>(m_acc[static_cast<std::size_t>(n)].imag()) - meanIm) * w;
+    }
+
+    fftw_execute(static_cast<fftw_plan>(m_plan));
+
+    const auto* out = static_cast<fftw_complex*>(m_out);
+    binsDbfs.resize(static_cast<std::size_t>(m_fftSize));
+    const int half = m_fftSize / 2;
+    for (int k = 0; k < m_fftSize; ++k) {
+        const int src = (k + half) % m_fftSize;                       // fftshift: DC -> centre
+        const double re = out[src][0];
+        const double im = out[src][1];
+        const double mag = std::sqrt(re * re + im * im) / m_coherentGain;
+        // IQ is normalized to full scale 1.0, so this is dBFS directly.
+        binsDbfs[static_cast<std::size_t>(k)] =
+            static_cast<float>(20.0 * std::log10(mag + 1e-12));
+    }
+}
+
+}  // namespace AetherSDR::colibri

--- a/src/core/backends/colibri/ColibriSpectrum.h
+++ b/src/core/backends/colibri/ColibriSpectrum.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <complex>
+#include <cstddef>
+#include <span>
+#include <vector>
+
+namespace AetherSDR::colibri {
+
+// The Colibri panadapter path: accumulate raw IQ (normalized [-1, 1)) into
+// fixed FFT frames and produce a DC-centered magnitude spectrum in dBFS.
+// A sibling of hl2::Hl2Spectrum (same Hanning window, per-frame DC removal,
+// coherent-gain normalization, fftshift) — duplicated under this family per
+// the per-family backend layout rather than promoted, so neither backend's
+// spectrum can be retuned out from under the other.
+//
+// Owns an FFTW plan; construction/destruction allocate, process() does not
+// (fftw_execute is allocation-free). FFTW's global planner is not thread-safe,
+// so construct instances off the real-time path.
+class ColibriSpectrum {
+public:
+    explicit ColibriSpectrum(int fftSize = 1024);
+    ~ColibriSpectrum();
+    ColibriSpectrum(const ColibriSpectrum&) = delete;
+    ColibriSpectrum& operator=(const ColibriSpectrum&) = delete;
+
+    [[nodiscard]] int fftSize() const noexcept { return m_fftSize; }
+
+    // Append IQ samples; each time a full frame accumulates, compute one
+    // spectrum. `binsDbfs` is resized to fftSize (DC at index fftSize/2) and
+    // holds the most recent frame. Returns the number of frames produced (a
+    // partial frame is carried to the next call).
+    int process(std::span<const std::complex<float>> iq, std::vector<float>& binsDbfs);
+
+    // Append IQ WITHOUT transforming, keeping only the newest samples — the
+    // display-rate cap's between-frames feed. Caps at fftSize - 1 so a
+    // pre-filled buffer cannot step past process()'s frame-boundary check.
+    void accumulate(std::span<const std::complex<float>> iq);
+
+    // Drop whatever partial frame has accumulated (geometry change).
+    void reset() noexcept { m_acc.clear(); }
+
+private:
+    void computeFrame(std::vector<float>& binsDbfs);
+
+    int m_fftSize;
+    std::vector<std::complex<float>> m_acc;   // accumulation buffer (< m_fftSize)
+    std::vector<double> m_window;             // Hanning window
+    double m_coherentGain = 1.0;              // sum(window) / 2
+    // Opaque FFTW handles (kept as void* so fftw3.h stays out of the header).
+    void* m_in = nullptr;                     // fftw_complex[m_fftSize]
+    void* m_out = nullptr;                    // fftw_complex[m_fftSize]
+    void* m_plan = nullptr;                   // fftw_plan
+};
+
+}  // namespace AetherSDR::colibri

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -9,6 +9,7 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 #include "core/backends/hl2/Hl2Discovery.h"
+#include "core/backends/colibri/ColibriDiscovery.h"
 #include "models/RadioModel.h"
 #include "models/BandSettings.h"
 #include "models/AntennaGeniusModel.h"
@@ -932,6 +933,9 @@ private:
     // HPSDR/Metis discovery for Hermes-Lite 2 radios. Feeds the same
     // ConnectionPanel slots as m_discovery, tagged family="hl2".
     hl2::Hl2Discovery m_hl2Discovery;
+    // ColibriNANO USB enumeration. Feeds the same ConnectionPanel slots,
+    // tagged family="colibri".
+    colibri::ColibriDiscovery m_colibriDiscovery;
     // Radio sessions (#3445 Camp B / #3351). Each session owns the full
     // per-radio aggregate; today there is exactly one. The vector sits at
     // the old `RadioModel m_radioModel` member position so destruction

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -244,6 +244,26 @@ void MainWindow::wireDiscovery()
     connect(&m_hl2Discovery, &hl2::Hl2Discovery::radioUpdated,
             this, &MainWindow::maybeAutoConnectToDiscoveredRadio);
     m_hl2Discovery.start();
+
+    // ColibriNANO discovery: same picker, same auto-reconnect slots, tagged
+    // family="colibri". Nothing here is family-special beyond the tag.
+    connect(&m_colibriDiscovery, &colibri::ColibriDiscovery::radioDiscovered,
+            m_connPanel, &ConnectionPanel::onRadioDiscovered);
+    connect(&m_colibriDiscovery, &colibri::ColibriDiscovery::radioUpdated,
+            m_connPanel, &ConnectionPanel::onRadioUpdated);
+    connect(&m_colibriDiscovery, &colibri::ColibriDiscovery::radioLost,
+            m_connPanel, &ConnectionPanel::onRadioLost);
+    connect(&m_colibriDiscovery, &colibri::ColibriDiscovery::radioLost, this,
+            [this](const QString& serial) {
+                m_autoConnectAttempts.remove(serial);
+                if (m_autoConnectSerial == serial)
+                    m_autoConnectSerial.clear();
+            });
+    connect(&m_colibriDiscovery, &colibri::ColibriDiscovery::radioDiscovered,
+            this, &MainWindow::maybeAutoConnectToDiscoveredRadio);
+    connect(&m_colibriDiscovery, &colibri::ColibriDiscovery::radioUpdated,
+            this, &MainWindow::maybeAutoConnectToDiscoveredRadio);
+    m_colibriDiscovery.start();
     connect(&m_discovery, &RadioDiscovery::radioUpdated,
             m_connPanel, &ConnectionPanel::onRadioUpdated);
     connect(&m_discovery, &RadioDiscovery::radioUpdated,

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -11,6 +11,7 @@
 #include "core/backends/icom/IcomCivBackend.h"  // Icom networked radios (family "icom")
 #include "core/backends/icom/IcomCredentials.h"  // password: keychain, never settings
 #include "core/backends/icom/IcomSettings.h"     // host/user/ports (Principle V)
+#include "core/backends/colibri/ColibriBackend.h"  // ColibriNANO backend (family "colibri")
 #include "core/AppSettings.h"
 #include "core/RadioStateMemory.h"  // RFC #4603 typed restore handoff
 #include "core/CwTrace.h"
@@ -556,6 +557,11 @@ std::unique_ptr<IRadioBackend> RadioModel::makeBackend(const QString& family)
     // restored state (Constitution II/III).
     if (family.compare(QLatin1String("icom"), Qt::CaseInsensitive) == 0)
         return std::make_unique<icom::IcomCivBackend>();
+    // ColibriNANO: pure-seam like HL2/Icom — no RadioConnection, no
+    // PanadapterStream — so setupBackend()'s Flex/Sim harvesting block
+    // skips it and only the neutral connects apply.
+    if (family.compare(QLatin1String("colibri"), Qt::CaseInsensitive) == 0)
+        return std::make_unique<colibri::ColibriBackend>();
     // RFC #4288 demo mode: the synthetic radio is selected here like any other
     // family, which is what completes the "wire it through the real SimBackend
     // factory" ask. Unlike HL2 it is a Route A hybrid — it owns a RadioConnection


### PR DESCRIPTION
First of two backends split out of #4904 at your request. Independent of the other one — this branch builds and tests on its own against `main`, and the two touch disjoint code apart from the `CORE_SOURCES` list, the `makeBackend` chain and the discovery block in `MainWindow`. Whichever lands second will need a trivial rebase there; happy to do it.

**Purely additive: 16 files, ~2600 insertions, zero deletions.** Nothing outside `src/core/backends/colibri/` changes except those three integration points, the capabilities map and the design doc.

## What the device is

A USB direct-sampling receiver: 122.88 MHz ADC, one DDC, IQ delivered to a process callback as normalized `float` pairs at one of nine rates (48 kHz…3.072 MHz). Driven exclusively through Expert Electronics' own `colibrinano_lib` — the library's published C API is the sole authority for every call signature, rate and bound in here, and no USB traffic is spoken below it. The DLL owns the FTDI transport.

## Shape

Modelled on the Hermes-Lite 2 backend, since both take raw IQ and run the DSP on this host (RFC §5.5 — *"DSP location is invisible here"*). Everything that differs subtracts:

- **One receiver, fixed.** `maxSlices = maxPanadapters = 1`, `createPanadapter()` stays false, and HL2's four-way index map collapses to constants.
- **RECEIVE-ONLY** — the first backend to report `canTransmit=false` as a *constant* rather than a gate. There is no transmitter for the engine TX guard to gate; `setKeying()` is the RFC §5.5 Q3 guarded no-op (Principle VI). `hostModulates` is false too, so an RX-only session never opens the mic.
- A span change **restarts the stream** (`stop` → `start(newRate)`) instead of poking a register, throttled so a zoom sweep does not thrash it.
- Its scope window is its own DDC, genuinely independent of the slice, so `setPanCenter`'s `Drag` and `Range` intents mean the same thing here.

## Threading

The one genuinely new piece: the DLL invokes its RX callback from the **library's own thread**. `ColibriDevice` copies the block there and lets a queued connection carry it to the I/O thread, so nothing downstream ever runs on a thread we do not own. That extra hop is not optional and the header says why. Counters the GUI reads are atomics; control verbs travel queued.

## Two constants measured on the air

Both carry the measurement in a comment (Principle VIII), because getting either wrong looks like a dead receiver rather than a mis-set gain:

- **IQ handedness** (`ColibriRxDsp::Config::wireAnalytic`). This library uses the HPSDR convention; the analytic default drew the spectrum mirrored about the pan centre. Persisted as a setting so re-calibrating against a known signal is a flip, not a rebuild.
- **AGC ceiling** (0.9 dB per slice-AGC unit, a 0..90 dB span). This receiver's IQ arrives tens of dB below an HL2's, so its AGC runs *at* the ceiling and that constant — not the AGC loop — sets the audio level. Measured on 20 m at +6 dB preamp: at a 78 dB ceiling the audio clipped and FT8 decoded nothing (`clipped=20/240`, zero raw rows); at 39 dB, the HL2 value, it was 55 dB quieter and equally undecodable. 0.9 puts the slice default near −24 dBFS, where FT8 decoders are happiest.

## Settings

One nested JSON object under a single `"Colibri"` root key (Principle V), read and written as a unit (Principle XIV), validated where it enters (Principle VII) so a hand-edited file cannot command a sample rate the library does not offer.

## Verified on live hardware

FT8 decoded end to end through the TCI server — F5SZY, HB9EKJ, OH1LA on 20 m, DT 0.2–0.8 s.

## Note for review

**Commits are unsigned.** Happy to set up SSH signing and force-push if you would rather not admin-merge — just say which you prefer.
