### PR TITLE
fix(tci): stop double-broadcasting vfo: on channel 0

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -1307,6 +1307,7 @@ void TciServer::tuneSliceAndConfirm(
         return;
     }
 
+    const long long beforeHz = TciProtocol::mhzToHz(slice->frequency());
     const double mhz = static_cast<double>(frequencyHz) / 1.0e6;
     // The in-span test is shared with the CAT/rigctld planes (#4497):
     // PanadapterModel::spanContainsMhz is the single definition, so the three
@@ -1359,15 +1360,26 @@ void TciServer::tuneSliceAndConfirm(
     // where it was; in both cases the honest answer is the value the model
     // holds, or a client's mirror drifts away from the radio.
     //
-    // Sent unconditionally even though a successful tune also reaches clients
-    // via frequencyChanged → broadcastSliceFrequencies(). That duplicates the
-    // channel-0 vfo: frame, which is idempotent and harmless — whereas the
-    // alternative failure, a client left with NO confirmation, hangs WSJT-X for
-    // its full rig-control timeout. Channel 1 is not covered by that automatic
-    // path at all unless the routing state happens to be bound, so suppressing
-    // this would make split confirmations depend on unrelated state.
+    // A successful tune also reaches clients via frequencyChanged →
+    // broadcastSliceFrequencies(), fired synchronously inside setFrequency()/
+    // tuneAndRecenter() above (their own qFuzzyCompare guard skips the emit on
+    // a genuine no-op). For channel 0 that sends an identical vfo:<trx>,0,<hz>;
+    // frame BEFORE this line ever runs, so confirming again here produced two
+    // near-simultaneous vfo: frames for the same value — suspected of racing a
+    // TCI client's own frequency-restore scheduler (#5086: intermittent RX
+    // frequency drift on WSJT-X "Fake It" split, after a TX/RX cycle). Detect
+    // that case by comparing the pre-tune and post-tune Hz value: if it moved,
+    // channel 0 is already covered and this broadcast would be the duplicate.
+    // A genuine no-op (locked slice, or the request matched what was already
+    // there) never emits frequencyChanged, so channel 0 still needs this
+    // explicit confirmation — otherwise a client is left with none and hangs
+    // for its full rig-control timeout. Channel 1 keeps its unconditional
+    // confirmation regardless of whether the frequency moved: the automatic
+    // path only covers it when the routing state happens to track this slice
+    // as TX, so it cannot be assumed sent.
     const long long acceptedHz = TciProtocol::mhzToHz(slice->frequency());
-    if (acceptedHz > 0) {
+    const bool channelZeroAlreadyBroadcast = (channel == 0 && acceptedHz != beforeHz);
+    if (acceptedHz > 0 && !channelZeroAlreadyBroadcast) {
         broadcast(QStringLiteral("vfo:%1,%2,%3;").arg(trx).arg(channel).arg(acceptedHz));
     }
 }

--- a/tests/tci_server_review_test.cpp
+++ b/tests/tci_server_review_test.cpp
@@ -1019,7 +1019,21 @@ public:
             return false;
 
         TciServer server(&model);
+        // In production this runs at session setup (MainWindow_Session.cpp),
+        // which is what makes frequencyChanged -> broadcastSliceFrequencies()
+        // live for a real move; without it this test would only ever exercise
+        // tuneSliceAndConfirm's own explicit confirmation, never the automatic
+        // path it now defers to on channel 0 (#5086).
+        server.wireSlice(0, slice);
         QWebSocket client;
+        // broadcastSliceFrequencies() bails early on an empty m_clients (it
+        // has no client to send to yet), unlike the explicit confirmation
+        // below it, which broadcast()s unconditionally. A registered client
+        // is what makes the automatic path observable here at all.
+        QWebSocket sock;
+        TciServer::ClientState cs;
+        cs.socket = &sock;
+        server.m_clients.append(cs);
 
         QStringList sent;
         QObject::connect(&server, &TciServer::tciMessage,
@@ -1130,6 +1144,60 @@ public:
         const long long parked = TciProtocol::mhzToHz(slice->frequency());
         server.tuneSliceAndConfirm(&client, 0, 0, 0, parked);
         return sent.contains(QStringLiteral("vfo:0,0,%1;").arg(parked));
+    }
+
+    // #5086: a channel-0 SET that actually moves the frequency is already
+    // broadcast once by frequencyChanged -> broadcastSliceFrequencies(),
+    // fired synchronously inside setFrequency()/tuneAndRecenter() before
+    // tuneSliceAndConfirm's own confirmation runs. Sending it again produced
+    // two near-simultaneous vfo: frames for the same value, suspected of
+    // racing a TCI client's own frequency-restore scheduler (intermittent RX
+    // frequency drift on WSJT-X "Fake It" split, after a TX/RX cycle). Exactly
+    // one vfo:0,0,<hz>; must reach the wire per real move, not two.
+    static bool vfoSetChannelZeroBroadcastsExactlyOnce()
+    {
+        RadioModel model;
+        QString error;
+        if (!model.automationApplySliceFixture(0, QString(), &error))
+            return false;
+        SliceModel* slice = model.slice(0);
+        if (!slice)
+            return false;
+
+        TciServer server(&model);
+        // Matches production session setup (MainWindow_Session.cpp): without
+        // this, frequencyChanged -> broadcastSliceFrequencies() is never
+        // live, and the test can't observe the duplicate this fix removes.
+        server.wireSlice(0, slice);
+        QWebSocket client;
+        // broadcastSliceFrequencies() bails early on an empty m_clients,
+        // unlike the explicit confirmation, which broadcast()s
+        // unconditionally — a registered client makes the automatic path
+        // observable here at all.
+        QWebSocket sock;
+        TciServer::ClientState cs;
+        cs.socket = &sock;
+        server.m_clients.append(cs);
+
+        QStringList sent;
+        QObject::connect(&server, &TciServer::tciMessage,
+                         [&sent](const QString& dir, const QString& msg) {
+            if (dir == QLatin1String("tx"))
+                sent << msg.trimmed();
+        });
+
+        const long long want = TciProtocol::mhzToHz(slice->frequency()) - 1000;
+        server.tuneSliceAndConfirm(&client, 0, 0, 0, want);
+
+        const QString expected = QStringLiteral("vfo:0,0,%1;").arg(want);
+        const int occurrences = sent.count(expected);
+        if (occurrences != 1) {
+            std::printf("      expected exactly one %s, saw %d (sent: %s)\n",
+                        qPrintable(expected), occurrences,
+                        qPrintable(sent.join(QStringLiteral(" "))));
+            return false;
+        }
+        return true;
     }
 
     // #4744: switching from resampled TCI RX to native rate carries staged
@@ -1276,6 +1344,8 @@ int main(int argc, char** argv)
         = AetherSDR::TciServerReviewTest::vfoSetConfirmsTruthWhenRefused();
     const bool vfoAcksNoOp
         = AetherSDR::TciServerReviewTest::vfoSetAcknowledgesANoOp();
+    const bool vfoChannelZeroOnce
+        = AetherSDR::TciServerReviewTest::vfoSetChannelZeroBroadcastsExactlyOnce();
     const bool txTrxResets
         = AetherSDR::TciServerReviewTest::lastTxTrxResetsOnClose();
     const bool activeSliceSeed
@@ -1336,6 +1406,9 @@ int main(int argc, char** argv)
                 vfoConfirmsRefusal ? "PASS" : "FAIL");
     std::printf("%s  vfo: SET still acknowledges a no-op\n",
                 vfoAcksNoOp ? "PASS" : "FAIL");
+    std::printf("%s  vfo: SET on channel 0 broadcasts exactly once per move "
+                "(#5086)\n",
+                vfoChannelZeroOnce ? "PASS" : "FAIL");
     std::printf("%s  PTT route log shows the cache disagreeing with live TX "
                 "(#4547)\n",
                 routeLogStaleCache ? "PASS" : "FAIL");
@@ -1355,6 +1428,7 @@ int main(int argc, char** argv)
         && activeSliceSeed && activeSliceRemoval && trxStableRecreate
         && trxDistinctReconnect && heldTrxRefuses
         && vfoConfirmsAccepted && vfoConfirmsRefusal && vfoAcksNoOp
+        && vfoChannelZeroOnce
         && routeLogStaleCache && routeLogSampleOrder && routeLogSanitizes
         && native24kPayload
         ? 0 : 1;


### PR DESCRIPTION
## Summary

Refs #5086. Not a fix for #5086 — that bug is now traced to the TCI client's own logic (see the #5086 write-up), but this is a real, independently-justified correctness fix uncovered during that investigation.

#4501 (fix(tci): confirm the frequency a `vfo:` SET actually reached) removed a no-op short-circuit in `tuneSliceAndConfirm()` and switched the Flex confirmation path from async-and-radio-paced to synchronous and optimistic: it now calls `slice->setFrequency()`/`tuneAndRecenter()` directly and confirms immediately, inline.

Those `SliceModel` setters already unconditionally `emit frequencyChanged()` on a real move (their own `qFuzzyCompare` guard only skips it on a genuine no-op), which drives `broadcastSliceFrequencies()` synchronously — sending an identical `vfo:<trx>,0,<hz>;` frame *before* `tuneSliceAndConfirm`'s own explicit confirmation runs. Every channel-0 `vfo:` SET that actually moved the frequency has, since #4501, produced two near-simultaneous `vfo:` frames for the same value in the same event-loop tick, where before #4501 they were naturally spaced by real network round-trip latency to the radio.

## Fix

In `src/core/TciServer.cpp`, `tuneSliceAndConfirm()`: compare the pre-tune and post-tune Hz value. If channel 0 moved, the automatic `frequencyChanged` path already broadcast it — skip the duplicate. If it didn't (locked slice refused the tune, or the request matched what was already there), `frequencyChanged` never fires, so the explicit confirmation still runs — otherwise a client is left with none and hangs for its full rig-control timeout. Channel 1 keeps its unconditional confirmation regardless: the automatic path only covers it when the routing state happens to track this slice as TX, so it cannot be assumed sent.

#4501's actual fix (confirm the accepted, not stale, frequency) is preserved in full — this only removes the second, redundant broadcast it introduced as a side effect.

## Constitution principle honored

Principle VIII — Evidence Over Assertion. Verified the duplicate exists in production (live FLEX-6700 debug log, two `vfo:0,0,<hz>;` lines per SET) before fixing, and verified it's gone after (single line per SET, same log method) — not asserted from reading the diff alone.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] New test `vfoSetChannelZeroBroadcastsExactlyOnce()` asserts exactly one `vfo:0,0,<hz>;` per real channel-0 move
- [x] Existing `tci_server_review_test`, `tci_protocol_test`, `tci_trxmap_test`, `tci_automation_test`, `hl2_tci_signaling_test` all pass
- [x] Verified on a live FLEX-6700: duplicate frame confirmed present before, confirmed gone after, via debug log capture

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room
- [x] No meter UI touched
- [x] No user-visible behavior change requiring docs updates