### PR TITLE
fix(crash): prevent multi-hour TCI mic backlog crash on Windows (Microsoft Store)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -652,6 +652,7 @@ set(CORE_SOURCES
     src/core/AudioOutputRouter.cpp
     src/core/AetherDspModePolicy.cpp
     src/core/AudioEngine.cpp
+    src/core/TxCaptureBuffer.cpp
     src/core/TxMicChannelNormalizer.cpp
     src/core/ChannelStripPresets.cpp
     src/core/Biquad.cpp
@@ -3647,6 +3648,7 @@ target_link_libraries(client_quindar_test PRIVATE Qt6::Core)
 
 add_executable(tx_mic_channel_normalizer_test
     tests/tx_mic_channel_normalizer_test.cpp
+    src/core/TxCaptureBuffer.cpp
     src/core/TxMicChannelNormalizer.cpp
     src/core/Resampler.cpp
 )

--- a/docs/architecture/audio-pipeline.md
+++ b/docs/architecture/audio-pipeline.md
@@ -338,9 +338,12 @@ flowchart TD
   which would otherwise grow in the app's own memory at the same ~192 KB/s. A
   multi-hour residue exceeded 2 GiB in v26.8.2 and overflowed the normalizer's
   old signed-`int` output-size calculation.
-- Pull-mode capture is drop-to-latest. Past 1 MiB of unread residue (about
-  5.5 s at 48 kHz stereo Int16) the stale head is skipped without allocating it,
-  so the block that reaches the air is the newest audio the backend holds rather
+- Capture is drop-to-latest on every platform. In pull mode, past 1 MiB of
+  unread residue (about 5.5 s at 48 kHz stereo Int16) the stale head is skipped
+  without allocating it; in macOS push mode, a block larger than the 256 KiB
+  ceiling — which a stalled audio thread produces, since nothing bounds what the
+  callback appends between 5 ms polls — is trimmed to its newest 256 KiB. Either
+  way the audio that reaches the air is the freshest the backend holds rather
   than a backlog replayed 1.36 s per callback. Discards are counted for the
   lifecycle and reported once as a capture-health event.
 
@@ -355,10 +358,13 @@ before the voice TX chain or early RADE/DAX branches:
 - The actual negotiated channel count is stored as `m_txInputChannels`.
 - Oversized realtime blocks are rejected before sample access or allocation on
   both the mic and radio-native DAX routes, and each rejection is logged. The
-  limit belongs to the normalizer, not to the capture read, so the DAX route —
-  which never passes through `TxCaptureBuffer` — is not bound to a microphone
-  constant. A trailing partial frame is truncated to the frame boundary rather
-  than dropping the block, and is recorded in the diagnostics. Buffer-size
+  limits belong to the normalizer rather than to the capture read, and the two
+  routes carry separate ones: the Int16 mic path matches the 256 KiB capture
+  chunk, while the float32 DAX path allows 1 MiB because it is fed by TCI, not
+  by a bounded device read, and its blocks arrive already upsampled — a 64 KiB
+  message from a conforming 8 kHz client expands roughly twelvefold (#3306).
+  A trailing partial frame is truncated to the frame boundary rather than
+  dropping the block, and is recorded in the diagnostics. Buffer-size
   calculations use `qsizetype`.
 - Mono input is duplicated to stereo with no level change.
 - Stereo input is reduced to one canonical mono voice signal before any

--- a/docs/architecture/audio-pipeline.md
+++ b/docs/architecture/audio-pipeline.md
@@ -329,6 +329,12 @@ flowchart TD
   5 ms timer polls that buffer and calls `onTxAudioReady()`.
 - Linux and Windows use pull mode: the device's `readyRead` signal calls
   `onTxAudioReady()` directly.
+- Pull-mode reads are capped at 256 KiB. While fresh TCI TX audio owns the
+  route, Linux and Windows continue consuming and discarding bounded mic
+  blocks. Linux needs this to preserve future `readyRead` edges; Windows needs
+  it because Qt/WASAPI otherwise appends unread capture into an unbounded
+  residue. A multi-hour residue exceeded 2 GiB in v26.8.2 and overflowed the
+  normalizer's old signed-`int` output-size calculation.
 
 When the capture sample rate is not 24 kHz, `m_txResampler` converts to the
 internal 24 kHz voice rate.
@@ -339,6 +345,8 @@ internal 24 kHz voice rate.
 before the voice TX chain or early RADE/DAX branches:
 
 - The actual negotiated channel count is stored as `m_txInputChannels`.
+- Oversized or frame-misaligned realtime blocks are rejected before sample
+  access or allocation; buffer-size calculations use `qsizetype`.
 - Mono input is duplicated to stereo with no level change.
 - Stereo input is reduced to one canonical mono voice signal before any
   resampling. Auto mode measures raw L/R RMS per block, selects the stronger

--- a/docs/architecture/audio-pipeline.md
+++ b/docs/architecture/audio-pipeline.md
@@ -329,12 +329,20 @@ flowchart TD
   5 ms timer polls that buffer and calls `onTxAudioReady()`.
 - Linux and Windows use pull mode: the device's `readyRead` signal calls
   `onTxAudioReady()` directly.
-- Pull-mode reads are capped at 256 KiB. While fresh TCI TX audio owns the
-  route, Linux and Windows continue consuming and discarding bounded mic
-  blocks. Linux needs this to preserve future `readyRead` edges; Windows needs
-  it because Qt/WASAPI otherwise appends unread capture into an unbounded
-  residue. A multi-hour residue exceeded 2 GiB in v26.8.2 and overflowed the
-  normalizer's old signed-`int` output-size calculation.
+- Pull-mode reads are capped at 256 KiB and frame-aligned to the negotiated
+  channel count.
+- While fresh TCI TX audio owns the route, every platform keeps consuming
+  capture instead of letting it pile up. Linux needs it to preserve future
+  `readyRead` edges; Windows needs it because Qt/WASAPI otherwise appends unread
+  capture into an unbounded residue; macOS clears its push-mode `m_micBuffer`,
+  which would otherwise grow in the app's own memory at the same ~192 KB/s. A
+  multi-hour residue exceeded 2 GiB in v26.8.2 and overflowed the normalizer's
+  old signed-`int` output-size calculation.
+- Pull-mode capture is drop-to-latest. Past 1 MiB of unread residue (about
+  5.5 s at 48 kHz stereo Int16) the stale head is skipped without allocating it,
+  so the block that reaches the air is the newest audio the backend holds rather
+  than a backlog replayed 1.36 s per callback. Discards are counted for the
+  lifecycle and reported once as a capture-health event.
 
 When the capture sample rate is not 24 kHz, `m_txResampler` converts to the
 internal 24 kHz voice rate.
@@ -345,8 +353,13 @@ internal 24 kHz voice rate.
 before the voice TX chain or early RADE/DAX branches:
 
 - The actual negotiated channel count is stored as `m_txInputChannels`.
-- Oversized or frame-misaligned realtime blocks are rejected before sample
-  access or allocation; buffer-size calculations use `qsizetype`.
+- Oversized realtime blocks are rejected before sample access or allocation on
+  both the mic and radio-native DAX routes, and each rejection is logged. The
+  limit belongs to the normalizer, not to the capture read, so the DAX route —
+  which never passes through `TxCaptureBuffer` — is not bound to a microphone
+  constant. A trailing partial frame is truncated to the frame boundary rather
+  than dropping the block, and is recorded in the diagnostics. Buffer-size
+  calculations use `qsizetype`.
 - Mono input is duplicated to stereo with no level change.
 - Stereo input is reduced to one canonical mono voice signal before any
   resampling. Auto mode measures raw L/R RMS per block, selects the stronger

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -721,6 +721,9 @@ handoffs: `buffer_bytes_available`, `buffer_capacity_bytes`,
 `source_was_active`, `saturation_observed`, `tci_suppressed_callbacks`,
 `full_buffer_during_tci_observations`, `idle_during_tci_transitions`,
 `post_tci_local_tx_while_saturated`, and `last_mic_read_age_ms`.
+Linux and Windows pull-mode inputs are drained in bounded blocks during TCI
+suppression, so a growing `buffer_bytes_available` value or a new saturation
+event now indicates that the backend has stopped making forward progress.
 `saturation_observed` is set when the capture buffer reaches its reported
 capacity during TCI suppression. An Active-to-Idle transition with suppressed
 callbacks and unread bytes remains a fallback for backends that do not expose a

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -720,10 +720,14 @@ The TX input endpoint also exposes in-memory capture-health evidence for TCI
 handoffs: `buffer_bytes_available`, `buffer_capacity_bytes`,
 `source_was_active`, `saturation_observed`, `tci_suppressed_callbacks`,
 `full_buffer_during_tci_observations`, `idle_during_tci_transitions`,
-`post_tci_local_tx_while_saturated`, and `last_mic_read_age_ms`.
-Linux and Windows pull-mode inputs are drained in bounded blocks during TCI
-suppression, so a growing `buffer_bytes_available` value or a new saturation
-event now indicates that the backend has stopped making forward progress.
+`post_tci_local_tx_while_saturated`, `capture_backlog_discards`,
+`capture_backlog_discarded_bytes`, and `last_mic_read_age_ms`.
+Capture is drained during TCI suppression on every platform — bounded blocks on
+Linux/Windows pull mode, a push-buffer clear on macOS — so a growing
+`buffer_bytes_available` value or a new saturation event now indicates that the
+backend has stopped making forward progress. A non-zero
+`capture_backlog_discards` means pull-mode capture had to skip stale audio to
+return to realtime; during a healthy soak it stays at zero.
 `saturation_observed` is set when the capture buffer reaches its reported
 capacity during TCI suppression. An Active-to-Idle transition with suppressed
 callbacks and unread bytes remains a fallback for backends that do not expose a

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -2,6 +2,7 @@
 #include "AppSettings.h"
 #include "AudioSummaryLogger.h"
 #include "AudioDeviceNegotiator.h"
+#include "TxCaptureBuffer.h"
 #include "ClientEq.h"
 #include "ClientComp.h"
 #include "ClientGate.h"
@@ -8034,15 +8035,16 @@ void AudioEngine::onTxAudioReady()
         if (event != TxCaptureHealthTracker::Event::None) {
             logTxCaptureHealthEvent(event);
         }
-#ifdef Q_OS_LINUX
-        // Qt/PipeWire capture is edge-driven: leaving the pull device unread
-        // fills its ring, after which no new readyRead edge arrives to resume
-        // PC Audio when TCI stops (#4230). Keep consuming the Linux source but
-        // discard these samples so only TCI audio reaches the radio. Windows
-        // and macOS retain their existing behavior until equivalent evidence
-        // exists for those backends.
+#ifndef Q_OS_MAC
+        // Pull-mode capture must keep consuming while TCI owns TX audio. An
+        // unread Qt/PipeWire ring stops producing readyRead edges (#4230), and
+        // Qt/WASAPI appends every unread block to an unbounded residue. The
+        // latter crossed 2 GiB after multi-hour TCI sessions and crashed the
+        // Int16 normalizer when local mic processing resumed. Discard one
+        // bounded block per callback so neither backend can accumulate.
         if (m_micDevice) {
-            const QByteArray discarded = m_micDevice->readAll();
+            const QByteArray discarded = TxCaptureBuffer::readBoundedInt16(
+                m_micDevice.data(), m_txInputChannels);
             if (!discarded.isEmpty()) {
                 m_txCaptureHealth.recordMicRead(txCaptureNowMs());
             }
@@ -8069,7 +8071,8 @@ void AudioEngine::onTxAudioReady()
 #else
     if (!m_micDevice
         || (!m_hostModulation && m_txStreamId == 0 && m_remoteTxStreamId == 0)) return;
-    QByteArray data = m_micDevice->readAll();
+    QByteArray data = TxCaptureBuffer::readBoundedInt16(
+        m_micDevice.data(), m_txInputChannels);
     if (data.isEmpty()) return;
     m_txReceivedAnyBytes = true;  // disarms the WASAPI silent-open watchdog (#2929)
 #endif
@@ -8087,7 +8090,15 @@ void AudioEngine::onTxAudioReady()
         m_txMicChannelMode,
         &m_txMicChannelState,
         &channelDiagnostics);
-    if (data.isEmpty()) return;
+    if (data.isEmpty()) {
+        if (channelDiagnostics.inputRejected) {
+            qCWarning(lcAudio) << "AudioEngine: rejected invalid TX mic block"
+                               << "bytes:" << channelDiagnostics.inputBytes
+                               << "rate:" << channelDiagnostics.inputSampleRate
+                               << "channels:" << channelDiagnostics.inputChannels;
+        }
+        return;
+    }
     logTxInputChannelDiagnostics(channelDiagnostics, "TX mic");
 
     // Resample canonical mono int16 to 24kHz duplicated stereo if needed, then

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -7450,8 +7450,13 @@ bool AudioEngine::tciAudioFresh() const
 
 void AudioEngine::observeTxCaptureState(QAudio::State state)
 {
+    observeTxCaptureState(state, txCaptureBufferedBytes());
+}
+
+void AudioEngine::observeTxCaptureState(QAudio::State state, qint64 bufferedBytes)
+{
     const TxCaptureHealthTracker::Event event = m_txCaptureHealth.observeState(
-        txCaptureState(state), tciAudioFresh(), txCaptureBufferedBytes());
+        txCaptureState(state), tciAudioFresh(), bufferedBytes);
     if (event != TxCaptureHealthTracker::Event::None) {
         logTxCaptureHealthEvent(event);
     }
@@ -8051,8 +8056,13 @@ void AudioEngine::onTxAudioReady()
     // produces continuous ambient packets. The 200 ms window comfortably
     // covers the 50 ms TCI frame cadence.
     if (tciAudioFresh()) {
+        // Sample the unread depth BEFORE the drain below empties it. The
+        // Active-to-Idle saturation fallback keys off "state went idle while
+        // bytes were still unread", so re-reading it afterwards would report
+        // zero every time and silently retire that signal.
+        const qint64 bufferedBeforeDrain = txCaptureBufferedBytes();
         const TxCaptureHealthTracker::Event event = m_txCaptureHealth.recordSuppressedCallback(
-            txCaptureBufferedBytes(), txCaptureBufferCapacityBytes());
+            bufferedBeforeDrain, txCaptureBufferCapacityBytes());
         if (event != TxCaptureHealthTracker::Event::None) {
             logTxCaptureHealthEvent(event);
         }
@@ -8088,7 +8098,7 @@ void AudioEngine::onTxAudioReady()
         }
 #endif
         if (m_audioSource) {
-            observeTxCaptureState(m_audioSource->state());
+            observeTxCaptureState(m_audioSource->state(), bufferedBeforeDrain);
         }
         return;
     }
@@ -8105,6 +8115,19 @@ void AudioEngine::onTxAudioReady()
     m_micBuffer->buffer().clear();
     m_micBuffer->seek(0);
     if (data.isEmpty()) return;
+    // Push mode has no read to bound: the capture callback keeps appending
+    // between 5 ms polls, so a stalled audio thread hands over one block as
+    // large as the stall. Apply the same drop-to-latest policy the pull path
+    // gets, or a stall past ~1.4 s would produce a block the normalizer refuses
+    // as oversized and the whole thing would be dropped instead of the stale
+    // part of it.
+    {
+        const qint64 stale = TxCaptureBuffer::trimToLatestBoundedInt16(
+            data, m_txInputChannels);
+        if (stale > 0) {
+            noteTxCaptureBacklogDiscard(stale);
+        }
+    }
 #else
     if (!m_micDevice
         || (!m_hostModulation && m_txStreamId == 0 && m_remoteTxStreamId == 0)) return;

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -2736,6 +2736,9 @@ QJsonArray AudioEngine::audioEndpointDiagnostics() const
     tx["idle_during_tci_transitions"] = static_cast<double>(txHealth.idleDuringTciTransitions);
     tx["post_tci_local_tx_while_saturated"] =
         static_cast<double>(txHealth.postTciLocalTxWhileSaturated);
+    tx["capture_backlog_discards"] = static_cast<double>(txHealth.captureBacklogDiscards);
+    tx["capture_backlog_discarded_bytes"] =
+        static_cast<double>(txHealth.captureBacklogDiscardedBytes);
     tx["last_mic_read_age_ms"] = txHealth.lastMicReadAgeMs >= 0
         ? QJsonValue(static_cast<double>(txHealth.lastMicReadAgeMs))
         : QJsonValue();
@@ -7472,6 +7475,21 @@ void AudioEngine::recordTxCaptureLocalTxAttempt()
     }
 }
 
+void AudioEngine::noteTxCaptureBacklogDiscard(qint64 discardedBytes)
+{
+    const TxCaptureHealthTracker::Event event =
+        m_txCaptureHealth.recordBacklogDiscard(discardedBytes);
+    if (event == TxCaptureHealthTracker::Event::None) {
+        return;
+    }
+    // Dropping stale capture is deliberate, but it means the backend outran the
+    // consumer — worth one warning per lifecycle even without the support
+    // debug toggle, since it is the symptom the soak test is looking for.
+    qCWarning(lcAudio) << "AudioEngine: discarded stale TX capture backlog"
+                       << "bytes:" << discardedBytes;
+    logTxCaptureHealthEvent(event);
+}
+
 void AudioEngine::logTxCaptureHealthEvent(TxCaptureHealthTracker::Event event)
 {
     switch (event) {
@@ -7480,6 +7498,9 @@ void AudioEngine::logTxCaptureHealthEvent(TxCaptureHealthTracker::Event event)
         break;
     case TxCaptureHealthTracker::Event::LocalTxWhileSaturated:
         logTxCaptureHealthSummary(QStringLiteral("local TX with saturated post-TCI capture"), true);
+        break;
+    case TxCaptureHealthTracker::Event::CaptureBacklogDiscarded:
+        logTxCaptureHealthSummary(QStringLiteral("stale capture backlog discarded"), true);
         break;
     case TxCaptureHealthTracker::Event::None:
         break;
@@ -8035,18 +8056,34 @@ void AudioEngine::onTxAudioReady()
         if (event != TxCaptureHealthTracker::Event::None) {
             logTxCaptureHealthEvent(event);
         }
-#ifndef Q_OS_MAC
-        // Pull-mode capture must keep consuming while TCI owns TX audio. An
-        // unread Qt/PipeWire ring stops producing readyRead edges (#4230), and
-        // Qt/WASAPI appends every unread block to an unbounded residue. The
-        // latter crossed 2 GiB after multi-hour TCI sessions and crashed the
-        // Int16 normalizer when local mic processing resumed. Discard one
-        // bounded block per callback so neither backend can accumulate.
+        // Capture must keep being consumed while TCI owns TX audio, on every
+        // platform — all three backends accumulate, just in different memory.
+#ifdef Q_OS_MAC
+        // Push mode: QAudioSource writes into m_micBuffer, which only the
+        // unsuppressed path below clears. Left alone it grows for the whole TCI
+        // session (~192 KB/s at 48 kHz stereo Int16) — the same multi-GB
+        // residue WASAPI builds, except it is our own resident memory, which
+        // the Store sandbox is least forgiving about.
+        if (m_micBuffer && m_micBuffer->isOpen() && m_micBuffer->pos() > 0) {
+            m_micBuffer->buffer().clear();
+            m_micBuffer->seek(0);
+            m_txCaptureHealth.recordMicRead(txCaptureNowMs());
+        }
+#else
+        // Pull mode: an unread Qt/PipeWire ring stops producing readyRead edges
+        // (#4230), and Qt/WASAPI appends every unread block to an unbounded
+        // residue. The latter crossed 2 GiB after multi-hour TCI sessions and
+        // crashed the Int16 normalizer when local mic processing resumed.
+        // Discard one bounded block per callback so neither can accumulate.
         if (m_micDevice) {
-            const QByteArray discarded = TxCaptureBuffer::readBoundedInt16(
-                m_micDevice.data(), m_txInputChannels);
-            if (!discarded.isEmpty()) {
+            const TxCaptureBuffer::BoundedRead drained =
+                TxCaptureBuffer::readLatestBoundedInt16(m_micDevice.data(),
+                                                        m_txInputChannels);
+            if (!drained.block.isEmpty() || drained.discardedBytes > 0) {
                 m_txCaptureHealth.recordMicRead(txCaptureNowMs());
+            }
+            if (drained.discardedBytes > 0) {
+                noteTxCaptureBacklogDiscard(drained.discardedBytes);
             }
         }
 #endif
@@ -8071,8 +8108,15 @@ void AudioEngine::onTxAudioReady()
 #else
     if (!m_micDevice
         || (!m_hostModulation && m_txStreamId == 0 && m_remoteTxStreamId == 0)) return;
-    QByteArray data = TxCaptureBuffer::readBoundedInt16(
-        m_micDevice.data(), m_txInputChannels);
+    // Drop-to-latest: if a residue survived the drain above, transmit the
+    // freshest block rather than walking a backlog of hours-old audio onto the
+    // air 1.36 s at a time.
+    const TxCaptureBuffer::BoundedRead micRead =
+        TxCaptureBuffer::readLatestBoundedInt16(m_micDevice.data(), m_txInputChannels);
+    if (micRead.discardedBytes > 0) {
+        noteTxCaptureBacklogDiscard(micRead.discardedBytes);
+    }
+    QByteArray data = micRead.block;
     if (data.isEmpty()) return;
     m_txReceivedAnyBytes = true;  // disarms the WASAPI silent-open watchdog (#2929)
 #endif
@@ -8092,7 +8136,7 @@ void AudioEngine::onTxAudioReady()
         &channelDiagnostics);
     if (data.isEmpty()) {
         if (channelDiagnostics.inputRejected) {
-            qCWarning(lcAudio) << "AudioEngine: rejected invalid TX mic block"
+            qCWarning(lcAudio) << "AudioEngine: rejected oversized TX mic block"
                                << "bytes:" << channelDiagnostics.inputBytes
                                << "rate:" << channelDiagnostics.inputSampleRate
                                << "channels:" << channelDiagnostics.inputChannels;
@@ -8793,7 +8837,19 @@ void AudioEngine::feedDaxTxAudioInternal(const QByteArray& inPcm,
         m_daxRadioTxChannelMode,
         &m_daxRadioTxChannelState,
         &daxDiagnostics);
-    if (mono.isEmpty()) return;
+    if (mono.isEmpty()) {
+        // Before the block cap an empty return here could only mean "fewer than
+        // one whole frame", which is unremarkable. It can now also mean the
+        // block was refused as oversized, which is a real fault that would
+        // otherwise drop TX audio with nothing in the log at any level.
+        if (daxDiagnostics.inputRejected) {
+            qCWarning(lcAudio) << "AudioEngine: rejected oversized DAX TX block"
+                               << "bytes:" << daxDiagnostics.inputBytes
+                               << "rate:" << daxDiagnostics.inputSampleRate
+                               << "channels:" << daxDiagnostics.inputChannels;
+        }
+        return;
+    }
     logTxInputChannelDiagnostics(daxDiagnostics, "DAX radio");
 
     m_txFloatAccumulator.append(mono);

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -886,6 +886,8 @@ private:
                                 bool markExternalSource,
                                 bool forceRadioDaxRoute);
     void observeTxCaptureState(QAudio::State state);
+    // Overload for callers that must sample the unread depth before draining it.
+    void observeTxCaptureState(QAudio::State state, qint64 bufferedBytes);
     void recordTxCaptureLocalTxAttempt();
     void noteTxCaptureBacklogDiscard(qint64 discardedBytes);
     void logTxCaptureHealthEvent(TxCaptureHealthTracker::Event event);

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -887,6 +887,7 @@ private:
                                 bool forceRadioDaxRoute);
     void observeTxCaptureState(QAudio::State state);
     void recordTxCaptureLocalTxAttempt();
+    void noteTxCaptureBacklogDiscard(qint64 discardedBytes);
     void logTxCaptureHealthEvent(TxCaptureHealthTracker::Event event);
     void logTxCaptureHealthSummary(const QString& reason, bool anomaly);
 

--- a/src/core/TxCaptureBuffer.cpp
+++ b/src/core/TxCaptureBuffer.cpp
@@ -22,6 +22,12 @@ qint64 alignDown(qint64 bytes, qint64 frameBytes)
     return bytes - (bytes % frameBytes);
 }
 
+qint64 alignUp(qint64 bytes, qint64 frameBytes)
+{
+    const qint64 remainder = bytes % frameBytes;
+    return remainder == 0 ? bytes : bytes + (frameBytes - remainder);
+}
+
 } // namespace
 
 BoundedRead readLatestBoundedInt16(QIODevice* device, int inputChannels)
@@ -69,8 +75,12 @@ qint64 trimToLatestBoundedInt16(QByteArray& block, int inputChannels)
         return 0;
     }
 
-    const qint64 discarded = block.size() - alignedLimit;
-    block = block.last(alignedLimit);
+    // Cut a whole number of frames off the front. Rounding the discard UP keeps
+    // the retained tail starting on a frame boundary even when the push buffer
+    // itself ended mid-frame — trimming a bare byte count there would shift the
+    // block by a sample and swap L/R for the rest of it.
+    const qint64 discarded = alignUp(block.size() - alignedLimit, frameBytes);
+    block = block.last(block.size() - discarded);
     return discarded;
 }
 

--- a/src/core/TxCaptureBuffer.cpp
+++ b/src/core/TxCaptureBuffer.cpp
@@ -1,0 +1,19 @@
+#include "TxCaptureBuffer.h"
+
+#include <QIODevice>
+
+namespace AetherSDR::TxCaptureBuffer {
+
+QByteArray readBoundedInt16(QIODevice* device, int inputChannels)
+{
+    if (!device) {
+        return {};
+    }
+
+    const qint64 channels = inputChannels <= 1 ? 1 : 2;
+    const qint64 frameBytes = channels * static_cast<qint64>(sizeof(qint16));
+    const qint64 alignedLimit = kMaxReadBytes - (kMaxReadBytes % frameBytes);
+    return device->read(alignedLimit);
+}
+
+} // namespace AetherSDR::TxCaptureBuffer

--- a/src/core/TxCaptureBuffer.cpp
+++ b/src/core/TxCaptureBuffer.cpp
@@ -2,18 +2,41 @@
 
 #include <QIODevice>
 
+#include <algorithm>
+
 namespace AetherSDR::TxCaptureBuffer {
 
-QByteArray readBoundedInt16(QIODevice* device, int inputChannels)
+BoundedRead readLatestBoundedInt16(QIODevice* device, int inputChannels)
 {
     if (!device) {
         return {};
     }
 
-    const qint64 channels = inputChannels <= 1 ? 1 : 2;
+    // Align to the device's real frame size, not the normalizer's 1-or-2 clamp:
+    // a 6-channel negotiated device has 12-byte frames, which 256 KiB does not
+    // divide evenly. Reading a partial frame would leave every later read
+    // straddling a frame boundary.
+    const qint64 channels = std::max<qint64>(1, inputChannels);
     const qint64 frameBytes = channels * static_cast<qint64>(sizeof(qint16));
     const qint64 alignedLimit = kMaxReadBytes - (kMaxReadBytes % frameBytes);
-    return device->read(alignedLimit);
+
+    BoundedRead out;
+
+    // Drop to latest before reading. skip() consumes in bounded internal chunks,
+    // so a multi-gigabyte residue is discarded without ever being allocated.
+    const qint64 available = device->bytesAvailable();
+    if (available > kCatchUpThresholdBytes) {
+        const qint64 staleBytes = available - alignedLimit;
+        const qint64 alignedStale = staleBytes - (staleBytes % frameBytes);
+        if (alignedStale > 0) {
+            // skip() returns -1 on a device error; treat that as "nothing was
+            // discarded" so the health counter never goes backwards.
+            out.discardedBytes = std::max<qint64>(0, device->skip(alignedStale));
+        }
+    }
+
+    out.block = device->read(alignedLimit);
+    return out;
 }
 
 } // namespace AetherSDR::TxCaptureBuffer

--- a/src/core/TxCaptureBuffer.cpp
+++ b/src/core/TxCaptureBuffer.cpp
@@ -6,19 +6,32 @@
 
 namespace AetherSDR::TxCaptureBuffer {
 
+namespace {
+
+// Align to the device's real frame size, not the normalizer's 1-or-2 clamp: a
+// 6-channel negotiated device has 12-byte frames, which 256 KiB does not divide
+// evenly. Keeping a partial frame would leave every later block straddling a
+// frame boundary.
+qint64 frameBytesFor(int inputChannels)
+{
+    return std::max<qint64>(1, inputChannels) * static_cast<qint64>(sizeof(qint16));
+}
+
+qint64 alignDown(qint64 bytes, qint64 frameBytes)
+{
+    return bytes - (bytes % frameBytes);
+}
+
+} // namespace
+
 BoundedRead readLatestBoundedInt16(QIODevice* device, int inputChannels)
 {
     if (!device) {
         return {};
     }
 
-    // Align to the device's real frame size, not the normalizer's 1-or-2 clamp:
-    // a 6-channel negotiated device has 12-byte frames, which 256 KiB does not
-    // divide evenly. Reading a partial frame would leave every later read
-    // straddling a frame boundary.
-    const qint64 channels = std::max<qint64>(1, inputChannels);
-    const qint64 frameBytes = channels * static_cast<qint64>(sizeof(qint16));
-    const qint64 alignedLimit = kMaxReadBytes - (kMaxReadBytes % frameBytes);
+    const qint64 frameBytes = frameBytesFor(inputChannels);
+    const qint64 alignedLimit = alignDown(kMaxReadBytes, frameBytes);
 
     BoundedRead out;
 
@@ -26,8 +39,7 @@ BoundedRead readLatestBoundedInt16(QIODevice* device, int inputChannels)
     // so a multi-gigabyte residue is discarded without ever being allocated.
     const qint64 available = device->bytesAvailable();
     if (available > kCatchUpThresholdBytes) {
-        const qint64 staleBytes = available - alignedLimit;
-        const qint64 alignedStale = staleBytes - (staleBytes % frameBytes);
+        const qint64 alignedStale = alignDown(available - alignedLimit, frameBytes);
         if (alignedStale > 0) {
             // skip() returns -1 on a device error; treat that as "nothing was
             // discarded" so the health counter never goes backwards.
@@ -35,8 +47,31 @@ BoundedRead readLatestBoundedInt16(QIODevice* device, int inputChannels)
         }
     }
 
-    out.block = device->read(alignedLimit);
+    // Ask only for what is there. QIODevice::read(qint64) sizes its result to
+    // maxSize before reading and only shrinks afterwards, so passing the full
+    // ceiling would allocate 256 KiB on every readyRead to carry a few KB. A
+    // device that reports nothing available still gets the full ceiling, since
+    // then the count cannot be trusted to mean "no data".
+    const qint64 want = available > 0
+        ? std::min(alignedLimit, alignDown(available, frameBytes))
+        : alignedLimit;
+    if (want > 0) {
+        out.block = device->read(want);
+    }
     return out;
+}
+
+qint64 trimToLatestBoundedInt16(QByteArray& block, int inputChannels)
+{
+    const qint64 frameBytes = frameBytesFor(inputChannels);
+    const qint64 alignedLimit = alignDown(kMaxReadBytes, frameBytes);
+    if (block.size() <= alignedLimit) {
+        return 0;
+    }
+
+    const qint64 discarded = block.size() - alignedLimit;
+    block = block.last(alignedLimit);
+    return discarded;
 }
 
 } // namespace AetherSDR::TxCaptureBuffer

--- a/src/core/TxCaptureBuffer.h
+++ b/src/core/TxCaptureBuffer.h
@@ -13,6 +13,27 @@ namespace AetherSDR::TxCaptureBuffer {
 // allocation. At 48 kHz stereo Int16 this is about 1.36 seconds of audio.
 inline constexpr qint64 kMaxReadBytes = 256 * 1024;
 
-QByteArray readBoundedInt16(QIODevice* device, int inputChannels);
+// Above this much unread residue the backend is past catch-up distance:
+// consuming it one bounded block per callback would put minutes of hours-stale
+// microphone audio on the air, 1.36 s at a time, with nothing to tell the
+// operator why. A realtime capture path wants the freshest block, so older
+// residue is skipped without allocating it. Four blocks is about 5.5 s at
+// 48 kHz stereo Int16 — well beyond any legitimate audio-thread scheduling
+// delay, and short enough that no stale tail is audible.
+inline constexpr qint64 kCatchUpThresholdBytes = 4 * kMaxReadBytes;
+
+struct BoundedRead {
+    // The freshest bounded block, frame-aligned for the negotiated channel
+    // count. Empty when the device held less than one whole frame.
+    QByteArray block;
+    // Stale bytes skipped to catch up; zero on the normal path. Non-zero means
+    // the backend outran the consumer and audio was dropped deliberately.
+    qint64 discardedBytes{0};
+};
+
+// Reads at most kMaxReadBytes from a pull-mode capture device, first skipping
+// any residue past kCatchUpThresholdBytes so the block returned is the newest
+// audio the backend holds rather than the oldest.
+BoundedRead readLatestBoundedInt16(QIODevice* device, int inputChannels);
 
 } // namespace AetherSDR::TxCaptureBuffer

--- a/src/core/TxCaptureBuffer.h
+++ b/src/core/TxCaptureBuffer.h
@@ -36,4 +36,11 @@ struct BoundedRead {
 // audio the backend holds rather than the oldest.
 BoundedRead readLatestBoundedInt16(QIODevice* device, int inputChannels);
 
+// Same drop-to-latest policy for push mode, where there is no read to bound:
+// macOS hands over everything the capture callback accumulated since the last
+// poll, so a stalled audio thread produces one oversized block. Trims block in
+// place to its newest frame-aligned kMaxReadBytes and returns the bytes
+// dropped (zero when it already fits).
+qint64 trimToLatestBoundedInt16(QByteArray& block, int inputChannels);
+
 } // namespace AetherSDR::TxCaptureBuffer

--- a/src/core/TxCaptureBuffer.h
+++ b/src/core/TxCaptureBuffer.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <QByteArray>
+#include <QtGlobal>
+
+class QIODevice;
+
+namespace AetherSDR::TxCaptureBuffer {
+
+// QAudioSource normally delivers a fraction of its ~200 ms device buffer per
+// readyRead. Keep a generous ceiling so a delayed audio-thread callback can
+// catch up without allowing an unbounded backend residue to become one giant
+// allocation. At 48 kHz stereo Int16 this is about 1.36 seconds of audio.
+inline constexpr qint64 kMaxReadBytes = 256 * 1024;
+
+QByteArray readBoundedInt16(QIODevice* device, int inputChannels);
+
+} // namespace AetherSDR::TxCaptureBuffer

--- a/src/core/TxCaptureHealthTracker.h
+++ b/src/core/TxCaptureHealthTracker.h
@@ -25,6 +25,7 @@ public:
         None,
         BufferSaturatedDuringTci,
         LocalTxWhileSaturated,
+        CaptureBacklogDiscarded,
     };
 
     struct Snapshot {
@@ -35,6 +36,8 @@ public:
         quint64 fullBufferDuringTciObservations{0};
         quint64 idleDuringTciTransitions{0};
         quint64 postTciLocalTxWhileSaturated{0};
+        quint64 captureBacklogDiscards{0};
+        qint64 captureBacklogDiscardedBytes{0};
         bool sourceWasActive{false};
         bool saturationObserved{false};
     };
@@ -53,6 +56,27 @@ public:
         m_fullBufferDuringTciObservations = 0;
         m_idleDuringTciTransitions = 0;
         m_postTciLocalTxWhileSaturated = 0;
+        m_captureBacklogDiscards = 0;
+        m_captureBacklogDiscardedBytes = 0;
+        m_backlogDiscardReported = false;
+    }
+
+    // The capture path dropped stale audio to catch up to realtime. Counted for
+    // the whole lifecycle, but reported as an event only the first time: a
+    // backend that keeps outrunning the consumer would otherwise warn on every
+    // callback, and the count is what a support dump actually needs.
+    Event recordBacklogDiscard(qint64 discardedBytes)
+    {
+        if (discardedBytes <= 0) {
+            return Event::None;
+        }
+        ++m_captureBacklogDiscards;
+        m_captureBacklogDiscardedBytes += discardedBytes;
+        if (m_backlogDiscardReported) {
+            return Event::None;
+        }
+        m_backlogDiscardReported = true;
+        return Event::CaptureBacklogDiscarded;
     }
 
     Event recordSuppressedCallback(qint64 bufferedBytes, qint64 bufferCapacityBytes)
@@ -156,6 +180,8 @@ public:
         out.fullBufferDuringTciObservations = m_fullBufferDuringTciObservations;
         out.idleDuringTciTransitions = m_idleDuringTciTransitions;
         out.postTciLocalTxWhileSaturated = m_postTciLocalTxWhileSaturated;
+        out.captureBacklogDiscards = m_captureBacklogDiscards;
+        out.captureBacklogDiscardedBytes = m_captureBacklogDiscardedBytes;
         out.sourceWasActive = m_sourceWasActive;
         out.saturationObserved = m_saturationReported;
         return out;
@@ -174,6 +200,9 @@ private:
     bool m_currentlySaturated{false};
     bool m_saturationReported{false};
     bool m_stalledLocalTxReported{false};
+    bool m_backlogDiscardReported{false};
+    quint64 m_captureBacklogDiscards{0};
+    qint64 m_captureBacklogDiscardedBytes{0};
     quint64 m_tciSuppressedCallbacks{0};
     qint64 m_suppressedBufferPeakBytes{0};
     quint64 m_fullBufferDuringTciObservations{0};

--- a/src/core/TxMicChannelNormalizer.cpp
+++ b/src/core/TxMicChannelNormalizer.cpp
@@ -10,14 +10,17 @@
 
 namespace AetherSDR::TxMicChannelNormalizer {
 
-// A bounded capture read must never be refused as oversized, and the block cap
-// must stay small enough that the int frame counts below cannot overflow.
-// Asserting both here keeps the two constants honest if either one moves.
+// A bounded capture read must never be refused as oversized, and neither cap
+// may grow past the point where the int frame counts below can overflow.
+// Asserting here keeps the constants honest if any of them moves.
 static_assert(kMaxRealtimeBlockBytes >= TxCaptureBuffer::kMaxReadBytes,
               "a bounded capture read must never be rejected as oversized");
 static_assert(kMaxRealtimeBlockBytes / static_cast<qsizetype>(sizeof(int16_t))
                   <= static_cast<qsizetype>(std::numeric_limits<int>::max()),
-              "validated frame counts must stay representable as int");
+              "validated Int16 frame counts must stay representable as int");
+static_assert(kMaxRealtimeFloatBlockBytes / static_cast<qsizetype>(sizeof(float))
+                  <= static_cast<qsizetype>(std::numeric_limits<int>::max()),
+              "validated float32 frame counts must stay representable as int");
 
 namespace {
 constexpr float kSilenceFloor = 0.0005623413f; // -65 dBFS
@@ -33,6 +36,7 @@ constexpr int kDefaultSampleRate = 24000;
 bool boundRealtimeBlock(const QByteArray& input,
                         qsizetype bytesPerSample,
                         int channels,
+                        qsizetype maxBlockBytes,
                         Diagnostics& diagnostics)
 {
     diagnostics.inputBytes = input.size();
@@ -42,7 +46,7 @@ bool boundRealtimeBlock(const QByteArray& input,
         return false;
     }
 
-    if (input.size() > kMaxRealtimeBlockBytes) {
+    if (input.size() > maxBlockBytes) {
         diagnostics.inputRejected = true;
         return false;
     }
@@ -245,7 +249,8 @@ QByteArray canonicalizeInt16ToMonoStereo(const QByteArray& input,
     Diagnostics diag;
     diag.inputChannels = channels;
     diag.inputSampleRate = inputSampleRate;
-    if (!boundRealtimeBlock(input, sizeof(int16_t), channels, diag)) {
+    if (!boundRealtimeBlock(input, sizeof(int16_t), channels,
+                            kMaxRealtimeBlockBytes, diag)) {
         if (diagnostics) {
             *diagnostics = diag;
         }
@@ -329,7 +334,8 @@ QByteArray collapseFloat32ToInt16MonoBigEndian(const QByteArray& input,
     Diagnostics diag;
     diag.inputChannels = channels;
     diag.inputSampleRate = inputSampleRate;
-    if (!boundRealtimeBlock(input, sizeof(float), channels, diag)) {
+    if (!boundRealtimeBlock(input, sizeof(float), channels,
+                            kMaxRealtimeFloatBlockBytes, diag)) {
         if (diagnostics) {
             *diagnostics = diag;
         }

--- a/src/core/TxMicChannelNormalizer.cpp
+++ b/src/core/TxMicChannelNormalizer.cpp
@@ -1,5 +1,7 @@
 #include "TxMicChannelNormalizer.h"
 
+#include "TxCaptureBuffer.h"
+
 #include <QtEndian>
 
 #include <algorithm>
@@ -11,6 +13,24 @@ namespace {
 constexpr float kSilenceFloor = 0.0005623413f; // -65 dBFS
 constexpr float kWeakToStrongRatio = 0.25118864f; // -12 dB
 constexpr int kDefaultSampleRate = 24000;
+
+bool validRealtimeBlock(const QByteArray& input,
+                        qsizetype bytesPerSample,
+                        int channels,
+                        Diagnostics& diagnostics)
+{
+    diagnostics.inputBytes = input.size();
+    if (input.isEmpty()) {
+        return false;
+    }
+
+    const qsizetype frameBytes = bytesPerSample * channels;
+    const bool valid = input.size() <= TxCaptureBuffer::kMaxReadBytes
+        && frameBytes > 0
+        && (input.size() % frameBytes) == 0;
+    diagnostics.inputRejected = !valid;
+    return valid;
+}
 
 int frameHoldCount(int sampleRate, int frames)
 {
@@ -203,24 +223,24 @@ QByteArray canonicalizeInt16ToMonoStereo(const QByteArray& input,
                                          Diagnostics* diagnostics)
 {
     const int channels = inputChannels <= 1 ? 1 : 2;
-    const int sampleCount = input.size() / static_cast<int>(sizeof(int16_t));
-    const int frames = sampleCount / channels;
-    if (frames <= 0) {
+    Diagnostics diag;
+    diag.inputChannels = channels;
+    diag.inputSampleRate = inputSampleRate;
+    if (!validRealtimeBlock(input, sizeof(int16_t), channels, diag)) {
         if (diagnostics) {
-            *diagnostics = {};
-            diagnostics->inputChannels = channels;
-            diagnostics->inputSampleRate = inputSampleRate;
+            *diagnostics = diag;
         }
         return {};
     }
 
-    Diagnostics diag;
-    diag.inputChannels = channels;
-    diag.inputSampleRate = inputSampleRate;
+    const qsizetype sampleCount = input.size() / static_cast<qsizetype>(sizeof(int16_t));
+    const int frames = static_cast<int>(sampleCount / channels);
     diag.frames = frames;
 
     const auto* src = reinterpret_cast<const int16_t*>(input.constData());
-    QByteArray stereo(frames * 2 * static_cast<int>(sizeof(int16_t)), Qt::Uninitialized);
+    const qsizetype outputBytes = static_cast<qsizetype>(frames)
+        * 2 * static_cast<qsizetype>(sizeof(int16_t));
+    QByteArray stereo(outputBytes, Qt::Uninitialized);
     auto* dst = reinterpret_cast<int16_t*>(stereo.data());
 
     if (channels == 1) {
@@ -284,24 +304,24 @@ QByteArray collapseFloat32ToInt16MonoBigEndian(const QByteArray& input,
                                                Diagnostics* diagnostics)
 {
     const int channels = inputChannels <= 1 ? 1 : 2;
-    const int sampleCount = input.size() / static_cast<int>(sizeof(float));
-    const int frames = sampleCount / channels;
-    if (frames <= 0) {
+    Diagnostics diag;
+    diag.inputChannels = channels;
+    diag.inputSampleRate = inputSampleRate;
+    if (!validRealtimeBlock(input, sizeof(float), channels, diag)) {
         if (diagnostics) {
-            *diagnostics = {};
-            diagnostics->inputChannels = channels;
-            diagnostics->inputSampleRate = inputSampleRate;
+            *diagnostics = diag;
         }
         return {};
     }
 
-    Diagnostics diag;
-    diag.inputChannels = channels;
-    diag.inputSampleRate = inputSampleRate;
+    const qsizetype sampleCount = input.size() / static_cast<qsizetype>(sizeof(float));
+    const int frames = static_cast<int>(sampleCount / channels);
     diag.frames = frames;
 
     const auto* src = reinterpret_cast<const float*>(input.constData());
-    QByteArray mono(frames * static_cast<int>(sizeof(qint16)), Qt::Uninitialized);
+    const qsizetype outputBytes = static_cast<qsizetype>(frames)
+        * static_cast<qsizetype>(sizeof(qint16));
+    QByteArray mono(outputBytes, Qt::Uninitialized);
     auto* dst = reinterpret_cast<qint16*>(mono.data());
 
     if (channels == 1) {

--- a/src/core/TxMicChannelNormalizer.cpp
+++ b/src/core/TxMicChannelNormalizer.cpp
@@ -6,30 +6,49 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 namespace AetherSDR::TxMicChannelNormalizer {
+
+// A bounded capture read must never be refused as oversized, and the block cap
+// must stay small enough that the int frame counts below cannot overflow.
+// Asserting both here keeps the two constants honest if either one moves.
+static_assert(kMaxRealtimeBlockBytes >= TxCaptureBuffer::kMaxReadBytes,
+              "a bounded capture read must never be rejected as oversized");
+static_assert(kMaxRealtimeBlockBytes / static_cast<qsizetype>(sizeof(int16_t))
+                  <= static_cast<qsizetype>(std::numeric_limits<int>::max()),
+              "validated frame counts must stay representable as int");
 
 namespace {
 constexpr float kSilenceFloor = 0.0005623413f; // -65 dBFS
 constexpr float kWeakToStrongRatio = 0.25118864f; // -12 dB
 constexpr int kDefaultSampleRate = 24000;
 
-bool validRealtimeBlock(const QByteArray& input,
+// Bounds a realtime block before any sample is dereferenced or any output is
+// allocated (Principle VII). Oversize is a hard reject: it is the signature of
+// an unbounded backend residue, and processing it once overflowed the output
+// size calculation. A trailing partial frame is not — it is truncated to the
+// frame boundary, as the pre-cap code did, so a momentarily misaligned backend
+// costs one sample rather than a whole-block dropout.
+bool boundRealtimeBlock(const QByteArray& input,
                         qsizetype bytesPerSample,
                         int channels,
                         Diagnostics& diagnostics)
 {
     diagnostics.inputBytes = input.size();
-    if (input.isEmpty()) {
+
+    const qsizetype frameBytes = bytesPerSample * channels;
+    if (frameBytes <= 0) {
         return false;
     }
 
-    const qsizetype frameBytes = bytesPerSample * channels;
-    const bool valid = input.size() <= TxCaptureBuffer::kMaxReadBytes
-        && frameBytes > 0
-        && (input.size() % frameBytes) == 0;
-    diagnostics.inputRejected = !valid;
-    return valid;
+    if (input.size() > kMaxRealtimeBlockBytes) {
+        diagnostics.inputRejected = true;
+        return false;
+    }
+
+    diagnostics.partialFrameBytes = input.size() % frameBytes;
+    return input.size() >= frameBytes;
 }
 
 int frameHoldCount(int sampleRate, int frames)
@@ -226,7 +245,7 @@ QByteArray canonicalizeInt16ToMonoStereo(const QByteArray& input,
     Diagnostics diag;
     diag.inputChannels = channels;
     diag.inputSampleRate = inputSampleRate;
-    if (!validRealtimeBlock(input, sizeof(int16_t), channels, diag)) {
+    if (!boundRealtimeBlock(input, sizeof(int16_t), channels, diag)) {
         if (diagnostics) {
             *diagnostics = diag;
         }
@@ -234,6 +253,9 @@ QByteArray canonicalizeInt16ToMonoStereo(const QByteArray& input,
     }
 
     const qsizetype sampleCount = input.size() / static_cast<qsizetype>(sizeof(int16_t));
+    // Narrowing is safe only because boundRealtimeBlock() capped the input at
+    // kMaxRealtimeBlockBytes: 256 KiB of Int16 is at most 65,536 frames. The
+    // static_assert above is what keeps that true if the cap ever moves.
     const int frames = static_cast<int>(sampleCount / channels);
     diag.frames = frames;
 
@@ -307,7 +329,7 @@ QByteArray collapseFloat32ToInt16MonoBigEndian(const QByteArray& input,
     Diagnostics diag;
     diag.inputChannels = channels;
     diag.inputSampleRate = inputSampleRate;
-    if (!validRealtimeBlock(input, sizeof(float), channels, diag)) {
+    if (!boundRealtimeBlock(input, sizeof(float), channels, diag)) {
         if (diagnostics) {
             *diagnostics = diag;
         }
@@ -315,6 +337,8 @@ QByteArray collapseFloat32ToInt16MonoBigEndian(const QByteArray& input,
     }
 
     const qsizetype sampleCount = input.size() / static_cast<qsizetype>(sizeof(float));
+    // Safe for the same reason as the Int16 path: the cap bounds frames well
+    // inside int, and float32 frames are larger still.
     const int frames = static_cast<int>(sampleCount / channels);
     diag.frames = frames;
 

--- a/src/core/TxMicChannelNormalizer.h
+++ b/src/core/TxMicChannelNormalizer.h
@@ -6,6 +6,14 @@
 
 namespace AetherSDR::TxMicChannelNormalizer {
 
+// The largest realtime block this normalizer will accept. Sized to match the
+// pull-mode capture chunk so a bounded read can never be rejected, but owned
+// HERE because the radio-native DAX route reaches this validator without going
+// through TxCaptureBuffer at all — raising the mic read chunk must not silently
+// loosen DSP validation on an unrelated route. TxMicChannelNormalizer.cpp
+// static_asserts the relationship in both directions.
+inline constexpr qsizetype kMaxRealtimeBlockBytes = 256 * 1024;
+
 enum class ChannelMode : uint8_t {
     Auto = 0,
     Left,
@@ -36,6 +44,11 @@ struct Diagnostics {
     int inputSampleRate{0};
     int frames{0};
     qsizetype inputBytes{0};
+    // Trailing bytes dropped because the block did not end on a frame boundary.
+    // The whole frames ahead of them are still processed.
+    qsizetype partialFrameBytes{0};
+    // Set only when the entire block was refused as oversized — a real fault
+    // worth logging, unlike an ordinary short or empty block.
     bool inputRejected{false};
 };
 

--- a/src/core/TxMicChannelNormalizer.h
+++ b/src/core/TxMicChannelNormalizer.h
@@ -35,6 +35,8 @@ struct Diagnostics {
     int inputChannels{0};
     int inputSampleRate{0};
     int frames{0};
+    qsizetype inputBytes{0};
+    bool inputRejected{false};
 };
 
 struct LevelBlock {

--- a/src/core/TxMicChannelNormalizer.h
+++ b/src/core/TxMicChannelNormalizer.h
@@ -6,13 +6,21 @@
 
 namespace AetherSDR::TxMicChannelNormalizer {
 
-// The largest realtime block this normalizer will accept. Sized to match the
-// pull-mode capture chunk so a bounded read can never be rejected, but owned
-// HERE because the radio-native DAX route reaches this validator without going
-// through TxCaptureBuffer at all — raising the mic read chunk must not silently
-// loosen DSP validation on an unrelated route. TxMicChannelNormalizer.cpp
+// The largest Int16 capture block this normalizer will accept. Sized to match
+// the pull-mode capture chunk so a bounded read can never be rejected, but
+// owned HERE rather than borrowed from TxCaptureBuffer: raising the microphone
+// read chunk must not silently loosen DSP validation. TxMicChannelNormalizer.cpp
 // static_asserts the relationship in both directions.
 inline constexpr qsizetype kMaxRealtimeBlockBytes = 256 * 1024;
+
+// The float32 route has its own, much larger ceiling because it is fed by TCI
+// rather than by a bounded device read, and its blocks arrive already
+// upsampled. A TCI message is capped at 64 KiB (TciServer kMaxWsMessageBytes);
+// the worst legal expansion is int16 mono at the lowest supported client rate,
+// where every 2-byte sample becomes three 8-byte stereo float frames — a factor
+// of 12, or ~768 KiB. Sizing this to the capture chunk instead would have
+// dropped every large frame from a conforming 8 or 12 kHz client (#3306).
+inline constexpr qsizetype kMaxRealtimeFloatBlockBytes = 1024 * 1024;
 
 enum class ChannelMode : uint8_t {
     Auto = 0,

--- a/tests/tx_capture_health_test.cpp
+++ b/tests/tx_capture_health_test.cpp
@@ -104,6 +104,19 @@ int main()
                == Event::BufferSaturatedDuringTci,
            "Active-to-Idle with unread bytes remains a saturation fallback");
 
+    TxCaptureHealthTracker backlog;
+    backlog.reset(CaptureState::Active, 0);
+    expect(backlog.recordBacklogDiscard(0) == Event::None,
+           "a zero-byte discard is not an event");
+    expect(backlog.recordBacklogDiscard(1048576) == Event::CaptureBacklogDiscarded,
+           "the first stale-backlog discard reports an event");
+    expect(backlog.recordBacklogDiscard(524288) == Event::None,
+           "repeat discards stay rate-limited so a lagging backend cannot spam");
+    const TxCaptureHealthTracker::Snapshot backlogSnapshot = backlog.snapshot(100);
+    expect(backlogSnapshot.captureBacklogDiscards == 2
+               && backlogSnapshot.captureBacklogDiscardedBytes == 1572864,
+           "every discard is still counted for the support summary");
+
     std::printf("\n%d of %d TX capture health tests failed.\n", g_failed, g_total);
     return g_failed == 0 ? 0 : 1;
 }

--- a/tests/tx_mic_channel_normalizer_test.cpp
+++ b/tests/tx_mic_channel_normalizer_test.cpp
@@ -421,13 +421,54 @@ void testShortBlockBelowOneFrameIsDroppedQuietly()
            out.isEmpty() && diag.frames == 0 && !diag.inputRejected);
 }
 
+void testPushModeBlockIsTrimmedToLatest()
+{
+    // macOS hands over everything accumulated since the last 5 ms poll, so a
+    // stalled audio thread produces one oversized block.
+    QByteArray block(TxCaptureBuffer::kMaxReadBytes, 's');
+    block.append(QByteArray(TxCaptureBuffer::kMaxReadBytes, 'f'));  // newest tail
+
+    const qint64 discarded = TxCaptureBuffer::trimToLatestBoundedInt16(block, 2);
+    report("push-mode stall is trimmed to one bounded block",
+           block.size() == TxCaptureBuffer::kMaxReadBytes
+               && discarded == TxCaptureBuffer::kMaxReadBytes);
+    report("push-mode trim keeps the newest audio",
+           block == QByteArray(TxCaptureBuffer::kMaxReadBytes, 'f'));
+
+    QByteArray small(4096, 'x');
+    report("a push-mode block that already fits is left alone",
+           TxCaptureBuffer::trimToLatestBoundedInt16(small, 2) == 0
+               && small.size() == 4096);
+}
+
+void testLargeUpsampledDaxBlockIsAccepted()
+{
+    // A conforming 8 kHz TCI client can send a 64 KiB int16 mono frame, which
+    // expands ~12x to ~768 KiB of stereo float32 before reaching this collapse
+    // (#3306). The mic capture chunk would have rejected it outright, so the
+    // float route carries its own, larger ceiling.
+    constexpr qsizetype worstCaseTciExpansion = 768 * 1024;
+    const QByteArray large(worstCaseTciExpansion, '\0');
+    Diagnostics diag;
+    const QByteArray out = collapseFloat32ToInt16MonoBigEndian(
+        large,
+        2,
+        24000,
+        ChannelMode::Average,
+        nullptr,
+        &diag);
+
+    report("worst-case upsampled TCI block is not rejected",
+           !out.isEmpty() && !diag.inputRejected
+               && diag.frames == worstCaseTciExpansion / 8);
+}
+
 void testOversizedDaxBlockIsRejected()
 {
-    // The DAX float32 route shares this validator without going through
-    // TxCaptureBuffer, so its ceiling is the normalizer's own constant.
+    // Past its own ceiling the float route still rejects before dereference.
     char sentinel = 0;
     const QByteArray oversized = QByteArray::fromRawData(
-        &sentinel, AetherSDR::TxMicChannelNormalizer::kMaxRealtimeBlockBytes + 8);
+        &sentinel, AetherSDR::TxMicChannelNormalizer::kMaxRealtimeFloatBlockBytes + 8);
     Diagnostics diag;
     const QByteArray out = collapseFloat32ToInt16MonoBigEndian(
         oversized,
@@ -460,6 +501,8 @@ int main()
     testDumpSizedMicBlockIsRejectedBeforeDereference();
     testMisalignedMicBlockIsTruncatedToFrameBoundary();
     testShortBlockBelowOneFrameIsDroppedQuietly();
+    testPushModeBlockIsTrimmedToLatest();
+    testLargeUpsampledDaxBlockIsAccepted();
     testOversizedDaxBlockIsRejected();
 
     std::printf("\n%s\n", g_failed == 0 ? "All tests passed." : "Some tests failed.");

--- a/tests/tx_mic_channel_normalizer_test.cpp
+++ b/tests/tx_mic_channel_normalizer_test.cpp
@@ -439,6 +439,13 @@ void testPushModeBlockIsTrimmedToLatest()
     report("a push-mode block that already fits is left alone",
            TxCaptureBuffer::trimToLatestBoundedInt16(small, 2) == 0
                && small.size() == 4096);
+
+    // A push buffer that ended mid-frame must not shift the retained tail by a
+    // sample, which would swap L/R for the rest of the block.
+    QByteArray ragged(TxCaptureBuffer::kMaxReadBytes + 4098, 'x');
+    const qint64 raggedDiscard = TxCaptureBuffer::trimToLatestBoundedInt16(ragged, 2);
+    report("a mid-frame push block is cut on a frame boundary",
+           raggedDiscard % 4 == 0 && ragged.size() <= TxCaptureBuffer::kMaxReadBytes);
 }
 
 void testLargeUpsampledDaxBlockIsAccepted()

--- a/tests/tx_mic_channel_normalizer_test.cpp
+++ b/tests/tx_mic_channel_normalizer_test.cpp
@@ -2,9 +2,11 @@
 // Run: ./build/tx_mic_channel_normalizer_test
 
 #include "core/Resampler.h"
+#include "core/TxCaptureBuffer.h"
 #include "core/TxMicChannelNormalizer.h"
 
 #include <QByteArray>
+#include <QBuffer>
 #include <QtEndian>
 
 #include <algorithm>
@@ -23,6 +25,7 @@ using AetherSDR::TxMicChannelNormalizer::canonicalizeInt16ToMonoStereo;
 using AetherSDR::TxMicChannelNormalizer::collapseFloat32ToInt16MonoBigEndian;
 using AetherSDR::TxMicChannelNormalizer::measureInt16StereoLevelBlock;
 using AetherSDR::TxMicChannelNormalizer::rmsFromLevelBlock;
+namespace TxCaptureBuffer = AetherSDR::TxCaptureBuffer;
 
 namespace {
 
@@ -306,6 +309,56 @@ void testDaxRadioNativeCollapseKeepsOneSidedLevel()
            diag.selectedMode == ChannelMode::Left && diag.oneSidedStereo);
 }
 
+void testCaptureReadIsBounded()
+{
+    QByteArray backlog(TxCaptureBuffer::kMaxReadBytes + 4096, 'x');
+    QBuffer device(&backlog);
+    device.open(QIODevice::ReadOnly);
+
+    const QByteArray block = TxCaptureBuffer::readBoundedInt16(&device, 2);
+    report("pull-mode capture reads at most one bounded block",
+           block.size() == TxCaptureBuffer::kMaxReadBytes);
+    report("bounded capture leaves excess backend residue for later callbacks",
+           device.bytesAvailable() == 4096);
+}
+
+void testDumpSizedMicBlockIsRejectedBeforeDereference()
+{
+    char sentinel = 0;
+    constexpr qsizetype dumpInputBytes = 0x80007900;
+    const QByteArray dumpSized = QByteArray::fromRawData(&sentinel, dumpInputBytes);
+    Diagnostics diag;
+
+    const QByteArray out = canonicalizeInt16ToMonoStereo(
+        dumpSized,
+        2,
+        48000,
+        ChannelMode::Average,
+        nullptr,
+        &diag);
+
+    report("2 GiB dump-sized mic block is rejected without allocation",
+           out.isEmpty() && diag.inputRejected);
+    report("rejection diagnostics preserve the dump byte count",
+           diag.inputBytes == dumpInputBytes && diag.frames == 0);
+}
+
+void testMisalignedMicBlockIsRejected()
+{
+    const QByteArray malformed(6, '\0'); // stereo Int16 requires 4-byte frames
+    Diagnostics diag;
+    const QByteArray out = canonicalizeInt16ToMonoStereo(
+        malformed,
+        2,
+        48000,
+        ChannelMode::Auto,
+        nullptr,
+        &diag);
+
+    report("partial stereo Int16 frame is rejected at the boundary",
+           out.isEmpty() && diag.inputRejected && diag.inputBytes == malformed.size());
+}
+
 int main()
 {
     std::printf("TX mic channel normalizer tests\n\n");
@@ -319,6 +372,9 @@ int main()
     testPcMicMeterSeesRightOnly();
     testOpusFrameSizingAfterNormalization();
     testDaxRadioNativeCollapseKeepsOneSidedLevel();
+    testCaptureReadIsBounded();
+    testDumpSizedMicBlockIsRejectedBeforeDereference();
+    testMisalignedMicBlockIsRejected();
 
     std::printf("\n%s\n", g_failed == 0 ? "All tests passed." : "Some tests failed.");
     return g_failed == 0 ? 0 : 1;

--- a/tests/tx_mic_channel_normalizer_test.cpp
+++ b/tests/tx_mic_channel_normalizer_test.cpp
@@ -315,11 +315,52 @@ void testCaptureReadIsBounded()
     QBuffer device(&backlog);
     device.open(QIODevice::ReadOnly);
 
-    const QByteArray block = TxCaptureBuffer::readBoundedInt16(&device, 2);
+    const TxCaptureBuffer::BoundedRead read =
+        TxCaptureBuffer::readLatestBoundedInt16(&device, 2);
     report("pull-mode capture reads at most one bounded block",
-           block.size() == TxCaptureBuffer::kMaxReadBytes);
-    report("bounded capture leaves excess backend residue for later callbacks",
-           device.bytesAvailable() == 4096);
+           read.block.size() == TxCaptureBuffer::kMaxReadBytes);
+    report("a within-catch-up residue is left for later callbacks, not dropped",
+           device.bytesAvailable() == 4096 && read.discardedBytes == 0);
+}
+
+void testCaptureReadDropsToLatestPastCatchUpThreshold()
+{
+    // The freshest block must be the one transmitted: mark the backlog so the
+    // returned bytes can only have come from its tail.
+    const qint64 backlogBytes = TxCaptureBuffer::kCatchUpThresholdBytes + 64 * 1024;
+    QByteArray backlog(backlogBytes, 's');           // stale head
+    backlog.replace(backlogBytes - TxCaptureBuffer::kMaxReadBytes,
+                    TxCaptureBuffer::kMaxReadBytes,
+                    QByteArray(TxCaptureBuffer::kMaxReadBytes, 'f'));  // fresh tail
+    QBuffer device(&backlog);
+    device.open(QIODevice::ReadOnly);
+
+    const TxCaptureBuffer::BoundedRead read =
+        TxCaptureBuffer::readLatestBoundedInt16(&device, 2);
+
+    report("catch-up returns one bounded block",
+           read.block.size() == TxCaptureBuffer::kMaxReadBytes);
+    report("catch-up transmits the newest audio, not the oldest",
+           read.block == QByteArray(TxCaptureBuffer::kMaxReadBytes, 'f'));
+    report("catch-up reports the stale bytes it skipped",
+           read.discardedBytes == backlogBytes - TxCaptureBuffer::kMaxReadBytes);
+    report("catch-up leaves the device drained",
+           device.bytesAvailable() == 0);
+}
+
+void testCaptureReadAlignsToRealChannelCount()
+{
+    // 6-channel Int16 frames are 12 bytes, which 256 KiB does not divide: the
+    // read must round down so later reads stay on frame boundaries.
+    QByteArray backlog(TxCaptureBuffer::kMaxReadBytes + 4096, 'x');
+    QBuffer device(&backlog);
+    device.open(QIODevice::ReadOnly);
+
+    const TxCaptureBuffer::BoundedRead read =
+        TxCaptureBuffer::readLatestBoundedInt16(&device, 6);
+    report("bounded read is frame-aligned for the negotiated channel count",
+           read.block.size() % 12 == 0 && read.block.size() <= TxCaptureBuffer::kMaxReadBytes
+               && read.block.size() > TxCaptureBuffer::kMaxReadBytes - 12);
 }
 
 void testDumpSizedMicBlockIsRejectedBeforeDereference()
@@ -343,8 +384,11 @@ void testDumpSizedMicBlockIsRejectedBeforeDereference()
            diag.inputBytes == dumpInputBytes && diag.frames == 0);
 }
 
-void testMisalignedMicBlockIsRejected()
+void testMisalignedMicBlockIsTruncatedToFrameBoundary()
 {
+    // A trailing partial frame costs one sample, not the whole block: dropping
+    // the block would be an audible dropout, and a device that stays misaligned
+    // would drop every block thereafter.
     const QByteArray malformed(6, '\0'); // stereo Int16 requires 4-byte frames
     Diagnostics diag;
     const QByteArray out = canonicalizeInt16ToMonoStereo(
@@ -355,8 +399,46 @@ void testMisalignedMicBlockIsRejected()
         nullptr,
         &diag);
 
-    report("partial stereo Int16 frame is rejected at the boundary",
-           out.isEmpty() && diag.inputRejected && diag.inputBytes == malformed.size());
+    report("partial stereo Int16 frame is truncated, whole frames survive",
+           out.size() == 4 && diag.frames == 1 && !diag.inputRejected);
+    report("truncation is recorded in the diagnostics",
+           diag.partialFrameBytes == 2 && diag.inputBytes == malformed.size());
+}
+
+void testShortBlockBelowOneFrameIsDroppedQuietly()
+{
+    const QByteArray tooShort(2, '\0'); // less than one stereo Int16 frame
+    Diagnostics diag;
+    const QByteArray out = canonicalizeInt16ToMonoStereo(
+        tooShort,
+        2,
+        48000,
+        ChannelMode::Auto,
+        nullptr,
+        &diag);
+
+    report("a sub-frame block yields nothing and is not flagged a fault",
+           out.isEmpty() && diag.frames == 0 && !diag.inputRejected);
+}
+
+void testOversizedDaxBlockIsRejected()
+{
+    // The DAX float32 route shares this validator without going through
+    // TxCaptureBuffer, so its ceiling is the normalizer's own constant.
+    char sentinel = 0;
+    const QByteArray oversized = QByteArray::fromRawData(
+        &sentinel, AetherSDR::TxMicChannelNormalizer::kMaxRealtimeBlockBytes + 8);
+    Diagnostics diag;
+    const QByteArray out = collapseFloat32ToInt16MonoBigEndian(
+        oversized,
+        2,
+        24000,
+        ChannelMode::Average,
+        nullptr,
+        &diag);
+
+    report("oversized DAX float32 block is rejected before dereference",
+           out.isEmpty() && diag.inputRejected && diag.frames == 0);
 }
 
 int main()
@@ -373,8 +455,12 @@ int main()
     testOpusFrameSizingAfterNormalization();
     testDaxRadioNativeCollapseKeepsOneSidedLevel();
     testCaptureReadIsBounded();
+    testCaptureReadDropsToLatestPastCatchUpThreshold();
+    testCaptureReadAlignsToRealChannelCount();
     testDumpSizedMicBlockIsRejectedBeforeDereference();
-    testMisalignedMicBlockIsRejected();
+    testMisalignedMicBlockIsTruncatedToFrameBoundary();
+    testShortBlockBelowOneFrameIsDroppedQuietly();
+    testOversizedDaxBlockIsRejected();
 
     std::printf("\n%s\n", g_failed == 0 ? "All tests passed." : "Some tests failed.");
     return g_failed == 0 ? 0 : 1;


### PR DESCRIPTION
## Summary

Fix a repeatable Windows access violation after multi-hour TCI transmit sessions by keeping the pull-mode microphone source drained while TCI owns TX audio and by bounding every pull-mode capture read before it reaches the channel normalizer.

Both supplied Store v26.8.2 dumps resolve against the exact matching PDB to the first output write in `TxMicChannelNormalizer::canonicalizeInt16ToMonoStereo()`, called by `AudioEngine::onTxAudioReady()`. In the larger dump, the input block is `0x80007900` bytes: 30,976 bytes beyond the signed 2 GiB boundary. The failure chain was:

1. TCI audio became fresh, so the local microphone callback returned without consuming the Windows `QAudioSource` pull device.
2. Qt/WASAPI continued appending unread capture blocks to its internal client residue at about 192,000 bytes/s for 48 kHz stereo Int16 audio.
3. When local microphone processing resumed, `readAll()` returned the multi-gigabyte residue in one `QByteArray`.
4. The normalizer calculated its output size with signed `int` arithmetic. The output byte count crossed `INT_MAX`, overflowed, and the first write landed in Qt's shared empty-data storage.

This PR:

- drains and discards bounded mic blocks on Windows, as already required on Linux, whenever fresh TCI audio suppresses the local mic route;
- replaces pull-mode `readAll()` with a frame-aligned 256 KiB maximum read (about 1.36 seconds at 48 kHz stereo Int16);
- rejects oversized or partial-frame realtime blocks before sample access or allocation;
- uses `qsizetype` for normalizer size calculations;
- drops to latest rather than replaying a backlog: past 1 MiB of unread residue the stale head is skipped without allocation, so the freshest block reaches the air;
- trims the macOS push-mode block the same way, since nothing bounds what the capture callback appends between 5 ms polls;
- gives the Int16 mic route and the float32 DAX route separate, normalizer-owned block ceilings instead of sharing a microphone read constant;
- truncates a trailing partial frame to the frame boundary rather than dropping the block;
- logs rejected TX mic and DAX block metadata for support diagnostics, and counts stale-backlog discards as a capture-health event;
- documents the capture/backpressure contract and how bridge capture-health metrics should behave after this fix.

## Constitution principle honored

Principle VII — Untrusted Input Is Validated At The Boundary. Capture blocks now have an explicit allocation cap and frame-shape validation before the normalizer dereferences or allocates from their contents.

## Crash-dump evidence

- Two independent dumps have the same exception and stack: write access violation in `canonicalizeInt16ToMonoStereo()`, then `onTxAudioReady()`.
- The Store binary and symbol GUID match the v26.8.2 Windows CI artifact exactly.
- The regression test presents a zero-allocation `QByteArray` view with the dump's exact `0x80007900` byte count, proving it is rejected before any dereference or output allocation.

## Test plan

- [x] Full macOS RelWithDebInfo app build passes with `cmake --build build -j22`.
- [x] Exact dump-size, bounded-read, partial-frame, mono/stereo, DAX, resampling, and channel-selection coverage passes in `tx_mic_channel_normalizer_test` (22 assertions).
- [x] Full headless suite passes: `QT_QPA_PLATFORM=offscreen ctest --test-dir build -j22 --output-on-failure` (288/288; two expected hardware/fixture skips).
- [x] Strict engine-boundary scan passes with 0 findings.
- [x] Fresh-build automation-bridge smoke test connects only to `DEMO-0001` with TX disabled; `get audio` reports an active TX source, zero buffered bytes, no saturation, and no pacing drops.
- [x] Windows CI build and tests pass.
- [ ] Multi-hour Windows TCI-to-local-mic soak confirms the WASAPI residue stays bounded on the reporter's path — tracked in #4969.

## Reproduction

1. On Windows, enable a 48 kHz stereo Int16 TX input and let TCI supply fresh TX audio while microphone capture remains active.
2. Leave the session running for roughly three hours or longer.
3. Stop TCI audio or otherwise return ownership to the local mic path.
4. Before this fix, Qt/WASAPI can deliver the entire unread residue through `readAll()`, and the app crashes on the first normalizer output write once the residue exceeds 2 GiB.

## Checklist

- [x] Commit is signed.
- [x] No new `AppSettings` keys.
- [x] Code is clean-room; analysis used AetherSDR symbols/source, Microsoft minidumps, and Qt's published source behavior, not proprietary disassembly.
- [x] Audio pipeline and automation bridge documentation updated; `CHANGELOG.md` untouched.
- [x] No radio command behavior or transmit intent changed.

Generated with OpenAI Codex (Daybreak Blue)

## Review follow-ups

Two review passes landed on this after the original commit; both are addressed in `6413e247` and `4716faaa`.

**Behavioural gaps around the cap**

- *No catch-up policy.* Bounding the read stopped the crash but meant an existing residue was transmitted rather than discarded — minutes of hours-stale mic audio on the air, 1.36 s per callback. Capture is now drop-to-latest past 1 MiB of residue, skipping the stale head via `QIODevice::skip()` so it is never allocated, and counting the discard as a capture-health event.
- *macOS excluded from the drain.* Its push-mode `QBuffer` accumulated the same way, in the app's own resident memory. It is now cleared during TCI suppression, and an oversized push block (an audio-thread stall past ~1.4 s, which nothing bounded) is trimmed to its newest 256 KiB rather than refused wholesale.

**A live defect the "polish" note uncovered**

The 256 KiB ceiling was a microphone read policy enforced in the shared normalizer, which the radio-native DAX route inherits without ever passing through `TxCaptureBuffer`. That was not only coupling — the number was wrong for that route. TCI caps a message at 64 KiB, and int16 mono from a conforming 8 kHz client expands twelvefold across the 8k→24k upsample to ~768 KiB:

| client rate | 64 KiB int16 mono → stereo float32 | under a 256 KiB cap |
|---|---|---|
| 8 kHz | 786,192 B | **rejected** |
| 12 kHz | 524,128 B | **rejected** |
| 24 kHz | 262,064 B | passes by 80 bytes |
| 48 kHz | 131,032 B | passes |

Low-rate clients are explicitly supported (#3306), so this would have silently dropped their TX audio. The float32 route now carries its own `kMaxRealtimeFloatBlockBytes` (1 MiB) derived from that worst case, with `static_assert`s tying the ceilings to the capture chunk and to the `int` frame-count narrowing they make safe.

**Also fixed**

- Partial frames are truncated to the frame boundary again rather than dropping the block — a misaligned backend stays misaligned across callbacks, so whole-block rejection would have lost every one of them.
- The suppression drain emptied the device before `observeState()` re-sampled the unread depth, which would have permanently retired the Active-to-Idle saturation fallback and left the soak's counters reading zero while looking healthy. The depth is now sampled once before draining.
- Pull-mode reads ask for what the device reports instead of always the full ceiling: `QIODevice::read(qint64)` sizes its result to `maxSize` before reading, so every `readyRead` was allocating 256 KiB on the audio thread to carry a few KB.
- `alignedLimit` was a no-op; it now aligns to the device's real channel count, which matters for a 6-channel device whose 12-byte frames do not divide 256 KiB.
- Rejections on the DAX route are logged instead of returning silently.

