### PR TITLE
fix(gui): SpotHub auto-scroll follows the sort-order-correct end

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4036,6 +4036,16 @@ target_include_directories(spot_mode_resolver_test PRIVATE src)
 target_link_libraries(spot_mode_resolver_test PRIVATE Qt6::Core)
 add_test(NAME spot_mode_resolver_test COMMAND spot_mode_resolver_test)
 
+# SpotHub's newest-spot-follows-the-viewport decision (#4889), header-only
+# and dependency-free by design so it's testable without DxClusterDialog's
+# full client/model dependency graph.
+add_executable(spot_auto_scroll_test
+    tests/spot_auto_scroll_test.cpp
+)
+target_include_directories(spot_auto_scroll_test PRIVATE src)
+target_link_libraries(spot_auto_scroll_test PRIVATE Qt6::Core)
+add_test(NAME spot_auto_scroll_test COMMAND spot_auto_scroll_test)
+
 add_executable(n1mm_spot_client_test
     tests/n1mm_spot_client_test.cpp
     src/core/N1MMSpotParser.cpp

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -2473,7 +2473,10 @@ void DxClusterDialog::buildSpotListTab(QTabWidget* tabs)
     m_spotTable->setColumnWidth(SpotTableModel::ColBand, 45);
     m_spotTable->setColumnWidth(SpotTableModel::ColSource, 55);
 
-    // No default sort — insertion order is newest-first
+    // The sort indicator is hidden, but the table IS sorted: setSortingEnabled(true)
+    // above applies the header's default indicator (Qt 6: section 0 — Time —
+    // descending), which happens to match the model's newest-first insertion
+    // order. Verified on Qt 6.8.3 and 6.11.1 (#4889).
     m_spotTable->horizontalHeader()->setSortIndicatorShown(false);
 
     // Column visibility (#4157): Time/Freq/DX Call stay always-on as the

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -5,6 +5,7 @@
 // must share its cap too. Header self-guards on HAVE_WEBSOCKETS.
 #include "FreeDvReporterDialog.h"
 #include "GuardedSlider.h"
+#include "SpotAutoScroll.h"
 #include "core/DxClusterClient.h"
 #include "core/AppSettings.h"
 #include "core/N1MMSpotParser.h"
@@ -713,8 +714,11 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
 #endif
 
     // Scroll spot table to show newest entries. The model is prepend-based
-    // (newest spot is always source row 0), and the table opens unsorted, so
-    // newest-first is the top, not the bottom (#4889).
+    // (newest spot is always source row 0), and the table is already sorted
+    // Time-descending by this point — setSortingEnabled(true) (buildSpotListTab)
+    // applies the header's default sort indicator (Qt 6: section 0, descending
+    // — the Time column, descending), which is the same order the model
+    // prepends in — so newest-first is the top, not the bottom (#4889).
     m_spotTable->scrollToTop();
 
     // Disable autoDefault on all buttons so Enter in command inputs
@@ -3342,37 +3346,26 @@ void DxClusterDialog::flushSpotBatch()
     // on that class). Which visual end that lands on depends on the current
     // sort, so "follow the newest spot" isn't always "follow the bottom"
     // the way it is for the append-only console panes this lambda was
-    // copied from (#4889):
-    //   - unsorted, or Time descending (newest first, same as source order)
-    //     → newest is at the TOP.
-    //   - Time ascending → newest is at the BOTTOM.
-    //   - sorted by any other column → newest lands wherever it lands;
-    //     don't auto-scroll and disturb where the user put the viewport.
-    const int sortCol = m_proxyModel->sortColumn();
-    const Qt::SortOrder sortOrder = m_proxyModel->sortOrder();
-    const bool newestAtTop = sortCol < 0
-        || (sortCol == SpotTableModel::ColTime && sortOrder == Qt::DescendingOrder);
-    const bool newestAtBottom = sortCol == SpotTableModel::ColTime
-        && sortOrder == Qt::AscendingOrder;
-
+    // copied from (#4889) — see decideSpotAutoScrollTarget() for the
+    // four-branch decision, pulled out as a pure function so it's testable
+    // without this dialog's dependency graph.
     auto* sb = m_spotTable->verticalScrollBar();
-    bool follow = false;
-    if (newestAtTop) {
-        follow = sb->value() <= 2;
-    } else if (newestAtBottom) {
-        follow = sb->value() >= sb->maximum() - 2;
-    }
+    const SpotAutoScrollTarget target = decideSpotAutoScrollTarget(
+        m_proxyModel->sortColumn(), m_proxyModel->sortOrder(),
+        SpotTableModel::ColTime, sb->value(), sb->maximum());
 
     m_spotModel->addSpots(m_spotBatch);
     m_spotBatch.clear();
 
-    if (!follow) {
-        return;
-    }
-    if (newestAtTop) {
+    switch (target) {
+    case SpotAutoScrollTarget::Top:
         m_spotTable->scrollToTop();
-    } else if (newestAtBottom) {
+        break;
+    case SpotAutoScrollTarget::Bottom:
         m_spotTable->scrollToBottom();
+        break;
+    case SpotAutoScrollTarget::None:
+        break;
     }
 }
 

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -712,8 +712,10 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
     // FreeDV log loaded in deferred loadLogFiles() (#748)
 #endif
 
-    // Scroll spot table to show newest entries
-    m_spotTable->scrollToBottom();
+    // Scroll spot table to show newest entries. The model is prepend-based
+    // (newest spot is always source row 0), and the table opens unsorted, so
+    // newest-first is the top, not the bottom (#4889).
+    m_spotTable->scrollToTop();
 
     // Disable autoDefault on all buttons so Enter in command inputs
     // only fires returnPressed, not random button clicks (#459)
@@ -818,7 +820,9 @@ void DxClusterDialog::loadLogFiles(const QString& clusterLog, const QString& rbn
     if (!allSpots.isEmpty())
         m_spotModel->addSpots(allSpots);
 
-    m_spotTable->scrollToBottom();
+    // Newest-first is the top, not the bottom — same reasoning as the
+    // constructor's initial scroll (#4889).
+    m_spotTable->scrollToTop();
 }
 
 void DxClusterDialog::buildClusterTab(QTabWidget* tabs)
@@ -3333,17 +3337,43 @@ void DxClusterDialog::flushSpotBatch()
     }
     if (m_spotBatch.isEmpty()) return;
 
-    auto isAtBottom = [](QAbstractScrollArea* w) {
-        auto* sb = w->verticalScrollBar();
-        return sb->value() >= sb->maximum() - 2;
-    };
-    bool follow = isAtBottom(m_spotTable);
+    // The source model is prepend-based (SpotTableModel::addSpot(s) inserts
+    // at row 0, so the newest spot is always source row 0 — see the comment
+    // on that class). Which visual end that lands on depends on the current
+    // sort, so "follow the newest spot" isn't always "follow the bottom"
+    // the way it is for the append-only console panes this lambda was
+    // copied from (#4889):
+    //   - unsorted, or Time descending (newest first, same as source order)
+    //     → newest is at the TOP.
+    //   - Time ascending → newest is at the BOTTOM.
+    //   - sorted by any other column → newest lands wherever it lands;
+    //     don't auto-scroll and disturb where the user put the viewport.
+    const int sortCol = m_proxyModel->sortColumn();
+    const Qt::SortOrder sortOrder = m_proxyModel->sortOrder();
+    const bool newestAtTop = sortCol < 0
+        || (sortCol == SpotTableModel::ColTime && sortOrder == Qt::DescendingOrder);
+    const bool newestAtBottom = sortCol == SpotTableModel::ColTime
+        && sortOrder == Qt::AscendingOrder;
+
+    auto* sb = m_spotTable->verticalScrollBar();
+    bool follow = false;
+    if (newestAtTop) {
+        follow = sb->value() <= 2;
+    } else if (newestAtBottom) {
+        follow = sb->value() >= sb->maximum() - 2;
+    }
 
     m_spotModel->addSpots(m_spotBatch);
     m_spotBatch.clear();
 
-    if (follow)
+    if (!follow) {
+        return;
+    }
+    if (newestAtTop) {
+        m_spotTable->scrollToTop();
+    } else if (newestAtBottom) {
         m_spotTable->scrollToBottom();
+    }
 }
 
 void DxClusterDialog::updateStatus()

--- a/src/gui/SpotAutoScroll.h
+++ b/src/gui/SpotAutoScroll.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <Qt>
+
+namespace AetherSDR {
+
+// Which end of the spot table view (if either) DxClusterDialog::flushSpotBatch()
+// should scroll to after inserting new spots.
+enum class SpotAutoScrollTarget { None, Top, Bottom };
+
+// Decides where the newest spot lands and whether the viewport is already
+// sitting there — pulled out of flushSpotBatch() as a pure function (#4889
+// review) so this four-branch decision is unit-testable without constructing
+// DxClusterDialog, which pulls in DxClusterClient, WsjtxClient,
+// SpotCollectorClient, PotaClient, EibiClient, N1MMSpotClient, FreeDvClient,
+// RadioModel and DxccColorProvider just to build.
+//
+// `sortColumn`/`sortOrder` are the spot proxy model's current sort state;
+// `timeColumn` is SpotTableModel::ColTime, passed in rather than depended on
+// so this header stays dependency-free. `scrollValue`/`scrollMaximum` are the
+// vertical scrollbar's state taken BEFORE the insert that triggered this call
+// — "was the user already looking at the end the newest spot is about to
+// land on" is what decides whether to follow.
+//
+// The source model is prepend-based (SpotTableModel::addSpot(s) always
+// inserts at row 0), so:
+//   - sortColumn < 0 (genuinely unsorted), or Time descending (newest first,
+//     same order as the source model) → newest lands at the TOP.
+//   - Time ascending → newest lands at the BOTTOM.
+//   - sorted by any other column → newest lands wherever it lands; never
+//     auto-scroll and disturb where the user put the viewport.
+//
+// The `sortColumn < 0` branch is defensive rather than reachable today:
+// QTableView::setSortingEnabled(true) applies the header's default sort
+// indicator immediately (Qt 6: section 0, descending — the Time column,
+// descending), so the spot table is never actually in an unsorted state
+// once shown. Kept because "unsorted" is a real value the proxy's API can
+// report, and this function shouldn't assume a caller-side invariant that
+// isn't its own to enforce.
+inline SpotAutoScrollTarget decideSpotAutoScrollTarget(
+    int sortColumn, Qt::SortOrder sortOrder, int timeColumn,
+    int scrollValue, int scrollMaximum)
+{
+    const bool newestAtTop = sortColumn < 0
+        || (sortColumn == timeColumn && sortOrder == Qt::DescendingOrder);
+    const bool newestAtBottom = sortColumn == timeColumn
+        && sortOrder == Qt::AscendingOrder;
+
+    if (newestAtTop && scrollValue <= 2) {
+        return SpotAutoScrollTarget::Top;
+    }
+    if (newestAtBottom && scrollValue >= scrollMaximum - 2) {
+        return SpotAutoScrollTarget::Bottom;
+    }
+    return SpotAutoScrollTarget::None;
+}
+
+} // namespace AetherSDR

--- a/tests/spot_auto_scroll_test.cpp
+++ b/tests/spot_auto_scroll_test.cpp
@@ -1,0 +1,119 @@
+// decideSpotAutoScrollTarget() unit tests (#4889 review).
+//
+// SpotHub's flushSpotBatch() used to unconditionally follow the BOTTOM of
+// the spot table view — a lambda copied from the append-only console panes,
+// where that's correct. The spot model is prepend-based (newest spot is
+// always source row 0), so that assumption is backwards whenever
+// newest-first is on screen (unsorted, or Time descending), and it's
+// self-latching: on an empty table value==maximum==0, so "follow" starts
+// true and scrollToBottom() keeps it true forever.
+//
+// This four-branch sort-state decision is exercised here as a pure function,
+// pulled out of DxClusterDialog specifically so it doesn't need that
+// dialog's dependency graph (DxClusterClient, WsjtxClient,
+// SpotCollectorClient, PotaClient, EibiClient, N1MMSpotClient, FreeDvClient,
+// RadioModel, DxccColorProvider) just to construct.
+
+#include "gui/SpotAutoScroll.h"
+
+#include <QCoreApplication>
+
+#include <cstdio>
+
+namespace AetherSDR {
+
+static int g_failures = 0;
+static void check(bool ok, const char* what)
+{
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what); ++g_failures; }
+}
+
+// Column 0 is Time in every call site (SpotTableModel::ColTime); a
+// different value is used here to prove the function doesn't hardcode it.
+constexpr int kTimeColumn = 0;
+constexpr int kOtherColumn = 2;  // e.g. DX Call
+
+// Unsorted (sortColumn < 0) is defensive rather than reachable in the live
+// app — QTableView::setSortingEnabled(true) applies a default sort
+// indicator immediately — but the function's own contract doesn't depend
+// on that, so it's pinned here directly.
+static void testUnsortedFollowsTop()
+{
+    check(decideSpotAutoScrollTarget(-1, Qt::AscendingOrder, kTimeColumn, 0, 500)
+              == SpotAutoScrollTarget::Top,
+          "unsorted at the top follows to the top");
+    check(decideSpotAutoScrollTarget(-1, Qt::AscendingOrder, kTimeColumn, 50, 500)
+              == SpotAutoScrollTarget::None,
+          "unsorted, scrolled away from the top, does not follow");
+}
+
+// Time descending is the state #4889 reports: newest spots are prepended
+// to the top of the source order, and the empty-table self-latch
+// (value==maximum==0) must not be mistaken for "at the bottom".
+static void testTimeDescendingFollowsTop()
+{
+    check(decideSpotAutoScrollTarget(kTimeColumn, Qt::DescendingOrder, kTimeColumn, 0, 0)
+              == SpotAutoScrollTarget::Top,
+          "an empty table (value==maximum==0) follows to the top, not the bottom");
+    check(decideSpotAutoScrollTarget(kTimeColumn, Qt::DescendingOrder, kTimeColumn, 1, 800)
+              == SpotAutoScrollTarget::Top,
+          "at the top (within the 2px tolerance) follows to the top");
+    check(decideSpotAutoScrollTarget(kTimeColumn, Qt::DescendingOrder, kTimeColumn, 400, 800)
+              == SpotAutoScrollTarget::None,
+          "scrolled into the middle does not follow — this is the exact bug: "
+          "the old bottom-follow logic dragged the viewport away from here");
+    check(decideSpotAutoScrollTarget(kTimeColumn, Qt::DescendingOrder, kTimeColumn, 800, 800)
+              == SpotAutoScrollTarget::None,
+          "at the bottom (wrong end for this sort) does not follow");
+}
+
+// Time ascending puts the newest spot at the bottom — the one direction the
+// original bottom-follow logic got right by accident.
+static void testTimeAscendingFollowsBottom()
+{
+    check(decideSpotAutoScrollTarget(kTimeColumn, Qt::AscendingOrder, kTimeColumn, 800, 800)
+              == SpotAutoScrollTarget::Bottom,
+          "at the bottom follows to the bottom");
+    check(decideSpotAutoScrollTarget(kTimeColumn, Qt::AscendingOrder, kTimeColumn, 799, 800)
+              == SpotAutoScrollTarget::Bottom,
+          "within the 2px tolerance of the bottom still follows");
+    check(decideSpotAutoScrollTarget(kTimeColumn, Qt::AscendingOrder, kTimeColumn, 0, 800)
+              == SpotAutoScrollTarget::None,
+          "at the top (wrong end for this sort) does not follow");
+    check(decideSpotAutoScrollTarget(kTimeColumn, Qt::AscendingOrder, kTimeColumn, 400, 800)
+              == SpotAutoScrollTarget::None,
+          "scrolled into the middle does not follow");
+}
+
+// Sorted by a non-Time column: the newest spot can land anywhere, so the
+// only correct answer is "leave the viewport where the user put it" —
+// never auto-scroll, regardless of scroll position.
+static void testOtherColumnNeverFollows()
+{
+    check(decideSpotAutoScrollTarget(kOtherColumn, Qt::AscendingOrder, kTimeColumn, 0, 800)
+              == SpotAutoScrollTarget::None,
+          "sorted by another column, at the top, does not follow");
+    check(decideSpotAutoScrollTarget(kOtherColumn, Qt::DescendingOrder, kTimeColumn, 800, 800)
+              == SpotAutoScrollTarget::None,
+          "sorted by another column, at the bottom, does not follow");
+    check(decideSpotAutoScrollTarget(kOtherColumn, Qt::AscendingOrder, kTimeColumn, 0, 0)
+              == SpotAutoScrollTarget::None,
+          "sorted by another column on an empty table does not follow either — "
+          "the self-latch trap must not resurface through this branch");
+}
+
+}  // namespace AetherSDR
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    AetherSDR::testUnsortedFollowsTop();
+    AetherSDR::testTimeDescendingFollowsTop();
+    AetherSDR::testTimeAscendingFollowsBottom();
+    AetherSDR::testOtherColumnNeverFollows();
+
+    if (AetherSDR::g_failures == 0)
+        std::fprintf(stderr, "spot_auto_scroll_test: all checks passed\n");
+    return AetherSDR::g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Closes #4889

The spot model is prepend-based — `SpotTableModel::addSpot()`/
`addSpots()` insert at row 0, so the newest spot is always source row
0. But the auto-scroll in `flushSpotBatch()` unconditionally follows
the **bottom** of the view, a lambda copied from the append-only
console panes where that's correct — `QPlainTextEdit` really does grow
downward there. For the spot table it's inverted, and self-latching:
on an empty table `value == maximum == 0`, so `follow` starts true,
and `scrollToBottom()` keeps `value == maximum` forever. Once the 1 Hz
batch timer starts firing, the viewport pins to the *oldest* end while
the thumb walks toward the bottom — exactly the reported screenshots.

Sorting Time descending puts newest at the top (same as the unsorted
default), which is why only that direction is visibly broken — Time
ascending happens to have newest at the bottom, where the old logic
was accidentally correct.

**Fix**, all in `flushSpotBatch()`: decide which visual end holds the
newest row from the current sort before deciding whether to follow:
- Unsorted, or Time descending → newest at the **top**: follow only if
  already at the top, then `scrollToTop()`.
- Time ascending → newest at the **bottom**: unchanged bottom-follow.
- Sorted by any other column (Freq, DX Call, …) → newest lands in the
  middle; don't auto-scroll and disturb where the user put the
  viewport.

Also replaced the two unconditional `scrollToBottom()` calls at the
end of the constructor and `loadLogFiles()` with `scrollToTop()` —
SpotHub's default order is newest-first, so opening it should show the
newest spots, not the oldest.

**Not included:** anchoring on the selected row so a clicked spot
doesn't shift under the cursor mid-flush. The Freeze button is an
existing, adequate manual workaround for that today; out of scope for
this fix.

**Testing:** built `AetherSDR` clean under the `main` this landed on
(v26.8.2 + follow-ups). Live-verified against a real, fast-moving RBN
feed on the DX Spider cluster (dxspider.co.uk) already configured on
this machine: opened SpotHub's Spot List tab, sorted Time descending,
and watched the spot count climb (158 → 161) over ~8s while the
scrollbar stayed pinned at the top instead of drifting toward the
bottom — the exact bug, reproduced and confirmed fixed live rather
than only by inspection.