### PR TITLE
feat(ft991): a Yaesu FT-991 backend (family "ft991")

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -802,6 +802,20 @@ set(CORE_SOURCES
     src/core/aprs/AprsSettings.cpp
 )
 
+if(Qt6SerialPort_FOUND)
+    # The FT-991 backend speaks CAT over QSerialPort; a build without Qt
+    # SerialPort simply has no "ft991" family (RadioModel and MainWindow
+    # guard their references on HAVE_SERIALPORT).
+    list(APPEND CORE_SOURCES
+        src/core/backends/ft991/Ft991Cat.cpp        # FT-991 — CAT frame codec (authority: Yaesu CAT manual)
+        src/core/backends/ft991/Ft991Spectrum.cpp   # FT-991 — audio-band FFT panadapter (FFTW)
+        src/core/backends/ft991/Ft991Device.cpp     # FT-991 — CAT serial + USB codec on the I/O thread
+        src/core/backends/ft991/Ft991Backend.cpp    # FT-991 — IRadioBackend impl (audio-lens pan)
+        src/core/backends/ft991/Ft991Discovery.cpp  # FT-991 — CP210x port scan -> picker
+        src/core/backends/ft991/Ft991Settings.cpp   # owned config object, "Ft991" root key (Principle V)
+    )
+endif()
+
 if(APPLE)
     list(APPEND CORE_SOURCES src/core/VirtualAudioBridge.cpp src/core/MacMicPermission.mm)
 elseif(UNIX)
@@ -4150,6 +4164,19 @@ add_executable(spe_protocol_test
 target_include_directories(spe_protocol_test PRIVATE src)
 target_link_libraries(spe_protocol_test PRIVATE Qt6::Core)
 add_test(NAME spe_protocol_test COMMAND spe_protocol_test)
+
+if(Qt6SerialPort_FOUND)
+    # Ft991Cat is deliberately free of QSerialPort so the wire vocabulary is
+    # testable without hardware; the guard is only here because the family
+    # itself is not built without Qt SerialPort.
+    add_executable(ft991_cat_test
+        tests/ft991_cat_test.cpp
+        src/core/backends/ft991/Ft991Cat.cpp
+    )
+    target_include_directories(ft991_cat_test PRIVATE src)
+    target_link_libraries(ft991_cat_test PRIVATE Qt6::Core)
+    add_test(NAME ft991_cat_test COMMAND ft991_cat_test)
+endif()
 
 add_executable(ole_compound_file_test
     tests/ole_compound_file_test.cpp

--- a/docs/architecture/aetherd-ft991-backend-design.md
+++ b/docs/architecture/aetherd-ft991-backend-design.md
@@ -1,0 +1,276 @@
+# aetherd — Yaesu FT-991 backend design
+
+Status: implemented (first cut)
+Family id: `ft991`
+Protocol authority: the **Yaesu FT-991/FT-991A CAT Operation Reference
+Manual**, published by Yaesu on its own download site — the vendor's complete,
+open specification of the serial command set this backend speaks (`FA`, `MD`,
+`TX`, `SM`, `PC`, `GT`, `AI`, `ID`, …). The audio plane is the radio's
+built-in **USB Audio CODEC**, a standard USB Audio Class device that needs no
+vendor protocol at all; the serial plane rides the radio's built-in Silicon
+Labs CP2105 dual UART (the *Enhanced* COM port carries CAT). No undocumented
+traffic is spoken: every byte this backend sends appears in the CAT manual.
+
+## What the device is
+
+A 100 W HF/50/144/430 MHz transceiver that demodulates and modulates
+**inside the radio**. What reaches this host is:
+
+- **RX**: the demodulated channel audio (≤ ~3.2 kHz wide) on the USB codec;
+- **TX**: baseband transmit audio we play into the codec (the radio's
+  DATA-USB path), plus CAT `TX1;`/`TX0;` for keying;
+- **CAT**: a polled command plane at 4800–38400 baud, 8N2.
+
+There is no IQ and no wideband data. That makes this the first backend whose
+"panadapter" is honest about being a **lens on one channel**: an audio-band
+FFT mapped onto RF using the dial frequency and the mode's sideband. The
+waterfall covers the audio passband (0–4 kHz of RF around the dial), not a
+band. Radio control, the host DSP chain (NR2/RN2/NR4/DFNR — the radio
+declares `hasRadioSideDsp=false`, so the host modules are the operator's DSP),
+and the TCI server all work exactly as on any other seam backend.
+
+## Shape of the backend
+
+The ColibriNANO backend is the structural template (one receiver, one pan,
+authoritative local state, I/O-thread device object), with the DSP chain
+*subtracted* — the radio already demodulated — and a transmitter *added*:
+
+- ONE slice, ONE pan, fixed: pan id `ft991-0`, slice id 0. The slice
+  frequency IS the radio's dial (VFO-A). `createPanadapter()` stays `false`.
+- `canTransmit=true`: keying is CAT `TX1;`/`TX0;`, always and only from
+  `setKeying()`/`setTune()` — the engine TX guard sits above the seam
+  (Principle VI: nothing here keys on restore, connect, or discovery).
+- `hostModulates=true`. Strictly the RF modulator is in the radio, but what
+  the capability actually gates — the mic-source list, the PC-audio lock,
+  TCI's TX routing — is *where the TX audio comes from*, and that is this
+  host: `submitTxAudio()` receives the engine's processed TX audio and plays
+  it into the codec. `setTune()` generates its own 1.5 kHz tone at the
+  operator's TUNE power (with the `PC` drive swapped and restored around it).
+- `clientSettingsDomains` is **EMPTY**. The FT-991 persists its own VFO,
+  mode and settings across power cycles — it is radio-authoritative
+  (Constitution II/III), like the Flex and unlike HL2/Colibri. The client
+  must restore nothing.
+- The CAT plane is polled (`AI0;` is set at connect; auto-information is
+  deliberately not used so every state read is an explicit, parseable
+  query/response pair): `FA`/`MD0`/`TX` at a few Hz, `SM0` for the S-meter,
+  `PC`/`GT0` slowly. Turning the radio's own dial therefore updates the
+  slice, the pan window and TCI within a poll period — the radio is the
+  authority; the client follows.
+
+## The panadapter is a lens (and says so)
+
+`Ft991Spectrum` runs a real-input FFT over the codec audio and keeps the
+bins from 0 to `kAudioSpanHz` (4 kHz). The window is **symmetric about the
+dial** — `[dial−4k, dial+4k]`, centre == dial — and the backend maps audio
+frequency `a` onto it per the mode's sideband:
+
+- USB-side modes (USB, DIGU, CW, RTTY-U displayed as DIGU): `RF = dial + a`
+  fills the RIGHT half; the left half is padded at the frame's own
+  measured floor plus a small deterministic ripple. Both halves of that
+  choice were forced by real failures: a sentinel far below the floor
+  (−160 dBm) poisons the display's auto-level statistics, and a *constant*
+  pad is exactly the clipped-floor signature SpectrumWidget's headroom
+  recovery hunts (long identical runs at the frame minimum) — it ratcheted
+  the range down 24 dB/s forever.
+- LSB-side modes (LSB, DIGL, CWL): `RF = dial − a` fills the LEFT half,
+  bins reversed; right half padded.
+- AM/FM (envelope audio, no sideband identity): mirrored onto BOTH halves.
+
+Symmetric-about-the-dial is load-bearing, not cosmetic. The first cut put
+the dial at the window's left EDGE (window `[dial, dial+4k]`), which
+collided with the GUI's slice-follow policy: it re-centres the pan onto
+the active slice, the backend mapped that centre back to `dial − span/2`,
+and the pair recursed — synchronously, through the seam, walking the REAL
+radio down 2 kHz per round via CAT until the stack overflowed. With
+centre == dial the re-centre request is the identity and dies in the
+change gate. A depth guard in the tune verbs (`kMaxTuneVerbDepth`) remains
+as a tripwire: any future policy loop truncates and logs instead of
+crashing.
+
+`panCenterBandwidthChanged` always reports exactly the window the bins
+cover (the #4142/#4470 honesty rule — the padded half is *reported* as
+covered and carries the explicit below-floor pad), and
+`panBandwidthLimitsChanged` reports min == max == 8 kHz so the zoom clamp
+knows there is nothing to zoom. `setPanBandwidth` re-emits the unchanged
+span (snap-back); `setPanCenter` retunes the dial (moving the window IS
+retuning the radio). CW is mapped like USB *without* a pitch correction,
+deliberately: the slice filter overlay uses the same audio-offset
+convention, so a tuned-in CW station falls inside its displayed passband.
+
+Levels are dBFS of the codec stream plus one constant (`kFullScaleDbm`),
+uncalibrated by construction — and worse than on an IQ backend, because the
+radio's own AGC sits in front of the codec and moves the floor. Accepted
+and documented: this display is for seeing the channel, not measuring it.
+
+## Threading
+
+The Colibri discipline: the backend owns a `QThread` (`ft991-io`);
+`Ft991Device` — the QSerialPort, the QAudioSource/QAudioSink, the FFT and
+the resamplers — lives on it. Qt delivers serial and audio readyRead on the
+owning thread, so unlike the Colibri DLL there is no foreign-thread hop.
+Control verbs travel GUI → I/O via queued `invokeMethod`; counters the GUI
+reads (`linkStats()`, `healthSnapshot()`) are atomics in the device. Audio
+and spectrum come up as queued signals carrying `std::vector<float>`.
+
+## Audio plane
+
+- **RX**: the codec is opened at its preferred format (the WfmDemodulator
+  rule: capture at the device's native rate; forcing one makes the OS mixer
+  resample). Channel 0 is converted to float, linearly resampled to 24 kHz
+  (AudioEngine's native RX rate — 48 kHz native makes this an exact 2:1),
+  shaped by the **slice passband** (a host-side 4th-order Butterworth
+  biquad cascade — the radio already demodulated, so this is the only
+  place the app's filter handles can narrow anything; wide-open edges are
+  skipped, and the spectrum is deliberately fed PRE-filter, like a real
+  pan), then duplicated to interleaved stereo and emitted as
+  `audioFrameReady` + `sliceAudioFrameReady(0, …)` — the latter is what
+  feeds TCI channel 1 (the Colibri-proven route). The filter shapes both
+  feeds (the Flex semantic: DAX carries the slice's filtered audio); the
+  speaker copy additionally applies the slice mute/gain/balance, and the
+  per-slice copy is pre-fader, so muting the monitor does not stop a
+  decoder. The host DSP chain (NR2/RN2/NR4/BNR/DFNR, client RX EQ) then
+  applies in AudioEngine exactly as on HL2/Colibri.
+- **TX**: `submitTxAudio()` (int16 interleaved stereo at the engine's rate)
+  is mixed to mono, scaled by the MIC gain, resampled to the codec output's
+  rate and written to the QAudioSink. Frames arriving while the radio is
+  not keyed by us are dropped — silence into a live SSB transmitter is no
+  RF, but the gate costs nothing and keeps the path inert when unkeyed.
+
+The device selection is a case-insensitive substring match on the device
+description ("USB Audio CODEC" by default — what the FT-991 enumerates as),
+overridable in `Ft991Settings` for stations with more than one codec.
+
+## Connect sequence
+
+open serial (8N2) → `AI0;` → `ID;` (must answer `0670`, the FT-991's CAT
+identity — anything else is a refused connect naming what answered) →
+`FA;` + `MD0;` (so the first pan/slice emission carries the radio's real
+state, not a placeholder) → open codec in/out → `opened()` → the backend
+emits pan geometry, zoom limits, slice state, meters. No reply within the
+retry budget → `openFailed` with the usual suspects named (wrong port, menu
+031 CAT RATE mismatch).
+
+## Persistence
+
+`Ft991Settings`, one root key `"Ft991"` (Principle V): `baudRate` (default
+38400 — set menu 031 CAT RATE to match), `audioInHint`, `audioOutHint`.
+Radio identity for `radio_settings` scoping is the discovery serial
+(`ft991-<port>`); with `clientSettingsDomains` empty there is no operating
+state to scope, and `persistsMemories=false` engages the client-side memory
+bank as usual.
+
+## Discovery
+
+`Ft991Discovery` polls `QSerialPortInfo::availablePorts()` on a timer and
+lists ports whose description/manufacturer matches the radio's CP210x
+bridge (skipping the CP2105's *Standard* port — CAT lives on *Enhanced*).
+Each match emits the same `RadioInfo` shape as the Colibri sweep
+(`family="ft991"`, synthetic LocalHost address, serial `ft991-<port>`).
+The match is a heuristic — any CP210x device is listed — and that is fine:
+listing is an offer, not an action, and connect verifies `ID;` before
+anything else happens.
+
+## Radio-side DSP (second cut)
+
+The radio's own DSP is driven through the seam:
+
+- **Filter width** — the slice passband handles act TWICE: the host biquad
+  cascade applies the exact edges instantly, and the radio's DSP width
+  follows via `NA` (narrow bank — chosen FIRST, the manual's order) + `SH`
+  (nearest index in the per-mode tables: SSB 200–3200 Hz in 21 steps,
+  CW/RTTY/DATA 50–3000 Hz in 17; AM/FM are fixed-width and take no SH).
+  The confirm-poll reflects what the radio took back into the displayed
+  edges (anchored at 1500 Hz for SSB/DATA, 700 Hz for CW, signed per
+  sideband) — the display converges on radio truth. Turning the radio's
+  own WIDTH knob updates the slice the same way (~5 s reflection cadence).
+- **NB / NR / ANF** — the VFO DSP buttons route through the new seam verbs
+  `setSliceNoiseBlanker/NoiseReduction/AutoNotch` (see below) onto CAT
+  `NB`+`NL` (level 0–10), `NR`+`RL` (DNR level 1–15) and `BC` (the DNF
+  auto notch). Levels stay 0–100 in the slice model and are mapped at the
+  boundary; an echo only rewrites the UI value when it lands on a
+  DIFFERENT radio step, so the coarse radio scale cannot yank a
+  fine-grained slider.
+- **Manual IF notch** (`BP`) — `setSliceManualNotch`. The seam's position
+  is 0..100 ACROSS THE PASSBAND rather than a frequency, so the notch
+  tracks the filter instead of being re-derived by every caller; this
+  radio places it in audio Hz, and the backend converts in both
+  directions, where it knows its own passband.
+
+All of this rides the seam's EXISTING receive-DSP verbs
+(`setSliceNoiseReduction`, `setSliceNoiseBlanker`, `setSliceAutoNotch`,
+`setSliceManualNotch`) — this backend adds none of its own. The capability
+tiers say exactly what this radio is: `hasRadioSideDsp` true (it runs its
+own NR/NB/ANF), `hasLmsNoiseFilters` false (nothing resembling
+NRL/ANFL/ANFT), `hasManualNotch` true. That is the same shape an Icom
+declares, and it is what keeps three Flex-only buttons from lighting up
+over registers this radio does not have.
+
+## Clarifier (RIT / XIT)
+
+`setRitEnabled`, `setXitEnabled` and `setRitOffset`. This radio has **one
+shared clarifier register with two independent enables** — precisely the
+shape the seam already models, so `setXitOffset` is deliberately left to
+its default (which routes to `setRitOffset`) rather than overridden: on
+this radio the aliasing is the truth, not an approximation.
+
+The wire has no absolute-offset command, so setting one is "clear then
+step": `RC;` zeroes the shared offset and `RU`/`RD` walk it to the
+target, written as one frame pair so nothing observes the intermediate
+zero. Readback is `IF;` — the only command that reports the clarifier at
+all — parsed at fixed field offsets (frequency 5..13, clarifier 14..18,
+RIT 19, XIT 20, mode 21) and polled about once a second.
+
+## Pan centre: drag versus zoom
+
+The lens is slaved to the VFO, so `setPanCenter`'s `PanCenterIntent` is
+load-bearing here rather than ignorable: a `Drag` is the operator asking
+to listen elsewhere and retunes the dial, while a `Range` centre riding
+along with a zoom is answered with the geometry we already have. Treating
+them alike would walk the radio across the band one zoom click at a time.
+
+## Split — blocked, and on what
+
+Not implemented, and not implementable behind the current seam. The
+FT-991's split is VFO-A receives / VFO-B transmits, but AetherSDR models
+split as *a second slice marked TX* — a Flex shape. With `maxSlices = 1`
+the SPLIT button's handler returns early, and the `slice create` it would
+otherwise send is Flex wire text that no seam backend receives. Wiring it
+up needs a slice-lifecycle verb on `IRadioBackend` (there is
+`createPanadapter`, but no `createSlice`), which is a family-neutral
+addition well beyond this backend. Until then the SPLIT badge is a silent
+no-op here — the same ungated-control shape as `+TNF`, and worth fixing
+in the same family-neutral pass.
+
+## Losing the link
+
+A serial `ResourceError`/`ReadError` (USB cable pulled), ten consecutive
+unanswered CAT queries (~5 s — the radio switched off), or a capture
+`IOError` all funnel into `failLink()`: the device tears itself down and
+emits `linkLost(reason)`, and the backend answers with `disconnected()`
+followed by `connectionError(reason)` — that order, so the session state
+is consistent before the reason is displayed. Without this the session
+was a zombie: no `readyRead` ever again, nothing surfaced, and only the
+heartbeat quietly going amber.
+
+## TX meters
+
+While `txState != 0` the S-meter poll is replaced by alternating `RM5`
+(PO) and `RM6` (SWR), published as `TX:FWDPWR` (watts) and `TX:SWR`.
+Both scalings are UNCALIBRATED linear estimates of the 0–255 raw count —
+the CAT manual publishes no calibration — so the SWR reading is a
+*trend*, not a measurement. Treat 1.0 as "meter at rest", not as a
+matched antenna.
+
+## Not in this cut (documented so nobody debugs their absence)
+
+- RF gain (`RG`), the radio's CONTOUR/APF: not driven. The AGC threshold
+  is display-only; AGC *mode* does map (`GT0x`). Host filtering narrower
+  than the radio's filter cannot recover AGC pumping from strong signals
+  the radio still passes to its own AGC — set the radio width down (the
+  filter handles now do) when a neighbour pumps.
+- TX meters (PO/SWR/ALC via `RM`), split/VFO-B, memory channels, clarifier.
+- `AI1;` push mode (polling is the contract; see above).
+- The `+TNF` button and TNF context-menu entries are Flex-only and today
+  UNGATED repo-wide — dead on every seam backend (HL2/Colibri too), the
+  known HERMES §17 shape. Gating them behind a capability is a separate,
+  family-neutral fix.

--- a/docs/architecture/radio-capabilities-map.md
+++ b/docs/architecture/radio-capabilities-map.md
@@ -33,6 +33,20 @@ traps and why the DAX crash guard is deliberately *not* the DAX capability.
 
 ## Wired and consumed
 
+**Yaesu FT-991 (family `ft991`)** — CAT over the radio's serial port, audio
+over its USB codec. `model` `"FT-991"`, `tuningMinHz/MaxHz` 30 kHz–470 MHz,
+`canTransmit` ✅ (CAT `TX1;`/`TX0;`), `txPowerMaxWatts` 100,
+`hostModulates` ✅ (the RF modulator is in the radio, but the capability's
+consumers — mic-source list, PC-audio lock, TCI TX routing — gate on where
+the TX *audio* comes from, and that is this host's codec playback),
+`clientSettingsDomains` **empty** (the radio persists its own VFO/mode —
+radio-authoritative, like the Icom). On the DSP tiers it is the same shape
+as an Icom: `hasRadioSideDsp` ✅ (CAT `NB`+`NL`, `NR`+`RL`, auto-notch
+`BC`), `hasLmsNoiseFilters` ❌ (nothing resembling NRL/ANFL/ANFT),
+`hasManualNotch` ✅ (`BP`, frequency-placed and converted to the seam's
+0..100 passband position in the backend). Only built when Qt SerialPort is
+(`HAVE_SERIALPORT`). Design doc `aetherd-ft991-backend-design.md`.
+
 | Field | Flex | HL2 | Sim | Read at | Effect |
 |---|:--:|:--:|:--:|---|---|
 | `family` | `"flex"` | `"hl2"` | `"sim"` | `MainWindow::rfGainSettingsKey` | Scopes the persisted RF-gain key per family |

--- a/src/core/backends/ft991/Ft991Backend.cpp
+++ b/src/core/backends/ft991/Ft991Backend.cpp
@@ -1,0 +1,1050 @@
+#include "core/backends/ft991/Ft991Backend.h"
+
+#include "core/backends/ft991/Ft991Cat.h"
+#include "core/backends/ft991/Ft991Settings.h"
+
+#include <QLoggingCategory>
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+Q_LOGGING_CATEGORY(lcFt991, "aether.ft991")
+
+namespace AetherSDR::ft991 {
+
+namespace {
+
+// Default RX passband per mode (Hz, sign carries the sideband — SliceModel's
+// convention). Display-side only on this radio: the FT-991's own filters are
+// untouched (design doc, "Not in this cut").
+std::pair<int, int> defaultPassbandForMode(const QString& mode)
+{
+    const QString u = mode.toUpper();
+    if (u == QLatin1String("USB"))  return {100, 2900};
+    if (u == QLatin1String("LSB"))  return {-2900, -100};
+    if (u == QLatin1String("DIGU")) return {150, 3000};
+    if (u == QLatin1String("DIGL")) return {-3000, -150};
+    if (u == QLatin1String("CW"))   return {350, 850};
+    if (u == QLatin1String("CWL"))  return {-850, -350};
+    if (u == QLatin1String("AM"))   return {-4000, 4000};
+    if (u == QLatin1String("FM") || u == QLatin1String("NFM"))
+        return {-8000, 8000};
+    return {150, 3000};
+}
+
+// Phase-1 data-plane payload: a raw little-endian float32 array.
+QByteArray floatBytes(const std::vector<float>& v)
+{
+    return {reinterpret_cast<const char*>(v.data()),
+            static_cast<qsizetype>(v.size() * sizeof(float))};
+}
+
+}  // namespace
+
+Ft991Backend::Ft991Backend(QObject* parent) : IRadioBackend(parent)
+{
+    // No parent: moveToThread() refuses an object that has one. Destroyed
+    // explicitly in the destructor after the thread is joined.
+    m_device = new Ft991Device(nullptr);
+
+    m_ioThread = new QThread(this);
+    m_ioThread->setObjectName(QStringLiteral("ft991-io"));
+    m_device->moveToThread(m_ioThread);
+    m_ioThread->start();
+
+    connect(m_device, &Ft991Device::opened, this,
+            [this](const Ft991Device::OpenInfo& info) {
+        m_openInfo = info;
+        m_coveredSpanHz = info.coveredSpanHz > 0.0 ? info.coveredSpanHz
+                                                   : kAudioSpanHz;
+        m_connected = true;
+        m_linkBlocksAtLastTick = 0;
+        m_linkStatsTimer->start();
+        emit connected();
+        // Publish initial pan/slice state AFTER connected() — RadioModel's
+        // onConnected() stages existing models as previous-session leftovers,
+        // so anything emitted earlier is wiped before the UI sees it. Pan
+        // FIRST: the pan must exist before anything describes it (#4470
+        // shape). The dial and mode are already real: the device fetched
+        // them before opened().
+        emitPanState();
+        emit panBandwidthLimitsChanged(panId(), m_coveredSpanHz * 2.0 / 1.0e6,
+                                       m_coveredSpanHz * 2.0 / 1.0e6);
+        const auto [lo, hi] = defaultPassbandForMode(m_mode);
+        m_filterLowHz = lo;
+        m_filterHighHz = hi;
+        pushPassbandToDevice();
+        emitSliceState();
+        defineMeters();
+        emitTransmitState();
+        if (m_openInfo.audioOutDesc.isEmpty())
+            qCWarning(lcFt991) << "no TX audio device — session is receive-only";
+    });
+    connect(m_device, &Ft991Device::openFailed, this, [this](const QString& reason) {
+        m_connected = false;
+        m_linkStatsTimer->stop();
+        emit connectionError(QStringLiteral("FT-991: %1").arg(reason));
+    });
+    connect(m_device, &Ft991Device::linkLost, this, [this](const QString& reason) {
+        // The device already tore itself down; this side only reports.
+        // disconnected() FIRST so the session state is consistent before
+        // the error dialog names the cause.
+        if (!m_connected)
+            return;
+        m_connected = false;
+        m_moxRequested = false;
+        m_tuneActive = false;
+        m_linkStatsTimer->stop();
+        emit disconnected();
+        emit connectionError(QStringLiteral("FT-991: %1").arg(reason));
+    });
+
+    // ---- CAT state up. The radio is the authority; these follow it. ----
+    connect(m_device, &Ft991Device::catFrequency, this, [this](double hz) {
+        m_dialHz = hz;
+        if (!m_connected)
+            return;   // pre-opened() initial fetch; opened() will publish
+        emitSliceState();
+        emitPanState();
+        emitTransmitState();
+    });
+    connect(m_device, &Ft991Device::catMode, this, [this](const QString& mode) {
+        const bool changed = mode.compare(m_mode, Qt::CaseInsensitive) != 0;
+        m_mode = mode;
+        if (changed) {
+            // The passband belongs to the mode; we own the audio filter, so
+            // nothing heals a stale one for us.
+            const auto [lo, hi] = defaultPassbandForMode(mode);
+            m_filterLowHz = lo;
+            m_filterHighHz = hi;
+            pushPassbandToDevice();
+        }
+        if (!m_connected)
+            return;
+        emitSliceState();
+        emitPanState();   // the sideband mapping may have flipped
+    });
+    connect(m_device, &Ft991Device::catTxState, this, [this](int state) {
+        const bool mox = state != 0;
+        if (mox == m_mox)
+            return;
+        m_mox = mox;
+        if (m_connected)
+            emitTransmitState();
+    });
+    connect(m_device, &Ft991Device::catPower, this, [this](int watts) {
+        m_rfPowerWatts = watts;
+        if (m_connected)
+            emitTransmitState();
+    });
+    connect(m_device, &Ft991Device::catAgc, this, [this](const QString& agc) {
+        m_agcMode = agc;
+        if (m_connected)
+            emitSliceState();
+    });
+    connect(m_device, &Ft991Device::catWidth, this, [this](int shIndex) {
+        m_radioShIndex = shIndex;
+        applyRadioWidth(
+            Ft991Cat::widthForIndex(m_mode, shIndex, m_radioNarrow));
+    });
+    connect(m_device, &Ft991Device::catNarrow, this, [this](bool narrow) {
+        m_radioNarrow = narrow;
+        if (m_radioShIndex >= 0)
+            applyRadioWidth(
+                Ft991Cat::widthForIndex(m_mode, m_radioShIndex, narrow));
+    });
+    connect(m_device, &Ft991Device::catNoiseBlanker, this, [this](bool on) {
+        m_nbOn = on;
+        if (m_connected)
+            emitSliceState();
+    });
+    connect(m_device, &Ft991Device::catNoiseBlankerLevel, this, [this](int level) {
+        if (std::lround(m_nbLevelUi / 10.0) == level)
+            return;   // our own echo, same radio step — keep the finer value
+        m_nbLevelUi = std::clamp(level * 10, 0, 100);
+        if (m_connected)
+            emitSliceState();
+    });
+    connect(m_device, &Ft991Device::catNoiseReduction, this, [this](bool on) {
+        m_nrOn = on;
+        if (m_connected)
+            emitSliceState();
+    });
+    connect(m_device, &Ft991Device::catNoiseReductionLevel, this, [this](int level) {
+        if (1 + std::lround(m_nrLevelUi * 14.0 / 100.0) == level)
+            return;
+        m_nrLevelUi = std::clamp(
+            static_cast<int>(std::lround((level - 1) * 100.0 / 14.0)), 0, 100);
+        if (m_connected)
+            emitSliceState();
+    });
+    connect(m_device, &Ft991Device::catAutoNotch, this, [this](bool on) {
+        m_anfOn = on;
+        if (m_connected)
+            emitSliceState();
+    });
+    connect(m_device, &Ft991Device::catManualNotch, this, [this](bool on) {
+        m_manualNotchOn = on;
+        if (m_connected)
+            emitSliceState();
+    });
+    connect(m_device, &Ft991Device::catManualNotchHz, this, [this](int hz) {
+        m_manualNotchHz = hz;
+        // Report the radio's audio Hz back as the seam's 0..100 position,
+        // measured across the CURRENT passband — the same conversion the
+        // set path does, inverted.
+        const int lo = std::min(std::abs(m_filterLowHz), std::abs(m_filterHighHz));
+        const int hi = std::max(std::abs(m_filterLowHz), std::abs(m_filterHighHz));
+        if (hi > lo)
+            m_manualNotchPos = std::clamp((hz - lo) * 100 / (hi - lo), 0, 100);
+        if (m_connected)
+            emitSliceState();
+    });
+    connect(m_device, &Ft991Device::catSMeter, this, [this](int raw) {
+        const double dbm = sMeterRawToDbm(raw);
+        // Smooth every reading, publish on the tick (Colibri/Flex ballistics
+        // so the needle behaves the same way across radios).
+        if (!m_haveSMeter) {
+            m_sMeterDbm = dbm;
+            m_haveSMeter = true;
+        } else {
+            const double alpha = (dbm > m_sMeterDbm) ? kMeterAttackAlpha
+                                                     : kMeterDecayAlpha;
+            m_sMeterDbm = alpha * dbm + (1.0 - alpha) * m_sMeterDbm;
+        }
+        if (m_sMeterClock.isValid()
+            && m_sMeterClock.elapsed() < kMeterPublishIntervalMs)
+            return;
+        m_sMeterClock.restart();
+        emit meterUpdate(QStringLiteral("SLC:LEVEL"), m_sMeterDbm);
+    });
+
+    connect(m_device, &Ft991Device::catClarifier, this,
+            [this](bool ritOn, bool xitOn, int offsetHz) {
+        m_ritOn = ritOn;
+        m_xitOn = xitOn;
+        m_clarifierHz = offsetHz;
+        if (m_connected)
+            emitSliceState();
+    });
+    connect(m_device, &Ft991Device::catTxPowerMeter, this, [this](int raw) {
+        if (m_connected)
+            emit meterUpdate(QStringLiteral("TX:FWDPWR"),
+                             raw * kPoMeterFullScaleWatts / 255.0);
+    });
+    connect(m_device, &Ft991Device::catTxSwrMeter, this, [this](int raw) {
+        if (m_connected)
+            emit meterUpdate(QStringLiteral("TX:SWR"),
+                             1.0 + raw * kSwrMeterSpanPerCount);
+    });
+
+    // ---- data plane up ----
+    connect(m_device, &Ft991Device::spectrumFrame, this,
+            [this](const std::vector<float>& binsDbfs) {
+        if (!m_connected)
+            return;
+        // The symmetric window: 2N bins, dial at the seam between them.
+        // dBFS -> displayed dBm is one constant, so nothing the client does
+        // moves the trace. The audio bins land on the active sideband's
+        // half (audio ascending = RF ascending on USB, descending on LSB);
+        // AM/FM envelope audio has no sideband identity, so it is mirrored
+        // onto both halves; a half with no data reads kPadFloorDbm.
+        const std::size_t n = binsDbfs.size();
+        if (n == 0)
+            return;
+        const Sideband sb = sideband();
+        // The padded half sits at the frame's own measured floor WITH a
+        // small deterministic texture. Both properties are load-bearing:
+        //   - a level below any real floor (−160 was tried) poisons the
+        //     display's auto-level statistics, which ramped without bound;
+        //   - a CONSTANT level (the frame minimum was tried) is exactly the
+        //     clipped-floor signature SpectrumWidget's headroom recovery
+        //     looks for (bins at the frame min, in long identical runs) —
+        //     it then requested 24 dB more range every second, forever.
+        // floor + 0..3 dB of index-keyed ripple reads as a quiet floor to
+        // both detectors, and is honest to the eye: visibly flat, visibly
+        // below the real data.
+        const float base = static_cast<float>(
+            *std::min_element(binsDbfs.begin(), binsDbfs.end())
+            + kFullScaleDbm);
+        const auto padAt = [base](std::size_t i) {
+            return base + 0.5f * static_cast<float>((i * 13u) % 7u);
+        };
+        std::vector<float> dbm(n * 2);
+        if (sb != Sideband::High) {
+            // Left half: RF below the dial — audio frequency DESCENDS
+            // toward the pan centre, so the bins go in reversed.
+            for (std::size_t i = 0; i < n; ++i)
+                dbm[i] = static_cast<float>(binsDbfs[n - 1 - i] + kFullScaleDbm);
+        } else {
+            for (std::size_t i = 0; i < n; ++i)
+                dbm[i] = padAt(i);
+        }
+        if (sb != Sideband::Low) {
+            for (std::size_t i = 0; i < n; ++i)
+                dbm[n + i] = static_cast<float>(binsDbfs[i] + kFullScaleDbm);
+        } else {
+            for (std::size_t i = 0; i < n; ++i)
+                dbm[n + i] = padAt(n + i);
+        }
+        emit spectrumFrameReady(0, floatBytes(dbm));
+    });
+    connect(m_device, &Ft991Device::audioBlockReady, this,
+            [this](const std::vector<float>& pcm) {
+        if (m_connected)
+            routeAudio(pcm);
+    });
+
+    m_linkStatsTimer = new QTimer(this);
+    m_linkStatsTimer->setInterval(kLinkStatsIntervalMs);
+    connect(m_linkStatsTimer, &QTimer::timeout, this,
+            &Ft991Backend::publishLinkStats);
+}
+
+Ft991Backend::~Ft991Backend()
+{
+    if (m_ioThread) {
+        // Close ON the device's own thread and WAIT: quit() below ends the
+        // event loop a queued close would need, and tearing the port down
+        // from this thread is an affinity bug. closeDevice() unkeys first.
+        QMetaObject::invokeMethod(m_device, &Ft991Device::closeDevice,
+                                  Qt::BlockingQueuedConnection);
+        m_ioThread->quit();
+        m_ioThread->wait();
+    }
+    delete m_device;
+}
+
+RadioCapabilities Ft991Backend::capabilities() const
+{
+    RadioCapabilities c;
+    c.family = familyName();
+    c.model = QStringLiteral("FT-991");
+    c.maxSlices = 1;          // one receiver behind one codec; not a policy
+    c.maxPanadapters = 1;
+    c.tuningMinHz = Ft991Cat::kTuningMinHz;
+    c.tuningMaxHz = Ft991Cat::kTuningMaxHz;
+    c.canTransmit = true;     // CAT TX1/TX0; the engine guard sits above
+    c.txPowerMaxWatts = 100.0;
+    // The RF modulator is in the radio, but what this capability gates —
+    // the mic-source list, the PC-audio lock, TCI TX routing — is where the
+    // TX AUDIO comes from, and that is this host (design doc).
+    c.hostModulates = true;
+    c.persistsMemories = false;   // client-side memory bank engages
+    c.canReboot = false;
+    c.hasTuner = false;           // the internal ATU has no status wire here (v1)
+    c.hasAmplifier = false;
+    c.hasExtendedDsp = false;
+    c.hasProfiles = false;
+    c.hasDaxStreams = false;
+    c.hasRadioSideWaterfallAutoBlack = false;
+    c.hasWaveforms = false;
+    c.hasMultiClientSessions = false;   // one serial port, one owner
+    c.hasGpsLocation = false;
+    c.hasSupplyVoltageTelemetry = false;
+    // The radio runs its own receive DSP and the seam verbs reach it:
+    // NB+NL, DNR NR+RL, auto-notch BC, manual notch BP.
+    c.hasRadioSideDsp = true;
+    // …but nothing resembling WDSP's LMS/FFT family (NRL/ANFL/ANFT). This
+    // is exactly the split hasLmsNoiseFilters was introduced for.
+    c.hasLmsNoiseFilters = false;
+    c.hasManualNotch = true;
+    // EMPTY, deliberately: the FT-991 persists its own VFO/mode/settings
+    // across power cycles — radio-authoritative (Constitution II/III), the
+    // Flex rule. The client must restore nothing.
+    c.clientSettingsDomains = {};
+    return c;
+}
+
+void Ft991Backend::connectRadio(const RadioConnectRequest& request)
+{
+    // Identity is the discovery serial "ft991-<port>"; explicit automation
+    // params override (same precedence shape as HL2/Colibri).
+    m_portName.clear();
+    const QString serial = request.serial;
+    const qsizetype dash = serial.indexOf(QLatin1Char('-'));
+    if (dash >= 0)
+        m_portName = serial.mid(dash + 1);
+    if (request.params.contains(QStringLiteral("serialPort")))
+        m_portName = request.params.value(QStringLiteral("serialPort")).toString();
+    if (m_portName.isEmpty()) {
+        emit connectionError(QStringLiteral(
+            "FT-991: no serial port in connect request (serial \"%1\")")
+                .arg(serial));
+        return;
+    }
+
+    m_baudRate = Ft991Settings::baudRate();
+    if (request.params.contains(QStringLiteral("baudRate")))
+        m_baudRate = request.params.value(QStringLiteral("baudRate")).toInt();
+
+    Ft991Device::Params p;
+    p.portName = m_portName;
+    p.baudRate = m_baudRate;
+    p.audioInHint = Ft991Settings::audioInHint();
+    p.audioOutHint = Ft991Settings::audioOutHint();
+    if (request.params.contains(QStringLiteral("audioIn")))
+        p.audioInHint = request.params.value(QStringLiteral("audioIn")).toString();
+    if (request.params.contains(QStringLiteral("audioOut")))
+        p.audioOutHint = request.params.value(QStringLiteral("audioOut")).toString();
+    p.spectrumSpanHz = kAudioSpanHz;
+
+    m_moxRequested = false;
+    m_tuneActive = false;
+    m_haveSMeter = false;
+
+    qCInfo(lcFt991) << "connecting:" << p.portName << "@" << p.baudRate
+                    << "baud, audio in/out hint" << p.audioInHint;
+    QMetaObject::invokeMethod(m_device, [dev = m_device, p] {
+        dev->openDevice(p);
+    }, Qt::QueuedConnection);
+}
+
+void Ft991Backend::disconnectRadio()
+{
+    QMetaObject::invokeMethod(m_device, &Ft991Device::closeDevice,
+                              Qt::BlockingQueuedConnection);
+    if (m_connected) {
+        m_connected = false;
+        m_linkStatsTimer->stop();
+        emit disconnected();
+    }
+}
+
+bool Ft991Backend::isConnected() const
+{
+    return m_connected;
+}
+
+bool Ft991Backend::isOurPan(const QString& id) const
+{
+    // An EMPTY pan id addresses the (only) receiver.
+    return id.isEmpty() || id == panId();
+}
+
+// ---------------------------------------------------------------------------
+// Slice verbs — optimistic local echo, the poll confirms (or corrects)
+// ---------------------------------------------------------------------------
+
+void Ft991Backend::setSliceFrequency(int sliceId, double hz)
+{
+    if (sliceId != 0)
+        return;
+    if (!(hz >= Ft991Cat::kTuningMinHz) || !(hz <= Ft991Cat::kTuningMaxHz)) {
+        qCWarning(lcFt991) << "tune refused:" << hz << "Hz out of range";
+        return;
+    }
+    // Integer Hz: CAT carries whole hertz, and an exactly-representable
+    // dial is what makes the pan<->slice round trip a fixed point instead
+    // of a sub-hertz oscillation.
+    const double dial = static_cast<double>(std::llround(hz));
+    if (dial == m_dialHz)
+        return;   // change-gated: an echo of our own state must die here
+    if (m_tuneVerbDepth >= kMaxTuneVerbDepth) {
+        qCWarning(lcFt991) << "tune verb recursion truncated at depth"
+                           << m_tuneVerbDepth << "(requested" << dial << "Hz)";
+        return;
+    }
+    ++m_tuneVerbDepth;
+    m_dialHz = dial;
+    QMetaObject::invokeMethod(m_device, [dev = m_device, dial] {
+        dev->setFrequencyHz(dial);
+    }, Qt::QueuedConnection);
+    emitSliceState();
+    emitPanState();
+    --m_tuneVerbDepth;
+}
+
+void Ft991Backend::setSliceMode(int sliceId, const QString& mode)
+{
+    if (sliceId != 0)
+        return;
+    if (Ft991Cat::modeToCat(mode).isNull()) {
+        qCWarning(lcFt991) << "mode" << mode << "has no FT-991 mapping";
+        return;
+    }
+    const bool changed = mode.compare(m_mode, Qt::CaseInsensitive) != 0;
+    m_mode = mode.toUpper();
+    if (changed) {
+        const auto [lo, hi] = defaultPassbandForMode(m_mode);
+        m_filterLowHz = lo;
+        m_filterHighHz = hi;
+        pushPassbandToDevice();
+    }
+    QMetaObject::invokeMethod(m_device, [dev = m_device, m = m_mode] {
+        dev->setMode(m);
+    }, Qt::QueuedConnection);
+    emitSliceState();
+    emitPanState();
+}
+
+void Ft991Backend::setSliceFilter(int sliceId, int lowHz, int highHz)
+{
+    if (sliceId != 0)
+        return;
+    // The handles are doubly real: the host biquad chain applies the exact
+    // edges immediately, AND the radio's own DSP width follows — snapped to
+    // the nearest CAT SH step. The width confirm-poll then reflects what
+    // the radio actually took (applyRadioWidth), so the display converges
+    // on radio truth rather than on the request.
+    m_filterLowHz = lowHz;
+    m_filterHighHz = highHz;
+    pushPassbandToDevice();
+    if (Ft991Cat::widthFamilyForMode(m_mode) != Ft991Cat::WidthFamily::Fixed) {
+        const int width = std::abs(highHz - lowHz);
+        QMetaObject::invokeMethod(m_device,
+            [dev = m_device, m = m_mode, width] {
+                dev->setRadioWidth(m, width);
+            }, Qt::QueuedConnection);
+    }
+    emitSliceState();
+}
+
+void Ft991Backend::setSliceAgc(int sliceId, const QString& mode, int thresholdDb)
+{
+    if (sliceId != 0)
+        return;
+    m_agcMode = mode;
+    m_agcThresholdDb = thresholdDb;   // no CAT threshold; kept for the UI echo
+    QMetaObject::invokeMethod(m_device, [dev = m_device, m = mode] {
+        dev->setAgc(m);
+    }, Qt::QueuedConnection);
+    emitSliceState();
+}
+
+void Ft991Backend::setSliceNoiseBlanker(int sliceId, bool on, int level)
+{
+    if (sliceId != 0)
+        return;
+    m_nbOn = on;
+    m_nbLevelUi = std::clamp(level, 0, 100);
+    const int radioLevel =
+        static_cast<int>(std::lround(m_nbLevelUi / 10.0));   // NL 0..10
+    QMetaObject::invokeMethod(m_device, [dev = m_device, on, radioLevel] {
+        dev->setRadioNoiseBlanker(on);
+        dev->setRadioNoiseBlankerLevel(radioLevel);
+    }, Qt::QueuedConnection);
+    emitSliceState();
+}
+
+void Ft991Backend::setSliceNoiseReduction(int sliceId, bool on, int level)
+{
+    if (sliceId != 0)
+        return;
+    m_nrOn = on;
+    m_nrLevelUi = std::clamp(level, 0, 100);
+    const int radioLevel = 1
+        + static_cast<int>(std::lround(m_nrLevelUi * 14.0 / 100.0));  // RL 1..15
+    QMetaObject::invokeMethod(m_device, [dev = m_device, on, radioLevel] {
+        dev->setRadioNoiseReduction(on);
+        dev->setRadioNoiseReductionLevel(radioLevel);
+    }, Qt::QueuedConnection);
+    emitSliceState();
+}
+
+void Ft991Backend::setSliceAutoNotch(int sliceId, bool on)
+{
+    if (sliceId != 0)
+        return;
+    m_anfOn = on;
+    QMetaObject::invokeMethod(m_device, [dev = m_device, on] {
+        dev->setRadioAutoNotch(on);
+    }, Qt::QueuedConnection);
+    emitSliceState();
+}
+
+void Ft991Backend::setSliceManualNotch(int sliceId, bool on, int position)
+{
+    if (sliceId != 0)
+        return;
+    // The seam's position is 0..100 ACROSS THE PASSBAND, not a frequency —
+    // so the notch tracks the filter instead of being re-derived by every
+    // caller. This radio places it in audio Hz (BP01, 10 Hz steps), and the
+    // passband is where that conversion belongs.
+    m_manualNotchPos = std::clamp(position, 0, 100);
+    const int lo = std::min(std::abs(m_filterLowHz), std::abs(m_filterHighHz));
+    const int hi = std::max(std::abs(m_filterLowHz), std::abs(m_filterHighHz));
+    const int hz = lo + (hi - lo) * m_manualNotchPos / 100;
+    m_manualNotchOn = on;
+    m_manualNotchHz = hz;
+    QMetaObject::invokeMethod(m_device, [dev = m_device, on, hz] {
+        dev->setRadioManualNotch(on, hz);
+    }, Qt::QueuedConnection);
+    emitSliceState();
+}
+
+void Ft991Backend::setRitEnabled(bool on)
+{
+    m_ritOn = on;
+    pushClarifier();
+}
+
+void Ft991Backend::setXitEnabled(bool on)
+{
+    m_xitOn = on;
+    pushClarifier();
+}
+
+void Ft991Backend::setRitOffset(int hz)
+{
+    // XIT routes here too (setXitOffset's default), which is the truth on
+    // this radio: one clarifier register, two enables.
+    m_clarifierHz = hz;
+    pushClarifier();
+}
+
+void Ft991Backend::pushClarifier()
+{
+    QMetaObject::invokeMethod(m_device,
+        [dev = m_device, r = m_ritOn, x = m_xitOn, o = m_clarifierHz] {
+            dev->setRadioClarifier(r, x, o);
+        }, Qt::QueuedConnection);
+    emitSliceState();
+}
+
+void Ft991Backend::setSliceAudioMute(int sliceId, bool mute)
+{
+    if (sliceId != 0)
+        return;
+    m_audioMuted = mute;
+    emitSliceState();
+}
+
+void Ft991Backend::setSliceAudioGain(int sliceId, int gainPercent)
+{
+    if (sliceId != 0)
+        return;
+    m_audioGain = static_cast<float>(std::clamp(gainPercent, 0, 100)) / 100.0f;
+    emitSliceState();
+}
+
+void Ft991Backend::setSliceAudioPan(int sliceId, int panPercent)
+{
+    if (sliceId != 0)
+        return;
+    m_audioPanPercent = std::clamp(panPercent, 0, 100);
+    emitSliceState();
+}
+
+void Ft991Backend::setActiveSlice(int sliceId)
+{
+    Q_UNUSED(sliceId);   // one slice; always active
+}
+
+void Ft991Backend::setTxSlice(int sliceId)
+{
+    Q_UNUSED(sliceId);   // one slice; transmit always lives on it
+}
+
+// ---------------------------------------------------------------------------
+// Pan verbs — the lens
+// ---------------------------------------------------------------------------
+
+Ft991Backend::Sideband Ft991Backend::sideband() const
+{
+    const QString u = m_mode.toUpper();
+    if (u == QLatin1String("AM") || u == QLatin1String("FM")
+        || u == QLatin1String("NFM"))
+        return Sideband::Both;
+    return Ft991Cat::isLowSideband(m_mode) ? Sideband::Low : Sideband::High;
+}
+
+void Ft991Backend::setPanCenter(const QString& id, double hz,
+                                PanCenterIntent intent)
+{
+    if (!isOurPan(id) || hz <= 0.0)
+        return;
+    // This window is the audio band around the dial — slaved to the VFO,
+    // exactly the case the intent exists for. A DRAG is the operator asking
+    // to listen elsewhere, so it retunes. A centre riding along with a zoom
+    // must NOT walk the radio across the band, so it is answered with the
+    // geometry we already have.
+    if (intent == PanCenterIntent::Range) {
+        emitPanState();
+        return;
+    }
+    // The window is centred ON the dial, so moving the window IS retuning
+    // the radio — and the GUI re-centring the pan onto the slice is the
+    // identity, which the change gate in setSliceFrequency absorbs.
+    const double dial = std::round(hz);
+    if (dial == m_dialHz) {
+        emitPanState();
+        return;
+    }
+    setSliceFrequency(0, dial);
+}
+
+void Ft991Backend::setPanBandwidth(const QString& id, double hz)
+{
+    if (!isOurPan(id) || hz <= 0.0)
+        return;
+    // The span is the audio window; there is nothing to zoom. Re-emitting
+    // the unchanged span is how the widget snaps back to what is real
+    // (#4470 honesty rule).
+    emitPanState();
+}
+
+void Ft991Backend::setPanFrameRate(const QString& id, int fps)
+{
+    if (!isOurPan(id))
+        return;
+    QMetaObject::invokeMethod(m_device, [dev = m_device, fps] {
+        dev->setSpectrumRateFps(fps);
+    }, Qt::QueuedConnection);
+}
+
+// ---------------------------------------------------------------------------
+// Transmit
+// ---------------------------------------------------------------------------
+
+void Ft991Backend::setKeying(bool key)
+{
+    if (!m_connected) {
+        if (key)
+            qCWarning(lcFt991) << "keying refused: not connected";
+        return;
+    }
+    m_moxRequested = key;
+    QMetaObject::invokeMethod(m_device, [dev = m_device, key] {
+        dev->setPtt(key);
+    }, Qt::QueuedConnection);
+    // Optimistic: the TX poll confirms (and reflects the radio's own
+    // unkeying — TOT, front-panel PTT release — either way).
+    m_mox = key;
+    emitTransmitState();
+}
+
+void Ft991Backend::setTune(bool on, int tunePowerPercent)
+{
+    if (!m_connected)
+        return;
+    if (on == m_tuneActive)
+        return;
+    m_tuneActive = on;
+    if (on) {
+        // Swap the drive to TUNE power for the duration; restore after.
+        m_preTunePowerWatts = m_rfPowerWatts;
+        if (tunePowerPercent >= 0) {
+            const int watts = std::clamp(tunePowerPercent, 5, 100);
+            QMetaObject::invokeMethod(m_device, [dev = m_device, watts] {
+                dev->setPowerWatts(watts);
+            }, Qt::QueuedConnection);
+        }
+        QMetaObject::invokeMethod(m_device, &Ft991Device::startTune,
+                                  Qt::QueuedConnection);
+        m_moxRequested = true;
+        m_mox = true;
+    } else {
+        QMetaObject::invokeMethod(m_device, &Ft991Device::stopTune,
+                                  Qt::QueuedConnection);
+        if (m_preTunePowerWatts > 0) {
+            const int watts = m_preTunePowerWatts;
+            QMetaObject::invokeMethod(m_device, [dev = m_device, watts] {
+                dev->setPowerWatts(watts);
+            }, Qt::QueuedConnection);
+            m_preTunePowerWatts = -1;
+        }
+        m_moxRequested = false;
+        m_mox = false;
+    }
+    emitTransmitState();
+}
+
+void Ft991Backend::setTxPower(int percent)
+{
+    // On HF the FT-991's PC range is 5..100 W, so percent maps 1:1 onto
+    // watts. Clamped low rather than refused: 0% means "as low as it goes".
+    const int watts = std::clamp(percent, 5, 100);
+    m_rfPowerWatts = watts;
+    QMetaObject::invokeMethod(m_device, [dev = m_device, watts] {
+        dev->setPowerWatts(watts);
+    }, Qt::QueuedConnection);
+    emitTransmitState();
+}
+
+void Ft991Backend::setMicGain(int level)
+{
+    // Applied digitally to the TX audio this host plays into the codec —
+    // the radio's own mic preamp is not in this path.
+    m_micGainPercent = std::clamp(level, 0, 100);
+}
+
+void Ft991Backend::submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz)
+{
+    if (!m_connected || !m_moxRequested)
+        return;
+    const float gain = static_cast<float>(m_micGainPercent) / 100.0f;
+    QMetaObject::invokeMethod(m_device,
+        [dev = m_device, pcm = int16Stereo, sampleRateHz, gain] {
+            dev->submitTxAudio(pcm, sampleRateHz, gain);
+        }, Qt::QueuedConnection);
+}
+
+void Ft991Backend::invokeExtension(const QString& ns, const QString& verb,
+                                   quint64 requestId, const QVariant& arg)
+{
+    Q_UNUSED(arg);
+    if (requestId == 0)
+        return;
+    emit extensionError(requestId,
+                        QStringLiteral("unknown extension %1.%2").arg(ns, verb));
+}
+
+// ---------------------------------------------------------------------------
+// State publication
+// ---------------------------------------------------------------------------
+
+void Ft991Backend::applyRadioWidth(int widthHz)
+{
+    if (widthHz <= 0)
+        return;
+    if (Ft991Cat::widthFamilyForMode(m_mode) == Ft991Cat::WidthFamily::Fixed)
+        return;
+    // Same width as already displayed: keep the operator's exact edges —
+    // the radio cannot represent an off-centre drag, and rewriting equal
+    // width with anchored edges would fight every fine adjustment.
+    if (std::abs(m_filterHighHz - m_filterLowHz) == widthHz)
+        return;
+    const bool cw = m_mode.compare(QLatin1String("CW"), Qt::CaseInsensitive) == 0
+        || m_mode.compare(QLatin1String("CWL"), Qt::CaseInsensitive) == 0;
+    int lo = 0;
+    int hi = 0;
+    if (cw) {
+        // CW displays carrier-centred (SliceModel heals CW filters to that
+        // convention anyway); the pitch offset is applied where the audio
+        // band is computed, in pushPassbandToDevice().
+        lo = -widthHz / 2;
+        hi = lo + widthHz;
+    } else {
+        lo = std::max(kMinFilterEdgeHz, kSsbWidthAnchorHz - widthHz / 2);
+        hi = lo + widthHz;
+        if (Ft991Cat::isLowSideband(m_mode)) {
+            const int t = lo;
+            lo = -hi;
+            hi = -t;
+        }
+    }
+    m_filterLowHz = lo;
+    m_filterHighHz = hi;
+    pushPassbandToDevice();
+    if (m_connected)
+        emitSliceState();
+}
+
+void Ft991Backend::pushPassbandToDevice()
+{
+    int lo = m_filterLowHz;
+    int hi = m_filterHighHz;
+    // CW's filter convention is CARRIER-centred (a 100 Hz filter displays
+    // as -50..+50), but the radio's demodulated audio puts the carrier at
+    // the sidetone pitch — the audio band is pitch ± width/2, and feeding
+    // the signed pair to the straddle logic below would low-pass at 50 Hz
+    // and silence the tone entirely.
+    const QString u = m_mode.toUpper();
+    if (u == QLatin1String("CW") || u == QLatin1String("CWL")) {
+        const int width = std::abs(hi - lo);
+        lo = std::max(10, kCwWidthAnchorHz - width / 2);
+        hi = lo + width;
+    }
+    QMetaObject::invokeMethod(m_device, [dev = m_device, lo, hi] {
+        dev->setAudioPassband(lo, hi);
+    }, Qt::QueuedConnection);
+}
+
+void Ft991Backend::routeAudio(const std::vector<float>& pcm)
+{
+    // THIS SLICE's audio, pre-mute and pre-gain — a decoder/TCI consumer
+    // must not stop decoding because the operator muted the speaker.
+    emit sliceAudioFrameReady(0, floatBytes(pcm));
+
+    if (m_audioMuted)
+        return;
+    if (m_audioGain == 1.0f && m_audioPanPercent == kAudioPanCentre) {
+        emit audioFrameReady(floatBytes(pcm));   // steady state: no copy
+        return;
+    }
+    // Balance is a BALANCE, not a constant-power pan: centre leaves both
+    // channels at unity rather than dipping them 3 dB.
+    const float left = m_audioPanPercent > kAudioPanCentre
+        ? static_cast<float>(100 - m_audioPanPercent) / 50.0f : 1.0f;
+    const float right = m_audioPanPercent < kAudioPanCentre
+        ? static_cast<float>(m_audioPanPercent) / 50.0f : 1.0f;
+    m_audioScratch.resize(pcm.size());
+    for (std::size_t i = 0; i + 1 < pcm.size(); i += 2) {
+        m_audioScratch[i] = pcm[i] * m_audioGain * left;
+        m_audioScratch[i + 1] = pcm[i + 1] * m_audioGain * right;
+    }
+    emit audioFrameReady(floatBytes(m_audioScratch));
+}
+
+double Ft991Backend::sMeterRawToDbm(int raw) const
+{
+    return kSMeterFloorDbm + std::clamp(raw, 0, 255) * kSMeterDbPerCount;
+}
+
+void Ft991Backend::emitSliceState()
+{
+    SliceDelta d;
+    d.panId = panId();
+    d.frequency = m_dialHz / 1.0e6;   // MHz — the dial IS the slice
+    d.mode = m_mode;
+    d.filterLow = m_filterLowHz;
+    d.filterHigh = m_filterHighHz;
+    d.agcMode = m_agcMode;
+    d.agcThreshold = m_agcThresholdDb;
+    d.audioMute = m_audioMuted;
+    d.audioPan = m_audioPanPercent;
+    // Radio-side DSP mirror: what the CAT plane last confirmed (or our
+    // optimistic set, corrected by the next poll).
+    d.nb = m_nbOn;
+    d.nbLevel = m_nbLevelUi;
+    d.nr = m_nrOn;
+    d.nrLevel = m_nrLevelUi;
+    d.anf = m_anfOn;
+    // The shared clarifier reported into BOTH halves — the model keeps
+    // them separate, but on this radio they are one number.
+    d.ritOn = m_ritOn;
+    d.ritFreq = m_clarifierHz;
+    d.xitOn = m_xitOn;
+    d.xitFreq = m_clarifierHz;
+    d.mn = m_manualNotchOn;
+    d.mnLevel = m_manualNotchPos;
+    // ONE slice: always active, always the TX slice — this radio's one
+    // transmitter lives wherever the dial is.
+    d.active = true;
+    d.txSlice = true;
+    emit sliceChanged(0, d);
+}
+
+void Ft991Backend::emitPanState()
+{
+    // Centre == dial, span == both halves of the symmetric window.
+    emit panCenterBandwidthChanged(panId(), m_dialHz / 1.0e6,
+                                   m_coveredSpanHz * 2.0 / 1.0e6);
+}
+
+void Ft991Backend::emitTransmitState()
+{
+    TransmitDelta d;
+    d.mox = m_mox;
+    d.tune = m_tuneActive;
+    d.rfPower = m_rfPowerWatts;      // 1:1 watts<->percent on this radio
+    d.maxPowerLevel = 100;
+    d.transmitFreq = m_dialHz / 1.0e6;
+    d.txSliceMode = m_mode;
+    emit transmitChanged(d);
+}
+
+void Ft991Backend::defineMeters()
+{
+    MeterDef d;
+    d.index = 1;
+    d.source = QStringLiteral("SLC");
+    d.name = QStringLiteral("LEVEL");
+    d.unit = QStringLiteral("dBm");
+    d.low = -140.0;
+    d.high = 0.0;
+    d.description = QStringLiteral("Receive signal level (radio S-meter, uncalibrated)");
+    emit meterDefined(d);
+
+    // TX meters, polled off RM5/RM6 while keyed. FWDPWR and SWR are the
+    // names MeterModel resolves for the TX gauges.
+    MeterDef po;
+    po.index = 2;
+    po.source = QStringLiteral("TX");
+    po.name = QStringLiteral("FWDPWR");
+    po.unit = QStringLiteral("W");
+    po.low = 0.0;
+    po.high = kPoMeterFullScaleWatts;
+    po.description = QStringLiteral("Forward power (radio PO meter, uncalibrated)");
+    emit meterDefined(po);
+
+    MeterDef swr;
+    swr.index = 3;
+    swr.source = QStringLiteral("TX");
+    swr.name = QStringLiteral("SWR");
+    swr.unit = QStringLiteral("SWR");
+    swr.low = 1.0;
+    swr.high = 5.0;
+    swr.description = QStringLiteral("Antenna SWR (radio meter, uncalibrated)");
+    emit meterDefined(swr);
+}
+
+void Ft991Backend::publishLinkStats()
+{
+    LinkStats s = linkStats();
+    // Fresh audio blocks since the last tick — the proof-of-life the
+    // heartbeat runs on. The codec stream is the transport of consequence:
+    // CAT alone answering while audio is dead IS a dead receiver.
+    const quint64 blocks = m_device ? m_device->audioBlocks() : 0;
+    s.alive = m_connected && blocks != m_linkBlocksAtLastTick;
+    m_linkBlocksAtLastTick = blocks;
+    emit linkStatsUpdated(s);
+}
+
+IRadioBackend::LinkStats Ft991Backend::linkStats() const
+{
+    LinkStats s;
+    s.reported = m_connected;
+    if (!m_connected || !m_device)
+        return s;
+    s.rxPackets = m_device->audioBlocks();
+    s.rxBytes = static_cast<qint64>(m_device->serialRxBytes()
+        + m_device->audioSamples() * sizeof(float));
+    s.txBytes = static_cast<qint64>(m_device->serialTxBytes());
+    // A real request/response RTT, from the CAT query clock.
+    s.rttMs = m_device->catRttMs();
+    s.jitterMs = -1;
+    s.localEndpoint = m_portName;
+    return s;
+}
+
+IRadioBackend::HealthSnapshot Ft991Backend::healthSnapshot() const
+{
+    HealthSnapshot h;
+    auto put = [&h](const QString& key, const QVariant& value, const QString& label) {
+        h.values.insert(key, value);
+        h.order.append(key);
+        h.labels.insert(key, label);
+    };
+    put(QStringLiteral("port"),
+        QStringLiteral("%1 @ %2 baud (8N2)").arg(m_portName).arg(m_baudRate),
+        QStringLiteral("CAT port"));
+    if (m_device) {
+        const int rtt = m_device->catRttMs();
+        if (rtt >= 0)
+            put(QStringLiteral("catRtt"), QStringLiteral("%1 ms").arg(rtt),
+                QStringLiteral("CAT round-trip"));
+        put(QStringLiteral("catTimeouts"), m_device->catTimeouts(),
+            QStringLiteral("CAT timeouts"));
+    }
+    if (m_connected) {
+        put(QStringLiteral("audioIn"),
+            QStringLiteral("%1 @ %2 Hz")
+                .arg(m_openInfo.audioInDesc)
+                .arg(m_openInfo.audioInRateHz),
+            QStringLiteral("RX audio"));
+        // "none" is information on a transceiver: it means TX is silent.
+        put(QStringLiteral("audioOut"),
+            m_openInfo.audioOutDesc.isEmpty()
+                ? QStringLiteral("none — TX audio unavailable")
+                : QStringLiteral("%1 @ %2 Hz")
+                      .arg(m_openInfo.audioOutDesc)
+                      .arg(m_openInfo.audioOutRateHz),
+            QStringLiteral("TX audio"));
+        put(QStringLiteral("lens"),
+            QStringLiteral("%1 Hz audio window")
+                .arg(static_cast<int>(std::lround(m_coveredSpanHz))),
+            QStringLiteral("Panadapter span"));
+        if (m_device)
+            put(QStringLiteral("audioBlocksIn"),
+                static_cast<qulonglong>(m_device->audioBlocks()),
+                QStringLiteral("Audio blocks received"));
+    }
+    h.sections.insert(h.order.isEmpty() ? QString{} : h.order.first(),
+                      QStringLiteral("FT-991"));
+    return h;
+}
+
+}  // namespace AetherSDR::ft991

--- a/src/core/backends/ft991/Ft991Backend.h
+++ b/src/core/backends/ft991/Ft991Backend.h
@@ -1,0 +1,226 @@
+#pragma once
+
+#include "core/backends/IRadioBackend.h"
+#include "core/backends/ft991/Ft991Device.h"
+
+#include <QElapsedTimer>
+#include <QString>
+#include <QThread>
+#include <QTimer>
+
+#include <vector>
+
+namespace AetherSDR::ft991 {
+
+// IRadioBackend implementation for the Yaesu FT-991/FT-991A: CAT over the
+// radio's serial port, audio over its USB codec. The radio demodulates and
+// modulates internally, so unlike HL2/Colibri there is NO host DSP chain
+// below this seam — what the backend owns is the CAT translation, the
+// audio plumbing, and the honest mapping of the 4 kHz audio window onto RF
+// (the "panadapter is a lens" contract; see the design doc).
+//
+// ONE slice, ONE pan, fixed: the slice frequency IS the radio's dial. The
+// radio persists its own state, so clientSettingsDomains is EMPTY — the
+// first radio-authoritative non-Flex backend (Constitution II/III).
+//
+// TRANSMIT-capable: keying is CAT TX1/TX0 from setKeying()/setTune() only;
+// submitTxAudio() plays the engine's processed TX audio into the codec.
+// hostModulates=true because what that capability gates — where the TX
+// audio comes from — is this host, even though the RF modulator is in the
+// radio.
+class Ft991Backend : public IRadioBackend {
+    Q_OBJECT
+
+public:
+    explicit Ft991Backend(QObject* parent = nullptr);
+    ~Ft991Backend() override;
+
+    RadioCapabilities capabilities() const override;
+    // Demodulated audio arrives over the seam; audio reaches the engine
+    // through the RadioModel relay exactly like HL2/Colibri — see
+    // MainWindow::backendFeedsEngineDirectly() before "simplifying" either.
+    bool ownsRxAudio() const override { return true; }
+
+    void connectRadio(const RadioConnectRequest& request) override;
+    void disconnectRadio() override;
+    bool isConnected() const override;
+
+    void setSliceFrequency(int sliceId, double hz) override;
+    void setSliceMode(int sliceId, const QString& mode) override;
+    void setSliceFilter(int sliceId, int lowHz, int highHz) override;
+    void setSliceAgc(int sliceId, const QString& mode, int thresholdDb) override;
+    void setSliceNoiseBlanker(int sliceId, bool on, int level) override;
+    void setSliceNoiseReduction(int sliceId, bool on, int level) override;
+    void setSliceAutoNotch(int sliceId, bool on) override;
+    void setSliceManualNotch(int sliceId, bool on, int position) override;
+    void setRitEnabled(bool on) override;
+    void setXitEnabled(bool on) override;
+    // ONE shared clarifier register — exactly the case setXitOffset's
+    // default aliasing was written for, so XIT deliberately inherits it.
+    void setRitOffset(int hz) override;
+    void setSliceAudioMute(int sliceId, bool mute) override;
+    void setSliceAudioGain(int sliceId, int gainPercent) override;
+    void setSliceAudioPan(int sliceId, int panPercent) override;
+    void setActiveSlice(int sliceId) override;
+    void setTxSlice(int sliceId) override;
+    void setPanCenter(const QString& panId, double hz,
+                      PanCenterIntent intent) override;
+    void setPanBandwidth(const QString& panId, double hz) override;
+    void setPanFrameRate(const QString& panId, int fps) override;
+    void setKeying(bool key) override;
+    void setTune(bool on, int tunePowerPercent) override;
+    void setTxPower(int percent) override;
+    void setMicGain(int level) override;
+    void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz) override;
+    void invokeExtension(const QString& ns, const QString& verb, quint64 requestId,
+                         const QVariant& arg) override;
+
+    HealthSnapshot healthSnapshot() const override;
+    LinkStats linkStats() const override;
+
+    static QString familyName() { return QStringLiteral("ft991"); }
+
+private:
+    // The seam's pan identifier for the one receiver.
+    static QString panId() { return QStringLiteral("ft991-0"); }
+    [[nodiscard]] bool isOurPan(const QString& id) const;
+
+    // The pan window is SYMMETRIC about the dial: [dial−span, dial+span]
+    // where span is the audio window. The half with no data is emitted at
+    // kPadFloorDbm. Symmetric is load-bearing, not cosmetic: every consumer
+    // assumes the active slice can sit at the pan centre, and the GUI's
+    // slice-follow policy re-centres the pan onto the slice — with the
+    // slice pinned to a window EDGE that became a feedback loop walking
+    // the dial span/2 per round, through the CAT to the real radio, until
+    // the stack overflowed (see the depth guard below, which caught it).
+    // centre == dial makes that re-centre request the identity.
+    enum class Sideband { High, Low, Both };
+    [[nodiscard]] Sideband sideband() const;
+
+    // Hand the current slice passband to the device's host-side biquad
+    // chain (queued) — the one place the filter handles become audible.
+    void pushPassbandToDevice();
+    // Hand the clarifier triple to the device (queued). One register, two
+    // enables — so every clarifier verb funnels through here.
+    void pushClarifier();
+
+    // Reflect the RADIO's filter width (SH/NA polls) into the slice's
+    // displayed passband: anchored per mode family, signed per sideband.
+    // Never sends anything back down — pure reflection.
+    void applyRadioWidth(int widthHz);
+
+    void emitSliceState();
+    void emitPanState();
+    void emitTransmitState();
+    void defineMeters();
+    void publishLinkStats();
+    void routeAudio(const std::vector<float>& pcm);
+    [[nodiscard]] double sMeterRawToDbm(int raw) const;
+
+    // ---- objects on the I/O thread ----
+    Ft991Device* m_device = nullptr;
+    QThread* m_ioThread = nullptr;
+
+    // ---- mirrored radio state (the CAT polls are the authority) ----
+    bool m_connected = false;
+    double m_dialHz = 14'074'000.0;
+    QString m_mode = QStringLiteral("USB");
+    int m_filterLowHz = 150;
+    int m_filterHighHz = 3000;
+    QString m_agcMode = QStringLiteral("med");
+    int m_agcThresholdDb = 65;      // display-side only; no CAT threshold
+    bool m_moxRequested = false;    // OUR keying intent
+    bool m_mox = false;             // what the radio reports (TX != 0)
+    bool m_tuneActive = false;
+    int m_rfPowerWatts = 100;
+    int m_preTunePowerWatts = -1;
+    int m_micGainPercent = 100;
+    bool m_audioMuted = false;
+    float m_audioGain = 1.0f;
+    int m_audioPanPercent = 50;
+
+    // Radio-side DSP mirror (CAT polls are the authority). Levels are kept
+    // in the slice's own 0..100 scale; the coarser radio scales (NL 0..10,
+    // RL 1..15) are mapped at the verb/echo boundary, and an echo only
+    // rewrites the UI value when it maps to a DIFFERENT radio step — so a
+    // slider at 47 is not yanked to 50 by its own echo.
+    bool m_nbOn = false;
+    int m_nbLevelUi = 50;
+    bool m_nrOn = false;
+    int m_nrLevelUi = 50;
+    bool m_anfOn = false;
+    int m_radioShIndex = -1;
+    bool m_radioNarrow = false;
+    bool m_manualNotchOn = false;
+    int m_manualNotchHz = 0;
+    // Clarifier mirror. ONE offset on this radio (see Ft991Cat); the seam
+    // already models that shape, so nothing is collapsed here.
+    bool m_ritOn = false;
+    bool m_xitOn = false;
+    int m_clarifierHz = 0;
+    // Manual notch position as the seam means it: 0..100 across the
+    // passband. Converted to the radio's audio Hz at the boundary.
+    int m_manualNotchPos = 50;
+
+    // Where the reflected passband anchors, per mode family (audio Hz).
+    // SSB/DATA centre their DSP width near 1500; CW near the sidetone.
+    static constexpr int kSsbWidthAnchorHz = 1500;
+    static constexpr int kCwWidthAnchorHz = 700;
+    static constexpr int kMinFilterEdgeHz = 50;
+    double m_coveredSpanHz = 4000.0;
+    Ft991Device::OpenInfo m_openInfo;
+    QString m_portName;
+    int m_baudRate = 38400;
+
+    // Re-entrancy depth across the tune verbs. The lens couples the pan
+    // centre rigidly to the dial, and every emission here is applied
+    // synchronously by RadioModel — so a GUI policy that answers a pan move
+    // with another pan move can recurse through this backend without a
+    // single queued hop in between (stack overflow, not a hang). The depth
+    // guard truncates any such cycle and names it in the log; the
+    // change-gating in the verbs keeps the guard from ever firing in
+    // healthy operation.
+    int m_tuneVerbDepth = 0;
+    static constexpr int kMaxTuneVerbDepth = 8;
+
+    // S-meter ballistics (shared numbers with Colibri/HL2/Flex).
+    QElapsedTimer m_sMeterClock;
+    double m_sMeterDbm = 0.0;
+    bool m_haveSMeter = false;
+
+    std::vector<float> m_audioScratch;
+
+    QTimer* m_linkStatsTimer = nullptr;
+    quint64 m_linkBlocksAtLastTick = 0;
+    static constexpr int kLinkStatsIntervalMs = 1000;
+
+    // The audio window the lens covers, Hz. 4 kHz holds the widest SSB
+    // filter (3.2 kHz) with margin; the honest covered span comes back from
+    // the device (bin rounding) in OpenInfo.
+    static constexpr double kAudioSpanHz = 4000.0;
+
+    // Displayed full-scale estimate, dBm at the top of the codec's range.
+    // UNCALIBRATED, and doubly so here: the radio's own AGC sits in front
+    // of the codec (see the design doc). One constant so nothing the client
+    // does moves the trace.
+    static constexpr double kFullScaleDbm = -10.0;
+
+    // TX meter scaling, raw 0..255, both UNCALIBRATED linear estimates
+    // (the CAT manual publishes no calibration): PO full scale = the HF
+    // 100 W rating; SWR spans 1.0..4.0 across the meter.
+    static constexpr double kPoMeterFullScaleWatts = 100.0;
+    static constexpr double kSwrMeterSpanPerCount = 3.0 / 255.0;
+
+    // S-meter raw 0..255 -> displayed dBm, linear and uncalibrated:
+    // 0 -> -127 dBm (S0-ish), 255 -> -34 dBm (~S9+40).
+    static constexpr double kSMeterFloorDbm = -127.0;
+    static constexpr double kSMeterDbPerCount = 93.0 / 255.0;
+
+    // Meter pacing/ballistics — shared numbers with HL2/Flex/Colibri.
+    static constexpr qint64 kMeterPublishIntervalMs = 100;
+    static constexpr double kMeterAttackAlpha = 0.5;
+    static constexpr double kMeterDecayAlpha = 0.15;
+    static constexpr int kAudioPanCentre = 50;
+};
+
+}  // namespace AetherSDR::ft991

--- a/src/core/backends/ft991/Ft991Cat.cpp
+++ b/src/core/backends/ft991/Ft991Cat.cpp
@@ -1,0 +1,509 @@
+#include "core/backends/ft991/Ft991Cat.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <iterator>
+#include <limits>
+
+namespace AetherSDR::ft991 {
+
+namespace Ft991Cat {
+
+namespace {
+
+// The FT-991 MD0 mode table (CAT manual, MD command). Kept as one table so
+// the two directions cannot drift apart.
+struct ModeRow {
+    char code;
+    const char* neutral;   // what SliceModel displays
+    bool lowSideband;
+    bool setTarget;        // the row modeToCat picks for this neutral name
+};
+constexpr ModeRow kModes[] = {
+    {'1', "LSB",  true,  true},
+    {'2', "USB",  false, true},
+    {'3', "CW",   false, true},    // CW-U
+    {'4', "FM",   false, true},
+    {'5', "AM",   false, true},
+    {'6', "DIGL", true,  false},   // RTTY-LSB, displayed as DIGL
+    {'7', "CWL",  true,  true},    // CW-R
+    {'8', "DIGL", true,  true},    // DATA-LSB
+    {'9', "DIGU", false, false},   // RTTY-USB, displayed as DIGU
+    {'A', "FM",   false, false},   // DATA-FM
+    {'B', "NFM",  false, true},    // FM-N
+    {'C', "DIGU", false, true},    // DATA-USB
+    {'D', "AM",   false, false},   // AM-N
+    {'E', "FM",   false, false},   // C4FM
+};
+
+// Neutral names with no FT-991 mode of their own, folded onto the nearest
+// real mode rather than refused — a mode verb that silently does nothing is
+// the worse failure.
+QString foldNeutral(const QString& u)
+{
+    if (u == QLatin1String("CWU")) return QStringLiteral("CW");
+    if (u == QLatin1String("DSB") || u == QLatin1String("SAM")
+        || u == QLatin1String("DRM"))
+        return QStringLiteral("AM");
+    if (u == QLatin1String("WBFM") || u == QLatin1String("WFM")
+        || u == QLatin1String("NFM"))
+        return u == QLatin1String("NFM") ? u : QStringLiteral("FM");
+    return u;
+}
+
+// The FT-991 SH width tables (CAT manual "SH" — shared with the FT-891;
+// hamlib ft991_ssb_widths/ft991_cw_widths carry the same numbers). Index 0
+// is the radio's per-mode DEFAULT width, whose meaning depends on NA.
+constexpr int kSsbWidths[] = {
+    0, 200, 400, 600, 850, 1100, 1350, 1500, 1650, 1800, 1950, 2100,
+    2200, 2300, 2400, 2500, 2600, 2700, 2800, 2900, 3000, 3200,
+};
+constexpr int kCwDataWidths[] = {
+    0, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500, 800, 1200,
+    1400, 1700, 2000, 2400, 3000,
+};
+// NA is narrow at or below these (per table; the CAT manual's split point).
+constexpr int kSsbNarrowMaxHz = 1800;
+constexpr int kCwDataNarrowMaxHz = 500;
+
+}  // namespace
+
+WidthFamily widthFamilyForMode(const QString& neutral)
+{
+    const QString u = foldNeutral(neutral.trimmed().toUpper());
+    if (u == QLatin1String("USB") || u == QLatin1String("LSB"))
+        return WidthFamily::Ssb;
+    if (u == QLatin1String("CW") || u == QLatin1String("CWL")
+        || u == QLatin1String("DIGU") || u == QLatin1String("DIGL"))
+        return WidthFamily::CwData;
+    return WidthFamily::Fixed;
+}
+
+int nearestWidthIndex(const QString& neutral, int widthHz)
+{
+    const WidthFamily family = widthFamilyForMode(neutral);
+    if (family == WidthFamily::Fixed)
+        return -1;
+    const int* table = family == WidthFamily::Ssb ? kSsbWidths : kCwDataWidths;
+    const int count = family == WidthFamily::Ssb
+        ? static_cast<int>(std::size(kSsbWidths))
+        : static_cast<int>(std::size(kCwDataWidths));
+    int best = 1;
+    int bestDistance = std::numeric_limits<int>::max();
+    for (int i = 1; i < count; ++i) {   // index 0 is "default", never chosen
+        const int distance = std::abs(table[i] - widthHz);
+        if (distance < bestDistance) {
+            bestDistance = distance;
+            best = i;
+        }
+    }
+    return best;
+}
+
+int widthForIndex(const QString& neutral, int index, bool narrow)
+{
+    const WidthFamily family = widthFamilyForMode(neutral);
+    if (family == WidthFamily::Fixed)
+        return -1;
+    const bool ssb = family == WidthFamily::Ssb;
+    const int* table = ssb ? kSsbWidths : kCwDataWidths;
+    const int count = ssb ? static_cast<int>(std::size(kSsbWidths))
+                          : static_cast<int>(std::size(kCwDataWidths));
+    if (index > 0 && index < count)
+        return table[index];
+    if (index != 0)
+        return -1;
+    // Index 0: the per-mode default (CAT manual; hamlib mirrors it) — SSB
+    // narrow 1500 / wide 2400; CW narrow 500 / wide 2400; DATA narrow 300 /
+    // wide 500.
+    const QString u = foldNeutral(neutral.trimmed().toUpper());
+    if (ssb)
+        return narrow ? 1500 : 2400;
+    if (u == QLatin1String("CW") || u == QLatin1String("CWL"))
+        return narrow ? 500 : 2400;
+    return narrow ? 300 : 500;
+}
+
+bool narrowForWidth(const QString& neutral, int widthHz)
+{
+    switch (widthFamilyForMode(neutral)) {
+    case WidthFamily::Ssb:    return widthHz <= kSsbNarrowMaxHz;
+    case WidthFamily::CwData: return widthHz <= kCwDataNarrowMaxHz;
+    case WidthFamily::Fixed:  return false;   // AM/FM narrow is a mode choice
+    }
+    return false;
+}
+
+QByteArray setWidthIndex(int index)
+{
+    if (index < 0 || index > 99)
+        return {};
+    return QByteArrayLiteral("SH0")
+        + QByteArray::number(index).rightJustified(2, '0') + ';';
+}
+
+QByteArray queryWidth()  { return QByteArrayLiteral("SH0;"); }
+QByteArray setNarrow(bool narrow)
+{
+    return narrow ? QByteArrayLiteral("NA01;") : QByteArrayLiteral("NA00;");
+}
+QByteArray queryNarrow() { return QByteArrayLiteral("NA0;"); }
+QByteArray setNoiseBlanker(bool on)
+{
+    return on ? QByteArrayLiteral("NB01;") : QByteArrayLiteral("NB00;");
+}
+QByteArray queryNoiseBlanker() { return QByteArrayLiteral("NB0;"); }
+
+QByteArray setNoiseBlankerLevel(int level0to10)
+{
+    const int level = std::clamp(level0to10, 0, 10);
+    return QByteArrayLiteral("NL00")
+        + QByteArray::number(level).rightJustified(2, '0') + ';';
+}
+
+QByteArray queryNoiseBlankerLevel() { return QByteArrayLiteral("NL0;"); }
+QByteArray setAutoNotch(bool on)
+{
+    return on ? QByteArrayLiteral("BC01;") : QByteArrayLiteral("BC00;");
+}
+QByteArray queryAutoNotch() { return QByteArrayLiteral("BC0;"); }
+QByteArray setNoiseReduction(bool on)
+{
+    return on ? QByteArrayLiteral("NR01;") : QByteArrayLiteral("NR00;");
+}
+QByteArray queryNoiseReduction() { return QByteArrayLiteral("NR0;"); }
+
+QByteArray setNoiseReductionLevel(int level1to15)
+{
+    const int level = std::clamp(level1to15, 1, 15);
+    return QByteArrayLiteral("RL0")
+        + QByteArray::number(level).rightJustified(2, '0') + ';';
+}
+
+QByteArray queryNoiseReductionLevel() { return QByteArrayLiteral("RL0;"); }
+QByteArray setManualNotch(bool on)
+{
+    return on ? QByteArrayLiteral("BP00001;") : QByteArrayLiteral("BP00000;");
+}
+
+QByteArray setManualNotchHz(int hz)
+{
+    // BP01 carries the notch position in 10 Hz steps, 10..3200 Hz.
+    const int steps = std::clamp(hz / 10, 1, 320);
+    return QByteArrayLiteral("BP01")
+        + QByteArray::number(steps).rightJustified(3, '0') + ';';
+}
+
+QByteArray queryManualNotch()   { return QByteArrayLiteral("BP00;"); }
+QByteArray queryManualNotchHz() { return QByteArrayLiteral("BP01;"); }
+QByteArray queryTxPowerMeter()  { return QByteArrayLiteral("RM5;"); }
+QByteArray queryTxSwrMeter()    { return QByteArrayLiteral("RM6;"); }
+
+QByteArray setRitEnabled(bool on)
+{
+    return on ? QByteArrayLiteral("RT1;") : QByteArrayLiteral("RT0;");
+}
+
+QByteArray setXitEnabled(bool on)
+{
+    return on ? QByteArrayLiteral("XT1;") : QByteArrayLiteral("XT0;");
+}
+
+QByteArray clearClarifier() { return QByteArrayLiteral("RC;"); }
+
+QByteArray setClarifierOffset(int hz)
+{
+    // The wire has no absolute-offset command: RC zeroes the shared
+    // clarifier and RU/RD step it. Both frames in one write so nothing can
+    // observe the intermediate zero.
+    const int clamped = std::clamp(hz, -9999, 9999);
+    QByteArray out = clearClarifier();
+    if (clamped == 0)
+        return out;
+    out += (clamped > 0 ? QByteArrayLiteral("RU") : QByteArrayLiteral("RD"));
+    out += QByteArray::number(std::abs(clamped)).rightJustified(4, '0');
+    out += ';';
+    return out;
+}
+
+QByteArray queryInfo() { return QByteArrayLiteral("IF;"); }
+
+QByteArray setFrequency(double hz)
+{
+    if (!(hz >= kTuningMinHz) || !(hz <= kTuningMaxHz))
+        return {};
+    const qint64 rounded = static_cast<qint64>(std::llround(hz));
+    return QByteArrayLiteral("FA")
+        + QByteArray::number(rounded).rightJustified(9, '0') + ';';
+}
+
+QByteArray queryFrequency() { return QByteArrayLiteral("FA;"); }
+
+QByteArray setMode(const QString& neutral)
+{
+    const QChar code = modeToCat(neutral);
+    if (code.isNull())
+        return {};
+    return QByteArrayLiteral("MD0") + char(code.toLatin1()) + ';';
+}
+
+QByteArray queryMode()   { return QByteArrayLiteral("MD0;"); }
+QByteArray setPtt(bool tx) { return tx ? QByteArrayLiteral("TX1;") : QByteArrayLiteral("TX0;"); }
+QByteArray queryPtt()    { return QByteArrayLiteral("TX;"); }
+QByteArray querySMeter() { return QByteArrayLiteral("SM0;"); }
+
+QByteArray setPowerWatts(int watts)
+{
+    const int w = std::clamp(watts, 5, 100);
+    return QByteArrayLiteral("PC")
+        + QByteArray::number(w).rightJustified(3, '0') + ';';
+}
+
+QByteArray queryPower() { return QByteArrayLiteral("PC;"); }
+
+QByteArray setAgc(const QString& neutral)
+{
+    const QString m = neutral.trimmed().toLower();
+    char code = '2';                          // med: the radio's MID
+    if (m == QLatin1String("off"))  code = '0';
+    else if (m == QLatin1String("fast")) code = '1';
+    else if (m == QLatin1String("slow")) code = '3';
+    return QByteArrayLiteral("GT0") + code + ';';
+}
+
+QByteArray queryAgc() { return QByteArrayLiteral("GT0;"); }
+QByteArray queryId()  { return QByteArrayLiteral("ID;"); }
+QByteArray setAutoInformation(bool on)
+{
+    return on ? QByteArrayLiteral("AI1;") : QByteArrayLiteral("AI0;");
+}
+
+QString catToMode(QChar code)
+{
+    const char c = code.toUpper().toLatin1();
+    for (const ModeRow& row : kModes) {
+        if (row.code == c)
+            return QString::fromLatin1(row.neutral);
+    }
+    return {};
+}
+
+QChar modeToCat(const QString& neutral)
+{
+    const QString u = foldNeutral(neutral.trimmed().toUpper());
+    for (const ModeRow& row : kModes) {
+        if (row.setTarget && u == QLatin1String(row.neutral))
+            return QLatin1Char(row.code);
+    }
+    return {};
+}
+
+bool isLowSideband(const QString& neutral)
+{
+    const QString u = foldNeutral(neutral.trimmed().toUpper());
+    for (const ModeRow& row : kModes) {
+        if (row.setTarget && u == QLatin1String(row.neutral))
+            return row.lowSideband;
+    }
+    return false;
+}
+
+std::optional<Response> parse(const QByteArray& frame)
+{
+    if (frame.isEmpty())
+        return std::nullopt;
+
+    Response r;
+    if (frame == "?") {
+        r.kind = Response::Kind::Rejected;
+        return r;
+    }
+
+    // Numeric tail helper: digits of `frame` from `from`, -1 on non-digits.
+    const auto digits = [&frame](int from, int count) -> qint64 {
+        if (frame.size() < from + count)
+            return -1;
+        qint64 v = 0;
+        for (int i = from; i < from + count; ++i) {
+            const char c = frame.at(i);
+            if (c < '0' || c > '9')
+                return -1;
+            v = v * 10 + (c - '0');
+        }
+        return v;
+    };
+
+    if (frame.startsWith("FA")) {
+        const qint64 hz = digits(2, frame.size() - 2);
+        if (hz < 0)
+            return r;   // Unknown — malformed digits must not tune anything
+        r.kind = Response::Kind::Frequency;
+        r.frequencyHz = static_cast<double>(hz);
+        return r;
+    }
+    if (frame.startsWith("MD0") && frame.size() == 4) {
+        const QString mode = catToMode(QLatin1Char(frame.at(3)));
+        if (mode.isEmpty())
+            return r;
+        r.kind = Response::Kind::Mode;
+        r.mode = mode;
+        return r;
+    }
+    if (frame.startsWith("TX") && frame.size() == 3) {
+        const qint64 s = digits(2, 1);
+        if (s < 0)
+            return r;
+        r.kind = Response::Kind::Tx;
+        r.txState = static_cast<int>(s);
+        return r;
+    }
+    if (frame.startsWith("SM0")) {
+        const qint64 v = digits(3, frame.size() - 3);
+        if (v < 0 || v > 255)
+            return r;
+        r.kind = Response::Kind::SMeter;
+        r.raw = static_cast<int>(v);
+        return r;
+    }
+    if (frame.startsWith("PC")) {
+        const qint64 v = digits(2, frame.size() - 2);
+        if (v < 0 || v > 200)
+            return r;
+        r.kind = Response::Kind::Power;
+        r.raw = static_cast<int>(v);
+        return r;
+    }
+    if (frame.startsWith("GT0") && frame.size() == 4) {
+        r.kind = Response::Kind::Agc;
+        switch (frame.at(3)) {
+        case '0': r.agcMode = QStringLiteral("off");  break;
+        case '1': r.agcMode = QStringLiteral("fast"); break;
+        case '3': r.agcMode = QStringLiteral("slow"); break;
+        // '2' MID and '4'/'5'/'6' AUTO variants all display as med.
+        default:  r.agcMode = QStringLiteral("med");  break;
+        }
+        return r;
+    }
+    if (frame.startsWith("ID")) {
+        r.kind = Response::Kind::Id;
+        r.id = QString::fromLatin1(frame.mid(2));
+        return r;
+    }
+    if (frame.startsWith("SH0")) {
+        const qint64 v = digits(3, frame.size() - 3);
+        if (v < 0 || v > 99)
+            return r;
+        r.kind = Response::Kind::Width;
+        r.raw = static_cast<int>(v);
+        return r;
+    }
+    if (frame.startsWith("NA0") && frame.size() == 4) {
+        const qint64 v = digits(3, 1);
+        if (v < 0 || v > 1)
+            return r;
+        r.kind = Response::Kind::Narrow;
+        r.raw = static_cast<int>(v);
+        return r;
+    }
+    if (frame.startsWith("NB0") && frame.size() == 4) {
+        const qint64 v = digits(3, 1);
+        if (v < 0)
+            return r;
+        r.kind = Response::Kind::NoiseBlanker;
+        r.raw = v != 0 ? 1 : 0;
+        return r;
+    }
+    if (frame.startsWith("NL0")) {
+        const qint64 v = digits(3, frame.size() - 3);
+        if (v < 0 || v > 10)
+            return r;
+        r.kind = Response::Kind::NoiseBlankerLevel;
+        r.raw = static_cast<int>(v);
+        return r;
+    }
+    if (frame.startsWith("NR0") && frame.size() == 4) {
+        const qint64 v = digits(3, 1);
+        if (v < 0 || v > 1)
+            return r;
+        r.kind = Response::Kind::NoiseReduction;
+        r.raw = static_cast<int>(v);
+        return r;
+    }
+    if (frame.startsWith("RL0")) {
+        const qint64 v = digits(3, frame.size() - 3);
+        if (v < 0 || v > 15)
+            return r;
+        r.kind = Response::Kind::NoiseReductionLevel;
+        r.raw = static_cast<int>(v);
+        return r;
+    }
+    if (frame.startsWith("BC0") && frame.size() == 4) {
+        const qint64 v = digits(3, 1);
+        if (v < 0 || v > 1)
+            return r;
+        r.kind = Response::Kind::AutoNotch;
+        r.raw = static_cast<int>(v);
+        return r;
+    }
+    if (frame.startsWith("IF")) {
+        // FT-991 IF response, ';' already stripped = 27 characters:
+        //   [0..1] "IF"  [2..4] memory ch  [5..13] VFO-A frequency
+        //   [14..18] clarifier (sign + 4 digits)  [19] RIT on  [20] XIT on
+        //   [21] mode  [22] VFO/memory  [23] CTCSS  [24..25] "00"  [26] shift
+        // The 9-digit frequency is what distinguishes it from the 26-char
+        // FT-450-style response; anything else is not ours to interpret.
+        if (frame.size() != 27)
+            return r;
+        const qint64 hz = digits(5, 9);
+        const qint64 offset = digits(15, 4);   // [14] is the sign
+        const char sign = frame.at(14);
+        if (hz < 0 || offset < 0 || (sign != '+' && sign != '-'))
+            return r;
+        const QString mode = catToMode(QLatin1Char(frame.at(21)));
+        if (mode.isEmpty())
+            return r;
+        r.kind = Response::Kind::Info;
+        r.frequencyHz = static_cast<double>(hz);
+        r.mode = mode;
+        r.clarifierHz = static_cast<int>(sign == '-' ? -offset : offset);
+        r.ritOn = frame.at(19) == '1';
+        r.xitOn = frame.at(20) == '1';
+        return r;
+    }
+    if (frame.startsWith("RM") && frame.size() == 6) {
+        const qint64 v = digits(3, 3);
+        if (v < 0 || v > 255)
+            return r;
+        if (frame.at(2) == '5')
+            r.kind = Response::Kind::TxPowerMeter;
+        else if (frame.at(2) == '6')
+            r.kind = Response::Kind::TxSwrMeter;
+        else
+            return r;   // a meter this backend does not poll
+        r.raw = static_cast<int>(v);
+        return r;
+    }
+    // 7, not 8: parse() receives the frame with the ';' already stripped.
+    if (frame.startsWith("BP0") && frame.size() == 7) {
+        // "BP00nnn" = on/off, "BP01nnn" = position in 10 Hz steps.
+        const qint64 v = digits(4, 3);
+        if (v < 0)
+            return r;
+        if (frame.at(3) == '0') {
+            r.kind = Response::Kind::ManualNotch;
+            r.raw = v != 0 ? 1 : 0;
+        } else if (frame.at(3) == '1') {
+            r.kind = Response::Kind::ManualNotchFreq;
+            r.raw = static_cast<int>(v) * 10;
+        } else {
+            return r;
+        }
+        return r;
+    }
+    return r;   // Unknown
+}
+
+}  // namespace Ft991Cat
+
+}  // namespace AetherSDR::ft991

--- a/src/core/backends/ft991/Ft991Cat.h
+++ b/src/core/backends/ft991/Ft991Cat.h
@@ -1,0 +1,152 @@
+#pragma once
+
+#include <QByteArray>
+#include <QString>
+
+#include <optional>
+
+namespace AetherSDR::ft991 {
+
+// Stateless codec for the Yaesu FT-991/FT-991A CAT wire (the CAT Operation
+// Reference Manual is the authority for every frame here). Build functions
+// return a complete ";"-terminated frame; parse() takes ONE frame with the
+// terminator already stripped. Keeping this free of QSerialPort makes the
+// wire vocabulary testable without hardware and keeps Ft991Device about
+// transport and scheduling only.
+//
+// The mirror-image of SmartCatProtocol (our TS-2000-dialect CAT *server*):
+// same textual family, opposite direction — but the FT-991's mode table is
+// Yaesu's own, NOT the TS-2000 one, so the two must not share maps.
+namespace Ft991Cat {
+
+// The FT-991's answer to "ID;". The FT-991A answers the same.
+inline const char* kRadioId = "0670";
+
+// ---- frame builders (all validated; empty on out-of-range input) ----
+QByteArray setFrequency(double hz);          // "FA<9 digits>;"
+QByteArray queryFrequency();                 // "FA;"
+QByteArray setMode(const QString& neutral);  // "MD0<x>;"
+QByteArray queryMode();                      // "MD0;"
+QByteArray setPtt(bool tx);                  // "TX1;" / "TX0;"
+QByteArray queryPtt();                       // "TX;"
+QByteArray querySMeter();                    // "SM0;"
+QByteArray setPowerWatts(int watts);         // "PC<3 digits>;" (5..100)
+QByteArray queryPower();                     // "PC;"
+QByteArray setAgc(const QString& neutral);   // "GT0<x>;" off/fast/med/slow
+QByteArray queryAgc();                       // "GT0;"
+QByteArray queryId();                        // "ID;"
+QByteArray setAutoInformation(bool on);      // "AI1;" / "AI0;"
+
+// ---- radio-side DSP (widths per the CAT manual's SH tables; hamlib's
+// ft991 driver encodes the same numbers and served as the cross-check) ----
+
+// Which SH width table the mode uses. Fixed modes (AM/FM) have no SH —
+// only the NA narrow/wide pair.
+enum class WidthFamily { Ssb, CwData, Fixed };
+WidthFamily widthFamilyForMode(const QString& neutral);
+
+// Snap a requested audio width (Hz) to the nearest SH index for this mode.
+// Returns -1 for Fixed modes (no SH table).
+int nearestWidthIndex(const QString& neutral, int widthHz);
+// The width (Hz) an SH index means for this mode; index 0 is the radio's
+// per-mode default and depends on the NA flag. -1 when unknown/Fixed.
+int widthForIndex(const QString& neutral, int index, bool narrow);
+// The NA (narrow) flag the radio wants for this width in this mode.
+bool narrowForWidth(const QString& neutral, int widthHz);
+
+QByteArray setWidthIndex(int index);         // "SH0<2 digits>;"
+QByteArray queryWidth();                     // "SH0;"
+QByteArray setNarrow(bool narrow);           // "NA0<x>;"
+QByteArray queryNarrow();                    // "NA0;"
+QByteArray setNoiseBlanker(bool on);         // "NB0<x>;"
+QByteArray queryNoiseBlanker();              // "NB0;"
+QByteArray setNoiseBlankerLevel(int level0to10);   // "NL00<2 digits>;"
+QByteArray queryNoiseBlankerLevel();         // "NL0;"
+QByteArray setAutoNotch(bool on);            // "BC0<x>;" — the DNF
+QByteArray queryAutoNotch();                 // "BC0;"
+QByteArray setNoiseReduction(bool on);       // "NR0<x>;" — the DNR
+QByteArray queryNoiseReduction();            // "NR0;"
+QByteArray setNoiseReductionLevel(int level1to15);   // "RL0<2 digits>;"
+QByteArray queryNoiseReductionLevel();       // "RL0;"
+QByteArray setManualNotch(bool on);          // "BP00001;" / "BP00000;"
+QByteArray setManualNotchHz(int hz);         // "BP01<3 digits>;" (10 Hz steps)
+QByteArray queryManualNotch();               // "BP00;"
+QByteArray queryManualNotchHz();             // "BP01;"
+QByteArray queryTxPowerMeter();              // "RM5;" — PO, 0..255
+QByteArray queryTxSwrMeter();                // "RM6;" — SWR, 0..255
+
+// ---- clarifier (RIT/XIT) ----
+//
+// ONE offset, TWO enable flags: the FT-991 has a single clarifier knob
+// shared by RX and TX, so RIT and XIT cannot hold different values here.
+// The absolute-offset setter is therefore "clear, then step": RC zeroes
+// the shared offset and RU/RD walk it to the target in one command each.
+QByteArray setRitEnabled(bool on);           // "RT0;" / "RT1;"
+QByteArray setXitEnabled(bool on);           // "XT0;" / "XT1;"
+QByteArray clearClarifier();                 // "RC;"
+QByteArray setClarifierOffset(int hz);       // "RC;" + "RU/RD<4 digits>;"
+QByteArray queryInfo();                      // "IF;" — freq+clarifier+flags
+
+// The IF response carries the clarifier state; parse() reports it as an
+// Info response with these fields populated.
+
+// The FT-991 tuning range this backend will command, Hz (RX coverage; the
+// radio itself refuses TX outside its bands, which is its call, not ours).
+inline constexpr double kTuningMinHz = 30'000.0;
+inline constexpr double kTuningMaxHz = 470'000'000.0;
+
+// ---- mode mapping ----
+// Neutral slice vocabulary <-> the FT-991 MD0 code. catToMode is LOSSY on
+// purpose (RTTY-L and DATA-L both display as DIGL); the raw code is only
+// re-sent on an explicit operator mode change, so a lossy display never
+// silently rewrites the radio's actual mode.
+QString catToMode(QChar code);               // '1'..'E' -> "LSB".."FM"; empty if unknown
+QChar modeToCat(const QString& neutral);     // "USB" -> '2'; '\0' if unmappable
+
+// True when `neutral` demodulates the LOWER sideband — the pan-mapping
+// direction (audio ascending maps RF DESCENDING from the dial).
+bool isLowSideband(const QString& neutral);
+
+// ---- response parsing ----
+struct Response {
+    enum class Kind {
+        Frequency,   // frequencyHz valid
+        Mode,        // mode (neutral) valid
+        Tx,          // txState valid: 0 = RX, 1 = CAT TX, 2 = radio PTT/other
+        SMeter,      // raw valid: 0..255
+        Power,       // raw valid: watts 5..100
+        Agc,         // agcMode (neutral) valid
+        Id,          // id valid ("0670" expected)
+        Width,           // raw valid: SH index
+        Narrow,          // raw valid: 0/1
+        NoiseBlanker,    // raw valid: 0/1
+        NoiseBlankerLevel,   // raw valid: 0..10
+        AutoNotch,       // raw valid: 0/1 (DNF)
+        NoiseReduction,      // raw valid: 0/1 (DNR)
+        NoiseReductionLevel, // raw valid: 1..15
+        ManualNotch,     // raw valid: 0/1
+        ManualNotchFreq, // raw valid: Hz
+        TxPowerMeter,    // raw valid: 0..255 (PO)
+        TxSwrMeter,      // raw valid: 0..255
+        Info,            // frequencyHz, mode, clarifierHz, ritOn, xitOn valid
+        Rejected,    // the radio answered "?" — command refused/unparsed
+        Unknown,     // well-formed but not a frame this backend consumes
+    };
+    Kind kind = Kind::Unknown;
+    double frequencyHz = 0.0;
+    QString mode;
+    QString agcMode;
+    int txState = 0;
+    int raw = 0;
+    QString id;
+    int clarifierHz = 0;   // signed; Info only
+    bool ritOn = false;    // Info only
+    bool xitOn = false;    // Info only
+};
+
+// Parse one ';'-stripped frame. nullopt only for an empty frame.
+std::optional<Response> parse(const QByteArray& frame);
+
+}  // namespace Ft991Cat
+
+}  // namespace AetherSDR::ft991

--- a/src/core/backends/ft991/Ft991Device.cpp
+++ b/src/core/backends/ft991/Ft991Device.cpp
@@ -1,0 +1,1101 @@
+#include "core/backends/ft991/Ft991Device.h"
+
+#include "core/backends/ft991/Ft991Cat.h"
+#include "core/backends/ft991/Ft991Spectrum.h"
+
+#include <QAudioSink>
+#include <QAudioSource>
+#include <QLoggingCategory>
+#include <QMediaDevices>
+#include <QSerialPort>
+#include <QTimer>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+Q_LOGGING_CATEGORY(lcFt991Dev, "aether.ft991.device")
+
+namespace AetherSDR::ft991 {
+
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+
+QAudioDevice findAudioDevice(const QList<QAudioDevice>& devices,
+                             const QString& hint)
+{
+    const QString needle = hint.toLower();
+    for (const QAudioDevice& dev : devices) {
+        if (dev.description().toLower().contains(needle))
+            return dev;
+    }
+    return {};
+}
+
+// The query frame a response of `kind` answers — how one-in-flight matching
+// works without tracking sequence numbers the wire does not have.
+QByteArray queryForKind(Ft991Cat::Response::Kind kind)
+{
+    using Kind = Ft991Cat::Response::Kind;
+    switch (kind) {
+    case Kind::Frequency: return Ft991Cat::queryFrequency();
+    case Kind::Mode:      return Ft991Cat::queryMode();
+    case Kind::Tx:        return Ft991Cat::queryPtt();
+    case Kind::SMeter:    return Ft991Cat::querySMeter();
+    case Kind::Power:     return Ft991Cat::queryPower();
+    case Kind::Agc:       return Ft991Cat::queryAgc();
+    case Kind::Id:        return Ft991Cat::queryId();
+    case Kind::Width:     return Ft991Cat::queryWidth();
+    case Kind::Narrow:    return Ft991Cat::queryNarrow();
+    case Kind::NoiseBlanker:      return Ft991Cat::queryNoiseBlanker();
+    case Kind::NoiseBlankerLevel: return Ft991Cat::queryNoiseBlankerLevel();
+    case Kind::AutoNotch:         return Ft991Cat::queryAutoNotch();
+    case Kind::NoiseReduction:      return Ft991Cat::queryNoiseReduction();
+    case Kind::NoiseReductionLevel: return Ft991Cat::queryNoiseReductionLevel();
+    case Kind::ManualNotch:       return Ft991Cat::queryManualNotch();
+    case Kind::ManualNotchFreq:   return Ft991Cat::queryManualNotchHz();
+    case Kind::TxPowerMeter:      return Ft991Cat::queryTxPowerMeter();
+    case Kind::TxSwrMeter:        return Ft991Cat::queryTxSwrMeter();
+    case Kind::Info:              return Ft991Cat::queryInfo();
+    default:              return {};
+    }
+}
+
+}  // namespace
+
+Ft991Device::Ft991Device(QObject* parent) : QObject(parent)
+{
+    qRegisterMetaType<std::vector<float>>("std::vector<float>");
+    qRegisterMetaType<Ft991Device::Params>(
+        "AetherSDR::ft991::Ft991Device::Params");
+    qRegisterMetaType<Ft991Device::OpenInfo>(
+        "AetherSDR::ft991::Ft991Device::OpenInfo");
+}
+
+Ft991Device::~Ft991Device()
+{
+    closeDevice();
+}
+
+void Ft991Device::openDevice(const Params& params)
+{
+    closeDevice();
+    m_params = params;
+
+    m_serial = new QSerialPort(params.portName, this);
+    m_serial->setBaudRate(params.baudRate);
+    m_serial->setDataBits(QSerialPort::Data8);
+    m_serial->setParity(QSerialPort::NoParity);
+    // 8N2 per the CAT manual — the FT-991 frames with two stop bits.
+    m_serial->setStopBits(QSerialPort::TwoStop);
+    m_serial->setFlowControl(QSerialPort::NoFlowControl);
+    if (!m_serial->open(QIODevice::ReadWrite)) {
+        const QString err = m_serial->errorString();
+        m_serial->deleteLater();
+        m_serial = nullptr;
+        emit openFailed(QStringLiteral("cannot open %1: %2")
+                            .arg(params.portName, err));
+        return;
+    }
+    // Never key anything through modem lines: this backend keys via CAT
+    // only, and a station wired for line PTT must not transmit on connect
+    // (Principle VI).
+    m_serial->setDataTerminalReady(false);
+    m_serial->setRequestToSend(false);
+    connect(m_serial, &QSerialPort::readyRead,
+            this, &Ft991Device::onSerialReadyRead);
+    // USB unplug lands here as ResourceError (Windows) — without this the
+    // session is a zombie: no readyRead ever again, no error surfaced, the
+    // heartbeat just goes quiet. PermanentError is the POSIX sibling.
+    connect(m_serial, &QSerialPort::errorOccurred, this,
+            [this](QSerialPort::SerialPortError error) {
+        if (error == QSerialPort::ResourceError
+            || error == QSerialPort::ReadError) {
+            failLink(QStringLiteral(
+                "serial port %1 lost (USB cable removed?)")
+                    .arg(m_params.portName));
+        }
+    });
+
+    if (!m_pollTimer) {
+        m_pollTimer = new QTimer(this);
+        m_pollTimer->setInterval(kPollIntervalMs);
+        connect(m_pollTimer, &QTimer::timeout, this, &Ft991Device::onPollTick);
+    }
+
+    m_rxBuf.clear();
+    m_pendingQueries.clear();
+    m_inFlight.clear();
+    m_tick = 0;
+    m_idAttempts = 0;
+    m_consecutiveTimeouts = 0;
+    m_haveFreq = false;
+    m_haveMode = false;
+    m_freqHz = 0.0;
+    m_mode.clear();
+    m_txState = 0;
+    m_powerWatts = -1;
+    m_agc.clear();
+    m_pttRequested = false;
+    m_shIndex = -1;
+    m_narrow = -1;
+    m_nb = -1;
+    m_nbLevel = -1;
+    m_autoNotch = -1;
+    m_nr = -1;
+    m_nrLevel = -1;
+    m_manualNotch = -1;
+    m_manualNotchHz = -1;
+    m_ritOn = -1;
+    m_xitOn = -1;
+    m_clarifierHz = 0;
+    m_haveClarifier = false;
+
+    // Polled operation is the contract (design doc): push mode off, then
+    // verify who is answering before anything else is said.
+    writeFrame(Ft991Cat::setAutoInformation(false));
+    m_state = State::AwaitId;
+    enqueueQuery(Ft991Cat::queryId());
+    trySendNextQuery();
+    m_pollTimer->start();
+}
+
+void Ft991Device::closeDevice()
+{
+    if (m_pollTimer)
+        m_pollTimer->stop();
+    stopTune();
+    if (m_serial) {
+        // Safety before anything else: if we keyed the radio, unkey it.
+        if (m_pttRequested)
+            writeFrame(Ft991Cat::setPtt(false));
+        m_serial->close();
+        m_serial->deleteLater();
+        m_serial = nullptr;
+    }
+    stopTxSink();
+    if (m_audioIn) {
+        m_audioIn->stop();
+        m_audioIn->deleteLater();
+        m_audioIn = nullptr;
+    }
+    if (m_capSink) {
+        m_capSink->close();
+        m_capSink->deleteLater();
+        m_capSink = nullptr;
+    }
+    m_spectrum.reset();
+    m_state = State::Idle;
+    m_pttRequested = false;
+    m_pendingQueries.clear();
+    m_inFlight.clear();
+}
+
+// ---------------------------------------------------------------------------
+// CAT plane
+// ---------------------------------------------------------------------------
+
+void Ft991Device::writeFrame(const QByteArray& frame)
+{
+    if (!m_serial || frame.isEmpty())
+        return;
+    m_serial->write(frame);
+    m_serialTxBytes.fetch_add(static_cast<std::uint64_t>(frame.size()));
+}
+
+void Ft991Device::enqueueQuery(const QByteArray& frame)
+{
+    if (frame.isEmpty() || m_inFlight == frame
+        || m_pendingQueries.contains(frame))
+        return;
+    m_pendingQueries.append(frame);
+}
+
+void Ft991Device::trySendNextQuery()
+{
+    if (!m_inFlight.isEmpty() || m_pendingQueries.isEmpty())
+        return;
+    m_inFlight = m_pendingQueries.takeFirst();
+    m_inFlightClock.restart();
+    writeFrame(m_inFlight);
+}
+
+void Ft991Device::onSerialReadyRead()
+{
+    const QByteArray chunk = m_serial->readAll();
+    m_serialRxBytes.fetch_add(static_cast<std::uint64_t>(chunk.size()));
+    m_rxBuf.append(chunk);
+    // Frames are ';'-terminated; anything before the first terminator that
+    // never completes is bounded by the buffer cap below.
+    int at = -1;
+    while ((at = m_rxBuf.indexOf(';')) >= 0) {
+        const QByteArray frame = m_rxBuf.left(at);
+        m_rxBuf.remove(0, at + 1);
+        handleFrame(frame.trimmed());
+    }
+    if (m_rxBuf.size() > 256) {
+        qCWarning(lcFt991Dev) << "CAT buffer overrun; discarding"
+                              << m_rxBuf.size() << "bytes";
+        m_rxBuf.clear();
+    }
+}
+
+void Ft991Device::handleFrame(const QByteArray& frame)
+{
+    const auto parsed = Ft991Cat::parse(frame);
+    if (!parsed)
+        return;
+    m_consecutiveTimeouts = 0;   // the radio is talking
+    using Kind = Ft991Cat::Response::Kind;
+    const Ft991Cat::Response& r = *parsed;
+
+    // Release the in-flight query this frame answers. "?" answers whatever
+    // was asked (the radio refused it); an unsolicited frame releases
+    // nothing.
+    if (!m_inFlight.isEmpty()) {
+        const bool answers = (r.kind == Kind::Rejected)
+            || (queryForKind(r.kind) == m_inFlight);
+        if (answers) {
+            const int rtt = static_cast<int>(m_inFlightClock.elapsed());
+            const int prev = m_rttMs.load();
+            m_rttMs.store(prev < 0 ? rtt : (prev * 3 + rtt) / 4);
+            m_inFlight.clear();
+        }
+    }
+
+    switch (r.kind) {
+    case Kind::Id: {
+        if (m_state != State::AwaitId)
+            break;
+        const QString id = r.id.trimmed();
+        if (id != QLatin1String(Ft991Cat::kRadioId)) {
+            failOpen(QStringLiteral(
+                "the device on %1 answered CAT ID \"%2\" — expected %3 "
+                "(FT-991/FT-991A)")
+                    .arg(m_params.portName, id,
+                         QLatin1String(Ft991Cat::kRadioId)));
+            return;
+        }
+        qCInfo(lcFt991Dev) << "FT-991 verified on" << m_params.portName;
+        m_state = State::AwaitInitial;
+        // Dial and mode BEFORE opened(): the backend's first pan/slice
+        // emission must carry the radio's real state, not a placeholder.
+        enqueueQuery(Ft991Cat::queryFrequency());
+        enqueueQuery(Ft991Cat::queryMode());
+        enqueueQuery(Ft991Cat::queryPower());
+        enqueueQuery(Ft991Cat::queryAgc());
+        enqueueQuery(Ft991Cat::queryPtt());
+        enqueueQuery(Ft991Cat::queryNarrow());
+        enqueueQuery(Ft991Cat::queryWidth());
+        enqueueQuery(Ft991Cat::queryNoiseBlanker());
+        enqueueQuery(Ft991Cat::queryNoiseBlankerLevel());
+        enqueueQuery(Ft991Cat::queryAutoNotch());
+        enqueueQuery(Ft991Cat::queryNoiseReduction());
+        enqueueQuery(Ft991Cat::queryNoiseReductionLevel());
+        enqueueQuery(Ft991Cat::queryManualNotch());
+        enqueueQuery(Ft991Cat::queryManualNotchHz());
+        break;
+    }
+    case Kind::Frequency:
+        if (r.frequencyHz != m_freqHz) {
+            m_freqHz = r.frequencyHz;
+            emit catFrequency(m_freqHz);
+        }
+        m_haveFreq = true;
+        break;
+    case Kind::Mode:
+        if (r.mode != m_mode) {
+            m_mode = r.mode;
+            emit catMode(m_mode);
+            // The SH tables and NA bank are per-mode: a mode change (ours
+            // or the radio's own) invalidates the cached width state.
+            enqueueQuery(Ft991Cat::queryNarrow());
+            enqueueQuery(Ft991Cat::queryWidth());
+        }
+        m_haveMode = true;
+        break;
+    case Kind::Tx:
+        if (r.txState != m_txState) {
+            m_txState = r.txState;
+            emit catTxState(m_txState);
+        }
+        break;
+    case Kind::SMeter:
+        emit catSMeter(r.raw);
+        break;
+    case Kind::Info: {
+        // IF carries the dial and mode too; feed them through the same
+        // change gates as the dedicated polls so the two agree.
+        if (r.frequencyHz != m_freqHz) {
+            m_freqHz = r.frequencyHz;
+            emit catFrequency(m_freqHz);
+        }
+        m_haveFreq = true;
+        const bool rit = r.ritOn;
+        const bool xit = r.xitOn;
+        if (!m_haveClarifier || m_ritOn != int(rit) || m_xitOn != int(xit)
+            || m_clarifierHz != r.clarifierHz) {
+            m_haveClarifier = true;
+            m_ritOn = rit;
+            m_xitOn = xit;
+            m_clarifierHz = r.clarifierHz;
+            qCDebug(lcFt991Dev) << "clarifier: rit" << rit << "xit" << xit
+                                << "offset" << r.clarifierHz << "Hz";
+            emit catClarifier(rit, xit, r.clarifierHz);
+        }
+        break;
+    }
+    case Kind::TxPowerMeter:
+        emit catTxPowerMeter(r.raw);
+        break;
+    case Kind::TxSwrMeter:
+        emit catTxSwrMeter(r.raw);
+        break;
+    case Kind::Power:
+        if (r.raw != m_powerWatts) {
+            m_powerWatts = r.raw;
+            emit catPower(m_powerWatts);
+        }
+        break;
+    case Kind::Agc:
+        if (r.agcMode != m_agc) {
+            m_agc = r.agcMode;
+            emit catAgc(m_agc);
+        }
+        break;
+    case Kind::Width:
+        if (r.raw != m_shIndex) {
+            m_shIndex = r.raw;
+            emit catWidth(m_shIndex);
+        }
+        break;
+    case Kind::Narrow:
+        if (r.raw != m_narrow) {
+            m_narrow = r.raw;
+            emit catNarrow(m_narrow != 0);
+        }
+        break;
+    case Kind::NoiseBlanker:
+        if (r.raw != m_nb) {
+            m_nb = r.raw;
+            emit catNoiseBlanker(m_nb != 0);
+        }
+        break;
+    case Kind::NoiseBlankerLevel:
+        if (r.raw != m_nbLevel) {
+            m_nbLevel = r.raw;
+            emit catNoiseBlankerLevel(m_nbLevel);
+        }
+        break;
+    case Kind::AutoNotch:
+        if (r.raw != m_autoNotch) {
+            m_autoNotch = r.raw;
+            emit catAutoNotch(m_autoNotch != 0);
+        }
+        break;
+    case Kind::NoiseReduction:
+        if (r.raw != m_nr) {
+            m_nr = r.raw;
+            emit catNoiseReduction(m_nr != 0);
+        }
+        break;
+    case Kind::NoiseReductionLevel:
+        if (r.raw != m_nrLevel) {
+            m_nrLevel = r.raw;
+            emit catNoiseReductionLevel(m_nrLevel);
+        }
+        break;
+    case Kind::ManualNotch:
+        if (r.raw != m_manualNotch) {
+            m_manualNotch = r.raw;
+            emit catManualNotch(m_manualNotch != 0);
+        }
+        break;
+    case Kind::ManualNotchFreq:
+        if (r.raw != m_manualNotchHz) {
+            m_manualNotchHz = r.raw;
+            emit catManualNotchHz(m_manualNotchHz);
+        }
+        break;
+    case Kind::Rejected:
+        qCDebug(lcFt991Dev) << "CAT command refused";
+        break;
+    case Kind::Unknown:
+        // An IF we could not read is worth saying out loud ONCE: the whole
+        // clarifier readback rides on that frame's field offsets, and the
+        // failure is otherwise completely silent (RIT would simply never
+        // move). Rate-limited to the first, so a chatty radio cannot flood.
+        if (frame.startsWith("IF") && !m_loggedBadInfo) {
+            m_loggedBadInfo = true;
+            qCWarning(lcFt991Dev)
+                << "unparsed IF response (" << frame.size() << "chars):"
+                << frame;
+        }
+        break;
+    }
+
+    if (m_state == State::AwaitInitial && m_haveFreq && m_haveMode) {
+        OpenInfo info;
+        QString error;
+        if (!openAudio(&info, &error)) {
+            failOpen(error);
+            return;
+        }
+        m_state = State::Running;
+        emit opened(info);
+    }
+
+    trySendNextQuery();
+}
+
+void Ft991Device::failOpen(const QString& reason)
+{
+    closeDevice();
+    emit openFailed(reason);
+}
+
+void Ft991Device::failLink(const QString& reason)
+{
+    // Pre-open failures keep the openFailed vocabulary; only a RUNNING
+    // session reports a lost link.
+    if (m_state != State::Running) {
+        failOpen(reason);
+        return;
+    }
+    qCWarning(lcFt991Dev) << "link lost:" << reason;
+    closeDevice();
+    emit linkLost(reason);
+}
+
+void Ft991Device::onPollTick()
+{
+    ++m_tick;
+
+    // Expire a query the radio never answered so the plane cannot wedge.
+    if (!m_inFlight.isEmpty()
+        && m_inFlightClock.elapsed() > kQueryTimeoutMs) {
+        m_catTimeouts.fetch_add(1);
+        const QByteArray lost = m_inFlight;
+        m_inFlight.clear();
+        if (m_state == State::AwaitId) {
+            if (++m_idAttempts >= kIdRetries) {
+                failOpen(QStringLiteral(
+                    "no CAT response on %1 at %2 baud — check the port and "
+                    "menu 031 CAT RATE")
+                        .arg(m_params.portName)
+                        .arg(m_params.baudRate));
+                return;
+            }
+            enqueueQuery(Ft991Cat::queryId());
+        } else {
+            qCDebug(lcFt991Dev) << "CAT query timed out:" << lost;
+            if (m_state == State::Running
+                && ++m_consecutiveTimeouts >= kMaxConsecutiveTimeouts) {
+                failLink(QStringLiteral(
+                    "CAT on %1 stopped answering — radio powered off?")
+                        .arg(m_params.portName));
+                return;
+            }
+        }
+    }
+
+    // The codec dying (USB unplug takes it with the serial port; the audio
+    // half can also die alone) has no signal of its own worth trusting —
+    // poll the error state once a second.
+    if (m_state == State::Running && m_tick % 10 == 0 && m_audioIn
+        && m_audioIn->error() == QAudio::IOError) {
+        failLink(QStringLiteral("audio capture from \"%1\" failed")
+                     .arg(m_params.audioInHint));
+        return;
+    }
+
+    if (m_state == State::Running) {
+        // The poll schedule. The S-meter leads (it is the fastest-moving
+        // display); dial and TX state follow at a few Hz so turning the
+        // radio's own knob lands within a poll period; drive and AGC crawl.
+        if (m_txState == 0)
+            enqueueQuery(Ft991Cat::querySMeter());
+        else if (m_tick % 2 == 0)
+            enqueueQuery(Ft991Cat::queryTxPowerMeter());
+        else
+            enqueueQuery(Ft991Cat::queryTxSwrMeter());
+        if (m_tick % 3 == 1)
+            enqueueQuery(Ft991Cat::queryFrequency());
+        if (m_tick % 5 == 2)
+            enqueueQuery(Ft991Cat::queryPtt());
+        if (m_tick % 10 == 4)
+            enqueueQuery(Ft991Cat::queryMode());
+        if (m_tick % 50 == 7)
+            enqueueQuery(Ft991Cat::queryPower());
+        if (m_tick % 50 == 27)
+            enqueueQuery(Ft991Cat::queryAgc());
+        // Radio-side DSP reflection, one query per ~5 s each, phase-spread:
+        // enough to follow the radio's own WIDTH/NB/DNF controls without
+        // crowding the fast dial/meter polls.
+        // IF: the clarifier's only readback (and a free dial cross-check).
+        if (m_tick % 10 == 6)
+            enqueueQuery(Ft991Cat::queryInfo());
+        if (m_tick % 50 == 12)
+            enqueueQuery(Ft991Cat::queryNarrow());
+        if (m_tick % 50 == 17)
+            enqueueQuery(Ft991Cat::queryWidth());
+        if (m_tick % 50 == 22)
+            enqueueQuery(Ft991Cat::queryNoiseReduction());
+        if (m_tick % 50 == 24)
+            enqueueQuery(Ft991Cat::queryNoiseReductionLevel());
+        if (m_tick % 50 == 32)
+            enqueueQuery(Ft991Cat::queryNoiseBlanker());
+        if (m_tick % 50 == 34)
+            enqueueQuery(Ft991Cat::queryNoiseBlankerLevel());
+        if (m_tick % 50 == 37)
+            enqueueQuery(Ft991Cat::queryAutoNotch());
+        if (m_tick % 50 == 42)
+            enqueueQuery(Ft991Cat::queryManualNotch());
+        if (m_tick % 50 == 47)
+            enqueueQuery(Ft991Cat::queryManualNotchHz());
+    }
+
+    trySendNextQuery();
+}
+
+// ---------------------------------------------------------------------------
+// Control verbs (invoked queued from the backend)
+// ---------------------------------------------------------------------------
+
+void Ft991Device::setFrequencyHz(double hz)
+{
+    writeFrame(Ft991Cat::setFrequency(hz));
+    enqueueQuery(Ft991Cat::queryFrequency());
+    trySendNextQuery();
+}
+
+void Ft991Device::setMode(const QString& neutral)
+{
+    writeFrame(Ft991Cat::setMode(neutral));
+    enqueueQuery(Ft991Cat::queryMode());
+    trySendNextQuery();
+}
+
+void Ft991Device::setPtt(bool tx)
+{
+    m_pttRequested = tx;
+    writeFrame(Ft991Cat::setPtt(tx));
+    enqueueQuery(Ft991Cat::queryPtt());
+    if (tx)
+        startTxSink();
+    else
+        stopTxSink();
+    trySendNextQuery();
+}
+
+void Ft991Device::setPowerWatts(int watts)
+{
+    writeFrame(Ft991Cat::setPowerWatts(watts));
+    enqueueQuery(Ft991Cat::queryPower());
+    trySendNextQuery();
+}
+
+void Ft991Device::setAgc(const QString& neutral)
+{
+    writeFrame(Ft991Cat::setAgc(neutral));
+    enqueueQuery(Ft991Cat::queryAgc());
+    trySendNextQuery();
+}
+
+void Ft991Device::setSpectrumRateFps(int fps)
+{
+    m_spectrumIntervalMs = fps > 0 ? 1000 / fps : 0;
+}
+
+void Ft991Device::setRadioWidth(const QString& neutralMode, int widthHz)
+{
+    const int index = Ft991Cat::nearestWidthIndex(neutralMode, widthHz);
+    if (index < 0)
+        return;   // AM/FM: fixed width, nothing to command
+    // NA FIRST (the CAT manual's order): the SH index lands in the narrow or
+    // wide bank depending on it.
+    writeFrame(Ft991Cat::setNarrow(
+        Ft991Cat::narrowForWidth(neutralMode, widthHz)));
+    writeFrame(Ft991Cat::setWidthIndex(index));
+    enqueueQuery(Ft991Cat::queryNarrow());
+    enqueueQuery(Ft991Cat::queryWidth());
+    trySendNextQuery();
+}
+
+void Ft991Device::setRadioNoiseBlanker(bool on)
+{
+    writeFrame(Ft991Cat::setNoiseBlanker(on));
+    enqueueQuery(Ft991Cat::queryNoiseBlanker());
+    trySendNextQuery();
+}
+
+void Ft991Device::setRadioNoiseBlankerLevel(int level0to10)
+{
+    writeFrame(Ft991Cat::setNoiseBlankerLevel(level0to10));
+    enqueueQuery(Ft991Cat::queryNoiseBlankerLevel());
+    trySendNextQuery();
+}
+
+void Ft991Device::setRadioAutoNotch(bool on)
+{
+    writeFrame(Ft991Cat::setAutoNotch(on));
+    enqueueQuery(Ft991Cat::queryAutoNotch());
+    trySendNextQuery();
+}
+
+void Ft991Device::setRadioNoiseReduction(bool on)
+{
+    writeFrame(Ft991Cat::setNoiseReduction(on));
+    enqueueQuery(Ft991Cat::queryNoiseReduction());
+    trySendNextQuery();
+}
+
+void Ft991Device::setRadioNoiseReductionLevel(int level1to15)
+{
+    writeFrame(Ft991Cat::setNoiseReductionLevel(level1to15));
+    enqueueQuery(Ft991Cat::queryNoiseReductionLevel());
+    trySendNextQuery();
+}
+
+void Ft991Device::setRadioClarifier(bool ritOn, bool xitOn, int offsetHz)
+{
+    // Offset first: enabling a clarifier that still holds the previous
+    // offset would pull the receiver off frequency for a poll period.
+    writeFrame(Ft991Cat::setClarifierOffset(offsetHz));
+    writeFrame(Ft991Cat::setRitEnabled(ritOn));
+    writeFrame(Ft991Cat::setXitEnabled(xitOn));
+    enqueueQuery(Ft991Cat::queryInfo());
+    trySendNextQuery();
+}
+
+void Ft991Device::setRadioManualNotch(bool on, int hz)
+{
+    // Position before enable, so the notch never bites at a stale offset.
+    if (hz > 0)
+        writeFrame(Ft991Cat::setManualNotchHz(hz));
+    writeFrame(Ft991Cat::setManualNotch(on));
+    enqueueQuery(Ft991Cat::queryManualNotchHz());
+    enqueueQuery(Ft991Cat::queryManualNotch());
+    trySendNextQuery();
+}
+
+void Ft991Device::setAudioPassband(int lowHz, int highHz)
+{
+    // SliceModel's signed edges -> the audio band the codec carries. A
+    // sideband pair (USB 100..2900, LSB -2900..-100) is the same audio
+    // band either way; a symmetric passband (AM -4000..4000) means BOTH
+    // sidebands landed in 0..4000 audio, so the low edge is 0, not 4000.
+    const bool straddlesZero = (lowHz < 0) != (highHz < 0);
+    const int absLo = std::min(std::abs(lowHz), std::abs(highHz));
+    const int absHi = std::max(std::abs(lowHz), std::abs(highHz));
+    const double loEdge = straddlesZero ? 0.0 : static_cast<double>(absLo);
+    const double hiEdge = static_cast<double>(absHi);
+
+    // 4th-order Butterworth = two cascaded sections at these Qs.
+    constexpr double kQ1 = 0.54119610;
+    constexpr double kQ2 = 1.30656296;
+    constexpr double kNyquistGuard = kEngineRxRateHz * 0.45;
+
+    // Wide-open edges are SKIPPED, not configured at an extreme corner —
+    // no group delay for a filter that would pass everything anyway.
+    m_rxHighpassOn = loEdge >= 30.0;
+    if (m_rxHighpassOn) {
+        m_rxHighpass[0].setCoefficients(Biquad::Type::HighPass,
+                                        kEngineRxRateHz, loEdge, kQ1);
+        m_rxHighpass[1].setCoefficients(Biquad::Type::HighPass,
+                                        kEngineRxRateHz, loEdge, kQ2);
+    }
+    m_rxLowpassOn = hiEdge > 0.0 && hiEdge < kNyquistGuard;
+    if (m_rxLowpassOn) {
+        m_rxLowpass[0].setCoefficients(Biquad::Type::LowPass,
+                                       kEngineRxRateHz, hiEdge, kQ1);
+        m_rxLowpass[1].setCoefficients(Biquad::Type::LowPass,
+                                       kEngineRxRateHz, hiEdge, kQ2);
+    }
+    // Discontinuous retune: old state at the new corner is just a click.
+    for (Biquad& b : m_rxHighpass)
+        b.reset();
+    for (Biquad& b : m_rxLowpass)
+        b.reset();
+    qCDebug(lcFt991Dev) << "audio passband" << loEdge << ".." << hiEdge
+                        << "Hz (hp" << m_rxHighpassOn << "lp" << m_rxLowpassOn
+                        << ")";
+}
+
+// ---------------------------------------------------------------------------
+// RX audio
+// ---------------------------------------------------------------------------
+
+bool Ft991Device::openAudio(OpenInfo* info, QString* error)
+{
+    const QAudioDevice inDev =
+        findAudioDevice(QMediaDevices::audioInputs(), m_params.audioInHint);
+    if (inDev.isNull()) {
+        *error = QStringLiteral(
+            "no audio capture device matching \"%1\" — is the radio's USB "
+            "cable connected?")
+                .arg(m_params.audioInHint);
+        return false;
+    }
+
+    // Capture at the device's NATIVE rate (the WfmDemodulator rule: forcing
+    // a rate makes the OS mixer resample silently). Int16 preferred, the
+    // device's own format as fallback.
+    const QAudioFormat preferred = inDev.preferredFormat();
+    QAudioFormat fmt;
+    fmt.setSampleRate(preferred.sampleRate() > 0 ? preferred.sampleRate()
+                                                 : kAudioOutRateFallbackHz);
+    fmt.setChannelCount(preferred.channelCount() > 0
+                            ? preferred.channelCount() : 2);
+    fmt.setSampleFormat(QAudioFormat::Int16);
+    if (!inDev.isFormatSupported(fmt))
+        fmt = preferred;
+    m_capFormat = fmt;
+
+    m_spectrum = std::make_unique<Ft991Spectrum>(fmt.sampleRate(),
+                                                 m_params.spectrumSpanHz);
+    m_rxPhase = 0.0;
+    m_rxLastSample = 0.0f;
+    m_lastSpectrumMs = 0;
+    m_spectrumClock.invalidate();
+
+    m_capSink = new Ft991CaptureSink(this);
+    m_capSink->open(QIODevice::WriteOnly);
+    connect(m_capSink, &Ft991CaptureSink::pcmReady,
+            this, &Ft991Device::onCapturePcm);
+
+    m_audioIn = new QAudioSource(inDev, fmt, this);
+    m_audioIn->start(m_capSink);
+    if (m_audioIn->error() != QAudio::NoError) {
+        *error = QStringLiteral("cannot start capture on \"%1\" (error %2)")
+                     .arg(inDev.description())
+                     .arg(static_cast<int>(m_audioIn->error()));
+        return false;
+    }
+
+    info->coveredSpanHz = m_spectrum->coveredSpanHz();
+    info->audioInDesc = inDev.description();
+    info->audioInRateHz = fmt.sampleRate();
+
+    // Resolve (but do not start) the playback device; the sink comes up on
+    // key. Absence is not an error — the session is then receive-only, and
+    // the health panel says so.
+    m_audioOutDevice =
+        findAudioDevice(QMediaDevices::audioOutputs(), m_params.audioOutHint);
+    if (!m_audioOutDevice.isNull()) {
+        const QAudioFormat outPreferred = m_audioOutDevice.preferredFormat();
+        QAudioFormat out;
+        out.setSampleRate(outPreferred.sampleRate() > 0
+                              ? outPreferred.sampleRate()
+                              : kAudioOutRateFallbackHz);
+        out.setChannelCount(2);
+        out.setSampleFormat(QAudioFormat::Int16);
+        if (!m_audioOutDevice.isFormatSupported(out))
+            out = outPreferred;
+        m_outFormat = out;
+        info->audioOutDesc = m_audioOutDevice.description();
+        info->audioOutRateHz = out.sampleRate();
+    } else {
+        qCWarning(lcFt991Dev)
+            << "no playback device matching" << m_params.audioOutHint
+            << "— TX audio unavailable this session";
+    }
+
+    qCInfo(lcFt991Dev) << "capture:" << inDev.description() << "@"
+                       << fmt.sampleRate() << "Hz ch" << fmt.channelCount()
+                       << "fmt" << fmt.sampleFormat();
+    return true;
+}
+
+void Ft991Device::appendMonoFloat(const QByteArray& pcm,
+                                  std::vector<float>& mono) const
+{
+    const int channels = std::max(1, m_capFormat.channelCount());
+    switch (m_capFormat.sampleFormat()) {
+    case QAudioFormat::Int16: {
+        const auto* s = reinterpret_cast<const qint16*>(pcm.constData());
+        const std::size_t frames =
+            static_cast<std::size_t>(pcm.size()) / (sizeof(qint16) * channels);
+        for (std::size_t i = 0; i < frames; ++i)
+            mono.push_back(static_cast<float>(s[i * channels]) / 32768.0f);
+        break;
+    }
+    case QAudioFormat::Int32: {
+        const auto* s = reinterpret_cast<const qint32*>(pcm.constData());
+        const std::size_t frames =
+            static_cast<std::size_t>(pcm.size()) / (sizeof(qint32) * channels);
+        for (std::size_t i = 0; i < frames; ++i)
+            mono.push_back(static_cast<float>(s[i * channels]) / 2147483648.0f);
+        break;
+    }
+    case QAudioFormat::Float: {
+        const auto* s = reinterpret_cast<const float*>(pcm.constData());
+        const std::size_t frames =
+            static_cast<std::size_t>(pcm.size()) / (sizeof(float) * channels);
+        for (std::size_t i = 0; i < frames; ++i)
+            mono.push_back(s[i * channels]);
+        break;
+    }
+    case QAudioFormat::UInt8: {
+        const auto* s = reinterpret_cast<const quint8*>(pcm.constData());
+        const std::size_t frames =
+            static_cast<std::size_t>(pcm.size()) / channels;
+        for (std::size_t i = 0; i < frames; ++i)
+            mono.push_back((static_cast<float>(s[i * channels]) - 128.0f)
+                           / 128.0f);
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+bool Ft991Device::spectrumFrameDue()
+{
+    if (m_spectrumIntervalMs <= 0)
+        return true;
+    if (!m_spectrumClock.isValid()) {
+        m_spectrumClock.start();
+        return true;
+    }
+    return m_spectrumClock.elapsed() - m_lastSpectrumMs
+        >= m_spectrumIntervalMs;
+}
+
+void Ft991Device::onCapturePcm(const QByteArray& pcm)
+{
+    if (!m_spectrum)
+        return;
+
+    m_monoScratch.clear();
+    appendMonoFloat(pcm, m_monoScratch);
+    if (m_monoScratch.empty())
+        return;
+
+    m_audioBlocks.fetch_add(1);
+    m_audioSamples.fetch_add(m_monoScratch.size());
+
+    // ---- panadapter (at the capture rate) ----
+    if (spectrumFrameDue()) {
+        const int frames = m_spectrum->process(m_monoScratch, m_binsScratch);
+        if (frames > 0) {
+            if (m_spectrumClock.isValid())
+                m_lastSpectrumMs = m_spectrumClock.elapsed();
+            emit spectrumFrame(m_binsScratch);
+        }
+    } else {
+        m_spectrum->accumulate(m_monoScratch);
+    }
+
+    // ---- speaker/decoder feed: linear resample to 24 kHz mono ----
+    const double inRate = m_capFormat.sampleRate();
+    const double step = inRate / static_cast<double>(kEngineRxRateHz);
+    m_mono24k.clear();
+    m_mono24k.reserve(static_cast<std::size_t>(
+        m_monoScratch.size() / step + 4));
+    // m_rxPhase in [-1, 0) indexes the PREVIOUS block's last sample
+    // (m_rxLastSample), so the interpolation is continuous across blocks.
+    double pos = m_rxPhase;
+    const std::size_t n = m_monoScratch.size();
+    while (pos < static_cast<double>(n) - 1.0) {
+        float sample = 0.0f;
+        if (pos < 0.0) {
+            const float frac = static_cast<float>(pos + 1.0);
+            sample = m_rxLastSample * (1.0f - frac) + m_monoScratch[0] * frac;
+        } else {
+            const std::size_t i = static_cast<std::size_t>(pos);
+            const float frac = static_cast<float>(pos - static_cast<double>(i));
+            sample = m_monoScratch[i] * (1.0f - frac)
+                   + m_monoScratch[i + 1] * frac;
+        }
+        m_mono24k.push_back(sample);
+        pos += step;
+    }
+    m_rxPhase = pos - static_cast<double>(n);
+    m_rxLastSample = m_monoScratch[n - 1];
+
+    // The slice passband (host-side; the spectrum above stays pre-filter).
+    if (m_rxHighpassOn) {
+        for (Biquad& b : m_rxHighpass)
+            b.process(m_mono24k.data(), m_mono24k.data(),
+                      static_cast<int>(m_mono24k.size()));
+    }
+    if (m_rxLowpassOn) {
+        for (Biquad& b : m_rxLowpass)
+            b.process(m_mono24k.data(), m_mono24k.data(),
+                      static_cast<int>(m_mono24k.size()));
+    }
+
+    m_stereoOut.clear();
+    m_stereoOut.reserve(m_mono24k.size() * 2);
+    for (const float s : m_mono24k) {
+        m_stereoOut.push_back(s);
+        m_stereoOut.push_back(s);
+    }
+    if (!m_stereoOut.empty())
+        emit audioBlockReady(m_stereoOut);
+}
+
+// ---------------------------------------------------------------------------
+// TX audio
+// ---------------------------------------------------------------------------
+
+void Ft991Device::startTxSink()
+{
+    if (m_txSink || m_audioOutDevice.isNull())
+        return;
+    m_txSink = new QAudioSink(m_audioOutDevice, m_outFormat, this);
+    // A quarter second of buffer: enough to ride scheduling jitter, small
+    // enough that unkeying does not trail audio.
+    m_txSink->setBufferSize(m_outFormat.bytesForDuration(250'000));
+    m_txIo = m_txSink->start();
+    m_txPhase = 0.0;
+    m_txLastL = 0.0f;
+    if (!m_txIo)
+        qCWarning(lcFt991Dev) << "TX sink failed to start:"
+                              << static_cast<int>(m_txSink->error());
+}
+
+void Ft991Device::stopTxSink()
+{
+    if (!m_txSink)
+        return;
+    m_txSink->stop();   // drops the queued tail — unkey means silence NOW
+    m_txSink->deleteLater();
+    m_txSink = nullptr;
+    m_txIo = nullptr;
+}
+
+void Ft991Device::submitTxAudio(const QByteArray& int16Stereo,
+                                int engineRateHz, float gain)
+{
+    // Inert unless WE keyed the radio: TX audio into an unkeyed radio is
+    // harmless, but the gate keeps the path provably quiet (Principle VI).
+    if (!m_pttRequested || !m_txIo || m_tuneToneActive || engineRateHz <= 0)
+        return;
+
+    const auto* in = reinterpret_cast<const qint16*>(int16Stereo.constData());
+    const std::size_t frames =
+        static_cast<std::size_t>(int16Stereo.size()) / (sizeof(qint16) * 2);
+    if (frames == 0)
+        return;
+
+    // Mono mix + gain, engine rate.
+    m_monoScratch.clear();
+    m_monoScratch.reserve(frames);
+    for (std::size_t i = 0; i < frames; ++i) {
+        const float l = static_cast<float>(in[i * 2]) / 32768.0f;
+        const float r = static_cast<float>(in[i * 2 + 1]) / 32768.0f;
+        m_monoScratch.push_back(std::clamp(0.5f * (l + r) * gain,
+                                           -1.0f, 1.0f));
+    }
+
+    // Linear resample engine rate -> codec rate (same phase discipline as
+    // the RX path), then interleave into the sink's format.
+    const double step = static_cast<double>(engineRateHz)
+        / std::max(1, m_outFormat.sampleRate());
+    const int outCh = std::max(1, m_outFormat.channelCount());
+    const bool outFloat = m_outFormat.sampleFormat() == QAudioFormat::Float;
+    const int bytesPerSample = outFloat ? 4 : 2;
+
+    m_txScratch.clear();
+    double pos = m_txPhase;
+    const std::size_t n = m_monoScratch.size();
+    while (pos < static_cast<double>(n) - 1.0) {
+        float sample = 0.0f;
+        if (pos < 0.0) {
+            const float frac = static_cast<float>(pos + 1.0);
+            sample = m_txLastL * (1.0f - frac) + m_monoScratch[0] * frac;
+        } else {
+            const std::size_t i = static_cast<std::size_t>(pos);
+            const float frac = static_cast<float>(pos - static_cast<double>(i));
+            sample = m_monoScratch[i] * (1.0f - frac)
+                   + m_monoScratch[i + 1] * frac;
+        }
+        for (int c = 0; c < outCh; ++c) {
+            if (outFloat) {
+                m_txScratch.append(reinterpret_cast<const char*>(&sample),
+                                   bytesPerSample);
+            } else {
+                const qint16 s16 =
+                    static_cast<qint16>(std::lround(sample * 32767.0f));
+                m_txScratch.append(reinterpret_cast<const char*>(&s16),
+                                   bytesPerSample);
+            }
+        }
+        pos += step;
+    }
+    m_txPhase = pos - static_cast<double>(n);
+    m_txLastL = m_monoScratch[n - 1];
+
+    if (!m_txScratch.isEmpty())
+        m_txIo->write(m_txScratch);   // partial acceptance = dropped tail; OK
+}
+
+// ---------------------------------------------------------------------------
+// TUNE tone
+// ---------------------------------------------------------------------------
+
+void Ft991Device::startTune()
+{
+    if (m_tuneToneActive)
+        return;
+    m_tuneToneActive = true;
+    m_tonePhase = 0.0;
+    setPtt(true);
+    if (!m_txIo) {
+        // No playback device: a keyed SSB transmitter with no audio makes no
+        // RF, so say why the TUNE button appears dead.
+        qCWarning(lcFt991Dev)
+            << "TUNE keyed but no TX audio device — no carrier will be made";
+        return;
+    }
+    if (!m_toneTimer) {
+        m_toneTimer = new QTimer(this);
+        m_toneTimer->setInterval(20);
+        connect(m_toneTimer, &QTimer::timeout, this, [this] {
+            if (!m_txIo)
+                return;
+            const int rate = std::max(1, m_outFormat.sampleRate());
+            const int outCh = std::max(1, m_outFormat.channelCount());
+            const bool outFloat =
+                m_outFormat.sampleFormat() == QAudioFormat::Float;
+            const int samplesPer = rate / 50;   // one 20 ms block
+            const double inc = 2.0 * kPi * kTuneToneHz / rate;
+            m_txScratch.clear();
+            for (int i = 0; i < samplesPer; ++i) {
+                const float sample = static_cast<float>(
+                    std::sin(m_tonePhase) * kTuneToneAmplitude);
+                m_tonePhase += inc;
+                for (int c = 0; c < outCh; ++c) {
+                    if (outFloat) {
+                        m_txScratch.append(
+                            reinterpret_cast<const char*>(&sample), 4);
+                    } else {
+                        const qint16 s16 = static_cast<qint16>(
+                            std::lround(sample * 32767.0f));
+                        m_txScratch.append(
+                            reinterpret_cast<const char*>(&s16), 2);
+                    }
+                }
+            }
+            if (m_tonePhase > 2.0 * kPi)
+                m_tonePhase = std::fmod(m_tonePhase, 2.0 * kPi);
+            m_txIo->write(m_txScratch);
+        });
+    }
+    m_toneTimer->start();
+}
+
+void Ft991Device::stopTune()
+{
+    if (!m_tuneToneActive)
+        return;
+    m_tuneToneActive = false;
+    if (m_toneTimer)
+        m_toneTimer->stop();
+    setPtt(false);
+}
+
+}  // namespace AetherSDR::ft991

--- a/src/core/backends/ft991/Ft991Device.h
+++ b/src/core/backends/ft991/Ft991Device.h
@@ -1,0 +1,295 @@
+#pragma once
+
+#include "core/Biquad.h"
+
+#include <QAudioDevice>
+#include <QAudioFormat>
+#include <QByteArray>
+#include <QElapsedTimer>
+#include <QIODevice>
+#include <QList>
+#include <QObject>
+#include <QString>
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+class QAudioSink;
+class QAudioSource;
+class QSerialPort;
+class QTimer;
+
+namespace AetherSDR::ft991 {
+
+class Ft991Spectrum;
+
+// QIODevice sink for the codec capture stream (the DaxIqCaptureDevice
+// pattern from WfmDemodulator): QAudioSource pushes into writeData, which
+// forwards the raw bytes as a signal on the owning (I/O) thread.
+class Ft991CaptureSink : public QIODevice {
+    Q_OBJECT
+public:
+    explicit Ft991CaptureSink(QObject* parent = nullptr) : QIODevice(parent) {}
+    bool isSequential() const override { return true; }
+    qint64 readData(char*, qint64) override { return 0; }
+    qint64 writeData(const char* data, qint64 len) override
+    {
+        emit pcmReady(QByteArray(data, static_cast<int>(len)));
+        return len;
+    }
+signals:
+    void pcmReady(const QByteArray& pcm);
+};
+
+// The device half of the FT-991 backend: owns the CAT serial port, the USB
+// codec capture/playback streams, the audio-band FFT and the resamplers.
+// Lives on the backend's I/O thread (created parentless, moveToThread'd) —
+// the ColibriDevice position, without the foreign-thread callback: Qt
+// delivers serial readyRead and codec PCM on this object's own thread.
+//
+// CAT is strictly one query in flight: a query is sent, its response (or a
+// timeout) releases the next. Set frames are written immediately — the radio
+// does not answer sets — each followed by an enqueued confirming query, so
+// the authoritative state always comes back off the wire.
+class Ft991Device : public QObject {
+    Q_OBJECT
+
+public:
+    explicit Ft991Device(QObject* parent = nullptr);
+    ~Ft991Device() override;
+
+    struct Params {
+        QString portName;        // "COM5", "/dev/ttyUSB0", …
+        int baudRate = 38400;    // menu 031 CAT RATE; framing fixed 8N2
+        QString audioInHint;     // substring match on capture description
+        QString audioOutHint;    // substring match on playback description
+        double spectrumSpanHz = 4000.0;
+    };
+
+    // What connect resolved — carried by opened() so the backend can report
+    // honest pan geometry and a truthful health panel.
+    struct OpenInfo {
+        double coveredSpanHz = 0.0;   // what the FFT bins genuinely cover
+        QString audioInDesc;
+        int audioInRateHz = 0;
+        QString audioOutDesc;         // empty: no playback device found (RX-only session)
+        int audioOutRateHz = 0;
+    };
+
+    // ---- counters, read by the GUI thread (linkStats/healthSnapshot) ----
+    [[nodiscard]] std::uint64_t serialRxBytes() const { return m_serialRxBytes.load(); }
+    [[nodiscard]] std::uint64_t serialTxBytes() const { return m_serialTxBytes.load(); }
+    [[nodiscard]] std::uint64_t audioBlocks() const { return m_audioBlocks.load(); }
+    [[nodiscard]] std::uint64_t audioSamples() const { return m_audioSamples.load(); }
+    [[nodiscard]] int catTimeouts() const { return m_catTimeouts.load(); }
+    [[nodiscard]] int catRttMs() const { return m_rttMs.load(); }
+
+public slots:
+    // Open the serial port, verify the radio (ID -> 0670), fetch the initial
+    // dial/mode, open the codec. Emits opened() or openFailed(reason); the
+    // initial catFrequency/catMode signals precede opened().
+    void openDevice(const AetherSDR::ft991::Ft991Device::Params& params);
+    // Unkey if we keyed, close everything. Idempotent.
+    void closeDevice();
+
+    void setFrequencyHz(double hz);
+    void setMode(const QString& neutral);
+    void setPtt(bool tx);
+    void setPowerWatts(int watts);
+    void setAgc(const QString& neutral);
+    void setSpectrumRateFps(int fps);
+
+    // ---- radio-side DSP (CAT SH/NA/NB/NL/BC/BP) ----
+    // Width: NA must be chosen before SH (the CAT manual's order — the SH
+    // index tables differ between narrow and wide banks).
+    void setRadioWidth(const QString& neutralMode, int widthHz);
+    void setRadioNoiseBlanker(bool on);
+    void setRadioNoiseBlankerLevel(int level0to10);
+    void setRadioAutoNotch(bool on);
+    void setRadioNoiseReduction(bool on);
+    void setRadioNoiseReductionLevel(int level1to15);
+    // The clarifier: ONE shared offset, two enable flags (see Ft991Cat).
+    // Offset first, then the flag — so enabling never bites at a stale one.
+    void setRadioClarifier(bool ritOn, bool xitOn, int offsetHz);
+    // Position first, then enable — so the notch never lands somewhere the
+    // operator did not ask for.
+    void setRadioManualNotch(bool on, int hz);
+
+    // The slice passband, in SliceModel's signed convention (LSB negative).
+    // Applied HOST-SIDE as a Butterworth biquad cascade on the 24 kHz audio
+    // — the radio already demodulated, so this is the only place the app's
+    // filter handles can actually narrow anything. Shapes the speaker AND
+    // the slice/TCI feed (the Flex semantic: DAX carries the slice's
+    // filtered audio); the spectrum stays pre-filter, like a real pan.
+    void setAudioPassband(int lowHz, int highHz);
+
+    // Engine TX audio: int16 interleaved stereo at engineRateHz, already
+    // shaped by the TX chain; gain is the backend's MIC-slider factor.
+    // Dropped when we have not keyed the radio.
+    void submitTxAudio(const QByteArray& int16Stereo, int engineRateHz,
+                       float gain);
+    // TUNE carrier: keys TX and plays a steady tone into the codec until
+    // stopTune(). Drive swapping (PC) is the backend's job — it knows the
+    // operator's RF/TUNE power split.
+    void startTune();
+    void stopTune();
+
+signals:
+    void opened(const AetherSDR::ft991::Ft991Device::OpenInfo& info);
+    void openFailed(const QString& reason);
+    // The link died mid-session: serial port gone (USB unplug), CAT gone
+    // quiet (radio powered off), or the codec capture failed. Emitted
+    // AFTER the device has torn itself down — the backend only reports.
+    void linkLost(const QString& reason);
+
+    // Change-gated CAT state (values as the radio reported them).
+    void catFrequency(double hz);
+    void catMode(const QString& neutral);
+    void catTxState(int state);            // 0 RX, 1 CAT TX, 2 radio PTT
+    void catSMeter(int raw0to255);         // every reading, not change-gated
+    void catPower(int watts);
+    void catAgc(const QString& neutral);
+    void catWidth(int shIndex);            // SH index; backend owns the table
+    void catNarrow(bool narrow);
+    void catNoiseBlanker(bool on);
+    void catNoiseBlankerLevel(int level0to10);
+    void catAutoNotch(bool on);
+    void catNoiseReduction(bool on);
+    void catNoiseReductionLevel(int level1to15);
+    void catManualNotch(bool on);
+    void catManualNotchHz(int hz);
+    // TX meters, every reading while transmitting (raw 0..255).
+    void catTxPowerMeter(int raw);
+    void catTxSwrMeter(int raw);
+    // Clarifier state from the IF poll (change-gated as a triple).
+    void catClarifier(bool ritOn, bool xitOn, int offsetHz);
+
+    // 24 kHz interleaved-stereo float RX audio (AudioEngine's native format).
+    void audioBlockReady(const std::vector<float>& stereoPcm);
+    // Audio-band spectrum, dBFS, index 0 = 0 Hz ascending (binCount bins
+    // covering OpenInfo::coveredSpanHz).
+    void spectrumFrame(const std::vector<float>& binsDbfs);
+
+private:
+    void onSerialReadyRead();
+    void onPollTick();
+    void onCapturePcm(const QByteArray& pcm);
+    void handleFrame(const QByteArray& frame);
+    void enqueueQuery(const QByteArray& frame);
+    void trySendNextQuery();
+    void writeFrame(const QByteArray& frame);
+    bool openAudio(OpenInfo* info, QString* error);
+    void startTxSink();
+    void stopTxSink();
+    void failOpen(const QString& reason);
+    void failLink(const QString& reason);
+    void appendMonoFloat(const QByteArray& pcm, std::vector<float>& mono) const;
+    [[nodiscard]] bool spectrumFrameDue();
+
+    // ---- CAT ----
+    QSerialPort* m_serial = nullptr;
+    QTimer* m_pollTimer = nullptr;
+    QByteArray m_rxBuf;
+    QList<QByteArray> m_pendingQueries;
+    QByteArray m_inFlight;
+    QElapsedTimer m_inFlightClock;
+    quint32 m_tick = 0;
+    int m_idAttempts = 0;
+    // Consecutive expired queries while Running — the radio-went-quiet
+    // detector. Reset by every parsed frame.
+    int m_consecutiveTimeouts = 0;
+
+    enum class State { Idle, AwaitId, AwaitInitial, Running };
+    State m_state = State::Idle;
+    bool m_haveFreq = false;
+    bool m_haveMode = false;
+
+    Params m_params;
+
+    // Last-reported CAT state, for change gating.
+    double m_freqHz = 0.0;
+    QString m_mode;
+    int m_txState = 0;
+    int m_powerWatts = -1;
+    QString m_agc;
+    bool m_pttRequested = false;
+    int m_shIndex = -1;
+    int m_narrow = -1;
+    int m_nb = -1;
+    int m_nbLevel = -1;
+    int m_autoNotch = -1;
+    int m_nr = -1;
+    int m_nrLevel = -1;
+    int m_manualNotch = -1;
+    int m_manualNotchHz = -1;
+    int m_ritOn = -1;
+    int m_xitOn = -1;
+    bool m_loggedBadInfo = false;
+    int m_clarifierHz = 0;
+    bool m_haveClarifier = false;
+
+    // ---- RX audio ----
+    QAudioSource* m_audioIn = nullptr;
+    Ft991CaptureSink* m_capSink = nullptr;
+    QAudioFormat m_capFormat;
+    std::unique_ptr<Ft991Spectrum> m_spectrum;
+    std::vector<float> m_monoScratch;
+    std::vector<float> m_binsScratch;
+    std::vector<float> m_mono24k;
+    std::vector<float> m_stereoOut;
+
+    // Host-side RX passband (see setAudioPassband). Two sections each way
+    // make a 4th-order Butterworth; skipped entirely at wide-open edges so
+    // the default AM/FM path adds no phase shift it does not need.
+    std::array<Biquad, 2> m_rxHighpass;
+    std::array<Biquad, 2> m_rxLowpass;
+    bool m_rxHighpassOn = false;
+    bool m_rxLowpassOn = false;
+    double m_rxPhase = 0.0;          // capture-rate -> 24 kHz resampler phase
+    float m_rxLastSample = 0.0f;     // previous input sample for interpolation
+
+    // Spectrum pacing (the colibri shape: skip the transform when a frame is
+    // not due; a due frame spans several PCM blocks, so the flag holds until
+    // one completes).
+    int m_spectrumIntervalMs = 0;    // 0 = uncapped
+    QElapsedTimer m_spectrumClock;
+    qint64 m_lastSpectrumMs = 0;
+
+    // ---- TX audio ----
+    QAudioDevice m_audioOutDevice;
+    QAudioFormat m_outFormat;
+    QAudioSink* m_txSink = nullptr;
+    QIODevice* m_txIo = nullptr;     // owned by m_txSink
+    double m_txPhase = 0.0;          // engine-rate -> codec-rate resampler phase
+    float m_txLastL = 0.0f;
+    QByteArray m_txScratch;
+    bool m_tuneToneActive = false;
+    QTimer* m_toneTimer = nullptr;
+    double m_tonePhase = 0.0;
+
+    // ---- counters (GUI-thread readable) ----
+    std::atomic<std::uint64_t> m_serialRxBytes{0};
+    std::atomic<std::uint64_t> m_serialTxBytes{0};
+    std::atomic<std::uint64_t> m_audioBlocks{0};
+    std::atomic<std::uint64_t> m_audioSamples{0};
+    std::atomic<int> m_catTimeouts{0};
+    std::atomic<int> m_rttMs{-1};
+
+    static constexpr int kPollIntervalMs = 100;
+    static constexpr int kQueryTimeoutMs = 400;
+    static constexpr int kIdRetries = 3;
+    // ~5 s of unanswered CAT (timeouts accumulate at ~2/s) = link dead.
+    static constexpr int kMaxConsecutiveTimeouts = 10;
+    static constexpr int kAudioOutRateFallbackHz = 48000;
+    static constexpr double kTuneToneHz = 1500.0;
+    static constexpr double kTuneToneAmplitude = 0.7;
+    static constexpr int kEngineRxRateHz = 24000;   // AudioEngine native RX rate
+};
+
+}  // namespace AetherSDR::ft991
+
+Q_DECLARE_METATYPE(AetherSDR::ft991::Ft991Device::Params)
+Q_DECLARE_METATYPE(AetherSDR::ft991::Ft991Device::OpenInfo)

--- a/src/core/backends/ft991/Ft991Discovery.cpp
+++ b/src/core/backends/ft991/Ft991Discovery.cpp
@@ -1,0 +1,95 @@
+#include "core/backends/ft991/Ft991Discovery.h"
+
+#include <QHostAddress>
+#include <QLoggingCategory>
+#include <QSerialPortInfo>
+#include <QTimer>
+
+Q_LOGGING_CATEGORY(lcFt991Disc, "aether.ft991.discovery")
+
+namespace AetherSDR::ft991 {
+
+namespace {
+
+// The FT-991's built-in USB bridge is a Silicon Labs CP2105 (dual UART).
+// Match on what QSerialPortInfo actually reports for it; the "Standard COM
+// Port" half is the radio's GPS/firmware channel, not CAT.
+bool looksLikeFt991Port(const QSerialPortInfo& info)
+{
+    const QString desc = info.description().toLower();
+    const QString manu = info.manufacturer().toLower();
+    const bool cp210 = desc.contains(QLatin1String("cp210"))
+        || manu.contains(QLatin1String("silicon lab"));
+    if (!cp210)
+        return false;
+    if (desc.contains(QLatin1String("standard com port")))
+        return false;
+    return true;
+}
+
+}  // namespace
+
+Ft991Discovery::Ft991Discovery(QObject* parent) : QObject(parent)
+{
+    m_timer = new QTimer(this);
+    connect(m_timer, &QTimer::timeout, this, &Ft991Discovery::pollNow);
+}
+
+Ft991Discovery::~Ft991Discovery() = default;
+
+QString Ft991Discovery::serialForPort(const QString& portName)
+{
+    return QStringLiteral("ft991-%1").arg(portName);
+}
+
+void Ft991Discovery::start(int intervalMs)
+{
+    m_timer->start(intervalMs);
+    pollNow();
+}
+
+void Ft991Discovery::stop()
+{
+    m_timer->stop();
+}
+
+void Ft991Discovery::pollNow()
+{
+    QHash<QString, RadioInfo> now;
+    const auto ports = QSerialPortInfo::availablePorts();
+    for (const QSerialPortInfo& port : ports) {
+        if (!looksLikeFt991Port(port))
+            continue;
+        RadioInfo info;
+        info.family = QStringLiteral("ft991");
+        info.name = QStringLiteral("FT-991");
+        info.model = QStringLiteral("FT-991");
+        info.serial = serialForPort(port.portName());
+        info.nickname = QStringLiteral("FT-991 (%1)").arg(port.portName());
+        info.address = QHostAddress(QHostAddress::LocalHost);   // synthetic; never dialed
+        info.port = 0;
+        info.status = QStringLiteral("Available");
+        info.inUse = false;
+        info.multiFlexEnabled = false;
+        info.isSystemModel = false;
+        now.insert(info.serial, info);
+    }
+
+    for (auto it = now.cbegin(); it != now.cend(); ++it) {
+        if (m_seen.contains(it.key()))
+            emit radioUpdated(it.value());
+        else {
+            qCInfo(lcFt991Disc) << "candidate" << it.key();
+            emit radioDiscovered(it.value());
+        }
+    }
+    for (auto it = m_seen.cbegin(); it != m_seen.cend(); ++it) {
+        if (!now.contains(it.key())) {
+            qCInfo(lcFt991Disc) << "lost" << it.key();
+            emit radioLost(it.key());
+        }
+    }
+    m_seen = now;
+}
+
+}  // namespace AetherSDR::ft991

--- a/src/core/backends/ft991/Ft991Discovery.h
+++ b/src/core/backends/ft991/Ft991Discovery.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "core/RadioDiscovery.h"   // RadioInfo
+
+#include <QHash>
+#include <QObject>
+#include <QString>
+
+class QTimer;
+
+namespace AetherSDR::ft991 {
+
+// FT-991 candidate enumeration, shaped to feed the same picker as the Flex,
+// HL2 and Colibri sweeps: RadioInfo with family="ft991", synthetic LocalHost
+// address (a serial device has no endpoint to dial), identity "ft991-<port>".
+//
+// A CAT radio cannot be probed without opening its port — and opening ports
+// speculatively is not this class's call to make (a port may belong to a
+// rotator, a keyer, anything). So this is a HEURISTIC listing: serial ports
+// whose description/manufacturer matches the FT-991's Silicon Labs CP210x
+// USB bridge (skipping the CP2105's "Standard" half — CAT lives on the
+// "Enhanced" COM port). Listing is an offer, not an action: connect verifies
+// the radio with "ID;" before anything else is said, so a wrong guess costs
+// one refused connect, never a mis-driven device.
+class Ft991Discovery : public QObject {
+    Q_OBJECT
+
+public:
+    explicit Ft991Discovery(QObject* parent = nullptr);
+    ~Ft991Discovery() override;
+
+    // Begin periodic polls. Safe to call twice; restarts the cadence.
+    void start(int intervalMs = 5000);
+    void stop();
+    void pollNow();
+
+    static QString serialForPort(const QString& portName);
+
+signals:
+    void radioDiscovered(const RadioInfo& info);
+    void radioUpdated(const RadioInfo& info);
+    void radioLost(const QString& serial);
+
+private:
+    QTimer* m_timer = nullptr;
+    QHash<QString, RadioInfo> m_seen;   // keyed by serial
+};
+
+}  // namespace AetherSDR::ft991

--- a/src/core/backends/ft991/Ft991Settings.cpp
+++ b/src/core/backends/ft991/Ft991Settings.cpp
@@ -1,0 +1,75 @@
+#include "core/backends/ft991/Ft991Settings.h"
+
+#include "core/AppSettings.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QString>
+
+namespace AetherSDR {
+
+namespace {
+// Single nested-JSON key holding this backend's config (Principle V).
+// Shape: {"baudRate":int, "audioInHint":string, "audioOutHint":string}.
+const QString kRootKey = QStringLiteral("Ft991");
+
+constexpr const char* kFieldBaudRate = "baudRate";
+constexpr const char* kFieldAudioInHint = "audioInHint";
+constexpr const char* kFieldAudioOutHint = "audioOutHint";
+
+constexpr int kDefaultBaud = 38400;
+}  // namespace
+
+QJsonObject Ft991Settings::readObj()
+{
+    const QString json =
+        AppSettings::instance().value(kRootKey, QString{}).toString();
+    if (json.isEmpty())
+        return {};
+    return QJsonDocument::fromJson(json.toUtf8()).object();
+}
+
+void Ft991Settings::writeObj(const QJsonObject& obj)
+{
+    // Read-modify-write the whole object so it is always persisted as a unit
+    // (Principle XIV) — never half a config after a crash mid-write.
+    auto& s = AppSettings::instance();
+    s.setValue(kRootKey,
+               QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+    s.save();
+}
+
+int Ft991Settings::baudRate()
+{
+    // Only the four rates the radio's menu offers are honoured; anything
+    // else (absent, hand-edited) falls to the default (Principle VII).
+    const int v = readObj().value(QLatin1String(kFieldBaudRate)).toInt(0);
+    if (v == 4800 || v == 9600 || v == 19200 || v == 38400)
+        return v;
+    return kDefaultBaud;
+}
+
+void Ft991Settings::setBaudRate(int baud)
+{
+    if (baud != 4800 && baud != 9600 && baud != 19200 && baud != 38400)
+        return;
+    QJsonObject o = readObj();
+    o[QLatin1String(kFieldBaudRate)] = baud;
+    writeObj(o);
+}
+
+QString Ft991Settings::audioInHint()
+{
+    const QString v =
+        readObj().value(QLatin1String(kFieldAudioInHint)).toString();
+    return v.isEmpty() ? QStringLiteral("usb audio codec") : v;
+}
+
+QString Ft991Settings::audioOutHint()
+{
+    const QString v =
+        readObj().value(QLatin1String(kFieldAudioOutHint)).toString();
+    return v.isEmpty() ? QStringLiteral("usb audio codec") : v;
+}
+
+}  // namespace AetherSDR

--- a/src/core/backends/ft991/Ft991Settings.h
+++ b/src/core/backends/ft991/Ft991Settings.h
@@ -1,0 +1,34 @@
+#pragma once
+
+class QJsonObject;
+class QString;
+
+namespace AetherSDR {
+
+// Owned configuration for the FT-991 backend, per Constitution Principle V:
+// one nested JSON object under a single root key ("Ft991"), read and written
+// atomically, with one place to default.
+//
+//   baudRate     — CAT serial rate. Default 38400; must match the radio's
+//                  menu 031 CAT RATE. (Framing is fixed 8N2 per the manual.)
+//   audioInHint  — case-insensitive substring matched against the capture
+//                  device description. Default "usb audio codec", which is
+//                  what the FT-991's built-in codec enumerates as.
+//   audioOutHint — same, for the TX playback device.
+//
+// The COM port is NOT stored here: it is the radio's discovery identity
+// (serial "ft991-<port>"), chosen in the picker like any other radio.
+class Ft991Settings {
+public:
+    static int baudRate();
+    static void setBaudRate(int baud);
+
+    static QString audioInHint();
+    static QString audioOutHint();
+
+private:
+    static QJsonObject readObj();
+    static void writeObj(const QJsonObject& obj);
+};
+
+}  // namespace AetherSDR

--- a/src/core/backends/ft991/Ft991Spectrum.cpp
+++ b/src/core/backends/ft991/Ft991Spectrum.cpp
@@ -1,0 +1,108 @@
+#include "core/backends/ft991/Ft991Spectrum.h"
+
+#include <fftw3.h>
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR::ft991 {
+
+namespace {
+constexpr double kPi = 3.14159265358979323846;
+}
+
+Ft991Spectrum::Ft991Spectrum(int sampleRateHz, double spanHz, int fftSize)
+    : m_fftSize(fftSize < 16 ? 16 : fftSize)
+{
+    const int rate = sampleRateHz > 0 ? sampleRateHz : 48000;
+    m_binHz = static_cast<double>(rate) / m_fftSize;
+    // Never past Nyquist, never zero: a span request the rate cannot cover
+    // clamps to what the transform actually produces.
+    const int nyquistBins = m_fftSize / 2;
+    m_binCount = std::clamp(static_cast<int>(std::lround(spanHz / m_binHz)),
+                            1, nyquistBins);
+
+    m_acc.reserve(static_cast<std::size_t>(m_fftSize));
+    m_window.resize(static_cast<std::size_t>(m_fftSize));
+    double sum = 0.0;
+    for (int n = 0; n < m_fftSize; ++n) {
+        m_window[static_cast<std::size_t>(n)] =
+            0.5 * (1.0 - std::cos(2.0 * kPi * n / (m_fftSize - 1)));   // Hanning
+        sum += m_window[static_cast<std::size_t>(n)];
+    }
+    m_coherentGain = sum / 2.0;
+    if (m_coherentGain < 1e-9)
+        m_coherentGain = 1.0;
+
+    m_in = fftw_malloc(sizeof(double) * static_cast<std::size_t>(m_fftSize));
+    m_out = fftw_malloc(sizeof(fftw_complex)
+                        * (static_cast<std::size_t>(m_fftSize) / 2 + 1));
+    m_plan = fftw_plan_dft_r2c_1d(m_fftSize, static_cast<double*>(m_in),
+                                  static_cast<fftw_complex*>(m_out),
+                                  FFTW_ESTIMATE);
+}
+
+Ft991Spectrum::~Ft991Spectrum()
+{
+    if (m_plan) fftw_destroy_plan(static_cast<fftw_plan>(m_plan));
+    if (m_in) fftw_free(m_in);
+    if (m_out) fftw_free(m_out);
+}
+
+int Ft991Spectrum::process(std::span<const float> mono, std::vector<float>& binsDbfs)
+{
+    int frames = 0;
+    for (const float s : mono) {
+        m_acc.push_back(s);
+        if (static_cast<int>(m_acc.size()) == m_fftSize) {
+            computeFrame(binsDbfs);
+            m_acc.clear();
+            ++frames;
+        }
+    }
+    return frames;
+}
+
+void Ft991Spectrum::accumulate(std::span<const float> mono)
+{
+    m_acc.insert(m_acc.end(), mono.begin(), mono.end());
+    // Hold at most fftSize - 1: exactly-full would wedge process()'s
+    // boundary check (it fires on == fftSize after a push_back).
+    const std::size_t keep = static_cast<std::size_t>(m_fftSize) - 1;
+    if (m_acc.size() > keep) {
+        m_acc.erase(m_acc.begin(),
+                    m_acc.end() - static_cast<std::ptrdiff_t>(keep));
+    }
+}
+
+void Ft991Spectrum::computeFrame(std::vector<float>& binsDbfs)
+{
+    // Remove the frame's DC offset (codec/ADC bias), then window.
+    double mean = 0.0;
+    for (const float s : m_acc)
+        mean += s;
+    mean /= m_fftSize;
+
+    auto* in = static_cast<double*>(m_in);
+    for (int n = 0; n < m_fftSize; ++n) {
+        in[n] = (static_cast<double>(m_acc[static_cast<std::size_t>(n)]) - mean)
+                * m_window[static_cast<std::size_t>(n)];
+    }
+
+    fftw_execute(static_cast<fftw_plan>(m_plan));
+
+    const auto* out = static_cast<fftw_complex*>(m_out);
+    binsDbfs.resize(static_cast<std::size_t>(m_binCount));
+    for (int k = 0; k < m_binCount; ++k) {
+        const double re = out[k][0];
+        const double im = out[k][1];
+        // A real input splits each tone across the +/- pair the r2c transform
+        // folds together; coherentGain already carries the /2, so a full-scale
+        // sine reads 0 dBFS here just as it does on the complex siblings.
+        const double mag = std::sqrt(re * re + im * im) / m_coherentGain;
+        binsDbfs[static_cast<std::size_t>(k)] =
+            static_cast<float>(20.0 * std::log10(mag + 1e-12));
+    }
+}
+
+}  // namespace AetherSDR::ft991

--- a/src/core/backends/ft991/Ft991Spectrum.h
+++ b/src/core/backends/ft991/Ft991Spectrum.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <cstddef>
+#include <span>
+#include <vector>
+
+namespace AetherSDR::ft991 {
+
+// The FT-991 "panadapter" path: accumulate demodulated REAL audio into fixed
+// FFT frames and keep the bins from 0 Hz to spanHz, in dBFS ascending audio
+// frequency. A sibling of colibri::ColibriSpectrum (same Hanning window,
+// per-frame DC removal, coherent-gain normalization) with the input real
+// instead of complex and NO fftshift — audio has no negative frequencies,
+// and the backend owns the audio->RF mapping (including the LSB reversal).
+// Duplicated per-family per the backend layout rather than promoted.
+//
+// Owns an FFTW plan; construction/destruction allocate, process() does not.
+// FFTW's global planner is not thread-safe, so construct off the sample path.
+class Ft991Spectrum {
+public:
+    // sampleRateHz is the CAPTURE rate (the codec's native rate); spanHz is
+    // how much of the audio band the frame keeps.
+    Ft991Spectrum(int sampleRateHz, double spanHz, int fftSize = 8192);
+    ~Ft991Spectrum();
+    Ft991Spectrum(const Ft991Spectrum&) = delete;
+    Ft991Spectrum& operator=(const Ft991Spectrum&) = delete;
+
+    [[nodiscard]] int fftSize() const noexcept { return m_fftSize; }
+    // Bins actually emitted per frame (0 Hz .. spanHz).
+    [[nodiscard]] int binCount() const noexcept { return m_binCount; }
+    [[nodiscard]] double binHz() const noexcept { return m_binHz; }
+    // The span the emitted bins genuinely cover: binCount * binHz — what the
+    // backend must advertise via panCenterBandwidthChanged, NOT the requested
+    // spanHz (they differ by up to one bin's rounding).
+    [[nodiscard]] double coveredSpanHz() const noexcept { return m_binCount * m_binHz; }
+
+    // Append mono audio; each time a full frame accumulates, compute one
+    // spectrum. `binsDbfs` is resized to binCount() (index 0 = 0 Hz,
+    // ascending audio frequency). Returns frames produced; a partial frame
+    // carries over.
+    int process(std::span<const float> mono, std::vector<float>& binsDbfs);
+
+    // Append WITHOUT transforming, keeping only the newest samples — the
+    // display-rate cap's between-frames feed (same shape as ColibriSpectrum).
+    void accumulate(std::span<const float> mono);
+
+    void reset() noexcept { m_acc.clear(); }
+
+private:
+    void computeFrame(std::vector<float>& binsDbfs);
+
+    int m_fftSize;
+    int m_binCount;
+    double m_binHz;
+    std::vector<float> m_acc;
+    std::vector<double> m_window;   // Hanning
+    double m_coherentGain = 1.0;    // sum(window) / 2
+    // Opaque FFTW handles (fftw3.h stays out of the header).
+    void* m_in = nullptr;           // double[m_fftSize]
+    void* m_out = nullptr;          // fftw_complex[m_fftSize/2 + 1]
+    void* m_plan = nullptr;         // fftw_plan (r2c)
+};
+
+}  // namespace AetherSDR::ft991

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -9,6 +9,9 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 #include "core/backends/hl2/Hl2Discovery.h"
+#ifdef HAVE_SERIALPORT
+#include "core/backends/ft991/Ft991Discovery.h"
+#endif
 #include "models/RadioModel.h"
 #include "models/BandSettings.h"
 #include "models/AntennaGeniusModel.h"
@@ -932,6 +935,11 @@ private:
     // HPSDR/Metis discovery for Hermes-Lite 2 radios. Feeds the same
     // ConnectionPanel slots as m_discovery, tagged family="hl2".
     hl2::Hl2Discovery m_hl2Discovery;
+#ifdef HAVE_SERIALPORT
+    // Yaesu FT-991 serial-port scan. Feeds the same ConnectionPanel slots,
+    // tagged family="ft991"; absent when Qt SerialPort is not built.
+    ft991::Ft991Discovery m_ft991Discovery;
+#endif
     // Radio sessions (#3445 Camp B / #3351). Each session owns the full
     // per-radio aggregate; today there is exactly one. The vector sits at
     // the old `RadioModel m_radioModel` member position so destruction

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -244,6 +244,28 @@ void MainWindow::wireDiscovery()
     connect(&m_hl2Discovery, &hl2::Hl2Discovery::radioUpdated,
             this, &MainWindow::maybeAutoConnectToDiscoveredRadio);
     m_hl2Discovery.start();
+
+#ifdef HAVE_SERIALPORT
+    // FT-991 serial-port scan: same picker, same auto-reconnect slots,
+    // tagged family="ft991". Nothing here is family-special beyond the tag.
+    connect(&m_ft991Discovery, &ft991::Ft991Discovery::radioDiscovered,
+            m_connPanel, &ConnectionPanel::onRadioDiscovered);
+    connect(&m_ft991Discovery, &ft991::Ft991Discovery::radioUpdated,
+            m_connPanel, &ConnectionPanel::onRadioUpdated);
+    connect(&m_ft991Discovery, &ft991::Ft991Discovery::radioLost,
+            m_connPanel, &ConnectionPanel::onRadioLost);
+    connect(&m_ft991Discovery, &ft991::Ft991Discovery::radioLost, this,
+            [this](const QString& serial) {
+                m_autoConnectAttempts.remove(serial);
+                if (m_autoConnectSerial == serial)
+                    m_autoConnectSerial.clear();
+            });
+    connect(&m_ft991Discovery, &ft991::Ft991Discovery::radioDiscovered,
+            this, &MainWindow::maybeAutoConnectToDiscoveredRadio);
+    connect(&m_ft991Discovery, &ft991::Ft991Discovery::radioUpdated,
+            this, &MainWindow::maybeAutoConnectToDiscoveredRadio);
+    m_ft991Discovery.start();
+#endif
     connect(&m_discovery, &RadioDiscovery::radioUpdated,
             m_connPanel, &ConnectionPanel::onRadioUpdated);
     connect(&m_discovery, &RadioDiscovery::radioUpdated,

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -11,6 +11,9 @@
 #include "core/backends/icom/IcomCivBackend.h"  // Icom networked radios (family "icom")
 #include "core/backends/icom/IcomCredentials.h"  // password: keychain, never settings
 #include "core/backends/icom/IcomSettings.h"     // host/user/ports (Principle V)
+#ifdef HAVE_SERIALPORT
+#include "core/backends/ft991/Ft991Backend.h"  // Yaesu FT-991 backend (family "ft991")
+#endif
 #include "core/AppSettings.h"
 #include "core/RadioStateMemory.h"  // RFC #4603 typed restore handoff
 #include "core/CwTrace.h"
@@ -556,6 +559,13 @@ std::unique_ptr<IRadioBackend> RadioModel::makeBackend(const QString& family)
     // restored state (Constitution II/III).
     if (family.compare(QLatin1String("icom"), Qt::CaseInsensitive) == 0)
         return std::make_unique<icom::IcomCivBackend>();
+#ifdef HAVE_SERIALPORT
+    // Yaesu FT-991: pure-seam, and radio-authoritative like the Icom — it
+    // declares no ClientSettingsDomains. Absent entirely when Qt SerialPort
+    // is not built.
+    if (family.compare(QLatin1String("ft991"), Qt::CaseInsensitive) == 0)
+        return std::make_unique<ft991::Ft991Backend>();
+#endif
     // RFC #4288 demo mode: the synthetic radio is selected here like any other
     // family, which is what completes the "wire it through the real SimBackend
     // factory" ask. Unlike HL2 it is a Route A hybrid — it owns a RadioConnection

--- a/tests/ft991_cat_test.cpp
+++ b/tests/ft991_cat_test.cpp
@@ -1,0 +1,283 @@
+#include "core/backends/ft991/Ft991Cat.h"
+
+#include <QByteArray>
+#include <QString>
+
+#include <cstdio>
+
+using namespace AetherSDR::ft991;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) {
+        ++g_failed;
+    }
+}
+
+bool parsesTo(const char* frame, Ft991Cat::Response::Kind kind, int raw)
+{
+    const auto r = Ft991Cat::parse(QByteArray(frame));
+    return r && r->kind == kind && r->raw == raw;
+}
+
+}  // namespace
+
+int main()
+{
+    // ── Frame builders. Every literal here is the CAT Operation Reference
+    //    Manual's own format for the FT-991; hamlib's ft991/newcat driver
+    //    encodes the same bytes and served as the cross-check. These are
+    //    written out rather than derived, so a wrong field width or a
+    //    dropped VFO digit fails loudly instead of being "consistent".
+    report("FA takes 9 zero-padded digits",
+           Ft991Cat::setFrequency(14'074'000.0) == QByteArray("FA014074000;"));
+    report("FA rounds fractional Hz to the nearest whole hertz",
+           Ft991Cat::setFrequency(14'074'000.6) == QByteArray("FA014074001;"));
+    report("FA refuses a frequency below the tuning floor",
+           Ft991Cat::setFrequency(1000.0).isEmpty());
+    report("FA refuses a frequency above the tuning ceiling",
+           Ft991Cat::setFrequency(9.0e8).isEmpty());
+
+    report("MD0 encodes USB as 2", Ft991Cat::setMode("USB") == QByteArray("MD02;"));
+    report("MD0 encodes LSB as 1", Ft991Cat::setMode("LSB") == QByteArray("MD01;"));
+    report("MD0 encodes DIGU as C (DATA-USB)",
+           Ft991Cat::setMode("DIGU") == QByteArray("MD0C;"));
+    report("MD0 encodes DIGL as 8 (DATA-LSB)",
+           Ft991Cat::setMode("DIGL") == QByteArray("MD08;"));
+    report("MD0 encodes CWL as 7 (CW-R)",
+           Ft991Cat::setMode("CWL") == QByteArray("MD07;"));
+    report("CWU folds onto CW (the radio has no separate CW-U code)",
+           Ft991Cat::setMode("CWU") == Ft991Cat::setMode("CW"));
+    report("an unmappable mode yields no frame rather than a wrong one",
+           Ft991Cat::setMode("PACTOR").isEmpty());
+
+    report("TX1 keys, TX0 unkeys",
+           Ft991Cat::setPtt(true) == QByteArray("TX1;")
+               && Ft991Cat::setPtt(false) == QByteArray("TX0;"));
+    report("PC takes 3 digits and clamps to the radio's 5..100 W range",
+           Ft991Cat::setPowerWatts(5) == QByteArray("PC005;")
+               && Ft991Cat::setPowerWatts(100) == QByteArray("PC100;")
+               && Ft991Cat::setPowerWatts(0) == QByteArray("PC005;")
+               && Ft991Cat::setPowerWatts(250) == QByteArray("PC100;"));
+    report("GT0 maps the neutral AGC vocabulary",
+           Ft991Cat::setAgc("off") == QByteArray("GT00;")
+               && Ft991Cat::setAgc("fast") == QByteArray("GT01;")
+               && Ft991Cat::setAgc("med") == QByteArray("GT02;")
+               && Ft991Cat::setAgc("slow") == QByteArray("GT03;"));
+
+    // ── Radio-side DSP builders ──────────────────────────────────────────
+    report("NB0/NR0/BC0 take one digit",
+           Ft991Cat::setNoiseBlanker(true) == QByteArray("NB01;")
+               && Ft991Cat::setNoiseReduction(false) == QByteArray("NR00;")
+               && Ft991Cat::setAutoNotch(true) == QByteArray("BC01;"));
+    report("NL level is 2 digits, clamped 0..10",
+           Ft991Cat::setNoiseBlankerLevel(7) == QByteArray("NL0007;")
+               && Ft991Cat::setNoiseBlankerLevel(99) == QByteArray("NL0010;")
+               && Ft991Cat::setNoiseBlankerLevel(-3) == QByteArray("NL0000;"));
+    report("RL (DNR level) is 2 digits, clamped 1..15 — never 0",
+           Ft991Cat::setNoiseReductionLevel(9) == QByteArray("RL009;")
+               && Ft991Cat::setNoiseReductionLevel(99) == QByteArray("RL015;"));
+    report("RL clamps below 1 to 1 (0 is not a level the radio accepts)",
+           Ft991Cat::setNoiseReductionLevel(0).endsWith("01;"));
+    report("BP01 carries the notch position in 10 Hz steps",
+           Ft991Cat::setManualNotchHz(1000) == QByteArray("BP01100;")
+               && Ft991Cat::setManualNotchHz(50) == QByteArray("BP01005;"));
+    report("BP00 carries the notch on/off flag",
+           Ft991Cat::setManualNotch(true) == QByteArray("BP00001;")
+               && Ft991Cat::setManualNotch(false) == QByteArray("BP00000;"));
+    report("SH takes a 2-digit index",
+           Ft991Cat::setWidthIndex(7) == QByteArray("SH007;")
+               && Ft991Cat::setWidthIndex(21) == QByteArray("SH021;"));
+    report("NA0 carries the narrow flag",
+           Ft991Cat::setNarrow(true) == QByteArray("NA01;")
+               && Ft991Cat::setNarrow(false) == QByteArray("NA00;"));
+
+    // ── Clarifier. There is no absolute-offset command on the wire, so the
+    //    setter is "clear then step" — and the FT-991 has ONE shared knob,
+    //    which is why RIT and XIT enable separately but cannot hold
+    //    different offsets.
+    report("RT/XT carry the two enable flags independently",
+           Ft991Cat::setRitEnabled(true) == QByteArray("RT1;")
+               && Ft991Cat::setRitEnabled(false) == QByteArray("RT0;")
+               && Ft991Cat::setXitEnabled(true) == QByteArray("XT1;")
+               && Ft991Cat::setXitEnabled(false) == QByteArray("XT0;"));
+    report("a positive offset clears then steps UP, 4 digits",
+           Ft991Cat::setClarifierOffset(1200) == QByteArray("RC;RU1200;"));
+    report("a negative offset clears then steps DOWN",
+           Ft991Cat::setClarifierOffset(-350) == QByteArray("RC;RD0350;"));
+    report("zero is a bare clear — no pointless step",
+           Ft991Cat::setClarifierOffset(0) == QByteArray("RC;"));
+    report("the offset clamps to the 4-digit field",
+           Ft991Cat::setClarifierOffset(50000) == QByteArray("RC;RU9999;")
+               && Ft991Cat::setClarifierOffset(-50000) == QByteArray("RC;RD9999;"));
+
+    // ── IF response. Field offsets are the whole content of this parse, and
+    //    every one of them is an opportunity for an off-by-one that silently
+    //    reads the neighbouring field. 27 chars with the ';' stripped:
+    //    IF|ch |frequency|clar |R|X|M|V|C|00|S
+    //           IF|ch |frequency|clar |RXM VC00S
+    {
+        const QByteArray f("IF001014074000+000000200000");
+        const auto r = Ft991Cat::parse(f);
+        report("the IF fixture is the 27 characters the radio really sends",
+               f.size() == 27);
+        report("IF decodes the 9-digit VFO-A frequency",
+               r && r->kind == Ft991Cat::Response::Kind::Info
+                   && r->frequencyHz == 14'074'000.0);
+    }
+    {
+        // clarifier +1200, RIT on, XIT off, mode 2 (USB)
+        const auto r = Ft991Cat::parse(QByteArray("IF001014074000+120010200000"));
+        report("IF decodes a positive clarifier with RIT on and XIT off",
+               r && r->kind == Ft991Cat::Response::Kind::Info
+                   && r->clarifierHz == 1200 && r->ritOn && !r->xitOn
+                   && r->mode == "USB");
+    }
+    {
+        // clarifier -0350, RIT off, XIT on, mode 1 (LSB)
+        const auto r = Ft991Cat::parse(QByteArray("IF001007074000-035001100000"));
+        report("IF decodes a negative clarifier with XIT on and RIT off",
+               r && r->clarifierHz == -350 && !r->ritOn && r->xitOn
+                   && r->mode == "LSB");
+    }
+    {
+        const auto r = Ft991Cat::parse(QByteArray("IF00114074000+0000002000000"));
+        report("a short IF (8-digit frequency, not ours) is Unknown",
+               r && r->kind == Ft991Cat::Response::Kind::Unknown);
+    }
+    {
+        const auto r = Ft991Cat::parse(QByteArray("IF0010140740000000000200000"));
+        report("an IF with no clarifier sign is Unknown, not a zero offset",
+               r && r->kind == Ft991Cat::Response::Kind::Unknown);
+    }
+
+    // ── Width tables. The values are the manual's SH tables (shared with the
+    //    FT-891); the snapping is ours. Index 0 is the per-mode DEFAULT and
+    //    must never be chosen by the snap — picking it would command "the
+    //    radio's idea of default" for every requested width.
+    report("SSB snaps 2400 Hz onto its own table entry",
+           Ft991Cat::widthForIndex("USB", Ft991Cat::nearestWidthIndex("USB", 2400),
+                                   false) == 2400);
+    report("SSB snaps an off-table 2450 Hz to a neighbour, not to default",
+           Ft991Cat::nearestWidthIndex("USB", 2450) > 0);
+    report("SSB's widest entry is 3200 Hz",
+           Ft991Cat::widthForIndex("USB", Ft991Cat::nearestWidthIndex("USB", 9000),
+                                   false) == 3200);
+    report("CW snaps 500 Hz onto its own table entry",
+           Ft991Cat::widthForIndex("CW", Ft991Cat::nearestWidthIndex("CW", 500),
+                                   false) == 500);
+    report("CW's narrowest entry is 50 Hz",
+           Ft991Cat::widthForIndex("CW", Ft991Cat::nearestWidthIndex("CW", 10),
+                                   false) == 50);
+    report("DATA modes use the CW table, not the SSB one",
+           Ft991Cat::widthFamilyForMode("DIGU") == Ft991Cat::WidthFamily::CwData
+               && Ft991Cat::widthFamilyForMode("DIGL") == Ft991Cat::WidthFamily::CwData);
+    report("AM/FM are fixed-width: no SH index exists for them",
+           Ft991Cat::nearestWidthIndex("AM", 6000) < 0
+               && Ft991Cat::nearestWidthIndex("FM", 12000) < 0);
+    report("the snap never returns index 0 (the radio's default slot)",
+           Ft991Cat::nearestWidthIndex("USB", 1) != 0
+               && Ft991Cat::nearestWidthIndex("CW", 1) != 0);
+    report("index 0 decodes to the per-mode default, and NA changes it",
+           Ft991Cat::widthForIndex("USB", 0, true) == 1500
+               && Ft991Cat::widthForIndex("USB", 0, false) == 2400
+               && Ft991Cat::widthForIndex("CW", 0, true) == 500
+               && Ft991Cat::widthForIndex("DIGU", 0, true) == 300);
+    report("NA follows the table's narrow_max split point",
+           Ft991Cat::narrowForWidth("USB", 1800)
+               && !Ft991Cat::narrowForWidth("USB", 1950)
+               && Ft991Cat::narrowForWidth("CW", 500)
+               && !Ft991Cat::narrowForWidth("CW", 800));
+
+    // ── Sideband mapping. This is what decides which half of the pan the
+    //    audio bins land on; getting it wrong draws the spectrum mirrored.
+    report("USB-side modes report the high sideband",
+           !Ft991Cat::isLowSideband("USB") && !Ft991Cat::isLowSideband("DIGU")
+               && !Ft991Cat::isLowSideband("CW"));
+    report("LSB-side modes report the low sideband",
+           Ft991Cat::isLowSideband("LSB") && Ft991Cat::isLowSideband("DIGL")
+               && Ft991Cat::isLowSideband("CWL"));
+
+    // ── Response parsing ─────────────────────────────────────────────────
+    {
+        const auto r = Ft991Cat::parse(QByteArray("FA014074000"));
+        report("FA response decodes to Hz",
+               r && r->kind == Ft991Cat::Response::Kind::Frequency
+                   && r->frequencyHz == 14'074'000.0);
+    }
+    {
+        const auto r = Ft991Cat::parse(QByteArray("MD02"));
+        report("MD0 response decodes to the neutral mode name",
+               r && r->kind == Ft991Cat::Response::Kind::Mode && r->mode == "USB");
+    }
+    {
+        const auto r = Ft991Cat::parse(QByteArray("MD06"));
+        report("RTTY-LSB displays as DIGL (documented lossy mapping)",
+               r && r->mode == "DIGL");
+    }
+    {
+        const auto r = Ft991Cat::parse(QByteArray("ID0670"));
+        report("ID response carries the FT-991 identity",
+               r && r->kind == Ft991Cat::Response::Kind::Id
+                   && r->id == QLatin1String(Ft991Cat::kRadioId));
+    }
+    {
+        const auto r = Ft991Cat::parse(QByteArray("?"));
+        report("a refused command is reported as Rejected, not as data",
+               r && r->kind == Ft991Cat::Response::Kind::Rejected);
+    }
+    {
+        const auto r = Ft991Cat::parse(QByteArray("FA0140740xx"));
+        report("a malformed FA is Unknown — it must never tune anything",
+               r && r->kind == Ft991Cat::Response::Kind::Unknown);
+    }
+    report("empty input yields no response at all",
+           !Ft991Cat::parse(QByteArray()).has_value());
+
+    report("SM0 decodes the S-meter raw count",
+           parsesTo("SM0128", Ft991Cat::Response::Kind::SMeter, 128));
+    {
+        const auto keyed = Ft991Cat::parse(QByteArray("TX1"));
+        const auto idle = Ft991Cat::parse(QByteArray("TX0"));
+        report("TX decodes the keying state",
+               keyed && keyed->kind == Ft991Cat::Response::Kind::Tx
+                   && keyed->txState == 1
+                   && idle && idle->txState == 0);
+    }
+    report("NB0/NR0/BC0 responses decode as flags",
+           parsesTo("NB01", Ft991Cat::Response::Kind::NoiseBlanker, 1)
+               && parsesTo("NR00", Ft991Cat::Response::Kind::NoiseReduction, 0)
+               && parsesTo("BC01", Ft991Cat::Response::Kind::AutoNotch, 1));
+    report("NL/RL responses decode as levels",
+           parsesTo("NL0007", Ft991Cat::Response::Kind::NoiseBlankerLevel, 7)
+               && parsesTo("RL009", Ft991Cat::Response::Kind::NoiseReductionLevel, 9));
+    report("SH0 response decodes the width index",
+           parsesTo("SH017", Ft991Cat::Response::Kind::Width, 17));
+    report("NA0 response decodes the narrow flag",
+           parsesTo("NA01", Ft991Cat::Response::Kind::Narrow, 1));
+    report("BP00 vs BP01 are distinguished, and BP01 scales to Hz",
+           parsesTo("BP00001", Ft991Cat::Response::Kind::ManualNotch, 1)
+               && parsesTo("BP01100", Ft991Cat::Response::Kind::ManualNotchFreq, 1000));
+    report("RM5/RM6 decode as the TX power and SWR meters",
+           parsesTo("RM5123", Ft991Cat::Response::Kind::TxPowerMeter, 123)
+               && parsesTo("RM6045", Ft991Cat::Response::Kind::TxSwrMeter, 45));
+    {
+        // A meter this backend does not poll must not be mistaken for one it
+        // does — the RM family shares a prefix across every meter.
+        const auto r = Ft991Cat::parse(QByteArray("RM1099"));
+        report("an unpolled RM meter is Unknown, not a mis-attributed reading",
+               r && r->kind == Ft991Cat::Response::Kind::Unknown);
+    }
+
+    if (g_failed == 0) {
+        std::printf("\nAll FT-991 CAT tests passed.\n");
+    } else {
+        std::printf("\n%d FT-991 CAT test(s) FAILED.\n", g_failed);
+    }
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Second of two backends split out of #4904 at your request. Independent of the ColibriNANO one — this branch builds and tests on its own against `main`, and the two touch disjoint code apart from the `CORE_SOURCES` list, the `makeBackend` chain and the discovery block in `MainWindow`. Whichever lands second will need a trivial rebase there; happy to do it.

**Purely additive: 19 files, ~4400 insertions, zero deletions.** Nothing outside `src/core/backends/ft991/` changes except those three integration points, one test target, the capabilities map and the design doc. **No seam verbs, capabilities or model signals are added** — this backend implements what is already there.

## What it is

CAT over the radio's serial port (the built-in CP2105's *Enhanced* half), audio over its built-in USB codec. The radio demodulates and modulates internally, so unlike HL2 and Colibri there is **no host DSP chain below the seam**: what the backend owns is the CAT translation, the audio plumbing, and an honest audio-band panadapter.

Protocol authority is Yaesu's own published **FT-991/FT-991A CAT Operation Reference Manual** — every byte this backend sends appears in it, and hamlib's `ft991` driver served only as a cross-check (Principle IV: clean room, no vendor code). Built only when Qt SerialPort is (`HAVE_SERIALPORT`), like every other serial consumer.

Radio-authoritative like the Icom: `clientSettingsDomains` is **empty** and nothing here restores live state the radio already remembers across power cycles (Principles II and III).

## The panadapter is a lens, and the doc leads with that

A real-input FFT of the demodulated audio on an 8 kHz window **symmetric about the dial**. It shows one channel, not a band — the waterfall covers ~8 kHz around the dial, and the design doc says so in its opening paragraph rather than burying it.

Two constants in that sentence were paid for on the air (Principle VIII):

- **Symmetric, not dial-at-the-left-edge.** The GUI's slice-follow policy re-centres the pan onto the active slice; with the slice pinned to a window *edge*, that recursed — synchronously, through the seam, walking the **real radio** down 2 kHz per round via CAT until the stack overflowed. `centre == dial` makes the re-centre request the identity, and it dies in the change gate. A depth guard in the tune verbs remains as a tripwire so any future policy loop truncates and logs instead of crashing.
- **The dataless half is padded at the frame's own measured floor plus a small deterministic ripple.** A sentinel far below the floor (−160 dBm) poisons the display's auto-level statistics; a *constant* pad is exactly the clipped-floor signature `SpectrumWidget`'s headroom recovery hunts, and it ratcheted the range down 24 dB/s forever. Both were observed, not theorised.

Because that window is slaved to the VFO, **`setPanCenter`'s `PanCenterIntent` is load-bearing here** rather than ignorable: a `Drag` retunes the dial, a `Range` centre riding along with a zoom is answered with the geometry we already have. Treating them alike walks the radio across the band one zoom click at a time — precisely the bug that parameter exists to prevent.

## Radio-side DSP, on the seam's existing verbs

- **Filter width** — `NA` (narrow bank, chosen *first*, the manual's order) + `SH` (nearest index in the per-mode tables: SSB 200–3200 Hz in 21 steps, CW/RTTY/DATA 50–3000 Hz in 17; AM/FM fixed). The confirm-poll reflects what the radio actually took back into the displayed passband, so the display converges on radio truth rather than on the request. Turning the radio's own WIDTH knob updates the slice the same way.
- **NB** (`NB`+`NL`), **DNR** (`NR`+`RL`), **auto-notch DNF** (`BC`) via `setSliceNoiseBlanker` / `setSliceNoiseReduction` / `setSliceAutoNotch`.
- **Manual notch** (`BP`) via `setSliceManualNotch`. The seam's 0..100 *passband position* is the better contract — this radio places its notch in audio Hz, and the backend converts in both directions where it knows its own passband.
- Capability tiers say what the radio is: `hasRadioSideDsp` ✅, `hasLmsNoiseFilters` ❌, `hasManualNotch` ✅ — the same shape an Icom declares, so three Flex-only buttons stay hidden rather than moving over registers this radio does not have.
- **Clarifier** — `setRitEnabled` / `setXitEnabled` / `setRitOffset`, with `setXitOffset` deliberately left to its aliasing default: one shared register with two enables is the truth on this radio, not an approximation. The wire has no absolute-offset command, so setting one is `RC;` then `RU`/`RD`, written as one frame pair so nothing observes the intermediate zero.

The slice filter handles act twice: a host-side 4th-order Butterworth applies the exact edges instantly, *and* the radio's own DSP width follows — so filtering happens ahead of the radio's AGC, where it can stop a strong neighbour pumping.

## Transmit

Keying is CAT `TX1`/`TX0` from `setKeying()`/`setTune()` only, and the modem lines are forced low at open so a station wired for line PTT cannot be keyed by connecting (Principle VI). `submitTxAudio()` plays the engine's already-processed TX audio into the codec; TUNE generates its own 1.5 kHz tone with the `PC` drive swapped and restored around it. PO and SWR (`RM5`/`RM6`) are polled while keyed, as uncalibrated linear estimates the doc states plainly rather than dressing up as measurements (Principle X).

## Losing the link

A serial `ResourceError`/`ReadError`, ten consecutive unanswered CAT queries (~5 s), or a capture `IOError` tear the device down and report a reason — instead of a zombie session whose only symptom is a heartbeat going amber.

## Tests

61 assertions over the CAT codec (`tests/ft991_cat_test.cpp`). `Ft991Cat` is deliberately free of `QSerialPort` so the wire vocabulary is testable without hardware, and **every literal is written out from the manual rather than derived from our own encoder** — so a wrong field width fails loudly instead of being self-consistently wrong (Principle XI).

They earned it twice: the `BP` (manual notch) response branch checked 8 characters where the stripped frame is 7 — the notch could never have been read back from the radio — and an `IF` fixture I wrote had the mode digit one field early, failing on my own test data before it could fail on the air.

`ctest -R "ft991|slice|aetherd|icom"` → 30/30 on this branch.

## Verified on live hardware (FT-991 on COM5)

Discovery filters the CP2105 *Standard* port; dial and mode follow the radio's knobs both ways; the 2.8k SSB filter edge is visible in the lens; FT8 renders in the waterfall at 14.074; the radio's NB toggles from the slice button and holds through the confirm-poll; +10 Hz of RIT set from the RX applet comes back through the `IF` poll as 10 Hz.

## Not here, and documented rather than half-built

- **Split.** This radio splits VFO-A/VFO-B, while AetherSDR models split as a second slice marked TX. With `maxSlices=1` the SPLIT handler returns early, and its `slice create` is Flex wire text no seam backend receives. That needs a slice-lifecycle verb on `IRadioBackend` — family-neutral work, out of scope here.
- **The TX chain has never been keyed on the air.** Everything up to the key is exercised; the transmit path itself is unproven, and the design doc says so.
- RF gain (`RG`), squelch (`SQ`), CW keyer (`KY`) and the radio's own memories are not mapped yet.

## Note for review

**Commits are unsigned.** Happy to set up SSH signing and force-push if you would rather not admin-merge — just say which you prefer.
