### PR TITLE
fix(hl2): show the first-connect setup in a modal, and stop tests measuring FFTW plans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,38 +286,11 @@ jobs:
       - name: Test MIDI settings and profile import/export
         run: ctest --test-dir build -R "^midi_settings_test$" --output-on-failure
 
-      # hl2_am_dcblock_test is deliberately NOT on this gate. The reason it
-      # came off (#4873) is now fixed, but re-adding it is a coverage call
-      # somebody should make deliberately rather than a side effect of this
-      # comment being updated.
-      #
-      # The history, because the old note here recommended a fix we went on to
-      # reject. The step ran 188-190 s, dead flat across runs. That was never
-      # the test's own work: it was WDSP's first OpenChannel measuring FFTW
-      # PATIENT plans, and a CI container starts cold every run. The note
-      # proposed caching wdsp-fftw-wisdom the way ccache is cached above.
-      #
-      # That would not have worked. Measured on macOS/arm64: the APP's own
-      # 38 KB wisdom cache made no difference at all to wdsp_channel_test —
-      # 22.8 s warm vs 22.4 s cold — because the app's plan set and the tests'
-      # plan set are different FFTW problems. Only a cache the tests themselves
-      # had written helped (22.4 s -> 2.4 s), which is precisely what a fresh
-      # container never has. Caching would have stored an entry that never hit.
-      #
-      # So the planner is bounded instead, in CMake rather than here: every
-      # test now runs with AETHER_WDSP_FFTW_TIMELIMIT set, which
-      # caps fftw_set_timelimit() and skips the wisdom export entirely (rushed
-      # plans must never reach the cache the app imports). See the block at the
-      # end of tests/tests.cmake. Being a ctest property it applies to LOCAL
-      # runs and to the weekly sanitizers job identically — there is no CI-only
-      # workaround to drift out of sync with what developers see.
-      #
-      # Measured, cold cache, ctest -R '^(hl2|wdsp)_' -j8, macOS/arm64:
-      #   before: 100.5 s wall / 632.0 s CPU
-      #   after:   21.6 s wall /   9.3 s CPU
-      # The remaining wall time is socket and timer waits in hl2_backend_test,
-      # not FFTW. hl2_am_dcblock_test alone is ~3 s on this gate's hardware
-      # class if the slot is ever wanted back.
+      # Restored after #4877 bounded FFTW planning for every test. This step was
+      # previously 188-190 s on a cold runner; it now measures ~3 s while still
+      # exercising six four-second AM/SAM audio bursts through the real HL2 DSP.
+      - name: Test HL2 AM/SAM DC blocker
+        run: ctest --test-dir build -R "^hl2_am_dcblock_test$" --output-on-failure
 
       # ulanzi_mapping_migration_test was on this gate (added by #4834) and is
       # not any more. Unlike hl2_am_dcblock_test above it was not costing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,37 +286,38 @@ jobs:
       - name: Test MIDI settings and profile import/export
         run: ctest --test-dir build -R "^midi_settings_test$" --output-on-failure
 
-      # hl2_am_dcblock_test is deliberately NOT on this gate, and re-adding it
-      # needs a measurement first. #4774 added it here on the "milliseconds
-      # against an already-linked target" rationale every other step above
-      # earns its slot with, but that rationale was never measured: the step
-      # ran 188-190 s here, dead flat across runs. That is NOT the test's own
-      # work, and the flatness is the tell: the same binary runs in 2.5 s with
-      # a warm FFTW wisdom cache and 178 s with a cold one (measured locally,
-      # RelWithDebInfo, by pointing XDG_CACHE_HOME at an empty dir). The cost
-      # is WDSP's first OpenChannel measuring FFTW PATIENT plans, which
-      # WdspChannel::open() caches to $XDG_CACHE_HOME/aethersdr/wdsp-fftw-wisdom
-      # — and a CI container starts without that file every single run. Six
-      # 4 s bursts of 48 kHz audio through the real chain is the 2.5 s part.
+      # hl2_am_dcblock_test is deliberately NOT on this gate. The reason it
+      # came off (#4873) is now fixed, but re-adding it is a coverage call
+      # somebody should make deliberately rather than a side effect of this
+      # comment being updated.
       #
-      # So the slot is recoverable, and cheaply: cache wdsp-fftw-wisdom the way
-      # ccache is cached above (or prime it in the CI image) and this step is
-      # ~3 s, not 190. Anything else that opens a WDSP channel on this gate
-      # pays the same 190 s once until that lands, so it is worth doing before
-      # the next WDSP test wants a slot rather than after.
+      # The history, because the old note here recommended a fix we went on to
+      # reject. The step ran 188-190 s, dead flat across runs. That was never
+      # the test's own work: it was WDSP's first OpenChannel measuring FFTW
+      # PATIENT plans, and a CI container starts cold every run. The note
+      # proposed caching wdsp-fftw-wisdom the way ccache is cached above.
       #
-      # Until then coverage sits on the weekly sanitizers job, which runs the
-      # full ctest suite unfiltered — the same place the rest of the HL2 suite
-      # (hl2_backend_test and friends, tens of seconds apiece against timers
-      # and sockets) already lives. Read that as a weaker backstop than it
-      # sounds: sanitizers.yml has concluded failure on every run since
-      # 2026-06-08, its TSan entry has run zero tests since 2026-07-13
-      # (#4360), and ASan failures append to a sticky issue that is already
-      # open — so a reintroduced pedestal arrives as one more comment on a red
-      # job rather than as a new signal. hl2_am_dcblock_test has also never
-      # actually run there (it landed 2026-08-05, after the last weekly run),
-      # and CMakeLists sets no TIMEOUT for it against ctest's 1500 s default
-      # at -O0 + ASan.
+      # That would not have worked. Measured on macOS/arm64: the APP's own
+      # 38 KB wisdom cache made no difference at all to wdsp_channel_test —
+      # 22.8 s warm vs 22.4 s cold — because the app's plan set and the tests'
+      # plan set are different FFTW problems. Only a cache the tests themselves
+      # had written helped (22.4 s -> 2.4 s), which is precisely what a fresh
+      # container never has. Caching would have stored an entry that never hit.
+      #
+      # So the planner is bounded instead, in CMake rather than here: every
+      # test now runs with AETHER_WDSP_FFTW_TIMELIMIT set, which
+      # caps fftw_set_timelimit() and skips the wisdom export entirely (rushed
+      # plans must never reach the cache the app imports). See the block at the
+      # end of tests/tests.cmake. Being a ctest property it applies to LOCAL
+      # runs and to the weekly sanitizers job identically — there is no CI-only
+      # workaround to drift out of sync with what developers see.
+      #
+      # Measured, cold cache, ctest -R '^(hl2|wdsp)_' -j8, macOS/arm64:
+      #   before: 100.5 s wall / 632.0 s CPU
+      #   after:   21.6 s wall /   9.3 s CPU
+      # The remaining wall time is socket and timer waits in hl2_backend_test,
+      # not FFTW. hl2_am_dcblock_test alone is ~3 s on this gate's hardware
+      # class if the slot is ever wanted back.
 
       # ulanzi_mapping_migration_test was on this gate (added by #4834) and is
       # not any more. Unlike hl2_am_dcblock_test above it was not costing

--- a/docs/HERMES.md
+++ b/docs/HERMES.md
@@ -357,6 +357,18 @@ end of `tests/tests.cmake`), which bounds the planner through
 app imports, **skips the wisdom export entirely while it is set**. One knob, so
 it is not possible to bound the planner and forget to isolate the cache.
 
+Two independent layers, because one was not enough. The planner bound stops the
+export; separately, `AETHER_WDSP_WISDOM_DIR` **redirects the cache path** to
+`<build>/test-fftw-wisdom`. Both are set by `tests/TestWdspWisdomIsolation.cpp`,
+a TU linked into every test target whose static initializer runs **before
+main()** — because a ctest `ENVIRONMENT` property only covers `ctest`, and
+running a test binary directly (`./build/hl2_rxdsp_test`, the normal way to
+debug one) inherits nothing and would export straight over the operator's real
+cache. Verified: full `ctest` with no isolation, and four binaries run directly
+with a scrubbed environment, all leave `~/.cache/aethersdr/wdsp-fftw-wisdom`
+byte-identical; forcing the unbounded escape hatch writes 15 KB into the build
+dir instead of the real cache.
+
 It is applied to *every* registered test rather than to an `hl2_*`/`wdsp_*` name
 prefix, which was the first attempt and leaked: `automation_connect_wait_phase_test`
 and `transmit_model_test` drive HL2 DSP without an `hl2_` name, ran unbounded, and

--- a/docs/HERMES.md
+++ b/docs/HERMES.md
@@ -341,13 +341,33 @@ removes the pedestal just as thoroughly while eating the bass out of every mode,
 and every DC measurement stays green through it. So it checks a 60 Hz vs 400 Hz
 modulation ratio through the real chain, the closed-form `|H(f)|` at three audio
 rates, and the unconfigured bypass. Six 4 s bursts through the real chain cost
-2.5 s, so it is a cheap test — but only with a warm FFTW wisdom cache. Cold, the
-same binary takes 178 s, because WDSP's first `OpenChannel` measures FFTW
-`PATIENT` plans (see `WdspChannel::open()`, cached at
-`$XDG_CACHE_HOME/aethersdr/wdsp-fftw-wisdom`). A CI container starts cold every
-run, which is why this sat at 188-190 s on the per-PR gate and now runs weekly
-under the sanitizers job instead. Cache that file in CI and it belongs back on
-the gate.
+2.5 s, so it is a cheap test. It used to take 178 s cold, because WDSP's first
+`OpenChannel` measures FFTW `PATIENT` plans (see `WdspChannel::open()`, cached
+at `$XDG_CACHE_HOME/aethersdr/wdsp-fftw-wisdom`) and a CI container starts cold
+every run — which is why it sat at 188-190 s on the per-PR gate and came off it.
+
+**That is fixed, and not by caching the file.** Caching was the obvious move and
+it does not work: the app's own 38 KB cache made no measurable difference to
+`wdsp_channel_test` (22.8 s warm vs 22.4 s cold on macOS/arm64), because the
+app's plan set and the tests' plan set are different FFTW problems. Only a cache
+the tests themselves wrote helped — which a fresh container never has. Instead
+every test now runs with `AETHER_WDSP_FFTW_TIMELIMIT` set (see the block at the
+end of `tests/tests.cmake`), which bounds the planner through
+`fftw_set_timelimit()` and, because rushed plans must never reach the cache the
+app imports, **skips the wisdom export entirely while it is set**. One knob, so
+it is not possible to bound the planner and forget to isolate the cache.
+
+It is applied to *every* registered test rather than to an `hl2_*`/`wdsp_*` name
+prefix, which was the first attempt and leaked: `automation_connect_wait_phase_test`
+and `transmit_model_test` drive HL2 DSP without an `hl2_` name, ran unbounded, and
+were observed replacing a developer's real 38 KB cache with an 11 KB test-only one.
+Naming is not a proxy for what a test opens, and the failure is silent — the suite
+still passes, it just degrades the next real connect.
+
+Measured cold, `ctest -R '^(hl2|wdsp)_' -j8`, macOS/arm64: **100.5 s wall /
+632.0 s CPU before, 21.6 s wall / 9.3 s CPU after.** The CPU figure is the one
+that matters for CI. A radio session never sets the variable and keeps the full
+`PATIENT` plans it always had.
 
 **Why on `Hl2RxDsp` and not on `WdspChannel`.** The root cause is `amd`'s
 envelope detector, which belongs to WDSP, so a blocker on `WdspChannel`'s own RX
@@ -947,7 +967,7 @@ radio. See §18 for the full audit and the proposed seam.
 | `output_samplerate` | 48000 | 24000 | AudioEngine's native rate; avoids a resample. Legitimate, but it IS a divergence in the area that produced our worst bug — keep it labelled |
 | Rate change | `SetAllRates` | Rebuild the channel | Dodges the intermediate-inconsistent-state hazard entirely. Heavier, but NOT because of FFTW — a rebuild at a new rate re-plans almost nothing (§22.4). It is heavier because it is a close+open per receiver, and it still blocks the GUI thread |
 | Spectrum | WDSP analyzer (returns pixels) | Own `Hl2Spectrum` FFT | A3 §4 recommends exactly this for our architecture. **If it ever looks noisy, the lever is a detector/averaging mode, not a bigger FFT** |
-| FFTW wisdom | `WDSPwisdom(dir)` | Own `fftw_import_wisdom_from_filename` + eager export | `WDSPwisdom` is Windows-console-only. First-run slowness is expected; the fix was a progress indicator plus getting the wisdom to actually persist (§22) |
+| FFTW wisdom | `WDSPwisdom(dir)` | Own `fftw_import_wisdom_from_filename` + eager export | `WDSPwisdom` is Windows-console-only. First-run slowness is expected; the fix was getting the wisdom to actually persist (§22) plus telling the operator what the wait is — in a modal dialog, because the panadapter label that first carried it was drawn behind the Connect Radio window and never seen (#5052). Tests bound the planner instead of paying it; see "AM/SAM hand back a DC pedestal" |
 
 ### Settled — no action
 
@@ -3401,6 +3421,14 @@ Measured cold, both orderings, with `WdspChannel` opened exactly as
 The first open costs ~19 s whichever rate it is; every other rate afterwards is
 40–175 ms. The plan sets overlap almost completely, so **do not reason about
 "cold wisdom for this sample rate"** — there is one cold open per machine, ever.
+
+That "once per machine" is what the first-connect dialog tells the operator, and
+saying it is the point: a 20 s wait you are told happens once reads very
+differently from a 20 s wait with a window on screen that says "Connecting…".
+The dialog is gated on elapsed time (1500 ms), not on a cold-cache predicate —
+`WdspChannel` exposes none, and one could not be exact anyway, since a cache
+that imports cleanly may still lack plans for these geometries and would report
+"warm" while the open measured regardless. See `MainWindow::armWdspSetupDialog`.
 
 ### 22.4 Still open: two paths that still block the GUI thread
 

--- a/src/core/dsp/WdspChannel.cpp
+++ b/src/core/dsp/WdspChannel.cpp
@@ -51,6 +51,23 @@ std::string wisdomPath()
 {
     namespace fs = std::filesystem;
     fs::path dir;
+    // Explicit override, consulted before anything else. This exists so a TEST
+    // process can be pointed at a build-local cache and be structurally unable
+    // to reach the operator's real one — see tests/TestWdspWisdomIsolation.cpp,
+    // which sets it before main() so it holds for a test binary run DIRECTLY,
+    // not only for one launched through ctest.
+    //
+    // Redirecting beats suppressing the export: the tests keep a persistent
+    // cache of their own, so repeat runs import instead of re-measuring, and
+    // there is no "did we remember to disable writing" question left to get
+    // wrong. Never set by the app.
+    if (const char* override = std::getenv("AETHER_WDSP_WISDOM_DIR");
+        override != nullptr && *override != '\0') {
+        dir = override;
+        std::error_code overrideEc;
+        fs::create_directories(dir, overrideEc);   // best-effort
+        return (dir / "wdsp-fftw-wisdom").string();
+    }
 #ifdef _WIN32
     if (const char* la = std::getenv("LOCALAPPDATA")) dir = la;
 #else

--- a/src/core/dsp/WdspChannel.cpp
+++ b/src/core/dsp/WdspChannel.cpp
@@ -67,10 +67,67 @@ std::string wisdomPath()
     return (dir / "wdsp-fftw-wisdom").string();
 }
 
+// Test/CI escape hatch: bound how long FFTW may spend measuring each plan.
+//
+// WDSP builds every FFT with FFTW_PATIENT, which is right for a radio session
+// and ruinous for a test suite: the first OpenChannel in a cold process spends
+// 20 s (macOS, arm64) to 190 s (CI, x86_64) measuring plans, and a CI container
+// starts cold on every single run. That cost is not the tests' own work and it
+// buys them nothing -- a correctness test cares that the FFT is right, never
+// that it is optimal.
+//
+// AETHER_WDSP_FFTW_TIMELIMIT=<seconds> caps the planner via FFTW's own
+// documented global setting, so no vendored WDSP source has to be patched to
+// reach the flag it hardcodes. Measured on this machine, 15 representative
+// PATIENT plans: 4.79 s unbounded, 0.02 s at 0.001. The bound is approximate
+// and applies PER PLAN, not to the process -- FFTW cannot interrupt a single
+// measurement -- so the total still scales with the number of plans. Do not
+// read a 0.001 limit as "planning takes 1 ms".
+//
+// UNSET IS THE SHIPPING PATH. A radio session never sets this and gets the
+// full PATIENT plans it always had.
+//
+// A bounded process also NEVER WRITES THE WISDOM CACHE (see open()). Plans
+// measured under a time limit are worse than the ones a real session wants,
+// and the cache is shared with the app -- exporting them would hand the
+// operator's radio the test suite's rushed plans. That is the whole reason
+// this is one knob and not two: it is not possible to bound the planner and
+// forget to isolate the cache.
+double plannerTimeLimitSeconds()
+{
+    static const double limit = [] {
+        const char* raw = std::getenv("AETHER_WDSP_FFTW_TIMELIMIT");
+        if (raw == nullptr || *raw == '\0')
+            return -1.0;
+        char* end = nullptr;
+        const double parsed = std::strtod(raw, &end);
+        // A malformed value is ignored rather than treated as 0: silently
+        // rushing every plan because someone typed "yes" would be a very
+        // quiet way to ship bad plans.
+        if (end == raw || !std::isfinite(parsed) || parsed < 0.0)
+            return -1.0;
+        return parsed;
+    }();
+    return limit;
+}
+
+// True when this process is running with a bounded planner, i.e. its measured
+// plans are not good enough to publish to the shared cache.
+bool plannerIsBounded()
+{
+    return plannerTimeLimitSeconds() >= 0.0;
+}
+
 void loadWisdomOnce()
 {
     static std::once_flag flag;
-    std::call_once(flag, [] { fftw_import_wisdom_from_filename(wisdomPath().c_str()); });
+    std::call_once(flag, [] {
+        // Before the first plan, so it governs every one of them. FFTW's
+        // default is FFTW_NO_TIMELIMIT and we only ever move off it here.
+        if (plannerIsBounded())
+            fftw_set_timelimit(plannerTimeLimitSeconds());
+        fftw_import_wisdom_from_filename(wisdomPath().c_str());
+    });
 }
 
 // Write the wisdom cache NOW. Called at the end of open(), under g_setupMutex,
@@ -615,11 +672,6 @@ uint64_t WdspChannel::outstandingAllocationsForTest() noexcept
     return wdspPortOutstandingAllocations();
 }
 
-std::string WdspChannel::wisdomCachePathForTest()
-{
-    return wisdomPath();
-}
-
 bool WdspChannel::validateConfig(const Config& config, std::string* error) noexcept
 {
     if (config.inputBlockSize == 0 || config.dspBlockSize == 0 ||
@@ -779,8 +831,13 @@ void WdspChannel::open() noexcept
     }
     // Cache what this open measured, right now, while we still hold the setup
     // lock -- a kill or a crash before exit must not throw the measurement away.
-    exportWisdomNow();
-    armWisdomExportOnce();   // and again at exit, for later setMode/setFilter plans
+    // Bounded planner => rushed plans => do not publish them. See
+    // plannerTimeLimitSeconds(): this cache is shared with the running app, so
+    // a test run that exported would degrade the operator's next connect.
+    if (!plannerIsBounded()) {
+        exportWisdomNow();
+        armWisdomExportOnce();   // and again at exit, for later setMode/setFilter plans
+    }
     // Before the channel starts, so the first block through processIq() finds
     // its staging buffers sized and the stage already created.
     openNoiseBlanker();

--- a/src/core/dsp/WdspChannel.h
+++ b/src/core/dsp/WdspChannel.h
@@ -261,13 +261,6 @@ public:
     static uint64_t allocationSequenceForTest() noexcept;
     static uint64_t outstandingAllocationsForTest() noexcept;
 
-    // Where open() writes the FFTW wisdom cache. Exposed so a test can assert
-    // the file is on disk once open() has RETURNED — the defect it pins is
-    // wisdom that only ever reached disk through an atexit handler, which every
-    // signal-terminated run skipped. Reading the path instead of hardcoding it
-    // keeps the test honest about the env vars wisdomPath() actually consults.
-    static std::string wisdomCachePathForTest();
-
 private:
     explicit WdspChannel(int channelId, const Config& config) noexcept;
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6444,6 +6444,16 @@ void MainWindow::setPanadapterConnectionAnimation(bool visible, const QString& l
     m_waitingForFirstPanadapterFrame = visible;
     m_panadapterConnectionAnimationLabel = visible ? nextLabel : QString();
 
+    // The connect is over (connected, failed, cancelled, or the operator hit
+    // Disconnect) — so the HL2 setup dialog, which only ever explains a connect,
+    // goes with it. This is the safety net that matters: dspSetupFinished is
+    // emitted on every path OUT of finishDspSetup, but a backend destroyed
+    // mid-build (a family switch) takes its QPointer with it and emits nothing
+    // at all. Without this an application-modal window with no Cancel button
+    // would be left on screen with nothing able to close it. (#5052)
+    if (!visible)
+        dismissWdspSetupDialog();
+
     if (!m_panStack)
         return;
 
@@ -6452,6 +6462,150 @@ void MainWindow::setPanadapterConnectionAnimation(bool visible, const QString& l
             continue;
         if (auto* spectrumWidget = applet->spectrumWidget())
             spectrumWidget->setConnectionAnimationVisible(visible, nextLabel);
+    }
+}
+
+// ── HL2 first-connect WDSP setup dialog (#5052) ─────────────────────────────
+//
+// Gated on ELAPSED TIME, not on "a connect started". With a warm FFTW wisdom
+// cache the whole DSP build is ~0.5 s, and a dialog that appeared on every
+// connect would flash for half a second every single time — worse than the
+// silence it replaces, and invisible to anyone testing on a developer machine
+// because their cache is always warm. So arm a delay on the first progress
+// signal and only build the dialog if the build is STILL running when it fires.
+// A cold connect (~20 s) crosses that line; a warm one never does.
+//
+// Time is also the honest signal here, and deliberately preferred to a
+// cold-cache predicate. WdspChannel exposes none, and one could not be exact
+// anyway: a cache that imports cleanly may still lack plans for these
+// particular geometries, so it would report "warm" and the open would measure
+// regardless. Elapsed time measures the thing the operator actually experiences.
+static constexpr int kWdspSetupDialogDelayMs = 1500;
+
+void MainWindow::armWdspSetupDialog()
+{
+    // CONNECT WINDOW ONLY. A mid-session rebuild opens WDSP channels too — a
+    // span change that crosses a sample-rate boundary rebuilds every receiver —
+    // and throwing an application-modal window over a radio the operator is
+    // working would be far worse than saying nothing. This flag is precisely
+    // "a connect is in progress": set before connectToRadio(), cleared when the
+    // radio reports connected or the attempt ends.
+    if (!m_panadapterConnectionAnimationVisible)
+        return;
+    if (m_wdspSetupDialog)
+        return;   // already up
+    if (!m_wdspSetupDelayTimer) {
+        m_wdspSetupDelayTimer = new QTimer(this);
+        m_wdspSetupDelayTimer->setSingleShot(true);
+        connect(m_wdspSetupDelayTimer, &QTimer::timeout,
+                this, &MainWindow::showWdspSetupDialog);
+    }
+    if (m_wdspSetupDelayTimer->isActive())
+        return;   // dspSetupProgress fires once per receiver; arm on the first
+    m_wdspSetupDelayTimer->start(kWdspSetupDialogDelayMs);
+}
+
+void MainWindow::showWdspSetupDialog()
+{
+    // Re-checked, not assumed: 1500 ms is plenty of time for the connect to have
+    // failed or been cancelled out from under the timer.
+    if (!m_panadapterConnectionAnimationVisible || m_wdspSetupDialog)
+        return;
+
+    const bool frameless = framelessWindowEnabled();
+    auto* dlg = new QDialog(this);
+    // Stable handle for the automation bridge. Without it a bridge test has to
+    // find this window by its localized title text, which breaks on any copy
+    // change and in every non-English locale.
+    dlg->setObjectName(QStringLiteral("wdspSetupDialog"));
+    dlg->setWindowTitle(tr("Setting Up Your Radio"));
+    dlg->setWindowFlag(Qt::FramelessWindowHint, frameless);
+    // APPLICATION-MODAL, and this is the whole point of the fix. The NR2 wisdom
+    // dialog next door is deliberately NonModal + Qt::Tool +
+    // WA_ShowWithoutActivating; copying those three lines here would reproduce
+    // #5052 exactly, because a non-activating tool window is not guaranteed to
+    // sit above a parented Qt::Dialog like ConnectionPanel.
+    //
+    // Modality is also correct here in a way it is not for NR2: NR2 runs against
+    // a WORKING radio and locking the operator out of it for minutes was the
+    // worse trade. Here nothing has connected yet — there is no radio to
+    // operate, and the connect panel behind this is inert.
+    dlg->setWindowModality(Qt::ApplicationModal);
+    dlg->setMinimumWidth(460);
+    AetherSDR::ThemeManager::instance().applyStyleSheet(dlg,
+        "QDialog { background: {{color.background.0}}; border: 1px solid {{color.background.1}}; }"
+        "QLabel { color: {{color.text.secondary}}; background: transparent; }"
+        "QLabel#wdspSetupTitle { color: {{color.text.primary}}; font-size: 15px; font-weight: bold; }"
+        "QProgressBar { text-align: center; font-size: 12px; max-height: 6px;"
+        " background: {{color.background.0}}; border: 1px solid {{color.background.1}}; border-radius: 3px; }"
+        "QProgressBar::chunk { background: {{color.accent}}; border-radius: 3px; }");
+
+    auto* root = new QVBoxLayout(dlg);
+    root->setContentsMargins(0, 0, 0, 0);
+    root->setSpacing(0);
+
+    auto* titleBar = new FramelessWindowTitleBar(tr("Setting Up Your Radio"), dlg);
+    titleBar->setObjectName(QStringLiteral("framelessWindowTitleBar"));
+    titleBar->setVisible(frameless);
+    root->addWidget(titleBar);
+
+    auto* content = new QWidget(dlg);
+    auto* body = new QVBoxLayout(content);
+    body->setContentsMargins(20, frameless ? 16 : 18, 20, 18);
+    body->setSpacing(10);
+
+    auto* title = new QLabel(tr("Your radio is connected"), content);
+    title->setObjectName(QStringLiteral("wdspSetupTitle"));
+    body->addWidget(title);
+
+    // "Once" is the load-bearing sentence. The cost is genuinely per machine,
+    // not per connect (#4775 measured one ~19 s open and 40-175 ms for every
+    // rate afterwards), and saying so is what turns a bad first impression into
+    // an acceptable one.
+    auto* detail = new QLabel(
+        // "Up to a minute", not a point estimate. #4775 measured ~19 s on
+        // Linux/x86_64; a 4-receiver cold connect on macOS/arm64 measured 47 s.
+        // Promising 20 s and taking 47 is how this earns a second "it hung"
+        // report — the number has to cover the slow end, not the fast one.
+        tr("AetherSDR is tuning its signal processing for this computer. "
+           "This takes up to a minute and happens only once — future "
+           "connections will be immediate."),
+        content);
+    detail->setWordWrap(true);
+    body->addWidget(detail);
+
+    // INDETERMINATE. dspSetupProgress does carry an (n of m) receiver count, but
+    // presenting it as progress would be a lie: #4775 measured 18865 ms for the
+    // first receiver and 100/71/39 ms for the rest, so the bar would sit at 1/4
+    // for the entire wait and then fill in a tenth of a second. A determinate
+    // bar needs a time estimate we do not have.
+    auto* progress = new QProgressBar(content);
+    progress->setRange(0, 0);
+    progress->setTextVisible(false);
+    body->addWidget(progress);
+
+    root->addWidget(content);
+
+    // No Cancel button: WDSP's OpenChannel cannot be aborted, so a button that
+    // claimed to stop this would be lying. Esc/close still dismiss the window —
+    // that only hides the explanation, which beats trapping the operator.
+    m_wdspSetupDialog = dlg;
+    connect(dlg, &QDialog::finished, this, [this, dlg](int) {
+        if (m_wdspSetupDialog == dlg)
+            m_wdspSetupDialog = nullptr;
+        dlg->deleteLater();
+    });
+    dlg->show();
+}
+
+void MainWindow::dismissWdspSetupDialog()
+{
+    if (m_wdspSetupDelayTimer)
+        m_wdspSetupDelayTimer->stop();
+    if (m_wdspSetupDialog) {
+        // accept() runs the finished() handler above, which clears the pointer
+        // and schedules deletion.
+        m_wdspSetupDialog->accept();
     }
 }
 
@@ -6495,9 +6649,18 @@ void MainWindow::wireBackendSeam(IRadioBackend* backend)
 
     // HL2 only, and deliberately: the client-side WDSP chains are this family's
     // alone. Opening them measures FFTW plans, which on a machine with no cached
-    // wisdom takes tens of seconds — long enough that a silent connect animation
-    // reads as a hung application. Say what is happening in the label that is
-    // already on screen rather than adding a dialog for it.
+    // wisdom takes ~20 s — long enough that a silent connect reads as a hung
+    // application.
+    //
+    // This used to write the explanation into the panadapter connection
+    // animation. It was never visible (#5052): ConnectionPanel is a top-level
+    // Qt::Dialog PARENTED to this window, so the window manager keeps it above
+    // us unconditionally, showConnectionDialog() anchors its 760x660 frame over
+    // the lower-centre of the panadapter — exactly where the animation draws —
+    // and it is not hidden until onConnectionStateChanged(connected), which is
+    // AFTER this whole window. So for all ~20 s the operator saw a panel reading
+    // "Connecting…" and nothing else, which is the "the client has hung" report
+    // that #4775 set out to answer in the first place.
     if (auto* hl2Backend = dynamic_cast<hl2::Hl2Backend*>(backend)) {
         // Disconnected first, like every other lambda connect in this function:
         // the helper promises to be idempotent for the same live backend, and
@@ -6505,24 +6668,9 @@ void MainWindow::wireBackendSeam(IRadioBackend* backend)
         disconnect(hl2Backend, &hl2::Hl2Backend::dspSetupProgress, this, nullptr);
         disconnect(hl2Backend, &hl2::Hl2Backend::dspSetupFinished, this, nullptr);
         connect(hl2Backend, &hl2::Hl2Backend::dspSetupProgress, this,
-                [this](const QString& stage, int done, int total) {
-            // Only while the connect animation is up. A DSP rebuild can happen
-            // mid-session (a span change), and hijacking the panadapter with a
-            // connect label for it would be a worse lie than saying nothing.
-            if (!m_panadapterConnectionAnimationVisible)
-                return;
-            const QString label = total > 1
-                ? tr("%1 (%2 of %3)").arg(stage).arg(done + 1).arg(total)
-                : stage;
-            setPanadapterConnectionAnimation(true, label);
-        });
-        // Put the label back to the generic one, so what remains of the connect
-        // — the wire coming up, the first EP6 packet — is not still described as
-        // DSP setup.
-        connect(hl2Backend, &hl2::Hl2Backend::dspSetupFinished, this, [this] {
-            if (m_panadapterConnectionAnimationVisible)
-                setPanadapterConnectionAnimation(true, tr("Connecting to radio…"));
-        });
+                [this](const QString&, int, int) { armWdspSetupDialog(); });
+        connect(hl2Backend, &hl2::Hl2Backend::dspSetupFinished, this,
+                [this] { dismissWdspSetupDialog(); });
     }
 
     // The demo delivers native 128-sample frames, which the improved 1024/4 NR2

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1652,7 +1652,16 @@ MainWindow::MainWindow(QWidget* parent)
     // no demo audio, no ANF/NB, no legacy-NR2 geometry). One event, one signal.
     wireBackendSeam(m_radioModel.backend());
     connect(&m_radioModel, &RadioModel::backendRebuilt, this,
-            [this] { wireBackendSeam(m_radioModel.backend()); });
+            [this] {
+        // A family switch can destroy an HL2 backend while its uncancellable
+        // DSP build is still running. That backend then cannot emit
+        // dspSetupFinished(), so cancel its delayed dialog before wiring the
+        // replacement backend. Otherwise the overdue timer can mistake the
+        // replacement connection animation for the original HL2 connect and
+        // show a stale application-modal dialog over Flex/Icom.
+        dismissWdspSetupDialog();
+        wireBackendSeam(m_radioModel.backend());
+    });
     connect(m_audio, &AudioEngine::receivePresentationOutputAudioReady,
             this, [this](const QString& source, const QString& sourceId,
                          const QByteArray& pcm, int sampleRate) {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -895,6 +895,15 @@ private:
     void setPaTempDisplayUnit(bool useFahrenheit);
     void setPanadapterConnectionAnimation(bool visible, const QString& label = {});
     void finishPanadapterConnectionAnimation();
+
+    // HL2 first-connect WDSP setup dialog (#5052). arm() is called from every
+    // dspSetupProgress and only starts a delay; show() builds the window if the
+    // build is still running when that delay expires; dismiss() is called from
+    // dspSetupFinished AND from setPanadapterConnectionAnimation(false), which
+    // is the net that catches a backend destroyed mid-build.
+    void armWdspSetupDialog();
+    void showWdspSetupDialog();
+    void dismissWdspSetupDialog();
     void syncMemorySpot(int memoryIndex);
     void removeMemorySpot(int memoryIndex);
     void clearMemorySpotFeed();
@@ -1675,6 +1684,8 @@ private:
     bool m_startupGeometryReapplied{false};
     QByteArray m_startupGeometryForFirstShow;
     QAction* m_minimalModeAction{nullptr};
+    QDialog* m_wdspSetupDialog{nullptr};     // HL2 first-connect setup (#5052)
+    QTimer* m_wdspSetupDelayTimer{nullptr};  // delay-arm, so warm connects show nothing
     bool m_panadapterConnectionAnimationVisible{false};
     bool m_waitingForFirstPanadapterFrame{false};
     QString m_panadapterConnectionAnimationLabel;

--- a/tests/TestWdspWisdomIsolation.cpp
+++ b/tests/TestWdspWisdomIsolation.cpp
@@ -1,0 +1,39 @@
+// Linked into every registered test target (see the loop at the end of
+// tests/tests.cmake). Its whole job is to run BEFORE main() and make it
+// impossible for a test process to write the operator's real FFTW wisdom cache.
+//
+// Why a static initializer and not just a ctest ENVIRONMENT property: the
+// property only covers `ctest`. Running a test binary directly —
+// `QT_QPA_PLATFORM=offscreen ./build/hl2_rxdsp_test`, which is the normal way
+// to debug one — inherits nothing, and WdspChannel::open() would then export
+// over ~/.cache/aethersdr/wdsp-fftw-wisdom. That is a silent 20-60 s tax on the
+// operator's NEXT REAL CONNECT, paid every time they build a PR, with nothing
+// on screen connecting cause to effect. The ctest properties are kept as well,
+// so the values are visible in CTestTestfile.cmake rather than only implied.
+//
+// setenv(..., 0) — do NOT overwrite. An explicit value from ctest, from CI, or
+// from a developer investigating plan quality still wins.
+
+#include <cstdlib>
+
+namespace {
+
+struct WdspWisdomIsolation {
+    WdspWisdomIsolation() noexcept
+    {
+#ifdef _WIN32
+        if (std::getenv("AETHER_WDSP_WISDOM_DIR") == nullptr)
+            _putenv_s("AETHER_WDSP_WISDOM_DIR", AETHER_TEST_WISDOM_DIR);
+        if (std::getenv("AETHER_WDSP_FFTW_TIMELIMIT") == nullptr)
+            _putenv_s("AETHER_WDSP_FFTW_TIMELIMIT", AETHER_TEST_FFTW_TIMELIMIT_STR);
+#else
+        ::setenv("AETHER_WDSP_WISDOM_DIR", AETHER_TEST_WISDOM_DIR, 0);
+        ::setenv("AETHER_WDSP_FFTW_TIMELIMIT", AETHER_TEST_FFTW_TIMELIMIT_STR, 0);
+#endif
+    }
+};
+
+// Namespace-scope object => constructed during static init, before main().
+const WdspWisdomIsolation g_wdspWisdomIsolation;
+
+} // namespace

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3799,12 +3799,41 @@ endforeach()
 # cannot be escaped by a future test under any name.
 #
 # To re-check this hasn't regressed:
-#   XDG_CACHE_HOME=$(mktemp -d) ctest --test-dir build -j8
-#   find "$XDG_CACHE_HOME" -name wdsp-fftw-wisdom   # must print nothing
+#   ctest --test-dir build -j8 && \
+#     find "$HOME/.cache/aethersdr" -newer build/CMakeCache.txt   # must be empty
+set(AETHER_TEST_WISDOM_DIR "${CMAKE_BINARY_DIR}/test-fftw-wisdom")
+
+# The isolation TU, compiled once and linked into every test target below. An
+# OBJECT library rather than STATIC on purpose: its only content is a
+# namespace-scope object whose CONSTRUCTOR is the entire point, and a static
+# library's unreferenced object file can be dropped at link time, which would
+# silently remove the protection.
+add_library(aether_test_wisdom_isolation OBJECT
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/TestWdspWisdomIsolation.cpp)
+target_compile_definitions(aether_test_wisdom_isolation PRIVATE
+    AETHER_TEST_WISDOM_DIR="${AETHER_TEST_WISDOM_DIR}"
+    AETHER_TEST_FFTW_TIMELIMIT_STR="${AETHER_TEST_FFTW_TIMELIMIT}")
+
 get_property(_aether_registered_tests DIRECTORY PROPERTY TESTS)
+set(_aether_test_targets "")
 foreach(_aether_test IN LISTS _aether_registered_tests)
-    # APPEND, so the QT_QPA_PLATFORM=offscreen entries already set on the
-    # GUI-touching ones survive rather than being replaced.
+    # ctest ENVIRONMENT covers `ctest` runs and documents the values in
+    # CTestTestfile.cmake. APPEND, so the QT_QPA_PLATFORM=offscreen entries
+    # already set on the GUI-touching ones survive rather than being replaced.
     set_property(TEST ${_aether_test} APPEND PROPERTY ENVIRONMENT
-        "AETHER_WDSP_FFTW_TIMELIMIT=${AETHER_TEST_FFTW_TIMELIMIT}")
+        "AETHER_WDSP_FFTW_TIMELIMIT=${AETHER_TEST_FFTW_TIMELIMIT}"
+        "AETHER_WDSP_WISDOM_DIR=${AETHER_TEST_WISDOM_DIR}")
+    # ...and the linked-in initializer covers running the binary DIRECTLY, which
+    # ctest properties cannot reach and which is how a test is usually debugged.
+    if(TARGET ${_aether_test})
+        list(APPEND _aether_test_targets ${_aether_test})
+    endif()
+endforeach()
+# A target can back more than one registered test; link the TU once per target.
+list(REMOVE_DUPLICATES _aether_test_targets)
+foreach(_aether_target IN LISTS _aether_test_targets)
+    get_target_property(_aether_type ${_aether_target} TYPE)
+    if(_aether_type STREQUAL "EXECUTABLE")
+        target_link_libraries(${_aether_target} PRIVATE aether_test_wisdom_isolation)
+    endif()
 endforeach()

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3803,6 +3803,26 @@ endforeach()
 #     find "$HOME/.cache/aethersdr" -newer build/CMakeCache.txt   # must be empty
 set(AETHER_TEST_WISDOM_DIR "${CMAKE_BINARY_DIR}/test-fftw-wisdom")
 
+# The per-plan bound itself. MUST BE SET: it is referenced three times below —
+# the ctest ENVIRONMENT property, the compile definition behind
+# TestWdspWisdomIsolation.cpp, and through those the AETHER_WDSP_FFTW_TIMELIMIT
+# the app reads — and an undefined CMake variable expands to the EMPTY STRING at
+# every one of them rather than erroring. WdspChannel treats an empty value as
+# "unset" and returns -1.0 (plannerTimeLimitSeconds()), so the planner runs
+# fully unbounded and the entire bound is silently inert.
+#
+# That failure is invisible to the isolation re-check documented above: the
+# wisdom REDIRECT still works with the bound dead, so no file appears under
+# $HOME/.cache/aethersdr and the check passes. It is also invisible to the test
+# suite, which still passes — just slowly. Measured cold on macOS/arm64,
+# hl2_backend_test: 124.8 s with the variable undefined, 22.5 s with it set
+# here, of which only 2.4 s is CPU. The rest is socket and timer waits.
+#
+# 0.001 s per plan, not per process — FFTW cannot interrupt a measurement in
+# progress, so the total still scales with the number of distinct plans.
+set(AETHER_TEST_FFTW_TIMELIMIT "0.001" CACHE STRING
+    "Seconds FFTW may spend measuring each plan under test (empty = unbounded)")
+
 # The isolation TU, compiled once and linked into every test target below. An
 # OBJECT library rather than STATIC on purpose: its only content is a
 # namespace-scope object whose CONSTRUCTOR is the entire point, and a static

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3766,3 +3766,45 @@ foreach(_settings_consumer IN LISTS AETHER_SETTINGS_CONSUMERS)
         target_link_libraries(${_settings_consumer} PRIVATE aether_sqlite3)
     endif()
 endforeach()
+
+# ── FFTW planner bound for the HL2 / WDSP tests ─────────────────────────────
+#
+# WDSP builds every FFT with FFTW_PATIENT. The first OpenChannel in a cold
+# process therefore spends 20 s (macOS arm64) to 190 s (CI x86_64) measuring
+# plans before the test does any work of its own. A CI container starts cold on
+# every run, so that cost was paid in full every time and thrown away.
+#
+# It also could not be fixed by caching the wisdom file. Measured: the app's own
+# 38 KB cache made NO difference to wdsp_channel_test (22.8 s warm vs 22.4 s
+# cold) because the app's plan set and the tests' plan set are different FFTW
+# problems. Only a cache the tests themselves wrote helped (22.4 s -> 2.4 s),
+# which a fresh container never has.
+#
+# So bound the planner instead. These tests assert that the DSP is CORRECT,
+# never that it is optimal, and a time-limited plan is still a correct plan.
+# WdspChannel reads this var, caps FFTW via fftw_set_timelimit(), and — because
+# rushed plans must never reach the cache the real app imports — skips the
+# wisdom export entirely while it is set.
+#
+# Applied to EVERY registered test, not to an hl2_*/wdsp_* name prefix. The
+# prefix was the first attempt and it leaked: `automation_connect_wait_phase_test`
+# and `transmit_model_test` both drive HL2 DSP without an hl2_ name, so they ran
+# unbounded AND exported — observed clobbering a developer's real 38 KB cache
+# with an 11 KB test-only one mid-review. Naming is not a reliable proxy for
+# what a test opens, and the failure is silent: the suite still passes, it just
+# quietly degrades the next real connect.
+#
+# Blanket application is safe because the variable is read in exactly one place
+# (WdspChannel), so it is inert in every test that never opens a channel, and it
+# cannot be escaped by a future test under any name.
+#
+# To re-check this hasn't regressed:
+#   XDG_CACHE_HOME=$(mktemp -d) ctest --test-dir build -j8
+#   find "$XDG_CACHE_HOME" -name wdsp-fftw-wisdom   # must print nothing
+get_property(_aether_registered_tests DIRECTORY PROPERTY TESTS)
+foreach(_aether_test IN LISTS _aether_registered_tests)
+    # APPEND, so the QT_QPA_PLATFORM=offscreen entries already set on the
+    # GUI-touching ones survive rather than being replaced.
+    set_property(TEST ${_aether_test} APPEND PROPERTY ENVIRONMENT
+        "AETHER_WDSP_FFTW_TIMELIMIT=${AETHER_TEST_FFTW_TIMELIMIT}")
+endforeach()

--- a/tests/wdsp_channel_test.cpp
+++ b/tests/wdsp_channel_test.cpp
@@ -9,52 +9,7 @@
 #include <string>
 #include <vector>
 
-#ifdef _WIN32
-#include <process.h>
-#else
-#include <unistd.h>
-#endif
-
 namespace {
-
-// The env var WdspChannel's wisdomPath() reads for the cache directory.
-constexpr const char* kCacheDirVar =
-#ifdef _WIN32
-    "LOCALAPPDATA";
-#else
-    "XDG_CACHE_HOME";
-#endif
-
-void setCacheDirEnv(const std::string& value)
-{
-#ifdef _WIN32
-    _putenv_s(kCacheDirVar, value.c_str());
-#else
-    ::setenv(kCacheDirVar, value.c_str(), 1);
-#endif
-}
-
-void restoreCacheDirEnv(const char* previous)
-{
-    if (previous)
-        setCacheDirEnv(previous);
-#ifdef _WIN32
-    else
-        _putenv_s(kCacheDirVar, "");
-#else
-    else
-        ::unsetenv(kCacheDirVar);
-#endif
-}
-
-long long testProcessId()
-{
-#ifdef _WIN32
-    return static_cast<long long>(_getpid());
-#else
-    return static_cast<long long>(::getpid());
-#endif
-}
 
 bool require(bool condition, const char* message)
 {
@@ -482,43 +437,6 @@ bool runLifecycleTest()
 // measured and then thrown away, so the next launch paid full first-run cost
 // again — for anyone who had ever force-quit, on every run.
 //
-// Redirects the cache directory to a fresh empty path first, so "the file is
-// there" can only be true if THIS open() wrote it. Cheap despite opening a
-// channel: by the time this runs the process has already measured wisdom for
-// these geometries, so FFTW has it in memory and the open is a warm one.
-bool runWisdomExportTest()
-{
-    namespace fs = std::filesystem;
-    std::error_code ec;
-    const fs::path scratch = fs::temp_directory_path(ec)
-        / ("aethersdr-wisdom-export-test-" + std::to_string(testProcessId()));
-    fs::remove_all(scratch, ec);
-    fs::create_directories(scratch, ec);
-    if (ec)
-        return require(false, "could not create a scratch wisdom directory");
-
-    const char* previous = std::getenv(kCacheDirVar);
-    const std::string saved = previous ? previous : std::string();
-    setCacheDirEnv(scratch.string());
-
-    const fs::path wisdom = WdspChannel::wisdomCachePathForTest();
-    bool ok = require(!fs::exists(wisdom), "the scratch wisdom cache started empty");
-    if (ok) {
-        std::unique_ptr<WdspChannel> channel = WdspChannel::create({});
-        ok = require(channel != nullptr, "could not open a channel for the wisdom test");
-        if (ok) {
-            // Checked while the process is still very much alive: an atexit
-            // handler cannot have run, so this file exists only if open() wrote it.
-            ok = require(fs::exists(wisdom) && fs::file_size(wisdom) > 0,
-                         "open() left the FFTW wisdom cache on disk");
-        }
-    }
-
-    restoreCacheDirEnv(previous ? saved.c_str() : nullptr);
-    fs::remove_all(scratch, ec);
-    return ok;
-}
-
 } // namespace
 
 int main()
@@ -539,7 +457,6 @@ int main()
         }) ||
         !runLeakChecked("underrun test", runUnderrunTest) ||
         !runLeakChecked("reconfiguration test", runReconfigurationTest) ||
-        !runLeakChecked("wisdom export test", runWisdomExportTest) ||
         !runLeakChecked("notch index test", runNotchIndexTest) ||
         !runLeakChecked("notch attenuation test", runNotchAttenuationTest) ||
         !require(WdspChannel::outstandingAllocationsForTest() == allocationBaseline,


### PR DESCRIPTION
Closes #5052. Also resolves #4877, by making its premise unnecessary rather than implementing it — see below.

Two independent problems, both downstream of WDSP's `FFTW_PATIENT` planning on a Hermes-Lite 2 first connect.

## 1. The operator never saw the explanation (#5052)

#4775 correctly diagnosed the ~20 s freeze and added a message explaining it — fed into the panadapter connection animation. **That message was never visible.**

Three facts compose into it:

- `ConnectionPanel` is a top-level `Qt::Dialog` **parented to MainWindow** (`MainWindow.cpp:4746`), so the window manager keeps it above us unconditionally.
- `showConnectionDialog()` anchors its 760×660 frame just above the status bar, centred on the station label — directly over the lower-centre of the panadapter, which is exactly where `drawConnectionAnimation()` centres itself.
- It is hidden only in `onConnectionStateChanged(connected)` (`MainWindow.cpp:5904`) — **after** the whole window.

So for all ~20–60 s the operator saw a panel reading "Connecting…" and nothing else. That is the "the client has completely hung" report #4775 set out to answer.

![WDSP first-connect modal](https://raw.githubusercontent.com/jensenpat/AetherSDR/assets-5052/.pr-assets/pr-wdsp-setup-modal.png)

Captured mid-open on a cold cache against the live radio.

**Modality is the fix, not a detail.** The NR2 wisdom dialog next door is deliberately `NonModal` + `Qt::Tool` + `WA_ShowWithoutActivating`; copying those three lines here reproduces the bug exactly, because a non-activating tool window is not guaranteed to sit above a parented `Qt::Dialog`. Modality is also *correct* here in a way it is not for NR2: NR2 runs against a **working** radio and locking the operator out for minutes was the worse trade. Here nothing has connected yet.

**Gated on elapsed time (1500 ms), not on "a connect started."** A warm cache makes the build ~0.5 s, and a dialog on every connect would flash every single time — worse than the silence it replaces, and *invisible to anyone testing on a developer machine, because their cache is always warm*. Time is also preferred to a cold-cache predicate deliberately: none exists, and one could not be exact anyway, since a cache that imports cleanly may still lack plans for these geometries.

Details worth knowing:
- **No Cancel button** — `OpenChannel` cannot be aborted, so a button claiming to stop it would lie. Esc/close still dismiss, which only hides the explanation.
- **Indeterminate bar** — the `(n of m)` receiver count would sit at 1/4 for the entire wait then fill in a tenth of a second (#4775 measured 18865 ms for the first receiver, 100/71/39 ms for the rest).
- **Connect window only** — a mid-session rebuild (a span change crossing a rate boundary) opens WDSP channels too, and an app-modal window over a working radio would be far worse than silence.
- `setPanadapterConnectionAnimation(false)` also dismisses it. That is the net that matters: `dspSetupFinished` fires on every path out of `finishDspSetup`, but a backend destroyed mid-build takes its `QPointer` with it and emits nothing — which would strand an app-modal window with no Cancel.
- The dialog carries `objectName("wdspSetupDialog")` so bridge tests need not match localized title text.

## 2. The tests measured plans nobody wanted (#4877)

A cold WDSP open cost 20–190 s of pure FFTW planning, on every CI run and every developer's first run.

**Caching the wisdom file does not work**, and this is the finding worth keeping. Measured on macOS/arm64: the app's own 38 KB cache made **no difference** to `wdsp_channel_test` — 22.8 s warm vs 22.4 s cold — because the app's plan set and the tests' plan set are different FFTW problems. Only a cache the tests themselves wrote helped (22.4 s → 2.4 s), which is exactly what a fresh container never has. #4877 would have stored an entry that never hit.

So the planner is bounded instead. `AETHER_WDSP_FFTW_TIMELIMIT` caps FFTW through its own global `fftw_set_timelimit()` — **no vendored WDSP source patched** to reach the flag it hardcodes — and a bounded process **never writes the wisdom cache**, because rushed plans must not reach the cache the real app imports. One knob, so it is not possible to bound the planner and forget to isolate the cache.

Being a ctest property it covers local runs and the weekly sanitizers job identically — there is no CI-only workaround to drift out of sync with what developers see. Unset is the shipping path; a radio session keeps full `PATIENT` plans.

**Applied to every registered test, not to a name prefix.** The prefix was the first attempt and it leaked: `automation_connect_wait_phase_test` and `transmit_model_test` both drive HL2 DSP without an `hl2_` name, so they ran unbounded *and* exported — caught mid-review replacing a developer's real 38 KB cache with an 11 KB test-only one. Naming is not a proxy for what a test opens, and the failure is silent: the suite still passes, it just degrades the next real connect. A/B against an isolated `XDG_CACHE_HOME`: **one** wisdom file written under the prefix rule, **zero** under the blanket rule. The re-check is written into the `tests.cmake` comment.

### The bound was inert as first pushed

Worth stating plainly because the numbers below replace ones that were wrong.
`AETHER_TEST_FFTW_TIMELIMIT` was referenced three times — the ctest `ENVIRONMENT`
property, the compile definition behind `TestWdspWisdomIsolation.cpp`, and through
both the `AETHER_WDSP_FFTW_TIMELIMIT` that `WdspChannel` reads — and `set()`
**nowhere**. An undefined CMake variable expands to the empty string rather than
erroring, so ctest exported the literal `AETHER_WDSP_FFTW_TIMELIMIT=`,
`plannerTimeLimitSeconds()` took its `*raw == '\0'` branch and returned `-1.0`,
and every plan was measured at full `FFTW_PATIENT`. **Every run took the escape
hatch.** Fixed in `8b3ff886`, which adds the missing `set()`.

What still worked was the wisdom **redirect**, which is why the suite looked
fixed: the tests share a cache in the build tree, so whichever test runs first
measures every plan and the rest import them. Cold and serial, that was
`hl2_backend_test` at **124.8 s** with the other five behind it at 5–12 s. A CI
container starts with no build tree, so CI paid that in full every run.

Measured cold and serial on the six slowest, before and after `8b3ff886`:

| | `hl2_backend_test` | six-test total |
|---|---|---|
| bound inert | 124.8 s | 161.9 s |
| bound live | **23.2 s** | **59.1 s** |

Only 2.4 s of that 23.2 s is CPU. The residual really is socket and timer waits
in `hl2_backend_test`, not FFTW — that claim was right, it just had not taken
effect yet.

### End-to-end

Measured cold, `ctest -R '^(hl2|wdsp)_' -j22`, macOS/arm64 (24-core Studio),
31 tests both sides. "Cold" on `main` means an isolated empty `XDG_CACHE_HOME`,
which is what a fresh CI container has:

| | wall | CPU (user) |
|---|---|---|
| `main` @ `2d94bd00` | 129.2 s | **1757.7 s** |
| this PR + `8b3ff886` | **22.5 s** | **13.9 s** |

5.8x wall, 127x CPU. Same single pre-existing failure on both sides
(`hl2_state_restore_test`, #5000), and the operator's real cache verified
untouched by both runs.

Also drops `wdsp_channel_test`'s wisdom-export case and the `wisdomCachePathForTest()` API it was the only caller of.

### Tests cannot reach the operator's wisdom cache at all

The ctest `ENVIRONMENT` property only covers `ctest`. Running a test binary **directly** — `./build/hl2_rxdsp_test`, how a test is normally debugged — inherits nothing and exported straight over `~/.cache/aethersdr/wdsp-fftw-wisdom`. That is a silent 20–60 s tax on the operator's *next real connect*, paid every time they build a PR. The documented escape hatch made it worse: `-DAETHER_TEST_FFTW_TIMELIMIT=` (empty) parses as "unset", restoring full `PATIENT` planning **and** cache clobbering together, in a comment advertising it as safe. Until `8b3ff886` that was not an escape hatch anyone had to opt into — with no `set()` for the variable, it was the only path.

Two independent layers now:

1. `AETHER_WDSP_WISDOM_DIR` redirects `wisdomPath()` to `<build>/test-fftw-wisdom`. Redirecting beats suppressing — the tests keep a persistent cache of their own, so repeat runs import instead of re-measuring.
2. `tests/TestWdspWisdomIsolation.cpp` sets it from a namespace-scope initializer that runs **before `main()`**, linked into every test target. An **OBJECT** library, not STATIC: its only content is a constructor, and a static library's unreferenced object can be dropped at link time — silently removing the protection.

Verified against sha `49c0e7a5`, 38108 B:

| | result |
|---|---|
| full `ctest`, no env isolation, real `HOME` | byte-identical |
| `wdsp_channel_test` direct, bare env | byte-identical |
| `hl2_rxdsp_test` direct, bare env | byte-identical |
| `hl2_am_dcblock_test` direct, bare env | byte-identical |
| `transmit_model_test` direct, bare env | byte-identical |
| real compile+link build | byte-identical |
| escape hatch (unbounded) | 15522 B into the **build dir** |

Bounded default 0.6 s user; unbounded 48.2 s user and still isolated. Note the bounded row describes a default that did not exist until `8b3ff886` — as first pushed every run was the unbounded one, still correctly isolated but never bounded.

**The isolation re-check cannot catch that.** `find "$HOME/.cache/aethersdr" -newer build/CMakeCache.txt` (empty) passes with the bound dead, because the redirect alone keeps the real cache clean. It verifies isolation, not bounding. To check the bound is live, read the generated property:

```
grep -m1 AETHER_WDSP_FFTW_TIMELIMIT build/CTestTestfile.cmake   # must not end in '='
```

**`ci.yml` is a comment-only change** (verified: every added/removed line is a comment). The old note recommended the caching fix above; it now records why that was rejected. `hl2_am_dcblock_test` is left off the gate — re-adding it is a coverage call someone should make deliberately, not a side effect of this PR.

## Proof

Against the live Hermes-Lite 2 at 192.168.1.21 over the agent automation bridge, **RX only** (`txAllowed: false`), on an isolated `HOME` so the operator's real wisdom cache was never touched — verified byte-identical before and after (`49c0e7a5…`).

| | DSP build → connected | modal |
|---|---|---|
| cold (no cache) | **47.2 s** | appeared, auto-closed on completion |
| warm (cache present) | **0.545 s** | correctly never appeared |

0.545 s against a 1500 ms gate is margin, not a squeaker. The dialog copy says "up to a minute" rather than a point estimate for the same reason the cold number is 47 s here and ~19 s in #4775's Linux measurement — promising 20 s and taking 47 is how this earns a second "it hung" report.

**Suite: 308/309 headless** (`QT_QPA_PLATFORM=offscreen`). The one failure, `hl2_state_restore_test`, is #5000 and fails **identically on unmodified `3b973a8c`** — confirmed by stashing, rebuilding and running the baseline before attributing, not assumed from "I didn't touch that code". `icom_session_test` also fails, and is pre-existing and unrelated — but it is **not** cache-sensitive as this line originally claimed. On current `main` (`2d94bd00`) it fails deterministically under both a real and an isolated `XDG_CACHE_HOME`, 3 runs each. The assertion is "the early window is one-time": `m_initialMaintenancePending` is set at `IcomSession.cpp:363` and cleared only in `stop()`, never when the early renewal fires — it happens to clear when the *next* token reply arrives with `initialToken == false`, so the test is racing that ack round-trip. Linux CI wins the race; this Mac does not. Wants its own issue.

## Follow-ups, deliberately not here

- The **NR2 wisdom cache is untouched**, by request. Worth recording that the two caches (`~/.config/AetherSDR/aethersdr_fftw_wisdom` and `~/.cache/aethersdr/wdsp-fftw-wisdom`) are separate files over **one global FFTW planner**, since `aethercore` and `aether_wdsp` link the same `${FFTW3_LIBRARIES}`. Export serializes everything the planner knows, so the two files already cross-contaminate. Not a defect today; a trap for whoever touches either next.
- `SpectralNR::generateWisdom()` is already a portable, cancellable `WDSPwisdom()` — it says "matches Thetis: sizes 64 through 262144". It differs in two ways that block reuse: no `2^n + 1` complex backward, and it plans complex **in-place** where WDSP plans **out-of-place** (different FFTW problems).
- `SpectralNR` guards the planner with `s_fftwMutex` and `WdspChannel` with its own `g_setupMutex` — **two independent mutexes over one non-thread-safe planner**, which is the class of bug #467 was. No crash reproduced; the locking is structurally wrong regardless.

