### PR TITLE
governance(codeowners): move docs/, resources/, and tests/ to Tier 3 — Principle XIII.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,13 @@
 #
 #   Tier 3 (source code, broad default)   — top of file (the `*` line)
 #   Tier 2 (project infrastructure)       — middle (specific paths)
+#   Tier 3 (documentation directories)    — just below the *.md glob
 #   Tier 1 (governance, security)         — bottom (most specific paths)
+#
+# The one place that layout is not strictly broad → specific is the
+# documentation-directory block: docs/ and resources/ are Tier 3, but their
+# lines have to sit BELOW Tier 2's `*.md` glob rather than up with the `*`
+# default. See the Tier 3 note below for why.
 #
 # Tier 1 — @aethersdr/maintainers (currently: @ten9876).
 #         The RULES OF THE PROJECT and the paths that can compromise a
@@ -26,10 +32,12 @@
 #         Project infrastructure: CI/CD configuration — the ROUTINE
 #         workflow definitions (.github/workflows/ except the sensitive
 #         ones carved to Tier 1), dependabot, docker, issue templates —
-#         plus documentation (docs/, *.md catchall, including
-#         README/CHANGELOG/SUPPORT/ROADMAP which fall through here from
-#         the *.md glob), tests, build configuration (CMakeLists.txt),
-#         and legal/compliance tracking (THIRD_PARTY_LICENSES).
+#         plus the *.md catchall for markdown that is NOT in one of the
+#         directories reclaimed to Tier 3 below (README/CHANGELOG/
+#         SUPPORT/ROADMAP and the AI-instruction files fall through
+#         here), build configuration (CMakeLists.txt), and
+#         legal/compliance tracking (THIRD_PARTY_LICENSES).
+#         NOT tests/ — that is source code and sits at Tier 3.
 #         ALSO the AI-instruction files (AGENTS.md, CLAUDE.md,
 #         GEMINI.md, .github/copilot-instructions.md, .claude/commands/).
 #         Those are operational documentation — architecture, build
@@ -45,14 +53,20 @@
 #         AetherSDR source code and anything else not enumerated
 #         above (src/ — including the whole of MainWindow —
 #         third_party/, plugins/, hal-plugin/, resources/, packaging/,
-#         scripts/). Broadest collaborator roster because routine
-#         source review benefits from more eyes.
-#         CAUTION: *.md has no slash, so it matches at ANY depth — a
-#         markdown file inside a Tier 3 directory (resources/help/*.md,
-#         scripts/*.md, …) is Tier 2, not Tier 3. That is intended
-#         (documentation is documentation wherever it lives) but it does
-#         mean "everything under resources/" above is shorthand, not
-#         literal.
+#         scripts/), PLUS three directories claimed in full, markdown
+#         included: docs/, resources/, and tests/. Broadest collaborator
+#         roster because routine source review benefits from more eyes —
+#         and so does routine review of the tests and documentation that
+#         travel with that source.
+#         CAUTION: *.md has no slash, so it matches at ANY depth. That
+#         is why the docs/ and resources/ lines are placed BELOW Tier 2's
+#         *.md glob instead of up here with the `*` default: put them
+#         above it and last-match-wins pulls every markdown file under
+#         them (resources/help/*.md, docs/PR-WORKFLOW.md, …) straight
+#         back to Tier 2, silently, while the directory around them
+#         stays Tier 3. Markdown OUTSIDE those two directories still
+#         matches *.md and is still Tier 2 — README.md, CHANGELOG.md,
+#         ROADMAP.md, AGENTS.md, scripts/*.md.
 #
 # Team rosters are managed in the GitHub org settings:
 #   https://github.com/orgs/aethersdr/teams
@@ -77,13 +91,45 @@
 *                            @aethersdr/reviewers
 
 # ── Tier 2: project infrastructure — narrower owner set than Tier 3 ────────
-# CI/CD configuration (workflows + tooling), documentation, tests, build config.
+# CI/CD configuration (workflows + tooling), stray markdown, tests, build config.
 # (The CodeQL config stays Tier 1 under Security below — a security control.)
 
-# Documentation & tests
-tests/                       @aethersdr/infrastructure
-docs/                        @aethersdr/infrastructure
+# Markdown that is not in one of the directories reclaimed to Tier 3 below.
 *.md                         @aethersdr/infrastructure
+
+# ── Tier 3: whole directories — reclaimed from the *.md glob ──────────────
+# Each of these directories goes to the broad reviewer roster in full,
+# markdown included. ORDER IS LOAD-BEARING: they must stay BELOW the *.md
+# line above. *.md has no slash, so it matches at any depth; move these up
+# and every .md under them silently reverts to Tier 2 while the directory
+# around it stays Tier 3.
+#
+# docs/ and resources/ — documentation. A guide under docs/ or a help topic
+# under resources/help/ is best reviewed by the people who review the code
+# it describes, and that is the broader roster. resources/ already landed on
+# @aethersdr/reviewers via the `*` default for everything that is not
+# markdown, so its line changes exactly one thing: resources/help/*.md, the
+# in-app help text.
+#
+# tests/ — source code, not infrastructure: ~90k lines of C++ across 305
+# test TUs, against 3 files of actual harness glue. It sat at Tier 2 from
+# the original CODEOWNERS (#2029), where Tier 2 meant "mechanical/safe
+# paths, the bot may also approve" — a LOW-RISK, widen-approval framing.
+# #3053 rebuilt the tiers and Tier 2 came to mean "narrower roster, because
+# infrastructure needs deeper repo context than routine source review",
+# which is close to the opposite; tests/ was carried along rather than
+# re-argued. A unit test for the HL2 decoder does not need deeper context
+# than the decoder — it needs context on that subsystem, which is what the
+# Tier 3 roster has. 182 of the last 300 commits touched src/ and tests/
+# together, so the old split cut through the middle of most code PRs.
+# Nobody loses authority: @aethersdr/infrastructure is a strict subset of
+# @aethersdr/reviewers, so this only ADDS eligible approvers.
+#
+# docs/RELEASE-SIGNING-KEY.pub.asc is carved back to Tier 1 further below —
+# it lives under docs/ but it is a signing key, not documentation.
+docs/                        @aethersdr/reviewers
+resources/                   @aethersdr/reviewers
+tests/                       @aethersdr/reviewers
 
 # AI-instruction files. AGENTS.md / CLAUDE.md / GEMINI.md /
 # .github/copilot-instructions.md all land here via the *.md glob above —
@@ -111,7 +157,15 @@ docs/                        @aethersdr/infrastructure
 .github/docker/              @aethersdr/infrastructure
 .github/ISSUE_TEMPLATE/      @aethersdr/infrastructure
 
-# Build configuration
+# Build configuration.
+# NOTE the same at-any-depth behaviour as *.md: `CMakeLists.txt` has no slash,
+# so it matches a CMakeLists.txt in ANY directory, and it sits below the Tier 3
+# block above. There is no CMakeLists.txt under tests/ today — every test is
+# registered in this root file — but if test registration is ever split out
+# into tests/CMakeLists.txt, this line silently claims it for Tier 2 and undoes
+# half the point of putting tests/ at Tier 3. Add an explicit
+# `tests/CMakeLists.txt @aethersdr/reviewers` line below this one if that split
+# happens.
 CMakeLists.txt               @aethersdr/infrastructure
 THIRD_PARTY_LICENSES         @aethersdr/infrastructure
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,13 +8,20 @@
 #
 #   Tier 3 (source code, broad default)   — top of file (the `*` line)
 #   Tier 2 (project infrastructure)       — middle (specific paths)
-#   Tier 3 (documentation directories)    — just below the *.md glob
+#   Tier 3 (docs/, resources/, tests/)    — just below the *.md glob
 #   Tier 1 (governance, security)         — bottom (most specific paths)
 #
 # The one place that layout is not strictly broad → specific is the
-# documentation-directory block: docs/ and resources/ are Tier 3, but their
-# lines have to sit BELOW Tier 2's `*.md` glob rather than up with the `*`
-# default. See the Tier 3 note below for why.
+# reclaimed-directory block: docs/, resources/ and tests/ are Tier 3, but all
+# three lines have to sit BELOW Tier 2's `*.md` glob rather than up with the
+# `*` default. See the Tier 3 note below for why.
+#
+# MATCHING SEMANTICS, since three comments below depend on them: CODEOWNERS
+# uses gitignore-style patterns. A pattern with no slash (`*.md`,
+# `CMakeLists.txt`) or with only a TRAILING slash (`docs/`, `tests/`) matches
+# at ANY depth. Only a LEADING slash anchors to the repository root — so
+# `docs/` also claims `third_party/crdv/docs/`, and `/docs/` would not. The
+# patterns here are deliberately left unanchored; see the Tier 3 note.
 #
 # Tier 1 — @aethersdr/maintainers (currently: @ten9876).
 #         The RULES OF THE PROJECT and the paths that can compromise a
@@ -59,14 +66,22 @@
 #         and so does routine review of the tests and documentation that
 #         travel with that source.
 #         CAUTION: *.md has no slash, so it matches at ANY depth. That
-#         is why the docs/ and resources/ lines are placed BELOW Tier 2's
-#         *.md glob instead of up here with the `*` default: put them
-#         above it and last-match-wins pulls every markdown file under
-#         them (resources/help/*.md, docs/PR-WORKFLOW.md, …) straight
-#         back to Tier 2, silently, while the directory around them
-#         stays Tier 3. Markdown OUTSIDE those two directories still
-#         matches *.md and is still Tier 2 — README.md, CHANGELOG.md,
-#         ROADMAP.md, AGENTS.md, scripts/*.md.
+#         is why the docs/, resources/ and tests/ lines are placed BELOW
+#         Tier 2's *.md glob instead of up here with the `*` default: put
+#         any of the three above it and last-match-wins pulls every
+#         markdown file under it (resources/help/*.md, docs/PR-WORKFLOW.md,
+#         tests/README.md, …) straight back to Tier 2, silently, while the
+#         directory around it stays Tier 3. Markdown OUTSIDE all three
+#         still matches *.md and is still Tier 2 — README.md,
+#         CHANGELOG.md, ROADMAP.md, AGENTS.md, plugins/*/README.md.
+#         Those three lines are themselves unanchored (trailing slash
+#         only), so each matches its directory name at any depth: docs/
+#         also claims third_party/crdv/docs/, tests/ also claims
+#         third_party/crdv/tests/. That is intended — a vendored tree's
+#         own docs and tests belong with the vendored code, which is
+#         already Tier 3 via `*`. Anchoring them (/docs/) would drop that
+#         markdown back onto *.md, i.e. Tier 2, recreating the split this
+#         block exists to close.
 #
 # Team rosters are managed in the GitHub org settings:
 #   https://github.com/orgs/aethersdr/teams
@@ -91,7 +106,7 @@
 *                            @aethersdr/reviewers
 
 # ── Tier 2: project infrastructure — narrower owner set than Tier 3 ────────
-# CI/CD configuration (workflows + tooling), stray markdown, tests, build config.
+# CI/CD configuration (workflows + tooling), stray markdown, build config.
 # (The CodeQL config stays Tier 1 under Security below — a security control.)
 
 # Markdown that is not in one of the directories reclaimed to Tier 3 below.
@@ -99,17 +114,17 @@
 
 # ── Tier 3: whole directories — reclaimed from the *.md glob ──────────────
 # Each of these directories goes to the broad reviewer roster in full,
-# markdown included. ORDER IS LOAD-BEARING: they must stay BELOW the *.md
-# line above. *.md has no slash, so it matches at any depth; move these up
-# and every .md under them silently reverts to Tier 2 while the directory
-# around it stays Tier 3.
+# markdown included. ORDER IS LOAD-BEARING: all three must stay BELOW the
+# *.md line above. *.md has no slash, so it matches at any depth; move any
+# of them up and every .md under it silently reverts to Tier 2 while the
+# directory around it stays Tier 3.
 #
 # docs/ and resources/ — documentation. A guide under docs/ or a help topic
 # under resources/help/ is best reviewed by the people who review the code
 # it describes, and that is the broader roster. resources/ already landed on
 # @aethersdr/reviewers via the `*` default for everything that is not
-# markdown, so its line changes exactly one thing: resources/help/*.md, the
-# in-app help text.
+# markdown, so its line moves exactly the 7 markdown files under it: the 6
+# help topics in resources/help/ plus resources/meterfaces/README.md.
 #
 # tests/ — source code, not infrastructure: ~90k lines of C++ across 305
 # test TUs, against 3 files of actual harness glue. It sat at Tier 2 from
@@ -199,6 +214,16 @@ SECURITY*                    @aethersdr/maintainers
 .github/CODEOWNERS           @aethersdr/maintainers
 .github/codeql/              @aethersdr/maintainers
 docs/RELEASE-SIGNING-KEY.pub.asc  @aethersdr/maintainers
+
+# The key's human-readable twin. docs/VERIFYING-RELEASES.md publishes the
+# release fingerprint (B765 6E6B … 3D59 18F3) and the `curl … | gpg --import`
+# line users follow, so it is the anchor an operator compares an artifact
+# against. A wrong fingerprint here cannot forge a signature, but it can talk
+# someone into accepting one — which is the "can compromise a signed release"
+# limb, reached through the operator rather than the pipeline. Gating the .asc
+# while leaving its published fingerprint a tier below was the carve-out
+# stopping one file short.
+docs/VERIFYING-RELEASES.md   @aethersdr/maintainers
 
 # Security-sensitive workflows — carved back to Tier 1 (last-match-wins) out of
 # the Tier-2 .github/workflows/ default above. The release signing/publish

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,14 +96,29 @@ GitHub on every tier — your own PR always needs review from someone else.
 
 | Tier | Paths | Who can approve |
 |---|---|---|
-| **Source (Tier 3)** | Everything not listed below — all of `src/`, **including the whole of `MainWindow`** | `@aethersdr/reviewers` (@ten9876, @jensenpat, @NF0T, @rfoust, @chibondking) |
-| **Infrastructure (Tier 2)** | `tests/`, `docs/`, `*.md` (including `README.md`, `CHANGELOG.md`, `ROADMAP.md`, and the AI-instruction files `AGENTS.md` / `CLAUDE.md` / `GEMINI.md` / `.github/copilot-instructions.md`), `.claude/commands/`, `CMakeLists.txt`, `THIRD_PARTY_LICENSES`, the routine `.github/workflows/`, `.github/dependabot.yml`, `.github/docker/`, `.github/ISSUE_TEMPLATE/` | `@aethersdr/infrastructure` (@ten9876, @jensenpat, @rfoust) |
+| **Source, tests & documentation (Tier 3)** | Everything not listed below — all of `src/`, **including the whole of `MainWindow`** — plus `tests/`, `docs/`, and `resources/` **in full, markdown included** (so `docs/DEVELOPER-GUIDE.md` and the in-app help text under `resources/help/` are both here) | `@aethersdr/reviewers` (@ten9876, @jensenpat, @NF0T, @rfoust, @chibondking) |
+| **Infrastructure (Tier 2)** | `*.md` *outside* `docs/`, `resources/`, and `tests/` (`README.md`, `CHANGELOG.md`, `ROADMAP.md`, `scripts/*.md`, and the AI-instruction files `AGENTS.md` / `CLAUDE.md` / `GEMINI.md` / `.github/copilot-instructions.md`), `.claude/commands/`, `CMakeLists.txt`, `THIRD_PARTY_LICENSES`, the routine `.github/workflows/`, `.github/dependabot.yml`, `.github/docker/`, `.github/ISSUE_TEMPLATE/` | `@aethersdr/infrastructure` (@ten9876, @jensenpat, @rfoust) |
 | **Maintainer-only (Tier 1)** | Governance docs (`CONSTITUTION.md` **and its canonical copy `.specify/memory/constitution.md`**, `GOVERNANCE.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `LICENSE`), security/compliance (`SECURITY*`, `.github/CODEOWNERS`, `.github/codeql/`, `docs/RELEASE-SIGNING-KEY.pub.asc`), and the workflows that hold release secrets, feed bytes into a signed artifact, or form part of the CodeQL scanner's trust chain (`sign-release.yml`, `codeql.yml`, `macos-dmg.yml`, `windows-installer.yml`, `appimage.yml`, `docker-ci-image.yml`, `streamdeck-plugins.yml`) | `@aethersdr/maintainers` (@ten9876) |
 
 The maintainer-only tier is deliberately narrow: it covers the rules of the
 project and the paths that can compromise a signed release. Everything that
 is *documentation about how to build the thing* — including the AI-instruction
 files — sits at Tier 2, so day-to-day iteration isn't maintainer-gated.
+
+Tests and documentation sit at Tier 3 alongside the code they belong to. A
+guide under `docs/`, a help topic under `resources/help/`, or a unit test under
+`tests/` is best reviewed by the same people who review the code it covers —
+and `tests/` is source code in its own right: ~90k lines of C++ against three
+files of harness glue. Most code changes touch `src/` and `tests/` together, so
+splitting them across tiers taxed nearly every well-tested PR for no gain.
+
+Note the ordering rule behind this, if you ever edit `.github/CODEOWNERS`:
+`*.md` has no slash, so it matches markdown at **any** depth, and CODEOWNERS
+resolves by *last match*, not by specificity. The `docs/`, `resources/`, and
+`tests/` lines only work because they sit below the `*.md` glob — move them
+above it and every `.md` under those directories quietly falls back to Tier 2.
+`CMakeLists.txt` has the same no-slash behaviour, which is why build config
+still reaches Tier 2 wherever it lives.
 
 `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` are Tier 2 because their content is
 operational: architecture, build steps, style guide, protocol notes. The policy
@@ -123,9 +138,9 @@ primary goal of the decomposition was widening review of that code to the team.
 
 Bot-opened PRs (e.g. @AetherClaude's) still require a human reviewer regardless
 of tier — the bot is intentionally **not** a code owner. The Infrastructure
-tier simply means low-risk changes (test additions, documentation tweaks,
-dependency bumps, template updates) need an infrastructure owner rather than a
-maintainer.
+tier simply means changes to the repo's own scaffolding (dependency bumps,
+issue templates, CI config, build config) need an infrastructure owner rather
+than a maintainer.
 
 For the mechanics around this gate — draft-PR conventions, the stale-branch
 policy, and how to recover a red `main` — see

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,9 +96,9 @@ GitHub on every tier — your own PR always needs review from someone else.
 
 | Tier | Paths | Who can approve |
 |---|---|---|
-| **Source, tests & documentation (Tier 3)** | Everything not listed below — all of `src/`, **including the whole of `MainWindow`** — plus `tests/`, `docs/`, and `resources/` **in full, markdown included** (so `docs/DEVELOPER-GUIDE.md` and the in-app help text under `resources/help/` are both here) | `@aethersdr/reviewers` (@ten9876, @jensenpat, @NF0T, @rfoust, @chibondking) |
-| **Infrastructure (Tier 2)** | `*.md` *outside* `docs/`, `resources/`, and `tests/` (`README.md`, `CHANGELOG.md`, `ROADMAP.md`, `scripts/*.md`, and the AI-instruction files `AGENTS.md` / `CLAUDE.md` / `GEMINI.md` / `.github/copilot-instructions.md`), `.claude/commands/`, `CMakeLists.txt`, `THIRD_PARTY_LICENSES`, the routine `.github/workflows/`, `.github/dependabot.yml`, `.github/docker/`, `.github/ISSUE_TEMPLATE/` | `@aethersdr/infrastructure` (@ten9876, @jensenpat, @rfoust) |
-| **Maintainer-only (Tier 1)** | Governance docs (`CONSTITUTION.md` **and its canonical copy `.specify/memory/constitution.md`**, `GOVERNANCE.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `LICENSE`), security/compliance (`SECURITY*`, `.github/CODEOWNERS`, `.github/codeql/`, `docs/RELEASE-SIGNING-KEY.pub.asc`), and the workflows that hold release secrets, feed bytes into a signed artifact, or form part of the CodeQL scanner's trust chain (`sign-release.yml`, `codeql.yml`, `macos-dmg.yml`, `windows-installer.yml`, `appimage.yml`, `docker-ci-image.yml`, `streamdeck-plugins.yml`) | `@aethersdr/maintainers` (@ten9876) |
+| **Source, tests & documentation (Tier 3)** | Everything not listed below — all of `src/`, **including the whole of `MainWindow`** — plus `tests/`, `docs/`, and `resources/`, **markdown included** (so `docs/DEVELOPER-GUIDE.md` and the in-app help text under `resources/help/` are both here). Two files under `docs/` are carved back to Tier 1 below | `@aethersdr/reviewers` (@ten9876, @jensenpat, @NF0T, @rfoust, @chibondking) |
+| **Infrastructure (Tier 2)** | `*.md` *outside* `docs/`, `resources/`, and `tests/` (`README.md`, `CHANGELOG.md`, `ROADMAP.md`, `plugins/*/README.md`, and the AI-instruction files `AGENTS.md` / `CLAUDE.md` / `GEMINI.md` / `.github/copilot-instructions.md`), `.claude/commands/`, `CMakeLists.txt`, `THIRD_PARTY_LICENSES`, the routine `.github/workflows/`, `.github/dependabot.yml`, `.github/docker/`, `.github/ISSUE_TEMPLATE/` | `@aethersdr/infrastructure` (@ten9876, @jensenpat, @rfoust) |
+| **Maintainer-only (Tier 1)** | Governance docs (`CONSTITUTION.md` **and its canonical copy `.specify/memory/constitution.md`**, `GOVERNANCE.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `LICENSE`), security/compliance (`SECURITY*`, `.github/CODEOWNERS`, `.github/codeql/`, `docs/RELEASE-SIGNING-KEY.pub.asc` and the `docs/VERIFYING-RELEASES.md` that publishes its fingerprint), and the workflows that hold release secrets, feed bytes into a signed artifact, or form part of the CodeQL scanner's trust chain (`sign-release.yml`, `codeql.yml`, `macos-dmg.yml`, `windows-installer.yml`, `appimage.yml`, `docker-ci-image.yml`, `streamdeck-plugins.yml`) | `@aethersdr/maintainers` (@ten9876) |
 
 The maintainer-only tier is deliberately narrow: it covers the rules of the
 project and the paths that can compromise a signed release. Everything that
@@ -119,6 +119,12 @@ resolves by *last match*, not by specificity. The `docs/`, `resources/`, and
 above it and every `.md` under those directories quietly falls back to Tier 2.
 `CMakeLists.txt` has the same no-slash behaviour, which is why build config
 still reaches Tier 2 wherever it lives.
+
+A trailing slash does not anchor a pattern either: only a *leading* slash
+(`/docs/`) pins one to the repository root. So `docs/` and `tests/` also claim
+`third_party/crdv/docs/` and `third_party/crdv/tests/` — intended, since a
+vendored tree's own docs and tests belong with its code, which is already
+Tier 3.
 
 `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` are Tier 2 because their content is
 operational: architecture, build steps, style guide, protocol notes. The policy

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -139,11 +139,16 @@ PR review is gated by [`.github/CODEOWNERS`](.github/CODEOWNERS), which is the
 authoritative source of who must approve what (last-match-wins). It defines
 three tiers, broadest → most restrictive:
 
-- **Tier 3 — source code** (`@aethersdr/reviewers`): all of `src/` — including
-  the whole of `MainWindow` — plus anything not enumerated below. The broad
-  reviewer roster; routine source review benefits from more eyes.
-- **Tier 2 — infrastructure** (`@aethersdr/infrastructure`): `docs/`, `*.md`
-  (including `ROADMAP.md`), `tests/`, `CMakeLists.txt`, the routine CI
+- **Tier 3 — source code, tests, and documentation** (`@aethersdr/reviewers`):
+  all of `src/` — including the whole of `MainWindow` — plus `tests/`,
+  `docs/`, and `resources/` in full (markdown included, so `resources/help/`
+  is here too), plus anything not enumerated below. The broad reviewer roster;
+  routine review of source, its tests, and its documentation all benefit from
+  more eyes. `tests/` is here because it *is* source — ~90k lines of C++ —
+  and because most code changes touch `src/` and `tests/` together.
+- **Tier 2 — infrastructure** (`@aethersdr/infrastructure`): `*.md` outside
+  those directories (`README.md`, `CHANGELOG.md`, `ROADMAP.md`,
+  `scripts/*.md`, …), `CMakeLists.txt`, the routine CI
   workflows under `.github/workflows/`, and the AI-instruction files
   (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`,
   `.github/copilot-instructions.md`, `.claude/commands/`).
@@ -161,6 +166,13 @@ and wins on any disagreement; the path-level breakdown for contributors is the
 table in [`CONTRIBUTING.md`](CONTRIBUTING.md#reviews-and-merging). Deliberately
 not restated here: the exact workflow filenames, which change as workflows are
 added and renamed.
+
+One subtlety worth knowing before editing `.github/CODEOWNERS`: a pattern with
+no slash matches at **any depth**, so the `*.md` glob reaches markdown inside
+every directory. The `docs/`, `resources/`, and `tests/` lines therefore have
+to come *after* it in the file for those directories' markdown to stay at
+Tier 3 — CODEOWNERS resolves by last match, not by specificity. `CMakeLists.txt`
+behaves the same way, which is noted inline where it appears.
 
 Tier 1 is deliberately narrow: a path belongs there only if a wrong change to
 it would alter **who decides things** or **what gets signed**. Documentation

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -53,7 +53,7 @@ Current domain areas:
 
 | Area | Path(s) | Notes |
 |------|---------|-------|
-| Documentation | `resources/help/`, `docs/`, `*.md` | Help text, wiki, guides |
+| Documentation | `resources/help/`, `docs/`, `*.md` | Help text, wiki, guides. Spans two CODEOWNERS tiers: `docs/` and `resources/help/` are Tier 3, bare `*.md` is Tier 2 |
 | Build / CI | `CMakeLists.txt`, `.github/` | Build system, CI pipelines |
 | Plugins | `plugins/` | Stream Deck, TCI plugins |
 | Platform: macOS | `src/platform/macos/` | macOS-specific code only |
@@ -141,14 +141,16 @@ three tiers, broadest → most restrictive:
 
 - **Tier 3 — source code, tests, and documentation** (`@aethersdr/reviewers`):
   all of `src/` — including the whole of `MainWindow` — plus `tests/`,
-  `docs/`, and `resources/` in full (markdown included, so `resources/help/`
-  is here too), plus anything not enumerated below. The broad reviewer roster;
+  `docs/`, and `resources/`, markdown included (so `resources/help/` is here
+  too), plus anything not enumerated below. The broad reviewer roster;
   routine review of source, its tests, and its documentation all benefit from
   more eyes. `tests/` is here because it *is* source — ~90k lines of C++ —
-  and because most code changes touch `src/` and `tests/` together.
+  and because most code changes touch `src/` and `tests/` together. Two files
+  under `docs/` are carved back to Tier 1 below, so "all of `docs/`" is the
+  rule and not quite the whole story.
 - **Tier 2 — infrastructure** (`@aethersdr/infrastructure`): `*.md` outside
   those directories (`README.md`, `CHANGELOG.md`, `ROADMAP.md`,
-  `scripts/*.md`, …), `CMakeLists.txt`, the routine CI
+  `plugins/*/README.md`, …), `CMakeLists.txt`, the routine CI
   workflows under `.github/workflows/`, and the AI-instruction files
   (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`,
   `.github/copilot-instructions.md`, `.claude/commands/`).
@@ -157,7 +159,8 @@ three tiers, broadest → most restrictive:
   `.specify/memory/constitution.md` and the root `CONSTITUTION.md` mirror —
   plus `GOVERNANCE.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `LICENSE`),
   the security/compliance paths (`SECURITY*`, `.github/CODEOWNERS` itself, the
-  CodeQL config, the release signing key), and the workflows that hold release
+  CodeQL config, the release signing key and the `docs/VERIFYING-RELEASES.md`
+  that publishes its fingerprint), and the workflows that hold release
   secrets or feed bytes into a signed artifact — which includes the CI-image
   build, since the CodeQL scan runs inside that image.
 
@@ -168,11 +171,17 @@ not restated here: the exact workflow filenames, which change as workflows are
 added and renamed.
 
 One subtlety worth knowing before editing `.github/CODEOWNERS`: a pattern with
-no slash matches at **any depth**, so the `*.md` glob reaches markdown inside
-every directory. The `docs/`, `resources/`, and `tests/` lines therefore have
-to come *after* it in the file for those directories' markdown to stay at
-Tier 3 — CODEOWNERS resolves by last match, not by specificity. `CMakeLists.txt`
-behaves the same way, which is noted inline where it appears.
+no slash (`*.md`, `CMakeLists.txt`) — **or with only a trailing one**
+(`docs/`, `tests/`) — matches at **any depth**. Only a *leading* slash
+(`/docs/`) anchors a pattern to the repository root.
+
+Two consequences. The `*.md` glob reaches markdown inside every directory, so
+the `docs/`, `resources/`, and `tests/` lines have to come *after* it in the
+file for those directories' markdown to stay at Tier 3 — CODEOWNERS resolves by
+last match, not by specificity. And those three lines are themselves
+unanchored, so they also claim `third_party/crdv/docs/` and
+`third_party/crdv/tests/`. That is intended: a vendored tree's own docs and
+tests belong with its code, which is already Tier 3.
 
 Tier 1 is deliberately narrow: a path belongs there only if a wrong change to
 it would alter **who decides things** or **what gets signed**. Documentation


### PR DESCRIPTION
## Summary

Three directories move from the Tier 2 infrastructure roster to the broad Tier 3 reviewer roster. **Nobody loses authority** — `@aethersdr/infrastructure` (@ten9876, @jensenpat, @rfoust) is a strict subset of `@aethersdr/reviewers` (those three + @NF0T + @chibondking), so this only *adds* eligible approvers.

## `docs/` and `resources/` — the `*.md` depth trap

`*.md` has no slash, so it matches markdown at **any depth**. That put every documentation file inside a Tier 3 directory — the in-app help text under `resources/help/`, the guides under `docs/` — on the infrastructure roster, while the directory around it stayed Tier 3.

A guide under `docs/` or a help topic under `resources/help/` is best reviewed by the people who review the code it describes, and that is the broader roster.

For `resources/` this changes exactly one thing: `resources/help/*.md`. Everything else there already resolved to `@aethersdr/reviewers` via the `*` default.

## `tests/` — source code, not infrastructure

~90k lines of C++ across 305 test TUs, against three files of actual harness glue (two `.cmake` helpers and one `.py`).

The tier assignment was an artifact of rationale drift, not a decision:

- **#2029** (the original CODEOWNERS) grouped `tests/` with docs under *"Tier 2: mechanical/safe paths — bot can also approve."* A **low-risk → widen approval** framing.
- **#3053** rebuilt the tiers a month later, and Tier 2 became *"narrower owner set because infrastructure needs deeper repo context than routine source review."* Close to the **opposite** framing. `tests/` was carried along rather than re-argued.

A unit test for the HL2 decoder does not need deeper repo context than the decoder — it needs context on *that subsystem*, which is what the Tier 3 roster has.

It also cut through most code PRs. Over the last 300 commits:

| | count |
|---|---|
| touched `src/` **and** `tests/` | 182 |
| `src/` only | 58 |
| `tests/` only | 11 |

## Ordering is load-bearing

All three lines sit **below** the `*.md` glob deliberately. CODEOWNERS resolves by *last match*, not by specificity — placing them above it would leave every `.md` under those directories on Tier 2 while looking correct. Comments in all three files now say so.

`CMakeLists.txt` has the same no-slash behaviour and stays Tier 2. There is no `CMakeLists.txt` under `tests/` today (every test is registered in the root file), but a note now warns that splitting registration out would silently land `tests/CMakeLists.txt` at Tier 2 and undo half the point of this change.

## Unchanged

- Markdown **outside** those directories — `README.md`, `CHANGELOG.md`, `ROADMAP.md`, `scripts/*.md`, the AI-instruction files — stays Tier 2.
- `docs/RELEASE-SIGNING-KEY.pub.asc` stays Tier 1 via its later carve-out (it lives under `docs/` but it is a signing key, not documentation).
- Every Tier 1 path is untouched.

## Verification

Replayed all 28 patterns through git's own gitignore matcher (CODEOWNERS uses gitignore-style matching) and took the last match per path:

| Path | Wins on | Owner |
|---|---|---|
| `tests/hl2_shift_test.cpp` | `tests/` | reviewers ✅ changed |
| `tests/README.md` | `tests/` | reviewers ✅ changed |
| `docs/PR-WORKFLOW.md` | `docs/` | reviewers ✅ changed |
| `resources/help/index.md` | `resources/` | reviewers ✅ changed |
| `CMakeLists.txt` | `CMakeLists.txt` | infrastructure (unchanged) |
| `README.md`, `scripts/foo.md` | `*.md` | infrastructure (unchanged) |
| `docs/RELEASE-SIGNING-KEY.pub.asc` | own line | maintainers (unchanged) |
| `CONTRIBUTING.md`, `SECURITY.md` | own lines | maintainers (unchanged) |
| `src/gui/MainWindow.cpp` | `*` | reviewers (unchanged) |
| `.github/workflows/ci.yml` | `.github/workflows/` | infrastructure (unchanged) |

## Governance note

This is an amendment under GOVERNANCE.md §Amendments — it moves a tier boundary — and all three touched files are Tier 1 paths, so it is maintainer-gated by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)