### PR TITLE
feat(workspace): applets on the canvas — live drag, resize, snap grid, escape hatches (RFC #4887 phases 3+5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,16 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: ctest --test-dir build -R "^workspace_" --output-on-failure
 
+      # The demo RX engine's worker-thread contract (#4878): affinity, 24 kHz
+      # pacing on a coarse timer, keyed-mute, stallscope. This is the fix for
+      # the demo making the GUI thread carry a 333 Hz precise timer plus the
+      # whole synthesis load — the regression class only an executed test
+      # keeps dead. Pure event-loop test; ~1.5 s measured.
+      - name: Test demo backend threading
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: ctest --test-dir build -R "^sim_signal_source_test$" --output-on-failure
+
       # hl2_am_dcblock_test is deliberately NOT on this gate, and re-adding it
       # needs a measurement first. #4774 added it here on the "milliseconds
       # against an already-linked target" rationale every other step above

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3495,6 +3495,11 @@ add_executable(workspace_canvas_widget_test
     src/gui/workspace/CanvasLayout.cpp
     src/gui/workspace/WorkspaceCanvas.cpp
     src/gui/workspace/WorkspaceGeometry.cpp
+    ${AETHER_SETTINGS_SOURCES}
+    src/core/ThemeManager.cpp
+    src/core/ThemeSeedGenerated.cpp
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
 )
 target_include_directories(workspace_canvas_widget_test PRIVATE src)
 target_link_libraries(workspace_canvas_widget_test PRIVATE Qt6::Widgets Qt6::Test)
@@ -6180,6 +6185,7 @@ set(AETHER_SETTINGS_CONSUMERS
     amp_applet_test
     container_manager_test
     container_nesting_test
+    workspace_canvas_widget_test
     workspace_container_mode_test
     workspace_controller_test
     mini_pan_widget_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -605,6 +605,7 @@ set(CORE_SOURCES
     src/core/backends/MemoryWireCodec.cpp    # memory kv-set decode, shared by Flex + local bank
     src/core/backends/flex/FlexBackend.cpp   # aetherd RFC step 2.2 (§5.5)
     src/core/backends/sim/SimBackend.cpp     # demo mode — 2nd IRadioBackend (RFC #4288)
+    src/core/backends/sim/SimSignalSource.cpp  # demo RX engine, worker thread (#4878)
     src/core/backends/sim/SpectrumPatternGenerator.cpp  # demo mode — signal engine (RFC #4288 Phase 2)
     src/core/backends/sim/NoiseMixer.cpp                 # demo mode — audio engine (RFC #4288 Phase 2b)
     src/core/backends/hl2/MetisProtocol.cpp  # aetherd HL2 Phase 1a (HPSDR Protocol 1)
@@ -3625,6 +3626,19 @@ set_target_properties(workspace_controller_test PROPERTIES AUTOMOC ON)
 add_test(NAME workspace_controller_test COMMAND workspace_controller_test)
 set_tests_properties(workspace_controller_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
+# Demo RX engine on a worker thread (#4878) — the generator's thread affinity,
+# 24 kHz long-run pacing on a coarse timer, keyed-mute, stallscope, and queued
+# controls. Pure QObject + event loop; no widgets, no radio.
+add_executable(sim_signal_source_test
+    tests/sim_signal_source_test.cpp
+    src/core/backends/sim/SimSignalSource.cpp
+    src/core/backends/sim/NoiseMixer.cpp
+)
+target_include_directories(sim_signal_source_test PRIVATE src)
+target_link_libraries(sim_signal_source_test PRIVATE Qt6::Core Qt6::Test)
+set_target_properties(sim_signal_source_test PROPERTIES AUTOMOC ON)
+add_test(NAME sim_signal_source_test COMMAND sim_signal_source_test)
 
 # KiwiSDR band-recall re-bind policy (#4158) — header-only, pure logic.
 add_executable(kiwi_rebind_tracker_test tests/kiwi_rebind_tracker_test.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -872,6 +872,7 @@ set(GUI_SOURCES
     src/gui/MainWindow_SwrSweep.cpp
     src/gui/MainWindow_AetherClock.cpp
     src/gui/MainWindow_Wiring.cpp
+    src/gui/MainWindow_Workspace.cpp
     src/gui/MainWindow_Nets.cpp
     src/gui/MainWindow_Callsign.cpp
     src/gui/MainWindow_ReceiveSync.cpp
@@ -1004,6 +1005,7 @@ set(GUI_SOURCES
     src/gui/workspace/CanvasLayout.cpp
     src/gui/workspace/ClassicLayout.cpp
     src/gui/workspace/WorkspaceCanvas.cpp
+    src/gui/workspace/WorkspaceController.cpp
     src/gui/workspace/WorkspaceDocument.cpp
     src/gui/workspace/WorkspaceGeometry.cpp
     src/gui/workspace/WorkspaceMigration.cpp
@@ -3540,6 +3542,66 @@ target_include_directories(workspace_store_test PRIVATE src tests)
 target_link_libraries(workspace_store_test PRIVATE aethercore Qt6::Core Qt6::Test)
 set_target_properties(workspace_store_test PROPERTIES AUTOMOC ON)
 add_test(NAME workspace_store_test COMMAND workspace_store_test)
+
+# Workspace canvas (RFC #4887) phase 3 — DockMode::Canvas at the manager
+# level: slot-preserving detach/return, float-docks-first, the evictor
+# routing, width-cap lift (#3451 on canvas), and a stored "canvas" mode
+# restoring panel-docked.
+add_executable(workspace_container_mode_test
+    tests/workspace_container_mode_test.cpp
+    src/gui/FramelessResizer.cpp
+    src/gui/containers/ContainerManager.cpp
+    src/gui/containers/ContainerTitleBar.cpp
+    src/gui/containers/ContainerWidget.cpp
+    src/gui/containers/FloatingContainerWindow.cpp
+    ${AETHER_SETTINGS_SOURCES}
+    src/core/ThemeManager.cpp
+    src/core/ThemeSeedGenerated.cpp
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+)
+target_include_directories(workspace_container_mode_test PRIVATE src tests)
+target_link_libraries(workspace_container_mode_test PRIVATE
+    Qt6::Core Qt6::Widgets Qt6::Test
+)
+set_target_properties(workspace_container_mode_test PROPERTIES AUTOMOC ON)
+add_test(NAME workspace_container_mode_test COMMAND workspace_container_mode_test)
+set_tests_properties(workspace_container_mode_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
+# Workspace canvas (RFC #4887) phase 3 — the controller end to end: first
+# enable migrates and places, explicit returns forget the canvas home while
+# closes keep it, drops move/place through the canvas's real event path, and
+# an unusable store fails the enable without moving a widget.
+add_executable(workspace_controller_test
+    tests/workspace_controller_test.cpp
+    src/gui/FramelessResizer.cpp
+    src/gui/containers/ContainerManager.cpp
+    src/gui/containers/ContainerTitleBar.cpp
+    src/gui/containers/ContainerWidget.cpp
+    src/gui/containers/FloatingContainerWindow.cpp
+    src/gui/workspace/CanvasLayout.cpp
+    src/gui/workspace/ClassicLayout.cpp
+    src/gui/workspace/WorkspaceCanvas.cpp
+    src/gui/workspace/WorkspaceController.cpp
+    src/gui/workspace/WorkspaceDocument.cpp
+    src/gui/workspace/WorkspaceGeometry.cpp
+    src/gui/workspace/WorkspaceMigration.cpp
+    src/gui/workspace/WorkspaceStore.cpp
+    ${AETHER_SETTINGS_SOURCES}
+    src/core/ThemeManager.cpp
+    src/core/ThemeSeedGenerated.cpp
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+)
+target_include_directories(workspace_controller_test PRIVATE src tests)
+target_link_libraries(workspace_controller_test PRIVATE
+    Qt6::Core Qt6::Widgets Qt6::Test
+)
+set_target_properties(workspace_controller_test PROPERTIES AUTOMOC ON)
+add_test(NAME workspace_controller_test COMMAND workspace_controller_test)
+set_tests_properties(workspace_controller_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
 # KiwiSDR band-recall re-bind policy (#4158) — header-only, pure logic.
 add_executable(kiwi_rebind_tracker_test tests/kiwi_rebind_tracker_test.cpp)
@@ -6100,6 +6162,8 @@ set(AETHER_SETTINGS_CONSUMERS
     amp_applet_test
     container_manager_test
     container_nesting_test
+    workspace_container_mode_test
+    workspace_controller_test
     mini_pan_widget_test
     log_manager_filter_rules_test
     bandplan_voice_labels_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1002,6 +1002,7 @@ set(GUI_SOURCES
     src/gui/containers/ContainerTitleBar.cpp
     src/gui/containers/ContainerWidget.cpp
     src/gui/containers/FloatingContainerWindow.cpp
+    src/gui/workspace/CanvasInteraction.cpp
     src/gui/workspace/CanvasLayout.cpp
     src/gui/workspace/ClassicLayout.cpp
     src/gui/workspace/WorkspaceCanvas.cpp
@@ -3542,6 +3543,18 @@ target_include_directories(workspace_store_test PRIVATE src tests)
 target_link_libraries(workspace_store_test PRIVATE aethercore Qt6::Core Qt6::Test)
 set_target_properties(workspace_store_test PROPERTIES AUTOMOC ON)
 add_test(NAME workspace_store_test COMMAND workspace_store_test)
+
+# Workspace canvas (RFC #4887) phase 5 — the pure interaction core: hit
+# zones, anchored resize (the anchored edge must never move), and the snap
+# solver (snaps only the gripped edges, never below the minimum).
+add_executable(workspace_interaction_test
+    tests/workspace_interaction_test.cpp
+    src/gui/workspace/CanvasInteraction.cpp
+    src/gui/workspace/WorkspaceGeometry.cpp
+)
+target_include_directories(workspace_interaction_test PRIVATE src)
+target_link_libraries(workspace_interaction_test PRIVATE Qt6::Core Qt6::Gui)
+add_test(NAME workspace_interaction_test COMMAND workspace_interaction_test)
 
 # Workspace canvas (RFC #4887) phase 3 — DockMode::Canvas at the manager
 # level: slot-preserving detach/return, float-docks-first, the evictor

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1003,6 +1003,7 @@ set(GUI_SOURCES
     src/gui/containers/ContainerWidget.cpp
     src/gui/containers/FloatingContainerWindow.cpp
     src/gui/workspace/CanvasInteraction.cpp
+    src/gui/workspace/CanvasItemFrame.cpp
     src/gui/workspace/CanvasLayout.cpp
     src/gui/workspace/ClassicLayout.cpp
     src/gui/workspace/WorkspaceCanvas.cpp
@@ -3489,8 +3490,10 @@ add_test(NAME workspace_layout_test COMMAND workspace_layout_test)
 # ownership contract phase 3 depends on.
 add_executable(workspace_canvas_widget_test
     tests/workspace_canvas_widget_test.cpp
-    src/gui/workspace/WorkspaceCanvas.cpp
+    src/gui/workspace/CanvasInteraction.cpp
+    src/gui/workspace/CanvasItemFrame.cpp
     src/gui/workspace/CanvasLayout.cpp
+    src/gui/workspace/WorkspaceCanvas.cpp
     src/gui/workspace/WorkspaceGeometry.cpp
 )
 target_include_directories(workspace_canvas_widget_test PRIVATE src)
@@ -3593,6 +3596,8 @@ add_executable(workspace_controller_test
     src/gui/containers/ContainerTitleBar.cpp
     src/gui/containers/ContainerWidget.cpp
     src/gui/containers/FloatingContainerWindow.cpp
+    src/gui/workspace/CanvasInteraction.cpp
+    src/gui/workspace/CanvasItemFrame.cpp
     src/gui/workspace/CanvasLayout.cpp
     src/gui/workspace/ClassicLayout.cpp
     src/gui/workspace/WorkspaceCanvas.cpp

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -3181,7 +3181,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `sim` | — | sim <swr\|dropslice\|stallscope\|disconnect\|malformed\|clear> [arg] — |
 | `record` | — | record <start\|stop\|status\|path\|dir> [args] |
 | `testtone` | — | testtone <on\|off> [freqHz levelDb] |
-| `pan` | — | pan <create\|add\|remove\|close\|center\|rfgain> [value] |
+| `pan` | — | pan <create\|add\|remove\|close\|center\|rfgain\|float\|dock> [value] — |
 | `layout` | — | layout <rearrange <id>\|get> — splitter layout exerciser |
 | `scale` | — | scale [pct] — report/persist the UI scale factor |
 | `panmessage` | — | panmessage <add\|remove\|clear\|list> <pan> [id timeout [tone=…] title\|detail] |

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -3141,7 +3141,7 @@ lands.
 The complete registry, generated from the `add(...)` table in `AutomationServer.cpp` by `tools/gen_bridge_docs.py`. CI fails if this drifts from the code.
 
 <!-- BEGIN GENERATED VERB TABLE (tools/gen_bridge_docs.py) -->
-<!-- Do not edit by hand — run tools/gen_bridge_docs.py. 64 verbs. -->
+<!-- Do not edit by hand — run tools/gen_bridge_docs.py. 65 verbs. -->
 
 | Verb | Aliases | Description |
 |---|---|---|
@@ -3182,6 +3182,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `record` | — | record <start\|stop\|status\|path\|dir> [args] |
 | `testtone` | — | testtone <on\|off> [freqHz levelDb] |
 | `pan` | — | pan <create\|add\|remove\|close\|center\|rfgain\|float\|dock> [value] — |
+| `workspace` | — | workspace <status\|enable\|disable\|place <itemId> <x> <y> [w h]> — |
 | `layout` | — | layout <rearrange <id>\|get> — splitter layout exerciser |
 | `scale` | — | scale [pct] — report/persist the UI scale factor |
 | `panmessage` | — | panmessage <add\|remove\|clear\|list> <pan> [id timeout [tone=…] title\|detail] |

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -3182,7 +3182,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `record` | — | record <start\|stop\|status\|path\|dir> [args] |
 | `testtone` | — | testtone <on\|off> [freqHz levelDb] |
 | `pan` | — | pan <create\|add\|remove\|close\|center\|rfgain\|float\|dock> [value] — |
-| `workspace` | — | workspace <status\|enable\|disable\|place <itemId> <x> <y> [w h]> — |
+| `workspace` | — | workspace <status\|enable\|disable\|edit on\|off\|place <itemId> <x> <y> |
 | `layout` | — | layout <rearrange <id>\|get> — splitter layout exerciser |
 | `scale` | — | scale [pct] — report/persist the UI scale factor |
 | `panmessage` | — | panmessage <add\|remove\|clear\|list> <pan> [id timeout [tone=…] title\|detail] |

--- a/docs/theming/canvas-tokens.md
+++ b/docs/theming/canvas-tokens.md
@@ -1,0 +1,47 @@
+# Workspace canvas token namespace
+
+The workspace canvas (RFC #4887) carves its two painted surfaces out of the
+generic categories into a dedicated `color.canvas.*` namespace, following the
+pattern `slider-knob-tokens.md` established for controls.
+
+## Namespaces
+
+```
+color.canvas.background     ← the canvas surface, wherever items leave it exposed
+color.canvas.dots           ← the 1 px snap-grid intersection dots
+```
+
+## Defaults and their derivation
+
+| Token | Default Dark | Default Light | Derivation |
+|---|---|---|---|
+| `color.canvas.background` | `#08080d` | `#7b7b7c` | `color.background.app` darkened 50% (each channel halved: `#0f0f1a` → `#08080d`, `#f5f5f8` → `#7b7b7c`), so exposed canvas reads as a distinct working surface below the app background |
+| `color.canvas.dots` | `#50e6f0fa` | `#501a2a3a` | the theme's primary text colour at ~31% alpha (`0x50`), stored as `#AARRGGBB` |
+
+Both are literals rather than `{alias}` references: the background is a
+*derived* value with no matching primitive, and the dots need baked-in alpha,
+which alias references cannot add.
+
+## How they are consumed
+
+`WorkspaceCanvas` paints both with raw `QPainter` via
+`ThemeManager::color(widget, token)` — not `applyStyleSheet()` — and
+re-paints on `themeChanged`. The dots token is used **verbatim by both dot
+passes** (the always-on background pass and the drag-time overlay pass), so a
+theme controls the dots with one value; there is no per-pass alpha adjustment
+in code.
+
+## Fallback
+
+Both tokens are in the generated seed (`tools/gen_theme_seed.py`), so a user
+theme written before this namespace resolves to the Default Dark values
+rather than transparent — the same degradation the slider and toggle
+namespaces chose (#3184 established why transparent-on-missing is the worst
+outcome).
+
+## Not yet tokenised
+
+The selection frame, grips, and snap guides still paint from
+`QPalette::highlight()`; the item title bars keep their existing container
+styling. Carving those out is a follow-up pass in this document's namespace
+when the canvas chrome gets its theme treatment.

--- a/resources/themes/default-dark.json
+++ b/resources/themes/default-dark.json
@@ -5,280 +5,172 @@
   "version": "1.5",
   "description": "AetherSDR's original dark theme — v2 schema (primitives + nested scopes).  Semantic tokens resolve through a tailwind-style palette of shared colour primitives via {alias} references; the rendered output is bit-identical to v1.3.",
   "primitives": {
-    "color.blue.500": "#00b4d8",
-    "color.blue.300": "#00c8f0",
-    "color.blue.700": "#0070c0",
-    "color.red.500": "#ff4d4d",
+    "color.blue.500":  "#00b4d8",
+    "color.blue.300":  "#00c8f0",
+    "color.blue.700":  "#0070c0",
+    "color.red.500":   "#ff4d4d",
     "color.amber.500": "#ffb84d",
     "color.green.500": "#4dd87a",
-    "color.gray.50": "#e6f0fa",
-    "color.gray.200": "#c8d8e8",
-    "color.gray.400": "#8ea8c0",
-    "color.gray.500": "#506070",
-    "color.gray.600": "#3a4a5a",
-    "color.gray.700": "#304050",
-    "color.gray.800": "#1a2a3a",
-    "color.gray.850": "#1a2330",
-    "color.gray.900": "#0f0f1a",
-    "color.gray.950": "#000000"
+    "color.gray.50":   "#e6f0fa",
+    "color.gray.200":  "#c8d8e8",
+    "color.gray.400":  "#8ea8c0",
+    "color.gray.500":  "#506070",
+    "color.gray.600":  "#3a4a5a",
+    "color.gray.700":  "#304050",
+    "color.gray.800":  "#1a2a3a",
+    "color.gray.850":  "#1a2330",
+    "color.gray.900":  "#0f0f1a",
+    "color.gray.950":  "#000000"
   },
   "scopes": {
     "root": {
       "tokens": {
         "color": {
           "background": {
-            "0": "{color.gray.900}",
-            "1": "{color.gray.800}",
-            "2": "{color.gray.700}",
-            "3": "{color.gray.500}",
-            "tx": "#3a2a0e",
-            "success": "#006040",
-            "warning": "#5a3a0a",
+            "0":        "{color.gray.900}",
+            "1":        "{color.gray.800}",
+            "2":        "{color.gray.700}",
+            "3":        "{color.gray.500}",
+            "tx":       "#3a2a0e",
+            "success":  "#006040",
+            "warning":  "#5a3a0a",
             "spectrum": "{color.gray.950}",
-            "app": "{color.gray.900}"
+            "app":      "{color.gray.900}"
           },
           "canvas": {
             "background": "#08080d",
-            "dots": "#50e6f0fa"
+            "dots":       "#50e6f0fa"
           },
-          "accent": "{color.blue.500}",
-          "accent.bright": "{color.blue.300}",
-          "accent.dim": "{color.blue.700}",
+          "accent":         "{color.blue.500}",
+          "accent.bright":  "{color.blue.300}",
+          "accent.dim":     "{color.blue.700}",
           "accent.warning": "{color.amber.500}",
-          "accent.danger": "{color.red.500}",
+          "accent.danger":  "{color.red.500}",
           "accent.success": "{color.green.500}",
-          "waterfall.live": "{color.red.500}",
+          "waterfall.live":    "{color.red.500}",
           "waterfall.history": "{color.gray.500}",
-          "tx.mox.border": "#d08020",
-          "tx.mox.text": "#f0c890",
+          "tx.mox.border":       "#d08020",
+          "tx.mox.text":         "#f0c890",
           "tx.mox.border.hover": "#e09030",
-          "tx.mox.text.hover": "#ffd8a0",
+          "tx.mox.text.hover":   "#ffd8a0",
           "text": {
-            "primary": "{color.gray.200}",
+            "primary":   "{color.gray.200}",
             "secondary": "{color.gray.400}",
-            "label": "{color.gray.500}",
-            "disabled": "{color.gray.600}"
+            "label":     "{color.gray.500}",
+            "disabled":  "{color.gray.600}"
           },
           "border": {
             "subtle": "{color.gray.850}",
             "strong": "#2a3a4d",
             "accent": "{color.blue.500}",
-            "tx": "#5a4a28"
+            "tx":     "#5a4a28"
           },
           "meter": {
-            "crst": "{color.red.500}",
-            "rms": "{color.blue.500}",
+            "crst":   "{color.red.500}",
+            "rms":    "{color.blue.500}",
             "thresh": "{color.amber.500}",
-            "peak": "{color.gray.50}",
+            "peak":   "{color.gray.50}",
             "gainReduction": "#f2c14e",
             "pivot.fill": "#050509",
-            "pivot.rim": "#3a3e48",
+            "pivot.rim":  "#3a3e48",
             "pivot.glow": "#ffb060",
             "bar.fill": "#405060",
             "bar.fillGradient": {
               "type": "linear-gradient",
               "angle": 0,
               "stops": [
-                {
-                  "at": 0.0,
-                  "color": "#2f9e6a"
-                },
-                {
-                  "at": 0.55,
-                  "color": "#6cc56a"
-                },
-                {
-                  "at": 0.8,
-                  "color": "#e8b94c"
-                },
-                {
-                  "at": 0.95,
-                  "color": "#e8553c"
-                },
-                {
-                  "at": 1.0,
-                  "color": "#f2362a"
-                }
+                { "at": 0.00, "color": "#2f9e6a" },
+                { "at": 0.55, "color": "#6cc56a" },
+                { "at": 0.80, "color": "#e8b94c" },
+                { "at": 0.95, "color": "#e8553c" },
+                { "at": 1.00, "color": "#f2362a" }
               ]
             }
           },
           "spectrum": {
-            "trace": "{color.blue.500}",
+            "trace":    "{color.blue.500}",
             "peakHold": "{color.amber.500}",
-            "average": "{color.gray.400}",
-            "grid": "{color.gray.850}"
+            "average":  "{color.gray.400}",
+            "grid":     "{color.gray.850}"
           },
           "waterfall.colormap": {
             "default": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                {
-                  "at": 0.0,
-                  "color": "#000000"
-                },
-                {
-                  "at": 0.15,
-                  "color": "#000080"
-                },
-                {
-                  "at": 0.3,
-                  "color": "#0040ff"
-                },
-                {
-                  "at": 0.45,
-                  "color": "#00c8ff"
-                },
-                {
-                  "at": 0.6,
-                  "color": "#00dc00"
-                },
-                {
-                  "at": 0.8,
-                  "color": "#ffff00"
-                },
-                {
-                  "at": 1.0,
-                  "color": "#ff0000"
-                }
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.15, "color": "#000080" },
+                { "at": 0.30, "color": "#0040ff" },
+                { "at": 0.45, "color": "#00c8ff" },
+                { "at": 0.60, "color": "#00dc00" },
+                { "at": 0.80, "color": "#ffff00" },
+                { "at": 1.00, "color": "#ff0000" }
               ]
             },
             "grayscale": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                {
-                  "at": 0.0,
-                  "color": "#000000"
-                },
-                {
-                  "at": 1.0,
-                  "color": "#ffffff"
-                }
+                { "at": 0.00, "color": "#000000" },
+                { "at": 1.00, "color": "#ffffff" }
               ]
             },
             "blueGreen": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                {
-                  "at": 0.0,
-                  "color": "#000000"
-                },
-                {
-                  "at": 0.25,
-                  "color": "#001e78"
-                },
-                {
-                  "at": 0.5,
-                  "color": "#0064b4"
-                },
-                {
-                  "at": 0.75,
-                  "color": "#00c882"
-                },
-                {
-                  "at": 1.0,
-                  "color": "#dcffdc"
-                }
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.25, "color": "#001e78" },
+                { "at": 0.50, "color": "#0064b4" },
+                { "at": 0.75, "color": "#00c882" },
+                { "at": 1.00, "color": "#dcffdc" }
               ]
             },
             "fire": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                {
-                  "at": 0.0,
-                  "color": "#000000"
-                },
-                {
-                  "at": 0.25,
-                  "color": "#800000"
-                },
-                {
-                  "at": 0.5,
-                  "color": "#dc5000"
-                },
-                {
-                  "at": 0.75,
-                  "color": "#ffc800"
-                },
-                {
-                  "at": 1.0,
-                  "color": "#ffffdc"
-                }
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.25, "color": "#800000" },
+                { "at": 0.50, "color": "#dc5000" },
+                { "at": 0.75, "color": "#ffc800" },
+                { "at": 1.00, "color": "#ffffdc" }
               ]
             },
             "plasma": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                {
-                  "at": 0.0,
-                  "color": "#000000"
-                },
-                {
-                  "at": 0.25,
-                  "color": "#50008c"
-                },
-                {
-                  "at": 0.5,
-                  "color": "#c80078"
-                },
-                {
-                  "at": 0.75,
-                  "color": "#f07800"
-                },
-                {
-                  "at": 1.0,
-                  "color": "#ffff50"
-                }
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.25, "color": "#50008c" },
+                { "at": 0.50, "color": "#c80078" },
+                { "at": 0.75, "color": "#f07800" },
+                { "at": 1.00, "color": "#ffff50" }
               ]
             },
             "purple": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                {
-                  "at": 0.0,
-                  "color": "#000000"
-                },
-                {
-                  "at": 0.15,
-                  "color": "#0000ff"
-                },
-                {
-                  "at": 0.3,
-                  "color": "#00ff00"
-                },
-                {
-                  "at": 0.45,
-                  "color": "#ffff00"
-                },
-                {
-                  "at": 0.6,
-                  "color": "#ff0000"
-                },
-                {
-                  "at": 0.75,
-                  "color": "#800080"
-                },
-                {
-                  "at": 1.0,
-                  "color": "#ffffff"
-                }
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.15, "color": "#0000ff" },
+                { "at": 0.30, "color": "#00ff00" },
+                { "at": 0.45, "color": "#ffff00" },
+                { "at": 0.60, "color": "#ff0000" },
+                { "at": 0.75, "color": "#800080" },
+                { "at": 1.00, "color": "#ffffff" }
               ]
             }
           },
           "slice": {
-            "a": "#00d4ff",
-            "b": "#ff40ff",
-            "c": "#40ff40",
-            "d": "#ffff00",
-            "e": "#ffa000",
-            "f": "#00e0c0",
-            "g": "#ff6080",
-            "h": "#b080ff",
+            "a":  "#00d4ff",
+            "b":  "#ff40ff",
+            "c":  "#40ff40",
+            "d":  "#ffff00",
+            "e":  "#ffa000",
+            "f":  "#00e0c0",
+            "g":  "#ff6080",
+            "h":  "#b080ff",
             "tx": "{color.red.500}",
             "dim": {
               "a": "#006080",
@@ -292,102 +184,74 @@
             }
           },
           "slider": {
-            "background": "{color.gray.800}",
-            "foreground": "{color.blue.500}",
-            "handle": "{color.gray.200}",
+            "background":          "{color.gray.800}",
+            "foreground":          "{color.blue.500}",
+            "handle":              "{color.gray.200}",
             "background.disabled": "{color.gray.850}",
             "foreground.disabled": "{color.gray.600}",
-            "handle.disabled": "{color.gray.500}"
+            "handle.disabled":     "{color.gray.500}"
           },
           "knob": {
-            "background": "{color.gray.800}",
-            "foreground": "{color.blue.700}",
-            "handle": "{color.gray.200}",
+            "background":          "{color.gray.800}",
+            "foreground":          "{color.blue.700}",
+            "handle":              "{color.gray.200}",
             "background.disabled": "{color.gray.850}",
             "foreground.disabled": "{color.gray.600}",
-            "handle.disabled": "{color.gray.500}"
+            "handle.disabled":     "{color.gray.500}"
           },
           "toggle": {
-            "background": "{color.gray.800}",
-            "foreground": "{color.gray.200}",
-            "border": "{color.gray.700}",
+            "background":          "{color.gray.800}",
+            "foreground":          "{color.gray.200}",
+            "border":              "{color.gray.700}",
             "background.disabled": "{color.gray.900}",
             "foreground.disabled": "{color.gray.600}",
-            "border.disabled": "{color.gray.900}",
-            "accent.background.checked": "{color.blue.700}",
-            "accent.foreground.checked": "{color.blue.500}",
-            "accent.border.checked": "{color.blue.500}",
+            "border.disabled":     "{color.gray.900}",
+            "accent.background.checked":  "{color.blue.700}",
+            "accent.foreground.checked":  "{color.blue.500}",
+            "accent.border.checked":      "{color.blue.500}",
             "success.background.checked": "#006040",
             "success.foreground.checked": "{color.green.500}",
-            "success.border.checked": "{color.green.500}",
+            "success.border.checked":     "{color.green.500}",
             "warning.background.checked": "#5a3a0a",
             "warning.foreground.checked": "{color.amber.500}",
-            "warning.border.checked": "{color.amber.500}"
+            "warning.border.checked":     "{color.amber.500}"
           },
           "highlight": {
-            "tx": "#fc4500",
-            "rx": "#379baf",
+            "tx":      "#fc4500",
+            "rx":      "#379baf",
             "message": "#e58be5",
-            "fg": "#000000"
+            "fg":      "#000000"
           },
           "button": {
-            "background.disabled": "#203040",
-            "foreground.disabled": "{color.gray.500}",
-            "border.disabled": "{color.gray.700}",
+            "background.disabled":        "#203040",
+            "foreground.disabled":        "{color.gray.500}",
+            "border.disabled":            "{color.gray.700}",
             "danger.background.disabled": "#2a1818",
             "danger.foreground.disabled": "#8a6055",
-            "danger.border.disabled": "#4a2828"
+            "danger.border.disabled":     "#4a2828"
           }
         },
         "font": {
           "family": {
-            "ui": {
-              "family": "Inter",
-              "size": 12,
-              "color": "#c8d8e8"
-            },
-            "mono": {
-              "family": "monospace",
-              "size": 12,
-              "color": "#c8d8e8"
-            },
-            "segment7": {
-              "family": "DSEG7 Modern",
-              "size": 14,
-              "color": "#00b4d8"
-            },
-            "segment14": {
-              "family": "DSEG14 Modern",
-              "size": 14,
-              "color": "#00b4d8"
-            },
-            "weather": {
-              "family": "DSEGWeather",
-              "size": 14,
-              "color": "#c8d8e8"
-            },
-            "freq": {
-              "family": "DSEG7 Modern",
-              "size": 20,
-              "color": "#00b4d8"
-            },
-            "temp": {
-              "family": "DSEG7 Modern",
-              "size": 12,
-              "color": "#8ea8c0"
-            }
+            "ui":         { "family": "Inter",         "size": 12, "color": "#c8d8e8" },
+            "mono":       { "family": "monospace",     "size": 12, "color": "#c8d8e8" },
+            "segment7":   { "family": "DSEG7 Modern",  "size": 14, "color": "#00b4d8" },
+            "segment14":  { "family": "DSEG14 Modern", "size": 14, "color": "#00b4d8" },
+            "weather":    { "family": "DSEGWeather",   "size": 14, "color": "#c8d8e8" },
+            "freq":       { "family": "DSEG7 Modern",  "size": 20, "color": "#00b4d8" },
+            "temp":       { "family": "DSEG7 Modern",  "size": 12, "color": "#8ea8c0" }
           },
           "size": {
-            "tiny": 9,
-            "small": 10,
+            "tiny":   9,
+            "small":  10,
             "normal": 12,
-            "large": 14
+            "large":  14
           }
         },
         "sizing": {
           "panel": {
-            "padding": 4,
-            "spacing": 4,
+            "padding":      4,
+            "spacing":      4,
             "cornerRadius": 4
           },
           "border": {
@@ -402,22 +266,22 @@
           "scopes": {
             "tx": {
               "tokens": {
-                "color.slider.foreground": "{color.red.500}",
-                "color.knob.foreground": "{color.red.500}",
+                "color.slider.foreground":                "{color.red.500}",
+                "color.knob.foreground":                  "{color.red.500}",
                 "color.toggle.accent.background.checked": "{color.red.500}"
               }
             },
             "rx": {
               "tokens": {
-                "color.slider.foreground": "{color.green.500}",
-                "color.knob.foreground": "{color.green.500}",
+                "color.slider.foreground":                "{color.green.500}",
+                "color.knob.foreground":                  "{color.green.500}",
                 "color.toggle.accent.background.checked": "{color.green.500}"
               }
             },
             "comp": {
               "tokens": {
-                "color.slider.foreground": "{color.amber.500}",
-                "color.knob.foreground": "{color.amber.500}",
+                "color.slider.foreground":                "{color.amber.500}",
+                "color.knob.foreground":                  "{color.amber.500}",
                 "color.toggle.accent.background.checked": "{color.amber.500}"
               }
             }

--- a/resources/themes/default-dark.json
+++ b/resources/themes/default-dark.json
@@ -5,168 +5,280 @@
   "version": "1.5",
   "description": "AetherSDR's original dark theme — v2 schema (primitives + nested scopes).  Semantic tokens resolve through a tailwind-style palette of shared colour primitives via {alias} references; the rendered output is bit-identical to v1.3.",
   "primitives": {
-    "color.blue.500":  "#00b4d8",
-    "color.blue.300":  "#00c8f0",
-    "color.blue.700":  "#0070c0",
-    "color.red.500":   "#ff4d4d",
+    "color.blue.500": "#00b4d8",
+    "color.blue.300": "#00c8f0",
+    "color.blue.700": "#0070c0",
+    "color.red.500": "#ff4d4d",
     "color.amber.500": "#ffb84d",
     "color.green.500": "#4dd87a",
-    "color.gray.50":   "#e6f0fa",
-    "color.gray.200":  "#c8d8e8",
-    "color.gray.400":  "#8ea8c0",
-    "color.gray.500":  "#506070",
-    "color.gray.600":  "#3a4a5a",
-    "color.gray.700":  "#304050",
-    "color.gray.800":  "#1a2a3a",
-    "color.gray.850":  "#1a2330",
-    "color.gray.900":  "#0f0f1a",
-    "color.gray.950":  "#000000"
+    "color.gray.50": "#e6f0fa",
+    "color.gray.200": "#c8d8e8",
+    "color.gray.400": "#8ea8c0",
+    "color.gray.500": "#506070",
+    "color.gray.600": "#3a4a5a",
+    "color.gray.700": "#304050",
+    "color.gray.800": "#1a2a3a",
+    "color.gray.850": "#1a2330",
+    "color.gray.900": "#0f0f1a",
+    "color.gray.950": "#000000"
   },
   "scopes": {
     "root": {
       "tokens": {
         "color": {
           "background": {
-            "0":        "{color.gray.900}",
-            "1":        "{color.gray.800}",
-            "2":        "{color.gray.700}",
-            "3":        "{color.gray.500}",
-            "tx":       "#3a2a0e",
-            "success":  "#006040",
-            "warning":  "#5a3a0a",
+            "0": "{color.gray.900}",
+            "1": "{color.gray.800}",
+            "2": "{color.gray.700}",
+            "3": "{color.gray.500}",
+            "tx": "#3a2a0e",
+            "success": "#006040",
+            "warning": "#5a3a0a",
             "spectrum": "{color.gray.950}",
-            "app":      "{color.gray.900}"
+            "app": "{color.gray.900}"
           },
-          "accent":         "{color.blue.500}",
-          "accent.bright":  "{color.blue.300}",
-          "accent.dim":     "{color.blue.700}",
+          "canvas": {
+            "background": "#08080d",
+            "dots": "#50e6f0fa"
+          },
+          "accent": "{color.blue.500}",
+          "accent.bright": "{color.blue.300}",
+          "accent.dim": "{color.blue.700}",
           "accent.warning": "{color.amber.500}",
-          "accent.danger":  "{color.red.500}",
+          "accent.danger": "{color.red.500}",
           "accent.success": "{color.green.500}",
-          "waterfall.live":    "{color.red.500}",
+          "waterfall.live": "{color.red.500}",
           "waterfall.history": "{color.gray.500}",
-          "tx.mox.border":       "#d08020",
-          "tx.mox.text":         "#f0c890",
+          "tx.mox.border": "#d08020",
+          "tx.mox.text": "#f0c890",
           "tx.mox.border.hover": "#e09030",
-          "tx.mox.text.hover":   "#ffd8a0",
+          "tx.mox.text.hover": "#ffd8a0",
           "text": {
-            "primary":   "{color.gray.200}",
+            "primary": "{color.gray.200}",
             "secondary": "{color.gray.400}",
-            "label":     "{color.gray.500}",
-            "disabled":  "{color.gray.600}"
+            "label": "{color.gray.500}",
+            "disabled": "{color.gray.600}"
           },
           "border": {
             "subtle": "{color.gray.850}",
             "strong": "#2a3a4d",
             "accent": "{color.blue.500}",
-            "tx":     "#5a4a28"
+            "tx": "#5a4a28"
           },
           "meter": {
-            "crst":   "{color.red.500}",
-            "rms":    "{color.blue.500}",
+            "crst": "{color.red.500}",
+            "rms": "{color.blue.500}",
             "thresh": "{color.amber.500}",
-            "peak":   "{color.gray.50}",
+            "peak": "{color.gray.50}",
             "gainReduction": "#f2c14e",
             "pivot.fill": "#050509",
-            "pivot.rim":  "#3a3e48",
+            "pivot.rim": "#3a3e48",
             "pivot.glow": "#ffb060",
             "bar.fill": "#405060",
             "bar.fillGradient": {
               "type": "linear-gradient",
               "angle": 0,
               "stops": [
-                { "at": 0.00, "color": "#2f9e6a" },
-                { "at": 0.55, "color": "#6cc56a" },
-                { "at": 0.80, "color": "#e8b94c" },
-                { "at": 0.95, "color": "#e8553c" },
-                { "at": 1.00, "color": "#f2362a" }
+                {
+                  "at": 0.0,
+                  "color": "#2f9e6a"
+                },
+                {
+                  "at": 0.55,
+                  "color": "#6cc56a"
+                },
+                {
+                  "at": 0.8,
+                  "color": "#e8b94c"
+                },
+                {
+                  "at": 0.95,
+                  "color": "#e8553c"
+                },
+                {
+                  "at": 1.0,
+                  "color": "#f2362a"
+                }
               ]
             }
           },
           "spectrum": {
-            "trace":    "{color.blue.500}",
+            "trace": "{color.blue.500}",
             "peakHold": "{color.amber.500}",
-            "average":  "{color.gray.400}",
-            "grid":     "{color.gray.850}"
+            "average": "{color.gray.400}",
+            "grid": "{color.gray.850}"
           },
           "waterfall.colormap": {
             "default": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                { "at": 0.00, "color": "#000000" },
-                { "at": 0.15, "color": "#000080" },
-                { "at": 0.30, "color": "#0040ff" },
-                { "at": 0.45, "color": "#00c8ff" },
-                { "at": 0.60, "color": "#00dc00" },
-                { "at": 0.80, "color": "#ffff00" },
-                { "at": 1.00, "color": "#ff0000" }
+                {
+                  "at": 0.0,
+                  "color": "#000000"
+                },
+                {
+                  "at": 0.15,
+                  "color": "#000080"
+                },
+                {
+                  "at": 0.3,
+                  "color": "#0040ff"
+                },
+                {
+                  "at": 0.45,
+                  "color": "#00c8ff"
+                },
+                {
+                  "at": 0.6,
+                  "color": "#00dc00"
+                },
+                {
+                  "at": 0.8,
+                  "color": "#ffff00"
+                },
+                {
+                  "at": 1.0,
+                  "color": "#ff0000"
+                }
               ]
             },
             "grayscale": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                { "at": 0.00, "color": "#000000" },
-                { "at": 1.00, "color": "#ffffff" }
+                {
+                  "at": 0.0,
+                  "color": "#000000"
+                },
+                {
+                  "at": 1.0,
+                  "color": "#ffffff"
+                }
               ]
             },
             "blueGreen": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                { "at": 0.00, "color": "#000000" },
-                { "at": 0.25, "color": "#001e78" },
-                { "at": 0.50, "color": "#0064b4" },
-                { "at": 0.75, "color": "#00c882" },
-                { "at": 1.00, "color": "#dcffdc" }
+                {
+                  "at": 0.0,
+                  "color": "#000000"
+                },
+                {
+                  "at": 0.25,
+                  "color": "#001e78"
+                },
+                {
+                  "at": 0.5,
+                  "color": "#0064b4"
+                },
+                {
+                  "at": 0.75,
+                  "color": "#00c882"
+                },
+                {
+                  "at": 1.0,
+                  "color": "#dcffdc"
+                }
               ]
             },
             "fire": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                { "at": 0.00, "color": "#000000" },
-                { "at": 0.25, "color": "#800000" },
-                { "at": 0.50, "color": "#dc5000" },
-                { "at": 0.75, "color": "#ffc800" },
-                { "at": 1.00, "color": "#ffffdc" }
+                {
+                  "at": 0.0,
+                  "color": "#000000"
+                },
+                {
+                  "at": 0.25,
+                  "color": "#800000"
+                },
+                {
+                  "at": 0.5,
+                  "color": "#dc5000"
+                },
+                {
+                  "at": 0.75,
+                  "color": "#ffc800"
+                },
+                {
+                  "at": 1.0,
+                  "color": "#ffffdc"
+                }
               ]
             },
             "plasma": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                { "at": 0.00, "color": "#000000" },
-                { "at": 0.25, "color": "#50008c" },
-                { "at": 0.50, "color": "#c80078" },
-                { "at": 0.75, "color": "#f07800" },
-                { "at": 1.00, "color": "#ffff50" }
+                {
+                  "at": 0.0,
+                  "color": "#000000"
+                },
+                {
+                  "at": 0.25,
+                  "color": "#50008c"
+                },
+                {
+                  "at": 0.5,
+                  "color": "#c80078"
+                },
+                {
+                  "at": 0.75,
+                  "color": "#f07800"
+                },
+                {
+                  "at": 1.0,
+                  "color": "#ffff50"
+                }
               ]
             },
             "purple": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                { "at": 0.00, "color": "#000000" },
-                { "at": 0.15, "color": "#0000ff" },
-                { "at": 0.30, "color": "#00ff00" },
-                { "at": 0.45, "color": "#ffff00" },
-                { "at": 0.60, "color": "#ff0000" },
-                { "at": 0.75, "color": "#800080" },
-                { "at": 1.00, "color": "#ffffff" }
+                {
+                  "at": 0.0,
+                  "color": "#000000"
+                },
+                {
+                  "at": 0.15,
+                  "color": "#0000ff"
+                },
+                {
+                  "at": 0.3,
+                  "color": "#00ff00"
+                },
+                {
+                  "at": 0.45,
+                  "color": "#ffff00"
+                },
+                {
+                  "at": 0.6,
+                  "color": "#ff0000"
+                },
+                {
+                  "at": 0.75,
+                  "color": "#800080"
+                },
+                {
+                  "at": 1.0,
+                  "color": "#ffffff"
+                }
               ]
             }
           },
           "slice": {
-            "a":  "#00d4ff",
-            "b":  "#ff40ff",
-            "c":  "#40ff40",
-            "d":  "#ffff00",
-            "e":  "#ffa000",
-            "f":  "#00e0c0",
-            "g":  "#ff6080",
-            "h":  "#b080ff",
+            "a": "#00d4ff",
+            "b": "#ff40ff",
+            "c": "#40ff40",
+            "d": "#ffff00",
+            "e": "#ffa000",
+            "f": "#00e0c0",
+            "g": "#ff6080",
+            "h": "#b080ff",
             "tx": "{color.red.500}",
             "dim": {
               "a": "#006080",
@@ -180,74 +292,102 @@
             }
           },
           "slider": {
-            "background":          "{color.gray.800}",
-            "foreground":          "{color.blue.500}",
-            "handle":              "{color.gray.200}",
+            "background": "{color.gray.800}",
+            "foreground": "{color.blue.500}",
+            "handle": "{color.gray.200}",
             "background.disabled": "{color.gray.850}",
             "foreground.disabled": "{color.gray.600}",
-            "handle.disabled":     "{color.gray.500}"
+            "handle.disabled": "{color.gray.500}"
           },
           "knob": {
-            "background":          "{color.gray.800}",
-            "foreground":          "{color.blue.700}",
-            "handle":              "{color.gray.200}",
+            "background": "{color.gray.800}",
+            "foreground": "{color.blue.700}",
+            "handle": "{color.gray.200}",
             "background.disabled": "{color.gray.850}",
             "foreground.disabled": "{color.gray.600}",
-            "handle.disabled":     "{color.gray.500}"
+            "handle.disabled": "{color.gray.500}"
           },
           "toggle": {
-            "background":          "{color.gray.800}",
-            "foreground":          "{color.gray.200}",
-            "border":              "{color.gray.700}",
+            "background": "{color.gray.800}",
+            "foreground": "{color.gray.200}",
+            "border": "{color.gray.700}",
             "background.disabled": "{color.gray.900}",
             "foreground.disabled": "{color.gray.600}",
-            "border.disabled":     "{color.gray.900}",
-            "accent.background.checked":  "{color.blue.700}",
-            "accent.foreground.checked":  "{color.blue.500}",
-            "accent.border.checked":      "{color.blue.500}",
+            "border.disabled": "{color.gray.900}",
+            "accent.background.checked": "{color.blue.700}",
+            "accent.foreground.checked": "{color.blue.500}",
+            "accent.border.checked": "{color.blue.500}",
             "success.background.checked": "#006040",
             "success.foreground.checked": "{color.green.500}",
-            "success.border.checked":     "{color.green.500}",
+            "success.border.checked": "{color.green.500}",
             "warning.background.checked": "#5a3a0a",
             "warning.foreground.checked": "{color.amber.500}",
-            "warning.border.checked":     "{color.amber.500}"
+            "warning.border.checked": "{color.amber.500}"
           },
           "highlight": {
-            "tx":      "#fc4500",
-            "rx":      "#379baf",
+            "tx": "#fc4500",
+            "rx": "#379baf",
             "message": "#e58be5",
-            "fg":      "#000000"
+            "fg": "#000000"
           },
           "button": {
-            "background.disabled":        "#203040",
-            "foreground.disabled":        "{color.gray.500}",
-            "border.disabled":            "{color.gray.700}",
+            "background.disabled": "#203040",
+            "foreground.disabled": "{color.gray.500}",
+            "border.disabled": "{color.gray.700}",
             "danger.background.disabled": "#2a1818",
             "danger.foreground.disabled": "#8a6055",
-            "danger.border.disabled":     "#4a2828"
+            "danger.border.disabled": "#4a2828"
           }
         },
         "font": {
           "family": {
-            "ui":         { "family": "Inter",         "size": 12, "color": "#c8d8e8" },
-            "mono":       { "family": "monospace",     "size": 12, "color": "#c8d8e8" },
-            "segment7":   { "family": "DSEG7 Modern",  "size": 14, "color": "#00b4d8" },
-            "segment14":  { "family": "DSEG14 Modern", "size": 14, "color": "#00b4d8" },
-            "weather":    { "family": "DSEGWeather",   "size": 14, "color": "#c8d8e8" },
-            "freq":       { "family": "DSEG7 Modern",  "size": 20, "color": "#00b4d8" },
-            "temp":       { "family": "DSEG7 Modern",  "size": 12, "color": "#8ea8c0" }
+            "ui": {
+              "family": "Inter",
+              "size": 12,
+              "color": "#c8d8e8"
+            },
+            "mono": {
+              "family": "monospace",
+              "size": 12,
+              "color": "#c8d8e8"
+            },
+            "segment7": {
+              "family": "DSEG7 Modern",
+              "size": 14,
+              "color": "#00b4d8"
+            },
+            "segment14": {
+              "family": "DSEG14 Modern",
+              "size": 14,
+              "color": "#00b4d8"
+            },
+            "weather": {
+              "family": "DSEGWeather",
+              "size": 14,
+              "color": "#c8d8e8"
+            },
+            "freq": {
+              "family": "DSEG7 Modern",
+              "size": 20,
+              "color": "#00b4d8"
+            },
+            "temp": {
+              "family": "DSEG7 Modern",
+              "size": 12,
+              "color": "#8ea8c0"
+            }
           },
           "size": {
-            "tiny":   9,
-            "small":  10,
+            "tiny": 9,
+            "small": 10,
             "normal": 12,
-            "large":  14
+            "large": 14
           }
         },
         "sizing": {
           "panel": {
-            "padding":      4,
-            "spacing":      4,
+            "padding": 4,
+            "spacing": 4,
             "cornerRadius": 4
           },
           "border": {
@@ -262,22 +402,22 @@
           "scopes": {
             "tx": {
               "tokens": {
-                "color.slider.foreground":                "{color.red.500}",
-                "color.knob.foreground":                  "{color.red.500}",
+                "color.slider.foreground": "{color.red.500}",
+                "color.knob.foreground": "{color.red.500}",
                 "color.toggle.accent.background.checked": "{color.red.500}"
               }
             },
             "rx": {
               "tokens": {
-                "color.slider.foreground":                "{color.green.500}",
-                "color.knob.foreground":                  "{color.green.500}",
+                "color.slider.foreground": "{color.green.500}",
+                "color.knob.foreground": "{color.green.500}",
                 "color.toggle.accent.background.checked": "{color.green.500}"
               }
             },
             "comp": {
               "tokens": {
-                "color.slider.foreground":                "{color.amber.500}",
-                "color.knob.foreground":                  "{color.amber.500}",
+                "color.slider.foreground": "{color.amber.500}",
+                "color.knob.foreground": "{color.amber.500}",
                 "color.toggle.accent.background.checked": "{color.amber.500}"
               }
             }

--- a/resources/themes/default-light.json
+++ b/resources/themes/default-light.json
@@ -5,281 +5,173 @@
   "version": "1.2",
   "description": "AetherSDR's first light theme — v2 schema (primitives + nested scopes).  Semantic tokens resolve through a tailwind-style palette via {alias} references; rendered output is bit-identical to v1.0.",
   "primitives": {
-    "color.blue.500": "#0088b0",
-    "color.blue.300": "#0098c0",
-    "color.blue.700": "#005080",
-    "color.red.500": "#c02020",
+    "color.blue.500":  "#0088b0",
+    "color.blue.300":  "#0098c0",
+    "color.blue.700":  "#005080",
+    "color.red.500":   "#c02020",
     "color.amber.500": "#d08010",
     "color.green.500": "#1a8040",
-    "color.gray.50": "#1a2a3a",
-    "color.gray.100": "#506070",
-    "color.gray.300": "#7090a8",
-    "color.gray.400": "#90a0b0",
-    "color.gray.500": "#a0b0c0",
-    "color.gray.600": "#b0bcc8",
-    "color.gray.700": "#c0c8d0",
-    "color.gray.750": "#c8d2dc",
-    "color.gray.800": "#dde5ed",
-    "color.gray.900": "#f5f5f8",
-    "color.gray.950": "#ffffff"
+    "color.gray.50":   "#1a2a3a",
+    "color.gray.100":  "#506070",
+    "color.gray.300":  "#7090a8",
+    "color.gray.400":  "#90a0b0",
+    "color.gray.500":  "#a0b0c0",
+    "color.gray.600":  "#b0bcc8",
+    "color.gray.700":  "#c0c8d0",
+    "color.gray.750":  "#c8d2dc",
+    "color.gray.800":  "#dde5ed",
+    "color.gray.900":  "#f5f5f8",
+    "color.gray.950":  "#ffffff"
   },
   "scopes": {
     "root": {
       "tokens": {
         "color": {
           "background": {
-            "0": "{color.gray.900}",
-            "1": "{color.gray.800}",
-            "2": "{color.gray.750}",
-            "3": "{color.gray.600}",
-            "tx": "#ffeacc",
-            "success": "#c8e8d0",
-            "warning": "#f5e8d0",
+            "0":        "{color.gray.900}",
+            "1":        "{color.gray.800}",
+            "2":        "{color.gray.750}",
+            "3":        "{color.gray.600}",
+            "tx":       "#ffeacc",
+            "success":  "#c8e8d0",
+            "warning":  "#f5e8d0",
             "spectrum": "{color.gray.950}",
-            "app": "{color.gray.900}"
+            "app":      "{color.gray.900}"
           },
           "canvas": {
             "background": "#7b7b7c",
-            "dots": "#501a2a3a"
+            "dots":       "#501a2a3a"
           },
-          "accent": "{color.blue.500}",
-          "accent.bright": "{color.blue.300}",
-          "accent.dim": "{color.blue.700}",
+          "accent":         "{color.blue.500}",
+          "accent.bright":  "{color.blue.300}",
+          "accent.dim":     "{color.blue.700}",
           "accent.warning": "{color.amber.500}",
-          "accent.danger": "{color.red.500}",
+          "accent.danger":  "{color.red.500}",
           "accent.success": "{color.green.500}",
-          "waterfall.live": "{color.red.500}",
+          "waterfall.live":    "{color.red.500}",
           "waterfall.history": "{color.gray.300}",
-          "tx.mox.border": "#d08020",
-          "tx.mox.text": "#f0c890",
+          "tx.mox.border":       "#d08020",
+          "tx.mox.text":         "#f0c890",
           "tx.mox.border.hover": "#e09030",
-          "tx.mox.text.hover": "#ffd8a0",
+          "tx.mox.text.hover":   "#ffd8a0",
           "text": {
-            "primary": "{color.gray.50}",
+            "primary":   "{color.gray.50}",
             "secondary": "{color.gray.100}",
-            "label": "{color.gray.300}",
-            "disabled": "{color.gray.500}"
+            "label":     "{color.gray.300}",
+            "disabled":  "{color.gray.500}"
           },
           "border": {
             "subtle": "{color.gray.700}",
             "strong": "{color.gray.400}",
             "accent": "{color.blue.500}",
-            "tx": "#b08840"
+            "tx":     "#b08840"
           },
           "meter": {
-            "crst": "{color.red.500}",
-            "rms": "{color.blue.500}",
+            "crst":   "{color.red.500}",
+            "rms":    "{color.blue.500}",
             "thresh": "{color.amber.500}",
-            "peak": "{color.gray.50}",
+            "peak":   "{color.gray.50}",
             "gainReduction": "#a06010",
             "pivot.fill": "#14181c",
-            "pivot.rim": "#3a4250",
+            "pivot.rim":  "#3a4250",
             "pivot.glow": "#ff9a40",
             "bar.fill": "{color.gray.700}",
             "bar.fillGradient": {
               "type": "linear-gradient",
               "angle": 0,
               "stops": [
-                {
-                  "at": 0.0,
-                  "color": "#2f9e6a"
-                },
-                {
-                  "at": 0.55,
-                  "color": "#6cc56a"
-                },
-                {
-                  "at": 0.8,
-                  "color": "#e8b94c"
-                },
-                {
-                  "at": 0.95,
-                  "color": "#e8553c"
-                },
-                {
-                  "at": 1.0,
-                  "color": "#f2362a"
-                }
+                { "at": 0.00, "color": "#2f9e6a" },
+                { "at": 0.55, "color": "#6cc56a" },
+                { "at": 0.80, "color": "#e8b94c" },
+                { "at": 0.95, "color": "#e8553c" },
+                { "at": 1.00, "color": "#f2362a" }
               ]
             }
           },
           "spectrum": {
-            "trace": "{color.blue.500}",
+            "trace":    "{color.blue.500}",
             "peakHold": "#c08020",
-            "average": "{color.gray.100}",
-            "grid": "#d0d8e0"
+            "average":  "{color.gray.100}",
+            "grid":     "#d0d8e0"
           },
           "waterfall.colormap": {
             "default": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                {
-                  "at": 0.0,
-                  "color": "#000000"
-                },
-                {
-                  "at": 0.15,
-                  "color": "#000080"
-                },
-                {
-                  "at": 0.3,
-                  "color": "#0040ff"
-                },
-                {
-                  "at": 0.45,
-                  "color": "#00c8ff"
-                },
-                {
-                  "at": 0.6,
-                  "color": "#00dc00"
-                },
-                {
-                  "at": 0.8,
-                  "color": "#ffff00"
-                },
-                {
-                  "at": 1.0,
-                  "color": "#ff0000"
-                }
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.15, "color": "#000080" },
+                { "at": 0.30, "color": "#0040ff" },
+                { "at": 0.45, "color": "#00c8ff" },
+                { "at": 0.60, "color": "#00dc00" },
+                { "at": 0.80, "color": "#ffff00" },
+                { "at": 1.00, "color": "#ff0000" }
               ]
             },
             "grayscale": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                {
-                  "at": 0.0,
-                  "color": "#000000"
-                },
-                {
-                  "at": 1.0,
-                  "color": "#ffffff"
-                }
+                { "at": 0.00, "color": "#000000" },
+                { "at": 1.00, "color": "#ffffff" }
               ]
             },
             "blueGreen": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                {
-                  "at": 0.0,
-                  "color": "#000000"
-                },
-                {
-                  "at": 0.25,
-                  "color": "#001e78"
-                },
-                {
-                  "at": 0.5,
-                  "color": "#0064b4"
-                },
-                {
-                  "at": 0.75,
-                  "color": "#00c882"
-                },
-                {
-                  "at": 1.0,
-                  "color": "#dcffdc"
-                }
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.25, "color": "#001e78" },
+                { "at": 0.50, "color": "#0064b4" },
+                { "at": 0.75, "color": "#00c882" },
+                { "at": 1.00, "color": "#dcffdc" }
               ]
             },
             "fire": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                {
-                  "at": 0.0,
-                  "color": "#000000"
-                },
-                {
-                  "at": 0.25,
-                  "color": "#800000"
-                },
-                {
-                  "at": 0.5,
-                  "color": "#dc5000"
-                },
-                {
-                  "at": 0.75,
-                  "color": "#ffc800"
-                },
-                {
-                  "at": 1.0,
-                  "color": "#ffffdc"
-                }
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.25, "color": "#800000" },
+                { "at": 0.50, "color": "#dc5000" },
+                { "at": 0.75, "color": "#ffc800" },
+                { "at": 1.00, "color": "#ffffdc" }
               ]
             },
             "plasma": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                {
-                  "at": 0.0,
-                  "color": "#000000"
-                },
-                {
-                  "at": 0.25,
-                  "color": "#50008c"
-                },
-                {
-                  "at": 0.5,
-                  "color": "#c80078"
-                },
-                {
-                  "at": 0.75,
-                  "color": "#f07800"
-                },
-                {
-                  "at": 1.0,
-                  "color": "#ffff50"
-                }
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.25, "color": "#50008c" },
+                { "at": 0.50, "color": "#c80078" },
+                { "at": 0.75, "color": "#f07800" },
+                { "at": 1.00, "color": "#ffff50" }
               ]
             },
             "purple": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                {
-                  "at": 0.0,
-                  "color": "#000000"
-                },
-                {
-                  "at": 0.15,
-                  "color": "#0000ff"
-                },
-                {
-                  "at": 0.3,
-                  "color": "#00ff00"
-                },
-                {
-                  "at": 0.45,
-                  "color": "#ffff00"
-                },
-                {
-                  "at": 0.6,
-                  "color": "#ff0000"
-                },
-                {
-                  "at": 0.75,
-                  "color": "#800080"
-                },
-                {
-                  "at": 1.0,
-                  "color": "#ffffff"
-                }
+                { "at": 0.00, "color": "#000000" },
+                { "at": 0.15, "color": "#0000ff" },
+                { "at": 0.30, "color": "#00ff00" },
+                { "at": 0.45, "color": "#ffff00" },
+                { "at": 0.60, "color": "#ff0000" },
+                { "at": 0.75, "color": "#800080" },
+                { "at": 1.00, "color": "#ffffff" }
               ]
             }
           },
           "slice": {
-            "a": "{color.blue.500}",
-            "b": "#a020a0",
-            "c": "#208020",
-            "d": "#a08000",
-            "e": "#c06000",
-            "f": "#008070",
-            "g": "#a04060",
-            "h": "#604090",
+            "a":  "{color.blue.500}",
+            "b":  "#a020a0",
+            "c":  "#208020",
+            "d":  "#a08000",
+            "e":  "#c06000",
+            "f":  "#008070",
+            "g":  "#a04060",
+            "h":  "#604090",
             "tx": "{color.red.500}",
             "dim": {
               "a": "#a0c8e0",
@@ -293,102 +185,74 @@
             }
           },
           "slider": {
-            "background": "{color.gray.700}",
-            "foreground": "{color.blue.500}",
-            "handle": "{color.gray.50}",
+            "background":          "{color.gray.700}",
+            "foreground":          "{color.blue.500}",
+            "handle":              "{color.gray.50}",
             "background.disabled": "{color.gray.800}",
             "foreground.disabled": "{color.gray.500}",
-            "handle.disabled": "{color.gray.400}"
+            "handle.disabled":     "{color.gray.400}"
           },
           "knob": {
-            "background": "{color.gray.800}",
-            "foreground": "{color.blue.700}",
-            "handle": "{color.gray.50}",
+            "background":          "{color.gray.800}",
+            "foreground":          "{color.blue.700}",
+            "handle":              "{color.gray.50}",
             "background.disabled": "{color.gray.700}",
             "foreground.disabled": "{color.gray.500}",
-            "handle.disabled": "{color.gray.400}"
+            "handle.disabled":     "{color.gray.400}"
           },
           "toggle": {
-            "background": "{color.gray.800}",
-            "foreground": "{color.gray.50}",
-            "border": "{color.gray.750}",
+            "background":          "{color.gray.800}",
+            "foreground":          "{color.gray.50}",
+            "border":              "{color.gray.750}",
             "background.disabled": "{color.gray.900}",
             "foreground.disabled": "{color.gray.500}",
-            "border.disabled": "{color.gray.900}",
-            "accent.background.checked": "{color.blue.700}",
-            "accent.foreground.checked": "{color.blue.500}",
-            "accent.border.checked": "{color.blue.500}",
+            "border.disabled":     "{color.gray.900}",
+            "accent.background.checked":  "{color.blue.700}",
+            "accent.foreground.checked":  "{color.blue.500}",
+            "accent.border.checked":      "{color.blue.500}",
             "success.background.checked": "#c8e8d0",
             "success.foreground.checked": "{color.green.500}",
-            "success.border.checked": "{color.green.500}",
+            "success.border.checked":     "{color.green.500}",
             "warning.background.checked": "#f5e8d0",
             "warning.foreground.checked": "{color.amber.500}",
-            "warning.border.checked": "{color.amber.500}"
+            "warning.border.checked":     "{color.amber.500}"
           },
           "highlight": {
-            "tx": "#fc4500",
-            "rx": "#379baf",
+            "tx":      "#fc4500",
+            "rx":      "#379baf",
             "message": "#e58be5",
-            "fg": "#000000"
+            "fg":      "#000000"
           },
           "button": {
-            "background.disabled": "{color.gray.700}",
-            "foreground.disabled": "{color.gray.500}",
-            "border.disabled": "{color.gray.600}",
+            "background.disabled":        "{color.gray.700}",
+            "foreground.disabled":        "{color.gray.500}",
+            "border.disabled":            "{color.gray.600}",
             "danger.background.disabled": "#f0d8d8",
             "danger.foreground.disabled": "#b08080",
-            "danger.border.disabled": "#d0a8a8"
+            "danger.border.disabled":     "#d0a8a8"
           }
         },
         "font": {
           "family": {
-            "ui": {
-              "family": "Inter",
-              "size": 12,
-              "color": "#1a2a3a"
-            },
-            "mono": {
-              "family": "monospace",
-              "size": 12,
-              "color": "#1a2a3a"
-            },
-            "segment7": {
-              "family": "DSEG7 Modern",
-              "size": 14,
-              "color": "#0088b0"
-            },
-            "segment14": {
-              "family": "DSEG14 Modern",
-              "size": 14,
-              "color": "#0088b0"
-            },
-            "weather": {
-              "family": "DSEGWeather",
-              "size": 14,
-              "color": "#1a2a3a"
-            },
-            "freq": {
-              "family": "DSEG7 Modern",
-              "size": 26,
-              "color": "#0088b0"
-            },
-            "temp": {
-              "family": "DSEG7 Modern",
-              "size": 12,
-              "color": "#506070"
-            }
+            "ui":         { "family": "Inter",         "size": 12, "color": "#1a2a3a" },
+            "mono":       { "family": "monospace",     "size": 12, "color": "#1a2a3a" },
+            "segment7":   { "family": "DSEG7 Modern",  "size": 14, "color": "#0088b0" },
+            "segment14":  { "family": "DSEG14 Modern", "size": 14, "color": "#0088b0" },
+            "weather":    { "family": "DSEGWeather",   "size": 14, "color": "#1a2a3a" },
+            "freq":       { "family": "DSEG7 Modern",  "size": 26, "color": "#0088b0" },
+            "temp":       { "family": "DSEG7 Modern",  "size": 12, "color": "#506070" }
           },
           "size": {
-            "tiny": 9,
-            "small": 10,
+            "tiny":   9,
+            "small":  10,
             "normal": 12,
-            "large": 14
+            "large":  14
           }
         },
         "sizing": {
           "panel": {
-            "padding": 4,
-            "spacing": 4,
+            "padding":      4,
+            "spacing":      4,
             "cornerRadius": 4
           },
           "border": {
@@ -403,22 +267,22 @@
           "scopes": {
             "tx": {
               "tokens": {
-                "color.slider.foreground": "{color.red.500}",
-                "color.knob.foreground": "{color.red.500}",
+                "color.slider.foreground":                "{color.red.500}",
+                "color.knob.foreground":                  "{color.red.500}",
                 "color.toggle.accent.background.checked": "{color.red.500}"
               }
             },
             "rx": {
               "tokens": {
-                "color.slider.foreground": "{color.green.500}",
-                "color.knob.foreground": "{color.green.500}",
+                "color.slider.foreground":                "{color.green.500}",
+                "color.knob.foreground":                  "{color.green.500}",
                 "color.toggle.accent.background.checked": "{color.green.500}"
               }
             },
             "comp": {
               "tokens": {
-                "color.slider.foreground": "{color.amber.500}",
-                "color.knob.foreground": "{color.amber.500}",
+                "color.slider.foreground":                "{color.amber.500}",
+                "color.knob.foreground":                  "{color.amber.500}",
                 "color.toggle.accent.background.checked": "{color.amber.500}"
               }
             }

--- a/resources/themes/default-light.json
+++ b/resources/themes/default-light.json
@@ -5,169 +5,281 @@
   "version": "1.2",
   "description": "AetherSDR's first light theme — v2 schema (primitives + nested scopes).  Semantic tokens resolve through a tailwind-style palette via {alias} references; rendered output is bit-identical to v1.0.",
   "primitives": {
-    "color.blue.500":  "#0088b0",
-    "color.blue.300":  "#0098c0",
-    "color.blue.700":  "#005080",
-    "color.red.500":   "#c02020",
+    "color.blue.500": "#0088b0",
+    "color.blue.300": "#0098c0",
+    "color.blue.700": "#005080",
+    "color.red.500": "#c02020",
     "color.amber.500": "#d08010",
     "color.green.500": "#1a8040",
-    "color.gray.50":   "#1a2a3a",
-    "color.gray.100":  "#506070",
-    "color.gray.300":  "#7090a8",
-    "color.gray.400":  "#90a0b0",
-    "color.gray.500":  "#a0b0c0",
-    "color.gray.600":  "#b0bcc8",
-    "color.gray.700":  "#c0c8d0",
-    "color.gray.750":  "#c8d2dc",
-    "color.gray.800":  "#dde5ed",
-    "color.gray.900":  "#f5f5f8",
-    "color.gray.950":  "#ffffff"
+    "color.gray.50": "#1a2a3a",
+    "color.gray.100": "#506070",
+    "color.gray.300": "#7090a8",
+    "color.gray.400": "#90a0b0",
+    "color.gray.500": "#a0b0c0",
+    "color.gray.600": "#b0bcc8",
+    "color.gray.700": "#c0c8d0",
+    "color.gray.750": "#c8d2dc",
+    "color.gray.800": "#dde5ed",
+    "color.gray.900": "#f5f5f8",
+    "color.gray.950": "#ffffff"
   },
   "scopes": {
     "root": {
       "tokens": {
         "color": {
           "background": {
-            "0":        "{color.gray.900}",
-            "1":        "{color.gray.800}",
-            "2":        "{color.gray.750}",
-            "3":        "{color.gray.600}",
-            "tx":       "#ffeacc",
-            "success":  "#c8e8d0",
-            "warning":  "#f5e8d0",
+            "0": "{color.gray.900}",
+            "1": "{color.gray.800}",
+            "2": "{color.gray.750}",
+            "3": "{color.gray.600}",
+            "tx": "#ffeacc",
+            "success": "#c8e8d0",
+            "warning": "#f5e8d0",
             "spectrum": "{color.gray.950}",
-            "app":      "{color.gray.900}"
+            "app": "{color.gray.900}"
           },
-          "accent":         "{color.blue.500}",
-          "accent.bright":  "{color.blue.300}",
-          "accent.dim":     "{color.blue.700}",
+          "canvas": {
+            "background": "#7b7b7c",
+            "dots": "#501a2a3a"
+          },
+          "accent": "{color.blue.500}",
+          "accent.bright": "{color.blue.300}",
+          "accent.dim": "{color.blue.700}",
           "accent.warning": "{color.amber.500}",
-          "accent.danger":  "{color.red.500}",
+          "accent.danger": "{color.red.500}",
           "accent.success": "{color.green.500}",
-          "waterfall.live":    "{color.red.500}",
+          "waterfall.live": "{color.red.500}",
           "waterfall.history": "{color.gray.300}",
-          "tx.mox.border":       "#d08020",
-          "tx.mox.text":         "#f0c890",
+          "tx.mox.border": "#d08020",
+          "tx.mox.text": "#f0c890",
           "tx.mox.border.hover": "#e09030",
-          "tx.mox.text.hover":   "#ffd8a0",
+          "tx.mox.text.hover": "#ffd8a0",
           "text": {
-            "primary":   "{color.gray.50}",
+            "primary": "{color.gray.50}",
             "secondary": "{color.gray.100}",
-            "label":     "{color.gray.300}",
-            "disabled":  "{color.gray.500}"
+            "label": "{color.gray.300}",
+            "disabled": "{color.gray.500}"
           },
           "border": {
             "subtle": "{color.gray.700}",
             "strong": "{color.gray.400}",
             "accent": "{color.blue.500}",
-            "tx":     "#b08840"
+            "tx": "#b08840"
           },
           "meter": {
-            "crst":   "{color.red.500}",
-            "rms":    "{color.blue.500}",
+            "crst": "{color.red.500}",
+            "rms": "{color.blue.500}",
             "thresh": "{color.amber.500}",
-            "peak":   "{color.gray.50}",
+            "peak": "{color.gray.50}",
             "gainReduction": "#a06010",
             "pivot.fill": "#14181c",
-            "pivot.rim":  "#3a4250",
+            "pivot.rim": "#3a4250",
             "pivot.glow": "#ff9a40",
             "bar.fill": "{color.gray.700}",
             "bar.fillGradient": {
               "type": "linear-gradient",
               "angle": 0,
               "stops": [
-                { "at": 0.00, "color": "#2f9e6a" },
-                { "at": 0.55, "color": "#6cc56a" },
-                { "at": 0.80, "color": "#e8b94c" },
-                { "at": 0.95, "color": "#e8553c" },
-                { "at": 1.00, "color": "#f2362a" }
+                {
+                  "at": 0.0,
+                  "color": "#2f9e6a"
+                },
+                {
+                  "at": 0.55,
+                  "color": "#6cc56a"
+                },
+                {
+                  "at": 0.8,
+                  "color": "#e8b94c"
+                },
+                {
+                  "at": 0.95,
+                  "color": "#e8553c"
+                },
+                {
+                  "at": 1.0,
+                  "color": "#f2362a"
+                }
               ]
             }
           },
           "spectrum": {
-            "trace":    "{color.blue.500}",
+            "trace": "{color.blue.500}",
             "peakHold": "#c08020",
-            "average":  "{color.gray.100}",
-            "grid":     "#d0d8e0"
+            "average": "{color.gray.100}",
+            "grid": "#d0d8e0"
           },
           "waterfall.colormap": {
             "default": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                { "at": 0.00, "color": "#000000" },
-                { "at": 0.15, "color": "#000080" },
-                { "at": 0.30, "color": "#0040ff" },
-                { "at": 0.45, "color": "#00c8ff" },
-                { "at": 0.60, "color": "#00dc00" },
-                { "at": 0.80, "color": "#ffff00" },
-                { "at": 1.00, "color": "#ff0000" }
+                {
+                  "at": 0.0,
+                  "color": "#000000"
+                },
+                {
+                  "at": 0.15,
+                  "color": "#000080"
+                },
+                {
+                  "at": 0.3,
+                  "color": "#0040ff"
+                },
+                {
+                  "at": 0.45,
+                  "color": "#00c8ff"
+                },
+                {
+                  "at": 0.6,
+                  "color": "#00dc00"
+                },
+                {
+                  "at": 0.8,
+                  "color": "#ffff00"
+                },
+                {
+                  "at": 1.0,
+                  "color": "#ff0000"
+                }
               ]
             },
             "grayscale": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                { "at": 0.00, "color": "#000000" },
-                { "at": 1.00, "color": "#ffffff" }
+                {
+                  "at": 0.0,
+                  "color": "#000000"
+                },
+                {
+                  "at": 1.0,
+                  "color": "#ffffff"
+                }
               ]
             },
             "blueGreen": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                { "at": 0.00, "color": "#000000" },
-                { "at": 0.25, "color": "#001e78" },
-                { "at": 0.50, "color": "#0064b4" },
-                { "at": 0.75, "color": "#00c882" },
-                { "at": 1.00, "color": "#dcffdc" }
+                {
+                  "at": 0.0,
+                  "color": "#000000"
+                },
+                {
+                  "at": 0.25,
+                  "color": "#001e78"
+                },
+                {
+                  "at": 0.5,
+                  "color": "#0064b4"
+                },
+                {
+                  "at": 0.75,
+                  "color": "#00c882"
+                },
+                {
+                  "at": 1.0,
+                  "color": "#dcffdc"
+                }
               ]
             },
             "fire": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                { "at": 0.00, "color": "#000000" },
-                { "at": 0.25, "color": "#800000" },
-                { "at": 0.50, "color": "#dc5000" },
-                { "at": 0.75, "color": "#ffc800" },
-                { "at": 1.00, "color": "#ffffdc" }
+                {
+                  "at": 0.0,
+                  "color": "#000000"
+                },
+                {
+                  "at": 0.25,
+                  "color": "#800000"
+                },
+                {
+                  "at": 0.5,
+                  "color": "#dc5000"
+                },
+                {
+                  "at": 0.75,
+                  "color": "#ffc800"
+                },
+                {
+                  "at": 1.0,
+                  "color": "#ffffdc"
+                }
               ]
             },
             "plasma": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                { "at": 0.00, "color": "#000000" },
-                { "at": 0.25, "color": "#50008c" },
-                { "at": 0.50, "color": "#c80078" },
-                { "at": 0.75, "color": "#f07800" },
-                { "at": 1.00, "color": "#ffff50" }
+                {
+                  "at": 0.0,
+                  "color": "#000000"
+                },
+                {
+                  "at": 0.25,
+                  "color": "#50008c"
+                },
+                {
+                  "at": 0.5,
+                  "color": "#c80078"
+                },
+                {
+                  "at": 0.75,
+                  "color": "#f07800"
+                },
+                {
+                  "at": 1.0,
+                  "color": "#ffff50"
+                }
               ]
             },
             "purple": {
               "type": "linear-gradient",
               "angle": 180,
               "stops": [
-                { "at": 0.00, "color": "#000000" },
-                { "at": 0.15, "color": "#0000ff" },
-                { "at": 0.30, "color": "#00ff00" },
-                { "at": 0.45, "color": "#ffff00" },
-                { "at": 0.60, "color": "#ff0000" },
-                { "at": 0.75, "color": "#800080" },
-                { "at": 1.00, "color": "#ffffff" }
+                {
+                  "at": 0.0,
+                  "color": "#000000"
+                },
+                {
+                  "at": 0.15,
+                  "color": "#0000ff"
+                },
+                {
+                  "at": 0.3,
+                  "color": "#00ff00"
+                },
+                {
+                  "at": 0.45,
+                  "color": "#ffff00"
+                },
+                {
+                  "at": 0.6,
+                  "color": "#ff0000"
+                },
+                {
+                  "at": 0.75,
+                  "color": "#800080"
+                },
+                {
+                  "at": 1.0,
+                  "color": "#ffffff"
+                }
               ]
             }
           },
           "slice": {
-            "a":  "{color.blue.500}",
-            "b":  "#a020a0",
-            "c":  "#208020",
-            "d":  "#a08000",
-            "e":  "#c06000",
-            "f":  "#008070",
-            "g":  "#a04060",
-            "h":  "#604090",
+            "a": "{color.blue.500}",
+            "b": "#a020a0",
+            "c": "#208020",
+            "d": "#a08000",
+            "e": "#c06000",
+            "f": "#008070",
+            "g": "#a04060",
+            "h": "#604090",
             "tx": "{color.red.500}",
             "dim": {
               "a": "#a0c8e0",
@@ -181,74 +293,102 @@
             }
           },
           "slider": {
-            "background":          "{color.gray.700}",
-            "foreground":          "{color.blue.500}",
-            "handle":              "{color.gray.50}",
+            "background": "{color.gray.700}",
+            "foreground": "{color.blue.500}",
+            "handle": "{color.gray.50}",
             "background.disabled": "{color.gray.800}",
             "foreground.disabled": "{color.gray.500}",
-            "handle.disabled":     "{color.gray.400}"
+            "handle.disabled": "{color.gray.400}"
           },
           "knob": {
-            "background":          "{color.gray.800}",
-            "foreground":          "{color.blue.700}",
-            "handle":              "{color.gray.50}",
+            "background": "{color.gray.800}",
+            "foreground": "{color.blue.700}",
+            "handle": "{color.gray.50}",
             "background.disabled": "{color.gray.700}",
             "foreground.disabled": "{color.gray.500}",
-            "handle.disabled":     "{color.gray.400}"
+            "handle.disabled": "{color.gray.400}"
           },
           "toggle": {
-            "background":          "{color.gray.800}",
-            "foreground":          "{color.gray.50}",
-            "border":              "{color.gray.750}",
+            "background": "{color.gray.800}",
+            "foreground": "{color.gray.50}",
+            "border": "{color.gray.750}",
             "background.disabled": "{color.gray.900}",
             "foreground.disabled": "{color.gray.500}",
-            "border.disabled":     "{color.gray.900}",
-            "accent.background.checked":  "{color.blue.700}",
-            "accent.foreground.checked":  "{color.blue.500}",
-            "accent.border.checked":      "{color.blue.500}",
+            "border.disabled": "{color.gray.900}",
+            "accent.background.checked": "{color.blue.700}",
+            "accent.foreground.checked": "{color.blue.500}",
+            "accent.border.checked": "{color.blue.500}",
             "success.background.checked": "#c8e8d0",
             "success.foreground.checked": "{color.green.500}",
-            "success.border.checked":     "{color.green.500}",
+            "success.border.checked": "{color.green.500}",
             "warning.background.checked": "#f5e8d0",
             "warning.foreground.checked": "{color.amber.500}",
-            "warning.border.checked":     "{color.amber.500}"
+            "warning.border.checked": "{color.amber.500}"
           },
           "highlight": {
-            "tx":      "#fc4500",
-            "rx":      "#379baf",
+            "tx": "#fc4500",
+            "rx": "#379baf",
             "message": "#e58be5",
-            "fg":      "#000000"
+            "fg": "#000000"
           },
           "button": {
-            "background.disabled":        "{color.gray.700}",
-            "foreground.disabled":        "{color.gray.500}",
-            "border.disabled":            "{color.gray.600}",
+            "background.disabled": "{color.gray.700}",
+            "foreground.disabled": "{color.gray.500}",
+            "border.disabled": "{color.gray.600}",
             "danger.background.disabled": "#f0d8d8",
             "danger.foreground.disabled": "#b08080",
-            "danger.border.disabled":     "#d0a8a8"
+            "danger.border.disabled": "#d0a8a8"
           }
         },
         "font": {
           "family": {
-            "ui":         { "family": "Inter",         "size": 12, "color": "#1a2a3a" },
-            "mono":       { "family": "monospace",     "size": 12, "color": "#1a2a3a" },
-            "segment7":   { "family": "DSEG7 Modern",  "size": 14, "color": "#0088b0" },
-            "segment14":  { "family": "DSEG14 Modern", "size": 14, "color": "#0088b0" },
-            "weather":    { "family": "DSEGWeather",   "size": 14, "color": "#1a2a3a" },
-            "freq":       { "family": "DSEG7 Modern",  "size": 26, "color": "#0088b0" },
-            "temp":       { "family": "DSEG7 Modern",  "size": 12, "color": "#506070" }
+            "ui": {
+              "family": "Inter",
+              "size": 12,
+              "color": "#1a2a3a"
+            },
+            "mono": {
+              "family": "monospace",
+              "size": 12,
+              "color": "#1a2a3a"
+            },
+            "segment7": {
+              "family": "DSEG7 Modern",
+              "size": 14,
+              "color": "#0088b0"
+            },
+            "segment14": {
+              "family": "DSEG14 Modern",
+              "size": 14,
+              "color": "#0088b0"
+            },
+            "weather": {
+              "family": "DSEGWeather",
+              "size": 14,
+              "color": "#1a2a3a"
+            },
+            "freq": {
+              "family": "DSEG7 Modern",
+              "size": 26,
+              "color": "#0088b0"
+            },
+            "temp": {
+              "family": "DSEG7 Modern",
+              "size": 12,
+              "color": "#506070"
+            }
           },
           "size": {
-            "tiny":   9,
-            "small":  10,
+            "tiny": 9,
+            "small": 10,
             "normal": 12,
-            "large":  14
+            "large": 14
           }
         },
         "sizing": {
           "panel": {
-            "padding":      4,
-            "spacing":      4,
+            "padding": 4,
+            "spacing": 4,
             "cornerRadius": 4
           },
           "border": {
@@ -263,22 +403,22 @@
           "scopes": {
             "tx": {
               "tokens": {
-                "color.slider.foreground":                "{color.red.500}",
-                "color.knob.foreground":                  "{color.red.500}",
+                "color.slider.foreground": "{color.red.500}",
+                "color.knob.foreground": "{color.red.500}",
                 "color.toggle.accent.background.checked": "{color.red.500}"
               }
             },
             "rx": {
               "tokens": {
-                "color.slider.foreground":                "{color.green.500}",
-                "color.knob.foreground":                  "{color.green.500}",
+                "color.slider.foreground": "{color.green.500}",
+                "color.knob.foreground": "{color.green.500}",
                 "color.toggle.accent.background.checked": "{color.green.500}"
               }
             },
             "comp": {
               "tokens": {
-                "color.slider.foreground":                "{color.amber.500}",
-                "color.knob.foreground":                  "{color.amber.500}",
+                "color.slider.foreground": "{color.amber.500}",
+                "color.knob.foreground": "{color.amber.500}",
                 "color.toggle.accent.background.checked": "{color.amber.500}"
               }
             }

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -23,6 +23,7 @@
 #include <QAction>
 #include <QLocalServer>
 #include <QScopeGuard>
+#include <QStatusBar>
 #include <QLocalSocket>
 #include <QApplication>
 #include <QScreen>
@@ -347,6 +348,15 @@ QJsonObject describeWidget(const QWidget* w)
     // restore / minimize without screenshotting, and prove the `window` verb
     // (resize only ever set explicit geometry, so an un-maximize was previously
     // unverifiable). (#3918)
+    // A QStatusBar's showMessage() text is otherwise unobservable from the
+    // tree — operator notices (e.g. the #4863 float-restore warning, or the
+    // canvas-unavailable message) could only be verified by screenshot
+    // (#4864, second gap).
+    if (const auto* sb = qobject_cast<const QStatusBar*>(w)) {
+        if (!sb->currentMessage().isEmpty())
+            o[QStringLiteral("statusMessage")] = sb->currentMessage();
+    }
+
     if (w->isWindow()) {
         const Qt::WindowStates st = w->windowState();
         const char* ws = "normal";
@@ -3063,12 +3073,14 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
         // was dropped and the two-argument form could never work — doPan()'s
         // rfgain branch already splits the joined value and handles both shapes,
         // so the handler was right and only the parser choice was wrong.
-        add("pan", {}, "pan <create|add|remove|close|center|rfgain> [value]",
+        add("pan", {},
+            "pan <create|add|remove|close|center|rfgain|float|dock> [value] — "
+            "float/dock drive PanadapterStack's real reparent path (#4864)",
             parseActionRest,
             [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
                 if (a.action.isEmpty())
                     return err(QStringLiteral(
-                        "pan requires an action (create|add|remove|close|center|rfgain)"));
+                        "pan requires an action (create|add|remove|close|center|rfgain|float|dock)"));
                 return s.doPan(a.action, a.value);
             });
 
@@ -9137,6 +9149,50 @@ QJsonObject AutomationServer::doPan(const QString& action, const QString& arg)
         return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("pan"), QStringLiteral("rfgain")},
                            {QStringLiteral("panId"), target},
                            {QStringLiteral("gain"), gain}, {QStringLiteral("requested"), true}};
+    }
+
+    if (action == QLatin1String("float") || action == QLatin1String("dock")) {
+        // `pan float <panId|index|active>` / `pan dock …` — the reparent +
+        // GPU re-initialize path (#2495/#4319/#4617) made drivable headlessly
+        // (#4864). The UI affordances are unreachable from the bridge: the
+        // per-pan float button hides in single-pan mode and the context-menu
+        // pop-out is a transient QMenu.
+        const QString a = arg.trimmed();
+        QString panId;
+        if (a.isEmpty() || a.compare(QLatin1String("active"), Qt::CaseInsensitive) == 0) {
+            if (const PanadapterModel* p = radio->activePanadapter())
+                panId = p->panId();
+        } else if (a.startsWith(QLatin1String("0x"), Qt::CaseInsensitive)) {
+            panId = a;
+        } else {
+            bool okIdx = false;
+            const int idx = a.toInt(&okIdx);
+            if (okIdx && idx >= 0 && idx < radio->panadapters().size())
+                panId = radio->panadapters().at(idx)->panId();
+        }
+        if (panId.isEmpty())
+            return err(QStringLiteral("pan %1: no panadapter to address (want "
+                                      "<panId|index|active>)").arg(action));
+
+        const QList<QWidget*> stacks =
+            findWidgetsByClass(QStringLiteral("PanadapterStack"));
+        if (stacks.isEmpty())
+            return err(QStringLiteral("no PanadapterStack found"));
+
+        QVariantMap snap;
+        if (!QMetaObject::invokeMethod(stacks.first(), "automationFloatDock",
+                                       Qt::DirectConnection,
+                                       Q_RETURN_ARG(QVariantMap, snap),
+                                       Q_ARG(QString, action),
+                                       Q_ARG(QString, panId))) {
+            return err(QStringLiteral("PanadapterStack::automationFloatDock failed"));
+        }
+        if (snap.contains(QStringLiteral("error")))
+            return err(snap.value(QStringLiteral("error")).toString());
+
+        QJsonObject out = QJsonObject::fromVariantMap(snap);
+        out[QStringLiteral("ok")] = true;
+        return out;
     }
 
     if (action == QLatin1String("close") || action == QLatin1String("remove")) {

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -3084,6 +3084,34 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
                 return s.doPan(a.action, a.value);
             });
 
+        add("workspace", {},
+            "workspace <status|enable|disable|place <itemId> <x> <y> [w h]> — "
+            "the canvas as data: items with fractional rects and z (#4887 ph4)",
+            parseActionRest,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                Q_UNUSED(s);
+                if (a.action.isEmpty())
+                    return err(QStringLiteral(
+                        "workspace requires an action (status|enable|disable|place)"));
+                QWidget* mw = primaryTopLevelWindow();
+                if (!mw)
+                    return err(QStringLiteral("no main window"));
+                QVariantMap snap;
+                if (!QMetaObject::invokeMethod(mw, "automationWorkspace",
+                                               Qt::DirectConnection,
+                                               Q_RETURN_ARG(QVariantMap, snap),
+                                               Q_ARG(QString, a.action),
+                                               Q_ARG(QString, a.value))) {
+                    return err(QStringLiteral(
+                        "MainWindow::automationWorkspace failed"));
+                }
+                if (snap.contains(QStringLiteral("error")))
+                    return err(snap.value(QStringLiteral("error")).toString());
+                QJsonObject out = QJsonObject::fromVariantMap(snap);
+                out[QStringLiteral("ok")] = true;
+                return out;
+            });
+
         add("layout", {}, "layout <rearrange <id>|get> — splitter layout exerciser",
             parseActionValue,
             [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -23,7 +23,6 @@
 #include <QAction>
 #include <QLocalServer>
 #include <QScopeGuard>
-#include <QStatusBar>
 #include <QLocalSocket>
 #include <QApplication>
 #include <QScreen>
@@ -351,10 +350,14 @@ QJsonObject describeWidget(const QWidget* w)
     // A QStatusBar's showMessage() text is otherwise unobservable from the
     // tree — operator notices (e.g. the #4863 float-restore warning, or the
     // canvas-unavailable message) could only be verified by screenshot
-    // (#4864, second gap).
-    if (const auto* sb = qobject_cast<const QStatusBar*>(w)) {
-        if (!sb->currentMessage().isEmpty())
-            o[QStringLiteral("statusMessage")] = sb->currentMessage();
+    // (#4864, second gap).  Read through the dynamic property MainWindow
+    // mirrors on the widget, NOT the QStatusBar type: core/ must not grow
+    // QtWidgets knowledge (engine-boundary EB2, aetherd RFC §10) — the gui
+    // side owns the widget, this side reads generic object data.
+    {
+        const QVariant msg = w->property("currentMessage");
+        if (msg.isValid() && !msg.toString().isEmpty())
+            o[QStringLiteral("statusMessage")] = msg.toString();
     }
 
     if (w->isWindow()) {

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -3088,8 +3088,9 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
             });
 
         add("workspace", {},
-            "workspace <status|enable|disable|place <itemId> <x> <y> [w h]> — "
-            "the canvas as data: items with fractional rects and z (#4887 ph4)",
+            "workspace <status|enable|disable|edit on|off|place <itemId> <x> <y> "
+            "[w h]> — the canvas as data: items with fractional rects and z; "
+            "edit flips the operator posture (#4887 ph4)",
             parseActionRest,
             [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
                 Q_UNUSED(s);

--- a/src/core/ThemeSeedGenerated.cpp
+++ b/src/core/ThemeSeedGenerated.cpp
@@ -47,6 +47,8 @@ void ThemeManager::seedGeneratedDefaults()
     m_tokens.insert("color.button.danger.border.disabled", QString("#4a2828"));
     m_tokens.insert("color.button.danger.foreground.disabled", QString("#8a6055"));
     m_tokens.insert("color.button.foreground.disabled", QString("#506070"));
+    m_tokens.insert("color.canvas.background", QString("#08080d"));
+    m_tokens.insert("color.canvas.dots", QString("#50e6f0fa"));
     m_tokens.insert("color.highlight.fg", QString("#000000"));
     m_tokens.insert("color.highlight.message", QString("#e58be5"));
     m_tokens.insert("color.highlight.rx", QString("#379baf"));

--- a/src/core/backends/sim/SimBackend.cpp
+++ b/src/core/backends/sim/SimBackend.cpp
@@ -5,29 +5,30 @@
 
 #include "core/RadioConnection.h"
 #include "core/PanadapterStream.h"
+#include "core/backends/sim/SimSignalSource.h"
 
 namespace AetherSDR {
 
 SimBackend::SimBackend(QObject* parent) : IRadioBackend(parent)
 {
-    // Frame cadence: kFrameLen (128) samples at kSampleRate (24 kHz) = 5.333 ms
-    // of audio per frame — NOT an integer number of milliseconds. Any fixed-ms
-    // timer interval is therefore wrong: 5 ms overproduces ~6%, 6 ms underproduces
-    // ~11%, and the sink drops/starves the mismatch periodically = the audible
-    // wobble (measured). So we do NOT emit one frame per tick. Instead the timer
-    // runs faster than needed and each tick emits as many whole frames as the REAL
-    // elapsed time has earned, carrying the fractional-sample remainder forward.
-    // The long-run output rate is then exactly 24 kHz regardless of timer jitter.
-    m_audioTimer.setTimerType(Qt::PreciseTimer);
-    m_audioTimer.setInterval(3);   // oversample the deadline; onAudioTick paces itself
-    connect(&m_audioTimer, &QTimer::timeout, this, &SimBackend::onAudioTick);
-    // Give the demo something audible out of the box: a pink-noise floor plus a
-    // birdie carrier — a scene that immediately shows what NR/notch can do.
-    m_audio.setEnabled(NoiseMixer::Channel::Pink, true);
-    m_audio.setLevelDb(NoiseMixer::Channel::Pink, -22.0);
-    m_audio.setEnabled(NoiseMixer::Channel::Birdie, true);
-    m_audio.setLevelDb(NoiseMixer::Channel::Birdie, -18.0);
-    m_audio.setKnob(NoiseMixer::Channel::Birdie, QStringLiteral("hz"), 1200.0);
+    // The synthetic RX engine, on its own worker (#4878). It was the only RX
+    // producer in the app on the GUI thread — a 3 ms Qt::PreciseTimer pinning
+    // the event dispatcher plus ~200 allocating emissions/s competing with
+    // paintEvent, which on software-GL machines is the reported multi-second
+    // input backlog. Signals cross back queued and are re-emitted over the
+    // seam below, the same topology as FlexBackend's wire objects (#502).
+    m_signalThread = new QThread(this);
+    m_signalThread->setObjectName("SimSignalSource");
+    m_signalSource = new SimSignalSource;   // no parent — moved to thread
+    m_signalSource->moveToThread(m_signalThread);
+    m_signalThread->start();
+
+    connect(m_signalSource, &SimSignalSource::audioFrameReady,
+            this, &IRadioBackend::audioFrameReady);
+    connect(m_signalSource, &SimSignalSource::sliceAudioFrameReady,
+            this, &IRadioBackend::sliceAudioFrameReady);
+    connect(m_signalSource, &SimSignalSource::spectrumFrameReady,
+            this, &IRadioBackend::spectrumFrameReady);
 
     // ---- Path B (RFC #4288): own a RadioConnection + PanadapterStream in
     // synthetic-demo mode, mirroring FlexBackend's ctor (same load-bearing #502
@@ -75,16 +76,16 @@ SimBackend::SimBackend(QObject* parent) : IRadioBackend(parent)
     // the audio/spectrum tick also starts producing on the live path.
     connect(m_connection, &RadioConnection::connected, this, [this]() {
         m_connected = true;
-        m_audioTimer.start();
+        QMetaObject::invokeMethod(m_signalSource, &SimSignalSource::start,
+                                  Qt::QueuedConnection);
         QTimer::singleShot(150, this, [this]() {
             if (m_connected) emitInitialState();
         });
     });
     connect(m_connection, &RadioConnection::disconnected, this, [this]() {
         m_connected = false;
-        m_audioTimer.stop();
-        m_audioClock.invalidate();   // fresh pacing baseline on the next connect
-        m_audioDebtNs = 0;
+        QMetaObject::invokeMethod(m_signalSource, &SimSignalSource::stop,
+                                  Qt::QueuedConnection);
     });
 }
 
@@ -95,6 +96,19 @@ SimBackend::~SimBackend()
     // quit/wait), then panStream — the #502 order.
     if (m_connection)
         disconnect(m_connection, nullptr, this, nullptr);
+
+    // The producer goes first: stop the tick on its own thread, then let the
+    // thread drain — the same BlockingQueued-stop shape as the two below.
+    if (m_signalSource && m_signalThread && m_signalThread->isRunning()) {
+        QMetaObject::invokeMethod(m_signalSource, &SimSignalSource::stop,
+                                  Qt::BlockingQueuedConnection);
+        m_signalSource->deleteLater();
+        m_signalThread->quit();
+        m_signalThread->wait(3000);
+    } else {
+        delete m_signalSource;
+    }
+    m_signalSource = nullptr;
 
     if (m_connection && m_connThread && m_connThread->isRunning()) {
         QMetaObject::invokeMethod(m_connection, &RadioConnection::disconnectFromRadio,
@@ -119,170 +133,50 @@ SimBackend::~SimBackend()
     m_panStream = nullptr;
 }
 
-QByteArray SimBackend::toStereoBytes(const QVector<float>& mono)
-{
-    // AudioEngine::feedAudioData() wants 24 kHz STEREO float32: duplicate each
-    // mono sample into L and R. Little-endian float32 (native x86/ARM order the
-    // engine's downstream DSP reads).
-    QByteArray out;
-    out.resize(mono.size() * 2 * static_cast<int>(sizeof(float)));
-    auto* p = reinterpret_cast<float*>(out.data());
-    for (int i = 0; i < mono.size(); ++i) {
-        p[2 * i] = mono[i];
-        p[2 * i + 1] = mono[i];
-    }
-    return out;
-}
-
-void SimBackend::onAudioTick()
-{
-    if (!m_connected) {
-        return;
-    }
-
-    // Emit exactly as many whole frames as REAL elapsed time has earned since the
-    // last tick, so the long-run rate is precisely kSampleRate regardless of the
-    // (jittery, integer-ms) timer. m_audioClock accumulates elapsed nanoseconds;
-    // each kFrameLen-sample frame is worth (kFrameLen / kSampleRate) seconds.
-    if (!m_audioClock.isValid()) {
-        m_audioClock.start();
-        m_audioDebtNs = 0;
-        return;   // establish the t0 baseline; first frames go out next tick
-    }
-    m_audioDebtNs += m_audioClock.nsecsElapsed();
-    m_audioClock.restart();
-
-    constexpr qint64 kNsPerFrame =
-        (static_cast<qint64>(NoiseMixer::kFrameLen) * 1'000'000'000)
-        / NoiseMixer::kSampleRate;   // ~5'333'333 ns
-
-    // Cap the catch-up burst so a long stall (debugger pause, scheduling gap)
-    // can't dump seconds of audio at once; drop the excess debt instead.
-    constexpr int kMaxFramesPerTick = 8;   // ~43 ms — plenty of headroom
-    int frames = static_cast<int>(m_audioDebtNs / kNsPerFrame);
-    if (frames > kMaxFramesPerTick) {
-        frames = kMaxFramesPerTick;
-        m_audioDebtNs = 0;   // resync after a gap rather than spiral
-    } else {
-        m_audioDebtNs -= static_cast<qint64>(frames) * kNsPerFrame;
-    }
-
-
-    for (int i = 0; i < frames; ++i) {
-        // Muted while keyed — a demo radio must never sound live on TX (Principle VI).
-        const QVector<float> frame = m_keyed
-            ? QVector<float>(NoiseMixer::kFrameLen, 0.0f)
-            : m_audio.mixFrame();
-        const QByteArray stereo = toStereoBytes(frame);
-        emit audioFrameReady(stereo);
-        // Per-slice audio too, on this backend's single slice.
-        //
-        // Not optional: the TCI receiver channels are fed from
-        // sliceAudioFrameReady, because the mixed feed cannot say which slice a
-        // buffer belongs to. That routing used to be a hardcoded "channel 1"
-        // fed from audioFrameReady, which worked only while every in-process
-        // backend had exactly one receiver. Demo mode still does — but it has to
-        // SAY so, or TCI audio in demo mode goes silent.
-        emit sliceAudioFrameReady(kSliceId, stereo);
-
-        // A panadapter row a few times a second (not every audio frame — the
-        // display updates far slower than audio). ~20 fps at the 5.33 ms frame ≈
-        // every 9th. The stallscope fault freezes the spectrum/waterfall (audio
-        // keeps flowing) to exercise AE's scope-stall watchdog (#1411-class);
-        // clearFaults() resumes it.
-        if (!m_scopeStalled
-            && ++m_audioFrames % kSpectrumRowEveryNFrames == 0) {
-            constexpr int kBins = 1024;
-            constexpr double kFloorDbm = -120.0;
-            constexpr double kAudioSpanHz = 8000.0;   // show ±4 kHz around the VFO
-            const QVector<float> row =
-                m_audio.spectrum(kBins, kFloorDbm, kAudioSpanHz, kBins / 2);
-            QByteArray bytes(reinterpret_cast<const char*>(row.constData()),
-                             row.size() * static_cast<int>(sizeof(float)));
-            emit spectrumFrameReady(kPanId, bytes);
-        }
-    }
-}
-
 void SimBackend::setDemoNoiseEnabled(const QString& channel, bool on)
 {
-    bool ok = false;
-    const NoiseMixer::Channel c = NoiseMixer::fromName(channel, &ok);
-    if (ok) m_audio.setEnabled(c, on);
+    QMetaObject::invokeMethod(m_signalSource, [src = m_signalSource, channel, on] {
+        src->setNoiseEnabled(channel, on);
+    }, Qt::QueuedConnection);
 }
 
 void SimBackend::setDemoNoiseLevel(const QString& channel, double levelDb)
 {
-    bool ok = false;
-    const NoiseMixer::Channel c = NoiseMixer::fromName(channel, &ok);
-    if (ok) m_audio.setLevelDb(c, levelDb);
+    QMetaObject::invokeMethod(m_signalSource, [src = m_signalSource, channel, levelDb] {
+        src->setNoiseLevel(channel, levelDb);
+    }, Qt::QueuedConnection);
 }
 
 void SimBackend::setDemoNoiseKnob(const QString& channel, const QString& knob,
                                   double value)
 {
-    bool ok = false;
-    const NoiseMixer::Channel c = NoiseMixer::fromName(channel, &ok);
-    if (!ok) return;
-
-    // The birdie's "hz" knob is an AUDIO pitch the operator dials, but the birdie
-    // itself is anchored to an absolute RF carrier so it behaves like a real
-    // signal under tuning. So re-anchor the carrier to (current VFO + requested
-    // pitch) and let updateBirdieFromVfo() derive the pitch from there.
-    //
-    // Writing the knob straight through instead would leave m_birdieCarrierMhz at
-    // its hard-coded default, and the very next VFO nudge would recompute the
-    // pitch from that stale carrier — silently discarding what the operator dialled.
-    if (c == NoiseMixer::Channel::Birdie && knob == QLatin1String("hz")) {
-        m_birdieCarrierMhz = m_sliceFreqMhz + (m_lsb ? -value : value) / 1.0e6;
-        updateBirdieFromVfo();
-        return;
-    }
-    m_audio.setKnob(c, knob, value);
+    // The birdie "hz" re-anchor logic lives with the mixer in the source —
+    // it needs the VFO and sideband atomically with the audio it changes.
+    QMetaObject::invokeMethod(m_signalSource,
+                              [src = m_signalSource, channel, knob, value] {
+        src->setNoiseKnob(channel, knob, value);
+    }, Qt::QueuedConnection);
 }
 
 void SimBackend::loadDemoNoisePreset(const QString& presetName)
 {
-    m_audio.loadPreset(presetName);
-}
-
-void SimBackend::updateBirdieFromVfo()
-{
-    // Audio pitch from the RF offset, per sideband:
-    //   USB: pitch = carrier - VFO  (a carrier ABOVE the VFO is audible)
-    //   LSB: pitch = VFO - carrier  (a carrier BELOW the VFO is audible)
-    // A carrier on the "wrong" side gives a negative offset → silence, exactly
-    // like a real receiver: switch sideband and it disappears. Near zero it
-    // approaches zero-beat.
-    //
-    // Anything outside the audio passband is silent too. That covers the wrong
-    // sideband (negative) AND a carrier far off frequency: offsetHz is an RF
-    // difference, so a band change makes it megahertz-scale, and feeding e.g.
-    // 7 MHz to a 24 kHz oscillator does not go quiet — it aliases back into the
-    // audio band as a loud screech exactly where silence is expected. Passing 0
-    // is what tells NoiseMixer "not audible" (see genBirdie).
-    static constexpr double kMinAudibleHz = 50.0;      // below this it is zero-beat
-    static constexpr double kMaxAudibleHz = 6000.0;    // generous SSB/CW passband,
-                                                       // well inside 12 kHz Nyquist
-    const double offsetHz = (m_birdieCarrierMhz - m_sliceFreqMhz) * 1.0e6;
-    const double audioHz = m_lsb ? -offsetHz : offsetHz;
-    const bool audible = audioHz >= kMinAudibleHz && audioHz <= kMaxAudibleHz;
-    m_audio.setKnob(NoiseMixer::Channel::Birdie, QStringLiteral("hz"),
-                    audible ? audioHz : 0.0);
+    QMetaObject::invokeMethod(m_signalSource, [src = m_signalSource, presetName] {
+        src->loadPreset(presetName);
+    }, Qt::QueuedConnection);
 }
 
 void SimBackend::setDemoAnf(bool on)
 {
-    // Auto-notch: engage → notch the active tonal channels (birdie/cw), which the
-    // mixer already identifies via autoNotchTones(). Off → clear. (Manual TNF
-    // notches aren't tracked separately yet, same as the PanadapterStream demo.)
-    if (on) m_audio.setNotches(m_audio.autoNotchTones());
-    else    m_audio.setNotches({});
+    QMetaObject::invokeMethod(m_signalSource, [src = m_signalSource, on] {
+        src->setAnf(on);
+    }, Qt::QueuedConnection);
 }
 
 void SimBackend::setDemoNb(bool on)
 {
-    m_audio.setNoiseBlank(on);
+    QMetaObject::invokeMethod(m_signalSource, [src = m_signalSource, on] {
+        src->setNb(on);
+    }, Qt::QueuedConnection);
 }
 
 QString SimBackend::demoModelName() { return QStringLiteral("AetherSDR Demo"); }
@@ -355,7 +249,8 @@ void SimBackend::connectRadio(const RadioConnectRequest& /*request*/)
     emit connected();
     emit capabilitiesChanged();
     emitInitialState();
-    m_audioTimer.start();   // begin delivering synthetic RX audio + spectrum
+    QMetaObject::invokeMethod(m_signalSource, &SimSignalSource::start,
+                              Qt::QueuedConnection);   // synthetic RX begins
 }
 
 void SimBackend::disconnectRadio()
@@ -363,9 +258,8 @@ void SimBackend::disconnectRadio()
     if (!m_connected) {
         return;
     }
-    m_audioTimer.stop();
-    m_audioClock.invalidate();   // reconnect re-establishes a fresh pacing baseline
-    m_audioDebtNs = 0;
+    QMetaObject::invokeMethod(m_signalSource, &SimSignalSource::stop,
+                              Qt::QueuedConnection);
     m_connected = false;
     emit sliceRemoved(kSliceId);
 
@@ -454,7 +348,11 @@ void SimBackend::setSliceFrequency(int sliceId, double hz)
         return;
     }
     m_sliceFreqMhz = hz / 1.0e6;
-    updateBirdieFromVfo();            // tuning must move the audio we actually hear
+    // Tuning must move the audio we actually hear — queued to the source.
+    QMetaObject::invokeMethod(m_signalSource,
+                              [src = m_signalSource, mhz = m_sliceFreqMhz] {
+        src->setVfoMhz(mhz);
+    }, Qt::QueuedConnection);
     SliceDelta d;
     d.frequency = m_sliceFreqMhz;
     emit sliceChanged(kSliceId, d);   // radio is authoritative: echo the change back (Principle II)
@@ -469,9 +367,11 @@ void SimBackend::setSliceMode(int sliceId, const QString& mode)
     // Lower-sideband family: LSB, DIGL, CWL. Everything else demodulates
     // USB-style. Drives which side of the VFO the birdie is audible on.
     const QString up = mode.toUpper();
-    m_lsb = (up == QLatin1String("LSB") || up == QLatin1String("DIGL")
-             || up == QLatin1String("CWL"));
-    updateBirdieFromVfo();
+    const bool lsb = (up == QLatin1String("LSB") || up == QLatin1String("DIGL")
+                      || up == QLatin1String("CWL"));
+    QMetaObject::invokeMethod(m_signalSource, [src = m_signalSource, lsb] {
+        src->setLowerSideband(lsb);
+    }, Qt::QueuedConnection);
     SliceDelta d;
     d.mode = m_sliceMode;
     emit sliceChanged(kSliceId, d);
@@ -525,10 +425,12 @@ void SimBackend::setPanCenter(const QString& panId, double hz, PanCenterIntent)
 void SimBackend::setKeying(bool key)
 {
     // RX-only (capabilities().canTransmit == false): the engine TX guard above
-    // the seam already denies keying. We DON'T transmit — but we do record the
-    // intent so onAudioTick() mutes the synthetic RX while "keyed", so the demo
-    // never plays receive audio over a (would-be) transmit (Principle VI).
-    m_keyed = key;
+    // the seam already denies keying. We DON'T transmit — but we do forward the
+    // intent so the source mutes the synthetic RX while "keyed": the demo never
+    // plays receive audio over a (would-be) transmit (Principle VI).
+    QMetaObject::invokeMethod(m_signalSource, [src = m_signalSource, key] {
+        src->setKeyed(key);
+    }, Qt::QueuedConnection);
 }
 
 void SimBackend::invokeExtension(const QString& ns, const QString& verb,
@@ -579,7 +481,9 @@ bool SimBackend::applyFault(const QString& fault, const QVariant& arg)
         return true;
     }
     if (f == QLatin1String("stallscope")) {
-        m_scopeStalled = true;   // onAudioTick stops emitting spectrum rows
+        QMetaObject::invokeMethod(m_signalSource, [src = m_signalSource] {
+            src->setScopeStalled(true);   // spectrum freezes; audio keeps flowing
+        }, Qt::QueuedConnection);
         return true;
     }
     if (f == QLatin1String("disconnect")) {
@@ -679,7 +583,9 @@ void SimBackend::clearFaults()
     // Resume normal operation: un-stall the scope and drop SWR back to nominal.
     // (dropslice/disconnect are one-shot state changes recovered by reconnect,
     // not by clear — clear only reverses the *sustained* faults.)
-    m_scopeStalled = false;
+    QMetaObject::invokeMethod(m_signalSource, [src = m_signalSource] {
+        src->setScopeStalled(false);
+    }, Qt::QueuedConnection);
     if (m_lastSwr > 1.0) {
         // Re-assert the DEFINITION before the value. A disconnect in between runs
         // RadioModel::onDisconnected -> MeterModel::clear(), which drops the def;

--- a/src/core/backends/sim/SimBackend.cpp
+++ b/src/core/backends/sim/SimBackend.cpp
@@ -76,6 +76,10 @@ SimBackend::SimBackend(QObject* parent) : IRadioBackend(parent)
     // the audio/spectrum tick also starts producing on the live path.
     connect(m_connection, &RadioConnection::connected, this, [this]() {
         m_connected = true;
+        // The wire script claims pan 0; dynamic creates append (#4887 ph 4).
+        m_wirePanIds = QStringList{wirePanIdFor(0)};
+        m_pansAwaitingGeometry.clear();
+        pushPanIndicesToSource();
         QMetaObject::invokeMethod(m_signalSource, &SimSignalSource::start,
                                   Qt::QueuedConnection);
         QTimer::singleShot(150, this, [this]() {
@@ -84,8 +88,38 @@ SimBackend::SimBackend(QObject* parent) : IRadioBackend(parent)
     });
     connect(m_connection, &RadioConnection::disconnected, this, [this]() {
         m_connected = false;
+        m_wirePanIds.clear();
+        m_pansAwaitingGeometry.clear();
         QMetaObject::invokeMethod(m_signalSource, &SimSignalSource::stop,
                                   Qt::QueuedConnection);
+    });
+
+    // Seam-geometry trigger for dynamically created pans (#4887 phase 4). A
+    // wire-claimed pan's center/bandwidth fields are never decoded in demo
+    // mode (that decode is m_flexBackend-gated), so each new pan needs the
+    // same normalized panCenterBandwidthChanged bridge pan 0 gets from
+    // emitInitialState() — but only AFTER RadioModel has claimed the pan,
+    // else the geometry is cached by index and the fresh pane starts blank.
+    // The wire status arriving HERE proves the line parsed; the zero-timer
+    // hop below then runs after RadioModel's own queued copy of the same
+    // emission, whichever order the two statusReceived connections were made
+    // in (both events are already in the GUI queue before the timer posts).
+    connect(m_connection, &RadioConnection::statusReceived, this,
+            [this](const QString& object, const QMap<QString, QString>& kvs) {
+        Q_UNUSED(kvs);
+        if (m_pansAwaitingGeometry.isEmpty()
+            || !object.startsWith(QLatin1String("display pan ")))
+            return;
+        const QString panId = object.section(QLatin1Char(' '), 2, 2).toLower();
+        if (!m_pansAwaitingGeometry.remove(panId))
+            return;
+        QTimer::singleShot(0, this, [this, panId]() {
+            if (!m_connected)
+                return;
+            emit panCenterBandwidthChanged(panId, m_sliceFreqMhz,
+                                           kDemoPanBandwidthMhz);
+            emit panWaterfallLineDurationChanged(panId, kWaterfallRate);
+        });
     });
 }
 
@@ -190,7 +224,11 @@ RadioCapabilities SimBackend::capabilities() const
     caps.manufacturer = QStringLiteral("AetherSDR");
     caps.model  = demoModelName();
     caps.maxSlices = 1;          // Phase 1: a single slice. Phase 2 raises this.
-    caps.maxPanadapters = 1;
+    // Four receivers since #4887 phase 4 — enough to exercise the workspace
+    // canvas's per-pan items and measure the multi-pan render budget in CI
+    // and smokes without a real radio. The slice stays singular: extra demo
+    // pans are extra VIEWS of the same antenna, not receivers-with-audio.
+    caps.maxPanadapters = 4;
     caps.sampleRatesHz = {};     // no data plane yet
     // A simulator must never look like something that can key a transmitter
     // (Principle VI). TX stays off in the skeleton.
@@ -576,6 +614,117 @@ void SimBackend::pushFaultStatus(const QString& line)
     if (m_connection)
         QMetaObject::invokeMethod(m_connection, "injectFaultStatus",
                                   Qt::QueuedConnection, Q_ARG(QString, line));
+}
+
+// ---- Multi-pan demo (#4887 phase 4) ----
+
+QString SimBackend::wirePanIdFor(int index)
+{
+    return QStringLiteral("0x%1").arg(0x40000000u + static_cast<quint32>(index),
+                                      8, 16, QLatin1Char('0'));
+}
+
+QString SimBackend::wireWfIdFor(int index)
+{
+    return QStringLiteral("0x%1").arg(0x42000000u + static_cast<quint32>(index),
+                                      8, 16, QLatin1Char('0'));
+}
+
+int SimBackend::wirePanIndexOf(const QString& panId)
+{
+    bool ok = false;
+    const quint32 raw = panId.mid(2).toUInt(&ok, 16);
+    if (!ok || raw < 0x40000000u || raw >= 0x40000000u + 64u)
+        return -1;
+    return static_cast<int>(raw - 0x40000000u);
+}
+
+void SimBackend::pushPanIndicesToSource()
+{
+    QList<int> indices;
+    for (const QString& id : m_wirePanIds) {
+        const int idx = wirePanIndexOf(id);
+        if (idx >= 0)
+            indices.append(idx);
+    }
+    QMetaObject::invokeMethod(m_signalSource,
+                              [src = m_signalSource, indices]() {
+        src->setPanIndices(indices);
+    }, Qt::QueuedConnection);
+}
+
+bool SimBackend::createPanadapter()
+{
+    // The seam branch of RadioModel::createPanadapter() lands here (the demo
+    // has no m_flexBackend). Mint the pan the way pan 0 was minted: inject
+    // the SAME "display pan"/"display waterfall" status shape the synthetic
+    // connect script uses (RadioConnection::startSyntheticDemoConnect), so
+    // RadioModel claims it over the wire and ONE path creates a demo pane.
+    // The normalized geometry bridge is emitted by the ctor's statusReceived
+    // listener once the claim has landed.
+    if (!m_connected)
+        return false;
+    if (m_wirePanIds.size() >= capabilities().maxPanadapters)
+        return false;   // RadioModel announces panadapterLimitReached
+
+    // Lowest free index, so remove-then-create reuses the slot — mirroring
+    // RadioModel::neutralPanIndexFor(), which keeps the two sides' index
+    // spaces agreeing across arbitrary create/remove sequences.
+    int index = 0;
+    while (m_wirePanIds.contains(wirePanIdFor(index)))
+        ++index;
+    const QString panId = wirePanIdFor(index);
+    const QString wfId  = wireWfIdFor(index);
+
+    // Centered on the current VFO: the demo's spectrum row IS the ±4 kHz
+    // audio scene, so every pan views the same antenna and the same span
+    // lockstep applies (see kDemoPanBandwidthMhz).
+    pushFaultStatus(QStringLiteral(
+        "SDE300001|display pan %1 client_handle=0xDE300001 "
+        "waterfall=%2 center=%3 bandwidth=%4 "
+        "min_dbm=-140 max_dbm=-20 x_pixels=1024 y_pixels=700 fps=25 "
+        "ant_list=ANT1")
+        .arg(panId, wfId,
+             QString::number(m_sliceFreqMhz, 'f', 6),
+             QString::number(kDemoPanBandwidthMhz, 'f', 6)));
+    pushFaultStatus(QStringLiteral(
+        "SDE300001|display waterfall %1 client_handle=0xDE300001 "
+        "panadapter=%2 line_duration=%3 auto_black=1 "
+        "black_level=15 color_gain=50")
+        .arg(wfId, panId, QString::number(kWaterfallRate)));
+
+    m_wirePanIds.append(panId);
+    m_pansAwaitingGeometry.insert(panId);
+    pushPanIndicesToSource();
+    return true;
+}
+
+bool SimBackend::removePanadapter(const QString& panId)
+{
+    if (!m_connected)
+        return false;
+    const QString normalized = panId.toLower();
+    if (!m_wirePanIds.contains(normalized))
+        return false;
+    // Pan 0 hosts the demo slice. A real radio tears a pan's slices down
+    // with it, and a demo that silently orphaned its only slice would be
+    // exercising a state no radio produces — refuse instead, the same
+    // "declined" a backend gives for its last receiver.
+    if (wirePanIndexOf(normalized) == 0)
+        return false;
+
+    // Teardown pair, mirroring the real Flex wire (#3843): the pan AND its
+    // waterfall, or the waterfall inventory keeps the orphan forever.
+    const int index = wirePanIndexOf(normalized);
+    pushFaultStatus(QStringLiteral("SDE300001|display pan %1 removed")
+                        .arg(normalized));
+    pushFaultStatus(QStringLiteral("SDE300001|display waterfall %1 removed")
+                        .arg(wireWfIdFor(index)));
+
+    m_wirePanIds.removeAll(normalized);
+    m_pansAwaitingGeometry.remove(normalized);
+    pushPanIndicesToSource();
+    return true;
 }
 
 void SimBackend::clearFaults()

--- a/src/core/backends/sim/SimBackend.h
+++ b/src/core/backends/sim/SimBackend.h
@@ -2,7 +2,9 @@
 
 #include <QByteArray>
 #include <QElapsedTimer>
+#include <QSet>
 #include <QString>
+#include <QStringList>
 #include <QTimer>
 #include <QVector>
 
@@ -62,6 +64,11 @@ public:
     void setSliceAgc(int sliceId, const QString& mode, int thresholdDb) override;
     void setPanCenter(const QString& panId, double hz,
                       PanCenterIntent intent) override;
+    // Multi-pan demo (#4887 phase 4). Create/remove run over the synthetic
+    // wire — the SAME status-line shape the connect script claims pan 0
+    // with — so there is one path that creates a demo pane, not two.
+    bool createPanadapter() override;
+    bool removePanadapter(const QString& panId) override;
     void setKeying(bool key) override;
     void invokeExtension(const QString& ns, const QString& verb,
                          quint64 requestId, const QVariant& arg = {}) override;
@@ -157,6 +164,18 @@ private:
     QThread*         m_signalThread{nullptr};
 
     bool   m_connected{false};
+    // Live synthetic pans by WIRE id ("0x40000000"+index, lowercase), in
+    // creation order. Pan 0 is seeded when the wire script claims it at
+    // connect; the rest are minted by createPanadapter(). The set tracks
+    // pans whose wire status is injected but whose normalized geometry has
+    // not been emitted yet — geometry must land AFTER RadioModel claims the
+    // pan (see the ctor's statusReceived listener).
+    QStringList m_wirePanIds;
+    QSet<QString> m_pansAwaitingGeometry;
+    static QString wirePanIdFor(int index);
+    static QString wireWfIdFor(int index);
+    static int wirePanIndexOf(const QString& panId);
+    void pushPanIndicesToSource();
     double m_sliceFreqMhz{14.100};   // default: 20 m, a lively demo band
     QString m_sliceMode{QStringLiteral("USB")};
     int    m_filterLowHz{100};

--- a/src/core/backends/sim/SimBackend.h
+++ b/src/core/backends/sim/SimBackend.h
@@ -8,6 +8,7 @@
 
 #include "core/backends/IRadioBackend.h"
 #include "core/backends/sim/NoiseMixer.h"
+#include "core/backends/sim/SimSignalSource.h"
 
 class QThread;
 
@@ -66,13 +67,13 @@ public:
                          quint64 requestId, const QVariant& arg = {}) override;
 
     // ---- Demo noise controls (RFC #4288) ----
-    // Drive THIS backend's NoiseMixer (m_audio) — the one whose output you hear
-    // (onAudioTick → audioFrameReady). The DemoApplet's controls route here.
-    // (PanadapterStream has a SECOND, now-unused NoiseMixer from the old shim
-    // path; wiring the applet to that one is why the controls did nothing.) Same
-    // thread as the applet (SimBackend is not moved to a worker thread), so these
-    // are safe direct calls. The birdie "hz" knob is RF-anchored: it sets the
-    // carrier's offset above the VFO, matching the standalone tool's behaviour.
+    // Drive the SimSignalSource's NoiseMixer — the one whose output you hear.
+    // The DemoApplet's controls route here. (PanadapterStream has a SECOND,
+    // now-unused NoiseMixer from the old shim path; wiring the applet to that
+    // one is why the controls did nothing.) The generator lives on a worker
+    // thread (#4878), so these forward as QUEUED calls — same seam shape as
+    // every other backend's wire objects. The birdie "hz" knob is RF-anchored:
+    // it sets the carrier's offset above the VFO.
     void setDemoNoiseEnabled(const QString& channel, bool on);
     void setDemoNoiseLevel(const QString& channel, double levelDb);
     void setDemoNoiseKnob(const QString& channel, const QString& knob, double value);
@@ -109,11 +110,6 @@ public:
     RadioConnection*  connection() const { return m_connection; }
     PanadapterStream* panStream()  const { return m_panStream; }
 
-private slots:
-    // Frame tick (kFrameLen / kSampleRate, ~5.3 ms): mixes one audio frame and
-    // emits it over the seam, plus a periodic spectrum row. Muted while keyed.
-    void onAudioTick();
-
 private:
     // Emit the initial synthetic snapshot a freshly-connected radio would report:
     // the radio-global delta (model/nickname/slices) and one active slice on a
@@ -142,7 +138,6 @@ private:
     // receive path (queued to its worker thread) so AE decodes it as radio-sent.
     void pushFaultStatus(const QString& line);
 
-    bool   m_scopeStalled{false};   // stallscope: onAudioTick skips the spectrum emit
     double m_lastSwr{1.0};          // last injected SWR (clearFaults resets to nominal)
     static constexpr int kSwrMeterIndex = 90;   // synthetic meter slot for the SWR fault
     // The SWR MeterDef, in one place: injectHighSwr() and clearFaults() both have
@@ -150,26 +145,16 @@ private:
     // different meter than the fault.
     static MeterDef swrMeterDef();
 
-    // Serialize a mono float frame to the 24 kHz STEREO float32 QByteArray
-    // AudioEngine::feedAudioData() expects (each mono sample duplicated L=R).
-    static QByteArray toStereoBytes(const QVector<float>& mono);
-
-    // Phase 2b (audio) — the synthesized-RX-audio engine (white/pink/qrn/birdie/…
-    // + TNF/ANF notch). onAudioTick() calls m_audio.mixFrame() and emits it over
-    // audioFrameReady() as 24 kHz stereo float32 — the format AudioEngine::
-    // feedAudioData() consumes, so the demo audio flows straight into AE's NR
-    // chain with no DSP change. spectrum() gives the matching panadapter render.
-    // Muted while keyed (Principle VI): a demo radio never sounds live on TX.
-    NoiseMixer m_audio;
-    QTimer     m_audioTimer;         // oversampled tick; onAudioTick() paces itself
-    // Real-time frame pacing: a 5.333 ms frame is not an integer ms, so a fixed
-    // timer interval drifts (over/underproduces → sink drop/starve = wobble).
-    // onAudioTick() instead emits whole frames per REAL elapsed time, carrying the
-    // sub-frame remainder in m_audioDebtNs so the long-run rate is exactly 24 kHz.
-    QElapsedTimer m_audioClock;      // wall clock between ticks (nanoseconds)
-    qint64        m_audioDebtNs{0};  // un-emitted elapsed time carried forward
-    bool       m_keyed{false};       // muted while keyed (Principle VI — never sounds live on TX)
-    quint64    m_audioFrames{0};     // frame counter (throttles the spectrum row)
+    // Phase 2b (audio) — the synthesized-RX-audio engine, on its OWN worker
+    // thread since #4878 (it was the only RX producer in the app on the GUI
+    // thread; on software-GL machines its 3 ms precise timer plus ~200
+    // allocating emissions a second was the reported multi-second input
+    // backlog). SimSignalSource owns the NoiseMixer, the pacing timer and the
+    // audio+spectrum emission; its signals cross back queued and this class
+    // re-emits them over the IRadioBackend seam — the same producer topology
+    // as FlexBackend's wire objects (#502).
+    SimSignalSource* m_signalSource{nullptr};   // owned; lives on m_signalThread
+    QThread*         m_signalThread{nullptr};
 
     bool   m_connected{false};
     double m_sliceFreqMhz{14.100};   // default: 20 m, a lively demo band
@@ -182,17 +167,12 @@ private:
     int     m_agcThresholdDb{65};
     static constexpr int kSliceId = 0;
 
-    // Birdie-vs-VFO geometry, mirroring PanadapterStream's demo behaviour but on
-    // the AUDIBLE mixer. The carrier sits a fixed 1200 Hz above the default VFO
-    // (matching the ctor's birdie pitch), so tuning across it sweeps the audio
-    // pitch down to zero-beat and out the far side.
-    bool   m_lsb{false};              // true when the slice mode is a lower sideband
-    double m_birdieCarrierMhz{14.100 + 1200.0 / 1.0e6};
-    void   updateBirdieFromVfo();     // recompute the birdie pitch from VFO+sideband
-
 public:
-    // One waterfall row per this many audio frames (see onAudioTick).
-    static constexpr int kSpectrumRowEveryNFrames = 9;
+    // One waterfall row per this many audio frames — the source's cadence,
+    // aliased here because RadioConnection's synthetic connect and the
+    // constants below derive from it.
+    static constexpr int kSpectrumRowEveryNFrames =
+        SimSignalSource::kSpectrumRowEveryNFrames;
     // The row cadence that follows, in whole ms: 9 × 128 / 24000 s = 48 ms.
     //
     // NOTHING READS THIS, and that is the honest state of it rather than an

--- a/src/core/backends/sim/SimSignalSource.cpp
+++ b/src/core/backends/sim/SimSignalSource.cpp
@@ -123,11 +123,22 @@ void SimSignalSource::onTick()
             constexpr double kAudioSpanHz = 8000.0;   // ±4 kHz around the VFO
             const QVector<float> row =
                 m_audio.spectrum(kBins, kFloorDbm, kAudioSpanHz, kBins / 2);
-            QByteArray bytes(reinterpret_cast<const char*>(row.constData()),
-                             row.size() * static_cast<int>(sizeof(float)));
-            emit spectrumFrameReady(kPanId, bytes);
+            const QByteArray bytes(
+                reinterpret_cast<const char*>(row.constData()),
+                row.size() * static_cast<int>(sizeof(float)));
+            // One row PER LIVE PAN, addressed by index. The mix is computed
+            // once — every demo pan views the same antenna — but each pan
+            // gets its own emission, so the seam carries real multi-pan load
+            // and RadioModel routes rows to the right pane (#4887 phase 4).
+            for (const int pan : m_panIndices)
+                emit spectrumFrameReady(pan, bytes);
         }
     }
+}
+
+void SimSignalSource::setPanIndices(const QList<int>& indices)
+{
+    m_panIndices = indices;
 }
 
 void SimSignalSource::setNoiseEnabled(const QString& channel, bool on)

--- a/src/core/backends/sim/SimSignalSource.cpp
+++ b/src/core/backends/sim/SimSignalSource.cpp
@@ -1,0 +1,215 @@
+#include "core/backends/sim/SimSignalSource.h"
+
+namespace AetherSDR {
+
+SimSignalSource::SimSignalSource(QObject* parent) : QObject(parent)
+{
+    // A member QObject has NO parent by default, and moveToThread() moves
+    // children only — an unparented member timer stays on the constructing
+    // thread and Qt refuses to start it from the worker ("timers cannot be
+    // started from another thread"). Parenting it here makes it ride along.
+    // Safe despite being a member: member destructors run before ~QObject,
+    // so the timer removes itself from the child list before the base would
+    // delete children. (Caught by sim_signal_source_test — zero frames.)
+    m_timer.setParent(this);
+
+    // Frame cadence: kFrameLen (128) samples at kSampleRate (24 kHz) = 5.333 ms
+    // of audio per frame — NOT an integer number of milliseconds, so no fixed
+    // interval can be right on its own. The timer only sets the CHECK cadence;
+    // onTick() emits as many whole frames as real elapsed time has earned and
+    // carries the remainder, so the long-run rate is exactly 24 kHz.
+    //
+    // 10 ms coarse, not 3 ms precise: this object lives on its own worker
+    // (#4878), where a precise short timer buys nothing and a coarse one lets
+    // the kernel batch wakeups. 10 ms earns 1–2 frames per tick; the burst cap
+    // below covers stalls.
+    m_timer.setTimerType(Qt::CoarseTimer);
+    m_timer.setInterval(10);
+    connect(&m_timer, &QTimer::timeout, this, &SimSignalSource::onTick);
+
+    // The out-of-the-box scene: a pink-noise floor plus a birdie carrier — a
+    // scene that immediately shows what NR/notch can do.
+    m_audio.setEnabled(NoiseMixer::Channel::Pink, true);
+    m_audio.setLevelDb(NoiseMixer::Channel::Pink, -22.0);
+    m_audio.setEnabled(NoiseMixer::Channel::Birdie, true);
+    m_audio.setLevelDb(NoiseMixer::Channel::Birdie, -18.0);
+    m_audio.setKnob(NoiseMixer::Channel::Birdie, QStringLiteral("hz"), 1200.0);
+}
+
+void SimSignalSource::start()
+{
+    m_clock.invalidate();   // fresh pacing baseline; first frames next tick
+    m_debtNs = 0;
+    m_timer.start();
+}
+
+void SimSignalSource::stop()
+{
+    m_timer.stop();
+    m_clock.invalidate();
+    m_debtNs = 0;
+}
+
+void SimSignalSource::setKeyed(bool keyed)
+{
+    m_keyed = keyed;
+}
+
+void SimSignalSource::setScopeStalled(bool stalled)
+{
+    m_scopeStalled = stalled;
+}
+
+QByteArray SimSignalSource::toStereoBytes(const QVector<float>& mono)
+{
+    // AudioEngine::feedAudioData() wants 24 kHz STEREO float32: duplicate each
+    // mono sample into L and R.
+    QByteArray out;
+    out.resize(mono.size() * 2 * static_cast<int>(sizeof(float)));
+    auto* p = reinterpret_cast<float*>(out.data());
+    for (int i = 0; i < mono.size(); ++i) {
+        p[2 * i] = mono[i];
+        p[2 * i + 1] = mono[i];
+    }
+    return out;
+}
+
+void SimSignalSource::onTick()
+{
+    // Emit exactly as many whole frames as REAL elapsed time has earned since
+    // the last tick — the pacing scheme is unchanged from the GUI-thread
+    // original; only the thread it runs on moved (#4878).
+    if (!m_clock.isValid()) {
+        m_clock.start();
+        m_debtNs = 0;
+        return;   // establish the t0 baseline; first frames go out next tick
+    }
+    m_debtNs += m_clock.nsecsElapsed();
+    m_clock.restart();
+
+    constexpr qint64 kNsPerFrame =
+        (static_cast<qint64>(NoiseMixer::kFrameLen) * 1'000'000'000)
+        / NoiseMixer::kSampleRate;   // ~5'333'333 ns
+
+    // Cap the catch-up burst so a long stall (debugger pause, scheduling gap)
+    // can't dump seconds of audio at once; drop the excess debt instead.
+    constexpr int kMaxFramesPerTick = 8;   // ~43 ms — plenty of headroom
+    int frames = static_cast<int>(m_debtNs / kNsPerFrame);
+    if (frames > kMaxFramesPerTick) {
+        frames = kMaxFramesPerTick;
+        m_debtNs = 0;   // resync after a gap rather than spiral
+    } else {
+        m_debtNs -= static_cast<qint64>(frames) * kNsPerFrame;
+    }
+
+    for (int i = 0; i < frames; ++i) {
+        // Muted while keyed — a demo radio must never sound live on TX
+        // (Principle VI).
+        const QVector<float> frame = m_keyed
+            ? QVector<float>(NoiseMixer::kFrameLen, 0.0f)
+            : m_audio.mixFrame();
+        const QByteArray stereo = toStereoBytes(frame);
+        emit audioFrameReady(stereo);
+        // Per-slice audio too — the TCI receiver channels are fed from
+        // sliceAudioFrameReady (see the SimBackend original for the history).
+        emit sliceAudioFrameReady(kSliceId, stereo);
+
+        // A panadapter row a few times a second (~21 fps at the 5.33 ms
+        // frame). The stallscope fault freezes the spectrum while audio keeps
+        // flowing, to exercise the scope-stall watchdog.
+        if (!m_scopeStalled && ++m_frames % kSpectrumRowEveryNFrames == 0) {
+            constexpr int kBins = 1024;
+            constexpr double kFloorDbm = -120.0;
+            constexpr double kAudioSpanHz = 8000.0;   // ±4 kHz around the VFO
+            const QVector<float> row =
+                m_audio.spectrum(kBins, kFloorDbm, kAudioSpanHz, kBins / 2);
+            QByteArray bytes(reinterpret_cast<const char*>(row.constData()),
+                             row.size() * static_cast<int>(sizeof(float)));
+            emit spectrumFrameReady(kPanId, bytes);
+        }
+    }
+}
+
+void SimSignalSource::setNoiseEnabled(const QString& channel, bool on)
+{
+    bool ok = false;
+    const NoiseMixer::Channel c = NoiseMixer::fromName(channel, &ok);
+    if (ok) m_audio.setEnabled(c, on);
+}
+
+void SimSignalSource::setNoiseLevel(const QString& channel, double levelDb)
+{
+    bool ok = false;
+    const NoiseMixer::Channel c = NoiseMixer::fromName(channel, &ok);
+    if (ok) m_audio.setLevelDb(c, levelDb);
+}
+
+void SimSignalSource::setNoiseKnob(const QString& channel, const QString& knob,
+                                   double value)
+{
+    bool ok = false;
+    const NoiseMixer::Channel c = NoiseMixer::fromName(channel, &ok);
+    if (!ok) return;
+
+    // The birdie's "hz" knob is an AUDIO pitch the operator dials, but the
+    // birdie itself is anchored to an absolute RF carrier so it behaves like a
+    // real signal under tuning: re-anchor the carrier to (current VFO +
+    // requested pitch) and derive the pitch from there. Writing the knob
+    // straight through would leave the carrier stale and the next VFO nudge
+    // would silently discard what the operator dialled.
+    if (c == NoiseMixer::Channel::Birdie && knob == QLatin1String("hz")) {
+        m_birdieCarrierMhz = m_sliceFreqMhz + (m_lsb ? -value : value) / 1.0e6;
+        updateBirdieFromVfo();
+        return;
+    }
+    m_audio.setKnob(c, knob, value);
+}
+
+void SimSignalSource::loadPreset(const QString& presetName)
+{
+    m_audio.loadPreset(presetName);
+}
+
+void SimSignalSource::setAnf(bool on)
+{
+    // Auto-notch: engage → notch the active tonal channels (birdie/cw), which
+    // the mixer identifies via autoNotchTones(). Off → clear.
+    if (on) m_audio.setNotches(m_audio.autoNotchTones());
+    else    m_audio.setNotches({});
+}
+
+void SimSignalSource::setNb(bool on)
+{
+    m_audio.setNoiseBlank(on);
+}
+
+void SimSignalSource::setVfoMhz(double mhz)
+{
+    m_sliceFreqMhz = mhz;
+    updateBirdieFromVfo();
+}
+
+void SimSignalSource::setLowerSideband(bool lsb)
+{
+    m_lsb = lsb;
+    updateBirdieFromVfo();
+}
+
+void SimSignalSource::updateBirdieFromVfo()
+{
+    // Audio pitch from the RF offset, per sideband:
+    //   USB: pitch = carrier - VFO;  LSB: pitch = VFO - carrier.
+    // A carrier on the "wrong" side or outside the audio passband is silent —
+    // passing 0 tells NoiseMixer "not audible". Megahertz-scale offsets MUST
+    // go silent rather than alias back into the audio band as a screech.
+    static constexpr double kMinAudibleHz = 50.0;    // below: zero-beat
+    static constexpr double kMaxAudibleHz = 6000.0;  // generous passband,
+                                                     // inside 12 kHz Nyquist
+    const double offsetHz = (m_birdieCarrierMhz - m_sliceFreqMhz) * 1.0e6;
+    const double audioHz = m_lsb ? -offsetHz : offsetHz;
+    const bool audible = audioHz >= kMinAudibleHz && audioHz <= kMaxAudibleHz;
+    m_audio.setKnob(NoiseMixer::Channel::Birdie, QStringLiteral("hz"),
+                    audible ? audioHz : 0.0);
+}
+
+}  // namespace AetherSDR

--- a/src/core/backends/sim/SimSignalSource.h
+++ b/src/core/backends/sim/SimSignalSource.h
@@ -2,6 +2,7 @@
 
 #include <QByteArray>
 #include <QElapsedTimer>
+#include <QList>
 #include <QObject>
 #include <QString>
 #include <QTimer>
@@ -68,6 +69,13 @@ public slots:
     void setVfoMhz(double mhz);
     void setLowerSideband(bool lsb);
 
+    // Which pans exist, as backend pan indices in creation order (#4887
+    // phase 4 — the demo grew real multi-pan). One spectrum row per live pan
+    // every kSpectrumRowEveryNFrames frames, each addressed by its index.
+    // The audio stays single-scene: every demo pan is a view of the same
+    // antenna, so the mix is computed once and only the emission fans out.
+    void setPanIndices(const QList<int>& indices);
+
 signals:
     // 24 kHz stereo float32, the format AudioEngine::feedAudioData() eats.
     void audioFrameReady(const QByteArray& stereo);
@@ -80,7 +88,6 @@ private:
     static QByteArray toStereoBytes(const QVector<float>& mono);
 
     static constexpr int kSliceId = 0;
-    static constexpr int kPanId = 0;
 
     NoiseMixer    m_audio;
     QTimer        m_timer;
@@ -89,6 +96,7 @@ private:
     quint64       m_frames{0};
     bool          m_keyed{false};
     bool          m_scopeStalled{false};
+    QList<int>    m_panIndices{0};   // pan 0 exists from connect
 
     double m_sliceFreqMhz{14.100};
     bool   m_lsb{false};

--- a/src/core/backends/sim/SimSignalSource.h
+++ b/src/core/backends/sim/SimSignalSource.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <QByteArray>
+#include <QElapsedTimer>
+#include <QObject>
+#include <QString>
+#include <QTimer>
+#include <QVector>
+
+#include "core/backends/sim/NoiseMixer.h"
+
+namespace AetherSDR {
+
+// SimSignalSource — the demo radio's synthetic RX engine, on a worker thread
+// (#4878).
+//
+// This is everything that used to tick inside SimBackend on the GUI thread:
+// the NoiseMixer, the frame-pacing timer, and the audio + spectrum emission.
+// It was the ONLY RX producer in AetherSDR living on the GUI thread — every
+// real backend runs its producers on workers precisely so signal generation
+// never competes with paintEvent (#502, AudioEngine; PanadapterStream
+// likewise) — and it is also the one producer that GENERATES its data rather
+// than merely decoding it. On a software-GL machine the combination (a 3 ms
+// Qt::PreciseTimer pinning the event dispatcher plus ~200 allocating signal
+// emissions a second) is exactly the multi-second input backlog #4878
+// reports.
+//
+// Threading contract: construct on any thread, moveToThread(worker), then
+// touch it ONLY through queued calls — every public slot below assumes it
+// runs on the worker. The member QTimer moves with its parent, and start()/
+// stop() are slots so the timer is always started from its own thread.
+// Signals are emitted from the worker and cross back queued, exactly like
+// FlexBackend's wire objects.
+//
+// The timer is 10 ms COARSE where the GUI-thread version was 3 ms PRECISE:
+// on a dedicated worker there is nothing to contend with, the debt-pacing in
+// onTick() already absorbs interval jitter (the long-run rate is exactly
+// kSampleRate regardless), and a coarse timer lets the kernel batch wakeups
+// instead of pinning the poll timeout app-wide.
+class SimSignalSource : public QObject {
+    Q_OBJECT
+
+public:
+    explicit SimSignalSource(QObject* parent = nullptr);
+
+    // One spectrum row per this many audio frames (~21 rows/s at 128/24k).
+    static constexpr int kSpectrumRowEveryNFrames = 9;
+
+public slots:
+    void start();
+    void stop();
+
+    void setKeyed(bool keyed);            // mute while keyed (Principle VI)
+    void setScopeStalled(bool stalled);   // the stallscope fault
+
+    // The DemoApplet's noise controls, queued across from the GUI thread.
+    void setNoiseEnabled(const QString& channel, bool on);
+    void setNoiseLevel(const QString& channel, double levelDb);
+    void setNoiseKnob(const QString& channel, const QString& knob, double value);
+    void loadPreset(const QString& presetName);
+    void setAnf(bool on);
+    void setNb(bool on);
+
+    // Birdie-vs-VFO geometry (the audible carrier is RF-anchored, so tuning
+    // sweeps its pitch like a real signal). The slice state lives with the
+    // mixer because the knob re-anchor and the pitch derivation both need it
+    // atomically with the audio it changes.
+    void setVfoMhz(double mhz);
+    void setLowerSideband(bool lsb);
+
+signals:
+    // 24 kHz stereo float32, the format AudioEngine::feedAudioData() eats.
+    void audioFrameReady(const QByteArray& stereo);
+    void sliceAudioFrameReady(int sliceId, const QByteArray& stereo);
+    void spectrumFrameReady(int panId, const QByteArray& bins);
+
+private:
+    void onTick();
+    void updateBirdieFromVfo();
+    static QByteArray toStereoBytes(const QVector<float>& mono);
+
+    static constexpr int kSliceId = 0;
+    static constexpr int kPanId = 0;
+
+    NoiseMixer    m_audio;
+    QTimer        m_timer;
+    QElapsedTimer m_clock;
+    qint64        m_debtNs{0};
+    quint64       m_frames{0};
+    bool          m_keyed{false};
+    bool          m_scopeStalled{false};
+
+    double m_sliceFreqMhz{14.100};
+    bool   m_lsb{false};
+    double m_birdieCarrierMhz{14.100 + 1200.0 / 1.0e6};
+};
+
+}  // namespace AetherSDR

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -236,16 +236,11 @@ protected:
         }
         if (srcIdx < 0) return;
 
-        // A canvas item dropped onto the panel is a return, not a reorder:
-        // the workspace controller takes it off the canvas and restores its
-        // panel slot (RFC #4887 phase 3), and the reorder below then moves
-        // it to where it was dropped like any other entry.
-        if (auto* cw = qobject_cast<ContainerWidget*>(
-                m_panel->m_appletOrder[srcIdx].widget);
-            cw && cw->isOnCanvas()) {
-            emit m_panel->canvasReturnRequested(draggedId);
-            if (cw->isOnCanvas()) return;   // nobody handled it — leave it be
-        }
+        // No canvas-return branch here (review m10): phase 5 replaced the
+        // canvas title-bar QDrag with the live gesture stream, so a canvas
+        // item can no longer arrive as a QDrag drop — returns flow through
+        // WorkspaceCanvas::itemDraggedOut and the controller's return
+        // target instead.
 
         // Adjust drop index if moving down (after removing source)
         if (dropIdx > srcIdx) dropIdx--;

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -1214,9 +1214,13 @@ void AppletPanel::rebuildStackOrder()
         auto* item = m_stack->takeAt(0);
         delete item;  // deletes the layout item, NOT the widget
     }
-    // Re-add in current order (skip floating containers to avoid stealing them)
+    // Re-add in current order.  Skip containers the panel does not currently
+    // own: floating ones live in their own window, and canvas ones are
+    // children of a WorkspaceCanvas (RFC #4887 phase 3).  Adding either here
+    // would steal it back out of its placement mid-rebuild.
     for (const auto& entry : m_appletOrder) {
-        if (auto* cw = qobject_cast<ContainerWidget*>(entry.widget); cw && cw->isFloating())
+        auto* cw = qobject_cast<ContainerWidget*>(entry.widget);
+        if (cw && (cw->isFloating() || cw->isOnCanvas()))
             continue;
         m_stack->addWidget(entry.widget);
     }

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -236,6 +236,17 @@ protected:
         }
         if (srcIdx < 0) return;
 
+        // A canvas item dropped onto the panel is a return, not a reorder:
+        // the workspace controller takes it off the canvas and restores its
+        // panel slot (RFC #4887 phase 3), and the reorder below then moves
+        // it to where it was dropped like any other entry.
+        if (auto* cw = qobject_cast<ContainerWidget*>(
+                m_panel->m_appletOrder[srcIdx].widget);
+            cw && cw->isOnCanvas()) {
+            emit m_panel->canvasReturnRequested(draggedId);
+            if (cw->isOnCanvas()) return;   // nobody handled it — leave it be
+        }
+
         // Adjust drop index if moving down (after removing source)
         if (dropIdx > srcIdx) dropIdx--;
         if (dropIdx == srcIdx) return;
@@ -1225,6 +1236,15 @@ void AppletPanel::rebuildStackOrder()
         m_stack->addWidget(entry.widget);
     }
     m_stack->addStretch(1);  // factor 1: absorb all surplus, pin tiles to sizeHint (#3461)
+}
+
+QStringList AppletPanel::appletIds() const
+{
+    QStringList ids;
+    ids.reserve(m_appletOrder.size());
+    for (const auto& entry : m_appletOrder)
+        ids.append(entry.id);
+    return ids;
 }
 
 void AppletPanel::saveOrder()

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -244,6 +244,11 @@ public:
     // for all legacy applets — these accessors exist so new features
     // can opt in to the container system early.
     ContainerManager* containerManager() { return m_containerMgr; }
+
+    // Canonical applet entry ids in current column order — the same ids the
+    // Applet_<ID> keys and AppletOrder use.  The workspace controller feeds
+    // these to the legacy-key migration (RFC #4887 phase 3).
+    QStringList appletIds() const;
     ContainerWidget*  rootSidebarContainer() { return m_rootSidebar; }
 
     // Global controls lock — disables wheel/mouse on sidebar sliders (#745)
@@ -262,6 +267,12 @@ public:
     };
 
     friend class AppletDropArea;
+
+signals:
+    // A canvas-mode container was dropped back onto the panel; the workspace
+    // controller owns the transition (RFC #4887 phase 3).
+    void canvasReturnRequested(const QString& appletId);
+
 
 protected:
     bool eventFilter(QObject* obj, QEvent* ev) override;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2049,6 +2049,7 @@ MainWindow::MainWindow(QWidget* parent)
     // PUDU monitor, RX chain edit) → wireDspApplets()
     // (MainWindow_DspApplets.cpp, #3351 Phase 2d).
     wireDspApplets();
+    wireWorkspaceCanvas();   // RFC #4887 phase 3 — MainWindow_Workspace.cpp
 
     // PROC / NOR / DX / DX+ -> the client compressor, on a radio that modulates
     // on this host. After wireDspApplets(), which is what gives the applet panel
@@ -2483,8 +2484,8 @@ MainWindow::MainWindow(QWidget* parent)
         QList<int> sizes(m_splitter->count(), 0);
         for (int i = 0; i < m_splitter->count(); ++i) {
             QWidget* w = m_splitter->widget(i);
-            if (w == m_panStack)         sizes[i] = centerW;
-            else if (w == m_appletPanel) sizes[i] = appletW;
+            if (w == centralPanWidget())  sizes[i] = centerW;
+            else if (w == m_appletPanel)  sizes[i] = appletW;
         }
         m_splitter->setSizes(sizes);
     });
@@ -8594,7 +8595,7 @@ void MainWindow::setAppletPanelDockedLeft(bool left)
     // (right dock).  insertWidget()/addWidget() on an already-attached child
     // reparents it to the new index without destroy/recreate.
     if (left) {
-        const int panIdx = m_splitter->indexOf(m_panStack);
+        const int panIdx = m_splitter->indexOf(centralPanWidget());
         if (panIdx < 0) return;
         m_splitter->insertWidget(panIdx, m_appletPanel);
     } else {
@@ -8604,7 +8605,7 @@ void MainWindow::setAppletPanelDockedLeft(bool left)
     // Re-apply stretch/collapse rules by widget identity (indices shifted).
     for (int i = 0; i < m_splitter->count(); ++i) {
         QWidget* w = m_splitter->widget(i);
-        m_splitter->setStretchFactor(i, w == m_panStack ? 1 : 0);
+        m_splitter->setStretchFactor(i, w == centralPanWidget() ? 1 : 0);
         m_splitter->setCollapsible(i, false);
     }
 
@@ -8628,8 +8629,8 @@ void MainWindow::setAppletPanelDockedLeft(bool left)
         QList<int> newSizes(m_splitter->count(), 0);
         for (int i = 0; i < m_splitter->count(); ++i) {
             QWidget* w = m_splitter->widget(i);
-            if (w == m_panStack)         newSizes[i] = centerW;
-            else if (w == m_appletPanel) newSizes[i] = appletW;
+            if (w == centralPanWidget())  newSizes[i] = centerW;
+            else if (w == m_appletPanel)  newSizes[i] = appletW;
         }
         m_splitter->setSizes(newSizes);
     }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -9585,37 +9585,53 @@ void MainWindow::createPansSequentially(const QString& layoutId, int total,
     // pan is new is found by DIFFING rather than parsing a create reply: the
     // backend numbers its own pans and skips retired numbers after a close.
     if (!m_radioModel.usesFlexCommandPlane()) {
-        QSet<QString> before;
+        auto before = std::make_shared<QSet<QString>>();
         for (auto* p : m_panStack->allApplets())
-            before.insert(p->panId());
+            before->insert(p->panId());
         for (auto* p : m_radioModel.panadapters())
-            if (p) before.insert(p->panId());
+            if (p) before->insert(p->panId());
 
         m_radioModel.createPanadapter();
 
-        QString createdId;
-        for (auto* p : m_radioModel.panadapters()) {
-            if (p && !before.contains(p->panId())) {
-                createdId = p->panId();
-                break;
+        // The seam create is NOT synchronous for every backend (red-team
+        // M4): HL2's is, but the demo mints its pan over the synthetic wire
+        // — two queued thread hops — so an immediate diff found nothing,
+        // declared "capacity full", and aborted the recursion while the pan
+        // materialised a moment later.  Diff after the create has settled;
+        // 300 ms covers both wire hops with margin and is indistinguishable
+        // from the existing 200 ms inter-create pacing for a synchronous
+        // backend.
+        QTimer::singleShot(300, this,
+                           [this, layoutId, total, panIds, created, before]() {
+            if (m_shuttingDown || !m_panStack) {
+                return;
             }
-        }
-        if (createdId.isEmpty()) {
-            // The backend refused — receiver count, or the link budget at this
-            // span. It has already logged which; surface it and stop rather than
-            // recursing against a limit that will refuse every remaining pan.
-            qWarning() << "applyPanLayout: backend declined pan"
-                       << (created + 1) << "of" << total;
-            showPanadapterSliceCapacityMessage();
-            return;
-        }
-        panIds->append(createdId);
-        qDebug() << "applyPanLayout: created pan" << (created + 1) << "of" << total
-                 << "id:" << createdId;
-        // Same inter-create delay as the Flex path. Adding a receiver restarts
-        // the EP6 stream, so back-to-back creates would stack restarts.
-        QTimer::singleShot(200, this, [this, layoutId, total, panIds, created]() {
-            createPansSequentially(layoutId, total, panIds, created + 1);
+            QString createdId;
+            for (auto* p : m_radioModel.panadapters()) {
+                if (p && !before->contains(p->panId())) {
+                    createdId = p->panId();
+                    break;
+                }
+            }
+            if (createdId.isEmpty()) {
+                // The backend refused — receiver count, or the link budget
+                // at this span. It has already logged which; surface it and
+                // stop rather than recursing against a limit that will
+                // refuse every remaining pan.
+                qWarning() << "applyPanLayout: backend declined pan"
+                           << (created + 1) << "of" << total;
+                showPanadapterSliceCapacityMessage();
+                return;
+            }
+            panIds->append(createdId);
+            qDebug() << "applyPanLayout: created pan" << (created + 1)
+                     << "of" << total << "id:" << createdId;
+            // Same inter-create pacing rationale as the Flex path: adding a
+            // receiver restarts the EP6 stream, so creates stay spaced.
+            QTimer::singleShot(200, this,
+                               [this, layoutId, total, panIds, created]() {
+                createPansSequentially(layoutId, total, panIds, created + 1);
+            });
         });
         return;
     }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5982,7 +5982,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
         if (m_bsAutoSaveTimer && m_bsAutoSaveTimer->isActive())
             m_bsAutoSaveTimer->stop();
         if (m_panStack) {
-            m_panStack->setBandStackVisible(false);
+            setBandStackPanelVisible(false);
         }
         refreshMemoryBrowsePanel();
         updateBandStackIndicator();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -785,6 +785,9 @@ private:
     void wireWorkspaceCanvas();
     void toggleWorkspaceCanvas(bool on);
     QWidget* centralPanWidget() const;
+    // One router for band-stack visibility: canvas mode hosts the panel as
+    // a canvas item, classic mode shows it inside the stack (#4887 ph 4).
+    void setBandStackPanelVisible(bool show);
 
     // Show/hide the applet panel — single source of truth that updates the
     // title-bar dock icons and the persisted "AppletPanelVisible" setting.

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1240,6 +1240,7 @@ private:
     WorkspaceCanvas*     m_workspaceCanvas{nullptr};
     WorkspaceController* m_workspaceController{nullptr};
     QAction*             m_workspaceCanvasAction{nullptr};
+    QAction*             m_workspaceEditAction{nullptr};
     QMetaObject::Connection m_miniPanFreqConn;    // active-slice freq → mini-pan centre
     QMetaObject::Connection m_miniPanFiltConn;    // active-slice filter → mini-pan passband
     bool m_miniPanFeedWanted{false};              // applet visible → consume frames

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -125,6 +125,8 @@ class IRadioBackend;
 class PanadapterApplet;
 class MiniPanApplet;
 class PanadapterStack;
+class WorkspaceCanvas;
+class WorkspaceController;
 class AdaptiveFilterEngine;
 class AppletPanel;
 class BandPlanManager;
@@ -779,6 +781,11 @@ private:
     // the title bar and persisted via "AppletPanelDockedLeft".
     void setAppletPanelDockedLeft(bool left);
 
+    // Workspace canvas (RFC #4887 phase 3) — MainWindow_Workspace.cpp.
+    void wireWorkspaceCanvas();
+    void toggleWorkspaceCanvas(bool on);
+    QWidget* centralPanWidget() const;
+
     // Show/hide the applet panel — single source of truth that updates the
     // title-bar dock icons and the persisted "AppletPanelVisible" setting.
     void setAppletPanelVisible(bool visible);
@@ -1217,6 +1224,14 @@ private:
     ::QSizeGrip*      m_sizeGrip{nullptr};
     QSplitter*        m_splitter{nullptr};
     PanadapterStack*  m_panStack{nullptr};
+    // Workspace canvas (RFC #4887 phase 3) — created in wireWorkspaceCanvas()
+    // (MainWindow_Workspace.cpp).  When canvas mode is on, m_workspaceCanvas
+    // sits in the splitter slot m_panStack normally occupies and hosts it as
+    // a canvas item; centralPanWidget() is what splitter size/stretch code
+    // compares against so both arrangements share one code path.
+    WorkspaceCanvas*     m_workspaceCanvas{nullptr};
+    WorkspaceController* m_workspaceController{nullptr};
+    QAction*             m_workspaceCanvasAction{nullptr};
     QMetaObject::Connection m_miniPanFreqConn;    // active-slice freq → mini-pan centre
     QMetaObject::Connection m_miniPanFiltConn;    // active-slice filter → mini-pan passband
     bool m_miniPanFeedWanted{false};              // applet visible → consume frames

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1241,6 +1241,7 @@ private:
     WorkspaceController* m_workspaceController{nullptr};
     QAction*             m_workspaceCanvasAction{nullptr};
     QAction*             m_workspaceEditAction{nullptr};
+    bool                 m_statusMessageMirrorWired{false};
     QMetaObject::Connection m_miniPanFreqConn;    // active-slice freq → mini-pan centre
     QMetaObject::Connection m_miniPanFiltConn;    // active-slice filter → mini-pan passband
     bool m_miniPanFeedWanted{false};              // applet visible → consume frames

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -239,6 +239,11 @@ public:
     // actions registered keysTx (the caller decides policy; the registration
     // site declares the data). Returns a ShortcutFire* code.
     Q_INVOKABLE int fireShortcutAction(const QString& id, bool allowTx);
+    // Workspace-canvas bridge hook (RFC #4887 phase 4): status / enable /
+    // disable / place, driven by the `workspace` automation verb.  Returns
+    // an error key instead of throwing, like the other automation hooks.
+    Q_INVOKABLE QVariantMap automationWorkspace(const QString& action,
+                                                const QString& args);
     // Inject one learned VFO-knob CC value through MidiControlManager for
     // automation proof. Returns 0 on acceptance, 1 if MIDI is unavailable,
     // and 2 for an out-of-range MIDI value.

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -817,6 +817,15 @@ void MainWindow::buildMenuBar()
 
     auto* viewMenu = menuBar()->addMenu("&View");
 
+    // Workspace canvas (RFC #4887 phase 3) — opt-in, reversible.  The check
+    // state persists inside the workspace document itself (Principle V), not
+    // in a settings key: wireWorkspaceCanvas() re-applies it at startup and
+    // enabledChanged keeps the action honest if enabling fails.
+    m_workspaceCanvasAction = viewMenu->addAction("Workspace &Canvas (experimental)");
+    m_workspaceCanvasAction->setCheckable(true);
+    connect(m_workspaceCanvasAction, &QAction::toggled, this,
+            [this](bool on) { toggleWorkspaceCanvas(on); });
+
     // Applet-panel show/hide and pop-out are now driven entirely from the
     // title-bar dock icons (#1713 Phase 6).  Ctrl+Shift+S retained here as
     // a window-scoped QShortcut so the keystroke survives the View-menu

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -821,10 +821,20 @@ void MainWindow::buildMenuBar()
     // state persists inside the workspace document itself (Principle V), not
     // in a settings key: wireWorkspaceCanvas() re-applies it at startup and
     // enabledChanged keeps the action honest if enabling fails.
-    m_workspaceCanvasAction = viewMenu->addAction("Workspace &Canvas (experimental)");
+    //
+    // Two postures since the edit-mode field request: Enabled turns the
+    // canvas shell on, Edit Layout arms placement (select/drag/resize/
+    // drops/nudges/dots).  Enabled-but-locked is the OPERATING posture —
+    // interacting with an applet just uses it.  Edit state is session-
+    // transient by design; wireWorkspaceCanvas() syncs both directions.
+    QMenu* wsMenu = viewMenu->addMenu("Workspace &Canvas (experimental)");
+    m_workspaceCanvasAction = wsMenu->addAction("&Enabled");
     m_workspaceCanvasAction->setCheckable(true);
     connect(m_workspaceCanvasAction, &QAction::toggled, this,
             [this](bool on) { toggleWorkspaceCanvas(on); });
+    m_workspaceEditAction = wsMenu->addAction("Edit &Layout");
+    m_workspaceEditAction->setCheckable(true);
+    m_workspaceEditAction->setEnabled(false);   // armed by enabledChanged
 
     // Applet-panel show/hide and pop-out are now driven entirely from the
     // title-bar dock icons (#1713 Phase 6).  Ctrl+Shift+S retained here as

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -62,6 +62,8 @@
 #include "core/AppSettings.h"
 #include "core/AutomationBridgeSettings.h"
 #include "core/AutomationServer.h"
+
+#include <QStatusBar>
 #include "core/LogManager.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
@@ -2318,6 +2320,23 @@ bool MainWindow::startAutomationBridge(const QString& sockName)
 
     if (!m_automation)
         m_automation = std::make_unique<AutomationServer>();
+
+    // dumpTree reports the status-bar message (#4864) by reading a generic
+    // dynamic property — core/ must not know the QStatusBar type
+    // (engine-boundary EB2).  The gui side owns the widget, and the mirror
+    // lives HERE, with the rest of the bridge wiring it serves (review m13:
+    // it was previously wired inside the workspace-canvas mount, which has
+    // no structural link to it).  Idempotent across re-wires: the property
+    // write is safe to connect once per server start.
+    if (!m_statusMessageMirrorWired) {
+        m_statusMessageMirrorWired = true;
+        connect(statusBar(), &QStatusBar::messageChanged, this,
+                [this](const QString& m) {
+                    statusBar()->setProperty("currentMessage", m);
+                });
+        statusBar()->setProperty("currentMessage",
+                                 statusBar()->currentMessage());
+    }
 
     m_automation->setRadioModel(&radioModel());  // for the get() verb
     m_automation->setAudioEngine(audioEngine());

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -51,6 +51,7 @@
 #include "DaxIqApplet.h"
 #include "TciApplet.h"
 #include "PanadapterStack.h"
+#include "workspace/WorkspaceController.h"
 #include "gui/MiniPanApplet.h"
 #include "gui/MiniPanScope.h"
 #include "models/PanadapterModel.h"
@@ -1719,7 +1720,20 @@ void MainWindow::wirePanLifecycle()
 
                 // Restore floating-pan state saved from the previous session.
                 // Runs for any pan count so a single floated pan is also restored.
-                m_panStack->restoreFloatingState();
+                //
+                // NOT while the workspace canvas is on (RFC #4887, maintainer
+                // ruling 2026-08-12): canvas mode owns placement, and replaying
+                // window-persistence floats under it hands the operator an
+                // uncontrollable always-above window that looks exactly like a
+                // broken canvas pan — stale FloatingPanIds from the pre-canvas
+                // era cost a full day of field debugging to identify. The
+                // restored pans have already arrived as canvas items at their
+                // slots by this point; popping out MANUALLY is untouched
+                // (decision 1 — pop-out stays), and the saved key is left
+                // alone so a canvas-off session still restores it.
+                if (!(m_workspaceController && m_workspaceController->isEnabled())) {
+                    m_panStack->restoreFloatingState();
+                }
             });
         }
         const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();

--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -634,7 +634,7 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
     }
     if (obj == m_bandStackIndicator && event->type() == QEvent::MouseButtonPress) {
         bool show = !m_panStack->bandStackPanel()->isVisible();
-        m_panStack->setBandStackVisible(show);
+        setBandStackPanelVisible(show);
         updateBandStackIndicator();
         return true;
     }

--- a/src/gui/MainWindow_Workspace.cpp
+++ b/src/gui/MainWindow_Workspace.cpp
@@ -168,7 +168,15 @@ void MainWindow::toggleWorkspaceCanvas(bool on)
             m_panStack->bandStackPanel()
             && m_panStack->bandStackPanel()->isVisibleTo(m_panStack);
 
-        m_splitter->replaceWidget(panIdx, m_workspaceCanvas);
+        // Detach the stack EXPLICITLY, then insert the canvas into the freed
+        // slot.  replaceWidget() would do a version of this internally, but
+        // the disable path cannot use it at all (below), and the two
+        // directions must mirror each other rather than lean on Qt's
+        // internal ordering.  The parentless moment is the same detour the
+        // phase-3 takeItem() made with the whole stack — field-proven here;
+        // on macOS this is the path refreshAfterReparent() exists for.
+        m_panStack->setParent(nullptr);
+        m_splitter->insertWidget(panIdx, m_workspaceCanvas);
         m_workspaceCanvas->show();
         // Since phase 4 the stack is not an item — its applets are.  It
         // rides hidden as the pans' owner (creation, wiring, float/dock,
@@ -212,7 +220,14 @@ void MainWindow::toggleWorkspaceCanvas(bool on)
     // flat column of whatever order the returns happened in.
     m_workspaceController->disable();
 
+    // The stack is a CHILD of the canvas while the mode is on, so the swap
+    // must detach it first — replaceWidget(canvas, stack) would be replacing
+    // a widget with its own descendant, which Qt part-executes into a wedged
+    // shell: the canvas leaves the splitter with the stack still inside it,
+    // and "classic mode" comes back as a blank centre with the pan painting
+    // at its stale canvas rect (the 8600 field report).
     const int canvasIdx = m_splitter->indexOf(m_workspaceCanvas);
+    m_panStack->setParent(nullptr);
     if (canvasIdx >= 0) {
         m_splitter->replaceWidget(canvasIdx, m_panStack);
     }

--- a/src/gui/MainWindow_Workspace.cpp
+++ b/src/gui/MainWindow_Workspace.cpp
@@ -93,26 +93,39 @@ void MainWindow::wireWorkspaceCanvas()
             m_workspaceController, &WorkspaceController::onPanDocked);
 
     // Each applet's title-strip live-move stream feeds the canvas gesture.
-    // Wired per applet at creation; the applet pointer is captured (not the
-    // id) so a band-recall rekey keeps the stream on the right item.
+    // The applet pointer is captured (not the id) so a band-recall rekey
+    // keeps the stream on the right item.
+    auto wirePanApplet = [this](PanadapterApplet* a) {
+        if (!a) {
+            return;
+        }
+        connect(a, &PanadapterApplet::canvasDragBegan,
+                m_workspaceController, [this, a](const QPoint& g) {
+                    m_workspaceController->beginPanItemMove(a->panId(), g);
+                });
+        connect(a, &PanadapterApplet::canvasDragMoved,
+                m_workspaceController, [this](const QPoint& g) {
+                    m_workspaceController->movePanItem(g);
+                });
+        connect(a, &PanadapterApplet::canvasDragEnded,
+                m_workspaceController, [this](const QPoint& g) {
+                    m_workspaceController->endPanItemMove(g);
+                });
+    };
+    // Pre-existing applets FIRST — the same rule the controller ctor
+    // follows for containers.  buildUI() creates the "default" placeholder
+    // pan long before this method runs, and the radio REKEYS that applet
+    // into its first real pan, so panAdded never fires for it: without
+    // this loop the PRIMARY pan of every session has a dead title strip
+    // (the 8600 "can't drag the pan" report) while pans 2+ wire normally.
+    // No double-wiring: addPanadapter() early-returns an existing applet
+    // without re-emitting panAdded.
+    for (PanadapterApplet* a : m_panStack->allApplets()) {
+        wirePanApplet(a);
+    }
     connect(m_panStack, &PanadapterStack::panAdded, this,
-            [this](const QString& panId) {
-                auto* a = m_panStack->panadapter(panId);
-                if (!a) {
-                    return;
-                }
-                connect(a, &PanadapterApplet::canvasDragBegan,
-                        m_workspaceController, [this, a](const QPoint& g) {
-                            m_workspaceController->beginPanItemMove(a->panId(), g);
-                        });
-                connect(a, &PanadapterApplet::canvasDragMoved,
-                        m_workspaceController, [this](const QPoint& g) {
-                            m_workspaceController->movePanItem(g);
-                        });
-                connect(a, &PanadapterApplet::canvasDragEnded,
-                        m_workspaceController, [this](const QPoint& g) {
-                            m_workspaceController->endPanItemMove(g);
-                        });
+            [this, wirePanApplet](const QString& panId) {
+                wirePanApplet(m_panStack->panadapter(panId));
             });
 
     connect(m_workspaceController, &WorkspaceController::enabledChanged,

--- a/src/gui/MainWindow_Workspace.cpp
+++ b/src/gui/MainWindow_Workspace.cpp
@@ -1,0 +1,132 @@
+// MainWindow_Workspace.cpp — the workspace canvas mount (RFC #4887 phase 3).
+//
+// Everything MainWindow contributes to canvas mode lives here: creating the
+// canvas + controller, the View-menu toggle, and the one structural move —
+// swapping the canvas into the splitter slot the PanadapterStack normally
+// occupies, with the stack riding along as a canvas item.  Placement policy
+// (what a drop means, which applets belong on the canvas, what the document
+// says) is WorkspaceController's business, deliberately not this file's.
+//
+// Sibling TU per docs/architecture/mainwindow-decomposition.md — methods are
+// MainWindow:: members declared in MainWindow.h.
+
+#include "MainWindow.h"
+
+#include "AppletPanel.h"
+#include "PanadapterStack.h"
+#include "containers/ContainerManager.h"
+#include "workspace/WorkspaceCanvas.h"
+#include "workspace/WorkspaceController.h"
+
+#include <QAction>
+#include <QSplitter>
+#include <QStatusBar>
+
+namespace AetherSDR {
+
+QWidget* MainWindow::centralPanWidget() const
+{
+    // The splitter's centre slot: the canvas when canvas mode holds the pan
+    // stack, the pan stack itself otherwise.  Splitter size/stretch code
+    // compares against this so both arrangements share one path.
+    if (m_workspaceController && m_workspaceController->isEnabled()) {
+        return m_workspaceCanvas;
+    }
+    return m_panStack;
+}
+
+void MainWindow::wireWorkspaceCanvas()
+{
+    m_workspaceCanvas = new WorkspaceCanvas;
+    m_workspaceCanvas->hide();   // mounted on demand by toggleWorkspaceCanvas()
+
+    m_workspaceController = new WorkspaceController(
+        m_appletPanel->containerManager(), m_workspaceCanvas, this);
+
+    connect(m_appletPanel, &AppletPanel::canvasReturnRequested,
+            m_workspaceController, &WorkspaceController::returnAppletToPanel);
+
+    connect(m_workspaceController, &WorkspaceController::enabledChanged,
+            this, [this](bool on) {
+                if (m_workspaceCanvasAction
+                    && m_workspaceCanvasAction->isChecked() != on) {
+                    QSignalBlocker blocker(m_workspaceCanvasAction);
+                    m_workspaceCanvasAction->setChecked(on);
+                }
+            });
+
+    // The stored document decides whether the mode comes back up.  boot()
+    // never migrates — a fresh install that has never enabled the canvas
+    // must not gain a Workspaces key just by launching.
+    if (m_workspaceController->boot()) {
+        toggleWorkspaceCanvas(true);
+    }
+}
+
+void MainWindow::toggleWorkspaceCanvas(bool on)
+{
+    if (!m_workspaceController || !m_splitter || !m_panStack) {
+        return;
+    }
+    if (on == m_workspaceController->isEnabled()) {
+        return;
+    }
+
+    if (on) {
+        // Mount first, then enable: the controller places items against the
+        // canvas's real size, so the canvas has to be in the splitter (and
+        // sized by it) before the document is replayed onto it.
+        //
+        // The swap is a same-top-level reparent, which is the SAFE pattern
+        // for the QRhiWidget spectrum children (#4091): the backing-store
+        // QRhi never changes, so no prepare/reset dance is needed — and
+        // deliberately none is done, because forcing one here would be the
+        // destroy/recreate storm that crashed the 2016-era Intel D3D11 UMD.
+        const int panIdx = m_splitter->indexOf(m_panStack);
+        if (panIdx < 0) {
+            return;
+        }
+        m_splitter->replaceWidget(panIdx, m_workspaceCanvas);
+        m_workspaceCanvas->show();
+        m_workspaceController->setPanStackWidget(m_panStack);
+
+        QString whyNot;
+        if (!m_workspaceController->enable(m_appletPanel->appletIds(), &whyNot)) {
+            // Put the shell back exactly as it was and say why, without a
+            // modal in the way of whatever the operator was doing.  The
+            // write-blocked newer-document case lands here (PR #4900 H1).
+            m_splitter->replaceWidget(m_splitter->indexOf(m_workspaceCanvas),
+                                      m_panStack);
+            m_workspaceCanvas->hide();
+            m_panStack->show();
+            if (m_workspaceCanvasAction) {
+                QSignalBlocker blocker(m_workspaceCanvasAction);
+                m_workspaceCanvasAction->setChecked(false);
+            }
+            statusBar()->showMessage(
+                tr("Workspace canvas unavailable: %1").arg(whyNot), 8000);
+            return;
+        }
+
+        // The stack is now a canvas item; the splitter slot follows
+        // centralPanWidget() from here on.
+        for (int i = 0; i < m_splitter->count(); ++i) {
+            m_splitter->setStretchFactor(
+                i, m_splitter->widget(i) == m_workspaceCanvas ? 1 : 0);
+        }
+        return;
+    }
+
+    // Disable: the controller returns every applet to its panel slot and
+    // releases the pan stack parentless; the splitter takes both back.
+    m_workspaceController->disable();
+
+    const int canvasIdx = m_splitter->indexOf(m_workspaceCanvas);
+    if (canvasIdx >= 0) {
+        m_splitter->replaceWidget(canvasIdx, m_panStack);
+    }
+    m_workspaceCanvas->hide();
+    m_panStack->show();
+}
+
+}  // namespace AetherSDR

--- a/src/gui/MainWindow_Workspace.cpp
+++ b/src/gui/MainWindow_Workspace.cpp
@@ -13,8 +13,11 @@
 #include "MainWindow.h"
 
 #include "AppletPanel.h"
+#include "BandStackPanel.h"
+#include "PanadapterApplet.h"
 #include "PanadapterStack.h"
 #include "containers/ContainerManager.h"
+#include "core/AppSettings.h"
 #include "workspace/WorkspaceCanvas.h"
 #include "workspace/WorkspaceController.h"
 
@@ -48,6 +51,67 @@ void MainWindow::wireWorkspaceCanvas()
             m_workspaceController, &WorkspaceController::returnAppletToPanel);
     // A live move released over the panel returns the applet to it.
     m_workspaceController->setReturnTarget(m_appletPanel);
+
+    // ── Pans as items (RFC #4887 phase 4) ────────────────────────────────
+    //
+    // The controller's pan seam is callbacks + slots, never a stack pointer:
+    // policy stays unit-testable against plain widgets.  These lambdas are
+    // the only place the two types meet.
+    WorkspaceController::PanHostHooks hooks;
+    hooks.panIds     = [this] { return m_panStack->panIds(); };
+    hooks.detach     = [this](const QString& id) -> QWidget* {
+        return m_panStack->detachForCanvas(id);
+    };
+    hooks.restore    = [this](const QString& id, QWidget* w) {
+        m_panStack->returnFromCanvas(id, qobject_cast<PanadapterApplet*>(w));
+    };
+    hooks.isFloating = [this](const QString& id) {
+        return m_panStack->isFloating(id);
+    };
+    hooks.requestFloat = [this](const QString& id) {
+        m_panStack->floatPanadapter(id);
+    };
+    hooks.bandStack = [this]() -> QWidget* {
+        return m_panStack->bandStackPanel();
+    };
+    hooks.reclaimBandStack = [this](QWidget*) {
+        m_panStack->reclaimBandStackPanel();
+    };
+    m_workspaceController->setPanHost(hooks);
+
+    connect(m_panStack, &PanadapterStack::panAdded,
+            m_workspaceController, &WorkspaceController::onPanAdded);
+    connect(m_panStack, &PanadapterStack::panRemoved,
+            m_workspaceController, &WorkspaceController::onPanRemoved);
+    connect(m_panStack, &PanadapterStack::panRekeyed,
+            m_workspaceController, &WorkspaceController::onPanRekeyed);
+    connect(m_panStack, &PanadapterStack::panFloated,
+            m_workspaceController, &WorkspaceController::onPanFloated);
+    connect(m_panStack, &PanadapterStack::panDocked,
+            m_workspaceController, &WorkspaceController::onPanDocked);
+
+    // Each applet's title-strip live-move stream feeds the canvas gesture.
+    // Wired per applet at creation; the applet pointer is captured (not the
+    // id) so a band-recall rekey keeps the stream on the right item.
+    connect(m_panStack, &PanadapterStack::panAdded, this,
+            [this](const QString& panId) {
+                auto* a = m_panStack->panadapter(panId);
+                if (!a) {
+                    return;
+                }
+                connect(a, &PanadapterApplet::canvasDragBegan,
+                        m_workspaceController, [this, a](const QPoint& g) {
+                            m_workspaceController->beginPanItemMove(a->panId(), g);
+                        });
+                connect(a, &PanadapterApplet::canvasDragMoved,
+                        m_workspaceController, [this](const QPoint& g) {
+                            m_workspaceController->movePanItem(g);
+                        });
+                connect(a, &PanadapterApplet::canvasDragEnded,
+                        m_workspaceController, [this](const QPoint& g) {
+                            m_workspaceController->endPanItemMove(g);
+                        });
+            });
 
     connect(m_workspaceController, &WorkspaceController::enabledChanged,
             this, [this](bool on) {
@@ -97,9 +161,18 @@ void MainWindow::toggleWorkspaceCanvas(bool on)
         if (panIdx < 0) {
             return;
         }
+        // Session-transient, so read it BEFORE the stack goes hidden.
+        const bool bandStackWasVisible =
+            m_panStack->bandStackPanel()
+            && m_panStack->bandStackPanel()->isVisibleTo(m_panStack);
+
         m_splitter->replaceWidget(panIdx, m_workspaceCanvas);
         m_workspaceCanvas->show();
-        m_workspaceController->setPanStackWidget(m_panStack);
+        // Since phase 4 the stack is not an item — its applets are.  It
+        // rides hidden as the pans' owner (creation, wiring, float/dock,
+        // render scheduling); enable() borrows each applet onto the canvas.
+        m_panStack->setParent(m_workspaceCanvas);
+        m_panStack->hide();
 
         QString whyNot;
         if (!m_workspaceController->enable(m_appletPanel->appletIds(), &whyNot)) {
@@ -119,8 +192,10 @@ void MainWindow::toggleWorkspaceCanvas(bool on)
             return;
         }
 
-        // The stack is now a canvas item; the splitter slot follows
-        // centralPanWidget() from here on.
+        if (bandStackWasVisible) {
+            m_workspaceController->setBandStackVisible(true);
+        }
+
         for (int i = 0; i < m_splitter->count(); ++i) {
             m_splitter->setStretchFactor(
                 i, m_splitter->widget(i) == m_workspaceCanvas ? 1 : 0);
@@ -129,7 +204,10 @@ void MainWindow::toggleWorkspaceCanvas(bool on)
     }
 
     // Disable: the controller returns every applet to its panel slot and
-    // releases the pan stack parentless; the splitter takes both back.
+    // every pan applet into the stack's splitter (the band stack too); the
+    // splitter takes the stack back, and the operator's saved pan layout is
+    // re-applied so Classic comes back as the arrangement it was, not as a
+    // flat column of whatever order the returns happened in.
     m_workspaceController->disable();
 
     const int canvasIdx = m_splitter->indexOf(m_workspaceCanvas);
@@ -138,6 +216,23 @@ void MainWindow::toggleWorkspaceCanvas(bool on)
     }
     m_workspaceCanvas->hide();
     m_panStack->show();
+    if (m_panStack->count() > 1) {
+        m_panStack->rearrangeLayout(
+            AppSettings::instance()
+                .value(QStringLiteral("PanadapterLayout"), QStringLiteral("1"))
+                .toString());
+    }
+}
+
+void MainWindow::setBandStackPanelVisible(bool show)
+{
+    if (m_workspaceController && m_workspaceController->isEnabled()) {
+        m_workspaceController->setBandStackVisible(show);
+        return;
+    }
+    if (m_panStack) {
+        m_panStack->setBandStackVisible(show);
+    }
 }
 
 }  // namespace AetherSDR

--- a/src/gui/MainWindow_Workspace.cpp
+++ b/src/gui/MainWindow_Workspace.cpp
@@ -43,6 +43,16 @@ QWidget* MainWindow::centralPanWidget() const
 
 void MainWindow::wireWorkspaceCanvas()
 {
+    // The automation bridge reports the status-bar message in dumpTree
+    // (#4864) by reading a generic dynamic property — core/ must not know
+    // the QStatusBar type (engine-boundary EB2).  The gui side owns the
+    // widget, so the mirror lives here, wired once at startup.
+    connect(statusBar(), &QStatusBar::messageChanged, this,
+            [this](const QString& m) {
+                statusBar()->setProperty("currentMessage", m);
+            });
+    statusBar()->setProperty("currentMessage", statusBar()->currentMessage());
+
     m_workspaceCanvas = new WorkspaceCanvas;
     m_workspaceCanvas->hide();   // mounted on demand by toggleWorkspaceCanvas()
 

--- a/src/gui/MainWindow_Workspace.cpp
+++ b/src/gui/MainWindow_Workspace.cpp
@@ -25,7 +25,6 @@
 #include <QVariantList>
 #include <QVariantMap>
 #include <QSplitter>
-#include <QStatusBar>
 #include <QTimer>
 
 namespace AetherSDR {
@@ -43,17 +42,11 @@ QWidget* MainWindow::centralPanWidget() const
 
 void MainWindow::wireWorkspaceCanvas()
 {
-    // The automation bridge reports the status-bar message in dumpTree
-    // (#4864) by reading a generic dynamic property — core/ must not know
-    // the QStatusBar type (engine-boundary EB2).  The gui side owns the
-    // widget, so the mirror lives here, wired once at startup.
-    connect(statusBar(), &QStatusBar::messageChanged, this,
-            [this](const QString& m) {
-                statusBar()->setProperty("currentMessage", m);
-            });
-    statusBar()->setProperty("currentMessage", statusBar()->currentMessage());
-
-    m_workspaceCanvas = new WorkspaceCanvas;
+    // Owned by the window from birth (review note: parentless, it leaked on
+    // never-enabled installs and after every disable) — and being a child
+    // of the same top level is ALSO what makes every mount move below a
+    // same-top-level reparent (red-team B1).
+    m_workspaceCanvas = new WorkspaceCanvas(this);
     m_workspaceCanvas->hide();   // mounted on demand by toggleWorkspaceCanvas()
 
     m_workspaceController = new WorkspaceController(
@@ -211,29 +204,41 @@ void MainWindow::toggleWorkspaceCanvas(bool on)
             m_panStack->bandStackPanel()
             && m_panStack->bandStackPanel()->isVisibleTo(m_panStack);
 
-        // Detach the stack EXPLICITLY, then insert the canvas into the freed
-        // slot.  replaceWidget() would do a version of this internally, but
-        // the disable path cannot use it at all (below), and the two
-        // directions must mirror each other rather than lean on Qt's
-        // internal ordering.  The parentless moment is the same detour the
-        // phase-3 takeItem() made with the whole stack — field-proven here;
-        // on macOS this is the path refreshAfterReparent() exists for.
-        m_panStack->setParent(nullptr);
-        m_splitter->insertWidget(panIdx, m_workspaceCanvas);
-        m_workspaceCanvas->show();
+        // EVERY move below is a ONE-STEP, SAME-TOP-LEVEL reparent — the
+        // #2495-safe pattern for the QRhiWidget children riding inside the
+        // stack.  No widget ever passes through setParent(nullptr): a
+        // parentless QWidget IS a transient top-level, and taking the
+        // stack's live QRhi children through one without float/dock's
+        // prepare/reset dance is the #1344/#4091 hazard (red-team B1 —
+        // the previous shape did exactly that, twice per toggle).  The
+        // canvas is a child of this window from construction, so
+        // stack→canvas and canvas→splitter both stay inside one top-level.
+        //
         // Since phase 4 the stack is not an item — its applets are.  It
         // rides hidden as the pans' owner (creation, wiring, float/dock,
         // render scheduling); enable() borrows each applet onto the canvas.
         m_panStack->setParent(m_workspaceCanvas);
         m_panStack->hide();
+        m_splitter->insertWidget(panIdx, m_workspaceCanvas);
+        m_workspaceCanvas->show();
 
         QString whyNot;
         if (!m_workspaceController->enable(m_appletPanel->appletIds(), &whyNot)) {
             // Put the shell back exactly as it was and say why, without a
             // modal in the way of whatever the operator was doing.  The
             // write-blocked newer-document case lands here (PR #4900 H1).
-            m_splitter->replaceWidget(m_splitter->indexOf(m_workspaceCanvas),
-                                      m_panStack);
+            // Same one-step discipline in reverse — the previous rollback
+            // called replaceWidget(canvas, <canvas's own child>), the
+            // exact wedged-shell shape the reviews flagged, on the one
+            // path that runs when something already went wrong.
+            m_panStack->setParent(this);
+            const int backIdx = m_splitter->indexOf(m_workspaceCanvas);
+            if (backIdx >= 0) {
+                m_splitter->replaceWidget(backIdx, m_panStack);
+            } else {
+                m_splitter->insertWidget(panIdx, m_panStack);
+            }
+            m_workspaceCanvas->setParent(this);
             m_workspaceCanvas->hide();
             m_panStack->show();
             if (m_workspaceCanvasAction) {
@@ -263,17 +268,22 @@ void MainWindow::toggleWorkspaceCanvas(bool on)
     // flat column of whatever order the returns happened in.
     m_workspaceController->disable();
 
-    // The stack is a CHILD of the canvas while the mode is on, so the swap
-    // must detach it first — replaceWidget(canvas, stack) would be replacing
-    // a widget with its own descendant, which Qt part-executes into a wedged
-    // shell: the canvas leaves the splitter with the stack still inside it,
-    // and "classic mode" comes back as a blank centre with the pan painting
-    // at its stale canvas rect (the 8600 field report).
+    // The stack is a CHILD of the canvas while the mode is on, so it steps
+    // to this window first (one-step, same-top-level — never through
+    // nullptr, red-team B1), then swaps into the canvas's slot.  The
+    // canvas is re-owned by this window afterwards: replaceWidget() drops
+    // its parent, and an unowned canvas leaks across mode cycles and
+    // never-enabled sessions (review note).
     const int canvasIdx = m_splitter->indexOf(m_workspaceCanvas);
-    m_panStack->setParent(nullptr);
+    m_panStack->setParent(this);
     if (canvasIdx >= 0) {
         m_splitter->replaceWidget(canvasIdx, m_panStack);
+    } else {
+        // The canvas is somehow already out of the splitter — never leave
+        // the shell without a centre widget (review note).
+        m_splitter->insertWidget(0, m_panStack);
     }
+    m_workspaceCanvas->setParent(this);
     m_workspaceCanvas->hide();
     m_panStack->show();
     if (m_panStack->count() > 1) {
@@ -383,6 +393,16 @@ QVariantMap MainWindow::automationWorkspace(const QString& action,
         }
         if (!okX || !okY || !okW || !okH) {
             out[QStringLiteral("error")] = QStringLiteral("unparseable coordinates");
+            return out;
+        }
+        // Reject, don't clamp, hostile numerics (red-team M2): inf/nan and
+        // zero/negative sizes used to collapse to a {0,0,0,0} rect that was
+        // persisted — a permanently unhittable item reported as ok:true.
+        // setItemRect refuses invalid rects too now; this check exists so
+        // the CALLER hears why instead of a silent no-op.
+        if (!r.isValid()) {
+            out[QStringLiteral("error")] = QStringLiteral(
+                "coordinates must be finite with positive size");
             return out;
         }
         m_workspaceCanvas->setItemRect(itemId, r);   // clamped; the

--- a/src/gui/MainWindow_Workspace.cpp
+++ b/src/gui/MainWindow_Workspace.cpp
@@ -135,7 +135,27 @@ void MainWindow::wireWorkspaceCanvas()
                     QSignalBlocker blocker(m_workspaceCanvasAction);
                     m_workspaceCanvasAction->setChecked(on);
                 }
+                // Edit Layout is meaningful only while the canvas is up.
+                if (m_workspaceEditAction) {
+                    m_workspaceEditAction->setEnabled(on);
+                }
             });
+
+    // Edit Layout ↔ canvas edit mode, both directions: the context menu's
+    // toggle and the controller's first-enable policy also flip the mode,
+    // and the menu action must stay honest.
+    if (m_workspaceEditAction) {
+        connect(m_workspaceEditAction, &QAction::toggled, this, [this](bool on) {
+            m_workspaceCanvas->setEditMode(on);
+        });
+        connect(m_workspaceCanvas, &WorkspaceCanvas::editModeChanged, this,
+                [this](bool on) {
+                    if (m_workspaceEditAction->isChecked() != on) {
+                        QSignalBlocker blocker(m_workspaceEditAction);
+                        m_workspaceEditAction->setChecked(on);
+                    }
+                });
+    }
 
     // The stored document decides whether the mode comes back up.  boot()
     // never migrates — a fresh install that has never enabled the canvas
@@ -266,6 +286,7 @@ QVariantMap MainWindow::automationWorkspace(const QString& action,
 
     if (action == QLatin1String("status") || action == QLatin1String("query")) {
         out[QStringLiteral("enabled")]  = enabled;
+        out[QStringLiteral("edit")]     = m_workspaceCanvas->isEditMode();
         out[QStringLiteral("gridSnap")] = m_workspaceCanvas->isGridSnapEnabled();
         out[QStringLiteral("selected")] = m_workspaceCanvas->selectedItem();
         QVariantList items;
@@ -305,6 +326,22 @@ QVariantMap MainWindow::automationWorkspace(const QString& action,
             out[QStringLiteral("error")] =
                 QStringLiteral("enable refused — see statusMessage");
         }
+        return out;
+    }
+
+    if (action == QLatin1String("edit")) {
+        // Operator posture only — `place` stays available in BOTH postures
+        // (the bridge is not an operator, and tests must be able to arrange
+        // a locked canvas).
+        const QString v = args.trimmed().toLower();
+        if (v == QLatin1String("on") || v == QLatin1String("off")) {
+            m_workspaceCanvas->setEditMode(v == QLatin1String("on"));
+        } else if (!v.isEmpty()) {
+            out[QStringLiteral("error")] =
+                QStringLiteral("edit wants on|off (or nothing to query)");
+            return out;
+        }
+        out[QStringLiteral("edit")] = m_workspaceCanvas->isEditMode();
         return out;
     }
 
@@ -351,7 +388,7 @@ QVariantMap MainWindow::automationWorkspace(const QString& action,
 
     out[QStringLiteral("error")] =
         QStringLiteral("unknown workspace action: %1 "
-                       "(status|enable|disable|place)").arg(action);
+                       "(status|enable|disable|edit|place)").arg(action);
     return out;
 }
 

--- a/src/gui/MainWindow_Workspace.cpp
+++ b/src/gui/MainWindow_Workspace.cpp
@@ -22,6 +22,8 @@
 #include "workspace/WorkspaceController.h"
 
 #include <QAction>
+#include <QVariantList>
+#include <QVariantMap>
 #include <QSplitter>
 #include <QStatusBar>
 #include <QTimer>
@@ -222,6 +224,100 @@ void MainWindow::toggleWorkspaceCanvas(bool on)
                 .value(QStringLiteral("PanadapterLayout"), QStringLiteral("1"))
                 .toString());
     }
+}
+
+QVariantMap MainWindow::automationWorkspace(const QString& action,
+                                            const QString& args)
+{
+    QVariantMap out;
+    if (!m_workspaceController || !m_workspaceCanvas) {
+        out[QStringLiteral("error")] = QStringLiteral("workspace canvas not wired");
+        return out;
+    }
+    const bool enabled = m_workspaceController->isEnabled();
+
+    if (action == QLatin1String("status") || action == QLatin1String("query")) {
+        out[QStringLiteral("enabled")]  = enabled;
+        out[QStringLiteral("gridSnap")] = m_workspaceCanvas->isGridSnapEnabled();
+        out[QStringLiteral("selected")] = m_workspaceCanvas->selectedItem();
+        QVariantList items;
+        for (const CanvasItem& it : m_workspaceCanvas->layout().itemsByZ()) {
+            QVariantMap m;
+            m[QStringLiteral("id")]   = it.id;
+            m[QStringLiteral("type")] = it.contentType;
+            m[QStringLiteral("x")]    = it.rect.x;
+            m[QStringLiteral("y")]    = it.rect.y;
+            m[QStringLiteral("w")]    = it.rect.w;
+            m[QStringLiteral("h")]    = it.rect.h;
+            m[QStringLiteral("z")]    = m_workspaceCanvas->layout().zOf(it.id);
+            items.append(m);
+        }
+        out[QStringLiteral("items")] = items;
+        out[QStringLiteral("count")] = items.size();
+        return out;
+    }
+
+    if (action == QLatin1String("enable") || action == QLatin1String("disable")) {
+        const bool want = (action == QLatin1String("enable"));
+        if (want != enabled) {
+            toggleWorkspaceCanvas(want);
+        }
+        const bool now = m_workspaceController->isEnabled();
+        out[QStringLiteral("enabled")] = now;
+        if (want && !now) {
+            // The refusal reason went to the status bar (the H1 path);
+            // dumpTree's statusMessage carries it for asserting.
+            out[QStringLiteral("error")] =
+                QStringLiteral("enable refused — see statusMessage");
+        }
+        return out;
+    }
+
+    if (action == QLatin1String("place")) {
+        if (!enabled) {
+            out[QStringLiteral("error")] = QStringLiteral("canvas mode is off");
+            return out;
+        }
+        const QStringList parts =
+            args.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        if (parts.size() != 3 && parts.size() != 5) {
+            out[QStringLiteral("error")] = QStringLiteral(
+                "place wants <itemId> <x> <y> [w h] (canvas fractions)");
+            return out;
+        }
+        const QString itemId = parts.at(0);
+        if (!m_workspaceCanvas->contains(itemId)) {
+            out[QStringLiteral("error")] =
+                QStringLiteral("no such item: %1").arg(itemId);
+            return out;
+        }
+        bool okX = false, okY = false, okW = true, okH = true;
+        NormRect r = m_workspaceCanvas->itemRect(itemId);
+        r.x = parts.at(1).toDouble(&okX);
+        r.y = parts.at(2).toDouble(&okY);
+        if (parts.size() == 5) {
+            r.w = parts.at(3).toDouble(&okW);
+            r.h = parts.at(4).toDouble(&okH);
+        }
+        if (!okX || !okY || !okW || !okH) {
+            out[QStringLiteral("error")] = QStringLiteral("unparseable coordinates");
+            return out;
+        }
+        m_workspaceCanvas->setItemRect(itemId, r);   // clamped; the
+        m_workspaceController->commitPlacement();    // controller records it
+        const NormRect applied = m_workspaceCanvas->itemRect(itemId);
+        out[QStringLiteral("id")] = itemId;
+        out[QStringLiteral("x")]  = applied.x;
+        out[QStringLiteral("y")]  = applied.y;
+        out[QStringLiteral("w")]  = applied.w;
+        out[QStringLiteral("h")]  = applied.h;
+        return out;
+    }
+
+    out[QStringLiteral("error")] =
+        QStringLiteral("unknown workspace action: %1 "
+                       "(status|enable|disable|place)").arg(action);
+    return out;
 }
 
 void MainWindow::setBandStackPanelVisible(bool show)

--- a/src/gui/MainWindow_Workspace.cpp
+++ b/src/gui/MainWindow_Workspace.cpp
@@ -21,6 +21,7 @@
 #include <QAction>
 #include <QSplitter>
 #include <QStatusBar>
+#include <QTimer>
 
 namespace AetherSDR {
 
@@ -58,8 +59,16 @@ void MainWindow::wireWorkspaceCanvas()
     // The stored document decides whether the mode comes back up.  boot()
     // never migrates — a fresh install that has never enabled the canvas
     // must not gain a Workspaces key just by launching.
+    //
+    // The mount itself is DEFERRED one event-loop turn: this runs in the
+    // MainWindow constructor, before show() and the first layout pass, and
+    // replaying the document onto a canvas with no real geometry is exactly
+    // how the phase 3 field report broke — every item displayed full-canvas
+    // for the whole session.  The model is bounds-only now so a degenerate
+    // size can no longer corrupt anything, but mounting after layout means
+    // the first frame the operator sees is the right one.
     if (m_workspaceController->boot()) {
-        toggleWorkspaceCanvas(true);
+        QTimer::singleShot(0, this, [this] { toggleWorkspaceCanvas(true); });
     }
 }
 

--- a/src/gui/MainWindow_Workspace.cpp
+++ b/src/gui/MainWindow_Workspace.cpp
@@ -265,6 +265,13 @@ QVariantMap MainWindow::automationWorkspace(const QString& action,
             m[QStringLiteral("w")]    = it.rect.w;
             m[QStringLiteral("h")]    = it.rect.h;
             m[QStringLiteral("z")]    = m_workspaceCanvas->layout().zOf(it.id);
+            // Whether the widget is REALLY a canvas child right now — the
+            // model can be healthy while a stack rebuild has reclaimed the
+            // widget (the 8600 theft), and this is how a smoke proves the
+            // difference without trusting the model it is auditing.
+            QWidget* w = m_workspaceCanvas->itemWidget(it.id);
+            m[QStringLiteral("hosted")] =
+                (w && w->parentWidget() == m_workspaceCanvas);
             items.append(m);
         }
         out[QStringLiteral("items")] = items;

--- a/src/gui/MainWindow_Workspace.cpp
+++ b/src/gui/MainWindow_Workspace.cpp
@@ -46,6 +46,8 @@ void MainWindow::wireWorkspaceCanvas()
 
     connect(m_appletPanel, &AppletPanel::canvasReturnRequested,
             m_workspaceController, &WorkspaceController::returnAppletToPanel);
+    // A live move released over the panel returns the applet to it.
+    m_workspaceController->setReturnTarget(m_appletPanel);
 
     connect(m_workspaceController, &WorkspaceController::enabledChanged,
             this, [this](bool on) {

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -50,6 +50,10 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
         "stop:0 {{color.text.disabled}}, stop:0.5 {{color.background.1}}, stop:1 #1a2a38); "
         "border-bottom: 1px solid #0a1a28; }");
     m_titleBar->installEventFilter(this);  // drag-to-move when floating
+    // Addressable for the automation bridge (#3646/#4864 pattern): the
+    // canvas live-move stream starts here, and a drag the bridge cannot
+    // aim at is a drag no smoke can regress-test.
+    m_titleBar->setAccessibleName(QStringLiteral("panTitleBar"));
     auto* titleBar = m_titleBar;
 
     auto* barLayout = new QHBoxLayout(titleBar);
@@ -864,8 +868,20 @@ bool PanadapterApplet::eventFilter(QObject* obj, QEvent* ev)
                 m_canvasPressed  = true;
                 m_canvasDragging = false;
                 m_canvasPressPos = me->globalPosition().toPoint();
+                // CONSUME the press.  The strip is a plain QWidget whose
+                // default handler IGNORES presses; an ignored press
+                // propagates to the applet and leaves the implicit mouse
+                // grab there, so every subsequent MouseMove bypasses this
+                // filter and the drag can never start (the 8600 "can't
+                // drag the pan" report — the selection that DID happen came
+                // from the canvas's press-raise filter on the propagated
+                // event, which masked the break).  ContainerTitleBar never
+                // had the problem: its reimplemented handler accepts.  The
+                // press's side effect is re-created here since the tail of
+                // this filter is no longer reached:
+                emit activated(m_panId);
+                return true;
             }
-            // fall through: the press still activates the pan below
         } else if (ev->type() == QEvent::MouseMove) {
             if (m_canvasPressed && (me->buttons() & Qt::LeftButton)) {
                 const QPoint g = me->globalPosition().toPoint();

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -549,6 +549,20 @@ void PanadapterApplet::setMultiPanMode(bool multi)
     if (m_closeBtn) m_closeBtn->setVisible(multi);
 }
 
+void PanadapterApplet::setOnCanvas(bool on)
+{
+    m_onCanvas = on;
+    m_canvasPressed  = false;
+    m_canvasDragging = false;
+    if (on && m_popOutBtn) {
+        // A canvas item can always pop out (RFC #4887 decision 1 — pop-out
+        // stays), even as the only pan: the single-pan button hiding is a
+        // stack-mode economy, not a rule about floating.  Off-canvas, the
+        // stack's next setMultiPanMode() re-applies its economy.
+        m_popOutBtn->setVisible(true);
+    }
+}
+
 void PanadapterApplet::setFloatingState(bool floating)
 {
     m_isFloating = floating;
@@ -834,6 +848,48 @@ bool PanadapterApplet::eventFilter(QObject* obj, QEvent* ev)
         }
     }
 #endif
+
+    // Canvas item (RFC #4887 phase 4): the title strip streams a live-move
+    // gesture, mirroring ContainerTitleBar's canvas mode.  A 6 px threshold
+    // separates a click (activate, below) from a drag; everything past it is
+    // consumed so the strip's floating-drag machinery never sees it.
+    if (obj == m_titleBar && m_onCanvas && !m_isFloating
+        && (ev->type() == QEvent::MouseButtonPress
+            || ev->type() == QEvent::MouseMove
+            || ev->type() == QEvent::MouseButtonRelease)) {
+        constexpr int kCanvasDragThresholdPx = 6;
+        auto* me = static_cast<QMouseEvent*>(ev);
+        if (ev->type() == QEvent::MouseButtonPress) {
+            if (me->button() == Qt::LeftButton) {
+                m_canvasPressed  = true;
+                m_canvasDragging = false;
+                m_canvasPressPos = me->globalPosition().toPoint();
+            }
+            // fall through: the press still activates the pan below
+        } else if (ev->type() == QEvent::MouseMove) {
+            if (m_canvasPressed && (me->buttons() & Qt::LeftButton)) {
+                const QPoint g = me->globalPosition().toPoint();
+                if (!m_canvasDragging) {
+                    if ((g - m_canvasPressPos).manhattanLength()
+                        < kCanvasDragThresholdPx) {
+                        return true;
+                    }
+                    m_canvasDragging = true;
+                    emit canvasDragBegan(m_canvasPressPos);
+                }
+                emit canvasDragMoved(g);
+                return true;
+            }
+        } else {   // MouseButtonRelease
+            if (m_canvasDragging) {
+                m_canvasDragging = false;
+                m_canvasPressed  = false;
+                emit canvasDragEnded(me->globalPosition().toPoint());
+                return true;
+            }
+            m_canvasPressed = false;
+        }
+    }
 
     if (obj == m_titleBar && m_isFloating && ev->type() == QEvent::MouseMove) {
         return FramelessMoveHelper::move(m_titleBar, static_cast<QMouseEvent*>(ev));

--- a/src/gui/PanadapterApplet.h
+++ b/src/gui/PanadapterApplet.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QPoint>
 #include <QWidget>
 
 class QComboBox;
@@ -45,6 +46,15 @@ public:
     void setMultiPanMode(bool multi);
     void setFloatingState(bool floating);
 
+    // Canvas hosting (RFC #4887 phase 4): while the applet is an item on the
+    // workspace canvas its title strip streams the live-move gesture, the
+    // same mechanism as ContainerTitleBar's canvas mode — a real gesture the
+    // canvas session follows, not a QDrag ghost.  Set by PanadapterStack's
+    // detachForCanvas()/returnFromCanvas(); mutually exclusive with
+    // floating, whose frameless-move branches take precedence.
+    void setOnCanvas(bool on);
+    bool isOnCanvas() const { return m_onCanvas; }
+
 #ifdef AETHER_ASR_ENABLED
     // Copy Assist (ASR) decode dock — mirrors the CW decode panel: docked under
     // the waterfall, resizable, hidden until shown. copyAssistPanel() lazily
@@ -85,6 +95,10 @@ public:
 
 signals:
     void activated(const QString& panId);
+    // The canvas live-move stream (RFC #4887 phase 4; only while on-canvas).
+    void canvasDragBegan(const QPoint& globalPos);
+    void canvasDragMoved(const QPoint& globalPos);
+    void canvasDragEnded(const QPoint& globalPos);
     void closeRequested(const QString& panId);
     void popOutClicked();
     void dockClicked();
@@ -124,6 +138,12 @@ private:
     QPushButton*    m_maxBtn{nullptr};
     QPushButton*    m_closeBtn{nullptr};
     bool            m_isFloating{false};
+
+    // Canvas-item state (RFC #4887 phase 4).
+    bool   m_onCanvas{false};
+    bool   m_canvasPressed{false};
+    bool   m_canvasDragging{false};
+    QPoint m_canvasPressPos;
 
     // Main vertical layout (SpectrumWidget + docks); kept so the Copy Assist
     // dock can be inserted at the bottom on demand.

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -172,6 +172,16 @@ void PanadapterStack::clearFloatingRestoreMarker()
     settings.save();
 }
 
+void PanadapterStack::reclaimBandStackPanel()
+{
+    if (!m_bandStackPanel) {
+        return;
+    }
+    if (auto* hbox = qobject_cast<QHBoxLayout*>(layout())) {
+        hbox->insertWidget(0, m_bandStackPanel);
+    }
+}
+
 void PanadapterStack::setBandStackVisible(bool visible)
 {
     m_bandStackPanel->setVisible(visible);

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -220,6 +220,9 @@ PanadapterApplet* PanadapterStack::addPanadapter(const QString& panId)
     if (multi)
         equalizeSizes();
 
+    if (!m_inApplyLayout)
+        emit panAdded(panId);
+
     return applet;
 }
 
@@ -237,6 +240,10 @@ void PanadapterStack::removePanadapter(const QString& panId)
 
     auto* applet = m_pans.take(panId);
     if (!applet) return;
+
+    // Unregistered but not yet destroyed: a canvas hosting this applet
+    // releases its entry here instead of waiting for the destroyed-watch.
+    emit panRemoved(panId);
 
     delete applet;
 
@@ -262,6 +269,7 @@ void PanadapterStack::rekey(const QString& oldId, const QString& newId)
         m_seenPanIds.insert(newId);
         if (m_activePanId == oldId)
             m_activePanId = newId;
+        emit panRekeyed(oldId, newId);
     }
 }
 
@@ -608,6 +616,9 @@ void PanadapterStack::removeAll()
     }
     m_floatingWindows.clear();
 
+    const QList<QString> ids = m_pans.keys();
+    for (const QString& id : ids)
+        emit panRemoved(id);
     qDeleteAll(m_pans);
     m_pans.clear();
     m_activePanId.clear();
@@ -725,6 +736,11 @@ void PanadapterStack::rebuildDockedSplitter()
 
 void PanadapterStack::applyLayout(const QString& layoutId, const QStringList& panIds)
 {
+    // Announce every applet this call creates exactly once, at the end —
+    // some branches go through addPanadapter(), some create inline.
+    const QList<QString> preExisting = m_pans.keys();
+    m_inApplyLayout = true;
+
     // Build structure based on layout ID.
     // Each layout adds applets to the correct splitter position.
     // panIds must have at least as many entries as the layout requires.
@@ -862,6 +878,12 @@ void PanadapterStack::applyLayout(const QString& layoutId, const QStringList& pa
         addPanadapter(panIds[2]);
         addPanadapter(panIds[3]);
     }
+
+    m_inApplyLayout = false;
+    for (auto it = m_pans.constBegin(); it != m_pans.constEnd(); ++it) {
+        if (!preExisting.contains(it.key()))
+            emit panAdded(it.key());
+    }
 }
 
 // ── Float / Dock ──────────────────────────────────────────────────────────
@@ -893,6 +915,30 @@ QVariantMap PanadapterStack::automationFloatDock(const QString& action,
         {QStringLiteral("floatingCount"), int(m_floatingWindows.size())},
         {QStringLiteral("dockedCount"), int(m_pans.size() - m_floatingWindows.size())},
     };
+}
+
+PanadapterApplet* PanadapterStack::detachForCanvas(const QString& panId)
+{
+    if (m_floatingWindows.contains(panId))
+        return nullptr;
+    PanadapterApplet* applet = m_pans.value(panId, nullptr);
+    if (applet)
+        applet->setOnCanvas(true);
+    return applet;
+}
+
+void PanadapterStack::returnFromCanvas(const QString& panId,
+                                       PanadapterApplet* applet)
+{
+    if (!applet || m_pans.value(panId, nullptr) != applet)
+        return;
+    applet->setOnCanvas(false);
+    m_splitter->addWidget(applet);
+    m_splitter->setStretchFactor(m_splitter->indexOf(applet), 1);
+    applet->show();
+    const bool multi = m_pans.size() > 1;
+    for (auto* a : m_pans)
+        a->setMultiPanMode(multi);
 }
 
 void PanadapterStack::floatPanadapter(const QString& panId)
@@ -934,6 +980,7 @@ void PanadapterStack::floatPanadapter(const QString& panId)
     // and lifetime.
     auto* fw = new PanFloatingWindow(window());
     fw->adoptApplet(applet);
+    applet->setOnCanvas(false);   // floating now; canvas releases its entry
     applet->spectrumWidget()->setFloating(true);
 
     m_floatingWindows[panId] = fw;

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -250,6 +250,7 @@ void PanadapterStack::removePanadapter(const QString& panId)
 
     auto* applet = m_pans.take(panId);
     if (!applet) return;
+    m_lentToCanvas.remove(panId);
 
     // Unregistered but not yet destroyed: a canvas hosting this applet
     // releases its entry here instead of waiting for the destroyed-watch.
@@ -275,6 +276,8 @@ void PanadapterStack::rekey(const QString& oldId, const QString& newId)
 {
     if (auto* applet = m_pans.take(oldId)) {
         m_pans[newId] = applet;
+        if (m_lentToCanvas.remove(oldId))
+            m_lentToCanvas.insert(newId);
         m_seenPanIds.remove(oldId);
         m_seenPanIds.insert(newId);
         if (m_activePanId == oldId)
@@ -451,8 +454,17 @@ void PanadapterStack::rearrangeLayout(const QString& layoutId)
         saveFloatingState();
     }
 
-    // Collect applets in order
-    QList<PanadapterApplet*> applets = m_pans.values();
+    // Collect applets in order — loaned ones are the canvas's to place, not
+    // this method's (see m_lentToCanvas; the connect-time layout restore
+    // lands here with canvas mode on, and must not reclaim a thing).  A
+    // float docked by the loop above re-lends itself DURING that loop: the
+    // panDocked emission is direct, the controller detaches on the spot,
+    // and the collection below correctly skips it.
+    QList<PanadapterApplet*> applets;
+    for (auto it = m_pans.cbegin(); it != m_pans.cend(); ++it) {
+        if (!m_lentToCanvas.contains(it.key()))
+            applets.append(it.value());
+    }
     if (applets.isEmpty()) return;
 
     // Build the new splitter first, then move applets straight into it below.
@@ -631,6 +643,7 @@ void PanadapterStack::removeAll()
         emit panRemoved(id);
     qDeleteAll(m_pans);
     m_pans.clear();
+    m_lentToCanvas.clear();
     m_activePanId.clear();
 
     // Delete the old splitter and create a fresh one
@@ -645,7 +658,10 @@ void PanadapterStack::rebuildDockedSplitter()
 {
     QList<PanadapterApplet*> docked;
     for (auto it = m_pans.cbegin(); it != m_pans.cend(); ++it) {
-        if (!m_floatingWindows.contains(it.key())) {
+        // A loaned applet is the CANVAS's to place — reparenting it here is
+        // the silent theft behind the 8600 field report (see m_lentToCanvas).
+        if (!m_floatingWindows.contains(it.key())
+            && !m_lentToCanvas.contains(it.key())) {
             docked.append(it.value());
         }
     }
@@ -932,8 +948,10 @@ PanadapterApplet* PanadapterStack::detachForCanvas(const QString& panId)
     if (m_floatingWindows.contains(panId))
         return nullptr;
     PanadapterApplet* applet = m_pans.value(panId, nullptr);
-    if (applet)
+    if (applet) {
         applet->setOnCanvas(true);
+        m_lentToCanvas.insert(panId);
+    }
     return applet;
 }
 
@@ -942,6 +960,7 @@ void PanadapterStack::returnFromCanvas(const QString& panId,
 {
     if (!applet || m_pans.value(panId, nullptr) != applet)
         return;
+    m_lentToCanvas.remove(panId);
     applet->setOnCanvas(false);
     m_splitter->addWidget(applet);
     m_splitter->setStretchFactor(m_splitter->indexOf(applet), 1);
@@ -990,6 +1009,7 @@ void PanadapterStack::floatPanadapter(const QString& panId)
     // and lifetime.
     auto* fw = new PanFloatingWindow(window());
     fw->adoptApplet(applet);
+    m_lentToCanvas.remove(panId); // the float window owns it now
     applet->setOnCanvas(false);   // floating now; canvas releases its entry
     applet->spectrumWidget()->setFloating(true);
 

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -410,6 +410,23 @@ QVariantMap PanadapterStack::automationRearrange(const QString& layoutId)
 
 void PanadapterStack::rearrangeLayout(const QString& layoutId)
 {
+    // Nothing to arrange while every non-floating applet is on loan to the
+    // canvas — and bail BEFORE the float-docking loop below, which used to
+    // run first: the layout dialog in canvas mode un-popped the operator's
+    // floats and then no-opped (review m4).  The canvas owns arrangement in
+    // that posture; this method arranges the stack's own splitter only.
+    {
+        bool anyOurs = false;
+        for (auto it = m_pans.cbegin(); it != m_pans.cend(); ++it) {
+            if (!m_lentToCanvas.contains(it.key())) {
+                anyOurs = true;
+                break;
+            }
+        }
+        if (!anyOurs) {
+            return;
+        }
+    }
     // Dock any floating pans first.  m_pans always contains every applet
     // including those currently in a PanFloatingWindow (floatPanadapter
     // never removes from m_pans), so the reparent loop below would yank

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -866,6 +866,35 @@ void PanadapterStack::applyLayout(const QString& layoutId, const QStringList& pa
 
 // ── Float / Dock ──────────────────────────────────────────────────────────
 
+QVariantMap PanadapterStack::automationFloatDock(const QString& action,
+                                                 const QString& panId)
+{
+    if (!m_pans.contains(panId)) {
+        return QVariantMap{
+            {QStringLiteral("error"),
+             QStringLiteral("unknown pan id: ") + panId},
+        };
+    }
+
+    const bool wantFloat = action == QLatin1String("float");
+    const bool already   = isFloating(panId) == wantFloat;
+    if (!already) {
+        // The real production paths — this is the whole point: the reparent
+        // and GPU re-init the crash lineage lives in, driven headlessly.
+        if (wantFloat) floatPanadapter(panId);
+        else           dockPanadapter(panId);
+    }
+
+    return QVariantMap{
+        {QStringLiteral("action"), action},
+        {QStringLiteral("panId"), panId},
+        {QStringLiteral("floating"), isFloating(panId)},
+        {QStringLiteral("alreadyThere"), already},
+        {QStringLiteral("floatingCount"), int(m_floatingWindows.size())},
+        {QStringLiteral("dockedCount"), int(m_pans.size() - m_floatingWindows.size())},
+    };
+}
+
 void PanadapterStack::floatPanadapter(const QString& panId)
 {
     PanadapterApplet* applet = m_pans.value(panId, nullptr);

--- a/src/gui/PanadapterStack.h
+++ b/src/gui/PanadapterStack.h
@@ -150,6 +150,18 @@ private:
     QMap<QString, PanFloatingWindow*> m_floatingWindows;
     // Preserve floating state for restored pans that were unavailable this run.
     QSet<QString> m_seenPanIds;
+    // Applets currently ON LOAN to the workspace canvas (RFC #4887 phase 4).
+    // THE INVARIANT EVERY REBUILD PATH MUST HONOR: an applet in this set is
+    // not the stack's to arrange.  rebuildDockedSplitter() and
+    // rearrangeLayout() both enumerate m_pans and reparent what they find —
+    // five call sites reach them (float, dock, the connect-time layout
+    // restore, pan close, the layout dialog), and before this set existed
+    // every one of them silently reclaimed canvas-hosted applets into the
+    // hidden stack: the canvas kept a healthy model while the widget on
+    // screen answered to a splitter, which surfaced as "the pan won't snap,
+    // won't stack, won't restore" (the 8600 field report).  detachForCanvas
+    // lends, returnFromCanvas/floatPanadapter/removePanadapter collect.
+    QSet<QString> m_lentToCanvas;
     QString m_activePanId;
     bool m_shutdownPrepared{false};
     // applyLayout() creates applets in its branches (some via addPanadapter,

--- a/src/gui/PanadapterStack.h
+++ b/src/gui/PanadapterStack.h
@@ -72,6 +72,19 @@ public:
     Q_INVOKABLE QVariantMap automationFloatDock(const QString& action,
                                                 const QString& panId);
 
+    // Workspace-canvas seam (RFC #4887 phase 4).  The stack stays the pans'
+    // OWNER — creation, wiring, render scheduling, float/dock — and lends
+    // applets to the canvas.  detachForCanvas() only decides WHETHER (a
+    // floating pan stays out; pop-out is its own state and dockPanadapter()
+    // is its way back); the canvas reparents the applet itself, a plain
+    // same-top-level move exactly like applyLayout()'s splitter shuffles —
+    // no GPU dance, which is reserved for real top-level changes (#2495).
+    // returnFromCanvas() re-homes ONE applet into the docked splitter
+    // (addWidget's one-step reparent — never through nullptr, #1344);
+    // callers rebuild the arrangement afterwards via rearrangeLayout().
+    PanadapterApplet* detachForCanvas(const QString& panId);
+    void returnFromCanvas(const QString& panId, PanadapterApplet* applet);
+
     // Float/dock panadapters
     void floatPanadapter(const QString& panId);
     void dockPanadapter(const QString& panId);
@@ -101,6 +114,15 @@ signals:
     void activePanChanged(const QString& panId);
     void panFloated(const QString& panId);
     void panDocked(const QString& panId);
+    // Pan lifecycle, for the workspace controller (RFC #4887 phase 4).
+    // panAdded fires once per applet however it was created (addPanadapter
+    // or an applyLayout branch); panRemoved fires after the applet is
+    // unregistered and BEFORE it is destroyed, so a canvas can release its
+    // entry rather than relying on the destroyed-watch; panRekeyed follows
+    // the FLEX band-recall id swap (same applet, new id).
+    void panAdded(const QString& panId);
+    void panRemoved(const QString& panId);
+    void panRekeyed(const QString& oldId, const QString& newId);
     // The previous session died while floating panadapters, so they were
     // dropped and this one came up docked. Carries how many were dropped —
     // enough for plural agreement in the operator notice, and nothing more:
@@ -124,6 +146,10 @@ private:
     QSet<QString> m_seenPanIds;
     QString m_activePanId;
     bool m_shutdownPrepared{false};
+    // applyLayout() creates applets in its branches (some via addPanadapter,
+    // some inline); panAdded is suppressed during it and swept at its end so
+    // each applet is announced exactly once.
+    bool m_inApplyLayout{false};
     // How many pans the constructor discarded because the previous process
     // never survived floating them. Announced on a zero-timer at launch (once
     // wirePanLifecycle() has connected to us) and again from

--- a/src/gui/PanadapterStack.h
+++ b/src/gui/PanadapterStack.h
@@ -4,6 +4,7 @@
 #include <QMap>
 #include <QSet>
 #include <QSplitter>
+#include <QStringList>
 
 class QTimer;
 
@@ -40,6 +41,7 @@ public:
     SpectrumWidget* spectrum(const QString& panId) const;
     int count() const { return m_pans.size(); }
     QList<PanadapterApplet*> allApplets() const { return m_pans.values(); }
+    QStringList panIds() const { return m_pans.keys(); }
 
     // Active pan (determines which pan the applet column shows controls for)
     QString activePanId() const { return m_activePanId; }
@@ -49,6 +51,10 @@ public:
     void setSplitterOrientation(Qt::Orientation o) { m_splitter->setOrientation(o); }
     BandStackPanel* bandStackPanel() const { return m_bandStackPanel; }
     void setBandStackVisible(bool visible);
+    // Re-home the band-stack panel after workspace-canvas hosting (#4887
+    // phase 4): back to slot 0 of the stack's own layout, left of the
+    // splitter, exactly where the constructor put it.
+    void reclaimBandStackPanel();
     void equalizeSizes();
     void rearrangeLayout(const QString& layoutId);
 

--- a/src/gui/PanadapterStack.h
+++ b/src/gui/PanadapterStack.h
@@ -62,6 +62,16 @@ public:
     // takes it (-1 = unknown id). Mirrors the >= guards — keep in sync.
     static int layoutRequiredPanCount(const QString& layoutId);
 
+    // Automation bridge hook (#4864): drive floatPanadapter()/dockPanadapter()
+    // headlessly, so the reparent + GPU re-initialize path — the #2495/#4319/
+    // #4617 crash lineage — is testable without a live multi-pan radio and a
+    // hidden-button workaround. Rejects unknown pan ids (error map); float on
+    // a floating pan / dock on a docked one is reported as alreadyThere
+    // rather than an error, because the caller asked for a state that holds.
+    // Returns the pan's floating state plus floating/docked counts.
+    Q_INVOKABLE QVariantMap automationFloatDock(const QString& action,
+                                                const QString& panId);
+
     // Float/dock panadapters
     void floatPanadapter(const QString& panId);
     void dockPanadapter(const QString& panId);

--- a/src/gui/containers/ContainerManager.cpp
+++ b/src/gui/containers/ContainerManager.cpp
@@ -296,6 +296,17 @@ void ContainerManager::floatContainer(const QString& id)
     ContainerWidget* c = m_containers.value(id).data();
     if (!c || c->isFloating()) return;
 
+    // A canvas-mode container leaves the canvas first, through the one
+    // hook that knows how, and arrives here panel-docked in its original
+    // slot — so the float below records a REAL slot to dock back to,
+    // not the canvas it can no longer see.
+    if (c->isOnCanvas()) {
+        if (!m_canvasEvictor) return;   // no canvas owner: nothing safe to do
+        m_canvasEvictor(id);
+        c = m_containers.value(id).data();
+        if (!c || c->isFloating() || c->isOnCanvas()) return;
+    }
+
     prepareRhiChildrenForReparent(c);   // #2495 — before any reparent below
 
     detachFromCurrentSlot(id, c);
@@ -431,7 +442,18 @@ void ContainerManager::onDockRequested()
 {
     auto* c = qobject_cast<ContainerWidget*>(sender());
     if (!c) return;
+    // On the canvas, "dock" means return to the panel — the evictor takes
+    // the item off the canvas and routes back through returnFromCanvas().
+    if (c->isOnCanvas()) {
+        if (m_canvasEvictor) m_canvasEvictor(c->id());
+        return;
+    }
     dockContainer(c->id()); // dockContainer() -> saveState() flushes (#4427)
+}
+
+void ContainerManager::setCanvasEvictor(std::function<void(const QString&)> evictor)
+{
+    m_canvasEvictor = std::move(evictor);
 }
 
 void ContainerManager::onCloseRequested()
@@ -591,6 +613,11 @@ void ContainerManager::restoreState()
         if (mode == ContainerWidget::DockMode::Floating) {
             floatContainer(id);
         }
+        // DockMode::Canvas deliberately falls through to panel-docked here:
+        // no canvas exists at restore time.  The WorkspaceController
+        // re-places canvas items from the workspace document when the mode
+        // is enabled — the document, not ContainerTree, is placement truth
+        // (Principle V); the mode string is a dual-write mirror.
     }
 }
 

--- a/src/gui/containers/ContainerManager.cpp
+++ b/src/gui/containers/ContainerManager.cpp
@@ -27,7 +27,12 @@ constexpr int         kSchemaVersion = 1;
 
 QString dockModeToString(ContainerWidget::DockMode m)
 {
-    return m == ContainerWidget::DockMode::Floating ? "floating" : "panel";
+    switch (m) {
+    case ContainerWidget::DockMode::Floating: return QStringLiteral("floating");
+    case ContainerWidget::DockMode::Canvas:   return QStringLiteral("canvas");
+    case ContainerWidget::DockMode::PanelDocked: break;
+    }
+    return QStringLiteral("panel");
 }
 
 // QRhiWidget descendants must deregister their cleanup callback from the old
@@ -55,8 +60,9 @@ void prepareRhiChildrenForReparent(QWidget* root)
 
 ContainerWidget::DockMode dockModeFromString(const QString& s)
 {
-    return s == "floating" ? ContainerWidget::DockMode::Floating
-                           : ContainerWidget::DockMode::PanelDocked;
+    if (s == QLatin1String("floating")) return ContainerWidget::DockMode::Floating;
+    if (s == QLatin1String("canvas"))   return ContainerWidget::DockMode::Canvas;
+    return ContainerWidget::DockMode::PanelDocked;
 }
 
 // Build the AppSettings key for a floating container's geometry.
@@ -235,14 +241,9 @@ int ContainerManager::containerCount() const
     return m_containers.size();
 }
 
-void ContainerManager::floatContainer(const QString& id)
+void ContainerManager::detachFromCurrentSlot(const QString& id, ContainerWidget* c)
 {
-    ContainerWidget* c = m_containers.value(id).data();
-    if (!c || c->isFloating()) return;
-
-    prepareRhiChildrenForReparent(c);   // #2495 — before any reparent below
-
-    // Remember the container's current slot so re-dock restores it.
+    // Remember the container's current slot so a later re-dock restores it.
     // Two cases: nested (parentId points at another container) and
     // top-level (no parent container, sitting in an external layout).
     auto& meta = m_meta[id];
@@ -263,6 +264,41 @@ void ContainerManager::floatContainer(const QString& id)
         }
         c->setParent(nullptr);
     }
+}
+
+void ContainerManager::restoreToOriginalSlot(const QString& id, ContainerWidget* c)
+{
+    const auto& meta = m_meta.value(id);
+
+    if (!meta.parentId.isEmpty()) {
+        ContainerWidget* parent = m_containers.value(meta.parentId).data();
+        if (parent) {
+            const int clamped = std::min(std::max(meta.originalIndex, 0),
+                                         parent->childWidgetCount());
+            parent->insertChildWidget(clamped, c);
+        }
+        return;
+    }
+
+    if (meta.originalParent) {
+        c->setParent(meta.originalParent);
+        if (auto* box = qobject_cast<QBoxLayout*>(meta.originalParent->layout())) {
+            const int clamped = std::min(std::max(meta.originalIndex, 0),
+                                         box->count());
+            box->insertWidget(clamped, c);
+        }
+        c->show();
+    }
+}
+
+void ContainerManager::floatContainer(const QString& id)
+{
+    ContainerWidget* c = m_containers.value(id).data();
+    if (!c || c->isFloating()) return;
+
+    prepareRhiChildrenForReparent(c);   // #2495 — before any reparent below
+
+    detachFromCurrentSlot(id, c);
 
     // Parent the popped-out window to the main application window so it
     // stays on top of MainWindow without becoming WindowStaysOnTopHint
@@ -280,7 +316,9 @@ void ContainerManager::floatContainer(const QString& id)
 
     m_floatingWindows.insert(id, win);
     win->setWindowTitle(c->title());
-    win->restoreAndEnsureVisible(meta.originalParent);
+    // detachFromCurrentSlot() recorded the slot we just left; the floating
+    // window uses that widget's screen to pick a sensible first position.
+    win->restoreAndEnsureVisible(m_meta.value(id).originalParent);
 
     // Apply the persisted always-on-top preference *after*
     // restoreAndEnsureVisible(): toggling Qt::WindowStaysOnTopHint
@@ -310,30 +348,45 @@ void ContainerManager::dockContainer(const QString& id)
     win->deleteLater();
     if (!released) return;
 
-    const auto& meta = m_meta.value(id);
+    // Nested containers re-enter their logical parent's body; top-level
+    // ones re-enter the external layout they came from.  A parent that is
+    // itself floating is not a special case — Qt reparenting is transparent
+    // to which top-level window the body happens to live in.
+    restoreToOriginalSlot(id, released);
+    saveState();
+}
 
-    if (!meta.parentId.isEmpty()) {
-        // Nested: re-insert into logical parent container's body.
-        // If the parent is itself currently floating, re-docking the
-        // child just re-inserts it into the parent's body which
-        // happens to live in a floating window — Qt reparenting is
-        // transparent to that.
-        ContainerWidget* parent = m_containers.value(meta.parentId).data();
-        if (parent) {
-            const int clamped = std::min(std::max(meta.originalIndex, 0),
-                                         parent->childWidgetCount());
-            parent->insertChildWidget(clamped, released);
-        }
-    } else if (meta.originalParent) {
-        // Top-level: re-insert into the external layout we came from.
-        released->setParent(meta.originalParent);
-        if (auto* box = qobject_cast<QBoxLayout*>(meta.originalParent->layout())) {
-            const int clamped = std::min(std::max(meta.originalIndex, 0),
-                                         box->count());
-            box->insertWidget(clamped, released);
-        }
-        released->show();
+ContainerWidget* ContainerManager::detachForCanvas(const QString& id)
+{
+    ContainerWidget* c = m_containers.value(id).data();
+    if (!c || c->isOnCanvas()) return nullptr;
+
+    // Float -> canvas goes through dock first, so the floating window is
+    // closed and its geometry saved by the one path that knows how.  That
+    // also means detachFromCurrentSlot() below always sees a panel-docked
+    // container, which is the only case it has ever had to handle.
+    if (c->isFloating()) {
+        dockContainer(id);
+        c = m_containers.value(id).data();
+        if (!c) return nullptr;
     }
+
+    prepareRhiChildrenForReparent(c);   // #2495 — before any reparent below
+
+    detachFromCurrentSlot(id, c);
+    c->setDockMode(ContainerWidget::DockMode::Canvas);
+    saveState();
+    return c;
+}
+
+void ContainerManager::returnFromCanvas(const QString& id, ContainerWidget* c)
+{
+    if (!c || !c->isOnCanvas()) return;
+
+    prepareRhiChildrenForReparent(c);   // #2495 — leaving the canvas is a reparent too
+
+    c->setDockMode(ContainerWidget::DockMode::PanelDocked);
+    restoreToOriginalSlot(id, c);
     saveState();
 }
 

--- a/src/gui/containers/ContainerManager.h
+++ b/src/gui/containers/ContainerManager.h
@@ -110,6 +110,16 @@ public:
     // (WorkspaceCanvas::takeItem()).
     void returnFromCanvas(const QString& id, ContainerWidget* c);
 
+    // The manager's one hook into whoever owns the canvas.  When a
+    // canvas-mode container asks to dock (title-bar button) or must leave
+    // the canvas before floating, the manager calls this to have the
+    // controller take the item off the canvas and hand the container back
+    // through returnFromCanvas().  Kept as a callback rather than a
+    // signal because the transition must complete synchronously — a
+    // float that queued the eviction would reparent a widget the canvas
+    // still owns.
+    void setCanvasEvictor(std::function<void(const QString&)> evictor);
+
     // Follow the main-window frameless setting for all active floating windows.
     void setFramelessMode(bool on);
 
@@ -169,6 +179,7 @@ private:
     QMap<QString, QPointer<ContainerWidget>> m_containers;
     QMap<QString, FloatingContainerWindow*> m_floatingWindows;
     QMap<QString, ContentFactory>           m_factories;
+    std::function<void(const QString&)>     m_canvasEvictor;
     QMap<QString, Meta>                     m_meta;
 
     // True only while restoreState() is replaying saved state, so saveState()

--- a/src/gui/containers/ContainerManager.h
+++ b/src/gui/containers/ContainerManager.h
@@ -86,6 +86,30 @@ public:
     void floatContainer(const QString& id);
     void dockContainer(const QString& id);
 
+    // ── Canvas transitions (RFC #4887 phase 3) ───────────────────
+    //
+    // The third placement: the container becomes a child of a
+    // WorkspaceCanvas, which owns its geometry from then on.
+    //
+    // These mirror float/dock deliberately — same detach-and-remember
+    // step, same #2495 RHI guard, same restore-to-the-original-slot on
+    // the way back.  The failure modes are identical, and a second,
+    // subtly different reparent path is how the float/dock crash
+    // lineage (#2495, #4319, #4617) got as long as it did.
+    //
+    // detachForCanvas() takes the container out of its panel slot and
+    // hands it back for the caller to place — the canvas needs a rect,
+    // which is workspace state this class does not own.  Returns
+    // nullptr for an unknown id or one already on a canvas.  A
+    // FLOATING container is docked first, so "float, then canvas" is
+    // not a special case anyone has to remember.
+    ContainerWidget* detachForCanvas(const QString& id);
+
+    // Put it back in the slot it left, exactly as dockContainer() does
+    // after a float.  The caller has already taken it off the canvas
+    // (WorkspaceCanvas::takeItem()).
+    void returnFromCanvas(const QString& id, ContainerWidget* c);
+
     // Follow the main-window frameless setting for all active floating windows.
     void setFramelessMode(bool on);
 
@@ -133,6 +157,14 @@ private:
     };
 
     void wireContainer(ContainerWidget* container);
+
+    // The two halves every placement transition shares: remember and leave
+    // the current slot, and return to the remembered one.  Factored out when
+    // the canvas became a third placement — float/dock and canvas/panel are
+    // the same reparent with a different destination, and keeping one
+    // implementation is what stops them drifting apart.
+    void detachFromCurrentSlot(const QString& id, ContainerWidget* c);
+    void restoreToOriginalSlot(const QString& id, ContainerWidget* c);
 
     QMap<QString, QPointer<ContainerWidget>> m_containers;
     QMap<QString, FloatingContainerWindow*> m_floatingWindows;

--- a/src/gui/containers/ContainerTitleBar.cpp
+++ b/src/gui/containers/ContainerTitleBar.cpp
@@ -67,6 +67,12 @@ ContainerTitleBar::ContainerTitleBar(const QString& title, QWidget* parent)
 
     // Drag grip glyph (⋮⋮) — purely decorative; actual drag events
     // come from mouseMoveEvent on the bar as a whole.
+    // Addressable from the automation bridge as "<container>/containerTitleBar"
+    // (#3646 pattern, same scoping as the buttons below) — the canvas
+    // live-move gesture starts from THIS widget's mouse handlers, so a
+    // bridge drag has to be able to land here, not on the container.
+    setAccessibleName(QStringLiteral("containerTitleBar"));
+
     auto* grip = new QLabel(QString::fromUtf8("\xe2\x8b\xae\xe2\x8b\xae"));
     AetherSDR::ThemeManager::instance().applyStyleSheet(grip, "QLabel { background: transparent; color: {{color.text.secondary}}; font-size: 10px; }");
     layout->addWidget(grip);
@@ -197,6 +203,19 @@ void ContainerTitleBar::mouseMoveEvent(QMouseEvent* ev)
         return;
     }
     const QPoint g = ev->globalPosition().toPoint();
+
+    // Canvas: a live gesture, not a QDrag.  The item follows the cursor via
+    // the canvas gesture session; the ghost-drag path below never runs.
+    if (m_onCanvas) {
+        if (!m_canvasDragging) {
+            if ((g - m_pressPos).manhattanLength() < kDragThresholdPx) return;
+            m_canvasDragging = true;
+            emit canvasDragBegan(m_pressPos);
+        }
+        emit canvasDragMoved(g);
+        return;
+    }
+
     if ((g - m_pressPos).manhattanLength() < kDragThresholdPx) return;
     // Let the owner handle the actual QDrag — Phase 1 just signals
     // that the user moved past the drag threshold.  Phases 3 / 4
@@ -211,6 +230,14 @@ void ContainerTitleBar::mouseReleaseEvent(QMouseEvent* ev)
     if (m_isFloating) {
         FramelessMoveHelper::finish(this, ev);
         setCursor(Qt::OpenHandCursor);
+        return;
+    }
+    if (m_canvasDragging) {
+        m_canvasDragging = false;
+        m_pressed = false;
+        setCursor(Qt::OpenHandCursor);
+        emit canvasDragEnded(ev->globalPosition().toPoint());
+        ev->accept();
         return;
     }
     QWidget::mouseReleaseEvent(ev);

--- a/src/gui/containers/ContainerTitleBar.cpp
+++ b/src/gui/containers/ContainerTitleBar.cpp
@@ -145,6 +145,20 @@ void ContainerTitleBar::setFloatingState(bool isFloating)
     if (m_pinBtn) m_pinBtn->setVisible(isFloating);
 }
 
+void ContainerTitleBar::setCanvasState(bool onCanvas)
+{
+    m_onCanvas = onCanvas;
+    if (!onCanvas) return;   // setFloatingState() repaints the other states
+
+    // On the canvas the one-button affordance means "back to the panel".
+    // Floating from the canvas is deliberately a two-step (return, then
+    // pop out) so there is exactly one reparent path per transition.
+    m_floatBtn->setText(QString::fromUtf8("\xe2\x86\x99"));   // same ↙ as float-mode dock
+    m_floatBtn->setToolTip(QStringLiteral("Return to panel"));
+    if (m_closeBtn) m_closeBtn->setVisible(m_closeAllowed);
+    if (m_pinBtn)   m_pinBtn->setVisible(false);
+}
+
 void ContainerTitleBar::setAlwaysOnTopState(bool on)
 {
     m_alwaysOnTop = on;

--- a/src/gui/containers/ContainerTitleBar.h
+++ b/src/gui/containers/ContainerTitleBar.h
@@ -55,6 +55,16 @@ signals:
     void alwaysOnTopToggled(bool on);
     void dragStartRequested(const QPoint& globalPos);
 
+    // Live canvas move (RFC #4887 phase 5).  On a canvas the title bar
+    // streams the gesture instead of starting a QDrag: began carries the
+    // PRESS position (the gesture origin — using the threshold-crossing
+    // point would make the item jump by the threshold), moved streams every
+    // motion, ended fires on release.  A press that never crosses the
+    // threshold emits none of these, so a plain click still just raises.
+    void canvasDragBegan(const QPoint& globalPos);
+    void canvasDragMoved(const QPoint& globalPos);
+    void canvasDragEnded(const QPoint& globalPos);
+
 protected:
     void mousePressEvent(QMouseEvent* ev) override;
     void mouseMoveEvent(QMouseEvent* ev) override;
@@ -70,6 +80,7 @@ private:
     bool         m_closeAllowed{true};   // false = explicitly disabled (sidebar)
     bool         m_isFloating{false};
     bool         m_onCanvas{false};
+    bool         m_canvasDragging{false};
     bool         m_alwaysOnTop{false};
 };
 

--- a/src/gui/containers/ContainerTitleBar.h
+++ b/src/gui/containers/ContainerTitleBar.h
@@ -40,6 +40,15 @@ public:
     void setAlwaysOnTopState(bool on);
     bool alwaysOnTopState() const { return m_alwaysOnTop; }
 
+    // Canvas placement (RFC #4887 phase 3).  Visually a variant of the
+    // docked state — the float/dock button reads "return to panel", the
+    // close button stays, the pin stays hidden — and the mouse handlers
+    // keep the DOCKED behaviour on purpose: title-bar drags still go
+    // through the owner's QDrag, which is what lets a canvas item be
+    // dragged to a new spot or back onto the panel with the exact
+    // mechanism the panel already uses for reordering.
+    void setCanvasState(bool onCanvas);
+
 signals:
     void floatToggleClicked();
     void closeClicked();
@@ -60,6 +69,7 @@ private:
     bool         m_pressed{false};
     bool         m_closeAllowed{true};   // false = explicitly disabled (sidebar)
     bool         m_isFloating{false};
+    bool         m_onCanvas{false};
     bool         m_alwaysOnTop{false};
 };
 

--- a/src/gui/containers/ContainerWidget.cpp
+++ b/src/gui/containers/ContainerWidget.cpp
@@ -150,11 +150,17 @@ void ContainerWidget::setDockMode(DockMode mode)
 void ContainerWidget::applyWidthPolicyTo(QWidget* child)
 {
     if (!child) return;
-    if (m_dockMode == DockMode::Floating) {
+    if (m_dockMode == DockMode::Floating || m_dockMode == DockMode::Canvas) {
         // Remember the docked cap once, then lift it so width-capped
         // applets fill the floating window instead of hugging the left
         // edge.  Uncapped content (maximumWidth == QWIDGETSIZE_MAX) is a
         // no-op here. (#3451)
+        //
+        // Canvas takes the same branch for the same reason: a canvas item is
+        // sized by the operator's rect, not by the panel's fixed column
+        // width, so a container that kept its docked cap would leave dead
+        // space to the right of its own content inside the rect the operator
+        // drew — the exact #3451 symptom, one placement mode over.
         if (!m_savedMaxWidths.contains(child))
             m_savedMaxWidths.insert(child, child->maximumWidth());
         child->setMaximumWidth(QWIDGETSIZE_MAX);

--- a/src/gui/containers/ContainerWidget.cpp
+++ b/src/gui/containers/ContainerWidget.cpp
@@ -134,7 +134,13 @@ void ContainerWidget::setDockMode(DockMode mode)
 {
     if (mode == m_dockMode) return;
     m_dockMode = mode;
-    if (m_titleBar) m_titleBar->setFloatingState(mode == DockMode::Floating);
+    if (m_titleBar) {
+        // Order matters: setFloatingState() repaints the docked/floating
+        // visuals, and setCanvasState() overrides them only when the new
+        // mode is Canvas.
+        m_titleBar->setFloatingState(mode == DockMode::Floating);
+        m_titleBar->setCanvasState(mode == DockMode::Canvas);
+    }
     // Re-apply the width policy to every body child for the new mode:
     // floating lifts width caps so content fills the window; docking
     // restores each child's original cap. (#3451)
@@ -177,7 +183,11 @@ void ContainerWidget::restoreWidthPolicy(QWidget* child)
 
 void ContainerWidget::onTitleBarFloatToggle()
 {
-    if (isFloating()) emit dockRequested();
+    // On the canvas the button means "return to panel", which is a dock:
+    // ContainerManager routes it through the canvas evictor.  Floating from
+    // the canvas is the two-step return-then-float, so every transition uses
+    // the one reparent path that already exists for it.
+    if (isFloating() || isOnCanvas()) emit dockRequested();
     else              emit floatRequested();
 }
 

--- a/src/gui/containers/ContainerWidget.cpp
+++ b/src/gui/containers/ContainerWidget.cpp
@@ -39,6 +39,12 @@ ContainerWidget::ContainerWidget(const QString& id, const QString& title,
             this, &ContainerWidget::alwaysOnTopToggled);
     connect(m_titleBar, &ContainerTitleBar::dragStartRequested,
             this, &ContainerWidget::onTitleBarDragStart);
+    connect(m_titleBar, &ContainerTitleBar::canvasDragBegan,
+            this, &ContainerWidget::canvasDragBegan);
+    connect(m_titleBar, &ContainerTitleBar::canvasDragMoved,
+            this, &ContainerWidget::canvasDragMoved);
+    connect(m_titleBar, &ContainerTitleBar::canvasDragEnded,
+            this, &ContainerWidget::canvasDragEnded);
 }
 
 ContainerWidget::~ContainerWidget() = default;

--- a/src/gui/containers/ContainerWidget.h
+++ b/src/gui/containers/ContainerWidget.h
@@ -26,6 +26,7 @@ public:
     enum class DockMode {
         PanelDocked,   // inside its parent's body layout
         Floating,      // owned by a FloatingContainerWindow
+        Canvas,        // freely placed on a WorkspaceCanvas (RFC #4887, phase 3)
     };
 
     explicit ContainerWidget(const QString& id,
@@ -80,6 +81,7 @@ public:
     DockMode dockMode() const { return m_dockMode; }
     bool isFloating() const     { return m_dockMode == DockMode::Floating; }
     bool isPanelDocked() const  { return m_dockMode == DockMode::PanelDocked; }
+    bool isOnCanvas() const     { return m_dockMode == DockMode::Canvas; }
 
     // Logical visibility — distinct from QWidget::isVisible, which
     // reflects the current layout state (a panel-docked container is

--- a/src/gui/containers/ContainerWidget.h
+++ b/src/gui/containers/ContainerWidget.h
@@ -117,6 +117,12 @@ signals:
     void floatRequested();
     void dockRequested();
 
+    // Live canvas move, forwarded from the title bar (RFC #4887 phase 5).
+    // The WorkspaceController routes these into the canvas gesture session.
+    void canvasDragBegan(const QPoint& globalPos);
+    void canvasDragMoved(const QPoint& globalPos);
+    void canvasDragEnded(const QPoint& globalPos);
+
     // Emitted when the user clicks the close (×) button in the
     // titlebar.  Connected code typically calls setContainerVisible(false)
     // but may choose to destroy the container instead.

--- a/src/gui/workspace/CanvasInteraction.cpp
+++ b/src/gui/workspace/CanvasInteraction.cpp
@@ -2,6 +2,7 @@
 
 #include <QtGlobal>
 
+#include <algorithm>
 #include <cmath>
 
 namespace AetherSDR {
@@ -236,6 +237,74 @@ SnapResult snapRect(const NormRect& moved, HitZone zone,
     }
 
     return result;
+}
+
+QList<TidyMove> tidyOverlaps(const QList<CanvasItem>& items,
+                             const QStringList& fixedIds)
+{
+    const auto overlaps = [](const NormRect& a, const NormRect& b) {
+        return a.x < b.right() && b.x < a.right()
+               && a.y < b.bottom() && b.y < a.bottom();
+    };
+
+    // Movable items in reading order (top-to-bottom, then left-to-right):
+    // the order the eye scans is the order tidy preserves.
+    QList<CanvasItem> movable;
+    for (const CanvasItem& it : items) {
+        if (!fixedIds.contains(it.id)) {
+            movable.append(it);
+        }
+    }
+    std::stable_sort(movable.begin(), movable.end(),
+                     [](const CanvasItem& a, const CanvasItem& b) {
+                         if (!qFuzzyCompare(a.rect.y + 1.0, b.rect.y + 1.0)) {
+                             return a.rect.y < b.rect.y;
+                         }
+                         return a.rect.x < b.rect.x;
+                     });
+
+    QList<TidyMove> moves;
+    QList<NormRect> placed;
+
+    for (const CanvasItem& it : movable) {
+        NormRect r = it.rect;
+
+        // Push down past every already-placed rect it overlaps, repeating
+        // until clear — a push can land it on a later obstacle.
+        bool pushed = true;
+        int guard = 0;
+        while (pushed && ++guard < 64) {
+            pushed = false;
+            for (const NormRect& p : placed) {
+                if (overlaps(r, p)) {
+                    r.y    = p.bottom();
+                    pushed = true;
+                }
+            }
+        }
+
+        // Off the bottom, or still colliding: leave the ORIGINAL placement.
+        // Tidy never trades one overlap for a worse one.
+        bool ok = r.bottom() <= 1.0 + 1e-9;
+        if (ok) {
+            for (const NormRect& p : placed) {
+                if (overlaps(r, p)) {
+                    ok = false;
+                    break;
+                }
+            }
+        }
+        if (!ok) {
+            placed.append(it.rect);
+            continue;
+        }
+
+        placed.append(r);
+        if (!(r == it.rect)) {
+            moves.append(TidyMove{it.id, r});
+        }
+    }
+    return moves;
 }
 
 }  // namespace AetherSDR

--- a/src/gui/workspace/CanvasInteraction.cpp
+++ b/src/gui/workspace/CanvasInteraction.cpp
@@ -186,7 +186,7 @@ SnapResult snapRect(const NormRect& moved, HitZone zone,
     };
     // The grid tier deliberately offers FEWER own-lines than the peer tier:
     // only the origin (or the gripped edge).  With left, right AND centre
-    // all courting a ~35 px-pitch grid at +/-8 px, nearly every position
+    // all courting the grid pitch at +/-8 px, nearly every position
     // captured somewhere and free placement needed Alt held permanently —
     // aligning edges and centres is what PEERS are for; the grid quantizes
     // where the item STARTS.

--- a/src/gui/workspace/CanvasInteraction.cpp
+++ b/src/gui/workspace/CanvasInteraction.cpp
@@ -125,7 +125,8 @@ SnapResult snapRect(const NormRect& moved, HitZone zone,
                     const QList<NormRect>& peers,
                     double tolNormX, double tolNormY,
                     const QSizeF& minNorm,
-                    int gridX, int gridY)
+                    int gridX, int gridY,
+                    double gridTolNormX, double gridTolNormY)
 {
     SnapResult result;
     result.rect = moved;
@@ -133,6 +134,9 @@ SnapResult snapRect(const NormRect& moved, HitZone zone,
     if (zone == HitZone::None || tolNormX < 0 || tolNormY < 0) {
         return result;
     }
+
+    if (gridTolNormX < 0) gridTolNormX = tolNormX;
+    if (gridTolNormY < 0) gridTolNormY = tolNormY;
 
     const bool move  = zone == HitZone::Move;
     const bool west  = zone == HitZone::W || zone == HitZone::NW || zone == HitZone::SW;
@@ -194,23 +198,23 @@ SnapResult snapRect(const NormRect& moved, HitZone zone,
                                   const QList<double>& tierOneOffsets,
                                   const QList<double>& grid,
                                   const QList<double>& gridOffsets, double base,
-                                  double tolerance) {
+                                  double tolerance, double gridTolerance) {
         const Best edges = pickFrom(tierOne, tierOneOffsets, base, tolerance);
         if (edges.found || grid.isEmpty()) {
             return edges;
         }
-        return pickFrom(grid, gridOffsets, base, tolerance);
+        return pickFrom(grid, gridOffsets, base, gridTolerance);
     };
 
     NormRect& r = result.rect;
 
     if (move) {
-        const Best bx = pick(xLines, {0.0, r.w, r.w / 2.0}, xGrid, {0.0}, r.x, tolNormX);
+        const Best bx = pick(xLines, {0.0, r.w, r.w / 2.0}, xGrid, {0.0}, r.x, tolNormX, gridTolNormX);
         if (bx.found) {
             r.x = clampD(bx.target - bx.ownOffset, 0.0, 1.0 - r.w);
             result.verticalGuides << bx.target;
         }
-        const Best by = pick(yLines, {0.0, r.h, r.h / 2.0}, yGrid, {0.0}, r.y, tolNormY);
+        const Best by = pick(yLines, {0.0, r.h, r.h / 2.0}, yGrid, {0.0}, r.y, tolNormY, gridTolNormY);
         if (by.found) {
             r.y = clampD(by.target - by.ownOffset, 0.0, 1.0 - r.h);
             result.horizontalGuides << by.target;
@@ -222,7 +226,7 @@ SnapResult snapRect(const NormRect& moved, HitZone zone,
     const double minH = clampD(minNorm.height(), 0.0, 1.0);
 
     if (east) {
-        const Best b = pick(xLines, {0.0}, xGrid, {0.0}, r.right(), tolNormX);
+        const Best b = pick(xLines, {0.0}, xGrid, {0.0}, r.right(), tolNormX, gridTolNormX);
         if (b.found) {
             const double right = clampD(b.target, r.x + minW, 1.0);
             if (std::fabs(right - b.target) < 1e-12) {
@@ -231,7 +235,7 @@ SnapResult snapRect(const NormRect& moved, HitZone zone,
             r.w = right - r.x;
         }
     } else if (west) {
-        const Best b = pick(xLines, {0.0}, xGrid, {0.0}, r.x, tolNormX);
+        const Best b = pick(xLines, {0.0}, xGrid, {0.0}, r.x, tolNormX, gridTolNormX);
         if (b.found) {
             const double right = r.right();
             const double left  = clampD(b.target, 0.0, right - minW);
@@ -244,7 +248,7 @@ SnapResult snapRect(const NormRect& moved, HitZone zone,
     }
 
     if (south) {
-        const Best b = pick(yLines, {0.0}, yGrid, {0.0}, r.bottom(), tolNormY);
+        const Best b = pick(yLines, {0.0}, yGrid, {0.0}, r.bottom(), tolNormY, gridTolNormY);
         if (b.found) {
             const double bottom = clampD(b.target, r.y + minH, 1.0);
             if (std::fabs(bottom - b.target) < 1e-12) {
@@ -253,7 +257,7 @@ SnapResult snapRect(const NormRect& moved, HitZone zone,
             r.h = bottom - r.y;
         }
     } else if (north) {
-        const Best b = pick(yLines, {0.0}, yGrid, {0.0}, r.y, tolNormY);
+        const Best b = pick(yLines, {0.0}, yGrid, {0.0}, r.y, tolNormY, gridTolNormY);
         if (b.found) {
             const double bottom = r.bottom();
             const double top    = clampD(b.target, 0.0, bottom - minH);

--- a/src/gui/workspace/CanvasInteraction.cpp
+++ b/src/gui/workspace/CanvasInteraction.cpp
@@ -1,0 +1,241 @@
+#include "gui/workspace/CanvasInteraction.h"
+
+#include <QtGlobal>
+
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+
+double clampD(double v, double lo, double hi)
+{
+    return v < lo ? lo : (v > hi ? hi : v);
+}
+
+}  // namespace
+
+HitZone hitZoneFor(const QRect& itemPx, const QPoint& posPx,
+                   int gripPx, int titleHPx)
+{
+    if (!itemPx.contains(posPx)) {
+        return HitZone::None;
+    }
+
+    const bool nearL = posPx.x() - itemPx.left()  < gripPx;
+    const bool nearR = itemPx.right() - posPx.x() < gripPx;
+    const bool nearT = posPx.y() - itemPx.top()   < gripPx;
+    const bool nearB = itemPx.bottom() - posPx.y() < gripPx;
+
+    // Corners first: within two bands at once.  Without this priority the
+    // top corners would be swallowed by the title strip and short items
+    // would have no reachable corner grips at all.
+    if (nearT && nearL) return HitZone::NW;
+    if (nearT && nearR) return HitZone::NE;
+    if (nearB && nearL) return HitZone::SW;
+    if (nearB && nearR) return HitZone::SE;
+    if (nearT) return HitZone::N;
+    if (nearB) return HitZone::S;
+    if (nearL) return HitZone::W;
+    if (nearR) return HitZone::E;
+
+    // The move strip sits below the top grip band.
+    if (posPx.y() - itemPx.top() < titleHPx) {
+        return HitZone::Move;
+    }
+    return HitZone::None;
+}
+
+Qt::CursorShape cursorForZone(HitZone zone)
+{
+    switch (zone) {
+    case HitZone::Move:              return Qt::SizeAllCursor;
+    case HitZone::N: case HitZone::S: return Qt::SizeVerCursor;
+    case HitZone::E: case HitZone::W: return Qt::SizeHorCursor;
+    case HitZone::NW: case HitZone::SE: return Qt::SizeFDiagCursor;
+    case HitZone::NE: case HitZone::SW: return Qt::SizeBDiagCursor;
+    case HitZone::None:              break;
+    }
+    return Qt::ArrowCursor;
+}
+
+bool isResizeZone(HitZone zone)
+{
+    return zone != HitZone::None && zone != HitZone::Move;
+}
+
+NormRect applyDrag(const NormRect& start, HitZone zone,
+                   double dxNorm, double dyNorm, const QSizeF& minNorm)
+{
+    if (zone == HitZone::None) {
+        return start;
+    }
+
+    if (zone == HitZone::Move) {
+        NormRect out = start;
+        out.x += dxNorm;
+        out.y += dyNorm;
+        return clampToBounds(out);
+    }
+
+    const bool west  = zone == HitZone::W || zone == HitZone::NW || zone == HitZone::SW;
+    const bool east  = zone == HitZone::E || zone == HitZone::NE || zone == HitZone::SE;
+    const bool north = zone == HitZone::N || zone == HitZone::NW || zone == HitZone::NE;
+    const bool south = zone == HitZone::S || zone == HitZone::SW || zone == HitZone::SE;
+
+    const double minW = clampD(minNorm.width(),  0.0, 1.0);
+    const double minH = clampD(minNorm.height(), 0.0, 1.0);
+
+    NormRect out = start;
+
+    // Horizontal.  The anchored edge is a constant; only the gripped edge
+    // moves, bounded by the surface on one side and the minimum on the other.
+    if (east) {
+        const double left = start.x;                       // anchor
+        double right = start.right() + dxNorm;
+        right = clampD(right, left + minW, 1.0);
+        out.w = right - left;
+    } else if (west) {
+        const double right = start.right();                // anchor
+        double left = start.x + dxNorm;
+        left = clampD(left, 0.0, right - minW);
+        out.x = left;
+        out.w = right - left;
+    }
+
+    // Vertical, same shape.
+    if (south) {
+        const double top = start.y;                        // anchor
+        double bottom = start.bottom() + dyNorm;
+        bottom = clampD(bottom, top + minH, 1.0);
+        out.h = bottom - top;
+    } else if (north) {
+        const double bottom = start.bottom();              // anchor
+        double top = start.y + dyNorm;
+        top = clampD(top, 0.0, bottom - minH);
+        out.y = top;
+        out.h = bottom - top;
+    }
+
+    return out;
+}
+
+SnapResult snapRect(const NormRect& moved, HitZone zone,
+                    const QList<NormRect>& peers,
+                    double tolNormX, double tolNormY,
+                    const QSizeF& minNorm)
+{
+    SnapResult result;
+    result.rect = moved;
+
+    if (zone == HitZone::None || tolNormX < 0 || tolNormY < 0) {
+        return result;
+    }
+
+    const bool move  = zone == HitZone::Move;
+    const bool west  = zone == HitZone::W || zone == HitZone::NW || zone == HitZone::SW;
+    const bool east  = zone == HitZone::E || zone == HitZone::NE || zone == HitZone::SE;
+    const bool north = zone == HitZone::N || zone == HitZone::NW || zone == HitZone::NE;
+    const bool south = zone == HitZone::S || zone == HitZone::SW || zone == HitZone::SE;
+
+    // Candidate lines: the surface's own edges and every peer edge + centre.
+    QList<double> xLines{0.0, 1.0};
+    QList<double> yLines{0.0, 1.0};
+    for (const NormRect& p : peers) {
+        xLines << p.x << p.right() << p.x + p.w / 2.0;
+        yLines << p.y << p.bottom() << p.y + p.h / 2.0;
+    }
+
+    // One axis at a time: find the nearest (candidate line, own edge) pair
+    // within tolerance and take it.  A Move offers left/right/centre; a
+    // resize offers only the gripped edge — the anchor must never move.
+    struct Best {
+        double distance;
+        double target;
+        double ownOffset;   // where the matched own-line sits relative to x/y
+        bool   found = false;
+    };
+
+    const auto pick = [](const QList<double>& lines,
+                         const QList<double>& ownOffsets, double base,
+                         double tolerance) {
+        Best best{tolerance, 0.0, 0.0, false};
+        for (double own : ownOffsets) {
+            const double at = base + own;
+            for (double line : lines) {
+                const double d = std::fabs(line - at);
+                if (d <= best.distance) {
+                    best = Best{d, line, own, true};
+                }
+            }
+        }
+        return best;
+    };
+
+    NormRect& r = result.rect;
+
+    if (move) {
+        const Best bx = pick(xLines, {0.0, r.w, r.w / 2.0}, r.x, tolNormX);
+        if (bx.found) {
+            r.x = clampD(bx.target - bx.ownOffset, 0.0, 1.0 - r.w);
+            result.verticalGuides << bx.target;
+        }
+        const Best by = pick(yLines, {0.0, r.h, r.h / 2.0}, r.y, tolNormY);
+        if (by.found) {
+            r.y = clampD(by.target - by.ownOffset, 0.0, 1.0 - r.h);
+            result.horizontalGuides << by.target;
+        }
+        return result;
+    }
+
+    const double minW = clampD(minNorm.width(),  0.0, 1.0);
+    const double minH = clampD(minNorm.height(), 0.0, 1.0);
+
+    if (east) {
+        const Best b = pick(xLines, {0.0}, r.right(), tolNormX);
+        if (b.found) {
+            const double right = clampD(b.target, r.x + minW, 1.0);
+            if (std::fabs(right - b.target) < 1e-12) {
+                result.verticalGuides << b.target;
+            }
+            r.w = right - r.x;
+        }
+    } else if (west) {
+        const Best b = pick(xLines, {0.0}, r.x, tolNormX);
+        if (b.found) {
+            const double right = r.right();
+            const double left  = clampD(b.target, 0.0, right - minW);
+            if (std::fabs(left - b.target) < 1e-12) {
+                result.verticalGuides << b.target;
+            }
+            r.x = left;
+            r.w = right - left;
+        }
+    }
+
+    if (south) {
+        const Best b = pick(yLines, {0.0}, r.bottom(), tolNormY);
+        if (b.found) {
+            const double bottom = clampD(b.target, r.y + minH, 1.0);
+            if (std::fabs(bottom - b.target) < 1e-12) {
+                result.horizontalGuides << b.target;
+            }
+            r.h = bottom - r.y;
+        }
+    } else if (north) {
+        const Best b = pick(yLines, {0.0}, r.y, tolNormY);
+        if (b.found) {
+            const double bottom = r.bottom();
+            const double top    = clampD(b.target, 0.0, bottom - minH);
+            if (std::fabs(top - b.target) < 1e-12) {
+                result.horizontalGuides << b.target;
+            }
+            r.y = top;
+            r.h = bottom - top;
+        }
+    }
+
+    return result;
+}
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/CanvasInteraction.cpp
+++ b/src/gui/workspace/CanvasInteraction.cpp
@@ -124,7 +124,8 @@ NormRect applyDrag(const NormRect& start, HitZone zone,
 SnapResult snapRect(const NormRect& moved, HitZone zone,
                     const QList<NormRect>& peers,
                     double tolNormX, double tolNormY,
-                    const QSizeF& minNorm)
+                    const QSizeF& minNorm,
+                    int gridX, int gridY)
 {
     SnapResult result;
     result.rect = moved;
@@ -139,12 +140,23 @@ SnapResult snapRect(const NormRect& moved, HitZone zone,
     const bool north = zone == HitZone::N || zone == HitZone::NW || zone == HitZone::NE;
     const bool south = zone == HitZone::S || zone == HitZone::SW || zone == HitZone::SE;
 
-    // Candidate lines: the surface's own edges and every peer edge + centre.
+    // Candidate lines in two tiers.  Tier one: the surface's own edges and
+    // every peer edge + centre.  Tier two: the grid.  The grid is consulted
+    // only when tier one finds nothing — a neighbour's edge within reach
+    // always beats a grid line.
     QList<double> xLines{0.0, 1.0};
     QList<double> yLines{0.0, 1.0};
     for (const NormRect& p : peers) {
         xLines << p.x << p.right() << p.x + p.w / 2.0;
         yLines << p.y << p.bottom() << p.y + p.h / 2.0;
+    }
+    QList<double> xGrid;
+    QList<double> yGrid;
+    for (int i = 1; i < gridX; ++i) {
+        xGrid << i / double(gridX);
+    }
+    for (int i = 1; i < gridY; ++i) {
+        yGrid << i / double(gridY);
     }
 
     // One axis at a time: find the nearest (candidate line, own edge) pair
@@ -157,9 +169,9 @@ SnapResult snapRect(const NormRect& moved, HitZone zone,
         bool   found = false;
     };
 
-    const auto pick = [](const QList<double>& lines,
-                         const QList<double>& ownOffsets, double base,
-                         double tolerance) {
+    const auto pickFrom = [](const QList<double>& lines,
+                             const QList<double>& ownOffsets, double base,
+                             double tolerance) {
         Best best{tolerance, 0.0, 0.0, false};
         for (double own : ownOffsets) {
             const double at = base + own;
@@ -172,16 +184,33 @@ SnapResult snapRect(const NormRect& moved, HitZone zone,
         }
         return best;
     };
+    // The grid tier deliberately offers FEWER own-lines than the peer tier:
+    // only the origin (or the gripped edge).  With left, right AND centre
+    // all courting a ~35 px-pitch grid at +/-8 px, nearly every position
+    // captured somewhere and free placement needed Alt held permanently —
+    // aligning edges and centres is what PEERS are for; the grid quantizes
+    // where the item STARTS.
+    const auto pick = [&pickFrom](const QList<double>& tierOne,
+                                  const QList<double>& tierOneOffsets,
+                                  const QList<double>& grid,
+                                  const QList<double>& gridOffsets, double base,
+                                  double tolerance) {
+        const Best edges = pickFrom(tierOne, tierOneOffsets, base, tolerance);
+        if (edges.found || grid.isEmpty()) {
+            return edges;
+        }
+        return pickFrom(grid, gridOffsets, base, tolerance);
+    };
 
     NormRect& r = result.rect;
 
     if (move) {
-        const Best bx = pick(xLines, {0.0, r.w, r.w / 2.0}, r.x, tolNormX);
+        const Best bx = pick(xLines, {0.0, r.w, r.w / 2.0}, xGrid, {0.0}, r.x, tolNormX);
         if (bx.found) {
             r.x = clampD(bx.target - bx.ownOffset, 0.0, 1.0 - r.w);
             result.verticalGuides << bx.target;
         }
-        const Best by = pick(yLines, {0.0, r.h, r.h / 2.0}, r.y, tolNormY);
+        const Best by = pick(yLines, {0.0, r.h, r.h / 2.0}, yGrid, {0.0}, r.y, tolNormY);
         if (by.found) {
             r.y = clampD(by.target - by.ownOffset, 0.0, 1.0 - r.h);
             result.horizontalGuides << by.target;
@@ -193,7 +222,7 @@ SnapResult snapRect(const NormRect& moved, HitZone zone,
     const double minH = clampD(minNorm.height(), 0.0, 1.0);
 
     if (east) {
-        const Best b = pick(xLines, {0.0}, r.right(), tolNormX);
+        const Best b = pick(xLines, {0.0}, xGrid, {0.0}, r.right(), tolNormX);
         if (b.found) {
             const double right = clampD(b.target, r.x + minW, 1.0);
             if (std::fabs(right - b.target) < 1e-12) {
@@ -202,7 +231,7 @@ SnapResult snapRect(const NormRect& moved, HitZone zone,
             r.w = right - r.x;
         }
     } else if (west) {
-        const Best b = pick(xLines, {0.0}, r.x, tolNormX);
+        const Best b = pick(xLines, {0.0}, xGrid, {0.0}, r.x, tolNormX);
         if (b.found) {
             const double right = r.right();
             const double left  = clampD(b.target, 0.0, right - minW);
@@ -215,7 +244,7 @@ SnapResult snapRect(const NormRect& moved, HitZone zone,
     }
 
     if (south) {
-        const Best b = pick(yLines, {0.0}, r.bottom(), tolNormY);
+        const Best b = pick(yLines, {0.0}, yGrid, {0.0}, r.bottom(), tolNormY);
         if (b.found) {
             const double bottom = clampD(b.target, r.y + minH, 1.0);
             if (std::fabs(bottom - b.target) < 1e-12) {
@@ -224,7 +253,7 @@ SnapResult snapRect(const NormRect& moved, HitZone zone,
             r.h = bottom - r.y;
         }
     } else if (north) {
-        const Best b = pick(yLines, {0.0}, r.y, tolNormY);
+        const Best b = pick(yLines, {0.0}, yGrid, {0.0}, r.y, tolNormY);
         if (b.found) {
             const double bottom = r.bottom();
             const double top    = clampD(b.target, 0.0, bottom - minH);

--- a/src/gui/workspace/CanvasInteraction.h
+++ b/src/gui/workspace/CanvasInteraction.h
@@ -1,0 +1,88 @@
+#pragma once
+
+// The pure half of canvas interaction (RFC #4887 phase 5): where a press
+// lands (move strip, resize grip, nothing), and what a drag does to a rect.
+//
+// Widget-free on purpose, like the rest of the model: every rule that can be
+// got wrong — which grip a corner press selects, which edge a resize
+// anchors, how minimums fight bounds — is decided here and pinned headless.
+// WorkspaceCanvas's overlay translates real mouse events into these calls
+// and applies the answers; it adds no rules of its own.
+//
+// All rect math is in normalized canvas space.  Pixel thresholds (grip size,
+// title strip height, snap tolerance) are converted by the caller against
+// the live canvas — interactions only happen on a real, laid-out canvas, so
+// unlike stored placement this code MAY know the canvas size; it just never
+// writes anything an operator did not do.
+
+#include "gui/workspace/WorkspaceGeometry.h"
+
+#include <QList>
+#include <QPoint>
+#include <QRect>
+#include <QSize>
+#include <QSizeF>
+
+#include <Qt>
+
+namespace AetherSDR {
+
+// Where a press lands on an item.  Move is the title strip; the eight
+// resize zones are bands just inside the item's edges.
+enum class HitZone {
+    None,
+    Move,
+    N, S, E, W,
+    NE, NW, SE, SW,
+};
+
+// Classify a point against an item's pixel rect.  `gripPx` is the resize
+// band width; `titleHPx` the height of the move strip below the top edge.
+// Corners win over edges (a press within two grip bands is a corner), and
+// the grip bands win over the title strip — otherwise the top corners would
+// be unreachable on short items.  A point outside the rect is None.
+HitZone hitZoneFor(const QRect& itemPx, const QPoint& posPx,
+                   int gripPx, int titleHPx);
+
+// The cursor an operator should see over a zone.
+Qt::CursorShape cursorForZone(HitZone zone);
+
+bool isResizeZone(HitZone zone);
+
+// Apply a drag to a rect.
+//
+// Move translates and then slides back inside the unit square (an overshoot
+// moves the item, never resizes it).  Resize moves ONLY the gripped edges —
+// the opposite edge is the anchor and must not budge, which is the property
+// an operator's hands rely on — respecting `minNorm` against the anchored
+// edge and capping at the surface.  The result is always inside the unit
+// square and at least the minimum on both axes.
+NormRect applyDrag(const NormRect& start, HitZone zone,
+                   double dxNorm, double dyNorm, const QSizeF& minNorm);
+
+// ── Snapping ─────────────────────────────────────────────────────────────
+//
+// Candidates are the canvas edges and every peer's edges and centres.  Only
+// the edges a gesture actually moves participate: a Move snaps its left,
+// right and centre lines; an E resize snaps only its right edge — snapping
+// an anchored edge would yank the item out from under the cursor.
+
+struct SnapResult {
+    NormRect rect;
+    // Guide lines to draw while the gesture holds a snap, in canvas
+    // fractions.  Empty when nothing snapped.
+    QList<double> verticalGuides;    // x positions
+    QList<double> horizontalGuides;  // y positions
+};
+
+// Snap `moved` (the rect applyDrag produced) against `peers`.  `tolNorm*`
+// is the capture distance per axis, already converted from pixels by the
+// caller; disabled (e.g. Alt held) is expressed by calling with zero
+// tolerance or simply not calling.  Resize snaps re-apply the minimum so a
+// snap can never shrink an item below it.
+SnapResult snapRect(const NormRect& moved, HitZone zone,
+                    const QList<NormRect>& peers,
+                    double tolNormX, double tolNormY,
+                    const QSizeF& minNorm);
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/CanvasInteraction.h
+++ b/src/gui/workspace/CanvasInteraction.h
@@ -15,7 +15,11 @@
 // unlike stored placement this code MAY know the canvas size; it just never
 // writes anything an operator did not do.
 
+#include "gui/workspace/CanvasItem.h"
 #include "gui/workspace/WorkspaceGeometry.h"
+
+#include <QString>
+#include <QStringList>
 
 #include <QList>
 #include <QPoint>
@@ -84,5 +88,22 @@ SnapResult snapRect(const NormRect& moved, HitZone zone,
                     const QList<NormRect>& peers,
                     double tolNormX, double tolNormY,
                     const QSizeF& minNorm);
+
+// ── Tidy (RFC #4887 phase 5) ─────────────────────────────────────────────
+//
+// Resolve overlaps between movable items by minimal downward pushes,
+// preserving every size and the left-to-right reading order.  Items named in
+// `fixedIds` neither move nor count as overlap (the pan area: a meter over
+// the spectrum is a feature, not disorder).  An item that cannot be pushed
+// inside the surface without a new overlap is left exactly where it was —
+// tidy never makes an arrangement worse.
+
+struct TidyMove {
+    QString  id;
+    NormRect rect;
+};
+
+QList<TidyMove> tidyOverlaps(const QList<CanvasItem>& items,
+                             const QStringList& fixedIds);
 
 }  // namespace AetherSDR

--- a/src/gui/workspace/CanvasInteraction.h
+++ b/src/gui/workspace/CanvasInteraction.h
@@ -84,10 +84,17 @@ struct SnapResult {
 // caller; disabled (e.g. Alt held) is expressed by calling with zero
 // tolerance or simply not calling.  Resize snaps re-apply the minimum so a
 // snap can never shrink an item below it.
+// `gridX`/`gridY` add a normalized grid (that many divisions per axis) to
+// the candidates; 0 disables it.  Two deliberate asymmetries against the
+// peer tier: the grid is consulted only when NO peer or surface edge is in
+// tolerance (aligning to a neighbour is more intentional than a grid line),
+// and for a move it courts only the item's ORIGIN — left/right/centre all
+// chasing a ~35 px grid at +/-8 px left almost nowhere free to stand.
 SnapResult snapRect(const NormRect& moved, HitZone zone,
                     const QList<NormRect>& peers,
                     double tolNormX, double tolNormY,
-                    const QSizeF& minNorm);
+                    const QSizeF& minNorm,
+                    int gridX = 0, int gridY = 0);
 
 // ── Tidy (RFC #4887 phase 5) ─────────────────────────────────────────────
 //

--- a/src/gui/workspace/CanvasInteraction.h
+++ b/src/gui/workspace/CanvasInteraction.h
@@ -90,11 +90,16 @@ struct SnapResult {
 // tolerance (aligning to a neighbour is more intentional than a grid line),
 // and for a move it courts only the item's ORIGIN — left/right/centre all
 // chasing a ~35 px grid at +/-8 px left almost nowhere free to stand.
+// `gridTolNormX/Y` give the grid tier its own capture distance (default:
+// same as the peer tier).  A dense grid with a full-strength magnet
+// quantizes nearly every position; callers pair high division counts with a
+// gentler pull.
 SnapResult snapRect(const NormRect& moved, HitZone zone,
                     const QList<NormRect>& peers,
                     double tolNormX, double tolNormY,
                     const QSizeF& minNorm,
-                    int gridX = 0, int gridY = 0);
+                    int gridX = 0, int gridY = 0,
+                    double gridTolNormX = -1.0, double gridTolNormY = -1.0);
 
 // ── Tidy (RFC #4887 phase 5) ─────────────────────────────────────────────
 //

--- a/src/gui/workspace/CanvasItemFrame.cpp
+++ b/src/gui/workspace/CanvasItemFrame.cpp
@@ -1,0 +1,100 @@
+#include "gui/workspace/CanvasItemFrame.h"
+
+#include "gui/workspace/WorkspaceCanvas.h"
+
+#include <QMouseEvent>
+#include <QPainter>
+#include <QRegion>
+
+namespace AetherSDR {
+
+CanvasItemFrame::CanvasItemFrame(WorkspaceCanvas* canvas)
+    : QWidget(canvas)
+    , m_canvas(canvas)
+{
+    setMouseTracking(true);   // hover cursors without a button down
+    hide();
+}
+
+void CanvasItemFrame::followItem(const QRect& itemRectPx)
+{
+    setGeometry(itemRectPx);
+
+    // Everything except the border band is cut out of the widget: paints
+    // nothing there, receives nothing there.  This is what keeps the
+    // applet interactive while selected.
+    QRegion band(rect());
+    band -= rect().adjusted(kGripPx, kGripPx, -kGripPx, -kGripPx);
+    setMask(band);
+}
+
+HitZone CanvasItemFrame::zoneAt(const QPoint& localPos) const
+{
+    // titleHPx = 0: moving is the title bar's job (and the pan stack, which
+    // has no title bar, is deliberately resize-only — its position is fully
+    // determined by dragging its four edges).
+    return hitZoneFor(rect(), localPos, kGripPx, /*titleHPx=*/0);
+}
+
+void CanvasItemFrame::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    const QColor accent = palette().highlight().color();
+
+    // The band outline…
+    p.setPen(QPen(accent, 1));
+    p.setBrush(Qt::NoBrush);
+    p.drawRect(rect().adjusted(0, 0, -1, -1));
+
+    // …and the eight grips: corners plus edge midpoints, filled squares the
+    // size of the band so what you can grab is exactly what you can see.
+    p.setBrush(accent);
+    const int g = kGripPx;
+    const int w = width(), h = height();
+    const QList<QPoint> grips{
+        {0, 0},           {w - g, 0},           {0, h - g},       {w - g, h - g},
+        {(w - g) / 2, 0}, {(w - g) / 2, h - g}, {0, (h - g) / 2}, {w - g, (h - g) / 2},
+    };
+    for (const QPoint& at : grips) {
+        p.drawRect(QRect(at, QSize(g - 1, g - 1)));
+    }
+}
+
+void CanvasItemFrame::mousePressEvent(QMouseEvent* ev)
+{
+    if (ev->button() != Qt::LeftButton) {
+        QWidget::mousePressEvent(ev);
+        return;
+    }
+    const HitZone zone = zoneAt(ev->position().toPoint());
+    if (!isResizeZone(zone)) {
+        return;
+    }
+    m_dragging = true;
+    m_canvas->beginFrameGesture(zone, ev->globalPosition().toPoint());
+    ev->accept();
+}
+
+void CanvasItemFrame::mouseMoveEvent(QMouseEvent* ev)
+{
+    if (m_dragging) {
+        m_canvas->moveGesture(ev->globalPosition().toPoint());
+        ev->accept();
+        return;
+    }
+    setCursor(cursorForZone(zoneAt(ev->position().toPoint())));
+    QWidget::mouseMoveEvent(ev);
+}
+
+void CanvasItemFrame::mouseReleaseEvent(QMouseEvent* ev)
+{
+    if (m_dragging && ev->button() == Qt::LeftButton) {
+        m_dragging = false;
+        m_canvas->endGesture(ev->globalPosition().toPoint());
+        ev->accept();
+        return;
+    }
+    QWidget::mouseReleaseEvent(ev);
+}
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/CanvasItemFrame.h
+++ b/src/gui/workspace/CanvasItemFrame.h
@@ -1,0 +1,49 @@
+#pragma once
+
+// The selection frame for a canvas item (RFC #4887 phase 5): a border band
+// with eight resize grips, drawn OVER the selected item by the canvas.
+//
+// The one trick that makes this workable: the widget covers the item's full
+// rect but is MASKED to the border band, so resize presses land on the frame
+// while every click inside the band passes straight through to the applet —
+// its sliders and buttons keep working with the frame up.  The containers
+// themselves are untouched; selection chrome is entirely the canvas's.
+//
+// The frame owns no policy: it classifies presses with hitZoneFor() and
+// hands the gesture to the canvas session, which does everything else.
+
+#include "gui/workspace/CanvasInteraction.h"
+
+#include <QWidget>
+
+namespace AetherSDR {
+
+class WorkspaceCanvas;
+
+class CanvasItemFrame : public QWidget {
+    Q_OBJECT
+
+public:
+    // Band width; also the grip square size.  8 px is wide enough to hit
+    // without stealing meaningful content area.
+    static constexpr int kGripPx = 8;
+
+    explicit CanvasItemFrame(WorkspaceCanvas* canvas);
+
+    // Cover `itemRectPx` (canvas coordinates) and re-mask to its border.
+    void followItem(const QRect& itemRectPx);
+
+protected:
+    void paintEvent(QPaintEvent* ev) override;
+    void mousePressEvent(QMouseEvent* ev) override;
+    void mouseMoveEvent(QMouseEvent* ev) override;
+    void mouseReleaseEvent(QMouseEvent* ev) override;
+
+private:
+    HitZone zoneAt(const QPoint& localPos) const;
+
+    WorkspaceCanvas* m_canvas{nullptr};
+    bool m_dragging{false};
+};
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/CanvasLayout.cpp
+++ b/src/gui/workspace/CanvasLayout.cpp
@@ -45,23 +45,24 @@ void CanvasLayout::normalizeZ()
     }
 }
 
-bool CanvasLayout::addItem(CanvasItem item, const QSize& canvas)
+bool CanvasLayout::addItem(CanvasItem item)
 {
     if (item.id.isEmpty() || contains(item.id)) {
         return false;
     }
 
-    // A new item lands on top and inside.  Assigning z here rather than
-    // trusting the caller keeps the dense-contiguous invariant true from the
-    // first insert, with no normalize pass needed.
+    // A new item lands on top and inside the unit square.  Assigning z here
+    // rather than trusting the caller keeps the dense-contiguous invariant
+    // true from the first insert, with no normalize pass needed.  Bounds
+    // only — the display clamp handles minimum sizes at render time.
     item.z    = static_cast<int>(m_items.size());
-    item.rect = clampToCanvas(item.rect, item.minimumSize, canvas);
+    item.rect = clampToBounds(item.rect);
 
     m_items.append(item);
     return true;
 }
 
-int CanvasLayout::restoreItems(const QList<CanvasItem>& items, const QSize& canvas)
+int CanvasLayout::restoreItems(const QList<CanvasItem>& items)
 {
     // Sort by stored z FIRST, then insert bottom-to-top, so each insert's
     // assigned rank matches the saved order.  Doing it the other way — insert
@@ -75,7 +76,7 @@ int CanvasLayout::restoreItems(const QList<CanvasItem>& items, const QSize& canv
 
     int inserted = 0;
     for (CanvasItem& item : ordered) {
-        if (addItem(item, canvas)) {
+        if (addItem(item)) {
             ++inserted;
         }
     }
@@ -129,27 +130,14 @@ QList<CanvasItem> CanvasLayout::itemsByZ() const
     return out;
 }
 
-bool CanvasLayout::setRect(const QString& id, const NormRect& rect, const QSize& canvas)
+bool CanvasLayout::setRect(const QString& id, const NormRect& rect)
 {
     CanvasItem* it = find(id);
     if (!it) {
         return false;
     }
-    it->rect = clampToCanvas(rect, it->minimumSize, canvas);
+    it->rect = clampToBounds(rect);
     return true;
-}
-
-QStringList CanvasLayout::reclampAll(const QSize& canvas)
-{
-    QStringList moved;
-    for (CanvasItem& it : m_items) {
-        const NormRect before = it.rect;
-        it.rect = clampToCanvas(it.rect, it.minimumSize, canvas);
-        if (!(it.rect == before)) {
-            moved.append(it.id);
-        }
-    }
-    return moved;
 }
 
 QString CanvasLayout::hitTest(const QPointF& normPoint) const

--- a/src/gui/workspace/CanvasLayout.h
+++ b/src/gui/workspace/CanvasLayout.h
@@ -30,13 +30,18 @@ public:
     // Rejects an empty or duplicate id: identity is what every other call
     // here takes as an argument, so letting a second "applet:RX" in would
     // make every later lookup ambiguous rather than merely wrong.  The item's
-    // z is assigned on insert (topmost) and its rect clamped, so a caller
-    // cannot introduce an off-canvas or buried item by construction.
+    // z is assigned on insert (topmost) and its rect bounds-clamped, so a
+    // caller cannot introduce an off-surface or buried item by construction.
+    //
+    // The model clamp is clampToBounds() — canvas-INDEPENDENT on purpose.
+    // Minimum-size enforcement happens at display time in WorkspaceCanvas;
+    // running it here once poisoned every stored rect when items were placed
+    // before the window was laid out (RFC #4887 phase 3 field report).
     //
     // For a NEW item this is what you want — it belongs where the operator can
     // see it.  To rehydrate a SAVED arrangement, use restoreItems(): the
     // stored z is meaningful there and this call would discard it.
-    bool addItem(CanvasItem item, const QSize& canvas);
+    bool addItem(CanvasItem item);
 
     // Rehydrate a whole saved surface at once.
     //
@@ -55,7 +60,7 @@ public:
     //
     // Items with an empty or duplicate id are skipped.  Returns how many
     // were inserted.
-    int restoreItems(const QList<CanvasItem>& items, const QSize& canvas);
+    int restoreItems(const QList<CanvasItem>& items);
     bool removeItem(const QString& id);
     void clear();
 
@@ -73,15 +78,10 @@ public:
 
     // ── Placement ────────────────────────────────────────────────────────
     //
-    // The rect is clamped against the canvas before it is stored, so the
-    // layout never holds a placement the operator cannot see.  Returns false
-    // for an unknown id only — a clamped-away rect is still a successful set.
-    bool setRect(const QString& id, const NormRect& rect, const QSize& canvas);
-
-    // Re-clamp every item, for when the canvas itself changed size.  Returns
-    // the ids whose rects actually moved, so a caller can persist just those
-    // (phase 2) rather than rewriting the whole document on every resize.
-    QStringList reclampAll(const QSize& canvas);
+    // The rect is bounds-clamped before it is stored, so the layout never
+    // holds a placement outside the unit square.  Returns false for an
+    // unknown id only — a clamped-away rect is still a successful set.
+    bool setRect(const QString& id, const NormRect& rect);
 
     // ── Hit testing ──────────────────────────────────────────────────────
     //

--- a/src/gui/workspace/ClassicLayout.cpp
+++ b/src/gui/workspace/ClassicLayout.cpp
@@ -113,9 +113,13 @@ QList<CanvasItem> composeClassic(const QStringList& panIds,
     // operator never asked for.
     const bool haveApplets = !appletIds.isEmpty();
     const double columnWidth = haveApplets ? kClassicAppletColumnWidth : 0.0;
-    const double panWidth = 1.0 - columnWidth;
-    const double panOriginX = appletsLeft ? columnWidth : 0.0;
-    const double columnOriginX = appletsLeft ? 0.0 : panWidth;
+    const int wrapCols = haveApplets
+                             ? qMin(3, (static_cast<int>(appletIds.size())
+                                        + kClassicMaxAppletsPerColumn - 1)
+                                           / kClassicMaxAppletsPerColumn)
+                             : 0;
+    const double panWidth = 1.0 - wrapCols * columnWidth;
+    const double panOriginX = appletsLeft ? wrapCols * columnWidth : 0.0;
 
     // ── Pans, in their layout's cells, scaled into the pan region ────────
     QList<NormRect> cells = panCellsForLayout(layoutId);
@@ -139,27 +143,47 @@ QList<CanvasItem> composeClassic(const QStringList& panIds,
         items.append(item);
     }
 
-    // ── Applets, stacked down the column ─────────────────────────────────
+    // ── Applets, stacked down the column(s) ──────────────────────────────
     //
-    // Each applet gets 1/n of the column.  Past roughly a dozen open applets
-    // on a 1080 px canvas that falls under CanvasItem's 90 px floor and the
-    // clamp makes them overlap, where the real panel scrolls instead.  Nothing
-    // consumes this yet, so it is not reachable in phase 2 — but it is a real
-    // gap against "an operator who never opens the editor sees exactly what
-    // they see today", and phase 3 owes it either a scrolling column or a
-    // sensible overflow (PR #4900 review, L3).
+    // Up to ~11 applets share one column (slots stay above the 90 px display
+    // floor on a 1080 px canvas).  Beyond that the column WRAPS instead of
+    // letting slots collapse into an overlap — the L3 answer from PR #4900:
+    // the real panel scrolls, the canvas cannot, so Classic trades spectrum
+    // width for a second (at most third) column.  Applets beyond three full
+    // columns compress within the last one; at that point the operator has
+    // more applets open than any arrangement can show, and the canvas is the
+    // tool for choosing which ones matter.
     if (haveApplets) {
-        const double slotHeight = 1.0 / appletIds.size();
-        for (int i = 0; i < appletIds.size(); ++i) {
-            CanvasItem item;
-            item.id          = QStringLiteral("applet:") + appletIds.at(i);
-            item.contentType = QStringLiteral("applet");
-            item.z           = static_cast<int>(items.size());
-            item.rect.x = columnOriginX;
-            item.rect.y = i * slotHeight;
-            item.rect.w = columnWidth;
-            item.rect.h = slotHeight;
-            items.append(item);
+        const int n = static_cast<int>(appletIds.size());
+        const int colCount = qMin(3, (n + kClassicMaxAppletsPerColumn - 1)
+                                         / kClassicMaxAppletsPerColumn);
+
+        // Even distribution: 12 applets become 6+6, not 11+1.
+        const int base  = n / colCount;
+        const int extra = n % colCount;
+
+        int index = 0;
+        for (int col = 0; col < colCount; ++col) {
+            const int inThisColumn = base + (col < extra ? 1 : 0);
+            const double slotHeight = 1.0 / qMax(1, inThisColumn);
+
+            // Columns fill from the panel side inward.  Right-docked panel:
+            // column 0 hugs the right edge, column 1 sits left of it.
+            const double colX = appletsLeft
+                                    ? col * columnWidth
+                                    : 1.0 - (col + 1) * columnWidth;
+
+            for (int j = 0; j < inThisColumn && index < n; ++j, ++index) {
+                CanvasItem item;
+                item.id          = QStringLiteral("applet:") + appletIds.at(index);
+                item.contentType = QStringLiteral("applet");
+                item.z           = static_cast<int>(items.size());
+                item.rect.x = colX;
+                item.rect.y = j * slotHeight;
+                item.rect.w = columnWidth;
+                item.rect.h = slotHeight;
+                items.append(item);
+            }
         }
     }
 

--- a/src/gui/workspace/ClassicLayout.h
+++ b/src/gui/workspace/ClassicLayout.h
@@ -31,6 +31,11 @@ namespace AetherSDR {
 // actually hosts the panel.
 inline constexpr double kClassicAppletColumnWidth = 0.18;
 
+// Applets per Classic column before it wraps into another (slots stay above
+// the 90 px display floor on a 1080 px canvas).  Classic caps at three
+// columns; beyond that, applets compress within the last one.
+inline constexpr int kClassicMaxAppletsPerColumn = 11;
+
 // The panadapter cells for a layout id, in the order the stack assigns pans
 // (A, B, C, ...), covering the whole unit square.
 //

--- a/src/gui/workspace/WorkspaceCanvas.cpp
+++ b/src/gui/workspace/WorkspaceCanvas.cpp
@@ -55,7 +55,7 @@ bool WorkspaceCanvas::addItem(const QString& id,
     item.rect        = rect;
     item.minimumSize = minimumSize;
 
-    if (!m_layout.addItem(item, size())) {
+    if (!m_layout.addItem(item)) {
         return false;
     }
 
@@ -157,7 +157,7 @@ QWidget* WorkspaceCanvas::itemWidget(const QString& id) const
 
 bool WorkspaceCanvas::setItemRect(const QString& id, const NormRect& rect)
 {
-    if (!m_layout.setRect(id, rect, size())) {
+    if (!m_layout.setRect(id, rect)) {
         return false;
     }
     applyGeometryFor(id);
@@ -263,16 +263,11 @@ void WorkspaceCanvas::resizeEvent(QResizeEvent* ev)
 {
     QWidget::resizeEvent(ev);
 
-    // A smaller canvas can push items out or below their minimum, so the
-    // model is re-clamped first and the pixels follow.  Only the items that
-    // actually moved are announced — a resize that changes nothing must not
-    // look like an edit (this is what keeps phase 2's auto-commit from
-    // writing the document on every frame of a window drag).
-    const QStringList moved = m_layout.reclampAll(size());
+    // Recompute display geometry only.  The model is untouched and nothing
+    // is announced: a resize is not an edit, and persisting what a small
+    // window forced on the view is how a transient startup size once
+    // destroyed a stored arrangement (RFC #4887 phase 3 field report).
     applyGeometry();
-    for (const QString& id : moved) {
-        emit itemRectChanged(id, itemRect(id));
-    }
 }
 
 bool WorkspaceCanvas::eventFilter(QObject* watched, QEvent* ev)
@@ -301,7 +296,12 @@ void WorkspaceCanvas::applyGeometryFor(const QString& id)
     if (!w || !it) {
         return;
     }
-    w->setGeometry(toPixels(it->rect, size()));
+    // The display clamp lives HERE and only here: minimum sizes are enforced
+    // against the canvas as it is right now, the stored rect stays pristine,
+    // and a canvas too small to honour a minimum shows a compromise it will
+    // abandon the moment the canvas grows back.
+    w->setGeometry(toPixels(clampToCanvas(it->rect, it->minimumSize, size()),
+                            size()));
 }
 
 void WorkspaceCanvas::applyGeometry()

--- a/src/gui/workspace/WorkspaceCanvas.cpp
+++ b/src/gui/workspace/WorkspaceCanvas.cpp
@@ -26,16 +26,23 @@ namespace {
 // (exposed canvas) and the gesture overlay (above everything, drag-scoped).
 void paintGridDots(QPainter& p, const QSize& size, const QColor& color)
 {
-    p.setPen(color);
+    // One batched call, not ~5.2k drawPoint() round-trips — the overlay
+    // repaints on every mouse-move of a live drag (review perf note).
+    static QVector<QPoint> dots;
+    dots.clear();
+    dots.reserve((WorkspaceCanvas::kSnapGridColumns - 1)
+                 * (WorkspaceCanvas::kSnapGridRows - 1));
     for (int ix = 1; ix < WorkspaceCanvas::kSnapGridColumns; ++ix) {
         const int x = qRound(ix * size.width()
                              / double(WorkspaceCanvas::kSnapGridColumns));
         for (int iy = 1; iy < WorkspaceCanvas::kSnapGridRows; ++iy) {
             const int y = qRound(iy * size.height()
                                  / double(WorkspaceCanvas::kSnapGridRows));
-            p.drawPoint(x, y);
+            dots.append(QPoint(x, y));
         }
     }
+    p.setPen(color);
+    p.drawPoints(dots.constData(), dots.size());
 }
 
 }  // namespace
@@ -157,6 +164,21 @@ bool WorkspaceCanvas::addItem(const QString& id,
         if (!m_layout.contains(id)) {
             return;
         }
+        // Everything releaseItem() clears must clear here too (red-team
+        // m5): a widget deleted OUTSIDE the release path — shutdown paths
+        // delete lent applets directly — must not leave the selection
+        // naming a dead item, the frame at a stale rect, or a keyboard
+        // grab held.
+        if (id == m_selectedId) {
+            clearSelection();
+        }
+        if (id == m_gestureId) {
+            m_gestureId.clear();
+            m_vGuides.clear();
+            m_hGuides.clear();
+            releaseKeyboard();
+            if (m_gestureOverlay) m_gestureOverlay->hide();
+        }
         m_widgets.remove(id);
         m_layout.removeItem(id);
         applyStacking();
@@ -261,6 +283,13 @@ QWidget* WorkspaceCanvas::itemWidget(const QString& id) const
 
 bool WorkspaceCanvas::setItemRect(const QString& id, const NormRect& rect)
 {
+    // The invariant WorkspaceGeometry.h states — a zero-area or non-finite
+    // rect maps to an invisible item that still answers nothing — is
+    // enforced HERE, at the one write boundary, so no caller (the bridge's
+    // `place` was one, red-team M2) can persist an unhittable item.
+    if (!rect.isValid()) {
+        return false;
+    }
     if (!m_layout.setRect(id, rect)) {
         return false;
     }
@@ -280,8 +309,19 @@ QString WorkspaceCanvas::hitTest(const QPoint& pos) const
     if (width() <= 0 || height() <= 0) {
         return {};
     }
-    return m_layout.hitTest(QPointF(pos.x() / static_cast<double>(width()),
-                                    pos.y() / static_cast<double>(height())));
+    // Against the DISPLAY rects, top-down — not the stored model rects
+    // (red-team M1).  Wherever the minimum-size clamp bites, the widget on
+    // screen is larger than its stored rect, and hit-testing the model
+    // sent every click in that margin to whatever sits behind: wrong
+    // selection, wrong raise, wrong context menu.  Input must agree with
+    // pixels; the model keeps its canvas-independence untouched.
+    const QList<CanvasItem> byZ = m_layout.itemsByZ();
+    for (auto it = byZ.crbegin(); it != byZ.crend(); ++it) {
+        if (displayRectFor(it->id).contains(pos)) {
+            return it->id;
+        }
+    }
+    return {};
 }
 
 bool WorkspaceCanvas::raiseItem(const QString& id)
@@ -667,12 +707,21 @@ void WorkspaceCanvas::mousePressEvent(QMouseEvent* ev)
     // kind would undo the selection the event filter just made (the click
     // landed ON the item, from the operator's point of view), so hit-test
     // rather than assume.
-    const QString hit = hitTest(ev->position().toPoint());
-    if (hit.isEmpty()) {
-        clearSelection();
-    } else {
-        bringItemToFront(hit);
-        selectItem(hit);   // no-op when the filter already selected it
+    //
+    // Edit mode gates the whole select/raise branch (red-team B2): this was
+    // the ONE press handler the Edit Layout commit did not gate, and a
+    // stray click on an applet's dead space while merely operating raised a
+    // pan over the controls, drew the frame, and persisted the z change —
+    // the 8600 field report reintroduced through the back door.  Left
+    // button only (m7): middle/back-button presses are not placement.
+    if (m_editMode && ev->button() == Qt::LeftButton) {
+        const QString hit = hitTest(ev->position().toPoint());
+        if (hit.isEmpty()) {
+            clearSelection();
+        } else {
+            bringItemToFront(hit);
+            selectItem(hit);   // no-op when the filter already selected it
+        }
     }
     setFocus(Qt::MouseFocusReason);
     QWidget::mousePressEvent(ev);

--- a/src/gui/workspace/WorkspaceCanvas.cpp
+++ b/src/gui/workspace/WorkspaceCanvas.cpp
@@ -550,7 +550,10 @@ void WorkspaceCanvas::moveGesture(const QPoint& globalPos)
             snapRect(r, m_gestureZone, peers,
                      kSnapTolerancePx / double(width()),
                      kSnapTolerancePx / double(height()), minN,
-                     kSnapGridColumns, kSnapGridRows);
+                     m_gridSnapEnabled ? kSnapGridColumns : 0,
+                     m_gridSnapEnabled ? kSnapGridRows : 0,
+                     kGridSnapTolerancePx / double(width()),
+                     kGridSnapTolerancePx / double(height()));
         r         = snapped.rect;
         m_vGuides = snapped.verticalGuides;
         m_hGuides = snapped.horizontalGuides;

--- a/src/gui/workspace/WorkspaceCanvas.cpp
+++ b/src/gui/workspace/WorkspaceCanvas.cpp
@@ -546,6 +546,36 @@ void WorkspaceCanvas::mousePressEvent(QMouseEvent* ev)
     QWidget::mousePressEvent(ev);
 }
 
+bool WorkspaceCanvas::event(QEvent* ev)
+{
+    // The main window binds the arrow family as application shortcuts —
+    // frequency nudges on Left/Right and Shift+Left/Right — and application
+    // shortcuts consume key events before the focused widget sees them.
+    // Accepting the ShortcutOverride reclaims the key for the widget.
+    //
+    // Scope is deliberate and narrow: only while a canvas item is SELECTED
+    // (or a gesture is live) and only while the canvas itself has focus —
+    // the override is consulted for the focus widget alone, so clicking into
+    // the spectrum or deselecting hands the VFO its keys straight back.
+    // Selecting an item is the operator saying "I'm placing things now."
+    if (ev->type() == QEvent::ShortcutOverride
+        && (!m_selectedId.isEmpty() || gestureActive())) {
+        auto* ke = static_cast<QKeyEvent*>(ev);
+        switch (ke->key()) {
+        case Qt::Key_Left:
+        case Qt::Key_Right:
+        case Qt::Key_Up:
+        case Qt::Key_Down:
+        case Qt::Key_Escape:
+            ke->accept();
+            return true;
+        default:
+            break;
+        }
+    }
+    return QWidget::event(ev);
+}
+
 void WorkspaceCanvas::keyPressEvent(QKeyEvent* ev)
 {
     if (ev->key() == Qt::Key_Escape) {

--- a/src/gui/workspace/WorkspaceCanvas.cpp
+++ b/src/gui/workspace/WorkspaceCanvas.cpp
@@ -561,11 +561,26 @@ void WorkspaceCanvas::moveGesture(const QPoint& globalPos)
     // Alt suppresses snapping for as long as it is held — checked per
     // motion so the operator can toggle precision mid-drag.
     if (!(QApplication::keyboardModifiers() & Qt::AltModifier)) {
+        // A pan aligns to the ROOM — the grid, the canvas edges, the other
+        // pans — never to the furniture riding on it.  Its edges sweep the
+        // whole surface, and with applets layered on top the 8 px peer tier
+        // (which deliberately beats the grid) captured on nearly every
+        // motion, so the grid never engaged: "the pan doesn't snap to grid"
+        // (8600 field report).  Applets keep every magnet, including pan
+        // edges — a meter aligned to the spectrum edge is the point.
+        const CanvasItem* moving = m_layout.item(m_gestureId);
+        const bool movingPan =
+            moving && moving->contentType == QLatin1String("panadapter");
         QList<NormRect> peers;
         for (const CanvasItem& other : m_layout.itemsByZ()) {
-            if (other.id != m_gestureId) {
-                peers.append(other.rect);
+            if (other.id == m_gestureId) {
+                continue;
             }
+            if (movingPan
+                && other.contentType != QLatin1String("panadapter")) {
+                continue;
+            }
+            peers.append(other.rect);
         }
         const SnapResult snapped =
             snapRect(r, m_gestureZone, peers,

--- a/src/gui/workspace/WorkspaceCanvas.cpp
+++ b/src/gui/workspace/WorkspaceCanvas.cpp
@@ -18,6 +18,65 @@
 
 namespace AetherSDR {
 
+namespace {
+
+// 1 px dots at every snap-grid intersection.  Shared by the background pass
+// (exposed canvas) and the gesture overlay (above everything, drag-scoped).
+void paintGridDots(QPainter& p, const QSize& size, const QColor& color)
+{
+    p.setPen(color);
+    for (int ix = 1; ix < WorkspaceCanvas::kSnapGridColumns; ++ix) {
+        const int x = qRound(ix * size.width()
+                             / double(WorkspaceCanvas::kSnapGridColumns));
+        for (int iy = 1; iy < WorkspaceCanvas::kSnapGridRows; ++iy) {
+            const int y = qRound(iy * size.height()
+                                 / double(WorkspaceCanvas::kSnapGridRows));
+            p.drawPoint(x, y);
+        }
+    }
+}
+
+}  // namespace
+
+// Paints only while a gesture is live: the snap guides and the grid dots,
+// above every item.  Mouse-transparent so it can sit on top without eating
+// a single event.
+class WorkspaceCanvas::GestureOverlay : public QWidget {
+public:
+    explicit GestureOverlay(WorkspaceCanvas* canvas)
+        : QWidget(canvas)
+        , m_canvas(canvas)
+    {
+        setAttribute(Qt::WA_TransparentForMouseEvents);
+        setAttribute(Qt::WA_NoSystemBackground);
+        hide();
+    }
+
+protected:
+    void paintEvent(QPaintEvent*) override
+    {
+        QPainter p(this);
+
+        QColor dot = palette().windowText().color();
+        dot.setAlpha(90);
+        paintGridDots(p, size(), dot);
+
+        QPen pen(palette().highlight().color(), 1, Qt::DashLine);
+        p.setPen(pen);
+        for (double x : m_canvas->m_vGuides) {
+            const int px = qRound(x * width());
+            p.drawLine(px, 0, px, height());
+        }
+        for (double y : m_canvas->m_hGuides) {
+            const int py = qRound(y * height());
+            p.drawLine(0, py, width(), py);
+        }
+    }
+
+private:
+    WorkspaceCanvas* m_canvas{nullptr};
+};
+
 WorkspaceCanvas::WorkspaceCanvas(QWidget* parent)
     : QWidget(parent)
 {
@@ -29,6 +88,7 @@ WorkspaceCanvas::WorkspaceCanvas(QWidget* parent)
     setAccessibleName(QStringLiteral("Workspace canvas"));
 
     m_frame = new CanvasItemFrame(this);
+    m_gestureOverlay = new GestureOverlay(this);
 }
 
 WorkspaceCanvas::~WorkspaceCanvas()
@@ -151,7 +211,7 @@ QWidget* WorkspaceCanvas::takeItem(const QString& id)
         m_vGuides.clear();
         m_hGuides.clear();
         releaseKeyboard();
-        update();
+        if (m_gestureOverlay) m_gestureOverlay->hide();
     }
 
     QWidget* w = m_widgets.take(id).data();
@@ -291,6 +351,9 @@ void WorkspaceCanvas::resizeEvent(QResizeEvent* ev)
     // window forced on the view is how a transient startup size once
     // destroyed a stored arrangement (RFC #4887 phase 3 field report).
     applyGeometry();
+    if (m_gestureOverlay && m_gestureOverlay->isVisible()) {
+        m_gestureOverlay->setGeometry(rect());
+    }
 }
 
 bool WorkspaceCanvas::eventFilter(QObject* watched, QEvent* ev)
@@ -354,9 +417,13 @@ void WorkspaceCanvas::applyStacking()
             w->raise();
         }
     }
-    // The selection frame rides above every item, always.
+    // The selection frame rides above every item, always; the gesture
+    // overlay above even that, so guides are never occluded mid-drag.
     if (m_frame && m_frame->isVisible()) {
         m_frame->raise();
+    }
+    if (m_gestureOverlay && m_gestureOverlay->isVisible()) {
+        m_gestureOverlay->raise();
     }
 }
 
@@ -435,6 +502,11 @@ void WorkspaceCanvas::beginGesture(const QString& id, HitZone zone,
     // mid-drag from a title bar that has the mouse grab.  Scoped strictly
     // to the gesture: released in endGesture()/cancelGesture().
     grabKeyboard();
+
+    m_gestureOverlay->setGeometry(rect());
+    m_gestureOverlay->show();
+    m_gestureOverlay->raise();
+
     emit gestureStarted(id, m_gestureStart);
 }
 
@@ -477,14 +549,15 @@ void WorkspaceCanvas::moveGesture(const QPoint& globalPos)
         const SnapResult snapped =
             snapRect(r, m_gestureZone, peers,
                      kSnapTolerancePx / double(width()),
-                     kSnapTolerancePx / double(height()), minN);
+                     kSnapTolerancePx / double(height()), minN,
+                     kSnapGridColumns, kSnapGridRows);
         r         = snapped.rect;
         m_vGuides = snapped.verticalGuides;
         m_hGuides = snapped.horizontalGuides;
     }
 
     setItemRect(m_gestureId, r);
-    update();   // guides
+    m_gestureOverlay->update();   // guides + grid dots
 }
 
 void WorkspaceCanvas::endGesture(const QPoint& globalPos)
@@ -498,7 +571,7 @@ void WorkspaceCanvas::endGesture(const QPoint& globalPos)
     m_vGuides.clear();
     m_hGuides.clear();
     releaseKeyboard();
-    update();
+    m_gestureOverlay->hide();
 
     // A MOVE released outside the canvas is not a placement — it is either a
     // return to the panel (the controller's call) or an abort.  Restore the
@@ -521,8 +594,8 @@ void WorkspaceCanvas::cancelGesture()
     m_vGuides.clear();
     m_hGuides.clear();
     releaseKeyboard();
+    m_gestureOverlay->hide();
     setItemRect(id, m_gestureStart);
-    update();
 }
 
 // ── Bare-canvas input (phase 5) ──────────────────────────────────────────
@@ -626,20 +699,14 @@ void WorkspaceCanvas::keyPressEvent(QKeyEvent* ev)
 void WorkspaceCanvas::paintEvent(QPaintEvent* ev)
 {
     QWidget::paintEvent(ev);
-    if (m_vGuides.isEmpty() && m_hGuides.isEmpty()) {
-        return;
-    }
+    // Background dots: visible wherever items leave the canvas exposed.
+    // (A widget paints UNDER its children, so this pass cannot show through
+    // the spectrum — the gesture overlay handles the on-top case, and the
+    // guides live there with it.)
     QPainter p(this);
-    QPen pen(palette().highlight().color(), 1, Qt::DashLine);
-    p.setPen(pen);
-    for (double x : m_vGuides) {
-        const int px = qRound(x * width());
-        p.drawLine(px, 0, px, height());
-    }
-    for (double y : m_hGuides) {
-        const int py = qRound(y * height());
-        p.drawLine(0, py, width(), py);
-    }
+    QColor dot = palette().windowText().color();
+    dot.setAlpha(60);
+    paintGridDots(p, size(), dot);
 }
 
 void WorkspaceCanvas::contextMenuEvent(QContextMenuEvent* ev)

--- a/src/gui/workspace/WorkspaceCanvas.cpp
+++ b/src/gui/workspace/WorkspaceCanvas.cpp
@@ -1,6 +1,10 @@
 #include "gui/workspace/WorkspaceCanvas.h"
 
+#include <QDragEnterEvent>
+#include <QDragMoveEvent>
+#include <QDropEvent>
 #include <QEvent>
+#include <QMimeData>
 #include <QMouseEvent>
 #include <QResizeEvent>
 
@@ -214,6 +218,45 @@ bool WorkspaceCanvas::sendItemToBack(const QString& id)
     applyStacking();
     emit itemStackingChanged(id);
     return true;
+}
+
+void WorkspaceCanvas::setDropMimeType(const QByteArray& mimeType)
+{
+    m_dropMimeType = mimeType;
+    setAcceptDrops(!mimeType.isEmpty());
+}
+
+void WorkspaceCanvas::dragEnterEvent(QDragEnterEvent* ev)
+{
+    if (!m_dropMimeType.isEmpty()
+        && ev->mimeData()->hasFormat(QString::fromLatin1(m_dropMimeType))) {
+        ev->acceptProposedAction();
+    }
+}
+
+void WorkspaceCanvas::dragMoveEvent(QDragMoveEvent* ev)
+{
+    if (!m_dropMimeType.isEmpty()
+        && ev->mimeData()->hasFormat(QString::fromLatin1(m_dropMimeType))) {
+        ev->acceptProposedAction();
+    }
+}
+
+void WorkspaceCanvas::dropEvent(QDropEvent* ev)
+{
+    if (m_dropMimeType.isEmpty()
+        || !ev->mimeData()->hasFormat(QString::fromLatin1(m_dropMimeType))
+        || width() <= 0 || height() <= 0) {
+        return;
+    }
+
+    const QString payload = QString::fromUtf8(
+        ev->mimeData()->data(QString::fromLatin1(m_dropMimeType)));
+    const QPointF pos(ev->position().x() / width(),
+                      ev->position().y() / height());
+
+    ev->acceptProposedAction();
+    emit dropReceived(payload, pos);
 }
 
 void WorkspaceCanvas::resizeEvent(QResizeEvent* ev)

--- a/src/gui/workspace/WorkspaceCanvas.cpp
+++ b/src/gui/workspace/WorkspaceCanvas.cpp
@@ -1,6 +1,12 @@
 #include "gui/workspace/WorkspaceCanvas.h"
 
+#include "gui/workspace/CanvasItemFrame.h"
+
+#include <QApplication>
+#include <QContextMenuEvent>
 #include <QDragEnterEvent>
+#include <QKeyEvent>
+#include <QPainter>
 #include <QDragMoveEvent>
 #include <QDropEvent>
 #include <QEvent>
@@ -19,6 +25,10 @@ WorkspaceCanvas::WorkspaceCanvas(QWidget* parent)
     // have no layout manager: one would fight applyGeometry() on every
     // resize and win.
     setMouseTracking(true);
+    setFocusPolicy(Qt::StrongFocus);   // keyboard placement (phase 5)
+    setAccessibleName(QStringLiteral("Workspace canvas"));
+
+    m_frame = new CanvasItemFrame(this);
 }
 
 WorkspaceCanvas::~WorkspaceCanvas()
@@ -129,6 +139,19 @@ QWidget* WorkspaceCanvas::takeItem(const QString& id)
 {
     if (!m_layout.contains(id)) {
         return nullptr;
+    }
+
+    if (id == m_selectedId) {
+        clearSelection();
+    }
+    if (id == m_gestureId) {
+        // The item is leaving mid-gesture (eviction, disable) — drop the
+        // session without touching a rect that no longer matters.
+        m_gestureId.clear();
+        m_vGuides.clear();
+        m_hGuides.clear();
+        releaseKeyboard();
+        update();
     }
 
     QWidget* w = m_widgets.take(id).data();
@@ -281,6 +304,7 @@ bool WorkspaceCanvas::eventFilter(QObject* watched, QEvent* ev)
                 // cost a whole-document write after the debounce — the same
                 // rule resizeEvent() follows (PR #4900 review, M2).
                 bringItemToFront(it.key());
+                selectItem(it.key());
                 break;
             }
         }
@@ -289,19 +313,29 @@ bool WorkspaceCanvas::eventFilter(QObject* watched, QEvent* ev)
     return QWidget::eventFilter(watched, ev);
 }
 
-void WorkspaceCanvas::applyGeometryFor(const QString& id)
+QRect WorkspaceCanvas::displayRectFor(const QString& id) const
 {
-    QWidget* w = m_widgets.value(id).data();
     const CanvasItem* it = m_layout.item(id);
-    if (!w || !it) {
-        return;
+    if (!it) {
+        return {};
     }
     // The display clamp lives HERE and only here: minimum sizes are enforced
     // against the canvas as it is right now, the stored rect stays pristine,
     // and a canvas too small to honour a minimum shows a compromise it will
     // abandon the moment the canvas grows back.
-    w->setGeometry(toPixels(clampToCanvas(it->rect, it->minimumSize, size()),
-                            size()));
+    return toPixels(clampToCanvas(it->rect, it->minimumSize, size()), size());
+}
+
+void WorkspaceCanvas::applyGeometryFor(const QString& id)
+{
+    QWidget* w = m_widgets.value(id).data();
+    if (!w || !m_layout.contains(id)) {
+        return;
+    }
+    w->setGeometry(displayRectFor(id));
+    if (id == m_selectedId) {
+        updateFrame();
+    }
 }
 
 void WorkspaceCanvas::applyGeometry()
@@ -320,6 +354,268 @@ void WorkspaceCanvas::applyStacking()
             w->raise();
         }
     }
+    // The selection frame rides above every item, always.
+    if (m_frame && m_frame->isVisible()) {
+        m_frame->raise();
+    }
+}
+
+// ── Selection (phase 5) ──────────────────────────────────────────────────
+
+void WorkspaceCanvas::selectItem(const QString& id)
+{
+    if (id == m_selectedId || !m_layout.contains(id)) {
+        return;
+    }
+    m_selectedId = id;
+    updateFrame();
+    if (QWidget* w = m_widgets.value(id).data()) {
+        setAccessibleDescription(
+            QStringLiteral("%1 selected").arg(w->accessibleName().isEmpty()
+                                                  ? id
+                                                  : w->accessibleName()));
+    }
+    emit selectionChanged(id);
+}
+
+void WorkspaceCanvas::clearSelection()
+{
+    if (m_selectedId.isEmpty()) {
+        return;
+    }
+    m_selectedId.clear();
+    updateFrame();
+    setAccessibleDescription(QString());
+    emit selectionChanged(QString());
+}
+
+void WorkspaceCanvas::updateFrame()
+{
+    if (!m_frame) {
+        return;
+    }
+    if (m_selectedId.isEmpty() || !m_layout.contains(m_selectedId)) {
+        m_frame->hide();
+        return;
+    }
+    m_frame->followItem(displayRectFor(m_selectedId));
+    m_frame->show();
+    m_frame->raise();
+}
+
+// ── The gesture session (phase 5) ────────────────────────────────────────
+
+QSizeF WorkspaceCanvas::minNormFor(const QString& id) const
+{
+    const CanvasItem* it = m_layout.item(id);
+    if (!it) {
+        return {};
+    }
+    return minimumNormSize(it->minimumSize, size());
+}
+
+void WorkspaceCanvas::beginGesture(const QString& id, HitZone zone,
+                                   const QPoint& globalPos)
+{
+    const CanvasItem* it = m_layout.item(id);
+    if (!it || zone == HitZone::None || width() <= 0 || height() <= 0) {
+        return;
+    }
+    if (gestureActive()) {
+        cancelGesture();   // one at a time; a stray second press wins cleanly
+    }
+
+    m_gestureId     = id;
+    m_gestureZone   = zone;
+    m_gestureStart  = it->rect;
+    m_gestureOrigin = globalPos;
+
+    selectItem(id);
+    // Esc-to-cancel has to work wherever focus happens to be, including
+    // mid-drag from a title bar that has the mouse grab.  Scoped strictly
+    // to the gesture: released in endGesture()/cancelGesture().
+    grabKeyboard();
+    emit gestureStarted(id, m_gestureStart);
+}
+
+void WorkspaceCanvas::beginMoveGesture(const QString& id, const QPoint& globalPos)
+{
+    beginGesture(id, HitZone::Move, globalPos);
+}
+
+void WorkspaceCanvas::beginFrameGesture(HitZone zone, const QPoint& globalPos)
+{
+    if (!m_selectedId.isEmpty()) {
+        beginGesture(m_selectedId, zone, globalPos);
+    }
+}
+
+void WorkspaceCanvas::moveGesture(const QPoint& globalPos)
+{
+    if (!gestureActive() || width() <= 0 || height() <= 0) {
+        return;
+    }
+
+    const QPoint deltaPx = globalPos - m_gestureOrigin;
+    const double dx = deltaPx.x() / double(width());
+    const double dy = deltaPx.y() / double(height());
+
+    const QSizeF minN = minNormFor(m_gestureId);
+    NormRect r = applyDrag(m_gestureStart, m_gestureZone, dx, dy, minN);
+
+    m_vGuides.clear();
+    m_hGuides.clear();
+    // Alt suppresses snapping for as long as it is held — checked per
+    // motion so the operator can toggle precision mid-drag.
+    if (!(QApplication::keyboardModifiers() & Qt::AltModifier)) {
+        QList<NormRect> peers;
+        for (const CanvasItem& other : m_layout.itemsByZ()) {
+            if (other.id != m_gestureId) {
+                peers.append(other.rect);
+            }
+        }
+        const SnapResult snapped =
+            snapRect(r, m_gestureZone, peers,
+                     kSnapTolerancePx / double(width()),
+                     kSnapTolerancePx / double(height()), minN);
+        r         = snapped.rect;
+        m_vGuides = snapped.verticalGuides;
+        m_hGuides = snapped.horizontalGuides;
+    }
+
+    setItemRect(m_gestureId, r);
+    update();   // guides
+}
+
+void WorkspaceCanvas::endGesture(const QPoint& globalPos)
+{
+    if (!gestureActive()) {
+        return;
+    }
+    const QString id   = m_gestureId;
+    const HitZone zone = m_gestureZone;
+    m_gestureId.clear();
+    m_vGuides.clear();
+    m_hGuides.clear();
+    releaseKeyboard();
+    update();
+
+    // A MOVE released outside the canvas is not a placement — it is either a
+    // return to the panel (the controller's call) or an abort.  Restore the
+    // start rect first so no path leaves the item where it cannot live.
+    if (zone == HitZone::Move && !rect().contains(mapFromGlobal(globalPos))) {
+        setItemRect(id, m_gestureStart);
+        emit itemDraggedOut(id, globalPos);
+        return;
+    }
+    emit gestureFinished(id);
+}
+
+void WorkspaceCanvas::cancelGesture()
+{
+    if (!gestureActive()) {
+        return;
+    }
+    const QString id = m_gestureId;
+    m_gestureId.clear();
+    m_vGuides.clear();
+    m_hGuides.clear();
+    releaseKeyboard();
+    setItemRect(id, m_gestureStart);
+    update();
+}
+
+// ── Bare-canvas input (phase 5) ──────────────────────────────────────────
+
+void WorkspaceCanvas::mousePressEvent(QMouseEvent* ev)
+{
+    // Reached two ways: a genuine bare-canvas press, and a press on a
+    // NON-INTERACTIVE part of an item whose widget ignored it — Qt
+    // propagates ignored presses to the parent.  Deselecting on the second
+    // kind would undo the selection the event filter just made (the click
+    // landed ON the item, from the operator's point of view), so hit-test
+    // rather than assume.
+    const QString hit = hitTest(ev->position().toPoint());
+    if (hit.isEmpty()) {
+        clearSelection();
+    } else {
+        bringItemToFront(hit);
+        selectItem(hit);   // no-op when the filter already selected it
+    }
+    setFocus(Qt::MouseFocusReason);
+    QWidget::mousePressEvent(ev);
+}
+
+void WorkspaceCanvas::keyPressEvent(QKeyEvent* ev)
+{
+    if (ev->key() == Qt::Key_Escape) {
+        if (gestureActive()) {
+            cancelGesture();
+        } else {
+            clearSelection();
+        }
+        ev->accept();
+        return;
+    }
+
+    // Keyboard placement: arrows nudge the selected item, Shift+arrows
+    // resize it (SE-corner semantics: right/bottom edges move), Ctrl makes
+    // either fine-grained.  Deliberately no snapping — reaching for the
+    // keyboard is a statement of precise intent.
+    const bool arrow = ev->key() == Qt::Key_Left || ev->key() == Qt::Key_Right
+                       || ev->key() == Qt::Key_Up || ev->key() == Qt::Key_Down;
+    if (!arrow || m_selectedId.isEmpty() || gestureActive()
+        || width() <= 0 || height() <= 0) {
+        QWidget::keyPressEvent(ev);
+        return;
+    }
+
+    const int px = (ev->modifiers() & Qt::ControlModifier) ? 1 : kNudgePx;
+    const double dx = (ev->key() == Qt::Key_Right ? px
+                       : ev->key() == Qt::Key_Left ? -px : 0) / double(width());
+    const double dy = (ev->key() == Qt::Key_Down ? px
+                       : ev->key() == Qt::Key_Up ? -px : 0) / double(height());
+
+    const CanvasItem* it = m_layout.item(m_selectedId);
+    if (!it) {
+        return;
+    }
+    const HitZone zone = (ev->modifiers() & Qt::ShiftModifier)
+                             ? HitZone::SE
+                             : HitZone::Move;
+    const NormRect before = it->rect;
+    const NormRect after =
+        applyDrag(before, zone, dx, dy, minNormFor(m_selectedId));
+
+    emit gestureStarted(m_selectedId, before);
+    setItemRect(m_selectedId, after);
+    emit gestureFinished(m_selectedId);
+    ev->accept();
+}
+
+void WorkspaceCanvas::paintEvent(QPaintEvent* ev)
+{
+    QWidget::paintEvent(ev);
+    if (m_vGuides.isEmpty() && m_hGuides.isEmpty()) {
+        return;
+    }
+    QPainter p(this);
+    QPen pen(palette().highlight().color(), 1, Qt::DashLine);
+    p.setPen(pen);
+    for (double x : m_vGuides) {
+        const int px = qRound(x * width());
+        p.drawLine(px, 0, px, height());
+    }
+    for (double y : m_hGuides) {
+        const int py = qRound(y * height());
+        p.drawLine(0, py, width(), py);
+    }
+}
+
+void WorkspaceCanvas::contextMenuEvent(QContextMenuEvent* ev)
+{
+    emit contextMenuRequested(hitTest(ev->pos()), ev->globalPos());
+    ev->accept();
 }
 
 }  // namespace AetherSDR

--- a/src/gui/workspace/WorkspaceCanvas.cpp
+++ b/src/gui/workspace/WorkspaceCanvas.cpp
@@ -332,6 +332,9 @@ void WorkspaceCanvas::setDropMimeType(const QByteArray& mimeType)
 
 void WorkspaceCanvas::dragEnterEvent(QDragEnterEvent* ev)
 {
+    if (!m_editMode) {
+        return;   // locked: not accepted, the panel ghost shows refusal
+    }
     if (!m_dropMimeType.isEmpty()
         && ev->mimeData()->hasFormat(QString::fromLatin1(m_dropMimeType))) {
         ev->acceptProposedAction();
@@ -379,7 +382,7 @@ void WorkspaceCanvas::resizeEvent(QResizeEvent* ev)
 
 bool WorkspaceCanvas::eventFilter(QObject* watched, QEvent* ev)
 {
-    if (ev->type() == QEvent::MouseButtonPress) {
+    if (m_editMode && ev->type() == QEvent::MouseButtonPress) {
         for (auto it = m_widgets.constBegin(); it != m_widgets.constEnd(); ++it) {
             if (it.value().data() == watched) {
                 // bringItemToFront() is false when the item was already
@@ -450,6 +453,22 @@ void WorkspaceCanvas::applyStacking()
 
 // ── Selection (phase 5) ──────────────────────────────────────────────────
 
+void WorkspaceCanvas::setEditMode(bool on)
+{
+    if (m_editMode == on) {
+        return;
+    }
+    m_editMode = on;
+    if (!on) {
+        // Leaving edit mid-gesture abandons the gesture (rect restored) and
+        // the selection with it — a locked canvas shows no frame.
+        cancelGesture();
+        clearSelection();
+    }
+    update();   // grid dots appear/disappear with the mode
+    emit editModeChanged(on);
+}
+
 void WorkspaceCanvas::selectItem(const QString& id)
 {
     if (id == m_selectedId || !m_layout.contains(id)) {
@@ -506,8 +525,9 @@ void WorkspaceCanvas::beginGesture(const QString& id, HitZone zone,
                                    const QPoint& globalPos)
 {
     const CanvasItem* it = m_layout.item(id);
-    if (!it || zone == HitZone::None || width() <= 0 || height() <= 0) {
-        return;
+    if (!m_editMode || !it || zone == HitZone::None
+        || width() <= 0 || height() <= 0) {
+        return;   // a locked canvas arms no placement gesture
     }
     if (gestureActive()) {
         cancelGesture();   // one at a time; a stray second press wins cleanly
@@ -670,7 +690,7 @@ bool WorkspaceCanvas::event(QEvent* ev)
     // the override is consulted for the focus widget alone, so clicking into
     // the spectrum or deselecting hands the VFO its keys straight back.
     // Selecting an item is the operator saying "I'm placing things now."
-    if (ev->type() == QEvent::ShortcutOverride
+    if (m_editMode && ev->type() == QEvent::ShortcutOverride
         && (!m_selectedId.isEmpty() || gestureActive())) {
         auto* ke = static_cast<QKeyEvent*>(ev);
         switch (ke->key()) {
@@ -690,6 +710,10 @@ bool WorkspaceCanvas::event(QEvent* ev)
 
 void WorkspaceCanvas::keyPressEvent(QKeyEvent* ev)
 {
+    if (!m_editMode) {
+        QWidget::keyPressEvent(ev);
+        return;
+    }
     if (ev->key() == Qt::Key_Escape) {
         if (gestureActive()) {
             cancelGesture();
@@ -748,8 +772,12 @@ void WorkspaceCanvas::paintEvent(QPaintEvent* ev)
     auto& theme = ThemeManager::instance();
     p.fillRect(rect(),
                theme.color(this, QStringLiteral("color.canvas.background")));
-    paintGridDots(p, size(),
-                  theme.color(this, QStringLiteral("color.canvas.dots")));
+    if (m_editMode) {
+        // Dots are placement targets; a locked canvas is an operating
+        // surface and shows none.
+        paintGridDots(p, size(),
+                      theme.color(this, QStringLiteral("color.canvas.dots")));
+    }
 }
 
 void WorkspaceCanvas::contextMenuEvent(QContextMenuEvent* ev)

--- a/src/gui/workspace/WorkspaceCanvas.cpp
+++ b/src/gui/workspace/WorkspaceCanvas.cpp
@@ -210,6 +210,16 @@ bool WorkspaceCanvas::removeItem(const QString& id)
 
 QWidget* WorkspaceCanvas::takeItem(const QString& id)
 {
+    QWidget* w = releaseItem(id);
+    if (w) {
+        w->hide();
+        w->setParent(nullptr);
+    }
+    return w;
+}
+
+QWidget* WorkspaceCanvas::releaseItem(const QString& id)
+{
     if (!m_layout.contains(id)) {
         return nullptr;
     }
@@ -236,8 +246,6 @@ QWidget* WorkspaceCanvas::takeItem(const QString& id)
         // would fire a lambda still holding this id — and if something else
         // has since taken the id, it would evict the wrong item.
         disconnect(w, &QObject::destroyed, this, nullptr);
-        w->hide();
-        w->setParent(nullptr);
     }
 
     // Removal renumbers z, so the surviving items' stacking has to be redone.

--- a/src/gui/workspace/WorkspaceCanvas.cpp
+++ b/src/gui/workspace/WorkspaceCanvas.cpp
@@ -2,6 +2,8 @@
 
 #include "gui/workspace/CanvasItemFrame.h"
 
+#include "core/ThemeManager.h"
+
 #include <QApplication>
 #include <QContextMenuEvent>
 #include <QDragEnterEvent>
@@ -57,9 +59,11 @@ protected:
     {
         QPainter p(this);
 
-        QColor dot = palette().windowText().color();
-        dot.setAlpha(90);
-        paintGridDots(p, size(), dot);
+        // The token carries its own alpha and is used verbatim by both dot
+        // passes, so themes control the dots with one value.
+        paintGridDots(p, size(),
+                      ThemeManager::instance().color(
+                          m_canvas, QStringLiteral("color.canvas.dots")));
 
         QPen pen(palette().highlight().color(), 1, Qt::DashLine);
         p.setPen(pen);
@@ -89,6 +93,15 @@ WorkspaceCanvas::WorkspaceCanvas(QWidget* parent)
 
     m_frame = new CanvasItemFrame(this);
     m_gestureOverlay = new GestureOverlay(this);
+
+    // The background and dots paint with raw QPainter from theme tokens, so
+    // unlike applyStyleSheet() registrants they need an explicit nudge when
+    // the theme changes.
+    connect(&ThemeManager::instance(), &ThemeManager::themeChanged, this,
+            [this] {
+                update();
+                if (m_gestureOverlay) m_gestureOverlay->update();
+            });
 }
 
 WorkspaceCanvas::~WorkspaceCanvas()
@@ -702,14 +715,18 @@ void WorkspaceCanvas::keyPressEvent(QKeyEvent* ev)
 void WorkspaceCanvas::paintEvent(QPaintEvent* ev)
 {
     QWidget::paintEvent(ev);
-    // Background dots: visible wherever items leave the canvas exposed.
-    // (A widget paints UNDER its children, so this pass cannot show through
-    // the spectrum — the gesture overlay handles the on-top case, and the
-    // guides live there with it.)
+    // Background + dots from the color.canvas.* tokens (default background:
+    // 50% darker than color.background.app, so exposed canvas reads as a
+    // distinct working surface).  Only visible wherever items leave the
+    // canvas exposed — a widget paints UNDER its children, so this pass
+    // cannot show through the spectrum; the gesture overlay handles the
+    // on-top case, and the guides live there with it.
     QPainter p(this);
-    QColor dot = palette().windowText().color();
-    dot.setAlpha(60);
-    paintGridDots(p, size(), dot);
+    auto& theme = ThemeManager::instance();
+    p.fillRect(rect(),
+               theme.color(this, QStringLiteral("color.canvas.background")));
+    paintGridDots(p, size(),
+                  theme.color(this, QStringLiteral("color.canvas.dots")));
 }
 
 void WorkspaceCanvas::contextMenuEvent(QContextMenuEvent* ev)

--- a/src/gui/workspace/WorkspaceCanvas.h
+++ b/src/gui/workspace/WorkspaceCanvas.h
@@ -22,6 +22,7 @@
 #include "gui/workspace/CanvasLayout.h"
 
 #include <QHash>
+#include <QPointF>
 #include <QPointer>
 #include <QSize>
 #include <QString>
@@ -94,7 +95,23 @@ public:
     // Read-only view of the model, for tests and for phase 2's serializer.
     const CanvasLayout& layout() const { return m_layout; }
 
+    // ── Drag-and-drop (RFC #4887 phase 3) ────────────────────────────────
+    //
+    // The canvas accepts drops of one MIME type and reports them upward as
+    // (payload, normalized point); it applies no policy of its own.  What a
+    // drop MEANS — place a panel applet, move an existing item, refuse —
+    // is the WorkspaceController's call, because the answer depends on
+    // state the canvas cannot see (the panel, the manager, the document).
+    // Empty MIME type (the default) leaves drops disabled.
+    void setDropMimeType(const QByteArray& mimeType);
+    QByteArray dropMimeType() const { return m_dropMimeType; }
+
 signals:
+    // A drop of the accepted MIME type landed at `pos` (canvas fractions).
+    // `payload` is the MIME data verbatim — for the applet MIME this is the
+    // container's dragId().
+    void dropReceived(const QString& payload, const QPointF& pos);
+
     // Emitted whenever an item's stored rect changes — including the clamps
     // applied on a canvas resize, which is why the rect is carried in the
     // signal rather than left for the receiver to read back.
@@ -110,6 +127,9 @@ signals:
 
 protected:
     void resizeEvent(QResizeEvent* ev) override;
+    void dragEnterEvent(QDragEnterEvent* ev) override;
+    void dragMoveEvent(QDragMoveEvent* ev) override;
+    void dropEvent(QDropEvent* ev) override;
 
     // Raises an item when its widget is pressed.  Installed on the item widget
     // itself, so a press landing on a deeper descendant does not raise — real
@@ -130,6 +150,7 @@ private:
 
     CanvasLayout m_layout;
     QHash<QString, QPointer<QWidget>> m_widgets;
+    QByteArray m_dropMimeType;
 };
 
 }  // namespace AetherSDR

--- a/src/gui/workspace/WorkspaceCanvas.h
+++ b/src/gui/workspace/WorkspaceCanvas.h
@@ -112,14 +112,16 @@ signals:
     // container's dragId().
     void dropReceived(const QString& payload, const QPointF& pos);
 
-    // Emitted whenever an item's stored rect changes — including the clamps
-    // applied on a canvas resize, which is why the rect is carried in the
-    // signal rather than left for the receiver to read back.
+    // Emitted when an item's STORED rect changes — placement gestures only.
+    // A canvas resize emits nothing: stored rects are canvas-independent,
+    // and the squeeze a small window forces on the view is display-time
+    // compromise (applyGeometryFor), never an edit.  Growing the window
+    // therefore restores the arrangement exactly, and a transient size at
+    // startup can no longer rewrite the document (the phase 3 field report).
     //
     // Both of these are edits: phase 2's auto-commit turns each into a
     // whole-document write, so neither fires for an operation that changed
-    // nothing.  A resize that clamps no item is silent, and so is raising an
-    // item that was already frontmost.
+    // nothing — raising an already-frontmost item is silent too.
     void itemRectChanged(const QString& id, const NormRect& rect);
     void itemStackingChanged(const QString& id);
     void itemAdded(const QString& id);

--- a/src/gui/workspace/WorkspaceCanvas.h
+++ b/src/gui/workspace/WorkspaceCanvas.h
@@ -19,6 +19,7 @@
 // theme seed: those are RFC #4764's files, and phase 1 runs in parallel with
 // it precisely because it stays out of them.
 
+#include "gui/workspace/CanvasInteraction.h"
 #include "gui/workspace/CanvasLayout.h"
 
 #include <QHash>
@@ -95,6 +96,33 @@ public:
     // Read-only view of the model, for tests and for phase 2's serializer.
     const CanvasLayout& layout() const { return m_layout; }
 
+    // ── Selection + interactive gestures (RFC #4887 phase 5) ─────────────
+    //
+    // One item may be selected; selection shows the grip frame (resize) and
+    // is what the keyboard operates on.  Pressing an item selects and
+    // raises it; pressing bare canvas clears.
+    void selectItem(const QString& id);
+    void clearSelection();
+    QString selectedItem() const { return m_selectedId; }
+
+    // The gesture session — one at a time, driven from three sources that
+    // all land here: the title bar's live-move stream (via the controller),
+    // the grip frame's resize drags, and the keyboard.  The session applies
+    // applyDrag()+snapRect() live, so the item follows the cursor with snap
+    // guides painted; Esc cancels (restores the start rect); holding Alt
+    // suppresses snapping for the duration of that motion.
+    void beginMoveGesture(const QString& id, const QPoint& globalPos);
+    void beginFrameGesture(HitZone zone, const QPoint& globalPos);  // on the selection
+    void moveGesture(const QPoint& globalPos);
+    void endGesture(const QPoint& globalPos);
+    void cancelGesture();
+    bool gestureActive() const { return !m_gestureId.isEmpty(); }
+
+    // Snap capture distance (px on the live canvas).
+    static constexpr int kSnapTolerancePx = 8;
+    // Keyboard nudge step (px); Ctrl divides it for fine placement.
+    static constexpr int kNudgePx = 8;
+
     // ── Drag-and-drop (RFC #4887 phase 3) ────────────────────────────────
     //
     // The canvas accepts drops of one MIME type and reports them upward as
@@ -111,6 +139,26 @@ signals:
     // `payload` is the MIME data verbatim — for the applet MIME this is the
     // container's dragId().
     void dropReceived(const QString& payload, const QPointF& pos);
+
+    // Selection, for the frame, the controller's context menu, and a11y.
+    void selectionChanged(const QString& id);   // empty = cleared
+
+    // A gesture began (undo snapshots hang off this) and committed.  A
+    // cancelled gesture emits neither finish nor a rect change beyond the
+    // restore.  Keyboard nudges emit the same pair, so every placement
+    // change flows through one seam.
+    void gestureStarted(const QString& id, const NormRect& startRect);
+    void gestureFinished(const QString& id);
+
+    // A live move was RELEASED outside the canvas.  The item has already
+    // been restored to its start rect — whoever owns the surroundings
+    // decides whether the release point means something (the controller
+    // returns applets dropped onto the panel).
+    void itemDraggedOut(const QString& id, const QPoint& globalPos);
+
+    // Context menu request: `id` is the item under the cursor, empty over
+    // bare canvas.  Policy lives with the controller.
+    void contextMenuRequested(const QString& id, const QPoint& globalPos);
 
     // Emitted when an item's STORED rect changes — placement gestures only.
     // A canvas resize emits nothing: stored rects are canvas-independent,
@@ -132,6 +180,10 @@ protected:
     void dragEnterEvent(QDragEnterEvent* ev) override;
     void dragMoveEvent(QDragMoveEvent* ev) override;
     void dropEvent(QDropEvent* ev) override;
+    void mousePressEvent(QMouseEvent* ev) override;   // bare canvas: deselect
+    void keyPressEvent(QKeyEvent* ev) override;
+    void paintEvent(QPaintEvent* ev) override;        // snap guides
+    void contextMenuEvent(QContextMenuEvent* ev) override;
 
     // Raises an item when its widget is pressed.  Installed on the item widget
     // itself, so a press landing on a deeper descendant does not raise — real
@@ -143,6 +195,14 @@ private:
     // Model -> pixels, for every item.
     void applyGeometry();
 
+    // The display rect of one item — the stored rect through the display
+    // clamp.  What applyGeometryFor() sets and what the frame follows.
+    QRect displayRectFor(const QString& id) const;
+
+    void beginGesture(const QString& id, HitZone zone, const QPoint& globalPos);
+    void updateFrame();
+    QSizeF minNormFor(const QString& id) const;
+
     // Model -> Qt stacking.  Raising bottom-to-top leaves the highest z on
     // top; Qt has no "set stacking index", so the order of these calls IS the
     // result.
@@ -153,6 +213,18 @@ private:
     CanvasLayout m_layout;
     QHash<QString, QPointer<QWidget>> m_widgets;
     QByteArray m_dropMimeType;
+
+    // Selection + frame (phase 5).
+    QString m_selectedId;
+    class CanvasItemFrame* m_frame{nullptr};
+
+    // Active gesture.
+    QString  m_gestureId;
+    HitZone  m_gestureZone{HitZone::None};
+    NormRect m_gestureStart;
+    QPoint   m_gestureOrigin;   // global press position
+    QList<double> m_vGuides;
+    QList<double> m_hGuides;
 };
 
 }  // namespace AetherSDR

--- a/src/gui/workspace/WorkspaceCanvas.h
+++ b/src/gui/workspace/WorkspaceCanvas.h
@@ -120,17 +120,24 @@ public:
 
     // Snap capture distance (px on the live canvas).
     static constexpr int kSnapTolerancePx = 8;
-    // The snap grid, in NORMALIZED divisions — 16x9 makes the cells EXACTLY
-    // square at a 16:9 window (1920/16 == 1080/9 == 120 px) and meaningfully
-    // coarse: 32x18 read as scatter rather than structure in field testing.
-    // Normalized on purpose: a pixel grid would put an item on-grid at one
-    // window size and off-grid at every other, which is the exact failure
-    // the fractional model exists to prevent.  1 px dots mark the
-    // intersections: always in the canvas background, and on top of
-    // everything while a gesture is live (the only time the targets matter
-    // more than the content).
-    static constexpr int kSnapGridColumns = 16;
-    static constexpr int kSnapGridRows    = 9;
+    // The snap grid, in NORMALIZED divisions — field-tuned to 96x54
+    // (~20 px cells at 1920, exactly square at 16:9).  Normalized on
+    // purpose: a pixel grid would put an item on-grid at one window size and
+    // off-grid at every other, which is the exact failure the fractional
+    // model exists to prevent.  1 px dots mark the intersections: always in
+    // the canvas background, and on top of everything while a gesture is
+    // live (the only time the targets matter more than the content).
+    static constexpr int kSnapGridColumns = 96;
+    static constexpr int kSnapGridRows    = 54;
+    // The grid's own magnet, gentler than the peer tier's: at ~20 px pitch a
+    // full 8 px pull would capture nearly every position and free placement
+    // would need Alt held permanently.
+    static constexpr int kGridSnapTolerancePx = 4;
+
+    // Whether gestures snap to the grid (the dots stay either way) — the
+    // RFC's "optional grid", toggled from the canvas context menu.
+    void setGridSnapEnabled(bool on) { m_gridSnapEnabled = on; }
+    bool isGridSnapEnabled() const { return m_gridSnapEnabled; }
     // Keyboard nudge step (px); Ctrl divides it for fine placement.
     static constexpr int kNudgePx = 8;
 
@@ -236,6 +243,7 @@ private:
     GestureOverlay* m_gestureOverlay{nullptr};
 
     // Active gesture.
+    bool m_gridSnapEnabled{true};
     QString  m_gestureId;
     HitZone  m_gestureZone{HitZone::None};
     NormRect m_gestureStart;

--- a/src/gui/workspace/WorkspaceCanvas.h
+++ b/src/gui/workspace/WorkspaceCanvas.h
@@ -176,6 +176,7 @@ signals:
     void itemRemoved(const QString& id);
 
 protected:
+    bool event(QEvent* ev) override;   // ShortcutOverride: placement keys win
     void resizeEvent(QResizeEvent* ev) override;
     void dragEnterEvent(QDragEnterEvent* ev) override;
     void dragMoveEvent(QDragMoveEvent* ev) override;

--- a/src/gui/workspace/WorkspaceCanvas.h
+++ b/src/gui/workspace/WorkspaceCanvas.h
@@ -76,6 +76,14 @@ public:
     // canvas and a container without destroying it.
     QWidget* takeItem(const QString& id);
 
+    // Drops the canvas's claim on the item — entry, selection, gesture,
+    // filter, destroyed-watch — WITHOUT touching the widget's parent.  The
+    // pan-item path (#4887 phase 4): a pan that floats has already been
+    // adopted by its PanFloatingWindow, and the detour takeItem() makes
+    // through setParent(nullptr) is exactly the transient-top-level move the
+    // #1344 lineage forbids for QRhi children.  Callers own the reparent.
+    QWidget* releaseItem(const QString& id);
+
     QWidget* itemWidget(const QString& id) const;
     bool contains(const QString& id) const { return m_layout.contains(id); }
     int itemCount() const { return m_layout.count(); }

--- a/src/gui/workspace/WorkspaceCanvas.h
+++ b/src/gui/workspace/WorkspaceCanvas.h
@@ -120,6 +120,15 @@ public:
 
     // Snap capture distance (px on the live canvas).
     static constexpr int kSnapTolerancePx = 8;
+    // The snap grid, in NORMALIZED divisions — 32x18 keeps the cells roughly
+    // square at 16:9.  Normalized on purpose: a pixel grid would put an item
+    // on-grid at one window size and off-grid at every other, which is the
+    // exact failure the fractional model exists to prevent.  1 px dots mark
+    // the intersections: always in the canvas background, and on top of
+    // everything while a gesture is live (the only time the targets matter
+    // more than the content).
+    static constexpr int kSnapGridColumns = 32;
+    static constexpr int kSnapGridRows    = 18;
     // Keyboard nudge step (px); Ctrl divides it for fine placement.
     static constexpr int kNudgePx = 8;
 
@@ -218,6 +227,11 @@ private:
     // Selection + frame (phase 5).
     QString m_selectedId;
     class CanvasItemFrame* m_frame{nullptr};
+    // Gesture visuals — guides + grid dots painted ABOVE the items (a
+    // widget's own paint sits under its children, so the canvas paintEvent
+    // can only reach exposed background).  Mouse-transparent.
+    class GestureOverlay;
+    GestureOverlay* m_gestureOverlay{nullptr};
 
     // Active gesture.
     QString  m_gestureId;

--- a/src/gui/workspace/WorkspaceCanvas.h
+++ b/src/gui/workspace/WorkspaceCanvas.h
@@ -146,6 +146,23 @@ public:
     // RFC's "optional grid", toggled from the canvas context menu.
     void setGridSnapEnabled(bool on) { m_gridSnapEnabled = on; }
     bool isGridSnapEnabled() const { return m_gridSnapEnabled; }
+
+    // ── Edit mode (8600 field request) ───────────────────────────────────
+    //
+    // A locked canvas is for OPERATING: no click-to-select, no frame, no
+    // title-strip drags, no drops, no nudge keys, no grid dots — presses go
+    // to the applet content and nothing arms placement.  Edit mode is the
+    // arranging posture: everything above comes back.  The BARE widget
+    // defaults to editing (a canvas with no controller is an editor — the
+    // phase-1 tests and any future preview use it that way); the
+    // controller imposes the locked operating posture at enable().
+    //
+    // Deliberately NOT gated here: setItemRect/restoreItems (lifecycle
+    // placement — reopen-restore, pan arrival, dock-return and the
+    // automation bridge are not operator edits), and the context-menu
+    // signal (the controller builds a mode-aware menu).
+    void setEditMode(bool on);
+    bool isEditMode() const { return m_editMode; }
     // Keyboard nudge step (px); Ctrl divides it for fine placement.
     static constexpr int kNudgePx = 8;
 
@@ -168,6 +185,10 @@ signals:
 
     // Selection, for the frame, the controller's context menu, and a11y.
     void selectionChanged(const QString& id);   // empty = cleared
+
+    // Edit mode flipped — the View-menu action and the context menu both
+    // drive it, so each keeps the other honest through this.
+    void editModeChanged(bool on);
 
     // A gesture began (undo snapshots hang off this) and committed.  A
     // cancelled gesture emits neither finish nor a rect change beyond the
@@ -252,6 +273,7 @@ private:
 
     // Active gesture.
     bool m_gridSnapEnabled{true};
+    bool m_editMode{true};
     QString  m_gestureId;
     HitZone  m_gestureZone{HitZone::None};
     NormRect m_gestureStart;

--- a/src/gui/workspace/WorkspaceCanvas.h
+++ b/src/gui/workspace/WorkspaceCanvas.h
@@ -120,15 +120,17 @@ public:
 
     // Snap capture distance (px on the live canvas).
     static constexpr int kSnapTolerancePx = 8;
-    // The snap grid, in NORMALIZED divisions — 32x18 keeps the cells roughly
-    // square at 16:9.  Normalized on purpose: a pixel grid would put an item
-    // on-grid at one window size and off-grid at every other, which is the
-    // exact failure the fractional model exists to prevent.  1 px dots mark
-    // the intersections: always in the canvas background, and on top of
+    // The snap grid, in NORMALIZED divisions — 16x9 makes the cells EXACTLY
+    // square at a 16:9 window (1920/16 == 1080/9 == 120 px) and meaningfully
+    // coarse: 32x18 read as scatter rather than structure in field testing.
+    // Normalized on purpose: a pixel grid would put an item on-grid at one
+    // window size and off-grid at every other, which is the exact failure
+    // the fractional model exists to prevent.  1 px dots mark the
+    // intersections: always in the canvas background, and on top of
     // everything while a gesture is live (the only time the targets matter
     // more than the content).
-    static constexpr int kSnapGridColumns = 32;
-    static constexpr int kSnapGridRows    = 18;
+    static constexpr int kSnapGridColumns = 16;
+    static constexpr int kSnapGridRows    = 9;
     // Keyboard nudge step (px); Ctrl divides it for fine placement.
     static constexpr int kNudgePx = 8;
 

--- a/src/gui/workspace/WorkspaceController.cpp
+++ b/src/gui/workspace/WorkspaceController.cpp
@@ -359,9 +359,10 @@ void WorkspaceController::onItemRectChanged(const QString& itemId, const NormRec
     if (m_applying || !m_enabled) {
         return;
     }
-    // Rect changes stream during a canvas resize, so this only touches; the
-    // debounce coalesces them (the store test pins that a resize storm is
-    // one write).  Discrete gestures flush at their own call sites.
+    // Only placement gestures reach here — a canvas resize emits nothing by
+    // design (stored rects are canvas-independent; the display clamp absorbs
+    // small windows).  Touch, don't flush: discrete gestures flush at their
+    // own call sites, and anything that streams coalesces in the debounce.
     writeItemRect(itemId, rect, /*flushNow=*/false);
 }
 

--- a/src/gui/workspace/WorkspaceController.cpp
+++ b/src/gui/workspace/WorkspaceController.cpp
@@ -445,7 +445,15 @@ bool WorkspaceController::sendPanToCanvas(const QString& panId)
     }
     const QString itemId = panItemIdFor(panId);
     if (m_canvas->contains(itemId)) {
-        return true;   // already placed — the state the caller asked for
+        QWidget* placed = m_canvas->itemWidget(itemId);
+        if (placed && placed->parentWidget() == m_canvas) {
+            return true;   // genuinely placed — the state the caller asked for
+        }
+        // The entry is a lie: the widget was reclaimed behind the canvas's
+        // back (a stack rebuild that predates the loan set, or any future
+        // path that forgets it).  Heal instead of trusting: drop the stale
+        // entry and fall through to a fresh detach-and-place.
+        m_canvas->releaseItem(itemId);
     }
 
     NormRect rect{0.2, 0.2, 0.6, 0.6};

--- a/src/gui/workspace/WorkspaceController.cpp
+++ b/src/gui/workspace/WorkspaceController.cpp
@@ -700,6 +700,12 @@ void WorkspaceController::onContextMenuRequested(const QString& itemId,
         menu.addSeparator();
     }
 
+    QAction* gridSnap = menu.addAction(QStringLiteral("Snap to grid"));
+    gridSnap->setCheckable(true);
+    gridSnap->setChecked(m_canvas->isGridSnapEnabled());
+    connect(gridSnap, &QAction::toggled, this,
+            [this](bool on) { m_canvas->setGridSnapEnabled(on); });
+
     QAction* undo = menu.addAction(QStringLiteral("Undo last placement"), this,
                                    [this] { undoLastPlacement(); });
     undo->setEnabled(canUndo());

--- a/src/gui/workspace/WorkspaceController.cpp
+++ b/src/gui/workspace/WorkspaceController.cpp
@@ -440,6 +440,16 @@ bool WorkspaceController::sendPanToCanvas(const QString& panId)
         }
         return false;
     }
+    // To the BACK, always.  addItem() places new items frontmost — right
+    // for applets, wrong for a pan: pans are the SURFACE the rest of the
+    // station sits on ("a meter over the spectrum is a feature").  Radio
+    // pans arrive seconds after enable-time placement (connect, band
+    // recall, dock), so without this every real-radio pan landed on top of
+    // the operator's arrangement and swallowed its clicks and wheel — the
+    // 8600 field report: only the pan and its VFO flag still responded.
+    // Boot-time placement honours stored z via restoreItems(); this keeps
+    // the late-arrival path consistent with it.
+    m_canvas->sendItemToBack(itemId);
     writeItemPresence(itemId, QStringLiteral("panadapter"),
                       m_canvas->itemRect(itemId), /*present=*/true,
                       /*flushNow=*/true);

--- a/src/gui/workspace/WorkspaceController.cpp
+++ b/src/gui/workspace/WorkspaceController.cpp
@@ -145,10 +145,13 @@ bool WorkspaceController::enable(const QStringList& knownAppletIds, QString* why
         // Remembered before the migration read so migrationPanSlotIds() can
         // consult the same legacy keys.
         m_knownAppletIds = knownAppletIds;
-        if (!m_store.loadOrMigrate(knownAppletIds, migrationPanSlotIds())) {
+        bool migrated = false;
+        if (!m_store.loadOrMigrate(knownAppletIds, migrationPanSlotIds(),
+                                   &migrated)) {
             if (whyNot) *whyNot = m_store.lastError();
             return false;
         }
+        m_justMigrated = migrated;
     }
 
     WorkspaceDocument doc = m_store.document();
@@ -181,6 +184,15 @@ bool WorkspaceController::enable(const QStringList& knownAppletIds, QString* why
     m_store.flush();
 
     m_enabled = true;
+
+    // The operating posture: enabled means USING the station, so the canvas
+    // comes up locked — except on the very first enable, which ran the
+    // migration: the operator just opted in precisely to arrange things,
+    // and greeting them with a locked surface would bury the feature they
+    // asked for behind a second menu trip.  Session-transient thereafter.
+    m_canvas->setEditMode(m_justMigrated);
+    m_justMigrated = false;
+
     emit enabledChanged(true);
     return true;
 }
@@ -1064,6 +1076,21 @@ void WorkspaceController::onContextMenuRequested(const QString& itemId,
     }
 
     QMenu menu;
+
+    // Edit Layout leads in BOTH postures — it is the door between them —
+    // and everything below it is placement, so a locked canvas shows only
+    // the door.
+    QAction* editToggle = menu.addAction(QStringLiteral("Edit layout"));
+    editToggle->setCheckable(true);
+    editToggle->setChecked(m_canvas->isEditMode());
+    connect(editToggle, &QAction::toggled, this,
+            [this](bool on) { m_canvas->setEditMode(on); });
+    if (!m_canvas->isEditMode()) {
+        menu.exec(globalPos);
+        return;
+    }
+    menu.addSeparator();
+
     const bool onApplet =
         !itemId.isEmpty() && itemId.startsWith(kAppletItemPrefix);
     const bool onPan = !itemId.isEmpty() && itemId.startsWith(kPanItemPrefix);

--- a/src/gui/workspace/WorkspaceController.cpp
+++ b/src/gui/workspace/WorkspaceController.cpp
@@ -24,7 +24,12 @@ const QByteArray kAppletMime = QByteArrayLiteral("application/x-aethersdr-applet
 
 }  // namespace
 
+namespace {
+const QString kPanItemPrefix = QStringLiteral("pan:");
+}
+
 const QString WorkspaceController::kPanStackItemId = QStringLiteral("panstack");
+const QString WorkspaceController::kBandStackItemId = QStringLiteral("bandstack");
 
 WorkspaceController::WorkspaceController(ContainerManager* manager,
                                          WorkspaceCanvas* canvas,
@@ -135,7 +140,10 @@ bool WorkspaceController::enable(const QStringList& knownAppletIds, QString* why
         // and it is deliberately here — behind the operator's explicit
         // opt-in — rather than at startup, so an install that never enables
         // the mode never gains the key.
-        if (!m_store.loadOrMigrate(knownAppletIds, /*panIds=*/{})) {
+        // Remembered before the migration read so migrationPanSlotIds() can
+        // consult the same legacy keys.
+        m_knownAppletIds = knownAppletIds;
+        if (!m_store.loadOrMigrate(knownAppletIds, migrationPanSlotIds())) {
             if (whyNot) *whyNot = m_store.lastError();
             return false;
         }
@@ -195,27 +203,71 @@ void WorkspaceController::placeActiveWorkspaceItems(WorkspaceDocument& doc,
     QList<CanvasItem> toPlace;
     QHash<QString, QWidget*> widgets;
 
-    // The reserved pan area first.  If the document has never seen one
-    // (first enable), it takes the region Classic left for it.
-    CanvasItem panItem;
-    const CanvasItem* stored = nullptr;
-    for (const CanvasItem& it : main->items) {
-        if (it.id == kPanStackItemId) stored = &it;
-    }
-    if (stored) {
-        panItem = *stored;
-    } else {
-        panItem.id          = kPanStackItemId;
-        panItem.contentType = QStringLiteral("panstack");
-        panItem.rect        = panStackRectFromDocument();
-        panItem.z           = -1;   // restoreItems sorts; keep it at the back
-        main->items.prepend(panItem);
+    // ── One-time split: the phase-3 reserved panstack item becomes per-pan
+    // slot items (#4887 phase 4).  Deterministic even with zero live pans:
+    // the slot count comes from the operator's own saved pan layout, and
+    // the cells are carved from the panstack rect they replace, so the
+    // arrangement the operator had is exactly what the slots reproduce.  A
+    // phase-3 build reading the result simply recreates a full-region
+    // panstack item and ignores the slots — downgrade-safe both ways.
+    for (int i = 0; i < main->items.size(); ++i) {
+        if (main->items.at(i).id != kPanStackItemId) continue;
+        const CanvasItem panstack = main->items.takeAt(i);
+        const LegacyLayoutState legacy =
+            readLegacyLayoutState(m_knownAppletIds);
+        QList<NormRect> cells = panCellsForLayout(legacy.panLayoutId);
+        if (cells.isEmpty()) {
+            cells = panCellsForLayout(QStringLiteral("1"));
+        }
+        int inserted = 0;
+        for (int c = 0; c < cells.size(); ++c) {
+            const QString slotId = kPanItemPrefix + QString::number(c);
+            bool exists = false;
+            for (const CanvasItem& it : main->items) {
+                if (it.id == slotId) { exists = true; break; }
+            }
+            if (exists) continue;
+            CanvasItem it;
+            it.id          = slotId;
+            it.contentType = QStringLiteral("panadapter");
+            it.rect.x = panstack.rect.x + cells.at(c).x * panstack.rect.w;
+            it.rect.y = panstack.rect.y + cells.at(c).y * panstack.rect.h;
+            it.rect.w = cells.at(c).w * panstack.rect.w;
+            it.rect.h = cells.at(c).h * panstack.rect.h;
+            it.z = panstack.z;
+            main->items.insert(i + inserted, it);
+            ++inserted;
+        }
         if (docChanged) *docChanged = true;
+        break;
     }
-    panItem.minimumSize = QSize(320, 240);
-    if (m_panStackWidget) {
-        toPlace.append(panItem);
-        widgets.insert(kPanStackItemId, m_panStackWidget.data());
+
+    // ── Pans, from their slot items ──────────────────────────────────────
+    const QStringList livePans =
+        m_panHost.panIds ? m_panHost.panIds() : QStringList{};
+    for (const QString& panId : livePans) {
+        if (m_panHost.isFloating && m_panHost.isFloating(panId)) {
+            continue;   // pop-out stays (RFC decision 1)
+        }
+        const QString itemId = panItemIdFor(panId);
+        CanvasItem item;
+        bool found = false;
+        for (const CanvasItem& it : main->items) {
+            if (it.id == itemId) { item = it; found = true; break; }
+        }
+        if (!found) {
+            item.id          = itemId;
+            item.contentType = QStringLiteral("panadapter");
+            item.rect        = NormRect{0.2, 0.2, 0.6, 0.6};
+            item.z           = 0;
+            main->items.append(item);
+            if (docChanged) *docChanged = true;
+        }
+        item.minimumSize = QSize(320, 180);
+        QWidget* w = m_panHost.detach ? m_panHost.detach(panId) : nullptr;
+        if (!w) continue;
+        toPlace.append(item);
+        widgets.insert(itemId, w);
     }
 
     for (const CanvasItem& item : main->items) {
@@ -247,8 +299,27 @@ void WorkspaceController::disable()
     m_applying = true;
     const QStringList ids = m_canvas->layout().ids();
     for (const QString& itemId : ids) {
+        if (itemId.startsWith(kPanItemPrefix)) {
+            // Back into the stack's splitter — release, never take: the
+            // restore hook reparents in ONE step (addWidget), and the
+            // nullptr detour is forbidden for QRhi children (#1344).
+            QWidget* w = m_canvas->releaseItem(itemId);
+            const QString panId = panIdForItem(itemId);
+            if (w && !panId.isEmpty() && m_panHost.restore) {
+                m_panHost.restore(panId, w);
+            }
+            continue;
+        }
+        if (itemId == kBandStackItemId) {
+            QWidget* w = m_canvas->releaseItem(itemId);
+            if (w && m_panHost.reclaimBandStack) {
+                m_panHost.reclaimBandStack(w);   // stays visible: it was
+            }
+            continue;
+        }
         if (itemId == kPanStackItemId) {
-            // Released parentless; MainWindow puts it back in the splitter.
+            // Phase-3 document robustness: released parentless; MainWindow
+            // puts it back in the splitter.
             m_canvas->takeItem(itemId);
             continue;
         }
@@ -270,9 +341,237 @@ void WorkspaceController::disable()
     emit enabledChanged(false);
 }
 
-void WorkspaceController::setPanStackWidget(QWidget* w)
+void WorkspaceController::setPanHost(const PanHostHooks& hooks)
 {
-    m_panStackWidget = w;
+    m_panHost = hooks;
+}
+
+// ── Pans as items (RFC #4887 phase 4) ────────────────────────────────────
+
+int WorkspaceController::slotForPan(const QString& panId)
+{
+    const auto it = m_panSlots.constFind(panId);
+    if (it != m_panSlots.constEnd()) {
+        return it.value();
+    }
+    // Lowest free, so remove-then-add reuses the slot — the same discipline
+    // as RadioModel::neutralPanIndexFor, for the same reason.
+    int slot = 0;
+    const QList<int> used = m_panSlots.values();
+    while (used.contains(slot)) {
+        ++slot;
+    }
+    m_panSlots.insert(panId, slot);
+    return slot;
+}
+
+QString WorkspaceController::panItemIdFor(const QString& panId)
+{
+    return kPanItemPrefix + QString::number(slotForPan(panId));
+}
+
+QString WorkspaceController::panIdForItem(const QString& itemId) const
+{
+    if (!itemId.startsWith(kPanItemPrefix)) {
+        return QString();
+    }
+    bool ok = false;
+    const int slot = itemId.mid(kPanItemPrefix.size()).toInt(&ok);
+    if (!ok) {
+        return QString();
+    }
+    for (auto it = m_panSlots.constBegin(); it != m_panSlots.constEnd(); ++it) {
+        if (it.value() == slot) {
+            return it.key();
+        }
+    }
+    return QString();
+}
+
+QStringList WorkspaceController::migrationPanSlotIds() const
+{
+    const int live = m_panHost.panIds
+                         ? static_cast<int>(m_panHost.panIds().size())
+                         : 0;
+    const LegacyLayoutState legacy = readLegacyLayoutState(m_knownAppletIds);
+    const int fromLayout = panCountForLayout(legacy.panLayoutId);
+    const int count = qMax(1, qMax(live, fromLayout));
+    QStringList ids;
+    for (int i = 0; i < count; ++i) {
+        ids.append(QString::number(i));
+    }
+    return ids;
+}
+
+bool WorkspaceController::sendPanToCanvas(const QString& panId)
+{
+    if (!m_enabled) {
+        return false;
+    }
+    if (m_panHost.isFloating && m_panHost.isFloating(panId)) {
+        return false;   // pop-out stays (RFC decision 1)
+    }
+    const QString itemId = panItemIdFor(panId);
+    if (m_canvas->contains(itemId)) {
+        return true;   // already placed — the state the caller asked for
+    }
+
+    NormRect rect{0.2, 0.2, 0.6, 0.6};
+    const WorkspaceDocument& doc = m_store.document();
+    if (const Workspace* ws = doc.workspace(doc.activeWorkspace)) {
+        if (const WorkspaceSurface* main = ws->surface(WorkspaceSurface::kMainId)) {
+            for (const CanvasItem& it : main->items) {
+                if (it.id == itemId) {
+                    rect = it.rect;
+                    break;
+                }
+            }
+        }
+    }
+
+    QWidget* w = m_panHost.detach ? m_panHost.detach(panId) : nullptr;
+    if (!w) {
+        return false;
+    }
+    if (!m_canvas->addItem(itemId, w, rect, QStringLiteral("panadapter"),
+                           QSize(320, 180))) {
+        if (m_panHost.restore) {
+            m_panHost.restore(panId, w);   // never strand a detached applet
+        }
+        return false;
+    }
+    writeItemPresence(itemId, QStringLiteral("panadapter"),
+                      m_canvas->itemRect(itemId), /*present=*/true,
+                      /*flushNow=*/true);
+    return true;
+}
+
+void WorkspaceController::onPanAdded(const QString& panId)
+{
+    if (!m_enabled) {
+        return;
+    }
+    sendPanToCanvas(panId);
+}
+
+void WorkspaceController::onPanRemoved(const QString& panId)
+{
+    // The stack emits this BEFORE destroying the applet, so releasing here
+    // (never reparenting — the widget is about to die) beats waiting for
+    // the destroyed-watch.  The document item is KEPT: a pan closing is not
+    // a statement about its spot, and the next pan in this slot takes it.
+    const auto it = m_panSlots.constFind(panId);
+    if (it != m_panSlots.constEnd()) {
+        m_canvas->releaseItem(kPanItemPrefix + QString::number(it.value()));
+        m_panSlots.erase(it);
+    }
+}
+
+void WorkspaceController::onPanRekeyed(const QString& oldId, const QString& newId)
+{
+    // Same applet, new radio id (FLEX band recall): the slot — and with it
+    // the canvas item — follows the applet.
+    const auto it = m_panSlots.constFind(oldId);
+    if (it != m_panSlots.constEnd()) {
+        const int slot = it.value();
+        m_panSlots.erase(it);
+        m_panSlots.insert(newId, slot);
+    }
+}
+
+void WorkspaceController::onPanFloated(const QString& panId)
+{
+    // The applet has already been adopted by its PanFloatingWindow — release
+    // the entry, never take it (#1344).  Slot and document item survive:
+    // a pan has no panel to be returned to, so its canvas home is where
+    // docking brings it back (unlike applets, floating forgets nothing).
+    const auto it = m_panSlots.constFind(panId);
+    if (it != m_panSlots.constEnd()) {
+        m_canvas->releaseItem(kPanItemPrefix + QString::number(it.value()));
+    }
+}
+
+void WorkspaceController::onPanDocked(const QString& panId)
+{
+    if (!m_enabled) {
+        return;
+    }
+    // dockPanadapter() has just re-homed the applet into the (hidden) stack
+    // splitter; bring it back to its canvas spot.
+    sendPanToCanvas(panId);
+}
+
+void WorkspaceController::beginPanItemMove(const QString& panId, const QPoint& globalPos)
+{
+    if (!m_enabled) {
+        return;
+    }
+    const QString itemId = panItemIdFor(panId);
+    if (m_canvas->contains(itemId)) {
+        m_canvas->beginMoveGesture(itemId, globalPos);
+    }
+}
+
+void WorkspaceController::movePanItem(const QPoint& globalPos)
+{
+    if (m_enabled) {
+        m_canvas->moveGesture(globalPos);
+    }
+}
+
+void WorkspaceController::endPanItemMove(const QPoint& globalPos)
+{
+    if (m_enabled) {
+        m_canvas->endGesture(globalPos);
+    }
+}
+
+void WorkspaceController::setBandStackVisible(bool on)
+{
+    if (!m_enabled || !m_panHost.bandStack) {
+        return;
+    }
+    QWidget* panel = m_panHost.bandStack();
+    if (!panel) {
+        return;
+    }
+
+    if (!on) {
+        if (m_canvas->contains(kBandStackItemId)) {
+            QWidget* w = m_canvas->releaseItem(kBandStackItemId);
+            if (w && m_panHost.reclaimBandStack) {
+                m_panHost.reclaimBandStack(w);
+            }
+            if (w) {
+                w->hide();
+            }
+        }
+        return;
+    }
+    if (m_canvas->contains(kBandStackItemId)) {
+        return;
+    }
+
+    // Its remembered spot, else a strip down the left edge.
+    NormRect rect{0.0, 0.0, 0.07, 1.0};
+    const WorkspaceDocument& doc = m_store.document();
+    if (const Workspace* ws = doc.workspace(doc.activeWorkspace)) {
+        if (const WorkspaceSurface* main = ws->surface(WorkspaceSurface::kMainId)) {
+            for (const CanvasItem& it : main->items) {
+                if (it.id == kBandStackItemId) {
+                    rect = it.rect;
+                    break;
+                }
+            }
+        }
+    }
+    if (m_canvas->addItem(kBandStackItemId, panel, rect,
+                          QStringLiteral("bandstack"), QSize(90, 240))) {
+        panel->show();
+        writeItemPresence(kBandStackItemId, QStringLiteral("bandstack"),
+                          m_canvas->itemRect(kBandStackItemId),
+                          /*present=*/true, /*flushNow=*/true);
+    }
 }
 
 // ── Applet movement ──────────────────────────────────────────────────────
@@ -496,9 +795,16 @@ void WorkspaceController::writeItemRect(const QString& itemId, const NormRect& r
             }
         }
     }
-    // No item — a rect change for something the document does not track
-    // (e.g. the pan stack before its first persist) is recorded by adding it.
-    if (itemId == kPanStackItemId) {
+    // No item — a rect change for something the document does not track is
+    // recorded by adding it (a pan placed before its slot item existed, the
+    // band stack, or a phase-3 panstack).
+    if (itemId.startsWith(kPanItemPrefix)) {
+        writeItemPresence(itemId, QStringLiteral("panadapter"), rect,
+                          /*present=*/true, flushNow);
+    } else if (itemId == kBandStackItemId) {
+        writeItemPresence(itemId, QStringLiteral("bandstack"), rect,
+                          /*present=*/true, flushNow);
+    } else if (itemId == kPanStackItemId) {
         writeItemPresence(itemId, QStringLiteral("panstack"), rect,
                           /*present=*/true, flushNow);
     }
@@ -592,10 +898,24 @@ void WorkspaceController::resetToClassic()
 
     m_applying = true;
 
-    // Everything off the surface: applets back to their panel slots, the
-    // pan stack held aside for the re-place below.
+    // Everything off the surface: applets back to their panel slots, pans
+    // merely RELEASED (they stay parented to the canvas; the re-place below
+    // re-adds them — no nullptr detour, #1344), the band stack re-homed and
+    // hidden (Classic is the stock shell, and the stock shell shows none).
     const QStringList ids = m_canvas->layout().ids();
     for (const QString& itemId : ids) {
+        if (itemId.startsWith(kPanItemPrefix)) {
+            m_canvas->releaseItem(itemId);
+            continue;
+        }
+        if (itemId == kBandStackItemId) {
+            QWidget* w = m_canvas->releaseItem(itemId);
+            if (w && m_panHost.reclaimBandStack) {
+                m_panHost.reclaimBandStack(w);
+            }
+            if (w) w->hide();
+            continue;
+        }
         if (itemId == kPanStackItemId) {
             m_canvas->takeItem(itemId);
             continue;
@@ -612,7 +932,8 @@ void WorkspaceController::resetToClassic()
     // One definition of Classic, used everywhere (WorkspaceMigration).
     WorkspaceDocument doc = m_store.document();
     const WorkspaceDocument classic =
-        buildClassicDocument(readLegacyLayoutState(m_knownAppletIds), {});
+        buildClassicDocument(readLegacyLayoutState(m_knownAppletIds),
+                             migrationPanSlotIds());
     if (const Workspace* freshWs = classic.workspace(classicWorkspaceId())) {
         if (const WorkspaceSurface* freshMain =
                 freshWs->surface(WorkspaceSurface::kMainId)) {
@@ -642,11 +963,17 @@ void WorkspaceController::tidyLayout()
     }
 
     QList<CanvasItem> items;
+    QStringList fixedIds{kPanStackItemId};
     for (const CanvasItem& it : m_canvas->layout().itemsByZ()) {
         items.append(it);
+        // Every pan item is fixed: an applet overlapping the spectrum is a
+        // feature (the phase-5 rule), and tidy shoving the spectrum itself
+        // around would be the disorder it exists to fix.
+        if (it.id.startsWith(kPanItemPrefix)) {
+            fixedIds.append(it.id);
+        }
     }
-    const QList<TidyMove> moves =
-        tidyOverlaps(items, QStringList{kPanStackItemId});
+    const QList<TidyMove> moves = tidyOverlaps(items, fixedIds);
 
     for (const TidyMove& mv : moves) {
         m_canvas->setItemRect(mv.id, mv.rect);   // rect stream → touch
@@ -660,8 +987,9 @@ void WorkspaceController::tidyLayout()
 void WorkspaceController::onItemDraggedOut(const QString& itemId,
                                            const QPoint& globalPos)
 {
-    if (m_applying || !m_enabled || itemId == kPanStackItemId) {
-        return;
+    if (m_applying || !m_enabled || itemId == kPanStackItemId
+        || itemId == kBandStackItemId || itemId.startsWith(kPanItemPrefix)) {
+        return;   // only applets have a panel to land on
     }
     // Only a release over the return target means anything; the canvas has
     // already restored the item's rect, so anything else is a completed
@@ -688,6 +1016,29 @@ void WorkspaceController::onContextMenuRequested(const QString& itemId,
     QMenu menu;
     const bool onApplet =
         !itemId.isEmpty() && itemId.startsWith(kAppletItemPrefix);
+    const bool onPan = !itemId.isEmpty() && itemId.startsWith(kPanItemPrefix);
+
+    if (onPan) {
+        const QString panId = panIdForItem(itemId);
+        QAction* popOut = menu.addAction(QStringLiteral("Pop out"), this,
+                                         [this, panId] {
+                                             if (m_panHost.requestFloat) {
+                                                 m_panHost.requestFloat(panId);
+                                             }
+                                         });
+        popOut->setEnabled(!panId.isEmpty()
+                           && static_cast<bool>(m_panHost.requestFloat));
+        menu.addAction(QStringLiteral("Bring to front"), this,
+                       [this, itemId] { m_canvas->bringItemToFront(itemId); });
+        menu.addAction(QStringLiteral("Send to back"), this,
+                       [this, itemId] { m_canvas->sendItemToBack(itemId); });
+        menu.addSeparator();
+    }
+    if (itemId == kBandStackItemId) {
+        menu.addAction(QStringLiteral("Hide band stack"), this,
+                       [this] { setBandStackVisible(false); });
+        menu.addSeparator();
+    }
 
     if (onApplet) {
         const QString appletId = itemId.mid(kAppletItemPrefix.size());
@@ -745,31 +1096,5 @@ NormRect WorkspaceController::defaultRectFor(const ContainerWidget* c,
     return r;
 }
 
-NormRect WorkspaceController::panStackRectFromDocument() const
-{
-    // First enable: the pan area takes whatever Classic left for it — the
-    // complement of the applet column, on whichever side the applets are.
-    const WorkspaceDocument& doc = m_store.document();
-    const Workspace* ws = doc.workspace(doc.activeWorkspace);
-    const WorkspaceSurface* main = ws ? ws->surface(WorkspaceSurface::kMainId) : nullptr;
-
-    bool haveApplets = false;
-    double minX = 1.0;
-    if (main) {
-        for (const CanvasItem& it : main->items) {
-            if (it.id.startsWith(kAppletItemPrefix)) {
-                haveApplets = true;
-                minX = qMin(minX, it.rect.x);
-            }
-        }
-    }
-
-    NormRect r{0.0, 0.0, 1.0, 1.0};
-    if (haveApplets) {
-        r.w = 1.0 - kClassicAppletColumnWidth;
-        r.x = (minX < 0.5) ? kClassicAppletColumnWidth : 0.0;   // column left → pans right
-    }
-    return r;
-}
 
 }  // namespace AetherSDR

--- a/src/gui/workspace/WorkspaceController.cpp
+++ b/src/gui/workspace/WorkspaceController.cpp
@@ -1,0 +1,561 @@
+#include "gui/workspace/WorkspaceController.h"
+
+#include "gui/containers/ContainerManager.h"
+#include "gui/containers/ContainerWidget.h"
+#include "gui/workspace/ClassicLayout.h"
+#include "gui/workspace/WorkspaceCanvas.h"
+
+#include <QHash>
+
+namespace AetherSDR {
+
+namespace {
+
+const QString kAppletItemPrefix = QStringLiteral("applet:");
+
+// The MIME type the panel's title-bar drags already carry (#3057); the
+// canvas accepts the same one so place/move/return are all one mechanism.
+const QByteArray kAppletMime = QByteArrayLiteral("application/x-aethersdr-applet");
+
+}  // namespace
+
+const QString WorkspaceController::kPanStackItemId = QStringLiteral("panstack");
+
+WorkspaceController::WorkspaceController(ContainerManager* manager,
+                                         WorkspaceCanvas* canvas,
+                                         QObject* parent)
+    : QObject(parent)
+    , m_manager(manager)
+    , m_canvas(canvas)
+{
+    Q_ASSERT(m_manager);
+    Q_ASSERT(m_canvas);
+
+    m_canvas->setDropMimeType(kAppletMime);
+
+    connect(m_canvas, &WorkspaceCanvas::dropReceived,
+            this, &WorkspaceController::onDropReceived);
+    connect(m_canvas, &WorkspaceCanvas::itemRectChanged,
+            this, &WorkspaceController::onItemRectChanged);
+    connect(m_canvas, &WorkspaceCanvas::itemStackingChanged,
+            this, [this](const QString&) {
+                if (m_applying || !m_enabled) return;
+                writeStackingFromCanvas();
+            });
+
+    // Leaving the canvas through the manager — the title-bar "return to
+    // panel" button, or the detour a float takes — always forgets the
+    // canvas home: the operator asked to not be on the canvas.
+    m_manager->setCanvasEvictor([this](const QString& containerId) {
+        ContainerWidget* c = m_manager->container(containerId);
+        if (c && c->isOnCanvas()) {
+            evictFromCanvas(c, /*forgetHome=*/true);
+        }
+    });
+
+    connect(m_manager, &ContainerManager::containerCreated,
+            this, &WorkspaceController::onContainerCreated);
+    for (ContainerWidget* c : m_manager->allContainers()) {
+        wireContainer(c);
+    }
+}
+
+// ── Identity plumbing ────────────────────────────────────────────────────
+//
+// Three names per applet, and the distinction matters exactly once (#1836):
+// the panel entry id and the drag payload are the dragId ("TXDSP"), while
+// the container's own id may differ ("tx_dsp").  Document items use the
+// dragId, because that is the name the migration read out of Applet_<ID>.
+
+ContainerWidget* WorkspaceController::containerForApplet(const QString& appletId) const
+{
+    if (ContainerWidget* direct = m_manager->container(appletId)) {
+        return direct;
+    }
+    for (ContainerWidget* c : m_manager->allContainers()) {
+        if (c && c->dragId() == appletId) {
+            return c;
+        }
+    }
+    return nullptr;
+}
+
+QString WorkspaceController::appletIdFor(const ContainerWidget* c) const
+{
+    return c ? c->dragId() : QString();
+}
+
+QString WorkspaceController::itemIdFor(const ContainerWidget* c) const
+{
+    return kAppletItemPrefix + appletIdFor(c);
+}
+
+// ── Lifecycle ────────────────────────────────────────────────────────────
+
+bool WorkspaceController::boot()
+{
+    if (m_store.loadWithStatus() != WorkspaceStore::LoadResult::Loaded) {
+        return false;
+    }
+    return m_store.document().canvasEnabled;
+}
+
+bool WorkspaceController::enable(const QStringList& knownAppletIds, QString* whyNot)
+{
+    if (m_enabled) {
+        return true;
+    }
+
+    if (!m_store.isLoaded()) {
+        // First enable on this install: migrate the legacy layout keys into
+        // Classic.  This is the moment RFC #4887's dual-write period starts,
+        // and it is deliberately here — behind the operator's explicit
+        // opt-in — rather than at startup, so an install that never enables
+        // the mode never gains the key.
+        if (!m_store.loadOrMigrate(knownAppletIds, /*panIds=*/{})) {
+            if (whyNot) *whyNot = m_store.lastError();
+            return false;
+        }
+    }
+
+    WorkspaceDocument doc = m_store.document();
+    const Workspace* ws = doc.workspace(doc.activeWorkspace);
+    if (!ws) {
+        if (whyNot) *whyNot = QStringLiteral("no active workspace");
+        return false;
+    }
+    const WorkspaceSurface* main = ws->surface(WorkspaceSurface::kMainId);
+    if (!main) {
+        if (whyNot) *whyNot = QStringLiteral("no main surface");
+        return false;
+    }
+
+    // Assemble the placement list from the document.  The replay itself is
+    // guarded: the canvas signals it fires describe what the document
+    // already says.
+    m_applying = true;
+
+    QList<CanvasItem> toPlace;
+    QHash<QString, QWidget*> widgets;
+    bool docChanged = false;
+
+    // The reserved pan area first.  If the document has never seen one
+    // (first enable), it takes the region Classic left for it.
+    CanvasItem panItem;
+    if (const CanvasItem* stored = [&]() -> const CanvasItem* {
+            for (const CanvasItem& it : main->items) {
+                if (it.id == kPanStackItemId) return &it;
+            }
+            return nullptr;
+        }()) {
+        panItem = *stored;
+    } else {
+        panItem.id          = kPanStackItemId;
+        panItem.contentType = QStringLiteral("panstack");
+        panItem.rect        = panStackRectFromDocument();
+        panItem.z           = -1;   // restoreItems sorts; keep it at the back
+        docChanged          = true;
+    }
+    panItem.minimumSize = QSize(320, 240);
+    if (m_panStackWidget) {
+        toPlace.append(panItem);
+        widgets.insert(kPanStackItemId, m_panStackWidget.data());
+    }
+
+    for (const CanvasItem& item : main->items) {
+        if (!item.id.startsWith(kAppletItemPrefix)) {
+            continue;
+        }
+        ContainerWidget* c = containerForApplet(item.id.mid(kAppletItemPrefix.size()));
+        // Closed applets keep their home but are not placed; floating ones
+        // stay out (pop-out stays, RFC decision 1) until they dock.
+        if (!c || !c->isContainerVisible() || c->isFloating()) {
+            continue;
+        }
+        if (m_manager->detachForCanvas(c->id()) != c) {
+            continue;
+        }
+        toPlace.append(item);
+        widgets.insert(item.id, c);
+    }
+
+    m_canvas->restoreItems(toPlace, widgets);
+    m_applying = false;
+
+    doc.canvasEnabled = true;
+    if (docChanged) {
+        Workspace* wsMut = nullptr;
+        for (Workspace& w : doc.workspaces) {
+            if (w.id == doc.activeWorkspace) wsMut = &w;
+        }
+        if (wsMut) {
+            for (WorkspaceSurface& s : wsMut->surfaces) {
+                if (s.id == WorkspaceSurface::kMainId) {
+                    s.items.prepend(panItem);
+                }
+            }
+        }
+    }
+    m_store.setDocument(doc);
+    m_store.flush();
+
+    m_enabled = true;
+    emit enabledChanged(true);
+    return true;
+}
+
+void WorkspaceController::disable()
+{
+    if (!m_enabled) {
+        return;
+    }
+
+    m_applying = true;
+    const QStringList ids = m_canvas->layout().ids();
+    for (const QString& itemId : ids) {
+        if (itemId == kPanStackItemId) {
+            // Released parentless; MainWindow puts it back in the splitter.
+            m_canvas->takeItem(itemId);
+            continue;
+        }
+        QWidget* w = m_canvas->takeItem(itemId);
+        if (auto* c = qobject_cast<ContainerWidget*>(w)) {
+            m_manager->returnFromCanvas(c->id(), c);
+        }
+    }
+    m_applying = false;
+
+    // Placement is kept — switching the mode off is not a statement about
+    // any applet — only the flag changes.
+    WorkspaceDocument doc = m_store.document();
+    doc.canvasEnabled = false;
+    m_store.setDocument(doc);
+    m_store.flush();
+
+    m_enabled = false;
+    emit enabledChanged(false);
+}
+
+void WorkspaceController::setPanStackWidget(QWidget* w)
+{
+    m_panStackWidget = w;
+}
+
+// ── Applet movement ──────────────────────────────────────────────────────
+
+bool WorkspaceController::sendAppletToCanvas(const QString& appletId,
+                                             const NormRect* where)
+{
+    if (!m_enabled) {
+        return false;
+    }
+    ContainerWidget* c = containerForApplet(appletId);
+    if (!c || c->isOnCanvas()) {
+        return false;
+    }
+
+    const QString itemId = itemIdFor(c);
+
+    // Placement priority: the caller's rect (a drop point), else the
+    // document's remembered home, else a default sized from the widget.
+    NormRect rect;
+    if (where) {
+        rect = *where;
+    } else {
+        bool haveStored = false;
+        const WorkspaceDocument& doc = m_store.document();
+        if (const Workspace* ws = doc.workspace(doc.activeWorkspace)) {
+            if (const WorkspaceSurface* main = ws->surface(WorkspaceSurface::kMainId)) {
+                for (const CanvasItem& it : main->items) {
+                    if (it.id == itemId) {
+                        rect       = it.rect;
+                        haveStored = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if (!haveStored) {
+            rect = defaultRectFor(c, nullptr);
+        }
+    }
+
+    if (m_manager->detachForCanvas(c->id()) != c) {
+        return false;
+    }
+    if (!m_canvas->addItem(itemId, c, rect, QStringLiteral("applet"))) {
+        // Should not happen (id collisions are checked above), but never
+        // strand a detached widget: put it straight back.
+        m_manager->returnFromCanvas(c->id(), c);
+        return false;
+    }
+
+    // The canvas clamped the rect; persist what is actually on screen.
+    writeItemPresence(itemId, QStringLiteral("applet"),
+                      m_canvas->itemRect(itemId), /*present=*/true,
+                      /*flushNow=*/true);
+    return true;
+}
+
+bool WorkspaceController::returnAppletToPanel(const QString& appletId)
+{
+    ContainerWidget* c = containerForApplet(appletId);
+    if (!c || !c->isOnCanvas()) {
+        return false;
+    }
+    evictFromCanvas(c, /*forgetHome=*/true);
+    return true;
+}
+
+void WorkspaceController::evictFromCanvas(ContainerWidget* c, bool forgetHome)
+{
+    const QString itemId = itemIdFor(c);
+
+    // Forget the home BEFORE the reparent: returnFromCanvas() flips the dock
+    // mode to PanelDocked, and the dockModeChanged hook re-sends any open
+    // applet whose item still exists — removing it first is what makes an
+    // explicit return stick instead of bouncing straight back.
+    if (forgetHome) {
+        writeItemPresence(itemId, QStringLiteral("applet"), NormRect{},
+                          /*present=*/false, /*flushNow=*/true);
+    }
+
+    m_canvas->takeItem(itemId);
+    m_manager->returnFromCanvas(c->id(), c);
+}
+
+// ── Canvas events ────────────────────────────────────────────────────────
+
+void WorkspaceController::onDropReceived(const QString& payload, const QPointF& pos)
+{
+    if (!m_enabled) {
+        return;
+    }
+    ContainerWidget* c = containerForApplet(payload);
+    if (!c) {
+        return;
+    }
+
+    if (c->isOnCanvas()) {
+        // Move: keep the size, centre the item on the drop point, and let
+        // the canvas clamp.  itemRectChanged writes the document; this is a
+        // discrete gesture, so flush behind it.
+        const QString itemId = itemIdFor(c);
+        const NormRect cur   = m_canvas->itemRect(itemId);
+        NormRect moved       = cur;
+        moved.x              = pos.x() - cur.w / 2.0;
+        moved.y              = pos.y() - cur.h / 2.0;
+        m_canvas->setItemRect(itemId, moved);
+        m_store.flush();
+        return;
+    }
+
+    NormRect rect = defaultRectFor(c, &pos);
+    sendAppletToCanvas(appletIdFor(c), &rect);
+}
+
+void WorkspaceController::onItemRectChanged(const QString& itemId, const NormRect& rect)
+{
+    if (m_applying || !m_enabled) {
+        return;
+    }
+    // Rect changes stream during a canvas resize, so this only touches; the
+    // debounce coalesces them (the store test pins that a resize storm is
+    // one write).  Discrete gestures flush at their own call sites.
+    writeItemRect(itemId, rect, /*flushNow=*/false);
+}
+
+void WorkspaceController::onContainerCreated(const QString& containerId)
+{
+    if (ContainerWidget* c = m_manager->container(containerId)) {
+        wireContainer(c);
+    }
+}
+
+void WorkspaceController::wireContainer(ContainerWidget* c)
+{
+    // Open/close from the bar buttons.  Closing an applet that lives on the
+    // canvas evicts it but keeps its home; reopening returns it there.
+    connect(c, &ContainerWidget::visibilityChanged, this, [this, c](bool visible) {
+        if (m_applying || !m_enabled) return;
+        if (!visible && c->isOnCanvas()) {
+            evictFromCanvas(c, /*forgetHome=*/false);
+        } else if (visible && !c->isOnCanvas() && !c->isFloating()) {
+            const WorkspaceDocument& doc = m_store.document();
+            if (const Workspace* ws = doc.workspace(doc.activeWorkspace)) {
+                if (const WorkspaceSurface* main =
+                        ws->surface(WorkspaceSurface::kMainId)) {
+                    for (const CanvasItem& it : main->items) {
+                        if (it.id == itemIdFor(c)) {
+                            sendAppletToCanvas(appletIdFor(c));
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    // A float that started from the canvas forgot its home on the way out
+    // (the evictor).  The one dock that must RETURN to the canvas is the
+    // applet whose item survived — floated while the mode was off, docked
+    // while it is on.
+    connect(c, &ContainerWidget::dockModeChanged, this,
+            [this, c](ContainerWidget::DockMode mode) {
+                if (m_applying || !m_enabled) return;
+                if (mode != ContainerWidget::DockMode::PanelDocked) return;
+                if (!c->isContainerVisible()) return;
+                const WorkspaceDocument& doc = m_store.document();
+                if (const Workspace* ws = doc.workspace(doc.activeWorkspace)) {
+                    if (const WorkspaceSurface* main =
+                            ws->surface(WorkspaceSurface::kMainId)) {
+                        for (const CanvasItem& it : main->items) {
+                            if (it.id == itemIdFor(c)) {
+                                sendAppletToCanvas(appletIdFor(c));
+                                break;
+                            }
+                        }
+                    }
+                }
+            });
+}
+
+// ── Document edits ───────────────────────────────────────────────────────
+
+void WorkspaceController::writeItemRect(const QString& itemId, const NormRect& rect,
+                                        bool flushNow)
+{
+    WorkspaceDocument doc = m_store.document();
+    for (Workspace& ws : doc.workspaces) {
+        if (ws.id != doc.activeWorkspace) continue;
+        for (WorkspaceSurface& s : ws.surfaces) {
+            if (s.id != WorkspaceSurface::kMainId) continue;
+            for (CanvasItem& it : s.items) {
+                if (it.id == itemId) {
+                    it.rect = rect;
+                    m_store.setDocument(doc);
+                    if (flushNow) m_store.flush();
+                    return;
+                }
+            }
+        }
+    }
+    // No item — a rect change for something the document does not track
+    // (e.g. the pan stack before its first persist) is recorded by adding it.
+    if (itemId == kPanStackItemId) {
+        writeItemPresence(itemId, QStringLiteral("panstack"), rect,
+                          /*present=*/true, flushNow);
+    }
+}
+
+void WorkspaceController::writeItemPresence(const QString& itemId,
+                                            const QString& contentType,
+                                            const NormRect& rect, bool present,
+                                            bool flushNow)
+{
+    WorkspaceDocument doc = m_store.document();
+    for (Workspace& ws : doc.workspaces) {
+        if (ws.id != doc.activeWorkspace) continue;
+        for (WorkspaceSurface& s : ws.surfaces) {
+            if (s.id != WorkspaceSurface::kMainId) continue;
+
+            int found = -1;
+            for (int i = 0; i < s.items.size(); ++i) {
+                if (s.items.at(i).id == itemId) { found = i; break; }
+            }
+
+            if (present) {
+                if (found >= 0) {
+                    s.items[found].rect = rect;
+                } else {
+                    CanvasItem item;
+                    item.id          = itemId;
+                    item.contentType = contentType;
+                    item.rect        = rect;
+                    item.z           = m_canvas->layout().zOf(itemId);
+                    s.items.append(item);
+                }
+            } else if (found >= 0) {
+                s.items.removeAt(found);
+            }
+
+            m_store.setDocument(doc);
+            if (flushNow) m_store.flush();
+            return;
+        }
+    }
+}
+
+void WorkspaceController::writeStackingFromCanvas()
+{
+    WorkspaceDocument doc = m_store.document();
+    for (Workspace& ws : doc.workspaces) {
+        if (ws.id != doc.activeWorkspace) continue;
+        for (WorkspaceSurface& s : ws.surfaces) {
+            if (s.id != WorkspaceSurface::kMainId) continue;
+            for (CanvasItem& it : s.items) {
+                const int z = m_canvas->layout().zOf(it.id);
+                if (z >= 0) it.z = z;
+            }
+        }
+    }
+    m_store.setDocument(doc);
+    m_store.flush();
+}
+
+// ── Geometry helpers ─────────────────────────────────────────────────────
+
+NormRect WorkspaceController::defaultRectFor(const ContainerWidget* c,
+                                             const QPointF* center) const
+{
+    // Size from the widget's own hint, normalized against the canvas — so a
+    // dropped applet arrives at roughly its panel size instead of a house
+    // number.  The canvas clamps against its minimum floor either way.
+    const QSize canvasSize = m_canvas->size();
+    const QSize hint = c ? c->sizeHint() : QSize();
+
+    NormRect r;
+    r.w = (canvasSize.width() > 0 && hint.width() > 0)
+              ? qMin(0.9, hint.width() / double(canvasSize.width()))
+              : 0.2;
+    r.h = (canvasSize.height() > 0 && hint.height() > 0)
+              ? qMin(0.9, hint.height() / double(canvasSize.height()))
+              : 0.3;
+    if (center) {
+        r.x = center->x() - r.w / 2.0;
+        r.y = center->y() - r.h / 2.0;
+    } else {
+        r.x = 1.0 - r.w;   // default lands where the panel column was
+        r.y = 0.0;
+    }
+    return r;
+}
+
+NormRect WorkspaceController::panStackRectFromDocument() const
+{
+    // First enable: the pan area takes whatever Classic left for it — the
+    // complement of the applet column, on whichever side the applets are.
+    const WorkspaceDocument& doc = m_store.document();
+    const Workspace* ws = doc.workspace(doc.activeWorkspace);
+    const WorkspaceSurface* main = ws ? ws->surface(WorkspaceSurface::kMainId) : nullptr;
+
+    bool haveApplets = false;
+    double minX = 1.0;
+    if (main) {
+        for (const CanvasItem& it : main->items) {
+            if (it.id.startsWith(kAppletItemPrefix)) {
+                haveApplets = true;
+                minX = qMin(minX, it.rect.x);
+            }
+        }
+    }
+
+    NormRect r{0.0, 0.0, 1.0, 1.0};
+    if (haveApplets) {
+        r.w = 1.0 - kClassicAppletColumnWidth;
+        r.x = (minX < 0.5) ? kClassicAppletColumnWidth : 0.0;   // column left → pans right
+    }
+    return r;
+}
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/WorkspaceController.cpp
+++ b/src/gui/workspace/WorkspaceController.cpp
@@ -2,10 +2,15 @@
 
 #include "gui/containers/ContainerManager.h"
 #include "gui/containers/ContainerWidget.h"
+#include "gui/workspace/CanvasInteraction.h"
 #include "gui/workspace/ClassicLayout.h"
+#include "gui/workspace/WorkspaceMigration.h"
 #include "gui/workspace/WorkspaceCanvas.h"
 
 #include <QHash>
+#include <QMenu>
+#include <QPoint>
+#include <QWidget>
 
 namespace AetherSDR {
 
@@ -42,6 +47,24 @@ WorkspaceController::WorkspaceController(ContainerManager* manager,
                 if (m_applying || !m_enabled) return;
                 writeStackingFromCanvas();
             });
+
+    // Gestures (phase 5): snapshot for undo at the start, flush the debounced
+    // rect stream at the end — the auto-commit gesture boundary.
+    connect(m_canvas, &WorkspaceCanvas::gestureStarted,
+            this, [this](const QString& itemId, const NormRect& startRect) {
+                if (m_applying || !m_enabled) return;
+                m_undoItemId = itemId;
+                m_undoRect   = startRect;
+            });
+    connect(m_canvas, &WorkspaceCanvas::gestureFinished,
+            this, [this](const QString&) {
+                if (m_applying || !m_enabled) return;
+                m_store.flush();
+            });
+    connect(m_canvas, &WorkspaceCanvas::itemDraggedOut,
+            this, &WorkspaceController::onItemDraggedOut);
+    connect(m_canvas, &WorkspaceCanvas::contextMenuRequested,
+            this, &WorkspaceController::onContextMenuRequested);
 
     // Leaving the canvas through the manager — the title-bar "return to
     // panel" button, or the detour a float takes — always forgets the
@@ -130,31 +153,64 @@ bool WorkspaceController::enable(const QStringList& knownAppletIds, QString* why
         return false;
     }
 
-    // Assemble the placement list from the document.  The replay itself is
-    // guarded: the canvas signals it fires describe what the document
-    // already says.
+    Q_UNUSED(main);
+
+    // Remembered for resetToClassic(), which re-derives Classic from the
+    // same legacy keys the first enable migrated from.
+    m_knownAppletIds = knownAppletIds;
+
+    // The replay itself is guarded: the canvas signals it fires describe
+    // what the document already says.
     m_applying = true;
+    bool docChanged = false;
+    placeActiveWorkspaceItems(doc, &docChanged);
+    m_applying = false;
+
+    doc.canvasEnabled = true;
+    m_store.setDocument(doc);
+    m_store.flush();
+
+    m_enabled = true;
+    emit enabledChanged(true);
+    return true;
+}
+
+void WorkspaceController::placeActiveWorkspaceItems(WorkspaceDocument& doc,
+                                                    bool* docChanged)
+{
+    Workspace* ws = nullptr;
+    for (Workspace& w : doc.workspaces) {
+        if (w.id == doc.activeWorkspace) ws = &w;
+    }
+    WorkspaceSurface* main = nullptr;
+    if (ws) {
+        for (WorkspaceSurface& surf : ws->surfaces) {
+            if (surf.id == WorkspaceSurface::kMainId) main = &surf;
+        }
+    }
+    if (!main) {
+        return;
+    }
 
     QList<CanvasItem> toPlace;
     QHash<QString, QWidget*> widgets;
-    bool docChanged = false;
 
     // The reserved pan area first.  If the document has never seen one
     // (first enable), it takes the region Classic left for it.
     CanvasItem panItem;
-    if (const CanvasItem* stored = [&]() -> const CanvasItem* {
-            for (const CanvasItem& it : main->items) {
-                if (it.id == kPanStackItemId) return &it;
-            }
-            return nullptr;
-        }()) {
+    const CanvasItem* stored = nullptr;
+    for (const CanvasItem& it : main->items) {
+        if (it.id == kPanStackItemId) stored = &it;
+    }
+    if (stored) {
         panItem = *stored;
     } else {
         panItem.id          = kPanStackItemId;
         panItem.contentType = QStringLiteral("panstack");
         panItem.rect        = panStackRectFromDocument();
         panItem.z           = -1;   // restoreItems sorts; keep it at the back
-        docChanged          = true;
+        main->items.prepend(panItem);
+        if (docChanged) *docChanged = true;
     }
     panItem.minimumSize = QSize(320, 240);
     if (m_panStackWidget) {
@@ -180,28 +236,6 @@ bool WorkspaceController::enable(const QStringList& knownAppletIds, QString* why
     }
 
     m_canvas->restoreItems(toPlace, widgets);
-    m_applying = false;
-
-    doc.canvasEnabled = true;
-    if (docChanged) {
-        Workspace* wsMut = nullptr;
-        for (Workspace& w : doc.workspaces) {
-            if (w.id == doc.activeWorkspace) wsMut = &w;
-        }
-        if (wsMut) {
-            for (WorkspaceSurface& s : wsMut->surfaces) {
-                if (s.id == WorkspaceSurface::kMainId) {
-                    s.items.prepend(panItem);
-                }
-            }
-        }
-    }
-    m_store.setDocument(doc);
-    m_store.flush();
-
-    m_enabled = true;
-    emit enabledChanged(true);
-    return true;
 }
 
 void WorkspaceController::disable()
@@ -375,6 +409,27 @@ void WorkspaceController::onContainerCreated(const QString& containerId)
 
 void WorkspaceController::wireContainer(ContainerWidget* c)
 {
+    // Live move (phase 5): the title bar streams the gesture; the canvas
+    // session makes the item follow the cursor with snapping.
+    connect(c, &ContainerWidget::canvasDragBegan, this,
+            [this, c](const QPoint& g) {
+                if (m_enabled && c->isOnCanvas()) {
+                    m_canvas->beginMoveGesture(itemIdFor(c), g);
+                }
+            });
+    connect(c, &ContainerWidget::canvasDragMoved, this,
+            [this, c](const QPoint& g) {
+                if (m_enabled && c->isOnCanvas()) {
+                    m_canvas->moveGesture(g);
+                }
+            });
+    connect(c, &ContainerWidget::canvasDragEnded, this,
+            [this, c](const QPoint& g) {
+                if (m_enabled && c->isOnCanvas()) {
+                    m_canvas->endGesture(g);
+                }
+            });
+
     // Open/close from the bar buttons.  Closing an applet that lives on the
     // canvas evicts it but keeps its home; reopening returns it there.
     connect(c, &ContainerWidget::visibilityChanged, this, [this, c](bool visible) {
@@ -502,6 +557,158 @@ void WorkspaceController::writeStackingFromCanvas()
     }
     m_store.setDocument(doc);
     m_store.flush();
+}
+
+// ── Escape hatches (phase 5) ─────────────────────────────────────────────
+
+void WorkspaceController::setReturnTarget(QWidget* target)
+{
+    m_returnTarget = target;
+}
+
+bool WorkspaceController::undoLastPlacement()
+{
+    if (!m_enabled || !canUndo()) {
+        return false;
+    }
+    if (!m_canvas->layout().contains(m_undoItemId)) {
+        m_undoItemId.clear();
+        return false;
+    }
+    // Swap current and remembered: undoing twice toggles, which is the
+    // single-slot version of redo.
+    const NormRect current = m_canvas->itemRect(m_undoItemId);
+    m_canvas->setItemRect(m_undoItemId, m_undoRect);
+    m_undoRect = current;
+    m_store.flush();
+    return true;
+}
+
+void WorkspaceController::resetToClassic()
+{
+    if (!m_enabled) {
+        return;
+    }
+
+    m_applying = true;
+
+    // Everything off the surface: applets back to their panel slots, the
+    // pan stack held aside for the re-place below.
+    const QStringList ids = m_canvas->layout().ids();
+    for (const QString& itemId : ids) {
+        if (itemId == kPanStackItemId) {
+            m_canvas->takeItem(itemId);
+            continue;
+        }
+        QWidget* w = m_canvas->takeItem(itemId);
+        if (auto* c = qobject_cast<ContainerWidget*>(w)) {
+            m_manager->returnFromCanvas(c->id(), c);
+        }
+    }
+
+    // Classic is re-derived from the same legacy keys the first enable
+    // migrated from — the panel still dual-writes them, so this reflects
+    // the operator's CURRENT open applets and order, not a stale snapshot.
+    // One definition of Classic, used everywhere (WorkspaceMigration).
+    WorkspaceDocument doc = m_store.document();
+    const WorkspaceDocument classic =
+        buildClassicDocument(readLegacyLayoutState(m_knownAppletIds), {});
+    if (const Workspace* freshWs = classic.workspace(classicWorkspaceId())) {
+        if (const WorkspaceSurface* freshMain =
+                freshWs->surface(WorkspaceSurface::kMainId)) {
+            for (Workspace& w : doc.workspaces) {
+                if (w.id != doc.activeWorkspace) continue;
+                for (WorkspaceSurface& surf : w.surfaces) {
+                    if (surf.id == WorkspaceSurface::kMainId) {
+                        surf.items = freshMain->items;
+                    }
+                }
+            }
+        }
+    }
+
+    placeActiveWorkspaceItems(doc, nullptr);
+    m_applying = false;
+
+    m_undoItemId.clear();   // a whole-surface change; a one-rect undo would lie
+    m_store.setDocument(doc);
+    m_store.flush();
+}
+
+void WorkspaceController::tidyLayout()
+{
+    if (!m_enabled) {
+        return;
+    }
+
+    QList<CanvasItem> items;
+    for (const CanvasItem& it : m_canvas->layout().itemsByZ()) {
+        items.append(it);
+    }
+    const QList<TidyMove> moves =
+        tidyOverlaps(items, QStringList{kPanStackItemId});
+
+    for (const TidyMove& mv : moves) {
+        m_canvas->setItemRect(mv.id, mv.rect);   // rect stream → touch
+    }
+    if (!moves.isEmpty()) {
+        m_undoItemId.clear();   // multi-item change; single-slot undo is out
+        m_store.flush();
+    }
+}
+
+void WorkspaceController::onItemDraggedOut(const QString& itemId,
+                                           const QPoint& globalPos)
+{
+    if (m_applying || !m_enabled || itemId == kPanStackItemId) {
+        return;
+    }
+    // Only a release over the return target means anything; the canvas has
+    // already restored the item's rect, so anything else is a completed
+    // abort.
+    QWidget* target = m_returnTarget.data();
+    if (!target || !target->isVisible()) {
+        return;
+    }
+    if (!target->rect().contains(target->mapFromGlobal(globalPos))) {
+        return;
+    }
+    if (itemId.startsWith(kAppletItemPrefix)) {
+        returnAppletToPanel(itemId.mid(kAppletItemPrefix.size()));
+    }
+}
+
+void WorkspaceController::onContextMenuRequested(const QString& itemId,
+                                                 const QPoint& globalPos)
+{
+    if (!m_enabled) {
+        return;
+    }
+
+    QMenu menu;
+    const bool onApplet =
+        !itemId.isEmpty() && itemId.startsWith(kAppletItemPrefix);
+
+    if (onApplet) {
+        const QString appletId = itemId.mid(kAppletItemPrefix.size());
+        menu.addAction(QStringLiteral("Return to panel"), this,
+                       [this, appletId] { returnAppletToPanel(appletId); });
+        menu.addAction(QStringLiteral("Bring to front"), this,
+                       [this, itemId] { m_canvas->bringItemToFront(itemId); });
+        menu.addAction(QStringLiteral("Send to back"), this,
+                       [this, itemId] { m_canvas->sendItemToBack(itemId); });
+        menu.addSeparator();
+    }
+
+    QAction* undo = menu.addAction(QStringLiteral("Undo last placement"), this,
+                                   [this] { undoLastPlacement(); });
+    undo->setEnabled(canUndo());
+    menu.addAction(QStringLiteral("Tidy layout"), this,
+                   [this] { tidyLayout(); });
+    menu.addAction(QStringLiteral("Reset layout to Classic"), this,
+                   [this] { resetToClassic(); });
+
+    menu.exec(globalPos);
 }
 
 // ── Geometry helpers ─────────────────────────────────────────────────────

--- a/src/gui/workspace/WorkspaceController.cpp
+++ b/src/gui/workspace/WorkspaceController.cpp
@@ -9,6 +9,8 @@
 
 #include <QHash>
 #include <QMenu>
+
+#include <algorithm>
 #include <QPoint>
 #include <QWidget>
 
@@ -240,6 +242,36 @@ void WorkspaceController::placeActiveWorkspaceItems(WorkspaceDocument& doc,
         }
         if (docChanged) *docChanged = true;
         break;
+    }
+
+    // ── Normalize: pans BELOW everything else, always ────────────────────
+    //
+    // The document's z is otherwise replayed verbatim, and a document that
+    // lived through the frontmost-arrival bug (or any future mishap) would
+    // resurrect pans over the operator's controls at every boot — the 8600
+    // field report's second act.  Pans are the surface the station sits on;
+    // enforcing that at replay costs a deliberate pan-over-applet stacking
+    // across restarts (nothing supports one today — phase 6's pinning is
+    // where that would live) and buys layouts that cannot rot.
+    {
+        QList<CanvasItem> ordered = main->items;
+        std::stable_sort(ordered.begin(), ordered.end(),
+                         [](const CanvasItem& a, const CanvasItem& b) {
+                             return a.z < b.z;
+                         });
+        std::stable_partition(ordered.begin(), ordered.end(),
+                              [](const CanvasItem& it) {
+                                  return it.id.startsWith(kPanItemPrefix);
+                              });
+        bool zChanged = false;
+        for (int i = 0; i < ordered.size(); ++i) {
+            if (ordered[i].z != i) {
+                ordered[i].z = i;
+                zChanged = true;
+            }
+        }
+        main->items = ordered;
+        if (zChanged && docChanged) *docChanged = true;
     }
 
     // ── Pans, from their slot items ──────────────────────────────────────

--- a/src/gui/workspace/WorkspaceController.cpp
+++ b/src/gui/workspace/WorkspaceController.cpp
@@ -135,6 +135,7 @@ bool WorkspaceController::enable(const QStringList& knownAppletIds, QString* why
     if (m_enabled) {
         return true;
     }
+    bool justMigrated = false;
 
     if (!m_store.isLoaded()) {
         // First enable on this install: migrate the legacy layout keys into
@@ -145,13 +146,11 @@ bool WorkspaceController::enable(const QStringList& knownAppletIds, QString* why
         // Remembered before the migration read so migrationPanSlotIds() can
         // consult the same legacy keys.
         m_knownAppletIds = knownAppletIds;
-        bool migrated = false;
         if (!m_store.loadOrMigrate(knownAppletIds, migrationPanSlotIds(),
-                                   &migrated)) {
+                                   &justMigrated)) {
             if (whyNot) *whyNot = m_store.lastError();
             return false;
         }
-        m_justMigrated = migrated;
     }
 
     WorkspaceDocument doc = m_store.document();
@@ -166,8 +165,6 @@ bool WorkspaceController::enable(const QStringList& knownAppletIds, QString* why
         return false;
     }
 
-    Q_UNUSED(main);
-
     // Remembered for resetToClassic(), which re-derives Classic from the
     // same legacy keys the first enable migrated from.
     m_knownAppletIds = knownAppletIds;
@@ -175,8 +172,7 @@ bool WorkspaceController::enable(const QStringList& knownAppletIds, QString* why
     // The replay itself is guarded: the canvas signals it fires describe
     // what the document already says.
     m_applying = true;
-    bool docChanged = false;
-    placeActiveWorkspaceItems(doc, &docChanged);
+    placeActiveWorkspaceItems(doc, nullptr);
     m_applying = false;
 
     doc.canvasEnabled = true;
@@ -190,8 +186,9 @@ bool WorkspaceController::enable(const QStringList& knownAppletIds, QString* why
     // migration: the operator just opted in precisely to arrange things,
     // and greeting them with a locked surface would bury the feature they
     // asked for behind a second menu trip.  Session-transient thereafter.
-    m_canvas->setEditMode(m_justMigrated);
-    m_justMigrated = false;
+    // (A local, deliberately — a member here went stale across a failed
+    // enable and opened editing on a later one that was not first: m8.)
+    m_canvas->setEditMode(justMigrated);
 
     emit enabledChanged(true);
     return true;
@@ -468,17 +465,30 @@ bool WorkspaceController::sendPanToCanvas(const QString& panId)
         m_canvas->releaseItem(itemId);
     }
 
+    bool haveStored = false;
     NormRect rect{0.2, 0.2, 0.6, 0.6};
     const WorkspaceDocument& doc = m_store.document();
     if (const Workspace* ws = doc.workspace(doc.activeWorkspace)) {
         if (const WorkspaceSurface* main = ws->surface(WorkspaceSurface::kMainId)) {
             for (const CanvasItem& it : main->items) {
                 if (it.id == itemId) {
-                    rect = it.rect;
+                    rect       = it.rect;
+                    haveStored = true;
                     break;
                 }
             }
         }
+    }
+    if (!haveStored) {
+        // Cascade, not one shared rect (red-team B3): every defaulted pan
+        // landing at the same {0.2,0.2,0.6,0.6} made `pan create` a visual
+        // no-op — three new pans stacked pixel-identical behind the first.
+        // The classic window-manager stagger, keyed by slot so it is
+        // deterministic; clamped by addItem either way.
+        const int slot = slotForPan(panId);
+        const double step = 0.05 * (slot % 5);
+        rect.x = 0.15 + step;
+        rect.y = 0.15 + step;
     }
 
     QWidget* w = m_panHost.detach ? m_panHost.detach(panId) : nullptr;
@@ -492,16 +502,26 @@ bool WorkspaceController::sendPanToCanvas(const QString& panId)
         }
         return false;
     }
-    // To the BACK, always.  addItem() places new items frontmost — right
-    // for applets, wrong for a pan: pans are the SURFACE the rest of the
-    // station sits on ("a meter over the spectrum is a feature").  Radio
-    // pans arrive seconds after enable-time placement (connect, band
-    // recall, dock), so without this every real-radio pan landed on top of
-    // the operator's arrangement and swallowed its clicks and wheel — the
-    // 8600 field report: only the pan and its VFO flag still responded.
-    // Boot-time placement honours stored z via restoreItems(); this keeps
-    // the late-arrival path consistent with it.
+    // Below every applet, always — pans are the SURFACE the station sits
+    // on ("a meter over the spectrum is a feature"), and a pan landing
+    // frontmost swallowed the operator's clicks and wheel (the 8600 field
+    // report: only the pan and its VFO flag still responded).  A stored
+    // rect (arrival into an existing arrangement) goes to the very back;
+    // a DEFAULTED rect is a deliberate new pan, and burying it under the
+    // older pans made `pan create` invisible (red-team B3, maintainer
+    // ruling): it stacks ABOVE the other pans, still below all applets.
     m_canvas->sendItemToBack(itemId);
+    if (!haveStored) {
+        int otherPans = 0;
+        for (const CanvasItem& it : m_canvas->layout().itemsByZ()) {
+            if (it.id != itemId && it.id.startsWith(kPanItemPrefix)) {
+                ++otherPans;
+            }
+        }
+        for (int i = 0; i < otherPans; ++i) {
+            m_canvas->raiseItem(itemId);
+        }
+    }
     writeItemPresence(itemId, QStringLiteral("panadapter"),
                       m_canvas->itemRect(itemId), /*present=*/true,
                       /*flushNow=*/true);
@@ -988,6 +1008,24 @@ void WorkspaceController::resetToClassic()
         }
     }
 
+    // Compact the slot map first (red-team M3): slots can be sparse after
+    // a mid-pan close ({0,2,3}), while the Classic being built is dense
+    // ("pan:0".."pan:n-1") — an uncompacted slot 3 would find no Classic
+    // item and land at the cascade default while a Classic cell sat
+    // widget-less.  Reset means "the sane shell"; renumbering during it is
+    // safe because every pan item is being rebuilt wholesale anyway.
+    {
+        QList<QPair<int, QString>> bySlot;
+        for (auto it = m_panSlots.constBegin(); it != m_panSlots.constEnd(); ++it) {
+            bySlot.append({it.value(), it.key()});
+        }
+        std::sort(bySlot.begin(), bySlot.end());
+        m_panSlots.clear();
+        for (int i = 0; i < bySlot.size(); ++i) {
+            m_panSlots.insert(bySlot.at(i).second, i);
+        }
+    }
+
     // Classic is re-derived from the same legacy keys the first enable
     // migrated from — the panel still dual-writes them, so this reflects
     // the operator's CURRENT open applets and order, not a stale snapshot.
@@ -1105,8 +1143,12 @@ void WorkspaceController::onContextMenuRequested(const QString& itemId,
                                          });
         popOut->setEnabled(!panId.isEmpty()
                            && static_cast<bool>(m_panHost.requestFloat));
-        menu.addAction(QStringLiteral("Bring to front"), this,
-                       [this, itemId] { m_canvas->bringItemToFront(itemId); });
+        // No "Bring to front" for pans (review m3, maintainer ruling): the
+        // replay normalization exists to keep pans below the controls and
+        // would undo it at the next mode cycle — offering a control the
+        // persistence layer reverts is worse than not offering it.
+        // Deliberate pan-over-applet layering arrives with phase 6's
+        // pinning, as a property the normalization respects.
         menu.addAction(QStringLiteral("Send to back"), this,
                        [this, itemId] { m_canvas->sendItemToBack(itemId); });
         menu.addSeparator();

--- a/src/gui/workspace/WorkspaceController.h
+++ b/src/gui/workspace/WorkspaceController.h
@@ -229,6 +229,7 @@ private:
     QString  m_undoItemId;      // last gesture's item…
     NormRect m_undoRect;        // …and the rect it started from
     bool m_enabled{false};
+    bool m_justMigrated{false};   // first enable opens editing (see enable())
     // True while enable()/disable() replay the document onto the canvas —
     // the canvas signals fired by that replay describe what the document
     // already says, and echoing them back into it would be the #4427

--- a/src/gui/workspace/WorkspaceController.h
+++ b/src/gui/workspace/WorkspaceController.h
@@ -229,7 +229,6 @@ private:
     QString  m_undoItemId;      // last gesture's item…
     NormRect m_undoRect;        // …and the rect it started from
     bool m_enabled{false};
-    bool m_justMigrated{false};   // first enable opens editing (see enable())
     // True while enable()/disable() replay the document onto the canvas —
     // the canvas signals fired by that replay describe what the document
     // already says, and echoing them back into it would be the #4427

--- a/src/gui/workspace/WorkspaceController.h
+++ b/src/gui/workspace/WorkspaceController.h
@@ -1,0 +1,140 @@
+#pragma once
+
+// The brain of canvas mode (RFC #4887 phase 3): the one object that knows the
+// store, the canvas and the container manager at the same time, and therefore
+// the only place placement POLICY lives.  The canvas stays a dumb surface,
+// the manager stays a reparenting mechanism, the store stays persistence —
+// what a drop means, when an applet belongs on the canvas, and what the
+// document says about any of it is decided here and nowhere else.
+//
+// This is deliberately a real class rather than a fistful of MainWindow
+// members — the #3557 direction: MainWindow mounts the canvas and forwards
+// the View-menu toggle, and everything else lives behind this seam.
+//
+// ── The membership rule ──────────────────────────────────────────────────
+//
+// A document item "applet:<id>" means "this applet BELONGS on the canvas".
+// The applet is actually PLACED when canvas mode is on, the applet is open,
+// and it is not floating (pop-out stays, RFC decision 1).  Consequences:
+//
+//   * closing an applet (bar button) evicts it but KEEPS its item, so
+//     reopening returns it to the spot it had;
+//   * leaving the canvas deliberately — the title-bar "return to panel"
+//     button, dragging it onto the panel, or popping it out — REMOVES the
+//     item: the operator said "not on the canvas", and a home that silently
+//     reasserts itself is how layouts stop being trusted;
+//   * disable() keeps every item, because switching the mode off is not a
+//     statement about any applet.
+//
+// The document is placement truth (Principle V).  ContainerTree's
+// mode:"canvas" string is a dual-write mirror, and ContainerManager::
+// restoreState() deliberately normalises it back to panel at startup — this
+// controller re-places from the document when the mode comes up.
+
+#include "gui/workspace/WorkspaceStore.h"
+
+#include <QObject>
+#include <QPointer>
+#include <QPointF>
+#include <QString>
+#include <QStringList>
+
+class QWidget;
+
+namespace AetherSDR {
+
+class ContainerManager;
+class ContainerWidget;
+class WorkspaceCanvas;
+
+class WorkspaceController : public QObject {
+    Q_OBJECT
+
+public:
+    // The reserved item holding the panadapter area in phase 3.  Phase 4
+    // splits it into per-pan items; until then it is one non-closable region
+    // whose rect the document carries like any other item's.
+    static const QString kPanStackItemId;
+
+    WorkspaceController(ContainerManager* manager,
+                        WorkspaceCanvas* canvas,
+                        QObject* parent = nullptr);
+
+    // Startup: read the stored document (never migrates — migration is an
+    // explicit consequence of the operator enabling the mode).  Returns true
+    // when a usable document asks for canvas mode, i.e. the caller should
+    // mount the canvas and call enable().
+    bool boot();
+
+    // Turn the mode on.  The canvas must already be mounted and
+    // setPanStackWidget() called.  First enable migrates the legacy layout
+    // keys into a Classic document (`knownAppletIds` scopes that read).
+    // False + `whyNot` when the store refuses — including the write-blocked
+    // newer-document case, which must surface rather than silently shrug.
+    bool enable(const QStringList& knownAppletIds, QString* whyNot = nullptr);
+
+    // Turn the mode off: every applet returns to its panel slot, the pan
+    // stack widget is released (parentless — the caller re-slots it), and
+    // the document keeps all placement for the next enable().
+    void disable();
+
+    bool isEnabled() const { return m_enabled; }
+
+    // The widget occupying the reserved pan area (the PanadapterStack).
+    // Held, not owned; enable() places it, disable() releases it.
+    void setPanStackWidget(QWidget* w);
+
+    // ── Applet movement ──────────────────────────────────────────────────
+    //
+    // `appletId` is the panel's entry id (== the container's dragId(); the
+    // container's own id may differ, e.g. TXDSP wraps "tx_dsp").
+    //
+    // Send: detach from the panel (docking first if floating) and place at
+    // `where` when given, else at the document's remembered rect, else at a
+    // default.  Return: back to the panel slot it came from, forgetting the
+    // canvas home.  Both are no-ops outside canvas mode.
+    bool sendAppletToCanvas(const QString& appletId,
+                            const NormRect* where = nullptr);
+    bool returnAppletToPanel(const QString& appletId);
+
+signals:
+    void enabledChanged(bool enabled);
+
+private:
+    ContainerWidget* containerForApplet(const QString& appletId) const;
+    QString appletIdFor(const ContainerWidget* c) const;
+    QString itemIdFor(const ContainerWidget* c) const;
+
+    // Take the container off the canvas and back to its panel slot.
+    // `forgetHome` distinguishes "the operator left the canvas" (remove the
+    // document item) from "the applet closed" (keep it for reopening).
+    void evictFromCanvas(ContainerWidget* c, bool forgetHome);
+
+    // Document edits.  Each takes the current document, applies one change,
+    // and hands it back to the store; `flushNow` marks the end of a gesture.
+    void writeItemRect(const QString& itemId, const NormRect& rect, bool flushNow);
+    void writeItemPresence(const QString& itemId, const QString& contentType,
+                           const NormRect& rect, bool present, bool flushNow);
+    void writeStackingFromCanvas();
+
+    void onDropReceived(const QString& payload, const QPointF& pos);
+    void onItemRectChanged(const QString& itemId, const NormRect& rect);
+    void onContainerCreated(const QString& containerId);
+    void wireContainer(ContainerWidget* c);
+
+    NormRect defaultRectFor(const ContainerWidget* c, const QPointF* center) const;
+    NormRect panStackRectFromDocument() const;
+
+    ContainerManager* m_manager{nullptr};
+    WorkspaceCanvas*  m_canvas{nullptr};
+    WorkspaceStore    m_store;
+    QPointer<QWidget> m_panStackWidget;
+    bool m_enabled{false};
+    // True while enable()/disable() replay the document onto the canvas —
+    // the canvas signals fired by that replay describe what the document
+    // already says, and echoing them back into it would be the #4427
+    // write-back-what-you-read mistake.
+    bool m_applying{false};
+};
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/WorkspaceController.h
+++ b/src/gui/workspace/WorkspaceController.h
@@ -33,11 +33,14 @@
 
 #include "gui/workspace/WorkspaceStore.h"
 
+#include <QHash>
 #include <QObject>
 #include <QPointer>
 #include <QPointF>
 #include <QString>
 #include <QStringList>
+
+#include <functional>
 
 class QWidget;
 
@@ -51,10 +54,13 @@ class WorkspaceController : public QObject {
     Q_OBJECT
 
 public:
-    // The reserved item holding the panadapter area in phase 3.  Phase 4
-    // splits it into per-pan items; until then it is one non-closable region
-    // whose rect the document carries like any other item's.
+    // The phase-3 reserved item holding the whole panadapter area.  Phase 4
+    // SPLITS it into per-pan slot items on first enable (see
+    // placeActiveWorkspaceItems); the constant survives for that split and
+    // for downgrade robustness — a phase-3 document is still understood.
     static const QString kPanStackItemId;
+    // The band-stack panel's canvas item (transient panel, persistent spot).
+    static const QString kBandStackItemId;
 
     WorkspaceController(ContainerManager* manager,
                         WorkspaceCanvas* canvas,
@@ -80,9 +86,56 @@ public:
 
     bool isEnabled() const { return m_enabled; }
 
-    // The widget occupying the reserved pan area (the PanadapterStack).
-    // Held, not owned; enable() places it, disable() releases it.
-    void setPanStackWidget(QWidget* w);
+    // ── Pans as items (RFC #4887 phase 4) ────────────────────────────────
+    //
+    // The stack stays the pans' OWNER; this controller decides placement.
+    // The seam is a bundle of callbacks plus the lifecycle slots below,
+    // wired by MainWindow_Workspace — deliberately NOT a PanadapterStack*:
+    // pan-placement policy is unit-tested against plain QWidgets, and the
+    // GPU-adjacent stack never links into the workspace suites.
+    struct PanHostHooks {
+        std::function<QStringList()> panIds;                    // live, stack order
+        std::function<QWidget*(const QString&)> detach;         // null = refuse
+        std::function<void(const QString&, QWidget*)> restore;  // back to stack
+        std::function<bool(const QString&)> isFloating;
+        std::function<void(const QString&)> requestFloat;       // pop out
+        std::function<QWidget*()> bandStack;                    // the panel
+        std::function<void(QWidget*)> reclaimBandStack;         // re-home it
+    };
+    void setPanHost(const PanHostHooks& hooks);
+
+    // Document identity: pans are stored as "pan:<slot>", a small
+    // creation-order ordinal (lowest free on reuse) — NEVER the radio's
+    // stream id, which is session-scoped (rekey exists precisely because ids
+    // change) and would orphan every stored layout on reconnect.  The slot
+    // discipline mirrors SpectrumWidget::setPanIndex and RadioModel::
+    // neutralPanIndexFor, so all three identity spaces agree.
+    QString panItemIdFor(const QString& panId);
+
+    // Place one live pan onto the canvas (its stored slot rect, else a
+    // default).  The pan analogue of sendAppletToCanvas().
+    bool sendPanToCanvas(const QString& panId);
+
+    // The pan title strip's live-move stream, forwarded per applet by
+    // MainWindow_Workspace (the controller never sees the applet type).
+    void beginPanItemMove(const QString& panId, const QPoint& globalPos);
+    void movePanItem(const QPoint& globalPos);
+    void endPanItemMove(const QPoint& globalPos);
+
+    // Band-stack hosting while the mode is on: the panel becomes the
+    // "bandstack" canvas item (its spot persists; visibility stays the
+    // session-transient flag it always was).
+    void setBandStackVisible(bool on);
+
+public slots:
+    // Stack lifecycle (wired from PanadapterStack's phase-4b signals).
+    void onPanAdded(const QString& panId);
+    void onPanRemoved(const QString& panId);
+    void onPanRekeyed(const QString& oldId, const QString& newId);
+    void onPanFloated(const QString& panId);
+    void onPanDocked(const QString& panId);
+
+public:
 
     // ── Applet movement ──────────────────────────────────────────────────
     //
@@ -153,12 +206,20 @@ private:
     void placeActiveWorkspaceItems(WorkspaceDocument& doc, bool* docChanged);
 
     NormRect defaultRectFor(const ContainerWidget* c, const QPointF* center) const;
-    NormRect panStackRectFromDocument() const;
+
+    // Slot bookkeeping (phase 4).
+    int slotForPan(const QString& panId);          // assigns on first sight
+    QString panIdForItem(const QString& itemId) const;
+    // The slot-id list migration/reset feed composeClassic ("0", "1", …):
+    // as many as the operator's saved pan layout has cells, or the live pan
+    // count if that is higher — deterministic even with no radio connected.
+    QStringList migrationPanSlotIds() const;
 
     ContainerManager* m_manager{nullptr};
     WorkspaceCanvas*  m_canvas{nullptr};
     WorkspaceStore    m_store;
-    QPointer<QWidget> m_panStackWidget;
+    PanHostHooks m_panHost;
+    QHash<QString, int> m_panSlots;   // live panId → document slot
     QPointer<QWidget> m_returnTarget;
     QStringList m_knownAppletIds;   // from enable(), for resetToClassic()
     QString  m_undoItemId;      // last gesture's item…

--- a/src/gui/workspace/WorkspaceController.h
+++ b/src/gui/workspace/WorkspaceController.h
@@ -122,6 +122,10 @@ public:
     void movePanItem(const QPoint& globalPos);
     void endPanItemMove(const QPoint& globalPos);
 
+    // Flush the debounced document write now — the automation bridge's
+    // gesture boundary (a `workspace place` is one discrete edit).
+    void commitPlacement() { m_store.flush(); }
+
     // Band-stack hosting while the mode is on: the panel becomes the
     // "bandstack" canvas item (its spot persists; visibility stays the
     // session-transient flag it always was).

--- a/src/gui/workspace/WorkspaceController.h
+++ b/src/gui/workspace/WorkspaceController.h
@@ -97,6 +97,29 @@ public:
                             const NormRect* where = nullptr);
     bool returnAppletToPanel(const QString& appletId);
 
+    // ── Escape hatches (RFC #4887 phase 5) ───────────────────────────────
+    //
+    // Undo restores the rect the last gesture (mouse or keyboard) started
+    // from — single-slot by design, per the RFC's "undo for the last
+    // placement"; invoking it twice toggles, which doubles as redo.
+    bool undoLastPlacement();
+    bool canUndo() const { return !m_undoItemId.isEmpty(); }
+
+    // Rebuild the active workspace's main surface as Classic — pan area plus
+    // the open applets in a fresh column — and re-place everything.  The one
+    // guaranteed way back to a sane shell.
+    void resetToClassic();
+
+    // Resolve applet-vs-applet overlaps by minimal downward pushes.  Items
+    // overlapping the PAN AREA are left alone on purpose: a meter over the
+    // spectrum is a feature, not disorder.
+    void tidyLayout();
+
+    // Where a live drag out of the canvas may land (the applet panel).
+    // Releasing a move over this widget returns the applet to it; anywhere
+    // else the drag is an abort (the canvas has already restored the rect).
+    void setReturnTarget(QWidget* target);
+
 signals:
     void enabledChanged(bool enabled);
 
@@ -121,6 +144,13 @@ private:
     void onItemRectChanged(const QString& itemId, const NormRect& rect);
     void onContainerCreated(const QString& containerId);
     void wireContainer(ContainerWidget* c);
+    void onItemDraggedOut(const QString& itemId, const QPoint& globalPos);
+    void onContextMenuRequested(const QString& itemId, const QPoint& globalPos);
+
+    // The placement replay shared by enable() and resetToClassic(): put the
+    // pan stack and every eligible applet item of the active workspace onto
+    // the (empty) canvas.  Callers hold m_applying.
+    void placeActiveWorkspaceItems(WorkspaceDocument& doc, bool* docChanged);
 
     NormRect defaultRectFor(const ContainerWidget* c, const QPointF* center) const;
     NormRect panStackRectFromDocument() const;
@@ -129,6 +159,10 @@ private:
     WorkspaceCanvas*  m_canvas{nullptr};
     WorkspaceStore    m_store;
     QPointer<QWidget> m_panStackWidget;
+    QPointer<QWidget> m_returnTarget;
+    QStringList m_knownAppletIds;   // from enable(), for resetToClassic()
+    QString  m_undoItemId;      // last gesture's item…
+    NormRect m_undoRect;        // …and the rect it started from
     bool m_enabled{false};
     // True while enable()/disable() replay the document onto the canvas —
     // the canvas signals fired by that replay describe what the document

--- a/src/gui/workspace/WorkspaceDocument.cpp
+++ b/src/gui/workspace/WorkspaceDocument.cpp
@@ -150,6 +150,9 @@ QJsonObject WorkspaceDocument::toJson() const
     root[QStringLiteral("version")]         = kSchemaVersion;
     root[QStringLiteral("activeWorkspace")] = activeWorkspace;
     root[QStringLiteral("workspaces")]      = wsArray;
+    if (canvasEnabled) {
+        root[QStringLiteral("canvasEnabled")] = true;
+    }
     if (!bindingsObj.isEmpty()) {
         root[QStringLiteral("bindings")] = bindingsObj;
     }
@@ -341,6 +344,8 @@ bool WorkspaceDocument::fromJson(const QJsonObject& root,
         }
         doc.bindings.insert(it.key(), target);
     }
+
+    doc.canvasEnabled = root.value(QStringLiteral("canvasEnabled")).toBool(false);
 
     doc.activeWorkspace = root.value(QStringLiteral("activeWorkspace")).toString();
     if (!doc.activeWorkspace.isEmpty() && !doc.contains(doc.activeWorkspace)) {

--- a/src/gui/workspace/WorkspaceDocument.h
+++ b/src/gui/workspace/WorkspaceDocument.h
@@ -79,6 +79,15 @@ public:
 
     QString activeWorkspace;
 
+    // Whether canvas mode is switched on (View menu).  Lives here rather
+    // than in a flat AppSettings key because the workspace document is the
+    // feature's single configuration object (Principle V) — the toggle is as
+    // much workspace state as the placement it reveals.  Optional in the
+    // stored form and absent when false, so phase-2 documents parse
+    // unchanged and a downgraded build that rewrites the document merely
+    // drops a flag whose feature it does not have.
+    bool canvasEnabled = false;
+
     // ── Queries ──────────────────────────────────────────────────────────
     const Workspace* workspace(const QString& id) const;
     bool contains(const QString& id) const { return workspace(id) != nullptr; }

--- a/src/gui/workspace/WorkspaceGeometry.cpp
+++ b/src/gui/workspace/WorkspaceGeometry.cpp
@@ -97,6 +97,23 @@ QSizeF minimumNormSize(const QSize& minPx, const QSize& canvas)
     return QSizeF(qMin(w, 1.0), qMin(h, 1.0));
 }
 
+NormRect clampToBounds(const NormRect& r)
+{
+    if (!finite(r.x) || !finite(r.y) || !finite(r.w) || !finite(r.h)) {
+        return {};
+    }
+
+    NormRect out = r;
+    // Size bounded, never grown: growth is a display concern.
+    out.w = clampDouble(out.w, 0.0, 1.0);
+    out.h = clampDouble(out.h, 0.0, 1.0);
+    // Position slides inside, same order as the display clamp: an overshoot
+    // moves the item back rather than resizing it.
+    out.x = clampDouble(out.x, 0.0, 1.0 - out.w);
+    out.y = clampDouble(out.y, 0.0, 1.0 - out.h);
+    return out;
+}
+
 NormRect clampToCanvas(const NormRect& r, const QSize& minPx, const QSize& canvas)
 {
     if (!canvasUsable(canvas)) {

--- a/src/gui/workspace/WorkspaceGeometry.h
+++ b/src/gui/workspace/WorkspaceGeometry.h
@@ -12,6 +12,7 @@
 // Nothing here knows what a QWidget is, so all of it is unit-tested headless
 // on every platform — see tests/workspace_geometry_test.cpp.
 
+#include <QMetaType>
 #include <QRect>
 #include <QSize>
 #include <QSizeF>
@@ -103,3 +104,7 @@ NormRect clampToBounds(const NormRect& r);
 NormRect clampToCanvas(const NormRect& r, const QSize& minPx, const QSize& canvas);
 
 }  // namespace AetherSDR
+
+// Signal parameter in WorkspaceCanvas (gestureStarted); registered so
+// QSignalSpy and queued connections can carry it.
+Q_DECLARE_METATYPE(AetherSDR::NormRect)

--- a/src/gui/workspace/WorkspaceGeometry.h
+++ b/src/gui/workspace/WorkspaceGeometry.h
@@ -68,6 +68,22 @@ NormRect fromPixels(const QRect& px, const QSize& canvas);
 // outcome than one that overflows a tiny window.
 QSizeF minimumNormSize(const QSize& minPx, const QSize& canvas);
 
+// Bring `r` inside the UNIT SQUARE, preserving its size wherever possible —
+// the canvas-independent half of clamping, and the only clamp the MODEL is
+// allowed to apply.
+//
+// Deliberately knows nothing about pixels: a stored rect must never depend
+// on how big the canvas happened to be when it was written.  The failure
+// this exists to prevent is real and was hit in the field: placing items at
+// startup, before the window is laid out, ran the pixel clamp against a
+// degenerate canvas, grew every item to full-surface to satisfy minimum
+// sizes, and wrecked the whole arrangement for the session (RFC #4887
+// phase 3 field report).  Minimum-size enforcement belongs to the DISPLAY
+// clamp below, applied at render time and never written back.
+//
+// Size is bounded to (0,1] with no growth; position slides inside.
+NormRect clampToBounds(const NormRect& r);
+
 // Bring `r` inside the canvas, preserving its size wherever possible.
 //
 // Order matters, and is chosen so a drag that overshoots an edge slides the
@@ -79,6 +95,11 @@ QSizeF minimumNormSize(const QSize& minPx, const QSize& canvas);
 // A degenerate canvas returns `r` untouched: with no surface to clamp against
 // there is no correct answer, and mangling the stored layout because a widget
 // has not been shown yet would lose real state.
+//
+// DISPLAY ONLY.  This result is what gets mapped to pixels; it is never
+// stored.  Feeding it back into the model bakes one window size's
+// compromises into the operator's arrangement — shrink the window once and
+// the layout would never recover.
 NormRect clampToCanvas(const NormRect& r, const QSize& minPx, const QSize& canvas);
 
 }  // namespace AetherSDR

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -5066,9 +5066,22 @@ void RadioModel::onBackendSpectrumFrame(int panId, const QByteArray& frame)
     // it directly, which ALSO bypassed the neutral consumers (the adaptive RX
     // filter and the S-history markers), so those received nothing at all.
     quint32 streamId = kNeutralPanStreamIdBase + static_cast<quint32>(panId);
-    // m_panadapters is keyed by the panId STRING, so resolve through the same
-    // helper the other backend-signal handlers use (addressed pan, else active).
-    if (auto* pan = resolvePan(neutralPanIdString(panId))) {
+    // The backend's OWN pan for this index first. A backend that claims its
+    // pans over a wire (the demo's Route A) keys m_panadapters by the WIRE
+    // id ("0x40000001"), which the neutral synthesis below can never
+    // produce — so before the multi-pan demo every demo row fell through to
+    // resolvePan()'s active-pan fallback, which is wrong the moment a second
+    // pan exists: every receiver's rows drew into whichever pane was active.
+    // The index↔backend-id pair is allocated by neutralPanIndexFor() when
+    // the pan's geometry first crosses the seam, which precedes any row.
+    PanadapterModel* pan = nullptr;
+    const QString backendPanId = m_backendPanIdByIndex.value(panId);
+    if (!backendPanId.isEmpty())
+        pan = m_panadapters.value(normalizePanadapterId(backendPanId), nullptr);
+    // Else the neutral resolution (HL2 pans; falls back to the active pan).
+    if (!pan)
+        pan = resolvePan(neutralPanIdString(panId));
+    if (pan) {
         if (const quint32 realId = pan->panStreamId())
             streamId = realId;
     }

--- a/tests/sim_signal_source_test.cpp
+++ b/tests/sim_signal_source_test.cpp
@@ -12,6 +12,7 @@
 
 #include <QCoreApplication>
 #include <QElapsedTimer>
+#include <QSet>
 #include <QThread>
 
 #include <cstdio>
@@ -69,6 +70,7 @@ public:
     int slice = 0;
     int spectrum = 0;
     int lastSliceId = -1;
+    QSet<int> panIdsSeen;
     qint64 samples = 0;
     QByteArray lastAudio;
 
@@ -86,7 +88,10 @@ public:
                     lastSliceId = id;
                 });
         connect(src, &AetherSDR::SimSignalSource::spectrumFrameReady, this,
-                [this](int, const QByteArray&) { ++spectrum; });
+                [this](int pan, const QByteArray&) {
+                    ++spectrum;
+                    panIdsSeen.insert(pan);
+                });
     }
 };
 
@@ -162,6 +167,19 @@ int main(int argc, char** argv)
     rx.audio = 0;
     report("controls apply on the worker without disturbing the stream",
            waitFor([&] { return rx.audio > 2; }, 1000));
+
+    // ── Multi-pan: rows address every live pan (#4887 phase 4) ───────────
+    QMetaObject::invokeMethod(src, [src] {
+        src->setScopeStalled(false);   // stallscope check above left it on
+        src->setPanIndices({0, 2});
+    }, Qt::QueuedConnection);
+    waitFor([&] { return false; }, 60);
+    rx.panIdsSeen.clear();
+    rx.spectrum = 0;
+    waitFor([&] { return rx.spectrum > 6; }, 2000);
+    report("spectrum rows address every live pan, and only those",
+           rx.panIdsSeen.contains(0) && rx.panIdsSeen.contains(2)
+               && rx.panIdsSeen.size() == 2);
 
     // ── Stop stops ───────────────────────────────────────────────────────
     QMetaObject::invokeMethod(src, &SimSignalSource::stop, Qt::QueuedConnection);

--- a/tests/sim_signal_source_test.cpp
+++ b/tests/sim_signal_source_test.cpp
@@ -1,0 +1,179 @@
+// SimSignalSource — the demo radio's RX engine on a worker thread (#4878).
+//
+// The property under test is the fix itself: the generator runs OFF the
+// thread that constructed it, keeps its 24 kHz long-run pacing there, and
+// every control crosses the boundary queued. The GUI-thread original was the
+// only RX producer in the app with GUI affinity, and on software-GL machines
+// its 3 ms precise timer plus ~200 allocating emissions/s was a multi-second
+// input backlog.
+
+#include "core/backends/sim/NoiseMixer.h"
+#include "core/backends/sim/SimSignalSource.h"
+
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QThread>
+
+#include <cstdio>
+#include <iostream>
+
+using AetherSDR::NoiseMixer;
+using AetherSDR::SimSignalSource;
+
+namespace {
+
+int g_failures = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) {
+        ++g_failures;
+    }
+}
+
+// Pump the main loop until `predicate` holds or the budget runs out.
+bool waitFor(const std::function<bool()>& predicate, int budgetMs)
+{
+    QElapsedTimer t;
+    t.start();
+    while (t.elapsed() < budgetMs) {
+        if (predicate()) {
+            return true;
+        }
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    }
+    return predicate();
+}
+
+bool frameIsSilent(const QByteArray& stereo)
+{
+    const auto* f = reinterpret_cast<const float*>(stereo.constData());
+    const int n = stereo.size() / int(sizeof(float));
+    for (int i = 0; i < n; ++i) {
+        if (f[i] != 0.0f) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// QSignalSpy connects DIRECT, so a cross-thread emitter appends to the spy's
+// storage from the worker while the main thread reads it — a data race that
+// segfaulted this test's first draft. This collector lives on the main
+// thread and receives QUEUED, so every count and payload is touched by one
+// thread only.
+class Collector : public QObject {
+public:
+    int audio = 0;
+    int slice = 0;
+    int spectrum = 0;
+    int lastSliceId = -1;
+    qint64 samples = 0;
+    QByteArray lastAudio;
+
+    explicit Collector(AetherSDR::SimSignalSource* src)
+    {
+        connect(src, &AetherSDR::SimSignalSource::audioFrameReady, this,
+                [this](const QByteArray& b) {
+                    ++audio;
+                    samples += b.size() / qint64(2 * sizeof(float));
+                    lastAudio = b;
+                });
+        connect(src, &AetherSDR::SimSignalSource::sliceAudioFrameReady, this,
+                [this](int id, const QByteArray&) {
+                    ++slice;
+                    lastSliceId = id;
+                });
+        connect(src, &AetherSDR::SimSignalSource::spectrumFrameReady, this,
+                [this](int, const QByteArray&) { ++spectrum; });
+    }
+};
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    QThread worker;
+    worker.setObjectName("SimSignalSourceTest");
+    auto* src = new SimSignalSource;
+    src->moveToThread(&worker);
+    worker.start();
+
+    report("the source lives on the worker, not the main thread",
+           src->thread() == &worker && src->thread() != app.thread());
+
+    Collector rx(src);
+
+    // ── Start, and measure the long-run pacing ───────────────────────────
+    QMetaObject::invokeMethod(src, &SimSignalSource::start, Qt::QueuedConnection);
+    report("audio frames arrive across the thread boundary",
+           waitFor([&] { return rx.audio > 4; }, 2000));
+
+    // Count samples over a measured window: the debt pacing must hold the
+    // long-run rate at 24 kHz regardless of the coarse 10 ms timer.
+    rx.audio = 0;
+    rx.samples = 0;
+    QElapsedTimer window;
+    window.start();
+    waitFor([&] { return window.elapsed() >= 500; }, 1500);
+    const qint64 elapsedMs = window.elapsed();
+    const double rate = rx.samples * 1000.0 / elapsedMs;
+    report("the long-run rate stays at 24 kHz on a coarse timer",
+           rate > 24000 * 0.85 && rate < 24000 * 1.15);
+    std::printf("       measured %.0f samples/s over %lld ms\n", rate,
+                static_cast<long long>(elapsedMs));
+
+    report("per-slice audio rides along", rx.slice > 0 && rx.lastSliceId == 0);
+    report("spectrum rows arrive at their cadence",
+           rx.spectrum > 0 && rx.spectrum < rx.audio + 1);
+
+    // ── Keyed mutes without stopping the stream ──────────────────────────
+    QMetaObject::invokeMethod(src, [src] { src->setKeyed(true); },
+                              Qt::QueuedConnection);
+    waitFor([&] { return false; }, 60);   // let the queued flip land
+    rx.audio = 0;
+    report("keyed frames keep flowing",
+           waitFor([&] { return rx.audio > 2; }, 1000));
+    report("...and are silent (Principle VI)",
+           !rx.lastAudio.isEmpty() && frameIsSilent(rx.lastAudio));
+    QMetaObject::invokeMethod(src, [src] { src->setKeyed(false); },
+                              Qt::QueuedConnection);
+
+    // ── Stallscope freezes the spectrum, audio unaffected ────────────────
+    QMetaObject::invokeMethod(src, [src] { src->setScopeStalled(true); },
+                              Qt::QueuedConnection);
+    waitFor([&] { return false; }, 60);
+    rx.spectrum = 0;
+    rx.audio = 0;
+    waitFor([&] { return rx.audio > 5; }, 1000);
+    report("stallscope stops spectrum rows while audio flows",
+           rx.spectrum == 0 && rx.audio > 5);
+
+    // ── A queued noise control lands (no crash, still producing) ─────────
+    QMetaObject::invokeMethod(src, [src] {
+        src->setNoiseEnabled(QStringLiteral("white"), true);
+        src->setNoiseLevel(QStringLiteral("white"), -30.0);
+        src->setVfoMhz(7.074);
+        src->setLowerSideband(true);
+    }, Qt::QueuedConnection);
+    rx.audio = 0;
+    report("controls apply on the worker without disturbing the stream",
+           waitFor([&] { return rx.audio > 2; }, 1000));
+
+    // ── Stop stops ───────────────────────────────────────────────────────
+    QMetaObject::invokeMethod(src, &SimSignalSource::stop, Qt::QueuedConnection);
+    waitFor([&] { return false; }, 120);   // drain in-flight emissions
+    rx.audio = 0;
+    waitFor([&] { return false; }, 250);
+    report("stop halts production", rx.audio == 0);
+
+    src->deleteLater();
+    worker.quit();
+    worker.wait(3000);
+
+    std::printf("\n%s\n", g_failures == 0 ? "All checks passed." : "FAILURES present.");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/workspace_canvas_widget_test.cpp
+++ b/tests/workspace_canvas_widget_test.cpp
@@ -20,10 +20,13 @@
 #include <QHash>
 #include <QKeyEvent>
 #include <QMouseEvent>
+#include <QShortcut>
+#include <QTest>
 #include <QRect>
 #include <QSignalSpy>
 #include <QStringList>
 #include <QWidget>
+#include <QWindow>
 
 #include <cmath>
 #include <cstdio>
@@ -483,6 +486,79 @@ int main(int argc, char** argv)
         QCoreApplication::sendEvent(&canvas, &esc);
         report("Esc clears the selection",
                canvas.selectedItem().isEmpty());
+    }
+
+    // ── Placement keys beat application shortcuts — only while selected ──
+    //
+    // The main window binds Left/Right and Shift+Left/Right to frequency
+    // nudges.  The field report: Shift+arrows only resized vertically,
+    // because the horizontal pair was eaten by those shortcuts before the
+    // canvas saw them.  Pinned with a real competing QShortcut and keys
+    // delivered through the full chain (QTest::keyClick consults the
+    // shortcut map; sendEvent would bypass it and prove nothing).
+    {
+        QWidget window;
+        window.resize(1000, 1000);
+        auto* canvas = new WorkspaceCanvas;
+        canvas->setParent(&window);
+        canvas->setGeometry(0, 0, 1000, 1000);
+        window.show();
+        canvas->show();
+
+        int nudges = 0;
+        auto* freqNudge = new QShortcut(
+            QKeySequence(Qt::SHIFT | Qt::Key_Right), &window);
+        // ApplicationShortcut: WindowShortcut needs an ACTIVE window, which
+        // the offscreen platform never grants.  Same QShortcutMap, same
+        // ShortcutOverride consultation — the mechanism under test.
+        freqNudge->setContext(Qt::ApplicationShortcut);
+        QObject::connect(freqNudge, &QShortcut::activated,
+                         [&nudges] { ++nudges; });
+
+        canvas->addItem("a", new QWidget, NormRect{0.1, 0.1, 0.4, 0.4});
+        canvas->setFocus();
+
+        // Keys must travel the REAL delivery chain — window system event →
+        // shortcut map → ShortcutOverride → focus widget.  The QWidget
+        // overload of keyClick sends straight to the widget and consults no
+        // shortcut map, which would pass here while proving nothing.
+        QWindow* handle = window.windowHandle();
+
+        // No selection: the shortcut owns the key, the item is untouched.
+        QTest::keyClick(handle, Qt::Key_Right, Qt::ShiftModifier);
+        report("without a selection the app shortcut fires", nudges == 1);
+        report("...and the item is untouched",
+               canvas->itemRect("a") == NormRect{0.1, 0.1, 0.4, 0.4});
+
+        // Selected: the canvas reclaims the key — Shift+Right resizes
+        // HORIZONTALLY, the axis the field report lost.
+        canvas->selectItem("a");
+        QTest::keyClick(handle, Qt::Key_Right, Qt::ShiftModifier);
+        report("with a selection Shift+Right resizes width",
+               nearly(canvas->itemRect("a").w, 0.4 + 8.0 / 1000.0));
+        report("...and the app shortcut did not fire", nudges == 1);
+
+        // Both axes under one modifier — no Shift/Ctrl+Shift axis split.
+        QTest::keyClick(handle, Qt::Key_Down, Qt::ShiftModifier);
+        report("Shift+Down resizes height under the same modifier",
+               nearly(canvas->itemRect("a").h, 0.4 + 8.0 / 1000.0));
+
+        // Plain arrows move while selected (they were also bound app-wide).
+        auto* plainNudge = new QShortcut(QKeySequence(Qt::Key_Left), &window);
+        plainNudge->setContext(Qt::ApplicationShortcut);
+        int plain = 0;
+        QObject::connect(plainNudge, &QShortcut::activated,
+                         [&plain] { ++plain; });
+        QTest::keyClick(handle, Qt::Key_Left, Qt::NoModifier);
+        report("plain arrows move the selected item, not the VFO",
+               plain == 0 && nearly(canvas->itemRect("a").x, 0.1 - 8.0 / 1000.0));
+
+        // Deselect: the keys go straight back to the shortcuts.
+        canvas->clearSelection();
+        QTest::keyClick(handle, Qt::Key_Right, Qt::ShiftModifier);
+        QTest::keyClick(handle, Qt::Key_Left, Qt::NoModifier);
+        report("deselecting returns the keys to the app",
+               nudges == 2 && plain == 1);
     }
 
     std::printf("\n%s\n", g_failures == 0 ? "All checks passed." : "FAILURES present.");

--- a/tests/workspace_canvas_widget_test.cpp
+++ b/tests/workspace_canvas_widget_test.cpp
@@ -463,6 +463,15 @@ int main(int argc, char** argv)
         report("a live move snaps to a peer edge",
                nearly(canvas.itemRect("a").right(), 0.6));
 
+        // The grid tier through a live gesture: from x=0.1, +213 px puts the
+        // origin at 0.313 — no peer line in reach, but 10/32 = 0.3125 is
+        // 0.0005 away — the move lands ON the grid line.
+        canvas.beginMoveGesture("a", origin);
+        canvas.moveGesture(origin + QPoint(213, 0));
+        canvas.endGesture(origin + QPoint(213, 0));
+        report("a live move lands on the snap grid",
+               nearly(canvas.itemRect("a").x, 10.0 / 32.0));
+
         // Keyboard: arrows nudge, Shift+arrows resize, both announce a
         // gesture pair (undo hangs off it).
         canvas.selectItem("a");

--- a/tests/workspace_canvas_widget_test.cpp
+++ b/tests/workspace_canvas_widget_test.cpp
@@ -18,12 +18,14 @@
 #include <QEvent>
 #include <QPointer>
 #include <QHash>
+#include <QKeyEvent>
 #include <QMouseEvent>
 #include <QRect>
 #include <QSignalSpy>
 #include <QStringList>
 #include <QWidget>
 
+#include <cmath>
 #include <cstdio>
 
 using AetherSDR::NormRect;
@@ -44,6 +46,11 @@ void report(const char* name, bool ok)
 // Position of a child in its parent's child list.  Qt's stacking order IS
 // this order — raise() moves a widget to the end — so it is how "on top" is
 // observed without a screen.
+bool nearly(double a, double b, double tol = 1e-9)
+{
+    return std::fabs(a - b) <= tol;
+}
+
 int childIndex(const QWidget* parent, QWidget* child)
 {
     return parent->children().indexOf(child);
@@ -378,6 +385,104 @@ int main(int argc, char** argv)
         report("an item with no widget is skipped",
                canvas.restoreItems({orphan}, {}) == 0
                    && !canvas.contains("ghost"));
+    }
+
+    // ── Selection + the gesture session (phase 5) ────────────────────────
+    {
+        using AetherSDR::HitZone;
+
+        WorkspaceCanvas canvas;
+        canvas.resize(1000, 1000);
+        canvas.show();
+
+        auto* a = new QWidget;
+        canvas.addItem("a", a, NormRect{0.1, 0.1, 0.4, 0.4});
+        canvas.addItem("b", new QWidget, NormRect{0.6, 0.6, 0.3, 0.3});
+
+        QSignalSpy selSpy(&canvas, &WorkspaceCanvas::selectionChanged);
+        QSignalSpy startSpy(&canvas, &WorkspaceCanvas::gestureStarted);
+        QSignalSpy finishSpy(&canvas, &WorkspaceCanvas::gestureFinished);
+        QSignalSpy outSpy(&canvas, &WorkspaceCanvas::itemDraggedOut);
+
+        // Pressing an item selects it (through the real event filter).
+        QMouseEvent press(QEvent::MouseButtonPress, QPointF(5, 5),
+                          a->mapToGlobal(QPointF(5, 5)),
+                          Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+        QCoreApplication::sendEvent(a, &press);
+        report("pressing an item selects it",
+               canvas.selectedItem() == "a" && selSpy.count() == 1);
+
+        // A move gesture: begin at a global point, move right+down, end.
+        const QPoint origin = canvas.mapToGlobal(QPoint(500, 500));
+        canvas.beginMoveGesture("a", origin);
+        report("the gesture reports its start rect",
+               startSpy.count() == 1
+                   && qvariant_cast<NormRect>(startSpy.at(0).at(1))
+                          == NormRect{0.1, 0.1, 0.4, 0.4});
+        canvas.moveGesture(origin + QPoint(100, 50));   // +0.1, +0.05
+        report("the item follows live",
+               canvas.itemRect("a") == NormRect{0.2, 0.15, 0.4, 0.4});
+        canvas.endGesture(origin + QPoint(100, 50));
+        report("release commits and announces",
+               finishSpy.count() == 1 && canvas.itemRect("a") == NormRect{0.2, 0.15, 0.4, 0.4});
+
+        // Esc mid-gesture restores the start rect and never announces.
+        canvas.beginMoveGesture("a", origin);
+        canvas.moveGesture(origin + QPoint(300, 300));
+        canvas.cancelGesture();
+        report("cancel restores the start rect",
+               canvas.itemRect("a") == NormRect{0.2, 0.15, 0.4, 0.4});
+        report("...and does not report a finish", finishSpy.count() == 1);
+
+        // A move released OUTSIDE the canvas restores the rect and reports
+        // the drag-out with the release point.
+        canvas.beginMoveGesture("a", origin);
+        canvas.moveGesture(origin + QPoint(200, 0));
+        canvas.endGesture(canvas.mapToGlobal(QPoint(2000, 500)));
+        report("a release outside restores the rect",
+               canvas.itemRect("a") == NormRect{0.2, 0.15, 0.4, 0.4});
+        report("...and reports the drag-out once",
+               outSpy.count() == 1 && finishSpy.count() == 1);
+
+        // Resize through the session: E grip, anchor pinned.
+        canvas.selectItem("a");
+        canvas.beginFrameGesture(HitZone::E, origin);
+        canvas.moveGesture(origin + QPoint(100, 0));
+        canvas.endGesture(origin + QPoint(100, 0));
+        report("a frame resize grows the gripped edge",
+               canvas.itemRect("a") == NormRect{0.2, 0.15, 0.5, 0.4});
+
+        // Snapping in a live move: b's left edge is at 0.6; drag a's right
+        // edge to 0.594 — within the 8 px tolerance — and it captures.
+        canvas.beginMoveGesture("a", origin);
+        canvas.moveGesture(origin + QPoint(-106, 0));
+        canvas.endGesture(origin + QPoint(-106, 0));
+        report("a live move snaps to a peer edge",
+               nearly(canvas.itemRect("a").right(), 0.6));
+
+        // Keyboard: arrows nudge, Shift+arrows resize, both announce a
+        // gesture pair (undo hangs off it).
+        canvas.selectItem("a");
+        const int startCount = startSpy.count();
+        const NormRect before = canvas.itemRect("a");
+        QKeyEvent right(QEvent::KeyPress, Qt::Key_Right, Qt::NoModifier);
+        QCoreApplication::sendEvent(&canvas, &right);
+        report("an arrow nudges by the step",
+               nearly(canvas.itemRect("a").x, before.x + 8.0 / 1000.0));
+        QKeyEvent grow(QEvent::KeyPress, Qt::Key_Down, Qt::ShiftModifier);
+        QCoreApplication::sendEvent(&canvas, &grow);
+        report("Shift+arrow resizes the SE corner",
+               nearly(canvas.itemRect("a").h, before.h + 8.0 / 1000.0)
+                   && nearly(canvas.itemRect("a").y, before.y));
+        report("keyboard placement announces gesture pairs",
+               startSpy.count() == startCount + 2
+                   && finishSpy.count() >= 3);
+
+        // Esc with no gesture clears the selection.
+        QKeyEvent esc(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
+        QCoreApplication::sendEvent(&canvas, &esc);
+        report("Esc clears the selection",
+               canvas.selectedItem().isEmpty());
     }
 
     std::printf("\n%s\n", g_failures == 0 ? "All checks passed." : "FAILURES present.");

--- a/tests/workspace_canvas_widget_test.cpp
+++ b/tests/workspace_canvas_widget_test.cpp
@@ -133,14 +133,26 @@ int main(int argc, char** argv)
                canvas.itemWidget("a")->geometry() == QRect(0, 0, 960, 540)
                    && canvas.itemWidget("b")->geometry() == QRect(960, 540, 960, 540));
 
-        // Both items fit at every size used above, so nothing was clamped and
-        // nothing should have been announced as an edit.
-        report("a resize that clamps nothing announces nothing",
-               rectChanges == 0);
+        // A resize is never an edit.  Not when everything fits...
+        report("a resize announces nothing", rectChanges == 0);
 
-        // Shrinking below the default minimum DOES move things, and must say so.
+        // ...and not when the canvas is too small to honour minimums: the
+        // DISPLAY compromises (the widget grows to stay usable) while the
+        // stored rect stays pristine.  Persisting the compromise is how a
+        // transient startup size once destroyed an arrangement for a whole
+        // session (phase 3 field report).
         resizeAndSettle(&canvas, 100, 100);
-        report("a resize that forces a clamp announces it", rectChanges > 0);
+        report("a squeezing resize still announces nothing", rectChanges == 0);
+        report("...the display compromises",
+               canvas.itemWidget("a")->geometry().width() > 50);
+        report("...but the stored rect is untouched",
+               canvas.itemRect("a") == NormRect{0.0, 0.0, 0.5, 0.5});
+
+        // And the arrangement comes back the moment the canvas does.
+        resizeAndSettle(&canvas, 1920, 1080);
+        report("growing the canvas restores the exact arrangement",
+               canvas.itemWidget("a")->geometry() == QRect(0, 0, 960, 540)
+                   && canvas.itemWidget("b")->geometry() == QRect(960, 540, 960, 540));
     }
 
     // ── Stacking ─────────────────────────────────────────────────────────

--- a/tests/workspace_canvas_widget_test.cpp
+++ b/tests/workspace_canvas_widget_test.cpp
@@ -517,6 +517,71 @@ int main(int argc, char** argv)
             canvas.setGridSnapEnabled(false);
         }
 
+        // ── Red-team gaps: the locked posture under REAL events ──────────
+        // No prior test ever pressed a locked canvas — the bare widget
+        // defaults to editing and every press fixture inherited it (B2/m6/
+        // m7 were invisible to the whole suite).
+        {
+            canvas.addItem("locked:x", new QWidget, NormRect{0.1, 0.6, 0.2, 0.2});
+            canvas.addItem("locked:y", new QWidget, NormRect{0.15, 0.65, 0.2, 0.2});
+            const int zBefore = canvas.layout().zOf("locked:x");
+            canvas.setEditMode(false);
+            report("leaving edit clears the selection",
+                   canvas.selectedItem().isEmpty());
+
+            // A press that lands on the canvas (an item's dead space
+            // propagating) must not select, raise, or persist anything.
+            QMouseEvent press(QEvent::MouseButtonPress,
+                              QPointF(150, 650),
+                              canvas.mapToGlobal(QPointF(150, 650)),
+                              Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+            QCoreApplication::sendEvent(&canvas, &press);
+            report("a locked canvas ignores presses (B2)",
+                   canvas.selectedItem().isEmpty()
+                       && canvas.layout().zOf("locked:x") == zBefore);
+
+            canvas.setEditMode(true);
+            QMouseEvent mid(QEvent::MouseButtonPress,
+                            QPointF(150, 650),
+                            canvas.mapToGlobal(QPointF(150, 650)),
+                            Qt::MiddleButton, Qt::MiddleButton, Qt::NoModifier);
+            QCoreApplication::sendEvent(&canvas, &mid);
+            report("middle-click is not placement (m7)",
+                   canvas.selectedItem().isEmpty());
+
+            canvas.removeItem("locked:x");
+            canvas.removeItem("locked:y");
+        }
+
+        // ── Red-team M1: hit-test what the operator SEES ─────────────────
+        // Stored below the 160x90 display floor: the widget is drawn
+        // min-clamped, and a click inside the visible margin must select
+        // THE item, not whatever the stored rect leaves behind it.
+        {
+            canvas.addItem("tiny", new QWidget, NormRect{0.30, 0.30, 0.02, 0.02});
+            // stored: 300..320 x 300..320 on the 1000px canvas; display:
+            // 300..460 x 300..390 (160x90 floor).
+            report("a click in the clamp margin hits the visible item (M1)",
+                   canvas.hitTest(QPoint(440, 370)) == QStringLiteral("tiny"));
+            report("...and past the display edge misses it",
+                   canvas.hitTest(QPoint(470, 400)) != QStringLiteral("tiny"));
+            canvas.removeItem("tiny");
+        }
+
+        // ── Red-team M2: the write boundary refuses hostile rects ────────
+        {
+            canvas.addItem("guard", new QWidget, NormRect{0.5, 0.5, 0.2, 0.2});
+            const NormRect held = canvas.itemRect("guard");
+            report("setItemRect refuses a zero-size rect",
+                   !canvas.setItemRect("guard", NormRect{0.1, 0.1, 0.0, 0.0})
+                       && canvas.itemRect("guard") == held);
+            report("...and a non-finite one",
+                   !canvas.setItemRect("guard",
+                                       NormRect{std::nan(""), 0.1, 0.2, 0.2})
+                       && canvas.itemRect("guard") == held);
+            canvas.removeItem("guard");
+        }
+
         // Keyboard: arrows nudge, Shift+arrows resize, both announce a
         // gesture pair (undo hangs off it).
         canvas.selectItem("a");

--- a/tests/workspace_canvas_widget_test.cpp
+++ b/tests/workspace_canvas_widget_test.cpp
@@ -481,6 +481,42 @@ int main(int argc, char** argv)
                nearly(canvas.itemRect("a").x, 30.0 / 96.0));
         canvas.setGridSnapEnabled(false);
 
+        // A PAN ignores applet magnets and reaches the grid (8600 field
+        // report): with an applet layered on it whose left edge (324 px) is
+        // 3 px from the drop point, the pan must pass it by and land on the
+        // grid line at 31/96 (322.9 px, 1.9 px away) — peer capture would
+        // have beaten the grid for any other item type.  The applet keeps
+        // its pan magnetism: dropped 2.9 px from the pan's right edge, it
+        // captures the edge even though a grid line sits further inside
+        // its own magnet range.
+        {
+            canvas.setGridSnapEnabled(true);
+            auto* pan = new QWidget;
+            canvas.addItem("pan:0", pan, NormRect{0.20, 0.50, 0.30, 0.30},
+                           QStringLiteral("panadapter"));
+            canvas.addItem("applet:A", new QWidget,
+                           NormRect{0.324, 0.50, 0.20, 0.25});
+
+            canvas.beginMoveGesture("pan:0", origin);
+            canvas.moveGesture(origin + QPoint(121, 0));
+            canvas.endGesture(origin + QPoint(121, 0));
+            report("a pan passes applet edges and snaps to the grid",
+                   nearly(canvas.itemRect("pan:0").x, 31.0 / 96.0)
+                       && nearly(canvas.itemRect("pan:0").y, 0.5));
+
+            const double panRight = canvas.itemRect("pan:0").x
+                                    + canvas.itemRect("pan:0").w;
+            canvas.beginMoveGesture("applet:A", origin);
+            canvas.moveGesture(origin + QPoint(296, 0));
+            canvas.endGesture(origin + QPoint(296, 0));
+            report("an applet still snaps to the pan's edge",
+                   nearly(canvas.itemRect("applet:A").x, panRight));
+
+            canvas.removeItem("pan:0");
+            canvas.removeItem("applet:A");
+            canvas.setGridSnapEnabled(false);
+        }
+
         // Keyboard: arrows nudge, Shift+arrows resize, both announce a
         // gesture pair (undo hangs off it).
         canvas.selectItem("a");

--- a/tests/workspace_canvas_widget_test.cpp
+++ b/tests/workspace_canvas_widget_test.cpp
@@ -402,6 +402,12 @@ int main(int argc, char** argv)
         canvas.addItem("a", a, NormRect{0.1, 0.1, 0.4, 0.4});
         canvas.addItem("b", new QWidget, NormRect{0.6, 0.6, 0.3, 0.3});
 
+        // Grid snap off for this scenario: it pins the session mechanics
+        // (follow, cancel, drag-out, keyboard), and on a 1000 px test canvas
+        // the 96-division grid has a line within the magnet of nearly every
+        // hand-picked rect.  The grid tier has its own case below.
+        canvas.setGridSnapEnabled(false);
+
         QSignalSpy selSpy(&canvas, &WorkspaceCanvas::selectionChanged);
         QSignalSpy startSpy(&canvas, &WorkspaceCanvas::gestureStarted);
         QSignalSpy finishSpy(&canvas, &WorkspaceCanvas::gestureFinished);
@@ -464,13 +470,16 @@ int main(int argc, char** argv)
                nearly(canvas.itemRect("a").right(), 0.6));
 
         // The grid tier through a live gesture: from x=0.1, +213 px puts the
-        // origin at 0.313 — no peer line in reach, but 5/16 = 0.3125 is
-        // 0.0005 away — the move lands ON the grid line.
+        // origin at 0.313 — no peer line in reach, but 30/96 = 0.3125 is
+        // 0.0005 away, inside the 4 px grid magnet — the move lands ON the
+        // grid line.
+        canvas.setGridSnapEnabled(true);
         canvas.beginMoveGesture("a", origin);
         canvas.moveGesture(origin + QPoint(213, 0));
         canvas.endGesture(origin + QPoint(213, 0));
         report("a live move lands on the snap grid",
-               nearly(canvas.itemRect("a").x, 5.0 / 16.0));
+               nearly(canvas.itemRect("a").x, 30.0 / 96.0));
+        canvas.setGridSnapEnabled(false);
 
         // Keyboard: arrows nudge, Shift+arrows resize, both announce a
         // gesture pair (undo hangs off it).

--- a/tests/workspace_canvas_widget_test.cpp
+++ b/tests/workspace_canvas_widget_test.cpp
@@ -464,13 +464,13 @@ int main(int argc, char** argv)
                nearly(canvas.itemRect("a").right(), 0.6));
 
         // The grid tier through a live gesture: from x=0.1, +213 px puts the
-        // origin at 0.313 — no peer line in reach, but 10/32 = 0.3125 is
+        // origin at 0.313 — no peer line in reach, but 5/16 = 0.3125 is
         // 0.0005 away — the move lands ON the grid line.
         canvas.beginMoveGesture("a", origin);
         canvas.moveGesture(origin + QPoint(213, 0));
         canvas.endGesture(origin + QPoint(213, 0));
         report("a live move lands on the snap grid",
-               nearly(canvas.itemRect("a").x, 10.0 / 32.0));
+               nearly(canvas.itemRect("a").x, 5.0 / 16.0));
 
         // Keyboard: arrows nudge, Shift+arrows resize, both announce a
         // gesture pair (undo hangs off it).

--- a/tests/workspace_container_mode_test.cpp
+++ b/tests/workspace_container_mode_test.cpp
@@ -1,0 +1,205 @@
+// DockMode::Canvas at the ContainerManager level (RFC #4887 phase 3a).
+//
+// The transitions are deliberately the same two halves float/dock use —
+// detach-and-remember, restore-to-slot — so what is pinned here is the
+// contract the WorkspaceController builds on: a container comes BACK to the
+// slot it left (order preserved), a floating container docks before it goes
+// to canvas, leaving the canvas is routed through the evictor, and the
+// mode survives ContainerTree serialisation without breaking a downgrade.
+//
+// Offscreen, with a real AppSettings in a temporary home (saveState writes
+// ContainerTree through it).
+
+#include "TestSettingsProfile.h"
+
+#include "core/AppSettings.h"
+#include "gui/containers/ContainerManager.h"
+#include "gui/containers/ContainerWidget.h"
+
+#include <QApplication>
+#include <QLabel>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include <cstdio>
+#include <iostream>
+
+using AetherSDR::AppSettings;
+using AetherSDR::ContainerManager;
+using AetherSDR::ContainerWidget;
+
+namespace {
+
+int g_failures = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) {
+        ++g_failures;
+    }
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile profile(QStringLiteral("aether-workspace-container-mode-test"));
+    if (!profile.isValid()) {
+        std::cerr << "[FAIL] create temporary home\n";
+        return 1;
+    }
+    QApplication app(argc, argv);
+    AppSettings::instance().load();
+
+    // ── Detach and return, with the slot preserved ───────────────────────
+    {
+        QWidget panel;
+        auto* lay = new QVBoxLayout(&panel);
+        ContainerManager mgr(&panel);
+
+        auto* a = mgr.createContainer("A", "A");
+        auto* b = mgr.createContainer("B", "B");
+        a->setContent(new QLabel("a"));
+        b->setContent(new QLabel("b"));
+        lay->addWidget(a);
+        lay->addWidget(b);
+        panel.show();
+
+        report("a docked container detaches for the canvas",
+               mgr.detachForCanvas("A") == a);
+        report("...and reports canvas mode", a->isOnCanvas());
+        report("...and left the panel layout", lay->indexOf(a) < 0);
+        report("...leaving its sibling in place", lay->indexOf(b) == 0);
+
+        report("a container already on canvas is refused",
+               mgr.detachForCanvas("A") == nullptr);
+        report("an unknown id is refused", mgr.detachForCanvas("nope") == nullptr);
+
+        // The mode string reaches ContainerTree — the dual-write mirror.
+        const QString tree =
+            AppSettings::instance().value(QStringLiteral("ContainerTree")).toString();
+        report("the canvas mode serialises", tree.contains(QStringLiteral("\"canvas\"")));
+
+        mgr.returnFromCanvas("A", a);
+        report("returning restores panel mode", a->isPanelDocked());
+        report("...at the slot it left, not the end", lay->indexOf(a) == 0);
+        report("...with its sibling after it", lay->indexOf(b) == 1);
+
+        report("returning a container not on canvas is a no-op",
+               (mgr.returnFromCanvas("A", a), a->isPanelDocked() && lay->indexOf(a) == 0));
+    }
+
+    // ── The width cap lifts on canvas and comes back on return (#3451) ───
+    {
+        QWidget panel;
+        auto* lay = new QVBoxLayout(&panel);
+        ContainerManager mgr(&panel);
+
+        auto* c = mgr.createContainer("W", "W");
+        auto* content = new QLabel("w");
+        content->setMaximumWidth(260);   // the panel's fixed-column cap
+        c->setContent(content);
+        lay->addWidget(c);
+        panel.show();
+
+        mgr.detachForCanvas("W");
+        report("the docked width cap lifts on canvas",
+               content->maximumWidth() == QWIDGETSIZE_MAX);
+
+        mgr.returnFromCanvas("W", c);
+        report("...and is restored on return", content->maximumWidth() == 260);
+    }
+
+    // ── Floating containers dock before they reach the canvas ────────────
+    {
+        QWidget panel;
+        auto* lay = new QVBoxLayout(&panel);
+        ContainerManager mgr(&panel);
+
+        auto* c = mgr.createContainer("F", "F");
+        c->setContent(new QLabel("f"));
+        lay->addWidget(c);
+        panel.show();
+
+        mgr.floatContainer("F");
+        report("the container floats first", c->isFloating());
+
+        ContainerWidget* detached = mgr.detachForCanvas("F");
+        report("a floating container still detaches for canvas", detached == c);
+        report("...arriving in canvas mode, not floating",
+               c->isOnCanvas() && !c->isFloating());
+
+        mgr.returnFromCanvas("F", c);
+        report("...and still returns to its panel slot",
+               c->isPanelDocked() && lay->indexOf(c) == 0);
+    }
+
+    // ── Leaving the canvas goes through the evictor ──────────────────────
+    {
+        QWidget panel;
+        auto* lay = new QVBoxLayout(&panel);
+        ContainerManager mgr(&panel);
+
+        auto* c = mgr.createContainer("E", "E");
+        c->setContent(new QLabel("e"));
+        lay->addWidget(c);
+        panel.show();
+
+        int evictions = 0;
+        mgr.setCanvasEvictor([&](const QString& id) {
+            ++evictions;
+            // What the controller does: off the canvas, back to the panel.
+            if (ContainerWidget* cc = mgr.container(id)) {
+                mgr.returnFromCanvas(id, cc);
+            }
+        });
+
+        mgr.detachForCanvas("E");
+        report("the container is on canvas", c->isOnCanvas());
+
+        // Float-from-canvas: the evictor runs first, then the float proceeds
+        // from the restored panel slot — so the float records a REAL slot to
+        // dock back to.
+        mgr.floatContainer("E");
+        report("floating from canvas evicts first", evictions == 1);
+        report("...and the float then proceeds", c->isFloating());
+
+        mgr.dockContainer("E");
+        report("...and docking lands back in the panel slot",
+               c->isPanelDocked() && lay->indexOf(c) == 0);
+
+        // The title-bar "return to panel" button emits dockRequested; for a
+        // canvas container the manager routes that through the evictor too.
+        mgr.detachForCanvas("E");
+        QMetaObject::invokeMethod(c, "dockRequested");
+        report("a canvas dock request routes through the evictor",
+               evictions == 2 && c->isPanelDocked() && lay->indexOf(c) == 0);
+    }
+
+    // ── A stored "canvas" mode restores as panel-docked ──────────────────
+    //
+    // restoreState() runs before any canvas exists; the document re-places
+    // items when the mode is enabled.  A stored canvas mode must therefore
+    // land panel-docked, not crash and not float.
+    {
+        AppSettings::instance().setValue(
+            QStringLiteral("ContainerTree"),
+            QStringLiteral(R"({"version":1,"containers":{)"
+                           R"("R":{"mode":"canvas","visible":true,)"
+                           R"("contentType":"","parent":""}}})"));
+
+        QWidget panel;
+        new QVBoxLayout(&panel);
+        ContainerManager mgr(&panel);
+        mgr.restoreState();
+
+        ContainerWidget* r = mgr.container("R");
+        report("restore creates the container", r != nullptr);
+        report("a stored canvas mode restores as panel-docked",
+               r && r->isPanelDocked() && !r->isFloating());
+    }
+
+    std::printf("\n%s\n", g_failures == 0 ? "All checks passed." : "FAILURES present.");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/workspace_controller_test.cpp
+++ b/tests/workspace_controller_test.cpp
@@ -20,6 +20,7 @@
 #include "gui/containers/ContainerWidget.h"
 #include "gui/workspace/WorkspaceCanvas.h"
 #include "gui/workspace/WorkspaceController.h"
+#include "gui/workspace/ClassicLayout.h"
 #include "gui/workspace/WorkspaceStore.h"
 
 #include <QApplication>
@@ -31,6 +32,7 @@
 #include <QVBoxLayout>
 #include <QWidget>
 
+#include <cmath>
 #include <cstdio>
 #include <iostream>
 
@@ -53,6 +55,11 @@ void report(const char* name, bool ok)
     if (!ok) {
         ++g_failures;
     }
+}
+
+bool nearly(double a, double b, double tol = 1e-9)
+{
+    return std::fabs(a - b) <= tol;
 }
 
 QString storedDocument()
@@ -246,6 +253,81 @@ int main(int argc, char** argv)
                    WorkspaceStore probe;
                    return probe.load() && probe.document().canvasEnabled;
                }());
+        ctl.disable();
+    }
+
+    // ── Phase 5: undo, tidy, reset, drag-out return ──────────────────────
+    {
+        // RX forgot its canvas home in the float block above, so re-enable
+        // places only TX; send RX back explicitly.
+        report("re-enable for the phase 5 block",
+               ctl.enable({"RX", "TX"}) && tx->isOnCanvas()
+                   && ctl.sendAppletToCanvas("RX") && rx->isOnCanvas());
+
+        // The offscreen platform stacks every top-level at the same origin,
+        // which would make "over the panel" also "inside the canvas".  Pull
+        // them apart so global points are unambiguous.
+        canvas.window()->move(0, 0);
+        panel.window()->move(3000, 0);
+
+        // Undo restores the rect the last gesture started from; twice
+        // toggles (single-slot redo).
+        const NormRect before = canvas.itemRect("applet:RX");
+        const QPoint origin = canvas.mapToGlobal(QPoint(500, 400));
+        canvas.beginMoveGesture("applet:RX", origin);
+        canvas.moveGesture(origin + QPoint(120, 80));
+        canvas.endGesture(origin + QPoint(120, 80));
+        const NormRect after = canvas.itemRect("applet:RX");
+        report("a live gesture moved the item", !(after == before));
+
+        report("undo restores the pre-gesture rect",
+               ctl.undoLastPlacement()
+                   && canvas.itemRect("applet:RX") == before);
+        report("undo again toggles back (redo)",
+               ctl.undoLastPlacement()
+                   && canvas.itemRect("applet:RX") == after);
+
+        // Tidy: overlap TX onto RX, then resolve — TX pushed clear, sizes
+        // kept; panstack overlaps ignored throughout.
+        const NormRect rxRect = canvas.itemRect("applet:RX");
+        NormRect overlap = rxRect;
+        overlap.y += rxRect.h / 2.0;   // half-covering RX
+        canvas.setItemRect("applet:TX", overlap);
+        ctl.tidyLayout();
+        const NormRect txTidied = canvas.itemRect("applet:TX");
+        report("tidy pushes the overlapping applet clear",
+               txTidied.y >= rxRect.bottom() - 1e-9
+                   && nearly(txTidied.h, overlap.h));
+
+        // Reset to Classic: fresh column derived from the live legacy keys.
+        canvas.setItemRect("applet:RX", NormRect{0.05, 0.05, 0.3, 0.3});
+        ctl.resetToClassic();
+        report("reset places the applets back in the Classic column",
+               nearly(canvas.itemRect("applet:RX").x,
+                      1.0 - AetherSDR::kClassicAppletColumnWidth)
+                   && rx->isOnCanvas() && tx->isOnCanvas());
+        report("...and the pan area takes the remainder",
+               nearly(canvas.itemRect(WorkspaceController::kPanStackItemId).w,
+                      1.0 - AetherSDR::kClassicAppletColumnWidth));
+
+        // Drag-out over the panel returns the applet to it; a drag-out over
+        // nothing is an abort the canvas already restored.
+        ctl.setReturnTarget(&panel);
+        const QPoint overPanel = panel.mapToGlobal(QPoint(10, 10));
+        canvas.beginMoveGesture("applet:RX", origin);
+        canvas.moveGesture(origin + QPoint(50, 0));
+        canvas.endGesture(overPanel);
+        report("a release over the panel returns the applet",
+               rx->isPanelDocked() && !canvas.contains("applet:RX"));
+
+        const NormRect txBefore = canvas.itemRect("applet:TX");
+        canvas.beginMoveGesture("applet:TX", origin);
+        canvas.moveGesture(origin + QPoint(50, 0));
+        canvas.endGesture(canvas.mapToGlobal(QPoint(-500, -500)));
+        report("a release over nothing restores and stays",
+               tx->isOnCanvas() && canvas.itemRect("applet:TX") == txBefore);
+
+        ctl.sendAppletToCanvas("RX");
         ctl.disable();
     }
 

--- a/tests/workspace_controller_test.cpp
+++ b/tests/workspace_controller_test.cpp
@@ -165,6 +165,8 @@ int main(int argc, char** argv)
         QString whyNot;
         report("enable succeeds", ctl.enable({"RX", "TX"}, &whyNot));
         report("...and reports enabled", ctl.isEnabled());
+        report("the FIRST enable (migration) opens editing",
+               canvas.isEditMode());
 
         report("both applets are on the canvas",
                rx->isOnCanvas() && tx->isOnCanvas()
@@ -275,6 +277,8 @@ int main(int argc, char** argv)
 
         report("re-enable places from the kept document",
                ctl.enable({"RX", "TX"}) && tx->isOnCanvas());
+        report("...and comes up LOCKED (operating posture)",
+               !canvas.isEditMode());
         report("...and boot on a fresh controller now asks for the mode",
                [&] {
                    WorkspaceStore probe;
@@ -290,6 +294,19 @@ int main(int argc, char** argv)
         report("re-enable for the phase 5 block",
                ctl.enable({"RX", "TX"}) && tx->isOnCanvas()
                    && ctl.sendAppletToCanvas("RX") && rx->isOnCanvas());
+
+        // Locked first: a gesture must be refused outright (the edit-mode
+        // field request — interacting with an applet must not arm
+        // placement), then editing is entered for the rest of the block.
+        {
+            const NormRect held = canvas.itemRect("applet:RX");
+            canvas.beginMoveGesture("applet:RX",
+                                    canvas.mapToGlobal(QPoint(500, 400)));
+            report("a locked canvas arms no gesture",
+                   !canvas.gestureActive()
+                       && canvas.itemRect("applet:RX") == held);
+        }
+        canvas.setEditMode(true);
 
         // The offscreen platform stacks every top-level at the same origin,
         // which would make "over the panel" also "inside the canvas".  Pull
@@ -362,6 +379,7 @@ int main(int argc, char** argv)
     {
         report("re-enable for the phase 4 block",
                ctl.enable({"RX", "TX"}) && canvas.contains("pan:0"));
+        canvas.setEditMode(true);   // the block below arranges
 
         // A second pan arrives (radio granted `pan create`).
         auto* panB = new QWidget(&panOwner);

--- a/tests/workspace_controller_test.cpp
+++ b/tests/workspace_controller_test.cpp
@@ -27,6 +27,8 @@
 #include <QDragEnterEvent>
 #include <QDropEvent>
 #include <QLabel>
+#include <QMap>
+#include <QSet>
 #include <QMimeData>
 #include <QRect>
 #include <QVBoxLayout>
@@ -126,9 +128,33 @@ int main(int argc, char** argv)
     canvas.resize(1000, 800);
     canvas.show();
 
-    QWidget panStack;
+    // A stand-in pan host (phase 4): one live pan as a plain QWidget, hooks
+    // over little lambdas — the same seam MainWindow_Workspace wires over
+    // the real PanadapterStack, with none of its GPU baggage.
+    QWidget panOwner;
+    auto* panBox = new QVBoxLayout(&panOwner);
+    QMap<QString, QWidget*> pans;
+    QSet<QString> floatingPans;
+    auto* panA = new QWidget(&panOwner);
+    panBox->addWidget(panA);
+    pans.insert(QStringLiteral("0x40000000"), panA);
+    panOwner.show();
+
     WorkspaceController ctl(&mgr, &canvas);
-    ctl.setPanStackWidget(&panStack);
+    WorkspaceController::PanHostHooks hooks;
+    hooks.panIds = [&] { return QStringList(pans.keys()); };
+    hooks.detach = [&](const QString& id) -> QWidget* {
+        return floatingPans.contains(id) ? nullptr : pans.value(id, nullptr);
+    };
+    hooks.restore = [&](const QString& id, QWidget* w) {
+        Q_UNUSED(id);
+        panBox->addWidget(w);
+        w->show();
+    };
+    hooks.isFloating = [&](const QString& id) {
+        return floatingPans.contains(id);
+    };
+    ctl.setPanHost(hooks);
 
     // ── Boot before any document exists ──────────────────────────────────
     report("boot with nothing stored asks for nothing", !ctl.boot());
@@ -145,16 +171,16 @@ int main(int argc, char** argv)
                    && canvas.contains("applet:RX") && canvas.contains("applet:TX"));
         report("...and left the panel layout",
                panelLayout->indexOf(rx) < 0 && panelLayout->indexOf(tx) < 0);
-        report("the pan stack rides as the reserved item",
-               canvas.contains(WorkspaceController::kPanStackItemId)
-                   && panStack.parentWidget() == &canvas);
-        report("the reserved pan area sits behind the applets",
-               canvas.layout().zOf(WorkspaceController::kPanStackItemId) == 0);
+        report("the live pan rides as its slot item (phase 4)",
+               canvas.contains(QStringLiteral("pan:0"))
+                   && panA->parentWidget() == &canvas);
+        report("the pan sits behind the applets",
+               canvas.layout().zOf(QStringLiteral("pan:0")) == 0);
 
         const QString doc = storedDocument();
         report("the document was flushed with the mode on",
                doc.contains(QStringLiteral("canvasEnabled"))
-                   && doc.contains(QStringLiteral("panstack")));
+                   && doc.contains(QStringLiteral("pan:0")));
         report("the legacy keys survive (dual-write)",
                AppSettings::instance().contains(QStringLiteral("Applet_RX")));
 
@@ -236,8 +262,9 @@ int main(int argc, char** argv)
         report("every applet is back in the panel",
                rx->isPanelDocked() && tx->isPanelDocked()
                    && panelLayout->indexOf(tx) >= 0);
-        report("the pan stack is released parentless",
-               panStack.parentWidget() == nullptr);
+        report("the pan went back to its owner, one-step (never nullptr)",
+               panA->parentWidget() == &panOwner
+                   && !canvas.contains(QStringLiteral("pan:0")));
         report("the canvas is empty", canvas.itemCount() == 0);
 
         const QString doc = storedDocument();
@@ -306,8 +333,8 @@ int main(int argc, char** argv)
                nearly(canvas.itemRect("applet:RX").x,
                       1.0 - AetherSDR::kClassicAppletColumnWidth)
                    && rx->isOnCanvas() && tx->isOnCanvas());
-        report("...and the pan area takes the remainder",
-               nearly(canvas.itemRect(WorkspaceController::kPanStackItemId).w,
+        report("...and the pan slot takes the remainder",
+               nearly(canvas.itemRect(QStringLiteral("pan:0")).w,
                       1.0 - AetherSDR::kClassicAppletColumnWidth));
 
         // Drag-out over the panel returns the applet to it; a drag-out over
@@ -377,9 +404,9 @@ int main(int argc, char** argv)
         // The canvas exists but has never been laid out — 0x0, exactly the
         // constructor-time state.
         WorkspaceCanvas coldCanvas;
-        QWidget coldPanStack;
         WorkspaceController coldCtl(&mgr3, &coldCanvas);
-        coldCtl.setPanStackWidget(&coldPanStack);
+        // Deliberately NO pan host: the controller must behave with every
+        // hook unset (a MainWindow that never wired pans).
 
         report("boot sees the enabled flag", coldCtl.boot());
         report("enable succeeds against an unsized canvas",
@@ -402,8 +429,8 @@ int main(int argc, char** argv)
                px == QRect(800, 80, 160, 160));
         report("...while the stored rect keeps its exact size",
                coldCanvas.itemRect("applet:RX") == NormRect{0.8, 0.1, 0.15, 0.2});
-        report("the pan area is not full-canvas either",
-               coldCanvas.itemRect(WorkspaceController::kPanStackItemId).w < 0.9);
+        report("no pan items appear without a pan host",
+               coldCanvas.itemCount() == 1);
 
         coldCtl.disable();
     }

--- a/tests/workspace_controller_test.cpp
+++ b/tests/workspace_controller_test.cpp
@@ -371,6 +371,12 @@ int main(int argc, char** argv)
                canvas.contains("pan:1") && panB->parentWidget() == &canvas);
         report("...and its slot is persisted",
                storedDocument().contains(QStringLiteral("pan:1")));
+        report("...at the BACK — never over the operator's arrangement "
+               "(the 8600 field report)",
+               canvas.layout().zOf(QStringLiteral("pan:1"))
+                       < canvas.layout().zOf(QStringLiteral("applet:RX"))
+                   && canvas.layout().zOf(QStringLiteral("pan:1"))
+                          < canvas.layout().zOf(QStringLiteral("applet:TX")));
 
         // Float: the applet has been adopted elsewhere (here: simulated by
         // the flag); the entry is released, the document item survives.

--- a/tests/workspace_controller_test.cpp
+++ b/tests/workspace_controller_test.cpp
@@ -436,6 +436,21 @@ int main(int argc, char** argv)
                    && bandStack.parentWidget() == &panOwner
                    && !bandStack.isVisible());
 
+        // A z-poisoned document cannot resurrect a pan over the controls:
+        // force the pan frontmost (recording it), cycle the mode, and the
+        // replay must normalize pans back below everything (8600 report).
+        canvas.bringItemToFront(QStringLiteral("pan:1"));
+        report("poison recorded: the pan sits over the applets",
+               canvas.layout().zOf(QStringLiteral("pan:1"))
+                   > canvas.layout().zOf(QStringLiteral("applet:RX")));
+        ctl.disable();
+        report("re-enable normalizes pans back to the bottom",
+               ctl.enable({"RX", "TX"})
+                   && canvas.layout().zOf(QStringLiteral("pan:1"))
+                          < canvas.layout().zOf(QStringLiteral("applet:RX"))
+                   && canvas.layout().zOf(QStringLiteral("pan:1"))
+                          < canvas.layout().zOf(QStringLiteral("applet:TX")));
+
         ctl.onPanRemoved(QStringLiteral("0x40000002"));
         pans.remove(QStringLiteral("0x40000002"));
         ctl.disable();

--- a/tests/workspace_controller_test.cpp
+++ b/tests/workspace_controller_test.cpp
@@ -358,6 +358,83 @@ int main(int argc, char** argv)
         ctl.disable();
     }
 
+    // ── Phase 4: pan lifecycle through the hooks seam ────────────────────
+    {
+        report("re-enable for the phase 4 block",
+               ctl.enable({"RX", "TX"}) && canvas.contains("pan:0"));
+
+        // A second pan arrives (radio granted `pan create`).
+        auto* panB = new QWidget(&panOwner);
+        pans.insert(QStringLiteral("0x40000001"), panB);
+        ctl.onPanAdded(QStringLiteral("0x40000001"));
+        report("a new pan is placed as the next slot",
+               canvas.contains("pan:1") && panB->parentWidget() == &canvas);
+        report("...and its slot is persisted",
+               storedDocument().contains(QStringLiteral("pan:1")));
+
+        // Float: the applet has been adopted elsewhere (here: simulated by
+        // the flag); the entry is released, the document item survives.
+        const NormRect homeB = canvas.itemRect("pan:1");
+        floatingPans.insert(QStringLiteral("0x40000001"));
+        ctl.onPanFloated(QStringLiteral("0x40000001"));
+        report("a floated pan leaves the canvas",
+               !canvas.contains("pan:1"));
+        report("...keeping its document home",
+               storedDocument().contains(QStringLiteral("pan:1")));
+
+        // Dock: back to the very spot.
+        floatingPans.remove(QStringLiteral("0x40000001"));
+        ctl.onPanDocked(QStringLiteral("0x40000001"));
+        report("docking returns the pan to its canvas home",
+               canvas.contains("pan:1") && canvas.itemRect("pan:1") == homeB);
+
+        // Rekey (FLEX band recall): same applet, new id, slot follows.
+        ctl.onPanRekeyed(QStringLiteral("0x40000001"),
+                         QStringLiteral("0x40000005"));
+        pans.insert(QStringLiteral("0x40000005"),
+                    pans.take(QStringLiteral("0x40000001")));
+        report("a rekeyed pan keeps its slot item",
+               ctl.panItemIdFor(QStringLiteral("0x40000005"))
+                       == QStringLiteral("pan:1")
+                   && canvas.contains("pan:1"));
+
+        // Remove: entry released pre-destruction, slot freed for reuse,
+        // document item kept.
+        ctl.onPanRemoved(QStringLiteral("0x40000005"));
+        pans.remove(QStringLiteral("0x40000005"));
+        report("a removed pan releases its entry",
+               !canvas.contains("pan:1"));
+        report("...but the document keeps the slot",
+               storedDocument().contains(QStringLiteral("pan:1")));
+
+        auto* panC = new QWidget(&panOwner);
+        pans.insert(QStringLiteral("0x40000002"), panC);
+        ctl.onPanAdded(QStringLiteral("0x40000002"));
+        report("the freed slot is reused, at its remembered rect",
+               canvas.contains("pan:1") && canvas.itemRect("pan:1") == homeB);
+
+        // Band stack: hosted as its own item while the mode is on.
+        QWidget bandStack(&panOwner);
+        hooks.bandStack        = [&]() -> QWidget* { return &bandStack; };
+        hooks.reclaimBandStack = [&](QWidget* w) {
+            w->setParent(&panOwner);
+        };
+        ctl.setPanHost(hooks);
+        ctl.setBandStackVisible(true);
+        report("the band stack becomes a canvas item",
+               canvas.contains(WorkspaceController::kBandStackItemId)
+                   && bandStack.parentWidget() == &canvas);
+        ctl.setBandStackVisible(false);
+        report("...and hiding re-homes it",
+               !canvas.contains(WorkspaceController::kBandStackItemId)
+                   && bandStack.parentWidget() == &panOwner
+                   && !bandStack.isVisible());
+
+        ctl.onPanRemoved(QStringLiteral("0x40000002"));
+        pans.remove(QStringLiteral("0x40000002"));
+        ctl.disable();
+    }
+
     // ── The field report: boot replay against a pre-layout canvas ────────
     //
     // The bug as reported: enable ran in the MainWindow constructor before

--- a/tests/workspace_controller_test.cpp
+++ b/tests/workspace_controller_test.cpp
@@ -1,0 +1,281 @@
+// WorkspaceController — canvas mode end to end (RFC #4887 phase 3), against
+// a real store, canvas and container manager in a temporary home.
+//
+// The contract under test is the membership rule stated in the controller's
+// header: a document item means "belongs on the canvas"; placement requires
+// mode-on + open + not-floating.  The cases that matter most:
+//
+//   * an explicit return FORGETS the canvas home (no bounce-back through the
+//     dockModeChanged hook), while closing an applet KEEPS it;
+//   * first enable migrates the legacy keys and starts dual-write — and a
+//     store refusing (newer-schema write block, PR #4900 H1) fails the
+//     enable cleanly instead of moving a single widget;
+//   * disable returns every widget yet keeps every item, so re-enable
+//     restores the arrangement.
+
+#include "TestSettingsProfile.h"
+
+#include "core/AppSettings.h"
+#include "gui/containers/ContainerManager.h"
+#include "gui/containers/ContainerWidget.h"
+#include "gui/workspace/WorkspaceCanvas.h"
+#include "gui/workspace/WorkspaceController.h"
+#include "gui/workspace/WorkspaceStore.h"
+
+#include <QApplication>
+#include <QDragEnterEvent>
+#include <QDropEvent>
+#include <QLabel>
+#include <QMimeData>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include <cstdio>
+#include <iostream>
+
+using AetherSDR::AppSettings;
+using AetherSDR::ContainerManager;
+using AetherSDR::ContainerWidget;
+using AetherSDR::NormRect;
+using AetherSDR::WorkspaceCanvas;
+using AetherSDR::WorkspaceController;
+using AetherSDR::WorkspaceStore;
+
+namespace {
+
+int g_failures = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) {
+        ++g_failures;
+    }
+}
+
+QString storedDocument()
+{
+    QString value;
+    if (!AppSettings::instance().readStationRowFromDisk(
+            WorkspaceStore::kSettingsKey, value)) {
+        return {};
+    }
+    return value;
+}
+
+// A drop of the applet MIME at a canvas position, exactly as Qt would
+// deliver it — this exercises the canvas's real drop path, not a shortcut
+// into the controller.
+void dropOnCanvas(WorkspaceCanvas* canvas, const QString& payload, QPointF norm)
+{
+    QMimeData mime;
+    mime.setData(QStringLiteral("application/x-aethersdr-applet"),
+                 payload.toUtf8());
+    const QPointF pos(norm.x() * canvas->width(), norm.y() * canvas->height());
+
+    QDragEnterEvent enter(pos.toPoint(), Qt::MoveAction, &mime,
+                          Qt::LeftButton, Qt::NoModifier);
+    QApplication::sendEvent(canvas, &enter);
+    QDropEvent drop(pos, Qt::MoveAction, &mime, Qt::LeftButton, Qt::NoModifier);
+    QApplication::sendEvent(canvas, &drop);
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile profile(QStringLiteral("aether-workspace-controller-test"));
+    if (!profile.isValid()) {
+        std::cerr << "[FAIL] create temporary home\n";
+        return 1;
+    }
+    QApplication app(argc, argv);
+    AppSettings::instance().load();
+
+    // Legacy keys the first enable migrates from.
+    AppSettings::instance().setValue(QStringLiteral("Applet_RX"), QStringLiteral("True"));
+    AppSettings::instance().setValue(QStringLiteral("Applet_TX"), QStringLiteral("True"));
+    AppSettings::instance().setValue(QStringLiteral("AppletOrder"), QStringLiteral("RX,TX"));
+
+    // The world: a stand-in panel, two applet containers, a canvas, and the
+    // pan stack widget the reserved item hosts.
+    QWidget panel;
+    auto* panelLayout = new QVBoxLayout(&panel);
+    ContainerManager mgr(&panel);
+
+    auto* rx = mgr.createContainer("RX", "RX Controls");
+    auto* tx = mgr.createContainer("TX", "TX Controls");
+    rx->setContent(new QLabel("rx"));
+    tx->setContent(new QLabel("tx"));
+    panelLayout->addWidget(rx);
+    panelLayout->addWidget(tx);
+    rx->setContainerVisible(true);
+    tx->setContainerVisible(true);
+    panel.show();
+
+    WorkspaceCanvas canvas;
+    canvas.resize(1000, 800);
+    canvas.show();
+
+    QWidget panStack;
+    WorkspaceController ctl(&mgr, &canvas);
+    ctl.setPanStackWidget(&panStack);
+
+    // ── Boot before any document exists ──────────────────────────────────
+    report("boot with nothing stored asks for nothing", !ctl.boot());
+    report("...and wrote no document", storedDocument().isEmpty());
+
+    // ── First enable: migrate + place ────────────────────────────────────
+    {
+        QString whyNot;
+        report("enable succeeds", ctl.enable({"RX", "TX"}, &whyNot));
+        report("...and reports enabled", ctl.isEnabled());
+
+        report("both applets are on the canvas",
+               rx->isOnCanvas() && tx->isOnCanvas()
+                   && canvas.contains("applet:RX") && canvas.contains("applet:TX"));
+        report("...and left the panel layout",
+               panelLayout->indexOf(rx) < 0 && panelLayout->indexOf(tx) < 0);
+        report("the pan stack rides as the reserved item",
+               canvas.contains(WorkspaceController::kPanStackItemId)
+                   && panStack.parentWidget() == &canvas);
+        report("the reserved pan area sits behind the applets",
+               canvas.layout().zOf(WorkspaceController::kPanStackItemId) == 0);
+
+        const QString doc = storedDocument();
+        report("the document was flushed with the mode on",
+               doc.contains(QStringLiteral("canvasEnabled"))
+                   && doc.contains(QStringLiteral("panstack")));
+        report("the legacy keys survive (dual-write)",
+               AppSettings::instance().contains(QStringLiteral("Applet_RX")));
+
+        report("enable twice is a no-op", ctl.enable({"RX", "TX"}));
+    }
+
+    // ── Explicit return forgets the home ─────────────────────────────────
+    {
+        report("an applet returns to the panel", ctl.returnAppletToPanel("RX"));
+        report("...panel-docked, in its old slot",
+               rx->isPanelDocked() && panelLayout->indexOf(rx) == 0);
+        report("...off the canvas", !canvas.contains("applet:RX"));
+        report("...and its home is forgotten",
+               !storedDocument().contains(QStringLiteral("applet:RX")));
+        report("returning it again fails", !ctl.returnAppletToPanel("RX"));
+
+        report("sending it back works", ctl.sendAppletToCanvas("RX"));
+        report("...and the home is recorded again",
+               storedDocument().contains(QStringLiteral("applet:RX")));
+    }
+
+    // ── Closing keeps the home; reopening returns to it ──────────────────
+    {
+        const NormRect before = canvas.itemRect("applet:TX");
+
+        tx->setContainerVisible(false);
+        report("a closed applet leaves the canvas",
+               !canvas.contains("applet:TX") && tx->isPanelDocked());
+        report("...but keeps its home",
+               storedDocument().contains(QStringLiteral("applet:TX")));
+
+        tx->setContainerVisible(true);
+        report("reopening returns it to the canvas", tx->isOnCanvas());
+        report("...at the rect it had",
+               canvas.itemRect("applet:TX") == before);
+    }
+
+    // ── Drops: move an item, place a panel applet ────────────────────────
+    {
+        dropOnCanvas(&canvas, "applet-move-check", QPointF(0.5, 0.5));
+        report("a drop naming nothing does nothing",
+               canvas.itemCount() == 3);
+
+        const NormRect before = canvas.itemRect("applet:RX");
+        dropOnCanvas(&canvas, "RX", QPointF(0.4, 0.6));
+        const NormRect after = canvas.itemRect("applet:RX");
+        report("dropping a canvas item moves it",
+               after.w == before.w && after.h == before.h
+                   && !(after == before));
+        report("...centred on the drop point",
+               qAbs((after.x + after.w / 2.0) - 0.4) < 0.01
+                   && qAbs((after.y + after.h / 2.0) - 0.6) < 0.01);
+        report("...and the move is persisted",
+               storedDocument().contains(QStringLiteral("applet:RX")));
+
+        ctl.returnAppletToPanel("RX");
+        dropOnCanvas(&canvas, "RX", QPointF(0.3, 0.3));
+        report("dropping a panel applet places it",
+               rx->isOnCanvas() && canvas.contains("applet:RX"));
+    }
+
+    // ── Float from the canvas: evicted, home forgotten ───────────────────
+    {
+        mgr.floatContainer("RX");
+        report("a canvas applet can float", rx->isFloating());
+        report("...leaving the canvas", !canvas.contains("applet:RX"));
+        report("...and forgetting its home",
+               !storedDocument().contains(QStringLiteral("applet:RX")));
+
+        mgr.dockContainer("RX");
+        report("docking after a canvas float lands in the panel, not the canvas",
+               rx->isPanelDocked() && !rx->isOnCanvas());
+    }
+
+    // ── Disable: everything returns, placement is kept ───────────────────
+    {
+        ctl.disable();
+        report("disable reports disabled", !ctl.isEnabled());
+        report("every applet is back in the panel",
+               rx->isPanelDocked() && tx->isPanelDocked()
+                   && panelLayout->indexOf(tx) >= 0);
+        report("the pan stack is released parentless",
+               panStack.parentWidget() == nullptr);
+        report("the canvas is empty", canvas.itemCount() == 0);
+
+        const QString doc = storedDocument();
+        report("the mode is off on disk",
+               !doc.contains(QStringLiteral("canvasEnabled")));
+        report("...but placement is kept for re-enable",
+               doc.contains(QStringLiteral("applet:TX")));
+
+        report("re-enable places from the kept document",
+               ctl.enable({"RX", "TX"}) && tx->isOnCanvas());
+        report("...and boot on a fresh controller now asks for the mode",
+               [&] {
+                   WorkspaceStore probe;
+                   return probe.load() && probe.document().canvasEnabled;
+               }());
+        ctl.disable();
+    }
+
+    // ── An unusable store fails the enable cleanly ───────────────────────
+    {
+        AppSettings::instance().setStationValue(WorkspaceStore::kSettingsKey,
+                                                QStringLiteral("{ corrupt"));
+        AppSettings::instance().save();
+
+        WorkspaceCanvas canvas2;
+        canvas2.resize(800, 600);
+        canvas2.show();
+        QWidget panel2;
+        auto* lay2 = new QVBoxLayout(&panel2);
+        ContainerManager mgr2(&panel2);
+        auto* solo = mgr2.createContainer("SOLO", "Solo");
+        solo->setContent(new QLabel("s"));
+        lay2->addWidget(solo);
+        solo->setContainerVisible(true);
+        panel2.show();
+
+        WorkspaceController ctl2(&mgr2, &canvas2);
+        QString whyNot;
+        report("enable against a corrupt store fails",
+               !ctl2.enable({"SOLO"}, &whyNot));
+        report("...and says why", !whyNot.isEmpty());
+        report("...moving nothing",
+               solo->isPanelDocked() && canvas2.itemCount() == 0);
+        report("...and the corrupt document is untouched (write block)",
+               storedDocument() == QStringLiteral("{ corrupt"));
+    }
+
+    std::printf("\n%s\n", g_failures == 0 ? "All checks passed." : "FAILURES present.");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/workspace_controller_test.cpp
+++ b/tests/workspace_controller_test.cpp
@@ -27,6 +27,7 @@
 #include <QDropEvent>
 #include <QLabel>
 #include <QMimeData>
+#include <QRect>
 #include <QVBoxLayout>
 #include <QWidget>
 
@@ -39,6 +40,7 @@ using AetherSDR::ContainerWidget;
 using AetherSDR::NormRect;
 using AetherSDR::WorkspaceCanvas;
 using AetherSDR::WorkspaceController;
+using AetherSDR::WorkspaceDocument;
 using AetherSDR::WorkspaceStore;
 
 namespace {
@@ -245,6 +247,83 @@ int main(int argc, char** argv)
                    return probe.load() && probe.document().canvasEnabled;
                }());
         ctl.disable();
+    }
+
+    // ── The field report: boot replay against a pre-layout canvas ────────
+    //
+    // The bug as reported: enable ran in the MainWindow constructor before
+    // the first layout pass, the canvas had no real geometry, every item was
+    // clamped to full-surface to satisfy pixel minimums, and the whole
+    // session displayed one applet covering everything.  The stored document
+    // survived only because the replay guard refused to write the wreckage
+    // back.  Pinned here: a replay against a degenerate canvas must leave
+    // stored rects untouched AND the display must recover on the first real
+    // resize.
+    {
+        AppSettings::instance().removeStationValue(WorkspaceStore::kSettingsKey);
+        AppSettings::instance().save();
+        {
+            // Author a document with a small applet rect, as the operator's
+            // session did.
+            WorkspaceStore author;
+            bool migrated = false;
+            author.loadOrMigrate({"RX", "TX"}, {}, &migrated);
+            WorkspaceDocument doc = author.document();
+            for (auto& ws : doc.workspaces) {
+                for (auto& surf : ws.surfaces) {
+                    for (auto& it : surf.items) {
+                        if (it.id == QStringLiteral("applet:RX")) {
+                            it.rect = NormRect{0.8, 0.1, 0.15, 0.2};
+                        }
+                    }
+                }
+            }
+            doc.canvasEnabled = true;
+            author.setDocument(doc);
+            author.flush();
+        }
+
+        QWidget panel3;
+        auto* lay3 = new QVBoxLayout(&panel3);
+        ContainerManager mgr3(&panel3);
+        auto* rx3 = mgr3.createContainer("RX", "RX");
+        rx3->setContent(new QLabel("rx"));
+        lay3->addWidget(rx3);
+        rx3->setContainerVisible(true);
+        panel3.show();
+
+        // The canvas exists but has never been laid out — 0x0, exactly the
+        // constructor-time state.
+        WorkspaceCanvas coldCanvas;
+        QWidget coldPanStack;
+        WorkspaceController coldCtl(&mgr3, &coldCanvas);
+        coldCtl.setPanStackWidget(&coldPanStack);
+
+        report("boot sees the enabled flag", coldCtl.boot());
+        report("enable succeeds against an unsized canvas",
+               coldCtl.enable({"RX", "TX"}));
+
+        report("the stored rect survives the cold replay",
+               coldCanvas.itemRect("applet:RX") == NormRect{0.8, 0.1, 0.15, 0.2});
+        report("...and on disk too",
+               storedDocument().contains(QStringLiteral("0.8")));
+
+        // First real layout: the display lands where the document says.
+        coldCanvas.resize(1000, 800);
+        coldCanvas.show();
+        QCoreApplication::processEvents();
+        const QRect px = coldCanvas.itemWidget("applet:RX")->geometry();
+        // 0.15 x 1000 = 150 px sits under the 160 px display floor, so the
+        // VIEW widens to the floor — while the stored rect stays 0.15.
+        // That split is the fix: display compromises, the document never does.
+        report("the first real resize shows the arrangement, not wreckage",
+               px == QRect(800, 80, 160, 160));
+        report("...while the stored rect keeps its exact size",
+               coldCanvas.itemRect("applet:RX") == NormRect{0.8, 0.1, 0.15, 0.2});
+        report("the pan area is not full-canvas either",
+               coldCanvas.itemRect(WorkspaceController::kPanStackItemId).w < 0.9);
+
+        coldCtl.disable();
     }
 
     // ── An unusable store fails the enable cleanly ───────────────────────

--- a/tests/workspace_controller_test.cpp
+++ b/tests/workspace_controller_test.cpp
@@ -436,6 +436,20 @@ int main(int argc, char** argv)
                    && bandStack.parentWidget() == &panOwner
                    && !bandStack.isVisible());
 
+        // A reclaimed widget cannot hide behind a healthy model: steal the
+        // pan back to its owner behind the canvas's back (what the stack's
+        // rebuild paths did in the 8600 field report), and the next
+        // placement request must heal — drop the stale entry, re-detach,
+        // re-place — rather than trust contains().
+        panBox->addWidget(pans.value(QStringLiteral("0x40000002")));   // theft
+        report("the model still claims the stolen pan",
+               canvas.contains("pan:1"));
+        ctl.onPanDocked(QStringLiteral("0x40000002"));
+        report("a placement request heals a stolen pan",
+               canvas.contains("pan:1")
+                   && pans.value(QStringLiteral("0x40000002"))->parentWidget()
+                          == &canvas);
+
         // A z-poisoned document cannot resurrect a pan over the controls:
         // force the pan frontmost (recording it), cycle the mode, and the
         // replay must normalize pans back below everything (8600 report).

--- a/tests/workspace_controller_test.cpp
+++ b/tests/workspace_controller_test.cpp
@@ -437,6 +437,31 @@ int main(int argc, char** argv)
         report("the freed slot is reused, at its remembered rect",
                canvas.contains("pan:1") && canvas.itemRect("pan:1") == homeB);
 
+        // Two pans with NO stored slot rect must not stack pixel-identical
+        // (red-team B3): defaults cascade, and a deliberate new pan sits
+        // above the older pans while staying below every applet.
+        {
+            auto* panD = new QWidget(&panOwner);
+            auto* panE = new QWidget(&panOwner);
+            pans.insert(QStringLiteral("0x40000010"), panD);
+            pans.insert(QStringLiteral("0x40000011"), panE);
+            // Fresh slots -> no document rect for either.
+            ctl.onPanAdded(QStringLiteral("0x40000010"));
+            ctl.onPanAdded(QStringLiteral("0x40000011"));
+            const QString dId = ctl.panItemIdFor(QStringLiteral("0x40000010"));
+            const QString eId = ctl.panItemIdFor(QStringLiteral("0x40000011"));
+            report("defaulted pans cascade to distinct rects (B3)",
+                   canvas.itemRect(dId).x != canvas.itemRect(eId).x);
+            report("...the newer sits above the older, below the applets",
+                   canvas.layout().zOf(eId) > canvas.layout().zOf(dId)
+                       && canvas.layout().zOf(eId)
+                              < canvas.layout().zOf(QStringLiteral("applet:RX")));
+            ctl.onPanRemoved(QStringLiteral("0x40000010"));
+            ctl.onPanRemoved(QStringLiteral("0x40000011"));
+            pans.remove(QStringLiteral("0x40000010"));
+            pans.remove(QStringLiteral("0x40000011"));
+        }
+
         // Band stack: hosted as its own item while the mode is on.
         QWidget bandStack(&panOwner);
         hooks.bandStack        = [&]() -> QWidget* { return &bandStack; };

--- a/tests/workspace_document_test.cpp
+++ b/tests/workspace_document_test.cpp
@@ -353,6 +353,24 @@ int main()
         report("...and says so", !warnings.isEmpty());
     }
 
+    // ── canvasEnabled round trip (phase 3) ───────────────────────────────
+    {
+        WorkspaceDocument off = sample();
+        report("canvasEnabled defaults to false", !off.canvasEnabled);
+
+        WorkspaceDocument offParsed;
+        WorkspaceDocument::fromStoredJson(off.toStoredJson(), &offParsed);
+        report("...and false is absent from the stored form",
+               !off.toStoredJson().contains("canvasEnabled")
+                   && !offParsed.canvasEnabled);
+
+        WorkspaceDocument on = sample();
+        on.canvasEnabled = true;
+        WorkspaceDocument onParsed;
+        WorkspaceDocument::fromStoredJson(on.toStoredJson(), &onParsed);
+        report("canvasEnabled survives a round trip", onParsed.canvasEnabled);
+    }
+
     // ── Binding lookup ───────────────────────────────────────────────────
     {
         const WorkspaceDocument doc = sample();

--- a/tests/workspace_geometry_test.cpp
+++ b/tests/workspace_geometry_test.cpp
@@ -19,6 +19,7 @@
 #include <limits>
 
 using AetherSDR::NormRect;
+using AetherSDR::clampToBounds;
 using AetherSDR::clampToCanvas;
 using AetherSDR::fromPixels;
 using AetherSDR::minimumNormSize;
@@ -176,6 +177,27 @@ int main()
         report("an item pushed past the origin slides back",
                nearly(neg.x, 0.0) && nearly(neg.y, 0.0)
                    && nearly(neg.w, 0.4) && nearly(neg.h, 0.4));
+    }
+
+    // ── Case 6b: the bounds clamp — canvas-independent, growth-free ──────
+    //
+    // The model's only clamp.  Its whole point is that it CANNOT depend on
+    // how big the canvas happens to be: growing stored rects to meet pixel
+    // minimums against a transient startup size is how a real arrangement
+    // was once displayed as full-canvas wreckage (phase 3 field report).
+    {
+        report("bounds clamp slides an overshoot back, keeping size",
+               clampToBounds(NormRect{0.9, 0.0, 0.3, 0.3})
+                   == NormRect{0.7, 0.0, 0.3, 0.3});
+        report("bounds clamp never grows a small rect",
+               clampToBounds(NormRect{0.4, 0.4, 0.01, 0.01})
+                   == NormRect{0.4, 0.4, 0.01, 0.01});
+        report("bounds clamp caps an oversized rect at the surface",
+               clampToBounds(NormRect{-0.5, 0.2, 1.7, 0.5})
+                   == NormRect{0.0, 0.2, 1.0, 0.5});
+        const double nan = std::numeric_limits<double>::quiet_NaN();
+        report("bounds clamp rejects a non-finite rect",
+               clampToBounds(NormRect{nan, 0.0, 0.5, 0.5}) == NormRect{});
     }
 
     // ── Case 7: minimum size ─────────────────────────────────────────────

--- a/tests/workspace_interaction_test.cpp
+++ b/tests/workspace_interaction_test.cpp
@@ -222,6 +222,54 @@ int main()
                s.rect.w >= minN.width() - 1e-12);
     }
 
+    // ── Snap: the grid tier ──────────────────────────────────────────────
+    {
+        const double tol = 0.02;
+        const QList<NormRect> noPeers;
+        const QList<NormRect> peers{NormRect{0.0, 0.0, 0.5, 0.5}};
+
+        // With no peers in reach, a 32-division grid captures: left edge at
+        // 0.255 → 8/32 = 0.25.
+        NormRect moved{0.255, 0.7, 0.2, 0.2};
+        auto s = snapRect(moved, HitZone::Move, noPeers, tol, tol, minN, 32, 18);
+        report("the grid captures when no peer is in reach",
+               nearly(s.rect.x, 0.25) && s.verticalGuides == QList<double>{0.25});
+
+        // A peer edge inside tolerance BEATS a nearer grid line: right edge
+        // at 0.507 — grid line 0.5 is 0.007 away, but so is the peer's right
+        // edge at 0.5... make them differ: peer right = 0.5, grid 16/32 =
+        // 0.5 identical.  Use x: item left at 0.515; peer.right = 0.5
+        // (0.015 away), grid 17/32 = 0.53125 (0.016 away) — both in tol,
+        // peer wins even though grid competes.
+        moved = NormRect{0.515, 0.7, 0.2, 0.2};
+        s = snapRect(moved, HitZone::Move, peers, tol, tol, minN, 32, 18);
+        report("a peer edge beats the grid when both are reachable",
+               nearly(s.rect.x, 0.5));
+
+        // The stronger claim: the peer wins even when the GRID is NEARER.
+        // Left edge at 0.53: grid 0.53125 is 0.00125 away, peer.right 0.5 is
+        // 0.03 away — out of tol... shrink the gap: left edge 0.512 → peer
+        // 0.012, grid 17/32 dist 0.019 — peer nearer anyway.  Construct
+        // nearer-grid: left 0.525 → grid 0.00625, peer 0.025 — both in tol
+        // (0.03): peer STILL wins by tier.
+        s = snapRect(NormRect{0.525, 0.7, 0.2, 0.2}, HitZone::Move, peers,
+                     0.03, 0.03, minN, 32, 18);
+        report("the peer tier wins even when a grid line is nearer",
+               nearly(s.rect.x, 0.5));
+
+        // Grid disabled: 0.255 stays free.
+        s = snapRect(NormRect{0.255, 0.7, 0.2, 0.2}, HitZone::Move, noPeers,
+                     tol, tol, minN, 0, 0);
+        report("grid zero disables the grid tier",
+               nearly(s.rect.x, 0.255) && s.verticalGuides.isEmpty());
+
+        // Resize: the gripped edge lands on a grid line, anchor untouched.
+        s = snapRect(NormRect{0.3, 0.5, 0.257, 0.2}, HitZone::E, noPeers,
+                     tol, tol, minN, 32, 18);
+        report("a resize snaps its gripped edge to the grid",
+               nearly(s.rect.right(), 0.5625) && nearly(s.rect.x, 0.3));
+    }
+
     // ── Tidy ─────────────────────────────────────────────────────────────
     {
         using AetherSDR::CanvasItem;

--- a/tests/workspace_interaction_test.cpp
+++ b/tests/workspace_interaction_test.cpp
@@ -228,34 +228,30 @@ int main()
         const QList<NormRect> noPeers;
         const QList<NormRect> peers{NormRect{0.0, 0.0, 0.5, 0.5}};
 
-        // With no peers in reach, a 32-division grid captures: left edge at
-        // 0.255 → 8/32 = 0.25.
+        // With no peers in reach, the 96-division grid captures: left edge
+        // at 0.255 → 24/96 = 0.25 (0.005 away; 25/96 is 0.0054 — the nearer
+        // line wins).
         NormRect moved{0.255, 0.7, 0.2, 0.2};
-        auto s = snapRect(moved, HitZone::Move, noPeers, tol, tol, minN, 32, 18);
+        auto s = snapRect(moved, HitZone::Move, noPeers, tol, tol, minN, 96, 54);
         report("the grid captures when no peer is in reach",
                nearly(s.rect.x, 0.25) && s.verticalGuides == QList<double>{0.25});
 
-        // A peer edge inside tolerance BEATS a nearer grid line: right edge
-        // at 0.507 — grid line 0.5 is 0.007 away, but so is the peer's right
-        // edge at 0.5... make them differ: peer right = 0.5, grid 16/32 =
-        // 0.5 identical.  Use x: item left at 0.515; peer.right = 0.5
-        // (0.015 away), grid 17/32 = 0.53125 (0.016 away) — both in tol,
-        // peer wins even though grid competes.
+        // A peer edge beats the grid even though a grid line is NEARER at
+        // this density: item left at 0.515 — grid 49/96 = 0.5104 is 0.0046
+        // away, the peer's right edge at 0.5 is 0.015 — the peer tier wins.
         moved = NormRect{0.515, 0.7, 0.2, 0.2};
-        s = snapRect(moved, HitZone::Move, peers, tol, tol, minN, 32, 18);
+        s = snapRect(moved, HitZone::Move, peers, tol, tol, minN, 96, 54);
         report("a peer edge beats the grid when both are reachable",
                nearly(s.rect.x, 0.5));
 
-        // The stronger claim: the peer wins even when the GRID is NEARER.
-        // Left edge at 0.53: grid 0.53125 is 0.00125 away, peer.right 0.5 is
-        // 0.03 away — out of tol... shrink the gap: left edge 0.512 → peer
-        // 0.012, grid 17/32 dist 0.019 — peer nearer anyway.  Construct
-        // nearer-grid: left 0.525 → grid 0.00625, peer 0.025 — both in tol
-        // (0.03): peer STILL wins by tier.
-        s = snapRect(NormRect{0.525, 0.7, 0.2, 0.2}, HitZone::Move, peers,
-                     0.03, 0.03, minN, 32, 18);
+        // Same claim, wider tolerance, constructed peer: peer right edge at
+        // 0.53, item left at 0.55 — grid 53/96 = 0.5521 is 0.0021 away, the
+        // peer 0.02 — the peer tier still wins.
+        const QList<NormRect> nearPeer{NormRect{0.03, 0.0, 0.5, 0.5}};
+        s = snapRect(NormRect{0.55, 0.7, 0.2, 0.2}, HitZone::Move, nearPeer,
+                     0.03, 0.03, minN, 96, 54);
         report("the peer tier wins even when a grid line is nearer",
-               nearly(s.rect.x, 0.5));
+               nearly(s.rect.x, 0.53));
 
         // Grid disabled: 0.255 stays free.
         s = snapRect(NormRect{0.255, 0.7, 0.2, 0.2}, HitZone::Move, noPeers,
@@ -263,9 +259,19 @@ int main()
         report("grid zero disables the grid tier",
                nearly(s.rect.x, 0.255) && s.verticalGuides.isEmpty());
 
+        // The grid's own gentler magnet: with gridTol 0.003 a line 0.005
+        // away is out of the GRID's reach even though the peer tolerance
+        // would span it — the tiers pull with different strength.
+        s = snapRect(NormRect{0.255, 0.7, 0.2, 0.2}, HitZone::Move, noPeers,
+                     tol, tol, minN, 96, 54, 0.003, 0.003);
+        report("the grid magnet can be gentler than the peer magnet",
+               nearly(s.rect.x, 0.255) && s.verticalGuides.isEmpty());
+
         // Resize: the gripped edge lands on a grid line, anchor untouched.
-        s = snapRect(NormRect{0.3, 0.5, 0.257, 0.2}, HitZone::E, noPeers,
-                     tol, tol, minN, 32, 18);
+        // Right edge at 0.5605 → 54/96 = 0.5625 (0.002 away; 53/96 is
+        // 0.0084).
+        s = snapRect(NormRect{0.3, 0.5, 0.2605, 0.2}, HitZone::E, noPeers,
+                     tol, tol, minN, 96, 54);
         report("a resize snaps its gripped edge to the grid",
                nearly(s.rect.right(), 0.5625) && nearly(s.rect.x, 0.3));
     }

--- a/tests/workspace_interaction_test.cpp
+++ b/tests/workspace_interaction_test.cpp
@@ -11,6 +11,8 @@
 #include <QList>
 #include <QPoint>
 #include <QRect>
+#include <QString>
+#include <QStringList>
 
 #include <cmath>
 #include <cstdio>
@@ -218,6 +220,86 @@ int main()
         s = snapRect(moved, HitZone::E, peers, tol, tol, minN);
         report("a snap cannot shrink below the minimum",
                s.rect.w >= minN.width() - 1e-12);
+    }
+
+    // ── Tidy ─────────────────────────────────────────────────────────────
+    {
+        using AetherSDR::CanvasItem;
+        using AetherSDR::TidyMove;
+        using AetherSDR::tidyOverlaps;
+
+        const auto make = [](const QString& id, const NormRect& r) {
+            CanvasItem it;
+            it.id   = id;
+            it.rect = r;
+            return it;
+        };
+
+        // Two overlapping items: the lower-in-reading-order one is pushed
+        // below the first, sizes intact.
+        {
+            const QList<CanvasItem> items{
+                make("a", NormRect{0.1, 0.1, 0.3, 0.3}),
+                make("b", NormRect{0.2, 0.2, 0.3, 0.3}),
+            };
+            const auto moves = tidyOverlaps(items, {});
+            report("tidy resolves a simple overlap downward",
+                   moves.size() == 1 && moves.first().id == "b"
+                       && nearly(moves.first().rect.y, 0.4)
+                       && nearly(moves.first().rect.x, 0.2)
+                       && nearly(moves.first().rect.h, 0.3));
+        }
+
+        // Already tidy: nothing moves, nothing reported.
+        {
+            const QList<CanvasItem> items{
+                make("a", NormRect{0.0, 0.0, 0.3, 0.3}),
+                make("b", NormRect{0.5, 0.5, 0.3, 0.3}),
+            };
+            report("tidy leaves a clean arrangement alone",
+                   tidyOverlaps(items, {}).isEmpty());
+        }
+
+        // Overlap with a FIXED item is not disorder: a meter over the pan
+        // area stays exactly where the operator put it.
+        {
+            const QList<CanvasItem> items{
+                make("panstack", NormRect{0.0, 0.0, 0.8, 1.0}),
+                make("meter",    NormRect{0.3, 0.3, 0.2, 0.2}),
+            };
+            report("tidy ignores overlap with fixed items",
+                   tidyOverlaps(items, {"panstack"}).isEmpty());
+        }
+
+        // A chain: pushing b below a lands it on c, so it pushes past c too.
+        {
+            const QList<CanvasItem> items{
+                make("a", NormRect{0.1, 0.0, 0.3, 0.3}),
+                make("b", NormRect{0.1, 0.1, 0.3, 0.3}),
+                make("c", NormRect{0.1, 0.35, 0.3, 0.2}),
+            };
+            // Reading order places b (y=0.1) before c (y=0.35): b slots in
+            // directly below a, and c — now overlapped by b's new position —
+            // is pushed through it to below both.
+            const auto moves = tidyOverlaps(items, {});
+            bool bMoved = false, cChained = false;
+            for (const TidyMove& mv : moves) {
+                if (mv.id == "b") bMoved   = nearly(mv.rect.y, 0.3);
+                if (mv.id == "c") cChained = nearly(mv.rect.y, 0.6);
+            }
+            report("tidy pushes through chained obstacles", bMoved && cChained);
+        }
+
+        // No room below: the item is left exactly where it was — tidy never
+        // makes an arrangement worse.
+        {
+            const QList<CanvasItem> items{
+                make("a", NormRect{0.0, 0.0, 1.0, 0.6}),
+                make("b", NormRect{0.0, 0.5, 1.0, 0.6}),
+            };
+            report("tidy gives up rather than push off the surface",
+                   tidyOverlaps(items, {}).isEmpty());
+        }
     }
 
     std::printf("\n%s\n", g_failures == 0 ? "All checks passed." : "FAILURES present.");

--- a/tests/workspace_interaction_test.cpp
+++ b/tests/workspace_interaction_test.cpp
@@ -1,0 +1,225 @@
+// The pure interaction core of RFC #4887 phase 5: hit zones, anchored
+// resize, and the snap solver.
+//
+// Two properties carry the operator's trust and are pinned hardest here:
+// a resize NEVER moves the anchored edge (that is what hands rely on), and
+// a snap NEVER shrinks an item below its minimum or moves an anchor.  Pure
+// logic, no widgets.
+
+#include "gui/workspace/CanvasInteraction.h"
+
+#include <QList>
+#include <QPoint>
+#include <QRect>
+
+#include <cmath>
+#include <cstdio>
+
+using AetherSDR::HitZone;
+using AetherSDR::NormRect;
+using AetherSDR::applyDrag;
+using AetherSDR::cursorForZone;
+using AetherSDR::hitZoneFor;
+using AetherSDR::isResizeZone;
+using AetherSDR::snapRect;
+
+namespace {
+
+int g_failures = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) {
+        ++g_failures;
+    }
+}
+
+bool nearly(double a, double b, double tol = 1e-9)
+{
+    return std::fabs(a - b) <= tol;
+}
+
+bool rectNear(const NormRect& a, const NormRect& b)
+{
+    return nearly(a.x, b.x) && nearly(a.y, b.y)
+           && nearly(a.w, b.w) && nearly(a.h, b.h);
+}
+
+}  // namespace
+
+int main()
+{
+    const QRect item(100, 100, 300, 200);   // px: 100..400 x 100..300
+    const int grip = 6;
+    const int titleH = 18;
+
+    // ── Hit zones ────────────────────────────────────────────────────────
+    {
+        report("outside is None",
+               hitZoneFor(item, QPoint(50, 50), grip, titleH) == HitZone::None);
+        report("body is None",
+               hitZoneFor(item, QPoint(250, 200), grip, titleH) == HitZone::None);
+        report("the title strip is Move",
+               hitZoneFor(item, QPoint(250, 110), grip, titleH) == HitZone::Move);
+
+        report("left band is W",
+               hitZoneFor(item, QPoint(103, 200), grip, titleH) == HitZone::W);
+        report("right band is E",
+               hitZoneFor(item, QPoint(398, 200), grip, titleH) == HitZone::E);
+        report("top band is N — grips beat the title strip",
+               hitZoneFor(item, QPoint(250, 103), grip, titleH) == HitZone::N);
+        report("bottom band is S",
+               hitZoneFor(item, QPoint(250, 297), grip, titleH) == HitZone::S);
+
+        report("two bands make a corner: NW",
+               hitZoneFor(item, QPoint(103, 103), grip, titleH) == HitZone::NW);
+        report("two bands make a corner: SE",
+               hitZoneFor(item, QPoint(398, 297), grip, titleH) == HitZone::SE);
+        report("NE corner beats both N and the title strip",
+               hitZoneFor(item, QPoint(398, 103), grip, titleH) == HitZone::NE);
+
+        report("resize zones are resize zones",
+               isResizeZone(HitZone::E) && isResizeZone(HitZone::NW)
+                   && !isResizeZone(HitZone::Move) && !isResizeZone(HitZone::None));
+        report("cursors match the axes",
+               cursorForZone(HitZone::E) == Qt::SizeHorCursor
+                   && cursorForZone(HitZone::N) == Qt::SizeVerCursor
+                   && cursorForZone(HitZone::SE) == Qt::SizeFDiagCursor
+                   && cursorForZone(HitZone::SW) == Qt::SizeBDiagCursor
+                   && cursorForZone(HitZone::Move) == Qt::SizeAllCursor);
+    }
+
+    const NormRect start{0.3, 0.3, 0.4, 0.3};
+    const QSizeF minN(0.1, 0.1);
+
+    // ── Move ─────────────────────────────────────────────────────────────
+    {
+        report("move translates",
+               rectNear(applyDrag(start, HitZone::Move, 0.1, -0.05, minN),
+                        NormRect{0.4, 0.25, 0.4, 0.3}));
+        report("an overshoot slides back inside, size intact",
+               rectNear(applyDrag(start, HitZone::Move, 0.9, 0.9, minN),
+                        NormRect{0.6, 0.7, 0.4, 0.3}));
+        report("None is inert", rectNear(applyDrag(start, HitZone::None, 0.5, 0.5, minN), start));
+    }
+
+    // ── Resize anchors ───────────────────────────────────────────────────
+    {
+        // E: the LEFT edge is the anchor and must not budge.
+        NormRect r = applyDrag(start, HitZone::E, 0.15, 0.5, minN);
+        report("E grows the right edge only",
+               rectNear(r, NormRect{0.3, 0.3, 0.55, 0.3}));
+
+        // W: the RIGHT edge is the anchor.
+        r = applyDrag(start, HitZone::W, 0.1, 0.0, minN);
+        report("W moves the left edge, right edge fixed",
+               rectNear(r, NormRect{0.4, 0.3, 0.3, 0.3}) && nearly(r.right(), 0.7));
+
+        // N/S vertical mirrors.
+        r = applyDrag(start, HitZone::N, 0.0, -0.1, minN);
+        report("N raises the top, bottom fixed",
+               rectNear(r, NormRect{0.3, 0.2, 0.4, 0.4}) && nearly(r.bottom(), 0.6));
+        r = applyDrag(start, HitZone::S, 0.0, 0.2, minN);
+        report("S drops the bottom, top fixed",
+               rectNear(r, NormRect{0.3, 0.3, 0.4, 0.5}));
+
+        // Corner: both axes at once, both opposite edges anchored.
+        r = applyDrag(start, HitZone::SE, 0.1, 0.1, minN);
+        report("SE moves two edges, anchors two",
+               rectNear(r, NormRect{0.3, 0.3, 0.5, 0.4}));
+        r = applyDrag(start, HitZone::NW, 0.05, 0.05, minN);
+        report("NW moves the origin, far corner fixed",
+               rectNear(r, NormRect{0.35, 0.35, 0.35, 0.25})
+                   && nearly(r.right(), 0.7) && nearly(r.bottom(), 0.6));
+    }
+
+    // ── Resize limits ────────────────────────────────────────────────────
+    {
+        // Collapse past the minimum: stops at min, anchor untouched.
+        NormRect r = applyDrag(start, HitZone::E, -0.9, 0.0, minN);
+        report("E collapse stops at the minimum",
+               rectNear(r, NormRect{0.3, 0.3, 0.1, 0.3}));
+        r = applyDrag(start, HitZone::W, 0.9, 0.0, minN);
+        report("W collapse stops at the minimum, right edge fixed",
+               nearly(r.right(), 0.7) && nearly(r.w, 0.1));
+
+        // Grow past the surface: stops at the edge, anchor untouched.
+        r = applyDrag(start, HitZone::E, 0.9, 0.0, minN);
+        report("E growth stops at the surface",
+               nearly(r.x, 0.3) && nearly(r.right(), 1.0));
+        r = applyDrag(start, HitZone::NW, -0.9, -0.9, minN);
+        report("NW growth stops at the origin",
+               nearly(r.x, 0.0) && nearly(r.y, 0.0)
+                   && nearly(r.right(), 0.7) && nearly(r.bottom(), 0.6));
+    }
+
+    // ── Snap: move ───────────────────────────────────────────────────────
+    {
+        const QList<NormRect> peers{NormRect{0.0, 0.0, 0.5, 0.5}};
+        const double tol = 0.02;
+
+        // Left edge near a peer's right edge → captured, guide reported.
+        NormRect moved{0.51, 0.7, 0.2, 0.2};
+        auto s = snapRect(moved, HitZone::Move, peers, tol, tol, minN);
+        report("move snaps edge-to-edge",
+               nearly(s.rect.x, 0.5) && s.verticalGuides == QList<double>{0.5});
+        report("...without touching the free axis", nearly(s.rect.y, 0.7));
+
+        // Centre lines participate for a move.
+        moved = NormRect{0.16, 0.7, 0.2, 0.2};   // centre 0.26, peer centre 0.25
+        s = snapRect(moved, HitZone::Move, peers, tol, tol, minN);
+        report("move snaps centre-to-centre",
+               nearly(s.rect.x + s.rect.w / 2.0, 0.25));
+
+        // The canvas edges are candidates too.
+        moved = NormRect{0.005, 0.99, 0.2, 0.2};
+        s = snapRect(moved, HitZone::Move, peers, tol, tol, minN);
+        report("move snaps to the surface edges",
+               nearly(s.rect.x, 0.0) && !s.horizontalGuides.isEmpty());
+
+        // Out of tolerance: untouched, no guides.
+        moved = NormRect{0.55, 0.7, 0.2, 0.2};
+        s = snapRect(moved, HitZone::Move, peers, tol, tol, minN);
+        report("beyond tolerance nothing snaps",
+               rectNear(s.rect, moved) && s.verticalGuides.isEmpty()
+                   && s.horizontalGuides.isEmpty());
+
+        // Zero tolerance = suppressed (the Alt-key path).
+        moved = NormRect{0.501, 0.7, 0.2, 0.2};
+        s = snapRect(moved, HitZone::Move, peers, 0.0, 0.0, minN);
+        report("zero tolerance suppresses close snaps",
+               rectNear(s.rect, moved));
+    }
+
+    // ── Snap: resize ─────────────────────────────────────────────────────
+    {
+        const QList<NormRect> peers{NormRect{0.6, 0.0, 0.2, 0.2}};
+        const double tol = 0.02;
+
+        // E resize near the peer's left edge: right edge captured, LEFT
+        // anchor untouched.
+        NormRect moved{0.3, 0.5, 0.29, 0.2};
+        auto s = snapRect(moved, HitZone::E, peers, tol, tol, minN);
+        report("E snap captures the right edge",
+               nearly(s.rect.right(), 0.6) && s.verticalGuides == QList<double>{0.6});
+        report("...anchor untouched", nearly(s.rect.x, 0.3));
+
+        // A resize must not snap the edges it does not move: a W grip with
+        // the RIGHT edge sitting on a line stays put.
+        moved = NormRect{0.35, 0.5, 0.25, 0.2};   // right = 0.6 on the line
+        s = snapRect(moved, HitZone::W, peers, tol, tol, minN);
+        report("W snap ignores the anchored right edge",
+               nearly(s.rect.x, 0.35) || !nearly(s.rect.right(), 0.6001));
+
+        // A snap can never shrink below the minimum: candidate inside min
+        // range is clamped, and then reports no guide (it did not land).
+        moved = NormRect{0.55, 0.5, 0.12, 0.2};   // E at 0.67; peer line 0.6 would leave 0.05 < min
+        s = snapRect(moved, HitZone::E, peers, tol, tol, minN);
+        report("a snap cannot shrink below the minimum",
+               s.rect.w >= minN.width() - 1e-12);
+    }
+
+    std::printf("\n%s\n", g_failures == 0 ? "All checks passed." : "FAILURES present.");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/workspace_layout_test.cpp
+++ b/tests/workspace_layout_test.cpp
@@ -32,8 +32,6 @@ void report(const char* name, bool ok)
     }
 }
 
-const QSize kCanvas(1000, 1000);
-
 CanvasItem make(const QString& id, const NormRect& rect)
 {
     CanvasItem it;
@@ -78,11 +76,11 @@ int main()
         report("empty layout has no items", layout.isEmpty() && layout.count() == 0);
 
         report("an item can be added",
-               layout.addItem(make("a", NormRect{0.0, 0.0, 0.4, 0.4}), kCanvas));
+               layout.addItem(make("a", NormRect{0.0, 0.0, 0.4, 0.4})));
         report("a duplicate id is refused",
-               !layout.addItem(make("a", NormRect{0.5, 0.5, 0.2, 0.2}), kCanvas));
+               !layout.addItem(make("a", NormRect{0.5, 0.5, 0.2, 0.2})));
         report("an empty id is refused",
-               !layout.addItem(make("", NormRect{0.5, 0.5, 0.2, 0.2}), kCanvas));
+               !layout.addItem(make("", NormRect{0.5, 0.5, 0.2, 0.2})));
         report("the refusals did not change the layout", layout.count() == 1);
 
         report("contains() finds it",        layout.contains("a"));
@@ -95,24 +93,36 @@ int main()
         report("layout is empty again",       layout.isEmpty());
     }
 
-    // ── Insert clamps placement ──────────────────────────────────────────
+    // ── Insert clamps placement — bounds only, never growth ──────────────
     {
         CanvasLayout layout;
         CanvasItem it = make("wide", NormRect{0.8, 0.8, 0.5, 0.5});
         it.minimumSize = QSize(100, 100);
-        layout.addItem(it, kCanvas);
+        layout.addItem(it);
 
         const NormRect stored = layout.item("wide")->rect;
-        report("an item added off-canvas is clamped on the way in",
+        report("an item added off-surface slides back inside",
                std::fabs(stored.x - 0.5) < 1e-9 && std::fabs(stored.y - 0.5) < 1e-9);
+        report("...keeping its size", std::fabs(stored.w - 0.5) < 1e-9);
+
+        // The model clamp is canvas-independent BY DESIGN: minimum sizes are
+        // a display concern.  Growing stored rects to meet a minimum against
+        // whatever size the canvas happened to be is how a pre-layout replay
+        // once rewrote an arrangement to full-canvas (phase 3 field report).
+        CanvasItem tiny = make("tiny", NormRect{0.4, 0.4, 0.01, 0.01});
+        tiny.minimumSize = QSize(400, 400);
+        layout.addItem(tiny);
+        report("a stored rect is never grown to meet a minimum",
+               std::fabs(layout.item("tiny")->rect.w - 0.01) < 1e-9
+                   && std::fabs(layout.item("tiny")->rect.h - 0.01) < 1e-9);
     }
 
     // ── z assignment and density ─────────────────────────────────────────
     {
         CanvasLayout layout;
-        layout.addItem(make("a", NormRect{0.0, 0.0, 0.3, 0.3}), kCanvas);
-        layout.addItem(make("b", NormRect{0.1, 0.1, 0.3, 0.3}), kCanvas);
-        layout.addItem(make("c", NormRect{0.2, 0.2, 0.3, 0.3}), kCanvas);
+        layout.addItem(make("a", NormRect{0.0, 0.0, 0.3, 0.3}));
+        layout.addItem(make("b", NormRect{0.1, 0.1, 0.3, 0.3}));
+        layout.addItem(make("c", NormRect{0.2, 0.2, 0.3, 0.3}));
 
         report("each new item lands on top",
                layout.zOf("a") == 0 && layout.zOf("b") == 1 && layout.zOf("c") == 2);
@@ -147,7 +157,7 @@ int main()
         c.z = 1;
 
         report("every stored item is restored",
-               layout.restoreItems({a, b, c}, kCanvas) == 3);
+               layout.restoreItems({a, b, c}) == 3);
         report("a restored arrangement keeps its saved stacking",
                zOrder(layout) == QStringList({"b", "c", "a"}));
         report("...and z is dense afterwards", zIsDense(layout));
@@ -159,7 +169,7 @@ int main()
         CanvasItem y = make("y", NormRect{0.2, 0.2, 0.2, 0.2});
         x.z = 40;
         y.z = 10;
-        sparse.restoreItems({x, y}, kCanvas);
+        sparse.restoreItems({x, y});
         report("sparse saved z is densified, preserving order",
                zOrder(sparse) == QStringList({"y", "x"}) && zIsDense(sparse));
 
@@ -169,7 +179,7 @@ int main()
         CanvasItem dup2 = make("dup", NormRect{0.3, 0.3, 0.2, 0.2});
         CanvasItem anon = make("", NormRect{0.5, 0.5, 0.2, 0.2});
         report("restore skips duplicate and anonymous items",
-               guarded.restoreItems({dup1, dup2, anon}, kCanvas) == 1
+               guarded.restoreItems({dup1, dup2, anon}) == 1
                    && guarded.count() == 1);
 
         // A plain add still puts a NEW item where the operator can see it,
@@ -177,8 +187,8 @@ int main()
         CanvasLayout fresh;
         CanvasItem buried = make("buried", NormRect{0.0, 0.0, 0.2, 0.2});
         buried.z = -99;
-        fresh.addItem(make("first", NormRect{0.3, 0.3, 0.2, 0.2}), kCanvas);
-        fresh.addItem(buried, kCanvas);
+        fresh.addItem(make("first", NormRect{0.3, 0.3, 0.2, 0.2}));
+        fresh.addItem(buried);
         report("addItem ignores the caller's z and lands on top",
                zOrder(fresh) == QStringList({"first", "buried"}));
     }
@@ -186,10 +196,10 @@ int main()
     // ── Stacking operations ──────────────────────────────────────────────
     {
         CanvasLayout layout;
-        layout.addItem(make("a", NormRect{0.0, 0.0, 0.3, 0.3}), kCanvas);
-        layout.addItem(make("b", NormRect{0.1, 0.1, 0.3, 0.3}), kCanvas);
-        layout.addItem(make("c", NormRect{0.2, 0.2, 0.3, 0.3}), kCanvas);
-        layout.addItem(make("d", NormRect{0.3, 0.3, 0.3, 0.3}), kCanvas);
+        layout.addItem(make("a", NormRect{0.0, 0.0, 0.3, 0.3}));
+        layout.addItem(make("b", NormRect{0.1, 0.1, 0.3, 0.3}));
+        layout.addItem(make("c", NormRect{0.2, 0.2, 0.3, 0.3}));
+        layout.addItem(make("d", NormRect{0.3, 0.3, 0.3, 0.3}));
         // bottom -> top: a b c d
 
         report("raise moves one step",
@@ -233,8 +243,8 @@ int main()
     {
         CanvasLayout layout;
         // Two items that overlap in the middle of the canvas.
-        layout.addItem(make("under", NormRect{0.10, 0.10, 0.40, 0.40}), kCanvas);
-        layout.addItem(make("over",  NormRect{0.30, 0.30, 0.40, 0.40}), kCanvas);
+        layout.addItem(make("under", NormRect{0.10, 0.10, 0.40, 0.40}));
+        layout.addItem(make("over",  NormRect{0.30, 0.30, 0.40, 0.40}));
 
         report("a point over only the lower item hits it",
                layout.hitTest(QPointF(0.15, 0.15)) == "under");
@@ -254,35 +264,21 @@ int main()
                layout.hitTest(QPointF(-0.5, 0.5)).isEmpty());
     }
 
-    // ── setRect and reclampAll ───────────────────────────────────────────
+    // ── setRect ──────────────────────────────────────────────────────────
     {
         CanvasLayout layout;
-        layout.addItem(make("a", NormRect{0.0, 0.0, 0.4, 0.4}), kCanvas);
+        layout.addItem(make("a", NormRect{0.0, 0.0, 0.4, 0.4}));
 
         report("setRect on an unknown id fails",
-               !layout.setRect("nope", NormRect{0.0, 0.0, 0.2, 0.2}, kCanvas));
+               !layout.setRect("nope", NormRect{0.0, 0.0, 0.2, 0.2}));
 
         report("setRect stores the new placement",
-               layout.setRect("a", NormRect{0.5, 0.5, 0.25, 0.25}, kCanvas)
+               layout.setRect("a", NormRect{0.5, 0.5, 0.25, 0.25})
                    && layout.item("a")->rect == NormRect{0.5, 0.5, 0.25, 0.25});
 
-        report("setRect clamps an off-canvas request",
-               layout.setRect("a", NormRect{0.9, 0.9, 0.5, 0.5}, kCanvas)
+        report("setRect slides an off-surface request back inside",
+               layout.setRect("a", NormRect{0.9, 0.9, 0.5, 0.5})
                    && layout.item("a")->rect == NormRect{0.5, 0.5, 0.5, 0.5});
-
-        // A resize that changes nothing must report nothing changed: this is
-        // what stops phase 2's auto-commit writing the document on every frame
-        // of a window drag.
-        CanvasLayout stable;
-        CanvasItem fits = make("fits", NormRect{0.1, 0.1, 0.2, 0.2});
-        fits.minimumSize = QSize(10, 10);
-        stable.addItem(fits, kCanvas);
-        report("a resize that changes nothing reports nothing",
-               stable.reclampAll(QSize(2000, 2000)).isEmpty());
-
-        // A canvas too small for the minimum does move it, and says so.
-        report("a resize that forces a clamp reports the moved item",
-               stable.reclampAll(QSize(20, 20)) == QStringList({"fits"}));
     }
 
     std::printf("\n%s\n", g_failures == 0 ? "All checks passed." : "FAILURES present.");

--- a/tests/workspace_migration_test.cpp
+++ b/tests/workspace_migration_test.cpp
@@ -296,6 +296,49 @@ int main(int argc, char** argv)
         report("composed items carry dense ascending z", zAscending);
     }
 
+    // ── Classic column wrap (phase 5 — the PR #4900 L3 answer) ───────────
+    {
+        QStringList many;
+        for (int i = 0; i < 12; ++i) many << QStringLiteral("A%1").arg(i);
+        const QList<CanvasItem> wrapped =
+            composeClassic({}, many, QStringLiteral("1"), false);
+
+        report("12 applets wrap into two columns",
+               wrapped.size() == 12);
+        // Even split: 6 + 6, not 11 + 1.
+        int rightCol = 0, innerCol = 0;
+        for (const CanvasItem& it : wrapped) {
+            if (nearly(it.rect.x, 1.0 - AetherSDR::kClassicAppletColumnWidth)) {
+                ++rightCol;
+            } else if (nearly(it.rect.x,
+                              1.0 - 2 * AetherSDR::kClassicAppletColumnWidth)) {
+                ++innerCol;
+            }
+        }
+        report("...split evenly", rightCol == 6 && innerCol == 6);
+        report("...slots above the collapse point",
+               nearly(wrapped.first().rect.h, 1.0 / 6.0));
+
+        // Small counts stay one column — the shipped behaviour is unchanged.
+        const QList<CanvasItem> few =
+            composeClassic({}, {"RX", "TX", "PWR"}, QStringLiteral("1"), false);
+        bool oneColumn = true;
+        for (const CanvasItem& it : few) {
+            if (!nearly(it.rect.x, 1.0 - AetherSDR::kClassicAppletColumnWidth)) {
+                oneColumn = false;
+            }
+        }
+        report("3 applets keep the single column", oneColumn);
+
+        // The pan region cedes width to every wrapped column.
+        const QList<CanvasItem> withPan =
+            composeClassic({"p"}, many, QStringLiteral("1"), false);
+        const CanvasItem* pan = findItem(withPan, QStringLiteral("pan:p"));
+        report("the pan region accounts for wrapped columns",
+               pan && nearly(pan->rect.w,
+                             1.0 - 2 * AetherSDR::kClassicAppletColumnWidth));
+    }
+
     // ── Reading the legacy keys ──────────────────────────────────────────
     {
         clearLegacyKeys();


### PR DESCRIPTION
## Summary

Phases 3, **4** and 5 of the workspace canvas (RFC #4887, approved; sequencing
per the [recorded decisions](https://github.com/aethersdr/AetherSDR/issues/4887#issuecomment-5257449229)).
Phases 3+5 ship together because a placement surface nobody can resize is not a
shippable increment; phase 4 joins them because a canvas whose pans can't move
is not the feature (maintainer ruling, 2026-08-11).

**Draft on purpose** — this is the trunk the remaining phases build on top of
(phase 6: workspace profiles; phase 7: additional canvas windows). It is
feature-complete and field-tested for what it claims, not parked.

### What it does

**View ▸ Workspace Canvas (experimental)** — off by default. An operator who
never touches the menu sees today's application unchanged, and an install that
never enables the mode never gains a settings key: `boot()` reads but never
migrates, and the legacy-key migration runs behind the operator's explicit
opt-in (the moment dual-write starts).

Enabled: the canvas takes the pan stack's splitter slot and hosts the stack as
one reserved item; open applets leave the panel and become freely placed,
resizable, layered items at their migrated Classic rects. Disable restores the
shell exactly and keeps all placement for next time.

**Interaction** (phase 5, priority order from field testing):

- **Live drag** — the title bar streams the gesture; the item follows the
  cursor. Esc cancels, Alt suppresses snapping per motion, release over the
  panel returns the applet.
- **Resize** — click to select; a canvas-owned frame masked to an 8 px border
  band carries eight grips, so everything inside it still clicks through to the
  applet. The anchored edge never moves. The pan area is resize-only by design
  (no title bar; its position falls out of its four edges).
- **Snapping** — peer edges/centres and canvas edges at 8 px, painted guides;
  plus a normalized **96×54 snap grid** (~20 px cells at 1920, exactly square
  at 16:9) with 1 px dots and its own gentler 4 px magnet, origin-only, so free
  placement between lines survives. Peer edges beat the grid even when the grid
  line is nearer. "Snap to grid" is a context-menu toggle; the dots stay.
- **Escape hatches** — undo last placement (twice = redo), tidy (pushes
  applet-vs-applet overlaps clear; overlap with the pan area is deliberately
  untouched — a meter over the spectrum is a feature), reset to Classic
  (re-derived from the live legacy keys, not a snapshot), per-item
  return/front/back.
- **Edit Layout mode** (field request) — the canvas has two postures.
  Locked (default whenever the mode comes up): no click-select, frame,
  drags, drops, nudge keys, or grid dots — operating the station never
  brushes the arranging machinery. Edit Layout (View submenu + context
  menu) arms placement; the first-ever enable opens editing (the operator
  just opted in to arrange). Lifecycle placement and the bridge's `place`
  work in both postures; `workspace edit on|off` drives it headlessly.
- **Keyboard** — arrows move 8 px, Ctrl 1 px, Shift resizes both axes,
  Ctrl+Shift fine resize. The canvas claims these keys via `ShortcutOverride`
  **only while an item is selected and the canvas has focus** — deselect or
  click into the spectrum and the VFO nudge shortcuts get them straight back.
- **Theming** — new `color.canvas.background` / `color.canvas.dots` tokens
  (`docs/theming/canvas-tokens.md`), in the regenerated seed so pre-existing
  custom themes degrade to defaults rather than transparent.
- **Bridge verbs** (#4864, folded in) — `pan float <panId|index|active>` /
  `pan dock <…>` drive the stack's real reparent path headlessly via a
  Q_INVOKABLE hook in `automationRearrange()`'s mold, and `dumpTree` now
  serializes `QStatusBar` messages so operator notices are assertable.
  Live-smoked: float/dock out of the canvas-hosted stack, 10 rapid cycles
  through the reparent path, process clean throughout.
- **Demo GUI-thread fix** (#4878, folded in) — the demo's synthetic RX engine
  was the only producer in the app on the GUI thread (3 ms precise timer +
  full synthesis competing with paintEvent; the reported multi-second backlog
  on software-GL machines). Extracted to `SimSignalSource` on a worker with a
  10 ms coarse timer; A/B-measured live (idle main-thread CPU ~10.7% → ~6.3%,
  333 Hz timer gone), 11-check suite gates it in CI.

### Pans as individual items (phase 4)

The phase-3 reserved `panstack` item **dissolves**: on first phase-4 enable it
splits into per-pan slot items — cells from the operator's own saved
`PanadapterLayout`, carved from the panstack rect they replace — deterministic
with zero live pans and downgrade-safe both ways (a phase-3 build recreates a
full-region panstack and ignores the slots; verified live against a real
phase-3 field-test document, whose applet survived to the 7th decimal).

- **Identity** — items are `pan:<slot>` (creation-order ordinal, lowest free
  on reuse), never the radio's stream id: ids are session-scoped (rekey exists
  precisely because they change) and would orphan every stored layout on
  reconnect. Slot discipline mirrors `SpectrumWidget::setPanIndex` and
  `RadioModel::neutralPanIndexFor`, so all three identity spaces agree.
- **Ownership** — the stack stays the pans' owner (creation, wiring,
  float/dock, render scheduling) and rides hidden; the canvas borrows applets
  via `detachForCanvas`/`returnFromCanvas`. Canvas↔splitter moves are plain
  same-top-level reparents (the `applyLayout` precedent); the GPU dance stays
  where it belongs — real top-level changes (float/dock, untouched). New
  `releaseItem()` drops a canvas entry *without* `takeItem()`'s
  `setParent(nullptr)` detour, which is the #1344-forbidden move for QRhi
  children.
- **Lifecycle** — new pan → placed at its stored slot rect; close → entry
  released, document slot kept (the next pan in that slot inherits the spot);
  band-recall rekey → slot follows the applet; **float keeps the slot** — a
  pan has no panel to return to, so its canvas home is where docking brings
  it back (live-verified: float → dock → exact rect).
- **The pan's own title strip** streams the live-move gesture (same 6 px
  threshold as `ContainerTitleBar`); resize/selection ride the existing frame.
  Tidy treats pans as fixed — an applet over the spectrum is a feature, and
  tidy shoving the spectrum around would be the disorder it exists to fix.
- **Band stack** — the panel lives *inside* the stack widget and would vanish
  with it; while the mode is on it becomes the `bandstack` canvas item (spot
  persists, visibility stays session-transient), one `MainWindow` router picks
  canvas item vs stack panel.
- **`workspace` bridge verb** — `status` (items with fractional rects + z, the
  document's own units), `enable`/`disable` (the real View-menu path),
  `place` (the same setItemRect + auto-commit seam a gesture uses, returning
  the clamped rect). Docs regenerated (65 verbs).
- **Demo multi-pan** (prerequisite) — the demo grows real `pan create/remove`
  over its synthetic wire (same status shape the connect script claims pan 0
  with; teardown pair per #3843; cap 4), one spectrum row **per live pan**,
  and the routing fix that made it visible: demo rows resolved via the neutral
  id synthesis, which never matches wire-claimed ids, so every row rode the
  active-pan fallback — wrong the moment a second pan exists.

**The RFC's risk-2 render budget, measured** (4 demo pans, full GUI, real
GPU): tiled 2×2 = 387 main-thread wakeups/s, ~5.6% of a core, ping p95
0.51 ms; all four **fully overlapped** = 387 wakeups/s, ~5.5%, p95 0.38 ms.
Overlap costs nothing over tiling — no visible-spectrum cap needed on real
GPUs. (Software-GL machines get their relief from the #4878 fix below.)

### The membership rule (the design decision reviews should poke at)

A document item means "this applet **belongs** on the canvas"; placement
requires mode-on + open + not-floating. Closing an applet keeps its home
(reopening restores it); leaving deliberately — return button, drag to panel,
pop out — forgets it, so an explicit return sticks instead of bouncing back.
The document is placement truth (Principle V); `ContainerTree`'s
`mode:"canvas"` is a dual-write mirror that a downgrade reads as panel-docked.

### One reparent path, not two

Canvas transitions are built from the same detach/restore halves float/dock
already used (`detachFromCurrentSlot` / `restoreToOriginalSlot`), with the same
#2495 RHI guard. Float-from-canvas routes through the evictor first so the
float records a real panel slot to dock back to. Two transition classes,
stated precisely (review m9): **applet** container moves go through the
manager's detach halves, whose top-level branch is guarded by
`prepareRhiChildrenForReparent`; **pan** moves and the mount's splitter swaps
are strictly one-step, same-top-level reparents — since the red-team pass,
nothing on the mount path passes through `setParent(nullptr)` at all, and the
canvas is owned by the main window from construction. Deliberately no
prepare/reset dance anywhere on the same-top-level paths — forcing one would
itself be the #4091 destroy/recreate storm.

### Three field reports found in testing, fixed and regression-pinned

1. **Boot replay against a pre-layout canvas** displayed every item full-canvas
   for a session. Fix: stored rects are now canvas-independent by construction
   (`clampToBounds` for the model, min-size enforcement display-only, never
   written back) — which also makes shrink-then-grow restore the arrangement
   exactly. The reporter's document survived untouched because the replay guard
   refused to persist the wreckage.
2. **Shift+arrows only resized vertically** — the app's frequency-nudge
   shortcuts were eating the horizontal pair. Fixed via scoped
   `ShortcutOverride`; pinned with a real competing `QShortcut` delivered
   through the window handle (the widget-level `keyClick` bypasses the shortcut
   map and would have proven nothing).
3. **Clicking a non-interactive part of an applet deselected it** — ignored
   presses propagate to the canvas, whose bare-press handler undid the
   selection the event filter had just made. Now hit-tested.

### Red-team review round (2026-08-12)

A commissioned adversarial review (plus two independent agent reviews) found
3 blockers, 4 majors and 13 minors; all are fixed in the `redteam` commits:
the un-gated locked-canvas press handler (B2 — the one press path Edit mode
missed), the mount's `setParent(nullptr)` detours replaced by strictly
one-step same-top-level reparents (B1, including the enable-failure
rollback's replace-with-own-descendant), cascade + above-older-pans placement
for defaulted pans (B3), display-truth hit-testing (M1), hostile-numeric
rejection at both the bridge and the `setItemRect` write boundary (M2),
slot compaction in reset (M3), the async-safe seam-create diff (M4), and the
minor sweep (verb docs, destroyed-watch cleanup, dead code, theme-file
reformat reverted to a 4-line-per-file diff, status-mirror relocation).
The reviewer's three named test gaps are closed: locked-posture presses,
model/display hit-test divergence, and hostile numerics all have executed
checks now, plus a twin-defaults pin for B3.

## Constitution principle honored

- **Principle V** — placement, the enabled flag, and (future) bindings live in
  the one workspace document; no new flat `AppSettings` keys. Migration only
  *reads* the legacy keys; their owners keep writing them (dual-write).
- **Principle XIV** — auto-commit at the gesture boundary: rect streams touch
  the debounce, release flushes one whole-document write.
- **Principle XI** — the claims are demonstrated: live bridge smokes drove the
  View toggle, a real title-bar drag (−228,+144 px → stored rect exactly
  {0.5, 0.299} on disk), boot-restore across a process restart, and the
  selection frame in a grab — plus two full manual field passes by the
  maintainer on the FLEX-8600.
- **Principle VIII** — store writes verified against the settings file, not the
  cache; CI runtimes measured, not asserted.

## Test plan

- [x] Local build passes — full app target, no new warnings; theme seed gate
      green (gen + check)
- [x] Behavior verified on a real radio — two manual field passes on the
      FLEX-8600 against written test plans (phase 3 and phase 5); the three
      field reports above came out of them and are fixed
- [x] Existing tests pass (CI) — including the six phase 1+2 suites
- [x] **477 checks across nine `workspace_*` suites** under the existing CI
      gate step (`^workspace_`), plus 11 in the demo-threading gate: geometry
      and bounds clamps, layout/z invariants, document schema + guards,
      migration off the real legacy keys, store auto-commit + write-block,
      container canvas transitions, controller membership rules **and the
      phase-4 pan lifecycle** (slot placement/persistence, float releases /
      dock returns home, rekey keeps the slot, removal frees it for reuse at
      the remembered rect, band-stack hosting — all through PanHostHooks over
      plain QWidgets, no GPU stack in CI), interaction core, and the full
      gesture session offscreen
- [x] Phase-4 live smoke (full GUI, demo): boot split of a real phase-3
      document, `pan create` ×3, 2×2 tile and full overlap via `workspace
      place`, float→dock exact-home round trip, disable→Classic restore
      (saved `PanadapterLayout` re-applied), re-enable with every rect kept,
      process stable throughout

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls (Principle V) — `canvasEnabled` lives
      inside the workspace document
- [x] Code is clean-room
- [x] All meter UI uses `MeterSmoother` — n/a
- [x] Documentation — `docs/theming/canvas-tokens.md` added; user-facing help
      deferred until the feature leaves (experimental)
- [x] No CHANGELOG entry

## Known gaps, stated rather than discovered

- ~~Applets not rendering above pans on Wayland~~ — **resolved, and it was
  never compositing**: the "pan" in every report was a `PanFloatingWindow`
  pop-out auto-restored at connect from stale pre-canvas `FloatingPanIds`
  (found by auditing the live session: nineteen healthy canvas items, zero
  pan items). Canvas mode no longer replays saved floats (maintainer
  ruling); compositing is verified correct at the pixel level on X11 and
  by field use on Wayland since the fix.

- Full `QAccessibleInterface` for canvas items is named follow-up in the #4896
  line (#3957/#3959 mold); keyboard operability + accessible names shipped.
- The selection frame, grips, and guides still paint from palette highlight —
  follow-up pass in the `color.canvas.*` namespace.
- Panel→canvas drag remains ghost-style (cross-widget QDrag); canvas-side drags
  are live.

Refs #4887
Fixes #4864
Fixes #4878

🤖 Generated with [Claude Code](https://claude.com/claude-code)
