### PR TITLE
fix(tci): move start; before ready; and echo start/stop (#5007)

### DIFF
--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -500,20 +500,25 @@ QString TciProtocol::generateInitBurst()
     burst += QStringLiteral("tx_stream_audio_buffering:50;");
     burst += QStringLiteral("iq_samplerate:48000;");
 
+    // START is a bidirectional device-state notification and belongs in the
+    // state dump, not after it: WSJT-X's TCITransceiver gates its
+    // frequency/PTT path on a "SDR switched on" flag fed only by START, and
+    // evaluates that flag at READY time. Emitting START after READY (as
+    // before) leaves the flag false when WSJT-X checks it (#5007). Real
+    // ExpertSDR3 emits START as part of the dump, before READY closes it.
+    // This does not disturb the argument-less audio_start/iq_start
+    // avoidance from #3913 (stream lifecycle commands are still never
+    // emitted here) or the READY-after-iq_samplerate ordering SDC/CW
+    // Skimmer need (#3498/#3502) — only START's position relative to READY
+    // changes.
+    burst += QStringLiteral("start;");
+
     // READY terminates the settings dump — it must follow EVERY setting
-    // (in particular iq_samplerate), because SDC / CW Skimmer reads its
-    // cached settings the moment READY arrives.  Matches real
+    // (in particular iq_samplerate and start), because SDC / CW Skimmer
+    // reads its cached settings the moment READY arrives.  Matches real
     // ExpertSDR3 behavior and the spec's READY definition ("sent after
     // the initialization commands").  Reported by Yuri UT4LW.
     burst += QStringLiteral("ready;");
-
-    // START is a bidirectional device-state notification. Stream lifecycle
-    // commands are client-owned: AUDIO_START and IQ_START require a receiver
-    // argument and are sent by the client after READY. Emitting the old
-    // argument-less audio_start primer here wedged SDC before it processed
-    // START, so its TCI connection never became active and it never requested
-    // the IQ stream used by the CW skimmer (#3913 test-build finding).
-    burst += QStringLiteral("start;");
 
     return burst;
 }
@@ -662,13 +667,13 @@ std::optional<TciProtocol::TrxRequest> TciProtocol::takeTrxRequest()
 QString TciProtocol::cmdStart()
 {
     m_started = true;
-    return {};
+    return QStringLiteral("start;");
 }
 
 QString TciProtocol::cmdStop()
 {
     m_started = false;
-    return {};
+    return QStringLiteral("stop;");
 }
 
 // ── VFO: get/set frequency ─────────────────────────────────────────────────

--- a/tests/tci_protocol_test.cpp
+++ b/tests/tci_protocol_test.cpp
@@ -1157,10 +1157,10 @@ int main(int argc, char** argv)
     const int startIndex = greeting.indexOf(QStringLiteral("start"));
     const int channelsIndex = greeting.indexOf(QStringLiteral("channels_count:2"));
     if (readyIndex < 0 || iqRateIndex < 0 || startIndex < 0 || channelsIndex < 0
-        || iqRateIndex >= readyIndex || readyIndex >= startIndex) {
+        || iqRateIndex >= readyIndex || startIndex >= readyIndex) {
         std::fprintf(stderr,
             "TCI greeting must advertise two channels and order "
-            "iq_samplerate before ready before start\n");
+            "iq_samplerate before start before ready (#5007)\n");
         return 1;
     }
 
@@ -1172,6 +1172,20 @@ int main(int argc, char** argv)
                          command.toUtf8().constData());
             return 1;
         }
+    }
+
+    // A client-issued START/STOP is a bidirectional device-state
+    // notification and must be confirmed, not answered with silence (#5007):
+    // WSJT-X's TCITransceiver blocks on the echo.
+    if (protocol.handleCommand(QStringLiteral("start"))
+            != QStringLiteral("start;")) {
+        std::fprintf(stderr, "start; must be echoed back to the client\n");
+        return 1;
+    }
+    if (protocol.handleCommand(QStringLiteral("stop"))
+            != QStringLiteral("stop;")) {
+        std::fprintf(stderr, "stop; must be echoed back to the client\n");
+        return 1;
     }
 
     if (!testRoutingPolicy() || !testStaleRouteFailsSafe()


### PR DESCRIPTION
## Summary

Fixes #5007. WSJT-X's TCITransceiver gates its "SDR switched on" flag
on the TCI `start;` message and evaluates that flag at `ready;` time.
AetherSDR emitted `start;` *after* `ready;` in the init burst, so the
flag was still false when WSJT-X checked it — `TCI SDR is not switched
on`, even though the connection and all other radio state (CAT, audio)
were working correctly. Real ExpertSDR3 emits START as part of the
state dump, before READY closes it.

`cmdStart()`/`cmdStop()` also returned an empty reply instead of
echoing `start;`/`stop;`, so a client-issued START/STOP (part of
WSJT-X's own init handshake) got silence instead of confirmation — the
second half of the same gate.

**Changes**, both in `src/core/TciProtocol.cpp`:
- `generateInitBurst()`: emit `start;` before `ready;` instead of after.
- `cmdStart()`/`cmdStop()`: return `"start;"`/`"stop;"` so a
  client-issued command is confirmed.

`tests/tci_protocol_test.cpp`: flipped the greeting ordering assertion
(start must now precede ready, not follow it) and added coverage that
`handleCommand("start"/"stop")` echoes back rather than returning empty.

Root cause was originally diagnosed in the issue thread by
@aethersdr-agent; this PR implements that diagnosis, scoped to the
confirmed cause.

**Deliberately left out of this PR**, per the issue's own root-cause
analysis: adding `tx_profiles_ex` (the field is genuinely absent from
the burst, but the analysis concludes it is not why WSJT-X fails, and
there's no spec'd default-profile format to test against), and wiring
the existing `m_started` flag into TX/PTT gating (a separate
architectural decision, not needed to fix "not switched on").

## Constitution principle honored

Principle VIII — Evidence Over Assertion. The fix claim isn't resting
on the diagnosis alone: verified against a live FLEX-6700 (fw
4.2.20.41343) with WSJT-X 3.0.0 Improved connecting over TCI on a
separate machine, reporting the SDR as switched on, and successfully
logging an FT8 QSO — the exact failure scenario reported in the issue
thread (by both the original reporter on Windows and a second
confirmation on macOS/Intel) no longer reproduces.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio (FLEX-6700) — WSJT-X TCI
      connect + FT8 QSO logged
- [x] `tci_protocol_test` passes, including new start/stop echo
      assertions
- [x] Reproduction steps from the issue no longer reproduce

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room — reordering/return-value change only, no
      external code referenced
- [x] No meter UI touched
- [x] No user-visible behavior change requiring `docs/` updates beyond
      what this PR describes