### PR TITLE
fix(workspace): palette greys undetected hardware instead of erasing it — restores the Amplifiers category

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -3182,7 +3182,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `record` | — | record <start\|stop\|status\|path\|dir> [args] |
 | `testtone` | — | testtone <on\|off> [freqHz levelDb] |
 | `pan` | — | pan <create\|add\|remove\|close\|center\|rfgain\|float\|dock> [value] — float/dock drive PanadapterStack's real reparent path (#4864) |
-| `workspace` | — | workspace <status\|enable\|disable\|edit\|place\|list\|switch\|create\|bind\|import-floats> — the canvas and its workspaces as data; arg shapes in docs/automation-bridge.md (#4887 ph4/ph6) |
+| `workspace` | — | workspace <status\|enable\|disable\|edit\|place\|list\|switch\|create\|bind\|import-floats\|palette> — the canvas and its workspaces as data; arg shapes in docs/automation-bridge.md (#4887 ph4/ph6) |
 | `layout` | — | layout <rearrange <id>\|get> — splitter layout exerciser |
 | `scale` | — | scale [pct] — report/persist the UI scale factor |
 | `panmessage` | — | panmessage <add\|remove\|clear\|list> <pan> [id timeout [tone=…] title\|detail] |

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -3089,8 +3089,8 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
 
         add("workspace", {},
             "workspace <status|enable|disable|edit|place|list|switch|create|"
-            "bind|import-floats> — the canvas and its workspaces as data; "
-            "arg shapes in docs/automation-bridge.md (#4887 ph4/ph6)",
+            "bind|import-floats|palette> — the canvas and its workspaces as "
+            "data; arg shapes in docs/automation-bridge.md (#4887 ph4/ph6)",
             parseActionRest,
             [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
                 Q_UNUSED(s);

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -1678,6 +1678,22 @@ void AppletPanel::setShackSwitchVisible(bool visible)
     applyBarLayout();
 }
 
+void AppletPanel::setDemoVisible(bool visible)
+{
+    // DEMO's "hardware" is the connected radio being the simulator — a
+    // live connection edge exactly like the six detected-device setters
+    // above.  Availability must ride this edge or the palette greys
+    // Demo Noise forever (#4968 red-team B1): markHardwareConditional
+    // set the bit false at construction and nothing else ever wrote it,
+    // so on the one radio the applet exists for it was refused at the
+    // door and a workspace switch could close it with no way back.
+    updateHardwareAvailability("DEMO", "Applet_DEMO", visible);
+    applyBarLayout();
+    // The tile additionally auto-opens with the demo connection and
+    // auto-closes when it drops (RFC #4288) — unchanged.
+    setAppletVisible(QStringLiteral("DEMO"), visible);
+}
+
 bool AppletPanel::controlsLocked() const
 {
     return ControlsLock::isLocked();

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -1274,21 +1274,6 @@ QList<AppletPanel::AppletCatalogEntry> AppletPanel::appletCatalog() const
         {QStringLiteral("PROF"),  QStringLiteral("Station")},
     };
 
-    // Hardware-conditional applets (TGXL/PGXL/ACOM/SPE…) hide from the BAR
-    // when their hardware is absent; the palette must not offer them
-    // either (review M3): on the demo it listed live entries that placed
-    // dead amplifier applets.  The bar's own record — BarButton::
-    // hardwareAvailable, driven by markHardwareConditional()/
-    // updateHardwareAvailability() — is the single source of that truth.
-    auto hardwareHidden = [this](const QString& id) {
-        for (const auto& bb : m_barButtons) {
-            if (bb.id == id) {
-                return !bb.hardwareAvailable;
-            }
-        }
-        return false;   // no bar record: not hardware-conditional
-    };
-
     QList<AppletCatalogEntry> out;
     out.reserve(m_appletOrder.size() + 1);
     // The VU/S-Meter container is created directly on the manager rather
@@ -1299,10 +1284,14 @@ QList<AppletPanel::AppletCatalogEntry> AppletPanel::appletCatalog() const
         out.append({QStringLiteral("VU"), m_sMeterContainer->title(),
                     QStringLiteral("Metering")});
     }
+    // Every applet, ALWAYS — the catalog is the recall universe (red-team
+    // B1) and the palette's taxonomy, and FILTERING here was the 8600
+    // amplifier regression: the catalog is snapshotted at construction,
+    // before any radio connects, so hardware detected later (TGXL/PGXL
+    // discovery is post-connect) stayed missing from the palette — and
+    // from workspace recall — forever.  Availability is a LIVE question,
+    // answered per menu-open through appletHardwareAvailable().
     for (const auto& entry : m_appletOrder) {
-        if (hardwareHidden(entry.id)) {
-            continue;
-        }
         AppletCatalogEntry e;
         e.id = entry.id;
         if (auto* c = qobject_cast<ContainerWidget*>(entry.widget)) {
@@ -1315,6 +1304,20 @@ QList<AppletPanel::AppletCatalogEntry> AppletPanel::appletCatalog() const
         out.append(e);
     }
     return out;
+}
+
+bool AppletPanel::appletHardwareAvailable(const QString& id) const
+{
+    // The bar's own record — BarButton::hardwareAvailable, driven by
+    // markHardwareConditional()/updateHardwareAvailability() — read LIVE,
+    // so the palette greys exactly what the bar currently hides (review
+    // M3) and recovers the moment detection flips it.
+    for (const auto& bb : m_barButtons) {
+        if (bb.id == id) {
+            return bb.hardwareAvailable;
+        }
+    }
+    return true;   // no bar record: not hardware-conditional
 }
 
 QStringList AppletPanel::appletIds() const

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -178,6 +178,9 @@ public:
 
     // Show/hide the ShackSwitch applet based on device presence.
     void setShackSwitchVisible(bool visible);
+    // DEMO's availability edge — its "hardware" is the connected radio
+    // being the simulator (#4968 red-team B1).
+    void setDemoVisible(bool visible);
 
     // Show/hide the PROF button and applet based on whether the connected radio
     // has an on-radio profile store (RadioCapabilities::hasProfiles).

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -260,6 +260,8 @@ public:
         QString category;
     };
     QList<AppletCatalogEntry> appletCatalog() const;
+    // Live hardware availability for one applet (the bar's own record).
+    bool appletHardwareAvailable(const QString& id) const;
 
     // While true, recall-driven visibility changes do NOT write the
     // operator's Applet_<ID> preferences (red-team B2): a workspace switch

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5637,7 +5637,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
     if (m_appletPanel) {
         auto* conn = m_radioModel.connection();
         const bool demo = connected && conn && conn->isSyntheticDemo();
-        m_appletPanel->setAppletVisible(QStringLiteral("DEMO"), demo);
+        m_appletPanel->setDemoVisible(demo);
         if (demo) {
             if (auto* applet = m_appletPanel->demoApplet())
                 applet->pushSceneToEngine();

--- a/src/gui/MainWindow_Workspace.cpp
+++ b/src/gui/MainWindow_Workspace.cpp
@@ -599,6 +599,39 @@ QVariantMap MainWindow::automationWorkspace(const QString& action,
         return out;
     }
 
+    if (action == QLatin1String("palette")) {
+        // The Add-widget menu itself is a stack-local QMenu no bridge
+        // verb can reach (it would block inside exec()), so this reports
+        // the same classification the menu renders — the #4968 red-team
+        // could not verify the greying at runtime; now anything can.
+        QVariantList entries;
+        for (const auto& pe : m_workspaceController->paletteState()) {
+            QVariantMap m;
+            m[QStringLiteral("id")]       = pe.id;
+            m[QStringLiteral("title")]    = pe.title;
+            m[QStringLiteral("category")] = pe.category;
+            using S = WorkspaceController::PaletteEntry::State;
+            switch (pe.state) {
+            case S::Addable:
+                m[QStringLiteral("state")] = QStringLiteral("addable");
+                break;
+            case S::OnCanvas:
+                m[QStringLiteral("state")] = QStringLiteral("on-canvas");
+                break;
+            case S::NotDetected:
+                m[QStringLiteral("state")] = QStringLiteral("not-detected");
+                break;
+            case S::Absent:
+                m[QStringLiteral("state")] = QStringLiteral("absent");
+                break;
+            }
+            entries.append(m);
+        }
+        out[QStringLiteral("entries")] = entries;
+        out[QStringLiteral("count")]   = entries.size();
+        return out;
+    }
+
     if (action == QLatin1String("list")) {
         QVariantList wsList;
         for (const auto& [id, label] : m_workspaceController->workspaceList()) {

--- a/src/gui/MainWindow_Workspace.cpp
+++ b/src/gui/MainWindow_Workspace.cpp
@@ -110,6 +110,10 @@ void MainWindow::wireWorkspaceCanvas()
             catalog.append({e.id, e.title, e.category});
         }
         m_workspaceController->setWidgetCatalog(catalog);
+        m_workspaceController->setWidgetAvailabilityHook(
+            [this](const QString& id) {
+                return m_appletPanel->appletHardwareAvailable(id);
+            });
     }
 
     // Profile-bound recall (phase 6, decisions 6/8): a bound GLOBAL

--- a/src/gui/workspace/WorkspaceController.cpp
+++ b/src/gui/workspace/WorkspaceController.cpp
@@ -1223,10 +1223,13 @@ void WorkspaceController::onContextMenuRequested(const QString& itemId,
                 }
                 QAction* a = catMenu->addAction(menuText(e.title));
                 ContainerWidget* c = containerForApplet(e.id);
-                if (!c) {
-                    // Catalogued but not constructed in this session — a
-                    // live-looking entry that silently no-ops is worse
-                    // than a grey one (review M3).
+                if (!c || (m_widgetAvailable && !m_widgetAvailable(e.id))) {
+                    // Catalogued but not constructed, or its hardware is
+                    // not (currently) detected — GREY, never hidden: the
+                    // category and the taxonomy stay visible (the 8600
+                    // amplifier regression), the dead-add stays impossible
+                    // (review M3), and the entry recovers on the next menu
+                    // open once detection flips.
                     a->setEnabled(false);
                 } else if (c->isOnCanvas()) {
                     a->setCheckable(true);
@@ -1593,6 +1596,12 @@ void WorkspaceController::setWidgetCatalog(const QList<WidgetCatalogEntry>& cata
     m_widgetCatalog = catalog;
 }
 
+void WorkspaceController::setWidgetAvailabilityHook(
+    std::function<bool(const QString&)> hook)
+{
+    m_widgetAvailable = std::move(hook);
+}
+
 bool WorkspaceController::addAppletFromPalette(const QString& appletId,
                                                const QPointF& canvasPos)
 {
@@ -1602,6 +1611,9 @@ bool WorkspaceController::addAppletFromPalette(const QString& appletId,
     ContainerWidget* c = containerForApplet(appletId);
     if (!c || c->isOnCanvas()) {
         return false;   // absent, or already there — the menu shows why
+    }
+    if (m_widgetAvailable && !m_widgetAvailable(appletId)) {
+        return false;   // hardware not detected — the menu greys these
     }
 
     const QString itemId = itemIdFor(c);

--- a/src/gui/workspace/WorkspaceController.cpp
+++ b/src/gui/workspace/WorkspaceController.cpp
@@ -11,6 +11,7 @@
 
 #include <QHash>
 #include <QMenu>
+#include <QToolTip>
 
 #include <algorithm>
 #include <QPoint>
@@ -1209,38 +1210,68 @@ void WorkspaceController::onContextMenuRequested(const QString& itemId,
                           m_canvas->mapFromGlobal(globalPos).y()
                               / double(m_canvas->height()));
 
+        const QList<PaletteEntry> pal = paletteState();
         QStringList categoryOrder;
-        for (const WidgetCatalogEntry& e : m_widgetCatalog) {
+        for (const PaletteEntry& e : pal) {
             if (!categoryOrder.contains(e.category)) {
                 categoryOrder.append(e.category);
             }
         }
         for (const QString& category : categoryOrder) {
             QMenu* catMenu = add->addMenu(menuText(category));
-            for (const WidgetCatalogEntry& e : m_widgetCatalog) {
+            for (const PaletteEntry& e : pal) {
                 if (e.category != category) {
                     continue;
                 }
-                QAction* a = catMenu->addAction(menuText(e.title));
-                ContainerWidget* c = containerForApplet(e.id);
-                if (!c || (m_widgetAvailable && !m_widgetAvailable(e.id))) {
-                    // Catalogued but not constructed, or its hardware is
-                    // not (currently) detected — GREY, never hidden: the
-                    // category and the taxonomy stay visible (the 8600
-                    // amplifier regression), the dead-add stays impossible
-                    // (review M3), and the entry recovers on the next menu
-                    // open once detection flips.
-                    a->setEnabled(false);
-                } else if (c->isOnCanvas()) {
+                switch (e.state) {
+                case PaletteEntry::State::OnCanvas: {
+                    QAction* a = catMenu->addAction(menuText(e.title));
                     a->setCheckable(true);
                     a->setChecked(true);
                     a->setEnabled(false);
-                } else {
+                    break;
+                }
+                case PaletteEntry::State::NotDetected: {
+                    // GREY, never hidden — the category and taxonomy stay
+                    // visible (the 8600 amplifier regression) and the
+                    // entry recovers on the next menu open once detection
+                    // flips.  The suffix says WHY it is dimmed: a screen
+                    // reader hears "disabled" and nothing else, and this
+                    // grey means three different things (#4968 m3, a11y
+                    // commitment in #4896).
+                    QAction* a = catMenu->addAction(
+                        menuText(e.title)
+                        + tr(" (not detected)"));
+                    a->setEnabled(false);
+                    break;
+                }
+                case PaletteEntry::State::Absent: {
+                    // Catalogued but not constructed in this session — a
+                    // live-looking entry that silently no-ops is worse
+                    // than a grey one (review M3).
+                    QAction* a = catMenu->addAction(menuText(e.title));
+                    a->setEnabled(false);
+                    break;
+                }
+                case PaletteEntry::State::Addable: {
+                    QAction* a = catMenu->addAction(menuText(e.title));
                     const QString appletId = e.id;
+                    const QString title    = e.title;
                     connect(a, &QAction::triggered, this,
-                            [this, appletId, canvasPos] {
-                                addAppletFromPalette(appletId, canvasPos);
+                            [this, appletId, title, canvasPos, globalPos] {
+                                if (!addAppletFromPalette(appletId,
+                                                          canvasPos)) {
+                                    // Detection flipped between menu build
+                                    // and click (#4968 m1) — a refused add
+                                    // must never be a silent no-op.
+                                    QToolTip::showText(
+                                        globalPos,
+                                        tr("%1 is not available right now")
+                                            .arg(title));
+                                }
                             });
+                    break;
+                }
                 }
             }
         }
@@ -1543,6 +1574,12 @@ bool WorkspaceController::switchWorkspaceInternal(const QString& id, bool force)
     // recall guard so the panel's preference dual-write stays silent
     // (red-team B2) — workspace recall is not the operator editing their
     // Classic preferences.
+    // Hardware availability (m_widgetAvailable) is deliberately NOT
+    // consulted here: the document is the operator's own recorded intent,
+    // and detection can lag connect by seconds — gating recall on it
+    // would make a switch racy and recall workspaces incomplete.  Recall
+    // outranks availability; only ADDING via the palette is gated
+    // (#4968 red-team M2, ruled by the maintainer).
     if (m_panHost.recallGuard) m_panHost.recallGuard(true);
     for (const WidgetCatalogEntry& entry : m_widgetCatalog) {
         ContainerWidget* c = containerForApplet(entry.id);
@@ -1602,6 +1639,34 @@ void WorkspaceController::setWidgetAvailabilityHook(
     m_widgetAvailable = std::move(hook);
 }
 
+QList<WorkspaceController::PaletteEntry> WorkspaceController::paletteState() const
+{
+    QList<PaletteEntry> out;
+    out.reserve(m_widgetCatalog.size());
+    for (const WidgetCatalogEntry& e : m_widgetCatalog) {
+        PaletteEntry p;
+        p.id       = e.id;
+        p.title    = e.title;
+        p.category = e.category;
+        ContainerWidget* c = containerForApplet(e.id);
+        // Order matters (#4968 red-team M2): an applet ON the canvas is
+        // reported as such even while its hardware is undetected —
+        // recall outranks availability, so that state is legitimate and
+        // the entry must show "placed", not "unavailable".
+        if (c && c->isOnCanvas()) {
+            p.state = PaletteEntry::State::OnCanvas;
+        } else if (!c) {
+            p.state = PaletteEntry::State::Absent;
+        } else if (m_widgetAvailable && !m_widgetAvailable(e.id)) {
+            p.state = PaletteEntry::State::NotDetected;
+        } else {
+            p.state = PaletteEntry::State::Addable;
+        }
+        out.append(p);
+    }
+    return out;
+}
+
 bool WorkspaceController::addAppletFromPalette(const QString& appletId,
                                                const QPointF& canvasPos)
 {
@@ -1613,7 +1678,12 @@ bool WorkspaceController::addAppletFromPalette(const QString& appletId,
         return false;   // absent, or already there — the menu shows why
     }
     if (m_widgetAvailable && !m_widgetAvailable(appletId)) {
-        return false;   // hardware not detected — the menu greys these
+        // Hardware not detected — the menu greys these.  Availability
+        // gates ADDING only: recall (switchWorkspaceInternal) and
+        // placement deliberately ignore it, because the workspace
+        // document is the operator's own recorded intent (#4968 M2
+        // ruling).
+        return false;
     }
 
     const QString itemId = itemIdFor(c);

--- a/src/gui/workspace/WorkspaceController.h
+++ b/src/gui/workspace/WorkspaceController.h
@@ -173,6 +173,10 @@ public:
         QString category;
     };
     void setWidgetCatalog(const QList<WidgetCatalogEntry>& catalog);
+    // Live per-applet hardware availability (the 8600 amplifier
+    // regression: availability is post-connect state and must never be
+    // baked into the catalog snapshot).  Unset = everything available.
+    void setWidgetAvailabilityHook(std::function<bool(const QString&)> hook);
 
     // Add one applet from the palette at a canvas position (fractions).
     // Opens a closed applet, docks a floating one, places an open one —
@@ -312,6 +316,7 @@ private:
     WorkspaceStore    m_store;
     PanHostHooks m_panHost;
     QList<WidgetCatalogEntry> m_widgetCatalog;
+    std::function<bool(const QString&)> m_widgetAvailable;
     QHash<QString, int> m_panSlots;   // live panId → document slot
     QPointer<QWidget> m_returnTarget;
     QStringList m_knownAppletIds;   // from enable(), for resetToClassic()

--- a/src/gui/workspace/WorkspaceController.h
+++ b/src/gui/workspace/WorkspaceController.h
@@ -178,6 +178,24 @@ public:
     // baked into the catalog snapshot).  Unset = everything available.
     void setWidgetAvailabilityHook(std::function<bool(const QString&)> hook);
 
+    // One catalog entry as the palette would render it.  The menu is a
+    // stack-local QMenu no test or bridge verb can reach, so the
+    // CLASSIFICATION lives here where both can (#4968 red-team M1): the
+    // menu consumes this verbatim, the unit suite pins it, and the
+    // `workspace palette` verb reports it.
+    struct PaletteEntry {
+        QString id;
+        QString title;
+        QString category;
+        enum class State {
+            Addable,       // enabled entry; click adds it
+            OnCanvas,      // checked + disabled — already placed
+            NotDetected,   // greyed: hardware-conditional, not detected
+            Absent,        // greyed: catalogued but not constructed
+        } state = State::Addable;
+    };
+    QList<PaletteEntry> paletteState() const;
+
     // Add one applet from the palette at a canvas position (fractions).
     // Opens a closed applet, docks a floating one, places an open one —
     // and refuses an applet already on the canvas.

--- a/tests/workspace_controller_test.cpp
+++ b/tests/workspace_controller_test.cpp
@@ -872,6 +872,31 @@ int main(int argc, char** argv)
                                             QPointF(0.5, 0.5))
                        && tx->isOnCanvas());
             canvas.setEditMode(true);
+
+            // Hardware availability is a LIVE question, never a catalog
+            // filter (the 8600 amplifier regression: TGXL/PGXL detection
+            // is post-connect, but the catalog snapshot is taken at
+            // construction — filtering there erased the Amplifiers
+            // category, and the amps' recall membership, permanently).
+            // The engine refuses while the hook says unavailable and
+            // recovers the instant it flips — no re-snapshot needed.
+            bool ampDetected = false;
+            ctl.setWidgetAvailabilityHook(
+                [&ampDetected](const QString& id) {
+                    return id != QStringLiteral("TX") || ampDetected;
+                });
+            ctl.returnAppletToPanel("TX");
+            tx->setContainerVisible(false);
+            report("palette refuses undetected hardware (live hook)",
+                   !ctl.addAppletFromPalette(QStringLiteral("TX"),
+                                             QPointF(0.5, 0.5))
+                       && !tx->isOnCanvas());
+            ampDetected = true;
+            report("palette recovers when detection flips, no re-wire",
+                   ctl.addAppletFromPalette(QStringLiteral("TX"),
+                                            QPointF(0.5, 0.5))
+                       && tx->isOnCanvas());
+            ctl.setWidgetAvailabilityHook({});
         }
 
         // Mode-off switch only retargets.

--- a/tests/workspace_controller_test.cpp
+++ b/tests/workspace_controller_test.cpp
@@ -896,6 +896,40 @@ int main(int argc, char** argv)
                    ctl.addAppletFromPalette(QStringLiteral("TX"),
                                             QPointF(0.5, 0.5))
                        && tx->isOnCanvas());
+            // paletteState() is the exact classification the Add-widget
+            // menu renders (#4968 red-team M1: the menu is a stack-local
+            // QMenu nothing can reach, so the logic lives where the suite
+            // and the `workspace palette` verb can pin it).
+            using PE = WorkspaceController::PaletteEntry;
+            ctl.setWidgetCatalog(
+                {{QStringLiteral("RX"), QStringLiteral("RX Controls"),
+                  QStringLiteral("Receive")},
+                 {QStringLiteral("TX"), QStringLiteral("TX Controls"),
+                  QStringLiteral("Transmit")},
+                 {QStringLiteral("GHOST"), QStringLiteral("Not Built"),
+                  QStringLiteral("Receive")}});
+            ctl.setWidgetAvailabilityHook(
+                [](const QString& id) { return id != QStringLiteral("TX"); });
+            auto stateOf = [&ctl](const QString& id) {
+                for (const PE& e : ctl.paletteState())
+                    if (e.id == id) return e.state;
+                return PE::State::Absent;
+            };
+            // TX is undetected AND on the canvas: on-canvas must win
+            // (#4968 M2 ordering — recall outranks availability, so a
+            // placed applet shows "placed", never "unavailable").
+            report("palette: on-canvas outranks not-detected",
+                   tx->isOnCanvas()
+                       && stateOf(QStringLiteral("TX")) == PE::State::OnCanvas);
+            ctl.returnAppletToPanel("TX");
+            tx->setContainerVisible(false);
+            report("palette: undetected hardware classifies not-detected",
+                   stateOf(QStringLiteral("TX")) == PE::State::NotDetected);
+            report("palette: unconstructed applet classifies absent",
+                   stateOf(QStringLiteral("GHOST")) == PE::State::Absent);
+            if (rx->isOnCanvas()) ctl.returnAppletToPanel("RX");
+            report("palette: available applet classifies addable",
+                   stateOf(QStringLiteral("RX")) == PE::State::Addable);
             ctl.setWidgetAvailabilityHook({});
         }
 


### PR DESCRIPTION
## Regression

Field report from the 8600: the **Amplifiers** category vanished from the canvas Add widget ▸ menu.

The #4964 review-M3 fix filtered hardware-conditional applets out of `AppletPanel::appletCatalog()` when `BarButton::hardwareAvailable` was false. But MainWindow snapshots that catalog **once, in its constructor** — before any radio connects — and TGXL/PGXL/ACOM/SPE detection is post-connect state. So on a real station the amps were filtered at startup and never returned: all three Amplifiers applets disappeared, taking the category with them.

The blast radius was wider than the amps:

- `markHardwareConditional` covers **seven** ids — TUN, AMP, ACOM, SPE, plus DEMO, AG, and SS — so Demo Noise, Antenna Genius, and ShackSwitch were being erased the same way.
- The same catalog is the recall universe from the B1 fix, so those seven applets had also silently dropped out of workspace open/close recall.

## Fix

Availability is a live question and is now answered that way:

- `appletCatalog()` lists every applet, always — the catalog is taxonomy and recall universe, never an availability filter.
- New `AppletPanel::appletHardwareAvailable(id)` exposes the bar's own record for live reads.
- `WorkspaceController` consults it through a hook **at menu-build time** and greys unavailable entries — same treatment as an absent container. The category and taxonomy stay visible, the dead-add M3 actually objected to stays impossible, and entries recover on the next menu open the moment detection flips. No re-snapshot, no re-wiring.
- `addAppletFromPalette()` refuses while the hook says unavailable — the backstop for detection flipping between menu build and click (the menu is its only caller today).

Full accounting: 28 entries across 8 categories (27 `m_appletOrder` ids — the category map covers all 27 exactly — plus the explicit VU row); any future unmapped id lands under "Other" rather than disappearing.

## Tests

Pinned in `workspace_controller_test`: the engine refuses while the hook reports undetected and recovers when it flips. Full suite green locally, 292/292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Round 2 (red-team fixes, `bfe09dbe`)

The [red-team review](https://github.com/aethersdr/AetherSDR/pull/4968#issuecomment-5276030989) found one blocker and two majors; all findings addressed:

- **B1**: `AppletPanel::setDemoVisible()` now drives DEMO availability on the demo-connect edge (it was permanently false -- nothing ever wrote it). Verified live over the bridge: `not-detected` -> connect `DEMO-0001` -> `addable` -> disconnect -> `not-detected`.
- **M1**: palette classification extracted to `WorkspaceController::paletteState()` -- the menu consumes it verbatim, the unit suite pins all four states, and a new `workspace palette` bridge verb reports it at runtime (28 entries / 8 categories confirmed live, pre- and post-connect).
- **M2**: maintainer ruling -- **recall outranks availability**. The workspace document is the operator's recorded intent and detection can lag connect, so `switchWorkspaceInternal` deliberately ignores the hook; only palette ADDs are gated. Stated in code at both sites. The ordering sub-bug (on-canvas amp rendered greyed-unchecked) is fixed and pinned.
- **m1**: a refused add now shows a tooltip instead of silently no-op'ing.
- **m2**: the body sentence above corrected -- there were no bridge callers.
- **m3**: greyed hardware entries carry a " (not detected)" suffix (a11y, #4896).
