### PR TITLE
build: stop the digital-voice ASan opt-in from breaking the TSan job (#4360)

### DIFF
--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -77,7 +77,60 @@ if((UNIX OR WIN32) AND ENABLE_DSTAR)
             -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/run_digital_voice_waveform_no_args.cmake
     )
 
+    # These targets opt IN to ASan+UBSan locally, so a developer running them
+    # by hand gets the checks without configuring anything.
+    #
+    # STAND DOWN when the build is already being compiled under a sanitizer of
+    # its own. ASan and TSan are mutually exclusive — `cc1plus: error:
+    # '-fsanitize=thread' is incompatible with '-fsanitize=address'` — so
+    # adding ASan unconditionally here breaks the TSan CI job at COMPILE time,
+    # and it breaks it for the whole repo, not just these 13 targets: the job
+    # never gets far enough to run anything. That is what took thread-sanitizer
+    # coverage to zero for ten consecutive weekly runs (issue #4360).
+    #
+    # Keyed off the flags actually arriving from the environment rather than off
+    # a known list of sanitizer names, so a future MSan/HWASan job inherits the
+    # right behaviour without editing this function.
+    #
+    # BOTH language flags are checked. Most of these targets are C, but Qt's
+    # AUTOMOC generates a C++ TU (mocs_compilation.cpp) for each of them —
+    # CMAKE_AUTOMOC is ON globally — and that generated file is the one CI
+    # actually dies on, compiled by c++ with CMAKE_CXX_FLAGS. Today's workflow
+    # sets only CXXFLAGS, so CXX alone would be enough; checking CFLAGS too
+    # means a job that sets only CFLAGS does not quietly reintroduce this.
+    #
+    # ONLY A CONFLICTING SANITIZER DISARMS THIS, not any sanitizer at all.
+    # The distinction is load-bearing and the naive test gets it backwards:
+    # sanitizers.yml sets CXXFLAGS but never CFLAGS, so on the ASAN job a
+    # blanket "an external sanitizer is present" test would stand this opt-in
+    # down and nothing would replace it for the C sources — the .c files would
+    # silently lose the ASan coverage this helper exists to give them, in the
+    # one job that currently reports real results. ASan+UBSan arriving from the
+    # environment is what we add anyway, so there is nothing to stand down for;
+    # only a sanitizer that cannot coexist with address (thread, memory) forces
+    # the retreat.
+    set(_aether_dv_external_sanitizer OFF)
+    foreach(_aether_dv_flags "${CMAKE_CXX_FLAGS}" "${CMAKE_C_FLAGS}")
+        if(_aether_dv_flags MATCHES "-fsanitize=[a-z,]*(thread|memory)")
+            set(_aether_dv_external_sanitizer ON)
+        endif()
+    endforeach()
+    if(_aether_dv_external_sanitizer)
+        message(STATUS
+            "Digital-voice tests: a conflicting sanitizer (thread/memory) is in "
+            "the C/CXX flags — not adding ASan+UBSan, they cannot coexist")
+    endif()
+    # Cached so the function does not depend on its caller's scope: today every
+    # call site is in this file, but a function reading a plain variable set
+    # elsewhere would silently re-arm if it were ever called from another
+    # directory scope.
+    set(AETHER_DV_EXTERNAL_SANITIZER "${_aether_dv_external_sanitizer}"
+        CACHE INTERNAL "A conflicting sanitizer arrived in CMAKE_{C,CXX}_FLAGS")
+
     function(aether_enable_digital_voice_test_sanitizers target)
+        if(AETHER_DV_EXTERNAL_SANITIZER)
+            return()
+        endif()
         if(NOT WIN32 AND CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
             target_compile_options(${target} PRIVATE
                 -fsanitize=address,undefined

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -88,9 +88,12 @@ if((UNIX OR WIN32) AND ENABLE_DSTAR)
     # never gets far enough to run anything. That is what took thread-sanitizer
     # coverage to zero for ten consecutive weekly runs (issue #4360).
     #
-    # Keyed off the flags actually arriving from the environment rather than off
-    # a known list of sanitizer names, so a future MSan/HWASan job inherits the
-    # right behaviour without editing this function.
+    # Keyed off the flags actually arriving from the environment, but matched
+    # against a DELIBERATELY NARROW list of sanitizer names — see the last
+    # paragraph for why it cannot be "any sanitizer". The list is thread,
+    # memory and hwaddress: the three that cannot coexist with address. A new
+    # sanitizer that also conflicts has to be added here; the alternation is
+    # the whole contract, so keep it and the message below in step.
     #
     # BOTH language flags are checked. Most of these targets are C, but Qt's
     # AUTOMOC generates a C++ TU (mocs_compilation.cpp) for each of them —
@@ -107,18 +110,25 @@ if((UNIX OR WIN32) AND ENABLE_DSTAR)
     # silently lose the ASan coverage this helper exists to give them, in the
     # one job that currently reports real results. ASan+UBSan arriving from the
     # environment is what we add anyway, so there is nothing to stand down for;
-    # only a sanitizer that cannot coexist with address (thread, memory) forces
-    # the retreat.
+    # only a sanitizer that cannot coexist with address (thread, memory,
+    # hwaddress) forces the retreat.
+    #
+    # `[a-z,]*` matches neither `-` nor `=` nor space, which is what keeps the
+    # alternation from over-reaching: `-fno-sanitize=thread` has no
+    # `-fsanitize=` substring, `-fsanitize=kernel-address` stops at the hyphen,
+    # and `-fsanitize=address` does not contain `hwaddress`. Reordered lists
+    # (`-fsanitize=undefined,thread`) still match.
     set(_aether_dv_external_sanitizer OFF)
     foreach(_aether_dv_flags "${CMAKE_CXX_FLAGS}" "${CMAKE_C_FLAGS}")
-        if(_aether_dv_flags MATCHES "-fsanitize=[a-z,]*(thread|memory)")
+        if(_aether_dv_flags MATCHES "-fsanitize=[a-z,]*(thread|memory|hwaddress)")
             set(_aether_dv_external_sanitizer ON)
         endif()
     endforeach()
     if(_aether_dv_external_sanitizer)
         message(STATUS
-            "Digital-voice tests: a conflicting sanitizer (thread/memory) is in "
-            "the C/CXX flags — not adding ASan+UBSan, they cannot coexist")
+            "Digital-voice tests: a conflicting sanitizer "
+            "(thread/memory/hwaddress) is in the C/CXX flags — not adding "
+            "ASan+UBSan, they cannot coexist")
     endif()
     # Cached so the function does not depend on its caller's scope: today every
     # call site is in this file, but a function reading a plain variable set


### PR DESCRIPTION
Fixes the TSan half of #4360. The ASan+UBSan half is a separate fault and is **not** touched here.

## The fault

`aether_enable_digital_voice_test_sanitizers()` (CMakeLists.txt:1861) added `-fsanitize=address,undefined` to 13 targets with no guard of any kind. ASan and TSan cannot coexist, so the weekly Sanitizers TSan job died at compile time:

```
cc1plus: error: '-fsanitize=thread' is incompatible with '-fsanitize=address'
```

The blast radius is the **whole repo**, not those 13 targets — the job fails during the build, so it never runs a single test.

One detail worth recording, because it is not obvious from the source: the TU that actually fails is `mocs_compilation.cpp`. Most of these targets are C, and the workflow sets only `CXXFLAGS` — so at first glance the TSan flags should never reach them. They do, because Qt's AUTOMOC generates a **C++** source for each target, compiled by `c++` with `CMAKE_CXX_FLAGS`. From the failing CI log:

```
/usr/bin/c++ ... -fsanitize=thread -g3 -fno-omit-frame-pointer -O1 -O2 -g -DNDEBUG \
  -std=gnu++20 -fsanitize=address,undefined ... -c .../mocs_compilation.cpp
```

Both flag sets on one command line.

## Not the other `-fsanitize` site

For the record, since #4360's discussion could point at it: the `-fsanitize=address` on `aethercore`/`AetherSDR` (CMakeLists.txt:2939/2943) is **not** implicated. It is guarded by `$<$<CONFIG:Debug>:...>` and the TSan job builds `RelWithDebInfo`, so it never fires there. The workflow comment at sanitizers.yml:47-48 shows that was already understood. This helper was the one with no config guard — which is exactly why it, and not that one, is what breaks.

## The fix

Stand the opt-in down when the build already carries a sanitizer from the environment. Keyed off the flags themselves rather than a hardcoded list of sanitizer names, so a future MSan/HWASan job inherits the right behaviour without editing this function.

Both C and CXX flags are checked. Only `CXXFLAGS` is set today, so `CMAKE_CXX_FLAGS` alone would suffice — but a job setting only `CFLAGS` would otherwise silently reintroduce this.

Developers running these tests by hand still get ASan+UBSan. That path is unchanged, and is the reason for a guard rather than deleting the flags.

## Verification

I could not configure the full project on my Linux host (Ubuntu 24.04 ships Qt 6.4.2, below the 6.8 floor), so I extracted the edited block from `CMakeLists.txt` verbatim and ran **CMake itself** over it on linux-aether, gcc 13.3:

| case | result |
|---|---|
| `CXXFLAGS=-fsanitize=thread` (the CI shape) | guard fires; target **compiles and links** — previously a hard error |
| `CFLAGS=-fsanitize=thread` (hypothetical future job) | guard fires; stands down |
| no external sanitizer (plain dev build) | `-fsanitize=address,undefined` still applied |

The underlying conflict was confirmed against the same compiler first, so the "before" state is reproduced rather than assumed:

```
$ gcc -fsanitize=thread -fsanitize=address,undefined m.c
cc1: error: '-fsanitize=thread' is incompatible with '-fsanitize=address'
$ gcc -fsanitize=thread m.c        # fine
```

**What this does not prove:** I have not run the full TSan job end to end — that needs the CI container's Qt. This change clears the compile-time blocker; whether TSan then reports pre-existing data races in code that has had no thread-sanitizer coverage since 2026-06-01 is a separate question, and I would expect the first green-building run to surface a backlog. That is the point of unblocking it, but it may mean this job is noisy before it is clean.

The ASan+UBSan ctest failures (5 of 278) are untouched here. Per my analysis in #4360 they are timeouts under the instrumented build, not sanitizer findings — there is not one `ERROR: AddressSanitizer` or `runtime error:` in the log. Happy to take that separately if wanted.
