### PR TITLE
feat(workspace): additional canvas windows — multi-surface placement, Move to ▸, hide-and-keep. Phase 7 (#4887)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1014,6 +1014,7 @@ set(GUI_SOURCES
     src/gui/workspace/WorkspaceGeometry.cpp
     src/gui/workspace/WorkspaceMigration.cpp
     src/gui/workspace/WorkspaceStore.cpp
+    src/gui/workspace/WorkspaceWindow.cpp
     src/gui/ClientCompApplet.cpp
     src/gui/ClientCompCurveWidget.cpp
     src/gui/ClientCompKnob.cpp

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -3189,7 +3189,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `record` | — | record <start\|stop\|status\|path\|dir> [args] |
 | `testtone` | — | testtone <on\|off> [freqHz levelDb] |
 | `pan` | — | pan <create\|add\|remove\|close\|center\|rfgain\|float\|dock> [value] — float/dock drive PanadapterStack's real reparent path (#4864) |
-| `workspace` | — | workspace <status\|enable\|disable\|edit\|place\|list\|switch\|create\|bind\|import-floats\|palette> — the canvas and its workspaces as data; arg shapes in docs/automation-bridge.md (#4887 ph4/ph6) |
+| `workspace` | — | workspace <status\|enable\|disable\|edit\|place\|list\|switch\|create\|bind\|import-floats\|palette\|window\|move\|add> — the canvas, its workspaces and its extra windows as data; arg shapes in docs/automation-bridge.md (#4887 ph4/ph6/ph7) |
 | `layout` | — | layout <rearrange <id>\|get> — splitter layout exerciser |
 | `scale` | — | scale [pct] — report/persist the UI scale factor |
 | `panmessage` | — | panmessage <add\|remove\|clear\|list> <pan> [id timeout [tone=…] title\|detail] |

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -3089,8 +3089,9 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
 
         add("workspace", {},
             "workspace <status|enable|disable|edit|place|list|switch|create|"
-            "bind|import-floats|palette> — the canvas and its workspaces as "
-            "data; arg shapes in docs/automation-bridge.md (#4887 ph4/ph6)",
+            "bind|import-floats|palette|window|move|add> — the canvas, its "
+            "workspaces and its extra windows as data; arg shapes in "
+            "docs/automation-bridge.md (#4887 ph4/ph6/ph7)",
             parseActionRest,
             [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
                 Q_UNUSED(s);

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -417,7 +417,13 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     m_sMeterContainer->setContent(sMeterContent);
     connect(m_sMeterContainer, &ContainerWidget::dockModeChanged,
             m_sMeter, [this](ContainerWidget::DockMode mode) {
-                m_sMeter->setFloating(mode == ContainerWidget::DockMode::Floating);
+                // Canvas takes the floating presentation (8600 field
+                // report: an item resized on the canvas kept the rail's
+                // Fixed vertical policy and refused to grow — the meter
+                // must fill the rect the operator drew, exactly as it
+                // fills a pop-out window).
+                m_sMeter->setFloating(
+                    mode != ContainerWidget::DockMode::PanelDocked);
             });
     const bool sMeterOn = AppSettings::instance()
         .value("Applet_VU", "True").toString() == "True";
@@ -716,8 +722,10 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
             connect(container, &ContainerWidget::dockModeChanged,
                     m_crossNeedleApplet,
                     [this](ContainerWidget::DockMode mode) {
+                        // Canvas = floating presentation (see the VU
+                        // handler above).
                         m_crossNeedleApplet->setFloating(
-                            mode == ContainerWidget::DockMode::Floating);
+                            mode != ContainerWidget::DockMode::PanelDocked);
                     });
         }
         m_appletOrder.append(powerEntry);
@@ -912,7 +920,11 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
         if (auto* c = qobject_cast<ContainerWidget*>(catEntry.widget)) {
             connect(c, &ContainerWidget::dockModeChanged, m_catControlApplet,
                     [this](ContainerWidget::DockMode mode) {
-                        m_catControlApplet->setFloating(mode == ContainerWidget::DockMode::Floating);
+                        // Canvas = the full-table floating view (see the
+                        // VU handler above): the operator sized the rect,
+                        // so the simple rail page wastes it.
+                        m_catControlApplet->setFloating(
+                            mode != ContainerWidget::DockMode::PanelDocked);
                     });
         }
     }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -239,6 +239,7 @@
 #include "core/backends/hl2/Hl2Backend.h"  // dynamic_cast for WDSP setup progress
 #include "core/backends/sim/SimBackend.h"  // dynamic_cast for demo noise controls
 #include "workspace/WorkspaceController.h"  // prepareShutdown (phase 7 canvas windows)
+#include "workspace/WorkspaceWindow.h"      // shutdown sweep of hidden windows (M1)
 #if defined(Q_OS_MAC)
 #include "core/VirtualAudioBridge.h"
 #include <QFileInfo>
@@ -2737,6 +2738,19 @@ void MainWindow::preparePanadapterUiForShutdown()
     if (m_workspaceController) {
         m_workspaceController->prepareShutdown();
     }
+    // The controller only knows OPEN windows; hidden ones (hide-and-keep)
+    // and windows orphaned by disable() live solely in this map — sweep it
+    // whole (red-team #4971 M1: disable-then-quit left every canvas window
+    // to ~QWidget, the #2495 crash shape).  Their widgets were evicted
+    // when they were hidden, so deletion here orphans nothing.
+    for (auto it = m_workspaceWindows.begin(); it != m_workspaceWindows.end();
+         ++it) {
+        if (it.value()) {
+            it.value()->prepareShutdown();
+            delete it.value();
+        }
+    }
+    m_workspaceWindows.clear();
 
     const QList<SpectrumWidget*> spectra = findChildren<SpectrumWidget*>();
     for (SpectrumWidget* spectrum : spectra) {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -238,6 +238,7 @@
 #include "core/backends/IRadioBackend.h"   // seam: SimBackend::audioFrameReady wiring
 #include "core/backends/hl2/Hl2Backend.h"  // dynamic_cast for WDSP setup progress
 #include "core/backends/sim/SimBackend.h"  // dynamic_cast for demo noise controls
+#include "workspace/WorkspaceController.h"  // prepareShutdown (phase 7 canvas windows)
 #if defined(Q_OS_MAC)
 #include "core/VirtualAudioBridge.h"
 #include <QFileInfo>
@@ -2725,6 +2726,16 @@ void MainWindow::preparePanadapterUiForShutdown()
 
     if (auto* stream = m_radioModel.panStream()) {
         QObject::disconnect(stream, nullptr, this, nullptr);
+    }
+
+    // Canvas windows first (phase 7): persist their geometry hints, flush
+    // the workspace document, evict their widgets back to the stack/panel
+    // — which still own them — and delete the windows explicitly (the
+    // #2495 lesson: a floating top-level left to ~QWidget cleanup crashed
+    // at exit).  Must precede the stack/container teardown below, which
+    // assumes it can reach every applet.
+    if (m_workspaceController) {
+        m_workspaceController->prepareShutdown();
     }
 
     const QList<SpectrumWidget*> spectra = findChildren<SpectrumWidget*>();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -127,6 +127,7 @@ class MiniPanApplet;
 class PanadapterStack;
 class WorkspaceCanvas;
 class WorkspaceController;
+class WorkspaceWindow;
 class AdaptiveFilterEngine;
 class AppletPanel;
 class BandPlanManager;
@@ -796,6 +797,7 @@ private:
     // Rebuilds the View-menu workspace switcher on every open (phase 6) —
     // a dynamic menu is never stale and needs no change bookkeeping.
     void rebuildWorkspaceSwitcherMenu(QMenu* menu);
+    void rebuildCanvasWindowsMenu(QMenu* menu);
 
     // Show/hide the applet panel — single source of truth that updates the
     // title-bar dock icons and the persisted "AppletPanelVisible" setting.
@@ -1243,6 +1245,10 @@ private:
     WorkspaceCanvas*     m_workspaceCanvas{nullptr};
     WorkspaceController* m_workspaceController{nullptr};
     QAction*             m_workspaceCanvasAction{nullptr};
+    // Additional canvas windows (phase 7), keyed by surface id.  A hidden
+    // window stays in the map (hide-and-keep reuses its canvas object);
+    // only remove/shutdown deletes.
+    QHash<QString, WorkspaceWindow*> m_workspaceWindows;
     QAction*             m_workspaceEditAction{nullptr};
     bool                 m_statusMessageMirrorWired{false};
     QMetaObject::Connection m_miniPanFreqConn;    // active-slice freq → mini-pan centre

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -845,6 +845,12 @@ void MainWindow::buildMenuBar()
     connect(switcher, &QMenu::aboutToShow, this,
             [this, switcher] { rebuildWorkspaceSwitcherMenu(switcher); });
 
+    // Additional canvas windows (phase 7): rebuilt on every open, same
+    // staleness rule as the switcher.
+    QMenu* canvasWindows = wsMenu->addMenu("Canvas Wi&ndows");
+    connect(canvasWindows, &QMenu::aboutToShow, this,
+            [this, canvasWindows] { rebuildCanvasWindowsMenu(canvasWindows); });
+
     // Applet-panel show/hide and pop-out are now driven entirely from the
     // title-bar dock icons (#1713 Phase 6).  Ctrl+Shift+S retained here as
     // a window-scoped QShortcut so the keystroke survives the View-menu

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -829,7 +829,7 @@ void MainWindow::buildMenuBar()
     // drops/nudges/dots).  Enabled-but-locked is the OPERATING posture —
     // interacting with an applet just uses it.  Edit state is session-
     // transient by design; wireWorkspaceCanvas() syncs both directions.
-    QMenu* wsMenu = viewMenu->addMenu("Workspace &Canvas (experimental)");
+    QMenu* wsMenu = viewMenu->addMenu("Workspace &Canvas");
     m_workspaceCanvasAction = wsMenu->addAction("&Enabled");
     m_workspaceCanvasAction->setCheckable(true);
     connect(m_workspaceCanvasAction, &QAction::toggled, this,

--- a/src/gui/MainWindow_Workspace.cpp
+++ b/src/gui/MainWindow_Workspace.cpp
@@ -21,6 +21,7 @@
 #include "core/AppSettings.h"
 #include "workspace/WorkspaceCanvas.h"
 #include "workspace/WorkspaceController.h"
+#include "workspace/WorkspaceWindow.h"
 
 #include <QAction>
 #include <QInputDialog>
@@ -100,7 +101,77 @@ void MainWindow::wireWorkspaceCanvas()
     hooks.recallGuard = [this](bool on) {
         m_appletPanel->setRecallInProgress(on);
     };
+    // Cross-top-level pan moves (phase 7): the floatPanadapter GPU recipe,
+    // split around the controller's one-step reparent.
+    hooks.prepareTopLevelMove = [this](const QString& id) {
+        m_panStack->preparePanForTopLevelMove(id);
+    };
+    hooks.finishTopLevelMove = [this](const QString& id) {
+        m_panStack->finishPanTopLevelMove(id);
+    };
     m_workspaceController->setPanHost(hooks);
+
+    // ── Additional canvas windows (RFC #4887 phase 7) ────────────────────
+    //
+    // The controller owns surface policy; this window owns the real
+    // top-level WorkspaceWindows, following FloatingContainerWindow's
+    // frameless/shutdown contract.  A hidden window is kept (its canvas
+    // object is reused on reopen — the controller's wire-once guard
+    // depends on that); only destroyWindow deletes.
+    {
+        WorkspaceController::WindowHostHooks wh;
+        wh.openWindow = [this](const QString& surfaceId, const QString& label,
+                               const QByteArray& hint) -> WorkspaceCanvas* {
+            WorkspaceWindow* w = m_workspaceWindows.value(surfaceId);
+            if (!w) {
+                w = new WorkspaceWindow(surfaceId, window());
+                m_workspaceWindows.insert(surfaceId, w);
+                connect(w, &WorkspaceWindow::closeRequested, this,
+                        [this](const QString& sid) {
+                            if (m_workspaceController) {
+                                m_workspaceController->setCanvasWindowOpen(
+                                    sid, false);
+                            }
+                        });
+                connect(w, &WorkspaceWindow::geometryHintChanged, this,
+                        [this](const QString& sid, const QByteArray& h) {
+                            if (m_workspaceController) {
+                                m_workspaceController->noteWindowGeometryHint(
+                                    sid, h);
+                            }
+                        });
+            }
+            w->setSurfaceLabel(label);
+            w->restoreFromHint(hint, this);
+            w->show();
+            w->raise();
+            return w->canvas();
+        };
+        wh.closeWindow = [this](const QString& surfaceId) {
+            if (WorkspaceWindow* w = m_workspaceWindows.value(surfaceId)) {
+                w->hide();
+            }
+        };
+        wh.destroyWindow = [this](const QString& surfaceId) {
+            if (WorkspaceWindow* w = m_workspaceWindows.take(surfaceId)) {
+                w->prepareShutdown();
+                delete w;
+            }
+        };
+        wh.setWindowLabel = [this](const QString& surfaceId,
+                                   const QString& label) {
+            if (WorkspaceWindow* w = m_workspaceWindows.value(surfaceId)) {
+                w->setSurfaceLabel(label);
+            }
+        };
+        wh.geometryHint = [this](const QString& surfaceId) -> QByteArray {
+            if (WorkspaceWindow* w = m_workspaceWindows.value(surfaceId)) {
+                return w->currentGeometryHint();
+            }
+            return QByteArray();
+        };
+        m_workspaceController->setWindowHost(wh);
+    }
 
     // The widget palette (Add widget ▸): AppletPanel owns the applet
     // universe and the category taxonomy; the controller only renders it.
@@ -538,6 +609,74 @@ void MainWindow::rebuildWorkspaceSwitcherMenu(QMenu* menu)
     }
 }
 
+void MainWindow::rebuildCanvasWindowsMenu(QMenu* menu)
+{
+    menu->clear();
+    qDeleteAll(menu->findChildren<QMenu*>(QString(), Qt::FindDirectChildrenOnly));
+    if (!m_workspaceController) {
+        return;
+    }
+    const bool enabled = m_workspaceController->isEnabled();
+    auto menuText = [](const QString& t) {
+        return QString(t).replace(QLatin1Char('&'), QStringLiteral("&&"));
+    };
+
+    const auto windows = m_workspaceController->canvasWindowList();
+    for (const auto& info : windows) {
+        // Checked = open.  Toggling is hide-and-keep in both directions.
+        QAction* a = menu->addAction(menuText(info.label));
+        a->setCheckable(true);
+        a->setChecked(info.open);
+        a->setEnabled(enabled);
+        const QString sid = info.id;
+        connect(a, &QAction::triggered, this, [this, sid](bool on) {
+            m_workspaceController->setCanvasWindowOpen(sid, on);
+        });
+    }
+    if (!windows.isEmpty()) {
+        menu->addSeparator();
+    }
+
+    QAction* add = menu->addAction(tr("New canvas window…"));
+    add->setEnabled(enabled);
+    connect(add, &QAction::triggered, this, [this] {
+        const QString label = QInputDialog::getText(
+            this, tr("New canvas window"), tr("Name:"));
+        if (!label.isEmpty()) {
+            m_workspaceController->addCanvasWindow(label);
+        }
+    });
+
+    if (windows.isEmpty()) {
+        return;
+    }
+    QMenu* renameMenu = menu->addMenu(tr("Rename"));
+    QMenu* removeMenu = menu->addMenu(tr("Remove"));
+    renameMenu->setEnabled(enabled);
+    removeMenu->setEnabled(enabled);
+    for (const auto& info : windows) {
+        const QString sid   = info.id;
+        const QString label = info.label;
+        renameMenu->addAction(menuText(label), this, [this, sid, label] {
+            const QString l = QInputDialog::getText(
+                this, tr("Rename canvas window"), tr("Name:"),
+                QLineEdit::Normal, label);
+            if (!l.isEmpty() && l != label) {
+                m_workspaceController->renameCanvasWindow(sid, l);
+            }
+        });
+        removeMenu->addAction(menuText(label), this, [this, sid, label] {
+            if (QMessageBox::question(
+                    this, tr("Remove canvas window"),
+                    tr("Remove \"%1\"? Its widgets move back to the main "
+                       "window.").arg(label))
+                == QMessageBox::Yes) {
+                m_workspaceController->removeCanvasWindow(sid);
+            }
+        });
+    }
+}
+
 QVariantMap MainWindow::automationWorkspace(const QString& action,
                                             const QString& args)
 {
@@ -559,27 +698,59 @@ QVariantMap MainWindow::automationWorkspace(const QString& action,
         out[QStringLiteral("edit")]     = m_workspaceCanvas->isEditMode();
         out[QStringLiteral("gridSnap")] = m_workspaceCanvas->isGridSnapEnabled();
         out[QStringLiteral("selected")] = m_workspaceCanvas->selectedItem();
+        // Every surface's canvas (phase 7), each item tagged with its
+        // surface so a harness can tell two windows' layouts apart.
         QVariantList items;
-        for (const CanvasItem& it : m_workspaceCanvas->layout().itemsByZ()) {
-            QVariantMap m;
-            m[QStringLiteral("id")]   = it.id;
-            m[QStringLiteral("type")] = it.contentType;
-            m[QStringLiteral("x")]    = it.rect.x;
-            m[QStringLiteral("y")]    = it.rect.y;
-            m[QStringLiteral("w")]    = it.rect.w;
-            m[QStringLiteral("h")]    = it.rect.h;
-            m[QStringLiteral("z")]    = m_workspaceCanvas->layout().zOf(it.id);
-            // Whether the widget is REALLY a canvas child right now — the
-            // model can be healthy while a stack rebuild has reclaimed the
-            // widget (the 8600 theft), and this is how a smoke proves the
-            // difference without trusting the model it is auditing.
-            QWidget* w = m_workspaceCanvas->itemWidget(it.id);
-            m[QStringLiteral("hosted")] =
-                (w && w->parentWidget() == m_workspaceCanvas);
-            items.append(m);
+        QVariantList surfaces;
+        auto reportCanvas = [&items](WorkspaceCanvas* canvas,
+                                     const QString& surfaceId) {
+            int hostedCount = 0;
+            for (const CanvasItem& it : canvas->layout().itemsByZ()) {
+                QVariantMap m;
+                m[QStringLiteral("id")]      = it.id;
+                m[QStringLiteral("type")]    = it.contentType;
+                m[QStringLiteral("surface")] = surfaceId;
+                m[QStringLiteral("x")]       = it.rect.x;
+                m[QStringLiteral("y")]       = it.rect.y;
+                m[QStringLiteral("w")]       = it.rect.w;
+                m[QStringLiteral("h")]       = it.rect.h;
+                m[QStringLiteral("z")]       = canvas->layout().zOf(it.id);
+                // Whether the widget is REALLY a child of the canvas that
+                // claims it — the model can be healthy while a stack
+                // rebuild has reclaimed the widget (the 8600 theft), and
+                // this is how a smoke proves the difference without
+                // trusting the model it is auditing.
+                QWidget* w = canvas->itemWidget(it.id);
+                const bool hosted = (w && w->parentWidget() == canvas);
+                m[QStringLiteral("hosted")] = hosted;
+                if (hosted) ++hostedCount;
+                items.append(m);
+            }
+            return hostedCount;
+        };
+        {
+            QVariantMap sm;
+            sm[QStringLiteral("id")]    = WorkspaceSurface::kMainId;
+            sm[QStringLiteral("open")]  = true;
+            sm[QStringLiteral("hostedItems")] =
+                reportCanvas(m_workspaceCanvas, WorkspaceSurface::kMainId);
+            surfaces.append(sm);
         }
-        out[QStringLiteral("items")] = items;
-        out[QStringLiteral("count")] = items.size();
+        for (const auto& info : m_workspaceController->canvasWindowList()) {
+            QVariantMap sm;
+            sm[QStringLiteral("id")]    = info.id;
+            sm[QStringLiteral("label")] = info.label;
+            sm[QStringLiteral("open")]  = info.open;
+            if (WorkspaceCanvas* canvas =
+                    m_workspaceController->canvasForSurface(info.id)) {
+                sm[QStringLiteral("hostedItems")] =
+                    reportCanvas(canvas, info.id);
+            }
+            surfaces.append(sm);
+        }
+        out[QStringLiteral("surfaces")] = surfaces;
+        out[QStringLiteral("items")]    = items;
+        out[QStringLiteral("count")]    = items.size();
         return out;
     }
 
@@ -755,6 +926,146 @@ QVariantMap MainWindow::automationWorkspace(const QString& action,
         return out;
     }
 
+    if (action == QLatin1String("window")) {
+        // window new [label] | list | open <id> | close <id> |
+        //        remove <id> | rename <id> <label>
+        const QStringList parts =
+            args.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        const QString sub = parts.value(0);
+        if (sub == QLatin1String("list") || sub.isEmpty()) {
+            QVariantList wins;
+            for (const auto& info : m_workspaceController->canvasWindowList()) {
+                QVariantMap w;
+                w[QStringLiteral("id")]    = info.id;
+                w[QStringLiteral("label")] = info.label;
+                w[QStringLiteral("open")]  = info.open;
+                wins.append(w);
+            }
+            out[QStringLiteral("windows")] = wins;
+            out[QStringLiteral("count")]   = wins.size();
+            return out;
+        }
+        if (!enabled) {
+            out[QStringLiteral("error")] = QStringLiteral("canvas mode is off");
+            return out;
+        }
+        if (sub == QLatin1String("new")) {
+            const QString label = parts.mid(1).join(QLatin1Char(' '));
+            const QString sid = m_workspaceController->addCanvasWindow(label);
+            if (sid.isEmpty()) {
+                out[QStringLiteral("error")] = QStringLiteral("create failed");
+                return out;
+            }
+            out[QStringLiteral("id")] = sid;
+            for (const auto& info : m_workspaceController->canvasWindowList()) {
+                if (info.id == sid) {
+                    // The ACTUAL label (dedup may have suffixed it) — the
+                    // create-verb lesson (review, K6OZY).
+                    out[QStringLiteral("label")] = info.label;
+                    break;
+                }
+            }
+            return out;
+        }
+        const QString sid = parts.value(1);
+        if (sub == QLatin1String("open") || sub == QLatin1String("close")) {
+            if (!m_workspaceController->setCanvasWindowOpen(
+                    sid, sub == QLatin1String("open"))) {
+                out[QStringLiteral("error")] =
+                    QStringLiteral("no such canvas window: %1").arg(sid);
+                return out;
+            }
+            out[QStringLiteral("id")]   = sid;
+            out[QStringLiteral("open")] = (sub == QLatin1String("open"));
+            return out;
+        }
+        if (sub == QLatin1String("remove")) {
+            if (!m_workspaceController->removeCanvasWindow(sid)) {
+                out[QStringLiteral("error")] =
+                    QStringLiteral("no such canvas window: %1").arg(sid);
+                return out;
+            }
+            out[QStringLiteral("removed")] = sid;
+            return out;
+        }
+        if (sub == QLatin1String("rename")) {
+            const QString label = parts.mid(2).join(QLatin1Char(' '));
+            if (label.isEmpty()
+                || !m_workspaceController->renameCanvasWindow(sid, label)) {
+                out[QStringLiteral("error")] = QStringLiteral(
+                    "rename wants <id> <label> naming an existing window");
+                return out;
+            }
+            out[QStringLiteral("id")] = sid;
+            for (const auto& info : m_workspaceController->canvasWindowList()) {
+                if (info.id == sid) {
+                    out[QStringLiteral("label")] = info.label;
+                    break;
+                }
+            }
+            return out;
+        }
+        out[QStringLiteral("error")] = QStringLiteral(
+            "window wants new|list|open|close|remove|rename");
+        return out;
+    }
+
+    if (action == QLatin1String("add")) {
+        // add <appletId> [surfaceId] — the palette engine over the bridge:
+        // opens/docks/places at the target surface's centre, refusing
+        // exactly what the menu greys (on-canvas, absent, undetected).
+        if (!enabled) {
+            out[QStringLiteral("error")] = QStringLiteral("canvas mode is off");
+            return out;
+        }
+        const QStringList parts =
+            args.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        if (parts.isEmpty()) {
+            out[QStringLiteral("error")] =
+                QStringLiteral("add wants <appletId> [surfaceId]");
+            return out;
+        }
+        const QString surfaceId = parts.value(1);
+        if (!m_workspaceController->addAppletFromPalette(
+                parts.at(0), QPointF(0.5, 0.5), surfaceId)) {
+            out[QStringLiteral("error")] =
+                QStringLiteral("cannot add %1 (on canvas already, absent, "
+                               "or hardware not detected)")
+                    .arg(parts.at(0));
+            return out;
+        }
+        out[QStringLiteral("id")] = QStringLiteral("applet:") + parts.at(0);
+        out[QStringLiteral("surface")] = m_workspaceController->surfaceHosting(
+            QStringLiteral("applet:") + parts.at(0));
+        return out;
+    }
+
+    if (action == QLatin1String("move")) {
+        if (!enabled) {
+            out[QStringLiteral("error")] = QStringLiteral("canvas mode is off");
+            return out;
+        }
+        const QStringList parts =
+            args.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        if (parts.size() != 2) {
+            out[QStringLiteral("error")] = QStringLiteral(
+                "move wants <itemId> <surfaceId>");
+            return out;
+        }
+        if (!m_workspaceController->moveItemToSurface(parts.at(0),
+                                                      parts.at(1))) {
+            out[QStringLiteral("error")] =
+                QStringLiteral("cannot move %1 to %2 (unknown item or "
+                               "surface, or shell furniture)")
+                    .arg(parts.at(0), parts.at(1));
+            return out;
+        }
+        out[QStringLiteral("id")]      = parts.at(0);
+        out[QStringLiteral("surface")] =
+            m_workspaceController->surfaceHosting(parts.at(0));
+        return out;
+    }
+
     if (action == QLatin1String("edit")) {
         // Operator posture only — `place` stays available in BOTH postures
         // (the bridge is not an operator, and tests must be able to arrange
@@ -784,13 +1095,19 @@ QVariantMap MainWindow::automationWorkspace(const QString& action,
             return out;
         }
         const QString itemId = parts.at(0);
-        if (!m_workspaceCanvas->contains(itemId)) {
+        // The item may live on any surface (phase 7) — place targets the
+        // canvas that hosts it.
+        const QString surfId = m_workspaceController->surfaceHosting(itemId);
+        WorkspaceCanvas* canvas =
+            surfId.isEmpty() ? nullptr
+                             : m_workspaceController->canvasForSurface(surfId);
+        if (!canvas) {
             out[QStringLiteral("error")] =
                 QStringLiteral("no such item: %1").arg(itemId);
             return out;
         }
         bool okX = false, okY = false, okW = true, okH = true;
-        NormRect r = m_workspaceCanvas->itemRect(itemId);
+        NormRect r = canvas->itemRect(itemId);
         r.x = parts.at(1).toDouble(&okX);
         r.y = parts.at(2).toDouble(&okY);
         if (parts.size() == 5) {
@@ -811,10 +1128,11 @@ QVariantMap MainWindow::automationWorkspace(const QString& action,
                 "coordinates must be finite with positive size");
             return out;
         }
-        m_workspaceCanvas->setItemRect(itemId, r);   // clamped; the
-        m_workspaceController->commitPlacement();    // controller records it
-        const NormRect applied = m_workspaceCanvas->itemRect(itemId);
-        out[QStringLiteral("id")] = itemId;
+        canvas->setItemRect(itemId, r);            // clamped; the
+        m_workspaceController->commitPlacement();  // controller records it
+        const NormRect applied = canvas->itemRect(itemId);
+        out[QStringLiteral("id")]      = itemId;
+        out[QStringLiteral("surface")] = surfId;
         out[QStringLiteral("x")]  = applied.x;
         out[QStringLiteral("y")]  = applied.y;
         out[QStringLiteral("w")]  = applied.w;
@@ -824,7 +1142,8 @@ QVariantMap MainWindow::automationWorkspace(const QString& action,
 
     out[QStringLiteral("error")] =
         QStringLiteral("unknown workspace action: %1 (status|enable|disable|"
-                       "edit|place|list|switch|create|bind|import-floats)")
+                       "edit|place|list|switch|create|bind|import-floats|"
+                       "palette|window|move|add)")
             .arg(action);
     return out;
 }

--- a/src/gui/MainWindow_Workspace.cpp
+++ b/src/gui/MainWindow_Workspace.cpp
@@ -736,8 +736,11 @@ QVariantMap MainWindow::automationWorkspace(const QString& action,
         };
         {
             QVariantMap sm;
-            sm[QStringLiteral("id")]    = WorkspaceSurface::kMainId;
-            sm[QStringLiteral("open")]  = true;
+            sm[QStringLiteral("id")]     = WorkspaceSurface::kMainId;
+            sm[QStringLiteral("open")]   = true;
+            // Uniform with the extra surfaces (red-team #4971 N6): main
+            // is always wanted — it cannot be closed.
+            sm[QStringLiteral("wanted")] = true;
             sm[QStringLiteral("hostedItems")] =
                 reportCanvas(m_workspaceCanvas, WorkspaceSurface::kMainId);
             surfaces.append(sm);
@@ -1040,11 +1043,27 @@ QVariantMap MainWindow::automationWorkspace(const QString& action,
             return out;
         }
         const QString surfaceId = parts.value(1);
+        // Accurate refusals (red-team #4971 N4, twice): an unknown surface
+        // is its own error, and the closed-home case names itself instead
+        // of hiding behind three reasons that are all false.
+        if (!surfaceId.isEmpty()
+            && surfaceId != WorkspaceSurface::kMainId) {
+            bool known = false;
+            for (const auto& info : m_workspaceController->canvasWindowList()) {
+                if (info.id == surfaceId) { known = true; break; }
+            }
+            if (!known) {
+                out[QStringLiteral("error")] =
+                    QStringLiteral("no such surface: %1").arg(surfaceId);
+                return out;
+            }
+        }
         if (!m_workspaceController->addAppletFromPalette(
                 parts.at(0), QPointF(0.5, 0.5), surfaceId)) {
             out[QStringLiteral("error")] =
                 QStringLiteral("cannot add %1 (on canvas already, absent, "
-                               "or hardware not detected)")
+                               "hardware not detected, or its home window "
+                               "is closed)")
                     .arg(parts.at(0));
             return out;
         }

--- a/src/gui/MainWindow_Workspace.cpp
+++ b/src/gui/MainWindow_Workspace.cpp
@@ -170,6 +170,12 @@ void MainWindow::wireWorkspaceCanvas()
             }
             return QByteArray();
         };
+        wh.applyGeometryHint = [this](const QString& surfaceId,
+                                      const QByteArray& hint) {
+            if (WorkspaceWindow* w = m_workspaceWindows.value(surfaceId)) {
+                w->restoreFromHint(hint, this);
+            }
+        };
         m_workspaceController->setWindowHost(wh);
     }
 
@@ -740,7 +746,14 @@ QVariantMap MainWindow::automationWorkspace(const QString& action,
             QVariantMap sm;
             sm[QStringLiteral("id")]    = info.id;
             sm[QStringLiteral("label")] = info.label;
-            sm[QStringLiteral("open")]  = info.open;
+            // `open` is the LIVE truth (a window exists right now);
+            // `wanted` is the document's intent.  They differ while the
+            // mode is off and during the deferred enable turn — the same
+            // honesty split the per-item `hosted` flag draws (red-team
+            // #4971 M3: `open` used to read the document and reported
+            // windows that did not exist).
+            sm[QStringLiteral("open")]   = info.live;
+            sm[QStringLiteral("wanted")] = info.open;
             if (WorkspaceCanvas* canvas =
                     m_workspaceController->canvasForSurface(info.id)) {
                 sm[QStringLiteral("hostedItems")] =
@@ -936,9 +949,10 @@ QVariantMap MainWindow::automationWorkspace(const QString& action,
             QVariantList wins;
             for (const auto& info : m_workspaceController->canvasWindowList()) {
                 QVariantMap w;
-                w[QStringLiteral("id")]    = info.id;
-                w[QStringLiteral("label")] = info.label;
-                w[QStringLiteral("open")]  = info.open;
+                w[QStringLiteral("id")]     = info.id;
+                w[QStringLiteral("label")]  = info.label;
+                w[QStringLiteral("open")]   = info.live;   // live truth (M3)
+                w[QStringLiteral("wanted")] = info.open;   // document intent
                 wins.append(w);
             }
             out[QStringLiteral("windows")] = wins;

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -972,6 +972,30 @@ PanadapterApplet* PanadapterStack::detachForCanvas(const QString& panId)
     return applet;
 }
 
+void PanadapterStack::preparePanForTopLevelMove(const QString& panId)
+{
+    PanadapterApplet* applet = m_pans.value(panId, nullptr);
+    SpectrumWidget* sw = applet ? applet->spectrumWidget() : nullptr;
+    if (!sw) return;
+    sw->hide();
+    sw->prepareForTopLevelChange();
+    sw->resetGpuResources();
+}
+
+void PanadapterStack::finishPanTopLevelMove(const QString& panId)
+{
+    PanadapterApplet* applet = m_pans.value(panId, nullptr);
+    SpectrumWidget* sw = applet ? applet->spectrumWidget() : nullptr;
+    if (!sw) return;
+    // Deferred like floatPanadapter(): the graphics API binds to the new
+    // native surface before the first render, never during the turn that
+    // moved it.
+    QTimer::singleShot(0, this, [this, sw]() {
+        refreshAfterReparent(sw);
+        sw->show();
+    });
+}
+
 void PanadapterStack::returnFromCanvas(const QString& panId,
                                        PanadapterApplet* applet)
 {

--- a/src/gui/PanadapterStack.h
+++ b/src/gui/PanadapterStack.h
@@ -91,6 +91,16 @@ public:
     PanadapterApplet* detachForCanvas(const QString& panId);
     void returnFromCanvas(const QString& panId, PanadapterApplet* applet);
 
+    // Bracket a canvas-driven reparent of this pan's widget ACROSS TOP
+    // LEVELS (RFC #4887 phase 7: additional canvas windows).  Same GPU
+    // recipe as floatPanadapter()/dockPanadapter() — hide + release the
+    // QRhi resources BEFORE the move, deferred refresh + show after —
+    // because a QRhiWidget crossing a top-level boundary without it is
+    // the #2495/#4617/#4319/#1344 crash lineage.  The move itself (a
+    // one-step reparent) is the caller's; these only own the GPU side.
+    void preparePanForTopLevelMove(const QString& panId);
+    void finishPanTopLevelMove(const QString& panId);
+
     // Float/dock panadapters
     void floatPanadapter(const QString& panId);
     void dockPanadapter(const QString& panId);

--- a/src/gui/workspace/WorkspaceCanvas.cpp
+++ b/src/gui/workspace/WorkspaceCanvas.cpp
@@ -429,17 +429,41 @@ void WorkspaceCanvas::resizeEvent(QResizeEvent* ev)
 bool WorkspaceCanvas::eventFilter(QObject* watched, QEvent* ev)
 {
     if (m_editMode && ev->type() == QEvent::MouseButtonPress) {
-        for (auto it = m_widgets.constBegin(); it != m_widgets.constEnd(); ++it) {
-            if (it.value().data() == watched) {
+        // Walk UP from wherever the press landed: an item's children
+        // consume presses before the item widget sees them — the pan's
+        // title strip eats every left press for its drag machinery, so
+        // matching `watched` directly meant the selection frame only
+        // appeared on the clicks nothing swallowed (in practice, right
+        // clicks — the 8600 field report, twice).  The app-wide filter
+        // installed for edit mode is what routes descendant presses here
+        // at all; this walk is what makes them count.
+        QWidget* w = qobject_cast<QWidget*>(watched);
+        bool matched = false;
+        while (w && w != this && !matched) {
+            for (auto it = m_widgets.constBegin(); it != m_widgets.constEnd();
+                 ++it) {
+                if (it.value().data() != w) {
+                    continue;
+                }
                 // bringItemToFront() is false when the item was already
-                // frontmost, and then nothing is emitted.  Without that, every
-                // click anywhere on the canvas would look like an edit and
-                // cost a whole-document write after the debounce — the same
-                // rule resizeEvent() follows (PR #4900 review, M2).
-                bringItemToFront(it.key());
+                // frontmost, and then nothing is emitted.  Without that,
+                // every click anywhere on the canvas would look like an
+                // edit and cost a whole-document write after the debounce
+                // — the same rule resizeEvent() follows (PR #4900 review,
+                // M2).  Pans are exempt from the raise entirely: they are
+                // the surface the station sits on, and click-raising one
+                // over the applets would undo the phase-4 stacking rule
+                // until the next replay repaired it.
+                const CanvasItem* item = m_layout.item(it.key());
+                if (!item
+                    || item->contentType != QStringLiteral("panadapter")) {
+                    bringItemToFront(it.key());
+                }
                 selectItem(it.key());
+                matched = true;
                 break;
             }
+            w = w->parentWidget();
         }
     }
     // Never consumed: raising is incidental to whatever the press was for.
@@ -505,7 +529,14 @@ void WorkspaceCanvas::setEditMode(bool on)
         return;
     }
     m_editMode = on;
-    if (!on) {
+    if (on) {
+        // Presses land on the deepest willing DESCENDANT of an item, not
+        // the item widget itself — only an app-wide filter sees them all.
+        // Install is idempotent (Qt ignores a duplicate), active only in
+        // the one posture where any click on an item must select it.
+        qApp->installEventFilter(this);
+    } else {
+        qApp->removeEventFilter(this);
         // Leaving edit mid-gesture abandons the gesture (rect restored) and
         // the selection with it — a locked canvas shows no frame.
         cancelGesture();

--- a/src/gui/workspace/WorkspaceCanvas.cpp
+++ b/src/gui/workspace/WorkspaceCanvas.cpp
@@ -98,6 +98,12 @@ WorkspaceCanvas::WorkspaceCanvas(QWidget* parent)
     setFocusPolicy(Qt::StrongFocus);   // keyboard placement (phase 5)
     setAccessibleName(QStringLiteral("Workspace canvas"));
 
+    // The bare widget DEFAULTS to edit mode without a setEditMode() call
+    // (the early-return would skip the install there), so the descendant-
+    // press filter starts installed.  Removed/re-added by setEditMode();
+    // Qt drops it automatically when the canvas is destroyed.
+    qApp->installEventFilter(this);
+
     m_frame = new CanvasItemFrame(this);
     m_gestureOverlay = new GestureOverlay(this);
 

--- a/src/gui/workspace/WorkspaceCanvas.cpp
+++ b/src/gui/workspace/WorkspaceCanvas.cpp
@@ -98,11 +98,6 @@ WorkspaceCanvas::WorkspaceCanvas(QWidget* parent)
     setFocusPolicy(Qt::StrongFocus);   // keyboard placement (phase 5)
     setAccessibleName(QStringLiteral("Workspace canvas"));
 
-    // The bare widget DEFAULTS to edit mode without a setEditMode() call
-    // (the early-return would skip the install there), so the descendant-
-    // press filter starts installed.  Removed/re-added by setEditMode();
-    // Qt drops it automatically when the canvas is destroyed.
-    qApp->installEventFilter(this);
 
     m_frame = new CanvasItemFrame(this);
     m_gestureOverlay = new GestureOverlay(this);
@@ -158,6 +153,16 @@ bool WorkspaceCanvas::addItem(const QString& id,
     content->setParent(this);
     content->installEventFilter(this);
     m_widgets.insert(id, content);
+
+    // The descendant-press filter is app-wide, so it installs only when
+    // there is something to select (red-team #4971 N3: the bare default —
+    // edit mode, zero items — had every stock session running an
+    // application-wide press filter for a feature that was switched off).
+    // installEventFilter() moves an existing registration, so this is
+    // idempotent across items.
+    if (m_editMode) {
+        qApp->installEventFilter(this);
+    }
 
     // If the widget dies without going through takeItem()/removeItem() — a
     // parent destroyed out from under us, or content someone else owns — the
@@ -440,6 +445,15 @@ bool WorkspaceCanvas::eventFilter(QObject* watched, QEvent* ev)
         QWidget* w = qobject_cast<QWidget*>(watched);
         bool matched = false;
         while (w && w != this && !matched) {
+            // Never cross a top-level boundary (red-team #4971 N5): a
+            // combo popup or a dialog opened FROM a canvas applet is
+            // parented to it, so an unbounded walk would select — and
+            // possibly raise, a whole-document write — on a click inside
+            // a popup.  Items are plain children, so every legitimate
+            // press reaches its item before any window boundary.
+            if (w->isWindow()) {
+                break;
+            }
             for (auto it = m_widgets.constBegin(); it != m_widgets.constEnd();
                  ++it) {
                 if (it.value().data() != w) {
@@ -532,9 +546,12 @@ void WorkspaceCanvas::setEditMode(bool on)
     if (on) {
         // Presses land on the deepest willing DESCENDANT of an item, not
         // the item widget itself — only an app-wide filter sees them all.
-        // Install is idempotent (Qt ignores a duplicate), active only in
-        // the one posture where any click on an item must select it.
-        qApp->installEventFilter(this);
+        // Installed only when there is something to select (N3); addItem
+        // covers the items-arrive-later case.  installEventFilter() moves
+        // an existing registration, so double-install cannot happen.
+        if (!m_widgets.isEmpty()) {
+            qApp->installEventFilter(this);
+        }
     } else {
         qApp->removeEventFilter(this);
         // Leaving edit mid-gesture abandons the gesture (rect restored) and

--- a/src/gui/workspace/WorkspaceController.cpp
+++ b/src/gui/workspace/WorkspaceController.cpp
@@ -436,6 +436,34 @@ void WorkspaceController::disable()
     releaseAllItems(/*returnPansToStack=*/true, /*hideBandStack=*/false);
     m_applying = false;
 
+    // Reopen what hide-and-keep transiently closed (red-team #4971 M2):
+    // an applet recorded open on a HIDDEN window is on no canvas, so the
+    // release sweep above never touched it — and Classic came up with an
+    // applet missing that Applet_<ID> says is open.  Disabling is not a
+    // statement about any applet; give them back to the panel, silently.
+    {
+        const WorkspaceDocument& d = m_store.document();
+        if (const Workspace* ws = d.workspace(d.activeWorkspace)) {
+            if (m_panHost.recallGuard) m_panHost.recallGuard(true);
+            m_applying = true;
+            for (const WorkspaceSurface& surf : ws->surfaces) {
+                if (!surf.hidden) continue;
+                for (const CanvasItem& it : surf.items) {
+                    if (!it.id.startsWith(kAppletItemPrefix) || it.closed) {
+                        continue;
+                    }
+                    ContainerWidget* c = containerForApplet(
+                        it.id.mid(kAppletItemPrefix.size()));
+                    if (c && !c->isContainerVisible() && !c->isFloating()) {
+                        c->setContainerVisible(true);
+                    }
+                }
+            }
+            m_applying = false;
+            if (m_panHost.recallGuard) m_panHost.recallGuard(false);
+        }
+    }
+
     // Extra canvas windows close with the mode (their hidden flags are
     // untouched — disabling is not a statement about any window); their
     // geometry hints are captured first, since hiding is how they would
@@ -478,6 +506,14 @@ void WorkspaceController::wireCanvas(WorkspaceCanvas* canvas)
         return;   // a reopened window hands back the same canvas object
     }
     m_wiredCanvases.insert(canvas);
+    // Forget the pointer the moment the canvas dies — whatever deletes it
+    // (removeCanvasWindow, resetToClassic, shutdown, or the host's own
+    // teardown).  A destroyed-watch beats manual removal at every destroy
+    // site: red-team #4971 M1 found hidden windows deleted through paths
+    // no manual remove covered, and a recycled allocation landing on a
+    // stale set entry comes up dead (e85f9c81).
+    connect(canvas, &QObject::destroyed, this,
+            [this, canvas] { m_wiredCanvases.remove(canvas); });
     canvas->setDropMimeType(kAppletMime);
 
     connect(canvas, &WorkspaceCanvas::dropReceived, this,
@@ -573,7 +609,7 @@ QString WorkspaceController::surfaceHosting(const QString& itemId) const
     return QString();
 }
 
-void WorkspaceController::reconcileWindowsWithActiveWorkspace()
+void WorkspaceController::reconcileWindowsWithActiveWorkspace(bool reapplyHints)
 {
     const WorkspaceDocument& doc = m_store.document();
     const Workspace* ws = doc.workspace(doc.activeWorkspace);
@@ -604,6 +640,15 @@ void WorkspaceController::reconcileWindowsWithActiveWorkspace()
         if (m_extraCanvases.value(s.id)) {
             if (m_windowHost.setWindowLabel) {
                 m_windowHost.setWindowLabel(s.id, s.label);
+            }
+            // On a workspace SWITCH the same surface id reuses the open
+            // window, but each workspace records its own geometry — apply
+            // the target's hint (red-team #4971 L2).  Not on every
+            // reconcile: re-applying a possibly-stale stored hint outside
+            // a switch would snap back a window the operator just dragged
+            // (the debounce is 400 ms wide).
+            if (reapplyHints && m_windowHost.applyGeometryHint) {
+                m_windowHost.applyGeometryHint(s.id, s.windowGeometry);
             }
             continue;
         }
@@ -1245,53 +1290,81 @@ void WorkspaceController::writeItemPresence(const QString& itemId,
     for (Workspace& ws : doc.workspaces) {
         if (ws.id != doc.activeWorkspace) continue;
 
-        // An EXISTING item is updated (or removed) on whichever surface
-        // holds it — presence is not a move (phase 7).  A NEW item lands
-        // on the surface whose canvas currently hosts the widget, else
-        // main.
-        for (WorkspaceSurface& s : ws.surfaces) {
-            for (int i = 0; i < s.items.size(); ++i) {
-                if (s.items.at(i).id != itemId) continue;
-                if (present) {
-                    s.items[i].rect = rect;
-                    // Making an item PRESENT is the one statement that its
-                    // applet is wanted on the surface — the closed flag
-                    // clears here, in one place, instead of at whichever
-                    // call sites remembered to (review, K6OZY: two of four
-                    // compensated by hand and the reopen-while-disabled
-                    // path cleared nothing).
-                    s.items[i].closed = false;
-                } else {
-                    s.items.removeAt(i);
+        // Find the surface that currently holds the item, if any.
+        int surfIdx = -1, itemIdx = -1;
+        for (int si = 0; si < ws.surfaces.size(); ++si) {
+            for (int ii = 0; ii < ws.surfaces.at(si).items.size(); ++ii) {
+                if (ws.surfaces.at(si).items.at(ii).id == itemId) {
+                    surfIdx = si;
+                    itemIdx = ii;
+                    break;
                 }
+            }
+            if (surfIdx >= 0) break;
+        }
+
+        if (!present) {
+            if (surfIdx >= 0) {
+                ws.surfaces[surfIdx].items.removeAt(itemIdx);
                 m_store.setDocument(doc);
                 if (flushNow) m_store.flush();
-                return;
             }
-        }
-        if (!present) {
             return;   // removing something untracked is a no-op
         }
+
+        // An EXPLICIT surfaceId is the caller stating intent — it
+        // RELOCATES an existing entry (red-team #4971 B1: the palette's
+        // target surface was silently discarded whenever the applet
+        // already had a home, so 'Add widget' on a canvas window placed
+        // on the wrong surface at the wrong size).  An IMPLICIT write
+        // (empty surfaceId) updates in place: presence is not a move.
         QString targetSurface = surfaceId;
         if (targetSurface.isEmpty()) {
-            targetSurface = surfaceHosting(itemId);
+            targetSurface = (surfIdx >= 0) ? ws.surfaces.at(surfIdx).id
+                                           : surfaceHosting(itemId);
         }
         if (targetSurface.isEmpty() || !ws.surface(targetSurface)) {
             targetSurface = WorkspaceSurface::kMainId;
         }
-        for (WorkspaceSurface& s : ws.surfaces) {
-            if (s.id != targetSurface) continue;
-            CanvasItem item;
+
+        CanvasItem item;
+        if (surfIdx >= 0) {
+            item = ws.surfaces.at(surfIdx).items.at(itemIdx);
+            if (ws.surfaces.at(surfIdx).id == targetSurface) {
+                // Making an item PRESENT is the one statement that its
+                // applet is wanted on the surface — the closed flag
+                // clears here, in one place, instead of at whichever
+                // call sites remembered to (review, K6OZY: two of four
+                // compensated by hand and the reopen-while-disabled
+                // path cleared nothing).
+                ws.surfaces[surfIdx].items[itemIdx].rect   = rect;
+                ws.surfaces[surfIdx].items[itemIdx].closed = false;
+                m_store.setDocument(doc);
+                if (flushNow) m_store.flush();
+                return;
+            }
+            ws.surfaces[surfIdx].items.removeAt(itemIdx);
+        } else {
             item.id          = itemId;
             item.contentType = contentType;
-            item.rect        = rect;
-            WorkspaceCanvas* canvas = canvasForSurface(targetSurface);
-            item.z = canvas ? canvas->layout().zOf(itemId) : 0;
-            s.items.append(item);
-            m_store.setDocument(doc);
-            if (flushNow) m_store.flush();
-            return;
         }
+        item.rect   = rect;
+        item.closed = false;
+        {
+            WorkspaceCanvas* canvas = canvasForSurface(targetSurface);
+            // Never below zero (red-team #4971 L4): the widget lands
+            // after this write, so zOf() answers -1 and a fresh applet
+            // sorted below the pans at replay.
+            item.z = canvas ? qMax(0, canvas->layout().zOf(itemId)) : 0;
+        }
+        for (WorkspaceSurface& s : ws.surfaces) {
+            if (s.id != targetSurface) continue;
+            s.items.append(item);
+            break;
+        }
+        m_store.setDocument(doc);
+        if (flushNow) m_store.flush();
+        return;
     }
 }
 
@@ -1376,11 +1449,9 @@ void WorkspaceController::resetToClassic()
             }
         }
         for (const QString& sid : extras) {
-            if (m_extraCanvases.contains(sid)) {
-                m_wiredCanvases.remove(m_extraCanvases.value(sid).data());
-                m_extraCanvases.remove(sid);
-                if (m_windowHost.destroyWindow) m_windowHost.destroyWindow(sid);
-            }
+            m_extraCanvases.remove(sid);
+            // Unconditional — hidden windows too (red-team #4971 M1).
+            if (m_windowHost.destroyWindow) m_windowHost.destroyWindow(sid);
             doc.removeSurface(doc.activeWorkspace, sid);
         }
     }
@@ -1769,6 +1840,7 @@ void WorkspaceController::evictSurfaceTransiently(const QString& surfaceId)
     if (!canvas || canvas == m_canvas) {
         return;   // the main surface never evicts wholesale
     }
+    const bool wasApplying = m_applying;   // nest-safe (review L6)
     m_applying = true;
     if (m_panHost.recallGuard) m_panHost.recallGuard(true);
     const QStringList ids = canvas->layout().ids();
@@ -1798,7 +1870,7 @@ void WorkspaceController::evictSurfaceTransiently(const QString& surfaceId)
         }
     }
     if (m_panHost.recallGuard) m_panHost.recallGuard(false);
-    m_applying = false;
+    m_applying = wasApplying;
 }
 
 void WorkspaceController::placeSurfaceItems(const QString& surfaceId)
@@ -1814,6 +1886,7 @@ void WorkspaceController::placeSurfaceItems(const QString& surfaceId)
         return;
     }
 
+    const bool wasApplying = m_applying;   // nest-safe (review L6)
     m_applying = true;
     if (m_panHost.recallGuard) m_panHost.recallGuard(true);
 
@@ -1868,7 +1941,7 @@ void WorkspaceController::placeSurfaceItems(const QString& surfaceId)
     }
 
     if (m_panHost.recallGuard) m_panHost.recallGuard(false);
-    m_applying = false;
+    m_applying = wasApplying;
 }
 
 QString WorkspaceController::addCanvasWindow(const QString& label)
@@ -1906,10 +1979,14 @@ bool WorkspaceController::removeCanvasWindow(const QString& surfaceId)
     // deleted below, so this is best-effort.
     if (m_extraCanvases.contains(surfaceId)) {
         evictSurfaceTransiently(surfaceId);
-        m_wiredCanvases.remove(m_extraCanvases.value(surfaceId).data());
         m_extraCanvases.remove(surfaceId);
-        if (m_windowHost.destroyWindow) m_windowHost.destroyWindow(surfaceId);
     }
+    // Destroy UNCONDITIONALLY (red-team #4971 M1): a hidden window is out
+    // of m_extraCanvases but its WorkspaceWindow is alive in the host —
+    // gating on the map leaked it (and re-minting its surface id later
+    // resurrected the corpse).  The host's destroy is a no-op for ids it
+    // does not hold.
+    if (m_windowHost.destroyWindow) m_windowHost.destroyWindow(surfaceId);
     if (!doc.removeSurface(doc.activeWorkspace, surfaceId)) {
         return false;
     }
@@ -1926,6 +2003,9 @@ bool WorkspaceController::removeCanvasWindow(const QString& surfaceId)
 bool WorkspaceController::renameCanvasWindow(const QString& surfaceId,
                                              const QString& label)
 {
+    if (!m_enabled) {
+        return false;   // consistency with the rest of the window CRUD
+    }
     WorkspaceDocument doc = m_store.document();
     if (!doc.renameSurface(doc.activeWorkspace, surfaceId, label)) {
         return false;
@@ -2009,6 +2089,7 @@ WorkspaceController::canvasWindowList() const
             info.id    = s.id;
             info.label = s.label.isEmpty() ? s.id : s.label;
             info.open  = !s.hidden;
+            info.live  = (canvasForSurface(s.id) != nullptr);
             out.append(info);
         }
     }
@@ -2120,6 +2201,18 @@ bool WorkspaceController::moveItemToSurface(const QString& itemId,
                 source->takeItem(itemId);
                 m_manager->returnFromCanvas(c->id(), c);
             }
+            // Coming OFF a hidden window: hide-and-keep left the applet
+            // transiently closed and on no canvas.  The move to a live
+            // surface is the operator asking to SEE it — reopen under the
+            // guard, exactly as placeSurfaceItems does on window reopen
+            // (red-team #4971 M4: the document moved, nothing appeared,
+            // and the divergence popped the applet open at the next full
+            // recall with no user action).
+            if (!moved.closed && !c->isContainerVisible() && !c->isFloating()) {
+                if (m_panHost.recallGuard) m_panHost.recallGuard(true);
+                c->setContainerVisible(true);
+                if (m_panHost.recallGuard) m_panHost.recallGuard(false);
+            }
             if (c->isContainerVisible() && !c->isFloating()
                 && m_manager->detachForCanvas(c->id()) == c) {
                 target->addItem(itemId, c, moved.rect,
@@ -2167,13 +2260,13 @@ void WorkspaceController::prepareShutdown()
         // and the panel every container — a window deleted around them
         // would take them along (they are its children at this point).
         evictSurfaceTransiently(sid);
-        // Forget the canvas pointer in the wire-once set too: a later
-        // allocation could reuse the address and would silently never be
-        // wired.
-        m_wiredCanvases.remove(m_extraCanvases.value(sid).data());
         m_extraCanvases.remove(sid);
         if (m_windowHost.destroyWindow) m_windowHost.destroyWindow(sid);
     }
+    // Hidden windows are NOT in m_extraCanvases and their widgets are
+    // already evicted — the HOST sweeps its whole window map after this
+    // (red-team #4971 M1: disable-then-quit left every canvas window to
+    // ~QWidget, the exact #2495 shape this method exists to prevent).
 }
 
 // ── Workspaces (RFC #4887 phase 6) ───────────────────────────────────────
@@ -2324,6 +2417,17 @@ bool WorkspaceController::switchWorkspaceInternal(const QString& id, bool force)
         return true;
     }
 
+    // The OLD workspace's window geometry is captured before the pivot —
+    // the hint writes must land on the workspace that owns those windows,
+    // not the one we are switching to (red-team #4971 L2).
+    for (auto it = m_extraCanvases.constBegin();
+         it != m_extraCanvases.constEnd(); ++it) {
+        if (m_windowHost.geometryHint) {
+            noteWindowGeometryHint(it.key(), m_windowHost.geometryHint(it.key()));
+        }
+    }
+    doc = m_store.document();   // the hint writes made the local copy stale
+
     // THE DOCUMENT PIVOTS FIRST (review, K6OZY): releaseAllItems() reaches
     // ContainerManager::saveState() — a real disk flush, deliberately — and
     // between it and the old document write sat the reparent storm.  A kill
@@ -2349,8 +2453,9 @@ bool WorkspaceController::switchWorkspaceInternal(const QString& id, bool force)
     // into the document.
     // Windows first (phase 7): close the ones the target does not want,
     // open the ones it does — placement below needs the canvases to
-    // exist.  The widgets were all released above.
-    reconcileWindowsWithActiveWorkspace();
+    // exist.  The widgets were all released above.  Hints re-apply: each
+    // workspace owns its windows' geometry (L2).
+    reconcileWindowsWithActiveWorkspace(/*reapplyHints=*/true);
 
     QSet<QString> wanted;
     if (const Workspace* ws = doc.workspace(id)) {
@@ -2489,6 +2594,31 @@ bool WorkspaceController::addAppletFromPalette(const QString& appletId,
     }
 
     const QString itemId = itemIdFor(c);
+
+    // Refusals come BEFORE any write (red-team #4971 B2: a refused add
+    // had already committed writeItemPresence, mangling a hidden
+    // window's stored rect with coordinates from a different canvas).
+    // With no explicit surface, the add lands wherever the item lives —
+    // and a hidden home means there is nothing to place on: refuse as a
+    // genuine no-op.  An explicit surface is intent and relocates, so a
+    // hidden home is no obstacle — but a hidden TARGET is.
+    {
+        const WorkspaceDocument& doc = m_store.document();
+        if (const Workspace* ws = doc.workspace(doc.activeWorkspace)) {
+            QString effective = surfaceId;
+            if (effective.isEmpty()) {
+                effective = docSurfaceForItem(*ws, itemId);
+            }
+            if (!effective.isEmpty()) {
+                if (const WorkspaceSurface* surf = ws->surface(effective)) {
+                    if (surf->hidden) {
+                        return false;   // its window is closed
+                    }
+                }
+            }
+        }
+    }
+
     const NormRect rect  = defaultRectFor(c, &canvasPos,
                                           canvasForSurface(surfaceId));
 
@@ -2496,7 +2626,8 @@ bool WorkspaceController::addAppletFromPalette(const QString& appletId,
     // an OPEN applet placed at the click point ON THE CANVAS THE MENU WAS
     // OPENED OVER (phase 7).  The rect is recorded first so every path
     // below places from the document — the same one-placement-path shape
-    // import-floats uses — and recording carries the surface.
+    // import-floats uses — and recording carries the surface (an explicit
+    // surface relocates a previous home, red-team #4971 B1).
     writeItemPresence(itemId, QStringLiteral("applet"), rect,
                       /*present=*/true, /*flushNow=*/false, surfaceId);
 
@@ -2552,8 +2683,14 @@ int WorkspaceController::importFloatingOntoCanvas()
             continue;
         }
         capImportRect(&mapped);
+        // Explicit main (red-team #4971 L1): the rects are mapped against
+        // the MAIN canvas, and an applet whose item lived on an extra
+        // window would otherwise import onto that window at main-mapped
+        // coordinates.  Import is main-surface by design; the explicit
+        // surface relocates a stray home.
         writeItemPresence(itemIdFor(c), QStringLiteral("applet"), mapped,
-                          /*present=*/true, /*flushNow=*/false);
+                          /*present=*/true, /*flushNow=*/false,
+                          WorkspaceSurface::kMainId);
         writeItemClosed(itemIdFor(c), false, /*flushNow=*/false);
         m_manager->dockContainer(c->id());
         if (c->isOnCanvas()) {
@@ -2584,7 +2721,8 @@ int WorkspaceController::importFloatingOntoCanvas()
             capImportRect(&mapped);
             writeItemPresence(panItemIdFor(panId),
                               QStringLiteral("panadapter"), mapped,
-                              /*present=*/true, /*flushNow=*/false);
+                              /*present=*/true, /*flushNow=*/false,
+                              WorkspaceSurface::kMainId);
             m_panHost.requestDock(panId);
             // Correct while docking places synchronously (it does — the
             // panDocked emission is direct); a future queued dock would

--- a/src/gui/workspace/WorkspaceController.cpp
+++ b/src/gui/workspace/WorkspaceController.cpp
@@ -2604,15 +2604,33 @@ bool WorkspaceController::addAppletFromPalette(const QString& appletId,
     // hidden home is no obstacle — but a hidden TARGET is.
     {
         const WorkspaceDocument& doc = m_store.document();
-        if (const Workspace* ws = doc.workspace(doc.activeWorkspace)) {
-            QString effective = surfaceId;
-            if (effective.isEmpty()) {
-                effective = docSurfaceForItem(*ws, itemId);
+        const Workspace* ws = doc.workspace(doc.activeWorkspace);
+        if (!ws) {
+            return false;
+        }
+        if (!surfaceId.isEmpty()) {
+            const WorkspaceSurface* target = ws->surface(surfaceId);
+            if (!target) {
+                // A typo'd or stale surface must be an ERROR, exactly as
+                // it is for moveItemToSurface — not a silent landing on
+                // main (red-team #4971 N4).
+                return false;
             }
-            if (!effective.isEmpty()) {
-                if (const WorkspaceSurface* surf = ws->surface(effective)) {
+            if (target->hidden) {
+                // An EXPLICIT hidden target is the operator asking to see
+                // it there — the same rule moveItemToSurface states.
+                // Reopening also re-places the window's existing items,
+                // so the add below lands on a live canvas.
+                if (!setCanvasWindowOpen(surfaceId, true)) {
+                    return false;
+                }
+            }
+        } else {
+            const QString home = docSurfaceForItem(*ws, itemId);
+            if (!home.isEmpty()) {
+                if (const WorkspaceSurface* surf = ws->surface(home)) {
                     if (surf->hidden) {
-                        return false;   // its window is closed
+                        return false;   // implicit add: its window is closed
                     }
                 }
             }

--- a/src/gui/workspace/WorkspaceController.cpp
+++ b/src/gui/workspace/WorkspaceController.cpp
@@ -1377,6 +1377,7 @@ void WorkspaceController::resetToClassic()
         }
         for (const QString& sid : extras) {
             if (m_extraCanvases.contains(sid)) {
+                m_wiredCanvases.remove(m_extraCanvases.value(sid).data());
                 m_extraCanvases.remove(sid);
                 if (m_windowHost.destroyWindow) m_windowHost.destroyWindow(sid);
             }
@@ -1905,6 +1906,7 @@ bool WorkspaceController::removeCanvasWindow(const QString& surfaceId)
     // deleted below, so this is best-effort.
     if (m_extraCanvases.contains(surfaceId)) {
         evictSurfaceTransiently(surfaceId);
+        m_wiredCanvases.remove(m_extraCanvases.value(surfaceId).data());
         m_extraCanvases.remove(surfaceId);
         if (m_windowHost.destroyWindow) m_windowHost.destroyWindow(surfaceId);
     }
@@ -2165,6 +2167,10 @@ void WorkspaceController::prepareShutdown()
         // and the panel every container — a window deleted around them
         // would take them along (they are its children at this point).
         evictSurfaceTransiently(sid);
+        // Forget the canvas pointer in the wire-once set too: a later
+        // allocation could reuse the address and would silently never be
+        // wired.
+        m_wiredCanvases.remove(m_extraCanvases.value(sid).data());
         m_extraCanvases.remove(sid);
         if (m_windowHost.destroyWindow) m_windowHost.destroyWindow(sid);
     }

--- a/src/gui/workspace/WorkspaceController.cpp
+++ b/src/gui/workspace/WorkspaceController.cpp
@@ -11,6 +11,7 @@
 
 #include <QHash>
 #include <QMenu>
+#include <QTimer>
 #include <QToolTip>
 
 #include <algorithm>
@@ -42,7 +43,18 @@ const QByteArray kAppletMime = QByteArrayLiteral("application/x-aethersdr-applet
 
 namespace {
 const QString kPanItemPrefix = QStringLiteral("pan:");
+
+// The surface an item BELONGS to per the document; empty when untracked.
+QString docSurfaceForItem(const Workspace& ws, const QString& itemId)
+{
+    for (const WorkspaceSurface& s : ws.surfaces) {
+        for (const CanvasItem& it : s.items) {
+            if (it.id == itemId) return s.id;
+        }
+    }
+    return QString();
 }
+}  // namespace
 
 const QString WorkspaceController::kPanStackItemId = QStringLiteral("panstack");
 const QString WorkspaceController::kBandStackItemId = QStringLiteral("bandstack");
@@ -57,35 +69,7 @@ WorkspaceController::WorkspaceController(ContainerManager* manager,
     Q_ASSERT(m_manager);
     Q_ASSERT(m_canvas);
 
-    m_canvas->setDropMimeType(kAppletMime);
-
-    connect(m_canvas, &WorkspaceCanvas::dropReceived,
-            this, &WorkspaceController::onDropReceived);
-    connect(m_canvas, &WorkspaceCanvas::itemRectChanged,
-            this, &WorkspaceController::onItemRectChanged);
-    connect(m_canvas, &WorkspaceCanvas::itemStackingChanged,
-            this, [this](const QString&) {
-                if (m_applying || !m_enabled) return;
-                writeStackingFromCanvas();
-            });
-
-    // Gestures (phase 5): snapshot for undo at the start, flush the debounced
-    // rect stream at the end — the auto-commit gesture boundary.
-    connect(m_canvas, &WorkspaceCanvas::gestureStarted,
-            this, [this](const QString& itemId, const NormRect& startRect) {
-                if (m_applying || !m_enabled) return;
-                m_undoItemId = itemId;
-                m_undoRect   = startRect;
-            });
-    connect(m_canvas, &WorkspaceCanvas::gestureFinished,
-            this, [this](const QString&) {
-                if (m_applying || !m_enabled) return;
-                m_store.flush();
-            });
-    connect(m_canvas, &WorkspaceCanvas::itemDraggedOut,
-            this, &WorkspaceController::onItemDraggedOut);
-    connect(m_canvas, &WorkspaceCanvas::contextMenuRequested,
-            this, &WorkspaceController::onContextMenuRequested);
+    wireCanvas(m_canvas);
 
     // Leaving the canvas through the manager — the title-bar "return to
     // panel" button, or the detour a float takes — always forgets the
@@ -204,6 +188,26 @@ bool WorkspaceController::enable(const QStringList& knownAppletIds, QString* why
     // enable and opened editing on a later one that was not first: m8.)
     m_canvas->setEditMode(justMigrated);
 
+    // Extra canvas windows open one event-loop turn later: enable() runs
+    // inside the shell-swap turn, and creating top-level surfaces there is
+    // the wl_subsurface "no parent" hazard the disable path already dodges
+    // (the compositor kills the client).  One turn lets Qt commit the
+    // reparented tree first; the windows' items place scoped, exactly as
+    // a reopened window's do.
+    QTimer::singleShot(0, this, [this] {
+        if (!m_enabled) return;
+        reconcileWindowsWithActiveWorkspace();
+        const WorkspaceDocument& d = m_store.document();
+        if (const Workspace* w = d.workspace(d.activeWorkspace)) {
+            for (const WorkspaceSurface& surf : w->surfaces) {
+                if (surf.id != WorkspaceSurface::kMainId && !surf.hidden
+                    && canvasForSurface(surf.id)) {
+                    placeSurfaceItems(surf.id);
+                }
+            }
+        }
+    });
+
     emit enabledChanged(true);
     return true;
 }
@@ -225,8 +229,13 @@ void WorkspaceController::placeActiveWorkspaceItems(WorkspaceDocument& doc,
         return;
     }
 
-    QList<CanvasItem> toPlace;
-    QHash<QString, QWidget*> widgets;
+    // Per-surface batches (phase 7): each surface restores onto its own
+    // canvas.  A hidden surface (window closed, hide-and-keep) or one
+    // whose window is not open yet places nothing — its items stay
+    // recorded, its pans stay in the (hidden) stack.
+    QHash<QString, QList<CanvasItem>> toPlace;
+    QHash<QString, QHash<QString, QWidget*>> widgets;
+    QStringList crossMovedPans;   // pans placed onto another top level
 
     // ── One-time split: the phase-3 reserved panstack item becomes per-pan
     // slot items (#4887 phase 4).  Deterministic even with zero live pans:
@@ -267,7 +276,7 @@ void WorkspaceController::placeActiveWorkspaceItems(WorkspaceDocument& doc,
         break;
     }
 
-    // ── Normalize: pans BELOW everything else, always ────────────────────
+    // ── Normalize: pans BELOW everything else, always — on EVERY surface ─
     //
     // The document's z is otherwise replayed verbatim, and a document that
     // lived through the frontmost-arrival bug (or any future mishap) would
@@ -276,8 +285,8 @@ void WorkspaceController::placeActiveWorkspaceItems(WorkspaceDocument& doc,
     // enforcing that at replay costs a deliberate pan-over-applet stacking
     // across restarts (nothing supports one today — phase 6's pinning is
     // where that would live) and buys layouts that cannot rot.
-    {
-        QList<CanvasItem> ordered = main->items;
+    for (WorkspaceSurface& surf : ws->surfaces) {
+        QList<CanvasItem> ordered = surf.items;
         std::stable_sort(ordered.begin(), ordered.end(),
                          [](const CanvasItem& a, const CanvasItem& b) {
                              return a.z < b.z;
@@ -293,11 +302,11 @@ void WorkspaceController::placeActiveWorkspaceItems(WorkspaceDocument& doc,
                 zChanged = true;
             }
         }
-        main->items = ordered;
+        surf.items = ordered;
         if (zChanged && docChanged) *docChanged = true;
     }
 
-    // ── Pans, from their slot items ──────────────────────────────────────
+    // ── Pans, from their slot items — routed to their owning surface ─────
     const QStringList livePans =
         m_panHost.panIds ? m_panHost.panIds() : QStringList{};
     for (const QString& panId : livePans) {
@@ -305,9 +314,18 @@ void WorkspaceController::placeActiveWorkspaceItems(WorkspaceDocument& doc,
             continue;   // pop-out stays (RFC decision 1)
         }
         const QString itemId = panItemIdFor(panId);
+        QString surfId = docSurfaceForItem(*ws, itemId);
+        WorkspaceSurface* surf = nullptr;
+        for (WorkspaceSurface& candidate : ws->surfaces) {
+            if (candidate.id == surfId) { surf = &candidate; break; }
+        }
+        if (!surf) {
+            surf   = main;
+            surfId = WorkspaceSurface::kMainId;
+        }
         CanvasItem item;
         bool found = false;
-        for (const CanvasItem& it : main->items) {
+        for (const CanvasItem& it : surf->items) {
             if (it.id == itemId) { item = it; found = true; break; }
         }
         if (!found) {
@@ -320,51 +338,92 @@ void WorkspaceController::placeActiveWorkspaceItems(WorkspaceDocument& doc,
             const double step = 0.05 * (slot % 5);
             item.rect        = NormRect{0.15 + step, 0.15 + step, 0.6, 0.6};
             item.z           = 0;
-            main->items.append(item);
+            surf->items.append(item);
             if (docChanged) *docChanged = true;
         }
-        item.minimumSize = QSize(320, 180);
-        QWidget* w = m_panHost.detach ? m_panHost.detach(panId) : nullptr;
-        if (!w) continue;
-        toPlace.append(item);
-        widgets.insert(itemId, w);
-    }
-
-    for (const CanvasItem& item : main->items) {
-        if (!item.id.startsWith(kAppletItemPrefix)) {
+        // A hidden window's pans stay in the (hidden) stack — the item is
+        // kept, nothing is placed (hide-and-keep).
+        if (surf->hidden || !canvasForSurface(surfId)) {
             continue;
         }
-        ContainerWidget* c = containerForApplet(item.id.mid(kAppletItemPrefix.size()));
-        // A closed-flagged item belongs to the workspace but its applet is
-        // shut (phase 6 full recall) — placement skips it.  UNLESS the
-        // applet is currently OPEN: it was reopened while the mode was off
-        // (the visibility hook early-returns there), and the operator's
-        // click outranks the stale flag (review, K6OZY) — clear and place.
-        if (item.closed) {
+        item.minimumSize = QSize(320, 180);
+        const bool cross = (surfId != WorkspaceSurface::kMainId);
+        // A pan headed for another top level takes the floatPanadapter
+        // GPU recipe: prepare BEFORE the detach-and-reparent, finish
+        // (deferred refresh + show) after restoreItems — the
+        // #2495/#4617/#4319 lineage.
+        if (cross && m_panHost.prepareTopLevelMove) {
+            m_panHost.prepareTopLevelMove(panId);
+        }
+        QWidget* w = m_panHost.detach ? m_panHost.detach(panId) : nullptr;
+        if (!w) continue;
+        toPlace[surfId].append(item);
+        widgets[surfId].insert(itemId, w);
+        if (cross) crossMovedPans.append(panId);
+    }
+
+    // ── Applets, per surface ─────────────────────────────────────────────
+    for (WorkspaceSurface& surf : ws->surfaces) {
+        WorkspaceCanvas* canvas = canvasForSurface(surf.id);
+        const bool placeable = !surf.hidden && canvas;
+        for (const CanvasItem& item : surf.items) {
+            if (!item.id.startsWith(kAppletItemPrefix)) {
+                continue;
+            }
+            ContainerWidget* c =
+                containerForApplet(item.id.mid(kAppletItemPrefix.size()));
+            if (!placeable) {
+                // Hide-and-keep: an applet recorded on a closed window is
+                // transiently shut so it cannot sit open-but-invisible
+                // behind the hidden panel.  No document write — the item
+                // and its closed flag are exactly as recorded.
+                if (c && !item.closed && c->isContainerVisible()
+                    && !c->isFloating()) {
+                    if (m_panHost.recallGuard) m_panHost.recallGuard(true);
+                    c->setContainerVisible(false);
+                    if (m_panHost.recallGuard) m_panHost.recallGuard(false);
+                }
+                continue;
+            }
+            // A closed-flagged item belongs to the workspace but its applet
+            // is shut (phase 6 full recall) — placement skips it.  UNLESS
+            // the applet is currently OPEN: it was reopened while the mode
+            // was off (the visibility hook early-returns there), and the
+            // operator's click outranks the stale flag (review, K6OZY) —
+            // clear and place.
+            if (item.closed) {
+                if (!c || !c->isContainerVisible() || c->isFloating()) {
+                    continue;
+                }
+                for (CanvasItem& live : surf.items) {
+                    if (live.id == item.id) {
+                        live.closed = false;
+                        if (docChanged) *docChanged = true;
+                        break;
+                    }
+                }
+            }
+            // Closed applets keep their home but are not placed; floating
+            // ones stay out (pop-out stays, RFC decision 1) until they dock.
             if (!c || !c->isContainerVisible() || c->isFloating()) {
                 continue;
             }
-            for (CanvasItem& live : main->items) {
-                if (live.id == item.id) {
-                    live.closed = false;
-                    if (docChanged) *docChanged = true;
-                    break;
-                }
+            if (m_manager->detachForCanvas(c->id()) != c) {
+                continue;
             }
+            toPlace[surf.id].append(item);
+            widgets[surf.id].insert(item.id, c);
         }
-        // Closed applets keep their home but are not placed; floating ones
-        // stay out (pop-out stays, RFC decision 1) until they dock.
-        if (!c || !c->isContainerVisible() || c->isFloating()) {
-            continue;
-        }
-        if (m_manager->detachForCanvas(c->id()) != c) {
-            continue;
-        }
-        toPlace.append(item);
-        widgets.insert(item.id, c);
     }
 
-    m_canvas->restoreItems(toPlace, widgets);
+    for (auto it = toPlace.constBegin(); it != toPlace.constEnd(); ++it) {
+        if (WorkspaceCanvas* canvas = canvasForSurface(it.key())) {
+            canvas->restoreItems(it.value(), widgets.value(it.key()));
+        }
+    }
+    for (const QString& panId : crossMovedPans) {
+        if (m_panHost.finishTopLevelMove) m_panHost.finishTopLevelMove(panId);
+    }
 }
 
 void WorkspaceController::disable()
@@ -376,6 +435,19 @@ void WorkspaceController::disable()
     m_applying = true;
     releaseAllItems(/*returnPansToStack=*/true, /*hideBandStack=*/false);
     m_applying = false;
+
+    // Extra canvas windows close with the mode (their hidden flags are
+    // untouched — disabling is not a statement about any window); their
+    // geometry hints are captured first, since hiding is how they would
+    // otherwise be lost.
+    const QStringList openWindows = m_extraCanvases.keys();
+    for (const QString& sid : openWindows) {
+        if (m_windowHost.geometryHint) {
+            noteWindowGeometryHint(sid, m_windowHost.geometryHint(sid));
+        }
+        m_extraCanvases.remove(sid);
+        if (m_windowHost.closeWindow) m_windowHost.closeWindow(sid);
+    }
 
     // Placement is kept — switching the mode off is not a statement about
     // any applet — only the flag changes.
@@ -391,6 +463,168 @@ void WorkspaceController::disable()
 void WorkspaceController::setPanHost(const PanHostHooks& hooks)
 {
     m_panHost = hooks;
+}
+
+void WorkspaceController::setWindowHost(const WindowHostHooks& hooks)
+{
+    m_windowHost = hooks;
+}
+
+// ── Multi-surface plumbing (phase 7) ─────────────────────────────────────
+
+void WorkspaceController::wireCanvas(WorkspaceCanvas* canvas)
+{
+    if (m_wiredCanvases.contains(canvas)) {
+        return;   // a reopened window hands back the same canvas object
+    }
+    m_wiredCanvases.insert(canvas);
+    canvas->setDropMimeType(kAppletMime);
+
+    connect(canvas, &WorkspaceCanvas::dropReceived, this,
+            [this, canvas](const QString& payload, const QPointF& pos) {
+                onDropReceived(canvas, payload, pos);
+            });
+    connect(canvas, &WorkspaceCanvas::itemRectChanged,
+            this, &WorkspaceController::onItemRectChanged);
+    connect(canvas, &WorkspaceCanvas::itemStackingChanged,
+            this, [this](const QString&) {
+                if (m_applying || !m_enabled) return;
+                writeStackingFromCanvas();
+            });
+
+    // Gestures (phase 5): snapshot for undo at the start, flush the debounced
+    // rect stream at the end — the auto-commit gesture boundary.
+    connect(canvas, &WorkspaceCanvas::gestureStarted,
+            this, [this](const QString& itemId, const NormRect& startRect) {
+                if (m_applying || !m_enabled) return;
+                m_undoItemId = itemId;
+                m_undoRect   = startRect;
+            });
+    connect(canvas, &WorkspaceCanvas::gestureFinished,
+            this, [this](const QString&) {
+                if (m_applying || !m_enabled) return;
+                m_store.flush();
+            });
+    connect(canvas, &WorkspaceCanvas::itemDraggedOut,
+            this, &WorkspaceController::onItemDraggedOut);
+    connect(canvas, &WorkspaceCanvas::contextMenuRequested, this,
+            [this, canvas](const QString& itemId, const QPoint& globalPos) {
+                onContextMenuRequested(canvas, itemId, globalPos);
+            });
+
+    // Edit posture is CONTROLLER-wide (one Edit Layout toggles every
+    // surface): mirror any canvas's flip onto all the others, guarded
+    // against the echo.
+    connect(canvas, &WorkspaceCanvas::editModeChanged, this,
+            [this](bool on) {
+                if (m_syncingEditMode) return;
+                m_syncingEditMode = true;
+                for (WorkspaceCanvas* c : attachedCanvases()) {
+                    if (c->isEditMode() != on) c->setEditMode(on);
+                }
+                m_syncingEditMode = false;
+            });
+}
+
+QList<WorkspaceCanvas*> WorkspaceController::attachedCanvases() const
+{
+    QList<WorkspaceCanvas*> out;
+    out.append(m_canvas);
+    for (auto it = m_extraCanvases.constBegin();
+         it != m_extraCanvases.constEnd(); ++it) {
+        if (it.value()) out.append(it.value().data());
+    }
+    return out;
+}
+
+WorkspaceCanvas* WorkspaceController::canvasForSurface(const QString& surfaceId) const
+{
+    if (surfaceId.isEmpty() || surfaceId == WorkspaceSurface::kMainId) {
+        return m_canvas;
+    }
+    return m_extraCanvases.value(surfaceId).data();
+}
+
+WorkspaceCanvas* WorkspaceController::canvasHolding(const QString& itemId) const
+{
+    for (WorkspaceCanvas* c : attachedCanvases()) {
+        if (c->contains(itemId)) return c;
+    }
+    return nullptr;
+}
+
+QString WorkspaceController::surfaceOf(const WorkspaceCanvas* canvas) const
+{
+    if (canvas == m_canvas) {
+        return WorkspaceSurface::kMainId;
+    }
+    for (auto it = m_extraCanvases.constBegin();
+         it != m_extraCanvases.constEnd(); ++it) {
+        if (it.value().data() == canvas) return it.key();
+    }
+    return WorkspaceSurface::kMainId;
+}
+
+QString WorkspaceController::surfaceHosting(const QString& itemId) const
+{
+    for (WorkspaceCanvas* c : attachedCanvases()) {
+        if (c->contains(itemId)) return surfaceOf(c);
+    }
+    return QString();
+}
+
+void WorkspaceController::reconcileWindowsWithActiveWorkspace()
+{
+    const WorkspaceDocument& doc = m_store.document();
+    const Workspace* ws = doc.workspace(doc.activeWorkspace);
+
+    // Close (hide) every open window the target does not want open.  The
+    // widgets were already released by the caller.
+    const QStringList openIds = m_extraCanvases.keys();
+    for (const QString& sid : openIds) {
+        bool wanted = false;
+        if (ws) {
+            for (const WorkspaceSurface& s : ws->surfaces) {
+                if (s.id == sid && !s.hidden) { wanted = true; break; }
+            }
+        }
+        if (!wanted) {
+            m_extraCanvases.remove(sid);
+            if (m_windowHost.closeWindow) m_windowHost.closeWindow(sid);
+        }
+    }
+    if (!ws) {
+        return;
+    }
+    // Open the target's visible extra surfaces and attach their canvases.
+    for (const WorkspaceSurface& s : ws->surfaces) {
+        if (s.id == WorkspaceSurface::kMainId || s.hidden) {
+            continue;
+        }
+        if (m_extraCanvases.value(s.id)) {
+            if (m_windowHost.setWindowLabel) {
+                m_windowHost.setWindowLabel(s.id, s.label);
+            }
+            continue;
+        }
+        if (!m_windowHost.openWindow) {
+            continue;
+        }
+        WorkspaceCanvas* canvas =
+            m_windowHost.openWindow(s.id, s.label, s.windowGeometry);
+        if (!canvas) {
+            continue;
+        }
+        wireCanvas(canvas);   // idempotent per canvas object
+        m_extraCanvases.insert(s.id, canvas);
+        // Posture follows the controller, and locked is the operating
+        // default — same rule as enable().
+        if (canvas->isEditMode() != m_canvas->isEditMode()) {
+            m_syncingEditMode = true;
+            canvas->setEditMode(m_canvas->isEditMode());
+            m_syncingEditMode = false;
+        }
+    }
 }
 
 // ── Pans as items (RFC #4887 phase 4) ────────────────────────────────────
@@ -471,31 +705,46 @@ bool WorkspaceController::sendPanToCanvas(const QString& panId)
         return false;   // pop-out stays (RFC decision 1)
     }
     const QString itemId = panItemIdFor(panId);
-    if (m_canvas->contains(itemId)) {
-        QWidget* placed = m_canvas->itemWidget(itemId);
-        if (placed && placed->parentWidget() == m_canvas) {
+
+    // The pan belongs to whichever surface its item is recorded on
+    // (phase 7); untracked pans land on main.  A hidden surface keeps the
+    // pan in the stack — hide-and-keep.
+    QString surfId = WorkspaceSurface::kMainId;
+    bool haveStored = false;
+    NormRect rect{0.2, 0.2, 0.6, 0.6};
+    const WorkspaceDocument& doc = m_store.document();
+    if (const Workspace* ws = doc.workspace(doc.activeWorkspace)) {
+        const QString owner = docSurfaceForItem(*ws, itemId);
+        if (!owner.isEmpty()) {
+            surfId = owner;
+            if (const WorkspaceSurface* surf = ws->surface(owner)) {
+                if (surf->hidden) {
+                    return false;   // window closed; the item stands
+                }
+                for (const CanvasItem& it : surf->items) {
+                    if (it.id == itemId) {
+                        rect       = it.rect;
+                        haveStored = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    WorkspaceCanvas* canvas = canvasForSurface(surfId);
+    if (!canvas) {
+        return false;   // window not open yet; placement follows it
+    }
+    if (canvas->contains(itemId)) {
+        QWidget* placed = canvas->itemWidget(itemId);
+        if (placed && placed->parentWidget() == canvas) {
             return true;   // genuinely placed — the state the caller asked for
         }
         // The entry is a lie: the widget was reclaimed behind the canvas's
         // back (a stack rebuild that predates the loan set, or any future
         // path that forgets it).  Heal instead of trusting: drop the stale
         // entry and fall through to a fresh detach-and-place.
-        m_canvas->releaseItem(itemId);
-    }
-
-    bool haveStored = false;
-    NormRect rect{0.2, 0.2, 0.6, 0.6};
-    const WorkspaceDocument& doc = m_store.document();
-    if (const Workspace* ws = doc.workspace(doc.activeWorkspace)) {
-        if (const WorkspaceSurface* main = ws->surface(WorkspaceSurface::kMainId)) {
-            for (const CanvasItem& it : main->items) {
-                if (it.id == itemId) {
-                    rect       = it.rect;
-                    haveStored = true;
-                    break;
-                }
-            }
-        }
+        canvas->releaseItem(itemId);
     }
     if (!haveStored) {
         // Cascade, not one shared rect (red-team B3): every defaulted pan
@@ -509,14 +758,21 @@ bool WorkspaceController::sendPanToCanvas(const QString& panId)
         rect.y = 0.15 + step;
     }
 
+    const bool cross = (surfId != WorkspaceSurface::kMainId);
+    if (cross && m_panHost.prepareTopLevelMove) {
+        m_panHost.prepareTopLevelMove(panId);   // the GPU recipe (#4617)
+    }
     QWidget* w = m_panHost.detach ? m_panHost.detach(panId) : nullptr;
     if (!w) {
         return false;
     }
-    if (!m_canvas->addItem(itemId, w, rect, QStringLiteral("panadapter"),
-                           QSize(320, 180))) {
+    if (!canvas->addItem(itemId, w, rect, QStringLiteral("panadapter"),
+                         QSize(320, 180))) {
         if (m_panHost.restore) {
             m_panHost.restore(panId, w);   // never strand a detached applet
+        }
+        if (cross && m_panHost.finishTopLevelMove) {
+            m_panHost.finishTopLevelMove(panId);
         }
         return false;
     }
@@ -528,20 +784,23 @@ bool WorkspaceController::sendPanToCanvas(const QString& panId)
     // a DEFAULTED rect is a deliberate new pan, and burying it under the
     // older pans made `pan create` invisible (red-team B3, maintainer
     // ruling): it stacks ABOVE the other pans, still below all applets.
-    m_canvas->sendItemToBack(itemId);
+    canvas->sendItemToBack(itemId);
     if (!haveStored) {
         int otherPans = 0;
-        for (const CanvasItem& it : m_canvas->layout().itemsByZ()) {
+        for (const CanvasItem& it : canvas->layout().itemsByZ()) {
             if (it.id != itemId && it.id.startsWith(kPanItemPrefix)) {
                 ++otherPans;
             }
         }
         for (int i = 0; i < otherPans; ++i) {
-            m_canvas->raiseItem(itemId);
+            canvas->raiseItem(itemId);
         }
     }
+    if (cross && m_panHost.finishTopLevelMove) {
+        m_panHost.finishTopLevelMove(panId);
+    }
     writeItemPresence(itemId, QStringLiteral("panadapter"),
-                      m_canvas->itemRect(itemId), /*present=*/true,
+                      canvas->itemRect(itemId), /*present=*/true,
                       /*flushNow=*/true);
     return true;
 }
@@ -562,7 +821,10 @@ void WorkspaceController::onPanRemoved(const QString& panId)
     // a statement about its spot, and the next pan in this slot takes it.
     const auto it = m_panSlots.constFind(panId);
     if (it != m_panSlots.constEnd()) {
-        m_canvas->releaseItem(kPanItemPrefix + QString::number(it.value()));
+        const QString itemId = kPanItemPrefix + QString::number(it.value());
+        if (WorkspaceCanvas* canvas = canvasHolding(itemId)) {
+            canvas->releaseItem(itemId);
+        }
         m_panSlots.erase(it);
     }
 }
@@ -587,7 +849,10 @@ void WorkspaceController::onPanFloated(const QString& panId)
     // docking brings it back (unlike applets, floating forgets nothing).
     const auto it = m_panSlots.constFind(panId);
     if (it != m_panSlots.constEnd()) {
-        m_canvas->releaseItem(kPanItemPrefix + QString::number(it.value()));
+        const QString itemId = kPanItemPrefix + QString::number(it.value());
+        if (WorkspaceCanvas* canvas = canvasHolding(itemId)) {
+            canvas->releaseItem(itemId);
+        }
     }
 }
 
@@ -607,22 +872,24 @@ void WorkspaceController::beginPanItemMove(const QString& panId, const QPoint& g
         return;
     }
     const QString itemId = panItemIdFor(panId);
-    if (m_canvas->contains(itemId)) {
-        m_canvas->beginMoveGesture(itemId, globalPos);
+    if (WorkspaceCanvas* canvas = canvasHolding(itemId)) {
+        canvas->beginMoveGesture(itemId, globalPos);
+        m_gestureCanvas = canvas;
     }
 }
 
 void WorkspaceController::movePanItem(const QPoint& globalPos)
 {
-    if (m_enabled) {
-        m_canvas->moveGesture(globalPos);
+    if (m_enabled && m_gestureCanvas) {
+        m_gestureCanvas->moveGesture(globalPos);
     }
 }
 
 void WorkspaceController::endPanItemMove(const QPoint& globalPos)
 {
-    if (m_enabled) {
-        m_canvas->endGesture(globalPos);
+    if (m_enabled && m_gestureCanvas) {
+        m_gestureCanvas->endGesture(globalPos);
+        m_gestureCanvas = nullptr;
     }
 }
 
@@ -689,34 +956,49 @@ bool WorkspaceController::sendAppletToCanvas(const QString& appletId,
 
     const QString itemId = itemIdFor(c);
 
+    // The applet belongs to whichever surface its item is recorded on
+    // (phase 7); untracked ones land on main.  A hidden surface keeps the
+    // applet off-canvas — hide-and-keep.
+    QString surfId = WorkspaceSurface::kMainId;
     // Placement priority: the caller's rect (a drop point), else the
     // document's remembered home, else a default sized from the widget.
     NormRect rect;
-    if (where) {
-        rect = *where;
-    } else {
-        bool haveStored = false;
+    bool haveStored = false;
+    {
         const WorkspaceDocument& doc = m_store.document();
         if (const Workspace* ws = doc.workspace(doc.activeWorkspace)) {
-            if (const WorkspaceSurface* main = ws->surface(WorkspaceSurface::kMainId)) {
-                for (const CanvasItem& it : main->items) {
-                    if (it.id == itemId) {
-                        rect       = it.rect;
-                        haveStored = true;
-                        break;
+            const QString owner = docSurfaceForItem(*ws, itemId);
+            if (!owner.isEmpty()) {
+                surfId = owner;
+                if (const WorkspaceSurface* surf = ws->surface(owner)) {
+                    if (surf->hidden) {
+                        return false;   // window closed; the item stands
+                    }
+                    for (const CanvasItem& it : surf->items) {
+                        if (it.id == itemId) {
+                            rect       = it.rect;
+                            haveStored = true;
+                            break;
+                        }
                     }
                 }
             }
         }
-        if (!haveStored) {
-            rect = defaultRectFor(c, nullptr);
-        }
+    }
+    WorkspaceCanvas* canvas = canvasForSurface(surfId);
+    if (!canvas) {
+        return false;   // window not open yet; placement follows it
+    }
+    if (where) {
+        rect = *where;
+    } else if (!haveStored) {
+        rect = defaultRectFor(c, nullptr);
     }
 
     if (m_manager->detachForCanvas(c->id()) != c) {
         return false;
     }
-    if (!m_canvas->addItem(itemId, c, rect, QStringLiteral("applet"))) {
+    if (!canvas->addItem(itemId, c, rect, QStringLiteral("applet"))) {
         // Should not happen (id collisions are checked above), but never
         // strand a detached widget: put it straight back.
         m_manager->returnFromCanvas(c->id(), c);
@@ -725,7 +1007,7 @@ bool WorkspaceController::sendAppletToCanvas(const QString& appletId,
 
     // The canvas clamped the rect; persist what is actually on screen.
     writeItemPresence(itemId, QStringLiteral("applet"),
-                      m_canvas->itemRect(itemId), /*present=*/true,
+                      canvas->itemRect(itemId), /*present=*/true,
                       /*flushNow=*/true);
     return true;
 }
@@ -753,13 +1035,17 @@ void WorkspaceController::evictFromCanvas(ContainerWidget* c, bool forgetHome)
                           /*present=*/false, /*flushNow=*/true);
     }
 
-    m_canvas->takeItem(itemId);
+    if (WorkspaceCanvas* canvas = canvasHolding(itemId)) {
+        canvas->takeItem(itemId);
+    }
     m_manager->returnFromCanvas(c->id(), c);
 }
 
 // ── Canvas events ────────────────────────────────────────────────────────
 
-void WorkspaceController::onDropReceived(const QString& payload, const QPointF& pos)
+void WorkspaceController::onDropReceived(WorkspaceCanvas* canvas,
+                                         const QString& payload,
+                                         const QPointF& pos)
 {
     if (!m_enabled) {
         return;
@@ -768,23 +1054,40 @@ void WorkspaceController::onDropReceived(const QString& payload, const QPointF& 
     if (!c) {
         return;
     }
+    const QString itemId = itemIdFor(c);
 
     if (c->isOnCanvas()) {
+        WorkspaceCanvas* holder = canvasHolding(itemId);
+        if (holder && holder != canvas) {
+            // Dragged from one window's panel strip onto ANOTHER canvas:
+            // that is a move between surfaces (phase 7), through the one
+            // path that owns cross-top-level reparents.
+            moveItemToSurface(itemId, surfaceOf(canvas));
+            holder = canvasHolding(itemId);
+        }
+        if (!holder) {
+            return;
+        }
         // Move: keep the size, centre the item on the drop point, and let
         // the canvas clamp.  itemRectChanged writes the document; this is a
         // discrete gesture, so flush behind it.
-        const QString itemId = itemIdFor(c);
-        const NormRect cur   = m_canvas->itemRect(itemId);
-        NormRect moved       = cur;
-        moved.x              = pos.x() - cur.w / 2.0;
-        moved.y              = pos.y() - cur.h / 2.0;
-        m_canvas->setItemRect(itemId, moved);
+        const NormRect cur = holder->itemRect(itemId);
+        NormRect moved     = cur;
+        moved.x            = pos.x() - cur.w / 2.0;
+        moved.y            = pos.y() - cur.h / 2.0;
+        holder->setItemRect(itemId, moved);
         m_store.flush();
         return;
     }
 
-    NormRect rect = defaultRectFor(c, &pos);
+    // A drop lands on the canvas it was dropped on: record the home there
+    // first, then send — sendAppletToCanvas routes by the document.
+    NormRect rect = defaultRectFor(c, &pos, canvas);
+    writeItemPresence(itemId, QStringLiteral("applet"), rect,
+                      /*present=*/true, /*flushNow=*/false,
+                      surfaceOf(canvas));
     sendAppletToCanvas(appletIdFor(c), &rect);
+    m_store.flush();
 }
 
 void WorkspaceController::onItemRectChanged(const QString& itemId, const NormRect& rect)
@@ -812,20 +1115,23 @@ void WorkspaceController::wireContainer(ContainerWidget* c)
     // session makes the item follow the cursor with snapping.
     connect(c, &ContainerWidget::canvasDragBegan, this,
             [this, c](const QPoint& g) {
-                if (m_enabled && c->isOnCanvas()) {
-                    m_canvas->beginMoveGesture(itemIdFor(c), g);
+                if (!m_enabled || !c->isOnCanvas()) return;
+                if (WorkspaceCanvas* canvas = canvasHolding(itemIdFor(c))) {
+                    canvas->beginMoveGesture(itemIdFor(c), g);
+                    m_gestureCanvas = canvas;
                 }
             });
     connect(c, &ContainerWidget::canvasDragMoved, this,
             [this, c](const QPoint& g) {
-                if (m_enabled && c->isOnCanvas()) {
-                    m_canvas->moveGesture(g);
+                if (m_enabled && c->isOnCanvas() && m_gestureCanvas) {
+                    m_gestureCanvas->moveGesture(g);
                 }
             });
     connect(c, &ContainerWidget::canvasDragEnded, this,
             [this, c](const QPoint& g) {
-                if (m_enabled && c->isOnCanvas()) {
-                    m_canvas->endGesture(g);
+                if (m_enabled && c->isOnCanvas() && m_gestureCanvas) {
+                    m_gestureCanvas->endGesture(g);
+                    m_gestureCanvas = nullptr;
                 }
             });
 
@@ -846,16 +1152,11 @@ void WorkspaceController::wireContainer(ContainerWidget* c)
         } else if (visible && !c->isOnCanvas() && !c->isFloating()) {
             const WorkspaceDocument& doc = m_store.document();
             if (const Workspace* ws = doc.workspace(doc.activeWorkspace)) {
-                if (const WorkspaceSurface* main =
-                        ws->surface(WorkspaceSurface::kMainId)) {
-                    for (const CanvasItem& it : main->items) {
-                        if (it.id == itemIdFor(c)) {
-                            // sendAppletToCanvas's writeItemPresence clears
-                            // the closed flag — the invariant lives there.
-                            sendAppletToCanvas(appletIdFor(c));
-                            break;
-                        }
-                    }
+                if (!docSurfaceForItem(*ws, itemIdFor(c)).isEmpty()) {
+                    // sendAppletToCanvas's writeItemPresence clears the
+                    // closed flag — the invariant lives there — and the
+                    // send routes to the item's own surface (phase 7).
+                    sendAppletToCanvas(appletIdFor(c));
                 }
             }
         }
@@ -872,14 +1173,8 @@ void WorkspaceController::wireContainer(ContainerWidget* c)
                 if (!c->isContainerVisible()) return;
                 const WorkspaceDocument& doc = m_store.document();
                 if (const Workspace* ws = doc.workspace(doc.activeWorkspace)) {
-                    if (const WorkspaceSurface* main =
-                            ws->surface(WorkspaceSurface::kMainId)) {
-                        for (const CanvasItem& it : main->items) {
-                            if (it.id == itemIdFor(c)) {
-                                sendAppletToCanvas(appletIdFor(c));
-                                break;
-                            }
-                        }
+                    if (!docSurfaceForItem(*ws, itemIdFor(c)).isEmpty()) {
+                        sendAppletToCanvas(appletIdFor(c));
                     }
                 }
             });
@@ -893,8 +1188,9 @@ void WorkspaceController::writeItemRect(const QString& itemId, const NormRect& r
     WorkspaceDocument doc = m_store.document();
     for (Workspace& ws : doc.workspaces) {
         if (ws.id != doc.activeWorkspace) continue;
+        // Item ids are workspace-wide identity: whichever surface holds
+        // the item is where the rect lands (phase 7).
         for (WorkspaceSurface& s : ws.surfaces) {
-            if (s.id != WorkspaceSurface::kMainId) continue;
             for (CanvasItem& it : s.items) {
                 if (it.id == itemId) {
                     it.rect = rect;
@@ -927,7 +1223,6 @@ void WorkspaceController::writeItemClosed(const QString& itemId, bool closed,
     for (Workspace& ws : doc.workspaces) {
         if (ws.id != doc.activeWorkspace) continue;
         for (WorkspaceSurface& s : ws.surfaces) {
-            if (s.id != WorkspaceSurface::kMainId) continue;
             for (CanvasItem& it : s.items) {
                 if (it.id == itemId && it.closed != closed) {
                     it.closed = closed;
@@ -943,41 +1238,56 @@ void WorkspaceController::writeItemClosed(const QString& itemId, bool closed,
 void WorkspaceController::writeItemPresence(const QString& itemId,
                                             const QString& contentType,
                                             const NormRect& rect, bool present,
-                                            bool flushNow)
+                                            bool flushNow,
+                                            const QString& surfaceId)
 {
     WorkspaceDocument doc = m_store.document();
     for (Workspace& ws : doc.workspaces) {
         if (ws.id != doc.activeWorkspace) continue;
+
+        // An EXISTING item is updated (or removed) on whichever surface
+        // holds it — presence is not a move (phase 7).  A NEW item lands
+        // on the surface whose canvas currently hosts the widget, else
+        // main.
         for (WorkspaceSurface& s : ws.surfaces) {
-            if (s.id != WorkspaceSurface::kMainId) continue;
-
-            int found = -1;
             for (int i = 0; i < s.items.size(); ++i) {
-                if (s.items.at(i).id == itemId) { found = i; break; }
-            }
-
-            if (present) {
-                if (found >= 0) {
-                    s.items[found].rect = rect;
+                if (s.items.at(i).id != itemId) continue;
+                if (present) {
+                    s.items[i].rect = rect;
                     // Making an item PRESENT is the one statement that its
                     // applet is wanted on the surface — the closed flag
                     // clears here, in one place, instead of at whichever
                     // call sites remembered to (review, K6OZY: two of four
                     // compensated by hand and the reopen-while-disabled
                     // path cleared nothing).
-                    s.items[found].closed = false;
+                    s.items[i].closed = false;
                 } else {
-                    CanvasItem item;
-                    item.id          = itemId;
-                    item.contentType = contentType;
-                    item.rect        = rect;
-                    item.z           = m_canvas->layout().zOf(itemId);
-                    s.items.append(item);
+                    s.items.removeAt(i);
                 }
-            } else if (found >= 0) {
-                s.items.removeAt(found);
+                m_store.setDocument(doc);
+                if (flushNow) m_store.flush();
+                return;
             }
-
+        }
+        if (!present) {
+            return;   // removing something untracked is a no-op
+        }
+        QString targetSurface = surfaceId;
+        if (targetSurface.isEmpty()) {
+            targetSurface = surfaceHosting(itemId);
+        }
+        if (targetSurface.isEmpty() || !ws.surface(targetSurface)) {
+            targetSurface = WorkspaceSurface::kMainId;
+        }
+        for (WorkspaceSurface& s : ws.surfaces) {
+            if (s.id != targetSurface) continue;
+            CanvasItem item;
+            item.id          = itemId;
+            item.contentType = contentType;
+            item.rect        = rect;
+            WorkspaceCanvas* canvas = canvasForSurface(targetSurface);
+            item.z = canvas ? canvas->layout().zOf(itemId) : 0;
+            s.items.append(item);
             m_store.setDocument(doc);
             if (flushNow) m_store.flush();
             return;
@@ -991,9 +1301,10 @@ void WorkspaceController::writeStackingFromCanvas()
     for (Workspace& ws : doc.workspaces) {
         if (ws.id != doc.activeWorkspace) continue;
         for (WorkspaceSurface& s : ws.surfaces) {
-            if (s.id != WorkspaceSurface::kMainId) continue;
+            WorkspaceCanvas* canvas = canvasForSurface(s.id);
+            if (!canvas) continue;   // hidden window: stored z stands
             for (CanvasItem& it : s.items) {
-                const int z = m_canvas->layout().zOf(it.id);
+                const int z = canvas->layout().zOf(it.id);
                 if (z >= 0) it.z = z;
             }
         }
@@ -1014,14 +1325,15 @@ bool WorkspaceController::undoLastPlacement()
     if (!m_enabled || !canUndo()) {
         return false;
     }
-    if (!m_canvas->layout().contains(m_undoItemId)) {
+    WorkspaceCanvas* canvas = canvasHolding(m_undoItemId);
+    if (!canvas) {
         m_undoItemId.clear();
         return false;
     }
     // Swap current and remembered: undoing twice toggles, which is the
     // single-slot version of redo.
-    const NormRect current = m_canvas->itemRect(m_undoItemId);
-    m_canvas->setItemRect(m_undoItemId, m_undoRect);
+    const NormRect current = canvas->itemRect(m_undoItemId);
+    canvas->setItemRect(m_undoItemId, m_undoRect);
     m_undoRect = current;
     m_store.flush();
     return true;
@@ -1035,39 +1347,42 @@ void WorkspaceController::resetToClassic()
 
     m_applying = true;
 
-    // Everything off the surface: applets back to their panel slots, pans
-    // merely RELEASED (they stay parented to the canvas; the re-place below
-    // re-adds them — no nullptr detour, #1344), the band stack re-homed and
-    // hidden (Classic is the stock shell, and the stock shell shows none).
-    const QStringList ids = m_canvas->layout().ids();
-    for (const QString& itemId : ids) {
-        if (itemId.startsWith(kPanItemPrefix)) {
-            m_canvas->releaseItem(itemId);
-            continue;
-        }
-        if (itemId == kBandStackItemId) {
-            QWidget* w = m_canvas->releaseItem(itemId);
-            if (w && m_panHost.reclaimBandStack) {
-                m_panHost.reclaimBandStack(w);
-            }
-            if (w) w->hide();
-            continue;
-        }
-        if (itemId == kPanStackItemId) {
-            m_canvas->takeItem(itemId);
-            continue;
-        }
-        QWidget* w = m_canvas->takeItem(itemId);
-        if (auto* c = qobject_cast<ContainerWidget*>(w)) {
-            m_manager->returnFromCanvas(c->id(), c);
-        }
-    }
+    // Everything off EVERY surface: applets back to their panel slots
+    // (open), main-canvas pans merely released (they stay parented; the
+    // re-place below re-adds them — no nullptr detour, #1344), extra-
+    // window pans back to the stack through the GPU recipe, the band
+    // stack re-homed and hidden (Classic is the stock shell, and the
+    // stock shell shows none).
+    releaseAllItems(/*returnPansToStack=*/false, /*hideBandStack=*/true);
 
     // Classic is re-derived from the same legacy keys the first enable
     // migrated from — the panel still dual-writes them, so this reflects
     // the operator's CURRENT open applets and order, not a stale snapshot.
     // One definition of Classic, used everywhere (WorkspaceMigration).
     WorkspaceDocument doc = m_store.document();
+
+    // Classic is the STOCK shell, and the stock shell is one window: the
+    // active workspace's extra surfaces collapse (phase 7).  removeSurface
+    // parks their items on main, where the fresh Classic composition below
+    // overwrites them — reset is authoritative, that is its whole promise
+    // ("back to a sane shell in one action").
+    {
+        QStringList extras;
+        if (const Workspace* ws = doc.workspace(doc.activeWorkspace)) {
+            for (const WorkspaceSurface& surf : ws->surfaces) {
+                if (surf.id != WorkspaceSurface::kMainId) {
+                    extras.append(surf.id);
+                }
+            }
+        }
+        for (const QString& sid : extras) {
+            if (m_extraCanvases.contains(sid)) {
+                m_extraCanvases.remove(sid);
+                if (m_windowHost.destroyWindow) m_windowHost.destroyWindow(sid);
+            }
+            doc.removeSurface(doc.activeWorkspace, sid);
+        }
+    }
     // Classic is composed against the pans' ACTUAL slots — sparse and all
     // (review, K6OZY): the old global renumber fixed the active workspace
     // and orphaned every OTHER workspace's pan items, since slots are the
@@ -1103,17 +1418,21 @@ void WorkspaceController::resetToClassic()
     m_undoItemId.clear();   // a whole-surface change; a one-rect undo would lie
     m_store.setDocument(doc);
     m_store.flush();
+    emit workspacesChanged();   // the window list may have collapsed
 }
 
-void WorkspaceController::tidyLayout()
+void WorkspaceController::tidyLayout(WorkspaceCanvas* canvas)
 {
     if (!m_enabled) {
         return;
     }
+    if (!canvas) {
+        canvas = m_canvas;
+    }
 
     QList<CanvasItem> items;
     QStringList fixedIds{kPanStackItemId};
-    for (const CanvasItem& it : m_canvas->layout().itemsByZ()) {
+    for (const CanvasItem& it : canvas->layout().itemsByZ()) {
         items.append(it);
         // Every pan item is fixed: an applet overlapping the spectrum is a
         // feature (the phase-5 rule), and tidy shoving the spectrum itself
@@ -1125,7 +1444,7 @@ void WorkspaceController::tidyLayout()
     const QList<TidyMove> moves = tidyOverlaps(items, fixedIds);
 
     for (const TidyMove& mv : moves) {
-        m_canvas->setItemRect(mv.id, mv.rect);   // rect stream → touch
+        canvas->setItemRect(mv.id, mv.rect);   // rect stream → touch
     }
     if (!moves.isEmpty()) {
         m_undoItemId.clear();   // multi-item change; single-slot undo is out
@@ -1155,10 +1474,11 @@ void WorkspaceController::onItemDraggedOut(const QString& itemId,
     }
 }
 
-void WorkspaceController::onContextMenuRequested(const QString& itemId,
+void WorkspaceController::onContextMenuRequested(WorkspaceCanvas* canvas,
+                                                 const QString& itemId,
                                                  const QPoint& globalPos)
 {
-    if (!m_enabled) {
+    if (!m_enabled || !canvas) {
         return;
     }
 
@@ -1166,10 +1486,10 @@ void WorkspaceController::onContextMenuRequested(const QString& itemId,
 
     // Edit Layout leads in BOTH postures — it is the door between them —
     // and everything below it is placement, so a locked canvas shows only
-    // the door.
+    // the door.  Posture is controller-wide; any canvas answers for all.
     QAction* editToggle = menu.addAction(QStringLiteral("Edit layout"));
     editToggle->setCheckable(true);
-    editToggle->setChecked(m_canvas->isEditMode());
+    editToggle->setChecked(canvas->isEditMode());
     connect(editToggle, &QAction::toggled, this,
             [this](bool on) { m_canvas->setEditMode(on); });
 
@@ -1203,12 +1523,13 @@ void WorkspaceController::onContextMenuRequested(const QString& itemId,
                            " background: {{color.accent.dim}};"
                            " color: {{color.background.0}}; }"));
         const QPointF canvasPos =
-            m_canvas->rect().isEmpty()
+            canvas->rect().isEmpty()
                 ? QPointF(0.5, 0.5)
-                : QPointF(m_canvas->mapFromGlobal(globalPos).x()
-                              / double(m_canvas->width()),
-                          m_canvas->mapFromGlobal(globalPos).y()
-                              / double(m_canvas->height()));
+                : QPointF(canvas->mapFromGlobal(globalPos).x()
+                              / double(canvas->width()),
+                          canvas->mapFromGlobal(globalPos).y()
+                              / double(canvas->height()));
+        const QString menuSurface = surfaceOf(canvas);
 
         const QList<PaletteEntry> pal = paletteState();
         QStringList categoryOrder;
@@ -1258,9 +1579,11 @@ void WorkspaceController::onContextMenuRequested(const QString& itemId,
                     const QString appletId = e.id;
                     const QString title    = e.title;
                     connect(a, &QAction::triggered, this,
-                            [this, appletId, title, canvasPos, globalPos] {
+                            [this, appletId, title, canvasPos, globalPos,
+                             menuSurface] {
                                 if (!addAppletFromPalette(appletId,
-                                                          canvasPos)) {
+                                                          canvasPos,
+                                                          menuSurface)) {
                                     // Detection flipped between menu build
                                     // and click (#4968 m1) — a refused add
                                     // must never be a silent no-op.
@@ -1279,7 +1602,7 @@ void WorkspaceController::onContextMenuRequested(const QString& itemId,
     }
 
 
-    if (!m_canvas->isEditMode()) {
+    if (!canvas->isEditMode()) {
         menu.exec(globalPos);
         return;
     }
@@ -1288,6 +1611,44 @@ void WorkspaceController::onContextMenuRequested(const QString& itemId,
     const bool onApplet =
         !itemId.isEmpty() && itemId.startsWith(kAppletItemPrefix);
     const bool onPan = !itemId.isEmpty() && itemId.startsWith(kPanItemPrefix);
+
+    // Move to ▸ (phase 7, maintainer ruling: the menu IS the move
+    // mechanism this phase) — one deliberate action through the one path
+    // that owns cross-top-level reparents.  Applets and pans only; the
+    // band stack and the phase-3 panstack are shell furniture.
+    if (onApplet || onPan) {
+        QMenu* moveMenu = menu.addMenu(QStringLiteral("Move to"));
+        const QString here = surfaceOf(canvas);
+        if (here != WorkspaceSurface::kMainId) {
+            moveMenu->addAction(QStringLiteral("Main window"), this,
+                                [this, itemId] {
+                                    moveItemToSurface(
+                                        itemId, WorkspaceSurface::kMainId);
+                                });
+        }
+        for (const CanvasWindowInfo& info : canvasWindowList()) {
+            if (info.id == here) continue;
+            const QString sid = info.id;
+            // A hidden window is a legal target: moving something to it
+            // reopens it (moveItemToSurface clears the flag).
+            moveMenu->addAction(
+                menuText(info.label)
+                    + (info.open ? QString() : tr(" (closed)")),
+                this, [this, itemId, sid] {
+                    moveItemToSurface(itemId, sid);
+                });
+        }
+        moveMenu->addSeparator();
+        moveMenu->addAction(QStringLiteral("New canvas window"), this,
+                            [this, itemId] {
+                                const QString sid =
+                                    addCanvasWindow(QString());
+                                if (!sid.isEmpty()) {
+                                    moveItemToSurface(itemId, sid);
+                                }
+                            });
+        menu.addSeparator();
+    }
 
     if (onPan) {
         const QString panId = panIdForItem(itemId);
@@ -1306,7 +1667,7 @@ void WorkspaceController::onContextMenuRequested(const QString& itemId,
         // Deliberate pan-over-applet layering arrives with phase 6's
         // pinning, as a property the normalization respects.
         menu.addAction(QStringLiteral("Send to back"), this,
-                       [this, itemId] { m_canvas->sendItemToBack(itemId); });
+                       [canvas, itemId] { canvas->sendItemToBack(itemId); });
         menu.addSeparator();
     }
     if (itemId == kBandStackItemId) {
@@ -1320,23 +1681,23 @@ void WorkspaceController::onContextMenuRequested(const QString& itemId,
         menu.addAction(QStringLiteral("Return to panel"), this,
                        [this, appletId] { returnAppletToPanel(appletId); });
         menu.addAction(QStringLiteral("Bring to front"), this,
-                       [this, itemId] { m_canvas->bringItemToFront(itemId); });
+                       [canvas, itemId] { canvas->bringItemToFront(itemId); });
         menu.addAction(QStringLiteral("Send to back"), this,
-                       [this, itemId] { m_canvas->sendItemToBack(itemId); });
+                       [canvas, itemId] { canvas->sendItemToBack(itemId); });
         menu.addSeparator();
     }
 
     QAction* gridSnap = menu.addAction(QStringLiteral("Snap to grid"));
     gridSnap->setCheckable(true);
-    gridSnap->setChecked(m_canvas->isGridSnapEnabled());
+    gridSnap->setChecked(canvas->isGridSnapEnabled());
     connect(gridSnap, &QAction::toggled, this,
-            [this](bool on) { m_canvas->setGridSnapEnabled(on); });
+            [canvas](bool on) { canvas->setGridSnapEnabled(on); });
 
     QAction* undo = menu.addAction(QStringLiteral("Undo last placement"), this,
                                    [this] { undoLastPlacement(); });
     undo->setEnabled(canUndo());
     menu.addAction(QStringLiteral("Tidy layout"), this,
-                   [this] { tidyLayout(); });
+                   [this, canvas] { tidyLayout(canvas); });
     menu.addAction(QStringLiteral("Reset layout to Classic"), this,
                    [this] { resetToClassic(); });
 
@@ -1346,41 +1707,466 @@ void WorkspaceController::onContextMenuRequested(const QString& itemId,
 void WorkspaceController::releaseAllItems(bool returnPansToStack,
                                           bool hideBandStack)
 {
-    const QStringList ids = m_canvas->layout().ids();
+    for (WorkspaceCanvas* canvas : attachedCanvases()) {
+        // A pan leaving an EXTRA canvas crosses top levels either way —
+        // back to the stack now, or detached again by the placement that
+        // follows — so it always returns to the stack here, wrapped in
+        // the GPU recipe.  Main-canvas pans keep the fast path: on a
+        // switch they stay parented and the re-place is same-top-level.
+        const bool cross = (canvas != m_canvas);
+        const QStringList ids = canvas->layout().ids();
+        for (const QString& itemId : ids) {
+            if (itemId.startsWith(kPanItemPrefix)) {
+                // Release, never take: the restore hook reparents in ONE
+                // step (addWidget), and the nullptr detour is forbidden
+                // for QRhi children (#1344).
+                const QString panId = panIdForItem(itemId);
+                const bool toStack = returnPansToStack || cross;
+                if (cross && !panId.isEmpty()
+                    && m_panHost.prepareTopLevelMove) {
+                    m_panHost.prepareTopLevelMove(panId);
+                }
+                QWidget* w = canvas->releaseItem(itemId);
+                if (toStack && w && !panId.isEmpty() && m_panHost.restore) {
+                    m_panHost.restore(panId, w);
+                }
+                if (cross && !panId.isEmpty()
+                    && m_panHost.finishTopLevelMove) {
+                    m_panHost.finishTopLevelMove(panId);
+                }
+                continue;
+            }
+            if (itemId == kBandStackItemId) {
+                QWidget* w = canvas->releaseItem(itemId);
+                if (w && m_panHost.reclaimBandStack) {
+                    m_panHost.reclaimBandStack(w);
+                }
+                if (w && hideBandStack) {
+                    w->hide();   // session-transient; a switch starts it hidden
+                }
+                continue;
+            }
+            if (itemId == kPanStackItemId) {
+                // Phase-3 document robustness: released parentless;
+                // MainWindow puts it back in the splitter.
+                canvas->takeItem(itemId);
+                continue;
+            }
+            QWidget* w = canvas->takeItem(itemId);
+            if (auto* c = qobject_cast<ContainerWidget*>(w)) {
+                m_manager->returnFromCanvas(c->id(), c);
+            }
+        }
+    }
+}
+
+// ── Additional canvas windows (RFC #4887 phase 7) ────────────────────────
+
+void WorkspaceController::evictSurfaceTransiently(const QString& surfaceId)
+{
+    WorkspaceCanvas* canvas = canvasForSurface(surfaceId);
+    if (!canvas || canvas == m_canvas) {
+        return;   // the main surface never evicts wholesale
+    }
+    m_applying = true;
+    if (m_panHost.recallGuard) m_panHost.recallGuard(true);
+    const QStringList ids = canvas->layout().ids();
     for (const QString& itemId : ids) {
         if (itemId.startsWith(kPanItemPrefix)) {
-            // Release, never take: the restore hook reparents in ONE step
-            // (addWidget), and the nullptr detour is forbidden for QRhi
-            // children (#1344).  On a workspace SWITCH the pan stays
-            // parented to the canvas — the placement that follows re-adds
-            // it, a canvas→canvas move.
-            QWidget* w = m_canvas->releaseItem(itemId);
             const QString panId = panIdForItem(itemId);
-            if (returnPansToStack && w && !panId.isEmpty() && m_panHost.restore) {
-                m_panHost.restore(panId, w);
+            if (!panId.isEmpty() && m_panHost.prepareTopLevelMove) {
+                m_panHost.prepareTopLevelMove(panId);
+            }
+            QWidget* w = canvas->releaseItem(itemId);
+            if (w && !panId.isEmpty() && m_panHost.restore) {
+                m_panHost.restore(panId, w);   // back to the hidden stack
+            }
+            if (!panId.isEmpty() && m_panHost.finishTopLevelMove) {
+                m_panHost.finishTopLevelMove(panId);
             }
             continue;
         }
-        if (itemId == kBandStackItemId) {
-            QWidget* w = m_canvas->releaseItem(itemId);
-            if (w && m_panHost.reclaimBandStack) {
-                m_panHost.reclaimBandStack(w);
-            }
-            if (w && hideBandStack) {
-                w->hide();   // session-transient; a switch starts it hidden
-            }
-            continue;
-        }
-        if (itemId == kPanStackItemId) {
-            // Phase-3 document robustness: released parentless; MainWindow
-            // puts it back in the splitter.
-            m_canvas->takeItem(itemId);
-            continue;
-        }
-        QWidget* w = m_canvas->takeItem(itemId);
+        QWidget* w = canvas->takeItem(itemId);
         if (auto* c = qobject_cast<ContainerWidget*>(w)) {
             m_manager->returnFromCanvas(c->id(), c);
+            // Transiently closed (hide-and-keep): no document write, so
+            // the item and its closed flag stay exactly as recorded and
+            // reopening the window restores this applet open.  The guard
+            // keeps the panel's Applet_<ID> dual-write silent too.
+            c->setContainerVisible(false);
         }
+    }
+    if (m_panHost.recallGuard) m_panHost.recallGuard(false);
+    m_applying = false;
+}
+
+void WorkspaceController::placeSurfaceItems(const QString& surfaceId)
+{
+    WorkspaceCanvas* canvas = canvasForSurface(surfaceId);
+    if (!canvas) {
+        return;
+    }
+    WorkspaceDocument doc = m_store.document();
+    const Workspace* ws = doc.workspace(doc.activeWorkspace);
+    const WorkspaceSurface* surf = ws ? ws->surface(surfaceId) : nullptr;
+    if (!surf || surf->hidden) {
+        return;
+    }
+
+    m_applying = true;
+    if (m_panHost.recallGuard) m_panHost.recallGuard(true);
+
+    QList<CanvasItem> toPlace;
+    QHash<QString, QWidget*> widgets;
+    QStringList crossPans;
+    const bool cross = (surfaceId != WorkspaceSurface::kMainId);
+
+    for (const CanvasItem& item : surf->items) {
+        if (item.id.startsWith(kPanItemPrefix)) {
+            const QString panId = panIdForItem(item.id);
+            if (panId.isEmpty()) continue;   // no live pan in this slot
+            if (m_panHost.isFloating && m_panHost.isFloating(panId)) {
+                continue;   // pop-out stays (RFC decision 1)
+            }
+            if (canvas->contains(item.id)) continue;
+            if (cross && m_panHost.prepareTopLevelMove) {
+                m_panHost.prepareTopLevelMove(panId);
+            }
+            QWidget* w = m_panHost.detach ? m_panHost.detach(panId) : nullptr;
+            if (!w) continue;
+            CanvasItem placed = item;
+            placed.minimumSize = QSize(320, 180);
+            toPlace.append(placed);
+            widgets.insert(item.id, w);
+            if (cross) crossPans.append(panId);
+            continue;
+        }
+        if (!item.id.startsWith(kAppletItemPrefix) || item.closed) {
+            continue;
+        }
+        ContainerWidget* c =
+            containerForApplet(item.id.mid(kAppletItemPrefix.size()));
+        if (!c || c->isOnCanvas() || c->isFloating()) {
+            continue;
+        }
+        // Reopen the transient close the hide performed — under the guard,
+        // so neither the document nor the panel's preferences hear it.
+        if (!c->isContainerVisible()) {
+            c->setContainerVisible(true);
+        }
+        if (m_manager->detachForCanvas(c->id()) != c) {
+            continue;
+        }
+        toPlace.append(item);
+        widgets.insert(item.id, c);
+    }
+
+    canvas->restoreItems(toPlace, widgets);
+    for (const QString& panId : crossPans) {
+        if (m_panHost.finishTopLevelMove) m_panHost.finishTopLevelMove(panId);
+    }
+
+    if (m_panHost.recallGuard) m_panHost.recallGuard(false);
+    m_applying = false;
+}
+
+QString WorkspaceController::addCanvasWindow(const QString& label)
+{
+    if (!m_enabled || !m_store.isLoaded()) {
+        return QString();
+    }
+    WorkspaceDocument doc = m_store.document();
+    const QString sid = doc.addSurface(doc.activeWorkspace, label);
+    if (sid.isEmpty()) {
+        return QString();
+    }
+    m_store.setDocument(doc);
+    if (!m_store.flush()) {
+        qWarning() << "WorkspaceController: workspace edit did not persist (read-only session?)";
+    }
+    reconcileWindowsWithActiveWorkspace();
+    // Creating is arranging — the same reasoning as createWorkspace(): a
+    // fresh, empty window greets the operator ready to receive widgets.
+    if (canvasForSurface(sid)) {
+        m_canvas->setEditMode(true);   // mirrored to every surface
+    }
+    emit workspacesChanged();
+    return sid;
+}
+
+bool WorkspaceController::removeCanvasWindow(const QString& surfaceId)
+{
+    if (!m_enabled || surfaceId == WorkspaceSurface::kMainId) {
+        return false;
+    }
+    WorkspaceDocument doc = m_store.document();
+    // Capture the window's last geometry hint before it goes, purely so a
+    // future re-add starts somewhere sensible — the surface itself is
+    // deleted below, so this is best-effort.
+    if (m_extraCanvases.contains(surfaceId)) {
+        evictSurfaceTransiently(surfaceId);
+        m_extraCanvases.remove(surfaceId);
+        if (m_windowHost.destroyWindow) m_windowHost.destroyWindow(surfaceId);
+    }
+    if (!doc.removeSurface(doc.activeWorkspace, surfaceId)) {
+        return false;
+    }
+    m_store.setDocument(doc);
+    if (!m_store.flush()) {
+        qWarning() << "WorkspaceController: workspace edit did not persist (read-only session?)";
+    }
+    // The orphans moved to the main surface; the forced re-place brings
+    // them (and everything else) up in one pass, transient closes undone.
+    switchWorkspaceInternal(doc.activeWorkspace, /*force=*/true);
+    return true;
+}
+
+bool WorkspaceController::renameCanvasWindow(const QString& surfaceId,
+                                             const QString& label)
+{
+    WorkspaceDocument doc = m_store.document();
+    if (!doc.renameSurface(doc.activeWorkspace, surfaceId, label)) {
+        return false;
+    }
+    m_store.setDocument(doc);
+    if (!m_store.flush()) {
+        qWarning() << "WorkspaceController: workspace edit did not persist (read-only session?)";
+    }
+    if (const Workspace* ws = m_store.document().workspace(
+            m_store.document().activeWorkspace)) {
+        if (const WorkspaceSurface* surf = ws->surface(surfaceId)) {
+            if (m_windowHost.setWindowLabel) {
+                m_windowHost.setWindowLabel(surfaceId, surf->label);
+            }
+        }
+    }
+    emit workspacesChanged();
+    return true;
+}
+
+bool WorkspaceController::setCanvasWindowOpen(const QString& surfaceId, bool open)
+{
+    if (!m_enabled || surfaceId == WorkspaceSurface::kMainId) {
+        return false;
+    }
+    WorkspaceDocument doc = m_store.document();
+    Workspace* ws = nullptr;
+    for (Workspace& w : doc.workspaces) {
+        if (w.id == doc.activeWorkspace) ws = &w;
+    }
+    if (!ws) {
+        return false;
+    }
+    WorkspaceSurface* surf = nullptr;
+    for (WorkspaceSurface& candidate : ws->surfaces) {
+        if (candidate.id == surfaceId) surf = &candidate;
+    }
+    if (!surf) {
+        return false;
+    }
+    if (surf->hidden == !open) {
+        return true;   // the state the caller asked for
+    }
+
+    if (!open) {
+        // HIDE-AND-KEEP (maintainer ruling): widgets evicted transiently,
+        // items untouched, geometry hint captured, window hidden.
+        if (m_windowHost.geometryHint) {
+            surf->windowGeometry = m_windowHost.geometryHint(surfaceId);
+        }
+        surf->hidden = true;
+        m_store.setDocument(doc);
+        if (!m_store.flush()) {
+            qWarning() << "WorkspaceController: workspace edit did not persist (read-only session?)";
+        }
+        evictSurfaceTransiently(surfaceId);
+        m_extraCanvases.remove(surfaceId);
+        if (m_windowHost.closeWindow) m_windowHost.closeWindow(surfaceId);
+    } else {
+        surf->hidden = false;
+        m_store.setDocument(doc);
+        if (!m_store.flush()) {
+            qWarning() << "WorkspaceController: workspace edit did not persist (read-only session?)";
+        }
+        reconcileWindowsWithActiveWorkspace();
+        placeSurfaceItems(surfaceId);
+    }
+    emit workspacesChanged();
+    return true;
+}
+
+QList<WorkspaceController::CanvasWindowInfo>
+WorkspaceController::canvasWindowList() const
+{
+    QList<CanvasWindowInfo> out;
+    const WorkspaceDocument& doc = m_store.document();
+    if (const Workspace* ws = doc.workspace(doc.activeWorkspace)) {
+        for (const WorkspaceSurface& s : ws->surfaces) {
+            if (s.id == WorkspaceSurface::kMainId) continue;
+            CanvasWindowInfo info;
+            info.id    = s.id;
+            info.label = s.label.isEmpty() ? s.id : s.label;
+            info.open  = !s.hidden;
+            out.append(info);
+        }
+    }
+    return out;
+}
+
+bool WorkspaceController::moveItemToSurface(const QString& itemId,
+                                            const QString& surfaceId)
+{
+    if (!m_enabled) {
+        return false;
+    }
+    if (itemId == kBandStackItemId || itemId == kPanStackItemId) {
+        return false;   // shell furniture stays on the main surface
+    }
+    WorkspaceDocument doc = m_store.document();
+    Workspace* ws = nullptr;
+    for (Workspace& w : doc.workspaces) {
+        if (w.id == doc.activeWorkspace) ws = &w;
+    }
+    if (!ws || !ws->surface(surfaceId)) {
+        return false;
+    }
+    const QString from = docSurfaceForItem(*ws, itemId);
+    if (from == surfaceId) {
+        return true;   // the state the caller asked for
+    }
+
+    // DOCUMENT FIRST (the switch-pivot lesson): the item entry moves
+    // surfaces atomically, so a crash mid-reparent boots into a document
+    // that already says where the item lives.
+    CanvasItem moved;
+    bool found = false;
+    for (WorkspaceSurface& surf : ws->surfaces) {
+        for (int i = 0; i < surf.items.size(); ++i) {
+            if (surf.items.at(i).id == itemId) {
+                moved = surf.items.takeAt(i);
+                found = true;
+                break;
+            }
+        }
+        if (found) break;
+    }
+    if (!found) {
+        // Untracked but live (a pan placed this session): synthesize from
+        // the canvas.
+        WorkspaceCanvas* holder = canvasHolding(itemId);
+        if (!holder) {
+            return false;
+        }
+        moved.id          = itemId;
+        moved.contentType = itemId.startsWith(kPanItemPrefix)
+                                ? QStringLiteral("panadapter")
+                                : QStringLiteral("applet");
+        moved.rect        = holder->itemRect(itemId);
+    }
+    for (WorkspaceSurface& surf : ws->surfaces) {
+        if (surf.id == surfaceId) {
+            // Moving something TO a window is asking to see it there.
+            surf.hidden = false;
+            surf.items.append(moved);
+            break;
+        }
+    }
+    m_store.setDocument(doc);
+    if (!m_store.flush()) {
+        qWarning() << "WorkspaceController: workspace edit did not persist (read-only session?)";
+    }
+    reconcileWindowsWithActiveWorkspace();
+
+    WorkspaceCanvas* target = canvasForSurface(surfaceId);
+    WorkspaceCanvas* source = canvasHolding(itemId);
+    if (!target) {
+        emit workspacesChanged();
+        return true;   // recorded; the window will place it when it opens
+    }
+
+    // ── The widget follows, in ONE step ──────────────────────────────────
+    // A cross-window move is a cross-TOP-LEVEL reparent — the
+    // #2495/#4617/#4319 crash lineage — so pans take the floatPanadapter
+    // recipe through the pan-host hooks and applets go through the
+    // manager's reparent preparation (returnFromCanvas/detachForCanvas
+    // both call prepareRhiChildrenForReparent).
+    m_applying = true;
+    if (itemId.startsWith(kPanItemPrefix)) {
+        const QString panId = panIdForItem(itemId);
+        if (!panId.isEmpty()) {
+            if (m_panHost.prepareTopLevelMove) {
+                m_panHost.prepareTopLevelMove(panId);
+            }
+            QWidget* w = source ? source->releaseItem(itemId) : nullptr;
+            if (!w && m_panHost.detach) {
+                w = m_panHost.detach(panId);   // e.g. still in the stack
+            }
+            if (w) {
+                target->addItem(itemId, w, moved.rect,
+                                QStringLiteral("panadapter"), QSize(320, 180));
+                target->sendItemToBack(itemId);
+            }
+            if (m_panHost.finishTopLevelMove) {
+                m_panHost.finishTopLevelMove(panId);
+            }
+        }
+    } else if (itemId.startsWith(kAppletItemPrefix)) {
+        ContainerWidget* c =
+            containerForApplet(itemId.mid(kAppletItemPrefix.size()));
+        if (c) {
+            if (c->isOnCanvas() && source) {
+                source->takeItem(itemId);
+                m_manager->returnFromCanvas(c->id(), c);
+            }
+            if (c->isContainerVisible() && !c->isFloating()
+                && m_manager->detachForCanvas(c->id()) == c) {
+                target->addItem(itemId, c, moved.rect,
+                                QStringLiteral("applet"));
+            }
+        }
+    }
+    m_applying = false;
+
+    emit workspacesChanged();
+    return true;
+}
+
+void WorkspaceController::noteWindowGeometryHint(const QString& surfaceId,
+                                                 const QByteArray& hint)
+{
+    WorkspaceDocument doc = m_store.document();
+    for (Workspace& ws : doc.workspaces) {
+        if (ws.id != doc.activeWorkspace) continue;
+        for (WorkspaceSurface& s : ws.surfaces) {
+            if (s.id != surfaceId) continue;
+            if (s.windowGeometry == hint) return;
+            s.windowGeometry = hint;
+            m_store.setDocument(doc);   // touch — the store debounces
+            return;
+        }
+    }
+}
+
+void WorkspaceController::prepareShutdown()
+{
+    // BEFORE the pan/container teardown (MainWindow's ordered shutdown):
+    // capture every open window's geometry hint, flush the document once,
+    // then destroy the windows — explicitly, the #2495 lesson: a floating
+    // top-level left to ~QWidget cleanup crashed on macOS at exit.
+    const QStringList openWindows = m_extraCanvases.keys();
+    for (const QString& sid : openWindows) {
+        if (m_windowHost.geometryHint) {
+            noteWindowGeometryHint(sid, m_windowHost.geometryHint(sid));
+        }
+    }
+    m_store.flush();
+    for (const QString& sid : openWindows) {
+        // Evict BEFORE destroying: the stack still owns every pan applet
+        // and the panel every container — a window deleted around them
+        // would take them along (they are its children at this point).
+        evictSurfaceTransiently(sid);
+        m_extraCanvases.remove(sid);
+        if (m_windowHost.destroyWindow) m_windowHost.destroyWindow(sid);
     }
 }
 
@@ -1555,10 +2341,19 @@ bool WorkspaceController::switchWorkspaceInternal(const QString& id, bool force)
     // other OPEN applet closes.  All visibility changes run under
     // m_applying so the visibilityChanged hook does not echo them back
     // into the document.
+    // Windows first (phase 7): close the ones the target does not want,
+    // open the ones it does — placement below needs the canvases to
+    // exist.  The widgets were all released above.
+    reconcileWindowsWithActiveWorkspace();
+
     QSet<QString> wanted;
     if (const Workspace* ws = doc.workspace(id)) {
-        if (const WorkspaceSurface* main = ws->surface(WorkspaceSurface::kMainId)) {
-            for (const CanvasItem& it : main->items) {
+        for (const WorkspaceSurface& surf : ws->surfaces) {
+            if (surf.hidden) {
+                continue;   // hide-and-keep: a closed window's applets
+                            // stay transiently shut until it reopens
+            }
+            for (const CanvasItem& it : surf.items) {
                 if (it.id.startsWith(kAppletItemPrefix) && !it.closed) {
                     wanted.insert(it.id.mid(kAppletItemPrefix.size()));
                 }
@@ -1668,7 +2463,8 @@ QList<WorkspaceController::PaletteEntry> WorkspaceController::paletteState() con
 }
 
 bool WorkspaceController::addAppletFromPalette(const QString& appletId,
-                                               const QPointF& canvasPos)
+                                               const QPointF& canvasPos,
+                                               const QString& surfaceId)
 {
     if (!m_enabled) {
         return false;   // adding is allowed in BOTH postures (review m3)
@@ -1687,14 +2483,16 @@ bool WorkspaceController::addAppletFromPalette(const QString& appletId,
     }
 
     const QString itemId = itemIdFor(c);
-    const NormRect rect  = defaultRectFor(c, &canvasPos);
+    const NormRect rect  = defaultRectFor(c, &canvasPos,
+                                          canvasForSurface(surfaceId));
 
     // Whatever state the applet is in, the palette add ends the same way:
-    // an OPEN applet placed at the click point.  The rect is recorded
-    // first so every path below places from the document — the same
-    // one-placement-path shape import-floats uses.
+    // an OPEN applet placed at the click point ON THE CANVAS THE MENU WAS
+    // OPENED OVER (phase 7).  The rect is recorded first so every path
+    // below places from the document — the same one-placement-path shape
+    // import-floats uses — and recording carries the surface.
     writeItemPresence(itemId, QStringLiteral("applet"), rect,
-                      /*present=*/true, /*flushNow=*/false);
+                      /*present=*/true, /*flushNow=*/false, surfaceId);
 
     if (c->isFloating()) {
         // An explicit palette add outranks decision 1's leave-it-floating:
@@ -1857,12 +2655,13 @@ void WorkspaceController::onRadioProfileLoaded(const QString& profileType,
 // ── Geometry helpers ─────────────────────────────────────────────────────
 
 NormRect WorkspaceController::defaultRectFor(const ContainerWidget* c,
-                                             const QPointF* center) const
+                                             const QPointF* center,
+                                             const WorkspaceCanvas* canvas) const
 {
     // Size from the widget's own hint, normalized against the canvas — so a
     // dropped applet arrives at roughly its panel size instead of a house
     // number.  The canvas clamps against its minimum floor either way.
-    const QSize canvasSize = m_canvas->size();
+    const QSize canvasSize = (canvas ? canvas : m_canvas)->size();
     const QSize hint = c ? c->sizeHint() : QSize();
 
     NormRect r;

--- a/src/gui/workspace/WorkspaceController.h
+++ b/src/gui/workspace/WorkspaceController.h
@@ -33,7 +33,9 @@
 
 #include "gui/workspace/WorkspaceStore.h"
 
+#include <QByteArray>
 #include <QHash>
+#include <QSet>
 #include <QObject>
 #include <QPointer>
 #include <QPointF>
@@ -108,8 +110,78 @@ public:
         // Bracket recall-driven bulk visibility changes (red-team B2): the
         // panel suppresses its Applet_<ID> preference writes inside.
         std::function<void(bool)> recallGuard;
+        // Cross-top-level pan moves (phase 7): the floatPanadapter GPU
+        // recipe, split around the controller's one-step reparent —
+        // prepare = hide + prepareForTopLevelChange + resetGpuResources;
+        // finish = deferred refreshAfterReparent + show.  Same seam rule
+        // as everything above: the GPU-adjacent types never link into the
+        // workspace suites.
+        std::function<void(const QString&)> prepareTopLevelMove;
+        std::function<void(const QString&)> finishTopLevelMove;
     };
     void setPanHost(const PanHostHooks& hooks);
+
+    // ── Additional canvas windows (RFC #4887 phase 7) ────────────────────
+    //
+    // Same seam philosophy as PanHostHooks: the controller owns surface
+    // POLICY (which surfaces exist, what lives on them, what closing
+    // means), MainWindow owns the real top-level WorkspaceWindows, and the
+    // unit suite provides bare WorkspaceCanvas widgets — so multi-surface
+    // policy stays headless-testable and the controller never constructs a
+    // window.
+    struct WindowHostHooks {
+        // Create (or re-show) the window realising `surfaceId`; return its
+        // canvas.  The host applies the label and geometry hint.
+        std::function<WorkspaceCanvas*(const QString& surfaceId,
+                                       const QString& label,
+                                       const QByteArray& geometryHint)>
+            openWindow;
+        // Hide the window (hide-and-keep).  Widgets are already evicted.
+        std::function<void(const QString& surfaceId)> closeWindow;
+        // Destroy the window outright (surface removed / shutdown).
+        std::function<void(const QString& surfaceId)> destroyWindow;
+        std::function<void(const QString& surfaceId, const QString& label)>
+            setWindowLabel;
+        // The live geometry hint, for persisting at shutdown.
+        std::function<QByteArray(const QString& surfaceId)> geometryHint;
+    };
+    void setWindowHost(const WindowHostHooks& hooks);
+
+    // Create a new (empty, visible) canvas window on the ACTIVE workspace.
+    // Returns the surface id, empty on failure.
+    QString addCanvasWindow(const QString& label);
+    // Destroy the window; its items move to the END of the main surface
+    // and are re-placed there.  Refuses "main".
+    bool removeCanvasWindow(const QString& surfaceId);
+    bool renameCanvasWindow(const QString& surfaceId, const QString& label);
+    // open=false is HIDE-AND-KEEP (maintainer ruling): widgets are evicted
+    // transiently — applets close under the recall guard with NO document
+    // closed-flags, pans restore to the hidden stack — the surface keeps
+    // every item, and reopening re-places them exactly.
+    bool setCanvasWindowOpen(const QString& surfaceId, bool open);
+    struct CanvasWindowInfo {
+        QString id;
+        QString label;
+        bool open{false};
+    };
+    QList<CanvasWindowInfo> canvasWindowList() const;
+
+    // Move one item (applet or pan) to another surface — the "Move to ▸"
+    // action.  A cross-window move is a cross-TOP-LEVEL reparent, the
+    // #2495/#4617/#4319 crash lineage: pans go through the pan host's
+    // prepare/finish hooks (the floatPanadapter recipe), applets through
+    // the manager's reparent preparation.  Document first, widget second.
+    bool moveItemToSurface(const QString& itemId, const QString& surfaceId);
+
+    // The window's debounced move/resize stream lands here; the hint is
+    // stored on the surface (touch, not flush — the store debounces).
+    void noteWindowGeometryHint(const QString& surfaceId,
+                                const QByteArray& hint);
+
+    // Ordered teardown, called from MainWindow's shutdown path BEFORE the
+    // pan/container teardown: persist every open window's geometry hint,
+    // flush the store, destroy the windows.
+    void prepareShutdown();
 
     // Document identity: pans are stored as "pan:<slot>", a small
     // creation-order ordinal (lowest free on reuse) — NEVER the radio's
@@ -199,7 +271,9 @@ public:
     // Add one applet from the palette at a canvas position (fractions).
     // Opens a closed applet, docks a floating one, places an open one —
     // and refuses an applet already on the canvas.
-    bool addAppletFromPalette(const QString& appletId, const QPointF& canvasPos);
+    // `surfaceId` targets the canvas the palette menu was opened on.
+    bool addAppletFromPalette(const QString& appletId, const QPointF& canvasPos,
+                              const QString& surfaceId = QString());
 
     // Import every pop-out — floating applet containers and floating pans —
     // onto the canvas at rects mapped from their window geometry (the RFC's
@@ -258,7 +332,9 @@ public:
     // Resolve applet-vs-applet overlaps by minimal downward pushes.  Items
     // overlapping the PAN AREA are left alone on purpose: a meter over the
     // spectrum is a feature, not disorder.
-    void tidyLayout();
+    // Tidies one canvas (the one the context menu was opened on); null =
+    // the main canvas.
+    void tidyLayout(WorkspaceCanvas* canvas = nullptr);
 
     // Where a live drag out of the canvas may land (the applet panel).
     // Releasing a move over this widget returns the applet to it; anywhere
@@ -267,6 +343,13 @@ public:
     // re-shows it; the per-item "Return to panel" action and the palette
     // are the ordinary paths now (review m2).
     void setReturnTarget(QWidget* target);
+
+    // The canvas realising `surfaceId` right now: the main canvas, an open
+    // window's, or null (hidden/unknown).  For the bridge's status report.
+    WorkspaceCanvas* canvasForSurface(const QString& surfaceId) const;
+    // Which surface's canvas currently HOSTS the item; empty when nothing
+    // does.  Bridge plumbing (status/place across windows).
+    QString surfaceHosting(const QString& itemId) const;
 
 signals:
     void enabledChanged(bool enabled);
@@ -296,23 +379,51 @@ private:
     // either restore to the stack (disable) or stay parented for immediate
     // re-placement (switch).  Callers hold m_applying.
     void releaseAllItems(bool returnPansToStack, bool hideBandStack);
+    // `surfaceId` places a NEW item on that surface explicitly (drop or
+    // palette add on a window's canvas); empty = the surface whose canvas
+    // hosts the widget, else main.  An EXISTING item stays where it is —
+    // presence is never a move (moveItemToSurface is).
     void writeItemPresence(const QString& itemId, const QString& contentType,
-                           const NormRect& rect, bool present, bool flushNow);
+                           const NormRect& rect, bool present, bool flushNow,
+                           const QString& surfaceId = QString());
     void writeStackingFromCanvas();
 
-    void onDropReceived(const QString& payload, const QPointF& pos);
+    void onDropReceived(WorkspaceCanvas* canvas, const QString& payload,
+                        const QPointF& pos);
     void onItemRectChanged(const QString& itemId, const NormRect& rect);
     void onContainerCreated(const QString& containerId);
     void wireContainer(ContainerWidget* c);
     void onItemDraggedOut(const QString& itemId, const QPoint& globalPos);
-    void onContextMenuRequested(const QString& itemId, const QPoint& globalPos);
+    void onContextMenuRequested(WorkspaceCanvas* canvas, const QString& itemId,
+                                const QPoint& globalPos);
+
+    // ── Multi-surface plumbing (phase 7) ─────────────────────────────────
+    // Wire one canvas's signals into the shared handlers.  The main canvas
+    // is wired in the ctor; every attached window canvas goes through the
+    // same seam, so policy cannot diverge per surface.
+    void wireCanvas(WorkspaceCanvas* canvas);
+    QList<WorkspaceCanvas*> attachedCanvases() const;
+    WorkspaceCanvas* canvasHolding(const QString& itemId) const;
+    QString surfaceOf(const WorkspaceCanvas* canvas) const;
+    // Open the active workspace's non-hidden extra windows and attach
+    // their canvases (idempotent); close/detach ones that should not be
+    // open.  Placement is the caller's business.
+    void reconcileWindowsWithActiveWorkspace();
+    // Evict one surface's widgets transiently (hide-and-keep): applets
+    // close under the recall guard with no document writes, pans restore
+    // to the (hidden) stack.
+    void evictSurfaceTransiently(const QString& surfaceId);
+    // Place one surface's items onto its canvas (the scoped version of
+    // placeActiveWorkspaceItems, for reopening a hidden window).
+    void placeSurfaceItems(const QString& surfaceId);
 
     // The placement replay shared by enable() and resetToClassic(): put the
     // pan stack and every eligible applet item of the active workspace onto
     // the (empty) canvas.  Callers hold m_applying.
     void placeActiveWorkspaceItems(WorkspaceDocument& doc, bool* docChanged);
 
-    NormRect defaultRectFor(const ContainerWidget* c, const QPointF* center) const;
+    NormRect defaultRectFor(const ContainerWidget* c, const QPointF* center,
+                            const WorkspaceCanvas* canvas = nullptr) const;
 
     // Slot bookkeeping (phase 4).
     int slotForPan(const QString& panId);          // assigns on first sight
@@ -333,6 +444,16 @@ private:
     WorkspaceCanvas*  m_canvas{nullptr};
     WorkspaceStore    m_store;
     PanHostHooks m_panHost;
+    WindowHostHooks m_windowHost;
+    // Open extra-surface canvases, keyed by surface id.  QPointer: the
+    // host owns the windows and may destroy them (shutdown path).
+    QHash<QString, QPointer<WorkspaceCanvas>> m_extraCanvases;
+    // Re-entrancy guard for cross-canvas edit-mode mirroring.
+    bool m_syncingEditMode{false};
+    // Canvas objects already wired into the shared handlers.  A hidden
+    // window keeps its canvas alive, so reopening hands back the SAME
+    // object — wiring it again would double every connection.
+    QSet<const WorkspaceCanvas*> m_wiredCanvases;
     QList<WidgetCatalogEntry> m_widgetCatalog;
     std::function<bool(const QString&)> m_widgetAvailable;
     QHash<QString, int> m_panSlots;   // live panId → document slot
@@ -340,6 +461,9 @@ private:
     QStringList m_knownAppletIds;   // from enable(), for resetToClassic()
     QString  m_undoItemId;      // last gesture's item…
     NormRect m_undoRect;        // …and the rect it started from
+    // The canvas a title-strip live-move stream is driving (phase 7: the
+    // begin call resolves it once; move/end follow it, not "the" canvas).
+    QPointer<WorkspaceCanvas> m_gestureCanvas;
     bool m_enabled{false};
     // True while enable()/disable() replay the document onto the canvas —
     // the canvas signals fired by that replay describe what the document

--- a/src/gui/workspace/WorkspaceController.h
+++ b/src/gui/workspace/WorkspaceController.h
@@ -144,6 +144,12 @@ public:
             setWindowLabel;
         // The live geometry hint, for persisting at shutdown.
         std::function<QByteArray(const QString& surfaceId)> geometryHint;
+        // Re-apply a stored hint to an ALREADY-OPEN window — a workspace
+        // switch reuses windows by surface id, and each workspace records
+        // its own geometry (red-team #4971 L2: the target's hint was
+        // never applied, and the debounced write cross-pollinated).
+        std::function<void(const QString& surfaceId, const QByteArray& hint)>
+            applyGeometryHint;
     };
     void setWindowHost(const WindowHostHooks& hooks);
 
@@ -162,7 +168,14 @@ public:
     struct CanvasWindowInfo {
         QString id;
         QString label;
+        // The document's intent: the operator has not closed this window.
         bool open{false};
+        // The LIVE truth: a real window is attached right now.  False
+        // while the mode is off and during the deferred enable turn —
+        // the honesty distinction the per-item `hosted` flag draws
+        // (red-team #4971 M3: `open` read the document and reported
+        // windows that did not exist).
+        bool live{false};
     };
     QList<CanvasWindowInfo> canvasWindowList() const;
 
@@ -408,7 +421,7 @@ private:
     // Open the active workspace's non-hidden extra windows and attach
     // their canvases (idempotent); close/detach ones that should not be
     // open.  Placement is the caller's business.
-    void reconcileWindowsWithActiveWorkspace();
+    void reconcileWindowsWithActiveWorkspace(bool reapplyHints = false);
     // Evict one surface's widgets transiently (hide-and-keep): applets
     // close under the recall guard with no document writes, pans restore
     // to the (hidden) stack.

--- a/src/gui/workspace/WorkspaceDocument.cpp
+++ b/src/gui/workspace/WorkspaceDocument.cpp
@@ -181,6 +181,112 @@ bool WorkspaceDocument::renameWorkspace(const QString& id, const QString& label)
     return false;
 }
 
+QString WorkspaceDocument::uniqueSurfaceId(const QString& workspaceId) const
+{
+    const Workspace* w = workspace(workspaceId);
+    if (!w) {
+        return QString();
+    }
+    int n = 2;
+    while (w->surface(QStringLiteral("canvas%1").arg(n))) {
+        ++n;
+    }
+    return QStringLiteral("canvas%1").arg(n);
+}
+
+QString WorkspaceDocument::addSurface(const QString& workspaceId,
+                                      const QString& label)
+{
+    for (Workspace& w : workspaces) {
+        if (w.id != workspaceId) continue;
+        WorkspaceSurface s;
+        s.id = uniqueSurfaceId(workspaceId);
+        // Labels are de-duplicated within the workspace, same reasoning as
+        // workspace labels: the window-list menu and the bridge address
+        // surfaces by label as operator text.
+        const QString wanted = label.trimmed().isEmpty()
+                                   ? QStringLiteral("Canvas")
+                                   : label.trimmed();
+        auto taken = [&w](const QString& l) {
+            for (const WorkspaceSurface& surf : w.surfaces) {
+                if (surf.label == l) return true;
+            }
+            return false;
+        };
+        QString unique = wanted;
+        int n = 2;
+        while (taken(unique)) {
+            unique = QStringLiteral("%1 (%2)").arg(wanted).arg(n++);
+        }
+        s.label = unique;
+        w.surfaces.append(s);
+        return s.id;
+    }
+    return QString();
+}
+
+bool WorkspaceDocument::removeSurface(const QString& workspaceId,
+                                      const QString& surfaceId)
+{
+    if (surfaceId == WorkspaceSurface::kMainId) {
+        return false;
+    }
+    for (Workspace& w : workspaces) {
+        if (w.id != workspaceId) continue;
+        int idx = -1;
+        for (int i = 0; i < w.surfaces.size(); ++i) {
+            if (w.surfaces.at(i).id == surfaceId) { idx = i; break; }
+        }
+        if (idx < 0) {
+            return false;
+        }
+        const QList<CanvasItem> orphans = w.surfaces.at(idx).items;
+        w.surfaces.removeAt(idx);
+        for (WorkspaceSurface& s : w.surfaces) {
+            if (s.id == WorkspaceSurface::kMainId) {
+                // Identity is workspace-wide (the parser enforces it), so a
+                // straight append cannot collide.
+                s.items.append(orphans);
+                break;
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
+bool WorkspaceDocument::renameSurface(const QString& workspaceId,
+                                      const QString& surfaceId,
+                                      const QString& label)
+{
+    for (Workspace& w : workspaces) {
+        if (w.id != workspaceId) continue;
+        for (WorkspaceSurface& s : w.surfaces) {
+            if (s.id != surfaceId) continue;
+            const QString wanted = label.trimmed().isEmpty()
+                                       ? QStringLiteral("Canvas")
+                                       : label.trimmed();
+            // Exclude self from the collision scan (the workspace-rename
+            // M4 lesson, applied on arrival).
+            auto taken = [&w, &s](const QString& l) {
+                for (const WorkspaceSurface& other : w.surfaces) {
+                    if (&other != &s && other.label == l) return true;
+                }
+                return false;
+            };
+            QString unique = wanted;
+            int n = 2;
+            while (taken(unique)) {
+                unique = QStringLiteral("%1 (%2)").arg(wanted).arg(n++);
+            }
+            s.label = unique;
+            return true;
+        }
+        return false;
+    }
+    return false;
+}
+
 bool WorkspaceDocument::removeWorkspace(const QString& id)
 {
     if (workspaces.size() <= 1 || !contains(id)) {
@@ -224,6 +330,9 @@ QJsonObject WorkspaceDocument::toJson() const
             if (!s.windowGeometry.isEmpty()) {
                 so[QStringLiteral("windowGeometry")] =
                     QString::fromLatin1(s.windowGeometry.toBase64());
+            }
+            if (s.hidden) {
+                so[QStringLiteral("hidden")] = true;
             }
             surfaceArray.append(so);
         }
@@ -318,6 +427,11 @@ bool WorkspaceDocument::fromJson(const QJsonObject& root,
                           QStringLiteral("workspace '%1' has a non-array surfaces field")
                               .arg(ws.id));
         }
+        // Item ids are WORKSPACE-wide identity (phase 7): an item on two
+        // surfaces of one workspace would be placed twice by the replay
+        // and fight itself.  The dedup set therefore spans the surface
+        // loop, not each surface.
+        QSet<QString> seenItemIds;
         for (const QJsonValue& sValue : wo.value(QStringLiteral("surfaces")).toArray()) {
             if (!sValue.isObject()) {
                 appendWarning(warnings,
@@ -366,6 +480,15 @@ bool WorkspaceDocument::fromJson(const QJsonObject& root,
                 }
             }
 
+            surface.hidden = so.value(QStringLiteral("hidden")).toBool(false);
+            if (surface.hidden && surface.id == WorkspaceSurface::kMainId) {
+                // The main window's canvas cannot be "closed" — repair.
+                surface.hidden = false;
+                appendWarning(warnings,
+                              QStringLiteral("main surface of '%1' was marked "
+                                             "hidden").arg(ws.id));
+            }
+
             if (so.contains(QStringLiteral("items"))
                 && !so.value(QStringLiteral("items")).isArray()) {
                 appendWarning(warnings,
@@ -373,7 +496,6 @@ bool WorkspaceDocument::fromJson(const QJsonObject& root,
                                   .arg(ws.id, surface.id));
             }
 
-            QSet<QString> seenItemIds;
             for (const QJsonValue& iValue : so.value(QStringLiteral("items")).toArray()) {
                 if (!iValue.isObject()) {
                     appendWarning(warnings,

--- a/src/gui/workspace/WorkspaceDocument.h
+++ b/src/gui/workspace/WorkspaceDocument.h
@@ -49,6 +49,13 @@ struct WorkspaceSurface {
     // business.  Never authoritative — see the file comment.
     QByteArray windowGeometry;
 
+    // An extra canvas window the operator closed (hide-and-keep, phase 7
+    // maintainer ruling): the surface and its items stay recorded, the
+    // window just does not open until asked.  Meaningless for "main".
+    // Absent-when-false in the stored form, so phase-6 documents parse
+    // unchanged and a downgrade merely drops the flag.
+    bool hidden = false;
+
     QList<CanvasItem> items;
 };
 
@@ -118,6 +125,26 @@ public:
     QString addBlank(const QString& label);
 
     bool renameWorkspace(const QString& id, const QString& label);
+
+    // ── Surface CRUD (phase 7 — additional canvas windows) ──────────────
+    //
+    // Same ownership rule as workspace CRUD: the document owns identity
+    // (sequential unique ids "canvas2", "canvas3", … and per-workspace
+    // de-duplicated labels); which WINDOW realises a surface is the
+    // controller's business.
+    QString uniqueSurfaceId(const QString& workspaceId) const;
+
+    // Append an empty extra surface to `workspaceId`.  Returns the new
+    // surface id, empty when the workspace does not exist.
+    QString addSurface(const QString& workspaceId, const QString& label);
+
+    // Refuses "main".  The surface's items move to the END of the main
+    // surface (identity is workspace-wide, so no collision is possible);
+    // the caller re-places them.
+    bool removeSurface(const QString& workspaceId, const QString& surfaceId);
+
+    bool renameSurface(const QString& workspaceId, const QString& surfaceId,
+                       const QString& label);
 
     // Refuses the last workspace (a document with none cannot describe the
     // shell).  Bindings pointing at it drop — the same rule the parser

--- a/src/gui/workspace/WorkspaceWindow.cpp
+++ b/src/gui/workspace/WorkspaceWindow.cpp
@@ -84,6 +84,12 @@ void WorkspaceWindow::setSurfaceLabel(const QString& label)
 void WorkspaceWindow::restoreFromHint(const QByteArray& hint, QWidget* anchor)
 {
     m_restoring = true;
+    // A minimized window must come back when asked (red-team #4971 N2):
+    // show() is a no-op on an iconified window and saveGeometry() carries
+    // only maximized/fullScreen, so the Canvas Windows menu and the
+    // bridge's `window open` could never un-minimize — the only in-app
+    // controls for this window, dead against it.
+    setWindowState(windowState() & ~Qt::WindowMinimized);
     bool restored = !hint.isEmpty() && restoreGeometry(hint);
     if (!restored) {
         resize(kDefaultW, kDefaultH);

--- a/src/gui/workspace/WorkspaceWindow.cpp
+++ b/src/gui/workspace/WorkspaceWindow.cpp
@@ -1,0 +1,143 @@
+#include "gui/workspace/WorkspaceWindow.h"
+
+#include "gui/workspace/WorkspaceCanvas.h"
+
+#include "core/AppSettings.h"
+#include "gui/FramelessResizer.h"
+#include "gui/Theme.h"
+
+#include <QCloseEvent>
+#include <QGuiApplication>
+#include <QScreen>
+#include <QVBoxLayout>
+
+namespace AetherSDR {
+
+namespace {
+// First-open size when there is no hint: generous enough to arrange in,
+// small enough to fit any monitor the anchor lives on.
+constexpr int kDefaultW = 960;
+constexpr int kDefaultH = 600;
+}  // namespace
+
+WorkspaceWindow::WorkspaceWindow(const QString& surfaceId, QWidget* parent)
+    : QWidget(parent, Qt::Window)
+    , m_surfaceId(surfaceId)
+{
+    // The FloatingContainerWindow frameless contract, verbatim: honour the
+    // app-wide setting, and re-apply via setWindowFlags — some platform
+    // plugins ignore the constructor bitmask and need the explicit call
+    // before show().
+    const bool frameless =
+        AppSettings::instance().value("FramelessWindow", "True").toString()
+        == "True";
+    Qt::WindowFlags flags = Qt::Window;
+    if (frameless) flags |= Qt::FramelessWindowHint;
+    setWindowFlags(flags);
+    setAttribute(Qt::WA_DeleteOnClose, false);
+    setAttribute(Qt::WA_QuitOnClose, false);
+    setAttribute(Qt::WA_StyledBackground, true);
+    applyAppTheme(this);
+
+    m_layout = new QVBoxLayout(this);
+    m_layout->setContentsMargins(0, 0, 0, 0);
+    m_layout->setSpacing(0);
+
+    m_canvas = new WorkspaceCanvas(this);
+    // dumpTree/grab targeting: every canvas needs a distinct name once
+    // there is more than one.
+    m_canvas->setObjectName(QStringLiteral("WorkspaceCanvas:%1").arg(surfaceId));
+    m_layout->addWidget(m_canvas, 1);
+
+    m_hintTimer.setSingleShot(true);
+    m_hintTimer.setInterval(400);
+    connect(&m_hintTimer, &QTimer::timeout, this, [this] {
+        emit geometryHintChanged(m_surfaceId, saveGeometry());
+    });
+
+    FramelessResizer::install(this);
+}
+
+void WorkspaceWindow::setSurfaceLabel(const QString& label)
+{
+    setWindowTitle(label.isEmpty() ? m_surfaceId : label);
+}
+
+void WorkspaceWindow::restoreFromHint(const QByteArray& hint, QWidget* anchor)
+{
+    m_restoring = true;
+    bool restored = !hint.isEmpty() && restoreGeometry(hint);
+    if (!restored) {
+        resize(kDefaultW, kDefaultH);
+        QScreen* screen = anchor && anchor->screen()
+                              ? anchor->screen()
+                              : QGuiApplication::primaryScreen();
+        if (screen) {
+            const QRect g = screen->availableGeometry();
+            move(g.center().x() - kDefaultW / 2,
+                 g.center().y() - kDefaultH / 2);
+        }
+    } else {
+        // Clamp to a connected screen: the hint may name a monitor that is
+        // no longer there, and an off-screen canvas window reads as a lost
+        // arrangement even though every item rect is intact.
+        bool onScreen = false;
+        const QPoint tl = geometry().topLeft();
+        for (QScreen* s : QGuiApplication::screens()) {
+            if (s->availableGeometry().contains(tl)) {
+                onScreen = true;
+                break;
+            }
+        }
+        if (!onScreen) {
+            QScreen* screen = anchor && anchor->screen()
+                                  ? anchor->screen()
+                                  : QGuiApplication::primaryScreen();
+            if (screen) {
+                const QRect g = screen->availableGeometry();
+                move(g.center().x() - width() / 2,
+                     g.center().y() - height() / 2);
+            }
+        }
+    }
+    m_restoring = false;
+}
+
+QByteArray WorkspaceWindow::currentGeometryHint() const
+{
+    return saveGeometry();
+}
+
+void WorkspaceWindow::prepareShutdown()
+{
+    m_hintTimer.stop();
+    emit geometryHintChanged(m_surfaceId, saveGeometry());
+    m_shuttingDown = true;
+    close();
+}
+
+void WorkspaceWindow::closeEvent(QCloseEvent* ev)
+{
+    if (m_shuttingDown) {
+        ev->accept();
+        return;
+    }
+    // Never act locally: the controller must evict the surface's widgets
+    // BEFORE the window disappears (hide-and-keep), and only it knows how.
+    ev->ignore();
+    emit closeRequested(m_surfaceId);
+}
+
+void WorkspaceWindow::moveEvent(QMoveEvent* ev)
+{
+    QWidget::moveEvent(ev);
+    if (!m_restoring) m_hintTimer.start();
+}
+
+void WorkspaceWindow::resizeEvent(QResizeEvent* ev)
+{
+    QWidget::resizeEvent(ev);
+    if (!m_restoring) m_hintTimer.start();
+}
+
+}  // namespace AetherSDR

--- a/src/gui/workspace/WorkspaceWindow.cpp
+++ b/src/gui/workspace/WorkspaceWindow.cpp
@@ -4,6 +4,7 @@
 
 #include "core/AppSettings.h"
 #include "gui/FramelessResizer.h"
+#include "gui/FramelessWindowTitleBar.h"
 #include "gui/Theme.h"
 
 #include <QCloseEvent>
@@ -43,6 +44,19 @@ WorkspaceWindow::WorkspaceWindow(const QString& surfaceId, QWidget* parent)
     m_layout->setContentsMargins(0, 0, 0, 0);
     m_layout->setSpacing(0);
 
+    // Move/close chrome (8600 field report: a frameless canvas window had
+    // no way to be moved at all — FramelessResizer only owns the edges).
+    // FramelessWindowTitleBar brings drag-to-move via FramelessMoveHelper
+    // (the #4725 native-Wayland path), min/max/close, and double-click
+    // maximize.  Its close button calls window()->close(), which lands in
+    // closeEvent below — so chrome-close IS hide-and-keep, same as the
+    // WM's.  Native decorations already provide all of this, so the bar
+    // exists only in frameless mode.
+    if (frameless) {
+        m_titleBar = new FramelessWindowTitleBar(surfaceId, this);
+        m_layout->addWidget(m_titleBar);
+    }
+
     m_canvas = new WorkspaceCanvas(this);
     // dumpTree/grab targeting: every canvas needs a distinct name once
     // there is more than one.
@@ -60,7 +74,11 @@ WorkspaceWindow::WorkspaceWindow(const QString& surfaceId, QWidget* parent)
 
 void WorkspaceWindow::setSurfaceLabel(const QString& label)
 {
-    setWindowTitle(label.isEmpty() ? m_surfaceId : label);
+    const QString title = label.isEmpty() ? m_surfaceId : label;
+    setWindowTitle(title);
+    if (m_titleBar) {
+        m_titleBar->setTitleText(title);
+    }
 }
 
 void WorkspaceWindow::restoreFromHint(const QByteArray& hint, QWidget* anchor)

--- a/src/gui/workspace/WorkspaceWindow.h
+++ b/src/gui/workspace/WorkspaceWindow.h
@@ -30,6 +30,7 @@ class QVBoxLayout;
 
 namespace AetherSDR {
 
+class FramelessWindowTitleBar;
 class WorkspaceCanvas;
 
 class WorkspaceWindow : public QWidget {
@@ -79,6 +80,10 @@ protected:
 private:
     QString m_surfaceId;
     WorkspaceCanvas* m_canvas{nullptr};
+    // Present only in frameless mode: the window's move/close chrome.
+    // With native decorations the desktop provides both and a second
+    // bar would be duplication.
+    FramelessWindowTitleBar* m_titleBar{nullptr};
     QVBoxLayout* m_layout{nullptr};
     QTimer m_hintTimer;
     bool m_restoring{false};

--- a/src/gui/workspace/WorkspaceWindow.h
+++ b/src/gui/workspace/WorkspaceWindow.h
@@ -1,0 +1,88 @@
+#pragma once
+
+// One additional canvas window (RFC #4887 phase 7): a thin top-level that
+// hosts one WorkspaceCanvas and remembers its own geometry HINT.  The canvas
+// does the work; this class holds it — deliberately following
+// FloatingContainerWindow's existing frameless/shutdown contract (flags
+// re-applied before show, WA_DeleteOnClose off, screen-clamped restore,
+// debounced geometry save, an explicit prepareShutdown()) rather than
+// inventing a new one, because that contract is where the #2495/#4803
+// top-level-window lessons already live.
+//
+// Geometry is a HINT by schema design (WorkspaceDocument.h): item rects are
+// authoritative fractions of this window's canvas, restored exactly; where
+// the desktop puts the window is advisory, and Wayland always declines the
+// position half.  A hint that is ignored costs one drag and loses no layout.
+//
+// Lifecycle is the controller's call, made through MainWindow's window-host
+// hooks: closing the window is HIDE-AND-KEEP (maintainer ruling) — the
+// closeEvent is forwarded as a request, never acted on locally, so the
+// controller can evict the surface's widgets first and record the hidden
+// flag.  Only prepareShutdown() closes for real.
+
+#include <QByteArray>
+#include <QString>
+#include <QTimer>
+#include <QWidget>
+
+class QCloseEvent;
+class QVBoxLayout;
+
+namespace AetherSDR {
+
+class WorkspaceCanvas;
+
+class WorkspaceWindow : public QWidget {
+    Q_OBJECT
+
+public:
+    // `surfaceId` names the WorkspaceSurface this window realises.  Parent
+    // with mainWindow->window(), the FloatingContainerWindow pattern: the
+    // window rides above the shell without WindowStaysOnTopHint.
+    explicit WorkspaceWindow(const QString& surfaceId, QWidget* parent);
+
+    QString surfaceId() const { return m_surfaceId; }
+    WorkspaceCanvas* canvas() const { return m_canvas; }
+
+    // The surface label is the window title (mnemonics do not apply here —
+    // titles are not menu text).
+    void setSurfaceLabel(const QString& label);
+
+    // Restore from the document's stored hint; on garbage or first open,
+    // fall back to a sensible size centred on the anchor's screen.  A
+    // restored position naming a disconnected monitor is clamped back onto
+    // a live one — the FloatingContainerWindow::restoreAndEnsureVisible
+    // discipline, the only such guard in the tree.
+    void restoreFromHint(const QByteArray& hint, QWidget* anchor);
+
+    // The live hint, for persisting (QWidget::saveGeometry form).
+    QByteArray currentGeometryHint() const;
+
+    // Orderly teardown: stop the debounce, emit one final hint, mark
+    // shutting-down so the close is accepted instead of forwarded.
+    void prepareShutdown();
+
+signals:
+    // The operator asked to close the window (title-bar close, Alt+F4).
+    // Nothing has happened yet — the controller owns what closing means.
+    void closeRequested(const QString& surfaceId);
+
+    // Debounced move/resize stream (400 ms, the FloatingContainerWindow
+    // cadence): the current saveGeometry() blob, for the document.
+    void geometryHintChanged(const QString& surfaceId, const QByteArray& hint);
+
+protected:
+    void closeEvent(QCloseEvent* ev) override;
+    void moveEvent(QMoveEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
+
+private:
+    QString m_surfaceId;
+    WorkspaceCanvas* m_canvas{nullptr};
+    QVBoxLayout* m_layout{nullptr};
+    QTimer m_hintTimer;
+    bool m_restoring{false};
+    bool m_shuttingDown{false};
+};
+
+}  // namespace AetherSDR

--- a/tests/workspace_canvas_widget_test.cpp
+++ b/tests/workspace_canvas_widget_test.cpp
@@ -339,6 +339,46 @@ int main(int argc, char** argv)
         // Pressing it again is now a no-op.
         press(under);
         report("pressing it again emits nothing", stackSpy.count() == 1);
+
+        // A press on a DESCENDANT selects too (8600 field report: applet
+        // content consumes presses before the item widget sees them, so
+        // the resize frame only appeared on right-clicks — the one press
+        // nothing swallowed).  The app-wide filter walks up from wherever
+        // the press landed; left and right buttons alike.
+        {
+            auto* child = new QWidget(over);
+            child->setGeometry(2, 2, 20, 20);
+            child->show();
+            canvas.clearSelection();
+            QMouseEvent ev(QEvent::MouseButtonPress, QPointF(3, 3),
+                           child->mapToGlobal(QPointF(3, 3)),
+                           Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+            QCoreApplication::sendEvent(child, &ev);
+            report("a press on an item's descendant selects it",
+                   canvas.selectedItem() == QStringLiteral("over"));
+
+            canvas.clearSelection();
+            QMouseEvent right(QEvent::MouseButtonPress, QPointF(3, 3),
+                              child->mapToGlobal(QPointF(3, 3)),
+                              Qt::RightButton, Qt::RightButton,
+                              Qt::NoModifier);
+            QCoreApplication::sendEvent(child, &right);
+            report("...right-press selects the same way",
+                   canvas.selectedItem() == QStringLiteral("over"));
+
+            // Locked canvas: descendant presses select NOTHING — the
+            // app-wide filter leaves with edit mode.
+            canvas.setEditMode(false);
+            canvas.clearSelection();
+            QMouseEvent lockedEv(QEvent::MouseButtonPress, QPointF(3, 3),
+                                 child->mapToGlobal(QPointF(3, 3)),
+                                 Qt::LeftButton, Qt::LeftButton,
+                                 Qt::NoModifier);
+            QCoreApplication::sendEvent(child, &lockedEv);
+            report("...but never while locked",
+                   canvas.selectedItem().isEmpty());
+            canvas.setEditMode(true);
+        }
     }
 
     // ── Restoring a saved surface through the widget ─────────────────────

--- a/tests/workspace_canvas_widget_test.cpp
+++ b/tests/workspace_canvas_widget_test.cpp
@@ -344,9 +344,19 @@ int main(int argc, char** argv)
         // content consumes presses before the item widget sees them, so
         // the resize frame only appeared on right-clicks — the one press
         // nothing swallowed).  The app-wide filter walks up from wherever
-        // the press landed; left and right buttons alike.
+        // the press landed; left and right buttons alike.  The child
+        // ACCEPTS its presses, like the pan title strip does — a plain
+        // QWidget ignores them and Qt re-delivers to the parent, which
+        // let the pre-fix direct-match pass this test while the field
+        // stayed broken (the second 8600 report).
+        class PressEater : public QWidget {
+        public:
+            using QWidget::QWidget;
+        protected:
+            void mousePressEvent(QMouseEvent* e) override { e->accept(); }
+        };
         {
-            auto* child = new QWidget(over);
+            auto* child = new PressEater(over);
             child->setGeometry(2, 2, 20, 20);
             child->show();
             canvas.clearSelection();
@@ -378,6 +388,30 @@ int main(int argc, char** argv)
             report("...but never while locked",
                    canvas.selectedItem().isEmpty());
             canvas.setEditMode(true);
+        }
+
+        // A pan item selects on descendant press but is NOT raised: pans
+        // are the surface the station sits on (phase-4 stacking rule),
+        // and click-raising one over the applets would undo it until the
+        // next replay.
+        {
+            auto* pan = new QWidget;
+            canvas.addItem("pan:9", pan, NormRect{0.2, 0.2, 0.5, 0.5},
+                           QStringLiteral("panadapter"));
+            canvas.sendItemToBack("pan:9");
+            auto* strip = new PressEater(pan);
+            strip->setGeometry(2, 2, 30, 10);
+            strip->show();
+            canvas.clearSelection();
+            const int zBefore = canvas.layout().zOf("pan:9");
+            QMouseEvent ev(QEvent::MouseButtonPress, QPointF(3, 3),
+                           strip->mapToGlobal(QPointF(3, 3)),
+                           Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+            QCoreApplication::sendEvent(strip, &ev);
+            report("a pan's descendant press selects it",
+                   canvas.selectedItem() == QStringLiteral("pan:9"));
+            report("...without raising it over the applets",
+                   canvas.layout().zOf("pan:9") == zBefore);
         }
     }
 

--- a/tests/workspace_canvas_widget_test.cpp
+++ b/tests/workspace_canvas_widget_test.cpp
@@ -413,6 +413,24 @@ int main(int argc, char** argv)
             report("...without raising it over the applets",
                    canvas.layout().zOf("pan:9") == zBefore);
         }
+
+        // The walk never crosses a top-level boundary (red-team #4971
+        // N5): a popup or dialog opened FROM a canvas applet is parented
+        // to it, and selecting — possibly raising, a whole-document
+        // write — on a click inside one is not what the click meant.
+        {
+            auto* dlg = new QWidget(over, Qt::Window);
+            dlg->resize(60, 40);
+            dlg->show();
+            canvas.clearSelection();
+            QMouseEvent ev(QEvent::MouseButtonPress, QPointF(5, 5),
+                           dlg->mapToGlobal(QPointF(5, 5)),
+                           Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+            QCoreApplication::sendEvent(dlg, &ev);
+            report("a press inside an item's popup/dialog selects nothing",
+                   canvas.selectedItem().isEmpty());
+            dlg->hide();
+        }
     }
 
     // ── Restoring a saved surface through the widget ─────────────────────

--- a/tests/workspace_controller_test.cpp
+++ b/tests/workspace_controller_test.cpp
@@ -49,6 +49,7 @@ using AetherSDR::WorkspaceCanvas;
 using AetherSDR::WorkspaceController;
 using AetherSDR::WorkspaceDocument;
 using AetherSDR::WorkspaceStore;
+using AetherSDR::WorkspaceSurface;
 
 namespace {
 
@@ -1091,6 +1092,115 @@ int main(int argc, char** argv)
                        && ctl.canvasWindowList().isEmpty()
                        && !storedDocument().contains(sid2)
                        && tx->parentWidget() == &canvas);
+
+            // A window created AFTER a destroy must come up FULLY WIRED.
+            // The wire-once set keyed the deleted canvas by raw address; a
+            // fresh allocation reusing it was silently skipped by
+            // wireCanvas() and came up dead — no drops, no context menu,
+            // no gesture persistence (e85f9c81).  Two cycles: the
+            // allocator hands the SECOND fresh canvas the freed address
+            // (red-team #4971 M6, patch adopted verbatim).  Edit-mode
+            // mirroring is the cheapest observable only a live connection
+            // can produce.
+            {
+                bool wired = true;
+                for (int cycle = 0; cycle < 2; ++cycle) {
+                    const QString sidN =
+                        ctl.addCanvasWindow(QStringLiteral("Recycled"));
+                    WorkspaceCanvas* fresh = wins.value(sidN);
+                    if (!fresh) { wired = false; break; }
+                    fresh->setEditMode(!canvas.isEditMode());
+                    if (fresh->isEditMode() != canvas.isEditMode()) {
+                        wired = false;   // its signal never reached us
+                    }
+                    ctl.removeCanvasWindow(sidN);
+                }
+                report("...and a canvas allocated after one is wired", wired);
+            }
+
+            // The GPU recipe brackets EVERY cross-top-level pan move
+            // (red-team #4971 M5: nothing pinned it — deleting the hooks
+            // from all five call sites left the suite green).  prepare
+            // must precede the landing, finish must follow, and the
+            // counts must balance across move, hide, reopen and remove.
+            {
+                int prep = 0, fin = 0;
+                bool ordered = true;
+                hooks.prepareTopLevelMove = [&](const QString&) {
+                    if (prep != fin) ordered = false;   // unbalanced nesting
+                    ++prep;
+                };
+                hooks.finishTopLevelMove = [&](const QString&) {
+                    ++fin;
+                    if (fin > prep) ordered = false;    // finish before prepare
+                };
+                ctl.setPanHost(hooks);
+
+                const QString sidG =
+                    ctl.addCanvasWindow(QStringLiteral("GpuProbe"));
+                const QString panItemG =
+                    ctl.panItemIdFor(QStringLiteral("0x40000000"));
+                ctl.moveItemToSurface(panItemG, sidG);
+                const int afterMove = prep;
+                ctl.setCanvasWindowOpen(sidG, false);   // evict -> stack
+                ctl.setCanvasWindowOpen(sidG, true);    // re-place
+                ctl.removeCanvasWindow(sidG);           // evict + re-home
+                report("cross-top-level pan moves are GPU-bracketed (M5)",
+                       afterMove >= 1 && prep >= 4 && prep == fin && ordered);
+
+                hooks.prepareTopLevelMove = {};
+                hooks.finishTopLevelMove  = {};
+                ctl.setPanHost(hooks);   // detach before the locals die
+            }
+
+            // B1: an explicit palette surface RELOCATES a stale home.  TX
+            // recorded closed on MAIN; adding it from a window's palette
+            // must land it on THAT window, not resurrect it on main.
+            {
+                if (!tx->isContainerVisible()) tx->setContainerVisible(true);
+                if (!tx->isOnCanvas()) ctl.sendAppletToCanvas("TX");
+                tx->setContainerVisible(false);   // closed; home kept on main
+                const QString sidB =
+                    ctl.addCanvasWindow(QStringLiteral("B1Probe"));
+                report("palette add onto a window relocates the home (B1)",
+                       ctl.addAppletFromPalette(QStringLiteral("TX"),
+                                                QPointF(0.5, 0.5), sidB)
+                           && ctl.surfaceHosting(QStringLiteral("applet:TX"))
+                                  == sidB
+                           && tx->parentWidget() == wins.value(sidB)
+                           && !canvas.contains("applet:TX"));
+
+                // B2: a REFUSED add is a genuine no-op — hide the window,
+                // then try an implicit add: the home is hidden, so it must
+                // refuse BEFORE any write, leaving the document identical.
+                ctl.setCanvasWindowOpen(sidB, false);
+                const QString before = storedDocument();
+                report("a refused add writes NOTHING (B2)",
+                       !ctl.addAppletFromPalette(QStringLiteral("TX"),
+                                                 QPointF(0.5, 0.5))
+                           && storedDocument() == before);
+
+                // M2: disable() must hand hide-and-keep's transient closes
+                // back to the Classic shell — TX is recorded open on the
+                // hidden window and currently shut.
+                ctl.disable();
+                report("disable reopens a hidden window's applets (M2)",
+                       tx->isContainerVisible());
+                ctl.enable({"RX", "TX"});
+                canvas.setEditMode(true);
+
+                // M4: moving an item OFF a hidden window is an operator
+                // asking to SEE it — reopen and place, not a document-only
+                // edit that resurrects later.
+                report("move off a hidden window reopens and places (M4)",
+                       ctl.moveItemToSurface(QStringLiteral("applet:TX"),
+                                             WorkspaceSurface::kMainId)
+                           && tx->isContainerVisible()
+                           && tx->parentWidget() == &canvas
+                           && ctl.surfaceHosting(QStringLiteral("applet:TX"))
+                                  == WorkspaceSurface::kMainId);
+                ctl.removeCanvasWindow(sidB);
+            }
 
             ctl.setWindowHost({});
         }

--- a/tests/workspace_controller_test.cpp
+++ b/tests/workspace_controller_test.cpp
@@ -1123,31 +1123,57 @@ int main(int argc, char** argv)
             // from all five call sites left the suite green).  prepare
             // must precede the landing, finish must follow, and the
             // counts must balance across move, hide, reopen and remove.
+            // Ordering is PER PAN, not global (red-team #4971 N1): the
+            // replay paths deliberately BATCH — prepare(A) prepare(B) …
+            // restoreItems … finish(A) finish(B) — so a global
+            // alternation rule failed a correct implementation the
+            // moment a window held two pans, and the batched multi-pan
+            // shape (the realistic one) went unpinned.  Two live pans
+            // exercise it; the invariants are per-id bracketing and
+            // global balance.
             {
+                QHash<QString, int> pending;   // panId -> open prepares
                 int prep = 0, fin = 0;
                 bool ordered = true;
-                hooks.prepareTopLevelMove = [&](const QString&) {
-                    if (prep != fin) ordered = false;   // unbalanced nesting
+                hooks.prepareTopLevelMove = [&](const QString& id) {
+                    if (pending.value(id) != 0) ordered = false;
+                    pending[id] += 1;
                     ++prep;
                 };
-                hooks.finishTopLevelMove = [&](const QString&) {
+                hooks.finishTopLevelMove = [&](const QString& id) {
+                    if (pending.value(id) <= 0) ordered = false;
+                    pending[id] -= 1;
                     ++fin;
-                    if (fin > prep) ordered = false;    // finish before prepare
                 };
                 ctl.setPanHost(hooks);
+
+                auto* panG2 = new QWidget(&panOwner);
+                pans.insert(QStringLiteral("0x40000050"), panG2);
+                ctl.onPanAdded(QStringLiteral("0x40000050"));
 
                 const QString sidG =
                     ctl.addCanvasWindow(QStringLiteral("GpuProbe"));
                 const QString panItemG =
                     ctl.panItemIdFor(QStringLiteral("0x40000000"));
+                const QString panItemH =
+                    ctl.panItemIdFor(QStringLiteral("0x40000050"));
                 ctl.moveItemToSurface(panItemG, sidG);
+                ctl.moveItemToSurface(panItemH, sidG);
                 const int afterMove = prep;
-                ctl.setCanvasWindowOpen(sidG, false);   // evict -> stack
-                ctl.setCanvasWindowOpen(sidG, true);    // re-place
+                ctl.setCanvasWindowOpen(sidG, false);   // batched evict
+                ctl.setCanvasWindowOpen(sidG, true);    // batched re-place
                 ctl.removeCanvasWindow(sidG);           // evict + re-home
-                report("cross-top-level pan moves are GPU-bracketed (M5)",
-                       afterMove >= 1 && prep >= 4 && prep == fin && ordered);
+                bool allClosed = true;
+                for (int v : pending) {
+                    if (v != 0) allClosed = false;
+                }
+                report("cross-top-level pan moves are GPU-bracketed, "
+                       "batches included (M5/N1)",
+                       afterMove >= 2 && prep >= 8 && prep == fin && ordered
+                           && allClosed);
 
+                ctl.onPanRemoved(QStringLiteral("0x40000050"));
+                pans.remove(QStringLiteral("0x40000050"));
                 hooks.prepareTopLevelMove = {};
                 hooks.finishTopLevelMove  = {};
                 ctl.setPanHost(hooks);   // detach before the locals die
@@ -1199,6 +1225,32 @@ int main(int argc, char** argv)
                            && tx->parentWidget() == &canvas
                            && ctl.surfaceHosting(QStringLiteral("applet:TX"))
                                   == WorkspaceSurface::kMainId);
+
+                // N4: sibling verbs agree.  An unknown target surface is
+                // an ERROR (not a silent landing on main), and an
+                // EXPLICIT hidden target un-hides — the moveItemToSurface
+                // rule, applied to the palette engine.
+                report("add to an unknown surface refuses (N4)",
+                       !ctl.addAppletFromPalette(QStringLiteral("TX"),
+                                                 QPointF(0.5, 0.5),
+                                                 QStringLiteral("nosuch"))
+                           && ctl.surfaceHosting(QStringLiteral("applet:TX"))
+                                  == WorkspaceSurface::kMainId);
+                ctl.setCanvasWindowOpen(sidB, false);
+                ctl.returnAppletToPanel("TX");
+                tx->setContainerVisible(true);
+                report("add to an explicitly-named hidden window un-hides "
+                       "it (N4)",
+                       ctl.addAppletFromPalette(QStringLiteral("TX"),
+                                                QPointF(0.5, 0.5), sidB)
+                           && tx->parentWidget() == wins.value(sidB)
+                           && [&] {
+                                  for (const auto& info :
+                                       ctl.canvasWindowList()) {
+                                      if (info.id == sidB) return info.open;
+                                  }
+                                  return false;
+                              }());
                 ctl.removeCanvasWindow(sidB);
             }
 

--- a/tests/workspace_controller_test.cpp
+++ b/tests/workspace_controller_test.cpp
@@ -26,6 +26,9 @@
 #include <QApplication>
 #include <QDragEnterEvent>
 #include <QDropEvent>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QLabel>
 #include <QMap>
 #include <QSet>
@@ -931,6 +934,165 @@ int main(int argc, char** argv)
             report("palette: available applet classifies addable",
                    stateOf(QStringLiteral("RX")) == PE::State::Addable);
             ctl.setWidgetAvailabilityHook({});
+        }
+
+        // ── Additional canvas windows (RFC #4887 phase 7) ────────────
+        {
+            ctl.switchWorkspace(wsA);
+            ctl.setWidgetCatalog(
+                {{QStringLiteral("RX"), QStringLiteral("RX Controls"),
+                  QStringLiteral("Receive")},
+                 {QStringLiteral("TX"), QStringLiteral("TX Controls"),
+                  QStringLiteral("Transmit")}});
+            rx->setContainerVisible(true);
+            tx->setContainerVisible(true);
+            if (!rx->isOnCanvas()) ctl.sendAppletToCanvas("RX");
+            if (!tx->isOnCanvas()) ctl.sendAppletToCanvas("TX");
+            // The LIVE widget for this pan id — an earlier block replaced
+            // the original (slot reuse test), so never assert against the
+            // stale panA pointer.
+            QWidget* livePan = pans.value(QStringLiteral("0x40000000"));
+
+            // The window host provides bare canvases — the controller
+            // must never construct a real window; headless testability is
+            // the seam's whole point (the PanHostHooks rule again).
+            QMap<QString, WorkspaceCanvas*> wins;
+            QStringList closedWins, destroyedWins;
+            WorkspaceController::WindowHostHooks wh;
+            wh.openWindow = [&](const QString& sid, const QString&,
+                                const QByteArray&) -> WorkspaceCanvas* {
+                if (!wins.contains(sid)) {
+                    auto* c = new WorkspaceCanvas;
+                    c->resize(1000, 800);
+                    c->show();
+                    wins.insert(sid, c);
+                }
+                return wins.value(sid);
+            };
+            wh.closeWindow = [&](const QString& sid) {
+                closedWins.append(sid);   // hide — the canvas object stays
+            };
+            wh.destroyWindow = [&](const QString& sid) {
+                delete wins.take(sid);
+                destroyedWins.append(sid);
+            };
+            wh.geometryHint = [](const QString&) {
+                return QByteArrayLiteral("HINT");
+            };
+            ctl.setWindowHost(wh);
+
+            auto itemClosedInDoc = [&](const QString& itemId) {
+                const QJsonDocument d =
+                    QJsonDocument::fromJson(storedDocument().toUtf8());
+                for (const QJsonValue& w :
+                     d.object().value(QStringLiteral("workspaces")).toArray()) {
+                    for (const QJsonValue& sv :
+                         w.toObject().value(QStringLiteral("surfaces")).toArray()) {
+                        for (const QJsonValue& iv :
+                             sv.toObject().value(QStringLiteral("items")).toArray()) {
+                            if (iv.toObject().value(QStringLiteral("id"))
+                                    .toString() == itemId) {
+                                return iv.toObject()
+                                    .value(QStringLiteral("closed"))
+                                    .toBool(false);
+                            }
+                        }
+                    }
+                }
+                return false;
+            };
+
+            const QString sid =
+                ctl.addCanvasWindow(QStringLiteral("Right monitor"));
+            report("addCanvasWindow opens a window surface",
+                   !sid.isEmpty() && wins.contains(sid));
+            {
+                bool listed = false, open = false;
+                for (const auto& info : ctl.canvasWindowList())
+                    if (info.id == sid) { listed = true; open = info.open; }
+                report("...listed and open", listed && open);
+            }
+            report("...and persisted", storedDocument().contains(sid));
+
+            // Cross-surface move: document first, widget follows.
+            report("moveItemToSurface moves an applet's widget",
+                   ctl.moveItemToSurface(QStringLiteral("applet:RX"), sid)
+                       && rx->parentWidget() == wins.value(sid)
+                       && wins.value(sid)->contains("applet:RX")
+                       && !canvas.contains("applet:RX"));
+            report("...surfaceHosting agrees",
+                   ctl.surfaceHosting(QStringLiteral("applet:RX")) == sid);
+            const QString panItem =
+                ctl.panItemIdFor(QStringLiteral("0x40000000"));
+            report("moveItemToSurface moves a pan's widget",
+                   ctl.moveItemToSurface(panItem, sid)
+                       && livePan->parentWidget() == wins.value(sid));
+            report("...pans stay below applets on the new surface",
+                   wins.value(sid)->layout().zOf(panItem) == 0);
+
+            // A rect edit on the window canvas persists like any other.
+            wins.value(sid)->setItemRect("applet:RX",
+                                         NormRect{0.6, 0.6, 0.3, 0.3});
+            ctl.commitPlacement();
+
+            // HIDE-AND-KEEP (maintainer ruling): closing evicts
+            // transiently — the applet shuts with NO closed flag recorded,
+            // the pan returns to the stack — and reopening restores both.
+            report("closing the window hides and keeps",
+                   ctl.setCanvasWindowOpen(sid, false)
+                       && closedWins.contains(sid)
+                       && !rx->isContainerVisible()
+                       && livePan->parentWidget() != wins.value(sid));
+            report("...items stay recorded, closed flag ABSENT",
+                   storedDocument().contains(QStringLiteral("applet:RX"))
+                       && !itemClosedInDoc(QStringLiteral("applet:RX")));
+            report("reopening re-places applet and pan",
+                   ctl.setCanvasWindowOpen(sid, true)
+                       && rx->isContainerVisible()
+                       && rx->parentWidget() == wins.value(sid)
+                       && livePan->parentWidget() == wins.value(sid));
+            report("...at the edited rect",
+                   nearly(wins.value(sid)->itemRect("applet:RX").x, 0.6,
+                          0.05));
+
+            // A switch closes windows the target lacks and reopens them on
+            // the way back — with the arrangement intact.
+            const int closesBefore = closedWins.size();
+            const QString plain = ctl.createWorkspace(
+                WorkspaceController::NewWorkspaceSource::Blank,
+                QStringLiteral("NoWindows"));
+            report("switching away closes the window (hide, not destroy)",
+                   closedWins.size() > closesBefore
+                       && destroyedWins.isEmpty()
+                       && ctl.canvasWindowList().isEmpty());
+            ctl.switchWorkspace(wsA);
+            report("switching back reopens and re-places",
+                   rx->parentWidget() == wins.value(sid)
+                       && livePan->parentWidget() == wins.value(sid));
+            ctl.deleteWorkspace(plain);
+
+            // Removing the window moves its items home to main.
+            report("removeCanvasWindow destroys and re-homes",
+                   ctl.removeCanvasWindow(sid)
+                       && destroyedWins.contains(sid)
+                       && rx->isOnCanvas()
+                       && rx->parentWidget() == &canvas
+                       && livePan->parentWidget() == &canvas
+                       && ctl.canvasWindowList().isEmpty());
+
+            // Reset to Classic collapses extra surfaces: the stock shell
+            // is one window.
+            const QString sid2 =
+                ctl.addCanvasWindow(QStringLiteral("Doomed"));
+            ctl.moveItemToSurface(QStringLiteral("applet:TX"), sid2);
+            ctl.resetToClassic();
+            report("resetToClassic collapses extra windows",
+                   destroyedWins.contains(sid2)
+                       && ctl.canvasWindowList().isEmpty()
+                       && !storedDocument().contains(sid2)
+                       && tx->parentWidget() == &canvas);
+
+            ctl.setWindowHost({});
         }
 
         // Mode-off switch only retargets.

--- a/tests/workspace_document_test.cpp
+++ b/tests/workspace_document_test.cpp
@@ -477,6 +477,137 @@ int main()
         Q_UNUSED(before);
     }
 
+    // ── Surface CRUD + hide-and-keep flag (RFC #4887 phase 7) ────────────
+    {
+        WorkspaceDocument doc;
+        const QString ws = doc.addBlank(QStringLiteral("Main"));
+        doc.activeWorkspace = ws;
+
+        const QString s1 = doc.addSurface(ws, QStringLiteral("Right"));
+        const QString s2 = doc.addSurface(ws, QStringLiteral("Right"));
+        report("addSurface mints sequential ids and de-dups labels",
+               s1 == QStringLiteral("canvas2") && s2 == QStringLiteral("canvas3")
+                   && doc.workspace(ws)->surface(s2)->label
+                          == QStringLiteral("Right (2)"));
+        report("rename to own label is a no-op, not a suffix",
+               doc.renameSurface(ws, s1, QStringLiteral("Right"))
+                   && doc.workspace(ws)->surface(s1)->label
+                          == QStringLiteral("Right"));
+        report("main cannot be removed",
+               !doc.removeSurface(ws, WorkspaceSurface::kMainId));
+
+        // hidden round-trips, absent-when-false; a hidden MAIN repairs.
+        for (Workspace& w : doc.workspaces) {
+            for (WorkspaceSurface& surf : w.surfaces) {
+                if (surf.id == s1) surf.hidden = true;
+            }
+        }
+        {
+            const QByteArray blob = doc.toStoredJson();
+            report("hidden serializes on the closed window only",
+                   blob.contains("\"hidden\"")
+                       && blob.count("\"hidden\"") == 1);
+            WorkspaceDocument back;
+            report("...and round-trips",
+                   WorkspaceDocument::fromStoredJson(blob, &back)
+                       && back.workspace(ws)->surface(s1)->hidden
+                       && !back.workspace(ws)->surface(s2)->hidden);
+        }
+        {
+            QJsonObject root = doc.toJson();
+            QJsonArray wsArr = root.value(QStringLiteral("workspaces")).toArray();
+            QJsonObject w0   = wsArr.at(0).toObject();
+            QJsonArray surfs = w0.value(QStringLiteral("surfaces")).toArray();
+            QJsonObject main = surfs.at(0).toObject();
+            main[QStringLiteral("hidden")] = true;
+            surfs[0] = main;
+            w0[QStringLiteral("surfaces")] = surfs;
+            wsArr[0] = w0;
+            root[QStringLiteral("workspaces")] = wsArr;
+            WorkspaceDocument repaired;
+            QStringList warnings;
+            report("a hidden MAIN surface is repaired with a warning",
+                   WorkspaceDocument::fromJson(root, &repaired, nullptr,
+                                               &warnings)
+                       && !repaired.workspace(ws)
+                               ->surface(WorkspaceSurface::kMainId)
+                               ->hidden
+                       && !warnings.isEmpty());
+        }
+
+        // Item ids are WORKSPACE-wide identity: a duplicate on another
+        // surface is dropped at parse, not placed twice.
+        {
+            QJsonObject root = doc.toJson();
+            QJsonArray wsArr = root.value(QStringLiteral("workspaces")).toArray();
+            QJsonObject w0   = wsArr.at(0).toObject();
+            QJsonArray surfs = w0.value(QStringLiteral("surfaces")).toArray();
+            QJsonObject item;
+            item[QStringLiteral("id")]   = QStringLiteral("applet:DUP");
+            item[QStringLiteral("rect")] =
+                QJsonArray{0.1, 0.1, 0.5, 0.5};
+            for (int i = 0; i < 2; ++i) {
+                QJsonObject so   = surfs.at(i).toObject();
+                QJsonArray items = so.value(QStringLiteral("items")).toArray();
+                items.append(item);
+                so[QStringLiteral("items")] = items;
+                surfs[i] = so;
+            }
+            w0[QStringLiteral("surfaces")] = surfs;
+            wsArr[0] = w0;
+            root[QStringLiteral("workspaces")] = wsArr;
+            WorkspaceDocument back;
+            QStringList warnings;
+            int found = 0;
+            const bool ok =
+                WorkspaceDocument::fromJson(root, &back, nullptr, &warnings);
+            if (ok) {
+                for (const WorkspaceSurface& surf :
+                     back.workspace(ws)->surfaces) {
+                    for (const CanvasItem& it : surf.items) {
+                        if (it.id == QStringLiteral("applet:DUP")) ++found;
+                    }
+                }
+            }
+            report("duplicate item ids are deduped ACROSS surfaces",
+                   ok && found == 1 && !warnings.isEmpty());
+        }
+
+        // removeSurface parks the orphans on main.
+        {
+            for (Workspace& w : doc.workspaces) {
+                for (WorkspaceSurface& surf : w.surfaces) {
+                    if (surf.id == s2) {
+                        CanvasItem it;
+                        it.id   = QStringLiteral("applet:ORPHAN");
+                        it.rect = NormRect{0.2, 0.2, 0.4, 0.4};
+                        surf.items.append(it);
+                    }
+                }
+            }
+            report("removeSurface moves items to main",
+                   doc.removeSurface(ws, s2)
+                       && !doc.workspace(ws)->surface(s2)
+                       && [&] {
+                              for (const CanvasItem& it :
+                                   doc.workspace(ws)
+                                       ->surface(WorkspaceSurface::kMainId)
+                                       ->items) {
+                                  if (it.id == QStringLiteral("applet:ORPHAN"))
+                                      return true;
+                              }
+                              return false;
+                          }());
+        }
+        // duplicate deep-copies surfaces (pre-existing behaviour, now
+        // load-bearing for phase 7).
+        const QString clone = doc.addDuplicateOf(ws, QStringLiteral("Clone"));
+        report("duplicating a workspace clones its extra surfaces",
+               !clone.isEmpty()
+                   && doc.workspace(clone)->surface(s1) != nullptr
+                   && doc.workspace(clone)->surface(s1)->hidden);
+    }
+
     std::printf("\n%s\n", g_failures == 0 ? "All checks passed." : "FAILURES present.");
     return g_failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## RFC #4887, phase 7 — additional canvas windows

A workspace can now span top-level canvas windows: **View ▸ Workspace Canvas ▸ Canvas Windows** creates, opens/closes, renames and removes them, and every item — applets and pans alike — moves between surfaces through a right-click **Move to ▸** menu.

Two maintainer rulings shaped the phase:

- **Hide-and-keep**: closing a canvas window hides the surface; its items stay recorded and return exactly on reopen. "Remove window" is the destructive path (items re-home to main). 
- **Menu-only moves this phase**: live cross-window drag is deferred — cross-window moves are cross-top-level reparents, the #2495/#4617/#4319 crash lineage, and they go through one deliberate, safe path.

## The schema needed nothing

`surfaces[]` and the `windowGeometry` hint shipped in phase 2 and have round-tripped ever since — this phase is their first consumer. Item rects stay authoritative fractions of their surface; window placement stays a hint (Wayland declines position; that costs one drag, never a layout). Still schema v1; a phase-6 build downgrades gracefully. Two additive changes: a per-surface `hidden` flag (absent-when-false; a hidden `main` is repaired at parse) and item-id dedup widened to workspace scope (item ids are cross-surface identity now).

## Shape

- **`WorkspaceWindow`** — a thin top-level hosting one `WorkspaceCanvas`, following `FloatingContainerWindow`'s frameless/shutdown contract: flags re-applied before show, screen-clamped hint restore (the disconnected-monitor guard), debounced hint save, `prepareShutdown()`, explicit delete at exit (#2495). Wired into MainWindow's ordered teardown, which previously had no workspace step at all.
- **`WorkspaceController` grows a `WindowHostHooks` seam** (the `PanHostHooks` philosophy): MainWindow owns real windows, the unit suite provides bare canvases, surface *policy* stays headless-tested. The single-canvas assumption is gone — placement, release, recall, stacking, undo, tidy, gestures and every document writer are surface-keyed.
- **Cross-window moves**: pans take the `floatPanadapter` GPU recipe through new `PanadapterStack::prepare/finishPanTopLevelMove`; applets go through the manager's existing reparent preparation. Document pivots first, widget follows (the switch-ordering lesson from #4964, applied to moves).
- **Lifecycle**: windows follow workspace switches (close/open to match the target), survive restarts, and open one deferred event-loop turn at enable — the `wl_subsurface` no-parent hazard the disable path already dodges. Reset-to-Classic collapses extra surfaces: the stock shell is one window.
- **Bridge**: `workspace window <new|list|open|close|remove|rename>`, `workspace move <itemId> <surfaceId>`, `workspace add <appletId> [surfaceId]` (the palette engine's first non-menu caller, same availability gate as the menu), `status` grows per-item `surface` tags plus a `surfaces[]` block, `place` routes to the hosting canvas. Docs regenerated; `--check` green.

## Tests

- `workspace_controller_test`: full multi-surface block — window CRUD, cross-moves (applet and pan), hide-and-keep round trip with the closed-flag-absent pin, switch reconciliation (hide, not destroy), remove re-homing, reset collapse.
- `workspace_document_test`: surface CRUD, `hidden` round-trip and hidden-main repair, cross-surface dedup, duplicate-workspace deep-copy of surfaces.
- Full suite: 292/292.

## Live verification (offscreen, real `WorkspaceWindow`, bridge-driven)

Window create → `add RX` directly onto it → `move pan:0` across (pan stays below the applet on the new surface) → hide/reopen round trip with both items re-hosted → `place` routes to the window canvas → remove re-homes to main → **restart restores the window open with both items hosted**.

## Known scope edges

- Live cross-window drag: deferred by ruling (the Move to ▸ path has to prove itself in the field first).
- Band stack, import-floats and the phase-3 panstack stay main-surface by design.
- An open applet with no workspace item is still not auto-placed (the phase-3 membership rule; the palette is the add path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Round 2 (red-team fixes, `b2dbec99`)

The [red-team review](https://github.com/aethersdr/AetherSDR/pull/4971#issuecomment-5285669873) found two blockers (one root cause: `writeItemPresence`'s surface argument was dead for existing items), a window-lifetime hole, and precise test-honesty gaps. All addressed:

- **B1/B2**: an explicit palette surface now **relocates** a stale home; refusals come before any write (byte-identical no-op, pinned + live-verified).
- **M1**: hidden windows destroy properly everywhere — unconditional destroys, a destroyed-watch on the wire-once set, and a whole-map shutdown sweep in MainWindow. Live-verified via dumpTree.
- **M2**: `disable()` reopens applets a hidden window transiently closed. **M3**: `open` reports live truth, `wanted` carries document intent. **M4**: moving an item off a hidden window reopens and places it.
- **M5/M6**: the GPU recipe is now pinned by counting hooks, and the reviewer's two-cycle wire-once probe is adopted verbatim.
- **L1–L6**: import targets main explicitly, per-workspace geometry hints survive switches, z clamps to ≥ 0, rename gains the enabled guard, the transient helpers are nest-safe.

Full suite 292/292 offscreen after the round.

