### PR TITLE
refactor(rn2): unify frame accumulation

### DIFF
--- a/src/core/RNNoiseFilter.cpp
+++ b/src/core/RNNoiseFilter.cpp
@@ -78,107 +78,120 @@ void RNNoiseFilter::reset()
         m_processed48kFloat[channel].clear();
     }
     m_outAccum.resize(0);
+    m_warnedChannelLengthMismatch = false;
 }
 
-QByteArray RNNoiseFilter::process(const QByteArray& pcm24kStereo)
+void RNNoiseFilter::processStereoFrames(const float* interleavedStereo,
+                                        int stereoFrames)
 {
-    if (m_rateDomain != RateDomain::Legacy24k) {
-        qCWarning(lcRn2)
-            << "RNNoiseFilter: 24 kHz process() called on native-48 kHz instance";
-        return pcm24kStereo;
-    }
-    if (!isValid() || pcm24kStereo.isEmpty())
-        return pcm24kStereo;
-
-    const auto* src = reinterpret_cast<const float*>(pcm24kStereo.constData());
-    const int stereoFrames =
-        pcm24kStereo.size() / (2 * static_cast<int>(sizeof(float)));
     const int channels = processingChannels();
 
-    // 1. Split RX stereo into matched channel paths. ProcessedMono is the TX
-    //    path and intentionally retains the historical L/R downmix.
-    for (int channel = 0; channel < channels; ++channel)
-        m_input24k[channel].resize(stereoFrames);
-    for (int i = 0; i < stereoFrames; ++i) {
-        if (channels == 2) {
-            m_input24k[0][i] = src[i * 2];
-            m_input24k[1][i] = src[i * 2 + 1];
-        } else {
-            m_input24k[0][i] = 0.5f * (src[i * 2] + src[i * 2 + 1]);
+    if (m_rateDomain == RateDomain::Legacy24k) {
+        // Split RX stereo into matched channel paths. ProcessedMono is the TX
+        // path and intentionally retains the historical L/R downmix.
+        for (int channel = 0; channel < channels; ++channel) {
+            m_input24k[channel].resize(stereoFrames);
+        }
+        for (int frame = 0; frame < stereoFrames; ++frame) {
+            if (channels == 2) {
+                m_input24k[0][frame] = interleavedStereo[frame * 2];
+                m_input24k[1][frame] = interleavedStereo[frame * 2 + 1];
+            } else {
+                m_input24k[0][frame] = 0.5f * (
+                    interleavedStereo[frame * 2]
+                    + interleavedStereo[frame * 2 + 1]);
+            }
         }
     }
 
-    // 2. Append to input accumulator and process complete 480-sample frames
-    //    RNNoise expects [-32768, 32768] range, so scale from [-1, 1]
+    // Append to the shared 48 kHz input accumulator. RNNoise expects
+    // [-32768, 32768] input, so scale from normalized float samples.
     std::array<int, 2> totalAccumSamples{0, 0};
     int completeFrames = std::numeric_limits<int>::max();
     for (int channel = 0; channel < channels; ++channel) {
-        const QByteArray mono48k =
-            m_up[channel]->process(m_input24k[channel].data(), stereoFrames);
-        const auto* mono48kSamples =
-            reinterpret_cast<const float*>(mono48k.constData());
-        const int monoSamples48k = mono48k.size() / static_cast<int>(sizeof(float));
-        const int startIdx =
+        const int start =
             m_inAccum[channel].size() / static_cast<int>(sizeof(float));
-        m_inAccum[channel].resize((startIdx + monoSamples48k)
-                                  * static_cast<int>(sizeof(float)));
-        auto* floatBuf = reinterpret_cast<float*>(m_inAccum[channel].data());
-        for (int i = 0; i < monoSamples48k; ++i)
-            floatBuf[startIdx + i] = mono48kSamples[i] * 32768.0f;
-        totalAccumSamples[channel] = startIdx + monoSamples48k;
+        if (m_rateDomain == RateDomain::Legacy24k) {
+            const QByteArray mono48k =
+                m_up[channel]->process(m_input24k[channel].data(), stereoFrames);
+            const auto* mono48kSamples =
+                reinterpret_cast<const float*>(mono48k.constData());
+            const int monoSamples48k =
+                mono48k.size() / static_cast<int>(sizeof(float));
+            m_inAccum[channel].resize((start + monoSamples48k)
+                                      * static_cast<int>(sizeof(float)));
+            auto* accum = reinterpret_cast<float*>(m_inAccum[channel].data());
+            for (int sample = 0; sample < monoSamples48k; ++sample) {
+                accum[start + sample] = mono48kSamples[sample] * 32768.0f;
+            }
+            totalAccumSamples[channel] = start + monoSamples48k;
+        } else {
+            m_inAccum[channel].resize(
+                (start + stereoFrames) * static_cast<int>(sizeof(float)));
+            auto* accum = reinterpret_cast<float*>(m_inAccum[channel].data());
+            for (int frame = 0; frame < stereoFrames; ++frame) {
+                const float sample = channels == 2
+                    ? interleavedStereo[frame * 2 + channel]
+                    : 0.5f * (interleavedStereo[frame * 2]
+                              + interleavedStereo[frame * 2 + 1]);
+                accum[start + frame] = sample * 32768.0f;
+            }
+            totalAccumSamples[channel] = start + stereoFrames;
+        }
         completeFrames =
             std::min(completeFrames, totalAccumSamples[channel] / FRAME_SIZE);
     }
 
-    if (completeFrames > 0) {
-        const int consumedSamples = completeFrames * FRAME_SIZE;
-        const int outputMonoSamples = consumedSamples;
-        std::array<QByteArray, 2> downsampled;
+    if (completeFrames <= 0) {
+        return;
+    }
 
-        // Both channels run the same frame count off the same block, so their
-        // RNNoise states advance in lockstep — that lockstep IS the fix, and
-        // step 4 below asserts it survived the resamplers.
-        for (int channel = 0; channel < channels; ++channel) {
-            m_processed48k[channel].resize(outputMonoSamples);
-            auto* accumData = reinterpret_cast<float*>(m_inAccum[channel].data());
-            for (int f = 0; f < completeFrames; ++f) {
-                if (m_dryMix > 0.0f) {
-                    rnnoise_process_frame_with_dry_mix(
-                        m_states[channel],
-                        &m_processed48k[channel][f * FRAME_SIZE],
-                        &accumData[f * FRAME_SIZE],
-                        m_dryMix);
-                } else {
-                    rnnoise_process_frame(m_states[channel],
-                                          &m_processed48k[channel][f * FRAME_SIZE],
-                                          &accumData[f * FRAME_SIZE]);
-                }
-            }
+    const int consumedSamples = completeFrames * FRAME_SIZE;
+    std::array<QByteArray, 2> downsampled;
 
-            // Keep leftover input samples
-            const int leftoverSamples = totalAccumSamples[channel] - consumedSamples;
-            if (leftoverSamples > 0) {
-                m_inAccum[channel] = QByteArray(
-                    reinterpret_cast<const char*>(&accumData[consumedSamples]),
-                    leftoverSamples * static_cast<int>(sizeof(float)));
+    // Both channels run the same frame count off the same block, so their
+    // RNNoise states advance in lockstep. This is important for RX stereo:
+    // independently accumulating a frame boundary makes the image drift.
+    for (int channel = 0; channel < channels; ++channel) {
+        m_processed48k[channel].resize(consumedSamples);
+        auto* accumData = reinterpret_cast<float*>(m_inAccum[channel].data());
+        for (int frame = 0; frame < completeFrames; ++frame) {
+            float* frameOutput =
+                &m_processed48k[channel][frame * FRAME_SIZE];
+            float* frameInput = &accumData[frame * FRAME_SIZE];
+            if (m_dryMix > 0.0f) {
+                rnnoise_process_frame_with_dry_mix(
+                    m_states[channel], frameOutput, frameInput, m_dryMix);
             } else {
-                m_inAccum[channel].resize(0);
+                rnnoise_process_frame(m_states[channel], frameOutput, frameInput);
             }
-
-            // 3. Scale RNNoise output back to [-1, 1], then downsample each
-            //    channel through its matched 48kHz → 24kHz path.
-            m_processed48kFloat[channel].resize(outputMonoSamples);
-            for (int i = 0; i < outputMonoSamples; ++i)
-                m_processed48kFloat[channel][i] = m_processed48k[channel][i] / 32768.0f;
-            downsampled[channel] = m_down[channel]->process(
-                m_processed48kFloat[channel].data(), outputMonoSamples);
         }
 
-        // 4. Interleave. The two resamplers are identically configured and fed
-        //    identical sample counts, so they cannot return different lengths.
-        //    If that ever changes, truncating to the shorter one desyncs L/R
-        //    permanently and *silently* — the exact failure this filter exists
-        //    to prevent — so say so once instead of drifting quietly.
+        const int leftoverSamples = totalAccumSamples[channel] - consumedSamples;
+        if (leftoverSamples > 0) {
+            std::memmove(accumData, &accumData[consumedSamples],
+                         leftoverSamples * sizeof(float));
+            m_inAccum[channel].resize(
+                leftoverSamples * static_cast<int>(sizeof(float)));
+        } else {
+            m_inAccum[channel].resize(0);
+        }
+
+        if (m_rateDomain == RateDomain::Legacy24k) {
+            m_processed48kFloat[channel].resize(consumedSamples);
+            for (int sample = 0; sample < consumedSamples; ++sample) {
+                m_processed48kFloat[channel][sample] =
+                    m_processed48k[channel][sample] / 32768.0f;
+            }
+            downsampled[channel] = m_down[channel]->process(
+                m_processed48kFloat[channel].data(), consumedSamples);
+        }
+    }
+
+    if (m_rateDomain == RateDomain::Legacy24k) {
+        // The two resamplers are identically configured and fed identical
+        // sample counts. Do not silently let a divergence advance a channel
+        // on a different timeline.
         int downsampledFrames =
             downsampled[0].size() / static_cast<int>(sizeof(float));
         if (channels == 2) {
@@ -212,17 +225,47 @@ QByteArray RNNoiseFilter::process(const QByteArray& pcm24kStereo)
         }
 
         m_outAccum.append(processedStereo);
+        return;
     }
 
-    // 5. Return exactly the same number of bytes as input
+    const int oldOutputSamples =
+        m_outAccum.size() / static_cast<int>(sizeof(float));
+    m_outAccum.resize(
+        (oldOutputSamples + consumedSamples * 2)
+        * static_cast<int>(sizeof(float)));
+    auto* stereo = reinterpret_cast<float*>(m_outAccum.data()) + oldOutputSamples;
+    for (int sample = 0; sample < consumedSamples; ++sample) {
+        const float left = m_processed48k[0][sample] / 32768.0f;
+        const float right = channels == 2
+            ? m_processed48k[1][sample] / 32768.0f
+            : left;
+        stereo[sample * 2] = left;
+        stereo[sample * 2 + 1] = right;
+    }
+}
+
+QByteArray RNNoiseFilter::process(const QByteArray& pcm24kStereo)
+{
+    if (m_rateDomain != RateDomain::Legacy24k) {
+        qCWarning(lcRn2)
+            << "RNNoiseFilter: 24 kHz process() called on native-48 kHz instance";
+        return pcm24kStereo;
+    }
+    if (!isValid() || pcm24kStereo.isEmpty()) {
+        return pcm24kStereo;
+    }
+
+    const int stereoFrames =
+        pcm24kStereo.size() / (2 * static_cast<int>(sizeof(float)));
+    const auto* input = reinterpret_cast<const float*>(pcm24kStereo.constData());
+    processStereoFrames(input, stereoFrames);
+
     const int needed = pcm24kStereo.size();
     if (m_outAccum.size() >= needed) {
-        QByteArray result = m_outAccum.left(needed);
+        QByteArray output = m_outAccum.left(needed);
         m_outAccum.remove(0, needed);
-        return result;
+        return output;
     }
-
-    // Not enough output yet — return silence (only happens during startup)
     return QByteArray(needed, '\0');
 }
 
@@ -255,71 +298,8 @@ int RNNoiseFilter::process48kStereo(
         return 0;
     }
 
-    const auto* src = reinterpret_cast<const float*>(pcm48kStereo.constData());
-    const int channels = processingChannels();
-    int completeFrames = std::numeric_limits<int>::max();
-    std::array<int, 2> totalAccumSamples{0, 0};
-
-    for (int channel = 0; channel < channels; ++channel) {
-        const int start = m_inAccum[channel].size() / static_cast<int>(sizeof(float));
-        m_inAccum[channel].resize(
-            (start + stereoFrames) * static_cast<int>(sizeof(float)));
-        auto* accum = reinterpret_cast<float*>(m_inAccum[channel].data());
-        for (int frame = 0; frame < stereoFrames; ++frame) {
-            const float sample = channels == 2
-                ? src[frame * 2 + channel]
-                : 0.5f * (src[frame * 2] + src[frame * 2 + 1]);
-            accum[start + frame] = sample * 32768.0f;
-        }
-        totalAccumSamples[channel] = start + stereoFrames;
-        completeFrames = std::min(
-            completeFrames, totalAccumSamples[channel] / FRAME_SIZE);
-    }
-
-    if (completeFrames > 0) {
-        const int consumedSamples = completeFrames * FRAME_SIZE;
-        for (int channel = 0; channel < channels; ++channel) {
-            m_processed48k[channel].resize(consumedSamples);
-            auto* accum = reinterpret_cast<float*>(m_inAccum[channel].data());
-            for (int frame = 0; frame < completeFrames; ++frame) {
-                float* frameOutput =
-                    &m_processed48k[channel][frame * FRAME_SIZE];
-                float* input = &accum[frame * FRAME_SIZE];
-                if (m_dryMix > 0.0f) {
-                    rnnoise_process_frame_with_dry_mix(
-                        m_states[channel], frameOutput, input, m_dryMix);
-                } else {
-                    rnnoise_process_frame(m_states[channel], frameOutput, input);
-                }
-            }
-
-            const int leftover = totalAccumSamples[channel] - consumedSamples;
-            if (leftover > 0) {
-                std::memmove(accum, &accum[consumedSamples],
-                             leftover * sizeof(float));
-                m_inAccum[channel].resize(
-                    leftover * static_cast<int>(sizeof(float)));
-            } else {
-                m_inAccum[channel].resize(0);
-            }
-        }
-
-        const int oldOutputSamples =
-            m_outAccum.size() / static_cast<int>(sizeof(float));
-        m_outAccum.resize(
-            (oldOutputSamples + consumedSamples * 2)
-            * static_cast<int>(sizeof(float)));
-        auto* dst = reinterpret_cast<float*>(m_outAccum.data())
-            + oldOutputSamples;
-        for (int frame = 0; frame < consumedSamples; ++frame) {
-            const float left = m_processed48k[0][frame] / 32768.0f;
-            const float right = channels == 2
-                ? m_processed48k[1][frame] / 32768.0f
-                : left;
-            dst[frame * 2] = left;
-            dst[frame * 2 + 1] = right;
-        }
-    }
+    const auto* input = reinterpret_cast<const float*>(pcm48kStereo.constData());
+    processStereoFrames(input, stereoFrames);
 
     const int needed = pcm48kStereo.size();
     if (m_outAccum.size() >= needed) {

--- a/src/core/RNNoiseFilter.h
+++ b/src/core/RNNoiseFilter.h
@@ -69,6 +69,7 @@ public:
 
 private:
     int processingChannels() const;
+    void processStereoFrames(const float* interleavedStereo, int stereoFrames);
 
     std::array<DenoiseState*, 2> m_states{nullptr, nullptr};
     std::array<std::unique_ptr<Resampler>, 2> m_up;    // 24kHz → 48kHz per channel

--- a/tests/rnnoise_filter_test.cpp
+++ b/tests/rnnoise_filter_test.cpp
@@ -139,6 +139,70 @@ QByteArray processInBlocks(RNNoiseFilter& filter, const QByteArray& input,
     return output;
 }
 
+bool processNativeInBlocks(RNNoiseFilter& filter, const QByteArray& input,
+                           const std::vector<int>& blockFrames,
+                           QByteArray& output)
+{
+    constexpr int kStereoFrameBytes = 2 * static_cast<int>(sizeof(float));
+    const int totalFrames = input.size() / kStereoFrameBytes;
+    output.resize(0);
+    output.reserve(input.size());
+    QByteArray blockOutput;
+    int offsetFrames = 0;
+    int blockIndex = 0;
+    while (offsetFrames < totalFrames) {
+        const int requestedFrames = blockFrames[blockIndex % blockFrames.size()];
+        const int frames = std::min(requestedFrames, totalFrames - offsetFrames);
+        const QByteArray inputBlock = input.mid(
+            offsetFrames * kStereoFrameBytes, frames * kStereoFrameBytes);
+        const int outputFrames = filter.process48kStereo(inputBlock, blockOutput);
+        if (outputFrames != frames || blockOutput.size() != inputBlock.size()) {
+            return false;
+        }
+        output.append(blockOutput);
+        offsetFrames += frames;
+        ++blockIndex;
+    }
+    return true;
+}
+
+QByteArray makeStereoSine(int sampleRate, int frames, float rightGain)
+{
+    QByteArray block(frames * 2 * static_cast<int>(sizeof(float)),
+                     Qt::Uninitialized);
+    auto* samples = reinterpret_cast<float*>(block.data());
+    for (int frame = 0; frame < frames; ++frame) {
+        const float seconds = static_cast<float>(frame) / sampleRate;
+        const float left = 0.45f * std::sin(2.0f * kPi * 430.0f * seconds);
+        samples[frame * 2] = left;
+        samples[frame * 2 + 1] = rightGain * left;
+    }
+    return block;
+}
+
+bool hasAudibleLeftChannel(const QByteArray& samples, int startFrame, int frames)
+{
+    const auto* interleaved = reinterpret_cast<const float*>(samples.constData());
+    for (int frame = startFrame; frame < startFrame + frames; ++frame) {
+        if (std::abs(interleaved[frame * 2]) > 1.0e-4f) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int firstAudibleLeftFrame(const QByteArray& samples)
+{
+    const auto* interleaved = reinterpret_cast<const float*>(samples.constData());
+    const int frames = samples.size() / (2 * static_cast<int>(sizeof(float)));
+    for (int frame = 0; frame < frames; ++frame) {
+        if (std::abs(interleaved[frame * 2]) > 1.0e-4f) {
+            return frame;
+        }
+    }
+    return -1;
+}
+
 QByteArray makeUnequalStereoBlock(int blockIndex)
 {
     QByteArray block(kBlockFrames * 2 * static_cast<int>(sizeof(float)),
@@ -281,6 +345,144 @@ bool testProcessedMonoOutputIsDuplicated()
     if (!heardProcessedAudio) {
         std::printf("processed-mono output remained silent after startup\n");
         return false;
+    }
+    return true;
+}
+
+bool testIrregularPartitionsPreserveRnnoiseLatency()
+{
+    constexpr int kTotalFrames = 2 * kSampleRate;
+    constexpr int kLegacyFirstAudibleMin = 4500;
+    constexpr int kLegacyFirstAudibleMax = 4525;
+    constexpr int kNativeFirstAudibleMin = 1850;
+    constexpr int kNativeFirstAudibleMax = 1880;
+    const std::vector<int> partitions{73, 211, 17, 604, 91};
+
+    RNNoiseFilter legacyFilter;
+    legacyFilter.setDryMix(1.0f);
+    const QByteArray legacyInput = makeStereoSine(kSampleRate, kTotalFrames, 0.25f);
+    const QByteArray legacyOutput = processInBlocks(
+        legacyFilter, legacyInput, partitions);
+    const int legacyFirstAudible = firstAudibleLeftFrame(legacyOutput);
+    if (legacyOutput.size() != legacyInput.size()
+        || legacyFirstAudible < kLegacyFirstAudibleMin
+        || legacyFirstAudible > kLegacyFirstAudibleMax) {
+        std::printf("legacy RN2 irregular partitions changed output size or latency "
+                    "(first audible frame %d)\n", legacyFirstAudible);
+        return false;
+    }
+
+    RNNoiseFilter nativeFilter(
+        RNNoiseFilter::OutputMode::PreserveRxStereo,
+        RNNoiseFilter::RateDomain::Native48k);
+    nativeFilter.setDryMix(1.0f);
+    const QByteArray nativeInput = makeStereoSine(48000, kTotalFrames, 0.25f);
+    QByteArray nativeOutput;
+    const bool nativeProcessed = processNativeInBlocks(
+        nativeFilter, nativeInput, partitions, nativeOutput);
+    const int nativeFirstAudible = firstAudibleLeftFrame(nativeOutput);
+    if (!nativeProcessed
+        || nativeOutput.size() != nativeInput.size()
+        || nativeFirstAudible < kNativeFirstAudibleMin
+        || nativeFirstAudible > kNativeFirstAudibleMax) {
+        std::printf("native RN2 irregular partitions changed output size or latency "
+                    "(first audible frame %d)\n", nativeFirstAudible);
+        return false;
+    }
+    std::printf("RN2 irregular partition latency: legacy=%d native=%d frames\n",
+                legacyFirstAudible, nativeFirstAudible);
+    return true;
+}
+
+bool testNative48PreservesRxStereoIndependence()
+{
+    constexpr int kTotalFrames = 4 * kRnNoiseLatencyFrames;
+    RNNoiseFilter filter(
+        RNNoiseFilter::OutputMode::PreserveRxStereo,
+        RNNoiseFilter::RateDomain::Native48k);
+    filter.setDryMix(1.0f);
+
+    const QByteArray input = makeStereoSine(48000, kTotalFrames, 0.0f);
+    QByteArray output;
+    if (!processNativeInBlocks(filter, input, {91, 389, 27, 613}, output)
+        || output.size() != input.size()) {
+        std::printf("native RX stereo path did not preserve its output contract\n");
+        return false;
+    }
+
+    const auto* samples = reinterpret_cast<const float*>(output.constData());
+    for (int frame = kRnNoiseLatencyFrames; frame < kTotalFrames; ++frame) {
+        if (std::abs(samples[frame * 2 + 1]) > 1.0e-6f) {
+            std::printf("native RX stereo path mixed left into right at frame %d\n", frame);
+            return false;
+        }
+    }
+    if (!hasAudibleLeftChannel(
+            output, kRnNoiseLatencyFrames,
+            kTotalFrames - kRnNoiseLatencyFrames)) {
+        std::printf("native RX stereo path did not retain the left channel\n");
+        return false;
+    }
+    return true;
+}
+
+bool testNative48ProcessedMonoIrregularPartitionsPreserveFifo()
+{
+    constexpr int kTotalFrames = 2 * kSampleRate;
+    constexpr int kComparedFrames = 4096;
+    const QByteArray input = makeStereoSine(48000, kTotalFrames, -0.35f);
+
+    RNNoiseFilter alignedFilter(
+        RNNoiseFilter::OutputMode::ProcessedMono,
+        RNNoiseFilter::RateDomain::Native48k);
+    alignedFilter.setDryMix(1.0f);
+    QByteArray alignedOutput;
+    if (!processNativeInBlocks(alignedFilter, input, {480}, alignedOutput)) {
+        std::printf("native processed-mono aligned reference failed\n");
+        return false;
+    }
+
+    RNNoiseFilter irregularFilter(
+        RNNoiseFilter::OutputMode::ProcessedMono,
+        RNNoiseFilter::RateDomain::Native48k);
+    irregularFilter.setDryMix(1.0f);
+    QByteArray irregularOutput;
+    if (!processNativeInBlocks(
+            irregularFilter, input, {73, 211, 17, 604, 91}, irregularOutput)
+        || irregularOutput.size() != input.size()) {
+        std::printf("native processed-mono irregular output contract failed\n");
+        return false;
+    }
+
+    const auto* irregularSamples =
+        reinterpret_cast<const float*>(irregularOutput.constData());
+    for (int frame = 0; frame < kTotalFrames; ++frame) {
+        if (std::abs(irregularSamples[frame * 2]
+                     - irregularSamples[frame * 2 + 1]) > 1.0e-6f) {
+            std::printf("native processed-mono output diverged at frame %d\n", frame);
+            return false;
+        }
+    }
+
+    const int alignedStart = firstAudibleLeftFrame(alignedOutput);
+    const int irregularStart = firstAudibleLeftFrame(irregularOutput);
+    if (alignedStart < 0 || irregularStart < 0
+        || alignedStart + kComparedFrames > kTotalFrames
+        || irregularStart + kComparedFrames > kTotalFrames) {
+        std::printf("native processed-mono FIFO comparison lacked audible output\n");
+        return false;
+    }
+
+    const auto* alignedSamples =
+        reinterpret_cast<const float*>(alignedOutput.constData());
+    for (int frame = 0; frame < kComparedFrames; ++frame) {
+        const float aligned = alignedSamples[(alignedStart + frame) * 2];
+        const float irregular = irregularSamples[(irregularStart + frame) * 2];
+        if (std::abs(aligned - irregular) > 1.0e-6f) {
+            std::printf("native processed-mono FIFO changed at compared frame %d\n",
+                        frame);
+            return false;
+        }
     }
     return true;
 }
@@ -721,6 +923,9 @@ int main()
     if (!testSpectralDryMixUsesOneSynthesisTimeline()
         || !testDryMixDefaultsToFullSuppressionAndClamps()
         || !testProcessedMonoOutputIsDuplicated()
+        || !testIrregularPartitionsPreserveRnnoiseLatency()
+        || !testNative48PreservesRxStereoIndependence()
+        || !testNative48ProcessedMonoIrregularPartitionsPreserveFifo()
         || !testNoiseFloorDoesNotBreatheWithSpeech()
         || !testStereoChannelsStaySynchronizedWithConstantDryFloor()
         || !testBinauralPhaseDifferenceSurvivesDenoising()


### PR DESCRIPTION
## Summary

Fixes #5013.

`RNNoiseFilter::process()` and `process48kStereo()` had separate copies of the same 48 kHz frame-accumulation, RNNoise processing, leftover compaction, and output interleave loop. That duplication made the legacy 24 kHz RX and native 48 kHz RX/TX paths easy to change independently. `reset()` also left the one-shot legacy resampler mismatch latch set, so a second divergence after reset would not be reported.

This change routes both public entry points through one private `processStereoFrames()` core while keeping rate-specific input conversion and legacy downsampling at the edges. It preserves the public output-size/startup-silence contracts, RX stereo independence, TX processed-mono duplication, FIFO ordering, and reusable native output capacity. Reset now re-arms the existing L/R resampler mismatch warning. Native 48 kHz has no L/R resampler-length mismatch surface, so the warning remains correctly scoped to the legacy resampling path.

Regression coverage now exercises irregular input partitions in both rate domains, the established startup latency, native RX channel independence, and native processed-mono TX duplication/FIFO order.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The shared core is covered by deterministic irregular-partition tests for both RX and TX modes, an ARM64 application build, and an agent automation bridge RN2 stereo probe.

## Agent automation bridge proof

The freshly built app was launched with `AETHER_AUTOMATION=1` and connected to a FLEX-6700 running firmware 4.2.18.41174. No transmit-capable automation was enabled or invoked.

`audioCapture probeNr2Stereo` exercised the production legacy RN2 filter entry point and reported:

- `coverageStatus: complete`, `fullCoverage: true`, 36,000 analyzed frames
- input L/R RMS ratio: `4.0`
- output L/R RMS ratio: `4.0`
- `ratioError: 0`, `preserved: true`, `audible: true`

`get transmit` reported `transmitting: false`, `mox: false`, and `tuning: false` before and after the probe. The irregular-partition and native-48 kHz TX cases are not parameterizable through the bridge, so those are demonstrated by the focused regression test below.

## Test plan

- [x] ARM64 application bundle builds and links with the repository toolchain
- [x] `ctest --test-dir build-codex-arm64 --output-on-failure -R '^(rnnoise_filter_test|tx_voice_processor_test)$'`
- [x] `python3 tools/check_engine_boundary.py --strict`
- [x] `python3 tools/check_test_registration.py --strict`
- [x] `git diff --check`
- [x] Agent automation bridge RN2 stereo probe passes in a connected real-radio app
- [x] Full CI matrix: Linux build/tests, macOS build/regressions, Windows build/tests, and static checks

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no settings changes
- [x] Code is clean-room — no proprietary source used
- [x] All meter UI uses `MeterSmoother` — no meter/UI changes
- [x] Documentation updated if user-visible behavior changed — no user-visible behavior or documentation change
- [x] Security-sensitive changes reference a GHSA — not security-sensitive

Generated with OpenAI Codex.
