### PR TITLE
fix(logs): Add lightweight shutdown phase breadcrumbs

### DIFF
--- a/src/asr/AsrEngine.cpp
+++ b/src/asr/AsrEngine.cpp
@@ -3,6 +3,7 @@
 #include "asr/SileroVad.h"
 #include "asr/SpeakerEmbedder.h"
 #include "core/Resampler.h"
+#include "core/ShutdownTrace.h"
 
 #include <QLoggingCategory>
 #include <QRegularExpression>
@@ -522,6 +523,7 @@ void AsrEngine::startThread(AsrBackendFactory factory, const AsrSegmenter::Confi
 
 AsrEngine::~AsrEngine()
 {
+    ShutdownTrace trace("asr.thread.join");
     if (m_thread != nullptr) {
         if (m_worker != nullptr) {
             // Qt's own quit() already stops the worker from starting any FURTHER

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -3,6 +3,7 @@
 #include "AudioSummaryLogger.h"
 #include "AudioDeviceNegotiator.h"
 #include "TxCaptureBuffer.h"
+#include "ShutdownTrace.h"
 #include "ClientEq.h"
 #include "ClientComp.h"
 #include "ClientGate.h"
@@ -2602,7 +2603,9 @@ AudioEngine::AudioEngine(QObject* parent)
 
 AudioEngine::~AudioEngine()
 {
+    ShutdownTrace destructorTrace("audio.destructor");
     {
+        ShutdownTrace trace("audio.dsp_initialization.join");
         std::lock_guard<std::mutex> lock(m_dspInitializationTasksMutex);
         m_dspInitializationStopping = true;
         m_dspInitializationTasks.waitForFinished();

--- a/src/core/DxccColorProvider.cpp
+++ b/src/core/DxccColorProvider.cpp
@@ -1,5 +1,6 @@
 #include "DxccColorProvider.h"
 #include "AdifParser.h"
+#include "ShutdownTrace.h"
 
 #include <QFileInfo>
 #include <QMetaObject>
@@ -67,6 +68,7 @@ DxccColorProvider::DxccColorProvider(QObject* parent)
 
 DxccColorProvider::~DxccColorProvider()
 {
+    ShutdownTrace trace("dxcc.parser_thread.join");
     m_parseThread.quit();
     m_parseThread.wait();
     delete m_parser;

--- a/src/core/KiwiSdrManager.cpp
+++ b/src/core/KiwiSdrManager.cpp
@@ -385,6 +385,7 @@ KiwiSdrManager::~KiwiSdrManager()
         ShutdownTrace trace("kiwi.thread.join");
         m_clientThread->quit();
         if (!m_clientThread->wait(3000)) {
+            trace.fail("thread_join_timeout");
             qCWarning(lcKiwiSdr)
                 << "KiwiSDR client thread did not stop during manager teardown";
             m_clientThread->setParent(nullptr);

--- a/src/core/KiwiSdrManager.cpp
+++ b/src/core/KiwiSdrManager.cpp
@@ -2,6 +2,7 @@
 
 #include "AppSettings.h"
 #include "LogManager.h"
+#include "ShutdownTrace.h"
 
 #include <QDir>
 #include <QFile>
@@ -372,12 +373,16 @@ KiwiSdrManager::KiwiSdrManager(
 
 KiwiSdrManager::~KiwiSdrManager()
 {
-    disconnectAll();
-    const QStringList ids = m_clients.keys();
-    for (const QString& id : ids) {
-        destroyClient(id, true);
+    {
+        ShutdownTrace trace("kiwi.clients.destroy");
+        disconnectAll();
+        const QStringList ids = m_clients.keys();
+        for (const QString& id : ids) {
+            destroyClient(id, true);
+        }
     }
     if (m_clientThread) {
+        ShutdownTrace trace("kiwi.thread.join");
         m_clientThread->quit();
         if (!m_clientThread->wait(3000)) {
             qCWarning(lcKiwiSdr)

--- a/src/core/ShutdownTrace.h
+++ b/src/core/ShutdownTrace.h
@@ -4,30 +4,71 @@
 #include <QElapsedTimer>
 #include <QMessageLogger>
 
+#include <source_location>
+
 namespace AetherSDR {
 
 // A deliberately small shutdown breadcrumb. If teardown blocks inside a scope,
-// the support log ends with its begin record; successful scopes add elapsed time.
+// the support log ends with its begin record; successful scopes add elapsed time
+// and an explicit outcome.
+//
+// THE OUTCOME IS NOT OPTIONAL, because "end" alone lies about a timeout. A join
+// that never completes still leaves its scope when wait(3000) gives up, so
+// without fail() the record reads `event=end elapsed_ms=3000` — indistinguishable
+// from a clean join to every reader except one who happens to know the timeout is
+// 3000. That is exactly the case this instrumentation exists to catch on a
+// Windows force-quit log, so every bounded wait must report which way it went.
+//
+// NOT A Q_LOGGING_CATEGORY, and deliberately absent from LogManager's registry
+// table. QMessageLogger(..., "aether.shutdown").info() bypasses category
+// filtering entirely — unlike the qCInfo(cat) macro it never consults the
+// category's enabled state, so the string only ends up in the message context.
+// These records are therefore in EVERY support log, which is the one property
+// they need: a hang cannot be reproduced on request with logging turned up, and
+// a breadcrumb you can accidentally switch off is useless in a force-quit log.
+// Registering it would put a toggle in the Log Settings UI that either does
+// nothing or, worse, works. Cf. the aether.hl2.tx note in LogManager.cpp, which
+// documents the OPPOSITE failure (a category invisible because it was missing
+// from that table) — the lesson there does not apply here, and someone applying
+// it anyway would silently make these suppressible.
 class ShutdownTrace final
 {
 public:
-    explicit ShutdownTrace(const char* phase)
-        : m_phase(phase)
+    // The location defaults to the CALLER, not to this header. Captured through
+    // std::source_location because __FILE__/__LINE__/Q_FUNC_INFO expand where
+    // they are written: with them inside message() every breadcrumb in the log
+    // reported its origin as ShutdownTrace.h, in message(), rather than the
+    // teardown site it describes.
+    explicit ShutdownTrace(const char* phase,
+                           std::source_location where = std::source_location::current())
+        : m_phase(phase), m_where(where)
     {
         m_timer.start();
-        message().noquote().nospace()
+        message(m_where).noquote().nospace()
             << "phase=" << m_phase << " event=begin";
     }
 
     ~ShutdownTrace()
     {
-        message().noquote().nospace()
-            << "phase=" << m_phase << " event=end elapsed_ms=" << m_timer.elapsed();
+        message(m_where).noquote().nospace()
+            << "phase=" << m_phase << " event=end"
+            << " result=" << (m_why ? m_why : "ok")
+            << " elapsed_ms=" << m_timer.elapsed();
     }
 
-    static void complete(const char* phase)
+    // Record that the scope did NOT complete cleanly. `why` is a short stable
+    // token (no spaces) so a log scraper can group on it. First call wins: the
+    // first thing that went wrong is the one worth chasing.
+    void fail(const char* why) noexcept
     {
-        message().noquote().nospace()
+        if (!m_why)
+            m_why = why;
+    }
+
+    static void complete(const char* phase,
+                         std::source_location where = std::source_location::current())
+    {
+        message(where).noquote().nospace()
             << "phase=" << phase << " event=complete";
     }
 
@@ -35,13 +76,15 @@ public:
     ShutdownTrace& operator=(const ShutdownTrace&) = delete;
 
 private:
-    static QDebug message()
+    static QDebug message(const std::source_location& where)
     {
-        return QMessageLogger(__FILE__, __LINE__, Q_FUNC_INFO,
-                              "aether.shutdown").info();
+        return QMessageLogger(where.file_name(), static_cast<int>(where.line()),
+                              where.function_name(), "aether.shutdown").info();
     }
 
     const char* m_phase;
+    const char* m_why = nullptr;   // nullptr = ok
+    std::source_location m_where;
     QElapsedTimer m_timer;
 };
 

--- a/src/core/ShutdownTrace.h
+++ b/src/core/ShutdownTrace.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <QDebug>
+#include <QElapsedTimer>
+#include <QMessageLogger>
+
+namespace AetherSDR {
+
+// A deliberately small shutdown breadcrumb. If teardown blocks inside a scope,
+// the support log ends with its begin record; successful scopes add elapsed time.
+class ShutdownTrace final
+{
+public:
+    explicit ShutdownTrace(const char* phase)
+        : m_phase(phase)
+    {
+        m_timer.start();
+        message().noquote().nospace()
+            << "phase=" << m_phase << " event=begin";
+    }
+
+    ~ShutdownTrace()
+    {
+        message().noquote().nospace()
+            << "phase=" << m_phase << " event=end elapsed_ms=" << m_timer.elapsed();
+    }
+
+    static void complete(const char* phase)
+    {
+        message().noquote().nospace()
+            << "phase=" << phase << " event=complete";
+    }
+
+    ShutdownTrace(const ShutdownTrace&) = delete;
+    ShutdownTrace& operator=(const ShutdownTrace&) = delete;
+
+private:
+    static QDebug message()
+    {
+        return QMessageLogger(__FILE__, __LINE__, Q_FUNC_INFO,
+                              "aether.shutdown").info();
+    }
+
+    const char* m_phase;
+    QElapsedTimer m_timer;
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -38,6 +38,7 @@
 #include "PanLayoutDialog.h"
 #include "core/RadioMessageTypes.h"   // MessageSeverity for onRadioMessage
 #include "core/LogManager.h"
+#include "core/ShutdownTrace.h"
 #include "core/PerfTelemetry.h"
 #include "core/PeripheralSettings.h"
 #include "core/VoiceSignalDetector.h"
@@ -2526,6 +2527,7 @@ MainWindow::MainWindow(QWidget* parent)
 
 MainWindow::~MainWindow()
 {
+    ShutdownTrace destructorTrace("main_window.destructor_body");
     qApp->removeEventFilter(this);
     preparePanadapterUiForShutdown();
 
@@ -2534,6 +2536,7 @@ MainWindow::~MainWindow()
     // them down while MainWindow members are still alive instead of waiting for
     // QWidget child cleanup after member destruction.
     if (m_kiwiSdrManager) {
+        ShutdownTrace trace("kiwi.manager.destroy");
         QObject::disconnect(m_kiwiSdrManager, nullptr, this, nullptr);
         if (m_audio) {
             QObject::disconnect(m_kiwiSdrManager, nullptr, m_audio, nullptr);
@@ -2546,7 +2549,10 @@ MainWindow::~MainWindow()
     // Stop the CWX sidetone keyer (its own worker thread) before AudioEngine is
     // torn down below — its onKeyDownChange callback touches m_audio->cwSidetone()
     // (#3623). reset() joins the worker, so no key edge can fire afterward.
-    m_cwxLocalKeyer.reset();
+    {
+        ShutdownTrace trace("cwx.keyer.destroy");
+        m_cwxLocalKeyer.reset();
+    }
 
 #ifdef HAVE_RADE
     if (m_radeSliceId >= 0)
@@ -2568,6 +2574,7 @@ MainWindow::~MainWindow()
     // UAF pattern as m_networkDiagnosticsDialog above. Tear it down now
     // while AudioEngine is still alive.
     if (m_ax25HfPacketDecodeDialog) {
+        ShutdownTrace trace("ax25.dialog.destroy");
         delete m_ax25HfPacketDecodeDialog.data();
         m_ax25HfPacketDecodeDialog = nullptr;
     }
@@ -2576,20 +2583,28 @@ MainWindow::~MainWindow()
     // Use BlockingQueuedConnection to ensure completion before we proceed.
     if (m_audio && m_audioThread && m_audioThread->isRunning()) {
         AudioEngine* audio = m_audio;
-        QMetaObject::invokeMethod(audio, [audio]() {
-            audio->setNr2Enabled(false);
-            audio->setRn2Enabled(false);
-            audio->setNvAfxEnabled(false);
-            audio->stopRxStream();
-            audio->stopTxStream();
-        }, Qt::BlockingQueuedConnection);
+        {
+            ShutdownTrace trace("audio.stop.invoke");
+            QMetaObject::invokeMethod(audio, [audio]() {
+                ShutdownTrace workerTrace("audio.stop.worker");
+                audio->setNr2Enabled(false);
+                audio->setRn2Enabled(false);
+                audio->setNvAfxEnabled(false);
+                audio->stopRxStream();
+                audio->stopTxStream();
+            }, Qt::BlockingQueuedConnection);
+        }
         audio->deleteLater();
-        m_audioThread->quit();
-        m_audioThread->wait(3000);
+        {
+            ShutdownTrace trace("audio.thread.join");
+            m_audioThread->quit();
+            m_audioThread->wait(3000);
+        }
     } else {
         delete m_audio;
     }
     if (m_audioThread && m_audioThread->isRunning()) {
+        ShutdownTrace trace("audio.thread.join_retry");
         m_audioThread->quit();
         m_audioThread->wait(3000);
     }
@@ -2606,7 +2621,10 @@ MainWindow::~MainWindow()
     // back-reference first so no dangling pointer remains in the widget tree.
     if (m_appletPanel && m_appletPanel->tciApplet())
         m_appletPanel->tciApplet()->setTciServer(nullptr);
-    m_session->shutdownTciServer();
+    {
+        ShutdownTrace trace("tci.server.destroy");
+        m_session->shutdownTciServer();
+    }
 #endif
 
     // Stop external controller thread (#502)
@@ -2615,8 +2633,14 @@ MainWindow::~MainWindow()
         // the cross-thread QObject access crash (QSerialPort has thread affinity
         // to m_extCtrlThread; calling close() from main thread hits a fatal assert).
 #ifdef HAVE_SERIALPORT
-        QMetaObject::invokeMethod(m_serialPort, [this] { m_serialPort->close(); },
-                                  Qt::BlockingQueuedConnection);
+        {
+            ShutdownTrace trace("controllers.serial.close");
+            QMetaObject::invokeMethod(m_serialPort, [this] {
+                ShutdownTrace workerTrace("controllers.serial.close.worker");
+                m_serialPort->close();
+            },
+                                      Qt::BlockingQueuedConnection);
+        }
         // FlexControlManager owns its own QSerialPort.  Close it
         // synchronously on the ExtControllers thread before tearing the
         // thread down — otherwise on Windows the OS handle for the
@@ -2628,19 +2652,31 @@ MainWindow::~MainWindow()
         // TaskManager.  Same pattern as the m_midiControl /
         // m_hidEncoder closes below.
         if (m_flexControl) {
-            QMetaObject::invokeMethod(m_flexControl, &FlexControlManager::close,
+            ShutdownTrace trace("controllers.flex_control.close");
+            QMetaObject::invokeMethod(m_flexControl, [this] {
+                ShutdownTrace workerTrace("controllers.flex_control.close.worker");
+                m_flexControl->close();
+            },
                                       Qt::BlockingQueuedConnection);
         }
 #endif
 #ifdef HAVE_MIDI
         if (m_midiControl) {
-            QMetaObject::invokeMethod(m_midiControl, &MidiControlManager::closePort,
+            ShutdownTrace trace("controllers.midi.close");
+            QMetaObject::invokeMethod(m_midiControl, [this] {
+                ShutdownTrace workerTrace("controllers.midi.close.worker");
+                m_midiControl->closePort();
+            },
                                       Qt::BlockingQueuedConnection);
         }
 #endif
 #ifdef HAVE_HIDAPI
         if (m_hidEncoder) {
-            QMetaObject::invokeMethod(m_hidEncoder, &HidEncoderManager::close,
+            ShutdownTrace trace("controllers.hid.close");
+            QMetaObject::invokeMethod(m_hidEncoder, [this] {
+                ShutdownTrace workerTrace("controllers.hid.close.worker");
+                m_hidEncoder->close();
+            },
                                       Qt::BlockingQueuedConnection);
         }
 #endif
@@ -2657,8 +2693,11 @@ MainWindow::~MainWindow()
             m_midiControl->deleteLater();
         }
 #endif
-        m_extCtrlThread->quit();
-        m_extCtrlThread->wait(3000);
+        {
+            ShutdownTrace trace("controllers.thread.join");
+            m_extCtrlThread->quit();
+            m_extCtrlThread->wait(3000);
+        }
         // Delete ExtControllers objects synchronously after the thread stops.
         // deleteLater() races with quit() and can leave destructors unrun.
         // On macOS, UlanziDialMacOSManager::stop() calls
@@ -2667,7 +2706,10 @@ MainWindow::~MainWindow()
         // the main thread is blocked waiting for the cross-thread call to return.
         // Safe to call directly here: the ExtControllers thread has stopped so
         // there is no race on m_dialBackend's state.
-        if (m_dialBackend) m_dialBackend->stop();
+        if (m_dialBackend) {
+            ShutdownTrace trace("controllers.dial.stop");
+            m_dialBackend->stop();
+        }
         delete m_dialBackend;
         m_dialBackend = nullptr;
 #ifdef HAVE_HIDAPI
@@ -3564,6 +3606,7 @@ void MainWindow::changeEvent(QEvent* event)
 
 void MainWindow::closeEvent(QCloseEvent* event)
 {
+    ShutdownTrace closeEventTrace("main_window.close_event");
     // Release the TGXL/PGXL native control sockets explicitly so the radio
     // can resume polling them on behalf of other clients (e.g. Maestro).
     // The radio-disconnect handler does this via a queued connection on
@@ -3727,7 +3770,10 @@ void MainWindow::closeEvent(QCloseEvent* event)
         deactivateRADE();
 #endif
 
-    m_radioModel.disconnectFromRadio();
+    {
+        ShutdownTrace trace("radio.disconnect");
+        m_radioModel.disconnectFromRadio();
+    }
     audioStopRx();
 
     // Stop spot client worker thread
@@ -3743,26 +3789,50 @@ void MainWindow::closeEvent(QCloseEvent* event)
 #ifdef HAVE_WEBSOCKETS
             FreeDvClient* freedvClient = m_freedvClient;
 #endif
-            QMetaObject::invokeMethod(dxCluster, [dxCluster] { dxCluster->disconnect(); },
-                                      Qt::BlockingQueuedConnection);
-            QMetaObject::invokeMethod(rbnClient, [rbnClient] { rbnClient->disconnect(); },
-                                      Qt::BlockingQueuedConnection);
-            QMetaObject::invokeMethod(wsjtxClient, [wsjtxClient] { wsjtxClient->stopListening(); },
-                                      Qt::BlockingQueuedConnection);
-            QMetaObject::invokeMethod(spotCollectorClient,
-                                      [spotCollectorClient] { spotCollectorClient->stopListening(); },
-                                      Qt::BlockingQueuedConnection);
-            QMetaObject::invokeMethod(potaClient, [potaClient] { potaClient->stopPolling(); },
-                                      Qt::BlockingQueuedConnection);
-            QMetaObject::invokeMethod(eibiClient, [eibiClient] { eibiClient->setEnabled(false); },
-                                      Qt::BlockingQueuedConnection);
-            QMetaObject::invokeMethod(n1mmSpotClient,
-                                      [n1mmSpotClient] { n1mmSpotClient->stopListening(); },
-                                      Qt::BlockingQueuedConnection);
+            {
+                ShutdownTrace trace("spots.dx_cluster.disconnect");
+                QMetaObject::invokeMethod(dxCluster, [dxCluster] { dxCluster->disconnect(); },
+                                          Qt::BlockingQueuedConnection);
+            }
+            {
+                ShutdownTrace trace("spots.rbn.disconnect");
+                QMetaObject::invokeMethod(rbnClient, [rbnClient] { rbnClient->disconnect(); },
+                                          Qt::BlockingQueuedConnection);
+            }
+            {
+                ShutdownTrace trace("spots.wsjtx.stop");
+                QMetaObject::invokeMethod(wsjtxClient, [wsjtxClient] { wsjtxClient->stopListening(); },
+                                          Qt::BlockingQueuedConnection);
+            }
+            {
+                ShutdownTrace trace("spots.collector.stop");
+                QMetaObject::invokeMethod(spotCollectorClient,
+                                          [spotCollectorClient] { spotCollectorClient->stopListening(); },
+                                          Qt::BlockingQueuedConnection);
+            }
+            {
+                ShutdownTrace trace("spots.pota.stop");
+                QMetaObject::invokeMethod(potaClient, [potaClient] { potaClient->stopPolling(); },
+                                          Qt::BlockingQueuedConnection);
+            }
+            {
+                ShutdownTrace trace("spots.eibi.stop");
+                QMetaObject::invokeMethod(eibiClient, [eibiClient] { eibiClient->setEnabled(false); },
+                                          Qt::BlockingQueuedConnection);
+            }
+            {
+                ShutdownTrace trace("spots.n1mm.stop");
+                QMetaObject::invokeMethod(n1mmSpotClient,
+                                          [n1mmSpotClient] { n1mmSpotClient->stopListening(); },
+                                          Qt::BlockingQueuedConnection);
+            }
 #ifdef HAVE_WEBSOCKETS
-            QMetaObject::invokeMethod(freedvClient,
-                                      [freedvClient] { freedvClient->stopConnection(); },
-                                      Qt::BlockingQueuedConnection);
+            {
+                ShutdownTrace trace("spots.freedv.stop");
+                QMetaObject::invokeMethod(freedvClient,
+                                          [freedvClient] { freedvClient->stopConnection(); },
+                                          Qt::BlockingQueuedConnection);
+            }
 #endif
             dxCluster->deleteLater();
             rbnClient->deleteLater();
@@ -3774,8 +3844,11 @@ void MainWindow::closeEvent(QCloseEvent* event)
 #ifdef HAVE_WEBSOCKETS
             freedvClient->deleteLater();
 #endif
-            m_spotThread->quit();
-            m_spotThread->wait(3000);
+            {
+                ShutdownTrace trace("spots.thread.join");
+                m_spotThread->quit();
+                m_spotThread->wait(3000);
+            }
         } else {
             delete m_dxCluster;
             delete m_rbnClient;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2598,7 +2598,8 @@ MainWindow::~MainWindow()
         {
             ShutdownTrace trace("audio.thread.join");
             m_audioThread->quit();
-            m_audioThread->wait(3000);
+            if (!m_audioThread->wait(3000))
+                trace.fail("thread_join_timeout");
         }
     } else {
         delete m_audio;
@@ -2606,7 +2607,8 @@ MainWindow::~MainWindow()
     if (m_audioThread && m_audioThread->isRunning()) {
         ShutdownTrace trace("audio.thread.join_retry");
         m_audioThread->quit();
-        m_audioThread->wait(3000);
+        if (!m_audioThread->wait(3000))
+            trace.fail("thread_join_timeout");
     }
     m_audio = nullptr;
 
@@ -2696,7 +2698,8 @@ MainWindow::~MainWindow()
         {
             ShutdownTrace trace("controllers.thread.join");
             m_extCtrlThread->quit();
-            m_extCtrlThread->wait(3000);
+            if (!m_extCtrlThread->wait(3000))
+                trace.fail("thread_join_timeout");
         }
         // Delete ExtControllers objects synchronously after the thread stops.
         // deleteLater() races with quit() and can leave destructors unrun.
@@ -3791,46 +3794,70 @@ void MainWindow::closeEvent(QCloseEvent* event)
 #endif
             {
                 ShutdownTrace trace("spots.dx_cluster.disconnect");
-                QMetaObject::invokeMethod(dxCluster, [dxCluster] { dxCluster->disconnect(); },
+                QMetaObject::invokeMethod(dxCluster, [dxCluster] {
+                    ShutdownTrace workerTrace("spots.dx_cluster.disconnect.worker");
+                    dxCluster->disconnect();
+                },
                                           Qt::BlockingQueuedConnection);
             }
             {
                 ShutdownTrace trace("spots.rbn.disconnect");
-                QMetaObject::invokeMethod(rbnClient, [rbnClient] { rbnClient->disconnect(); },
+                QMetaObject::invokeMethod(rbnClient, [rbnClient] {
+                    ShutdownTrace workerTrace("spots.rbn.disconnect.worker");
+                    rbnClient->disconnect();
+                },
                                           Qt::BlockingQueuedConnection);
             }
             {
                 ShutdownTrace trace("spots.wsjtx.stop");
-                QMetaObject::invokeMethod(wsjtxClient, [wsjtxClient] { wsjtxClient->stopListening(); },
+                QMetaObject::invokeMethod(wsjtxClient, [wsjtxClient] {
+                    ShutdownTrace workerTrace("spots.wsjtx.stop.worker");
+                    wsjtxClient->stopListening();
+                },
                                           Qt::BlockingQueuedConnection);
             }
             {
                 ShutdownTrace trace("spots.collector.stop");
                 QMetaObject::invokeMethod(spotCollectorClient,
-                                          [spotCollectorClient] { spotCollectorClient->stopListening(); },
+                                          [spotCollectorClient] {
+                    ShutdownTrace workerTrace("spots.collector.stop.worker");
+                    spotCollectorClient->stopListening();
+                },
                                           Qt::BlockingQueuedConnection);
             }
             {
                 ShutdownTrace trace("spots.pota.stop");
-                QMetaObject::invokeMethod(potaClient, [potaClient] { potaClient->stopPolling(); },
+                QMetaObject::invokeMethod(potaClient, [potaClient] {
+                    ShutdownTrace workerTrace("spots.pota.stop.worker");
+                    potaClient->stopPolling();
+                },
                                           Qt::BlockingQueuedConnection);
             }
             {
                 ShutdownTrace trace("spots.eibi.stop");
-                QMetaObject::invokeMethod(eibiClient, [eibiClient] { eibiClient->setEnabled(false); },
+                QMetaObject::invokeMethod(eibiClient, [eibiClient] {
+                    ShutdownTrace workerTrace("spots.eibi.stop.worker");
+                    eibiClient->setEnabled(false);
+                },
                                           Qt::BlockingQueuedConnection);
             }
             {
                 ShutdownTrace trace("spots.n1mm.stop");
                 QMetaObject::invokeMethod(n1mmSpotClient,
-                                          [n1mmSpotClient] { n1mmSpotClient->stopListening(); },
+                                          [n1mmSpotClient] {
+                    ShutdownTrace workerTrace("spots.n1mm.stop.worker");
+                    n1mmSpotClient->stopListening();
+                },
                                           Qt::BlockingQueuedConnection);
             }
 #ifdef HAVE_WEBSOCKETS
             {
                 ShutdownTrace trace("spots.freedv.stop");
                 QMetaObject::invokeMethod(freedvClient,
-                                          [freedvClient] { freedvClient->stopConnection(); },
+                                          [freedvClient] {
+                    ShutdownTrace workerTrace("spots.freedv.stop.worker");
+                    freedvClient->stopConnection();
+                },
                                           Qt::BlockingQueuedConnection);
             }
 #endif
@@ -3847,7 +3874,8 @@ void MainWindow::closeEvent(QCloseEvent* event)
             {
                 ShutdownTrace trace("spots.thread.join");
                 m_spotThread->quit();
-                m_spotThread->wait(3000);
+                if (!m_spotThread->wait(3000))
+                    trace.fail("thread_join_timeout");
             }
         } else {
             delete m_dxCluster;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include "core/DisplayPresence.h"
 #include "core/GpuSelector.h"
 #include "core/LogManager.h"
+#include "core/ShutdownTrace.h"
 #include "core/MacMicPermission.h"
 #include "core/AutomationServer.h"
 
@@ -734,6 +735,8 @@ int main(int argc, char* argv[])
 
         exitCode = app.exec();
     }
+
+    AetherSDR::ShutdownTrace::complete("application");
 
     qInstallMessageHandler(nullptr);
     logManager.shutdownLogging();

--- a/src/models/DaxIqModel.cpp
+++ b/src/models/DaxIqModel.cpp
@@ -1,5 +1,6 @@
 #include "DaxIqModel.h"
 #include "core/LogManager.h"
+#include "core/ShutdownTrace.h"
 
 #include <QDebug>
 #include <QMetaMethod>
@@ -102,6 +103,7 @@ DaxIqModel::DaxIqModel(QObject* parent)
 
 DaxIqModel::~DaxIqModel()
 {
+    ShutdownTrace trace("dax_iq.thread.join");
     m_workerThread.quit();
     m_workerThread.wait();
 }

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -13,6 +13,7 @@
 #include "core/backends/icom/IcomSettings.h"     // host/user/ports (Principle V)
 #include "core/AppSettings.h"
 #include "core/RadioStateMemory.h"  // RFC #4603 typed restore handoff
+#include "core/ShutdownTrace.h"
 #include "core/CwTrace.h"
 #include "core/DigitalVoiceModeRegistry.h"
 #include "core/DigitalVoiceWaveformProcess.h"
@@ -2134,6 +2135,7 @@ RadioModel::~RadioModel()
     // their worker threads: ~FlexBackend runs the exact #502 teardown ordering
     // (BlockingQueued disconnect/stop → deleteLater → thread quit/wait) that
     // used to live here. (aetherd 2.2b)
+    ShutdownTrace trace("radio.backend.destroy");
     teardownBackend();
 }
 


### PR DESCRIPTION
## Summary

- add lightweight paired `begin` / `end` shutdown breadcrumbs with elapsed time
- instrument radio, audio, KiwiSDR, external controllers, spot clients, and late worker-thread teardown
- distinguish a blocked queued invocation from a close routine that entered its worker and then blocked
- emit a final `application complete` marker after `MainWindow` and member destruction

## Motivation

Windows users have reported AetherSDR hanging during application close and requiring a force quit, including #4273. Existing logs show that shutdown started, but do not identify which blocking close or thread join was still in progress when the process was killed.

This is diagnostic instrumentation only; it does not claim to fix the underlying hang or change shutdown ordering.

Each phase logs through the existing asynchronous support-log writer under `aether.shutdown`:

```text
phase=controllers.serial.close event=begin
phase=controllers.serial.close.worker event=begin
phase=controllers.serial.close.worker event=end elapsed_ms=0
phase=controllers.serial.close event=end elapsed_ms=0
```

If a force-quit log contains the caller-side `begin` but no worker-side `begin`, the worker event loop did not service the blocking invocation. If the worker-side `begin` is present without its `end`, the device close itself blocked.

The implementation deliberately adds no new waits, watchdog thread, synchronous flush, or shutdown behavior change. The existing independent log writer wakes on each record and flushes on its normal interval.

## Coverage

- radio disconnect and late backend destruction
- KiwiSDR client destruction and worker join
- audio stream stop, worker entry, DSP initialization tasks, and audio thread joins
- serial, FlexControl, MIDI, HID, and dial controller shutdown
- DX Cluster, RBN, WSJT-X, collector, POTA, EiBi, N1MM, and FreeDV spot clients
- TCI, CWX, AX.25, ASR, DAX IQ, and DXCC parser teardown
- whole close-event, destructor-body, and application-complete boundaries

## Validation

- macOS RelWithDebInfo application build passed
- `QT_QPA_PLATFORM=offscreen ctest --test-dir build -j22 --output-on-failure`: 293/293 passed; 2 tests skipped by their existing runtime gates
- focused Flex, Icom, simulator, RadioModel, and HL2 lifecycle tests passed
- two isolated, TX-disabled automation-bridge close cycles exited normally
- verified the complete ordered breadcrumb sequence in the rotated support log, including `phase=radio.backend.destroy event=end` and `phase=application event=complete`
- `git diff --check` passed

Generated with OpenAI Codex (Daybreak Blue)
