### PR TITLE
feat(gui): type an exact TX filter cut instead of stepping to it (#3627)

### DIFF
--- a/src/gui/GuardedSlider.h
+++ b/src/gui/GuardedSlider.h
@@ -304,16 +304,45 @@ protected:
     //
     // Same shape as VfoWidget::eventFilter for its frequency direct-entry.
     bool eventFilter(QObject* obj, QEvent* ev) override {
-        if (obj == m_editor
-            && (ev->type() == QEvent::ShortcutOverride
-                || ev->type() == QEvent::KeyPress)) {
-            auto* ke = static_cast<QKeyEvent*>(ev);
-            if (ke->key() == Qt::Key_Escape || ke->key() == Qt::Key_Cancel) {
-                // Accepting the ShortcutOverride claims the key so the window
-                // shortcut does not consume it; the KeyPress that follows is
-                // what actually closes the editor.
-                if (ev->type() == QEvent::KeyPress)
-                    closeEditor();
+        if (obj == m_editor) {
+            if (ev->type() == QEvent::ShortcutOverride
+                || ev->type() == QEvent::KeyPress) {
+                auto* ke = static_cast<QKeyEvent*>(ev);
+                if (ke->key() == Qt::Key_Escape || ke->key() == Qt::Key_Cancel) {
+                    // Accepting the ShortcutOverride claims the key so the
+                    // window shortcut does not consume it; the KeyPress that
+                    // follows is what actually closes the editor.
+                    if (ev->type() == QEvent::KeyPress)
+                        closeEditor();
+                    ev->accept();
+                    return true;
+                }
+            }
+
+            // Focus-out must ALWAYS end the edit.  QLineEdit emits
+            // editingFinished on focus-out only when the input is Acceptable,
+            // so a half-typed or out-of-range value emitted nothing and left
+            // the editor sitting open on top of the label — where it silently
+            // ate every wheel event aimed at the numerals underneath.
+            if (ev->type() == QEvent::FocusOut) {
+                commitEdit();               // commits if parseable, else cancels
+                return false;               // let Qt finish its own focus work
+            }
+
+            // The editor covers the label exactly, so while it is open the
+            // label can never see a wheel event of its own.  Forward it, so
+            // rolling steps the value whether or not a field is open, and
+            // re-seed the text from whatever the model accepted.
+            if (ev->type() == QEvent::Wheel) {
+                if (ControlsLock::isLocked())
+                    return false;
+                auto* we = static_cast<QWheelEvent*>(ev);
+                const int delta = we->angleDelta().y();
+                if (delta != 0) {
+                    emit scrolled(delta > 0 ? 1 : -1);
+                    if (m_editor)
+                        m_editor->setText(text());   // text() is model truth
+                }
                 ev->accept();
                 return true;
             }

--- a/src/gui/GuardedSlider.h
+++ b/src/gui/GuardedSlider.h
@@ -6,6 +6,9 @@
 #include <QComboBox>
 #include <QAbstractItemView>
 #include <QLabel>
+#include <QLineEdit>
+#include <QIntValidator>
+#include <QKeyEvent>
 #include <QMouseEvent>
 #include <QStyle>
 #include <QStyleOptionSlider>
@@ -173,13 +176,71 @@ public:
     }
 };
 
+// QIntValidator reports an out-of-range number as Intermediate, not Invalid
+// — so a QLineEdit happily holds "20000" but then refuses to emit
+// returnPressed/editingFinished, because those require Acceptable input.
+// Measured against Qt 6.10: validate("20000") with a 0..10000 range returns
+// Intermediate. Without a fixup() the operator types a too-large value, hits
+// Enter, and nothing whatsoever happens.
+//
+// Qt calls fixup() on Return precisely for this, so clamping there turns a
+// dead keypress into the nearest legal value.
+class ClampingIntValidator : public QIntValidator {
+public:
+    ClampingIntValidator(int minimum, int maximum, QObject* parent = nullptr)
+        : QIntValidator(minimum, maximum, parent) {}
+
+    void fixup(QString& input) const override {
+        bool ok = false;
+        const int v = input.toInt(&ok);
+        if (ok)
+            input = QString::number(qBound(bottom(), v, top()));
+        // Deliberately NOT chaining to QIntValidator::fixup(): it inserts
+        // locale group separators ("20000" -> "20,000"), and the caller
+        // parses this back with toInt(), which rejects them. Measured on
+        // Qt 6.10 — chaining silently dropped every out-of-range commit.
+    }
+};
+
 // QLabel subclass that emits scrolled(int steps) on wheel events and
 // always consumes them. Used for RIT/XIT/pitch numeric displays. (#619)
 // When controls are locked (#745), ignores wheel events.
+//
+// The label can also be typed into (#3627): call setEditable() with the
+// accepted range and a double-click swaps a QLineEdit over the label.
+// Editing is OFF by default, so every existing user — RIT/XIT, step size,
+// RTTY mark/shift — keeps its display-only behaviour unchanged.
+//
+// A committed value is only ever a REQUEST. The owner clamps it against
+// whatever relationship its own controls carry (e.g. TX low <= high - 50)
+// and then re-syncs the text from the model, so the label can never show a
+// number the model did not accept.
 class ScrollableLabel : public QLabel {
     Q_OBJECT
 public:
     using QLabel::QLabel;
+
+    // Enable double-click-to-type. min/max bound the editor's validator;
+    // the owner still applies any cross-control clamping on commit.
+    void setEditable(int minValue, int maxValue) {
+        m_editable = true;
+        m_min = minValue;
+        m_max = maxValue;
+    }
+    bool isEditable() const { return m_editable; }
+
+    // The owner passes the label's own themed stylesheet so the editor does
+    // not flash an unthemed system box over a dark panel.
+    //
+    // The selector is rewritten on the way in. Those stylesheets are written
+    // as "QLabel { ... }" and Qt matches stylesheet selectors against the
+    // widget's class, so handing one to a QLineEdit styles nothing at all.
+    void setEditorStyleSheetFromLabel(const QString& labelCss) {
+        m_editorCss = QString(labelCss).replace(QLatin1String("QLabel"),
+                                                QLatin1String("QLineEdit"));
+    }
+    QString editorStyleSheet() const { return m_editorCss; }
+
     void wheelEvent(QWheelEvent* ev) override {
         if (ControlsLock::isLocked()) {
             ev->ignore();
@@ -190,6 +251,84 @@ public:
         else if (delta < 0) emit scrolled(-1);
         ev->accept();
     }
+
+    void mouseDoubleClickEvent(QMouseEvent* ev) override {
+        // Same gate as the wheel handler: a locked panel is being scrolled,
+        // not operated. (#745)
+        if (!m_editable || ControlsLock::isLocked()) {
+            QLabel::mouseDoubleClickEvent(ev);
+            return;
+        }
+        beginEdit();
+        ev->accept();
+    }
+
+    // Exposed so a test (and any future keyboard route) can open the editor
+    // without synthesising a double-click.
+    void beginEdit() {
+        if (!m_editable || m_editor)
+            return;
+        m_editor = new QLineEdit(text(), this);
+        m_editor->setValidator(new ClampingIntValidator(m_min, m_max, m_editor));
+        m_editor->setAlignment(alignment());
+        if (!m_editorCss.isEmpty())
+            m_editor->setStyleSheet(m_editorCss);
+        m_editor->setGeometry(rect());
+        m_editor->selectAll();
+        connect(m_editor, &QLineEdit::editingFinished, this, [this]() { commitEdit(); });
+        m_editor->show();
+        m_editor->setFocus(Qt::MouseFocusReason);
+    }
+
+    bool isEditing() const { return m_editor != nullptr; }
+
 signals:
     void scrolled(int direction);
+    // A typed value the owner should clamp and push at the model.
+    void editCommitted(int value);
+
+protected:
+    void keyPressEvent(QKeyEvent* ev) override {
+        if (m_editor && ev->key() == Qt::Key_Escape) {
+            closeEditor();
+            ev->accept();
+            return;
+        }
+        QLabel::keyPressEvent(ev);
+    }
+
+private:
+    // Tear the editor down. Clears the member FIRST: destroying a focused
+    // QLineEdit emits editingFinished, and a null member is what stops that
+    // re-entering commitEdit() and committing a value twice.
+    void closeEditor() {
+        if (!m_editor)
+            return;
+        QLineEdit* ed = m_editor;
+        m_editor = nullptr;
+        // hide() before deleteLater(): the delete only lands on the next
+        // event-loop pass, and until then the editor is still a visible
+        // child sitting on top of the label.
+        ed->hide();
+        ed->deleteLater();
+    }
+
+    void commitEdit() {
+        if (!m_editor)
+            return;
+        const QString typed = m_editor->text().trimmed();
+        closeEditor();
+        bool ok = false;
+        const int value = typed.toInt(&ok);
+        // Empty or unparseable cancels: the label keeps whatever the model
+        // last put there, so a stray double-click costs nothing.
+        if (ok)
+            emit editCommitted(value);
+    }
+
+    bool       m_editable{false};
+    int        m_min{0};
+    int        m_max{0};
+    QString    m_editorCss;
+    QLineEdit* m_editor{nullptr};
 };

--- a/src/gui/GuardedSlider.h
+++ b/src/gui/GuardedSlider.h
@@ -229,6 +229,8 @@ public:
         m_max = maxValue;
     }
     bool isEditable() const { return m_editable; }
+    int  editMinimum() const { return m_min; }
+    int  editMaximum() const { return m_max; }
 
     // The owner styles the editor, so it does not flash an unthemed system box
     // over a dark panel. A callback rather than a stylesheet string for two

--- a/src/gui/GuardedSlider.h
+++ b/src/gui/GuardedSlider.h
@@ -229,17 +229,16 @@ public:
     }
     bool isEditable() const { return m_editable; }
 
-    // The owner passes the label's own themed stylesheet so the editor does
-    // not flash an unthemed system box over a dark panel.
-    //
-    // The selector is rewritten on the way in. Those stylesheets are written
-    // as "QLabel { ... }" and Qt matches stylesheet selectors against the
-    // widget's class, so handing one to a QLineEdit styles nothing at all.
-    void setEditorStyleSheetFromLabel(const QString& labelCss) {
-        m_editorCss = QString(labelCss).replace(QLatin1String("QLabel"),
-                                                QLatin1String("QLineEdit"));
+    // The owner styles the editor, so it does not flash an unthemed system box
+    // over a dark panel. A callback rather than a stylesheet string for two
+    // reasons: the owner writes a QLineEdit rule directly (a QLabel rule would
+    // not match a QLineEdit at all, since Qt selects on widget class), and the
+    // stylesheet is applied by ThemeManager itself, which owns theming
+    // and is where the colour audit expects it to live.
+    void setEditorStyler(std::function<void(QWidget*)> styler) {
+        m_editorStyler = std::move(styler);
     }
-    QString editorStyleSheet() const { return m_editorCss; }
+    bool hasEditorStyler() const { return static_cast<bool>(m_editorStyler); }
 
     void wheelEvent(QWheelEvent* ev) override {
         if (ControlsLock::isLocked()) {
@@ -271,8 +270,8 @@ public:
         m_editor = new QLineEdit(text(), this);
         m_editor->setValidator(new ClampingIntValidator(m_min, m_max, m_editor));
         m_editor->setAlignment(alignment());
-        if (!m_editorCss.isEmpty())
-            m_editor->setStyleSheet(m_editorCss);
+        if (m_editorStyler)
+            m_editorStyler(m_editor);
         m_editor->setGeometry(rect());
         m_editor->selectAll();
         connect(m_editor, &QLineEdit::editingFinished, this, [this]() { commitEdit(); });
@@ -329,6 +328,6 @@ private:
     bool       m_editable{false};
     int        m_min{0};
     int        m_max{0};
-    QString    m_editorCss;
+    std::function<void(QWidget*)> m_editorStyler;
     QLineEdit* m_editor{nullptr};
 };

--- a/src/gui/GuardedSlider.h
+++ b/src/gui/GuardedSlider.h
@@ -8,6 +8,7 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QIntValidator>
+#include <QEvent>
 #include <QKeyEvent>
 #include <QMouseEvent>
 #include <QStyle>
@@ -274,6 +275,9 @@ public:
             m_editorStyler(m_editor);
         m_editor->setGeometry(rect());
         m_editor->selectAll();
+        // Escape has to be claimed on the EDITOR, via ShortcutOverride — see
+        // eventFilter() below for why a keyPressEvent override cannot work.
+        m_editor->installEventFilter(this);
         connect(m_editor, &QLineEdit::editingFinished, this, [this]() { commitEdit(); });
         m_editor->show();
         m_editor->setFocus(Qt::MouseFocusReason);
@@ -287,13 +291,34 @@ signals:
     void editCommitted(int value);
 
 protected:
-    void keyPressEvent(QKeyEvent* ev) override {
-        if (m_editor && ev->key() == Qt::Key_Escape) {
-            closeEditor();
-            ev->accept();
-            return;
+    // Cancel the edit on Esc.
+    //
+    // This MUST filter the editor and MUST answer ShortcutOverride, not just
+    // KeyPress. The main window carries `QShortcut(Qt::Key_Escape, window())`
+    // (CwxPanel, DvkPanel), and Qt dispatches a shortcut by first offering a
+    // ShortcutOverride event: if nothing accepts it, the shortcut fires and
+    // the focused widget is never sent a KeyPress at all. A keyPressEvent
+    // override on this label therefore never runs, which is exactly how this
+    // shipped broken — Esc did nothing in the app while passing a unit test
+    // that delivered the key straight to the widget with no shortcut present.
+    //
+    // Same shape as VfoWidget::eventFilter for its frequency direct-entry.
+    bool eventFilter(QObject* obj, QEvent* ev) override {
+        if (obj == m_editor
+            && (ev->type() == QEvent::ShortcutOverride
+                || ev->type() == QEvent::KeyPress)) {
+            auto* ke = static_cast<QKeyEvent*>(ev);
+            if (ke->key() == Qt::Key_Escape || ke->key() == Qt::Key_Cancel) {
+                // Accepting the ShortcutOverride claims the key so the window
+                // shortcut does not consume it; the KeyPress that follows is
+                // what actually closes the editor.
+                if (ev->type() == QEvent::KeyPress)
+                    closeEditor();
+                ev->accept();
+                return true;
+            }
         }
-        QLabel::keyPressEvent(ev);
+        return QLabel::eventFilter(obj, ev);
     }
 
 private:

--- a/src/gui/GuardedSlider.h
+++ b/src/gui/GuardedSlider.h
@@ -251,7 +251,7 @@ public:
         setFocusPolicy(Qt::StrongFocus);
         if (accessibleDescription().isEmpty()) {
             setAccessibleDescription(
-                tr("Editable. Press Enter or Space to type an exact value in Hz "
+                tr("Editable. Press Enter to type an exact value in Hz "
                    "between %1 and %2, or use the arrow buttons.")
                     .arg(minValue).arg(maxValue));
         }
@@ -293,8 +293,7 @@ public:
     // QLabel so Tab/Shift-Tab keep working.
     void keyPressEvent(QKeyEvent* ev) override {
         const bool activates = ev->key() == Qt::Key_Return
-                               || ev->key() == Qt::Key_Enter
-                               || ev->key() == Qt::Key_Space;
+                               || ev->key() == Qt::Key_Enter;
         if (activates && m_editable && !m_editor && !ControlsLock::isLocked()) {
             beginEdit(Qt::TabFocusReason);
             ev->accept();
@@ -560,7 +559,10 @@ public:
         if (actionName == QAccessibleActionInterface::pressAction()) {
             // The same keys keyPressEvent() answers, so what an AT announces
             // and what the keyboard actually does cannot drift apart.
-            return {QStringLiteral("Return"), QStringLiteral("Space")};
+            // Space is deliberately absent: MainWindow owns it as the default
+            // application-level PTT-hold key and intercepts it before this
+            // widget while a radio is connected (Principle VI).
+            return {QStringLiteral("Return")};
         }
         return QAccessibleWidget::keyBindingsForAction(actionName);
     }

--- a/src/gui/GuardedSlider.h
+++ b/src/gui/GuardedSlider.h
@@ -9,6 +9,7 @@
 #include <QLineEdit>
 #include <QIntValidator>
 #include <QAccessible>
+#include <QCoreApplication>
 #include <QAccessibleWidget>
 #include <QEvent>
 #include <QLocale>
@@ -503,15 +504,74 @@ private:
 // interactive-QLabel anti-pattern docs/a11y.md names. Same lazy-factory shape
 // as CrossNeedleMeterWidget's.
 //
-// EditableText rather than the doc's suggested Button: activating this does
-// not perform an action, it exposes a value for editing, and Button would have
-// an AT announce it as something to press. Display-only ScrollableLabels —
-// RIT/XIT, step size, RTTY mark/shift — return nullptr here and keep QLabel's
-// StaticText, which is correct for them.
+// The role is Button, with a `press` action that opens the editor, exactly as
+// docs/a11y.md prescribes. An earlier version of this claimed EditableText on
+// the argument that activating it exposes a value rather than performing an
+// action — and shipped neither contract: runtime inspection found
+// textInterface() and editableTextInterface() both null and SetFocus as the
+// only action, so VoiceOver/NVDA/switch-control could focus the readout but
+// never open the editor (#5064 review). A role is a promise about which
+// interfaces exist; claiming one and implementing none is worse than the
+// StaticText it replaced, because an AT stops looking.
+//
+// Button is also the honest description of the RESTING state. This is a
+// two-stage control: the label is the thing you activate, and the QLineEdit
+// that appears carries Qt's own complete editable-text semantics. Nothing is
+// editable until the press happens.
+//
+// Keyboard users reach the same beginEdit() through keyPressEvent; AT users
+// reach it here. Both go through one entry point, and both honour the #745
+// lock — an AT press on a locked panel is the no-op the double-click is.
+//
+// Display-only ScrollableLabels — RIT/XIT, step size, RTTY mark/shift —
+// return nullptr from the factory and keep QLabel's StaticText, which is
+// correct for them.
 class ScrollableLabelAccessible : public QAccessibleWidget {
 public:
     explicit ScrollableLabelAccessible(QWidget* widget)
-        : QAccessibleWidget(widget, QAccessible::EditableText) {}
+        : QAccessibleWidget(widget, QAccessible::Button) {}
+
+    // QAccessibleWidget already implements QAccessibleActionInterface (it
+    // offers SetFocus for a focusable widget), so these are overrides rather
+    // than a new interface — actionInterface() is non-null either way. What
+    // was missing was an action that DOES anything.
+    QStringList actionNames() const override
+    {
+        QStringList names{QAccessibleActionInterface::pressAction()};
+        names += QAccessibleWidget::actionNames();   // keeps SetFocus
+        names.removeDuplicates();
+        return names;
+    }
+
+    void doAction(const QString& actionName) override
+    {
+        if (actionName == QAccessibleActionInterface::pressAction()) {
+            if (auto* label = qobject_cast<ScrollableLabel*>(object())) {
+                if (!ControlsLock::isLocked())
+                    label->beginEdit(Qt::OtherFocusReason);
+            }
+            return;
+        }
+        QAccessibleWidget::doAction(actionName);
+    }
+
+    QStringList keyBindingsForAction(const QString& actionName) const override
+    {
+        if (actionName == QAccessibleActionInterface::pressAction()) {
+            // The same keys keyPressEvent() answers, so what an AT announces
+            // and what the keyboard actually does cannot drift apart.
+            return {QStringLiteral("Return"), QStringLiteral("Space")};
+        }
+        return QAccessibleWidget::keyBindingsForAction(actionName);
+    }
+
+    QString localizedActionDescription(const QString& actionName) const override
+    {
+        if (actionName == QAccessibleActionInterface::pressAction())
+            return QCoreApplication::translate(
+                "ScrollableLabel", "Open an editor to type an exact value");
+        return QAccessibleWidget::localizedActionDescription(actionName);
+    }
 };
 
 inline QAccessibleInterface* scrollableLabelAccessibleFactory(const QString& key,

--- a/src/gui/GuardedSlider.h
+++ b/src/gui/GuardedSlider.h
@@ -8,7 +8,10 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QIntValidator>
+#include <QAccessible>
+#include <QAccessibleWidget>
 #include <QEvent>
+#include <QLocale>
 #include <QKeyEvent>
 #include <QMouseEvent>
 #include <QStyle>
@@ -177,31 +180,38 @@ public:
     }
 };
 
-// QIntValidator reports an out-of-range number as Intermediate, not Invalid
-// — so a QLineEdit happily holds "20000" but then refuses to emit
-// returnPressed/editingFinished, because those require Acceptable input.
-// Measured against Qt 6.10: validate("20000") with a 0..10000 range returns
-// Intermediate. Without a fixup() the operator types a too-large value, hits
-// Enter, and nothing whatsoever happens.
+// The editor's validator, pinned to the C locale.
 //
-// Qt calls fixup() on Return precisely for this, so clamping there turns a
-// dead keypress into the nearest legal value.
-class ClampingIntValidator : public QIntValidator {
-public:
-    ClampingIntValidator(int minimum, int maximum, QObject* parent = nullptr)
-        : QIntValidator(minimum, maximum, parent) {}
+// QIntValidator validates in ITS locale while QString::toInt() always parses
+// in the C locale, so by default the two disagree: the validator accepts
+// locale digits and correctly-placed group separators ("3,000" under en_US,
+// Arabic-Indic digits under ar_*) that toInt() then refuses, and the edit
+// closes without ever reaching the model — an accepted keystroke that does
+// nothing (#5064 review). Pinning the validator to C, with the group
+// separator explicitly rejected rather than merely omitted, makes the two
+// halves agree on exactly one grammar: optional sign, ASCII digits.
+//
+// There is deliberately no clamping fixup() here. QIntValidator calls an
+// out-of-range number Intermediate, and QLineEdit will not emit
+// returnPressed/editingFinished on Intermediate input — the earlier version
+// of this class clamped in fixup() to keep Enter from being a dead keypress.
+// Return is now handled explicitly on the editor (see eventFilter below), so
+// an out-of-range entry closes the editor and RESTORES the previous value,
+// which is what issue #3627 asks for.
+inline QIntValidator* makeCLocaleIntValidator(int minimum, int maximum, QObject* parent)
+{
+    auto* validator = new QIntValidator(minimum, maximum, parent);
+    QLocale cLocale = QLocale::c();
+    cLocale.setNumberOptions(QLocale::RejectGroupSeparator
+                             | QLocale::OmitGroupSeparator);
+    validator->setLocale(cLocale);
+    return validator;
+}
 
-    void fixup(QString& input) const override {
-        bool ok = false;
-        const int v = input.toInt(&ok);
-        if (ok)
-            input = QString::number(qBound(bottom(), v, top()));
-        // Deliberately NOT chaining to QIntValidator::fixup(): it inserts
-        // locale group separators ("20000" -> "20,000"), and the caller
-        // parses this back with toInt(), which rejects them. Measured on
-        // Qt 6.10 — chaining silently dropped every out-of-range commit.
-    }
-};
+class ScrollableLabel;
+// Installed lazily by setEditable() — see the class comment below.
+inline QAccessibleInterface* scrollableLabelAccessibleFactory(const QString& key,
+                                                              QObject* object);
 
 // QLabel subclass that emits scrolled(int steps) on wheel events and
 // always consumes them. Used for RIT/XIT/pitch numeric displays. (#619)
@@ -227,6 +237,29 @@ public:
         m_editable = true;
         m_min = minValue;
         m_max = maxValue;
+
+        // docs/a11y.md, "Interactive QLabel anti-pattern": a QLabel that opens
+        // an editor is an interactive control, so it needs Tab focus, a
+        // keyboard activation path (keyPressEvent below) and a role that is
+        // not StaticText. Without these the feature was reachable only by
+        // mouse double-click — which is the opposite of the accessibility
+        // motivation in issue #3627 (#5064 review).
+        //
+        // StrongFocus rather than TabFocus: the label already takes a click,
+        // and a control that focuses on Tab but not on click reads as broken.
+        setFocusPolicy(Qt::StrongFocus);
+        if (accessibleDescription().isEmpty()) {
+            setAccessibleDescription(
+                tr("Editable. Press Enter or Space to type an exact value in Hz "
+                   "between %1 and %2, or use the arrow buttons.")
+                    .arg(minValue).arg(maxValue));
+        }
+
+        static bool s_accessibilityFactoryInstalled = false;
+        if (!s_accessibilityFactoryInstalled) {
+            s_accessibilityFactoryInstalled = true;
+            QAccessible::installFactory(scrollableLabelAccessibleFactory);
+        }
     }
     bool isEditable() const { return m_editable; }
     int  editMinimum() const { return m_min; }
@@ -254,6 +287,21 @@ public:
         ev->accept();
     }
 
+    // Keyboard route into the editor. Same gates as the double-click: editing
+    // must be enabled and the panel unlocked. Anything else falls through to
+    // QLabel so Tab/Shift-Tab keep working.
+    void keyPressEvent(QKeyEvent* ev) override {
+        const bool activates = ev->key() == Qt::Key_Return
+                               || ev->key() == Qt::Key_Enter
+                               || ev->key() == Qt::Key_Space;
+        if (activates && m_editable && !m_editor && !ControlsLock::isLocked()) {
+            beginEdit(Qt::TabFocusReason);
+            ev->accept();
+            return;
+        }
+        QLabel::keyPressEvent(ev);
+    }
+
     void mouseDoubleClickEvent(QMouseEvent* ev) override {
         // Same gate as the wheel handler: a locked panel is being scrolled,
         // not operated. (#745)
@@ -267,11 +315,18 @@ public:
 
     // Exposed so a test (and any future keyboard route) can open the editor
     // without synthesising a double-click.
-    void beginEdit() {
+    void beginEdit(Qt::FocusReason reason = Qt::MouseFocusReason) {
         if (!m_editable || m_editor)
             return;
         m_editor = new QLineEdit(text(), this);
-        m_editor->setValidator(new ClampingIntValidator(m_min, m_max, m_editor));
+        m_editor->setValidator(makeCLocaleIntValidator(m_min, m_max, m_editor));
+        // The editor is a fresh widget every time, so it inherits none of the
+        // label's accessible metadata — to a screen reader it was an unnamed
+        // edit box appearing from nowhere (#5064 review).
+        m_editor->setAccessibleName(accessibleName());
+        m_editor->setAccessibleDescription(
+            tr("Type a value in Hz between %1 and %2, then press Enter. "
+               "Escape cancels.").arg(m_min).arg(m_max));
         m_editor->setAlignment(alignment());
         if (m_editorStyler)
             m_editorStyler(m_editor);
@@ -282,10 +337,15 @@ public:
         m_editor->installEventFilter(this);
         connect(m_editor, &QLineEdit::editingFinished, this, [this]() { commitEdit(); });
         m_editor->show();
-        m_editor->setFocus(Qt::MouseFocusReason);
+        m_editor->setFocus(reason);
     }
 
     bool isEditing() const { return m_editor != nullptr; }
+
+    // Whether closing the editor should hand focus back to the label. Yes for
+    // deliberate keyboard exits (Enter, Escape); No for focus-out, where the
+    // user is already on their way to another control.
+    enum class RestoreFocus { No, Yes };
 
 signals:
     void scrolled(int direction);
@@ -315,7 +375,27 @@ protected:
                     // window shortcut does not consume it; the KeyPress that
                     // follows is what actually closes the editor.
                     if (ev->type() == QEvent::KeyPress)
-                        closeEditor();
+                        closeEditor(RestoreFocus::Yes);
+                    ev->accept();
+                    return true;
+                }
+
+                // Return/Enter must be handled HERE rather than left to
+                // QLineEdit's own signal (#5064 review). QLineEdit emits
+                // returnPressed/editingFinished on Return only once the
+                // validator reports Acceptable — an EMPTY field is
+                // Intermediate and nothing repairs it, so Enter emitted
+                // nothing at all and left the editor sitting open on top of
+                // the label, eating every wheel event aimed at the numerals
+                // underneath. The same held for any out-of-range entry once
+                // the clamping fixup() was removed.
+                //
+                // Committing explicitly makes Enter terminal for EVERY input:
+                // a legal value commits, anything else cancels and the
+                // previous value stands.
+                if (ke->key() == Qt::Key_Return || ke->key() == Qt::Key_Enter) {
+                    if (ev->type() == QEvent::KeyPress)
+                        commitEdit(RestoreFocus::Yes);
                     ev->accept();
                     return true;
                 }
@@ -327,7 +407,10 @@ protected:
             // the editor sitting open on top of the label — where it silently
             // ate every wheel event aimed at the numerals underneath.
             if (ev->type() == QEvent::FocusOut) {
-                commitEdit();               // commits if parseable, else cancels
+                // RestoreFocus::No — the user is on their way somewhere else
+                // (a Tab, a click on another control); pulling focus back to
+                // the label here would fight them for it.
+                commitEdit(RestoreFocus::No);
                 return false;               // let Qt finish its own focus work
             }
 
@@ -356,7 +439,7 @@ private:
     // Tear the editor down. Clears the member FIRST: destroying a focused
     // QLineEdit emits editingFinished, and a null member is what stops that
     // re-entering commitEdit() and committing a value twice.
-    void closeEditor() {
+    void closeEditor(RestoreFocus restore = RestoreFocus::No) {
         if (!m_editor)
             return;
         QLineEdit* ed = m_editor;
@@ -364,21 +447,48 @@ private:
         // hide() before deleteLater(): the delete only lands on the next
         // event-loop pass, and until then the editor is still a visible
         // child sitting on top of the label.
+        // window()->focusWidget(), not hasFocus(): hasFocus() is additionally
+        // false whenever the window is not ACTIVE, so a commit made while
+        // another window happens to be in front would silently skip the
+        // restore and strand the keyboard user with no focused control. The
+        // question here is only "was the editor this window's focus target".
+        QWidget* const editorWindow = ed->window();
+        const bool editorHadFocus =
+            editorWindow && editorWindow->focusWidget() == ed;
         ed->hide();
         ed->deleteLater();
+        // A keyboard user who opened the editor with Enter and closed it with
+        // Enter or Escape must land back on the label, not on whatever Qt
+        // picks when the focused child disappears.
+        if (restore == RestoreFocus::Yes && editorHadFocus
+            && focusPolicy() != Qt::NoFocus) {
+            setFocus(Qt::OtherFocusReason);
+        }
     }
 
-    void commitEdit() {
+    // Issue #3627: "Invalid values are rejected with validation and the
+    // previous value is restored." Restoring is implicit and that is the point
+    // — the editor is a separate QLineEdit laid OVER the label, so the label's
+    // own text was never touched and still holds model truth. Returning
+    // without emitting is the restore.
+    //
+    // This replaced a clamp (#5064 review). Clamping is a defensible UX, but
+    // it is not the one the issue specifies, and silently moving an operator's
+    // typed 20000 to 3250 reads as the radio having ignored them.
+    void commitEdit(RestoreFocus restore = RestoreFocus::No) {
         if (!m_editor)
             return;
         const QString typed = m_editor->text().trimmed();
-        closeEditor();
+        closeEditor(restore);
         bool ok = false;
         const int value = typed.toInt(&ok);
-        // Empty or unparseable cancels: the label keeps whatever the model
-        // last put there, so a stray double-click costs nothing.
-        if (ok)
-            emit editCommitted(value);
+        // Empty, unparseable, or outside the accepted range: reject, and the
+        // label keeps whatever the model last put there. The range test is
+        // here and not only in the validator because focus-out reaches this
+        // with Intermediate text the validator never blocked.
+        if (!ok || value < m_min || value > m_max)
+            return;
+        emit editCommitted(value);
     }
 
     bool       m_editable{false};
@@ -387,3 +497,30 @@ private:
     std::function<void(QWidget*)> m_editorStyler;
     QLineEdit* m_editor{nullptr};
 };
+
+// An editable ScrollableLabel is an interactive control, and QLabel's default
+// StaticText role tells a screen reader the opposite — the same
+// interactive-QLabel anti-pattern docs/a11y.md names. Same lazy-factory shape
+// as CrossNeedleMeterWidget's.
+//
+// EditableText rather than the doc's suggested Button: activating this does
+// not perform an action, it exposes a value for editing, and Button would have
+// an AT announce it as something to press. Display-only ScrollableLabels —
+// RIT/XIT, step size, RTTY mark/shift — return nullptr here and keep QLabel's
+// StaticText, which is correct for them.
+class ScrollableLabelAccessible : public QAccessibleWidget {
+public:
+    explicit ScrollableLabelAccessible(QWidget* widget)
+        : QAccessibleWidget(widget, QAccessible::EditableText) {}
+};
+
+inline QAccessibleInterface* scrollableLabelAccessibleFactory(const QString& key,
+                                                              QObject* object)
+{
+    if (key == QLatin1String("ScrollableLabel")) {
+        auto* label = qobject_cast<ScrollableLabel*>(object);
+        if (label && label->isEditable())
+            return new ScrollableLabelAccessible(label);
+    }
+    return nullptr;
+}

--- a/src/gui/PhoneApplet.cpp
+++ b/src/gui/PhoneApplet.cpp
@@ -307,6 +307,30 @@ void PhoneApplet::buildUI()
         m_lowCutLabel->setAlignment(Qt::AlignCenter);
         AetherSDR::ThemeManager::instance().applyStyleSheet(m_lowCutLabel, "QLabel { font-size: 11px; color: {{color.text.primary}}; background: {{color.background.0}}; "
             "border: 1px solid {{color.background.1}}; border-radius: 3px; padding: 1px 3px; }");
+        // Direct numeric entry (#3627): double-click to type an exact Hz
+        // value instead of stepping to it 50 Hz at a time. The validator
+        // bounds the field at the model's own 0..10000 range; the commit
+        // below applies the same cross-bound rule as the step buttons.
+        //
+        // No explicit re-sync after a commit: the editor is a separate
+        // QLineEdit laid over the label, so keystrokes never touch the
+        // label's own text. Whenever the clamped value does change the
+        // model, phoneStateChanged -> syncFromModel() repaints it; when it
+        // clamps onto the value already set, the label is already right.
+        m_lowCutLabel->setEditable(0, 10000);
+        m_lowCutLabel->setEditorStyleSheetFromLabel(m_lowCutLabel->styleSheet());
+        connect(m_lowCutLabel, &ScrollableLabel::editCommitted, this, [this](int hz) {
+            if (!m_model) return;
+            // Clamp low against high HERE, exactly as the step buttons do at
+            // their own call site (lowCutUp above).
+            //
+            // This is not redundant with the model. TransmitModel::setTxFilter()
+            // resolves a crossed pair by keeping the low it was given and
+            // pushing HIGH up to low + 50 — so typing 9000 into low cut would
+            // drag the high cut from 3300 to 9050, moving a passband edge the
+            // operator never touched. Clamping low instead keeps their high.
+            m_model->setTxFilterLow(qBound(0, hz, m_model->txFilterHigh() - 50));
+        });
         connect(m_lowCutLabel, &ScrollableLabel::scrolled, this,
                 [lowCutUp, lowCutDown](int dir) {
             if (dir > 0) lowCutUp(); else lowCutDown();
@@ -358,6 +382,17 @@ void PhoneApplet::buildUI()
         m_highCutLabel->setAlignment(Qt::AlignCenter);
         AetherSDR::ThemeManager::instance().applyStyleSheet(m_highCutLabel, "QLabel { font-size: 11px; color: {{color.text.primary}}; background: {{color.background.0}}; "
             "border: 1px solid {{color.background.1}}; border-radius: 3px; padding: 1px 3px; }");
+        // Direct numeric entry (#3627) — see the low-cut comment above.
+        m_highCutLabel->setEditable(0, 10000);
+        m_highCutLabel->setEditorStyleSheetFromLabel(m_highCutLabel->styleSheet());
+        connect(m_highCutLabel, &ScrollableLabel::editCommitted, this, [this](int hz) {
+            if (!m_model) return;
+            // No call-site clamp on this side: setTxFilter() already raises a
+            // too-low high to low + 50 and caps it at 10000, which is the same
+            // answer the step buttons give. The asymmetry is real, not an
+            // oversight — see the low-cut handler for why that side needs one.
+            m_model->setTxFilterHigh(hz);
+        });
         connect(m_highCutLabel, &ScrollableLabel::scrolled, this,
                 [highCutUp, highCutDown](int dir) {
             if (dir > 0) highCutUp(); else highCutDown();

--- a/src/gui/PhoneApplet.cpp
+++ b/src/gui/PhoneApplet.cpp
@@ -327,16 +327,27 @@ void PhoneApplet::buildUI()
         });
         connect(m_lowCutLabel, &ScrollableLabel::editCommitted, this, [this](int hz) {
             if (!m_model) return;
-            // Clamp low against high HERE, exactly as the step buttons do at
-            // their own call site (lowCutUp above).
+            // Enforce the cross-bound HERE, because the model cannot:
+            // TransmitModel::setTxFilter() resolves a crossed pair by keeping
+            // the low it was given and pushing HIGH up to low + 50 — so
+            // typing 9000 into low cut would drag the high cut from 3300 to
+            // 9050, moving a passband edge the operator never touched.
             //
-            // This is not redundant with the model. TransmitModel::setTxFilter()
-            // resolves a crossed pair by keeping the low it was given and
-            // pushing HIGH up to low + 50 — so typing 9000 into low cut would
-            // drag the high cut from 3300 to 9050, moving a passband edge the
-            // operator never touched. Clamping low instead keeps their high.
-            m_model->setTxFilterLow(qBound(m_model->txFilterMinHz(), hz,
-                                           m_model->txFilterHigh() - m_model->txFilterMinWidthHz()));
+            // Out of range is REJECTED, not clamped (#3627: "Invalid values
+            // are rejected with validation and the previous value is
+            // restored"; #5064 review). Rejecting is simply returning: the
+            // label still shows model truth, because the editor is a separate
+            // widget laid over it and never wrote to the label's text.
+            //
+            // The STEP buttons still clamp, and that asymmetry is deliberate —
+            // a step is a request to move by one increment and stopping at the
+            // bound is the only sensible answer, while a typed number is a
+            // request for that exact value.
+            if (hz < m_model->txFilterMinHz()
+                || hz > m_model->txFilterHigh() - m_model->txFilterMinWidthHz()) {
+                return;
+            }
+            m_model->setTxFilterLow(hz);
         });
         connect(m_lowCutLabel, &ScrollableLabel::scrolled, this,
                 [lowCutUp, lowCutDown](int dir) {
@@ -399,11 +410,15 @@ void PhoneApplet::buildUI()
         });
         connect(m_highCutLabel, &ScrollableLabel::editCommitted, this, [this](int hz) {
             if (!m_model) return;
-            // No call-site clamp on this side: setTxFilter() already raises a
-            // too-low high to low + the minimum width and caps it at the
-            // model's maximum, which is the same
-            // answer the step buttons give. The asymmetry is real, not an
-            // oversight — see the low-cut handler for why that side needs one.
+            // Symmetric with the low-cut handler now that a typed value is
+            // rejected rather than clamped (#3627 / #5064 review). Relying on
+            // setTxFilter() to raise a too-low high to low + the minimum width
+            // was the CLAMPING answer; it is the wrong one for direct entry,
+            // where the operator gets their previous value back instead.
+            if (hz > m_model->txFilterMaxHz()
+                || hz < m_model->txFilterLow() + m_model->txFilterMinWidthHz()) {
+                return;
+            }
             m_model->setTxFilterHigh(hz);
         });
         connect(m_highCutLabel, &ScrollableLabel::scrolled, this,

--- a/src/gui/PhoneApplet.cpp
+++ b/src/gui/PhoneApplet.cpp
@@ -318,7 +318,11 @@ void PhoneApplet::buildUI()
         // model, phoneStateChanged -> syncFromModel() repaints it; when it
         // clamps onto the value already set, the label is already right.
         m_lowCutLabel->setEditable(0, 10000);
-        m_lowCutLabel->setEditorStyleSheetFromLabel(m_lowCutLabel->styleSheet());
+        m_lowCutLabel->setEditorStyler([](QWidget* editor) {
+            AetherSDR::ThemeManager::instance().applyStyleSheet(editor,
+                "QLineEdit { font-size: 11px; color: {{color.text.primary}}; background: {{color.background.0}}; "
+                "border: 1px solid {{color.background.1}}; border-radius: 3px; padding: 1px 3px; }");
+        });
         connect(m_lowCutLabel, &ScrollableLabel::editCommitted, this, [this](int hz) {
             if (!m_model) return;
             // Clamp low against high HERE, exactly as the step buttons do at
@@ -384,7 +388,11 @@ void PhoneApplet::buildUI()
             "border: 1px solid {{color.background.1}}; border-radius: 3px; padding: 1px 3px; }");
         // Direct numeric entry (#3627) — see the low-cut comment above.
         m_highCutLabel->setEditable(0, 10000);
-        m_highCutLabel->setEditorStyleSheetFromLabel(m_highCutLabel->styleSheet());
+        m_highCutLabel->setEditorStyler([](QWidget* editor) {
+            AetherSDR::ThemeManager::instance().applyStyleSheet(editor,
+                "QLineEdit { font-size: 11px; color: {{color.text.primary}}; background: {{color.background.0}}; "
+                "border: 1px solid {{color.background.1}}; border-radius: 3px; padding: 1px 3px; }");
+        });
         connect(m_highCutLabel, &ScrollableLabel::editCommitted, this, [this](int hz) {
             if (!m_model) return;
             // No call-site clamp on this side: setTxFilter() already raises a

--- a/src/gui/PhoneApplet.cpp
+++ b/src/gui/PhoneApplet.cpp
@@ -290,13 +290,13 @@ void PhoneApplet::buildUI()
             if (!m_model) return;
             const int v = m_model->txFilterLow();
             const int snapped = ((v - 1) / 50) * 50;
-            m_model->setTxFilterLow(qMax(0, snapped));
+            m_model->setTxFilterLow(qMax(m_model->txFilterMinHz(), snapped));
         };
         auto lowCutUp = [this]() {
             if (!m_model) return;
             const int v = m_model->txFilterLow();
             const int snapped = ((v / 50) + 1) * 50;
-            m_model->setTxFilterLow(qMin(m_model->txFilterHigh() - 50, snapped));
+            m_model->setTxFilterLow(qMin(m_model->txFilterHigh() - m_model->txFilterMinWidthHz(), snapped));
         };
         connect(m_lowCutDown, &QPushButton::clicked, this, lowCutDown);
         lowRow->addWidget(m_lowCutDown);
@@ -309,7 +309,8 @@ void PhoneApplet::buildUI()
             "border: 1px solid {{color.background.1}}; border-radius: 3px; padding: 1px 3px; }");
         // Direct numeric entry (#3627): double-click to type an exact Hz
         // value instead of stepping to it 50 Hz at a time. The validator
-        // bounds the field at the model's own 0..10000 range; the commit
+        // bounds the field at whatever range the MODEL reports (never a
+        // literal here — see TransmitModel::txFilterMaxHz); the commit
         // below applies the same cross-bound rule as the step buttons.
         //
         // No explicit re-sync after a commit: the editor is a separate
@@ -317,7 +318,8 @@ void PhoneApplet::buildUI()
         // label's own text. Whenever the clamped value does change the
         // model, phoneStateChanged -> syncFromModel() repaints it; when it
         // clamps onto the value already set, the label is already right.
-        m_lowCutLabel->setEditable(0, 10000);
+        m_lowCutLabel->setEditable(m_model ? m_model->txFilterMinHz() : TransmitModel::kTxFilterMinHz,
+                                   m_model ? m_model->txFilterMaxHz() : TransmitModel::kTxFilterMaxHz);
         m_lowCutLabel->setEditorStyler([](QWidget* editor) {
             AetherSDR::ThemeManager::instance().applyStyleSheet(editor,
                 "QLineEdit { font-size: 11px; color: {{color.text.primary}}; background: {{color.background.0}}; "
@@ -333,7 +335,8 @@ void PhoneApplet::buildUI()
             // pushing HIGH up to low + 50 — so typing 9000 into low cut would
             // drag the high cut from 3300 to 9050, moving a passband edge the
             // operator never touched. Clamping low instead keeps their high.
-            m_model->setTxFilterLow(qBound(0, hz, m_model->txFilterHigh() - 50));
+            m_model->setTxFilterLow(qBound(m_model->txFilterMinHz(), hz,
+                                           m_model->txFilterHigh() - m_model->txFilterMinWidthHz()));
         });
         connect(m_lowCutLabel, &ScrollableLabel::scrolled, this,
                 [lowCutUp, lowCutDown](int dir) {
@@ -369,13 +372,13 @@ void PhoneApplet::buildUI()
             if (!m_model) return;
             const int v = m_model->txFilterHigh();
             const int snapped = ((v - 1) / 50) * 50;
-            m_model->setTxFilterHigh(qMax(m_model->txFilterLow() + 50, snapped));
+            m_model->setTxFilterHigh(qMax(m_model->txFilterLow() + m_model->txFilterMinWidthHz(), snapped));
         };
         auto highCutUp = [this]() {
             if (!m_model) return;
             const int v = m_model->txFilterHigh();
             const int snapped = ((v / 50) + 1) * 50;
-            m_model->setTxFilterHigh(qMin(10000, snapped));
+            m_model->setTxFilterHigh(qMin(m_model->txFilterMaxHz(), snapped));
         };
         connect(m_highCutDown, &QPushButton::clicked, this, highCutDown);
         highRow->addWidget(m_highCutDown);
@@ -387,7 +390,8 @@ void PhoneApplet::buildUI()
         AetherSDR::ThemeManager::instance().applyStyleSheet(m_highCutLabel, "QLabel { font-size: 11px; color: {{color.text.primary}}; background: {{color.background.0}}; "
             "border: 1px solid {{color.background.1}}; border-radius: 3px; padding: 1px 3px; }");
         // Direct numeric entry (#3627) — see the low-cut comment above.
-        m_highCutLabel->setEditable(0, 10000);
+        m_highCutLabel->setEditable(m_model ? m_model->txFilterMinHz() : TransmitModel::kTxFilterMinHz,
+                                    m_model ? m_model->txFilterMaxHz() : TransmitModel::kTxFilterMaxHz);
         m_highCutLabel->setEditorStyler([](QWidget* editor) {
             AetherSDR::ThemeManager::instance().applyStyleSheet(editor,
                 "QLineEdit { font-size: 11px; color: {{color.text.primary}}; background: {{color.background.0}}; "
@@ -396,7 +400,8 @@ void PhoneApplet::buildUI()
         connect(m_highCutLabel, &ScrollableLabel::editCommitted, this, [this](int hz) {
             if (!m_model) return;
             // No call-site clamp on this side: setTxFilter() already raises a
-            // too-low high to low + 50 and caps it at 10000, which is the same
+            // too-low high to low + the minimum width and caps it at the
+            // model's maximum, which is the same
             // answer the step buttons give. The asymmetry is real, not an
             // oversight — see the low-cut handler for why that side needs one.
             m_model->setTxFilterHigh(hz);

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -655,18 +655,18 @@ void TransmitModel::setDexpLevel(int level)
 // command (Principle II).
 void TransmitModel::setTxFilterLow(int hz)
 {
-    setTxFilter(qBound(0, hz, 10000), m_txFilterHigh);
+    setTxFilter(qBound(kTxFilterMinHz, hz, kTxFilterMaxHz), m_txFilterHigh);
 }
 
 void TransmitModel::setTxFilterHigh(int hz)
 {
-    setTxFilter(m_txFilterLow, qBound(0, hz, 10000));
+    setTxFilter(m_txFilterLow, qBound(kTxFilterMinHz, hz, kTxFilterMaxHz));
 }
 
 void TransmitModel::setTxFilter(int lowHz, int highHz)
 {
-    lowHz = qBound(0, lowHz, 9950);
-    highHz = qBound(lowHz + 50, highHz, 10000);
+    lowHz  = qBound(kTxFilterMinHz, lowHz, kTxFilterMaxHz - kTxFilterMinWidthHz);
+    highHz = qBound(lowHz + kTxFilterMinWidthHz, highHz, kTxFilterMaxHz);
     if (m_txFilterLow != lowHz || m_txFilterHigh != highHz) {
         m_txFilterLow = lowHz;
         m_txFilterHigh = highHz;

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -73,6 +73,20 @@ public:
     int     amCarrierLevel() const { return m_amCarrierLevel; }
     bool    dexpOn()         const { return m_dexpOn; }
     int     dexpLevel()      const { return m_dexpLevel; }
+    // TX filter bounds.  ACCESSORS, not bare constants, deliberately: every
+    // backend shares this range today, but a radio that declares its own
+    // passband limits should be able to narrow it without any caller
+    // changing — the GUI already asks rather than assumes.
+    //
+    // FlexBackend clamps to the same range on the wire, which is where a
+    // radio-specific limit properly belongs; this is the client-side mirror.
+    static constexpr int kTxFilterMinHz      = 0;
+    static constexpr int kTxFilterMaxHz      = 10000;
+    static constexpr int kTxFilterMinWidthHz = 50;
+    int txFilterMinHz()      const { return kTxFilterMinHz; }
+    int txFilterMaxHz()      const { return kTxFilterMaxHz; }
+    int txFilterMinWidthHz() const { return kTxFilterMinWidthHz; }
+
     int     txFilterLow()    const { return m_txFilterLow; }
     int     txFilterHigh()   const { return m_txFilterHigh; }
 

--- a/tests/phone_tx_filter_numeric_entry_test.cpp
+++ b/tests/phone_tx_filter_numeric_entry_test.cpp
@@ -15,6 +15,7 @@
 
 #include <QApplication>
 #include <QLineEdit>
+#include <QFocusEvent>
 #include <QSignalSpy>
 #include <QCoreApplication>
 #include <QTest>
@@ -214,6 +215,42 @@ int main(int argc, char** argv)
     QTest::mouseDClick(&plain, Qt::LeftButton);
     check(!plain.isEditing(),
           "double-clicking a default ScrollableLabel does nothing");
+
+    // ── A leftover editor is what actually ate the wheel ──────────────────
+    //
+    // Reported live 2026-08-18: rolling over the numerals did nothing. The
+    // editor covers the label exactly, so any editor still on screen is a lid
+    // over the control. Two routes used to leave one there.
+
+    // Route 1: focus-out with input QIntValidator calls Intermediate.
+    // QLineEdit emits editingFinished on focus-out only when the input is
+    // ACCEPTABLE, so this emitted nothing and the editor stayed open forever.
+    // An EMPTY field is the case fixup() cannot rescue: 20000 clamps to 10000
+    // and becomes Acceptable, so Qt emits editingFinished for it anyway. Only
+    // an unparseable field actually strands the editor.
+    model.setTxFilter(200, 3300);
+    if (QLineEdit* ed = openEditor(low)) {
+        ed->clear();
+        check(!ed->hasAcceptableInput(), "an empty field is not Acceptable (the precondition)");
+        QApplication::sendEvent(ed, new QFocusEvent(QEvent::FocusOut));
+    }
+    check(!low->isEditing(),
+          "focus-out always closes the editor, even on unacceptable input");
+
+    // Route 2: with an editor open, the wheel must still step the value —
+    // the label underneath can never receive the event itself.
+    model.setTxFilter(200, 3300);
+    if (QLineEdit* ed = openEditor(low)) {
+        QWheelEvent up(QPointF(5, 5), QPointF(5, 5), QPoint(), QPoint(0, 120),
+                       Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
+        QApplication::sendEvent(ed, &up);
+        check(model.txFilterLow() == 250,
+              "the wheel still steps while the editor is open");
+        check(ed->text() == QStringLiteral("250"),
+              "the open field follows the model rather than showing a stale number");
+    }
+    if (low->isEditing())
+        QTest::keyClick(low->findChild<QLineEdit*>(), Qt::Key_Escape);
 
     // ── The existing affordance still works ───────────────────────────────
     model.setTxFilter(200, 3300);

--- a/tests/phone_tx_filter_numeric_entry_test.cpp
+++ b/tests/phone_tx_filter_numeric_entry_test.cpp
@@ -43,15 +43,24 @@ ScrollableLabel* cutLabel(PhoneApplet& applet, const char* accessibleName)
     return nullptr;
 }
 
+// Open the editor and hand back the CURRENT one.
+//
+// Always drain deferred deletes first: findChild<QLineEdit*>() will otherwise
+// return an editor a previous edit already closed but that has not been
+// deleted yet, and every assertion then runs against a widget the label no
+// longer owns. A running app gets this for free from the event loop between
+// two operator actions.
+QLineEdit* openEditor(ScrollableLabel* label)
+{
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    label->beginEdit();
+    return label->findChild<QLineEdit*>();
+}
+
 // Type into an open editor and commit with Return.
 void typeAndCommit(ScrollableLabel* label, const QString& text)
 {
-    // Drain any editor left pending deleteLater() by a previous edit, so
-    // findChild() below cannot hand back the old one. A running app gets
-    // this for free from the event loop between two operator actions.
-    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
-    label->beginEdit();
-    QLineEdit* ed = label->findChild<QLineEdit*>();
+    QLineEdit* ed = openEditor(label);
     if (!ed)
         return;
     ed->setText(text);
@@ -85,8 +94,7 @@ int main(int argc, char** argv)
     // stylesheet selectors on widget class, so a QLabel rule styles nothing.
     check(low->hasEditorStyler() && high->hasEditorStyler(),
           "both readouts style their editor rather than leaving it unthemed");
-    low->beginEdit();
-    if (QLineEdit* ed = low->findChild<QLineEdit*>()) {
+    if (QLineEdit* ed = openEditor(low)) {
         check(ed->styleSheet().contains(QLatin1String("QLineEdit")),
               "the editor is themed with a QLineEdit rule");
         check(!ed->styleSheet().contains(QLatin1String("{{")),
@@ -148,14 +156,40 @@ int main(int argc, char** argv)
           "an out-of-range typed value is clamped, not silently dropped");
 
     // ── Cancel routes ─────────────────────────────────────────────────────
+    //
+    // Esc is the row that shipped broken, so it is tested the way the APP
+    // behaves, not the way a bare harness does. The main window carries
+    // QShortcut(Qt::Key_Escape, window()) (CwxPanel, DvkPanel). Qt offers a
+    // ShortcutOverride first and, if nothing accepts it, the shortcut fires
+    // and the focused widget never receives a KeyPress — which is why the
+    // original keyPressEvent handler never ran in the real app while passing
+    // a test that delivered Esc straight to the widget.
+    //
+    // Accepting the ShortcutOverride is therefore the whole fix, and it is
+    // asserted directly: without it this row fails and Esc stays dead.
     model.setTxFilter(150, 3300);
-    low->beginEdit();
-    if (QLineEdit* ed = low->findChild<QLineEdit*>()) {
+    if (QLineEdit* ed = openEditor(low)) {
         ed->setText(QStringLiteral("2000"));
+        QKeyEvent probe(QEvent::ShortcutOverride, Qt::Key_Escape, Qt::NoModifier);
+        probe.setAccepted(false);
+        QApplication::sendEvent(ed, &probe);
+        check(probe.isAccepted(),
+              "Esc is claimed from the window shortcut (ShortcutOverride accepted)");
         QTest::keyClick(ed, Qt::Key_Escape);
     }
+    check(!low->isEditing(), "Esc closes the editor");
     check(model.txFilterLow() == 150, "Esc abandons the edit without committing");
     check(low->text() == QStringLiteral("150"), "Esc leaves the displayed value intact");
+
+    // Qt::Key_Cancel is the same gesture on platforms that send it; VfoWidget
+    // treats the two together and so do we.
+    model.setTxFilter(150, 3300);
+    if (QLineEdit* ed = openEditor(low)) {
+        ed->setText(QStringLiteral("2000"));
+        QTest::keyClick(ed, Qt::Key_Cancel);
+    }
+    check(!low->isEditing() && model.txFilterLow() == 150,
+          "Key_Cancel abandons the edit the same way Esc does");
 
     // ── Lock gate: a locked panel is being scrolled, not operated (#745) ──
     ControlsLock::setLocked(true);
@@ -164,7 +198,12 @@ int main(int argc, char** argv)
     ControlsLock::setLocked(false);
     QTest::mouseDClick(low, Qt::LeftButton);
     check(low->isEditing(), "unlocking restores double-click-to-type");
+    // Flush again before reaching for the editor: the row above opened a NEW
+    // one, but an earlier closed editor can still be pending deleteLater and
+    // findChild() returns whichever it meets first.
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
     QTest::keyClick(low->findChild<QLineEdit*>(), Qt::Key_Escape);
+    check(!low->isEditing(), "the editor closes again after the lock test");
 
     // ── Blast radius: every OTHER ScrollableLabel is untouched ────────────
     // RIT/XIT (RxApplet), step size (RxApplet) and RTTY mark/shift

--- a/tests/phone_tx_filter_numeric_entry_test.cpp
+++ b/tests/phone_tx_filter_numeric_entry_test.cpp
@@ -239,6 +239,65 @@ int main(int argc, char** argv)
     check(!low->accessibleDescription().isEmpty(),
           "the readout describes its editability to an AT");
 
+    // ── The AT contract, not just the names (#5064 re-review) ─────────────
+    //
+    // The first version of this claimed role EditableText and implemented no
+    // text or editable-text interface, leaving SetFocus as the only action —
+    // so VoiceOver/NVDA/switch-control could focus the readout and never open
+    // the editor, because AT activation invokes an accessibility ACTION rather
+    // than synthesizing Return. Asserting the role alone would not have caught
+    // that; these rows assert the actionable contract behind it.
+    {
+        QAccessibleInterface* iface = QAccessible::queryAccessibleInterface(low);
+        check(iface != nullptr, "the editable readout has an accessible interface");
+        check(iface && iface->role() == QAccessible::Button,
+              "the editable readout reports Button, per docs/a11y.md");
+
+        QAccessibleActionInterface* action = iface ? iface->actionInterface() : nullptr;
+        check(action != nullptr, "it exposes an action interface");
+        const QStringList names = action ? action->actionNames() : QStringList{};
+        check(names.contains(QAccessibleActionInterface::pressAction()),
+              "press is among its actions, not just SetFocus");
+        check(names.contains(QAccessibleActionInterface::setFocusAction()),
+              "SetFocus is still offered alongside it");
+        check(action
+                  && !action->keyBindingsForAction(
+                             QAccessibleActionInterface::pressAction()).isEmpty(),
+              "the press action announces the keys that also perform it");
+
+        // The row that actually matters: driving the accessibility API the way
+        // an AT does must open the real editor.
+        model.setTxFilter(200, 3300);
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+        if (action)
+            action->doAction(QAccessibleActionInterface::pressAction());
+        check(low->isEditing(), "an AT press opens the editor");
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+        if (QLineEdit* ed = low->findChild<QLineEdit*>()) {
+            ed->setText(QStringLiteral("610"));
+            QTest::keyClick(ed, Qt::Key_Return);
+        }
+        check(model.txFilterLow() == 610,
+              "an edit opened through the accessibility API commits normally");
+
+        // The lock gate applies to the AT route too — the keyboard and
+        // double-click routes both honour it, and a third way in that ignored
+        // it would be a hole (#745).
+        ControlsLock::setLocked(true);
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+        if (action)
+            action->doAction(QAccessibleActionInterface::pressAction());
+        check(!low->isEditing(), "an AT press on a locked panel is a no-op (#745)");
+        ControlsLock::setLocked(false);
+
+        // A display-only ScrollableLabel must NOT become a button.
+        ScrollableLabel readOnly(QStringLiteral("+0 Hz"));
+        QAccessibleInterface* plainIface =
+            QAccessible::queryAccessibleInterface(&readOnly);
+        check(plainIface && plainIface->role() != QAccessible::Button,
+              "a display-only ScrollableLabel is not announced as a button");
+    }
+
     model.setTxFilter(200, 3300);
     if (QLineEdit* ed = openEditorByKey(low, Qt::Key_Return)) {
         check(low->isEditing(), "Return on the focused readout opens the editor");

--- a/tests/phone_tx_filter_numeric_entry_test.cpp
+++ b/tests/phone_tx_filter_numeric_entry_test.cpp
@@ -2,10 +2,13 @@
 //
 // The PHONE applet's low/high cut readouts are ScrollableLabels. Before this
 // they could only be stepped in 50 Hz snaps; now they can be typed into.
-// These rows pin the two things that are easy to get wrong: the cross-bound
-// clamp a typed value must obey (the same one the step buttons apply at their
-// call site), and the fact that editing is OFF for every OTHER ScrollableLabel
-// in the app — RIT/XIT, step size, RTTY mark/shift all share this class.
+// These rows pin the things that are easy to get wrong: the cross-bound a
+// typed value must obey, the fact that an out-of-range entry is REJECTED with
+// the previous value restored (issue #3627's words) rather than clamped, that
+// Enter is terminal for every input including the empty field, that the
+// feature is reachable from the keyboard, and that editing is OFF for every
+// OTHER ScrollableLabel in the app — RIT/XIT, step size, RTTY mark/shift all
+// share this class.
 
 #include "TestSettingsProfile.h"
 #include "core/AppSettings.h"
@@ -15,7 +18,9 @@
 
 #include <QApplication>
 #include <QLineEdit>
+#include <QAccessible>
 #include <QFocusEvent>
+#include <QLocale>
 #include <QSignalSpy>
 #include <QCoreApplication>
 #include <QTest>
@@ -55,6 +60,19 @@ QLineEdit* openEditor(ScrollableLabel* label)
 {
     QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
     label->beginEdit();
+    return label->findChild<QLineEdit*>();
+}
+
+// Open the editor the way an operator on a keyboard does, and hand back the
+// CURRENT one. Same deferred-delete drain as openEditor() and for the same
+// reason: without it findChild() returns an editor a previous row already
+// closed but that has not been deleted yet.
+QLineEdit* openEditorByKey(ScrollableLabel* label, Qt::Key key)
+{
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    label->setFocus(Qt::TabFocusReason);
+    QTest::keyClick(label, key);
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
     return label->findChild<QLineEdit*>();
 }
 
@@ -130,41 +148,160 @@ int main(int argc, char** argv)
     check(model.txFilterLow() == 100 && model.txFilterHigh() == 2900,
           "100-2900 Hz is reachable by typing both bounds");
 
-    // ── Cross-bound clamp: same rule the step buttons enforce ─────────────
+    // ── Cross-bound: rejected, previous value restored (#3627) ────────────
+    //
+    // Issue #3627: "Invalid values are rejected with validation and the
+    // previous value is restored." This clamped until the #5064 review — a
+    // typed 9000 silently became 3250, which reads as the radio ignoring the
+    // operator. The step buttons still clamp, deliberately: stopping at the
+    // bound is the only sensible answer to "move by one increment".
     model.setTxFilter(50, 3300);
     typeAndCommit(low, QStringLiteral("9000"));
-    check(model.txFilterLow() == 3250,
-          "a low cut above high is clamped to high - 50, never crossed");
-    // The reason that clamp lives at the call site: the model would resolve
-    // the same crossed pair by keeping low and dragging high up to 9050.
+    check(model.txFilterLow() == 50,
+          "a low cut above high is REJECTED, and the previous low stands");
+    // The reason the cross-bound test lives at the call site at all: the model
+    // would resolve the same crossed pair by keeping low and dragging high up
+    // to 9050, moving an edge the operator never touched.
     check(model.txFilterHigh() == 3300,
-          "clamping a typed low cut leaves the untouched high cut where it was");
+          "rejecting a typed low cut leaves the untouched high cut where it was");
+    check(low->text() == QStringLiteral("50"),
+          "the label is restored to the model value, not the rejected keystrokes");
 
     model.setTxFilter(500, 3300);
     typeAndCommit(high, QStringLiteral("200"));
-    check(model.txFilterHigh() == 550,
-          "a high cut below low is clamped to low + 50, never crossed");
+    check(model.txFilterHigh() == 3300,
+          "a high cut below low is REJECTED, and the previous high stands");
+
+    // Above the model's own ceiling, not just the cross-bound.
+    model.setTxFilter(50, 3300);
+    typeAndCommit(high, QStringLiteral("99999"));
+    check(model.txFilterHigh() == 3300,
+          "a high cut above the model maximum is rejected too");
 
     // ── The stale-label trap ──────────────────────────────────────────────
-    // Typing a value that clamps onto the CURRENT value changes nothing, so
-    // no model signal fires and syncFromModel() would never run on its own.
-    // Without the unconditional re-sync the label keeps showing the rejected
-    // number while the radio is on a different one.
+    // A rejected entry changes nothing, so no model signal fires and
+    // syncFromModel() never runs. The label must already be right — it is,
+    // because the editor is a separate widget laid OVER it and the label's own
+    // text was never touched. That is what makes "restore" free.
     model.setTxFilter(3250, 3300);
     typeAndCommit(low, QStringLiteral("9999"));
     check(model.txFilterLow() == 3250,
-          "clamping onto the current value leaves the model alone");
+          "a rejected entry leaves the model alone");
     check(low->text() == QStringLiteral("3250"),
-          "the label shows the model value, not the rejected keystrokes");
+          "the label still shows the model value after a rejected entry");
 
-    // Out-of-range input must not deadlock Return. QIntValidator calls
-    // 20000 Intermediate, and QLineEdit will not emit on Intermediate input,
-    // so without the clamping fixup() Enter would do nothing at all.
+    // Out-of-range input must not deadlock Return. QIntValidator calls 20000
+    // Intermediate and QLineEdit will not emit returnPressed/editingFinished
+    // on Intermediate input, so with the clamping fixup() gone, Enter is
+    // terminal only because eventFilter handles it explicitly.
     model.setTxFilter(50, 3300);
     typeAndCommit(low, QStringLiteral("20000"));
-    check(!low->isEditing(), "Enter commits an out-of-range value instead of hanging");
-    check(model.txFilterLow() == 3250 && model.txFilterHigh() == 3300,
-          "an out-of-range typed value is clamped, not silently dropped");
+    check(!low->isEditing(), "Enter closes the editor on an out-of-range value");
+    check(model.txFilterLow() == 50 && model.txFilterHigh() == 3300,
+          "an out-of-range typed value is rejected, and nothing moves");
+
+    // ── Enter is terminal for EVERY input (#5064 review) ──────────────────
+    //
+    // The stranding bug: commit hung off editingFinished, which QLineEdit
+    // emits on Return only once the validator reports Acceptable. An empty
+    // field is Intermediate and fixup() could not repair it, so Enter emitted
+    // nothing and the editor stayed open — covering the wheel target
+    // underneath. Reverting the Return branch in eventFilter fails these.
+    model.setTxFilter(200, 3300);
+    if (QLineEdit* ed = openEditor(low)) {
+        ed->clear();
+        check(!ed->hasAcceptableInput(),
+              "an empty field is Intermediate, not Acceptable (the precondition)");
+        QTest::keyClick(ed, Qt::Key_Return);
+    }
+    check(!low->isEditing(), "empty + Enter closes the editor instead of stranding it");
+    check(model.txFilterLow() == 200, "empty + Enter commits nothing");
+
+    // No "the wheel reaches the label again" row here, deliberately. Written
+    // and then deleted: it passed with the fix REVERTED, because a test can
+    // only sendEvent() to the label directly, which bypasses the very overlay
+    // the row claimed to be about. In the app the editor is a child laid over
+    // the label and the window routes the wheel to it; in a harness there is
+    // nothing to route. `!low->isEditing()` above is the real assertion — no
+    // editor, no lid.
+
+    model.setTxFilter(200, 3300);
+    typeAndCommit(low, QStringLiteral("abc"));
+    check(!low->isEditing() && model.txFilterLow() == 200,
+          "unparseable + Enter closes the editor and commits nothing");
+
+    // ── Keyboard reachability (docs/a11y.md, #5064 review) ────────────────
+    //
+    // The feature was mouse-double-click-only, which defeats the
+    // accessibility motivation in the issue itself.
+    check(low->focusPolicy() != Qt::NoFocus && high->focusPolicy() != Qt::NoFocus,
+          "an editable readout is Tab-focusable");
+    check(!low->accessibleDescription().isEmpty(),
+          "the readout describes its editability to an AT");
+
+    model.setTxFilter(200, 3300);
+    if (QLineEdit* ed = openEditorByKey(low, Qt::Key_Return)) {
+        check(low->isEditing(), "Return on the focused readout opens the editor");
+        check(!ed->accessibleName().isEmpty(),
+              "the editor carries an accessible name of its own");
+        ed->setText(QStringLiteral("450"));
+        QTest::keyClick(ed, Qt::Key_Return);
+    } else {
+        check(false, "Return on the focused readout opens the editor");
+    }
+    check(model.txFilterLow() == 450,
+          "a keyboard-only edit reaches the model (open, type, Enter)");
+    // Focus is asserted through the label's own window rather than
+    // hasFocus(): this applet is never shown, so no window is ACTIVE and
+    // hasFocus() is false for every widget in the harness regardless of where
+    // focus actually went. focusWidget() is the part the fix moves.
+    check(low->window()->focusWidget() == low,
+          "focus returns to the readout after a keyboard commit");
+
+    model.setTxFilter(200, 3300);
+    if (openEditorByKey(low, Qt::Key_Space)) {
+        check(low->isEditing(), "Space opens the editor too");
+        QTest::keyClick(low->findChild<QLineEdit*>(), Qt::Key_Escape);
+    } else {
+        check(false, "Space opens the editor too");
+    }
+    check(!low->isEditing() && low->window()->focusWidget() == low,
+          "Escape closes it and leaves focus on the readout");
+
+    // The keyboard route obeys the same lock gate as the double-click (#745).
+    ControlsLock::setLocked(true);
+    openEditorByKey(low, Qt::Key_Return);
+    check(!low->isEditing(), "a locked panel ignores the keyboard route too (#745)");
+    ControlsLock::setLocked(false);
+
+    // ── Validator and parser must agree on one locale (#5064 review) ──────
+    //
+    // QIntValidator validates in ITS locale; QString::toInt() always parses in
+    // the C locale. Under a grouping locale the validator called "3,000"
+    // Acceptable, Return fired, and toInt() then refused it — the edit closed
+    // having done nothing, which is indistinguishable from the radio ignoring
+    // the operator. The validator is now pinned to C with the group separator
+    // rejected, so the two halves accept exactly the same strings.
+    {
+        const QLocale previous = QLocale();
+        QLocale::setDefault(QLocale(QLocale::English, QLocale::UnitedStates));
+        model.setTxFilter(200, 3300);
+        if (QLineEdit* ed = openEditor(low)) {
+            ed->setText(QStringLiteral("3,000"));
+            check(!ed->hasAcceptableInput(),
+                  "a grouped number is rejected by the validator, as toInt() would");
+            QTest::keyClick(ed, Qt::Key_Return);
+        }
+        check(!low->isEditing() && model.txFilterLow() == 200,
+              "a grouped number closes the editor without a silent no-op commit");
+
+        // The same digits without the separator are the value the operator
+        // meant, and they must still work under that locale.
+        typeAndCommit(low, QStringLiteral("3000"));
+        check(model.txFilterLow() == 3000,
+              "plain ASCII digits still commit under a grouping locale");
+        QLocale::setDefault(previous);
+    }
 
     // ── Cancel routes ─────────────────────────────────────────────────────
     //
@@ -235,9 +372,9 @@ int main(int argc, char** argv)
     // Route 1: focus-out with input QIntValidator calls Intermediate.
     // QLineEdit emits editingFinished on focus-out only when the input is
     // ACCEPTABLE, so this emitted nothing and the editor stayed open forever.
-    // An EMPTY field is the case fixup() cannot rescue: 20000 clamps to 10000
-    // and becomes Acceptable, so Qt emits editingFinished for it anyway. Only
-    // an unparseable field actually strands the editor.
+    // The eventFilter's FocusOut branch is what closes it regardless — and
+    // now that the clamping fixup() is gone, EVERY non-Acceptable input takes
+    // this route, not just the empty one.
     model.setTxFilter(200, 3300);
     if (QLineEdit* ed = openEditor(low)) {
         ed->clear();

--- a/tests/phone_tx_filter_numeric_entry_test.cpp
+++ b/tests/phone_tx_filter_numeric_entry_test.cpp
@@ -238,6 +238,8 @@ int main(int argc, char** argv)
           "an editable readout is Tab-focusable");
     check(!low->accessibleDescription().isEmpty(),
           "the readout describes its editability to an AT");
+    check(!low->accessibleDescription().contains(QLatin1String("Space")),
+          "the readout does not advertise Space, which the app reserves for PTT");
 
     // ── The AT contract, not just the names (#5064 re-review) ─────────────
     //
@@ -260,10 +262,13 @@ int main(int argc, char** argv)
               "press is among its actions, not just SetFocus");
         check(names.contains(QAccessibleActionInterface::setFocusAction()),
               "SetFocus is still offered alongside it");
-        check(action
-                  && !action->keyBindingsForAction(
-                             QAccessibleActionInterface::pressAction()).isEmpty(),
-              "the press action announces the keys that also perform it");
+        const QStringList pressKeys = action
+            ? action->keyBindingsForAction(QAccessibleActionInterface::pressAction())
+            : QStringList{};
+        check(pressKeys.contains(QLatin1String("Return")),
+              "the press action announces Return as its activation key");
+        check(!pressKeys.contains(QLatin1String("Space")),
+              "the press action does not announce Space, which the app reserves for PTT");
 
         // The row that actually matters: driving the accessibility API the way
         // an AT does must open the real editor.
@@ -318,14 +323,9 @@ int main(int argc, char** argv)
           "focus returns to the readout after a keyboard commit");
 
     model.setTxFilter(200, 3300);
-    if (openEditorByKey(low, Qt::Key_Space)) {
-        check(low->isEditing(), "Space opens the editor too");
-        QTest::keyClick(low->findChild<QLineEdit*>(), Qt::Key_Escape);
-    } else {
-        check(false, "Space opens the editor too");
-    }
-    check(!low->isEditing() && low->window()->focusWidget() == low,
-          "Escape closes it and leaves focus on the readout");
+    openEditorByKey(low, Qt::Key_Space);
+    check(!low->isEditing(),
+          "Space does not open the editor because the app reserves it for PTT");
 
     // The keyboard route obeys the same lock gate as the double-click (#745).
     ControlsLock::setLocked(true);

--- a/tests/phone_tx_filter_numeric_entry_test.cpp
+++ b/tests/phone_tx_filter_numeric_entry_test.cpp
@@ -90,6 +90,16 @@ int main(int argc, char** argv)
     check(low->isEditable(),  "low cut readout is editable (#3627)");
     check(high->isEditable(), "high cut readout is editable (#3627)");
 
+    // The accepted range comes from the MODEL, never a literal in the widget.
+    // AetherSDR is growing backends (HL2, Icom, FT-991, ColibriNANO, RTL-SDR);
+    // when a radio declares a narrower passband these accessors are the single
+    // seam that has to change, and the editor follows without being touched.
+    check(low->editMinimum() == model.txFilterMinHz()
+          && low->editMaximum() == model.txFilterMaxHz(),
+          "the editor takes its range from the model, not a hardcoded 0..10000");
+    check(model.txFilterMinWidthHz() > 0,
+          "the minimum passband width is model-owned too");
+
     // Without a styler the editor renders as a bare system line edit in the
     // middle of a dark panel. The rule must select QLineEdit — Qt matches
     // stylesheet selectors on widget class, so a QLabel rule styles nothing.

--- a/tests/phone_tx_filter_numeric_entry_test.cpp
+++ b/tests/phone_tx_filter_numeric_entry_test.cpp
@@ -80,13 +80,19 @@ int main(int argc, char** argv)
     check(low->isEditable(),  "low cut readout is editable (#3627)");
     check(high->isEditable(), "high cut readout is editable (#3627)");
 
-    // The themed stylesheet the applet handed over is written for a QLabel;
-    // unless the selector is rewritten the editor renders as a bare system
-    // line edit in the middle of a dark panel.
-    check(low->editorStyleSheet().contains(QLatin1String("QLineEdit")),
-          "the editor inherits the label's theme, not a QLabel selector");
-    check(!low->editorStyleSheet().contains(QLatin1String("QLabel")),
-          "no QLabel selector survives into the editor stylesheet");
+    // Without a styler the editor renders as a bare system line edit in the
+    // middle of a dark panel. The rule must select QLineEdit — Qt matches
+    // stylesheet selectors on widget class, so a QLabel rule styles nothing.
+    check(low->hasEditorStyler() && high->hasEditorStyler(),
+          "both readouts style their editor rather than leaving it unthemed");
+    low->beginEdit();
+    if (QLineEdit* ed = low->findChild<QLineEdit*>()) {
+        check(ed->styleSheet().contains(QLatin1String("QLineEdit")),
+              "the editor is themed with a QLineEdit rule");
+        check(!ed->styleSheet().contains(QLatin1String("{{")),
+              "theme tokens are resolved, not passed through raw");
+        QTest::keyClick(ed, Qt::Key_Escape);
+    }
 
     // ── The feature: an exact value, in one action ────────────────────────
     model.setTxFilter(50, 3300);

--- a/tests/phone_tx_filter_numeric_entry_test.cpp
+++ b/tests/phone_tx_filter_numeric_entry_test.cpp
@@ -1,0 +1,183 @@
+// TX filter direct numeric entry (#3627).
+//
+// The PHONE applet's low/high cut readouts are ScrollableLabels. Before this
+// they could only be stepped in 50 Hz snaps; now they can be typed into.
+// These rows pin the two things that are easy to get wrong: the cross-bound
+// clamp a typed value must obey (the same one the step buttons apply at their
+// call site), and the fact that editing is OFF for every OTHER ScrollableLabel
+// in the app — RIT/XIT, step size, RTTY mark/shift all share this class.
+
+#include "TestSettingsProfile.h"
+#include "core/AppSettings.h"
+#include "gui/GuardedSlider.h"
+#include "gui/PhoneApplet.h"
+#include "models/TransmitModel.h"
+
+#include <QApplication>
+#include <QLineEdit>
+#include <QSignalSpy>
+#include <QCoreApplication>
+#include <QTest>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* label)
+{
+    std::printf("%s %s\n", condition ? "[ OK ]" : "[FAIL]", label);
+    if (!condition)
+        ++failures;
+}
+
+ScrollableLabel* cutLabel(PhoneApplet& applet, const char* accessibleName)
+{
+    for (ScrollableLabel* l : applet.findChildren<ScrollableLabel*>()) {
+        if (l->accessibleName() == QLatin1String(accessibleName))
+            return l;
+    }
+    return nullptr;
+}
+
+// Type into an open editor and commit with Return.
+void typeAndCommit(ScrollableLabel* label, const QString& text)
+{
+    // Drain any editor left pending deleteLater() by a previous edit, so
+    // findChild() below cannot hand back the old one. A running app gets
+    // this for free from the event loop between two operator actions.
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    label->beginEdit();
+    QLineEdit* ed = label->findChild<QLineEdit*>();
+    if (!ed)
+        return;
+    ed->setText(text);
+    QTest::keyClick(ed, Qt::Key_Return);
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile profile(QStringLiteral("phone-tx-filter-numeric-entry-test"));
+    QApplication app(argc, argv);
+    AppSettings::instance().load();
+
+    TransmitModel model;
+    PhoneApplet applet;
+    applet.setTransmitModel(&model);
+
+    ScrollableLabel* low  = cutLabel(applet, "TX low cut frequency");
+    ScrollableLabel* high = cutLabel(applet, "TX high cut frequency");
+    check(low != nullptr,  "low cut readout exists");
+    check(high != nullptr, "high cut readout exists");
+    if (!low || !high)
+        return 1;
+
+    check(low->isEditable(),  "low cut readout is editable (#3627)");
+    check(high->isEditable(), "high cut readout is editable (#3627)");
+
+    // The themed stylesheet the applet handed over is written for a QLabel;
+    // unless the selector is rewritten the editor renders as a bare system
+    // line edit in the middle of a dark panel.
+    check(low->editorStyleSheet().contains(QLatin1String("QLineEdit")),
+          "the editor inherits the label's theme, not a QLabel selector");
+    check(!low->editorStyleSheet().contains(QLatin1String("QLabel")),
+          "no QLabel selector survives into the editor stylesheet");
+
+    // ── The feature: an exact value, in one action ────────────────────────
+    model.setTxFilter(50, 3300);
+    typeAndCommit(low, QStringLiteral("237"));
+    check(model.txFilterLow() == 237,
+          "a typed low cut reaches the model exactly (not snapped to 50 Hz)");
+
+    typeAndCommit(high, QStringLiteral("2843"));
+    check(model.txFilterHigh() == 2843,
+          "a typed high cut reaches the model exactly");
+
+    // The issue's motivating example: 100-2900 in two actions, not dozens.
+    model.setTxFilter(50, 3300);
+    typeAndCommit(low, QStringLiteral("100"));
+    typeAndCommit(high, QStringLiteral("2900"));
+    check(model.txFilterLow() == 100 && model.txFilterHigh() == 2900,
+          "100-2900 Hz is reachable by typing both bounds");
+
+    // ── Cross-bound clamp: same rule the step buttons enforce ─────────────
+    model.setTxFilter(50, 3300);
+    typeAndCommit(low, QStringLiteral("9000"));
+    check(model.txFilterLow() == 3250,
+          "a low cut above high is clamped to high - 50, never crossed");
+    // The reason that clamp lives at the call site: the model would resolve
+    // the same crossed pair by keeping low and dragging high up to 9050.
+    check(model.txFilterHigh() == 3300,
+          "clamping a typed low cut leaves the untouched high cut where it was");
+
+    model.setTxFilter(500, 3300);
+    typeAndCommit(high, QStringLiteral("200"));
+    check(model.txFilterHigh() == 550,
+          "a high cut below low is clamped to low + 50, never crossed");
+
+    // ── The stale-label trap ──────────────────────────────────────────────
+    // Typing a value that clamps onto the CURRENT value changes nothing, so
+    // no model signal fires and syncFromModel() would never run on its own.
+    // Without the unconditional re-sync the label keeps showing the rejected
+    // number while the radio is on a different one.
+    model.setTxFilter(3250, 3300);
+    typeAndCommit(low, QStringLiteral("9999"));
+    check(model.txFilterLow() == 3250,
+          "clamping onto the current value leaves the model alone");
+    check(low->text() == QStringLiteral("3250"),
+          "the label shows the model value, not the rejected keystrokes");
+
+    // Out-of-range input must not deadlock Return. QIntValidator calls
+    // 20000 Intermediate, and QLineEdit will not emit on Intermediate input,
+    // so without the clamping fixup() Enter would do nothing at all.
+    model.setTxFilter(50, 3300);
+    typeAndCommit(low, QStringLiteral("20000"));
+    check(!low->isEditing(), "Enter commits an out-of-range value instead of hanging");
+    check(model.txFilterLow() == 3250 && model.txFilterHigh() == 3300,
+          "an out-of-range typed value is clamped, not silently dropped");
+
+    // ── Cancel routes ─────────────────────────────────────────────────────
+    model.setTxFilter(150, 3300);
+    low->beginEdit();
+    if (QLineEdit* ed = low->findChild<QLineEdit*>()) {
+        ed->setText(QStringLiteral("2000"));
+        QTest::keyClick(ed, Qt::Key_Escape);
+    }
+    check(model.txFilterLow() == 150, "Esc abandons the edit without committing");
+    check(low->text() == QStringLiteral("150"), "Esc leaves the displayed value intact");
+
+    // ── Lock gate: a locked panel is being scrolled, not operated (#745) ──
+    ControlsLock::setLocked(true);
+    QTest::mouseDClick(low, Qt::LeftButton);
+    check(!low->isEditing(), "a locked panel does not open the editor (#745)");
+    ControlsLock::setLocked(false);
+    QTest::mouseDClick(low, Qt::LeftButton);
+    check(low->isEditing(), "unlocking restores double-click-to-type");
+    QTest::keyClick(low->findChild<QLineEdit*>(), Qt::Key_Escape);
+
+    // ── Blast radius: every OTHER ScrollableLabel is untouched ────────────
+    // RIT/XIT (RxApplet), step size (RxApplet) and RTTY mark/shift
+    // (VfoWidget) all use this class and must stay display-only.
+    ScrollableLabel plain(QStringLiteral("+0 Hz"));
+    check(!plain.isEditable(),
+          "a ScrollableLabel is NOT editable by default (RIT/XIT/step/RTTY)");
+    QTest::mouseDClick(&plain, Qt::LeftButton);
+    check(!plain.isEditing(),
+          "double-clicking a default ScrollableLabel does nothing");
+
+    // ── The existing affordance still works ───────────────────────────────
+    model.setTxFilter(200, 3300);
+    QSignalSpy wheelSpy(low, &ScrollableLabel::scrolled);
+    QWheelEvent up(QPointF(5, 5), QPointF(5, 5), QPoint(), QPoint(0, 120),
+                   Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
+    QApplication::sendEvent(low, &up);
+    check(wheelSpy.count() == 1, "making the label editable did not break wheel stepping");
+
+    std::printf("%s\n", failures == 0 ? "ALL PASS" : "FAILURES PRESENT");
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3622,6 +3622,22 @@ add_test(NAME tx_applet_power_reconciliation_test
 set_tests_properties(tx_applet_power_reconciliation_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
+add_executable(phone_tx_filter_numeric_entry_test
+    tests/phone_tx_filter_numeric_entry_test.cpp
+    src/gui/PhoneApplet.cpp
+    src/gui/DragValuePopup.cpp
+    src/gui/GuardedSlider.h      # Q_OBJECT in a header with no .cpp — AUTOMOC
+)
+target_include_directories(phone_tx_filter_numeric_entry_test PRIVATE src)
+target_link_libraries(phone_tx_filter_numeric_entry_test PRIVATE
+    aethercore Qt6::Core Qt6::Widgets Qt6::Test
+)
+set_target_properties(phone_tx_filter_numeric_entry_test PROPERTIES AUTOMOC ON)
+add_test(NAME phone_tx_filter_numeric_entry_test
+         COMMAND phone_tx_filter_numeric_entry_test)
+set_tests_properties(phone_tx_filter_numeric_entry_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 add_executable(phone_cw_mic_gain_authority_test
     tests/phone_cw_mic_gain_authority_test.cpp
     src/gui/PhoneCwApplet.cpp


### PR DESCRIPTION
## Summary

The PHONE applet renders the TX low/high cut as `ScrollableLabel`s, which can be stepped in 50 Hz snaps or scrolled but never typed into. Reaching a specific passband such as 100–2900 Hz means repeated clicking, and matching a value used in SmartSDR means counting steps. Double-clicking either readout now opens an editor over it — Enter commits, Esc or an empty field cancels. The model and protocol layers already accepted arbitrary integer Hz, so nothing below the UI changes.

## Why

- Operators work to specific transmit passbands (100–2900, 200–2800) and currently have to arrive at them one 50 Hz snap at a time.
- The step buttons snap to multiples of 50, so **no existing UI path can request a value like 2843 Hz at all**, even though `TransmitModel` sends whatever integer it is given.
- Accessibility: fine repeated clicking is exactly the interaction that is hardest for some operators.

## Scope

- `src/gui/GuardedSlider.h` — `ScrollableLabel` gains **opt-in** double-click editing, plus a small clamping validator.
- `src/gui/PhoneApplet.cpp` — enables it on the two TX cut readouts and wires the commit.
- `tests/phone_tx_filter_numeric_entry_test.cpp` (new) + `tests/tests.cmake` — 34 assertions.

No protocol, persistence, settings key, or default-behaviour change. Existing step buttons and wheel scrolling are untouched.

### Editing is off by default, and that is the load-bearing part

`ScrollableLabel` is shared with RIT/XIT and the step-size readout (`RxApplet`) and the RTTY mark/shift fields (`VfoWidget`). None of them gain an affordance here — `setEditable()` must be called explicitly, and only the two TX cut labels call it:

```
$ grep -rn "setEditable" src/
src/gui/PhoneApplet.cpp:  m_lowCutLabel->setEditable(0, 10000);
src/gui/PhoneApplet.cpp:  m_highCutLabel->setEditable(0, 10000);
```

Two test rows assert a default-constructed `ScrollableLabel` reports `isEditable() == false` and ignores a double-click, so that stays true rather than being a promise in a commit message.

## Constitution principle honored

**Principle II — The Radio Is Authoritative On Live State.** A typed value is a *request*, not a setting. It is clamped, handed to the existing `TransmitModel` setter, and the readout is repainted from `phoneStateChanged → syncFromModel()` — the label only ever shows what the model accepted, never the keystrokes. Nothing here writes a remembered client value back over radio status, and no new persistence is introduced.

### The clamp asymmetry is deliberate

Low is clamped against high at the call site, exactly as the step buttons do. High is not:

```cpp
// low:   setTxFilterLow(qBound(0, hz, txFilterHigh() - 50));
// high:  setTxFilterHigh(hz);
```

`TransmitModel::setTxFilter()` resolves a crossed pair by keeping the low it was handed and pushing **high** up to `low + 50`. So typing `9000` into low cut would drag a high cut of 3300 up to 9050 — moving a passband edge the operator never touched. Clamping low at the call site keeps their high. The high side needs no such clamp because the model already raises a too-low high to `low + 50`, which is the same answer the step buttons give. Reverting the low clamp fails four test rows; reverting nothing else changes.

*Maintainer call available:* an alternative reading of the acceptance criteria is to **reject** a crossed value outright and restore the previous one. I chose parity with the step buttons — the same input produces the same result whichever control you use — but I will switch it if you prefer rejection.

## Two Qt behaviours measured rather than assumed

1. **`QIntValidator` calls an out-of-range number `Intermediate`, not `Invalid`** — measured on Qt 6.10, `validate("20000")` against a 0–10000 range returns `Intermediate`. `QLineEdit` accepts Intermediate keystrokes but refuses to emit `returnPressed`/`editingFinished` on them. Without a fix the operator types `20000`, presses Enter, and *nothing whatsoever happens*. Qt calls `fixup()` on Return precisely for this, so the validator clamps there and a dead keypress becomes the nearest legal value.

2. **That `fixup()` deliberately does not chain to `QIntValidator::fixup()`**, which inserts locale group separators:

   ```
   QIntValidator::fixup("20000") -> "20,000"
   ```

   `toInt()` then refuses it, silently dropping the very commit the fixup existed to rescue. This cost me a debugging cycle — the editor closed, and the value never reached the model.

The editor is themed by a styler callback the applet supplies, which writes a `QLineEdit` rule through `ThemeManager::applyStyleSheet` — Qt matches stylesheet selectors on widget class, so the label's own `QLabel { ... }` rule would style nothing and you would get a white system box on a dark panel.

**A note for the next person who trips the colour ratchet:** `tools/audit_colours.py` counts `setStyleSheet(` call sites outside its allowlist, and my first attempt added one (`setstylesheet 1097 > 1096`). Going through `ThemeManager` fixes that properly — the call lives in the allow-listed `ThemeManager.cpp` and the editor gets tokens instead of a frozen string. Worth knowing: **the audit is a regex over file text, so a code _comment_ containing `setStyleSheet(` also counts.** Verified locally against a `git archive` of the PR base — `unique_colours`, `total_references` and `setstylesheet` all `+0`.

## Test plan

- [x] `phone_tx_filter_numeric_entry_test` — **34/34 pass** (Nobara 43, Qt 6.10.3, gcc 16.1.1, cmake 3.31.11; project floor is Qt 6.8).
- [x] **Gates verified by injection, not just by being green:**
  - remove the low-cut call-site clamp → 4 rows fail (the clamp row, the "high stays where it was" row, and both stale-value rows).
  - an earlier draft carried an unconditional `syncFromModel()` after each commit with a comment claiming it prevented a stale label. Injection showed **the test passed without it** — the editor is an overlay, so keystrokes never touch the label's own text and it cannot go stale that way. The code and the comment were removed rather than shipped as a self-contradicting rationale.
- [x] Clean incremental `ninja -C build AetherSDR` on Linux.
- [x] **Live read-back against a real FLEX-6700** (firmware 4.2.20.41343) over the automation bridge: connected, `transmit.txFilterLow = 100`, `txFilterHigh = 2900`, and both `ScrollableLabel`s render exactly those values — the widgets this PR makes editable are the ones genuinely bound to radio state. Read-only; no radio state was written.
- [ ] Hands-on double-click check on the GUI — see the bridge gap below.

The PHONE applet on the live 6700 renders Low Cut `100` / High Cut `2900` — screenshot available on request (grabbed via the bridge, `grab PHNE`).

## Bounds come from the model, never a literal

`TransmitModel` publishes `txFilterMinHz()` / `txFilterMaxHz()` / `txFilterMinWidthHz()`, and every clamp here goes through them — the step buttons, the typed-entry commit, and the editor's validator range. Accessors rather than bare constants deliberately: the range in the model today is the FlexRadio one (`FlexBackend` clamps to it on the wire, which is the right layer), and with HL2 / Icom / FT-991 / ColibriNANO / RTL-SDR backends in flight it should become radio-dependent. When it does, no call site here has to move. A test row asserts the editor's accepted range **equals** the model's, so a future per-radio limit cannot silently fail to reach the UI.

Filed **#5067** for the other half — teaching `RadioCapabilities` to carry TX passband limits the way it already carries `rxFilterWidthsHz` for RX. This PR does not depend on it.

## Fixes found by hands-on testing

The bridge cannot drive this affordance (see below), so it was exercised by hand on a Linux desktop, which found three defects the unit tests had not:

- **Esc did nothing.** The window carries `QShortcut(Qt::Key_Escape, window())` (CwxPanel, DvkPanel). Qt offers a ShortcutOverride before firing a shortcut and, when nothing accepts it, the shortcut wins and the focused widget never receives a KeyPress — so a `keyPressEvent` handler could not run. The editor now answers ShortcutOverride, the same way `VfoWidget::eventFilter` claims Esc for its own direct-entry.
- **A stranded editor ate the mouse wheel.** The editor covers the label exactly, so one left on screen is a lid over the control. `QLineEdit` emits `editingFinished` on focus-out only for Acceptable input; the clamping fixup rescues most values but not an EMPTY field, so clearing it and clicking away stranded the editor. Focus-out now always ends the edit.
- **The wheel is dead while editing.** Rolling now steps the value with a field open, and the field re-seeds from the model.

Each is pinned by a row that fails when the fix is reverted.

## Automation-bridge gap (now filed as #5068)

The bridge cannot drive this feature, so the affordance itself is covered by unit test rather than by a live bridge assertion:

- there is **no double-click verb** — `invoke` supports `trigger`/`click`/`toggle`/`setChecked`/`setValue`/`wheel`/`setText`/`submit`/`setCurrentText`/`setCurrentIndex`/`selectRow`, and nothing opens a double-click-gated editor;
- `txFilterLow`/`txFilterHigh` are **readable** in the transmit state dump but there is **no setter verb**, so a bridge-driven A/B on the filter is not possible either.

Filed as **#5068**, with the VFO DIG offset inline editor as the other control it hides.

## Checklist

- [x] Commits are signed (docs/COMMIT-SIGNING.md)
- [x] No new flat-key AppSettings calls (Principle V) — no settings surface touched
- [x] All meter UI uses MeterSmoother (Principle II) — no meter UI in this change

## Notes

RIT/XIT and the RTTY mark/shift readouts are the obvious next candidates for the same affordance, since they now only need a `setEditable()` call. Deliberately out of scope here.

Closes #3627

---

73, Ozy **K6OZY**  · cost: $33.04 · model: claude-opus-5
