### PR TITLE
ci: restore compiler caches everywhere, save only on main

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -3,10 +3,18 @@ name: Cache cleanup
 # Deletes Actions cache entries that nothing can read any more, keeping the
 # repository inside its 10 GB allowance.
 #
-# Background: caches are scoped by ref and evicted by LAST ACCESS date, and
-# GitHub removes anything not accessed in over 7 days. That 7-day retention is
-# NOT configurable, so an entry that stops being read still occupies budget for
-# up to a week unless something deletes it.
+# Background: caches are scoped by ref and evicted by LAST ACCESS date, and this
+# repository is on the default seven-day retention — anything not accessed for
+# seven days is removed. So an entry that stops being read still occupies budget
+# for up to a week unless something deletes it.
+#
+# Retention IS a policy, not a platform constant: the same 2025-11-20 changelog
+# that made the size limit configurable introduced a retention limit (days)
+# alongside it, manageable by enterprise/org/repo admins in Actions settings.
+# Whether it can be lowered on this org's Free plan is undocumented and the API
+# does not expose it, so this workflow assumes the default and does the job in
+# code. If retention is ever lowered, revisit whether prune-main is still
+# earning its keep — a short retention does much of the same work for free.
 #
 # One cause is handled here — SUPERSEDED main entries. ci.yml saves a compiler
 # cache on every green main build, keyed on run_id because actions/cache entries
@@ -15,10 +23,16 @@ name: Cache cleanup
 # unreachable it is never accessed again, so nothing refreshes its LRU position
 # and nothing deletes it.
 #
-# That adds up faster than it looks: main runs ~9.2x/day and each writes ~1.0 GiB
-# across the three platforms, so unmanaged this alone accumulates ~9 GiB/day and
-# would pin the repo at its allowance holding roughly a day of caches nothing
-# will ever read.
+# That adds up faster than it looks. Measured entry sizes on refs/heads/main,
+# with the Linux cap raised to 2000M:
+#
+#   ccache-linux-build-   ~1.1 GiB      sccache-windows-   ~0.38 GiB
+#   ccache-ccache-macos-  ~0.18 GiB     ccache-sid-canary- ~0.57 GiB
+#
+# so a main CI run writes ~1.66 GiB across its three platforms, ~9.2x/day —
+# ~15 GiB/day of entries that are unreachable within the hour. Unmanaged, that
+# pins the repo at its allowance on its own, holding well under a day of caches
+# nothing will ever read.
 #
 # NOT handled here: caches on refs/pull/N/merge, which become unreadable when
 # the PR closes. A job for those was written and pulled back out before merge —
@@ -98,6 +112,11 @@ jobs:
             # an empty array and this job reports "nothing to prune" and exits
             # green — the exact silent-success mode this workflow exists to stop.
             # Assigning from a command substitution keeps `set -e` in play.
+            # --limit 100 is per prefix and only ever sees the newest 100. A
+            # sustained outage of this job could therefore strand entries older
+            # than that — the seven-day retention reaps them anyway, so this is a
+            # slower cleanup rather than a leak, but it is why the limit is
+            # generous relative to the ~2 entries a healthy run finds.
             listing=$(
               gh cache list --ref refs/heads/main --key "$prefix" \
                 --limit 100 --sort created_at --order desc \

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,41 +1,50 @@
 name: Cache cleanup
 
-# Delete a PR's Actions caches when it closes.
+# Keeps the repository's Actions cache inside its 10 GB allowance by deleting
+# entries that nothing can read any more. Two distinct jobs, two distinct
+# causes of dead entries — see each job's comment.
 #
-# The repository shares a single 10 GB Actions cache budget, evicted by LRU.
-# Caches are scoped by ref, and a PR's caches live on refs/pull/N/merge — a ref
-# that only that PR can read. Once the PR closes, nothing can ever read them
-# again, but they keep occupying budget until LRU gets around to them, evicting
-# entries on refs/heads/main that every job CAN read.
-#
-# ci.yml's save-on-main split (see "Compiler-cache strategy" there) stops PRs
-# writing the big compiler caches. This handles the rest: PR runs still populate
-# the dependency caches (Qt, FFTW3, DeepFilterNet3, qtkeychain) whose keys are
-# content-hashed rather than run-scoped, and those are not small — a single
-# install-qt-action entry runs to hundreds of MB.
-#
-# Runs on close rather than merge: an abandoned PR's caches are exactly as dead
-# as a merged one's, and abandoned PRs are the ones nobody comes back to.
+# Background for both: caches are scoped by ref and evicted by LAST ACCESS
+# date, and GitHub removes anything not accessed in over 7 days. That 7-day
+# retention is NOT configurable, so an entry that stops being read still
+# occupies budget for up to a week unless something deletes it. Both jobs here
+# exist because "stops being read" is predictable in two specific cases.
 
 on:
   pull_request:
     types: [closed]
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
 
-# Deliberately NOT pull_request_target. That variant runs against the base repo
-# with a writable token and is the standard fork-PR privilege-escalation vector;
-# this job needs no repo contents and no fork input, so the safe trigger is the
-# ordinary one. actions:write is the only scope required, and it cannot reach
-# anything outside the cache API.
+# Deliberately NOT pull_request_target for the PR trigger. That variant runs
+# against the base repo with a writable token and is the standard fork-PR
+# privilege-escalation vector; neither job needs repo contents or fork input.
+# actions:write is the only elevated scope, and it cannot reach anything
+# outside the cache API.
+#
+# This lives here rather than as a step in ci.yml specifically so that ci.yml
+# keeps `contents: read` and nothing that compiles PR-authored code ever holds
+# a write scope.
 permissions:
   actions: write
   contents: read
 
-concurrency:
-  group: cache-cleanup-${{ github.event.pull_request.number }}
-  cancel-in-progress: false
-
 jobs:
-  cleanup:
+  # ── Dead cause 1: the PR closed ──────────────────────────────────────────
+  # A PR's caches live on refs/pull/N/merge, a ref only that PR can read. Once
+  # it closes nothing can ever read them again.
+  #
+  # ci.yml's save-on-main split already stops PRs writing the big compiler
+  # caches. This handles the rest: PR runs still populate content-hash-keyed
+  # dependency caches (Qt, FFTW3, DeepFilterNet3, qtkeychain) that the split
+  # does not touch, and they are not small — PR #4910 held 2.3 GiB, of which a
+  # single Qt entry was 1,297 MiB.
+  #
+  # On close rather than merge: an abandoned PR's caches are exactly as dead as
+  # a merged one's, and abandoned PRs are the ones nobody comes back to.
+  pr-caches:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Delete caches for the closed PR
@@ -47,28 +56,97 @@ jobs:
           set -euo pipefail
           REF="refs/pull/${PR}/merge"
 
-          # List first purely for the log — deletion below is a single call, so
-          # without this the step would report nothing about what it removed.
-          # --limit 100 is far above what one PR accumulates (busiest observed: 4).
+          # Listed first purely for the log — the delete below is one call, so
+          # without this the step would not report what it removed.
           echo "Caches on $REF:"
           gh cache list --ref "$REF" --limit 100 \
             --json key,sizeInBytes \
             --jq '.[] | "  \(.key)  (\((.sizeInBytes/1048576)|floor) MiB)"' || true
 
-          # --all --ref deletes the whole ref's caches in one call.
           # --succeed-on-no-caches keeps the step green when there is nothing to
-          # do, which is the common case for a PR whose caches LRU already took.
+          # do, the common case for a PR whose caches LRU already took.
           gh cache delete --all --ref "$REF" --succeed-on-no-caches
 
-      - name: Report remaining repo cache usage
-        # Visibility, not a gate. The failure this whole change addresses was
-        # silent — builds got slower, nothing went red — so the usage number
-        # belongs somewhere a person will eventually read it.
-        if: always()
+  # ── Dead cause 2: a newer main cache superseded an older one ─────────────
+  # ci.yml saves a compiler cache on every green main build, keyed on run_id
+  # because actions/cache entries are immutable. Restores resolve through
+  # restore-keys to the MOST RECENT match, so the moment run N+1 saves, run N's
+  # entry is unreachable — but it still counts against the allowance for up to
+  # 7 days.
+  #
+  # That adds up faster than it looks: main runs ~9.2x/day and each writes
+  # ~1.0 GiB across the three platforms, so unmanaged this alone accumulates
+  # ~9 GiB/day and pins the repo at its 10 GB allowance holding roughly a day
+  # of caches that nothing will ever read. Pruning to the newest few keeps
+  # steady state near ~4 GB, which is what leaves the Qt/FFTW/DeepFilter
+  # entries clear of the LRU cliff.
+  prune-main:
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune superseded main compiler caches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          # Keep 2, not 1. Only the newest is ever restored, so the second is
+          # insurance: if a save lands a sparse or corrupt entry, deleting it by
+          # hand falls back to a known-good one instead of a cold build for
+          # everybody until the next green main run.
+          KEEP: "2"
+        run: |
+          set -euo pipefail
+
+          # One prefix per compiler cache in ci.yml. The macOS key is doubled
+          # ("ccache-ccache-...") because hendrikmuhs/ccache-action prepends its
+          # own "ccache-" to the key input, which is already "ccache-macos-ci".
+          PREFIXES="ccache-linux-build- sccache-windows- ccache-ccache-macos-ci-"
+
+          total=0
+          for prefix in $PREFIXES; do
+            # created_at, not last_accessed_at: "newest" here means most
+            # recently WRITTEN. Sorting by access would rank a stale entry that
+            # a straggler run happened to read above the current one.
+            mapfile -t IDS < <(
+              gh cache list --ref refs/heads/main --key "$prefix" \
+                --limit 100 --sort created_at --order desc \
+                --json id --jq ".[${KEEP}:] | .[].id"
+            )
+
+            if [ "${#IDS[@]}" -eq 0 ]; then
+              echo "$prefix: nothing to prune (<= $KEEP entries)"
+              continue
+            fi
+
+            echo "$prefix: pruning ${#IDS[@]} superseded entr(ies)"
+            for id in "${IDS[@]}"; do
+              # Delete by id, which is unambiguous; deleting by key would need
+              # --ref and could match another ref's identically-keyed entry.
+              # Tolerate individual failures: LRU can take an entry between the
+              # list and the delete, and one 404 must not strand the rest.
+              if gh cache delete "$id"; then
+                total=$((total + 1))
+              else
+                echo "  already gone: $id"
+              fi
+            done
+          done
+          echo "Pruned $total superseded cache(s)."
+
+  # Visibility, not a gate. The failure this whole workflow addresses was
+  # silent — builds got slower, nothing went red — so the usage number belongs
+  # somewhere a person will eventually read it. Runs after whichever job fired.
+  report:
+    if: always()
+    needs: [pr-caches, prune-main]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report repo cache usage
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           gh api "repos/${{ github.repository }}/actions/cache/usage" \
-            --jq '"Repo Actions cache: \(.active_caches_count) entries, \((.active_caches_size_in_bytes/1073741824)*100|floor/100) GiB of 10 GiB"' \
+            --jq '"Repo Actions cache: \(.active_caches_count) entries, \((.active_caches_size_in_bytes/1073741824)*100|floor/100) GiB of 10 GiB allowance"' \
             | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,74 @@
+name: Cache cleanup
+
+# Delete a PR's Actions caches when it closes.
+#
+# The repository shares a single 10 GB Actions cache budget, evicted by LRU.
+# Caches are scoped by ref, and a PR's caches live on refs/pull/N/merge — a ref
+# that only that PR can read. Once the PR closes, nothing can ever read them
+# again, but they keep occupying budget until LRU gets around to them, evicting
+# entries on refs/heads/main that every job CAN read.
+#
+# ci.yml's save-on-main split (see "Compiler-cache strategy" there) stops PRs
+# writing the big compiler caches. This handles the rest: PR runs still populate
+# the dependency caches (Qt, FFTW3, DeepFilterNet3, qtkeychain) whose keys are
+# content-hashed rather than run-scoped, and those are not small — a single
+# install-qt-action entry runs to hundreds of MB.
+#
+# Runs on close rather than merge: an abandoned PR's caches are exactly as dead
+# as a merged one's, and abandoned PRs are the ones nobody comes back to.
+
+on:
+  pull_request:
+    types: [closed]
+
+# Deliberately NOT pull_request_target. That variant runs against the base repo
+# with a writable token and is the standard fork-PR privilege-escalation vector;
+# this job needs no repo contents and no fork input, so the safe trigger is the
+# ordinary one. actions:write is the only scope required, and it cannot reach
+# anything outside the cache API.
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: cache-cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete caches for the closed PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          REF="refs/pull/${PR}/merge"
+
+          # List first purely for the log — deletion below is a single call, so
+          # without this the step would report nothing about what it removed.
+          # --limit 100 is far above what one PR accumulates (busiest observed: 4).
+          echo "Caches on $REF:"
+          gh cache list --ref "$REF" --limit 100 \
+            --json key,sizeInBytes \
+            --jq '.[] | "  \(.key)  (\((.sizeInBytes/1048576)|floor) MiB)"' || true
+
+          # --all --ref deletes the whole ref's caches in one call.
+          # --succeed-on-no-caches keeps the step green when there is nothing to
+          # do, which is the common case for a PR whose caches LRU already took.
+          gh cache delete --all --ref "$REF" --succeed-on-no-caches
+
+      - name: Report remaining repo cache usage
+        # Visibility, not a gate. The failure this whole change addresses was
+        # silent — builds got slower, nothing went red — so the usage number
+        # belongs somewhere a person will eventually read it.
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${{ github.repository }}/actions/cache/usage" \
+            --jq '"Repo Actions cache: \(.active_caches_count) entries, \((.active_caches_size_in_bytes/1073741824)*100|floor/100) GiB of 10 GiB"' \
+            | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,88 +1,64 @@
 name: Cache cleanup
 
-# Keeps the repository's Actions cache inside its 10 GB allowance by deleting
-# entries that nothing can read any more. Two distinct jobs, two distinct
-# causes of dead entries — see each job's comment.
+# Deletes Actions cache entries that nothing can read any more, keeping the
+# repository inside its 10 GB allowance.
 #
-# Background for both: caches are scoped by ref and evicted by LAST ACCESS
-# date, and GitHub removes anything not accessed in over 7 days. That 7-day
-# retention is NOT configurable, so an entry that stops being read still
-# occupies budget for up to a week unless something deletes it. Both jobs here
-# exist because "stops being read" is predictable in two specific cases.
+# Background: caches are scoped by ref and evicted by LAST ACCESS date, and
+# GitHub removes anything not accessed in over 7 days. That 7-day retention is
+# NOT configurable, so an entry that stops being read still occupies budget for
+# up to a week unless something deletes it.
+#
+# One cause is handled here — SUPERSEDED main entries. ci.yml saves a compiler
+# cache on every green main build, keyed on run_id because actions/cache entries
+# are immutable. Restores resolve through restore-keys to the MOST RECENT match,
+# so the moment run N+1 saves, run N's entry is unreachable — and being
+# unreachable it is never accessed again, so nothing refreshes its LRU position
+# and nothing deletes it.
+#
+# That adds up faster than it looks: main runs ~9.2x/day and each writes ~1.0 GiB
+# across the three platforms, so unmanaged this alone accumulates ~9 GiB/day and
+# would pin the repo at its allowance holding roughly a day of caches nothing
+# will ever read.
+#
+# NOT handled here: caches on refs/pull/N/merge, which become unreadable when
+# the PR closes. A job for those was written and pulled back out before merge —
+# `pull_request` grants a read-only GITHUB_TOKEN for fork PRs and `permissions:`
+# cannot elevate it, so `gh cache delete` 403s; 22 of 25 open PRs are from
+# forks, so it would have failed on nearly every close. It also may not be
+# needed: PRs only WRITE a dependency cache (Qt, FFTW, DeepFilterNet) when the
+# key is not already readable, and the reason they were doing so is that main's
+# copy kept being evicted by the churn ci.yml's save-on-main split removes. Left
+# for a follow-up that can measure whether anything is still accumulating there,
+# and settle the trigger (a scheduled sweep avoids the privileged-trigger
+# question entirely).
 
 on:
-  pull_request:
-    types: [closed]
   workflow_run:
     workflows: [CI]
     types: [completed]
 
-# Deliberately NOT pull_request_target for the PR trigger. That variant runs
-# against the base repo with a writable token and is the standard fork-PR
-# privilege-escalation vector; neither job needs repo contents or fork input.
-# actions:write is the only elevated scope, and it cannot reach anything
-# outside the cache API.
+# actions:write is the only elevated scope and it cannot reach anything outside
+# the cache API. It lives in this workflow rather than as a step in ci.yml
+# specifically so ci.yml keeps `contents: read` — nothing that compiles
+# PR-authored code ever holds a write scope.
 #
-# This lives here rather than as a step in ci.yml specifically so that ci.yml
-# keeps `contents: read` and nothing that compiles PR-authored code ever holds
-# a write scope.
+# workflow_run runs in the BASE repository context with a full token even when
+# the run that triggered it came from a fork, which is why this job works where
+# a `pull_request`-triggered one would not.
 permissions:
   actions: write
   contents: read
 
 jobs:
-  # ── Dead cause 1: the PR closed ──────────────────────────────────────────
-  # A PR's caches live on refs/pull/N/merge, a ref only that PR can read. Once
-  # it closes nothing can ever read them again.
-  #
-  # ci.yml's save-on-main split already stops PRs writing the big compiler
-  # caches. This handles the rest: PR runs still populate content-hash-keyed
-  # dependency caches (Qt, FFTW3, DeepFilterNet3, qtkeychain) that the split
-  # does not touch, and they are not small — PR #4910 held 2.3 GiB, of which a
-  # single Qt entry was 1,297 MiB.
-  #
-  # On close rather than merge: an abandoned PR's caches are exactly as dead as
-  # a merged one's, and abandoned PRs are the ones nobody comes back to.
-  pr-caches:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Delete caches for the closed PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          REF="refs/pull/${PR}/merge"
-
-          # Listed first purely for the log — the delete below is one call, so
-          # without this the step would not report what it removed.
-          echo "Caches on $REF:"
-          gh cache list --ref "$REF" --limit 100 \
-            --json key,sizeInBytes \
-            --jq '.[] | "  \(.key)  (\((.sizeInBytes/1048576)|floor) MiB)"' || true
-
-          # --succeed-on-no-caches keeps the step green when there is nothing to
-          # do, the common case for a PR whose caches LRU already took.
-          gh cache delete --all --ref "$REF" --succeed-on-no-caches
-
-  # ── Dead cause 2: a newer main cache superseded an older one ─────────────
-  # ci.yml saves a compiler cache on every green main build, keyed on run_id
-  # because actions/cache entries are immutable. Restores resolve through
-  # restore-keys to the MOST RECENT match, so the moment run N+1 saves, run N's
-  # entry is unreachable — but it still counts against the allowance for up to
-  # 7 days.
-  #
-  # That adds up faster than it looks: main runs ~9.2x/day and each writes
-  # ~1.0 GiB across the three platforms, so unmanaged this alone accumulates
-  # ~9 GiB/day and pins the repo at its 10 GB allowance holding roughly a day
-  # of caches that nothing will ever read. Pruning to the newest few keeps
-  # steady state near ~4 GB, which is what leaves the Qt/FFTW/DeepFilter
-  # entries clear of the LRU cliff.
   prune-main:
+    # workflow_run.event == 'push', NOT head_branch == 'main'. A fork's default
+    # branch is usually also called main, so a head_branch test fires on fork PR
+    # runs too — harmless in effect (the prune is idempotent and no fork run
+    # writes to refs/heads/main) but it would run this job on all ~35 CI runs a
+    # day instead of the ~9 that actually saved something.
     if: >-
       github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     steps:
@@ -98,29 +74,48 @@ jobs:
         run: |
           set -euo pipefail
 
-          # One prefix per compiler cache in ci.yml. The macOS key is doubled
-          # ("ccache-ccache-...") because hendrikmuhs/ccache-action prepends its
-          # own "ccache-" to the key input, which is already "ccache-macos-ci".
-          PREFIXES="ccache-linux-build- sccache-windows- ccache-ccache-macos-ci-"
+          # EVERY run_id-keyed compiler cache in the repo, not just ci.yml's.
+          # The macOS key is doubled ("ccache-ccache-...") because
+          # hendrikmuhs/ccache-action prepends its own "ccache-" to the key
+          # input, which is already "ccache-macos-ci".
+          #
+          # ccache-sid-canary- belongs to system-libs-canary.yml, which is a
+          # separate workflow on the same push:main trigger. It was missed on
+          # the first pass precisely because the rule was written as "caches in
+          # ci.yml" — the scope that matters is the repository's 10 GB, so if
+          # you add a run_id-keyed compiler cache in ANY workflow, add it here.
+          PREFIXES="
+            ccache-linux-build-
+            sccache-windows-
+            ccache-ccache-macos-ci-
+            ccache-sid-canary-
+          "
 
           total=0
           for prefix in $PREFIXES; do
-            # created_at, not last_accessed_at: "newest" here means most
-            # recently WRITTEN. Sorting by access would rank a stale entry that
-            # a straggler run happened to read above the current one.
-            mapfile -t IDS < <(
+            # Capture to a variable rather than `mapfile < <(...)`: pipefail does
+            # NOT cover process substitution, so a failed API call there yields
+            # an empty array and this job reports "nothing to prune" and exits
+            # green — the exact silent-success mode this workflow exists to stop.
+            # Assigning from a command substitution keeps `set -e` in play.
+            listing=$(
               gh cache list --ref refs/heads/main --key "$prefix" \
                 --limit 100 --sort created_at --order desc \
                 --json id --jq ".[${KEEP}:] | .[].id"
             )
 
-            if [ "${#IDS[@]}" -eq 0 ]; then
+            if [ -z "$listing" ]; then
               echo "$prefix: nothing to prune (<= $KEEP entries)"
               continue
             fi
 
-            echo "$prefix: pruning ${#IDS[@]} superseded entr(ies)"
-            for id in "${IDS[@]}"; do
+            # created_at, not last_accessed_at: "newest" here must mean most
+            # recently WRITTEN. Sorting by access would rank a stale entry that
+            # a straggler run happened to read above the current one, and the
+            # prune would then delete the wrong thing.
+            count=$(printf '%s\n' "$listing" | wc -l)
+            echo "$prefix: pruning $count superseded entr(ies)"
+            while IFS= read -r id; do
               # Delete by id, which is unambiguous; deleting by key would need
               # --ref and could match another ref's identically-keyed entry.
               # Tolerate individual failures: LRU can take an entry between the
@@ -130,19 +125,18 @@ jobs:
               else
                 echo "  already gone: $id"
               fi
-            done
+            done <<< "$listing"
           done
           echo "Pruned $total superseded cache(s)."
 
-  # Visibility, not a gate. The failure this whole workflow addresses was
-  # silent — builds got slower, nothing went red — so the usage number belongs
-  # somewhere a person will eventually read it. Runs after whichever job fired.
-  report:
-    if: always()
-    needs: [pr-caches, prune-main]
-    runs-on: ubuntu-latest
-    steps:
       - name: Report repo cache usage
+        # Visibility, not a gate — the failure this workflow addresses was
+        # silent, so the usage number belongs somewhere a person will read it.
+        # A step of this job rather than a job of its own: as a separate job it
+        # needed `if: always()` + `needs:`, which fired on every CI completion —
+        # ~35 runners a day to print one line, nearly all of them after a prune
+        # that had been skipped.
+        if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,14 +64,22 @@ jobs:
       # This is the reversible first step; read the `cleanups` counter and the
       # hit rate in the "ccache stats" step before going further.
       #
-      # Budget check at 2000M, against the repo's 10 GB cache allowance:
-      #   Linux    ~1.1 GB entry x 2 retained  = 2.2 GB
-      #   Windows  ~0.32 GB x 2                = 0.6 GB
-      #   macOS    ~0.14 GB x 2                = 0.3 GB
-      #   deps (Qt 1.3 GB, DeepFilterNet, FFTW, qtkeychain)
-      #                                        ~ 2.0 GB
-      #                                        -------
-      #                                        ~ 5.1 GB
+      # Budget check at 2000M, against the repo's 10 GB cache allowance. Entry
+      # sizes are MEASURED on refs/heads/main, not projected, except Linux which
+      # is extrapolated from the 55% compression ratio at the new cap:
+      #   Linux    ~1.1 GiB entry x 2 retained  = 2.2 GiB
+      #   Windows  ~0.38 GiB x 2                = 0.8 GiB
+      #   macOS    ~0.18 GiB x 2                = 0.4 GiB
+      #   canary   ~0.57 GiB x 2                = 1.1 GiB
+      #   deps (Qt, DeepFilterNet, FFTW, qtkeychain; 9 entries)
+      #                                         ~ 1.8 GiB
+      #                                         --------
+      #                                         ~ 6.3 GiB
+      # The canary line is system-libs-canary.yml's cache, which an earlier
+      # revision of this table omitted — the same omission that left it out of
+      # cache-cleanup.yml's PREFIXES. Counting it moves the projection from
+      # ~5.1 to ~6.3 GiB: still comfortably inside the allowance, with less
+      # headroom than the earlier figure implied.
       # See "Compiler-cache strategy" at the bottom of this file for why only
       # main writes an entry, and cache-cleanup.yml for what prunes the rest.
       CCACHE_MAXSIZE: 2000M
@@ -973,12 +981,13 @@ jobs:
 # - Do not add an exact-match key to the RESTORE steps. The prefix fallback is
 #   the mechanism; an exact key that never matches just adds a lookup.
 # - SUPERSEDED main entries are swept by .github/workflows/cache-cleanup.yml.
-#   This matters because the 7-day retention is NOT configurable: restores
+#   This matters because we are on the default seven-day retention: restores
 #   resolve to the most recent match, so run N's cache is unreachable the moment
 #   run N+1 saves, and an unreachable entry is never accessed again — so nothing
 #   refreshes its LRU position and nothing deletes it. Left alone, main writes
-#   ~1.0 GiB x ~9.2 runs/day and would pin the repo at its allowance on its own.
-#   That job prunes each prefix to the newest 2.
+#   ~1.66 GiB x ~9.2 runs/day and would pin the repo at its allowance on its
+#   own. That job prunes each prefix to the newest 2. (Retention is itself a
+#   configurable policy as of 2025-11; see cache-cleanup.yml's header.)
 # - IF YOU ADD A run_id-KEYED COMPILER CACHE IN ANY WORKFLOW, add its key prefix
 #   to that job's PREFIXES list. Note "any workflow", not "this file": the first
 #   version of that list was written as "one prefix per compiler cache in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,14 @@ jobs:
       CCACHE_DIR: /ccache
       # Sized from measurement, not guesswork: a full cold build of this
       # configuration settles at ~0.5 GB. 1000M leaves headroom without wasting
-      # budget — and budget pressure here is about entry COUNT, not entry size,
-      # because the cache key carries github.run_id so every run writes a fresh
-      # entry. An oversized cap multiplies what each of those costs against the
-      # repo's 10 GB ceiling and risks LRU-evicting the Qt / FFTW / DeepFilterNet
-      # entries the other jobs depend on. (check-macos runs at 500M, but on a
-      # lighter configuration — no ENABLE_NVIDIA_AFX.)
+      # budget against the repo's 10 GB ceiling, where an oversized cap risks
+      # LRU-evicting the Qt / FFTW / DeepFilterNet entries the other jobs depend
+      # on. (check-macos runs at 500M, but on a lighter configuration — no
+      # ENABLE_NVIDIA_AFX.)
+      #
+      # This cap used to carry more weight than it could bear: entry COUNT, not
+      # entry size, was the binding constraint, and only main writes an entry
+      # now. See "Compiler-cache strategy" at the bottom of this file.
       CCACHE_MAXSIZE: 1000M
 
     steps:
@@ -58,16 +60,16 @@ jobs:
       - name: Ensure ccache is present
         run: command -v ccache || (apt-get update && apt-get install -y ccache)
 
-      - name: Cache ccache objects
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      # RESTORE on every run, SAVE only on main — see "Compiler-cache strategy"
+      # at the bottom of this file for the measurements behind the split.
+      - name: Restore ccache objects
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: /ccache
-          # Exact key never hits (run_id is unique) so every run writes a fresh
-          # entry; restore-keys pulls the most recent prior one. Standard ccache
-          # pattern — GitHub evicts by LRU within the repo's 10 GB budget, which
-          # is why CCACHE_MAXSIZE is capped well under it: this cache must not
-          # evict the Qt/FFTW/DeepFilter entries the other jobs depend on.
-          key: ccache-linux-build-${{ github.run_id }}
+          # There is deliberately no exact-match key here: the prefix fallback
+          # IS the mechanism, and restore-keys picks the most recently created
+          # matching entry, which under save-on-main is the newest main build.
+          key: ccache-linux-build-
           restore-keys: |
             ccache-linux-build-
 
@@ -311,6 +313,24 @@ jobs:
         if: always()
         run: ccache --show-stats
 
+      # Save LAST, and only from a green main build.
+      #
+      # `success()` is not about correctness — ccache keys each object on a hash
+      # of the preprocessed source plus flags, so objects from a failed build are
+      # still valid, just fewer. It is about not letting a build that died early
+      # write a SPARSE entry that restore-keys then prefers over the fuller one
+      # before it, because restore-keys resolves to the most recent match. Every
+      # PR would restore that thinner cache until the next green main run.
+      - name: Save ccache objects
+        if: github.ref == 'refs/heads/main' && success()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: /ccache
+          # run_id keeps the key unique: actions/cache entries are immutable, so
+          # a stable key would make every save after the first a silent no-op
+          # and freeze the cache at its first-ever contents.
+          key: ccache-linux-build-${{ github.run_id }}
+
 
   # Cross-platform build check — runs on every PR (no path gating).
   #
@@ -402,16 +422,14 @@ jobs:
         run: .\scripts\setup\setup-deepfilter.ps1
 
       # Restored BEFORE sccache first runs, so the server sees a populated
-      # SCCACHE_DIR when it starts. Exact key never hits (run_id is unique) so
-      # every run writes a fresh entry; restore-keys pulls the most recent
-      # prior one. Same pattern as the Linux build's ccache step — the prefix
-      # fallback is the entire point, since it survives the key drift that made
-      # the exact-key GHA backend miss 100%.
-      - name: Cache sccache objects
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      # SCCACHE_DIR when it starts. The prefix fallback is the entire point,
+      # since it survives the key drift that made the exact-key GHA backend
+      # miss 100%. Same save-on-main split as the Linux ccache step.
+      - name: Restore sccache objects
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: D:\sccache
-          key: sccache-windows-${{ github.run_id }}
+          key: sccache-windows-
           restore-keys: |
             sccache-windows-
 
@@ -579,12 +597,22 @@ jobs:
       - name: sccache stats
         if: always()
         # Stop the server after reporting: it holds the cache files open, and
-        # actions/cache archives SCCACHE_DIR in the post-job step. Stopping
-        # first is what guarantees everything this run compiled is flushed to
-        # disk and actually ends up in the saved entry.
+        # the save step below archives SCCACHE_DIR. Stopping first is what
+        # guarantees everything this run compiled is flushed to disk and
+        # actually ends up in the saved entry — which is also why the save is
+        # an explicit step AFTER this one rather than a post-job hook.
         run: |
           sccache --show-stats
           sccache --stop-server
+
+      # Save LAST, and only from a green main build — see the Linux job's
+      # equivalent step and "Compiler-cache strategy" at the bottom of the file.
+      - name: Save sccache objects
+        if: github.ref == 'refs/heads/main' && success()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: D:\sccache
+          key: sccache-windows-${{ github.run_id }}
 
   # macOS build check — runs on every PR (no path gating), same rationale
   # as check-windows above.  Catches Q_OS_MAC / CoreAudio / Cocoa-bridge
@@ -731,6 +759,22 @@ jobs:
         with:
           key: ccache-macos-ci
           max-size: 500M
+          # Same save-on-main split as the Linux and Windows jobs, expressed
+          # through this action's own `save` input rather than a restore/save
+          # pair. Restore stays on (default) so PRs read main's entry.
+          #
+          # append-timestamp stays at its default (true) deliberately: the
+          # action needs a unique key per save because actions/cache entries are
+          # immutable, so pinning it to the bare `ccache-macos-ci` would make
+          # every save after the first a silent no-op and freeze the cache.
+          #
+          # KNOWN GAP vs the other two jobs: this input is evaluated when the
+          # step runs, and the action saves from its own post-job hook, so there
+          # is no `success()` half — a failed main build here still writes an
+          # entry. Tolerated rather than worked around: the cost is a sparser
+          # cache until the next green main run, not a wrong one, and at 500M on
+          # the lighter macOS configuration that is the smallest of the three.
+          save: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Ensure offline Metal toolchain
         # Build-time ASR kernel compilation (#4535) needs the offline Metal
@@ -818,3 +862,72 @@ jobs:
             -DGGML_METAL_EMBED_LIBRARY=1 -DGGML_METAL_HAS_BF16=1 -c "$src" -o - |
             xcrun -sdk macosx metallib - -o "$RUNNER_TEMP/ggml-metal-intel-dmg.metallib"
           ls -l "$RUNNER_TEMP/ggml-metal-intel-dmg.metallib"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Compiler-cache strategy: restore everywhere, save only on main
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# All three build jobs restore their compiler cache on every run but save only
+# from a green build of main. This section records why, because the previous
+# arrangement was a reasonable-looking pattern that failed silently for months.
+#
+# WHAT WENT WRONG BEFORE
+#
+# Every job keyed its save on github.run_id, so every run — PR runs included —
+# wrote a fresh ~0.6 GB entry. GitHub Actions caches are scoped by ref, and a
+# PR's entry lands on refs/pull/N/merge, which NO OTHER PR is permitted to
+# read. Only entries on refs/heads/main are readable repo-wide.
+#
+# So each PR run wrote an entry that nothing else could ever use, into a budget
+# capped at 10 GB for the whole repository, evicting by LRU. Measured on
+# 2026-08-16, with 26 PRs open:
+#
+#   refs/pull/*/merge   14 entries   8.62 GB   <- unreadable by anything else
+#   refs/heads/main      9 entries   2.00 GB   <- the only shared entries
+#                                   -------
+#                        active total 10.80 GB against a 10 GB ceiling
+#
+# 80% of the budget was PR-scoped, and its only effect was evicting the shared
+# main entry. There was at that point NO Linux ccache or Windows sccache entry
+# on main at all — both had been evicted — so PR builds and main builds alike
+# were running cold. The tell is a "Restore" step completing in 0 s where a
+# healthy one takes ~12 s.
+#
+# The arithmetic says this could not have held: ~35 CI runs/day x ~2 GB of
+# compiler cache per run is 50-80 GB/day pushed through a 10 GB budget. The
+# whole cache turned over several times a day. Capping CCACHE_MAXSIZE limits
+# each entry's SIZE and does nothing about entry COUNT, which was the binding
+# constraint.
+#
+# WHY SAVE-ON-MAIN FIXES IT
+#
+# PR runs now write nothing, so the shared main entry stops being evicted by
+# caches nobody can read. main refreshes it 9.2 times/day (median gap 54 min),
+# and ccache is incremental — each main run restores the previous entry and adds
+# to it, so there is no cold-refresh cycle to wait through.
+#
+# WHAT IT COSTS
+#
+# A PR no longer accumulates its own cache across pushes. That is a real loss on
+# paper and was already lost in practice: cache turnover was a few hours against
+# a median PR lifetime of 17.6 h, so a PR's own entry was almost always gone by
+# its second push.
+#
+# The genuine new cost is the overnight gap — up to 9.7 h between main runs, so
+# an early-morning PR restores a night-stale cache. ccache degrades in
+# proportion to how much of src/ changed, so that is a hit-rate dip rather than
+# a cold build. A scheduled nightly main run would close it; not added, because
+# the "ccache stats" / "sccache stats" steps already print the hit rate and that
+# is the number to look at before spending a job on it.
+#
+# IF YOU ARE CHANGING THIS
+#
+# - Keep run_id (or the macOS action's append-timestamp) in the SAVE key.
+#   actions/cache entries are immutable, so a stable key makes every save after
+#   the first a silent no-op and freezes the cache at its first-ever contents.
+# - Keep the save steps last, after the stats steps, and after
+#   `sccache --stop-server` on Windows — the server holds cache files open.
+# - Do not add an exact-match key to the RESTORE steps. The prefix fallback is
+#   the mechanism; an exact key that never matches just adds a lookup.
+# - PR-scoped caches from the other steps (Qt, FFTW, DeepFilterNet, qtkeychain)
+#   are cleaned up when a PR closes by .github/workflows/cache-cleanup.yml.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,10 @@ jobs:
       CCACHE_DIR: /ccache
       # Sized from measurement, not guesswork: a full cold build of this
       # configuration settles at ~0.5 GB. 1000M leaves headroom without wasting
-      # budget against the repo's 10 GB ceiling, where an oversized cap risks
-      # LRU-evicting the Qt / FFTW / DeepFilterNet entries the other jobs depend
-      # on. (check-macos runs at 500M, but on a lighter configuration — no
-      # ENABLE_NVIDIA_AFX.)
+      # budget against the repo's 10 GB cache allowance, where an oversized cap
+      # risks LRU-evicting the Qt / FFTW / DeepFilterNet entries the other jobs
+      # depend on. (check-macos runs at 500M, but on a lighter configuration —
+      # no ENABLE_NVIDIA_AFX.)
       #
       # This cap used to carry more weight than it could bear: entry COUNT, not
       # entry size, was the binding constraint, and only main writes an entry
@@ -879,13 +879,13 @@ jobs:
 # read. Only entries on refs/heads/main are readable repo-wide.
 #
 # So each PR run wrote an entry that nothing else could ever use, into a budget
-# capped at 10 GB for the whole repository, evicting by LRU. Measured on
-# 2026-08-16, with 26 PRs open:
+# with a 10 GB allowance for the whole repository, evicting by LRU. Measured
+# on 2026-08-16, with 26 PRs open:
 #
 #   refs/pull/*/merge   14 entries   8.62 GB   <- unreadable by anything else
 #   refs/heads/main      9 entries   2.00 GB   <- the only shared entries
 #                                   -------
-#                        active total 10.80 GB against a 10 GB ceiling
+#                        active total 10.80 GB against a 10 GB allowance
 #
 # 80% of the budget was PR-scoped, and its only effect was evicting the shared
 # main entry. There was at that point NO Linux ccache or Windows sccache entry
@@ -894,10 +894,18 @@ jobs:
 # healthy one takes ~12 s.
 #
 # The arithmetic says this could not have held: ~35 CI runs/day x ~2 GB of
-# compiler cache per run is 50-80 GB/day pushed through a 10 GB budget. The
+# compiler cache per run is 50-80 GB/day pushed through a 10 GB allowance. The
 # whole cache turned over several times a day. Capping CCACHE_MAXSIZE limits
 # each entry's SIZE and does nothing about entry COUNT, which was the binding
 # constraint.
+#
+# NOTE the 10 GB is an ALLOWANCE, not a hard cap. Since 2025-11 it is
+# configurable upward by enterprise/org/repo admins, billed at $0.07/GB-month
+# above 10 GB — but doing so "requires a valid Pro, Team, or Enterprise
+# account", and the aethersdr org is on Free. Raising it was considered and
+# rejected: it would have paid to warehouse the 8.62 GB of PR-scoped entries
+# that nothing is permitted to read. This change removes that waste instead,
+# and lands the repo well inside the free allowance.
 #
 # WHY SAVE-ON-MAIN FIXES IT
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -937,5 +937,14 @@ jobs:
 #   `sccache --stop-server` on Windows — the server holds cache files open.
 # - Do not add an exact-match key to the RESTORE steps. The prefix fallback is
 #   the mechanism; an exact key that never matches just adds a lookup.
-# - PR-scoped caches from the other steps (Qt, FFTW, DeepFilterNet, qtkeychain)
-#   are cleaned up when a PR closes by .github/workflows/cache-cleanup.yml.
+# - Two kinds of dead entry are swept by .github/workflows/cache-cleanup.yml,
+#   and both matter because the 7-day retention is NOT configurable, so an
+#   entry that stops being read still costs budget for a week:
+#     * PR-scoped caches from the other steps (Qt, FFTW, DeepFilterNet,
+#       qtkeychain), deleted when the PR closes;
+#     * SUPERSEDED main entries. Restores resolve to the most recent match, so
+#       run N's cache is unreachable the moment run N+1 saves. Left alone, main
+#       writes ~1.0 GiB x ~9.2 runs/day and would pin the repo at its allowance
+#       on its own. That job prunes each prefix to the newest 2.
+#   If you add a compiler cache here, add its key prefix to that job's
+#   PREFIXES list or it will accumulate silently.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,17 +38,43 @@ jobs:
     # the cache and the compiler side.
     env:
       CCACHE_DIR: /ccache
-      # Sized from measurement, not guesswork: a full cold build of this
-      # configuration settles at ~0.5 GB. 1000M leaves headroom without wasting
-      # budget against the repo's 10 GB cache allowance, where an oversized cap
-      # risks LRU-evicting the Qt / FFTW / DeepFilterNet entries the other jobs
-      # depend on. (check-macos runs at 500M, but on a lighter configuration —
-      # no ENABLE_NVIDIA_AFX.)
+      # Raised 1000M -> 2000M. This cache was FULL and evicting internally: the
+      # last green main run before this change reported
       #
-      # This cap used to carry more weight than it could bear: entry COUNT, not
-      # entry size, was the binding constraint, and only main writes an entry
-      # now. See "Compiler-cache strategy" at the bottom of this file.
-      CCACHE_MAXSIZE: 1000M
+      #   Cache size (GB):  1.0 /  1.0 (95.41%)   Hits 2082/2210 (94.21%)
+      #
+      # A cold build settles at ~0.5 GB, so 1000M looked like 2x headroom — but
+      # this entry does not hold one build, it accumulates objects across ~9.2
+      # main merges a day. At 1.0 GB it was continuously discarding its own
+      # oldest objects, so it only ever represented a narrow window of recent
+      # main, and a PR branched from a day-old main took misses on objects that
+      # had fallen out of ccache rather than out of the GitHub cache.
+      #
+      # Raised for THIS job only. The other two are not constrained and would
+      # pay transfer time for nothing — do not raise them on symmetry grounds:
+      #   check-macos     0.3 / 0.5 GB (57.63%)
+      #   check-windows   628 MiB / 1 GiB (61%)
+      #
+      # 2000M, not the 5000M the headroom would allow, because the binding
+      # constraint is TRANSFER TIME, not storage. Entries compress to ~55% of
+      # the ccache directory (1.0 GB of ccache -> a 556 MiB entry), and restore
+      # cost scales with it: 12 s at 556 MiB today, ~24 s at 2000M, ~60 s at
+      # 5000M — paid on EVERY run, against a benefit that only materialises
+      # for misses that were eviction-caused rather than genuinely new source.
+      # This is the reversible first step; read the `cleanups` counter and the
+      # hit rate in the "ccache stats" step before going further.
+      #
+      # Budget check at 2000M, against the repo's 10 GB cache allowance:
+      #   Linux    ~1.1 GB entry x 2 retained  = 2.2 GB
+      #   Windows  ~0.32 GB x 2                = 0.6 GB
+      #   macOS    ~0.14 GB x 2                = 0.3 GB
+      #   deps (Qt 1.3 GB, DeepFilterNet, FFTW, qtkeychain)
+      #                                        ~ 2.0 GB
+      #                                        -------
+      #                                        ~ 5.1 GB
+      # See "Compiler-cache strategy" at the bottom of this file for why only
+      # main writes an entry, and cache-cleanup.yml for what prunes the rest.
+      CCACHE_MAXSIZE: 2000M
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,6 +391,13 @@ jobs:
   # 9.18 GB of the 10 GB budget across 3471 entries, LRU-evicting the shared
   # entries and reinforcing the miss.
   #
+  # Read that alongside "Compiler-cache strategy" at the bottom of this file:
+  # the same ref-scoping fact ("a PR may only read its base branch's cache")
+  # later turned out to be wasting most of the budget through the DIRECTORY
+  # caches too, not just the per-object backend this paragraph retired. Same
+  # root cause, two symptoms, fixed years apart — which is why the note below
+  # spells out the rule rather than just the fix.
+  #
   # The exact-key requirement is what makes that fatal rather than merely
   # lossy: any key drift is a total miss with no fallback. The Linux build
   # avoids it by caching a ccache DIRECTORY with prefix `restore-keys:` — it
@@ -408,9 +415,11 @@ jobs:
       # Local disk cache, not the GHA backend — see the note above. D: is the
       # fast runner volume and the one the workspace already lives on.
       SCCACHE_DIR: D:\sccache
-      # Matches ccache's cap on the Linux build, and for the same reason: every
-      # run writes a fresh cache entry, so budget pressure here is about entry
-      # size × count against the repo's 10 GB ceiling.
+      # Left at 1G. The Linux ccache was raised to 2000M because it was
+      # measurably full (1.0/1.0 GB, 95.41%); this one measured 628 MiB of 1 GiB
+      # on the same run, so raising it would buy nothing and cost transfer time
+      # on every restore. Do not raise the three caps together on symmetry
+      # grounds — check the stats step first.
       SCCACHE_CACHE_SIZE: 1G
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -963,14 +972,23 @@ jobs:
 #   `sccache --stop-server` on Windows — the server holds cache files open.
 # - Do not add an exact-match key to the RESTORE steps. The prefix fallback is
 #   the mechanism; an exact key that never matches just adds a lookup.
-# - Two kinds of dead entry are swept by .github/workflows/cache-cleanup.yml,
-#   and both matter because the 7-day retention is NOT configurable, so an
-#   entry that stops being read still costs budget for a week:
-#     * PR-scoped caches from the other steps (Qt, FFTW, DeepFilterNet,
-#       qtkeychain), deleted when the PR closes;
-#     * SUPERSEDED main entries. Restores resolve to the most recent match, so
-#       run N's cache is unreachable the moment run N+1 saves. Left alone, main
-#       writes ~1.0 GiB x ~9.2 runs/day and would pin the repo at its allowance
-#       on its own. That job prunes each prefix to the newest 2.
-#   If you add a compiler cache here, add its key prefix to that job's
-#   PREFIXES list or it will accumulate silently.
+# - SUPERSEDED main entries are swept by .github/workflows/cache-cleanup.yml.
+#   This matters because the 7-day retention is NOT configurable: restores
+#   resolve to the most recent match, so run N's cache is unreachable the moment
+#   run N+1 saves, and an unreachable entry is never accessed again — so nothing
+#   refreshes its LRU position and nothing deletes it. Left alone, main writes
+#   ~1.0 GiB x ~9.2 runs/day and would pin the repo at its allowance on its own.
+#   That job prunes each prefix to the newest 2.
+# - IF YOU ADD A run_id-KEYED COMPILER CACHE IN ANY WORKFLOW, add its key prefix
+#   to that job's PREFIXES list. Note "any workflow", not "this file": the first
+#   version of that list was written as "one prefix per compiler cache in
+#   ci.yml" and duly missed system-libs-canary.yml's ccache-sid-canary-, which
+#   is the same run_id-keyed pattern on the same push:main trigger. The scope
+#   that matters is the repository's 10 GB allowance, not this file's share.
+# - PR-scoped caches (Qt, FFTW, DeepFilterNet, qtkeychain on refs/pull/N/merge)
+#   are NOT swept. A job for them was written and pulled before merge: a
+#   `pull_request` trigger gets a read-only token on fork PRs and cannot be
+#   elevated, and 22 of 25 open PRs are forks. It may also prove unnecessary —
+#   PRs only WRITE those when the key is not already readable, which was itself
+#   a symptom of main's copies being evicted by the churn the split above
+#   removes. Deferred to a follow-up that can measure it first.


### PR DESCRIPTION
## The problem

The repository shares **one 10 GB Actions cache budget**, evicted by LRU. Every CI run — PR runs included — wrote a fresh ~0.6 GB compiler-cache entry keyed on `github.run_id`.

Actions caches are **scoped by ref**. A PR's entry lands on `refs/pull/N/merge`, which **no other PR is permitted to read**. Only `refs/heads/main` entries are readable repo-wide.

So every PR run wrote an entry nothing else could ever use — and its only effect was evicting the shared `main` entry that all 26 open PRs *can* read. Measured 2026-08-16:

| ref | entries | size |
|---|---|---|
| `refs/pull/*/merge` | 14 | **8.62 GB** — unreadable by anything else |
| `refs/heads/main` | 9 | 2.00 GB — the only shared entries |
| | | **10.80 GB active, against a 10 GB ceiling** |

**80% of the budget was PR-scoped.** By then there was no Linux ccache or Windows sccache entry left on `main` at all — both evicted — so PR builds *and* main builds were running cold:

- PR #5002: **19+ minutes** against a 7–13 min norm
- the `main` run that merged #5001: **26 minutes**
- the tell is a restore step finishing in **0 s** where a healthy one takes ~12 s

It could never have held arithmetically: **~35 runs/day × ~2 GB per run = 50–80 GB/day through a 10 GB budget**, turning the whole cache over several times daily.

`CCACHE_MAXSIZE` caps entry **size**. The binding constraint was entry **count**, so that cap could not help — and its comment claimed it could. Corrected here.

## The change

All three build jobs now **restore on every run, save only from a green `main` build**.

```yaml
- name: Restore ccache objects
  uses: actions/cache/restore@<pinned>
  with:
    key: ccache-linux-build-          # prefix fallback IS the mechanism
    restore-keys: ccache-linux-build-

# ... build, stats ...

- name: Save ccache objects
  if: github.ref == 'refs/heads/main' && success()
  uses: actions/cache/save@<pinned>
  with:
    key: ccache-linux-build-${{ github.run_id }}
```

PR runs write nothing, so the shared entry stops being evicted by caches nobody can read. `main` refreshes it **9.2×/day (median gap 54 min)**, and ccache is incremental — each main run restores the previous entry and adds to it, so there's no cold-refresh cycle.

macOS uses `hendrikmuhs/ccache-action`'s own `save:` input for the same split.

### Why `success()`

**Not correctness.** ccache keys each object on a hash of preprocessed source plus flags, so objects from a failed build are perfectly valid — just fewer.

It stops a build that died early writing a **sparse** entry that `restore-keys` — which resolves to the most *recent* match — would then hand to every PR until the next green `main` run. The macOS action saves from a post-job hook and can't express that half; the gap is documented inline rather than worked around, since its cost is a thinner cache at 500M on the lightest configuration.

### Why `run_id` stays in the save key

`actions/cache` entries are **immutable**. A stable key would make every save after the first a silent no-op and freeze the cache at its first-ever contents. Same reason macOS keeps `append-timestamp` at its default.

## `cache-cleanup.yml`

Deletes a PR's caches when it closes. Needed **even with** the above, because PR runs still populate content-hash-keyed *dependency* caches that save-on-main doesn't touch:

```
PR #4910:  ccache-linux-build-…      556 MiB
           qt-6.8.3-macos-clang64…  1297 MiB   <- dependency cache
           ccache-macos-ci-…         136 MiB
           sccache-windows-…         322 MiB
           ─────────────────────────────────
                                    2.3 GiB, all dead once the PR closed
```

Uses plain `pull_request`, **not** `pull_request_target` — that variant runs against the base repo with a writable token and is the standard fork-PR escalation vector. Takes only `actions: write`. Also prints repo cache usage to the step summary, because the failure this whole PR addresses was silent: builds got slower, nothing went red.

## What it costs — stated plainly

A PR no longer accumulates its own cache across pushes. **That was already lost**: turnover was a few hours against a median PR lifetime of 17.6 h, so a PR's own entry was almost always gone by its second push.

The genuine new cost is the **overnight gap** — up to 9.7 h between `main` runs, so an early-morning PR restores a night-stale cache. ccache degrades in proportion to how much of `src/` changed, so that's a hit-rate dip, not a cold build.

**No nightly refresh job added.** The existing `ccache stats` / `sccache stats` steps already print the hit rate; that's the number to look at before spending a job on it.

## Expected effect

Footprint should drop from ~10.8 GB to roughly **6.3 GiB**, leaving headroom so the Qt/FFTW/DeepFilterNet entries stop being eviction candidates.

Entry sizes measured on `refs/heads/main` (Linux extrapolated to the new 2000M cap at the observed 55% compression ratio):

| | entry | ×2 retained |
|---|---|---|
| `ccache-linux-build-` | ~1.1 GiB | 2.2 GiB |
| `sccache-windows-` | 0.38 GiB | 0.8 GiB |
| `ccache-ccache-macos-ci-` | 0.18 GiB | 0.4 GiB |
| `ccache-sid-canary-` | 0.57 GiB | 1.1 GiB |
| dependency caches (9 entries) | — | 1.8 GiB |
| **total** | | **~6.3 GiB of 10** |

*An earlier revision of this section said ~3.5 GB and the in-file table said ~5.1 GB. Both were wrong: the first predated the `CCACHE_MAXSIZE` raise, and both omitted the canary cache — the same omission that left it out of `PREFIXES`.*

## Verification

- Both workflows parse (`yaml.safe_load`).
- Both save steps confirmed **last in their job** (17/17 and 19/19) and guarded by `github.ref == 'refs/heads/main' && success()`.
- Windows save is ordered after `sccache --stop-server`, which flushes open cache files — the reason it's an explicit step rather than a post-job hook.
- `gh cache list/delete --ref` flags verified against the installed `gh`; the cleanup query dry-run returns the expected rows for #4910/#5002 and empty for #5001.
- The functional diff is exactly five edits; everything else is comments.

**The first `main` run after this lands will build cold (~26 min) and write the seed entry.** Every run after that, on `main` and on every PR, restores from it.

A "Compiler-cache strategy" section at the bottom of `ci.yml` records the measurements, the trade-offs, and what not to change — the previous arrangement looked reasonable and failed silently for months, so the reasoning belongs next to the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Constitution principle honored

**Principle VIII — Evidence Over Assertion.** Every load-bearing number here is measured rather than reasoned: the 0 s vs 12 s restore that identified the defect, the per-ref cache breakdown, the `1.0 / 1.0 GB (95.41%)` that justifies the `CCACHE_MAXSIZE` raise, and the entry sizes in the table above. Where a figure is extrapolated rather than observed it says so.

**Principle XI — Fixes Are Demonstrated** is the one this PR cannot fully satisfy, and that is worth stating plainly rather than leaving implied. Every `save` step is gated on `github.ref == 'refs/heads/main'`, and `workflow_run` workflows only execute from the default branch — so **neither the save path nor `prune-main` can run on this PR**. The first real exercise is the first push to `main` after merge. What *is* demonstrated is in the test plan below.

## Test plan

Executed against the live repository, since CI cannot reach the gated paths:

- **Prune selection**, run under bash 5 with all four prefixes against the live cache API: correctly identifies superseded entries, correctly reports "nothing to prune" at `KEEP=2` when a prefix has ≤2, and the empty case yields a clean skip rather than a spurious delete.
- **`gh` flag surface** verified against the installed CLI: `cache list --key/--sort created_at/--order desc`, `--json id,key,ref,sizeInBytes`, and `cache delete <id>`.
- **`hendrikmuhs/ccache-action` inputs** confirmed by fetching `action.yml` at pin `d62db5f` — `save`, `restore`, `append-timestamp` all present, all default `true`. Independently verified by @nigelfenton.
- **Doubled macOS key** (`ccache-ccache-macos-ci-`) confirmed against the live cache listing rather than inferred.
- **Both workflows parse** (`yaml.safe_load`), and both `save` steps confirmed last in their job and correctly gated.
- **CI green** on all five checks for the `ci.yml` half.

**After merge, read the first `main` run before trusting it:** if it fails, `success()` means no entry is written and the next PR is cold too. Then read `cleanups` and the hit rate in the `ccache stats` step to decide whether 2000M was enough.
