### PR TITLE
fix(icom): register the Icom log categories, and log every CI-V frame

### DIFF
--- a/src/core/LogManager.cpp
+++ b/src/core/LogManager.cpp
@@ -122,6 +122,18 @@ LogManager::LogManager()
         // one control, and someone chasing transmit telemetry will tick the
         // wrong box and conclude the logging is still broken.
         {"aether.hl2.tx",     "Hermes-Lite 2 TX", "HL2 transmit telemetry: TX IQ FIFO depth with underflow/overflow flags, and forward/reflected power counts. Separate toggle — ticking \"Hermes-Lite 2\" does NOT enable this (high-rate)"},
+        // ICOM — the same "declared locally, never registered" hole the HL2
+        // categories above had. All five were unreachable: applyFilterRules()'s
+        // blanket `aether.*.debug=false` switched them off and no UI toggle
+        // could switch them back on, so an Icom session logged nothing beyond
+        // its INF lines. Chasing a mode-reporting bug on a live IC-9700 that
+        // way means guessing from published state instead of reading frames.
+        {"aether.icom.session", "Icom Session",  "Icom RS-BA1 session: handshake, token/auth, capabilities, keepalive"},
+        {"aether.icom.stream",  "Icom Streams",  "Icom UDP stream lifecycle: control/serial/audio handshakes and ports"},
+        {"aether.icom.civ",     "Icom CI-V",     "Every CI-V frame in and out, decoded — command, subcommand and payload bytes. The only way to tell 'the radio never sent it' from 'we sent it and dropped the reply' (high-rate)"},
+        {"aether.icom.pan",     "Icom Scope",    "Icom spectrum scope: sweep frames, division reassembly, bounds"},
+        {"aether.icom.link",    "Icom Link",     "Icom backend link state: connect/disconnect, model resolution, capability publication"},
+        {"aether.icom.cred",    "Icom Credentials", "Icom credential storage and retrieval (no secret values are logged)"},
     };
 
     // QLoggingCategory objects are defined above via Q_LOGGING_CATEGORY macros.

--- a/src/core/backends/icom/CivCodec.cpp
+++ b/src/core/backends/icom/CivCodec.cpp
@@ -47,6 +47,40 @@ std::vector<std::uint8_t> buildFrameSub(std::uint8_t to, std::uint8_t cmd, std::
     return buildFrame(to, cmd, body);
 }
 
+// Which commands carry a subcommand is a per-command fact, not a positional
+// one. Treating every second byte as a subcommand would turn command 0x05's
+// first frequency digit into a "subcommand"; treating none of them as one
+// would collapse every 0x27 scope reply into a single undifferentiated blob.
+// So the set is enumerated — ONCE, here, because a second copy of it can drift
+// silently and a drift produces exactly the wrong-but-plausible decode this
+// enumeration exists to prevent. parseFrame() and the CI-V trace both read it.
+bool commandHasSubcommand(std::uint8_t command)
+{
+    switch (command) {
+    case cmd::kLevel:
+    case cmd::kMeter:
+    case cmd::kFunction:
+    case cmd::kPower:
+    case cmd::kReadId:
+    case cmd::kSetting:
+    case cmd::kControl:
+    case cmd::kScope:
+    // 0x21 WAS MISSING, and it is sub-addressed like the rest: 21 00 is the
+    // offset, 21 01 the RIT enable, 21 02 the dTX enable. Without it every RIT
+    // reply parsed with the subcommand sitting in the payload, so the decode
+    // could not tell an enable from an offset and dropped all three.
+    case cmd::kTuneOffset:
+    case cmd::kRxAntenna:
+    // 0x26 is sub-addressed by VFO: 26 00 is the selected VFO, 26 01 the
+    // unselected one. Without this the selector stays in the payload and every
+    // mode/DATA/filter field is decoded one byte off.
+    case cmd::kVfoMode:
+        return true;
+    default:
+        return false;
+    }
+}
+
 std::optional<CivFrame> parseFrame(std::span<const std::uint8_t> frame)
 {
     // FE FE <to> <from> <cmd> ... <FD>  — the shortest legal frame is 6 bytes
@@ -69,37 +103,14 @@ std::optional<CivFrame> parseFrame(std::span<const std::uint8_t> frame)
     if (bodyEnd <= bodyBegin)
         return f;   // bare command or FB/FA with no data
 
-    // Which commands carry a subcommand is a per-command fact, not a positional
-    // one. Treating every second byte as a subcommand would turn command 0x05's
-    // first frequency digit into a "subcommand"; treating none of them as one
-    // would collapse every 0x27 scope reply into a single undifferentiated
-    // blob. So the set is enumerated.
-    switch (f.cmd) {
-    case cmd::kLevel:
-    case cmd::kMeter:
-    case cmd::kFunction:
-    case cmd::kPower:
-    case cmd::kReadId:
-    case cmd::kSetting:
-    case cmd::kControl:
-    case cmd::kScope:
-    // 0x21 WAS MISSING, and it is sub-addressed like the rest: 21 00 is the
-    // offset, 21 01 the RIT enable, 21 02 the dTX enable. Without it every RIT
-    // reply parsed with the subcommand sitting in the payload, so the decode
-    // could not tell an enable from an offset and dropped all three.
-    case cmd::kTuneOffset:
-    case cmd::kRxAntenna:
-    // 0x26 is sub-addressed by VFO: 26 00 is the selected VFO, 26 01 the
-    // unselected one. Without this the selector stays in the payload and every
-    // mode/DATA/filter field is decoded one byte off.
-    case cmd::kVfoMode:
+    // See commandHasSubcommand() above for why this is an enumeration and not a
+    // positional rule.
+    if (commandHasSubcommand(f.cmd)) {
         f.hasSub = true;
         f.sub    = frame[bodyBegin];
         f.data.assign(frame.begin() + bodyBegin + 1, frame.begin() + bodyEnd);
-        break;
-    default:
+    } else {
         f.data.assign(frame.begin() + bodyBegin, frame.begin() + bodyEnd);
-        break;
     }
     return f;
 }

--- a/src/core/backends/icom/CivCodec.h
+++ b/src/core/backends/icom/CivCodec.h
@@ -83,6 +83,13 @@ struct CivFrame {
                                                       std::uint8_t sub,
                                                       std::span<const std::uint8_t> payload = {});
 
+// Whether a command is sub-addressed — i.e. whether the byte after it is a
+// subcommand or the first byte of the payload. This is a per-command fact and
+// there is exactly ONE list of it: parseFrame() decodes by it, and the CI-V
+// trace labels by it. A second copy can drift, and a drift here produces the
+// wrong-but-plausible decode the enumeration exists to prevent.
+[[nodiscard]] bool commandHasSubcommand(std::uint8_t command);
+
 // Decode one complete frame (FE FE … FD). Returns nullopt if it is malformed.
 [[nodiscard]] std::optional<CivFrame> parseFrame(std::span<const std::uint8_t> frame);
 

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -27,6 +27,19 @@ Q_LOGGING_CATEGORY(lcIcomPan, "aether.icom.pan")
 // wants to switch on after a hang is the stall warning, and nothing else.
 Q_LOGGING_CATEGORY(lcIcomLink, "aether.icom.link")
 
+// EVERY CI-V FRAME, both directions, as hex.
+//
+// The in-memory ring behind `civ trace` already recorded these, but it dies
+// with the backend — disconnect and the evidence is gone, which is exactly
+// when you want it. A log category survives the session and can be read after
+// the fact.
+//
+// This is the difference between three indistinguishable failures: the query
+// was never sent, the radio never answered, or the answer arrived and our
+// decode rejected it. Diagnosing a mode-reporting bug without it means
+// inferring from published state, which cannot tell those apart.
+Q_LOGGING_CATEGORY(lcIcomCiv, "aether.icom.civ")
+
 // Metering is examined this often; the MeterPoller decides what is actually
 // due. Deliberately faster than the fastest meter interval so a due meter is
 // not delayed by up to a whole tick.
@@ -2408,6 +2421,32 @@ void IcomCivBackend::traceCiv(bool outbound, std::span<const std::uint8_t> frame
     m_civTrace.push_back({QDateTime::currentMSecsSinceEpoch(), outbound, hex});
     while (m_civTrace.size() > kCivTraceMax)
         m_civTrace.pop_front();
+
+    // Also to the log, which outlives the backend. Decode the command and
+    // subcommand alongside the raw bytes: `1a 06` means nothing to a reader
+    // scanning a log, and the whole point of switching this on is to answer
+    // "did the 1A 06 query go out, and did the radio answer it".
+    if (lcIcomCiv().isDebugEnabled()) {
+        QString tag;
+        if (frame.size() >= 5) {
+            tag = QStringLiteral(" cmd=%1").arg(frame[4], 2, 16, QLatin1Char('0'));
+            // Which commands carry a subcommand is a per-command fact — the
+            // same enumeration parseFrame() uses. Getting it wrong here would
+            // label command 0x05's first frequency digit as a subcommand.
+            if (frame.size() >= 6) {
+                switch (frame[4]) {
+                case cmd::kLevel: case cmd::kMeter: case cmd::kFunction:
+                case cmd::kPower: case cmd::kReadId: case cmd::kSetting:
+                case cmd::kControl: case cmd::kScope: case cmd::kTuneOffset:
+                    tag += QStringLiteral(" sub=%1").arg(frame[5], 2, 16, QLatin1Char('0'));
+                    break;
+                default: break;
+                }
+            }
+        }
+        qCDebug(lcIcomCiv).noquote().nospace()
+            << (outbound ? "TX -> " : "RX <- ") << hex << tag;
+    }
 }
 
 QVariantList IcomCivBackend::civTrace(bool includeRoutine) const

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -2427,18 +2427,35 @@ void IcomCivBackend::traceCiv(bool outbound, std::span<const std::uint8_t> frame
     // scanning a log, and the whole point of switching this on is to answer
     // "did the 1A 06 query go out, and did the radio answer it".
     if (lcIcomCiv().isDebugEnabled()) {
+        // THE TWO CALL SITES PASS DIFFERENT LAYOUTS, so the command index is a
+        // parameter and not an assumption:
+        //
+        //   TX (sendUserCommand) — the raw wire frame from buildFrame:
+        //       FE FE <to> <from> <cmd> [<sub>] <data…> FD   -> cmd at 4
+        //   RX (onCivFrame)      — re-serialised, envelope deliberately dropped
+        //       <cmd> [<sub>] <data…>                        -> cmd at 0
+        //
+        // Reading index 4 for both printed a payload byte as the command on
+        // every received frame, and silently printed NOTHING for any RX frame
+        // shorter than five bytes — which is most of them. `1a 06 01 01`, the
+        // reply this whole category was added to make visible, is four bytes
+        // and came out undecorated. Exactly the wrong-but-plausible output the
+        // comment below warns about, in the direction that was not checked.
+        const int cmdIdx = outbound ? 4 : 0;
         QString tag;
-        if (frame.size() >= 5) {
-            tag = QStringLiteral(" cmd=%1").arg(frame[4], 2, 16, QLatin1Char('0'));
+        if (frame.size() > static_cast<std::size_t>(cmdIdx)) {
+            const std::uint8_t c = frame[cmdIdx];
+            tag = QStringLiteral(" cmd=%1").arg(c, 2, 16, QLatin1Char('0'));
             // Which commands carry a subcommand is a per-command fact — the
             // same enumeration parseFrame() uses. Getting it wrong here would
             // label command 0x05's first frequency digit as a subcommand.
-            if (frame.size() >= 6) {
-                switch (frame[4]) {
+            if (frame.size() > static_cast<std::size_t>(cmdIdx) + 1) {
+                switch (c) {
                 case cmd::kLevel: case cmd::kMeter: case cmd::kFunction:
                 case cmd::kPower: case cmd::kReadId: case cmd::kSetting:
                 case cmd::kControl: case cmd::kScope: case cmd::kTuneOffset:
-                    tag += QStringLiteral(" sub=%1").arg(frame[5], 2, 16, QLatin1Char('0'));
+                    tag += QStringLiteral(" sub=%1")
+                               .arg(frame[cmdIdx + 1], 2, 16, QLatin1Char('0'));
                     break;
                 default: break;
                 }

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -2446,19 +2446,16 @@ void IcomCivBackend::traceCiv(bool outbound, std::span<const std::uint8_t> frame
         if (frame.size() > static_cast<std::size_t>(cmdIdx)) {
             const std::uint8_t c = frame[cmdIdx];
             tag = QStringLiteral(" cmd=%1").arg(c, 2, 16, QLatin1Char('0'));
-            // Which commands carry a subcommand is a per-command fact — the
-            // same enumeration parseFrame() uses. Getting it wrong here would
-            // label command 0x05's first frequency digit as a subcommand.
-            if (frame.size() > static_cast<std::size_t>(cmdIdx) + 1) {
-                switch (c) {
-                case cmd::kLevel: case cmd::kMeter: case cmd::kFunction:
-                case cmd::kPower: case cmd::kReadId: case cmd::kSetting:
-                case cmd::kControl: case cmd::kScope: case cmd::kTuneOffset:
-                    tag += QStringLiteral(" sub=%1")
-                               .arg(frame[cmdIdx + 1], 2, 16, QLatin1Char('0'));
-                    break;
-                default: break;
-                }
+            // Which commands carry a subcommand is a per-command fact, and
+            // commandHasSubcommand() is the single list parseFrame() decodes
+            // by. Keeping a second copy here would let the two drift, and a
+            // drift would label command 0x05's first frequency digit as a
+            // subcommand — the wrong-but-plausible output this tag exists to
+            // avoid.
+            if (frame.size() > static_cast<std::size_t>(cmdIdx) + 1
+                && commandHasSubcommand(c)) {
+                tag += QStringLiteral(" sub=%1")
+                           .arg(frame[cmdIdx + 1], 2, 16, QLatin1Char('0'));
             }
         }
         qCDebug(lcIcomCiv).noquote().nospace()

--- a/tests/icom_backend_test.cpp
+++ b/tests/icom_backend_test.cpp
@@ -18,13 +18,17 @@
 #include "core/backends/icom/IcomCivBackend.h"
 
 #include <QCoreApplication>
+#include <QLoggingCategory>
 #include <QSignalSpy>
+#include <QStringList>
 #include <QTest>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <span>
 #include <cstdio>
+#include <cstring>
 
 using namespace AetherSDR;
 using namespace AetherSDR::icom;
@@ -60,6 +64,34 @@ static bool movesPttOrTuner(const CivFrame& f)
     return f.cmd == cmd::kControl && f.hasSub
         && (f.sub == control::kPtt || f.sub == control::kTuner)
         && !f.data.empty();
+}
+
+// ---------------------------------------------------------------------------
+// CI-V trace capture
+//
+// traceCiv writes the decoded `cmd=`/`sub=` tag ONLY to qCDebug — the in-memory
+// ring stores raw hex. So the tag can only be asserted by capturing log output,
+// which is why this needs a message handler rather than a getter.
+// ---------------------------------------------------------------------------
+static QStringList g_civLines;
+static bool g_capturing = false;
+static QtMessageHandler g_prevHandler = nullptr;
+
+static void civCapture(QtMsgType type, const QMessageLogContext& ctx, const QString& msg)
+{
+    if (g_capturing && ctx.category && std::strcmp(ctx.category, "aether.icom.civ") == 0)
+        g_civLines << msg;
+    if (g_prevHandler)
+        g_prevHandler(type, ctx, msg);
+}
+
+// The most recent captured line beginning with `prefix`, or a null string.
+static QString lastLineStartingWith(const QString& prefix)
+{
+    for (auto it = g_civLines.crbegin(); it != g_civLines.crend(); ++it)
+        if (it->startsWith(prefix))
+            return *it;
+    return {};
 }
 
 int main(int argc, char** argv)
@@ -853,6 +885,88 @@ int main(int argc, char** argv)
               "and the correction arrives on the next event-loop turn, naming the "
               "mode the radio is really in");
         QObject::disconnect(conn);
+    }
+
+    // ---- the CI-V trace tag decodes the RIGHT byte in BOTH directions -------
+    //
+    // The two call sites hand traceCiv DIFFERENT layouts, and the tag decoder
+    // has to follow:
+    //
+    //   TX (sendUserCommand) — the raw wire frame from buildFrame:
+    //       FE FE <to> <from> <cmd> [<sub>] <data…> FD    -> cmd at index 4
+    //   RX (onCivFrame)      — re-serialised, envelope deliberately dropped:
+    //       <cmd> [<sub>] <data…>                         -> cmd at index 0
+    //
+    // Reading index 4 for both is the defect this guards: on RX it printed a
+    // PAYLOAD byte as the command, and printed nothing at all for frames
+    // shorter than five bytes — which is most of them.
+    //
+    // These assertions are falsifiable by construction: restore the old
+    // `frame[4]` / `size() >= 5` form and the RX cases below fail, because
+    // 1A 06 01 01 is four bytes (no tag at all) and a frequency reply puts a
+    // BCD digit pair where the command was assumed to be.
+    {
+        QLoggingCategory::setFilterRules(QStringLiteral("aether.icom.civ.debug=true"));
+        g_prevHandler = qInstallMessageHandler(civCapture);
+        g_capturing = true;
+
+        // RX, SHORT FRAME — the 1A 06 DATA-flag reply. Four bytes once the
+        // envelope is stripped, so the old `size() >= 5` guard skipped it
+        // silently. This is the exact reply the category was added to make
+        // visible (the radio never volunteers it), so "no tag" is the whole
+        // failure rather than a cosmetic one.
+        g_civLines.clear();
+        radio.pushCiv({0xFE, 0xFE, kControllerAddress, kIc705Addr,
+                       cmd::kSetting, 0x06, 0x01, 0x01, kCivEom});
+        QTest::qWait(120);
+        {
+            const QString line = lastLineStartingWith(QStringLiteral("RX <- 1a 06"));
+            check(!line.isNull(), "the 1A 06 DATA-flag reply reaches the CI-V trace");
+            check(line.contains(QStringLiteral("cmd=1a")),
+                  "and a four-byte RX frame is TAGGED — the old size()>=5 guard "
+                  "dropped the tag on the very reply this category exists for");
+            check(line.contains(QStringLiteral("sub=06")),
+                  "with the subcommand read from index 1, not index 5");
+        }
+
+        // RX, LONG FRAME — a frequency report. Six bytes, so the old guard
+        // PASSED and produced a confidently wrong label: for 14.074 MHz the
+        // BCD payload puts 0x14 at index 4, which is cmd::kLevel, so a
+        // frequency reply was printed as "cmd=14 sub=00" — a level command.
+        // Plausible, wrong, and aimed at someone who switched this on because
+        // they no longer trust their reading of the code.
+        g_civLines.clear();
+        radio.pushCiv({0xFE, 0xFE, kControllerAddress, kIc705Addr,
+                       cmd::kReadFreq, 0x00, 0x40, 0x07, 0x14, 0x00, kCivEom});
+        QTest::qWait(120);
+        {
+            const QString line = lastLineStartingWith(QStringLiteral("RX <- 03"));
+            check(!line.isNull(), "the frequency report reaches the CI-V trace");
+            check(line.contains(QStringLiteral("cmd=03")),
+                  "a frequency reply is tagged as READ-FREQUENCY, not as the "
+                  "level command its BCD payload happens to spell at index 4");
+            check(!line.contains(QStringLiteral("sub=")),
+                  "and read-frequency carries no subcommand, so none is invented");
+        }
+
+        // TX — unchanged behaviour, asserted so the RX fix cannot silently
+        // break the direction that was already right. The raw wire frame keeps
+        // its envelope, so the command really is at index 4 here. AF gain is
+        // command 14 SUB 01, which is a subcommand-bearing frame — the case
+        // where a wrong index would show.
+        g_civLines.clear();
+        backend.setSliceAudioGain(0, 42);
+        QTest::qWait(120);
+        {
+            const QString line = lastLineStartingWith(QStringLiteral("TX -> fe fe"));
+            check(!line.isNull(), "the outbound frame reaches the CI-V trace");
+            check(line.contains(QStringLiteral("cmd=14")) && line.contains(QStringLiteral("sub=01")),
+                  "a TX frame still decodes from index 4/5, past the envelope");
+        }
+
+        g_capturing = false;
+        qInstallMessageHandler(g_prevHandler);
+        QLoggingCategory::setFilterRules(QString());
     }
 
     // ---- health -----------------------------------------------------------

--- a/tests/icom_civ_test.cpp
+++ b/tests/icom_civ_test.cpp
@@ -433,6 +433,45 @@ static void testDataMode()
           "to a bool — an invented DATA state is the lie this command removes");
 }
 
+// commandHasSubcommand() is the ONE list of which commands are sub-addressed.
+// parseFrame() decodes by it and the CI-V trace labels by it, so the property
+// that matters is that the predicate and the parser cannot disagree — a drift
+// between them is what produces a confidently mislabelled frame.
+//
+// Asserting the predicate against a hand-written list would just be a third
+// copy. So this drives every one of the 256 command values through parseFrame()
+// and checks the parser's own hasSub against the predicate.
+static void testSubcommandPredicate()
+{
+    int subAddressed = 0;
+    for (int c = 0; c <= 0xFF; ++c) {
+        const auto command = static_cast<std::uint8_t>(c);
+        // Two payload bytes, so there is something for either reading to claim:
+        // if the command is sub-addressed the first is the subcommand, and if
+        // it is not, both are data.
+        const std::vector<std::uint8_t> wire{
+            0xFE, 0xFE, kControllerAddress, kIc705, command, 0x01, 0x02, kCivEom};
+        const auto parsed = parseFrame(wire);
+        if (!parsed)
+            continue;
+        const bool predicate = commandHasSubcommand(command);
+        check(parsed->hasSub == predicate,
+              "parseFrame and commandHasSubcommand agree for every command byte");
+        if (predicate) {
+            ++subAddressed;
+            check(parsed->sub == 0x01 && parsed->data.size() == 1,
+                  "a sub-addressed command takes the subcommand out of the payload");
+        } else {
+            check(parsed->data.size() == 2,
+                  "a bare command keeps both payload bytes");
+        }
+    }
+    // The eleven that carry subcommands: 12 14 15 16 18 19 1A 1C 21 26 27. A
+    // change to the list is a deliberate protocol decision, so it should have
+    // to come past this number rather than arrive as a silent side effect.
+    check(subAddressed == 11, "exactly eleven CI-V commands are sub-addressed");
+}
+
 int main()
 {
     testFraming();
@@ -441,6 +480,7 @@ int main()
     testModes();
     testCommands();
     testDataMode();
+    testSubcommandPredicate();
 
     if (g_failures == 0)
         std::printf("icom_civ_test: all checks passed\n");


### PR DESCRIPTION
## The problem

**None of the five Icom logging categories is registered in `LogManager`.** They are declared locally in the Icom sources — `aether.icom.session`, `.stream`, `.pan`, `.link`, `.cred` — but never listed in the registry table, so `applyFilterRules()`'s blanket `aether.*.debug=false` switches them all off and **no UI toggle can switch them back on**.

The net effect is that an Icom session logs its INF lines and nothing else, permanently.

This is the same defect the comment above the `aether.hl2.tx` entry already documents, in this file:

> *"The category is declared locally in Hl2Backend.cpp and was never listed here, so `applyFilterRules()`'s blanket `aether.*.debug=false` switched it off and no UI toggle could switch it back on."*

It was fixed for HL2 and left in place for Icom.

## The change

Registers the five existing categories, and adds one: **`aether.icom.civ`** — every CI-V frame, both directions, as hex, with the command and subcommand decoded alongside the raw bytes.

The subcommand is labelled from the same per-command enumeration `parseFrame()` uses. Guessing positionally would print command `0x05`'s first frequency digit as a "subcommand", which is exactly the kind of wrong-but-plausible output that makes a diagnostic worse than none. Marked high-rate in its description so it is not left on by accident.

## Why the new category, and not just the registration

The in-memory ring behind `civ trace` already records these frames, but it **dies with the backend** — disconnect and the evidence is gone, which is precisely when you want it. A log category outlives the session and can be read after the fact.

## What it was worth in practice

This came out of chasing the DFM mode-reporting bug in #4930 on a live IC-9700. Without frame visibility there were three indistinguishable possibilities:

1. the query was never sent
2. the radio never answered
3. the reply arrived and our decode rejected it

I guessed, and **guessed wrong twice** — first concluding the read side had failed on hardware, then that RX frames arrived preamble-stripped and were being rejected by `parseFrame()`. Neither was true. The second one nearly sent me rewriting a decoder that was already correct.

With this category on, the answer took about two minutes and was unambiguous:

```
[21:29:24.831] RX <- 04 05 01        mode reply: FM, filter 1
[21:29:24.839] RX <- 1a 06 01 01     data flag: ON
[21:34:47.920] RX <- 01 05 01        front-panel DATA press -> mode frame only
```

One `1A 06` in the whole session, against two mode frames — which is what showed that the radio pushes mode changes unprompted but **never volunteers the DATA flag**. That is the finding the #4930 fix is built on, and it was not reachable by reading the code.

## Testing

Built clean on Windows/MSVC. Exercised against a real IC-9700 over the RS-BA1 transport for a full session: connect, front-panel mode and DATA changes, and mode writes from AetherSDR — several hundred frames captured with correct command/subcommand decoding in both directions.

No behaviour change when the category is off, which is the default.
