### PR TITLE
fix(cw): shift the sidetone anchor forward for late key edges instead of clamping (#4890)

### DIFF
--- a/src/core/CwSidetoneGenerator.cpp
+++ b/src/core/CwSidetoneGenerator.cpp
@@ -116,6 +116,7 @@ void CwSidetoneGenerator::reset() noexcept
     m_haveAnchor = false;
     m_streamPos = 0;
     m_idleSamples = 0;
+    m_anchorSlack = 0;
     // Drop queued edges (consumer-side drain: only the tail moves).
     m_edgeTail.store(m_edgeHead.load(std::memory_order_acquire),
                      std::memory_order_release);
@@ -273,20 +274,38 @@ bool CwSidetoneGenerator::process(float* out, int frames) noexcept
             break;
         const KeyEdge e = m_edgeQueue[tail % kEdgeQueueSize];
         if (!m_haveAnchor) {
-            // First edge of a burst plays at this block's start — the
-            // same onset latency as the old block-polling gate; every
-            // later edge lands relative to it, sample-exact.
+            // First edge of a burst plays at this block's start plus the
+            // slack learned from earlier late edges — every later edge
+            // lands relative to it, sample-exact.  Zero slack reproduces
+            // the old onset latency exactly.
             m_anchorTime = e.t;
-            m_anchorPos  = blockStart;
+            m_anchorPos  = blockStart + m_anchorSlack;
             m_haveAnchor = true;
         }
-        const int64_t target = m_anchorPos +
+        int64_t target = m_anchorPos +
             std::chrono::duration_cast<std::chrono::nanoseconds>(
                 e.t - m_anchorTime).count() * m_sampleRateHz / 1'000'000'000LL;
         if (target >= blockEnd)
             break;  // future block — edges are time-ordered, stop here
-        const int off = static_cast<int>(
-            std::max<int64_t>(target, blockStart) - blockStart);
+        if (target < blockStart) {
+            // The edge's exact position is already rendered.  Clamping just
+            // this edge would quantize it to the block boundary (#4890 —
+            // under a push-model sink the render head advances at wall-clock
+            // pace, so edges lose this race about half the time, and by whole
+            // refill-sized steps after a pump stall).  Shift the whole
+            // mapping forward instead: this edge plays at the head, every
+            // later edge keeps its exact distance from THIS one, and the
+            // learned slack makes the next burst anchor far enough ahead to
+            // stop racing.  Rhythm is preserved; only onset latency grows,
+            // bounded by the slack cap.
+            const int64_t deficit = blockStart - target;
+            m_anchorPos += deficit;
+            m_anchorSlack = std::min<int64_t>(
+                m_anchorSlack + deficit,
+                static_cast<int64_t>(m_sampleRateHz) * kAnchorSlackCapMs / 1000);
+            target = blockStart;
+        }
+        const int off = static_cast<int>(target - blockStart);
         blockEdges.append({off, e.down});
         m_edgeTail.store(tail + 1, std::memory_order_release);
     }

--- a/src/core/CwSidetoneGenerator.cpp
+++ b/src/core/CwSidetoneGenerator.cpp
@@ -295,6 +295,15 @@ bool CwSidetoneGenerator::process(float* out, int frames) noexcept
             m_anchorPos  = blockStart + m_anchorSlack;
             m_haveAnchor = true;
             m_anchorWentLate = false;
+            // A fresh edge is activity: restart the idle clock.  Left
+            // running, a counter still saturated from the stall that
+            // taught the slack releases this anchor in the run-up blocks
+            // before its first edge renders (slack > one block maps the
+            // edge past blockEnd, so the clear below never fires), halving
+            // the slack once per block until it fits inside one — which
+            // silently caps carried slack at the sink's block size instead
+            // of kAnchorSlackCapMs.
+            m_idleSamples = 0;
         }
         int64_t target = m_anchorPos +
             std::chrono::duration_cast<std::chrono::nanoseconds>(

--- a/src/core/CwSidetoneGenerator.cpp
+++ b/src/core/CwSidetoneGenerator.cpp
@@ -381,6 +381,17 @@ bool CwSidetoneGenerator::process(float* out, int frames) noexcept
                 // converges within a few bursts while still costing several
                 // bursts to climb back if the stall repeats, and the floor
                 // avoids a long tail of single-sample slack.
+                // Two limits on the decay's reach: it runs only on the IDLE
+                // release of an anchor (the staleness re-anchor above frees
+                // the anchor with no decay decision either way), and
+                // kReanchorIdleMs of continuous idle is rare inside sustained
+                // sending — word gaps qualify below ~34 WPM, inter-character
+                // gaps below ~15 WPM, otherwise only the pauses between
+                // transmissions.  Under persistent sink clock drift slack
+                // cannot converge below the drift accrued per anchor
+                // lifetime: late anchors regrow what clean-anchor halvings
+                // release, and a pause-free stretch long enough to accrue the
+                // cap latches there until the next qualifying idle.
                 if (!m_anchorWentLate && m_anchorSlack > 0) {
                     m_anchorSlack /= 2;
                     if (m_anchorSlack < m_sampleRateHz / 1000)  // < 1 ms

--- a/src/core/CwSidetoneGenerator.cpp
+++ b/src/core/CwSidetoneGenerator.cpp
@@ -117,6 +117,9 @@ void CwSidetoneGenerator::reset() noexcept
     m_streamPos = 0;
     m_idleSamples = 0;
     m_anchorSlack = 0;
+    m_anchorWentLate = false;
+    m_shiftCount = 0;
+    m_staleReanchors = 0;
     // Drop queued edges (consumer-side drain: only the tail moves).
     m_edgeTail.store(m_edgeHead.load(std::memory_order_acquire),
                      std::memory_order_release);
@@ -241,15 +244,25 @@ bool CwSidetoneGenerator::process(float* out, int frames) noexcept
                    * m_sampleRateHz / 1'000'000'000LL;
         };
         // (1) The mapping itself has gone stale — wall clock has run ahead of
-        // the samples we have rendered by more than a re-anchor's worth,
-        // which only happens when process() stopped being called.  Tested
-        // one-sided on purpose: a stream position ahead of wall clock is
-        // ordinary prefill (the QAudioSink path fills a 50 ms buffer up
-        // front) and must not re-anchor.
+        // the samples we have rendered by more than a re-anchor's worth.
+        // What this measures is a stalled pump plus the carried slack: a
+        // fresh anchor is placed at blockStart + m_anchorSlack, so the
+        // mapping starts that far ahead of the head, and the cap on slack is
+        // what keeps that inside this threshold.  The per-edge forward shift
+        // does NOT accumulate here despite moving m_anchorPos — it moves the
+        // mapping onto the head, so afterwards this quantity is the wall time
+        // since that edge rather than a running total (measured: 2.4 ms peak
+        // over a 119-shift racing burst, no re-anchor).  Reaching the
+        // threshold therefore still means process() stopped being called.
+        // Tested one-sided on purpose: a stream position ahead
+        // of wall clock is ordinary prefill (the QAudioSink path fills a
+        // 50 ms buffer up front) and must not re-anchor.
         if (m_haveAnchor) {
             const int64_t expected = m_anchorPos + toSamples(nowTp - m_anchorTime);
-            if (expected - blockStart > idleLimit)
+            if (expected - blockStart > idleLimit) {
                 m_haveAnchor = false;
+                ++m_staleReanchors;
+            }
         }
         // (2) About to anchor afresh: drop edges old enough to belong to a
         // previous keying sequence rather than replaying them here.  The
@@ -281,6 +294,7 @@ bool CwSidetoneGenerator::process(float* out, int frames) noexcept
             m_anchorTime = e.t;
             m_anchorPos  = blockStart + m_anchorSlack;
             m_haveAnchor = true;
+            m_anchorWentLate = false;
         }
         int64_t target = m_anchorPos +
             std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -296,13 +310,26 @@ bool CwSidetoneGenerator::process(float* out, int frames) noexcept
             // mapping forward instead: this edge plays at the head, every
             // later edge keeps its exact distance from THIS one, and the
             // learned slack makes the next burst anchor far enough ahead to
-            // stop racing.  Rhythm is preserved; only onset latency grows,
-            // bounded by the slack cap.
+            // stop racing.  Rhythm is preserved; only onset latency grows.
+            //
+            // The shift is not capped, and deliberately so: it re-aligns the
+            // mapping ONTO the render head rather than pushing it past, so it
+            // does not accumulate against the staleness guard.  After a shift
+            // the guard's quantity is the wall time elapsed since this edge,
+            // not a running total — measured at 2.4 ms peak over a racing
+            // burst of 119 shifts, against a 250 ms threshold, with no
+            // re-anchor.  Bounding it was tried and strands the mapping behind
+            // the head, so every later edge in the anchor clamps and element
+            // durations collapse to block multiples (5.0 ms rendering as
+            // 2.8 ms) — reintroducing the defect this branch removes.
+            // Only the CARRIED slack is capped, below.
             const int64_t deficit = blockStart - target;
             m_anchorPos += deficit;
             m_anchorSlack = std::min<int64_t>(
                 m_anchorSlack + deficit,
                 static_cast<int64_t>(m_sampleRateHz) * kAnchorSlackCapMs / 1000);
+            m_anchorWentLate = true;
+            ++m_shiftCount;
             target = blockStart;
         }
         const int off = static_cast<int>(target - blockStart);
@@ -331,8 +358,21 @@ bool CwSidetoneGenerator::process(float* out, int frames) noexcept
             // exact.  Only a genuine pause releases the mapping.
             m_idleSamples += frames;
             if (m_idleSamples >=
-                static_cast<int64_t>(m_sampleRateHz) * kReanchorIdleMs / 1000)
+                static_cast<int64_t>(m_sampleRateHz) * kReanchorIdleMs / 1000) {
+                // Releasing an anchor that never ran late says the sink had
+                // headroom to spare for that whole burst, so give some back:
+                // slack has to be able to shrink or one transient stall would
+                // tax onset latency for the rest of the session.  Halving
+                // converges within a few bursts while still costing several
+                // bursts to climb back if the stall repeats, and the floor
+                // avoids a long tail of single-sample slack.
+                if (!m_anchorWentLate && m_anchorSlack > 0) {
+                    m_anchorSlack /= 2;
+                    if (m_anchorSlack < m_sampleRateHz / 1000)  // < 1 ms
+                        m_anchorSlack = 0;
+                }
                 m_haveAnchor = false;
+            }
         }
         if (tapSet) {
             QVarLengthArray<float, 1024> silence(frames);

--- a/src/core/CwSidetoneGenerator.cpp
+++ b/src/core/CwSidetoneGenerator.cpp
@@ -323,6 +323,12 @@ bool CwSidetoneGenerator::process(float* out, int frames) noexcept
             // durations collapse to block multiples (5.0 ms rendering as
             // 2.8 ms) — reintroducing the defect this branch removes.
             // Only the CARRIED slack is capped, below.
+            //
+            // m_anchorTime is deliberately NOT advanced alongside m_anchorPos.
+            // That asymmetry is what makes the guard quantity come out as
+            // S(now - e.t) — wall time since THIS edge — rather than a running
+            // total: moving both would turn the guard back into an accumulator
+            // and reintroduce the mid-burst re-anchor this design rules out.
             const int64_t deficit = blockStart - target;
             m_anchorPos += deficit;
             m_anchorSlack = std::min<int64_t>(

--- a/src/core/CwSidetoneGenerator.h
+++ b/src/core/CwSidetoneGenerator.h
@@ -51,6 +51,15 @@ public:
     // m_keyDown.
     void setKeyDown(bool down) noexcept;
 
+    // Late-edge branch fire count since reset() (#4890).  Exists so a test can
+    // prove it exercised that branch rather than passing vacuously; read from
+    // the same thread as process().
+    int64_t shiftCount() const noexcept { return m_shiftCount; }
+
+    // Staleness re-anchors since reset() (#4890) — mapping dropped because
+    // wall clock ran away from the render head.  Read from process()'s thread.
+    int64_t staleReanchorCount() const noexcept { return m_staleReanchors; }
+
     bool  isEnabled() const noexcept { return m_enabled.load(std::memory_order_relaxed); }
     float pitchHz() const noexcept   { return m_pitchHz.load(std::memory_order_relaxed); }
     float volume() const noexcept    { return m_volume.load(std::memory_order_relaxed); }
@@ -111,10 +120,25 @@ private:
     // edge may be before a fresh anchor discards it instead of replaying it.
     static constexpr int kReanchorIdleMs = 250;
 
-    // Upper bound on m_anchorSlack (#4890).  Must stay well below
-    // kReanchorIdleMs: the staleness guard measures anchor-vs-wall-clock
-    // drift THROUGH the slack, so slack eats into that margin.
+    // Upper bound on m_anchorSlack (#4890) — the headroom a NEW anchor starts
+    // with, and the only offset that is carried rather than corrective.  It
+    // sits inside the staleness guard's margin (a fresh anchor is placed at
+    // blockStart + slack, so the mapping starts that far ahead of the head),
+    // hence the relationship the assert pins.
+    //
+    // The per-edge forward shift is deliberately NOT bounded by this or any
+    // constant.  A shift is a re-alignment, not drift: it moves the mapping to
+    // the render head, so afterwards the guard quantity is the wall time since
+    // that edge, not a running total.  Measured over a sustained racing burst
+    // (119 shifts) the quantity peaked at 2.4 ms against this 250 ms threshold
+    // and never re-anchored.  Capping the shift was tried and is actively
+    // harmful: it strands the mapping behind the head, so every later edge in
+    // that anchor clamps and element durations collapse to block multiples
+    // (measured: 5.0 ms elements rendering as 2.8 ms) — the exact defect this
+    // change exists to remove.
     static constexpr int kAnchorSlackCapMs = 100;
+    static_assert(kAnchorSlackCapMs < kReanchorIdleMs,
+                  "carried slack must leave the staleness guard margin");
 
     void applyKeyEdge(bool down) noexcept;  // state-machine transition
 
@@ -165,7 +189,29 @@ private:
     // absolute onset latency grows — and the deficit accumulates here so the
     // NEXT burst anchors with enough headroom to stop racing at all.
     // Bounded by kAnchorSlackCapMs; reset with the mapping.
+    //
+    // It decays as well as grows, and must: this generator exists because the
+    // radio's own sidetone costs 30-100 ms round trip, so a slack that only
+    // ratcheted upward would let one transient stall park the client tone
+    // inside the very range it is meant to avoid, for the rest of the
+    // session.  An anchor that completed without ever running late is
+    // evidence the sink has headroom to spare, and halves it.
     int64_t  m_anchorSlack{0};
+
+    // Whether the current anchor has ever had to shift for a late edge.  An
+    // anchor released without one is evidence the sink had headroom to spare
+    // for that whole burst, which is when slack gives ground.
+    bool     m_anchorWentLate{false};
+
+    // Test-only observability (#4890).  m_shiftCount: a harness that cannot
+    // get the render head ahead of wall clock never exercises the late-edge
+    // branch, and its assertions would then pass against the pre-fix code too,
+    // so a test can require the branch actually fired.  m_staleReanchors: pins
+    // that sustained racing does NOT walk the mapping into the staleness guard
+    // — the concern that motivated bounding the shift, which measurement
+    // refuted.
+    int64_t  m_shiftCount{0};
+    int64_t  m_staleReanchors{0};
 
     // Mirror sink for the TX decode path (#2417).  Holds null until
     // AudioEngine plugs in its TX-decoder feeder.  When non-null, every

--- a/src/core/CwSidetoneGenerator.h
+++ b/src/core/CwSidetoneGenerator.h
@@ -148,6 +148,10 @@ private:
     // a 22 s hand-keyed session measured 5.5 ms of total learned slack, and
     // the deliberate 800 ms pump stall in the decay test needs only enough to
     // clear one refill.
+    // The cap also SPENDS the staleness guard's stall tolerance rather than
+    // merely staying under it: a fresh anchor starts at blockStart + slack,
+    // so at the cap a genuine pump stall has kReanchorIdleMs - 40 ms of
+    // margin left, not the full 250 ms.
 
     void applyKeyEdge(bool down) noexcept;  // state-machine transition
 

--- a/src/core/CwSidetoneGenerator.h
+++ b/src/core/CwSidetoneGenerator.h
@@ -111,6 +111,11 @@ private:
     // edge may be before a fresh anchor discards it instead of replaying it.
     static constexpr int kReanchorIdleMs = 250;
 
+    // Upper bound on m_anchorSlack (#4890).  Must stay well below
+    // kReanchorIdleMs: the staleness guard measures anchor-vs-wall-clock
+    // drift THROUGH the slack, so slack eats into that margin.
+    static constexpr int kAnchorSlackCapMs = 100;
+
     void applyKeyEdge(bool down) noexcept;  // state-machine transition
 
     int                m_sampleRateHz;
@@ -148,6 +153,19 @@ private:
     std::chrono::steady_clock::time_point m_anchorTime;
     int64_t  m_anchorPos{0};
     int64_t  m_idleSamples{0};      // contiguous idle samples since the last edge
+
+    // Learned anchor headroom, in samples (#4890).  A push-model sink keeps
+    // its device buffer full, so m_streamPos advances at wall-clock pace and
+    // every edge target races the render head: an edge whose exact position
+    // was already rendered used to be clamped to the current block start,
+    // quantizing BOTH edges of an element to block boundaries (measured on
+    // Linux: dit SD 0.2 ms at emission -> 6-8 ms rendered, in whole-block
+    // steps).  When an edge arrives late, process() now shifts the whole
+    // anchor forward instead — relative spacing (the rhythm) survives, only
+    // absolute onset latency grows — and the deficit accumulates here so the
+    // NEXT burst anchors with enough headroom to stop racing at all.
+    // Bounded by kAnchorSlackCapMs; reset with the mapping.
+    int64_t  m_anchorSlack{0};
 
     // Mirror sink for the TX decode path (#2417).  Holds null until
     // AudioEngine plugs in its TX-decoder feeder.  When non-null, every

--- a/src/core/CwSidetoneGenerator.h
+++ b/src/core/CwSidetoneGenerator.h
@@ -136,9 +136,18 @@ private:
     // that anchor clamps and element durations collapse to block multiples
     // (measured: 5.0 ms elements rendering as 2.8 ms) — the exact defect this
     // change exists to remove.
-    static constexpr int kAnchorSlackCapMs = 100;
+    static constexpr int kAnchorSlackCapMs = 40;
     static_assert(kAnchorSlackCapMs < kReanchorIdleMs,
                   "carried slack must leave the staleness guard margin");
+    // The assert pins the SAFETY relationship, but it is not the binding
+    // constraint on this value: slack IS onset latency, so the ceiling that
+    // matters is the 30-100 ms radio round trip this generator exists to beat
+    // (see m_anchorSlack).  A cap at the top of that range would let the
+    // client tone silently become no better than the radio's.  40 ms keeps it
+    // clearly ahead while leaving room for several refills' worth of learning:
+    // a 22 s hand-keyed session measured 5.5 ms of total learned slack, and
+    // the deliberate 800 ms pump stall in the decay test needs only enough to
+    // clear one refill.
 
     void applyKeyEdge(bool down) noexcept;  // state-machine transition
 

--- a/tests/cw_sidetone_test.cpp
+++ b/tests/cw_sidetone_test.cpp
@@ -424,5 +424,84 @@ int main()
                      "element after a consumer pause still sounds, once");
     }
 
+    // ── 12. Push-pump race: an element keyed while the render head is ahead
+    // of wall clock keeps its exact duration (#4890).  A push-model sink
+    // keeps the device buffer full, so process() renders ahead of real time
+    // and an edge's timestamp-mapped position can already be rendered by the
+    // time the edge is consumed.  Clamping just that edge to the block start
+    // quantized BOTH edges of the element to render-head positions — on the
+    // bench this collapsed rhythm into whole-block steps (Linux: emission
+    // SD 0.2 ms rendered as 6–8 ms, in 5.3 ms quanta).  The anchor must
+    // shift forward instead, preserving the element's length.
+    {
+        using clock = std::chrono::steady_clock;
+        CwSidetoneGenerator gen(48000);
+        gen.setEnabled(true);
+        gen.setVolume(1.0f);
+        gen.setShapingMs(0.0f);
+
+        // Element A anchors the burst and flushes normally.  Deliberately
+        // twice element B's length: if B collapses at the render head, the
+        // last loud run the assertions measure is A, and A's length must
+        // not fit B's expected window.
+        gen.setKeyDown(true);
+        auto blk = runFrames(gen, 128);
+        std::vector<float> cat(blk.begin(), blk.end());
+        const auto a1 = clock::now();
+        while (clock::now() - a1 < std::chrono::milliseconds(20)) { /* spin */ }
+        gen.setKeyDown(false);
+        while (cat.size() < 2000) {
+            blk = runFrames(gen, 128);
+            cat.insert(cat.end(), blk.begin(), blk.end());
+        }
+
+        // Inter-element gap, during which the "pump" tops the buffer up —
+        // the render head moves ~80 ms ahead while the anchor is retained
+        // (gap and lead both well under the idle re-anchor threshold).
+        const auto g0 = clock::now();
+        while (clock::now() - g0 < std::chrono::milliseconds(40)) { /* spin */ }
+        while (cat.size() < 6000) {
+            blk = runFrames(gen, 128);
+            cat.insert(cat.end(), blk.begin(), blk.end());
+        }
+
+        // Element B: keyed in real time, consumed with the head far ahead.
+        gen.setKeyDown(true);
+        const auto b1 = clock::now();
+        while (clock::now() - b1 < std::chrono::milliseconds(10)) { /* spin */ }
+        const auto c0 = clock::now();
+        gen.setKeyDown(false);
+        const auto c1 = clock::now();
+        for (int b = 0; b < 40; ++b) {
+            blk = runFrames(gen, 128);
+            cat.insert(cat.end(), blk.begin(), blk.end());
+        }
+
+        // Locate element B — the last loud run — and measure its length.
+        int lastStart = -1, lastEnd = -1;
+        bool loudRun = false;
+        for (int i = 0; i + 8 <= static_cast<int>(cat.size()); i += 8) {
+            const float peak = maxAbs(std::vector<float>(
+                cat.begin() + i, cat.begin() + i + 8));
+            const bool loud = peak > 0.1f;
+            if (loud && !loudRun) lastStart = i;
+            if (loud) lastEnd = i + 8;
+            loudRun = loud;
+        }
+        ok &= expect(toneBursts(cat) == 2,
+                     "push-pump race: late element still renders as its own"
+                     " burst");
+        const auto loNs = std::chrono::duration_cast<std::chrono::nanoseconds>(c0 - b1).count();
+        const auto hiNs = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            c1 - (b1 - std::chrono::milliseconds(0))).count();
+        const int lo = static_cast<int>(loNs * 48000 / 1'000'000'000LL) - 16;
+        const int hi = static_cast<int>(hiNs * 48000 / 1'000'000'000LL) + 144;
+        const int lenB = (lastStart >= 0 && lastEnd > lastStart)
+                             ? lastEnd - lastStart : -1;
+        ok &= expect(lenB >= lo && lenB <= hi,
+                     "push-pump race: element duration is preserved, not"
+                     " clamped to the render head");
+    }
+
     return ok ? 0 : 1;
 }

--- a/tests/cw_sidetone_test.cpp
+++ b/tests/cw_sidetone_test.cpp
@@ -491,9 +491,14 @@ int main()
         ok &= expect(toneBursts(cat) == 2,
                      "push-pump race: late element still renders as its own"
                      " burst");
+        // The assertions below only exercise the late-edge branch if the
+        // render head actually got ahead of wall clock above; on a runner
+        // where runFrames() is slower than real time nothing is ever late and
+        // they would pass against the pre-fix code too.  Require the branch.
+        ok &= expect(gen.shiftCount() > 0,
+                     "push-pump race: the late-edge branch actually fired");
         const auto loNs = std::chrono::duration_cast<std::chrono::nanoseconds>(c0 - b1).count();
-        const auto hiNs = std::chrono::duration_cast<std::chrono::nanoseconds>(
-            c1 - (b1 - std::chrono::milliseconds(0))).count();
+        const auto hiNs = std::chrono::duration_cast<std::chrono::nanoseconds>(c1 - b1).count();
         const int lo = static_cast<int>(loNs * 48000 / 1'000'000'000LL) - 16;
         const int hi = static_cast<int>(hiNs * 48000 / 1'000'000'000LL) + 144;
         const int lenB = (lastStart >= 0 && lastEnd > lastStart)
@@ -501,6 +506,101 @@ int main()
         ok &= expect(lenB >= lo && lenB <= hi,
                      "push-pump race: element duration is preserved, not"
                      " clamped to the render head");
+    }
+
+    // ── 13. Sustained racing does not walk the mapping into the staleness
+    // guard (#4890).  Review asked whether the per-edge forward shift, being
+    // uncapped, could accumulate until the guard fires mid-burst and re-quantizes
+    // an onset at an unpredictable moment.  It cannot: a shift moves the mapping
+    // ONTO the render head rather than past it, so the guard's quantity after a
+    // shift is the wall time since that edge, not a running total.  This pins
+    // that — a long burst rendered faster than real time, so every element
+    // shifts, must produce no staleness re-anchor at all.
+    {
+        using clock = std::chrono::steady_clock;
+        CwSidetoneGenerator gen(48000);
+        gen.setEnabled(true);
+        gen.setVolume(1.0f);
+        gen.setShapingMs(0.0f);
+        const auto spin = [](int ms) {
+            const auto t = clock::now();
+            while (clock::now() - t < std::chrono::milliseconds(ms)) { /* spin */ }
+        };
+
+        // 60 elements keyed on the real clock but rendered ~3x faster, so the
+        // head gains on wall clock every single element and each edge is late.
+        for (int n = 0; n < 60; ++n) {
+            gen.setKeyDown(true);
+            spin(5);
+            for (int b = 0; b < 6; ++b) runFrames(gen, 128);   // 16 ms audio / 5 ms real
+            gen.setKeyDown(false);
+            spin(5);
+            for (int b = 0; b < 6; ++b) runFrames(gen, 128);
+        }
+        ok &= expect(gen.shiftCount() > 20,
+                     "sustained racing: the late-edge branch fired throughout");
+        ok &= expect(gen.staleReanchorCount() == 0,
+                     "sustained racing: shifts never trip the staleness guard");
+    }
+
+    // ── 14. Learned slack decays (#4890).  It must be able to shrink: this
+    // generator exists to beat the radio's 30–100 ms round trip, so a slack
+    // that only ratcheted upward would let one transient stall park the tone
+    // inside that range for the rest of the session.  A burst that never runs
+    // late is evidence the sink has headroom, and gives some back.
+    {
+        using clock = std::chrono::steady_clock;
+        CwSidetoneGenerator gen(48000);
+        gen.setEnabled(true);
+        gen.setVolume(1.0f);
+        gen.setShapingMs(0.0f);
+
+        const auto spin = [](int ms) {
+            const auto t = clock::now();
+            while (clock::now() - t < std::chrono::milliseconds(ms)) { /* spin */ }
+        };
+
+        // Stall the pump so an edge arrives far behind the render head; that
+        // teaches the mapping the maximum slack.
+        gen.setKeyDown(true);
+        for (int b = 0; b < 300; ++b) runFrames(gen, 128);   // race ~800 ms ahead
+        gen.setKeyDown(false);
+        gen.setKeyDown(true);
+        gen.setKeyDown(false);
+        for (int b = 0; b < 8; ++b) runFrames(gen, 128);
+        ok &= expect(gen.shiftCount() > 0, "slack decay: the stall produced late edges");
+
+        // Clean bursts: both edges are queued with no rendering between them,
+        // so neither can land behind the head however far ahead the head is —
+        // the anchor is taken relative to the current block. Each burst is
+        // followed by enough idle to release the anchor, which is where a
+        // burst that never ran late gives slack back.
+        const auto cleanBurst = [&](int idleBlocks, std::vector<float>* out) {
+            gen.setKeyDown(true);
+            spin(5);
+            gen.setKeyDown(false);
+            for (int b = 0; b < idleBlocks; ++b) {
+                auto blk = runFrames(gen, 128);
+                if (out) out->insert(out->end(), blk.begin(), blk.end());
+            }
+        };
+
+        for (int burst = 0; burst < 8; ++burst)
+            cleanBurst(130, nullptr);          // 130×128 ≈ 347 ms > kReanchorIdleMs
+
+        std::vector<float> seg;
+        cleanBurst(40, &seg);
+        int64_t onset = -1;
+        for (int i = 0; i + 8 <= static_cast<int>(seg.size()); i += 8) {
+            float peak = 0.0f;
+            for (int j = i; j < i + 8; ++j) peak = std::max(peak, std::abs(seg[j]));
+            if (peak > 0.1f) { onset = i / 2; break; }
+        }
+        // Onset offset within the burst IS the carried slack. After repeated
+        // clean bursts it must have decayed back to (about) the block start
+        // instead of staying latched at what the stall taught it.
+        ok &= expect(onset >= 0 && onset <= 256,
+                     "slack decay: onset returns to the block start after clean bursts");
     }
 
     return ok ? 0 : 1;

--- a/tests/cw_sidetone_test.cpp
+++ b/tests/cw_sidetone_test.cpp
@@ -591,20 +591,45 @@ int main()
             }
         };
 
-        for (int burst = 0; burst < 8; ++burst)
-            cleanBurst(130, nullptr);          // 130×128 ≈ 347 ms > kReanchorIdleMs
+        // Release the stall's anchor (it ran late, so releasing it does not
+        // halve the slack) so the next burst re-anchors fresh: the onset that
+        // burst renders IS the carried slack, measured end to end.
+        for (int b = 0; b < 100; ++b) runFrames(gen, 128);  // > kReanchorIdleMs
 
+        // seg is mono — runFrames() returns one entry per frame.
+        const auto onsetOf = [](const std::vector<float>& seg) -> int64_t {
+            for (int i = 0; i + 8 <= static_cast<int>(seg.size()); i += 8) {
+                float peak = 0.0f;
+                for (int j = i; j < i + 8; ++j)
+                    peak = std::max(peak, std::abs(seg[j]));
+                if (peak > 0.1f) return i;
+            }
+            return -1;
+        };
+
+        // Both ends of the decay are pinned.  Near end: the first fresh
+        // anchor after the stall spends the full taught slack, so the onset
+        // sits at the cap (1920 samples = 40 ms at 48 kHz).  If the idle
+        // counter survived the anchor take, the still-saturated counter
+        // would release each new anchor once per empty run-up block and
+        // halve the slack every time — collapsing the onset to under five
+        // blocks (measured: 632 samples) and silently capping carried slack
+        // at one audio block instead of kAnchorSlackCapMs.
+        std::vector<float> first;
+        cleanBurst(130, &first);           // 130×128 ≈ 347 ms > kReanchorIdleMs
+        const int64_t onset0 = onsetOf(first);
+        ok &= expect(onset0 >= 1920 - 256 && onset0 <= 1920 + 256,
+                     "slack decay: first fresh anchor spends the full taught slack");
+
+        for (int burst = 0; burst < 8; ++burst)
+            cleanBurst(130, nullptr);
+
+        // Far end: after repeated clean bursts the slack must have decayed
+        // back to (about) the block start instead of staying latched at what
+        // the stall taught it.
         std::vector<float> seg;
         cleanBurst(40, &seg);
-        int64_t onset = -1;
-        for (int i = 0; i + 8 <= static_cast<int>(seg.size()); i += 8) {
-            float peak = 0.0f;
-            for (int j = i; j < i + 8; ++j) peak = std::max(peak, std::abs(seg[j]));
-            if (peak > 0.1f) { onset = i / 2; break; }
-        }
-        // Onset offset within the burst IS the carried slack. After repeated
-        // clean bursts it must have decayed back to (about) the block start
-        // instead of staying latched at what the stall taught it.
+        const int64_t onset = onsetOf(seg);
         ok &= expect(onset >= 0 && onset <= 256,
                      "slack decay: onset returns to the block start after clean bursts");
     }

--- a/tests/cw_sidetone_test.cpp
+++ b/tests/cw_sidetone_test.cpp
@@ -69,6 +69,12 @@ int toneBursts(const std::vector<float>& buf)
 }
 
 // Key one element of `ms` on, `ms` off, spinning on the real clock.
+//
+// The spin is this file's convention, not an oversight: every timing test here
+// advances the same real clock the generator reads, and the element durations
+// they assert on are only as tight as the wait that produces them.  Swapping in
+// sleep_for() would be a file-wide change with those assertions downstream of
+// it, so it wants to be one deliberate decision rather than a local edit.
 void keyElement(CwSidetoneGenerator& gen, int ms)
 {
     using clock = std::chrono::steady_clock;


### PR DESCRIPTION
## What this addresses

The **render-side component of #4890**: the local sidetone generator was
re-timing key edges it received late, quantizing hand-keyed elements to audio
block boundaries. #4890 stays open when this merges — the emission layer
itself jitters on macOS (dit SD 2.74 ms on the reporter's M2, 2.30 ms measured
on Intel Mac — [results on the issue](https://github.com/aethersdr/AetherSDR/issues/4890#issuecomment-5258764730)),
and this change does not touch that. The emission component is a separate
keyer-side mechanism; I plan to bring a sample-domain duration design for it
to the issue for discussion, as a separate PR.

Linux reproduction with per-stream isolation, evidence bundle, and the block-grid
fingerprints are in [my findings comment on the issue](https://github.com/aethersdr/AetherSDR/issues/4890#issuecomment-5249585126).

## Root cause

In `CwSidetoneGenerator::process()`, the timestamp→sample mapping clamped any
edge whose mapped sample was already rendered to the current block start:

```cpp
const int off = static_cast<int>(
    std::max<int64_t>(target, blockStart) - blockStart);
```

Under a push-model sink the device buffer stays full, so the render head
advances at wall-clock pace with **zero headroom** — every queued edge races
the head, and edges lose about half the time. A lost race snaps that edge to a
block boundary, so both edges of an element quantize independently; an anchor
captured at low buffer fill displaces whole bursts by refill-sized steps.
Measured on Linux (QAudioSink 24 kHz push fallback): element durations cluster
on the 5.333 ms block grid (circular clustering R = 0.92), onsets on a
10.667 ms grid (R = 0.997), while the same elements left the keyer with
0.20 ms SD.

## The fix

A late edge now shifts the **whole anchor** forward by its deficit instead of
being clamped alone: the edge plays at the render head, every later edge keeps
its exact distance from it — so the element keeps its measured duration and
the rhythm survives — and the deficit accumulates as learned slack (capped at
`kAnchorSlackCapMs` = 40 ms, deliberately well under the 250 ms
`kReanchorIdleMs` staleness guard, which measures drift through the slack) so
subsequent bursts anchor with enough headroom to stop racing entirely.

The tradeoff is explicit: bounded, self-tuning onset latency in exchange for
exact rhythm. Observed in a 22-second hand-keyed session: one slack-learning
step of +5.5 ms total. With zero slack the mapping reproduces the old onset
latency exactly, and pull-model sinks that already render with headroom rarely
produce late edges, so their behavior is effectively unchanged.

## Measured before/after (Linux, FLEX-8400 on dummy load, HaliKey paddle, 25 WPM, hand-keyed K's)

Same protocol and instruments both runs: `aether.cw` key-edge trace (emission)
+ per-stream audio capture of the generator's own output stream; the RX/network
stream recorded simultaneously as a control was **all-zero in both runs**.

| | before (`f6f56865`) | after (this PR) |
|---|---|---|
| emission dit SD | 0.20 ms | 0.21 ms |
| **audio dit SD** | **7.75 ms** | **0.215 ms** |
| audio dit range | 42.5–64.2 ms | 47.4–48.5 ms |
| audio dah SD | 5.33 ms | 0.91 ms (0.34 excluding the one slack step) |

After the fix, rendered audio matches the emission log at the ~0.2 ms level —
the sidetone is now a faithful recording of what the keyer produced. The
before-run's whole-block displacement clusters (dits at 42.5 / 64.2 ms) are
gone. Exactly one element in the after-run carries the predicted slack-learning
step (+5.5 ms, at t ≈ 1 s); every element after it is sample-exact (66 elements,
22 K's).

## Platform datapoint (Intel macOS)

Measured 2026-08-11 on an Intel Mac (macOS 15.7.7) running this branch (`0da3bf93`): that machine selects the **PortAudio pull sink** (device match succeeds), so the push-model race fixed here does not arise on that path, and the build runs and keys normally there (held-paddle runs + 50 hand-keyed K's; full data in the #4890 thread). The separate emission-side scatter measured on macOS (dit SD ~2.3 ms, load-independent) is upstream of the sidetone renderer and out of scope for this change.

## Regression test

New case in `tests/cw_sidetone_test.cpp`: drives the generator in the
push-pump regime (rendering ahead of real-time keying), then keys an element
whose edges arrive with the render head ahead, and asserts the late element
still renders as its own burst with its measured duration instead of
collapsing at the head. The two elements have deliberately asymmetric lengths
so a collapse cannot pass by accident; reverting the fix fails both asserts
(mutation-checked).

Against the five criteria suggested in the issue:

1. **DAH ≈ 3× DIT** — after-fix audio dah/dit = 2.99 (144.18 / 48.19 ms).
2. **DAHs within a K equivalent** — dah SD 0.34 ms (excluding the disclosed slack step).
3. **DIT→DAH / DAH→DIT onset stability** — rendered onset intervals reproduce
   the emitted intervals (DAH→DIT: 192.1 ms emitted / 192.3 ms rendered);
   remaining interval variation is already present in the emission log
   (input side, out of scope for this render fix).
4. **Onsets tied to the timestamp mapping, not block boundaries** — the new
   test asserts it; measured after-run shows no block-grid clustering (dit
   spread 1.1 ms vs the 5.33 ms block).
5. **Exercises the inter-element Idle state** — the test's inter-element gap
   has the envelope at Idle with the anchor retained, and the hand-keyed
   before/after runs exercise real inter-element idles throughout.

Full suite: 273/279 — every non-passing case verified pre-existing on stock
`f6f56865` (a11y/geometry) or a parallel-run flake that passes alone.

## Out of scope, disclosed

- **Micro-blip clicks** (~0.2 ms, from a non-keyer producer path): pre-existing
  on stock and *reduced* under this change (stock runs: 39/130 and 21/78
  elements affected → fix runs: 5/66 and 4/30). Consistent with the already-filed
  double-`setKeyDown` echo issue; not addressed here.
- **Why this box runs the fallback sink**: PortAudio sidetone fails device
  match on Linux ("selected Qt output device was not found in PortAudio") and
  the app falls back to QAudioSink push mode. Happy to file separately if useful.

## Evidence

Attached zip: whole unedited app logs from both runs, per-stream WAVs
(including the all-zero RX controls), both analysis scripts, About-dialog
screenshot proving the build SHA. The before-run bundle is already attached to
the findings comment on #4890.

[aethersdr-issue4890-linux-fixAB-2026-08-11.zip](https://github.com/user-attachments/files/30946156/aethersdr-issue4890-linux-fixAB-2026-08-11.zip)



— authored by agent (Claude Code) on behalf of @skerker

## Constitution principle honored

Principle VIII — Evidence Over Assertion: every behavioral claim in this PR is backed by measurements in the linked issue thread or by the tests added here.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — **n/a, no settings read or written**
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` — **n/a, no meter UI touched**
- [x] Documentation updated if user-visible behavior changed — **n/a: no doc covers sidetone timing; the behavior change is described above**
- [x] Security-sensitive changes reference a GHSA — **n/a, not security-sensitive**
