### PR TITLE
fix(midi): profile store — dotted names round-trip, and a name is a name, not a path (#4974, #4975)

### DIFF
--- a/src/core/MidiSettings.cpp
+++ b/src/core/MidiSettings.cpp
@@ -615,17 +615,23 @@ void MidiSettings::writeBindingsToXml(const QString& filePath,
 bool MidiSettings::isValidProfileName(const QString& name)
 {
     // Separators are tested directly rather than via an allowlist so
-    // non-ASCII station and contest names keep working. "." and ".." are the
-    // two names that are pure path syntax. Rejecting (not stripping) is
-    // deliberate: stripping "../foo" to "foo" would silently overwrite an
-    // unrelated existing profile. (#4975)
+    // non-ASCII station and contest names keep working. A leading dot is
+    // filesystem semantics too: on Unix it is the hidden-file convention, so
+    // the QDir::Files listing omits an accepted ".hidden.xml" — saved, but
+    // vanished from availableProfiles() — and refusing it also covers "."
+    // and "..", the two names that are pure path syntax. Rejecting (not
+    // stripping) is deliberate: stripping "../foo" to "foo" would silently
+    // overwrite an unrelated existing profile. (#4975)
     const QString trimmed = name.trimmed();
-    if (trimmed.isEmpty())
+    if (trimmed.isEmpty()) {
         return false;
-    if (trimmed == QLatin1String(".") || trimmed == QLatin1String(".."))
+    }
+    if (trimmed.startsWith(QLatin1Char('.'))) {
         return false;
-    if (trimmed.contains(QLatin1Char('/')) || trimmed.contains(QLatin1Char('\\')))
+    }
+    if (trimmed.contains(QLatin1Char('/')) || trimmed.contains(QLatin1Char('\\'))) {
         return false;
+    }
     return true;
 }
 
@@ -643,8 +649,9 @@ QStringList MidiSettings::availableProfiles() const
         // file whose name the store now refuses (e.g. a backslash, legal in
         // Unix filenames and creatable by the pre-guard GUI) would otherwise
         // list but never load or delete. The file itself stays on disk.
-        if (isValidProfileName(name))
+        if (isValidProfileName(name)) {
             result.append(name);
+        }
     }
     return result;
 }
@@ -652,15 +659,17 @@ QStringList MidiSettings::availableProfiles() const
 void MidiSettings::saveProfile(const QString& name,
                                 const QVector<MidiBinding>& bindings)
 {
-    if (!isValidProfileName(name))
+    if (!isValidProfileName(name)) {
         return;
+    }
     writeBindingsToXml(profileDir() + "/" + name + ".xml", bindings);
 }
 
 QVector<MidiBinding> MidiSettings::loadProfile(const QString& name) const
 {
-    if (!isValidProfileName(name))
+    if (!isValidProfileName(name)) {
         return {};
+    }
     return parseBindingsFromXml(profileDir() + "/" + name + ".xml");
 }
 
@@ -668,8 +677,9 @@ void MidiSettings::deleteProfile(const QString& name)
 {
     // The guard matters most here: a mis-resolved delete is the one
     // unrecoverable operation of the three. (#4975)
-    if (!isValidProfileName(name))
+    if (!isValidProfileName(name)) {
         return;
+    }
     QFile::remove(profileDir() + "/" + name + ".xml");
 }
 
@@ -769,8 +779,9 @@ MidiImportResult MidiSettings::importProfile(
     // Not just isEmpty(): a file named "...map" derives ".." here, which the
     // store rightly refuses — without this fallback the refusal surfaces as a
     // misleading "couldn't write" error instead of a stored profile.
-    if (!isValidProfileName(name))
+    if (!isValidProfileName(name)) {
         name = QStringLiteral("Imported profile");
+    }
     const QStringList existing = availableProfiles();
     const auto taken = [&existing](const QString& candidate) {
         for (const auto& p : existing)

--- a/src/core/MidiSettings.cpp
+++ b/src/core/MidiSettings.cpp
@@ -612,28 +612,57 @@ void MidiSettings::writeBindingsToXml(const QString& filePath,
 
 // ── Profiles ────────────────────────────────────────────────────────────────
 
+bool MidiSettings::isValidProfileName(const QString& name)
+{
+    // Separators are tested directly rather than via an allowlist so
+    // non-ASCII station and contest names keep working. "." and ".." are the
+    // two names that are pure path syntax. Rejecting (not stripping) is
+    // deliberate: stripping "../foo" to "foo" would silently overwrite an
+    // unrelated existing profile. (#4975)
+    const QString trimmed = name.trimmed();
+    if (trimmed.isEmpty())
+        return false;
+    if (trimmed == QLatin1String(".") || trimmed == QLatin1String(".."))
+        return false;
+    if (trimmed.contains(QLatin1Char('/')) || trimmed.contains(QLatin1Char('\\')))
+        return false;
+    return true;
+}
+
 QStringList MidiSettings::availableProfiles() const
 {
     QDir dir(profileDir());
     QStringList result;
     for (const auto& fi : dir.entryInfoList({"*.xml"}, QDir::Files))
-        result.append(fi.baseName());
+        // completeBaseName(), not baseName(): the writers below append exactly
+        // one ".xml", so the reader must strip exactly one extension —
+        // baseName() cuts at the FIRST dot, so a dotted name ("CTR2 v1.0")
+        // listed truncated and could then never be loaded. (#4974)
+        result.append(fi.completeBaseName());
     return result;
 }
 
 void MidiSettings::saveProfile(const QString& name,
                                 const QVector<MidiBinding>& bindings)
 {
+    if (!isValidProfileName(name))
+        return;
     writeBindingsToXml(profileDir() + "/" + name + ".xml", bindings);
 }
 
 QVector<MidiBinding> MidiSettings::loadProfile(const QString& name) const
 {
+    if (!isValidProfileName(name))
+        return {};
     return parseBindingsFromXml(profileDir() + "/" + name + ".xml");
 }
 
 void MidiSettings::deleteProfile(const QString& name)
 {
+    // The guard matters most here: a mis-resolved delete is the one
+    // unrecoverable operation of the three. (#4975)
+    if (!isValidProfileName(name))
+        return;
     QFile::remove(profileDir() + "/" + name + ".xml");
 }
 
@@ -721,18 +750,15 @@ MidiImportResult MidiSettings::importProfile(
 
     // Store name = file base name; never overwrite an existing profile. The
     // prompt-vs-suffix collision policy is an open maintainer call, and a
-    // suffix is the reversible default. Dots are replaced because the store
-    // round-trips names through QFileInfo::baseName(), which cuts at the
-    // first dot — a dotted name would list, load, and collide wrongly.
+    // suffix is the reversible default. Dotted names round-trip through the
+    // store now that it lists via completeBaseName() (#4974), so the old
+    // dots-to-underscores substitution is gone.
     //
     // completeBaseName() operates on fileName(), so any directory component of
-    // the chosen path is already stripped: "../../evil.map" yields "evil". That
-    // is what keeps this call site safe, because saveProfile() — and its load
-    // and delete siblings — concatenate the name straight into profileDir()
-    // with no sanitizing. Do not swap this for a name taken from the document
-    // body or from filePath without stripping separators first.
+    // the chosen path is already stripped: "../../evil.map" yields "evil" —
+    // and the store rejects separator-bearing names itself (#4975), so a name
+    // taken from anywhere else is guarded too.
     QString name = QFileInfo(filePath).completeBaseName().trimmed();
-    name.replace(QLatin1Char('.'), QLatin1Char('_'));
     if (name.isEmpty())
         name = QStringLiteral("Imported profile");
     const QStringList existing = availableProfiles();

--- a/src/core/MidiSettings.cpp
+++ b/src/core/MidiSettings.cpp
@@ -633,12 +633,19 @@ QStringList MidiSettings::availableProfiles() const
 {
     QDir dir(profileDir());
     QStringList result;
-    for (const auto& fi : dir.entryInfoList({"*.xml"}, QDir::Files))
+    for (const auto& fi : dir.entryInfoList({"*.xml"}, QDir::Files)) {
         // completeBaseName(), not baseName(): the writers below append exactly
         // one ".xml", so the reader must strip exactly one extension —
         // baseName() cuts at the FIRST dot, so a dotted name ("CTR2 v1.0")
         // listed truncated and could then never be loaded. (#4974)
-        result.append(fi.completeBaseName());
+        const QString name = fi.completeBaseName();
+        // List only names the other three operations will serve: a legacy
+        // file whose name the store now refuses (e.g. a backslash, legal in
+        // Unix filenames and creatable by the pre-guard GUI) would otherwise
+        // list but never load or delete. The file itself stays on disk.
+        if (isValidProfileName(name))
+            result.append(name);
+    }
     return result;
 }
 
@@ -759,7 +766,10 @@ MidiImportResult MidiSettings::importProfile(
     // and the store rejects separator-bearing names itself (#4975), so a name
     // taken from anywhere else is guarded too.
     QString name = QFileInfo(filePath).completeBaseName().trimmed();
-    if (name.isEmpty())
+    // Not just isEmpty(): a file named "...map" derives ".." here, which the
+    // store rightly refuses — without this fallback the refusal surfaces as a
+    // misleading "couldn't write" error instead of a stored profile.
+    if (!isValidProfileName(name))
         name = QStringLiteral("Imported profile");
     const QStringList existing = availableProfiles();
     const auto taken = [&existing](const QString& candidate) {

--- a/src/core/MidiSettings.h
+++ b/src/core/MidiSettings.h
@@ -61,8 +61,9 @@ public:
 
     // A profile name is a name, not a path: the store concatenates it into
     // profileDir(), so all three operations above refuse a name this predicate
-    // rejects (separators, "." / "..", empty). Public so the GUI can validate
-    // against the same rule it will be held to.
+    // rejects (separators, a leading dot — hidden-file semantics that would
+    // drop the file from the listing — and empty). Public so the GUI can
+    // validate against the same rule it will be held to.
     static bool isValidProfileName(const QString& name);
 
     // Import a profile file into the store. Accepts the native <MidiProfile>

--- a/src/core/MidiSettings.h
+++ b/src/core/MidiSettings.h
@@ -59,6 +59,12 @@ public:
     QVector<MidiBinding> loadProfile(const QString& name) const;
     void deleteProfile(const QString& name);
 
+    // A profile name is a name, not a path: the store concatenates it into
+    // profileDir(), so all three operations above refuse a name this predicate
+    // rejects (separators, "." / "..", empty). Public so the GUI can validate
+    // against the same rule it will be held to.
+    static bool isValidProfileName(const QString& name);
+
     // Import a profile file into the store. Accepts the native <MidiProfile>
     // XML or a SmartSDR iOS/Mac ".map" (auto-detected by content). The store
     // name derives from the file name; an existing name gets a " (2)" style

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -311,7 +311,7 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
                 FramelessMessageBox::warning(
                     this, QStringLiteral("Save Profile"),
                     QStringLiteral("\"%1\" isn't a valid profile name — a name "
-                                   "can't contain / or \\ or be \".\" or \"..\".")
+                                   "can't contain / or \\ or start with \".\".")
                         .arg(name));
                 return;
             }

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -305,6 +305,15 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
         connect(saveProfileBtn, &QPushButton::clicked, this, [this] {
             QString name = m_profileCombo->currentText().trimmed();
             if (name.isEmpty()) return;
+            if (!MidiSettings::isValidProfileName(name)) {
+                // The store refuses these names silently; say why here so the
+                // operator isn't left with a Save that does nothing. (#4975)
+                FramelessMessageBox::warning(
+                    this, QStringLiteral("Save Profile"),
+                    QStringLiteral("\"%1\" isn't a valid profile name — a name "
+                                   "can't contain / or \\.").arg(name));
+                return;
+            }
             MidiSettings::instance().saveProfile(name, m_manager->bindings());
             refreshProfileList();
         });

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -311,7 +311,8 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
                 FramelessMessageBox::warning(
                     this, QStringLiteral("Save Profile"),
                     QStringLiteral("\"%1\" isn't a valid profile name — a name "
-                                   "can't contain / or \\.").arg(name));
+                                   "can't contain / or \\ or be \".\" or \"..\".")
+                        .arg(name));
                 return;
             }
             MidiSettings::instance().saveProfile(name, m_manager->bindings());

--- a/tests/midi_settings_test.cpp
+++ b/tests/midi_settings_test.cpp
@@ -715,6 +715,37 @@ int main(int argc, char** argv)
                  "profile store: delete with ../ removes nothing outside the store");
     QFile::remove(appConfigDir + "/planted.xml");
 
+    // A legacy file whose name the guard refuses (backslash is a legal Unix
+    // filename character, and the pre-guard GUI could create it) must not
+    // list: the list may only hand out names load/delete will serve. The
+    // file itself stays on disk.
+#ifndef Q_OS_WIN
+    {
+        QFile legacy(appConfigDir + "/midi/back\\slash.xml");
+        QDir().mkpath(appConfigDir + "/midi");
+        if (legacy.open(QIODevice::WriteOnly | QIODevice::Text)) {
+            legacy.write("<MidiProfile version=\"1\">"
+                         "<Binding param=\"rx.afGain\" channel=\"0\" type=\"0\""
+                         " number=\"7\" inverted=\"False\"/></MidiProfile>\n");
+            legacy.close();
+        }
+    }
+    ok &= expect(!settings.availableProfiles().contains("back\\slash"),
+                 "profile store: a legacy separator-named file does not list");
+    ok &= expect(QFile::exists(appConfigDir + "/midi/back\\slash.xml"),
+                 "profile store: the unlisted legacy file stays on disk");
+    QFile::remove(appConfigDir + "/midi/back\\slash.xml");
+#endif
+
+    // An import whose file name derives a refused store name ("...map" ->
+    // "..") falls back to the default name instead of surfacing a
+    // misleading write error.
+    const auto rDotsName = settings.importProfile(
+        writeImportFile("...map", mapContent), validator);
+    ok &= expect(rDotsName.ok()
+                     && rDotsName.profileName.startsWith("Imported profile"),
+                 "import: a refused derived name falls back to the default");
+
     QFile::remove(configRoot + "/AetherSDR/midi.settings");
     QDir(configRoot + "/AetherSDR").removeRecursively();
 

--- a/tests/midi_settings_test.cpp
+++ b/tests/midi_settings_test.cpp
@@ -155,7 +155,7 @@ int main(int argc, char** argv)
     const auto r1 = settings.importProfile(mapPath, validator);
     ok &= expect(r1.ok(), "map import succeeds");
     ok &= expect(r1.importedCount == 6, "map import count (freq, cwspeed, paddles, nr, ptt)");
-    ok &= expect(r1.profileName == "CTR2-Test_v1_0", "map import names profile from file name");
+    ok &= expect(r1.profileName == "CTR2-Test_v1.0", "map import names profile from file name");
     ok &= expect(r1.skippedUnknownParam.contains("bwset")
                      && r1.skippedUnknownParam.contains("openft8"),
                  "unknown map functions are skipped by name");
@@ -177,7 +177,7 @@ int main(int argc, char** argv)
     }
 
     const auto r2 = settings.importProfile(mapPath, validator);
-    ok &= expect(r2.ok() && r2.profileName == "CTR2-Test_v1_0 (2)",
+    ok &= expect(r2.ok() && r2.profileName == "CTR2-Test_v1.0 (2)",
                  "a name collision gets a suffix, never an overwrite");
 
     // Sections we never bind from carry the vendor's own key dialect. Judging
@@ -262,11 +262,11 @@ int main(int argc, char** argv)
     {
         // Native XML round trip: the profile the map import just stored.
         const auto r4 = settings.importProfile(
-            configRoot + "/AetherSDR/midi/CTR2-Test_v1_0.xml", validator);
+            configRoot + "/AetherSDR/midi/CTR2-Test_v1.0.xml", validator);
         ok &= expect(r4.ok() && r4.importedCount == 6, "native XML profile re-imports");
-        ok &= expect(r4.profileName == "CTR2-Test_v1_0 (3)", "XML re-import takes the next suffix");
+        ok &= expect(r4.profileName == "CTR2-Test_v1.0 (3)", "XML re-import takes the next suffix");
         const auto again = settings.loadProfile(r4.profileName);
-        const auto first = settings.loadProfile("CTR2-Test_v1_0");
+        const auto first = settings.loadProfile("CTR2-Test_v1.0");
         bool same = again.size() == first.size();
         for (int i = 0; same && i < again.size(); ++i)
             same = sameBinding(again[i], first[i]);
@@ -419,14 +419,14 @@ int main(int argc, char** argv)
 
     // Export → Import round trip through the user-facing export path.
     const auto exported = settings.exportProfile(
-        fakeHome.path() + "/exported.xml", settings.loadProfile("CTR2-Test_v1_0"));
+        fakeHome.path() + "/exported.xml", settings.loadProfile("CTR2-Test_v1.0"));
     ok &= expect(exported.ok() && exported.exportedCount == 6,
                  "export writes the current profile");
     const auto r8 = settings.importProfile(fakeHome.path() + "/exported.xml", validator);
     ok &= expect(r8.ok() && r8.importedCount == 6, "exported file re-imports cleanly");
     const auto exportFail = settings.exportProfile(
         fakeHome.path() + "/no-such-dir/out.xml",
-        settings.loadProfile("CTR2-Test_v1_0"));
+        settings.loadProfile("CTR2-Test_v1.0"));
     ok &= expect(!exportFail.ok(), "export to an unwritable path reports an error");
 
     // An empty set must not report success: it serializes to a childless
@@ -661,6 +661,59 @@ int main(int argc, char** argv)
     ok &= expect(rPitch.skippedBadType.size() == 1
                      && rPitch.skippedBadType.first().contains("number"),
                  "XML: the out-of-range Pitch Bend row is named");
+
+    // ── Profile store: dotted names list + round-trip (#4974) ───────────────
+
+    settings.saveProfile("CTR2 v1.0", saved);
+    ok &= expect(settings.availableProfiles().contains("CTR2 v1.0"),
+                 "profile store: dotted name lists untruncated");
+    ok &= expect(settings.loadProfile("CTR2 v1.0").size() == saved.size(),
+                 "profile store: dotted name loads what was saved");
+    settings.deleteProfile("CTR2 v1.0");
+    ok &= expect(!settings.availableProfiles().contains("CTR2 v1.0"),
+                 "profile store: dotted name deletes its own file");
+
+    // ── Profile store: names are names, not paths (#4975) ───────────────────
+
+    ok &= expect(MidiSettings::isValidProfileName("CTR2 v1.0"),
+                 "name guard: ordinary dotted name accepted");
+    ok &= expect(MidiSettings::isValidProfileName("Tenerife contest ÉÑ"),
+                 "name guard: non-ASCII name accepted");
+    ok &= expect(!MidiSettings::isValidProfileName("a/b"),
+                 "name guard: forward separator rejected");
+    ok &= expect(!MidiSettings::isValidProfileName("a\\b"),
+                 "name guard: backslash separator rejected");
+    ok &= expect(!MidiSettings::isValidProfileName("."),
+                 "name guard: '.' rejected");
+    ok &= expect(!MidiSettings::isValidProfileName(".."),
+                 "name guard: '..' rejected");
+    ok &= expect(!MidiSettings::isValidProfileName("   "),
+                 "name guard: whitespace-only rejected");
+
+    // The guards hold at the filesystem, not only in the predicate.
+    const QString appConfigDir = configRoot + "/AetherSDR";
+    settings.saveProfile("../escape", saved);
+    ok &= expect(!QFile::exists(appConfigDir + "/escape.xml"),
+                 "profile store: save with ../ writes nothing outside the store");
+    settings.saveProfile("a/b", saved);
+    ok &= expect(!QDir(appConfigDir + "/midi/a").exists(),
+                 "profile store: save with a separator creates no directory chain");
+
+    {
+        QFile planted(appConfigDir + "/planted.xml");
+        if (planted.open(QIODevice::WriteOnly | QIODevice::Text)) {
+            planted.write("<MidiProfile version=\"1\">"
+                          "<Binding param=\"rx.afGain\" channel=\"0\" type=\"0\""
+                          " number=\"7\" inverted=\"False\"/></MidiProfile>\n");
+            planted.close();
+        }
+    }
+    ok &= expect(settings.loadProfile("../planted").isEmpty(),
+                 "profile store: load with ../ reads nothing outside the store");
+    settings.deleteProfile("../planted");
+    ok &= expect(QFile::exists(appConfigDir + "/planted.xml"),
+                 "profile store: delete with ../ removes nothing outside the store");
+    QFile::remove(appConfigDir + "/planted.xml");
 
     QFile::remove(configRoot + "/AetherSDR/midi.settings");
     QDir(configRoot + "/AetherSDR").removeRecursively();

--- a/tests/midi_settings_test.cpp
+++ b/tests/midi_settings_test.cpp
@@ -687,6 +687,8 @@ int main(int argc, char** argv)
                  "name guard: '.' rejected");
     ok &= expect(!MidiSettings::isValidProfileName(".."),
                  "name guard: '..' rejected");
+    ok &= expect(!MidiSettings::isValidProfileName(".hidden"),
+                 "name guard: leading-dot (hidden-file) name rejected");
     ok &= expect(!MidiSettings::isValidProfileName("   "),
                  "name guard: whitespace-only rejected");
 
@@ -698,6 +700,15 @@ int main(int argc, char** argv)
     settings.saveProfile("a/b", saved);
     ok &= expect(!QDir(appConfigDir + "/midi/a").exists(),
                  "profile store: save with a separator creates no directory chain");
+    // A leading dot is the Unix hidden-file convention: the listing's
+    // QDir::Files scan omits ".hidden.xml", so an accepted save would
+    // succeed and then vanish from availableProfiles() (#5083 review).
+    // The guard refuses the name before a file exists to hide.
+    settings.saveProfile(".hidden", saved);
+    ok &= expect(!QFile::exists(appConfigDir + "/midi/.hidden.xml"),
+                 "profile store: leading-dot name writes no hidden file");
+    ok &= expect(settings.loadProfile(".hidden").isEmpty(),
+                 "profile store: leading-dot name loads nothing");
 
     {
         QFile planted(appConfigDir + "/planted.xml");


### PR DESCRIPTION
## Summary

Fixes #4974. Fixes #4975.

Two defects in the same four functions of the MIDI profile store
(`src/core/MidiSettings.cpp`):

- **#4974** — `availableProfiles()` listed via `QFileInfo::baseName()`, which
  cuts at the *first* dot, while save/load/delete round-trip the full name. A
  profile saved as `CTR2 v1.0` listed as `CTR2 v1`, and loading that entry
  resolved a path that does not exist — silently, because a missing-profile
  load no-ops. The fix is the one-word change the issue and triage both named:
  `completeBaseName()`, which strips exactly the one `.xml` the writers append.
- **#4975** — all three of `saveProfile`/`loadProfile`/`deleteProfile`
  concatenated the operator-typed name straight into `profileDir()`. A name
  containing a separator resolved outside the store: a write created the
  traversed directory chain, and a delete — the unrecoverable one — could
  remove a file elsewhere. The fix is one predicate, `isValidProfileName()`
  (rejects separators, `.`/`..`, empty), guarding all three operations inside
  the store so the property holds for every present and future producer by
  construction.

Rejecting rather than stripping is deliberate, per the triage's hazard note:
stripping `../foo` to `foo` would silently overwrite an unrelated existing
profile. The dialog validates against the same public predicate and says why
a name was refused, so Save never silently does nothing.

This also retires #4898's dots-to-underscores import workaround (its comment
documented both defects and this exact retirement path), so imported profiles
now keep their dotted names: `CTR2-Test_v1.0.map` stores as `CTR2-Test_v1.0`,
not `CTR2-Test_v1_0`.

**User-visible migration note** (flagged in #4974; release-note line is the
maintainer's call): a dotted profile already on disk listed truncated before
and lists under its full name after — the full name is the one that loads, so
this is a repair, not a rename. One more consequence, found in a pre-ready
adversarial pass and fixed in the second commit: a legacy profile file whose
name the store now refuses (e.g. a backslash in the filename, creatable by
the pre-guard GUI on Mac/Linux) no longer lists — previously it listed and
loaded. The file stays on disk untouched.

## Constitution principle honored

Principle VII — untrusted input is validated at the boundary: the
operator-typed profile name is guarded once, inside the store where the path
is built, rather than at whichever call site a future feature happens to use.

## Changes

- `src/core/MidiSettings.h` — declare `static bool isValidProfileName()`
  (public, so the GUI validates against the rule it is held to).
- `src/core/MidiSettings.cpp` — the predicate; guards in
  `saveProfile`/`loadProfile`/`deleteProfile`; `baseName()` →
  `completeBaseName()` in `availableProfiles()`; the importer's
  dot-substitution removed and its comment updated.
- `src/gui/MidiMappingDialog.cpp` — Save rejects an invalid name with a
  message (same `FramelessMessageBox` shape the adjacent Load failure uses).
- `tests/midi_settings_test.cpp` — 17 new checks (14 in the first commit, 3
  in the revision): dotted-name list/load/delete round-trip, the predicate's
  accept/reject table (non-ASCII accepted), filesystem-level proofs that
  `../` names write, read, and delete nothing outside the store, a legacy
  separator-named file neither listing nor being touched, and a refused
  derived import name falling back to the default. Six existing assertions
  that pinned the import workaround's underscored names now pin the fixed
  dotted names.

## Test plan

- [x] Local build passes (`cmake --build build`) — clean wipe-and-reconfigure
  build on macOS off `main` @ `5a499ef6`
- [x] Behavior verified on a real radio if applicable — **n/a: client-side
  profile storage; no radio involvement**
- [x] Existing tests pass (CI) — `midi_settings_test` **95/95** locally;
  full suite 301/308, the 7 failures all pre-existing on unmodified trees
  (the known HL2 cluster incl. #5000's `hl2_state_restore_test`, plus
  `vkamp_connection_test`, reproduced failing on a build without this
  change)
- [x] Reproduction steps documented if user-reported bug — in #4974/#4975
  (self-reported, source-cited)

Mutation checks, both directions: reverting `completeBaseName()` →
`baseName()` fails 3 checks (the dotted-name cases plus two pre-existing
collision tests that depend on correct listing); forcing the predicate to
accept everything fails 9 (the accept/reject table and all four
filesystem-level traversal proofs). Restored: green.

Sanitizer pass: `midi_settings_test` rebuilt under AddressSanitizer
(`Debug` config, `ASAN_OPTIONS=detect_leaks=1:detect_stack_use_after_return=1`)
— 95/95, zero reports.

A fresh-context local adversarial review ran before the ready flip; its
three findings (a legacy separator-named file listing but refusing to load,
a misleading import error for a refused derived name, and incomplete
rejection-message wording — all within the two issues' scope) are fixed in
the second commit with tests where testable.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — **n/a: no settings surface
  touched**
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered
- [x] All meter UI uses `MeterSmoother` — **n/a: no meter UI touched**
- [x] Documentation updated if user-visible behavior changed — **n/a: no
  docs/README describes profile naming; the migration note above covers the
  visible change**
- [x] Security-sensitive changes reference a GHSA — **n/a: robustness fix on
  operator-local input, not a security boundary (per #4975's own framing)**

— authored by agent (Claude Code) on behalf of @skerker
