### PR TITLE
fix: the two tests that never run to completion — an invalid qApp downcast, and a restore read back off an unseeded receiver

### DIFF
--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -100,6 +100,25 @@ struct ResolvedAction {
     QPointer<QMenu> menu;
 };
 
+// The context object for the deferred-to-the-main-loop singleShot()s below.
+//
+// `qApp` is NOT usable here. Once <QApplication> is included this file gets the
+// QtWidgets spelling of the macro — static_cast<QApplication*>(instance()) —
+// and the bridge's own console tests construct a plain QCoreApplication. That
+// downcast is then undefined behaviour, and UBSan's vptr check makes it fatal:
+// automation_connect_family_test and automation_connect_wait_phase_test both
+// aborted inside doConnect() on the weekly sanitizers run, mid-test, so their
+// remaining assertions never ran at all.
+//
+// singleShot() only ever wants a QObject to take thread affinity and lifetime
+// from, which the application object is regardless of its concrete type. The
+// QApplication-ness was never used — every site below passed `qApp` straight
+// through as a QObject*.
+QObject* appContext()
+{
+    return QCoreApplication::instance();
+}
+
 // mark→tail correlation (#3756): doMark needs the seq/mono the log tap assigns
 // to the MARK message itself, not whatever m_logSeq/back() read afterward — a
 // concurrent logging thread can push between the qCInfo() and the re-lock. The
@@ -3913,7 +3932,7 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
             // (#3646 fidelity — re-entrancy crash fix)
             QPointer<QAction> ag = menuAction;
             QPointer<QMenu> mg = menu;
-            QTimer::singleShot(0, qApp, [ag, mg]() {
+            QTimer::singleShot(0, appContext(), [ag, mg]() {
                 if (!ag) return;
                 // Activate the main window first so a menu action that opens a
                 // dialog / pops a menu has a valid active window (avoids the
@@ -4044,7 +4063,7 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
                 action == QLatin1String("toggle") && b->isCheckable();
             QPointer<QAbstractButton> bg = b;
             QPointer<QWidget> win = b->window();
-            QTimer::singleShot(0, qApp, [bg, win, useToggle]() {
+            QTimer::singleShot(0, appContext(), [bg, win, useToggle]() {
                 if (!bg) return;
                 // Activate the button's window first so a popup menu it raises
                 // has a valid active window (backgrounded automation otherwise
@@ -5712,7 +5731,7 @@ QJsonObject AutomationServer::doConnect(const QString& action,
 
             QPointer<QObject> guard(conn->asQObject());
             QPointer<AutomationServer> self(this);
-            QTimer::singleShot(0, qApp, [guard, self, conn, selectedSerial] {
+            QTimer::singleShot(0, appContext(), [guard, self, conn, selectedSerial] {
                 if (!guard) {
                     return;
                 }
@@ -5742,7 +5761,7 @@ QJsonObject AutomationServer::doConnect(const QString& action,
 
                 QPointer<QObject> guard(conn->asQObject());
                 QPointer<AutomationServer> self(this);
-                QTimer::singleShot(0, qApp, [guard, self, conn, serial] {
+                QTimer::singleShot(0, appContext(), [guard, self, conn, serial] {
                     if (!guard) {
                         return;
                     }
@@ -5850,7 +5869,7 @@ QJsonObject AutomationServer::doConnect(const QString& action,
 
         QPointer<QObject> guard(conn->asQObject());
         QPointer<AutomationServer> self(this);
-        QTimer::singleShot(0, qApp, [guard, self, conn, target, family] {
+        QTimer::singleShot(0, appContext(), [guard, self, conn, target, family] {
             if (!guard) {
                 return;
             }
@@ -5897,7 +5916,7 @@ QJsonObject AutomationServer::doConnectDialog(const QString& action)
     const bool wasVisible = conn && conn->automationDialogVisible();
     QPointer<QObject> guardedHost = host;
     QPointer<QObject> guard(conn ? conn->asQObject() : nullptr);
-    QTimer::singleShot(0, qApp, [guardedHost, guard, conn, show] {
+    QTimer::singleShot(0, appContext(), [guardedHost, guard, conn, show] {
         if (guardedHost) {
             const char* method = show ? "showConnectionDialog" : "hideConnectionDialog";
             if (QMetaObject::invokeMethod(guardedHost, method, Qt::DirectConnection)) {
@@ -5935,7 +5954,7 @@ QJsonObject AutomationServer::doDisconnect()
 
     QPointer<QObject> guard(conn->asQObject());
     QPointer<AutomationServer> self(this);
-    QTimer::singleShot(0, qApp, [guard, self, conn] {
+    QTimer::singleShot(0, appContext(), [guard, self, conn] {
         if (!guard) {
             return;
         }
@@ -8348,7 +8367,7 @@ QJsonObject AutomationServer::doClose(const QString& target) const
     const QString title = win->windowTitle();
     const QString cls = shortClassName(win);
     QPointer<QWidget> wg = win;
-    QTimer::singleShot(0, qApp, [wg]() {
+    QTimer::singleShot(0, appContext(), [wg]() {
         if (wg) wg->close();
     });
     qCInfo(lcAutomation).noquote() << "close window for" << target << "(" << cls << ")";
@@ -9063,7 +9082,7 @@ QJsonObject AutomationServer::doShowMenu(const QString& target) const
     QPointer<QMenu> mg = menu;
     QPointer<QWidget> bg = w;
     QPointer<QWidget> win = w->window();
-    QTimer::singleShot(0, qApp, [mg, bg, win]() {
+    QTimer::singleShot(0, appContext(), [mg, bg, win]() {
         if (!mg || !bg)
             return;
         if (win && win->isVisible()) {   // realize + activate so Cocoa has an anchor
@@ -9160,7 +9179,7 @@ QJsonObject AutomationServer::postDeferredMenuTrigger(
 
     QPointer<QWidget> wp = w;
     QPointer<QWidget> win = w->window();
-    QTimer::singleShot(0, qApp, [wp, win, local, send = std::move(send)]() {
+    QTimer::singleShot(0, appContext(), [wp, win, local, send = std::move(send)]() {
         if (!wp)
             return;
         if (win && win->isVisible()) {   // realize + activate so Cocoa has an anchor
@@ -9400,7 +9419,7 @@ QJsonObject AutomationServer::doClickAt(const QString& target,
     if (transmitControl) {
         markTxBridgeInitiated();
     }
-    QTimer::singleShot(0, qApp, [wp, win, local, global]() {
+    QTimer::singleShot(0, appContext(), [wp, win, local, global]() {
         if (!wp)
             return;
         raiseWindowForPopup(win);  // valid active window for any popup it raises

--- a/tests/hl2_state_restore_test.cpp
+++ b/tests/hl2_state_restore_test.cpp
@@ -11,13 +11,20 @@
 #include "core/backends/hl2/Hl2Bands.h"
 
 #include "core/backends/SliceDelta.h"
+#include "core/backends/hl2/MetisProtocol.h"
 
 #include <QCoreApplication>
+#include <QHostAddress>
 #include <QJsonObject>
 #include <QEventLoop>
+#include <QNetworkDatagram>
 #include <QObject>
+#include <QSignalSpy>
 #include <QTimer>
+#include <QUdpSocket>
 #include <QVariantMap>
+
+#include <cstdint>
 
 #include <iostream>
 #include <map>
@@ -55,6 +62,68 @@ RadioConnectRequest hl2Request(const QString& serial, int numRx = 1)
     if (numRx > 1)
         req.params.insert(QStringLiteral("numRx"), numRx);
     return req;
+}
+
+// A fake HL2 on loopback, answering every EP2 with an EP6.
+//
+// Needed by exactly the cases that read a RESTORED value back out of
+// currentOperatingState(). That accessor reports the LIVE receiver, and the
+// restore only reaches the receiver in pushInitialState(), which Hl2Backend
+// runs from MetisClient::linkUp — the FIRST EP6. A connect to TEST-NET-1 (what
+// hl2Request() builds, and what every case here that only needs connectRadio()
+// to have run uses) never gets one, so an unlinked backend answers
+// currentOperatingState() with the receiver's construction defaults no matter
+// what was restored into it. Asserting a restored passband against that reads
+// as a product bug and is really the test never having reached the code.
+//
+// Same shape as hl2_backend_test's fake: the packet only has to be well-formed
+// enough for MetisClient to call it a link.
+struct FakeHl2Radio {
+    QUdpSocket socket;
+    std::uint32_t seq = 0;
+
+    static QByteArray ep6(std::uint32_t s)
+    {
+        QByteArray p(static_cast<int>(hl2::kUsbPacketSize), 0);
+        auto* b = reinterpret_cast<std::uint8_t*>(p.data());
+        b[0] = 0xEF; b[1] = 0xFE; b[2] = 0x01; b[3] = 0x06;
+        b[4] = static_cast<std::uint8_t>(s >> 24);
+        b[5] = static_cast<std::uint8_t>(s >> 16);
+        b[6] = static_cast<std::uint8_t>(s >> 8);
+        b[7] = static_cast<std::uint8_t>(s);
+        b[8] = b[9] = b[10] = 0x7F;
+        b[8 + hl2::kFrameSize] = b[9 + hl2::kFrameSize] = b[10 + hl2::kFrameSize] = 0x7F;
+        return p;
+    }
+
+    bool bind()
+    {
+        if (!socket.bind(QHostAddress::LocalHost, 0))
+            return false;
+        QObject::connect(&socket, &QUdpSocket::readyRead, &socket, [this] {
+            while (socket.hasPendingDatagrams()) {
+                const QNetworkDatagram dg = socket.receiveDatagram();
+                socket.writeDatagram(ep6(seq++), dg.senderAddress(), dg.senderPort());
+            }
+        });
+        return true;
+    }
+
+    quint16 port() { return socket.localPort(); }
+};
+
+// Connect to a fake radio and wait for the link, so pushInitialState() has run
+// and currentOperatingState() describes a seeded receiver. Bounded, so a
+// backend that never links fails the check rather than hanging the suite.
+bool linkUpConnect(hl2::Hl2Backend& backend, FakeHl2Radio& radio, const QString& serial)
+{
+    QSignalSpy connectedSpy(&backend, &IRadioBackend::connected);
+    RadioConnectRequest req;
+    req.host = QStringLiteral("127.0.0.1");
+    req.port = radio.port();
+    req.serial = serial;
+    backend.connectRadio(req);
+    return connectedSpy.wait(120'000) || !connectedSpy.isEmpty();
 }
 
 // Let a connect finish before issuing the next one.
@@ -679,17 +748,32 @@ int main(int argc, char** argv)
     // clientSettingsDomain, so those old pairs are on operators' disks. Replayed
     // they get the BFO added a second time and the demodulator opens a whole
     // pitch above the marker — silence, which capture then writes back.
+    //
+    // Read back through a LINKED backend. currentOperatingState() reports the
+    // live receiver, and applyRestoredState() only validates into
+    // m_restoredState — pushInitialState() is what copies the survivor onto the
+    // receiver, and it runs on the first EP6. Asserted against an unlinked
+    // backend these three read the receiver's construction defaults instead,
+    // which is 0..0 for every case and so fails all three no matter what the
+    // guard does. That is how they were written and they have been red on main
+    // since #4914 (no unfiltered ctest gate catches it — #5032).
     {
+        FakeHl2Radio radio;
+        check(radio.bind(), "the fake radio for the CW guard binds");
+
         hl2::Hl2Backend backend;
         RestoredRadioState stale;
         stale.mode = QStringLiteral("CWU");
         stale.filterLowHz  = 350.0;    // the old audio-relative domain
         stale.filterHighHz = 850.0;
         backend.applyRestoredState(stale);
+        check(linkUpConnect(backend, radio, QStringLiteral("AA:BB:CC:DD:EE:01")),
+              "the CW-guard backend links up");
 
         const RestoredRadioState snap = backend.currentOperatingState();
         check(snap.filterLowHz < 0.0 && snap.filterHighHz > 0.0,
               "a pre-#4914 CW passband is dropped for one that contains the carrier");
+        backend.disconnectRadio();
 
         // The same pair under a NON-CW mode is legitimate and must survive:
         // the guard keys on the mode, not on the numbers.
@@ -699,9 +783,12 @@ int main(int argc, char** argv)
         ssb.filterLowHz  = 350.0;
         ssb.filterHighHz = 850.0;
         usb.applyRestoredState(ssb);
+        check(linkUpConnect(usb, radio, QStringLiteral("AA:BB:CC:DD:EE:02")),
+              "the USB backend links up");
         const RestoredRadioState usbSnap = usb.currentOperatingState();
         check(usbSnap.filterLowHz == 350.0 && usbSnap.filterHighHz == 850.0,
               "a one-sided passband under USB is untouched by the CW guard");
+        usb.disconnectRadio();
 
         // And a NEW-domain CW pair must pass through unchanged, or the guard
         // would be rewriting the operator's own width on every connect.
@@ -711,9 +798,12 @@ int main(int argc, char** argv)
         fresh.filterLowHz  = -150.0;
         fresh.filterHighHz =  150.0;
         cw.applyRestoredState(fresh);
+        check(linkUpConnect(cw, radio, QStringLiteral("AA:BB:CC:DD:EE:03")),
+              "the new-domain CW backend links up");
         const RestoredRadioState cwSnap = cw.currentOperatingState();
         check(cwSnap.filterLowHz == -150.0 && cwSnap.filterHighHz == 150.0,
               "a new-domain CW passband survives the guard unchanged");
+        cw.disconnectRadio();
     }
 
     // ---- the flat AGC model, across more than one receiver -----------------


### PR DESCRIPTION
Two tests never run to completion. They fail for unrelated reasons, and neither is a flake.

| test | where it is red | why |
|---|---|---|
| `automation_connect_family_test` | weekly sanitizers only | UBSan kills it mid-run at an invalid `qApp` downcast |
| `automation_connect_wait_phase_test` | weekly sanitizers only | same cast, same line |
| `hl2_state_restore_test` | **plain local `ctest` and CI** | three checks read the restore back through an accessor that describes a receiver they never seeded |

## 1. The bridge's deferred main-loop hops downcast `qApp`

`AutomationServer.cpp` includes `<QApplication>`, so `qApp` is the QtWidgets spelling of the macro — `static_cast<QApplication *>(QCoreApplication::instance())`. Eleven `QTimer::singleShot(0, qApp, ...)` sites passed it straight through as the context object. `singleShot` only wants a `QObject` to take thread affinity and lifetime from; the QApplication-ness was never used, and `qApp->` appears nowhere in the file.

The bridge's own console tests construct a plain `QCoreApplication`, so the downcast is undefined behaviour. The sanitizers job builds with `-fno-sanitize-recover=undefined`, so the process dies at the cast rather than reporting and continuing:

```
AutomationServer.cpp:5853:31: runtime error: downcast of address 0x7fe005c00160
which does not point to an object of type 'QApplication'
note: object is of type 'QCoreApplication'
    #0 AetherSDR::AutomationServer::doConnect(...) AutomationServer.cpp:5853
```

Both tests die inside `doConnect()` — the family test on its first call, the wait-phase test on its ninth check. Neither prints a summary. **They are not failing assertions; they are never reaching them**, which is why the run log shows a plausible-looking wall of `Hl2Backend` output that simply stops.

**Why nobody sees it locally.** On a single-inheritance hierarchy the cast does not move the address, so an ordinary build behaves correctly and a plain `ctest` passes. It is also not reproducible with Apple clang's default `-fsanitize=undefined`, which leaves `vptr` out of the group — reproducing it on macOS needs `-fsanitize=undefined,vptr` explicitly. The CI toolchain includes it.

Fixed with an `appContext()` helper rather than eleven inline `QCoreApplication::instance()` calls, so the trap is written down once where the next call site will read it.

### Proof

A UBSan build (`-fsanitize=undefined,vptr -fno-sanitize-recover`) of both test targets, A/B against unmodified `origin/main`:

| | `automation_connect_family_test` | `automation_connect_wait_phase_test` |
|---|---|---|
| pre-fix | downcast reported at `AutomationServer.cpp:5853:31` | same, `exit=1` |
| post-fix | 0 UBSan reports, `all checks passed` | 0 UBSan reports, `all checks passed` |

Isolated first in a 20-line standalone reproducer, which gives byte-identical diagnostic text and `exit=134` under `-fno-sanitize-recover=all` — the abort CI actually takes.

The deferred paths this touches were then driven against a real window over the automation bridge (isolated `HOME`, no radio): `connect show` → panel `visible:true`, `invoke connectionSmartLinkModeButton click` → `checked:false` → `checked:true`, `connect hide` → `visible:false`. All three ran their deferred lambda with a valid context.

## 2. The pre-#4914 CW guard checks observe a receiver nothing seeded

Three checks in `hl2_state_restore_test` have been red since #4914 added them — **in plain local `ctest`, not only in CI**. This is the failure mode #5032 describes: the only unfiltered full-suite run is a weekly job that has been failing for months, so a test can merge red and stay red.

The guard is correct and demonstrably fires:

```
HL2: dropping pre-#4914 CW passband 350 .. 850 for "CWU" -> mode default -250 .. 250
```

But `applyRestoredState()` validates into `m_restoredState`, and the checks read back through `currentOperatingState()`, which reports the **live receiver**. The restore only reaches a receiver in `pushInitialState()`, which `Hl2Backend` runs from `MetisClient::linkUp` — the first EP6. Two of the three cases never called `connectRadio()` at all, and the third connected to TEST-NET-1, which never answers. All three therefore read the receiver's construction defaults of `0 .. 0` and failed regardless of what the guard did — including the two cases that assert the guard does **not** fire.

Fixed by giving them a link: a loopback fake HL2 answering every EP2 with an EP6, the same shape `hl2_backend_test` already uses.

### Still a discriminator

Widening an observation window can quietly delete the thing a test was pinning. Checked directly — with the guard's condition forced to `false` in `Hl2Backend.cpp`:

```
[FAIL] a pre-#4914 CW passband is dropped for one that contains the carrier
```

and the other two stay green, which is the correct split: they assert the guard leaves their input alone.

62 checks pass, and the file gets slightly faster — 16.1 s → 13.2 s.

## On #5062

Worth stating plainly, since these were investigated together: **#5062 does not fix either test, and neither of these fixes depends on it.** Its FFTW planner bound has nothing to do with a vptr downcast, and `hl2_state_restore_test` never opened a channel in the failing cases.

Two observations from measuring alongside it, offered as data rather than as objections:

- **`hl2_backend_test` writes the operator's real wisdom cache.** Cold, with an isolated `XDG_CACHE_HOME`, it takes 123 s and leaves a 14.6 KB `wdsp-fftw-wisdom` behind. That corroborates the isolation half of #5062 directly.
- **The two tests #5062 names as the reason for the blanket rule did not reproduce here.** On `origin/main`, macOS/arm64, with an isolated `XDG_CACHE_HOME`, `automation_connect_wait_phase_test` (1.5 s) and `transmit_model_test` (0.35 s) both write nothing and never plan an FFT — neither opens a WDSP channel. The blanket rule still looks right to me, and `hl2_backend_test` above is a better example for it; only the two named ones seem to be misattributed.

## Testing

- Full `ctest -j8`, macOS/arm64, `QT_QPA_PLATFORM=offscreen`, isolated `XDG_CACHE_HOME`: **308/309**. The one failure is `vkamp_connection_test`, which is **pre-existing and flaky** — it fails roughly 1 run in 3 standalone (`[FAIL] out-of-range antenna ports never reach the wire`), passed in the run before these changes, touches nothing here, and is also red under TSan in CI. Not addressed in this PR.
- UBSan A/B above.
- Bridge run on a real window, isolated profile; operator's real settings verified untouched.

I have not re-run the weekly sanitizers job on this branch — worth dispatching before merge if you want the two tests observed green in the environment that reports them.
