### PR TITLE
feat(core): startup hardware/capability inventory — CPU SIMD features vs the speech-engine ISA baseline, RAM, GPU VRAM (#4986)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1554,6 +1554,13 @@ if (ENABLE_ASR)
             set_target_properties(ggml        PROPERTIES INTERFACE_LINK_LIBRARIES "ggml-base;ggml-cpu;ggml-vulkan")
             set_target_properties(whisper     PROPERTIES INTERFACE_LINK_LIBRARIES "ggml;Threads::Threads")
             message(STATUS "ASR: prebuilt whisper-gpu ${_whisper_gpu_ver} pack consumed (skipped ~1h+ MSVC compile)")
+            # The pack is produced by a stock in-tree build (GGML_NATIVE=OFF →
+            # ggml's fixed x86-64 feature set; MSVC /arch:AVX2 additionally
+            # implies FMA+F16C). Recorded here for the startup inventory
+            # (#4986) because the GGML_* options that would say so only exist
+            # when ggml's own CMake runs — which this branch skips. Re-derive
+            # if the pack is ever rebuilt with different ISA settings.
+            set(_aether_prebuilt_ggml_baseline "SSE42,AVX,AVX2,FMA,F16C,BMI2")
         else()
             # Build whisper/ggml as static objects, not .so's.
             set(_aether_saved_shared_libs ${BUILD_SHARED_LIBS})
@@ -2707,14 +2714,27 @@ target_compile_definitions(aethercore PUBLIC
 # builds (their baseline is the distro's choice and unknowable here) and on
 # non-x86 hosts (all options default OFF there), which the code reports as
 # "unknown"/skips.
-set(_aether_ggml_baseline "")
-foreach(_aether_isa SSE42 AVX AVX2 FMA F16C BMI2)
-    if (DEFINED GGML_${_aether_isa} AND GGML_${_aether_isa})
-        list(APPEND _aether_ggml_baseline ${_aether_isa})
-    endif()
-endforeach()
-if (_aether_ggml_baseline)
+if (DEFINED _aether_prebuilt_ggml_baseline)
+    # Prebuilt whisper-gpu pack (Windows release): ggml's CMake never ran, so
+    # the baseline comes from the pack's recorded build settings above.
+    set(_aether_ggml_baseline_str "${_aether_prebuilt_ggml_baseline}")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|i[3-6]86")
+    # x86 targets only: ggml defines these options unguarded on every
+    # architecture (INS_ENB defaults them ON whenever GGML_NATIVE is forced
+    # OFF on a native build), so on ARM they sit ON in the cache while the
+    # compile ignores them — scanning them there would stamp an x86 baseline
+    # into an ARM binary.
+    set(_aether_ggml_baseline "")
+    foreach(_aether_isa SSE42 AVX AVX2 FMA F16C BMI2)
+        if (DEFINED GGML_${_aether_isa} AND GGML_${_aether_isa})
+            list(APPEND _aether_ggml_baseline ${_aether_isa})
+        endif()
+    endforeach()
     list(JOIN _aether_ggml_baseline "," _aether_ggml_baseline_str)
+else()
+    set(_aether_ggml_baseline_str "")
+endif()
+if (NOT _aether_ggml_baseline_str STREQUAL "")
     target_compile_definitions(aethercore PUBLIC
         AETHER_GGML_CPU_BASELINE="${_aether_ggml_baseline_str}"
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2714,7 +2714,12 @@ target_compile_definitions(aethercore PUBLIC
 # builds (their baseline is the distro's choice and unknowable here) and on
 # non-x86 hosts (all options default OFF there), which the code reports as
 # "unknown"/skips.
-if (DEFINED _aether_prebuilt_ggml_baseline)
+set(_aether_ggml_baseline_str "")
+if (NOT ENABLE_ASR)
+    # No speech engine in this binary — never record a baseline, even if a
+    # stale cache still carries GGML_* entries from an earlier ASR configure
+    # (which would otherwise arm an ASR warning in an ASR-less build).
+elseif (DEFINED _aether_prebuilt_ggml_baseline)
     # Prebuilt whisper-gpu pack (Windows release): ggml's CMake never ran, so
     # the baseline comes from the pack's recorded build settings above.
     set(_aether_ggml_baseline_str "${_aether_prebuilt_ggml_baseline}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2723,6 +2723,10 @@ elseif (DEFINED _aether_prebuilt_ggml_baseline)
     # Prebuilt whisper-gpu pack (Windows release): ggml's CMake never ran, so
     # the baseline comes from the pack's recorded build settings above.
     set(_aether_ggml_baseline_str "${_aether_prebuilt_ggml_baseline}")
+elseif (USE_SYSTEM_LIBWHISPER)
+    # Distro libwhisper: its ISA baseline is the packager's choice and not
+    # knowable here. Explicit, not implied by GGML_* being unset — those are
+    # cache entries and survive a reconfigure from the vendored engine.
 elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|i[3-6]86")
     # x86 targets only: ggml defines these options unguarded on every
     # architecture (INS_ENB defaults them ON whenever GGML_NATIVE is forced

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -770,6 +770,7 @@ set(CORE_SOURCES
     src/core/ShortcutManager.cpp
     src/core/SupportBundle.cpp
     src/core/IssueReport.cpp
+    src/core/SystemInventory.cpp
     src/core/DeviceDiagnostics.cpp
     src/core/SerialPortController.cpp
     src/core/FlexControlManager.cpp
@@ -2696,6 +2697,28 @@ endif()
 target_compile_definitions(aethercore PUBLIC
     AETHERSDR_VERSION="${PROJECT_VERSION}"
 )
+
+# Expose the vendored ggml CPU ISA baseline to code (#4986) so the startup
+# inventory can compare it against the running CPU: GGML_NATIVE is forced OFF
+# above, which in ggml's build system enables this fixed feature set on
+# x86-64 (third_party/whisper.cpp/ggml/CMakeLists.txt, INS_ENB). On MSVC,
+# FMA/F16C have no separate options — /arch:AVX2 implies both — so the list
+# names only the options that exist. Left undefined on system-libwhisper
+# builds (their baseline is the distro's choice and unknowable here) and on
+# non-x86 hosts (all options default OFF there), which the code reports as
+# "unknown"/skips.
+set(_aether_ggml_baseline "")
+foreach(_aether_isa SSE42 AVX AVX2 FMA F16C BMI2)
+    if (DEFINED GGML_${_aether_isa} AND GGML_${_aether_isa})
+        list(APPEND _aether_ggml_baseline ${_aether_isa})
+    endif()
+endforeach()
+if (_aether_ggml_baseline)
+    list(JOIN _aether_ggml_baseline "," _aether_ggml_baseline_str)
+    target_compile_definitions(aethercore PUBLIC
+        AETHER_GGML_CPU_BASELINE="${_aether_ggml_baseline_str}"
+    )
+endif()
 
 # Compiler warnings — same flags for both first-party targets. Vendored
 # sources compiled into aethercore keep their per-source -w COMPILE_FLAGS,

--- a/src/asr/WhisperAsrBackend.cpp
+++ b/src/asr/WhisperAsrBackend.cpp
@@ -541,6 +541,15 @@ std::vector<AsrGpuDevice> asrGpuDevices()
                     // usable. The device is kept in the list either way, so
                     // the indices whisper's gpu_device refers to never shift.
                     try {
+                        // Physical-memory query first (#4986): device
+                        // properties only, useful even for a device that then
+                        // fails the probe. A throw here lands in the same
+                        // latch handlers as a probe throw — a device that
+                        // cannot answer a property query is not one to retry.
+                        size_t vramFree = 0, vramTotal = 0;
+                        ggml_backend_dev_memory(dev, &vramFree, &vramTotal);
+                        d.vramFreeBytes = vramFree;
+                        d.vramTotalBytes = vramTotal;
                         d.usable = asrDeviceUsableForDecode(dev);
                         if (!d.usable) {
                             qCInfo(lcAsrWhisper)
@@ -571,6 +580,21 @@ std::vector<AsrGpuDevice> asrGpuDevices()
                             << "failed the capability probe (unknown exception)"
                             << "- not offered, and not retried this session";
                     }
+                }
+                // One inventory line per device — name, VRAM, verdict — so a
+                // support log answers "which GPU, how much memory" without a
+                // follow-up ask (#4986).
+                if (d.vramTotalBytes > 0) {
+                    qCInfo(lcAsrWhisper)
+                        << "GPU device" << d.index << d.name
+                        << "- VRAM free" << (d.vramFreeBytes / (1024 * 1024))
+                        << "of" << (d.vramTotalBytes / (1024 * 1024)) << "MB -"
+                        << (d.usable ? "usable" : "not offered");
+                } else {
+                    qCInfo(lcAsrWhisper)
+                        << "GPU device" << d.index << d.name
+                        << "- VRAM unknown -"
+                        << (d.usable ? "usable" : "not offered");
                 }
                 devices.push_back(std::move(d));
             }

--- a/src/asr/WhisperAsrBackend.cpp
+++ b/src/asr/WhisperAsrBackend.cpp
@@ -570,14 +570,14 @@ std::vector<AsrGpuDevice> asrGpuDevices()
                         asrMarkGpuDeviceFailed(d.index);
                         qCWarning(lcAsrWhisper)
                             << "GPU device" << d.index << d.name
-                            << "failed the capability probe:" << e.what()
+                            << "threw during the memory query or capability probe:" << e.what()
                             << "- not offered, and not retried this session";
                     } catch (...) {
                         d.usable = false;
                         asrMarkGpuDeviceFailed(d.index);
                         qCWarning(lcAsrWhisper)
                             << "GPU device" << d.index << d.name
-                            << "failed the capability probe (unknown exception)"
+                            << "threw during the memory query or capability probe (unknown exception)"
                             << "- not offered, and not retried this session";
                     }
                 }

--- a/src/asr/WhisperAsrBackend.h
+++ b/src/asr/WhisperAsrBackend.h
@@ -79,6 +79,11 @@ struct AsrGpuDevice {
     int index = 0;
     QString name;
     bool usable = true;
+    // Physical memory as reported by ggml_backend_dev_memory (#4986); both 0
+    // when unknown — query unavailable, or the device was latched out before
+    // it could be asked.
+    quint64 vramFreeBytes = 0;
+    quint64 vramTotalBytes = 0;
 };
 
 // Factory for wiring AsrEngine to the production whisper backend. Kept here so

--- a/src/core/IssueReport.cpp
+++ b/src/core/IssueReport.cpp
@@ -53,7 +53,10 @@ QString buildIssueReport(const SupportBundle::SystemInfo& sys,
     body += QString("- AetherSDR: %1\n").arg(sys.aetherVersion);
     body += QString("- Qt: %1\n").arg(sys.qtVersion);
     body += QString("- OS: %1 (kernel %2)\n").arg(sys.osName, sys.kernelVersion);
-    body += QString("- Arch: %1\n").arg(sys.cpuArch);
+    // Model + arch + SIMD features in one line: the hardware facts that
+    // decide GPU/ISA crash reports (#4986) — not sensitive, unlike serial/IP.
+    body += QString("- CPU: %1\n").arg(sys.cpu);
+    body += QString("- RAM: %1\n").arg(sys.ram);
     body += QString("- Build: %1\n\n").arg(sys.buildDate);
 
     body += "### Recent log\n";

--- a/src/core/IssueReport.cpp
+++ b/src/core/IssueReport.cpp
@@ -57,6 +57,7 @@ QString buildIssueReport(const SupportBundle::SystemInfo& sys,
     // decide GPU/ISA crash reports (#4986) — not sensitive, unlike serial/IP.
     body += QString("- CPU: %1\n").arg(sys.cpu);
     body += QString("- RAM: %1\n").arg(sys.ram);
+    body += QString("- GPU: %1\n").arg(sys.gpu);
     body += QString("- Build: %1\n\n").arg(sys.buildDate);
 
     body += "### Recent log\n";

--- a/src/core/LogManager.cpp
+++ b/src/core/LogManager.cpp
@@ -134,6 +134,7 @@ LogManager::LogManager()
         {"aether.icom.pan",     "Icom Scope",    "Icom spectrum scope: sweep frames, division reassembly, bounds"},
         {"aether.icom.link",    "Icom Link",     "Icom backend link state: connect/disconnect, model resolution, capability publication"},
         {"aether.icom.cred",    "Icom Credentials", "Icom credential storage and retrieval (no secret values are logged)"},
+        {"aether.sysinfo",    "System Info",  "Startup hardware/capability inventory: OS, CPU model + SIMD features, RAM, and the speech-engine ISA baseline check (#4986). A few lines once per launch"},
     };
 
     // QLoggingCategory objects are defined above via Q_LOGGING_CATEGORY macros.
@@ -399,7 +400,7 @@ void LogManager::loadSettings()
     // Default Discovery, Commands, and Status to on
     static const QStringList defaultOn = {
         "aether.discovery", "aether.connection", "aether.protocol",
-        "aether.audio.summary", "aether.kiwisdr"
+        "aether.audio.summary", "aether.kiwisdr", "aether.sysinfo"
     };
     for (auto& c : m_categories) {
         QString def = defaultOn.contains(c.id) ? "True" : "False";

--- a/src/core/SupportBundle.cpp
+++ b/src/core/SupportBundle.cpp
@@ -123,19 +123,13 @@ QString SupportBundle::createBundle(const RadioInfo& radio)
         }
     }
 
-    // 2. System info JSON
+    // 2. System info JSON — field set defined (and regression-pinned) via
+    // systemInfoJson() in the header.
     {
-        auto sys = collectSystemInfo();
-        QJsonObject obj;
-        obj["aetherVersion"] = sys.aetherVersion;
-        obj["qtVersion"]     = sys.qtVersion;
-        obj["os"]            = sys.osName;
-        obj["kernel"]        = sys.kernelVersion;
-        obj["cpu"]           = sys.cpuArch;
-        obj["buildDate"]     = sys.buildDate;
         QFile f(tmp + "/system-info.json");
         if (f.open(QIODevice::WriteOnly))
-            f.write(QJsonDocument(obj).toJson(QJsonDocument::Indented));
+            f.write(QJsonDocument(systemInfoJson(collectSystemInfo()))
+                        .toJson(QJsonDocument::Indented));
     }
 
     // 3. Radio info JSON

--- a/src/core/SupportBundle.cpp
+++ b/src/core/SupportBundle.cpp
@@ -3,6 +3,7 @@
 #include "SettingsSanitizer.h"
 #include "AsyncLogWriter.h"  // redactPii — GHSA-ccrg-j8cp-qhc4
 #include "LogManager.h"
+#include "SystemInventory.h"
 #include "ZipArchive.h"
 #include "models/RadioModel.h"
 
@@ -68,7 +69,9 @@ SupportBundle::SystemInfo SupportBundle::collectSystemInfo()
         QSysInfo::prettyProductName(),
         QSysInfo::kernelVersion(),
         QSysInfo::currentCpuArchitecture(),
-        QString::fromLatin1(__DATE__)
+        QString::fromLatin1(__DATE__),
+        SystemInventory::cpuSummary(),
+        SystemInventory::ramSummary()
     };
 }
 
@@ -247,7 +250,8 @@ void SupportBundle::openEmailClient(const QString& bundlePath,
     body += QString("App: AetherSDR v%1\n").arg(sys.aetherVersion);
     body += QString("Qt: %1\n").arg(sys.qtVersion);
     body += QString("OS: %1 (kernel %2)\n").arg(sys.osName, sys.kernelVersion);
-    body += QString("CPU: %1\n").arg(sys.cpuArch);
+    body += QString("CPU: %1\n").arg(sys.cpu);
+    body += QString("RAM: %1\n").arg(sys.ram);
     body += QString("Build: %1\n").arg(sys.buildDate);
 
     if (radio.connected) {

--- a/src/core/SupportBundle.cpp
+++ b/src/core/SupportBundle.cpp
@@ -4,6 +4,7 @@
 #include "AsyncLogWriter.h"  // redactPii — GHSA-ccrg-j8cp-qhc4
 #include "LogManager.h"
 #include "SystemInventory.h"
+#include "GpuSelector.h"
 #include "ZipArchive.h"
 #include "models/RadioModel.h"
 
@@ -71,7 +72,8 @@ SupportBundle::SystemInfo SupportBundle::collectSystemInfo()
         QSysInfo::currentCpuArchitecture(),
         QString::fromLatin1(__DATE__),
         SystemInventory::cpuSummary(),
-        SystemInventory::ramSummary()
+        SystemInventory::ramSummary(),
+        GpuSelector::appliedSummary()
     };
 }
 
@@ -246,6 +248,7 @@ void SupportBundle::openEmailClient(const QString& bundlePath,
     body += QString("OS: %1 (kernel %2)\n").arg(sys.osName, sys.kernelVersion);
     body += QString("CPU: %1\n").arg(sys.cpu);
     body += QString("RAM: %1\n").arg(sys.ram);
+    body += QString("GPU: %1\n").arg(sys.gpu);
     body += QString("Build: %1\n").arg(sys.buildDate);
 
     if (radio.connected) {

--- a/src/core/SupportBundle.h
+++ b/src/core/SupportBundle.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QJsonObject>
 #include <QString>
 
 namespace AetherSDR {
@@ -35,6 +36,28 @@ public:
 
     // Collect system info from QSysInfo + app version.
     static SystemInfo collectSystemInfo();
+
+    // The bundle's system-info.json content. Header-inline and pure so the
+    // regression test can pin the field set without SupportBundle.cpp's
+    // model/zip dependencies: the archive is the structured artifact that
+    // survives a user editing the mail body, so the CPU/RAM facts that
+    // decide hardware-dependent crash reports (#4986) must be HERE, not
+    // only in the email text.
+    static QJsonObject systemInfoJson(const SystemInfo& sys)
+    {
+        QJsonObject obj;
+        obj["aetherVersion"] = sys.aetherVersion;
+        obj["qtVersion"]     = sys.qtVersion;
+        obj["os"]            = sys.osName;
+        obj["kernel"]        = sys.kernelVersion;
+        // "cpu" carries the full model + arch + SIMD summary; "arch" keeps
+        // the bare architecture string.
+        obj["cpu"]           = sys.cpu;
+        obj["arch"]          = sys.cpuArch;
+        obj["ram"]           = sys.ram;
+        obj["buildDate"]     = sys.buildDate;
+        return obj;
+    }
 
     // Collect radio info from RadioModel (safe if null/disconnected).
     static RadioInfo collectRadioInfo(const RadioModel* model);

--- a/src/core/SupportBundle.h
+++ b/src/core/SupportBundle.h
@@ -19,6 +19,8 @@ public:
         QString kernelVersion;
         QString cpuArch;
         QString buildDate;
+        QString cpu;  // model + arch + SIMD features (SystemInventory::cpuSummary)
+        QString ram;  // total physical RAM (SystemInventory::ramSummary)
     };
 
     struct RadioInfo {

--- a/src/core/SupportBundle.h
+++ b/src/core/SupportBundle.h
@@ -22,6 +22,7 @@ public:
         QString buildDate;
         QString cpu;  // model + arch + SIMD features (SystemInventory::cpuSummary)
         QString ram;  // total physical RAM (SystemInventory::ramSummary)
+        QString gpu;  // render GPU decision (GpuSelector::appliedSummary)
     };
 
     struct RadioInfo {
@@ -55,6 +56,7 @@ public:
         obj["cpu"]           = sys.cpu;
         obj["arch"]          = sys.cpuArch;
         obj["ram"]           = sys.ram;
+        obj["gpu"]           = sys.gpu;
         obj["buildDate"]     = sys.buildDate;
         return obj;
     }

--- a/src/core/SystemInventory.cpp
+++ b/src/core/SystemInventory.cpp
@@ -93,18 +93,29 @@ SystemInventory::CpuInfo SystemInventory::detectCpu()
     info.x86 = true;
     info.brand = cpuBrandString();
     quint32 regs[4] = {};
+    // Max basic leaf first: MSVC's __cpuidex — unlike GCC's
+    // __get_cpuid_count, which performs this check itself — does not guard
+    // out-of-range leaves, and Intel CPUs answer them with the highest
+    // supported leaf's registers instead of zeros. Unguarded, a leaf-7 query
+    // could read AVX2/BMI2 as present on exactly the pre-AVX2 parts the
+    // baseline warning exists for.
+    cpuidCount(0, 0, regs);
+    const quint32 maxBasicLeaf = regs[0];
     // Leaf 1 ECX: SSE4.2 bit 20, FMA bit 12, AVX bit 28, F16C bit 29. These
     // are CPU capability bits; OS XSAVE state is assumed (universal on the
-    // OS versions Qt 6 supports).
+    // OS versions Qt 6 supports). Leaf 1 exists on every CPU that can start
+    // this app.
     cpuidCount(1, 0, regs);
     info.sse42 = (regs[2] >> 20) & 1u;
     info.fma   = (regs[2] >> 12) & 1u;
     info.avx   = (regs[2] >> 28) & 1u;
     info.f16c  = (regs[2] >> 29) & 1u;
-    // Leaf 7.0 EBX: AVX2 bit 5, BMI2 bit 8 (leaf 7 absent → zeros).
-    cpuidCount(7, 0, regs);
-    info.avx2 = (regs[1] >> 5) & 1u;
-    info.bmi2 = (regs[1] >> 8) & 1u;
+    // Leaf 7.0 EBX: AVX2 bit 5, BMI2 bit 8 — only when the CPU has leaf 7.
+    if (maxBasicLeaf >= 7) {
+        cpuidCount(7, 0, regs);
+        info.avx2 = (regs[1] >> 5) & 1u;
+        info.bmi2 = (regs[1] >> 8) & 1u;
+    }
 #endif
     return info;
 }

--- a/src/core/SystemInventory.cpp
+++ b/src/core/SystemInventory.cpp
@@ -79,6 +79,16 @@ SystemInventory::CpuInfo SystemInventory::detectCpu()
 {
     CpuInfo info;
     info.arch = QSysInfo::currentCpuArchitecture();
+#if defined(Q_OS_MACOS) && !defined(Q_PROCESSOR_X86)
+    // Apple Silicon: no cpuid, but the kernel publishes the marketing name
+    // ("Apple M2" …) — a bug report saying "arm64" alone is much weaker.
+    {
+        char brand[64] = {};
+        size_t len = sizeof(brand) - 1;
+        if (sysctlbyname("machdep.cpu.brand_string", brand, &len, nullptr, 0) == 0)
+            info.brand = QString::fromLatin1(brand).simplified();
+    }
+#endif
 #if defined(Q_PROCESSOR_X86)
     info.x86 = true;
     info.brand = cpuBrandString();
@@ -172,17 +182,24 @@ void SystemInventory::logSystemInventory()
         << "OS:" << QSysInfo::prettyProductName()
         << "kernel" << QSysInfo::kernelVersion()
         << "arch" << cpu.arch;
-    qCInfo(lcSysInfo).noquote()
-        << "CPU:" << (cpu.brand.isEmpty() ? cpu.arch : cpu.brand)
-        << (cpu.x86 ? QStringLiteral("features: %1").arg(
-                          presentFeatures(cpu).join(QLatin1Char(' ')))
-                    : QString());
+    if (cpu.x86) {
+        qCInfo(lcSysInfo).noquote()
+            << "CPU:" << (cpu.brand.isEmpty() ? cpu.arch : cpu.brand)
+            << QStringLiteral("features: %1").arg(
+                   presentFeatures(cpu).join(QLatin1Char(' ')));
+    } else {
+        qCInfo(lcSysInfo).noquote()
+            << "CPU:" << (cpu.brand.isEmpty() ? cpu.arch : cpu.brand);
+    }
     qCInfo(lcSysInfo).noquote() << "RAM:" << ramMb << "MB";
 
     const QString baseline = compiledGgmlBaseline();
+    // Empty when the build can't know it: system-libwhisper builds (the
+    // distro chose the flags) and non-x86 hosts (the x86 option set is all
+    // OFF there).
     qCInfo(lcSysInfo).noquote()
         << "Speech engine CPU baseline:"
-        << (baseline.isEmpty() ? QStringLiteral("unknown (system libwhisper)")
+        << (baseline.isEmpty() ? QStringLiteral("not recorded for this build")
                                : baseline);
 
     const QStringList missing = missingCpuFeatures(cpu, baseline);
@@ -200,8 +217,11 @@ QString SystemInventory::cpuSummary()
 {
     const CpuInfo cpu = detectCpu();
     const QString name = cpu.brand.isEmpty() ? cpu.arch : cpu.brand;
-    if (!cpu.x86)
-        return name;
+    if (!cpu.x86) {
+        return cpu.brand.isEmpty()
+            ? name
+            : QStringLiteral("%1 (%2)").arg(name, cpu.arch);
+    }
     const QStringList features = presentFeatures(cpu);
     return QStringLiteral("%1 (%2; %3)")
         .arg(name, cpu.arch,

--- a/src/core/SystemInventory.cpp
+++ b/src/core/SystemInventory.cpp
@@ -1,0 +1,217 @@
+#include "SystemInventory.h"
+
+#include <QLoggingCategory>
+#include <QSysInfo>
+
+#include <cstring>
+
+#if defined(Q_OS_WIN)
+#ifndef NOMINMAX
+#define NOMINMAX  // guard: may already be defined by the build system (#4031)
+#endif
+#include <windows.h>
+#elif defined(Q_OS_MACOS)
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#elif defined(Q_OS_LINUX)
+#include <sys/sysinfo.h>
+#endif
+
+#if defined(Q_PROCESSOR_X86)
+#if defined(_MSC_VER)
+#include <intrin.h>
+#else
+#include <cpuid.h>
+#endif
+#endif
+
+// Declared QtWarningMsg like the other curated categories: the info tier is
+// raised by LogManager::applyFilterRules() once the category is enabled
+// (default-on via loadSettings), and the baseline-mismatch warning below
+// passes regardless of the toggle.
+Q_LOGGING_CATEGORY(lcSysInfo, "aether.sysinfo", QtWarningMsg)
+
+namespace AetherSDR {
+
+namespace {
+
+#if defined(Q_PROCESSOR_X86)
+void cpuidCount(quint32 leaf, quint32 subleaf, quint32 out[4])
+{
+#if defined(_MSC_VER)
+    int regs[4] = {};
+    __cpuidex(regs, static_cast<int>(leaf), static_cast<int>(subleaf));
+    for (int i = 0; i < 4; ++i)
+        out[i] = static_cast<quint32>(regs[i]);
+#else
+    unsigned int a = 0, b = 0, c = 0, d = 0;
+    if (!__get_cpuid_count(leaf, subleaf, &a, &b, &c, &d)) {
+        out[0] = out[1] = out[2] = out[3] = 0;
+        return;
+    }
+    out[0] = a;
+    out[1] = b;
+    out[2] = c;
+    out[3] = d;
+#endif
+}
+
+QString cpuBrandString()
+{
+    // Leaves 0x80000002-4 spell the 48-byte brand string; guard on the
+    // extended-leaf ceiling first (pre-2001 parts lack them).
+    quint32 regs[4] = {};
+    cpuidCount(0x80000000u, 0, regs);
+    if (regs[0] < 0x80000004u)
+        return {};
+    char brand[49] = {};
+    for (quint32 leaf = 0; leaf < 3; ++leaf) {
+        cpuidCount(0x80000002u + leaf, 0, regs);
+        memcpy(brand + leaf * 16, regs, 16);
+    }
+    return QString::fromLatin1(brand).simplified();
+}
+#endif // Q_PROCESSOR_X86
+
+} // namespace
+
+SystemInventory::CpuInfo SystemInventory::detectCpu()
+{
+    CpuInfo info;
+    info.arch = QSysInfo::currentCpuArchitecture();
+#if defined(Q_PROCESSOR_X86)
+    info.x86 = true;
+    info.brand = cpuBrandString();
+    quint32 regs[4] = {};
+    // Leaf 1 ECX: SSE4.2 bit 20, FMA bit 12, AVX bit 28, F16C bit 29. These
+    // are CPU capability bits; OS XSAVE state is assumed (universal on the
+    // OS versions Qt 6 supports).
+    cpuidCount(1, 0, regs);
+    info.sse42 = (regs[2] >> 20) & 1u;
+    info.fma   = (regs[2] >> 12) & 1u;
+    info.avx   = (regs[2] >> 28) & 1u;
+    info.f16c  = (regs[2] >> 29) & 1u;
+    // Leaf 7.0 EBX: AVX2 bit 5, BMI2 bit 8 (leaf 7 absent → zeros).
+    cpuidCount(7, 0, regs);
+    info.avx2 = (regs[1] >> 5) & 1u;
+    info.bmi2 = (regs[1] >> 8) & 1u;
+#endif
+    return info;
+}
+
+quint64 SystemInventory::totalRamBytes()
+{
+#if defined(Q_OS_WIN)
+    MEMORYSTATUSEX status;
+    status.dwLength = sizeof(status);
+    if (GlobalMemoryStatusEx(&status))
+        return status.ullTotalPhys;
+    return 0;
+#elif defined(Q_OS_MACOS)
+    quint64 bytes = 0;
+    size_t len = sizeof(bytes);
+    if (sysctlbyname("hw.memsize", &bytes, &len, nullptr, 0) == 0)
+        return bytes;
+    return 0;
+#elif defined(Q_OS_LINUX)
+    struct sysinfo info = {};
+    if (sysinfo(&info) == 0)
+        return quint64(info.totalram) * info.mem_unit;
+    return 0;
+#else
+    return 0;
+#endif
+}
+
+QStringList SystemInventory::presentFeatures(const CpuInfo& cpu)
+{
+    if (!cpu.x86)
+        return {};
+    QStringList features;
+    if (cpu.sse42) features << QStringLiteral("SSE42");
+    if (cpu.avx)   features << QStringLiteral("AVX");
+    if (cpu.avx2)  features << QStringLiteral("AVX2");
+    if (cpu.fma)   features << QStringLiteral("FMA");
+    if (cpu.f16c)  features << QStringLiteral("F16C");
+    if (cpu.bmi2)  features << QStringLiteral("BMI2");
+    return features;
+}
+
+QStringList SystemInventory::missingCpuFeatures(const CpuInfo& cpu, const QString& baseline)
+{
+    if (!cpu.x86 || baseline.trimmed().isEmpty())
+        return {};
+    const QStringList have = presentFeatures(cpu);
+    QStringList missing;
+    const QStringList required = baseline.split(QLatin1Char(','), Qt::SkipEmptyParts);
+    for (const QString& tokenRaw : required) {
+        const QString token = tokenRaw.trimmed().toUpper();
+        if (token.isEmpty())
+            continue;
+        if (!have.contains(token))
+            missing << token;
+    }
+    return missing;
+}
+
+QString SystemInventory::compiledGgmlBaseline()
+{
+#ifdef AETHER_GGML_CPU_BASELINE
+    return QStringLiteral(AETHER_GGML_CPU_BASELINE);
+#else
+    return {};
+#endif
+}
+
+void SystemInventory::logSystemInventory()
+{
+    const CpuInfo cpu = detectCpu();
+    const quint64 ramMb = totalRamBytes() / (1024 * 1024);
+
+    qCInfo(lcSysInfo).noquote()
+        << "OS:" << QSysInfo::prettyProductName()
+        << "kernel" << QSysInfo::kernelVersion()
+        << "arch" << cpu.arch;
+    qCInfo(lcSysInfo).noquote()
+        << "CPU:" << (cpu.brand.isEmpty() ? cpu.arch : cpu.brand)
+        << (cpu.x86 ? QStringLiteral("features: %1").arg(
+                          presentFeatures(cpu).join(QLatin1Char(' ')))
+                    : QString());
+    qCInfo(lcSysInfo).noquote() << "RAM:" << ramMb << "MB";
+
+    const QString baseline = compiledGgmlBaseline();
+    qCInfo(lcSysInfo).noquote()
+        << "Speech engine CPU baseline:"
+        << (baseline.isEmpty() ? QStringLiteral("unknown (system libwhisper)")
+                               : baseline);
+
+    const QStringList missing = missingCpuFeatures(cpu, baseline);
+    if (!missing.isEmpty()) {
+        // Warning tier deliberately: "this binary's speech engine cannot run
+        // on this CPU" must reach the log even with the category toggled off.
+        qCWarning(lcSysInfo).noquote()
+            << "CPU lacks features the bundled speech engine requires:"
+            << missing.join(QLatin1Char(' '))
+            << "- enabling Copy Assist (ASR) would fault on this machine (#4986)";
+    }
+}
+
+QString SystemInventory::cpuSummary()
+{
+    const CpuInfo cpu = detectCpu();
+    const QString name = cpu.brand.isEmpty() ? cpu.arch : cpu.brand;
+    if (!cpu.x86)
+        return name;
+    const QStringList features = presentFeatures(cpu);
+    return QStringLiteral("%1 (%2; %3)")
+        .arg(name, cpu.arch,
+             features.isEmpty() ? QStringLiteral("no SIMD features detected")
+                                : features.join(QLatin1Char(' ')));
+}
+
+QString SystemInventory::ramSummary()
+{
+    return QStringLiteral("%1 MB").arg(totalRamBytes() / (1024 * 1024));
+}
+
+} // namespace AetherSDR

--- a/src/core/SystemInventory.h
+++ b/src/core/SystemInventory.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+
+namespace AetherSDR {
+
+// Startup hardware/capability inventory (#4986). Collects the facts that
+// decide hardware-dependent crash reports — CPU model + SIMD features, total
+// RAM — and compares the CPU against the ISA baseline the vendored ggml was
+// compiled with, so "this binary cannot run on this CPU" appears in the log
+// instead of only as an illegal-instruction fault (#4509).
+//
+// Deliberately free of ggml/whisper includes: on a CPU below the baseline,
+// executing any ggml code IS the crash, so the inventory must be able to run
+// and log before that code is ever entered.
+class SystemInventory {
+public:
+    struct CpuInfo {
+        QString arch;   // QSysInfo::currentCpuArchitecture()
+        QString brand;  // cpuid brand string; empty on non-x86
+        bool x86 = false;  // feature flags below are meaningful only when true
+        bool sse42 = false;
+        bool avx = false;
+        bool avx2 = false;
+        bool fma = false;
+        bool f16c = false;
+        bool bmi2 = false;
+    };
+
+    // cpuid-based detection; on non-x86 hosts returns arch with x86=false and
+    // all feature flags false.
+    static CpuInfo detectCpu();
+
+    static quint64 totalRamBytes();
+
+    // Feature tokens `cpu` provides, in ggml's option spelling
+    // (SSE42/AVX/AVX2/FMA/F16C/BMI2). Empty on non-x86.
+    static QStringList presentFeatures(const CpuInfo& cpu);
+
+    // Tokens named in `baseline` (comma-separated, as CMake bakes into
+    // AETHER_GGML_CPU_BASELINE) that `cpu` does not provide. Empty when the
+    // baseline is empty/unknown or when `cpu` is not x86 (non-x86 baselines
+    // are not expressed in this scheme). Unknown tokens are reported missing:
+    // a baseline this code cannot vouch for must not read as satisfied.
+    static QStringList missingCpuFeatures(const CpuInfo& cpu, const QString& baseline);
+
+    // The baseline compiled into this binary, or empty when unknown
+    // (system-libwhisper builds).
+    static QString compiledGgmlBaseline();
+
+    // Emit the one-per-launch inventory block under aether.sysinfo, plus a
+    // warning naming any baseline features the CPU lacks. Caller flushes the
+    // log afterwards (the async writer only force-flushes on fatal).
+    static void logSystemInventory();
+
+    // One-line summaries for SupportBundle / IssueReport.
+    static QString cpuSummary();  // "<brand> (<arch>; SSE42 AVX AVX2 ...)"
+    static QString ramSummary();  // "<N> MB"
+};
+
+} // namespace AetherSDR

--- a/src/core/SystemInventory.h
+++ b/src/core/SystemInventory.h
@@ -51,7 +51,7 @@ public:
 
     // Emit the one-per-launch inventory block under aether.sysinfo, plus a
     // warning naming any baseline features the CPU lacks. Caller flushes the
-    // log afterwards (the async writer only force-flushes on fatal).
+    // log afterwards so the block is on disk before startup continues.
     static void logSystemInventory();
 
     // One-line summaries for SupportBundle / IssueReport.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,7 @@
 #include "core/GpuSelector.h"
 #include "core/LogManager.h"
 #include "core/ShutdownTrace.h"
+#include "core/SystemInventory.h"
 #include "core/MacMicPermission.h"
 #include "core/AutomationServer.h"
 
@@ -693,6 +694,16 @@ int main(int argc, char* argv[])
 
     // Load per-module logging toggles (must be after AppSettings::load)
     AetherSDR::LogManager::instance().loadSettings();
+
+    // Hardware/capability inventory (#4986): after loadSettings() so the
+    // aether.sysinfo filter rules are live, and before the main window exists
+    // so no ggml code can have run yet (Copy Assist is built lazily on first
+    // panel open — on a CPU below the speech engine's ISA baseline, entering
+    // ggml is the crash this block diagnoses). Flushed immediately so the
+    // inventory survives a hard kill later in the session: the async writer
+    // otherwise force-flushes only on fatal messages.
+    AetherSDR::SystemInventory::logSystemInventory();
+    AetherSDR::LogManager::instance().flushLog();
 
     qDebug() << "Starting AetherSDR" << app.applicationVersion();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -699,9 +699,9 @@ int main(int argc, char* argv[])
     // aether.sysinfo filter rules are live, and before the main window exists
     // so no ggml code can have run yet (Copy Assist is built lazily on first
     // panel open — on a CPU below the speech engine's ISA baseline, entering
-    // ggml is the crash this block diagnoses). Flushed immediately so the
-    // inventory survives a hard kill later in the session: the async writer
-    // otherwise force-flushes only on fatal messages.
+    // ggml is the crash this block diagnoses). Flushed explicitly so the block
+    // is on disk before anything else in startup runs, rather than on the
+    // async writer's next periodic flush.
     AetherSDR::SystemInventory::logSystemInventory();
     AetherSDR::LogManager::instance().flushLog();
 

--- a/tests/issue_report_test.cpp
+++ b/tests/issue_report_test.cpp
@@ -26,6 +26,8 @@ SupportBundle::SystemInfo sampleSys()
     sys.kernelVersion = "1.2.3";
     sys.cpuArch       = "x86_64";
     sys.buildDate     = "Jan 1 2026";
+    sys.cpu           = "Test CPU 9000 (x86_64; SSE42 AVX AVX2)";
+    sys.ram           = "16384 MB";
     return sys;
 }
 
@@ -109,6 +111,25 @@ void testSnapshotSectionsPresent()
            && body.contains("SmartLink account names"));
 }
 
+// The bundle's system-info.json is the structured artifact that survives a
+// user editing the mail body, so the CPU/RAM facts that decide
+// hardware-dependent crash reports (#4986) must be pinned there — not only
+// in the email text.
+void testBundleSystemInfoJsonCarriesHardwareFacts()
+{
+    const QJsonObject obj = SupportBundle::systemInfoJson(sampleSys());
+    report("json cpu carries the full model+features summary",
+           obj.value("cpu").toString() == "Test CPU 9000 (x86_64; SSE42 AVX AVX2)");
+    report("json keeps the bare arch string",
+           obj.value("arch").toString() == "x86_64");
+    report("json carries total RAM",
+           obj.value("ram").toString() == "16384 MB");
+    report("json keeps the pre-existing os/kernel/version fields",
+           obj.value("os").toString() == "Test OS"
+           && obj.value("kernel").toString() == "1.2.3"
+           && obj.value("aetherVersion").toString() == "26.7.3");
+}
+
 } // namespace
 
 int main(int, char**)
@@ -117,6 +138,7 @@ int main(int, char**)
     testRadioPiiScrubbedButPublicKept();
     testOmittedLogNote();
     testSnapshotSectionsPresent();
+    testBundleSystemInfoJsonCarriesHardwareFacts();
 
     std::printf("\n%s\n", g_failed == 0 ? "ALL PASSED" : "FAILURES PRESENT");
     return g_failed == 0 ? 0 : 1;

--- a/tests/issue_report_test.cpp
+++ b/tests/issue_report_test.cpp
@@ -28,6 +28,7 @@ SupportBundle::SystemInfo sampleSys()
     sys.buildDate     = "Jan 1 2026";
     sys.cpu           = "Test CPU 9000 (x86_64; SSE42 AVX AVX2)";
     sys.ram           = "16384 MB";
+    sys.gpu           = "Test GPU (auto)";
     return sys;
 }
 
@@ -124,6 +125,8 @@ void testBundleSystemInfoJsonCarriesHardwareFacts()
            obj.value("arch").toString() == "x86_64");
     report("json carries total RAM",
            obj.value("ram").toString() == "16384 MB");
+    report("json carries the render GPU decision",
+           obj.value("gpu").toString() == "Test GPU (auto)");
     report("json keeps the pre-existing os/kernel/version fields",
            obj.value("os").toString() == "Test OS"
            && obj.value("kernel").toString() == "1.2.3"

--- a/tests/system_inventory_test.cpp
+++ b/tests/system_inventory_test.cpp
@@ -1,0 +1,148 @@
+// Contract tests for the startup hardware inventory (#4986).
+//
+// The detection half (cpuid, RAM syscalls) is measured on whatever machine
+// runs the suite, so these tests pin the *contracts* that don't depend on the
+// host: the baseline-comparison logic that decides the "this binary cannot
+// run on this CPU" warning (the #4509 class), and the self-consistency of
+// detection on the running host (present features never contradict the
+// feature flags; a host below the compiled baseline could not be running
+// this test binary, so its own baseline check must come back clean).
+
+#include "core/SystemInventory.h"
+
+#include <QtGlobal>
+#include <cstdio>
+#include <cstdlib>
+
+using AetherSDR::SystemInventory;
+
+static int g_failures = 0;
+
+#define CHECK(cond, what)                                                     \
+    do {                                                                      \
+        if (cond) {                                                           \
+            std::printf("[ok] %s\n", what);                                   \
+        } else {                                                              \
+            std::printf("[FAIL] %s (line %d)\n", what, __LINE__);             \
+            ++g_failures;                                                     \
+        }                                                                     \
+    } while (false)
+
+static SystemInventory::CpuInfo phenomLikeCpu()
+{
+    // The #4509 machine class: x86-64 with SSE4.2-era features and no AVX of
+    // any kind (AMD Phenom II).
+    SystemInventory::CpuInfo cpu;
+    cpu.arch = QStringLiteral("x86_64");
+    cpu.brand = QStringLiteral("AMD Phenom(tm) II X6 1055T Processor");
+    cpu.x86 = true;
+    cpu.sse42 = false;  // Phenom II is SSE4a, not SSE4.2
+    return cpu;
+}
+
+static SystemInventory::CpuInfo modernCpu()
+{
+    SystemInventory::CpuInfo cpu;
+    cpu.arch = QStringLiteral("x86_64");
+    cpu.brand = QStringLiteral("Test Modern CPU");
+    cpu.x86 = true;
+    cpu.sse42 = cpu.avx = cpu.avx2 = cpu.fma = cpu.f16c = cpu.bmi2 = true;
+    return cpu;
+}
+
+int main()
+{
+    const QString fullBaseline = QStringLiteral("SSE42,AVX,AVX2,FMA,F16C,BMI2");
+
+    // A CPU with everything satisfies the full baseline.
+    CHECK(SystemInventory::missingCpuFeatures(modernCpu(), fullBaseline).isEmpty(),
+          "modern CPU satisfies the full baseline");
+
+    // The #4509 machine reports every baseline feature missing — this list
+    // becoming non-empty is exactly what arms the startup warning.
+    {
+        const QStringList missing =
+            SystemInventory::missingCpuFeatures(phenomLikeCpu(), fullBaseline);
+        CHECK(missing.size() == 6, "no-AVX CPU misses all six baseline features");
+        CHECK(missing.contains(QStringLiteral("AVX2")),
+              "AVX2 is named among the missing features");
+    }
+
+    // Partial coverage: only the genuinely absent features are named, in
+    // baseline order.
+    {
+        SystemInventory::CpuInfo cpu = modernCpu();
+        cpu.avx2 = false;
+        cpu.bmi2 = false;
+        const QStringList missing =
+            SystemInventory::missingCpuFeatures(cpu, fullBaseline);
+        CHECK(missing == QStringList({QStringLiteral("AVX2"), QStringLiteral("BMI2")}),
+              "only absent features are reported, in baseline order");
+    }
+
+    // Empty/unknown baseline (system-libwhisper builds) never warns.
+    CHECK(SystemInventory::missingCpuFeatures(phenomLikeCpu(), QString()).isEmpty(),
+          "empty baseline yields no missing features");
+    CHECK(SystemInventory::missingCpuFeatures(phenomLikeCpu(), QStringLiteral("  ")).isEmpty(),
+          "blank baseline yields no missing features");
+
+    // Non-x86 hosts are out of scope for the x86 token scheme.
+    {
+        SystemInventory::CpuInfo arm;
+        arm.arch = QStringLiteral("arm64");
+        arm.x86 = false;
+        CHECK(SystemInventory::missingCpuFeatures(arm, fullBaseline).isEmpty(),
+              "non-x86 CPU is exempt from the x86 baseline");
+    }
+
+    // Tokens this code cannot vouch for must read as missing, not satisfied —
+    // a future baseline (e.g. AVX512F) must not silently pass.
+    CHECK(SystemInventory::missingCpuFeatures(modernCpu(), QStringLiteral("AVX512F"))
+              == QStringList({QStringLiteral("AVX512F")}),
+          "unknown baseline token reads as missing");
+
+    // Tolerant parsing: whitespace and case from a hand-edited define.
+    CHECK(SystemInventory::missingCpuFeatures(phenomLikeCpu(),
+                                              QStringLiteral(" avx2 , fma "))
+              == QStringList({QStringLiteral("AVX2"), QStringLiteral("FMA")}),
+          "baseline tokens are trimmed and case-folded");
+
+    // presentFeatures mirrors the flags exactly.
+    {
+        SystemInventory::CpuInfo cpu = phenomLikeCpu();
+        cpu.sse42 = true;
+        CHECK(SystemInventory::presentFeatures(cpu)
+                  == QStringList({QStringLiteral("SSE42")}),
+              "presentFeatures lists exactly the set flags");
+        CHECK(SystemInventory::presentFeatures(modernCpu()).size() == 6,
+              "presentFeatures lists all six when all are set");
+    }
+
+    // Host self-consistency: this binary is running, so the host cannot be
+    // missing any feature of the baseline it was compiled with.
+    {
+        const SystemInventory::CpuInfo host = SystemInventory::detectCpu();
+        CHECK(!host.arch.isEmpty(), "host arch detected");
+        CHECK(SystemInventory::missingCpuFeatures(
+                  host, SystemInventory::compiledGgmlBaseline()).isEmpty(),
+              "running host satisfies its own compiled baseline");
+        // presentFeatures agrees with the individual flags on the real host.
+        const QStringList present = SystemInventory::presentFeatures(host);
+        CHECK(present.contains(QStringLiteral("AVX2")) == host.avx2,
+              "presentFeatures agrees with the host avx2 flag");
+    }
+
+    // RAM detection returns something plausible on every supported platform:
+    // nonzero, and at least 256 MB (no machine that runs Qt 6 has less).
+    {
+        const quint64 ram = SystemInventory::totalRamBytes();
+        CHECK(ram >= 256ull * 1024 * 1024, "total RAM detected and plausible");
+    }
+
+    if (g_failures != 0) {
+        std::printf("%d failure(s)\n", g_failures);
+        return EXIT_FAILURE;
+    }
+    std::printf("all ok\n");
+    return EXIT_SUCCESS;
+}

--- a/tests/system_inventory_test.cpp
+++ b/tests/system_inventory_test.cpp
@@ -5,8 +5,10 @@
 // host: the baseline-comparison logic that decides the "this binary cannot
 // run on this CPU" warning (the #4509 class), and the self-consistency of
 // detection on the running host (present features never contradict the
-// feature flags; a host below the compiled baseline could not be running
-// this test binary, so its own baseline check must come back clean).
+// feature flags). The host is deliberately NOT checked against the compiled
+// baseline: this test links no ggml objects and carries no ISA flags, so it
+// runs fine on a below-baseline CPU where that check would fail for the lab,
+// not the code.
 
 #include "core/SystemInventory.h"
 
@@ -118,14 +120,10 @@ int main()
               "presentFeatures lists all six when all are set");
     }
 
-    // Host self-consistency: this binary is running, so the host cannot be
-    // missing any feature of the baseline it was compiled with.
+    // Host self-consistency of detection (not of the baseline — see header).
     {
         const SystemInventory::CpuInfo host = SystemInventory::detectCpu();
         CHECK(!host.arch.isEmpty(), "host arch detected");
-        CHECK(SystemInventory::missingCpuFeatures(
-                  host, SystemInventory::compiledGgmlBaseline()).isEmpty(),
-              "running host satisfies its own compiled baseline");
         // presentFeatures agrees with the individual flags on the real host.
         const QStringList present = SystemInventory::presentFeatures(host);
         CHECK(present.contains(QStringLiteral("AVX2")) == host.avx2,

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3838,6 +3838,23 @@ set(AETHER_TEST_WISDOM_DIR "${CMAKE_BINARY_DIR}/test-fftw-wisdom")
 set(AETHER_TEST_FFTW_TIMELIMIT "0.001" CACHE STRING
     "Seconds FFTW may spend measuring each plan under test (empty = unbounded)")
 
+# Startup hardware inventory (#4986): pins the baseline-comparison contracts
+# that arm the "CPU below the speech-engine baseline" warning, plus host
+# self-consistency of the detection. Compiled with the same baseline define as
+# aethercore so the host check exercises the real compiled value.
+add_executable(system_inventory_test
+    tests/system_inventory_test.cpp
+    src/core/SystemInventory.cpp
+)
+target_include_directories(system_inventory_test PRIVATE src)
+target_link_libraries(system_inventory_test PRIVATE Qt6::Core)
+if (_aether_ggml_baseline)
+    target_compile_definitions(system_inventory_test PRIVATE
+        AETHER_GGML_CPU_BASELINE="${_aether_ggml_baseline_str}")
+endif()
+add_test(NAME system_inventory_test COMMAND system_inventory_test)
+
+
 # The isolation TU, compiled once and linked into every test target below. An
 # OBJECT library rather than STATIC on purpose: its only content is a
 # namespace-scope object whose CONSTRUCTOR is the entire point, and a static

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3848,7 +3848,7 @@ add_executable(system_inventory_test
 )
 target_include_directories(system_inventory_test PRIVATE src)
 target_link_libraries(system_inventory_test PRIVATE Qt6::Core)
-if (_aether_ggml_baseline)
+if (NOT _aether_ggml_baseline_str STREQUAL "")
     target_compile_definitions(system_inventory_test PRIVATE
         AETHER_GGML_CPU_BASELINE="${_aether_ggml_baseline_str}")
 endif()


### PR DESCRIPTION
## Summary

Fixes #4986. Three live ASR crash reports (#4509 instruction set, #4972 video
memory, #4502 unknown) each stalled on hardware facts that had to be requested
by hand. This PR makes the app log them itself, once per launch:

- A new **`aether.sysinfo`** log category (curated list, default-on) emits an
  inventory block at startup: OS/kernel/arch, CPU model + SIMD features
  (SSE42/AVX/AVX2/FMA/F16C/BMI2 via cpuid), total RAM, and the **ISA baseline
  the vendored ggml was compiled with** (new `AETHER_GGML_CPU_BASELINE`
  compile definition, captured from the `GGML_*` configure options).
- When the CPU lacks a baseline feature, a **warning names it** — on the #4509
  machine the log now states "CPU lacks features the bundled speech engine
  requires: SSE42 AVX AVX2 FMA F16C BMI2" instead of the process dying with an
  unexplained `0xc000001d`. The warning passes even if the category is
  toggled off. (Acting on the mismatch — disabling ASR gracefully — is a
  follow-up, per the issue's non-goals.)
- The block is emitted **before any ggml code can run** (Copy Assist is built
  lazily) and flushed explicitly so it is on disk before startup continues
  (the async writer otherwise flushes on a 250 ms timer).
- **Support bundle and the in-app File-an-Issue report** gain the same CPU +
  RAM facts plus the render-GPU decision (`GpuSelector::appliedSummary()`,
  already logged at startup) — #4972's 1,880-line log contained zero hardware
  facts. `system-info.json` carries `cpu`/`arch`/`ram`/`gpu`; the field set is
  pinned by `issue_report_test`.
- **ASR GPU enumeration** now records per-device free/total VRAM
  (`ggml_backend_dev_memory`) on `AsrGpuDevice` and logs one inventory line
  per device with its verdict.

Refs #2554 — this is the static, crash-surviving half; a future System Info
dialog can display the same data live.

## Constitution principle honored

Principle VIII — Evidence Over Assertion, extended to user crash reports:
the hardware facts that decide them are measured and logged by the app
rather than asserted (or hand-collected) after the fact.

## What changed

- `src/core/SystemInventory.{h,cpp}` (new) — cpuid feature detection, brand
  string, total RAM (GlobalMemoryStatusEx / sysinfo / sysctl hw.memsize),
  pure `missingCpuFeatures()` comparison, `logSystemInventory()`. No
  ggml/whisper includes — on a below-baseline CPU, entering ggml *is* the
  crash this block diagnoses.
- `src/main.cpp` — emit after `LogManager::loadSettings()` (filter rules
  live), before the main window exists; then `flushLog()`.
- `src/core/LogManager.cpp` — `aether.sysinfo` in the curated category list
  and the default-on list.
- `CMakeLists.txt` — `AETHER_GGML_CPU_BASELINE`: explicit record on the
  prebuilt whisper-gpu path, derived from the `GGML_*` cache options on
  vendored x86 builds, absent otherwise (logged as "not recorded for this
  build"); new source file; new test target.
- `src/core/SupportBundle.{h,cpp}`, `src/core/IssueReport.cpp` — CPU, RAM and
  GPU lines in the email body and issue report; `systemInfoJson()` defines
  the bundle's `system-info.json` field set.
- `src/asr/WhisperAsrBackend.{h,cpp}` — VRAM fields + per-device log line;
  memory query inside the existing per-device guard, ahead of the probe, so a
  throw hits the same latch handlers.
- `tests/system_inventory_test.cpp` (new) — baseline-comparison contracts
  (all-missing on a Phenom-II-class CpuInfo, partial coverage in baseline
  order, empty/blank baseline exempt, non-x86 exempt, unknown token reads as
  missing, trim/case tolerance) + detection self-consistency on the host +
  RAM plausibility. The host is deliberately not checked against the compiled
  baseline: the test links no ggml objects, so it runs on a below-baseline
  CPU where that check would fail for the lab, not the code.

## Platform notes

- cpuid: `__cpuidex` (MSVC) / `<cpuid.h>` (GCC/Clang), compiled only under
  `Q_PROCESSOR_X86`. ARM hosts are exempt from the x86 baseline scheme at
  runtime AND at configure time — ggml defines its x86 ISA options unguarded
  on every architecture (with `INS_ENB` defaulting them ON), so the CMake
  scan is gated on the project's x86 `CMAKE_SYSTEM_PROCESSOR` pattern to keep
  an x86 baseline string out of ARM binaries.
- **Windows release builds consume the prebuilt whisper-gpu pack and never
  run ggml's CMake**, so the baseline there comes from an explicit record of
  the pack's build settings (stock in-tree build, `GGML_NATIVE OFF`, MSVC
  `/arch:AVX2` implying FMA+F16C) declared where the pack is consumed —
  without it, the platform #4509 lives on would have had no baseline and a
  warning that could never fire. This is a recorded assumption about the
  pack, not a value the pack carries — the comment next to it says to
  re-derive if the pack is rebuilt with different ISA settings.
- Vendored x86 builds (Linux, Intel macOS): baseline derived from the
  `GGML_*` options; resolves to `SSE42,AVX,AVX2,FMA,F16C,BMI2` — measured on
  this build. Under `SOURCE_DATE_EPOCH` (reproducible packaging) ggml's
  `INS_ENB` defaults OFF, the options read OFF, and the baseline is logged as
  "not recorded" — consistent with the binary actually produced. `GGML_NATIVE OFF` enabling ggml's fixed x86-64 feature set is
  exactly what makes #4509's Phenom II fault.
- System-libwhisper builds: no baseline is knowable; an explicit
  `USE_SYSTEM_LIBWHISPER` branch yields none (not inferred from `GGML_*`
  being unset — those are cache entries), logged as "not recorded for this
  build" and the comparison is skipped.
- Apple Silicon reports the marketing name via `machdep.cpu.brand_string`
  (bare "arm64" would make reports half-blind on that family). Both
  architectures syntax-checked (`clang++ -fsyntax-only -arch {x86_64,arm64}`);
  CI's arm64 check-macos runner compiles the branch and runs
  `asr_gpu_probe_test`, which exercises the VRAM query on Metal.
- The VRAM query runs wherever GPU enumeration runs today (Vulkan on
  Windows/Linux, Metal on Apple Silicon).

## Platform evidence table

| Platform | Build | Evidence |
|---|---|---|
| macOS x86-64 | clean at `6b4ff2c1` (current head), About-dialog SHA confirmed | full block + `system-info.json` with `cpu`/`ram`/`gpu` (below); suite 287/295 ×2 at pre-rebase equivalent |
| Linux x86-64 (Ubuntu 24.04) | clean at `df90e8c2`, `strings` SHA confirmed | full block + Vulkan VRAM lines, both GPUs (below) |
| Windows 11 x86-64 (25H2) | clean at `df90e8c2` via `build.ps1` (full CI flag set), configure + `Select-String` SHA confirmed | full block + prebuilt-pack baseline check PASSED + Vulkan VRAM lines (below) |
| Apple Silicon (fork-CI arm64 runner) | branch built on `macos-15`; `system_inventory_test` PASSED on arm64 | full offscreen runtime block (below) |

Provenance note: the Linux and Windows captures ran at pre-rebase head
`df90e8c2`. The branch has since been rebased twice (onto `63b97516`, then
onto `18260524` as `9426a733` + `d95f2a77` + `bbe52634`, the second rebase
disclosed in the thread) and gained the review-round-3 commit `6b4ff2c1`.
`git range-diff` across both rebases shows the inventory code byte-identical
except where the `tests/tests.cmake` relocation forced it, and round 3
does not touch the startup block — so the Linux/Windows blocks quoted below
are what the current head emits on those platforms. The macOS capture was
redone at `6b4ff2c1`.

### Linux evidence (clean build at `df90e8c2`, session `20260814-121903`)

```text
[12:19:03.609] INF aether.sysinfo: OS: Ubuntu 24.04.4 LTS kernel 7.0.0-28-generic arch x86_64
[12:19:03.609] INF aether.sysinfo: CPU: Intel(R) Core(TM) i9-14900HX features: SSE42 AVX AVX2 FMA F16C BMI2
[12:19:03.609] INF aether.sysinfo: RAM: 31807 MB
[12:19:03.609] INF aether.sysinfo: Speech engine CPU baseline: SSE42,AVX,AVX2,FMA,F16C,BMI2
```

First runtime exercise of the Vulkan VRAM query — a dual-GPU host, both
devices reporting free/total and verdict:

```text
[12:20:15.054] INF aether.asr.whisper: GPU device 0 "Intel(R) Graphics (RPL-S)" - VRAM free 21470 of 23855 MB - usable
[12:20:15.174] INF aether.asr.whisper: GPU device 1 "NVIDIA GeForce RTX 5060 Laptop GPU" - VRAM free 7479 of 8151 MB - usable
```

### Windows evidence (clean build at `df90e8c2` via `build.ps1`, session `20260814-123739`)

Configure consumed the prebuilt whisper-gpu pack — i.e. this run exercises
the prebuilt-path baseline recording, which is the fix's key case:

```text
-- ASR: Vulkan GPU backend enabled via prebuilt whisper-gpu pack
-- ASR: prebuilt whisper-gpu 1.9.1 pack consumed (skipped ~1h+ MSVC compile)
```

```text
[12:37:39.546] INF aether.sysinfo: OS: Windows 11 Version 25H2 kernel 10.0.26200 arch x86_64
[12:37:39.546] INF aether.sysinfo: CPU: Intel(R) Core(TM) i9-14900HX features: SSE42 AVX AVX2 FMA F16C BMI2
[12:37:39.546] INF aether.sysinfo: RAM: 32491 MB
[12:37:39.546] INF aether.sysinfo: Speech engine CPU baseline: SSE42,AVX,AVX2,FMA,F16C,BMI2
```

The baseline line shows the feature list, not "not recorded for this
build" — the explicit pack record engaged. Same laptop as the Linux run
(dual-boot), and the CPU line is identical across the two OSes.

Device lines (second launch, same build, session `20260814-124653`):

```text
[12:47:16.393] INF aether.asr.whisper: GPU device 0 "NVIDIA GeForce RTX 5060 Laptop GPU" - VRAM free 6881 of 7810 MB - usable
[12:47:16.424] INF aether.asr.whisper: GPU device 1 "Intel(R) RaptorLake-S Mobile Graphics Controller" - VRAM free 15452 of 16245 MB - usable
```

### Apple Silicon evidence (fork-CI `macos-15` arm64 runner, offscreen launch)

```text
[20:10:33.385] INF aether.sysinfo: OS: macOS Sequoia (15.7) kernel 24.6.0 arch arm64
[20:10:33.385] INF aether.sysinfo: CPU: Apple M1 (Virtual)
[20:10:33.385] INF aether.sysinfo: RAM: 7168 MB
[20:10:33.385] INF aether.sysinfo: Speech engine CPU baseline: not recorded for this build
```

This exercises both ARM-only paths: the `machdep.cpu.brand_string` name
(virtualized identity on a runner VM — a physical M-series Mac would show
the marketing name) and the "not recorded" label, which doubles as proof
the CMake arch gate kept the x86 baseline string out of an ARM binary.
`system_inventory_test` passed 15/15 on the same runner.

Worth noting what the new lines surfaced on their first cross-OS outing:
on this identical hardware the in-app device order is **reversed between
Windows and Linux** (RTX first on Windows, iGPU first on Linux) while the
raw ICD order (`vulkaninfo --summary`) is iGPU-first on BOTH — same
whisper.cpp 1.9.1 on both sides, so version skew is ruled out. Mechanism
not yet identified (suspect, unverified: the Windows loader's per-process
adapter ordering). Consequence: ggml's first-usable default resolves to a
different GPU per OS on the same machine. Pre-existing behavior, not
introduced here — recorded because this is precisely the class of fact the
inventory exists to make visible, and it was invisible before these lines.

## Test plan

- [x] Local build passes — clean wipe-and-reconfigure at `6b4ff2c1`
      (RelWithDebInfo, macOS x86-64, Qt 6.8.3): 2,920/2,920 targets. Binary
      carries the SHA (About dialog). Earlier heads `f895adf8`/`df90e8c2`
      were built and verified the same way.
- [x] `system_inventory_test` — 14/14 [ok] at `6b4ff2c1` (15 before the
      host-baseline assertion was dropped). Mutation-checked twice: inverting
      the missing-feature membership branch fails 7 assertions; dropping the
      baseline-token case-folding fails the targeted assertion.
      `issue_report_test` 23/23 incl. the `gpu` JSON field.
- [x] Full suite — **287/295 passed, 2 expected skips, 8 failed — the
      IDENTICAL fail set on two complete runs** (deterministic): 3 =
      this machine's known pre-existing GUI a11y/geometry failures
      (`s_meter_geometry_test`, `range_slider_a11y_test`,
      `relay_bar_a11y_test`, same set as the #4767-era baseline); 5 = an
      HL2 cluster (`hl2_backend/link_stats/link_stats_model/receiver_churn/
      connect_reentrancy`) whose tests are NEW since this machine's last
      full-suite baseline and fail at link bring-up (`connected() on the
      first EP6` never comes true — everything downstream cascades). The
      diff does not touch HL2, and a clean stock build at base `2a754f56`
      reproduces **all five failures identically — including the same
      SEGFAULT on `hl2_receiver_churn_test`** — so the cluster is
      pre-existing at base on this machine, measured both ways (same
      method as #4767's control arm). Suite ran on the `f895adf8` build;
      the head delta
      (`df90e8c2`: CMake baseline plumbing, fallback label, arm64 brand
      string) is covered by its own unit test rerun at head (15/15).
- [x] Runtime [RIG] — startup block captured from the current head build's
      own log (session `20260820-174441`, clean build at `6b4ff2c1`, About SHA
      verified):
      ```text
      [17:44:41.311] INF default: GpuSelector: render GPU -> Auto (system default — no override)
      [17:44:41.313] INF aether.sysinfo: OS: macOS Sequoia (15.7) kernel 24.6.0 arch x86_64
      [17:44:41.313] INF aether.sysinfo: CPU: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz features: SSE42 AVX AVX2 FMA F16C BMI2
      [17:44:41.313] INF aether.sysinfo: RAM: 32768 MB
      [17:44:41.313] INF aether.sysinfo: Speech engine CPU baseline: SSE42,AVX,AVX2,FMA,F16C,BMI2
      ```
      No mismatch warning — correct: this host satisfies the compiled
      baseline. Help → File an Issue… on the same session produced
      `support-bundle-20260820-174607.zip`; its `system-info.json`:
      ```json
      {
          "aetherVersion": "26.8.3",
          "arch": "x86_64",
          "buildDate": "Aug 20 2026",
          "cpu": "Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz (x86_64; SSE42 AVX AVX2 FMA F16C BMI2)",
          "gpu": "Auto (system default — no override)",
          "kernel": "24.6.0",
          "os": "macOS Sequoia (15.7)",
          "qtVersion": "6.8.3",
          "ram": "32768 MB"
      }
      ```
      The `gpu` value is the same `GpuSelector::appliedSummary()` string the
      first log line carries — one platform-independent code path, so the
      Linux/Windows bundles differ only in the strings.
- [x] Static gates runnable locally: `tools/check_engine_boundary.py --strict`
      → 0 blocking. (`bin/validate-diff.sh` named in CONSTITUTION.md §VIII is
      not present on main — `git ls-files` has no match — so CI's checks are
      the verification surface for the rest.)
- [x] Behavior on a real radio: not applicable (no radio-path changes)

## Test boundary (stated plainly)

- This dev machine is an Intel Mac, where `asrGpuDevices()` returns before
  enumeration (`asrMetalUsableHost()` false) — the per-device VRAM line is
  compile-proven here and unit-covered at the struct level, but its runtime
  form comes from CI's arm64 probe test / the first Vulkan-host run, not from
  this machine.
- The baseline-mismatch warning cannot fire on any machine that can run the
  binary (by construction); its logic is pinned by the unit test's synthetic
  CpuInfo instead. The [RIG] arm for the *warning* would need a below-baseline
  CPU, which is exactly the #4509 reporter's machine.

## Checklist

- [x] Commits signed (`9426a733`/`d95f2a77`/`bbe52634`/`6b4ff2c1`, all
      `%G?` = G)
- [x] No new flat-key AppSettings calls (only the existing per-category
      LogCategory keys via LogManager)
- [x] Clean-room
- [x] No CHANGELOG.md edits
- [x] Not security-sensitive

— authored by agent (Claude Code) on behalf of @skerker

