### PR TITLE
feat(psk-reporter): add smooth trackpad pinch-to-zoom — Principle VIII.

### DIFF
--- a/tests/map_wrap_test.cpp
+++ b/tests/map_wrap_test.cpp
@@ -5,7 +5,9 @@
 #include <QGeoView/QGVProjection.h>
 
 #include <QApplication>
+#include <QNativeGestureEvent>
 #include <QPoint>
+#include <QPointingDevice>
 #include <QWheelEvent>
 #include <QtGlobal>
 
@@ -17,6 +19,13 @@ namespace {
 bool nearlyEqual(double lhs, double rhs)
 {
     return std::abs(lhs - rhs) < 1e-9;
+}
+
+bool withinPixels(const QPointF& lhs, const QPointF& rhs,
+                  double scale, double tolerance)
+{
+    const QPointF delta = lhs - rhs;
+    return std::hypot(delta.x(), delta.y()) * scale <= tolerance;
 }
 
 bool expect(bool condition, const char* message)
@@ -123,6 +132,46 @@ int main(int argc, char** argv)
     }
     ok &= expect(nearlyEqual(roundTrip / startScale, 1.0),
                  "equal wheel notches in and out should return the same scale");
+
+    // macOS and Wayland deliver trackpad pinches as native gestures, not wheel
+    // events. Each incremental value must adjust the fractional camera scale
+    // directly and keep the map coordinate beneath the pinch centroid fixed.
+    map.cameraTo(QGVCameraActions(&map).scaleTo(1.0), false);
+    app.processEvents();
+    const QPoint pinchPos(map.geoView()->viewport()->width() / 3,
+                          map.geoView()->viewport()->height() / 4);
+    const QPointF pinchGlobal =
+        map.geoView()->viewport()->mapToGlobal(pinchPos);
+    const QPointF anchorBefore = map.geoView()->mapToScene(pinchPos);
+    const auto pinch = [&](double value,
+                           Qt::NativeGestureType type = Qt::ZoomNativeGesture) {
+        QNativeGestureEvent event(type,
+                                  QPointingDevice::primaryPointingDevice(),
+                                  2, pinchPos, pinchPos, pinchGlobal,
+                                  value, QPointF());
+        QApplication::sendEvent(map.geoView()->viewport(), &event);
+        app.processEvents();
+    };
+
+    pinch(0.05);
+    const double pinchedScale = map.getCamera().scale();
+    const QPointF anchorAfter = map.geoView()->mapToScene(pinchPos);
+    ok &= expect(nearlyEqual(pinchedScale, 1.05),
+                 "a small pinch delta should produce a fractional scale, "
+                 "not a zoom step");
+    ok &= expect(withinPixels(anchorBefore, anchorAfter, pinchedScale, 1.0),
+                 "pinch zoom should keep its off-centre map anchor fixed");
+
+    // The inverse factor should return exactly to the starting scale. Equal
+    // signed deltas are not inverses under Qt's documented (1 + value) rule.
+    pinch((1.0 / 1.05) - 1.0);
+    ok &= expect(nearlyEqual(map.getCamera().scale(), 1.0),
+                 "inverse pinch factors should return to the starting scale");
+
+    const double beforeRotate = map.getCamera().scale();
+    pinch(15.0, Qt::RotateNativeGesture);
+    ok &= expect(nearlyEqual(map.getCamera().scale(), beforeRotate),
+                 "non-zoom native gestures must not change map scale");
 
     return ok ? 0 : 1;
 }

--- a/third_party/QGeoView/AETHERSDR-PATCHES.md
+++ b/third_party/QGeoView/AETHERSDR-PATCHES.md
@@ -74,3 +74,11 @@ this list current when updating the snapshot.
    for; with patch 5 the several visible copies of one tile all resolve to the
    same canonical URL, so that would issue one identical concurrent GET per
    copy. The finished reply is now fanned out to every copy waiting on it.
+
+10. **`lib/src/QGVMapQGView.cpp` — native trackpad pinch zoom.** Qt delivers
+    macOS and Wayland trackpad pinches as incremental `ZoomNativeGesture`
+    events rather than wheel events. The view now applies every fractional
+    scale delta directly, without animation or integer zoom-level snapping,
+    and keeps the projected point beneath the pinch centroid fixed. Both the
+    view and viewport delivery paths are covered because `QGraphicsView`
+    input targeting differs by platform.

--- a/third_party/QGeoView/lib/include/QGeoView/QGVMapQGView.h
+++ b/third_party/QGeoView/lib/include/QGeoView/QGVMapQGView.h
@@ -32,6 +32,7 @@
 #include <QMimeData>
 
 class QGVMap;
+class QNativeGestureEvent;
 
 class QGV_LIB_DECL QGVMapQGView : public QGraphicsView
 {
@@ -68,6 +69,7 @@ private:
     void applyCameraUpdate(const QGVCameraState& oldState);
 
     void showTooltip(QHelpEvent* helpEvent);
+    bool zoomByNativeGesture(QNativeGestureEvent* event);
     void zoomByWheel(QWheelEvent* event);
     void startMoving(QMouseEvent* event);
     void startMovingObject(QMouseEvent* event);
@@ -86,6 +88,7 @@ private:
     void showMenu(QMouseEvent* event);
 
     bool event(QEvent* event) override final;
+    bool viewportEvent(QEvent* event) override final;
     void wheelEvent(QWheelEvent* event) override final;
     void mousePressEvent(QMouseEvent* event) override final;
     void mouseReleaseEvent(QMouseEvent* event) override final;

--- a/third_party/QGeoView/lib/src/QGVMapQGView.cpp
+++ b/third_party/QGeoView/lib/src/QGVMapQGView.cpp
@@ -25,6 +25,7 @@
 #include "QGVWidget.h"
 
 #include <QApplication>
+#include <QNativeGestureEvent>
 #include <QParallelAnimationGroup>
 #include <QScrollBar>
 #include <QSequentialAnimationGroup>
@@ -287,6 +288,39 @@ void QGVMapQGView::showTooltip(QHelpEvent* helpEvent)
     } else {
         QToolTip::hideText();
     }
+}
+
+bool QGVMapQGView::zoomByNativeGesture(QNativeGestureEvent* event)
+{
+    if (event->gestureType() != Qt::ZoomNativeGesture
+        || !mMouseActions.testFlag(QGV::MouseAction::ZoomWheel)) {
+        return false;
+    }
+
+    event->accept();
+    const double factor = 1.0 + event->value();
+    if (!qIsFinite(factor) || factor <= 0.0 || qFuzzyCompare(factor, 1.0)) {
+        return true;
+    }
+
+    // Native gestures may target either the view or its viewport. Normalize
+    // from the stable global position, then keep the projected point beneath
+    // the pinch centroid fixed while applying every fractional scale update.
+    const QPoint eventPos =
+        viewport()->mapFromGlobal(event->globalPosition()).toPoint();
+    const QPointF projAnchor = mapToScene(eventPos);
+    const QGVCameraState oldState = getCamera();
+    blockCameraUpdate();
+    cameraScale(mScale * factor);
+
+    const QPointF projMouse = mapToScene(eventPos);
+    const QPointF delta = projMouse - projAnchor;
+    if (!qFuzzyIsNull(delta.x()) || !qFuzzyIsNull(delta.y())) {
+        cameraMove(viewRect().center() - delta);
+    }
+    unblockCameraUpdate();
+    applyCameraUpdate(oldState);
+    return true;
 }
 
 void QGVMapQGView::zoomByWheel(QWheelEvent* event)
@@ -570,11 +604,24 @@ void QGVMapQGView::showMenu(QMouseEvent* event)
 
 bool QGVMapQGView::event(QEvent* event)
 {
+    if (event->type() == QEvent::NativeGesture
+        && zoomByNativeGesture(static_cast<QNativeGestureEvent*>(event))) {
+        return true;
+    }
     event->ignore();
     if (event->type() == QEvent::ToolTip) {
         showTooltip(static_cast<QHelpEvent*>(event));
     }
     return QGraphicsView::event(event);
+}
+
+bool QGVMapQGView::viewportEvent(QEvent* event)
+{
+    if (event->type() == QEvent::NativeGesture
+        && zoomByNativeGesture(static_cast<QNativeGestureEvent*>(event))) {
+        return true;
+    }
+    return QGraphicsView::viewportEvent(event);
 }
 
 void QGVMapQGView::wheelEvent(QWheelEvent* event)


### PR DESCRIPTION
## Summary

Adds native trackpad pinch-to-zoom support to the PSK Reporter map. Pinch gestures now apply each fractional scale delta directly instead of stepping through the discrete zoom levels used by the +/- buttons. Zooming remains anchored beneath the pinch centroid, and the implementation handles native gestures delivered to either the map view or its viewport on macOS and Wayland.

The vendored QGeoView modification is documented in `third_party/QGeoView/AETHERSDR-PATCHES.md`.

## Constitution principle honored

Principle VIII — Evidence Over Assertion. The change includes a synthetic native-gesture regression test demonstrating fractional scaling, off-center anchor stability, reversible scaling, and rejection of non-zoom native gestures.

## Test plan

- [x] Local ARM64 build passes (`cmake --build build-codex-arm64 -j8`)
- [x] Behavior manually verified with a physical trackpad
- [x] Focused `map_wrap_test` passes locally
- [ ] Existing tests pass in CI
- [x] Reproduction steps documented:
  1. Open **View → PSK Reporter**
  2. Place two fingers over an off-center map location
  3. Pinch in and out
  4. Confirm zooming is continuous and the location beneath the pinch remains stationary
  5. Confirm the +/- buttons retain their existing discrete zoom behavior

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no settings changed
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary
- [x] All meter UI uses `MeterSmoother` — no meter UI changed
- [x] User-visible behavior is documented in `third_party/QGeoView/AETHERSDR-PATCHES.md`; `CHANGELOG.md` is unchanged
- [x] Security-sensitive changes reference a GHSA if applicable — not applicable
