### PR TITLE
fix(gui): sever qApp::focusChanged before MainWindow member teardown (#4857)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2515,6 +2515,15 @@ MainWindow::MainWindow(QWidget* parent)
 MainWindow::~MainWindow()
 {
     qApp->removeEventFilter(this);
+
+    // The qApp::focusChanged lambda (MainWindow_Shortcuts.cpp) runs
+    // releaseSliderShortcutLease(), which touches m_shortcutManager and the
+    // m_sliderShortcutLease* members. Those are value members, so they are gone
+    // by the time the QWidget base destructor's deleteChildren() clears focus on
+    // a focused child and re-emits focusChanged. QObject's context auto-disconnect
+    // only fires in ~QObject, which is later still. Sever it here (#4857).
+    QObject::disconnect(qApp, &QApplication::focusChanged, this, nullptr);
+
     preparePanadapterUiForShutdown();
 
     // KiwiSDR profile clients are QObject children, but their disconnect path emits


### PR DESCRIPTION
Fixes #4857.

`m_shortcutManager` is a value member of `MainWindow`, so it is destroyed after the `~MainWindow()` body but before the `QWidget` base destructor runs `deleteChildren()`. When `deleteChildren()` reaches a focused child, that child's `clearFocus()` re-emits `QApplication::focusChanged`, which is still wired to the slider-shortcut-lease lambda. The lambda calls `releaseSliderShortcutLease()`, which unconditionally reaches `m_shortcutManager.setShortcutsEnabled(true)` and iterates the already-freed `QVector<QShortcut*>` buffer.

`QObject`'s context-based auto-disconnect does not help: it runs in `~QObject`, after `~QWidget`. Disconnecting explicitly at the top of `~MainWindow()` means the window between member teardown and `~QObject` is never entered. Targeted to `focusChanged` rather than a blanket `disconnect(qApp, nullptr, this, nullptr)`.

The same lambda path also touches `m_sliderShortcutLease` and `m_sliderShortcutLeaseTimer`. All three are non-static data members, so all three are destroyed before the `QWidget` base destructor runs `deleteChildren()` — which is when the lambda fires. (Among themselves `m_shortcutManager` goes first, being declared last, but that ordering is irrelevant here since the base destructor runs after all of them.) ASan does not flag the lease members because they sit inside the still-allocated `MainWindow` block rather than separate allocations, but they are the same UB and this fix covers them.

**Verification — Debug/ASan on RPi 5 (Debian trixie), A/B on otherwise identical builds:**

*Without the fix* — heap-use-after-free reproduced on quit:

```
READ  ShortcutManager::setShortcutsEnabled  ShortcutManager.cpp:697
   <- MainWindow::releaseSliderShortcutLease  MainWindow_Shortcuts.cpp:360
   <- lambda                                  MainWindow_Shortcuts.cpp:1260
   <- QApplication::focusChanged <- QWidget::clearFocus() <- ~QPushButton
   <- QObjectPrivate::deleteChildren() <- ~TitleBar <- ~MainWindow
FREED ~ShortcutManager (ShortcutManager.h:33), same ~MainWindow frame
```

*With the fix* — clean exit, no ASan diagnostics.

Release/macOS masks this either way, since the freed region is typically still intact at shutdown, so the ASan run is the meaningful check.

Built and smoke tested on: MacBook Air M2 / RPi 5 Debian trixie / Win 11 i3
