### PR TITLE
Fix duplicate pan wiring callbacks

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1425,6 +1425,8 @@ private:
     DvkPanel* m_dvkPanel{nullptr};
     QLabel* m_dvkIndicator{nullptr};
     QLabel* m_fdxIndicator{nullptr};
+    QMetaObject::Connection m_tnfIndicatorConnection;
+    QMetaObject::Connection m_fdxIndicatorConnection;
     // Manufacturer row above the model. Hidden unless the connected radio
     // reports a make its own model string does not already carry — see
     // refreshRadioIdentityLabels().

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -28,6 +28,7 @@
 #include "AppletPanel.h"
 #include "DbmRangeTransition.h"
 #include "MainWindowHelpers.h"
+#include "OwnedSingleShotTimer.h"
 #include "PanRecenterPolicy.h"
 #include "PanadapterApplet.h"
 #include "PanadapterMessageOverlay.h"
@@ -3681,22 +3682,24 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     // old yPixels scale.  This causes a ~5 dB noise-floor offset until restart.
     // A 300ms debounce avoids flooding the radio during animated resizes.
     {
-        auto* resizeTimer = new QTimer(sw);  // parented to sw → auto-deleted
-        resizeTimer->setSingleShot(true);
-        resizeTimer->setInterval(300);
-        connect(sw, &SpectrumWidget::dimensionsChanged,
-                resizeTimer, [resizeTimer](int, int) { resizeTimer->start(); });
-        connect(resizeTimer, &QTimer::timeout,
-                this, [this, applet, sw]() {
-            auto* pan = m_radioModel.panadapter(applet->panId());
-            if (!pan || !sw) {
-                return;
-            }
-            if (!panPixelDimensionsReady(sw)) {
-                return;
-            }
-            requestPanDimensionsForRadio(pan->panId(), sw);
-        });
+        const OwnedSingleShotTimer resizeTimer = ensureOwnedSingleShotTimer(
+            sw, QStringLiteral("panDimensionDebounceTimer"), 300);
+        if (resizeTimer.newlyCreated) {
+            connect(sw, &SpectrumWidget::dimensionsChanged,
+                    resizeTimer.timer,
+                    [timer = resizeTimer.timer](int, int) { timer->start(); });
+            connect(resizeTimer.timer, &QTimer::timeout,
+                    this, [this, applet, sw]() {
+                auto* pan = m_radioModel.panadapter(applet->panId());
+                if (!pan || !sw) {
+                    return;
+                }
+                if (!panPixelDimensionsReady(sw)) {
+                    return;
+                }
+                requestPanDimensionsForRadio(pan->panId(), sw);
+            });
+        }
     }
 
     // ── Tuning step size → this pan's spectrum widget ─────────────────────
@@ -3952,12 +3955,18 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             ? "QLabel { color: #00b4d8; font-weight: bold; font-size: 24px; }"
             : "QLabel { color: #404858; font-weight: bold; font-size: 24px; }");
     });
-    connect(sw, &SpectrumWidget::tnfCreateRequested,   tnf, &TnfModel::createTnf);
-    connect(sw, &SpectrumWidget::tnfMoveRequested,     tnf, &TnfModel::setTnfFreq);
-    connect(sw, &SpectrumWidget::tnfRemoveRequested,   tnf, &TnfModel::requestRemoveTnf);
-    connect(sw, &SpectrumWidget::tnfWidthRequested,    tnf, &TnfModel::setTnfWidth);
-    connect(sw, &SpectrumWidget::tnfDepthRequested,    tnf, &TnfModel::setTnfDepth);
-    connect(sw, &SpectrumWidget::tnfPermanentRequested,tnf, &TnfModel::setTnfPermanent);
+    connect(sw, &SpectrumWidget::tnfCreateRequested,   tnf, &TnfModel::createTnf,
+            Qt::UniqueConnection);
+    connect(sw, &SpectrumWidget::tnfMoveRequested,     tnf, &TnfModel::setTnfFreq,
+            Qt::UniqueConnection);
+    connect(sw, &SpectrumWidget::tnfRemoveRequested,   tnf, &TnfModel::requestRemoveTnf,
+            Qt::UniqueConnection);
+    connect(sw, &SpectrumWidget::tnfWidthRequested,    tnf, &TnfModel::setTnfWidth,
+            Qt::UniqueConnection);
+    connect(sw, &SpectrumWidget::tnfDepthRequested,    tnf, &TnfModel::setTnfDepth,
+            Qt::UniqueConnection);
+    connect(sw, &SpectrumWidget::tnfPermanentRequested, tnf, &TnfModel::setTnfPermanent,
+            Qt::UniqueConnection);
 
     // ── Spot markers ─────────────────────────────────────────────────────
     auto* spots = &m_radioModel.spotModel();
@@ -3994,20 +4003,31 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     // that stutters the waterfall. A short single-shot timer collapses a burst
     // of N spot signals into one rebuild. Parented to sw so it dies with the
     // pan; QPointer in rebuildSpots already guards against a dangling widget.
-    auto* spotRebuildTimer = new QTimer(sw);
-    spotRebuildTimer->setSingleShot(true);
-    spotRebuildTimer->setInterval(50);  // ~20 Hz, below the FFT repaint cadence
-    connect(spotRebuildTimer, &QTimer::timeout, sw, rebuildSpots);
-    QPointer<QTimer> rebuildTimerGuard(spotRebuildTimer);
-    auto scheduleRebuildSpots = [rebuildTimerGuard]() {
-        if (rebuildTimerGuard && !rebuildTimerGuard->isActive())
-            rebuildTimerGuard->start();
-    };
-    connect(spots, &SpotModel::spotAdded,   this, scheduleRebuildSpots);
-    connect(spots, &SpotModel::spotUpdated, this, scheduleRebuildSpots);
-    connect(spots, &SpotModel::spotRemoved, this, scheduleRebuildSpots);
-    connect(spots, &SpotModel::spotsCleared,this, scheduleRebuildSpots);
-    connect(spots, &SpotModel::spotsRefreshed, this, scheduleRebuildSpots);
+    const OwnedSingleShotTimer spotRebuildTimer = ensureOwnedSingleShotTimer(
+        sw, QStringLiteral("spotRebuildTimer"), 50);  // ~20 Hz, below FFT repaint cadence
+    if (spotRebuildTimer.newlyCreated) {
+        connect(spotRebuildTimer.timer, &QTimer::timeout, sw, rebuildSpots);
+        QPointer<QTimer> rebuildTimerGuard(spotRebuildTimer.timer);
+        auto scheduleRebuildSpots = [rebuildTimerGuard]() {
+            if (rebuildTimerGuard && !rebuildTimerGuard->isActive()) {
+                rebuildTimerGuard->start();
+            }
+        };
+        // Use the per-widget timer as the connection context so removing the
+        // pan also removes these model subscriptions.  MainWindow outlives
+        // every pan, so using `this` would retain one inert QPointer callback
+        // for every pan that had ever existed.
+        connect(spots, &SpotModel::spotAdded,
+                spotRebuildTimer.timer, scheduleRebuildSpots);
+        connect(spots, &SpotModel::spotUpdated,
+                spotRebuildTimer.timer, scheduleRebuildSpots);
+        connect(spots, &SpotModel::spotRemoved,
+                spotRebuildTimer.timer, scheduleRebuildSpots);
+        connect(spots, &SpotModel::spotsCleared,
+                spotRebuildTimer.timer, scheduleRebuildSpots);
+        connect(spots, &SpotModel::spotsRefreshed,
+                spotRebuildTimer.timer, scheduleRebuildSpots);
+    }
     {
         auto& s = AppSettings::instance();
         sw->setShowSpots(s.value("IsSpotsEnabled", "True").toString() == "True");

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -3550,6 +3550,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         applet->panId(), sw,
         m_radioModel.panMinBandwidthMhz(applet->panId()),
         m_radioModel.panMaxBandwidthMhz(applet->panId()));
+    QObject::disconnect(&m_radioModel, &RadioModel::panBandwidthLimitsChanged,
+                        sw, nullptr);
     connect(&m_radioModel, &RadioModel::panBandwidthLimitsChanged,
             sw, [this, applet, sw](const QString& panId, double minMhz, double maxMhz) {
         // Applets exist before any backend connects, so a connect-time report has
@@ -3579,7 +3581,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
 
     // Antenna list → this overlay menu (per-pan, mirrors VfoWidget pattern) (#1260)
     connect(&m_radioModel, &RadioModel::antListChanged,
-            menu, &SpectrumOverlayMenu::setAntennaList);
+            menu, &SpectrumOverlayMenu::setAntennaList,
+            Qt::UniqueConnection);
     menu->setAntennaList(m_radioModel.antennaList());
 
     // Apply smart spot filter state to this (possibly new) panadapter
@@ -3606,7 +3609,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
 
     if (auto* pan = m_radioModel.panadapter(applet->panId())) {
         connect(pan, &PanadapterModel::wideChanged,
-                sw, &SpectrumWidget::setWideActive);
+                sw, &SpectrumWidget::setWideActive,
+                Qt::UniqueConnection);
         sw->setWideActive(pan->wideActive());
         connect(pan, &PanadapterModel::wnbStateChanged,
                 sw, &SpectrumWidget::syncWnbState,
@@ -3625,6 +3629,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         //      local change while waiting for the radio to confirm the command, and
         //   b) in multi-pan setups, a level update on pan B doesn't incorrectly
         //      update pan A's dBm scale.
+        QObject::disconnect(pan, &PanadapterModel::levelChanged, sw, nullptr);
         connect(pan, &PanadapterModel::levelChanged,
                 sw, [sw, pendingDbm, setStreamDbmRange,
                      applyAuthoritativeDbmRange,
@@ -3711,7 +3716,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
 
     // ── Pan activation: clicking on this pan makes it active ─────────────
     connect(applet, &PanadapterApplet::activated,
-            m_panStack, &PanadapterStack::setActivePan);
+            m_panStack, &PanadapterStack::setActivePan,
+            Qt::UniqueConnection);
 
     // ── Close pan: X button on title bar closes this pan ────────────────
     connect(applet, &PanadapterApplet::closeRequested,
@@ -3937,24 +3943,31 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             markers.append({e.id, e.freqMhz, e.widthHz, e.depthDb, e.permanent});
         swGuard->setTnfMarkers(markers);
     };
-    connect(tnf, &TnfModel::tnfChanged,  this, rebuildTnfMarkers);
-    connect(tnf, &TnfModel::tnfRemoved,  this, rebuildTnfMarkers);
+    QObject::disconnect(tnf, &TnfModel::tnfChanged, sw, nullptr);
+    QObject::disconnect(tnf, &TnfModel::tnfRemoved, sw, nullptr);
+    connect(tnf, &TnfModel::tnfChanged,  sw, rebuildTnfMarkers);
+    connect(tnf, &TnfModel::tnfRemoved,  sw, rebuildTnfMarkers);
     connect(tnf, &TnfModel::globalEnabledChanged,
-            sw, &SpectrumWidget::setTnfGlobalEnabled);
-    connect(tnf, &TnfModel::globalEnabledChanged,
-            this, [this](bool on) {
-        m_tnfIndicator->setStyleSheet(on
-            ? "QLabel { color: #00b4d8; font-weight: bold; font-size: 24px; }"
-            : "QLabel { color: #404858; font-weight: bold; font-size: 24px; }");
-    });
+            sw, &SpectrumWidget::setTnfGlobalEnabled,
+            Qt::UniqueConnection);
+    QObject::disconnect(m_tnfIndicatorConnection);
+    m_tnfIndicatorConnection = connect(
+        tnf, &TnfModel::globalEnabledChanged,
+        this, [this](bool on) {
+            m_tnfIndicator->setStyleSheet(on
+                ? "QLabel { color: #00b4d8; font-weight: bold; font-size: 24px; }"
+                : "QLabel { color: #404858; font-weight: bold; font-size: 24px; }");
+        });
 
     // FDX indicator style update
-    connect(&m_radioModel, &RadioModel::infoChanged, this, [this]() {
-        bool fdx = m_radioModel.fullDuplexEnabled();
-        m_fdxIndicator->setStyleSheet(fdx
-            ? "QLabel { color: #00b4d8; font-weight: bold; font-size: 24px; }"
-            : "QLabel { color: #404858; font-weight: bold; font-size: 24px; }");
-    });
+    QObject::disconnect(m_fdxIndicatorConnection);
+    m_fdxIndicatorConnection = connect(
+        &m_radioModel, &RadioModel::infoChanged, this, [this]() {
+            const bool fdx = m_radioModel.fullDuplexEnabled();
+            m_fdxIndicator->setStyleSheet(fdx
+                ? "QLabel { color: #00b4d8; font-weight: bold; font-size: 24px; }"
+                : "QLabel { color: #404858; font-weight: bold; font-size: 24px; }");
+        });
     connect(sw, &SpectrumWidget::tnfCreateRequested,   tnf, &TnfModel::createTnf,
             Qt::UniqueConnection);
     connect(sw, &SpectrumWidget::tnfMoveRequested,     tnf, &TnfModel::setTnfFreq,
@@ -4009,8 +4022,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         connect(spotRebuildTimer.timer, &QTimer::timeout, sw, rebuildSpots);
         QPointer<QTimer> rebuildTimerGuard(spotRebuildTimer.timer);
         auto scheduleRebuildSpots = [rebuildTimerGuard]() {
-            if (rebuildTimerGuard && !rebuildTimerGuard->isActive()) {
-                rebuildTimerGuard->start();
+            if (rebuildTimerGuard) {
+                startSingleShotTimerIfIdle(rebuildTimerGuard.data());
             }
         };
         // Use the per-widget timer as the connection context so removing the
@@ -4060,27 +4073,38 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
 
     // ── Per-pan display controls (client-side) ───────────────────────────
     connect(menu, &SpectrumOverlayMenu::fftFillAlphaChanged,
-            sw, &SpectrumWidget::setFftFillAlpha);
+            sw, &SpectrumWidget::setFftFillAlpha,
+            Qt::UniqueConnection);
     connect(menu, &SpectrumOverlayMenu::fftFillColorChanged,
-            sw, &SpectrumWidget::setFftFillColor);
+            sw, &SpectrumWidget::setFftFillColor,
+            Qt::UniqueConnection);
     connect(menu, &SpectrumOverlayMenu::fftLineColorChanged,
-            sw, &SpectrumWidget::setFftLineColor);
+            sw, &SpectrumWidget::setFftLineColor,
+            Qt::UniqueConnection);
     connect(menu, &SpectrumOverlayMenu::fftHeatMapChanged,
-            sw, &SpectrumWidget::setFftHeatMap);
+            sw, &SpectrumWidget::setFftHeatMap,
+            Qt::UniqueConnection);
     connect(menu, &SpectrumOverlayMenu::showGridChanged,
-            sw, &SpectrumWidget::setShowGrid);
+            sw, &SpectrumWidget::setShowGrid,
+            Qt::UniqueConnection);
     connect(menu, &SpectrumOverlayMenu::freqGridSpacingChanged,
-            sw, &SpectrumWidget::setFreqGridSpacing);
+            sw, &SpectrumWidget::setFreqGridSpacing,
+            Qt::UniqueConnection);
     connect(menu, &SpectrumOverlayMenu::freqScaleFontPtChanged,
-            sw, &SpectrumWidget::setFreqScaleFontPt);
+            sw, &SpectrumWidget::setFreqScaleFontPt,
+            Qt::UniqueConnection);
     connect(menu, &SpectrumOverlayMenu::fftLineWidthChanged,
-            sw, &SpectrumWidget::setFftLineWidth);
+            sw, &SpectrumWidget::setFftLineWidth,
+            Qt::UniqueConnection);
     connect(menu, &SpectrumOverlayMenu::noiseFloorPositionChanged,
-            sw, &SpectrumWidget::setNoiseFloorPosition);
+            sw, &SpectrumWidget::setNoiseFloorPosition,
+            Qt::UniqueConnection);
     connect(menu, &SpectrumOverlayMenu::noiseFloorEnableChanged,
-            sw, &SpectrumWidget::setNoiseFloorEnable);
+            sw, &SpectrumWidget::setNoiseFloorEnable,
+            Qt::UniqueConnection);
     connect(sw, &SpectrumWidget::noiseFloorPositionResolved,
-            menu, &SpectrumOverlayMenu::syncNoiseFloorPosition);
+            menu, &SpectrumOverlayMenu::syncNoiseFloorPosition,
+            Qt::UniqueConnection);
 
     // ── Auto-squelch wiring ───────────────────────────────────────────────
     // RxApplet signals → per-pan spectrum widget
@@ -4206,7 +4230,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         auto* pan = m_radioModel.panadapter(applet->panId());
         if (pan) {
             connect(pan, &PanadapterModel::daxiqChannelChanged,
-                    menu, &SpectrumOverlayMenu::syncDaxIqChannel);
+                    menu, &SpectrumOverlayMenu::syncDaxIqChannel,
+                    Qt::UniqueConnection);
             menu->syncDaxIqChannel(pan->daxiqChannel());
 
             // DAX IQ channel restore deferred — the radio persists
@@ -4242,17 +4267,23 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             QString("display pan set %1 weighted_average=%2").arg(applet->panId()).arg(on ? 1 : 0));
     });
     connect(menu, &SpectrumOverlayMenu::wfColorSchemeChanged,
-            sw, &SpectrumWidget::setWfColorScheme);
+            sw, &SpectrumWidget::setWfColorScheme,
+            Qt::UniqueConnection);
     connect(menu, &SpectrumOverlayMenu::spectrumRenderModeChanged,
-            sw, &SpectrumWidget::setSpectrumRenderMode);
+            sw, &SpectrumWidget::setSpectrumRenderMode,
+            Qt::UniqueConnection);
     connect(menu, &SpectrumOverlayMenu::dssFloorDepthChanged,
-            sw, &SpectrumWidget::setDssFloorDepth);
+            sw, &SpectrumWidget::setDssFloorDepth,
+            Qt::UniqueConnection);
     connect(sw, &SpectrumWidget::dssFloorDepthResolved,
-            menu, &SpectrumOverlayMenu::syncDssFloorDepth);
+            menu, &SpectrumOverlayMenu::syncDssFloorDepth,
+            Qt::UniqueConnection);
     connect(menu, &SpectrumOverlayMenu::dssGainChanged,
-            sw, &SpectrumWidget::setDssGain);
+            sw, &SpectrumWidget::setDssGain,
+            Qt::UniqueConnection);
     connect(menu, &SpectrumOverlayMenu::dssRowSpanChanged,
-            sw, &SpectrumWidget::setDssRowSpan);
+            sw, &SpectrumWidget::setDssRowSpan,
+            Qt::UniqueConnection);
     connect(menu, &SpectrumOverlayMenu::wfColorGainChanged,
             this, [this, applet, sw](int v) {
         if (kiwiSdrPanDisplaysKiwi(applet->panId())) {
@@ -4425,9 +4456,11 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     });
     // NB Waterfall Blanker (#277)
     connect(menu, &SpectrumOverlayMenu::wfBlankerEnabledChanged,
-            sw, &SpectrumWidget::setWfBlankerEnabled);
+            sw, &SpectrumWidget::setWfBlankerEnabled,
+            Qt::UniqueConnection);
     connect(menu, &SpectrumOverlayMenu::wfBlankerThresholdChanged,
-            sw, &SpectrumWidget::setWfBlankerThreshold);
+            sw, &SpectrumWidget::setWfBlankerThreshold,
+            Qt::UniqueConnection);
     connect(menu, &SpectrumOverlayMenu::backgroundImageRequested,
             this, [sw] {
         const QString path = getBackgroundImagePath(sw->window(), "Choose Background Image");

--- a/src/gui/OwnedSingleShotTimer.h
+++ b/src/gui/OwnedSingleShotTimer.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QTimer>
+
+namespace AetherSDR {
+
+// Returns one named, direct-child single-shot timer for an owner.  Callers use
+// newlyCreated to install the signal path exactly once when an object is wired
+// more than once during placeholder-to-live pan replacement.
+struct OwnedSingleShotTimer {
+    QTimer* timer{nullptr};
+    bool newlyCreated{false};
+};
+
+inline OwnedSingleShotTimer ensureOwnedSingleShotTimer(QObject* owner,
+                                                        const QString& objectName,
+                                                        int intervalMs)
+{
+    Q_ASSERT(owner != nullptr);
+    Q_ASSERT(!objectName.isEmpty());
+
+    QTimer* timer = owner->findChild<QTimer*>(objectName, Qt::FindDirectChildrenOnly);
+    if (timer != nullptr) {
+        return {timer, false};
+    }
+
+    timer = new QTimer(owner);
+    timer->setObjectName(objectName);
+    timer->setSingleShot(true);
+    timer->setInterval(intervalMs);
+    return {timer, true};
+}
+
+} // namespace AetherSDR

--- a/src/gui/OwnedSingleShotTimer.h
+++ b/src/gui/OwnedSingleShotTimer.h
@@ -23,6 +23,7 @@ inline OwnedSingleShotTimer ensureOwnedSingleShotTimer(QObject* owner,
 
     QTimer* timer = owner->findChild<QTimer*>(objectName, Qt::FindDirectChildrenOnly);
     if (timer != nullptr) {
+        Q_ASSERT(timer->interval() == intervalMs);
         return {timer, false};
     }
 
@@ -31,6 +32,17 @@ inline OwnedSingleShotTimer ensureOwnedSingleShotTimer(QObject* owner,
     timer->setSingleShot(true);
     timer->setInterval(intervalMs);
     return {timer, true};
+}
+
+inline bool startSingleShotTimerIfIdle(QTimer* timer)
+{
+    Q_ASSERT(timer != nullptr);
+    if (timer->isActive()) {
+        return false;
+    }
+
+    timer->start();
+    return true;
 }
 
 } // namespace AetherSDR

--- a/tests/owned_single_shot_timer_test.cpp
+++ b/tests/owned_single_shot_timer_test.cpp
@@ -59,12 +59,10 @@ int main(int argc, char** argv)
     CHECK(firstSpotTimer.timer == secondSpotTimer.timer);
 
     QSignalSpy spotTimeouts(firstSpotTimer.timer, &QTimer::timeout);
-    firstSpotTimer.timer->start();
+    CHECK(startSingleShotTimerIfIdle(firstSpotTimer.timer));
     QTest::qWait(60);
     const int spotRemainingBeforeSchedule = firstSpotTimer.timer->remainingTime();
-    if (!secondSpotTimer.timer->isActive()) {
-        secondSpotTimer.timer->start();
-    }
+    CHECK(!startSingleShotTimerIfIdle(secondSpotTimer.timer));
     const int spotRemainingAfterSchedule = secondSpotTimer.timer->remainingTime();
     CHECK(spotRemainingAfterSchedule <= spotRemainingBeforeSchedule);
     CHECK(spotTimeouts.wait(500));

--- a/tests/owned_single_shot_timer_test.cpp
+++ b/tests/owned_single_shot_timer_test.cpp
@@ -1,0 +1,84 @@
+#include "gui/OwnedSingleShotTimer.h"
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <QTest>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* expression, int line)
+{
+    if (!condition) {
+        std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, line, expression);
+        ++g_failures;
+    }
+}
+
+#define CHECK(condition) check((condition), #condition, __LINE__)
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    QObject dimensionOwner;
+    const OwnedSingleShotTimer firstDimensionTimer = ensureOwnedSingleShotTimer(
+        &dimensionOwner, QStringLiteral("dimensionTimer"), 200);
+    const OwnedSingleShotTimer secondDimensionTimer = ensureOwnedSingleShotTimer(
+        &dimensionOwner, QStringLiteral("dimensionTimer"), 200);
+    CHECK(firstDimensionTimer.newlyCreated);
+    CHECK(!secondDimensionTimer.newlyCreated);
+    CHECK(firstDimensionTimer.timer == secondDimensionTimer.timer);
+    CHECK(dimensionOwner.findChildren<QTimer*>(QStringLiteral("dimensionTimer"),
+                                               Qt::FindDirectChildrenOnly).size() == 1);
+
+    QSignalSpy dimensionTimeouts(firstDimensionTimer.timer, &QTimer::timeout);
+    firstDimensionTimer.timer->start();
+    QTest::qWait(60);
+    const int dimensionRemainingBeforeRestart = firstDimensionTimer.timer->remainingTime();
+    secondDimensionTimer.timer->start();
+    const int dimensionRemainingAfterRestart = secondDimensionTimer.timer->remainingTime();
+    CHECK(dimensionRemainingAfterRestart > dimensionRemainingBeforeRestart);
+    CHECK(dimensionTimeouts.wait(500));
+    CHECK(dimensionTimeouts.count() == 1);
+
+    QObject spotOwner;
+    const OwnedSingleShotTimer firstSpotTimer = ensureOwnedSingleShotTimer(
+        &spotOwner, QStringLiteral("spotTimer"), 200);
+    const OwnedSingleShotTimer secondSpotTimer = ensureOwnedSingleShotTimer(
+        &spotOwner, QStringLiteral("spotTimer"), 200);
+    CHECK(firstSpotTimer.newlyCreated);
+    CHECK(!secondSpotTimer.newlyCreated);
+    CHECK(firstSpotTimer.timer == secondSpotTimer.timer);
+
+    QSignalSpy spotTimeouts(firstSpotTimer.timer, &QTimer::timeout);
+    firstSpotTimer.timer->start();
+    QTest::qWait(60);
+    const int spotRemainingBeforeSchedule = firstSpotTimer.timer->remainingTime();
+    if (!secondSpotTimer.timer->isActive()) {
+        secondSpotTimer.timer->start();
+    }
+    const int spotRemainingAfterSchedule = secondSpotTimer.timer->remainingTime();
+    CHECK(spotRemainingAfterSchedule <= spotRemainingBeforeSchedule);
+    CHECK(spotTimeouts.wait(500));
+    CHECK(spotTimeouts.count() == 1);
+
+    QObject independentOwner;
+    const OwnedSingleShotTimer independentTimer = ensureOwnedSingleShotTimer(
+        &independentOwner, QStringLiteral("dimensionTimer"), 20);
+    CHECK(independentTimer.newlyCreated);
+    CHECK(independentTimer.timer != firstDimensionTimer.timer);
+    QSignalSpy independentTimeouts(independentTimer.timer, &QTimer::timeout);
+    independentTimer.timer->start();
+    CHECK(independentTimeouts.wait(500));
+    CHECK(independentTimeouts.count() == 1);
+
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -2703,6 +2703,13 @@ target_link_libraries(panadapter_dbm_range_test PRIVATE aethercore Qt6::Core)
 set_target_properties(panadapter_dbm_range_test PROPERTIES AUTOMOC ON)
 add_test(NAME panadapter_dbm_range_test COMMAND panadapter_dbm_range_test)
 
+# wirePanadapter() can see the placeholder SpectrumWidget more than once. The
+# helper keeps one timer/path per widget while retaining separate per-pan timers.
+add_executable(owned_single_shot_timer_test tests/owned_single_shot_timer_test.cpp)
+target_include_directories(owned_single_shot_timer_test PRIVATE src)
+target_link_libraries(owned_single_shot_timer_test PRIVATE Qt6::Core Qt6::Test)
+add_test(NAME owned_single_shot_timer_test COMMAND owned_single_shot_timer_test)
+
 # The bridge preserves dragAt, target-tune, memory-recall, and authenticated
 # positional requests across its bare and JSON protocol forms.
 add_executable(automation_drag_at_test tests/automation_drag_at_test.cpp)


### PR DESCRIPTION
## Summary

Fixes #5030.

Pan placeholder replacement wires the same SpectrumWidget twice. The existing cleanup only disconnects routes whose receiver is MainWindow, so widget-owned resize timers survived both passes and emitted duplicate display pan dimension commands. This change reuses one named timer and signal path per widget while preserving the trailing-edge debounce and deliberate same-value reassertions after reconnect, profile load, or radio reset.

The issue and PR reviews identified the same receiver-side blind spot in adjacent paths. This PR makes the stable pan, overlay, TNF, and indicator routes idempotent, and reuses one spot rebuild timer. It also fixes a lifetime leak in the old spot wiring: five SpotModel subscriptions previously remained as inert MainWindow callbacks for every removed pan; using the widget-owned timer as their context now removes them with the pan.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The duplicate command path was reproduced and the corrected path was measured through the automation bridge against a real FLEX-6700, in addition to focused timer regression coverage and a full current-main ARM64 build.

## Test plan

- [x] Full local ARM64 RelWithDebInfo build passes on upstream/main 5c405a2d
- [x] owned_single_shot_timer_test passes and covers same-owner reuse, trailing-edge restart, production start-if-idle coalescing, and independent owners
- [x] Strict test-registration and engine-boundary checks pass with zero blockers
- [x] Real-radio RX-only bridge proof: one resize produced exactly one sendCommand, one TX command, and one success response
- [x] Real-radio RX-only bridge proof: a rapid two-resize burst coalesced to exactly one final dimension command and one success response
- [x] Final radio state remained transmitting=false, mox=false, tuning=false
- [x] Original reproduction and root cause are documented in #5030

The automation bridge does not expose SpectrumWidget TNF gestures or internal spot rebuild counts, so those adjacent fixes are covered by connection semantics, lifecycle review, and the focused timer test rather than direct radio automation. No screenshot is included because this is a timing and command-routing fix with no visual delta.

## Checklist

- [x] Commits are signed
- [x] No new AppSettings persistence
- [x] Code is clean-room
- [x] Meter UI is unaffected
- [x] No documentation or CHANGELOG update is needed for this localized bug fix
- [x] No security-sensitive changes

Generated with OpenAI Codex.
