### PR TITLE
feat(tci): support four concurrent DAX IQ skimmer streams

### DIFF
--- a/docs/architecture/tci-receivers.md
+++ b/docs/architecture/tci-receivers.md
@@ -132,24 +132,82 @@ The receiver-index policy is only one half of the routing contract. Channel
 ## IQ Stream Subscriptions
 
 TCI IQ subscriptions are scoped by both client and receiver. One WebSocket may
-send `iq_start:0;`, `iq_start:1;`, `iq_start:2;`, and `iq_start:3;` to run four
-band skimmers concurrently. Each receiver maps to the corresponding 1-based
-Flex DAX IQ channel (`trx 0` to DAX IQ 1, through `trx 3` to DAX IQ 4), and
-type-0 binary frames carry that receiver index in their header.
+send `iq_start:0;` through `iq_start:3;` to run several band skimmers
+concurrently. `iq_stop:<n>;` affects only that receiver for that client; the
+client's other band streams continue uninterrupted. Type-0 binary frames carry
+the subscribed receiver index in their header.
 
-The radio-side stream is shared. AetherSDR creates at most one DAX IQ stream
-per receiver, keeps it while any TCI client remains subscribed, and removes it
-when the last subscriber stops or disconnects. A stream that was already
-owned by the DAX IQ applet is borrowed rather than removed by TCI cleanup.
-`iq_stop:<n>;` affects only that receiver for that client; the client's other
-band streams continue uninterrupted.
+**A receiver's IQ comes from the DAX IQ channel bound to that receiver's *pan*,
+not from `trx + 1` directly.** On a FLEX, `daxiq_channel` is a Panadapter
+property, and the pan↔channel binding is 1:1 in **both** directions — measured
+on a FLEX-6700 running V1.4.0.0: binding a channel to a second panadapter makes
+the radio push `daxiq_channel=0` to the first, unasked. Two consequences follow,
+and they are the whole shape of this design:
 
-`iq_samplerate` is the shared achieved rate for active TCI IQ receivers. A
-valid change is applied to every active DAX IQ stream and remembered for
-streams started later. Logical subscriptions survive a radio reconnect and
-are re-armed against the same stable receiver/pan binding when its slice
-returns. The pan binding is required because the DAX IQ channel is centered on
-the pan reported by `dds`, not merely on its slice frequency.
+1. **Receivers whose slices share a panadapter share one DAX IQ channel.**
+   The ordinary A/B layout puts two slices on one pan. Binding a second channel
+   there would silently steal the first one back, leaving a subscription that
+   was acknowledged, still holds one of the four DAX IQ slots, and carries
+   nothing — with no log line and nothing in `tci status` to tell it from a
+   working one. Since both receivers see the *same* spectrum, one stream
+   legitimately serves both: the payload is fanned out once per subscribed
+   receiver, each frame stamped with that receiver's own index. Four skimmers
+   therefore need four panadapters, not four slices, and a shared pan costs one
+   DAX IQ slot rather than two.
+
+2. **A channel the DAX IQ applet already owns is refused, never borrowed.**
+   TCI only ever drives channels it created. Taking over an existing stream
+   would move the operator's pan off it (per the 1:1 rule above, stopping their
+   IQ consumer at the source) and force TCI's sample rate onto it, and nothing
+   restores either. `iq_start` for such a receiver is refused instead.
+
+The receiver a channel is allocated *for* still follows #3913's mapping — TCI
+receiver `n` takes DAX IQ channel `n + 1` when its pan does not already have one:
+
+| TCI receiver | DAX IQ channel |
+|---:|---:|
+| 0 | 1 |
+| 1 | 2 |
+| 2 | 3 |
+| 3 | 4 |
+
+**A refused `iq_start` answers.** #3913 established that a skimmer blocks on the
+confirmation, so silence hangs it. Every refusal — unmapped receiver, borrowed
+channel, foreign-owned pan, a backend with no DAX — replies `iq_stop:<n>;`, the
+truthful state echo, and the receiver is *not* subscribed. Equally, `iq_start:`
+is only answered once the stream is actually armed: acknowledging a start whose
+create or pan bind was refused tells a client it has a receiver it can never
+use, and a client cannot retry what it was told worked. The `display pan set`
+ownership gate (#3977) is checked before anything is claimed, so a pan another
+client owns refuses the start rather than leaving an inert stream behind.
+
+The radio-side stream is shared and reference-counted. AetherSDR keeps a channel
+while any TCI client remains subscribed to any receiver bound to it, and on the
+last stop or disconnect removes the stream **and releases the pan binding**
+(`daxiq_channel=0`) — leaving it set would end a session with a panadapter
+routed at a channel nothing reads, which then blocks the applet from using that
+pan. A stop that beats the radio's stream-create status parks until the status
+arrives, because `DaxIqModel` cannot remove an id it has not learned yet.
+
+Ownership, an unconfirmed create, and a pending removal are tracked as three
+separate facts. Conflating them wedges a receiver: a create that is lost or
+rejected can never be re-issued, and the claim survives the `stop()`/`start()`
+cycle that the TCI applet's enable toggle and port change both perform on the
+same server object, so no later client can get IQ either.
+
+`iq_samplerate` is the shared rate for all TCI IQ receivers. A valid SET is
+applied to every channel TCI owns and remembered for channels created later, and
+is announced to peers as well as the requester (#3913). A GET, and a rejected
+SET, report the rate in force on a live stream rather than the last value TCI
+was asked for. The default is 48000, and TCI asserts it on the channels it
+creates — it does not discover a rate from the radio. A client connecting after
+another has moved the rate is told the rate in force in its init burst, not the
+default.
+
+Logical subscriptions survive a radio reconnect and the stable-receiver slice
+recreation window, and are re-armed against the same receiver/pan binding when
+the slice returns. The pan binding is required because the DAX IQ channel is
+centered on the pan reported by `dds`, not merely on its slice frequency.
 
 ## Spot Click Notifications
 

--- a/docs/architecture/tci-receivers.md
+++ b/docs/architecture/tci-receivers.md
@@ -15,16 +15,20 @@ The receiver-index policy is only one half of the routing contract. Channel
 
 ## Rules
 
-1. **Contiguous `0..N-1` indexing.**
-   Receiver indexes are the position of each slice in the owned-slice
-   list, starting at zero.  If you own slices with Flex IDs 1 and 3, TCI
-   advertises `trx_count:2` and maps them to receivers 0 and 1.
+1. **Dense initial `0..N-1` indexing.**
+   Each newly seen slice is assigned the lowest free receiver index. If you
+   initially own slices with Flex IDs 1 and 3, TCI advertises `trx_count:2`
+   and maps them to receivers 0 and 1. Raw Flex IDs never appear on the wire.
 
-2. **Indexes can shift at runtime.**
-   If a lower-numbered owned slice is removed (e.g. another client
-   deletes it), the remaining slices are re-indexed.  TCI clients receive
-   updated notifications but should be prepared for index changes between
-   sessions.
+2. **Live indexes are stable.**
+   A receiver binding is pinned to its Flex slice ID. A band-stack
+   destroy/recreate holds that binding through the settle window, so the
+   recreated slice returns on the same receiver and surviving slices do not
+   silently move. A genuinely closed slice frees its receiver after the
+   settle window; a later slice fills the lowest hole. `trx_count` remains one
+   plus the highest held/live receiver, so a temporary hole never invalidates
+   a receiver a client is already using. Clients should still rediscover the
+   mapping on a new radio session.
 
 3. **Legacy-client fallback.**
    `TciProtocol::sliceForTrx()` includes a compatibility path: if the
@@ -124,6 +128,28 @@ The receiver-index policy is only one half of the routing contract. Channel
    so transmit safety and the documented receiver-prefixed form win. The
    parser fails closed rather than risk either keying the address or silently
    removing a legitimate numeric payload (Constitution VI/VII).
+
+## IQ Stream Subscriptions
+
+TCI IQ subscriptions are scoped by both client and receiver. One WebSocket may
+send `iq_start:0;`, `iq_start:1;`, `iq_start:2;`, and `iq_start:3;` to run four
+band skimmers concurrently. Each receiver maps to the corresponding 1-based
+Flex DAX IQ channel (`trx 0` to DAX IQ 1, through `trx 3` to DAX IQ 4), and
+type-0 binary frames carry that receiver index in their header.
+
+The radio-side stream is shared. AetherSDR creates at most one DAX IQ stream
+per receiver, keeps it while any TCI client remains subscribed, and removes it
+when the last subscriber stops or disconnects. A stream that was already
+owned by the DAX IQ applet is borrowed rather than removed by TCI cleanup.
+`iq_stop:<n>;` affects only that receiver for that client; the client's other
+band streams continue uninterrupted.
+
+`iq_samplerate` is the shared achieved rate for active TCI IQ receivers. A
+valid change is applied to every active DAX IQ stream and remembered for
+streams started later. Logical subscriptions survive a radio reconnect and
+are re-armed against the same stable receiver/pan binding when its slice
+returns. The pan binding is required because the DAX IQ channel is centered on
+the pan reported by `dds`, not merely on its slice frequency.
 
 ## Spot Click Notifications
 

--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -498,7 +498,7 @@ QString TciProtocol::generateInitBurst()
     burst += QStringLiteral("audio_stream_channels:2;");
     burst += QStringLiteral("audio_stream_samples:2048;");
     burst += QStringLiteral("tx_stream_audio_buffering:50;");
-    burst += QStringLiteral("iq_samplerate:48000;");
+    burst += QStringLiteral("iq_samplerate:%1;").arg(m_iqSampleRate);
 
     // START is a bidirectional device-state notification and belongs in the
     // state dump, not after it: WSJT-X's TCITransceiver gates its
@@ -567,9 +567,12 @@ QString TciProtocol::handleCommand(const QString& cmd)
     if (name == "spot")             return cmdSpot(args);
     if (name == "spot_delete")      return cmdSpotDelete(args);
     if (name == "spot_clear")       return cmdSpotClear();
-    if (name == "iq_start")         return cmdIqStart(args);
-    if (name == "iq_stop")          return cmdIqStop(args);
-    if (name == "iq_samplerate")    return cmdIqSampleRate(args, args.size() >= 1 && !args[0].isEmpty());
+    // iq_start / iq_stop / iq_samplerate are handled entirely in
+    // TciServer::onTextMessage, which owns the shared DAX IQ stream lifecycle
+    // (per-receiver subscription sets, pan↔channel binding, refcounting across
+    // clients). The single-stream implementations that used to live here were
+    // removed rather than left unreachable: two implementations of one
+    // lifecycle, one of them wrong, is how the wrong one comes back.
     if (name == "keyer")            return cmdKeyer(args);
     if (name == "cw_keyer_speed")   return cmdCwKeyerSpeed(args, isSet);
     if (name == "cw_macros_delay")  return cmdCwMacrosDelay(args, isSet);
@@ -1695,103 +1698,6 @@ QString TciProtocol::cmdCwMacrosStop()
         model->cwxModel().clearBuffer();
     }, Qt::QueuedConnection);
     return {};
-}
-
-// ── IQ streaming ───────────────────────────────────────────────────────────
-
-QString TciProtocol::cmdIqStart(const QStringList& args)
-{
-    if (!m_model || args.isEmpty()) return {};
-    // Bound the index BEFORE the arithmetic: argToInt accepts INT_MAX (it
-    // parses cleanly — it is "99999999999" that clears ok), and `trx + 1`
-    // would then be signed overflow, i.e. UB reachable from any TCI client on
-    // the one PR whose whole subject is boundary validation. Checking the
-    // index rather than the result also subsumes the old channel range test.
-    //
-    // No observable behaviour changes: DaxIqModel::createStream() already
-    // rejects an out-of-range channel, so this is strictly about keeping the
-    // arithmetic defined for the weekly UBSan job. There is deliberately no
-    // test asserting the rejection — there would be nothing to observe — only
-    // a positive control that an in-range index still creates its stream.
-    int trx = 0;
-    if (!argToInt(args, 0, trx)) return {};
-    if (trx < 0 || trx > 3) return {};       // DAX IQ channels are 1-4
-    const int channel = trx + 1;  // TRX 0 → DAX IQ channel 1
-    // Creating the dax_iq stream is not enough to make IQ flow: on FlexRadio
-    // `daxiq_channel` is a Panadapter property, so the radio streams nothing
-    // (or a stale pan's IQ) until a panadapter is routed to this channel with
-    // `display pan set <panId> daxiq_channel=N`. The GUI does this from the
-    // spectrum overlay menu, but a TCI skimmer client (SDC / CW Skimmer) has no
-    // such hook — so bind the requested TRX's pan here. Mirrors the only other
-    // non-GUI IQ consumer, WfmDemodulator, and centers the stream on the same
-    // pan whose center is reported to the client via dds: (#3910/#3913).
-    const SliceModel* s = sliceForTrx(trx);
-    const QString panId = s ? s->panId() : QString();
-    QMetaObject::invokeMethod(m_model, [model = m_model, channel, panId]() {
-        model->daxIqModel().createStream(channel);
-        if (!panId.isEmpty())
-            model->sendCommand(QStringLiteral("display pan set %1 daxiq_channel=%2")
-                                   .arg(panId).arg(channel));
-    }, Qt::QueuedConnection);
-    return {};
-}
-
-QString TciProtocol::cmdIqStop(const QStringList& args)
-{
-    if (!m_model || args.isEmpty()) return {};
-    // Bounded before the addition, same as cmdIqStart above.
-    int trx = 0;
-    if (!argToInt(args, 0, trx)) return {};
-    if (trx < 0 || trx > 3) return {};       // DAX IQ channels are 1-4
-    const int channel = trx + 1;
-    QMetaObject::invokeMethod(m_model, [model = m_model, channel]() {
-        model->daxIqModel().removeStream(channel);
-    }, Qt::QueuedConnection);
-    return {};
-}
-
-QString TciProtocol::cmdIqSampleRate(const QStringList& args, bool isSet)
-{
-    if (!isSet) {
-        if (m_model) {
-            int rate = m_model->daxIqModel().stream(1).sampleRate;
-            return QStringLiteral("iq_samplerate:%1;").arg(rate);
-        }
-        return QStringLiteral("iq_samplerate:48000;");
-    }
-
-    if (args.isEmpty()) return {};
-    // Deliberately NOT the drop-on-unparseable posture the rest of this file
-    // uses: an unparseable rate joins the unsupported-rate branch below rather
-    // than returning {}. #3913 made this command reply to a rejection on
-    // purpose, because a skimmer (CW Skimmer / SDC) blocks waiting for the
-    // confirmation and silence would hang it. Rejecting is still rejecting —
-    // it just says so out loud, which is strictly better than dropping here.
-    int rate = 0;
-    const bool rateParsed = argToInt(args, 0, rate);
-    if (!rateParsed
-        || (rate != 24000 && rate != 48000 && rate != 96000 && rate != 192000)) {
-        // Reject without hanging the requester: report the rate that remains
-        // in force. No pending notification is set because other clients saw
-        // no state change (#3913 review).
-        const int currentRate = m_model
-            ? m_model->daxIqModel().stream(1).sampleRate
-            : 48000;
-        return QStringLiteral("iq_samplerate:%1;").arg(currentRate);
-    }
-    if (m_model) {
-        QMetaObject::invokeMethod(m_model, [model = m_model, rate]() {
-            model->daxIqModel().setSampleRate(1, rate);
-        }, Qt::QueuedConnection);
-    }
-    // Echo the achieved rate to BOTH the requester and other clients. The
-    // server is authoritative for the rate (it clamps/rejects above), so a
-    // skimmer (CW Skimmer / SDC) blocks waiting for this confirmation. The
-    // dispatcher sends the return value to the requesting socket and the
-    // pendingNotification to all *other* sockets, so each client gets exactly
-    // one copy — without the return, the requester got no reply at all. (#3910)
-    m_pendingNotification = QStringLiteral("iq_samplerate:%1;").arg(rate);
-    return QStringLiteral("iq_samplerate:%1;").arg(rate);
 }
 
 // ── CW keyer (straight key via TCI) ────────────────────────────────────────

--- a/src/core/TciProtocol.h
+++ b/src/core/TciProtocol.h
@@ -89,6 +89,12 @@ public:
     // the socket. Enforcing it in the setter keeps the invariant independent of
     // any caller remembering (Principle VII). Sanitizing is idempotent, so the
     // server sanitizing first costs nothing.
+    // The IQ sample rate is shared server state (TciServer owns it across all
+    // clients and all four channels), but it is announced in this client's init
+    // burst — so the server seeds it here rather than the burst hardcoding a
+    // default a later SET has already moved off.
+    void setIqSampleRate(int rate) { m_iqSampleRate = rate; }
+
     void setActiveSlice(int trx, const QString& letter)
     {
         m_activeTrx = trx;
@@ -142,9 +148,6 @@ private:
     QString cmdStart();
     QString cmdStop();
     QString cmdTxEnable(const QStringList& args);
-    QString cmdIqStart(const QStringList& args);
-    QString cmdIqStop(const QStringList& args);
-    QString cmdIqSampleRate(const QStringList& args, bool isSet);
     QString cmdKeyer(const QStringList& args);
     QString cmdCwKeyerSpeed(const QStringList& args, bool isSet);
     QString cmdCwMacrosDelay(const QStringList& args, bool isSet);
@@ -244,6 +247,7 @@ private:
     int         m_pendingMasterVolume{-1};   // -1 = no change requested
     int         m_pendingTxGain{-1};         // -1 = no change requested
     int         m_activeTrx{-1};             // -1 = focus not yet known (#4160)
+    int         m_iqSampleRate{48000};       // seeded by TciServer, see setIqSampleRate
     QString     m_activeLetter;              // focused slice's display letter (#4160)
     bool        m_started{false};  // client sent START
 };

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -235,8 +235,10 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
                 // manage.
                 m_channelTrx.clear();
                 m_tciDaxSlices.clear();
-                m_tciIqChannels.clear();
-                m_pendingIqRemovals.clear();
+                // The radio's streams and pan bindings died with the
+                // connection; only the logical subscriptions survive, and
+                // reconcileIqStreams() re-arms them when slices return.
+                resetIqStreamBookkeeping();
                 m_trxMap.clear();  // #4567: slices die with the connection
                 m_lastDdsCenterHz.clear();
                 m_routingState.reset();
@@ -432,8 +434,11 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
         // the just-created stream as soon as that status arrives.
         connect(&m_model->daxIqModel(), &DaxIqModel::streamChanged,
                 this, [this](int channel) {
+            // A status for this channel settles any create we had outstanding,
+            // whether it succeeded or not, so a later iq_start can re-arm.
+            m_iqCreateInFlight.remove(channel);
             if (!m_pendingIqRemovals.contains(channel)
-                || iqReceiverInUse(channel - 1)) {
+                || iqChannelInUse(channel)) {
                 return;
             }
             const DaxIqModel::IqStream& stream = m_model->daxIqModel().stream(channel);
@@ -557,6 +562,9 @@ void TciServer::stop()
 
     // Server shutdown bypasses onClientDisconnected(), so release every IQ
     // stream TCI created before throwing away the per-client subscriptions.
+    // TciApplet stops and restarts this same object (enable toggle, port
+    // change) rather than re-constructing it, so any bookkeeping left here
+    // outlives the session that made it.
     releaseAllIqStreams();
 
     for (auto& cs : m_clients) {
@@ -774,6 +782,9 @@ void TciServer::onNewConnection()
         // if no focus change has been observed yet, in which case the
         // protocol falls back to scanning.
         protocol->setActiveSlice(m_activeTrx, m_activeLetter);
+        // The IQ rate is shared across clients; a client joining after another
+        // has moved it must not be told the 48000 default in its init burst.
+        protocol->setIqSampleRate(m_iqSampleRate);
 
         ClientState cs;
         cs.socket = ws;
@@ -827,6 +838,9 @@ void TciServer::onClientDisconnected()
             }
             // Drop every receiver this client subscribed, independently. The
             // stream survives when another client still consumes that receiver.
+            // Clearing the set BEFORE the release loop is load-bearing: it is
+            // what stops iqChannelInUse() from seeing the departing client and
+            // refusing to release the channel it was the last consumer of.
             const QSet<int> iqReceivers = m_clients[i].iqReceivers;
             m_clients[i].iqReceivers.clear();
             for (int trx : iqReceivers) {
@@ -1242,8 +1256,12 @@ void TciServer::onTextMessage(const QString& msg)
             const QString value = colonIdx2 >= 0
                 ? trimmed.mid(colonIdx2 + 1).section(QLatin1Char(','), 0, 0).trimmed()
                 : QString();
+            // A GET and a rejected SET both report the rate actually in force
+            // on a live stream, not the last value TCI was asked for — a
+            // skimmer that reads back its own unapplied request learns nothing.
             if (value.isEmpty()) {
-                replyText(ws, QStringLiteral("iq_samplerate:%1;").arg(m_iqSampleRate));
+                replyText(ws, QStringLiteral("iq_samplerate:%1;")
+                                  .arg(achievedIqSampleRate()));
                 continue;
             }
             bool ok = false;
@@ -1252,24 +1270,31 @@ void TciServer::onTextMessage(const QString& msg)
                 && (rate == 24000 || rate == 48000
                     || rate == 96000 || rate == 192000);
             if (!supported) {
-                replyText(ws, QStringLiteral("iq_samplerate:%1;").arg(m_iqSampleRate));
+                replyText(ws, QStringLiteral("iq_samplerate:%1;")
+                                  .arg(achievedIqSampleRate()));
                 continue;
             }
             m_iqSampleRate = rate;
-            QSet<int> activeReceivers;
-            for (const ClientState& cs : std::as_const(m_clients)) {
-                activeReceivers.unite(cs.iqReceivers);
-            }
-            for (int trx : activeReceivers) {
-                if (m_model) {
-                    m_model->daxIqModel().setSampleRate(trx + 1, rate);
+            if (m_model) {
+                for (int channel : std::as_const(m_tciIqChannels)) {
+                    m_model->daxIqModel().setSampleRate(channel, rate);
                 }
             }
+            // Keep every client's init burst honest: a client connecting after
+            // this SET must be told the rate in force, not the 48000 default.
+            for (ClientState& cs : m_clients) {
+                if (cs.protocol) {
+                    cs.protocol->setIqSampleRate(rate);
+                }
+            }
+            // #3913: the requester and every peer each get exactly one copy.
+            // Routed through sendClientText() so the peer sends stay in the
+            // outbound accounting and the `TCI tx→client:` diagnostic log.
             const QString response = QStringLiteral("iq_samplerate:%1;").arg(rate);
             replyText(ws, response);
             for (ClientState& cs : m_clients) {
                 if (cs.socket != ws) {
-                    cs.socket->sendTextMessage(response);
+                    sendClientText(cs.socket, response);
                 }
             }
             continue;
@@ -1283,16 +1308,27 @@ void TciServer::onTextMessage(const QString& msg)
             const int trx = trimmed.mid(colonIdx2 + 1)
                                 .section(QLatin1Char(','), 0, 0)
                                 .trimmed().toInt(&ok);
-            if (!ok || trx < 0 || trx >= DaxIqModel::NUM_CHANNELS
-                || !m_trxMap.trxHasLiveSlice(m_model, trx)) {
+            if (!ok || trx < 0 || trx >= DaxIqModel::NUM_CHANNELS) {
+                // Nothing addressable to answer — there is no receiver here.
                 qCWarning(lcCat) << "TCI: refusing IQ start for unknown receiver"
                                  << trimmed.mid(colonIdx2 + 1).left(32);
                 continue;
             }
-            startIqForClient(client, trx);
+            // A refusal ANSWERS. #3913 established that a skimmer (CW Skimmer /
+            // SDC) blocks on the confirmation, so silence hangs it — and a
+            // client that raced the trx map at connect has no way to learn it
+            // should retry. `iq_stop:<trx>;` is the truthful state echo.
+            if (!startIqForClient(client, trx)) {
+                qCWarning(lcCat) << "TCI: IQ start refused for client"
+                                 << ws->peerAddress().toString()
+                                 << "trx=" << trx;
+                replyText(ws, QStringLiteral("iq_stop:%1;").arg(trx));
+                continue;
+            }
             qCInfo(lcCat) << "TCI: IQ started for client"
                           << ws->peerAddress().toString()
-                          << "trx=" << trx;
+                          << "trx=" << trx
+                          << "channel=" << iqChannelForTrx(trx);
             replyText(ws, QStringLiteral("iq_start:%1;").arg(trx));
             emit clientsChanged();
             continue;
@@ -3744,13 +3780,21 @@ void TciServer::onDaxStreamUnregistered(int channel, quint32 /*streamId*/)
 
 void TciServer::onIqDataReady(int channel, const QByteArray& rawPayload, int sampleRate)
 {
-    // Check if any client wants IQ for this channel
-    bool anyIq = false;
-    int trx = channel - 1;  // DAX IQ channel 1 → TRX 0
+    // Which receivers does this channel feed? Normally one (receiver n ↔ channel
+    // n+1), but two receivers whose slices share a panadapter share its channel
+    // — and see the same spectrum, so both are served from this one payload,
+    // each with its own receiver index in the frame header. Sorted so the send
+    // order is reproducible rather than QSet hash order.
+    QList<int> receivers;
     for (const auto& cs : m_clients) {
-        if (cs.iqReceivers.contains(trx)) { anyIq = true; break; }
+        for (int trx : cs.iqReceivers) {
+            if (iqChannelForTrx(trx) == channel && !receivers.contains(trx)) {
+                receivers.append(trx);
+            }
+        }
     }
-    if (!anyIq) return;
+    if (receivers.isEmpty()) return;
+    std::sort(receivers.begin(), receivers.end());
 
     // dax_iq payloads are LITTLE-endian float32 (the radio reports
     // payload_endian=little for this stream type, unlike pan/wf/meter/audio
@@ -3767,34 +3811,50 @@ void TciServer::onIqDataReady(int channel, const QByteArray& rawPayload, int sam
 
     // Build TCI IQ binary frame (type=0, channels=2 for I/Q pair)
     const int iqFrames = numFloats / 2;  // I/Q pairs
-    QByteArray frame = buildAudioFrame(trx, 0 /*IQ*/, sampleRate, 2,
-                                       reinterpret_cast<const float*>(swapped.constData()),
-                                       iqFrames);
-
-    for (auto& cs : m_clients) {
-        if (cs.iqReceivers.contains(trx))
-            cs.socket->sendBinaryMessage(frame);
+    for (int trx : std::as_const(receivers)) {
+        const QByteArray frame = buildAudioFrame(
+            trx, 0 /*IQ*/, sampleRate, 2,
+            reinterpret_cast<const float*>(swapped.constData()), iqFrames);
+        for (auto& cs : m_clients) {
+            if (cs.iqReceivers.contains(trx))
+                cs.socket->sendBinaryMessage(frame);
+        }
     }
 }
 
-bool TciServer::iqReceiverInUse(int trx, const QWebSocket* except) const
+int TciServer::iqChannelForTrx(int trx) const
+{
+    SliceModel* slice = sliceForTrx(trx);
+    if (!slice || slice->panId().isEmpty()) {
+        return 0;
+    }
+    return m_iqPanChannel.value(slice->panId(), 0);
+}
+
+bool TciServer::iqChannelInUse(int channel) const
 {
     for (const ClientState& cs : m_clients) {
-        if (cs.socket != except && cs.iqReceivers.contains(trx)) {
-            return true;
+        for (int trx : cs.iqReceivers) {
+            if (iqChannelForTrx(trx) == channel) {
+                return true;
+            }
         }
     }
     return false;
 }
 
-void TciServer::startIqForClient(ClientState& client, int trx)
+bool TciServer::startIqForClient(ClientState& client, int trx)
 {
+    // Subscribe only once the physical stream is actually armed. Recording the
+    // subscription first and answering `iq_start:` unconditionally told a
+    // skimmer it had a receiver when the create, the pan bind, or the DAX
+    // capability check had in fact refused — and a client cannot retry what it
+    // was told worked.
+    if (!ensureIqStream(trx)) {
+        return false;
+    }
     client.iqReceivers.insert(trx);
-    m_pendingIqRemovals.remove(trx + 1);
-    // IQ_START is idempotent, but it is also a useful re-arm after a radio or
-    // pan-side stream disappeared without a matching IQ_STOP. Always reconcile
-    // the physical stream instead of treating a duplicate SET as a no-op.
-    ensureIqStream(trx);
+    return true;
 }
 
 void TciServer::stopIqForClient(ClientState& client, int trx)
@@ -3805,53 +3865,132 @@ void TciServer::stopIqForClient(ClientState& client, int trx)
     releaseIqStreamIfUnused(trx);
 }
 
-void TciServer::ensureIqStream(int trx)
+bool TciServer::ensureIqStream(int trx)
 {
     if (!m_model || trx < 0 || trx >= DaxIqModel::NUM_CHANNELS
-        || !m_trxMap.trxHasLiveSlice(m_model, trx)
-        || !m_model->backendCapabilities().hasDaxStreams) {
-        return;
+        || !m_model->backendCapabilities().hasDaxStreams
+        || !m_trxMap.trxHasLiveSlice(m_model, trx)) {
+        return false;
     }
 
     SliceModel* slice = sliceForTrx(trx);
-    if (!slice) {
-        return;
+    if (!slice || slice->panId().isEmpty()) {
+        return false;
     }
-    const int channel = trx + 1;
+    const QString panId = slice->panId();
     DaxIqModel& iq = m_model->daxIqModel();
-    iq.setSampleRate(channel, m_iqSampleRate);
-    if (!iq.stream(channel).exists && !m_tciIqChannels.contains(channel)) {
-        m_tciIqChannels.insert(channel);
-        iq.createStream(channel);
+
+    // A DAX IQ stream is inert until a pan owns its channel, and a pan owns
+    // exactly one. If this receiver's pan already carries a TCI channel, share
+    // it — re-binding would only steal it from the receiver that has it.
+    const int shared = m_iqPanChannel.value(panId, 0);
+    if (shared != 0) {
+        m_pendingIqRemovals.remove(shared);
+        iq.setSampleRate(shared, m_iqSampleRate);
+        if (!iq.stream(shared).exists && !m_iqCreateInFlight.contains(shared)) {
+            m_iqCreateInFlight.insert(shared);
+            iq.createStream(shared);
+        }
+        return true;
     }
 
-    // A DAX IQ stream is inert until a pan owns its channel. Bind the stable
-    // receiver's current pan, preserving #3913's dds == IQ-center contract.
-    if (!slice->panId().isEmpty()) {
-        m_model->sendCommand(QStringLiteral("display pan set %1 daxiq_channel=%2")
-                                 .arg(slice->panId()).arg(channel));
+    // Otherwise this receiver takes its documented channel, trx+1 (#3913).
+    const int channel = trx + 1;
+
+    // Never borrow. A channel that exists but TCI did not create belongs to the
+    // DAX IQ applet; binding it here would move the operator's pan off it (the
+    // radio pushes daxiq_channel=0 to the displaced pan) and force our rate
+    // onto their consumer, with nothing restoring either.
+    if (iq.stream(channel).exists && !m_tciIqChannels.contains(channel)) {
+        qCWarning(lcCat) << "TCI: refusing IQ start for trx" << trx
+                         << "— DAX IQ channel" << channel
+                         << "belongs to the DAX IQ applet";
+        return false;
     }
+
+    // The receiver's slice moved pans. Unbind the stale pan before re-pointing
+    // the channel, so a pan is never left routed at a channel nothing reads.
+    const QString stalePan = m_iqPanChannel.key(channel, QString());
+    if (!stalePan.isEmpty() && stalePan != panId) {
+        m_model->sendCommand(
+            QStringLiteral("display pan set %1 daxiq_channel=0").arg(stalePan));
+        m_iqPanChannel.remove(stalePan);
+    }
+
+    // #3977 makes RadioModel::sendCommand() DROP a `display pan set` for a pan
+    // the radio has said another client owns (the #3951 signature). Test that
+    // condition here rather than reading sendCommand()'s bool: that return also
+    // folds in transport state, so treating it as the answer would report a
+    // receiver unarmed merely because the command was queued. This is the case
+    // the contract is about — without it TCI creates the stream, the bind is
+    // silently dropped, and the skimmer is told it started.
+    if (PanadapterModel* pan = m_model->panadapter(panId);
+        pan && !pan->ownedByClient(m_model->ourClientHandle())) {
+        qCWarning(lcCat) << "TCI: refusing IQ start for trx" << trx
+                         << "— pan" << panId << "is owned by another client";
+        return false;
+    }
+    m_model->sendCommand(QStringLiteral("display pan set %1 daxiq_channel=%2")
+                             .arg(panId).arg(channel));
+
+    m_iqPanChannel.insert(panId, channel);
+    m_tciIqChannels.insert(channel);
+    m_pendingIqRemovals.remove(channel);
+    iq.setSampleRate(channel, m_iqSampleRate);
+    if (!iq.stream(channel).exists && !m_iqCreateInFlight.contains(channel)) {
+        m_iqCreateInFlight.insert(channel);
+        iq.createStream(channel);
+    }
+    return true;
 }
 
 void TciServer::releaseIqStreamIfUnused(int trx)
 {
-    if (!m_model || trx < 0 || trx >= DaxIqModel::NUM_CHANNELS
-        || iqReceiverInUse(trx)) {
+    if (!m_model || trx < 0 || trx >= DaxIqModel::NUM_CHANNELS) {
         return;
     }
-    const int channel = trx + 1;
-    if (!m_tciIqChannels.contains(channel)) {
-        return;  // borrowed from the DAX IQ applet / another local consumer
+    const int channel = iqChannelForTrx(trx);
+    if (channel == 0 || iqChannelInUse(channel)) {
+        return;  // another subscribed receiver shares this pan's channel
+    }
+    releaseIqChannel(channel);
+}
+
+void TciServer::releaseIqChannel(int channel)
+{
+    if (!m_model || !m_tciIqChannels.contains(channel)) {
+        return;  // not ours to remove
+    }
+    // Release the pan binding as well as the stream. Leaving it set ends a
+    // session with a panadapter routed at a channel nothing reads, which then
+    // blocks the DAX IQ applet from using that pan.
+    const QString panId = m_iqPanChannel.key(channel, QString());
+    if (!panId.isEmpty()) {
+        m_model->sendCommand(
+            QStringLiteral("display pan set %1 daxiq_channel=0").arg(panId));
+        m_iqPanChannel.remove(panId);
     }
     if (!m_model->daxIqModel().stream(channel).exists) {
+        // iq_stop won the race against the create status; DaxIqModel cannot
+        // remove an id it has not learned. The streamChanged reaper finishes.
         m_pendingIqRemovals.insert(channel);
         return;
     }
     m_model->daxIqModel().removeStream(channel);
     m_tciIqChannels.remove(channel);
+    m_iqCreateInFlight.remove(channel);
     m_pendingIqRemovals.remove(channel);
 }
 
+// The DaxIqModel mutations below are called DIRECTLY, not via
+// QMetaObject::invokeMethod(..., Qt::QueuedConnection) as the single-stream
+// code they replace did. That deferral was not needed for thread safety —
+// TciServer is constructed on the GUI thread alongside RadioModel
+// (MainWindow_Session.cpp) — and dropping it is deliberate, so that
+// ensureIqStream() can report whether the receiver was actually armed. The
+// consequence to keep in mind when editing: the streamChanged reaper can now
+// run reentrantly inside onTextMessage()/onClientDisconnected(). It only reads
+// m_clients, never mutates it, which is what makes that safe.
 void TciServer::reconcileIqStreams()
 {
     QSet<int> receivers;
@@ -3866,19 +4005,43 @@ void TciServer::reconcileIqStreams()
 void TciServer::releaseAllIqStreams()
 {
     if (!m_model) {
-        m_tciIqChannels.clear();
-        m_pendingIqRemovals.clear();
+        resetIqStreamBookkeeping();
         return;
     }
-    const QSet<int> ownedChannels = m_tciIqChannels;
-    for (int channel : ownedChannels) {
-        if (m_model->daxIqModel().stream(channel).exists) {
-            m_model->daxIqModel().removeStream(channel);
-            m_tciIqChannels.remove(channel);
-        } else {
-            m_pendingIqRemovals.insert(channel);
+    const QSet<int> owned = m_tciIqChannels;
+    for (int channel : owned) {
+        releaseIqChannel(channel);
+    }
+    // Keep exactly the ownership entries the reaper still needs; drop the rest.
+    // The same TciServer object is stopped and restarted by TciApplet (enable
+    // toggle, port change), so a claim left behind here outlives the session
+    // that made it.
+    m_iqCreateInFlight.clear();
+    m_iqPanChannel.clear();
+    m_tciIqChannels.intersect(m_pendingIqRemovals);
+}
+
+void TciServer::resetIqStreamBookkeeping()
+{
+    m_tciIqChannels.clear();
+    m_iqCreateInFlight.clear();
+    m_pendingIqRemovals.clear();
+    m_iqPanChannel.clear();
+}
+
+int TciServer::achievedIqSampleRate() const
+{
+    if (m_model) {
+        QList<int> channels(m_tciIqChannels.cbegin(), m_tciIqChannels.cend());
+        std::sort(channels.begin(), channels.end());
+        for (int channel : std::as_const(channels)) {
+            const DaxIqModel::IqStream& stream = m_model->daxIqModel().stream(channel);
+            if (stream.exists) {
+                return stream.sampleRate;
+            }
         }
     }
+    return m_iqSampleRate;  // nothing up yet: the rate that will be applied
 }
 
 // ── Waterfall row → TCI binary spectrum frames (type=4) ──────────────────────

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -235,6 +235,8 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
                 // manage.
                 m_channelTrx.clear();
                 m_tciDaxSlices.clear();
+                m_tciIqChannels.clear();
+                m_pendingIqRemovals.clear();
                 m_trxMap.clear();  // #4567: slices die with the connection
                 m_lastDdsCenterHz.clear();
                 m_routingState.reset();
@@ -256,9 +258,10 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
                     qCInfo(lcCat) << "TCI: radio reconnected — re-arming DAX"
                                   << "for pending audio client (#3270)";
                     ensureDaxForTci();
-                    return;
+                    break;
                 }
             }
+            reconcileIqStreams();
         });
         connect(m_model, &RadioModel::sliceAdded,
                 this, [this](SliceModel* s) {
@@ -290,9 +293,14 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
                     qCInfo(lcCat) << "TCI: slice added — re-arming DAX"
                                   << "for active audio client (#3270)";
                     ensureDaxForTci();
-                    return;
+                    break;
                 }
             }
+            // IQ subscriptions survive a radio reconnect and the 500 ms
+            // stable-receiver slice recreation window. Reconcile after the
+            // trx map has been rebound so every stream returns to the same
+            // receiver/pan instead of silently following list position.
+            reconcileIqStreams();
         });
         // A removed slice never fires daxChannelChanged, so without this the
         // Tci hold on its channel stays set forever and the dax_rx stream
@@ -418,6 +426,24 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
         for (auto* pan : m_model->panadapters()) {
             wirePan(pan);
         }
+
+        // If iq_stop/disconnect wins the race against the radio's stream-create
+        // status, DaxIqModel cannot remove an id it has not learned yet. Reap
+        // the just-created stream as soon as that status arrives.
+        connect(&m_model->daxIqModel(), &DaxIqModel::streamChanged,
+                this, [this](int channel) {
+            if (!m_pendingIqRemovals.contains(channel)
+                || iqReceiverInUse(channel - 1)) {
+                return;
+            }
+            const DaxIqModel::IqStream& stream = m_model->daxIqModel().stream(channel);
+            if (!stream.exists) {
+                return;
+            }
+            m_model->daxIqModel().removeStream(channel);
+            m_pendingIqRemovals.remove(channel);
+            m_tciIqChannels.remove(channel);
+        });
     }
 
     // Periodic status broadcast (200ms — S-meter, TX sensors, TX state)
@@ -528,6 +554,10 @@ void TciServer::stop()
     stopTxChrono();
 
     if (!m_server) return;
+
+    // Server shutdown bypasses onClientDisconnected(), so release every IQ
+    // stream TCI created before throwing away the per-client subscriptions.
+    releaseAllIqStreams();
 
     for (auto& cs : m_clients) {
         cs.socket->disconnect(this);   // prevent onClientDisconnected re-entry
@@ -795,23 +825,12 @@ void TciServer::onClientDisconnected()
             if (ws == m_tciPttClient || ws == m_txChronoClient) {
                 abortTciPtt();
             }
-            // Clean up IQ stream if this client started one
-            if (m_clients[i].iqEnabled && m_model) {
-                int ch = m_clients[i].iqChannel + 1;  // TRX 0 → DAX channel 1
-                // Only remove if no other client uses the same IQ channel
-                bool otherUsing = false;
-                for (int j = 0; j < m_clients.size(); ++j) {
-                    if (j != i && m_clients[j].iqEnabled &&
-                        m_clients[j].iqChannel == m_clients[i].iqChannel) {
-                        otherUsing = true;
-                        break;
-                    }
-                }
-                if (!otherUsing) {
-                    QMetaObject::invokeMethod(m_model, [this, ch]() {
-                        m_model->daxIqModel().removeStream(ch);
-                    }, Qt::QueuedConnection);
-                }
+            // Drop every receiver this client subscribed, independently. The
+            // stream survives when another client still consumes that receiver.
+            const QSet<int> iqReceivers = m_clients[i].iqReceivers;
+            m_clients[i].iqReceivers.clear();
+            for (int trx : iqReceivers) {
+                releaseIqStreamIfUnused(trx);
             }
             delete m_clients[i].protocol;
             qDeleteAll(m_clients[i].resamplers);
@@ -874,7 +893,7 @@ QVector<TciClientInfo> TciServer::connectedClients() const
         info.peerPort     = cs.socket->peerPort();
         info.audio        = cs.audioEnabled;
         info.audioReceiver= cs.audioReceiver;
-        info.iq           = cs.iqEnabled;
+        info.iq           = !cs.iqReceivers.isEmpty();
         info.rxSensors    = cs.rxSensorsEnabled;
         info.txSensors    = cs.txSensorsEnabled;
         out.append(info);
@@ -1213,55 +1232,87 @@ void TciServer::onTextMessage(const QString& msg)
             continue;
         }
 
-        // IQ start/stop — track per-client IQ state, then forward to protocol.
-        //
-        // The trx is parsed with the ok flag checked for the same reason
-        // TciProtocol's argToInt exists (#4867): an unchecked toInt() turns
-        // `iq_start:abc;` into trx 0. That used to be merely wrong in the same
-        // way on both sides — the protocol also resolved it to 0 and created
-        // DAX IQ channel 1, so server bookkeeping and radio state agreed. Now
-        // that cmdIqStart rejects it, an unchecked parse here would leave the
-        // two DISAGREEING: this client registered as a subscriber on trx 0
-        // with no stream ever created for it, receiving another client's
-        // channel-1 IQ frames (onIqDataReady) and eligible to tear that
-        // client's stream down on disconnect. Drop the command instead, which
-        // is also what the protocol does with it half a dozen lines later.
-        if (trimmed.startsWith("iq_start:")) {
-            const int colonIdx2 = trimmed.indexOf(':');
-            bool trxOk = false;
-            const int trx = trimmed.mid(colonIdx2 + 1).trimmed().toInt(&trxOk);
-            if (!trxOk || trx < 0 || trx > 3)
+        // IQ sample rate is one achieved setting shared by the four physical
+        // DAX IQ streams. Apply it to every active receiver and remember it for
+        // streams started later. A valid SET is still announced to peers, as
+        // established by #3913; a rejected SET answers only the requester.
+        if (trimmed == QLatin1String("iq_samplerate")
+            || trimmed.startsWith(QLatin1String("iq_samplerate:"))) {
+            const int colonIdx2 = trimmed.indexOf(QLatin1Char(':'));
+            const QString value = colonIdx2 >= 0
+                ? trimmed.mid(colonIdx2 + 1).section(QLatin1Char(','), 0, 0).trimmed()
+                : QString();
+            if (value.isEmpty()) {
+                replyText(ws, QStringLiteral("iq_samplerate:%1;").arg(m_iqSampleRate));
                 continue;
-            client.iqEnabled = true;
-            client.iqChannel = trx;
+            }
+            bool ok = false;
+            const int rate = value.toInt(&ok);
+            const bool supported = ok
+                && (rate == 24000 || rate == 48000
+                    || rate == 96000 || rate == 192000);
+            if (!supported) {
+                replyText(ws, QStringLiteral("iq_samplerate:%1;").arg(m_iqSampleRate));
+                continue;
+            }
+            m_iqSampleRate = rate;
+            QSet<int> activeReceivers;
+            for (const ClientState& cs : std::as_const(m_clients)) {
+                activeReceivers.unite(cs.iqReceivers);
+            }
+            for (int trx : activeReceivers) {
+                if (m_model) {
+                    m_model->daxIqModel().setSampleRate(trx + 1, rate);
+                }
+            }
+            const QString response = QStringLiteral("iq_samplerate:%1;").arg(rate);
+            replyText(ws, response);
+            for (ClientState& cs : m_clients) {
+                if (cs.socket != ws) {
+                    cs.socket->sendTextMessage(response);
+                }
+            }
+            continue;
+        }
+
+        // IQ start/stop — subscriptions are sets, so one SDC connection can
+        // keep skimmers open on four receiver/pan pairs at once.
+        if (trimmed.startsWith("iq_start:")) {
+            const int colonIdx2 = trimmed.indexOf(QLatin1Char(':'));
+            bool ok = false;
+            const int trx = trimmed.mid(colonIdx2 + 1)
+                                .section(QLatin1Char(','), 0, 0)
+                                .trimmed().toInt(&ok);
+            if (!ok || trx < 0 || trx >= DaxIqModel::NUM_CHANNELS
+                || !m_trxMap.trxHasLiveSlice(m_model, trx)) {
+                qCWarning(lcCat) << "TCI: refusing IQ start for unknown receiver"
+                                 << trimmed.mid(colonIdx2 + 1).left(32);
+                continue;
+            }
+            startIqForClient(client, trx);
             qCInfo(lcCat) << "TCI: IQ started for client"
                           << ws->peerAddress().toString()
                           << "trx=" << trx;
-            // Forward to protocol to create DAX IQ stream on the radio
-            QString response = client.protocol->handleCommand(cmd.trimmed());
-            if (!response.isEmpty())
-                replyText(ws,response);
+            replyText(ws, QStringLiteral("iq_start:%1;").arg(trx));
             emit clientsChanged();
             continue;
         }
         if (trimmed.startsWith("iq_stop:")) {
-            // Checked for the same reason as iq_start above: an unchecked
-            // parse would clear iqEnabled for a client whose channel really
-            // is 0 whenever any garbage arrived, while the protocol declined
-            // to remove the stream.
-            const int colonIdx2 = trimmed.indexOf(':');
-            bool trxOk = false;
-            const int trx = trimmed.mid(colonIdx2 + 1).trimmed().toInt(&trxOk);
-            if (!trxOk || trx < 0 || trx > 3)
+            const int colonIdx2 = trimmed.indexOf(QLatin1Char(':'));
+            bool ok = false;
+            const int trx = trimmed.mid(colonIdx2 + 1)
+                                .section(QLatin1Char(','), 0, 0)
+                                .trimmed().toInt(&ok);
+            if (!ok || trx < 0 || trx >= DaxIqModel::NUM_CHANNELS) {
+                qCWarning(lcCat) << "TCI: refusing IQ stop for invalid receiver"
+                                 << trimmed.mid(colonIdx2 + 1).left(32);
                 continue;
-            if (client.iqChannel == trx)
-                client.iqEnabled = false;
+            }
+            stopIqForClient(client, trx);
             qCInfo(lcCat) << "TCI: IQ stopped for client"
                           << ws->peerAddress().toString()
                           << "trx=" << trx;
-            QString response = client.protocol->handleCommand(cmd.trimmed());
-            if (!response.isEmpty())
-                replyText(ws,response);
+            replyText(ws, QStringLiteral("iq_stop:%1;").arg(trx));
             emit clientsChanged();
             continue;
         }
@@ -3697,7 +3748,7 @@ void TciServer::onIqDataReady(int channel, const QByteArray& rawPayload, int sam
     bool anyIq = false;
     int trx = channel - 1;  // DAX IQ channel 1 → TRX 0
     for (const auto& cs : m_clients) {
-        if (cs.iqEnabled && cs.iqChannel == trx) { anyIq = true; break; }
+        if (cs.iqReceivers.contains(trx)) { anyIq = true; break; }
     }
     if (!anyIq) return;
 
@@ -3721,8 +3772,112 @@ void TciServer::onIqDataReady(int channel, const QByteArray& rawPayload, int sam
                                        iqFrames);
 
     for (auto& cs : m_clients) {
-        if (cs.iqEnabled && cs.iqChannel == trx)
+        if (cs.iqReceivers.contains(trx))
             cs.socket->sendBinaryMessage(frame);
+    }
+}
+
+bool TciServer::iqReceiverInUse(int trx, const QWebSocket* except) const
+{
+    for (const ClientState& cs : m_clients) {
+        if (cs.socket != except && cs.iqReceivers.contains(trx)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void TciServer::startIqForClient(ClientState& client, int trx)
+{
+    client.iqReceivers.insert(trx);
+    m_pendingIqRemovals.remove(trx + 1);
+    // IQ_START is idempotent, but it is also a useful re-arm after a radio or
+    // pan-side stream disappeared without a matching IQ_STOP. Always reconcile
+    // the physical stream instead of treating a duplicate SET as a no-op.
+    ensureIqStream(trx);
+}
+
+void TciServer::stopIqForClient(ClientState& client, int trx)
+{
+    if (client.iqReceivers.remove(trx) == 0) {
+        return;
+    }
+    releaseIqStreamIfUnused(trx);
+}
+
+void TciServer::ensureIqStream(int trx)
+{
+    if (!m_model || trx < 0 || trx >= DaxIqModel::NUM_CHANNELS
+        || !m_trxMap.trxHasLiveSlice(m_model, trx)
+        || !m_model->backendCapabilities().hasDaxStreams) {
+        return;
+    }
+
+    SliceModel* slice = sliceForTrx(trx);
+    if (!slice) {
+        return;
+    }
+    const int channel = trx + 1;
+    DaxIqModel& iq = m_model->daxIqModel();
+    iq.setSampleRate(channel, m_iqSampleRate);
+    if (!iq.stream(channel).exists && !m_tciIqChannels.contains(channel)) {
+        m_tciIqChannels.insert(channel);
+        iq.createStream(channel);
+    }
+
+    // A DAX IQ stream is inert until a pan owns its channel. Bind the stable
+    // receiver's current pan, preserving #3913's dds == IQ-center contract.
+    if (!slice->panId().isEmpty()) {
+        m_model->sendCommand(QStringLiteral("display pan set %1 daxiq_channel=%2")
+                                 .arg(slice->panId()).arg(channel));
+    }
+}
+
+void TciServer::releaseIqStreamIfUnused(int trx)
+{
+    if (!m_model || trx < 0 || trx >= DaxIqModel::NUM_CHANNELS
+        || iqReceiverInUse(trx)) {
+        return;
+    }
+    const int channel = trx + 1;
+    if (!m_tciIqChannels.contains(channel)) {
+        return;  // borrowed from the DAX IQ applet / another local consumer
+    }
+    if (!m_model->daxIqModel().stream(channel).exists) {
+        m_pendingIqRemovals.insert(channel);
+        return;
+    }
+    m_model->daxIqModel().removeStream(channel);
+    m_tciIqChannels.remove(channel);
+    m_pendingIqRemovals.remove(channel);
+}
+
+void TciServer::reconcileIqStreams()
+{
+    QSet<int> receivers;
+    for (const ClientState& cs : std::as_const(m_clients)) {
+        receivers.unite(cs.iqReceivers);
+    }
+    for (int trx : receivers) {
+        ensureIqStream(trx);
+    }
+}
+
+void TciServer::releaseAllIqStreams()
+{
+    if (!m_model) {
+        m_tciIqChannels.clear();
+        m_pendingIqRemovals.clear();
+        return;
+    }
+    const QSet<int> ownedChannels = m_tciIqChannels;
+    for (int channel : ownedChannels) {
+        if (m_model->daxIqModel().stream(channel).exists) {
+            m_model->daxIqModel().removeStream(channel);
+            m_tciIqChannels.remove(channel);
+        } else {
+            m_pendingIqRemovals.insert(channel);
+        }
     }
 }
 

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -264,8 +264,11 @@ private:
         QHash<int, QByteArray> rxAccumBuf;
         bool         rxSensorsEnabled{false};
         bool         txSensorsEnabled{false};
-        bool         iqEnabled{false};       // client sent IQ_START
-        int          iqChannel{0};           // TCI TRX → DAX IQ channel (0-based)
+        // TCI IQ subscriptions are per client AND per receiver. SDC can open
+        // several skimmers over one WebSocket by sending iq_start for each
+        // receiver; a single scalar silently replaced the previous receiver
+        // and left its radio-side DAX IQ stream orphaned.
+        QSet<int>    iqReceivers;             // TCI TRX indexes (0..3)
         bool         spectrumEnabled{false}; // client sent spectrum_event:on;
         // Payload-free lifecycle telemetry retained across disconnect. Command
         // names are stored without their arguments, so diagnostics can identify
@@ -279,6 +282,14 @@ private:
         int          lastSocketError{-1};
         QString      lastSocketErrorString;
     };
+
+    bool iqReceiverInUse(int trx, const QWebSocket* except = nullptr) const;
+    void startIqForClient(ClientState& client, int trx);
+    void stopIqForClient(ClientState& client, int trx);
+    void ensureIqStream(int trx);
+    void releaseIqStreamIfUnused(int trx);
+    void reconcileIqStreams();
+    void releaseAllIqStreams();
 
     // Minimum frames to accumulate before flushing to r8brain.
     // ~21ms at 24kHz — large enough for clean resampling, small enough
@@ -302,6 +313,12 @@ private:
     QPointer<SliceModel> m_activeSlice;
     QString           m_activeLetter;   // focused slice's display letter (#4160)
     QMap<int, int>     m_channelTrx;            // DAX channel → last-resolved TCI TRX (routing cache, #3669)
+    // DAX IQ channels created by TCI rather than borrowed from another local
+    // consumer. Only owned channels are removed when the last TCI subscriber
+    // leaves. Pending removal covers iq_stop racing the stream-create status.
+    QSet<int>         m_tciIqChannels;          // 1-based DAX IQ channels
+    QSet<int>         m_pendingIqRemovals;      // 1-based channels awaiting create status
+    int               m_iqSampleRate{48000};   // shared achieved rate for all TCI IQ receivers
     QHash<QString, long long> m_lastDdsCenterHz; // panId → last broadcast dds center, gates zoom-only re-emits (#3910)
     TciRoutingState m_routingState;
     // #4567: stable sliceId→trx receiver bindings. Acquired on sliceAdded,

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -283,13 +283,26 @@ private:
         QString      lastSocketErrorString;
     };
 
-    bool iqReceiverInUse(int trx, const QWebSocket* except = nullptr) const;
-    void startIqForClient(ClientState& client, int trx);
+    // TCI IQ subscription plumbing. A receiver's IQ comes from the DAX IQ
+    // channel bound to that receiver's *pan*, not from trx+1 directly: on a
+    // FLEX `daxiq_channel` is a Panadapter property and the pan↔channel
+    // binding is 1:1 in both directions, so two receivers whose slices share
+    // a panadapter necessarily share one channel (measured on a FLEX-6700,
+    // firmware V1.4.0.0 — binding a channel to a second pan makes the radio
+    // push `daxiq_channel=0` to the first). Since those two receivers also see
+    // the same spectrum, one stream legitimately serves both; the frames are
+    // stamped with each subscriber's own receiver index on the way out.
+    int  iqChannelForTrx(int trx) const;   // 0 when the receiver has no channel
+    bool iqChannelInUse(int channel) const;
+    bool startIqForClient(ClientState& client, int trx);
     void stopIqForClient(ClientState& client, int trx);
-    void ensureIqStream(int trx);
+    bool ensureIqStream(int trx);
     void releaseIqStreamIfUnused(int trx);
+    void releaseIqChannel(int channel);
     void reconcileIqStreams();
     void releaseAllIqStreams();
+    void resetIqStreamBookkeeping();
+    int  achievedIqSampleRate() const;
 
     // Minimum frames to accumulate before flushing to r8brain.
     // ~21ms at 24kHz — large enough for clean resampling, small enough
@@ -313,12 +326,16 @@ private:
     QPointer<SliceModel> m_activeSlice;
     QString           m_activeLetter;   // focused slice's display letter (#4160)
     QMap<int, int>     m_channelTrx;            // DAX channel → last-resolved TCI TRX (routing cache, #3669)
-    // DAX IQ channels created by TCI rather than borrowed from another local
-    // consumer. Only owned channels are removed when the last TCI subscriber
-    // leaves. Pending removal covers iq_stop racing the stream-create status.
-    QSet<int>         m_tciIqChannels;          // 1-based DAX IQ channels
-    QSet<int>         m_pendingIqRemovals;      // 1-based channels awaiting create status
-    int               m_iqSampleRate{48000};   // shared achieved rate for all TCI IQ receivers
+    // DAX IQ channels created by TCI. A channel the DAX IQ applet already owns
+    // is never taken over: `iq_start` is refused rather than retargeting the
+    // operator's pan and rate behind their back. Ownership, in-flight create
+    // and pending removal are three separate facts — conflating them wedged a
+    // receiver whose create was lost or which outlived a stop()/start() cycle.
+    QSet<int>          m_tciIqChannels;      // 1-based channels TCI created
+    QSet<int>          m_iqCreateInFlight;   // create issued, status not yet seen
+    QSet<int>          m_pendingIqRemovals;  // awaiting a create status to reap
+    QHash<QString,int> m_iqPanChannel;       // panId → TCI-owned DAX IQ channel
+    int                m_iqSampleRate{48000};// shared requested rate, all TCI receivers
     QHash<QString, long long> m_lastDdsCenterHz; // panId → last broadcast dds center, gates zoom-only re-emits (#3910)
     TciRoutingState m_routingState;
     // #4567: stable sliceId→trx receiver bindings. Acquired on sliceAdded,

--- a/tests/tci_server_review_test.cpp
+++ b/tests/tci_server_review_test.cpp
@@ -40,6 +40,45 @@ void captureLogHandler(QtMsgType, const QMessageLogContext&, const QString& msg)
     }
 }
 
+// RadioModel has no outbound-command signal, and the pan↔channel binding this
+// file now asserts goes out through RadioModel::sendCommand(), not DaxIqModel.
+// It is logged at debug on aether.protocol, so capture that for the lifetime of
+// a test rather than leaving the bind unasserted — without it, four channels
+// fighting over one panadapter looks identical to four working streams.
+class ScopedCommandLog
+{
+public:
+    ScopedCommandLog()
+    {
+        g_logSink = &m_lines;
+        m_previous = qInstallMessageHandler(captureLogHandler);
+        QLoggingCategory::setFilterRules(QStringLiteral("aether.protocol.debug=true"));
+    }
+    ~ScopedCommandLog()
+    {
+        QLoggingCategory::setFilterRules(QString());
+        qInstallMessageHandler(m_previous);
+        g_logSink = nullptr;
+    }
+    ScopedCommandLog(const ScopedCommandLog&) = delete;
+    ScopedCommandLog& operator=(const ScopedCommandLog&) = delete;
+
+    bool contains(const QString& fragment) const
+    {
+        for (const QString& line : m_lines) {
+            if (line.contains(fragment)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    void clear() { m_lines.clear(); }
+
+private:
+    QStringList      m_lines;
+    QtMessageHandler m_previous{nullptr};
+};
+
 // Collect everything logged while `body` runs. aether.cat defaults to
 // QtWarningMsg, so the info-level route line needs the rule as well as the
 // handler.
@@ -1340,12 +1379,47 @@ public:
                            static_cast<size_t>(expectedPcm.size())) == 0;
     }
 
-    // SDC can open several skimmers over one WebSocket by subscribing each
-    // advertised receiver. The pre-fix scalar iqChannel retained only the last
-    // iq_start, so only one band received frames and the earlier DAX IQ streams
-    // leaked. Exercise the actual socket parser and binary sender for all four.
-    static bool oneClientReceivesFourIqStreams()
+    // Put a fixture slice on a panadapter of its own. automationApplySliceFixture
+    // hardcodes pan 0x40000000 for every slice, which is the shared-pan case —
+    // useful on its own, but it cannot exercise four distinct channels.
+    static void movePan(RadioModel& model, int sliceId, const QString& panId)
     {
+        QMap<QString, QString> kvs;
+        kvs.insert(QStringLiteral("pan"), panId);
+        model.handleSliceStatusForTest(sliceId, kvs, false);
+    }
+
+    struct IqHarness {
+        QStringList         iqCommands;
+        QVector<QByteArray> frames;
+    };
+
+    static QSet<int> frameReceivers(const QVector<QByteArray>& frames)
+    {
+        QSet<int> receivers;
+        for (const QByteArray& frame : frames) {
+            if (frame.size() < 64) {
+                continue;
+            }
+            quint32 receiver = 0;
+            quint32 type = 0;
+            std::memcpy(&receiver, frame.constData(), sizeof(receiver));
+            std::memcpy(&type,
+                        frame.constData() + 6 * static_cast<int>(sizeof(quint32)),
+                        sizeof(type));
+            if (type == 0) {
+                receivers.insert(static_cast<int>(receiver));
+            }
+        }
+        return receivers;
+    }
+
+    // Four receivers on four panadapters: the ordinary skimmer setup. Each takes
+    // its documented channel (trx n → DAX IQ channel n+1, #3913), each pan is
+    // bound to it, and stopping one leaves the other three streaming.
+    static bool fourPansGiveFourIqStreams()
+    {
+        ScopedCommandLog cmdLog;
         RadioModel model;
         TciServer server(&model);
 
@@ -1356,25 +1430,22 @@ public:
                             error.toUtf8().constData());
                 return false;
             }
+            movePan(model, sliceId,
+                    QStringLiteral("0x4000000%1").arg(sliceId));
         }
 
-        QStringList iqCommands;
+        IqHarness h;
         QObject::connect(&model.daxIqModel(), &DaxIqModel::commandReady,
-                         [&iqCommands](const QString& command) {
-            iqCommands.append(command);
-        });
+                         [&h](const QString& c) { h.iqCommands.append(c); });
 
         if (!server.start(0) || !server.m_server) {
             std::printf("      TCI server failed to bind an ephemeral port\n");
             return false;
         }
 
-        QVector<QByteArray> receivedFrames;
         QWebSocket client;
         QObject::connect(&client, &QWebSocket::binaryMessageReceived,
-                         [&receivedFrames](const QByteArray& frame) {
-            receivedFrames.append(frame);
-        });
+                         [&h](const QByteArray& f) { h.frames.append(f); });
         client.open(QUrl(QStringLiteral("ws://127.0.0.1:%1").arg(server.port())));
         for (int i = 0; i < 100
              && (client.state() != QAbstractSocket::ConnectedState
@@ -1403,10 +1474,20 @@ public:
             return false;
         }
         for (int channel = 1; channel <= DaxIqModel::NUM_CHANNELS; ++channel) {
-            if (!iqCommands.contains(
+            if (!h.iqCommands.contains(
                     QStringLiteral("stream create type=dax_iq daxiq_channel=%1")
                         .arg(channel))) {
                 std::printf("      no DAX IQ create for channel %d\n", channel);
+                return false;
+            }
+            // The stream is inert until its pan is routed to it. Assert the
+            // bind, not just the create — nothing else in this file did, so
+            // four channels fighting over one pan looked identical to four
+            // working streams.
+            if (!cmdLog.contains(
+                    QStringLiteral("display pan set 0x4000000%1 daxiq_channel=%2")
+                        .arg(channel - 1).arg(channel))) {
+                std::printf("      no pan bind for channel %d\n", channel);
                 return false;
             }
         }
@@ -1418,80 +1499,321 @@ public:
             server.onIqDataReady(channel, rawPayload, 96000);
         }
         for (int i = 0; i < 100
-             && receivedFrames.size() < DaxIqModel::NUM_CHANNELS; ++i) {
+             && h.frames.size() < DaxIqModel::NUM_CHANNELS; ++i) {
             spin(10);
         }
-
-        const auto frameReceivers = [](const QVector<QByteArray>& frames) {
-            QSet<int> receivers;
-            for (const QByteArray& frame : frames) {
-                if (frame.size() < 64) {
-                    continue;
-                }
-                quint32 receiver = 0;
-                quint32 type = 0;
-                std::memcpy(&receiver, frame.constData(), sizeof(receiver));
-                std::memcpy(&type,
-                            frame.constData() + 6 * static_cast<int>(sizeof(quint32)),
-                            sizeof(type));
-                if (type == 0) {
-                    receivers.insert(static_cast<int>(receiver));
-                }
-            }
-            return receivers;
-        };
-        if (frameReceivers(receivedFrames) != allReceivers) {
+        if (frameReceivers(h.frames) != allReceivers) {
             std::printf("      four-stream frame receivers=%lld\n",
-                        static_cast<long long>(frameReceivers(receivedFrames).size()));
+                        static_cast<long long>(frameReceivers(h.frames).size()));
             return false;
         }
 
-        // Stopping receiver 1 must leave 0, 2 and 3 live on this same socket.
+        // Stopping receiver 1 must leave 0, 2 and 3 live on this same socket,
+        // and must release channel 2 — stream AND pan binding, so the pan is
+        // not left routed at a channel nothing reads.
+        cmdLog.clear();
         client.sendTextMessage(QStringLiteral("iq_stop:1;"));
         for (int i = 0; i < 100
              && server.m_clients.first().iqReceivers.contains(1); ++i) {
             spin(10);
         }
-        receivedFrames.clear();
+        if (!cmdLog.contains(
+                QStringLiteral("display pan set 0x40000001 daxiq_channel=0"))) {
+            std::printf("      stopped receiver left its pan bound\n");
+            return false;
+        }
+        h.frames.clear();
         for (int channel = 1; channel <= DaxIqModel::NUM_CHANNELS; ++channel) {
             server.onIqDataReady(channel, rawPayload, 96000);
         }
-        for (int i = 0; i < 100 && receivedFrames.size() < 3; ++i) {
+        for (int i = 0; i < 100 && h.frames.size() < 3; ++i) {
             spin(10);
         }
         return server.m_clients.first().iqReceivers == QSet<int>{0, 2, 3}
-            && frameReceivers(receivedFrames) == QSet<int>{0, 2, 3};
+            && frameReceivers(h.frames) == QSet<int>{0, 2, 3};
     }
 
-    // Receiver resources are multicast/reference-counted across clients. One
-    // client's stop must not remove a stream another still consumes, and a
-    // stop racing the create status must remain pending until an id exists.
+    // Two receivers whose slices share a panadapter — the ordinary A/B layout.
+    // On a FLEX the pan↔channel binding is 1:1 in both directions, so binding a
+    // second channel to the same pan takes the first one away and the earlier
+    // skimmer goes silent with no error anywhere. Both receivers see the same
+    // spectrum, so ONE channel serves both, and each gets its own frame header.
+    static bool receiversSharingAPanShareOneChannel()
+    {
+        ScopedCommandLog cmdLog;
+        RadioModel model;
+        TciServer server(&model);
+
+        QString error;
+        for (int sliceId = 0; sliceId < 2; ++sliceId) {
+            if (!model.automationApplySliceFixture(sliceId, QString(), &error)) {
+                return false;
+            }
+        }
+        // Both fixtures are already on 0x40000000; assert that rather than
+        // assume it, so a fixture change cannot quietly void this test.
+        if (model.slice(0)->panId() != model.slice(1)->panId()) {
+            std::printf("      fixtures are not on a shared pan\n");
+            return false;
+        }
+
+        IqHarness h;
+        QObject::connect(&model.daxIqModel(), &DaxIqModel::commandReady,
+                         [&h](const QString& c) { h.iqCommands.append(c); });
+
+        if (!server.start(0) || !server.m_server) {
+            std::printf("      TCI server failed to bind an ephemeral port\n");
+            return false;
+        }
+        QWebSocket client;
+        QObject::connect(&client, &QWebSocket::binaryMessageReceived,
+                         [&h](const QByteArray& f) { h.frames.append(f); });
+        client.open(QUrl(QStringLiteral("ws://127.0.0.1:%1").arg(server.port())));
+        for (int i = 0; i < 100
+             && (client.state() != QAbstractSocket::ConnectedState
+                 || server.m_clients.isEmpty()); ++i) {
+            spin(10);
+        }
+        if (server.m_clients.isEmpty()) return false;
+
+        client.sendTextMessage(QStringLiteral("iq_start:0;iq_start:1;"));
+        for (int i = 0; i < 100
+             && server.m_clients.first().iqReceivers.size() != 2; ++i) {
+            spin(10);
+        }
+        if (server.m_clients.first().iqReceivers != QSet<int>{0, 1}) {
+            std::printf("      shared-pan receivers=%lld\n",
+                        static_cast<long long>(
+                            server.m_clients.first().iqReceivers.size()));
+            return false;
+        }
+        // Exactly one stream, on channel 1, and no second pan bind that would
+        // have stolen it back.
+        if (h.iqCommands.filter(QStringLiteral("stream create type=dax_iq")).size() != 1
+            || !h.iqCommands.contains(
+                   QStringLiteral("stream create type=dax_iq daxiq_channel=1"))) {
+            std::printf("      shared pan created %d streams\n",
+                        static_cast<int>(h.iqCommands
+                            .filter(QStringLiteral("stream create type=dax_iq")).size()));
+            return false;
+        }
+        if (cmdLog.contains(
+                QStringLiteral("display pan set 0x40000000 daxiq_channel=2"))) {
+            std::printf("      second receiver stole the pan binding\n");
+            return false;
+        }
+
+        // One payload on that one channel feeds both receivers, each stamped
+        // with its own receiver index.
+        float iqPair[2]{0.25f, -0.5f};
+        QByteArray rawPayload(reinterpret_cast<const char*>(iqPair),
+                              static_cast<int>(sizeof(iqPair)));
+        server.onIqDataReady(1, rawPayload, 48000);
+        for (int i = 0; i < 100 && h.frames.size() < 2; ++i) {
+            spin(10);
+        }
+        if (frameReceivers(h.frames) != QSet<int>{0, 1}) {
+            std::printf("      shared-channel frame receivers=%lld\n",
+                        static_cast<long long>(frameReceivers(h.frames).size()));
+            return false;
+        }
+
+        // Stopping one must NOT tear down the channel the other still uses.
+        cmdLog.clear();
+        client.sendTextMessage(QStringLiteral("iq_stop:0;"));
+        for (int i = 0; i < 100
+             && server.m_clients.first().iqReceivers.contains(0); ++i) {
+            spin(10);
+        }
+        if (!server.m_tciIqChannels.contains(1)
+            || cmdLog.contains(
+                   QStringLiteral("display pan set 0x40000000 daxiq_channel=0"))) {
+            std::printf("      shared channel released while still in use\n");
+            return false;
+        }
+        h.frames.clear();
+        server.onIqDataReady(1, rawPayload, 48000);
+        for (int i = 0; i < 100 && h.frames.isEmpty(); ++i) {
+            spin(10);
+        }
+        return frameReceivers(h.frames) == QSet<int>{1};
+    }
+
+    // A DAX IQ channel the operator's applet already owns is never taken over.
+    // Binding it to the TCI slice's pan makes the radio push daxiq_channel=0 to
+    // the operator's pan and stops their consumer at the source, and nothing
+    // ever puts it back — so refuse, and SAY so rather than going silent.
+    static bool borrowedIqChannelIsRefused()
+    {
+        ScopedCommandLog cmdLog;
+        RadioModel model;
+        TciServer server(&model);
+
+        QString error;
+        if (!model.automationApplySliceFixture(0, QString(), &error)) {
+            return false;
+        }
+        // The applet owns channel 1: the stream exists and TCI did not make it.
+        QMap<QString, QString> kvs;
+        kvs.insert(QStringLiteral("daxiq_channel"), QStringLiteral("1"));
+        kvs.insert(QStringLiteral("daxiq_rate"), QStringLiteral("192000"));
+        model.daxIqModel().applyStreamStatus(0x2000abcd, kvs);
+        if (!model.daxIqModel().stream(1).exists) {
+            std::printf("      applet stream fixture did not take\n");
+            return false;
+        }
+
+        IqHarness h;
+        QObject::connect(&model.daxIqModel(), &DaxIqModel::commandReady,
+                         [&h](const QString& c) { h.iqCommands.append(c); });
+
+        if (!server.start(0) || !server.m_server) {
+            std::printf("      TCI server failed to bind an ephemeral port\n");
+            return false;
+        }
+        QStringList replies;
+        QWebSocket client;
+        QObject::connect(&client, &QWebSocket::textMessageReceived,
+                         [&replies](const QString& m) { replies.append(m); });
+        client.open(QUrl(QStringLiteral("ws://127.0.0.1:%1").arg(server.port())));
+        for (int i = 0; i < 100
+             && (client.state() != QAbstractSocket::ConnectedState
+                 || server.m_clients.isEmpty()); ++i) {
+            spin(10);
+        }
+        if (server.m_clients.isEmpty()) return false;
+        replies.clear();
+
+        client.sendTextMessage(QStringLiteral("iq_start:0;"));
+        for (int i = 0; i < 60; ++i) {
+            spin(10);
+        }
+        if (!server.m_clients.first().iqReceivers.isEmpty()) {
+            std::printf("      refused start still subscribed the receiver\n");
+            return false;
+        }
+        // The operator's pan binding and rate are untouched...
+        if (cmdLog.contains(QStringLiteral("display pan set"))) {
+            std::printf("      borrow retargeted the operator's pan\n");
+            return false;
+        }
+        if (!h.iqCommands.isEmpty()) {
+            std::printf("      borrow touched the applet's stream: %s\n",
+                        h.iqCommands.first().toUtf8().constData());
+            return false;
+        }
+        // ...and the refusal ANSWERS, so a blocked skimmer does not hang.
+        for (const QString& r : std::as_const(replies)) {
+            if (r.contains(QStringLiteral("iq_stop:0;"))) {
+                return true;
+            }
+        }
+        std::printf("      refused start sent no reply\n");
+        return false;
+    }
+
+    // Ownership, in-flight-create and pending-removal are three separate facts.
+    // Conflating them wedged a receiver whose stream create was never confirmed:
+    // repeated iq_start could not re-create it (contradicting the documented
+    // re-arm), and a stop()/start() cycle — TciApplet's enable toggle and port
+    // change both do exactly that on this same object — carried the stale claim
+    // into the next session, so no client could ever get IQ again.
+    static bool iqStreamRearmsAfterStopStartCycle()
+    {
+        RadioModel model;
+        TciServer server(&model);
+
+        QString error;
+        if (!model.automationApplySliceFixture(0, QString(), &error)) {
+            return false;
+        }
+        QStringList iqCommands;
+        QObject::connect(&model.daxIqModel(), &DaxIqModel::commandReady,
+                         [&iqCommands](const QString& c) { iqCommands.append(c); });
+
+        // Deliberately NOT registered in m_clients: stop() closes and deletes
+        // every registered socket, and this test only needs the subscription
+        // bookkeeping that startIqForClient drives.
+        TciServer::ClientState cs;
+        const auto startOnce = [&](TciServer& srv) {
+            return srv.startIqForClient(cs, 0);
+        };
+
+        if (!server.start(0) || !server.m_server) {
+            std::printf("      TCI server failed to bind an ephemeral port\n");
+            return false;
+        }
+        if (!startOnce(server)
+            || !iqCommands.contains(
+                   QStringLiteral("stream create type=dax_iq daxiq_channel=1"))) {
+            std::printf("      first iq_start did not create a stream\n");
+            return false;
+        }
+        // The radio never confirms the create, so stream(1).exists stays false.
+        // A repeated iq_start must not re-issue a create while that one is still
+        // outstanding — but it must not be wedged by it either.
+        server.stop();
+        iqCommands.clear();
+
+        if (!server.start(0) || !server.m_server) {
+            return false;
+        }
+        if (!startOnce(server)) {
+            std::printf("      iq_start refused after a stop()/start() cycle\n");
+            return false;
+        }
+        if (!iqCommands.contains(
+                QStringLiteral("stream create type=dax_iq daxiq_channel=1"))) {
+            std::printf("      receiver wedged: no create after restart\n");
+            return false;
+        }
+        return true;
+    }
+
+    // Receiver resources are refcounted across clients. One client's stop must
+    // not remove a stream another still consumes; only the last stop releases
+    // it, and a stop racing the create status stays pending until an id exists.
     static bool sharedIqSubscriptionIsClientScoped()
     {
         RadioModel model;
         TciServer server(&model);
+
+        QString error;
+        if (!model.automationApplySliceFixture(0, QString(), &error)) {
+            return false;
+        }
         QWebSocket clientA;
         QWebSocket clientB;
         TciServer::ClientState a;
         a.socket = &clientA;
-        a.iqReceivers.insert(1);
         TciServer::ClientState b;
         b.socket = &clientB;
-        b.iqReceivers.insert(1);
         server.m_clients.append(a);
         server.m_clients.append(b);
-        server.m_tciIqChannels.insert(2);
-
-        server.stopIqForClient(server.m_clients[0], 1);
-        if (!server.m_tciIqChannels.contains(2)
-            || server.m_pendingIqRemovals.contains(2)
-            || !server.m_clients[1].iqReceivers.contains(1)) {
+        if (!server.startIqForClient(server.m_clients[0], 0)
+            || !server.startIqForClient(server.m_clients[1], 0)) {
+            std::printf("      shared start refused\n");
+            return false;
+        }
+        if (!server.m_tciIqChannels.contains(1)
+            || server.m_iqPanChannel.value(model.slice(0)->panId()) != 1) {
             return false;
         }
 
-        server.stopIqForClient(server.m_clients[1], 1);
-        return server.m_tciIqChannels.contains(2)
-            && server.m_pendingIqRemovals.contains(2);
+        server.stopIqForClient(server.m_clients[0], 0);
+        if (!server.m_tciIqChannels.contains(1)
+            || server.m_pendingIqRemovals.contains(1)
+            || !server.m_clients[1].iqReceivers.contains(0)) {
+            std::printf("      one client's stop released a shared channel\n");
+            return false;
+        }
+
+        // Last subscriber leaves. The radio never confirmed the create, so the
+        // removal parks until the status lands — and the pan binding is dropped
+        // now rather than being left routed at a channel nothing reads.
+        server.stopIqForClient(server.m_clients[1], 0);
+        return server.m_pendingIqRemovals.contains(1)
+            && server.m_iqPanChannel.isEmpty();
     }
 };
 
@@ -1556,7 +1878,13 @@ int main(int argc, char** argv)
     const bool native24kPayload
         = AetherSDR::TciServerReviewTest::native24kAudioRetainsAccumulatedPayload();
     const bool fourIqStreams
-        = AetherSDR::TciServerReviewTest::oneClientReceivesFourIqStreams();
+        = AetherSDR::TciServerReviewTest::fourPansGiveFourIqStreams();
+    const bool sharedPanChannel
+        = AetherSDR::TciServerReviewTest::receiversSharingAPanShareOneChannel();
+    const bool borrowRefused
+        = AetherSDR::TciServerReviewTest::borrowedIqChannelIsRefused();
+    const bool iqRearms
+        = AetherSDR::TciServerReviewTest::iqStreamRearmsAfterStopStartCycle();
     const bool iqClientScoped
         = AetherSDR::TciServerReviewTest::sharedIqSubscriptionIsClientScoped();
 
@@ -1617,8 +1945,14 @@ int main(int argc, char** argv)
                 routeLogSanitizes ? "PASS" : "FAIL");
     std::printf("%s  native 24 kHz TCI RX retains accumulated payload (#4744)\n",
                 native24kPayload ? "PASS" : "FAIL");
-    std::printf("%s  one TCI client receives four independent IQ streams\n",
+    std::printf("%s  four pans give one TCI client four independent IQ streams\n",
                 fourIqStreams ? "PASS" : "FAIL");
+    std::printf("%s  receivers sharing a pan share one DAX IQ channel\n",
+                sharedPanChannel ? "PASS" : "FAIL");
+    std::printf("%s  an applet-owned DAX IQ channel is refused, not borrowed\n",
+                borrowRefused ? "PASS" : "FAIL");
+    std::printf("%s  IQ re-arms after a stop()/start() cycle\n",
+                iqRearms ? "PASS" : "FAIL");
     std::printf("%s  shared IQ subscriptions are client-scoped\n",
                 iqClientScoped ? "PASS" : "FAIL");
 
@@ -1632,6 +1966,7 @@ int main(int argc, char** argv)
         && vfoConfirmsAccepted && vfoConfirmsRefusal && vfoAcksNoOp
         && vfoChannelZeroOnce
         && routeLogStaleCache && routeLogSampleOrder && routeLogSanitizes
-        && native24kPayload && fourIqStreams && iqClientScoped
+        && native24kPayload && fourIqStreams && sharedPanChannel
+        && borrowRefused && iqRearms && iqClientScoped
         ? 0 : 1;
 }

--- a/tests/tci_server_review_test.cpp
+++ b/tests/tci_server_review_test.cpp
@@ -1339,6 +1339,160 @@ public:
                            expectedPcm.constData(),
                            static_cast<size_t>(expectedPcm.size())) == 0;
     }
+
+    // SDC can open several skimmers over one WebSocket by subscribing each
+    // advertised receiver. The pre-fix scalar iqChannel retained only the last
+    // iq_start, so only one band received frames and the earlier DAX IQ streams
+    // leaked. Exercise the actual socket parser and binary sender for all four.
+    static bool oneClientReceivesFourIqStreams()
+    {
+        RadioModel model;
+        TciServer server(&model);
+
+        QString error;
+        for (int sliceId = 0; sliceId < DaxIqModel::NUM_CHANNELS; ++sliceId) {
+            if (!model.automationApplySliceFixture(sliceId, QString(), &error)) {
+                std::printf("      IQ fixture %d failed: %s\n", sliceId,
+                            error.toUtf8().constData());
+                return false;
+            }
+        }
+
+        QStringList iqCommands;
+        QObject::connect(&model.daxIqModel(), &DaxIqModel::commandReady,
+                         [&iqCommands](const QString& command) {
+            iqCommands.append(command);
+        });
+
+        if (!server.start(0) || !server.m_server) {
+            std::printf("      TCI server failed to bind an ephemeral port\n");
+            return false;
+        }
+
+        QVector<QByteArray> receivedFrames;
+        QWebSocket client;
+        QObject::connect(&client, &QWebSocket::binaryMessageReceived,
+                         [&receivedFrames](const QByteArray& frame) {
+            receivedFrames.append(frame);
+        });
+        client.open(QUrl(QStringLiteral("ws://127.0.0.1:%1").arg(server.port())));
+        for (int i = 0; i < 100
+             && (client.state() != QAbstractSocket::ConnectedState
+                 || server.m_clients.isEmpty()); ++i) {
+            spin(10);
+        }
+        if (client.state() != QAbstractSocket::ConnectedState
+            || server.m_clients.isEmpty()) {
+            return false;
+        }
+
+        client.sendTextMessage(QStringLiteral(
+            "iq_samplerate:96000;iq_start:0;iq_start:1;iq_start:2;iq_start:3;"));
+        for (int i = 0; i < 100
+             && server.m_clients.first().iqReceivers.size()
+                    != DaxIqModel::NUM_CHANNELS; ++i) {
+            spin(10);
+        }
+        const QSet<int> allReceivers{0, 1, 2, 3};
+        if (server.m_iqSampleRate != 96000
+            || server.m_clients.first().iqReceivers != allReceivers) {
+            std::printf("      IQ subscriptions=%lld rate=%d\n",
+                        static_cast<long long>(
+                            server.m_clients.first().iqReceivers.size()),
+                        server.m_iqSampleRate);
+            return false;
+        }
+        for (int channel = 1; channel <= DaxIqModel::NUM_CHANNELS; ++channel) {
+            if (!iqCommands.contains(
+                    QStringLiteral("stream create type=dax_iq daxiq_channel=%1")
+                        .arg(channel))) {
+                std::printf("      no DAX IQ create for channel %d\n", channel);
+                return false;
+            }
+        }
+
+        float iqPair[2]{0.25f, -0.5f};
+        QByteArray rawPayload(reinterpret_cast<const char*>(iqPair),
+                              static_cast<int>(sizeof(iqPair)));
+        for (int channel = 1; channel <= DaxIqModel::NUM_CHANNELS; ++channel) {
+            server.onIqDataReady(channel, rawPayload, 96000);
+        }
+        for (int i = 0; i < 100
+             && receivedFrames.size() < DaxIqModel::NUM_CHANNELS; ++i) {
+            spin(10);
+        }
+
+        const auto frameReceivers = [](const QVector<QByteArray>& frames) {
+            QSet<int> receivers;
+            for (const QByteArray& frame : frames) {
+                if (frame.size() < 64) {
+                    continue;
+                }
+                quint32 receiver = 0;
+                quint32 type = 0;
+                std::memcpy(&receiver, frame.constData(), sizeof(receiver));
+                std::memcpy(&type,
+                            frame.constData() + 6 * static_cast<int>(sizeof(quint32)),
+                            sizeof(type));
+                if (type == 0) {
+                    receivers.insert(static_cast<int>(receiver));
+                }
+            }
+            return receivers;
+        };
+        if (frameReceivers(receivedFrames) != allReceivers) {
+            std::printf("      four-stream frame receivers=%lld\n",
+                        static_cast<long long>(frameReceivers(receivedFrames).size()));
+            return false;
+        }
+
+        // Stopping receiver 1 must leave 0, 2 and 3 live on this same socket.
+        client.sendTextMessage(QStringLiteral("iq_stop:1;"));
+        for (int i = 0; i < 100
+             && server.m_clients.first().iqReceivers.contains(1); ++i) {
+            spin(10);
+        }
+        receivedFrames.clear();
+        for (int channel = 1; channel <= DaxIqModel::NUM_CHANNELS; ++channel) {
+            server.onIqDataReady(channel, rawPayload, 96000);
+        }
+        for (int i = 0; i < 100 && receivedFrames.size() < 3; ++i) {
+            spin(10);
+        }
+        return server.m_clients.first().iqReceivers == QSet<int>{0, 2, 3}
+            && frameReceivers(receivedFrames) == QSet<int>{0, 2, 3};
+    }
+
+    // Receiver resources are multicast/reference-counted across clients. One
+    // client's stop must not remove a stream another still consumes, and a
+    // stop racing the create status must remain pending until an id exists.
+    static bool sharedIqSubscriptionIsClientScoped()
+    {
+        RadioModel model;
+        TciServer server(&model);
+        QWebSocket clientA;
+        QWebSocket clientB;
+        TciServer::ClientState a;
+        a.socket = &clientA;
+        a.iqReceivers.insert(1);
+        TciServer::ClientState b;
+        b.socket = &clientB;
+        b.iqReceivers.insert(1);
+        server.m_clients.append(a);
+        server.m_clients.append(b);
+        server.m_tciIqChannels.insert(2);
+
+        server.stopIqForClient(server.m_clients[0], 1);
+        if (!server.m_tciIqChannels.contains(2)
+            || server.m_pendingIqRemovals.contains(2)
+            || !server.m_clients[1].iqReceivers.contains(1)) {
+            return false;
+        }
+
+        server.stopIqForClient(server.m_clients[1], 1);
+        return server.m_tciIqChannels.contains(2)
+            && server.m_pendingIqRemovals.contains(2);
+    }
 };
 
 } // namespace AetherSDR
@@ -1401,6 +1555,10 @@ int main(int argc, char** argv)
         = AetherSDR::TciServerReviewTest::pttRouteLogSanitizesClientSource();
     const bool native24kPayload
         = AetherSDR::TciServerReviewTest::native24kAudioRetainsAccumulatedPayload();
+    const bool fourIqStreams
+        = AetherSDR::TciServerReviewTest::oneClientReceivesFourIqStreams();
+    const bool iqClientScoped
+        = AetherSDR::TciServerReviewTest::sharedIqSubscriptionIsClientScoped();
 
     std::printf("%s  isolated settings profile\n",
                 validProfile ? "PASS" : "FAIL");
@@ -1459,6 +1617,10 @@ int main(int argc, char** argv)
                 routeLogSanitizes ? "PASS" : "FAIL");
     std::printf("%s  native 24 kHz TCI RX retains accumulated payload (#4744)\n",
                 native24kPayload ? "PASS" : "FAIL");
+    std::printf("%s  one TCI client receives four independent IQ streams\n",
+                fourIqStreams ? "PASS" : "FAIL");
+    std::printf("%s  shared IQ subscriptions are client-scoped\n",
+                iqClientScoped ? "PASS" : "FAIL");
 
     return validProfile && deferredAbort && observableFailure
         && payloadFreeDisconnect && outboundTextAccounting && pttBindsReceiver
@@ -1470,6 +1632,6 @@ int main(int argc, char** argv)
         && vfoConfirmsAccepted && vfoConfirmsRefusal && vfoAcksNoOp
         && vfoChannelZeroOnce
         && routeLogStaleCache && routeLogSampleOrder && routeLogSanitizes
-        && native24kPayload
+        && native24kPayload && fourIqStreams && iqClientScoped
         ? 0 : 1;
 }

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3147,6 +3147,12 @@ if(Qt6WebSockets_FOUND)
     )
     add_test(NAME tci_automation_test COMMAND tci_automation_test)
 
+    # Socket-owning test: our own TCI server is the subject, so this is inside
+    # the AGENTS.md carve-out. It binds an EPHEMERAL TCP port (QWebSocketServer
+    # via TciServer::start(0)) on 127.0.0.1 and connects QWebSocket clients to
+    # it in-process — no fixed port, no external peer, no fake radio firmware.
+    # Each case that binds fails fast when it cannot, rather than consuming the
+    # test timeout.
     add_executable(tci_server_review_test tests/tci_server_review_test.cpp)
     target_include_directories(tci_server_review_test PRIVATE src tests)
     target_link_libraries(tci_server_review_test PRIVATE


### PR DESCRIPTION
<img width="2762" height="1620" alt="Screenshot 2026-08-11 at 7 02 14 PM" src="https://github.com/user-attachments/assets/4bb39686-86d1-435f-8ac6-9b808766daa2" />

# feat(tci): support four concurrent DAX IQ skimmer streams

## What

Extends the SDC / CW Skimmer support from #3913 and #4172 so a TCI client can subscribe to four receiver-specific DAX IQ streams concurrently. Operators can run skimmers on several bands at once—for example 20 m, 40 m, 10 m, and a fourth band—through the same AetherSDR TCI server.

This is a follow-up to #3910. It preserves the existing DDS/pan-center, IQ byte-order, sample-rate confirmation, stable receiver-map, and reconnect contracts added by the earlier TCI work.

## Why

`TciServer::ClientState` previously stored IQ state as one boolean plus one receiver index. Every new `iq_start:<trx>;` replaced the client's previous receiver. The radio could create several DAX IQ streams, but the client received frames only for the last receiver, and earlier streams could be left orphaned.

That made the original single-skimmer path work while preventing one TCI session from keeping multiple band skimmers live.

## Changes

### Four receiver subscriptions per client

- Replace the scalar IQ receiver with a per-client receiver set.
- Accept independent `iq_start:<trx>;` / `iq_stop:<trx>;` commands for receivers 0 through 3.
- Route type-0 TCI binary IQ frames to every client subscribed to the frame's receiver.
- Keep `iq_start` idempotent and use repeated starts to re-arm a missing radio-side stream.
- Reject starts for invalid or currently unmapped receivers instead of silently routing them to another slice, **and answer the rejection** — #3913 established that a skimmer blocks on the confirmation, so a silent refusal hangs it. Every refusal replies `iq_stop:<n>;`.
- Answer `iq_start:<n>;` only once the receiver is actually armed. Acknowledging a start whose stream create or pan bind was refused tells a client it has a receiver it can never use, and a client cannot retry what it was told worked.

### DAX IQ channels are bound per PANADAPTER, not per receiver

On a FLEX, `daxiq_channel` is a Panadapter property and the pan↔channel binding
is 1:1 in **both** directions. @Ozy311 measured this on a FLEX-6700 running
V1.4.0.0 during review: binding a channel to a second panadapter makes the radio
push `daxiq_channel=0` to the first, unasked. Binding one channel per *receiver*
therefore broke in two ways, both fixed here:

- **Receivers sharing a panadapter collided.** The ordinary A/B layout puts two
  slices on one pan; the second `iq_start` stole the binding the first had just
  made, leaving a subscription that was acknowledged, still held one of the four
  DAX IQ slots, and carried nothing — no log line, nothing in `tci status` to
  tell it from a working one. Which skimmer survived depended on `QSet`
  iteration order. **Now they share the channel**: both receivers see the same
  spectrum, so one stream serves both and the payload is fanned out once per
  subscriber with each receiver's own index in the frame header. Four skimmers
  need four *panadapters*, not four slices, and a shared pan costs one DAX IQ
  slot instead of two.
- **A channel the DAX IQ applet owned was taken over.** Reusing it moved the
  operator's pan off it (stopping their IQ consumer at the source, per the 1:1
  rule) and forced TCI's sample rate onto it, restoring neither on cleanup.
  **Such a channel is now refused, never borrowed** — TCI only drives channels
  it created.

A receiver whose pan does not already carry a channel still takes its documented
one, preserving the contract established by #3913:

| TCI receiver | DAX IQ channel |
|---:|---:|
| 0 | 1 |
| 1 | 2 |
| 2 | 3 |
| 3 | 4 |

### Shared radio-stream lifecycle

The physical DAX IQ stream is shared across TCI clients:

- Create at most one radio-side stream per **panadapter**.
- Keep it alive while any client remains subscribed to any receiver bound to it.
- Stop only the addressed receiver for the requesting client.
- Remove a TCI-created stream **and release its pan binding** (`daxiq_channel=0`) when its last subscriber stops or disconnects. Leaving the binding set would end a session with a panadapter routed at a channel nothing reads, which then blocks the applet from using that pan.
- Refuse, rather than borrow, a DAX IQ channel the applet already owns.
- Check the #3977 `display pan set` ownership gate before claiming anything, so a pan another client owns refuses the start instead of leaving an inert stream behind.
- Reap a late stream-create status when `iq_stop` or disconnect wins the create/remove race.
- Track ownership, an unconfirmed create, and a pending removal as **three separate facts**. Conflating them wedged a receiver: a lost or rejected create could never be re-issued, and the stale claim survived the `stop()`/`start()` cycle `TciApplet` performs on this same object for its enable toggle and port change, so no later client could get IQ either.
- Release all TCI-owned IQ streams when the server stops.

### Rate, pan, and reconnect behavior

- Treat `iq_samplerate` as the shared rate for all TCI IQ receivers.
- Apply a valid rate change to every channel TCI owns and remember it for channels created later.
- Preserve the #3913 accepted/rejected SET response behavior, and route the peer echo through `sendClientText()` so those sends stay in the outbound accounting and the `TCI tx→client:` diagnostic log.
- Report the rate **in force on a live stream** for a GET and for a rejected SET, rather than the last value TCI was asked for.
- Seed each client's init burst with the shared rate instead of a hardcoded `iq_samplerate:48000;`, so a client connecting after another has moved it is not told the default.
- Bind each receiver's DAX IQ channel to that receiver's current pan, keeping IQ centered on the same pan reported by `dds:`.
- Preserve logical client subscriptions across radio reconnects and stable slice recreation, then re-arm them through `TciTrxMap` when their receiver/pan returns.

### Documentation

Update the TCI receiver architecture document to describe:

- stable live receiver indexes from the recent TCI mapping work;
- the distinction between `trx_count` and the two VFO channels advertised by `channels_count:2`;
- four receiver-scoped IQ subscriptions;
- the pan-scoped channel binding, the 1:1 rule it follows from, and the two consequences (shared-pan sharing, borrow refusal);
- that a refused `iq_start` answers, and what it answers;
- shared ownership, cleanup, sample-rate, pan-center, and reconnect behavior.

## Regression safety

This change retains the recent TCI contracts rather than reintroducing positional routing:

- `dds:` remains the DAX IQ pan center, not the slice frequency (#3913).
- User pan recentering and reconnect authority remain synchronized (#4172).
- IQ payloads remain little-endian float32 on the TCI path (#3913).
- Receiver identity continues through the stable `TciTrxMap` used by current multi-slice audio/PTT routing.
- `channels_count:2` remains unchanged because it describes the two VFO channels per receiver; concurrent skimmers are represented by receiver indexes and `trx_count`.

## Regression coverage

`tci_server_review_test` exercises the actual WebSocket and binary-send path.
It is a **socket-owning test** — our own TCI server is the subject, so it sits
inside the `AGENTS.md` carve-out. It binds an *ephemeral* 127.0.0.1 port via
`TciServer::start(0)` and connects in-process `QWebSocket` clients to it: no
fixed port, no external peer, no fake radio firmware, and every case that binds
fails fast rather than consuming the timeout. Its `tests.cmake` block now names
that socket, per the disclosure rule.

1. **Four pans give four independent streams.** Four slice fixtures moved onto
   four panadapters, 96 kHz negotiated, `iq_start:0;`–`iq_start:3;` over one
   socket; asserts a DAX IQ create for channels 1–4 **and the `display pan set …
   daxiq_channel=N` bind for each**. Nothing asserted the bind before, which is
   exactly why four channels fighting over one pan looked identical to four
   working streams. Injects IQ per channel and verifies the type-0 headers
   identify receivers 0–3; stops receiver 1 and verifies 0, 2, 3 continue *and*
   that channel 2's pan binding is released.
2. **Receivers sharing a pan share one channel.** Two fixtures on one pan →
   exactly one `stream create`, no second bind stealing it back, one injected
   payload delivered to both receivers with their own indexes, and one client's
   stop leaving the channel up for the other.
3. **An applet-owned channel is refused, not borrowed.** The receiver is not
   subscribed, no `display pan set` and no DAX IQ command is issued, and the
   refusal replies `iq_stop:0;`.
4. **IQ re-arms after a `stop()`/`start()` cycle** with an unconfirmed create
   outstanding — the wedge described above.
5. **Cross-client refcounting and the stop-before-create-status race.**

All four fixes are **mutation-verified**: reverting each one in turn fails the
test that pins it (pan sharing → case 2; borrow refusal → case 3; the ownership/
in-flight conflation → cases 1 and 4; the pan unbind → case 1).

## Verification

### Build and static checks

- `cmake --build build -j22` — PASS (macOS arm64, RelWithDebInfo)
- Full `ninja` build after the review fixes — PASS (Linux, Debug, gcc)
- `python3 tools/check_engine_boundary.py --strict` — PASS, 0 blocking findings
- `git diff --check` — PASS

### Tests

- Focused TCI suite — 4/4 PASS:
  - `tci_protocol_test`
  - `tci_trxmap_test`
  - `tci_automation_test`
  - `tci_server_review_test`
- Re-run after the review fixes (Linux): `tci_trxmap_test`, `tci_automation_test`, `tci_server_review_test`, `hl2_tci_signaling_test` — all PASS.
- Full headless CTest suite — 0 failures across 288 tests; 286 passed and 2 expected fixture/platform skips.
- The full run includes `hl2_tci_signaling_test` and the recent receiver-map/radio-family regression coverage.

### Manual SDC validation

The verified bundle is deployed to the remote test Mac as:

```text
/Users/patj/Desktop/AetherSDR 3910-four-dax-iq-streams 1831.app
```

Live SDC validation passed with simultaneous skimmers on 40 m and 20 m over
the same AetherSDR TCI connection. Both receiver panes showed live IQ, decoded
CW independently, and populated the decoded-callsign list at the correct band
frequencies. The four-receiver capacity and stop-one/keep-three routing shape
are pinned by the end-to-end WebSocket/binary regression test above.

## Out of scope

- Secure remote TCI transport or authentication.
- int16 IQ transport.
- Increasing the existing four-channel Flex DAX IQ capacity.
- Changing the 1:1 pan↔channel rule itself — that is radio behaviour, not ours. Four concurrent skimmers require four panadapters; receivers sharing a pan share its channel.
- Changing the default IQ sample rate.
- UI changes to the DAX IQ applet.

## Automation follow-up

A useful follow-up would extend `tci status` with per-receiver subscription state, DAX IQ stream IDs, achieved sample rates, frame counts, and sequence-gap counters. That would let automation distinguish routing, continuity, and frequency-reference failures without an external skimmer.

👨🏼‍💻 Generated with OpenAI Codex (Daybreak Blue)

