### PR TITLE
ci(sign-release): fire on tag builds, and archive the tag rather than main

### DIFF
--- a/.github/workflows/sign-release.yml
+++ b/.github/workflows/sign-release.yml
@@ -4,10 +4,17 @@ name: Sign Release Artifacts
 # macOS artifacts are signed via Apple codesign + notarization.
 
 on:
+  # NO `branches:` filter here, deliberately.  `branches: [main]` restricts the
+  # workflow_run event to runs whose head branch is `main`, but a tag build's
+  # head_branch is the tag (`v26.8.3`) — and the job's own `if` below requires
+  # exactly that.  The two were mutually exclusive, so this trigger could only
+  # ever skip: every signed release through v26.8.1 was signed by a manual
+  # workflow_dispatch instead, and v26.8.2 shipped unsigned because nobody
+  # remembered to run one.  The `if` is what restricts this to tags; a `main`
+  # build still reaches it and is still skipped there.
   workflow_run:
     workflows: ["AppImage", "Windows Installer"]
     types: [completed]
-    branches: [main]
   workflow_dispatch:
     inputs:
       tag:
@@ -16,6 +23,14 @@ on:
 
 permissions:
   contents: write
+
+# Both AppImage and Windows Installer trigger this, so one tag produces two
+# runs.  Serialise them per tag rather than letting them race on the same
+# --clobber uploads; the second run re-signs the same complete set, which is
+# harmless because signing is idempotent in effect.
+concurrency:
+  group: sign-release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
 
 jobs:
   sign:
@@ -26,7 +41,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Check out the TAG being signed, not the default branch.  "Generate source
+      # archive" below is `git archive HEAD`, so without this it archives main's
+      # tip: a tarball named for the tag, containing whatever had merged since.
+      # Signing that produces an authenticated misstatement, which is worse than
+      # an unsigned release — so this ref is load-bearing, not tidiness.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.workflow_run.head_branch }}
 
       - name: Determine tag
         id: tag
@@ -36,6 +58,34 @@ jobs:
           else
             echo "tag=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
           fi
+
+      # Whichever build finishes first triggers this run, while the other may
+      # still be uploading.  Signing then covers a partial set and — worse —
+      # SHA256SUMS.txt silently omits whatever had not landed yet, while still
+      # looking like a complete manifest.  Wait for the full signable set first.
+      # macOS DMGs are deliberately absent: they are Apple-notarized, not GPG
+      # signed, so they are neither waited for nor signed here.
+      - name: Wait for every signable artifact to be attached
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          want="x86_64.AppImage aarch64.AppImage Windows-x64-setup.exe Windows-x64-portable.zip"
+          for i in $(seq 1 90); do
+            names=$(gh release view "$TAG" --json assets --jq '[.assets[].name] | join(" ")')
+            missing=
+            for w in $want; do
+              case "$names" in *"$w"*) ;; *) missing="$missing $w" ;; esac
+            done
+            if [ -z "$missing" ]; then
+              echo "All signable artifacts present."
+              exit 0
+            fi
+            echo "Waiting for:$missing  ($i/90)"
+            sleep 20
+          done
+          echo "::error::Timed out after 30 min waiting for release artifacts:$missing"
+          exit 1
 
       - name: Download release artifacts
         env:


### PR DESCRIPTION
Three defects in `sign-release.yml`. One of them has already shipped an unsigned release, and another would have signed a tarball that misstates its own contents.

Found during v26.8.3 release prep, when the signing job never ran on the tag.

## 1. The automatic trigger could never fire

```yaml
on:
  workflow_run:
    branches: [main]      # only runs whose head branch is main
...
    if: ... startsWith(github.event.workflow_run.head_branch, 'v')   # only tags
```

`branches: [main]` filters the event out before the job condition is evaluated, and a tag build's `head_branch` is the tag (`v26.8.3`), not `main`. The two conditions are mutually exclusive, so the `workflow_run` path could only ever skip.

The run history is exactly that shape — every success is a manual `workflow_dispatch`, and the single `workflow_run` event was **skipped**:

| Run | Event | Result |
|---|---|---|
| 2026-07-26 | workflow_dispatch | success (v26.7.4) |
| 2026-08-02 | workflow_run | **skipped** |
| 2026-08-02 | workflow_dispatch | success (v26.8.1) |

So signing has been a manual step nobody documented, and the consequence is on the releases page:

| Release | Signatures |
|---|---|
| v26.7.4 | full set |
| v26.8.1 | full set |
| **v26.8.2** | **none** — public since 2026-08-09 |
| **v26.8.3** | **none** — published today |

Dropping `branches:` is the fix. The `if` is what scopes this to tags; a `main` build still reaches the job and is still skipped there.

## 2. The source archive came from `main`, not the tag

`actions/checkout` took no `ref:`, so a `workflow_dispatch` checked out the default branch — and `git archive … HEAD` then archived main's tip under the tag's filename.

This is not hypothetical. `main` is routinely ahead of the tag by the time anyone dispatches: signing v26.8.2 by hand today would have produced `AetherSDR-v26.8.2-source.tar.gz` containing **54 commits of later work**, then GPG-signed it and hashed it into a signed `SHA256SUMS.txt`. A signature exists to assert that bytes are what they claim; that would have authenticated the opposite. Worse than an unsigned release.

Fixed by checking out the tag being signed:

```yaml
ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.workflow_run.head_branch }}
```

## 3. Fixing (1) exposes a race that (1) was hiding

Both `AppImage` and `Windows Installer` trigger this workflow, so one tag produces two runs — and whichever build finishes first starts signing while the other is still uploading. Signing would then cover a partial set, and `SHA256SUMS.txt` would omit whatever had not landed **while still looking like a complete manifest**. On this very release AppImage finished well before Windows Installer, so this would have fired immediately.

Two additions:

- **A wait step** that blocks until all four signable binaries are attached (both AppImages, `setup.exe`, `portable.zip`), polling for up to 30 minutes and failing loudly rather than signing a subset.
- **A `concurrency` group keyed on the tag**, `cancel-in-progress: false`, so the two runs serialise instead of racing on the same `--clobber` uploads. The second re-signs the same complete set, which is harmless.

## Scope notes

- **macOS DMGs are unchanged** — Apple codesign + notarization, not GPG, so they are neither waited for nor signed here.
- **`streamcontroller-aethersdr.zip` is signed but not waited for.** It matches the existing `*.zip` pattern, and the Stream Deck job is by far the fastest of the four, so in practice it is always attached first. It is deliberately not in the wait list: blocking on it would mean a Stream Deck failure could stop the binaries everyone actually verifies from being signed at all.
- No change to the signing commands, key handling, or upload step.

## Test plan

- [x] `yaml.safe_load` parses the file; trigger keys, step order, `concurrency.group` and the checkout `ref` all confirmed post-edit
- [x] Wait-step substring patterns checked against v26.8.3's real asset names (`AetherSDR-v26.8.3-x86_64.AppImage`, `-aarch64.AppImage`, `-Windows-x64-setup.exe`, `-Windows-x64-portable.zip`) — all four match
- [x] `git archive HEAD` is unaffected by checkout's default `fetch-depth: 1`; it archives the checked-out tree
- [ ] End-to-end verification requires merging and dispatching, since the trigger and the secrets only exist on `main`

## After this merges

**v26.8.2 and v26.8.3 still need signing**, and this PR does not do that:

```sh
gh workflow run sign-release.yml -f tag=v26.8.3
gh workflow run sign-release.yml -f tag=v26.8.2
```

With the `ref:` fix in place both will archive the correct tree. Until then, both releases' notes point users at `docs/VERIFYING-RELEASES.md` for signatures that do not exist.

Worth a separate look: **v26.8.1's source tarball may already have defect 2**, since it was dispatched on 2026-08-02 and `main` may have moved past the tag by then. Verifiable by downloading it and diffing against the tag tree.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — n/a, CI only
- [x] Code is clean-room — n/a
- [x] All meter UI uses `MeterSmoother` — n/a
- [x] Documentation updated — the reasoning is in the workflow comments, where the next person to edit these lines will see it
- [ ] Security-sensitive changes reference a GHSA — n/a, no vulnerability; this restores an intended integrity control

🤖 Generated with [Claude Code](https://claude.com/claude-code)