### PR TITLE
feat(icom): schedule CI-V meters, controls, and PTT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,8 +334,15 @@ jobs:
       # command shape" and all four checks stayed green, because nothing in this
       # file ran that target either. A capability flag that gates which frame
       # reaches the radio is exactly the kind of claim worth failing a merge on.
-      - name: Test Icom CI-V codec and model table
-        run: ctest --test-dir build -R "^icom_(civ|meters)_test$" --output-on-failure
+      - name: Test Icom CI-V codec, model table, command scheduler and backend
+        # icom_civ_scheduler_test and icom_backend_test are on this gate
+        # deliberately. The scheduler arbitrates PTT and the operator's control
+        # writes on a single serial command plane, and icom_backend_test is
+        # where every convergence claim about it is asserted. Leaving them to
+        # the weekly sanitizers job would repeat the hasVfoModeCommand lesson
+        # in the comment above: the assertion existed, nothing on a PR ran it,
+        # and all four checks stayed green. ~21 s for the pair.
+        run: ctest --test-dir build -R "^icom_(civ|civ_scheduler|meters|backend)_test$" --output-on-failure
 
       # Mirrors check-windows' "sccache stats" step, and exists for the same
       # reason: #1963 disabled the Windows compiler cache for three months

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -626,6 +626,7 @@ set(CORE_SOURCES
     src/core/backends/icom/IcomScope.cpp     # IcomCIV Phase 2 (0x27 waveform -> panadapter)
     src/core/backends/icom/IcomAudio.cpp     # IcomCIV Phase 3 (codecs + the 1364/556 split)
     src/core/backends/icom/IcomMeters.cpp    # IcomCIV Phase 4 (calibration + poll scheduler)
+    src/core/backends/icom/IcomCivScheduler.cpp # RFC #4983 shared CI-V pacing + causality
     src/core/backends/icom/IcomModels.cpp    # IcomCIV Phase 5 (per-model capability table)
     src/core/backends/icom/IcomControls.cpp  # the CI-V control registry (controls.map / controls.scrub)
     src/core/backends/icom/IcomCivBackend.cpp # IcomCIV (IRadioBackend impl)

--- a/docs/architecture/aetherd-icom-civ-backend-design.md
+++ b/docs/architecture/aetherd-icom-civ-backend-design.md
@@ -270,15 +270,49 @@ single writer above `IcomSession::sendCiv()` and:
 - filters its own request/response traffic out of anything re-exported (CAT
   pass-through, TCI) — kappanhang does exactly this and it matters.
 
+The semantic key is deliberately **coarser than the register**: `04`, `06`,
+`26` and the transceive forms all key on `mode`, which is what makes an
+operator mode write supersede an in-flight mode read of any form. Coalescing
+does *not* inherit that coarseness — two reads collapse only when they ask the
+same register the same way. `04` (mode) and `26` (mode + DATA + filter) are
+both issued at connect on purpose, because `26` is what corrects `04` when the
+two disagree.
+
+Aging tops out at the **visible-meter** band, one step below the PTT fallback
+poll, not at the poll itself. Dispatch breaks an equal-priority tie in favour
+of the older entry, so work that aged all the way to `Ptt` would be dispatched
+*ahead* of the keyed-state poll rather than merely tying with it. Stopping one
+band short still beats fresh meter traffic on that tie — which is all
+anti-starvation needs — while leaving PTT an edge no amount of waiting erodes.
+
 Writes consume the reply slot too: their `FB`/`FA` acknowledgement must be
 retired before a later read is sent, or that ACK can be mistaken for the read's
 answer. An unsupported read may itself finish with `FB`/`FA`; that releases the
 slot but is never decoded as state.
 
+A transaction that outlives its 350 ms timeout, or that a fail-safe unkey
+displaces, stays **recognisable for a further two seconds**. The timeout means
+"stop waiting", not "this can never arrive": without that memory the identical
+frame is rejected as stale at 349 ms and adopted as fresh radio truth at
+351 ms, which is enough to put an obsolete reading back over a newer operator
+write on every register.
+
 PTT additionally carries an intent generation and a one-second confirmation
-window. A delayed pre-key `RX` answer is stale after a newer `TX` intent and
-cannot unkey the model; matching readback confirms the intent, while radio
-truth wins again when the bounded window expires.
+window — one second because it must comfortably cover a lost reply (350 ms)
+plus the 250 ms fallback poll that follows it, and still expire well inside the
+time an operator would take to notice a wrong transmit indicator.
+
+**The window is one-directional, and that asymmetry is the point.** While a
+key-*on* intent is pending, a contradictory `RX` report is the delayed pre-key
+poll answer and is suppressed: this is RFC #4983's captured FT8 failure, where
+treating it as current state tore down transmit audio on a radio that then
+keyed normally. While a key-*off* intent is pending, a contradictory `TX`
+report is never suppressed — a lost, refused, or front-panel-overridden unkey
+is exactly the case where the radio's report is the only thing telling the
+operator they are still on the air. RFC #4983 states the rule directly
+("explicit PTT OFF and fail-safe unkey are never suppressed by a key-on
+transition guard") and Constitution VI requires every path that can transmit to
+fail closed. Radio truth wins again as soon as the bounded window expires.
 
 | group | interval | condition |
 |---|---:|---|

--- a/docs/architecture/aetherd-icom-civ-backend-design.md
+++ b/docs/architecture/aetherd-icom-civ-backend-design.md
@@ -253,19 +253,44 @@ not invent a dB scale from the raw register.
 
 ### Gap B — metering is a scheduler, not a subscription
 
-This is new. Flex streams meters; the HL2 embeds them. Icom needs a **poll
-scheduler** that:
+Flex streams meters; the HL2 embeds them. Icom uses one CI-V command plane for
+meters, startup snapshots, periodic controls and PTT. `IcomCivScheduler` is the
+single writer above `IcomSession::sendCiv()` and:
 
 - polls only meters currently visible in the UI;
-- runs S-meter at ~10 Hz and everything else at ~5 Hz;
+- paces dispatches into 25 ms slots and permits one ordinary command/reply
+  transaction at a time;
 - stops TX meters entirely while receiving, and RX meters while transmitting;
-- yields to user-initiated commands, so tuning never queues behind metering;
+- puts operator writes and their radio-authoritative readbacks ahead of polls;
+- coalesces duplicate reads and rapid writes by semantic register, preserving
+  the newest write generation;
+- expires a lost reply after 350 ms and ages background work so PTT or S-meter
+  traffic cannot starve slower controls;
+- lets fail-safe unkey bypass pacing and the outstanding reply slot; and
 - filters its own request/response traffic out of anything re-exported (CAT
   pass-through, TCI) — kappanhang does exactly this and it matters.
 
-wfview's per-rig `Periodic\N\Command` list with priorities is the proven shape.
-This should be a named component (`IcomMeters`) with its own test, not a timer
-sprinkled through the backend.
+Writes consume the reply slot too: their `FB`/`FA` acknowledgement must be
+retired before a later read is sent, or that ACK can be mistaken for the read's
+answer. An unsupported read may itself finish with `FB`/`FA`; that releases the
+slot but is never decoded as state.
+
+PTT additionally carries an intent generation and a one-second confirmation
+window. A delayed pre-key `RX` answer is stale after a newer `TX` intent and
+cannot unkey the model; matching readback confirms the intent, while radio
+truth wins again when the bounded window expires.
+
+| group | interval | condition |
+|---|---:|---|
+| PTT fallback | 250 ms | always connected; Transceive is only a hint |
+| S meter | 100 ms | RX and visible |
+| power, SWR, ALC, compression | 200 ms | TX and visible |
+| PA current | 500 ms | TX and visible |
+| voltage | 1000 ms | visible |
+| overflow | 500 ms | RX and visible |
+| NR, NB, auto/manual notch state | 1000 ms | connected |
+| frequency, mode/DATA, monitor and VOX state | 2000 ms | connected |
+| levels, RF power, preamp, AGC, attenuator, tuner, RIT/XIT | 3000 ms | connected |
 
 #### State convergence is snapshot + transceive + polling
 
@@ -279,11 +304,10 @@ Reliable remote state therefore has three layers:
 3. rotate explicit reads on the link timer for states the model guide permits.
 
 Poll slowly enough to leave command latency and meter traffic headroom. The
-current backend uses six one-second phases, with at most four adjacent control
-reads in a phase, and gives operator writes a 500 ms quiet window. NR/NB
-function and level reads therefore rotate at about six seconds; TX state is
-faster because it gates transmit-only meters. A reply is radio
-authority and updates the model without reflecting a new command back down.
+current intervals are in the table above; priority, coalescing and aging bound
+their interaction instead of relying on independent timers to miss each other.
+A reply is radio authority and updates the model without reflecting a new
+command back down.
 Radio-authoritative Icom state must not be replayed from client persistence on
 reconnect.
 

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -2958,6 +2958,27 @@ reconnect grant stopped its media streams around 45 seconds even though the
 ordinary 60-second renewal was later accepted. After that one early renewal,
 the session returns to the wfview/kappanhang 60-second cadence.
 
+**`civ scheduler`** reports the shared command-plane scheduler rather than one
+producer in isolation:
+
+```json
+→ {"cmd":"civ","action":"scheduler"}
+← {"ok":true,"civ":"scheduler","result":{
+   "idle":false,"slotMs":25,"readTimeoutMs":350,
+   "queueDepth":3,"readInFlight":true,"inFlightKey":"meter.s",
+   "queued":812,"dispatched":799,"coalesced":96,
+   "replies":796,"staleReplies":1,"timeouts":2,
+   "pendingPttIntent":false}}
+```
+
+Use it when controls feel delayed or meters stop. A bounded queue with replies
+advancing is healthy. A growing queue plus timeouts identifies CI-V command-
+plane loss even if RS-BA1 link counters and the panadapter still move.
+`staleReplies` is expected to remain near zero; it proves an old poll was
+discarded after a newer operator intent instead of rolling the UI backward.
+Poll this read-only verb until `idle:true` when a test needs deterministic
+write/readback convergence.
+
 **`civ trace [all]`** reads the bounded decoded CI-V frame trace. The default
 omits routine meter traffic; `all` includes it. **`civ send <hex>`** injects
 command bytes through the active Icom session and is reserved for controlled
@@ -3022,15 +3043,20 @@ alone proves nothing. `IDLE` distinguishes a transmit-only meter that is
 correctly quiet while receiving from one that is broken.
 
 **`controls scrub [id|plane]`** — the linkage check. Drives every settable
-control through its seam verb **at its current value**, then looks for the frame
-on the wire. Nothing on the radio moves.
+control through its seam verb **at its current value**, then verifies that the
+exact frame reached either the wire or the CI-V scheduler. Nothing on the radio
+moves. Because dispatch is asynchronous, finish a scrub by polling
+`civ scheduler` until `idle:true`; no increase in `timeouts` proves every
+admitted command completed its dispatch/readback transaction.
 
 ```json
 → {"cmd":"controls","args":"scrub"}
 ← {"ok":true,"result":{"checked":25,"linked":17,"broken":0,"notTested":8,
    "rows":[{"id":"rf.gain","civ":"14 02","seamVerb":"setPanRfGain",
-            "reachedWire":true,"status":"LINKED",
-            "verdict":"the seam verb put this command on the wire"},
+            "reachedWire":false,"reachedScheduler":true,"status":"LINKED",
+            "verdict":"the seam verb admitted this exact command to the CI-V
+                       scheduler; wait for `civ scheduler` idle with no new
+                       timeout to prove dispatch and readback"},
            {"id":"rit.offset","civ":"21 00","status":"NOT-TESTED",
             "verdict":"no safe way to re-assert this without changing the
                        operator's setting — not a fault, not a pass"}]}}
@@ -3039,6 +3065,11 @@ on the wire. Nothing on the radio moves.
 Three outcomes, not two. `NOT-TESTED` is a real state — a control the scrub
 could not drive without changing the operator's setting — and collapsing it into
 either pass or fail would misreport it.
+
+`reachedWire` and `reachedScheduler` are deliberately separate. An idle
+scheduler with unchanged timeout count promotes the latter from accepted work
+to completed wire/readback proof without making the synchronous scrub block the
+application event loop.
 
 The scrub clears the enable-dedupe sentinels first: NR, NB and both notches
 suppress an enable that matches what was last sent, which is correct in normal
@@ -3426,7 +3457,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `audioCapture` | — | audioCapture <start\|stop\|status\|read\|probeNr2Stereo\|probeDspStereo> [args] |
 | `txwaterfall` | — | txwaterfall <on\|off> — show keyed TX in the waterfall |
 | `liveness` | — | liveness — per-class data ages and the producer->consumer meter join |
-| `civ` | — | civ <send <hex>\|trace [all]\|session> — CI-V inject, frame trace, or RS-BA1 lease health (Icom; send is TX-gated) |
+| `civ` | — | civ <send <hex>\|trace [all]\|session\|scheduler> — CI-V inject, frame trace, RS-BA1 lease health, or command-scheduler health (Icom; send is TX-gated) |
 | `controls` | — | controls <map\|meters\|scrub [id\|plane]> — the CI-V control and meter registry joined against what is actually wired, and a linkage check that drives every settable control without moving any of them (Icom) |
 | `radiocert` | — | radiocert <tune\|rx\|tx\|meters\|all> [freqMhz] — radio bring-up diagnostic, in dependency order (tx/meters key) |
 | `key` | — | key <ptt on\|off \| mox> — semantic keying (TX-gated) |

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -2971,6 +2971,13 @@ producer in isolation:
    "pendingPttIntent":false}}
 ```
 
+While a PTT request is awaiting confirmation the reply also carries
+`"pttIntent"` (the requested state) and `"pttIntentRemainingMs"` (how much of
+the bounded window is left). Suppression applies only while `pttIntent` is
+`true`: a radio reporting TX after an unkey request is always published, never
+held back. See the Icom CI-V backend design doc for why the two directions are
+not symmetric.
+
 Use it when controls feel delayed or meters stop. A bounded queue with replies
 advancing is healthy. A growing queue plus timeouts identifies CI-V command-
 plane loss even if RS-BA1 link counters and the panadapter still move.

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -2976,8 +2976,12 @@ advancing is healthy. A growing queue plus timeouts identifies CI-V command-
 plane loss even if RS-BA1 link counters and the panadapter still move.
 `staleReplies` is expected to remain near zero; it proves an old poll was
 discarded after a newer operator intent instead of rolling the UI backward.
-Poll this read-only verb until `idle:true` when a test needs deterministic
-write/readback convergence.
+A few per session are normal — one per operator write that overtook a poll
+already on the wire. It climbing *with* `timeouts`, or tracking the rate the
+operator moves controls, means replies are routinely arriving after their
+transaction expired: read it alongside `queueDepth` and treat the pair, not
+`staleReplies` alone, as the congestion signal. Poll this read-only verb until
+`idle:true` when a test needs deterministic write/readback convergence.
 
 **`civ trace [all]`** reads the bounded decoded CI-V frame trace. The default
 omits routine meter traffic; `all` includes it. **`civ send <hex>`** injects

--- a/docs/radio-certification.md
+++ b/docs/radio-certification.md
@@ -272,10 +272,12 @@ turned out to be `declared-only`: named in the codec, reached by nothing.
 connect is the interesting case, and it is the one no document can report.
 
 **It answers for all of them at once.** `controls scrub` drives every settable
-control through its seam verb *at its current value* and looks for the frame on
-the wire. Nothing on the radio moves. On the IC-705 that is 25 controls in one
-call: 17 linked, 0 broken, 8 that cannot be re-asserted without changing an
-operator setting.
+control through its seam verb *at its current value* and verifies scheduler
+admission or immediate wire dispatch. Nothing on the radio moves. Poll
+`civ scheduler` until `idle:true` with no new timeout to complete the
+dispatch/readback proof. On the IC-705 that is 25 controls in one call: 17
+linked, 0 broken, 8 that cannot be re-asserted without changing an operator
+setting.
 
 Three design choices in the scrub are worth copying into any backend that grows
 one:
@@ -319,8 +321,9 @@ passed it — the meter was defined, mapped, polled and published.
 
 ### What the harness still cannot tell you
 
-- **That the radio obeyed.** The scrub proves an intent reached the wire and the
-  radio acknowledged it. An `FB` means "understood", not "applied" — an IC-705
+- **That the radio obeyed.** Scrub plus a clean scheduler drain proves an intent
+  reached the wire and the radio answered its transaction. An `FB` means
+  "understood", not "applied" — an IC-705
   answers `FB` to a P.AMP2 request above 50 MHz that it then ignores.
 - **That the value is right.** A control can be linked, in range, and scaled
   wrongly. `14 02` published as decibels instead of percent would still scrub

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -2591,7 +2591,8 @@ bool isReadOnlyRequest(const QString& name, const QString& action)
     }
     if (name == QLatin1String("civ")) {
         return normalizedAction == QLatin1String("trace")
-            || normalizedAction == QLatin1String("session");
+            || normalizedAction == QLatin1String("session")
+            || normalizedAction == QLatin1String("scheduler");
     }
     return false;
 }
@@ -3289,7 +3290,9 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
             });
 
         add("civ", {},
-            "civ <send <hex>|trace [all]|session> — CI-V inject, frame trace, or RS-BA1 lease health (Icom; send is TX-gated)",
+            "civ <send <hex>|trace [all]|session|scheduler> — CI-V inject, frame "
+            "trace, RS-BA1 lease health, or command-scheduler health (Icom; send "
+            "is TX-gated)",
             parseActionRest,
             [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
                 return s.doCiv(a.action, a.value);
@@ -7529,8 +7532,9 @@ QJsonObject AutomationServer::doCiv(const QString& action, const QString& arg)
 
     const QString a = action.trimmed().toLower();
     if (a.isEmpty() || (a != QLatin1String("send") && a != QLatin1String("trace")
-                        && a != QLatin1String("session"))) {
-        return err(QStringLiteral("civ requires an action (send|trace|session)"));
+                        && a != QLatin1String("session")
+                        && a != QLatin1String("scheduler"))) {
+        return err(QStringLiteral("civ requires an action (send|trace|session|scheduler)"));
     }
     if (a == QLatin1String("send") && !m_txAllowed) {
         return err(QStringLiteral(
@@ -7538,7 +7542,7 @@ QJsonObject AutomationServer::doCiv(const QString& action, const QString& arg)
             "radio. Relaunch with AETHER_AUTOMATION_ALLOW_TX=1"));
     }
 
-    // The Icom backend answers all three verbs synchronously inside
+    // The Icom backend answers these diagnostic verbs synchronously inside
     // invokeExtension, so a direct connection lands before the call returns.
     // Anything that does not answer leaves `answered` false and is reported as
     // unsupported rather than as success — a fire-and-forget reply here would
@@ -7564,6 +7568,8 @@ QJsonObject AutomationServer::doCiv(const QString& action, const QString& arg)
 
     const QString verb = a == QLatin1String("send") ? QStringLiteral("civ.send")
                        : a == QLatin1String("trace") ? QStringLiteral("civ.trace")
+                       : a == QLatin1String("scheduler")
+                           ? QStringLiteral("civ.scheduler.status")
                                                      : QStringLiteral("civ.session");
     backend->invokeExtension(QStringLiteral("icom"), verb, rid, arg.trimmed());
     disconnect(okConn);

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -26,6 +26,7 @@ Q_LOGGING_CATEGORY(lcIcomPan, "aether.icom.pan")
 // Link health. Separate from the pan category because the one thing anyone
 // wants to switch on after a hang is the stall warning, and nothing else.
 Q_LOGGING_CATEGORY(lcIcomLink, "aether.icom.link")
+Q_LOGGING_CATEGORY(lcIcomScheduler, "aether.icom.scheduler")
 
 // Which CI-V address we ended up talking to, and why. Its own category because
 // a wrong address is SILENT — the radio simply never answers — so when the
@@ -37,7 +38,7 @@ Q_LOGGING_CATEGORY(lcIcomAddr, "aether.icom.address")
 // Metering is examined this often; the MeterPoller decides what is actually
 // due. Deliberately faster than the fastest meter interval so a due meter is
 // not delayed by up to a whole tick.
-constexpr int kMeterTickMs = 40;
+constexpr int kMeterTickMs = 10;
 // Transport counters publish on a FIXED cadence, not on receive: "nothing
 // arrived this second" is the observation the heartbeat's alarm path waits for,
 // and a backend that emits only on receive can never report its own silence.
@@ -336,11 +337,24 @@ void IcomCivBackend::connectRadio(const RadioConnectRequest& request)
 
 void IcomCivBackend::disconnectRadio()
 {
-    // TUNE temporarily replaces the ordinary RF-power setpoint. Restore it
-    // while the command path still exists; clearing the sentinel first left
-    // the physical radio at tune power after an operator disconnect.
-    if (m_tuning && m_session && m_connected)
-        setTune(false, m_preTuneTxPowerPercent);
+    // Teardown is not allowed to wait for an ordinary outstanding read.  Drop
+    // all background work, fail-safe unkey on every connected disconnect, and
+    // restore the operator's RF-power setpoint if TUNE had borrowed it.  These
+    // are response-free emergency dispatches so both datagrams reach the
+    // session before its sockets close; no state is optimistically adopted.
+    if (m_session && m_connected) {
+        m_civScheduler.reset();
+        queueEmergencyWriteNoReply(cmdSetPtt(m_session->civAddress(), false), "ptt");
+        if (m_tuning && m_preTuneTxPowerPercent >= 0) {
+            queueEmergencyWriteNoReply(
+                cmdSetLevel(m_session->civAddress(), level::kRfPower,
+                            percentToLevelRaw(m_preTuneTxPowerPercent)),
+                "level.rfPower");
+        }
+        const qint64 now = QDateTime::currentMSecsSinceEpoch();
+        pumpCiv(now);
+        pumpCiv(now);
+    }
 
     for (QTimer** t : {&m_meterTimer, &m_linkTimer, &m_civDetectTimer}) {
         if (*t) {
@@ -356,6 +370,11 @@ void IcomCivBackend::disconnectRadio()
     m_rxResampler.reset();
     m_scope.reset();
     m_meters.reset();
+    m_civScheduler.reset();
+    m_schedulerTimeoutsReported = 0;
+    serviceSchedulerWaiters(QDateTime::currentMSecsSinceEpoch());
+    m_pendingPttIntent.reset();
+    m_pendingPttUntilMs = 0;
     // The radio keeps its own DSP state across our sessions and we have not
     // read it back, so "unknown" is the only honest starting point — carrying
     // the last session's belief would suppress the first command that matters.
@@ -369,6 +388,7 @@ void IcomCivBackend::disconnectRadio()
     m_controlsValueKnown.clear();
     m_controlsSeen.clear();
     m_controlsSent.clear();
+    m_controlsScheduled.clear();
     m_framesObserved = 0;
     // The CI-V address resolution is per-session for the same reason: the
     // operator can move to a different radio, or change the address on this one,
@@ -391,9 +411,8 @@ bool IcomCivBackend::isConnected() const { return m_connected; }
 
 // The connect-edge read burst.
 //
-// MOVED HERE VERBATIM from onSessionConnected — not one frame added, removed or
-// reordered inside it. It is a function for two reasons and neither of them is
-// pacing:
+// Kept as one named snapshot so every connect and address retarget enters the
+// same scheduler path:
 //
 //   * a radio whose NAME we do not recognise has to learn its CI-V address from
 //     the broadcast reply before there is a correct address to burst at, and
@@ -402,9 +421,9 @@ bool IcomCivBackend::isConnected() const { return m_connected; }
 //     radio actually reported is the only thing that recovers the session, and
 //     it is cheap because it happens at most once per connect.
 //
-// ⛔ DO NOT re-pace or re-order this. RFC #4983 attributes an unrecoverable CI-V
-// command-plane stall to request bunching and names a burst of this shape as the
-// bunching it exists to fix. That work is the scheduler's, not this function's.
+// The order below expresses startup preference only. IcomCivScheduler paces the
+// frames, coalesces duplicates, and keeps this snapshot from becoming the
+// connect-edge burst called out by RFC #4983.
 void IcomCivBackend::sendConnectReadBurst()
 {
     if (!m_session)
@@ -421,9 +440,13 @@ void IcomCivBackend::sendConnectReadBurst()
     // Still DIRECTED, alongside the broadcast the caller sent: this one confirms
     // that the address we are actually using has something behind it, which the
     // broadcast cannot tell us on a bus with more than one device.
-    m_session->sendCiv(cmdReadId(m_session->civAddress()));
-    m_session->sendCiv(cmdReadFrequency(m_session->civAddress()));
-    m_session->sendCiv(cmdReadMode(m_session->civAddress()));
+    const auto queueStartupRead = [this](const std::vector<std::uint8_t>& frame) {
+        queueRead(frame, semanticKey(frame), IcomCivScheduler::Priority::Maintenance);
+    };
+    queueRead(cmdReadId(m_session->civAddress()), "identity.directed",
+              IcomCivScheduler::Priority::Maintenance);
+    queueStartupRead(cmdReadFrequency(m_session->civAddress()));
+    queueStartupRead(cmdReadMode(m_session->civAddress()));
     // ...AND WHETHER THAT MODE IS A DATA MODE. 04 answers USB for both USB and
     // USB-D, so without this a radio the operator left in USB-D was adopted as
     // plain USB at every connect — the mode indicator, the passband and the
@@ -432,17 +455,17 @@ void IcomCivBackend::sendConnectReadBurst()
     // DATA. 26 00 reports mode, DATA and filter together, so it also corrects
     // the 04 above if the two ever disagree.
     if (m_model->hasVfoModeCommand)
-        m_session->sendCiv(cmdReadVfoMode(m_session->civAddress()));
+        queueStartupRead(cmdReadVfoMode(m_session->civAddress()));
 
     // ASK WHERE THE RADIO TAKES ITS MODULATION FROM. Not cosmetic: if this is
     // not WLAN, everything else about transmit can be perfect and the operator
     // still gets zero output. Diagnosing it from the outside means noticing
     // that a keyed radio with healthy audio counters makes no power, which is
     // exactly the dead end this avoids.
-    m_session->sendCiv(cmdReadSetting(m_session->civAddress(),
-                                      setting::kDataOffModInput));
-    m_session->sendCiv(cmdReadSetting(m_session->civAddress(),
-                                      setting::kDataModInput));
+    queueStartupRead(cmdReadSetting(m_session->civAddress(),
+                                    setting::kDataOffModInput));
+    queueStartupRead(cmdReadSetting(m_session->civAddress(),
+                                    setting::kDataModInput));
 
     // ADOPT THE RADIO'S OWN LEVELS. Constitution II/III says an Icom is
     // authoritative over its operating state and the client must never push a
@@ -458,7 +481,7 @@ void IcomCivBackend::sendConnectReadBurst()
                                level::kMicGain, level::kCompLevel, level::kMonitor,
                                level::kNrLevel, level::kNbLevel,
                                level::kNotchPos, level::kRf, level::kVoxGain})
-        m_session->sendCiv(cmdReadLevel(m_session->civAddress(), which));
+        queueStartupRead(cmdReadLevel(m_session->civAddress(), which));
 
     // ...and the switches, which have the same problem: the applet toggles all
     // read "off" on a radio that may have NR or the compressor running.
@@ -466,18 +489,19 @@ void IcomCivBackend::sendConnectReadBurst()
                             func::kNoiseBlanker, func::kAutoNotch,
                             func::kManualNotch,
                             func::kCompressor, func::kMonitorFn, func::kVox})
-        m_session->sendCiv(cmdReadFunction(m_session->civAddress(), fn));
+        queueStartupRead(cmdReadFunction(m_session->civAddress(), fn));
 
     // The attenuator is NOT sub-addressed, so it needs its own read rather than
     // a slot in the loop above.
-    m_session->sendCiv(cmdReadAttenuator(m_session->civAddress()));
+    queueStartupRead(cmdReadAttenuator(m_session->civAddress()));
     // RIT / XIT and the antenna tuner. All four were write-only: the controls
     // opened at OUR defaults, so an operator who set RIT on the radio and
     // reconnected saw zero on a rig that was still offset.
     for (std::uint8_t sub : {tuneOffset::kFrequency, tuneOffset::kRitOnOff,
                              tuneOffset::kXitOnOff})
-        m_session->sendCiv(cmdReadTuneOffset(m_session->civAddress(), sub));
-    m_session->sendCiv(cmdReadTuner(m_session->civAddress()));}
+        queueStartupRead(cmdReadTuneOffset(m_session->civAddress(), sub));
+    queueStartupRead(cmdReadTuner(m_session->civAddress()));
+}
 
 // The radio answered 0x19 0x00. Decide whether to believe it, and where that
 // leaves the destination.
@@ -546,8 +570,14 @@ void IcomCivBackend::adoptReportedCivAddress(std::uint8_t reported)
 
             // Back to what the operator or the handshake gave us. That is a
             // choice with a reason behind it; "whoever spoke first" is not.
-            if (m_session && m_session->civAddress() != m_civSeedAddress) {
-                m_session->setCivAddress(m_civSeedAddress);
+            // Discard everything queued for the responder we no longer trust,
+            // including a directed identity read that may already be in flight.
+            // The replacement snapshot below is the only work allowed to
+            // survive the destination change.
+            m_civScheduler.reset();
+            if (m_session) {
+                if (m_session->civAddress() != m_civSeedAddress)
+                    m_session->setCivAddress(m_civSeedAddress);
                 sendConnectReadBurst();
                 // Same destination argument as the retarget path below: the
                 // switches went to a responder we have just walked away from.
@@ -594,6 +624,10 @@ void IcomCivBackend::adoptReportedCivAddress(std::uint8_t reported)
     // and the radio has just said otherwise about itself — which it is entitled
     // to do, because the address is changeable on the radio's own front panel
     // and nothing on our side can know that.
+    // No queued or in-flight command addressed to the old destination can be
+    // reused after this point. In particular, semantic read coalescing must not
+    // mistake an old-address startup read for the replacement snapshot.
+    m_civScheduler.reset();
     qCInfo(lcIcomAddr) << "retargeting CI-V from" << Qt::hex << m_session->civAddress()
                    << "to the address the radio reported:" << reported;
     m_session->setCivAddress(reported);
@@ -772,17 +806,19 @@ void IcomCivBackend::onSessionConnected(const QString& deviceName)
     //
     // SENT ONCE PER CONNECT. Never polled, never retried on a timer — see the
     // bounded wait below and RFC #4983.
-    if (!m_civAddressPinned)
-        m_session->sendCiv(cmdReadId(kBroadcastAddress));
+    if (!m_civAddressPinned) {
+        queueRead(cmdReadId(kBroadcastAddress), "identity.broadcast",
+                  IcomCivScheduler::Priority::Maintenance);
+    }
 
-    // THE COMMON PATH'S TIMING IS UNCHANGED.
+    // THE COMMON PATH STARTS WITHOUT AN AUTO-DETECT WAIT.
     //
     // Whenever the name resolved — both lab radios and all seven models in
-    // kModels — the address is already right, so the burst goes out now exactly
-    // as it did before and the broadcast above rides alongside it as a
+    // kModels — the address is already right, so the snapshot is admitted now
+    // and the broadcast above leads it through the shared scheduler as a
     // correction path. Only a radio whose name we do not recognise waits, and
-    // only for as long as it takes to learn where to send the burst; sending it
-    // to a guessed address first would be twenty frames to nobody.
+    // only for as long as it takes to learn where to send the snapshot; sending
+    // it to a guessed address first would be twenty frames to nobody.
     if (m_civAddressPinned || m_modelByName) {
         sendConnectReadBurst();
     } else {
@@ -802,7 +838,6 @@ void IcomCivBackend::onSessionConnected(const QString& deviceName)
         });
         m_civDetectTimer->start(kCivDetectTimeoutMs);
     }
-
     applyScopeStartup();
 
     // CONNECTED FIRST, then the state.
@@ -919,6 +954,10 @@ void IcomCivBackend::onSessionConnected(const QString& deviceName)
     connect(m_linkTimer, &QTimer::timeout, this, &IcomCivBackend::onLinkTick);
     m_linkTimer->start(kLinkTickMs);
 
+    // Start the first snapshot request now.  Every remaining startup/control/
+    // meter request leaves through the same paced writer on timer ticks.
+    pumpCiv(QDateTime::currentMSecsSinceEpoch());
+
 
 }
 
@@ -1023,8 +1062,10 @@ void IcomCivBackend::applyScopeStartup()
     m_scopeStarted = true;
     // BOTH switches. Enabling only 0x27 0x10 turns the scope on the radio's own
     // screen and sends us nothing — the number-one "black panadapter" cause.
-    m_session->sendCiv(cmdScopeOnOff(m_session->civAddress(), true));
-    m_session->sendCiv(cmdScopeDataOutput(m_session->civAddress(), true));
+    queueWrite(cmdScopeOnOff(m_session->civAddress(), true), "scope.on",
+               IcomCivScheduler::Priority::Maintenance, false);
+    queueWrite(cmdScopeDataOutput(m_session->civAddress(), true), "scope.output",
+               IcomCivScheduler::Priority::Maintenance, false);
 }
 
 // ---------------------------------------------------------------------------
@@ -1055,7 +1096,9 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
         return;
     }
 
-    noteControlSeen(frame.cmd, frame.sub, frame.hasSub);
+    const qint64 frameAtMs = QDateTime::currentMSecsSinceEpoch();
+    ++m_framesObserved;
+    m_lastInboundCivAtMs = frameAtMs;
 
     // PAST THE SCOPE RETURN, so sweeps never enter the ring. Re-serialised
     // rather than captured raw because the parsed frame is what we have here,
@@ -1068,20 +1111,39 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
         if (frame.hasSub)
             flat.push_back(frame.sub);
         flat.insert(flat.end(), frame.data.begin(), frame.data.end());
-        traceCiv(/*outbound=*/false, flat);
+        const bool routine = frame.cmd == cmd::kMeter
+            || (frame.cmd == cmd::kControl && frame.hasSub && frame.sub == control::kPtt);
+        traceCiv(/*outbound=*/false, flat, routine);
     }
+
+    // A bus echo is not a reply. IcomSession normally removes it, but keep the
+    // scheduler from retiring an identity transaction if an echo reaches this
+    // seam: the echoed 19 00 has the same command shape as the real answer.
+    if (frame.cmd == cmd::kReadId && frame.from == kControllerAddress)
+        return;
+
+    const IcomCivScheduler::Observation observation =
+        m_civScheduler.observe(frame, frameAtMs);
+    // Identity can retarget the CI-V destination. Do not dispatch the next
+    // queued startup frame until adoptReportedCivAddress() has either confirmed
+    // the address or discarded all work aimed at the old one.
+    const bool identityReply = frame.cmd == cmd::kReadId;
+    if (!identityReply)
+        pumpCiv(frameAtMs);
+    const bool isPttState = frame.cmd == cmd::kControl && frame.hasSub
+        && frame.sub == control::kPtt && !frame.data.empty();
+    if (observation == IcomCivScheduler::Observation::Stale && !isPttState) {
+        qCWarning(lcIcomScheduler)
+            << "suppressed stale CI-V completion" << frame.cmd << frame.sub;
+        if (identityReply)
+            pumpCiv(frameAtMs);
+        return;
+    }
+
+    noteControlSeen(frame.cmd, frame.sub, frame.hasSub);
 
     switch (frame.cmd) {
     case cmd::kReadId: {
-        // NOT OUR OWN ECHO. CI-V is a bus and the radio echoes back every frame
-        // it carried, so the first 0x19 0x00 seen after a broadcast is always
-        // the one we sent — measured on both lab radios, echo before reply,
-        // every run. IcomSession's filter drops it and this is the second line
-        // of that defence: the echo carries no data byte, so parseModelIdReply
-        // rejects it too, but "a frame from 0xE0 is ours" is the rule that will
-        // still hold when someone adds a 0x19 form that does carry one.
-        if (frame.from == kControllerAddress)
-            return;
         if (auto addr = parseModelIdReply(frame)) {
             // THE ADDRESS ARRIVES TWICE — in the frame's `from` byte and in the
             // payload — and they agreed on every measured run. Prefer the
@@ -1099,8 +1161,10 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
             // AMBIGUOUS BUS: two devices answered with different addresses, so
             // neither one's identity can be trusted either. Leave m_model where
             // the name put it.
-            if (m_civAmbiguous)
+            if (m_civAmbiguous) {
+                pumpCiv(frameAtMs);
                 return;
+            }
             if (const IcomModel* m = modelForCivAddress(*addr)) {
                 m_model = m;
                 // The span limits and scope geometry are model facts, so they
@@ -1142,6 +1206,7 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
                                         static_cast<int>(m_model->name.size()));
             emit radioChanged(r);
         }
+        pumpCiv(frameAtMs);
         return;
     }
 
@@ -1195,7 +1260,9 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
         // transient false DIGU/DIGL (or false voice mode) until 26 answered.
         // Command 26 is the single authoritative publication for these models.
         if (frame.cmd == cmd::kSetModeTrx && m_session && m_model->hasVfoModeCommand) {
-            m_session->sendCiv(cmdReadVfoMode(m_session->civAddress()));
+            const auto read = cmdReadVfoMode(m_session->civAddress());
+            queueRead(read, semanticKey(read), IcomCivScheduler::Priority::Maintenance);
+            pumpCiv(QDateTime::currentMSecsSinceEpoch());
         } else if (!m_model->hasVfoModeCommand) {
             // This model has no verified DATA readback. An ordinary mode frame
             // can only justify an ordinary mode claim.
@@ -1518,6 +1585,28 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
     case cmd::kControl: {
         if (frame.hasSub && frame.sub == control::kPtt && !frame.data.empty()) {
             const bool keyed = frame.data[0] != 0;
+            // A read can already be on the wire when the operator keys.  Its
+            // pre-write OFF answer then arrives after the newer ON request.
+            // During the bounded confirmation window only the requested value
+            // may confirm the intent; a contradictory value is diagnostic
+            // history, not a newer state transition.  Once the window expires,
+            // the next fresh radio report wins again (Constitution II).
+            if (m_pendingPttIntent) {
+                if (keyed == *m_pendingPttIntent) {
+                    m_pendingPttIntent.reset();
+                    m_pendingPttUntilMs = 0;
+                } else if (frameAtMs < m_pendingPttUntilMs) {
+                    qCWarning(lcIcomScheduler)
+                        << "suppressed contradictory PTT state during confirmation"
+                        << "reported" << keyed << "intent" << *m_pendingPttIntent;
+                    return;
+                } else {
+                    m_pendingPttIntent.reset();
+                    m_pendingPttUntilMs = 0;
+                }
+            } else if (observation == IcomCivScheduler::Observation::Stale) {
+                return;
+            }
             // ON CHANGE ONLY. This is the answer to a poll that runs four times
             // a second, and it used to republish the transmit state on every
             // one of them — a 4 Hz stream of "the radio is transmitting" events
@@ -1730,34 +1819,218 @@ void IcomCivBackend::submitTxAudio(const QByteArray& int16Stereo, int sampleRate
 // Intents DOWN
 // ---------------------------------------------------------------------------
 
+std::string IcomCivBackend::semanticKey(std::span<const std::uint8_t> frame) const
+{
+    const std::optional<CivFrame> parsed = parseFrame(frame);
+    if (!parsed) {
+        return {};
+    }
+    switch (parsed->cmd) {
+    case cmd::kSetFreqTrx:
+    case cmd::kReadFreq:
+    case cmd::kSetFreq:
+        return "frequency";
+    case cmd::kSetModeTrx:
+    case cmd::kReadMode:
+    case cmd::kSetMode:
+    case cmd::kVfoMode:
+        return "mode";
+    default:
+        break;
+    }
+    if (parsed->cmd == cmd::kControl && parsed->hasSub) {
+        if (parsed->sub == control::kPtt) {
+            return "ptt";
+        }
+        if (parsed->sub == control::kTuner) {
+            return "tuner";
+        }
+    }
+    std::string key = "civ." + std::to_string(parsed->cmd);
+    if (parsed->hasSub) {
+        key += "." + std::to_string(parsed->sub);
+    }
+    // SET-menu reads share 1A 05 but name their leaf in the first two data
+    // bytes.  Keep the leaves separate so one startup query cannot coalesce a
+    // different setting merely because their outer command matches.
+    if (parsed->cmd == cmd::kSetting && parsed->hasSub && parsed->data.size() >= 2) {
+        key += "." + std::to_string(parsed->data[0]);
+        key += "." + std::to_string(parsed->data[1]);
+    }
+    return key;
+}
+
+std::optional<std::vector<std::uint8_t>>
+IcomCivBackend::confirmationFor(std::span<const std::uint8_t> frame) const
+{
+    const std::optional<CivFrame> parsed = parseFrame(frame);
+    if (!parsed || parsed->data.empty()) {
+        return std::nullopt;
+    }
+    const std::uint8_t addr = m_session ? m_session->civAddress() : 0xA4;
+    switch (parsed->cmd) {
+    case cmd::kSetFreq:
+        return cmdReadFrequency(addr);
+    case cmd::kSetMode:
+        return cmdReadMode(addr);
+    case cmd::kVfoMode:
+        return cmdReadVfoMode(addr);
+    case cmd::kLevel:
+    case cmd::kFunction:
+    case cmd::kControl:
+    case cmd::kTuneOffset:
+        if (parsed->hasSub) {
+            return buildFrameSub(addr, parsed->cmd, parsed->sub);
+        }
+        break;
+    case cmd::kAttenuator:
+        return cmdReadAttenuator(addr);
+    default:
+        break;
+    }
+    return std::nullopt;
+}
+
+void IcomCivBackend::queueRead(const std::vector<std::uint8_t>& frame,
+                               const std::string& key,
+                               IcomCivScheduler::Priority priority,
+                               qint64 notBeforeMs)
+{
+    const std::optional<CivFrame> parsed = parseFrame(frame);
+    if (!parsed) {
+        return;
+    }
+    IcomCivScheduler::Request request;
+    request.frame = frame;
+    request.key = key.empty() ? semanticKey(frame) : key;
+    request.priority = priority;
+    request.expectsReply = true;
+    request.replyCmd = parsed->cmd;
+    request.replyHasSub = parsed->hasSub;
+    request.replySub = parsed->sub;
+    request.notBeforeMs = notBeforeMs;
+    m_civScheduler.enqueue(std::move(request), QDateTime::currentMSecsSinceEpoch());
+}
+
+void IcomCivBackend::queueWrite(const std::vector<std::uint8_t>& frame,
+                                const std::string& key,
+                                IcomCivScheduler::Priority priority,
+                                bool supersedes)
+{
+    IcomCivScheduler::Request request;
+    request.frame = frame;
+    request.key = key.empty() ? semanticKey(frame) : key;
+    request.priority = priority;
+    request.expectsReply = true;
+    request.acceptsGenericReply = true;
+    request.supersedes = supersedes;
+    m_civScheduler.enqueue(std::move(request), QDateTime::currentMSecsSinceEpoch());
+}
+
+void IcomCivBackend::queueEmergencyWriteNoReply(const std::vector<std::uint8_t>& frame,
+                                                const std::string& key)
+{
+    IcomCivScheduler::Request request;
+    request.frame = frame;
+    request.key = key.empty() ? semanticKey(frame) : key;
+    request.priority = IcomCivScheduler::Priority::Emergency;
+    request.supersedes = true;
+    request.coalesce = false;
+    m_civScheduler.enqueue(std::move(request), QDateTime::currentMSecsSinceEpoch());
+}
+
+void IcomCivBackend::pumpCiv(qint64 nowMs)
+{
+    if (!m_session || !m_connected) {
+        serviceSchedulerWaiters(nowMs);
+        return;
+    }
+    const std::optional<IcomCivScheduler::Dispatch> dispatch = m_civScheduler.takeNext(nowMs);
+    if (!dispatch) {
+        serviceSchedulerWaiters(nowMs);
+        return;
+    }
+    traceCiv(/*outbound=*/true, dispatch->frame,
+             dispatch->priority >= IcomCivScheduler::Priority::Ptt);
+    if (dispatch->supersedes) {
+        if (dispatch->frame.size() > 5) {
+            noteControlSent(dispatch->frame[4], dispatch->frame[5], true);
+        } else if (dispatch->frame.size() > 4) {
+            noteControlSent(dispatch->frame[4], 0, false);
+        }
+    }
+    if (dispatch->frame.size() > 4) {
+        QString hex;
+        for (std::size_t i = 4; i + 1 < dispatch->frame.size(); ++i) {
+            hex += QStringLiteral("%1 ").arg(dispatch->frame[i], 2, 16, QLatin1Char('0'));
+        }
+        m_lastOutboundCiv = hex.trimmed();
+        m_lastOutboundCivAtMs = nowMs;
+    }
+    m_session->sendCiv(dispatch->frame);
+    serviceSchedulerWaiters(nowMs);
+}
+
+QVariantMap IcomCivBackend::schedulerDiagnostics() const
+{
+    const IcomCivScheduler::Stats stats = m_civScheduler.stats();
+    QVariantMap out;
+    out.insert(QStringLiteral("idle"), m_civScheduler.idle());
+    out.insert(QStringLiteral("slotMs"), IcomCivScheduler::kSlotMs);
+    out.insert(QStringLiteral("readTimeoutMs"), IcomCivScheduler::kReadTimeoutMs);
+    out.insert(QStringLiteral("queueDepth"), static_cast<qulonglong>(stats.queueDepth));
+    out.insert(QStringLiteral("readInFlight"), stats.readInFlight);
+    out.insert(QStringLiteral("inFlightKey"), QString::fromStdString(stats.inFlightKey));
+    out.insert(QStringLiteral("queued"), static_cast<qulonglong>(stats.queued));
+    out.insert(QStringLiteral("dispatched"), static_cast<qulonglong>(stats.dispatched));
+    out.insert(QStringLiteral("coalesced"), static_cast<qulonglong>(stats.coalesced));
+    out.insert(QStringLiteral("replies"), static_cast<qulonglong>(stats.replies));
+    out.insert(QStringLiteral("staleReplies"), static_cast<qulonglong>(stats.staleReplies));
+    out.insert(QStringLiteral("timeouts"), static_cast<qulonglong>(stats.timeouts));
+    out.insert(QStringLiteral("pendingPttIntent"), m_pendingPttIntent.has_value());
+    if (m_pendingPttIntent) {
+        out.insert(QStringLiteral("pttIntent"), *m_pendingPttIntent);
+        out.insert(QStringLiteral("pttIntentDeadlineMs"), m_pendingPttUntilMs);
+    }
+    return out;
+}
+
+void IcomCivBackend::serviceSchedulerWaiters(qint64 nowMs)
+{
+    for (auto it = m_schedulerWaiters.begin(); it != m_schedulerWaiters.end();) {
+        if (!m_civScheduler.idle() && nowMs < it->deadlineMs) {
+            ++it;
+            continue;
+        }
+        QVariantMap result = schedulerDiagnostics();
+        result.insert(QStringLiteral("timedOut"), !m_civScheduler.idle());
+        emit extensionResult(it->requestId, result);
+        it = m_schedulerWaiters.erase(it);
+    }
+}
+
 void IcomCivBackend::sendUserCommand(const std::vector<std::uint8_t>& frame)
 {
     if (!m_session || !m_connected)
         return;
-    // Tell the scheduler a real command just went out, so metering yields and
-    // the command is not stuck behind a queue of polls.
     const qint64 now = QDateTime::currentMSecsSinceEpoch();
-    m_meters.noteUserCommand(now);
-    m_controlPollQuietUntilMs = now + kControlPollQuietMs;
-    traceCiv(/*outbound=*/true, frame);
-    // Record WHICH registry row this frame belongs to. Byte 4 is the command and
-    // byte 5 the subcommand when the row has one — the same layout buildFrame
-    // writes. This is what turns the registry's declared wiring into an observed
-    // fact: `controls.map` can then say a row claims to be sent AND has been.
-    if (frame.size() > 5)
-        noteControlSent(frame[4], frame[5], true);
-    else if (frame.size() > 4)
-        noteControlSent(frame[4], 0, false);
-    // Remembered for the stall warning in onLinkTick: what was the radio last
-    // asked to do before it went quiet.
-    if (frame.size() > 4) {
-        QString hex;
-        for (std::size_t i = 4; i + 1 < frame.size(); ++i)
-            hex += QStringLiteral("%1 ").arg(frame[i], 2, 16, QLatin1Char('0'));
-        m_lastOutboundCiv = hex.trimmed();
-        m_lastOutboundCivAtMs = QDateTime::currentMSecsSinceEpoch();
+    const std::string key = semanticKey(frame);
+    const std::optional<CivFrame> parsed = parseFrame(frame);
+    if (parsed) {
+        noteControlScheduled(parsed->cmd, parsed->sub, parsed->hasSub);
     }
-    m_session->sendCiv(frame);
+    const bool failSafeUnkey = parsed && parsed->cmd == cmd::kControl
+        && parsed->hasSub && parsed->sub == control::kPtt
+        && !parsed->data.empty() && parsed->data.front() == 0;
+    queueWrite(frame, key, failSafeUnkey ? IcomCivScheduler::Priority::Emergency
+                                        : IcomCivScheduler::Priority::Operator);
+    if (const auto confirmation = confirmationFor(frame)) {
+        // Let the radio apply the write before asking.  The confirmation has
+        // the same semantic generation, while any read already on the wire is
+        // older and will be rejected by observe().
+        queueRead(*confirmation, key, IcomCivScheduler::Priority::Operator, now + 60);
+    }
+    pumpCiv(now);
 }
 
 void IcomCivBackend::setSliceFrequency(int, double hz)
@@ -1852,9 +2125,6 @@ void IcomCivBackend::setSliceMode(int, const QString& mode)
     // publish below if the radio refused or altered the change — a mode with no
     // DATA variant, a band where the radio will not enter it. One extra frame
     // on the operator's own mode change, not a new poll.
-    if (m_session && m_model->hasVfoModeCommand)
-        m_session->sendCiv(cmdReadVfoMode(addr));
-
     // PUBLISH THE PASSBAND NOW, from the mode we just commanded.
     //
     // Waiting for the radio to report the mode back is not good enough: the
@@ -1909,9 +2179,6 @@ void IcomCivBackend::setSliceFilter(int, int lowHz, int highHz)
     // A write is intent; the radio's own reply is state. This also corrects the
     // optimistic passband below if the radio clamps or refuses the requested
     // slot while CI-V Transceive is disabled.
-    if (m_session && m_model->hasVfoModeCommand)
-        m_session->sendCiv(cmdReadVfoMode(addr));
-
     // PUBLISH THE PASSBAND NOW, for the same reason setSliceMode does: the
     // radio's mode report only comes back if CI-V Transceive is on, and the
     // operator who just clicked a filter button is owed an immediate answer.
@@ -2261,10 +2528,8 @@ void IcomCivBackend::setAtu(bool start)
 {
     sendUserCommand(cmdSetTuner(m_session ? m_session->civAddress() : 0xA4,
                                 start ? 0x02 : 0x00));
-    // Ask what it did. The radio does not report the outcome unprompted, and
-    // "tuning" is a transient the operator needs to see end.
-    if (m_session)
-        m_session->sendCiv(cmdReadTuner(m_session->civAddress()));
+    // sendUserCommand queues a readback after the radio has applied the write;
+    // that confirmation is also what lets the transient tuning state settle.
 }
 
 void IcomCivBackend::setSliceSquelch(int, bool on, int level)
@@ -2303,6 +2568,8 @@ void IcomCivBackend::setKeying(bool key)
 {
     if (!m_model->hasTransmit)
         return;   // an unknown radio is not advertised as transmit-capable
+    m_pendingPttIntent = key;
+    m_pendingPttUntilMs = QDateTime::currentMSecsSinceEpoch() + 1000;
     sendUserCommand(cmdSetPtt(m_session ? m_session->civAddress() : 0xA4, key));
     // PUBLISH IT. Setting m_keyed silently here and leaving the announcement to
     // the poll does not work now that the poll only speaks on change: our own
@@ -2405,10 +2672,17 @@ void IcomCivBackend::noteControlSent(std::uint8_t cmd, std::uint8_t sub, bool ha
     });
 }
 
+void IcomCivBackend::noteControlScheduled(std::uint8_t cmd, std::uint8_t sub,
+                                          bool hasSub)
+{
+    forEachSpecForFrame(cmd, sub, hasSub, [this](const icom::ControlSpec& c) {
+        const QString id = QString::fromUtf8(c.id.data(), static_cast<int>(c.id.size()));
+        m_controlsScheduled.insert(id);
+    });
+}
+
 void IcomCivBackend::noteControlSeen(std::uint8_t cmd, std::uint8_t sub, bool hasSub)
 {
-    ++m_framesObserved;
-    m_lastInboundCivAtMs = QDateTime::currentMSecsSinceEpoch();
     forEachSpecForFrame(cmd, sub, hasSub, [this](const icom::ControlSpec& c) {
         const QString id = QString::fromUtf8(c.id.data(), static_cast<int>(c.id.size()));
         m_controlsSeen.insert(id);
@@ -2577,6 +2851,7 @@ QVariantMap IcomCivBackend::controlScrub(const QString& filter)
 
         ++checked;
         m_controlsSent.remove(id);
+        m_controlsScheduled.remove(id);
 
         // DRIVE IT THROUGH THE SEAM, with a value that changes nothing.
         //
@@ -2586,7 +2861,9 @@ QVariantMap IcomCivBackend::controlScrub(const QString& filter)
         // rearranged.
         const bool driven = scrubDrive(c);
         const bool onWire = m_controlsSent.contains(id);
-        if (onWire)
+        const bool scheduled = m_controlsScheduled.contains(id);
+        const bool linked = onWire || scheduled;
+        if (linked)
             ++reached;
         else if (!driven)
             ++skipped;
@@ -2600,13 +2877,18 @@ QVariantMap IcomCivBackend::controlScrub(const QString& filter)
                           : QStringLiteral("%1").arg(c.cmd, 2, 16, QLatin1Char('0')));
         r.insert(QStringLiteral("seamVerb"), sv(c.seamVerb));
         r.insert(QStringLiteral("reachedWire"), onWire);
+        r.insert(QStringLiteral("reachedScheduler"), scheduled);
         r.insert(QStringLiteral("status"),
-                 onWire    ? QStringLiteral("LINKED")
+                 linked    ? QStringLiteral("LINKED")
                  : !driven ? QStringLiteral("NOT-TESTED")
                            : QStringLiteral("BROKEN"));
         r.insert(QStringLiteral("verdict"),
                  onWire
                      ? QStringLiteral("the seam verb put this command on the wire")
+                 : scheduled
+                     ? QStringLiteral("the seam verb admitted this exact command to the CI-V "
+                                      "scheduler; wait for `civ scheduler` idle with no new "
+                                      "timeout to prove dispatch and readback")
                  : !driven
                      ? QStringLiteral("no safe way to re-assert this without changing "
                                       "the operator's setting — not a fault, not a pass")
@@ -2623,7 +2905,8 @@ QVariantMap IcomCivBackend::controlScrub(const QString& filter)
     out.insert(QStringLiteral("note"),
                QStringLiteral("Each control is re-asserted at its CURRENT value, so nothing "
                               "on the radio moves. PTT, the antenna tuner and power-off are "
-                              "never scrubbed."));
+                              "never scrubbed. Scheduler admission is reported separately "
+                              "from physical dispatch; finish the proof with `civ scheduler`."));
     return out;
 }
 
@@ -2798,7 +3081,8 @@ bool IcomCivBackend::scrubDrive(const icom::ControlSpec& c)
     return false;
 }
 
-void IcomCivBackend::traceCiv(bool outbound, std::span<const std::uint8_t> frame)
+void IcomCivBackend::traceCiv(bool outbound, std::span<const std::uint8_t> frame,
+                              bool routine)
 {
     QString hex;
     hex.reserve(static_cast<int>(frame.size()) * 3);
@@ -2807,7 +3091,7 @@ void IcomCivBackend::traceCiv(bool outbound, std::span<const std::uint8_t> frame
             hex += QLatin1Char(' ');
         hex += QStringLiteral("%1").arg(b, 2, 16, QLatin1Char('0'));
     }
-    m_civTrace.push_back({QDateTime::currentMSecsSinceEpoch(), outbound, hex});
+    m_civTrace.push_back({QDateTime::currentMSecsSinceEpoch(), outbound, routine, hex});
     while (m_civTrace.size() > kCivTraceMax)
         m_civTrace.pop_front();
 }
@@ -2825,11 +3109,8 @@ QVariantList IcomCivBackend::civTrace(bool includeRoutine) const
         //
         // Hidden, not dropped: `civ trace all` still returns them, because
         // "the meters stopped answering" is itself a diagnosis and needs them.
-        if (!includeRoutine && !e.outbound) {
-            if (e.hex.startsWith(QLatin1String("15 "))
-                || e.hex.startsWith(QLatin1String("1c 00"))) {
-                continue;
-            }
+        if (!includeRoutine && e.routine) {
+            continue;
         }
         QVariantMap m;
         // AGE, not a wall clock. The consumer is an agent correlating a reply
@@ -2922,6 +3203,24 @@ void IcomCivBackend::invokeExtension(const QString& ns, const QString& verb, qui
     }
     if (verb == QLatin1String("controls.scrub")) {
         emit extensionResult(requestId, controlScrub(arg.toString().trimmed()));
+        return;
+    }
+    if (verb == QLatin1String("civ.scheduler.status")) {
+        emit extensionResult(requestId, schedulerDiagnostics());
+        return;
+    }
+    if (verb == QLatin1String("civ.scheduler.wait-idle")) {
+        int timeoutMs = arg.toMap().value(QStringLiteral("timeoutMs"), 3000).toInt();
+        if (!arg.canConvert<QVariantMap>()) {
+            timeoutMs = arg.toInt();
+            if (timeoutMs <= 0) {
+                timeoutMs = 3000;
+            }
+        }
+        timeoutMs = std::clamp(timeoutMs, 0, 10000);
+        m_schedulerWaiters.push_back(
+            SchedulerWaiter{requestId, QDateTime::currentMSecsSinceEpoch() + timeoutMs});
+        serviceSchedulerWaiters(QDateTime::currentMSecsSinceEpoch());
         return;
     }
     if (verb == QLatin1String("civ.trace")) {
@@ -3040,8 +3339,9 @@ void IcomCivBackend::onMeterTick()
     // report, and it is a receive-side blindness rather than a metering bug.
     if (m_session && now - m_lastPttPollMs >= kPttPollMs) {
         m_lastPttPollMs = now;
-        m_session->sendCiv(buildFrameSub(m_session->civAddress(), cmd::kControl,
-                                         control::kPtt));
+        const auto frame = buildFrameSub(m_session->civAddress(), cmd::kControl,
+                                         control::kPtt);
+        queueRead(frame, "ptt", IcomCivScheduler::Priority::Ptt);
     }
 
     for (MeterId id : m_meters.due(now)) {
@@ -3051,8 +3351,10 @@ void IcomCivBackend::onMeterTick()
         // Deliberately NOT sendUserCommand(): a meter poll must not reset the
         // scheduler's own user-command guard, or metering would permanently
         // suppress itself.
-        m_session->sendCiv(cmdReadMeter(m_session->civAddress(), spec->sub));
+        const auto frame = cmdReadMeter(m_session->civAddress(), spec->sub);
+        queueRead(frame, semanticKey(frame), IcomCivScheduler::Priority::ActiveMeter);
     }
+    pumpCiv(now);
 }
 
 void IcomCivBackend::onLinkTick()
@@ -3076,6 +3378,15 @@ void IcomCivBackend::onLinkTick()
     m_link = out;
     emit linkStatsUpdated(out);
 
+    const IcomCivScheduler::Stats schedulerStats = m_civScheduler.stats();
+    if (schedulerStats.timeouts > m_schedulerTimeoutsReported) {
+        qCWarning(lcIcomScheduler)
+            << "CI-V read timeout; scheduler recovered"
+            << "timeouts" << schedulerStats.timeouts
+            << "queueDepth" << schedulerStats.queueDepth;
+        m_schedulerTimeoutsReported = schedulerStats.timeouts;
+    }
+
     // ---- CI-V STALL DETECTION ------------------------------------------
     //
     // The UDP transport can be perfectly healthy while the COMMAND PLANE is
@@ -3094,44 +3405,51 @@ void IcomCivBackend::onLinkTick()
         return;
     const qint64 now = QDateTime::currentMSecsSinceEpoch();
 
-    // CI-V transceive does not announce most knob/switch changes. Poll small,
-    // rotating groups so front-panel state reaches the UI without a ten-frame
-    // burst, and yield briefly after operator writes so reconciliation cannot
-    // immediately overtake intent. RFC #4983 centralizes this policy later.
+    // CI-V Transceive is a low-latency hint, not a subscription. Queue bounded
+    // reconciliation groups; the scheduler turns them into one paced stream,
+    // coalesces duplicates and lets an operator command overtake all of them.
     const std::uint8_t addr = m_session->civAddress();
-    if (now >= m_controlPollQuietUntilMs) {
-        switch (m_controlPollPhase++ % 6) {
-        case 0:
-            m_session->sendCiv(cmdReadLevel(addr, level::kRf));
-            if (!m_tuning)
-                m_session->sendCiv(cmdReadLevel(addr, level::kRfPower));
-            m_session->sendCiv(cmdReadLevel(addr, level::kMicGain));
-            break;
-        case 1:
-            for (std::uint8_t which : {level::kMonitor, level::kVoxGain,
-                                       level::kNotchPos})
-                m_session->sendCiv(cmdReadLevel(addr, which));
-            break;
-        case 2:
-            for (std::uint8_t which : {level::kNrLevel, level::kNbLevel})
-                m_session->sendCiv(cmdReadLevel(addr, which));
-            for (std::uint8_t fn : {func::kMonitorFn, func::kVox})
-                m_session->sendCiv(cmdReadFunction(addr, fn));
-            break;
-        case 3:
-            for (std::uint8_t fn : {func::kAutoNotch, func::kManualNotch,
-                                    func::kNoiseReduce, func::kNoiseBlanker})
-                m_session->sendCiv(cmdReadFunction(addr, fn));
-            break;
-        case 4:
-            m_session->sendCiv(cmdReadFunction(addr, func::kPreamp));
-            m_session->sendCiv(cmdReadAttenuator(addr));
-            break;
-        default:
-            m_session->sendCiv(cmdReadTuner(addr));
-            break;
+    const auto queueControl = [this](const std::vector<std::uint8_t>& frame) {
+        queueRead(frame, semanticKey(frame), IcomCivScheduler::Priority::Control);
+    };
+    const int phase = ++m_controlPollPhase;
+
+    // Switches whose front-panel state must feel live. NR/NB were the measured
+    // failure: Transceive sometimes announced them and sometimes did not.
+    for (std::uint8_t fn : {func::kAutoNotch, func::kManualNotch,
+                            func::kNoiseReduce, func::kNoiseBlanker}) {
+        queueControl(cmdReadFunction(addr, fn));
+    }
+
+    if (phase % 2 == 0) {
+        queueControl(cmdReadFrequency(addr));
+        queueControl(m_model->hasVfoModeCommand ? cmdReadVfoMode(addr)
+                                                : cmdReadMode(addr));
+        for (std::uint8_t fn : {func::kMonitorFn, func::kVox}) {
+            queueControl(cmdReadFunction(addr, fn));
         }
     }
+
+    if (phase % 3 == 0) {
+        for (std::uint8_t which : {level::kRf, level::kMicGain, level::kMonitor,
+                                   level::kVoxGain, level::kNotchPos,
+                                   level::kNrLevel, level::kNbLevel}) {
+            queueControl(cmdReadLevel(addr, which));
+        }
+        if (!m_tuning) {
+            queueControl(cmdReadLevel(addr, level::kRfPower));
+        }
+        for (std::uint8_t fn : {func::kPreamp, func::kAgc}) {
+            queueControl(cmdReadFunction(addr, fn));
+        }
+        queueControl(cmdReadAttenuator(addr));
+        queueControl(cmdReadTuner(addr));
+        for (std::uint8_t sub : {tuneOffset::kFrequency, tuneOffset::kRitOnOff,
+                                 tuneOffset::kXitOnOff}) {
+            queueControl(cmdReadTuneOffset(addr, sub));
+        }
+    }
+    pumpCiv(now);
     if (m_lastInboundCivAtMs <= 0) {
         m_lastInboundCivAtMs = now;   // start the clock at the first tick
         return;

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -36,8 +36,12 @@ Q_LOGGING_CATEGORY(lcIcomScheduler, "aether.icom.scheduler")
 Q_LOGGING_CATEGORY(lcIcomAddr, "aether.icom.address")
 
 // Metering is examined this often; the MeterPoller decides what is actually
-// due. Deliberately faster than the fastest meter interval so a due meter is
-// not delayed by up to a whole tick.
+// due. This is ALSO the scheduler's pump, which is why it is 10 ms and not the
+// 40 ms the meter intervals alone would justify: IcomCivScheduler releases at
+// most one frame per kSlotMs (25 ms), and a tick slower than the slot would
+// stretch the effective dispatch interval to tick + slot. At 10 ms the pump
+// costs a `due()` scan and one takeNext() on an empty queue, and the slot —
+// not this timer — remains what paces the wire.
 constexpr int kMeterTickMs = 10;
 // Transport counters publish on a FIXED cadence, not on receive: "nothing
 // arrived this second" is the observation the heartbeat's alarm path waits for,
@@ -1591,19 +1595,37 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
             // may confirm the intent; a contradictory value is diagnostic
             // history, not a newer state transition.  Once the window expires,
             // the next fresh radio report wins again (Constitution II).
+            //
+            // ONE DIRECTION ONLY — suppression applies while the pending intent
+            // is KEY ON, never while it is key off.  The two directions are not
+            // symmetric risks.  Swallowing a stale OFF after a key-on request
+            // costs a transmission (the captured FT8 failure).  Swallowing an
+            // unexpected ON after an unkey request costs the operator any
+            // indication that the radio is still on the air — when the unkey was
+            // lost, refused, or overridden at the front panel, that report is
+            // the only thing that says so.  RFC #4983 states the rule directly:
+            // "Explicit PTT OFF and fail-safe unkey are never suppressed by a
+            // key-on transition guard", and Constitution VI wants every path
+            // that can transmit to fail closed.
             if (m_pendingPttIntent) {
-                if (keyed == *m_pendingPttIntent) {
-                    m_pendingPttIntent.reset();
-                    m_pendingPttUntilMs = 0;
-                } else if (frameAtMs < m_pendingPttUntilMs) {
+                const bool confirmsIntent = keyed == *m_pendingPttIntent;
+                const bool guarding = *m_pendingPttIntent
+                    && !confirmsIntent && frameAtMs < m_pendingPttUntilMs;
+                if (guarding) {
                     qCWarning(lcIcomScheduler)
                         << "suppressed contradictory PTT state during confirmation"
                         << "reported" << keyed << "intent" << *m_pendingPttIntent;
                     return;
-                } else {
-                    m_pendingPttIntent.reset();
-                    m_pendingPttUntilMs = 0;
                 }
+                if (!confirmsIntent && !*m_pendingPttIntent) {
+                    // The radio says it is keyed while we asked it to stop.
+                    // Publish it and say so — this is the fail-closed path.
+                    qCWarning(lcIcomScheduler)
+                        << "radio reports KEYED after an unkey request; "
+                           "publishing radio truth";
+                }
+                m_pendingPttIntent.reset();
+                m_pendingPttUntilMs = 0;
             } else if (observation == IcomCivScheduler::Observation::Stale) {
                 return;
             }
@@ -1950,8 +1972,14 @@ void IcomCivBackend::pumpCiv(qint64 nowMs)
         serviceSchedulerWaiters(nowMs);
         return;
     }
-    traceCiv(/*outbound=*/true, dispatch->frame,
-             dispatch->priority >= IcomCivScheduler::Priority::Ptt);
+    // ROUTINE = the high-rate loops only.  `>= Ptt` also swept up Control and
+    // Maintenance, which hid the startup snapshot and the scope on/output
+    // writes from the default `civ trace` — the frames behind the documented
+    // number-one "black panadapter" cause. Before the scheduler every outbound
+    // frame was shown; keep it that way for everything but the pollers.
+    const bool routineDispatch = dispatch->priority == IcomCivScheduler::Priority::Ptt
+        || dispatch->priority == IcomCivScheduler::Priority::ActiveMeter;
+    traceCiv(/*outbound=*/true, dispatch->frame, routineDispatch);
     if (dispatch->supersedes) {
         if (dispatch->frame.size() > 5) {
             noteControlSent(dispatch->frame[4], dispatch->frame[5], true);
@@ -1997,16 +2025,25 @@ QVariantMap IcomCivBackend::schedulerDiagnostics() const
 
 void IcomCivBackend::serviceSchedulerWaiters(qint64 nowMs)
 {
+    // COLLECT, ERASE, THEN EMIT. extensionResult is a direct connection, so a
+    // slot that registers another waiter would reallocate the vector under an
+    // iterator we are still holding. Finishing all mutation first makes the
+    // re-entrant case merely queue more work instead of corrupting the walk.
+    std::vector<quint64> ready;
     for (auto it = m_schedulerWaiters.begin(); it != m_schedulerWaiters.end();) {
         if (!m_civScheduler.idle() && nowMs < it->deadlineMs) {
             ++it;
             continue;
         }
-        QVariantMap result = schedulerDiagnostics();
-        result.insert(QStringLiteral("timedOut"), !m_civScheduler.idle());
-        emit extensionResult(it->requestId, result);
+        ready.push_back(it->requestId);
         it = m_schedulerWaiters.erase(it);
     }
+    if (ready.empty())
+        return;
+    QVariantMap result = schedulerDiagnostics();
+    result.insert(QStringLiteral("timedOut"), !m_civScheduler.idle());
+    for (quint64 requestId : ready)
+        emit extensionResult(requestId, result);
 }
 
 void IcomCivBackend::sendUserCommand(const std::vector<std::uint8_t>& frame)
@@ -2121,10 +2158,12 @@ void IcomCivBackend::setSliceMode(int, const QString& mode)
         sendUserCommand(cmdSetMode(addr, *civ, m_filter));
     }
     // CONFIRM. Everything above is a request; only the radio's own answer is
-    // state (Constitution II). This read is what corrects the optimistic
-    // publish below if the radio refused or altered the change — a mode with no
-    // DATA variant, a band where the radio will not enter it. One extra frame
-    // on the operator's own mode change, not a new poll.
+    // state (Constitution II). sendUserCommand queues that confirmation read
+    // itself, at Operator priority and one generation ahead of any poll already
+    // on the wire, and it is what corrects the optimistic publish below if the
+    // radio refused or altered the change — a mode with no DATA variant, a band
+    // where the radio will not enter it. One extra frame on the operator's own
+    // mode change, not a new poll.
     // PUBLISH THE PASSBAND NOW, from the mode we just commanded.
     //
     // Waiting for the radio to report the mode back is not good enough: the
@@ -2176,9 +2215,11 @@ void IcomCivBackend::setSliceFilter(int, int lowHz, int highHz)
         sendUserCommand(cmdSetVfoMode(addr, m_mode, m_dataMode, filter));
     else
         sendUserCommand(cmdSetMode(addr, m_mode, filter));
-    // A write is intent; the radio's own reply is state. This also corrects the
-    // optimistic passband below if the radio clamps or refuses the requested
-    // slot while CI-V Transceive is disabled.
+    // A write is intent; the radio's own reply is state. sendUserCommand
+    // schedules that readback itself now (confirmationFor maps 26 -> read 26,
+    // 06 -> read 04), so it also corrects the optimistic passband below if the
+    // radio clamps or refuses the requested slot while CI-V Transceive is off.
+    //
     // PUBLISH THE PASSBAND NOW, for the same reason setSliceMode does: the
     // radio's mode report only comes back if CI-V Transceive is on, and the
     // operator who just clicked a filter button is owed an immediate answer.

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -64,6 +64,23 @@ QByteArray floatBytes(const std::vector<float>& v)
 IcomCivBackend::IcomCivBackend(QObject* parent)
     : IRadioBackend(parent), m_model(&unknownModel())
 {
+    // MONOTONIC, NOT WALL CLOCK. Every timestamp in this file measures an
+    // INTERVAL — a dispatch slot, a reply timeout, a poll period, a stall
+    // threshold, a frame's age in the trace — and none is ever reported as an
+    // absolute time. Wall clock was therefore never the right source, and once
+    // every CI-V producer runs through one scheduler it is an actively
+    // dangerous one: a backward step (an NTP correction after suspend/resume
+    // being the realistic case) makes every `now - then` negative at once, so
+    // the dispatch slot never opens, the in-flight read never times out, and
+    // the stall detector never warns. That is a silent, total command-plane
+    // freeze — meters, controls, PTT poll and operator writes alike —
+    // recoverable only by reconnecting. QElapsedTimer cannot step backwards.
+    m_clock.start();
+}
+
+qint64 IcomCivBackend::nowMs() const
+{
+    return m_clock.elapsed();
 }
 
 IcomCivBackend::~IcomCivBackend() = default;
@@ -355,7 +372,7 @@ void IcomCivBackend::disconnectRadio()
                             percentToLevelRaw(m_preTuneTxPowerPercent)),
                 "level.rfPower");
         }
-        const qint64 now = QDateTime::currentMSecsSinceEpoch();
+        const qint64 now = nowMs();
         pumpCiv(now);
         pumpCiv(now);
     }
@@ -376,7 +393,7 @@ void IcomCivBackend::disconnectRadio()
     m_meters.reset();
     m_civScheduler.reset();
     m_schedulerTimeoutsReported = 0;
-    serviceSchedulerWaiters(QDateTime::currentMSecsSinceEpoch());
+    serviceSchedulerWaiters(nowMs());
     m_pendingPttIntent.reset();
     m_pendingPttUntilMs = 0;
     // The radio keeps its own DSP state across our sessions and we have not
@@ -960,7 +977,7 @@ void IcomCivBackend::onSessionConnected(const QString& deviceName)
 
     // Start the first snapshot request now.  Every remaining startup/control/
     // meter request leaves through the same paced writer on timer ticks.
-    pumpCiv(QDateTime::currentMSecsSinceEpoch());
+    pumpCiv(nowMs());
 
 
 }
@@ -1100,7 +1117,7 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
         return;
     }
 
-    const qint64 frameAtMs = QDateTime::currentMSecsSinceEpoch();
+    const qint64 frameAtMs = nowMs();
     ++m_framesObserved;
     m_lastInboundCivAtMs = frameAtMs;
 
@@ -1266,7 +1283,7 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
         if (frame.cmd == cmd::kSetModeTrx && m_session && m_model->hasVfoModeCommand) {
             const auto read = cmdReadVfoMode(m_session->civAddress());
             queueRead(read, semanticKey(read), IcomCivScheduler::Priority::Maintenance);
-            pumpCiv(QDateTime::currentMSecsSinceEpoch());
+            pumpCiv(nowMs());
         } else if (!m_model->hasVfoModeCommand) {
             // This model has no verified DATA readback. An ordinary mode frame
             // can only justify an ordinary mode claim.
@@ -1561,7 +1578,7 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
         if (!raw)
             return;
 
-        m_meters.markAnswered(spec->id, QDateTime::currentMSecsSinceEpoch());
+        m_meters.markAnswered(spec->id, nowMs());
         const double value = meterValue(spec->id, *raw,
                                         s9ReferenceFor(m_frequencyHz),
                                         m_model ? m_model->civAddress : 0xA4);
@@ -1931,7 +1948,7 @@ void IcomCivBackend::queueRead(const std::vector<std::uint8_t>& frame,
     request.replyHasSub = parsed->hasSub;
     request.replySub = parsed->sub;
     request.notBeforeMs = notBeforeMs;
-    m_civScheduler.enqueue(std::move(request), QDateTime::currentMSecsSinceEpoch());
+    m_civScheduler.enqueue(std::move(request), nowMs());
 }
 
 void IcomCivBackend::queueWrite(const std::vector<std::uint8_t>& frame,
@@ -1946,7 +1963,7 @@ void IcomCivBackend::queueWrite(const std::vector<std::uint8_t>& frame,
     request.expectsReply = true;
     request.acceptsGenericReply = true;
     request.supersedes = supersedes;
-    m_civScheduler.enqueue(std::move(request), QDateTime::currentMSecsSinceEpoch());
+    m_civScheduler.enqueue(std::move(request), nowMs());
 }
 
 void IcomCivBackend::queueEmergencyWriteNoReply(const std::vector<std::uint8_t>& frame,
@@ -1958,7 +1975,7 @@ void IcomCivBackend::queueEmergencyWriteNoReply(const std::vector<std::uint8_t>&
     request.priority = IcomCivScheduler::Priority::Emergency;
     request.supersedes = true;
     request.coalesce = false;
-    m_civScheduler.enqueue(std::move(request), QDateTime::currentMSecsSinceEpoch());
+    m_civScheduler.enqueue(std::move(request), nowMs());
 }
 
 void IcomCivBackend::pumpCiv(qint64 nowMs)
@@ -2018,7 +2035,12 @@ QVariantMap IcomCivBackend::schedulerDiagnostics() const
     out.insert(QStringLiteral("pendingPttIntent"), m_pendingPttIntent.has_value());
     if (m_pendingPttIntent) {
         out.insert(QStringLiteral("pttIntent"), *m_pendingPttIntent);
-        out.insert(QStringLiteral("pttIntentDeadlineMs"), m_pendingPttUntilMs);
+        // REMAINING, not a deadline. The backend's clock is monotonic since
+        // construction, so the absolute value means nothing to a consumer;
+        // "how much longer can this suppress a contradictory report" is the
+        // question anyone reads this field to answer.
+        out.insert(QStringLiteral("pttIntentRemainingMs"),
+                   std::max<qint64>(0, m_pendingPttUntilMs - nowMs()));
     }
     return out;
 }
@@ -2050,7 +2072,7 @@ void IcomCivBackend::sendUserCommand(const std::vector<std::uint8_t>& frame)
 {
     if (!m_session || !m_connected)
         return;
-    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    const qint64 now = nowMs();
     const std::string key = semanticKey(frame);
     const std::optional<CivFrame> parsed = parseFrame(frame);
     if (parsed) {
@@ -2610,7 +2632,7 @@ void IcomCivBackend::setKeying(bool key)
     if (!m_model->hasTransmit)
         return;   // an unknown radio is not advertised as transmit-capable
     m_pendingPttIntent = key;
-    m_pendingPttUntilMs = QDateTime::currentMSecsSinceEpoch() + 1000;
+    m_pendingPttUntilMs = nowMs() + 1000;
     sendUserCommand(cmdSetPtt(m_session ? m_session->civAddress() : 0xA4, key));
     // PUBLISH IT. Setting m_keyed silently here and leaving the announcement to
     // the poll does not work now that the poll only speaks on change: our own
@@ -2821,7 +2843,7 @@ QVariantList IcomCivBackend::meterMap() const
     const auto sv = [](std::string_view v) {
         return QString::fromUtf8(v.data(), static_cast<int>(v.size()));
     };
-    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    const qint64 now = nowMs();
 
     QVariantList out;
     for (const auto& m : meterSpecs()) {
@@ -3132,14 +3154,14 @@ void IcomCivBackend::traceCiv(bool outbound, std::span<const std::uint8_t> frame
             hex += QLatin1Char(' ');
         hex += QStringLiteral("%1").arg(b, 2, 16, QLatin1Char('0'));
     }
-    m_civTrace.push_back({QDateTime::currentMSecsSinceEpoch(), outbound, routine, hex});
+    m_civTrace.push_back({nowMs(), outbound, routine, hex});
     while (m_civTrace.size() > kCivTraceMax)
         m_civTrace.pop_front();
 }
 
 QVariantList IcomCivBackend::civTrace(bool includeRoutine) const
 {
-    const std::int64_t now = QDateTime::currentMSecsSinceEpoch();
+    const std::int64_t now = nowMs();
     QVariantList out;
     for (const auto& e : m_civTrace) {
         // ROUTINE POLL TRAFFIC IS HIDDEN BY DEFAULT, and this was learned by
@@ -3260,8 +3282,8 @@ void IcomCivBackend::invokeExtension(const QString& ns, const QString& verb, qui
         }
         timeoutMs = std::clamp(timeoutMs, 0, 10000);
         m_schedulerWaiters.push_back(
-            SchedulerWaiter{requestId, QDateTime::currentMSecsSinceEpoch() + timeoutMs});
-        serviceSchedulerWaiters(QDateTime::currentMSecsSinceEpoch());
+            SchedulerWaiter{requestId, nowMs() + timeoutMs});
+        serviceSchedulerWaiters(nowMs());
         return;
     }
     if (verb == QLatin1String("civ.trace")) {
@@ -3367,7 +3389,7 @@ void IcomCivBackend::onMeterTick()
 {
     if (!m_session || !m_connected)
         return;
-    const std::int64_t now = QDateTime::currentMSecsSinceEpoch();
+    const std::int64_t now = nowMs();
 
     // ASK THE RADIO WHETHER IT IS TRANSMITTING, rather than assuming we are the
     // only thing that can key it.
@@ -3444,7 +3466,7 @@ void IcomCivBackend::onLinkTick()
     // warning that repeats every second is one nobody reads.
     if (!m_connected)
         return;
-    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    const qint64 now = nowMs();
 
     // CI-V Transceive is a low-latency hint, not a subscription. Queue bounded
     // reconciliation groups; the scheduler turns them into one paced stream,

--- a/src/core/backends/icom/IcomCivBackend.h
+++ b/src/core/backends/icom/IcomCivBackend.h
@@ -6,6 +6,7 @@
 #include <QVariantMap>
 #include <QString>
 #include <QVariantList>
+#include <QElapsedTimer>
 
 #include <deque>
 #include <memory>
@@ -179,6 +180,11 @@ private:
     void queueEmergencyWriteNoReply(const std::vector<std::uint8_t>& frame,
                                     const std::string& key);
     void pumpCiv(qint64 nowMs);
+    // Monotonic milliseconds since construction. THE clock for this backend:
+    // every interval here (dispatch slot, reply timeout, poll period, stall
+    // threshold, trace age) is measured against it, and none of them survives
+    // a wall-clock step. See the constructor.
+    [[nodiscard]] qint64 nowMs() const;
     [[nodiscard]] std::string semanticKey(std::span<const std::uint8_t> frame) const;
     [[nodiscard]] std::optional<std::vector<std::uint8_t>>
         confirmationFor(std::span<const std::uint8_t> frame) const;
@@ -241,6 +247,7 @@ private:
     ScopeCalibration m_scopeCal;
     MeterPoller m_meters;
     IcomCivScheduler m_civScheduler;
+    QElapsedTimer m_clock;
 
     // 48 kHz mono from the radio -> 24 kHz interleaved stereo for the engine.
     //

--- a/src/core/backends/icom/IcomCivBackend.h
+++ b/src/core/backends/icom/IcomCivBackend.h
@@ -9,10 +9,14 @@
 
 #include <deque>
 #include <memory>
+#include <optional>
 #include <span>
+#include <string>
+#include <vector>
 
 #include "core/backends/IRadioBackend.h"
 #include "core/backends/icom/CivCodec.h"
+#include "core/backends/icom/IcomCivScheduler.h"
 #include "core/backends/icom/IcomMeters.h"
 #include "core/backends/icom/IcomControls.h"   // the control registry scrubDrive walks
 #include "core/backends/icom/IcomModels.h"
@@ -112,9 +116,11 @@ public:
     // this session. Cheap, read-only, and safe with no radio attached.
     //
     // controlScrub() is the CHECK. For every settable control it drives the seam
-    // and looks for the frame on the wire, so "we believe this is wired" becomes
-    // "this reached the radio and it answered". `filter` narrows it to one id or
-    // one plane; empty scrubs everything safe.
+    // and verifies that the exact frame reached either the wire or the scheduler.
+    // Because the bridge request is synchronous while CI-V dispatch is not, a
+    // scheduled result is completed by waiting for `civ scheduler` to drain
+    // without a timeout. `filter` narrows it to one id or one plane; empty
+    // scrubs everything safe.
     //
     // NEITHER KEYS THE TRANSMITTER. The scrub deliberately excludes ptt, tuner
     // and power: two of them transmit and the third cannot be undone over WiFi.
@@ -166,6 +172,18 @@ private:
     void publishModeState();
     void publishMeterDefs();
     void sendUserCommand(const std::vector<std::uint8_t>& frame);
+    void queueRead(const std::vector<std::uint8_t>& frame, const std::string& key,
+                   IcomCivScheduler::Priority priority, qint64 notBeforeMs = 0);
+    void queueWrite(const std::vector<std::uint8_t>& frame, const std::string& key,
+                    IcomCivScheduler::Priority priority, bool supersedes = true);
+    void queueEmergencyWriteNoReply(const std::vector<std::uint8_t>& frame,
+                                    const std::string& key);
+    void pumpCiv(qint64 nowMs);
+    [[nodiscard]] std::string semanticKey(std::span<const std::uint8_t> frame) const;
+    [[nodiscard]] std::optional<std::vector<std::uint8_t>>
+        confirmationFor(std::span<const std::uint8_t> frame) const;
+    [[nodiscard]] QVariantMap schedulerDiagnostics() const;
+    void serviceSchedulerWaiters(qint64 nowMs);
     void applyScopeStartup();
     // The connect-edge read burst, lifted out of onSessionConnected UNCHANGED.
     //
@@ -222,6 +240,7 @@ private:
     ScopeDecoder m_scope;
     ScopeCalibration m_scopeCal;
     MeterPoller m_meters;
+    IcomCivScheduler m_civScheduler;
 
     // 48 kHz mono from the radio -> 24 kHz interleaved stereo for the engine.
     //
@@ -261,6 +280,8 @@ private:
     bool m_dataMode = false;
     bool m_connected = false;
     bool m_keyed = false;
+    std::optional<bool> m_pendingPttIntent;
+    qint64 m_pendingPttUntilMs = 0;
     bool m_overflow = false;
     double m_vdVolts = 0.0;
     double m_idAmps = 0.0;
@@ -326,7 +347,6 @@ private:
     bool    m_xitOn = false;
     int     m_ritOffsetHz = 0;
     int     m_controlPollPhase = 0;
-    qint64  m_controlPollQuietUntilMs = 0;
     bool    m_rxAntennaExternal = false;
 
     // The radio's MOD Input selection, as last reported (-1 = not yet read).
@@ -378,9 +398,10 @@ private:
     struct CivTraceEntry {
         std::int64_t atMs = 0;
         bool outbound = false;
+        bool routine = false;
         QString hex;
     };
-    void traceCiv(bool outbound, std::span<const std::uint8_t> frame);
+    void traceCiv(bool outbound, std::span<const std::uint8_t> frame, bool routine = false);
     [[nodiscard]] QVariantList civTrace(bool includeRoutine) const;
     std::deque<CivTraceEntry> m_civTrace;
     static constexpr std::size_t kCivTraceMax = 200;
@@ -390,6 +411,10 @@ private:
     // claims is wired but that has never been seen on the wire is exactly the
     // half-wired state the table exists to expose.
     QSet<QString> m_controlsSent;
+    // Exact set commands admitted by the scheduler. A scrub runs
+    // synchronously while CI-V dispatch/reply is intentionally asynchronous,
+    // so admission and physical dispatch must be reported separately.
+    QSet<QString> m_controlsScheduled;
     QSet<QString> m_controlsSeen;
     // Rows whose scrub mirror holds a REAL value — the radio answered for it,
     // or we commanded it. Deliberately NOT m_controlsSent, which controlScrub()
@@ -402,6 +427,13 @@ private:
     // radio from a registry that matches nothing.
     quint64 m_framesObserved = 0;
 
+    struct SchedulerWaiter {
+        quint64 requestId = 0;
+        qint64 deadlineMs = 0;
+    };
+    std::vector<SchedulerWaiter> m_schedulerWaiters;
+    quint64 m_schedulerTimeoutsReported = 0;
+
     // CI-V stall detection. The transport can be healthy while the command
     // plane is dead — see onLinkTick — so these track the command plane alone.
     qint64  m_lastInboundCivAtMs = 0;
@@ -412,12 +444,9 @@ private:
     // 1 s and a user-command guard can defer it — short enough that an operator
     // has not yet had time to wonder why the S-meter stopped.
     static constexpr qint64 kCivStallMs = 5000;
-    // Reconciliation must yield after an operator write.  This prevents the
-    // next one-second phase from placing stale reads directly behind a set;
-    // RFC #4983 will replace this coarse window with response-aware scheduling.
-    static constexpr qint64 kControlPollQuietMs = 500;
     // Note the id for a frame we are about to send or have just decoded.
     void noteControlSent(std::uint8_t cmd, std::uint8_t sub, bool hasSub);
+    void noteControlScheduled(std::uint8_t cmd, std::uint8_t sub, bool hasSub);
     void noteControlSeen(std::uint8_t cmd, std::uint8_t sub, bool hasSub);
     LinkStats m_link;
 };

--- a/src/core/backends/icom/IcomCivScheduler.cpp
+++ b/src/core/backends/icom/IcomCivScheduler.cpp
@@ -5,6 +5,24 @@
 
 namespace AetherSDR::icom {
 
+// Two requests are duplicates only if they ask the SAME register the same way.
+//
+// The semantic key is deliberately coarse — 04, 06, 26 and the transceive
+// forms all key on "mode" — because that coarseness is what makes an operator
+// mode write supersede an in-flight mode read of any form.  Coalescing must
+// not inherit it: 04 (mode) and 26 (mode + DATA + filter) are different
+// registers, and sendConnectReadBurst queues both on purpose so 26 can correct
+// 04 when they disagree.  Collapsing them by key alone silently deleted one of
+// the two, and which one survived depended on enqueue order.
+bool IcomCivScheduler::sameReplyShape(const Request& a, const Request& b) noexcept
+{
+    return a.expectsReply == b.expectsReply
+        && a.acceptsGenericReply == b.acceptsGenericReply
+        && a.replyCmd == b.replyCmd
+        && a.replyHasSub == b.replyHasSub
+        && (!a.replyHasSub || a.replySub == b.replySub);
+}
+
 std::uint64_t IcomCivScheduler::enqueue(Request request, std::int64_t nowMs)
 {
     if (request.frame.empty() || request.key.empty()) {
@@ -19,12 +37,28 @@ std::uint64_t IcomCivScheduler::enqueue(Request request, std::int64_t nowMs)
         ++currentGeneration;
     }
 
+    // CLAMP BEFORE COALESCING, not after.  The loop below compares this
+    // against the notBeforeMs of queued entries, which were clamped to a real
+    // monotonic timestamp when THEY were enqueued.  Comparing those against an
+    // unclamped 0 — the default every periodic producer passes — made the
+    // "an equal-or-better one is already queued" test below always false, so a
+    // duplicate erased and re-pushed the queued entry instead of collapsing
+    // into it.  That reset enqueuedAtMs, and enqueuedAtMs is what
+    // effectivePriority() ages on: any group re-queued at or faster than
+    // kPriorityAgingMs (onLinkTick re-queues NR/NB/notch every 1000 ms) could
+    // never age at all, and an Operator confirmation read was demoted to
+    // Control by the next poll tick that touched the same register.
+    if (request.notBeforeMs < nowMs) {
+        request.notBeforeMs = nowMs;
+    }
+
     if (request.coalesce) {
         // A duplicate read in flight is already the freshest read for this
         // generation.  Do not accumulate a second copy behind it.
         if (!request.supersedes && m_inFlight
             && m_inFlight->request.key == request.key
-            && m_inFlight->generation == currentGeneration) {
+            && m_inFlight->generation == currentGeneration
+            && sameReplyShape(m_inFlight->request, request)) {
             ++m_stats.coalesced;
             return 0;
         }
@@ -37,9 +71,7 @@ std::uint64_t IcomCivScheduler::enqueue(Request request, std::int64_t nowMs)
             // A newer write replaces an older queued write.  A confirmation
             // read must coexist with the write it confirms, so only collapse
             // requests with the same reply-bearing shape.
-            const bool sameShape = it->request.expectsReply == request.expectsReply
-                && it->request.acceptsGenericReply == request.acceptsGenericReply;
-            if (!sameShape) {
+            if (!sameReplyShape(it->request, request)) {
                 ++it;
                 continue;
             }
@@ -61,9 +93,6 @@ std::uint64_t IcomCivScheduler::enqueue(Request request, std::int64_t nowMs)
         }
     }
 
-    if (request.notBeforeMs < nowMs) {
-        request.notBeforeMs = nowMs;
-    }
     m_queue.push_back(Queued{std::move(request), currentGeneration, ++m_sequence, nowMs});
     ++m_stats.queued;
     m_stats.queueDepth = m_queue.size();
@@ -78,8 +107,27 @@ void IcomCivScheduler::expireRead(std::int64_t nowMs)
     if (nowMs - m_inFlightAtMs < kReadTimeoutMs) {
         return;
     }
+    // A timed-out transaction is no longer in flight, but the radio may still
+    // answer it — a late reply is exactly what kReadTimeoutMs exists to stop
+    // waiting for, not a promise that it will never arrive.  Remember it so
+    // observe() can still recognise the answer and reject it against a newer
+    // generation.  Without this the SAME frame was Stale at 349 ms and
+    // unmatched-therefore-authoritative at 351 ms, which let an obsolete read
+    // overwrite a newer operator write on every register except PTT (which the
+    // backend's separate intent window happens to cover).
+    m_expired.push_back(Expired{*m_inFlight, nowMs + kLateReplyGraceMs});
+    while (m_expired.size() > kMaxExpiredTracked) {
+        m_expired.pop_front();
+    }
     m_inFlight.reset();
     ++m_stats.timeouts;
+}
+
+void IcomCivScheduler::dropStaleExpired(std::int64_t nowMs)
+{
+    while (!m_expired.empty() && m_expired.front().forgetAtMs <= nowMs) {
+        m_expired.pop_front();
+    }
 }
 
 std::optional<IcomCivScheduler::Dispatch> IcomCivScheduler::takeNext(std::int64_t nowMs)
@@ -120,11 +168,16 @@ std::optional<IcomCivScheduler::Dispatch> IcomCivScheduler::takeNext(std::int64_
     m_lastDispatchMs = nowMs;
     if (selected.request.expectsReply) {
         // A fail-safe unkey is the sole command allowed to interrupt an
-        // unanswered transaction.  Forgetting that transaction is safe: any
-        // late keyed state is generation-guarded, and the unkey ACK must own
-        // the serial reply slot from this point forward.
-        if (selected.request.priority == Priority::Emergency) {
-            m_inFlight.reset();
+        // unanswered transaction.  Displacing that transaction is safe, but it
+        // must not be forgotten outright: the radio can still answer it, and
+        // the answer predates the unkey.  Park it with the timed-out ones so
+        // observe() keeps generation-guarding it instead of treating a late
+        // pre-unkey reading as fresh radio truth.
+        if (selected.request.priority == Priority::Emergency && m_inFlight) {
+            m_expired.push_back(Expired{*m_inFlight, nowMs + kLateReplyGraceMs});
+            while (m_expired.size() > kMaxExpiredTracked) {
+                m_expired.pop_front();
+            }
         }
         m_inFlight = selected;
         m_inFlightAtMs = nowMs;
@@ -144,11 +197,19 @@ IcomCivScheduler::Priority
 IcomCivScheduler::effectivePriority(const Queued& request, std::int64_t nowMs) const noexcept
 {
     // Emergency/operator ordering is invariant. Background work ages up only
-    // as far as the PTT fallback poll, so a dead or slow radio cannot let the
+    // as far as the visible-meter band, so a dead or slow radio cannot let the
     // high-rate PTT/S-meter loops permanently starve control reconciliation
     // or startup. An actual PTT write/confirmation remains Operator priority.
+    //
+    // THE FLOOR IS ActiveMeter, NOT Ptt.  takeNext() breaks an equal-priority
+    // tie on sequence, and an aged item always has the lower sequence — so
+    // letting background work reach Priority::Ptt did not merely stop
+    // outranking the keyed-state fallback poll, it dispatched ahead of it, one
+    // whole poll interval per aged entry.  Aging to ActiveMeter still beats
+    // fresh meter traffic on the FIFO tie (which is all anti-starvation needs)
+    // while leaving PTT a strict edge that no amount of waiting can erode.
     const int base = static_cast<int>(request.request.priority);
-    const int floor = static_cast<int>(Priority::Ptt);
+    const int floor = static_cast<int>(Priority::ActiveMeter);
     if (base <= floor) {
         return request.request.priority;
     }
@@ -181,7 +242,33 @@ IcomCivScheduler::Observation IcomCivScheduler::observe(const CivFrame& frame,
                                                         std::int64_t nowMs)
 {
     expireRead(nowMs);
+    dropStaleExpired(nowMs);
+
+    // A generic FB/FA only ever completes the live transaction.  Matching it
+    // against a parked one would let one ACK retire two transactions.
+    const bool generic = frame.isOk() || frame.isNg();
+
     if (!m_inFlight || !matches(frame, *m_inFlight)) {
+        if (generic) {
+            return Observation::Unmatched;
+        }
+        // Late answer to a transaction we stopped waiting for.  It is only
+        // reportable when a newer intent has since superseded it; otherwise it
+        // is simply a slow reply and the backend should adopt it as usual.
+        for (auto it = m_expired.begin(); it != m_expired.end(); ++it) {
+            if (!matches(frame, it->request)) {
+                continue;
+            }
+            const auto generation = m_generations.find(it->request.request.key);
+            const bool superseded = generation != m_generations.end()
+                && it->request.generation < generation->second;
+            m_expired.erase(it);
+            if (superseded) {
+                ++m_stats.staleReplies;
+                return Observation::Stale;
+            }
+            return Observation::Unmatched;
+        }
         return Observation::Unmatched;
     }
 
@@ -203,6 +290,7 @@ void IcomCivScheduler::reset() noexcept
 {
     m_queue.clear();
     m_inFlight.reset();
+    m_expired.clear();
     m_generations.clear();
     m_sequence = 0;
     m_lastDispatchMs = 0;

--- a/src/core/backends/icom/IcomCivScheduler.cpp
+++ b/src/core/backends/icom/IcomCivScheduler.cpp
@@ -1,0 +1,222 @@
+#include "core/backends/icom/IcomCivScheduler.h"
+
+#include <algorithm>
+#include <utility>
+
+namespace AetherSDR::icom {
+
+std::uint64_t IcomCivScheduler::enqueue(Request request, std::int64_t nowMs)
+{
+    if (request.frame.empty() || request.key.empty()) {
+        return 0;
+    }
+
+    std::uint64_t& currentGeneration = m_generations[request.key];
+    if (currentGeneration == 0) {
+        currentGeneration = 1;
+    }
+    if (request.supersedes) {
+        ++currentGeneration;
+    }
+
+    if (request.coalesce) {
+        // A duplicate read in flight is already the freshest read for this
+        // generation.  Do not accumulate a second copy behind it.
+        if (!request.supersedes && m_inFlight
+            && m_inFlight->request.key == request.key
+            && m_inFlight->generation == currentGeneration) {
+            ++m_stats.coalesced;
+            return 0;
+        }
+
+        for (auto it = m_queue.begin(); it != m_queue.end();) {
+            if (it->request.key != request.key) {
+                ++it;
+                continue;
+            }
+            // A newer write replaces an older queued write.  A confirmation
+            // read must coexist with the write it confirms, so only collapse
+            // requests with the same reply-bearing shape.
+            const bool sameShape = it->request.expectsReply == request.expectsReply
+                && it->request.acceptsGenericReply == request.acceptsGenericReply;
+            if (!sameShape) {
+                ++it;
+                continue;
+            }
+            // A new write generation and its confirmation replace an older
+            // queued generation.  This is what makes a fast slider converge
+            // on its newest value rather than preserving the first unsent one.
+            if (it->generation < currentGeneration) {
+                it = m_queue.erase(it);
+                ++m_stats.coalesced;
+                continue;
+            }
+            if (it->request.priority <= request.priority
+                && it->request.notBeforeMs <= request.notBeforeMs) {
+                ++m_stats.coalesced;
+                return 0;
+            }
+            it = m_queue.erase(it);
+            ++m_stats.coalesced;
+        }
+    }
+
+    if (request.notBeforeMs < nowMs) {
+        request.notBeforeMs = nowMs;
+    }
+    m_queue.push_back(Queued{std::move(request), currentGeneration, ++m_sequence, nowMs});
+    ++m_stats.queued;
+    m_stats.queueDepth = m_queue.size();
+    return currentGeneration;
+}
+
+void IcomCivScheduler::expireRead(std::int64_t nowMs)
+{
+    if (!m_inFlight) {
+        return;
+    }
+    if (nowMs - m_inFlightAtMs < kReadTimeoutMs) {
+        return;
+    }
+    m_inFlight.reset();
+    ++m_stats.timeouts;
+}
+
+std::optional<IcomCivScheduler::Dispatch> IcomCivScheduler::takeNext(std::int64_t nowMs)
+{
+    expireRead(nowMs);
+    if (m_queue.empty()) {
+        return std::nullopt;
+    }
+
+    auto best = m_queue.end();
+    for (auto it = m_queue.begin(); it != m_queue.end(); ++it) {
+        if (it->request.notBeforeMs > nowMs) {
+            continue;
+        }
+        const bool emergency = it->request.priority == Priority::Emergency;
+        if (it->request.expectsReply && m_inFlight && !emergency) {
+            continue;
+        }
+        if (!emergency && m_lastDispatchMs > 0 && nowMs - m_lastDispatchMs < kSlotMs) {
+            continue;
+        }
+        const Priority candidatePriority = effectivePriority(*it, nowMs);
+        const Priority bestPriority = best == m_queue.end()
+            ? Priority::Maintenance : effectivePriority(*best, nowMs);
+        if (best == m_queue.end()
+            || candidatePriority < bestPriority
+            || (candidatePriority == bestPriority
+                && it->sequence < best->sequence)) {
+            best = it;
+        }
+    }
+    if (best == m_queue.end()) {
+        return std::nullopt;
+    }
+
+    Queued selected = std::move(*best);
+    m_queue.erase(best);
+    m_lastDispatchMs = nowMs;
+    if (selected.request.expectsReply) {
+        // A fail-safe unkey is the sole command allowed to interrupt an
+        // unanswered transaction.  Forgetting that transaction is safe: any
+        // late keyed state is generation-guarded, and the unkey ACK must own
+        // the serial reply slot from this point forward.
+        if (selected.request.priority == Priority::Emergency) {
+            m_inFlight.reset();
+        }
+        m_inFlight = selected;
+        m_inFlightAtMs = nowMs;
+    }
+    ++m_stats.dispatched;
+    m_stats.queueDepth = m_queue.size();
+    m_stats.lastDispatchMs = nowMs;
+    m_stats.readInFlight = m_inFlight.has_value();
+    m_stats.inFlightKey = m_inFlight ? m_inFlight->request.key : std::string{};
+
+    return Dispatch{std::move(selected.request.frame), std::move(selected.request.key),
+                    selected.request.priority, selected.generation,
+                    selected.request.supersedes};
+}
+
+IcomCivScheduler::Priority
+IcomCivScheduler::effectivePriority(const Queued& request, std::int64_t nowMs) const noexcept
+{
+    // Emergency/operator ordering is invariant. Background work ages up only
+    // as far as the PTT fallback poll, so a dead or slow radio cannot let the
+    // high-rate PTT/S-meter loops permanently starve control reconciliation
+    // or startup. An actual PTT write/confirmation remains Operator priority.
+    const int base = static_cast<int>(request.request.priority);
+    const int floor = static_cast<int>(Priority::Ptt);
+    if (base <= floor) {
+        return request.request.priority;
+    }
+    const std::int64_t waitedMs = std::max<std::int64_t>(0, nowMs - request.enqueuedAtMs);
+    const int aged = base - static_cast<int>(waitedMs / kPriorityAgingMs);
+    return static_cast<Priority>(std::max(floor, aged));
+}
+
+bool IcomCivScheduler::matches(const CivFrame& frame, const Queued& request) const noexcept
+{
+    // FB/FA is the radio's terminal response even when a queried leaf is not
+    // implemented.  With exactly one ordinary command outstanding, it is
+    // unambiguously the completion for that transaction.  It releases the
+    // slot but carries no state; the backend therefore decodes nothing from
+    // it and remains radio-authoritative.
+    if (frame.isOk() || frame.isNg()) {
+        return true;
+    }
+    if (request.request.acceptsGenericReply) {
+        return false;
+    }
+    if (frame.cmd != request.request.replyCmd
+        || frame.hasSub != request.request.replyHasSub) {
+        return false;
+    }
+    return !frame.hasSub || frame.sub == request.request.replySub;
+}
+
+IcomCivScheduler::Observation IcomCivScheduler::observe(const CivFrame& frame,
+                                                        std::int64_t nowMs)
+{
+    expireRead(nowMs);
+    if (!m_inFlight || !matches(frame, *m_inFlight)) {
+        return Observation::Unmatched;
+    }
+
+    const Queued completed = *m_inFlight;
+    m_inFlight.reset();
+    ++m_stats.replies;
+    m_stats.readInFlight = false;
+    m_stats.inFlightKey.clear();
+
+    const auto generation = m_generations.find(completed.request.key);
+    if (generation != m_generations.end() && completed.generation < generation->second) {
+        ++m_stats.staleReplies;
+        return Observation::Stale;
+    }
+    return Observation::Accepted;
+}
+
+void IcomCivScheduler::reset() noexcept
+{
+    m_queue.clear();
+    m_inFlight.reset();
+    m_generations.clear();
+    m_sequence = 0;
+    m_lastDispatchMs = 0;
+    m_inFlightAtMs = 0;
+    m_stats = Stats{};
+}
+
+IcomCivScheduler::Stats IcomCivScheduler::stats() const
+{
+    Stats out = m_stats;
+    out.queueDepth = m_queue.size();
+    out.readInFlight = m_inFlight.has_value();
+    out.inFlightKey = m_inFlight ? m_inFlight->request.key : std::string{};
+    return out;
+}
+
+}  // namespace AetherSDR::icom

--- a/src/core/backends/icom/IcomCivScheduler.h
+++ b/src/core/backends/icom/IcomCivScheduler.h
@@ -92,6 +92,12 @@ public:
     static constexpr int kSlotMs = 25;
     static constexpr int kReadTimeoutMs = 350;
     static constexpr int kPriorityAgingMs = 1000;
+    // How long a timed-out or displaced transaction stays recognisable, so a
+    // late answer is still generation-checked rather than adopted as fresh
+    // radio truth. Comfortably longer than kReadTimeoutMs and shorter than the
+    // slowest reconciliation interval, so it never spans two generations of
+    // the same register.
+    static constexpr int kLateReplyGraceMs = 2000;
 
 private:
     struct Queued {
@@ -101,13 +107,25 @@ private:
         std::int64_t enqueuedAtMs = 0;
     };
 
+    struct Expired {
+        Queued request;
+        std::int64_t forgetAtMs = 0;
+    };
+
+    [[nodiscard]] static bool sameReplyShape(const Request& a, const Request& b) noexcept;
     [[nodiscard]] bool matches(const CivFrame& frame, const Queued& request) const noexcept;
     [[nodiscard]] Priority effectivePriority(const Queued& request,
                                              std::int64_t nowMs) const noexcept;
     void expireRead(std::int64_t nowMs);
+    void dropStaleExpired(std::int64_t nowMs);
+
+    // Bounded: one ordinary transaction is outstanding at a time and each entry
+    // lives only kLateReplyGraceMs, so this cannot grow with queue depth.
+    static constexpr std::size_t kMaxExpiredTracked = 16;
 
     std::deque<Queued> m_queue;
     std::optional<Queued> m_inFlight;
+    std::deque<Expired> m_expired;
     std::unordered_map<std::string, std::uint64_t> m_generations;
     std::uint64_t m_sequence = 0;
     std::int64_t m_lastDispatchMs = 0;

--- a/src/core/backends/icom/IcomCivScheduler.h
+++ b/src/core/backends/icom/IcomCivScheduler.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <cstdint>
+#include <deque>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "core/backends/icom/CivCodec.h"
+
+namespace AetherSDR::icom {
+
+// The single ordinary writer for Icom CI-V traffic.
+//
+// An Icom has no meter stream: meters, front-panel reconciliation, startup
+// snapshots and operator commands all share one serial command plane.  Sending
+// each producer directly creates bursts, unbounded stale reads and, for PTT, a
+// causal inversion where an old RX answer can arrive after a newer TX request.
+//
+// This class owns policy but not a timer or socket.  The backend supplies a
+// monotonic clock, takes dispatches, and writes them through IcomSession.  That
+// makes pacing, coalescing and lost/late replies deterministic unit tests.
+class IcomCivScheduler {
+public:
+    enum class Priority : std::uint8_t {
+        Emergency = 0,   // fail-safe unkey / teardown; bypasses pacing
+        Operator = 1,    // direct operator write and its confirmation
+        Ptt = 2,         // radio-authoritative PTT fallback poll
+        ActiveMeter = 3, // visible RX/TX instrumentation
+        Control = 4,     // periodic front-panel reconciliation
+        Maintenance = 5, // startup/scope housekeeping
+    };
+
+    struct Request {
+        std::vector<std::uint8_t> frame;
+        std::string key;
+        Priority priority = Priority::Control;
+        bool expectsReply = false;
+        // Ordinary writes complete with CI-V FB/FA rather than a keyed state
+        // frame.  They still occupy the one command/reply slot so their ACK
+        // cannot be mistaken for the reply to a later read.
+        bool acceptsGenericReply = false;
+        std::uint8_t replyCmd = 0;
+        bool replyHasSub = false;
+        std::uint8_t replySub = 0;
+        // A write supersedes all older observations of the same semantic key.
+        bool supersedes = false;
+        // Reads and repeated slider writes collapse to the newest queued item.
+        bool coalesce = true;
+        std::int64_t notBeforeMs = 0;
+    };
+
+    struct Dispatch {
+        std::vector<std::uint8_t> frame;
+        std::string key;
+        Priority priority = Priority::Control;
+        std::uint64_t generation = 0;
+        bool supersedes = false;
+    };
+
+    enum class Observation : std::uint8_t {
+        Unmatched,
+        Accepted,
+        Stale,
+    };
+
+    struct Stats {
+        std::uint64_t queued = 0;
+        std::uint64_t dispatched = 0;
+        std::uint64_t coalesced = 0;
+        std::uint64_t replies = 0;
+        std::uint64_t staleReplies = 0;
+        std::uint64_t timeouts = 0;
+        std::size_t queueDepth = 0;
+        bool readInFlight = false;
+        std::string inFlightKey;
+        std::int64_t lastDispatchMs = 0;
+    };
+
+    // Returns the semantic generation assigned to the request.  A return of
+    // zero means an identical read was already queued/in flight and this one
+    // was coalesced away.
+    std::uint64_t enqueue(Request request, std::int64_t nowMs);
+    [[nodiscard]] std::optional<Dispatch> takeNext(std::int64_t nowMs);
+    [[nodiscard]] Observation observe(const CivFrame& frame, std::int64_t nowMs);
+
+    void reset() noexcept;
+    [[nodiscard]] Stats stats() const;
+    [[nodiscard]] bool idle() const noexcept { return m_queue.empty() && !m_inFlight; }
+
+    static constexpr int kSlotMs = 25;
+    static constexpr int kReadTimeoutMs = 350;
+    static constexpr int kPriorityAgingMs = 1000;
+
+private:
+    struct Queued {
+        Request request;
+        std::uint64_t generation = 0;
+        std::uint64_t sequence = 0;
+        std::int64_t enqueuedAtMs = 0;
+    };
+
+    [[nodiscard]] bool matches(const CivFrame& frame, const Queued& request) const noexcept;
+    [[nodiscard]] Priority effectivePriority(const Queued& request,
+                                             std::int64_t nowMs) const noexcept;
+    void expireRead(std::int64_t nowMs);
+
+    std::deque<Queued> m_queue;
+    std::optional<Queued> m_inFlight;
+    std::unordered_map<std::string, std::uint64_t> m_generations;
+    std::uint64_t m_sequence = 0;
+    std::int64_t m_lastDispatchMs = 0;
+    std::int64_t m_inFlightAtMs = 0;
+    Stats m_stats;
+};
+
+}  // namespace AetherSDR::icom

--- a/tests/IcomFakeRadio.h
+++ b/tests/IcomFakeRadio.h
@@ -663,11 +663,20 @@ private:
         if (frame->cmd == cmd::kControl && frame->hasSub
             && frame->sub == control::kPtt) {
             if (frame->data.empty()) {
+                const bool report = m_pttOverride ? *m_pttOverride : m_ptt;
                 pushCiv({0xFE, 0xFE, kControllerAddress, kIc705Addr, cmd::kControl,
-                         control::kPtt, static_cast<std::uint8_t>(m_ptt ? 1 : 0), kCivEom});
+                         control::kPtt, static_cast<std::uint8_t>(report ? 1 : 0), kCivEom});
                 return;
             }
-            m_ptt = frame->data.front() != 0;
+            // A radio that ACKs a PTT write and does not act on it is not
+            // hypothetical: the write can be lost on the bus, refused (band
+            // edge, SWR fold-back), or immediately overridden at the front
+            // panel. `FB` means "understood", never "applied" — see
+            // docs/radio-certification.md. Without a fake that can disagree
+            // with the client's intent there is no way to test what the
+            // backend does when radio truth contradicts a pending request.
+            if (!m_pttOverride)
+                m_ptt = frame->data.front() != 0;
             pushCiv({0xFE, 0xFE, kControllerAddress, kIc705Addr, kCivOk, kCivEom});
             return;
         }
@@ -730,6 +739,10 @@ public:
     bool m_xitOn = false;
     std::uint8_t m_tunerState = 0x01;   // matched
     bool m_ptt = false;
+    // Force what 1C 00 REPORTS, regardless of what it is told. While set, PTT
+    // writes are still acknowledged but do not move m_ptt — the radio insists
+    // on this state. Clear it (std::nullopt) to go back to an obedient radio.
+    std::optional<bool> m_pttOverride;
 
 private:
 

--- a/tests/IcomFakeRadio.h
+++ b/tests/IcomFakeRadio.h
@@ -573,6 +573,18 @@ private:
                 return;
             }
         }
+        if (frame->cmd == cmd::kLevel && frame->hasSub && !frame->data.empty()) {
+            if (const std::optional<int> value = decodeLevel(frame->data)) {
+                m_levels[frame->sub] = *value;
+            }
+            pushCiv({0xFE, 0xFE, kControllerAddress, kIc705Addr, kCivOk, kCivEom});
+            return;
+        }
+        if (frame->cmd == cmd::kFunction && frame->hasSub && !frame->data.empty()) {
+            m_functions[frame->sub] = frame->data.front();
+            pushCiv({0xFE, 0xFE, kControllerAddress, kIc705Addr, kCivOk, kCivEom});
+            return;
+        }
         if (frame->cmd == cmd::kTuneOffset && frame->hasSub && frame->data.empty()) {
             if (frame->sub == tuneOffset::kFrequency) {
                 // Two BCD bytes little-endian, then a sign byte.
@@ -642,6 +654,23 @@ private:
                      control::kTuner, m_tunerState, kCivEom});
             return;
         }
+        if (frame->cmd == cmd::kControl && frame->hasSub
+            && frame->sub == control::kTuner && !frame->data.empty()) {
+            m_tunerState = frame->data.front() == 0x00 ? 0x00 : 0x01;
+            pushCiv({0xFE, 0xFE, kControllerAddress, kIc705Addr, kCivOk, kCivEom});
+            return;
+        }
+        if (frame->cmd == cmd::kControl && frame->hasSub
+            && frame->sub == control::kPtt) {
+            if (frame->data.empty()) {
+                pushCiv({0xFE, 0xFE, kControllerAddress, kIc705Addr, cmd::kControl,
+                         control::kPtt, static_cast<std::uint8_t>(m_ptt ? 1 : 0), kCivEom});
+                return;
+            }
+            m_ptt = frame->data.front() != 0;
+            pushCiv({0xFE, 0xFE, kControllerAddress, kIc705Addr, kCivOk, kCivEom});
+            return;
+        }
 
         // Everything else is acknowledged.
         pushCiv({0xFE, 0xFE, kControllerAddress, kIc705Addr, kCivOk, kCivEom});
@@ -700,6 +729,7 @@ public:
     bool m_ritOn = true;
     bool m_xitOn = false;
     std::uint8_t m_tunerState = 0x01;   // matched
+    bool m_ptt = false;
 
 private:
 

--- a/tests/icom_backend_test.cpp
+++ b/tests/icom_backend_test.cpp
@@ -88,6 +88,11 @@ int main(int argc, char** argv)
     SliceDelta lastSliceState;
     TransmitDelta lastTransmitState;
     std::vector<QString> publishedModes;
+    // Every mox edge in order. The PTT confirmation window is defined by which
+    // transitions it lets through, so the SEQUENCE is the assertion, not the
+    // final value — a suppressed-then-corrected state and a never-suppressed
+    // one both end up in the same place.
+    std::vector<bool> moxPublications;
     const auto mergeSlice = [&lastSliceState](const SliceDelta& d) {
         if (d.nr) lastSliceState.nr = d.nr;
         if (d.nb) lastSliceState.nb = d.nb;
@@ -122,6 +127,7 @@ int main(int argc, char** argv)
         if (d.transmitFreq) lastTransmitState.transmitFreq = d.transmitFreq;
         if (d.atuEnabled) lastTransmitState.atuEnabled = d.atuEnabled;
         if (d.atuStatusRaw) lastTransmitState.atuStatusRaw = d.atuStatusRaw;
+        if (d.mox) { lastTransmitState.mox = d.mox; moxPublications.push_back(*d.mox); }
     });
 
     QSignalSpy connectedSpy(&backend, &IRadioBackend::connected);
@@ -364,6 +370,59 @@ int main(int argc, char** argv)
         QTest::qWait(120);
         check(radio.audioPacketsFromClient() == afterUnkey,
               "and stops again on unkey");
+    }
+
+    // ---- THE PTT CONFIRMATION WINDOW, IN BOTH DIRECTIONS ------------------
+    //
+    // RFC #4983's captured FT8 failure and its explicit counter-rule live here.
+    // The window is what lets a newer key-on intent outlive an older poll's OFF
+    // answer; it must NOT also let a client's unkey request outlive the radio
+    // saying it is still transmitting.
+    {
+        // (a) THE CAPTURED FAILURE. Key on, then have the radio insist it is
+        //     still RX — exactly the pre-key poll answer arriving late. The
+        //     model must not follow it back to RX inside the window.
+        backend.setKeying(false);
+        check(waitSchedulerIdle(), "PTT fixture starts unkeyed");
+        moxPublications.clear();
+
+        radio.m_pttOverride = false;         // radio keeps answering "RX"
+        backend.setKeying(true);
+        QTest::qWait(600);                   // several 250 ms fallback polls
+        check(std::find(moxPublications.begin(), moxPublications.end(), false)
+                  == moxPublications.end(),
+              "a contradictory PTT OFF is suppressed while a key-on intent is "
+              "pending — the captured FT8 transmit-audio teardown");
+        check(lastTransmitState.mox.value_or(false),
+              "and the model stays keyed for the operator who asked to transmit");
+
+        // The window is BOUNDED. Past it the radio wins again (Constitution II),
+        // otherwise a client belief outlives the hardware indefinitely.
+        QTest::qWait(700);
+        check(!lastTransmitState.mox.value_or(true),
+              "once the 1 s window expires the radio's own report wins again");
+
+        // (b) THE DIRECTION THAT MUST NEVER BE SUPPRESSED. Ask to unkey while
+        //     the radio insists it is transmitting — a lost or refused unkey.
+        //     Swallowing this is the one failure that leaves an operator on the
+        //     air with a UI that says otherwise (Constitution VI fails closed).
+        radio.m_pttOverride = true;
+        moxPublications.clear();
+        backend.setKeying(false);
+        check(waitFor([&] {
+                  return std::find(moxPublications.begin(), moxPublications.end(),
+                                   true) != moxPublications.end();
+              }, 1000),
+              "a radio reporting KEYED after an unkey request is published "
+              "immediately, NOT suppressed by the confirmation window");
+        check(lastTransmitState.mox.value_or(false),
+              "and the model shows the transmitter that is actually on the air");
+
+        radio.m_pttOverride.reset();
+        backend.setKeying(false);
+        check(waitFor([&] { return !lastTransmitState.mox.value_or(true); }, 2000),
+              "an obedient radio then unkeys normally");
+        check(waitSchedulerIdle(), "PTT fixture drains");
     }
 
     // TUNE temporarily borrows the RF-power register. Releasing it must put

--- a/tests/icom_backend_test.cpp
+++ b/tests/icom_backend_test.cpp
@@ -143,6 +143,29 @@ int main(int argc, char** argv)
     check(waitFor([&] { return backend.isConnected(); }), "the backend connects");
     check(connectedSpy.count() == 1, "and emits connected() exactly once");
 
+    quint64 schedulerRequestId = 9000;
+    const auto waitSchedulerIdle = [&](int timeoutMs = 5000) {
+        QSignalSpy replySpy(&backend, &IRadioBackend::extensionResult);
+        const quint64 requestId = ++schedulerRequestId;
+        QVariantMap arg;
+        arg.insert(QStringLiteral("timeoutMs"), timeoutMs);
+        backend.invokeExtension(QStringLiteral("icom"),
+                                QStringLiteral("civ.scheduler.wait-idle"),
+                                requestId, arg);
+        QVariantMap result;
+        const bool replied = waitFor([&] {
+            for (const QList<QVariant>& reply : replySpy) {
+                if (reply.at(0).toULongLong() == requestId) {
+                    result = reply.at(1).toMap();
+                    return true;
+                }
+            }
+            return false;
+        }, timeoutMs + 500);
+        return replied && result.value(QStringLiteral("idle")).toBool()
+            && !result.value(QStringLiteral("timedOut")).toBool();
+    };
+
     // ---- capability -------------------------------------------------------
     const RadioCapabilities caps = backend.capabilities();
     check(caps.family == QStringLiteral("icom"), "family is icom");
@@ -180,6 +203,10 @@ int main(int argc, char** argv)
           "the backend ASKS the radio what it is (0x19 0x00) rather than assuming");
     check(backend.model().name == "IC-705", "and resolves the IC-705");
     check(backend.model().verified, "whose capability numbers are tier-1 verified");
+    check(waitSchedulerIdle(),
+          "connect-time radio-authoritative state converges through the scheduler");
+    const SliceDelta connectedSliceState = lastSliceState;
+    const TransmitDelta connectedTransmitState = lastTransmitState;
 
     // ---- THE AUDIO CONTRACT (TCI / WSJT-X) --------------------------------
     //
@@ -303,6 +330,11 @@ int main(int argc, char** argv)
         // KEYED: the same buffers must arrive.
         radio.clearCivLog();
         backend.setKeying(true);
+        check(waitFor([&] {
+                  return std::any_of(radio.civCommands().begin(), radio.civCommands().end(),
+                                     movesPttOrTuner);
+              }, 1000),
+              "the keyed intent reaches the radio through the scheduler");
         for (int i = 0; i < 20; ++i)
             backend.submitTxAudio(pcm, 24000);
         QTest::qWait(200);
@@ -321,6 +353,7 @@ int main(int argc, char** argv)
               "scrub's 'never keys' check is not vacuous");
 
         backend.setKeying(false);
+        check(waitSchedulerIdle(), "unkey and its radio confirmation complete");
 
         // ...and stops again on unkey, rather than draining a backlog into the
         // next transmission.
@@ -338,12 +371,12 @@ int main(int argc, char** argv)
     // changes the next voice/data transmission (and the UI follows the poll).
     {
         backend.setTxPower(37);
-        QTest::qWait(80);
+        check(waitSchedulerIdle(), "ordinary RF power converges before TUNE");
         radio.clearCivLog();
         backend.setTune(true, 10);
-        QTest::qWait(80);
+        check(waitSchedulerIdle(), "temporary TUNE drive and tuner state converge");
         backend.setTune(false);
-        QTest::qWait(120);
+        check(waitSchedulerIdle(), "TUNE release and RF-power restore converge");
 
         std::vector<int> powerWrites;
         for (const CivFrame& f : radio.civCommands()) {
@@ -374,8 +407,8 @@ int main(int argc, char** argv)
     // a read that is issued and whose reply is dropped looks exactly like a read
     // that was never issued.
     {
-        const SliceDelta sl = lastSliceState;
-        const TransmitDelta tx = lastTransmitState;
+        const SliceDelta sl = connectedSliceState;
+        const TransmitDelta tx = connectedTransmitState;
 
         check(sl.nr.value_or(false), "NR ON is adopted from the radio");
         check(sl.nb.value_or(false), "NB ON is adopted");
@@ -493,6 +526,7 @@ int main(int argc, char** argv)
         backend.setSliceFilter(0, -1800, 0);   // 1.8 kHz — the SSB ladder's FIL3
         check(waitFor([&] { return radio.m_filter == 3; }),
               "the filter request reaches the radio and selects FIL3");
+        check(waitSchedulerIdle(), "the filter write's compound readback completes");
         check(radio.m_dataOn,
               "and leaves it IN DATA — a filter button must not silently take an "
               "FT8 operator back to microphone audio");
@@ -567,7 +601,7 @@ int main(int argc, char** argv)
         backend.setTxPower(10);
         backend.setMicGain(10);
         backend.setTxMonitor(true, 10);
-        QTest::qWait(150);
+        check(waitSchedulerIdle(), "percentage control writes and confirmations converge");
 
         const auto rawFor = [&](std::uint8_t sub) -> std::optional<int> {
             const auto& frames = radio.civCommands();
@@ -597,17 +631,38 @@ int main(int argc, char** argv)
     // stopped answering after 16 02 02" is a bug report; "the radio stopped
     // answering" is a guess.
     {
+        const auto periodicallyRead = [&](std::uint8_t command, std::uint8_t sub) {
+            return std::any_of(radio.civCommands().begin(), radio.civCommands().end(),
+                               [=](const CivFrame& f) {
+                return f.cmd == command && f.hasSub && f.sub == sub && f.data.empty();
+            });
+        };
+
+        // Prove reconciliation while CI-V is healthy. Once replies stop, each
+        // transaction is deliberately bounded by the timeout; a silence test
+        // should not require the scheduler to spray every register into a
+        // black hole merely to prove those reads exist.
+        radio.clearCivLog();
+        check(waitFor([&] {
+                  return periodicallyRead(cmd::kFunction, func::kNoiseReduce)
+                      && periodicallyRead(cmd::kFunction, func::kNoiseBlanker)
+                      && periodicallyRead(cmd::kLevel, level::kNrLevel)
+                      && periodicallyRead(cmd::kLevel, level::kNbLevel);
+              }, 5000),
+              "NR/NB state and levels are periodically reconciled while CI-V is live");
+
         radio.clearCivLog();
         radio.setCivSilent(true);
 
         // A command the radio receives and does not answer.
         backend.setPanPreamp(QStringLiteral("0"), 1);
-        QTest::qWait(150);
-        check(std::any_of(radio.civCommands().begin(), radio.civCommands().end(),
-                          [](const CivFrame& f) {
-                              return f.cmd == cmd::kFunction && f.hasSub
-                                  && f.sub == func::kPreamp;
-                          }),
+        check(waitFor([&] {
+                  return std::any_of(radio.civCommands().begin(), radio.civCommands().end(),
+                                     [](const CivFrame& f) {
+                                         return f.cmd == cmd::kFunction && f.hasSub
+                                             && f.sub == func::kPreamp;
+                                     });
+              }, 1000),
               "a deaf radio still RECEIVES — the command reached it");
 
         // The detector needs its own threshold to elapse with no inbound frame.
@@ -626,21 +681,6 @@ int main(int argc, char** argv)
         check(backend.isConnected(),
               "and isConnected() still reports true — the lie the detector exists "
               "to break");
-
-        const auto periodicallyRead = [&](std::uint8_t command, std::uint8_t sub) {
-            return std::any_of(radio.civCommands().begin(), radio.civCommands().end(),
-                               [=](const CivFrame& f) {
-                return f.cmd == command && f.hasSub && f.sub == sub && f.data.empty();
-            });
-        };
-        check(periodicallyRead(cmd::kFunction, func::kNoiseReduce),
-              "NR state is periodically read instead of relying on CI-V transceive");
-        check(periodicallyRead(cmd::kFunction, func::kNoiseBlanker),
-              "NB state is periodically read instead of relying on CI-V transceive");
-        check(periodicallyRead(cmd::kLevel, level::kNrLevel),
-              "NR level is periodically reconciled too");
-        check(periodicallyRead(cmd::kLevel, level::kNbLevel),
-              "NB level is periodically reconciled too");
 
         radio.setCivSilent(false);
         QTest::qWait(300);
@@ -756,10 +796,15 @@ int main(int argc, char** argv)
     {
         radio.clearCivLog();
         const QVariantMap res = backend.controlScrub(QString());
-        QTest::qWait(200);
+        check(waitSchedulerIdle(), "the full control scrub drains through the scheduler");
         const auto& sent = radio.civCommands();
 
         check(!res.contains(QStringLiteral("error")), "the scrub runs on a live session");
+        check(res.value(QStringLiteral("broken")).toInt() == 0,
+              "scheduler admission keeps the synchronous scrub from falsely "
+              "reporting queued controls as broken");
+        check(res.value(QStringLiteral("linked")).toInt() > 0,
+              "the scrub reports controls admitted to the scheduler as linked");
 
         // 1. THE MIRROR MUST HOLD THE RADIO'S VALUE, NOT OUR DEFAULT.
         //
@@ -801,7 +846,7 @@ int main(int argc, char** argv)
         // this is the nr/nb/anf/notch sentinel rule, generalised.
         const bool touchedAtten = std::any_of(sent.begin(), sent.end(),
                                               [](const CivFrame& f) {
-            return f.cmd == cmd::kAttenuator;
+            return f.cmd == cmd::kAttenuator && !f.data.empty();
         });
         check(!touchedAtten,
               "a control the radio never reported is NOT driven — re-asserting an "
@@ -904,9 +949,9 @@ int main(int argc, char** argv)
     // An operator disconnect while TUNE is active must unkey and restore the
     // borrowed RF-power register before the serial command path disappears.
     backend.setTxPower(37);
-    QTest::qWait(80);
+    check(waitSchedulerIdle(), "disconnect fixture's ordinary power converges");
     backend.setTune(true, 10);
-    QTest::qWait(80);
+    check(waitSchedulerIdle(), "disconnect fixture reaches active TUNE");
     radio.clearCivLog();
     backend.disconnectRadio();
     QTest::qWait(100);
@@ -1043,8 +1088,7 @@ int main(int argc, char** argv)
         c.backend.connectRadio(r);
         check(waitFor([&] { return c.backend.isConnected(); }),
               "wrong pin: the session still comes up - the RS-BA1 transport is fine");
-        QTest::qWait(300);
-        check(c.sentTo(0xA4) > 1,
+        check(waitFor([&] { return c.sentTo(0xA4) > 1; }, 6000),
               "wrong pin: the reads go where the operator said, not where the "
               "radio is");
         check(c.frequencyMHz == 0.0,
@@ -1093,9 +1137,10 @@ int main(int argc, char** argv)
         check(waitFor([&] { return c.frequencyMHz > 14.0 && c.frequencyMHz < 14.1; }),
               "retarget: the broadcast reply moves the reads to 0x50 and the "
               "radio answers");
-        check(c.sentTo(0xA2) > 1,
-              "retarget: the name seed DID address the wrong device first - "
-              "that is the setup for this case, not the defect");
+        check(c.sentTo(0xA2) == 0,
+              "retarget: the broadcast identity probe leads the scheduler, so "
+              "the queued snapshot for the stale name-derived address is "
+              "discarded before it reaches the wire");
 
         // THE DISCRIMINATING ASSERTION. 0x27 is the scope pair and an IC-9700
         // has a scope, so if "started" is latched per SESSION those two frames

--- a/tests/icom_civ_scheduler_test.cpp
+++ b/tests/icom_civ_scheduler_test.cpp
@@ -1,0 +1,159 @@
+#include "core/backends/icom/IcomCivScheduler.h"
+
+#include <array>
+#include <cstdio>
+#include <string>
+
+using namespace AetherSDR::icom;
+
+namespace {
+int g_failures = 0;
+
+void check(bool condition, const char* what)
+{
+    if (!condition) {
+        std::fprintf(stderr, "FAIL: %s\n", what);
+        ++g_failures;
+    }
+}
+
+IcomCivScheduler::Request read(std::string key, std::uint8_t cmd, std::uint8_t sub,
+                               IcomCivScheduler::Priority priority)
+{
+    IcomCivScheduler::Request request;
+    request.frame = buildFrameSub(0xB6, cmd, sub);
+    request.key = std::move(key);
+    request.priority = priority;
+    request.expectsReply = true;
+    request.replyCmd = cmd;
+    request.replyHasSub = true;
+    request.replySub = sub;
+    return request;
+}
+
+IcomCivScheduler::Request write(std::string key, std::uint8_t cmd, std::uint8_t sub,
+                                std::uint8_t value,
+                                IcomCivScheduler::Priority priority)
+{
+    IcomCivScheduler::Request request;
+    request.frame = buildFrameSub(0xB6, cmd, sub, std::array{value});
+    request.key = std::move(key);
+    request.priority = priority;
+    request.expectsReply = true;
+    request.acceptsGenericReply = true;
+    request.supersedes = true;
+    return request;
+}
+
+CivFrame reply(std::uint8_t cmd, std::uint8_t sub, std::uint8_t value)
+{
+    return CivFrame{0xE0, 0xB6, cmd, true, sub, {value}};
+}
+
+CivFrame ok()
+{
+    return CivFrame{0xE0, 0xB6, kCivOk, false, 0, {}};
+}
+}  // namespace
+
+int main()
+{
+    using Priority = IcomCivScheduler::Priority;
+
+    {
+        IcomCivScheduler scheduler;
+        scheduler.enqueue(read("meter.s", 0x15, 0x02, Priority::ActiveMeter), 1000);
+        scheduler.enqueue(read("meter.s", 0x15, 0x02, Priority::ActiveMeter), 1000);
+        check(scheduler.stats().queueDepth == 1, "duplicate reads coalesce");
+        const auto first = scheduler.takeNext(1000);
+        check(first && first->key == "meter.s", "first read dispatches");
+        check(!scheduler.takeNext(1100), "only one reply-bearing read is outstanding");
+        check(scheduler.observe(reply(0x15, 0x02, 0), 1110)
+                  == IcomCivScheduler::Observation::Accepted,
+              "matching reply completes the outstanding read");
+    }
+
+    {
+        IcomCivScheduler scheduler;
+        scheduler.enqueue(read("ptt", 0x1C, 0x00, Priority::Ptt), 2000);
+        check(scheduler.takeNext(2000).has_value(), "PTT fallback poll dispatches");
+
+        scheduler.enqueue(write("ptt", 0x1C, 0x00, 1, Priority::Operator), 2005);
+        const auto operatorWrite = scheduler.takeNext(2030);
+        check(!operatorWrite, "operator write waits for the outstanding reply slot");
+
+        scheduler.enqueue(read("ptt", 0x1C, 0x00, Priority::Operator), 2005);
+        check(scheduler.observe(reply(0x1C, 0x00, 0), 2040)
+                  == IcomCivScheduler::Observation::Stale,
+              "old PTT OFF completion is rejected after newer PTT ON intent");
+        const auto writeDispatch = scheduler.takeNext(2065);
+        check(writeDispatch && writeDispatch->priority == Priority::Operator,
+              "operator write runs as soon as the old reply is consumed");
+        check(scheduler.observe(ok(), 2070) == IcomCivScheduler::Observation::Accepted,
+              "generic write ACK releases the serial reply slot");
+        const auto confirmation = scheduler.takeNext(2090);
+        check(confirmation && confirmation->key == "ptt",
+              "fresh PTT confirmation follows the stale completion");
+        check(scheduler.observe(reply(0x1C, 0x00, 1), 2100)
+                  == IcomCivScheduler::Observation::Accepted,
+              "fresh PTT ON confirmation is accepted");
+    }
+
+    {
+        IcomCivScheduler scheduler;
+        scheduler.enqueue(read("control.nr", 0x16, 0x40, Priority::Control), 3000);
+        scheduler.enqueue(read("meter.s", 0x15, 0x02, Priority::ActiveMeter), 3000);
+        scheduler.enqueue(write("ptt", 0x1C, 0x00, 0, Priority::Emergency), 3000);
+        const auto emergency = scheduler.takeNext(3000);
+        check(emergency && emergency->priority == Priority::Emergency,
+              "fail-safe unkey wins over every meter/control request");
+        check(scheduler.observe(ok(), 3010) == IcomCivScheduler::Observation::Accepted,
+              "fail-safe unkey ACK releases the reply slot");
+        const auto meter = scheduler.takeNext(3030);
+        check(meter && meter->key == "meter.s", "active meter precedes background control");
+    }
+
+    {
+        IcomCivScheduler scheduler;
+        scheduler.enqueue(read("control.nr", 0x16, 0x40, Priority::Control), 4000);
+        check(scheduler.takeNext(4000).has_value(), "lost-reply fixture dispatches");
+        scheduler.enqueue(read("meter.s", 0x15, 0x02, Priority::ActiveMeter), 4010);
+        check(!scheduler.takeNext(4349), "read remains bounded until timeout");
+        const auto recovered = scheduler.takeNext(4350);
+        check(recovered && recovered->key == "meter.s", "scheduler recovers after lost reply");
+        check(scheduler.stats().timeouts == 1, "lost reply is counted");
+    }
+
+    {
+        IcomCivScheduler scheduler;
+        scheduler.enqueue(read("control.nr", 0x16, 0x40, Priority::Control), 5000);
+        scheduler.enqueue(read("meter.s", 0x15, 0x02, Priority::ActiveMeter), 5000);
+        const auto meter = scheduler.takeNext(5000);
+        check(meter && meter->key == "meter.s", "fresh active meter wins initially");
+        check(scheduler.observe(reply(0x15, 0x02, 0), 5010)
+                  == IcomCivScheduler::Observation::Accepted,
+              "meter completion precedes the aging fixture");
+        scheduler.enqueue(read("meter.power", 0x15, 0x11, Priority::ActiveMeter), 7050);
+        const auto agedControl = scheduler.takeNext(7050);
+        check(agedControl && agedControl->key == "control.nr",
+              "aged control reconciliation cannot be starved by fresh meters");
+    }
+
+    {
+        IcomCivScheduler scheduler;
+        scheduler.enqueue(write("level.rf", 0x14, 0x02, 10, Priority::Operator), 7000);
+        scheduler.enqueue(write("level.rf", 0x14, 0x02, 20, Priority::Operator), 7001);
+        check(scheduler.stats().queueDepth == 1, "rapid writes coalesce to one transaction");
+        const auto latest = scheduler.takeNext(7001);
+        const auto parsed = latest ? parseFrame(latest->frame) : std::nullopt;
+        check(parsed && !parsed->data.empty() && parsed->data.front() == 20,
+              "rapid writes preserve the newest value");
+    }
+
+    if (g_failures == 0) {
+        std::printf("icom_civ_scheduler_test: all checks passed\n");
+        return 0;
+    }
+    std::fprintf(stderr, "icom_civ_scheduler_test: %d failure(s)\n", g_failures);
+    return 1;
+}

--- a/tests/icom_civ_scheduler_test.cpp
+++ b/tests/icom_civ_scheduler_test.cpp
@@ -150,6 +150,85 @@ int main()
               "rapid writes preserve the newest value");
     }
 
+    // Aging must survive the RE-QUEUE, not just the wait. onLinkTick re-asks
+    // for NR/NB/notch every 1000 ms — the same period as kPriorityAgingMs — so
+    // a collapse that rebuilds the entry restarts its clock and the group can
+    // never age at all. The single-enqueue fixture above cannot see that.
+    {
+        IcomCivScheduler scheduler;
+        const std::int64_t t0 = 1755300000000LL;   // a real epoch-ms, as the backend passes
+        scheduler.enqueue(read("meter.s", 0x15, 0x02, Priority::ActiveMeter), t0);
+        check(scheduler.takeNext(t0).has_value(), "aging fixture occupies the reply slot");
+        scheduler.enqueue(read("control.nr", 0x16, 0x40, Priority::Control), t0);
+        for (int tick = 1; tick <= 6; ++tick)
+            scheduler.enqueue(read("control.nr", 0x16, 0x40, Priority::Control),
+                              t0 + tick * 1000);
+        check(scheduler.stats().queueDepth == 1,
+              "a re-queued read collapses instead of accumulating");
+        scheduler.enqueue(read("meter.power", 0x15, 0x11, Priority::ActiveMeter),
+                          t0 + 6001);
+        const auto aged = scheduler.takeNext(t0 + 6001);
+        check(aged && aged->key == "control.nr",
+              "a control re-queued every second still ages past fresh meter work");
+    }
+
+    // Aging tops out BELOW the PTT fallback poll. takeNext breaks an equal
+    // priority tie on sequence and an aged entry always has the lower one, so
+    // aging as far as Priority::Ptt would dispatch ahead of the keyed-state
+    // poll rather than merely tying with it.
+    {
+        IcomCivScheduler scheduler;
+        const std::int64_t t0 = 1755300000000LL;
+        for (int i = 0; i < 10; ++i)
+            scheduler.enqueue(read("c" + std::to_string(i), 0x16,
+                                   static_cast<std::uint8_t>(0x40 + i),
+                                   Priority::Control), t0);
+        scheduler.enqueue(read("ptt", 0x1C, 0x00, Priority::Ptt), t0 + 5000);
+        const auto next = scheduler.takeNext(t0 + 5000);
+        check(next && next->key == "ptt",
+              "a fresh PTT poll outranks background work aged for five seconds");
+    }
+
+    // Two DIFFERENT registers share the coarse "mode" semantic key on purpose,
+    // so a mode write supersedes an in-flight read of either. Coalescing must
+    // not inherit that: sendConnectReadBurst queues 04 and 26 together because
+    // 26 corrects 04 when they disagree.
+    {
+        IcomCivScheduler scheduler;
+        const std::int64_t t0 = 1755300000000LL;
+        scheduler.enqueue(read("mode", 0x04, 0x00, Priority::Maintenance), t0);
+        scheduler.enqueue(read("mode", 0x26, 0x00, Priority::Maintenance), t0);
+        check(scheduler.stats().queueDepth == 2,
+              "reads of different registers are not coalesced by a shared key");
+        scheduler.enqueue(read("meter.s", 0x15, 0x02, Priority::ActiveMeter), t0);
+        scheduler.enqueue(read("meter.s", 0x15, 0x02, Priority::ActiveMeter), t0);
+        check(scheduler.stats().queueDepth == 3,
+              "while a true duplicate read still coalesces");
+    }
+
+    // A reply later than kReadTimeoutMs is still generation-checked. Without
+    // this the identical frame is Stale at 349 ms and authoritative at 351 ms.
+    {
+        IcomCivScheduler scheduler;
+        scheduler.enqueue(read("level.rf", 0x14, 0x02, Priority::Control), 0);
+        check(scheduler.takeNext(0).has_value(), "late-reply fixture dispatches");
+        scheduler.enqueue(write("level.rf", 0x14, 0x02, 99, Priority::Operator), 100);
+        check(scheduler.observe(reply(0x14, 0x02, 0x50), 360)
+                  == IcomCivScheduler::Observation::Stale,
+              "a reply that misses the timeout is still rejected against a "
+              "newer write generation");
+    }
+    {
+        // ...but a merely slow reply with nothing newer behind it is not
+        // reportable as stale; the backend should still adopt it.
+        IcomCivScheduler scheduler;
+        scheduler.enqueue(read("level.rf", 0x14, 0x02, Priority::Control), 0);
+        check(scheduler.takeNext(0).has_value(), "slow-reply fixture dispatches");
+        check(scheduler.observe(reply(0x14, 0x02, 0x50), 360)
+                  == IcomCivScheduler::Observation::Unmatched,
+              "a late reply with no newer intent behind it is not marked stale");
+    }
+
     if (g_failures == 0) {
         std::printf("icom_civ_scheduler_test: all checks passed\n");
         return 0;

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -348,6 +348,13 @@ add_executable(icom_civ_test
 target_include_directories(icom_civ_test PRIVATE src)
 add_test(NAME icom_civ_test COMMAND icom_civ_test)
 
+add_executable(icom_civ_scheduler_test
+    tests/icom_civ_scheduler_test.cpp
+    src/core/backends/icom/IcomCivScheduler.cpp
+    src/core/backends/icom/CivCodec.cpp)
+target_include_directories(icom_civ_scheduler_test PRIVATE src)
+add_test(NAME icom_civ_scheduler_test COMMAND icom_civ_scheduler_test)
+
 add_executable(icom_scope_test
     tests/icom_scope_test.cpp
     src/core/backends/icom/IcomScope.cpp


### PR DESCRIPTION
## Summary

This implements the first production CI-V command scheduler from #4983 for the Icom backend. It replaces independent direct sends from meter, control, startup, reconciliation, and PTT producers with one ordered command plane that can preserve causal intent under load.

- add `IcomCivScheduler` as the single ordinary writer above `IcomSession::sendCiv()`
- pace CI-V dispatches into 25 ms slots with one reply-bearing ordinary transaction in flight
- prioritize emergency unkey, operator controls, PTT, active meters, reconciliation, and maintenance work
- coalesce duplicate reads and rapid writes by semantic register while preserving the newest write generation
- reject stale completions after a newer intent, including the captured delayed PTT-OFF-after-PTT-ON failure mode
- add bounded timeout recovery, priority aging, explicit write-ACK retirement, and radio-authoritative confirmation reads
- add scheduler health and queue convergence to the automation bridge and radio-certification workflow
- document the Icom meter/control/PTT schedule and the proof boundary

This is intentionally Icom-only. It does not change FlexRadio or Hermes-Lite 2 command, meter, PTT, persistence, or stream behavior.

## Root cause

Before this change, several independent timers and operator paths could call the CI-V transport directly. Under normal FT8 activity they could create bursts of meter reads, periodic control reconciliation, PTT fallback polls, and writes on the same request/reply stream.

That produced two related hazards:

1. latency and head-of-line blocking were accidental properties of timer phase rather than an explicit policy; and
2. an old read could complete after a newer operator write and publish obsolete radio state.

The captured PTT failure was the critical example: a pre-key PTT poll requested `OFF`, the client then issued `ON`, and the delayed `OFF` reply arrived after that intent. Treating the reply as current state stopped transmit audio before the radio's real `ON` confirmation arrived.

## Scheduler design

| Priority | Work | Behavior |
|---|---|---|
| Emergency | fail-safe unkey and teardown safety | bypasses ordinary pacing and the outstanding-reply slot |
| Operator | control writes and authoritative confirmation reads | runs ahead of all periodic work |
| PTT | keyed-state fallback polling | safety-sensitive and independent of Transceive hints |
| Active meter | RX or TX meters currently useful to the UI | visibility- and transmit-state-gated |
| Control | periodic front-panel/control reconciliation | coalesced by semantic register |
| Maintenance | low-rate background state | ages upward without outranking PTT |

Core invariants:

- one ordinary dispatch slot every 25 ms
- one ordinary reply-bearing transaction in flight
- 350 ms lost-reply timeout so the queue cannot wedge permanently
- generic `FB`/`FA` write acknowledgements retire the transaction before a later read is dispatched
- semantic generations prevent an old completion from overwriting a newer write
- operator writes schedule a radio-authoritative confirmation read after 60 ms
- PTT intent has a bounded one-second confirmation window: contradictory stale state is suppressed inside the window, matching state confirms it, and radio truth wins again after expiry
- priority aging prevents slow control groups from starving behind continuous meter/PTT work

## Poll and reconciliation schedule

| Command or meter group | Interval | Condition |
|---|---:|---|
| PTT fallback | 250 ms | always while connected; CI-V Transceive is treated as a hint, not sole authority |
| S meter | 100 ms | receiving and visible |
| RF power, SWR, ALC, compression | 200 ms | transmitting and visible |
| PA current (`Id`) | 500 ms | transmitting and visible |
| supply voltage (`Vd`) | 1000 ms | visible |
| overflow | 500 ms | receiving and visible |
| NR, NB, automatic notch, manual notch | 1000 ms | connected |
| frequency, mode/DATA, monitor, VOX | 2000 ms | connected |
| gain/level controls, RF power setting, preamp, AGC, attenuator, tuner, RIT/XIT | 3000 ms | connected |

TX-only meters stop while receiving, and RX-only meters stop while transmitting. Operator commands do not wait behind those polling groups.

## Automation and RadioCert changes

The new read-only `civ scheduler` bridge action reports:

- queue depth and current in-flight semantic key
- slot and read-timeout configuration
- queued, dispatched, coalesced, reply, stale-reply, and timeout counters
- idle state and pending PTT intent

`controls scrub` now distinguishes immediate wire dispatch from scheduler admission. Tests can poll `civ scheduler` until `idle:true` and require an unchanged timeout counter to prove that every admitted control completed its dispatch/readback transaction without blocking the application event loop.

The fake Icom radio and backend integration tests now cover startup convergence, keyed intent, TX-audio gating, tune-power restoration, control confirmations, periodic NR/NB reconciliation, scheduler-backed scrubbing, and safe disconnect restoration.

## Deterministic scheduler coverage

`icom_civ_scheduler_test` exercises:

- duplicate-read coalescing
- one-outstanding-reply serialization
- the stale PTT `OFF` completion after a newer `ON` intent
- write acknowledgement followed by authoritative confirmation
- emergency-unkey preemption
- lost-reply timeout recovery
- anti-starvation priority aging
- rapid slider writes preserving the newest value

## Integration with merged PR #4991

This branch is rebased directly onto `c5ea2f74`, the merge commit for #4991's
Icom login, CI-V auto-address, retained-connection, credential, and experimental-
radio workflow.

The textual conflict exposed a real scheduling boundary, so the resolution is
covered as behavior rather than just a conflict edit:

- the single broadcast `19 00` identity probe is admitted through the scheduler
  and leads the connect snapshot;
- the directed identity read has a distinct semantic key, so it is not
  coalesced with the broadcast probe;
- an identity reply is decoded before the scheduler may dispatch the next
  startup frame, allowing the radio to retarget the CI-V destination first;
- retargeting or detecting two responders discards queued/in-flight work for
  the old destination, then rebuilds the startup and scope snapshot for the
  selected destination; and
- an explicitly pinned wrong address remains pinned; its negative-path test now
  waits through the scheduler's bounded reply timeout instead of assuming an
  immediate request burst.

The combined backend test proves normal auto-detect, wrong pinned addresses,
model-pick correction, a radio whose address changed at the front panel, late
model resolution, unknown models, a silent radio, two responders, and a
self-disagreeing identity reply under the scheduled command plane.

## Live radio proof

Tested locally against an IC-7300MK2 on ANT1 into a dummy load, with transmit constrained to the authorized 20 W ceiling.

- exercised control, meter, and PTT paths end to end through CI-V and the ASDR surface
- completed two low-power keyed carrier runs while checking PTT/audio alignment and TX meter gating
- repeated the control/meter convergence after an application restart
- observed a drained scheduler with no stale-reply or timeout growth during the proof run

The implementation uses commands shared with the IC-705, but this PR does not claim live IC-705 hardware proof.

## Validation after rebasing onto current `origin/main` / #4991

- `cmake --build build -j22` — passed at `5aba6e38`
- combined scheduler/login/address/UI suite — 10/10 passed
- `icom_backend_test` — passed all scheduler plus #4991 auto-detect, retarget, pinned-address, silent-radio, and multi-responder cases
- `python3 tools/check_engine_boundary.py --strict` — 0 blocking findings
- `git diff --check origin/main...HEAD` — passed
- `git merge-tree --write-tree origin/main HEAD` — clean

One existing `icom_session_test` assertion still fails: `the early window is one-time — the next renewal uses the steady cadence`. It is the same current-main failure disclosed by #4991. The scheduler commit changes neither `IcomSession` nor `icom_session_test`; the inherited failure is disclosed here rather than attributed to this integration.

## Review focus

Please pay particular attention to:

- semantic-key and generation boundaries for reads versus writes
- generic ACK ownership before the next read is dispatched
- the bounded PTT-intent window and return to radio authority
- emergency-unkey behavior during an occupied or stalled ordinary slot
- the interaction between 25 ms pacing, 350 ms timeout, and the documented poll rates
- the Icom seam: the only shared-surface change is a read-only automation diagnostic

## Deliberately deferred

This initial production slice uses fixed pacing and timeout bounds. Adaptive RTT-based widening, a formal circuit breaker/session reopen policy, and latency-percentile telemetry remain follow-up work in #4983. It also does not enable or persistently change `CI-V Output (for ANT)`.

Generated with OpenAI Codex (Daybreak Blue)



---

## Review follow-up (added by @ten9876, 2026-08-16)

Rebased onto `d3995654` and three review-fix commits pushed on top. Original
authorship and design are unchanged; these address the posted review threads,
all now resolved. Each fix is pinned by a test that fails when it is reverted.

| Commit | Fixes |
|---|---|
| `0e998b9c` | Rebase onto current `main`. #5002 moved test registration to `tests/tests.cmake`, so `icom_civ_scheduler_test` moved with it; `CMakeLists.txt` keeps only the `CORE_SOURCES` line. |
| `e82f14e8` | Scheduler: clamp `notBeforeMs` before coalescing (re-queued groups could never age); cap aging at `ActiveMeter` so a fresh PTT poll is never out-FIFO'd by aged work; coalesce on reply shape so the connect snapshot's `04` and `26` reads stop collapsing into one; keep timed-out/displaced transactions generation-checked for 2 s. Backend: PTT confirmation window made one-directional per RFC #4983 and Constitution VI; `civ trace` routine classification narrowed back to the poll loops; waiter iteration made re-entrancy-safe. CI: `icom_civ_scheduler_test` and `icom_backend_test` added to the PR gate. |
| `b913183d` | All 18 wall-clock timestamps in `IcomCivBackend` moved to a monotonic `QElapsedTimer`. Every one measures an interval, and a backward NTP step froze the whole command plane silently. `pttIntentDeadlineMs` → `pttIntentRemainingMs`. |

**Correction to "Validation" above:** the disclosed `icom_session_test` failure
(`the early window is one-time…`) does **not** reproduce — 10/10 passes at
`5aba6e38` and on every later head. Treat that line as stale rather than as a
known-failing assertion.

**Undisclosed in the original body, now documented in code:** `kMeterTickMs`
40 → 10 ms (it is the scheduler pump, not a meter tick — comment rewritten),
and `civ.scheduler.wait-idle`, which is a test-only extension verb with no
bridge action routing to it (`civ scheduler` polling is the documented path).
