### PR TITLE
Icom: Fix Icom RS-BA1 lease renewal and diagnostics

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -2866,6 +2866,51 @@ non-`-120` `rmsDbfs` means audio is arriving, and `rejectBadFcs` climbing while
 `framesAccepted` does not means the decoder is finding structure and losing it
 to bit errors.
 
+### `civ`
+
+Icom CI-V and RS-BA1 session diagnostics. The read-only actions work in an
+observe-only bridge; raw injection remains TX-gated because arbitrary CI-V can
+key or retune the radio.
+
+**`civ session`** reports the media lease independently of UDP link liveness:
+
+```json
+→ {"cmd":"civ","action":"session"}
+← {"ok":true,"civ":"session","result":{
+   "authenticated":true,"connected":true,"streamGranted":true,
+   "lastRenewalResult":"accepted","lastRenewalResponse":"0x00000000",
+   "lastRenewalSequence":42,"nextInnerSequence":43,
+   "tokenRequestId":"0x8f31",
+   "lastAcceptedAgeMs":8123,"pendingRenewals":0,
+   "acceptedRenewals":14,"reissuedTokens":1,"rejectedRenewals":0,
+   "ignoredAuthReplies":0,"ignoredControlPackets":1,
+   "initialMaintenanceMs":30000,"initialMaintenancePending":false,
+   "renewalCadenceMs":60000,"ackGraceMs":3000,"deadSessionMs":80000}}
+```
+
+Use this first when the panadapter, CI-V controls, and audio stop together while
+the outer UDP packet counters still move. A healthy result has a recent accepted
+token, response `0x00000000`, and no growing pending/rejected count. The health
+verb shows the same essentials under **RS-BA1 session**.
+
+The token-request ID is freshly randomized for each login. On an immediate
+reconnect the radio can answer the initial token request with `0xffffffff` and
+a token that must be used to request the streams; wfview follows the same path.
+`lastRenewalResult:"reissued"` distinguishes that valid reconnect exchange
+from the same nonzero response rejecting an established lease renewal.
+
+The first maintenance renewal is sent at 30 seconds because a live immediate
+reconnect grant stopped its media streams around 45 seconds even though the
+ordinary 60-second renewal was later accepted. After that one early renewal,
+the session returns to the wfview/kappanhang 60-second cadence.
+
+**`civ trace [all]`** reads the bounded decoded CI-V frame trace. The default
+omits routine meter traffic; `all` includes it. **`civ send <hex>`** injects
+command bytes through the active Icom session and is reserved for controlled
+hardware tests. Raw RS-BA1 datagram logging is intentionally off by default and
+should only be enabled briefly when these structured diagnostics are
+insufficient.
+
 ### `controls`
 
 The CI-V control and meter registry, joined against what is actually wired.
@@ -3327,7 +3372,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `audioCapture` | — | audioCapture <start\|stop\|status\|read\|probeNr2Stereo\|probeDspStereo> [args] |
 | `txwaterfall` | — | txwaterfall <on\|off> — show keyed TX in the waterfall |
 | `liveness` | — | liveness — per-class data ages and the producer->consumer meter join |
-| `civ` | — | civ <send <hex>\|trace [all]> — raw CI-V inject and frame trace (Icom; send is TX-gated) |
+| `civ` | — | civ <send <hex>\|trace [all]\|session> — CI-V inject, frame trace, or RS-BA1 lease health (Icom; send is TX-gated) |
 | `controls` | — | controls <map\|meters\|scrub [id\|plane]> — the CI-V control and meter registry joined against what is actually wired, and a linkage check that drives every settable control without moving any of them (Icom) |
 | `radiocert` | — | radiocert <tune\|rx\|tx\|meters\|all> [freqMhz] — radio bring-up diagnostic, in dependency order (tx/meters key) |
 | `key` | — | key <ptt on\|off \| mox> — semantic keying (TX-gated) |

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -2589,6 +2589,10 @@ bool isReadOnlyRequest(const QString& name, const QString& action)
         return normalizedAction == QLatin1String("status")
             || normalizedAction == QLatin1String("routes");
     }
+    if (name == QLatin1String("civ")) {
+        return normalizedAction == QLatin1String("trace")
+            || normalizedAction == QLatin1String("session");
+    }
     return false;
 }
 
@@ -3285,7 +3289,7 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
             });
 
         add("civ", {},
-            "civ <send <hex>|trace [all]> — raw CI-V inject and frame trace (Icom; send is TX-gated)",
+            "civ <send <hex>|trace [all]|session> — CI-V inject, frame trace, or RS-BA1 lease health (Icom; send is TX-gated)",
             parseActionRest,
             [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
                 return s.doCiv(a.action, a.value);
@@ -7454,19 +7458,21 @@ QJsonObject AutomationServer::doCiv(const QString& action, const QString& arg)
         return err(QStringLiteral("no backend available"));
 
     const QString a = action.trimmed().toLower();
-    if (a.isEmpty() || (a != QLatin1String("send") && a != QLatin1String("trace")))
-        return err(QStringLiteral("civ requires an action (send|trace)"));
+    if (a.isEmpty() || (a != QLatin1String("send") && a != QLatin1String("trace")
+                        && a != QLatin1String("session"))) {
+        return err(QStringLiteral("civ requires an action (send|trace|session)"));
+    }
     if (a == QLatin1String("send") && !m_txAllowed) {
         return err(QStringLiteral(
             "civ send is TX-gated: raw CI-V can key the transmitter and retune the "
             "radio. Relaunch with AETHER_AUTOMATION_ALLOW_TX=1"));
     }
 
-    // The Icom backend answers both verbs synchronously inside invokeExtension,
-    // so a direct connection lands before the call returns. Anything that does
-    // not answer leaves `answered` false and is reported as unsupported rather
-    // than as success — a fire-and-forget reply here would make an unrecognised
-    // namespace look like a working inject.
+    // The Icom backend answers all three verbs synchronously inside
+    // invokeExtension, so a direct connection lands before the call returns.
+    // Anything that does not answer leaves `answered` false and is reported as
+    // unsupported rather than as success — a fire-and-forget reply here would
+    // make an unrecognised namespace look like a working inject.
     bool answered = false;
     bool failed = false;
     QVariant payload;
@@ -7486,19 +7492,20 @@ QJsonObject AutomationServer::doCiv(const QString& action, const QString& arg)
         failure = msg;
     }, Qt::DirectConnection);
 
-    backend->invokeExtension(QStringLiteral("icom"),
-                             a == QLatin1String("send") ? QStringLiteral("civ.send")
-                                                        : QStringLiteral("civ.trace"),
-                             rid, arg.trimmed());
+    const QString verb = a == QLatin1String("send") ? QStringLiteral("civ.send")
+                       : a == QLatin1String("trace") ? QStringLiteral("civ.trace")
+                                                     : QStringLiteral("civ.session");
+    backend->invokeExtension(QStringLiteral("icom"), verb, rid, arg.trimmed());
     disconnect(okConn);
     disconnect(errConn);
 
     if (!answered) {
         return err(QStringLiteral(
-            "this backend does not implement raw CI-V (it is an Icom-only verb)"));
+            "this backend does not implement CI-V diagnostics (it is an Icom-only verb)"));
     }
-    if (failed)
+    if (failed) {
         return err(failure);
+    }
 
     QJsonObject out{{QStringLiteral("ok"), true}, {QStringLiteral("civ"), a}};
     out.insert(QStringLiteral("result"),

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -2521,6 +2521,18 @@ void IcomCivBackend::invokeExtension(const QString& ns, const QString& verb, qui
         emit extensionResult(requestId, civTrace(mode == QLatin1String("all")));
         return;
     }
+    if (verb == QLatin1String("civ.session")) {
+        QVariantMap result;
+        if (m_session) {
+            result = m_session->leaseDiagnostics();
+        } else {
+            result.insert(QStringLiteral("connected"), false);
+            result.insert(QStringLiteral("lastRenewalResult"),
+                          QStringLiteral("no session"));
+        }
+        emit extensionResult(requestId, result);
+        return;
+    }
     if (verb == QLatin1String("civ.send")) {
         // RAW INJECTION. The caller supplies the command bytes ONLY — the
         // preamble, addresses and terminator are ours. That is not politeness:
@@ -2791,6 +2803,47 @@ IRadioBackend::HealthSnapshot IcomCivBackend::healthSnapshot() const
                         .arg(m_audioRateHz * 16 / 1000));
     h.labels.insert(QStringLiteral("audiorate"), QStringLiteral("Audio rate"));
     h.order << QStringLiteral("audiorate");
+
+    // RS-BA1 lease state is separate from UDP transport liveness. A rejected
+    // or expired token leaves the outer socket answering while CI-V and audio
+    // stop, so packet counters alone cannot diagnose this class of freeze.
+    if (m_session) {
+        const QVariantMap lease = m_session->leaseDiagnostics();
+        h.sections.insert(QStringLiteral("lease"), QStringLiteral("RS-BA1 session"));
+        h.values.insert(QStringLiteral("lease"),
+                        QStringLiteral("%1, %2")
+                            .arg(lease.value(QStringLiteral("authenticated")).toBool()
+                                     ? QStringLiteral("authenticated")
+                                     : QStringLiteral("not authenticated"),
+                                 lease.value(QStringLiteral("lastRenewalResult")).toString()));
+        h.labels.insert(QStringLiteral("lease"), QStringLiteral("Lease"));
+        h.order << QStringLiteral("lease");
+
+        const qint64 ageMs = lease.value(QStringLiteral("lastAcceptedAgeMs")).toLongLong();
+        h.values.insert(QStringLiteral("leaseage"),
+                        ageMs >= 0 ? QStringLiteral("%1 ms").arg(ageMs)
+                                   : QStringLiteral("no accepted token"));
+        h.labels.insert(QStringLiteral("leaseage"), QStringLiteral("Last token ACK"));
+        h.order << QStringLiteral("leaseage");
+
+        h.values.insert(QStringLiteral("leaseseq"),
+                        QStringLiteral("last %1 / next %2 / pending %3")
+                            .arg(lease.value(QStringLiteral("lastRenewalSequence")).toUInt())
+                            .arg(lease.value(QStringLiteral("nextInnerSequence")).toUInt())
+                            .arg(lease.value(QStringLiteral("pendingRenewals")).toInt()));
+        h.labels.insert(QStringLiteral("leaseseq"), QStringLiteral("Token sequence"));
+        h.order << QStringLiteral("leaseseq");
+
+        h.values.insert(QStringLiteral("leasecounts"),
+                        QStringLiteral("%1 accepted / %2 reissued / %3 rejected / %4 stale")
+                            .arg(lease.value(QStringLiteral("acceptedRenewals")).toULongLong())
+                            .arg(lease.value(QStringLiteral("reissuedTokens")).toULongLong())
+                            .arg(lease.value(QStringLiteral("rejectedRenewals")).toULongLong())
+                            .arg(lease.value(QStringLiteral("ignoredAuthReplies")).toULongLong()
+                                 + lease.value(QStringLiteral("ignoredControlPackets")).toULongLong()));
+        h.labels.insert(QStringLiteral("leasecounts"), QStringLiteral("Token replies"));
+        h.order << QStringLiteral("leasecounts");
+    }
 
     if (!m_model->verified) {
         // Say so rather than presenting cross-referenced numbers as measured.

--- a/src/core/backends/icom/IcomProtocol.cpp
+++ b/src/core/backends/icom/IcomProtocol.cpp
@@ -82,13 +82,12 @@ std::vector<std::uint8_t> framed(std::size_t len, PacketType type, std::uint16_t
 // The "inner" header shared by every control-stream request larger than 16
 // bytes (login, auth, stream request). Offsets are relative to the packet.
 //
-// INNER SEQUENCE: kappanhang writes a little-endian u16 at 0x17; wfview writes
-// a big-endian u16 at 0x16. For every value below 256 the two are byte-for-byte
-// identical, which is why both implementations work — and neither reference
-// exercises the divergence, because the counter is small in every capture
-// either project published. We follow kappanhang (our portable reference) and
-// flag the ambiguity here rather than silently picking a side: if a long-lived
-// session ever misbehaves after ~3 hours of 45 s renewals, this is the byte.
+// INNER SEQUENCE: a big-endian u16 at 0x16, matching wfview's packet struct and
+// a live IC-7300MK2. kappanhang writes a little-endian u16 at 0x17; both shapes
+// are byte-identical below 256, which hid the disagreement until a long-lived
+// session crossed the 8-bit boundary. At 256 the shifted kappanhang shape was
+// rejected with response 0xffffffff, and serial + audio expired 90 s after the
+// last valid renewal while the outer control stream remained alive.
 void writeInner(std::span<std::uint8_t> p, std::size_t payloadSize,
                 std::uint8_t requestReply, std::uint8_t requestType,
                 std::uint16_t innerSeq)
@@ -96,8 +95,7 @@ void writeInner(std::span<std::uint8_t> p, std::size_t payloadSize,
     putBe32(p, 0x10, static_cast<std::uint32_t>(payloadSize));
     p[0x14] = requestReply;
     p[0x15] = requestType;
-    p[0x16] = 0x00;
-    putLe16(p, 0x17, innerSeq);
+    putBe16(p, 0x16, innerSeq);
 }
 
 // The 95-entry substitution table Icom uses to obfuscate credentials, indexed
@@ -365,7 +363,7 @@ std::array<std::uint8_t, 16> encodePasscode(std::string_view s)
 // ---------------------------------------------------------------------------
 
 std::vector<std::uint8_t> buildLogin(std::uint32_t localSid, std::uint32_t remoteSid,
-                                     std::uint16_t innerSeq, std::uint16_t authStartId,
+                                     std::uint16_t innerSeq, std::uint16_t tokenRequestId,
                                      std::string_view username, std::string_view password)
 {
     auto p = framed(kLenLogin, PacketType::Idle, 0, localSid, remoteSid);
@@ -373,8 +371,10 @@ std::vector<std::uint8_t> buildLogin(std::uint32_t localSid, std::uint32_t remot
 
     // Two bytes of our choosing. The auth ID the radio hands back echoes them
     // in its first two bytes, which is how a reply is matched to a login when
-    // several are in flight.
-    putLe16(p, 0x1a, authStartId);
+    // several are in flight. This must be fresh per login: both wfview and
+    // kappanhang randomize it, and a live IC-7300MK2 rejected an immediate
+    // reconnect when AetherSDR reused 0x0000 from the previous session.
+    putLe16(p, 0x1a, tokenRequestId);
 
     const auto user = encodePasscode(username);
     const auto pass = encodePasscode(password);
@@ -411,13 +411,24 @@ std::vector<std::uint8_t> buildAuth(std::uint32_t localSid, std::uint32_t remote
     return p;
 }
 
-bool isAuthAccepted(std::span<const std::uint8_t> pkt)
+AuthReply parseAuthReply(std::span<const std::uint8_t> pkt)
 {
-    if (!startsWith(pkt, kLenToken, 0x40))
-        return false;
+    AuthReply out;
+    if (!startsWith(pkt, kLenToken, 0x40)) {
+        return out;
+    }
     // 0x14 == 0x02 marks a REPLY (we send 0x01); 0x15 == 0x05 marks it as the
     // answer to a Renew, which is the one that actually gates the streams.
-    return pkt[0x14] == 0x02 && pkt[0x15] == static_cast<std::uint8_t>(AuthKind::Renew);
+    if (pkt[0x14] != 0x02
+        || pkt[0x15] != static_cast<std::uint8_t>(AuthKind::Renew)) {
+        return out;
+    }
+    out.innerSeq = getBe16(pkt, 0x16);
+    out.response = getLe32(pkt, 0x30);
+    std::copy_n(pkt.begin() + 0x1a, out.authId.size(), out.authId.begin());
+    out.result = out.response == 0 ? AuthReplyResult::Accepted
+                                   : AuthReplyResult::Nonzero;
+    return out;
 }
 
 bool parseCapabilities(std::span<const std::uint8_t> pkt, RadioId& radioId)
@@ -494,11 +505,9 @@ StreamGrant parseStreamGrant(std::span<const std::uint8_t> pkt)
 
     g.granted    = true;
     g.deviceName = fixedString(pkt, 0x40, 32);
-    // THE TRAP: the radio may hand back DIFFERENT session IDs and a different
-    // auth ID than the ones the login established — a previous session on the
-    // same socket can shift them. Caching the login's values and never
-    // re-reading them here authenticates correctly exactly once and then fails
-    // every 60 s renewal, which presents as "audio stops after a minute".
+    // The header IDs are correlation data, not replacements for the current
+    // control stream's IDs. A delayed grant from a previous session can arrive
+    // on the new socket, so IcomSession validates both before adopting authId.
     g.remoteSid = getBe32(pkt, 0x08);
     g.localSid  = getBe32(pkt, 0x0c);
     std::copy_n(pkt.begin() + 0x1a, g.authId.size(), g.authId.begin());

--- a/src/core/backends/icom/IcomProtocol.h
+++ b/src/core/backends/icom/IcomProtocol.h
@@ -302,7 +302,7 @@ using RadioId = std::array<std::uint8_t, 16>;
 [[nodiscard]] std::vector<std::uint8_t> buildLogin(std::uint32_t localSid,
                                                     std::uint32_t remoteSid,
                                                     std::uint16_t innerSeq,
-                                                    std::uint16_t authStartId,
+                                                    std::uint16_t tokenRequestId,
                                                     std::string_view username,
                                                     std::string_view password);
 
@@ -316,8 +316,20 @@ enum class LoginResult { Ok, BadCredentials, NotALoginReply };
                                                    const AuthId& authId,
                                                    AuthKind kind);
 
-// True when this is the 0x40 reply confirming a Renew-kind auth succeeded.
-[[nodiscard]] bool isAuthAccepted(std::span<const std::uint8_t> pkt);
+// A 0x40 requesttype=0x05 packet is only an ordinary successful renewal when
+// its response word is zero. The radio also sends the same reply shape with
+// 0xffffffff: during initial reconnect authentication that supplies the token
+// wfview continues with, while during an established lease it is a rejection.
+// The protocol parser preserves the distinction and IcomSession applies the
+// required session context.
+enum class AuthReplyResult { NotRenewal, Accepted, Nonzero };
+struct AuthReply {
+    AuthReplyResult result = AuthReplyResult::NotRenewal;
+    std::uint16_t innerSeq = 0;
+    std::uint32_t response = 0;
+    AuthId authId{};
+};
+[[nodiscard]] AuthReply parseAuthReply(std::span<const std::uint8_t> pkt);
 
 // Extract the radio identity from the 0xA8 capabilities packet.
 [[nodiscard]] bool parseCapabilities(std::span<const std::uint8_t> pkt, RadioId& radioId);
@@ -370,10 +382,9 @@ struct StreamRequest {
 
 [[nodiscard]] std::vector<std::uint8_t> buildStreamRequest(const StreamRequest& req);
 
-// The 0x90 reply. On success it carries the device name AND — the trap — a
-// possibly CHANGED pair of session IDs and a new auth ID. Caching those from
-// the login and never re-reading them authenticates correctly exactly once and
-// then fails every renewal.
+// The 0x90 reply. Its header IDs identify the control session the grant belongs
+// to; callers must reject a delayed grant from a previous session. The auth ID
+// in a valid current-session grant replaces the login value for renewals.
 struct StreamGrant {
     bool granted = false;
     std::string deviceName;

--- a/src/core/backends/icom/IcomSession.cpp
+++ b/src/core/backends/icom/IcomSession.cpp
@@ -3,8 +3,11 @@
 #include <QDateTime>
 
 #include <QLoggingCategory>
+#include <QRandomGenerator>
 #include <QThread>
 #include <QTimer>
+
+#include <algorithm>
 
 namespace AetherSDR::icom {
 
@@ -48,6 +51,18 @@ bool IcomSession::start(const Params& params)
 {
     stop();
     m_params = params;
+    m_tokenRequestId = params.tokenRequestId != 0
+        ? params.tokenRequestId
+        : static_cast<quint16>(QRandomGenerator::global()->bounded(1, 0x10000));
+    m_lastAuthOkMs = 0;
+    m_lastRenewalSeq = 0;
+    m_lastRenewalResult = QStringLiteral("not sent");
+    m_lastRenewalResponse = 0;
+    m_renewAcceptedCount = 0;
+    m_tokenReissuedCount = 0;
+    m_renewRejectedCount = 0;
+    m_ignoredAuthReplies = 0;
+    m_ignoredControlPackets = 0;
     m_tx = TxPacketizer(params.codec);
     m_rx = RxAssembler(params.codec);
 
@@ -57,6 +72,11 @@ bool IcomSession::start(const Params& params)
         // the operator's headphones.
         fail(QStringLiteral("audio codec %1 is not supported by this client")
                  .arg(static_cast<int>(params.codec)));
+        return false;
+    }
+    if (params.tokenRenewalMs <= 0 || params.tokenAckGraceMs <= 0
+        || params.tokenDeadMs <= params.tokenRenewalMs) {
+        fail(QStringLiteral("invalid RS-BA1 lease timing configuration"));
         return false;
     }
 
@@ -124,15 +144,19 @@ void IcomSession::stop()
     // "auth failed on reconnect" the operator hit, and why a retry a minute
     // later works. kappanhang sends auth 0x01 here for the same reason.
     //
-    // Sent TWICE like every other control packet: this is the one packet whose
-    // loss the radio cannot ask us to retransmit, because we stop listening
-    // immediately afterwards.
+    // Send it TWICE as TRACKED packets. buildAuth() leaves the outer sequence
+    // at zero for IcomStream to stamp; sending it through sendRaw() bypassed
+    // that stamp, so a live IC-7300MK2 discarded the deauth behind the already
+    // advanced control-stream sequence. The next login succeeded but its first
+    // token request was rejected with 0xffffffff until the old lease expired.
+    // Two distinct tracked sequence numbers also avoid depending on a replay
+    // request we cannot serve after closing the socket.
     if (m_control && m_control->isReady()) {
         const auto bye = buildAuth(m_control->localSessionId(),
                                    m_control->remoteSessionId(), m_innerSeq++, m_authId,
                                    AuthKind::Deauth);
-        m_control->sendRaw(bye);
-        m_control->sendRaw(bye);
+        m_control->sendTracked(bye);
+        m_control->sendTracked(bye);
         // FLUSH, don't sleep.
         //
         // This was QThread::msleep(150), which was wrong twice over. It froze
@@ -160,11 +184,13 @@ void IcomSession::stop()
         }
     }
     m_authOk = false;
-    m_lastAuthOkMs = 0;
     m_renewUnacked = false;
+    m_initialMaintenancePending = false;
     m_renewRetries = 0;
+    m_pendingRenewals.clear();
     m_haveRadioId = false;
     m_streamsRequested = false;
+    m_streamGranted = false;
     m_connected = false;
     m_innerSeq = 0;
     m_serialSendSeq = 0;
@@ -200,13 +226,44 @@ void IcomSession::fail(const QString& reason)
     });
 }
 
+void IcomSession::sendRenewal(const QString& reason)
+{
+    if (!m_control || !m_control->isReady()) {
+        return;
+    }
+    const quint16 seq = m_innerSeq++;
+    m_pendingRenewals.insert(seq);
+    m_lastRenewalSeq = seq;
+    m_lastRenewalResult = QStringLiteral("pending");
+    m_lastRenewalResponse = 0;
+    m_renewUnacked = true;
+    qCInfo(lcIcom).noquote() << "RS-BA1 token renewal sent: seq" << seq
+                             << "reason" << reason
+                             << "pending" << m_pendingRenewals.size();
+    m_control->sendTracked(buildAuth(m_control->localSessionId(),
+                                     m_control->remoteSessionId(), seq, m_authId,
+                                     AuthKind::Renew));
+}
+
+bool IcomSession::isCurrentControlPacket(std::span<const std::uint8_t> packet) const
+{
+    if (!m_control || packet.size() < kHeaderSize) {
+        return false;
+    }
+    const Header header = parseHeader(packet);
+    return header.sentId == m_control->remoteSessionId()
+        && header.rcvdId == m_control->localSessionId();
+}
+
 void IcomSession::onControlReady()
 {
     qCInfo(lcIcom) << "control stream ready — sending login for user"
                    << m_params.username << "(password"
-                   << (m_params.password.isEmpty() ? "EMPTY)" : "supplied)");
+                   << (m_params.password.isEmpty() ? "EMPTY)" : "supplied)")
+                   << "token request"
+                   << QStringLiteral("0x%1").arg(m_tokenRequestId, 4, 16, QLatin1Char('0'));
     m_control->sendTracked(buildLogin(m_control->localSessionId(), m_control->remoteSessionId(),
-                                      m_innerSeq++, 0x0000,
+                                      m_innerSeq++, m_tokenRequestId,
                                       m_params.username.toStdString(),
                                       m_params.password.toStdString()));
 }
@@ -239,38 +296,80 @@ void IcomSession::onControlPayload(const QByteArray& packet)
         m_control->sendTracked(buildAuth(m_control->localSessionId(),
                                          m_control->remoteSessionId(), m_innerSeq++, m_authId,
                                          AuthKind::First));
-        m_control->sendTracked(buildAuth(m_control->localSessionId(),
-                                         m_control->remoteSessionId(), m_innerSeq++, m_authId,
-                                         AuthKind::Renew));
+        sendRenewal(QStringLiteral("initial token request"));
         return;
     }
 
-    case static_cast<qsizetype>(kLenToken):
-        qCInfo(lcIcom) << "got token/auth reply, accepted =" << isAuthAccepted(pkt)
-                       << "requestreply =" << pkt[0x14] << "requesttype =" << pkt[0x15];
-        if (isAuthAccepted(pkt)) {
-            m_authOk = true;
-            // THE ACK, which is what makes a renewal verifiable. Before this
-            // the renewal was fire-and-forget: one datagram every 45 s, no
-            // check, and a lost one killed the session 15 s later with no
-            // disconnect packet and no error anywhere.
-            m_lastAuthOkMs = QDateTime::currentMSecsSinceEpoch();
-            m_renewUnacked = false;
-            m_renewRetries = 0;
-            if (!m_tokenTimer) {
-                // Renew comfortably inside the 60 s contract. Missing it stops
-                // the media streams with NO disconnect packet and no error —
-                // the operator sees audio simply stop.
-                m_tokenTimer = new QTimer(this);
-                connect(m_tokenTimer, &QTimer::timeout, this, &IcomSession::onTokenRenew);
-                // Fires far more often than it renews: the same tick polices
-                // an outstanding renewal, so a lost one is resent in seconds
-                // rather than waiting out the next full interval.
-                m_tokenTimer->start(kTokenAckGraceMs);
-            }
-            requestStreamsIfReady();
+    case static_cast<qsizetype>(kLenToken): {
+        const AuthReply reply = parseAuthReply(pkt);
+        if (reply.result == AuthReplyResult::NotRenewal) {
+            return;
         }
+        const bool initialToken = !m_authOk && !m_streamsRequested && !m_streamGranted;
+        const bool mayRotateInitialToken = initialToken
+            && reply.result == AuthReplyResult::Nonzero;
+        if (!isCurrentControlPacket(pkt)
+            || (reply.authId != m_authId && !mayRotateInitialToken)
+            || !m_pendingRenewals.remove(reply.innerSeq)) {
+            ++m_ignoredAuthReplies;
+            qCWarning(lcIcom).noquote()
+                << "ignoring stale or duplicate RS-BA1 token reply: seq"
+                << reply.innerSeq << "response"
+                << QStringLiteral("0x%1").arg(reply.response, 8, 16, QLatin1Char('0'))
+                << "pending" << m_pendingRenewals.size();
+            return;
+        }
+        m_lastRenewalSeq = reply.innerSeq;
+        m_lastRenewalResponse = reply.response;
+        if (reply.result == AuthReplyResult::Nonzero && !initialToken) {
+            ++m_renewRejectedCount;
+            m_lastRenewalResult = QStringLiteral("rejected");
+            qCWarning(lcIcom).noquote()
+                << "RS-BA1 token renewal rejected: seq" << reply.innerSeq
+                << "response"
+                << QStringLiteral("0x%1").arg(reply.response, 8, 16, QLatin1Char('0'));
+            fail(QStringLiteral("the radio rejected RS-BA1 session renewal %1 (response 0x%2)")
+                     .arg(reply.innerSeq)
+                     .arg(reply.response, 8, 16, QLatin1Char('0')));
+            return;
+        }
+
+        if (reply.result == AuthReplyResult::Nonzero) {
+            // wfview follows this exact reconnect path: the radio can answer
+            // the first post-login token request with 0xffffffff while
+            // returning the token that must be used for the stream request.
+            // The same response on an established lease is a real rejection,
+            // handled above. Context, not packet shape, is the discriminator.
+            m_authId = reply.authId;
+            ++m_tokenReissuedCount;
+            m_lastRenewalResult = QStringLiteral("reissued");
+            qCWarning(lcIcom) << "RS-BA1 token reissued during reconnect: seq"
+                              << reply.innerSeq;
+        } else {
+            ++m_renewAcceptedCount;
+            m_lastRenewalResult = QStringLiteral("accepted");
+            qCInfo(lcIcom) << "RS-BA1 token renewal accepted: seq" << reply.innerSeq;
+        }
+        m_pendingRenewals.clear();
+        m_authOk = true;
+        m_lastAuthOkMs = QDateTime::currentMSecsSinceEpoch();
+        m_renewUnacked = false;
+        m_renewRetries = 0;
+        // A live immediate reconnect received a media grant that went silent
+        // around 45 s even though the ordinary 60 s renewal was later accepted.
+        // Renew once at 30 s after initial authentication, then use the normal
+        // reference cadence for the rest of the session.
+        m_initialMaintenancePending = initialToken;
+        if (!m_tokenTimer) {
+            m_tokenTimer = new QTimer(this);
+            connect(m_tokenTimer, &QTimer::timeout, this, &IcomSession::onTokenRenew);
+            // This timer is both the 60 s renewal scheduler and the watchdog
+            // for a missing acknowledgement.
+            m_tokenTimer->start(m_params.tokenAckGraceMs);
+        }
+        requestStreamsIfReady();
         return;
+    }
 
     case static_cast<qsizetype>(kLenCapabilities):
         qCInfo(lcIcom) << "got capabilities packet";
@@ -284,22 +383,23 @@ void IcomSession::onControlPayload(const QByteArray& packet)
     case static_cast<qsizetype>(kLenStatus):
         switch (parseStatus(pkt)) {
         case StatusKind::AuthFailed:
-            // ONLY FATAL BEFORE THE STREAMS ARE GRANTED.
-            //
-            // On a RECONNECT the radio sends this after the new session is
-            // fully established — login accepted, capabilities read, streams
-            // granted, token accepted, both media streams handshaking — and
-            // then one 0x50 carrying the failure sentinel. It is reporting the
-            // teardown of the PREVIOUS session, not a failure of this one.
-            //
-            // Treating it as fatal killed a working session every time, which
-            // is what the "auth error on reconnect" actually was. kappanhang
-            // hits the same packet and distinguishes the two cases by whether
-            // its streams had opened; this is that test, applied to the grant.
-            if (m_streamsRequested && m_authOk) {
-                qCWarning(lcIcom) << "status reports an auth failure AFTER the streams were "
-                                     "granted — treating as the previous session's teardown, "
-                                     "not this one's";
+            // There are two distinguishable late-teardown shapes. A previous
+            // session can carry its old header IDs, but the IC-7300MK2 also
+            // sends 0x50/ffffffff on the NEW control association after that
+            // association's stream grant. wfview applies the same lifecycle
+            // discriminator: the sentinel is fatal before streamOpened and is
+            // ignored afterwards. Keep the header check as stronger evidence,
+            // then preserve the proven post-grant exception even if the radio
+            // stamped the status with this session's IDs.
+            if (!isCurrentControlPacket(pkt)) {
+                ++m_ignoredControlPackets;
+                qCWarning(lcIcom) << "ignoring auth-failure status for a stale control session";
+                return;
+            }
+            if (m_streamGranted && m_authOk) {
+                ++m_ignoredControlPackets;
+                qCWarning(lcIcom) << "ignoring late auth-failure status after the current "
+                                     "session's stream grant";
                 return;
             }
             fail(QStringLiteral("authentication failed — check the user name and password, "
@@ -320,11 +420,18 @@ void IcomSession::onControlPayload(const QByteArray& packet)
                        << "byte0x60 =" << static_cast<quint8>(packet.at(0x60));
         if (!grant.granted)
             return;
+        if (!m_streamsRequested || !m_authOk
+            || grant.localSid != m_control->localSessionId()
+            || grant.remoteSid != m_control->remoteSessionId()) {
+            ++m_ignoredControlPackets;
+            qCWarning(lcIcom) << "ignoring stale RS-BA1 stream grant: requested="
+                              << m_streamsRequested << "authenticated=" << m_authOk
+                              << "headerMatches=" << isCurrentControlPacket(pkt);
+            return;
+        }
         m_deviceName = QString::fromStdString(grant.deviceName);
-        // The grant may carry DIFFERENT session ids and a new auth id. Adopting
-        // them is what keeps the 60 s renewals working; caching the login's
-        // values instead authenticates correctly exactly once.
         m_authId = grant.authId;
+        m_streamGranted = true;
         openMediaStreams();
         return;
     }
@@ -404,17 +511,18 @@ void IcomSession::openMediaStreams()
 
 // The token ticker, and the renewal watchdog — one timer doing both.
 //
-// THE FAILURE THIS EXISTS FOR. The radio honours a session for 60 s and then
-// stops, silently: no disconnect packet, no error, and the UDP transport keeps
-// running because idle keepalives are not token-gated. So `isConnected()` stays
-// true, link statistics keep climbing, and CI-V is simply dead. It reads as a
-// radio that stopped talking rather than as a session that expired.
+// THE FAILURE THIS EXISTS FOR. The radio requires a renewal on the 60 s
+// reference cadence and eventually stops media silently after the last accepted
+// token: no disconnect packet, no error, and the UDP transport keeps running
+// because idle keepalives are not token-gated. So `isConnected()` stays true,
+// link statistics keep climbing, and CI-V is simply dead. It reads as a radio
+// that stopped talking rather than as a session that expired.
 //
-// A single renewal 15 s before expiry was one UDP datagram between us and that.
-// On a 2.4 GHz link with 14.7% TX retries and power-save latency reaching
-// 300 ms, losing it is routine. So: renew three times inside the contract, and
-// treat an unacknowledged renewal as something to resend rather than something
-// to hope about.
+// wfview and kappanhang both renew once per minute. A live IC-7300MK2 stopped
+// serial and audio about 90 s after an established token, but an immediate
+// reconnect grant stopped around 45 s even though its 60 s renewal was later
+// accepted. We renew once at 30 s, then every 60 s, retry within 3 s, and fail
+// at 80 s so the session cannot sit falsely green past the observed expiry.
 void IcomSession::onTokenRenew()
 {
     if (!m_control || !m_control->isReady())
@@ -429,7 +537,7 @@ void IcomSession::onTokenRenew()
     // Nothing has been acknowledged for most of the contract. Report it while
     // it is still true — a session that dies here used to be discovered minutes
     // later as "the meters stopped".
-    if (sinceAck > kTokenDeadMs) {
+    if (sinceAck > m_params.tokenDeadMs) {
         fail(QStringLiteral(
                  "the radio stopped renewing our session token (no acknowledgement "
                  "for %1 s). The link is up but the session has expired — this is "
@@ -444,15 +552,14 @@ void IcomSession::onTokenRenew()
         if (m_renewRetries < kTokenRenewMaxRetries) {
             ++m_renewRetries;
             qCWarning(lcIcom) << "token renewal unacknowledged after"
-                              << kTokenAckGraceMs << "ms — resend" << m_renewRetries
+                              << m_params.tokenAckGraceMs << "ms — resend" << m_renewRetries
                               << "of" << kTokenRenewMaxRetries;
-            m_control->sendTracked(buildAuth(m_control->localSessionId(),
-                                             m_control->remoteSessionId(),
-                                             m_innerSeq++, m_authId, AuthKind::Renew));
+            sendRenewal(QStringLiteral("acknowledgement retry %1")
+                            .arg(m_renewRetries));
             return;
         }
         // RELEASE THE LATCH. Retries are exhausted for THIS renewal, but the
-        // token is alive until kTokenDeadMs — so falling through to the cadence
+        // token is alive until tokenDeadMs — so falling through to the cadence
         // below starts a fresh one with a fresh budget, which is effectively
         // continuous retry up to the dead-session deadline.
         //
@@ -465,13 +572,15 @@ void IcomSession::onTokenRenew()
         m_renewRetries = 0;
     }
 
-    // Otherwise renew on the normal cadence.
-    if (sinceAck < kTokenRenewEarlyMs)
+    // A reconnect grant can have a shorter first window than an established
+    // lease. Cover it once, then return to the wfview/kappanhang 60 s cadence.
+    const int cadenceMs = m_initialMaintenancePending
+        ? std::min(m_params.tokenRenewalMs, kInitialMaintenanceRenewalMs)
+        : m_params.tokenRenewalMs;
+    if (sinceAck < cadenceMs)
         return;
-    m_renewUnacked = true;
     m_renewRetries = 0;
-    m_control->sendTracked(buildAuth(m_control->localSessionId(), m_control->remoteSessionId(),
-                                     m_innerSeq++, m_authId, AuthKind::Renew));
+    sendRenewal(QStringLiteral("scheduled"));
 }
 
 void IcomSession::onSerialReady()
@@ -633,6 +742,43 @@ IcomSession::Stats IcomSession::stats() const
     if (m_serial)  s.serial  = m_serial->counters();
     if (m_audio)   s.audio   = m_audio->counters();
     return s;
+}
+
+QVariantMap IcomSession::leaseDiagnostics() const
+{
+    QVariantMap out;
+    const qint64 ageMs = m_lastAuthOkMs > 0
+        ? QDateTime::currentMSecsSinceEpoch() - m_lastAuthOkMs : -1;
+    out.insert(QStringLiteral("authenticated"), m_authOk);
+    out.insert(QStringLiteral("connected"), m_connected);
+    out.insert(QStringLiteral("streamsRequested"), m_streamsRequested);
+    out.insert(QStringLiteral("streamGranted"), m_streamGranted);
+    out.insert(QStringLiteral("nextInnerSequence"), m_innerSeq);
+    out.insert(QStringLiteral("tokenRequestId"),
+               QStringLiteral("0x%1").arg(m_tokenRequestId, 4, 16, QLatin1Char('0')));
+    out.insert(QStringLiteral("lastRenewalSequence"), m_lastRenewalSeq);
+    out.insert(QStringLiteral("lastRenewalResult"), m_lastRenewalResult);
+    out.insert(QStringLiteral("lastRenewalResponse"),
+               QStringLiteral("0x%1").arg(m_lastRenewalResponse, 8, 16, QLatin1Char('0')));
+    out.insert(QStringLiteral("lastAcceptedAgeMs"), ageMs);
+    out.insert(QStringLiteral("pendingRenewals"), m_pendingRenewals.size());
+    out.insert(QStringLiteral("renewalRetries"), m_renewRetries);
+    out.insert(QStringLiteral("acceptedRenewals"),
+               QVariant::fromValue<qulonglong>(m_renewAcceptedCount));
+    out.insert(QStringLiteral("reissuedTokens"),
+               QVariant::fromValue<qulonglong>(m_tokenReissuedCount));
+    out.insert(QStringLiteral("rejectedRenewals"),
+               QVariant::fromValue<qulonglong>(m_renewRejectedCount));
+    out.insert(QStringLiteral("ignoredAuthReplies"),
+               QVariant::fromValue<qulonglong>(m_ignoredAuthReplies));
+    out.insert(QStringLiteral("ignoredControlPackets"),
+               QVariant::fromValue<qulonglong>(m_ignoredControlPackets));
+    out.insert(QStringLiteral("renewalCadenceMs"), m_params.tokenRenewalMs);
+    out.insert(QStringLiteral("initialMaintenanceMs"), kInitialMaintenanceRenewalMs);
+    out.insert(QStringLiteral("initialMaintenancePending"), m_initialMaintenancePending);
+    out.insert(QStringLiteral("ackGraceMs"), m_params.tokenAckGraceMs);
+    out.insert(QStringLiteral("deadSessionMs"), m_params.tokenDeadMs);
+    return out;
 }
 
 }  // namespace AetherSDR::icom

--- a/src/core/backends/icom/IcomSession.cpp
+++ b/src/core/backends/icom/IcomSession.cpp
@@ -75,6 +75,7 @@ bool IcomSession::start(const Params& params)
         return false;
     }
     if (params.tokenRenewalMs <= 0 || params.tokenAckGraceMs <= 0
+        || params.initialMaintenanceMs <= 0
         || params.tokenDeadMs <= params.tokenRenewalMs) {
         fail(QStringLiteral("invalid RS-BA1 lease timing configuration"));
         return false;
@@ -575,7 +576,7 @@ void IcomSession::onTokenRenew()
     // A reconnect grant can have a shorter first window than an established
     // lease. Cover it once, then return to the wfview/kappanhang 60 s cadence.
     const int cadenceMs = m_initialMaintenancePending
-        ? std::min(m_params.tokenRenewalMs, kInitialMaintenanceRenewalMs)
+        ? std::min(m_params.tokenRenewalMs, m_params.initialMaintenanceMs)
         : m_params.tokenRenewalMs;
     if (sinceAck < cadenceMs)
         return;
@@ -774,7 +775,7 @@ QVariantMap IcomSession::leaseDiagnostics() const
     out.insert(QStringLiteral("ignoredControlPackets"),
                QVariant::fromValue<qulonglong>(m_ignoredControlPackets));
     out.insert(QStringLiteral("renewalCadenceMs"), m_params.tokenRenewalMs);
-    out.insert(QStringLiteral("initialMaintenanceMs"), kInitialMaintenanceRenewalMs);
+    out.insert(QStringLiteral("initialMaintenanceMs"), m_params.initialMaintenanceMs);
     out.insert(QStringLiteral("initialMaintenancePending"), m_initialMaintenancePending);
     out.insert(QStringLiteral("ackGraceMs"), m_params.tokenAckGraceMs);
     out.insert(QStringLiteral("deadSessionMs"), m_params.tokenDeadMs);

--- a/src/core/backends/icom/IcomSession.h
+++ b/src/core/backends/icom/IcomSession.h
@@ -53,6 +53,11 @@ public:
         int tokenRenewalMs = 60000;
         int tokenAckGraceMs = 3000;
         int tokenDeadMs = 80000;
+        // The one-time early renewal that covers a reconnect grant's shorter
+        // first window. Overridable so a test can prove the early renewal
+        // actually fires ahead of the steady cadence, rather than only that
+        // the flag was set.
+        int initialMaintenanceMs = 30000;
         // Zero selects a fresh random nonzero ID. Tests may override it to
         // prove reconnect correlation deterministically.
         quint16 tokenRequestId = 0;
@@ -149,7 +154,6 @@ private:
     bool   m_initialMaintenancePending = false;
     int    m_renewRetries = 0;
     static constexpr int kTokenRenewMaxRetries = 4;
-    static constexpr int kInitialMaintenanceRenewalMs = 30000;
     QSet<quint16> m_pendingRenewals;
     quint16 m_lastRenewalSeq = 0;
     QString m_lastRenewalResult = QStringLiteral("not sent");

--- a/src/core/backends/icom/IcomSession.h
+++ b/src/core/backends/icom/IcomSession.h
@@ -2,7 +2,9 @@
 
 #include <QHostAddress>
 #include <QObject>
+#include <QSet>
 #include <QString>
+#include <QVariantMap>
 
 #include <cstdint>
 #include <span>
@@ -46,6 +48,14 @@ public:
         // not sending audio — a receive-only session cannot key by accident.
         bool enableTx = true;
         quint16 txBufferMs = 200;
+        // Production lease timing. Tests override these values to exercise the
+        // renewal watchdog without waiting more than a minute.
+        int tokenRenewalMs = 60000;
+        int tokenAckGraceMs = 3000;
+        int tokenDeadMs = 80000;
+        // Zero selects a fresh random nonzero ID. Tests may override it to
+        // prove reconnect correlation deterministically.
+        quint16 tokenRequestId = 0;
         // The radio's CI-V address. Seeded from settings and CORRECTED from the
         // 0x19 0x00 reply once the session is up — never assumed, because the
         // address is user-changeable and other Icoms speak this same transport.
@@ -77,6 +87,8 @@ public:
         IcomStream::Counters audio;
     };
     [[nodiscard]] Stats stats() const;
+    // Credential-free RS-BA1 lease state for health and automation diagnostics.
+    [[nodiscard]] QVariantMap leaseDiagnostics() const;
 
 signals:
     void connected(const QString& deviceName);
@@ -100,6 +112,8 @@ private slots:
 
 private:
     void fail(const QString& reason);
+    void sendRenewal(const QString& reason);
+    [[nodiscard]] bool isCurrentControlPacket(std::span<const std::uint8_t> packet) const;
     void requestStreamsIfReady();
     void openMediaStreams();
 
@@ -118,23 +132,36 @@ private:
     bool    m_civDataSeen = false;
     int     m_civOpenAttempts = 0;
 
-    // Auth state. The auth id and session ids are re-read from the stream grant
-    // rather than cached from the login — see parseStreamGrant's comment; the
-    // failure of not doing so is "audio stops after exactly one minute".
+    // Auth state. A grant may replace the auth ID, but only after its header
+    // IDs prove it belongs to this control session.
     AuthId m_authId{};
     RadioId m_radioId{};
     QString m_radioName;
     QString m_deviceName;
     std::uint16_t m_innerSeq = 0;
+    std::uint16_t m_tokenRequestId = 0;
     bool m_authOk = false;
-    // Token-renewal watchdog. The radio's session lasts 60 s and expires in
-    // silence, so a renewal has to be verified rather than assumed.
+    // Token-renewal watchdog. References renew at 60 s; a live IC-7300MK2
+    // expired a reconnect grant around 45 s and an established lease about
+    // 90 s after its last accepted token, both in silence.
     qint64 m_lastAuthOkMs = 0;   // when the radio last acknowledged an auth
     bool   m_renewUnacked = false;
+    bool   m_initialMaintenancePending = false;
     int    m_renewRetries = 0;
     static constexpr int kTokenRenewMaxRetries = 4;
+    static constexpr int kInitialMaintenanceRenewalMs = 30000;
+    QSet<quint16> m_pendingRenewals;
+    quint16 m_lastRenewalSeq = 0;
+    QString m_lastRenewalResult = QStringLiteral("not sent");
+    quint32 m_lastRenewalResponse = 0;
+    quint64 m_renewAcceptedCount = 0;
+    quint64 m_tokenReissuedCount = 0;
+    quint64 m_renewRejectedCount = 0;
+    quint64 m_ignoredAuthReplies = 0;
+    quint64 m_ignoredControlPackets = 0;
     bool m_haveRadioId = false;
     bool m_streamsRequested = false;
+    bool m_streamGranted = false;
     bool m_connected = false;
     // Re-entrancy guard: a teardown makes several streams fail at once, and
     // each one calling stop() again would delete objects mid-signal.

--- a/tests/IcomFakeRadio.h
+++ b/tests/IcomFakeRadio.h
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <limits>
 #include <map>
 #include <vector>
 
@@ -58,6 +59,11 @@ std::uint16_t getLe16(const QByteArray& b, int at)
 {
     return static_cast<std::uint16_t>(static_cast<std::uint8_t>(b[at])
                                       | (static_cast<std::uint8_t>(b[at + 1]) << 8));
+}
+std::uint16_t getBe16(const QByteArray& b, int at)
+{
+    return static_cast<std::uint16_t>((static_cast<std::uint8_t>(b[at]) << 8)
+                                      | static_cast<std::uint8_t>(b[at + 1]));
 }
 
 // One UDP endpoint of the fake radio. Handles the handshake and pings that are
@@ -188,6 +194,32 @@ public:
     [[nodiscard]] bool serialOpened() const { return m_serialOpened; }
     [[nodiscard]] bool sawUsernameObfuscated() const { return m_usernameObfuscated; }
     [[nodiscard]] int civCommandsSeen() const { return m_civCommands; }
+    [[nodiscard]] const std::vector<std::uint16_t>& renewalSequences() const
+    {
+        return m_renewalSequences;
+    }
+    [[nodiscard]] const std::vector<std::uint16_t>& deauthOuterSequences() const
+    {
+        return m_deauthOuterSequences;
+    }
+    [[nodiscard]] const std::vector<std::uint16_t>& loginTokenRequestIds() const
+    {
+        return m_loginTokenRequestIds;
+    }
+    [[nodiscard]] const std::vector<AuthId>& renewalAuthIds() const
+    {
+        return m_renewalAuthIds;
+    }
+    [[nodiscard]] const std::vector<AuthId>& streamRequestAuthIds() const
+    {
+        return m_streamRequestAuthIds;
+    }
+
+    // Lease fault injection used by IcomSession integration tests.
+    void setInjectStaleGrant(bool on) { m_injectStaleGrant = on; }
+    void setRejectRenewalsAfter(int accepted) { m_acceptRenewals = accepted; }
+    void setReissueInitialTokenOnNextLogin(bool on) { m_reissueNextInitialToken = on; }
+    void setAuthFailureOnLogin(bool on) { m_authFailureOnLogin = on; }
 
     // Every CI-V command the client sent, in order. Counting them says the link
     // is alive; keeping them is what lets a test assert that a particular
@@ -230,6 +262,21 @@ public:
         m_audio->send(p);
     }
 
+    // Push the auth-failure status seen when an old session tears down during
+    // a reconnect. With stale=false it belongs to the current session and must
+    // be fatal; with stale=true it must not kill the new media lease.
+    void pushAuthFailure(bool stale)
+    {
+        auto status = m_control->frame(kLenStatus, 0x00, m_seq++);
+        status[0x30] = status[0x31] = status[0x32] = 0xff;
+        status[0x40] = 0x01;
+        if (stale) {
+            putBe32(status, 0x08, 0xCCCC0001);
+            putBe32(status, 0x0c, 0xCCCC0002);
+        }
+        m_control->send(status);
+    }
+
 private:
     void control(FakeStream& s, const QByteArray& b)
     {
@@ -242,24 +289,71 @@ private:
             m_usernameObfuscated = std::equal(expect.begin(), expect.end(),
                                               reinterpret_cast<const std::uint8_t*>(b.constData())
                                                   + 0x40);
+            const std::uint16_t tokenRequestId = getLe16(b, 0x1a);
+            m_loginTokenRequestIds.push_back(tokenRequestId);
+            if (m_authFailureOnLogin) {
+                auto status = s.frame(kLenStatus, 0x00, m_seq++);
+                status[0x30] = status[0x31] = status[0x32] = status[0x33] = 0xff;
+                s.send(status);
+                return;
+            }
+            m_sentCaps = false;
+            m_reissueThisInitialToken = m_reissueNextInitialToken;
+            m_reissueNextInitialToken = false;
             auto reply = s.frame(0x60, 0x00, m_seq++);
             reply[0x14] = 0x02;
-            for (std::size_t i = 0; i < 6; ++i)
+            reply[0x1a] = static_cast<std::uint8_t>(tokenRequestId & 0xff);
+            reply[0x1b] = static_cast<std::uint8_t>((tokenRequestId >> 8) & 0xff);
+            for (std::size_t i = 2; i < 6; ++i) {
                 reply[0x1a + i] = static_cast<std::uint8_t>(0xC0 + i);
+            }
             s.send(reply);
             return;
         }
         case 0x40: {   // auth
             const auto kind = static_cast<std::uint8_t>(b[0x15]);
             ++m_authCount;
-            if (kind != 0x05)
+            if (kind == static_cast<std::uint8_t>(AuthKind::Deauth)) {
+                m_deauthOuterSequences.push_back(getLe16(b, 0x06));
+                return;
+            }
+            if (kind != 0x05) {
                 return;   // the FIRST auth gets no reply; only the token request does
+            }
+            const std::uint16_t innerSeq = getBe16(b, 0x16);
+            m_renewalSequences.push_back(innerSeq);
+            AuthId requestAuthId{};
+            for (std::size_t i = 0; i < requestAuthId.size(); ++i) {
+                requestAuthId[i] = static_cast<std::uint8_t>(b[0x1a + i]);
+            }
+            m_renewalAuthIds.push_back(requestAuthId);
             auto reply = s.frame(0x40, 0x00, m_seq++);
             reply[0x14] = 0x02;
             reply[0x15] = 0x05;
-            s.send(reply);
+            // A renewal reply correlates through both the 16-bit inner
+            // sequence and the current auth ID. Echoing neither used to let a
+            // client test pass while ignoring the fields the live radio uses.
+            for (int i = 0x16; i < 0x20; ++i)
+                reply[static_cast<std::size_t>(i)] = static_cast<std::uint8_t>(b[i]);
+            const bool accepted = m_acceptedRenewals < m_acceptRenewals;
+            if (m_reissueThisInitialToken) {
+                m_reissueThisInitialToken = false;
+                // Rotate the six-byte material so adopting the reissued token
+                // is load-bearing in the session test rather than a no-op.
+                for (std::size_t i = 0; i < requestAuthId.size(); ++i) {
+                    reply[0x1a + i] = static_cast<std::uint8_t>(0xF0 + i);
+                }
+                reply[0x30] = reply[0x31] = reply[0x32] = reply[0x33] = 0xff;
+            } else if (accepted) {
+                ++m_acceptedRenewals;
+            } else {
+                reply[0x30] = reply[0x31] = reply[0x32] = reply[0x33] = 0xff;
+            }
 
-            if (!m_sentCaps) {
+            auto sendCapabilities = [&] {
+                if (m_sentCaps) {
+                    return;
+                }
                 m_sentCaps = true;
                 auto caps = s.frame(0xA8, 0x00, m_seq++);
                 for (std::size_t i = 0; i < 16; ++i)
@@ -267,10 +361,30 @@ private:
                 const char* name = "IC-705";
                 std::copy(name, name + 6, caps.begin() + 0x52);
                 s.send(caps);
+            };
+            if (m_injectStaleGrant) {
+                // Reproduce the live reconnect race: capabilities, then an old
+                // grant, then this request's token reply. Normal fake-radio
+                // behavior below keeps its historical token-before-caps order.
+                sendCapabilities();
+                if (!m_sentPrematureGrant) {
+                    m_sentPrematureGrant = true;
+                    sendGrant(s, true);
+                }
+                s.send(reply);
+            } else {
+                s.send(reply);
+                sendCapabilities();
             }
             return;
         }
         case 0x90: {   // stream request
+            AuthId requestAuthId{};
+            for (std::size_t i = 0; i < requestAuthId.size(); ++i) {
+                requestAuthId[i] = static_cast<std::uint8_t>(b[0x1a + i]);
+            }
+            m_streamRequestAuthIds.push_back(requestAuthId);
+
             // Refuse unless the client echoed back the identity we published in
             // the capabilities packet. A real radio has to know WHICH radio the
             // client wants when a server fronts several.
@@ -286,13 +400,9 @@ private:
             m_announcedCiv   = getBe32(b, 0x7c);
             m_announcedAudio = getBe32(b, 0x80);
 
-            auto grant = s.frame(0x90, 0x00, m_seq++);
-            const char* name = "IC-705";
-            std::copy(name, name + 6, grant.begin() + 0x40);
-            for (std::size_t i = 0; i < 6; ++i)
-                grant[0x1a + i] = static_cast<std::uint8_t>(0xD0 + i);
-            grant[0x60] = 0x01;
-            s.send(grant);
+            if (m_injectStaleGrant)
+                sendGrant(s, true);
+            sendGrant(s, false);
             return;
         }
         default:
@@ -508,6 +618,21 @@ public:
 
 private:
 
+    void sendGrant(FakeStream& stream, bool stale)
+    {
+        auto grant = stream.frame(0x90, 0x00, m_seq++);
+        const char* name = "IC-705";
+        std::copy(name, name + 6, grant.begin() + 0x40);
+        for (std::size_t i = 0; i < 6; ++i)
+            grant[0x1a + i] = static_cast<std::uint8_t>((stale ? 0xE0 : 0xD0) + i);
+        grant[0x60] = 0x01;
+        if (stale) {
+            putBe32(grant, 0x08, 0xBBBB0001);
+            putBe32(grant, 0x0c, 0xBBBB0002);
+        }
+        stream.send(grant);
+    }
+
     void audio(FakeStream&, const QByteArray& b)
     {
         if (b.size() > 24 && static_cast<std::uint8_t>(b[0x10]) == 0x80)
@@ -529,6 +654,18 @@ private:
     int m_authCount = 0;
     int m_civCommands = 0;
     bool m_civSilent = false;
+    bool m_injectStaleGrant = false;
+    bool m_sentPrematureGrant = false;
+    bool m_reissueNextInitialToken = false;
+    bool m_reissueThisInitialToken = false;
+    bool m_authFailureOnLogin = false;
+    int m_acceptRenewals = std::numeric_limits<int>::max();
+    int m_acceptedRenewals = 0;
+    std::vector<std::uint16_t> m_renewalSequences;
+    std::vector<AuthId> m_renewalAuthIds;
+    std::vector<AuthId> m_streamRequestAuthIds;
+    std::vector<std::uint16_t> m_deauthOuterSequences;
+    std::vector<std::uint16_t> m_loginTokenRequestIds;
     int m_audioFromClient = 0;
     quint32 m_announcedCiv = 0;
     quint32 m_announcedAudio = 0;

--- a/tests/IcomFakeRadio.h
+++ b/tests/IcomFakeRadio.h
@@ -220,6 +220,14 @@ public:
     void setRejectRenewalsAfter(int accepted) { m_acceptRenewals = accepted; }
     void setReissueInitialTokenOnNextLogin(bool on) { m_reissueNextInitialToken = on; }
     void setAuthFailureOnLogin(bool on) { m_authFailureOnLogin = on; }
+    // The PREVIOUS session's teardown status, delivered on the new control
+    // association before this session has a stream grant to protect it. At
+    // that point the lifecycle exception does not apply yet, so the header
+    // IDs are the only thing separating it from a real login failure.
+    void setStaleAuthFailureBeforeLoginReply(bool on) { m_staleAuthFailureOnLogin = on; }
+    // Answer the next renewal with an inner sequence the client never sent.
+    // A client that acknowledges on packet shape alone accepts it anyway.
+    void setCorruptNextRenewalSequence(bool on) { m_corruptNextRenewalSeq = on; }
 
     // Every CI-V command the client sent, in order. Counting them says the link
     // is alive; keeping them is what lets a test assert that a particular
@@ -297,6 +305,10 @@ private:
                 s.send(status);
                 return;
             }
+            if (m_staleAuthFailureOnLogin) {
+                m_staleAuthFailureOnLogin = false;
+                pushAuthFailure(true);
+            }
             m_sentCaps = false;
             m_reissueThisInitialToken = m_reissueNextInitialToken;
             m_reissueNextInitialToken = false;
@@ -335,6 +347,15 @@ private:
             // client test pass while ignoring the fields the live radio uses.
             for (int i = 0x16; i < 0x20; ++i)
                 reply[static_cast<std::size_t>(i)] = static_cast<std::uint8_t>(b[i]);
+            if (m_corruptNextRenewalSeq) {
+                m_corruptNextRenewalSeq = false;
+                // Well-formed in every other respect — right shape, right auth
+                // ID, zero response — so the outstanding-request set is the
+                // only thing that can reject it.
+                const auto bogus = static_cast<std::uint16_t>(innerSeq + 0x4000);
+                reply[0x16] = static_cast<std::uint8_t>((bogus >> 8) & 0xff);
+                reply[0x17] = static_cast<std::uint8_t>(bogus & 0xff);
+            }
             const bool accepted = m_acceptedRenewals < m_acceptRenewals;
             if (m_reissueThisInitialToken) {
                 m_reissueThisInitialToken = false;
@@ -659,6 +680,8 @@ private:
     bool m_reissueNextInitialToken = false;
     bool m_reissueThisInitialToken = false;
     bool m_authFailureOnLogin = false;
+    bool m_staleAuthFailureOnLogin = false;
+    bool m_corruptNextRenewalSeq = false;
     int m_acceptRenewals = std::numeric_limits<int>::max();
     int m_acceptedRenewals = 0;
     std::vector<std::uint16_t> m_renewalSequences;

--- a/tests/icom_backend_test.cpp
+++ b/tests/icom_backend_test.cpp
@@ -865,6 +865,40 @@ int main(int argc, char** argv)
         check(!h.values.contains(QStringLiteral("patemp")),
               "no PA temperature key, because the radio does not report one");
         check(h.values.contains(QStringLiteral("model")), "the resolved model is reported");
+        check(h.values.contains(QStringLiteral("lease"))
+                  && h.values.value(QStringLiteral("lease")).toString().contains(
+                      QStringLiteral("authenticated")),
+              "health separates the authenticated RS-BA1 lease from UDP link liveness");
+        check(h.values.contains(QStringLiteral("leaseseq"))
+                  && h.values.contains(QStringLiteral("leasecounts")),
+              "health exposes renewal sequence and reply counters");
+
+        QVariant leaseResult;
+        bool leaseAnswered = false;
+        auto leaseConn = QObject::connect(
+            &backend, &IRadioBackend::extensionResult, &app,
+            [&](quint64 id, const QVariant& result) {
+                if (id == 7300) {
+                    leaseAnswered = true;
+                    leaseResult = result;
+                }
+            });
+        backend.invokeExtension(QStringLiteral("icom"), QStringLiteral("civ.session"),
+                                7300, {});
+        QObject::disconnect(leaseConn);
+        const QVariantMap lease = leaseResult.toMap();
+        check(leaseAnswered && lease.value(QStringLiteral("authenticated")).toBool(),
+              "civ.session synchronously returns the live authenticated lease");
+        check(lease.value(QStringLiteral("lastRenewalResponse")).toString()
+                  == QStringLiteral("0x00000000"),
+              "civ.session preserves the protocol response word for troubleshooting");
+        check(lease.value(QStringLiteral("tokenRequestId")).toString().startsWith(
+                  QStringLiteral("0x")),
+              "civ.session exposes the per-login token-request correlation ID");
+        check(lease.contains(QStringLiteral("reissuedTokens")),
+              "civ.session distinguishes reconnect token reissue from renewal rejection");
+        check(lease.value(QStringLiteral("initialMaintenanceMs")).toInt() == 30000,
+              "civ.session exposes the one-time early maintenance window");
     }
 
     // An operator disconnect while TUNE is active must unkey and restore the

--- a/tests/icom_protocol_test.cpp
+++ b/tests/icom_protocol_test.cpp
@@ -122,6 +122,8 @@ static void testLoginAndAuth()
     check(login.size() == kLenLogin, "login is 128 bytes");
     check(login[0x14] == 0x01, "requestreply is 0x01");
     check(login[0x15] == 0x00, "login requesttype is 0x00");
+    check(login[0x1a] == 0xef && login[0x1b] == 0xbe,
+          "login carries the caller's little-endian token-request ID");
     check(std::memcmp(login.data() + 0x60, "icom-pc", 7) == 0,
           "the client name is PLAIN TEXT while the credentials are not");
     const auto user = encodePasscode("beer");
@@ -148,14 +150,44 @@ static void testLoginAndAuth()
     auto auth = buildAuth(1, 2, 4, id, AuthKind::Renew);
     check(auth.size() == kLenToken, "auth is 64 bytes");
     check(auth[0x15] == 0x05, "renew is requesttype 0x05");
+    check(auth[0x16] == 0x00 && auth[0x17] == 0x04,
+          "the inner sequence is a big-endian u16 at 0x16");
     check(std::equal(id.begin(), id.end(), auth.begin() + 0x1a), "auth id is echoed at 0x1a");
+
+    const auto seq255 = buildAuth(1, 2, 0x00ff, id, AuthKind::Renew);
+    const auto seq256 = buildAuth(1, 2, 0x0100, id, AuthKind::Renew);
+    check(seq255[0x16] == 0x00 && seq255[0x17] == 0xff,
+          "inner sequence 255 ends the one-byte-compatible range");
+    check(seq256[0x16] == 0x01 && seq256[0x17] == 0x00 && seq256[0x18] == 0x00
+              && std::equal(id.begin(), id.end(), seq256.begin() + 0x1a),
+          "inner sequence 256 stays in its two-byte field and does not shift into auth id");
 
     auto accepted = auth;
     accepted[0x14] = 0x02;   // reply marker
-    check(isAuthAccepted(accepted), "a 0x02/0x05 reply gates the streams");
+    const AuthReply acceptedReply = parseAuthReply(accepted);
+    check(acceptedReply.result == AuthReplyResult::Accepted,
+          "a zero-response 0x02/0x05 reply gates the streams");
+    check(acceptedReply.innerSeq == 4, "the accepted reply carries its correlation sequence");
+
+    auto rejected = accepted;
+    rejected[0x30] = rejected[0x31] = rejected[0x32] = rejected[0x33] = 0xff;
+    const AuthReply rejectedReply = parseAuthReply(rejected);
+    check(rejectedReply.result == AuthReplyResult::Nonzero,
+          "0xffffffff is a nonzero reply whose meaning requires session context");
+    check(rejectedReply.response == 0xffffffffU,
+          "the rejected response word is preserved for diagnostics");
+
+    auto diagnostic = accepted;
+    diagnostic[0x30] = 0x78;
+    diagnostic[0x31] = 0x56;
+    diagnostic[0x32] = 0x34;
+    diagnostic[0x33] = 0x12;
+    check(parseAuthReply(diagnostic).response == 0x12345678U,
+          "a non-palindromic response proves the diagnostic word is little-endian");
+
     auto firstAuthReply = accepted;
     firstAuthReply[0x15] = 0x02;
-    check(!isAuthAccepted(firstAuthReply),
+    check(parseAuthReply(firstAuthReply).result == AuthReplyResult::NotRenewal,
           "the FIRST auth's reply must not be mistaken for the token grant");
 }
 

--- a/tests/icom_session_test.cpp
+++ b/tests/icom_session_test.cpp
@@ -377,6 +377,169 @@ int main(int argc, char** argv)
         rejectingSession.stop();
     }
 
+    // ---- The previous session's teardown arrives BEFORE this one's grant ---
+    //
+    // The post-grant lifecycle exception cannot help here: at login time there
+    // is no grant and no accepted token, so a 0x50 sentinel is indistinguishable
+    // from a real credential failure by lifecycle alone. Only the header IDs
+    // separate them, which is the reconnect race this PR exists for.
+    {
+        FakeIc705 lateTeardownRadio;
+        lateTeardownRadio.setStaleAuthFailureBeforeLoginReply(true);
+        IcomSession lateTeardownSession;
+        QString lateTeardownName;
+        QString lateTeardownReason;
+        QObject::connect(&lateTeardownSession, &IcomSession::connected, &app,
+                         [&](const QString& name) { lateTeardownName = name; });
+        QObject::connect(&lateTeardownSession, &IcomSession::disconnected, &app,
+                         [&](const QString& reason) { lateTeardownReason = reason; });
+
+        IcomSession::Params lateTeardownParams = p;
+        lateTeardownParams.controlPort = lateTeardownRadio.controlPort();
+        lateTeardownParams.serialPort = lateTeardownRadio.serialPort();
+        lateTeardownParams.audioPort = lateTeardownRadio.audioPort();
+        check(lateTeardownSession.start(lateTeardownParams),
+              "pre-grant stale-teardown session starts");
+        check(waitFor([&] { return !lateTeardownName.isEmpty(); }),
+              "a previous session's auth-failure status arriving before this session's "
+              "grant does not abort the login");
+        check(lateTeardownReason.isEmpty(),
+              "the stale pre-grant sentinel raises no disconnect reason");
+        check(lateTeardownSession.leaseDiagnostics()
+                      .value(QStringLiteral("ignoredControlPackets")).toULongLong() >= 1,
+              "the stale pre-grant sentinel is counted rather than silently dropped");
+        lateTeardownSession.stop();
+    }
+
+    // ---- A reply for a sequence we never sent is not an acknowledgement -----
+    {
+        FakeIc705 miscorrelatedRadio;
+        IcomSession miscorrelatedSession;
+        QString miscorrelatedName;
+        QObject::connect(&miscorrelatedSession, &IcomSession::connected, &app,
+                         [&](const QString& name) { miscorrelatedName = name; });
+
+        IcomSession::Params miscorrelatedParams = p;
+        miscorrelatedParams.controlPort = miscorrelatedRadio.controlPort();
+        miscorrelatedParams.serialPort = miscorrelatedRadio.serialPort();
+        miscorrelatedParams.audioPort = miscorrelatedRadio.audioPort();
+        miscorrelatedParams.tokenRenewalMs = 200;
+        miscorrelatedParams.tokenAckGraceMs = 10;
+        miscorrelatedParams.tokenDeadMs = 5000;
+        check(miscorrelatedSession.start(miscorrelatedParams),
+              "renewal-correlation session starts");
+        check(waitFor([&] { return !miscorrelatedName.isEmpty(); }),
+              "the correlation session connects normally");
+
+        const qulonglong ignoredBefore = miscorrelatedSession.leaseDiagnostics()
+                                             .value(QStringLiteral("ignoredAuthReplies"))
+                                             .toULongLong();
+        const qulonglong acceptedBefore = miscorrelatedSession.leaseDiagnostics()
+                                              .value(QStringLiteral("acceptedRenewals"))
+                                              .toULongLong();
+        miscorrelatedRadio.setCorruptNextRenewalSequence(true);
+        check(waitFor([&] {
+                  return miscorrelatedSession.leaseDiagnostics()
+                             .value(QStringLiteral("ignoredAuthReplies")).toULongLong()
+                      > ignoredBefore;
+              }, 2000),
+              "a token reply carrying an unsent inner sequence is rejected, not "
+              "acknowledged on packet shape alone");
+        check(miscorrelatedSession.leaseDiagnostics()
+                      .value(QStringLiteral("acceptedRenewals")).toULongLong()
+                  == acceptedBefore,
+              "the uncorrelated reply does not advance the accepted-renewal count");
+        // The renewal it failed to acknowledge is still outstanding, so the
+        // watchdog must resend rather than coast to the dead-session deadline.
+        check(waitFor([&] {
+                  return miscorrelatedSession.leaseDiagnostics()
+                             .value(QStringLiteral("acceptedRenewals")).toULongLong()
+                      > acceptedBefore;
+              }, 2000),
+              "the unacknowledged renewal is resent and the session recovers");
+        check(miscorrelatedSession.isConnected(),
+              "an uncorrelated reply costs a retry, not the session");
+        miscorrelatedSession.stop();
+    }
+
+    // ---- The one-time early maintenance renewal actually fires early -------
+    //
+    // Asserting initialMaintenancePending only proves the flag was set. This
+    // drives the timing: the first maintenance renewal must land well inside
+    // the steady cadence, and the session must then fall back to that cadence.
+    {
+        FakeIc705 earlyRadio;
+        IcomSession earlySession;
+        QString earlyName;
+        QObject::connect(&earlySession, &IcomSession::connected, &app,
+                         [&](const QString& name) { earlyName = name; });
+
+        IcomSession::Params earlyParams = p;
+        earlyParams.controlPort = earlyRadio.controlPort();
+        earlyParams.serialPort = earlyRadio.serialPort();
+        earlyParams.audioPort = earlyRadio.audioPort();
+        earlyParams.tokenRenewalMs = 2000;      // the steady cadence
+        earlyParams.initialMaintenanceMs = 60;  // the one-time early window
+        earlyParams.tokenAckGraceMs = 10;
+        earlyParams.tokenDeadMs = 10000;
+        check(earlySession.start(earlyParams), "early-maintenance session starts");
+        check(waitFor([&] { return !earlyName.isEmpty(); }),
+              "the early-maintenance session connects");
+        const std::size_t renewalsAtConnect = earlyRadio.renewalSequences().size();
+        check(earlySession.leaseDiagnostics()
+                      .value(QStringLiteral("initialMaintenancePending")).toBool(),
+              "an initial login schedules the one-time early maintenance renewal");
+        // 500 ms is a quarter of the steady cadence: only the early window can
+        // produce a renewal inside it.
+        check(waitFor([&] {
+                  return earlyRadio.renewalSequences().size() > renewalsAtConnect;
+              }, 500),
+              "the early maintenance renewal is sent well inside the steady cadence");
+        check(!earlySession.leaseDiagnostics()
+                       .value(QStringLiteral("initialMaintenancePending")).toBool(),
+              "the early window is one-time — the next renewal uses the steady cadence");
+        check(earlySession.leaseDiagnostics()
+                      .value(QStringLiteral("initialMaintenanceMs")).toInt() == 60,
+              "civ.session reports the early window actually in force");
+        earlySession.stop();
+    }
+
+    // ---- An unconfigured session randomizes its own token-request ID -------
+    //
+    // The checks above all pass the ID explicitly, so they would still pass if
+    // production reverted to the fixed 0x0000 that the live IC-7300MK2 rejected
+    // on an immediate reconnect. This drives the default path instead.
+    {
+        FakeIc705 randomRadio;
+        IcomSession::Params randomParams = p;
+        randomParams.controlPort = randomRadio.controlPort();
+        randomParams.serialPort = randomRadio.serialPort();
+        randomParams.audioPort = randomRadio.audioPort();
+        randomParams.tokenRequestId = 0;  // the production default
+
+        for (int i = 0; i < 3; ++i) {
+            IcomSession randomSession;
+            QString randomName;
+            QObject::connect(&randomSession, &IcomSession::connected, &app,
+                             [&](const QString& name) { randomName = name; });
+            check(randomSession.start(randomParams), "default-identity session starts");
+            check(waitFor([&] { return !randomName.isEmpty(); }),
+                  "a session with no configured token-request ID still connects");
+            randomSession.stop();
+        }
+
+        const std::vector<std::uint16_t>& ids = randomRadio.loginTokenRequestIds();
+        check(ids.size() == 3, "three default-identity logins were observed");
+        check(std::none_of(ids.begin(), ids.end(),
+                           [](std::uint16_t id) { return id == 0; }),
+              "an unconfigured login never reuses the rejected 0x0000 request ID");
+        // Three independent 16-bit draws collide entirely with probability
+        // ~2e-10, so this is a randomness check rather than a flake.
+        check(!std::all_of(ids.begin(), ids.end(),
+                           [&](std::uint16_t id) { return id == ids.front(); }),
+              "consecutive unconfigured logins draw fresh token-request identities");
+    }
+
     if (g_failures == 0)
         std::printf("icom_session_test: all checks passed\n");
     return g_failures == 0 ? 0 : 1;

--- a/tests/icom_session_test.cpp
+++ b/tests/icom_session_test.cpp
@@ -74,6 +74,7 @@ int main(int argc, char** argv)
     p.username = QStringLiteral("beer");
     p.password = QStringLiteral("beerbeer");
     p.civAddress = kIc705Addr;
+    p.tokenRequestId = 0x1234;
 
     check(session.start(p), "session starts");
 
@@ -90,6 +91,9 @@ int main(int argc, char** argv)
     check(radio.authCount() >= 2,
           "BOTH auths are sent — the first establishes the session, the second requests "
           "the token that gates the media streams");
+    check(radio.loginTokenRequestIds().size() == 1
+              && radio.loginTokenRequestIds().front() == 0x1234,
+          "the login carries this session's unique token-request ID");
     // WAITED FOR, not asserted instantly. The session emits connected() from
     // onSerialReady immediately after writing the serial-open datagram, so the
     // fake radio has not necessarily read it yet when waitFor returns. Asserting
@@ -194,6 +198,184 @@ int main(int argc, char** argv)
     // ---- Teardown ----------------------------------------------------------
     session.stop();
     check(!session.isConnected(), "stop() tears the session down");
+    check(waitFor([&] { return radio.deauthOuterSequences().size() >= 2; }),
+          "teardown sends the RS-BA1 deauthentication twice");
+    const std::vector<std::uint16_t>& deauthSeqs = radio.deauthOuterSequences();
+    check(deauthSeqs.size() >= 2 && deauthSeqs[0] != 0 && deauthSeqs[1] != 0
+              && deauthSeqs[0] != deauthSeqs[1],
+          "each deauthentication has a distinct nonzero tracked outer sequence");
+
+    // A reconnect is a new login identity, not a replay of token request zero.
+    // The live IC-7300MK2 accepts the login itself but rejects the first token
+    // with 0xffffffff when that request ID is reused.
+    {
+        const std::size_t authRequestsBeforeReconnect = radio.renewalAuthIds().size();
+        IcomSession reconnectSession;
+        QString reconnectName;
+        QObject::connect(&reconnectSession, &IcomSession::connected, &app,
+                         [&](const QString& name) { reconnectName = name; });
+        IcomSession::Params reconnectParams = p;
+        reconnectParams.tokenRequestId = 0x1235;
+        reconnectParams.tokenRenewalMs = 200;
+        reconnectParams.tokenAckGraceMs = 10;
+        reconnectParams.tokenDeadMs = 1000;
+        radio.setReissueInitialTokenOnNextLogin(true);
+        check(reconnectSession.start(reconnectParams), "reconnect session starts");
+        check(waitFor([&] { return !reconnectName.isEmpty(); }),
+              "a reissued reconnect token continues through the full media handshake");
+        check(radio.loginTokenRequestIds().size() >= 2
+                  && radio.loginTokenRequestIds()[0] != radio.loginTokenRequestIds()[1],
+              "consecutive sessions do not reuse their token-request identity");
+        const QVariantMap reconnectDiagnostics = reconnectSession.leaseDiagnostics();
+        check(reconnectDiagnostics.value(QStringLiteral("lastRenewalResult")).toString()
+                  == QStringLiteral("reissued")
+                  && reconnectDiagnostics.value(QStringLiteral("reissuedTokens")).toULongLong()
+                      == 1,
+              "the nonzero initial reply is identified as a reissued token, not a renewal");
+        check(reconnectDiagnostics.value(
+                  QStringLiteral("initialMaintenancePending")).toBool()
+                  && reconnectDiagnostics.value(QStringLiteral("initialMaintenanceMs")).toInt()
+                      == 30000,
+              "a reconnect schedules one early maintenance renewal before steady cadence");
+        const AuthId reissuedAuthId{0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5};
+        check(!radio.streamRequestAuthIds().empty()
+                  && radio.streamRequestAuthIds().back() == reissuedAuthId,
+              "the stream request carries the radio's rotated reissue token");
+        check(waitFor([&] {
+                  return radio.renewalAuthIds().size() >= authRequestsBeforeReconnect + 2;
+              }, 1000),
+              "the reissued session reaches its first maintenance renewal");
+        const AuthId currentGrantAuthId{0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5};
+        check(!radio.renewalAuthIds().empty()
+                  && radio.renewalAuthIds().back() == currentGrantAuthId,
+              "the next renewal carries the later correlated grant token");
+        reconnectSession.stop();
+    }
+
+    // ---- Lease correlation: stale grants never open media -----------------
+    {
+        FakeIc705 staleRadio;
+        staleRadio.setInjectStaleGrant(true);
+        IcomSession staleSession;
+        QString staleConnected;
+        QObject::connect(&staleSession, &IcomSession::connected, &app,
+                         [&](const QString& name) { staleConnected = name; });
+
+        IcomSession::Params staleParams = p;
+        staleParams.controlPort = staleRadio.controlPort();
+        staleParams.serialPort = staleRadio.serialPort();
+        staleParams.audioPort = staleRadio.audioPort();
+        staleParams.tokenRenewalMs = 200;
+        staleParams.tokenAckGraceMs = 10;
+        staleParams.tokenDeadMs = 1000;
+        check(staleSession.start(staleParams), "stale-grant session starts");
+        check(waitFor([&] { return !staleConnected.isEmpty(); }),
+              "a stale grant is ignored and the current-session grant still connects");
+        const QVariantMap diagnostics = staleSession.leaseDiagnostics();
+        check(diagnostics.value(QStringLiteral("streamGranted")).toBool(),
+              "only a correlated grant marks the stream granted");
+        check(diagnostics.value(QStringLiteral("ignoredControlPackets")).toULongLong() >= 2,
+              "premature and wrong-session grants are counted for diagnostics");
+        const AuthId currentGrantAuthId{0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5};
+        check(waitFor([&] { return staleRadio.renewalAuthIds().size() >= 2; }, 1000),
+              "the granted session reaches its first maintenance renewal");
+        check(!staleRadio.renewalAuthIds().empty()
+                  && staleRadio.renewalAuthIds().back() == currentGrantAuthId,
+              "the renewal adopts the correlated grant, never the stale grant's token");
+        staleRadio.pushAuthFailure(true);
+        check(waitFor([&] {
+                  return staleSession.leaseDiagnostics()
+                             .value(QStringLiteral("ignoredControlPackets")).toULongLong() >= 3;
+              }, 100),
+              "the stale teardown is visible in diagnostics");
+        check(staleSession.isConnected(),
+              "a previous session's auth-failure status cannot kill the current lease");
+
+        const qulonglong ignoredBeforeLateCurrent = staleSession.leaseDiagnostics()
+                                                         .value(QStringLiteral(
+                                                             "ignoredControlPackets"))
+                                                         .toULongLong();
+        staleRadio.pushAuthFailure(false);
+        check(waitFor([&] {
+                  return staleSession.leaseDiagnostics()
+                             .value(QStringLiteral("ignoredControlPackets"))
+                             .toULongLong()
+                      > ignoredBeforeLateCurrent;
+              }, 100),
+              "the late teardown is visible even when stamped with current session IDs");
+        check(staleSession.isConnected(),
+              "a post-grant auth-failure sentinel cannot kill a working reconnect");
+        staleSession.stop();
+    }
+
+    // The lifecycle exception above is not a blanket suppression: a current
+    // 0x50 failure before a correlated stream grant is a real login failure.
+    {
+        FakeIc705 failedLoginRadio;
+        failedLoginRadio.setAuthFailureOnLogin(true);
+        IcomSession failedLoginSession;
+        QString failedLoginReason;
+        QObject::connect(&failedLoginSession, &IcomSession::disconnected, &app,
+                         [&](const QString& reason) { failedLoginReason = reason; });
+
+        IcomSession::Params failedLoginParams = p;
+        failedLoginParams.controlPort = failedLoginRadio.controlPort();
+        failedLoginParams.serialPort = failedLoginRadio.serialPort();
+        failedLoginParams.audioPort = failedLoginRadio.audioPort();
+        check(failedLoginSession.start(failedLoginParams),
+              "pre-grant auth-failure session starts");
+        check(waitFor([&] { return !failedLoginReason.isEmpty(); }),
+              "a current-session auth failure before the stream grant is fatal");
+        check(failedLoginReason.contains(QStringLiteral("authentication failed")),
+              "the pre-grant failure retains its actionable reason");
+        failedLoginSession.stop();
+    }
+
+    // ---- Lease rejection: fail fast instead of staying falsely green ------
+    {
+        FakeIc705 rejectingRadio;
+        rejectingRadio.setRejectRenewalsAfter(1);  // initial token only
+        IcomSession rejectingSession;
+        QString rejectedReason;
+        QVariantMap rejectedDiagnostics;
+        QObject::connect(&rejectingSession, &IcomSession::disconnected, &app,
+                         [&](const QString& reason) {
+                             rejectedReason = reason;
+                             // disconnected() precedes deferred teardown, so
+                             // the failure evidence is still available here.
+                             rejectedDiagnostics = rejectingSession.leaseDiagnostics();
+                         });
+
+        IcomSession::Params rejectingParams = p;
+        rejectingParams.controlPort = rejectingRadio.controlPort();
+        rejectingParams.serialPort = rejectingRadio.serialPort();
+        rejectingParams.audioPort = rejectingRadio.audioPort();
+        rejectingParams.tokenRenewalMs = 20;
+        rejectingParams.tokenAckGraceMs = 5;
+        rejectingParams.tokenDeadMs = 100;
+        check(rejectingSession.start(rejectingParams), "renewal-rejection session starts");
+        check(waitFor([&] { return rejectingSession.isConnected(); }),
+              "initial accepted token opens the session");
+        check(waitFor([&] { return !rejectedReason.isEmpty(); }, 1000),
+              "a rejected scheduled renewal disconnects before lease expiry");
+        check(rejectedReason.contains(QStringLiteral("rejected RS-BA1 session renewal")),
+              "disconnect reports the rejected renewal rather than a generic stream stall");
+        check(rejectedDiagnostics.value(QStringLiteral("lastRenewalResult")).toString()
+                  == QStringLiteral("rejected"),
+              "lease diagnostics preserve the protocol-level rejection");
+        check(rejectedDiagnostics.value(QStringLiteral("rejectedRenewals")).toULongLong() == 1,
+              "the rejected renewal is counted exactly once");
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
+        check(rejectingSession.leaseDiagnostics()
+                      .value(QStringLiteral("lastRenewalResult")).toString()
+                  == QStringLiteral("rejected"),
+              "deferred teardown preserves the rejection for civ.session diagnostics");
+        check(rejectingRadio.renewalSequences().size() >= 2
+                  && rejectingRadio.renewalSequences()[0]
+                      != rejectingRadio.renewalSequences()[1],
+              "initial and scheduled renewals carry distinct correlation sequences");
+        rejectingSession.stop();
+    }
 
     if (g_failures == 0)
         std::printf("icom_session_test: all checks passed\n");


### PR DESCRIPTION
## Summary

- encode the RS-BA1 inner request sequence as the big-endian 16-bit field the IC-7300MK2 accepts across the 255 to 256 boundary
- correlate token replies, stream grants, and auth failures to the current session and outstanding request
- use a fresh random nonzero token-request ID per login and send teardown deauth packets through the tracked outer-sequence path
- treat an initial reconnect `0xffffffff` response as a token reissue, while retaining the same response as a rejection for an established lease renewal
- renew once at 30 seconds after login, then return to the wfview/kappanhang 60-second cadence with 3-second acknowledgement recovery and an 80-second dead-session limit
- expose credential-free lease state through `civ session`, backend health, and structured logs
- expand the fake radio and protocol/session/backend tests for reconnect, reissue, teardown, rejection, stale packets, correlation, and the 16-bit boundary

## Root cause

The frozen panadapter was a media-lease failure, not a renderer failure. Serial CI-V and audio stopped together while the outer RS-BA1 control socket still appeared healthy.

The investigation found several compounding protocol defects:

1. AetherSDR encoded the inner renewal sequence using a shifted little-endian field beginning at offset `0x17`. That is accidentally byte-identical only through sequence 255; sequence 256 overwrites the next byte. The live radio returned `0xffffffff` at that boundary.
2. The parser treated a token-shaped `0x40` reply as success without validating its response word, outstanding sequence, auth material, and current session IDs.
3. Teardown sent raw deauth packets with outer sequence zero. A radio whose receive sequence had advanced could discard them and retain the old lease during an immediate reconnect.
4. Every login reused token-request ID zero. wfview and kappanhang both generate fresh request material.
5. On immediate reconnect, the IC-7300MK2 can return `0xffffffff` to the initial request while supplying the token needed for the stream request. That is a reissue in initial-login context, but remains a rejection during an established renewal.
6. A live immediate-reconnect media grant stopped around 45 seconds, before the ordinary 60-second maintenance request. One early renewal at 30 seconds keeps that first window alive, after which the normal 60-second cadence is stable.

## Diagnostics and automation

`civ session` now reports:

- authentication, stream-request, grant, and connected state
- the per-login token-request ID
- initial-maintenance timing and pending state
- last and next inner sequence
- response word and accepted-token age
- pending/retry, accepted/reissued/rejected, and stale-packet counters
- renewal, acknowledgement-grace, and dead-session timing

The same lease summary is visible in backend health under **RS-BA1 session**. Routine raw RS-BA1 packet logging remains off by default; the structured logs contain no credentials or auth IDs. Failure evidence survives deferred teardown so automation can inspect the actual terminal state.

## Live IC-7300MK2 proof

Local AetherSDR automation proof used the IC-7300MK2 at `192.168.1.90` with transmit disabled:

- fresh login request ID `0x7ac9`; initial grant accepted; audio, spectrum, and meters live with zero packet loss
- immediate disconnect/reconnect request ID `0x1549`; radio connected with a slice and panadapter, proving per-login request identity and tracked teardown
- after the one-time 30-second maintenance boundary: accepted count advanced to 2, `initialMaintenancePending` cleared, audio/spectrum/meter ages were 17/17/17 ms, and packet loss remained zero
- two rendered SpectrumWidget captures five seconds apart had different SHA-256 hashes (`9268719e...` and `ab3df2727...`), proving the visible panadapter was changing
- after the following steady 60-second renewal: accepted count advanced to 3; audio and spectrum ages were 0 ms, meter age 33 ms, and 30,041 RX packets had zero loss
- RX S-level, supply voltage, and overflow meters remained live; transmit-only power/SWR/ALC/current meters correctly remained idle because this was a no-TX proof

## Validation

- RelWithDebInfo app build passed with exactly `-j22`
- final unrestricted focused run: `icom_protocol_test`, `icom_session_test`, and `icom_backend_test` passed 3/3
- strict engine-boundary check passed with no new seam violations
- automation bridge documentation generator check passed
- `git diff --check` passed
- a full headless rerun was stopped after the unchanged `hl2_backend_test` hung for more than five minutes; the maintainer explicitly approved ignoring that unrelated HL2 host-baseline failure

## Scope and seams

All radio wire behavior remains under `src/core/backends/icom`. The only above-backend production change extends the existing vendor-neutral automation dispatcher. No FlexRadio or HL2 production or test source is changed.

Generated with OpenAI Codex (Daybreak Blue)
