### PR TITLE
feat(automation): expand RN2 proof modes

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -2601,6 +2601,83 @@ The JSON file contains chunks with `point`, `source`, optional `sourceId`,
 base64 `pcmBase64`. Use `audioCapture status` for metadata only and
 `audioCapture stop` to stop early.
 
+#### RN2 deterministic stereo probe
+
+`audioCapture probeDspStereo RN2` is an automation-only, synthetic RX proof
+surface for RN2. It creates a deterministic three-second stereo float32 signal
+inside `AudioEngine`; it neither connects to a radio nor changes RX routing,
+playback, TX permission, or TX state. It may take up to 120 seconds through the
+automation bridge because it deliberately runs a selected filter and a fresh,
+aligned reference filter.
+
+The two temporary filters use `probeDryMix=1.0`, reported in the response. That
+keeps the proof independent of a user's RN2 strength and of whether RNNoise
+classifies the synthetic tones as speech: RNNoise still executes its frame,
+resampler, accumulator, channel-mode, and FIFO paths, while this probe measures
+those transport contracts rather than denoising quality. Production RX/TX RN2
+settings and DSP behavior are untouched.
+
+The legacy no-option form remains unchanged, including its 24 kHz / 960-frame
+RX-compatible defaults. `probeNr2Stereo` is the older SpectralNR/`NR2` alias;
+it is not an RN2 spelling and still takes no RN2 options.
+
+```text
+# Legacy RX-compatible run with an irregular cyclic partition sequence.
+python tools/automation_probe.py audioCapture probeDspStereo RN2 blocks=73,211,17,604,91
+
+# Native 48 kHz, stereo-preserving RN2.
+python tools/automation_probe.py audioCapture probeDspStereo RN2 rate=Native48k output=PreserveRxStereo blocks=73,211,17,604,91
+
+# Native 48 kHz, intentional mono/downmix path duplicated to L/R.
+python tools/automation_probe.py audioCapture probeDspStereo RN2 rate=Native48k output=ProcessedMono blocks=73,211,17,604,91
+```
+
+The same request is available through JSON; the CLI driver preserves all
+key/value tokens in `value`:
+
+```json
+→ {"cmd":"audioCapture","action":"probeDspStereo",
+   "value":"RN2 rate=Native48k output=ProcessedMono blocks=480,960"}
+```
+
+Only `probeDspStereo RN2` accepts case-insensitive `rate`, `output`, and
+`blocks` tokens. `rate` is `Legacy24k` (default) or `Native48k`; `output` is
+`PreserveRxStereo` (default) or `ProcessedMono`; `blocks` is a bounded,
+positive comma-separated cyclic list of input-frame counts (default `960`).
+Unknown, repeated, non-positive, oversized, or excessive-count options fail
+before running a filter. These options are rejected for `all` and every
+non-RN2 mode. The legacy comma form `RN2,strict` remains valid.
+
+Every RN2 response retains the established `frames`, `discardFrames`, RMS
+`input`/`output`, `ratioError`, level-ratio, `audible`, and `preserved` fields.
+It additionally reports canonical `rateDomain`, `sampleRate`, `outputMode`,
+and `blockPartitions`; input/output frame and byte totals; `inputCoverage`,
+`outputCoverage`, per-block `blockOutput`, and `outputSizeExact`; and the
+selected/reference `firstAudibleFrame` and millisecond positions. No fixed
+latency limit is asserted: those positions are evidence for the caller to
+inspect. `startupLatencyDeltaFrames`/`Ms` and `startupLatencyEquivalent` make
+partition-dependent leading silence explicit. `sequenceComparisonFrames`,
+`sequenceMaxError`, `sequenceEquivalent`, and `sequenceOrder` compare a
+substantial first-audible-aligned deterministic window against the fresh
+reference run. `fifoOrderPreserved` means that aligned payload stayed in
+reference order; `fifoSequenceEquivalent` is stricter and is true only when
+both that payload and its startup position match the reference.
+`firstOutputSizeMismatchBlock` and `sequenceFirstMismatchFrame`/`Channel` are
+`-1` on a clean run and identify the first failing location otherwise.
+
+For `PreserveRxStereo`, `ratioPreserved` is the explicit ratio-preservation
+result (and `preserved` keeps its historical meaning). For `ProcessedMono`,
+`leftRightMaxDelta` and `duplicated` prove that the intentional mono result was
+copied to both output channels; `ok` requires audibility, exact output sizing,
+duplication, and sequence equivalence. In preserve mode, `ok` also requires
+the legacy stereo-ratio check.
+
+This probe cannot expose RN2's internal one-time resampler divergence warning
+latch: it is not surfaced by the public filter API, and two matched resamplers
+cannot be induced to diverge through public inputs without invasive fault
+injection. The output-size and aligned-reference evidence above therefore
+proves the public contract, not that hidden warning-latch path.
+
 ### `floors`
 Per-pan **measured FFT noise floor** and the **display floor** (dBm), read off the
 live spectrum without a screenshot — the numeric way to assert post-TX floor
@@ -3465,7 +3542,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `link` | `ax25` | link <status\|connect <call> [via <digi>]\|disconnect\|mycall <call>\|listen <call>\|alias <call>\|pms on\|off> — connected-mode AX.25 terminal + mailbox, with measured RTT vs configured T1 |
 | `memprofile` | — | memprofile <snapshot\|start\|sample\|status\|report\|samples\|stop\|reset> [intervalMs maxSamples] |
 | `tci` | — | tci start\|status\|stop\|send\|trace\|routes [@id] [rx=N] — TCI simulator (multi-client: @id names a client, rx=N its audio_start receiver) and protocol diagnostics |
-| `audioCapture` | — | audioCapture <start\|stop\|status\|read\|probeNr2Stereo\|probeDspStereo> [args] |
+| `audioCapture` | — | audioCapture <start\|stop\|status\|read\|probeNr2Stereo\|probeDspStereo> [args] — RN2 probe accepts rate=Legacy24k\|Native48k output=PreserveRxStereo\|ProcessedMono blocks=<frames,...> |
 | `txwaterfall` | — | txwaterfall <on\|off> — show keyed TX in the waterfall |
 | `liveness` | — | liveness — per-class data ages and the producer->consumer meter join |
 | `civ` | — | civ <send <hex>\|trace [all]\|session\|scheduler> — CI-V inject, frame trace, RS-BA1 lease health, or command-scheduler health (Icom; send is TX-gated) |

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -69,6 +69,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QStringList>
+#include <QVector>
 #include <QtGlobal>
 #include <QtConcurrent/QtConcurrentRun>
 #include <algorithm>
@@ -2929,25 +2930,416 @@ constexpr int kAutomationDspProbeFrames = AudioEngine::DEFAULT_SAMPLE_RATE * 3;
 constexpr int kAutomationDspProbeDiscardFrames =
     AudioEngine::DEFAULT_SAMPLE_RATE + AudioEngine::DEFAULT_SAMPLE_RATE / 2;
 constexpr int kAutomationDspProbeBlockFrames = 960;
+constexpr int kAutomationRn2ProbeMaxBlockPartitions = 64;
+constexpr float kAutomationRn2ProbeDryMix = 1.0f;
 
-QByteArray makeAutomationDspStereoProbeInput()
+QByteArray makeAutomationDspStereoProbeInput(int sampleRate = AudioEngine::DEFAULT_SAMPLE_RATE)
 {
-    QByteArray input(kAutomationDspProbeFrames * 2 * static_cast<int>(sizeof(float)),
-                     Qt::Uninitialized);
+    const int frames = sampleRate * 3;
+    QByteArray input(frames * 2 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
     auto* src = reinterpret_cast<float*>(input.data());
-    for (int i = 0; i < kAutomationDspProbeFrames; ++i) {
-        const double t = static_cast<double>(i) / AudioEngine::DEFAULT_SAMPLE_RATE;
-        const float envelope = static_cast<float>(
-            0.62 + 0.38 * std::sin(2.0 * std::numbers::pi * 4.2 * t));
-        const float signal = static_cast<float>(
-            envelope * (0.30 * std::sin(2.0 * std::numbers::pi * 720.0 * t)
-                      + 0.16 * std::sin(2.0 * std::numbers::pi * 1180.0 * t)
-                      + 0.08 * std::sin(2.0 * std::numbers::pi * 1740.0 * t))
-          + 0.03 * std::sin(2.0 * std::numbers::pi * 43.0 * t));
+    for (int i = 0; i < frames; ++i) {
+        const double t = static_cast<double>(i) / sampleRate;
+        const float envelope =
+            static_cast<float>(0.62 + 0.38 * std::sin(2.0 * std::numbers::pi * 4.2 * t));
+        const float signal =
+            static_cast<float>(envelope * (0.30 * std::sin(2.0 * std::numbers::pi * 720.0 * t) +
+                                           0.16 * std::sin(2.0 * std::numbers::pi * 1180.0 * t) +
+                                           0.08 * std::sin(2.0 * std::numbers::pi * 1740.0 * t)) +
+                               0.03 * std::sin(2.0 * std::numbers::pi * 43.0 * t));
         src[2 * i] = 0.80f * signal;
         src[2 * i + 1] = 0.20f * signal;
     }
     return input;
+}
+
+struct AutomationRn2ProbeOptions {
+    RNNoiseFilter::RateDomain rateDomain{RNNoiseFilter::RateDomain::Legacy24k};
+    RNNoiseFilter::OutputMode outputMode{RNNoiseFilter::OutputMode::PreserveRxStereo};
+    QVector<int> blockPartitions{kAutomationDspProbeBlockFrames};
+};
+
+QString rn2ProbeRateDomainName(RNNoiseFilter::RateDomain rateDomain)
+{
+    return rateDomain == RNNoiseFilter::RateDomain::Native48k ? QStringLiteral("Native48k")
+                                                              : QStringLiteral("Legacy24k");
+}
+
+QString rn2ProbeOutputModeName(RNNoiseFilter::OutputMode outputMode)
+{
+    return outputMode == RNNoiseFilter::OutputMode::ProcessedMono
+               ? QStringLiteral("ProcessedMono")
+               : QStringLiteral("PreserveRxStereo");
+}
+
+int rn2ProbeSampleRate(RNNoiseFilter::RateDomain rateDomain)
+{
+    return rateDomain == RNNoiseFilter::RateDomain::Native48k ? 48000
+                                                              : AudioEngine::DEFAULT_SAMPLE_RATE;
+}
+
+QStringList automationDspProbeTokens(const QString& request)
+{
+    QStringList tokens;
+    QString token;
+    const auto appendToken = [&tokens, &token]() {
+        if (!token.isEmpty()) {
+            tokens.append(token);
+            token.clear();
+        }
+    };
+
+    for (qsizetype i = 0; i < request.size(); ++i) {
+        const QChar character = request.at(i);
+        if (character.isSpace()) {
+            appendToken();
+            continue;
+        }
+        if (character == QLatin1Char(',')) {
+            // Commas retain the legacy "RN2,strict" spelling, except inside
+            // blocks= where they are the intentionally comma-separated frame list.
+            const bool nextIsFrame = i + 1 < request.size() && request.at(i + 1).isDigit();
+            if (token.startsWith(QStringLiteral("blocks="), Qt::CaseInsensitive) && nextIsFrame) {
+                token.append(character);
+            } else {
+                appendToken();
+            }
+            continue;
+        }
+        token.append(character);
+    }
+    appendToken();
+    return tokens;
+}
+
+QJsonObject stereoRmsRatio(const QByteArray& pcm, int startFrame);
+
+bool parseAutomationRn2ProbeOptions(const QStringList& optionTokens,
+                                    AutomationRn2ProbeOptions& options, QString& error)
+{
+    bool sawRate = false;
+    bool sawOutput = false;
+    bool sawBlocks = false;
+    for (const QString& token : optionTokens) {
+        const qsizetype separator = token.indexOf(QLatin1Char('='));
+        if (separator <= 0 || separator != token.lastIndexOf(QLatin1Char('='))) {
+            error = QStringLiteral("RN2 probe options must be key=value tokens");
+            return false;
+        }
+        const QString key = token.left(separator).trimmed().toLower();
+        const QString value = token.mid(separator + 1).trimmed();
+        if (key == QLatin1String("rate")) {
+            if (sawRate) {
+                error = QStringLiteral("RN2 probe option rate may appear only once");
+                return false;
+            }
+            sawRate = true;
+            if (value.compare(QStringLiteral("Legacy24k"), Qt::CaseInsensitive) == 0) {
+                options.rateDomain = RNNoiseFilter::RateDomain::Legacy24k;
+            } else if (value.compare(QStringLiteral("Native48k"), Qt::CaseInsensitive) == 0) {
+                options.rateDomain = RNNoiseFilter::RateDomain::Native48k;
+            } else {
+                error = QStringLiteral("RN2 probe rate must be Legacy24k or Native48k");
+                return false;
+            }
+        } else if (key == QLatin1String("output")) {
+            if (sawOutput) {
+                error = QStringLiteral("RN2 probe option output may appear only once");
+                return false;
+            }
+            sawOutput = true;
+            if (value.compare(QStringLiteral("PreserveRxStereo"), Qt::CaseInsensitive) == 0) {
+                options.outputMode = RNNoiseFilter::OutputMode::PreserveRxStereo;
+            } else if (value.compare(QStringLiteral("ProcessedMono"), Qt::CaseInsensitive) == 0) {
+                options.outputMode = RNNoiseFilter::OutputMode::ProcessedMono;
+            } else {
+                error =
+                    QStringLiteral("RN2 probe output must be PreserveRxStereo or ProcessedMono");
+                return false;
+            }
+        } else if (key == QLatin1String("blocks")) {
+            if (sawBlocks) {
+                error = QStringLiteral("RN2 probe option blocks may appear only once");
+                return false;
+            }
+            sawBlocks = true;
+            const QStringList frameTokens = value.split(QLatin1Char(','), Qt::KeepEmptyParts);
+            if (frameTokens.isEmpty() ||
+                frameTokens.size() > kAutomationRn2ProbeMaxBlockPartitions) {
+                error = QStringLiteral("RN2 probe blocks has an excessive partition count");
+                return false;
+            }
+            options.blockPartitions.clear();
+            for (const QString& frameToken : frameTokens) {
+                bool valid = false;
+                const int frames = frameToken.toInt(&valid);
+                if (!valid || frames <= 0) {
+                    error = QStringLiteral(
+                        "RN2 probe blocks must contain positive, bounded frame counts");
+                    return false;
+                }
+                options.blockPartitions.append(frames);
+            }
+        } else {
+            error = QStringLiteral("unknown RN2 probe option: ") + key;
+            return false;
+        }
+    }
+
+    // A rate token may follow blocks. Re-check once the final rate is known.
+    const int maxFrames = rn2ProbeSampleRate(options.rateDomain) * 3;
+    for (const int frames : options.blockPartitions) {
+        if (frames > maxFrames) {
+            error = QStringLiteral("RN2 probe blocks exceeds the selected three-second input");
+            return false;
+        }
+    }
+    return true;
+}
+
+struct AutomationRn2ProbeRun {
+    QByteArray output;
+    QJsonArray blockResults;
+    int inputCoverageFrames{0};
+    int outputCoverageFrames{0};
+    int firstOutputSizeMismatchBlock{-1};
+    bool outputSizeExact{true};
+};
+
+AutomationRn2ProbeRun runAutomationRn2Probe(RNNoiseFilter& filter, const QByteArray& input,
+                                            const QVector<int>& partitions,
+                                            RNNoiseFilter::RateDomain rateDomain)
+{
+    AutomationRn2ProbeRun run;
+    const int frameBytes = 2 * static_cast<int>(sizeof(float));
+    const int inputFrames = input.size() / frameBytes;
+    run.output.reserve(input.size());
+    int offsetFrames = 0;
+    int partitionIndex = 0;
+    int blockIndex = 0;
+    while (offsetFrames < inputFrames) {
+        const int requestedFrames = partitions.at(partitionIndex);
+        const int blockFrames = std::min(requestedFrames, inputFrames - offsetFrames);
+        const QByteArray block = input.mid(offsetFrames * frameBytes, blockFrames * frameBytes);
+        QByteArray blockOutput;
+        if (rateDomain == RNNoiseFilter::RateDomain::Native48k) {
+            filter.process48kStereo(block, blockOutput);
+        } else {
+            blockOutput = filter.process(block);
+        }
+        const int outputFrames = blockOutput.size() / frameBytes;
+        const bool exact = blockOutput.size() == block.size();
+        if (!exact && run.firstOutputSizeMismatchBlock < 0) {
+            run.firstOutputSizeMismatchBlock = blockIndex;
+        }
+        run.output.append(blockOutput);
+        run.inputCoverageFrames += blockFrames;
+        run.outputCoverageFrames += outputFrames;
+        run.outputSizeExact = run.outputSizeExact && exact;
+        run.blockResults.append(QJsonObject{
+            {QStringLiteral("inputFrames"), blockFrames},
+            {QStringLiteral("inputBytes"), block.size()},
+            {QStringLiteral("outputFrames"), outputFrames},
+            {QStringLiteral("outputBytes"), blockOutput.size()},
+            {QStringLiteral("outputSizeExact"), exact},
+        });
+        offsetFrames += blockFrames;
+        partitionIndex = (partitionIndex + 1) % partitions.size();
+        ++blockIndex;
+    }
+    run.outputSizeExact = run.outputSizeExact && run.output.size() == input.size();
+    return run;
+}
+
+int firstAudibleFrame(const QByteArray& pcm)
+{
+    constexpr float kAudibleEpsilon = 1.0e-7f;
+    const auto* samples = reinterpret_cast<const float*>(pcm.constData());
+    const int frames = pcm.size() / (2 * static_cast<int>(sizeof(float)));
+    for (int frame = 0; frame < frames; ++frame) {
+        if (std::fabs(samples[2 * frame]) > kAudibleEpsilon ||
+            std::fabs(samples[2 * frame + 1]) > kAudibleEpsilon) {
+            return frame;
+        }
+    }
+    return -1;
+}
+
+QJsonObject completedAutomationRn2Probe(const AutomationRn2ProbeOptions& options,
+                                        const QByteArray& input,
+                                        const AutomationRn2ProbeRun& selected,
+                                        const AutomationRn2ProbeRun& reference)
+{
+    constexpr double kMinOutputInputRmsRatio = 0.02;
+    constexpr float kSequenceTolerance = 1.0e-5f;
+    constexpr float kDuplicateTolerance = 1.0e-7f;
+    const int sampleRate = rn2ProbeSampleRate(options.rateDomain);
+    const int discardFrames = sampleRate + sampleRate / 2;
+    const QJsonObject inputRms = stereoRmsRatio(input, discardFrames);
+    const QJsonObject outputRms = stereoRmsRatio(selected.output, discardFrames);
+    const double inputRatio = inputRms.value(QStringLiteral("ratio")).toDouble();
+    const double outputRatio = outputRms.value(QStringLiteral("ratio")).toDouble();
+    const double ratioError = std::fabs(outputRatio - inputRatio);
+    const double leftLevelRatio =
+        outputRms.value(QStringLiteral("leftRms")).toDouble() /
+        std::max(inputRms.value(QStringLiteral("leftRms")).toDouble(), 1.0e-12);
+    const double rightLevelRatio =
+        outputRms.value(QStringLiteral("rightRms")).toDouble() /
+        std::max(inputRms.value(QStringLiteral("rightRms")).toDouble(), 1.0e-12);
+    const bool audible =
+        leftLevelRatio >= kMinOutputInputRmsRatio && rightLevelRatio >= kMinOutputInputRmsRatio;
+    const bool ratioPreserved = ratioError < 0.08 && audible;
+    const int selectedFirstAudible = firstAudibleFrame(selected.output);
+    const int referenceFirstAudible = firstAudibleFrame(reference.output);
+
+    const int selectedFrames = selected.output.size() / (2 * static_cast<int>(sizeof(float)));
+    const int referenceFrames = reference.output.size() / (2 * static_cast<int>(sizeof(float)));
+    int comparisonFrames = 0;
+    int firstSequenceMismatchFrame = -1;
+    int firstSequenceMismatchChannel = -1;
+    float maxSequenceError = -1.0f;
+    if (selectedFirstAudible >= 0 && referenceFirstAudible >= 0) {
+        comparisonFrames = std::min({sampleRate, selectedFrames - selectedFirstAudible,
+                                     referenceFrames - referenceFirstAudible});
+        maxSequenceError = 0.0f;
+        const auto* selectedSamples = reinterpret_cast<const float*>(selected.output.constData());
+        const auto* referenceSamples = reinterpret_cast<const float*>(reference.output.constData());
+        for (int frame = 0; frame < comparisonFrames; ++frame) {
+            for (int channel = 0; channel < 2; ++channel) {
+                const float error = std::fabs(
+                    selectedSamples[2 * (selectedFirstAudible + frame) + channel] -
+                    referenceSamples[2 * (referenceFirstAudible + frame) + channel]);
+                maxSequenceError = std::max(maxSequenceError, error);
+                if (error > kSequenceTolerance && firstSequenceMismatchFrame < 0) {
+                    firstSequenceMismatchFrame = frame;
+                    firstSequenceMismatchChannel = channel;
+                }
+            }
+        }
+    }
+    const bool sequenceEquivalent =
+        comparisonFrames == sampleRate && maxSequenceError <= kSequenceTolerance;
+    const bool startupLatencyMeasured =
+        selectedFirstAudible >= 0 && referenceFirstAudible >= 0;
+    const int startupLatencyDeltaFrames = startupLatencyMeasured
+        ? selectedFirstAudible - referenceFirstAudible
+        : -1;
+    const bool startupLatencyEquivalent =
+        startupLatencyMeasured && startupLatencyDeltaFrames == 0;
+    const bool fifoOrderPreserved = sequenceEquivalent;
+    const bool fifoSequenceEquivalent =
+        fifoOrderPreserved && startupLatencyEquivalent;
+
+    float leftRightMaxDelta = 0.0f;
+    const auto* outputSamples = reinterpret_cast<const float*>(selected.output.constData());
+    for (int frame = 0; frame < selectedFrames; ++frame) {
+        leftRightMaxDelta = std::max(
+            leftRightMaxDelta, std::fabs(outputSamples[2 * frame] - outputSamples[2 * frame + 1]));
+    }
+    const bool duplicated = leftRightMaxDelta <= kDuplicateTolerance;
+    const bool preserveRxStereo = options.outputMode == RNNoiseFilter::OutputMode::PreserveRxStereo;
+    const bool inputCoverageComplete =
+        selected.inputCoverageFrames == input.size() / (2 * static_cast<int>(sizeof(float)));
+    const bool outputCoverageComplete =
+        selected.outputCoverageFrames == input.size() / (2 * static_cast<int>(sizeof(float)));
+    const bool ok = preserveRxStereo
+                        ? audible && inputCoverageComplete && outputCoverageComplete &&
+                              selected.outputSizeExact && ratioPreserved &&
+                              startupLatencyMeasured && fifoOrderPreserved
+                        : audible && inputCoverageComplete && outputCoverageComplete &&
+                              selected.outputSizeExact && duplicated && startupLatencyMeasured &&
+                              fifoOrderPreserved;
+
+    QJsonArray partitions;
+    for (const int frames : options.blockPartitions) {
+        partitions.append(frames);
+    }
+    return QJsonObject{
+        {QStringLiteral("ok"), ok},
+        {QStringLiteral("mode"), QStringLiteral("RN2")},
+        {QStringLiteral("available"), true},
+        {QStringLiteral("skipped"), false},
+        {QStringLiteral("tested"), true},
+        {QStringLiteral("frames"), selectedFrames},
+        {QStringLiteral("discardFrames"), discardFrames},
+        {QStringLiteral("input"), inputRms},
+        {QStringLiteral("output"), outputRms},
+        {QStringLiteral("ratioError"), ratioError},
+        {QStringLiteral("leftLevelRatio"), leftLevelRatio},
+        {QStringLiteral("rightLevelRatio"), rightLevelRatio},
+        {QStringLiteral("minimumLevelRatio"), kMinOutputInputRmsRatio},
+        {QStringLiteral("audible"), audible},
+        {QStringLiteral("preserved"), ratioPreserved},
+        {QStringLiteral("ratioPreserved"), ratioPreserved},
+        {QStringLiteral("rateDomain"), rn2ProbeRateDomainName(options.rateDomain)},
+        {QStringLiteral("sampleRate"), sampleRate},
+        {QStringLiteral("outputMode"), rn2ProbeOutputModeName(options.outputMode)},
+        {QStringLiteral("probeDryMix"), kAutomationRn2ProbeDryMix},
+        {QStringLiteral("blockPartitions"), partitions},
+        {QStringLiteral("config"), QJsonObject{
+             {QStringLiteral("rateDomain"), rn2ProbeRateDomainName(options.rateDomain)},
+             {QStringLiteral("sampleRate"), sampleRate},
+             {QStringLiteral("outputMode"), rn2ProbeOutputModeName(options.outputMode)},
+             {QStringLiteral("blockPartitions"), partitions},
+         }},
+        {QStringLiteral("referenceBlockFrames"),
+         options.rateDomain == RNNoiseFilter::RateDomain::Native48k ? 480 : 960},
+        {QStringLiteral("inputFrames"),
+         input.size() / (2 * static_cast<int>(sizeof(float)))},
+        {QStringLiteral("inputBytes"), input.size()},
+        {QStringLiteral("outputFrames"), selectedFrames},
+        {QStringLiteral("outputBytes"), selected.output.size()},
+        {QStringLiteral("inputCoverage"), QJsonObject{
+             {QStringLiteral("frames"), selected.inputCoverageFrames},
+             {QStringLiteral("bytes"),
+              selected.inputCoverageFrames * 2 * static_cast<int>(sizeof(float))},
+             {QStringLiteral("complete"), inputCoverageComplete},
+         }},
+        {QStringLiteral("outputCoverage"), QJsonObject{
+             {QStringLiteral("frames"), selected.outputCoverageFrames},
+             {QStringLiteral("bytes"),
+              selected.outputCoverageFrames * 2 * static_cast<int>(sizeof(float))},
+             {QStringLiteral("complete"), outputCoverageComplete},
+         }},
+        {QStringLiteral("outputSizeExact"), selected.outputSizeExact},
+        {QStringLiteral("firstOutputSizeMismatchBlock"),
+         selected.firstOutputSizeMismatchBlock},
+        {QStringLiteral("inputCoverageComplete"), inputCoverageComplete},
+        {QStringLiteral("outputCoverageComplete"), outputCoverageComplete},
+        {QStringLiteral("inputCoverageFrames"), selected.inputCoverageFrames},
+        {QStringLiteral("inputCoverageBytes"),
+         selected.inputCoverageFrames * 2 * static_cast<int>(sizeof(float))},
+        {QStringLiteral("outputCoverageFrames"), selected.outputCoverageFrames},
+        {QStringLiteral("outputCoverageBytes"),
+         selected.outputCoverageFrames * 2 * static_cast<int>(sizeof(float))},
+        {QStringLiteral("blockOutput"), selected.blockResults},
+        {QStringLiteral("firstAudibleFrame"), selectedFirstAudible},
+        {QStringLiteral("firstAudibleMs"),
+         selectedFirstAudible < 0 ? -1.0
+                                  : 1000.0 * selectedFirstAudible / sampleRate},
+        {QStringLiteral("referenceFirstAudibleFrame"), referenceFirstAudible},
+        {QStringLiteral("referenceFirstAudibleMs"),
+         referenceFirstAudible < 0 ? -1.0
+                                   : 1000.0 * referenceFirstAudible / sampleRate},
+        {QStringLiteral("startupLatencyMeasured"), startupLatencyMeasured},
+        {QStringLiteral("startupLatencyDeltaFrames"), startupLatencyDeltaFrames},
+        {QStringLiteral("startupLatencyDeltaMs"),
+         startupLatencyMeasured
+             ? 1000.0 * startupLatencyDeltaFrames / sampleRate
+             : -1.0},
+        {QStringLiteral("startupLatencyEquivalent"), startupLatencyEquivalent},
+        {QStringLiteral("sequenceComparisonFrames"), comparisonFrames},
+        {QStringLiteral("sequenceComparisonCount"), comparisonFrames},
+        {QStringLiteral("sequenceMaxError"), maxSequenceError},
+        {QStringLiteral("sequenceFirstMismatchFrame"), firstSequenceMismatchFrame},
+        {QStringLiteral("sequenceFirstMismatchChannel"), firstSequenceMismatchChannel},
+        {QStringLiteral("sequenceEquivalent"), sequenceEquivalent},
+        {QStringLiteral("sequenceOrder"), QStringLiteral("firstAudibleAligned")},
+        {QStringLiteral("fifoOrderPreserved"), fifoOrderPreserved},
+        {QStringLiteral("fifoSequenceEquivalent"), fifoSequenceEquivalent},
+        {QStringLiteral("leftRightMaxDelta"), leftRightMaxDelta},
+        {QStringLiteral("duplicated"), duplicated},
+    };
 }
 
 QJsonObject stereoRmsRatio(const QByteArray& pcm, int startFrame)
@@ -3064,16 +3456,16 @@ QJsonObject AudioEngine::automationDspStereoProbe(const QString& mode) const
     }
 
     const QByteArray input = makeAutomationDspStereoProbeInput();
-    QString tokenText = mode.trimmed();
-    tokenText.replace(QLatin1Char(','), QLatin1Char(' '));
-    const QStringList requestTokens =
-        tokenText.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+    const QStringList requestTokens = automationDspProbeTokens(mode.trimmed());
     QStringList modeTokens;
+    QStringList rn2OptionTokens;
     bool strictCoverage = false;
     for (const QString& token : requestTokens) {
         const QString normalizedToken = token.toUpper();
         if (normalizedToken == QLatin1String("STRICT")) {
             strictCoverage = true;
+        } else if (token.contains(QLatin1Char('='))) {
+            rn2OptionTokens.append(token);
         } else {
             modeTokens.append(normalizedToken);
         }
@@ -3088,8 +3480,24 @@ QJsonObject AudioEngine::automationDspStereoProbe(const QString& mode) const
     const QString normalizedMode = modeTokens.isEmpty()
         ? QStringLiteral("ALL")
         : modeTokens.constFirst();
+    if (!rn2OptionTokens.isEmpty() && normalizedMode != QLatin1String("RN2")) {
+        return QJsonObject{
+            {QStringLiteral("ok"), false},
+            {QStringLiteral("error"),
+             QStringLiteral("RN2 probe options require probeDspStereo RN2")},
+        };
+    }
+    AutomationRn2ProbeOptions rn2Options;
+    QString rn2OptionError;
+    if (normalizedMode == QLatin1String("RN2") &&
+        !parseAutomationRn2ProbeOptions(rn2OptionTokens, rn2Options, rn2OptionError)) {
+        return QJsonObject{
+            {QStringLiteral("ok"), false},
+            {QStringLiteral("error"), rn2OptionError},
+        };
+    }
 
-    const auto probeOne = [this, &input](const QString& requestedMode) -> QJsonObject {
+    const auto probeOne = [this, &input, &rn2Options](const QString& requestedMode) -> QJsonObject {
         if (requestedMode == QLatin1String("NR2")) {
             std::unique_ptr<SpectralNR> nr2 = createNr2Filter(
                 QStringLiteral("automation probe"));
@@ -3113,8 +3521,11 @@ QJsonObject AudioEngine::automationDspStereoProbe(const QString& mode) const
         }
 
         if (requestedMode == QLatin1String("RN2")) {
-            RNNoiseFilter rn2;
+            const int sampleRate = rn2ProbeSampleRate(rn2Options.rateDomain);
+            const QByteArray rn2Input = makeAutomationDspStereoProbeInput(sampleRate);
+            RNNoiseFilter rn2(rn2Options.outputMode, rn2Options.rateDomain);
             applyRn2Settings(rn2);
+            rn2.setDryMix(kAutomationRn2ProbeDryMix);
             if (!rn2.isValid()) {
                 return QJsonObject{
                     {QStringLiteral("ok"), false},
@@ -3124,9 +3535,27 @@ QJsonObject AudioEngine::automationDspStereoProbe(const QString& mode) const
                     {QStringLiteral("error"), QStringLiteral("RN2 initialization failed")},
                 };
             }
-            const QByteArray output = processAutomationDspProbeBlocks(
-                input, [&rn2](const QByteArray& block) { return rn2.process(block); });
-            return completedAutomationDspProbe(requestedMode, input, output);
+            const AutomationRn2ProbeRun selected = runAutomationRn2Probe(
+                rn2, rn2Input, rn2Options.blockPartitions, rn2Options.rateDomain);
+
+            const int referenceBlockFrames =
+                rn2Options.rateDomain == RNNoiseFilter::RateDomain::Native48k ? 480 : 960;
+            RNNoiseFilter reference(rn2Options.outputMode, rn2Options.rateDomain);
+            applyRn2Settings(reference);
+            reference.setDryMix(kAutomationRn2ProbeDryMix);
+            if (!reference.isValid()) {
+                return QJsonObject{
+                    {QStringLiteral("ok"), false},
+                    {QStringLiteral("mode"), requestedMode},
+                    {QStringLiteral("available"), false},
+                    {QStringLiteral("skipped"), false},
+                    {QStringLiteral("error"),
+                     QStringLiteral("RN2 aligned-reference initialization failed")},
+                };
+            }
+            const AutomationRn2ProbeRun alignedReference = runAutomationRn2Probe(
+                reference, rn2Input, QVector<int>{referenceBlockFrames}, rn2Options.rateDomain);
+            return completedAutomationRn2Probe(rn2Options, rn2Input, selected, alignedReference);
         }
 
         if (requestedMode == QLatin1String("NR4")) {

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -3249,7 +3249,7 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
             });
 
         add("audioCapture", {},
-            "audioCapture <start|stop|status|read|probeNr2Stereo|probeDspStereo> [args]",
+            "audioCapture <start|stop|status|read|probeNr2Stereo|probeDspStereo> [args] — RN2 probe accepts rate=Legacy24k|Native48k output=PreserveRxStereo|ProcessedMono blocks=<frames,...>",
             parseActionRest,
             [](AutomationServer& s, A& a, QLocalSocket*) {
                 return s.doAudioCapture(a.action.isEmpty() ? QStringLiteral("status")

--- a/tests/automation_rn2_probe_test.cpp
+++ b/tests/automation_rn2_probe_test.cpp
@@ -1,0 +1,189 @@
+// Automation-only RN2 probe contract. This deliberately calls the bridge's
+// private line dispatcher through its existing test friend: the test proves
+// both bare and JSON forwarding without a socket, RadioModel, or TX surface.
+#include "core/AudioEngine.h"
+#include "core/QsoRecorder.h"
+#include "models/RadioModel.h"
+#include "core/AutomationServer.h"
+
+#include <QCoreApplication>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include <cstdio>
+
+namespace AetherSDR {
+
+class AutomationServerTestAccess {
+  public:
+    static QJsonObject handleLine(AutomationServer& server, const QByteArray& line)
+    {
+        return server.handleLine(line, nullptr);
+    }
+};
+
+} // namespace AetherSDR
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* message)
+{
+    if (!condition) {
+        std::fprintf(stderr, "FAIL: %s\n", message);
+        ++failures;
+    }
+}
+
+QJsonObject bare(AetherSDR::AutomationServer& server, const QString& line)
+{
+    return AetherSDR::AutomationServerTestAccess::handleLine(server, line.toUtf8());
+}
+
+QJsonObject json(AetherSDR::AutomationServer& server, const QJsonObject& request)
+{
+    return AetherSDR::AutomationServerTestAccess::handleLine(
+        server, QJsonDocument(request).toJson(QJsonDocument::Compact));
+}
+
+bool hasLegacyStereoFields(const QJsonObject& result)
+{
+    return result.contains(QStringLiteral("frames")) &&
+           result.contains(QStringLiteral("discardFrames")) &&
+           result.contains(QStringLiteral("input")) && result.contains(QStringLiteral("output")) &&
+           result.contains(QStringLiteral("ratioError")) &&
+           result.contains(QStringLiteral("audible")) &&
+           result.contains(QStringLiteral("preserved"));
+}
+
+void checkRn2Contract(const QJsonObject& result, const QString& rateDomain, int sampleRate,
+                      const QString& outputMode, const char* description)
+{
+    check(result.value(QStringLiteral("ok")).toBool(),
+          "RN2 response passes its complete proof contract");
+    check(result.value(QStringLiteral("mode")).toString() == QLatin1String("RN2"), description);
+    check(result.value(QStringLiteral("rateDomain")).toString() == rateDomain,
+          "RN2 response has canonical rate domain");
+    check(result.value(QStringLiteral("sampleRate")).toInt() == sampleRate,
+          "RN2 response has selected sample rate");
+    check(result.value(QStringLiteral("outputMode")).toString() == outputMode,
+          "RN2 response has canonical output mode");
+    check(result.value(QStringLiteral("probeDryMix")).toDouble() == 1.0,
+          "RN2 probe reports its deterministic dry-mix isolation");
+    check(result.value(QStringLiteral("inputFrames")).toInt() == sampleRate * 3,
+          "RN2 input is the deterministic three-second run");
+    check(result.value(QStringLiteral("outputFrames")).toInt() == sampleRate * 3,
+          "RN2 output frame count matches input");
+    check(result.value(QStringLiteral("inputCoverage"))
+              .toObject()
+              .value(QStringLiteral("complete"))
+              .toBool(),
+          "RN2 input coverage is complete");
+    check(result.value(QStringLiteral("outputCoverage"))
+              .toObject()
+              .value(QStringLiteral("complete"))
+              .toBool(),
+          "RN2 output coverage is complete");
+    check(result.value(QStringLiteral("outputSizeExact")).toBool(),
+          "RN2 output size is exact for every partition");
+    check(result.value(QStringLiteral("firstOutputSizeMismatchBlock")).toInt() == -1,
+          "RN2 reports no per-block output-size mismatch");
+    check(result.value(QStringLiteral("firstAudibleFrame")).toInt(-1) >= 0,
+          "RN2 reports selected first audible frame");
+    check(result.value(QStringLiteral("referenceFirstAudibleFrame")).toInt(-1) >= 0,
+          "RN2 reports reference first audible frame");
+    check(result.value(QStringLiteral("sequenceComparisonFrames")).toInt() >= sampleRate,
+          "RN2 compares a substantial aligned sequence window");
+    check(result.value(QStringLiteral("sequenceEquivalent")).toBool(),
+          "RN2 selected partitions match aligned reference");
+    check(result.value(QStringLiteral("sequenceFirstMismatchFrame")).toInt() == -1,
+          "RN2 reports no FIFO sequence mismatch");
+    check(result.value(QStringLiteral("startupLatencyMeasured")).toBool(),
+          "RN2 measures selected and reference startup latency");
+    check(result.value(QStringLiteral("fifoOrderPreserved")).toBool(),
+          "RN2 preserves reference sample order after startup");
+    check(result.value(QStringLiteral("fifoSequenceEquivalent")).toBool() ==
+              (result.value(QStringLiteral("sequenceEquivalent")).toBool() &&
+               result.value(QStringLiteral("startupLatencyEquivalent")).toBool()),
+          "RN2 distinguishes FIFO timing equivalence from aligned sample order");
+    check(result.value(QStringLiteral("sequenceOrder")).toString() ==
+              QLatin1String("firstAudibleAligned"),
+          "RN2 sequence order reports first-audible alignment");
+    check(hasLegacyStereoFields(result), "RN2 retains legacy stereo metrics");
+    check(result.value(QStringLiteral("audible")).toBool(), "RN2 output is audible after startup");
+    if (outputMode == QLatin1String("PreserveRxStereo")) {
+        check(result.value(QStringLiteral("ratioPreserved")).toBool(),
+              "PreserveRxStereo retains the L/R level ratio");
+    } else {
+        check(result.value(QStringLiteral("duplicated")).toBool(),
+              "ProcessedMono duplicates its result to L/R");
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    qputenv("AETHER_AUTOMATION", "1");
+    QCoreApplication app(argc, argv);
+    AetherSDR::AudioEngine engine;
+    AetherSDR::AutomationServer server;
+    server.setAudioEngine(&engine);
+
+    const QJsonObject legacyDefault =
+        bare(server, QStringLiteral("audioCapture probeDspStereo RN2"));
+    checkRn2Contract(legacyDefault, QStringLiteral("Legacy24k"), 24000,
+                     QStringLiteral("PreserveRxStereo"), "bare no-option RN2 probe succeeds");
+    check(legacyDefault.value(QStringLiteral("blockPartitions")).toArray() == QJsonArray{960},
+          "no-option RN2 probe keeps the legacy 960-frame partition");
+
+    const QJsonObject legacyIrregular = bare(
+        server, QStringLiteral("audioCapture probeDspStereo RN2,strict blocks=73,211,17,604,91"));
+    checkRn2Contract(legacyIrregular, QStringLiteral("Legacy24k"), 24000,
+                     QStringLiteral("PreserveRxStereo"), "legacy irregular RN2 probe succeeds");
+    check(legacyIrregular.value(QStringLiteral("strict")).toBool(),
+          "legacy RN2,strict syntax remains accepted");
+
+    const QJsonObject nativePreserve = json(
+        server,
+        QJsonObject{
+            {QStringLiteral("cmd"), QStringLiteral("audioCapture")},
+            {QStringLiteral("action"), QStringLiteral("probeDspStereo")},
+            {QStringLiteral("value"), QStringLiteral("RN2 rate=Native48k output=PreserveRxStereo "
+                                                     "blocks=73,211,17,604,91")},
+        });
+    checkRn2Contract(nativePreserve, QStringLiteral("Native48k"), 48000,
+                     QStringLiteral("PreserveRxStereo"),
+                     "JSON Native48k preserve-stereo probe succeeds");
+    check(nativePreserve.value(QStringLiteral("ratioPreserved")).toBool(),
+          "Native48k preserve-stereo probe retains the L/R ratio");
+
+    const QJsonObject nativeMono =
+        bare(server, QStringLiteral("audioCapture probeDspStereo RN2 rate=Native48k "
+                                    "output=ProcessedMono blocks=73,211,17,604,91"));
+    checkRn2Contract(nativeMono, QStringLiteral("Native48k"), 48000,
+                     QStringLiteral("ProcessedMono"), "Native48k processed-mono probe succeeds");
+    check(nativeMono.value(QStringLiteral("duplicated")).toBool(),
+          "ProcessedMono output is duplicated to L/R");
+
+    const QJsonObject nr2Alias = bare(server, QStringLiteral("audioCapture probeNr2Stereo"));
+    check(nr2Alias.value(QStringLiteral("probe")).toString() == QLatin1String("nr2StereoBalance"),
+          "probeNr2Stereo remains the no-option SpectralNR alias");
+
+    const QJsonObject foreignOption =
+        bare(server, QStringLiteral("audioCapture probeDspStereo all rate=Native48k"));
+    check(!foreignOption.value(QStringLiteral("ok")).toBool(),
+          "RN2-only options are rejected for all");
+    const QJsonObject duplicateOption = bare(
+        server, QStringLiteral("audioCapture probeDspStereo RN2 rate=Legacy24k rate=Native48k"));
+    check(!duplicateOption.value(QStringLiteral("ok")).toBool(),
+          "duplicate RN2 options are rejected");
+    const QJsonObject invalidBlocks =
+        bare(server, QStringLiteral("audioCapture probeDspStereo RN2 blocks=0"));
+    check(!invalidBlocks.value(QStringLiteral("ok")).toBool(),
+          "non-positive RN2 partitions are rejected");
+
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -2997,6 +2997,15 @@ target_link_libraries(automation_tx_watchdog_test PRIVATE
 )
 add_test(NAME automation_tx_watchdog_test COMMAND automation_tx_watchdog_test)
 
+add_executable(automation_rn2_probe_test
+    tests/automation_rn2_probe_test.cpp
+)
+target_include_directories(automation_rn2_probe_test PRIVATE src)
+target_link_libraries(automation_rn2_probe_test PRIVATE
+    aethercore Qt6::Core Qt6::Network
+)
+add_test(NAME automation_rn2_probe_test COMMAND automation_rn2_probe_test)
+
 add_executable(aetherclock_model_test tests/aetherclock_model_test.cpp)
 target_include_directories(aetherclock_model_test PRIVATE src)
 target_link_libraries(aetherclock_model_test PRIVATE aethercore Qt6::Core Qt6::Test)

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -41,6 +41,7 @@ Usage:
     python tools/automation_probe.py panmessage add 0 kiwi 0 "Waiting|Queued"
     python tools/automation_probe.py audioCapture start 3000 raw,post,final
     python tools/automation_probe.py audioCapture probeDspStereo all [strict]  # may take up to 120s
+    python tools/automation_probe.py audioCapture probeDspStereo RN2 rate=Native48k output=ProcessedMono blocks=480,960
     python tools/automation_probe.py audioCapture read /tmp/aether-audio.json
 """
 
@@ -443,6 +444,7 @@ def main():
                "  automation_probe.py audioCapture start 3000 raw,post,final\n"
                "  automation_probe.py audioCapture probeNr2Stereo\n"
                "  automation_probe.py audioCapture probeDspStereo all [strict]  # up to 120s\n"
+               "  automation_probe.py audioCapture probeDspStereo RN2 rate=Native48k output=ProcessedMono blocks=480,960  # up to 120s\n"
                "  automation_probe.py audioCapture read /tmp/aether-audio.json\n"
                "  automation_probe.py grab SpectrumWidget /tmp/pan.png\n"
                "  automation_probe.py grab pan-visible 1 /tmp/pan1-visible.png\n"

--- a/tools/test_automation_probe.py
+++ b/tools/test_automation_probe.py
@@ -31,6 +31,25 @@ def test_memory_mapping():
     }, f"unexpected memory mapping: {request}")
 
 
+def test_audio_capture_mapping():
+    mapper = automation_probe.MAPPERS["audioCapture"]
+    check(mapper([]) == {"action": "status"},
+          "audioCapture defaults to a status request")
+    check(mapper(["probeNr2Stereo"]) == {"action": "probeNr2Stereo"},
+          "legacy probeNr2Stereo stays a no-option action")
+    check(mapper(["probeDspStereo", "all", "strict"]) == {
+        "action": "probeDspStereo", "value": "all strict",
+    }, "legacy all strict probe forwards unchanged")
+    check(mapper(["probeDspStereo", "RN2", "rate=Native48k",
+                  "output=ProcessedMono", "blocks=480,960"]) == {
+        "action": "probeDspStereo",
+        "value": "RN2 rate=Native48k output=ProcessedMono blocks=480,960",
+    }, "RN2 key=value options forward unchanged")
+    check(mapper(["read", "/tmp/aether-audio.json"]) == {
+        "action": "read", "path": "/tmp/aether-audio.json",
+    }, "audioCapture read retains its JSON path field")
+
+
 def test_token_attachment():
     captured = {}
     bridge = automation_probe.Bridge.__new__(automation_probe.Bridge)
@@ -59,5 +78,6 @@ def test_token_attachment():
 if __name__ == "__main__":
     test_drag_at_mapping()
     test_memory_mapping()
+    test_audio_capture_mapping()
     test_token_attachment()
     print("automation probe request-mapping checks passed")


### PR DESCRIPTION
## Summary

Fixes #5042.

Extends the automation-only RN2 stereo probe with case-insensitive `rate=`,
`output=`, and deterministic cyclic `blocks=` options. The response now carries
machine-checkable input/output coverage, per-block sizing, first-audible and
reference latency, stereo-ratio or mono-duplication results, and aligned FIFO
order/sequence diagnostics.

The existing no-option `probeDspStereo RN2` defaults and response fields remain,
and `probeNr2Stereo` remains the legacy SpectralNR/NR2 alias rather than being
silently repurposed as RNNoise. The two temporary proof filters use a reported
`probeDryMix=1.0` so the synthetic proof isolates RNNoise's frame, resampler,
accumulator, mode, and FIFO contracts from speech classification and user
settings. Production RNNoise behavior, routing, settings, and TX state are
unchanged.

Related: #5013 and #5039. This is a separate bridge-only follow-up based on
current `main`, which now includes #5039.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The new modes are tested through the
real automation command dispatcher and proven again through the freshly built
agent automation bridge.

## Test plan

- [x] macOS ARM64 app and focused targets build with the repository ARM64
      toolchain; app and test binary are Mach-O arm64
- [x] `ctest --test-dir build-codex-arm64 --output-on-failure -R '^(automation_rn2_probe_test|rnnoise_filter_test|tx_voice_processor_test|automation_probe_field_mapping|bridge_docs_check)$'` — 5/5 passed
- [x] `python3 tools/check_engine_boundary.py --strict` — 0 blockers
- [x] `python3 tools/check_test_registration.py --strict`
- [x] `python3 tools/gen_bridge_docs.py --check`
- [x] `git diff --check`
- [x] Fresh agent automation bridge proof with `txAllowed=false`, no connected
      radio, and final `transmitting=false`
- [x] Real-radio behavior is not applicable: the probe is deliberately
      synthetic, local, and RX-safe

### Agent automation bridge proof

All three commands used `blocks=73,211,17,604,91` and returned `ok=true`,
complete input/output coverage, exact per-call and aggregate sizes,
`firstOutputSizeMismatchBlock=-1`, `sequenceMaxError=0`,
`sequenceFirstMismatchFrame=-1`, and `fifoOrderPreserved=true`.

```text
python3 tools/automation_probe.py audioCapture probeDspStereo RN2 rate=Legacy24k output=PreserveRxStereo blocks=73,211,17,604,91
```

- 72,000 input/output frames (576,000 bytes), ratio preserved with error 0
- first audible 4,249 frames / 177.042 ms; fixed reference 3,572 / 148.833 ms
- measured partition latency delta 677 frames / 28.208 ms

```text
python3 tools/automation_probe.py audioCapture probeDspStereo RN2 rate=Native48k output=PreserveRxStereo blocks=73,211,17,604,91
```

- 144,000 input/output frames (1,152,000 bytes), ratio preserved with error 0
- first audible 1,866 frames / 38.875 ms; fixed reference 961 / 20.021 ms
- measured partition latency delta 905 frames / 18.854 ms

```text
python3 tools/automation_probe.py audioCapture probeDspStereo RN2 rate=Native48k output=ProcessedMono blocks=73,211,17,604,91
```

- 144,000 input/output frames (1,152,000 bytes)
- L/R duplicated exactly (`leftRightMaxDelta=0`)
- same measured 905-frame / 18.854-ms partition latency delta

The irregular calls intentionally demonstrate that aligned payload order is
identical while startup position differs from the fixed-block reference, so
`fifoSequenceEquivalent=false` and `startupLatencyEquivalent=false` are honest
rather than silently aligning that timing difference away.

### Remaining honest gap

The private one-shot resampler-divergence warning latch is not exposed through
the bridge. Matched private resamplers cannot be induced to diverge through the
public API, and adding a fault-injection seam would be disproportionate and
invasive. #5039 supplies the reset re-arm behavior; this PR does not manufacture
a false warning-path proof or modify `RNNoiseFilter`.

## Checklist

- [x] Commit is signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room
- [x] No meter UI changes
- [x] Protocol/CLI documentation updated; `CHANGELOG.md` untouched
- [x] No security-sensitive changes

---

🤖 Generated with [OpenAI Codex](https://openai.com/codex/)
