### PR TITLE
feat(hl2): Add Hermes Lite 2 client-timed CW transmit and persistence

### DIFF
--- a/docs/HERMES.md
+++ b/docs/HERMES.md
@@ -1081,6 +1081,44 @@ Practical check before claiming a control works: trace the widget's `connect()`
 to the model method it calls, and confirm that method reaches
 `IRadioBackend`. If it only emits `commandReady`, it is Flex-only.
 
+#### Client-timed CW on HL2
+
+Keyboard, serial and MIDI paddles run through AetherSDR's `IambicKeyer`; their
+output is already a timed stream of complete key-down/key-up elements. Flex
+sends those elements over NetCW. HL2 routes them through the typed
+`IRadioBackend::setCwKeying` seam instead, because a Flex `cw key` command has no
+meaning on a Protocol 1 connection.
+
+The HL2 implementation deliberately uses host-generated IQ rather than the
+gateware's CWX state machine. CWX is useful for radio-side timing, but its MOX
+semantics do not cover the existing semi-break-in workflow where the operator
+holds manual MOX/PTT and sends several client-timed elements. The software path
+keeps both workflows consistent:
+
+- with **Break In** enabled, the first element raises MOX and key-up starts the
+  configured delay before MOX falls;
+- with **Break In** disabled, elements produce RF only inside an already-active
+  manual MOX/PTT envelope;
+- the EP2 builder generates a zero-offset carrier at the TX NCO with a 5 ms
+  raised-cosine edge, paced by the fixed 48 kHz transmit stream;
+- CW owns the IQ payload until that PTT envelope ends, so queued microphone IQ
+  cannot leak into inter-element spaces;
+- both MOX and carrier generation remain behind `MetisClient`'s final
+  transmit-permission gate.
+
+The marker is already the transmit carrier frequency. `cwPitch` continues to
+control the receive BFO and local sidetone; adding the pitch to transmit IQ
+would move the on-air signal away from the displayed frequency. Sidebar speed,
+iambic mode and paddle swap configure the local keyer, while Break In and Delay
+configure the HL2 PTT envelope.
+
+HL2 also declares the client-owned `Cw` operating-state domain. AetherSDR stores
+the complete sidebar surface (speed, pitch, Break In, delay, sidetone enable,
+iambic enable/mode, paddle swap, CWL, monitor gain and monitor pan) in the
+radio-scoped `OperatingState` document and restores it before the backend
+connects. Flex declares no client-owned CW domain, so its radio-reported values
+remain authoritative and are never overwritten by this path.
+
 ### 14.6 The wrong-sideband bug, and why nothing internal could find it
 
 Transmit went out on the WRONG SIDEBAND for the entire bring-up. The HPSDR wire

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -691,7 +691,7 @@ connects).
 | `dsp` | — | client-side AetherDSP noise-reduction state — see [`get dsp`](#get-dsp) |
 | `radio` | — | radio snapshot (name, model, version, connected, fullDuplex, transmitting, txPower, paTemp, slice/pan counts) |
 | `gps` | — | GPS status, tracked/visible counts, grid, radio-format coordinates, altitude, speed, course, UTC time, frequency error, and oscillator-reference state |
-| `transmit` | — | TX-chain snapshot: RF/tune power, mic/processor/monitor, VOX/AM/DEXP, TX filter, CW (speed/pitch/breakin/delay/sidetone/iambic/monitor), ATU, APD. Validate that a TX/Phone/CW applet control reached the radio model. |
+| `transmit` | — | TX-chain snapshot: RF/tune power, mic/processor/monitor, VOX/AM/DEXP, TX filter, CW (speed/pitch/break-in/delay/sidetone/iambic mode/paddle swap/CWL/monitor gain+pan), ATU, APD. Validate that a TX/Phone/CW applet control reached the radio model. |
 | `cwx` | — | CWX keyer + queue-drain watch — see [`get cwx`](#get-cwx) |
 | `equalizer` (or `eq`) | — | 8-band RX+TX graphic EQ: `rxEnabled`/`txEnabled` and `rx`/`tx` band maps keyed by label (`63`…`8k`). Validate EQ-applet slider changes. |
 | `meters` | — | `{all:[…]}` — every radio meter with `name`, `value`, `unit`, `low`/`high`, `description`, and **`age_ms`** (staleness): a meter that updates has small `age_ms` and a tracking `value`. |

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1841,6 +1841,9 @@ QJsonObject transmitSnapshot(const TransmitModel* t)
         {QStringLiteral("cwDelay"),         t->cwDelay()},
         {QStringLiteral("cwSidetone"),      t->cwSidetone()},
         {QStringLiteral("cwIambic"),        t->cwIambic()},
+        {QStringLiteral("cwIambicMode"),    t->cwIambicMode()},
+        {QStringLiteral("cwSwapPaddles"),   t->cwSwapPaddles()},
+        {QStringLiteral("cwlEnabled"),      t->cwlEnabled()},
         {QStringLiteral("monGainCw"),       t->monGainCw()},
         {QStringLiteral("monPanCw"),        t->monPanCw()},
         // ATU / APD

--- a/src/core/IambicKeyer.h
+++ b/src/core/IambicKeyer.h
@@ -16,12 +16,10 @@ namespace AetherSDR {
 //
 // Architecture
 // ────────────
-// The radio has its own iambic engine on the RF side; we feed it raw
-// paddle states via RadioModel::sendCwPaddle(dit, dah) and let the radio
-// produce the on-air signal.  This class runs an *identical* iambic
-// state machine locally for the sole purpose of driving the sidetone
-// gate with sub-5 ms latency.  Both engines see the same paddle inputs;
-// configured at the same WPM they produce identical Morse timing.
+// Paddle timing belongs here so every backend sees the same completed element
+// edges. Flex forwards those edges to NetCW; a host-modulating backend such as
+// HL2 turns them into shaped IQ. The same state machine also drives the local
+// sidetone gate with sub-5 ms latency.
 //
 // Threading
 // ─────────
@@ -37,10 +35,9 @@ namespace AetherSDR {
 //   - onKeyDownChange(bool down) — flips the sidetone gate.  Called
 //     directly from the worker thread; the receiver MUST be lock-free
 //     (e.g. CwSidetoneGenerator::setKeyDown which is std::atomic).
-//   - onPaddleEvent(bool dit, bool dah) — passes raw paddle states to
-//     the caller for forwarding to the radio.  The caller is responsible
-//     for hopping to the radio thread (Qt::QueuedConnection or
-//     QMetaObject::invokeMethod).
+//   - onPaddleEvent(bool dit, bool dah) — reports raw paddle transitions for
+//     diagnostics and any backend-specific observer. Timed RF key edges come
+//     from onKeyDownChange.
 class IambicKeyer {
 public:
     enum class Mode : int {

--- a/src/core/RadioStateMemory.cpp
+++ b/src/core/RadioStateMemory.cpp
@@ -71,6 +71,19 @@ RestoredRadioState load(const RadioSettingsScope& scope,
         state.agcThreshold =
             doc.value(QStringLiteral("agcThreshold")).toInt(-1);
     }
+    if (has(caps, Domain::Cw)) {
+        state.cwSpeed = doc.value(QStringLiteral("cwSpeed")).toInt();
+        state.cwPitch = doc.value(QStringLiteral("cwPitch")).toInt();
+        state.cwBreakIn = doc.value(QStringLiteral("cwBreakIn")).toInt(-1);
+        state.cwDelay = doc.value(QStringLiteral("cwDelay")).toInt(-1);
+        state.cwSidetone = doc.value(QStringLiteral("cwSidetone")).toInt(-1);
+        state.cwIambic = doc.value(QStringLiteral("cwIambic")).toInt(-1);
+        state.cwIambicMode = doc.value(QStringLiteral("cwIambicMode")).toInt(-1);
+        state.cwSwapPaddles = doc.value(QStringLiteral("cwSwapPaddles")).toInt(-1);
+        state.cwlEnabled = doc.value(QStringLiteral("cwlEnabled")).toInt(-1);
+        state.monGainCw = doc.value(QStringLiteral("monGainCw")).toInt(-1);
+        state.monPanCw = doc.value(QStringLiteral("monPanCw")).toInt(-1);
+    }
 
     // The extension is gated per domain too: only a declared domain's
     // sub-object is handed over, so a narrowed declaration cannot smuggle
@@ -106,7 +119,7 @@ bool store(const RadioSettingsScope& scope, const RadioCapabilities& caps,
     }
 
     // Read-only toward the future: never overwrite a document written by a
-    // newer schema — a v1 rebuild would drop the fields v1 doesn't know and
+    // newer schema — an older rebuild would drop fields it doesn't know and
     // stamp the version back down (PR #4614 review, three independent
     // reports). Mirrors SettingsDatabase's own newer-schema rule.
     // EXACT row only: the guard judges the document this write would
@@ -147,6 +160,41 @@ bool store(const RadioSettingsScope& scope, const RadioCapabilities& caps,
         // >= 0, so a threshold of 0 IS written — the sentinel is -1.
         if (state.agcThreshold >= 0) {
             doc.insert(QStringLiteral("agcThreshold"), state.agcThreshold);
+        }
+    }
+    if (has(caps, Domain::Cw)) {
+        if (state.cwSpeed > 0) {
+            doc.insert(QStringLiteral("cwSpeed"), state.cwSpeed);
+        }
+        if (state.cwPitch > 0) {
+            doc.insert(QStringLiteral("cwPitch"), state.cwPitch);
+        }
+        if (state.cwBreakIn >= 0) {
+            doc.insert(QStringLiteral("cwBreakIn"), state.cwBreakIn);
+        }
+        if (state.cwDelay >= 0) {
+            doc.insert(QStringLiteral("cwDelay"), state.cwDelay);
+        }
+        if (state.cwSidetone >= 0) {
+            doc.insert(QStringLiteral("cwSidetone"), state.cwSidetone);
+        }
+        if (state.cwIambic >= 0) {
+            doc.insert(QStringLiteral("cwIambic"), state.cwIambic);
+        }
+        if (state.cwIambicMode >= 0) {
+            doc.insert(QStringLiteral("cwIambicMode"), state.cwIambicMode);
+        }
+        if (state.cwSwapPaddles >= 0) {
+            doc.insert(QStringLiteral("cwSwapPaddles"), state.cwSwapPaddles);
+        }
+        if (state.cwlEnabled >= 0) {
+            doc.insert(QStringLiteral("cwlEnabled"), state.cwlEnabled);
+        }
+        if (state.monGainCw >= 0) {
+            doc.insert(QStringLiteral("monGainCw"), state.monGainCw);
+        }
+        if (state.monPanCw >= 0) {
+            doc.insert(QStringLiteral("monPanCw"), state.monPanCw);
         }
     }
 

--- a/src/core/RadioStateMemory.h
+++ b/src/core/RadioStateMemory.h
@@ -33,7 +33,7 @@ namespace RadioStateMemory {
 
 // The feature document name in radio_settings, and its current schema.
 inline QString featureName() { return QStringLiteral("OperatingState"); }
-constexpr int kSchemaVersion = 1;
+constexpr int kSchemaVersion = 2;
 
 // The single engagement predicate: restore/capture happen only for declared
 // domains. Deliberately a function so tests and call sites share one truth.

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -356,6 +356,19 @@ public:
     // capabilities().canTransmit is false implements this as a no-op.
     virtual void setKeying(bool key) = 0;
 
+    // A client-timed CW element. This is deliberately separate from setKeying:
+    // setKeying is the transmitter/PTT envelope, while this is the carrier
+    // inside that envelope. A host-modulating backend turns the element into
+    // shaped IQ and may use breakIn to raise/drop PTT around it; a radio-side
+    // keyer translates it to its own key-line protocol. Flex keeps using its
+    // timestamped NetCW path above this seam, so the default is a no-op.
+    virtual void setCwKeying(bool down, bool breakIn, int breakInDelayMs)
+    {
+        Q_UNUSED(down);
+        Q_UNUSED(breakIn);
+        Q_UNUSED(breakInDelayMs);
+    }
+
     // Let receive audio through WHILE TRANSMITTING.
     //
     // Receive audio is normally muted on transmit — the radio hears its own

--- a/src/core/backends/RadioCapabilities.h
+++ b/src/core/backends/RadioCapabilities.h
@@ -169,6 +169,7 @@ struct RadioCapabilities {
         TxSetpoints = 1u << 4,  // TX drive setpoints (per band); never keying
         Memories    = 1u << 5,  // host-side memory bank documents (#4590 fold-in)
         Agc         = 1u << 6,  // AGC mode + threshold (client-side WDSP AGC)
+        Cw          = 1u << 7,  // client-side keyer/sidetone setpoints; never keying
     };
     Q_DECLARE_FLAGS(ClientSettingsDomains, ClientSettingsDomain)
     ClientSettingsDomains clientSettingsDomains;   // default: empty — restore nothing

--- a/src/core/backends/RestoredRadioState.h
+++ b/src/core/backends/RestoredRadioState.h
@@ -46,6 +46,22 @@ struct RestoredRadioState {
                                   // agcThresholdDb nearby. Matches
                                   // SliceDelta::agcThreshold, the same 0..100 scale.
 
+    // CW controls. Flex persists and reports these in the radio; a host-keyed
+    // backend has no such authority, so a backend declaring the Cw domain makes
+    // the client its radio-scoped memory. Sentinel values distinguish an older
+    // document with no CW section from deliberate zero/false selections.
+    int cwSpeed = 0;              // Cw — 5..100 WPM; 0 = not restored
+    int cwPitch = 0;              // Cw — 100..6000 Hz; 0 = not restored
+    int cwBreakIn = -1;           // Cw — 0/1; -1 = not restored
+    int cwDelay = -1;             // Cw — 0..2000 ms; -1 = not restored
+    int cwSidetone = -1;          // Cw — 0/1; -1 = not restored
+    int cwIambic = -1;            // Cw — 0/1; -1 = not restored
+    int cwIambicMode = -1;        // Cw — 0=A, 1=B; -1 = not restored
+    int cwSwapPaddles = -1;       // Cw — 0/1; -1 = not restored
+    int cwlEnabled = -1;          // Cw — 0/1; -1 = not restored
+    int monGainCw = -1;           // Cw — 0..100; -1 = not restored
+    int monPanCw = -1;            // Cw — 0..100; -1 = not restored
+
     // Per-family extension document (per-band gain/drive maps live here —
     // RFC PR 3). Versioned by its owner. GATED PER DOMAIN at the top level:
     // the engine hands over only the sub-objects named for declared domains —
@@ -66,6 +82,10 @@ struct RestoredRadioState {
         return rfFrequencyHz == 0.0 && mode.isEmpty() && filterLowHz == 0.0
                && filterHighHz == 0.0 && sampleRateHz == 0
                && agcMode.isEmpty() && agcThreshold < 0
+               && cwSpeed == 0 && cwPitch == 0 && cwBreakIn < 0
+               && cwDelay < 0 && cwSidetone < 0 && cwIambic < 0
+               && cwIambicMode < 0 && cwSwapPaddles < 0 && cwlEnabled < 0
+               && monGainCw < 0 && monPanCw < 0
                && extension.isEmpty();
     }
 };

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -3009,6 +3009,19 @@ void Hl2Backend::setKeying(bool key)
                           "without AETHER_AUTOMATION_ALLOW_TX";
         return;
     }
+    // A manual PTT/MOX asserted while Break-In owns the current key transfers
+    // that ownership to the operator. The backend is already keyed, so without
+    // this explicit handoff the pending CW hang timer would later unkey a PTT
+    // that is still being held.
+    //
+    // The automatic CW path sets m_cwAutoKeyed only AFTER its own setKeying(true)
+    // call below, so that internal key-up cannot be mistaken for manual intent.
+    if (key && m_keyed && m_cwAutoKeyed) {
+        if (m_cwHangTimer) {
+            m_cwHangTimer->stop();
+        }
+        m_cwAutoKeyed = false;
+    }
     // THE ALC'S HOLD THRESHOLD IS A SILENT CLIFF, so say when an operator has
     // fallen off it.
     //
@@ -3210,8 +3223,8 @@ void Hl2Backend::setCwKeying(bool down, bool breakIn, int breakInDelayMs)
         // an MOX/PTT the operator already asserted — matching Flex behavior and
         // piHPSDR's software-keyer path.
         if (breakIn && !m_keyed) {
-            m_cwAutoKeyed = true;
             setKeying(true);
+            m_cwAutoKeyed = true;
         }
         return;
     }

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -394,6 +394,16 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
     m_txDsp->moveToThread(m_ioThread);
     m_ioThread->start();
 
+    m_cwHangTimer = new QTimer(this);
+    m_cwHangTimer->setSingleShot(true);
+    connect(m_cwHangTimer, &QTimer::timeout, this, [this] {
+        if (!m_cwAutoKeyed) {
+            return;
+        }
+        m_cwAutoKeyed = false;
+        setKeying(false);
+    });
+
     // Raw IQ -> the per-receiver DSP chains. ONE connection for every receiver,
     // rather than one per receiver, because the demux has already happened at
     // the wire: blocks[i] is DDC i. Fanning out here keeps the sample path a
@@ -1493,6 +1503,11 @@ RadioCapabilities Hl2Backend::capabilities() const
                             // reopened on Config's defaults every launch and
                             // the setting reverted to med/65 (#4909).
                             | RadioCapabilities::ClientSettingsDomain::Agc
+                            // CW timing and sidetone are also host-owned. A
+                            // Flex persists these in radio firmware; HL2 has no
+                            // corresponding readable state, so RadioModel keeps
+                            // the complete CW surface per radio.
+                            | RadioCapabilities::ClientSettingsDomain::Cw
                             // Memories: the client owns them (persistsMemories
                             // is false above). NOTE the bank itself engages on
                             // persistsMemories and keeps its own SHARED
@@ -3036,7 +3051,18 @@ void Hl2Backend::setKeying(bool key)
         m_fwdPeakWatts = 0.0;
     }
 
+    const bool keyChanged = m_keyed != key;
     m_keyed = key;
+    if (keyChanged) {
+        // Manual PTT is already mirrored optimistically by RadioModel, but CW
+        // break-in keys inside this backend. Publish that edge so the TX
+        // indicator, TCI clients and receive-side TX gates see the real state.
+        // TransmitDelta::mox is observed state, not client intent, so this does
+        // not start microphone capture or feed a second key command back down.
+        TransmitDelta delta;
+        delta.mox = key;
+        emit transmitChanged(delta);
+    }
     // MUTE RECEIVE AUDIO WHILE TRANSMITTING.
     //
     // The HL2 keeps receiving while it transmits, and what it receives is our
@@ -3088,6 +3114,10 @@ void Hl2Backend::setKeying(bool key)
     if (key && !m_tuning && m_toneFromTune)
         setTxTestTone(0.0, 0.0);
     if (!key) {
+        if (m_cwHangTimer) {
+            m_cwHangTimer->stop();
+        }
+        m_cwAutoKeyed = false;
         // An unkey ends tune too, however it was started — so the drive register
         // has to come back HERE, not in setTune()'s release branch.
         //
@@ -3132,10 +3162,73 @@ void Hl2Backend::setKeying(bool key)
         // on hardware — a key with no audio at all still produced ~1000 counts
         // of forward power for a moment, which was the previous transmission's
         // last half second going out on the air.
-        if (m_txDsp)
+        if (m_txDsp) {
             QMetaObject::invokeMethod(m_txDsp, "reset", Qt::QueuedConnection);
-        if (m_metis)
+        }
+        if (m_metis) {
             QMetaObject::invokeMethod(m_metis, "flushTxIq", Qt::QueuedConnection);
+        }
+        if (m_metis) {
+            QMetaObject::invokeMethod(m_metis, "clearCwKeying", Qt::QueuedConnection);
+        }
+    }
+}
+
+void Hl2Backend::setCwKeying(bool down, bool breakIn, int breakInDelayMs)
+{
+    if (!m_txAllowed) {
+        if (down) {
+            qWarning() << "Hl2Backend: CW key refused — automation bridge is active "
+                          "without AETHER_AUTOMATION_ALLOW_TX";
+        }
+        return;
+    }
+
+    const Receiver* txReceiver = rx(m_txDdc);
+    const QString mode = txReceiver ? txReceiver->mode.toUpper() : QString();
+    if (mode != QLatin1String("CW") && mode != QLatin1String("CWU")
+        && mode != QLatin1String("CWL")) {
+        // A key binding pressed in SSB must not become an unmodulated carrier.
+        // Release still clears a previously-held edge during a mode change.
+        if (down) {
+            qCWarning(lcHl2) << "HL2 CW key ignored outside CW mode:" << mode;
+            return;
+        }
+    }
+
+    if (m_cwHangTimer) {
+        m_cwHangTimer->stop();
+    }
+    if (m_metis) {
+        QMetaObject::invokeMethod(m_metis, "setCwKeyDown", Qt::QueuedConnection,
+            Q_ARG(bool, down));
+    }
+
+    if (down) {
+        // Full break-in raises MOX on the first element and keeps it through
+        // the configured inter-element hang. With break-in off, CW only rides
+        // an MOX/PTT the operator already asserted — matching Flex behavior and
+        // piHPSDR's software-keyer path.
+        if (breakIn && !m_keyed) {
+            m_cwAutoKeyed = true;
+            setKeying(true);
+        }
+        return;
+    }
+
+    if (m_cwAutoKeyed && m_cwHangTimer) {
+        // Preserve the complete five-millisecond fall even when the sidebar is
+        // set to zero delay; otherwise MOX could fall before the shaped tail is
+        // emitted. The configured delay remains the dominant hang at normal
+        // operating values.
+        constexpr int kCwEnvelopeReleaseMs = 6;
+        m_cwHangTimer->start(std::max(kCwEnvelopeReleaseMs,
+                                      std::clamp(breakInDelayMs, 0, 2000)));
+    } else if (!m_keyed && m_metis) {
+        // A break-in-off key press without manual PTT produced no RF. Do not
+        // leave CW owning the IQ stream after its release, or a later voice MOX
+        // would correctly key but transmit only silence.
+        QMetaObject::invokeMethod(m_metis, "clearCwKeying", Qt::QueuedConnection);
     }
 }
 

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -94,6 +94,7 @@ public:
     void removeNotch(int notchId) override;
     void setNotchesEnabled(bool on) override;
     void setKeying(bool key) override;
+    void setCwKeying(bool down, bool breakIn, int breakInDelayMs) override;
     void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz,
                        bool clientLeveled) override;
     void setTxPower(int percent) override;
@@ -646,6 +647,8 @@ private:
     bool m_adcOverload = false;
     bool m_keyed = false;
     bool m_tuning = false;
+    bool m_cwAutoKeyed = false;
+    QTimer* m_cwHangTimer = nullptr;
     bool m_txMonitor = false;
     bool m_toneFromTune = false;
     // Last drive the operator asked for through setTxPower(), so TUNE can drop to

--- a/src/core/backends/hl2/MetisClient.cpp
+++ b/src/core/backends/hl2/MetisClient.cpp
@@ -596,6 +596,38 @@ void MetisClient::setTxDriveLevel(int level)
     m_oneShot.push_back(m_ccTxDrive);
 }
 
+void MetisClient::setCwKeyDown(bool down)
+{
+    // Refuse the carrier at the same final wire authority that refuses MOX.
+    // Do not even latch a pending down edge: opening the gate later must never
+    // turn an earlier refused request into RF.
+    if (down && !m_txAllowed) {
+        return;
+    }
+    if (!down && !m_cwMode) {
+        return;
+    }
+    if (down && !m_cwMode) {
+        // CW owns the IQ stream until PTT drops. Voice already queued behind a
+        // manual MOX must not leak into the spaces between elements.
+        m_txIq.clear();
+        m_cwEnvelope = 0.0;
+    }
+    m_cwMode = true;
+    m_cwKeyDown = down;
+}
+
+void MetisClient::clearCwKeying()
+{
+    m_cwMode = false;
+    m_cwKeyDown = false;
+    m_cwEnvelope = 0.0;
+    // Anything captured while CW owned the stream is stale by definition.
+    // Dropping it here prevents an explicit CW-mode exit under a still-keyed
+    // manual PTT from releasing old microphone audio onto the wire.
+    m_txIq.clear();
+}
+
 void MetisClient::queueTxIq(std::span<const std::complex<float>> iq)
 {
     for (const auto& s : iq)
@@ -656,7 +688,27 @@ std::array<std::uint8_t, kUsbPacketSize> MetisClient::buildNextControlPacket()
     // Only put samples on the wire while actually keyed. Unkeyed frames carry
     // transmit silence, which is what ep2Packet's zero fill already gives us --
     // and which also keeps EADDR zero (see ep2WriteTxIq).
-    if (keyed && m_toneAmp > 0.0) {
+    if (keyed && m_cwMode) {
+        // piHPSDR's local/PC keyer likewise transmits host-generated IQ under
+        // MOX. Five milliseconds is long enough to suppress key clicks while
+        // staying short against a 40 ms dit at 30 WPM. A raised cosine has zero
+        // slope at both ends, unlike a linear edge.
+        constexpr double kCwCarrierAmplitude = 0.5;
+        constexpr int kCwRampSamples = 5 * kEp2AudioRateHz / 1000;
+        constexpr double kRampStep = 1.0 / static_cast<double>(kCwRampSamples);
+        constexpr double kPi = 3.14159265358979323846;
+        std::vector<std::complex<float>> block(kTxSamplesPerPacket);
+        for (std::complex<float>& sample : block) {
+            if (m_cwKeyDown) {
+                m_cwEnvelope = std::min(1.0, m_cwEnvelope + kRampStep);
+            } else {
+                m_cwEnvelope = std::max(0.0, m_cwEnvelope - kRampStep);
+            }
+            const double shaped = 0.5 - 0.5 * std::cos(kPi * m_cwEnvelope);
+            sample = {static_cast<float>(kCwCarrierAmplitude * shaped), 0.0f};
+        }
+        ep2WriteTxIq(pkt, block);
+    } else if (keyed && m_toneAmp > 0.0) {
         // EP2 is clocked at a fixed 48 kHz regardless of the RX sample rate.
         std::vector<std::complex<float>> block(kTxSamplesPerPacket);
         const double dphi = 2.0 * 3.14159265358979323846 * m_toneHz / kEp2AudioRateHz;

--- a/src/core/backends/hl2/MetisClient.h
+++ b/src/core/backends/hl2/MetisClient.h
@@ -29,8 +29,8 @@ namespace AetherSDR::hl2 {
 // the GUI thread, any GUI stall long enough to miss it would wedge the radio --
 // after which the board stops answering discovery until it is power-cycled.
 //
-// RX-ONLY: every C&C it sends comes from MetisProtocol's even-C0 encoders, so
-// the MOX bit is never set — this class cannot key the radio.
+// TX remains fail-closed: enableTransmit() must explicitly open the final wire
+// gate before either MOX or transmit samples can leave this object.
 class MetisClient : public QObject {
     Q_OBJECT
 
@@ -211,6 +211,15 @@ public:
     Q_INVOKABLE void setTxFrequencyHz(std::uint32_t hz);
     Q_INVOKABLE void setTxDriveLevel(int level);
 
+    // Software CW for a PC/USB/MIDI keyer. The carrier is generated in the EP2
+    // packet builder so its envelope is sample-paced by the radio's fixed
+    // 48 kHz transmit stream rather than by GUI or producer-thread timing.
+    // It still requires MOX; Hl2Backend owns break-in and manual-PTT policy.
+    Q_INVOKABLE void setCwKeyDown(bool down);
+    Q_INVOKABLE void clearCwKeying();
+    [[nodiscard]] bool cwModeActive() const noexcept { return m_cwMode; }
+    [[nodiscard]] bool cwKeyDown() const noexcept { return m_cwKeyDown; }
+
     // Build the EP2 packet this client would send next, without sending it.
     // Exists so the gate can be tested on the exact bytes that would go out.
     std::array<std::uint8_t, kUsbPacketSize> buildNextControlPacket();
@@ -353,6 +362,9 @@ private:
     double m_toneHz = 0.0;
     double m_toneAmp = 0.0;
     double m_tonePhase = 0.0;   // radians, carried across packets
+    bool m_cwMode = false;      // while true, CW owns TX IQ (silence between elements)
+    bool m_cwKeyDown = false;
+    double m_cwEnvelope = 0.0;  // 0..1 raised-cosine ramp position
     bool m_mox = false;         // requested key state, only honoured if m_txAllowed
 
     std::uint32_t m_txSeq = 0;           // outgoing EP2 sequence

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -2333,9 +2333,9 @@ void MainWindow::wireExternalControllers()
         m_lastCwPaddleTraceId.store(0, std::memory_order_relaxed);
         m_lastCwPaddleSourceMs.store(0, std::memory_order_relaxed);
         // When the local iambic keyer is running, feed it the raw paddle
-        // state — it forwards to the radio AND drives the sidetone gate
-        // directly.  Otherwise pass straight through to the radio (radio's
-        // RF iambic is still authoritative for the on-air signal).
+        // state — it emits timed element edges AND drives the sidetone gate
+        // directly. Otherwise the paddle acts as a straight key. The backend
+        // decides whether those edges use a radio-side keyer or host IQ.
         if (m_iambicKeyer && m_iambicKeyer->isRunning()) {
             m_iambicKeyer->setPaddleState(dit, dah);
         } else {

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1091,6 +1091,7 @@ void MainWindow::wireRadioModel()
                                        ? IambicKeyer::Mode::IambicA
                                        : IambicKeyer::Mode::IambicB);
             m_iambicKeyer->setWpm(tx.cwSpeed());
+            m_iambicKeyer->setSwapPaddles(tx.cwSwapPaddles());
             if (wantOn && !m_iambicKeyer->isRunning()) {
                 m_iambicKeyer->start();
             } else if (!wantOn && m_iambicKeyer->isRunning()) {
@@ -1142,19 +1143,16 @@ void MainWindow::wireRadioModel()
             if (m_cwxLocalKeyer) m_cwxLocalKeyer->stop();
         });
 
-        // Local iambic keyer — when the radio's iambic mode is on, this
-        // state machine runs in parallel and drives the local sidetone gate
-        // at sub-5 ms latency (the radio's keyed-back signal carries 50–200
-        // ms of round-trip jitter that's painful for paddle ops).  The radio
-        // still produces the on-air signal; we forward paddle states to it,
-        // and both engines run at the same WPM to stay phase-aligned.
+        // Local iambic keyer — when iambic mode is on, this state machine drives
+        // the local sidetone gate and produces the completed element edges.
+        // Flex forwards those edges over NetCW; a host-modulating backend such
+        // as HL2 turns them into shaped IQ. Keeping the timing here avoids
+        // radio-round-trip jitter in both the sidetone and the RF pattern.
         m_iambicKeyer = std::make_unique<IambicKeyer>();
         m_iambicKeyer->setOnKeyDownChange([this](bool down) {
             // Drive the local sidetone gate (lock-free atomic on the audio
             // thread) and the radio's per-element key edge in parallel.
-            // The radio sees `cw key 1` / `cw key 0` matching our element
-            // timing — same RF pattern the radio's own iambic engine
-            // would have produced from a hardware paddle.
+            // The backend sees key-down/key-up matching our element timing.
             if (m_audio)
                 m_audio->setCwKeyDown(down);   // keys audible + recorder sidetone
             const quint64 traceId = m_lastCwPaddleTraceId.load(std::memory_order_relaxed);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -445,8 +445,85 @@ void RadioModel::persistOperatingState(bool force)
     if (!RadioStateMemory::shouldEngage(caps)) {
         return;
     }
-    RadioStateMemory::store(settingsScope(), caps,
-                            m_backend->currentOperatingState());
+    RestoredRadioState state = m_backend->currentOperatingState();
+    if (caps.clientSettingsDomains.testFlag(
+            RadioCapabilities::ClientSettingsDomain::Cw)) {
+        captureClientOwnedCwState(state);
+    }
+    RadioStateMemory::store(settingsScope(), caps, state);
+}
+
+void RadioModel::scheduleOperatingStateSave()
+{
+    if (!m_backend || !isConnected()
+        || !RadioStateMemory::shouldEngage(m_backend->capabilities())) {
+        return;
+    }
+    m_operatingStateSaveTimer.start();
+    if (!m_operatingStateMaxWaitTimer.isActive()) {
+        m_operatingStateMaxWaitTimer.start();
+    }
+}
+
+void RadioModel::captureClientOwnedCwState(RestoredRadioState& state) const
+{
+    state.cwSpeed = m_transmitModel.cwSpeed();
+    state.cwPitch = m_transmitModel.cwPitch();
+    state.cwBreakIn = m_transmitModel.cwBreakIn() ? 1 : 0;
+    state.cwDelay = m_transmitModel.cwDelay();
+    state.cwSidetone = m_transmitModel.cwSidetone() ? 1 : 0;
+    state.cwIambic = m_transmitModel.cwIambic() ? 1 : 0;
+    state.cwIambicMode = m_transmitModel.cwIambicMode();
+    state.cwSwapPaddles = m_transmitModel.cwSwapPaddles() ? 1 : 0;
+    state.cwlEnabled = m_transmitModel.cwlEnabled() ? 1 : 0;
+    state.monGainCw = m_transmitModel.monGainCw();
+    state.monPanCw = m_transmitModel.monPanCw();
+}
+
+void RadioModel::restoreClientOwnedCwState(const RestoredRadioState& state)
+{
+    // FULL replacement, not a present-only merge. An empty/older document is
+    // the construction defaults for this radio; keeping the previous model
+    // values would leak radio A's keyer and sidetone preferences into radio B.
+    auto rangedOrDefault = [](int value, int absent, int low, int high,
+                              int fallback, const char* name) {
+        if (value == absent) {
+            return fallback;
+        }
+        if (value >= low && value <= high) {
+            return value;
+        }
+        qWarning() << "RadioModel: dropping invalid restored CW" << name << value;
+        return fallback;
+    };
+    auto boolOrDefault = [](int value, bool fallback, const char* name) {
+        if (value < 0) {
+            return fallback;
+        }
+        if (value == 0 || value == 1) {
+            return value != 0;
+        }
+        qWarning() << "RadioModel: dropping invalid restored CW" << name << value;
+        return fallback;
+    };
+
+    TransmitDelta delta;
+    delta.cwSpeed = rangedOrDefault(state.cwSpeed, 0, 5, 100, 20, "speed");
+    delta.cwPitch = rangedOrDefault(state.cwPitch, 0, 100, 6000, 600, "pitch");
+    delta.cwBreakIn = boolOrDefault(state.cwBreakIn, false, "break-in");
+    delta.cwDelay = rangedOrDefault(state.cwDelay, -1, 0, 2000, 500, "delay");
+    delta.cwSidetone = boolOrDefault(state.cwSidetone, true, "sidetone");
+    delta.cwIambic = boolOrDefault(state.cwIambic, true, "iambic");
+    delta.cwIambicMode =
+        rangedOrDefault(state.cwIambicMode, -1, 0, 1, 0, "iambic mode");
+    delta.cwSwapPaddles =
+        boolOrDefault(state.cwSwapPaddles, false, "swap paddles");
+    delta.cwlEnabled = boolOrDefault(state.cwlEnabled, false, "CWL");
+    delta.monGainCw =
+        rangedOrDefault(state.monGainCw, -1, 0, 100, 50, "sidetone gain");
+    delta.monPanCw =
+        rangedOrDefault(state.monPanCw, -1, 0, 100, 50, "sidetone pan");
+    m_transmitModel.applyChanges(delta);
 }
 
 void RadioModel::flushPendingOperatingState()
@@ -506,6 +583,10 @@ void RadioModel::handRestoredStateToBackend(const QString& serial)
 
     const RestoredRadioState state =
         RadioStateMemory::load(RadioSettingsScope(m_family, serial), caps);
+    if (caps.clientSettingsDomains.testFlag(
+            RadioCapabilities::ClientSettingsDomain::Cw)) {
+        restoreClientOwnedCwState(state);
+    }
     // UNCONDITIONALLY — an empty state is the reset that stops a same-family
     // backend reuse leaking radio A's maps and live members into radio B
     // ("this radio has no memory" is information, not a no-op).
@@ -1029,12 +1110,7 @@ void RadioModel::setupBackend(const QString& family)
     // for an empty declaration (Flex, Sim) the signal is never emitted AND
     // the store call is gated again in persistOperatingState().
     connect(m_backend.get(), &IRadioBackend::operatingStateChanged, this,
-            [this] {
-        m_operatingStateSaveTimer.start();
-        if (!m_operatingStateMaxWaitTimer.isActive()) {
-            m_operatingStateMaxWaitTimer.start();
-        }
-    });
+            [this] { scheduleOperatingStateSave(); });
     // Flush the pending capture BEFORE the rest of the disconnect teardown
     // touches identity — this connection is made first, and same-thread
     // signal delivery runs slots in connection order, so the scope still
@@ -1764,6 +1840,21 @@ RadioModel::RadioModel(QObject* parent)
             [this](int hz) {
         if (m_backend && !usesFlexCommandPlane())
             m_backend->setCwPitch(hz);
+    });
+
+    // Host-keyed radios have nowhere to retain their keyer and sidetone
+    // controls. Persist the complete CW surface only when the live backend
+    // explicitly declares client ownership of that domain. Flex declares an
+    // empty domain set, so its radio-authoritative state is never captured or
+    // reasserted by this path.
+    connect(&m_transmitModel, &TransmitModel::phoneStateChanged, this,
+            [this] {
+        if (!m_backend
+            || !m_backend->capabilities().clientSettingsDomains.testFlag(
+                RadioCapabilities::ClientSettingsDomain::Cw)) {
+            return;
+        }
+        scheduleOperatingStateSave();
     });
 
     // And on connect, for the same reason the power push above exists:
@@ -3972,8 +4063,13 @@ void RadioModel::sendCwKey(bool down, const QString& debugSource,
     // the radio queues the key but doesn't transmit until the operator
     // explicitly asserts CW PTT (Space PTT, MOX, or hardware PTT) — the
     // standard semi-break-in workflow per FlexLib Radio.cs:8890–8965.
-    sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0),
-                     debugSource, debugTraceId, debugSourceMs);
+    if (m_backend && !usesFlexCommandPlane()) {
+        m_backend->setCwKeying(down, m_transmitModel.cwBreakIn(),
+                               m_transmitModel.cwDelay());
+    } else {
+        sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0),
+                         debugSource, debugTraceId, debugSourceMs);
+    }
     if (prev != down)
         emit cwKeyDownChanged(down);
 }
@@ -3994,8 +4090,12 @@ void RadioModel::sendCwPaddle(bool dit, bool dah, const QString& debugSource,
 void RadioModel::sendCwPtt(bool on, const QString& debugSource,
                            quint64 debugTraceId, quint64 debugSourceMs)
 {
-    sendNetCwCommand(on ? QStringLiteral("cw ptt 1") : QStringLiteral("cw ptt 0"),
-                     debugSource, debugTraceId, debugSourceMs);
+    if (m_backend && !usesFlexCommandPlane()) {
+        m_backend->setKeying(on);
+    } else {
+        sendNetCwCommand(on ? QStringLiteral("cw ptt 1") : QStringLiteral("cw ptt 0"),
+                         debugSource, debugTraceId, debugSourceMs);
+    }
 }
 
 void RadioModel::sendCwKeyEdge(bool down, const QString& debugSource,
@@ -4003,8 +4103,13 @@ void RadioModel::sendCwKeyEdge(bool down, const QString& debugSource,
 {
     const bool prev = m_cwKeyActive;
     m_cwKeyActive = down;
-    sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0),
-                     debugSource, debugTraceId, debugSourceMs);
+    if (m_backend && !usesFlexCommandPlane()) {
+        m_backend->setCwKeying(down, m_transmitModel.cwBreakIn(),
+                               m_transmitModel.cwDelay());
+    } else {
+        sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0),
+                         debugSource, debugTraceId, debugSourceMs);
+    }
     if (prev != down)
         emit cwKeyDownChanged(down);
 }

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -3786,6 +3786,25 @@ bool RadioModel::refuseKeyOnTransmitIncapableBackend()
     return false;
 }
 
+bool RadioModel::forwardNonFlexCwKeying(bool down)
+{
+    if (!m_backend) {
+        return false;
+    }
+    // Release is unconditional. Capability or pan state may change while an
+    // element is down; applying the preflight to key-up could leave the carrier
+    // (and Break-In MOX) asserted indefinitely.
+    if (down
+        && (!refuseKeyOnTransmitIncapableBackend()
+            || transmitStartBlockedByInhibit(QStringLiteral("cw-key")))) {
+        return false;
+    }
+    emit backendCwKeyingForwarded(down);
+    m_backend->setCwKeying(down, m_transmitModel.cwBreakIn(),
+                           m_transmitModel.cwDelay());
+    return true;
+}
+
 void RadioModel::setTransmit(bool tx, TransmitModel::PttSource source)
 {
     if (tx) {
@@ -4055,8 +4074,6 @@ QString RadioModel::audioCompressionParam() const
 void RadioModel::sendCwKey(bool down, const QString& debugSource,
                            quint64 debugTraceId, quint64 debugSourceMs)
 {
-    const bool prev = m_cwKeyActive;
-    m_cwKeyActive = down;
     // Send only the key edge — the radio's break-in setting decides whether
     // it transmits.  With break_in=1 (QSK), `cw key 1` triggers TX and
     // break_in_delay holds the relay between elements.  With break_in=0,
@@ -4064,12 +4081,15 @@ void RadioModel::sendCwKey(bool down, const QString& debugSource,
     // explicitly asserts CW PTT (Space PTT, MOX, or hardware PTT) — the
     // standard semi-break-in workflow per FlexLib Radio.cs:8890–8965.
     if (m_backend && !usesFlexCommandPlane()) {
-        m_backend->setCwKeying(down, m_transmitModel.cwBreakIn(),
-                               m_transmitModel.cwDelay());
+        if (!forwardNonFlexCwKeying(down)) {
+            return;
+        }
     } else {
         sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0),
                          debugSource, debugTraceId, debugSourceMs);
     }
+    const bool prev = m_cwKeyActive;
+    m_cwKeyActive = down;
     if (prev != down)
         emit cwKeyDownChanged(down);
 }
@@ -4101,15 +4121,16 @@ void RadioModel::sendCwPtt(bool on, const QString& debugSource,
 void RadioModel::sendCwKeyEdge(bool down, const QString& debugSource,
                                quint64 debugTraceId, quint64 debugSourceMs)
 {
-    const bool prev = m_cwKeyActive;
-    m_cwKeyActive = down;
     if (m_backend && !usesFlexCommandPlane()) {
-        m_backend->setCwKeying(down, m_transmitModel.cwBreakIn(),
-                               m_transmitModel.cwDelay());
+        if (!forwardNonFlexCwKeying(down)) {
+            return;
+        }
     } else {
         sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0),
                          debugSource, debugTraceId, debugSourceMs);
     }
+    const bool prev = m_cwKeyActive;
+    m_cwKeyActive = down;
     if (prev != down)
         emit cwKeyDownChanged(down);
 }

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1421,6 +1421,9 @@ private:
     static std::unique_ptr<IRadioBackend> makeBackend(const QString& family);
     void handRestoredStateToBackend(const QString& serial);  // RFC #4603
     void persistOperatingState(bool force = false);          // RFC #4603 PR 3
+    void scheduleOperatingStateSave();
+    void captureClientOwnedCwState(RestoredRadioState& state) const;
+    void restoreClientOwnedCwState(const RestoredRadioState& state);
 
     // aetherd Gap B: build/destroy the backend for a radio family. The backend
     // follows the radio the operator picks in the connection manager, so these

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -953,6 +953,10 @@ signals:
     // Wired to AudioEngine's CwSidetoneGenerator for low-latency local
     // sidetone independent of the radio's own DAX-fed sidetone.
     void cwKeyDownChanged(bool down);
+    // Non-Flex diagnostic edge emitted only after transmit preflight, directly
+    // before IRadioBackend::setCwKeying(). Lets tests and diagnostics prove a
+    // refused key-down did not cross the radio seam.
+    void backendCwKeyingForwarded(bool down);
     void sliceAdded(SliceModel* slice);
     void sliceRemoved(int sliceId);
     void rawSliceModeListsChanged();
@@ -1751,6 +1755,10 @@ private:
     // keying may proceed; on refusal it rolls back the optimistic transmit state
     // and notifies, so no raw-TX edge is ever published for a refused key.
     bool refuseKeyOnTransmitIncapableBackend();
+    // Apply the same capability + receive-only-pan preflight to a non-Flex CW
+    // carrier edge before it crosses the backend seam. Key-up always passes so
+    // an inhibit arriving mid-element can never strand RF on.
+    bool forwardNonFlexCwKeying(bool down);
     bool interlockNotificationArmed() const;
     void emitInterlockNotification(const QString& message,
                                    const QString& key,

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -753,11 +753,19 @@ void TransmitModel::setCwIambicMode(int mode)
 
 void TransmitModel::setCwSwapPaddles(bool on)
 {
+    if (m_cwSwapPaddles != on) {
+        m_cwSwapPaddles = on;
+        emit phoneStateChanged();
+    }
     emit commandReady(QString("cw swap %1").arg(on ? 1 : 0));
 }
 
 void TransmitModel::setCwlEnabled(bool on)
 {
+    if (m_cwlEnabled != on) {
+        m_cwlEnabled = on;
+        emit phoneStateChanged();
+    }
     emit commandReady(QString("cw cwl_enabled %1").arg(on ? 1 : 0));
 }
 

--- a/tests/hl2_backend_test.cpp
+++ b/tests/hl2_backend_test.cpp
@@ -103,6 +103,7 @@ int main(int argc, char** argv)
 
     QCoreApplication app(argc, argv);
     qRegisterMetaType<SliceDelta>();
+    qRegisterMetaType<TransmitDelta>();
     // QSignalSpy stores a notchChanged argument by metatype, so the notch
     // session-scope case below reads an empty QVariant without this.
     qRegisterMetaType<NotchDelta>();
@@ -276,10 +277,18 @@ int main(int argc, char** argv)
     // ---- keying does not disturb the link ----
     // Whether this actually keys depends on the transmit gate above; what
     // matters here is that asking does not upset the connection either way.
+    QSignalSpy keyStateSpy(&backend, &IRadioBackend::transmitChanged);
     backend.setKeying(true);
     check(backend.isConnected(), "setKeying(true) does not disrupt the link");
+    check(!keyStateSpy.isEmpty()
+              && keyStateSpy.last().at(0).value<TransmitDelta>().mox.value_or(false),
+          "key-down publishes observed MOX for backend-owned CW break-in");
+    keyStateSpy.clear();
     backend.setKeying(false);
     check(backend.isConnected(), "setKeying(false) does not disrupt the link");
+    check(!keyStateSpy.isEmpty()
+              && !keyStateSpy.last().at(0).value<TransmitDelta>().mox.value_or(true),
+          "key-up publishes observed MOX for backend-owned CW break-in");
 
     // ---- invokeExtension honors the async contract ----
     backend.invokeExtension(QStringLiteral("hl2"), QStringLiteral("noop"), 42, {});

--- a/tests/hl2_backend_test.cpp
+++ b/tests/hl2_backend_test.cpp
@@ -290,6 +290,25 @@ int main(int argc, char** argv)
               && !keyStateSpy.last().at(0).value<TransmitDelta>().mox.value_or(true),
           "key-up publishes observed MOX for backend-owned CW break-in");
 
+    // ---- manual MOX takes ownership from the Break-In hang ----
+    // A completed element leaves MOX up for the configured hang. If the
+    // operator asserts manual PTT during that window, the old timer must not
+    // later drop the still-held manual transmission.
+    backend.setSliceMode(0, QStringLiteral("CW"));
+    keyStateSpy.clear();
+    backend.setCwKeying(true, true, 30);
+    backend.setCwKeying(false, true, 30);
+    backend.setKeying(true);  // manual takeover while the hang is pending
+    keyStateSpy.clear();
+    spin(60);                 // past the stale hang deadline
+    check(keyStateSpy.isEmpty(),
+          "manual MOX takeover cancels the pending CW hang unkey");
+    backend.setKeying(false);
+    check(!keyStateSpy.isEmpty()
+              && !keyStateSpy.last().at(0).value<TransmitDelta>().mox.value_or(true),
+          "manual release unkeys after taking ownership from CW Break-In");
+    backend.setSliceMode(0, QStringLiteral("LSB"));
+
     // ---- invokeExtension honors the async contract ----
     backend.invokeExtension(QStringLiteral("hl2"), QStringLiteral("noop"), 42, {});
     check(errSpy.count() == 1, "awaited invokeExtension -> one extensionError");

--- a/tests/hl2_tx_gate_test.cpp
+++ b/tests/hl2_tx_gate_test.cpp
@@ -36,6 +36,20 @@ static bool anyFrameKeyed(const std::array<std::uint8_t, kUsbPacketSize>& pkt)
     return false;
 }
 
+static bool payloadNonZero(const std::array<std::uint8_t, kUsbPacketSize>& pkt)
+{
+    const std::size_t frameStarts[2] = {8, 8 + kFrameSize};
+    for (const std::size_t fs : frameStarts) {
+        const std::uint8_t* pay = pkt.data() + fs + 8;
+        for (std::size_t k = 0; k < kFramePayload; ++k) {
+            if (pay[k] != 0) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 int main(int argc, char** argv)
 {
     QCoreApplication app(argc, argv);
@@ -139,16 +153,6 @@ int main(int argc, char** argv)
     // still being fed IQ is not transmitting, but it is one stray MOX bit away
     // from doing so with whatever happens to be in the buffer.
     {
-        auto payloadNonZero = [](const std::array<std::uint8_t, kUsbPacketSize>& pkt) {
-            const std::size_t frameStarts[2] = {8, 8 + kFrameSize};
-            for (const std::size_t fs : frameStarts) {
-                const std::uint8_t* pay = pkt.data() + fs + 8;
-                for (std::size_t k = 0; k < kFramePayload; ++k)
-                    if (pay[k] != 0) return true;
-            }
-            return false;
-        };
-
         MetisClient c2;
         std::vector<std::complex<float>> tone(512, std::complex<float>(0.5f, -0.5f));
 
@@ -197,6 +201,49 @@ int main(int argc, char** argv)
             c2.buildNextControlPacket();
         check(!payloadNonZero(c2.buildNextControlPacket()),
               "an empty queue transmits silence rather than repeating");
+    }
+
+    // ---- PC/MIDI CW is a shaped, packet-paced carrier under MOX ----
+    {
+        MetisClient cw;
+        cw.setCwKeyDown(true);
+        check(!cw.cwModeActive(),
+              "CW down is not latched while the transmit gate is closed");
+        check(!payloadNonZero(cw.buildNextControlPacket()),
+              "a refused CW edge puts no samples on the wire");
+
+        cw.enableTransmit(true);
+        cw.setCwKeyDown(true);
+        check(cw.cwModeActive() && cw.cwKeyDown(),
+              "an allowed CW down edge enters software-CW mode");
+        check(!payloadNonZero(cw.buildNextControlPacket()),
+              "CW still requires MOX — break-in policy belongs to the backend");
+
+        cw.setMox(true);
+        bool sawCarrier = false;
+        for (int i = 0; i < 5; ++i) {
+            sawCarrier |= payloadNonZero(cw.buildNextControlPacket());
+        }
+        check(sawCarrier, "key-down emits the raised-cosine CW carrier under MOX");
+
+        // Voice queued behind manual PTT must not leak between CW elements.
+        std::vector<std::complex<float>> voice(512, std::complex<float>(0.4f, -0.4f));
+        cw.queueTxIq(voice);
+        cw.setCwKeyDown(false);
+        for (int i = 0; i < 6; ++i) {
+            cw.buildNextControlPacket();
+        }
+        check(!payloadNonZero(cw.buildNextControlPacket()),
+              "key-up finishes its five-ms fall then emits silence, not queued voice");
+
+        cw.clearCwKeying();
+        check(!cw.cwModeActive() && !cw.cwKeyDown(),
+              "ending the CW PTT envelope releases IQ ownership");
+        check(!payloadNonZero(cw.buildNextControlPacket()),
+              "ending CW drops microphone IQ queued during the element sequence");
+        cw.queueTxIq(voice);
+        check(payloadNonZero(cw.buildNextControlPacket()),
+              "normal transmit IQ resumes after CW mode is cleared");
     }
 
     if (g_failures == 0)

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -399,6 +399,63 @@ int main(int argc, char** argv)
               "HL2 declares Memories (the #4590 bank's channels are client-"
               "owned; the bank engages on persistsMemories and keeps its own "
               "shared document — RFC #4603 PR 6)");
+
+        // CW-down is a transmit start even though the carrier and PTT envelope
+        // are separate below the seam. Pin both public element entry points:
+        // a receive-only pan must stop them before Hl2Backend sees the edge,
+        // while release remains unconditional. The final uninhibited edge is
+        // the control proving this fixture really can cross the backend seam.
+        QString fixtureError;
+        check(model.automationApplySliceFixture(0, QString(), &fixtureError),
+              "CW inhibit fixture creates a slice");
+        SliceModel* cwSlice = model.slice(0);
+        check(cwSlice != nullptr, "CW inhibit fixture resolves its slice");
+        if (cwSlice) {
+            SliceDelta txOn;
+            txOn.txSlice = true;
+            txOn.panId = QStringLiteral("0");
+            cwSlice->applyChanges(txOn);
+            const QString panId = cwSlice->panId();
+            check(model.txSlice() == cwSlice,
+                  "CW inhibit fixture assigns the transmit slice");
+            check(!panId.isEmpty(), "CW inhibit fixture has a pan identity");
+            model.setPanTransmitInhibited(
+                panId, true, QStringLiteral("receive-only CW regression"));
+            check(model.panTransmitInhibited(panId),
+                  "CW inhibit fixture marks its pan receive-only");
+            QSignalSpy keyEdgeSpy(&model, &RadioModel::cwKeyDownChanged);
+            QSignalSpy forwardedSpy(&model,
+                                    &RadioModel::backendCwKeyingForwarded);
+
+            model.sendCwKey(true);
+            check(forwardedSpy.count() == 0,
+                  "inhibited straight-key down never crosses the backend seam");
+            model.sendCwKey(false);  // release must always be accepted
+            check(forwardedSpy.count() == 1
+                      && !forwardedSpy.last().value(0).toBool(),
+                  "straight-key release crosses the seam despite the inhibit");
+
+            model.sendCwKeyEdge(true);
+            check(forwardedSpy.count() == 1,
+                  "inhibited iambic down never crosses the backend seam");
+            model.sendCwKeyEdge(false);  // release must always be accepted
+            check(forwardedSpy.count() == 2
+                      && !forwardedSpy.last().value(0).toBool(),
+                  "iambic release crosses the seam despite the inhibit");
+            check(keyEdgeSpy.count() == 0,
+                  "refused CW downs do not publish false key-active state");
+
+            model.setPanTransmitInhibited(panId, false);
+            check(!model.panTransmitInhibited(panId),
+                  "CW inhibit fixture can clear the receive-only state");
+            model.sendCwKeyEdge(true);
+            check(forwardedSpy.count() == 3
+                      && forwardedSpy.last().value(0).toBool(),
+                  "the same uninhibited down crosses the backend seam");
+            check(keyEdgeSpy.count() == 1,
+                  "an accepted down publishes one key-active edge");
+            model.sendCwKeyEdge(false);
+        }
     }
 
     // ---- Sim declares none of them, and is genuinely CONNECTED -----------
@@ -612,6 +669,15 @@ int main(int argc, char** argv)
               "TX-intent ownership check runs disconnected, on the sim backend");
         check(!model.backendCapabilities().canTransmit,
               "TX-intent ownership check runs against an RX-only backend");
+        QSignalSpy cwForwardedSpy(&model,
+                                  &RadioModel::backendCwKeyingForwarded);
+        model.sendCwKey(true);
+        check(cwForwardedSpy.count() == 0,
+              "CW down never crosses the seam of a receive-only backend");
+        model.sendCwKey(false);
+        check(cwForwardedSpy.count() == 1
+                  && !cwForwardedSpy.last().value(0).toBool(),
+              "CW release still crosses a receive-only backend seam");
         QSignalSpy spy(&model.transmitModel(), &TransmitModel::tuneCommandIssued);
         const bool invoked = QMetaObject::invokeMethod(
             &model.transmitModel(), "tuneCommandIssued", Qt::DirectConnection,

--- a/tests/radio_state_memory_test.cpp
+++ b/tests/radio_state_memory_test.cpp
@@ -42,7 +42,8 @@ RadioCapabilities hl2Caps()
     caps.family = QStringLiteral("hl2");
     caps.clientSettingsDomains = Domain::Tuning | Domain::Passband
                                  | Domain::SpanRate | Domain::RfGain
-                                 | Domain::TxSetpoints | Domain::Agc;
+                                 | Domain::TxSetpoints | Domain::Agc
+                                 | Domain::Cw;
     return caps;
 }
 
@@ -56,6 +57,17 @@ RestoredRadioState sampleState()
     state.sampleRateHz = 192'000;
     state.agcMode = QStringLiteral("slow");
     state.agcThreshold = 40;
+    state.cwSpeed = 31;
+    state.cwPitch = 720;
+    state.cwBreakIn = 1;
+    state.cwDelay = 275;
+    state.cwSidetone = 0;
+    state.cwIambic = 0;
+    state.cwIambicMode = 1;
+    state.cwSwapPaddles = 1;
+    state.cwlEnabled = 1;
+    state.monGainCw = 73;
+    state.monPanCw = 22;
     state.extensionSchemaVersion = 1;
     // The extension's top level is domain sub-objects (the per-domain gate);
     // each sub-object's contents are backend-owned.
@@ -119,6 +131,14 @@ int main(int argc, char** argv)
         check(restored.agcMode == QStringLiteral("slow")
                   && restored.agcThreshold == 40,
               "AGC mode and threshold round-trip (#4909)");
+        check(restored.cwSpeed == 31 && restored.cwPitch == 720
+                  && restored.cwBreakIn == 1 && restored.cwDelay == 275
+                  && restored.cwSidetone == 0 && restored.cwIambic == 0
+                  && restored.cwIambicMode == 1
+                  && restored.cwSwapPaddles == 1
+                  && restored.cwlEnabled == 1 && restored.monGainCw == 73
+                  && restored.monPanCw == 22,
+              "the complete client-owned CW surface round-trips");
         check(restored.extensionSchemaVersion == 1
                   && restored.extension.value(QStringLiteral("rfGain"))
                              .toObject()
@@ -162,6 +182,45 @@ int main(int argc, char** argv)
         // deliberate AGC-T of 0.
         check(gated.agcMode.isEmpty() && gated.agcThreshold == -1,
               "an undeclared Agc domain is absent, not a threshold of 0");
+        check(gated.cwSpeed == 0 && gated.cwPitch == 0
+                  && gated.cwBreakIn == -1 && gated.cwDelay == -1
+                  && gated.monGainCw == -1 && gated.monPanCw == -1,
+              "an undeclared CW domain stays absent");
+    }
+
+    // ---- deliberate false/zero CW values survive -------------------------
+    // Every boolean and slider can legitimately sit at zero. The absent
+    // sentinel is therefore -1 for those fields, while speed/pitch use zero
+    // because their valid ranges start above it.
+    {
+        RadioCapabilities cwOnly;
+        cwOnly.family = QStringLiteral("hl2");
+        cwOnly.clientSettingsDomains = Domain::Cw;
+        const RadioSettingsScope zeroCwRadio(
+            QStringLiteral("hl2"), QStringLiteral("00:00:00:00:00:C0"));
+        RestoredRadioState state;
+        state.cwSpeed = 5;
+        state.cwPitch = 100;
+        state.cwBreakIn = 0;
+        state.cwDelay = 0;
+        state.cwSidetone = 0;
+        state.cwIambic = 0;
+        state.cwIambicMode = 0;
+        state.cwSwapPaddles = 0;
+        state.cwlEnabled = 0;
+        state.monGainCw = 0;
+        state.monPanCw = 0;
+        check(RadioStateMemory::store(zeroCwRadio, cwOnly, state),
+              "deliberate false/zero CW values store");
+        const RestoredRadioState back =
+            RadioStateMemory::load(zeroCwRadio, cwOnly);
+        check(back.cwSpeed == 5 && back.cwPitch == 100
+                  && back.cwBreakIn == 0 && back.cwDelay == 0
+                  && back.cwSidetone == 0 && back.cwIambic == 0
+                  && back.cwIambicMode == 0 && back.cwSwapPaddles == 0
+                  && back.cwlEnabled == 0 && back.monGainCw == 0
+                  && back.monPanCw == 0,
+              "false/zero CW values are not mistaken for absent");
     }
 
     // ---- a threshold of ZERO survives the round-trip -----------------------

--- a/tests/transmit_model_test.cpp
+++ b/tests/transmit_model_test.cpp
@@ -102,6 +102,25 @@ int main(int argc, char** argv)
     // mic selection.
     commands.clear();
 
+    // CW controls must adopt operator intent even when no radio-side status
+    // echo exists (HL2/software keyer). Otherwise the shortcut toggles the
+    // same stale value forever and the local iambic keyer never sees swap.
+    int cwPhoneEdges = 0;
+    QObject::connect(&tx, &TransmitModel::phoneStateChanged,
+                     [&cwPhoneEdges] { ++cwPhoneEdges; });
+    tx.setCwSwapPaddles(true);
+    ok &= expect(tx.cwSwapPaddles()
+                 && commands == QStringList({"cw swap 1"})
+                 && cwPhoneEdges == 1,
+                 "CW paddle swap is adopted locally and still commands Flex");
+    commands.clear();
+    tx.setCwlEnabled(true);
+    ok &= expect(tx.cwlEnabled()
+                 && commands == QStringList({"cw cwl_enabled 1"})
+                 && cwPhoneEdges == 2,
+                 "CWL selection is adopted locally and still commands Flex");
+    commands.clear();
+
     tx.startTwoToneTune();
     ok &= expect(commands == QStringList({
                      "transmit set tune_mode=two_tone",


### PR DESCRIPTION
## Summary

This delivers a complete Hermes Lite 2 CW feature set in AetherSDR:

- straight-key, dit/dah paddle, serial-keyer, MIDI-keyer, and keyboard shortcut transmit
- host-timed iambic A/B keying with speed and paddle-swap controls
- Break In automatic MOX with configurable key-up hang, plus manual-MOX semi-break-in operation
- click-shaped, zero-offset CW carrier generation in the Protocol 1 EP2 IQ stream
- local sidetone enable, pitch, volume, and stereo balance
- CWU/CWL selection and receiver-BFO synchronization
- radio-scoped persistence for the complete HL2 CW control surface

This PR intentionally ships CW transmit, sidebar behavior, and persistence as one cohesive HL2 feature. HL2 has no radio-side CW state store, so working controls without client-owned persistence would reopen on defaults after every restart. Flex continues to use its radio-authoritative CW state and NetCW transport.

## Architecture

`IRadioBackend::setCwKeying()` carries timed element edges to host-modulating backends. HL2 turns those edges into a 5 ms raised-cosine carrier envelope at the displayed TX frequency. Break In raises MOX on the first element and releases it after the configured delay; with Break In disabled, CW remains inside an operator-controlled MOX/PTT envelope.

CW owns the HL2 IQ payload for its PTT envelope so queued microphone samples cannot leak into inter-element spaces. Both MOX and carrier generation remain behind the final transmit-permission gate.

HL2 declares a typed client-owned CW settings domain. `RadioModel` atomically stores and restores speed, pitch, Break In, delay, sidetone enable, iambic enable/mode, paddle swap, CWL, sidetone gain, and sidetone pan in the radio-scoped operating-state document. Flex declares no client-owned CW domain and is never overwritten by this path.

## Transmit safety

Every non-Flex CW key-down now passes the same backend-capability and receive-only-pan transmit preflight used by normal PTT before crossing the radio seam. A refused straight-key or iambic down never reaches HL2 and does not publish false key-active state. Key-up always crosses the seam, even if capability or pan state changes mid-element, so an inhibit cannot strand RF on.

## Hardware proof

Manual Hermes Lite 2 test by @jensenpat at 14.340 MHz, 1 W, into the ANT1 dummy load:

- MOX, straight-key, dit, and dah shortcuts transmitted on the wire
- Break In automatically raised and released PTT
- manual-MOX semi-break-in worked with Break In disabled
- speed, pitch, delay, sidetone volume, balance, iambic mode, paddle swap, and CWL controls worked live
- radio was left unkeyed after testing

## Tests

- focused CW, persistence, model, DSP, and transmit-inhibit tests: 6/6 passed in 5.9 seconds
- inhibited straight-key and iambic downs do not cross the backend seam
- key-up crosses the seam under both receive-only-pan and receive-only-backend states
- the same uninhibited down crosses the seam and publishes one key-active edge
- `hl2_tx_loopback_test` passed against `./hpsdrsim -hermeslite2 -P1`
- strict engine-boundary check passed with baseline warnings only
- GitHub macOS, Windows, Linux, and static checks passed on the original feature head; the review-fix head will rerun them

## Agent automation bridge gap

Momentary keyer inputs still need a TX-gated phaseful action such as `shortcutEdge <id> down|up`. The current shortcut action is atomic and cannot independently hold and release a straight key or paddle edge.

Generated with OpenAI Codex (Daybreak Blue)
