### PR TITLE
fix(test): make Icom CI-V trace assertion scheduler-safe

### DIFF
--- a/tests/icom_backend_test.cpp
+++ b/tests/icom_backend_test.cpp
@@ -1136,7 +1136,10 @@ int main(int argc, char** argv)
         backend.setSliceAudioGain(0, 42);
         QTest::qWait(120);
         {
-            const QString line = lastLineStartingWith(QStringLiteral("TX -> fe fe"));
+            // The scheduler keeps draining unrelated commands during the wait,
+            // so select the AF-gain frame rather than whichever TX happened last.
+            const QString line =
+                lastLineStartingWith(QStringLiteral("TX -> fe fe a4 e0 14 01"));
             check(!line.isNull(), "the outbound frame reaches the CI-V trace");
             check(line.contains(QStringLiteral("cmd=14")) && line.contains(QStringLiteral("sub=01")),
                   "a TX frame still decodes from index 4/5, past the envelope");


### PR DESCRIPTION
## Summary

- make the existing Icom CI-V TX trace assertion select the intended `14 01` AF-gain command
- leave all production CI-V protocol and logging behavior unchanged
- repair the Linux PR gate regression introduced by #4965 and exposed on #5043

## Root cause

The test cleared its captured log, queued an AF-gain command, waited 120 ms, and then selected the most recent line beginning with the generic `TX -> fe fe` prefix. The asynchronous scheduler continued draining commands during that wait, so the correctly decoded `cmd=14 sub=01` line was followed by an unrelated `cmd=16 sub=48` line. The assertion inspected that later frame and failed even though the production decoder output was correct.

This change narrows the raw-frame prefix to the intended `14 01` command before checking its decoded tags.

## CI impact

No tests, workflow steps, waits, or repetitions are added. The existing Linux-only Icom group remains unchanged at about 20.7 seconds per PR; macOS and Windows do not run this group.

## Validation

- configured successfully with CMake
- built the four existing Icom CI targets with 8 cores
- ran the exact Linux CI group three consecutive times with `--repeat until-fail:3`: all four tests passed on every run
- `git diff --check` passed
- the full local macOS build reached the modified test and then stopped at the existing `iconutil` `Invalid Iconset` packaging failure; no application code is changed here

The agent automation bridge and screenshots are not applicable to this test-only change. No new automation verbs are warranted.
