### PR TITLE
ci: run midi_settings_test on the Linux PR gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,24 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: ctest --test-dir build -R "^sim_signal_source_test$" --output-on-failure
 
+      # The MIDI settings store and the #4888 profile import/export boundary:
+      # the .map/XML importers (a parser fed contributor-supplied files —
+      # Principle VII's own example), the export round trip, the store's
+      # save/load, and the binding-collision rules. Until this step the suite
+      # ran in no job (#4898 approval: "green here means the tree compiled"),
+      # and its history shows what that costs: the suite sat green at 47
+      # checks while an unbounded read an operator could reach from the
+      # Import… picker waited for review to find it, and green again at 67
+      # while the Pitch Bend export→import round trip was broken (#5024) —
+      # Principle VIII's executed-vs-linked distinction, same as the
+      # workspace-canvas block above. Qt6::Core only — no widgets, no QPA
+      # platform, no radio, no wall clock; file I/O confined to its own temp
+      # dir. Measured, not assumed: 0.06 s warm / 0.32 s first run
+      # (RelWithDebInfo, Intel Mac), against a target the Build step already
+      # linked.
+      - name: Test MIDI settings and profile import/export
+        run: ctest --test-dir build -R "^midi_settings_test$" --output-on-failure
+
       # hl2_am_dcblock_test is deliberately NOT on this gate, and re-adding it
       # needs a measurement first. #4774 added it here on the "milliseconds
       # against an already-linked target" rationale every other step above


### PR DESCRIPTION
## Summary

Adds `midi_settings_test` to the Linux build job's test gate, invited by the #4898 approval review: "`midi_settings_test` appears in no `-R` filter in `ci.yml`, so none of these 67 checks gate a merge... Worth its own PR." (https://github.com/aethersdr/AetherSDR/pull/4898#pullrequestreview-4946621686). No originating issue — this PR implements that review note directly.

The suite covers the MIDI settings store and the #4888 profile import/export boundary — the `.map`/XML importers (a parser fed contributor-supplied files), the export round trip, save/load, and the binding-collision rules. Its own history is the argument for the slot: the suite was green at 47 checks while an operator-reachable unbounded read (`Import…` → `/dev/zero`) waited for review to find it, and green at 67 while the Pitch Bend export→import round trip was broken (#5024). Green meant the tree compiled, not that the boundary held.

Slot cost, measured per this file's own `hl2_am_dcblock_test` standard: **0.06 s warm / 0.32 s first run** (RelWithDebInfo, Intel Mac), 67/67 passing, against a target the Build step already links (Linux compiles `all`). The test links `Qt6::Core` only — no widgets, no QPA platform env needed, no radio, no network, no wall clock; file I/O is confined to its own temp directory. Linux-only gating follows the `band_edges_test` precedent: deterministic everywhere, so one platform is enough.

One file changed, 18 lines added (one step plus its rationale comment in the file's house style).

## Constitution principle honored

Principle VIII — Evidence Over Assertion: a claim whose verification step was not actually run is a hypothesis. This step is what turns `midi_settings_test`'s 67 assertions from linked prose back into evidence, the same executed-vs-linked distinction the workspace-canvas block above it records.

## Test plan

- [x] YAML validated locally
- [x] `midi_settings_test` built and run locally at `e7a8d3c1` + this change: 67/67, 0.06 s warm / 0.32 s cold (RelWithDebInfo, Intel Mac)
- [ ] Existing tests pass (CI) — this PR's own run exercises the new step
- [ ] Behavior verified on a real radio — n/a, CI configuration only

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls — no application code touched
- [x] Code is clean-room
- [ ] All meter UI uses `MeterSmoother` — n/a
- [ ] Documentation updated — n/a, no user-visible behavior change
- [ ] Security-sensitive changes reference a GHSA — n/a (routine workflow edit; touches no Tier-1 workflow)

— authored by agent (Claude Code) on behalf of @skerker
