### PR TITLE
Icom: DFM in the mode map, and let the IC-9700 use 0x26 so the DATA flag reaches the radio (#4931)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,18 @@ jobs:
       - name: Test TCI protocol parsing and malformed-input rejection
         run: ctest --test-dir build -R "^tci_protocol_test$" --output-on-failure
 
+      # THE CI-V MODE MAP IS INVISIBLE FROM THE UI. A missing arm in
+      # modeFromNeutral() does not throw, does not log, and does not fail to
+      # build — setSliceMode() takes the "no equivalent" path and re-asserts the
+      # radio's current mode, so the control appears to do nothing. That is what
+      # hid the DFM hole: selecting FM-D simply reverted, and the on-air cost was
+      # a radio transmitting from the MICROPHONE instead of the modulator.
+      #
+      # These are table assertions — no radio, no sockets, no event loop, ~0.1 s
+      # against a target the Build step already linked.
+      - name: Test Icom CI-V codec (mode map, filters, frame building)
+        run: ctest --test-dir build -R "^icom_civ_test$" --output-on-failure
+
       # Mirrors check-windows' "sccache stats" step, and exists for the same
       # reason: #1963 disabled the Windows compiler cache for three months
       # without anyone noticing, because nothing made the hit rate visible.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,8 +291,15 @@ jobs:
       #
       # These are table assertions — no radio, no sockets, no event loop, ~0.1 s
       # against a target the Build step already linked.
-      - name: Test Icom CI-V codec (mode map, filters, frame building)
-        run: ctest --test-dir build -R "^icom_civ_test$" --output-on-failure
+      #
+      # icom_meters_test rides along because it owns the model table's
+      # invariants, and this PR proved they were unguarded: setting the
+      # IC-9700's hasVfoModeCommand tripped "no model silently inherits a DATA
+      # command shape" and all four checks stayed green, because nothing in this
+      # file ran that target either. A capability flag that gates which frame
+      # reaches the radio is exactly the kind of claim worth failing a merge on.
+      - name: Test Icom CI-V codec and model table
+        run: ctest --test-dir build -R "^icom_(civ|meters)_test$" --output-on-failure
 
       # Mirrors check-windows' "sccache stats" step, and exists for the same
       # reason: #1963 disabled the Windows compiler cache for three months

--- a/src/core/backends/icom/CivCodec.cpp
+++ b/src/core/backends/icom/CivCodec.cpp
@@ -291,6 +291,19 @@ std::optional<CivMode> modeFromNeutral(const std::string& neutral, bool& dataMod
     // microphone while the operator is running FT8.
     if (u == "DIGU") { dataModeOut = true; return CivMode::Usb; }
     if (u == "DIGL") { dataModeOut = true; return CivMode::Lsb; }
+    // DFM is FM with the same DATA flag, and it was missing here. Two costs,
+    // and the second is the expensive one:
+    //
+    //   1. DFM fell through to nullopt, so setSliceMode() took the "no
+    //      equivalent" path and re-asserted the radio's current mode. Selecting
+    //      DFM in the UI simply reverted — indistinguishable from the control
+    //      being ignored.
+    //   2. Worse, on the paths that DID reach the radio as plain FM the DATA
+    //      flag stayed clear, so transmit audio came from the MICROPHONE rather
+    //      than the WLAN modulator — exactly the failure the DIGU/DIGL comment
+    //      above describes, but for packet instead of FT8. A 2 m AX.25 frame
+    //      keyed the radio and put room noise on the air.
+    if (u == "DFM")  { dataModeOut = true; return CivMode::Fm; }
     if (u == "RTTY") return CivMode::Rtty;
 
     // DSB, SAM and DRM have no IC-705 equivalent. Returning nullopt rather than
@@ -307,7 +320,12 @@ std::string modeToNeutral(CivMode mode, bool dataMode)
     case CivMode::Am:   return "AM";
     case CivMode::Cw:   return "CWU";
     case CivMode::CwR:  return "CWL";
-    case CivMode::Fm:   return "FM";
+    // Symmetric with Lsb/Usb above: the DATA flag is what distinguishes FM-D
+    // from FM, and returning plain "FM" for both made the round trip lossy. A
+    // radio sitting in FM-D reported as FM, so the UI showed FM, and the next
+    // mode write sent FM with the flag clear — silently taking the radio OUT of
+    // data mode and back onto the microphone.
+    case CivMode::Fm:   return dataMode ? "DFM" : "FM";
     case CivMode::Wfm:  return "WFM";
     // AetherSDR has no RTTY neutral mode. Mapping to the data mode on the
     // matching sideband is LOSSY IN NAME but correct in the two things that

--- a/src/core/backends/icom/CivCodec.cpp
+++ b/src/core/backends/icom/CivCodec.cpp
@@ -298,11 +298,13 @@ std::optional<CivMode> modeFromNeutral(const std::string& neutral, bool& dataMod
     //      equivalent" path and re-asserted the radio's current mode. Selecting
     //      DFM in the UI simply reverted — indistinguishable from the control
     //      being ignored.
-    //   2. Worse, on the paths that DID reach the radio as plain FM the DATA
-    //      flag stayed clear, so transmit audio came from the MICROPHONE rather
-    //      than the WLAN modulator — exactly the failure the DIGU/DIGL comment
-    //      above describes, but for packet instead of FT8. A 2 m AX.25 frame
-    //      keyed the radio and put room noise on the air.
+    //   2. Worse, a radio the operator had put into FM-D from the front panel
+    //      reported back as plain FM (modeToNeutral was lossy the same way), so
+    //      the next mode write cleared the DATA flag and transmit audio came
+    //      from the MICROPHONE rather than the WLAN modulator — exactly the
+    //      failure the DIGU/DIGL comment above describes, but for packet
+    //      instead of FT8. A 2 m AX.25 frame keyed the radio and put room noise
+    //      on the air.
     if (u == "DFM")  { dataModeOut = true; return CivMode::Fm; }
     if (u == "RTTY") return CivMode::Rtty;
 

--- a/src/core/backends/icom/IcomModels.cpp
+++ b/src/core/backends/icom/IcomModels.cpp
@@ -58,6 +58,19 @@ constexpr std::array<IcomModel, 7> kModels{{
         true, 100.0,
         144'000'000ULL, 1'300'000'000ULL,
         /*verified*/ false,
+        // 0x26 MEASURED on the live radio at 10.0.0.7, 2026-08-14 (G0JKN), the
+        // same standard of evidence as the scope geometry above:
+        //
+        //   tx: fe fe a2 e0 26 00 fd
+        //   rx: 26 00 05 00 01          (vfo 00, mode 05=FM, DATA 00, FIL1)
+        //
+        // A structured reply, not FA. Without this the 9700 fell to the legacy
+        // 06 branch in setSliceMode(), which forces m_dataMode = false and
+        // sends a body of {mode, filter} with NO DATA byte — so selecting FM-D
+        // wrote plain FM and the mode reverted in the UI. On air that left
+        // transmit audio on the MICROPHONE, so a 2 m AX.25 frame keyed the
+        // radio and put room noise out instead of the modem's AFSK.
+        /*hasVfoModeCommand*/ true,
     },
     {
         0x98, "IC-7610", 2, 1,

--- a/src/core/backends/icom/IcomModels.h
+++ b/src/core/backends/icom/IcomModels.h
@@ -68,9 +68,19 @@ struct IcomModel {
     // filter in one 26 00 frame. The IC-705 and IC-7300MK2 guides in
     // sources/icom-official/ document this exact form.
     //
-    // FALSE UNTIL VERIFIED FOR EACH MODEL. Some Icoms expose a different 0x26
+    // FALSE UNTIL ATTESTED FOR EACH MODEL. Some Icoms expose a different 0x26
     // shape, and a mode change sent in the wrong form is silently unapplied.
     // The conservative fallback is plain 0x06 with no DATA control or claim.
+    //
+    // ATTESTED IS NOT `verified` ABOVE, deliberately. `verified` is a claim
+    // about this whole row — geometry, amplitude range, tuning limits, all
+    // confirmed against the model's own guide. The 0x26 shape is one narrow
+    // question that a measured round trip answers on its own, and the IC-9700
+    // is exactly that case: geometry still assumed, 26 00 read off the radio.
+    // Coupling the two would force either an overclaimed row or a discarded
+    // trace. So record the evidence in a comment beside the flag AND add the
+    // address to kAttestedVfoMode in icom_meters_test.cpp — that list is what
+    // stops a new row copied from the IC-705 inheriting a shape nobody checked.
     bool hasVfoModeCommand = false;
 
     [[nodiscard]] bool isKnown() const noexcept { return civAddress != 0; }

--- a/tests/icom_civ_test.cpp
+++ b/tests/icom_civ_test.cpp
@@ -209,6 +209,14 @@ static void testModes()
     // what routes audio to the WLAN modulator instead of the microphone.
     check(modeFromNeutral("DIGU", data) == CivMode::Usb && data, "DIGU is USB + data");
     check(modeFromNeutral("DIGL", data) == CivMode::Lsb && data, "DIGL is LSB + data");
+    // DFM is FM + DATA, and it was missing entirely. Selecting DFM fell through
+    // to the "no equivalent" path, so setSliceMode() re-asserted the radio's
+    // current mode and the control appeared to do nothing. The expensive half
+    // was the DATA flag: without it the radio transmits from the MICROPHONE
+    // rather than the WLAN modulator, so a 2 m AX.25 frame keyed the rig and
+    // put room noise on the air. Found on an IC-9700, 2026-08-09.
+    check(modeFromNeutral("DFM", data) == CivMode::Fm && data, "DFM is FM + data");
+    check(modeFromNeutral("FM", data) == CivMode::Fm && !data, "plain FM has no data flag");
     check(modeFromNeutral("CW", data) == CivMode::Cw, "bare CW maps, not just CWU");
     check(modeFromNeutral("CWL", data) == CivMode::CwR, "CWL is CW-reverse");
     // No IC-705 equivalent: refuse rather than silently substituting USB.
@@ -217,6 +225,12 @@ static void testModes()
 
     check(modeToNeutral(CivMode::Usb, false) == "USB", "reverse USB");
     check(modeToNeutral(CivMode::Usb, true) == "DIGU", "reverse DIGU");
+    // The round trip has to survive too. Returning plain "FM" for a radio in
+    // FM-D made the UI show FM, and the next mode write then sent FM with the
+    // flag CLEAR — silently taking the radio out of data mode and back onto the
+    // microphone without the operator touching anything.
+    check(modeToNeutral(CivMode::Fm, false) == "FM", "reverse FM");
+    check(modeToNeutral(CivMode::Fm, true) == "DFM", "reverse DFM keeps the data flag");
     check(modeToNeutral(CivMode::Dv, false).empty(), "D-STAR has no neutral mode");
 
     // THE LADDER IS PER MODE. FIL1 is 3.0 kHz in SSB, 1.2 kHz in CW, 9 kHz in

--- a/tests/icom_civ_test.cpp
+++ b/tests/icom_civ_test.cpp
@@ -212,9 +212,10 @@ static void testModes()
     // DFM is FM + DATA, and it was missing entirely. Selecting DFM fell through
     // to the "no equivalent" path, so setSliceMode() re-asserted the radio's
     // current mode and the control appeared to do nothing. The expensive half
-    // was the DATA flag: without it the radio transmits from the MICROPHONE
-    // rather than the WLAN modulator, so a 2 m AX.25 frame keyed the rig and
-    // put room noise on the air. Found on an IC-9700, 2026-08-09.
+    // was the DATA flag: a radio already in FM-D reported back as plain FM, so
+    // the next mode write cleared the flag and the radio transmitted from the
+    // MICROPHONE rather than the WLAN modulator — a 2 m AX.25 frame keyed the
+    // rig and put room noise on the air. Found on an IC-9700, 2026-08-09.
     check(modeFromNeutral("DFM", data) == CivMode::Fm && data, "DFM is FM + data");
     check(modeFromNeutral("FM", data) == CivMode::Fm && !data, "plain FM has no data flag");
     check(modeFromNeutral("CW", data) == CivMode::Cw, "bare CW maps, not just CWU");

--- a/tests/icom_meters_test.cpp
+++ b/tests/icom_meters_test.cpp
@@ -9,6 +9,7 @@
 #include "core/backends/icom/IcomModels.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdio>
 
@@ -241,6 +242,19 @@ static void testModelTable()
     check(ic7610 && !ic7610->hasVfoModeCommand,
           "so it does not inherit the IC-705's selected-VFO 26 00 shape");
 
+    // The IC-9700 is the case that shows the two claims are independent. Its
+    // scope geometry is still ASSUMED from the IC-705, so `verified` stays
+    // false — but its 26 00 shape was read off the radio, so the DATA-capable
+    // flag is true. Without the flag, selecting FM-D falls to the legacy 06
+    // branch, which sends no DATA byte and takes the radio back OUT of data
+    // mode — the failure #4931 reported, on the radio that reported it.
+    const IcomModel* ic9700 = modelForCivAddress(0xA2);
+    check(ic9700 != nullptr, "the IC-9700 is in the table");
+    check(ic9700 && !ic9700->verified,
+          "its geometry is cross-referenced, not confirmed against its own guide");
+    check(ic9700 && ic9700->hasVfoModeCommand,
+          "yet its measured 26 00 mode/DATA/filter shape is attested independently");
+
     // Six-byte frequencies. A codec against a hardcoded 5 misaligns by two
     // bytes and decodes a plausible-looking wrong frequency.
     const IcomModel* ic905 = modelForCivAddress(0xAC);
@@ -278,10 +292,44 @@ static void testModelTable()
     check(modelForCivAddress(0x01) == nullptr,
           "an unrecognised address resolves to nothing — a normal outcome, not an error");
     check(!knownModels().empty(), "the table is populated");
+    // NO MODEL INHERITS THE 26 00 SHAPE BY ASSUMPTION.
+    //
+    // This started life as `m.verified || !m.hasVfoModeCommand`, which read the
+    // right intent off the wrong field. `verified` is a claim about the WHOLE
+    // row — scope geometry, amplitude range, tuning limits, all confirmed
+    // against that model's own CI-V Reference Guide. The 0x26 shape is a
+    // narrower and independent question, and coupling them forced a choice
+    // between two dishonest options for a radio whose 0x26 form has been
+    // measured but whose scope geometry is still assumed: either overclaim the
+    // whole row, or drop a flag that a live trace supports.
+    //
+    // So attest the flag directly. The hazard the original guarded against is
+    // SILENT inheritance — a new row copied from the IC-705 and quietly picking
+    // up a command shape nobody checked on that radio. Naming each address here
+    // keeps that guard: the flag cannot go true without a deliberate edit to
+    // this list, and the comment beside it has to say what the evidence was.
+    static const std::array<std::uint8_t, 3> kAttestedVfoMode{
+        0xA4,  // IC-705     — its own CI-V Reference Guide documents 26 00
+        0xB6,  // IC-7300MK2 — likewise, from its own guide
+        0xA2,  // IC-9700    — measured on a live radio, 2026-08-14: 26 00 read
+               //              answered 26 00 05 00 01, the same three-byte
+               //              mode/DATA/filter body cmdSetVfoMode writes
+    };
     check(std::all_of(knownModels().begin(), knownModels().end(), [](const IcomModel& m) {
-              return m.verified || !m.hasVfoModeCommand;
+              return !m.hasVfoModeCommand
+                  || std::find(kAttestedVfoMode.begin(), kAttestedVfoMode.end(),
+                               m.civAddress)
+                      != kAttestedVfoMode.end();
           }),
-          "no unverified model silently inherits a DATA command shape");
+          "no model silently inherits a DATA command shape");
+    // The converse, so the list cannot rot into a permission slip for rows that
+    // no longer set the flag.
+    check(std::all_of(kAttestedVfoMode.begin(), kAttestedVfoMode.end(),
+                      [](std::uint8_t addr) {
+                          const IcomModel* m = modelForCivAddress(addr);
+                          return m && m->hasVfoModeCommand;
+                      }),
+          "every attested address is a real model that actually sets the flag");
 }
 
 static void testUnknownModelIsConservative()


### PR DESCRIPTION
Finishes the DFM half of #4931. #4989 made the DATA byte reach the radio for the
sideband data modes; `DFM` itself was still missing from the codec's mode map, so
FM never got there — and on the IC-9700 the 0x26 path was gated off, so even a
correct mapping could not have reached the radio.

## The bug

`modeFromNeutral()` had `DIGU` and `DIGL` but no `DFM`, and `modeToNeutral()`
returned plain `"FM"` regardless of the DATA flag. Two costs, and the second is
the expensive one:

1. **DFM fell through to `nullopt`.** `setSliceMode()` then took the "no
   equivalent" path and re-asserted the radio's current mode, so selecting DFM in
   the UI simply reverted — indistinguishable from the control being ignored.

2. **A radio already in FM-D reported back as plain FM**, so the UI showed FM and
   the next mode write sent FM with the DATA flag **clear** — silently taking the
   radio out of data mode without the operator touching anything. Transmit audio
   then came from the **microphone** rather than the WLAN modulator: a 2 m AX.25
   frame keyed the radio and put room noise on the air. Same failure the existing
   DIGU/DIGL comment in this file describes, but for packet instead of FT8.

## The fix

```cpp
if (u == "DFM")  { dataModeOut = true; return CivMode::Fm; }
...
case CivMode::Fm:   return dataMode ? "DFM" : "FM";
```

Symmetric with the `Lsb`/`Usb` cases directly above, which already did this.

## The IC-9700 also needs `hasVfoModeCommand`

The mapping alone is not enough on the radio that generated #4931's evidence.
With the flag false, `setSliceMode()` falls to the legacy `06` branch, which
forces `m_dataMode = false` and sends `{mode, filter}` with **no DATA byte** — so
selecting FM-D wrote plain FM, and the write itself took the radio back out of
data mode. `06 05 01` on the wire, byte-identical to the frame #4931 quotes as
the bug.

0x26 measured on the live radio at 10.0.0.7, 2026-08-14 (G0JKN):

```
tx: fe fe a2 e0 26 00 fd
rx: 26 00 05 00 01          (vfo 00, mode 05=FM, DATA 00, FIL1)
```

A structured reply, not FA — and the three-byte `mode / DATA / filter` body is
the same shape `cmdSetVfoMode()` writes.

### Why that needed the invariant to change

#4989 added `hasVfoModeCommand` and, with it, a table invariant:

```cpp
return m.verified || !m.hasVfoModeCommand;   // "no unverified model
                                             //  silently inherits a
                                             //  DATA command shape"
```

The IC-9700 is `verified = false` — its scope geometry is still assumed from the
IC-705 — so setting the flag failed that check. It went unnoticed under four
green checks because `icom_meters_test` was in no CI `-R` filter.

The invariant read the right intent off the wrong field. `verified` is a claim
about the **whole row**; the 0x26 shape is one narrow question a measured round
trip answers on its own. Coupling them left only dishonest options here:
overclaim the entire row, or discard the trace and keep the FM-D-clearing bug.

So the flag is now attested directly, by address, with the evidence recorded
beside each one — `kAttestedVfoMode` in `icom_meters_test.cpp`. The original
hazard was **silent** inheritance (a row copied from the IC-705 quietly picking
up a shape nobody checked); naming addresses keeps that guard rather than
weakening it, since the flag cannot go true without a deliberate edit to the
list. A converse check stops the list rotting into a permission slip for rows
that no longer set the flag.

## Tests

Four checks added to `icom_civ_test`, covering both directions and the negative
case (plain `FM` must NOT set the flag). Plus the IC-9700 row assertions
`icom_meters_test` was missing entirely — it pinned `hasVfoModeCommand` for the
IC-705, IC-7610 and IC-7300MK2, but not for the one model this PR changes.

Every fix here was verified by reverting it on purpose:

| Reverted | Result |
|---|---|
| the `DFM` arm in `modeFromNeutral` | `FAIL: DFM is FM + data` |
| `modeToNeutral(Fm, …)` data-awareness | `FAIL: reverse DFM keeps the data flag` |
| blanket `dataModeOut = true` on plain FM | `FAIL: plain FM has no data flag` |
| give the IC-7610 the flag unattested | `FAIL: no model silently inherits a DATA command shape` |
| drop the IC-9700 flag, leave it listed | `FAIL: every attested address is a real model that actually sets the flag` |

A green run alone would not have shown the tests were load-bearing.

## CI

`icom_civ_test` and `icom_meters_test` now gate a merge. Neither ran in CI
before: every `ctest` step in `ci.yml` is `-R`-filtered, and `icom` appeared in
none of them — which is exactly why the invariant break above survived four green
checks. Table assertions, no radio and no event loop, ~0.1 s against targets the
Build step already links.

## Hardware

Found on an **IC-9700** over LAN, 2026-08-09, while chasing 2 m AX.25 packet
transmit. Issue #4931 records the CI-V trace showing `DFM` and `FM` are
byte-identical on the wire. #4930 carried an earlier `1A 06` approach to the same
problem and is now closed — #4989's single-frame `26` design superseded it, and
the mode-map half is what survived into this PR.
