### PR TITLE
ci: take the colour ratchet's base from the merge base, not live main (#4956)

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -140,10 +140,30 @@ jobs:
       # already required — so sharing the runner costs one step and saves a
       # whole checkout. A worktree rather than a second actions/checkout: the
       # base tree is only ever read by a text scanner.
+      #
+      # The base is the MERGE BASE of what was actually checked out, not live
+      # origin/<base_ref> (#4956). For a pull_request event github.sha is frozen
+      # when the run is CREATED, so the PR side is main-as-of-then while
+      # origin/<base_ref> resolves when the job RUNS. When main LOSES colours in
+      # between, the drop is billed to whichever PR happens to be running: #4895
+      # — a five-line C++ comment edit, which strip_comments() makes invisible to
+      # the scanner by construction — failed +5 setstylesheet off a 22h-old
+      # pinned tree, reporting #4866's cleanup sign-flipped. Re-resolving
+      # refs/pull/N/merge is not the fix: it races the ref and would scan a
+      # different tree than the SHA this run reports. The merge base asks the
+      # delta question against the tree the PR was actually written on, and is
+      # insensitive to how long the run sat queued — which is why fork PRs, held
+      # for workflow approval, were the most exposed. The a11y step below is
+      # already merge-base correct via its three-dot diff.
+      #
+      # Captured into a variable, not inlined: `bash -e` does not abort on a
+      # failed command substitution used as an argument, so an inline form would
+      # silently pass an empty base to `git worktree add`.
       - name: Hardcoded-colour ratchet
         if: ${{ !cancelled() }}
         run: |
-          git worktree add /tmp/colour-base "origin/${{ github.base_ref }}"
+          BASE=$(git merge-base HEAD "origin/${{ github.base_ref }}")
+          git worktree add /tmp/colour-base "$BASE"
           python tools/audit_colours.py \
             --src src \
             --compare-src /tmp/colour-base/src \

--- a/docs/style/theme-style-guide.md
+++ b/docs/style/theme-style-guide.md
@@ -198,20 +198,20 @@ python tools/audit_colours.py --src src --summary-only
 CI runs the same tool as a **blocking** gate. The "Hardcoded-colour
 ratchet" step in `.github/workflows/static-checks.yml` runs it with
 `--compare-src <base>/src --strict`, which exits 1 if your branch raises
-the unique-colour, total-reference or `setStyleSheet()` count above the
-**tip of your base branch at CI time** — not above your merge base. To
-see the same verdict before you push:
+the unique-colour, total-reference or `setStyleSheet()` count above **the
+merge base of your branch and `main`**. To see the same verdict before
+you push:
 
 ```bash
-git worktree add /tmp/colour-base origin/main
+BASE=$(git merge-base HEAD origin/main)
+git worktree add /tmp/colour-base "$BASE"
 python tools/audit_colours.py --src src \
     --compare-src /tmp/colour-base/src --summary-only --strict
+git worktree remove /tmp/colour-base
 ```
 
-Because the comparison is against `main`'s tip, a branch that has fallen
-behind can fail on counts *`main` itself reduced*. If the gate reports a
-rise you cannot find in your own diff, merge `main` and re-run before
-hunting for it.
+The base is the merge base rather than `main`'s tip so that colours
+`main` removed after you branched cannot be billed to your PR (#4956).
 
 Conformance is an authoring-time responsibility: choose the token when
 you write the code, and the gate has nothing to flag.


### PR DESCRIPTION
## Summary

The hardcoded-colour ratchet compared two trees that are not required to share a
`main`. One line in `.github/workflows/static-checks.yml`: take the base from the
merge base of what was actually checked out, rather than resolving `origin/main`
live at job-run time.

Closes #4956.

## The bug

For a `pull_request` event, `github.sha` is frozen when the run is **created**, so
the PR side is main-as-of-then. `origin/${{ github.base_ref }}` resolves when the
job **runs**. When main *loses* colours in between, the drop is billed to whichever
PR happens to be running.

#4895 is the worked example — a five-line C++ comment edit, which `strip_comments()`
(`tools/audit_colours.py:293`) makes invisible to the scanner by construction:

```
OVER setstylesheet       1107  (base 1102, +5)
FAIL: this PR raises the hardcoded-colour count above its base.
```

The same job log names both sides outright:

```
HEAD is now at 34a898ed  Merge 652207e5... into f6f56865...   <- PR side: main of 08-10
Preparing worktree (detached HEAD a136f8f2)                   <- base side: main of 08-12
```

22 h 26 m apart. Running the repo's own scanner across main's history locates the +5:

| main commit | `setStyleSheet()` |
|---|---|
| `f6f56865` (#4863) | **1107** ← PR side |
| `9454d2c8` (#4900) | 1107 |
| `0bd3c493` (#4866) | **1102** ← the drop |
| `a136f8f2` (#4913) | **1102** ← base side |

`0bd3c493` is #4866, which removes 6 `setStyleSheet` call sites and adds 1. **The
gate reported #4866's cleanup, sign-flipped, against #4895.**

`audit_colours.py:123-146` argues the delta design exists precisely so main's drift
cannot stale the gate. That reasoning is right, but it only closed the direction
where main *gains* colours. When main *loses* them, a pinned-stale PR tree
reproduces the same failure mode inverted.

## Why the merge base, and not a re-resolved merge ref

Re-resolving `refs/pull/N/merge` would have fixed this instance, but it races the
ref and would have the colour gate scan a different tree than the SHA the run
reports. The merge base asks the question the gate is documented to ask — "did
THIS PR add colours?" — against the tree the PR was actually written on, and is
insensitive to how long the run sat queued. That last property is what matters for
fork PRs, whose workflow-approval hold guarantees the gap (22 h here).

The pattern is already in this job: the next step's three-dot
`git diff origin/<base>...HEAD` is merge-base based and got the right answer in the
same failing run. A grep confirms line 146 was the only live-base comparison left
in `.github/workflows/`.

The base is captured into a variable rather than inlined because `bash -e` does not
abort on a failed command substitution used as an argument — inlining would pass an
empty base to `git worktree add`.

## Verification

- **Replayed the failing run.** Reconstructed the pinned merge commit (`652207e5`
  merged into `f6f56865`), ran the edited step verbatim: `merge-base` resolves to
  `f6f56865` — exactly the tree the PR was pinned onto — and the gate reports `+0`
  on all three counters, **exit 0**. ✅
- **Negative control.** Injected a genuine new literal and a new `setStyleSheet`
  call site into the same tree: `OVER` on all three counters, `FAIL`, **exit 1**. ✅
  The fix corrects the base; it does not weaken the gate.
- **Reproduced the counts table** above with the repo's own scanner, pinned to one
  version so the scanner is not a variable. ✅
- **Not affected**, confirmed by grep over all of `.github/workflows/`: the a11y
  step (three-dot, already merge-base correct) and the engine-boundary /
  network-timeout / shader / theme-seed gates, which take no base tree at all. ✅
- **This PR self-tests** — `.github/workflows/static-checks.yml` is in the workflow's
  own `paths:` trigger, so the edited step runs on this PR.

## Scope

Strictly a correctness fix to how the base is computed. It takes no position on the
retire-vs-demote-the-ratchet discussion in #4657 / #4850 — and it is worth having
under either outcome, since an advisory gate printing untrustworthy numbers is
noise in the channel that would measure whether the theme style guide moves the
trend.

## Constitution principle honored

**Principle VIII** — the claims above were verified by running them, in both
directions, rather than described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
