### PR TITLE
test: register issue_report_test and async_log_writer_test so they actually run

### DIFF
--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3515,6 +3515,7 @@ if(UNIX)
     target_link_libraries(issue_report_test PRIVATE pthread)
 endif()
 set_target_properties(issue_report_test PROPERTIES AUTOMOC ON)
+add_test(NAME issue_report_test COMMAND issue_report_test)
 
 add_executable(perf_telemetry_test
     tests/perf_telemetry_test.cpp

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3482,6 +3482,7 @@ if(UNIX)
     target_link_libraries(async_log_writer_test PRIVATE pthread)
 endif()
 set_target_properties(async_log_writer_test PROPERTIES AUTOMOC ON)
+add_test(NAME async_log_writer_test COMMAND async_log_writer_test)
 
 # Support & Diagnostics category toggle must enable Info alongside Debug
 # (#4419): most categories declare a QtWarningMsg threshold, and the filter


### PR DESCRIPTION
## Summary

Registers two test targets with ctest. That is the entire change — two lines in `tests/tests.cmake`, no workflow edit:

```cmake
add_test(NAME issue_report_test      COMMAND issue_report_test)
add_test(NAME async_log_writer_test  COMMAND async_log_writer_test)
```

Both targets have existed for a long time with `add_executable`, includes, `target_link_libraries` and `AUTOMOC` — everything except the line that makes them tests. They compiled on every build and executed in no context at all: not on a PR, not in the weekly sanitizer sweep, not in a contributor's local `ctest` run.

Together they guard the redaction boundary of the issue body an operator pastes out of the app, which is the fix for **GHSA-ccrg-j8cp-qhc4** (cited in `IssueReport.cpp:2`, `IssueReport.h:20`, `SupportBundle.cpp:4,148`). They split the work:

- **`issue_report_test`** (23 checks) pins the *render boundary* — that planted access/refresh/bearer tokens, the SmartLink account name, GPS coordinates and the radio serial are all absent from the rendered body, while callsign, model and firmware survive it, and that the `system-info.json` field set is carried.
- **`async_log_writer_test`** (33 checks) pins the *rules themselves* — IPv4 last-octet, radio serial last-group, MAC dash and colon forms, the 4-char token prefix kept for cross-line correlation — plus the false-positive guards that `ver=` firmware strings and three-octet version numbers are not mangled.

A regression in either would have reached a release with nothing in CI able to notice, and the failure mode is not a broken feature — it is an operator publishing their own token into a public issue.

## What registration buys, precisely

`full-suite.yml:111` and `sanitizers.yml:225` both run `ctest --test-dir build --no-tests=error` **unfiltered** over a tree built as `all`. So a declared test joins both lanes from the moment it is registered, and these two now do: the post-merge run on every push to `main`, and the weekly sanitizer sweep.

This is **not** merge-gating, and the body of this PR should not be read as claiming otherwise. Per the frozen test gate (#5405), `.github/ci-test-gate.txt` says "This list does not grow" and `tools/check_ci_test_gate.py` fails Static checks on any `ci.yml` `-R` pattern resolving to a name not on that list. A new test gets no step in `ci.yml`, however invisible the defect it pins. A regression here surfaces minutes after a merge on `full-suite.yml`, not before it.

> **History:** this PR originally added a `ci.yml` gate step, and its earlier reviews (including @jensenpat's P1 on `--no-tests=error` and the count pin) were written against that shape. #5405 landed the gate freeze in the meantime; the branch was rebased onto current `main` and the workflow hunks dropped, because canon now forbids them. The remaining registration lines are what survives, and under the new regime they are sufficient. The five `ci.yml` review threads are outdated for that reason.

## Constitution principle honored

**Principle VIII — Evidence Over Assertion.** "A claim whose verification step was not actually run is demoted to a hypothesis" (`CONSTITUTION.md:226`). Fifty-six assertions about a security boundary were exactly that: linked, compiled, and never executed.

## Test plan

- [x] `ctest -N` confirms neither target was registered before this change; `check_ci_test_gate.py` reports 347 registered after it (was 346), `ok: per-PR gate matches the frozen list`
- [x] Both pass: `ctest -R '^(issue_report|async_log_writer)_test$'` → 2/2, **0.07 s** total (RelWithDebInfo, Linux, Qt 6.8.3)
- [x] **Mutation-checked** — neutering `redactPii()` at `src/core/AsyncLogWriter.cpp:76` (early `return out;`) fails `issue_report_test` on 7 assertions (access_token, refresh_token, bearer, SmartLink name, GPS, redaction marker, radio serial) and ctest exits non-zero. Restored: 23/23. The gate fails when the thing it guards breaks.
- [x] **Sanitizer-clean before enrolling them in the weekly lane**, using `sanitizers.yml`'s own runtime options. `async_log_writer_test` is the one that matters here — unlike `issue_report_test` it spawns the writer's worker thread and does real file I/O. TSan (with `tests/sanitizers/tsan.supp`): 33/33, no race reports. ASan+UBSan (`detect_leaks=1`, `strict_string_checks=1`, `detect_stack_use_after_return=1`): 33/33, no errors. `issue_report_test` clean on both too.
- [x] **Flake-checked at 60 runs** — 40 plain, 10 under TSan, 10 under ASan — **zero failures**. It isolates its log tree in a `QTemporaryDir`, and `AsyncLogWriter`'s `std::thread` is only started by the paths the test drives deliberately.
- [x] Socket-free: neither test source hits `QTcpServer`/`QTcpSocket`/`QUdpSocket`/`QLocalServer`/`QWebSocket`/`bind(`/`listen(`/`connectToHost`, and neither uses a synthetic firmware peer — so no test-layer-boundary notification applies
- [x] Behavior verified on a real radio — n/a, test registration only

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls — no application code touched
- [x] Code is clean-room
- [x] All meter UI uses `MeterSmoother` — n/a
- [x] Documentation updated — n/a, no user-visible behavior change
- [x] Security-sensitive changes reference a GHSA — n/a as a change; noted above that the guarded code is the fix for GHSA-ccrg-j8cp-qhc4

## Known follow-up (not this PR)

`tests/tests.cmake` has **354 `add_executable` targets against 347 registrations**, and carries no `# not registered: <reason>` markers, so nothing distinguishes deliberate exclusions from oversights. Some are clearly intentional — `*_live_*_probe`, `kiwi_directory_poc`, `ax25_replay`, `hl2_signal_stop_child` as a child helper, and `rigctld_test`, which owns a socket and should stay out per the test-layer boundary. But `app_settings_safety_test`, `container_manager_test`, `container_nesting_test`, `navtex_model_test`, `xvtr_policy_test`, `ole_compound_file_test`, `help_dialog_test`, `settings_browser_dialog_test` and eight `client_*_test` DSP targets look like they are in the same position these two were. Worth its own issue rather than widening this one.
