### PR TITLE
fix(icom): restore WSPR, PC Audio routing, and CW decoder

### DIFF
--- a/docs/architecture/aetherd-icom-civ-backend-design.md
+++ b/docs/architecture/aetherd-icom-civ-backend-design.md
@@ -97,7 +97,7 @@ and it is the cleanest part of that codebase.
 | `setMicGain` | CI-V `14 0B`, 0000–0255 BCD |
 | `setTxMonitor` | CI-V `16 45` enable plus `14 15` level |
 | `setTxFilter` | CI-V `1A 05 0020/0021/0022` — **discrete WIDE/MID/NAR**, not Hz |
-| `submitTxAudio` | audio stream, codec 4 — **requires DATA MOD = WLAN (IC-705) or LAN (IC-7300MK2)** |
+| `submitTxAudio` | audio stream, codec 4 — **requires the model's network source** (WLAN on IC-705, LAN on IC-7300MK2) in `DATA MOD` for data modes and `DATA OFF MOD` for voice |
 | `setSliceAudioGain` | CI-V `14 01` (AF level) |
 | `createPanadapter` | `false` — one receiver, one scope |
 
@@ -349,6 +349,45 @@ The one measured exception is a write-only-in-practice register such as the
 IC-7300MK2 RX-ANT selection: its documented read produced only `FB`. Scope the
 send-only control to the model, keep its optimistic state session-local, and
 document why it cannot participate in the ordinary polling contract.
+
+#### `DATA OFF MOD` is written; `DATA MOD` is not. Why the two differ
+
+Both are `1A 05` SET-menu leaves the radio persists identically, so the
+asymmetry needs stating rather than assuming.
+
+`DATA OFF MOD` selects where **voice** modulation comes from, and PC Audio is
+the operator saying "my voice is on this computer" — the two answer the same
+question, so a click on that button is a legible request to change it
+(Principle II: a user action is a request). `DATA MOD` selects where **data**
+modulation comes from, and nothing in AetherSDR's UI expresses an intent about
+it: WSJT-X, fldigi and the built-in beacons all reach the radio the same way
+whichever source is selected, so a client that wrote it would be changing
+operator state on a guess. It stays read-and-report.
+
+Three rules keep the writable half inside Principle III:
+
+1. **Only an operator click writes.** The connect edge *publishes* the client's
+   PC Audio state (`icom/audio.pc.state`) so `checkModInput()` can warn about a
+   mismatch; the write lives behind `icom/audio.pc`, which nothing but the
+   button calls. Replaying the client-persisted `PcAudioEnabled` key onto the
+   register at connect is precisely the two-sources-of-truth fight Principle III
+   exists to prevent.
+2. **"Off" restores, it does not assume.** The register is four-valued on an
+   IC-705 and six-valued on an IC-7300MK2; the button has two states. The
+   backend latches the radio's own value immediately before its first write of
+   the session and puts *that* back, falling back to the profile's `micValue`
+   only when there was nothing to capture. Writing a fixed MIC would delete an
+   operator's USB or ACC selection with no undo and no dialog.
+3. **Unverified models are refused, not guessed at.** `modulationProfileFor()`
+   answers only for models whose own CI-V guide has been checked. A click on any
+   other Icom is declined and says so; nothing is read, written or shown.
+
+That third rule has a cost worth naming: on a model with no profile, Radio
+Health shows no `DATA OFF MOD` / `DATA MOD` row at all, where it used to show
+one. The old row read items 118/119 on **every** Icom and labelled the result
+from the IC-705's enum — which is how an IC-9700 correctly set to LAN reported
+"USB" and got warned at, every session. A row that is wrong is worse than a
+missing one; the fix is another verified profile, not a re-enabled guess.
 
 #### A 0000–0255 level is not a 0–255 meter
 

--- a/docs/architecture/aetherd-icom-civ-backend-design.md
+++ b/docs/architecture/aetherd-icom-civ-backend-design.md
@@ -97,7 +97,7 @@ and it is the cleanest part of that codebase.
 | `setMicGain` | CI-V `14 0B`, 0000–0255 BCD |
 | `setTxMonitor` | CI-V `16 45` enable plus `14 15` level |
 | `setTxFilter` | CI-V `1A 05 0020/0021/0022` — **discrete WIDE/MID/NAR**, not Hz |
-| `submitTxAudio` | audio stream, codec 4 — **requires DATA MOD = WLAN** |
+| `submitTxAudio` | audio stream, codec 4 — **requires DATA MOD = WLAN (IC-705) or LAN (IC-7300MK2)** |
 | `setSliceAudioGain` | CI-V `14 01` (AF level) |
 | `createPanadapter` | `false` — one receiver, one scope |
 
@@ -520,7 +520,8 @@ single-packet WLAN waveform, emit spectrum and waterfall. Proof: a screenshot
 with a real signal at a known frequency landing in the right bin.
 
 **Phase 3 — audio.** `IcomAudio`: codec 4 LPCM 48 k mono, RX first. Then TX,
-which needs DATA MOD = WLAN on the radio and **verification outside the system** —
+which needs the model's network source in DATA MOD (WLAN on IC-705, LAN on
+IC-7300MK2) and **verification outside the system** —
 a second receiver or a WebSDR, per `feedback-verify-outside-the-system`. A TX
 path that looks perfect from inside AetherSDR and is silent on the air is the
 exact failure mode this project has already been bitten by.

--- a/docs/architecture/audio-pipeline.md
+++ b/docs/architecture/audio-pipeline.md
@@ -225,6 +225,12 @@ The same setting is exposed in Radio Setup > Audio > PC Audio Devices as
 "Prompt on Audio Device Changes"; that checkbox is checked when notifications
 are enabled and unchecked when the suppression setting is active.
 
+On networked Icom radios the title-bar PC Audio toggle also owns the voice-mode
+input selection. On selects the model's network source in `DATA OFF MOD`
+(WLAN on IC-705, LAN on IC-7300MK2) and opens PC microphone capture; off selects
+MIC and closes capture so the hand microphone remains the voice source.
+`DATA MOD` is separate radio-owned state and is never changed by this toggle.
+
 Accepting the dialog queues `AudioEngine::setInputDevice()` and
 `AudioEngine::setOutputDevice()` onto the audio worker thread. Those setters are
 the only place that persists the chosen device IDs and restarts the affected

--- a/docs/architecture/audio-pipeline.md
+++ b/docs/architecture/audio-pipeline.md
@@ -225,11 +225,22 @@ The same setting is exposed in Radio Setup > Audio > PC Audio Devices as
 "Prompt on Audio Device Changes"; that checkbox is checked when notifications
 are enabled and unchecked when the suppression setting is active.
 
-On networked Icom radios the title-bar PC Audio toggle also owns the voice-mode
-input selection. On selects the model's network source in `DATA OFF MOD`
-(WLAN on IC-705, LAN on IC-7300MK2) and opens PC microphone capture; off selects
-MIC and closes capture so the hand microphone remains the voice source.
-`DATA MOD` is separate radio-owned state and is never changed by this toggle.
+On networked Icom radios an operator **click** on the title-bar PC Audio toggle
+also requests the voice-mode input selection. On selects the model's network
+source in `DATA OFF MOD` (WLAN on IC-705, LAN on IC-7300MK2) and opens PC
+microphone capture; off puts back whatever the radio held before the first
+request of the session — `MIC` only when nothing was captured — and closes
+capture. `DATA MOD` is separate radio-owned state and is never changed by this
+toggle.
+
+Only a click writes. `DATA OFF MOD` is a SET-menu register the radio persists,
+so Constitution III forbids replaying the client-persisted `PcAudioEnabled` key
+onto it: a connect *publishes* the client's PC Audio state
+(`RadioModel::notePcAudioEnabled`) so the backend can warn about a mismatch, and
+never commands. Without that split an operator who set `DATA OFF MOD` to USB for
+a rig interface would find it silently rewritten on every connect. On a model
+with no verified SET-menu map the click is refused and says so, rather than
+guessing another radio's item numbers.
 
 Accepting the dialog queues `AudioEngine::setInputDevice()` and
 `AudioEngine::setOutputDevice()` onto the audio worker thread. Those setters are

--- a/docs/architecture/pipelines.md
+++ b/docs/architecture/pipelines.md
@@ -104,9 +104,10 @@ TX AUDIO ROUTING SUMMARY:                  ◄── AUDIO THREAD
 
 The PSK Reporter WSPR beacon is a one-shot, operator-armed digital source. A
 precise timer on the AudioEngine worker thread generates sample-accurate 4-FSK
-independently of microphone callbacks and sends it through a client-owned
-`dax_tx` stream in DIGU. Its dedicated non-voice PTT source suppresses Quindar,
-and the generator holds silence through the unkey edge.
+independently of microphone callbacks. It uses a client-owned `dax_tx` stream
+on Flex and the normalized transmit-audio seam on Icom/HL2, in DIGU. Its
+dedicated non-voice PTT source suppresses Quindar, and the generator holds
+silence through the unkey edge.
 
 Four conventions in that generator are taken from WSJT-X's `Modulator.cpp`
 rather than invented, because a WSPR frame is judged by decoders we do not own:

--- a/docs/radio-certification.md
+++ b/docs/radio-certification.md
@@ -275,7 +275,7 @@ connect is the interesting case, and it is the one no document can report.
 control through its seam verb *at its current value* and verifies scheduler
 admission or immediate wire dispatch. Nothing on the radio moves. Poll
 `civ scheduler` until `idle:true` with no new timeout to complete the
-dispatch/readback proof. On the IC-705 that is 25 controls in one call: 17
+dispatch/readback proof. On the IC-705 that is 26 controls in one call: 18
 linked, 0 broken, 8 that cannot be re-asserted without changing an operator
 setting.
 

--- a/src/core/backends/icom/CivCodec.h
+++ b/src/core/backends/icom/CivCodec.h
@@ -286,16 +286,7 @@ inline constexpr std::uint8_t kDialLock      = 0x50;
 // is no error anywhere: the transmit path is working perfectly into a modulator
 // that is listening somewhere else.
 namespace setting {
-inline constexpr int kDataOffModInput = 118;   // SSB/CW/AM/FM — "DATA OFF MOD"
-inline constexpr int kDataModInput    = 119;   // data modes    — "DATA MOD"
-inline constexpr int kWlanModLevel    = 117;
 inline constexpr int kVoxDelay        = 359;   // 00..20, in 0.1 s steps
-
-// 1A 05 values for the two above.
-inline constexpr std::uint8_t kModMic     = 0x00;
-inline constexpr std::uint8_t kModUsb     = 0x01;
-inline constexpr std::uint8_t kModMicUsb  = 0x02;
-inline constexpr std::uint8_t kModWlan    = 0x03;
 }  // namespace setting
 
 // Read or write a 1A 05 SET-menu item. `item` is the DECIMAL menu number as

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -204,6 +204,7 @@ RadioCapabilities IcomCivBackend::capabilities() const
     // II/III says the client must not re-assert them. This backend READS state
     // at connect; it never pushes a restored one.
     c.clientSettingsDomains = {};
+    c.extensionNamespaces << QStringLiteral("icom");
 
     return c;
 }
@@ -478,15 +479,18 @@ void IcomCivBackend::sendConnectReadBurst()
     if (m_model->hasVfoModeCommand)
         queueStartupRead(cmdReadVfoMode(m_session->civAddress()));
 
-    // ASK WHERE THE RADIO TAKES ITS MODULATION FROM. Not cosmetic: if this is
-    // not WLAN, everything else about transmit can be perfect and the operator
-    // still gets zero output. Diagnosing it from the outside means noticing
-    // that a keyed radio with healthy audio counters makes no power, which is
-    // exactly the dead end this avoids.
-    queueStartupRead(cmdReadSetting(m_session->civAddress(),
-                                    setting::kDataOffModInput));
-    queueStartupRead(cmdReadSetting(m_session->civAddress(),
-                                    setting::kDataModInput));
+    // ASK WHERE THE RADIO TAKES ITS MODULATION FROM, using this model's own
+    // guide. The SET-menu numbers and enum values differ even between the
+    // IC-705 and IC-7300MK2, so an unknown model is deliberately left unread.
+    if (const auto mod = modulationProfileFor(*m_model)) {
+        for (int item : {mod->dataOffInputItem, mod->dataInputItem,
+                         mod->usbLevelItem, mod->accessoryLevelItem,
+                         mod->networkLevelItem}) {
+            if (item >= 0) {
+                queueStartupRead(cmdReadSetting(m_session->civAddress(), item));
+            }
+        }
+    }
 
     // ADOPT THE RADIO'S OWN LEVELS. Constitution II/III says an Icom is
     // authoritative over its operating state and the client must never push a
@@ -994,80 +998,46 @@ void IcomCivBackend::onSessionDisconnected(const QString& reason)
 
 void IcomCivBackend::checkModInput()
 {
-    // Report ONCE both answers are in, and only when something is actually
-    // wrong. A warning that fires on a correctly configured radio is one the
-    // operator learns to scroll past (CERTIFICATION.md 1.28).
-    if (m_dataOffModInput < 0 || m_dataModInput < 0)
+    const auto mod = modulationProfileFor(*m_model);
+    if (!mod)
         return;
-
-    // ONLY a radio with Wi-Fi has a WLAN modulation source to select.
-    //
-    // The 1A 05 item numbers (118/119) and the value table below are read from
-    // ONE model's CI-V Reference Guide and sent to every Icom, but each model
-    // numbers its own SET menu and its own enum. On an IC-9700 — LAN only, no
-    // Wi-Fi — both items were set correctly on the front panel and the radio
-    // answered 0x01, which this table calls "USB". So either 118/119 are not
-    // MOD Input on that model, or 0x01 IS its network source; either way
-    // demanding 0x03 asks for a setting the radio cannot offer, and the warning
-    // could never be satisfied by any front-panel action.
-    //
-    // Reported by an operator with the radio in front of them (2026-08-05): set
-    // to LAN on both, warned anyway, every session. A check that fires on a
-    // correctly configured radio is worse than no check — it is the one the
-    // operator learns to scroll past, and it trains them past the real ones.
-    //
-    // Staying silent here loses nothing that was working: the warning was
-    // WRONG on this radio, not merely noisy. Re-enable per model once the
-    // mapping is confirmed against that model's own guide (the same bar
-    // IcomModel::verified sets for the rest of the table).
-    // Note this also silences the check on an UNIDENTIFIED radio, since
-    // kUnknown carries hasWifi=false. That is the right outcome, though for a
-    // second reason: kUnknown is also hasTransmit=false, and a radio this
-    // client will not let key has no modulation path to warn about. Warning
-    // there would be advice about a transmission that cannot happen, decoded
-    // through a value table not known to apply to that model.
-    if (!m_model->hasWifi)
-        return;
-
-    const bool voiceOk = m_dataOffModInput == setting::kModWlan;
-    const bool dataOk  = m_dataModInput == setting::kModWlan;
-    if (voiceOk && dataOk)
-        return;
-
-    auto name = [](int v) -> QString {
-        switch (v) {
-        case setting::kModMic:    return QStringLiteral("MIC");
-        case setting::kModUsb:    return QStringLiteral("USB");
-        case setting::kModMicUsb: return QStringLiteral("MIC+USB");
-        case setting::kModWlan:   return QStringLiteral("WLAN");
-        default:                  return QStringLiteral("unknown(%1)").arg(v);
+    const auto name = [&mod](int value) {
+        for (const ModulationInputChoice& choice : mod->choices) {
+            if (choice.value == value) {
+                return QString::fromUtf8(choice.label.data(),
+                                         static_cast<int>(choice.label.size()));
+            }
         }
+        return QStringLiteral("unknown(%1)").arg(value);
     };
 
     QStringList wrong;
-    if (!voiceOk)
-        wrong << QStringLiteral("voice modes take modulation from %1")
-                     .arg(name(m_dataOffModInput));
-    if (!dataOk)
-        wrong << QStringLiteral("data modes take modulation from %1")
+    if (m_pcAudioEnabled && m_dataOffModInput >= 0) {
+        const int expected = *m_pcAudioEnabled ? mod->networkOnlyValue : 0x00;
+        if (m_dataOffModInput != expected) {
+            wrong << QStringLiteral("PC Audio is %1 but DATA OFF MOD is %2")
+                         .arg(*m_pcAudioEnabled ? QStringLiteral("on")
+                                                : QStringLiteral("off"),
+                              name(m_dataOffModInput));
+        }
+    }
+    if (m_dataMode && m_dataModInput >= 0
+        && m_dataModInput != mod->networkOnlyValue) {
+        wrong << QStringLiteral("DATA MOD is %1, so generated digital audio is ignored")
                      .arg(name(m_dataModInput));
+    }
+    if (wrong.isEmpty()) {
+        m_lastModInputWarning.clear();
+        return;
+    }
 
-    // A configurationWarning, NOT a connectionError: this is advice about a
-    // radio that is otherwise working perfectly. connectionError is fatal to
-    // every consumer — RadioModel starts its reconnect timer on it — so raising
-    // it here dropped the session ~4 ms after the CI-V stream came live and
-    // reconnected into the same check forever. The operator saw a radio that
-    // would not stay connected and a message about a menu setting, with no way
-    // to tell that the message WAS the disconnect.
-    //
-    // It still reaches the operator; it just no longer costs them the session.
-    emit configurationWarning(
-        QStringLiteral("The radio is not listening to network audio — %1. "
-                       "AetherSDR's transmit audio will be ignored and the radio "
-                       "will key at zero output. On the radio: MENU > SET > "
-                       "Connectors > MOD Input > set DATA OFF MOD and DATA MOD "
-                       "to WLAN.")
-            .arg(wrong.join(QStringLiteral(", "))));
+    const QString warning = QStringLiteral("Icom modulation input: %1. Check Radio Health "
+                                           "for the reported source and level.")
+                                .arg(wrong.join(QStringLiteral(", ")));
+    if (warning != m_lastModInputWarning) {
+        m_lastModInputWarning = warning;
+        emit configurationWarning(warning);
+    }
 }
 
 void IcomCivBackend::applyScopeStartup()
@@ -1330,6 +1300,7 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
         }
         case level::kMicGain: {
             m_micGainPercent = pct;
+            m_micGainReported = true;
             TransmitDelta t; t.micLevel = pct;
             emit transmitChanged(t);
             return;
@@ -1529,12 +1500,7 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
         if (st->filter != 0)
             m_filter = st->filter;
         publishModeState();
-        // NOT a modulation-source re-check. checkModInput() reads DATA OFF MOD
-        // and DATA MOD together and warns if either is wrong, so its answer
-        // does not depend on which of the two the radio is currently in — but
-        // its usefulness did: until this decoded, "DATA MOD is set to WLAN"
-        // could be true while the radio sat in DATA OFF and modulated from the
-        // microphone anyway. That gap closes here, by the mode being right.
+        checkModInput();
         return;
     }
 
@@ -1543,13 +1509,28 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
         if (!frame.hasSub || frame.sub != 0x05 || frame.data.size() < 3)
             return;
         const int item = decodeBcdByte(frame.data[0]) * 100 + decodeBcdByte(frame.data[1]);
-        const int value = frame.data[2];
-        if (item == setting::kDataOffModInput)
-            m_dataOffModInput = value;
-        else if (item == setting::kDataModInput)
-            m_dataModInput = value;
-        else
+        const auto mod = modulationProfileFor(*m_model);
+        if (!mod)
             return;
+        if (item == mod->dataOffInputItem) {
+            m_dataOffModInput = frame.data[2];
+        } else if (item == mod->dataInputItem) {
+            m_dataModInput = frame.data[2];
+        } else {
+            const auto raw = decodeLevel(std::span(frame.data).subspan(2));
+            if (!raw)
+                return;
+            const int pct = levelRawToPercent(*raw);
+            if (item == mod->usbLevelItem) {
+                m_usbModLevelPercent = pct;
+            } else if (item == mod->accessoryLevelItem) {
+                m_accessoryModLevelPercent = pct;
+            } else if (item == mod->networkLevelItem) {
+                m_networkModLevelPercent = pct;
+            } else {
+                return;
+            }
+        }
         checkModInput();
         return;
     }
@@ -1924,6 +1905,13 @@ IcomCivBackend::confirmationFor(std::span<const std::uint8_t> frame) const
     case cmd::kTuneOffset:
         if (parsed->hasSub) {
             return buildFrameSub(addr, parsed->cmd, parsed->sub);
+        }
+        break;
+    case cmd::kSetting:
+        if (parsed->hasSub && parsed->sub == 0x05 && parsed->data.size() >= 3) {
+            const int item = decodeBcdByte(parsed->data[0]) * 100
+                + decodeBcdByte(parsed->data[1]);
+            return cmdReadSetting(addr, item);
         }
         break;
     case cmd::kAttenuator:
@@ -2463,6 +2451,7 @@ void IcomCivBackend::setSpeechProcessor(bool on, int level)
 void IcomCivBackend::setMicGain(int gainPercent)
 {
     m_micGainPercent = gainPercent;
+    m_micGainReported = true;
     sendUserCommand(cmdSetLevel(m_session ? m_session->civAddress() : 0xA4,
                                 level::kMicGain, percentToLevelRaw(gainPercent)));
 }
@@ -3260,6 +3249,28 @@ void IcomCivBackend::invokeExtension(const QString& ns, const QString& verb, qui
         emit extensionResult(requestId, true);
         return;
     }
+    if (verb == QLatin1String("audio.pc")) {
+        const auto mod = modulationProfileFor(*m_model);
+        if (!mod) {
+            const QString reason = QStringLiteral(
+                "PC Audio cannot select DATA OFF MOD for this Icom model: "
+                "its model-specific SET-menu map is not verified.");
+            emit configurationWarning(reason);
+            if (requestId != 0) {
+                emit extensionError(requestId, reason);
+            }
+            return;
+        }
+        const bool on = arg.toBool();
+        m_pcAudioEnabled = on;
+        sendUserCommand(cmdWriteSetting(
+            m_session ? m_session->civAddress() : m_model->civAddress,
+            mod->dataOffInputItem, on ? mod->networkOnlyValue : 0x00));
+        if (requestId != 0) {
+            emit extensionResult(requestId, true);
+        }
+        return;
+    }
     if (verb == QLatin1String("controls.map")) {
         emit extensionResult(requestId, controlMap());
         return;
@@ -3516,6 +3527,20 @@ void IcomCivBackend::onLinkTick()
             queueControl(cmdReadTuneOffset(addr, sub));
         }
     }
+    // SET-menu changes can originate on the front panel. Refresh slowly: they
+    // are troubleshooting state, not interactive controls, and share this CI-V
+    // stream with tuning and meters.
+    if (phase % 12 == 0) {
+        if (const auto mod = modulationProfileFor(*m_model)) {
+            for (int item : {mod->dataOffInputItem, mod->dataInputItem,
+                             mod->usbLevelItem, mod->accessoryLevelItem,
+                             mod->networkLevelItem}) {
+                if (item >= 0) {
+                    queueControl(cmdReadSetting(addr, item));
+                }
+            }
+        }
+    }
     pumpCiv(now);
     if (m_lastInboundCivAtMs <= 0) {
         m_lastInboundCivAtMs = now;   // start the clock at the first tick
@@ -3555,33 +3580,59 @@ IRadioBackend::HealthSnapshot IcomCivBackend::healthSnapshot() const
                     QStringLiteral("0x%1").arg(m_model->civAddress, 2, 16, QLatin1Char('0')));
     h.labels.insert(QStringLiteral("civ"), QStringLiteral("CI-V address"));
 
-    // WHERE THE RADIO TAKES ITS MODULATION FROM. On a health readout because
-    // "keys but makes no power" has no other visible cause: the audio counters
-    // climb, the meters are fresh, and the modulator is listening elsewhere.
-    if (m_dataOffModInput >= 0 || m_dataModInput >= 0) {
-        auto name = [](int v) -> QString {
-            switch (v) {
-            case setting::kModMic:    return QStringLiteral("MIC");
-            case setting::kModUsb:    return QStringLiteral("USB");
-            case setting::kModMicUsb: return QStringLiteral("MIC+USB");
-            case setting::kModWlan:   return QStringLiteral("WLAN");
-            default:                  return QStringLiteral("?");
+    // WHERE THE RADIO TAKES ITS MODULATION FROM, plus the level of every source
+    // named by that selection. These are separate rows because DATA OFF and
+    // DATA are independent radio-owned settings; folding them together hid the
+    // exact half responsible for a keyed-but-silent transmission.
+    if (const auto mod = modulationProfileFor(*m_model)) {
+        const auto describe = [this, &mod](int value) {
+            const ModulationInputChoice* selected = nullptr;
+            for (const ModulationInputChoice& choice : mod->choices) {
+                if (choice.value == value) {
+                    selected = &choice;
+                    break;
+                }
             }
+            if (!selected) {
+                return QStringLiteral("unknown (%1)").arg(value);
+            }
+            QString result = QString::fromUtf8(selected->label.data(),
+                                               static_cast<int>(selected->label.size()));
+            QStringList levels;
+            const auto addLevel = [&levels](const QString& name, int percent) {
+                levels << (percent >= 0 ? QStringLiteral("%1 %2%").arg(name).arg(percent)
+                                        : QStringLiteral("%1 not reported").arg(name));
+            };
+            if ((selected->sources & ModSourceMic) != 0U) {
+                addLevel(QStringLiteral("MIC Gain"),
+                         m_micGainReported ? m_micGainPercent : -1);
+            }
+            if ((selected->sources & ModSourceUsb) != 0U) {
+                addLevel(QStringLiteral("USB MOD Level"), m_usbModLevelPercent);
+            }
+            if ((selected->sources & ModSourceAccessory) != 0U) {
+                addLevel(QStringLiteral("ACC MOD Level"), m_accessoryModLevelPercent);
+            }
+            if ((selected->sources & ModSourceNetwork) != 0U) {
+                const QString name = m_model->hasWifi ? QStringLiteral("WLAN MOD Level")
+                                                       : QStringLiteral("LAN MOD Level");
+                addLevel(name, m_networkModLevelPercent);
+            }
+            if (!levels.isEmpty()) {
+                result += QStringLiteral(" — ") + levels.join(QStringLiteral(", "));
+            }
+            return result;
         };
-        // The verdict, like the warning in checkModInput(), is only meaningful
-        // on a radio that HAS a WLAN source. Elsewhere show the raw values and
-        // pass no judgement: an IC-9700 set correctly to LAN reads back 0x01
-        // here, and appending "NOT WLAN" to that is telling the operator their
-        // working radio is misconfigured.
-        const bool ok = !m_model->hasWifi
-                        || (m_dataOffModInput == setting::kModWlan
-                            && m_dataModInput == setting::kModWlan);
-        h.values.insert(QStringLiteral("modinput"),
-                        QStringLiteral("%1 voice / %2 data%3")
-                            .arg(name(m_dataOffModInput), name(m_dataModInput),
-                                 ok ? QString() : QStringLiteral("  — NOT WLAN")));
-        h.labels.insert(QStringLiteral("modinput"), QStringLiteral("MOD Input"));
-        h.order << QStringLiteral("modinput");
+        if (m_dataOffModInput >= 0) {
+            h.values.insert(QStringLiteral("dataoffmod"), describe(m_dataOffModInput));
+            h.labels.insert(QStringLiteral("dataoffmod"), QStringLiteral("DATA OFF MOD"));
+            h.order << QStringLiteral("dataoffmod");
+        }
+        if (m_dataModInput >= 0) {
+            h.values.insert(QStringLiteral("datamod"), describe(m_dataModInput));
+            h.labels.insert(QStringLiteral("datamod"), QStringLiteral("DATA MOD"));
+            h.order << QStringLiteral("datamod");
+        }
     }
     h.order << QStringLiteral("civ");
 

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -990,6 +990,24 @@ void IcomCivBackend::onSessionDisconnected(const QString& reason)
 {
     const bool was = m_connected;
     m_connected = false;
+
+    // UNKNOWN IS THE ONLY HONEST STARTING POINT for anything the radio told
+    // us, and this object outlives the session: the same backend serves the
+    // next connect, and a radio swap in one process reaches a DIFFERENT radio.
+    // Carrying these over meant Radio Health could print the previous radio's
+    // MOD levels beside the new radio's selection, and a surviving
+    // m_lastModInputWarning silently swallowed a warning that was still true
+    // in the new session because it happened to read the same.
+    m_dataOffModInput = -1;
+    m_dataModInput = -1;
+    m_usbModLevelPercent = -1;
+    m_accessoryModLevelPercent = -1;
+    m_networkModLevelPercent = -1;
+    m_micGainReported = false;
+    m_pcAudioEnabled.reset();
+    m_dataOffModRestore.reset();
+    m_lastModInputWarning.clear();
+
     if (was)
         emit disconnected();
     if (!reason.isEmpty())
@@ -1012,14 +1030,16 @@ void IcomCivBackend::checkModInput()
     };
 
     QStringList wrong;
-    if (m_pcAudioEnabled && m_dataOffModInput >= 0) {
-        const int expected = *m_pcAudioEnabled ? mod->networkOnlyValue : 0x00;
-        if (m_dataOffModInput != expected) {
-            wrong << QStringLiteral("PC Audio is %1 but DATA OFF MOD is %2")
-                         .arg(*m_pcAudioEnabled ? QStringLiteral("on")
-                                                : QStringLiteral("off"),
-                              name(m_dataOffModInput));
-        }
+    // ONLY THE "ON" DIRECTION IS THE CLIENT'S BUSINESS. PC Audio on and
+    // DATA OFF MOD somewhere else is a real fault: the radio keys and puts no
+    // modulation on the air. PC Audio OFF makes no claim at all — the operator
+    // is then free to route voice from MIC, USB, ACC or anything else, and
+    // asserting an expected value there would be the client telling a working
+    // radio it is misconfigured.
+    if (m_pcAudioEnabled && *m_pcAudioEnabled && m_dataOffModInput >= 0
+        && m_dataOffModInput != mod->networkOnlyValue) {
+        wrong << QStringLiteral("PC Audio is on but DATA OFF MOD is %1")
+                     .arg(name(m_dataOffModInput));
     }
     if (m_dataMode && m_dataModInput >= 0
         && m_dataModInput != mod->networkOnlyValue) {
@@ -1031,9 +1051,17 @@ void IcomCivBackend::checkModInput()
         return;
     }
 
-    const QString warning = QStringLiteral("Icom modulation input: %1. Check Radio Health "
-                                           "for the reported source and level.")
-                                .arg(wrong.join(QStringLiteral(", ")));
+    // NAME THE REMEDY, because this client deliberately will not apply it
+    // unasked: DATA OFF MOD is the radio's to persist (Constitution III), so
+    // the fix has to come from the operator. Without the second sentence the
+    // advisory describes a fault and leaves them to guess that the button they
+    // already have is what corrects it.
+    const QString warning =
+        QStringLiteral("Icom modulation input: %1. Toggle PC Audio off and on to "
+                       "select it, or set it on the radio's front panel "
+                       "(MENU > SET > Connectors > MOD Input). Check Radio Health "
+                       "for the reported source and level.")
+            .arg(wrong.join(QStringLiteral(", ")));
     if (warning != m_lastModInputWarning) {
         m_lastModInputWarning = warning;
         emit configurationWarning(warning);
@@ -3014,6 +3042,22 @@ bool IcomCivBackend::scrubDrive(const icom::ControlSpec& c)
     if (id == QLatin1String("agc"))      { setSliceAgc(slice, m_agcMode, 0); return true; }
     if (id == QLatin1String("tx.power")) { setTxPower(m_txPowerPercent); return true; }
     if (id == QLatin1String("mic.gain")) { setMicGain(m_micGainPercent); return true; }
+    if (id == QLatin1String("mod.input.dataoff")) {
+        // Re-assert the CURRENT selection, which is the whole scrub contract:
+        // the question is whether the intent reaches the wire, not whether the
+        // radio obeys. Falls through to NOT-TESTED on a model with no verified
+        // SET-menu map, or before the readback has landed — there is no safe
+        // value to send in either case, and inventing one would move the
+        // operator's radio.
+        const auto mod = modulationProfileFor(*m_model);
+        if (!mod || m_dataOffModInput < 0)
+            return false;
+        sendUserCommand(cmdWriteSetting(
+            m_session ? m_session->civAddress() : m_model->civAddress,
+            mod->dataOffInputItem,
+            static_cast<std::uint8_t>(m_dataOffModInput)));
+        return true;
+    }
     if (id == QLatin1String("monitor") || id == QLatin1String("monitor.level")) {
         m_monitorSent = -1;
         setTxMonitor(m_monitorOn, m_monitorLevelPercent);
@@ -3249,9 +3293,37 @@ void IcomCivBackend::invokeExtension(const QString& ns, const QString& verb, qui
         emit extensionResult(requestId, true);
         return;
     }
+    // TWO VERBS, because there are two different things to say about PC Audio
+    // and only one of them is a command.
+    //
+    // `audio.pc.state` is an OBSERVATION — the client's local audio routing is
+    // on or off. It is what the connect edge publishes, and it exists so
+    // checkModInput() can advise ("PC Audio is on but DATA OFF MOD is MIC")
+    // without the client writing anything. Replaying a client-persisted value
+    // onto DATA OFF MOD at connect is what Constitution III forbids in as many
+    // words: the radio persists that register itself, so a client that pushes
+    // its remembered copy back hands the operator two sources of truth that
+    // fight on every reconnect.
+    //
+    // `audio.pc` is a REQUEST, and only an operator click issues it.
+    // Principle II allows exactly that — a user action is a request to the
+    // radio — which is why the write lives here and nowhere else.
+    if (verb == QLatin1String("audio.pc.state")) {
+        m_pcAudioEnabled = arg.toBool();
+        checkModInput();
+        if (requestId != 0) {
+            emit extensionResult(requestId, true);
+        }
+        return;
+    }
     if (verb == QLatin1String("audio.pc")) {
         const auto mod = modulationProfileFor(*m_model);
         if (!mod) {
+            // Reachable only from an operator click now that the connect edge
+            // publishes state instead of commanding. A warning that answers a
+            // request the radio cannot honour is the useful kind — unlike the
+            // once-per-session one on a correctly configured radio, which is
+            // the one the operator learns to scroll past.
             const QString reason = QStringLiteral(
                 "PC Audio cannot select DATA OFF MOD for this Icom model: "
                 "its model-specific SET-menu map is not verified.");
@@ -3262,10 +3334,29 @@ void IcomCivBackend::invokeExtension(const QString& ns, const QString& verb, qui
             return;
         }
         const bool on = arg.toBool();
+        // CAPTURE WHATEVER IS ABOUT TO BE OVERWRITTEN, every time rather than
+        // only once. This is the last moment the operator's own selection is
+        // observable — after the write the readback reports what we put there.
+        //
+        // Re-capturing matters because the register is theirs between clicks:
+        // an operator who turns PC Audio off and then moves DATA OFF MOD to ACC
+        // on the front panel must get ACC back next time, not the USB the
+        // session opened on. The link-tick poll keeps m_dataOffModInput current,
+        // so the value here is the radio's, not a stale belief.
+        //
+        // The network source is never captured: putting THAT back on "off"
+        // would leave PC Audio off with the radio still listening to the
+        // network, which is the state where nothing modulates at all.
+        if (m_dataOffModInput >= 0 && m_dataOffModInput != mod->networkOnlyValue) {
+            m_dataOffModRestore = m_dataOffModInput;
+        }
         m_pcAudioEnabled = on;
+        const auto value = static_cast<std::uint8_t>(
+            on ? mod->networkOnlyValue
+               : m_dataOffModRestore.value_or(mod->micValue));
         sendUserCommand(cmdWriteSetting(
             m_session ? m_session->civAddress() : m_model->civAddress,
-            mod->dataOffInputItem, on ? mod->networkOnlyValue : 0x00));
+            mod->dataOffInputItem, value));
         if (requestId != 0) {
             emit extensionResult(requestId, true);
         }

--- a/src/core/backends/icom/IcomCivBackend.h
+++ b/src/core/backends/icom/IcomCivBackend.h
@@ -390,6 +390,15 @@ private:
     int m_networkModLevelPercent = -1;
     bool m_micGainReported = false;
     std::optional<bool> m_pcAudioEnabled;
+    // WHAT THE OPERATOR HAD, so "off" can put it back instead of guessing.
+    //
+    // DATA OFF MOD is a four- (IC-705) or six-valued (IC-7300MK2) enum the
+    // RADIO persists; PC Audio is a two-state button. Writing a fixed MIC on
+    // "off" therefore destroys a USB / ACC / MIC+USB selection the operator
+    // set on the front panel and never gets it back. Latched from the readback
+    // the instant before this client's FIRST write of the session, so the
+    // value put back is the radio's own, not one we invented.
+    std::optional<int> m_dataOffModRestore;
     QString m_lastModInputWarning;
     void checkModInput();
 

--- a/src/core/backends/icom/IcomCivBackend.h
+++ b/src/core/backends/icom/IcomCivBackend.h
@@ -385,6 +385,12 @@ private:
 
     int m_dataOffModInput = -1;   // SSB / CW / AM / FM
     int m_dataModInput    = -1;   // data modes (FT8 and friends)
+    int m_usbModLevelPercent = -1;
+    int m_accessoryModLevelPercent = -1;
+    int m_networkModLevelPercent = -1;
+    bool m_micGainReported = false;
+    std::optional<bool> m_pcAudioEnabled;
+    QString m_lastModInputWarning;
     void checkModInput();
 
     std::int64_t m_scopeCentreHz = 0;

--- a/src/core/backends/icom/IcomControls.cpp
+++ b/src/core/backends/icom/IcomControls.cpp
@@ -259,17 +259,18 @@ constexpr std::array kSpecs = {
 
     // ---- SET menu (0x1A 05) ----------------------------------------------
     ControlSpec{"mod.input.dataoff", 0x1A, 0x05, true, "DATA OFF MOD input",
-                Plane::Radio, Encoding::Bcd4, Wiring::DecodeOnly,
-                0, 3, "enum", 0, 3,
-                "", "", true,
-                "MENU ITEM 118. THE SINGLE MOST IMPORTANT SETTING FOR TRANSMIT: if "
-                "it is not WLAN the radio discards every byte of our audio, keys, "
-                "and reports zero forward power with no error. Read and warned "
-                "about, deliberately never written."},
+                Plane::Radio, Encoding::Bcd4, Wiring::Both,
+                0, 5, "enum", 0, 5,
+                "invokeExtension icom/audio.pc", "pcAudioBtn", true,
+                "MODEL-SPECIFIC: item 0118 and WLAN=03 on IC-705; item 0084 "
+                "and LAN=05 on IC-7300MK2. PC Audio writes only this voice-mode "
+                "selection and confirms it by readback."},
     ControlSpec{"mod.input.data", 0x1A, 0x05, true, "DATA MOD input",
                 Plane::Radio, Encoding::Bcd4, Wiring::DecodeOnly,
-                0, 3, "enum", 0, 3,
-                "", "", true, "MENU ITEM 119 — the data-mode half of the above."},
+                0, 5, "enum", 0, 5,
+                "", "", true,
+                "MODEL-SPECIFIC: item 0119 on IC-705 and 0085 on IC-7300MK2. "
+                "Radio-authoritative and deliberately never written by PC Audio."},
 
     // ---- Scope (0x27) ----------------------------------------------------
     ControlSpec{"scope.onoff", 0x27, 0x10, true, "Scope on/off",

--- a/src/core/backends/icom/IcomModels.cpp
+++ b/src/core/backends/icom/IcomModels.cpp
@@ -215,13 +215,13 @@ std::optional<ModulationProfile> modulationProfileFor(const IcomModel& model)
     // IC-705 CI-V guide: USB/WLAN levels 0116/0117, DATA OFF/DATA MOD
     // selections 0118/0119.
     if (model.civAddress == 0xA4) {
-        return ModulationProfile{116, -1, 117, 118, 119, 0x03,
+        return ModulationProfile{116, -1, 117, 118, 119, 0x03, 0x00,
                                  kIc705ModInputs};
     }
     // IC-7300MK2 CI-V guide: USB/ACC/LAN levels 0081/0082/0083, DATA OFF/DATA
     // MOD selections 0084/0085. LAN is value 05, not the IC-705's WLAN 03.
     if (model.civAddress == 0xB6) {
-        return ModulationProfile{81, 82, 83, 84, 85, 0x05,
+        return ModulationProfile{81, 82, 83, 84, 85, 0x05, 0x00,
                                  kIc7300Mk2ModInputs};
     }
     return std::nullopt;

--- a/src/core/backends/icom/IcomModels.cpp
+++ b/src/core/backends/icom/IcomModels.cpp
@@ -156,6 +156,22 @@ constexpr IcomModel kUnknown{
     /*hasVfoModeCommand*/ false,
 };
 
+constexpr std::array<ModulationInputChoice, 4> kIc705ModInputs{{
+    {0x00, "MIC",     ModSourceMic},
+    {0x01, "USB",     ModSourceUsb},
+    {0x02, "MIC+USB", ModSourceMic | ModSourceUsb},
+    {0x03, "WLAN",    ModSourceNetwork},
+}};
+
+constexpr std::array<ModulationInputChoice, 6> kIc7300Mk2ModInputs{{
+    {0x00, "MIC",     ModSourceMic},
+    {0x01, "USB",     ModSourceUsb},
+    {0x02, "ACC",     ModSourceAccessory},
+    {0x03, "MIC+USB", ModSourceMic | ModSourceUsb},
+    {0x04, "MIC+ACC", ModSourceMic | ModSourceAccessory},
+    {0x05, "LAN",     ModSourceNetwork},
+}};
+
 }  // namespace
 
 const IcomModel* modelForCivAddress(std::uint8_t addr)
@@ -193,6 +209,23 @@ const IcomModel* modelForName(std::string_view name)
 std::span<const IcomModel> knownModels() { return kModels; }
 
 const IcomModel& unknownModel() { return kUnknown; }
+
+std::optional<ModulationProfile> modulationProfileFor(const IcomModel& model)
+{
+    // IC-705 CI-V guide: USB/WLAN levels 0116/0117, DATA OFF/DATA MOD
+    // selections 0118/0119.
+    if (model.civAddress == 0xA4) {
+        return ModulationProfile{116, -1, 117, 118, 119, 0x03,
+                                 kIc705ModInputs};
+    }
+    // IC-7300MK2 CI-V guide: USB/ACC/LAN levels 0081/0082/0083, DATA OFF/DATA
+    // MOD selections 0084/0085. LAN is value 05, not the IC-705's WLAN 03.
+    if (model.civAddress == 0xB6) {
+        return ModulationProfile{81, 82, 83, 84, 85, 0x05,
+                                 kIc7300Mk2ModInputs};
+    }
+    return std::nullopt;
+}
 
 std::optional<std::uint8_t> parseModelIdReply(const CivFrame& frame)
 {

--- a/src/core/backends/icom/IcomModels.h
+++ b/src/core/backends/icom/IcomModels.h
@@ -110,6 +110,12 @@ struct ModulationProfile {
     int dataOffInputItem = -1;
     int dataInputItem = -1;
     std::uint8_t networkOnlyValue = 0;
+    // What PC Audio "off" falls back to when there is no captured selection to
+    // put back — the hand microphone, which every Icom has. It lives in the
+    // table rather than at the call site for the same reason networkOnlyValue
+    // does: the enum is model-specific, and a future radio whose MIC is not
+    // 0x00 must not silently inherit this one's.
+    std::uint8_t micValue = 0;
     std::span<const ModulationInputChoice> choices;
 };
 

--- a/src/core/backends/icom/IcomModels.h
+++ b/src/core/backends/icom/IcomModels.h
@@ -86,6 +86,38 @@ struct IcomModel {
     [[nodiscard]] bool isKnown() const noexcept { return civAddress != 0; }
 };
 
+enum ModulationSource : unsigned {
+    ModSourceNone      = 0,
+    ModSourceMic       = 1U << 0,
+    ModSourceUsb       = 1U << 1,
+    ModSourceAccessory = 1U << 2,
+    ModSourceNetwork   = 1U << 3,
+};
+
+struct ModulationInputChoice {
+    std::uint8_t value = 0;
+    std::string_view label;
+    unsigned sources = ModSourceNone;
+};
+
+// Model-specific 1A 05 SET-menu map. Icom does not keep these item numbers or
+// enum values stable between radios: the IC-705 calls its network source WLAN
+// at value 03, while the IC-7300MK2 calls it LAN at value 05.
+struct ModulationProfile {
+    int usbLevelItem = -1;
+    int accessoryLevelItem = -1;
+    int networkLevelItem = -1;
+    int dataOffInputItem = -1;
+    int dataInputItem = -1;
+    std::uint8_t networkOnlyValue = 0;
+    std::span<const ModulationInputChoice> choices;
+};
+
+// Empty when this model's own official CI-V guide has not been checked. A
+// caller must not borrow another model's SET-menu map as a fallback.
+[[nodiscard]] std::optional<ModulationProfile>
+modulationProfileFor(const IcomModel& model);
+
 // Look up by the address the radio reported. Returns nullptr for an address we
 // do not recognise — which is a real and expected outcome, not an error: Icom
 // has ~130 CI-V addresses and this table has a handful.

--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -1,5 +1,6 @@
 #include "CwxPanel.h"
 #include "core/AppSettings.h"
+#include "VoiceModeGate.h"   // isCwMode() — one CW-mode list, not thirteen
 #include "core/TxKeyingMarker.h"
 #include "models/CwxModel.h"
 
@@ -303,7 +304,7 @@ CwxPanel::CwxPanel(CwxModel* model, QWidget* parent)
             if (!m_model) return;
             if (m_txModeProvider) {
                 const QString mode = m_txModeProvider();
-                if (mode != QLatin1String("CW") && mode != QLatin1String("CWL"))
+                if (!isCwMode(mode))
                     return;
             }
             // Log the macro text to the history feed BEFORE firing the

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1983,6 +1983,20 @@ MainWindow::MainWindow(QWidget* parent)
             });
             m_radioModel.removeRxAudioStream();
         }
+
+        // On Icom this toggle owns only DATA OFF MOD: network audio while on,
+        // the radio's hand microphone while off. DATA MOD is deliberately left
+        // to the radio, since digital-mode routing is independent operator state.
+        m_radioModel.setPcAudioEnabled(on);
+        const RadioCapabilities caps = m_radioModel.backendCapabilities();
+        if (m_radioModel.isConnected() && caps.takesTxAudioOverSeam
+            && !caps.hostModulates) {
+            if (on && !m_audio->isTxStreaming()) {
+                audioStartTx(m_radioModel.radioAddress(), 4991);
+            } else if (!on && m_audio->isTxStreaming()) {
+                audioStopTx();
+            }
+        }
     });
     // Master volume — title bar slider routes through applyMasterVolume()
     // so the TCI `volume:N;` command (#1764) can hit the same code path
@@ -8333,7 +8347,7 @@ void MainWindow::refreshCwDecodeState()
     const bool anyOn = rxOn || txOn;
 
     auto* s = activeSlice();
-    const bool isCw = s && (s->mode() == "CW" || s->mode() == "CWL");
+    const bool isCw = s && isCwMode(s->mode());
 
     // Panel is visible only in CW receive mode — the operator's CW
     // text view is anchored to a CW slice's panadapter.  TX-side

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1984,11 +1984,19 @@ MainWindow::MainWindow(QWidget* parent)
             m_radioModel.removeRxAudioStream();
         }
 
-        // On Icom this toggle owns only DATA OFF MOD: network audio while on,
-        // the radio's hand microphone while off. DATA MOD is deliberately left
-        // to the radio, since digital-mode routing is independent operator state.
-        m_radioModel.setPcAudioEnabled(on);
+        // On Icom this CLICK -- and only a click -- asks the radio to switch
+        // DATA OFF MOD: the network source while on, and whatever the operator
+        // had before we first touched it while off. DATA MOD is deliberately
+        // left alone, since digital-mode routing is independent operator state.
+        //
+        // Guarded on the connection for the same reason the audio calls below
+        // are: with no session the write is dropped anyway, and all a
+        // disconnected click could still do is raise the unverified-model
+        // advisory about a radio that is not there.
         const RadioCapabilities caps = m_radioModel.backendCapabilities();
+        if (m_radioModel.isConnected()) {
+            m_radioModel.setPcAudioEnabled(on);
+        }
         if (m_radioModel.isConnected() && caps.takesTxAudioOverSeam
             && !caps.hostModulates) {
             if (on && !m_audio->isTxStreaming()) {
@@ -9351,7 +9359,7 @@ void MainWindow::updateKeyerAvailability()
     const bool hasVoiceKeyer = m_radioModel.hasVoiceKeyer();
 
     const bool txIsCw  = hasCwKeyer
-                         && (txMode == "CW" || txMode == "CWL");
+                         && isCwMode(txMode);
     // Voice-mode test through the shared predicate: the ASR block below asks
     // the same question of a DIFFERENT slice, and one list keeps the two from
     // drifting on which modes count (VoiceModeGate.h).

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -20,6 +20,7 @@
 
 #include "FlexControlDialog.h"
 #include "MainWindowHelpers.h"
+#include "VoiceModeGate.h"   // isCwMode() — one CW-mode list, not thirteen
 #include "SpectrumOverlayMenu.h"
 #include "core/AppSettings.h"
 #include "core/CwTrace.h"
@@ -495,7 +496,7 @@ void MainWindow::handleFlexControlButton(int button, int action)
             QString panId = s->panId();
             if (panId.isEmpty())
                 panId = m_panStack ? m_panStack->activePanId() : m_radioModel.panId();
-            const bool isCw = s->mode() == "CW" || s->mode() == "CWL";
+            const bool isCw = isCwMode(s->mode());
             const double txFreq = s->frequency() + (isCw ? 0.001 : 0.005);
             m_splitActive = true;
             m_splitRxSliceId = s->sliceId();
@@ -1013,7 +1014,7 @@ void MainWindow::dispatchHidAction(const QString& actionName,
                 QString panId = s->panId().isEmpty()
                     ? (m_panStack ? m_panStack->activePanId() : m_radioModel.panId())
                     : s->panId();
-                const bool isCw = s->mode() == "CW" || s->mode() == "CWL";
+                const bool isCw = isCwMode(s->mode());
                 m_splitActive    = true;
                 m_splitRxSliceId = s->sliceId();
                 m_radioModel.sendCommand(

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -720,9 +720,13 @@ void MainWindow::wireRadioModel()
         // PC audio is not optional on a host-modulating backend: all audio, both
         // directions, lives on this computer. Turning it off would leave the
         // operator deaf and mute with nothing to explain it.
-        if (m_titleBar)
-            m_titleBar->setPcAudioLocked(connected && seamTxAudio);
-        if (connected && seamTxAudio) {
+        const bool pcAudioRequired = seamTxAudio && caps.hostModulates;
+        const bool pcAudioEnabled = pcAudioRequired
+            || AppSettings::instance().value("PcAudioEnabled", "True").toString() == "True";
+        if (m_titleBar) {
+            m_titleBar->setPcAudioLocked(connected && pcAudioRequired);
+        }
+        if (connected && seamTxAudio && pcAudioEnabled) {
             if (!m_audio->isTxStreaming())
                 audioStartTx(m_radioModel.radioAddress(), 4991);
             // RX must be started imperatively, exactly like TX. Locking the
@@ -733,11 +737,16 @@ void MainWindow::wireRadioModel()
             // persisted, and the locked button can no longer be clicked to
             // recover -- leaving the sink Stopped with the button showing ON.
             // Persist the setting too, so those paths agree on the next launch.
-            AppSettings::instance().setValue("PcAudioEnabled", "True");
-            AppSettings::instance().save();
-            audioStartRx();
-        } else if (!connected && seamTxAudio) {
+            if (pcAudioRequired) {
+                AppSettings::instance().setValue("PcAudioEnabled", "True");
+                AppSettings::instance().save();
+                audioStartRx();
+            }
+        } else if (seamTxAudio && m_audio->isTxStreaming()) {
             audioStopTx();
+        }
+        if (connected) {
+            m_radioModel.setPcAudioEnabled(pcAudioEnabled);
         }
     });
 

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -745,8 +745,17 @@ void MainWindow::wireRadioModel()
         } else if (seamTxAudio && m_audio->isTxStreaming()) {
             audioStopTx();
         }
+        // TELL THE BACKEND, DO NOT COMMAND IT. `pcAudioEnabled` comes from a
+        // client-persisted key; DATA OFF MOD is a SET-menu item the RADIO
+        // persists and recalls itself. Writing one from the other on the
+        // connect edge is the two-sources-of-truth fight Constitution III
+        // exists to prevent -- an operator who set DATA OFF MOD to USB for
+        // their rig interface would find it silently rewritten every session,
+        // with no dialog and no undo. Publishing the state instead lets the
+        // backend ADVISE on a mismatch (checkModInput) while the radio stays
+        // authoritative; only an operator click writes (setPcAudioEnabled).
         if (connected) {
-            m_radioModel.setPcAudioEnabled(pcAudioEnabled);
+            m_radioModel.notePcAudioEnabled(pcAudioEnabled);
         }
     });
 

--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -16,6 +16,7 @@
 #include "MainWindow.h"
 
 #include "MainWindowHelpers.h"
+#include "VoiceModeGate.h"   // isCwMode() — one CW-mode list, not thirteen
 #include "AppletPanel.h"
 #include "BandStackPanel.h"
 #include "CwxPanel.h"
@@ -968,7 +969,7 @@ void MainWindow::registerShortcutActions()
                 QString panId = s->panId();
                 if (panId.isEmpty())
                     panId = m_panStack ? m_panStack->activePanId() : m_radioModel.panId();
-                bool isCw = s->mode() == "CW" || s->mode() == "CWL";
+                bool isCw = isCwMode(s->mode());
                 double txFreq = s->frequency() + (isCw ? 0.001 : 0.005);
                 m_splitActive = true;
                 m_splitRxSliceId = s->sliceId();

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -20,6 +20,7 @@
 #include "MainWindow.h"
 
 #include "AetherDspWidget.h"
+#include "VoiceModeGate.h"   // isCwMode() — one CW-mode list, not thirteen
 #include "BandRecallSliceSelectionPolicy.h"
 #include "models/BandPlanManager.h"
 #include "DisplayStatusGate.h"       // #4261 adaptive-throttle echo gate
@@ -5712,7 +5713,7 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
 
             // CW split: offset 1 kHz up (convention). Other modes: 5 kHz up.
             const QString mode = rxSlice->mode();
-            bool isCw = mode == "CW" || mode == "CWL";
+            bool isCw = isCwMode(mode);
             double offsetMhz = isCw ? 0.001 : 0.005;
             double txFreq = rxSlice->frequency() + offsetMhz;
 

--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -1,5 +1,6 @@
 #include "PhoneCwApplet.h"
 #include "GuardedSlider.h"
+#include "VoiceModeGate.h"   // isCwMode() — one CW-mode list, not thirteen
 #include "ComboStyle.h"
 #include "HGauge.h"
 #include "models/TransmitModel.h"
@@ -747,8 +748,9 @@ void PhoneCwApplet::buildCwPanel()
 
 void PhoneCwApplet::setMode(const QString& mode)
 {
-    // CWL is not a separate slice mode on fw v1.4.0.0 — only "CW" appears.
-    bool isCw = (mode == "CW");
+    // A Flex reports bare "CW"; an Icom and an HL2 spell the same mode CWU,
+    // and CWL is the reverse-side one. All three drive this applet.
+    bool isCw = isCwMode(mode);
     m_stack->setCurrentIndex(isCw ? 1 : 0);
 }
 

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -2,6 +2,7 @@
 
 #include "gui/FilterStepMath.h"
 #include "FilterPassbandWidget.h"
+#include "VoiceModeGate.h"   // isCwMode() — one CW-mode list, not thirteen
 #include "FrequencyEntryParser.h"
 #include "GuardedSlider.h"
 #include "ComboStyle.h"
@@ -270,7 +271,7 @@ static const ModeSettings& modeSettingsFor(const QString& mode)
 
     if (mode == "USB" || mode == "LSB")  return ssbSettings;
     if (mode == "AM"  || mode == "SAM")  return amSettings;
-    if (mode == "CW")                    return cwSettings;
+    if (isCwMode(mode))                  return cwSettings;
     if (mode == "DIGU" || mode == "DIGL" || mode == "NT") return digSettings;
     if (mode == "RTTY")                  return rttySettings;
     if (mode == "FM" || mode == "NFM" || mode == "DFM") return fmSettings;
@@ -2529,7 +2530,7 @@ void RxApplet::applyFilterPreset(int widthHz)
         int mid = -shift / 2;  // midpoint between mark(0) and space(-shift)
         lo = mid - widthHz / 2;
         hi = mid + widthHz / 2;
-    } else if (mode == "CW" || mode == "CWL") {
+    } else if (isCwMode(mode)) {
         // Centered on carrier — the radio's BFO/demodulator applies the
         // pitch offset internally so signals at 0 Hz are heard at the sidetone.
         lo = -widthHz / 2;
@@ -2701,7 +2702,7 @@ void RxApplet::updateModeSettings(const QString& mode)
     m_xitContainer->setVisible(!isFM);
 
     // QSK visibility — only meaningful in CW mode
-    m_qskBtn->setVisible(mode == "CW");
+    m_qskBtn->setVisible(isCwMode(mode));
 
     // Disable squelch in digital, RTTY, and CW modes
     // Digital/RTTY: audio feeds external decoders via DAX, SQL not meaningful
@@ -2709,7 +2710,7 @@ void RxApplet::updateModeSettings(const QString& mode)
     // CW: radio locks squelch on at fixed level, rejects changes
     bool sqlDisabled = (mode == "DIGU" || mode == "DIGL" || mode == "NT"
                         || mode == "RTTY"
-                        || mode == "CW" || mode == "CWL");
+                        || isCwMode(mode));
     m_sqlBtn->setEnabled(!sqlDisabled);
     // Slider enabled when the mode allows squelch AND we're not in SqlMode::Off.
     // Manual mode = threshold input; Auto mode = dB margin input.

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -301,6 +301,7 @@ TitleBar::TitleBar(QWidget* parent)
 
     // PC Audio toggle
     m_pcBtn = new QPushButton("PC Audio");
+    m_pcBtn->setObjectName(QStringLiteral("pcAudioBtn"));
     m_pcBtn->setCheckable(true);
     m_pcBtn->setFixedHeight(22);
     m_pcBtn->setFixedWidth(70);
@@ -308,7 +309,8 @@ TitleBar::TitleBar(QWidget* parent)
     bool pcOn = s.value("PcAudioEnabled", "True").toString() == "True";
     m_pcBtn->setChecked(pcOn);
     m_pcBtn->setAccessibleName("PC Audio");
-    m_pcBtn->setAccessibleDescription("Toggle PC audio receive playback");
+    m_pcBtn->setAccessibleDescription(
+        "Toggle PC receive playback and PC microphone voice transmit");
     updatePcAudioToolTip();
 
     auto updatePcStyle = [this]() {
@@ -848,10 +850,13 @@ void TitleBar::setPcAudioLocked(bool locked)
     if (locked)
         setPcAudioEnabled(true);      // locked ON, never locked off
     m_pcBtn->setEnabled(!locked);
-    m_pcBtn->setToolTip(
-        locked ? tr("PC audio is required: this radio's audio is produced and "
-                    "captured on this computer, so it cannot be turned off.")
-               : QString());
+    if (locked) {
+        m_pcBtn->setToolTip(
+            tr("PC audio is required: this radio's audio is produced and "
+               "captured on this computer, so it cannot be turned off."));
+    } else {
+        updatePcAudioToolTip();
+    }
 }
 
 void TitleBar::setPcAudioEnabled(bool on)

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1,5 +1,6 @@
 #include "VfoWidget.h"
 #include "PhaseKnob.h"
+#include "VoiceModeGate.h"   // isCwMode() — one CW-mode list, not thirteen
 #include "SmartMtrWidget.h"
 #include "MeterViewController.h"
 #include "DisplaySettings.h"
@@ -3188,7 +3189,7 @@ void VfoWidget::updateExtendedDspVisibility()
 {
     const QString mode = m_slice->mode();
     const bool isFm = isFmRfMode(mode);
-    const bool isCw = (mode == "CW" || mode == "CWL");
+    const bool isCw = isCwMode(mode);
     m_nrsBtn->setVisible(!isFm && m_hasExtendedDsp);
     m_rnnBtn->setVisible(!isCw && !isFm && m_hasExtendedDsp);
     m_nrfBtn->setVisible(!isFm && m_hasExtendedDsp);
@@ -4394,7 +4395,7 @@ void VfoWidget::setSlice(SliceModel* slice)
         // Show/hide mode-specific DSP controls
         // Categorize by mode family (supports future/unknown modes)
         bool isRtty = (mode == "RTTY");
-        bool isCw   = (mode == "CW" || mode == "CWL");
+        bool isCw   = isCwMode(mode);
         bool isDig  = (mode == "DIGL" || mode == "DIGU" || mode == "NT");
         bool isFm   = isFmRfMode(mode);
         bool hasToneControls = hasFmToneControls(mode);
@@ -5005,7 +5006,7 @@ void VfoWidget::syncFromSlice()
     m_markLabel->setText(QString::number(m_slice->rttyMark()));
     m_shiftLabel->setText(QString::number(m_slice->rttyShift()));
     m_rttyContainer->setVisible(isRtty);
-    bool isCw = (m_slice->mode() == "CW" || m_slice->mode() == "CWL");
+    bool isCw = isCwMode(m_slice->mode());
     bool isDig = (m_slice->mode() == "DIGL" || m_slice->mode() == "DIGU" || m_slice->mode() == "NT");
     bool isFm = isFmRfMode(m_slice->mode());
     bool hasToneControls = hasFmToneControls(m_slice->mode());
@@ -5279,7 +5280,7 @@ static const ModeFilterPresets& filterPresetsFor(const QString& mode)
 
     if (mode == "USB" || mode == "LSB") return usb;
     if (mode == "AM" || mode == "SAM") return am;
-    if (mode == "CW") return cw;
+    if (isCwMode(mode)) return cw;
     if (mode == "DIGU" || mode == "DIGL" || mode == "NT") return dig;
     if (mode == "RTTY") return rtty;
     if (mode == "DFM") return dfm;
@@ -5580,7 +5581,7 @@ void VfoWidget::rebuildFilterButtons()
     }
 
     // Add CW autotune row spanning all 4 columns when in CW mode
-    if (m_slice && (m_slice->mode() == "CW" || m_slice->mode() == "CWL")) {
+    if (m_slice && isCwMode(m_slice->mode())) {
         int row = (m_filterWidths.size() + 3) / 4 + 1;
 
         m_autotuneContainer = new QWidget;

--- a/src/gui/VoiceModeGate.h
+++ b/src/gui/VoiceModeGate.h
@@ -31,6 +31,14 @@ inline bool isVoiceMode(const QString& mode)
         || mode == QLatin1String("DFM");
 }
 
+// AetherSDR's older neutral vocabulary used CW for upper-side CW. Icom and
+// HL2 report that same mode explicitly as CWU; CWL is the reverse-side mode.
+inline bool isCwMode(const QString& mode)
+{
+    return mode == QLatin1String("CW") || mode == QLatin1String("CWU")
+        || mode == QLatin1String("CWL");
+}
+
 // Whether an ALREADY-OPEN Copy Assist panel should be torn down, as
 // MainWindow::updateKeyerAvailability() decides it. Pure, so the decision can
 // be pinned by a test — updateKeyerAvailability() itself cannot be, since

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -470,6 +470,15 @@ void RadioModel::invokeBackendExtension(const QString& ns, const QString& verb,
     m_backend->invokeExtension(ns, verb, requestId, arg);
 }
 
+void RadioModel::setPcAudioEnabled(bool on)
+{
+    if (!m_backend || m_backend->capabilities().family != QLatin1String("icom")) {
+        return;
+    }
+    m_backend->invokeExtension(QStringLiteral("icom"),
+                               QStringLiteral("audio.pc"), 0, on);
+}
+
 void RadioModel::handRestoredStateToBackend(const QString& serial)
 {
     if (!m_backend) {
@@ -1438,7 +1447,7 @@ void RadioModel::teardownBackend()
     // Any backend replacement invalidates a WSPR transmit-route claim. Cleared
     // here rather than only in onDisconnected(), because a family switch never
     // reaches that path — see hasWsprTxStream().
-    m_wsprTxHostModulated = false;
+    m_wsprTxSeamAudioArmed = false;
     m_backend.reset();
     m_connection = nullptr;
     m_panStream = nullptr;
@@ -6379,7 +6388,7 @@ void RadioModel::onDisconnected()
     // and the next connect re-reads it from status.
     m_wsprTxRestoreDax = false;
     m_wsprTxPreviousDax = false;
-    m_wsprTxHostModulated = false;
+    m_wsprTxSeamAudioArmed = false;
     m_deadDaxRxSeen.clear();
     m_externalDaxTxSeen.clear();
     m_externalDaxRxSeen.clear();
@@ -10543,12 +10552,10 @@ bool RadioModel::prepareWsprTransmit()
     if (!backendCapabilities().canTransmit) {
         return false;
     }
-    // A host-modulating backend (HL2) runs the modulator on THIS host, so the
-    // beacon needs no transport at all: AudioEngine's WSPR pump already reaches
-    // it through feedDaxTxAudioInternal()'s m_hostModulation branch →
-    // txFinalMonitorPcmReady → submitTxAudio, the same tap the microphone and
-    // TCI use. There is nothing to create and nothing to borrow, so this arm
-    // takes none of the station state the Flex arm below does.
+    // A seam-audio backend needs no Flex DAX stream. HL2 modulates locally and
+    // Icom ships the PCM to the radio's own modulator; both paths converge at
+    // txFinalMonitorPcmReady → submitTxAudio. There is nothing to create and
+    // nothing to borrow, so this arm takes none of the Flex station state below.
     //
     // Nor does it need `transmit dax`: that setting exists to tell a FLEX to
     // take its modulator input from the DAX stream instead of the mic jacks,
@@ -10560,7 +10567,7 @@ bool RadioModel::prepareWsprTransmit()
     // Any backend whose transmit audio leaves through the seam, not only one
     // that modulates locally — the beacon reaches submitTxAudio either way.
     if (backendCapabilities().takesTxAudioOverSeam) {
-        m_wsprTxHostModulated = true;
+        m_wsprTxSeamAudioArmed = true;
         return true;
     }
     // Every other non-Flex family: the beacon rides a Flex `dax_tx` stream and
@@ -10600,13 +10607,13 @@ bool RadioModel::prepareWsprTransmit()
 
 void RadioModel::releaseWsprTransmit()
 {
-    // Host-modulated: nothing was borrowed, so nothing is handed back. Dropping
+    // Seam audio: nothing was borrowed, so nothing is handed back. Dropping
     // the latch is the whole release — and it must happen before the DAX arm so
     // a stale m_daxTxStreamId from an earlier Flex session in the same process
     // cannot make this path issue `stream set … tx=0` at a radio that has no
     // such stream.
-    if (m_wsprTxHostModulated) {
-        m_wsprTxHostModulated = false;
+    if (m_wsprTxSeamAudioArmed) {
+        m_wsprTxSeamAudioArmed = false;
         return;
     }
     if (m_wsprTxOwnershipRequested && m_wsprTxYieldAfterUse) {

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -479,6 +479,15 @@ void RadioModel::setPcAudioEnabled(bool on)
                                QStringLiteral("audio.pc"), 0, on);
 }
 
+void RadioModel::notePcAudioEnabled(bool on)
+{
+    if (!m_backend || m_backend->capabilities().family != QLatin1String("icom")) {
+        return;
+    }
+    m_backend->invokeExtension(QStringLiteral("icom"),
+                               QStringLiteral("audio.pc.state"), 0, on);
+}
+
 void RadioModel::handRestoredStateToBackend(const QString& serial)
 {
     if (!m_backend) {

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -55,6 +55,12 @@
 
 namespace AetherSDR {
 
+inline bool wsprSeamAudioRouteReady(bool armed, const RadioCapabilities& capabilities)
+{
+    return armed && capabilities.canTransmit
+        && capabilities.takesTxAudioOverSeam;
+}
+
 class IRadioBackend;   // aetherd RFC §5.5 radio-facing seam (owned via unique_ptr below)
 class FlexBackend;     // transitional concrete alias for 2.3 status-decode driving
 
@@ -555,13 +561,14 @@ public:
     // operator-issue setters so the change routes through the backend seam.
     void recallLocalMemory(int index);
     void createAudioStream();
+    void setPcAudioEnabled(bool on);
     bool ensureDaxTxStream(DaxTxRequestReason reason);
     bool prepareWsprTransmit();
     void releaseWsprTransmit();
     void restoreWsprTransmitDax();
     // "The WSPR beacon's transmit-audio route is ready." On a Flex that is
-    // literally a `dax_tx` stream; on a host-modulating backend (HL2) there is
-    // no stream to own — the modulator is ours and the pump feeds it through
+    // literally a `dax_tx` stream; on a seam-audio backend (HL2 or Icom) there
+    // is no stream to own — the pump feeds the backend through
     // txFinalMonitorPcmReady → submitTxAudio, which needs nothing created.
     //
     // The dialog polls this every 50 ms while transmitting and aborts the frame
@@ -582,7 +589,8 @@ public:
         // teardownBackend() now clears the latch as well; this is the backstop
         // that makes a missed clear harmless rather than dangerous, which is the
         // right split for anything guarding a transmitter.
-        if (m_wsprTxHostModulated && backendCapabilities().hostModulates)
+        if (wsprSeamAudioRouteReady(m_wsprTxSeamAudioArmed,
+                                    backendCapabilities()))
             return true;
         return m_daxTxStreamId != 0 && m_daxTxActive;
     }
@@ -1839,10 +1847,10 @@ private:
     bool        m_wsprTxReleaseWhenReady{false};
     bool        m_wsprTxPreviousDax{false};   // `transmit dax` before the beacon armed
     bool        m_wsprTxRestoreDax{false};    // beacon changed it and owes a restore
-    // The beacon armed against a host-modulating backend, so it borrowed no DAX
+    // The beacon armed against a seam-audio backend, so it borrowed no Flex DAX
     // stream and no `transmit dax`. Latched by prepareWsprTransmit() and the
     // only thing releaseWsprTransmit() has to undo on that path.
-    bool        m_wsprTxHostModulated{false};
+    bool        m_wsprTxSeamAudioArmed{false};
     quint32     m_daxTxClientHandle{0};  // Tracked for diagnostics only — not consulted in routing.
     bool        m_daxTxCreatePending{false};
     QSet<quint32> m_deadDaxRxSeen;

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -561,7 +561,15 @@ public:
     // operator-issue setters so the change routes through the backend seam.
     void recallLocalMemory(int index);
     void createAudioStream();
+    // An operator CLICK on the PC Audio button. On an Icom this asks the radio
+    // to switch its voice-mode modulation input, which Principle II permits
+    // because a user action is a request. Nothing else may call it — see
+    // notePcAudioEnabled() for the connect edge.
     void setPcAudioEnabled(bool on);
+    // The client's PC Audio state, published so the backend can ADVISE on a
+    // mismatch. Writes nothing: Principle III owns DATA OFF MOD to the radio,
+    // so a connect must never replay this client-persisted flag onto it.
+    void notePcAudioEnabled(bool on);
     bool ensureDaxTxStream(DaxTxRequestReason reason);
     bool prepareWsprTransmit();
     void releaseWsprTransmit();

--- a/tests/IcomFakeRadio.h
+++ b/tests/IcomFakeRadio.h
@@ -195,6 +195,14 @@ public:
     [[nodiscard]] bool serialOpened() const { return m_serialOpened; }
     [[nodiscard]] bool sawUsernameObfuscated() const { return m_usernameObfuscated; }
     [[nodiscard]] int civCommandsSeen() const { return m_civCommands; }
+    // What the radio currently holds for a 1A 05 leaf — the persisted-state
+    // question a client must not answer from its own memory.
+    [[nodiscard]] int setting(int item) const
+    {
+        auto it = m_settings.find(item);
+        return it == m_settings.end() ? -1 : static_cast<int>(it->second);
+    }
+    void setSetting(int item, std::uint8_t value) { m_settings[item] = value; }
     [[nodiscard]] const std::vector<std::uint16_t>& renewalSequences() const
     {
         return m_renewalSequences;
@@ -585,6 +593,33 @@ private:
             pushCiv({0xFE, 0xFE, kControllerAddress, kIc705Addr, kCivOk, kCivEom});
             return;
         }
+        // ---- 1A 05 SET MENU ----------------------------------------------
+        //
+        // The item number is TWO BCD bytes, so 0118 arrives as 0x01 0x18; a
+        // fake that read them as one byte would answer the wrong leaf. Read is
+        // the two-byte form, write carries a third byte — the same read/write
+        // split as every command pair above.
+        //
+        // Held as persisted state for the same reason the levels are: DATA OFF
+        // MOD is a setting the RADIO remembers across power cycles, and a fake
+        // that ACKs the read without answering it cannot tell a client which
+        // adopts the radio's value from one that quietly keeps its own.
+        if (frame->cmd == cmd::kSetting && frame->hasSub && frame->sub == 0x05
+            && frame->data.size() >= 2) {
+            const int item = decodeBcdByte(frame->data[0]) * 100
+                + decodeBcdByte(frame->data[1]);
+            if (frame->data.size() == 2) {
+                auto it = m_settings.find(item);
+                if (it == m_settings.end())
+                    return;   // no such leaf on this model — silence, not an error
+                pushCiv({0xFE, 0xFE, kControllerAddress, kIc705Addr, cmd::kSetting,
+                         0x05, frame->data[0], frame->data[1], it->second, kCivEom});
+                return;
+            }
+            m_settings[item] = frame->data[2];
+            pushCiv({0xFE, 0xFE, kControllerAddress, kIc705Addr, kCivOk, kCivEom});
+            return;
+        }
         if (frame->cmd == cmd::kTuneOffset && frame->hasSub && frame->data.empty()) {
             if (frame->sub == tuneOffset::kFrequency) {
                 // Two BCD bytes little-endian, then a sign byte.
@@ -713,6 +748,17 @@ public:
         {level::kCompLevel, 102}, // ~40 %
         {level::kNotchPos, 128},  // ~50 %
         {level::kVoxGain, 204},   // ~80 %
+    };
+    // 1A 05 SET-menu leaves, by DECIMAL item number. The IC-705's DATA OFF MOD
+    // starts at USB (0x01) rather than the WLAN (0x03) this client wants: an
+    // operator with a rig interface on the USB port is the ordinary case, and
+    // a fake that already sat on WLAN could not tell "PC Audio put it back"
+    // from "PC Audio never touched it".
+    std::map<int, std::uint8_t> m_settings{
+        {118, 0x01},   // DATA OFF MOD = USB
+        {119, 0x03},   // DATA MOD     = WLAN
+        {116, 0x80},   // USB MOD level
+        {117, 0x80},   // WLAN MOD level
     };
     // USB-D on FIL2 — NOT the client's construction default (USB, FIL1), so a
     // test asserting DIGU is asserting the client actually read 26 rather than

--- a/tests/icom_backend_test.cpp
+++ b/tests/icom_backend_test.cpp
@@ -425,6 +425,80 @@ int main(int argc, char** argv)
         check(waitSchedulerIdle(), "PTT fixture drains");
     }
 
+    // ── PC AUDIO OWNS DATA OFF MOD ONLY WHEN THE OPERATOR CLICKS ─────────
+    //
+    // DATA OFF MOD (1A 05 item 0118 on this radio) is a SET-menu register the
+    // RADIO persists. Constitution III therefore forbids the client replaying
+    // its own remembered PC Audio flag onto it at connect — and the register is
+    // four-valued while the button is two-valued, so "off" has to put back what
+    // the operator had rather than assuming MIC. Both were live defects; both
+    // are pinned here.
+    //
+    // The fake starts at USB (0x01), the ordinary setting for an operator with
+    // a rig interface on the USB port. A fake already sitting on WLAN could not
+    // tell "PC Audio put it back" from "PC Audio never touched it".
+    {
+        const auto writesTo118 = [](const std::vector<CivFrame>& log) {
+            std::vector<int> values;
+            for (const CivFrame& f : log) {
+                // A WRITE is the three-byte form. The two-byte form is a read,
+                // and counting those would make this assertion vacuous.
+                if (f.cmd == cmd::kSetting && f.hasSub && f.sub == 0x05
+                    && f.data.size() == 3
+                    && decodeBcdByte(f.data[0]) * 100 + decodeBcdByte(f.data[1]) == 118) {
+                    values.push_back(f.data[2]);
+                }
+            }
+            return values;
+        };
+
+        check(waitSchedulerIdle(), "the connect burst drains before the check");
+        check(writesTo118(radio.civCommands()).empty(),
+              "CONNECT WRITES NOTHING to DATA OFF MOD — the client publishes its "
+              "PC Audio state, it does not replay it onto radio-owned config "
+              "(Constitution III)");
+        check(radio.setting(118) == 0x01,
+              "so the operator's own USB selection survives the connect");
+        check(waitFor([&] {
+                  return backend.healthSnapshot().values.contains(
+                      QStringLiteral("dataoffmod"));
+              }, 3000),
+              "and the client ADOPTED it — Radio Health reports DATA OFF MOD");
+
+        // The observation verb is not a back door to the write.
+        radio.clearCivLog();
+        backend.invokeExtension(QStringLiteral("icom"),
+                                QStringLiteral("audio.pc.state"), 0, true);
+        check(waitSchedulerIdle(), "the state publication settles");
+        check(writesTo118(radio.civCommands()).empty(),
+              "publishing PC Audio state writes nothing either");
+
+        // An operator CLICK is a request, and Principle II allows exactly that.
+        radio.clearCivLog();
+        backend.invokeExtension(QStringLiteral("icom"),
+                                QStringLiteral("audio.pc"), 0, true);
+        check(waitSchedulerIdle(), "the PC Audio ON request converges");
+        check(writesTo118(radio.civCommands()) == std::vector<int>{0x03},
+              "a click selects WLAN (0x03) on an IC-705");
+        check(radio.setting(118) == 0x03, "and the radio holds it");
+
+        // ...and OFF restores what was captured, NOT a hardcoded MIC. This is
+        // the assertion that fails if the restore is dropped: MIC is 0x00 and
+        // the operator's USB is 0x01, so the two cannot be confused.
+        radio.clearCivLog();
+        backend.invokeExtension(QStringLiteral("icom"),
+                                QStringLiteral("audio.pc"), 0, false);
+        check(waitSchedulerIdle(), "the PC Audio OFF request converges");
+        check(writesTo118(radio.civCommands()) == std::vector<int>{0x01},
+              "turning PC Audio off puts back the operator's USB (0x01) — NOT a "
+              "hardcoded MIC, which would destroy their rig-interface routing "
+              "with no undo");
+        check(radio.setting(118) == 0x01, "and the radio ends where it started");
+        check(radio.setting(119) == 0x03,
+              "DATA MOD is never written by PC Audio — digital routing stays "
+              "radio-authoritative");
+    }
+
     // TUNE temporarily borrows the RF-power register. Releasing it must put
     // the operator's ordinary drive back; otherwise a low-power tune silently
     // changes the next voice/data transmission (and the UI follows the poll).

--- a/tests/icom_civ_test.cpp
+++ b/tests/icom_civ_test.cpp
@@ -359,6 +359,16 @@ static void testCommands()
     // Indices shifted by one when the leading fixed 0x00 was added.
     check(refClamped[9] == 0x00 && refClamped[7] == 0x20,
           "out-of-range reference clamps to +20.0 rather than wrapping");
+
+    check(bytesAre(cmdWriteSetting(0xA4, 118, 0x03),
+                   {0xFE, 0xFE, 0xA4, 0xE0, 0x1A, 0x05, 0x01, 0x18, 0x03, 0xFD}),
+          "IC-705 PC Audio selects WLAN with SET 0118 value 03");
+    check(bytesAre(cmdWriteSetting(0xB6, 84, 0x05),
+                   {0xFE, 0xFE, 0xB6, 0xE0, 0x1A, 0x05, 0x00, 0x84, 0x05, 0xFD}),
+          "IC-7300MK2 PC Audio selects LAN with SET 0084 value 05");
+    check(bytesAre(cmdWriteSetting(0xB6, 84, 0x00),
+                   {0xFE, 0xFE, 0xB6, 0xE0, 0x1A, 0x05, 0x00, 0x84, 0x00, 0xFD}),
+          "IC-7300MK2 PC Audio off restores MIC without touching DATA MOD 0085");
 }
 
 // DATA mode — command 26.

--- a/tests/icom_family_test.cpp
+++ b/tests/icom_family_test.cpp
@@ -80,13 +80,30 @@ int main(int argc, char** argv)
           "no IQ on any networked Icom — a true here offers a DAX-IQ path that cannot exist");
     check(caps.clientSettingsDomains == RadioCapabilities::ClientSettingsDomains{},
           "an Icom remembers its own state, so the client restores NOTHING");
-    // The MOD Input warning demands a WLAN modulation source. Only a radio with
-    // Wi-Fi has one -- and in kModels exactly ONE model does (the IC-705, whose
-    // 0xA4 is also the default CI-V address, which is almost certainly the radio
-    // the check was written against). On every other networked Icom the warning
-    // asked for a setting the radio cannot offer: an IC-9700 set correctly to
-    // LAN on the front panel reports 0x01 and was warned at it on every single
-    // session. Pin the discriminator so the gate cannot quietly come back.
+    RadioCapabilities transmittingIcom = caps;
+    transmittingIcom.canTransmit = true;
+    check(wsprSeamAudioRouteReady(true, transmittingIcom),
+          "an armed Icom seam-audio route is ready without host modulation");
+    transmittingIcom.takesTxAudioOverSeam = false;
+    check(!wsprSeamAudioRouteReady(true, transmittingIcom),
+          "the WSPR route fails closed if the current backend cannot take seam audio");
+
+    const auto ic705Mod = icom::modulationProfileFor(
+        *icom::modelForCivAddress(0xA4));
+    const auto mk2Mod = icom::modulationProfileFor(
+        *icom::modelForCivAddress(0xB6));
+    check(ic705Mod && ic705Mod->dataOffInputItem == 118
+              && ic705Mod->dataInputItem == 119
+              && ic705Mod->networkOnlyValue == 0x03,
+          "IC-705 uses SET 0118/0119 and WLAN value 03");
+    check(mk2Mod && mk2Mod->dataOffInputItem == 84
+              && mk2Mod->dataInputItem == 85
+              && mk2Mod->networkOnlyValue == 0x05,
+          "IC-7300MK2 uses SET 0084/0085 and LAN value 05");
+    // An IC-9700 has no Wi-Fi and, unlike the two profiles above, no verified
+    // model-specific modulation map. It must therefore remain outside this
+    // read/write path instead of borrowing the IC-705's WLAN table. Pin that
+    // distinction so the old false warning cannot quietly come back.
     check(!AetherSDR::icom::modelForCivAddress(0xA2)->hasWifi,
           "the IC-9700 has no Wi-Fi — so no WLAN MOD Input to demand");
     check(AetherSDR::icom::modelForCivAddress(0xA4)->hasWifi,

--- a/tests/icom_family_test.cpp
+++ b/tests/icom_family_test.cpp
@@ -100,6 +100,13 @@ int main(int argc, char** argv)
               && mk2Mod->dataInputItem == 85
               && mk2Mod->networkOnlyValue == 0x05,
           "IC-7300MK2 uses SET 0084/0085 and LAN value 05");
+    // The fallback PC Audio "off" writes when there is nothing captured to put
+    // back. It belongs to the model, not to the call site: these two agree at
+    // 0x00 today, and a third model whose MIC is elsewhere must not inherit it.
+    check(ic705Mod && ic705Mod->micValue == 0x00
+              && mk2Mod && mk2Mod->micValue == 0x00,
+          "both verified models name MIC in their own profile rather than "
+          "leaving the caller to hardcode it");
     // An IC-9700 has no Wi-Fi and, unlike the two profiles above, no verified
     // model-specific modulation map. It must therefore remain outside this
     // read/write path instead of borrowing the IC-705's WLAN table. Pin that

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -816,6 +816,9 @@ int main(int argc, char** argv)
               "active slice in CW: ASR indicator stays dimmed (nothing to transcribe)");
         check(!isVoiceMode(QStringLiteral("CWL")),
               "active slice in CWL: ASR indicator stays dimmed");
+        check(isCwMode(QStringLiteral("CW")) && isCwMode(QStringLiteral("CWU"))
+                  && isCwMode(QStringLiteral("CWL")),
+              "CW decoder gate accepts legacy CW plus explicit CWU/CWL names");
         check(!isVoiceMode(QStringLiteral("DIGU")) && !isVoiceMode(QStringLiteral("DIGL")),
               "active slice in DIGU/DIGL: ASR indicator stays dimmed");
         check(!isVoiceMode(QStringLiteral("RTTY")),


### PR DESCRIPTION
## Summary

- Restore WSPR transmit readiness for Icom and every other TX-capable backend that accepts modulated audio through the backend seam.
- Map DATA OFF MOD, DATA MOD and the modulation levels from each **verified** model's own CI-V guide, instead of sending one model's SET-menu numbers to every Icom.
- Let an operator **click** on PC Audio request the model-specific voice modulation input — and only a click. The connect edge publishes state and never writes.
- Leave DATA MOD untouched so digital-mode routing stays radio-authoritative.
- Add DATA OFF MOD and DATA MOD source/level detail to Radio Health on verified models.
- Recognize normalized `CWU` alongside `CW` and `CWL` at every CW gate, not just the decoder's.

## Root causes

### WSPR

`prepareWsprTransmit()` already armed the seam-audio path for Icom, but `hasWsprTxStream()` accepted that latch only when `hostModulates` was true. Icom deliberately reports `hostModulates == false` (`IcomCivBackend.cpp:99,104` — its own firmware modulates, from PCM this computer ships), so PSK Reporter never considered the WSPR stream ready and never advanced to PTT. `wsprSeamAudioRouteReady()` now widens the check to any TX-capable backend that takes TX audio over the seam, and re-checks it against the **currently** connected backend so a family switch cannot carry an armed beacon onto a radio that never armed one.

### CW decoder

The Icom mode normalizer reports upper-sideband CW as `CWU`, while AetherSDR's CW gates recognized only `CW` and `CWL`. `isCwMode()` now names all three in one place, and every gate that asks "is the operator doing CW" uses it.

## Icom CI-V behavior

PC Audio changes only DATA OFF MOD, and only on an operator click:

| Radio | Click ON | Click OFF | DATA MOD |
|---|---|---|---|
| IC-705 | WLAN (`03`) | restores the captured value (MIC `00` if none) | read only / unchanged |
| IC-7300MK2 | LAN (`05`) | restores the captured value (MIC `00` if none) | read only / unchanged |

Three rules keep this inside Constitution III, and `docs/architecture/aetherd-icom-civ-backend-design.md` now states the DATA OFF MOD / DATA MOD asymmetry and its reasoning rather than leaving it implicit:

1. **Only a click writes.** DATA OFF MOD is a SET-menu register the radio persists, so the client must not replay its own `PcAudioEnabled` key onto it. A connect calls `RadioModel::notePcAudioEnabled()` → `icom/audio.pc.state`, which publishes the client's state so `checkModInput()` can *advise* on a mismatch and writes nothing. The write lives behind `icom/audio.pc`, which nothing but the button calls.
2. **"Off" restores, it does not assume.** The register is four-valued on an IC-705 and six-valued on an IC-7300MK2; the button has two states. The backend latches the radio's own value immediately before its first write of the session and puts *that* back — so an operator running DATA OFF MOD = USB for a rig interface gets USB back, not MIC. `ModulationProfile::micValue` is the fallback only when there was nothing to capture.
3. **Unverified models are refused, not guessed at.** `modulationProfileFor()` answers only for `0xA4` and `0xB6`. A click on any other Icom is declined and says so; nothing is read, written or shown, and no advisory fires on connect.

## Behavior changes worth calling out

- **The PC Audio button is now unlockable on Icom.** `pcAudioRequired` narrows from `seamTxAudio` to `seamTxAudio && hostModulates`, so a backend that ships TX audio over the seam but does *not* host-modulate no longer forces PC Audio on. HL2 (`hostModulates = true`) is unchanged; the demo backend never took the branch. Icom is the only family affected, and it is the capability-correct answer — an Icom's own microphone is a real alternative.
- **Radio Health no longer shows a MOD Input row on models with no verified profile** (IC-9700, IC-7610, IC-785x, IC-7300, IC-905, and any unrecognized address). The old row read items 118/119 on *every* Icom and labelled them from the IC-705's enum — which is how an IC-9700 correctly set to LAN reported "USB" and got warned at, every session. A wrong row is worse than a missing one; the fix is another verified profile, not a re-enabled guess. Documented in the design doc.
- **The CWU sweep also picks up CWL at three sites** that tested bare `"CW"` only: the RX settings bucket (`RxApplet.cpp:273`), QSK button visibility (`RxApplet.cpp:2704`) and the filter-preset table (`VfoWidget.cpp:5282`). Those sent a CWL slice to the SSB bucket. Sideband tests (`VfoWidget.h`'s `lowerSideband`) are deliberately untouched — they are asking a different question.

## Validation

- Linux RelWithDebInfo build clean; `git diff --check` clean; `tools/gen_bridge_docs.py --check` reports no drift.
- Focused suite green: `icom_civ`, `icom_civ_scheduler`, `icom_scope`, `icom_audio`, `icom_meters`, `icom_session`, `icom_backend`, `icom_settings`, `icom_family`, `icom_replay`, `radio_capability_gating`, `wspr_beacon`, `map_wrap`.
- **The new pins were mutation-tested.** Reverting `wsprSeamAudioRouteReady` to `armed && hostModulates` fails `icom_family_test`; reverting `isCwMode` to `CW || CWL` fails `radio_capability_gating_test`; dropping the DATA OFF MOD restore fails `icom_backend_test`.
- `icom_backend_test` gained a PC Audio block that drives the real fake IC-705 (`IcomFakeRadio` now speaks the `1A 05` SET menu as persisted state) and asserts: connect writes nothing to item 0118, the operator's USB selection survives, `audio.pc.state` writes nothing, a click ON selects WLAN, a click OFF restores USB rather than MIC, and DATA MOD is never written.
- CW gate verified against the running app on the built-in demo simulator: `CW`/`CWU`/`CWL` open `cwDecodePanel`, `USB` closes it.
- Live IC-7300MK2 validation of the WSPR path used the pre-rebase patch-equivalent commit `3387569a`: WSPR keyed and transmitted successfully, producing 20 external PSK Reporter reception reports for KI6BCJ across the continental US and Alaska with reported SNRs from -22 to +4 dB.

## Known follow-ups

- Icom still emits benign Flex-oriented `remote_audio_rx failed, no command plane` diagnostics during PC Audio toggles. Existing log noise; it does not prevent audio or PTT.
- An automation verb such as `get icom modulation` would make DATA OFF MOD, DATA MOD, selected sources and their levels directly assertable without parsing Radio Health text.
