### PR TITLE
fix(icom): DFM was missing from the CI-V mode map, in both directions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,27 @@ jobs:
       - name: Test TCI protocol parsing and malformed-input rejection
         run: ctest --test-dir build -R "^tci_protocol_test$" --output-on-failure
 
+      # icom_civ_test joins the gate for the same reason as the steps above, and
+      # the DFM mode mapping is what earned it the slot. `modeFromNeutral()`
+      # handled FM and NFM but not DFM, so DFM fell through to the "no
+      # equivalent" arm and setSliceMode() re-asserted whatever the radio was
+      # already in: the mode control silently reverted, with no crash, no log
+      # line above DEBUG, and no other assertion in the tree able to see it.
+      # The reverse direction was the same shape — CivMode::Fm returned "FM"
+      # regardless of the data flag, so a radio in FM-D reported as plain FM and
+      # the next mode write cleared the flag, taking the radio out of data mode
+      # on its own.
+      #
+      # A mode map is exactly the kind of table that grows a hole when a mode is
+      # added elsewhere and forgotten here, and the failure is invisible from
+      # the UI, which shows the mode it asked for either way. That is only worth
+      # guarding if it runs before the merge.
+      #
+      # Pure string-to-enum arithmetic against a target the Build step already
+      # linked: no radio, no sockets, no event loop, milliseconds to run.
+      - name: Test Icom CI-V codec and mode mapping
+        run: ctest --test-dir build -R "^icom_civ_test$" --output-on-failure
+
       # Mirrors check-windows' "sccache stats" step, and exists for the same
       # reason: #1963 disabled the Windows compiler cache for three months
       # without anyone noticing, because nothing made the hit rate visible.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2967,7 +2967,14 @@ add_test(NAME icom_protocol_test COMMAND icom_protocol_test)
 
 add_executable(icom_civ_test
     tests/icom_civ_test.cpp
-    src/core/backends/icom/CivCodec.cpp)
+    src/core/backends/icom/CivCodec.cpp
+    # The model table joins the codec here because 1A 06 (data mode) is gated on
+    # a per-model capability flag — asserting the frame bytes without asserting
+    # WHICH models are allowed to send them would leave the gate untested.
+    # IcomMeters carries the power curves the table references; both are plain
+    # data with no Qt, so the target stays pure protocol.
+    src/core/backends/icom/IcomModels.cpp
+    src/core/backends/icom/IcomMeters.cpp)
 target_include_directories(icom_civ_test PRIVATE src)
 add_test(NAME icom_civ_test COMMAND icom_civ_test)
 

--- a/src/core/backends/icom/CivCodec.cpp
+++ b/src/core/backends/icom/CivCodec.cpp
@@ -275,6 +275,19 @@ std::optional<CivMode> modeFromNeutral(const std::string& neutral, bool& dataMod
     // microphone while the operator is running FT8.
     if (u == "DIGU") { dataModeOut = true; return CivMode::Usb; }
     if (u == "DIGL") { dataModeOut = true; return CivMode::Lsb; }
+    // DFM is FM with the same DATA flag, and it was missing here. Two costs,
+    // and the second is the expensive one:
+    //
+    //   1. DFM fell through to nullopt, so setSliceMode() took the "no
+    //      equivalent" path and re-asserted the radio's current mode. Selecting
+    //      DFM in the UI simply reverted — indistinguishable from the control
+    //      being ignored.
+    //   2. Worse, on the paths that DID reach the radio as plain FM the DATA
+    //      flag stayed clear, so transmit audio came from the MICROPHONE rather
+    //      than the WLAN modulator — exactly the failure the DIGU/DIGL comment
+    //      above describes, but for packet instead of FT8. A 2 m AX.25 frame
+    //      keyed the radio and put room noise on the air.
+    if (u == "DFM")  { dataModeOut = true; return CivMode::Fm; }
     if (u == "RTTY") return CivMode::Rtty;
 
     // DSB, SAM and DRM have no IC-705 equivalent. Returning nullopt rather than
@@ -291,7 +304,12 @@ std::string modeToNeutral(CivMode mode, bool dataMode)
     case CivMode::Am:   return "AM";
     case CivMode::Cw:   return "CWU";
     case CivMode::CwR:  return "CWL";
-    case CivMode::Fm:   return "FM";
+    // Symmetric with Lsb/Usb above: the DATA flag is what distinguishes FM-D
+    // from FM, and returning plain "FM" for both made the round trip lossy. A
+    // radio sitting in FM-D reported as FM, so the UI showed FM, and the next
+    // mode write sent FM with the flag clear — silently taking the radio OUT of
+    // data mode and back onto the microphone.
+    case CivMode::Fm:   return dataMode ? "DFM" : "FM";
     case CivMode::Wfm:  return "WFM";
     // AetherSDR has no RTTY neutral mode. Mapping to the data mode on the
     // matching sideband is LOSSY IN NAME but correct in the two things that

--- a/src/core/backends/icom/CivCodec.cpp
+++ b/src/core/backends/icom/CivCodec.cpp
@@ -496,6 +496,40 @@ std::vector<std::uint8_t> cmdSetDataMode(std::uint8_t to, bool dataMode, int fil
     return buildFrameSub(to, cmd::kSetting, setting::kDataMode, body);
 }
 
+std::vector<std::uint8_t> cmdReadDataMode(std::uint8_t to)
+{
+    // 1A 06 with no payload asks; the radio answers 1A 06 <flag> <filter>.
+    return buildFrameSub(to, cmd::kSetting, setting::kDataMode, std::array<std::uint8_t, 0>{});
+}
+
+std::optional<DataModeReply> parseDataModeReply(const CivFrame& frame)
+{
+    // Must be 1A 06 specifically. The 1A 05 handler next door hard-rejects any
+    // sub != 0x05, which is exactly why this reply was being dropped before it
+    // reached any logic — a different subcommand needs its own decode.
+    if (frame.cmd != cmd::kSetting || !frame.hasSub || frame.sub != setting::kDataMode)
+        return std::nullopt;
+    if (frame.data.empty())
+        return std::nullopt;   // the bare query echoed back, not an answer
+
+    DataModeReply out{};
+    out.dataMode = frame.data[0] != 0x00;
+    // The guide pairs `00` with a `00` filter byte, so an OFF reply carries no
+    // meaningful slot. Report 0 rather than inventing FIL1 — the filter travels
+    // with 0x06 anyway, and a fabricated slot here would fight it.
+    if (!out.dataMode) {
+        out.filter = 0;
+        return out;
+    }
+    if (frame.data.size() < 2)
+        return std::nullopt;   // ON without a slot is malformed; do not guess
+    const int slot = frame.data[1];
+    if (slot < 1 || slot > 3)
+        return std::nullopt;
+    out.filter = slot;
+    return out;
+}
+
 std::vector<std::uint8_t> cmdSetLevel(std::uint8_t to, std::uint8_t which, int value)
 {
     const auto bcd = encodeLevel(std::clamp(value, 0, 255));

--- a/src/core/backends/icom/CivCodec.cpp
+++ b/src/core/backends/icom/CivCodec.cpp
@@ -470,6 +470,32 @@ std::vector<std::uint8_t> cmdReadMode(std::uint8_t to)
     return buildFrame(to, cmd::kReadMode);
 }
 
+std::vector<std::uint8_t> cmdSetDataMode(std::uint8_t to, bool dataMode, int filter)
+{
+    // 0x06 (set mode) carries the mode and the FILTER SLOT — it has no data-mode
+    // byte at all. The DATA flag is a SEPARATE command, and without it selecting
+    // DIGU/DIGL/DFM changed the mode while leaving the radio's modulation input
+    // alone: transmit audio kept coming from the MICROPHONE instead of the
+    // USB/WLAN modulator. `DIGU` and `USB` were byte-identical on the wire.
+    //
+    // Format, from the IC-9700 CI-V Reference Guide p.18 ("Data mode with filter
+    // width settings", command 1A 06):
+    //
+    //     byte 1   00 = Data mode OFF, 01 = Data mode ON
+    //     byte 2   01 = FIL1, 02 = FIL2, 03 = FIL3
+    //
+    // ⚠ The guide's own footnote: "When 00 is set, also set 00 to [byte 2]."
+    // So the OFF frame is 00 00 — NOT 00 followed by the current filter slot.
+    // Sending the filter alongside OFF is out of spec, and a radio is free to
+    // reject or misread it; the filter travels with 0x06 anyway, so nothing is
+    // lost by honouring this.
+    const std::uint8_t flag = dataMode ? 0x01 : 0x00;
+    const std::array<std::uint8_t, 2> body{
+        flag,
+        dataMode ? static_cast<std::uint8_t>(std::clamp(filter, 1, 3)) : std::uint8_t{0x00}};
+    return buildFrameSub(to, cmd::kSetting, setting::kDataMode, body);
+}
+
 std::vector<std::uint8_t> cmdSetLevel(std::uint8_t to, std::uint8_t which, int value)
 {
     const auto bcd = encodeLevel(std::clamp(value, 0, 255));

--- a/src/core/backends/icom/CivCodec.h
+++ b/src/core/backends/icom/CivCodec.h
@@ -385,6 +385,21 @@ enum class CivMode : std::uint8_t {
 // ⚠ Per the guide, the OFF frame is `00 00` — when the flag is 00 the filter
 // byte must be 00 too, not the current slot. cmdSetDataMode enforces that.
 [[nodiscard]] std::vector<std::uint8_t> cmdSetDataMode(std::uint8_t to, bool dataMode, int filter);
+// READ the DATA flag. Required, not optional: the flag is the ONLY thing that
+// distinguishes FM-D from FM (and DIGU from USB) on this radio, and 0x06's mode
+// reply does not carry it. Without this read the client's idea of the flag can
+// only ever come from its own last write, so an operator selecting FM-D on the
+// front panel leaves the client believing plain FM — and the next mode change
+// silently takes the radio back out of data mode. Constitution II: radio state
+// is read as truth. See parseDataModeReply().
+[[nodiscard]] std::vector<std::uint8_t> cmdReadDataMode(std::uint8_t to);
+// Decode a 1A 06 reply -> {dataMode, filter}. nullopt when the frame is not that
+// reply, or is too short to trust.
+struct DataModeReply {
+    bool dataMode;
+    int  filter;      // 1..3; 0 when the flag is off (the guide's own `00 00`)
+};
+[[nodiscard]] std::optional<DataModeReply> parseDataModeReply(const CivFrame& frame);
 [[nodiscard]] std::vector<std::uint8_t> cmdSetLevel(std::uint8_t to, std::uint8_t which, int value);
 [[nodiscard]] std::vector<std::uint8_t> cmdReadMeter(std::uint8_t to, std::uint8_t which);
 // The READ forms of 0x14 and 0x16 — same subcommand, no payload. The radio

--- a/src/core/backends/icom/CivCodec.h
+++ b/src/core/backends/icom/CivCodec.h
@@ -260,6 +260,11 @@ inline constexpr std::uint8_t kModMic     = 0x00;
 inline constexpr std::uint8_t kModUsb     = 0x01;
 inline constexpr std::uint8_t kModMicUsb  = 0x02;
 inline constexpr std::uint8_t kModWlan    = 0x03;
+
+// ⚠ NOT a 1A 05 menu item — this is the 1A SUB-COMMAND for the data-mode
+// setting, a sibling of 0x05 rather than a value within it. The items above are
+// decimal menu numbers encoded as BCD; this is a raw sub-command byte.
+inline constexpr std::uint8_t kDataMode   = 0x06;   // 1A 06 — data mode + filter
 }  // namespace setting
 
 // Read or write a 1A 05 SET-menu item. `item` is the DECIMAL menu number as
@@ -374,6 +379,12 @@ enum class CivMode : std::uint8_t {
 [[nodiscard]] std::vector<std::uint8_t> cmdReadFrequency(std::uint8_t to);
 [[nodiscard]] std::vector<std::uint8_t> cmdSetMode(std::uint8_t to, CivMode mode, int filter);
 [[nodiscard]] std::vector<std::uint8_t> cmdReadMode(std::uint8_t to);
+// 1A 06 — the DATA flag, which 0x06 (cmdSetMode) does not carry. Without this,
+// DIGU and USB are byte-identical on the wire and the radio's modulation input
+// never follows the mode: FT8 keys the rig with the MICROPHONE live.
+// ⚠ Per the guide, the OFF frame is `00 00` — when the flag is 00 the filter
+// byte must be 00 too, not the current slot. cmdSetDataMode enforces that.
+[[nodiscard]] std::vector<std::uint8_t> cmdSetDataMode(std::uint8_t to, bool dataMode, int filter);
 [[nodiscard]] std::vector<std::uint8_t> cmdSetLevel(std::uint8_t to, std::uint8_t which, int value);
 [[nodiscard]] std::vector<std::uint8_t> cmdReadMeter(std::uint8_t to, std::uint8_t which);
 // The READ forms of 0x14 and 0x16 — same subcommand, no payload. The radio

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -177,6 +177,35 @@ RadioCapabilities IcomCivBackend::capabilities() const
 
 void IcomCivBackend::publishCapabilities() { emit capabilitiesChanged(); }
 
+// Publish the radio's CURRENT mode as a neutral name, with the passband that
+// belongs to it.
+//
+// Extracted so the two inputs that can change the answer share one path: the
+// mode reply (0x06 / Transceive) and the DATA-flag reply (1A 06). The neutral
+// name is a function of BOTH — FM vs DFM, USB vs DIGU — so a flag-only change
+// must republish even though m_mode did not move. Before this was shared, only
+// the mode reply published, and a front-panel FM-D never reached the UI.
+void IcomCivBackend::publishModeFromRadio()
+{
+    const QString neutral = QString::fromStdString(modeToNeutral(m_mode, m_dataMode));
+    if (neutral.isEmpty())
+        return;   // D-STAR: a waveform, not a demodulator setting
+    SliceDelta s;
+    s.mode = neutral;
+    // The passband travels WITH the mode, in the same delta, because the
+    // radio will never send one. Applied after the mode by SliceModel's own
+    // ordering, which is what stops a narrow CW window surviving into DIGU.
+    const auto [low, high] =
+        passbandForModeAndFilter(currentLadderMode().toStdString(), m_filter);
+    s.filterLow  = low;
+    s.filterHigh = high;
+    emit sliceChanged(sliceId(), s);
+    // The filter LADDER changes with the mode, so the buttons have to be
+    // rebuilt from the new one. Change-gated inside the models, so the
+    // repeat this produces on an unchanged mode costs nothing.
+    publishCapabilities();
+}
+
 void IcomCivBackend::publishScopeDbmRange()
 {
     // kUnknown has hasScope=false, so this is a quiet no-op on a backend whose
@@ -361,6 +390,18 @@ void IcomCivBackend::onSessionConnected(const QString& deviceName)
                                       setting::kDataOffModInput));
     m_session->sendCiv(cmdReadSetting(m_session->civAddress(),
                                       setting::kDataModInput));
+
+    // ASK FOR THE DATA FLAG, because 0x06's mode reply does not carry it and
+    // m_dataMode would otherwise be seeded from nothing but our own last write.
+    // That asymmetry is the bug: m_mode and m_filter are adopted from the radio
+    // (including unsolicited Transceive frames when the operator turns the front
+    // panel knob), so publishing modeToNeutral(m_mode, m_dataMode) mixes a
+    // radio-sourced value with a client-only one. An operator who selects FM-D
+    // on the radio then sees plain FM in the UI — and the next mode write takes
+    // the radio back out of data mode. Constitution II: read radio state as
+    // truth. Same "the reading half was missing" defect as the levels below.
+    if (m_model && m_model->hasDataModeCommand)
+        m_session->sendCiv(cmdReadDataMode(m_session->civAddress()));
 
     // ADOPT THE RADIO'S OWN LEVELS. Constitution II/III says an Icom is
     // authoritative over its operating state and the client must never push a
@@ -720,23 +761,7 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
         // changing the filter on the radio's own front panel.
         if (frame.data.size() >= 2 && frame.data[1] >= 1 && frame.data[1] <= 3)
             m_filter = frame.data[1];
-        const QString neutral = QString::fromStdString(modeToNeutral(m_mode, m_dataMode));
-        if (neutral.isEmpty())
-            return;   // D-STAR: a waveform, not a demodulator setting
-        SliceDelta s;
-        s.mode = neutral;
-        // The passband travels WITH the mode, in the same delta, because the
-        // radio will never send one. Applied after the mode by SliceModel's own
-        // ordering, which is what stops a narrow CW window surviving into DIGU.
-        const auto [low, high] =
-            passbandForModeAndFilter(currentLadderMode().toStdString(), m_filter);
-        s.filterLow  = low;
-        s.filterHigh = high;
-        emit sliceChanged(sliceId(), s);
-        // The filter LADDER changes with the mode, so the buttons have to be
-        // rebuilt from the new one. Change-gated inside the models, so the
-        // repeat this produces on an unchanged mode costs nothing.
-        publishCapabilities();
+        publishModeFromRadio();
         return;
     }
 
@@ -939,6 +964,29 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
     }
 
     case cmd::kSetting: {
+        // 1A 06 — the DATA flag. Handled BEFORE the 1A 05 gate below, which
+        // rejects every other subcommand and was silently dropping this reply.
+        //
+        // This is what makes m_dataMode radio-authoritative rather than a echo
+        // of our own last write. It arrives both as the answer to the connect
+        // query and unsolicited via Transceive when the operator changes the
+        // mode on the front panel, so turning the knob to plain FM now clears
+        // the flag here instead of leaving it stale and publishing DFM for a
+        // mode the radio is not in.
+        if (frame.hasSub && frame.sub == setting::kDataMode) {
+            const auto reply = parseDataModeReply(frame);
+            if (!reply)
+                return;
+            const bool changed = (m_dataMode != reply->dataMode);
+            m_dataMode = reply->dataMode;
+            // Republish the mode: the neutral name depends on this flag, so a
+            // flag-only change (FM -> FM-D on the front panel) alters what the
+            // rest of the app should be showing even though m_mode did not move.
+            if (changed)
+                publishModeFromRadio();
+            return;
+        }
+
         // 1A 05 <item hi> <item lo> <value>
         if (!frame.hasSub || frame.sub != 0x05 || frame.data.size() < 3)
             return;

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -762,6 +762,24 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
         if (frame.data.size() >= 2 && frame.data[1] >= 1 && frame.data[1] <= 3)
             m_filter = frame.data[1];
         publishModeFromRadio();
+
+        // RE-ASK FOR THE DATA FLAG. The radio pushes a mode frame when the
+        // operator changes mode OR presses DATA, but it NEVER volunteers 1A 06
+        // — measured on an IC-9700 (2026-08-12): across a whole session the
+        // only 1A 06 frame was the answer to our own connect-time query, while
+        // mode frames arrived both on connect and on a front-panel DATA press.
+        //
+        // Without this re-query m_dataMode is radio-authoritative exactly once,
+        // at connect, and stale for the rest of the session: clearing DATA on
+        // the front panel left AetherSDR publishing DFM for a radio sitting in
+        // plain FM. That is the misreport #4930's review identified, reproduced
+        // live before this line existed.
+        //
+        // The reply lands in the kSetting case below and republishes the mode
+        // if the flag actually moved, so a mode change with no flag change
+        // costs one frame and emits nothing.
+        if (m_model && m_model->hasDataModeCommand && m_session)
+            m_session->sendCiv(cmdReadDataMode(m_session->civAddress()));
         return;
     }
 

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -1300,7 +1300,24 @@ void IcomCivBackend::setSliceMode(int, const QString& mode)
     // every mode change jumped to the widest filter, so an operator working a
     // narrow CW filter lost it the moment they visited another mode and came
     // back.
-    sendUserCommand(cmdSetMode(m_session ? m_session->civAddress() : 0xA4, *civ, m_filter));
+    const std::uint8_t addr = m_session ? m_session->civAddress() : 0xA4;
+    sendUserCommand(cmdSetMode(addr, *civ, m_filter));
+
+    // THE DATA FLAG IS A SEPARATE COMMAND. 0x06 above carries {mode, filter}
+    // and has nowhere to put it, so until this was added `m_dataMode` was
+    // computed, stored, and never sent: DIGU and USB went out as identical
+    // frames and the radio kept transmitting from whichever modulation input it
+    // was already on. The radio ACKs `fb` either way, and our own read-back
+    // reports the mode we just set, so every software surface agreed with itself
+    // — it took watching the rig's front panel to see the mode not follow.
+    //
+    // UNCONDITIONAL on models that take it, not just when `data` is true: the
+    // flag is a radio-side toggle that persists, so leaving a data mode has to
+    // clear it explicitly. Sending only the ON edge would strand the radio in
+    // data mode on the next move to plain USB — the mirror of the bug being
+    // fixed, and the one an operator would notice second.
+    if (m_model && m_model->hasDataModeCommand)
+        sendUserCommand(cmdSetDataMode(addr, data, m_filter));
 
     // PUBLISH THE PASSBAND NOW, from the mode we just commanded.
     //

--- a/src/core/backends/icom/IcomCivBackend.h
+++ b/src/core/backends/icom/IcomCivBackend.h
@@ -144,6 +144,9 @@ private slots:
 
 private:
     void publishCapabilities();
+    // Publish the radio's current mode + passband. Shared by the mode reply and
+    // the DATA-flag reply, because the neutral name depends on both.
+    void publishModeFromRadio();
     // Publish the scope's dBm axis, derived from the SAME ScopeCalibration that
     // toDbm() decodes with. Call whenever anything it depends on changes — at
     // connect, and on every reference-level change.

--- a/src/core/backends/icom/IcomModels.cpp
+++ b/src/core/backends/icom/IcomModels.cpp
@@ -50,6 +50,13 @@ constexpr std::array<IcomModel, 7> kModels{{
         // this model — worth recording precisely because it could not be
         // assumed. The IC-7610 row below is the counter-example: 689 points and
         // a 0..200 range.
+        //
+        // `hasDataModeCommand` is TRUE here and nowhere else: 1A 06 is read from
+        // THIS model's own guide (p.18, "Data mode with filter width settings")
+        // and the resulting frames were checked on the radio at 10.0.0.7. The
+        // IC-705 row above stays false despite being `verified` — that flag
+        // covers the scope/tuning numbers, and its guide is not in the tree to
+        // confirm this sub-command against.
         0xA2, "IC-9700", 2, 2,
         /*hasNetwork*/ true, /*hasWifi*/ false,
         /*hasScope*/ true, 475, 160, 11,
@@ -57,6 +64,7 @@ constexpr std::array<IcomModel, 7> kModels{{
         true, 100.0,
         144'000'000ULL, 1'300'000'000ULL,
         /*verified*/ false,
+        /*hasDataModeCommand*/ true,
     },
     {
         0x98, "IC-7610", 2, 1,

--- a/src/core/backends/icom/IcomModels.h
+++ b/src/core/backends/icom/IcomModels.h
@@ -64,6 +64,21 @@ struct IcomModel {
     // should decline to advertise capabilities it cannot stand behind.
     bool verified = false;
 
+    // Accepts `1A 06` (data mode + filter width). Command 0x06 carries the mode
+    // and the filter slot but NOT the DATA flag, so without this a data mode is
+    // byte-identical to its plain counterpart on the wire and the radio keeps
+    // transmitting from whatever modulation input it was already on.
+    //
+    // Defaults to FALSE and is opt-in per model, for the same reason `verified`
+    // exists: the 1A sub-command map is model-specific, and an unsupported
+    // sub-command is a write to an unknown setting, not a harmless no-op. Turn
+    // it on only with that model's own CI-V guide in hand.
+    //
+    // ⚠ NEW FIELDS GO HERE, at the END. kModels uses positional initialisers,
+    // so inserting a member above `verified` silently shifts every row's value
+    // into the wrong field.
+    bool hasDataModeCommand = false;
+
     [[nodiscard]] bool isKnown() const noexcept { return civAddress != 0; }
 };
 

--- a/tests/icom_civ_test.cpp
+++ b/tests/icom_civ_test.cpp
@@ -185,6 +185,14 @@ static void testModes()
     // what routes audio to the WLAN modulator instead of the microphone.
     check(modeFromNeutral("DIGU", data) == CivMode::Usb && data, "DIGU is USB + data");
     check(modeFromNeutral("DIGL", data) == CivMode::Lsb && data, "DIGL is LSB + data");
+    // DFM is FM + DATA, and it was missing entirely. Selecting DFM fell through
+    // to the "no equivalent" path, so setSliceMode() re-asserted the radio's
+    // current mode and the control appeared to do nothing. The expensive half
+    // was the DATA flag: without it the radio transmits from the MICROPHONE
+    // rather than the WLAN modulator, so a 2 m AX.25 frame keyed the rig and
+    // put room noise on the air. Found on an IC-9700, 2026-08-09.
+    check(modeFromNeutral("DFM", data) == CivMode::Fm && data, "DFM is FM + data");
+    check(modeFromNeutral("FM", data) == CivMode::Fm && !data, "plain FM has no data flag");
     check(modeFromNeutral("CW", data) == CivMode::Cw, "bare CW maps, not just CWU");
     check(modeFromNeutral("CWL", data) == CivMode::CwR, "CWL is CW-reverse");
     // No IC-705 equivalent: refuse rather than silently substituting USB.
@@ -193,6 +201,12 @@ static void testModes()
 
     check(modeToNeutral(CivMode::Usb, false) == "USB", "reverse USB");
     check(modeToNeutral(CivMode::Usb, true) == "DIGU", "reverse DIGU");
+    // The round trip has to survive too. Returning plain "FM" for a radio in
+    // FM-D made the UI show FM, and the next mode write then sent FM with the
+    // flag CLEAR — silently taking the radio out of data mode and back onto the
+    // microphone without the operator touching anything.
+    check(modeToNeutral(CivMode::Fm, false) == "FM", "reverse FM");
+    check(modeToNeutral(CivMode::Fm, true) == "DFM", "reverse DFM keeps the data flag");
     check(modeToNeutral(CivMode::Dv, false).empty(), "D-STAR has no neutral mode");
 
     // THE LADDER IS PER MODE. FIL1 is 3.0 kHz in SSB, 1.2 kHz in CW, 9 kHz in

--- a/tests/icom_civ_test.cpp
+++ b/tests/icom_civ_test.cpp
@@ -321,6 +321,56 @@ static void testCommands()
                    {0xFE, 0xFE, 0xA4, 0xE0, 0x1A, 0x06, 0x00, 0x00, 0xFD}),
           "data mode OFF is 00 00, not 00 plus the filter slot");
 
+    // ── READING the flag back. Without this the client can only ever know what
+    // it last wrote, so a front-panel FM-D is invisible and the next mode write
+    // cancels it. See parseDataModeReply().
+    check(bytesAre(cmdReadDataMode(kIc705),
+                   {0xFE, 0xFE, 0xA4, 0xE0, 0x1A, 0x06, 0xFD}),
+          "the data-mode QUERY is a bare 1A 06 with no payload");
+
+    {
+        auto on = parseFrame(std::vector<std::uint8_t>{
+            0xFE, 0xFE, 0xE0, 0xA4, 0x1A, 0x06, 0x01, 0x02, 0xFD});
+        check(on.has_value(), "a 1A 06 ON reply parses as a frame");
+        auto r = parseDataModeReply(*on);
+        check(r.has_value() && r->dataMode && r->filter == 2,
+              "1A 06 01 02 decodes as data mode ON, filter 2");
+
+        auto off = parseFrame(std::vector<std::uint8_t>{
+            0xFE, 0xFE, 0xE0, 0xA4, 0x1A, 0x06, 0x00, 0x00, 0xFD});
+        auto ro = parseDataModeReply(*off);
+        // Filter 0, NOT an invented FIL1: the guide pairs OFF with a 00 slot,
+        // and the real filter travels with 0x06. Fabricating one here would
+        // fight the mode reply.
+        check(ro.has_value() && !ro->dataMode && ro->filter == 0,
+              "1A 06 00 00 decodes as OFF with no meaningful filter slot");
+
+        // A DIFFERENT 1A subcommand must not be mistaken for this one. 1A 05 is
+        // the menu-item read living next door, and it carries three data bytes.
+        auto menu = parseFrame(std::vector<std::uint8_t>{
+            0xFE, 0xFE, 0xE0, 0xA4, 0x1A, 0x05, 0x00, 0x62, 0x01, 0xFD});
+        check(menu.has_value() && !parseDataModeReply(*menu).has_value(),
+              "a 1A 05 menu reply is NOT decoded as a data-mode reply");
+
+        // ON without a slot is malformed — refuse rather than guess a filter.
+        auto trunc = parseFrame(std::vector<std::uint8_t>{
+            0xFE, 0xFE, 0xE0, 0xA4, 0x1A, 0x06, 0x01, 0xFD});
+        check(trunc.has_value() && !parseDataModeReply(*trunc).has_value(),
+              "data mode ON with no filter byte is rejected, not guessed");
+
+        // Out-of-range slot is refused too: 0 and 4 are not FIL1..3.
+        auto bad = parseFrame(std::vector<std::uint8_t>{
+            0xFE, 0xFE, 0xE0, 0xA4, 0x1A, 0x06, 0x01, 0x04, 0xFD});
+        check(bad.has_value() && !parseDataModeReply(*bad).has_value(),
+              "a filter slot outside 1..3 is rejected");
+
+        // The bare query echoed back is not an answer.
+        auto echo = parseFrame(std::vector<std::uint8_t>{
+            0xFE, 0xFE, 0xE0, 0xA4, 0x1A, 0x06, 0xFD});
+        check(echo.has_value() && !parseDataModeReply(*echo).has_value(),
+              "an empty 1A 06 (the query itself) is not treated as a reply");
+    }
+
     // BOTH scope switches exist and both are needed — enabling only the first
     // turns the scope on the radio's screen and sends us nothing.
     check(bytesAre(cmdScopeOnOff(kIc705, true), {0xFE, 0xFE, 0xA4, 0xE0, 0x27, 0x10, 0x01, 0xFD}),

--- a/tests/icom_civ_test.cpp
+++ b/tests/icom_civ_test.cpp
@@ -22,6 +22,12 @@ static void check(bool cond, const char* what)
 }
 
 static constexpr std::uint8_t kIc705 = 0xA4;
+// The IC-9700. The 1A 06 tests below are addressed to this model deliberately:
+// it is the radio the command was read and checked against, and it is the one
+// IcomModels marks as having the command. Building those frames for the IC-705
+// made two halves of this file read as if they disagreed — testDataModeGating
+// asserts, correctly, that an IC-705 must never be sent 1A 06.
+static constexpr std::uint8_t kIc9700 = 0xA2;
 
 static bool bytesAre(const std::vector<std::uint8_t>& got,
                      std::initializer_list<std::uint8_t> want)
@@ -302,42 +308,49 @@ static void testCommands()
     // is the property an operator depends on (asking for a data mode must reach
     // the wire differently), and it stays meaningful if the frame layout later
     // changes.
-    check(cmdSetMode(kIc705, CivMode::Usb, 1) == cmdSetMode(kIc705, CivMode::Usb, 1),
-          "cmdSetMode is deterministic");
-    check(cmdSetDataMode(kIc705, true, 1) != cmdSetDataMode(kIc705, false, 1),
+    //
+    // A `cmdSetMode(...) == cmdSetMode(...)` check stood here and was removed on
+    // review: comparing a pure function's output to itself cannot fail for any
+    // implementation, correct or not, so it pinned nothing. The property it was
+    // reaching for — that 0x06 alone cannot distinguish a data mode from its
+    // plain counterpart — is not assertable until the codec exposes a
+    // mode-plus-data pair, so the honest move is to leave it unasserted rather
+    // than to keep an assertion that only looks like one.
+    check(cmdSetDataMode(kIc9700, true, 1) != cmdSetDataMode(kIc9700, false, 1),
           "a data mode must not be byte-identical to its plain counterpart");
 
-    // 1A 06, per the IC-9700 CI-V Reference Guide p.18.
-    check(bytesAre(cmdSetDataMode(kIc705, true, 1),
-                   {0xFE, 0xFE, 0xA4, 0xE0, 0x1A, 0x06, 0x01, 0x01, 0xFD}),
+    // 1A 06, per the IC-9700 CI-V Reference Guide p.18 — and addressed to the
+    // IC-9700 (0xA2), the model the command was read and checked against.
+    check(bytesAre(cmdSetDataMode(kIc9700, true, 1),
+                   {0xFE, 0xFE, 0xA2, 0xE0, 0x1A, 0x06, 0x01, 0x01, 0xFD}),
           "data mode ON with FIL1 is 1A 06 01 01");
-    check(bytesAre(cmdSetDataMode(kIc705, true, 2),
-                   {0xFE, 0xFE, 0xA4, 0xE0, 0x1A, 0x06, 0x01, 0x02, 0xFD}),
+    check(bytesAre(cmdSetDataMode(kIc9700, true, 2),
+                   {0xFE, 0xFE, 0xA2, 0xE0, 0x1A, 0x06, 0x01, 0x02, 0xFD}),
           "data mode ON carries the filter slot");
     // ⚠ The guide's footnote: "When 00 is set, also set 00 to [the filter
     // byte]." So OFF is `00 00` — NOT 00 followed by the current slot. Passing
     // filter 3 here proves the OFF path ignores it rather than echoing it.
-    check(bytesAre(cmdSetDataMode(kIc705, false, 3),
-                   {0xFE, 0xFE, 0xA4, 0xE0, 0x1A, 0x06, 0x00, 0x00, 0xFD}),
+    check(bytesAre(cmdSetDataMode(kIc9700, false, 3),
+                   {0xFE, 0xFE, 0xA2, 0xE0, 0x1A, 0x06, 0x00, 0x00, 0xFD}),
           "data mode OFF is 00 00, not 00 plus the filter slot");
 
     // ── READING the flag back. Without this the client can only ever know what
     // it last wrote, so a front-panel FM-D is invisible and the next mode write
     // cancels it. See parseDataModeReply().
-    check(bytesAre(cmdReadDataMode(kIc705),
-                   {0xFE, 0xFE, 0xA4, 0xE0, 0x1A, 0x06, 0xFD}),
+    check(bytesAre(cmdReadDataMode(kIc9700),
+                   {0xFE, 0xFE, 0xA2, 0xE0, 0x1A, 0x06, 0xFD}),
           "the data-mode QUERY is a bare 1A 06 with no payload");
 
     {
         auto on = parseFrame(std::vector<std::uint8_t>{
-            0xFE, 0xFE, 0xE0, 0xA4, 0x1A, 0x06, 0x01, 0x02, 0xFD});
+            0xFE, 0xFE, 0xE0, 0xA2, 0x1A, 0x06, 0x01, 0x02, 0xFD});
         check(on.has_value(), "a 1A 06 ON reply parses as a frame");
         auto r = parseDataModeReply(*on);
         check(r.has_value() && r->dataMode && r->filter == 2,
               "1A 06 01 02 decodes as data mode ON, filter 2");
 
         auto off = parseFrame(std::vector<std::uint8_t>{
-            0xFE, 0xFE, 0xE0, 0xA4, 0x1A, 0x06, 0x00, 0x00, 0xFD});
+            0xFE, 0xFE, 0xE0, 0xA2, 0x1A, 0x06, 0x00, 0x00, 0xFD});
         auto ro = parseDataModeReply(*off);
         // Filter 0, NOT an invented FIL1: the guide pairs OFF with a 00 slot,
         // and the real filter travels with 0x06. Fabricating one here would

--- a/tests/icom_civ_test.cpp
+++ b/tests/icom_civ_test.cpp
@@ -5,6 +5,7 @@
 // Pure protocol: no sockets, no Qt, no hardware.
 
 #include "core/backends/icom/CivCodec.h"
+#include "core/backends/icom/IcomModels.h"
 
 #include <cstdio>
 #include <vector>
@@ -291,6 +292,35 @@ static void testCommands()
                    {0xFE, 0xFE, 0xA4, 0xE0, 0x14, 0x0A, 0x02, 0x55, 0xFD}),
           "RF power 100% is 14 0A 0255");
 
+    // THE DATA FLAG IS NOT IN 0x06. This is the assertion whose absence let the
+    // defect ship: 0x06 carries {mode, filter} only, so a data mode and its
+    // plain counterpart produce the SAME frame. Measured on a real IC-9700 —
+    // DIGU and USB both went out as `06 01 01` and the radio ACKed both, so no
+    // software surface disagreed with any other.
+    //
+    // Assert the inequality directly rather than just the bytes of each: this
+    // is the property an operator depends on (asking for a data mode must reach
+    // the wire differently), and it stays meaningful if the frame layout later
+    // changes.
+    check(cmdSetMode(kIc705, CivMode::Usb, 1) == cmdSetMode(kIc705, CivMode::Usb, 1),
+          "cmdSetMode is deterministic");
+    check(cmdSetDataMode(kIc705, true, 1) != cmdSetDataMode(kIc705, false, 1),
+          "a data mode must not be byte-identical to its plain counterpart");
+
+    // 1A 06, per the IC-9700 CI-V Reference Guide p.18.
+    check(bytesAre(cmdSetDataMode(kIc705, true, 1),
+                   {0xFE, 0xFE, 0xA4, 0xE0, 0x1A, 0x06, 0x01, 0x01, 0xFD}),
+          "data mode ON with FIL1 is 1A 06 01 01");
+    check(bytesAre(cmdSetDataMode(kIc705, true, 2),
+                   {0xFE, 0xFE, 0xA4, 0xE0, 0x1A, 0x06, 0x01, 0x02, 0xFD}),
+          "data mode ON carries the filter slot");
+    // ⚠ The guide's footnote: "When 00 is set, also set 00 to [the filter
+    // byte]." So OFF is `00 00` — NOT 00 followed by the current slot. Passing
+    // filter 3 here proves the OFF path ignores it rather than echoing it.
+    check(bytesAre(cmdSetDataMode(kIc705, false, 3),
+                   {0xFE, 0xFE, 0xA4, 0xE0, 0x1A, 0x06, 0x00, 0x00, 0xFD}),
+          "data mode OFF is 00 00, not 00 plus the filter slot");
+
     // BOTH scope switches exist and both are needed — enabling only the first
     // turns the scope on the radio's screen and sends us nothing.
     check(bytesAre(cmdScopeOnOff(kIc705, true), {0xFE, 0xFE, 0xA4, 0xE0, 0x27, 0x10, 0x01, 0xFD}),
@@ -330,6 +360,39 @@ static void testCommands()
           "out-of-range reference clamps to +20.0 rather than wrapping");
 }
 
+// 1A 06 is opt-in per model, because the 1A sub-command map is model-specific
+// and an unsupported sub-command is a write to an unknown setting, not a
+// harmless no-op. Pin BOTH halves of that: the model we read the guide for is
+// enabled, and the ones we did not are not.
+static void testDataModeGating()
+{
+    const auto* ic9700 = modelForCivAddress(0xA2);
+    check(ic9700 != nullptr, "IC-9700 is in the model table");
+    check(ic9700 && ic9700->hasDataModeCommand,
+          "IC-9700 takes 1A 06 — its guide p.18 documents it and the frames were checked on the radio");
+
+    // The IC-705 is `verified` for scope/tuning, which is NOT the same claim.
+    // Its guide is not in the tree, so 1A 06 stays off: being confident about
+    // one part of a model's command table is not evidence about another.
+    const auto* ic705 = modelForCivAddress(0xA4);
+    check(ic705 != nullptr, "IC-705 is in the model table");
+    check(ic705 && !ic705->hasDataModeCommand,
+          "IC-705 does NOT advertise 1A 06 — verified scope geometry is not evidence about sub-commands");
+
+    // An unknown radio must never be sent a speculative 1A write.
+    check(!unknownModel().hasDataModeCommand,
+          "the unknown-radio fallback does not send 1A 06");
+
+    // Nothing else in the table has been checked against its own guide yet, so
+    // this is currently the ONLY model with the flag. If a future model turns it
+    // on, this count changes deliberately — with that model's guide read.
+    int enabled = 0;
+    for (const auto& m : knownModels())
+        if (m.hasDataModeCommand)
+            ++enabled;
+    check(enabled == 1, "exactly one model advertises 1A 06 today");
+}
+
 int main()
 {
     testFraming();
@@ -337,6 +400,7 @@ int main()
     testReassembler();
     testModes();
     testCommands();
+    testDataModeGating();
 
     if (g_failures == 0)
         std::printf("icom_civ_test: all checks passed\n");


### PR DESCRIPTION
Fixes #4931. Supersedes #4884.

**Body rewritten after @ten9876's review** — the previous one said "Part 1 only" while the diff carried a CI-V write command. That was blocker 1, and it was fair: this PR is reviewed on what it actually contains, described below.

## What this is now

The DFM mode map, the `1A 06` DATA-flag write, **and the read side that makes the flag radio-authoritative**. The read side is new since the review, and it exists because blocker 2 was correct.

## Blocker 2 — confirmed, then fixed

`m_dataMode` had exactly one assignment in the whole backend, from our own request, while `m_mode` and `m_filter` are adopted from the radio. Publishing `modeToNeutral(m_mode, m_dataMode)` therefore mixed a radio-sourced value with a client-only one.

I reproduced the consequence on a live IC-9700 before fixing it: **radio in plain FM, AetherSDR publishing DFM.** Exactly the misreport you predicted from reading the code.

The fix makes the flag radio-authoritative:

- `cmdReadDataMode()` / `parseDataModeReply()` — query and decode. `cmdReadSetting()` hardcodes `0x05` and cannot express `1A 06`.
- The `kSetting` handler takes `1A 06` **before** the `sub != 0x05` gate that was silently dropping it.
- Queried at connect, gated on `hasDataModeCommand`.
- `publishModeFromRadio()` extracted so the mode reply and the flag reply share one path — the neutral name depends on **both**, so a flag-only change must republish even though `m_mode` did not move.

## The bench finding that the connect query alone did not cover

Measured on the radio, and this is the part no amount of code reading would have produced:

```
every 1a 06 in a whole session:   1   (the answer to our own connect query)
every mode frame in the same:     2   (connect poll + a front-panel DATA press)
```

**CI-V Transceive is on** — the radio pushes `cmd 00` (frequency) and `cmd 01` (mode) unprompted. It does **not** push `1A 06`. Pressing DATA on the front panel emits a mode frame and nothing else, so the flag went stale for the rest of the session.

So the last commit re-asks on every mode frame. The reply republishes only if the flag actually moved, so a mode change with no flag change costs one frame and emits nothing.

## Verified on hardware — both directions

IC-9700 at 146.985 MHz, from the CI-V frame log:

```
RX <- 04 05 01      connect: mode FM
RX <- 1a 06 00 00   connect: flag OFF        -> AetherSDR publishes FM
RX <- 01 05 01      front-panel DATA press
RX <- 1a 06 01 01   re-query: flag ON        -> AetherSDR publishes DFM
RX <- 01 05 01      pressed again
RX <- 1a 06 00 00   re-query: flag OFF       -> AetherSDR publishes FM
RX <- 01 05 01      and again
RX <- 1a 06 01 01   re-query: flag ON        -> AetherSDR publishes DFM
```

Write direction still works: selecting the mode in AetherSDR sends `06 05 01` then `1a 06 <flag> <filter>`, and the radio follows. Final state checked against the physical panel — radio showing **FM-D**, AetherSDR reporting **DFM**.

Unit tests pin the query bytes, the ON/OFF decodes and four refusal cases (including a `1A 05` menu reply not being mistaken for this one). Mutation-checked: making the OFF reply invent filter 1 fails the OFF assertion and exits 1.

## Known limitation, stated rather than hidden

`m_dataMode` is a **single scalar**, and an IC-9700 has two receivers with two VFOs each. The backend does not model per-VFO state at all today (`IcomCivBackend.cpp` mentions "vfo" once), so this is correct for the active receiver and not yet correct where two VFOs differ. Pre-existing shape, not introduced here, but the flag work makes it worth naming.

## Depends on

The CI-V frame logging in the companion PR is what made this diagnosable — before it, "the query was never sent", "the radio never answered" and "we dropped the reply" were indistinguishable. Not a build dependency; they can merge in either order.
