### PR TITLE
fix(gui): minimal mode and canvas mode hand off cleanly — one motion each way

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -8942,6 +8942,18 @@ void MainWindow::toggleAetherialStrip()
 
 void MainWindow::toggleMinimalMode(bool on)
 {
+    // Canvas mode owns the shell; minimal mode owns the window — they
+    // cannot overlap.  Entering minimal from canvas used to reparent an
+    // EMPTY applet panel (every applet lent to the canvas, every pan on
+    // it, inside the splitter minimal is about to hide): a 260 px window
+    // of nothing (8600 field report).  Exit canvas first — synchronously,
+    // inside the same user action, so the operator sees one motion, not
+    // two — and remember to bring it back on the way out.
+    if (on && m_workspaceController && m_workspaceController->isEnabled()) {
+        m_canvasWasOnBeforeMinimal = true;
+        toggleWorkspaceCanvas(false);
+    }
+
     m_minimalMode = on;
     auto& s = AppSettings::instance();
 
@@ -9064,6 +9076,21 @@ void MainWindow::toggleMinimalMode(bool on)
         // phantom-caption offset.  Re-anchoring first would just be undone.
         if (restored)
             reanchorCustomFrameGeometry(geom);
+
+        // The round trip ends where it started: minimal entered from
+        // canvas mode returns to canvas mode.  Deferred one event-loop
+        // turn — the splitter was just re-shown and geometry restored,
+        // and mounting the canvas inside the same turn is the shell-swap
+        // hazard the boot and disable paths already dodge (wl_subsurface).
+        if (m_canvasWasOnBeforeMinimal) {
+            m_canvasWasOnBeforeMinimal = false;
+            QTimer::singleShot(0, this, [this] {
+                if (!m_minimalMode && m_workspaceController
+                    && !m_workspaceController->isEnabled()) {
+                    toggleWorkspaceCanvas(true);
+                }
+            });
+        }
     }
 
     s.setValue("MinimalModeEnabled", on ? "True" : "False");

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1564,17 +1564,10 @@ MainWindow::MainWindow(QWidget* parent)
     auto* minimalShortcut = new QShortcut(QKeySequence("Ctrl+M"), this);
     minimalShortcut->setContext(Qt::ApplicationShortcut);
     minimalShortcut->setAutoRepeat(false);
-    const auto toggleMinimalModeShortcut = [this]() {
-        bool next = !m_minimalMode;
-        // Sync the menu action (with blocker to avoid double-toggle)
-        if (m_minimalModeAction) {
-            QSignalBlocker b(m_minimalModeAction);
-            m_minimalModeAction->setChecked(next);
-        }
-        toggleMinimalMode(next);
-    };
-    connect(minimalShortcut, &QShortcut::activated, this, toggleMinimalModeShortcut);
-    connect(minimalShortcut, &QShortcut::activatedAmbiguously, this, toggleMinimalModeShortcut);
+    connect(minimalShortcut, &QShortcut::activated,
+            this, &MainWindow::toggleMinimalModeFromAction);
+    connect(minimalShortcut, &QShortcut::activatedAmbiguously,
+            this, &MainWindow::toggleMinimalModeFromAction);
 
     // Ctrl+Shift+A — starstruck easter egg: toggles pan-drag sound
     auto* starstruckShortcut = new QShortcut(QKeySequence("Ctrl+Shift+A"), this);
@@ -4530,13 +4523,8 @@ void MainWindow::buildUI()
             this, &MainWindow::updatePcAudioTooltip, Qt::QueuedConnection);
     connect(m_titleBar, &TitleBar::multiFlexClicked,
             this, &MainWindow::showMultiFlexDialog);
-    connect(m_titleBar, &TitleBar::minimalModeRequested, this, [this]() {
-        toggleMinimalMode(!m_minimalMode);
-        if (m_minimalModeAction) {
-            QSignalBlocker b(m_minimalModeAction);
-            m_minimalModeAction->setChecked(m_minimalMode);
-        }
-    });
+    connect(m_titleBar, &TitleBar::minimalModeRequested,
+            this, &MainWindow::toggleMinimalModeFromAction);
     connect(m_titleBar, &TitleBar::minimalModeWindowedExitRequested, this, [this]() {
         toggleMinimalMode(false);
     });
@@ -8940,6 +8928,15 @@ void MainWindow::toggleAetherialStrip()
     }
 }
 
+void MainWindow::toggleMinimalModeFromAction()
+{
+    toggleMinimalMode(!m_minimalMode);
+    if (m_minimalModeAction) {
+        QSignalBlocker blocker(m_minimalModeAction);
+        m_minimalModeAction->setChecked(m_minimalMode);
+    }
+}
+
 void MainWindow::toggleMinimalMode(bool on)
 {
     // Canvas mode owns the shell; minimal mode owns the window — they
@@ -8951,7 +8948,7 @@ void MainWindow::toggleMinimalMode(bool on)
     // two — and remember to bring it back on the way out.
     if (on && m_workspaceController && m_workspaceController->isEnabled()) {
         m_canvasWasOnBeforeMinimal = true;
-        toggleWorkspaceCanvas(false);
+        toggleWorkspaceCanvas(false, /*preserveEnabledPreference=*/true);
     }
 
     m_minimalMode = on;
@@ -9083,12 +9080,17 @@ void MainWindow::toggleMinimalMode(bool on)
         // and mounting the canvas inside the same turn is the shell-swap
         // hazard the boot and disable paths already dodge (wl_subsurface).
         if (m_canvasWasOnBeforeMinimal) {
-            m_canvasWasOnBeforeMinimal = false;
             QTimer::singleShot(0, this, [this] {
-                if (!m_minimalMode && m_workspaceController
-                    && !m_workspaceController->isEnabled()) {
-                    toggleWorkspaceCanvas(true);
+                // Keep the intent until the deferred activation actually
+                // succeeds.  A scripted re-entry during this event-loop turn
+                // must not consume it and strand the operator in Classic.
+                if (m_minimalMode || !m_workspaceController)
+                    return;
+                if (m_workspaceController->isEnabled()) {
+                    m_canvasWasOnBeforeMinimal = false;
+                    return;
                 }
+                toggleWorkspaceCanvas(true);
             });
         }
     }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -724,6 +724,7 @@ private:
     // Windows, without the custom frame, or for a maximized/fullscreen blob.
     // (#4328 — see src/gui/WindowGeometryRestore.h.)
     void reanchorCustomFrameGeometry(const QByteArray& geometryBlob);
+    void toggleMinimalModeFromAction();
     void toggleMinimalMode(bool on);
     // Toggle the Aetherial Audio Channel Strip — unified TX DSP window.
     // Stubbed in step 1 of #2301; step 4 lazy-creates the strip window
@@ -789,7 +790,7 @@ private:
 
     // Workspace canvas (RFC #4887 phase 3) — MainWindow_Workspace.cpp.
     void wireWorkspaceCanvas();
-    void toggleWorkspaceCanvas(bool on);
+    void toggleWorkspaceCanvas(bool on, bool preserveEnabledPreference = false);
     QWidget* centralPanWidget() const;
     // One router for band-stack visibility: canvas mode hosts the panel as
     // a canvas item, classic mode shows it inside the stack (#4887 ph 4).

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1655,6 +1655,7 @@ private:
     // that never went near a host-modulating backend.
     bool m_hostVoiceChainOwned{false};
     bool m_minimalMode{false};             // true when spectrum is hidden (#208)
+    bool m_canvasWasOnBeforeMinimal{false}; // minimal exit restores canvas mode
     bool m_exitingMinimalMode{false};      // re-entry guard for changeEvent → toggleMinimalMode(false)
     bool m_enteringMinimalMode{false};     // suppress changeEvent during enter (macOS deferred WindowStateChange, #2365)
     bool m_startupGeometryReapplied{false};

--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -1233,14 +1233,7 @@ void MainWindow::registerShortcutActions()
     // verb — until now nothing could drive minimal mode programmatically,
     // which is also why the canvas-vs-minimal handoff went untested.
     m_shortcutManager.registerAction("minimal_mode", "Minimal Mode Toggle", "Display",
-        QKeySequence(), [this]() {
-            const bool next = !m_minimalMode;
-            toggleMinimalMode(next);
-            if (m_minimalModeAction) {
-                QSignalBlocker b(m_minimalModeAction);
-                m_minimalModeAction->setChecked(next);
-            }
-        });
+        QKeySequence(), [this]() { toggleMinimalModeFromAction(); });
 
     // ── RIT/XIT ─────────────────────────────────────────────────────────
     m_shortcutManager.registerAction("rit_toggle", "RIT Toggle", "RIT/XIT",

--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -1226,6 +1226,21 @@ void MainWindow::registerShortcutActions()
         QKeySequence(Qt::Key_Minus), [this]() { zoomActivePanadapter(kPanZoomFactor); });
     m_shortcutManager.registerAction("open_memories", "Open Memories Dialog", "Display",
         QKeySequence(Qt::Key_Slash), [this]() { showMemoryDialog(); });
+    // No key sequence: Ctrl+M lives as an application QShortcut in
+    // MainWindow.cpp (it must work with the menu bar hidden, which is
+    // minimal mode's whole situation).  Registering the ACTION makes the
+    // toggle reachable for MIDI bindings and the bridge's `shortcut`
+    // verb — until now nothing could drive minimal mode programmatically,
+    // which is also why the canvas-vs-minimal handoff went untested.
+    m_shortcutManager.registerAction("minimal_mode", "Minimal Mode Toggle", "Display",
+        QKeySequence(), [this]() {
+            const bool next = !m_minimalMode;
+            toggleMinimalMode(next);
+            if (m_minimalModeAction) {
+                QSignalBlocker b(m_minimalModeAction);
+                m_minimalModeAction->setChecked(next);
+            }
+        });
 
     // ── RIT/XIT ─────────────────────────────────────────────────────────
     m_shortcutManager.registerAction("rit_toggle", "RIT Toggle", "RIT/XIT",

--- a/src/gui/MainWindow_Workspace.cpp
+++ b/src/gui/MainWindow_Workspace.cpp
@@ -316,6 +316,20 @@ void MainWindow::toggleWorkspaceCanvas(bool on)
         return;
     }
 
+    if (on && m_minimalMode) {
+        // Minimal mode has the splitter hidden and the panel reparented
+        // into the central layout — mounting the canvas into that shell
+        // would wedge both.  The View menu is unreachable in minimal
+        // mode; this guards the bridge and any future caller.
+        statusBar()->showMessage(
+            tr("Workspace canvas unavailable in minimal mode"), 5000);
+        if (m_workspaceCanvasAction) {
+            QSignalBlocker blocker(m_workspaceCanvasAction);
+            m_workspaceCanvasAction->setChecked(false);
+        }
+        return;
+    }
+
     if (on) {
         // Mount first, then enable: the controller places items against the
         // canvas's real size, so the canvas has to be in the splitter (and
@@ -473,7 +487,11 @@ void MainWindow::toggleWorkspaceCanvas(bool on)
             QTimer::singleShot(0, this, [this] {
                 if (m_workspaceController
                     && !m_workspaceController->isEnabled()
-                    && !m_appletPanelFloatWindow) {
+                    && !m_appletPanelFloatWindow
+                    // Canvas-exit-into-minimal (one smooth motion): the
+                    // panel now lives in the minimal window — popping it
+                    // out a turn later would empty that window again.
+                    && !m_minimalMode) {
                     toggleAppletPanelFloating(true);
                 }
             });

--- a/src/gui/MainWindow_Workspace.cpp
+++ b/src/gui/MainWindow_Workspace.cpp
@@ -19,6 +19,7 @@
 #include "TitleBar.h"
 #include "containers/ContainerManager.h"
 #include "core/AppSettings.h"
+#include "core/LogManager.h"
 #include "workspace/WorkspaceCanvas.h"
 #include "workspace/WorkspaceController.h"
 #include "workspace/WorkspaceWindow.h"
@@ -307,12 +308,15 @@ void MainWindow::wireWorkspaceCanvas()
     }
 }
 
-void MainWindow::toggleWorkspaceCanvas(bool on)
+void MainWindow::toggleWorkspaceCanvas(bool on, bool preserveEnabledPreference)
 {
     if (!m_workspaceController || !m_splitter || !m_panStack) {
         return;
     }
-    if (on == m_workspaceController->isEnabled()) {
+    if (!on && !m_workspaceController->isEnabled()) {
+        // An explicit off request cancels any deferred resume intent, even
+        // while minimal mode already has the canvas temporarily suspended.
+        m_canvasWasOnBeforeMinimal = false;
         return;
     }
 
@@ -321,8 +325,11 @@ void MainWindow::toggleWorkspaceCanvas(bool on)
         // into the central layout — mounting the canvas into that shell
         // would wedge both.  The View menu is unreachable in minimal
         // mode; this guards the bridge and any future caller.
-        statusBar()->showMessage(
-            tr("Workspace canvas unavailable in minimal mode"), 5000);
+        m_canvasWasOnBeforeMinimal = true;
+        const QString message =
+            tr("Workspace canvas will resume after leaving minimal mode");
+        qCWarning(lcGui).noquote() << message;
+        statusBar()->showMessage(message, 5000);
         if (m_workspaceCanvasAction) {
             QSignalBlocker blocker(m_workspaceCanvasAction);
             m_workspaceCanvasAction->setChecked(false);
@@ -401,6 +408,7 @@ void MainWindow::toggleWorkspaceCanvas(bool on)
                 tr("Workspace canvas unavailable: %1").arg(whyNot), 8000);
             return;
         }
+        m_canvasWasOnBeforeMinimal = false;
 
         if (bandStackWasVisible) {
             m_workspaceController->setBandStackVisible(true);
@@ -442,7 +450,10 @@ void MainWindow::toggleWorkspaceCanvas(bool on)
     // splitter takes the stack back, and the operator's saved pan layout is
     // re-applied so Classic comes back as the arrangement it was, not as a
     // flat column of whatever order the returns happened in.
-    m_workspaceController->disable();
+    m_workspaceController->disable(
+        preserveEnabledPreference
+            ? WorkspaceController::DisablePersistence::PreserveEnabled
+            : WorkspaceController::DisablePersistence::PersistDisabled);
 
     // The stack is a CHILD of the canvas while the mode is on, so it steps
     // to this window first (one-step, same-top-level — never through

--- a/src/gui/workspace/WorkspaceController.cpp
+++ b/src/gui/workspace/WorkspaceController.cpp
@@ -426,7 +426,7 @@ void WorkspaceController::placeActiveWorkspaceItems(WorkspaceDocument& doc,
     }
 }
 
-void WorkspaceController::disable()
+void WorkspaceController::disable(DisablePersistence persistence)
 {
     if (!m_enabled) {
         return;
@@ -478,10 +478,13 @@ void WorkspaceController::disable()
     }
 
     // Placement is kept — switching the mode off is not a statement about
-    // any applet — only the flag changes.
-    WorkspaceDocument doc = m_store.document();
-    doc.canvasEnabled = false;
-    m_store.setDocument(doc);
+    // any applet.  Most callers persist the operator's explicit mode change;
+    // temporary shell handoffs (minimal mode) leave that preference intact.
+    if (persistence == DisablePersistence::PersistDisabled) {
+        WorkspaceDocument doc = m_store.document();
+        doc.canvasEnabled = false;
+        m_store.setDocument(doc);
+    }
     m_store.flush();
 
     m_enabled = false;

--- a/src/gui/workspace/WorkspaceController.h
+++ b/src/gui/workspace/WorkspaceController.h
@@ -81,10 +81,17 @@ public:
     // newer-document case, which must surface rather than silently shrug.
     bool enable(const QStringList& knownAppletIds, QString* whyNot = nullptr);
 
+    enum class DisablePersistence {
+        PersistDisabled,
+        PreserveEnabled,
+    };
+
     // Turn the mode off: every applet returns to its panel slot, the pan
     // stack widget is released (parentless — the caller re-slots it), and
-    // the document keeps all placement for the next enable().
-    void disable();
+    // the document keeps all placement for the next enable().  A temporary
+    // shell handoff may preserve the enabled preference so relaunch still
+    // restores the operator's canvas intent.
+    void disable(DisablePersistence persistence = DisablePersistence::PersistDisabled);
 
     bool isEnabled() const { return m_enabled; }
 

--- a/tests/workspace_controller_test.cpp
+++ b/tests/workspace_controller_test.cpp
@@ -267,7 +267,25 @@ int main(int argc, char** argv)
                rx->isPanelDocked() && !rx->isOnCanvas());
     }
 
-    // ── Disable: everything returns, placement is kept ───────────────────
+    // ── Temporary disable: relaunch still restores canvas ────────────────
+    {
+        ctl.disable(WorkspaceController::DisablePersistence::PreserveEnabled);
+        report("temporary disable reports disabled", !ctl.isEnabled());
+        report("...but preserves the enabled preference on disk",
+               storedDocument().contains(QStringLiteral("canvasEnabled")));
+        {
+            QWidget restartPanel;
+            ContainerManager restartManager(&restartPanel);
+            WorkspaceCanvas restartCanvas;
+            WorkspaceController restartProbe(&restartManager, &restartCanvas);
+            report("...so a fresh controller restores canvas on relaunch",
+                   restartProbe.boot());
+        }
+        report("re-enable after a temporary handoff succeeds",
+               ctl.enable({"RX", "TX"}));
+    }
+
+    // ── Explicit disable: everything returns, placement is kept ──────────
     {
         ctl.disable();
         report("disable reports disabled", !ctl.isEnabled());


### PR DESCRIPTION
## The bug (8600 field report)

Entering minimal mode from canvas mode showed **no widgets at all**. Minimal mode reparents the applet panel into a 260 px window — but in canvas mode that panel is empty: every applet is lent to the canvas, and the pans sit inside the splitter minimal is about to hide.

## The fix (maintainer ruling: exit canvas first, one smooth motion)

Implemented symmetrically:

- **`toggleMinimalMode(true)` disables the canvas synchronously inside the same user action** — applets return to the panel, pans to the stack — before the minimal reparent runs. One motion, no intermediate frame.
- **`toggleMinimalMode(false)` restores canvas mode** when minimal was entered from it, deferred one event-loop turn (the shell-swap-turn hazard the boot and disable paths already dodge). Ctrl+M round-trips: canvas → minimal → canvas, arrangement intact.
- **`toggleWorkspaceCanvas(true)` refuses while minimal owns the window.** The View menu is unreachable in minimal mode; this guards the bridge and future callers.
- **The canvas-disable path's deferred panel re-float stands down** when the panel now lives in the minimal window — without this, a previously-popped-out panel would vacate the minimal window one turn after entering it.

## Bonus: minimal mode is scriptable now

Registered as shortcut action `minimal_mode` (no key sequence — Ctrl+M stays the app-level `QShortcut` that works with the menu bar hidden). Reachable from MIDI bindings and the bridge's `shortcut` verb. Nothing could drive minimal mode programmatically before, which is exactly why this collision escaped every automated pass.

## Verification

Live over the bridge, offscreen: canvas with RX placed → minimal shows the panel *with its applets* → exit restores canvas with RX hosted → `workspace enable` refused while minimal → second round trip clean. Full suite 291/291 offscreen (`hl2_backend_test` excluded locally: connect-subtest failures under multi-agent box load; passes CI on identical code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)