### PR TITLE
feat(icom): transmit-audio taps that bracket the RS-BA1 seam, and the fixes they needed (#5011)

### DIFF
--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -3239,10 +3239,11 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
             });
 
         add("txwave", {},
-            "txwave <arm|save|off> [samples|path] — record the actual SAMPLES "
-            "handed to the radio backend and write them to a WAV. `txaudio` "
-            "gives levels; only the samples show clipping or a preamble that "
-            "never becomes data",
+            "txwave <arm [post|samples]|save <path>|off> — record the actual "
+            "SAMPLES of a transmission to a WAV (feed it to Direwolf's atest). "
+            "`arm` taps submitTxAudio; `arm post` taps AFTER the Icom's "
+            "24k->48k resampler, the last point AE sees its own audio — the two "
+            "bracket the client half of the transmit path",
             parseActionRest,
             [](AutomationServer& s, A& a, QLocalSocket*) {
                 return s.doTxWave(a.action, a.value);
@@ -6461,19 +6462,30 @@ QJsonObject AutomationServer::doTxWave(const QString& action, const QString& res
     const QString a = action.trimmed().toLower();
 
     if (a == QLatin1String("arm")) {
+        // `txwave arm post` captures AFTER the Icom's 24k->48k resampler — the
+        // LAST point AE sees its own audio — instead of at submitTxAudio. The
+        // two bracket the client half of the transmit path: atest decodes the
+        // pre-resample capture perfectly while the same transmission off the
+        // air decodes nowhere, so which side stays decodable localises it.
+        const QString arg = rest.trimmed().toLower();
+        const bool post = arg.startsWith(QLatin1String("post"));
         bool ok = false;
-        const int req = rest.trimmed().toInt(&ok);
+        const int req = post ? 0 : arg.toInt(&ok);
+        m_radioModel->setTxPostResampleTapEnabled(post);
         m_radioModel->setTxAudioRecordEnabled(true, ok ? req : 0);
         // Arm the level tap too, so a run reports both without a second verb.
         m_radioModel->setTxAudioTapEnabled(true);
         return QJsonObject{
             {QStringLiteral("ok"), true},
             {QStringLiteral("txwave"), QStringLiteral("armed")},
+            {QStringLiteral("tap"), post ? QStringLiteral("post-resample")
+                                         : QStringLiteral("submitTxAudio")},
         };
     }
 
     if (a == QLatin1String("off")) {
         m_radioModel->setTxAudioRecordEnabled(false);
+        m_radioModel->setTxPostResampleTapEnabled(false);
         return QJsonObject{
             {QStringLiteral("ok"), true},
             {QStringLiteral("txwave"), QStringLiteral("off")},

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -10,6 +10,7 @@
 #include "NvidiaBnrSettings.h"   // BNR intensity (in-process AFX, #3902)
 #include "ClientTxTestTone.h"     // testtone() verb — client-side TX test tone
 #include "QsoRecorder.h"          // record() verb — Client-Side QSO recorder
+#include "ClientPuduMonitor.h"    // txmonitor() verb — post-final-limiter TX tap
 #include "CallsignLookupService.h" // qrz() verb — QRZ lookup cache/service
 #include "CallsignUtils.h"
 #include "models/Nr2SettingsModel.h"
@@ -3228,6 +3229,34 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
                 return s.doRecord(a.action, a.value);
             });
 
+        add("txaudio", {},
+            "txaudio <on|off|status> — summarise the audio handed to the RADIO "
+            "BACKEND (peak/RMS/blocks), on every backend. Unlike txmonitor this "
+            "sits on the path modem TX audio actually takes",
+            parseActionOnly,
+            [](AutomationServer& s, A& a, QLocalSocket*) {
+                return s.doTxAudioTap(a.action);
+            });
+
+        add("txwave", {},
+            "txwave <arm|save|off> [samples|path] — record the actual SAMPLES "
+            "handed to the radio backend and write them to a WAV. `txaudio` "
+            "gives levels; only the samples show clipping or a preamble that "
+            "never becomes data",
+            parseActionRest,
+            [](AutomationServer& s, A& a, QLocalSocket*) {
+                return s.doTxWave(a.action, a.value);
+            });
+
+        add("txmonitor", {},
+            "txmonitor <start|stop|status> — capture the post-final-limiter TX "
+            "stream (what the radio is TOLD to transmit) to a WAV; pairs with "
+            "`modem txprobe` (what the modulator BUILT) to bracket the seam",
+            parseActionOnly,
+            [](AutomationServer& s, A& a, QLocalSocket*) {
+                return s.doTxMonitor(a.action);
+            });
+
         add("testtone", {}, "testtone <on|off> [freqHz levelDb]",
             parseActionRest,
             [](AutomationServer& s, A& a, QLocalSocket*) {
@@ -4522,6 +4551,11 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
 void AutomationServer::setClockModel(AetherClockModel* model)
 {
     m_clockModel = model;
+}
+
+void AutomationServer::setTxFinalMonitor(ClientPuduMonitor* mon)
+{
+    m_txFinalMonitor = mon;
 }
 
 namespace {
@@ -6365,6 +6399,243 @@ QJsonObject AutomationServer::doRecord(const QString& action, const QString& val
         };
     }
     return err(QStringLiteral("record: unknown action '%1' (start|stop|status|path|dir)")
+                   .arg(action));
+}
+
+QJsonObject AutomationServer::doTxAudioTap(const QString& action)
+{
+    // txaudio on|off|status — summarise what the BACKEND WAS GIVEN.
+    //
+    // This is the probe `txmonitor` should have been for modem transmit audio.
+    // ClientPuduMonitor taps the VOICE channel strip: on 2026-08-13 an AX.25
+    // transmission that decoded correctly at the far end produced an entirely
+    // silent Pudu capture, because modem audio never traverses that strip. This
+    // tap sits on RadioModel::submitTxAudio(), the single funnel every backend
+    // shares, so it sees the audio on both the host-modulating (HL2) and seam
+    // (Icom) paths.
+    //
+    // `on` resets the accumulator, so a run is: txaudio on -> transmit ->
+    // txaudio status. Not TX-gated: it observes, it never keys.
+    if (!m_radioModel)
+        return err(QStringLiteral("no radio model available"));
+
+    const QString a = action.trimmed().toLower();
+
+    if (a == QLatin1String("on") || a == QLatin1String("off")) {
+        m_radioModel->setTxAudioTapEnabled(a == QLatin1String("on"));
+        QJsonObject reply = m_radioModel->txAudioTapSnapshot();
+        reply.insert(QStringLiteral("ok"), true);
+        reply.insert(QStringLiteral("txaudio"), a);
+        return reply;
+    }
+
+    if (a.isEmpty() || a == QLatin1String("status")) {
+        QJsonObject reply = m_radioModel->txAudioTapSnapshot();
+        reply.insert(QStringLiteral("ok"), true);
+        reply.insert(QStringLiteral("txaudio"), QStringLiteral("status"));
+        return reply;
+    }
+
+    return err(QStringLiteral("txaudio: unknown action '%1' (on|off|status)").arg(action));
+}
+
+QJsonObject AutomationServer::doTxWave(const QString& action, const QString& rest)
+{
+    // txwave arm|save|off — record the actual SAMPLES handed to the backend.
+    //
+    // `txaudio` reports peak/RMS, and that is precisely why it could not answer
+    // the question that mattered on 2026-08-14: it read a healthy −9.1 dBFS for
+    // a transmission whose waterfall was a harmonic comb with no decodable frame
+    // in it. A level is an average; clipping and a preamble that never becomes
+    // data are both shapes. Only the samples show a shape.
+    //
+    // Usage: txwave arm -> transmit -> txwave save <path>. Recording the FIRST
+    // samples of the burst is deliberate — the preamble-to-data transition is at
+    // the start, and that transition is what is under test.
+    //
+    // Not TX-gated: it observes a transmission the operator has already caused
+    // and keys nothing itself.
+    if (!m_radioModel)
+        return err(QStringLiteral("no radio model available"));
+
+    const QString a = action.trimmed().toLower();
+
+    if (a == QLatin1String("arm")) {
+        bool ok = false;
+        const int req = rest.trimmed().toInt(&ok);
+        m_radioModel->setTxAudioRecordEnabled(true, ok ? req : 0);
+        // Arm the level tap too, so a run reports both without a second verb.
+        m_radioModel->setTxAudioTapEnabled(true);
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("txwave"), QStringLiteral("armed")},
+        };
+    }
+
+    if (a == QLatin1String("off")) {
+        m_radioModel->setTxAudioRecordEnabled(false);
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("txwave"), QStringLiteral("off")},
+        };
+    }
+
+    if (a == QLatin1String("save")) {
+        const QString path = rest.trimmed();
+        if (path.isEmpty())
+            return err(QStringLiteral("txwave save: a file path is required"));
+
+        int rate = 0;
+        const QVector<qint16> pcm = m_radioModel->takeTxAudioRecording(&rate);
+        if (pcm.isEmpty())
+            return err(QStringLiteral("txwave save: nothing recorded (arm before transmitting?)"));
+        if (rate <= 0)
+            rate = 48000;
+
+        // Stereo int16 WAV. The tap carries interleaved stereo, so write it as
+        // such rather than guessing which channel to keep — if the two channels
+        // ever differ, that is itself a finding.
+        QFile f(path);
+        if (!f.open(QIODevice::WriteOnly))
+            return err(QStringLiteral("txwave save: cannot open '%1'").arg(path));
+
+        const quint32 dataBytes = quint32(pcm.size()) * 2u;
+        const quint16 channels = 2;
+        const quint32 byteRate = quint32(rate) * channels * 2u;
+
+        QByteArray hdr;
+        const auto u32 = [&hdr](quint32 v) {
+            hdr.append(char(v & 0xff));
+            hdr.append(char((v >> 8) & 0xff));
+            hdr.append(char((v >> 16) & 0xff));
+            hdr.append(char((v >> 24) & 0xff));
+        };
+        const auto u16 = [&hdr](quint16 v) {
+            hdr.append(char(v & 0xff));
+            hdr.append(char((v >> 8) & 0xff));
+        };
+        hdr.append("RIFF", 4);
+        u32(36u + dataBytes);
+        hdr.append("WAVE", 4);
+        hdr.append("fmt ", 4);
+        u32(16);            // PCM chunk size
+        u16(1);             // format = PCM
+        u16(channels);
+        u32(quint32(rate));
+        u32(byteRate);
+        u16(quint16(channels * 2));  // block align
+        u16(16);                     // bits per sample
+        hdr.append("data", 4);
+        u32(dataBytes);
+        f.write(hdr);
+        f.write(reinterpret_cast<const char*>(pcm.constData()), qint64(dataBytes));
+        f.close();
+
+        m_radioModel->setTxAudioRecordEnabled(false);
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("txwave"), QStringLiteral("saved")},
+            {QStringLiteral("path"), path},
+            {QStringLiteral("samples"), pcm.size()},
+            {QStringLiteral("frames"), pcm.size() / 2},
+            {QStringLiteral("sampleRate"), rate},
+            {QStringLiteral("seconds"),
+             std::round(double(pcm.size() / 2) / double(rate) * 1000.0) / 1000.0},
+        };
+    }
+
+    return err(QStringLiteral("txwave: unknown action '%1' (arm|save|off)").arg(action));
+}
+
+QJsonObject AutomationServer::doTxMonitor(const QString& action)
+{
+    // txmonitor start|stop|status — capture the POST-FINAL-LIMITER transmit
+    // stream: the exact int16 bytes that get packetised into VITA-49, i.e. what
+    // the radio is TOLD to transmit.
+    //
+    // Why this is not the `record` verb: that one drives the QSO recorder, which
+    // captures RECEIVE audio. Between them they bracket the seam — `txprobe`
+    // reports what the modulator BUILT, this reports what was SENT, and `record`
+    // reports what came back. A fault that lives between "built" and "sent" is
+    // invisible to the other two, and that is exactly the gap this closes:
+    // 2026-08-13, an AX.25 transmit whose modulator output measured clean at
+    // −9.1 dBFS was audibly wrong on the air, with no instrument able to see
+    // which side of the seam corrupted it.
+    //
+    // Not TX-gated: it only observes a transmission the operator has already
+    // caused, and keys nothing itself. Gating an observer behind the permission
+    // whose effects it observes would make the failure it exists for unreachable.
+    if (!m_txFinalMonitor)
+        return err(QStringLiteral("TX monitor unavailable (no main window registered it)"));
+
+    const QString a = action.trimmed().toLower();
+
+    if (a.isEmpty() || a == QLatin1String("status")) {
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("txmonitor"), QStringLiteral("status")},
+            {QStringLiteral("recording"), m_txFinalMonitor->isRecording()},
+            {QStringLiteral("hasRecording"), m_txFinalMonitor->hasRecording()},
+            {QStringLiteral("recordedMs"), m_txFinalMonitor->recordedMs()},
+            {QStringLiteral("sampleRate"), ClientPuduMonitor::kSampleRate},
+            {QStringLiteral("channels"), ClientPuduMonitor::kChannels},
+            {QStringLiteral("maxSeconds"), ClientPuduMonitor::kMaxSeconds},
+        };
+    }
+
+    if (a == QLatin1String("start")) {
+        // Report the pre-existing state rather than stamping "started" onto a
+        // capture already in flight — startRecording() is a no-op then, and a
+        // reply that claimed otherwise would describe a recording that never began.
+        const bool was = m_txFinalMonitor->isRecording();
+        // Lambda form, not invokeMethod-by-name: startRecording() is a plain
+        // public method, not a slot, so a string lookup would fail at RUNTIME
+        // with only a warning — the verb would report ok while recording nothing.
+        //
+        // QUEUED, NOT BLOCKING. BlockingQueuedConnection waits forever if the GUI
+        // thread is stuck, and a bridge verb that can hang the whole app is worse
+        // than one that is slightly racy: observed 2026-08-13, an IC-9700 locked
+        // up mid-transmit, the GUI thread stopped servicing its event loop, and
+        // this call took the bridge — and every other verb, including the unkey
+        // path — down with it while the radio was KEYED. An observer must never
+        // be able to do that.
+        if (!was) {
+            QMetaObject::invokeMethod(m_txFinalMonitor,
+                                      [m = m_txFinalMonitor] { if (m) m->startRecording(); },
+                                      Qt::QueuedConnection);
+        }
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("txmonitor"), QStringLiteral("start")},
+            {QStringLiteral("alreadyRecording"), was},
+            {QStringLiteral("recording"), m_txFinalMonitor->isRecording()},
+        };
+    }
+
+    if (a == QLatin1String("stop")) {
+        const bool was = m_txFinalMonitor->isRecording();
+        // Queued for the same reason as start — see the note there. The reply's
+        // recordedMs/hasRecording are therefore read BEFORE the stop lands, so
+        // they describe the capture in flight; the WAV is written by the queued
+        // call moments later. Poll `txmonitor status` if you need the final size.
+        if (was) {
+            QMetaObject::invokeMethod(m_txFinalMonitor,
+                                      [m = m_txFinalMonitor] { if (m) m->stopRecording(); },
+                                      Qt::QueuedConnection);
+        }
+        // stopRecording() writes the WAV; name it so a caller can go and measure
+        // the samples instead of trusting a level readout.
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("txmonitor"), QStringLiteral("stop")},
+            {QStringLiteral("wasRecording"), was},
+            {QStringLiteral("recordedMs"), m_txFinalMonitor->recordedMs()},
+            {QStringLiteral("hasRecording"), m_txFinalMonitor->hasRecording()},
+            {QStringLiteral("path"), QDir::temp().filePath(QStringLiteral("pudu_monitor.wav"))},
+        };
+    }
+
+    return err(QStringLiteral("txmonitor: unknown action '%1' (start|stop|status)")
                    .arg(action));
 }
 

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -3239,11 +3239,14 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
             });
 
         add("txwave", {},
-            "txwave <arm [post|samples]|save <path>|off> — record the actual "
-            "SAMPLES of a transmission to a WAV (feed it to Direwolf's atest). "
-            "`arm` taps submitTxAudio; `arm post` taps AFTER the Icom's "
-            "24k->48k resampler, the last point AE sees its own audio — the two "
-            "bracket the client half of the transmit path",
+            "txwave <arm [post|wire|dual|samples]|save <path>|save2 <path>|off> "
+            "— record the actual SAMPLES of a transmission to a WAV (feed it to "
+            "Direwolf's atest). `arm` taps submitTxAudio; `arm post` taps AFTER "
+            "the Icom's 24k->48k resampler; `arm wire` taps the PAYLOAD OF THE "
+            "OUTBOUND UDP DATAGRAM, the last observable point before the radio; "
+            "`arm dual` records post AND wire from ONE transmission into "
+            "separate buffers (save = post, save2 = wire) so they can be "
+            "compared sample-for-sample rather than across two bursts",
             parseActionRest,
             [](AutomationServer& s, A& a, QLocalSocket*) {
                 return s.doTxWave(a.action, a.value);
@@ -6469,38 +6472,75 @@ QJsonObject AutomationServer::doTxWave(const QString& action, const QString& res
         // air decodes nowhere, so which side stays decodable localises it.
         const QString arg = rest.trimmed().toLower();
         const bool post = arg.startsWith(QLatin1String("post"));
+        // `wire` is one stage beyond `post`: the payload of the UDP datagram
+        // itself, captured after the socket write. Post-resample audio decodes
+        // 3/3 in atest while the same transmission off the air decodes nowhere,
+        // so this is the last place the client can still be asked.
+        const bool wire = arg.startsWith(QLatin1String("wire"));
+        // `dual` runs the post-resample and wire taps on ONE transmission into
+        // SEPARATE buffers — `save` writes the post side, `save2` the wire.
+        // Comparing two keyings cannot distinguish "the wire alters the audio"
+        // from "those were different bursts"; this can.
+        const bool dual = arg.startsWith(QLatin1String("dual"));
         bool ok = false;
-        const int req = post ? 0 : arg.toInt(&ok);
+        const int req = (post || wire || dual) ? 0 : arg.toInt(&ok);
+        if (dual) {
+            m_radioModel->setTxDualCaptureEnabled(true, 0);
+            m_radioModel->setTxAudioRecordEnabled(true, 0);
+            m_radioModel->setTxAudioTapEnabled(true);
+            return QJsonObject{
+                {QStringLiteral("ok"), true},
+                {QStringLiteral("txwave"), QStringLiteral("armed")},
+                {QStringLiteral("tap"), QStringLiteral("dual")},
+                {QStringLiteral("note"), QStringLiteral(
+                     "save = post-resample, save2 = wire, same transmission")},
+            };
+        }
+        // EXACTLY ONE TAP OWNS THE RECORDER. They run at different rates and
+        // share one buffer, so arming two interleaves them into a WAV that
+        // decodes as nothing whatever the audio was.
+        m_radioModel->setTxDualCaptureEnabled(false, 0);
         m_radioModel->setTxPostResampleTapEnabled(post);
+        m_radioModel->setTxWireTapEnabled(wire);
         m_radioModel->setTxAudioRecordEnabled(true, ok ? req : 0);
         // Arm the level tap too, so a run reports both without a second verb.
         m_radioModel->setTxAudioTapEnabled(true);
         return QJsonObject{
             {QStringLiteral("ok"), true},
             {QStringLiteral("txwave"), QStringLiteral("armed")},
-            {QStringLiteral("tap"), post ? QStringLiteral("post-resample")
-                                         : QStringLiteral("submitTxAudio")},
+            {QStringLiteral("tap"), wire ? QStringLiteral("wire")
+                                         : post ? QStringLiteral("post-resample")
+                                                : QStringLiteral("submitTxAudio")},
         };
     }
 
     if (a == QLatin1String("off")) {
         m_radioModel->setTxAudioRecordEnabled(false);
+        m_radioModel->setTxDualCaptureEnabled(false, 0);
         m_radioModel->setTxPostResampleTapEnabled(false);
+        m_radioModel->setTxWireTapEnabled(false);
         return QJsonObject{
             {QStringLiteral("ok"), true},
             {QStringLiteral("txwave"), QStringLiteral("off")},
         };
     }
 
-    if (a == QLatin1String("save")) {
+    // `save` writes the primary recorder; `save2` writes the WIRE buffer filled
+    // by a dual capture. ONE writer for both — a second copy of the header code
+    // is how the two files would drift into being not-comparable, which is the
+    // whole point of capturing them together.
+    if (a == QLatin1String("save") || a == QLatin1String("save2")) {
+        const bool second = (a == QLatin1String("save2"));
         const QString path = rest.trimmed();
         if (path.isEmpty())
-            return err(QStringLiteral("txwave save: a file path is required"));
+            return err(QStringLiteral("txwave %1: a file path is required").arg(a));
 
         int rate = 0;
-        const QVector<qint16> pcm = m_radioModel->takeTxAudioRecording(&rate);
+        const QVector<qint16> pcm = second ? m_radioModel->takeTxWireRecording(&rate)
+                                           : m_radioModel->takeTxAudioRecording(&rate);
         if (pcm.isEmpty())
-            return err(QStringLiteral("txwave save: nothing recorded (arm before transmitting?)"));
+            return err(QStringLiteral("txwave %1: nothing recorded (arm before transmitting?)")
+                           .arg(a));
         if (rate <= 0)
             rate = 48000;
 
@@ -6509,7 +6549,7 @@ QJsonObject AutomationServer::doTxWave(const QString& action, const QString& res
         // ever differ, that is itself a finding.
         QFile f(path);
         if (!f.open(QIODevice::WriteOnly))
-            return err(QStringLiteral("txwave save: cannot open '%1'").arg(path));
+            return err(QStringLiteral("txwave %1: cannot open '%2'").arg(a, path));
 
         const quint32 dataBytes = quint32(pcm.size()) * 2u;
         const quint16 channels = 2;
@@ -6543,10 +6583,16 @@ QJsonObject AutomationServer::doTxWave(const QString& action, const QString& res
         f.write(reinterpret_cast<const char*>(pcm.constData()), qint64(dataBytes));
         f.close();
 
-        m_radioModel->setTxAudioRecordEnabled(false);
+        // Only the SECOND save disarms: on a dual capture the caller needs both
+        // halves, and disarming on the first would discard the wire buffer
+        // before it could be written.
+        if (second || !m_radioModel->txDualCaptureActive())
+            m_radioModel->setTxAudioRecordEnabled(false);
         return QJsonObject{
             {QStringLiteral("ok"), true},
             {QStringLiteral("txwave"), QStringLiteral("saved")},
+            {QStringLiteral("tap"), second ? QStringLiteral("wire")
+                                           : QStringLiteral("post-resample")},
             {QStringLiteral("path"), path},
             {QStringLiteral("samples"), pcm.size()},
             {QStringLiteral("frames"), pcm.size() / 2},
@@ -6556,7 +6602,7 @@ QJsonObject AutomationServer::doTxWave(const QString& action, const QString& res
         };
     }
 
-    return err(QStringLiteral("txwave: unknown action '%1' (arm|save|off)").arg(action));
+    return err(QStringLiteral("txwave: unknown action '%1' (arm|save|save2|off)").arg(action));
 }
 
 QJsonObject AutomationServer::doTxMonitor(const QString& action)

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -3367,7 +3367,7 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
             });
 
         add("modem", {"aethermodem"},
-            "modem <status|profile hf300|profile vhf1200|on|off|preamble <flags|auto>> — AetherModem demod profile, TXDELAY, RX tap, and decoder health",
+            "modem <status|profile hf300|profile vhf1200|on|off|preamble <flags|auto>|txprobe [text]> — AetherModem demod profile, TXDELAY, RX tap, decoder health, and a non-keying transmit-chain probe",
             parseActionRest,
             [](AutomationServer& s, A& a, QLocalSocket*) {
                 return s.doModemAutomation(QStringLiteral("modem"), a.action, a.value);

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -33,6 +33,7 @@ class RadioModel;
 class SliceModel;
 class AudioEngine;
 class QsoRecorder;
+class ClientPuduMonitor;
 class AetherClockModel;
 
 // In-app, agent-first automation bridge (issue #3646, Phases 0-1).
@@ -255,6 +256,14 @@ public:
     void setClockModel(AetherClockModel* model);  // out-of-line: QPointer needs the complete type
     // QSO recorder handle for the record() verb (start/stop/status/path).
     void setQsoRecorder(QsoRecorder* rec) { m_qsoRecorder = rec; }
+    // Post-final-limiter TX monitor for the txmonitor() verb. This taps the
+    // exact int16 stream that gets packetised into VITA-49 — what the radio is
+    // TOLD to transmit — so a test can capture the modulator's real output
+    // rather than inferring it. Distinct from the QSO recorder, which records
+    // RECEIVE audio. May be null in an engine-only build.
+    // Out-of-line for the same reason as setClockModel(): assigning a
+    // QPointer needs the complete type, and this header only forward-declares it.
+    void setTxFinalMonitor(ClientPuduMonitor* mon);
     // Real connection hook for the connect/disconnect/dialog verbs. The bridge
     // asks the implementor (the GUI's ConnectionPanel) to drive the same path
     // the visible buttons do, so automation exercises the normal
@@ -603,6 +612,12 @@ private:
     // recorder, read the WAV path, or point recordings at a path (for live
     // capture-file verification on TCC-restricted boxes).
     QJsonObject doRecord(const QString& action, const QString& value);
+    QJsonObject doTxMonitor(const QString& action);
+    QJsonObject doTxAudioTap(const QString& action);
+    // txwave arm|save|off — record the SAMPLES the backend was handed, not just
+    // their level, and write a WAV. Clipping and a flags-only burst are shapes;
+    // a dBFS figure cannot show either.
+    QJsonObject doTxWave(const QString& action, const QString& rest);
     // testtone on [freqHz] [levelDb] | off — drive the client-side TX test tone
     // through onTxAudioReady so a recording gets a deterministic "phone" segment
     // (verifies SSB<->CW switching while recording). The actual transmit still
@@ -751,6 +766,7 @@ private:
     QPointer<RadioModel> m_radioModel;           // for get(); may be null
     QPointer<AudioEngine> m_audioEngine;          // for get audio; may be null
     QPointer<QsoRecorder> m_qsoRecorder;          // for record(); may be null
+    QPointer<ClientPuduMonitor> m_txFinalMonitor;  // for txmonitor(); may be null
     QPointer<AetherClockModel> m_clockModel;      // for get clock; may be null
     IConnectionAutomation* m_connection = nullptr;  // connect/disconnect verbs
     QPointer<QObject> m_connectionGuard;            // auto-nulls when the impl is destroyed

--- a/src/core/backends/icom/IcomAudio.cpp
+++ b/src/core/backends/icom/IcomAudio.cpp
@@ -159,8 +159,27 @@ void TxPacketizer::submit(std::span<const float> mono)
     // Drop the OLDEST on overflow. On transmit the freshest audio is what
     // matters; keeping a backlog just means the operator's voice arrives late
     // and keeps getting later.
-    while (m_pending.size() > kMaxPendingBytes)
+    //
+    // COUNTED, because for a DIGITAL burst this rule is destructive in a way it
+    // never is for voice: the oldest bytes of an AX.25 transmission are the
+    // preamble and the opening flag, so dropping from the front leaves a frame
+    // that still sounds like packet and syncs on nothing. A 596 ms burst is
+    // 2.4x this queue, and onTxPaceTick's catch-up pacing ships a larger chunk
+    // whenever a tick lands late — so an oversized submit is reachable in
+    // production, not just in theory.
+    //
+    // Counting rather than logging keeps this file free of Qt logging (it is
+    // pure protocol, no QObject, and the unit test links it standalone). The
+    // owner reads droppedBytes() and decides what to say about it.
+    std::size_t dropped = 0;
+    while (m_pending.size() > kMaxPendingBytes) {
         m_pending.pop_front();
+        ++dropped;
+    }
+    if (dropped > 0) {
+        m_droppedBytes += dropped;
+        ++m_dropEvents;
+    }
 }
 
 std::vector<TxPacketizer::Chunk> TxPacketizer::takeFrame()

--- a/src/core/backends/icom/IcomAudio.h
+++ b/src/core/backends/icom/IcomAudio.h
@@ -87,6 +87,19 @@ public:
 
     [[nodiscard]] std::size_t pendingBytes() const noexcept { return m_pending.size(); }
 
+    // Overflow accounting. submit() drops the OLDEST bytes past
+    // kMaxPendingBytes, which is right for voice and destructive for a digital
+    // burst — the oldest bytes of an AX.25 transmission are its preamble and
+    // opening flag, so what survives syncs on nothing while still sounding like
+    // packet. These make that visible instead of silent.
+    //
+    // droppedBytes() is cumulative for the session; dropEvents() counts the
+    // submits that overflowed, so one huge write and a thousand small ones are
+    // distinguishable.
+    [[nodiscard]] std::size_t droppedBytes() const noexcept { return m_droppedBytes; }
+    [[nodiscard]] std::size_t dropEvents() const noexcept { return m_dropEvents; }
+    void resetDropCounters() noexcept { m_droppedBytes = 0; m_dropEvents = 0; }
+
     // Roughly 250 ms at 48 kHz mono s16. Past that the operator is hearing
     // their own latency, so dropping beats growing the backlog.
     static constexpr std::size_t kMaxPendingBytes = 24000;
@@ -94,6 +107,8 @@ public:
 private:
     AudioCodec m_codec;
     std::deque<std::uint8_t> m_pending;
+    std::size_t m_droppedBytes = 0;
+    std::size_t m_dropEvents = 0;
 };
 
 // ---------------------------------------------------------------------------

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -750,7 +750,42 @@ void IcomCivBackend::connectRadio(const RadioConnectRequest& request)
                 // The result reads as "the wire is corrupt" when the only thing
                 // wrong is the instrument. submitTxAudio gates on exactly this
                 // for the same reason; so does this.
-                if (!m_keyed && !m_tuning)
+                //
+                // LATCHED, not sampled per packet. Gating on the INSTANTANEOUS
+                // key state truncates the capture at a point that MOVES from
+                // run to run, because unkey and the packetiser's drain race:
+                // setKeying(false) clears m_keyed and only then calls
+                // flushTxAudio(), while onTxPump() fires every 10 ms in
+                // between, so a variable number of frames escape after the tap
+                // has already stopped recording.
+                //
+                // Measured 2026-08-17, IC-9700, two identical AX.25 bursts: the
+                // wire capture diverged from the post-resample capture at frame
+                // 8 (160 ms) on one run and frame 24 (480 ms) on the next, and
+                // came out 828 samples SHORTER than the post capture on one and
+                // 3264 samples LONGER on the other — while the post capture was
+                // 86016 samples both times. A capture whose LENGTH varies for a
+                // transmission of constant length is an instrument fault, and
+                // it reads exactly like "the wire is corrupt".
+                //
+                // So: latch on at key-down, and hold until the packetiser has
+                // actually drained. The burst is then captured whole, and the
+                // inter-burst stream still never reaches the recording.
+                const bool keyingNow = m_keyed || m_tuning;
+                if (keyingNow) {
+                    m_wireTapLatched = true;
+                } else if (m_wireTapLatched) {
+                    // Unkeyed: keep recording only while audio from the
+                    // transmission that just ended is still queued or in
+                    // flight. flushTxAudio() empties the queue on unkey, so
+                    // this closes promptly rather than bleeding into the next
+                    // over.
+                    const bool draining =
+                        m_session && m_session->stats().txPendingBytes > 0;
+                    if (!draining)
+                        m_wireTapLatched = false;
+                }
+                if (!m_wireTapLatched)
                     return;
                 const auto* p = reinterpret_cast<const std::uint8_t*>(lpcm.constData());
                 auto mono = decodeAudio(AudioCodec::Lpcm1ch16,

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -5634,6 +5634,29 @@ void IcomCivBackend::onLinkTick()
     }
     m_lastTxDroppedBytes = s.txDroppedBytes;
 
+    // ---- TX FEED vs DRAIN ------------------------------------------------
+    //
+    // Starvation is the quiet half of the same problem and nothing else
+    // reports it: onTxPump() finding less than a whole 20 ms frame simply
+    // sends nothing, which is indistinguishable from "nothing to send".
+    //
+    // Reported once per keyed tick while the numbers are moving. The ratio
+    // that matters is txFramesSent vs the audio actually handed in: a 597 ms
+    // AX.25 burst is ~30 frames of 960 samples, so markedly fewer frames sent
+    // — with txPumpEmpty climbing — means the wire got a fragment of the
+    // transmission, with the preamble already on the air.
+    if (m_keyed && s.txSubmitCalls != m_lastTxSubmitCalls) {
+        const double submittedMs =
+            s.txSubmitSamples > 0 ? (static_cast<double>(s.txSubmitSamples) / 48.0) : 0.0;
+        qCInfo(lcIcomLink).nospace()
+            << "Icom TX flow: submitted " << s.txSubmitCalls << " call(s)/"
+            << s.txSubmitSamples << " samples (" << submittedMs << " ms), frames sent "
+            << s.txFramesSent << " (" << (s.txFramesSent * 20) << " ms), pump ticks "
+            << s.txPumpTicks << " of which " << s.txPumpEmpty << " found no whole frame"
+            << ", pending=" << s.txPendingBytes;
+        m_lastTxSubmitCalls = s.txSubmitCalls;
+    }
+
     // ---- CI-V STALL DETECTION ------------------------------------------
     //
     // The UDP transport can be perfectly healthy while the COMMAND PLANE is

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -2908,6 +2908,31 @@ void IcomCivBackend::submitTxAudio(const QByteArray& int16Stereo, int sampleRate
     if (m_txPostResampleTapEnabled.load(std::memory_order_relaxed))
         emit txPostResampleAudio(mono, m_audioRateHz);
 
+    // THE FAR END OF THE HASH PAIR. RadioModel::noteTxAudioSubmission() hashes
+    // what this backend was GIVEN; this hashes what it HANDS ON, after the
+    // 24k->48k resample. Comparing the two distinct-counts localises a
+    // duplication to one side of the resampler without a radio: equal counts
+    // mean this stretch is faithful and the repetition arrived from upstream.
+    //
+    // Needed because a real burst reached the wire as 35 frames of which only
+    // 11 were distinct (tshark, 2026-08-17) while the post-resample tap showed
+    // all 89 the modulator built — and the packetiser between them measures
+    // clean offline, so one of those observations is not what it appears.
+    {
+        std::uint64_t h = 1469598103934665603ULL;
+        const auto* raw = reinterpret_cast<const std::uint8_t*>(mono.data());
+        const std::size_t n = mono.size() * sizeof(float);
+        for (std::size_t i = 0; i < n; ++i) {
+            h ^= raw[i];
+            h *= 1099511628211ULL;
+        }
+        ++m_txOutBlocks;
+        if (m_txOutBlocks > 1 && h == m_txOutLastHash)
+            ++m_txOutRepeats;
+        m_txOutLastHash = h;
+        m_txOutHashes.insert(h);
+    }
+
     m_session->sendAudio(mono);
 }
 
@@ -5653,7 +5678,11 @@ void IcomCivBackend::onLinkTick()
             << s.txSubmitSamples << " samples (" << submittedMs << " ms), frames sent "
             << s.txFramesSent << " (" << (s.txFramesSent * 20) << " ms), pump ticks "
             << s.txPumpTicks << " of which " << s.txPumpEmpty << " found no whole frame"
-            << ", pending=" << s.txPendingBytes;
+            << ", pending=" << s.txPendingBytes
+            // DISTINCT, not just count. A burst that arrives as a few blocks
+            // repeated many times is invisible to every other number here.
+            << "; out-blocks " << m_txOutBlocks << " (" << m_txOutHashes.size()
+            << " distinct, " << m_txOutRepeats << " consecutive repeats)";
         m_lastTxSubmitCalls = s.txSubmitCalls;
     }
 

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -5542,6 +5542,31 @@ void IcomCivBackend::onLinkTick()
         }
         m_schedulerTimeoutsReported = schedulerStats.timeouts;
     }
+    // ---- TX PACKETISER OVERFLOW ----------------------------------------
+    //
+    // submit() drops the OLDEST bytes past its 250 ms cap, which is right for
+    // voice — latency must not grow — and destructive for a digital burst,
+    // where the oldest bytes are the preamble and the opening flag. What
+    // survives keys the radio and sounds exactly like packet while syncing on
+    // nothing, so this failure is otherwise completely silent: no error, no
+    // gap in the audio, and a transmission the operator can hear on a second
+    // receiver.
+    //
+    // Reported on the EDGE and with a running total, once per tick rather than
+    // once per drop: an oversized submit sheds thousands of bytes in one loop
+    // and a per-drop message would be unreadable. WARNING level because audio
+    // the client generated and then discarded is not a debug detail.
+    if (s.txDroppedBytes > m_lastTxDroppedBytes) {
+        qCWarning(lcIcomLink).nospace()
+            << "Icom TX packetiser DROPPED audio: +"
+            << (s.txDroppedBytes - m_lastTxDroppedBytes) << " bytes this tick, "
+            << s.txDroppedBytes << " total over " << s.txDropEvents
+            << " overflow(s); pending=" << s.txPendingBytes
+            << "/" << AetherSDR::icom::TxPacketizer::kMaxPendingBytes
+            << ". On an AX.25 burst the dropped bytes are the PREAMBLE — the "
+               "transmission will be audible and undecodable.";
+    }
+    m_lastTxDroppedBytes = s.txDroppedBytes;
 
     // ---- CI-V STALL DETECTION ------------------------------------------
     //

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -734,9 +734,40 @@ void IcomCivBackend::connectRadio(const RadioConnectRequest& request)
                 onCivFrame(frame, sessionGeneration);
             });
     connect(m_session.get(), &IcomSession::audioReady, this, &IcomCivBackend::onAudio);
+    // The wire tap. Decoded back to float with the SAME decodeAudio() the
+    // receive path uses, so a difference between this and the post-resample tap
+    // is a difference in the BYTES, not in how they were interpreted here.
+    connect(m_session.get(), &IcomSession::txAudioPayload, this,
+            [this](const QByteArray& lpcm) {
+                // KEYED ONLY, and this is not optional for a diagnostic.
+                //
+                // The audio stream runs continuously once the session is up:
+                // the packetiser is fed between overs and those frames go out
+                // as ordinary audio datagrams. An ungated tap therefore records
+                // the whole stream, and the 600 ms burst under test arrives
+                // diluted in seconds of inter-burst audio — measured at 96.7 %
+                // non-zero over a 2.1 s capture, which atest cannot sync on.
+                // The result reads as "the wire is corrupt" when the only thing
+                // wrong is the instrument. submitTxAudio gates on exactly this
+                // for the same reason; so does this.
+                if (!m_keyed && !m_tuning)
+                    return;
+                const auto* p = reinterpret_cast<const std::uint8_t*>(lpcm.constData());
+                auto mono = decodeAudio(AudioCodec::Lpcm1ch16,
+                                        std::span<const std::uint8_t>(
+                                            p, static_cast<std::size_t>(lpcm.size())));
+                if (!mono.empty())
+                    emit txWireAudio(mono, m_audioRateHz);
+            });
 
     if (!m_session->start(p))
         emit connectionError(QStringLiteral("could not open the Icom session"));
+}
+
+void IcomCivBackend::setTxWireTapEnabled(bool on)
+{
+    if (m_session)
+        m_session->setTxPayloadTapEnabled(on);
 }
 
 void IcomCivBackend::disconnectRadio()

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -2831,6 +2831,17 @@ void IcomCivBackend::submitTxAudio(const QByteArray& int16Stereo, int sampleRate
         const auto* f = reinterpret_cast<const float*>(out.constData());
         mono.assign(f, f + out.size() / static_cast<int>(sizeof(float)));
     }
+    // THE LAST POINT AE SEES ITS OWN TRANSMIT AUDIO. Everything after this line
+    // is the codec, UDP and the radio. `txwave` records the other end of this
+    // stretch (what enters RadioModel::submitTxAudio), and Direwolf's atest
+    // decodes that recording perfectly — 3/3 AX.25 frames, mark/space 20/20 —
+    // while the same transmission off the air decodes nowhere. Capturing here
+    // and feeding it back to atest brackets the client half of the gap:
+    // decodable here clears this file; undecodable here indicts the resampler
+    // directly above.
+    if (m_txPostResampleTapEnabled.load(std::memory_order_relaxed))
+        emit txPostResampleAudio(mono, m_audioRateHz);
+
     m_session->sendAudio(mono);
 }
 

--- a/src/core/backends/icom/IcomCivBackend.h
+++ b/src/core/backends/icom/IcomCivBackend.h
@@ -158,6 +158,19 @@ public:
     // fallback until the radio answers.
     [[nodiscard]] const IcomModel& model() const noexcept { return *m_model; }
 
+signals:
+    // The post-resample transmit tap (see m_txPostResampleTapEnabled). Mono
+    // float at the session's negotiated rate — the exact samples handed to
+    // IcomSession::sendAudio, which is the last thing AE controls.
+    void txPostResampleAudio(const std::vector<float>& mono, int sampleRateHz);
+
+public:
+    // Arm/disarm the post-resample tap. Diagnostic; keys nothing.
+    void setTxPostResampleTapEnabled(bool on)
+    {
+        m_txPostResampleTapEnabled.store(on, std::memory_order_relaxed);
+    }
+
 private slots:
     void onSessionConnected(const QString& deviceName);
     void onSessionDisconnected(const QString& reason);
@@ -361,6 +374,22 @@ private:
     std::unique_ptr<Resampler> m_txResampler;
     int m_txResamplerFromHz = 0;
     int m_txResamplerToHz = 0;
+
+    // POST-RESAMPLE TRANSMIT TAP — the LAST point AE sees its own audio before
+    // it becomes UDP. `txwave` records what enters RadioModel::submitTxAudio;
+    // Direwolf's atest decodes that recording perfectly (3/3 AX.25 frames,
+    // mark/space 20/20), yet the same transmission off the air decodes nowhere.
+    // The fault therefore lives between that entry point and the antenna, and
+    // this brackets the client half of it: resample 24k->48k, then the codec and
+    // the network.
+    //
+    // Emitted AFTER the resampler and immediately before m_session->sendAudio(),
+    // so a WAV built from it can be fed straight back to atest. Decodable here
+    // clears everything in this file; undecodable here indicts the resampler.
+    //
+    // Off unless armed, and read with a relaxed atomic so an idle transmit path
+    // pays one load. Diagnostic only: it observes, it never keys.
+    std::atomic<bool> m_txPostResampleTapEnabled{false};
     // The DEFAULT audio rate, not the only one. 48 kHz 16-bit mono LPCM is
     // 768 kbps in each direction — about 1.5 Mbps of uncompressed UDP for a
     // duplex session, which saturates a marginal 2.4 GHz link and starves the

--- a/src/core/backends/icom/IcomCivBackend.h
+++ b/src/core/backends/icom/IcomCivBackend.h
@@ -434,6 +434,11 @@ private:
     // readback of OFF (or completed teardown). Capability may change while a
     // command is in flight, but the obligation to release the radio may not.
     bool m_xfcReleaseRequired = false;
+
+    // Latch for the txwave WIRE tap. Sampling m_keyed per packet truncates the
+    // capture at a point that moves between runs, because unkey races the
+    // packetiser drain — see the tap in IcomCivBackend.cpp.
+    bool m_wireTapLatched = false;
     std::optional<bool> m_pendingPttIntent;
     qint64 m_pendingPttUntilMs = 0;
     bool m_pttIncidentReported = false;

--- a/src/core/backends/icom/IcomCivBackend.h
+++ b/src/core/backends/icom/IcomCivBackend.h
@@ -164,12 +164,23 @@ signals:
     // IcomSession::sendAudio, which is the last thing AE controls.
     void txPostResampleAudio(const std::vector<float>& mono, int sampleRateHz);
 
+    // The WIRE tap, one stage beyond the post-resample one: the audio payload
+    // of each outbound UDP datagram, decoded back to float so it reaches the
+    // same recorder and the same WAV writer. Post-resample audio decodes 3/3 in
+    // atest while the transmission off the air decodes nowhere, so this is the
+    // last client-side question: do the bytes on the wire still carry it?
+    void txWireAudio(const std::vector<float>& mono, int sampleRateHz);
+
 public:
     // Arm/disarm the post-resample tap. Diagnostic; keys nothing.
     void setTxPostResampleTapEnabled(bool on)
     {
         m_txPostResampleTapEnabled.store(on, std::memory_order_relaxed);
     }
+
+    // Arm/disarm the WIRE tap. Diagnostic; keys nothing and alters nothing that
+    // is sent — it observes the datagram after the socket write.
+    void setTxWireTapEnabled(bool on);
 
 private slots:
     void onSessionConnected(const QString& deviceName);

--- a/src/core/backends/icom/IcomCivBackend.h
+++ b/src/core/backends/icom/IcomCivBackend.h
@@ -407,6 +407,11 @@ private:
     // total every tick; this holds the last value so only new drops are logged.
     std::size_t m_lastTxDroppedBytes = 0;
     std::size_t m_lastTxSubmitCalls = 0;
+    // Far end of the submitTxAudio hash pair — see the block above sendAudio().
+    std::uint64_t m_txOutLastHash = 0;
+    std::size_t m_txOutBlocks = 0;
+    std::size_t m_txOutRepeats = 0;
+    std::set<std::uint64_t> m_txOutHashes;
     // The DEFAULT audio rate, not the only one. 48 kHz 16-bit mono LPCM is
     // 768 kbps in each direction — about 1.5 Mbps of uncompressed UDP for a
     // duplex session, which saturates a marginal 2.4 GHz link and starves the

--- a/src/core/backends/icom/IcomCivBackend.h
+++ b/src/core/backends/icom/IcomCivBackend.h
@@ -390,6 +390,11 @@ private:
     // Off unless armed, and read with a relaxed atomic so an idle transmit path
     // pays one load. Diagnostic only: it observes, it never keys.
     std::atomic<bool> m_txPostResampleTapEnabled{false};
+
+    // Edge detection for the TX packetiser's drop counter (see onLinkTick).
+    // The counter is cumulative, so reporting it directly would repeat the same
+    // total every tick; this holds the last value so only new drops are logged.
+    std::size_t m_lastTxDroppedBytes = 0;
     // The DEFAULT audio rate, not the only one. 48 kHz 16-bit mono LPCM is
     // 768 kbps in each direction — about 1.5 Mbps of uncompressed UDP for a
     // duplex session, which saturates a marginal 2.4 GHz link and starves the

--- a/src/core/backends/icom/IcomCivBackend.h
+++ b/src/core/backends/icom/IcomCivBackend.h
@@ -406,6 +406,7 @@ private:
     // The counter is cumulative, so reporting it directly would repeat the same
     // total every tick; this holds the last value so only new drops are logged.
     std::size_t m_lastTxDroppedBytes = 0;
+    std::size_t m_lastTxSubmitCalls = 0;
     // The DEFAULT audio rate, not the only one. 48 kHz 16-bit mono LPCM is
     // 768 kbps in each direction — about 1.5 Mbps of uncompressed UDP for a
     // duplex session, which saturates a marginal 2.4 GHz link and starves the

--- a/src/core/backends/icom/IcomCivBackend.h
+++ b/src/core/backends/icom/IcomCivBackend.h
@@ -11,6 +11,7 @@
 #include <deque>
 #include <memory>
 #include <optional>
+#include <set>
 #include <span>
 #include <string>
 #include <vector>

--- a/src/core/backends/icom/IcomSession.cpp
+++ b/src/core/backends/icom/IcomSession.cpp
@@ -736,13 +736,33 @@ void IcomSession::onTxPump()
     // Drain every frame that is ready, not just one: a host audio callback can
     // deliver several frames' worth in one block, and pacing them out one per
     // 10 ms tick would fall permanently behind.
+    ++m_txPumpTicks;
+    bool sentAny = false;
     for (auto chunks = m_tx.takeFrame(); !chunks.empty(); chunks = m_tx.takeFrame()) {
         for (const auto& c : chunks) {
             m_audio->sendTracked(buildAudio(m_audio->localSessionId(),
                                             m_audio->remoteSessionId(), 0, m_audioSendSeq++,
                                             c.bytes));
         }
+        ++m_txFramesSent;
+        sentAny = true;
     }
+    // A tick that found less than a whole 20 ms frame. Harmless for voice —
+    // the next tick is 10 ms away — but on a digital burst it is a GAP in the
+    // middle of a frame whose preamble has already gone out, and nothing else
+    // reports it: takeFrame() returning {} is indistinguishable from "nothing
+    // to send" here.
+    if (!sentAny)
+        ++m_txPumpEmpty;
+}
+
+void IcomSession::resetTxFlowCounters()
+{
+    m_txSubmitCalls = 0;
+    m_txSubmitSamples = 0;
+    m_txFramesSent = 0;
+    m_txPumpTicks = 0;
+    m_txPumpEmpty = 0;
 }
 
 void IcomSession::sendCiv(std::span<const std::uint8_t> frame)
@@ -769,6 +789,8 @@ void IcomSession::sendAudio(std::span<const float> mono)
 {
     if (!m_params.enableTx)
         return;
+    ++m_txSubmitCalls;
+    m_txSubmitSamples += mono.size();
     m_tx.submit(mono);
 }
 
@@ -792,6 +814,11 @@ IcomSession::Stats IcomSession::stats() const
     s.txDroppedBytes = m_tx.droppedBytes();
     s.txDropEvents   = m_tx.dropEvents();
     s.txPendingBytes = m_tx.pendingBytes();
+    s.txSubmitCalls   = m_txSubmitCalls;
+    s.txSubmitSamples = m_txSubmitSamples;
+    s.txFramesSent    = m_txFramesSent;
+    s.txPumpTicks     = m_txPumpTicks;
+    s.txPumpEmpty     = m_txPumpEmpty;
     return s;
 }
 

--- a/src/core/backends/icom/IcomSession.cpp
+++ b/src/core/backends/icom/IcomSession.cpp
@@ -99,6 +99,10 @@ bool IcomSession::start(const Params& params)
     connect(m_audio, &IcomStream::ready, this, &IcomSession::onAudioReady);
     connect(m_audio, &IcomStream::payloadReady, this, &IcomSession::onAudioPayload);
     connect(m_audio, &IcomStream::failed, this, &IcomSession::fail);
+    // The wire tap, forwarded verbatim: the session adds nothing to it, because
+    // anything the session did to these bytes would be a difference between
+    // what was captured and what went out.
+    connect(m_audio, &IcomStream::txAudioPayload, this, &IcomSession::txAudioPayload);
     // LOSS IS CONCEALED, not merely counted.
     //
     // This used to forward the count and stop there, and nothing downstream
@@ -769,6 +773,15 @@ void IcomSession::sendAudio(std::span<const float> mono)
 }
 
 void IcomSession::flushTxAudio() { m_tx.flush(); }
+
+void IcomSession::setTxPayloadTapEnabled(bool on)
+{
+    // Audio stream only. The control and serial streams carry no audio payload,
+    // and isAudioData() would reject their datagrams anyway — arming them would
+    // be a no-op that reads like coverage.
+    if (m_audio)
+        m_audio->setTxPayloadTapEnabled(on);
+}
 
 IcomSession::Stats IcomSession::stats() const
 {

--- a/src/core/backends/icom/IcomSession.cpp
+++ b/src/core/backends/icom/IcomSession.cpp
@@ -776,6 +776,9 @@ IcomSession::Stats IcomSession::stats() const
     if (m_control) s.control = m_control->counters();
     if (m_serial)  s.serial  = m_serial->counters();
     if (m_audio)   s.audio   = m_audio->counters();
+    s.txDroppedBytes = m_tx.droppedBytes();
+    s.txDropEvents   = m_tx.dropEvents();
+    s.txPendingBytes = m_tx.pendingBytes();
     return s;
 }
 

--- a/src/core/backends/icom/IcomSession.h
+++ b/src/core/backends/icom/IcomSession.h
@@ -107,6 +107,13 @@ public:
         IcomStream::Counters control;
         IcomStream::Counters serial;
         IcomStream::Counters audio;
+        // TX packetiser overflow. Non-zero means submit() discarded audio the
+        // client had already generated, from the FRONT of the queue — which on
+        // an AX.25 burst is the preamble and opening flag. Silent otherwise:
+        // the transmission still keys and still sounds like packet.
+        std::size_t txDroppedBytes = 0;
+        std::size_t txDropEvents = 0;
+        std::size_t txPendingBytes = 0;
     };
     [[nodiscard]] Stats stats() const;
     // Credential-free RS-BA1 lease state for health and automation diagnostics.

--- a/src/core/backends/icom/IcomSession.h
+++ b/src/core/backends/icom/IcomSession.h
@@ -103,6 +103,11 @@ public:
     // Discard queued transmit audio. Call on unkey.
     void flushTxAudio();
 
+    // Arm the WIRE TAP on the audio stream: the payload bytes of every outbound
+    // audio datagram, at the last instruction before the socket. Diagnostic;
+    // keys nothing and changes nothing that is sent.
+    void setTxPayloadTapEnabled(bool on);
+
     struct Stats {
         IcomStream::Counters control;
         IcomStream::Counters serial;
@@ -130,6 +135,9 @@ signals:
     void civFrameReady(const AetherSDR::icom::CivFrame& frame);
     void audioReady(const std::vector<float>& mono);
     void audioLost(int packets);
+    // Outbound audio payload bytes, from the wire tap. LPCM s16 LE at the
+    // negotiated rate, envelope stripped.
+    void txAudioPayload(const QByteArray& lpcm);
 
 private slots:
     void onControlReady();

--- a/src/core/backends/icom/IcomSession.h
+++ b/src/core/backends/icom/IcomSession.h
@@ -119,7 +119,26 @@ public:
         std::size_t txDroppedBytes = 0;
         std::size_t txDropEvents = 0;
         std::size_t txPendingBytes = 0;
+        // FEED vs DRAIN. The packetiser can be starved as well as overrun, and
+        // starvation is the quieter failure: onTxPump() simply sends nothing on
+        // a tick where takeFrame() has less than a whole 20 ms frame, so the
+        // radio's jitter buffer sees a gap rather than an error. On an AX.25
+        // burst that gap lands in the middle of a frame whose preamble has
+        // already gone out.
+        //
+        // txSubmitCalls/txSubmitSamples = what the modem HANDED US.
+        // txFramesSent = whole 20 ms frames that actually reached the wire.
+        // txPumpTicks = pump ticks while keyed; txPumpEmpty = ticks that found
+        // less than a frame ready. A burst whose audio is 597 ms should yield
+        // ~30 frames; markedly fewer, with txPumpEmpty climbing, is starvation.
+        std::size_t txSubmitCalls = 0;
+        std::size_t txSubmitSamples = 0;
+        std::size_t txFramesSent = 0;
+        std::size_t txPumpTicks = 0;
+        std::size_t txPumpEmpty = 0;
     };
+    // Zero the feed/drain counters so one transmission can be measured alone.
+    void resetTxFlowCounters();
     [[nodiscard]] Stats stats() const;
     // Credential-free RS-BA1 lease state for health and automation diagnostics.
     [[nodiscard]] QVariantMap leaseDiagnostics() const;
@@ -208,6 +227,12 @@ private:
 
     std::uint16_t m_serialSendSeq = 0;
     std::uint16_t m_audioSendSeq = 1;
+    // Feed/drain instrumentation — see Stats above.
+    std::size_t m_txSubmitCalls = 0;
+    std::size_t m_txSubmitSamples = 0;
+    std::size_t m_txFramesSent = 0;
+    std::size_t m_txPumpTicks = 0;
+    std::size_t m_txPumpEmpty = 0;
 
     CivReassembler m_civ;
     TxPacketizer m_tx;

--- a/src/core/backends/icom/IcomStream.cpp
+++ b/src/core/backends/icom/IcomStream.cpp
@@ -189,26 +189,15 @@ void IcomStream::sendRaw(std::span<const std::uint8_t> packet)
         m_counters.txBytes += static_cast<quint64>(n);
         ++m_counters.txPackets;
         m_lastTxAtMs = m_activityClock.elapsed();
-
-        // THE WIRE TAP. After the write, so what is reported is what was
-        // actually handed to the socket rather than what we were about to hand
-        // it — a write that fails should not appear in the capture as if it had
-        // gone out. It also sits after the counters above (added by #5274) so
-        // the telemetry describes the same write the tap then reports on.
-        //
-        // isAudioData() rather than a size test: it is structural, and the size
-        // whitelist both reference implementations use is only correct at
-        // 48 kHz. Keepalives, pings, retransmit requests and the serial stream
-        // all fail it, so an armed tap on the CONTROL or SERIAL stream stays
-        // silent rather than capturing envelope bytes that are not audio.
-        if (m_txPayloadTapEnabled.load(std::memory_order_relaxed) && isAudioData(packet)) {
-            const auto pcm = audioPayload(packet);
-            if (!pcm.empty()) {
-                emit txAudioPayload(QByteArray(reinterpret_cast<const char*>(pcm.data()),
-                                               static_cast<qsizetype>(pcm.size())));
-            }
-        }
     }
+    // NO WIRE TAP HERE, deliberately. sendRaw() is called again for every
+    // retransmit, so tapping here double-recorded a packet that only went on
+    // the air once. The tap moved to the first-send path; see the commit that
+    // made this change.
+    //
+    // The byte/packet counters above are a different thing and DO belong here:
+    // they count writes to the socket, and a retransmit really is another
+    // write. Telemetry from #5274 — left exactly as main has it.
 }
 
 void IcomStream::flush()
@@ -268,6 +257,37 @@ void IcomStream::sendTrackedImpl(std::vector<std::uint8_t> packet, bool isPayloa
     packet[0x06] = static_cast<std::uint8_t>(seq & 0xff);
     packet[0x07] = static_cast<std::uint8_t>((seq >> 8) & 0xff);
     sendRaw(packet);
+
+    // THE WIRE TAP — here, on the FIRST transmission of a payload, and NOT in
+    // sendRaw().
+    //
+    // sendRaw() is also the replay path: a retransmit request is served by
+    // sendRaw(*it) on the retained copy, and sendRawTwice() deliberately writes
+    // the same bytes twice. A tap in sendRaw() therefore records a packet again
+    // every time the radio asks for it, out of order and interleaved with the
+    // live stream — which is indistinguishable from corrupted audio in the
+    // capture and is NOT what went on the air once.
+    //
+    // Measured 2026-08-17, IC-9700 over LAN: the wire capture ran 234 ms LONGER
+    // than the post-resample capture of the same transmission, with duplicated
+    // and reordered 20 ms frames, and Direwolf decoded 0 of 3 bursts from it
+    // while decoding 4 of 5 from the post capture. Placed here it records each
+    // payload exactly once, in send order.
+    //
+    // isAudioData() rather than a size test: it is structural, and the size
+    // whitelist both reference implementations use is only correct at 48 kHz.
+    // Keepalives, pings, retransmit requests and the serial stream all fail it,
+    // so an armed tap on the CONTROL or SERIAL stream stays silent rather than
+    // capturing envelope bytes that are not audio.
+    if (isPayload && m_txPayloadTapEnabled.load(std::memory_order_relaxed)
+        && isAudioData(packet)) {
+        const auto pcm = audioPayload(packet);
+        if (!pcm.empty()) {
+            emit txAudioPayload(QByteArray(reinterpret_cast<const char*>(pcm.data()),
+                                           static_cast<qsizetype>(pcm.size())));
+        }
+    }
+
     retain(seq, packet);
     // Only PAYLOAD resets the quiet clock. Letting the keepalive reset it would
     // make the stream permanently believe it had just sent something real, so

--- a/src/core/backends/icom/IcomStream.cpp
+++ b/src/core/backends/icom/IcomStream.cpp
@@ -189,6 +189,25 @@ void IcomStream::sendRaw(std::span<const std::uint8_t> packet)
         m_counters.txBytes += static_cast<quint64>(n);
         ++m_counters.txPackets;
         m_lastTxAtMs = m_activityClock.elapsed();
+
+        // THE WIRE TAP. After the write, so what is reported is what was
+        // actually handed to the socket rather than what we were about to hand
+        // it — a write that fails should not appear in the capture as if it had
+        // gone out. It also sits after the counters above (added by #5274) so
+        // the telemetry describes the same write the tap then reports on.
+        //
+        // isAudioData() rather than a size test: it is structural, and the size
+        // whitelist both reference implementations use is only correct at
+        // 48 kHz. Keepalives, pings, retransmit requests and the serial stream
+        // all fail it, so an armed tap on the CONTROL or SERIAL stream stays
+        // silent rather than capturing envelope bytes that are not audio.
+        if (m_txPayloadTapEnabled.load(std::memory_order_relaxed) && isAudioData(packet)) {
+            const auto pcm = audioPayload(packet);
+            if (!pcm.empty()) {
+                emit txAudioPayload(QByteArray(reinterpret_cast<const char*>(pcm.data()),
+                                               static_cast<qsizetype>(pcm.size())));
+            }
+        }
     }
 }
 

--- a/src/core/backends/icom/IcomStream.h
+++ b/src/core/backends/icom/IcomStream.h
@@ -9,6 +9,7 @@
 #include <deque>
 #include <QObject>
 
+#include <atomic>
 #include <cstdint>
 #include <span>
 #include <vector>
@@ -118,7 +119,31 @@ public:
     };
     [[nodiscard]] Counters counters() const;
 
+    // THE WIRE TAP — the outbound audio payload, at the last instruction before
+    // the socket.
+    //
+    // Every tap upstream of this point has now been cleared (modulator,
+    // submitTxAudio, the 24k->48k resampler, the LPCM encode, the packetiser),
+    // and atest decodes all of them; the same transmission off the air decodes
+    // nowhere. What remains between here and the antenna is UDP and the radio,
+    // so this answers the one question left on the client side: do the BYTES
+    // handed to the socket still carry correct AFSK?
+    //
+    // Emitted only for datagrams isAudioData() accepts, and only while armed —
+    // this is on the transmit path at ~100 packets/s.
+    //
+    // ⚠ Payload only, envelope stripped: a consumer reassembling these gets the
+    // 1364+556 halves back in send order, which is the same byte stream
+    // TxPacketizer produced. That is deliberate — reassembling to LPCM and
+    // feeding it to atest is the whole point.
+    void setTxPayloadTapEnabled(bool on) noexcept
+    {
+        m_txPayloadTapEnabled.store(on, std::memory_order_relaxed);
+    }
+
 signals:
+    // Outbound audio payload bytes (LPCM s16 LE at the negotiated rate).
+    void txAudioPayload(const QByteArray& lpcm);
     // Handshake complete; the stream will now carry payload.
     void ready();
     void failed(const QString& reason);
@@ -165,6 +190,8 @@ private:
     // number and can be asked for) but must not reset the quiet clock, or the
     // idle cadence never relaxes.
     void sendTrackedImpl(std::vector<std::uint8_t> packet, bool isPayload);
+
+    std::atomic<bool> m_txPayloadTapEnabled{false};
 
     QUdpSocket* m_socket = nullptr;
     QTimer* m_idleTimer = nullptr;

--- a/src/core/tnc/AetherAx25LibmodemShim.cpp
+++ b/src/core/tnc/AetherAx25LibmodemShim.cpp
@@ -90,6 +90,18 @@ constexpr int kTxPreambleFlags = ax25::kAx25Hf300PreambleFlags;        // HF 300
 constexpr int kVhf1200TxPreambleFlags = ax25::kAx25Vhf1200PreambleFlags; // VHF: ~0.43 s
 constexpr int kTxPostambleFlags = ax25::kAx25TxPostambleFlags;
 constexpr int kTxVitaPacketFrames = 128;
+// ⚠ MEASURED 2026-08-15: on the IC-9700's RS-BA1 LAN audio path this value has
+// NO EFFECT ON TRANSMITTED DEVIATION. Raised to 0.90 on the bench — the
+// modulator moved as expected (txprobe −9.1 → −0.9 dBFS peak, +8.2 dB) and the
+// level received at an independent receiver did not change at all (rms 4763 vs
+// 4710–4779 at 0.35). The radio's own `LAN MOD Level` is equally inert: 8 % and
+// 80 % measure the same on air. The 9700 appears to limit/AGC LAN audio to a
+// fixed deviation.
+//
+// Left at 0.35 because nothing on this path justifies changing it, and 0.35 is
+// what every other backend has been validated against. If deviation ever needs
+// to be operator-settable, this constant is where it would live — there is no
+// control for it anywhere today.
 constexpr double kTxAfskAmplitude = 0.35;
 // Phase diversity compensates for 300 baud HF timing drift until the shim grows
 // a proper packet-synchronous timing loop. Phase 1 is retained because captures

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -2461,9 +2461,26 @@ void Ax25HfPacketDecodeDialog::beginTransmitWhenReady()
         txModel.setDax(true);
     }
 
-    const QString route = bypassesDax
-        ? QStringLiteral("host-modulated (no DAX stream)")
-        : QStringLiteral("DAX TX stream 0x%1").arg(m_audio->txStreamId(), 0, 16);
+    // NAME THE ROUTE THAT ACTUALLY FIRED. txAudioBypassesDax() is an OR of two
+    // different reasons — the host runs the modulator (HL2), or the audio
+    // crosses the seam to a radio that modulates it (Icom) — and reporting both
+    // as "host-modulated" describes the HL2's case on a radio where
+    // hostModulates is FALSE.
+    //
+    // Not cosmetic in practice: chasing an AX.25 transmit fault on an IC-9700,
+    // this line said "host-modulated (no DAX stream)" while `modem txprobe`
+    // reported hostModulates:false for the same transmission. The two read as a
+    // contradiction and cost a diversion looking for a missing DAX stream on a
+    // radio that has never had one. The internal qCInfo below was already
+    // correct ("seam/host"); only the operator-facing line was wrong.
+    const RadioCapabilities routeCaps =
+        m_radio ? m_radio->backendCapabilities() : RadioCapabilities{};
+    const QString route =
+        !bypassesDax
+            ? QStringLiteral("DAX TX stream 0x%1").arg(m_audio->txStreamId(), 0, 16)
+        : routeCaps.hostModulates
+            ? QStringLiteral("host-modulated (no DAX stream)")
+            : QStringLiteral("over the radio seam (no DAX stream)");
     appendSystemLine(QStringLiteral("Keying transmitter for AX.25 TX on %1; %2.")
         .arg(transmitSliceSummary(), route));
     qCInfo(lcAx25).noquote()

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -1618,6 +1618,177 @@ QJsonObject linkSnapshot(const Ax25Connection& link)
 
 } // namespace
 
+QJsonObject Ax25HfPacketDecodeDialog::automationTxProbe(const QString& text)
+{
+    // Walk the transmit chain one stage at a time and report each transition,
+    // WITHOUT keying. The failure this exists for is a transmit that keys the
+    // radio, emits RF, and reports txBytes=0 with the receiver seeing no frame
+    // structure at all (rejectBadFcs=0 against thousands of HDLC candidates) —
+    // three symptoms that are equally consistent with "the modulator emits
+    // nothing coherent" and with "no bytes ever reached the modulator". A
+    // measurement of the whole chain cannot tell those apart; a measurement of
+    // each seam can.
+    //
+    // Deliberately does NOT transmit: it builds what WOULD be sent. That keeps
+    // it usable with no radio, off the air, and outside the TX gate — the
+    // diagnostic should not need the permission whose absence it may be
+    // diagnosing.
+    const QString payload = text.trimmed().isEmpty()
+        ? QStringLiteral("PROBE") : text.trimmed();
+
+    QJsonArray stages;
+    auto stage = [&stages](const char* name, bool ok, const QString& detail,
+                           QJsonObject extra = {}) {
+        extra.insert(QStringLiteral("stage"), QString::fromLatin1(name));
+        extra.insert(QStringLiteral("ok"), ok);
+        if (!detail.isEmpty())
+            extra.insert(QStringLiteral("detail"), detail);
+        stages.append(extra);
+    };
+
+    // ── stage 1: text → AX.25 frame → modulated PCM ────────────────────────
+    // ax25BuildTransmitAudio does both in one call, but its result carries the
+    // intermediate frame, so the two are still separately observable.
+    const Ax25TransmitResult tx =
+        ax25BuildTransmitAudio(m_shimConfig, payload, defaultTransmitSource());
+
+    stage("build", tx.ok, tx.ok ? QString() : tx.error);
+    if (!tx.ok) {
+        return QJsonObject{{QStringLiteral("ok"), false},
+                           {QStringLiteral("error"), tx.error},
+                           {QStringLiteral("txprobe"), stages}};
+    }
+
+    stage("frame", tx.frameBytes > 0,
+          tx.frameBytes > 0 ? QString()
+                            : QStringLiteral("frame encoded to zero bytes"),
+          QJsonObject{
+              {QStringLiteral("source"), tx.frame.source},
+              {QStringLiteral("destination"), tx.frame.destination},
+              {QStringLiteral("path"), tx.frame.path.join(QStringLiteral(","))},
+              {QStringLiteral("control"), int(tx.frame.control)},
+              {QStringLiteral("pid"), int(tx.frame.pid)},
+              {QStringLiteral("payloadText"), tx.frame.payloadText},
+              {QStringLiteral("payloadHex"), tx.frame.payloadHex},
+              {QStringLiteral("frameBytes"), tx.frameBytes},
+          });
+
+    // ── stage 2: is the PCM real audio, or silence? ────────────────────────
+    // A modulator that returns the right NUMBER of samples but leaves them at
+    // zero looks identical to a working one from every counter AE keeps. Peak
+    // and RMS are what separate them.
+    const int floatCount =
+        int(tx.stereoFloat32Pcm.size() / qsizetype(sizeof(float)));
+    double peak = 0.0;
+    double sumSquares = 0.0;
+    if (floatCount > 0) {
+        const auto* s =
+            reinterpret_cast<const float*>(tx.stereoFloat32Pcm.constData());
+        for (int i = 0; i < floatCount; ++i) {
+            const double v = std::abs(double(s[i]));
+            if (std::isfinite(v)) {
+                peak = std::max(peak, v);
+                sumSquares += v * v;
+            }
+        }
+    }
+    const double rms = floatCount > 0 ? std::sqrt(sumSquares / floatCount) : 0.0;
+    const auto dbfs = [](double lin) {
+        return lin > 1e-12 ? 20.0 * std::log10(lin) : -140.0;
+    };
+    const int frames = tx.sampleRate > 0 ? floatCount / 2 : 0;
+    const double durationMs =
+        tx.sampleRate > 0 ? 1000.0 * frames / tx.sampleRate : 0.0;
+
+    // Silence is the interesting failure, so it is called out by name rather
+    // than left for the reader to infer from a -140 dBFS reading.
+    const bool audible = peak > 1e-6;
+    stage("modulate", audible,
+          audible ? QString()
+                  : QStringLiteral("PCM is digital silence — the modulator "
+                                   "produced samples but no signal"),
+          QJsonObject{
+              {QStringLiteral("sampleRate"), tx.sampleRate},
+              {QStringLiteral("baud"), tx.baud},
+              {QStringLiteral("markHz"), tx.markHz},
+              {QStringLiteral("spaceHz"), tx.spaceHz},
+              {QStringLiteral("preambleFlags"), tx.preambleFlags},
+              {QStringLiteral("postambleFlags"), tx.postambleFlags},
+              {QStringLiteral("pcmBytes"), int(tx.stereoFloat32Pcm.size())},
+              {QStringLiteral("frames"), frames},
+              {QStringLiteral("durationMs"), std::round(durationMs * 10.0) / 10.0},
+              {QStringLiteral("peakDbfs"), std::round(dbfs(peak) * 10.0) / 10.0},
+              {QStringLiteral("rmsDbfs"), std::round(dbfs(rms) * 10.0) / 10.0},
+          });
+
+    // ── stage 3: would the queue actually release it? ──────────────────────
+    // maybeStartNextKissTx() defers while the radio reports transmitting, and
+    // a radio stuck keyed therefore starves the queue for ever while every
+    // counter stays at zero. Report the gate's inputs rather than its verdict,
+    // so a reader can see WHICH condition is holding it.
+    const bool haveAudio = m_audio != nullptr;
+    const bool haveRadio = m_radio != nullptr;
+    const bool radioTransmitting =
+        haveRadio && (m_radio->isRadioTransmitting()
+                      || m_radio->transmitModel().isTransmitting());
+    const bool queueClear = !m_txActive && !m_txPendingStream;
+    const bool wouldSend =
+        haveAudio && haveRadio && queueClear && !radioTransmitting;
+    stage("txgate", wouldSend,
+          wouldSend ? QString()
+                    : QStringLiteral("a transmit started now would be deferred "
+                                     "or dropped, not sent"),
+          QJsonObject{
+              {QStringLiteral("audioEngine"), haveAudio},
+              {QStringLiteral("radioModel"), haveRadio},
+              {QStringLiteral("radioTransmitting"), radioTransmitting},
+              {QStringLiteral("txActive"), m_txActive},
+              {QStringLiteral("txPendingStream"), m_txPendingStream},
+              {QStringLiteral("queuedFrames"), int(m_kissTxQueue.size())},
+          });
+
+    // ── stage 4: the route the PCM would take to the radio ─────────────────
+    // A host-modulating or seam backend takes the direct path; anything else
+    // waits for a DAX TX stream, and waits for ever if the backend has none.
+    QJsonObject route{{QStringLiteral("bypassesDax"), false},
+                      {QStringLiteral("txStreamId"), 0}};
+    bool routeOk = false;
+    QString routeDetail = QStringLiteral("no radio connected");
+    if (haveRadio) {
+        const RadioCapabilities caps = m_radio->backendCapabilities();
+        const bool bypasses = txAudioBypassesDax();
+        const int streamId = haveAudio ? int(m_audio->txStreamId()) : 0;
+        route = QJsonObject{
+            {QStringLiteral("hostModulates"), caps.hostModulates},
+            {QStringLiteral("takesTxAudioOverSeam"), caps.takesTxAudioOverSeam},
+            {QStringLiteral("hasDaxStreams"), caps.hasDaxStreams},
+            {QStringLiteral("bypassesDax"), bypasses},
+            {QStringLiteral("txStreamId"), streamId},
+        };
+        routeOk = bypasses || streamId != 0;
+        if (!routeOk)
+            routeDetail = QStringLiteral(
+                "needs a DAX TX stream and none is open — TX would wait for a "
+                "stream that may never arrive");
+        else
+            routeDetail.clear();
+    }
+    stage("route", routeOk, routeDetail, route);
+
+    bool allOk = true;
+    for (const QJsonValue& v : std::as_const(stages)) {
+        if (!v.toObject().value(QStringLiteral("ok")).toBool())
+            allOk = false;
+    }
+
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("chainOk"), allOk},
+        {QStringLiteral("text"), payload},
+        {QStringLiteral("txprobe"), stages},
+    };
+}
+
 QJsonObject Ax25HfPacketDecodeDialog::automationCommand(const QString& verb,
                                                         const QString& action,
                                                         const QString& value)
@@ -1677,9 +1848,11 @@ QJsonObject Ax25HfPacketDecodeDialog::automationCommand(const QString& verb,
                     "TXDELAY flags out of range 0-127 (got %1)").arg(flags));
             m_terminalTxPreamble->setValue(flags);
             applyTerminalConfigFromUi(true);
+        } else if (action == QLatin1String("txprobe")) {
+            return automationTxProbe(value);
         } else if (!action.isEmpty() && action != QLatin1String("status")) {
             return automationError(QStringLiteral(
-                "unknown modem action '%1' (status|profile|on|off|preamble)").arg(action));
+                "unknown modem action '%1' (status|profile|on|off|preamble|txprobe)").arg(action));
         }
 
         QJsonObject modem{

--- a/src/gui/Ax25HfPacketDecodeDialog.h
+++ b/src/gui/Ax25HfPacketDecodeDialog.h
@@ -144,6 +144,13 @@ public:
     QJsonObject automationCommand(const QString& verb, const QString& action,
                                   const QString& value);
 
+    // `modem txprobe [text]` — build what WOULD be transmitted and report each
+    // seam of the chain (frame encode, modulation, the queue gate, and the
+    // audio route to the radio) without keying. Separates "the modulator emits
+    // nothing coherent" from "no bytes ever reached the modulator", which every
+    // whole-chain measurement conflates.
+    QJsonObject automationTxProbe(const QString& text);
+
 protected:
     // Command history (Up/Down) on the terminal input line.
     bool eventFilter(QObject* watched, QEvent* event) override;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1692,6 +1692,33 @@ MainWindow::MainWindow(QWidget* parent)
     // radio side and ignores this.
     connect(m_audio, &AudioEngine::txFinalMonitorPcmReady,
             this, [this](const QByteArray& pcm, bool clientLeveled) {
+        // ⛔ NOT WHILE THE MODEM IS TRANSMITTING. This tap is mic-driven — the
+        // comment above says so, and the emit site calls it "phone/SSB" — but
+        // submitTxAudio() is a FUNNEL, shared with AetherModem's AX.25 audio.
+        // Both reach the radio's single modulator input and SUM there.
+        //
+        // Measured 2026-08-15, IC-9700 over LAN. A capture taken at the far end
+        // of this funnel contains two interleaved sources in ~0.9 s blocks:
+        //   - peak ~11476, energy at 1180/1210/1310/1330 Hz  = the modem's AFSK
+        //   - peak ~16000, BROADBAND, dominant frequency wandering 770-1200 Hz
+        //     every 100 ms                                    = this path
+        // Direwolf's atest decodes the modem's audio perfectly on its own (3/3
+        // frames, mark/space 20/20) and decodes NOTHING from the mixture. On the
+        // air that is a transmission which is loud, on frequency, with correct
+        // tones, and undecodable by any TNC — the fault chased since 2026-08-12.
+        //
+        // ⛔ DO NOT GATE THIS ON isDaxTxMode(). Tried 2026-08-15 and it is
+        // WRONG: the modem's own AFSK reaches this same signal. Its chunks go
+        // AudioEngine::sendModemTxAudio() -> feedDaxTxAudioInternal() -> emit
+        // txFinalMonitorPcmReady, so a DAX-TX-mode gate here silences the modem
+        // rather than the microphone — measured on air as "RF power but no
+        // modulation".
+        //
+        // The mixing problem is real (two sources sum into the radio's single
+        // modulator input; a post-funnel capture shows the modem's AFSK at peak
+        // ~11476 interleaved with a broadband ~16000 source), but the separation
+        // has to happen where the two are still distinguishable — upstream of
+        // this shared tap — not here, where they are already one stream.
         m_radioModel.submitTxAudio(pcm, AudioEngine::DEFAULT_SAMPLE_RATE,
                                    clientLeveled);
     });

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -2577,6 +2577,7 @@ bool MainWindow::startAutomationBridge(const QString& sockName)
     m_automation->setRadioModel(&radioModel());  // for the get() verb
     m_automation->setAudioEngine(audioEngine());
     m_automation->setQsoRecorder(qsoRecorder());  // for the record() verb
+    m_automation->setTxFinalMonitor(m_finalMonitor);  // for the txmonitor() verb
     m_automation->setClockModel(m_clockModel);  // for the `get clock` verb
     m_automation->setConnectionDialogHost(this);
     m_automation->setConnectionAutomation(

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -41,6 +41,7 @@
 #include <QtEndian>
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 #include <limits>
 #include <memory>
 #include <utility>
@@ -8051,8 +8052,138 @@ void RadioModel::setTxAudioMonitor(bool on)
 void RadioModel::submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz,
                                bool clientLeveled)
 {
+    // Observation tap on the ONE funnel every backend's transmit audio passes
+    // through — host-modulating (HL2) and seam (Icom) alike. Deliberately here
+    // rather than in a backend: instrumenting Hl2Backend would have measured
+    // one path and left the other invisible, which is the mistake that cost
+    // 2026-08-13.
+    //
+    // Placed BEFORE the backend call so it records what the backend was GIVEN.
+    // A backend that drops the audio (Hl2Backend returns early when unkeyed, or
+    // when the rate is not 24 kHz) then shows as "offered N bytes, transmitted
+    // nothing" rather than as silence with no explanation.
+    //
+    // Why not ClientPuduMonitor: that tap sits on the VOICE channel strip.
+    // Proven 2026-08-13 — an AX.25 transmission that decoded correctly produced
+    // an entirely silent Pudu capture, because modem audio never traverses it.
+    if (m_txAudioTapEnabled.load(std::memory_order_relaxed))
+        noteTxAudioSubmission(int16Stereo, sampleRateHz);
+
     if (m_backend)
         m_backend->submitTxAudio(int16Stereo, sampleRateHz, clientLeveled);
+}
+
+void RadioModel::noteTxAudioSubmission(const QByteArray& int16Stereo, int sampleRateHz)
+{
+    // Cheap running summary, not a buffer: this runs on the audio path, so it
+    // must not allocate or block. Peak/RMS answer the question that matters —
+    // "did real audio reach the backend, and at what level" — without keeping
+    // the samples.
+    const int samples = static_cast<int>(int16Stereo.size() / sizeof(qint16));
+    if (samples <= 0)
+        return;
+    const auto* pcm = reinterpret_cast<const qint16*>(int16Stereo.constData());
+
+    int peak = 0;
+    double sumSquares = 0.0;
+    for (int i = 0; i < samples; ++i) {
+        const int v = std::abs(static_cast<int>(pcm[i]));
+        if (v > peak)
+            peak = v;
+        sumSquares += static_cast<double>(v) * static_cast<double>(v);
+    }
+
+    QMutexLocker lock(&m_txAudioTapMutex);
+    ++m_txAudioTapBlocks;
+    m_txAudioTapSamples += samples;
+    m_txAudioTapSampleRate = sampleRateHz;
+    if (peak > m_txAudioTapPeak)
+        m_txAudioTapPeak = peak;
+    m_txAudioTapSumSquares += sumSquares;
+
+    if (m_txAudioRecordEnabled.load(std::memory_order_relaxed))
+        recordTxAudioSamples(pcm, samples);
+}
+
+// Called with m_txAudioTapMutex already held, on the audio path. Appends into
+// already-reserved capacity and stops at the cap — never grows the buffer here.
+void RadioModel::recordTxAudioSamples(const qint16* pcm, int samples)
+{
+    const int room = m_txAudioRecordCapacity - m_txAudioRecordBuffer.size();
+    if (room <= 0)
+        return;
+    const int take = std::min(room, samples);
+    // resize() within the reserved capacity does not reallocate; memcpy into
+    // the tail avoids a per-sample push_back on the audio path.
+    const int oldSize = m_txAudioRecordBuffer.size();
+    m_txAudioRecordBuffer.resize(oldSize + take);
+    std::memcpy(m_txAudioRecordBuffer.data() + oldSize, pcm, size_t(take) * sizeof(qint16));
+}
+
+void RadioModel::setTxAudioRecordEnabled(bool on, int maxSamples)
+{
+    // Reserve up front so the audio path never allocates. 48000*2*8 = ~13 s of
+    // stereo at 48 kHz; ample for a burst, and 1.5 MB is cheap for a
+    // diagnostic that only exists while armed.
+    constexpr int kDefaultSamples = 48000 * 2 * 8;
+    constexpr int kMaxSamples = 48000 * 2 * 30;
+    const int cap = std::clamp(maxSamples > 0 ? maxSamples : kDefaultSamples, 1, kMaxSamples);
+
+    QMutexLocker lock(&m_txAudioTapMutex);
+    if (on) {
+        m_txAudioRecordBuffer.clear();
+        m_txAudioRecordBuffer.reserve(cap);
+        m_txAudioRecordCapacity = cap;
+    } else {
+        m_txAudioRecordCapacity = 0;
+    }
+    m_txAudioRecordEnabled.store(on, std::memory_order_relaxed);
+}
+
+QVector<qint16> RadioModel::takeTxAudioRecording(int* sampleRateHz)
+{
+    QMutexLocker lock(&m_txAudioTapMutex);
+    if (sampleRateHz)
+        *sampleRateHz = m_txAudioTapSampleRate;
+    QVector<qint16> out;
+    out.swap(m_txAudioRecordBuffer);
+    return out;
+}
+
+QJsonObject RadioModel::txAudioTapSnapshot() const
+{
+    QMutexLocker lock(&m_txAudioTapMutex);
+    const auto dbfs = [](double lin) {
+        return lin > 1e-12 ? 20.0 * std::log10(lin) : -140.0;
+    };
+    const double peakLin = m_txAudioTapPeak / 32768.0;
+    const double rmsLin = m_txAudioTapSamples > 0
+        ? std::sqrt(m_txAudioTapSumSquares / double(m_txAudioTapSamples)) / 32768.0
+        : 0.0;
+    return QJsonObject{
+        {QStringLiteral("enabled"), m_txAudioTapEnabled.load(std::memory_order_relaxed)},
+        {QStringLiteral("blocks"), qint64(m_txAudioTapBlocks)},
+        {QStringLiteral("samples"), qint64(m_txAudioTapSamples)},
+        {QStringLiteral("sampleRate"), m_txAudioTapSampleRate},
+        {QStringLiteral("peakDbfs"), std::round(dbfs(peakLin) * 10.0) / 10.0},
+        {QStringLiteral("rmsDbfs"), std::round(dbfs(rmsLin) * 10.0) / 10.0},
+        // Digital silence is the finding this exists to name, so say it rather
+        // than leaving a reader to infer it from a -140 reading.
+        {QStringLiteral("silent"), m_txAudioTapPeak == 0},
+    };
+}
+
+void RadioModel::setTxAudioTapEnabled(bool on)
+{
+    if (on) {
+        QMutexLocker lock(&m_txAudioTapMutex);
+        m_txAudioTapBlocks = 0;
+        m_txAudioTapSamples = 0;
+        m_txAudioTapPeak = 0;
+        m_txAudioTapSumSquares = 0.0;
+        m_txAudioTapSampleRate = 0;
+    }
+    m_txAudioTapEnabled.store(on, std::memory_order_relaxed);
 }
 
 bool RadioModel::sendCommand(const QString& cmd)

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -779,6 +779,40 @@ void RadioModel::setupBackend(const QString& family)
     // so this connect is harmless for Flex and load-bearing for HL2.
     connect(m_backend.get(), &IRadioBackend::spectrumFrameReady,
             this, &RadioModel::onBackendSpectrumFrame);
+
+    // POST-RESAMPLE TX TAP (Icom only — it is the one backend that resamples on
+    // the way out). Feeds the SAME sample recorder `txwave` drains, so
+    // `txwave arm` -> transmit -> `txwave save` writes whichever side of the
+    // resampler is armed and the WAV goes straight to Direwolf's atest.
+    //
+    // Why it matters: atest decodes the PRE-resample recording perfectly (3/3
+    // AX.25 frames) while the same transmission off the air decodes nowhere.
+    // This is the other end of that stretch.
+    if (auto* icom = qobject_cast<icom::IcomCivBackend*>(m_backend.get())) {
+        connect(icom, &icom::IcomCivBackend::txPostResampleAudio, this,
+                [this](const std::vector<float>& mono, int rateHz) {
+                    if (!m_txAudioRecordEnabled.load(std::memory_order_relaxed))
+                        return;
+                    // The recorder holds interleaved int16 stereo, matching the
+                    // pre-resample capture, so one WAV writer serves both and
+                    // atest sees the same shape either way.
+                    QMutexLocker lock(&m_txAudioTapMutex);
+                    m_txAudioTapSampleRate = rateHz;
+                    const int room = m_txAudioRecordCapacity - m_txAudioRecordBuffer.size();
+                    if (room <= 0)
+                        return;
+                    const int take = std::min<int>(room, int(mono.size()) * 2);
+                    const int oldSize = m_txAudioRecordBuffer.size();
+                    m_txAudioRecordBuffer.resize(oldSize + take);
+                    qint16* dst = m_txAudioRecordBuffer.data() + oldSize;
+                    for (int i = 0; i < take / 2; ++i) {
+                        const float v = std::clamp(mono[size_t(i)], -1.0f, 1.0f);
+                        const auto s = static_cast<qint16>(std::lround(v * 32767.0f));
+                        dst[i * 2] = s;
+                        dst[i * 2 + 1] = s;
+                    }
+                });
+    }
     // Liveness stamps, on the arrival edge rather than anywhere downstream: a
     // frame that arrives and is then discarded still proves the link is alive,
     // and that is the question these answer.
@@ -8138,6 +8172,16 @@ void RadioModel::setTxAudioRecordEnabled(bool on, int maxSamples)
         m_txAudioRecordCapacity = 0;
     }
     m_txAudioRecordEnabled.store(on, std::memory_order_relaxed);
+}
+
+void RadioModel::setTxPostResampleTapEnabled(bool on)
+{
+    // Icom only: it is the one backend that resamples on the way out, and this
+    // tap exists to bracket that resampler. A no-op elsewhere rather than an
+    // error — asking a Flex for its post-resample audio is a question with no
+    // referent, not a failure.
+    if (auto* backend = qobject_cast<icom::IcomCivBackend*>(m_backend.get()))
+        backend->setTxPostResampleTapEnabled(on);
 }
 
 QVector<qint16> RadioModel::takeTxAudioRecording(int* sampleRateHz)

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -793,6 +793,11 @@ void RadioModel::setupBackend(const QString& family)
                 [this](const std::vector<float>& mono, int rateHz) {
                     if (!m_txAudioRecordEnabled.load(std::memory_order_relaxed))
                         return;
+                    // Only if THIS tap owns the recorder — the signal stays
+                    // connected whether or not it is the armed one.
+                    if (m_txRecordOwner.load(std::memory_order_relaxed)
+                        != TxRecordOwner::PostResample)
+                        return;
                     // The recorder holds interleaved int16 stereo, matching the
                     // pre-resample capture, so one WAV writer serves both and
                     // atest sees the same shape either way.
@@ -811,6 +816,60 @@ void RadioModel::setupBackend(const QString& family)
                     // the block sizes are both even, so `room` stayed even),
                     // but this is a diagnostic whose whole value is that its
                     // output can be trusted.
+                    const int take = std::min<int>(room, int(mono.size()) * 2) & ~1;
+                    if (take <= 0)
+                        return;
+                    const int oldSize = m_txAudioRecordBuffer.size();
+                    m_txAudioRecordBuffer.resize(oldSize + take);
+                    qint16* dst = m_txAudioRecordBuffer.data() + oldSize;
+                    for (int i = 0; i < take / 2; ++i) {
+                        const float v = std::clamp(mono[size_t(i)], -1.0f, 1.0f);
+                        const auto s = static_cast<qint16>(std::lround(v * 32767.0f));
+                        dst[i * 2] = s;
+                        dst[i * 2 + 1] = s;
+                    }
+                });
+        // The WIRE tap — one stage further out, and the last one there is. Same
+        // recorder, same exclusivity rule as the post-resample tap: these two
+        // and the pre-resample path all write one buffer, so exactly one of
+        // them may own it at a time or the WAV interleaves streams that are not
+        // even at the same rate. That failure produced a capture which read as
+        // a corrupt transmitter for an entire evening.
+        connect(icom, &icom::IcomCivBackend::txWireAudio, this,
+                [this](const std::vector<float>& mono, int rateHz) {
+                    if (!m_txAudioRecordEnabled.load(std::memory_order_relaxed))
+                        return;
+                    // DUAL CAPTURE: write the SECOND buffer and leave the
+                    // primary to the post-resample tap, so one transmission is
+                    // observed at both points.
+                    if (m_txDualCapture.load(std::memory_order_relaxed)) {
+                        QMutexLocker lock(&m_txAudioTapMutex);
+                        m_txWireTapSampleRate = rateHz;
+                        const int room = m_txWireRecordCapacity - m_txWireRecordBuffer.size();
+                        if (room <= 0)
+                            return;
+                        const int take = std::min<int>(room, int(mono.size()) * 2) & ~1;
+                        if (take <= 0)
+                            return;
+                        const int oldSize = m_txWireRecordBuffer.size();
+                        m_txWireRecordBuffer.resize(oldSize + take);
+                        qint16* dst = m_txWireRecordBuffer.data() + oldSize;
+                        for (int i = 0; i < take / 2; ++i) {
+                            const float v = std::clamp(mono[size_t(i)], -1.0f, 1.0f);
+                            const auto s = static_cast<qint16>(std::lround(v * 32767.0f));
+                            dst[i * 2] = s;
+                            dst[i * 2 + 1] = s;
+                        }
+                        return;
+                    }
+                    if (m_txRecordOwner.load(std::memory_order_relaxed)
+                        != TxRecordOwner::Wire)
+                        return;
+                    QMutexLocker lock(&m_txAudioTapMutex);
+                    m_txAudioTapSampleRate = rateHz;
+                    const int room = m_txAudioRecordCapacity - m_txAudioRecordBuffer.size();
+                    if (room <= 0)
+                        return;
                     const int take = std::min<int>(room, int(mono.size()) * 2) & ~1;
                     if (take <= 0)
                         return;
@@ -8142,11 +8201,22 @@ void RadioModel::noteTxAudioSubmission(const QByteArray& int16Stereo, int sample
     QMutexLocker lock(&m_txAudioTapMutex);
     ++m_txAudioTapBlocks;
     m_txAudioTapSamples += samples;
-    m_txAudioTapSampleRate = sampleRateHz;
     if (peak > m_txAudioTapPeak)
         m_txAudioTapPeak = peak;
     m_txAudioTapSumSquares += sumSquares;
 
+    // STAND ASIDE UNLESS THIS PATH OWNS THE RECORDER. All three taps write this
+    // buffer and this rate at DIFFERENT rates (24 kHz here, 48 kHz after the
+    // resampler and on the wire). Recording two interleaves them into one WAV
+    // stamped with whichever wrote last — the file then fails to decode for a
+    // reason that has nothing to do with the audio under test, which is exactly
+    // the confusion this diagnostic exists to remove.
+    // The level accumulator above still runs: peak/RMS at submitTxAudio stay
+    // meaningful regardless of which side is being recorded.
+    if (m_txRecordOwner.load(std::memory_order_relaxed) != TxRecordOwner::PreResample)
+        return;
+
+    m_txAudioTapSampleRate = sampleRateHz;
     if (m_txAudioRecordEnabled.load(std::memory_order_relaxed))
         recordTxAudioSamples(pcm, samples);
 }
@@ -8192,8 +8262,74 @@ void RadioModel::setTxPostResampleTapEnabled(bool on)
     // tap exists to bracket that resampler. A no-op elsewhere rather than an
     // error — asking a Flex for its post-resample audio is a question with no
     // referent, not a failure.
+    //
+    // Claim the recorder BEFORE arming the backend tap, so no post-resample
+    // block can land while the pre-resample path is still appending. See
+    // m_txAudioRecordPostResample: the two taps carry different sample rates
+    // and share one buffer.
+    // Claim or release ownership WITHOUT disturbing another tap's claim: a
+    // plain store here is what let `setTxWireTapEnabled(false)` clear the claim
+    // `setTxPostResampleTapEnabled(true)` had just made, two lines apart.
+    if (on)
+        m_txRecordOwner.store(TxRecordOwner::PostResample, std::memory_order_relaxed);
+    else if (m_txRecordOwner.load(std::memory_order_relaxed) == TxRecordOwner::PostResample)
+        m_txRecordOwner.store(TxRecordOwner::PreResample, std::memory_order_relaxed);
     if (auto* backend = qobject_cast<icom::IcomCivBackend*>(m_backend.get()))
         backend->setTxPostResampleTapEnabled(on);
+}
+
+void RadioModel::setTxWireTapEnabled(bool on)
+{
+    // Same exclusivity, same release-only-your-own-claim rule as above.
+    if (on)
+        m_txRecordOwner.store(TxRecordOwner::Wire, std::memory_order_relaxed);
+    else if (m_txRecordOwner.load(std::memory_order_relaxed) == TxRecordOwner::Wire)
+        m_txRecordOwner.store(TxRecordOwner::PreResample, std::memory_order_relaxed);
+    if (auto* backend = qobject_cast<icom::IcomCivBackend*>(m_backend.get()))
+        backend->setTxWireTapEnabled(on);
+}
+
+void RadioModel::setTxDualCaptureEnabled(bool on, int maxSamples)
+{
+    // Arms BOTH taps at once. The post-resample side owns the PRIMARY recorder
+    // (so `txwave save` is unchanged) and the wire side writes its own buffer,
+    // which is why this cannot be expressed with the single-owner enum: here
+    // two taps really do record simultaneously, into different places.
+    constexpr int kDefaultSamples = 48000 * 2 * 8;
+    constexpr int kMaxSamples = 48000 * 2 * 30;
+    const int cap = std::clamp(maxSamples > 0 ? maxSamples : kDefaultSamples, 1, kMaxSamples);
+
+    {
+        QMutexLocker lock(&m_txAudioTapMutex);
+        if (on) {
+            m_txWireRecordBuffer.clear();
+            m_txWireRecordBuffer.reserve(cap);
+            m_txWireRecordCapacity = cap;
+            m_txWireTapSampleRate = 0;
+        } else {
+            m_txWireRecordCapacity = 0;
+        }
+    }
+    m_txDualCapture.store(on, std::memory_order_relaxed);
+
+    // Post-resample claims the primary recorder; the wire tap is armed at the
+    // backend so its datagrams are emitted at all.
+    m_txRecordOwner.store(on ? TxRecordOwner::PostResample : TxRecordOwner::PreResample,
+                          std::memory_order_relaxed);
+    if (auto* backend = qobject_cast<icom::IcomCivBackend*>(m_backend.get())) {
+        backend->setTxPostResampleTapEnabled(on);
+        backend->setTxWireTapEnabled(on);
+    }
+}
+
+QVector<qint16> RadioModel::takeTxWireRecording(int* sampleRateHz)
+{
+    QMutexLocker lock(&m_txAudioTapMutex);
+    if (sampleRateHz)
+        *sampleRateHz = m_txWireTapSampleRate;
+    QVector<qint16> out;
+    out.swap(m_txWireRecordBuffer);
+    return out;
 }
 
 QVector<qint16> RadioModel::takeTxAudioRecording(int* sampleRateHz)

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -801,7 +801,19 @@ void RadioModel::setupBackend(const QString& family)
                     const int room = m_txAudioRecordCapacity - m_txAudioRecordBuffer.size();
                     if (room <= 0)
                         return;
-                    const int take = std::min<int>(room, int(mono.size()) * 2);
+                    // ROUND DOWN TO A WHOLE STEREO PAIR. `room` is a raw
+                    // capacity difference and can be odd; an odd `take` writes
+                    // take/2 pairs into take slots, leaving one sample
+                    // uninitialised AND starting the next block at an odd
+                    // offset — which swaps left and right for the rest of the
+                    // capture and makes the WAV undecodable no matter how good
+                    // the audio is. Not observed in practice (the capacity and
+                    // the block sizes are both even, so `room` stayed even),
+                    // but this is a diagnostic whose whole value is that its
+                    // output can be trusted.
+                    const int take = std::min<int>(room, int(mono.size()) * 2) & ~1;
+                    if (take <= 0)
+                        return;
                     const int oldSize = m_txAudioRecordBuffer.size();
                     m_txAudioRecordBuffer.resize(oldSize + take);
                     qint16* dst = m_txAudioRecordBuffer.data() + oldSize;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -8198,12 +8198,37 @@ void RadioModel::noteTxAudioSubmission(const QByteArray& int16Stereo, int sample
         sumSquares += static_cast<double>(v) * static_cast<double>(v);
     }
 
+    // CONTENT HASH, because a count of blocks cannot detect the same block
+    // arriving twice — and that is precisely the failure mode under
+    // investigation. Captured off the wire with tshark on 2026-08-17, one AX.25
+    // burst left the machine as 35 frames of which only ELEVEN were distinct:
+    // the two preamble frames repeated 24 times in place of the information
+    // field. Every level, tone and block-count measurement called that healthy,
+    // because the blocks really were submitted. They were duplicates.
+    //
+    // FNV-1a over the PCM. Cheap, allocation-free, and adequate for "is this
+    // byte-for-byte the block I just saw" — this is duplicate detection, not
+    // cryptography.
+    std::uint64_t hash = 1469598103934665603ULL;
+    const auto* raw = reinterpret_cast<const std::uint8_t*>(int16Stereo.constData());
+    for (int i = 0; i < int16Stereo.size(); ++i) {
+        hash ^= raw[i];
+        hash *= 1099511628211ULL;
+    }
+
     QMutexLocker lock(&m_txAudioTapMutex);
     ++m_txAudioTapBlocks;
     m_txAudioTapSamples += samples;
     if (peak > m_txAudioTapPeak)
         m_txAudioTapPeak = peak;
     m_txAudioTapSumSquares += sumSquares;
+    // Consecutive repeats are the signature of a stalled producer re-offering
+    // its last buffer; total distinct is the signature of a burst whose payload
+    // never reached us at all. They are different faults, so count both.
+    if (m_txAudioTapBlocks > 1 && hash == m_txAudioTapLastHash)
+        ++m_txAudioTapRepeats;
+    m_txAudioTapLastHash = hash;
+    m_txAudioTapHashes.insert(hash);
 
     // STAND ASIDE UNLESS THIS PATH OWNS THE RECORDER. All three taps write this
     // buffer and this rate at DIFFERENT rates (24 kHz here, 48 kHz after the
@@ -8362,6 +8387,13 @@ QJsonObject RadioModel::txAudioTapSnapshot() const
         // Digital silence is the finding this exists to name, so say it rather
         // than leaving a reader to infer it from a -140 reading.
         {QStringLiteral("silent"), m_txAudioTapPeak == 0},
+        // DUPLICATE DETECTION. `blocks` counts submissions; `distinctBlocks`
+        // counts how many carried content not seen before, and `repeatedBlocks`
+        // how many were byte-identical to the block immediately before. A burst
+        // that arrives as a handful of distinct blocks repeated many times
+        // reads as perfectly healthy on every other field here.
+        {QStringLiteral("distinctBlocks"), qint64(m_txAudioTapHashes.size())},
+        {QStringLiteral("repeatedBlocks"), qint64(m_txAudioTapRepeats)},
     };
 }
 
@@ -8374,6 +8406,9 @@ void RadioModel::setTxAudioTapEnabled(bool on)
         m_txAudioTapPeak = 0;
         m_txAudioTapSumSquares = 0.0;
         m_txAudioTapSampleRate = 0;
+        m_txAudioTapLastHash = 0;
+        m_txAudioTapRepeats = 0;
+        m_txAudioTapHashes.clear();
     }
     m_txAudioTapEnabled.store(on, std::memory_order_relaxed);
 }

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1899,6 +1899,11 @@ private:
     std::atomic<bool> m_txAudioTapEnabled{false};
     mutable QMutex m_txAudioTapMutex;
     quint64 m_txAudioTapBlocks{0};
+    // Duplicate detection at the submit funnel — a block count cannot see the
+    // same block arriving twice. See noteTxAudioSubmission().
+    std::uint64_t m_txAudioTapLastHash{0};
+    quint64 m_txAudioTapRepeats{0};
+    std::set<std::uint64_t> m_txAudioTapHashes;
     quint64 m_txAudioTapSamples{0};
     int m_txAudioTapPeak{0};
     double m_txAudioTapSumSquares{0.0};

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -45,6 +45,8 @@
 #include <QString>
 #include <QList>
 #include <QJsonObject>
+#include <QMutex>
+#include <atomic>
 #include <QHash>
 #include <QMap>
 #include <QSet>
@@ -1268,6 +1270,19 @@ public:
     // audio, whose level the sender owns (#4796).
     void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz,
                        bool clientLeveled);
+    // TX-audio observation tap. Summarises what the BACKEND WAS GIVEN — every
+    // backend, host-modulating and seam alike, since they share this funnel.
+    // Answers "did real audio reach the backend, and at what level", which no
+    // other instrument does: ClientPuduMonitor sits on the voice channel strip
+    // and sees nothing of modem transmit audio (proven 2026-08-13).
+    void setTxAudioTapEnabled(bool on);
+    QJsonObject txAudioTapSnapshot() const;
+    // Arm/disarm the bounded SAMPLE recorder and drain it. Levels cannot see
+    // clipping or a preamble that never becomes data; the samples can.
+    // maxSamples is clamped, and the buffer is reserved here rather than on the
+    // audio path.
+    void setTxAudioRecordEnabled(bool on, int maxSamples = 0);
+    QVector<qint16> takeTxAudioRecording(int* sampleRateHz = nullptr);
     // Let receive audio through while transmitting. Diagnostic use only — see
     // IRadioBackend::setTxAudioMonitor.
     void setTxAudioMonitor(bool on);
@@ -1859,6 +1874,34 @@ private:
     }
 
 private:
+    // TX-audio tap (see setTxAudioTapEnabled). Off by default and read with a
+    // relaxed atomic so the audio path pays a single load when idle. The
+    // accumulator is mutex-guarded because a snapshot must be self-consistent.
+    void noteTxAudioSubmission(const QByteArray& int16Stereo, int sampleRateHz);
+    std::atomic<bool> m_txAudioTapEnabled{false};
+    mutable QMutex m_txAudioTapMutex;
+    quint64 m_txAudioTapBlocks{0};
+    quint64 m_txAudioTapSamples{0};
+    int m_txAudioTapPeak{0};
+    double m_txAudioTapSumSquares{0.0};
+    int m_txAudioTapSampleRate{0};
+
+    // Optional SAMPLE recorder, distinct from the peak/RMS accumulator above.
+    // Levels answer "did audio arrive"; they cannot answer "is it clipped" or
+    // "does the pattern ever change from flags to data" — both of which are
+    // questions about the WAVEFORM. Answering those from a dBFS figure is the
+    // mistake that cost 2026-08-14: the tap read a healthy -9.1 dBFS while the
+    // waterfall showed a harmonic comb with no frame in it.
+    //
+    // Capacity is reserved once when recording is armed, never on the audio
+    // path, and capture stops silently at the cap. Recording the FIRST samples
+    // rather than the last is deliberate: the preamble-to-data transition is at
+    // the START of a burst, and that transition is the thing under test.
+    void recordTxAudioSamples(const qint16* pcm, int samples);
+    std::atomic<bool> m_txAudioRecordEnabled{false};
+    QVector<qint16> m_txAudioRecordBuffer;   // guarded by m_txAudioTapMutex
+    int m_txAudioRecordCapacity{0};
+
     QList<SliceModel*> m_slices;
     QMap<int, QString> m_rawSliceModeLists;
     QMap<int, SliceModel*> m_staleSlices;  // previous session, kept alive for UI reuse

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1287,6 +1287,20 @@ public:
     // Both feed the same recorder, so `txwave save` writes whichever is armed
     // and the WAV goes straight to Direwolf's atest either way.
     void setTxPostResampleTapEnabled(bool on);
+    // Arm the WIRE tap — the audio payload of each outbound UDP datagram, the
+    // last observable point on the client side (Icom only).
+    void setTxWireTapEnabled(bool on);
+    // Arm BOTH taps on ONE transmission, into separate buffers. This is the
+    // only way to ask "does the wire carry what the resampler produced" of the
+    // same samples rather than of two different bursts.
+    void setTxDualCaptureEnabled(bool on, int maxSamples = 0);
+    [[nodiscard]] bool txDualCaptureActive() const noexcept
+    {
+        return m_txDualCapture.load(std::memory_order_relaxed);
+    }
+    // Drain the WIRE buffer (the post-resample side comes from
+    // takeTxAudioRecording as usual).
+    QVector<qint16> takeTxWireRecording(int* sampleRateHz = nullptr);
     // Let receive audio through while transmitting. Diagnostic use only — see
     // IRadioBackend::setTxAudioMonitor.
     void setTxAudioMonitor(bool on);
@@ -1905,6 +1919,37 @@ private:
     std::atomic<bool> m_txAudioRecordEnabled{false};
     QVector<qint16> m_txAudioRecordBuffer;   // guarded by m_txAudioTapMutex
     int m_txAudioRecordCapacity{0};
+    // WHICH tap owns the recorder — THREE-STATE, not a pair of booleans.
+    //
+    // The taps run at DIFFERENT RATES (24 kHz at submitTxAudio, 48 kHz after
+    // the resampler and on the wire) and all three append to
+    // m_txAudioRecordBuffer and stamp m_txAudioTapSampleRate. Exactly one may
+    // own it, or the WAV interleaves streams that are not even the same rate.
+    //
+    // This was a bool per tap and that was WRONG: arming `post` called
+    // setTxPostResampleTapEnabled(true) and then setTxWireTapEnabled(false),
+    // and the second call CLEARED the flag the first had set — so the
+    // pre-resample path resumed recording and a `post` capture came back at
+    // 24 kHz / 16 s. One owner, one variable.
+    enum class TxRecordOwner { PreResample, PostResample, Wire };
+    std::atomic<TxRecordOwner> m_txRecordOwner{TxRecordOwner::PreResample};
+
+    // DUAL CAPTURE — the post-resample and wire taps recording the SAME
+    // transmission into separate buffers.
+    //
+    // Comparing them across two keyings answered the wrong question: the frames
+    // are identical but the audio is not the same samples, so a 0.80
+    // correlation could mean "the wire alters the audio" OR "these are two
+    // different bursts". Only one transmission observed at both points can tell
+    // those apart, and that needs a second buffer — the taps run concurrently.
+    //
+    // `m_txWireRecordBuffer` holds the wire side; the primary buffer holds the
+    // post-resample side, so `txwave save` keeps working unchanged and
+    // `txwave save2` writes the second.
+    std::atomic<bool> m_txDualCapture{false};
+    QVector<qint16> m_txWireRecordBuffer;    // guarded by m_txAudioTapMutex
+    int m_txWireRecordCapacity{0};
+    int m_txWireTapSampleRate{0};
 
     QList<SliceModel*> m_slices;
     QMap<int, QString> m_rawSliceModeLists;

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -52,6 +52,7 @@
 #include <QSet>
 #include <functional>
 #include <memory>
+#include <set>
 
 #include <QTimer>
 #include <QElapsedTimer>

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1283,6 +1283,10 @@ public:
     // audio path.
     void setTxAudioRecordEnabled(bool on, int maxSamples = 0);
     QVector<qint16> takeTxAudioRecording(int* sampleRateHz = nullptr);
+    // Arm the POST-RESAMPLE tap instead of the pre-resample one (Icom only).
+    // Both feed the same recorder, so `txwave save` writes whichever is armed
+    // and the WAV goes straight to Direwolf's atest either way.
+    void setTxPostResampleTapEnabled(bool on);
     // Let receive audio through while transmitting. Diagnostic use only — see
     // IRadioBackend::setTxAudioMonitor.
     void setTxAudioMonitor(bool on);


### PR DESCRIPTION
Closes nothing — this is the **instrumentation** that made #5011 measurable, plus the fixes those instruments needed in order not to lie. The taps have done their job on my bench; what I am asking for is a maintainer's read on whether this shape belongs in the tree, and a direction on the one architecture question below (`submitTxAudio()` as a shared funnel) that I have deliberately not answered myself.

> **Re-scoped 2026-08-26.** The original body framed this around a suspected audio-seam fault inside AE. That framing needs correcting in two directions: AE's client TX path is clean and should stop being re-tested, but the fault is **not** the PTT-timing defect either — that was tested live on 08-24 with the fix in place and decode still failed. The live candidate is a radio-side deviation shortfall. The instruments in this PR are what established all three of those things.

## Why taps and fixes are one PR

They cannot be split. Three commits repair the taps corrupting each other's captures, and the code they repair is not on `main` — cherry-picking the fixes alone fails to compile (`m_txPostResampleTapEnabled: undeclared identifier`).

## What this is for

[#5011](https://github.com/aethersdr/AetherSDR/issues/5011): AX.25 transmit over RS-BA1 LAN audio is **loud, on frequency, with correct tones, and undecodable by any TNC**. Nothing in the tree could say why, because every existing instrument reports **levels**, and a level cannot distinguish a correct burst from silence — peak and RMS read −9.1 dBFS for both. These commits add the ability to record **samples**, at two points that bracket the seam.

## What the instruments found

**1. AE's client TX path is clean, end to end.**

| stage | measured |
|---|---|
| resample 24k→48k | ratio **1.0000** (16240 → 32480 samples) |
| LPCM round trip | worst sample error 0.000026, quantum 0.000031 |
| packetiser | no drops on a normal burst |
| tap fidelity | mark 1200 Hz 0.350, space 2200 Hz 0.050 preserved |

Direwolf's `atest` decodes AE's own transmit audio **3/3 frames** when captured at the tap. This is settled and should not be re-tested.

**2. The fault is radio-side.** The 08-20 off-air bench (RTL-SDR V4 as an independent receiver, IC-9700 into a dummy load) found three front-panel faults invisible to AE — DATA MOD input on `ACC` (radio radiated a **dead carrier**: RF present, 0 Hz content), TX bandwidth on `DX+`, and drive level wrong in both directions. AE's own post-resample tap decoded 3/3 in that same session. Note AE deliberately never writes `mod.input.data` (radio-authoritative per its own `controls map`), so AE cannot detect or fix that class of fault.

**3. The remaining fault is a deviation shortfall, and it is not PTT timing.** After ten runs: tones correct (1175/2224 Hz), balance flat, four clean bursts per run, but deviation stuck at ~**370 Hz RMS / 650 Hz p99.5** where 1200-baud packet wants ~2500–3000 Hz. Separately, the space tone reads 2224 Hz at the client tap and **1775 Hz off-air** — a spectral discrepancy the taps are what surfaced.

Pat's PTT/CI-V timing defect is real and worth landing on its own merits, but it is **excluded as the cause here**: re-tested live 08-24 with the fix in place, decode still fails.

**4. `submitTxAudio()` is a shared funnel.** In `MainWindow.cpp`, the mic-driven `txFinalMonitorPcmReady` path and AetherModem's AX.25 audio both reach the radio's single modulator input and **sum there**. A capture at the far end contains two interleaved sources in ~0.9 s blocks — the modem's AFSK (peak ~11476, energy 1180–1330 Hz) and the mic path (peak ~16000, broadband, dominant frequency wandering 770–1200 Hz every 100 ms). `atest` decodes the modem's audio alone perfectly and **nothing** from the mixture.

The comment there also records a **wrong fix that was tried and measured**: gating the feed on `isDaxTxMode()` silences the *modem*, not the microphone, because the modem's AFSK reaches the same signal via `sendModemTxAudio() → feedDaxTxAudioInternal() → txFinalMonitorPcmReady`. On air that presents as "RF power but no modulation". I have deliberately **not** applied a separation fix — it has to happen upstream of the shared tap where the two sources are still distinguishable, and that is the architecture decision I would rather a maintainer direct than guess at.

## Using these taps: they no-op silently on a non-native backend

The taps arm only behind a `qobject_cast<IcomCivBackend*>`. Connecting via Aether-gate — which presents as a FLEX-6700 — makes them **silently no-op**: three real-RF trigger attempts recorded zero samples with no error of any kind. Confirm `get radio` reports the native `icom:<ip>` before trusting a "nothing recorded" result. This has cost time twice.

## Commits

- `feat(modem)` — a non-keying transmit-chain probe for AetherModem
- `feat(modem)` — record TX-audio **samples**, not just their level
- `fix(automation)` — register the TX final monitor so `txmonitor` has a source
- `fix(ax25)` — name the transmit route that actually fired
- `feat(icom)` — tap transmit audio **after** the resampler, to bracket the seam
- `feat(icom)` — count and report TX packetiser drops instead of losing audio silently
- `fix(icom)` — round the post-resample tap's copy to a whole stereo pair
- `docs(ax25)` — warn against gating the TX seam feed on `isDaxTxMode` *(code comments only — no `docs/` file)*
- `fix(icom)` — stop txwave's taps corrupting each other's captures, and add a wire tap

The packetiser drop counter is the one behaviour change beyond instrumentation: `submit()` drops the **oldest** bytes past its 250 ms cap — right for voice, destructive for a digital burst where the oldest bytes are the preamble and opening flag. Previously silent: no error, no gap in the audio. It now warns on the edge with a running total.

**That counter work is split out as #5162** and is awaiting review; this branch keeps the production counters it needs and no longer carries their tests.

**Test suite split out too.** The four `test(icom)` commits that were here are now a standalone branch (`test/icom-tx-resample-ax25`), opening as its own PR once #5162 lands — the test file includes only `Resampler.h` and `IcomAudio.h`, references no tap symbol, and depends on #5162's `droppedBytes()`/`dropEvents()`. That takes this PR from 1938 lines to **1431**, leaving the taps and the fixes they needed — the part that actually needs the architecture call.

## Verification

Rebased onto current `main` (`56edc21b`) and built clean on Windows/MSVC — `AetherSDR.exe` links, exit 0.

Icom and AX.25 suites on this branch, run rather than assumed — **12/12 pass**:

```
icom_civ_test              PASS    icom_civ_scheduler_test    PASS
icom_protocol_test         PASS    icom_family_test           PASS
icom_audio_test            PASS    icom_meters_test           PASS
icom_settings_test         PASS    icom_scope_test            PASS
ax25_frame_formatter_test  PASS    ax25_libmodem_shim_test    PASS
ax25_link_timing_test      PASS    hdlc_codec_test            PASS
```

The end-to-end TX-chain measurements this PR's instruments produced (resample ratio 1.0000, LPCM worst error 0.000026 against a 0.000031 quantum, AFSK tones preserved, drop counters 40960 bytes / 1 event) now live in the split-out test branch, not here — see the split note above.

⚠ `icom_backend_test` and `icom_session_test` are declared in `tests/tests.cmake` but do not reach the generated build on this configuration, so they were **not** exercised. That is a pre-existing property of the tree on Windows, not something this branch changes — flagging it rather than listing them as passing.

## What is not done

- **No fix for the funnel mixing.** This PR makes it visible and documents where separation has to happen; it does not implement it. That is the maintainer-review question.
- **The deciding experiment has not been run** — a matched same-day triple capture (post-resample tap + wire tap + RTL IQ). Everything above compares captures up to 8 days apart, which is a real caveat on the 2224-vs-1775 Hz discrepancy.
- **Windows/MSVC only.** Not built on Linux or macOS.
- **One radio.** IC-9700 over RS-BA1 LAN. Not tried on USB, nor on another Icom.
- **34 commits behind `main`** as of this edit; will rebase before marking ready.

