### PR TITLE
fix(map): eliminate PSK Reporter navigation stalls and fix world wrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,18 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: ctest --test-dir build -R "^workspace_" --output-on-failure
 
+      # Slippy-map world wrap. Same reasoning as the step above: the target is
+      # already linked by Build, the test runs in milliseconds, and it touches
+      # no network — but without a step here it would compile and go green
+      # having never executed. It pins the tile-hierarchy floor for negative
+      # tile x (the world copy west of the base one), the canonical-URL
+      # mapping, the camera crossing the dateline without the scene rect
+      # clamping it, and the wheel-zoom round trip.
+      - name: Test map wrap
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: ctest --test-dir build -R "^map_wrap_test$" --output-on-failure
+
       # The demo RX engine's worker-thread contract (#4878): affinity, 24 kHz
       # pacing on a coarse timer, keyed-mute, stallscope. This is the fix for
       # the demo making the GUI thread carry a 333 Hz precise timer plus the

--- a/src/gui/map/MapMarkerItem.cpp
+++ b/src/gui/map/MapMarkerItem.cpp
@@ -24,8 +24,10 @@ QFont markerFont()
 }
 } // namespace
 
-MapMarkerItem::MapMarkerItem(const MapView::Marker& marker)
+MapMarkerItem::MapMarkerItem(const MapView::Marker& marker,
+                             int relativeWorldOffset)
     : m_marker(marker)
+    , m_relativeWorldOffset(relativeWorldOffset)
 {
     setFlags(QGV::ItemFlag::IgnoreScale | QGV::ItemFlag::IgnoreAzimuth
              | QGV::ItemFlag::Clickable);
@@ -54,8 +56,32 @@ void MapMarkerItem::setPulsePhase(double phase)
 void MapMarkerItem::onProjection(QGVMap* geoMap)
 {
     QGVDrawItem::onProjection(geoMap);
-    m_projPos = geoMap->getProjection()->geoToProj(
+    m_baseProjPos = geoMap->getProjection()->geoToProj(
         QGV::GeoPos(m_marker.lat, m_marker.lon));
+    moveToNearestWorld(geoMap->getCamera());
+}
+
+void MapMarkerItem::onCamera(const QGVCameraState& oldState,
+                             const QGVCameraState& newState)
+{
+    const QPointF oldPosition = m_projPos;
+    moveToNearestWorld(newState);
+    if (oldPosition != m_projPos) {
+        resetBoundary();
+    }
+    QGVDrawItem::onCamera(oldState, newState);
+    if (oldPosition != m_projPos) {
+        refresh();
+    }
+}
+
+void MapMarkerItem::moveToNearestWorld(const QGVCameraState& camera)
+{
+    const double worldWidth = camera.getProjection()->boundaryProjRect().width();
+    const double worldOffset = m_relativeWorldOffset + qRound(
+        (camera.projCenter().x() - m_baseProjPos.x()) / worldWidth);
+    m_projPos = QPointF(m_baseProjPos.x() + worldOffset * worldWidth,
+                        m_baseProjPos.y());
 }
 
 QPointF MapMarkerItem::projAnchor() const

--- a/src/gui/map/MapMarkerItem.h
+++ b/src/gui/map/MapMarkerItem.h
@@ -14,7 +14,8 @@ class MapMarkerItem : public QGVDrawItem {
     Q_OBJECT
 
 public:
-    explicit MapMarkerItem(const MapView::Marker& marker);
+    explicit MapMarkerItem(const MapView::Marker& marker,
+                           int relativeWorldOffset = 0);
 
     void setMarker(const MapView::Marker& marker);
     const MapView::Marker& marker() const { return m_marker; }
@@ -25,14 +26,19 @@ public:
 
 private:
     void onProjection(QGVMap* geoMap) override;
+    void onCamera(const QGVCameraState& oldState,
+                  const QGVCameraState& newState) override;
     QPainterPath projShape() const override;
     QPointF projAnchor() const override;
     void projPaint(QPainter* painter) override;
     QString projTooltip(const QPointF& projPos) const override;
 
     QRectF labelRect() const;
+    void moveToNearestWorld(const QGVCameraState& camera);
 
     MapView::Marker m_marker;
+    int m_relativeWorldOffset{0};
+    QPointF m_baseProjPos;
     QPointF m_projPos;
     double m_pulsePhase{-1.0};
 };

--- a/src/gui/map/MapPathItem.cpp
+++ b/src/gui/map/MapPathItem.cpp
@@ -41,11 +41,13 @@ QGV::GeoPos slerp(double lat1, double lon1, double lat2, double lon2,
 } // namespace
 
 MapPathItem::MapPathItem(double fromLat, double fromLon,
-                         double toLat, double toLon, const QColor& color)
+                         double toLat, double toLon, const QColor& color,
+                         int relativeWorldOffset)
     : m_fromLat(fromLat)
     , m_fromLon(fromLon)
     , m_toLat(toLat)
     , m_toLon(toLon)
+    , m_relativeWorldOffset(relativeWorldOffset)
     , m_color(color)
 {
     setSelectable(false);
@@ -61,19 +63,38 @@ void MapPathItem::onProjection(QGVMap* geoMap)
     // width means the great circle wrapped — start a new subpath.
     const double worldWidth = proj->boundaryProjRect().width();
 
-    m_projPath = QPainterPath();
+    m_baseProjPath = QPainterPath();
     QPointF prev;
     for (int i = 0; i <= kSegments; ++i) {
         const double t = static_cast<double>(i) / kSegments;
         const QPointF p = proj->geoToProj(
             slerp(m_fromLat, m_fromLon, m_toLat, m_toLon, t));
         if (i == 0 || std::abs(p.x() - prev.x()) > worldWidth / 2.0) {
-            m_projPath.moveTo(p);
+            m_baseProjPath.moveTo(p);
         } else {
-            m_projPath.lineTo(p);
+            m_baseProjPath.lineTo(p);
         }
         prev = p;
     }
+    m_projPath = m_baseProjPath;
+    onCamera(geoMap->getCamera(), geoMap->getCamera());
+}
+
+void MapPathItem::onCamera(const QGVCameraState& oldState,
+                           const QGVCameraState& newState)
+{
+    const double worldWidth = newState.getProjection()->boundaryProjRect().width();
+    const double worldOffset = m_relativeWorldOffset + qRound(
+        (newState.projCenter().x() - m_baseProjPath.boundingRect().center().x())
+        / worldWidth);
+    const QPainterPath shifted = QTransform::fromTranslate(
+        worldOffset * worldWidth, 0.0).map(m_baseProjPath);
+    if (shifted != m_projPath) {
+        m_projPath = shifted;
+        resetBoundary();
+        refresh();
+    }
+    QGVDrawItem::onCamera(oldState, newState);
 }
 
 QPainterPath MapPathItem::projShape() const

--- a/src/gui/map/MapPathItem.cpp
+++ b/src/gui/map/MapPathItem.cpp
@@ -6,6 +6,8 @@
 #include <QPainter>
 #include <QtMath>
 
+#include <limits>
+
 namespace AetherSDR {
 
 namespace {
@@ -76,6 +78,16 @@ void MapPathItem::onProjection(QGVMap* geoMap)
         }
         prev = p;
     }
+    // Anchor the world-copy choice on the DESTINATION endpoint — exactly the
+    // point MapMarkerItem rounds against for the spot this path terminates at.
+    // The path's bounding-rect centre is not usable: a great circle crossing
+    // the antimeridian is split into subpaths hard against both edges, so its
+    // centre collapses toward the projection origin and bears no relation to
+    // either endpoint. Rounding the two against different anchors makes them
+    // disagree about which copies exist over a wide band of camera positions,
+    // and a spot ends up drawn with no path running to it.
+    m_baseAnchor = proj->geoToProj(QGV::GeoPos(m_toLat, m_toLon));
+    m_appliedWorldOffset = std::numeric_limits<int>::min();
     m_projPath = m_baseProjPath;
     onCamera(geoMap->getCamera(), geoMap->getCamera());
 }
@@ -84,13 +96,17 @@ void MapPathItem::onCamera(const QGVCameraState& oldState,
                            const QGVCameraState& newState)
 {
     const double worldWidth = newState.getProjection()->boundaryProjRect().width();
-    const double worldOffset = m_relativeWorldOffset + qRound(
-        (newState.projCenter().x() - m_baseProjPath.boundingRect().center().x())
-        / worldWidth);
-    const QPainterPath shifted = QTransform::fromTranslate(
-        worldOffset * worldWidth, 0.0).map(m_baseProjPath);
-    if (shifted != m_projPath) {
-        m_projPath = shifted;
+    const int worldOffset = m_relativeWorldOffset + qRound(
+        (newState.projCenter().x() - m_baseAnchor.x()) / worldWidth);
+    // Compare the integer copy index rather than the mapped path. The offset
+    // only changes when the camera crosses a world boundary, so an ordinary
+    // drag frame costs two doubles here instead of a QTransform::map() over
+    // every segment plus a full QPainterPath comparison — per item, at several
+    // items per spot, on the very drag path this change exists to keep clear.
+    if (worldOffset != m_appliedWorldOffset) {
+        m_appliedWorldOffset = worldOffset;
+        m_projPath = QTransform::fromTranslate(
+            worldOffset * worldWidth, 0.0).map(m_baseProjPath);
         resetBoundary();
         refresh();
     }

--- a/src/gui/map/MapPathItem.h
+++ b/src/gui/map/MapPathItem.h
@@ -5,6 +5,8 @@
 #include <QColor>
 #include <QVector>
 
+#include <limits>
+
 namespace AetherSDR {
 
 // Great-circle path from the home station to a reception spot.
@@ -31,6 +33,12 @@ private:
     QColor m_color;
     QPainterPath m_baseProjPath;
     QPainterPath m_projPath;
+    // Projected destination endpoint: the anchor the world-copy index is
+    // rounded against, shared with the MapMarkerItem for the same spot.
+    QPointF m_baseAnchor;
+    // Copy index currently baked into m_projPath. Seeded below any reachable
+    // value so the first onCamera() after onProjection() always applies.
+    int m_appliedWorldOffset{std::numeric_limits<int>::min()};
 };
 
 } // namespace AetherSDR

--- a/src/gui/map/MapPathItem.h
+++ b/src/gui/map/MapPathItem.h
@@ -16,15 +16,20 @@ class MapPathItem : public QGVDrawItem {
 
 public:
     MapPathItem(double fromLat, double fromLon,
-                double toLat, double toLon, const QColor& color);
+                double toLat, double toLon, const QColor& color,
+                int relativeWorldOffset = 0);
 
 private:
     void onProjection(QGVMap* geoMap) override;
+    void onCamera(const QGVCameraState& oldState,
+                  const QGVCameraState& newState) override;
     QPainterPath projShape() const override;
     void projPaint(QPainter* painter) override;
 
     double m_fromLat, m_fromLon, m_toLat, m_toLon;
+    int m_relativeWorldOffset{0};
     QColor m_color;
+    QPainterPath m_baseProjPath;
     QPainterPath m_projPath;
 };
 

--- a/src/gui/map/MapView.cpp
+++ b/src/gui/map/MapView.cpp
@@ -45,8 +45,11 @@ constexpr qint64 kTileCacheBytes = 256LL * 1024 * 1024;
 // aborts the reply at that point — but until then the tile stays blank with the
 // socket held open and nothing logged.
 constexpr int kTransferTimeoutMs = 15000;
-constexpr int kFirstVisibleWorldCopy = -1;
-constexpr int kLastVisibleWorldCopy = 1;
+// Upper bound on how many world copies either side of the base one markers and
+// paths are replicated into. The live value is m_worldCopyRange, derived from
+// the viewport in requiredWorldCopyRange(); this only stops a degenerate
+// aspect ratio from asking for an unbounded number of scene items.
+constexpr int kMaxWorldCopyRange = 4;
 } // namespace
 
 void MapView::ensureTileNetworkManager()
@@ -85,10 +88,21 @@ MapView::MapView(QWidget* parent)
     layout->addWidget(m_map);
 
     auto* osmLayer = new QGVLayerOSM();
-    // One tile beyond the viewport is enough to hide network latency without
-    // making every drag boundary enqueue a 7x7 block (the upstream default).
-    // Recently decoded images stay in QGVLayerTilesOnline's memory cache, so
-    // revisiting an area does not repeat PNG decode or scene upload work.
+    // Deliberately tighter than QGVLayerTiles' upstream defaults, in both
+    // dimensions — the decoded-image cache in QGVLayerTilesOnline is what pays
+    // for it, since re-entering an area now costs a memcpy rather than a fetch
+    // and a PNG decode.
+    //
+    //   * preload ring, no zoom change: 3 -> 1. One tile beyond the viewport
+    //     hides network latency without making every drag boundary enqueue a
+    //     7x7 block. (The with-zoom-change margin is already 1 upstream; it is
+    //     set here only so both are stated in one place.)
+    //   * retained fallback layers: 10 below / 10 above -> 2 below / 1 above.
+    //     This is a REDUCTION in how much coarse imagery is kept behind the
+    //     current zoom. Two levels is enough to cover a zoom transition; past
+    //     that the tiles are never drawn and only cost memory, which matters
+    //     more now that horizontal wrap lets the camera visit unboundedly many
+    //     world copies.
     osmLayer->setTilesMarginWithZoomChange(1);
     osmLayer->setTilesMarginNoZoomChange(1);
     osmLayer->setVisibleZoomLayersBelowCurrent(2);
@@ -249,23 +263,11 @@ void MapView::setHomePosition(double lat, double lon, const QString& label,
     m_hasHome = true;
 
     if (showMarker) {
-        Marker home;
-        home.lat = lat;
-        home.lon = lon;
-        home.label = label;
-        home.tooltip = label.isEmpty() ? QStringLiteral("Station location")
-                                       : label;
-        home.color = QColor(0, 122, 255);
-        home.isHome = true;
+        m_homeMarkerShown = true;
         if (m_homeMarkers.isEmpty()) {
-            for (int relativeCopy = kFirstVisibleWorldCopy;
-                 relativeCopy <= kLastVisibleWorldCopy; ++relativeCopy) {
-                auto* marker = new MapMarkerItem(home, relativeCopy);
-                marker->setZValue(10);
-                m_homeMarkers.append(marker);
-                m_markerLayer->addItem(marker);
-            }
+            rebuildHomeMarkers();
         } else {
+            const Marker home = homeMarkerData();
             for (MapMarkerItem* marker : std::as_const(m_homeMarkers)) {
                 marker->setMarker(home);
             }
@@ -291,10 +293,10 @@ void MapView::setMarkers(const QVector<Marker>& markers)
 {
     clearMarkers();
     m_markerData = markers;
-    m_markers.reserve(markers.size() * 3);
+    m_markers.reserve(markers.size() * (2 * m_worldCopyRange + 1));
     for (const Marker& m : markers) {
-        for (int relativeCopy = kFirstVisibleWorldCopy;
-             relativeCopy <= kLastVisibleWorldCopy; ++relativeCopy) {
+        for (int relativeCopy = -m_worldCopyRange;
+             relativeCopy <= m_worldCopyRange; ++relativeCopy) {
             auto* item = new MapMarkerItem(m, relativeCopy);
             m_markers.append(item);
             m_markerLayer->addItem(item);
@@ -322,10 +324,10 @@ void MapView::rebuildPaths()
     if (!m_pathsVisible || !m_hasHome) {
         return;
     }
-    m_paths.reserve(m_markerData.size() * 3);
+    m_paths.reserve(m_markerData.size() * (2 * m_worldCopyRange + 1));
     for (const Marker& m : std::as_const(m_markerData)) {
-        for (int relativeCopy = kFirstVisibleWorldCopy;
-             relativeCopy <= kLastVisibleWorldCopy; ++relativeCopy) {
+        for (int relativeCopy = -m_worldCopyRange;
+             relativeCopy <= m_worldCopyRange; ++relativeCopy) {
             auto* path = new MapPathItem(m_homeLat, m_homeLon,
                                          m.lat, m.lon, m.color, relativeCopy);
             m_paths.append(path);
@@ -494,7 +496,9 @@ void MapView::layoutOverlayButtons()
 void MapView::clampMinZoomToViewport()
 {
     // The world repeats horizontally, but not vertically. Pin the minimum
-    // scale so Web Mercator still covers the viewport north-to-south.
+    // scale so Web Mercator still covers the viewport north-to-south. (Before
+    // wrap this also had to cover it east-to-west; the repeating tile layer
+    // does that now, which is what lets a wide widget zoom out further.)
     auto* view = m_map->geoView();
     const QGVProjection* proj = m_map->getProjection();
     if (view == nullptr || proj == nullptr) {
@@ -504,11 +508,91 @@ void MapView::clampMinZoomToViewport()
     if (world.width() <= 0.0 || world.height() <= 0.0) {
         return;
     }
-    const double minScale = static_cast<double>(height()) / world.height();
+    // Floor: QGVLayerTiles::processCamera() derives a zoom as
+    // qRound(17 + log2(scale)) and returns immediately — touching no tile at
+    // all — when that lands outside the layer's [minZoomlevel, maxZoomlevel].
+    // Dropping the width term above lets a short widget reach a scale below
+    // QGVLayerOSM's zoom 0, where the failure mode is not coarse tiles but a
+    // map that silently stops updating. 2^-17.5 is the smallest scale that
+    // still rounds to zoom 0.
+    const double minTileScale = std::pow(2.0, -17.5);
+    const double minScale = qMax(static_cast<double>(height()) / world.height(),
+                                 minTileScale);
     view->setScaleLimits(minScale, view->getMaxScale());
     if (m_map->getCamera().scale() < minScale) {
         m_map->cameraTo(QGVCameraActions(m_map).scaleTo(minScale));
     }
+
+    const int range = requiredWorldCopyRange();
+    if (range != m_worldCopyRange) {
+        m_worldCopyRange = range;
+        rebuildWorldCopies();
+    }
+}
+
+int MapView::requiredWorldCopyRange() const
+{
+    auto* view = m_map != nullptr ? m_map->geoView() : nullptr;
+    const QGVProjection* proj = m_map != nullptr ? m_map->getProjection()
+                                                 : nullptr;
+    if (view == nullptr || proj == nullptr || width() <= 0) {
+        return 1;
+    }
+    const QRectF world = proj->boundaryProjRect();
+    const double minScale = view->getMinScale();
+    if (world.width() <= 0.0 || minScale <= 0.0) {
+        return 1;
+    }
+    // The viewport is widest, measured in world copies, at the minimum scale.
+    // Each item sits at its own longitude plus an integer number of worlds and
+    // re-homes to the copy nearest the camera, so the copies span
+    // camera +/- (range + 0.5) worlds. Covering a viewport `worlds` wide
+    // therefore needs range >= (worlds - 1) / 2 — at or below one world that
+    // is the single base copy, and the +/-1 default carries up to three.
+    const double worlds = width() / (world.width() * minScale);
+    const int range = static_cast<int>(std::ceil((worlds - 1.0) / 2.0));
+    return qBound(1, range, kMaxWorldCopyRange);
+}
+
+MapView::Marker MapView::homeMarkerData() const
+{
+    Marker home;
+    home.lat = m_homeLat;
+    home.lon = m_homeLon;
+    home.label = m_homeLabel;
+    home.tooltip = m_homeLabel.isEmpty() ? QStringLiteral("Station location")
+                                         : m_homeLabel;
+    home.color = QColor(0, 122, 255);
+    home.isHome = true;
+    return home;
+}
+
+void MapView::rebuildHomeMarkers()
+{
+    for (MapMarkerItem* marker : std::as_const(m_homeMarkers)) {
+        m_markerLayer->removeItem(marker);
+        delete marker;
+    }
+    m_homeMarkers.clear();
+    if (!m_homeMarkerShown || !m_hasHome) {
+        return;
+    }
+    const Marker home = homeMarkerData();
+    for (int relativeCopy = -m_worldCopyRange;
+         relativeCopy <= m_worldCopyRange; ++relativeCopy) {
+        auto* marker = new MapMarkerItem(home, relativeCopy);
+        marker->setZValue(10);
+        m_homeMarkers.append(marker);
+        m_markerLayer->addItem(marker);
+    }
+}
+
+void MapView::rebuildWorldCopies()
+{
+    rebuildHomeMarkers();
+    // setMarkers() clears m_markerData on the way through, so hand it a copy.
+    const QVector<Marker> markers = m_markerData;
+    setMarkers(markers);
 }
 
 void MapView::resizeEvent(QResizeEvent* event)

--- a/src/gui/map/MapView.cpp
+++ b/src/gui/map/MapView.cpp
@@ -45,6 +45,8 @@ constexpr qint64 kTileCacheBytes = 256LL * 1024 * 1024;
 // aborts the reply at that point — but until then the tile stays blank with the
 // socket held open and nothing logged.
 constexpr int kTransferTimeoutMs = 15000;
+constexpr int kFirstVisibleWorldCopy = -1;
+constexpr int kLastVisibleWorldCopy = 1;
 } // namespace
 
 void MapView::ensureTileNetworkManager()
@@ -82,7 +84,18 @@ MapView::MapView(QWidget* parent)
     m_map = new QGVMap(this);
     layout->addWidget(m_map);
 
-    m_map->addItem(new QGVLayerOSM());
+    auto* osmLayer = new QGVLayerOSM();
+    // One tile beyond the viewport is enough to hide network latency without
+    // making every drag boundary enqueue a 7x7 block (the upstream default).
+    // Recently decoded images stay in QGVLayerTilesOnline's memory cache, so
+    // revisiting an area does not repeat PNG decode or scene upload work.
+    osmLayer->setTilesMarginWithZoomChange(1);
+    osmLayer->setTilesMarginNoZoomChange(1);
+    osmLayer->setVisibleZoomLayersBelowCurrent(2);
+    osmLayer->setVisibleZoomLayersAboveCurrent(1);
+    osmLayer->setHorizontalWrapEnabled(true);
+    m_map->addItem(osmLayer);
+    m_map->geoView()->setHorizontalWrapEnabled(true);
 
     m_markerLayer = new QGVLayer();
     m_markerLayer->setName(QStringLiteral("Markers"));
@@ -110,19 +123,19 @@ MapView::MapView(QWidget* parent)
     m_pulseAnim->setDuration(1000);
     connect(m_pulseAnim, &QVariantAnimation::valueChanged, this,
             [this](const QVariant& v) {
-                if (m_homeMarker != nullptr) {
-                    m_homeMarker->setPulsePhase(v.toDouble());
+                for (MapMarkerItem* marker : std::as_const(m_homeMarkers)) {
+                    marker->setPulsePhase(v.toDouble());
                 }
             });
     connect(m_pulseAnim, &QVariantAnimation::finished, this, [this] {
-        if (m_homeMarker != nullptr) {
-            m_homeMarker->setPulsePhase(-1.0);
+        for (MapMarkerItem* marker : std::as_const(m_homeMarkers)) {
+            marker->setPulsePhase(-1.0);
         }
     });
     m_pulseTimer = new QTimer(this);
     m_pulseTimer->setInterval(3000);
     connect(m_pulseTimer, &QTimer::timeout, this, [this] {
-        if (m_homeMarker != nullptr && isVisible()
+        if (!m_homeMarkers.isEmpty() && isVisible()
             && m_pulseAnim->state() != QVariantAnimation::Running) {
             m_pulseAnim->start();
         }
@@ -180,6 +193,11 @@ bool MapView::eventFilter(QObject* watched, QEvent* event)
     if (watched == m_map->geoView()->viewport()) {
         if (event->type() == QEvent::MouseMove) {
             auto* me = static_cast<QMouseEvent*>(event);
+            if (me->buttons() != Qt::NoButton) {
+                m_hoverMarker = nullptr;
+                m_hoverCard->hide();
+                return QWidget::eventFilter(watched, event);
+            }
             // Viewport pixels → scene/projection coordinates for the hit test.
             showHoverTooltip(m_map->geoView()->mapToScene(me->pos()));
         } else if (event->type() == QEvent::Leave) {
@@ -239,12 +257,18 @@ void MapView::setHomePosition(double lat, double lon, const QString& label,
                                        : label;
         home.color = QColor(0, 122, 255);
         home.isHome = true;
-        if (m_homeMarker == nullptr) {
-            m_homeMarker = new MapMarkerItem(home);
-            m_homeMarker->setZValue(10);
-            m_markerLayer->addItem(m_homeMarker);
+        if (m_homeMarkers.isEmpty()) {
+            for (int relativeCopy = kFirstVisibleWorldCopy;
+                 relativeCopy <= kLastVisibleWorldCopy; ++relativeCopy) {
+                auto* marker = new MapMarkerItem(home, relativeCopy);
+                marker->setZValue(10);
+                m_homeMarkers.append(marker);
+                m_markerLayer->addItem(marker);
+            }
         } else {
-            m_homeMarker->setMarker(home);
+            for (MapMarkerItem* marker : std::as_const(m_homeMarkers)) {
+                marker->setMarker(home);
+            }
         }
     }
 
@@ -267,11 +291,14 @@ void MapView::setMarkers(const QVector<Marker>& markers)
 {
     clearMarkers();
     m_markerData = markers;
-    m_markers.reserve(markers.size());
+    m_markers.reserve(markers.size() * 3);
     for (const Marker& m : markers) {
-        auto* item = new MapMarkerItem(m);
-        m_markers.append(item);
-        m_markerLayer->addItem(item);
+        for (int relativeCopy = kFirstVisibleWorldCopy;
+             relativeCopy <= kLastVisibleWorldCopy; ++relativeCopy) {
+            auto* item = new MapMarkerItem(m, relativeCopy);
+            m_markers.append(item);
+            m_markerLayer->addItem(item);
+        }
     }
     rebuildPaths();
 }
@@ -295,12 +322,15 @@ void MapView::rebuildPaths()
     if (!m_pathsVisible || !m_hasHome) {
         return;
     }
-    m_paths.reserve(m_markerData.size());
+    m_paths.reserve(m_markerData.size() * 3);
     for (const Marker& m : std::as_const(m_markerData)) {
-        auto* path = new MapPathItem(m_homeLat, m_homeLon,
-                                     m.lat, m.lon, m.color);
-        m_paths.append(path);
-        m_markerLayer->addItem(path);
+        for (int relativeCopy = kFirstVisibleWorldCopy;
+             relativeCopy <= kLastVisibleWorldCopy; ++relativeCopy) {
+            auto* path = new MapPathItem(m_homeLat, m_homeLon,
+                                         m.lat, m.lon, m.color, relativeCopy);
+            m_paths.append(path);
+            m_markerLayer->addItem(path);
+        }
     }
 }
 
@@ -335,6 +365,10 @@ void MapView::setLegend(const QVector<QPair<QString, QColor>>& entries)
 
 void MapView::clearMarkers()
 {
+    m_hoverMarker = nullptr;
+    if (m_hoverCard != nullptr) {
+        m_hoverCard->hide();
+    }
     for (MapMarkerItem* item : std::as_const(m_markers)) {
         m_markerLayer->removeItem(item);
         delete item;
@@ -354,10 +388,17 @@ void MapView::resetToHome()
         m_map->cameraTo(QGVCameraActions(m_map).scaleTo(kWorldRect), true);
         return;
     }
-    const QGV::GeoRect rect{ m_homeLat + m_homeSpanDeg / 2.0,
-                             m_homeLon - m_homeSpanDeg,
-                             m_homeLat - m_homeSpanDeg / 2.0,
-                             m_homeLon + m_homeSpanDeg };
+    const QGVProjection* projection = m_map->getProjection();
+    const QPointF center = projection->geoToProj(
+        QGV::GeoPos(m_homeLat, m_homeLon));
+    const QPointF top = projection->geoToProj(
+        QGV::GeoPos(m_homeLat + m_homeSpanDeg / 2.0, m_homeLon));
+    const QPointF bottom = projection->geoToProj(
+        QGV::GeoPos(m_homeLat - m_homeSpanDeg / 2.0, m_homeLon));
+    const double halfWidth = projection->boundaryProjRect().width()
+        * m_homeSpanDeg / 360.0;
+    const QRectF rect(QPointF(center.x() - halfWidth, top.y()),
+                      QPointF(center.x() + halfWidth, bottom.y()));
     m_map->cameraTo(QGVCameraActions(m_map).scaleTo(rect), true);
 }
 
@@ -452,10 +493,8 @@ void MapView::layoutOverlayButtons()
 
 void MapView::clampMinZoomToViewport()
 {
-    // QGeoView renders a single (non-repeating) world, so zooming out past
-    // the point where the world fills the viewport exposes blank tiles on
-    // the sides. Pin the minimum scale so the world always covers the view
-    // in both axes. Recomputed on every resize.
+    // The world repeats horizontally, but not vertically. Pin the minimum
+    // scale so Web Mercator still covers the viewport north-to-south.
     auto* view = m_map->geoView();
     const QGVProjection* proj = m_map->getProjection();
     if (view == nullptr || proj == nullptr) {
@@ -465,8 +504,7 @@ void MapView::clampMinZoomToViewport()
     if (world.width() <= 0.0 || world.height() <= 0.0) {
         return;
     }
-    const double minScale = qMax(static_cast<double>(width()) / world.width(),
-                                 static_cast<double>(height()) / world.height());
+    const double minScale = static_cast<double>(height()) / world.height();
     view->setScaleLimits(minScale, view->getMaxScale());
     if (m_map->getCamera().scale() < minScale) {
         m_map->cameraTo(QGVCameraActions(m_map).scaleTo(minScale));

--- a/src/gui/map/MapView.h
+++ b/src/gui/map/MapView.h
@@ -3,6 +3,7 @@
 #include <QWidget>
 #include <QTimer>
 #include <QColor>
+#include <QPointer>
 #include <QVector>
 
 #include <QGeoView/QGVGlobal.h>
@@ -98,6 +99,17 @@ private:
     void layoutOverlayButtons();
     void rebuildPaths();
     void clampMinZoomToViewport();
+    // How many world copies either side of the base one the markers and paths
+    // must be replicated into for the widest viewport this widget can reach.
+    // The world repeats horizontally, but each item can only be in one place,
+    // so a copy per visible world is what keeps spots on screen after the
+    // camera crosses the antimeridian.
+    int requiredWorldCopyRange() const;
+    // Re-create every marker and path at the current copy range. Only called
+    // when requiredWorldCopyRange() actually changes, which needs a resize.
+    void rebuildWorldCopies();
+    void rebuildHomeMarkers();
+    Marker homeMarkerData() const;
     // Instant hover tooltip driven by mouse-move (QGeoView's built-in
     // tooltip waits for the OS hover delay, which is too slow here).
     void showHoverTooltip(const QPointF& projPos);
@@ -105,7 +117,9 @@ private:
     QGVMap*  m_map{nullptr};
     QGVLayer* m_markerLayer{nullptr};
     QVector<MapMarkerItem*> m_homeMarkers;
-    MapMarkerItem* m_hoverMarker{nullptr};
+    // QPointer, not a raw pointer: marker items are deleted from more than one
+    // path and this must never outlive the item it names.
+    QPointer<MapMarkerItem> m_hoverMarker;
     QLabel* m_hoverCard{nullptr};
     QVector<MapMarkerItem*> m_markers;
     QVector<Marker> m_markerData;
@@ -117,7 +131,9 @@ private:
     double m_homeLon{0.0};
     QString m_homeLabel;
     bool   m_hasHome{false};
+    bool   m_homeMarkerShown{false};
     bool   m_firstShow{true};
+    int    m_worldCopyRange{1};
     double m_homeSpanDeg{30.0};
 
     // Zoom / recenter overlay buttons (upper-right).

--- a/src/gui/map/MapView.h
+++ b/src/gui/map/MapView.h
@@ -104,7 +104,7 @@ private:
 
     QGVMap*  m_map{nullptr};
     QGVLayer* m_markerLayer{nullptr};
-    MapMarkerItem* m_homeMarker{nullptr};
+    QVector<MapMarkerItem*> m_homeMarkers;
     MapMarkerItem* m_hoverMarker{nullptr};
     QLabel* m_hoverCard{nullptr};
     QVector<MapMarkerItem*> m_markers;

--- a/tests/map_wrap_test.cpp
+++ b/tests/map_wrap_test.cpp
@@ -1,0 +1,87 @@
+#include <QGeoView/QGVGlobal.h>
+#include <QGeoView/QGVCamera.h>
+#include <QGeoView/QGVMap.h>
+#include <QGeoView/QGVMapQGView.h>
+#include <QGeoView/QGVProjection.h>
+
+#include <QApplication>
+#include <QtGlobal>
+
+#include <cmath>
+#include <iostream>
+
+namespace {
+
+bool nearlyEqual(double lhs, double rhs)
+{
+    return std::abs(lhs - rhs) < 1e-9;
+}
+
+bool expect(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << message << '\n';
+    }
+    return condition;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QApplication app(argc, argv);
+    bool ok = true;
+    ok &= expect(nearlyEqual(QGV::wrapProjectionX(180.0, -180.0, 360.0),
+                             -180.0),
+                 "+180 should wrap to -180");
+    ok &= expect(nearlyEqual(QGV::wrapProjectionX(181.0, -180.0, 360.0),
+                             -179.0),
+                 "eastward camera motion should wrap across the dateline");
+    ok &= expect(nearlyEqual(QGV::wrapProjectionX(-181.0, -180.0, 360.0),
+                             179.0),
+                 "westward camera motion should wrap across the dateline");
+    ok &= expect(nearlyEqual(QGV::wrapProjectionX(901.0, -180.0, 360.0),
+                             -179.0),
+                 "multiple eastward world copies should normalize");
+
+    ok &= expect(QGV::wrapTileX(2, -1) == 3,
+                 "tile immediately west of the world should use the east edge");
+    ok &= expect(QGV::wrapTileX(2, 4) == 0,
+                 "tile immediately east of the world should use the west edge");
+    ok &= expect(QGV::wrapTileX(3, 17) == 1,
+                 "tile wrapping should handle multiple world copies");
+    ok &= expect(QGV::wrapTileX(-1, 17) == 17,
+                 "invalid zoom should leave tile x unchanged");
+
+    // Exercise QGraphicsView's real centering constraint at the whole-world
+    // scale. A wide viewport is wider than two worlds here; without the
+    // moving wrap scene rectangle, centerOn() clamps before the dateline and
+    // the tile surface goes blank even though the coordinate math is right.
+    QGVMap map;
+    map.resize(1262, 572);
+    map.show();
+    app.processEvents();
+    map.geoView()->setHorizontalWrapEnabled(true);
+    const QRectF world = map.getProjection()->boundaryProjRect();
+    const double wholeWorldScale = 572.0 / world.height();
+    map.geoView()->setScaleLimits(wholeWorldScale, 16.0);
+    const QPointF beyondWest(world.left() - world.width() * 0.01,
+                             world.center().y());
+    map.cameraTo(QGVCameraActions(&map)
+                     .scaleTo(wholeWorldScale)
+                     .moveTo(beyondWest),
+                 false);
+    const double expectedWest = beyondWest.x();
+    const double actualWest = map.getCamera().projCenter().x();
+    const double centerErrorPixels =
+        std::abs(actualWest - expectedWest) * wholeWorldScale;
+    if (centerErrorPixels > 1.0) {
+        std::cerr << "wrapped camera center: actual=" << actualWest
+                  << " expected=" << expectedWest
+                  << " errorPixels=" << centerErrorPixels << '\n';
+    }
+    ok &= expect(centerErrorPixels <= 1.0,
+                 "wide wrapped camera should reach the dateline without scene clamping");
+
+    return ok ? 0 : 1;
+}

--- a/tests/map_wrap_test.cpp
+++ b/tests/map_wrap_test.cpp
@@ -5,6 +5,8 @@
 #include <QGeoView/QGVProjection.h>
 
 #include <QApplication>
+#include <QPoint>
+#include <QWheelEvent>
 #include <QtGlobal>
 
 #include <cmath>
@@ -31,18 +33,6 @@ int main(int argc, char** argv)
 {
     QApplication app(argc, argv);
     bool ok = true;
-    ok &= expect(nearlyEqual(QGV::wrapProjectionX(180.0, -180.0, 360.0),
-                             -180.0),
-                 "+180 should wrap to -180");
-    ok &= expect(nearlyEqual(QGV::wrapProjectionX(181.0, -180.0, 360.0),
-                             -179.0),
-                 "eastward camera motion should wrap across the dateline");
-    ok &= expect(nearlyEqual(QGV::wrapProjectionX(-181.0, -180.0, 360.0),
-                             179.0),
-                 "westward camera motion should wrap across the dateline");
-    ok &= expect(nearlyEqual(QGV::wrapProjectionX(901.0, -180.0, 360.0),
-                             -179.0),
-                 "multiple eastward world copies should normalize");
 
     ok &= expect(QGV::wrapTileX(2, -1) == 3,
                  "tile immediately west of the world should use the east edge");
@@ -52,6 +42,22 @@ int main(int argc, char** argv)
                  "tile wrapping should handle multiple world copies");
     ok &= expect(QGV::wrapTileX(-1, 17) == 17,
                  "invalid zoom should leave tile x unchanged");
+
+    // GeoTilePos::parent() must FLOOR, not truncate. Wrap is what first makes
+    // tile x negative, and contains() is built on parent(), so a truncating
+    // divide reports a western-copy tile as a child of a base-world tile —
+    // which makes removeWhenCovered() evict a fallback tile while the base
+    // world behind it is still half empty, leaving a hole at the antimeridian.
+    ok &= expect(QGV::GeoTilePos(5, QPoint(-1, 0)).parent(4).pos().x() == -1,
+                 "parent() of tile x=-1 should floor to -1, not truncate to 0");
+    ok &= expect(QGV::GeoTilePos(5, QPoint(-3, 0)).parent(4).pos().x() == -2,
+                 "parent() of tile x=-3 should floor to -2, not truncate to -1");
+    ok &= expect(QGV::GeoTilePos(4, QPoint(-1, 0))
+                         .contains(QGV::GeoTilePos(5, QPoint(-1, 0))),
+                 "a western-copy tile should be a child of its own parent");
+    ok &= expect(!QGV::GeoTilePos(4, QPoint(0, 0))
+                          .contains(QGV::GeoTilePos(5, QPoint(-1, 0))),
+                 "a western-copy tile must not count as a base-world child");
 
     // Exercise QGraphicsView's real centering constraint at the whole-world
     // scale. A wide viewport is wider than two worlds here; without the
@@ -82,6 +88,41 @@ int main(int argc, char** argv)
     }
     ok &= expect(centerErrorPixels <= 1.0,
                  "wide wrapped camera should reach the dateline without scene clamping");
+
+    // Zoom symmetry: n notches in followed by n notches out must land back on
+    // the scale we started from. Upstream's asymmetric in/out exponents lost
+    // ~11% per round trip, so the operator drifted away from their own view
+    // just by rocking the wheel. This is the invariant the single symmetric
+    // curve establishes, so pin it rather than the constants.
+    map.geoView()->setScaleLimits(1e-6, 1e3);
+    map.cameraTo(QGVCameraActions(&map).scaleTo(1.0), false);
+    app.processEvents();
+    const double startScale = map.getCamera().scale();
+    const auto wheel = [&](int notches) {
+        for (int i = 0; i < std::abs(notches); ++i) {
+            const QPointF pos(map.geoView()->width() / 2.0,
+                              map.geoView()->height() / 2.0);
+            QWheelEvent event(pos, map.geoView()->mapToGlobal(pos.toPoint()),
+                              QPoint(0, 0),
+                              QPoint(0, notches > 0 ? 120 : -120),
+                              Qt::NoButton, Qt::NoModifier,
+                              Qt::NoScrollPhase, false);
+            QApplication::sendEvent(map.geoView()->viewport(), &event);
+            app.processEvents();
+        }
+    };
+    wheel(4);
+    const double zoomedIn = map.getCamera().scale();
+    wheel(-4);
+    const double roundTrip = map.getCamera().scale();
+    ok &= expect(zoomedIn > startScale * 1.5,
+                 "four wheel notches in should zoom in appreciably");
+    if (!nearlyEqual(roundTrip / startScale, 1.0)) {
+        std::cerr << "zoom round trip: start=" << startScale
+                  << " in=" << zoomedIn << " back=" << roundTrip << '\n';
+    }
+    ok &= expect(nearlyEqual(roundTrip / startScale, 1.0),
+                 "equal wheel notches in and out should return the same scale");
 
     return ok ? 0 : 1;
 }

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -843,6 +843,21 @@ add_executable(display_status_gate_test tests/display_status_gate_test.cpp)
 target_include_directories(display_status_gate_test PRIVATE src)
 add_test(NAME display_status_gate_test COMMAND display_status_gate_test)
 
+# Slippy-map cylindrical-world math plus QGraphicsView camera constraints.
+# Drives a real QGVMap, so it needs the offscreen platform; never touches the
+# tile network.
+add_executable(map_wrap_test tests/map_wrap_test.cpp)
+target_link_libraries(map_wrap_test PRIVATE
+    qgeoview
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Widgets
+    Qt6::Network
+)
+add_test(NAME map_wrap_test COMMAND map_wrap_test)
+set_tests_properties(map_wrap_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 # Frameless-window geometry restore (#4328) — blob parse + the caption-free
 # re-clamp.  Windows-only in effect, but the logic is pure, so it is pinned on
 # every platform; case 4 drives a real QWidget so a future Qt changing the

--- a/third_party/QGeoView/AETHERSDR-PATCHES.md
+++ b/third_party/QGeoView/AETHERSDR-PATCHES.md
@@ -26,11 +26,51 @@ this list current when updating the snapshot.
    OSM and plain HTTP redirects anyway).
 
 5. **`QGVGlobal`, `QGVMapQGView`, and the tile layers** — added optional
-   horizontal world repetition. The camera stays continuous across the
-   antimeridian, logical tile x positions repeat while network URLs remain
-   canonical, and a bounded decoded-image cache avoids repeated PNG decode on
-   nearby revisits.
+   horizontal world repetition (`setHorizontalWrapEnabled()`, off by default,
+   so an unpatched caller behaves exactly as upstream). The camera keeps
+   projection x continuous across the antimeridian — `QGVMapQGView` slides the
+   scene rect to follow it rather than wrapping the coordinate — while logical
+   tile x repeats and `QGV::wrapTileX()` maps it back onto the canonical XYZ
+   range so network URLs and the HTTP cache never see the repetition.
+   `wrapTileX` is used by the tile layer only; the camera does not need it.
+   `QGVLayerTilesOnline` also gained a bounded decoded-image cache, so
+   re-entering an area costs a memcpy instead of a fetch and a PNG decode.
 
 6. **`lib/src/QGVMapQGView.cpp`** — normalized wheel and high-resolution
    touchpad zoom to one symmetric exponential curve. Upstream's asymmetric
-   in/out exponents made navigation feel markedly different by direction.
+   in/out exponents (`2^(1/2)` in, `2^(1/1.5)` out) meant equal numbers of
+   notches in and out did not return the operator to the scale they started
+   from — a mouse wheel lost about 11% of scale per in/out round trip.
+   Magnitudes, for the record: for a mouse wheel, zoom-**in** is numerically
+   identical to upstream (`2^(delta/240)`) and zoom-**out** is ~19% gentler
+   (`0.707x` per notch instead of `0.630x`). The high-resolution path changes
+   more — upstream fed `pixelDelta` through the same `/120` divisor and the
+   same asymmetric exponents, so `kTrackpadPixelsPerDoubling = 120.0` makes
+   trackpad zoom-in exactly **2x faster per pixel** than upstream.
+   `map_wrap_test` pins the round-trip property.
+
+7. **`lib/src/QGVGlobal.cpp` — `GeoTilePos::parent()` floors instead of
+   truncating.** Upstream divides two `int`s and calls `qFloor` on the
+   already-truncated quotient, which rounds toward zero. That is only
+   reachable once patch 5 makes tile x negative in the world copy west of the
+   base one, and `contains()` is built on `parent()`, so the truncated form
+   reported a western-copy tile as a child of a base-world tile.
+   `removeWhenCovered()` counts coverage through `contains()`, so it would
+   evict a fallback tile while the base world behind it was still half loaded —
+   a blank hole at the antimeridian, i.e. exactly the symptom patch 5 exists
+   to remove. Identical results for x >= 0. Pinned in `map_wrap_test`.
+
+8. **`lib/src/QGVLayerTiles.cpp` — off-screen tiles are culled at every zoom
+   level, not just the current one.** Upstream culls only `mCurZoom` against
+   the active rect; tiles at the retained neighbouring zoom levels are removed
+   solely by coverage or by zoom distance. That was safe while tile x was
+   clamped to `[0, 2^zoom]`, because the set was finite by construction. With
+   patch 5 it is not: every world copy the camera crossed left behind another
+   band of fallback tiles that nothing ever reclaimed. `overlapsActiveRect()`
+   adds the positional test, and it runs only when wrap is enabled.
+
+9. **`lib/src/QGVLayerTilesOnline.cpp` — in-flight requests are keyed on the
+   canonical tile.** Upstream keys `mRequest` on the position it was asked
+   for; with patch 5 the several visible copies of one tile all resolve to the
+   same canonical URL, so that would issue one identical concurrent GET per
+   copy. The finished reply is now fanned out to every copy waiting on it.

--- a/third_party/QGeoView/AETHERSDR-PATCHES.md
+++ b/third_party/QGeoView/AETHERSDR-PATCHES.md
@@ -24,3 +24,13 @@ this list current when updating the snapshot.
    `http://{a,b,c}.tile.openstreetmap.org` to
    `https://tile.openstreetmap.org` (subdomain aliases are deprecated by
    OSM and plain HTTP redirects anyway).
+
+5. **`QGVGlobal`, `QGVMapQGView`, and the tile layers** — added optional
+   horizontal world repetition. The camera stays continuous across the
+   antimeridian, logical tile x positions repeat while network URLs remain
+   canonical, and a bounded decoded-image cache avoids repeated PNG decode on
+   nearby revisits.
+
+6. **`lib/src/QGVMapQGView.cpp`** — normalized wheel and high-resolution
+   touchpad zoom to one symmetric exponential curve. Upstream's asymmetric
+   in/out exponents made navigation feel markedly different by direction.

--- a/third_party/QGeoView/lib/include/QGeoView/QGVGlobal.h
+++ b/third_party/QGeoView/lib/include/QGeoView/QGVGlobal.h
@@ -195,10 +195,11 @@ QGV_LIB_DECL QNetworkAccessManager* getNetworkManager();
 QGV_LIB_DECL void setTileUserAgent(const QByteArray& userAgent);
 QGV_LIB_DECL QByteArray getTileUserAgent();
 
-// AetherSDR patch: helpers shared by the horizontally repeating camera and
-// tile layers. Projection x is wrapped into [left, left + width); XYZ tile x
-// is wrapped into [0, 2^zoom). Invalid inputs are returned unchanged.
-QGV_LIB_DECL double wrapProjectionX(double x, double left, double width);
+// AetherSDR patch: helper for the horizontally repeating tile layers. Maps the
+// unbounded logical tile x of a repeated world copy onto the canonical XYZ
+// range [0, 2^zoom) so the network URL stays canonical. An invalid zoom returns
+// x unchanged. The camera does NOT use this — it keeps projection x continuous
+// across the antimeridian instead (QGVMapQGView slides the scene rect).
 QGV_LIB_DECL int wrapTileX(int zoom, int x);
 
 QGV_LIB_DECL QTransform createTransfrom(QPointF const& projAnchor, double scale, double azimuth);

--- a/third_party/QGeoView/lib/include/QGeoView/QGVGlobal.h
+++ b/third_party/QGeoView/lib/include/QGeoView/QGVGlobal.h
@@ -195,6 +195,12 @@ QGV_LIB_DECL QNetworkAccessManager* getNetworkManager();
 QGV_LIB_DECL void setTileUserAgent(const QByteArray& userAgent);
 QGV_LIB_DECL QByteArray getTileUserAgent();
 
+// AetherSDR patch: helpers shared by the horizontally repeating camera and
+// tile layers. Projection x is wrapped into [left, left + width); XYZ tile x
+// is wrapped into [0, 2^zoom). Invalid inputs are returned unchanged.
+QGV_LIB_DECL double wrapProjectionX(double x, double left, double width);
+QGV_LIB_DECL int wrapTileX(int zoom, int x);
+
 QGV_LIB_DECL QTransform createTransfrom(QPointF const& projAnchor, double scale, double azimuth);
 QGV_LIB_DECL QTransform createTransfromScale(QPointF const& projAnchor, double scale);
 QGV_LIB_DECL QTransform createTransfromAzimuth(QPointF const& projAnchor, double azimuth);

--- a/third_party/QGeoView/lib/include/QGeoView/QGVLayerTiles.h
+++ b/third_party/QGeoView/lib/include/QGeoView/QGVLayerTiles.h
@@ -52,6 +52,9 @@ protected:
 
 private:
     void processCamera();
+    // AetherSDR patch: cross-zoom positional test used to cull off-screen
+    // fallback tiles once horizontal wrap makes tile x unbounded.
+    bool overlapsActiveRect(const QGV::GeoTilePos& tilePos) const;
     void removeAllAbove(const QGV::GeoTilePos& tilePos);
     void removeWhenCovered(const QGV::GeoTilePos& tilePos);
     void removeForPerfomance(const QGV::GeoTilePos& tilePos);

--- a/third_party/QGeoView/lib/include/QGeoView/QGVLayerTiles.h
+++ b/third_party/QGeoView/lib/include/QGeoView/QGVLayerTiles.h
@@ -35,6 +35,7 @@ public:
     void setVisibleZoomLayersBelowCurrent(size_t value);
     void setVisibleZoomLayersAboveCurrent(size_t value);
     void setCameraUpdatesDuringAnimation(bool value);
+    void setHorizontalWrapEnabled(bool enabled);
 
 protected:
     void onProjection(QGVMap* geoMap) override;
@@ -66,6 +67,7 @@ private:
     QMap<int, QMap<QGV::GeoTilePos, QGVDrawItem*>> mIndex;
 
     QElapsedTimer mLastAnimation;
+    bool mHorizontalWrapEnabled = false;
 
     struct
     {

--- a/third_party/QGeoView/lib/include/QGeoView/QGVLayerTilesOnline.h
+++ b/third_party/QGeoView/lib/include/QGeoView/QGVLayerTilesOnline.h
@@ -20,6 +20,10 @@
 
 #include "QGVLayerTiles.h"
 
+#include <QCache>
+#include <QImage>
+#include <QUrl>
+
 #include <QNetworkReply>
 
 class QGV_LIB_DECL QGVLayerTilesOnline : public QGVLayerTiles
@@ -27,12 +31,14 @@ class QGV_LIB_DECL QGVLayerTilesOnline : public QGVLayerTiles
     Q_OBJECT
 
 public:
+    QGVLayerTilesOnline();
     ~QGVLayerTilesOnline();
 
 protected:
     virtual QString tilePosToUrl(const QGV::GeoTilePos& tilePos) const = 0;
 
 private:
+    QRectF tileProjectionRect(const QGV::GeoTilePos& tilePos) const;
     void request(const QGV::GeoTilePos& tilePos) override;
     void cancel(const QGV::GeoTilePos& tilePos) override;
     void onReplyFinished(QNetworkReply* reply, const QGV::GeoTilePos& tilePos);
@@ -40,4 +46,5 @@ private:
 
 private:
     QMap<QGV::GeoTilePos, QNetworkReply*> mRequest;
+    QCache<QUrl, QImage> mDecodedTileCache;
 };

--- a/third_party/QGeoView/lib/include/QGeoView/QGVLayerTilesOnline.h
+++ b/third_party/QGeoView/lib/include/QGeoView/QGVLayerTilesOnline.h
@@ -38,6 +38,7 @@ protected:
     virtual QString tilePosToUrl(const QGV::GeoTilePos& tilePos) const = 0;
 
 private:
+    static QGV::GeoTilePos canonicalTile(const QGV::GeoTilePos& tilePos);
     QRectF tileProjectionRect(const QGV::GeoTilePos& tilePos) const;
     void request(const QGV::GeoTilePos& tilePos) override;
     void cancel(const QGV::GeoTilePos& tilePos) override;
@@ -45,6 +46,10 @@ private:
     void removeReply(const QGV::GeoTilePos& tilePos);
 
 private:
+    // AetherSDR patch: both maps are keyed on the CANONICAL tile, so the world
+    // copies of one tile share a single GET. mWaiting holds the unwrapped x of
+    // every copy still expecting that reply (copies differ only in x).
     QMap<QGV::GeoTilePos, QNetworkReply*> mRequest;
+    QMap<QGV::GeoTilePos, QList<int>> mWaiting;
     QCache<QUrl, QImage> mDecodedTileCache;
 };

--- a/third_party/QGeoView/lib/include/QGeoView/QGVMapQGView.h
+++ b/third_party/QGeoView/lib/include/QGeoView/QGVMapQGView.h
@@ -48,6 +48,8 @@ public:
     double getMinScale() const;
     double getMaxScale() const;
     void setScaleLimits(double minScale, double maxScale);
+    void setHorizontalWrapEnabled(bool enabled);
+    bool horizontalWrapEnabled() const;
     void cleanState();
 
 Q_SIGNALS:
@@ -60,6 +62,7 @@ private:
     void cameraScale(const QRectF& projRect);
     void cameraRotate(double azimuth);
     void cameraMove(const QPointF& projPos);
+    void updateHorizontalWrapSceneRect(const QPointF& center);
     void blockCameraUpdate();
     void unblockCameraUpdate();
     void applyCameraUpdate(const QGVCameraState& oldState);
@@ -103,6 +106,7 @@ private:
     double mMaxScale;
     double mScale;
     double mAzimuth;
+    bool mHorizontalWrapEnabled;
     QGV::MouseActions mMouseActions;
     QRect mViewRect;
     QGV::MapState mState;

--- a/third_party/QGeoView/lib/src/QGVGlobal.cpp
+++ b/third_party/QGeoView/lib/src/QGVGlobal.cpp
@@ -478,6 +478,28 @@ QByteArray getTileUserAgent()
     return tileUserAgent;
 }
 
+double wrapProjectionX(double x, double left, double width)
+{
+    if (!qIsFinite(x) || !qIsFinite(left) || !qIsFinite(width) || width <= 0.0) {
+        return x;
+    }
+    double offset = std::fmod(x - left, width);
+    if (offset < 0.0) {
+        offset += width;
+    }
+    return left + offset;
+}
+
+int wrapTileX(int zoom, int x)
+{
+    if (zoom < 0 || zoom >= 31) {
+        return x;
+    }
+    const int tileCount = 1 << zoom;
+    const int remainder = x % tileCount;
+    return remainder < 0 ? remainder + tileCount : remainder;
+}
+
 } // namespace QGV
 
 QDebug operator<<(QDebug debug, const QGV::GeoPos& value)

--- a/third_party/QGeoView/lib/src/QGVGlobal.cpp
+++ b/third_party/QGeoView/lib/src/QGVGlobal.cpp
@@ -336,8 +336,17 @@ GeoTilePos GeoTilePos::parent(int parentZoom) const
     }
     const int deltaZoom = zoom() - parentZoom;
     const int factor = static_cast<int>(qPow(2, deltaZoom));
-    const int x = static_cast<int>(qFloor(pos().x() / factor));
-    const int y = static_cast<int>(qFloor(pos().y() / factor));
+    // AetherSDR patch: divide in floating point before flooring. Both operands
+    // are int, so plain `pos().x() / factor` truncates toward zero and qFloor
+    // never sees a fraction — which rounds the wrong way for negative tile x.
+    // Horizontal wrap makes x negative in the world copy west of the base one,
+    // and contains() is built on parent(), so the truncated form reports a
+    // western-copy tile as a child of a base-world tile. removeWhenCovered()
+    // counts coverage through contains(), so it would evict a fallback tile
+    // while the base world behind it was still half empty — a blank hole at the
+    // antimeridian. Identical for x >= 0, so nothing off the wrap path changes.
+    const int x = static_cast<int>(qFloor(static_cast<double>(pos().x()) / factor));
+    const int y = static_cast<int>(qFloor(static_cast<double>(pos().y()) / factor));
     return GeoTilePos(parentZoom, QPoint(x, y));
 }
 
@@ -476,18 +485,6 @@ void setTileUserAgent(const QByteArray& userAgent)
 QByteArray getTileUserAgent()
 {
     return tileUserAgent;
-}
-
-double wrapProjectionX(double x, double left, double width)
-{
-    if (!qIsFinite(x) || !qIsFinite(left) || !qIsFinite(width) || width <= 0.0) {
-        return x;
-    }
-    double offset = std::fmod(x - left, width);
-    if (offset < 0.0) {
-        offset += width;
-    }
-    return left + offset;
 }
 
 int wrapTileX(int zoom, int x)

--- a/third_party/QGeoView/lib/src/QGVLayerTiles.cpp
+++ b/third_party/QGeoView/lib/src/QGVLayerTiles.cpp
@@ -63,6 +63,15 @@ void QGVLayerTiles::setCameraUpdatesDuringAnimation(bool value)
     qgvDebug() << "CameraUpdatesDuringAnimation changed to" << value;
 }
 
+void QGVLayerTiles::setHorizontalWrapEnabled(bool enabled)
+{
+    if (mHorizontalWrapEnabled == enabled) {
+        return;
+    }
+    mHorizontalWrapEnabled = enabled;
+    processCamera();
+}
+
 void QGVLayerTiles::onProjection(QGVMap* geoMap)
 {
     QGVLayer::onProjection(geoMap);
@@ -147,7 +156,14 @@ void QGVLayerTiles::processCamera()
     }
     const QGVProjection* projection = getMap()->getProjection();
     const QGVCameraState camera = getMap()->getCamera();
-    const QRectF areaProjRect = camera.projRect().intersected(projection->boundaryProjRect());
+    QRectF areaProjRect = camera.projRect();
+    const QRectF world = projection->boundaryProjRect();
+    if (mHorizontalWrapEnabled) {
+        areaProjRect.setTop(qMax(areaProjRect.top(), world.top()));
+        areaProjRect.setBottom(qMin(areaProjRect.bottom(), world.bottom()));
+    } else {
+        areaProjRect = areaProjRect.intersected(world);
+    }
     const QGV::GeoRect areaGeoRect = projection->projToGeo(areaProjRect);
 
     int originZoom = scaleToZoom(camera.scale());
@@ -163,11 +179,23 @@ void QGVLayerTiles::processCamera()
                                      : static_cast<int>(mPerfomanceProfile.TilesMarginNoZoomChange);
     const int sizePerZoom = static_cast<int>(qPow(2, mCurZoom));
     const QRect maxRect = QRect(QPoint(0, 0), QPoint(sizePerZoom, sizePerZoom));
-    const QPoint topLeft = QGV::GeoTilePos::geoToTilePos(mCurZoom, areaGeoRect.topLeft()).pos();
-    const QPoint bottomRight = QGV::GeoTilePos::geoToTilePos(mCurZoom, areaGeoRect.bottomRight()).pos();
+    QPoint topLeft = QGV::GeoTilePos::geoToTilePos(mCurZoom, areaGeoRect.topLeft()).pos();
+    QPoint bottomRight = QGV::GeoTilePos::geoToTilePos(mCurZoom, areaGeoRect.bottomRight()).pos();
+    if (mHorizontalWrapEnabled) {
+        const double tilesPerProjectionUnit = sizePerZoom / world.width();
+        topLeft.setX(static_cast<int>(qFloor(
+            (areaProjRect.left() - world.left()) * tilesPerProjectionUnit)));
+        bottomRight.setX(static_cast<int>(qFloor(
+            (areaProjRect.right() - world.left()) * tilesPerProjectionUnit)));
+    }
     QRect activeRect = QRect(topLeft, bottomRight);
     activeRect = activeRect.adjusted(-margin, -margin, margin, margin);
-    activeRect = activeRect.intersected(maxRect);
+    if (mHorizontalWrapEnabled) {
+        activeRect.setTop(qMax(activeRect.top(), maxRect.top()));
+        activeRect.setBottom(qMin(activeRect.bottom(), maxRect.bottom()));
+    } else {
+        activeRect = activeRect.intersected(maxRect);
+    }
     const bool rectChanged = (!zoomChanged && (mCurRect != activeRect));
     mCurRect = activeRect;
 

--- a/third_party/QGeoView/lib/src/QGVLayerTiles.cpp
+++ b/third_party/QGeoView/lib/src/QGVLayerTiles.cpp
@@ -236,6 +236,31 @@ void QGVLayerTiles::processCamera()
         }
     }
 
+    // AetherSDR patch: the cull above only touches mCurZoom. Tiles at the other
+    // retained zoom levels are evicted solely by removeWhenCovered(),
+    // removeAllAbove() and removeForPerfomance(), all of which key on coverage
+    // or on zoom distance and never on position. Upstream that was safe because
+    // tile x was clamped to [0, 2^zoom], so the set was finite by construction.
+    // Horizontal wrap removes that clamp, so every world copy the camera
+    // crosses leaves behind another band of fallback tiles that nothing ever
+    // reclaims — unbounded growth on exactly the pan-forever path wrap adds.
+    // Cull those positionally too, against the same rect.
+    if (mHorizontalWrapEnabled && (zoomChanged || rectChanged)) {
+        const int fromZoom = minZoomlevel();
+        const int toZoom = maxZoomlevel();
+        for (int zoom = fromZoom; zoom <= toZoom; ++zoom) {
+            if (zoom == mCurZoom) {
+                continue;
+            }
+            for (const QGV::GeoTilePos& tilePos : existingTiles(zoom)) {
+                if (!overlapsActiveRect(tilePos)) {
+                    qgvDebug() << "delete out of active rect" << tilePos;
+                    removeTile(tilePos);
+                }
+            }
+        }
+    }
+
     QMultiMap<qreal, QGV::GeoTilePos> missing;
     for (int x = mCurRect.left(); x < mCurRect.right(); ++x) {
         for (int y = mCurRect.top(); y < mCurRect.bottom(); ++y) {
@@ -251,6 +276,42 @@ void QGVLayerTiles::processCamera()
     for (const QGV::GeoTilePos& tilePos : missing) {
         addTile(tilePos, nullptr);
     }
+}
+
+// AetherSDR patch: does `tilePos` — which may be at any zoom level — cover any
+// part of the current active rect? Used to cull off-screen fallback tiles once
+// horizontal wrap makes tile x unbounded. Everything is done in qint64 so the
+// span of a very coarse tile expressed in mCurZoom units cannot overflow.
+bool QGVLayerTiles::overlapsActiveRect(const QGV::GeoTilePos& tilePos) const
+{
+    const int zoom = tilePos.zoom();
+    if (zoom == mCurZoom) {
+        return mCurRect.contains(tilePos.pos());
+    }
+    const int deltaZoom = qAbs(zoom - mCurZoom);
+    if (deltaZoom > 30) {
+        // Far outside any retained window; leave it to removeForPerfomance().
+        return true;
+    }
+    const qint64 factor = Q_INT64_C(1) << deltaZoom;
+    qint64 left = 0, right = 0, top = 0, bottom = 0;
+    if (zoom > mCurZoom) {
+        // Finer than the current level: many child tiles per current-level one.
+        const auto floorDiv = [](qint64 value, qint64 by) {
+            const qint64 q = value / by;
+            return (value % by != 0 && (value < 0) != (by < 0)) ? q - 1 : q;
+        };
+        left = right = floorDiv(tilePos.pos().x(), factor);
+        top = bottom = floorDiv(tilePos.pos().y(), factor);
+    } else {
+        // Coarser: this one tile spans `factor` current-level tiles per axis.
+        left = static_cast<qint64>(tilePos.pos().x()) * factor;
+        right = left + factor - 1;
+        top = static_cast<qint64>(tilePos.pos().y()) * factor;
+        bottom = top + factor - 1;
+    }
+    return right >= mCurRect.left() && left <= mCurRect.right()
+            && bottom >= mCurRect.top() && top <= mCurRect.bottom();
 }
 
 void QGVLayerTiles::removeAllAbove(const QGV::GeoTilePos& tilePos)

--- a/third_party/QGeoView/lib/src/QGVLayerTilesOnline.cpp
+++ b/third_party/QGeoView/lib/src/QGVLayerTilesOnline.cpp
@@ -37,6 +37,18 @@ QGVLayerTilesOnline::~QGVLayerTilesOnline()
     qDeleteAll(mRequest);
 }
 
+// AetherSDR patch: the canonical (unwrapped) tile every repeated world copy
+// resolves to. Requests are keyed on this so N visible copies of the same tile
+// share one GET instead of issuing N identical ones.
+QGV::GeoTilePos QGVLayerTilesOnline::canonicalTile(
+    const QGV::GeoTilePos& tilePos)
+{
+    return QGV::GeoTilePos(
+        tilePos.zoom(),
+        QPoint(QGV::wrapTileX(tilePos.zoom(), tilePos.pos().x()),
+               tilePos.pos().y()));
+}
+
 QRectF QGVLayerTilesOnline::tileProjectionRect(
     const QGV::GeoTilePos& tilePos) const
 {
@@ -55,19 +67,39 @@ void QGVLayerTilesOnline::request(const QGV::GeoTilePos& tilePos)
 {
     Q_ASSERT(QGV::getNetworkManager());
 
-    const QGV::GeoTilePos sourceTilePos(
-        tilePos.zoom(),
-        QPoint(QGV::wrapTileX(tilePos.zoom(), tilePos.pos().x()),
-               tilePos.pos().y()));
+    const QGV::GeoTilePos sourceTilePos = canonicalTile(tilePos);
     const QUrl url(tilePosToUrl(sourceTilePos));
 
     if (const QImage* cached = mDecodedTileCache.object(url)) {
         auto* tile = new QGVImage();
         tile->setGeometry(tileProjectionRect(tilePos));
         tile->loadImage(*cached);
+        // AetherSDR patch: this re-enters onTile() SYNCHRONOUSLY, unlike every
+        // other path here, which arrives from a queued reply. onTile() calls
+        // addTile() and then removeAllAbove()/removeWhenCovered(), all of which
+        // mutate mIndex while QGVLayerTiles::processCamera() may still be
+        // iterating its `missing` list. That is safe today only because
+        // `missing` is a separate container, existingTiles() returns keys by
+        // value, and neither remover touches the zoom level being added — none
+        // of which upstream guarantees. Callers must not be iterating mIndex.
         onTile(tilePos, tile);
         return;
     }
+
+    // AetherSDR patch: coalesce the repeated world copies. Every visible copy of
+    // this tile resolves to the same canonical URL, so keying the in-flight map
+    // on the unwrapped position would fire one identical GET per copy. Key on
+    // the canonical tile and fan the finished reply out to everyone waiting.
+    // Copies of one tile differ only in x (same zoom, same y), and GeoTilePos
+    // has no operator==, so the waiter list holds the unwrapped x values.
+    auto waiting = mWaiting.find(sourceTilePos);
+    if (waiting != mWaiting.end()) {
+        if (!waiting->contains(tilePos.pos().x())) {
+            waiting->append(tilePos.pos().x());
+        }
+        return;
+    }
+    mWaiting.insert(sourceTilePos, { tilePos.pos().x() });
 
     QNetworkRequest request(url);
     // AetherSDR patch: honor proper TLS verification and an app-identifying
@@ -78,15 +110,27 @@ void QGVLayerTilesOnline::request(const QGV::GeoTilePos& tilePos)
 
     QNetworkReply* reply = QGV::getNetworkManager()->get(request);
 
-    mRequest[tilePos] = reply;
-    connect(reply, &QNetworkReply::finished, reply, [this, reply, tilePos]() { onReplyFinished(reply, tilePos); });
+    mRequest[sourceTilePos] = reply;
+    connect(reply, &QNetworkReply::finished, reply,
+            [this, reply, sourceTilePos]() { onReplyFinished(reply, sourceTilePos); });
 
     qgvDebug() << "request" << url;
 }
 
 void QGVLayerTilesOnline::cancel(const QGV::GeoTilePos& tilePos)
 {
-    removeReply(tilePos);
+    // AetherSDR patch: one reply can serve several world copies, so only abort
+    // it once the last copy waiting on it has gone away.
+    const QGV::GeoTilePos sourceTilePos = canonicalTile(tilePos);
+    auto waiting = mWaiting.find(sourceTilePos);
+    if (waiting != mWaiting.end()) {
+        waiting->removeAll(tilePos.pos().x());
+        if (!waiting->isEmpty()) {
+            return;
+        }
+        mWaiting.erase(waiting);
+    }
+    removeReply(sourceTilePos);
 }
 
 void QGVLayerTilesOnline::onReplyFinished(QNetworkReply* reply, const QGV::GeoTilePos& tilePos)
@@ -95,6 +139,7 @@ void QGVLayerTilesOnline::onReplyFinished(QNetworkReply* reply, const QGV::GeoTi
         if (reply->error() != QNetworkReply::OperationCanceledError) {
             qgvCritical() << "ERROR" << reply->errorString();
         }
+        mWaiting.remove(tilePos);
         removeReply(tilePos);
         return;
     }
@@ -102,24 +147,35 @@ void QGVLayerTilesOnline::onReplyFinished(QNetworkReply* reply, const QGV::GeoTi
     QImage decodedImage;
     if (!decodedImage.loadFromData(rawImage)) {
         qgvCritical() << "ERROR failed to decode tile" << reply->url();
+        mWaiting.remove(tilePos);
         removeReply(tilePos);
         return;
     }
     const qsizetype decodedBytes = decodedImage.sizeInBytes();
     const int cacheCost = static_cast<int>(qMin<qsizetype>(
         decodedBytes, std::numeric_limits<int>::max()));
-    mDecodedTileCache.insert(reply->url(), new QImage(decodedImage), cacheCost);
-    auto tile = new QGVImage();
-    tile->setGeometry(tileProjectionRect(tilePos));
-    tile->loadImage(decodedImage);
-    tile->setProperty("drawDebug",
-                      QString("%1\ntile(%2,%3,%4)")
-                              .arg(reply->url().toString())
-                              .arg(tilePos.zoom())
-                              .arg(tilePos.pos().x())
-                              .arg(tilePos.pos().y()));
+    const QUrl url = reply->url();
+    mDecodedTileCache.insert(url, new QImage(decodedImage), cacheCost);
+
+    // Detach the waiter list and drop the reply BEFORE dispatching: onTile()
+    // can re-enter removeTile() -> cancel(), which mutates mWaiting.
+    const QList<int> copies = mWaiting.take(tilePos);
     removeReply(tilePos);
-    onTile(tilePos, tile);
+
+    for (const int copyX : copies) {
+        const QGV::GeoTilePos copy(tilePos.zoom(),
+                                   QPoint(copyX, tilePos.pos().y()));
+        auto* tile = new QGVImage();
+        tile->setGeometry(tileProjectionRect(copy));
+        tile->loadImage(decodedImage);
+        tile->setProperty("drawDebug",
+                          QString("%1\ntile(%2,%3,%4)")
+                                  .arg(url.toString())
+                                  .arg(copy.zoom())
+                                  .arg(copy.pos().x())
+                                  .arg(copy.pos().y()));
+        onTile(copy, tile);
+    }
 }
 
 void QGVLayerTilesOnline::removeReply(const QGV::GeoTilePos& tilePos)

--- a/third_party/QGeoView/lib/src/QGVLayerTilesOnline.cpp
+++ b/third_party/QGeoView/lib/src/QGVLayerTilesOnline.cpp
@@ -18,17 +18,56 @@
 
 #include "QGVLayerTilesOnline.h"
 #include "Raster/QGVImage.h"
+#include "QGVMap.h"
+#include "QGVProjection.h"
+
+#include <limits>
+
+namespace {
+constexpr int kDecodedTileCacheBytes = 64 * 1024 * 1024;
+}
+
+QGVLayerTilesOnline::QGVLayerTilesOnline()
+{
+    mDecodedTileCache.setMaxCost(kDecodedTileCacheBytes);
+}
 
 QGVLayerTilesOnline::~QGVLayerTilesOnline()
 {
     qDeleteAll(mRequest);
 }
 
+QRectF QGVLayerTilesOnline::tileProjectionRect(
+    const QGV::GeoTilePos& tilePos) const
+{
+    const int sourceX = QGV::wrapTileX(tilePos.zoom(), tilePos.pos().x());
+    const int tileCount = 1 << tilePos.zoom();
+    const int worldCopy = (tilePos.pos().x() - sourceX) / tileCount;
+    const QGV::GeoTilePos sourceTile(
+        tilePos.zoom(), QPoint(sourceX, tilePos.pos().y()));
+    const QGVProjection* projection = getMap()->getProjection();
+    QRectF rect = projection->geoToProj(sourceTile.toGeoRect());
+    rect.translate(worldCopy * projection->boundaryProjRect().width(), 0.0);
+    return rect;
+}
+
 void QGVLayerTilesOnline::request(const QGV::GeoTilePos& tilePos)
 {
     Q_ASSERT(QGV::getNetworkManager());
 
-    const QUrl url(tilePosToUrl(tilePos));
+    const QGV::GeoTilePos sourceTilePos(
+        tilePos.zoom(),
+        QPoint(QGV::wrapTileX(tilePos.zoom(), tilePos.pos().x()),
+               tilePos.pos().y()));
+    const QUrl url(tilePosToUrl(sourceTilePos));
+
+    if (const QImage* cached = mDecodedTileCache.object(url)) {
+        auto* tile = new QGVImage();
+        tile->setGeometry(tileProjectionRect(tilePos));
+        tile->loadImage(*cached);
+        onTile(tilePos, tile);
+        return;
+    }
 
     QNetworkRequest request(url);
     // AetherSDR patch: honor proper TLS verification and an app-identifying
@@ -59,10 +98,20 @@ void QGVLayerTilesOnline::onReplyFinished(QNetworkReply* reply, const QGV::GeoTi
         removeReply(tilePos);
         return;
     }
-    const auto rawImage = reply->readAll();
+    const QByteArray rawImage = reply->readAll();
+    QImage decodedImage;
+    if (!decodedImage.loadFromData(rawImage)) {
+        qgvCritical() << "ERROR failed to decode tile" << reply->url();
+        removeReply(tilePos);
+        return;
+    }
+    const qsizetype decodedBytes = decodedImage.sizeInBytes();
+    const int cacheCost = static_cast<int>(qMin<qsizetype>(
+        decodedBytes, std::numeric_limits<int>::max()));
+    mDecodedTileCache.insert(reply->url(), new QImage(decodedImage), cacheCost);
     auto tile = new QGVImage();
-    tile->setGeometry(tilePos.toGeoRect());
-    tile->loadImage(rawImage);
+    tile->setGeometry(tileProjectionRect(tilePos));
+    tile->loadImage(decodedImage);
     tile->setProperty("drawDebug",
                       QString("%1\ntile(%2,%3,%4)")
                               .arg(reply->url().toString())

--- a/third_party/QGeoView/lib/src/QGVMapQGView.cpp
+++ b/third_party/QGeoView/lib/src/QGVMapQGView.cpp
@@ -34,8 +34,8 @@
 
 namespace {
 int wheelAreaMargin = 10;
-double wheelExponentDown = qPow(2, 1.0 / 2.0);
-double wheelExponentUp = qPow(2, 1.0 / 1.5);
+constexpr double kWheelDeltaPerDoubling = 240.0;
+constexpr double kTrackpadPixelsPerDoubling = 120.0;
 }
 
 QGVMapQGView::QGVMapQGView(QGVMap* geoMap)
@@ -48,6 +48,7 @@ QGVMapQGView::QGVMapQGView(QGVMap* geoMap)
     mMaxScale = 1e+2;
     mScale = 1.0;
     mAzimuth = 0.0;
+    mHorizontalWrapEnabled = false;
     mMouseActions = QGV::MouseAction::All;
     mViewRect = viewport()->rect();
     mState = QGV::MapState::Idle;
@@ -63,7 +64,10 @@ QGVMapQGView::QGVMapQGView(QGVMap* geoMap)
     setOptimizationFlag(DontAdjustForAntialiasing, true);
     setViewportUpdateMode(QGraphicsView::SmartViewportUpdate);
     setRenderHint(QPainter::Antialiasing, true);
-    setCacheMode(QGraphicsView::CacheBackground);
+    // Tiles are scene items, not the QGraphicsView background. Caching the
+    // solid fallback brush adds no value and leaves stale/black buffers when
+    // the scene rectangle slides to support repeated worlds.
+    setCacheMode(QGraphicsView::CacheNone);
     setMouseTracking(true);
     setBackgroundBrush(QBrush(Qt::lightGray));
     setAcceptDrops(true);
@@ -114,6 +118,27 @@ void QGVMapQGView::setScaleLimits(double minScale, double maxScale)
     cameraScale(mScale);
 }
 
+void QGVMapQGView::setHorizontalWrapEnabled(bool enabled)
+{
+    if (mHorizontalWrapEnabled == enabled) {
+        return;
+    }
+    mHorizontalWrapEnabled = enabled;
+    if (enabled) {
+        updateHorizontalWrapSceneRect(viewRect().center());
+    } else {
+        QRectF sceneRect = mGeoMap->getProjection()->boundaryProjRect();
+        sceneRect.adjust(-sceneRect.width(), -sceneRect.height(),
+                         sceneRect.width(), sceneRect.height());
+        scene()->setSceneRect(sceneRect);
+    }
+}
+
+bool QGVMapQGView::horizontalWrapEnabled() const
+{
+    return mHorizontalWrapEnabled;
+}
+
 void QGVMapQGView::cleanState()
 {
     changeState(QGV::MapState::Idle);
@@ -150,6 +175,7 @@ void QGVMapQGView::changeState(QGV::MapState state)
 void QGVMapQGView::cameraScale(double scale)
 {
     const QGVCameraState oldState = getCamera();
+    const QPointF oldCenter = viewRect().center();
     const double oldScale = mScale;
     const double newScale = qMax(mMinScale, qMin(mMaxScale, scale));
     if (qFuzzyCompare(oldScale, newScale)) {
@@ -158,6 +184,10 @@ void QGVMapQGView::cameraScale(double scale)
     const double deltaScale = newScale / oldScale;
     QGraphicsView::scale(deltaScale, deltaScale);
     mScale = newScale;
+    if (mHorizontalWrapEnabled) {
+        updateHorizontalWrapSceneRect(oldCenter);
+        QGraphicsView::centerOn(oldCenter);
+    }
     applyCameraUpdate(oldState);
     qgvDebug() << "cameraScale" << scale;
 }
@@ -180,11 +210,38 @@ void QGVMapQGView::cameraMove(const QPointF& projPos)
 {
     const QGVCameraState oldState = getCamera();
     const QPointF oldCenter = viewRect().center();
-    if (oldCenter != projPos) {
-        QGraphicsView::centerOn(projPos);
-        applyCameraUpdate(oldState);
-        qgvDebug() << "cameraMove" << projPos;
+    const QPointF target = projPos;
+    if (mHorizontalWrapEnabled) {
+        // Keep x continuous instead of snapping the camera back into the base
+        // world at the dateline. Tiles and overlays follow the current world
+        // copy, so a drag never swaps the scene underneath the pointer.
+        updateHorizontalWrapSceneRect(target);
     }
+    if (oldCenter != target) {
+        QGraphicsView::centerOn(target);
+        applyCameraUpdate(oldState);
+        qgvDebug() << "cameraMove" << target;
+    }
+}
+
+void QGVMapQGView::updateHorizontalWrapSceneRect(const QPointF& center)
+{
+    if (!mHorizontalWrapEnabled) {
+        return;
+    }
+    // QGraphicsView clamps centerOn() to the scene rectangle. The upstream
+    // rectangle is three worlds wide, which is still narrower than an
+    // ultrawide viewport at the whole-world zoom and makes a wrapped drag
+    // land on the clamp instead of the requested center. Keep a moving scene
+    // window around the canonical camera center: one full world of breathing
+    // room beyond each visible edge, without growing the scrollbar range at
+    // high zoom until it overflows QGraphicsView's integer scrollbars.
+    const QRectF world = mGeoMap->getProjection()->boundaryProjRect();
+    const double halfWidth = viewRect().width() * 0.5 + world.width();
+    QRectF sceneRect = scene()->sceneRect();
+    sceneRect.setLeft(center.x() - halfWidth);
+    sceneRect.setRight(center.x() + halfWidth);
+    scene()->setSceneRect(sceneRect);
 }
 
 void QGVMapQGView::blockCameraUpdate()
@@ -242,13 +299,12 @@ void QGVMapQGView::zoomByWheel(QWheelEvent* event)
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     const QPoint eventPos(qRound(event->position().x()), qRound(event->position().y()));
-    int eventDelta = event->angleDelta().y();
-    if (eventDelta == 0) {
-        eventDelta = event->pixelDelta().y();
-    }
+    const int angleDelta = event->angleDelta().y();
+    const int pixelDelta = event->pixelDelta().y();
 #else
     const QPoint eventPos(event->pos().x(), event->pos().y());
-    const auto eventDelta = event->delta();
+    const int angleDelta = event->delta();
+    const int pixelDelta = 0;
 #endif
 
     if (mState != QGV::MapState::Wheel) {
@@ -268,10 +324,11 @@ void QGVMapQGView::zoomByWheel(QWheelEvent* event)
     blockCameraUpdate();
     double newScale = mScale;
 
-    if (eventDelta > 0) {
-        newScale *= qPow(wheelExponentDown, eventDelta / 120.0);
-    } else if (eventDelta < 0) {
-        newScale /= qPow(wheelExponentUp, -eventDelta / 120.0);
+    const double zoomExponent = angleDelta != 0
+        ? static_cast<double>(angleDelta) / kWheelDeltaPerDoubling
+        : static_cast<double>(pixelDelta) / kTrackpadPixelsPerDoubling;
+    if (!qFuzzyIsNull(zoomExponent)) {
+        newScale *= qPow(2.0, zoomExponent);
     }
     cameraScale(newScale);
 
@@ -586,8 +643,13 @@ void QGVMapQGView::mouseDoubleClickEvent(QMouseEvent* event)
 void QGVMapQGView::resizeEvent(QResizeEvent* event)
 {
     const QGVCameraState oldState = getCamera();
+    const QPointF oldCenter = viewRect().center();
     QGraphicsView::resizeEvent(event);
     mViewRect = viewport()->rect();
+    if (mHorizontalWrapEnabled) {
+        updateHorizontalWrapSceneRect(oldCenter);
+        QGraphicsView::centerOn(oldCenter);
+    }
     mGeoMap->anchoreWidgets();
     applyCameraUpdate(oldState);
 }


### PR DESCRIPTION
## What this fixes

The PSK Reporter map had two user-facing navigation bugs:

- dragging and trackpad scrolling felt sluggish because map movement repeatedly churned tiles, decoded cached PNGs again, and performed marker hit-testing during every drag frame;
- horizontal navigation stopped at the antimeridian, forcing users to pan all the way around the opposite direction to compare reception across Asia and North America.

## What changed

- make the Web Mercator camera and tile layer repeat continuously across the antimeridian;
- keep wrapped tile requests on canonical OSM URLs while positioning tiles, spot markers, home markers, and propagation paths in the visible world copy;
- coalesce the in-flight request for a tile across its visible world copies, so the repetition costs no extra GETs;
- add a bounded 64 MiB decoded-image cache on top of the existing 256 MiB HTTP disk cache;
- normalize mouse-wheel and high-resolution trackpad deltas onto one symmetric zoom curve;
- skip expensive marker hit-testing while a drag is active;
- remove the stale QGraphicsView background cache that could leave black buffers after repeated world crossings;
- add regression coverage for tile wrapping, wide-viewport camera movement past the dateline, the tile-hierarchy floor, and zoom round-tripping.

### Behaviour changes worth calling out explicitly

These are user-visible and are *not* obvious from the summary above:

- **The tile layer is retuned in both directions, and the fallback retention goes down, not up.** Against `QGVLayerTiles`' upstream defaults: the no-zoom-change preload ring drops from 3 tiles to 1 (the with-zoom-change margin was already 1), and retained fallback zoom layers drop from **10 below / 10 above to 2 below / 1 above**. That is a reduction in how much coarse imagery is kept behind the current zoom. The decoded-image cache is what pays for it. This is the tuning that decides whether blank edges appear on a slow link.
- **`clampMinZoomToViewport()` lost its width term.** The world now repeats horizontally, so only the vertical axis has to be covered. This is what allows a wide widget to zoom out far enough to see more than one world — and it is load-bearing for the world-copy count below. A floor was added so the minimum scale can never drop below the tile layer's own minimum zoom, where `processCamera()` would otherwise bail out and stop updating tiles entirely.
- **Markers and paths are replicated into every visible world copy**, with the count derived from the viewport at its minimum scale rather than hardcoded, so a widget several worlds wide does not show empty outer copies.
- **Trackpad zoom-in is 2x faster per pixel than before.** For a mouse wheel, zoom-in is numerically identical to upstream and zoom-out is ~19% gentler; the symmetry fix is that equal notches in and out now return exactly to the starting scale, where upstream lost ~11% per round trip. The high-resolution path changes more: upstream fed `pixelDelta` through the same `/120` divisor and the asymmetric exponents, so one doubling per 120 px instead of per 240 px is a genuine rate change. `map_wrap_test` pins the round-trip property.
- **`MapView::clearMarkers()` now clears `m_hoverMarker` and hides the hover card.** This is a use-after-free fix, not tidiness: a periodic PSK refresh arriving while the cursor rested on a spot left a dangling pointer that the next mouse move dereferenced. `m_hoverMarker` is now a `QPointer` so it is structural rather than remembered.

### Vendored QGeoView

Every divergence from the upstream snapshot is recorded in `third_party/QGeoView/AETHERSDR-PATCHES.md` (entries 5–9). Wrap is opt-in via `setHorizontalWrapEnabled()` and off by default, so an unpatched caller behaves exactly as upstream. Three of those entries are defects that were latent upstream and only became reachable once wrap made tile x unbounded:

- `GeoTilePos::parent()` divided two `int`s and floored the already-truncated quotient, so it rounded the wrong way for negative tile x. Since `contains()` is built on `parent()`, a western-copy tile counted as a child of a base-world tile, and `removeWhenCovered()` would evict a fallback tile while the base world behind it was still half loaded — a blank hole at the antimeridian.
- `processCamera()` only culled the current zoom level against the active rect, so every world copy the camera crossed left behind a band of fallback tiles that nothing ever reclaimed.
- `mRequest` was keyed on the unwrapped position, so each visible copy issued its own concurrent GET for the identical canonical URL.

## User impact

The map now follows drag and trackpad input smoothly, revisits nearby areas without repeated decode work, and pans indefinitely east or west without a hard edge. PSK Reporter spots and paths remain aligned with the repeated map, including across the dateline.

## Validation

- `cmake --build build -j32`
- `QT_QPA_PLATFORM=offscreen ctest --test-dir build --output-on-failure`
- `map_wrap_test` is now registered with the offscreen environment property and runs in CI under its own step; it fails when the wrap fix is reverted, and its new assertions fail against the un-floored `GeoTilePos::parent()`.
- Off-screen tile accumulation measured directly against `libqgeoview.a`, 12 laps of "pan one world east, wobble the zoom": live scene items stay flat at 26 where they previously grew 39 → 215 without plateauing.
- automation-bridge sweep across five consecutive world boundaries with no blank edge, snap-back, or stale render
- live operator verification of drag and trackpad scrolling
