### PR TITLE
test(a11y): skip announcement checks where the platform has no a11y backend (#4360)

### DIFF
--- a/tests/range_slider_a11y_test.cpp
+++ b/tests/range_slider_a11y_test.cpp
@@ -1,4 +1,4 @@
-// RangeSlider accessibility announcement contract (#4565).
+﻿// RangeSlider accessibility announcement contract (#4565).
 //
 // Two behaviours have to hold at the same time, and they pull against each
 // other, which is why they are pinned together here:
@@ -83,6 +83,27 @@ int main(int argc, char** argv)
         QAccessible::installUpdateHandler(captureAccessibleValueUpdate);
     const bool wasAccessible = QAccessible::isActive();
     QAccessible::setActive(true);
+
+    // setActive(true) is a request Qt refuses when the platform plugin has no
+    // accessibility backend — true of offscreen/minimal, which is what CI uses.
+    // The widget is then correct to stay silent and every announcement check
+    // below fails as `got []`. Skip rather than fail; see the longer note in
+    // relay_bar_a11y_test.cpp and issue #4360.
+    //
+    // Skipping also removes the ASSERT crash this test produced in CI: once the
+    // announcement list is empty, the .first() call below trips Qt's
+    // `ASSERT: "!isEmpty()" in qlist.h` and the test aborts rather than
+    // reporting, which is why it showed as "Subprocess aborted" and not a
+    // normal failure.
+    if (!QAccessible::isActive()) {
+        std::cerr << "SKIP: the platform plugin ("
+                  << QApplication::platformName().toStdString()
+                  << ") has no accessibility backend, so QAccessible::setActive(true) "
+                     "does not take — announcements cannot be observed here.\n";
+        QAccessible::installUpdateHandler(previousHandler);
+        QAccessible::setActive(wasAccessible);
+        return 77;
+    }
 
     // Mirrors the CW decoder Pitch slider in PanadapterApplet.
     QWidget host;

--- a/tests/relay_bar_a11y_test.cpp
+++ b/tests/relay_bar_a11y_test.cpp
@@ -1,4 +1,4 @@
-// RelayBar accessibility announcement contract (#4565).
+﻿// RelayBar accessibility announcement contract (#4565).
 //
 // RelayBar::setValue() is driven by TunerModel::stateChanged, which relays
 // TGXL hardware state pushes with no rate limiting on the wire — an ATU
@@ -75,6 +75,31 @@ int main(int argc, char** argv)
         QAccessible::installUpdateHandler(captureAccessibleValueUpdate);
     const bool wasAccessible = QAccessible::isActive();
     QAccessible::setActive(true);
+
+    // QAccessible::setActive(true) is a REQUEST, not an assignment: Qt gates it
+    // on the platform plugin having a live accessibility backend, and the
+    // headless plugins (offscreen, minimal) have none — isActive() reads false
+    // again immediately, with no warning and no error.
+    //
+    // Every announcement in this file is emitted behind an
+    // `if (!hasFocus() || !QAccessible::isActive()) return;` guard in the
+    // widget, so without a backend the widget is CORRECT to stay silent and
+    // every expectation below fails as `got []`. That is a property of the
+    // environment, not a defect in the code under test — so SKIP rather than
+    // fail, the same way crdv_quarantined_test does (ctest SKIP_RETURN_CODE 77).
+    //
+    // This is what took the ASan+UBSan sanitizer job red from 2026-07-20 (see
+    // issue #4360): that job is the only CI job that runs these tests at all,
+    // and it runs them under QT_QPA_PLATFORM=offscreen.
+    if (!QAccessible::isActive()) {
+        std::cerr << "SKIP: the platform plugin ("
+                  << QApplication::platformName().toStdString()
+                  << ") has no accessibility backend, so QAccessible::setActive(true) "
+                     "does not take — announcements cannot be observed here.\n";
+        QAccessible::installUpdateHandler(previousHandler);
+        QAccessible::setActive(wasAccessible);
+        return 77;
+    }
 
     // Mirrors the C1 relay indicator in TunerApplet.
     QWidget host;

--- a/tests/s_meter_geometry_test.cpp
+++ b/tests/s_meter_geometry_test.cpp
@@ -1,4 +1,4 @@
-#include "TestSettingsProfile.h"
+﻿#include "TestSettingsProfile.h"
 #include "core/AppSettings.h"
 #include "gui/AnalogMeterFaceTheme.h"
 #include "gui/RadioSwrValidityFilter.h"
@@ -29,6 +29,11 @@
 namespace {
 
 int g_failures = 0;
+
+// True once the announcement section has actually run its checks. Reported in
+// the final pass line so a partial skip is visible in the ctest log — see the
+// note where it is printed.
+bool g_announcementsChecked = false;
 
 struct AccessibleValueUpdate {
     QObject* object{nullptr};
@@ -105,6 +110,30 @@ void testAccessibilityAnnouncements()
     const bool wasAccessible = QAccessible::isActive();
     QAccessible::setActive(true);
 
+    // setActive(true) is a request Qt refuses when the platform plugin has no
+    // accessibility backend — true of offscreen/minimal, which is what CI uses.
+    // The widget is then correct to stay silent and every announcement check
+    // below fails as `got []`. Skip rather than fail; see the longer note in
+    // relay_bar_a11y_test.cpp and issue #4360.
+    //
+    // NOTE this file is NOT only an accessibility test: the SWR hold/reset
+    // coverage further down asserts pure model state (txSwrHeld,
+    // txSwrMinimumForwardWatts) that has nothing to do with announcements and
+    // runs perfectly well headless. So this skips the announcement SECTION and
+    // lets the rest execute — returning 77 here would silently drop that SWR
+    // coverage, and since the sanitizer job is the only job that runs this
+    // test at all, "silently" would mean nothing watches it anywhere.
+    if (!QAccessible::isActive()) {
+        std::cerr << "SKIP (announcements only): the platform plugin ("
+                  << QApplication::platformName().toStdString()
+                  << ") has no accessibility backend, so QAccessible::setActive(true) "
+                     "does not take. The SWR coverage below still runs.\n";
+        QAccessible::installUpdateHandler(previousHandler);
+        QAccessible::setActive(wasAccessible);
+        g_accessibleValueUpdates = nullptr;
+        return;
+    }
+
     AetherSDR::SMeterWidget meter;
     meter.show();
     meter.activateWindow();
@@ -178,6 +207,7 @@ void testAccessibilityAnnouncements()
         QStringLiteral("return to receive transition"));
 
     meter.close();
+    g_announcementsChecked = true;
     QAccessible::installUpdateHandler(previousHandler);
     QAccessible::setActive(wasAccessible);
     g_accessibleValueUpdates = nullptr;
@@ -1158,7 +1188,17 @@ int main(int argc, char** argv)
     expect(changedPixelCount(enlargedRender) > 1000, "enlarged face renders");
 
     if (g_failures == 0) {
-        std::cout << "All standard S-meter geometry checks passed\n";
+        // SAY WHICH HALF RAN. Without this the binary exits 0 whether or not the
+        // announcement section executed, and ctest reports a bare "Passed" for
+        // both — so a platform that quietly stopped supporting accessibility
+        // would look identical to a full run. There is no ctest-visible signal
+        // for a partial skip (SKIP_RETURN_CODE is whole-binary), so the pass
+        // line carries it instead.
+        std::cout << (g_announcementsChecked
+                          ? "All standard S-meter geometry checks passed"
+                          : "S-meter geometry + SWR checks passed "
+                            "(announcement section SKIPPED — no a11y backend)")
+                  << "\n";
     }
     return g_failures == 0 ? 0 : 1;
 }

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -2104,8 +2104,12 @@ target_link_libraries(range_slider_a11y_test PRIVATE
 )
 set_target_properties(range_slider_a11y_test PROPERTIES AUTOMOC ON)
 add_test(NAME range_slider_a11y_test COMMAND range_slider_a11y_test)
+# Exit 77 == "no accessibility backend on this platform", not a failure. Qt
+# refuses QAccessible::setActive(true) under the headless plugins, so the
+# announcements this test asserts can never be emitted. See #4360.
 set_tests_properties(range_slider_a11y_test PROPERTIES
-    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+    SKIP_RETURN_CODE 77)
 
 # RelayBar accessibility announcements (#4565): an ATU sweep debounces to one
 # settled position, and the last-published value is forgotten on focus loss so
@@ -2122,8 +2126,10 @@ target_link_libraries(relay_bar_a11y_test PRIVATE
 )
 set_target_properties(relay_bar_a11y_test PROPERTIES AUTOMOC ON)
 add_test(NAME relay_bar_a11y_test COMMAND relay_bar_a11y_test)
+# Exit 77 == no accessibility backend; see range_slider_a11y_test above.
 set_tests_properties(relay_bar_a11y_test PROPERTIES
-    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+    SKIP_RETURN_CODE 77)
 
 # `get rhi` native-widget topology contract (#4339): the native QRhi leaf,
 # ancestor-isolation attribute, and native-ancestor count reported to agents.


### PR DESCRIPTION
Fixes **3 of the 5** ASan+UBSan ctest failures from #4360. The other two are unrelated and are described at the bottom — one of them looks like a genuine safety defect and wants its own issue.

Stacked on #4947 (the TSan half); the a11y commit is the second commit here.

## These are not memory bugs

Worth stating plainly, because "ASan job is red" reads as one: **there is not a single `ERROR: AddressSanitizer`, `runtime error:`, or leak report in the entire CI log.** The sanitizers found nothing. These are ordinary test failures that only ever run under this job.

I also have to correct something I wrote on #4360: I said these looked like timeouts under a slow instrumented build. **That was wrong.** ctest prints `***Failed`, not `***Timeout`; none of these tests sets a `TIMEOUT` property, so ctest's 1500 s default applies and `hl2_backend_test` at 240 s was nowhere near it. I only found the real cause by building it and running it.

## Root cause (3 of the 5)

`QAccessible::setActive(true)` is a **request, not an assignment**. Qt gates it on the platform plugin having a live accessibility backend, and the headless plugins have none — so it silently does not take. Verified directly against Qt 6.8.3:

```
QAccessible::setActive(true);
QAccessible::isActive();   // -> 0, under BOTH offscreen and minimal
```

Every announcement these tests assert is emitted behind this guard in the widget (`HGauge.h:615`, and the same pattern in `RangeSlider.h` / `SMeterWidget.h`):

```cpp
if (!hasFocus() || !QAccessible::isActive()) return;
```

So with no backend the widget is **correct** to stay silent, and every expectation fails as `got []`. The production code is fine — the tests assumed an activation the platform refuses. Note the tests' *focus* assertions pass; only the announcement ones fail, which is what points at `isActive()` rather than at the fixture.

That also explains the `Subprocess aborted`, which I had assumed was a separate fault: once the captured announcement list is empty, `.first()` trips Qt's `ASSERT: "!isEmpty()" in qlist.h` and the process aborts instead of reporting. Same root cause.

## The fix

Skip rather than fail, via ctest `SKIP_RETURN_CODE 77` — the convention already used by `crdv_quarantined_test`.

`s_meter_geometry_test` is handled **differently on purpose**: it also covers SWR hold/reset model state (`txSwrHeld`, `txSwrMinimumForwardWatts`) that has nothing to do with announcements and runs fine headless. So only the announcement section is skipped and the rest still executes. Returning 77 for the whole binary would have silently dropped that coverage — and since this job is the only one that runs the test at all, nothing anywhere would have noticed.

## Verification

On linux-aether (gcc 13.3, Qt 6.8.3), CI flags, `QT_QPA_PLATFORM=offscreen`:

| | before | after |
|---|---|---|
| `relay_bar_a11y_test` | 4 FAILs | Skipped (77), with a reason |
| `range_slider_a11y_test` | 2 FAILs then **abort** | Skipped (77), no abort |
| `s_meter_geometry_test` | 6 FAILs | **passes** — geometry + SWR half runs |
| `ctest` on the three | 3 failed | `100% tests passed, 0 tests failed` |

**The guard was falsified, not just observed to work.** Forcing the condition off (`if (false)`) and rebuilding brings all four `relay_bar` assertions straight back and exits 1:

```
FAIL: a settled relay step announces exactly once, got []
FAIL: an ATU sweep emits exactly one update, got []
FAIL: the sweep announces the settled position, got []
FAIL: a position that wandered away and back is announced, got []
EXIT=1
```

So the skip changes only the no-backend case; the assertions still bite wherever accessibility is genuinely available. What this does **not** prove is the positive path — I had no Xvfb/AT-SPI on that box, so I have not watched these announcements pass with a real backend attached. If CI ever grows an AT-SPI-capable job, these should light up there rather than skip.

## Two things this does NOT fix

**1. `icom_backend_test` — possibly a real defect, not a test problem.** One assertion fails:

```
FAIL: and the scrub never touches PTT or the antenna tuner
```

That is the Principle VI safety check that a control scrub never keys PTT or the ATU (`tests/icom_backend_test.cpp:565`). I have not diagnosed it and deliberately have not touched it — if the scrub really is emitting a PTT or tuner frame, that deserves its own issue and a careful look, not a quiet fix buried in a CI-green PR. Happy to take it separately.

**2. `hl2_backend_test`** — not yet diagnosed.

## Separate observation: the sanitizer job captures no failure output

Worth flagging because it is why this took so long to diagnose. `sanitizer.log` is complete (proper CTest summary at the end) but contains **zero** test output — no Qt test markers from any of the 278 tests, passing or failing. `report.txt`, which is what gets attached to the auto-filed issue, is 601 lines of tests *passing*, truncated mid-word.

The `--output-on-failure` flag itself is fine — locally it captures all 4 FAIL lines from the same binary. So something between ctest and the artifact is losing it, and I have not found what. Until it is fixed, this job reports *that* it failed but never *why*, and the auto-filed issue carries a wall of green noise. I would suggest a follow-up issue for that on its own.
