### PR TITLE
feat(automation): add FM repeater verbs — squelch, CTCSS, offset, transmit power (#5102)

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -3636,7 +3636,7 @@ receiver capacity. It never enables transmit and remains available without
 The complete registry, generated from the `add(...)` table in `AutomationServer.cpp` by `tools/gen_bridge_docs.py`. CI fails if this drifts from the code.
 
 <!-- BEGIN GENERATED VERB TABLE (tools/gen_bridge_docs.py) -->
-<!-- Do not edit by hand — run tools/gen_bridge_docs.py. 68 verbs. -->
+<!-- Do not edit by hand — run tools/gen_bridge_docs.py. 69 verbs. -->
 
 | Verb | Aliases | Description |
 |---|---|---|

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -27,7 +27,7 @@ production; it only exists when you ask for it via an env var.
 | Visually check a dialog or applet layout | **Yes** — `grab <widget>` → view the PNG. |
 | Click a button or move a slider programmatically | **Yes** — `invoke <target> <action> [value]`. |
 | Read live model truth (freq, mode, center, dBm, NB/NR) | **Yes** — `get radio\|slice\|pan …`. Assert on state, no pixels. |
-| Key the radio (MOX/PTT/Tune) | **Only deliberately** — `invoke` refuses transmit controls by design; the dedicated [transmit verbs](#transmit-verbs--gated) (`key`/`cwx`/`txtest`/`atu`) work **only** under `AETHER_AUTOMATION_ALLOW_TX=1` (see [TX safety](#tx-safety)). |
+| Key the radio (MOX/PTT/Tune) | **Only deliberately** — `invoke` refuses transmit controls by design; the dedicated [transmit verbs](#transmit-verbs--gated) (`key`/`cwx`/`txtest`/`atu`/`transmit`) work **only** under `AETHER_AUTOMATION_ALLOW_TX=1` (see [TX safety](#tx-safety)). |
 | Read client-side DSP / window / floor state | **Yes** — `get dsp`, `dumpTree` `windowState`, `floors`. |
 
 ---
@@ -147,7 +147,7 @@ The verbs kept behind `bridge_command` on purpose: the low-level widget
 primitives (`close`, `hover`, `tooltip`, `scrollTo`, `drag`, `showMenu`,
 `contextMenu`, `rightClick`, `hitTest`, `clickAt`, `doubleClick`,
 `doubleClickAt` — `invoke`/`grab` cover the common cases), the transmit-keying verbs (`key`, `txtest`,
-`atu`, `cwx`, `testtone`, `txwaterfall` — gated by
+`atu`, `cwx`, `testtone`, `txwaterfall`, `transmit` — gated by
 `AETHER_AUTOMATION_ALLOW_TX`, deliberately less convenient), and the
 niche/complex ones (`dss`, `layout`, `scale`, `panmessage`, `tci`,
 `station`, `resize`, `qrz`).
@@ -354,7 +354,7 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 | **Tuning & slices** | [`tune <mhz>`](#tune) | Set the active slice frequency (VFO; not keying). |
 | | [`targettune <mhz>`](#targettune) | Absolute tune through the commanded-target and band-stack path. |
 | | [`memory activate <index> [panId]`](#memory) | Recall a radio memory through the normal UI policy. |
-| | [`slice <action>`](#slice) | add/remove/select/tx/mode/filter/agc/diversity/centerlock/txant/rxant/rxsource. |
+| | [`slice <action>`](#slice) | Per-slice actions — mode, filter, AGC, DSP, FM tone/offset, antennas, links, fixtures. The authoritative set is the [`slice` action table](#slice); it is pinned to the code by `tools/gen_bridge_docs.py --check`. |
 | **GPS fixtures** | [`gps fixture <6000\|8000>`](#gps) | Disconnected-only GPS status fixture using each production wire format. |
 | **Display / pans** | [`pan <action>`](#pan) | create / center / close a panadapter. |
 | | [`panmessage <action>`](#panmessage) | Add, remove, clear, or list panadapter overlay messages for UI testing. |
@@ -373,6 +373,7 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 | | [`txtest twotone\|off`](#txtest) | Two-tone test signal. |
 | | [`atu bypass\|start`](#atu) | ATU bypass (no TX) / tune cycle (keys TX). |
 | | [`testtone on [hz] [db] \| off`](#testtone) | Client TX test tone into the mic path. |
+| | [`transmit rfpower\|tunepower <0..100>`](#transmit) | Set RF / tune drive (clamped by `AETHER_AUTOMATION_TX_MAX_POWER`). |
 
 > **Two request forms, always interchangeable.** Bare line (`get slice active mode`)
 > or JSON (`{"cmd":"get","model":"slice","selector":"active","property":"mode"}`).
@@ -1400,6 +1401,9 @@ re-poll `get slices`.
 | `mode` | `<name>` e.g. `DSTR` | set the active slice mode through `SliceModel`; validated against the radio-advertised mode list |
 | `filter` | `<lowHz> <highHz>` e.g. `-3000 -150` | set the active slice passband through `SliceModel::setFilterWidth`, the operator-intent setter — so the edges reach `IRadioBackend::setSliceFilter` and not just the model. Necessary because a mode change mirrors the passband *inside* the model without emitting that intent, which can leave a backend that owns its own DSP chain running the pre-mirror passband while `get_state` reports the mirrored one. Assert the passband before measuring anything through the audio path. Returns both the requested edges and the post-normalization `filterLow`/`filterHigh` the model actually holds. Use `-4000 4000` for a carrier-straddling AM passband |
 | `agc` | `<off\|slow\|med\|fast> [threshold 0..100]` | set the active slice's receive AGC through `SliceModel`'s operator setters, so it emits `agcCommandIssued` and reaches `IRadioBackend::setSliceAgc`. Applies the threshold before the mode so a combined request arrives at the backend as one coherent pair. On a backend that owns its DSP chain (HL2) this maps to the WDSP RXA AGC mode and the AGC ceiling in dB; on Flex it is the firmware's own AGC. Use `off` with a low threshold to get a linear path for measurement |
+| `dsp` | `<nr\|nb\|anf\|squelch> <on\|off> [level]` | drive the receive DSP controls an operator drives — noise blanker, noise reduction, auto-notch, and squelch (with an optional 0..100 level). `slice dsp squelch` is the squelch path; there is deliberately no separate squelch verb (#5102) |
+| `tone` | `<off\|ctcss_tx> [freq]` | set the FM CTCSS encode mode and tone. The value is applied before the mode, so enabling CTCSS never keys on the previous tone for a round trip. The mode pair is what a FlexRadio slice carries |
+| `offset` | `<simplex\|up\|down> [mhz]` | set repeater duplex. The magnitude is unsigned (0..100 MHz — the GUI spinboxes' own bound); the direction carries the sign. Writes all three radio fields — `repeater_offset_dir`, `fm_repeater_offset_freq` **and** the signed `tx_offset_freq` that actually moves the transmitter — then reports `txOffsetFreq` so the applied split can be asserted rather than assumed |
 | `diversity` | `<sliceId> <on\|off>` | enable or disable diversity through the slice model; re-poll `get slices` for parent/child state |
 | `centerlock` | `<sliceId> <on\|off>` | enable or disable Center Lock for that exact slice through the same per-pan path as the context menu; an explicit id permits testing either diversity member |
 | `link` | `<sliceIdA> <sliceIdB> <on\|off>` | engage or dissolve one cross-panadapter Slice Link pair through the same MainWindow handler as the context menu; multiple independent pairs are supported, but each owned non-diversity slice may belong to only one pair — assert each pair via the reciprocal `linkedTo` snapshot fields |
@@ -3416,6 +3420,26 @@ antenna gates in [`TX_TEST_PROMPT.md`](automation/TX_TEST_PROMPT.md).
 ← {"ok":true,"txtest":"off"}
 ```
 
+### `transmit`
+Set the transmit drive — `rfpower` (RF Power) or `tunepower` (Tune Power), 0..100.
+TX-gated like `key`, and the gate is reported **before** the value is validated so
+it cannot be probed with nonsense.
+
+The value is additionally **clamped to `AETHER_AUTOMATION_TX_MAX_POWER`**. That
+ceiling is enforced elsewhere in `invoke()`'s widget path, keyed on the control's
+accessible name, so a verb reaching `TransmitModel` directly would otherwise inherit
+no bound at all — on the surface most likely to be feeding a transverter or an
+amplifier. When a request is clamped the reply says so rather than quietly honouring
+a different number than was asked for.
+
+```json
+→ {"cmd":"transmit","action":"rfpower","value":"25"}   # gated
+← {"ok":true,"transmit":"rfpower","rfPower":25,"tunePower":10}
+
+→ {"cmd":"transmit","action":"rfpower","value":"90"}   # ceiling of 30 in force
+← {"ok":true,"transmit":"rfpower","rfPower":30,"tunePower":10,"requested":90,"clampedTo":30}
+```
+
 ### `atu`
 Antenna-tuner control. `bypass` is relay-only (takes the tuner out of circuit so
 meters see the raw load) and does **not** transmit; `start` runs a tune cycle that
@@ -3672,6 +3696,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `civ` | — | civ <send <hex>\|trace [all]\|session\|scheduler> — CI-V inject, frame trace, RS-BA1 lease health, or command-scheduler health (Icom; send is TX-gated) |
 | `controls` | — | controls <map\|meters\|scrub [id\|plane]> — the CI-V control and meter registry joined against what is actually wired, and a linkage check that drives every settable control without moving any of them (Icom) |
 | `radiocert` | — | radiocert <tune\|rx\|tx\|meters\|all> [freqMhz] — radio bring-up diagnostic, in dependency order (tx/meters key) |
+| `transmit` | — | transmit <rfpower\|tunepower> <0..100> — transmit drive (TX-gated) |
 | `key` | — | key <ptt on\|off \| mox> — semantic keying (TX-gated) |
 | `station` | — | station <name> — set the GUI-client station name |
 | `resize` | — | resize <w> <h> [target] — resize a window |

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -7222,13 +7222,13 @@ QJsonObject AutomationServer::doSlice(const QString& action, const QString& arg)
         double offsetMhz = -1.0;
         if (parts.size() >= 2) {
             bool okM = false;
-            offsetMhz = std::abs(parts[1].toDouble(&okM));
-            if (!okM)
+            offsetMhz = parts[1].toDouble(&okM);
+            if (!okM || !std::isfinite(offsetMhz))
                 return err(QStringLiteral("offset must be a frequency in MHz"));
             // The same bound both GUI spinboxes carry (RxApplet.cpp,
             // VfoWidget.cpp: setRange(0.0, 100.0)), so the bridge cannot
             // request duplex no operator could dial in.
-            if (offsetMhz > 100.0)
+            if (offsetMhz < 0.0 || offsetMhz > 100.0)
                 return err(QStringLiteral(
                     "offset magnitude must be 0..100 MHz"));
         }

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1179,6 +1179,18 @@ QImage grabWidget(QWidget* w)
     return w->grab().toImage();
 }
 
+// The single list of slice actions. It previously existed twice, by hand, and
+// the two copies drifted: the `unknown slice action:` message omitted filter,
+// agc and dsp — all of which work. That omission is not cosmetic; it is how a
+// caller concludes a working action does not exist (#5102 was filed reporting
+// squelch as absent when `slice dsp squelch` had implemented it all along).
+QString sliceActionList()
+{
+    return QStringLiteral(
+        "add|remove|select|tx|mode|filter|agc|dsp|tone|offset|diversity|"
+        "centerlock|link|txant|rxant|rxsource|fixture|clearfixture");
+}
+
 QJsonObject err(const QString& msg)
 {
     return QJsonObject{{QStringLiteral("ok"), false},
@@ -3018,9 +3030,8 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
             [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
                 if (a.action.isEmpty())
                     return err(QStringLiteral(
-                        "slice requires an action (add|remove|select|tx|mode|filter|"
-                        "agc|dsp|diversity|centerlock|link|txant|rxant|rxsource|fixture|"
-                        "clearfixture)"));
+                        "slice requires an action (")
+                        + sliceActionList() + QStringLiteral(")"));
                 return s.doSlice(a.action, a.value);
             });
 
@@ -7108,73 +7119,6 @@ QJsonObject AutomationServer::doSlice(const QString& action, const QString& arg)
                            {QStringLiteral("id"), id},
                            {QStringLiteral("sliceCount"), radio->slices().size()}};
     }
-    if (action == QLatin1String("squelch")
-        || action == QLatin1String("squelchlevel")) {
-        // "slice squelch <on|off> [level 0..100]" / "slice squelchlevel <0..100>"
-        // Selecting FM auto-enables squelch, which gates the audio an automated
-        // capture is trying to measure — so this is the difference between an FM
-        // capture workflow that runs unattended and one that needs a human.
-        const QStringList parts =
-            arg.trimmed().split(QRegularExpression(QStringLiteral("[\\s,]+")),
-                                Qt::SkipEmptyParts);
-        const bool levelOnly = (action == QLatin1String("squelchlevel"));
-        if (parts.isEmpty())
-            return err(levelOnly
-                           ? QStringLiteral("slice squelchlevel requires '<0..100>'")
-                           : QStringLiteral("slice squelch requires '<on|off> [level]'"));
-
-        // Validate everything the caller sent BEFORE resolving a slice, so a
-        // malformed request is refused at the boundary rather than after the
-        // radio has been reached for (Principle VII) — and so the rejection
-        // paths are assertable without a radio attached.
-        const int levelIdx = levelOnly ? 0 : 1;
-        bool requestedOn = false;
-        bool haveOn = false;
-        if (!levelOnly) {
-            const QString state = parts[0].toLower();
-            if (state == QLatin1String("on") || state == QLatin1String("1"))
-                requestedOn = true;
-            else if (state == QLatin1String("off") || state == QLatin1String("0"))
-                requestedOn = false;
-            else
-                return err(QStringLiteral("squelch state must be on|off"));
-            haveOn = true;
-        }
-        int requestedLevel = -1;
-        if (parts.size() > levelIdx) {
-            bool okL = false;
-            const int value = parts[levelIdx].toInt(&okL);
-            if (!okL || value < 0 || value > 100)
-                return err(QStringLiteral("squelch level must be an integer 0..100"));
-            requestedLevel = value;
-        }
-        if (levelOnly && requestedLevel < 0)
-            return err(QStringLiteral("slice squelchlevel requires '<0..100>'"));
-
-        SliceModel* s = nullptr;
-        for (SliceModel* candidate : radio->slices()) {
-            if (candidate->isActive()) { s = candidate; break; }
-        }
-        if (!s && !radio->slices().isEmpty())
-            s = radio->slices().first();
-        if (!s)
-            return err(QStringLiteral("no slice available to set squelch on"));
-
-        // Unspecified halves keep their current value, so `squelchlevel` never
-        // silently toggles the gate and `squelch on` never resets the level.
-        const bool on = haveOn ? requestedOn : s->squelchOn();
-        const int level = (requestedLevel >= 0) ? requestedLevel : s->squelchLevel();
-
-        // One setter carries both halves, so state and level always reach the
-        // backend as a coherent pair (same reasoning as the AGC arm above).
-        s->setSquelch(on, level);
-        return QJsonObject{{QStringLiteral("ok"), true},
-                           {QStringLiteral("slice"), action},
-                           {QStringLiteral("id"), s->sliceId()},
-                           {QStringLiteral("squelch"), s->squelchOn()},
-                           {QStringLiteral("squelchLevel"), s->squelchLevel()}};
-    }
-
     if (action == QLatin1String("tone")) {
         // "slice tone <off|ctcss_tx> [freq]" — a FlexRadio slice carries a single
         // TX CTCSS tone, so the mode pair is off/ctcss_tx (see MemoryCsvCompat,
@@ -7269,9 +7213,7 @@ QJsonObject AutomationServer::doSlice(const QString& action, const QString& arg)
     }
 
     return err(QStringLiteral("unknown slice action: ") + action
-               + QStringLiteral(" (add|remove|select|tx|mode|filter|agc|dsp|squelch|"
-                                "squelchlevel|tone|offset|diversity|centerlock|"
-                                "link|txant|rxant|rxsource|fixture|clearfixture)"));
+               + QStringLiteral(" (") + sliceActionList() + QStringLiteral(")"));
 }
 
 QJsonObject AutomationServer::doGps(const QString& action, const QString& format)
@@ -8046,17 +7988,37 @@ QJsonObject AutomationServer::doTransmit(const QString& action, const QString& a
             return err(QStringLiteral("transmit ") + a
                        + QStringLiteral(" must be an integer 0..100"));
 
+        // The power-ceiling rail is WIDGET-scoped: it lives in invoke()'s
+        // setValue path and keys off accessibleName, so a verb that reaches the
+        // model directly does not inherit it. `radiocert` already had to pass
+        // m_txMaxPower down its own path for the same reason. Clamp explicitly —
+        // otherwise AETHER_AUTOMATION_TX_MAX_POWER silently stops bounding the
+        // one surface most likely to be driving a transverter or an amplifier.
+        int applied = pct;
+        if (m_txMaxPower >= 0 && applied > m_txMaxPower) {
+            qCWarning(lcAutomation).noquote()
+                << "power ceiling: clamped transmit" << a << pct << "->" << m_txMaxPower;
+            applied = m_txMaxPower;
+        }
+
         if (a == QLatin1String("rfpower"))
-            tx.setRfPower(pct);
+            tx.setRfPower(applied);
         else
-            tx.setTunePower(pct);
+            tx.setTunePower(applied);
 
         qCInfo(lcAutomation).noquote()
-            << "transmit" << a << pct << "(ALLOW_TX)";
-        return QJsonObject{{QStringLiteral("ok"), true},
-                           {QStringLiteral("transmit"), a},
-                           {QStringLiteral("rfPower"), tx.rfPower()},
-                           {QStringLiteral("tunePower"), tx.tunePower()}};
+            << "transmit" << a << applied << "(ALLOW_TX)";
+        QJsonObject reply{{QStringLiteral("ok"), true},
+                          {QStringLiteral("transmit"), a},
+                          {QStringLiteral("rfPower"), tx.rfPower()},
+                          {QStringLiteral("tunePower"), tx.tunePower()}};
+        if (applied != pct) {
+            // Say so rather than silently honouring a different number than the
+            // caller asked for.
+            reply.insert(QStringLiteral("requested"), pct);
+            reply.insert(QStringLiteral("clampedTo"), applied);
+        }
+        return reply;
     }
 
     return err(QStringLiteral("transmit requires an action (rfpower|tunepower)"));
@@ -11365,6 +11327,10 @@ QJsonObject AutomationServer::doAudioCapture(const QString& action,
         snapshot[QStringLiteral("chunksOmitted")] =
             snapshot.value(QStringLiteral("chunkCount"));
         snapshot.remove(QStringLiteral("chunks"));
+        // Without this, chunksOmitted == chunkCount reads as "the capture was
+        // lost" when the audio is intact and simply needs somewhere to go.
+        snapshot[QStringLiteral("hint")] = QStringLiteral(
+            "audio retained; pass path=<file> to audioCapture read to write it out");
         return snapshot;
     };
 

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1,4 +1,5 @@
 #include "AutomationServer.h"
+#include "core/CtcssTones.h"
 #include "core/RadioCertification.h"
 #include "LogManager.h"
 #include "AppSettings.h"          // StationName (restore the user's real station name)
@@ -1659,6 +1660,10 @@ QJsonObject sliceSnapshot(const SliceModel* s, int linkedTo)
         {QStringLiteral("fmToneValue"), s->fmToneValue()},
         {QStringLiteral("repeaterOffsetDir"), s->repeaterOffsetDir()},
         {QStringLiteral("fmRepeaterOffsetFreq"), s->fmRepeaterOffsetFreq()},
+        // The signed one — the number that decides where the radio transmits.
+        // An FM session can assert the duplex it just applied, not just that
+        // the request was accepted.
+        {QStringLiteral("txOffsetFreq"), s->txOffsetFreq()},
         {QStringLiteral("receiveAgcMode"), s->receiveAgcMode()},
         {QStringLiteral("receiveAgcThreshold"), s->receiveAgcThreshold()},
         {QStringLiteral("receiveAgcOffLevel"), s->receiveAgcOffLevel()},
@@ -7139,9 +7144,14 @@ QJsonObject AutomationServer::doSlice(const QString& action, const QString& arg)
         if (parts.size() >= 2) {
             bool okF = false;
             const double hz = parts[1].toDouble(&okF);
-            if (!okF || hz <= 0.0 || hz > 300.0)
+            // Against the SAME table the operator's dropdown is built from
+            // (core/CtcssTones.h), not a range: a bare 0 < f <= 300 bound
+            // accepted 123.4 Hz, which is not a CTCSS tone and which no
+            // operator could dial in from the applet.
+            if (!okF || !isCtcssFrequency(hz))
                 return err(QStringLiteral(
-                    "tone freq must be a CTCSS frequency in Hz (0 < f <= 300)"));
+                    "tone freq must be a standard CTCSS tone in Hz "
+                    "(67.0 .. 254.1, e.g. 100.0)"));
             toneValue = QString::number(hz, 'f', 1);
         }
 
@@ -7188,6 +7198,12 @@ QJsonObject AutomationServer::doSlice(const QString& action, const QString& arg)
             offsetMhz = std::abs(parts[1].toDouble(&okM));
             if (!okM)
                 return err(QStringLiteral("offset must be a frequency in MHz"));
+            // The same bound both GUI spinboxes carry (RxApplet.cpp,
+            // VfoWidget.cpp: setRange(0.0, 100.0)), so the bridge cannot
+            // request duplex no operator could dial in.
+            if (offsetMhz > 100.0)
+                return err(QStringLiteral(
+                    "offset magnitude must be 0..100 MHz"));
         }
 
         SliceModel* s = nullptr;
@@ -7204,12 +7220,23 @@ QJsonObject AutomationServer::doSlice(const QString& action, const QString& arg)
         if (offsetMhz >= 0.0)
             s->setFmRepeaterOffsetFreq(offsetMhz);
         s->setRepeaterOffsetDir(dir);
+        // ...and then the field that actually moves the transmitter. Direction
+        // and magnitude each send only their own key; tx_offset_freq is a
+        // separate one the radio carries in its own right (FlexBackend
+        // decodes it as its own value), so without this a slice records
+        // "down, 5 MHz" and still transmits on the receive frequency. Last,
+        // so the split is only armed once both operands are in place — and
+        // unconditional, because a direction unchanged from its current value
+        // still has to recompute against a magnitude that just moved.
+        s->setTxOffsetFreq(SliceModel::txOffsetForDirection(
+            dir, s->fmRepeaterOffsetFreq()));
         return QJsonObject{{QStringLiteral("ok"), true},
                            {QStringLiteral("slice"), QStringLiteral("offset")},
                            {QStringLiteral("id"), s->sliceId()},
                            {QStringLiteral("repeaterOffsetDir"), s->repeaterOffsetDir()},
                            {QStringLiteral("fmRepeaterOffsetFreq"),
-                            s->fmRepeaterOffsetFreq()}};
+                            s->fmRepeaterOffsetFreq()},
+                           {QStringLiteral("txOffsetFreq"), s->txOffsetFreq()}};
     }
 
     return err(QStringLiteral("unknown slice action: ") + action

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1641,6 +1641,12 @@ QJsonObject sliceSnapshot(const SliceModel* s, int linkedTo)
         {QStringLiteral("flexSquelchLevel"), s->flexSquelchLevel()},
         {QStringLiteral("agcMode"),    s->agcMode()},
         {QStringLiteral("agcThreshold"), s->agcThreshold()},
+        // FM / repeater duplex — readable so an automated FM session can assert
+        // the repeater setup it just applied, not just fire and hope.
+        {QStringLiteral("fmToneMode"),  s->fmToneMode()},
+        {QStringLiteral("fmToneValue"), s->fmToneValue()},
+        {QStringLiteral("repeaterOffsetDir"), s->repeaterOffsetDir()},
+        {QStringLiteral("fmRepeaterOffsetFreq"), s->fmRepeaterOffsetFreq()},
         {QStringLiteral("receiveAgcMode"), s->receiveAgcMode()},
         {QStringLiteral("receiveAgcThreshold"), s->receiveAgcThreshold()},
         {QStringLiteral("receiveAgcOffLevel"), s->receiveAgcOffLevel()},
@@ -3354,6 +3360,15 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
                 return s.doRadioCert(a.action, a.value);
             });
 
+        add("transmit", {},
+            "transmit <rfpower|tunepower> <0..100> — transmit drive (TX-gated)",
+            parseActionValue,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.action.isEmpty())
+                    return err(QStringLiteral(
+                        "transmit requires an action (rfpower|tunepower)"));
+                return s.doTransmit(a.action, a.value);
+            });
         add("key", {}, "key <ptt on|off | mox> — semantic keying (TX-gated)",
             parseActionValue,
             [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
@@ -7093,8 +7108,169 @@ QJsonObject AutomationServer::doSlice(const QString& action, const QString& arg)
                            {QStringLiteral("id"), id},
                            {QStringLiteral("sliceCount"), radio->slices().size()}};
     }
+    if (action == QLatin1String("squelch")
+        || action == QLatin1String("squelchlevel")) {
+        // "slice squelch <on|off> [level 0..100]" / "slice squelchlevel <0..100>"
+        // Selecting FM auto-enables squelch, which gates the audio an automated
+        // capture is trying to measure — so this is the difference between an FM
+        // capture workflow that runs unattended and one that needs a human.
+        const QStringList parts =
+            arg.trimmed().split(QRegularExpression(QStringLiteral("[\\s,]+")),
+                                Qt::SkipEmptyParts);
+        const bool levelOnly = (action == QLatin1String("squelchlevel"));
+        if (parts.isEmpty())
+            return err(levelOnly
+                           ? QStringLiteral("slice squelchlevel requires '<0..100>'")
+                           : QStringLiteral("slice squelch requires '<on|off> [level]'"));
+
+        // Validate everything the caller sent BEFORE resolving a slice, so a
+        // malformed request is refused at the boundary rather than after the
+        // radio has been reached for (Principle VII) — and so the rejection
+        // paths are assertable without a radio attached.
+        const int levelIdx = levelOnly ? 0 : 1;
+        bool requestedOn = false;
+        bool haveOn = false;
+        if (!levelOnly) {
+            const QString state = parts[0].toLower();
+            if (state == QLatin1String("on") || state == QLatin1String("1"))
+                requestedOn = true;
+            else if (state == QLatin1String("off") || state == QLatin1String("0"))
+                requestedOn = false;
+            else
+                return err(QStringLiteral("squelch state must be on|off"));
+            haveOn = true;
+        }
+        int requestedLevel = -1;
+        if (parts.size() > levelIdx) {
+            bool okL = false;
+            const int value = parts[levelIdx].toInt(&okL);
+            if (!okL || value < 0 || value > 100)
+                return err(QStringLiteral("squelch level must be an integer 0..100"));
+            requestedLevel = value;
+        }
+        if (levelOnly && requestedLevel < 0)
+            return err(QStringLiteral("slice squelchlevel requires '<0..100>'"));
+
+        SliceModel* s = nullptr;
+        for (SliceModel* candidate : radio->slices()) {
+            if (candidate->isActive()) { s = candidate; break; }
+        }
+        if (!s && !radio->slices().isEmpty())
+            s = radio->slices().first();
+        if (!s)
+            return err(QStringLiteral("no slice available to set squelch on"));
+
+        // Unspecified halves keep their current value, so `squelchlevel` never
+        // silently toggles the gate and `squelch on` never resets the level.
+        const bool on = haveOn ? requestedOn : s->squelchOn();
+        const int level = (requestedLevel >= 0) ? requestedLevel : s->squelchLevel();
+
+        // One setter carries both halves, so state and level always reach the
+        // backend as a coherent pair (same reasoning as the AGC arm above).
+        s->setSquelch(on, level);
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("slice"), action},
+                           {QStringLiteral("id"), s->sliceId()},
+                           {QStringLiteral("squelch"), s->squelchOn()},
+                           {QStringLiteral("squelchLevel"), s->squelchLevel()}};
+    }
+
+    if (action == QLatin1String("tone")) {
+        // "slice tone <off|ctcss_tx> [freq]" — a FlexRadio slice carries a single
+        // TX CTCSS tone, so the mode pair is off/ctcss_tx (see MemoryCsvCompat,
+        // which degrades CHIRP's richer taxonomy onto exactly these two).
+        const QStringList parts =
+            arg.trimmed().split(QRegularExpression(QStringLiteral("[\\s,]+")),
+                                Qt::SkipEmptyParts);
+        if (parts.isEmpty())
+            return err(QStringLiteral(
+                "slice tone requires '<off|ctcss_tx> [freq]'"));
+        const QString mode = parts[0].toLower();
+        static const QStringList kToneModes{QStringLiteral("off"),
+                                            QStringLiteral("ctcss_tx")};
+        if (!kToneModes.contains(mode))
+            return err(QStringLiteral("tone mode must be one of: ")
+                       + kToneModes.join(QLatin1Char('/')));
+        QString toneValue;
+        if (parts.size() >= 2) {
+            bool okF = false;
+            const double hz = parts[1].toDouble(&okF);
+            if (!okF || hz <= 0.0 || hz > 300.0)
+                return err(QStringLiteral(
+                    "tone freq must be a CTCSS frequency in Hz (0 < f <= 300)"));
+            toneValue = QString::number(hz, 'f', 1);
+        }
+
+        SliceModel* s = nullptr;
+        for (SliceModel* candidate : radio->slices()) {
+            if (candidate->isActive()) { s = candidate; break; }
+        }
+        if (!s && !radio->slices().isEmpty())
+            s = radio->slices().first();
+        if (!s)
+            return err(QStringLiteral("no slice available to set tone on"));
+
+        // Value before mode: enabling ctcss_tx while the old tone is still set
+        // would key the repeater on the wrong tone for one round trip.
+        if (!toneValue.isEmpty())
+            s->setFmToneValue(toneValue);
+        s->setFmToneMode(mode);
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("slice"), QStringLiteral("tone")},
+                           {QStringLiteral("id"), s->sliceId()},
+                           {QStringLiteral("fmToneMode"), s->fmToneMode()},
+                           {QStringLiteral("fmToneValue"), s->fmToneValue()}};
+    }
+
+    if (action == QLatin1String("offset")) {
+        // "slice offset <simplex|up|down> [mhz]" — repeater duplex. The offset
+        // magnitude is unsigned; the direction carries the sign.
+        const QStringList parts =
+            arg.trimmed().split(QRegularExpression(QStringLiteral("[\\s,]+")),
+                                Qt::SkipEmptyParts);
+        if (parts.isEmpty())
+            return err(QStringLiteral(
+                "slice offset requires '<simplex|up|down> [mhz]'"));
+        const QString dir = parts[0].toLower();
+        static const QStringList kDirs{QStringLiteral("simplex"),
+                                       QStringLiteral("up"),
+                                       QStringLiteral("down")};
+        if (!kDirs.contains(dir))
+            return err(QStringLiteral("offset direction must be one of: ")
+                       + kDirs.join(QLatin1Char('/')));
+        double offsetMhz = -1.0;
+        if (parts.size() >= 2) {
+            bool okM = false;
+            offsetMhz = std::abs(parts[1].toDouble(&okM));
+            if (!okM)
+                return err(QStringLiteral("offset must be a frequency in MHz"));
+        }
+
+        SliceModel* s = nullptr;
+        for (SliceModel* candidate : radio->slices()) {
+            if (candidate->isActive()) { s = candidate; break; }
+        }
+        if (!s && !radio->slices().isEmpty())
+            s = radio->slices().first();
+        if (!s)
+            return err(QStringLiteral("no slice available to set offset on"));
+
+        // Magnitude before direction, so a single request never leaves the radio
+        // briefly duplexing by a stale offset.
+        if (offsetMhz >= 0.0)
+            s->setFmRepeaterOffsetFreq(offsetMhz);
+        s->setRepeaterOffsetDir(dir);
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("slice"), QStringLiteral("offset")},
+                           {QStringLiteral("id"), s->sliceId()},
+                           {QStringLiteral("repeaterOffsetDir"), s->repeaterOffsetDir()},
+                           {QStringLiteral("fmRepeaterOffsetFreq"),
+                            s->fmRepeaterOffsetFreq()}};
+    }
+
     return err(QStringLiteral("unknown slice action: ") + action
-               + QStringLiteral(" (add|remove|select|tx|mode|diversity|centerlock|"
+               + QStringLiteral(" (add|remove|select|tx|mode|filter|agc|dsp|squelch|"
+                                "squelchlevel|tone|offset|diversity|centerlock|"
                                 "link|txant|rxant|rxsource|fixture|clearfixture)"));
 }
 
@@ -7843,6 +8019,48 @@ QJsonObject AutomationServer::doRadioCert(const QString& phaseArg, const QString
 // deterministic and focus-independent. KEYING is gated by the same
 // AETHER_AUTOMATION_ALLOW_TX rail as txtest/atu and arms the force-unkey
 // watchdog; UNKEY is always allowed (it only reduces TX risk).
+
+QJsonObject AutomationServer::doTransmit(const QString& action, const QString& arg)
+{
+    if (!m_radioModel)
+        return err(QStringLiteral("no radio model available"));
+    auto& tx = m_radioModel->transmitModel();
+    const QString a = action.trimmed().toLower();
+
+    if (a == QLatin1String("rfpower") || a == QLatin1String("tunepower")) {
+        // TX-gated for the same reason `key` is: these set how hard the radio
+        // will drive whatever is downstream of it — a transverter or an
+        // amplifier — so a session that may not transmit may not change them
+        // either. Reading them stays ungated via `get transmit`.
+        if (!m_txAllowed)
+            return err(QStringLiteral("blocked: transmit ") + a
+                       + QStringLiteral(" sets transmit drive — set "
+                                        "AETHER_AUTOMATION_ALLOW_TX=1 to allow"));
+        const QString v = arg.trimmed();
+        if (v.isEmpty())
+            return err(QStringLiteral("transmit ") + a
+                       + QStringLiteral(" requires a percentage 0..100"));
+        bool okP = false;
+        const int pct = v.toInt(&okP);
+        if (!okP || pct < 0 || pct > 100)
+            return err(QStringLiteral("transmit ") + a
+                       + QStringLiteral(" must be an integer 0..100"));
+
+        if (a == QLatin1String("rfpower"))
+            tx.setRfPower(pct);
+        else
+            tx.setTunePower(pct);
+
+        qCInfo(lcAutomation).noquote()
+            << "transmit" << a << pct << "(ALLOW_TX)";
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("transmit"), a},
+                           {QStringLiteral("rfPower"), tx.rfPower()},
+                           {QStringLiteral("tunePower"), tx.tunePower()}};
+    }
+
+    return err(QStringLiteral("transmit requires an action (rfpower|tunepower)"));
+}
 
 QJsonObject AutomationServer::doKey(const QString& name, const QString& arg)
 {

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -2703,6 +2703,25 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
             a.value = vtok(p, 2);
             return {};
         };
+        // Like parseActionValue, but REFUSES a trailing operand instead of
+        // dropping it. parseActionValue keeps p[2] and discards everything
+        // after, so `transmit rfpower 30 90` set the drive to 30 and answered
+        // ok — the tail vanished before any handler could object to it, which
+        // is why this has to be enforced in the parser and not downstream.
+        auto parseActionValueExact = [](const QList<QByteArray>& p,
+                                        A& a) -> QJsonObject {
+            if (p.size() > 3) {
+                return err(QString::fromUtf8(p.value(0))
+                           + QStringLiteral(" takes exactly one value; got ")
+                           + QString::number(p.size() - 2)
+                           + QStringLiteral(" ('")
+                           + QString::fromUtf8(p.value(3))
+                           + QStringLiteral("' is unexpected)"));
+            }
+            a.action = vtok(p, 1);
+            a.value = vtok(p, 2);
+            return {};
+        };
         auto parseActionRest = [](const QList<QByteArray>& p, A& a) -> QJsonObject {
             a.action = vtok(p, 1);
             a.value = vjoin(p, 2);
@@ -3378,7 +3397,7 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
 
         add("transmit", {},
             "transmit <rfpower|tunepower> <0..100> — transmit drive (TX-gated)",
-            parseActionValue,
+            parseActionValueExact,
             [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
                 if (a.action.isEmpty())
                     return err(QStringLiteral(
@@ -7134,6 +7153,10 @@ QJsonObject AutomationServer::doSlice(const QString& action, const QString& arg)
         if (parts.isEmpty())
             return err(QStringLiteral(
                 "slice tone requires '<off|ctcss_tx> [freq]'"));
+        if (parts.size() > 2)
+            return err(QStringLiteral(
+                "slice tone takes '<off|ctcss_tx> [freq]' and nothing more ('")
+                + parts[2] + QStringLiteral("' is unexpected)"));
         const QString mode = parts[0].toLower();
         static const QStringList kToneModes{QStringLiteral("off"),
                                             QStringLiteral("ctcss_tx")};
@@ -7185,6 +7208,10 @@ QJsonObject AutomationServer::doSlice(const QString& action, const QString& arg)
         if (parts.isEmpty())
             return err(QStringLiteral(
                 "slice offset requires '<simplex|up|down> [mhz]'"));
+        if (parts.size() > 2)
+            return err(QStringLiteral(
+                "slice offset takes '<simplex|up|down> [mhz]' and nothing more "
+                "('") + parts[2] + QStringLiteral("' is unexpected)"));
         const QString dir = parts[0].toLower();
         static const QStringList kDirs{QStringLiteral("simplex"),
                                        QStringLiteral("up"),

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -662,6 +662,7 @@ private:
     // and the mox_toggle shortcut make, but reachable headlessly. Keying is gated
     // by AETHER_AUTOMATION_ALLOW_TX (the same rail as txtest/atu); unkey is not.
     QJsonObject doKey(const QString& name, const QString& arg);
+    QJsonObject doTransmit(const QString& action, const QString& arg);
     QJsonObject doRadioCert(const QString& phaseArg, const QString& freqArg);
     // Drive the CWX keyer (send a CW string / set WPM / abort). `send` keys the
     // transmitter so it sits on the AETHER_AUTOMATION_ALLOW_TX rail and arms the

--- a/src/core/CtcssTones.h
+++ b/src/core/CtcssTones.h
@@ -1,0 +1,61 @@
+#pragma once
+
+// The CTCSS tone set, in one place.
+//
+// The operator's dropdown (RxApplet) and the automation bridge's `slice tone`
+// verb must agree about what a legal tone is: a bridge that accepts 123.4 Hz
+// can ask the radio for a tone no operator could ever dial in, and nothing
+// downstream says no.
+//
+// The set is the one #5140 landed on main for the Icom backend: the Motorola
+// PL tones plus the EIA interstitials. An interstitial has no PL code or
+// designation, so it carries code 0 and an empty designation, and callers
+// that render a label fall back to the bare frequency for those (see
+// RxApplet). Hoisting it here rather than keeping a per-widget copy is the
+// point of this file: main now offers 50 tones in two dropdowns, and the
+// bridge has to accept exactly those.
+
+#include <cmath>
+#include <cstddef>
+
+namespace AetherSDR {
+
+struct CtcssTone {
+    int code;
+    const char* designation;
+    double frequency;
+};
+
+inline constexpr CtcssTone kCtcssTones[] = {
+    { 1, "XZ", 67.0},  { 0, "", 69.3},    { 2, "XA", 71.9},  { 3, "WA", 74.4},
+    { 4, "XB", 77.0},
+    { 5, "WB", 79.7},  { 6, "YZ", 82.5},  { 7, "YA", 85.4},  { 8, "YB", 88.5},
+    { 9, "ZZ", 91.5},  {10, "ZA", 94.8},  {11, "ZB", 97.4},  {12, "1Z",100.0},
+    {13, "1A",103.5},  {14, "1B",107.2},  {15, "2Z",110.9},  {16, "2A",114.8},
+    {17, "2B",118.8},  {18, "3Z",123.0},  {19, "3A",127.3},  {20, "3B",131.8},
+    {21, "4Z",136.5},  {22, "4A",141.3},  {23, "4B",146.2},  {24, "5Z",151.4},
+    {25, "5A",156.7},  { 0, "",159.8},    {26, "5B",162.2},  { 0, "",165.5},
+    {27, "6Z",167.9},  { 0, "",171.3},    {28, "6A",173.8},  { 0, "",177.3},
+    {29, "6B",179.9},  { 0, "",183.5},    {30, "7Z",186.2},  { 0, "",189.9},
+    {31, "7A",192.8},  { 0, "",196.6},    { 0, "",199.5},    {32, "M1",203.5},
+    {33, "8Z",206.5},  {34, "M2",210.7},  {35, "M3",218.1},  {36, "M4",225.7},
+    {37, "9Z",229.1},  {38, "M5",233.6},  {39, "M6",241.8},  {40, "M7",250.3},
+    {41, "0Z",254.1},
+};
+
+inline constexpr std::size_t kCtcssToneCount =
+    sizeof(kCtcssTones) / sizeof(kCtcssTones[0]);
+
+// Tones are quoted to one decimal everywhere (the slice carries "100.0"), so
+// the comparison is to that precision rather than exact — a caller typing
+// 100.00 means the same tone as one typing 100.0.
+inline bool isCtcssFrequency(double hz)
+{
+    for (const CtcssTone& t : kCtcssTones) {
+        if (std::fabs(t.frequency - hz) < 0.05)
+            return true;
+    }
+    return false;
+}
+
+} // namespace AetherSDR

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -1,4 +1,5 @@
 #include "RxApplet.h"
+#include "core/CtcssTones.h"
 
 #include "gui/FilterStepMath.h"
 #include "FilterPassbandWidget.h"
@@ -281,29 +282,13 @@ static const ModeSettings& modeSettingsFor(const QString& mode)
 
 // ── Standard CTCSS tone table (EIA/TIA-603) ──────────────────────────────────
 
-struct CTCSSTone {
-    int code;
-    const char* designation;
-    double frequency;
-};
-
-static constexpr CTCSSTone CTCSS_TONES[] = {
-    { 1, "XZ", 67.0},  { 0, "", 69.3},    { 2, "XA", 71.9},  { 3, "WA", 74.4},
-    { 4, "XB", 77.0},
-    { 5, "WB", 79.7},  { 6, "YZ", 82.5},  { 7, "YA", 85.4},  { 8, "YB", 88.5},
-    { 9, "ZZ", 91.5},  {10, "ZA", 94.8},  {11, "ZB", 97.4},  {12, "1Z",100.0},
-    {13, "1A",103.5},  {14, "1B",107.2},  {15, "2Z",110.9},  {16, "2A",114.8},
-    {17, "2B",118.8},  {18, "3Z",123.0},  {19, "3A",127.3},  {20, "3B",131.8},
-    {21, "4Z",136.5},  {22, "4A",141.3},  {23, "4B",146.2},  {24, "5Z",151.4},
-    {25, "5A",156.7},  { 0, "",159.8},    {26, "5B",162.2},  { 0, "",165.5},
-    {27, "6Z",167.9},  { 0, "",171.3},    {28, "6A",173.8},  { 0, "",177.3},
-    {29, "6B",179.9},  { 0, "",183.5},    {30, "7Z",186.2},  { 0, "",189.9},
-    {31, "7A",192.8},  { 0, "",196.6},    { 0, "",199.5},    {32, "M1",203.5},
-    {33, "8Z",206.5},  {34, "M2",210.7},  {35, "M3",218.1},  {36, "M4",225.7},
-    {37, "9Z",229.1},  {38, "M5",233.6},  {39, "M6",241.8},  {40, "M7",250.3},
-    {41, "0Z",254.1},
-};
-static constexpr int CTCSS_COUNT = sizeof(CTCSS_TONES) / sizeof(CTCSS_TONES[0]);
+// The tone table moved to core/CtcssTones.h so the automation bridge's
+// `slice tone` verb validates against the same set this dropdown offers
+// (#5102). Aliased rather than renamed at every use site.
+using CTCSSTone = AetherSDR::CtcssTone;
+static constexpr auto& CTCSS_TONES = AetherSDR::kCtcssTones;
+static constexpr int CTCSS_COUNT =
+    static_cast<int>(AetherSDR::kCtcssToneCount);
 
 // Small checkable button used throughout the applet.
 static QPushButton* mkToggle(const QString& text, QWidget* parent = nullptr)
@@ -3080,13 +3065,8 @@ void RxApplet::applyOffsetDir(const QString& dir)
     m_slice->setRepeaterOffsetDir(dir);
 
     // Compute and apply tx_offset_freq
-    const double offset = m_slice->fmRepeaterOffsetFreq();
-    if (dir == "up")
-        m_slice->setTxOffsetFreq(offset);
-    else if (dir == "down")
-        m_slice->setTxOffsetFreq(-offset);
-    else
-        m_slice->setTxOffsetFreq(0.0);
+    m_slice->setTxOffsetFreq(SliceModel::txOffsetForDirection(
+        dir, m_slice->fmRepeaterOffsetFreq()));
 
     // Clear REV when direction changes
     if (!usesTransmitFrequencyCheck()) {

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -2369,10 +2369,8 @@ void VfoWidget::buildTabContent()
                 if (m_fmOffsetSpin->signalsBlocked()) return;
                 if (!m_slice) return;
                 m_slice->setFmRepeaterOffsetFreq(val);
-                const QString& dir = m_slice->repeaterOffsetDir();
-                if (dir == "up") m_slice->setTxOffsetFreq(val);
-                else if (dir == "down") m_slice->setTxOffsetFreq(-val);
-                else m_slice->setTxOffsetFreq(0);
+                m_slice->setTxOffsetFreq(SliceModel::txOffsetForDirection(
+                    m_slice->repeaterOffsetDir(), val));
             });
 
             // Direction: − | Simplex | + | REV
@@ -2382,10 +2380,8 @@ void VfoWidget::buildTabContent()
             auto applyDir = [this](const QString& dir) {
                 if (!m_slice) return;
                 m_slice->setRepeaterOffsetDir(dir);
-                double offset = m_slice->fmRepeaterOffsetFreq();
-                if (dir == "up") m_slice->setTxOffsetFreq(offset);
-                else if (dir == "down") m_slice->setTxOffsetFreq(-offset);
-                else m_slice->setTxOffsetFreq(0);
+                m_slice->setTxOffsetFreq(SliceModel::txOffsetForDirection(
+                    dir, m_slice->fmRepeaterOffsetFreq()));
                 m_fmOffsetDown->setChecked(dir == "down");
                 m_fmSimplexBtn->setChecked(dir == "simplex");
                 m_fmOffsetUp->setChecked(dir == "up");

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1,4 +1,5 @@
 #include "VfoWidget.h"
+#include "core/CtcssTones.h"
 #include "PhaseKnob.h"
 #include "VoiceModeGate.h"   // isCwMode() — one CW-mode list, not thirteen
 #include "SmartMtrWidget.h"
@@ -2317,17 +2318,16 @@ void VfoWidget::buildTabContent()
             AetherSDR::applyComboStyle(m_fmToneModeCmb);
             toneRow->addWidget(m_fmToneModeCmb, 1);
 
-            // Tone value — simplified list of common CTCSS tones
+            // Tone value — from core/CtcssTones.h, the same table the RX
+            // applet's dropdown and the automation bridge's `slice tone`
+            // validation use. This list used to be a third hand-typed copy of
+            // the same 41 doubles; the values agreed, which is exactly how a
+            // copy survives long enough to stop agreeing.
             m_fmToneValueCmb = new GuardedComboBox;
             m_fmToneValueCmb->setAccessibleName("FM tone frequency");
-            const double tones[] = {67.0,69.3,71.9,74.4,77.0,79.7,82.5,85.4,88.5,91.5,94.8,
-                97.4,100.0,103.5,107.2,110.9,114.8,118.8,123.0,127.3,131.8,
-                136.5,141.3,146.2,151.4,156.7,159.8,162.2,165.5,167.9,171.3,
-                173.8,177.3,179.9,183.5,186.2,189.9,192.8,196.6,199.5,203.5,
-                206.5,210.7,218.1,225.7,229.1,233.6,241.8,250.3,254.1};
-            for (double f : tones)
-                m_fmToneValueCmb->addItem(QString::number(f, 'f', 1),
-                                           QString::number(f, 'f', 1));
+            for (const AetherSDR::CtcssTone& t : AetherSDR::kCtcssTones)
+                m_fmToneValueCmb->addItem(QString::number(t.frequency, 'f', 1),
+                                           QString::number(t.frequency, 'f', 1));
             AetherSDR::applyComboStyle(m_fmToneValueCmb);
             m_fmToneValueCmb->setEnabled(false);
             toneRow->addWidget(m_fmToneValueCmb, 1);

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -3,6 +3,8 @@
 #include "core/KiwiSdrProtocol.h"
 #include <QDebug>
 
+#include <cmath>
+
 namespace AetherSDR {
 
 // Note: antenna-list splitting now lives in FlexBackend::decodeSliceStatus
@@ -824,6 +826,14 @@ void SliceModel::applyRecalledFmRepeater(const QString& direction, double offset
     }
     emit fmRepeaterRecallCommandIssued(direction, offsetMhz * 1.0e6,
                                        toneMode, toneHz);
+}
+
+double SliceModel::txOffsetForDirection(const QString& dir, double magnitudeMhz)
+{
+    const double magnitude = std::abs(magnitudeMhz);
+    if (dir == QLatin1String("up"))   return  magnitude;
+    if (dir == QLatin1String("down")) return -magnitude;
+    return 0.0;   // simplex, and anything not a duplex direction
 }
 
 void SliceModel::setTxOffsetFreq(double mhz)

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -304,6 +304,12 @@ public:
     void applyRecalledFmRepeater(const QString& direction, double offsetMhz,
                                  const QString& toneMode, double toneHz);
     void setTxOffsetFreq(double mhz);
+    // The signed TX offset a repeater direction + unsigned magnitude imply.
+    // Direction and magnitude each send only their own key, so tx_offset_freq
+    // — the field that actually moves the transmitter — has to be written
+    // alongside them; every caller that sets duplex must send all three.
+    // One copy, because three hand-rolled ones is how this drifted (#5102).
+    static double txOffsetForDirection(const QString& dir, double magnitudeMhz);
     void setFmDeviation(int hz);
 
     // Apply a normalized, typed slice delta from the backend

--- a/tests/automation_fm_repeater_verbs_test.cpp
+++ b/tests/automation_fm_repeater_verbs_test.cpp
@@ -242,6 +242,15 @@ int main(int argc, char** argv)
     rejectedAtBoundary(socket, "offset magnitude 101 MHz is refused",
                        QByteArrayLiteral("slice offset up 101"),
                        QStringLiteral("0..100"));
+    rejectedAtBoundary(socket, "a negative offset magnitude is refused",
+                       QByteArrayLiteral("slice offset down -5"),
+                       QStringLiteral("0..100"));
+    rejectedAtBoundary(socket, "a NaN offset magnitude is refused",
+                       QByteArrayLiteral("slice offset up nan"),
+                       QStringLiteral("frequency"));
+    rejectedAtBoundary(socket, "an infinite offset magnitude is refused",
+                       QByteArrayLiteral("slice offset up inf"),
+                       QStringLiteral("frequency"));
 
     // ── transmit: gated, then clamped ────────────────────────────────────
     {

--- a/tests/automation_fm_repeater_verbs_test.cpp
+++ b/tests/automation_fm_repeater_verbs_test.cpp
@@ -16,8 +16,12 @@
 // reports its own error. If validation drifts back behind slice resolution the
 // two collapse into one message and these rows fail.
 //
-// Apply paths are proven against a live FLEX-6500 and a real repeater; see the
-// PR. They are deliberately not faked here.
+// The APPLY path is asserted too, at the end, through the repo's own
+// `slice fixture` action — a disconnected-only synthetic slice. That is what
+// catches a verb that accepts a request, answers ok, and writes only two of
+// the three fields a duplex split needs. A live FLEX-6500 exercised the same
+// path against a real repeater; the fixture rows are what keep it honest in
+// CI, where there is no radio.
 
 #include "core/AudioEngine.h"
 #include "core/QsoRecorder.h"
@@ -162,6 +166,31 @@ int main(int argc, char** argv)
                unknown.contains(QStringLiteral("tone"))
                    && unknown.contains(QStringLiteral("offset")),
                unknown);
+
+        // ...and every advertised action actually DISPATCHES. The rows above
+        // pin the two messages to each other, which can only catch someone
+        // re-hardcoding one of them. The defect class in #5102 was
+        // list ≠ dispatch: an action can be advertised and still fall through
+        // to "unknown slice action". So drive each one and assert it does not.
+        // Each is sent bare, so most are refused for their own reasons (a
+        // missing argument, no slice, no radio) — any of those proves the
+        // action was routed. Only falling through to the unknown-action arm
+        // fails this row.
+        QStringList notDispatched;
+        const QStringList advertised =
+            unknown.section(QLatin1Char('('), 1).section(QLatin1Char(')'), 0, 0)
+                .split(QLatin1Char('|'), Qt::SkipEmptyParts);
+        for (const QString& act : advertised) {
+            const QString e = errorOf(
+                request(socket, ("slice " + act).toUtf8()));
+            if (e.contains(QStringLiteral("unknown slice action")))
+                notDispatched << act;
+        }
+        report("every advertised slice action dispatches",
+               !advertised.isEmpty() && notDispatched.isEmpty(),
+               notDispatched.isEmpty()
+                   ? QStringLiteral("%1 actions driven").arg(advertised.size())
+                   : QStringLiteral("no handler: ") + notDispatched.join(QLatin1Char(' ')));
     }
 
     // ── the pre-existing squelch route still works ───────────────────────
@@ -191,6 +220,16 @@ int main(int argc, char** argv)
                        QByteArrayLiteral("slice tone ctcss_tx 9999"), QStringLiteral("CTCSS"));
     rejectedAtBoundary(socket, "tone freq 0 is refused",
                        QByteArrayLiteral("slice tone ctcss_tx 0"), QStringLiteral("CTCSS"));
+    // 123.4 sits inside the old 0 < f <= 300 bound and is NOT a CTCSS tone.
+    // The verb now validates against core/CtcssTones.h — the same table the
+    // operator's dropdown is built from — so the bridge cannot ask the radio
+    // for a tone nobody could dial in.
+    rejectedAtBoundary(socket, "a non-CTCSS tone inside the old range is refused",
+                       QByteArrayLiteral("slice tone ctcss_tx 123.4"),
+                       QStringLiteral("CTCSS"));
+    rejectedAtBoundary(socket, "67.1 Hz — one tick off a real tone — is refused",
+                       QByteArrayLiteral("slice tone ctcss_tx 67.1"),
+                       QStringLiteral("CTCSS"));
 
     // ── offset ───────────────────────────────────────────────────────────
     rejectedAtBoundary(socket, "offset with no argument is refused",
@@ -200,6 +239,9 @@ int main(int argc, char** argv)
                        QStringLiteral("simplex/up/down"));
     rejectedAtBoundary(socket, "offset magnitude 'far' is refused",
                        QByteArrayLiteral("slice offset up far"), QStringLiteral("MHz"));
+    rejectedAtBoundary(socket, "offset magnitude 101 MHz is refused",
+                       QByteArrayLiteral("slice offset up 101"),
+                       QStringLiteral("0..100"));
 
     // ── transmit: gated, then clamped ────────────────────────────────────
     {
@@ -263,6 +305,98 @@ int main(int argc, char** argv)
     }
     rejectedAtBoundary(socket, "rfpower 101 is refused even with TX allowed",
                        QByteArrayLiteral("transmit rfpower 101"), QStringLiteral("0..100"));
+
+    // ── the applied duplex, through the repo's own disconnected fixture ──
+    //
+    // `slice fixture` synthesizes an owned slice through the normal
+    // slice-status path with no radio attached, which is what lets these rows
+    // assert the APPLY path and not merely the boundary.
+    //
+    // The bug these exist for: the verb set repeater_offset_dir and
+    // fm_repeater_offset_freq and stopped there. tx_offset_freq is a field the
+    // radio carries in its own right — FlexBackend decodes it as its own value,
+    // and every other writer of duplex in the tree (RxApplet::applyOffsetDir,
+    // VfoWidget's spin + applyDir, MemoryRecallPolicy's slice fixup) sends all
+    // three. Sending two of three records "down, 5 MHz" on a slice that still
+    // transmits on the receive frequency, and no reply field said so.
+    {
+        const QJsonObject fx = request(socket, QByteArrayLiteral("slice fixture 0"));
+        report("disconnected slice fixture is available",
+               fx.value(QStringLiteral("ok")).toBool(), errorOf(fx));
+    }
+    QCoreApplication::processEvents();
+
+    auto offsetApplies = [&socket](const char* name, const QByteArray& line,
+                                   double wantTx, const QString& wantDir,
+                                   double wantMagnitude) {
+        const QJsonObject r = request(socket, line);
+        const double tx = r.value(QStringLiteral("txOffsetFreq")).toDouble();
+        const QString dir = r.value(QStringLiteral("repeaterOffsetDir")).toString();
+        const double mag =
+            r.value(QStringLiteral("fmRepeaterOffsetFreq")).toDouble();
+        report(name,
+               r.value(QStringLiteral("ok")).toBool()
+                   && qFuzzyCompare(tx + 1.0, wantTx + 1.0)
+                   && dir == wantDir
+                   && qFuzzyCompare(mag + 1.0, wantMagnitude + 1.0),
+               QString::fromUtf8(
+                   QJsonDocument(r).toJson(QJsonDocument::Compact)));
+    };
+
+    offsetApplies("down 5 MHz applies tx_offset_freq -5 (the TX split)",
+                  QByteArrayLiteral("slice offset down 5"), -5.0,
+                  QStringLiteral("down"), 5.0);
+    offsetApplies("up 5 MHz applies +5 — the direction carries the sign",
+                  QByteArrayLiteral("slice offset up 5"), 5.0,
+                  QStringLiteral("up"), 5.0);
+    offsetApplies("simplex zeroes the TX offset",
+                  QByteArrayLiteral("slice offset simplex"), 0.0,
+                  QStringLiteral("simplex"), 5.0);
+    // A magnitude change with the direction UNCHANGED. setRepeaterOffsetDir()
+    // early-returns when the value has not moved, so a recompute conditioned on
+    // the direction changing would leave the old split in place here.
+    offsetApplies("down 5 MHz, from simplex",
+                  QByteArrayLiteral("slice offset down 5"), -5.0,
+                  QStringLiteral("down"), 5.0);
+    offsetApplies("a magnitude-only change recomputes the split",
+                  QByteArrayLiteral("slice offset down 0.6"), -0.6,
+                  QStringLiteral("down"), 0.6);
+
+    {
+        // ...and the number is readable, so a session can assert the duplex it
+        // applied rather than assume the request took.
+        const QJsonObject r = request(socket, QByteArrayLiteral("get slice active"));
+        const QJsonObject snap =
+            r.value(QStringLiteral("slice")).isObject()
+                ? r.value(QStringLiteral("slice")).toObject()
+                : r;
+        report("the slice snapshot carries txOffsetFreq",
+               snap.contains(QStringLiteral("txOffsetFreq"))
+                   && qFuzzyCompare(
+                       snap.value(QStringLiteral("txOffsetFreq")).toDouble() + 1.0,
+                       -0.6 + 1.0),
+               QString::fromUtf8(QJsonDocument(r).toJson(QJsonDocument::Compact)));
+    }
+
+    {
+        // A legal tone applies, to the same fixture slice, and 123.0 is a real
+        // table entry while the neighbouring 123.4 above is not.
+        const QJsonObject r =
+            request(socket, QByteArrayLiteral("slice tone ctcss_tx 123.0"));
+        report("a standard CTCSS tone applies",
+               r.value(QStringLiteral("ok")).toBool()
+                   && r.value(QStringLiteral("fmToneMode")).toString()
+                          == QLatin1String("ctcss_tx")
+                   && r.value(QStringLiteral("fmToneValue")).toString()
+                          == QLatin1String("123.0"),
+               QString::fromUtf8(QJsonDocument(r).toJson(QJsonDocument::Compact)));
+    }
+
+    {
+        const QJsonObject r = request(socket, QByteArrayLiteral("slice clearfixture 0"));
+        report("slice fixture is removed again",
+               r.value(QStringLiteral("ok")).toBool(), errorOf(r));
+    }
 
     socket.disconnectFromServer();
     server.stop();

--- a/tests/automation_fm_repeater_verbs_test.cpp
+++ b/tests/automation_fm_repeater_verbs_test.cpp
@@ -1,21 +1,23 @@
-// FM repeater verbs: slice squelch / squelchlevel / tone / offset, and
-// transmit rfpower / tunepower (#5102).
+// FM repeater verbs: slice tone / slice offset, transmit rfpower / tunepower,
+// and the single shared slice-action list (#5102).
 //
-// The bridge could not operate an FM repeater at all: it could not hear one
-// (no squelch control), open one (no CTCSS), transmit to one (no offset), or
-// set its drive. Every setter already existed on SliceModel/TransmitModel —
-// only the bridge could not reach them.
+// #5102 was filed reporting squelch as unreachable from the bridge. It was not:
+// `slice dsp squelch <on|off> [level]` had implemented it all along. The report
+// happened because two hand-maintained copies of the slice-action list had
+// drifted, and the one a caller actually hits — `unknown slice action:` — omitted
+// filter, agc and dsp. So the list is now derived from one function, and the row
+// below that pins both messages to it is the regression guard that matters most
+// here: it is the defect that manufactured a false bug report.
 //
-// What this file pins is the BOUNDARY behaviour, which is what a radio-less
-// CI run can actually assert: a malformed request must be refused by the verb
-// itself, BEFORE any slice is resolved (Principle VII). The distinction is
-// visible precisely because this fixture has a RadioModel with no slices —
-// a well-formed request gets "no slice available", a malformed one gets its
-// own validation error. If validation ever drifts back behind slice
-// resolution, the two collapse into the same message and these rows fail.
+// What this file pins is BOUNDARY behaviour, which is what a radio-less CI run
+// can assert. Validation must happen before any slice is resolved (Principle
+// VII), and the fixture makes that observable by carrying a RadioModel with NO
+// slices: a well-formed request reports "no slice available", a malformed one
+// reports its own error. If validation drifts back behind slice resolution the
+// two collapse into one message and these rows fail.
 //
-// The apply paths are proven against a live FLEX-6500 and a real repeater;
-// see the PR. They are deliberately not faked here.
+// Apply paths are proven against a live FLEX-6500 and a real repeater; see the
+// PR. They are deliberately not faked here.
 
 #include "core/AudioEngine.h"
 #include "core/QsoRecorder.h"
@@ -42,7 +44,7 @@ int g_failed = 0;
 
 void report(const char* name, bool ok, const QString& detail = QString())
 {
-    std::printf("%s %-56s %s\n", ok ? "[ OK ]" : "[FAIL]", name, qPrintable(detail));
+    std::printf("%s %-58s %s\n", ok ? "[ OK ]" : "[FAIL]", name, qPrintable(detail));
     if (!ok)
         ++g_failed;
 }
@@ -77,15 +79,16 @@ QString errorOf(const QJsonObject& o)
 }
 
 // A rejection that came from the VERB, not from the radio layer behind it.
-void reportRejectedAtBoundary(QLocalSocket& socket, const char* name,
-                              const QByteArray& line, const QString& expectFragment)
+void rejectedAtBoundary(QLocalSocket& socket, const char* name,
+                        const QByteArray& line, const QString& expectFragment)
 {
     const QJsonObject r = request(socket, line);
     const QString e = errorOf(r);
-    const bool refused = (r.value(QStringLiteral("ok")).toBool() == false);
-    const bool ownError = e.contains(expectFragment, Qt::CaseInsensitive);
-    const bool notRadioError = !e.contains(QStringLiteral("no slice available"));
-    report(name, refused && ownError && notRadioError, e.isEmpty() ? QStringLiteral("(no error field)") : e);
+    report(name,
+           r.value(QStringLiteral("ok")).toBool() == false
+               && e.contains(expectFragment, Qt::CaseInsensitive)
+               && !e.contains(QStringLiteral("no slice available")),
+           e.isEmpty() ? QStringLiteral("(no error field)") : e);
 }
 
 } // namespace
@@ -103,12 +106,15 @@ int main(int argc, char** argv)
     qputenv("TMPDIR", root);
     if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM"))
         qputenv("QT_QPA_PLATFORM", "offscreen");
-    // Left deliberately unset: the transmit rows below assert the TX gate.
+    // Unset: the gate rows below assert TX is refused by default.
     qunsetenv("AETHER_AUTOMATION_ALLOW_TX");
+    // start() reads the ceiling unconditionally, so it is in force the moment
+    // TX is later permitted at runtime.
+    qputenv("AETHER_AUTOMATION_TX_MAX_POWER", "30");
 
     QGuiApplication app(argc, argv);
 
-    RadioModel radio;   // no slices — see the header comment
+    RadioModel radio;   // deliberately no slices — see the header comment
     AutomationServer server;
     server.setRadioModel(&radio);
 
@@ -129,7 +135,73 @@ int main(int argc, char** argv)
     }
     QCoreApplication::processEvents();
 
-    // ── the verbs exist at all ───────────────────────────────────────────
+    // ── the one shared action list ───────────────────────────────────────
+    // THE row this file exists for. Two hand-maintained copies drifted and the
+    // divergence caused a false bug report; both messages must now name the
+    // same set.
+    {
+        const QString empty = errorOf(request(socket, QByteArrayLiteral("slice")));
+        const QString unknown =
+            errorOf(request(socket, QByteArrayLiteral("slice bogusaction")));
+        bool sameSet = true;
+        for (const char* a : {"add", "remove", "select", "tx", "mode", "filter", "agc",
+                              "dsp", "tone", "offset", "diversity", "centerlock",
+                              "link", "txant", "rxant", "rxsource", "fixture",
+                              "clearfixture"}) {
+            const QString act = QString::fromLatin1(a);
+            if (empty.contains(act) != unknown.contains(act))
+                sameSet = false;
+        }
+        report("both slice error messages name the same action set", sameSet);
+        report("the previously-omitted actions are advertised",
+               unknown.contains(QStringLiteral("filter"))
+                   && unknown.contains(QStringLiteral("agc"))
+                   && unknown.contains(QStringLiteral("dsp")),
+               unknown);
+        report("the new actions are advertised",
+               unknown.contains(QStringLiteral("tone"))
+                   && unknown.contains(QStringLiteral("offset")),
+               unknown);
+    }
+
+    // ── the pre-existing squelch route still works ───────────────────────
+    // #5102 reported squelch as missing; `slice dsp squelch` already did it.
+    // Nothing here may break that path — reaching the radio layer is the proof
+    // the action is still routed.
+    {
+        const QJsonObject r = request(socket, QByteArrayLiteral("slice dsp squelch off"));
+        report("slice dsp squelch still routes (the pre-existing path)",
+               errorOf(r).contains(QStringLiteral("no slice available")), errorOf(r));
+    }
+
+    // ── control row: a WELL-FORMED request reaches the radio layer ───────
+    // Everything below is only meaningful against this.
+    {
+        const QJsonObject r = request(socket, QByteArrayLiteral("slice tone ctcss_tx 100.0"));
+        report("well-formed tone reaches the radio layer",
+               errorOf(r).contains(QStringLiteral("no slice available")), errorOf(r));
+    }
+
+    // ── tone ─────────────────────────────────────────────────────────────
+    rejectedAtBoundary(socket, "tone with no argument is refused",
+                       QByteArrayLiteral("slice tone"), QStringLiteral("requires"));
+    rejectedAtBoundary(socket, "tone mode 'dcs' is refused",
+                       QByteArrayLiteral("slice tone dcs"), QStringLiteral("off/ctcss_tx"));
+    rejectedAtBoundary(socket, "tone freq 9999 is refused",
+                       QByteArrayLiteral("slice tone ctcss_tx 9999"), QStringLiteral("CTCSS"));
+    rejectedAtBoundary(socket, "tone freq 0 is refused",
+                       QByteArrayLiteral("slice tone ctcss_tx 0"), QStringLiteral("CTCSS"));
+
+    // ── offset ───────────────────────────────────────────────────────────
+    rejectedAtBoundary(socket, "offset with no argument is refused",
+                       QByteArrayLiteral("slice offset"), QStringLiteral("requires"));
+    rejectedAtBoundary(socket, "offset direction 'sideways' is refused",
+                       QByteArrayLiteral("slice offset sideways"),
+                       QStringLiteral("simplex/up/down"));
+    rejectedAtBoundary(socket, "offset magnitude 'far' is refused",
+                       QByteArrayLiteral("slice offset up far"), QStringLiteral("MHz"));
+
+    // ── transmit: gated, then clamped ────────────────────────────────────
     {
         const QJsonObject verbs = request(socket, QByteArrayLiteral("verbs"));
         bool hasTransmit = false;
@@ -139,51 +211,6 @@ int main(int argc, char** argv)
                 hasTransmit = true;
         report("transmit verb is registered", hasTransmit);
     }
-
-    // ── the control row: a WELL-FORMED request reaches the radio layer ───
-    // Everything below is only meaningful against this. If this row ever
-    // reports a validation error instead, the fixture has changed and the
-    // boundary rows below are no longer proving what they claim.
-    {
-        const QJsonObject r = request(socket, QByteArrayLiteral("slice squelch on 30"));
-        report("well-formed squelch reaches the radio layer",
-               errorOf(r).contains(QStringLiteral("no slice available")), errorOf(r));
-    }
-
-    // ── squelch: refused at the boundary ─────────────────────────────────
-    reportRejectedAtBoundary(socket, "squelch with no argument is refused",
-                             QByteArrayLiteral("slice squelch"), QStringLiteral("requires"));
-    reportRejectedAtBoundary(socket, "squelch state 'maybe' is refused",
-                             QByteArrayLiteral("slice squelch maybe"), QStringLiteral("on|off"));
-    reportRejectedAtBoundary(socket, "squelch level 101 is refused",
-                             QByteArrayLiteral("slice squelch on 101"), QStringLiteral("0..100"));
-    reportRejectedAtBoundary(socket, "squelch level -1 is refused",
-                             QByteArrayLiteral("slice squelch on -1"), QStringLiteral("0..100"));
-    reportRejectedAtBoundary(socket, "squelchlevel with no argument is refused",
-                             QByteArrayLiteral("slice squelchlevel"), QStringLiteral("requires"));
-    reportRejectedAtBoundary(socket, "squelchlevel 'loud' is refused",
-                             QByteArrayLiteral("slice squelchlevel loud"), QStringLiteral("0..100"));
-
-    // ── tone ─────────────────────────────────────────────────────────────
-    reportRejectedAtBoundary(socket, "tone with no argument is refused",
-                             QByteArrayLiteral("slice tone"), QStringLiteral("requires"));
-    reportRejectedAtBoundary(socket, "tone mode 'dcs' is refused",
-                             QByteArrayLiteral("slice tone dcs"), QStringLiteral("off/ctcss_tx"));
-    reportRejectedAtBoundary(socket, "tone freq 9999 is refused",
-                             QByteArrayLiteral("slice tone ctcss_tx 9999"), QStringLiteral("CTCSS"));
-    reportRejectedAtBoundary(socket, "tone freq 0 is refused",
-                             QByteArrayLiteral("slice tone ctcss_tx 0"), QStringLiteral("CTCSS"));
-
-    // ── offset ───────────────────────────────────────────────────────────
-    reportRejectedAtBoundary(socket, "offset with no argument is refused",
-                             QByteArrayLiteral("slice offset"), QStringLiteral("requires"));
-    reportRejectedAtBoundary(socket, "offset direction 'sideways' is refused",
-                             QByteArrayLiteral("slice offset sideways"),
-                             QStringLiteral("simplex/up/down"));
-    reportRejectedAtBoundary(socket, "offset magnitude 'far' is refused",
-                             QByteArrayLiteral("slice offset up far"), QStringLiteral("MHz"));
-
-    // ── transmit: TX-gated, and gated BEFORE the value is even parsed ────
     {
         const QJsonObject r = request(socket, QByteArrayLiteral("transmit rfpower 40"));
         report("transmit rfpower is blocked without ALLOW_TX",
@@ -192,33 +219,50 @@ int main(int argc, char** argv)
                errorOf(r));
     }
     {
-        // Principle VI: the gate must not be bypassable by sending nonsense —
-        // an out-of-range value on a TX-gated verb still reports the gate.
+        // Principle VI: the gate must not be probeable with nonsense.
         const QJsonObject r = request(socket, QByteArrayLiteral("transmit rfpower 9999"));
         report("gate reports before value validation on a TX verb",
                errorOf(r).contains(QStringLiteral("ALLOW_TX")), errorOf(r));
     }
-    reportRejectedAtBoundary(socket, "unknown transmit action is refused",
-                             QByteArrayLiteral("transmit wattage 5"),
-                             QStringLiteral("rfpower|tunepower"));
-    reportRejectedAtBoundary(socket, "transmit with no action is refused",
-                             QByteArrayLiteral("transmit"), QStringLiteral("requires an action"));
+    rejectedAtBoundary(socket, "unknown transmit action is refused",
+                       QByteArrayLiteral("transmit wattage 5"),
+                       QStringLiteral("rfpower|tunepower"));
+    rejectedAtBoundary(socket, "transmit with no action is refused",
+                       QByteArrayLiteral("transmit"), QStringLiteral("requires an action"));
 
-    // ── the action list a caller is told about must be true ──────────────
+    // Now permit TX and prove the ceiling still binds. The invoke() power rail
+    // is widget-scoped (it keys off accessibleName in the setValue path), so a
+    // verb reaching the model directly does NOT inherit it — this row is the
+    // reason the clamp is written out explicitly in doTransmit().
+    server.setTxAllowed(true);
+    QCoreApplication::processEvents();
     {
-        const QJsonObject r = request(socket, QByteArrayLiteral("slice bogusaction"));
-        const QString e = errorOf(r);
-        report("slice error lists the new actions",
-               e.contains(QStringLiteral("squelch")) && e.contains(QStringLiteral("tone"))
-                   && e.contains(QStringLiteral("offset")),
-               e);
-        // These three worked long before this change and were missing from the
-        // list, which is how a caller concludes a working action does not exist.
-        report("slice error lists the previously-omitted actions",
-               e.contains(QStringLiteral("filter")) && e.contains(QStringLiteral("agc"))
-                   && e.contains(QStringLiteral("dsp")),
-               e);
+        const QJsonObject r = request(socket, QByteArrayLiteral("transmit rfpower 90"));
+        report("transmit rfpower is accepted once TX is allowed",
+               r.value(QStringLiteral("ok")).toBool(), errorOf(r));
+        report("transmit rfpower is clamped to AETHER_AUTOMATION_TX_MAX_POWER",
+               r.value(QStringLiteral("clampedTo")).toInt() == 30
+                   && r.value(QStringLiteral("requested")).toInt() == 90,
+               QString::fromUtf8(QJsonDocument(r).toJson(QJsonDocument::Compact)));
+        report("the clamp is reported, not silent",
+               r.contains(QStringLiteral("requested"))
+                   && r.contains(QStringLiteral("clampedTo")));
     }
+    {
+        const QJsonObject r = request(socket, QByteArrayLiteral("transmit tunepower 90"));
+        report("tunepower is clamped by the same ceiling",
+               r.value(QStringLiteral("clampedTo")).toInt() == 30,
+               QString::fromUtf8(QJsonDocument(r).toJson(QJsonDocument::Compact)));
+    }
+    {
+        const QJsonObject r = request(socket, QByteArrayLiteral("transmit rfpower 10"));
+        report("a request under the ceiling is not annotated",
+               r.value(QStringLiteral("ok")).toBool()
+                   && !r.contains(QStringLiteral("clampedTo")),
+               QString::fromUtf8(QJsonDocument(r).toJson(QJsonDocument::Compact)));
+    }
+    rejectedAtBoundary(socket, "rfpower 101 is refused even with TX allowed",
+                       QByteArrayLiteral("transmit rfpower 101"), QStringLiteral("0..100"));
 
     socket.disconnectFromServer();
     server.stop();

--- a/tests/automation_fm_repeater_verbs_test.cpp
+++ b/tests/automation_fm_repeater_verbs_test.cpp
@@ -1,0 +1,228 @@
+// FM repeater verbs: slice squelch / squelchlevel / tone / offset, and
+// transmit rfpower / tunepower (#5102).
+//
+// The bridge could not operate an FM repeater at all: it could not hear one
+// (no squelch control), open one (no CTCSS), transmit to one (no offset), or
+// set its drive. Every setter already existed on SliceModel/TransmitModel —
+// only the bridge could not reach them.
+//
+// What this file pins is the BOUNDARY behaviour, which is what a radio-less
+// CI run can actually assert: a malformed request must be refused by the verb
+// itself, BEFORE any slice is resolved (Principle VII). The distinction is
+// visible precisely because this fixture has a RadioModel with no slices —
+// a well-formed request gets "no slice available", a malformed one gets its
+// own validation error. If validation ever drifts back behind slice
+// resolution, the two collapse into the same message and these rows fail.
+//
+// The apply paths are proven against a live FLEX-6500 and a real repeater;
+// see the PR. They are deliberately not faked here.
+
+#include "core/AudioEngine.h"
+#include "core/QsoRecorder.h"
+#include "models/RadioModel.h"
+#include "core/AutomationServer.h"
+
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QGuiApplication>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLocalSocket>
+#include <QTemporaryDir>
+#include <QThread>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const QString& detail = QString())
+{
+    std::printf("%s %-56s %s\n", ok ? "[ OK ]" : "[FAIL]", name, qPrintable(detail));
+    if (!ok)
+        ++g_failed;
+}
+
+QJsonObject request(QLocalSocket& socket, const QByteArray& line)
+{
+    socket.write(line + '\n');
+    socket.flush();
+
+    QByteArray response;
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < 2000 && !response.contains('\n')) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+        response.append(socket.readAll());
+        if (!response.contains('\n'))
+            QThread::msleep(1);
+    }
+    if (!response.contains('\n'))
+        return QJsonObject{{QStringLiteral("testError"), QStringLiteral("timeout")}};
+
+    QJsonParseError error{};
+    const QJsonDocument doc = QJsonDocument::fromJson(response.trimmed(), &error);
+    if (error.error != QJsonParseError::NoError || !doc.isObject())
+        return QJsonObject{{QStringLiteral("testError"), error.errorString()}};
+    return doc.object();
+}
+
+QString errorOf(const QJsonObject& o)
+{
+    return o.value(QStringLiteral("error")).toString();
+}
+
+// A rejection that came from the VERB, not from the radio layer behind it.
+void reportRejectedAtBoundary(QLocalSocket& socket, const char* name,
+                              const QByteArray& line, const QString& expectFragment)
+{
+    const QJsonObject r = request(socket, line);
+    const QString e = errorOf(r);
+    const bool refused = (r.value(QStringLiteral("ok")).toBool() == false);
+    const bool ownError = e.contains(expectFragment, Qt::CaseInsensitive);
+    const bool notRadioError = !e.contains(QStringLiteral("no slice available"));
+    report(name, refused && ownError && notRadioError, e.isEmpty() ? QStringLiteral("(no error field)") : e);
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QTemporaryDir testRoot;
+    if (!testRoot.isValid()) {
+        std::printf("[FAIL] temporary HOME could not be created\n");
+        return 1;
+    }
+    const QByteArray root = testRoot.path().toUtf8();
+    qputenv("HOME", root);
+    qputenv("XDG_CONFIG_HOME", root);
+    qputenv("TMPDIR", root);
+    if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM"))
+        qputenv("QT_QPA_PLATFORM", "offscreen");
+    // Left deliberately unset: the transmit rows below assert the TX gate.
+    qunsetenv("AETHER_AUTOMATION_ALLOW_TX");
+
+    QGuiApplication app(argc, argv);
+
+    RadioModel radio;   // no slices — see the header comment
+    AutomationServer server;
+    server.setRadioModel(&radio);
+
+    const QString serverName = QStringLiteral("aethersdr-fmverbs-test-%1")
+                                   .arg(QCoreApplication::applicationPid());
+    const bool started = server.start(serverName);
+    report("bridge starts", started, server.fullServerName());
+    if (!started)
+        return 1;
+
+    QLocalSocket socket;
+    socket.connectToServer(serverName);
+    const bool connected = socket.waitForConnected(2000);
+    report("probe connects", connected, socket.errorString());
+    if (!connected) {
+        server.stop();
+        return 1;
+    }
+    QCoreApplication::processEvents();
+
+    // ── the verbs exist at all ───────────────────────────────────────────
+    {
+        const QJsonObject verbs = request(socket, QByteArrayLiteral("verbs"));
+        bool hasTransmit = false;
+        for (const QJsonValue& v : verbs.value(QStringLiteral("verbs")).toArray())
+            if (v.toObject().value(QStringLiteral("name")).toString()
+                == QLatin1String("transmit"))
+                hasTransmit = true;
+        report("transmit verb is registered", hasTransmit);
+    }
+
+    // ── the control row: a WELL-FORMED request reaches the radio layer ───
+    // Everything below is only meaningful against this. If this row ever
+    // reports a validation error instead, the fixture has changed and the
+    // boundary rows below are no longer proving what they claim.
+    {
+        const QJsonObject r = request(socket, QByteArrayLiteral("slice squelch on 30"));
+        report("well-formed squelch reaches the radio layer",
+               errorOf(r).contains(QStringLiteral("no slice available")), errorOf(r));
+    }
+
+    // ── squelch: refused at the boundary ─────────────────────────────────
+    reportRejectedAtBoundary(socket, "squelch with no argument is refused",
+                             QByteArrayLiteral("slice squelch"), QStringLiteral("requires"));
+    reportRejectedAtBoundary(socket, "squelch state 'maybe' is refused",
+                             QByteArrayLiteral("slice squelch maybe"), QStringLiteral("on|off"));
+    reportRejectedAtBoundary(socket, "squelch level 101 is refused",
+                             QByteArrayLiteral("slice squelch on 101"), QStringLiteral("0..100"));
+    reportRejectedAtBoundary(socket, "squelch level -1 is refused",
+                             QByteArrayLiteral("slice squelch on -1"), QStringLiteral("0..100"));
+    reportRejectedAtBoundary(socket, "squelchlevel with no argument is refused",
+                             QByteArrayLiteral("slice squelchlevel"), QStringLiteral("requires"));
+    reportRejectedAtBoundary(socket, "squelchlevel 'loud' is refused",
+                             QByteArrayLiteral("slice squelchlevel loud"), QStringLiteral("0..100"));
+
+    // ── tone ─────────────────────────────────────────────────────────────
+    reportRejectedAtBoundary(socket, "tone with no argument is refused",
+                             QByteArrayLiteral("slice tone"), QStringLiteral("requires"));
+    reportRejectedAtBoundary(socket, "tone mode 'dcs' is refused",
+                             QByteArrayLiteral("slice tone dcs"), QStringLiteral("off/ctcss_tx"));
+    reportRejectedAtBoundary(socket, "tone freq 9999 is refused",
+                             QByteArrayLiteral("slice tone ctcss_tx 9999"), QStringLiteral("CTCSS"));
+    reportRejectedAtBoundary(socket, "tone freq 0 is refused",
+                             QByteArrayLiteral("slice tone ctcss_tx 0"), QStringLiteral("CTCSS"));
+
+    // ── offset ───────────────────────────────────────────────────────────
+    reportRejectedAtBoundary(socket, "offset with no argument is refused",
+                             QByteArrayLiteral("slice offset"), QStringLiteral("requires"));
+    reportRejectedAtBoundary(socket, "offset direction 'sideways' is refused",
+                             QByteArrayLiteral("slice offset sideways"),
+                             QStringLiteral("simplex/up/down"));
+    reportRejectedAtBoundary(socket, "offset magnitude 'far' is refused",
+                             QByteArrayLiteral("slice offset up far"), QStringLiteral("MHz"));
+
+    // ── transmit: TX-gated, and gated BEFORE the value is even parsed ────
+    {
+        const QJsonObject r = request(socket, QByteArrayLiteral("transmit rfpower 40"));
+        report("transmit rfpower is blocked without ALLOW_TX",
+               r.value(QStringLiteral("ok")).toBool() == false
+                   && errorOf(r).contains(QStringLiteral("ALLOW_TX")),
+               errorOf(r));
+    }
+    {
+        // Principle VI: the gate must not be bypassable by sending nonsense —
+        // an out-of-range value on a TX-gated verb still reports the gate.
+        const QJsonObject r = request(socket, QByteArrayLiteral("transmit rfpower 9999"));
+        report("gate reports before value validation on a TX verb",
+               errorOf(r).contains(QStringLiteral("ALLOW_TX")), errorOf(r));
+    }
+    reportRejectedAtBoundary(socket, "unknown transmit action is refused",
+                             QByteArrayLiteral("transmit wattage 5"),
+                             QStringLiteral("rfpower|tunepower"));
+    reportRejectedAtBoundary(socket, "transmit with no action is refused",
+                             QByteArrayLiteral("transmit"), QStringLiteral("requires an action"));
+
+    // ── the action list a caller is told about must be true ──────────────
+    {
+        const QJsonObject r = request(socket, QByteArrayLiteral("slice bogusaction"));
+        const QString e = errorOf(r);
+        report("slice error lists the new actions",
+               e.contains(QStringLiteral("squelch")) && e.contains(QStringLiteral("tone"))
+                   && e.contains(QStringLiteral("offset")),
+               e);
+        // These three worked long before this change and were missing from the
+        // list, which is how a caller concludes a working action does not exist.
+        report("slice error lists the previously-omitted actions",
+               e.contains(QStringLiteral("filter")) && e.contains(QStringLiteral("agc"))
+                   && e.contains(QStringLiteral("dsp")),
+               e);
+    }
+
+    socket.disconnectFromServer();
+    server.stop();
+
+    std::printf("\n%s\n", g_failed == 0 ? "all rows passed" : "FAILURES PRESENT");
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/automation_fm_repeater_verbs_test.cpp
+++ b/tests/automation_fm_repeater_verbs_test.cpp
@@ -378,6 +378,109 @@ int main(int argc, char** argv)
                QString::fromUtf8(QJsonDocument(r).toJson(QJsonDocument::Compact)));
     }
 
+    // ── trailing operands are refused, and change nothing ────────────────
+    //
+    // The verbs took "<a> <b>" and read parts[0]/parts[1], so a third token was
+    // silently dropped: `slice offset down 5 typo` answered ok and moved the
+    // radio. Principle VII wants malformed input refused at the boundary, and
+    // "refused" has to mean the model did not move — an error message alone
+    // would not have caught this, because the error was never the problem.
+    //
+    // These rows carry the state assertion for that reason: each sends a
+    // malformed command and asserts the slice (and the transmitter) reads
+    // exactly as it did before.
+    {
+        auto sliceState = [&socket]() -> QString {
+            const QJsonObject r =
+                request(socket, QByteArrayLiteral("get slice active"));
+            const QJsonObject sl = r.value(QStringLiteral("slice")).toObject();
+            return QStringLiteral("%1/%2/%3/%4/%5")
+                .arg(sl.value(QStringLiteral("fmToneMode")).toString(),
+                     sl.value(QStringLiteral("fmToneValue")).toString(),
+                     sl.value(QStringLiteral("repeaterOffsetDir")).toString())
+                .arg(sl.value(QStringLiteral("fmRepeaterOffsetFreq")).toDouble())
+                .arg(sl.value(QStringLiteral("txOffsetFreq")).toDouble());
+        };
+        auto txState = [&socket]() -> QString {
+            const QJsonObject r = request(socket, QByteArrayLiteral("get transmit"));
+            const QJsonObject t = r.value(QStringLiteral("transmit")).toObject();
+            return QStringLiteral("%1/%2")
+                .arg(t.value(QStringLiteral("rfPower")).toInt())
+                .arg(t.value(QStringLiteral("tunePower")).toInt());
+        };
+
+        auto refusedAndUnchanged = [&](const char* name, const QByteArray& line,
+                                       bool transmitVerb) {
+            const QString before = transmitVerb ? txState() : sliceState();
+            const QJsonObject r = request(socket, line);
+            const QString after = transmitVerb ? txState() : sliceState();
+            const QString e = errorOf(r);
+            report(name,
+                   r.value(QStringLiteral("ok")).toBool() == false
+                       && !e.isEmpty() && after == before,
+                   after == before
+                       ? (e.isEmpty() ? QStringLiteral("(accepted)") : e)
+                       : QStringLiteral("MUTATED %1 -> %2 (%3)")
+                             .arg(before, after, e.isEmpty()
+                                                     ? QStringLiteral("ok")
+                                                     : e));
+        };
+
+        refusedAndUnchanged("offset with a trailing operand changes nothing",
+                            QByteArrayLiteral("slice offset down 5 typo"), false);
+        refusedAndUnchanged("tone with a trailing operand changes nothing",
+                            QByteArrayLiteral("slice tone ctcss_tx 100.0 typo"),
+                            false);
+        // `transmit` drops the tail in its REGISTRY PARSER, before the handler
+        // sees it — so this one cannot be caught downstream of parsing.
+        refusedAndUnchanged("transmit with a trailing operand changes nothing",
+                            QByteArrayLiteral("transmit rfpower 30 90"), true);
+        // Both request forms, because they reach the arity check differently:
+        // the JSON `args` string is folded into a bare request and re-parsed by
+        // the registry parser, while explicit `action`/`value` fields skip the
+        // parser entirely and are caught downstream. A fix in only one place
+        // leaves the other form able to move the transmitter.
+        refusedAndUnchanged("json args form refuses the trailing operand too",
+                            QByteArrayLiteral(
+                                "{\"cmd\":\"transmit\",\"args\":\"rfpower 30 90\"}"),
+                            true);
+        refusedAndUnchanged("json action/value form refuses it as well",
+                            QByteArrayLiteral(
+                                "{\"cmd\":\"transmit\",\"action\":\"rfpower\","
+                                "\"value\":\"30 90\"}"),
+                            true);
+
+        // The well-formed shapes must keep working — an arity check that is
+        // just "too many tokens" is easy to write one token too tight.
+        {
+            const QJsonObject r =
+                request(socket, QByteArrayLiteral("slice offset down 5"));
+            report("the well-formed offset still applies",
+                   r.value(QStringLiteral("ok")).toBool()
+                       && qFuzzyCompare(
+                           r.value(QStringLiteral("txOffsetFreq")).toDouble() + 1.0,
+                           -5.0 + 1.0),
+                   QString::fromUtf8(QJsonDocument(r).toJson(QJsonDocument::Compact)));
+        }
+        {
+            const QJsonObject r =
+                request(socket, QByteArrayLiteral("slice offset simplex"));
+            report("a one-token offset still applies",
+                   r.value(QStringLiteral("ok")).toBool()
+                       && r.value(QStringLiteral("repeaterOffsetDir")).toString()
+                              == QLatin1String("simplex"),
+                   QString::fromUtf8(QJsonDocument(r).toJson(QJsonDocument::Compact)));
+        }
+        {
+            const QJsonObject r =
+                request(socket, QByteArrayLiteral("transmit rfpower 25"));
+            report("the well-formed transmit still applies",
+                   r.value(QStringLiteral("ok")).toBool()
+                       && r.value(QStringLiteral("rfPower")).toInt() == 25,
+                   QString::fromUtf8(QJsonDocument(r).toJson(QJsonDocument::Compact)));
+        }
+    }
+
     {
         // A legal tone applies, to the same fixture slice, and 123.0 is a real
         // table entry while the neighbouring 123.4 above is not.

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -2846,6 +2846,16 @@ add_test(NAME automation_double_click_test COMMAND automation_double_click_test)
 set_tests_properties(automation_double_click_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
+add_executable(automation_fm_repeater_verbs_test tests/automation_fm_repeater_verbs_test.cpp)
+target_include_directories(automation_fm_repeater_verbs_test PRIVATE src)
+target_link_libraries(automation_fm_repeater_verbs_test PRIVATE
+    aethercore Qt6::Core Qt6::Network Qt6::Widgets
+)
+set_target_properties(automation_fm_repeater_verbs_test PROPERTIES AUTOMOC ON)
+add_test(NAME automation_fm_repeater_verbs_test COMMAND automation_fm_repeater_verbs_test)
+set_tests_properties(automation_fm_repeater_verbs_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 add_executable(automation_drag_at_test tests/automation_drag_at_test.cpp)
 target_include_directories(automation_drag_at_test PRIVATE src)
 target_link_libraries(automation_drag_at_test PRIVATE

--- a/tools/gen_bridge_docs.py
+++ b/tools/gen_bridge_docs.py
@@ -141,8 +141,21 @@ def extract_slice_actions(cpp_path):
     return [a for a in joined.split("|") if a]
 
 
+# Deliberately documented, deliberately NOT in sliceActionList(): `source` is
+# an accepted alias of `rxsource` (AutomationServer.cpp, the `rxsource`/`source`
+# branch) that the advertised list omits on purpose. Naming it here is the
+# difference between a lint that encodes one known exception and a lint someone
+# turns off.
+DOCUMENTED_SLICE_ALIASES = {"source"}
+
+
 def documented_slice_actions(md_text):
-    """Action names named in the first column of the `slice` section's table."""
+    """Action names in the first column of the `slice` section's table body.
+
+    Header rows are skipped structurally — a markdown table's header is the row
+    before its `|---|` separator — rather than by filtering the word "action",
+    which would also hide a real action called `action`.
+    """
     lines = md_text.splitlines()
     start = None
     for i, ln in enumerate(lines):
@@ -154,12 +167,21 @@ def documented_slice_actions(md_text):
             "error: no '### `slice`' section in the docs — the slice-action "
             "lint cannot run.")
     found = set()
+    pending_header = None
+    body = False
     for ln in lines[start + 1:]:
         # Stop at the next section of the same level; #### subsections belong
         # to `slice` and may legitimately carry rows.
         if ln.startswith("### ") and ln.strip() != "### `slice`":
             break
         if not ln.startswith("|"):
+            pending_header, body = None, False
+            continue
+        if re.fullmatch(r'\|[\s|:-]+', ln.strip()):
+            pending_header, body = None, True   # separator: header was above
+            continue
+        if not body:
+            pending_header = ln                 # candidate header, not counted
             continue
         first_cell = ln.split("|")[1]
         found.update(re.findall(r'`([a-z]+)`', first_cell))
@@ -226,8 +248,12 @@ def main():
     dups = find_duplicate_headings(md)
 
     slice_actions = extract_slice_actions(CPP)
-    undocumented = [a for a in slice_actions
-                    if a not in documented_slice_actions(md)]
+    documented = documented_slice_actions(md)
+    undocumented = [a for a in slice_actions if a not in documented]
+    # ...and the other direction: an action the docs still describe after the
+    # code stopped advertising it. A reader cannot tell a removed action from a
+    # working one, and the drift that produced #5102 ran this way round too.
+    stale_docs = sorted(documented - set(slice_actions) - DOCUMENTED_SLICE_ALIASES)
 
     if args.check:
         problems = []
@@ -245,6 +271,12 @@ def main():
                 + ", ".join(undocumented)
                 + " — document them (this table cannot be generated; the "
                   "per-action prose is hand-written on purpose)")
+        if stale_docs:
+            problems.append(
+                "slice action(s) documented in the `slice` action table but "
+                "NOT advertised by sliceActionList(): " + ", ".join(stale_docs)
+                + " — remove the row, or add the action back to the code "
+                  "(known aliases live in DOCUMENTED_SLICE_ALIASES)")
         if problems:
             for p in problems:
                 print("FAIL:", p, file=sys.stderr)
@@ -260,6 +292,9 @@ def main():
     if undocumented:
         print("warning: slice action(s) missing from the docs table: "
               + ", ".join(undocumented), file=sys.stderr)
+    if stale_docs:
+        print("warning: slice action(s) documented but not advertised: "
+              + ", ".join(stale_docs), file=sys.stderr)
     if want != md:
         with open(DOCS, "w", encoding="utf-8") as f:
             f.write(want)

--- a/tools/gen_bridge_docs.py
+++ b/tools/gen_bridge_docs.py
@@ -116,6 +116,56 @@ def generated_block(verbs):
             f"{END}")
 
 
+# The slice ACTION set is its own drift surface. #5102 was filed against a
+# working feature because two hand-maintained copies of this list disagreed;
+# the in-code copies were then collapsed into sliceActionList(). The docs held
+# a third and a fourth copy, and the `slice` action table is the one a reader
+# actually consults — so pin it to the code the same way the verb table is.
+_SLICE_LIST_RE = re.compile(
+    r'QString\s+sliceActionList\(\)\s*\{\s*return\s+QStringLiteral\('
+    r'(?P<body>(?:\s*"(?:[^"\\]|\\.)*")+)\s*\)\s*;',
+    re.DOTALL)
+
+
+def extract_slice_actions(cpp_path):
+    """The action names sliceActionList() advertises, in code order."""
+    with open(cpp_path, encoding="utf-8") as f:
+        src = f.read()
+    m = _SLICE_LIST_RE.search(src)
+    if not m:
+        raise SystemExit(
+            "error: could not parse sliceActionList() from "
+            f"{cpp_path} — the docs-vs-code slice-action lint cannot run, and "
+            "silently skipping it is how the list drifted in the first place.")
+    joined = _join_literals(m.group("body"))
+    return [a for a in joined.split("|") if a]
+
+
+def documented_slice_actions(md_text):
+    """Action names named in the first column of the `slice` section's table."""
+    lines = md_text.splitlines()
+    start = None
+    for i, ln in enumerate(lines):
+        if ln.strip() == "### `slice`":
+            start = i
+            break
+    if start is None:
+        raise SystemExit(
+            "error: no '### `slice`' section in the docs — the slice-action "
+            "lint cannot run.")
+    found = set()
+    for ln in lines[start + 1:]:
+        # Stop at the next section of the same level; #### subsections belong
+        # to `slice` and may legitimately carry rows.
+        if ln.startswith("### ") and ln.strip() != "### `slice`":
+            break
+        if not ln.startswith("|"):
+            continue
+        first_cell = ln.split("|")[1]
+        found.update(re.findall(r'`([a-z]+)`', first_cell))
+    return found
+
+
 def find_duplicate_headings(md_text):
     # Track fenced code blocks so a ``` … ### foo … ``` example isn't mistaken
     # for a real heading — otherwise this lint could block CI on doc content
@@ -175,6 +225,10 @@ def main():
     # honest regardless of what the generator would produce.
     dups = find_duplicate_headings(md)
 
+    slice_actions = extract_slice_actions(CPP)
+    undocumented = [a for a in slice_actions
+                    if a not in documented_slice_actions(md)]
+
     if args.check:
         problems = []
         if want != md:
@@ -184,17 +238,28 @@ def main():
         if dups:
             problems.append("duplicate detail-section heading(s): "
                             + ", ".join(sorted(set(dups))))
+        if undocumented:
+            problems.append(
+                "slice action(s) advertised by sliceActionList() but absent "
+                "from the `slice` action table in the docs: "
+                + ", ".join(undocumented)
+                + " — document them (this table cannot be generated; the "
+                  "per-action prose is hand-written on purpose)")
         if problems:
             for p in problems:
                 print("FAIL:", p, file=sys.stderr)
             return 1
         print(f"ok: docs verb table matches the registry ({len(verbs)} verbs), "
-              "no duplicate headings")
+              f"no duplicate headings, all {len(slice_actions)} slice actions "
+              "documented")
         return 0
 
     if dups:
         print("warning: duplicate detail-section heading(s): "
               + ", ".join(sorted(set(dups))), file=sys.stderr)
+    if undocumented:
+        print("warning: slice action(s) missing from the docs table: "
+              + ", ".join(undocumented), file=sys.stderr)
     if want != md:
         with open(DOCS, "w", encoding="utf-8") as f:
             f.write(want)


### PR DESCRIPTION
## Summary

Adds the two FM-repeater write paths the automation bridge genuinely lacked — CTCSS and repeater
offset — plus a `transmit` verb for RF/tune power, and fixes the drifted slice-action list that
caused #5102 to be filed against a working feature in the first place.

Closes #5102.

> **Scope corrected after upstream triage.** The issue's headline claim — that squelch was
> unreachable — was wrong: `slice dsp squelch <on|off> [level]` has always routed to
> `SliceModel::setSquelch`. The `slice squelch` / `slice squelchlevel` verbs from the first commit
> are **removed**. See
> [this comment](https://github.com/aethersdr/AetherSDR/issues/5102#issuecomment-5349859030).

> **Review round 2 (`2344f1cd`).** `slice offset` wrote two of the three fields a duplex split
> needs, so it recorded the offset and never moved the transmitter. Measured on the radio, fixed,
> and the docs drift that hid it is now pinned to the code. Details below.

> **Review round 3 (rebased).** Trailing operands are refused before anything mutates. Per
> maintainer direction, the `.github/workflows/ci.yml` gate is removed from this PR and will arrive
> separately; the regression remains registered with CTest and is exercised in the local exact-head
> verification below.

## The root cause is worth more than the verbs

The slice-action list existed **twice, by hand**, and the two copies drifted. The message a caller
actually hits — `unknown slice action:` — omitted `filter`, `agc` and `dsp`. The one omitted action
that would have made the whole investigation unnecessary was `dsp`.

Both messages now derive from a single `sliceActionList()`. The docs held a **third and a fourth**
copy: one is deleted outright, and the surviving `slice` action table is pinned to the code by
`tools/gen_bridge_docs.py --check`. A hand-maintained list that can silently drift is what
manufactured a false bug report; that is the defect this PR most wants to close.

## What changed

- **`slice tone <off|ctcss_tx> [freq]`** — value applied before mode, so enabling CTCSS never keys
  on the previous tone for a round trip. The frequency is validated against the **same table the
  operator's dropdown is built from**, now shared at `core/CtcssTones.h`; the previous
  `0 < f <= 300` bound accepted 123.4 Hz, which is not a CTCSS tone.
- **`slice offset <simplex|up|down> [mhz]`** — magnitude before direction, then the signed
  `tx_offset_freq` that actually moves the transmitter. Magnitude is unsigned and bounded
  `0..100` MHz, the bound both GUI spinboxes carry.
- **`transmit <rfpower|tunepower> <0..100>`** — TX-gated like `key` and `txtest`, **and clamped to
  `m_txMaxPower`**. The power-ceiling rail is widget-scoped — it lives in `invoke()`'s `setValue`
  path and keys off `accessibleName` — so a verb reaching `TransmitModel` directly inherits
  nothing. Without the explicit clamp, `AETHER_AUTOMATION_TX_MAX_POWER` silently stopped bounding
  the surface most likely to be driving a transverter or an amplifier. The reply carries
  `requested` / `clampedTo` rather than quietly honouring a different number than was asked for.
- **Slice snapshot** now serializes `fmToneMode`, `fmToneValue`, `repeaterOffsetDir`,
  `fmRepeaterOffsetFreq` and `txOffsetFreq` — the model had them all along, the snapshot was blind.
- **`audioCapture`** compact snapshots carry a hint naming `path=<file>`, so
  `chunksOmitted == chunkCount` no longer reads as a lost capture.
- **Offset magnitude validation** rejects negative, NaN and infinite values before any model mutation.
- **Exact arity on all three verbs.** They read `parts[0]`/`parts[1]` and dropped the rest, so
  `slice offset down 5 typo` answered `ok` and moved the radio. `tone` and `offset` check in the
  handler, where every request form still has the operands joined; `transmit` had to change its
  registry parser, because `parseActionValue` discarded the tail before any handler could see it.

## The offset bug, and how the radio answered it

`slice offset` called `setRepeaterOffsetDir()` and `setFmRepeaterOffsetFreq()`. Each setter sends
only its own key, and `tx_offset_freq` is a third one — `FlexBackend` decodes it as a value in its
own right, and every other writer of duplex in the tree sends all three
(`RxApplet::applyOffsetDir`, `VfoWidget`'s spin handler and `applyDir`,
`MemoryRecallPolicy::buildMemoryRecallSliceFixupCommand`). So the verb recorded "down, 5 MHz" on a
slice that still transmitted on its receive frequency.

**Asked the radio directly** — FLEX-6500, FM, RX only, no transmit at any point:

| what was written to slice 0 | what the radio then reports |
|---|---|
| `repeater_offset_dir=down` + `fm_repeater_offset_freq=5` only (the pre-fix path) | `tx_offset_freq=0` |
| all three, via `slice offset down 5` (fixed) | `tx_offset_freq=-5` |
| all three, via `slice offset up 5` (fixed) | `tx_offset_freq=+5` |

The radio does **not** derive the split from the direction, so the other three writers are not
sending a redundant field — the verb was short one. Read back from the radio's own echoed status,
not from the local model.

*One observed aside, not a defect:* in **USB** the radio reports `tx_offset_freq=0` even when it is
written, and applies the stored value on the switch to FM. The split is FM-only radio-side.

The sign rule now lives once, in `SliceModel::txOffsetForDirection()`, and the two GUI copies call
it — three hand-rolled copies of one rule is the same defect shape as the action list above. The
write is **unconditional**, because `setRepeaterOffsetDir()` early-returns when the direction has
not changed, so a recompute conditioned on direction would miss a magnitude-only change.

## Scope

Eleven files. Two are the bridge itself (`AutomationServer.{h,cpp}`); `SliceModel.{h,cpp}` and the
new `core/CtcssTones.h` hold the two rules that were being copied by hand; `RxApplet.cpp` and
`VfoWidget.cpp` are behaviour-preserving call-site swaps onto those (`VfoWidget`'s CTCSS list was
verified identical in value and order before the swap); `docs/automation-bridge.md` and
`tools/gen_bridge_docs.py` are the drift fix; plus the CTest registration and focused test suite.
The `.github/workflows/ci.yml` work is deliberately excluded for a follow-on PR.

No backend or wire-protocol work — every field and setter this touches already exists and is
exercised by the GUI and memory-recall paths. It does add protocol *surface*: one top-level verb,
two slice actions, five snapshot keys. #5102 proposed all of them and carries `protocol` +
`maintainer-review`; that ruling is yours, not mine.

## Constitution principle honored

**Principle I — FlexLib is protocol authority.** The radio, not the client, decides what a repeater
split is: it carries `tx_offset_freq` as its own field and does not infer it. The fix is to send
what the protocol requires, matching every other writer in the tree, and the table above is the
radio's own answer rather than an argument about it.

**Principle VII — Untrusted Input Is Validated At The Boundary.** Arguments are validated *before*
any slice is resolved. The fixture carries a `RadioModel` with **no slices**, which makes the
ordering observable: a well-formed request reports `no slice available`, a malformed one reports
its own error.

**Principle VI — AetherSDR Never Transmits Without Operator Intent.** The transmit verbs are gated
on `AETHER_AUTOMATION_ALLOW_TX`, the gate is reported *before* value validation so it cannot be
probed with nonsense, and the power ceiling binds even once TX is permitted.

## Test plan

- [x] `automation_fm_repeater_verbs_test` — **49 rows, all pass** on the exact rebased head
- [x] **The apply path is asserted locally.** The rows drive the repo's own disconnected
      `slice fixture` action. Adding this suite and `bridge_docs_check` to the pull-request gate is
      deliberately deferred to the follow-on CI PR.
- [x] **Each guarantee falsified separately:**
      - revert the `tx_offset_freq` write → **5 rows fail**
      - drop `txOffsetFreq` from the slice snapshot → **1 row fails**
      - drop the `0..100` magnitude bound → **1 row fails**
      - revert any one of the three arity checks → its row fails **naming the mutation it caused**
        (`MUTATED off/100.0/down/0.6/-0.6 -> off/100.0/down/5/-5`), which is the point of asserting
        state rather than only the error string
      - advertise an action with no handler → the dispatch row fails, naming it
      - let the two action lists drift → **1 row fails**
      - move validation back behind slice resolution → **4 rows fail**
      - remove the power clamp → **3 rows fail**, and `transmit rfpower 90` returns `rfPower: 90`
        under a ceiling of 30
- [x] `tools/gen_bridge_docs.py --check` green, and the slice-action lint falsified in **all four**
      directions: delete a docs row → fails naming the action; add an unadvertised action to
      `sliceActionList()` → fails naming it; document an action the code dropped → fails naming it;
      remove the `source` alias exemption → flags `source`, proving the exemption is load-bearing
      rather than decorative
- [x] `ctest -R "bridge_docs_check|automation_|slice_model_|memory_recall_policy_test|tci_"` —
      **21/21 pass**
- [x] Regression row: `slice dsp squelch` still routes — the pre-existing path this PR must not
      break
- [x] Full `ninja -C build` clean (Nobara 43, Qt 6.11.1, gcc 16.1.1, cmake 4.3.0)
- [x] **Exercised on hardware** — live FLEX-6500, FM, RX only, radio restored to its as-found
      state. The A/B table above is that session.

      *Stated precisely:* the earlier hardware session (first review round) configured an FM
      session through the bridge and captured RX audio at −22.32 dBFS. **It could not have caught
      this bug** — receive does not move with `tx_offset_freq`, so a capture proves the RX side and
      is silent about the split. That claim is corrected, not defended.

## Checklist

- [x] Commits are signed (docs/COMMIT-SIGNING.md)
- [x] No new flat-key AppSettings calls (Principle V)
- [x] All meter UI uses MeterSmoother (Principle II) — n/a, no meter UI here

---

73, Ozy **K6OZY**  · cost: $16.23 · model: claude-opus-5
