### PR TITLE
fix(audio): default PC Audio off so a fresh install keeps hardware speakers live

### DIFF
--- a/src/core/DeviceDiagnostics.cpp
+++ b/src/core/DeviceDiagnostics.cpp
@@ -231,7 +231,7 @@ QJsonObject buildAudioDevicesSnapshot(const AudioEngine* audio, const QJsonObjec
     const QJsonObject mic = transmit["mic"].toObject();
     const QJsonObject radio = snapshot["radio"].toObject();
     const QJsonObject remoteAudioRx = radio["remote_audio_rx"].toObject();
-    const bool pcAudioEnabled = isSavedTrue(QStringLiteral("PcAudioEnabled"), QStringLiteral("True"));
+    const bool pcAudioEnabled = isSavedTrue(QStringLiteral("PcAudioEnabled"));
 
     QJsonObject rxRoute;
     rxRoute["output"] = pcAudioEnabled ? "PC audio" : "Radio audio";
@@ -379,7 +379,7 @@ QJsonObject buildAudioStartupSnapshot(const AudioEngine* audio, const QJsonObjec
 
     const QJsonObject transmit = snapshot["transmit"].toObject();
     const QJsonObject mic = transmit["mic"].toObject();
-    const bool pcAudioEnabled = isSavedTrue(QStringLiteral("PcAudioEnabled"), QStringLiteral("True"));
+    const bool pcAudioEnabled = isSavedTrue(QStringLiteral("PcAudioEnabled"));
 
     QJsonObject rxRoute;
     rxRoute["output"] = pcAudioEnabled ? "PC audio" : "Radio audio";

--- a/src/core/QsoRecordStartPolicy.h
+++ b/src/core/QsoRecordStartPolicy.h
@@ -90,7 +90,9 @@ enum class RecordStartDecision {
 // explanation is worse than none.
 //
 // `clientSideMode`      AppSettings "RecordingMode" == "Client" (the default).
-// `pcAudioEnabled`      AppSettings "PcAudioEnabled" == "True" (the default).
+// `pcAudioEnabled`      AppSettings "PcAudioEnabled" == "True" (default "False",
+//                       flipped in #1826 so a fresh install keeps the radio's
+//                       hardware speakers live instead of silently muting them).
 // `backendOwnsRxAudio`  IRadioBackend::ownsRxAudio() — the connected backend
 //                       demodulates in-process and feeds the recorder over the
 //                       seam, so `remote_audio_rx` (and PC Audio) is not in the

--- a/src/core/QsoRecorder.cpp
+++ b/src/core/QsoRecorder.cpp
@@ -108,7 +108,7 @@ RecordStartDecision QsoRecorder::evaluateStart() const
     const bool clientSide =
         s.value("RecordingMode", "Client").toString() == "Client";
     const bool pcAudio =
-        s.value("PcAudioEnabled", "True").toString() == "True";
+        s.value("PcAudioEnabled", "False").toString() == "True";
     // No provider installed (unit tests, no radio) reads as false: the Flex
     // answer, and the one that keeps the guard active rather than silently off.
     const bool seamNative = m_backendOwnsRxAudio && m_backendOwnsRxAudio();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5695,7 +5695,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
         // Always sync the button to the setting here so any divergence
         // (e.g. from a profile load before connect) is corrected (#1536).
         {
-            const bool pcAudio = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
+            const bool pcAudio = AppSettings::instance().value("PcAudioEnabled", "False").toString() == "True";
             m_titleBar->setPcAudioEnabled(pcAudio);
             if (pcAudio)
                 audioStartRx();
@@ -6630,7 +6630,7 @@ void MainWindow::applyMasterVolume(int pct)
 {
     if (pct < 0)   pct = 0;
     if (pct > 100) pct = 100;
-    bool pcAudio = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
+    bool pcAudio = AppSettings::instance().value("PcAudioEnabled", "False").toString() == "True";
     if (pcAudio)
         m_audio->setRxVolume(pct / 100.0f);
     else

--- a/src/gui/MainWindow_DspApplets.cpp
+++ b/src/gui/MainWindow_DspApplets.cpp
@@ -215,7 +215,7 @@ void MainWindow::wirePooDooTiles()
         // the engine (not signals) so an already-on NR module shows up
         // immediately instead of waiting for the next toggle.
         const bool pcOn = AppSettings::instance()
-            .value("PcAudioEnabled", "True").toString() == "True";
+            .value("PcAudioEnabled", "False").toString() == "True";
         chain->setRxPcAudioEnabled(pcOn);
         if (m_aetherialStrip) m_aetherialStrip->setRxPcAudioEnabled(pcOn);
         dspState->nr2  = m_audio->nr2Enabled();

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1660,7 +1660,7 @@ void MainWindow::onSliceAdded(SliceModel* s)
         // through the radio's hardware outputs, don't switch to PC. (#336)
         if (m_needAudioStream) {
             m_needAudioStream = false;
-            if (AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True")
+            if (AppSettings::instance().value("PcAudioEnabled", "False").toString() == "True")
                 m_radioModel.createRxAudioStream();
         }
 
@@ -2827,7 +2827,7 @@ void MainWindow::runProfileLoadRecoveryPass(const QString& profileType,
         }
     }
 
-    if (AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True") {
+    if (AppSettings::instance().value("PcAudioEnabled", "False").toString() == "True") {
         audioStartRx();
     }
 

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -289,7 +289,7 @@ TitleBar::TitleBar(QWidget* parent)
     m_pcBtn->setFixedHeight(22);
     m_pcBtn->setFixedWidth(70);
 
-    bool pcOn = s.value("PcAudioEnabled", "True").toString() == "True";
+    bool pcOn = s.value("PcAudioEnabled", "False").toString() == "True";
     m_pcBtn->setChecked(pcOn);
     m_pcBtn->setAccessibleName("PC Audio");
     m_pcBtn->setAccessibleDescription("Toggle PC audio receive playback");

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -7479,7 +7479,14 @@ void RadioModel::removeRxAudioStream()
 
 void RadioModel::scheduleRxAudioStreamEnsure(const QString& reason)
 {
-    const bool pcAudio = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
+    // Default is "False", not "True" (#1826). The stream this creates tells
+    // the radio to route RX audio to the PC instead of its own hardware
+    // speakers -- so on a fresh install, or any upgrade where the operator
+    // never touched the PC Audio button, a "True" default silently muted the
+    // radio's rear-panel speakers ~3s into every connect with no way to tell
+    // why. Existing users who explicitly chose PC Audio on keep that choice:
+    // this only changes what an unset/never-persisted key means.
+    const bool pcAudio = AppSettings::instance().value("PcAudioEnabled", "False").toString() == "True";
     if (!pcAudio) {
         qCDebug(lcProtocol) << "RadioModel: PC audio disabled — skipping remote_audio_rx";
         if (m_rxAudio.streamId != 0) {
@@ -7492,7 +7499,7 @@ void RadioModel::scheduleRxAudioStreamEnsure(const QString& reason)
 
     logRemoteAudioRxSummary(QStringLiteral("ensure scheduled: ") + reason);
     QTimer::singleShot(350, this, [this, reason]() {
-        const bool pcAudioNow = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
+        const bool pcAudioNow = AppSettings::instance().value("PcAudioEnabled", "False").toString() == "True";
         if (!isConnected()) {
             logRemoteAudioRxSummary(QStringLiteral("ensure canceled: disconnected"));
             return;
@@ -7553,7 +7560,7 @@ bool RadioModel::handleRemoteAudioRxStreamStatus(const QString& object,
         break;
     }
 
-    const bool pcAudio = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
+    const bool pcAudio = AppSettings::instance().value("PcAudioEnabled", "False").toString() == "True";
     if (!pcAudio && m_rxAudio.streamId != 0
         && (action == RadioStatusOwnership::RemoteAudioRxAction::Adopted
             || action == RadioStatusOwnership::RemoteAudioRxAction::Updated)) {
@@ -7570,7 +7577,7 @@ bool RadioModel::handleRemoteAudioRxStreamStatus(const QString& object,
 
 void RadioModel::logRemoteAudioRxSummary(const QString& reason) const
 {
-    const bool pcAudio = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
+    const bool pcAudio = AppSettings::instance().value("PcAudioEnabled", "False").toString() == "True";
     const bool autoStartTci = AppSettings::instance().value("AutoStartTCI", "False").toString() == "True";
     const bool ownerKnown = m_rxAudio.clientHandle != 0;
     const bool ownedByUs = ownerKnown && m_rxAudio.clientHandle == clientHandle();
@@ -10471,7 +10478,7 @@ QJsonObject RadioModel::troubleshootingSnapshot() const
     audioOutputs["front_speaker_mute"] = m_frontSpeakerMute;
     radio["audio_outputs"] = audioOutputs;
 
-    const bool pcAudioSetting = AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
+    const bool pcAudioSetting = AppSettings::instance().value("PcAudioEnabled", "False").toString() == "True";
     QJsonObject remoteAudioRx;
     remoteAudioRx["stream_id"] = m_rxAudio.streamId == 0
         ? QJsonValue()

--- a/tests/qso_recorder_pc_audio_guard_test.cpp
+++ b/tests/qso_recorder_pc_audio_guard_test.cpp
@@ -92,6 +92,34 @@ int main(int argc, char** argv)
     QCoreApplication app(argc, argv);
     AppSettings::instance().load();
 
+    // ── Fresh install: PC Audio defaults off (#1826) ────────────────────────
+    // A never-persisted PcAudioEnabled key used to read as "True", so a fresh
+    // install (or an upgrade where the operator never touched the button)
+    // opened the remote_audio_rx stream and muted the radio's own speakers
+    // with no explanation. Deliberately skips setMode() -- the whole point is
+    // to observe what an UNSET key resolves to, not one this test sets.
+    {
+        QTemporaryDir tmp;
+        EXPECT_TRUE(tmp.isValid());
+
+        QsoRecorder rec;
+        rec.setRecordingDir(tmp.path());
+
+        EXPECT_TRUE(rec.evaluateStart()
+                    == RecordStartDecision::BlockedPcAudioDisabled);
+
+        int blocked = 0;
+        RecordStartDecision reason = RecordStartDecision::Allow;
+        QObject::connect(&rec, &QsoRecorder::recordingBlocked,
+                         &rec, [&](RecordStartDecision r) { ++blocked; reason = r; });
+
+        rec.startRecording();
+        EXPECT_TRUE(!rec.isRecording());
+        EXPECT_EQ_INT(fileCount(tmp.path()), 0);
+        EXPECT_EQ_INT(blocked, 1);
+        EXPECT_TRUE(reason == RecordStartDecision::BlockedPcAudioDisabled);
+    }
+
     // ── The bug: Client-Side + PC Audio off ─────────────────────────────────
     {
         QTemporaryDir tmp;


### PR DESCRIPTION
## Problem
Fixes #1826. `RadioModel::scheduleRxAudioStreamEnsure()` created a
`remote_audio_rx` VITA-49 stream whenever `PcAudioEnabled` read as
`"True"` — including its previous default when the key had never
been persisted. That stream's mere existence causes FlexRadio
firmware to mute its own rear-panel speakers and route RX audio to
the PC instead. Result: a fresh install (or an upgrade where the
operator never touched the PC Audio button) went silent ~3 seconds
into every connect, with nothing in the UI to explain why.

## Fix
Flip the default from `"True"` to `"False"` at all 14 read call
sites (`RadioModel`, `MainWindow` + `Wiring`/`DspApplets`,
`TitleBar`, `QsoRecorder`, `DeviceDiagnostics`).

Existing users who explicitly toggled PC Audio on are unaffected —
the setting is only ever force-written to `"True"` by the button
click itself, or for host-modulating backends (HL2, Icom) that have
no hardware speaker path to fall back to. This change only affects
what an *unset* key resolves to.

## Testing
- Full app build clean
- **New regression test** in `qso_recorder_pc_audio_guard_test`:
  every existing scenario in that file set `PcAudioEnabled`
  explicitly before asserting, so none of them actually covered the
  unset-key default this PR changes. Added a case that skips that
  setup on a fresh settings profile and asserts the recorder
  correctly refuses to start. Verified it fails (red) against the
  old `"True"` default and passes (green) against this fix.
- `qso_recorder_pc_audio_guard_test` (9/9) and `hl2_pc_audio_lock_test`
  pass
- Live-verified on a fresh, isolated settings profile
  (`HOME`/`XDG_CONFIG_HOME`/`CFFIXED_USER_HOME` redirected to a temp
  dir): no `PcAudioEnabled` row in the fresh DB, PC Audio button
  renders OFF by default
- Confirmed against my own real settings DB (`PcAudioEnabled=True`
  explicitly persisted) that the fix leaves existing users untouched