### PR TITLE
fix(gui): gate the Copy Assist indicator on the active slice, not the TX slice

### DIFF
--- a/docs/asr-copy-assist.md
+++ b/docs/asr-copy-assist.md
@@ -29,6 +29,11 @@ Design + decision record: RFC **#4333** (accepted). Engine: **whisper.cpp**
   voice mode** — clicking to a CW slice while Copy Assist is running closes the
   panel and stops transcription, even if the voice slice you were transcribing is
   still audible. Re-select the voice slice and re-open to resume.
+- A slice that momentarily **goes away** is not treated as leaving voice mode: a
+  band-stack recall drops and re-creates the slice, and disconnecting clears them
+  all, so an open panel is left alone in those states rather than torn down. The
+  `ASR` toggle stays clickable whenever the panel is open, so you can always
+  close it by hand even while it is dimmed.
 - The status line shows a **`Queue: N s`** backlog — seconds of received audio not
   yet transcribed. It stays near 0 when the engine keeps up and climbs
   (amber→red) when it can't (e.g. whisper on a Raspberry Pi), so you can see ASR

--- a/docs/asr-copy-assist.md
+++ b/docs/asr-copy-assist.md
@@ -28,12 +28,17 @@ Design + decision record: RFC **#4333** (accepted). Engine: **whisper.cpp**
   ASR off. "Leaving voice mode" includes **selecting a slice that is not in a
   voice mode** — clicking to a CW slice while Copy Assist is running closes the
   panel and stops transcription, even if the voice slice you were transcribing is
-  still audible. Re-select the voice slice and re-open to resume.
-- A slice that momentarily **goes away** is not treated as leaving voice mode: a
-  band-stack recall drops and re-creates the slice, and disconnecting clears them
-  all, so an open panel is left alone in those states rather than torn down. The
-  `ASR` toggle stays clickable whenever the panel is open, so you can always
-  close it by hand even while it is dimmed.
+  still audible. To resume, re-select the voice slice, re-open the panel and
+  tick **Enable** again — closing the panel unticks it.
+- A **band-stack recall is not** leaving voice mode, and neither is a disconnect.
+  A recall drops the slice and re-creates it on the new band a moment later, and
+  a disconnect clears every slice, so an open panel is left alone in both states
+  rather than torn down — transcription survives a band change. That holds
+  whether or not another slice survives the recall: with a second slice on the
+  pan the client re-selects it while the radio rebuilds, and a surviving CW or
+  DIGx slice does not count as you leaving voice mode either.
+- Whenever the panel is open the `ASR` toggle is **lit and clickable**, in every
+  one of those states, so you can always close it by hand.
 - The status line shows a **`Queue: N s`** backlog — seconds of received audio not
   yet transcribed. It stays near 0 when the engine keeps up and climbs
   (amber→red) when it can't (e.g. whisper on a Raspberry Pi), so you can see ASR

--- a/docs/asr-copy-assist.md
+++ b/docs/asr-copy-assist.md
@@ -13,13 +13,22 @@ Design + decision record: RFC **#4333** (accepted). Engine: **whisper.cpp**
   which shows/hides the panel. The toggle is the inverse of `CWX`:
   **enabled in voice modes** (USB/LSB/AM/SAM/FM/NFM/DFM), **dimmed in CW and
   DIGx/RTTY**.
+- That mode test reads the **slice you have selected**, not the transmit slice —
+  Copy Assist is a receive-side feature, so it is available with **TX off** and
+  on a receive-only setup (#4825). Its two neighbours in the status bar behave
+  the opposite way on purpose: `CWX` and `DVK` are transmit keyers and follow the
+  TX slice, so the three indicators can legitimately disagree — with a CW
+  transmit slice and a USB slice selected, `CWX` and `ASR` are both live.
 - Tick **Enable**. On first enable the selected model is downloaded (see below),
   verified, and loaded; a loading indicator shows progress. Then transcription
   of the audio you're hearing streams into the panel.
 - Text is **color-coded by recognition confidence**: green (high) → yellow →
   orange → red (low), mirroring the CW decoder.
 - Hiding the panel (the status-bar **ASR** toggle / leaving voice mode) turns
-  ASR off.
+  ASR off. "Leaving voice mode" includes **selecting a slice that is not in a
+  voice mode** — clicking to a CW slice while Copy Assist is running closes the
+  panel and stops transcription, even if the voice slice you were transcribing is
+  still audible. Re-select the voice slice and re-open to resume.
 - The status line shows a **`Queue: N s`** backlog — seconds of received audio not
   yet transcribed. It stays near 0 when the engine keeps up and climbs
   (amber→red) when it can't (e.g. whisper on a Raspberry Pi), so you can see ASR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -9223,11 +9223,27 @@ void MainWindow::updateKeyerAvailability()
         m_asrIndicator->setEnabled(asrIsVoice);
         const bool asrVisible =
             m_copyAssistApplet && m_copyAssistApplet->isCopyAssistVisible();
-        // Same shape as the keyer auto-hides: only a slice that EXISTS and is in
-        // the wrong mode closes an open panel, so a transient no-active-slice
-        // window (slice teardown, band-stack rebuild) can't yank one the user
-        // has to re-open by hand (#4173).
-        if (asrSlice && !asrIsVoice && asrVisible) {
+        // NOT the keyers' shape, deliberately. They require their slice to EXIST
+        // before auto-hiding, so a transient no-TX-slice window during a TX
+        // handoff can't yank an open panel (#4173) — a handoff is frequent and
+        // normal. ASR closes on a null slice too, because "no slice at all" is
+        // not a handoff, and the alternative is a trap: the indicator would be
+        // setEnabled(false) yet styled kActive by the branch below, and a
+        // disabled indicator swallows its own clicks (MainWindow_Shortcuts.cpp)
+        // while the panel carries no close button of its own — leaving an open
+        // Copy Assist the operator cannot dismiss. Closing here keeps the two
+        // states that exist coherent: panel open ⇒ voice mode ⇒ indicator live
+        // and clickable.
+        //
+        // The null-slice case is ordinary, not exotic: DISCONNECT reaches it on
+        // every session. RadioModel clears m_slices without emitting
+        // sliceRemoved, so onSliceRemoved() never runs — but capabilitiesChanged
+        // fires on the disconnect edge, applyCapabilitiesToUi() calls this
+        // function, and activeSlice() then answers nullptr. Before this branch
+        // covered null, disconnecting with Copy Assist open left the panel
+        // stranded on screen. (AetherSDR's own ✕ handlers refuse to remove a
+        // last slice, so disconnect and a foreign client are the ways in.)
+        if (!asrIsVoice && asrVisible) {
             m_copyAssistApplet->setCopyAssistVisible(false);
             setIndicatorStyle(m_asrIndicator, kDisabled);
         } else if (asrVisible) {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -9220,17 +9220,6 @@ void MainWindow::updateKeyerAvailability()
     SliceModel* asrSlice = activeSlice();
     const bool asrIsVoice = asrSlice && isVoiceMode(asrSlice->mode());
     if (m_asrIndicator) {
-        const bool asrVisible =
-            m_copyAssistApplet && m_copyAssistApplet->isCopyAssistVisible();
-        // Enabled when the mode allows OPENING it, or whenever the panel is
-        // already open so it can always be CLOSED. The second half exists
-        // because a disabled QLabel swallows its own clicks
-        // (MainWindow_Shortcuts.cpp) and CopyAssistPanel has no close button of
-        // its own — without it, any state that leaves the panel open while the
-        // gate says no strands a panel the operator cannot dismiss. Fixing that
-        // here, in the panel's own affordance, is what lets the auto-hide below
-        // keep the conservative shape (PR #4932 review).
-        m_asrIndicator->setEnabled(asrIsVoice || asrVisible);
         // The keyers' shape, and for the keyers' reason: only a slice that
         // EXISTS and is in the wrong mode closes an open panel. A slice that is
         // momentarily ABSENT is not a mode change, and on this radio it is
@@ -9245,15 +9234,61 @@ void MainWindow::updateKeyerAvailability()
         // m_slices and capabilitiesChanged drives applyCapabilitiesToUi ->
         // this function). Leaving the panel up there is the right outcome too —
         // the last transcript stays readable, and the enabled-while-visible
-        // rule above means it can be closed by hand.
-        if (asrSlice && !asrIsVoice && asrVisible) {
+        // rule below means it can be closed by hand.
+        //
+        // A non-null slice is NOT enough on its own, because a band recall does
+        // not have to empty slices() to reach here. With a second slice on the
+        // pan, onSliceRemoved() re-selects it (slices.first(), TopologyFallback)
+        // instead of taking the empty branch — so recalling a band on the
+        // transcribed slice hands the gate a surviving CW/DIGx slice, and a
+        // slice-exists guard alone sees a live slice in the wrong mode and
+        // tears the panel down. Same #4158 rebuild, one slice further along.
+        // m_bandRecallSelection is the window that already answers "this pan is
+        // mid-rebuild, treat radio-driven selection as synchronization-only"
+        // (BandRecallSelectionGuard.h, armed on the band write and refreshed by
+        // onSliceRemoved()), which is exactly the question being asked here.
+        //
+        // The decision itself lives in VoiceModeGate.h so a test can pin it —
+        // this function is not reachable from the gating-test target — and the
+        // reason each clause is there is stated with it (#4932 review).
+        const bool bandRecallInFlight =
+            asrSlice
+            && m_bandRecallSelection.isActive(asrSlice->panId(),
+                                              QDateTime::currentMSecsSinceEpoch());
+        if (shouldAutoHideCopyAssist(
+                m_copyAssistApplet && m_copyAssistApplet->isCopyAssistVisible(),
+                asrSlice != nullptr,
+                asrSlice ? asrSlice->mode() : QString(),
+                bandRecallInFlight)) {
             m_copyAssistApplet->setCopyAssistVisible(false);
-            setIndicatorStyle(m_asrIndicator, kDisabled);
-        } else if (asrVisible) {
-            setIndicatorStyle(m_asrIndicator, kActive);
-        } else {
-            setIndicatorStyle(m_asrIndicator, asrIsVoice ? kAvail : kDisabled);
         }
+
+        // Read visibility AFTER the auto-hide, not before. The enabled state
+        // and the cursor both key off it, and computing them from the pre-hide
+        // value left the indicator enabled with a pointing hand over a panel
+        // that had just been closed: the click passed the isEnabled() guard in
+        // MainWindow_Shortcuts.cpp, showCopyAssist() re-opened the panel, and
+        // this function closed it again in the same handler — an affordance
+        // that promised something and did nothing, until some unrelated
+        // refresh happened along (PR #4932 review).
+        const bool asrVisible =
+            m_copyAssistApplet && m_copyAssistApplet->isCopyAssistVisible();
+
+        // Enabled when the mode allows OPENING it, or whenever the panel is
+        // already open so it can always be CLOSED. The second half exists
+        // because a disabled QLabel swallows its own clicks
+        // (MainWindow_Shortcuts.cpp) and CopyAssistPanel has no close button of
+        // its own — without it, any state that leaves the panel open while the
+        // gate says no strands a panel the operator cannot dismiss. Fixing that
+        // here, in the panel's own affordance, is what lets the auto-hide above
+        // keep the conservative shape (PR #4932 review).
+        m_asrIndicator->setEnabled(asrIsVoice || asrVisible);
+        // An open panel reads kActive whatever the mode says — including the
+        // band-recall and disconnect cases the auto-hide deliberately skips,
+        // where ASR is genuinely still running.
+        setIndicatorStyle(m_asrIndicator,
+                          asrVisible ? kActive
+                                     : (asrIsVoice ? kAvail : kDisabled));
         // Cursor tracks the ENABLED state, not the mode, so the hand appears on
         // exactly the clicks that do something — including the close-an-open-
         // panel case where the mode gate says no.

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -9220,30 +9220,33 @@ void MainWindow::updateKeyerAvailability()
     SliceModel* asrSlice = activeSlice();
     const bool asrIsVoice = asrSlice && isVoiceMode(asrSlice->mode());
     if (m_asrIndicator) {
-        m_asrIndicator->setEnabled(asrIsVoice);
         const bool asrVisible =
             m_copyAssistApplet && m_copyAssistApplet->isCopyAssistVisible();
-        // NOT the keyers' shape, deliberately. They require their slice to EXIST
-        // before auto-hiding, so a transient no-TX-slice window during a TX
-        // handoff can't yank an open panel (#4173) — a handoff is frequent and
-        // normal. ASR closes on a null slice too, because "no slice at all" is
-        // not a handoff, and the alternative is a trap: the indicator would be
-        // setEnabled(false) yet styled kActive by the branch below, and a
-        // disabled indicator swallows its own clicks (MainWindow_Shortcuts.cpp)
-        // while the panel carries no close button of its own — leaving an open
-        // Copy Assist the operator cannot dismiss. Closing here keeps the two
-        // states that exist coherent: panel open ⇒ voice mode ⇒ indicator live
-        // and clickable.
+        // Enabled when the mode allows OPENING it, or whenever the panel is
+        // already open so it can always be CLOSED. The second half exists
+        // because a disabled QLabel swallows its own clicks
+        // (MainWindow_Shortcuts.cpp) and CopyAssistPanel has no close button of
+        // its own — without it, any state that leaves the panel open while the
+        // gate says no strands a panel the operator cannot dismiss. Fixing that
+        // here, in the panel's own affordance, is what lets the auto-hide below
+        // keep the conservative shape (PR #4932 review).
+        m_asrIndicator->setEnabled(asrIsVoice || asrVisible);
+        // The keyers' shape, and for the keyers' reason: only a slice that
+        // EXISTS and is in the wrong mode closes an open panel. A slice that is
+        // momentarily ABSENT is not a mode change, and on this radio it is
+        // routinely not even a removal — with band_persistence a FLEX band
+        // recall DROPS the slice and RE-CREATES it under the same id a moment
+        // later (KiwiRebindTracker.h, #4158). On the ordinary single-slice
+        // setup that empties slices(), so a null-slice auto-hide would stop
+        // transcription on every band change and never restore it: this
+        // function only ever hides, showing is user-driven.
         //
-        // The null-slice case is ordinary, not exotic: DISCONNECT reaches it on
-        // every session. RadioModel clears m_slices without emitting
-        // sliceRemoved, so onSliceRemoved() never runs — but capabilitiesChanged
-        // fires on the disconnect edge, applyCapabilitiesToUi() calls this
-        // function, and activeSlice() then answers nullptr. Before this branch
-        // covered null, disconnecting with Copy Assist open left the panel
-        // stranded on screen. (AetherSDR's own ✕ handlers refuse to remove a
-        // last slice, so disconnect and a foreign client are the ways in.)
-        if (!asrIsVoice && asrVisible) {
+        // Disconnect also lands here with a null slice (RadioModel clears
+        // m_slices and capabilitiesChanged drives applyCapabilitiesToUi ->
+        // this function). Leaving the panel up there is the right outcome too —
+        // the last transcript stays readable, and the enabled-while-visible
+        // rule above means it can be closed by hand.
+        if (asrSlice && !asrIsVoice && asrVisible) {
             m_copyAssistApplet->setCopyAssistVisible(false);
             setIndicatorStyle(m_asrIndicator, kDisabled);
         } else if (asrVisible) {
@@ -9251,8 +9254,12 @@ void MainWindow::updateKeyerAvailability()
         } else {
             setIndicatorStyle(m_asrIndicator, asrIsVoice ? kAvail : kDisabled);
         }
-        m_asrIndicator->setCursor(asrIsVoice ? Qt::PointingHandCursor
-                                             : Qt::ArrowCursor);
+        // Cursor tracks the ENABLED state, not the mode, so the hand appears on
+        // exactly the clicks that do something — including the close-an-open-
+        // panel case where the mode gate says no.
+        m_asrIndicator->setCursor((asrIsVoice || asrVisible)
+                                      ? Qt::PointingHandCursor
+                                      : Qt::ArrowCursor);
     }
 #endif
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -9188,12 +9188,21 @@ void MainWindow::updateKeyerAvailability()
 
 #ifdef AETHER_ASR_ENABLED
     // ASR (Copy Assist): the inverse of CWX on mode — available in voice modes
-    // only, dimmed in CW and DIGx/RTTY — but NOT on slice. Copy Assist is a
-    // receive-side decode of the audio the operator is listening to, and it is
-    // already bound to the ACTIVE slice: setActiveSliceInternal() rebinds
-    // m_copyAssistFreqConn to that slice's frequencyChanged and calls onRetune()
-    // on a switch. The CW decoder, this feature's CW-mode counterpart, reads the
-    // same slice (refreshCwDecodeState()).
+    // only, dimmed in CW and DIGx/RTTY — but NOT on slice. It follows the slice
+    // the operator has SELECTED, which is also the slice the rest of Copy Assist
+    // tracks: setActiveSliceInternal() rebinds m_copyAssistFreqConn to that
+    // slice's frequencyChanged and calls onRetune() on a switch. The CW decoder,
+    // this feature's CW-mode counterpart, gates on the same slice
+    // (refreshCwDecodeState()).
+    //
+    // The selected slice is a PROXY, not the audio source, and the difference
+    // matters to anyone changing this: the tap subscribes to
+    // AudioEngine::receivePresentationPostDspAudioReady and AsrTapPolicy locks
+    // onto a RECEIVER (the Flex, the applet Kiwi, an external Kiwi) on a
+    // first-block-wins rule with a 2 s release window — never onto a slice. On a
+    // Flex that stream is every audible slice already mixed together. So this
+    // gate answers "is the operator listening to something transcribable",
+    // which is a heuristic; it does not and cannot name the audio being decoded.
     //
     // It was gated on the TX slice for a visually consistent indicator row, and
     // that cost the feature entirely with TX off: no slice carries isTxSlice(),
@@ -9201,6 +9210,13 @@ void MainWindow::updateKeyerAvailability()
     // could not open Copy Assist at all (#4825). Row consistency is the weaker
     // constraint — CWX and DVK key the TX slice and genuinely belong to it, so
     // the three indicators may now disagree, which is correct.
+    //
+    // NOTE the auto-hide below now has teeth it did not have on the TX gate:
+    // hiding the panel calls setAsrEnabled(false) (PanadapterApplet), which
+    // disables the tap and drops the receiver lock. Selecting a CW slice
+    // therefore STOPS a running transcription, where before only a TX-slice mode
+    // change could. Deliberate — the indicator must track the selected slice to
+    // be worth anything — but it is the sharp edge of this change.
     SliceModel* asrSlice = activeSlice();
     const bool asrIsVoice = asrSlice && isVoiceMode(asrSlice->mode());
     if (m_asrIndicator) {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -112,6 +112,7 @@
 #include "FlexControlDialog.h"
 #include "CwxPanel.h"
 #include "DvkAvailabilityGate.h"
+#include "VoiceModeGate.h"
 #include "DvkPanel.h"
 #include "core/DvkWavTransfer.h"
 #include "AmpApplet.h"
@@ -7581,7 +7582,10 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
     routeRttyDecoderOutput();
     refreshRttyDecodeState();
 
-    // Update CWX/DVK indicator availability (follows the TX slice, #4173)
+    // Update CWX/DVK indicator availability (follows the TX slice, #4173) and
+    // the ASR indicator's (follows the ACTIVE slice, #4825) — this call is what
+    // covers an active-slice SWITCH for ASR; the mode-change edge on a non-TX
+    // active slice is handled in the modeChanged wiring.
     updateKeyerAvailability();
 
     // Detect band from frequency
@@ -9120,10 +9124,10 @@ void MainWindow::updateKeyerAvailability()
 
     const bool txIsCw  = hasCwKeyer
                          && (txMode == "CW" || txMode == "CWL");
-    const bool txIsSsb = (txMode == "USB" || txMode == "LSB"
-                          || txMode == "AM" || txMode == "SAM"
-                          || txMode == "FM" || txMode == "NFM"
-                          || txMode == "DFM");
+    // Voice-mode test through the shared predicate: the ASR block below asks
+    // the same question of a DIFFERENT slice, and one list keeps the two from
+    // drifting on which modes count (VoiceModeGate.h).
+    const bool txIsSsb = isVoiceMode(txMode);
 
     // DVK carries a second, mode-independent gate: the radio's own DVK
     // entitlement. Unlike the mode gate it survives every mode change, so it is
@@ -9134,10 +9138,10 @@ void MainWindow::updateKeyerAvailability()
         txIsSsb,
         m_radioModel.licenseFeatureSeen(kDvkLicenseFeature),
         m_radioModel.licenseFeatureEnabled(kDvkLicenseFeature));
-    // hasVoiceKeyer is ANDed in HERE rather than into txIsSsb, because txIsSsb
-    // also drives the ASR indicator further down and Copy Assist is host-side —
-    // folding a voice-keyer capability into the shared mode test would take a
-    // working transcription feature down with the keyer.
+    // hasVoiceKeyer is ANDed in HERE rather than into the mode test, because
+    // isVoiceMode() is shared with the ASR indicator below and Copy Assist is
+    // host-side — folding a radio-side voice-keyer capability into the shared
+    // predicate would take a working transcription feature down with the keyer.
     const bool dvkAvailable = hasVoiceKeyer
                               && (dvkBlocker == DvkIndicatorBlocker::None);
     const bool dvkUnlicensed = (dvkBlocker == DvkIndicatorBlocker::NotLicensed);
@@ -9183,22 +9187,40 @@ void MainWindow::updateKeyerAvailability()
     m_dvkIndicator->setToolTip(dvkIndicatorTooltip(dvkBlocker));
 
 #ifdef AETHER_ASR_ENABLED
-    // ASR (Copy Assist): the inverse of CWX — available in voice modes only,
-    // dimmed/disabled in CW and DIGx/RTTY. A receive-side decode, but gated on
-    // the same slice's mode as the other indicators for a consistent row.
+    // ASR (Copy Assist): the inverse of CWX on mode — available in voice modes
+    // only, dimmed in CW and DIGx/RTTY — but NOT on slice. Copy Assist is a
+    // receive-side decode of the audio the operator is listening to, and it is
+    // already bound to the ACTIVE slice: setActiveSliceInternal() rebinds
+    // m_copyAssistFreqConn to that slice's frequencyChanged and calls onRetune()
+    // on a switch. The CW decoder, this feature's CW-mode counterpart, reads the
+    // same slice (refreshCwDecodeState()).
+    //
+    // It was gated on the TX slice for a visually consistent indicator row, and
+    // that cost the feature entirely with TX off: no slice carries isTxSlice(),
+    // so txMode is empty and a receive-only or antenna-disconnected operator
+    // could not open Copy Assist at all (#4825). Row consistency is the weaker
+    // constraint — CWX and DVK key the TX slice and genuinely belong to it, so
+    // the three indicators may now disagree, which is correct.
+    SliceModel* asrSlice = activeSlice();
+    const bool asrIsVoice = asrSlice && isVoiceMode(asrSlice->mode());
     if (m_asrIndicator) {
-        m_asrIndicator->setEnabled(txIsSsb);
+        m_asrIndicator->setEnabled(asrIsVoice);
         const bool asrVisible =
             m_copyAssistApplet && m_copyAssistApplet->isCopyAssistVisible();
-        if (txSlice && !txIsSsb && asrVisible) {
+        // Same shape as the keyer auto-hides: only a slice that EXISTS and is in
+        // the wrong mode closes an open panel, so a transient no-active-slice
+        // window (slice teardown, band-stack rebuild) can't yank one the user
+        // has to re-open by hand (#4173).
+        if (asrSlice && !asrIsVoice && asrVisible) {
             m_copyAssistApplet->setCopyAssistVisible(false);
             setIndicatorStyle(m_asrIndicator, kDisabled);
         } else if (asrVisible) {
             setIndicatorStyle(m_asrIndicator, kActive);
         } else {
-            setIndicatorStyle(m_asrIndicator, txIsSsb ? kAvail : kDisabled);
+            setIndicatorStyle(m_asrIndicator, asrIsVoice ? kAvail : kDisabled);
         }
-        m_asrIndicator->setCursor(txIsSsb ? Qt::PointingHandCursor : Qt::ArrowCursor);
+        m_asrIndicator->setCursor(asrIsVoice ? Qt::PointingHandCursor
+                                             : Qt::ArrowCursor);
     }
 #endif
 }

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -2070,7 +2070,13 @@ void MainWindow::onSliceAdded(SliceModel* s)
         // those two slices changes mode — narrowing this to the TX slice would
         // leave the ASR indicator stale after a CW→USB change on a non-TX
         // active slice, with no other edge to correct it.
-        if (s->isTxSlice() || s->sliceId() == m_activeSliceId)
+        //
+        // Through activeSlice(), not an m_activeSliceId comparison: the gate
+        // itself calls activeSlice(), which falls back to the first isActive()
+        // slice when the cached id's slice is not active. Asking the same
+        // question the gate asks keeps the trigger and the gate from diverging
+        // inside that fallback window (PR #4932 review).
+        if (s->isTxSlice() || activeSlice() == s)
             updateKeyerAvailability();
 #ifdef HAVE_RADE
         if (mode.startsWith("FDV"))
@@ -2427,7 +2433,10 @@ void MainWindow::onSliceRemoved(int id)
             // it. The re-select branch above reaches updateKeyerAvailability()
             // through setActiveSliceInternal(); this branch has no such call,
             // and without one the row keeps whatever state the departed slice
-            // left it in — a live ASR indicator with nothing to decode (#4825).
+            // left it in — a live-looking ASR indicator with nothing to decode,
+            // over an open Copy Assist panel that the (now disabled) indicator
+            // could no longer dismiss. The ASR gate closes the panel on a null
+            // slice for exactly that reason; this call is what runs it (#4825).
             updateKeyerAvailability();
         }
     }

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -2064,9 +2064,13 @@ void MainWindow::onSliceAdded(SliceModel* s)
         // restrictive audible slice controls the global client DSP state.
         updateAetherDspModePolicy();
 
-        // CWX/DVK availability and their F1-F12 shortcuts follow the TX slice,
-        // so re-evaluate only when the TX slice changes mode (#4173).
-        if (s->isTxSlice())
+        // CWX/DVK availability and their F1-F12 shortcuts follow the TX slice
+        // (#4173); the ASR (Copy Assist) indicator follows the ACTIVE slice,
+        // because it decodes received audio (#4825). Re-evaluate when either of
+        // those two slices changes mode — narrowing this to the TX slice would
+        // leave the ASR indicator stale after a CW→USB change on a non-TX
+        // active slice, with no other edge to correct it.
+        if (s->isTxSlice() || s->sliceId() == m_activeSliceId)
             updateKeyerAvailability();
 #ifdef HAVE_RADE
         if (mode.startsWith("FDV"))
@@ -2419,6 +2423,12 @@ void MainWindow::onSliceRemoved(int id)
             if (m_ax25HfPacketDecodeDialog)
                 m_ax25HfPacketDecodeDialog->setAttachedSlice(nullptr);
             refreshMiniPanFollow();   // no active slice → blank the mini-pan readout/passband
+            // The last slice is gone, so every indicator's slice is gone with
+            // it. The re-select branch above reaches updateKeyerAvailability()
+            // through setActiveSliceInternal(); this branch has no such call,
+            // and without one the row keeps whatever state the departed slice
+            // left it in — a live ASR indicator with nothing to decode (#4825).
+            updateKeyerAvailability();
         }
     }
 

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -2433,10 +2433,14 @@ void MainWindow::onSliceRemoved(int id)
             // it. The re-select branch above reaches updateKeyerAvailability()
             // through setActiveSliceInternal(); this branch has no such call,
             // and without one the row keeps whatever state the departed slice
-            // left it in — a live-looking ASR indicator with nothing to decode,
-            // over an open Copy Assist panel that the (now disabled) indicator
-            // could no longer dismiss. The ASR gate closes the panel on a null
-            // slice for exactly that reason; this call is what runs it (#4825).
+            // left it in.
+            //
+            // Refresh only — deliberately NOT a teardown. The gate leaves an
+            // open Copy Assist panel alone on a null slice, because this branch
+            // is on the band-recall path: with band_persistence the radio drops
+            // and re-creates the slice under the same id (KiwiRebindTracker.h,
+            // #4158), and a single-slice setup passes through here on every band
+            // change (#4932 review).
             updateKeyerAvailability();
         }
     }

--- a/src/gui/VoiceModeGate.h
+++ b/src/gui/VoiceModeGate.h
@@ -31,4 +31,38 @@ inline bool isVoiceMode(const QString& mode)
         || mode == QLatin1String("DFM");
 }
 
+// Whether an ALREADY-OPEN Copy Assist panel should be torn down, as
+// MainWindow::updateKeyerAvailability() decides it. Pure, so the decision can
+// be pinned by a test — updateKeyerAvailability() itself cannot be, since
+// MainWindow is not linkable from the gating-test target.
+//
+// The asymmetry that shapes every clause below: updateKeyerAvailability() only
+// ever HIDES — showing is user-driven — and hiding calls setAsrEnabled(false),
+// which drops the audio tap and unticks Enable. So a hide the operator did not
+// ask for costs them a running transcription and cannot be undone by any later
+// refresh, while declining to hide costs a click. Every uncertain case
+// therefore resolves to false.
+//
+//  * `panelVisible` — nothing to tear down otherwise.
+//  * `haveActiveSlice` — an ABSENT slice is not a mode change. A single-slice
+//    band recall empties slices() (band_persistence drops and re-creates the
+//    slice under the same id: KiwiRebindTracker.h, #4158), and a disconnect
+//    clears them all.
+//  * `activeSliceMode` — the actual gate: the operator selected a slice that
+//    carries nothing transcribable.
+//  * `bandRecallInFlight` — the same recall reaching this code one slice
+//    further along. With a second slice on the pan, onSliceRemoved() re-selects
+//    it rather than taking the empty-slices branch, so the gate is handed a
+//    live CW/DIGx slice mid-rebuild and `haveActiveSlice` no longer protects
+//    it. BandRecallSelectionGuard already owns "this pan is rebuilding, treat
+//    radio-driven selection as synchronization-only" (#4932 review).
+inline bool shouldAutoHideCopyAssist(bool panelVisible,
+                                     bool haveActiveSlice,
+                                     const QString& activeSliceMode,
+                                     bool bandRecallInFlight)
+{
+    return panelVisible && haveActiveSlice && !bandRecallInFlight
+        && !isVoiceMode(activeSliceMode);
+}
+
 }  // namespace AetherSDR

--- a/src/gui/VoiceModeGate.h
+++ b/src/gui/VoiceModeGate.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <QLatin1String>
+#include <QString>
+
+namespace AetherSDR {
+
+// The modes that carry human-intelligible voice audio, as the status-bar
+// indicators gate on them: the SSB pair, AM/SAM and the FM family. CW, RTTY,
+// the DIGx pair and the FreeDV/RADE modes are out — nothing a voice keyer
+// should play into, and nothing an acoustic speech model can transcribe.
+//
+// One list, two callers reading DIFFERENT slices:
+//
+//  * the DVK indicator asks about the TRANSMIT slice's mode — the keyer keys
+//    that slice, so its availability follows it (#4173);
+//  * the Copy Assist (ASR) indicator asks about the ACTIVE slice's mode — a
+//    receive-side decode of the audio the operator is listening to, exactly as
+//    the CW decoder's own gate reads activeSlice() in refreshCwDecodeState()
+//    (#4825).
+//
+// Which slice is the caller's decision; WHICH MODES COUNT is stated once here
+// so the two answers cannot drift apart. An empty mode (no such slice) is not
+// a voice mode, which is what keeps both gates closed when their slice is
+// absent.
+inline bool isVoiceMode(const QString& mode)
+{
+    return mode == QLatin1String("USB") || mode == QLatin1String("LSB")
+        || mode == QLatin1String("AM")  || mode == QLatin1String("SAM")
+        || mode == QLatin1String("FM")  || mode == QLatin1String("NFM")
+        || mode == QLatin1String("DFM");
+}
+
+}  // namespace AetherSDR

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -771,9 +771,18 @@ int main(int argc, char** argv)
     // who turns TX off (antenna disconnected, bench work) or listens receive-only
     // lost the feature outright.
     //
-    // The mode half below is the production predicate; the slice half is
-    // restated, because MainWindow is not linkable from this target (it links
-    // aethercore, not the GUI) — the same compromise the keyer helpers above make.
+    // WHAT THIS BLOCK DOES NOT PIN, stated plainly because the assertions read
+    // like they cover the fix and they do not: every check here calls
+    // isVoiceMode(), and the PRE-FIX code used the same mode list. This block
+    // would pass, green, against the bug. It pins the mode list — which is worth
+    // pinning, it is now shared by two indicators — while the slice SOURCE, the
+    // actual subject of #4825, is out of reach: MainWindow is not linkable from
+    // this target (it links aethercore, not the GUI), so nothing here can ask
+    // updateKeyerAvailability() which slice it read. Same compromise the keyer
+    // helpers above make, and the same one the file header warns about. The fix
+    // itself was verified on hardware (a FLEX-6500 with TX off, and a two-slice
+    // TX=CW / active=USB pair); if that ever needs to become a test, the tri-state
+    // decision has to move out of MainWindow into VoiceModeGate.h first.
     {
         // TX off: no slice carries isTxSlice(), so txSlice() is null and
         // updateKeyerAvailability() reads an empty TX mode.

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -100,6 +100,7 @@
 #include "models/RadioModel.h"
 #include "models/ModelCapabilities.h"
 #include "gui/DvkAvailabilityGate.h"
+#include "gui/VoiceModeGate.h"
 #include "core/RadioDiscovery.h"
 #include "core/backends/flex/FlexBackend.h"
 #include "core/backends/sim/SimBackend.h"
@@ -758,6 +759,73 @@ int main(int argc, char** argv)
         check(!disconnected.hasManualNotch(),
               "disconnected: hasManualNotch() is NOT permissive — no MN button on an "
               "empty window");
+    }
+
+    // ---- ASR (Copy Assist) indicator: gated on the ACTIVE slice (#4825) ----
+    //
+    // The two status-bar keyers and the ASR indicator ask the SAME mode question
+    // (isVoiceMode) of DIFFERENT slices, and that difference is the whole fix.
+    // CWX and DVK key the TX slice, so an absent TX slice must close them. Copy
+    // Assist decodes received audio and is already bound to the ACTIVE slice, so
+    // an absent TX slice must NOT close it — it did, which is #4825: an operator
+    // who turns TX off (antenna disconnected, bench work) or listens receive-only
+    // lost the feature outright.
+    //
+    // The mode half below is the production predicate; the slice half is
+    // restated, because MainWindow is not linkable from this target (it links
+    // aethercore, not the GUI) — the same compromise the keyer helpers above make.
+    {
+        // TX off: no slice carries isTxSlice(), so txSlice() is null and
+        // updateKeyerAvailability() reads an empty TX mode.
+        const QString txModeWithTxOff;                          // txSlice() == nullptr
+        const QString activeModeUsb = QStringLiteral("USB");
+
+        check(!isVoiceMode(txModeWithTxOff),
+              "TX off: the TX-slice mode test is false — CWX/DVK close, which is "
+              "right, there is nothing to key");
+        check(dvkIndicatorBlocker(isVoiceMode(txModeWithTxOff),
+                                  /*licenseSeen=*/false, /*licenseEnabled=*/false)
+                  == DvkIndicatorBlocker::TxModeNotVoice,
+              "TX off: the DVK gate names the mode as its blocker");
+        check(isVoiceMode(activeModeUsb),
+              "TX off while listening on USB: the ACTIVE slice's mode is still a "
+              "voice mode, so the ASR indicator stays available (#4825)");
+
+        // The row may now disagree with itself, and that is the intended
+        // outcome, not a regression: the indicators answer about two slices.
+        check(isVoiceMode(activeModeUsb) != isVoiceMode(txModeWithTxOff),
+              "the ASR and DVK indicators can disagree — they read different "
+              "slices, so a consistent-looking row is not the invariant");
+
+        // Mode gate itself is UNCHANGED: voice only. ASR in CW or DIGx would
+        // have nothing intelligible to transcribe.
+        check(!isVoiceMode(QStringLiteral("CW")),
+              "active slice in CW: ASR indicator stays dimmed (nothing to transcribe)");
+        check(!isVoiceMode(QStringLiteral("CWL")),
+              "active slice in CWL: ASR indicator stays dimmed");
+        check(!isVoiceMode(QStringLiteral("DIGU")) && !isVoiceMode(QStringLiteral("DIGL")),
+              "active slice in DIGU/DIGL: ASR indicator stays dimmed");
+        check(!isVoiceMode(QStringLiteral("RTTY")),
+              "active slice in RTTY: ASR indicator stays dimmed");
+        check(!isVoiceMode(QStringLiteral("FDVU")),
+              "active slice in FreeDV: ASR indicator stays dimmed (RADAE-encoded, "
+              "not acoustic speech)");
+
+        // The whole voice family, so a later edit cannot quietly drop one.
+        for (const QString& mode : {QStringLiteral("USB"), QStringLiteral("LSB"),
+                                    QStringLiteral("AM"),  QStringLiteral("SAM"),
+                                    QStringLiteral("FM"),  QStringLiteral("NFM"),
+                                    QStringLiteral("DFM")}) {
+            check(isVoiceMode(mode),
+                  "voice family member is a voice mode for both indicators");
+        }
+
+        // No active slice at all (last slice removed): an empty mode is not a
+        // voice mode, so the indicator closes. This is what the added
+        // updateKeyerAvailability() call in onSliceRemoved()'s no-slices branch
+        // is there to APPLY — without it the gate is right and never evaluated.
+        check(!isVoiceMode(QString()),
+              "no active slice: empty mode is not a voice mode — ASR closes");
     }
 
     if (g_failures == 0)

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -829,12 +829,16 @@ int main(int argc, char** argv)
                   "voice family member is a voice mode for both indicators");
         }
 
-        // No active slice at all (last slice removed): an empty mode is not a
-        // voice mode, so the indicator closes. This is what the added
-        // updateKeyerAvailability() call in onSliceRemoved()'s no-slices branch
-        // is there to APPLY — without it the gate is right and never evaluated.
+        // No active slice at all: an empty mode is not a voice mode, so the
+        // indicator dims. It does NOT close an open panel — the auto-hide
+        // requires the slice to exist, because a band recall drops and
+        // re-creates the slice under the same id and would otherwise stop
+        // transcription on every band change (KiwiRebindTracker.h, #4158).
+        // The panel stays dismissible in that state because the indicator is
+        // enabled whenever it is visible (#4932 review).
         check(!isVoiceMode(QString()),
-              "no active slice: empty mode is not a voice mode — ASR closes");
+              "no active slice: empty mode is not a voice mode — ASR dims "
+              "(an open panel is left alone; band recall passes through here)");
     }
 
     if (g_failures == 0)

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -771,18 +771,22 @@ int main(int argc, char** argv)
     // who turns TX off (antenna disconnected, bench work) or listens receive-only
     // lost the feature outright.
     //
-    // WHAT THIS BLOCK DOES NOT PIN, stated plainly because the assertions read
-    // like they cover the fix and they do not: every check here calls
-    // isVoiceMode(), and the PRE-FIX code used the same mode list. This block
-    // would pass, green, against the bug. It pins the mode list — which is worth
-    // pinning, it is now shared by two indicators — while the slice SOURCE, the
-    // actual subject of #4825, is out of reach: MainWindow is not linkable from
-    // this target (it links aethercore, not the GUI), so nothing here can ask
-    // updateKeyerAvailability() which slice it read. Same compromise the keyer
-    // helpers above make, and the same one the file header warns about. The fix
-    // itself was verified on hardware (a FLEX-6500 with TX off, and a two-slice
-    // TX=CW / active=USB pair); if that ever needs to become a test, the tri-state
-    // decision has to move out of MainWindow into VoiceModeGate.h first.
+    // WHAT THE MODE CHECKS BELOW DO NOT PIN, stated plainly because they read
+    // like they cover the fix and they do not: every isVoiceMode() check here
+    // would pass, green, against the bug — the PRE-FIX code used the same mode
+    // list. They pin the mode list, which is worth pinning now that two
+    // indicators share it. The slice SOURCE, the actual subject of #4825, is
+    // still out of reach: MainWindow is not linkable from this target (it links
+    // aethercore, not the GUI), so nothing here can ask
+    // updateKeyerAvailability() which slice it read. That half rests on the
+    // hardware verification (a FLEX-6500 with TX off, and a two-slice TX=CW /
+    // active=USB pair).
+    //
+    // The teardown decision IS pinned, in the second block below.
+    // shouldAutoHideCopyAssist() was moved into VoiceModeGate.h for exactly the
+    // reason this comment used to give for not pinning it, so the clause that
+    // keeps a band recall from stopping a running transcription has a test that
+    // fails when it is removed.
     {
         // TX off: no slice carries isTxSlice(), so txSlice() is null and
         // updateKeyerAvailability() reads an empty TX mode.
@@ -830,15 +834,68 @@ int main(int argc, char** argv)
         }
 
         // No active slice at all: an empty mode is not a voice mode, so the
-        // indicator dims. It does NOT close an open panel — the auto-hide
-        // requires the slice to exist, because a band recall drops and
-        // re-creates the slice under the same id and would otherwise stop
-        // transcription on every band change (KiwiRebindTracker.h, #4158).
-        // The panel stays dismissible in that state because the indicator is
-        // enabled whenever it is visible (#4932 review).
+        // indicator dims. Whether that also CLOSES an open panel is a separate
+        // decision, pinned in the next block.
         check(!isVoiceMode(QString()),
-              "no active slice: empty mode is not a voice mode — ASR dims "
-              "(an open panel is left alone; band recall passes through here)");
+              "no active slice: empty mode is not a voice mode — ASR dims");
+    }
+
+    // ---- Copy Assist auto-hide: what may tear down a RUNNING transcription ----
+    //
+    // Hiding the panel calls setAsrEnabled(false) — the audio tap is dropped and
+    // Enable is unticked — and updateKeyerAvailability() only ever hides, never
+    // shows. So a hide the operator did not ask for cannot be undone by any
+    // later refresh, which is why every clause of this predicate exists to say
+    // NO. Two of them were regressions caught in review on this PR, and this
+    // block is what stops them coming back.
+    {
+        const QString usb = QStringLiteral("USB");
+        const QString cw  = QStringLiteral("CW");
+
+        // The one case that SHOULD tear down: the operator selected a live
+        // slice that carries nothing transcribable, with no rebuild in flight.
+        check(shouldAutoHideCopyAssist(/*panelVisible=*/true,
+                                       /*haveActiveSlice=*/true, cw,
+                                       /*bandRecallInFlight=*/false),
+              "operator selects a live CW slice: an open panel closes — this is "
+              "the auto-hide's whole purpose (#4825)");
+
+        // Nothing open, nothing to tear down.
+        check(!shouldAutoHideCopyAssist(false, true, cw, false),
+              "panel already closed: nothing to hide");
+
+        // A voice slice never closes it, recall or not.
+        check(!shouldAutoHideCopyAssist(true, true, usb, false),
+              "live USB slice: the panel stays open");
+
+        // #4158 / single-slice band recall, and disconnect: the slice is ABSENT.
+        // band_persistence drops the slice and re-creates it under the same id a
+        // moment later; on a single-slice setup that empties slices() and lands
+        // here. Closing would stop transcription on every band change and never
+        // restore it.
+        check(!shouldAutoHideCopyAssist(true, /*haveActiveSlice=*/false,
+                                        QString(), false),
+              "no active slice (single-slice band recall, or disconnect): the "
+              "panel is left alone — an absent slice is not a mode change");
+
+        // #4158 again, one slice further along, and the regression this PR's
+        // review caught second: with a SECOND slice on the pan, onSliceRemoved()
+        // re-selects it (slices.first()) instead of taking the empty-slices
+        // branch, so the gate is handed a live CW slice mid-rebuild and
+        // haveActiveSlice no longer protects anything. Only the recall window
+        // tells this apart from the operator clicking that CW slice themselves.
+        check(!shouldAutoHideCopyAssist(true, /*haveActiveSlice=*/true, cw,
+                                        /*bandRecallInFlight=*/true),
+              "band recall in flight with a surviving CW slice: the panel is "
+              "left alone — Copy Assist survives a band change on a multi-slice "
+              "pan too (#4932 review)");
+
+        // The guard is scoped to the recall window, not a blanket suppression:
+        // once it expires, selecting that same CW slice closes the panel again.
+        check(shouldAutoHideCopyAssist(true, true, cw, false)
+                  != shouldAutoHideCopyAssist(true, true, cw, true),
+              "the band-recall window is the ONLY thing separating those two "
+              "cases — remove it and a band change stops transcription");
     }
 
     if (g_failures == 0)


### PR DESCRIPTION
## Summary

Fixes #4825. The status-bar **ASR** (Copy Assist) indicator was greyed out whenever no
slice was flagged as the transmit slice — with TX off, or on a receive-only setup — so
an operator who disables TX for safety (antenna disconnected, bench work) could not open
Copy Assist at all. It is a receive-side transcription feature; nothing about it depends
on the transmit slice.

`updateKeyerAvailability()` derived one mode string from `txSlice()` and shared it across
all three indicators in that row. With no TX slice, `txSlice()` returns `nullptr`, the mode
string is empty, and the ASR gate closes. The ASR block now reads `activeSlice()` instead.
The mode gate itself is unchanged — voice modes only (USB/LSB/AM/SAM/FM/NFM/DFM), dimmed in
CW, DIGx, RTTY and FreeDV.

CWX and DVK are transmit keyers and keep following the TX slice (FlexLib scopes CWX to the
transmit slice — `FlexLib/CWX.cs:186-199`), so their gating is untouched.

### What changed

- **`src/gui/VoiceModeGate.h`** (new, header-only) — `isVoiceMode()`, the voice-mode list
  stated once now that two indicators ask the same question of different slices. Same
  pattern as the neighbouring `DvkAvailabilityGate.h`, so tests can link it.
- **`src/gui/MainWindow.cpp`** — the ASR block reads the active slice for its enabled state,
  auto-hide and cursor. `txIsSsb` now calls the shared predicate; DVK path unchanged.
- **`src/gui/MainWindow_Wiring.cpp`** — `modeChanged` re-evaluates on the TX slice **or** the
  active slice (previously TX-only, so a CW→USB change on a non-TX active slice had no edge
  to correct it). `onSliceRemoved()`'s no-slices-left branch now refreshes the row — it never
  did, which left stale state for CWX/DVK too.
- **`docs/asr-copy-assist.md`** — documents which slice the gate reads and the consequence
  below.

### Two consequences worth stating plainly

**The indicator row can now disagree with itself, by design.** With a CW transmit slice and a
USB slice selected, `CWX` and `ASR` are both live while `DVK` is dim. The row previously
looked consistent only because one of the three was reading the wrong slice.

**The auto-hide now stops a running transcription.** Hiding the panel calls
`setAsrEnabled(false)`, which disables the audio tap and drops the receiver lock. On the old
gate only a TX-slice mode change could reach that; now selecting a CW slice closes the panel
and stops transcription, even if the voice slice you were transcribing is still audible. This
is deliberate — an indicator that tracks the selected slice has to act on it — but it is the
sharp edge of this change and is documented in `docs/asr-copy-assist.md`.

### What the gate is, precisely

The selected slice is a **proxy for what the operator is listening to, not the audio source**.
`AsrAudioTap` subscribes to `AudioEngine::receivePresentationPostDspAudioReady`, and
`AsrTapPolicy` locks onto a *receiver* (the Flex, the applet Kiwi, an external Kiwi)
first-block-wins with a 2 s release window — never onto a slice. On a Flex that stream is
every audible slice already mixed. So this gate answers "is the operator listening to
something transcribable", which is a heuristic. It is still strictly better than the transmit
slice, which is not a proxy for a receive feature at all.

## Constitution principle honored

**Principle VIII — Evidence Over Assertion.** The behavioral claims here were verified on
hardware, and the code comments state what the gate actually knows (a proxy for the operator's
listening context) rather than the tidier claim that it names the decoded audio. The added test
block's real coverage is stated in the test file instead of being implied by its name.

**Principle XI — Fixes Are Demonstrated.** The verification above is the implementing agent's
hypothesis plus contributor testing on a 6500; the independent check is still the squash-merge
CI re-run on `main`, which this PR does not substitute for.

No protocol surface, no radio writes and no transmit path are touched; the active-slice notion
is client-owned by design (AGENTS.md: never send `slice set active=1`).

## Test plan

- [x] Local build passes — macOS (`ENABLE_ASR=ON`) on every commit; RPi 5 (Debug)
      and Windows 11 through `60308de1` (see the footer — the later review commits
      are macOS-only, both remote machines being powered down)
- [x] Behavior verified on a real radio — FLEX-6500, four cases below
- [x] Existing tests pass — `radio_capability_gating_test`, `copy_assist_panel_test`,
      `copy_assist_settings_dialog_test`
- [x] Reproduction steps documented — in #4825

**Verified on a FLEX-6500:**

1. TX off, active slice on USB → ASR enables. The reported bug.
2. Two slices, TX = the CW slice: on the USB slice both `CWX` and `ASR` are lit; selecting the
   CW slice dims ASR and closes an open Copy Assist panel.
3. Active (non-TX) slice CW → USB → ASR becomes available. Exercises the widened
   `modeChanged` trigger.
4. Keyers unregressed: `CWX` stayed live while the CW slice held TX regardless of which slice
   was selected, and went dim once the USB slice was made TX.

Also reproduced and fixed against the built-in sim, which allows no transmit at all and
therefore has no TX slice — the #4825 condition by construction.

**On the added test coverage, honestly:** every assertion in the new
`radio_capability_gating_test` block calls `isVoiceMode()`, and the pre-fix code used the same
mode list — so that block would pass green against the bug. It pins the mode list, which is
worth pinning now that two indicators share it. The slice *source* is not reachable from that
target, which links `aethercore` and not the GUI; pinning it would mean moving the tri-state
decision out of `MainWindow` into `VoiceModeGate.h` first. The fix itself rests on the hardware
verification above. This is called out in the test file rather than left for a reviewer to find.

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room
- [x] All meter UI uses `MeterSmoother` — n/a, no meter UI
- [x] Documentation updated — `docs/asr-copy-assist.md`
- [x] Security-sensitive changes reference a GHSA if applicable — n/a

---

Built and smoke tested on: MacBook Air M2 / RPi 5 Debian trixie (Debug) / Win 11 i3

Scope of that claim, precisely: all three platforms were built at `60308de1`. The
two review commits after it (`7e622a35` and this body edit) are macOS-only — the
RPi 5 and Windows 11 machines are powered down and unavailable. Those commits touch
`MainWindow.cpp` and `MainWindow_Wiring.cpp` plus comments, the test's assertion
text and the doc, with no platform-specific code, but the footer should not imply
coverage that was not run.

