### PR TITLE
fix(audio): reach PortAudio's default-device path for a default sidetone selection (#4978)

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -4150,7 +4150,7 @@ bool AudioEngine::startSidetoneStream()
         }
         explicitSelection = (dev.id() == m_outputDevice.id());
         if (!explicitSelection) {
-            qCWarning(lcAudio) << "AudioEngine: saved sidetone output device is unavailable, using the system default output instead";
+            qCWarning(lcAudio) << "AudioEngine: saved sidetone output device is unavailable, using the backend's default output instead";
         }
     }
 

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -2,6 +2,7 @@
 #include "AppSettings.h"
 #include "AudioSummaryLogger.h"
 #include "AudioDeviceNegotiator.h"
+#include "CwSidetoneStartPolicy.h"
 #include "TxCaptureBuffer.h"
 #include "ShutdownTrace.h"
 #include "ClientEq.h"
@@ -4148,7 +4149,8 @@ bool AudioEngine::startSidetoneStream()
             // handles follow the selected endpoint after hotplug/default churn.
             if (d.id() == m_outputDevice.id()) { dev = d; break; }
         }
-        explicitSelection = (dev.id() == m_outputDevice.id());
+        explicitSelection = isExplicitSidetoneSelection(
+            /*savedDeviceSet*/ true, /*savedDeviceEnumerable*/ dev.id() == m_outputDevice.id());
         if (!explicitSelection) {
             qCWarning(lcAudio) << "AudioEngine: saved sidetone output device is unavailable, using the backend's default output instead";
         }
@@ -4159,14 +4161,21 @@ bool AudioEngine::startSidetoneStream()
     // backend a null device so it resolves its own default output instead of
     // name-matching Qt's description against PortAudio's device names — on
     // Linux those come from different audio APIs (PulseAudio/PipeWire vs ALSA)
-    // and never coincide, which stranded every default-configured box on the
-    // QAudioSink fallback (#4978). The QAudioSink attempts keep the concrete
-    // device: that backend resolves a null itself but flags it as a fallback,
-    // which a deliberate default selection is not.
+    // and cannot coincide for analog/USB descriptions, which stranded boxes
+    // with no saved output selection on the QAudioSink fallback (#4978); a
+    // saved-but-unmatchable selection still falls back, pending the
+    // escape-hatch setting. The QAudioSink attempts keep the concrete device:
+    // that backend resolves a null itself but flags it as a fallback, which a
+    // deliberate default selection is not. The decision table lives in
+    // CwSidetoneStartPolicy.h, where it is pinned by
+    // tests/cw_sidetone_start_policy_test.cpp.
     const bool sidetoneOnPortAudio =
         qstrcmp(m_sidetoneSink->name(), "PortAudio") == 0;
     const QAudioDevice startDev =
-        (sidetoneOnPortAudio && !explicitSelection) ? QAudioDevice() : dev;
+        sidetoneStartDevice(explicitSelection, sidetoneOnPortAudio)
+                == SidetoneStartDevice::BackendDefault
+            ? QAudioDevice()
+            : dev;
     bool sidetoneFallbackOccurred = false;
     QStringList sidetoneFallbackReasons;
     QStringList sidetoneAttempts;

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -4172,9 +4172,7 @@ bool AudioEngine::startSidetoneStream()
     QStringList sidetoneAttempts;
     const QString portAudioAttempt = QStringLiteral("PortAudio 48000Hz 2ch Float, native-rate fallback if needed");
     const QString qAudioSinkAttempt = QStringLiteral("QAudioSink 48000Hz/44100Hz/24000Hz 2ch Float, then Int16");
-    sidetoneAttempts << (qstrcmp(m_sidetoneSink->name(), "PortAudio") == 0
-        ? portAudioAttempt
-        : qAudioSinkAttempt);
+    sidetoneAttempts << (sidetoneOnPortAudio ? portAudioAttempt : qAudioSinkAttempt);
     if (!m_sidetoneSink->start(startDev, 48000, m_cwSidetone.get())) {
         // Backend failed — try the other one before giving up.  Most likely
         // path: PortAudio init failed on a quirky device, fall back to Qt.

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -4140,6 +4140,7 @@ bool AudioEngine::startSidetoneStream()
     if (!m_cwSidetone) return false;
 
     QAudioDevice dev = QMediaDevices::defaultAudioOutput();
+    bool explicitSelection = false;
     if (!m_outputDevice.isNull()) {
         const auto outputs = QMediaDevices::audioOutputs();
         for (const auto& d : outputs) {
@@ -4147,12 +4148,25 @@ bool AudioEngine::startSidetoneStream()
             // handles follow the selected endpoint after hotplug/default churn.
             if (d.id() == m_outputDevice.id()) { dev = d; break; }
         }
-        if (dev.id() != m_outputDevice.id()) {
+        explicitSelection = (dev.id() == m_outputDevice.id());
+        if (!explicitSelection) {
             qCWarning(lcAudio) << "AudioEngine: saved sidetone output device is unavailable, using the system default output instead";
         }
     }
 
     m_sidetoneSink = makeSidetoneBackend(this);
+    // When the effective selection is the system default, hand the PortAudio
+    // backend a null device so it resolves its own default output instead of
+    // name-matching Qt's description against PortAudio's device names — on
+    // Linux those come from different audio APIs (PulseAudio/PipeWire vs ALSA)
+    // and never coincide, which stranded every default-configured box on the
+    // QAudioSink fallback (#4978). The QAudioSink attempts keep the concrete
+    // device: that backend resolves a null itself but flags it as a fallback,
+    // which a deliberate default selection is not.
+    const bool sidetoneOnPortAudio =
+        qstrcmp(m_sidetoneSink->name(), "PortAudio") == 0;
+    const QAudioDevice startDev =
+        (sidetoneOnPortAudio && !explicitSelection) ? QAudioDevice() : dev;
     bool sidetoneFallbackOccurred = false;
     QStringList sidetoneFallbackReasons;
     QStringList sidetoneAttempts;
@@ -4161,12 +4175,12 @@ bool AudioEngine::startSidetoneStream()
     sidetoneAttempts << (qstrcmp(m_sidetoneSink->name(), "PortAudio") == 0
         ? portAudioAttempt
         : qAudioSinkAttempt);
-    if (!m_sidetoneSink->start(dev, 48000, m_cwSidetone.get())) {
+    if (!m_sidetoneSink->start(startDev, 48000, m_cwSidetone.get())) {
         // Backend failed — try the other one before giving up.  Most likely
         // path: PortAudio init failed on a quirky device, fall back to Qt.
 #ifdef HAVE_PORTAUDIO
-        if (qstrcmp(m_sidetoneSink->name(), "PortAudio") == 0) {
-            qCWarning(lcAudio) << "AudioEngine: PortAudio sidetone failed, falling back to QAudioSink";
+        if (sidetoneOnPortAudio) {
+            qCWarning(lcAudio) << "AudioEngine: PortAudio sidetone failed, falling back to QAudioSink — sidetone will run on the push-model timing path";
             sidetoneFallbackOccurred = true;
             sidetoneFallbackReasons << QStringLiteral("PortAudio failed -> QAudioSink");
             m_sidetoneSink.reset(new CwSidetoneQAudioSink(this));
@@ -4215,6 +4229,12 @@ bool AudioEngine::startSidetoneStream()
     summary.backend = QString::fromLatin1(m_sidetoneSink->name());
     summary.deviceDescription = m_sidetoneSink->deviceDescription();
     summary.sampleRate = m_sidetoneSink->actualRateHz();
+    // Name the timing consequence, not just the backend: pull = the audio
+    // system drains the generator on demand (PortAudio callback), push = the
+    // 2 ms-timer block writer QAudioSink uses (#4890's timing-race host).
+    summary.timingPath = qstrcmp(m_sidetoneSink->name(), "PortAudio") == 0
+        ? QStringLiteral("pull")
+        : QStringLiteral("push");
     summary.fallbackOccurred = sidetoneFallbackOccurred;
     summary.fallbackReason = sidetoneFallbackReasons.join(QStringLiteral("; "));
     AudioSummaryLogger::logCwSidetone(summary);

--- a/src/core/AudioSummaryLogger.cpp
+++ b/src/core/AudioSummaryLogger.cpp
@@ -179,10 +179,11 @@ QString formatCwSidetone(const CwSidetoneSummary& summary)
 {
     QStringList lines;
     lines << QStringLiteral("Audio CW sidetone summary:")
-          << QStringLiteral("  backend=\"%1\" %2 rate=%3Hz")
+          << QStringLiteral("  backend=\"%1\" %2 rate=%3Hz path=%4")
                  .arg(valueOrUnknown(summary.backend),
                       field(QStringLiteral("device"), summary.deviceDescription))
                  .arg(summary.sampleRate)
+                 .arg(valueOrUnknown(summary.timingPath))
           << QStringLiteral("  %1").arg(fallbackText(summary.fallbackOccurred,
                                                      summary.fallbackReason));
     return lines.join(QLatin1Char('\n'));

--- a/src/core/AudioSummaryLogger.h
+++ b/src/core/AudioSummaryLogger.h
@@ -31,6 +31,7 @@ struct CwSidetoneSummary {
     QString backend;
     QString deviceDescription;
     int sampleRate{0};
+    QString timingPath;  // "pull" (PortAudio callback) or "push" (QAudioSink timer)
     bool fallbackOccurred{false};
     QString fallbackReason;
 };

--- a/src/core/CwSidetonePortAudioSink.cpp
+++ b/src/core/CwSidetonePortAudioSink.cpp
@@ -60,8 +60,26 @@ PaDeviceIndex findPortAudioOutputDevice(const QAudioDevice& device)
         }
     }
 
-    if (partials.isEmpty())
+    if (partials.isEmpty()) {
+        // Name every output-capable candidate so field reports show what was
+        // available to match, not just that nothing did (#4978). Failure-path
+        // only — the second enumeration costs nothing on a successful match.
+        QStringList candidates;
+        for (PaDeviceIndex i = 0; i < count; ++i) {
+            const PaDeviceInfo* info = Pa_GetDeviceInfo(i);
+            if (!info || info->maxOutputChannels <= 0 || !info->name)
+                continue;
+            const PaHostApiInfo* api = Pa_GetHostApiInfo(info->hostApi);
+            candidates << QStringLiteral("\"%1\" [%2]")
+                              .arg(QString::fromUtf8(info->name),
+                                   api && api->name ? QString::fromUtf8(api->name)
+                                                    : QStringLiteral("?"));
+        }
+        qCWarning(lcAudio) << "CwSidetonePortAudioSink: no PortAudio output matches"
+                           << device.description()
+                           << "- candidates:" << qUtf8Printable(candidates.join(QStringLiteral(", ")));
         return paNoDevice;
+    }
 
     if (partials.size() == 1) {
         qCWarning(lcAudio) << "CwSidetonePortAudioSink: selected Qt output device"
@@ -91,9 +109,13 @@ PaDeviceIndex findPortAudioOutputDevice(const QAudioDevice& device)
     }
 #endif
 
+    QStringList matchedNames;
+    for (const Candidate& c : partials)
+        matchedNames << QStringLiteral("\"%1\"").arg(c.rawName);
     qCWarning(lcAudio) << "CwSidetonePortAudioSink: selected Qt output device"
                        << device.description()
-                       << "matched multiple PortAudio outputs";
+                       << "matched multiple PortAudio outputs:"
+                       << qUtf8Printable(matchedNames.join(QStringLiteral(", ")));
     return paNoDevice;
 }
 

--- a/src/core/CwSidetonePortAudioSink.cpp
+++ b/src/core/CwSidetonePortAudioSink.cpp
@@ -71,8 +71,8 @@ PaDeviceIndex findPortAudioOutputDevice(const QAudioDevice& device)
                 continue;
             const PaHostApiInfo* api = Pa_GetHostApiInfo(info->hostApi);
             candidates << QStringLiteral("\"%1\" [%2]")
-                              .arg(QString::fromLocal8Bit(info->name),
-                                   api && api->name ? QString::fromLocal8Bit(api->name)
+                              .arg(QString::fromUtf8(info->name),
+                                   api && api->name ? QString::fromUtf8(api->name)
                                                     : QStringLiteral("?"));
         }
         qCWarning(lcAudio) << "CwSidetonePortAudioSink: no PortAudio output matches"
@@ -133,19 +133,17 @@ PaDeviceIndex defaultPortAudioOutputDevice()
     // Pa_GetDefaultOutputDevice() on Windows typically returns an MME device
     // (the first enumerated host API), which has 50–150 ms OS-level buffering.
     // Prefer WASAPI shared mode (~10 ms) to reduce CW timing jitter on fast
-    // keying. Mirrors the Linux JACK preference above. (#3193)
-    if (devIdx == paNoDevice) {
-        const PaHostApiIndex apiCount = Pa_GetHostApiCount();
-        for (PaHostApiIndex i = 0; i < apiCount; ++i) {
-            const PaHostApiInfo* api = Pa_GetHostApiInfo(i);
-            if (!api || !api->name) continue;
-            if (qstrncmp(api->name, "Windows WASAPI", 14) == 0
-                && api->defaultOutputDevice != paNoDevice) {
-                devIdx = api->defaultOutputDevice;
-                qCInfo(lcAudio) << "CwSidetonePortAudioSink: using WASAPI host API"
-                                << "(device" << devIdx << ")";
-                break;
-            }
+    // keying. (#3193)
+    const PaHostApiIndex apiCount = Pa_GetHostApiCount();
+    for (PaHostApiIndex i = 0; i < apiCount; ++i) {
+        const PaHostApiInfo* api = Pa_GetHostApiInfo(i);
+        if (!api || !api->name) continue;
+        if (qstrncmp(api->name, "Windows WASAPI", 14) == 0
+            && api->defaultOutputDevice != paNoDevice) {
+            devIdx = api->defaultOutputDevice;
+            qCInfo(lcAudio) << "CwSidetonePortAudioSink: using WASAPI host API"
+                            << "(device" << devIdx << ")";
+            break;
         }
     }
 #endif

--- a/src/core/CwSidetonePortAudioSink.cpp
+++ b/src/core/CwSidetonePortAudioSink.cpp
@@ -71,8 +71,8 @@ PaDeviceIndex findPortAudioOutputDevice(const QAudioDevice& device)
                 continue;
             const PaHostApiInfo* api = Pa_GetHostApiInfo(info->hostApi);
             candidates << QStringLiteral("\"%1\" [%2]")
-                              .arg(QString::fromUtf8(info->name),
-                                   api && api->name ? QString::fromUtf8(api->name)
+                              .arg(QString::fromLocal8Bit(info->name),
+                                   api && api->name ? QString::fromLocal8Bit(api->name)
                                                     : QStringLiteral("?"));
         }
         qCWarning(lcAudio) << "CwSidetonePortAudioSink: no PortAudio output matches"
@@ -121,23 +121,14 @@ PaDeviceIndex findPortAudioOutputDevice(const QAudioDevice& device)
 
 PaDeviceIndex defaultPortAudioOutputDevice()
 {
+    // No JACK preference here: a default selection must land on the same
+    // output the rest of the app's audio uses (Pa_GetDefaultOutputDevice —
+    // the ALSA `default` route on Linux, which follows the system mixer).
+    // Preferring a reachable JACK server's device would silently split the
+    // sidetone from RX audio; routing INTO a JACK graph should be an
+    // explicit selection (see #4978's escape-hatch follow-up), not a
+    // side effect of leaving the device unset.
     PaDeviceIndex devIdx = paNoDevice;
-#ifdef Q_OS_LINUX
-    {
-        const PaHostApiIndex apiCount = Pa_GetHostApiCount();
-        for (PaHostApiIndex i = 0; i < apiCount; ++i) {
-            const PaHostApiInfo* api = Pa_GetHostApiInfo(i);
-            if (!api || !api->name) continue;
-            if (qstrncmp(api->name, "JACK", 4) == 0
-                && api->defaultOutputDevice != paNoDevice) {
-                devIdx = api->defaultOutputDevice;
-                qCInfo(lcAudio) << "CwSidetonePortAudioSink: using JACK host API"
-                                << "(device" << devIdx << ")";
-                break;
-            }
-        }
-    }
-#endif
 #ifdef Q_OS_WIN
     // Pa_GetDefaultOutputDevice() on Windows typically returns an MME device
     // (the first enumerated host API), which has 50–150 ms OS-level buffering.
@@ -239,18 +230,6 @@ bool CwSidetonePortAudioSink::start(const QAudioDevice& device,
                            << "to PortAudio output" << devInfo->name;
     }
     m_deviceDescription = QString::fromLocal8Bit(devInfo->name ? devInfo->name : "");
-
-    // Detect JACK-host-API selection from defaultPortAudioOutputDevice() so the
-    // summary logger sees it as a backend-substituted fallback. (The selection
-    // itself happens inside the namespace-scope helper, which can't touch
-    // member state directly.)
-    if (device.isNull()) {
-        const PaHostApiInfo* api = Pa_GetHostApiInfo(devInfo->hostApi);
-        if (api && api->name && qstrncmp(api->name, "JACK", 4) == 0) {
-            m_fallbackOccurred = true;
-            m_fallbackReason = QStringLiteral("backend selected JACK default output");
-        }
-    }
 
     // Prefer 48 kHz; fall back to the device's native rate only if the
     // device explicitly rejects 48 kHz.

--- a/src/core/CwSidetoneStartPolicy.h
+++ b/src/core/CwSidetoneStartPolicy.h
@@ -1,0 +1,96 @@
+#pragma once
+
+// CwSidetoneStartPolicy — which device does the CW sidetone backend get handed
+// at start()? (#4978)
+//
+// AudioEngine::startSidetoneStream() resolves a QAudioDevice for the sidetone
+// the same way the RX sink does: the saved AudioOutputDeviceId if it is still
+// enumerable, otherwise Qt's current default output. Before #4978 that
+// resolved device was handed to the backend unconditionally. For the PortAudio
+// backend that meant every start went through a cross-API NAME match (Qt's
+// device description against PortAudio's device names). On Linux those come
+// from different audio APIs — PulseAudio/PipeWire descriptions such as
+// "Built-in Audio Analog Stereo" versus ALSA names such as
+// "HDA Intel PCH: ALC257 Analog (hw:1,0)", "pulse", "default" — so the match
+// cannot succeed for analog/USB device descriptions and a box with no saved
+// selection silently landed on the QAudioSink push path. The PortAudio
+// backend's own default-device branch (device.isNull()) existed all along but
+// was unreachable, because no caller ever passed it a null device.
+//
+// The two backends give a null device OPPOSITE meanings, which is why this is a
+// policy and not a one-liner at the call site:
+//
+//   PortAudio   null  = "resolve your own default output"
+//                       (Pa_GetDefaultOutputDevice — the same notion of
+//                       default the rest of the system mixer uses). Not a
+//                       fallback; the intended path for a default selection.
+//   QAudioSink  null  = "requested output unavailable -> system default",
+//                       flagged fallbackOccurred=true in the summary. Handing
+//                       it a null for a deliberate default selection would
+//                       log a fallback that did not happen.
+//
+// So: a PortAudio backend gets a null device exactly when the selection is not
+// explicit; a QAudioSink backend always gets the resolved device.
+//
+// ── What "explicit" means, and the limit it documents ───────────────────────
+//
+// A selection is explicit when a device id is SAVED and that id is still
+// ENUMERABLE. It is explicit EVEN IF the saved device happens to be the system
+// default: the user picked it from the Radio Setup output combo, and the
+// escape-hatch follow-up in #4978 (not this file) is where an explicit
+// selection that fails the name match gets a second chance. A box whose saved
+// device is the system default therefore still takes the name-match path on
+// Linux and still falls back to QAudioSink — that is the documented reach of
+// the #4978 fix, pinned here so a later edit cannot widen or narrow it by
+// accident. #4978 stays open for that case.
+//
+// Pure and header-only, with no Qt types, so every case is a compile-time
+// assertion and a unit-test row (tests/cw_sidetone_start_policy_test.cpp) —
+// the #3306 pattern (policy as a pure function over injected facts, platform
+// as data) applied to device SELECTION rather than format negotiation. The
+// decision itself is platform-independent: the operating system enters only
+// through whether a PortAudio backend was constructed at all (HAVE_PORTAUDIO
+// is pkg-config-gated, so Windows builds never construct one and always take
+// the `Resolved` row). Mirrors QsoRecordStartPolicy / DaxTxPolicy.
+
+namespace AetherSDR {
+
+enum class SidetoneStartDevice {
+    // Hand the backend the resolved QAudioDevice (saved device, or Qt's
+    // default). Always the answer for QAudioSink; the answer for PortAudio
+    // only when the selection is explicit.
+    Resolved,
+    // Hand the backend a null QAudioDevice so it resolves its own default
+    // output. PortAudio only, non-explicit selection only.
+    BackendDefault,
+};
+
+// `savedDeviceSet`         AudioEngine::m_outputDevice is non-null — an
+//                          AudioOutputDeviceId is saved.
+// `savedDeviceEnumerable`  that id was found in QMediaDevices::audioOutputs()
+//                          at start time. False when the device is gone; in
+//                          practice startRxStream() has already nulled a
+//                          missing saved device before the sidetone starts, so
+//                          this arrives as savedDeviceSet=false on the normal
+//                          path — the row is kept for the Q_INVOKABLE entry
+//                          point and for a hotplug between the two
+//                          enumerations.
+constexpr bool isExplicitSidetoneSelection(bool savedDeviceSet,
+                                           bool savedDeviceEnumerable)
+{
+    return savedDeviceSet && savedDeviceEnumerable;
+}
+
+// `explicitSelection`   isExplicitSidetoneSelection(...) above.
+// `backendIsPortAudio`  the constructed sink reports name() == "PortAudio"
+//                       (false when HAVE_PORTAUDIO is off, or when the user
+//                       opted out with CwSidetoneBackend=QAudioSink).
+constexpr SidetoneStartDevice sidetoneStartDevice(bool explicitSelection,
+                                                  bool backendIsPortAudio)
+{
+    if (backendIsPortAudio && !explicitSelection)
+        return SidetoneStartDevice::BackendDefault;
+    return SidetoneStartDevice::Resolved;
+}
+
+} // namespace AetherSDR

--- a/tests/cw_sidetone_start_policy_test.cpp
+++ b/tests/cw_sidetone_start_policy_test.cpp
@@ -1,0 +1,134 @@
+// Unit test for CwSidetoneStartPolicy (#4978).
+//
+// The CW sidetone is the path a CW operator hears on every element, so the
+// decision of which device the backend is handed at start() is pinned here in
+// full. The defect this policy fixes was a three-way boolean hidden inline in a
+// ~100-line member function: a default selection was always name-matched
+// against PortAudio's device list, which on Linux cannot succeed for
+// analog/USB descriptions, so every box with no saved output device silently
+// ran its sidetone on the QAudioSink push path.
+//
+// Two rows are load-bearing and are asserted at compile time:
+//
+//   * no saved device + PortAudio backend  -> BackendDefault   (the fix)
+//   * saved device that IS the system default + PortAudio -> Resolved
+//     (the documented LIMIT of the fix — the reporting box in #4978 has a
+//      saved device and is not reached; #4978 stays open for the
+//      escape-hatch follow-up. A refactor that "helpfully" widens this row
+//      would change the PR's stated reach.)
+//
+// Pure policy, so no Qt, no audio backend, no device enumeration — and
+// constexpr, so the whole table is also checked at compile time.
+
+#include "core/CwSidetoneStartPolicy.h"
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+static int g_checks = 0;
+
+#define EXPECT_START_DEVICE(explicitSel, portAudio, expected, why) do { \
+    ++g_checks; \
+    const SidetoneStartDevice got_ = sidetoneStartDevice((explicitSel), (portAudio)); \
+    if (got_ != (expected)) { \
+        std::fprintf(stderr, "FAIL %s:%d  sidetoneStartDevice(explicit=%d, " \
+                             "portAudio=%d) = %d, expected %d — %s\n", \
+                     __FILE__, __LINE__, int(explicitSel), int(portAudio), \
+                     int(got_), int(expected), (why)); \
+        ++g_failures; \
+    } else { \
+        std::printf("[ OK ] %s\n", (why)); \
+    } \
+} while (0)
+
+#define EXPECT_EXPLICIT(saved, enumerable, expected, why) do { \
+    ++g_checks; \
+    const bool got_ = isExplicitSidetoneSelection((saved), (enumerable)); \
+    if (got_ != (expected)) { \
+        std::fprintf(stderr, "FAIL %s:%d  isExplicitSidetoneSelection(saved=%d, " \
+                             "enumerable=%d) = %d, expected %d — %s\n", \
+                     __FILE__, __LINE__, int(saved), int(enumerable), \
+                     int(got_), int(expected), (why)); \
+        ++g_failures; \
+    } else { \
+        std::printf("[ OK ] %s\n", (why)); \
+    } \
+} while (0)
+
+// ── Compile-time proof of both truth tables ─────────────────────────────────
+// A regression that makes any of these false is a build error, not a weekly
+// sweep failure.
+
+//                                    explicit  portAudio
+static_assert(sidetoneStartDevice(false, true)  == SidetoneStartDevice::BackendDefault,
+              "default selection on PortAudio must resolve the backend's own default (#4978)");
+static_assert(sidetoneStartDevice(true,  true)  == SidetoneStartDevice::Resolved,
+              "explicit selection on PortAudio keeps the resolved device (name match, then QAudioSink fallback)");
+static_assert(sidetoneStartDevice(false, false) == SidetoneStartDevice::Resolved,
+              "QAudioSink must never be handed a null for a deliberate default selection (it logs it as a fallback)");
+static_assert(sidetoneStartDevice(true,  false) == SidetoneStartDevice::Resolved,
+              "explicit selection on QAudioSink keeps the resolved device");
+
+//                                          saved  enumerable
+static_assert(isExplicitSidetoneSelection(false, false) == false, "nothing saved is not explicit");
+static_assert(isExplicitSidetoneSelection(false, true)  == false, "nothing saved is not explicit even if something enumerates");
+static_assert(isExplicitSidetoneSelection(true,  false) == false, "a saved device that is gone is not explicit");
+static_assert(isExplicitSidetoneSelection(true,  true)  == true,  "a saved, present device is explicit — even when it is the system default");
+
+int main()
+{
+    // ── sidetoneStartDevice: the four combinations, named by scenario ───────
+    EXPECT_START_DEVICE(false, true, SidetoneStartDevice::BackendDefault,
+        "Linux/macOS, nothing saved, PortAudio -> backend resolves its own default (the #4978 fix)");
+    EXPECT_START_DEVICE(true, true, SidetoneStartDevice::Resolved,
+        "Linux/macOS, saved+present device, PortAudio -> resolved device, name-matched (explicit path unchanged)");
+    EXPECT_START_DEVICE(false, false, SidetoneStartDevice::Resolved,
+        "Windows (no PortAudio) or CwSidetoneBackend=QAudioSink, nothing saved -> resolved device, not null");
+    EXPECT_START_DEVICE(true, false, SidetoneStartDevice::Resolved,
+        "Windows (no PortAudio) or CwSidetoneBackend=QAudioSink, saved device -> resolved device");
+
+    // ── isExplicitSidetoneSelection: what counts as explicit ───────────────
+    EXPECT_EXPLICIT(false, false, false,
+        "no AudioOutputDeviceId saved -> not explicit");
+    EXPECT_EXPLICIT(true, true, true,
+        "saved id still enumerable -> explicit");
+    EXPECT_EXPLICIT(true, false, false,
+        "saved id no longer enumerable (hotplug window / Q_INVOKABLE entry) -> not explicit");
+
+    // ── The documented limit, end to end ────────────────────────────────────
+    // The #4978 reporting box has AudioOutputDeviceId saved and present. It is
+    // explicit, so on PortAudio it takes the name-match path exactly as before
+    // this fix. This row exists so that reach is a stated fact, not a surprise.
+    {
+        ++g_checks;
+        const bool explicitSel = isExplicitSidetoneSelection(/*saved*/ true, /*enumerable*/ true);
+        const SidetoneStartDevice got = sidetoneStartDevice(explicitSel, /*portAudio*/ true);
+        if (got != SidetoneStartDevice::Resolved) {
+            std::fprintf(stderr, "FAIL %s:%d  a saved device that is the system default must still "
+                                 "take the explicit (name-match) path — the #4978 fix does not reach it\n",
+                         __FILE__, __LINE__);
+            ++g_failures;
+        } else {
+            std::printf("[ OK ] saved device that IS the system default -> explicit -> Resolved (documented limit; #4978 stays open)\n");
+        }
+    }
+
+    // ── The fix, end to end ─────────────────────────────────────────────────
+    {
+        ++g_checks;
+        const bool explicitSel = isExplicitSidetoneSelection(/*saved*/ false, /*enumerable*/ false);
+        const SidetoneStartDevice got = sidetoneStartDevice(explicitSel, /*portAudio*/ true);
+        if (got != SidetoneStartDevice::BackendDefault) {
+            std::fprintf(stderr, "FAIL %s:%d  nothing saved on PortAudio must hand the backend a null device\n",
+                         __FILE__, __LINE__);
+            ++g_failures;
+        } else {
+            std::printf("[ OK ] nothing saved -> not explicit -> BackendDefault (PortAudio resolves Pa_GetDefaultOutputDevice)\n");
+        }
+    }
+
+    std::printf("%d/%d checks passed\n", g_checks - g_failures, g_checks);
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -2410,6 +2410,16 @@ target_include_directories(cw_sidetone_test PRIVATE src)
 target_link_libraries(cw_sidetone_test PRIVATE Qt6::Core)
 add_test(NAME cw_sidetone_test COMMAND cw_sidetone_test)
 
+# #4978 — which device the CW sidetone backend is handed at start(). Pure,
+# header-only policy, so the whole truth table is a compile-time assertion; the
+# "saved device that IS the system default still takes the name-match path" row
+# pins the documented reach of the fix.
+add_executable(cw_sidetone_start_policy_test
+    tests/cw_sidetone_start_policy_test.cpp
+)
+target_include_directories(cw_sidetone_start_policy_test PRIVATE src)
+add_test(NAME cw_sidetone_start_policy_test COMMAND cw_sidetone_start_policy_test)
+
 add_executable(cwx_local_keyer_drift_test
     tests/cwx_local_keyer_drift_test.cpp
     src/core/CwxLocalKeyer.cpp


### PR DESCRIPTION
Refs #4978 — the default-selection half; the saved-device case (including the reporting box) stays open there, see *Reach* below.

## Root cause

Two facts, both from the issue thread (diagnosed by @aethersdr-agent, then measured on the reporting box):

1. `CwSidetonePortAudioSink::start()` has a `device.isNull()` branch that resolves PortAudio's **own** default output (`defaultPortAudioOutputDevice()`, with the Linux JACK preference) — but its only caller, `AudioEngine::startSidetoneStream()`, always resolved a concrete `QAudioDevice` first, so that branch was effectively unreachable (only a system with zero audio outputs could pass a null device). Every real-world start went through the name match.
2. The name match compares Qt's device *description* against PortAudio's device *names*. On Linux those are disjoint vocabularies — Qt's PulseAudio/PipeWire backend reports `"Built-in Audio Analog Stereo"` while distro PortAudio (ALSA-only 19.6) reports `"HDA Intel PCH: ALC257 Analog (hw:1,0)"`, `"pulse"`, `"default"` — so the match cannot succeed for analog/USB device descriptions and a Linux box with no saved output selection silently lands on the QAudioSink push path. (A short ALSA plugin name such as `hdmi` can still substring-match an HDMI description — a pre-existing misroute on the explicit path, filed separately as #5123 and untouched here.)

## Reach

The fix reaches a selection that is **not explicit**: nothing saved, or a saved device that is no longer enumerable. A saved device that is still present is explicit **even when it is the system default** — the user picked it from the Radio Setup combo, which has no "System Default" entry and writes a concrete id on any change (`RadioSetupDialog.cpp:3428`, `:3471`). On Linux that box still takes the name-match path and still falls back; #4978's reporting box has a saved device and is in that set, which is why this PR says `Refs` and #4978 stays open for the "System Default" entry and the exact-name escape hatch. On macOS the same case is benign (exact CoreAudio name match — measured below). The decision table is `CwSidetoneStartPolicy.h`, pinned by `tests/cw_sidetone_start_policy_test.cpp`.

## The fix

`startSidetoneStream()` now hands the **PortAudio attempt** a null device whenever the effective selection is the system default — in practice, whenever nothing is saved: `startRxStream()` already nulls a saved-but-missing device before this runs, so the saved-device-gone case arrives here as "nothing saved". That makes the existing default-device path live: PortAudio resolves its own default output, and the selection no longer depends on any cross-API name relation.

Deliberately unchanged, per the policy discussion in the issue: an **explicitly selected** device that fails to match still falls back to QAudioSink — silently rerouting audio to a different physical output would be worse than a backend swap. The QAudioSink attempts also keep the concrete device (that backend resolves a null itself but flags it as a fallback, which a deliberate default selection is not).

Observability, same commit (the issue's item-1/2 follow-through):

- The no-match warning now lists **every output-capable PortAudio candidate** with its host API; the multi-match warning names the contenders.
- The backend-fallback warning names the consequence ("sidetone will run on the push-model timing path").
- The CW sidetone summary gains `path=pull|push`.

## Platforms

`HAVE_PORTAUDIO` is pkg-config-gated (`CMakeLists.txt:212`, `:2402`) with no platform condition. Linux (AppImage installs `portaudio19-dev`) and macOS (`ci.yml` brews it; the DMG builds it in) compile the PortAudio backend and are changed by this PR; **Windows does not compile it** — `sidetoneOnPortAudio` is false and the change is a runtime no-op there. The WASAPI preference block in `defaultPortAudioOutputDevice()` is nevertheless *edited* here (dedented; the tautological `paNoDevice` guard removed) and that block is Windows-only logic CI never compiles (`ci.yml:391`, the #3241 note); `devIdx` is still initialised to `paNoDevice` and the post-`#endif` `Pa_GetDefaultOutputDevice()` fallback is intact. `PaJack_SetClientName` is untouched (`CwSidetonePortAudioSink.cpp:190`) — the JACK node naming stays; only the never-reachable routing preference is gone.

Evidence per platform is posted in #4978 as whole, unedited log files with the key lines quoted: macOS before/after (`issuecomment-5359411535`), Linux before/after (`issuecomment-5360172660`), Windows before/after (`issuecomment-5360814978`).

## Verification (live, FLEX-8400)

All arms below are from clean builds of **this head, `0927a161`** (About dialog + configure-log `Build SHA` line + `lsof` on the running process, per platform), each platform in one session, in the app's stock category logs, keyed arms into a 50 Ω dummy load only.

**Arm 1 — explicit saved selection (behavior preserved + new logging):**

```
WRN aether.audio: CwSidetonePortAudioSink: no PortAudio output matches "Built-in Audio Analog Stereo" - candidates: "HDA NVidia: HDMI 0 (hw:0,3)" [ALSA], ..., "hdmi" [ALSA], "pipewire" [ALSA], "pulse" [ALSA], "default" [ALSA]
WRN aether.audio: CwSidetonePortAudioSink: selected Qt output device "Built-in Audio Analog Stereo" was not found in PortAudio; falling back to QAudioSink
WRN aether.audio: AudioEngine: PortAudio sidetone failed, falling back to QAudioSink — sidetone will run on the push-model timing path
INF aether.audio.summary: Audio CW sidetone summary:
  backend="QAudioSink" device="Built-in Audio Analog Stereo" rate=24000Hz path=push
  fallback=yes (PortAudio failed -> QAudioSink; negotiated 24000Hz Float)
```

Note the candidate list in action: the physical analog device (`hw:1,0`) is absent — PipeWire held it — which is exactly why matching raw ALSA card names would be fragile even if the vocabularies met.

**Arm 2 — default selection (the fix):** cleared `AudioOutputDeviceId`, relaunched the same binary:

```
INF aether.audio: CwSidetonePortAudioSink: started device= default rate= 48000 Hz outputLatency= 2.66667 ms
INF aether.audio: AudioEngine: sidetone running on PortAudio rate= 48000 Hz
INF aether.audio.summary: Audio CW sidetone summary:
  backend="PortAudio" device="default" rate=48000Hz path=pull
  fallback=no
```

Before → after for a default-configured Linux box: QAudioSink 24 kHz push (fallback=yes) → **PortAudio 48 kHz pull, 2.67 ms output latency, fallback=no**. On the unfixed build the second scenario cannot take this path — the caller never hands the null device to PortAudio — which is the mutation this proof pins.

**Arm 3 — the pull path, keyed.** Arms 1 and 2 show which backend opened; they cannot show that it renders, and the failure mode named above prints the same summary either way. Same binary, default selection, radio into a 50 Ω dummy load — no antenna, no on-air transmission. 141 hand-keyed elements at 25 WPM on this head (re-keyed after #4942 `20d472c4` changed the render path; every edge now carries `schedMs=`): dits n=47, min 42, max 54, median 48, mean 48.1, SD 1.95 ms; dahs n=94, min 139, max 152, median 144, mean 144.5, SD 1.88 ms; ratio 3.00; 25.0 WPM from the mean dit (radio set to 25).

```
INF aether.audio: CwSidetonePortAudioSink: started device= default rate= 48000 Hz outputLatency= 2.66667 ms
INF aether.audio.summary: Audio CW sidetone summary:
  backend="PortAudio" device="default" rate=48000Hz path=pull
  fallback=no
...
DBG aether.cw: CW iambic key-edge trace=1 t=0ms sinceSourceMs=-1 down=true
DBG aether.cw: CW iambic key-edge trace=1 t=144ms sinceSourceMs=-1 down=false
DBG aether.cw: CW iambic key-edge trace=3 t=247ms sinceSourceMs=1 down=true
DBG aether.cw: CW iambic key-edge trace=3 t=295ms sinceSourceMs=49 down=false
```

The sidetone is audible throughout, so on this box the callback schedules and the tone renders on the ALSA `default` route.

**macOS — before/after** (Intel MacBook Pro, Homebrew PortAudio 19.7.0; before = clean build of `main` `990f3391`, after = this head; full logs in #4978). Default selection, before: `matched selected Qt output "MacBook Pro Speakers" to PortAudio output MacBook Pro Speakers` → `started device= MacBook Pro Speakers rate= 48000 Hz outputLatency= 10.3958 ms` → `backend="PortAudio" device="MacBook Pro Speakers" rate=48000Hz` / `fallback=no`. After: the match line is gone, `started device= MacBook Pro Speakers … 10.3958 ms`, `backend="PortAudio" device="MacBook Pro Speakers" rate=48000Hz path=pull` / `fallback=no` — same device, rate and latency, so the resolution swap is neutral on CoreAudio. Changing the system output while running re-resolved to the new device within a second (`output device set to ""` → RX restart → `started device= External Headphones …`), since the RX restart recreates the sink and re-initialises PortAudio. Keyed 81 elements on the pull path, audible (dits n=30 median 50 SD 2.58 ms; dahs n=51 median 145 SD 2.03 ms; ratio 2.90). Explicit selections — headphones, then the speakers that are the system default — name-match exactly on both builds and stay on `path=pull`. Opt-out `CwSidetoneBackend=QAudioSink` → `path=push fallback=no`, unchanged.

**Windows — Arm 1** (PortAudio not compiled; before = `main` `990f3391`, after = this head, same machine and flags, full logs in #4978). Neither configure log contains a PortAudio probe (pkg-config absent, as on CI's Windows job) and the build graph has zero `HAVE_PORTAUDIO` definitions, so the edited backend file is not in the binary. Before: `backend="QAudioSink" device="Speakers (Realtek(R) Audio)" rate=48000Hz` / `fallback=no`. After: same line + `path=push`, still `fallback=no` — the summary field is the PR's only Windows-visible effect. Keyed 155 elements at 25 WPM on the push path, audible (dits n=51 median 48 SD 0.66 ms; dahs n=104 median 145 SD 0.86 ms; ratio 3.02); every edge carries `schedMs=`, confirming #4934/#4942 remain the timing story on this path.

## Relationship to #3306

The QAudioSink backend — the opt-out and the PortAudio-failed fallback — still receives the concrete device and negotiates through `AudioDeviceNegotiator` exactly as on `main`; no #3306 seam (negotiator ladder, `AudioOutputRouter`, null-device semantics) changes here. The one conceptual departure: a default-selection PortAudio sidetone now follows **PortAudio's** default (`Pa_GetDefaultOutputDevice()`) rather than Qt's. Those coincide on CoreAudio and on Linux with pipewire-alsa/pulse `default`; on a box where ALSA `default` is `hw:0` they can differ, which is the case the escape-hatch follow-up in #4978 is for. `CwSidetonePortAudioSink` remains the one sidetone backend not yet on the negotiator; migrating it is a #3306 follow-up, not this PR.

## Test (fourth commit, `0927a161`)

`CwSidetoneStartPolicy.h` extracts the start-device decision as two `constexpr` functions with no Qt dependency, and `tests/cw_sidetone_start_policy_test.cpp` pins both truth tables by `static_assert` and runtime rows — including "saved device that is the system default → name-match path" and the Windows/no-PortAudio row. Dropping the `!explicitSelection` term fails the build. Same idiom as `QsoRecordStartPolicy`; the #3306 pattern (pure function over injected facts) applied to device selection — the decision is platform-independent, so there is no `TargetOs` parameter. Registered in `tests/tests.cmake`; runs under ctest and the weekly sanitizers sweep, **not on the PR gate** (a gate is a separate change, as with #5025). Behavior unchanged; the `AudioEngine.cpp` call site reads the policy instead of restating it.

## Relationship to #4934

This PR does not obsolete #4934: the push path remains in use on Windows (PortAudio detection is pkg-config-only there), wherever PortAudio isn't compiled in, and for explicit selections that fail to match. #4934 fixes that path's timing; this PR stops routing default-configured Linux users onto it by accident. #4934 has since merged (`4dd3bf0f`), so that sequencing is cleared.

## Follow-ups observed, out of scope here

- The Radio Setup output combo has **no "System Default" entry** — once a concrete device is ever picked there is no UI path back to a default selection (this proof had to clear the setting by hand). A selectable default entry would let existing configs benefit from this fix.
- The issue's remaining items: an exact-name escape-hatch setting for unmatched explicit selections (also the natural home for deliberate JACK/pro-audio routing — see the second-commit note above), and structured audio facts in the support bundle.

## Second commit — findings from a fresh-context adversarial pass

Before requesting review, this PR went through an independent adversarial review pass briefed to refute it. It surfaced one real problem in the first commit: making the default-device path reachable also revived two dormant JACK code blocks — a Linux preference routing a default selection to a reachable JACK server's device (Ubuntu's `libportaudio2` links `libjack`, so any running jackd or pipewire-jack surfaces the JACK host API), and a companion block flagging that successful selection `fallback=yes`. On a box running jackd against a different card, that would silently split the sidetone from RX audio — the exact reroute this PR's policy section forswears — and falsify `fallback=no`.

The second commit deletes both blocks. They were unreachable before this PR, but they were not unannounced: `CHANGELOG.md:6705` (v0.9.1, 2026-04-27) published the JACK preference as the workaround for PipeWire's ALSA shim silently breaking callback-mode streams on some setups — `Pa_StartStream` returns success but the audio thread never schedules the callback. Deleting it is a deliberate call rather than cleanup, and it carries a risk worth stating plainly: a default selection now always resolves `Pa_GetDefaultOutputDevice()` on Linux (the ALSA `default` route, following the system mixer), so a box that hits the shim bug would get a stream that opens, reports a latency, and renders nothing. Arm 3 below keys that path on this box and the tone renders — one setup, not every PipeWire configuration. Windows keeps its WASAPI preference (#3193). If deliberate JACK routing is wanted, it belongs to the explicit device-selection follow-up below as a user choice, and this deletion is one small revert away.

The same commit also reworded the saved-device-missing warning: PortAudio resolves its own default, so it no longer claims "system default".

## Constitution principle honored

Principle XI — Fixes Are Demonstrated: the `Fixes #4978` claim is demonstrated on the reporting box in the app's own logs, and the functional check that decides it — does the pull path render a tone — is Arm 3 above. Suggested squash subject:

```
fix(audio): reach PortAudio's default-device path for a default sidetone selection — Principle XI. (#5085)
```

## Test plan

- [x] Clean builds of `0927a161` (head) on Linux and macOS, About SHA verified in each binary; macOS before-build of `main` `990f3391` likewise
- [x] `cw_sidetone_start_policy_test` 9/9 (+8 `static_assert`), `cw_sidetone_test` 30/30, `audio_format_negotiation_test` 29/29 from the build; mutation (drop `!explicitSelection`) = build error
- [x] Arm 1 live: explicit selection preserved (QAudioSink fallback) + candidate-list/consequence/path logging present
- [x] Arm 2 live: default selection reaches PortAudio pull path, `fallback=no`
- [x] Arm 3 live, re-keyed on this head after #4942: the pull path keyed and audible — the check that separates "stream opened" from "stream renders"
- [x] macOS: before/after on the same machine, device-change following, keyed, explicit ×2, opt-out — all logged in #4978
- [x] Windows: Arm 1 (runtime no-op confirmed): before/after summary identical apart from the new `path=push` field; PortAudio provably absent from both builds; keyed and audible on the push path — logged in #4978
- [x] Radio safe: keying into a 50 Ω dummy load only, no antenna and no on-air transmission; device selection restored afterwards on every box

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — **n/a, no settings read or written by this change**
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` — **n/a, no meter UI touched**
- [x] Documentation updated if user-visible behavior changed — **n/a: no doc describes the sidetone device-selection semantics (`docs/audio-sink-factory.md` covers format negotiation only); the behavior change is described above**
- [x] Security-sensitive changes reference a GHSA — **n/a, not security-sensitive**

— authored by agent (Claude Code) on behalf of @skerker


