### PR TITLE
fix(midi): let the app's own Pitch Bend export re-import

### DIFF
--- a/src/core/MidiSettings.cpp
+++ b/src/core/MidiSettings.cpp
@@ -384,21 +384,26 @@ QVector<MidiBinding> parseProfileXml(const QByteArray& bytes,
                 << param + QStringLiteral(" (channel \"%1\")").arg(channelAttr.toString());
             continue;
         }
-        // Range-checked for every type, Pitch Bend included. Pitch Bend
-        // ignores `number` at dispatch (key() substitutes 0xFF and
-        // sourceDisplayName() omits it), so an out-of-range value there is
-        // inert rather than dangerous — but storing and re-exporting a number
-        // no MIDI message can carry leaves a file that says something untrue,
-        // and Principle VII asks the boundary to validate ranges, not just
-        // the ranges that currently matter.
+        // Range-checked per type. Pitch Bend's message carries no controller
+        // number: Learn and manual entry store -1 for it and the shared
+        // writer exports that verbatim, so a Pitch Bend row must accept -1
+        // to round-trip the app's own export (#5024). In-range numbers on a
+        // PB row stay accepted as before, but every accepted PB row now
+        // stores -1 — dispatch ignores the number anyway (key() substitutes
+        // 0xFF), and normalizing means the store can never re-export a
+        // number no PB message can carry. Out-of-range values remain named
+        // skips for every type (Principle VII).
         const auto numberAttr = attrs.value("number");
         bool numberOk = true;
-        const int number = numberAttr.isNull() ? 0 : numberAttr.toInt(&numberOk);
-        if (!numberOk || number < 0 || number > 127) {
+        int number = numberAttr.isNull() ? 0 : numberAttr.toInt(&numberOk);
+        const int numberFloor = (type == MidiBinding::PitchBend) ? -1 : 0;
+        if (!numberOk || number < numberFloor || number > 127) {
             result.skippedBadType
                 << param + QStringLiteral(" (number \"%1\")").arg(numberAttr.toString());
             continue;
         }
+        if (type == MidiBinding::PitchBend)
+            number = -1;
 
         if (paramValidator && !paramValidator(param)) {
             result.skippedUnknownParam << param;

--- a/tests/midi_settings_test.cpp
+++ b/tests/midi_settings_test.cpp
@@ -376,6 +376,61 @@ int main(int argc, char** argv)
     ok &= expect(!exportEmpty.ok() && exportEmpty.exportedCount == 0,
                  "exporting an empty binding set is refused, not written as a stub");
 
+    // Pitch Bend round trip (#5024): Learn and manual entry store number = -1
+    // (the PB message carries no controller number) and the writer exports it
+    // verbatim, so the app's own export must come back as a binding, not a
+    // "bad values" skip.
+    {
+        MidiBinding pb;
+        pb.paramId = "rx.afGain";
+        pb.channel = 2;
+        pb.msgType = MidiBinding::PitchBend;
+        pb.number = -1;
+        const auto pbExported = settings.exportProfile(
+            fakeHome.path() + "/pb.xml", QVector<MidiBinding>{pb});
+        ok &= expect(pbExported.ok() && pbExported.exportedCount == 1,
+                     "a learned Pitch Bend binding exports");
+        const auto rPb = settings.importProfile(fakeHome.path() + "/pb.xml", validator);
+        ok &= expect(rPb.ok() && rPb.importedCount == 1
+                         && rPb.skippedBadType.isEmpty(),
+                     "the app's own Pitch Bend export re-imports as a binding");
+        const auto pbStored = settings.loadProfile(rPb.profileName);
+        ok &= expect(pbStored.size() == 1
+                         && pbStored.first().msgType == MidiBinding::PitchBend
+                         && pbStored.first().number == -1
+                         && pbStored.first().channel == 2,
+                     "the round-tripped Pitch Bend keeps number -1 and its channel");
+
+        // A hand-written PB row may omit the meaningless number entirely —
+        // normalize to -1 rather than the other attributes' default of 0.
+        const auto rPbAbsent = settings.importProfile(
+            writeImportFile("pb-absent.xml",
+                            "<MidiProfile>"
+                            "<Binding param=\"rx.afGain\" channel=\"0\" type=\"3\"/>"
+                            "</MidiProfile>\n"),
+            validator);
+        ok &= expect(rPbAbsent.ok() && rPbAbsent.importedCount == 1,
+                     "a Pitch Bend row without a number imports");
+        const auto pbAbsentStored = settings.loadProfile(rPbAbsent.profileName);
+        ok &= expect(pbAbsentStored.size() == 1 && pbAbsentStored.first().number == -1,
+                     "an absent Pitch Bend number normalizes to -1");
+
+        // An in-range number on a hand-written PB row stays accepted (it
+        // always was), but the stored binding normalizes to -1 so the store
+        // can never re-export a number no PB message carries.
+        const auto rPbInRange = settings.importProfile(
+            writeImportFile("pb-inrange.xml",
+                            "<MidiProfile>"
+                            "<Binding param=\"rx.afGain\" channel=\"0\" type=\"3\" number=\"64\"/>"
+                            "</MidiProfile>\n"),
+            validator);
+        ok &= expect(rPbInRange.ok() && rPbInRange.importedCount == 1,
+                     "an in-range Pitch Bend number still imports");
+        const auto pbInRangeStored = settings.loadProfile(rPbInRange.profileName);
+        ok &= expect(pbInRangeStored.size() == 1 && pbInRangeStored.first().number == -1,
+                     "an accepted Pitch Bend row stores number -1, not the file's value");
+    }
+
     // ── Non-regular files: the size cap cannot see them ─────────────────────
     //
     // QFile::size() reports 0 for character devices, FIFOs and most /proc


### PR DESCRIPTION
## Summary

Closes #5024. Learn and manual entry store `number = -1` for Pitch Bend bindings (the PB message carries no controller number) and the shared writer exports it verbatim, but the XML importer's range check rejected `number < 0` for every type — so a profile the app itself exported came back with its PB row as a "bad values" skip. Store-path loads use the lenient reader and were unaffected.

The fix widens the PB row's floor to -1 and normalizes every accepted PB row to -1 on import. In-range numbers on hand-written PB rows stay accepted exactly as before; the normalization means the store can no longer carry (and later re-export) a number no PB message can emit. Out-of-range values remain named skips for every type. The `.map` path has no Pitch Bend rows (C/B keys only) and is untouched.

## Constitution principle honored

Principle VII — Untrusted Input Is Validated At The Boundary: the boundary keeps rejecting values no MIDI message can carry; it just no longer rejects the app's own truthful -1 convention, and it stops admitting untrue numbers into the store by normalizing accepted PB rows.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] `midi_settings_test`: 74/74 — adds the round trip the suite lacked (export a learned-shape PB binding → re-import → binding, not a skip), absent-number normalization, in-range acceptance with stored -1; the existing out-of-range PB skip assertions pass unmodified
- [x] Existing tests pass (CI)

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention) — n/a, no UI change
- [x] Documentation updated if user-visible behavior changed — n/a, fixes the app's own export/import contract; described in Summary
- [x] Security-sensitive changes reference a GHSA if applicable — n/a
