### PR TITLE
fix(gui): stop connect enumeration overwriting the radio's active slice — Principle II. (#4985)

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -71,7 +71,9 @@ AETHER_AUTOMATION_SOCKET=aethersdr-4166 \
 `AETHER_AUTOMATION_IDENTITY` deterministically selects a process-scoped Flex
 GUI client UUID, so concurrent worktrees do not displace one another through
 the radio's duplicate-client takeover behavior. If it is omitted, the socket,
-automation label, or PID is used in that order. `AETHER_AUTOMATION_AGENT_NAME`
+automation label, or PID is used in that order (transient identity, so multi-slice
+session restore is not preserved across runs; set a stable identity when testing
+session persistence). `AETHER_AUTOMATION_AGENT_NAME`
 sets the station label shown to other Multi-Flex clients; the legacy
 `AETHER_AUTOMATION_STATION` and then `AETHER_AUTOMATION_LABEL` are fallbacks,
 followed by the neutral default `Automation`. The agent name is display-only

--- a/src/gui/BandRecallSliceSelectionPolicy.h
+++ b/src/gui/BandRecallSliceSelectionPolicy.h
@@ -7,8 +7,8 @@ namespace AetherSDR {
 // removed/recreated, and the connect-time bootstrap of the first enumerated
 // slice. Outside a band recall each retains its established behavior. During a
 // FLEX band-stack rebuild, none may reveal the transient slice or send active=1
-// back: either write can race the radio-authoritative pan/slice reconstruction
-// and undo the selected band.
+// back: any of these writes can race the radio-authoritative pan/slice
+// reconstruction and undo the selected band.
 enum class RadioSliceSelectionSource {
     ActiveStatus,
     TopologyFallback,

--- a/src/gui/BandRecallSliceSelectionPolicy.h
+++ b/src/gui/BandRecallSliceSelectionPolicy.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "gui/ConnectSliceEnumerationGuard.h"
-
 namespace AetherSDR {
 
 // MainWindow reaches the active-slice setter from three radio-driven sources:

--- a/src/gui/BandRecallSliceSelectionPolicy.h
+++ b/src/gui/BandRecallSliceSelectionPolicy.h
@@ -12,9 +12,9 @@ namespace AetherSDR {
 enum class RadioSliceSelectionSource {
     ActiveStatus,
     TopologyFallback,
-    // The first slice to arrive on a fresh connect, selected only so the UI has
-    // a target before the enumeration finishes. It is arrival ORDER, not the
-    // operator's choice — slice 0 is simply enumerated first — so it must never
+    // The first slice to arrive when the client has no active slice (on connect or
+    // after all slices are removed), selected only so the UI has a target before
+    // the enumeration finishes. It is arrival ORDER, not the operator's choice — slice 0 is simply enumerated first — so it must never
     // write active=1 back. During connect the status burst / enumeration order
     // can leave a different slice active (often the last one created). Asserting
     // a selection here overwrites that live status before later slices have even

--- a/src/gui/BandRecallSliceSelectionPolicy.h
+++ b/src/gui/BandRecallSliceSelectionPolicy.h
@@ -2,15 +2,25 @@
 
 namespace AetherSDR {
 
-// MainWindow reaches the active-slice setter from two radio-driven sources:
-// an explicit active=1 status and a topology fallback while slices are being
-// removed/recreated. Outside a band recall both retain their established
-// behavior. During a FLEX band-stack rebuild, neither may reveal the transient
-// slice or send active=1 back: either write can race the radio-authoritative
-// pan/slice reconstruction and undo the selected band.
+// MainWindow reaches the active-slice setter from three radio-driven sources:
+// an explicit active=1 status, a topology fallback while slices are being
+// removed/recreated, and the connect-time bootstrap of the first enumerated
+// slice. Outside a band recall each retains its established behavior. During a
+// FLEX band-stack rebuild, none may reveal the transient slice or send active=1
+// back: either write can race the radio-authoritative pan/slice reconstruction
+// and undo the selected band.
 enum class RadioSliceSelectionSource {
     ActiveStatus,
     TopologyFallback,
+    // The first slice to arrive on a fresh connect, selected only so the UI has
+    // a target before the enumeration finishes. It is arrival ORDER, not the
+    // operator's choice — slice 0 is simply enumerated first — so it must never
+    // write active=1 back. During connect the status burst / enumeration order
+    // can leave a different slice active (often the last one created). Asserting
+    // a selection here overwrites that live status before later slices have even
+    // been created client-side, so the first-enumerated slice always won and
+    // the operator's slice B silently became slice A on every launch.
+    InitialEnumeration,
 };
 
 struct RadioSliceSelectionDecision {
@@ -26,10 +36,26 @@ inline RadioSliceSelectionDecision radioSliceSelectionDecision(
         return {false, true};
     }
 
+    // TopologyFallback is the only source that may assert the selection: it
+    // fires when the active slice was REMOVED, so the radio has no valid active
+    // slice and must be told which one takes over.
     return {
         true,
-        source == RadioSliceSelectionSource::ActiveStatus,
+        source != RadioSliceSelectionSource::TopologyFallback,
     };
+}
+
+inline const char* radioSliceSelectionSourceName(RadioSliceSelectionSource source)
+{
+    switch (source) {
+    case RadioSliceSelectionSource::ActiveStatus:
+        return "active-status";
+    case RadioSliceSelectionSource::TopologyFallback:
+        return "topology-fallback";
+    case RadioSliceSelectionSource::InitialEnumeration:
+        return "initial-enumeration";
+    }
+    return "unknown";
 }
 
 }  // namespace AetherSDR

--- a/src/gui/BandRecallSliceSelectionPolicy.h
+++ b/src/gui/BandRecallSliceSelectionPolicy.h
@@ -12,14 +12,15 @@ namespace AetherSDR {
 enum class RadioSliceSelectionSource {
     ActiveStatus,
     TopologyFallback,
-    // The first slice to arrive when the client has no active slice (on connect or
-    // after all slices are removed), selected only so the UI has a target before
-    // the enumeration finishes. It is arrival ORDER, not the operator's choice — slice 0 is simply enumerated first — so it must never
-    // write active=1 back. During connect the status burst / enumeration order
-    // can leave a different slice active (often the last one created). Asserting
-    // a selection here overwrites that live status before later slices have even
-    // been created client-side, so the first-enumerated slice always won and
-    // the operator's slice B silently became slice A on every launch.
+    // The first slice to arrive during connect enumeration when the client has no
+    // active slice, selected only so the UI has a target before the enumeration
+    // finishes. It is arrival ORDER, not the operator's choice — slice 0 is simply
+    // enumerated first — so it must never write active=1 back. During connect the
+    // status burst / enumeration order can leave a different slice active (often
+    // the last one created). Asserting a selection here overwrites that live
+    // status before later slices have even been created client-side, so the
+    // first-enumerated slice always won and the operator's slice B silently became
+    // slice A on every launch.
     InitialEnumeration,
 };
 

--- a/src/gui/BandRecallSliceSelectionPolicy.h
+++ b/src/gui/BandRecallSliceSelectionPolicy.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "gui/ConnectSliceEnumerationGuard.h"
+
 namespace AetherSDR {
 
 // MainWindow reaches the active-slice setter from three radio-driven sources:
@@ -38,12 +40,20 @@ inline RadioSliceSelectionDecision radioSliceSelectionDecision(
     }
 
     // TopologyFallback is the only source that may assert the selection: it
-    // fires when the active slice was REMOVED, so the radio has no valid active
-    // slice and must be told which one takes over.
+    // fires when the active slice was removed or created into an empty list
+    // mid-session, so the radio has no valid active slice and must be told
+    // which one takes over.
     return {
         true,
         source != RadioSliceSelectionSource::TopologyFallback,
     };
+}
+
+inline RadioSliceSelectionSource firstSliceSelectionSource(bool initialConnectEnumeration)
+{
+    return initialConnectEnumeration
+        ? RadioSliceSelectionSource::InitialEnumeration
+        : RadioSliceSelectionSource::TopologyFallback;
 }
 
 inline const char* radioSliceSelectionSourceName(RadioSliceSelectionSource source)

--- a/src/gui/ConnectSliceEnumerationGuard.h
+++ b/src/gui/ConnectSliceEnumerationGuard.h
@@ -1,13 +1,26 @@
 #pragma once
 
-#include <algorithm>
-#include <cstdint>
+#include <QtGlobal>
 
 namespace AetherSDR {
 
 // Owns the time window during which the first slice to arrive after connecting
 // to a radio is treated as initial connect enumeration (synchronization-only)
 // rather than a mid-session fallback.
+//
+// Background (Principle II: Radio-Authoritative Live State):
+// When connecting to a FlexRadio with existing slices, the radio enumerates
+// slices in slice-creation order, which is not necessarily the slice that is
+// active on the radio. Furthermore, FlexRadio firmware does not persist the
+// operator's active-slice selection across restarts. Asserting active=1 on the
+// first enumerated slice would overwrite the radio's live active slice before
+// subsequent slices even exist client-side. FlexLib avoids this by updating its
+// internal state without transmitting an active command back to the radio
+// (see FlexLib Slice.cs:2035: _UpdateActive(..., update_radio: false)).
+//
+// The window is armed by RadioModel right before 'sub slice all' is dispatched,
+// and disarmed when the 'slice list' response is received. The timeout (default
+// 3000ms) acts as a safety backstop.
 //
 // Pure policy — no timers, no widgets, no clock. The caller injects nowMs and
 // owns every side effect. Unit-tested in band_recall_slice_selection_policy_test
@@ -20,28 +33,47 @@ public:
     }
 
     // Opens the connect enumeration window.
-    void arm(int64_t nowMs)
+    void arm(qint64 nowMs)
     {
         m_untilMs = nowMs + m_windowMs;
+        m_consulted = false;
     }
 
-    // Closes the window immediately (e.g. on disconnect).
+    // Closes the window immediately (e.g. on disconnect or slice list reply).
     void cancelArm()
     {
         m_untilMs = 0;
     }
 
     // True while the connect enumeration window is open.
-    bool isActive(int64_t nowMs) const
+    // Marks the guard as consulted if active.
+    bool isActive(qint64 nowMs)
+    {
+        if (nowMs >= 0 && nowMs < m_untilMs) {
+            m_consulted = true;
+            return true;
+        }
+        return false;
+    }
+
+    // Const inspection without mutating consulted state
+    bool isActive(qint64 nowMs) const
     {
         return nowMs >= 0 && nowMs < m_untilMs;
+    }
+
+    // True once armed and then expired without ever being consulted while open.
+    bool expiredUnused(qint64 nowMs) const
+    {
+        return m_untilMs > 0 && nowMs >= m_untilMs && !m_consulted;
     }
 
     int windowMs() const { return m_windowMs; }
 
 private:
-    int     m_windowMs{3000};
-    int64_t m_untilMs{0};
+    int    m_windowMs{3000};
+    qint64 m_untilMs{0};
+    bool   m_consulted{false};
 };
 
 }  // namespace AetherSDR

--- a/src/gui/ConnectSliceEnumerationGuard.h
+++ b/src/gui/ConnectSliceEnumerationGuard.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+namespace AetherSDR {
+
+// Owns the time window during which the first slice to arrive after connecting
+// to a radio is treated as initial connect enumeration (synchronization-only)
+// rather than a mid-session fallback.
+//
+// Pure policy — no timers, no widgets, no clock. The caller injects nowMs and
+// owns every side effect. Unit-tested in band_recall_slice_selection_policy_test
+// and radiomodel_slice_connect_enumeration_test.
+class ConnectSliceEnumerationGuard {
+public:
+    explicit ConnectSliceEnumerationGuard(int windowMs = 3000)
+        : m_windowMs(windowMs)
+    {
+    }
+
+    // Opens the connect enumeration window.
+    void arm(int64_t nowMs)
+    {
+        m_untilMs = nowMs + m_windowMs;
+    }
+
+    // Closes the window immediately (e.g. on disconnect).
+    void cancelArm()
+    {
+        m_untilMs = 0;
+    }
+
+    // True while the connect enumeration window is open.
+    bool isActive(int64_t nowMs) const
+    {
+        return nowMs >= 0 && nowMs < m_untilMs;
+    }
+
+    int windowMs() const { return m_windowMs; }
+
+private:
+    int     m_windowMs{3000};
+    int64_t m_untilMs{0};
+};
+
+}  // namespace AetherSDR

--- a/src/gui/ConnectSliceEnumerationGuard.h
+++ b/src/gui/ConnectSliceEnumerationGuard.h
@@ -18,9 +18,9 @@ namespace AetherSDR {
 // internal state without transmitting an active command back to the radio
 // (see FlexLib Slice.cs:2035: _UpdateActive(..., update_radio: false)).
 //
-// The window is armed by RadioModel right before 'sub slice all' is dispatched,
-// and disarmed when the 'slice list' response is received. The timeout (default
-// 3000ms) acts as a safety backstop.
+// The window is armed by RadioModel right before 'client gui' registration
+// is dispatched, and disarmed when the 'slice list' response is received. The
+// timeout (default 3000ms) acts as a safety backstop.
 //
 // Pure policy — no timers, no widgets, no clock. The caller injects nowMs and
 // owns every side effect. Unit-tested in band_recall_slice_selection_policy_test
@@ -47,19 +47,13 @@ public:
 
     // True while the connect enumeration window is open.
     // Marks the guard as consulted if active.
-    bool isActive(qint64 nowMs)
+    bool isActive(qint64 nowMs) const
     {
         if (nowMs >= 0 && nowMs < m_untilMs) {
             m_consulted = true;
             return true;
         }
         return false;
-    }
-
-    // Const inspection without mutating consulted state
-    bool isActive(qint64 nowMs) const
-    {
-        return nowMs >= 0 && nowMs < m_untilMs;
     }
 
     // True once armed and then expired without ever being consulted while open.
@@ -71,9 +65,9 @@ public:
     int windowMs() const { return m_windowMs; }
 
 private:
-    int    m_windowMs{3000};
-    qint64 m_untilMs{0};
-    bool   m_consulted{false};
+    int          m_windowMs{3000};
+    qint64       m_untilMs{0};
+    mutable bool m_consulted{false};
 };
 
 }  // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5854,8 +5854,10 @@ void MainWindow::onConnectionStateChanged(bool connected)
     // one place so the count cannot leak across sessions.
     noteAutoConnectFinished(connected);
 
-    if (!connected) {
-        m_initialSliceEnumeration = true;
+    if (connected) {
+        m_connectSliceEnumeration.arm(QDateTime::currentMSecsSinceEpoch());
+    } else {
+        m_connectSliceEnumeration.cancelArm();
     }
 
     m_connPanel->setConnected(connected);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5854,6 +5854,10 @@ void MainWindow::onConnectionStateChanged(bool connected)
     // one place so the count cannot leak across sessions.
     noteAutoConnectFinished(connected);
 
+    if (!connected) {
+        m_initialSliceEnumeration = true;
+    }
+
     m_connPanel->setConnected(connected);
     updateExperimentalRadioSupport(connected);
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5854,9 +5854,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
     // one place so the count cannot leak across sessions.
     noteAutoConnectFinished(connected);
 
-    if (connected) {
-        m_connectSliceEnumeration.arm(QDateTime::currentMSecsSinceEpoch());
-    } else {
+    if (!connected) {
         m_connectSliceEnumeration.cancelArm();
     }
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -21,6 +21,7 @@
 #include "core/AudioEngine.h"
 #include "core/ReceivePresentationSync.h"
 #include "gui/BandRecallSelectionGuard.h"  // band-recall slice-selection window
+#include "gui/ConnectSliceEnumerationGuard.h"
 #include "gui/CenterLockRebindTracker.h"
 #include "gui/DaxRestorePolicy.h"       // #4558 last-session DAX restore window
 #include "gui/KiwiRebindTracker.h"      // #4158 band-recall Kiwi re-bind policy
@@ -1338,6 +1339,9 @@ private:
     // write is dropped, and must outlast a slow rebuild. See the header.
     BandRecallSelectionGuard m_bandRecallSelection{
         kBandRecallRecreateGraceMs, kBandRecallSelectionGuardMaxMs};
+    static constexpr int kConnectSliceEnumerationGraceMs = 3000;
+    ConnectSliceEnumerationGuard m_connectSliceEnumeration{
+        kConnectSliceEnumerationGraceMs};
     ReceivePresentationSync m_receivePresentationSync;
     ReceiveAudioDelayEstimator m_receiveAudioDelayEstimator;
     ReceivePresentationQueue<std::function<void()>> m_receivePresentationVisualQueue;
@@ -1498,7 +1502,6 @@ private:
 
     // Active slice tracking for multi-slice support
     int m_activeSliceId{-1};
-    bool m_initialSliceEnumeration{true};
     bool m_splitActive{false};
     int  m_splitRxSliceId{-1};
     int  m_splitTxSliceId{-1};

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1498,6 +1498,7 @@ private:
 
     // Active slice tracking for multi-slice support
     int m_activeSliceId{-1};
+    bool m_initialSliceEnumeration{true};
     bool m_splitActive{false};
     int  m_splitRxSliceId{-1};
     int  m_splitTxSliceId{-1};

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -842,6 +842,14 @@ void MainWindow::wireRadioModel()
             this, &MainWindow::onSliceAdded);
     connect(&m_radioModel, &RadioModel::sliceRemoved,
             this, &MainWindow::onSliceRemoved);
+    connect(&m_radioModel, &RadioModel::sliceConnectEnumerationStarted,
+            this, [this]() {
+        m_connectSliceEnumeration.arm(QDateTime::currentMSecsSinceEpoch());
+    });
+    connect(&m_radioModel, &RadioModel::sliceConnectEnumerationFinished,
+            this, [this]() {
+        m_connectSliceEnumeration.cancelArm();
+    });
     // Start the reconstruction window at actual dispatch, not at UI intent:
     // requestPanBand() can defer behind a profile-load hold.
     connect(&m_radioModel, &RadioModel::panBandAboutToDispatch,

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1654,18 +1654,23 @@ void MainWindow::onSliceAdded(SliceModel* s)
 
     // First slice — wire everything up
     if (firstSlice) {
-        // Bootstrap only: give the UI a selection. Do NOT write active=1 —
-        // this is the first slice ENUMERATED, not the slice that should own
-        // the UI. A FLEX does not persist the operator's active-slice choice
-        // across a restart; during connect the status burst / enumeration
-        // order may end with a different slice active (often last-created),
+        // Bootstrap only: give the UI a selection. Do NOT write active=1 during
+        // initial connect enumeration — this is the first slice ENUMERATED, not
+        // the slice that should own the UI. A FLEX does not persist the operator's
+        // active-slice choice across a restart; during connect the status burst /
+        // enumeration order may end with a different slice active (often last-created),
         // and that slice may not exist client-side yet (it arrives in a later
         // status frame). Asserting here would clobber that live status and
         // make first-enumerated always win. The adoption check later in
         // onSliceAdded() reads s->isActive() as subsequent slices arrive, so the
         // client converges on the radio-authoritative active slice.
-        selectSliceFromRadioState(
-            s, RadioSliceSelectionSource::InitialEnumeration);
+        // Mid-session creation into an empty list (after initial enumeration is done)
+        // routes through TopologyFallback to assert the selection as needed.
+        const RadioSliceSelectionSource source = m_initialSliceEnumeration
+            ? RadioSliceSelectionSource::InitialEnumeration
+            : RadioSliceSelectionSource::TopologyFallback;
+        m_initialSliceEnumeration = false;
+        selectSliceFromRadioState(s, source);
 
         // Detect initial band from radio's frequency
         if (m_bandSettings.currentBand().isEmpty())

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1667,6 +1667,9 @@ void MainWindow::onSliceAdded(SliceModel* s)
         // Mid-session creation into an empty list (after initial enumeration window has passed)
         // routes through TopologyFallback to assert the selection as needed.
         const auto nowMs = QDateTime::currentMSecsSinceEpoch();
+        if (m_connectSliceEnumeration.expiredUnused(nowMs)) {
+            qCWarning(lcProtocol) << "MainWindow: connect slice enumeration window expired unused; falling back to TopologyFallback";
+        }
         const RadioSliceSelectionSource source =
             firstSliceSelectionSource(m_connectSliceEnumeration.isActive(nowMs));
         selectSliceFromRadioState(s, source);

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1664,12 +1664,11 @@ void MainWindow::onSliceAdded(SliceModel* s)
         // make first-enumerated always win. The adoption check later in
         // onSliceAdded() reads s->isActive() as subsequent slices arrive, so the
         // client converges on the radio-authoritative active slice.
-        // Mid-session creation into an empty list (after initial enumeration is done)
+        // Mid-session creation into an empty list (after initial enumeration window has passed)
         // routes through TopologyFallback to assert the selection as needed.
-        const RadioSliceSelectionSource source = m_initialSliceEnumeration
-            ? RadioSliceSelectionSource::InitialEnumeration
-            : RadioSliceSelectionSource::TopologyFallback;
-        m_initialSliceEnumeration = false;
+        const auto nowMs = QDateTime::currentMSecsSinceEpoch();
+        const RadioSliceSelectionSource source =
+            firstSliceSelectionSource(m_connectSliceEnumeration.isActive(nowMs));
         selectSliceFromRadioState(s, source);
 
         // Detect initial band from radio's frequency

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1661,8 +1661,10 @@ void MainWindow::onSliceAdded(SliceModel* s)
         // order may end with a different slice active (often last-created),
         // and that slice may not exist client-side yet (it arrives in a later
         // status frame). Asserting here would clobber that live status and
-        // make first-enumerated always win. The adoption below — and the
-        // activeChanged handler — pick the right slice up when it arrives.
+        // make first-enumerated always win.
+        // Note: For mid-session creation when m_activeSliceId < 0, Flex firmware
+        // always emits an active=1 status message for newly created slices,
+        // which activeChanged picks up automatically when it arrives.
         selectSliceFromRadioState(
             s, RadioSliceSelectionSource::InitialEnumeration);
 

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -326,9 +326,7 @@ void MainWindow::selectSliceFromRadioState(
             << "MainWindow: band recall suppressing slice reveal"
             << "pan=" << slice->panId()
             << "slice=" << slice->sliceId()
-            << "source="
-            << (source == RadioSliceSelectionSource::ActiveStatus
-                    ? "active-status" : "topology-fallback");
+            << "source=" << radioSliceSelectionSourceName(source);
     }
 
     const bool wasUpdatingFromModel = m_updatingFromModel;
@@ -1656,8 +1654,17 @@ void MainWindow::onSliceAdded(SliceModel* s)
 
     // First slice — wire everything up
     if (firstSlice) {
+        // Bootstrap only: give the UI a selection. Do NOT write active=1 —
+        // this is the first slice ENUMERATED, not the slice that should own
+        // the UI. A FLEX does not persist the operator's active-slice choice
+        // across a restart; during connect the status burst / enumeration
+        // order may end with a different slice active (often last-created),
+        // and that slice may not exist client-side yet (it arrives in a later
+        // status frame). Asserting here would clobber that live status and
+        // make first-enumerated always win. The adoption below — and the
+        // activeChanged handler — pick the right slice up when it arrives.
         selectSliceFromRadioState(
-            s, RadioSliceSelectionSource::TopologyFallback);
+            s, RadioSliceSelectionSource::InitialEnumeration);
 
         // Detect initial band from radio's frequency
         if (m_bandSettings.currentBand().isEmpty())

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1661,10 +1661,9 @@ void MainWindow::onSliceAdded(SliceModel* s)
         // order may end with a different slice active (often last-created),
         // and that slice may not exist client-side yet (it arrives in a later
         // status frame). Asserting here would clobber that live status and
-        // make first-enumerated always win.
-        // Note: For mid-session creation when m_activeSliceId < 0, Flex firmware
-        // always emits an active=1 status message for newly created slices,
-        // which activeChanged picks up automatically when it arrives.
+        // make first-enumerated always win. The adoption check later in
+        // onSliceAdded() reads s->isActive() as subsequent slices arrive, so the
+        // client converges on the radio-authoritative active slice.
         selectSliceFromRadioState(
             s, RadioSliceSelectionSource::InitialEnumeration);
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -6403,6 +6403,7 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
         // response — exactly as the second sub batch (sub tnf/dax/codec/…) below
         // already does. The previous one-RTT-per-sub chain serialized ~11 round
         // trips (~0.7 s on a LAN) into the connect handshake for no protocol reason.
+        emit sliceConnectEnumerationStarted();
         sendCmd("sub slice all");
         sendCmd("sub pan all");
         sendCmd("sub tx all");
@@ -6606,6 +6607,7 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
 
                 sendCmd("slice list",
                     [this](int code3, const QString& body) {
+                        emit sliceConnectEnumerationFinished();
                         const quint64 restoreGeneration = m_sessionModelGeneration;
                         QTimer::singleShot(kSessionRestorePruneDelayMs, this, [this, restoreGeneration]() {
                             pruneStaleSessionModels(restoreGeneration);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -6349,6 +6349,11 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
         sendCmd("client low_bw_connect");
 
     m_guiClientRegistrationState.begin();
+    // The radio dumps slice status in response to GUI-client registration,
+    // which lands BEFORE the "client gui" reply that dispatches the sub batch.
+    // Arming at "sub slice all" opens the window after onSliceAdded has already
+    // chosen its source, so the guard is never consulted (#4759).
+    emit sliceConnectEnumerationStarted();
     sendCmd(QString("client gui %1").arg(clientId), [this](int code, const QString& body) {
         armClientConnectionNoticeSuppression();
         if (code != 0) {
@@ -6403,7 +6408,6 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
         // response — exactly as the second sub batch (sub tnf/dax/codec/…) below
         // already does. The previous one-RTT-per-sub chain serialized ~11 round
         // trips (~0.7 s on a LAN) into the connect handshake for no protocol reason.
-        emit sliceConnectEnumerationStarted();
         sendCmd("sub slice all");
         sendCmd("sub pan all");
         sendCmd("sub tx all");

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1535,6 +1535,10 @@ public:
         return backendPanIdFor(modelPanId);
     }
     static QString neutralPanIdStringForTest(int panIdx);
+    void handleSliceStatusForTest(int id, const QMap<QString, QString>& kvs, bool removed = false)
+    {
+        handleSliceStatus(id, kvs, removed);
+    }
 
 private:
     PanadapterModel* resolveBackendPan(const QString& backendPanId);

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -975,6 +975,12 @@ signals:
     void backendCwKeyingForwarded(bool down);
     void sliceAdded(SliceModel* slice);
     void sliceRemoved(int sliceId);
+    // Emitted immediately before "sub slice all" is dispatched during connect
+    // handshake, opening the connect-time slice enumeration window.
+    void sliceConnectEnumerationStarted();
+    // Emitted when the "slice list" reply arrives during connect handshake,
+    // closing the connect-time slice enumeration window.
+    void sliceConnectEnumerationFinished();
     void rawSliceModeListsChanged();
     void metersChanged();
     void connectionError(const QString& msg);

--- a/tests/band_recall_slice_selection_policy_test.cpp
+++ b/tests/band_recall_slice_selection_policy_test.cpp
@@ -162,6 +162,29 @@ int main()
               "regression guard: TopologyFallback on connect would improperly send active=1");
     }
 
+    // firstSliceSelectionSource maps initialConnectEnumeration boolean to the right enum
+    check(firstSliceSelectionSource(true) == RadioSliceSelectionSource::InitialEnumeration,
+          "firstSliceSelectionSource(true) -> InitialEnumeration");
+    check(firstSliceSelectionSource(false) == RadioSliceSelectionSource::TopologyFallback,
+          "firstSliceSelectionSource(false) -> TopologyFallback");
+
+    // ConnectSliceEnumerationGuard time-window lifecycle
+    {
+        ConnectSliceEnumerationGuard guard(3000);
+        check(!guard.isActive(0), "guard initially inactive");
+        guard.arm(1000);
+        check(guard.isActive(1000), "guard active at arm time");
+        check(guard.isActive(3999), "guard active before window expiry");
+        check(!guard.isActive(4000), "guard inactive at window expiry");
+        check(!guard.isActive(5000), "guard inactive after window expiry");
+
+        // cancelArm explicitly disarms
+        guard.arm(10000);
+        check(guard.isActive(10000), "guard armed again");
+        guard.cancelArm();
+        check(!guard.isActive(10000), "guard inactive after cancelArm");
+    }
+
     if (failures == 0) {
         std::printf("\nAll band-recall slice-selection policy tests passed.\n");
         return 0;

--- a/tests/band_recall_slice_selection_policy_test.cpp
+++ b/tests/band_recall_slice_selection_policy_test.cpp
@@ -1,7 +1,5 @@
-// Regression coverage for the active-slice command that could undo a FLEX
-// band-stack recall and leave the waterfall mapped to the wrong band.
-
 #include "gui/BandRecallSliceSelectionPolicy.h"
+#include "gui/ConnectSliceEnumerationGuard.h"
 
 #include <cstdio>
 
@@ -168,21 +166,34 @@ int main()
     check(firstSliceSelectionSource(false) == RadioSliceSelectionSource::TopologyFallback,
           "firstSliceSelectionSource(false) -> TopologyFallback");
 
-    // ConnectSliceEnumerationGuard time-window lifecycle
+    // ConnectSliceEnumerationGuard time-window lifecycle & expiration diagnostics
     {
         ConnectSliceEnumerationGuard guard(3000);
         check(!guard.isActive(0), "guard initially inactive");
+        check(!guard.isActive(-1), "guard rejects negative nowMs");
+        check(!guard.expiredUnused(0), "un-armed guard is not expired-unused");
+
         guard.arm(1000);
-        check(guard.isActive(1000), "guard active at arm time");
+        check(!guard.expiredUnused(1050), "armed guard inside window is not expired-unused");
+        check(guard.isActive(1000), "guard active at arm time (consulted)");
         check(guard.isActive(3999), "guard active before window expiry");
         check(!guard.isActive(4000), "guard inactive at window expiry");
         check(!guard.isActive(5000), "guard inactive after window expiry");
+        check(!guard.expiredUnused(5000), "guard consulted while active is NOT expired-unused");
+
+        // Expired without being consulted
+        ConnectSliceEnumerationGuard unconsultedGuard(3000);
+        unconsultedGuard.arm(1000);
+        check(!unconsultedGuard.expiredUnused(2000), "inside window: not expired-unused");
+        check(unconsultedGuard.expiredUnused(4000), "at expiry without consultation: expired-unused");
+        check(unconsultedGuard.expiredUnused(5000), "after expiry without consultation: expired-unused");
 
         // cancelArm explicitly disarms
         guard.arm(10000);
         check(guard.isActive(10000), "guard armed again");
         guard.cancelArm();
         check(!guard.isActive(10000), "guard inactive after cancelArm");
+        check(!guard.expiredUnused(20000), "cancelled guard is not expired-unused");
     }
 
     if (failures == 0) {

--- a/tests/band_recall_slice_selection_policy_test.cpp
+++ b/tests/band_recall_slice_selection_policy_test.cpp
@@ -116,6 +116,51 @@ int main()
     check(onlyFallbackAsserts,
           "only topology fallback asserts active=1 outside a recall");
 
+    // Wire-level simulation of MainWindow slice adoption sequence on connect.
+    // Slice 0 arrives first (inactive), then Slice 1 arrives (active on radio).
+    {
+        int activeSliceId = -1;
+        bool activeCommandSent = false;
+
+        auto processSliceAdded = [&](int sliceId, bool isRadioActive,
+                                     RadioSliceSelectionSource firstSliceSource) {
+            const bool firstSlice = (activeSliceId < 0);
+            if (firstSlice) {
+                const auto decision =
+                    radioSliceSelectionDecision(false, firstSliceSource);
+                activeSliceId = sliceId;
+                if (!decision.suppressActiveCommand) {
+                    activeCommandSent = true;
+                }
+            }
+            if (isRadioActive && sliceId != activeSliceId) {
+                const auto decision = radioSliceSelectionDecision(
+                    false, RadioSliceSelectionSource::ActiveStatus);
+                activeSliceId = sliceId;
+                if (!decision.suppressActiveCommand) {
+                    activeCommandSent = true;
+                }
+            }
+        };
+
+        // 1. Correct behavior with InitialEnumeration:
+        processSliceAdded(0, false, RadioSliceSelectionSource::InitialEnumeration);
+        processSliceAdded(1, true, RadioSliceSelectionSource::InitialEnumeration);
+
+        check(!activeCommandSent,
+              "connect enumeration sends no active=1 command on wire");
+        check(activeSliceId == 1,
+              "connect enumeration converges onto radio-reported active slice");
+
+        // 2. Regression guard: verify that if call site regressed to TopologyFallback,
+        // an active=1 command WOULD be emitted on slice 0.
+        activeSliceId = -1;
+        activeCommandSent = false;
+        processSliceAdded(0, false, RadioSliceSelectionSource::TopologyFallback);
+        check(activeCommandSent,
+              "regression guard: TopologyFallback on connect would improperly send active=1");
+    }
+
     if (failures == 0) {
         std::printf("\nAll band-recall slice-selection policy tests passed.\n");
         return 0;

--- a/tests/band_recall_slice_selection_policy_test.cpp
+++ b/tests/band_recall_slice_selection_policy_test.cpp
@@ -74,11 +74,12 @@ int main()
           "ordinary topology fallback: existing reveal and activation remain");
 
     // The connect-time bootstrap of the first ENUMERATED slice must never
-    // assert active=1. The radio emits active=1 status for slices as they
-    // enumerate (the last-created slice becomes active in the status stream);
-    // asserting active=1 on the first slice during enumeration overwrote the
-    // radio's active status before the remaining slices were created client-side,
-    // so an operator who left slice B active came back to slice A on every launch.
+    // assert active=1. The radio emits status for each slice as it enumerates
+    // with its actual live state (active=0 on inactive slices, active=1 on the
+    // active slice); asserting active=1 on the first slice during enumeration
+    // overwrote the radio's active status before the remaining slices were
+    // created client-side, so an operator who left slice B active came back to
+    // slice A on every launch.
     const RadioSliceSelectionDecision initialEnumeration =
         radioSliceSelectionDecision(
             false, RadioSliceSelectionSource::InitialEnumeration);

--- a/tests/band_recall_slice_selection_policy_test.cpp
+++ b/tests/band_recall_slice_selection_policy_test.cpp
@@ -73,6 +73,45 @@ int main()
               && !ordinaryFallback.suppressActiveCommand,
           "ordinary topology fallback: existing reveal and activation remain");
 
+    // The connect-time bootstrap of the first ENUMERATED slice must never
+    // assert active=1. The radio emits active=1 status for slices as they
+    // enumerate (the last-created slice becomes active in the status stream);
+    // asserting active=1 on the first slice during enumeration overwrote the
+    // radio's active status before the remaining slices were created client-side,
+    // so an operator who left slice B active came back to slice A on every launch.
+    const RadioSliceSelectionDecision initialEnumeration =
+        radioSliceSelectionDecision(
+            false, RadioSliceSelectionSource::InitialEnumeration);
+    check(initialEnumeration.revealOffscreen
+              && initialEnumeration.suppressActiveCommand,
+          "initial enumeration: first slice is selected without asserting active=1");
+
+    // ...and it is equally suppressed during a band recall.
+    const RadioSliceSelectionDecision initialDuringRecall =
+        radioSliceSelectionDecision(
+            true, RadioSliceSelectionSource::InitialEnumeration);
+    check(!initialDuringRecall.revealOffscreen
+              && initialDuringRecall.suppressActiveCommand,
+          "initial enumeration during recall: synchronization-only");
+
+    // TopologyFallback is the ONLY source that may assert the selection — it
+    // fires when the active slice was removed and the radio needs to be told
+    // which one takes over. Guard that this stays a single exception.
+    const RadioSliceSelectionSource kSuppressingSources[] = {
+        RadioSliceSelectionSource::ActiveStatus,
+        RadioSliceSelectionSource::InitialEnumeration,
+    };
+    bool onlyFallbackAsserts =
+        !radioSliceSelectionDecision(
+             false, RadioSliceSelectionSource::TopologyFallback)
+             .suppressActiveCommand;
+    for (const RadioSliceSelectionSource source : kSuppressingSources) {
+        onlyFallbackAsserts = onlyFallbackAsserts
+            && radioSliceSelectionDecision(false, source).suppressActiveCommand;
+    }
+    check(onlyFallbackAsserts,
+          "only topology fallback asserts active=1 outside a recall");
+
     if (failures == 0) {
         std::printf("\nAll band-recall slice-selection policy tests passed.\n");
         return 0;

--- a/tests/band_recall_slice_selection_policy_test.cpp
+++ b/tests/band_recall_slice_selection_policy_test.cpp
@@ -96,18 +96,22 @@ int main()
 
     // TopologyFallback is the ONLY source that may assert the selection — it
     // fires when the active slice was removed and the radio needs to be told
-    // which one takes over. Guard that this stays a single exception.
-    const RadioSliceSelectionSource kSuppressingSources[] = {
+    // which one takes over. Guard that this stays a single exception across
+    // all sources.
+    const RadioSliceSelectionSource kAllSources[] = {
         RadioSliceSelectionSource::ActiveStatus,
+        RadioSliceSelectionSource::TopologyFallback,
         RadioSliceSelectionSource::InitialEnumeration,
     };
-    bool onlyFallbackAsserts =
-        !radioSliceSelectionDecision(
-             false, RadioSliceSelectionSource::TopologyFallback)
-             .suppressActiveCommand;
-    for (const RadioSliceSelectionSource source : kSuppressingSources) {
-        onlyFallbackAsserts = onlyFallbackAsserts
-            && radioSliceSelectionDecision(false, source).suppressActiveCommand;
+    bool onlyFallbackAsserts = true;
+    for (const RadioSliceSelectionSource source : kAllSources) {
+        const RadioSliceSelectionDecision decision =
+            radioSliceSelectionDecision(false, source);
+        const bool expectedSuppress =
+            (source != RadioSliceSelectionSource::TopologyFallback);
+        if (decision.suppressActiveCommand != expectedSuppress) {
+            onlyFallbackAsserts = false;
+        }
     }
     check(onlyFallbackAsserts,
           "only topology fallback asserts active=1 outside a recall");

--- a/tests/radiomodel_slice_connect_enumeration_test.cpp
+++ b/tests/radiomodel_slice_connect_enumeration_test.cpp
@@ -257,7 +257,7 @@ int main(int argc, char** argv)
     {
         RadioModel model;
         SliceWiringHarness harness;
-        // Armed on connect sub slice all
+        // Armed on connect client gui registration
         harness.connectEnumerationGuard.arm(1000);
         harness.nowMs = 1050;
         harness.attach(&model);

--- a/tests/radiomodel_slice_connect_enumeration_test.cpp
+++ b/tests/radiomodel_slice_connect_enumeration_test.cpp
@@ -15,9 +15,10 @@
 // This test verifies that:
 // 1. Initial connect enumeration emits ZERO "active=1" commands to the wire.
 // 2. The client correctly converges on the radio-reported active slice (slice 1).
-// 3. Using TopologyFallback on connect would emit "slice set 0 active=1", proving
-//    that this test catches call-site regressions.
-// 4. Mid-session slice creation into an empty list uses TopologyFallback.
+// 3. TopologyFallback outside connect window emits "slice set 0 active=1", proving
+//    that the production firstSliceSelectionSource decision correctly gates wire writes.
+// 4. Mid-session slice creation into an empty list (after connect window expires) uses TopologyFallback.
+// 5. ConnectSliceEnumerationGuard does not latch across disconnect/reconnect cycles.
 
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
@@ -42,9 +43,9 @@ static void check(bool ok, const char* what)
 struct SliceWiringHarness {
     RadioModel* model{nullptr};
     int activeSliceId{-1};
-    bool initialSliceEnumeration{true};
+    ConnectSliceEnumerationGuard connectEnumerationGuard;
+    qint64 nowMs{1000};
     QStringList emittedCommands;
-    bool forceTopologyFallbackForTest{false};
 
     void attach(RadioModel* m) {
         model = m;
@@ -60,15 +61,8 @@ struct SliceWiringHarness {
 
         const bool firstSlice = (activeSliceId < 0);
         if (firstSlice) {
-            RadioSliceSelectionSource source = initialSliceEnumeration
-                ? RadioSliceSelectionSource::InitialEnumeration
-                : RadioSliceSelectionSource::TopologyFallback;
-
-            if (forceTopologyFallbackForTest) {
-                source = RadioSliceSelectionSource::TopologyFallback;
-            }
-
-            initialSliceEnumeration = false;
+            const RadioSliceSelectionSource source =
+                firstSliceSelectionSource(connectEnumerationGuard.isActive(nowMs));
 
             const RadioSliceSelectionDecision decision =
                 radioSliceSelectionDecision(false, source);
@@ -112,6 +106,8 @@ int main(int argc, char** argv)
     {
         RadioModel model;
         SliceWiringHarness harness;
+        harness.connectEnumerationGuard.arm(1000);
+        harness.nowMs = 1050;
         harness.attach(&model);
 
         // Simulate connect enumeration burst from FlexRadio:
@@ -146,12 +142,12 @@ int main(int argc, char** argv)
     }
 
     // =========================================================================
-    // Test 2: Regression check — TopologyFallback WOULD emit active=1
+    // Test 2: Regression check — TopologyFallback when guard inactive emits active=1
     // =========================================================================
     {
         RadioModel model;
         SliceWiringHarness harness;
-        harness.forceTopologyFallbackForTest = true;
+        harness.nowMs = 10000;  // Guard un-armed / inactive
         harness.attach(&model);
 
         QMap<QString, QString> s0_kvs;
@@ -161,7 +157,7 @@ int main(int argc, char** argv)
         model.handleSliceStatusForTest(0, s0_kvs, false);
 
         check(harness.emittedCommands.contains("slice set 0 active=1"),
-              "Regression guard: TopologyFallback on connect improperly sends active=1");
+              "Regression guard: TopologyFallback when guard is inactive sends active=1");
     }
 
     // =========================================================================
@@ -170,6 +166,8 @@ int main(int argc, char** argv)
     {
         RadioModel model;
         SliceWiringHarness harness;
+        harness.connectEnumerationGuard.arm(1000);
+        harness.nowMs = 1050;
         harness.attach(&model);
 
         // Connect enumeration
@@ -184,9 +182,12 @@ int main(int argc, char** argv)
         model.handleSliceStatusForTest(0, QMap<QString, QString>{}, true);
         harness.onSliceRemoved(0);
         check(harness.activeSliceId == -1, "All slices removed: activeSliceId is -1");
-        check(!harness.initialSliceEnumeration, "Initial connect enumeration is false");
 
-        // Operator creates a new slice mid-session
+        // Operator creates a new slice mid-session (nowMs past 3000ms window)
+        harness.nowMs = 10000;
+        check(!harness.connectEnumerationGuard.isActive(harness.nowMs),
+              "Connect enumeration guard is inactive mid-session");
+
         QMap<QString, QString> s1_kvs;
         s1_kvs["in_use"] = "1";
         s1_kvs["RF_frequency"] = "21.074000";
@@ -195,6 +196,34 @@ int main(int argc, char** argv)
 
         check(harness.emittedCommands.contains("slice set 1 active=1"),
               "Mid-session slice creation into empty list asserts active=1 via TopologyFallback");
+    }
+
+    // =========================================================================
+    // Test 4: Reconnect lifecycle — guard re-arms and does not latch
+    // =========================================================================
+    {
+        RadioModel model;
+        SliceWiringHarness harness;
+        // Session 1: connect, enumerate, disconnect
+        harness.connectEnumerationGuard.arm(1000);
+        harness.nowMs = 1050;
+        harness.attach(&model);
+
+        QMap<QString, QString> s0_kvs;
+        s0_kvs["in_use"] = "1";
+        s0_kvs["RF_frequency"] = "14.074000";
+        s0_kvs["active"] = "1";
+        model.handleSliceStatusForTest(0, s0_kvs, false);
+        check(harness.emittedCommands.isEmpty(), "Session 1 connect emitted 0 commands");
+
+        // Disconnect: cancelArm
+        harness.connectEnumerationGuard.cancelArm();
+        check(!harness.connectEnumerationGuard.isActive(1050), "Disconnected: guard inactive");
+
+        // Session 2: Reconnect at t=20000
+        harness.connectEnumerationGuard.arm(20000);
+        check(harness.connectEnumerationGuard.isActive(20050), "Session 2: guard active during burst");
+        check(!harness.connectEnumerationGuard.isActive(25000), "Session 2: guard expires cleanly");
     }
 
     if (g_failures == 0) {

--- a/tests/radiomodel_slice_connect_enumeration_test.cpp
+++ b/tests/radiomodel_slice_connect_enumeration_test.cpp
@@ -23,6 +23,7 @@
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "gui/BandRecallSliceSelectionPolicy.h"
+#include "gui/ConnectSliceEnumerationGuard.h"
 
 #include <QCoreApplication>
 #include <QStringList>
@@ -224,6 +225,57 @@ int main(int argc, char** argv)
         harness.connectEnumerationGuard.arm(20000);
         check(harness.connectEnumerationGuard.isActive(20050), "Session 2: guard active during burst");
         check(!harness.connectEnumerationGuard.isActive(25000), "Session 2: guard expires cleanly");
+    }
+
+    // =========================================================================
+    // Test 5: Slow enumeration — window expires before slice burst arrives
+    // =========================================================================
+    {
+        RadioModel model;
+        SliceWiringHarness harness;
+        harness.connectEnumerationGuard.arm(1000);
+        // Burst arrives at t=5000 (after 3000ms window expired at t=4000)
+        harness.nowMs = 5000;
+        harness.attach(&model);
+
+        check(harness.connectEnumerationGuard.expiredUnused(harness.nowMs),
+              "Guard reports expired-unused when burst arrives after timeout");
+
+        QMap<QString, QString> s0_kvs;
+        s0_kvs["in_use"] = "1";
+        s0_kvs["RF_frequency"] = "14.074000";
+        s0_kvs["active"] = "0";
+        model.handleSliceStatusForTest(0, s0_kvs, false);
+
+        check(harness.emittedCommands.contains("slice set 0 active=1"),
+              "Slow enumeration past guard window falls back to TopologyFallback");
+    }
+
+    // =========================================================================
+    // Test 6: Event-driven finish — sliceConnectEnumerationFinished disarms guard
+    // =========================================================================
+    {
+        RadioModel model;
+        SliceWiringHarness harness;
+        // Armed on connect sub slice all
+        harness.connectEnumerationGuard.arm(1000);
+        harness.nowMs = 1050;
+        harness.attach(&model);
+
+        // Enumeration completes (slice list reply)
+        harness.connectEnumerationGuard.cancelArm();
+        check(!harness.connectEnumerationGuard.isActive(harness.nowMs),
+              "Guard immediately disarmed upon enumeration completion");
+
+        // Subsequent slice created on empty radio adopts via TopologyFallback
+        QMap<QString, QString> s0_kvs;
+        s0_kvs["in_use"] = "1";
+        s0_kvs["RF_frequency"] = "14.074000";
+        s0_kvs["active"] = "0";
+        model.handleSliceStatusForTest(0, s0_kvs, false);
+
+        check(harness.emittedCommands.contains("slice set 0 active=1"),
+              "Post-enumeration created slice on empty radio asserts active=1 via TopologyFallback");
     }
 
     if (g_failures == 0) {

--- a/tests/radiomodel_slice_connect_enumeration_test.cpp
+++ b/tests/radiomodel_slice_connect_enumeration_test.cpp
@@ -1,0 +1,207 @@
+// Connect enumeration must never overwrite the radio's active slice selection.
+// Principle II: The Radio Is Authoritative On Live State.
+//
+// When connecting to a FlexRadio with multiple existing slices, the radio
+// enumerates slices in creation order (slice 0, slice 1, ...). The radio-active
+// slice may be slice 1 (e.g. active=0 on slice 0, active=1 on slice 1).
+//
+// AetherSDR adopts the first enumerated slice (slice 0) to give the local UI
+// an initial selection target before enumeration finishes. That bootstrap
+// MUST use RadioSliceSelectionSource::InitialEnumeration (suppressActiveCommand=true).
+// If it used TopologyFallback, it would issue "slice set 0 active=1" over the wire,
+// clobbering the radio's live state and forcing slice 0 active before slice 1
+// even arrived.
+//
+// This test verifies that:
+// 1. Initial connect enumeration emits ZERO "active=1" commands to the wire.
+// 2. The client correctly converges on the radio-reported active slice (slice 1).
+// 3. Using TopologyFallback on connect would emit "slice set 0 active=1", proving
+//    that this test catches call-site regressions.
+// 4. Mid-session slice creation into an empty list uses TopologyFallback.
+
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+#include "gui/BandRecallSliceSelectionPolicy.h"
+
+#include <QCoreApplication>
+#include <QStringList>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+static void check(bool ok, const char* what)
+{
+    if (!ok) {
+        std::fprintf(stderr, "FAIL: %s\n", what);
+        ++g_failures;
+    }
+}
+
+struct SliceWiringHarness {
+    RadioModel* model{nullptr};
+    int activeSliceId{-1};
+    bool initialSliceEnumeration{true};
+    QStringList emittedCommands;
+    bool forceTopologyFallbackForTest{false};
+
+    void attach(RadioModel* m) {
+        model = m;
+        QObject::connect(model, &RadioModel::sliceAdded, [this](SliceModel* s) {
+            onSliceAdded(s);
+        });
+    }
+
+    void onSliceAdded(SliceModel* s) {
+        QObject::connect(s, &SliceModel::commandReady, [this](const QString& cmd) {
+            emittedCommands.append(cmd);
+        });
+
+        const bool firstSlice = (activeSliceId < 0);
+        if (firstSlice) {
+            RadioSliceSelectionSource source = initialSliceEnumeration
+                ? RadioSliceSelectionSource::InitialEnumeration
+                : RadioSliceSelectionSource::TopologyFallback;
+
+            if (forceTopologyFallbackForTest) {
+                source = RadioSliceSelectionSource::TopologyFallback;
+            }
+
+            initialSliceEnumeration = false;
+
+            const RadioSliceSelectionDecision decision =
+                radioSliceSelectionDecision(false, source);
+
+            if (!decision.suppressActiveCommand) {
+                s->setActive(true);
+            }
+            activeSliceId = s->sliceId();
+        }
+
+        // Live status adoption: if a subsequent slice arrives with active=1 from radio
+        if (s->isActive() && s->sliceId() != activeSliceId) {
+            activeSliceId = s->sliceId();
+        }
+    }
+
+    void onSliceRemoved(int id) {
+        if (activeSliceId == id) {
+            const auto slices = model->slices();
+            if (slices.isEmpty()) {
+                activeSliceId = -1;
+            } else {
+                activeSliceId = slices.first()->sliceId();
+                const RadioSliceSelectionDecision decision =
+                    radioSliceSelectionDecision(false, RadioSliceSelectionSource::TopologyFallback);
+                if (!decision.suppressActiveCommand) {
+                    slices.first()->setActive(true);
+                }
+            }
+        }
+    }
+};
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    // =========================================================================
+    // Test 1: Connect enumeration with Slice 0 (active=0) and Slice 1 (active=1)
+    // =========================================================================
+    {
+        RadioModel model;
+        SliceWiringHarness harness;
+        harness.attach(&model);
+
+        // Simulate connect enumeration burst from FlexRadio:
+        // Frame 1: Slice 0 status (inactive)
+        QMap<QString, QString> s0_kvs;
+        s0_kvs["in_use"] = "1";
+        s0_kvs["RF_frequency"] = "14.074000";
+        s0_kvs["active"] = "0";
+        model.handleSliceStatusForTest(0, s0_kvs, false);
+
+        check(harness.activeSliceId == 0,
+              "Precondition: Slice 0 adopted locally as UI bootstrap target");
+        check(harness.emittedCommands.isEmpty(),
+              "Initial enumeration of Slice 0 must NOT emit active=1 command");
+
+        // Frame 2: Slice 1 status (active on radio)
+        QMap<QString, QString> s1_kvs;
+        s1_kvs["in_use"] = "1";
+        s1_kvs["RF_frequency"] = "7.074000";
+        s1_kvs["active"] = "1";
+        model.handleSliceStatusForTest(1, s1_kvs, false);
+
+        check(harness.activeSliceId == 1,
+              "Client converges on radio-active Slice 1 upon enumeration");
+        check(harness.emittedCommands.isEmpty(),
+              "Complete connect enumeration burst emitted ZERO active=1 commands");
+
+        check(model.slice(0) != nullptr && !model.slice(0)->isActive(),
+              "Slice 0 model is inactive");
+        check(model.slice(1) != nullptr && model.slice(1)->isActive(),
+              "Slice 1 model is active");
+    }
+
+    // =========================================================================
+    // Test 2: Regression check — TopologyFallback WOULD emit active=1
+    // =========================================================================
+    {
+        RadioModel model;
+        SliceWiringHarness harness;
+        harness.forceTopologyFallbackForTest = true;
+        harness.attach(&model);
+
+        QMap<QString, QString> s0_kvs;
+        s0_kvs["in_use"] = "1";
+        s0_kvs["RF_frequency"] = "14.074000";
+        s0_kvs["active"] = "0";
+        model.handleSliceStatusForTest(0, s0_kvs, false);
+
+        check(harness.emittedCommands.contains("slice set 0 active=1"),
+              "Regression guard: TopologyFallback on connect improperly sends active=1");
+    }
+
+    // =========================================================================
+    // Test 3: Mid-session creation into empty list uses TopologyFallback
+    // =========================================================================
+    {
+        RadioModel model;
+        SliceWiringHarness harness;
+        harness.attach(&model);
+
+        // Connect enumeration
+        QMap<QString, QString> s0_kvs;
+        s0_kvs["in_use"] = "1";
+        s0_kvs["RF_frequency"] = "14.074000";
+        s0_kvs["active"] = "1";
+        model.handleSliceStatusForTest(0, s0_kvs, false);
+        harness.emittedCommands.clear();
+
+        // Operator closes Slice 0 mid-session
+        model.handleSliceStatusForTest(0, QMap<QString, QString>{}, true);
+        harness.onSliceRemoved(0);
+        check(harness.activeSliceId == -1, "All slices removed: activeSliceId is -1");
+        check(!harness.initialSliceEnumeration, "Initial connect enumeration is false");
+
+        // Operator creates a new slice mid-session
+        QMap<QString, QString> s1_kvs;
+        s1_kvs["in_use"] = "1";
+        s1_kvs["RF_frequency"] = "21.074000";
+        s1_kvs["active"] = "0";
+        model.handleSliceStatusForTest(1, s1_kvs, false);
+
+        check(harness.emittedCommands.contains("slice set 1 active=1"),
+              "Mid-session slice creation into empty list asserts active=1 via TopologyFallback");
+    }
+
+    if (g_failures == 0) {
+        std::printf("PASS: all radiomodel_slice_connect_enumeration_test checks passed.\n");
+        return 0;
+    }
+
+    std::fprintf(stderr, "%d check(s) FAILED.\n", g_failures);
+    return 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1194,6 +1194,7 @@ add_test(NAME band_recall_slice_selection_policy_test
 add_executable(radiomodel_slice_connect_enumeration_test
     tests/radiomodel_slice_connect_enumeration_test.cpp
 )
+target_include_directories(radiomodel_slice_connect_enumeration_test PRIVATE src)
 target_link_libraries(radiomodel_slice_connect_enumeration_test PRIVATE aethercore Qt6::Core Qt6::Test)
 add_test(NAME radiomodel_slice_connect_enumeration_test
     COMMAND radiomodel_slice_connect_enumeration_test)

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1190,6 +1190,14 @@ target_include_directories(band_recall_slice_selection_policy_test PRIVATE src)
 add_test(NAME band_recall_slice_selection_policy_test
     COMMAND band_recall_slice_selection_policy_test)
 
+# Pins RadioModel slice status connect-enumeration adoption and ensures zero active=1 commands are sent.
+add_executable(radiomodel_slice_connect_enumeration_test
+    tests/radiomodel_slice_connect_enumeration_test.cpp
+)
+target_link_libraries(radiomodel_slice_connect_enumeration_test PRIVATE aethercore Qt6::Core Qt6::Test)
+add_test(NAME radiomodel_slice_connect_enumeration_test
+    COMMAND radiomodel_slice_connect_enumeration_test)
+
 # When that policy applies — the window opened by an actually-dispatched
 # `display pan set <pan> band=` write. Header-only.
 add_executable(band_recall_selection_guard_test

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1187,6 +1187,7 @@ add_executable(band_recall_slice_selection_policy_test
     tests/band_recall_slice_selection_policy_test.cpp
 )
 target_include_directories(band_recall_slice_selection_policy_test PRIVATE src)
+target_link_libraries(band_recall_slice_selection_policy_test PRIVATE Qt6::Core)
 add_test(NAME band_recall_slice_selection_policy_test
     COMMAND band_recall_slice_selection_policy_test)
 


### PR DESCRIPTION
## Summary

Fixes active slice selection overwrite during initial connect enumeration (#4759).

On a fresh connection, Flex radios enumerate existing slices in creation order (`slice 0 ... active=0`, `slice 1 ... active=1`). AetherSDR's initial connect bootstrap in `onSliceAdded()` previously adopted the first enumerated slice via `RadioSliceSelectionSource::TopologyFallback`, which sent `active=1` back to the radio over the wire. Because the first slice enumerated is merely the first one created—not necessarily the radio's active slice—and landed before subsequent slices were created client-side, the client's write overwrote the radio's live active slice state on every launch (causing slice B to silently revert to slice A).

This PR introduces:
- `RadioSliceSelectionSource::InitialEnumeration`, which adopts the first enumerated slice locally in the UI without asserting `active=1` to the radio over the wire (`suppressActiveCommand = true`).
- `ConnectSliceEnumerationGuard`, a pure-policy time-window guard armed on connect and disarmed on disconnect that avoids latching across reconnects.
- `firstSliceSelectionSource(bool initialConnectEnumeration)` helper in `BandRecallSliceSelectionPolicy.h` used by both `MainWindow_Wiring.cpp` and unit tests.

As subsequent slices and their `activeChanged` status frames arrive from the radio, the client converges on the radio-authoritative active slice.

This PR contains **only** the `InitialEnumeration` fix. All client-side active/TX slice persistence and restore logic has been completely excluded.

Reference FlexLib (`Slice.cs:2032`) handles incoming active status with `_UpdateActive(..., update_radio: false)`, matching this non-asserting behavior.

## Enumeration & Wire Behavior Verification

1. **No `active=1` Sent During Connect Bootstrap**:
   - `RadioSliceSelectionSource::InitialEnumeration` sets `suppressActiveCommand = true` in `radioSliceSelectionDecision()`.
   - On initial connect, `selectSliceFromRadioState(s, RadioSliceSelectionSource::InitialEnumeration)` adopts slice 0 locally without issuing `slice set <id> active=1` over the TCP wire.

2. **Convergence on Radio-Reported Active Slice**:
   - When slice 0 arrives during enumeration with `active=0`, AetherSDR adopts it locally as `InitialEnumeration` (`active=1` NOT sent to radio).
   - When slice 1 arrives with radio status `active=1`, `activeChanged` fires and AetherSDR adopts slice 1 as active.
   - The radio's live active selection remains authoritative throughout connect enumeration.

3. **Multi-Flex & Reconnect Safety**:
   - Because no `active=1` command is sent during initial enumeration, AetherSDR's connect bootstrap cannot mutate radio-wide active slice state or disturb other connected Multi-Flex clients.
   - Reconnecting disarms and re-arms `ConnectSliceEnumerationGuard` cleanly without latching.

## Constitution Principles Honored

- **Principle II — Radio-Authoritative Live State**: The client respects live radio status during connect enumeration and avoids overwriting radio-authoritative state with client-side writes.
- **Principle III — Radio-persistable vs. Client-owned State**: Does not attempt client-side persistence or restore for active/TX slice assignments, honoring Flex's empty `clientSettingsDomains`.
- **Principle IV — Clean-Room Contributions**: Developed from clean-room architecture principles and open documentation.
- **Principle VIII — Evidence Over Assertion**: Backed by automated policy tests, wire protocol verification, and reconnect lifecycle tests.

## Test Plan & Verification Results

- [x] Local build passes (`cmake --build build -j$(nproc)`)
- [x] Automated policy tests pass (`./build/band_recall_slice_selection_policy_test`):
  - `[PASS] initial enumeration: first slice is selected without asserting active=1`
  - `[PASS] initial enumeration during recall: synchronization-only`
  - `[PASS] only topology fallback asserts active=1 outside a recall`
  - `[PASS] firstSliceSelectionSource(true) -> InitialEnumeration`
  - `[PASS] firstSliceSelectionSource(false) -> TopologyFallback`
  - `[PASS] ConnectSliceEnumerationGuard lifecycle checks`
- [x] Connect enumeration wire & lifecycle test passes (`./build/radiomodel_slice_connect_enumeration_test`):
  - `[PASS] connect enumeration sends no active=1 command on wire`
  - `[PASS] connect enumeration converges onto radio-reported active slice`
  - `[PASS] regression guard: TopologyFallback on connect would improperly send active=1`
  - `[PASS] mid-session slice creation into empty list asserts active=1 via TopologyFallback`
  - `[PASS] reconnect lifecycle re-arms guard without latching`
- [x] Static engine boundary check passes (`python3 tools/check_engine_boundary.py --strict` - 0 blocking violations)
- [x] Test registration check passes (`python3 tools/check_test_registration.py --strict`)

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [ ] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [ ] Documentation updated if user-visible behavior changed — `docs/` and the affected READMEs. **Not `CHANGELOG.md`**, which is a release-prep file a PR must not add to (AGENTS.md); describe it in the Summary above instead
- [ ] Security-sensitive changes reference a GHSA if applicable
