### PR TITLE
feat(icom): add initial IC-9700 integration

### DIFF
--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -2074,8 +2074,9 @@ QJsonObject metersSnapshot(MeterModel* m, const QString& radioModel)
     }
 
     return QJsonObject{
-        {QStringLiteral("fwdPower"),        m->fwdPower()},           // Watts (smoothed)
-        {QStringLiteral("fwdPowerInstant"), m->fwdPowerInstant()},    // Watts (peak)
+        {QStringLiteral("fwdPower"),        m->fwdPower()},           // native declared unit
+        {QStringLiteral("fwdPowerInstant"), m->fwdPowerInstant()},    // native unit, unsmoothed
+        {QStringLiteral("fwdPowerUnit"),    m->forwardPowerUnit()},
         {QStringLiteral("fwdPowerAgeMs"),   age(m->fwdPowerUpdatedAtMs())},
         {QStringLiteral("reflectedPower"),  m->reflectedPower()},
         {QStringLiteral("reflectedPowerAgeMs"),
@@ -2091,7 +2092,8 @@ QJsonObject metersSnapshot(MeterModel* m, const QString& radioModel)
         {QStringLiteral("swrAgeMs"),        age(m->swrUpdatedAtMs())},
         {QStringLiteral("paTemp"),          m->paTemp()},             // °C
         {QStringLiteral("supplyVolts"),     m->supplyVolts()},        // V
-        {QStringLiteral("swAlc"),           m->swAlc()},              // dBFS post-ALC SSB peak
+        {QStringLiteral("swAlc"),           m->swAlc()},              // native declared unit
+        {QStringLiteral("swAlcUnit"),       m->swAlcUnit()},
         {QStringLiteral("hwAlc"),           m->hwAlc()},              // dBFS external HW-ALC
         {QStringLiteral("micPeak"),         m->micPeak()},            // dBFS
         {QStringLiteral("micLevel"),        m->micLevel()},           // dBFS

--- a/src/core/MeterSurfaces.h
+++ b/src/core/MeterSurfaces.h
@@ -80,7 +80,7 @@ inline constexpr std::array<MeterSurface, 9> kMeterSurfaces{{
     {"SLC:LEVEL", "dBm", "MeterModel::sLevelChanged / sLevel()",
      "S-meter applet; VFO slice signal flag; AGC calibration dialog", true},
 
-    {"TX:FWDPWR", "Watts,dBm", "MeterModel::directionalPowerMetersChanged / fwdPowerInstant()",
+    {"TX:FWDPWR", "Watts,dBm,Percent", "MeterModel::directionalPowerMetersChanged / fwdPowerInstant()",
      "TX Controls power gauge (PEP peak-hold); Health applet", true},
 
     {"TX:REFPWR", "Watts,dBm", "MeterModel::directionalPowerMetersChanged / reflectedPower()",

--- a/src/core/RadioCertification.cpp
+++ b/src/core/RadioCertification.cpp
@@ -251,8 +251,16 @@ QJsonObject RadioCertification::renderedSnapshot() const
     // seam's dBm.
     const qint64 fwdAge = ageOf(meters.fwdPowerUpdatedAtMs());
     const bool fwdLive = fwdAge >= 0 && fwdAge <= MeterModel::kTxMeterStaleMs;
-    out[QStringLiteral("fwdPowerWatts")] =
+    const QString fwdUnit = meters.forwardPowerUnit();
+    const bool fwdIsWatts =
+        fwdUnit.compare(QLatin1String("Watts"), Qt::CaseInsensitive) == 0
+        || fwdUnit.compare(QLatin1String("W"), Qt::CaseInsensitive) == 0;
+    out[QStringLiteral("fwdPowerValue")] =
         fwdLive ? QJsonValue(static_cast<double>(meters.fwdPowerInstant())) : QJsonValue();
+    out[QStringLiteral("fwdPowerUnit")] = fwdUnit;
+    out[QStringLiteral("fwdPowerWatts")] =
+        fwdLive && fwdIsWatts
+        ? QJsonValue(static_cast<double>(meters.fwdPowerInstant())) : QJsonValue();
     out[QStringLiteral("fwdPowerAgeMs")] = static_cast<double>(fwdAge);
     out[QStringLiteral("fwdPowerLive")] = fwdLive;
 
@@ -275,8 +283,14 @@ QJsonObject RadioCertification::renderedSnapshot() const
     const int alcIdx = meters.findMeter(QStringLiteral("TX"), QStringLiteral("ALC"));
     const qint64 alcAge = alcIdx >= 0 ? meters.valueAgeMs(alcIdx) : -1;
     const bool alcLive = alcAge >= 0 && alcAge <= MeterModel::kTxMeterStaleMs;
-    out[QStringLiteral("alcDbfs")] =
+    const QString alcUnit = meters.swAlcUnit();
+    out[QStringLiteral("alcValue")] =
         alcLive ? QJsonValue(static_cast<double>(meters.swAlc())) : QJsonValue();
+    out[QStringLiteral("alcUnit")] = alcUnit;
+    const bool alcIsDbfs = alcUnit.isEmpty()
+        || alcUnit.compare(QLatin1String("dBFS"), Qt::CaseInsensitive) == 0;
+    out[QStringLiteral("alcDbfs")] = alcLive && alcIsDbfs
+        ? QJsonValue(static_cast<double>(meters.swAlc())) : QJsonValue();
     out[QStringLiteral("alcAgeMs")] = static_cast<double>(alcAge);
     out[QStringLiteral("alcLive")] = alcLive;
     return out;

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -132,7 +132,10 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
             &TciServer::onRadioTransmittingChanged);
         connect(&m_model->meterModel(), &MeterModel::txMetersChanged,
                 this, [this](float fwd, float swr, bool swrValid) {
-            m_cachedFwdPower = fwd;
+            const QString unit = m_model->meterModel().forwardPowerUnit();
+            m_cachedFwdPower =
+                unit.compare(QLatin1String("Percent"), Qt::CaseInsensitive) == 0
+                ? 0.0f : fwd;
             // TCI's wire format has no absent marker; 1.0 is what this cache
             // held before any SWR arrived, so absence maps back to it rather
             // than to 0.0 (which is out of the meter's domain).
@@ -143,8 +146,21 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
             m_cachedMicLevel = micLevel;
         });
         connect(&m_model->meterModel(), &MeterModel::swAlcChanged,
-                this, [this](float dbfs) {
-            m_cachedAlc = dbfs;
+                this, [this](float value) {
+            const QString unit = m_model->meterModel().swAlcUnit();
+            m_cachedAlcDbfsValid = unit.isEmpty()
+                || unit.compare(QLatin1String("dBFS"), Qt::CaseInsensitive) == 0;
+            if (m_cachedAlcDbfsValid) {
+                m_cachedAlc = value;
+            }
+        });
+        connect(&m_model->meterModel(), &MeterModel::swAlcUnitChanged,
+                this, [this](const QString& unit) {
+            m_cachedAlcDbfsValid = unit.isEmpty()
+                || unit.compare(QLatin1String("dBFS"), Qt::CaseInsensitive) == 0;
+            if (!m_cachedAlcDbfsValid) {
+                m_cachedAlc = 0.0f;
+            }
         });
 
         // RF/tune power → `drive:` / `tune_drive:` broadcast (#4161). Without
@@ -3336,13 +3352,19 @@ void TciServer::broadcastStatus()
             // tx_sensors:trx,mic_dbm,fwd_watts,peak_watts,swr,alc_dbfs
             // alc_dbfs (trailing field, AetherSDR extension) is the SW-ALC
             // peak; index-based parsers safely ignore the extra field.
-            cs.socket->sendTextMessage(
-                QStringLiteral("tx_sensors:0,%1,%2,%3,%4,%5;")
-                    .arg(m_cachedMicLevel, 0, 'f', 1)
-                    .arg(m_cachedFwdPower, 0, 'f', 1)
-                    .arg(m_cachedFwdPower, 0, 'f', 1)  // peak ≈ avg for now
-                    .arg(m_cachedSwr, 0, 'f', 1)
-                    .arg(m_cachedAlc, 0, 'f', 1));
+            QString message = QStringLiteral("tx_sensors:0,%1,%2,%3,%4")
+                .arg(m_cachedMicLevel, 0, 'f', 1)
+                .arg(m_cachedFwdPower, 0, 'f', 1)
+                .arg(m_cachedFwdPower, 0, 'f', 1)  // peak ≈ avg for now
+                .arg(m_cachedSwr, 0, 'f', 1);
+            // The trailing dBFS field is an AetherSDR extension. Omit it when
+            // the radio declares a relative indication rather than inventing
+            // a physical conversion TCI cannot label honestly.
+            if (m_cachedAlcDbfsValid) {
+                message += QStringLiteral(",%1").arg(m_cachedAlc, 0, 'f', 1);
+            }
+            message += QLatin1Char(';');
+            cs.socket->sendTextMessage(message);
         }
     }
 }

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -365,7 +365,8 @@ private:
     float             m_cachedFwdPower{0};
     float             m_cachedSwr{1.0f};
     float             m_cachedMicLevel{-50.0f};
-    float             m_cachedAlc{0.0f};       // SW-ALC peak, dBFS
+    float             m_cachedAlc{0.0f};       // SW-ALC peak, dBFS when valid
+    bool              m_cachedAlcDbfsValid{true};
 };
 
 } // namespace AetherSDR

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -106,6 +106,10 @@ public:
     virtual RestoredRadioState currentOperatingState() const { return {}; }
     virtual void disconnectRadio() = 0;
     virtual bool isConnected() const = 0;
+    // Some radios require an acknowledged, asynchronous logout after their
+    // connected edge drops. The application may keep its live object graph
+    // until this becomes false; ordinary backends complete immediately.
+    virtual bool shutdownPending() const { return false; }
 
     // ---- intents DOWN: canonical core-profile verbs (grow per burndown) ----
     // The backend translates each to its vendor wire protocol.
@@ -579,6 +583,7 @@ public:
     {
         Q_UNUSED(level);
     }
+    virtual void setMicInput(const QString& input) { Q_UNUSED(input); }
 
     // Processed transmit audio, int16 interleaved stereo at sampleRateHz.
     //

--- a/src/core/backends/RadioCapabilities.h
+++ b/src/core/backends/RadioCapabilities.h
@@ -2,10 +2,17 @@
 
 #include <QFlags>
 #include <QString>
+#include <QStringList>
 #include <QVector>
 #include <QVariantMap>
 
 namespace AetherSDR {
+
+struct TxPowerBand {
+    double lowHz = 0.0;
+    double highHz = 0.0;
+    double maxWatts = 0.0;
+};
 
 // The honest, self-declared feature set of a connected radio, produced by an
 // IRadioBackend and surfaced to clients (aetherd RFC §4.1 `welcome`). Clients
@@ -102,6 +109,19 @@ struct RadioCapabilities {
     // keying intent regardless of client requests.
     bool canTransmit = false;
     double txPowerMaxWatts = 0.0;  // 0 when RX-only
+    // Optional band-specific barefoot limits. Empty means the single maximum
+    // above applies across the radio's transmit range.
+    QVector<TxPowerBand> txPowerBands;
+
+    [[nodiscard]] double txPowerMaxWattsAt(double frequencyHz) const
+    {
+        for (const TxPowerBand& band : txPowerBands) {
+            if (frequencyHz >= band.lowHz && frequencyHz <= band.highHz) {
+                return band.maxWatts;
+            }
+        }
+        return txPowerMaxWatts;
+    }
 
     // TX audio is modulated on THIS host rather than inside the radio. True for
     // direct-sampling backends (HL2) where the PC runs the modulator and streams
@@ -261,6 +281,10 @@ struct RadioCapabilities {
     // TunerModel::presenceChanged), and the HL2 declares it false while
     // genuinely having a PA. It already means something other than this.
     bool hasSupplyVoltageTelemetry = false;
+    bool hasPaTemperatureTelemetry = false;
+    bool hasMainFanTelemetry = false;
+    // Zero means no PA-current meter. Non-zero is the face maximum in amps.
+    double paCurrentMaxAmps = 0.0;
 
     // The radio exposes SELECTABLE HARDWARE microphone inputs — the Phone
     // applet's MIC / BAL / LINE / ACC choices, which are FlexRadio's front and
@@ -278,6 +302,35 @@ struct RadioCapabilities {
     // hear network audio produces a transmission with no modulation, which
     // looks like a hardware fault.
     bool hasSelectableMicInputs = false;
+    // Operator-facing input names. Empty means the client cannot select one.
+    QStringList micInputChoices;
+    // Empty means the processor follows the backend's existing all-mode
+    // behaviour. A non-empty list restricts PROC/compression to those modes.
+    QStringList speechProcessorModes;
+
+    // FM repeater-access modes this backend can actually command. Values are
+    // the canonical SliceModel tokens; the UI supplies the translated labels.
+    // Keep this explicit per backend so an Icom extension cannot silently add
+    // unsupported DTCS choices to the shipping Flex surface.
+    QStringList fmRepeaterAccessModes;
+    // Independent TX/RX CTCSS, DTCS polarity, and native duplex direction.
+    // False preserves the established Flex offset/reverse behavior.
+    bool hasExtendedFmRepeaterControls = false;
+
+    // Radio-side downward expander/compander exposed by the Phone panel.
+    // This is a distinct command from ordinary speech compression: an Icom
+    // supports PROC but has no Flex DEXP verb.
+    bool hasDownwardExpander = false;
+    bool hasContinuousSpeechProcessorLevel = false;
+    // VOX enable/gain and VOX hang time are not universally the same feature.
+    bool hasVoxDelayControl = false;
+    // The Phone panel's transmitted-audio passband reaches real hardware/DSP.
+    bool hasTxFilterControl = false;
+
+    // The operator can select among receive antenna inputs through this
+    // backend. False suppresses the ANT panel; a fixed band connector is
+    // status, not a selectable control.
+    bool hasSelectableRxAntenna = false;
 
     // Transmit audio reaches this backend through IRadioBackend::submitTxAudio
     // rather than through a Flex DAX/VITA-49 stream.
@@ -374,6 +427,10 @@ struct RadioCapabilities {
     // every family and must never be gated on this — on a radio reporting false
     // it is the only automatic floor the operator has.
     bool hasRadioSideWaterfallAutoBlack = false;
+    // Frequency-stamped history is useful for continuously pannable receivers.
+    // Radios whose scope jumps as one hardware aperture should start a fresh
+    // history on a large retune instead of exposing a partly black overlap.
+    bool preservesWaterfallHistoryOnLargeRetune = true;
 
     // NO hasTrackingNotchFilters HERE, deliberately. TNF looks like it belongs
     // beside the three below — TnfModel's whole surface is `tnf create/remove/

--- a/src/core/backends/SliceDelta.h
+++ b/src/core/backends/SliceDelta.h
@@ -110,6 +110,13 @@ struct SliceDelta {
     // FM duplex/repeater
     std::optional<QString>     fmToneMode;
     std::optional<double>      fmToneValue;
+    // Extended repeater access. fmToneValue remains the Flex-compatible TX
+    // CTCSS value; these fields carry the independent IC-9700 registers.
+    std::optional<double>      fmToneTxValue;
+    std::optional<double>      fmToneRxValue;
+    std::optional<int>         fmDtcsCode;
+    std::optional<bool>        fmDtcsTxReverse;
+    std::optional<bool>        fmDtcsRxReverse;
     std::optional<QString>     repeaterOffsetDir;
     std::optional<double>      fmRepeaterOffsetFreq;
     std::optional<double>      txOffsetFreq;

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -169,6 +169,11 @@ RadioCapabilities FlexBackend::capabilities() const
     // Global / TX / mic profiles are a SmartSDR feature on every current model.
     caps.hasProfiles = true;
     caps.hasSelectableMicInputs = true;
+    caps.micInputChoices = {QStringLiteral("MIC"), QStringLiteral("BAL"),
+                            QStringLiteral("LINE"), QStringLiteral("ACC"),
+                            QStringLiteral("PC")};
+    caps.fmRepeaterAccessModes = {QStringLiteral("off"),
+                                  QStringLiteral("ctcss_tx")};
 
     // FALSE, and stated rather than left to the default. A Flex modulates on
     // the radio AND takes its transmit audio over DAX/VITA-49, so it is the one
@@ -247,6 +252,15 @@ RadioCapabilities FlexBackend::capabilities() const
     // The "+13.8A" meter carries the PA supply rail (measurement point A,
     // before the fuse), which the status bar renders under the PA temperature.
     caps.hasSupplyVoltageTelemetry = true;
+    caps.hasPaTemperatureTelemetry = true;
+    caps.hasMainFanTelemetry = true;
+    // Deliberately omitted: current Flex meter metadata clips below real draw.
+    caps.paCurrentMaxAmps = 0.0;
+    // These are the native SmartSDR Phone surfaces. Keep them explicit now
+    // that the shared applets shape themselves to each backend's controls.
+    caps.hasDownwardExpander = true;
+    caps.hasContinuousSpeechProcessorLevel = false;
+    caps.hasTxFilterControl = true;
 
     // Advertise the "flex" extension namespace: the amp/tuner operate/bypass/
     // autotune verbs are now routed through invokeExtension() (#4092/#4094), and

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -1422,6 +1422,8 @@ RadioCapabilities Hl2Backend::capabilities() const
     // 3 §B4: the HL2 carries no DSP). NR and ANF are left off because they are
     // not implemented, not because they could not be.
     c.hasHostNoiseBlanker = true;
+    c.fmRepeaterAccessModes = {QStringLiteral("off"),
+                               QStringLiteral("ctcss_tx")};
     // The 76.8 MHz NCO scale is a localparam in the bitstream and nothing in the
     // HPSDR map can be told the crystal's real error — so the correction is ours
     // or it does not happen. See Hl2FreqCal for the derivation.
@@ -1486,6 +1488,14 @@ RadioCapabilities Hl2Backend::capabilities() const
     // from this radio, the supply rail is not reported at all. Only the volts
     // readout goes away — the temperature above it keeps working.
     c.hasSupplyVoltageTelemetry = false;
+    c.hasPaTemperatureTelemetry = true;
+    c.hasMainFanTelemetry = false;
+    c.paCurrentMaxAmps = 0.0;
+    // TX passband edges are implemented by the host-side WDSP transmitter.
+    // There is no separate HL2 DEXP/compander command.
+    c.hasDownwardExpander = false;
+    c.hasContinuousSpeechProcessorLevel = false;
+    c.hasTxFilterControl = true;
     // The HL2 persists NOTHING across power cycles — "the radio reports no
     // VFO, so the app is authoritative and must push" (pushInitialState).
     // These are the domains the client owns as the radio's memory

--- a/src/core/backends/icom/CivCodec.cpp
+++ b/src/core/backends/icom/CivCodec.cpp
@@ -60,6 +60,7 @@ bool commandHasSubcommand(std::uint8_t command)
     case cmd::kLevel:
     case cmd::kMeter:
     case cmd::kFunction:
+    case cmd::kTone:
     case cmd::kPower:
     case cmd::kReadId:
     case cmd::kSetting:
@@ -613,6 +614,12 @@ std::vector<std::uint8_t> cmdScopeDataOutput(std::uint8_t to, bool on)
     return buildFrameSub(to, cmd::kScope, scope::kDataOutput, body);
 }
 
+std::vector<std::uint8_t> cmdScopeMainSub(std::uint8_t to, bool sub)
+{
+    const std::array<std::uint8_t, 1> body{static_cast<std::uint8_t>(sub ? 0x01 : 0x00)};
+    return buildFrameSub(to, cmd::kScope, scope::kMainSub, body);
+}
+
 std::vector<std::uint8_t> cmdScopeMode(std::uint8_t to, bool fixed)
 {
     // 0000 = centre, 0001 = fixed. Two BCD bytes, not one.
@@ -688,6 +695,95 @@ std::vector<std::uint8_t> cmdReadLevel(std::uint8_t to, std::uint8_t which)
 std::vector<std::uint8_t> cmdReadFunction(std::uint8_t to, std::uint8_t which)
 {
     return buildFrameSub(to, cmd::kFunction, which);
+}
+
+std::vector<std::uint8_t> cmdReadRepeaterAccess(std::uint8_t to)
+{
+    return buildFrameSub(to, cmd::kFunction, func::kRepeaterAccess);
+}
+
+std::vector<std::uint8_t> cmdSetRepeaterAccess(std::uint8_t to, std::uint8_t mode)
+{
+    const std::array<std::uint8_t, 1> body{mode};
+    return buildFrameSub(to, cmd::kFunction, func::kRepeaterAccess, body);
+}
+
+std::vector<std::uint8_t> cmdReadTone(std::uint8_t to, std::uint8_t which)
+{
+    return buildFrameSub(to, cmd::kTone, which);
+}
+
+std::vector<std::uint8_t> cmdSetTone(std::uint8_t to, std::uint8_t which, int value,
+                                     bool txReverse, bool rxReverse)
+{
+    const int v = std::clamp(value, 0, 9999);
+    const std::array<std::uint8_t, 3> body{
+        static_cast<std::uint8_t>((txReverse ? 0x10 : 0x00) | (rxReverse ? 0x01 : 0x00)),
+        static_cast<std::uint8_t>((((v / 1000) % 10) << 4) | ((v / 100) % 10)),
+        static_cast<std::uint8_t>((((v / 10) % 10) << 4) | (v % 10)),
+    };
+    return buildFrameSub(to, cmd::kTone, which, body);
+}
+
+std::optional<ToneRegister> decodeTone(std::span<const std::uint8_t> payload)
+{
+    const auto validBcd = [](std::uint8_t b) {
+        return (b & 0x0f) <= 9 && ((b >> 4) & 0x0f) <= 9;
+    };
+    if (payload.size() != 3 || (payload[0] & 0xEE) != 0
+        || !validBcd(payload[1]) || !validBcd(payload[2])) {
+        return std::nullopt;
+    }
+    return ToneRegister{decodeBcdByte(payload[1]) * 100 + decodeBcdByte(payload[2]),
+                        (payload[0] & 0x10) != 0, (payload[0] & 0x01) != 0};
+}
+
+std::vector<std::uint8_t> cmdReadRepeaterOffset(std::uint8_t to)
+{
+    return buildFrame(to, cmd::kReadRepeaterOffset);
+}
+
+std::vector<std::uint8_t> cmdSetRepeaterOffset(std::uint8_t to, std::uint64_t hz)
+{
+    // Command 0D carries three little-endian BCD bytes in 100 Hz units.
+    // IC-9700 offsets are unsigned; command 0F owns the direction.
+    const std::uint64_t units = std::min<std::uint64_t>(hz / 100ULL, 999'999ULL);
+    const std::array<std::uint8_t, 3> body{
+        static_cast<std::uint8_t>((((units / 10ULL) % 10ULL) << 4)
+                                  | (units % 10ULL)),
+        static_cast<std::uint8_t>((((units / 1000ULL) % 10ULL) << 4)
+                                  | ((units / 100ULL) % 10ULL)),
+        static_cast<std::uint8_t>((((units / 100'000ULL) % 10ULL) << 4)
+                                  | ((units / 10'000ULL) % 10ULL)),
+    };
+    return buildFrame(to, cmd::kSetRepeaterOffset, body);
+}
+
+std::optional<std::uint64_t> decodeRepeaterOffset(std::span<const std::uint8_t> payload)
+{
+    if (payload.size() != 3) {
+        return std::nullopt;
+    }
+    for (std::uint8_t byte : payload) {
+        if ((byte & 0x0f) > 9 || ((byte >> 4) & 0x0f) > 9) {
+            return std::nullopt;
+        }
+    }
+    const std::uint64_t units = static_cast<std::uint64_t>(decodeBcdByte(payload[0]))
+        + static_cast<std::uint64_t>(decodeBcdByte(payload[1])) * 100ULL
+        + static_cast<std::uint64_t>(decodeBcdByte(payload[2])) * 10'000ULL;
+    return units * 100ULL;
+}
+
+std::vector<std::uint8_t> cmdReadDuplex(std::uint8_t to)
+{
+    return buildFrame(to, cmd::kDuplex);
+}
+
+std::vector<std::uint8_t> cmdSetDuplex(std::uint8_t to, std::uint8_t mode)
+{
+    const std::array<std::uint8_t, 1> body{mode};
+    return buildFrame(to, cmd::kDuplex, body);
 }
 
 std::vector<std::uint8_t> cmdReadSetting(std::uint8_t to, int item)

--- a/src/core/backends/icom/CivCodec.h
+++ b/src/core/backends/icom/CivCodec.h
@@ -185,9 +185,13 @@ inline constexpr std::uint8_t kReadFreq     = 0x03;
 inline constexpr std::uint8_t kReadMode     = 0x04;
 inline constexpr std::uint8_t kSetFreq      = 0x05;
 inline constexpr std::uint8_t kSetMode      = 0x06;
+inline constexpr std::uint8_t kReadRepeaterOffset = 0x0C;
+inline constexpr std::uint8_t kSetRepeaterOffset  = 0x0D;
+inline constexpr std::uint8_t kDuplex       = 0x0F;
 inline constexpr std::uint8_t kLevel        = 0x14;   // sub-addressed levels
 inline constexpr std::uint8_t kMeter        = 0x15;   // sub-addressed meters
 inline constexpr std::uint8_t kFunction     = 0x16;   // sub-addressed on/off functions
+inline constexpr std::uint8_t kTone         = 0x1B;   // repeater tone/code registers
 inline constexpr std::uint8_t kPower        = 0x18;   // 00 off, 01 on
 inline constexpr std::uint8_t kReadId       = 0x19;   // sub 00: read transceiver ID
 inline constexpr std::uint8_t kSetting      = 0x1A;   // memory / filter / SET menu
@@ -282,7 +286,20 @@ inline constexpr std::uint8_t kManualNotch   = 0x48;
 inline constexpr std::uint8_t kManualNotchWidth = 0x57;
 inline constexpr std::uint8_t kBreakIn       = 0x47;   // 00 off, 01 semi, 02 full
 inline constexpr std::uint8_t kDialLock      = 0x50;
+inline constexpr std::uint8_t kRepeaterAccess = 0x5D;
 }  // namespace func
+
+namespace tone {
+inline constexpr std::uint8_t kTxCtcss = 0x00;
+inline constexpr std::uint8_t kRxCtcss = 0x01;
+inline constexpr std::uint8_t kDtcs    = 0x02;
+}
+
+struct ToneRegister {
+    int value = 0;  // CTCSS tenths-of-Hz or the three-digit DTCS code
+    bool txReverse = false;
+    bool rxReverse = false;
+};
 
 // SET-menu items reached through 1A 05 <two BCD bytes>.
 //
@@ -293,7 +310,8 @@ inline constexpr std::uint8_t kDialLock      = 0x50;
 // is no error anywhere: the transmit path is working perfectly into a modulator
 // that is listening somewhere else.
 namespace setting {
-inline constexpr int kVoxDelay        = 359;   // 00..20, in 0.1 s steps
+// IC-9700 CI-V guide p.12: SET > Function > VOX DELAY.
+inline constexpr int kVoxDelay        = 330;   // 00..20, in 0.1 s steps
 }  // namespace setting
 
 // Read or write a 1A 05 SET-menu item. `item` is the DECIMAL menu number as
@@ -439,6 +457,22 @@ struct VfoModeState {
 [[nodiscard]] std::vector<std::uint8_t> cmdReadFunction(std::uint8_t to, std::uint8_t which);
 [[nodiscard]] std::vector<std::uint8_t> cmdSetFunction(std::uint8_t to, std::uint8_t which,
                                                         int value);
+[[nodiscard]] std::vector<std::uint8_t> cmdReadRepeaterAccess(std::uint8_t to);
+[[nodiscard]] std::vector<std::uint8_t> cmdSetRepeaterAccess(std::uint8_t to,
+                                                              std::uint8_t mode);
+[[nodiscard]] std::vector<std::uint8_t> cmdReadTone(std::uint8_t to, std::uint8_t which);
+[[nodiscard]] std::vector<std::uint8_t> cmdSetTone(std::uint8_t to, std::uint8_t which,
+                                                   int value, bool txReverse = false,
+                                                   bool rxReverse = false);
+[[nodiscard]] std::optional<ToneRegister> decodeTone(std::span<const std::uint8_t> payload);
+[[nodiscard]] std::vector<std::uint8_t> cmdReadRepeaterOffset(std::uint8_t to);
+[[nodiscard]] std::vector<std::uint8_t> cmdSetRepeaterOffset(std::uint8_t to,
+                                                              std::uint64_t hz);
+[[nodiscard]] std::optional<std::uint64_t>
+decodeRepeaterOffset(std::span<const std::uint8_t> payload);
+[[nodiscard]] std::vector<std::uint8_t> cmdReadDuplex(std::uint8_t to);
+[[nodiscard]] std::vector<std::uint8_t> cmdSetDuplex(std::uint8_t to,
+                                                      std::uint8_t mode);
 [[nodiscard]] std::vector<std::uint8_t> cmdSetPtt(std::uint8_t to, bool transmit);
 // Attenuator. `db` is the dB figure the radio prints (0 or 20 on an
 // IC-705), encoded as one BCD byte. The read form carries no payload.
@@ -453,6 +487,7 @@ struct VfoModeState {
 [[nodiscard]] std::vector<std::uint8_t> cmdReadId(std::uint8_t to);
 [[nodiscard]] std::vector<std::uint8_t> cmdScopeOnOff(std::uint8_t to, bool on);
 [[nodiscard]] std::vector<std::uint8_t> cmdScopeDataOutput(std::uint8_t to, bool on);
+[[nodiscard]] std::vector<std::uint8_t> cmdScopeMainSub(std::uint8_t to, bool sub);
 [[nodiscard]] std::vector<std::uint8_t> cmdScopeMode(std::uint8_t to, bool fixed);
 [[nodiscard]] std::vector<std::uint8_t> cmdScopeSpan(std::uint8_t to, int spanHz);
 [[nodiscard]] std::vector<std::uint8_t> cmdScopeReference(std::uint8_t to, double db);

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -1,4 +1,5 @@
 #include "core/backends/icom/IcomCivBackend.h"
+#include "models/FmRepeaterValues.h"
 
 #include <QDateTime>
 #include <QLoggingCategory>
@@ -9,6 +10,7 @@
 #include <array>
 #include <cmath>
 #include <functional>
+#include <limits>
 #include <optional>
 
 #include "core/backends/icom/IcomControls.h"
@@ -113,12 +115,22 @@ RadioCapabilities IcomCivBackend::capabilities() const
                                       : m_deviceName;
 
     c.maxSlices = m.receivers;
-    c.maxPanadapters = m.hasScope ? m.receivers : 0;
+    // The IC-9700 has MAIN/SUB receivers, but its CI-V scope is one shared
+    // hardware display aperture. MAIN/SUB selection (phase 2) must not be
+    // advertised as two independently placeable panadapters.
+    c.maxPanadapters = m.hasScope ? (m.civAddress == 0xA2 ? 1 : m.receivers) : 0;
     c.tuningMinHz = static_cast<double>(m.tuningMinHz);
     c.tuningMaxHz = static_cast<double>(m.tuningMaxHz);
 
     c.canTransmit = m.hasTransmit;
     c.txPowerMaxWatts = m.txPowerMaxWatts;
+    if (m.civAddress == 0xA2) {
+        c.txPowerBands = {
+            {144'000'000.0, 148'000'000.0, 100.0},
+            {430'000'000.0, 450'000'000.0, 75.0},
+            {1'240'000'000.0, 1'300'000'000.0, 10.0},
+        };
+    }
 
     // The scope scale is OURS, not the radio's: it comes from ScopeCalibration
     // (floor/span, shifted by the radio's own reference level), and there is no
@@ -164,6 +176,16 @@ RadioCapabilities IcomCivBackend::capabilities() const
     c.hasGpsLocation = false;
 
     c.hasSupplyVoltageTelemetry = true;   // 0x15 0x15 Vd
+    // The IC-9700 CI-V meter set reports supply voltage, but exposes neither
+    // PA heatsink temperature nor fan RPM.
+    c.hasPaTemperatureTelemetry = false;
+    c.hasMainFanTelemetry = false;
+    // Only publish a scale where the model's current conversion is verified.
+    // A guessed gauge is worse than no gauge: it gives an authoritative-looking
+    // but potentially unsafe reading for every other Icom model.
+    c.paCurrentMaxAmps = m.civAddress == 0xB6 ? 25.0
+                         : m.civAddress == 0xA2 ? 20.0
+                         : m.civAddress == 0xA4 ? 4.0 : 0.0;
 
     // THE ATU BUTTON IS REACHABLE AGAIN.
     //
@@ -178,12 +200,44 @@ RadioCapabilities IcomCivBackend::capabilities() const
     // So: offered, and honest about the outcome rather than about the hardware.
     // A start on a radio with no tuner reports NONE and the button returns to
     // rest, which is a better answer than a control that is not there.
-    c.hasTuner = m.hasTransmit;
+    c.hasTuner = m.hasTuner;
 
     // The radio chooses its own modulation input from its own menu (MOD Input
     // > DATA MOD, which must be WLAN for us to be heard at all). A client
     // cannot pick MIC / BAL / LINE / ACC, so the Phone applet collapses to PC.
     c.hasSelectableMicInputs = false;
+    if (m.civAddress == 0xA2) {
+        c.hasExtendedFmRepeaterControls = true;
+        c.hasSelectableMicInputs = true;
+        c.micInputChoices = {QStringLiteral("MIC"), QStringLiteral("ACC"),
+                             QStringLiteral("MIC+ACC"), QStringLiteral("USB"),
+                             QStringLiteral("MIC+USB"), QStringLiteral("PC")};
+    } else {
+        c.micInputChoices = {QStringLiteral("PC")};
+    }
+    c.hasDownwardExpander = false;
+    c.hasContinuousSpeechProcessorLevel = m.civAddress == 0xA2;
+    if (m.civAddress == 0xA2) {
+        c.speechProcessorModes = {QStringLiteral("USB"), QStringLiteral("LSB")};
+        c.fmRepeaterAccessModes = {
+            QStringLiteral("off"), QStringLiteral("ctcss_tx"),
+            QStringLiteral("ctcss_rx"), QStringLiteral("ctcss_txrx"),
+            QStringLiteral("dtcs_tx"), QStringLiteral("dtcs_txrx"),
+            QStringLiteral("ctcss_tx_dtcs_rx"),
+            QStringLiteral("dtcs_tx_ctcss_rx")};
+    } else {
+        // Preserve the pre-IC-9700 Icom surface until the richer command set is
+        // verified against each model rather than borrowing the 9700 map.
+        c.fmRepeaterAccessModes = {QStringLiteral("off"),
+                                   QStringLiteral("ctcss_tx")};
+    }
+    // VOX enable/gain are mapped. The model-specific delay SET item and
+    // arbitrary TX passband edges are not, so their UI must remain absent.
+    c.hasVoxDelayControl = m.civAddress == 0xA2;
+    c.hasTxFilterControl = false;
+    // Only the verified IC-7300MK2 map exposes ANT1/RX-ANT selection. The
+    // IC-9700's band-specific sockets are fixed hardware, not a menu choice.
+    c.hasSelectableRxAntenna = m.civAddress == 0xB6;
 
     // THREE, and only three — and WHICH three depends on the mode. FIL1 is
     // 3.0 kHz in SSB, 1.2 kHz in CW, 9 kHz in AM and 15 kHz in FM, so a single
@@ -206,6 +260,7 @@ RadioCapabilities IcomCivBackend::capabilities() const
     c.hasWaveforms = false;
     c.hasMultiClientSessions = false;
     c.hasRadioSideWaterfallAutoBlack = false;
+    c.preservesWaterfallHistoryOnLargeRetune = m.civAddress != 0xA2;
     c.persistsMemories = false;
 
     // A one-way trip over WiFi: 0x18 0x00 powers the radio off, which drops the
@@ -223,6 +278,24 @@ RadioCapabilities IcomCivBackend::capabilities() const
 }
 
 void IcomCivBackend::publishCapabilities() { emit capabilitiesChanged(); }
+
+void IcomCivBackend::publishRadioIdentity()
+{
+    RadioDelta radio;
+    const QString modelName = QString::fromUtf8(m_model->name.data(),
+                                                static_cast<int>(m_model->name.size()));
+    radio.model = modelName;
+    // This is the radio's default display identity, not the RS-BA1 client
+    // station name. Keep it in RadioDelta so a future radio chooser can
+    // replace it with a user-defined, per-radio nickname without changing the
+    // status-bar wiring.
+    radio.nickname = m_model == &unknownModel() ? QStringLiteral("Icom") : modelName;
+    const std::string_view bands = declaredBandsFor(*m_model);
+    // Present even when empty so an identity correction cannot leave the
+    // previous model's exact band set cached in RadioModel.
+    radio.bandsRaw = QString::fromUtf8(bands.data(), static_cast<int>(bands.size()));
+    emit radioChanged(radio);
+}
 
 void IcomCivBackend::publishScopeDbmRange()
 {
@@ -302,6 +375,8 @@ void IcomCivBackend::publishModeState()
 void IcomCivBackend::connectRadio(const RadioConnectRequest& request)
 {
     disconnectRadio();
+    m_staleSessionRetries = 0;
+    m_pendingSessionNotBeforeMs = 0;
 
     IcomSession::Params p;
     p.host = QHostAddress(request.host);
@@ -338,6 +413,14 @@ void IcomCivBackend::connectRadio(const RadioConnectRequest& request)
     m_civAmbiguous = false;
     m_connectBurstSent = false;
     m_modelByName = nullptr;
+    m_lastInboundCivAtMs = 0;
+    m_lastOutboundCivAtMs = 0;
+    m_lastOutboundCiv.clear();
+    m_civStallReported = false;
+    m_civRecoveryStartedAtMs = 0;
+    m_lastCivRecoveryAttemptAtMs = 0;
+    m_civRecoveryAttempts = 0;
+    m_civRecoveryProbeSent = false;
     // 48 kHz, FIXED — the rate is deliberately not negotiable here.
     //
     // It is tempting on a weak link: 48 kHz LPCM is ~768 kbps each way, and a
@@ -359,19 +442,61 @@ void IcomCivBackend::connectRadio(const RadioConnectRequest& request)
     m_audioRateHz = kRadioAudioRateHz;
     p.sampleRateHz = static_cast<quint32>(m_audioRateHz);
 
+    if (m_session && m_session->isStopping()) {
+        m_pendingSessionStart = p;
+        m_pendingSessionNotBeforeMs = 0;
+        return;
+    }
+    startSession(p);
+}
+
+void IcomCivBackend::startSession(const IcomSession::Params& p)
+{
+    m_activeSessionParams = p;
     m_session = std::make_unique<IcomSession>();
     connect(m_session.get(), &IcomSession::connected, this, &IcomCivBackend::onSessionConnected);
     connect(m_session.get(), &IcomSession::disconnected, this,
             &IcomCivBackend::onSessionDisconnected);
     connect(m_session.get(), &IcomSession::civFrameReady, this, &IcomCivBackend::onCivFrame);
     connect(m_session.get(), &IcomSession::audioReady, this, &IcomCivBackend::onAudio);
+    connect(m_session.get(), &IcomSession::shutdownFinished,
+            this, &IcomCivBackend::onSessionShutdownFinished,
+            Qt::QueuedConnection);
 
     if (!m_session->start(p))
         emit connectionError(QStringLiteral("could not open the Icom session"));
 }
 
+void IcomCivBackend::onSessionShutdownFinished()
+{
+    m_session.reset();
+    startPendingSessionWhenReady();
+}
+
+void IcomCivBackend::startPendingSessionWhenReady()
+{
+    if (!m_pendingSessionStart) {
+        return;
+    }
+    if (m_session && m_session->isStopping()) {
+        return;
+    }
+    const qint64 remainingMs = m_pendingSessionNotBeforeMs - nowMs();
+    if (remainingMs > 0) {
+        QTimer::singleShot(static_cast<int>(remainingMs), this,
+                           &IcomCivBackend::startPendingSessionWhenReady);
+        return;
+    }
+    const IcomSession::Params params = *m_pendingSessionStart;
+    m_pendingSessionStart.reset();
+    m_pendingSessionNotBeforeMs = 0;
+    startSession(params);
+}
+
 void IcomCivBackend::disconnectRadio()
 {
+    m_pendingSessionStart.reset();
+    m_pendingSessionNotBeforeMs = 0;
     // Teardown is not allowed to wait for an ordinary outstanding read.  Drop
     // all background work, fail-safe unkey on every connected disconnect, and
     // restore the operator's RF-power setpoint if TUNE had borrowed it.  These
@@ -390,6 +515,10 @@ void IcomCivBackend::disconnectRadio()
         pumpCiv(now);
         pumpCiv(now);
     }
+    if (m_connected || m_keyed) {
+        m_meters.setTransmitting(false);
+        publishIdleTxMeters();
+    }
 
     for (QTimer** t : {&m_meterTimer, &m_linkTimer, &m_civDetectTimer}) {
         if (*t) {
@@ -400,12 +529,19 @@ void IcomCivBackend::disconnectRadio()
     }
     if (m_session) {
         m_session->stop();
-        m_session.reset();
+        if (!m_session->isStopping()) {
+            m_session.reset();
+        }
     }
     m_rxResampler.reset();
     m_scope.reset();
     m_meters.reset();
     m_civScheduler.reset();
+    m_civRecoveryStartedAtMs = 0;
+    m_lastCivRecoveryAttemptAtMs = 0;
+    m_civRecoveryAttempts = 0;
+    m_civRecoveryProbeSent = false;
+    m_civStallReported = false;
     m_schedulerTimeoutsReported = 0;
     serviceSchedulerWaiters(nowMs());
     m_pendingPttIntent.reset();
@@ -443,6 +579,11 @@ void IcomCivBackend::disconnectRadio()
 }
 
 bool IcomCivBackend::isConnected() const { return m_connected; }
+
+bool IcomCivBackend::shutdownPending() const
+{
+    return m_session && m_session->isStopping();
+}
 
 // The connect-edge read burst.
 //
@@ -504,6 +645,9 @@ void IcomCivBackend::sendConnectReadBurst()
             }
         }
     }
+    if (m_model->civAddress == 0xA2) {
+        queueStartupRead(cmdReadSetting(m_session->civAddress(), setting::kVoxDelay));
+    }
 
     // ADOPT THE RADIO'S OWN LEVELS. Constitution II/III says an Icom is
     // authoritative over its operating state and the client must never push a
@@ -535,10 +679,22 @@ void IcomCivBackend::sendConnectReadBurst()
     // RIT / XIT and the antenna tuner. All four were write-only: the controls
     // opened at OUR defaults, so an operator who set RIT on the radio and
     // reconnected saw zero on a rig that was still offset.
-    for (std::uint8_t sub : {tuneOffset::kFrequency, tuneOffset::kRitOnOff,
-                             tuneOffset::kXitOnOff})
-        queueStartupRead(cmdReadTuneOffset(m_session->civAddress(), sub));
-    queueStartupRead(cmdReadTuner(m_session->civAddress()));
+    // They are outside the IC-9700 basic-functionality surface. In particular,
+    // its XIT and tuner reads answer FA, so polling them only burns CI-V slots.
+    if (m_model->civAddress != 0xA2) {
+        for (std::uint8_t sub : {tuneOffset::kFrequency, tuneOffset::kRitOnOff,
+                                 tuneOffset::kXitOnOff})
+            queueStartupRead(cmdReadTuneOffset(m_session->civAddress(), sub));
+        queueStartupRead(cmdReadTuner(m_session->civAddress()));
+    }
+    if (m_model->civAddress == 0xA2) {
+        queueStartupRead(cmdReadRepeaterOffset(m_session->civAddress()));
+        queueStartupRead(cmdReadDuplex(m_session->civAddress()));
+        queueStartupRead(cmdReadRepeaterAccess(m_session->civAddress()));
+        for (std::uint8_t sub : {tone::kTxCtcss, tone::kRxCtcss, tone::kDtcs}) {
+            queueStartupRead(cmdReadTone(m_session->civAddress(), sub));
+        }
+    }
 }
 
 // The radio answered 0x19 0x00. Decide whether to believe it, and where that
@@ -623,10 +779,7 @@ void IcomCivBackend::adoptReportedCivAddress(std::uint8_t reported)
                 applyScopeStartup();
             }
             publishCapabilities();
-            RadioDelta r;
-            r.model = QString::fromUtf8(m_model->name.data(),
-                                        static_cast<int>(m_model->name.size()));
-            emit radioChanged(r);
+            publishRadioIdentity();
         }
         return;
     }
@@ -889,6 +1042,7 @@ void IcomCivBackend::onSessionConnected(const QString& deviceName)
     // against a one-slice radio) and why txSlice never took.
     emit connected();
     publishCapabilities();
+    publishRadioIdentity();
 
     // THE PAN FIRST, then the slice that names it.
     //
@@ -1023,8 +1177,23 @@ void IcomCivBackend::onSessionDisconnected(const QString& reason)
 
     if (was)
         emit disconnected();
-    if (!reason.isEmpty())
+    if (reason.startsWith(QStringLiteral("the previous IC-9700 network session is still closing"))
+        && m_activeSessionParams && m_staleSessionRetries < 3) {
+        ++m_staleSessionRetries;
+        m_pendingSessionStart = *m_activeSessionParams;
+        m_pendingSessionNotBeforeMs = nowMs() + 5000;
+        qCWarning(lcIcomLink) << "IC-9700 previous-session sentinel during login; retrying in 5s"
+                              << "attempt" << m_staleSessionRetries << "of 3";
+        // This is an expected RS-BA1 lifecycle race, not a rejected password.
+        // Keep the supplied (non-persisted) credentials in this backend and
+        // retry without presenting a false error to the operator.
+        QTimer::singleShot(5000, this,
+                           &IcomCivBackend::startPendingSessionWhenReady);
+        return;
+    }
+    if (!reason.isEmpty()) {
         emit connectionError(reason);
+    }
 }
 
 void IcomCivBackend::checkModInput()
@@ -1098,6 +1267,15 @@ void IcomCivBackend::applyScopeStartup()
                IcomCivScheduler::Priority::Maintenance, false);
     queueWrite(cmdScopeDataOutput(m_session->civAddress(), true), "scope.output",
                IcomCivScheduler::Priority::Maintenance, false);
+    // IC-9700 has independent MAIN/SUB scope sources. Live-radio testing of
+    // the reference client selects MAIN explicitly with 27 12 00; without it
+    // AetherSDR can inherit SUB from the front panel and paint another receiver's sweep
+    // under the MAIN VFO.  Keep this model-gated: single-receiver Icoms need no
+    // such write, and their response to 27 12 has not been attested.
+    if (m_model->civAddress == 0xA2) {
+        queueWrite(cmdScopeMainSub(m_session->civAddress(), false), "scope.main",
+                   IcomCivScheduler::Priority::Maintenance, false);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1106,9 +1284,37 @@ void IcomCivBackend::applyScopeStartup()
 
 void IcomCivBackend::onCivFrame(const CivFrame& frame)
 {
+    // Scope traffic proves that the serial data pipe reopened, but not that
+    // ordinary CI-V requests are being answered. Ask for one cheap frequency
+    // read and retain the bounded recovery budget until its reply arrives.
+    const bool scopeFrame = frame.cmd == cmd::kScope && frame.hasSub
+        && frame.sub == scope::kWaveData;
+    if (m_civRecoveryStartedAtMs > 0) {
+        const bool probeWasSent = m_civRecoveryProbeSent;
+        if (!m_civRecoveryProbeSent && m_session) {
+            m_civRecoveryProbeSent = true;
+            const auto probe = cmdReadFrequency(m_session->civAddress());
+            queueRead(probe, semanticKey(probe),
+                      IcomCivScheduler::Priority::Maintenance);
+            pumpCiv(nowMs());
+        }
+        if (!scopeFrame && probeWasSent && frame.cmd == cmd::kReadFreq) {
+            qCInfo(lcIcomLink)
+                << "CI-V command plane verified after targeted data restart";
+            m_civRecoveryStartedAtMs = 0;
+            m_lastCivRecoveryAttemptAtMs = 0;
+            m_civRecoveryAttempts = 0;
+            m_civRecoveryProbeSent = false;
+            m_civStallReported = false;
+        }
+    }
+
     // Scope first: it is by far the highest-rate frame, and the decoder already
     // rejects anything that is not waveform data.
     if (auto sweep = m_scope.feed(frame)) {
+        if (sweep->receiver != 0x00) {
+            return;   // slice 0 is MAIN; dual-receiver support is future scope
+        }
         ScopeGeometry geom;
         geom.points = m_model->scopePoints ? m_model->scopePoints : kScopePointsIc705;
         geom.maxAmplitude = m_model->scopeMaxAmplitude ? m_model->scopeMaxAmplitude
@@ -1233,10 +1439,7 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
                 // known just now has not had them sent. No-op once started.
                 applyScopeStartup();
             }
-            RadioDelta r;
-            r.model = QString::fromUtf8(m_model->name.data(),
-                                        static_cast<int>(m_model->name.size()));
-            emit radioChanged(r);
+            publishRadioIdentity();
         }
         pumpCiv(frameAtMs);
         return;
@@ -1322,6 +1525,32 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
     // this branch, on a dozen sibling rows. The header's own claim — "a radio
     // that disagrees corrects these through the ordinary decode path" — is what
     // these assignments make true.
+    case cmd::kReadRepeaterOffset: {
+        const auto hz = decodeRepeaterOffset(frame.data);
+        if (!hz) {
+            return;
+        }
+        SliceDelta d;
+        d.fmRepeaterOffsetFreq = static_cast<double>(*hz) / 1.0e6;
+        emit sliceChanged(sliceId(), d);
+        return;
+    }
+
+    case cmd::kDuplex: {
+        if (frame.data.size() != 1) {
+            return;
+        }
+        SliceDelta d;
+        switch (frame.data[0]) {
+        case 0x10: d.repeaterOffsetDir = QStringLiteral("simplex"); break;
+        case 0x11: d.repeaterOffsetDir = QStringLiteral("down"); break;
+        case 0x12: d.repeaterOffsetDir = QStringLiteral("up"); break;
+        default: return;
+        }
+        emit sliceChanged(sliceId(), d);
+        return;
+    }
+
     case cmd::kLevel: {
         if (!frame.hasSub)
             return;
@@ -1478,13 +1707,53 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
             // The PREAMP control, not the RF-gain slider. It used to publish
             // into SliceDelta::rfGain, which is what made a three-position
             // switch look like a gain reading.
-            m_preampStep = std::clamp(v, 0, 2);
+            const int lastStep = m_model
+                ? std::max(0, static_cast<int>(preampLabelsFor(*m_model).size()) - 1)
+                : 0;
+            m_preampStep = std::clamp(v, 0, lastStep);
             emit panPreampChanged(panId(), m_preampStep);
+            return;
+        }
+        case func::kRepeaterAccess: {
+            static const std::array<const char*, 10> modes{
+                "off", "ctcss_tx", "ctcss_rx", "dtcs_txrx", nullptr, nullptr,
+                "dtcs_tx", "ctcss_tx_dtcs_rx", "dtcs_tx_ctcss_rx", "ctcss_txrx"};
+            if (v < 0 || v >= static_cast<int>(modes.size()) || modes[v] == nullptr) {
+                return;
+            }
+            SliceDelta d;
+            d.fmToneMode = QString::fromLatin1(modes[v]);
+            emit sliceChanged(sliceId(), d);
             return;
         }
         default:
             return;
         }
+    }
+
+    case cmd::kTone: {
+        if (!frame.hasSub) {
+            return;
+        }
+        const auto value = decodeTone(frame.data);
+        if (!value) {
+            return;
+        }
+        SliceDelta d;
+        if (frame.sub == tone::kTxCtcss) {
+            d.fmToneTxValue = value->value / 10.0;
+            d.fmToneValue = *d.fmToneTxValue;
+        } else if (frame.sub == tone::kRxCtcss) {
+            d.fmToneRxValue = value->value / 10.0;
+        } else if (frame.sub == tone::kDtcs) {
+            d.fmDtcsCode = value->value;
+            d.fmDtcsTxReverse = value->txReverse;
+            d.fmDtcsRxReverse = value->rxReverse;
+        } else {
+            return;
+        }
+        emit sliceChanged(sliceId(), d);
+        return;
     }
 
     case cmd::kAttenuator: {
@@ -1550,11 +1819,34 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
         if (!frame.hasSub || frame.sub != 0x05 || frame.data.size() < 3)
             return;
         const int item = decodeBcdByte(frame.data[0]) * 100 + decodeBcdByte(frame.data[1]);
+        if (m_model->civAddress == 0xA2 && item == setting::kVoxDelay) {
+            const int tenths = decodeBcdByte(frame.data[2]);
+            m_voxDelayMs = std::clamp(tenths, 0, 20) * 100;
+            TransmitDelta t;
+            // TransmitModel's 0..100 scale represents 0..2000 ms.
+            t.voxDelay = m_voxDelayMs / 20;
+            emit transmitChanged(t);
+            return;
+        }
         const auto mod = modulationProfileFor(*m_model);
         if (!mod)
             return;
         if (item == mod->dataOffInputItem) {
             m_dataOffModInput = frame.data[2];
+            for (const ModulationInputChoice& choice : mod->choices) {
+                if (choice.value != m_dataOffModInput) {
+                    continue;
+                }
+                QString label = QString::fromUtf8(choice.label.data(),
+                                                  static_cast<int>(choice.label.size())).toUpper();
+                if (label == QLatin1String("LAN") || label == QLatin1String("WLAN")) {
+                    label = QStringLiteral("PC");
+                }
+                TransmitDelta t;
+                t.micSelection = label;
+                emit transmitChanged(t);
+                break;
+            }
         } else if (item == mod->dataInputItem) {
             m_dataModInput = frame.data[2];
         } else {
@@ -1603,7 +1895,8 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
         m_meters.markAnswered(spec->id, nowMs());
         const double value = meterValue(spec->id, *raw,
                                         s9ReferenceFor(m_frequencyHz),
-                                        m_model ? m_model->civAddress : 0xA4);
+                                        m_model ? m_model->civAddress : 0xA4,
+                                        m_frequencyHz);
 
         if (spec->id == MeterId::Overflow) {
             m_overflow = value > 0.5;
@@ -1628,6 +1921,15 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
     case cmd::kControl: {
         if (frame.hasSub && frame.sub == control::kPtt && !frame.data.empty()) {
             const bool keyed = frame.data[0] != 0;
+            // A newer PTT write supersedes a read that was already on the
+            // wire. The scheduler has generation-checked that ordering, so
+            // reject the old answer in BOTH directions before applying the
+            // fail-closed pending-intent policy below. This does not hide a
+            // fresh failed-unkey report; only a provably pre-intent read is
+            // classified Stale.
+            if (observation == IcomCivScheduler::Observation::Stale) {
+                return;
+            }
             // A read can already be on the wire when the operator keys.  Its
             // pre-write OFF answer then arrives after the newer ON request.
             // During the bounded confirmation window only the requested value
@@ -1665,8 +1967,6 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
                 }
                 m_pendingPttIntent.reset();
                 m_pendingPttUntilMs = 0;
-            } else if (observation == IcomCivScheduler::Observation::Stale) {
-                return;
             }
             // ON CHANGE ONLY. This is the answer to a poll that runs four times
             // a second, and it used to republish the transmit state on every
@@ -1681,6 +1981,9 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame)
                 return;
             m_keyed = keyed;
             m_meters.setTransmitting(m_keyed);
+            if (!m_keyed) {
+                publishIdleTxMeters();
+            }
             TransmitDelta t;
             t.mox = m_keyed;
             emit transmitChanged(t);
@@ -1938,6 +2241,10 @@ IcomCivBackend::confirmationFor(std::span<const std::uint8_t> frame) const
         return cmdReadFrequency(addr);
     case cmd::kSetMode:
         return cmdReadMode(addr);
+    case cmd::kSetRepeaterOffset:
+        return cmdReadRepeaterOffset(addr);
+    case cmd::kDuplex:
+        return cmdReadDuplex(addr);
     case cmd::kVfoMode:
         return cmdReadVfoMode(addr);
     case cmd::kLevel:
@@ -2127,10 +2434,25 @@ void IcomCivBackend::sendUserCommand(const std::vector<std::uint8_t>& frame)
 
 void IcomCivBackend::setSliceFrequency(int, double hz)
 {
-    if (hz <= 0.0)
+    if (!std::isfinite(hz) || hz <= 0.0
+        || hz > static_cast<double>(std::numeric_limits<std::uint64_t>::max())) {
+        emit configurationWarning(QStringLiteral("Invalid frequency request."));
         return;
+    }
+    const std::uint64_t requestedHz = static_cast<std::uint64_t>(std::llround(hz));
+    if (m_model->tuningMaxHz > m_model->tuningMinHz
+        && !supportsFrequency(*m_model, requestedHz)) {
+        emit configurationWarning(
+            QStringLiteral("%1 MHz is outside the %2 tuning range (%3–%4 MHz).")
+                .arg(hz / 1.0e6, 0, 'f', 6)
+                .arg(QString::fromUtf8(m_model->name.data(),
+                                       static_cast<int>(m_model->name.size())))
+                .arg(static_cast<double>(m_model->tuningMinHz) / 1.0e6, 0, 'f', 3)
+                .arg(static_cast<double>(m_model->tuningMaxHz) / 1.0e6, 0, 'f', 3));
+        return;
+    }
     sendUserCommand(cmdSetFrequency(m_session ? m_session->civAddress() : 0xA4,
-                                    static_cast<std::uint64_t>(std::llround(hz))));
+                                    requestedHz));
 }
 
 void IcomCivBackend::setSliceMode(int, const QString& mode)
@@ -2427,7 +2749,10 @@ void IcomCivBackend::setPanRfGain(const QString&, int gainDb)
 void IcomCivBackend::setPanPreamp(const QString&, int step)
 {
     // Clamp, never refuse — the seam's rule for every stepped control.
-    const int wanted = std::clamp(step, 0, 2);
+    const int lastStep = m_model
+        ? std::max(0, static_cast<int>(preampLabelsFor(*m_model).size()) - 1)
+        : 0;
+    const int wanted = std::clamp(step, 0, lastStep);
     m_preampStep = wanted;
     sendUserCommand(cmdSetFunction(m_session ? m_session->civAddress() : 0xA4,
                                    func::kPreamp, wanted));
@@ -2479,13 +2804,18 @@ void IcomCivBackend::setSpeechProcessor(bool on, int level)
     if (!on)
         return;   // the level is meaningless while the compressor is bypassed
 
-    // NOR / DX / DX+ onto the radio's 0..10 scale. Icom publishes no mapping —
-    // these are thirds of its range, which is the honest reading of a
-    // three-position control against a continuous one, and they are here rather
-    // than open-coded so the choice is visible and adjustable.
-    static constexpr std::array<int, 3> kProcLevels{3, 6, 9};   // of 10
-    const int preset = std::clamp(level, 0, 2);
-    const int raw = kProcLevels[static_cast<std::size_t>(preset)] * 255 / 10;
+    int raw = 0;
+    if (m_model && m_model->civAddress == 0xA2) {
+        // IC-9700 exposes a continuous 0..10 setting. The seam carries it as
+        // 0..100 percent rather than inventing SmartSDR preset names.
+        raw = percentToLevelRaw(std::clamp(level, 0, 100));
+    } else {
+        // Preserve the established three-position mapping for other Icoms
+        // until their UI/control maps are individually attested.
+        static constexpr std::array<int, 3> kProcLevels{3, 6, 9};
+        raw = kProcLevels[static_cast<std::size_t>(std::clamp(level, 0, 2))]
+            * 255 / 10;
+    }
     sendUserCommand(cmdSetLevel(addr, level::kCompLevel, raw));
 }
 
@@ -2495,6 +2825,38 @@ void IcomCivBackend::setMicGain(int gainPercent)
     m_micGainReported = true;
     sendUserCommand(cmdSetLevel(m_session ? m_session->civAddress() : 0xA4,
                                 level::kMicGain, percentToLevelRaw(gainPercent)));
+}
+
+void IcomCivBackend::setMicInput(const QString& input)
+{
+    if (!m_model) {
+        return;
+    }
+    const auto mod = modulationProfileFor(*m_model);
+    if (!mod) {
+        return;
+    }
+    const QString requested = input.trimmed().toUpper();
+    int value = -1;
+    for (const ModulationInputChoice& choice : mod->choices) {
+        QString label = QString::fromUtf8(choice.label.data(),
+                                          static_cast<int>(choice.label.size())).toUpper();
+        if (label == QLatin1String("LAN") || label == QLatin1String("WLAN")) {
+            label = QStringLiteral("PC");
+        }
+        if (label == requested) {
+            value = choice.value;
+            break;
+        }
+    }
+    if (value < 0) {
+        return;
+    }
+    m_dataOffModInput = value;
+    sendUserCommand(cmdWriteSetting(m_session ? m_session->civAddress()
+                                              : m_model->civAddress,
+                                    mod->dataOffInputItem,
+                                    static_cast<std::uint8_t>(value)));
 }
 
 void IcomCivBackend::setTxAudioMonitor(bool on)
@@ -2594,14 +2956,11 @@ void IcomCivBackend::setSliceAudioGain(int, int gainPercent)
 // (14 16) — the same two-register shape the speech processor has, and the same
 // reason both arrive together.
 //
-// THE DELAY IS NOT HERE. The guide puts VOX DELAY in the SET menu at
-// 1A 05 0359 in 0.1 s steps, and 14 17 is the ANTI-vox gain, which is a third
-// control again. Writing a delay we were handed in milliseconds into a menu
-// item measured in tenths would be an invented conversion on a setting the
-// operator may have deliberately chosen, so it is left alone and said so.
+// Delay is the IC-9700's SET item 1A 05 0330, in 0.1 s steps. TransmitModel's
+// 0..100 slider represents 0..2000 ms, so five slider points are one wire step.
+// 14 17 remains ANTI-VOX gain and must not be conflated with this setting.
 void IcomCivBackend::setVox(bool on, int level, int delayMs)
 {
-    Q_UNUSED(delayMs);
     const std::uint8_t addr = m_session ? m_session->civAddress() : 0xA4;
     m_voxOn = on;
     m_voxLevelPercent = level;
@@ -2612,6 +2971,12 @@ void IcomCivBackend::setVox(bool on, int level, int delayMs)
     // The level slider is an explicit operator intent even while VOX is off:
     // the register survives disable and determines the next enable threshold.
     sendUserCommand(cmdSetLevel(addr, level::kVoxGain, percentToLevelRaw(level)));
+    if (m_model && m_model->civAddress == 0xA2) {
+        const int sliderValue = std::clamp(delayMs, 0, 100);
+        m_voxDelayMs = sliderValue * 20;
+        sendUserCommand(cmdWriteSetting(addr, setting::kVoxDelay,
+                                        encodeBcdByte((sliderValue + 2) / 5)));
+    }
 }
 
 // THE ANTENNA TUNER, and it keys.
@@ -2665,6 +3030,13 @@ void IcomCivBackend::setKeying(bool key)
 {
     if (!m_model->hasTransmit)
         return;   // an unknown radio is not advertised as transmit-capable
+    if (key) {
+        // Entering the high-rate TX-meter regime must not inherit a receive-
+        // side reconciliation backlog. Preserve any operator/PTT/meter work;
+        // only periodic background reads are disposable and will be rebuilt
+        // from radio state after unkey.
+        m_civScheduler.dropBackground();
+    }
     m_pendingPttIntent = key;
     m_pendingPttUntilMs = nowMs() + 1000;
     sendUserCommand(cmdSetPtt(m_session ? m_session->civAddress() : 0xA4, key));
@@ -2682,8 +3054,15 @@ void IcomCivBackend::setKeying(bool key)
         emit transmitChanged(t);
     }
     m_meters.setTransmitting(key);
-    if (!key && m_session)
-        m_session->flushTxAudio();   // queued audio belongs to the transmission that ended
+    if (!key) {
+        // Our own PTT intent updates m_keyed before the status poll arrives, so
+        // the poll's unchanged-state guard cannot be relied on to publish the
+        // idle samples. Clear every TX-only face at this edge as well.
+        publishIdleTxMeters();
+        if (m_session) {
+            m_session->flushTxAudio();   // audio belongs to the transmission that ended
+        }
+    }
 }
 
 void IcomCivBackend::setTune(bool on, int tunePowerPercent)
@@ -2885,8 +3264,22 @@ QVariantList IcomCivBackend::meterMap() const
         r.insert(QStringLiteral("id"), QStringLiteral("%1:%2").arg(sv(m.source), sv(m.name)));
         r.insert(QStringLiteral("civ"),
                  QStringLiteral("15 %1").arg(m.sub, 2, 16, QLatin1Char('0')));
-        r.insert(QStringLiteral("unit"), sv(m.unit));
-        r.insert(QStringLiteral("range"), QStringLiteral("%1..%2").arg(m.low).arg(m.high));
+        const bool relativePo = m.id == MeterId::Power && m_model
+                             && m_model->civAddress == 0xA2;
+        const bool ic9700Current = m.id == MeterId::Id && m_model
+                                && m_model->civAddress == 0xA2;
+        const bool ic7300Mk2Current = m.id == MeterId::Id && m_model
+                                   && m_model->civAddress == 0xB6;
+        r.insert(QStringLiteral("unit"), relativePo ? QStringLiteral("Percent") : sv(m.unit));
+        QString range = QStringLiteral("%1..%2").arg(m.low).arg(m.high);
+        if (relativePo) {
+            range = QStringLiteral("0..120");
+        } else if (ic9700Current) {
+            range = QStringLiteral("0..20");
+        } else if (ic7300Mk2Current) {
+            range = QStringLiteral("0..25");
+        }
+        r.insert(QStringLiteral("range"), range);
         r.insert(QStringLiteral("pollMs"), m.intervalMs);
         r.insert(QStringLiteral("when"),
                  m.when == MeterWhen::RxOnly   ? QStringLiteral("rx-only")
@@ -3043,9 +3436,24 @@ bool IcomCivBackend::scrubDrive(const icom::ControlSpec& c)
         return false;
 
     if (id == QLatin1String("rf.gain"))  { setPanRfGain(pan, m_rfGainPercent); return true; }
-    if (id == QLatin1String("preamp"))   { setPanPreamp(pan, m_preampStep); return true; }
-    if (id == QLatin1String("atten"))    { setPanAttenuator(pan, m_attenStep); return true; }
+    if (id == QLatin1String("preamp")) {
+        if (!m_model || preampLabelsFor(*m_model).empty()) {
+            return false;
+        }
+        setPanPreamp(pan, m_preampStep);
+        return true;
+    }
+    if (id == QLatin1String("atten")) {
+        if (!m_model || attenStepsFor(*m_model).empty()) {
+            return false;
+        }
+        setPanAttenuator(pan, m_attenStep);
+        return true;
+    }
     if (id == QLatin1String("rx.antenna")) {
+        if (!m_model || m_model->civAddress != 0xB6) {
+            return false;
+        }
         setSliceRxAntenna(slice, m_rxAntennaExternal
                                    ? QStringLiteral("RX-ANT")
                                    : QStringLiteral("ANT1"));
@@ -3346,6 +3754,118 @@ void IcomCivBackend::invokeExtension(const QString& ns, const QString& verb, qui
         emit extensionResult(requestId, true);
         return;
     }
+    if (verb == QLatin1String("repeater.access")) {
+        if (!m_session || m_model->civAddress != 0xA2) {
+            emit extensionError(requestId, QStringLiteral("repeater access requires IC-9700"));
+            return;
+        }
+        const QVariantMap values = arg.toMap();
+        static const QHash<QString, int> modeValues{
+            {QStringLiteral("off"), 0x00},
+            {QStringLiteral("ctcss_tx"), 0x01},
+            {QStringLiteral("ctcss_rx"), 0x02},
+            {QStringLiteral("dtcs_txrx"), 0x03},
+            {QStringLiteral("dtcs_tx"), 0x06},
+            {QStringLiteral("ctcss_tx_dtcs_rx"), 0x07},
+            {QStringLiteral("dtcs_tx_ctcss_rx"), 0x08},
+            {QStringLiteral("ctcss_txrx"), 0x09},
+        };
+        const QString mode = values.value(QStringLiteral("mode")).toString();
+        if (!modeValues.contains(mode)) {
+            emit extensionError(requestId, QStringLiteral("invalid repeater access mode"));
+            return;
+        }
+        const bool usesTxCtcss = mode == QLatin1String("ctcss_tx")
+            || mode == QLatin1String("ctcss_txrx")
+            || mode == QLatin1String("ctcss_tx_dtcs_rx");
+        const bool usesRxCtcss = mode == QLatin1String("ctcss_rx")
+            || mode == QLatin1String("ctcss_txrx")
+            || mode == QLatin1String("dtcs_tx_ctcss_rx");
+        const bool usesDtcs = mode == QLatin1String("dtcs_tx")
+            || mode == QLatin1String("dtcs_txrx")
+            || mode == QLatin1String("ctcss_tx_dtcs_rx")
+            || mode == QLatin1String("dtcs_tx_ctcss_rx");
+        const int txTone = qRound(values.value(QStringLiteral("txCtcssHz")).toDouble() * 10.0);
+        const int rxTone = qRound(values.value(QStringLiteral("rxCtcssHz")).toDouble() * 10.0);
+        const int dtcs = values.value(QStringLiteral("dtcsCode")).toInt();
+        if ((usesTxCtcss && !fm::isCtcssTone(txTone / 10.0))
+            || (usesRxCtcss && !fm::isCtcssTone(rxTone / 10.0))
+            || (usesDtcs && !fm::isDtcsCode(dtcs))) {
+            emit extensionError(requestId, QStringLiteral("invalid repeater tone value"));
+            return;
+        }
+        const std::uint8_t to = m_session->civAddress();
+        // Write only registers the selected mode consumes. Choosing OFF must
+        // not replace radio-persisted tone/code values with UI defaults.
+        if (usesTxCtcss) {
+            sendUserCommand(cmdSetTone(to, tone::kTxCtcss, txTone));
+        }
+        if (usesRxCtcss) {
+            sendUserCommand(cmdSetTone(to, tone::kRxCtcss, rxTone));
+        }
+        if (usesDtcs) {
+            sendUserCommand(cmdSetTone(to, tone::kDtcs, dtcs,
+                                values.value(QStringLiteral("dtcsTxReverse")).toBool(),
+                                values.value(QStringLiteral("dtcsRxReverse")).toBool()));
+        }
+        sendUserCommand(cmdSetRepeaterAccess(to,
+                            static_cast<std::uint8_t>(modeValues.value(mode))));
+        std::vector<std::vector<std::uint8_t>> reads;
+        if (usesTxCtcss) {
+            reads.push_back(cmdReadTone(to, tone::kTxCtcss));
+        }
+        if (usesRxCtcss) {
+            reads.push_back(cmdReadTone(to, tone::kRxCtcss));
+        }
+        if (usesDtcs) {
+            reads.push_back(cmdReadTone(to, tone::kDtcs));
+        }
+        reads.push_back(cmdReadRepeaterAccess(to));
+        for (const auto& read : reads) {
+            queueRead(read, semanticKey(read), IcomCivScheduler::Priority::Operator);
+        }
+        pumpCiv(nowMs());
+        if (requestId != 0) {
+            emit extensionResult(requestId, true);
+        }
+        return;
+    }
+    if (verb == QLatin1String("repeater.offset")) {
+        if (!m_session || m_model->civAddress != 0xA2) {
+            emit extensionError(requestId, QStringLiteral("repeater offset requires IC-9700"));
+            return;
+        }
+        const QVariantMap values = arg.toMap();
+        const QString direction = values.value(QStringLiteral("direction")).toString();
+        static const QHash<QString, int> duplexValues{
+            {QStringLiteral("simplex"), 0x10},
+            {QStringLiteral("down"), 0x11},
+            {QStringLiteral("up"), 0x12},
+        };
+        bool ok = false;
+        const double offsetMhz = values.value(QStringLiteral("offsetMhz")).toDouble(&ok);
+        if (!duplexValues.contains(direction) || !ok || !std::isfinite(offsetMhz)
+            || offsetMhz < 0.0 || offsetMhz > 99.9999) {
+            emit extensionError(requestId, QStringLiteral("invalid repeater offset"));
+            return;
+        }
+        const std::uint8_t to = m_session->civAddress();
+        const std::uint64_t offsetHz = static_cast<std::uint64_t>(
+            std::llround(offsetMhz * 1.0e6));
+        // Program the magnitude before enabling a direction, so changing from
+        // simplex never briefly keys with the radio's previous offset.
+        sendUserCommand(cmdSetRepeaterOffset(to, offsetHz));
+        sendUserCommand(cmdSetDuplex(
+            to, static_cast<std::uint8_t>(duplexValues.value(direction))));
+        for (const auto& read : {cmdReadRepeaterOffset(to), cmdReadDuplex(to)}) {
+            queueRead(read, semanticKey(read), IcomCivScheduler::Priority::Operator);
+        }
+        pumpCiv(nowMs());
+        if (requestId != 0) {
+            emit extensionResult(requestId, true);
+        }
+        return;
+    }
     // TWO VERBS, because there are two different things to say about PC Audio
     // and only one of them is a command.
     //
@@ -3530,23 +4050,45 @@ void IcomCivBackend::publishMeterDefs()
         // The Po meter's high depends on the model's measured curve, and a
         // model we have no curve for must NOT claim watts — see powerCurveFor.
         if (s.id == MeterId::Power) {
-            const auto curve = powerCurveFor(*m_model);
-            if (curve.empty()) {
+            const auto curve = powerCurveFor(*m_model, m_frequencyHz);
+            if (m_model->civAddress == 0xA2) {
+                d.unit = QStringLiteral("Percent");
+                d.high = 120.0;
+            } else if (curve.empty()) {
                 d.unit = QStringLiteral("Percent");
                 d.high = 100.0;
             } else {
                 d.high = curve.back().value;
             }
-        } else if (s.id == MeterId::Id && m_model->civAddress == 0xB6) {
-            d.high = 25.0;
+        } else if (s.id == MeterId::Id) {
+            if (m_model->civAddress == 0xA2) {
+                d.high = 20.0;
+            } else if (m_model->civAddress == 0xB6) {
+                d.high = 25.0;
+            }
         }
         emit meterDefined(d);
     }
 }
 
+void IcomCivBackend::publishIdleTxMeters()
+{
+    // TX-only polls stop after unkey. Their last samples are not receive-state
+    // telemetry, so clear the faces explicitly instead of leaving them latched.
+    emit meterUpdate(QStringLiteral("TX:FWDPWR"), 0.0);
+    emit meterUpdate(QStringLiteral("TX:SWR"), 1.0);
+    emit meterUpdate(QStringLiteral("TX:ALC"), 0.0);
+    emit meterUpdate(QStringLiteral("TX:COMPPEAK"), 0.0);
+    emit meterUpdate(QStringLiteral("RAD:PACURRENT"), 0.0);
+    m_idAmps = 0.0;
+}
+
 void IcomCivBackend::onMeterTick()
 {
-    if (!m_session || !m_connected)
+    // Once recovery starts, the only useful datagram is the serial-open retry.
+    // Continuing meter/PTT polling fed the silent stream throughout all three
+    // restart attempts, exactly unlike SDR9700's watchdog isolation.
+    if (!m_session || !m_connected || m_civRecoveryStartedAtMs > 0)
         return;
     const std::int64_t now = nowMs();
 
@@ -3559,7 +4101,8 @@ void IcomCivBackend::onMeterTick()
     // transmit meter suppressed and they read as "defined but never fed" while
     // the radio's own meters were plainly moving. That is the operator's
     // report, and it is a receive-side blindness rather than a metering bug.
-    if (m_session && now - m_lastPttPollMs >= kPttPollMs) {
+    const int pttPollMs = m_keyed ? kPttPollTxMs : kPttPollRxMs;
+    if (now - m_lastPttPollMs >= pttPollMs) {
         m_lastPttPollMs = now;
         const auto frame = buildFrameSub(m_session->civAddress(), cmd::kControl,
                                          control::kPtt);
@@ -3627,23 +4170,61 @@ void IcomCivBackend::onLinkTick()
         return;
     const qint64 now = nowMs();
 
+    // Mirror SDR9700's hardware-proven watchdog: while targeted recovery is in
+    // progress, do not feed ordinary commands into the silent stream; issue at
+    // most three CI-V data restarts one second apart. A real frame clears the
+    // recovery budget in onCivFrame().
+    if (m_civRecoveryStartedAtMs > 0) {
+        if (now - m_lastCivRecoveryAttemptAtMs < kCivRecoveryIntervalMs) {
+            return;
+        }
+        if (m_civRecoveryAttempts < kMaxCivRecoveryAttempts
+            && m_session->reopenCivPipe()) {
+            ++m_civRecoveryAttempts;
+            m_lastCivRecoveryAttemptAtMs = now;
+            qCWarning(lcIcomLink) << "CI-V data restart attempt"
+                                  << m_civRecoveryAttempts << "of"
+                                  << kMaxCivRecoveryAttempts;
+            return;
+        }
+        qCWarning(lcIcomLink)
+            << "CI-V data restarts produced no frames; reconnecting the full radio session";
+        const QString reason = QStringLiteral(
+            "Icom CI-V stream stopped responding; reconnecting the radio session");
+        disconnectRadio();
+        emit connectionError(reason);
+        return;
+    }
+
     // CI-V Transceive is a low-latency hint, not a subscription. Queue bounded
     // reconciliation groups; the scheduler turns them into one paced stream,
     // coalesces duplicates and lets an operator command overtake all of them.
+    //
+    // Do not run this background sweep while keyed. Five visible TX meters,
+    // PTT and PA telemetry already consume most of the IC-9700 serial command
+    // plane. Keeping the RX/control sweep active as well held the scheduler at
+    // 35--40 queued transactions in three real-radio captures immediately
+    // before the radio stopped answering CI-V (while its UDP control stream
+    // remained healthy). Operator writes, PTT, TX meters and the stall detector
+    // remain live; radio-authoritative reconciliation resumes on unkey.
     const std::uint8_t addr = m_session->civAddress();
     const auto queueControl = [this](const std::vector<std::uint8_t>& frame) {
         queueRead(frame, semanticKey(frame), IcomCivScheduler::Priority::Control);
     };
     const int phase = ++m_controlPollPhase;
 
-    // Switches whose front-panel state must feel live. NR/NB were the measured
-    // failure: Transceive sometimes announced them and sometimes did not.
-    for (std::uint8_t fn : {func::kAutoNotch, func::kManualNotch,
-                            func::kNoiseReduce, func::kNoiseBlanker}) {
-        queueControl(cmdReadFunction(addr, fn));
+    // SDR9700 leaves ordinary cached controls stale for 5--20 seconds. Keep
+    // ours deterministic, but in the same low-rate regime: the previous
+    // one-second sweep plus meters sustained nearly thirty CI-V reads/second.
+    // NR/NB/notch still reconcile promptly enough for a front-panel change.
+    if (!m_keyed && phase % 5 == 0) {
+        for (std::uint8_t fn : {func::kAutoNotch, func::kManualNotch,
+                                func::kNoiseReduce, func::kNoiseBlanker}) {
+            queueControl(cmdReadFunction(addr, fn));
+        }
     }
 
-    if (phase % 2 == 0) {
+    if (!m_keyed && phase % 2 == 0) {
         queueControl(cmdReadFrequency(addr));
         queueControl(m_model->hasVfoModeCommand ? cmdReadVfoMode(addr)
                                                 : cmdReadMode(addr));
@@ -3652,7 +4233,7 @@ void IcomCivBackend::onLinkTick()
         }
     }
 
-    if (phase % 3 == 0) {
+    if (!m_keyed && phase % 10 == 0) {
         for (std::uint8_t which : {level::kRf, level::kMicGain, level::kMonitor,
                                    level::kVoxGain, level::kNotchPos,
                                    level::kNrLevel, level::kNbLevel}) {
@@ -3665,16 +4246,26 @@ void IcomCivBackend::onLinkTick()
             queueControl(cmdReadFunction(addr, fn));
         }
         queueControl(cmdReadAttenuator(addr));
-        queueControl(cmdReadTuner(addr));
-        for (std::uint8_t sub : {tuneOffset::kFrequency, tuneOffset::kRitOnOff,
-                                 tuneOffset::kXitOnOff}) {
-            queueControl(cmdReadTuneOffset(addr, sub));
+        if (m_model->civAddress != 0xA2) {
+            queueControl(cmdReadTuner(addr));
+            for (std::uint8_t sub : {tuneOffset::kFrequency, tuneOffset::kRitOnOff,
+                                     tuneOffset::kXitOnOff}) {
+                queueControl(cmdReadTuneOffset(addr, sub));
+            }
+        }
+        if (m_model->civAddress == 0xA2) {
+            queueControl(cmdReadRepeaterOffset(addr));
+            queueControl(cmdReadDuplex(addr));
+            queueControl(cmdReadRepeaterAccess(addr));
+            for (std::uint8_t sub : {tone::kTxCtcss, tone::kRxCtcss, tone::kDtcs}) {
+                queueControl(cmdReadTone(addr, sub));
+            }
         }
     }
     // SET-menu changes can originate on the front panel. Refresh slowly: they
     // are troubleshooting state, not interactive controls, and share this CI-V
     // stream with tuning and meters.
-    if (phase % 12 == 0) {
+    if (!m_keyed && phase % 30 == 0) {
         if (const auto mod = modulationProfileFor(*m_model)) {
             for (int item : {mod->dataOffInputItem, mod->dataInputItem,
                              mod->usbLevelItem, mod->accessoryLevelItem,
@@ -3708,6 +4299,27 @@ void IcomCivBackend::onLinkTick()
         << "The transport is still up (rxPackets" << out.rxPackets
         << "), so this is the command plane alone."
         << "Read `civ trace all` for the frames either side of it.";
+
+    // The serial data pipe can stop while its authenticated control and audio
+    // siblings remain healthy. First discard transactions whose replies can no
+    // longer arrive and re-send the reference client's CI-V open handshake.
+    // A bounded grace period above retains the full reconnect as fallback.
+    m_civScheduler.reset();
+    m_schedulerWaiters.clear();
+    if (m_session->reopenCivPipe()) {
+        m_civRecoveryStartedAtMs = now;
+        m_lastCivRecoveryAttemptAtMs = now;
+        m_civRecoveryAttempts = 1;
+        m_civRecoveryProbeSent = false;
+        qCWarning(lcIcomLink) << "CI-V data restart attempt 1 of"
+                              << kMaxCivRecoveryAttempts;
+        return;
+    }
+
+    const QString reason = QStringLiteral(
+        "Icom CI-V stream stopped responding; reconnecting the radio session");
+    disconnectRadio();
+    emit connectionError(reason);
 }
 
 IRadioBackend::HealthSnapshot IcomCivBackend::healthSnapshot() const

--- a/src/core/backends/icom/IcomCivBackend.h
+++ b/src/core/backends/icom/IcomCivBackend.h
@@ -71,6 +71,7 @@ public:
     void connectRadio(const RadioConnectRequest& request) override;
     void disconnectRadio() override;
     [[nodiscard]] bool isConnected() const override;
+    [[nodiscard]] bool shutdownPending() const override;
 
     // ---- intents DOWN ----
     void setSliceFrequency(int sliceId, double hz) override;
@@ -89,6 +90,7 @@ public:
     void setTxPower(int percent) override;
     void setSpeechProcessor(bool on, int level) override;
     void setMicGain(int gainPercent) override;
+    void setMicInput(const QString& input) override;
     void setTxAudioMonitor(bool on) override;
     void setTxMonitor(bool on, int level) override;
     void setSliceNoiseReduction(int sliceId, bool on, int level) override;
@@ -154,6 +156,7 @@ private slots:
 
 private:
     void publishCapabilities();
+    void publishRadioIdentity();
     // Publish the scope's dBm axis, derived from the SAME ScopeCalibration that
     // toDbm() decodes with. Call whenever anything it depends on changes — at
     // connect, and on every reference-level change.
@@ -173,6 +176,7 @@ private:
     // mode indicator that never changed.
     void publishModeState();
     void publishMeterDefs();
+    void publishIdleTxMeters();
     void sendUserCommand(const std::vector<std::uint8_t>& frame);
     void queueRead(const std::vector<std::uint8_t>& frame, const std::string& key,
                    IcomCivScheduler::Priority priority, qint64 notBeforeMs = 0);
@@ -203,12 +207,19 @@ private:
     // bunching as a suspected cause of an unrecoverable CI-V stall; restructuring
     // it belongs to that scheduler work, not here.
     void sendConnectReadBurst();
+    void startSession(const IcomSession::Params& params);
+    void onSessionShutdownFinished();
+    void startPendingSessionWhenReady();
     // Adopt (or refuse) the address the radio reported in its 0x19 0x00 reply.
     void adoptReportedCivAddress(std::uint8_t reported);
     [[nodiscard]] int sliceId() const noexcept { return 0; }
     [[nodiscard]] QString panId() const { return QStringLiteral("0"); }
 
     std::unique_ptr<IcomSession> m_session;
+    std::optional<IcomSession::Params> m_pendingSessionStart;
+    std::optional<IcomSession::Params> m_activeSessionParams;
+    qint64 m_pendingSessionNotBeforeMs = 0;
+    int m_staleSessionRetries = 0;
     const IcomModel* m_model = nullptr;
 
     // ---- CI-V address resolution (see IcomSettings::CivSelection) ------------
@@ -298,7 +309,8 @@ private:
     // rather than inferred from our own commands. Slow: it only has to notice a
     // transmission, and it shares the CI-V stream with tuning.
     std::int64_t m_lastPttPollMs = 0;
-    static constexpr int kPttPollMs = 250;
+    static constexpr int kPttPollRxMs = 500;
+    static constexpr int kPttPollTxMs = 250;
     // The scope geometry the RADIO last reported, from its own sweeps. Both pan
     // intents reason against it: a zoom step needs to know which of the eight
     // spans it is leaving, and a centre request needs a truth to snap back to.
@@ -463,10 +475,15 @@ private:
     QString m_lastOutboundCiv;      // the last frame we sent, as hex
     qint64  m_lastOutboundCivAtMs = 0;
     bool    m_civStallReported = false;
-    // Long enough that a quiet moment is not an alarm — the slowest poll here is
-    // 1 s and a user-command guard can defer it — short enough that an operator
-    // has not yet had time to wonder why the S-meter stopped.
-    static constexpr qint64 kCivStallMs = 5000;
+    qint64  m_civRecoveryStartedAtMs = 0;
+    qint64  m_lastCivRecoveryAttemptAtMs = 0;
+    int     m_civRecoveryAttempts = 0;
+    bool    m_civRecoveryProbeSent = false;
+    // SDR9700's hardware-proven watchdog begins targeted CI-V recovery after
+    // two seconds while the authenticated control stream remains healthy.
+    static constexpr qint64 kCivStallMs = 2000;
+    static constexpr qint64 kCivRecoveryIntervalMs = 1000;
+    static constexpr int kMaxCivRecoveryAttempts = 3;
     // Note the id for a frame we are about to send or have just decoded.
     void noteControlSent(std::uint8_t cmd, std::uint8_t sub, bool hasSub);
     void noteControlScheduled(std::uint8_t cmd, std::uint8_t sub, bool hasSub);

--- a/src/core/backends/icom/IcomCivScheduler.cpp
+++ b/src/core/backends/icom/IcomCivScheduler.cpp
@@ -45,8 +45,8 @@ std::uint64_t IcomCivScheduler::enqueue(Request request, std::int64_t nowMs)
     // duplicate erased and re-pushed the queued entry instead of collapsing
     // into it.  That reset enqueuedAtMs, and enqueuedAtMs is what
     // effectivePriority() ages on: any group re-queued at or faster than
-    // kPriorityAgingMs (onLinkTick re-queues NR/NB/notch every 1000 ms) could
-    // never age at all, and an Operator confirmation read was demoted to
+    // kPriorityAgingMs (or another periodic producer re-queuing at that rate)
+    // could never age at all, and an Operator confirmation read was demoted to
     // Control by the next poll tick that touched the same register.
     if (request.notBeforeMs < nowMs) {
         request.notBeforeMs = nowMs;
@@ -284,6 +284,15 @@ IcomCivScheduler::Observation IcomCivScheduler::observe(const CivFrame& frame,
         return Observation::Stale;
     }
     return Observation::Accepted;
+}
+
+void IcomCivScheduler::dropBackground() noexcept
+{
+    std::erase_if(m_queue, [](const Queued& queued) {
+        return queued.request.priority == Priority::Control
+            || queued.request.priority == Priority::Maintenance;
+    });
+    m_stats.queueDepth = m_queue.size();
 }
 
 void IcomCivScheduler::reset() noexcept

--- a/src/core/backends/icom/IcomCivScheduler.h
+++ b/src/core/backends/icom/IcomCivScheduler.h
@@ -84,6 +84,10 @@ public:
     std::uint64_t enqueue(Request request, std::int64_t nowMs);
     [[nodiscard]] std::optional<Dispatch> takeNext(std::int64_t nowMs);
     [[nodiscard]] Observation observe(const CivFrame& frame, std::int64_t nowMs);
+    // Discard queued periodic reconciliation/maintenance work while preserving
+    // operator, PTT and meter traffic. An already-dispatched read remains
+    // tracked until reply/timeout so a late answer cannot become authoritative.
+    void dropBackground() noexcept;
 
     void reset() noexcept;
     [[nodiscard]] Stats stats() const;

--- a/src/core/backends/icom/IcomControls.cpp
+++ b/src/core/backends/icom/IcomControls.cpp
@@ -171,7 +171,7 @@ constexpr std::array kSpecs = {
                 0, 1, "on/off", 0, 1,
                 "setVox", "phoneVoxBtn", true,
                 "Enable only. The trigger threshold is a separate level (14 16) "
-                "and the DELAY is a SET-menu item (1A 05 0359, in 0.1 s steps) — "
+                "and the DELAY is a SET-menu item (1A 05 0330, in 0.1 s steps) — "
                 "not 14 17, which is the ANTI-vox gain."},
     ControlSpec{"vox.gain", 0x14, 0x16, true, "VOX gain",
                 Plane::Transmit, Encoding::Level255, Wiring::Both,

--- a/src/core/backends/icom/IcomMeters.cpp
+++ b/src/core/backends/icom/IcomMeters.cpp
@@ -32,6 +32,15 @@ constexpr std::array<CurvePoint, 4> kPowerIc7300Mk2{{
     {0, 0.0}, {143, 50.0}, {213, 100.0}, {255, 130.0},
 }};
 
+// IC-9700 Po meter, raw -> relative percent. The CI-V guide and the local
+// reference client define an indicated scale, not a calibrated wattmeter.
+// RF POWER=100 is a drive setpoint while 15 11 is independent PA telemetry.
+constexpr std::array<CurvePoint, 13> kPowerIc9700Relative{{
+    {0, 0.0},   {21, 5.0},  {43, 10.0}, {65, 15.0}, {83, 20.0},
+    {95, 25.0}, {105, 30.0},{114, 35.0},{124, 40.0},{143, 50.0},
+    {183, 75.0},{213, 100.0},{255, 120.0},
+}};
+
 // SWR. Icom's guide: 0 = 1.0, 48 = 1.5, 80 = 2.0, 120 = 3.0.
 //
 // The guide stops at 3.0 and the field is a full byte. The final point is an
@@ -52,9 +61,19 @@ constexpr std::array<CurvePoint, 3> kVd{{
     {0, 0.0}, {75, 5.0}, {241, 16.0},
 }};
 
+// IC-9700 desktop-radio Vd calibration from its CI-V guide. Raw 185 is the
+// nominal 13.8 V point; the portable-radio curve above under-reports it.
+constexpr std::array<CurvePoint, 4> kVdIc9700{{
+    {0, 0.0}, {13, 10.0}, {185, 13.8}, {241, 16.0},
+}};
+
 // Id (PA current), raw -> amps. Icom's guide: 0 = 0 A, 121 = 2 A, 241 = 4 A.
 constexpr std::array<CurvePoint, 3> kId{{
     {0, 0.0}, {121, 2.0}, {241, 4.0},
+}};
+
+constexpr std::array<CurvePoint, 3> kIdIc9700{{
+    {0, 0.0}, {121, 10.0}, {241, 20.0},
 }};
 
 // IC-7300MK2 desktop-radio calibration from its own CI-V guide.
@@ -80,22 +99,22 @@ constexpr std::array<MeterSpec, 8> kSpecs{{
     {MeterId::SMeter,   meter::kSMeter,   "SLC", "LEVEL",   "dBm",  -140.0,  -10.0,
      MeterWhen::RxOnly, 100},
     {MeterId::Power,    meter::kPower,    "TX",  "FWDPWR",  "Watts",   0.0,   12.0,
-     MeterWhen::TxOnly, 200},
+     MeterWhen::TxOnly, 250},
     {MeterId::Swr,      meter::kSwr,      "TX",  "SWR",     "SWR",     1.0,    6.4,
-     MeterWhen::TxOnly, 200},
+     MeterWhen::TxOnly, 250},
     {MeterId::Alc,      meter::kAlc,      "TX",  "ALC",     "Percent", 0.0,  100.0,
-     MeterWhen::TxOnly, 200},
+     MeterWhen::TxOnly, 250},
     {MeterId::Comp,     meter::kComp,     "TX",  "COMPPEAK","dB",      0.0,   25.5,
-     MeterWhen::TxOnly, 200},
-    {MeterId::Vd,       meter::kVd,       "RAD", "+13.8A",  "Volts",   0.0,   16.0,
-     MeterWhen::Always, 1000},
-    {MeterId::Id,       meter::kId,       "RAD", "PACURRENT","Amps",   0.0,    4.0,
      MeterWhen::TxOnly, 500},
+    {MeterId::Vd,       meter::kVd,       "RAD", "+13.8A",  "Volts",   0.0,   16.0,
+     MeterWhen::Always, 2000},
+    {MeterId::Id,       meter::kId,       "RAD", "PACURRENT","Amps",   0.0,    4.0,
+     MeterWhen::TxOnly, 1000},
     // OVF is a boolean the radio reports through the meter command. It belongs
     // in the health snapshot rather than on a meter face, but it is polled the
     // same way, so it lives here.
     {MeterId::Overflow, meter::kOverflow, "RAD", "OVF",     "Percent", 0.0,    1.0,
-     MeterWhen::RxOnly, 500},
+     MeterWhen::RxOnly, 1000},
 }};
 
 std::size_t indexOf(MeterId id) noexcept { return static_cast<std::size_t>(id); }
@@ -131,6 +150,7 @@ double interpolateCurve(std::span<const CurvePoint> curve, int raw)
 
 std::span<const CurvePoint> powerCurveIc705() { return kPowerIc705; }
 std::span<const CurvePoint> powerCurveIc7300Mk2() { return kPowerIc7300Mk2; }
+std::span<const CurvePoint> powerCurveIc9700() { return kPowerIc9700Relative; }
 std::span<const CurvePoint> swrCurve()        { return kSwr; }
 std::span<const CurvePoint> compCurve()       { return kComp; }
 std::span<const CurvePoint> vdCurve()         { return kVd; }
@@ -176,22 +196,31 @@ const MeterSpec* meterSpecForSub(std::uint8_t sub)
     return nullptr;
 }
 
-double meterValue(MeterId id, int raw, double s9Dbm, std::uint8_t civAddress)
+double meterValue(MeterId id, int raw, double s9Dbm, std::uint8_t civAddress,
+                  std::uint64_t frequencyHz)
 {
+    (void)frequencyHz; // Reserved for a future band-specific IC-9700 curve.
     switch (id) {
     case MeterId::SMeter:   return sMeterDbm(raw, s9Dbm);
-    case MeterId::Power:    return interpolateCurve(
-                                civAddress == 0xB6 ? powerCurveIc7300Mk2()
-                                                   : powerCurveIc705(), raw);
+    case MeterId::Power:
+        if (civAddress == 0xA2) {
+            return interpolateCurve(powerCurveIc9700(), raw);
+        }
+        return interpolateCurve(civAddress == 0xB6 ? powerCurveIc7300Mk2()
+                                                    : powerCurveIc705(), raw);
     case MeterId::Swr:      return interpolateCurve(kSwr, raw);
     case MeterId::Alc:      return interpolateCurve(kAlc, raw);
     case MeterId::Comp:     return interpolateCurve(kComp, raw);
     case MeterId::Vd:       return interpolateCurve(
-                                civAddress == 0xB6
+                                civAddress == 0xA2
+                                    ? std::span<const CurvePoint>(kVdIc9700)
+                                : civAddress == 0xB6
                                     ? std::span<const CurvePoint>(kVdIc7300Mk2)
                                     : std::span<const CurvePoint>(kVd), raw);
     case MeterId::Id:       return interpolateCurve(
-                                civAddress == 0xB6
+                                civAddress == 0xA2
+                                    ? std::span<const CurvePoint>(kIdIc9700)
+                                : civAddress == 0xB6
                                     ? std::span<const CurvePoint>(kIdIc7300Mk2)
                                     : std::span<const CurvePoint>(kId), raw);
     // OVF is 00/01 from the radio, not a scaled reading.
@@ -220,6 +249,28 @@ void MeterPoller::setVisible(MeterId id, bool visible)
 }
 
 bool MeterPoller::isVisible(MeterId id) const { return stateFor(id).visible; }
+
+void MeterPoller::setTransmitting(bool tx) noexcept
+{
+    if (m_transmitting == tx) {
+        return;
+    }
+    m_transmitting = tx;
+    if (!tx) {
+        return;
+    }
+
+    // Make visible TX meters due on the next backend tick instead of carrying
+    // a 200/500 ms interval (or an unanswered request) across transmissions.
+    for (const MeterSpec& spec : kSpecs) {
+        if (spec.when != MeterWhen::TxOnly) {
+            continue;
+        }
+        State& state = stateFor(spec.id);
+        state.inFlight = false;
+        state.nextDueMs = 0;
+    }
+}
 
 std::vector<MeterId> MeterPoller::due(std::int64_t nowMs)
 {

--- a/src/core/backends/icom/IcomMeters.h
+++ b/src/core/backends/icom/IcomMeters.h
@@ -62,6 +62,7 @@ struct CurvePoint {
 // source it came from.
 [[nodiscard]] std::span<const CurvePoint> powerCurveIc705();   // raw -> watts
 [[nodiscard]] std::span<const CurvePoint> powerCurveIc7300Mk2(); // raw -> watts
+[[nodiscard]] std::span<const CurvePoint> powerCurveIc9700(); // raw -> relative %
 [[nodiscard]] std::span<const CurvePoint> swrCurve();          // raw -> SWR
 [[nodiscard]] std::span<const CurvePoint> compCurve();         // raw -> dB
 [[nodiscard]] std::span<const CurvePoint> vdCurve();           // raw -> volts
@@ -131,7 +132,8 @@ struct MeterSpec {
 // Convert a raw reading to the spec's unit. `s9Dbm` selects the S-meter
 // reference and is ignored by every other meter.
 [[nodiscard]] double meterValue(MeterId id, int raw, double s9Dbm,
-                                std::uint8_t civAddress = 0xA4);
+                                std::uint8_t civAddress = 0xA4,
+                                std::uint64_t frequencyHz = 0);
 
 // ---------------------------------------------------------------------------
 // The poll scheduler
@@ -159,7 +161,7 @@ public:
     void setVisible(MeterId id, bool visible);
     [[nodiscard]] bool isVisible(MeterId id) const;
 
-    void setTransmitting(bool tx) noexcept { m_transmitting = tx; }
+    void setTransmitting(bool tx) noexcept;
     [[nodiscard]] bool isTransmitting() const noexcept { return m_transmitting; }
 
     // Which meters should be requested now. Marks each returned meter in

--- a/src/core/backends/icom/IcomModels.cpp
+++ b/src/core/backends/icom/IcomModels.cpp
@@ -31,7 +31,7 @@ constexpr std::array<IcomModel, 7> kModels{{
         /*hasScope*/ true, /*scopePoints*/ 475, /*scopeMaxAmplitude*/ 160,
         /*scopeDivisionsUsb*/ 11,
         /*freqBytes*/ kFreqBytes,
-        /*hasTransmit*/ true, /*txPowerMaxWatts*/ 10.0,
+        /*hasTransmit*/ true, /*txPowerMaxWatts*/ 10.0, /*hasTuner*/ true,
         /*tuningMinHz*/ 30'000ULL, /*tuningMaxHz*/ 470'000'000ULL,
         /*verified*/ true,
         /*hasVfoModeCommand*/ true,
@@ -55,7 +55,7 @@ constexpr std::array<IcomModel, 7> kModels{{
         /*hasNetwork*/ true, /*hasWifi*/ false,
         /*hasScope*/ true, 475, 160, 11,
         kFreqBytes,
-        true, 100.0,
+        true, 100.0, /*hasTuner*/ false,
         144'000'000ULL, 1'300'000'000ULL,
         /*verified*/ false,
         // 0x26 MEASURED on the live radio at 10.0.0.7, 2026-08-14 (G0JKN), the
@@ -79,7 +79,7 @@ constexpr std::array<IcomModel, 7> kModels{{
         // exactly why the scope geometry cannot be a compile-time constant.
         /*hasScope*/ true, 689, 200, 15,
         kFreqBytes,
-        true, 100.0,
+        true, 100.0, /*hasTuner*/ true,
         30'000ULL, 60'000'000ULL,
         /*verified*/ false,
     },
@@ -88,7 +88,7 @@ constexpr std::array<IcomModel, 7> kModels{{
         true, false,
         true, 689, 200, 15,
         kFreqBytes,
-        true, 200.0,
+        true, 200.0, /*hasTuner*/ true,
         30'000ULL, 60'000'000ULL,
         false,
     },
@@ -100,7 +100,7 @@ constexpr std::array<IcomModel, 7> kModels{{
         /*hasNetwork*/ false, /*hasWifi*/ false,
         true, 475, 160, 11,
         kFreqBytes,
-        true, 100.0,
+        true, 100.0, /*hasTuner*/ true,
         30'000ULL, 74'800'000ULL,
         false,
     },
@@ -121,7 +121,7 @@ constexpr std::array<IcomModel, 7> kModels{{
         /*hasNetwork*/ true, /*hasWifi*/ false,   // Ethernet, not WiFi
         /*hasScope*/ true, 475, 160, 11,
         kFreqBytes,
-        true, 100.0,
+        true, 100.0, /*hasTuner*/ true,
         30'000ULL, 74'800'000ULL,
         /*verified*/ true,
         /*hasVfoModeCommand*/ true,
@@ -134,7 +134,7 @@ constexpr std::array<IcomModel, 7> kModels{{
         true, false,
         true, 475, 160, 11,
         /*freqBytes*/ 6,
-        true, 10.0,
+        true, 10.0, /*hasTuner*/ false,
         144'000'000ULL, 10'500'000'000ULL,
         false,
     },
@@ -148,7 +148,7 @@ constexpr IcomModel kUnknown{
     /*hasScope*/ false, /*scopePoints*/ 0, /*scopeMaxAmplitude*/ 0,
     /*scopeDivisionsUsb*/ 11,
     /*freqBytes*/ kFreqBytes,
-    /*hasTransmit*/ false, /*txPowerMaxWatts*/ 0.0,
+    /*hasTransmit*/ false, /*txPowerMaxWatts*/ 0.0, /*hasTuner*/ false,
     /*tuningMinHz*/ 0, /*tuningMaxHz*/ 0,
     /*verified*/ false,
     // No 0x26: see the field's comment. An unknown radio gets the mode command
@@ -172,6 +172,15 @@ constexpr std::array<ModulationInputChoice, 6> kIc7300Mk2ModInputs{{
     {0x05, "LAN",     ModSourceNetwork},
 }};
 
+constexpr std::array<ModulationInputChoice, 6> kIc9700ModInputs{{
+    {0x00, "MIC",     ModSourceMic},
+    {0x01, "ACC",     ModSourceAccessory},
+    {0x02, "MIC+ACC", ModSourceMic | ModSourceAccessory},
+    {0x03, "USB",     ModSourceUsb},
+    {0x04, "MIC+USB", ModSourceMic | ModSourceUsb},
+    {0x05, "LAN",     ModSourceNetwork},
+}};
+
 }  // namespace
 
 const IcomModel* modelForCivAddress(std::uint8_t addr)
@@ -180,6 +189,19 @@ const IcomModel* modelForCivAddress(std::uint8_t addr)
         if (m.civAddress == addr)
             return &m;
     return nullptr;
+}
+
+std::string_view declaredBandsFor(const IcomModel& model) noexcept
+{
+    // The IC-9700 cannot tune the gaps between its 144, 430/440 and 1200 MHz
+    // modules. Its 144--1300 MHz min/max range is valid for coarse boundary
+    // checks but cannot describe a band menu. These are the canonical BandDefs
+    // tokens consumed by parseDeclaredBands(). Keep other models empty until
+    // their exact native band sets are attested.
+    if (model.civAddress == 0xA2) {
+        return "2m,440,23cm";
+    }
+    return {};
 }
 
 namespace {
@@ -212,6 +234,12 @@ const IcomModel& unknownModel() { return kUnknown; }
 
 std::optional<ModulationProfile> modulationProfileFor(const IcomModel& model)
 {
+    // IC-9700 guide: ACC/USB/LAN levels 0112/0113/0114 and DATA OFF/DATA MOD
+    // selections 0115/0116. LAN is the network source used by PC Audio.
+    if (model.civAddress == 0xA2) {
+        return ModulationProfile{113, 112, 114, 115, 116, 0x05, 0x00,
+                                 kIc9700ModInputs};
+    }
     // IC-705 CI-V guide: USB/WLAN levels 0116/0117, DATA OFF/DATA MOD
     // selections 0118/0119.
     if (model.civAddress == 0xA4) {
@@ -236,15 +264,21 @@ std::optional<std::uint8_t> parseModelIdReply(const CivFrame& frame)
     return frame.data[0];
 }
 
-std::span<const CurvePoint> powerCurveFor(const IcomModel& model)
+std::span<const CurvePoint> powerCurveFor(const IcomModel& model, std::uint64_t frequencyHz)
 {
+    (void)frequencyHz;
     // Only models with their own verified conversion are named here. Every
     // other model returns EMPTY so the caller reports percent rather than a
     // watts figure derived from a different radio's PA.
-    if (model.civAddress == 0xA4)
+    if (model.civAddress == 0xA4) {
         return powerCurveIc705();
-    if (model.civAddress == 0xB6)
+    }
+    if (model.civAddress == 0xB6) {
         return powerCurveIc7300Mk2();
+    }
+    if (model.civAddress == 0xA2) {
+        return powerCurveIc9700();
+    }
     return {};
 }
 
@@ -255,8 +289,16 @@ std::span<const std::string_view> preampLabelsFor(const IcomModel& model)
     // is published once rather than rewritten on every band change under an
     // operator who may be mid-adjustment.
     static constexpr std::array<std::string_view, 3> kIc705{"OFF", "P.AMP1", "P.AMP2"};
-    if (model.civAddress == 0xA4 || model.civAddress == 0xB6)
+    // The IC-9700 manual names one internal receive-preamp position on each of
+    // its three bands. Its separate per-band external-preamp power settings are
+    // not additional gain positions in this register.
+    static constexpr std::array<std::string_view, 2> kIc9700{"OFF", "P.AMP"};
+    if (model.civAddress == 0xA2) {
+        return kIc9700;
+    }
+    if (model.civAddress == 0xA4 || model.civAddress == 0xB6) {
         return kIc705;
+    }
     return {};
 }
 
@@ -277,6 +319,21 @@ double s9ReferenceFor(std::uint64_t hz) noexcept
     // 30 MHz and -93 dBm above. Using -73 everywhere reports VHF signals 20 dB
     // hot, which on a 2 m weak-signal band is the entire usable range.
     return usesVhfSReference(hz) ? kS9DbmVhf : kS9DbmHf;
+}
+
+bool supportsFrequency(const IcomModel& model, std::uint64_t frequencyHz) noexcept
+{
+    if (model.civAddress == 0xA2) {
+        // Union of the IC-9700 regional hardware coverage documented by the
+        // SDR9700 oracle. Region-specific restrictions remain radio-owned.
+        return (frequencyHz >= 144'000'000ULL && frequencyHz <= 148'000'000ULL)
+            || (frequencyHz >= 430'000'000ULL && frequencyHz <= 450'000'000ULL)
+            || (frequencyHz >= 1'240'000'000ULL && frequencyHz <= 1'300'000'000ULL);
+    }
+    if (model.tuningMaxHz <= model.tuningMinHz) {
+        return true;
+    }
+    return frequencyHz >= model.tuningMinHz && frequencyHz <= model.tuningMaxHz;
 }
 
 }  // namespace AetherSDR::icom

--- a/src/core/backends/icom/IcomModels.h
+++ b/src/core/backends/icom/IcomModels.h
@@ -56,6 +56,10 @@ struct IcomModel {
     bool hasTransmit = true;
     double txPowerMaxWatts = 0.0;
 
+    // Never infer this from hasTransmit. The IC-9700 transmits but has no ATU;
+    // models such as the IC-705 can drive an attached tuner with CI-V 1C 01.
+    bool hasTuner = false;
+
     std::uint64_t tuningMinHz = 0;
     std::uint64_t tuningMaxHz = 0;
 
@@ -124,10 +128,19 @@ struct ModulationProfile {
 [[nodiscard]] std::optional<ModulationProfile>
 modulationProfileFor(const IcomModel& model);
 
+// Most Icoms have one continuous range; the IC-9700 has three disjoint bands.
+[[nodiscard]] bool supportsFrequency(const IcomModel& model,
+                                     std::uint64_t frequencyHz) noexcept;
+
 // Look up by the address the radio reported. Returns nullptr for an address we
 // do not recognise — which is a real and expected outcome, not an error: Icom
 // has ~130 CI-V addresses and this table has a handful.
 [[nodiscard]] const IcomModel* modelForCivAddress(std::uint8_t addr);
+
+// Exact native amateur-band declaration for menus and band selection. Empty
+// means the model has not been verified as a discontinuous band-only receiver;
+// callers must then retain their ordinary tuning-range behaviour.
+[[nodiscard]] std::string_view declaredBandsFor(const IcomModel& model) noexcept;
 
 // Look up by the name the radio reports in its RS-BA1 capabilities packet
 // ("IC-705"). That name arrives during the HANDSHAKE — before the session is
@@ -160,13 +173,15 @@ modulationProfileFor(const IcomModel& model);
 // not model-dependent — see sMeterDbm().
 [[nodiscard]] double s9ReferenceFor(std::uint64_t hz) noexcept;
 
-// raw -> watts for this model's Po meter.
+// Raw Po meter conversion for this model. Calibrated models return watts;
+// the IC-9700 returns its documented relative indication.
 //
 // EMPTY means we have no measured curve for this model, and the caller must
 // report PERCENT rather than inventing watts. That distinction is the whole
 // point: a power meter showing "50 W" derived from another radio's curve is a
 // number an operator will act on.
-[[nodiscard]] std::span<const CurvePoint> powerCurveFor(const IcomModel& model);
+[[nodiscard]] std::span<const CurvePoint> powerCurveFor(const IcomModel& model,
+                                                        std::uint64_t frequencyHz = 0);
 
 // The front-end stages this model offers, in register order (index 0 is OFF).
 //

--- a/src/core/backends/icom/IcomProtocol.cpp
+++ b/src/core/backends/icom/IcomProtocol.cpp
@@ -364,7 +364,8 @@ std::array<std::uint8_t, 16> encodePasscode(std::string_view s)
 
 std::vector<std::uint8_t> buildLogin(std::uint32_t localSid, std::uint32_t remoteSid,
                                      std::uint16_t innerSeq, std::uint16_t tokenRequestId,
-                                     std::string_view username, std::string_view password)
+                                     std::string_view username, std::string_view password,
+                                     std::string_view clientName)
 {
     auto p = framed(kLenLogin, PacketType::Idle, 0, localSid, remoteSid);
     writeInner(p, kLenLogin - kHeaderSize, 0x01, 0x00, innerSeq);
@@ -381,11 +382,10 @@ std::vector<std::uint8_t> buildLogin(std::uint32_t localSid, std::uint32_t remot
     std::copy(user.begin(), user.end(), p.begin() + 0x40);
     std::copy(pass.begin(), pass.end(), p.begin() + 0x50);
 
-    // The client name, in PLAIN TEXT, unlike the credentials above it. Both
-    // reference implementations send exactly "icom-pc"; it is not known whether
-    // the radio validates it, so we do not get creative.
-    static constexpr char kClientName[] = "icom-pc";
-    std::memcpy(p.data() + 0x60, kClientName, sizeof(kClientName) - 1);
+    // The client/station name is a plain-text 16-byte field, unlike the
+    // credentials above it. Truncate at the radio's field boundary.
+    const std::size_t clientNameLen = std::min<std::size_t>(clientName.size(), 16);
+    std::memcpy(p.data() + 0x60, clientName.data(), clientNameLen);
     return p;
 }
 
@@ -393,12 +393,15 @@ LoginResult parseLoginReply(std::span<const std::uint8_t> pkt, AuthId& authId)
 {
     if (!startsWith(pkt, kLenLoginReply, 0x60))
         return LoginResult::NotALoginReply;
+    // Copy the echoed request identity even on rejection. A delayed rejection
+    // from an earlier login must be correlated before it is allowed to condemn
+    // the credentials used by the current attempt.
+    std::copy_n(pkt.begin() + 0x1a, authId.size(), authId.begin());
     // 0xFFFFFFFE in the error word is specifically "bad username/password", as
     // opposed to the 0xFFFFFF... prefix the status packet uses for a general
     // auth failure. Distinguishing them is what lets the UI say which one.
     if (pkt[0x30] == 0xff && pkt[0x31] == 0xff && pkt[0x32] == 0xff && pkt[0x33] == 0xfe)
         return LoginResult::BadCredentials;
-    std::copy_n(pkt.begin() + 0x1a, authId.size(), authId.begin());
     return LoginResult::Ok;
 }
 
@@ -429,6 +432,18 @@ AuthReply parseAuthReply(std::span<const std::uint8_t> pkt)
     out.result = out.response == 0 ? AuthReplyResult::Accepted
                                    : AuthReplyResult::Nonzero;
     return out;
+}
+
+bool isAuthOperationReply(std::span<const std::uint8_t> pkt, AuthKind kind,
+                          std::uint16_t innerSeq, const AuthId& authId)
+{
+    if (!startsWith(pkt, kLenToken, 0x40)
+        || pkt[0x14] != 0x02
+        || pkt[0x15] != static_cast<std::uint8_t>(kind)
+        || getBe16(pkt, 0x16) != innerSeq) {
+        return false;
+    }
+    return std::equal(authId.begin(), authId.end(), pkt.begin() + 0x1a);
 }
 
 bool parseCapabilities(std::span<const std::uint8_t> pkt, RadioId& radioId)
@@ -527,6 +542,15 @@ std::vector<std::uint8_t> buildSerialOpen(std::uint32_t localSid, std::uint32_t 
     p[0x12] = 0x00;
     putBe16(p, 0x13, sendSeq);
     p[0x15] = open ? 0x05 : 0x00;
+    return p;
+}
+
+std::vector<std::uint8_t> buildSerialRestart(std::uint32_t localSid,
+                                             std::uint32_t remoteSid,
+                                             std::uint16_t sendSeq)
+{
+    auto p = buildSerialOpen(localSid, remoteSid, sendSeq, true);
+    p[0x15] = 0x04;
     return p;
 }
 

--- a/src/core/backends/icom/IcomProtocol.h
+++ b/src/core/backends/icom/IcomProtocol.h
@@ -304,7 +304,8 @@ using RadioId = std::array<std::uint8_t, 16>;
                                                     std::uint16_t innerSeq,
                                                     std::uint16_t tokenRequestId,
                                                     std::string_view username,
-                                                    std::string_view password);
+                                                    std::string_view password,
+                                                    std::string_view clientName);
 
 // Outcome of the 0x60 login reply.
 enum class LoginResult { Ok, BadCredentials, NotALoginReply };
@@ -330,6 +331,11 @@ struct AuthReply {
     AuthId authId{};
 };
 [[nodiscard]] AuthReply parseAuthReply(std::span<const std::uint8_t> pkt);
+// Correlate an acknowledgement for a specific authentication operation.
+// Token removal uses request type 0x01 rather than the renewal parser's 0x05.
+[[nodiscard]] bool isAuthOperationReply(std::span<const std::uint8_t> pkt,
+                                        AuthKind kind, std::uint16_t innerSeq,
+                                        const AuthId& authId);
 
 // Extract the radio identity from the 0xA8 capabilities packet.
 [[nodiscard]] bool parseCapabilities(std::span<const std::uint8_t> pkt, RadioId& radioId);
@@ -403,6 +409,12 @@ struct StreamGrant {
                                                          std::uint32_t remoteSid,
                                                          std::uint16_t sendSeq,
                                                          bool open);
+
+// Restart an already-open CI-V data pipe. The IC-9700 distinguishes this
+// data-start request (magic 0x04) from the initial open above (magic 0x05).
+[[nodiscard]] std::vector<std::uint8_t> buildSerialRestart(std::uint32_t localSid,
+                                                            std::uint32_t remoteSid,
+                                                            std::uint16_t sendSeq);
 
 // Wrap one raw CI-V frame for the serial stream.
 //

--- a/src/core/backends/icom/IcomScope.cpp
+++ b/src/core/backends/icom/IcomScope.cpp
@@ -7,7 +7,7 @@ namespace {
 
 // Offsets inside a 0x27 0x00 frame's data (i.e. after cmd + subcommand).
 //
-//   data[0]      0x00, fixed
+//   data[0]      receiver: 00 MAIN, 01 SUB
 //   data[1]      division index, BCD 01..11
 //   data[2]      division maximum, BCD — 01 over WLAN, 11 over USB
 // then, ONLY when the division index is 1:
@@ -18,7 +18,7 @@ namespace {
 //   data[15..]   waveform, when this frame is also the LAST division (WLAN)
 // and for every division after the first:
 //   data[3..]    waveform
-constexpr std::size_t kOffFixed      = 0;
+constexpr std::size_t kOffReceiver   = 0;
 constexpr std::size_t kOffDivision   = 1;
 constexpr std::size_t kOffDivisionMax = 2;
 constexpr std::size_t kOffMode       = 3;
@@ -57,6 +57,8 @@ std::optional<ScopeFrame> ScopeDecoder::feed(const CivFrame& frame)
         // sweep was left half-assembled by packet loss, this is where it gets
         // discarded — keeping it would splice two sweeps into one trace.
         m_partial = ScopeFrame{};
+        m_partial.receiver = frame.data[kOffReceiver];
+        m_receiver = m_partial.receiver;
         m_assembling = true;
         m_expectedDivision = 1;
 
@@ -126,6 +128,12 @@ std::optional<ScopeFrame> ScopeDecoder::feed(const CivFrame& frame)
     // Continuation divisions (USB transport only).
     if (!m_assembling)
         return std::nullopt;   // mid-sweep frame with no first division — dropped
+    if (frame.data[kOffReceiver] != m_receiver) {
+        // MAIN and SUB share the same command stream. Never splice divisions
+        // from different receivers into one positional waveform.
+        m_assembling = false;
+        return std::nullopt;
+    }
     if (division != m_expectedDivision + 1) {
         // A gap means the sweep is unrecoverable: the waveform is positional and
         // there is no per-division index inside the payload to re-align against.
@@ -152,6 +160,7 @@ void ScopeDecoder::reset() noexcept
     m_partial = ScopeFrame{};
     m_assembling = false;
     m_expectedDivision = 0;
+    m_receiver = 0;
 }
 
 std::vector<float> toDbm(const ScopeFrame& frame, const ScopeGeometry& geom,

--- a/src/core/backends/icom/IcomScope.h
+++ b/src/core/backends/icom/IcomScope.h
@@ -53,6 +53,10 @@ enum class ScopeMode : std::uint8_t {
 
 // One fully-assembled sweep.
 struct ScopeFrame {
+    // Receiver selector carried by every 0x27 0x00 division: 00 MAIN, 01 SUB.
+    // AetherSDR currently exposes the Icom MAIN receiver as slice 0, so the
+    // backend uses this to prevent SUB sweeps from being painted onto it.
+    std::uint8_t receiver = 0;
     ScopeMode mode = ScopeMode::Centre;
     // Edges, in Hz, ALREADY normalised out of whichever representation the
     // radio used — see the note on Centre mode in IcomScope.cpp.
@@ -146,6 +150,7 @@ private:
     ScopeFrame m_partial;
     bool m_assembling = false;
     int  m_expectedDivision = 0;
+    std::uint8_t m_receiver = 0;
 };
 
 // ---------------------------------------------------------------------------

--- a/src/core/backends/icom/IcomSession.cpp
+++ b/src/core/backends/icom/IcomSession.cpp
@@ -11,6 +11,19 @@
 
 namespace AetherSDR::icom {
 
+namespace {
+
+QString processClientName()
+{
+    // Stable for this app process so a full radio-session reconnect retains
+    // its station identity, but a second AetherSDR instance is distinguishable.
+    static const QString name = QStringLiteral("AetherSDR-%1").arg(
+        QRandomGenerator::global()->bounded(0x1000000), 6, 16, QLatin1Char('0'));
+    return name;
+}
+
+} // namespace
+
 // The RS-BA1 handshake is a multi-step chain with no error packet for most of
 // its failure modes — a radio that refuses at any step simply stops answering.
 // Without these lines the whole sequence is a black box that either works or
@@ -29,7 +42,7 @@ constexpr int kTxPumpMs = 10;
 // while the link is demonstrably fine.
 constexpr int kCivFrameTimeoutMs = 100;
 // Re-send the CI-V data-stream open at the reference's cadence until the radio
-// starts streaming. Matches kappanhang / SDR9700 startCivDataTimer(100).
+// starts streaming. Matches the two independently tested reference clients.
 constexpr int kCivOpenRetryMs = 100;
 // ~5 s of asking. Long enough for a slow radio, short enough that a radio which
 // will never answer says so rather than retrying silently forever.
@@ -45,7 +58,7 @@ std::span<const std::uint8_t> asSpan(const QByteArray& b)
 
 IcomSession::IcomSession(QObject* parent) : QObject(parent) {}
 
-IcomSession::~IcomSession() { stop(); }
+IcomSession::~IcomSession() { stopImmediate(); }
 
 bool IcomSession::start(const Params& params)
 {
@@ -130,12 +143,100 @@ bool IcomSession::start(const Params& params)
 
 void IcomSession::stop()
 {
+    if (m_stopping) {
+        return;
+    }
+
+    // The IC-9700's LAN server was verified to require an acknowledged token
+    // removal before the control endpoint departs. Keep this model-gated until
+    // the same shutdown contract has been exercised on the other Icoms.
+    if (m_params.civAddress == 0xA2 && m_control && m_control->isReady()
+        && m_authOk) {
+        beginOrderlyShutdown();
+        return;
+    }
+    stopImmediate();
+}
+
+void IcomSession::stopOperationalTimers()
+{
     for (QTimer** t : {&m_tokenTimer, &m_txTimer, &m_civTimeout, &m_civOpenRetry}) {
         if (*t) {
             (*t)->stop();
             (*t)->deleteLater();
             *t = nullptr;
         }
+    }
+}
+
+void IcomSession::beginOrderlyShutdown()
+{
+    m_stopping = true;
+    m_connected = false;
+    m_shutdownAttempts = 0;
+    stopOperationalTimers();
+
+    // Close the CI-V data pipe before its UDP endpoint departs. Audio has no
+    // corresponding payload close; its type-0x05 departure is sufficient.
+    if (m_serial && m_serial->isReady()) {
+        m_serial->sendTracked(buildSerialOpen(m_serial->localSessionId(),
+                                              m_serial->remoteSessionId(),
+                                              m_serialSendSeq++, false));
+        m_serial->flush();
+    }
+
+    if (!m_shutdownTimer) {
+        m_shutdownTimer = new QTimer(this);
+        m_shutdownTimer->setSingleShot(true);
+        connect(m_shutdownTimer, &QTimer::timeout, this, &IcomSession::onShutdownStep);
+    }
+    // Hardware-verified IC-9700 settle interval from SDR9700: let stream-close
+    // traffic complete before removing the authentication token.
+    m_shutdownTimer->start(m_params.shutdownSettleMs);
+}
+
+void IcomSession::onShutdownStep()
+{
+    if (!m_stopping) {
+        return;
+    }
+    if (m_shutdownAttempts == 0) {
+        if (m_serial) {
+            m_serial->stop();
+        }
+        if (m_audio) {
+            m_audio->stop();
+        }
+    }
+    if (!m_control || !m_control->isReady()
+        || m_shutdownAttempts >= m_params.shutdownMaxAttempts) {
+        if (m_shutdownAttempts >= m_params.shutdownMaxAttempts) {
+            qCWarning(lcIcom) << "IC-9700 did not acknowledge token removal after"
+                              << m_params.shutdownMaxAttempts << "attempts";
+        }
+        finishShutdown();
+        return;
+    }
+
+    m_shutdownInnerSeq = m_innerSeq++;
+    ++m_shutdownAttempts;
+    qCInfo(lcIcom) << "IC-9700 token-removal attempt" << m_shutdownAttempts << "of"
+                   << m_params.shutdownMaxAttempts;
+    m_control->sendTracked(buildAuth(m_control->localSessionId(),
+                                     m_control->remoteSessionId(),
+                                     m_shutdownInnerSeq, m_authId,
+                                     AuthKind::Deauth));
+    m_control->flush();
+    m_shutdownTimer->start(m_params.shutdownRetryMs);
+}
+
+void IcomSession::stopImmediate()
+{
+    stopOperationalTimers();
+    if (m_shutdownTimer) {
+        m_shutdownTimer->stop();
+        m_shutdownTimer->deleteLater();
+        m_shutdownTimer = nullptr;
     }
     // DEAUTHENTICATE BEFORE TEARING DOWN.
     //
@@ -152,7 +253,7 @@ void IcomSession::stop()
     // token request was rejected with 0xffffffff until the old lease expired.
     // Two distinct tracked sequence numbers also avoid depending on a replay
     // request we cannot serve after closing the socket.
-    if (m_control && m_control->isReady()) {
+    if (m_control && m_control->isReady() && m_authOk && !m_stopping) {
         const auto bye = buildAuth(m_control->localSessionId(),
                                    m_control->remoteSessionId(), m_innerSeq++, m_authId,
                                    AuthKind::Deauth);
@@ -198,6 +299,15 @@ void IcomSession::stop()
     m_audioSendSeq = 1;
     m_civ.reset();
     m_tx.flush();
+    m_stopping = false;
+}
+
+void IcomSession::finishShutdown()
+{
+    // The media endpoints have already departed. The control departure must be
+    // last, after token removal acknowledgement (or the bounded timeout).
+    stopImmediate();
+    emit shutdownFinished();
 }
 
 void IcomSession::fail(const QString& reason)
@@ -266,12 +376,22 @@ void IcomSession::onControlReady()
     m_control->sendTracked(buildLogin(m_control->localSessionId(), m_control->remoteSessionId(),
                                       m_innerSeq++, m_tokenRequestId,
                                       m_params.username.toStdString(),
-                                      m_params.password.toStdString()));
+                                      m_params.password.toStdString(),
+                                      processClientName().toStdString()));
 }
 
 void IcomSession::onControlPayload(const QByteArray& packet)
 {
     const auto pkt = asSpan(packet);
+
+    if (m_stopping && isCurrentControlPacket(pkt)
+        && isAuthOperationReply(pkt, AuthKind::Deauth,
+                                m_shutdownInnerSeq, m_authId)) {
+        qCInfo(lcIcom) << "IC-9700 token removal acknowledged after"
+                       << m_shutdownAttempts << "attempt(s)";
+        finishShutdown();
+        return;
+    }
 
     // Dispatch on LENGTH, not on type: every one of these rides packet type
     // 0x00, and the length is the only thing that distinguishes them.
@@ -279,7 +399,20 @@ void IcomSession::onControlPayload(const QByteArray& packet)
     case static_cast<qsizetype>(kLenLoginReply): {
         qCInfo(lcIcom) << "got login reply";
         AuthId id{};
-        switch (parseLoginReply(pkt, id)) {
+        const LoginResult result = parseLoginReply(pkt, id);
+        const std::uint16_t echoedRequest = static_cast<std::uint16_t>(id[0])
+            | (static_cast<std::uint16_t>(id[1]) << 8U);
+        if (result != LoginResult::NotALoginReply
+            && echoedRequest != m_tokenRequestId) {
+            qCWarning(lcIcom) << "ignoring delayed login reply for request"
+                              << QStringLiteral("0x%1").arg(echoedRequest, 4, 16,
+                                                             QLatin1Char('0'))
+                              << "current request is"
+                              << QStringLiteral("0x%1").arg(m_tokenRequestId, 4, 16,
+                                                             QLatin1Char('0'));
+            return;
+        }
+        switch (result) {
         case LoginResult::BadCredentials:
             fail(QStringLiteral("the radio rejected the username or password"));
             return;
@@ -403,8 +536,13 @@ void IcomSession::onControlPayload(const QByteArray& packet)
                                      "session's stream grant";
                 return;
             }
-            fail(QStringLiteral("authentication failed — check the user name and password, "
-                                "or power-cycle the radio"));
+            if (m_params.civAddress == 0xA2) {
+                fail(QStringLiteral("the previous IC-9700 network session is still closing; "
+                                    "AetherSDR will retry automatically"));
+            } else {
+                fail(QStringLiteral("authentication failed; check the Icom username/password "
+                                    "and power-cycle the radio if a previous session is stuck"));
+            }
             return;
         case StatusKind::Disconnected:
             fail(QStringLiteral("the radio dropped the session"));
@@ -581,7 +719,16 @@ void IcomSession::onTokenRenew()
     if (sinceAck < cadenceMs)
         return;
     m_renewRetries = 0;
-    sendRenewal(QStringLiteral("scheduled"));
+    const bool earlyMaintenance = m_initialMaintenancePending;
+    sendRenewal(earlyMaintenance
+                    ? QStringLiteral("scheduled early maintenance")
+                    : QStringLiteral("scheduled"));
+    // This is a one-shot shorter window. Clear the state when the renewal is
+    // dispatched, not when its acknowledgement arrives, so a lost ACK cannot
+    // cause retries or diagnostics to re-enter the early cadence.
+    if (earlyMaintenance) {
+        m_initialMaintenancePending = false;
+    }
 }
 
 void IcomSession::onSerialReady()
@@ -601,7 +748,7 @@ void IcomSession::onSerialReady()
     // auto-ranges into a runaway MainWindow rejects once a second. The operator
     // sees a blank frequency and a waterfall that keeps resetting.
     //
-    // kappanhang and the SDR9700 reference both re-send the open on a 100 ms
+    // Both independently tested reference clients re-send the open on a 100 ms
     // timer until data flows (their startCivDataTimer), and Aether-gate does the
     // same driving THIS radio — 1356 frames in 45 s, 30.1 fps. An IC-705 that
     // happens to start on the first open would never expose this.
@@ -748,6 +895,18 @@ void IcomSession::sendCiv(std::span<const std::uint8_t> frame)
     m_serial->sendTracked(buildSerialData(m_serial->localSessionId(),
                                           m_serial->remoteSessionId(), 0, m_serialSendSeq++,
                                           frame));
+}
+
+bool IcomSession::reopenCivPipe()
+{
+    if (!m_serial || !m_serial->isReady()) {
+        return false;
+    }
+
+    m_serial->sendTracked(buildSerialRestart(m_serial->localSessionId(),
+                                             m_serial->remoteSessionId(),
+                                             m_serialSendSeq++));
+    return true;
 }
 
 void IcomSession::sendAudio(std::span<const float> mono)

--- a/src/core/backends/icom/IcomSession.h
+++ b/src/core/backends/icom/IcomSession.h
@@ -58,6 +58,12 @@ public:
         // actually fires ahead of the steady cadence, rather than only that
         // the flag was set.
         int initialMaintenanceMs = 30000;
+        // IC-9700 orderly shutdown timing. Production follows the intervals
+        // verified against SDR9700; tests shorten them to exercise retry and
+        // timeout behavior without slowing the suite.
+        int shutdownSettleMs = 500;
+        int shutdownRetryMs = 500;
+        int shutdownMaxAttempts = 8;
         // Zero selects a fresh random nonzero ID. Tests may override it to
         // prove reconnect correlation deterministically.
         quint16 tokenRequestId = 0;
@@ -72,6 +78,7 @@ public:
 
     Q_INVOKABLE bool start(const AetherSDR::icom::IcomSession::Params& params);
     Q_INVOKABLE void stop();
+    [[nodiscard]] bool isStopping() const noexcept { return m_stopping; }
 
     [[nodiscard]] bool isConnected() const noexcept { return m_connected; }
     [[nodiscard]] QString deviceName() const { return m_deviceName; }
@@ -93,6 +100,9 @@ public:
 
     // Send one CI-V frame. Frames are built by CivCodec's cmd* helpers.
     void sendCiv(std::span<const std::uint8_t> frame);
+    // Send one RS-BA1 CI-V data restart while retaining the authenticated
+    // control and audio streams. The backend owns the bounded retry policy.
+    bool reopenCivPipe();
     // Queue transmit audio (mono float). Nothing leaves until a full 20 ms
     // frame is available — the radio's jitter buffer reads a short packet as a
     // discontinuity.
@@ -112,6 +122,9 @@ public:
 signals:
     void connected(const QString& deviceName);
     void disconnected(const QString& reason);
+    // Emitted after an asynchronous IC-9700 token-removal handshake has
+    // finished and all three local sockets are closed.
+    void shutdownFinished();
     // One decoded CI-V frame from the radio. Echoes of our own commands are
     // already filtered out — see onSerialPayload().
     void civFrameReady(const AetherSDR::icom::CivFrame& frame);
@@ -128,6 +141,7 @@ private slots:
     void onTokenRenew();
     void onTxPump();
     void onCivFrameTimeout();
+    void onShutdownStep();
 
 private:
     void fail(const QString& reason);
@@ -135,6 +149,10 @@ private:
     [[nodiscard]] bool isCurrentControlPacket(std::span<const std::uint8_t> packet) const;
     void requestStreamsIfReady();
     void openMediaStreams();
+    void beginOrderlyShutdown();
+    void finishShutdown();
+    void stopImmediate();
+    void stopOperationalTimers();
 
     Params m_params;
 
@@ -148,6 +166,7 @@ private:
     // Re-sends the CI-V data-stream open until the radio actually starts
     // streaming. One open is not reliably enough — see onSerialReady().
     QTimer* m_civOpenRetry = nullptr;
+    QTimer* m_shutdownTimer = nullptr;
     bool    m_civDataSeen = false;
     int     m_civOpenAttempts = 0;
 
@@ -181,6 +200,9 @@ private:
     bool m_streamsRequested = false;
     bool m_streamGranted = false;
     bool m_connected = false;
+    bool m_stopping = false;
+    int m_shutdownAttempts = 0;
+    std::uint16_t m_shutdownInnerSeq = 0;
     // Re-entrancy guard: a teardown makes several streams fail at once, and
     // each one calling stop() again would delete objects mid-signal.
     bool m_failing = false;

--- a/src/core/backends/sim/SimBackend.cpp
+++ b/src/core/backends/sim/SimBackend.cpp
@@ -259,6 +259,8 @@ RadioCapabilities SimBackend::capabilities() const
     // The simulator has no profile store to list, load or save into.
     caps.hasProfiles = false;
     caps.hasSelectableMicInputs = false;
+    caps.fmRepeaterAccessModes = {QStringLiteral("off"),
+                                  QStringLiteral("ctcss_tx")};
 
     // The demo has no transmitter and no radio to ship audio to.
     caps.takesTxAudioOverSeam = false;
@@ -286,6 +288,12 @@ RadioCapabilities SimBackend::capabilities() const
     caps.notchMaxWidthHz = 0.0;
     caps.hasGpsLocation = false;         // synthetic radio has no position source
     caps.hasSupplyVoltageTelemetry = false;   // synthetic scene; no PA rail
+    caps.hasPaTemperatureTelemetry = false;
+    caps.hasMainFanTelemetry = false;
+    caps.paCurrentMaxAmps = 0.0;
+    caps.hasDownwardExpander = false;
+    caps.hasContinuousSpeechProcessorLevel = false;
+    caps.hasTxFilterControl = false;
     // The demo radio regenerates its synthetic scene on every connect; there
     // is no operating state worth resurrecting across sessions.
     caps.clientSettingsDomains = {};

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -1622,6 +1622,13 @@ void AppletPanel::setRadioFilterWidths(const QList<int>& widthsHz)
         m_rxApplet->setRadioFilterWidths(widthsHz);
 }
 
+void AppletPanel::setFmRepeaterAccessModes(const QStringList& modes)
+{
+    if (m_rxApplet) {
+        m_rxApplet->setFmRepeaterAccessModes(modes);
+    }
+}
+
 void AppletPanel::setMicLevelMeterAvailable(bool available)
 {
     if (m_phoneCwApplet)
@@ -1632,6 +1639,13 @@ void AppletPanel::setSelectableMicInputs(bool selectable)
 {
     if (m_phoneCwApplet)
         m_phoneCwApplet->setSelectableMicInputs(selectable);
+}
+
+void AppletPanel::setMicInputChoices(const QStringList& choices)
+{
+    if (m_phoneCwApplet) {
+        m_phoneCwApplet->setMicInputChoices(choices);
+    }
 }
 
 void AppletPanel::setProfilesVisible(bool visible)

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -201,8 +201,10 @@ public:
     void setProfilesVisible(bool visible);
     // Capability passthrough to the Phone/CW applet — same shape as above.
     void setSelectableMicInputs(bool selectable);
+    void setMicInputChoices(const QStringList& choices);
     void setMicLevelMeterAvailable(bool available);
     void setRadioFilterWidths(const QList<int>& widthsHz);
+    void setFmRepeaterAccessModes(const QStringList& modes);
 
     // Show/hide the DAX and DAX-IQ buttons and applets based on whether the
     // connected radio produces per-slice audio / per-pan IQ streams

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -2615,7 +2615,9 @@ void ConnectionPanel::probeRadio(const QString& ip, bool restoreSavedFamily)
         // only stable identity this radio has for us. It has to be SOMETHING:
         // the restore/persist scope keys off it.
         info.serial   = QStringLiteral("icom:%1").arg(resolved.toString());
-        info.nickname = info.model;
+        // Leave the nickname empty so the connected UI can replace the generic
+        // pre-identification model with the CI-V-reported identity (IC-9700).
+        info.nickname.clear();
         // Manual Icom sessions use the same retention path as routed Flex and
         // HL2 sessions. Without this marker MainWindow removes
         // LastRoutedRadioIp immediately, so the startup checkbox has no host to

--- a/src/gui/HGauge.h
+++ b/src/gui/HGauge.h
@@ -90,6 +90,14 @@ public:
         publishAutomationState();
         update();
     }
+    void setUnit(const QString& unit) {
+        if (m_unit == unit) {
+            return;
+        }
+        m_unit = unit;
+        publishAutomationState();
+        update();
+    }
 
     // The normalised [0,1] fill fraction, after ballistics. Distinct from
     // value()/min()/max(): those are the INPUTS, this is the derived state that

--- a/src/gui/HealthApplet.cpp
+++ b/src/gui/HealthApplet.cpp
@@ -492,11 +492,20 @@ void HealthApplet::setMeterModel(MeterModel* model)
                    this, nullptr);
         disconnect(m_model, &MeterModel::tgxlMetersChanged, this, nullptr);
         disconnect(m_model, &MeterModel::ampMetersChanged,  this, nullptr);
+        disconnect(m_model, &MeterModel::forwardPowerUnitChanged, this, nullptr);
     }
 
     m_model = model;
     if (!m_model)
         return;
+
+    m_radioSnapshot.powerRelative = m_model->forwardPowerUnit()
+        .compare(QLatin1String("Percent"), Qt::CaseInsensitive) == 0;
+    connect(m_model, &MeterModel::forwardPowerUnitChanged,
+            this, [this](const QString& unit) {
+        m_radioSnapshot.powerRelative =
+            unit.compare(QLatin1String("Percent"), Qt::CaseInsensitive) == 0;
+    });
 
     // Emission order matters: MeterModel::updateValues() emits
     // directionalPowerMetersChanged (carrying the INSTANTANEOUS forward power
@@ -533,6 +542,9 @@ void HealthApplet::setMeterModel(MeterModel* model)
 
 void HealthApplet::setPowerScale(int maxWatts, bool hasAmplifier)
 {
+    m_radioSnapshot.powerRelative = m_model
+        && m_model->forwardPowerUnit()
+            .compare(QLatin1String("Percent"), Qt::CaseInsensitive) == 0;
     if (m_havePowerScale && maxWatts == m_lastMaxWatts && hasAmplifier == m_lastHasAmplifier) {
         return;
     }
@@ -787,6 +799,7 @@ void HealthApplet::appendFrame()
 
     AntennaHealthSample sample;
     sample.powerWatts = m_displayPower;
+    sample.powerRelative = snapshot.powerRelative;
     sample.swr = m_displaySwr;
     sample.powerAverage = m_baselineReady ? m_powerAverage : std::max(1.0f, m_displayPower);
     sample.swrAverage = m_baselineReady ? m_swrAverage : 1.0f;
@@ -964,7 +977,9 @@ void HealthApplet::updateStatusLabels(const AntennaHealthSample& sample,
     m_returnLossLabel->setText(sample.active
         ? QStringLiteral("RL %1dB").arg(sample.returnLossDb, 0, 'f', 0)
         : QStringLiteral("RL --"));
-    m_powerLabel->setText(QStringLiteral("PWR %1").arg(formatPower(sample.powerWatts)));
+    m_powerLabel->setText(QStringLiteral("PWR %1")
+                              .arg(formatPower(sample.powerWatts,
+                                               sample.powerRelative)));
     m_varianceLabel->setText(sample.active
         ? QStringLiteral("VAR %1").arg(m_swrSpan, 0, 'f', 2)
         : QStringLiteral("VAR --"));
@@ -1015,8 +1030,12 @@ QString HealthApplet::sourceText(MeterSource source) const
     return QStringLiteral("--");
 }
 
-QString HealthApplet::formatPower(float watts) const
+QString HealthApplet::formatPower(float value, bool relative) const
 {
+    if (relative) {
+        return QStringLiteral("%1 %").arg(value, 0, 'f', 0);
+    }
+    const float watts = value;
     if (watts >= 995.0f)
         return QStringLiteral("%1 kW").arg(watts / 1000.0f, 0, 'f', 2);
     if (watts >= 100.0f)

--- a/src/gui/HealthApplet.h
+++ b/src/gui/HealthApplet.h
@@ -30,6 +30,7 @@ struct AntennaHealthSample {
     QString incidentLabel;
     bool active{false};
     bool incident{false};
+    bool powerRelative{false};
 };
 
 class HealthApplet : public QWidget {
@@ -66,6 +67,7 @@ private:
         qint64 swrQualifyingPowerUpdatedAtMs{0};
         qint64 swrSampleUpdatedAtMs{0};
         bool valid{false};
+        bool powerRelative{false};
     };
 
     void cacheMeters(MeterSource source, float fwdPowerWatts, float swr);
@@ -80,7 +82,7 @@ private:
     void showPausedState();
     void updateStatusLabels(const AntennaHealthSample& sample, MeterSource source);
     QString sourceText(MeterSource source) const;
-    QString formatPower(float watts) const;
+    QString formatPower(float value, bool relative) const;
     float computeSeverity(float powerWatts, float swr) const;
     void pushRecent(float powerWatts, float swr, float returnLossDb);
     void recomputeRecentStats();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -11,6 +11,7 @@
 #include "MainWindow.h"
 
 #include "MainWindowHelpers.h"
+#include <QEventLoop>
 #include "WindowGeometryRestore.h"
 
 #include "CwDecodeSettings.h"
@@ -3862,6 +3863,25 @@ void MainWindow::closeEvent(QCloseEvent* event)
     {
         ShutdownTrace trace("radio.disconnect");
         m_radioModel.disconnectFromRadio();
+        if (m_radioModel.backendShutdownPending()) {
+            // Keep the complete object graph alive while a backend performs an
+            // acknowledged logout. This wait belongs here, never in a
+            // destructor: optional controller and UI callbacks remain safe.
+            QEventLoop logoutWait;
+            QTimer poll;
+            poll.setInterval(10);
+            connect(&poll, &QTimer::timeout, &logoutWait, [this, &logoutWait] {
+                if (!m_radioModel.backendShutdownPending()) {
+                    logoutWait.quit();
+                }
+            });
+            QTimer::singleShot(5000, &logoutWait, &QEventLoop::quit);
+            poll.start();
+            logoutWait.exec(QEventLoop::ExcludeUserInputEvents);
+            if (m_radioModel.backendShutdownPending()) {
+                trace.fail("backend_shutdown_timeout");
+            }
+        }
     }
     audioStopRx();
 
@@ -7085,6 +7105,8 @@ void MainWindow::applyCapabilitiesToUi(bool connected, const RadioCapabilities& 
     // ── Mic sources: MIC / BAL / LINE / ACC are Flex connectors ────────────
     // A radio that cannot have its input chosen by a client collapses to PC.
     if (m_appletPanel) {
+        m_appletPanel->setMicInputChoices(connected ? caps.micInputChoices
+                                                    : QStringList{});
         m_appletPanel->setSelectableMicInputs(!connected || caps.hasSelectableMicInputs);
         // The mic-level gauge follows the METER, not the capability: a Flex
         // does not let a client pick its input either and still publishes
@@ -7094,8 +7116,29 @@ void MainWindow::applyCapabilitiesToUi(bool connected, const RadioCapabilities& 
         // than stranding them on the last radio's three filters.
         m_appletPanel->setRadioFilterWidths(connected ? caps.rxFilterWidthsHz
                                                       : QList<int>{});
+        m_appletPanel->setFmRepeaterAccessModes(
+            connected ? caps.fmRepeaterAccessModes
+                      : QStringList{QStringLiteral("off"),
+                                    QStringLiteral("ctcss_tx")});
         m_appletPanel->setMicLevelMeterAvailable(
             !connected || m_radioModel.meterModel().hasMicPeakMeter());
+        if (m_appletPanel->phoneCwApplet()) {
+            m_appletPanel->phoneCwApplet()->setSpeechProcessorCapabilities(
+                connected ? caps.speechProcessorModes : QStringList{},
+                connected && caps.hasContinuousSpeechProcessorLevel);
+        }
+        if (m_appletPanel->phoneApplet()) {
+            m_appletPanel->phoneApplet()->setControlVisibility(
+                !connected || caps.hasDownwardExpander,
+                !connected || caps.hasTxFilterControl);
+        }
+        if (m_appletPanel->meterApplet()) {
+            m_appletPanel->meterApplet()->setTelemetryVisibility(
+                !connected || caps.hasPaTemperatureTelemetry,
+                !connected || caps.hasSupplyVoltageTelemetry,
+                !connected || caps.hasMainFanTelemetry,
+                connected ? caps.paCurrentMaxAmps : 0.0);
+        }
     }
 
     // ── Display dBm scale: who owns it ─────────────────────────────────────
@@ -7194,6 +7237,8 @@ void MainWindow::applyCapabilitiesToUi(bool connected, const RadioCapabilities& 
             if (!sw) {
                 continue;
             }
+            sw->setPreserveWaterfallHistoryOnLargeRetune(
+                !connected || caps.preservesWaterfallHistoryOnLargeRetune);
             for (auto* vfo : sw->findChildren<VfoWidget*>()) {
                 vfo->setHasExtendedDsp(extendedDsp);
                 vfo->setHasRadioSideDsp(radioSideDsp);
@@ -7204,6 +7249,10 @@ void MainWindow::applyCapabilitiesToUi(bool connected, const RadioCapabilities& 
                 // radio; only the applet was being told what the hardware has.
                 vfo->setRadioFilterWidths(connected ? caps.rxFilterWidthsHz
                                                     : QList<int>{});
+                vfo->setFmRepeaterAccessModes(
+                    connected ? caps.fmRepeaterAccessModes
+                              : QStringList{QStringLiteral("off"),
+                                            QStringLiteral("ctcss_tx")});
             }
             // WNB lives in the pan's overlay menu, not the VFO.
             applyRadioSideDspToPanDisplay(sw);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -474,6 +474,7 @@ private:
     // Constructor wiring blocks extracted per #3351 Phase 2 — each runs once
     // from the constructor, in original order, defined in its subject TU.
     void wireMeters();              // MainWindow_Wiring.cpp
+    void refreshRadioPowerScale();  // MainWindow_Wiring.cpp
     void wireSpotSubsystem();       // MainWindow_Spots.cpp
     // RadioSession precursors (#3351 Phase 2c / #3445) — MainWindow_Session.cpp
     void wireDiscovery();

--- a/src/gui/MainWindow_DspApplets.cpp
+++ b/src/gui/MainWindow_DspApplets.cpp
@@ -259,9 +259,15 @@ void MainWindow::wireDspApplets()
             this, [this](float alc) {
         // FLEX-8000 TX-chain meters can publish quiescent RX values near 0 dBFS.
         // Only show SW ALC while the radio interlock says RF is actually keyed.
+        const bool relative = m_radioModel.meterModel().swAlcUnit()
+            .compare(QLatin1String("Percent"), Qt::CaseInsensitive) == 0;
         m_appletPanel->phoneCwApplet()->updateAlc(
-            m_radioModel.isRadioTransmitting() ? alc : -20.0f);
+            m_radioModel.isRadioTransmitting() ? alc : (relative ? 0.0f : -20.0f));
     });
+    connect(&m_radioModel.meterModel(), &MeterModel::swAlcUnitChanged,
+            m_appletPanel->phoneCwApplet(), &PhoneCwApplet::setAlcUnit);
+    m_appletPanel->phoneCwApplet()->setAlcUnit(
+        m_radioModel.meterModel().swAlcUnit());
     // Client-side PC mic metering — radio CODEC meters only see hardware mics.
     // Apply VU-style ballistics: fast attack, slow decay (~20 dB/sec).
     {

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -464,6 +464,12 @@ void MainWindow::maybeAutoConnectToDiscoveredRadio(const RadioInfo& info)
 {
     if (m_userDisconnected) return;
     if (m_radioModel.isConnected()) return;
+    // RadioModel owns retries once an attempt reaches the backend. Discovery
+    // may see the same radio while that retry is pending; a second RS-BA1
+    // login would displace the first session on a single-client Icom radio.
+    if (m_radioModel.isConnectAttemptInFlight()) {
+        return;
+    }
     if (AppSettings::instance().value("AutoConnectToLastRadio", "True").toString() != "True")
         return;
     const QString lastSerial = AppSettings::instance()
@@ -1769,6 +1775,10 @@ void MainWindow::wirePanLifecycle()
         connect(pan, &PanadapterModel::rfGainInfoChanged,
                 applet->spectrumWidget()->overlayMenu(),
                 &SpectrumOverlayMenu::setRfGainRange);
+        connect(pan, &PanadapterModel::rfGainInfoChanged,
+                this, [applet](int, int, int, const QString& unitSuffix) {
+            applet->spectrumWidget()->setRfGainUnitSuffix(unitSuffix);
+        });
         connect(pan, &PanadapterModel::rfGainChanged,
                 this, [applet](int gain) {
             applet->spectrumWidget()->setRfGain(gain);
@@ -1783,6 +1793,20 @@ void MainWindow::wirePanLifecycle()
         connect(pan, &PanadapterModel::preampStepChanged,
                 applet->spectrumWidget()->overlayMenu(),
                 &SpectrumOverlayMenu::setPreampStep);
+        const auto updatePreampIndicator = [pan, applet] {
+            const QStringList labels = pan->preampLabels();
+            const int step = pan->preampStep();
+            applet->spectrumWidget()->setPreampIndicator(
+                step >= 0 && step < labels.size() ? labels.at(step) : QString());
+        };
+        connect(pan, &PanadapterModel::preampLabelsChanged,
+                this, [updatePreampIndicator](const QStringList&) {
+            updatePreampIndicator();
+        });
+        connect(pan, &PanadapterModel::preampStepChanged,
+                this, [updatePreampIndicator](int) {
+            updatePreampIndicator();
+        });
         connect(pan, &PanadapterModel::attenuatorLabelsChanged,
                 applet->spectrumWidget()->overlayMenu(),
                 &SpectrumOverlayMenu::setAttenuatorLabels);
@@ -1805,8 +1829,10 @@ void MainWindow::wirePanLifecycle()
         applet->spectrumWidget()->overlayMenu()->setRfGainRange(
             pan->rfGainLow(), pan->rfGainHigh(), pan->rfGainStep(),
             pan->rfGainUnitSuffix());
+        applet->spectrumWidget()->setRfGainUnitSuffix(pan->rfGainUnitSuffix());
         applet->spectrumWidget()->overlayMenu()->setPreampLabels(pan->preampLabels());
         applet->spectrumWidget()->overlayMenu()->setPreampStep(pan->preampStep());
+        updatePreampIndicator();
         applet->spectrumWidget()->overlayMenu()->setAttenuatorLabels(pan->attenuatorLabels());
         applet->spectrumWidget()->overlayMenu()->setAttenuatorStep(pan->attenuatorStep());
 

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1955,6 +1955,9 @@ void MainWindow::onSliceAdded(SliceModel* s)
             updateTMate2Display();
 #endif
     });
+    connect(s, &SliceModel::frequencyChanged, this, [this](double) {
+        refreshRadioPowerScale();
+    });
 
     // Feed current frequency immediately (AG may connect later and reprocess).
     if (s->sliceId() == m_activeSliceId && s->frequency() > 0.0)
@@ -2182,7 +2185,10 @@ void MainWindow::onSliceAdded(SliceModel* s)
     // Refresh the split-pair visualization whenever this slice's TX role changes,
     // so an externally-initiated split (rigctld / CAT / TCI / front panel) is
     // reflected on the panadapter, not just GUI-initiated split. (#3726)
-    connect(s, &SliceModel::txSliceChanged, this, [this](bool) { updateSplitState(); });
+    connect(s, &SliceModel::txSliceChanged, this, [this](bool) {
+        updateSplitState();
+        refreshRadioPowerScale();
+    });
 
     // Slice Link bookkeeping: the eligible-peer roster follows diversity and
     // letter changes; a member entering diversity dissolves the link (the
@@ -3676,6 +3682,9 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         // echo a range — one runaway pane is enough to churn the session.
         sw->setRadioOwnsDbmScale(!m_radioModel.isConnected()
                                  || m_radioModel.backendCapabilities().radioOwnsDbmScale);
+        sw->setPreserveWaterfallHistoryOnLargeRetune(
+            !m_radioModel.isConnected()
+            || m_radioModel.backendCapabilities().preservesWaterfallHistoryOnLargeRetune);
 
         wirePanDisplayStatus(applet, pan);
     }
@@ -5140,24 +5149,42 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             }
             clearSwrSweepForBandChange(s->sliceId(), applet->panId(), bandName);
             m_bandSettings.setCurrentBand(bandName);
+            // The IC-9700's three declared hardware-band buttons are intended
+            // as an immediately usable VHF/UHF starting point.  Its generic
+            // BandDefs entries use weak-signal USB on 2 m and 23 cm, which
+            // also produces no carrier (and therefore no Po/SWR indication)
+            // on a bare PTT.  Keep that generic/Flex policy intact and apply
+            // the maintainer-selected FM default only to the Icom backend.
+            const QString requestedMode = caps.family == QLatin1String("icom")
+                ? QStringLiteral("FM") : mode;
             // MODE FIRST, then frequency. The backend adopts a mode-appropriate
             // passband on a mode CHANGE (Hl2Backend::setSliceMode), and the
             // frequency move is what re-selects the companion filter board — so
             // this order leaves both the passband and the band filter settled
             // for the band being arrived at, not the one being left.
-            if (!mode.isEmpty())
-                s->setMode(mode);
-            s->setFrequency(freqMhz);
-            // Centre the window on the new band. Without this the panadapter
-            // keeps the old band's NCO until the tune happens to fall outside
-            // the usable passband, so a band change could leave the trace
-            // centred a whole band away from the slice that just moved.
-            m_radioModel.requestPanCenter(applet->panId(), freqMhz);
+            if (!requestedMode.isEmpty())
+                s->setMode(requestedMode);
+            // One tune pipeline owns both the slice and pan move. Sending a
+            // direct slice tune followed by an independent pan-centre request
+            // let a rejected/echoed slice change leave RX Controls on the old
+            // frequency while the hardware scope jumped to the new band.
+            applyTuneRequest(s, freqMhz, TuneIntent::AbsoluteJump,
+                             "non-flex-band-select");
+            // Rebind the active-slice controls after the synthetic single-slice
+            // band jump.  Unlike a Flex band-stack recall, this path does not
+            // rebuild or reactivate the slice, so there is no subsequent
+            // setActiveSliceInternal() call to refresh an applet binding that
+            // was displaced while the IC-9700 changed scope bands.  Without
+            // this, the pan/VFO followed the model while RX Controls could
+            // retain the preceding band's frequency.
+            if (m_appletPanel && m_appletPanel->rxApplet()) {
+                m_appletPanel->rxApplet()->setSlice(s);
+            }
             qCDebug(lcProtocol).noquote().nospace()
                 << "MainWindow: band switch (no radio band stack) band=" << bandName
                 << " pan=" << applet->panId()
                 << " freq_mhz=" << QString::number(freqMhz, 'f', 6)
-                << " mode=" << mode;
+                << " mode=" << requestedMode;
             return;
         }
 
@@ -5909,6 +5936,45 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
 // MTR / HLTH / TX applet routing. Runs once at construction; kept in this
 // TU with the rest of the model→UI wiring.
 
+void MainWindow::refreshRadioPowerScale()
+{
+    int maxW = m_radioModel.transmitModel().maxPowerLevel();
+    const RadioCapabilities backendCaps = m_radioModel.backendCapabilities();
+    if (!backendCaps.txPowerBands.isEmpty()) {
+        SliceModel* powerSlice = nullptr;
+        for (SliceModel* slice : m_radioModel.slices()) {
+            if (slice->isTxSlice()) {
+                powerSlice = slice;
+                break;
+            }
+        }
+        if (!powerSlice) {
+            powerSlice = activeSlice();
+        }
+        if (powerSlice) {
+            const double bandMax = backendCaps.txPowerMaxWattsAt(
+                powerSlice->frequency() * 1'000'000.0);
+            if (bandMax > 0.0) {
+                maxW = qRound(bandMax);
+            }
+        }
+    }
+
+    // Aurora (AU-) radios have an integrated 600W PA (Overlord) but
+    // max_power_level only reports the exciter limit (100W). Use model
+    // name to detect the true PA capability. (#484)
+    const QString& model = m_radioModel.model();
+    if (model.startsWith("AU-") && maxW <= 100) {
+        maxW = 500;
+    }
+    const bool ampActive = m_radioModel.amplifier().present()
+                        && m_radioModel.amplifier().operate();
+    m_appletPanel->txApplet()->setPowerScale(maxW, ampActive);
+    m_appletPanel->tunerApplet()->setPowerScale(maxW, ampActive);
+    m_appletPanel->setMeterPowerScale(maxW, ampActive);
+    m_appletPanel->healthApplet()->setPowerScale(maxW, ampActive);
+}
+
 void MainWindow::wireMeters()
 {
     // ── S-Meter: MeterModel → SMeterWidget (active slice only) ─────────────
@@ -6500,24 +6566,10 @@ void MainWindow::wireMeters()
     // action calls setPowerScale(200, false) straight at the widget, and a
     // cache out here would then skip the real re-apply that has to
     // overwrite it.
-    auto updatePowerScale = [this]() {
-        int maxW = m_radioModel.transmitModel().maxPowerLevel();
-        // Aurora (AU-) radios have an integrated 600W PA (Overlord) but
-        // max_power_level only reports the exciter limit (100W). Use model
-        // name to detect the true PA capability. (#484)
-        const QString& model = m_radioModel.model();
-        if (model.startsWith("AU-") && maxW <= 100) {
-            maxW = 500;
-        }
-        const bool ampActive = m_radioModel.amplifier().present()
-                            && m_radioModel.amplifier().operate();
-        m_appletPanel->txApplet()->setPowerScale(maxW, ampActive);
-        m_appletPanel->tunerApplet()->setPowerScale(maxW, ampActive);
-        m_appletPanel->setMeterPowerScale(maxW, ampActive);
-        m_appletPanel->healthApplet()->setPowerScale(maxW, ampActive);
-    };
-    connect(&m_radioModel.amplifier(), &AmpModel::presenceChanged, this, updatePowerScale);
-    connect(&m_radioModel.amplifier(), &AmpModel::stateChanged, this, updatePowerScale);
+    connect(&m_radioModel.amplifier(), &AmpModel::presenceChanged,
+            this, &MainWindow::refreshRadioPowerScale);
+    connect(&m_radioModel.amplifier(), &AmpModel::stateChanged,
+            this, &MainWindow::refreshRadioPowerScale);
     // Also refresh on infoChanged (#4813): maxPowerLevelChanged only fires when
     // the numeric value actually changes, which it doesn't on connect if the
     // radio's exciter limit matches TransmitModel's compiled-in default (100W —
@@ -6530,7 +6582,8 @@ void MainWindow::wireMeters()
     // connect (RadioModel.cpp, connectToRadio()), but infoChanged is the
     // signal actually tied to the info data this branch reads, so it doesn't
     // depend on that seeding holding for every connect path.
-    connect(&m_radioModel, &RadioModel::infoChanged, this, updatePowerScale);
+    connect(&m_radioModel, &RadioModel::infoChanged,
+            this, &MainWindow::refreshRadioPowerScale);
 
     // TGXL indicator: two-line rich text — label on top, state smaller below.
     // Green = OPERATE, amber = BYPASS, grey = STANDBY (matches SmartSDR)
@@ -6604,7 +6657,7 @@ void MainWindow::wireMeters()
         }
     });
     connect(&m_radioModel.transmitModel(), &TransmitModel::maxPowerLevelChanged,
-            this, updatePowerScale);
+            this, &MainWindow::refreshRadioPowerScale);
 
     // ── Meter applet: all meters consolidated ──────────────────────────────
     m_appletPanel->meterApplet()->setMeterModel(&m_radioModel.meterModel());
@@ -6623,6 +6676,10 @@ void MainWindow::wireMeters()
     // sample and reset the hold on un-key. (#2561)
     connect(&m_radioModel.meterModel(), &MeterModel::txPeakChanged,
             m_appletPanel->txApplet(), &TxApplet::updatePeakPower);
+    connect(&m_radioModel.meterModel(), &MeterModel::forwardPowerUnitChanged,
+            m_appletPanel->txApplet(), &TxApplet::setForwardPowerUnit);
+    m_appletPanel->txApplet()->setForwardPowerUnit(
+        m_radioModel.meterModel().forwardPowerUnit());
     auto updateTxMeterGate = [this]() {
         const auto& tx = m_radioModel.transmitModel();
         m_appletPanel->txApplet()->setTransmitting(

--- a/src/gui/MeterApplet.cpp
+++ b/src/gui/MeterApplet.cpp
@@ -136,6 +136,12 @@ MeterApplet::MeterApplet(QWidget* parent)
     m_supplyGauge->setAccessibleName(tr("Supply voltage"));
     vbox->addWidget(m_supplyGauge);
 
+    m_paCurrentGauge = new HGauge(0.0f, 4.0f, 3.5f, "PA Current", "",
+        {{0, "0"}, {1, "1"}, {2, "2"}, {3, "3"}, {4, "4"}},
+        this, 3.0f);
+    m_paCurrentGauge->setAccessibleName(tr("PA drain current"));
+    vbox->addWidget(m_paCurrentGauge);
+
     // ── Main Fan gauge ─────────────────────────────────────────────────────────
     m_fanGauge = new HGauge(0.0f, 3000.0f, 2500.0f, "Main Fan", "",
         {{0, "0"}, {500, "500"}, {1000, "1k"}, {1500, "1.5k"}, {2000, "2k"}, {3000, "3k"}},
@@ -150,9 +156,20 @@ MeterApplet::MeterApplet(QWidget* parent)
 
 void MeterApplet::setMeterModel(MeterModel* model)
 {
+    if (m_model == model) {
+        return;
+    }
+    if (m_model) {
+        m_model->disconnect(this);
+    }
     m_model = model;
+    m_fanIdx = -1;
+    m_paCurrentIdx = -1;
+    if (!m_model) {
+        return;
+    }
 
-    connect(model, &MeterModel::hwTelemetryChanged,
+    connect(m_model, &MeterModel::hwTelemetryChanged,
             this, [this](float paTemp, float supplyV) {
         if (m_model->hasPaTemp()) {
             m_paTemp    = paTemp;
@@ -166,28 +183,67 @@ void MeterApplet::setMeterModel(MeterModel* model)
         m_supplyGauge->setLabel(QString("+%1V").arg(supplyV, 0, 'f', 2));
     });
 
-    connect(model, &MeterModel::meterUpdated,
+    connect(m_model, &MeterModel::meterUpdated,
             this, &MeterApplet::onMeterUpdated);
 
     resolveIndices();
 }
 
+void MeterApplet::setTelemetryVisibility(bool paTemperature, bool supplyVoltage,
+                                         bool mainFan, double paCurrentMaxAmps)
+{
+    m_paTempGauge->setVisible(paTemperature);
+    m_tempUnitBtn->setVisible(paTemperature);
+    m_supplyGauge->setVisible(supplyVoltage);
+    m_fanGauge->setVisible(mainFan);
+    const bool paCurrent = paCurrentMaxAmps > 0.0;
+    m_paCurrentGauge->setVisible(paCurrent);
+    if (paCurrent) {
+        const float maximum = static_cast<float>(paCurrentMaxAmps);
+        m_paCurrentGauge->setRange(0.0f, maximum, maximum * 0.875f,
+            {{0.0f, "0"},
+             {maximum * 0.25f, QString::number(maximum * 0.25f, 'g', 3)},
+             {maximum * 0.5f, QString::number(maximum * 0.5f, 'g', 3)},
+             {maximum * 0.75f, QString::number(maximum * 0.75f, 'g', 3)},
+             {maximum, QString::number(maximum, 'g', 3)}},
+            maximum * 0.75f);
+    }
+}
+
 void MeterApplet::resolveIndices()
 {
-    if (!m_model || m_resolved) return;
+    if (!m_model) {
+        return;
+    }
 
-    m_fanIdx = m_model->findMeter("RAD", "MAINFAN");
-    m_resolved = (m_fanIdx >= 0);
+    // Definitions arrive independently; keep resolving each missing index.
+    if (m_fanIdx < 0) {
+        m_fanIdx = m_model->findMeter("RAD", "MAINFAN");
+    }
+    if (m_paCurrentIdx < 0) {
+        m_paCurrentIdx = m_model->findMeter("RAD", "PACURRENT");
+    }
 }
 
 void MeterApplet::onMeterUpdated(int index, float value)
 {
-    if (!m_resolved)
-        resolveIndices();
+    resolveIndices();
 
     if (index == m_fanIdx && m_fanIdx >= 0) {
         m_fanGauge->setValue(value);
         m_fanGauge->setLabel(QStringLiteral("%1 rpm").arg(static_cast<int>(value)));
+    }
+    if (index == m_paCurrentIdx && m_paCurrentIdx >= 0) {
+        // The Icom backend publishes an explicit zero when TX ends because
+        // PACURRENT polling stops in receive. Snap that idle edge instead of
+        // feeding it through HGauge's display smoothing, which otherwise
+        // leaves the last keyed current visibly latched after unkey.
+        if (value <= 0.0f) {
+            m_paCurrentGauge->setValueImmediate(0.0f);
+        } else {
+            m_paCurrentGauge->setValue(value);
+        }
+        m_paCurrentGauge->setLabel(QStringLiteral("%1 A").arg(value, 0, 'f', 2));
     }
 }
 

--- a/src/gui/MeterApplet.h
+++ b/src/gui/MeterApplet.h
@@ -9,20 +9,17 @@ namespace AetherSDR {
 class MeterModel;
 class HGauge;
 
-// Radio hardware telemetry applet — shows PA temperature, supply voltage,
-// and fan speed. Uses hwTelemetryChanged for cached meters (PATEMP, +13.8A)
-// and meterUpdated for additional RAD meters resolved by index (MAINFAN).
-//
-// Note: PACURRENT is intentionally omitted — on FLEX-8000 series the meter
-// range is capped at 10A (declared max) while real PA draw exceeds this at
-// full power, causing the reading to clip. See FlexRadio community thread
-// "PA Current Meter for 6xxx" and bug SMART-11281.
+// Radio hardware telemetry applet. Faces are capability-shaped: PACURRENT is
+// offered only when a backend supplies a verified scale (not on Flex, whose
+// published range clips below real draw; SMART-11281).
 class MeterApplet : public QWidget {
     Q_OBJECT
 public:
     explicit MeterApplet(QWidget* parent = nullptr);
 
     void setMeterModel(MeterModel* model);
+    void setTelemetryVisibility(bool paTemperature, bool supplyVoltage,
+                                bool mainFan, double paCurrentMaxAmps);
 
 private:
     void resolveIndices();
@@ -34,6 +31,7 @@ private:
     HGauge* m_paTempGauge{nullptr};
     HGauge* m_supplyGauge{nullptr};
     HGauge* m_fanGauge{nullptr};
+    HGauge* m_paCurrentGauge{nullptr};
 
     QPushButton* m_tempUnitBtn{nullptr};
 
@@ -43,7 +41,7 @@ private:
 
     // Lazy-resolved meter index (-1 = not yet found)
     int m_fanIdx{-1};
-    bool m_resolved{false};
+    int m_paCurrentIdx{-1};
 };
 
 } // namespace AetherSDR

--- a/src/gui/PhoneApplet.cpp
+++ b/src/gui/PhoneApplet.cpp
@@ -88,6 +88,16 @@ PhoneApplet::PhoneApplet(QWidget* parent)
     setVisible(false);
 }
 
+void PhoneApplet::setControlVisibility(bool downwardExpander, bool txFilter)
+{
+    if (m_dexpRow) {
+        m_dexpRow->setVisible(downwardExpander);
+    }
+    if (m_txFilterSection) {
+        m_txFilterSection->setVisible(txFilter);
+    }
+}
+
 void PhoneApplet::buildUI()
 {
     auto* outer = new QVBoxLayout(this);
@@ -213,9 +223,9 @@ void PhoneApplet::buildUI()
 
     // ── DEXP row: toggle + level slider ────────────────────────────────
     {
-        auto* rowW = new QWidget;
-        rowW->setFixedHeight(24);
-        auto* row = new QHBoxLayout(rowW);
+        m_dexpRow = new QWidget;
+        m_dexpRow->setFixedHeight(24);
+        auto* row = new QHBoxLayout(m_dexpRow);
         row->setContentsMargins(0, 0, 0, 0);
         row->setSpacing(4);
 
@@ -253,14 +263,16 @@ void PhoneApplet::buildUI()
         AetherSDR::ThemeManager::instance().applyStyleSheet(m_dexpLabel, "QLabel { color: {{color.text.primary}}; font-size: 11px; }");
         row->addWidget(m_dexpLabel);
 
-        vbox->addWidget(rowW);
+        vbox->addWidget(m_dexpRow);
     }
 
     // ── TX filter section ────────────────────────────────────────────────
     // Two columns: Low Cut (left) and High Cut (right), each with header
     // centered over < value > step buttons.
     {
-        auto* grid = new QHBoxLayout;
+        m_txFilterSection = new QWidget;
+        auto* grid = new QHBoxLayout(m_txFilterSection);
+        grid->setContentsMargins(0, 0, 0, 0);
         grid->setSpacing(0);
 
         // ── Left column: Low Cut ─────────────────────────────────────────
@@ -372,7 +384,7 @@ void PhoneApplet::buildUI()
         highCol->addLayout(highRow);
         grid->addLayout(highCol);
 
-        vbox->addLayout(grid);
+        vbox->addWidget(m_txFilterSection);
     }
 
 }

--- a/src/gui/PhoneApplet.h
+++ b/src/gui/PhoneApplet.h
@@ -28,6 +28,7 @@ public:
     explicit PhoneApplet(QWidget* parent = nullptr);
 
     void setTransmitModel(TransmitModel* model);
+    void setControlVisibility(bool downwardExpander, bool txFilter);
 
 private:
     void buildUI();
@@ -50,10 +51,12 @@ private:
 
     // DEXP (radio compander control)
     QPushButton* m_dexpBtn{nullptr};
+    QWidget*     m_dexpRow{nullptr};
     GuardedSlider* m_dexpSlider{nullptr};
     QLabel*      m_dexpLabel{nullptr};
 
     // TX filter
+    QWidget* m_txFilterSection{nullptr};
     QSlider* m_lowCutSlider{nullptr};
     ScrollableLabel* m_lowCutLabel{nullptr};
     QPushButton* m_lowCutDown{nullptr};

--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -7,6 +7,7 @@
 #include "Theme.h"
 #include "core/AppSettings.h"
 
+#include <algorithm>
 #include <QPushButton>
 #include <QLabel>
 #include <QLineEdit>
@@ -142,9 +143,8 @@ void PhoneCwApplet::setSelectableMicInputs(bool selectable)
     // to its network port. PC is the only source we can actually feed.
     const QString wanted = selectable ? m_micSourceCombo->currentText()
                                       : QStringLiteral("PC");
-    const QStringList items = selectable
-        ? QStringList{"MIC", "BAL", "LINE", "ACC", "PC"}
-        : QStringList{"PC"};
+    const QStringList items = selectable ? m_micInputChoices
+                                         : QStringList{QStringLiteral("PC")};
     QStringList existing;
     for (int i = 0; i < m_micSourceCombo->count(); ++i)
         existing << m_micSourceCombo->itemText(i);
@@ -178,6 +178,20 @@ void PhoneCwApplet::setSelectableMicInputs(bool selectable)
                          "Its own input selection is made on the radio."));
 }
 
+void PhoneCwApplet::setMicInputChoices(const QStringList& choices)
+{
+    const QStringList normalized = choices.isEmpty()
+        ? QStringList{QStringLiteral("MIC"), QStringLiteral("BAL"),
+                      QStringLiteral("LINE"), QStringLiteral("ACC"),
+                      QStringLiteral("PC")}
+        : choices;
+    if (m_micInputChoices == normalized) {
+        return;
+    }
+    m_micInputChoices = normalized;
+    setSelectableMicInputs(m_selectableMicInputs);
+}
+
 void PhoneCwApplet::setMicLevelMeterAvailable(bool available)
 {
     if (m_micLevelMeterAvailable == available)
@@ -196,6 +210,38 @@ void PhoneCwApplet::setDaxVisible(bool visible)
         const QSignalBlocker blocker(m_daxBtn);
         m_daxBtn->setChecked(false);
     }
+}
+
+void PhoneCwApplet::setSpeechProcessorCapabilities(const QStringList& modes,
+                                                   bool continuous)
+{
+    m_speechProcessorModes = modes;
+    m_continuousSpeechProcessorLevel = continuous;
+
+    if (!m_procSlider) {
+        return;
+    }
+
+    const QSignalBlocker blocker(m_procSlider);
+    if (continuous) {
+        m_procLowLabel->setText(QStringLiteral("0"));
+        m_procMidLabel->setText(QStringLiteral("50"));
+        m_procHighLabel->setText(QStringLiteral("100"));
+        m_procSlider->setRange(0, 100);
+        m_procSlider->setPageStep(10);
+        m_procSlider->setAccessibleDescription(
+            QStringLiteral("Speech processor level, 0 to 100"));
+    } else {
+        m_procLowLabel->setText(QStringLiteral("NOR"));
+        m_procMidLabel->setText(QStringLiteral("DX"));
+        m_procHighLabel->setText(QStringLiteral("DX+"));
+        m_procSlider->setRange(0, 2);
+        m_procSlider->setPageStep(1);
+        m_procSlider->setAccessibleDescription(
+            QStringLiteral("Speech processor level: Normal, DX, or DX+"));
+    }
+    syncPhoneFromModel();
+    applySpeechProcessorVisibility();
 }
 
 void PhoneCwApplet::buildPhonePanel()
@@ -349,26 +395,26 @@ void PhoneCwApplet::buildPhonePanel()
         row->addWidget(m_procBtn);
 
         // 3-position slider with NOR / DX / DX+ labels
-        auto* procGroup = new QWidget;
-        auto* procVbox = new QVBoxLayout(procGroup);
+        m_procGroup = new QWidget;
+        auto* procVbox = new QVBoxLayout(m_procGroup);
         procVbox->setContentsMargins(0, 0, 0, 0);
         procVbox->setSpacing(0);
 
         auto* labelsRow = new QHBoxLayout;
         labelsRow->setContentsMargins(0, 0, 0, 0);
-        auto* norLbl = new QLabel("NOR");
-        auto* dxLbl = new QLabel("DX");
-        auto* dxPlusLbl = new QLabel("DX+");
+        m_procLowLabel = new QLabel("NOR");
+        m_procMidLabel = new QLabel("DX");
+        m_procHighLabel = new QLabel("DX+");
         const QString tickLabelStyle = "QLabel { color: #c8d8e8; font-size: 8px; }";
-        norLbl->setStyleSheet(tickLabelStyle);
-        dxLbl->setStyleSheet(tickLabelStyle);
-        dxPlusLbl->setStyleSheet(tickLabelStyle);
-        norLbl->setAlignment(Qt::AlignLeft | Qt::AlignBottom);
-        dxLbl->setAlignment(Qt::AlignCenter | Qt::AlignBottom);
-        dxPlusLbl->setAlignment(Qt::AlignRight | Qt::AlignBottom);
-        labelsRow->addWidget(norLbl);
-        labelsRow->addWidget(dxLbl);
-        labelsRow->addWidget(dxPlusLbl);
+        m_procLowLabel->setStyleSheet(tickLabelStyle);
+        m_procMidLabel->setStyleSheet(tickLabelStyle);
+        m_procHighLabel->setStyleSheet(tickLabelStyle);
+        m_procLowLabel->setAlignment(Qt::AlignLeft | Qt::AlignBottom);
+        m_procMidLabel->setAlignment(Qt::AlignCenter | Qt::AlignBottom);
+        m_procHighLabel->setAlignment(Qt::AlignRight | Qt::AlignBottom);
+        labelsRow->addWidget(m_procLowLabel);
+        labelsRow->addWidget(m_procMidLabel);
+        labelsRow->addWidget(m_procHighLabel);
         procVbox->addLayout(labelsRow);
 
         m_procSlider = new GuardedSlider(Qt::Horizontal);
@@ -382,7 +428,7 @@ void PhoneCwApplet::buildPhonePanel()
         applyPrimarySliderStyle(m_procSlider);
         procVbox->addWidget(m_procSlider);
 
-        row->addWidget(procGroup, 1);
+        row->addWidget(m_procGroup, 1);
 
         m_daxBtn = new QPushButton("DAX");
         m_daxBtn->setCheckable(true);
@@ -400,8 +446,9 @@ void PhoneCwApplet::buildPhonePanel()
 
         connect(m_procSlider, &QSlider::valueChanged, this, [this](int pos) {
             if (!m_updatingFromModel && m_model) {
-                static constexpr int kLevels[] = {0, 1, 2};
-                m_model->setSpeechProcessorLevel(kLevels[qBound(0, pos, 2)]);
+                m_model->setSpeechProcessorLevel(
+                    m_continuousSpeechProcessorLevel ? qBound(0, pos, 100)
+                                                     : qBound(0, pos, 2));
             }
         });
 
@@ -750,8 +797,26 @@ void PhoneCwApplet::setMode(const QString& mode)
 {
     // A Flex reports bare "CW"; an Icom and an HL2 spell the same mode CWU,
     // and CWL is the reverse-side one. All three drive this applet.
+    m_mode = mode;
     bool isCw = isCwMode(mode);
     m_stack->setCurrentIndex(isCw ? 1 : 0);
+    applySpeechProcessorVisibility();
+}
+
+void PhoneCwApplet::applySpeechProcessorVisibility()
+{
+    const bool available = m_speechProcessorModes.isEmpty()
+        || std::any_of(m_speechProcessorModes.cbegin(),
+                       m_speechProcessorModes.cend(),
+                       [this](const QString& mode) {
+            return mode.compare(m_mode, Qt::CaseInsensitive) == 0;
+        });
+    if (m_procBtn) {
+        m_procBtn->setVisible(available);
+    }
+    if (m_procGroup) {
+        m_procGroup->setVisible(available);
+    }
 }
 
 // ── Model binding ────────────────────────────────────────────────────────────
@@ -855,8 +920,9 @@ void PhoneCwApplet::syncPhoneFromModel()
     m_procBtn->setChecked(m_model->speechProcessorEnable());
 
     {
-        int level = m_model->speechProcessorLevel();
-        int pos = qBound(0, level, 2);
+        const int level = m_model->speechProcessorLevel();
+        const int pos = m_continuousSpeechProcessorLevel
+            ? qBound(0, level, 100) : qBound(0, level, 2);
         m_procSlider->setValue(pos);
     }
 
@@ -956,7 +1022,13 @@ void PhoneCwApplet::updateCompression(float compPeak)
     // MeterModel exposes COMPPEAK as a positive 0..25 dB compression amount.
     // The P/CW gauge face is reversed: 0 = none, -25 = full.
     const float compressionDb = qBound(0.0f, compPeak, 25.0f);
-    m_compGauge->setValue(-compressionDb);
+    if (compressionDb <= 0.0f) {
+        // TX-only metering stops after unkey. The backend's explicit idle
+        // sample must empty the face now, not decay through display smoothing.
+        m_compGauge->setValueImmediate(0.0f);
+    } else {
+        m_compGauge->setValue(-compressionDb);
+    }
 }
 
 void PhoneCwApplet::updateAlc(float alc)
@@ -964,8 +1036,56 @@ void PhoneCwApplet::updateAlc(float alc)
     // Single source (MeterModel::swAlcChanged) → both panel mirrors.
     // HGauge clamps to its construction range, so values outside [-20, 0]
     // pin at the appropriate end.
-    if (m_alcGaugePhone) m_alcGaugePhone->setValue(alc);
-    if (m_alcGaugeCw)    m_alcGaugeCw->setValue(alc);
+    const float idleValue = m_alcIsRelative ? 0.0f : kAlcGaugeFloorDbfs;
+    const bool idle = alc <= idleValue;
+    if (m_alcGaugePhone) {
+        idle ? m_alcGaugePhone->setValueImmediate(idleValue)
+             : m_alcGaugePhone->setValue(alc);
+    }
+    if (m_alcGaugeCw) {
+        idle ? m_alcGaugeCw->setValueImmediate(idleValue)
+             : m_alcGaugeCw->setValue(alc);
+    }
+}
+
+void PhoneCwApplet::setAlcUnit(const QString& unit)
+{
+    const bool relative = unit.compare(QLatin1String("Percent"), Qt::CaseInsensitive) == 0;
+    if (m_alcIsRelative == relative) {
+        return;
+    }
+    m_alcIsRelative = relative;
+
+    for (HGauge* gauge : {m_alcGaugePhone, m_alcGaugeCw}) {
+        if (!gauge) {
+            continue;
+        }
+        if (relative) {
+            gauge->setLabel(QStringLiteral("ALC (%)"));
+            gauge->setUnit(QStringLiteral("%"));
+            gauge->setFillFromRight(false);
+            gauge->setRange(0.0f, 100.0f, 100.0f,
+                            {{0, "0"}, {25, "25"}, {50, "50"},
+                             {75, "75"}, {100, "100"}});
+            gauge->setAccessibleDescription(
+                "Icom relative automatic-level-control indication");
+            gauge->setHoverValueFormatter([](float value) {
+                return QStringLiteral("%1 %").arg(QString::number(value, 'f', 1));
+            });
+            gauge->setValueImmediate(0.0f);
+        } else {
+            gauge->setLabel(QStringLiteral("ALC"));
+            gauge->setUnit(QStringLiteral("dBFS"));
+            gauge->setFillFromRight(true);
+            gauge->setRange(kAlcGaugeFloorDbfs, 0.0f, -3.0f,
+                            {{-20, "-20"}, {-15, "-15"}, {-10, "-10"},
+                             {-5, "-5"}, {0, "0"}});
+            gauge->setAccessibleDescription(
+                "Automatic level control — post-software-ALC SSB peak (dBFS)");
+            gauge->setHoverValueFormatter(alcHoverFormatter());
+            gauge->setValueImmediate(kAlcGaugeFloorDbfs);
+        }
+    }
 }
 
 bool PhoneCwApplet::eventFilter(QObject* obj, QEvent* ev)

--- a/src/gui/PhoneCwApplet.h
+++ b/src/gui/PhoneCwApplet.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QStringList>
 #include <QWidget>
 
 class QPushButton;
@@ -24,11 +25,16 @@ public:
     // Narrow the mic-source dropdown to PC on a radio whose input this client
     // cannot choose (capability hasSelectableMicInputs). Idempotent.
     void setSelectableMicInputs(bool selectable);
+    void setMicInputChoices(const QStringList& choices);
     // Show or hide the mic-level gauge. False on a radio that defines no
     // microphone-peak meter at all — the face would be permanently at its floor
     // and read as a fault rather than as an absence.
     void setMicLevelMeterAvailable(bool available);
     void setDaxVisible(bool visible);
+    // Empty modes preserves the established all-mode processor surface.
+    // Continuous selects a 0..100 level rather than NOR / DX / DX+.
+    void setSpeechProcessorCapabilities(const QStringList& modes,
+                                        bool continuous);
     explicit PhoneCwApplet(QWidget* parent = nullptr);
 
     void setTransmitModel(TransmitModel* model);
@@ -57,6 +63,7 @@ public slots:
 
     // CW meter (ALC 0–100)
     void updateAlc(float alc);
+    void setAlcUnit(const QString& unit);
 
     // Switch between Phone and CW sub-panels based on slice mode.
     void setMode(const QString& mode);
@@ -70,6 +77,7 @@ private:
     void syncPhoneFromModel();
     void syncCwFromModel();
     void applyLevelMeterReceiveGate();
+    void applySpeechProcessorVisibility();
 
     TransmitModel* m_model{nullptr};
     QStackedWidget* m_stack{nullptr};
@@ -86,13 +94,23 @@ private:
 
     QComboBox*   m_micSourceCombo{nullptr};
     bool          m_selectableMicInputs{true};
+    QStringList   m_micInputChoices{QStringLiteral("MIC"), QStringLiteral("BAL"),
+                                    QStringLiteral("LINE"), QStringLiteral("ACC"),
+                                    QStringLiteral("PC")};
     QSlider*     m_micLevelSlider{nullptr};
     QLabel*      m_micLevelLabel{nullptr};
     QPushButton* m_accBtn{nullptr};
 
     QPushButton* m_procBtn{nullptr};
-    QSlider*     m_procSlider{nullptr};   // 3-position: 0=NOR, 1=DX, 2=DX+
+    QWidget*     m_procGroup{nullptr};
+    QLabel*      m_procLowLabel{nullptr};
+    QLabel*      m_procMidLabel{nullptr};
+    QLabel*      m_procHighLabel{nullptr};
+    QSlider*     m_procSlider{nullptr};
     QPushButton* m_daxBtn{nullptr};
+    QStringList  m_speechProcessorModes;
+    QString      m_mode;
+    bool         m_continuousSpeechProcessorLevel{false};
 
     QPushButton* m_monBtn{nullptr};
     QSlider*     m_monSlider{nullptr};
@@ -104,6 +122,7 @@ private:
     // panel is active for the current mode.
     HGauge*      m_alcGaugePhone{nullptr};
     HGauge*      m_alcGaugeCw{nullptr};
+    bool         m_alcIsRelative{false};
 
     // ── CW sub-panel widgets ─────────────────────────────────────────────
 

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -10,6 +10,7 @@
 #include "SliceColorManager.h"
 #include "SliceLabel.h"
 #include "core/DigitalVoiceFeature.h"
+#include "models/FmRepeaterValues.h"
 #include "core/KiwiSdrManager.h"
 #include "core/KiwiSdrProtocol.h"
 #include "models/RadioModel.h"
@@ -48,9 +49,11 @@
 #include <QPainterPath>
 #include <QDoubleSpinBox>
 #include <QDir>
+#include <array>
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <utility>
 #include "core/ThemeManager.h"
 #include "FreqLineEdit.h"
 
@@ -278,29 +281,6 @@ static const ModeSettings& modeSettingsFor(const QString& mode)
     if (mode.startsWith("FDV"))          return digSettings;  // FreeDV digital voice
     return ssbSettings;  // fallback for unknown modes
 }
-
-// ── Standard CTCSS tone table (EIA/TIA-603) ──────────────────────────────────
-
-struct CTCSSTone {
-    int code;
-    const char* designation;
-    double frequency;
-};
-
-static constexpr CTCSSTone CTCSS_TONES[] = {
-    { 1, "XZ", 67.0},  { 2, "XA", 71.9},  { 3, "WA", 74.4},  { 4, "XB", 77.0},
-    { 5, "WB", 79.7},  { 6, "YZ", 82.5},  { 7, "YA", 85.4},  { 8, "YB", 88.5},
-    { 9, "ZZ", 91.5},  {10, "ZA", 94.8},  {11, "ZB", 97.4},  {12, "1Z",100.0},
-    {13, "1A",103.5},  {14, "1B",107.2},  {15, "2Z",110.9},  {16, "2A",114.8},
-    {17, "2B",118.8},  {18, "3Z",123.0},  {19, "3A",127.3},  {20, "3B",131.8},
-    {21, "4Z",136.5},  {22, "4A",141.3},  {23, "4B",146.2},  {24, "5Z",151.4},
-    {25, "5A",156.7},  {26, "5B",162.2},  {27, "6Z",167.9},  {28, "6A",173.8},
-    {29, "6B",179.9},  {30, "7Z",186.2},  {31, "7A",192.8},  {32, "M1",203.5},
-    {33, "8Z",206.5},  {34, "M2",210.7},  {35, "M3",218.1},  {36, "M4",225.7},
-    {37, "9Z",229.1},  {38, "M5",233.6},  {39, "M6",241.8},  {40, "M7",250.3},
-    {41, "0Z",254.1},
-};
-static constexpr int CTCSS_COUNT = sizeof(CTCSS_TONES) / sizeof(CTCSS_TONES[0]);
 
 // Small checkable button used throughout the applet.
 static QPushButton* mkToggle(const QString& text, QWidget* parent = nullptr)
@@ -736,32 +716,77 @@ void RxApplet::buildUI()
                     this, [this](int idx) {
                 if (m_toneModeCmb->signalsBlocked()) return;
                 const QString mode = m_toneModeCmb->itemData(idx).toString();
-                if (m_slice) m_slice->setFmToneMode(mode);
-                m_toneValueCmb->setEnabled(mode == "ctcss_tx");
+                updateFmToneControlVisibility(mode);
+                sendFmRepeaterAccess();
             });
         }
 
         // CTCSS tone value dropdown
         {
             m_toneValueCmb = new GuardedComboBox;
-            for (int i = 0; i < CTCSS_COUNT; ++i) {
-                const auto& t = CTCSS_TONES[i];
+            for (const fm::CtcssTone& t : fm::kCtcssTones) {
                 m_toneValueCmb->addItem(
                     QString("%1 %2 %3").arg(t.code).arg(t.designation)
                         .arg(t.frequency, 0, 'f', 1),
                     QString::number(t.frequency, 'f', 1));
             }
             AetherSDR::applyComboStyle(m_toneValueCmb);
-            m_toneValueCmb->setEnabled(false);  // enabled only when CTCSS TX
             fmLayout->addWidget(m_toneValueCmb);
 
             connect(m_toneValueCmb, QOverload<int>::of(&QComboBox::currentIndexChanged),
-                    this, [this](int idx) {
+                    this, [this](int) {
                 if (m_toneValueCmb->signalsBlocked()) return;
-                if (m_slice)
-                    m_slice->setFmToneValue(m_toneValueCmb->itemData(idx).toString());
+                sendFmRepeaterAccess();
             });
         }
+
+        {
+            auto* row = new QHBoxLayout;
+            row->setSpacing(2);
+            m_toneRxValueCmb = new GuardedComboBox;
+            m_toneRxValueCmb->setAccessibleName("Receive CTCSS frequency");
+            for (const fm::CtcssTone& tone : fm::kCtcssTones) {
+                m_toneRxValueCmb->addItem(
+                    QString("%1 %2 %3").arg(tone.code).arg(tone.designation)
+                        .arg(tone.frequency, 0, 'f', 1),
+                    tone.frequency);
+            }
+            AetherSDR::applyComboStyle(m_toneRxValueCmb);
+            row->addWidget(m_toneRxValueCmb);
+
+            m_dtcsCodeCmb = new GuardedComboBox;
+            m_dtcsCodeCmb->setAccessibleName("DTCS code");
+            for (int code : fm::kDtcsCodes) {
+                m_dtcsCodeCmb->addItem(
+                    QString("%1").arg(code, 3, 10, QLatin1Char('0')), code);
+            }
+            AetherSDR::applyComboStyle(m_dtcsCodeCmb);
+            row->addWidget(m_dtcsCodeCmb);
+
+            m_dtcsTxPolarityCmb = new GuardedComboBox;
+            m_dtcsTxPolarityCmb->addItem("TX N", false);
+            m_dtcsTxPolarityCmb->addItem("TX R", true);
+            AetherSDR::applyComboStyle(m_dtcsTxPolarityCmb);
+            row->addWidget(m_dtcsTxPolarityCmb);
+
+            m_dtcsRxPolarityCmb = new GuardedComboBox;
+            m_dtcsRxPolarityCmb->addItem("RX N", false);
+            m_dtcsRxPolarityCmb->addItem("RX R", true);
+            AetherSDR::applyComboStyle(m_dtcsRxPolarityCmb);
+            row->addWidget(m_dtcsRxPolarityCmb);
+            fmLayout->addLayout(row);
+
+            for (QComboBox* combo : {m_toneRxValueCmb, m_dtcsCodeCmb,
+                                     m_dtcsTxPolarityCmb, m_dtcsRxPolarityCmb}) {
+                connect(combo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                        this, [this](int) {
+                    if (!m_toneModeCmb->signalsBlocked()) {
+                        sendFmRepeaterAccess();
+                    }
+                });
+            }
+        }
+        updateFmToneControlVisibility(QStringLiteral("off"));
 
         // Offset frequency
         {
@@ -2403,13 +2428,13 @@ void RxApplet::connectSlice(SliceModel* s)
         QSignalBlocker b(m_toneModeCmb);
         int idx = m_toneModeCmb->findData(s->fmToneMode());
         if (idx >= 0) m_toneModeCmb->setCurrentIndex(idx);
-        m_toneValueCmb->setEnabled(s->fmToneMode() == "ctcss_tx");
+        updateFmToneControlVisibility(s->fmToneMode());
     }
     connect(s, &SliceModel::fmToneModeChanged, this, [this](const QString& mode) {
         QSignalBlocker b(m_toneModeCmb);
         int idx = m_toneModeCmb->findData(mode);
         if (idx >= 0) m_toneModeCmb->setCurrentIndex(idx);
-        m_toneValueCmb->setEnabled(mode == "ctcss_tx");
+        updateFmToneControlVisibility(mode);
     });
 
     // Tone value
@@ -2430,6 +2455,30 @@ void RxApplet::connectSlice(SliceModel* s)
                 break;
             }
         }
+    });
+    {
+        QSignalBlocker b1(m_toneRxValueCmb), b2(m_dtcsCodeCmb),
+            b3(m_dtcsTxPolarityCmb), b4(m_dtcsRxPolarityCmb);
+        int idx = m_toneRxValueCmb->findData(s->fmToneRxValue().toDouble());
+        if (idx >= 0) m_toneRxValueCmb->setCurrentIndex(idx);
+        idx = m_dtcsCodeCmb->findData(s->fmDtcsCode());
+        if (idx >= 0) m_dtcsCodeCmb->setCurrentIndex(idx);
+        m_dtcsTxPolarityCmb->setCurrentIndex(s->fmDtcsTxReverse() ? 1 : 0);
+        m_dtcsRxPolarityCmb->setCurrentIndex(s->fmDtcsRxReverse() ? 1 : 0);
+    }
+    connect(s, &SliceModel::fmRepeaterAccessChanged, this, [this]() {
+        if (!m_slice) return;
+        QSignalBlocker b1(m_toneValueCmb), b2(m_toneRxValueCmb),
+            b3(m_dtcsCodeCmb), b4(m_dtcsTxPolarityCmb), b5(m_dtcsRxPolarityCmb);
+        int idx = m_toneValueCmb->findData(m_slice->fmToneTxValue());
+        if (idx >= 0) m_toneValueCmb->setCurrentIndex(idx);
+        idx = m_toneRxValueCmb->findData(m_slice->fmToneRxValue().toDouble());
+        if (idx >= 0) m_toneRxValueCmb->setCurrentIndex(idx);
+        idx = m_dtcsCodeCmb->findData(m_slice->fmDtcsCode());
+        if (idx >= 0) m_dtcsCodeCmb->setCurrentIndex(idx);
+        m_dtcsTxPolarityCmb->setCurrentIndex(m_slice->fmDtcsTxReverse() ? 1 : 0);
+        m_dtcsRxPolarityCmb->setCurrentIndex(m_slice->fmDtcsRxReverse() ? 1 : 0);
+        updateFmToneControlVisibility(m_slice->fmToneMode());
     });
 
     // Repeater offset frequency
@@ -2999,6 +3048,66 @@ void RxApplet::updateOffsetDirButtons()
     m_offsetDown->setChecked(dir == "down");
     m_simplexBtn->setChecked(dir == "simplex");
     m_offsetUp->setChecked(dir == "up");
+}
+
+void RxApplet::updateFmToneControlVisibility(const QString& mode)
+{
+    const bool ctcssTx = mode == QLatin1String("ctcss_tx")
+        || mode == QLatin1String("ctcss_txrx")
+        || mode == QLatin1String("ctcss_tx_dtcs_rx");
+    const bool ctcssRx = mode == QLatin1String("ctcss_rx")
+        || mode == QLatin1String("ctcss_txrx")
+        || mode == QLatin1String("dtcs_tx_ctcss_rx");
+    const bool dtcsTx = mode == QLatin1String("dtcs_tx")
+        || mode == QLatin1String("dtcs_txrx")
+        || mode == QLatin1String("dtcs_tx_ctcss_rx");
+    const bool dtcsRx = mode == QLatin1String("dtcs_txrx")
+        || mode == QLatin1String("ctcss_tx_dtcs_rx");
+
+    m_toneValueCmb->setVisible(ctcssTx);
+    m_toneRxValueCmb->setVisible(ctcssRx);
+    m_dtcsCodeCmb->setVisible(dtcsTx || dtcsRx);
+    m_dtcsTxPolarityCmb->setVisible(dtcsTx);
+    m_dtcsRxPolarityCmb->setVisible(dtcsRx);
+}
+
+void RxApplet::setFmRepeaterAccessModes(const QStringList& modes)
+{
+    if (!m_toneModeCmb) return;
+    static const std::array<std::pair<const char*, const char*>, 8> kChoices{{
+        {"off", "Off"}, {"ctcss_tx", "CTCSS TX"},
+        {"ctcss_rx", "CTCSS RX"}, {"ctcss_txrx", "CTCSS TX/RX"},
+        {"dtcs_tx", "DTCS TX"}, {"dtcs_txrx", "DTCS TX/RX"},
+        {"ctcss_tx_dtcs_rx", "CTCSS TX / DTCS RX"},
+        {"dtcs_tx_ctcss_rx", "DTCS TX / CTCSS RX"},
+    }};
+    const QString wanted = m_slice ? m_slice->fmToneMode()
+                                   : m_toneModeCmb->currentData().toString();
+    const QSignalBlocker blocker(m_toneModeCmb);
+    m_toneModeCmb->clear();
+    for (const auto& [key, label] : kChoices) {
+        if (modes.contains(QString::fromLatin1(key))) {
+            m_toneModeCmb->addItem(QString::fromLatin1(label), QString::fromLatin1(key));
+        }
+    }
+    if (m_toneModeCmb->count() == 0) {
+        m_toneModeCmb->addItem(QStringLiteral("Off"), QStringLiteral("off"));
+    }
+    const int wantedIndex = m_toneModeCmb->findData(wanted);
+    m_toneModeCmb->setCurrentIndex(wantedIndex >= 0 ? wantedIndex : 0);
+    updateFmToneControlVisibility(m_toneModeCmb->currentData().toString());
+}
+
+void RxApplet::sendFmRepeaterAccess()
+{
+    if (!m_slice) return;
+    m_slice->setFmRepeaterAccess(
+        m_toneModeCmb->currentData().toString(),
+        m_toneValueCmb->currentData().toDouble(),
+        m_toneRxValueCmb->currentData().toDouble(),
+        m_dtcsCodeCmb->currentData().toInt(),
+        m_dtcsTxPolarityCmb->currentData().toBool(),
+        m_dtcsRxPolarityCmb->currentData().toBool());
 }
 
 void RxApplet::applyOffsetDir(const QString& dir)

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -181,6 +181,7 @@ public:
     // An EMPTY list restores the operator's own configurable set, so this is
     // reversible on disconnect rather than a one-way edit of their settings.
     void setRadioFilterWidths(const QList<int>& widthsHz);
+    void setFmRepeaterAccessModes(const QStringList& modes);
 private:
     // The list actually in force: the radio's when it declared one, else the
     // operator's configurable set. Every site that indexes filter buttons must
@@ -194,6 +195,8 @@ private:
     void updateAgcCombo();
     void updateOffsetDirButtons();
     void applyOffsetDir(const QString& dir);
+    void updateFmToneControlVisibility(const QString& mode);
+    void sendFmRepeaterAccess();
     static QString formatHz(int hz);
     static QString formatStepLabel(int hz);
 
@@ -264,6 +267,10 @@ private:
     QWidget*        m_fmContainer{nullptr};
     QComboBox*      m_toneModeCmb{nullptr};
     QComboBox*      m_toneValueCmb{nullptr};
+    QComboBox*      m_toneRxValueCmb{nullptr};
+    QComboBox*      m_dtcsCodeCmb{nullptr};
+    QComboBox*      m_dtcsTxPolarityCmb{nullptr};
+    QComboBox*      m_dtcsRxPolarityCmb{nullptr};
     QDoubleSpinBox* m_offsetSpin{nullptr};
     QPushButton*    m_offsetDown{nullptr};
     QPushButton*    m_simplexBtn{nullptr};

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -3031,7 +3031,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
         // from the declaration in BandDefs order instead of the HF layout
         // + model capability flags: the radio said what it can do, so the
         // menu offers exactly that (an IC-9700 gets 2m/440/23cm, not an
-        // HF grid it can't tune).  Utility and XVTR rows are unaffected.
+        // HF grid or utility/XVTR rows it can't tune).
         // NB buttons are built from BandDefs here, not via makeBandBtn():
         // BAND_GRID only carries the curated HF-menu entries, so declared
         // VHF/UHF names (440, 23cm, ...) have no BAND_GRID row to reuse.
@@ -3040,7 +3040,15 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
             const QString bandName = QString::fromLatin1(def.name);
             if (!m_declaredBands.contains(bandName))
                 continue;
-            auto* btn = new QPushButton(bandName, m_bandPanel);
+            QString buttonLabel = bandName;
+            if (bandName == QLatin1String("2m")) {
+                buttonLabel = QStringLiteral("144");
+            } else if (bandName == QLatin1String("440")) {
+                buttonLabel = QStringLiteral("430");
+            } else if (bandName == QLatin1String("23cm")) {
+                buttonLabel = QStringLiteral("1240");
+            }
+            auto* btn = new QPushButton(buttonLabel, m_bandPanel);
             btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
             btn->setStyleSheet(bandBtnStyle);
             const double  freq = def.defaultFreqMhz;
@@ -3080,56 +3088,61 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
         }
     }
 
-    // XVTR bands (inserted between HF and utility)
+    // XVTR bands (inserted between HF and utility). A non-empty declared set
+    // is authoritative: do not append configured transverters or generic
+    // utility destinations that the radio did not declare.
     m_xvtrBandBtns.clear();
-    for (int i = 0; i < bands.size(); ++i) {
-        auto* btn = new QPushButton(bands[i].name, m_bandPanel);
-        btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
-        btn->setStyleSheet(xvtrBtnStyle);
-        const double freq = bands[i].rfFreqMhz;
-        const QString name = bands[i].name;
-        const QString stackKey = bands[i].stackKey;
-        connect(btn, &QPushButton::clicked, this, [this, name, freq, stackKey]() {
-            hideAllSubPanels();
-            emit bandSelected(name, freq, "USB", stackKey);
-        });
-        grid->addWidget(btn, row + i / 3, i % 3);
-        m_xvtrBandBtns.append(btn);
-    }
-    if (!bands.isEmpty())
-        row += (bands.size() + 2) / 3;  // advance past XVTR rows
-
-    // Utility buttons: WWV, GEN, 2200, 630, XVTR config
-    constexpr int utilLayout[][3] = {
-        {11, 12, -1},   // WWV, GEN
-        {13, 14, 15},   // 2200, 630, XVTR
-    };
-    for (int r = 0; r < 2; ++r) {
-        for (int col = 0; col < 3; ++col) {
-            int idx = utilLayout[r][col];
-            if (idx < 0) continue;
-            auto* btn = new QPushButton(BAND_GRID[idx].label, m_bandPanel);
+    if (m_declaredBands.isEmpty()) {
+        for (int i = 0; i < bands.size(); ++i) {
+            auto* btn = new QPushButton(bands[i].name, m_bandPanel);
             btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
-            btn->setStyleSheet(bandBtnStyle);
-            QString bandName = QString::fromLatin1(BAND_GRID[idx].bandName);
-            double freq = BAND_GRID[idx].freqMhz;
-            QString mode = QString::fromLatin1(BAND_GRID[idx].mode);
-            if (idx == 15) {
-                connect(btn, &QPushButton::clicked, this, [this]() {
-                    hideAllSubPanels();
-                    emit xvtrSetupRequested();
-                });
-            } else if (bandName.isEmpty()) {
-                btn->setEnabled(false);
-            } else {
-                connect(btn, &QPushButton::clicked, this, [this, bandName, freq, mode]() {
-                    hideAllSubPanels();
-                    emit bandSelected(bandName, freq, mode);
-                });
-            }
-            grid->addWidget(btn, row, col);
+            btn->setStyleSheet(xvtrBtnStyle);
+            const double freq = bands[i].rfFreqMhz;
+            const QString name = bands[i].name;
+            const QString stackKey = bands[i].stackKey;
+            connect(btn, &QPushButton::clicked, this, [this, name, freq, stackKey]() {
+                hideAllSubPanels();
+                emit bandSelected(name, freq, "USB", stackKey);
+            });
+            grid->addWidget(btn, row + i / 3, i % 3);
+            m_xvtrBandBtns.append(btn);
         }
-        ++row;
+        if (!bands.isEmpty()) {
+            row += (bands.size() + 2) / 3;
+        }
+
+        // Utility buttons: WWV, GEN, 2200, 630, XVTR config
+        constexpr int utilLayout[][3] = {
+            {11, 12, -1},
+            {13, 14, 15},
+        };
+        for (int r = 0; r < 2; ++r) {
+            for (int col = 0; col < 3; ++col) {
+                const int idx = utilLayout[r][col];
+                if (idx < 0) {
+                    continue;
+                }
+                auto* btn = new QPushButton(BAND_GRID[idx].label, m_bandPanel);
+                btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
+                btn->setStyleSheet(bandBtnStyle);
+                const QString bandName = QString::fromLatin1(BAND_GRID[idx].bandName);
+                const double freq = BAND_GRID[idx].freqMhz;
+                const QString mode = QString::fromLatin1(BAND_GRID[idx].mode);
+                if (idx == 15) {
+                    connect(btn, &QPushButton::clicked, this, [this]() {
+                        hideAllSubPanels();
+                        emit xvtrSetupRequested();
+                    });
+                } else {
+                    connect(btn, &QPushButton::clicked, this, [this, bandName, freq, mode]() {
+                        hideAllSubPanels();
+                        emit bandSelected(bandName, freq, mode);
+                    });
+                }
+                grid->addWidget(btn, row, col);
+            }
+            ++row;
+        }
     }
 
     m_bandPanel->adjustSize();

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -7561,11 +7561,17 @@ void SpectrumWidget::setFrequencyRangeInternal(double centerMhz, double bandwidt
         if (m_panCenterAnim && m_panCenterAnim->state() != QAbstractAnimation::Stopped) {
             m_panCenterAnim->stop();
         }
-        if (oldBandwidthMhz > 0.0 && bandwidthMhz > 0.0) {
-            handleWaterfallFrequencyFrameChange(waterfallFrameCenterMhz,
-                                                oldBandwidthMhz,
-                                                centerMhz,
-                                                bandwidthMhz);
+        const bool waterfallFrameChanged = bwChanged
+            || std::abs(centerMhz - waterfallFrameCenterMhz) > 1e-9;
+        if (waterfallFrameChanged && oldBandwidthMhz > 0.0 && bandwidthMhz > 0.0) {
+            if (m_preserveWaterfallHistoryOnLargeRetune) {
+                handleWaterfallFrequencyFrameChange(waterfallFrameCenterMhz,
+                                                    oldBandwidthMhz,
+                                                    centerMhz,
+                                                    bandwidthMhz);
+            } else {
+                clearCurrentWaterfallRows();
+            }
         }
         const bool keptSpectrum = reprojectSpectrum(oldCenterMhz, oldBandwidthMhz,
                                                     centerMhz, bandwidthMhz);
@@ -13946,7 +13952,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                     && m_propKIndex >= 0
                     && m_propAIndex >= 0
                     && m_propSfi > 0;
-                if (m_wnbActive || m_rfGainValue != 0 || showProp || m_wideActive) {
+                if (m_wnbActive || m_rfGainValue != 0 || !m_preampIndicator.isEmpty()
+                    || showProp || m_wideActive) {
                     QFont indFont(p.font().family(), 14, QFont::Bold);
                     p.setFont(indFont);
                     const QColor indicatorColor(0xc8, 0xd8, 0xe8, 180);
@@ -13970,10 +13977,16 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                     }
                     if (m_rfGainValue != 0) {
                         drawSegment(
-                            QStringLiteral("%1%2 dB")
-                                .arg(m_rfGainValue > 0 ? "+" : "")
-                                .arg(m_rfGainValue),
+                            QStringLiteral("%1%2%3")
+                                .arg(m_rfGainValue > 0
+                                         && m_rfGainUnitSuffix.contains(QLatin1String("dB"))
+                                     ? "+" : "")
+                                .arg(m_rfGainValue)
+                                .arg(m_rfGainUnitSuffix),
                             indicatorColor);
+                    }
+                    if (!m_preampIndicator.isEmpty()) {
+                        drawSegment(m_preampIndicator, indicatorColor);
                     }
                     if (m_wnbActive) {
                         drawSegment(QStringLiteral("WNB"),
@@ -15092,7 +15105,8 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
             && m_propKIndex >= 0
             && m_propAIndex >= 0
             && m_propSfi > 0;
-        if (m_wnbActive || m_rfGainValue != 0 || showProp || m_wideActive) {
+        if (m_wnbActive || m_rfGainValue != 0 || !m_preampIndicator.isEmpty()
+            || showProp || m_wideActive) {
             QFont indFont = p.font();
             indFont.setPointSize(18);
             indFont.setBold(true);
@@ -15123,10 +15137,17 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
 
             // RF Gain (to the left of WIDE)
             if (m_rfGainValue != 0) {
-                const QString gainStr = (m_rfGainValue > 0)
-                    ? QString("+%1dB").arg(m_rfGainValue)
-                    : QString("%1dB").arg(m_rfGainValue);
+                const QString gainStr = QStringLiteral("%1%2%3")
+                    .arg(m_rfGainValue > 0
+                             && m_rfGainUnitSuffix.contains(QLatin1String("dB"))
+                         ? "+" : "")
+                    .arg(m_rfGainValue)
+                    .arg(m_rfGainUnitSuffix);
                 drawSegment(gainStr, indicatorColor);
+            }
+
+            if (!m_preampIndicator.isEmpty()) {
+                drawSegment(m_preampIndicator, indicatorColor);
             }
 
             // WNB (to the left of RF Gain)

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -143,6 +143,10 @@ public:
     // Same range update, but snaps instead of using the small pan-follow
     // animation. Center Lock uses this so the locked slice stays pinned.
     void setFrequencyRangeImmediate(double centerMhz, double bandwidthMhz);
+    void setPreserveWaterfallHistoryOnLargeRetune(bool preserve)
+    {
+        m_preserveWaterfallHistoryOnLargeRetune = preserve;
+    }
     void clearDisplay();  // blank spectrum and waterfall on disconnect
     void resetGpuResources();  // tear down GPU pipelines for reparenting (#1240)
     void prepareForTopLevelChange(); // unregister QRhiWidget from the current backing-store QRhi
@@ -394,6 +398,19 @@ public:
             reacquireNoiseFloorLock();
         }
         markOverlayDirty();
+    }
+    void setRfGainUnitSuffix(const QString& suffix) {
+        if (m_rfGainUnitSuffix != suffix) {
+            m_rfGainUnitSuffix = suffix;
+            markOverlayDirty();
+        }
+    }
+    void setPreampIndicator(const QString& label) {
+        const QString visibleLabel = label == QLatin1String("OFF") ? QString() : label;
+        if (m_preampIndicator != visibleLabel) {
+            m_preampIndicator = visibleLabel;
+            markOverlayDirty();
+        }
     }
     void setWideActive(bool on) {
         if (m_wideActive != on) {
@@ -1083,6 +1100,7 @@ private:
     // large fixed buffers behind indirection so this can't silently regress.
     static_assert(sizeof(WaterfallStreamState) < 16 * 1024);
     void clearCurrentWaterfallRows();
+    bool m_preserveWaterfallHistoryOnLargeRetune{true};
     void resetKiwiSdrWaterfallDisplayRange();
     void resetCurrentWaterfallRowsForSize(const QSize& waterfallSize,
                                           const QSize& historySize);
@@ -1741,6 +1759,8 @@ private:
     bool m_wnbActive{false};
     bool m_wnbUpdating{false};
     int  m_rfGainValue{0};
+    QString m_rfGainUnitSuffix{QStringLiteral(" dB")};
+    QString m_preampIndicator;
     bool m_wideActive{false};
 
     // HF propagation forecast overlay

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -633,6 +633,7 @@ void TxApplet::updateMeters(float fwdPower, float swr, bool swrValid)
         m_smoothedPower = 0.0f;
         static_cast<HGauge*>(m_fwdGauge)->setValueImmediate(0.0f);
         static_cast<HGauge*>(m_swrGauge)->setValueImmediate(1.0f);
+        static_cast<HGauge*>(m_swrGauge)->setLabel(QStringLiteral("SWR"));
         return;
     }
     m_smoothedPower = fwdPower;
@@ -640,7 +641,11 @@ void TxApplet::updateMeters(float fwdPower, float swr, bool swrValid)
     // Absent SWR parks the gauge at its 1.0 rest position; a raw 0.0 would
     // read as an off-scale value, and holding the last ratio is exactly the
     // stale display #4533 removed.
-    static_cast<HGauge*>(m_swrGauge)->setValue(swrValid ? swr : 1.0f);
+    auto* swrGauge = static_cast<HGauge*>(m_swrGauge);
+    swrGauge->setValue(swrValid ? swr : 1.0f);
+    swrGauge->setLabel(swrValid
+        ? QStringLiteral("SWR %1").arg(swr, 0, 'f', 2)
+        : QStringLiteral("SWR --"));
 }
 
 void TxApplet::updatePeakPower(float fwdPowerInstant)
@@ -673,6 +678,7 @@ void TxApplet::setTransmitting(bool tx)
         static_cast<HGauge*>(m_fwdGauge)->setValueImmediate(0.0f);
         static_cast<HGauge*>(m_fwdGauge)->setPeakValue(0.0f);
         static_cast<HGauge*>(m_swrGauge)->setValueImmediate(1.0f);
+        static_cast<HGauge*>(m_swrGauge)->setLabel(QStringLiteral("SWR"));
     }
 }
 
@@ -784,12 +790,40 @@ void TxApplet::setPowerScale(int maxWatts, bool hasAmplifier)
     m_lastMaxWatts = maxWatts;
     m_lastHasAmplifier = hasAmplifier;
 
+    if (m_forwardPowerIsRelative && maxWatts > 0) {
+        const QString description = QStringLiteral(
+            "Transmit RF power level, 0 to 100 percent of this band's %1 W maximum")
+            .arg(maxWatts);
+        m_rfPowerSlider->setAccessibleDescription(description);
+        m_rfPowerSlider->setToolTip(description);
+    } else {
+        m_rfPowerSlider->setAccessibleDescription(
+            QStringLiteral("Transmit RF power level, 0 to 100 percent of maximum"));
+        m_rfPowerSlider->setToolTip(QString());
+    }
+
     // TX applet always shows exciter (barefoot) power regardless of
     // hasAmplifier — cached above only so a redundant call can be detected.
     // Amplified output power is shown in the AMP applet.
     auto* gauge = static_cast<HGauge*>(m_fwdGauge);
     float gaugeFullScaleW = 0.0f;
-    if (maxWatts > 100) {
+    if (m_forwardPowerIsRelative) {
+        gauge->setLabel(QStringLiteral("RF Pwr (%)"));
+        gauge->setUnit(QStringLiteral("%"));
+        gauge->setRange(0.0f, 120.0f, 100.0f,
+            {{0, "0"}, {40, "40"}, {80, "80"}, {100, "100"}, {120, "120"}});
+        gauge->setAccessibleDescription("Icom relative forward-power indication in percent");
+        gauge->setHoverValueFormatter([](float v) {
+            return QStringLiteral("%1 %").arg(QString::number(std::lround(v)));
+        });
+        gaugeFullScaleW = 120.0f;
+    } else if (maxWatts > 100) {
+        gauge->setLabel(QStringLiteral("RF Pwr"));
+        gauge->setUnit(QStringLiteral("W"));
+        gauge->setAccessibleDescription("RF forward power in watts");
+        gauge->setHoverValueFormatter([](float v) {
+            return QStringLiteral("%1 W").arg(QString::number(std::lround(v)));
+        });
         // Aurora (500 W): 0–600 W, red > 500 W
         gauge->setRange(0.0f, 600.0f, 500.0f,
             {{0, "0"}, {100, "100"}, {200, "200"}, {300, "300"},
@@ -797,6 +831,12 @@ void TxApplet::setPowerScale(int maxWatts, bool hasAmplifier)
         gaugeFullScaleW = 600.0f;
     } else {
         // Barefoot: 0–120 W, red > 100 W
+        gauge->setLabel(QStringLiteral("RF Pwr"));
+        gauge->setUnit(QStringLiteral("W"));
+        gauge->setAccessibleDescription("RF forward power in watts");
+        gauge->setHoverValueFormatter([](float v) {
+            return QStringLiteral("%1 W").arg(QString::number(std::lround(v)));
+        });
         gauge->setRange(0.0f, 120.0f, 100.0f,
             {{0, "0"}, {40, "40"}, {80, "80"}, {100, "100"}, {120, "120"}});
         gaugeFullScaleW = 120.0f;
@@ -805,6 +845,17 @@ void TxApplet::setPowerScale(int maxWatts, bool hasAmplifier)
     // zero) so the visual feel is the same whether the rig is barefoot
     // or an Aurora 500 W exciter. (#2561)
     m_peakDecayWattsPerSec = gaugeFullScaleW / 2.5f;
+}
+
+void TxApplet::setForwardPowerUnit(const QString& unit)
+{
+    const bool relative = unit.compare(QLatin1String("Percent"), Qt::CaseInsensitive) == 0;
+    if (m_forwardPowerIsRelative == relative) {
+        return;
+    }
+    m_forwardPowerIsRelative = relative;
+    m_havePowerScale = false;
+    setPowerScale(m_lastMaxWatts > 0 ? m_lastMaxWatts : 100, m_lastHasAmplifier);
 }
 
 } // namespace AetherSDR

--- a/src/gui/TxApplet.h
+++ b/src/gui/TxApplet.h
@@ -53,6 +53,7 @@ public slots:
     // across overs. (#2561)
     void setTransmitting(bool tx);
     void setPowerScale(int maxWatts, bool hasAmplifier);
+    void setForwardPowerUnit(const QString& unit);
 
 private:
     void buildUI();
@@ -98,6 +99,7 @@ private:
     // Gauges (HGauge*)
     QWidget* m_fwdGauge{nullptr};
     QWidget* m_swrGauge{nullptr};
+    bool m_forwardPowerIsRelative{false};
 
     // Sliders
     GuardedSlider* m_rfPowerSlider{nullptr};

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -12,6 +12,7 @@
 #include "SliceColorManager.h"
 #include "SliceLabel.h"
 #include "core/DigitalVoiceFeature.h"
+#include "models/FmRepeaterValues.h"
 #include "core/KiwiSdrManager.h"
 #include "core/KiwiSdrProtocol.h"
 #include "models/RadioModel.h"
@@ -2320,30 +2321,74 @@ void VfoWidget::buildTabContent()
             // Tone value — simplified list of common CTCSS tones
             m_fmToneValueCmb = new GuardedComboBox;
             m_fmToneValueCmb->setAccessibleName("FM tone frequency");
-            const double tones[] = {67.0,71.9,74.4,77.0,79.7,82.5,85.4,88.5,91.5,94.8,
-                97.4,100.0,103.5,107.2,110.9,114.8,118.8,123.0,127.3,131.8,
-                136.5,141.3,146.2,151.4,156.7,162.2,167.9,173.8,179.9,186.2,
-                192.8,203.5,206.5,210.7,218.1,225.7,229.1,233.6,241.8,250.3,254.1};
-            for (double f : tones)
-                m_fmToneValueCmb->addItem(QString::number(f, 'f', 1),
-                                           QString::number(f, 'f', 1));
+            for (const fm::CtcssTone& tone : fm::kCtcssTones) {
+                m_fmToneValueCmb->addItem(QString::number(tone.frequency, 'f', 1),
+                                           QString::number(tone.frequency, 'f', 1));
+            }
             AetherSDR::applyComboStyle(m_fmToneValueCmb);
             m_fmToneValueCmb->setEnabled(false);
             toneRow->addWidget(m_fmToneValueCmb, 1);
             fvb->addWidget(m_fmToneContainer);
 
+            auto* receiveToneRow = new QHBoxLayout;
+            receiveToneRow->setSpacing(2);
+            m_fmToneRxValueCmb = new GuardedComboBox;
+            m_fmToneRxValueCmb->setAccessibleName("Receive CTCSS frequency");
+            for (const fm::CtcssTone& tone : fm::kCtcssTones) {
+                m_fmToneRxValueCmb->addItem(
+                    QString::number(tone.frequency, 'f', 1), tone.frequency);
+            }
+            AetherSDR::applyComboStyle(m_fmToneRxValueCmb);
+            receiveToneRow->addWidget(m_fmToneRxValueCmb);
+            m_fmDtcsCodeCmb = new GuardedComboBox;
+            m_fmDtcsCodeCmb->setAccessibleName("DTCS code");
+            for (int code : fm::kDtcsCodes) {
+                m_fmDtcsCodeCmb->addItem(
+                    QString("%1").arg(code, 3, 10, QLatin1Char('0')), code);
+            }
+            AetherSDR::applyComboStyle(m_fmDtcsCodeCmb);
+            receiveToneRow->addWidget(m_fmDtcsCodeCmb);
+            m_fmDtcsTxPolarityCmb = new GuardedComboBox;
+            m_fmDtcsTxPolarityCmb->addItem("TX N", false);
+            m_fmDtcsTxPolarityCmb->addItem("TX R", true);
+            AetherSDR::applyComboStyle(m_fmDtcsTxPolarityCmb);
+            receiveToneRow->addWidget(m_fmDtcsTxPolarityCmb);
+            m_fmDtcsRxPolarityCmb = new GuardedComboBox;
+            m_fmDtcsRxPolarityCmb->addItem("RX N", false);
+            m_fmDtcsRxPolarityCmb->addItem("RX R", true);
+            AetherSDR::applyComboStyle(m_fmDtcsRxPolarityCmb);
+            receiveToneRow->addWidget(m_fmDtcsRxPolarityCmb);
+            fvb->addLayout(receiveToneRow);
+
+            const auto sendRepeaterAccess = [this]() {
+                if (!m_slice) return;
+                m_slice->setFmRepeaterAccess(
+                    m_fmToneModeCmb->currentData().toString(),
+                    m_fmToneValueCmb->currentData().toDouble(),
+                    m_fmToneRxValueCmb->currentData().toDouble(),
+                    m_fmDtcsCodeCmb->currentData().toInt(),
+                    m_fmDtcsTxPolarityCmb->currentData().toBool(),
+                    m_fmDtcsRxPolarityCmb->currentData().toBool());
+            };
+
             connect(m_fmToneModeCmb, QOverload<int>::of(&QComboBox::currentIndexChanged),
-                    this, [this](int idx) {
+                    this, [this, sendRepeaterAccess](int idx) {
                 if (m_fmToneModeCmb->signalsBlocked()) return;
                 const QString mode = m_fmToneModeCmb->itemData(idx).toString();
-                if (m_slice) m_slice->setFmToneMode(mode);
-                m_fmToneValueCmb->setEnabled(mode == "ctcss_tx");
+                sendRepeaterAccess();
+                updateFmToneControlVisibility(mode);
             });
             connect(m_fmToneValueCmb, QOverload<int>::of(&QComboBox::currentIndexChanged),
-                    this, [this](int idx) {
+                    this, [this, sendRepeaterAccess](int) {
                 if (m_fmToneValueCmb->signalsBlocked()) return;
-                if (m_slice) m_slice->setFmToneValue(m_fmToneValueCmb->itemData(idx).toString());
+                sendRepeaterAccess();
             });
+            for (QComboBox* combo : {m_fmToneRxValueCmb, m_fmDtcsCodeCmb,
+                                     m_fmDtcsTxPolarityCmb, m_fmDtcsRxPolarityCmb}) {
+                connect(combo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                        this, [sendRepeaterAccess](int) { sendRepeaterAccess(); });
+            }
+            updateFmToneControlVisibility(QStringLiteral("off"));
 
             // Offset row
             auto* offRow = new QHBoxLayout;
@@ -4713,7 +4758,7 @@ void VfoWidget::setSlice(SliceModel* slice)
         QSignalBlocker sb(m_fmToneModeCmb);
         int idx = m_fmToneModeCmb->findData(mode);
         if (idx >= 0) m_fmToneModeCmb->setCurrentIndex(idx);
-        m_fmToneValueCmb->setEnabled(mode == "ctcss_tx");
+        updateFmToneControlVisibility(mode);
         m_updatingFromModel = false;
     });
     connect(m_slice, &SliceModel::fmToneValueChanged, this, [this](const QString& val) {
@@ -4722,6 +4767,20 @@ void VfoWidget::setSlice(SliceModel* slice)
         int idx = m_fmToneValueCmb->findData(val);
         if (idx >= 0) m_fmToneValueCmb->setCurrentIndex(idx);
         m_updatingFromModel = false;
+    });
+    connect(m_slice, &SliceModel::fmRepeaterAccessChanged, this, [this]() {
+        if (!m_slice) return;
+        QSignalBlocker b1(m_fmToneValueCmb), b2(m_fmToneRxValueCmb),
+            b3(m_fmDtcsCodeCmb), b4(m_fmDtcsTxPolarityCmb), b5(m_fmDtcsRxPolarityCmb);
+        int idx = m_fmToneValueCmb->findData(m_slice->fmToneTxValue());
+        if (idx >= 0) m_fmToneValueCmb->setCurrentIndex(idx);
+        idx = m_fmToneRxValueCmb->findData(m_slice->fmToneRxValue().toDouble());
+        if (idx >= 0) m_fmToneRxValueCmb->setCurrentIndex(idx);
+        idx = m_fmDtcsCodeCmb->findData(m_slice->fmDtcsCode());
+        if (idx >= 0) m_fmDtcsCodeCmb->setCurrentIndex(idx);
+        m_fmDtcsTxPolarityCmb->setCurrentIndex(m_slice->fmDtcsTxReverse() ? 1 : 0);
+        m_fmDtcsRxPolarityCmb->setCurrentIndex(m_slice->fmDtcsRxReverse() ? 1 : 0);
+        updateFmToneControlVisibility(m_slice->fmToneMode());
     });
     connect(m_slice, &SliceModel::repeaterOffsetDirChanged, this, [this](const QString& dir) {
         m_updatingFromModel = true;
@@ -4897,6 +4956,54 @@ bool VfoWidget::cancelDirectEntry()
     return true;
 }
 
+void VfoWidget::updateFmToneControlVisibility(const QString& mode)
+{
+    const bool ctcssTx = mode == QLatin1String("ctcss_tx")
+        || mode == QLatin1String("ctcss_txrx")
+        || mode == QLatin1String("ctcss_tx_dtcs_rx");
+    const bool ctcssRx = mode == QLatin1String("ctcss_rx")
+        || mode == QLatin1String("ctcss_txrx")
+        || mode == QLatin1String("dtcs_tx_ctcss_rx");
+    const bool dtcsTx = mode == QLatin1String("dtcs_tx")
+        || mode == QLatin1String("dtcs_txrx")
+        || mode == QLatin1String("dtcs_tx_ctcss_rx");
+    const bool dtcsRx = mode == QLatin1String("dtcs_txrx")
+        || mode == QLatin1String("ctcss_tx_dtcs_rx");
+
+    m_fmToneValueCmb->setVisible(ctcssTx);
+    m_fmToneRxValueCmb->setVisible(ctcssRx);
+    m_fmDtcsCodeCmb->setVisible(dtcsTx || dtcsRx);
+    m_fmDtcsTxPolarityCmb->setVisible(dtcsTx);
+    m_fmDtcsRxPolarityCmb->setVisible(dtcsRx);
+}
+
+void VfoWidget::setFmRepeaterAccessModes(const QStringList& modes)
+{
+    if (!m_fmToneModeCmb) return;
+    static const std::array<std::pair<const char*, const char*>, 8> kChoices{{
+        {"off", "Off"}, {"ctcss_tx", "CTCSS TX"},
+        {"ctcss_rx", "CTCSS RX"}, {"ctcss_txrx", "CTCSS TX/RX"},
+        {"dtcs_tx", "DTCS TX"}, {"dtcs_txrx", "DTCS TX/RX"},
+        {"ctcss_tx_dtcs_rx", "CTCSS TX / DTCS RX"},
+        {"dtcs_tx_ctcss_rx", "DTCS TX / CTCSS RX"},
+    }};
+    const QString wanted = m_slice ? m_slice->fmToneMode()
+                                   : m_fmToneModeCmb->currentData().toString();
+    const QSignalBlocker blocker(m_fmToneModeCmb);
+    m_fmToneModeCmb->clear();
+    for (const auto& [key, label] : kChoices) {
+        if (modes.contains(QString::fromLatin1(key))) {
+            m_fmToneModeCmb->addItem(QString::fromLatin1(label), QString::fromLatin1(key));
+        }
+    }
+    if (m_fmToneModeCmb->count() == 0) {
+        m_fmToneModeCmb->addItem(QStringLiteral("Off"), QStringLiteral("off"));
+    }
+    const int wantedIndex = m_fmToneModeCmb->findData(wanted);
+    m_fmToneModeCmb->setCurrentIndex(wantedIndex >= 0 ? wantedIndex : 0);
+    updateFmToneControlVisibility(m_fmToneModeCmb->currentData().toString());
+}
+
 void VfoWidget::syncFromSlice()
 {
     if (!m_slice) return;
@@ -5034,12 +5141,20 @@ void VfoWidget::syncFromSlice()
     m_sqlBtn->setEnabled(!isDig && !isCw);
     m_sqlSlider->setEnabled(!isDig && !isCw);
     if (isFm) {
-        QSignalBlocker b1(m_fmToneModeCmb), b2(m_fmToneValueCmb), b3(m_fmOffsetSpin);
+        QSignalBlocker b1(m_fmToneModeCmb), b2(m_fmToneValueCmb), b3(m_fmOffsetSpin),
+            b7(m_fmToneRxValueCmb), b8(m_fmDtcsCodeCmb),
+            b9(m_fmDtcsTxPolarityCmb), b10(m_fmDtcsRxPolarityCmb);
         int tmIdx = m_fmToneModeCmb->findData(m_slice->fmToneMode());
         if (tmIdx >= 0) m_fmToneModeCmb->setCurrentIndex(tmIdx);
-        m_fmToneValueCmb->setEnabled(m_slice->fmToneMode() == "ctcss_tx");
+        updateFmToneControlVisibility(m_slice->fmToneMode());
         int tvIdx = m_fmToneValueCmb->findData(m_slice->fmToneValue());
         if (tvIdx >= 0) m_fmToneValueCmb->setCurrentIndex(tvIdx);
+        tvIdx = m_fmToneRxValueCmb->findData(m_slice->fmToneRxValue().toDouble());
+        if (tvIdx >= 0) m_fmToneRxValueCmb->setCurrentIndex(tvIdx);
+        tvIdx = m_fmDtcsCodeCmb->findData(m_slice->fmDtcsCode());
+        if (tvIdx >= 0) m_fmDtcsCodeCmb->setCurrentIndex(tvIdx);
+        m_fmDtcsTxPolarityCmb->setCurrentIndex(m_slice->fmDtcsTxReverse() ? 1 : 0);
+        m_fmDtcsRxPolarityCmb->setCurrentIndex(m_slice->fmDtcsRxReverse() ? 1 : 0);
         m_fmOffsetSpin->setValue(m_slice->fmRepeaterOffsetFreq());
         QSignalBlocker b4(m_fmOffsetDown), b5(m_fmSimplexBtn), b6(m_fmOffsetUp);
         const QString& dir = m_slice->repeaterOffsetDir();

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -610,6 +610,7 @@ public:
     // the VFO grid was simply never given it, so the two filter surfaces
     // in the app disagreed about what the radio could do.
     void setRadioFilterWidths(const QList<int>& widthsHz);
+    void setFmRepeaterAccessModes(const QStringList& modes);
 
     // Reflect whether any client-side AetherDSP NR module (NR2 / NR4 / MNR /
     // BNR / DFNR / RN2) is active by accenting the ADSP launcher, so the cue is
@@ -624,6 +625,7 @@ public:
     void setMarkerWidth(int widthPx);
     void setFilterEdgesHidden(bool hide);
 private:
+    void updateFmToneControlVisibility(const QString& mode);
     int  m_markerWidth{1};
     bool m_filterEdgesHidden{false};
     // Marker: single button cycling Off → 1 px → 3 px on click.  Label
@@ -710,6 +712,10 @@ private:
     QWidget*       m_fmToneContainer{nullptr};
     QComboBox*     m_fmToneModeCmb{nullptr};
     QComboBox*     m_fmToneValueCmb{nullptr};
+    QComboBox*     m_fmToneRxValueCmb{nullptr};
+    QComboBox*     m_fmDtcsCodeCmb{nullptr};
+    QComboBox*     m_fmDtcsTxPolarityCmb{nullptr};
+    QComboBox*     m_fmDtcsRxPolarityCmb{nullptr};
     QDoubleSpinBox* m_fmOffsetSpin{nullptr};
     QPushButton*   m_fmOffsetDown{nullptr};
     QPushButton*   m_fmSimplexBtn{nullptr};

--- a/src/models/FmRepeaterValues.h
+++ b/src/models/FmRepeaterValues.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+namespace AetherSDR::fm {
+
+struct CtcssTone {
+    int code;
+    const char* designation;
+    double frequency;
+};
+
+// Standard EIA/TIA-603 values. One model-facing table serves the UI and the
+// backend boundary validation, so an offered value cannot drift from one the
+// engine accepts.
+inline constexpr std::array<CtcssTone, 41> kCtcssTones{{
+    { 1, "XZ", 67.0},  { 2, "XA", 71.9},  { 3, "WA", 74.4},  { 4, "XB", 77.0},
+    { 5, "WB", 79.7},  { 6, "YZ", 82.5},  { 7, "YA", 85.4},  { 8, "YB", 88.5},
+    { 9, "ZZ", 91.5},  {10, "ZA", 94.8},  {11, "ZB", 97.4},  {12, "1Z",100.0},
+    {13, "1A",103.5},  {14, "1B",107.2},  {15, "2Z",110.9},  {16, "2A",114.8},
+    {17, "2B",118.8},  {18, "3Z",123.0},  {19, "3A",127.3},  {20, "3B",131.8},
+    {21, "4Z",136.5},  {22, "4A",141.3},  {23, "4B",146.2},  {24, "5Z",151.4},
+    {25, "5A",156.7},  {26, "5B",162.2},  {27, "6Z",167.9},  {28, "6A",173.8},
+    {29, "6B",179.9},  {30, "7Z",186.2},  {31, "7A",192.8},  {32, "M1",203.5},
+    {33, "8Z",206.5},  {34, "M2",210.7},  {35, "M3",218.1},  {36, "M4",225.7},
+    {37, "9Z",229.1},  {38, "M5",233.6},  {39, "M6",241.8},  {40, "M7",250.3},
+    {41, "0Z",254.1},
+}};
+
+inline constexpr std::array<int, 104> kDtcsCodes{
+    23,25,26,31,32,36,43,47,51,53,54,65,71,72,73,74,
+    114,115,116,122,125,131,132,134,143,145,152,155,156,162,165,172,174,
+    205,212,223,225,226,243,244,245,246,251,252,255,261,263,265,266,271,
+    274,306,311,315,325,331,332,343,346,351,356,364,365,371,411,412,413,
+    423,431,432,445,446,452,454,455,462,464,465,466,503,506,516,523,526,
+    532,546,565,606,612,624,627,631,632,654,662,664,703,712,723,731,732,
+    734,746,754,
+};
+
+[[nodiscard]] inline bool isCtcssTone(double hz) noexcept
+{
+    if (!std::isfinite(hz)) {
+        return false;
+    }
+    return std::ranges::any_of(kCtcssTones, [hz](const CtcssTone& tone) {
+        return std::abs(tone.frequency - hz) < 0.01;
+    });
+}
+
+[[nodiscard]] inline bool isDtcsCode(int code) noexcept
+{
+    return std::ranges::find(kDtcsCodes, code) != kDtcsCodes.end();
+}
+
+} // namespace AetherSDR::fm

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -70,6 +70,25 @@ MeterModel::MeterModel(QObject* parent)
     : QObject(parent)
 {}
 
+void MeterModel::setTransmitting(bool transmitting)
+{
+    // Clear on both edges. The key-up clear guarantees that even a missed
+    // unkey notification cannot blend this transmission with the previous one.
+    m_fwdPower = 0.0f;
+    m_fwdPowerInstant = 0.0f;
+    m_reflectedPower = 0.0f;
+    m_swr = 1.0f;
+    m_lastTxMeterUpdateMs = 0;
+    m_lastFwdPowerUpdateMs = 0;
+    m_lastReflectedPowerUpdateMs = 0;
+    m_lastSwrUpdateMs = 0;
+
+    emit txMetersChanged(0.0f, 0.0f, false);
+    emit directionalPowerMetersChanged(0.0f, 0.0f, 0.0f, false, false);
+    emit txPeakChanged(0.0f);
+    Q_UNUSED(transmitting);
+}
+
 void MeterModel::setTgxlHandle(quint32 handle)
 {
     if (m_tgxlHandle == handle) return;
@@ -118,7 +137,10 @@ void MeterModel::defineMeter(const MeterDef& def)
         m_escLevelIdxBySlice[def.sourceIndex] = def.index;
     else if (def.source.startsWith("TX") && def.name == "FWDPWR") {
         m_fwdPwrIdx = def.index;
-        m_fwdPwrUnit = def.unit;
+        if (m_fwdPwrUnit != def.unit) {
+            m_fwdPwrUnit = def.unit;
+            emit forwardPowerUnitChanged(m_fwdPwrUnit);
+        }
     }
     else if (def.source.startsWith("TX") && def.name == "REFPWR") {
         m_refPwrIdx = def.index;
@@ -142,7 +164,10 @@ void MeterModel::defineMeter(const MeterDef& def)
         m_hwAlcIdx = def.index;
     else if (def.name == "ALC") {
         m_swAlcIdx = def.index;
-        m_swAlcUnit = def.unit;
+        if (m_swAlcUnit != def.unit) {
+            m_swAlcUnit = def.unit;
+            emit swAlcUnitChanged(m_swAlcUnit);
+        }
     }
     else if (isTxWaveformMeter(def)
              && (def.name == "SC_MIC" || def.name == "SC_FILT_1"
@@ -434,23 +459,6 @@ void MeterModel::clearCompressionState()
     m_lastCompressionSummaryReason.clear();
 }
 
-// Mirrors PhoneCwApplet's kAlcGaugeFloorDbfs. Duplicated rather than shared
-// because models must not include gui headers; meter_model_test pins the pair.
-static constexpr float kAlcGaugeFloorDbfs = -20.0f;
-
-float MeterModel::convertAlcToGaugeDbfs(float raw) const
-{
-    if (m_swAlcUnit.compare(QLatin1String("dBFS"), Qt::CaseInsensitive) == 0
-        || m_swAlcUnit.isEmpty()) {
-        return raw;   // already the gauge's own unit, or a backend from before this field
-    }
-    if (m_swAlcUnit.compare(QLatin1String("Percent"), Qt::CaseInsensitive) == 0) {
-        const float frac = qBound(0.0f, raw / 100.0f, 1.0f);
-        return kAlcGaugeFloorDbfs * (1.0f - frac);
-    }
-    return raw;
-}
-
 qint64 MeterModel::newestValueAgeMs() const
 {
     qint64 newest = -1;
@@ -705,7 +713,8 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
             // because that is what every backend predating this field meant.
             const bool alreadyWatts =
                 m_fwdPwrUnit.compare(QLatin1String("Watts"), Qt::CaseInsensitive) == 0
-                || m_fwdPwrUnit.compare(QLatin1String("W"), Qt::CaseInsensitive) == 0;
+                || m_fwdPwrUnit.compare(QLatin1String("W"), Qt::CaseInsensitive) == 0
+                || m_fwdPwrUnit.compare(QLatin1String("Percent"), Qt::CaseInsensitive) == 0;
             float watts = alreadyWatts ? v : std::pow(10.0f, v / 10.0f) / 1000.0f;
             m_fwdPowerInstant = watts;
             fwdInstantChanged = true;
@@ -782,16 +791,10 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
             m_hwAlc = v;
             hwAlcChangedFlag = true;
         } else if (idx == m_swAlcIdx) {
-            // The ALC consumers are a dBFS gauge (-20..0). A radio that runs its
-            // OWN ALC has no dBFS to give — the IC-705 reports 0..100 % of full
-            // scale — so a percentage handed straight over pins the gauge at the
-            // top and stays there, which is what "ALC is completely pegged"
-            // looked like.
-            //
-            // Map it onto the gauge instead. This is a PRESENTATION mapping and
-            // not a measurement: it says "this fraction of the radio's own ALC
-            // range", and the only honest claim it makes is proportionality.
-            m_swAlc = convertAlcToGaugeDbfs(v);
+            // Preserve the meter's declared native unit. A relative Icom ALC
+            // indication is not physically convertible to dBFS; consumers use
+            // swAlcUnit() to select the correct presentation.
+            m_swAlc = v;
             swAlcChangedFlag = true;
         } else if (activeScMicIdx >= 0 && idx == activeScMicIdx) {
             m_scMic = v;

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -49,6 +49,11 @@ public:
     // indexes against this slice instead of using last-match-wins globals.
     void setActiveTxSlice(int sliceIndex);
 
+    // Start a fresh TX-meter measurement epoch. TX-only producers commonly
+    // stop before a final zero reply arrives, so cached smoothing state must
+    // not cross an unkey/re-key boundary.
+    void setTransmitting(bool transmitting);
+
     // Process a batch of raw meter values from a VITA-49 packet.
     // ids[i] is the meter index, vals[i] is the raw int16 value.
     void updateValues(const QVector<quint16>& ids, const QVector<qint16>& vals);
@@ -195,6 +200,8 @@ public:
     // This is the indicator users actually want — moves with voice peaks
     // and CW keying envelope.  Drives the ALC gauges in the Phone/CW applet.
     float swAlc() const { return m_swAlc; }
+    QString swAlcUnit() const { return m_swAlcUnit; }
+    QString forwardPowerUnit() const { return m_fwdPwrUnit; }
 
     // Convenience: the TX-filter input/output pair (dBFS, from TX "SC_MIC" and
     // TX "SC_FILT_2").  SC_MIC is where PC/remote audio enters the TX chain;
@@ -290,6 +297,8 @@ signals:
     // Emitted when the post-software-ALC SSB-peak meter changes (dBFS).
     // Drives the in-app ALC gauges; fires during voice peaks and CW keying.
     void swAlcChanged(float dbfs);
+    void swAlcUnitChanged(const QString& unit);
+    void forwardPowerUnitChanged(const QString& unit);
 
     // Emitted when either side of the TX-filter pair changes (dBFS in, dBFS out).
     void txFilterLevelsChanged(float scFilt1, float scFilt2);
@@ -311,7 +320,6 @@ private:
     void recomputeSourceIndexMins();
     // Map a radio-side ALC reading onto the dBFS range the gauges are built
     // for. Identity when the backend already declares dBFS.
-    float convertAlcToGaugeDbfs(float raw) const;
     bool isTxWaveformMeter(const MeterDef& def) const;
     bool hasExplicitTxWaveformSourceIndex(const MeterDef& def) const;
     int implicitTxWaveformSliceIndex() const;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1200,7 +1200,36 @@ void RadioModel::setupBackend(const QString& family)
             // the DSP keeps whatever it was opened with — a dead slider.
             connect(s, &SliceModel::agcCommandIssued, this,
                     [this, s](const QString& mode, int thresholdDb) {
-                if (m_backend) m_backend->setSliceAgc(s->sliceId(), mode, thresholdDb);
+                        if (m_backend) m_backend->setSliceAgc(s->sliceId(), mode, thresholdDb);
+                    });
+            connect(s, &SliceModel::fmRepeaterAccessCommandIssued, this,
+                    [this](const QString& mode, double txCtcssHz, double rxCtcssHz,
+                           int dtcsCode, bool dtcsTxReverse, bool dtcsRxReverse) {
+                if (!m_backend
+                    || !m_backend->capabilities().hasExtendedFmRepeaterControls) {
+                    return;
+                }
+                QVariantMap access;
+                access.insert(QStringLiteral("mode"), mode);
+                access.insert(QStringLiteral("txCtcssHz"), txCtcssHz);
+                access.insert(QStringLiteral("rxCtcssHz"), rxCtcssHz);
+                access.insert(QStringLiteral("dtcsCode"), dtcsCode);
+                access.insert(QStringLiteral("dtcsTxReverse"), dtcsTxReverse);
+                access.insert(QStringLiteral("dtcsRxReverse"), dtcsRxReverse);
+                m_backend->invokeExtension(QStringLiteral("icom"),
+                                           QStringLiteral("repeater.access"), 0, access);
+            });
+            connect(s, &SliceModel::repeaterOffsetCommandIssued, this,
+                    [this](const QString& direction, double offsetMhz) {
+                if (!m_backend
+                    || !m_backend->capabilities().hasExtendedFmRepeaterControls) {
+                    return;
+                }
+                QVariantMap offset;
+                offset.insert(QStringLiteral("direction"), direction);
+                offset.insert(QStringLiteral("offsetMhz"), offsetMhz);
+                m_backend->invokeExtension(QStringLiteral("icom"),
+                                           QStringLiteral("repeater.offset"), 0, offset);
             });
             // Receive DSP the radio runs. Same reasoning as AGC above: the
             // applet toggles drive SliceModel, whose Flex wire text a non-Flex
@@ -1774,6 +1803,7 @@ RadioModel::RadioModel(QObject* parent)
     });
     connect(this, &RadioModel::radioTransmittingChanged,
             this, [this](bool transmitting) {
+        m_meterModel.setTransmitting(transmitting);
         if (!transmitting) {
             applyPendingDStarRuntimeConfiguration();
         }
@@ -2055,6 +2085,12 @@ RadioModel::RadioModel(QObject* parent)
             [this](int level) {
         if (m_backend && !usesFlexCommandPlane())
             m_backend->setMicGain(level);
+    });
+    connect(&m_transmitModel, &TransmitModel::micInputCommandIssued, this,
+            [this](const QString& input) {
+        if (m_backend && !usesFlexCommandPlane()) {
+            m_backend->setMicInput(input);
+        }
     });
 
     // Forward transmit model commands to the radio
@@ -3557,6 +3593,11 @@ void RadioModel::disconnectFromRadio()
     }
 }
 
+bool RadioModel::backendShutdownPending() const
+{
+    return m_backend && m_backend->shutdownPending();
+}
+
 void RadioModel::acceptPresentedWanCert()
 {
     if (m_wanConn)
@@ -3749,6 +3790,8 @@ void RadioModel::publishCapabilities(bool connected)
     // greyed out after unplugging an HL2 would look like a fault. Every
     // capability below follows the same `!connected || caps.x` shape.
     m_transmitModel.setHasTuner(!connected || caps.hasTuner);
+    m_transmitModel.setSpeechProcessorLevelMaximum(
+        connected && caps.hasContinuousSpeechProcessorLevel ? 100 : 2);
 
     emit capabilitiesChanged(connected, caps);
 }

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -741,6 +741,7 @@ public:
     // Called by MainWindow when the user cancels the conflict dialog.
     void cancelMultiFlexConflict();
     void disconnectFromRadio();
+    bool backendShutdownPending() const;
     void forceDisconnect();  // Close TCP but allow auto-reconnect
     // Send `radio reboot` (FlexLib Radio.cs:2575), surface a notification to
     // the operator, then trigger forceDisconnect so the standard reconnect

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -764,18 +764,45 @@ void SliceModel::setPlayOn(bool on)
 
 void SliceModel::setFmToneMode(const QString& mode)
 {
-    if (m_fmToneMode == mode) return;
-    m_fmToneMode = mode;
-    sendCommand(QString("slice set %1 fm_tone_mode=%2").arg(m_id).arg(mode));
-    emit fmToneModeChanged(mode);
+    setFmRepeaterAccess(mode, m_fmToneTxValue.toDouble(), m_fmToneRxValue.toDouble(),
+                        m_fmDtcsCode, m_fmDtcsTxReverse, m_fmDtcsRxReverse);
 }
 
 void SliceModel::setFmToneValue(const QString& value)
 {
-    if (m_fmToneValue == value) return;
+    const double hz = value.toDouble();
+    if (m_fmToneValue == value && m_fmToneTxValue == value) return;
     m_fmToneValue = value;
+    m_fmToneTxValue = value;
     sendCommand(QString("slice set %1 fm_tone_value=%2").arg(m_id).arg(value));
     emit fmToneValueChanged(value);
+    emit fmRepeaterAccessChanged();
+    emit fmRepeaterAccessCommandIssued(m_fmToneMode, hz, m_fmToneRxValue.toDouble(),
+                                       m_fmDtcsCode, m_fmDtcsTxReverse,
+                                       m_fmDtcsRxReverse);
+}
+
+void SliceModel::setFmRepeaterAccess(const QString& mode, double txCtcssHz,
+                                     double rxCtcssHz, int dtcsCode,
+                                     bool dtcsTxReverse, bool dtcsRxReverse)
+{
+    const bool modeChanged = m_fmToneMode != mode;
+    m_fmToneMode = mode;
+    m_fmToneTxValue = QString::number(txCtcssHz, 'f', 1);
+    m_fmToneRxValue = QString::number(rxCtcssHz, 'f', 1);
+    m_fmToneValue = m_fmToneTxValue;
+    m_fmDtcsCode = dtcsCode;
+    m_fmDtcsTxReverse = dtcsTxReverse;
+    m_fmDtcsRxReverse = dtcsRxReverse;
+    sendCommand(QString("slice set %1 fm_tone_mode=%2 fm_tone_value=%3")
+                    .arg(m_id).arg(mode).arg(m_fmToneValue));
+    if (modeChanged) {
+        emit fmToneModeChanged(mode);
+    }
+    emit fmToneValueChanged(m_fmToneValue);
+    emit fmRepeaterAccessChanged();
+    emit fmRepeaterAccessCommandIssued(mode, txCtcssHz, rxCtcssHz, dtcsCode,
+                                       dtcsTxReverse, dtcsRxReverse);
 }
 
 void SliceModel::setRepeaterOffsetDir(const QString& dir)
@@ -784,6 +811,7 @@ void SliceModel::setRepeaterOffsetDir(const QString& dir)
     m_repeaterOffsetDir = dir;
     sendCommand(QString("slice set %1 repeater_offset_dir=%2").arg(m_id).arg(dir));
     emit repeaterOffsetDirChanged(dir);
+    emit repeaterOffsetCommandIssued(m_repeaterOffsetDir, m_fmRepeaterOffsetFreq);
 }
 
 void SliceModel::setFmRepeaterOffsetFreq(double mhz)
@@ -793,6 +821,7 @@ void SliceModel::setFmRepeaterOffsetFreq(double mhz)
     sendCommand(QString("slice set %1 fm_repeater_offset_freq=%2")
                     .arg(m_id).arg(mhz, 0, 'f', 6));
     emit fmRepeaterOffsetFreqChanged(mhz);
+    emit repeaterOffsetCommandIssued(m_repeaterOffsetDir, m_fmRepeaterOffsetFreq);
 }
 
 void SliceModel::setTxOffsetFreq(double mhz)
@@ -1514,6 +1543,31 @@ void SliceModel::applyChanges(const SliceDelta& d)
         double v = *d.fmToneValue;
         m_fmToneValue = QString::number(v, 'f', 1);
         emit fmToneValueChanged(m_fmToneValue);
+    }
+    bool repeaterChanged = false;
+    if (d.fmToneTxValue) {
+        m_fmToneTxValue = QString::number(*d.fmToneTxValue, 'f', 1);
+        m_fmToneValue = m_fmToneTxValue;
+        repeaterChanged = true;
+    }
+    if (d.fmToneRxValue) {
+        m_fmToneRxValue = QString::number(*d.fmToneRxValue, 'f', 1);
+        repeaterChanged = true;
+    }
+    if (d.fmDtcsCode) {
+        m_fmDtcsCode = *d.fmDtcsCode;
+        repeaterChanged = true;
+    }
+    if (d.fmDtcsTxReverse.has_value()) {
+        m_fmDtcsTxReverse = *d.fmDtcsTxReverse;
+        repeaterChanged = true;
+    }
+    if (d.fmDtcsRxReverse.has_value()) {
+        m_fmDtcsRxReverse = *d.fmDtcsRxReverse;
+        repeaterChanged = true;
+    }
+    if (repeaterChanged) {
+        emit fmRepeaterAccessChanged();
     }
     if (d.repeaterOffsetDir.has_value()) {
         m_repeaterOffsetDir = *d.repeaterOffsetDir;

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -185,6 +185,11 @@ public:
     // Getters — FM duplex/repeater
     QString fmToneMode()          const { return m_fmToneMode; }
     QString fmToneValue()         const { return m_fmToneValue; }
+    QString fmToneTxValue()       const { return m_fmToneTxValue; }
+    QString fmToneRxValue()       const { return m_fmToneRxValue; }
+    int     fmDtcsCode()          const { return m_fmDtcsCode; }
+    bool    fmDtcsTxReverse()     const { return m_fmDtcsTxReverse; }
+    bool    fmDtcsRxReverse()     const { return m_fmDtcsRxReverse; }
     QString repeaterOffsetDir()   const { return m_repeaterOffsetDir; }
     double  fmRepeaterOffsetFreq()const { return m_fmRepeaterOffsetFreq; }
     double  txOffsetFreq()        const { return m_txOffsetFreq; }
@@ -299,6 +304,9 @@ public:
     // Setters — FM duplex/repeater
     void setFmToneMode(const QString& mode);
     void setFmToneValue(const QString& value);
+    void setFmRepeaterAccess(const QString& mode, double txCtcssHz,
+                             double rxCtcssHz, int dtcsCode,
+                             bool dtcsTxReverse, bool dtcsRxReverse);
     void setRepeaterOffsetDir(const QString& dir);
     void setFmRepeaterOffsetFreq(double mhz);
     void setTxOffsetFreq(double mhz);
@@ -453,8 +461,13 @@ signals:
     // FM duplex/repeater signals
     void fmToneModeChanged(const QString& mode);
     void fmToneValueChanged(const QString& value);
+    void fmRepeaterAccessChanged();
+    void fmRepeaterAccessCommandIssued(const QString& mode, double txCtcssHz,
+                                       double rxCtcssHz, int dtcsCode,
+                                       bool dtcsTxReverse, bool dtcsRxReverse);
     void repeaterOffsetDirChanged(const QString& dir);
     void fmRepeaterOffsetFreqChanged(double mhz);
+    void repeaterOffsetCommandIssued(const QString& dir, double mhz);
     void txOffsetFreqChanged(double mhz);
     void fmDeviationChanged(int hz);
 
@@ -592,6 +605,11 @@ private:
     // FM duplex/repeater state
     QString m_fmToneMode{"off"};
     QString m_fmToneValue{"100.0"};
+    QString m_fmToneTxValue{"100.0"};
+    QString m_fmToneRxValue{"100.0"};
+    int     m_fmDtcsCode{23};
+    bool    m_fmDtcsTxReverse{false};
+    bool    m_fmDtcsRxReverse{false};
     QString m_repeaterOffsetDir{"simplex"};
     double  m_fmRepeaterOffsetFreq{0.0};
     double  m_txOffsetFreq{0.0};

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -458,6 +458,7 @@ void TransmitModel::setMicSelection(const QString& input)
         m_micSelection = normalized;
         emit micStateChanged();
     }
+    emit micInputCommandIssued(normalized);
     emit commandReady(QString("mic input %1").arg(normalized));
 }
 
@@ -495,18 +496,34 @@ void TransmitModel::setSpeechProcessorEnable(bool on)
 
 void TransmitModel::setSpeechProcessorLevel(int level)
 {
-    // NOR=0, DX=1, DX+=2 (pcap confirmed: speech_processor_level, not compander_level).
+    // Flex uses NOR=0, DX=1, DX+=2; continuous-level radios publish a larger
+    // maximum through capabilities.
     // Optimistic update: radio does not echo in incremental status.
-    level = qBound(0, level, 2);
+    level = qBound(0, level, m_speechProcLevelMaximum);
     m_speechProcLevel = level;
     emit micStateChanged();
     emit speechProcessorCommandIssued(m_speechProcEnable, m_speechProcLevel);
     emit commandReady(QString("transmit set speech_processor_level=%1").arg(level));
 }
 
+void TransmitModel::setSpeechProcessorLevelMaximum(int maximum)
+{
+    maximum = qBound(2, maximum, 100);
+    if (m_speechProcLevelMaximum == maximum) {
+        return;
+    }
+    m_speechProcLevelMaximum = maximum;
+    const int boundedLevel = qBound(0, m_speechProcLevel,
+                                    m_speechProcLevelMaximum);
+    if (boundedLevel != m_speechProcLevel) {
+        m_speechProcLevel = boundedLevel;
+        emit micStateChanged();
+    }
+}
+
 bool TransmitModel::applySpeechProcessorState(bool on, int level)
 {
-    level = qBound(0, level, 2);
+    level = qBound(0, level, m_speechProcLevelMaximum);
     if (m_speechProcEnable == on && m_speechProcLevel == level) {
         return false;
     }

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -56,6 +56,7 @@ public:
     bool    micAcc()                const { return m_micAcc; }
     bool    speechProcessorEnable() const { return m_speechProcEnable; }
     int     speechProcessorLevel()  const { return m_speechProcLevel; }
+    int     speechProcessorLevelMaximum() const { return m_speechProcLevelMaximum; }
     bool    companderOn()           const { return m_companderOn; }
     int     companderLevel()        const { return m_companderLevel; }
     bool    daxOn()                 const { return m_daxOn; }
@@ -239,6 +240,7 @@ public:
     void setMicAcc(bool on);
     void setSpeechProcessorEnable(bool on);
     void setSpeechProcessorLevel(int level);
+    void setSpeechProcessorLevelMaximum(int maximum);
     // Adopt speech-processor state that did NOT come from this model — the
     // client-side compressor on a host-modulating backend, where PROC drives our
     // own DSP and the operator can also reach that same compressor through the
@@ -332,6 +334,7 @@ signals:
     // this, or a Flex's own `transmit set miclevel=` echo would be handed
     // straight back to the seam as a fresh command.
     void micLevelCommandIssued(int level);
+    void micInputCommandIssued(const QString& input);
     // The operator moved PROC or its NOR/DX/DX+ level. OPERATOR INTENT ONLY,
     // for the same reason as txFilterCommandIssued — and here the distinction is
     // what protects the operator's own work: the client compressor these drive is
@@ -414,6 +417,7 @@ private:
     bool    m_micAcc{false};
     bool    m_speechProcEnable{false};
     int     m_speechProcLevel{0};
+    int     m_speechProcLevelMaximum{2};
     bool    m_companderOn{false};
     int     m_companderLevel{0};
     bool    m_daxOn{false};

--- a/tests/IcomFakeRadio.h
+++ b/tests/IcomFakeRadio.h
@@ -193,6 +193,7 @@ public:
     [[nodiscard]] std::uint8_t announcedRxCodec() const { return m_announcedRxCodec; }
     [[nodiscard]] int authCount() const { return m_authCount; }
     [[nodiscard]] bool serialOpened() const { return m_serialOpened; }
+    [[nodiscard]] int serialOpenCount() const { return m_serialOpenCount; }
     [[nodiscard]] bool sawUsernameObfuscated() const { return m_usernameObfuscated; }
     [[nodiscard]] int civCommandsSeen() const { return m_civCommands; }
     // What the radio currently holds for a 1A 05 leaf — the persisted-state
@@ -210,6 +211,11 @@ public:
     [[nodiscard]] const std::vector<std::uint16_t>& deauthOuterSequences() const
     {
         return m_deauthOuterSequences;
+    }
+    void setIgnoredDeauthReplies(int count) { m_ignoredDeauthReplies = count; }
+    [[nodiscard]] bool deauthFollowedSerialClose() const
+    {
+        return m_deauthFollowedSerialClose;
     }
     [[nodiscard]] const std::vector<std::uint16_t>& loginTokenRequestIds() const
     {
@@ -229,6 +235,10 @@ public:
     void setRejectRenewalsAfter(int accepted) { m_acceptRenewals = accepted; }
     void setReissueInitialTokenOnNextLogin(bool on) { m_reissueNextInitialToken = on; }
     void setAuthFailureOnLogin(bool on) { m_authFailureOnLogin = on; }
+    void setAuthFailureOnStreamRequestOnce(bool on)
+    {
+        m_authFailureOnStreamRequestOnce = on;
+    }
     // The PREVIOUS session's teardown status, delivered on the new control
     // association before this session has a stream grant to protect it. At
     // that point the lifecycle exception does not apply yet, so the header
@@ -381,6 +391,18 @@ private:
             ++m_authCount;
             if (kind == static_cast<std::uint8_t>(AuthKind::Deauth)) {
                 m_deauthOuterSequences.push_back(getLe16(b, 0x06));
+                m_deauthFollowedSerialClose = !m_serialOpened;
+                if (m_ignoredDeauthReplies > 0) {
+                    --m_ignoredDeauthReplies;
+                    return;
+                }
+                auto reply = s.frame(kLenToken, 0x00, m_seq++);
+                reply[0x14] = 0x02;
+                reply[0x15] = static_cast<std::uint8_t>(AuthKind::Deauth);
+                for (int i = 0x16; i < 0x20; ++i) {
+                    reply[static_cast<std::size_t>(i)] = static_cast<std::uint8_t>(b[i]);
+                }
+                s.send(reply);
                 return;
             }
             if (kind != 0x05) {
@@ -459,6 +481,12 @@ private:
             }
             m_streamRequestAuthIds.push_back(requestAuthId);
 
+            if (m_authFailureOnStreamRequestOnce) {
+                m_authFailureOnStreamRequestOnce = false;
+                pushAuthFailure(false);
+                return;
+            }
+
             // Refuse unless the client echoed back the identity we published in
             // the capabilities packet. A real radio has to know WHICH radio the
             // client wants when a server fronts several.
@@ -488,7 +516,11 @@ private:
     {
         const auto marker = static_cast<std::uint8_t>(b[0x10]);
         if (b.size() == 0x16 && marker == 0xc0) {
-            m_serialOpened = static_cast<std::uint8_t>(b[0x15]) == 0x05;
+            const std::uint8_t magic = static_cast<std::uint8_t>(b[0x15]);
+            m_serialOpened = magic == 0x04 || magic == 0x05;
+            if (m_serialOpened) {
+                ++m_serialOpenCount;
+            }
             return;
         }
         if (marker != 0xc1)
@@ -828,6 +860,7 @@ private:
     std::vector<CivFrame> m_civLog;
     bool m_sentCaps = false;
     bool m_serialOpened = false;
+    int m_serialOpenCount = 0;
     bool m_usernameObfuscated = false;
     int m_authCount = 0;
     int m_civCommands = 0;
@@ -837,6 +870,7 @@ private:
     bool m_reissueNextInitialToken = false;
     bool m_reissueThisInitialToken = false;
     bool m_authFailureOnLogin = false;
+    bool m_authFailureOnStreamRequestOnce = false;
     bool m_staleAuthFailureOnLogin = false;
     bool m_corruptNextRenewalSeq = false;
     int m_acceptRenewals = std::numeric_limits<int>::max();
@@ -845,6 +879,8 @@ private:
     std::vector<AuthId> m_renewalAuthIds;
     std::vector<AuthId> m_streamRequestAuthIds;
     std::vector<std::uint16_t> m_deauthOuterSequences;
+    int m_ignoredDeauthReplies = 0;
+    bool m_deauthFollowedSerialClose = false;
     std::vector<std::uint16_t> m_loginTokenRequestIds;
     int m_audioFromClient = 0;
     quint32 m_announcedCiv = 0;

--- a/tests/health_applet_test.cpp
+++ b/tests/health_applet_test.cpp
@@ -82,6 +82,35 @@ QString statusText(HealthApplet& applet)
     return label ? label->text() : QStringLiteral("<missing>");
 }
 
+QString powerText(HealthApplet& applet)
+{
+    const QList<QLabel*> labels = applet.findChildren<QLabel*>();
+    for (QLabel* label : labels) {
+        if (label->text().startsWith(QStringLiteral("PWR "))) {
+            return label->text();
+        }
+    }
+    return QStringLiteral("<missing>");
+}
+
+void testRelativePowerIsNotLabelledWatts()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(1, QStringLiteral("FWDPWR"),
+                              QStringLiteral("Percent")));
+    model.defineMeter(txMeter(2, QStringLiteral("SWR"), QStringLiteral("SWR")));
+    HealthApplet applet;
+    applet.setMeterModel(&model);
+    applet.show();
+
+    model.updateValues({1, 2}, {50, rawMeterValue(1.1f)});
+    processEventsFor(120);
+    const QString text = powerText(applet);
+    report("relative forward power is labelled as percent, not watts",
+           text.contains(QLatin1Char('%')) && !text.contains(QLatin1String(" W")),
+           text);
+}
+
 void testUnkeyTransientDoesNotLatchWarning()
 {
     MeterModel model;
@@ -177,6 +206,7 @@ int main(int argc, char** argv)
     testKeyTransientDoesNotPoisonBaseline();
     testIntermittentSwrOutliersDoNotLatchWarning();
     testSustainedHighSwrStillWarnsAtLowPower();
+    testRelativePowerIsNotLabelledWatts();
 
     std::printf("\n%d health applet test(s) failed\n", g_failed);
     return g_failed == 0 ? 0 : 1;

--- a/tests/icom_backend_test.cpp
+++ b/tests/icom_backend_test.cpp
@@ -110,7 +110,7 @@ int main(int argc, char** argv)
                      [&](int, const QByteArray& pcm) {
                          ++sliceAudioBuffers;
                          sliceAudioBytes += pcm.size();
-                     });
+    });
     QObject::connect(&backend, &IRadioBackend::audioFrameReady, &app,
                      [&](const QByteArray&) { ++speakerBuffers; });
 
@@ -119,6 +119,7 @@ int main(int argc, char** argv)
     // nine that arrived in their own frames a millisecond earlier.
     SliceDelta lastSliceState;
     TransmitDelta lastTransmitState;
+    RadioDelta lastRadioState;
     std::vector<QString> publishedModes;
     // Every mox edge in order. The PTT confirmation window is defined by which
     // transitions it lets through, so the SEQUENCE is the assertion, not the
@@ -161,6 +162,11 @@ int main(int argc, char** argv)
         if (d.atuStatusRaw) lastTransmitState.atuStatusRaw = d.atuStatusRaw;
         if (d.mox) { lastTransmitState.mox = d.mox; moxPublications.push_back(*d.mox); }
     });
+    QObject::connect(&backend, &IRadioBackend::radioChanged, &app,
+                     [&](const RadioDelta& d) {
+                         if (d.model) lastRadioState.model = d.model;
+                         if (d.nickname) lastRadioState.nickname = d.nickname;
+                     });
 
     QSignalSpy connectedSpy(&backend, &IRadioBackend::connected);
     QSignalSpy sliceSpy(&backend, &IRadioBackend::sliceChanged);
@@ -180,6 +186,8 @@ int main(int argc, char** argv)
     backend.connectRadio(req);
     check(waitFor([&] { return backend.isConnected(); }), "the backend connects");
     check(connectedSpy.count() == 1, "and emits connected() exactly once");
+    check(lastRadioState.nickname == QStringLiteral("IC-705"),
+          "the known Icom model is published as the default radio nickname");
 
     quint64 schedulerRequestId = 9000;
     const auto waitSchedulerIdle = [&](int timeoutMs = 5000) {
@@ -241,6 +249,14 @@ int main(int argc, char** argv)
           "the backend ASKS the radio what it is (0x19 0x00) rather than assuming");
     check(backend.model().name == "IC-705", "and resolves the IC-705");
     check(backend.model().verified, "whose capability numbers are tier-1 verified");
+    const RadioCapabilities ic705Caps = backend.capabilities();
+    check(ic705Caps.hasTuner, "IC-705 retains its external-tuner control");
+    check(!ic705Caps.hasContinuousSpeechProcessorLevel,
+          "IC-705 retains the established three-preset processor surface");
+    check(ic705Caps.preservesWaterfallHistoryOnLargeRetune,
+          "IC-705 does not inherit IC-9700 waterfall reset semantics");
+    check(!ic705Caps.hasExtendedFmRepeaterControls,
+          "IC-705 does not inherit IC-9700 repeater commands");
     check(waitSchedulerIdle(),
           "connect-time radio-authoritative state converges through the scheduler");
     const SliceDelta connectedSliceState = lastSliceState;
@@ -389,6 +405,25 @@ int main(int argc, char** argv)
                           movesPttOrTuner),
               "and a real key IS caught by the TX-safety predicate, so the "
               "scrub's 'never keys' check is not vacuous");
+
+        // Once the pre-key reconciliation backlog has drained, transmit must
+        // reserve the CI-V command plane for PTT and meter traffic. The real
+        // IC-9700 stopped answering with 35--40 requests queued when the full
+        // receive/control sweep continued alongside five TX meters.
+        QTest::qWait(1600);
+        radio.clearCivLog();
+        QTest::qWait(1100);                  // crosses one link/control tick
+        const auto keyedCommands = radio.civCommands();
+        check(!keyedCommands.empty(),
+              "keyed polling remains live while background reconciliation is suspended");
+        check(std::all_of(keyedCommands.begin(), keyedCommands.end(),
+                          [](const CivFrame& frame) {
+                              return frame.cmd == cmd::kMeter
+                                  || (frame.cmd == cmd::kControl && frame.hasSub
+                                      && frame.sub == control::kPtt);
+                          }),
+              "keyed polling contains only meters and PTT, not the background "
+              "receive/control sweep that saturated the IC-9700 command plane");
 
         backend.setKeying(false);
         check(waitSchedulerIdle(), "unkey and its radio confirmation complete");
@@ -817,6 +852,9 @@ int main(int argc, char** argv)
               "NR/NB state and levels are periodically reconciled while CI-V is live");
 
         radio.clearCivLog();
+        QSignalSpy disconnectedSpy(&backend, &IRadioBackend::disconnected);
+        QSignalSpy connectionErrorSpy(&backend, &IRadioBackend::connectionError);
+        const int serialOpensBeforeStall = radio.serialOpenCount();
         radio.setCivSilent(true);
 
         // A command the radio receives and does not answer.
@@ -830,25 +868,69 @@ int main(int argc, char** argv)
               }, 1000),
               "a deaf radio still RECEIVES — the command reached it");
 
+        // A scope datagram after the targeted restart proves only that the
+        // serial pipe reopened. It must trigger an ordinary read probe rather
+        // than canceling recovery while command replies remain silent.
+        check(waitFor([&] {
+                  return radio.serialOpenCount() > serialOpensBeforeStall;
+              }, 4000),
+              "the first targeted CI-V restart is issued");
+        {
+            std::vector<std::uint8_t> body{0x00, encodeBcdByte(1), encodeBcdByte(1),
+                                           0x00};
+            const auto centre = encodeFreq(14'100'000);
+            const auto span = encodeFreq(100'000);
+            body.insert(body.end(), centre.begin(), centre.end());
+            body.insert(body.end(), span.begin(), span.end());
+            body.push_back(0x00);
+            for (int i = 0; i < kScopePointsIc705; ++i) {
+                body.push_back(static_cast<std::uint8_t>(i % (kScopeMaxAmplitude + 1)));
+            }
+            std::vector<std::uint8_t> scopeFrame{
+                0xFE, 0xFE, kControllerAddress, kIc705Addr,
+                cmd::kScope, scope::kWaveData};
+            scopeFrame.insert(scopeFrame.end(), body.begin(), body.end());
+            scopeFrame.push_back(kCivEom);
+            radio.pushCiv(scopeFrame);
+        }
+        check(waitFor([&] {
+                  return std::any_of(radio.civCommands().begin(), radio.civCommands().end(),
+                                     [](const CivFrame& f) {
+                                         return f.cmd == cmd::kReadFreq
+                                             && f.data.empty();
+                                     });
+              }, 1000),
+              "scope-only recovery triggers an ordinary command-plane probe");
+
         // The detector needs its own threshold to elapse with no inbound frame.
         // Deliberately wall-clock rather than injectable: the thing being tested
         // is that a real session notices real silence.
         QSignalSpy healthSpy(&backend, &IRadioBackend::linkStatsUpdated);
-        QTest::qWait(7000);
+        // onLinkTick is one-second paced and may observe the initial two-second
+        // threshold just after a boundary; allow a scheduling interval of
+        // margin, but continue as soon as fallback disconnect actually occurs.
+        const bool disconnectedAfterRecovery =
+            waitFor([&] { return !backend.isConnected(); }, 7000);
 
         check(healthSpy.count() > 0,
               "link statistics keep flowing while the command plane is dead — "
               "which is exactly why the transport cannot be trusted to report this");
 
-        // The warning is emitted through the log category rather than a signal,
-        // so what is asserted here is the STATE that produces it: the backend
-        // still believes it is connected while nothing has come back.
-        check(backend.isConnected(),
-              "and isConnected() still reports true — the lie the detector exists "
-              "to break");
+        check(radio.serialOpenCount() >= serialOpensBeforeStall + 3,
+              "a CI-V-only stall gets SDR9700's three targeted data restarts first");
+        check(disconnectedAfterRecovery,
+              "failed targeted recovery tears down the false-connected session");
+        check(disconnectedSpy.count() == 1,
+              "the dead three-stream session emits one disconnect edge");
+        check(connectionErrorSpy.count() == 1,
+              "the stall explains why the session was disconnected");
 
         radio.setCivSilent(false);
-        QTest::qWait(300);
+        backend.connectRadio(req);
+        check(waitFor([&] { return backend.isConnected(); }),
+              "a clean session reconnects after CI-V loss");
+        check(waitSchedulerIdle(),
+              "the reconnect's radio-authoritative read burst converges before later controls");
     }
 
     // ---- the pan intents --------------------------------------------------
@@ -1216,6 +1298,57 @@ int main(int argc, char** argv)
           "disconnect during TUNE restores ordinary RF power before teardown");
     check(!backend.isConnected(), "the backend disconnects cleanly");
 
+    // A current-session sentinel after authentication takes the orderly
+    // IC-9700 shutdown path. Its acknowledgement used to trigger the pending
+    // login immediately, bypassing the advertised five-second radio settle.
+    {
+        FakeIc705 staleRadio;
+        staleRadio.setCivAddress(0xA2);
+        staleRadio.setDeviceName("IC-9700");
+        staleRadio.setAuthFailureOnStreamRequestOnce(true);
+        IcomCivBackend staleBackend;
+        RadioConnectRequest staleRequest = req;
+        staleRequest.port = staleRadio.controlPort();
+        staleRequest.params.insert(QStringLiteral("icom.serialPort"),
+                                   staleRadio.serialPort());
+        staleRequest.params.insert(QStringLiteral("icom.audioPort"),
+                                   staleRadio.audioPort());
+        staleRequest.params.insert(QStringLiteral("icom.civAddress"), 0xA2);
+        staleBackend.connectRadio(staleRequest);
+        check(waitFor([&] { return staleRadio.loginTokenRequestIds().size() == 1; }),
+              "the stale-session fixture reaches its first login");
+        QTest::qWait(1500);
+        check(staleRadio.loginTokenRequestIds().size() == 1,
+              "token-removal acknowledgement cannot bypass the IC-9700 settle delay");
+        check(waitFor([&] { return staleBackend.isConnected(); }, 5000),
+              "the pending IC-9700 session starts after the settle delay");
+    }
+
+    // Orderly logout is awaited while the owner is still alive, never by
+    // pumping application events from a destructor.
+    {
+        FakeIc705 shutdownRadio;
+        shutdownRadio.setCivAddress(0xA2);
+        shutdownRadio.setDeviceName("IC-9700");
+        IcomCivBackend shutdownBackend;
+        RadioConnectRequest shutdownRequest = req;
+        shutdownRequest.port = shutdownRadio.controlPort();
+        shutdownRequest.params.insert(QStringLiteral("icom.serialPort"),
+                                      shutdownRadio.serialPort());
+        shutdownRequest.params.insert(QStringLiteral("icom.audioPort"),
+                                      shutdownRadio.audioPort());
+        shutdownRequest.params.insert(QStringLiteral("icom.civAddress"), 0xA2);
+        shutdownBackend.connectRadio(shutdownRequest);
+        check(waitFor([&] { return shutdownBackend.isConnected(); }),
+              "the orderly-shutdown fixture connects");
+        shutdownBackend.disconnectRadio();
+        check(shutdownBackend.shutdownPending(),
+              "IC-9700 exposes its asynchronous logout as pending");
+        check(waitFor([&] { return !shutdownBackend.shutdownPending(); }, 5000),
+              "IC-9700 orderly logout completes within its bounded budget");
+        check(shutdownRadio.deauthFollowedSerialClose(),
+              "orderly logout closes CI-V before removing the IC-9700 token");
+    }
 
     // =======================================================================
     // CI-V ADDRESS RESOLUTION
@@ -1315,11 +1448,94 @@ int main(int argc, char** argv)
               "auto: and the radio ANSWERS - a frequency arrives, where the "
               "0xA4-hardcoded path produced a permanently blank session");
         check(c.backend.model().civAddress == 0xA2, "auto: resolved as the IC-9700");
+        const RadioCapabilities ic9700Caps = c.backend.capabilities();
+        check(ic9700Caps.txPowerMaxWattsAt(145'000'000.0) == 100.0,
+              "IC-9700 advertises its 144 MHz 100 W limit");
+        check(ic9700Caps.txPowerMaxWattsAt(435'000'000.0) == 75.0,
+              "IC-9700 advertises its 430 MHz 75 W limit");
+        check(ic9700Caps.txPowerMaxWattsAt(1'296'000'000.0) == 10.0,
+              "IC-9700 advertises its 1240 MHz 10 W limit");
+        // Capture before the focused command tests clear the fake's log.
+        const int broadcasts = c.sentTo(kBroadcastAddress);
+
+        // Disabling access is one intent. It must not silently rewrite the
+        // radio's persisted tone and DTCS registers with UI defaults.
+        c.radio.clearCivLog();
+        QVariantMap repeaterOff;
+        repeaterOff.insert(QStringLiteral("mode"), QStringLiteral("off"));
+        c.backend.invokeExtension(QStringLiteral("icom"),
+                                  QStringLiteral("repeater.access"), 1,
+                                  repeaterOff);
+        check(waitFor([&] {
+                  return std::any_of(
+                      c.radio.civCommands().begin(), c.radio.civCommands().end(),
+                      [](const CivFrame& f) {
+                          return f.cmd == cmd::kFunction && f.hasSub
+                              && f.sub == func::kRepeaterAccess && !f.data.empty();
+                      });
+              }, 2000),
+              "repeater OFF reaches the radio through the paced scheduler");
+        const bool offWroteTone = std::any_of(
+            c.radio.civCommands().begin(), c.radio.civCommands().end(),
+            [](const CivFrame& f) {
+                return f.cmd == cmd::kTone && !f.data.empty();
+            });
+        const bool offWroteSelector = std::any_of(
+            c.radio.civCommands().begin(), c.radio.civCommands().end(),
+            [](const CivFrame& f) {
+                return f.cmd == cmd::kFunction && f.hasSub
+                    && f.sub == func::kRepeaterAccess && !f.data.empty();
+            });
+        check(!offWroteTone && offWroteSelector,
+              "repeater OFF changes only the access selector, preserving tone registers");
+
+        c.radio.clearCivLog();
+        QVariantMap ctcssTx;
+        ctcssTx.insert(QStringLiteral("mode"), QStringLiteral("ctcss_tx"));
+        ctcssTx.insert(QStringLiteral("txCtcssHz"), 100.0);
+        c.backend.invokeExtension(QStringLiteral("icom"),
+                                  QStringLiteral("repeater.access"), 2,
+                                  ctcssTx);
+        check(waitFor([&] {
+                  return std::any_of(
+                      c.radio.civCommands().begin(), c.radio.civCommands().end(),
+                      [](const CivFrame& f) {
+                          return f.cmd == cmd::kTone && f.hasSub
+                              && f.sub == tone::kTxCtcss && !f.data.empty();
+                      });
+              }, 2000),
+              "CTCSS TX reaches the radio through the paced scheduler");
+        const auto toneWrites = std::count_if(
+            c.radio.civCommands().begin(), c.radio.civCommands().end(),
+            [](const CivFrame& f) {
+                return f.cmd == cmd::kTone && !f.data.empty();
+            });
+        const bool wroteTxTone = std::any_of(
+            c.radio.civCommands().begin(), c.radio.civCommands().end(),
+            [](const CivFrame& f) {
+                return f.cmd == cmd::kTone && f.hasSub
+                    && f.sub == tone::kTxCtcss && !f.data.empty();
+            });
+        check(toneWrites == 1 && wroteTxTone,
+              "CTCSS TX writes only the selected TX tone register");
+
+        const bool polledDeferredRitXit = std::any_of(
+            c.radio.civCommands().begin(), c.radio.civCommands().end(),
+            [](const CivFrame& f) { return f.to == 0xA2 && f.cmd == cmd::kTuneOffset; });
+        const bool polledAbsentTuner = std::any_of(
+            c.radio.civCommands().begin(), c.radio.civCommands().end(),
+            [](const CivFrame& f) {
+                return f.to == 0xA2 && f.cmd == cmd::kControl && f.hasSub
+                    && f.sub == control::kTuner && f.data.empty();
+            });
+        check(!polledDeferredRitXit,
+              "IC-9700 basic support does not poll deferred RIT/XIT registers");
+        check(!polledAbsentTuner,
+              "IC-9700 does not poll the absent antenna tuner's state");
 
         // ONE broadcast per connect. Never polled, never retried on a timer:
         // RFC #4983 attributes an unrecoverable CI-V stall to request volume,
         // so the cost of this feature has to stay at exactly one frame.
-        const int broadcasts = c.sentTo(kBroadcastAddress);
         check(broadcasts == 1,
               "auto: exactly one broadcast 0x19 0x00 is sent for the whole connect");
     }

--- a/tests/icom_civ_scheduler_test.cpp
+++ b/tests/icom_civ_scheduler_test.cpp
@@ -62,6 +62,26 @@ int main()
 
     {
         IcomCivScheduler scheduler;
+        scheduler.enqueue(read("control", 0x16, 0x40, Priority::Control), 1000);
+        scheduler.enqueue(read("maintenance", 0x1a, 0x05, Priority::Maintenance), 1000);
+        scheduler.enqueue(read("meter", 0x15, 0x11, Priority::ActiveMeter), 1000);
+        scheduler.enqueue(write("ptt", 0x1c, 0x00, 1, Priority::Operator), 1000);
+
+        scheduler.dropBackground();
+        check(scheduler.stats().queueDepth == 2,
+              "keying drops queued control/maintenance reconciliation");
+        const auto first = scheduler.takeNext(1000);
+        check(first && first->priority == Priority::Operator,
+              "while preserving operator traffic");
+        check(scheduler.observe(ok(), 1010) == IcomCivScheduler::Observation::Accepted,
+              "the preserved operator write still completes normally");
+        const auto second = scheduler.takeNext(1030);
+        check(second && second->priority == Priority::ActiveMeter,
+              "and preserving active meter traffic");
+    }
+
+    {
+        IcomCivScheduler scheduler;
         scheduler.enqueue(read("meter.s", 0x15, 0x02, Priority::ActiveMeter), 1000);
         scheduler.enqueue(read("meter.s", 0x15, 0x02, Priority::ActiveMeter), 1000);
         check(scheduler.stats().queueDepth == 1, "duplicate reads coalesce");
@@ -151,8 +171,8 @@ int main()
     }
 
     // Aging must survive the RE-QUEUE, not just the wait. onLinkTick re-asks
-    // for NR/NB/notch every 1000 ms — the same period as kPriorityAgingMs — so
-    // a collapse that rebuilds the entry restarts its clock and the group can
+    // at the synthetic worst-case rate of every 1000 ms — the same period as
+    // kPriorityAgingMs — so a collapse that rebuilds the entry restarts its clock and the group can
     // never age at all. The single-enqueue fixture above cannot see that.
     {
         IcomCivScheduler scheduler;

--- a/tests/icom_civ_test.cpp
+++ b/tests/icom_civ_test.cpp
@@ -5,7 +5,9 @@
 // Pure protocol: no sockets, no Qt, no hardware.
 
 #include "core/backends/icom/CivCodec.h"
+#include "models/FmRepeaterValues.h"
 
+#include <cmath>
 #include <cstdio>
 #include <vector>
 
@@ -41,6 +43,11 @@ static void testFraming()
 
     auto s = buildFrameSub(kIc705, cmd::kScope, scope::kOnOff, std::array<std::uint8_t, 1>{0x01});
     check(bytesAre(s, {0xFE, 0xFE, 0xA4, 0xE0, 0x27, 0x10, 0x01, 0xFD}), "scope on frame");
+
+    const auto mainScope = cmdScopeMainSub(0xA2, false);
+    check(bytesAre(mainScope,
+                   {0xFE, 0xFE, 0xA2, 0xE0, 0x27, 0x12, 0x00, 0xFD}),
+          "IC-9700 MAIN scope selection frame");
 
     auto parsed = parseFrame(s);
     check(parsed.has_value(), "parses a sub-addressed frame");
@@ -476,10 +483,59 @@ static void testSubcommandPredicate()
                   "a bare command keeps both payload bytes");
         }
     }
-    // The eleven that carry subcommands: 12 14 15 16 18 19 1A 1C 21 26 27. A
+    // The twelve that carry subcommands: 12 14 15 16 18 19 1A 1B 1C 21 26 27. A
     // change to the list is a deliberate protocol decision, so it should have
     // to come past this number rather than arrive as a silent side effect.
-    check(subAddressed == 11, "exactly eleven CI-V commands are sub-addressed");
+    check(subAddressed == 12, "exactly twelve CI-V commands are sub-addressed");
+}
+
+static void testRepeaterAccess()
+{
+    constexpr std::uint8_t radio = 0xA2;
+    check(bytesAre(cmdReadRepeaterAccess(radio),
+                   {0xFE,0xFE,0xA2,0xE0,0x16,0x5D,0xFD}),
+          "IC-9700 repeater access read");
+    check(bytesAre(cmdSetRepeaterAccess(radio, 0x09),
+                   {0xFE,0xFE,0xA2,0xE0,0x16,0x5D,0x09,0xFD}),
+          "CTCSS TX/RX access selection");
+    check(bytesAre(cmdSetTone(radio, tone::kTxCtcss, 1273),
+                   {0xFE,0xFE,0xA2,0xE0,0x1B,0x00,0x00,0x12,0x73,0xFD}),
+          "127.3 Hz TX CTCSS BCD encoding");
+    check(bytesAre(cmdSetTone(radio, tone::kDtcs, 23, true, true),
+                   {0xFE,0xFE,0xA2,0xE0,0x1B,0x02,0x11,0x00,0x23,0xFD}),
+          "DTCS 023 with independent reversed polarities");
+    const std::array<std::uint8_t, 3> dtcs{0x10,0x07,0x54};
+    const auto decoded = decodeTone(dtcs);
+    check(decoded && decoded->value == 754 && decoded->txReverse
+              && !decoded->rxReverse, "DTCS payload decoding");
+    const std::array<std::uint8_t, 3> badBcd{0x00,0x0A,0x23};
+    check(!decodeTone(badBcd), "malformed tone BCD is rejected");
+
+    check(bytesAre(cmdReadRepeaterOffset(radio),
+                   {0xFE,0xFE,0xA2,0xE0,0x0C,0xFD}),
+          "IC-9700 repeater offset read");
+    check(bytesAre(cmdSetRepeaterOffset(radio, 5'000'000ULL),
+                   {0xFE,0xFE,0xA2,0xE0,0x0D,0x00,0x00,0x05,0xFD}),
+          "5 MHz repeater offset is little-endian BCD in 100 Hz units");
+    const std::array<std::uint8_t, 3> offset{0x00,0x00,0x05};
+    check(decodeRepeaterOffset(offset) == 5'000'000ULL,
+          "repeater offset reply decodes to Hz");
+    const std::array<std::uint8_t, 3> badOffset{0x00,0x0A,0x05};
+    check(!decodeRepeaterOffset(badOffset), "malformed repeater offset BCD is rejected");
+    check(bytesAre(cmdReadDuplex(radio), {0xFE,0xFE,0xA2,0xE0,0x0F,0xFD}),
+          "IC-9700 duplex read");
+    check(bytesAre(cmdSetDuplex(radio, 0x11),
+                   {0xFE,0xFE,0xA2,0xE0,0x0F,0x11,0xFD}),
+          "IC-9700 duplex-minus write");
+}
+
+static void testRepeaterValueValidation()
+{
+    check(AetherSDR::fm::isCtcssTone(103.5), "standard CTCSS tone is accepted");
+    check(!AetherSDR::fm::isCtcssTone(103.6), "non-standard CTCSS tone is rejected");
+    check(!AetherSDR::fm::isCtcssTone(std::nan("")), "non-finite CTCSS tone is rejected");
+    check(AetherSDR::fm::isDtcsCode(23), "standard DTCS 023 code is accepted");
+    check(!AetherSDR::fm::isDtcsCode(199), "non-standard DTCS code is rejected");
 }
 
 int main()
@@ -490,6 +546,8 @@ int main()
     testModes();
     testCommands();
     testDataMode();
+    testRepeaterAccess();
+    testRepeaterValueValidation();
     testSubcommandPredicate();
 
     if (g_failures == 0)

--- a/tests/icom_family_test.cpp
+++ b/tests/icom_family_test.cpp
@@ -107,14 +107,35 @@ int main(int argc, char** argv)
               && mk2Mod && mk2Mod->micValue == 0x00,
           "both verified models name MIC in their own profile rather than "
           "leaving the caller to hardcode it");
-    // An IC-9700 has no Wi-Fi and, unlike the two profiles above, no verified
-    // model-specific modulation map. It must therefore remain outside this
-    // read/write path instead of borrowing the IC-705's WLAN table. Pin that
-    // distinction so the old false warning cannot quietly come back.
+    // The IC-9700 has its own LAN modulation map. It must not borrow the
+    // IC-705's WLAN item numbers or source value merely because both radios
+    // use this transport.
+    const auto ic9700Mod = icom::modulationProfileFor(
+        *icom::modelForCivAddress(0xA2));
+    check(ic9700Mod && ic9700Mod->dataOffInputItem == 115
+              && ic9700Mod->dataInputItem == 116
+              && ic9700Mod->networkOnlyValue == 0x05,
+          "IC-9700 uses SET 0115/0116 and LAN value 05");
     check(!AetherSDR::icom::modelForCivAddress(0xA2)->hasWifi,
-          "the IC-9700 has no Wi-Fi — so no WLAN MOD Input to demand");
+          "the IC-9700 has Ethernet rather than the IC-705 WLAN source");
     check(AetherSDR::icom::modelForCivAddress(0xA4)->hasWifi,
           "the IC-705 does — the one model the WLAN check is legitimate for");
+    check(AetherSDR::icom::declaredBandsFor(
+              *AetherSDR::icom::modelForCivAddress(0xA2)) == "2m,440,23cm",
+          "the IC-9700 declares only its three discontinuous native bands");
+    check(AetherSDR::icom::declaredBandsFor(
+              *AetherSDR::icom::modelForCivAddress(0xA4)).empty(),
+          "continuous-coverage Icoms retain range-gated band menus");
+    check(!AetherSDR::icom::modelForCivAddress(0xA2)->hasTuner,
+          "the IC-9700 does not inherit ATU controls merely because it transmits");
+    const auto ic9700Preamp = AetherSDR::icom::preampLabelsFor(
+        *AetherSDR::icom::modelForCivAddress(0xA2));
+    check(ic9700Preamp.size() == 2
+              && ic9700Preamp[0] == "OFF" && ic9700Preamp[1] == "P.AMP",
+          "the IC-9700 publishes its verified single preamp position without "
+          "inventing a second gain level");
+    check(AetherSDR::icom::modelForCivAddress(0xA4)->hasTuner,
+          "the IC-705 retains its external-tuner command surface");
 
     check(!caps.radioOwnsDbmScale,
           "the scope scale is FIXED (ScopeCalibration), not the radio's to set — "
@@ -230,6 +251,20 @@ int main(int argc, char** argv)
     check(icom::modelForCivAddress(0xB6)->hasNetwork,
           "the IC-7300MK2 CAN - it has an Ethernet port, and dropping it from "
           "the chooser would hide the model this backend was validated on");
+
+    const icom::IcomModel* ic9700 = icom::modelForCivAddress(0xA2);
+    check(ic9700 && icom::supportsFrequency(*ic9700, 146'520'000ULL),
+          "IC-9700 accepts 2 m frequencies");
+    check(ic9700 && icom::supportsFrequency(*ic9700, 440'000'000ULL),
+          "IC-9700 accepts 70 cm frequencies");
+    check(ic9700 && icom::supportsFrequency(*ic9700, 1'296'000'000ULL),
+          "IC-9700 accepts 23 cm frequencies");
+    check(ic9700 && !icom::supportsFrequency(*ic9700, 200'000'000ULL)
+              && !icom::supportsFrequency(*ic9700, 800'000'000ULL),
+          "IC-9700 rejects gaps between its three tuning ranges");
+    const icom::IcomModel* ic705 = icom::modelForCivAddress(0xA4);
+    check(ic705 && icom::supportsFrequency(*ic705, 14'225'000ULL),
+          "continuous-range Icom validation is unchanged");
 
     // The name is FREE TEXT set on the radio, so the match has to survive the
     // ways it is really written.

--- a/tests/icom_meters_test.cpp
+++ b/tests/icom_meters_test.cpp
@@ -104,7 +104,11 @@ static void testPowerAndOthers()
 
     check(near(meterValue(MeterId::Comp, 130, 0), 15.0), "COMP 15 dB");
     check(near(meterValue(MeterId::Vd, 75, 0), 5.0), "Vd 5 V");
+    check(near(meterValue(MeterId::Vd, 185, 0, 0xA2), 13.8),
+          "IC-9700 Vd uses its desktop calibration");
     check(near(meterValue(MeterId::Id, 121, 0), 2.0), "Id 2 A");
+    check(near(meterValue(MeterId::Id, 121, 0, 0xA2), 10.0),
+          "IC-9700 Id uses its 20 A calibration");
     check(near(meterValue(MeterId::Vd, 13, 0, 0xB6), 10.0),
           "IC-7300MK2 Vd uses its desktop calibration");
     check(near(meterValue(MeterId::Id, 97, 0, 0xB6), 10.0),
@@ -155,6 +159,13 @@ static void testPollerVisibilityAndTxSplit()
     auto tx = p.due(3000);
     check(contains(tx, MeterId::Swr), "and IS polled while transmitting");
     check(!contains(tx, MeterId::SMeter), "while the RX-only S-meter stops");
+
+    p.markAnswered(MeterId::Swr, 3000);
+    p.setTransmitting(false);
+    p.setTransmitting(true);
+    auto rekey = p.due(3010);
+    check(contains(rekey, MeterId::Swr),
+          "a new TX edge bypasses the previous transmission's poll interval");
 }
 
 static void testPollerInFlight()
@@ -365,11 +376,19 @@ static void testPowerCurveIsNotShared()
     const IcomModel* ic705 = modelForCivAddress(0xA4);
     const IcomModel* ic9700 = modelForCivAddress(0xA2);
     check(ic705 && !powerCurveFor(*ic705).empty(), "the IC-705 has a measured watts curve");
-    // Handing back the IC-705's curve for another radio would produce a watts
-    // figure an operator would act on, derived from a different PA. Empty means
-    // "report percent", which is honest.
-    check(ic9700 && powerCurveFor(*ic9700).empty(),
-          "another model gets NO curve rather than the IC-705's");
+    // IC-9700 Po is a relative indication on every module, not calibrated
+    // watts inferred from each band's advertised maximum output.
+    check(ic9700 && !powerCurveFor(*ic9700, 144'000'000ULL).empty(),
+          "the IC-9700 has its own relative Po curve");
+    check(ic9700 && near(meterValue(MeterId::Power, 213, 0, 0xA2,
+                                    144'000'000ULL), 100.0),
+          "IC-9700 2 m nominal Po is 100 percent");
+    check(ic9700 && near(meterValue(MeterId::Power, 213, 0, 0xA2,
+                                    440'000'000ULL), 100.0),
+          "IC-9700 70 cm nominal Po is also 100 percent");
+    check(ic9700 && near(meterValue(MeterId::Power, 213, 0, 0xA2,
+                                    1'296'000'000ULL), 100.0),
+          "IC-9700 23 cm nominal Po is also 100 percent");
     check(powerCurveFor(unknownModel()).empty(), "and nor does an unknown radio");
 }
 

--- a/tests/icom_protocol_test.cpp
+++ b/tests/icom_protocol_test.cpp
@@ -118,14 +118,18 @@ static void testPasscode()
 
 static void testLoginAndAuth()
 {
-    auto login = buildLogin(0x11111111, 0x22222222, 3, 0xBEEF, "beer", "beerbeer");
+    auto login = buildLogin(0x11111111, 0x22222222, 3, 0xBEEF,
+                            "beer", "beerbeer", "AetherSDR-a1b2c3");
     check(login.size() == kLenLogin, "login is 128 bytes");
     check(login[0x14] == 0x01, "requestreply is 0x01");
     check(login[0x15] == 0x00, "login requesttype is 0x00");
     check(login[0x1a] == 0xef && login[0x1b] == 0xbe,
           "login carries the caller's little-endian token-request ID");
-    check(std::memcmp(login.data() + 0x60, "icom-pc", 7) == 0,
-          "the client name is PLAIN TEXT while the credentials are not");
+    check(std::memcmp(login.data() + 0x60, "AetherSDR-a1b2c3", 16) == 0,
+          "the caller's client name is plain text while the credentials are not");
+    auto longName = buildLogin(1, 2, 0, 1, "u", "p", "AetherSDR-name-is-too-long");
+    check(std::memcmp(longName.data() + 0x60, "AetherSDR-name-i", 16) == 0,
+          "an over-long client name stops at the radio's 16-byte field boundary");
     const auto user = encodePasscode("beer");
     check(std::equal(user.begin(), user.end(), login.begin() + 0x40), "username at 0x40");
     const auto pass = encodePasscode("beerbeer");
@@ -134,10 +138,13 @@ static void testLoginAndAuth()
     // A login reply carrying the bad-credentials sentinel.
     std::vector<std::uint8_t> reply(kLenLoginReply, 0);
     reply[0] = 0x60;
+    reply[0x1a] = 0xef; reply[0x1b] = 0xbe;
     reply[0x30] = 0xff; reply[0x31] = 0xff; reply[0x32] = 0xff; reply[0x33] = 0xfe;
     AuthId id{};
     check(parseLoginReply(reply, id) == LoginResult::BadCredentials,
           "0xFFFFFFFE is specifically bad username/password");
+    check(id[0] == 0xef && id[1] == 0xbe,
+          "a rejected login still returns its correlation identity");
 
     // A successful one hands back the six auth bytes.
     std::vector<std::uint8_t> ok(kLenLoginReply, 0);
@@ -153,6 +160,15 @@ static void testLoginAndAuth()
     check(auth[0x16] == 0x00 && auth[0x17] == 0x04,
           "the inner sequence is a big-endian u16 at 0x16");
     check(std::equal(id.begin(), id.end(), auth.begin() + 0x1a), "auth id is echoed at 0x1a");
+
+    auto deauthReply = auth;
+    deauthReply[0x14] = 0x02;
+    deauthReply[0x15] = static_cast<std::uint8_t>(AuthKind::Deauth);
+    check(isAuthOperationReply(deauthReply, AuthKind::Deauth, 4, id),
+          "token-removal acknowledgement correlates by operation, sequence and auth id");
+    deauthReply[0x17] ^= 0x01;
+    check(!isAuthOperationReply(deauthReply, AuthKind::Deauth, 4, id),
+          "a stale token-removal acknowledgement is rejected");
 
     const auto seq255 = buildAuth(1, 2, 0x00ff, id, AuthKind::Renew);
     const auto seq256 = buildAuth(1, 2, 0x0100, id, AuthKind::Renew);
@@ -323,6 +339,10 @@ static void testSerialEnvelope()
           "serial open is 0xc0 with magic 0x05");
     auto close = buildSerialOpen(1, 2, 1, false);
     check(close[0x15] == 0x00, "serial close is magic 0x00");
+    auto restart = buildSerialRestart(1, 2, 2);
+    check(restart.size() == kLenOpenClose && restart[0x10] == 0xc0
+              && restart[0x15] == 0x04,
+          "serial restart is 0xc0 with data-start magic 0x04");
 }
 
 static void testAudioEnvelope()

--- a/tests/icom_scope_test.cpp
+++ b/tests/icom_scope_test.cpp
@@ -76,6 +76,28 @@ static void testWlanSinglePacket()
     check(f->raw.size() == static_cast<std::size_t>(kScopePointsIc705), "475 points");
     check(f->raw[0] == 0 && f->raw[10] == 10, "waveform data is positional and intact");
     check(!f->outOfRange, "in range");
+    check(f->receiver == 0x00, "receiver byte identifies MAIN");
+}
+
+static void testReceiverIsolation()
+{
+    std::vector<std::uint8_t> wave(kScopePointsIc705, 42);
+    ScopeDecoder single;
+    CivFrame sub = makeFirst(1, 1, ScopeMode::Centre,
+                             439'864'060, 500'000, false, wave);
+    sub.data[0] = 0x01;
+    const auto decodedSub = single.feed(sub);
+    check(decodedSub && decodedSub->receiver == 0x01,
+          "IC-9700 SUB receiver byte survives decoding");
+
+    ScopeDecoder divided;
+    check(!divided.feed(makeFirst(1, 2, ScopeMode::Centre,
+                                  144'254'300, 500'000, false, {})),
+          "MAIN first division begins assembly");
+    CivFrame subContinuation = makeContinuation(2, 2, wave);
+    subContinuation.data[0] = 0x01;
+    check(!divided.feed(subContinuation),
+          "a SUB continuation is never spliced into a MAIN sweep");
 }
 
 static void testCentreModeHalfWidth()
@@ -312,6 +334,7 @@ static void testDbmMapping()
 int main()
 {
     testWlanSinglePacket();
+    testReceiverIsolation();
     testCentreModeHalfWidth();
     testZoomEscapesTheSnap();
     testScrollModesAndNegativeEdge();

--- a/tests/icom_session_test.cpp
+++ b/tests/icom_session_test.cpp
@@ -102,6 +102,12 @@ int main(int argc, char** argv)
     check(waitFor([&] { return radio.serialOpened(); }),
           "the CI-V pipe is explicitly opened after its handshake");
 
+    const int opensBeforeRecovery = radio.serialOpenCount();
+    check(session.reopenCivPipe(),
+          "a live session can re-open only its CI-V pipe");
+    check(waitFor([&] { return radio.serialOpenCount() > opensBeforeRecovery; }),
+          "targeted CI-V recovery sends another serial-open packet");
+
     // The ports the client announced must be the ones it actually bound. This
     // is the reason binding is separable from handshaking.
     check(radio.announcedCivPort() != 0 && radio.announcedAudioPort() != 0,
@@ -204,6 +210,78 @@ int main(int argc, char** argv)
     check(deauthSeqs.size() >= 2 && deauthSeqs[0] != 0 && deauthSeqs[1] != 0
               && deauthSeqs[0] != deauthSeqs[1],
           "each deauthentication has a distinct nonzero tracked outer sequence");
+
+    // IC-9700 shutdown is stricter than the legacy best-effort path above. Its
+    // LAN server must see the media departure, then acknowledge token removal,
+    // before the control endpoint departs. Drop the first acknowledgement to
+    // prove the retry is functional rather than merely scheduled.
+    {
+        FakeIc705 ic9700;
+        ic9700.setCivAddress(0xA2);
+        ic9700.setDeviceName("IC-9700");
+        ic9700.setIgnoredDeauthReplies(1);
+        IcomSession ic9700Session;
+        QString ic9700Name;
+        int shutdownFinished = 0;
+        QObject::connect(&ic9700Session, &IcomSession::connected, &app,
+                         [&](const QString& name) { ic9700Name = name; });
+        QObject::connect(&ic9700Session, &IcomSession::shutdownFinished, &app,
+                         [&] { ++shutdownFinished; });
+        IcomSession::Params ic9700Params = p;
+        ic9700Params.controlPort = ic9700.controlPort();
+        ic9700Params.serialPort = ic9700.serialPort();
+        ic9700Params.audioPort = ic9700.audioPort();
+        ic9700Params.civAddress = 0xA2;
+        ic9700Params.tokenRequestId = 0x9700;
+        ic9700Params.shutdownSettleMs = 10;
+        ic9700Params.shutdownRetryMs = 10;
+        check(ic9700Session.start(ic9700Params), "IC-9700 session starts");
+        check(waitFor([&] { return ic9700Name == QStringLiteral("IC-9700"); }),
+              "IC-9700 session reaches connected state before shutdown test");
+        ic9700Session.stop();
+        check(ic9700Session.isStopping(),
+              "IC-9700 stop remains alive while token removal is unacknowledged");
+        check(waitFor([&] { return shutdownFinished == 1; }, 2500),
+              "IC-9700 shutdown finishes after a correlated token-removal acknowledgement");
+        check(ic9700.deauthOuterSequences().size() == 2,
+              "IC-9700 retries token removal after a dropped acknowledgement");
+        check(ic9700.deauthFollowedSerialClose(),
+              "IC-9700 closes the CI-V stream before removing its token");
+        check(!ic9700Session.isStopping() && !ic9700Session.isConnected(),
+              "IC-9700 shutdown leaves no live local session");
+    }
+
+    // A missing radio acknowledgement must not retain the backend forever.
+    // Bound the retry count, then close the control endpoint as a fallback.
+    {
+        FakeIc705 silentIc9700;
+        silentIc9700.setCivAddress(0xA2);
+        silentIc9700.setDeviceName("IC-9700");
+        silentIc9700.setIgnoredDeauthReplies(99);
+        IcomSession timeoutSession;
+        QString timeoutName;
+        int shutdownFinished = 0;
+        QObject::connect(&timeoutSession, &IcomSession::connected, &app,
+                         [&](const QString& name) { timeoutName = name; });
+        QObject::connect(&timeoutSession, &IcomSession::shutdownFinished, &app,
+                         [&] { ++shutdownFinished; });
+        IcomSession::Params timeoutParams = p;
+        timeoutParams.controlPort = silentIc9700.controlPort();
+        timeoutParams.serialPort = silentIc9700.serialPort();
+        timeoutParams.audioPort = silentIc9700.audioPort();
+        timeoutParams.civAddress = 0xA2;
+        timeoutParams.shutdownSettleMs = 10;
+        timeoutParams.shutdownRetryMs = 10;
+        timeoutParams.shutdownMaxAttempts = 3;
+        check(timeoutSession.start(timeoutParams), "IC-9700 timeout session starts");
+        check(waitFor([&] { return timeoutName == QStringLiteral("IC-9700"); }),
+              "IC-9700 timeout session connects before shutdown");
+        timeoutSession.stop();
+        check(waitFor([&] { return shutdownFinished == 1; }, 500),
+              "IC-9700 shutdown has a bounded fallback when acknowledgements are lost");
+        check(silentIc9700.deauthOuterSequences().size() == 3,
+              "IC-9700 shutdown stops at the configured retry limit");
+    }
 
     // A reconnect is a new login identity, not a replay of token request zero.
     // The live IC-7300MK2 accepts the login itself but rejects the first token
@@ -327,7 +405,7 @@ int main(int argc, char** argv)
         check(waitFor([&] { return !failedLoginReason.isEmpty(); }),
               "a current-session auth failure before the stream grant is fatal");
         check(failedLoginReason.contains(QStringLiteral("authentication failed")),
-              "the pre-grant failure retains its actionable reason");
+              "other Icom models retain the existing actionable login diagnostic");
         failedLoginSession.stop();
     }
 

--- a/tests/meter_model_test.cpp
+++ b/tests/meter_model_test.cpp
@@ -306,6 +306,41 @@ void testForwardPowerHonoursItsDeclaredUnit()
         report("an undeclared unit is treated as dBm, as it always was",
                nearlyEqual(model.fwdPowerInstant(), 100.0f));
     }
+    {
+        MeterModel model;
+        int unitChanges = 0;
+        QObject::connect(&model, &MeterModel::forwardPowerUnitChanged,
+                         [&unitChanges](const QString&) { ++unitChanges; });
+        model.defineMeter(txMeter(8, "FWDPWR", "Percent"));
+        model.updateValues({8}, {50});
+        report("a relative FWDPWR percentage remains on its native scale",
+               nearlyEqual(model.fwdPowerInstant(), 50.0f));
+        report("and its declared unit is exposed to presentation consumers",
+               model.forwardPowerUnit() == QStringLiteral("Percent")
+               && unitChanges == 1);
+    }
+}
+
+void testForwardPowerHistoryDoesNotCrossTransmitEdges()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(8, "FWDPWR", "Watts"));
+    model.defineMeter(txMeter(10, "SWR", "SWR"));
+
+    model.setTransmitting(true);
+    model.updateValues({8, 10}, {80, rawDb(1.2f)});
+    const bool firstKeyReachedReading = nearlyEqual(model.fwdPower(), 80.0f);
+
+    model.setTransmitting(false);
+    const bool unkeyCleared = nearlyEqual(model.fwdPower(), 0.0f)
+        && nearlyEqual(model.fwdPowerInstant(), 0.0f)
+        && !model.swrIfLive().has_value();
+
+    model.setTransmitting(true);
+    model.updateValues({8}, {40});
+    report("MeterModel gives every transmission an unsmoothed first power sample",
+           firstKeyReachedReading && unkeyCleared
+               && nearlyEqual(model.fwdPower(), 40.0f));
 }
 
 // REFPWR was missed when FWDPWR and ALC were fixed, and MeterSurfaces.h already
@@ -332,11 +367,8 @@ void testReflectedPowerHonoursItsDeclaredUnit()
     }
 }
 
-void testAlcPercentIsMappedOntoTheGaugeRange()
+void testAlcPreservesItsDeclaredUnit()
 {
-    // The ALC consumers are a -20..0 dBFS gauge. A radio running its own ALC
-    // reports a percentage of ITS full scale; handed over raw it pins the gauge
-    // and stays there, which is what "ALC is completely pegged" looked like.
     MeterModel model;
     model.defineMeter(txMeter(11, "ALC", "Percent"));
 
@@ -344,16 +376,15 @@ void testAlcPercentIsMappedOntoTheGaugeRange()
     QObject::connect(&model, &MeterModel::swAlcChanged, [&alc](float v) { alc = v; });
 
     model.updateValues({11}, {0});
-    report("0 % ALC lands at the gauge floor", nearlyEqual(alc, -20.0f));
+    report("0 % ALC remains zero percent", nearlyEqual(alc, 0.0f));
 
     model.updateValues({11}, {50});
-    report("50 % ALC lands mid-scale", nearlyEqual(alc, -10.0f));
+    report("50 % ALC remains fifty percent", nearlyEqual(alc, 50.0f));
 
     model.updateValues({11}, {100});
-    report("100 % ALC lands at the gauge ceiling", nearlyEqual(alc, 0.0f));
+    report("100 % ALC remains full relative scale", nearlyEqual(alc, 100.0f));
 
-    // A dBFS backend must be untouched — this is a mapping for radios that
-    // cannot speak dBFS, not a reinterpretation of the ones that can.
+    // A native dBFS backend remains untouched as well.
     MeterModel dbfs;
     dbfs.defineMeter(txMeter(11, "ALC", "dBFS"));
     float passthrough = 999.0f;
@@ -914,8 +945,9 @@ int main(int argc, char** argv)
     testRemovingAdjacentMetersDoesNotClearCompPeak();
     testMicPeakAvailabilityTracksTheMeterList();
     testForwardPowerHonoursItsDeclaredUnit();
+    testForwardPowerHistoryDoesNotCrossTransmitEdges();
     testReflectedPowerHonoursItsDeclaredUnit();
-    testAlcPercentIsMappedOntoTheGaugeRange();
+    testAlcPreservesItsDeclaredUnit();
     testDirectionalPowerUsesDirectReflectedMeter();
     testNativeSwrRemainsRadioProvidedAtLowPower();
     testForwardPowerSnapsToZeroWhenTheCarrierStops();

--- a/tests/phone_cw_mic_gain_authority_test.cpp
+++ b/tests/phone_cw_mic_gain_authority_test.cpp
@@ -2,6 +2,7 @@
 #include "core/AppSettings.h"
 #include "core/backends/TransmitDelta.h"
 #include "gui/PhoneCwApplet.h"
+#include "gui/HGauge.h"
 #include "models/TransmitModel.h"
 
 #include <QApplication>
@@ -96,6 +97,34 @@ int main(int argc, char** argv)
           "synthetic PC operator move reaches the radio model");
     check(clientGain.isEmpty(),
           "synthetic PC operator move does not alter client PcMicGain");
+
+    QList<HGauge*> alcGauges;
+    for (QWidget* child : applet.findChildren<QWidget*>()) {
+        HGauge* gauge = dynamic_cast<HGauge*>(child);
+        if (!gauge) {
+            continue;
+        }
+        if (gauge->accessibleName().contains(QLatin1String("ALC gauge"))) {
+            alcGauges.append(gauge);
+        }
+    }
+    check(alcGauges.size() == 2, "Phone and CW ALC gauges exist");
+    applet.setAlcUnit(QStringLiteral("Percent"));
+    applet.updateAlc(0.0f);
+    bool relativeIdle = true;
+    for (HGauge* gauge : alcGauges) {
+        relativeIdle = relativeIdle && gauge->value() == 0.0f
+            && gauge->accessibleDescription().contains(QLatin1String("relative"));
+    }
+    check(relativeIdle, "relative ALC uses a zero-percent idle face");
+    applet.setAlcUnit(QStringLiteral("dBFS"));
+    applet.updateAlc(-20.0f);
+    bool dbfsIdle = true;
+    for (HGauge* gauge : alcGauges) {
+        dbfsIdle = dbfsIdle && gauge->value() == -20.0f
+            && gauge->accessibleDescription().contains(QLatin1String("dBFS"));
+    }
+    check(dbfsIdle, "Flex ALC restores the minus-20-dBFS idle face");
 
     return failures == 0 ? 0 : 1;
 }

--- a/tests/slice_model_letter_test.cpp
+++ b/tests/slice_model_letter_test.cpp
@@ -552,6 +552,57 @@ int main(int argc, char** argv)
         EXPECT_EQ(s.filterHigh(), -95);
     }
 
+    // ── Extended FM repeater commands preserve the complete access tuple for
+    // family backends (Icom uses this instead of the legacy Flex command).
+    {
+        SliceModel s(0);
+        QSignalSpy accessSpy(&s, &SliceModel::fmRepeaterAccessCommandIssued);
+        s.setFmRepeaterAccess(QStringLiteral("dtcs_txrx"), 100.0, 123.0,
+                              23, true, false);
+
+        EXPECT_EQ(accessSpy.count(), 1);
+        const QList<QVariant> args = accessSpy.takeFirst();
+        EXPECT_EQ(args.at(0).toString(), QStringLiteral("dtcs_txrx"));
+        EXPECT_EQ(args.at(1).toDouble(), 100.0);
+        EXPECT_EQ(args.at(2).toDouble(), 123.0);
+        EXPECT_EQ(args.at(3).toInt(), 23);
+        EXPECT_EQ(args.at(4).toBool(), true);
+        EXPECT_EQ(args.at(5).toBool(), false);
+    }
+
+    // ── Optional boolean status fields must apply false as a real update;
+    // testing optional truthiness here would leave reverse polarity stuck on.
+    {
+        SliceModel s(0);
+        s.applyChanges(delta([](SliceDelta& d) {
+            d.fmDtcsTxReverse = true;
+            d.fmDtcsRxReverse = true;
+        }));
+        EXPECT_EQ(s.fmDtcsTxReverse(), true);
+        EXPECT_EQ(s.fmDtcsRxReverse(), true);
+
+        s.applyChanges(delta([](SliceDelta& d) {
+            d.fmDtcsTxReverse = false;
+            d.fmDtcsRxReverse = false;
+        }));
+        EXPECT_EQ(s.fmDtcsTxReverse(), false);
+        EXPECT_EQ(s.fmDtcsRxReverse(), false);
+    }
+
+    // ── Native duplex changes carry direction and magnitude together. This
+    // drives Icom's -, +, and SIMPLEX controls without REV semantics.
+    {
+        SliceModel s(0);
+        QSignalSpy offsetSpy(&s, &SliceModel::repeaterOffsetCommandIssued);
+        s.setFmRepeaterOffsetFreq(0.6);
+        s.setRepeaterOffsetDir(QStringLiteral("up"));
+
+        EXPECT_EQ(offsetSpy.count(), 2);
+        const QList<QVariant> args = offsetSpy.takeLast();
+        EXPECT_EQ(args.at(0).toString(), QStringLiteral("up"));
+        EXPECT_EQ(args.at(1).toDouble(), 0.6);
+    }
+
     if (g_failures == 0) {
         std::printf("slice_model_letter_test: all checks passed\n");
         return 0;

--- a/tests/transmit_model_test.cpp
+++ b/tests/transmit_model_test.cpp
@@ -372,6 +372,19 @@ int main(int argc, char** argv)
                      "applying radio status does not emit mic operator intent");
     }
 
+    // Flex has three processor presets. A continuous-level backend must opt in,
+    // and returning to Flex must not leave an out-of-range percentage behind.
+    tx.setSpeechProcessorLevel(100);
+    ok &= expect(tx.speechProcessorLevel() == 2,
+                 "default speech processor level remains Flex-safe");
+    tx.setSpeechProcessorLevelMaximum(100);
+    tx.setSpeechProcessorLevel(73);
+    ok &= expect(tx.speechProcessorLevel() == 73,
+                 "continuous backend capability admits a percentage level");
+    tx.setSpeechProcessorLevelMaximum(2);
+    ok &= expect(tx.speechProcessorLevel() == 2,
+                 "returning to Flex clamps stale continuous state");
+
     ClientQuindarTone quindar;
     quindar.prepare(24000.0);
     quindar.setEnabled(true);

--- a/tests/tx_applet_power_reconciliation_test.cpp
+++ b/tests/tx_applet_power_reconciliation_test.cpp
@@ -126,6 +126,26 @@ void testTxMetersAreLiveOnly()
            powerGauge->value() == 0.0f);
 }
 
+void testRelativePowerDescribesBandMaximum()
+{
+    TxApplet applet;
+    QSlider* slider = powerSlider(applet, QStringLiteral("RF power"));
+    report("relative RF power slider exists", slider != nullptr);
+    if (!slider) {
+        return;
+    }
+
+    applet.setForwardPowerUnit(QStringLiteral("Percent"));
+    applet.setPowerScale(75, false);
+    report("relative RF power names the 70 cm maximum",
+           slider->accessibleDescription().contains(QStringLiteral("75 W maximum")));
+    applet.setPowerScale(10, false);
+    report("relative RF power follows the 23 cm maximum",
+           slider->accessibleDescription().contains(QStringLiteral("10 W maximum")));
+    report("relative RF power command remains percentage based",
+           slider->maximum() == 100);
+}
+
 void testAtuSuccessTogglesToBypass()
 {
     TransmitModel model;
@@ -180,6 +200,7 @@ int main(int argc, char** argv)
     testReleaseReconcilesAuthoritativePower(QStringLiteral("RF power"), true);
     testReleaseReconcilesAuthoritativePower(QStringLiteral("Tune power"), false);
     testTxMetersAreLiveOnly();
+    testRelativePowerDescribesBandMaximum();
     testAtuSuccessTogglesToBypass();
 
     std::printf("\n%s\n",


### PR DESCRIPTION
## Summary

Closes #5099.

This PR adds the initial, hardware-tested IC-9700 integration through the existing `IcomCivBackend` and normalized model seam. It makes the radio usable for basic single-receiver operation across 144, 430, and 1240 MHz while preserving the existing FlexRadio and Hermes-Lite 2 paths.

The change deliberately does **not** implement the dual-receiver architecture proposed in #4840. MAIN/SUB ownership, receiver swapping, two simultaneous panadapters, and a dedicated secondary-receiver applet remain deferred to that RFC. This PR keeps one active slice/pan and focuses on radio-authoritative basic operation.

@aethersdr-agent please review/triage this implementation against #5099, with particular attention to the Icom session lifecycle, CI-V command scheduling, transmit safety, meter units, and backend-family isolation.

### What changes

#### IC-9700 identity, capabilities, and bands

- Publishes `IC-9700` as the model nickname, with `Icom` retained as the generic fallback.
- Exposes only the model's `144`, `430`, and `1240` band choices instead of Flex-oriented WWV, GEN, 2200 m, 630 m, and XVTR entries.
- Seeds all three IC-9700 band-stack entries as FM for this initial milestone.
- Enforces the radio's band-dependent transmit limits: 100 W on 144 MHz, 75 W on 430 MHz, and 10 W on 1240 MHz.
- Reconciles the radio, slice, panadapter VFO, and RX Controls frequency displays after band changes and repeater-offset transmit cycles.
- Clears stale waterfall history when the IC-9700 hardware scope jumps bands.

#### FM and repeater controls

- Adds CI-V round trips for simplex, minus offset, plus offset, and reverse.
- Adds repeater offset, CTCSS TX, CTCSS TX/RX, DTCS TX, and DTCS TX/RX state.
- Shares validated tone/code tables through the model-facing `FmRepeaterValues` header, avoiding a new GUI-to-core implementation dependency.
- Limits repeater writes to the registers relevant to the selected access mode; disabling access writes only the selector rather than overwriting unrelated radio state.
- Keeps displayed RX/TX frequencies synchronized with the radio while keyed through an offset and restores the receive frequency after unkey.

#### Transmit controls and telemetry

- Adds radio-authoritative RF power control and reconciliation with the per-band ceiling.
- Adds IC-9700 support for PROC on/off and 0-100 level, DEXP, and TX low/high cut through the existing Phone/Phone-CW applets.
- Corrects IC-9700 RF power, SWR, supply current, supply voltage, compression, and ALC scaling/presentation.
- Represents IC-9700 ALC in its declared relative 0-100 unit instead of synthesizing dBFS. FlexRadio's native dBFS path remains intact; dBFS-only certification/TCI fields are null or omitted for relative ALC.
- Shows 1.0 SWR correctly and prevents RF power from artificially creeping toward a reported value.
- Clears RF power, SWR, current, compression, and ALC on PTT release and Icom disconnect so stale transmit values do not survive into RX.

#### Preamp, session lifecycle, and optional RC-28

- Adds IC-9700 internal preamp Off/P.AMP1/P.AMP2 control and indication; no indicator is shown while off, and no external preamp is inferred.
- Uses a per-session `AetherSDR-<random>` RS-BA1 station identity.
- Hardens login, stale-token removal, prior-session recovery, reconnect, and orderly shutdown based on repeated live-radio cycles and comparison with the open SDR9700 implementation.
- Removes unnecessary RIT/XIT polling because those controls are not implemented in this milestone.
- Requires a successful frequency probe before declaring CI-V command-plane recovery; continuing hardware-scope traffic alone no longer masks a stalled request/reply plane.
- Supports PTT from an optional Icom RC-28 while ensuring that an absent controller does not affect operation or teardown.

#### Regression coverage

- Extends CI-V codec, protocol, scheduler, session, scope, meter, and backend tests.
- Adds model and applet coverage for frequency reconciliation, meter units/resets, PROC range, RF-power limits, and capability-dependent presentation.
- Expresses family differences through backend capabilities/normalized state so the Flex and HL2 implementations keep their native behavior.

## Constitution principle honored

**Principle II — The Radio Is Authoritative On Live State** is the load-bearing principle for this work:

> “The radio holds the live state; the client mirrors it.”

User actions remain requests. CI-V status and confirmed replies reconcile the models and displays; command refusal, disconnect, or unkey cannot leave optimistic frequency, control, or meter state presented as truth. The signed commit subject also cites `Principle II.` as required by project governance.

Principle IV is also observed: the implementation is clean-room, based on public/open-source references, live IC-9700 behavior, CI-V traffic, application logs, and original implementation work. No proprietary binary was decompiled or consulted.

## Test plan

- [x] Local build passes (`cmake --build build -j8`)
- [x] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI) — pending the independent PR run
- [x] Reproduction steps documented if user-reported bug — see #5099

### Automated verification completed locally

- Full configured build graph: **1,976/1,976 Ninja steps passed**.
- Focused CTest suite: **15/15 passed**:
  - `icom_protocol_test`
  - `icom_civ_test`
  - `icom_civ_scheduler_test`
  - `icom_scope_test`
  - `icom_meters_test`
  - `icom_session_test`
  - `icom_backend_test`
  - `icom_family_test`
  - `slice_model_letter_test`
  - `meter_model_test`
  - `health_applet_test`
  - `tci_server_review_test`
  - `transmit_model_test`
  - `tx_applet_power_reconciliation_test`
  - `phone_cw_mic_gain_authority_test`
- `python3 tools/check_engine_boundary.py --strict`: **0 blocking findings**; only tracked legacy warnings.
- `python3 tools/check_test_registration.py --strict`: **passed**.
- `git diff --check`: **passed**.
- Commit signature verified locally as a good Ed25519 Git signature.

### Hardware verification completed

Testing used a physical IC-9700 over its RS-BA1 LAN interface and included:

- repeated connect/disconnect and application-shutdown cycles;
- receive audio and hardware scope/waterfall operation;
- switching among 144, 430, and 1240 MHz;
- simplex, +/- offset, reverse, CTCSS, and DTCS operation;
- RF power reconciliation and band-specific power limits;
- PTT cycles with RF power, SWR, current, voltage, compression, and ALC observation;
- PROC, DEXP, and TX-filter control checks;
- internal preamp state checks; and
- optional RC-28 PTT operation plus operation without assuming the controller is present.

## Compatibility and risk review

- **FlexRadio:** native dBFS ALC, native meter flow, discovery, command plane, and transmit behavior are preserved. Shared capability fields are populated explicitly by the Flex backend.
- **Hermes-Lite 2:** existing in-process DSP and relative-power behavior are preserved; new capability fields are populated by the HL2 backend rather than inferred in the GUI.
- **Other Icom models:** generic behavior remains capability/model-driven. IC-9700-specific bands, limits, scaling, preamp presentation, and lifecycle work are guarded by the detected model where required.
- **Transmit safety:** no autonomous keying is introduced. RC-28 and GUI PTT still require explicit operator action, and per-band output limits are reconciled with radio-reported state.
- **Architecture:** no new dependency or thread is introduced. CI-V work stays below the `IRadioBackend` seam; shared presentation consumes normalized capabilities/models.

## Known limitations / follow-up

- Dual-receiver support and MAIN/SUB swapping remain out of scope pending #4840.
- RIT and XIT are not implemented and are therefore not polled.
- External preamplifier state is not modeled.
- A general radio chooser and user-configurable per-radio nicknames remain future work.
- This PR does not claim complete support for every IC-9700 data-mode or accessory workflow; separately tracked issues remain separate.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All affected meter presentation uses the established smoothing/reset contracts (AGENTS.md convention)
- [x] User-visible behavior is documented in #5099 and this PR; `CHANGELOG.md` is intentionally untouched because it is release-prep only
- [x] Security-sensitive changes are not present; no GHSA applies

