### PR TITLE
Improve PSK Reporter map coverage and responsiveness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,18 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: ctest --test-dir build -R "^map_wrap_test$" --output-on-failure
 
+      # PSK Reporter query scope, parser bounds, rate-limit backoff, path
+      # unwrapping, and solar-position math. Pure Core test with no network.
+      - name: Test PSK Reporter map behavior
+        run: ctest --test-dir build -R "^psk_reporter_map_behavior_test$" --output-on-failure
+
+      # Async marker/path/terminator cache replacement must retain visible
+      # content and cancel superseded work. Offscreen GUI test, no network.
+      - name: Test PSK Reporter map live updates
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: ctest --test-dir build -R "^map_live_update_test$" --output-on-failure
+
       # The demo RX engine's worker-thread contract (#4878): affinity, 24 kHz
       # pacing on a coarse timer, keyed-mute, stallscope. This is the fix for
       # the demo making the GUI thread carry a 333 Hz precise timer plus the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -887,7 +887,6 @@ set(GUI_SOURCES
     src/gui/map/MapMarkerBatchItem.cpp
     src/gui/map/MapMarkerItem.cpp
     src/gui/map/MapPathBatchItem.cpp
-    src/gui/map/MapPathItem.cpp
     src/gui/map/MapTerminatorItem.cpp
     src/gui/PskReporterMapDialog.cpp
     src/gui/GpsLocationDialog.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -884,8 +884,11 @@ set(GUI_SOURCES
     src/gui/MainWindow_ReceiveSync.cpp
     src/gui/MainWindow_KiwiSdr.cpp
     src/gui/map/MapView.cpp
+    src/gui/map/MapMarkerBatchItem.cpp
     src/gui/map/MapMarkerItem.cpp
+    src/gui/map/MapPathBatchItem.cpp
     src/gui/map/MapPathItem.cpp
+    src/gui/map/MapTerminatorItem.cpp
     src/gui/PskReporterMapDialog.cpp
     src/gui/GpsLocationDialog.cpp
     src/gui/AgcCalibrationDialog.cpp
@@ -2788,4 +2791,3 @@ else()
         DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
     )
 endif()
-

--- a/src/core/PskReporterClient.cpp
+++ b/src/core/PskReporterClient.cpp
@@ -5,14 +5,17 @@
 #endif
 
 #include <QCoreApplication>
+#include <QCryptographicHash>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QLockFile>
 #include <QNetworkReply>
 #include <QSaveFile>
+#include <QSet>
 #include <QStandardPaths>
 #include <QUrlQuery>
 #include <QXmlStreamReader>
@@ -20,6 +23,7 @@
 #include <QLoggingCategory>
 
 #include <algorithm>
+#include <limits>
 
 Q_LOGGING_CATEGORY(lcPskReporter, "aether.pskreporter")
 
@@ -33,6 +37,7 @@ namespace {
 // time assembling before it writes anything. The polling floor is already five
 // minutes (kMinPollMs) for the same reason.
 constexpr int kTransferTimeoutMs = 30000;
+constexpr int kCoordinationRetryMs = 1000;
 } // namespace
 
 PskReporterClient::PskReporterClient(QObject* parent)
@@ -40,6 +45,10 @@ PskReporterClient::PskReporterClient(QObject* parent)
 {
     m_nam.setTransferTimeout(kTransferTimeoutMs);
     connect(&m_timer, &QTimer::timeout, this, &PskReporterClient::poll);
+    m_httpThrottleTimer.setSingleShot(true);
+    connect(&m_httpThrottleTimer, &QTimer::timeout,
+            this, &PskReporterClient::poll);
+    loadHttpThrottleState();
 
     // Five-minute MQTT health summary — enough to spot a dead or flapping
     // feed in the logs without per-spot noise.
@@ -77,19 +86,22 @@ PskReporterClient::~PskReporterClient()
 
 void PskReporterClient::setCallsign(const QString& callsign)
 {
-    if (m_callsign == callsign.trimmed().toUpper()) {
+    const QString normalized = callsign.trimmed().toUpper().left(32);
+    const QueryScope scope = normalized.isEmpty() ? QueryScope::Anyone
+                                                   : QueryScope::Callsign;
+    if (m_callsign == normalized && m_scope == scope) {
         return;
     }
-    m_callsign = callsign.trimmed().toUpper();
+    if (m_cacheDirty) {
+        saveCache();
+    }
+    m_callsign = normalized;
+    m_scope = scope;
     m_spots.clear();
+    m_monitors.clear();
+    m_resultsLimited = false;
     m_lastSeqNo = -1;
     emit spotsUpdated();
-    if (m_running) {
-        // Restart on the new callsign.
-        const int interval = m_intervalMs;
-        stop();
-        start(interval);
-    }
 }
 
 void PskReporterClient::setLookbackSeconds(int seconds)
@@ -127,14 +139,29 @@ QString PskReporterClient::transport() const
                                            : QStringLiteral("HTTP");
 }
 
+QDateTime PskReporterClient::lastHttpRequestAt() const
+{
+    return m_lastHttpRequestEpochMs > 0
+        ? QDateTime::fromMSecsSinceEpoch(m_lastHttpRequestEpochMs)
+        : QDateTime();
+}
+
+QDateTime PskReporterClient::nextHttpRequestAt() const
+{
+    return m_nextHttpAllowedEpochMs > 0
+        ? QDateTime::fromMSecsSinceEpoch(m_nextHttpAllowedEpochMs)
+        : QDateTime();
+}
+
 void PskReporterClient::start(int intervalMs)
 {
     stop();
-    if (m_callsign.isEmpty()) {
-        emit statusChanged(tr("No callsign — connect to a radio first"));
-        return;
-    }
-    m_intervalMs = (intervalMs == kLiveMqtt)
+    // The global MQTT wildcard is hundreds of reports per second.  "Anyone"
+    // therefore uses the bounded, policy-compliant HTTP snapshot even when
+    // the UI's update selector is set to Live.
+    m_intervalMs = (intervalMs == kLiveMqtt && m_scope == QueryScope::Anyone)
+                       ? kMinPollMs
+                       : (intervalMs == kLiveMqtt)
                        ? kLiveMqtt
                        : std::max(intervalMs, kMinPollMs);
     m_running = true;
@@ -163,10 +190,15 @@ void PskReporterClient::start(int intervalMs)
 
 void PskReporterClient::stop()
 {
+    ++m_queryGeneration;
     m_running = false;
     m_timer.stop();
     m_saveTimer.stop();
+    m_httpThrottleTimer.stop();
     stopMqtt();
+    if (m_queryReply != nullptr) {
+        m_queryReply->abort();
+    }
     if (m_cacheDirty) {
         saveCache();
     }
@@ -174,15 +206,64 @@ void PskReporterClient::stop()
 
 void PskReporterClient::poll()
 {
-    if (m_fetchInFlight || m_callsign.isEmpty()) {
+    if (m_fetchInFlight) {
         return;
     }
+    {
+        // Coordinate every AetherSDR process through one short-held lock.
+        // Without this claim, two instances whose timers expire together can
+        // both read the old deadline and send simultaneously.
+        const QString throttlePath = httpThrottleStateFilePath();
+        QDir().mkpath(QFileInfo(throttlePath).absolutePath());
+        QLockFile requestLock(throttlePath + QStringLiteral(".lock"));
+        requestLock.setStaleLockTime(kTransferTimeoutMs * 2);
+        if (!requestLock.tryLock(0)) {
+            m_nextHttpAllowedEpochMs = qMax(
+                m_nextHttpAllowedEpochMs,
+                QDateTime::currentMSecsSinceEpoch() + kCoordinationRetryMs);
+            scheduleHttpPollAtAllowedTime();
+            emit statusChanged(tr("HTTP refresh queued behind another "
+                                  "AetherSDR instance"));
+            emit connectionStateChanged();
+            return;
+        }
+
+        // Another process may have queried since this client started. Merge
+        // its shared deadline while holding the claim lock.
+        loadHttpThrottleState();
+        const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+        if (nowMs < m_nextHttpAllowedEpochMs) {
+            scheduleHttpPollAtAllowedTime();
+            const int cachedStations = m_spots.size() + m_monitors.size();
+            const QString nextTime = nextHttpRequestAt().toLocalTime().toString(
+                QStringLiteral("hh:mm:ss"));
+            emit statusChanged(cachedStations > 0
+                ? tr("Showing %1 cached station(s) — HTTP refresh throttled until %2")
+                      .arg(cachedStations).arg(nextTime)
+                : tr("HTTP refresh throttled until %1").arg(nextTime));
+            emit connectionStateChanged();
+            return;
+        }
+        m_lastHttpRequestEpochMs = nowMs;
+        m_nextHttpAllowedEpochMs = nowMs + kMinPollMs;
+        saveHttpThrottleState();
+    }
     m_fetchInFlight = true;
+    m_httpThrottleTimer.stop();
+    m_lastHttpStatus = 0;
+    m_lastHttpError.clear();
 
     QUrlQuery query;
-    query.addQueryItem(QStringLiteral("senderCallsign"), m_callsign);
-    query.addQueryItem(QStringLiteral("rronly"), QStringLiteral("1"));
-    query.addQueryItem(QStringLiteral("noactive"), QStringLiteral("1"));
+    if (m_scope == QueryScope::Callsign) {
+        // Generic callsign matches both sent-by and received-by reports, as
+        // the public PSK Reporter map does.
+        query.addQueryItem(QStringLiteral("callsign"), m_callsign);
+        query.addQueryItem(QStringLiteral("rronly"), QStringLiteral("1"));
+        query.addQueryItem(QStringLiteral("noactive"), QStringLiteral("1"));
+    } else {
+        query.addQueryItem(QStringLiteral("rptlimit"),
+                           QString::number(kMaxSpots));
+    }
     query.addQueryItem(QStringLiteral("appcontact"),
                        QStringLiteral("ki6bcj@aethersdr.com"));
     const bool initial = m_lastSeqNo < 0;
@@ -210,24 +291,86 @@ void PskReporterClient::poll()
 
     qCInfo(lcPskReporter) << "HTTP query"
                           << (initial ? "(initial)" : "(incremental)")
-                          << "senderCallsign" << m_callsign
+                          << "scope"
+                          << (m_scope == QueryScope::Anyone ? "anyone" : "callsign")
+                          << m_callsign
                           << "url" << url.toString(QUrl::RemoveQuery);
     emit statusChanged(tr("Updating…"));
-    auto* reply = m_nam.get(req);
-    connect(reply, &QNetworkReply::finished, this, [this, reply, initial, fetchDepth] {
+    emit connectionStateChanged();
+    QNetworkReply* reply = m_nam.get(req);
+    m_queryReply = reply;
+    const quint64 generation = m_queryGeneration;
+    connect(reply, &QNetworkReply::finished, this,
+            [this, reply, initial, fetchDepth, generation] {
         m_fetchInFlight = false;
+        if (m_queryReply == reply) {
+            m_queryReply = nullptr;
+        }
         reply->deleteLater();
+        if (generation != m_queryGeneration) {
+            if (m_running) {
+                QTimer::singleShot(0, this, &PskReporterClient::poll);
+            }
+            return;
+        }
         if (reply->error() != QNetworkReply::NoError) {
+            const int httpStatus = reply->attribute(
+                QNetworkRequest::HttpStatusCodeAttribute).toInt();
+            m_lastHttpStatus = httpStatus;
+            m_lastHttpError = reply->errorString();
             qCWarning(lcPskReporter)
                 << "HTTP error:" << reply->errorString()
-                << "status"
-                << reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
+                << "status" << httpStatus;
             m_lastHttpOk = false;
             m_sawError = true;
             emit connectionStateChanged();
-            emit statusChanged(tr("PSK Reporter error: %1")
-                                   .arg(reply->errorString()));
+            if (httpStatus == 429) {
+                ++m_consecutiveRateLimits;
+                const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+                qint64 retryAfterMs = 0;
+                const QByteArray retryHeader =
+                    reply->rawHeader("Retry-After").trimmed();
+                bool retrySecondsOk = false;
+                const qint64 retrySeconds =
+                    retryHeader.toLongLong(&retrySecondsOk);
+                if (retrySecondsOk && retrySeconds > 0) {
+                    retryAfterMs = retrySeconds * 1000;
+                } else if (!retryHeader.isEmpty()) {
+                    const QDateTime retryDate = QDateTime::fromString(
+                        QString::fromLatin1(retryHeader), Qt::RFC2822Date);
+                    if (retryDate.isValid()) {
+                        retryAfterMs = qMax<qint64>(
+                            0, retryDate.toMSecsSinceEpoch() - nowMs);
+                    }
+                }
+                // Retry-After is optional. Without a fallback, a server that
+                // omits it is hit again at the same five-minute cadence that
+                // just failed. Persist an exponential 15m..2h backoff so all
+                // AetherSDR processes share the more conservative deadline.
+                const qint64 delayMs = qMax(
+                    retryAfterMs, rateLimitBackoffMs(m_consecutiveRateLimits));
+                m_nextHttpAllowedEpochMs = qMax(
+                    m_nextHttpAllowedEpochMs, nowMs + delayMs);
+                saveHttpThrottleState();
+                scheduleHttpPollAtAllowedTime();
+                const int cachedStations = m_spots.size() + m_monitors.size();
+                emit statusChanged(cachedStations > 0
+                    ? tr("PSK Reporter rate limit — showing %1 cached "
+                         "station(s); retrying at the next update")
+                          .arg(cachedStations)
+                    : tr("PSK Reporter rate limit — retrying at the next update"));
+            } else {
+                emit statusChanged(tr("PSK Reporter error: %1")
+                                       .arg(reply->errorString()));
+            }
             return;
+        }
+        m_lastHttpStatus = reply->attribute(
+            QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        m_lastHttpError.clear();
+        if (m_consecutiveRateLimits != 0) {
+            m_consecutiveRateLimits = 0;
+            saveHttpThrottleState();
         }
         if (initial) {
             // We now hold history back to this depth; record it so narrowing
@@ -243,10 +386,79 @@ void PskReporterClient::poll()
     });
 }
 
+void PskReporterClient::scheduleHttpPollAtAllowedTime()
+{
+    if (!m_running) {
+        return;
+    }
+    const qint64 remainingMs = qMax<qint64>(
+        0, m_nextHttpAllowedEpochMs - QDateTime::currentMSecsSinceEpoch());
+    m_httpThrottleTimer.start(static_cast<int>(
+        qMin<qint64>(remainingMs, std::numeric_limits<int>::max())));
+}
+
+qint64 PskReporterClient::rateLimitBackoffMs(int consecutiveRateLimits)
+{
+    const int exponent = std::clamp(consecutiveRateLimits - 1, 0, 8);
+    return qMin(kRateLimitBaseMs * (1LL << exponent), kRateLimitMaxMs);
+}
+
+QString PskReporterClient::httpThrottleStateFilePath() const
+{
+    return QStandardPaths::writableLocation(QStandardPaths::CacheLocation)
+         + QDir::separator()
+         + QStringLiteral("psk-reporter-http-throttle.json");
+}
+
+void PskReporterClient::loadHttpThrottleState()
+{
+    QFile file(httpThrottleStateFilePath());
+    if (!file.open(QIODevice::ReadOnly)) {
+        return;
+    }
+    const QJsonObject root = QJsonDocument::fromJson(file.readAll()).object();
+    const qint64 lastRequest = static_cast<qint64>(
+        root.value(QLatin1String("lastRequestMs")).toDouble());
+    const qint64 nextAllowed = static_cast<qint64>(
+        root.value(QLatin1String("nextAllowedMs")).toDouble());
+    const int rateLimitCount =
+        root.value(QLatin1String("rateLimitCount")).toInt();
+    m_lastHttpRequestEpochMs = qMax(m_lastHttpRequestEpochMs, lastRequest);
+    m_nextHttpAllowedEpochMs = qMax(m_nextHttpAllowedEpochMs, nextAllowed);
+    m_consecutiveRateLimits = qMax(
+        m_consecutiveRateLimits, rateLimitCount);
+}
+
+void PskReporterClient::saveHttpThrottleState() const
+{
+    const QString path = httpThrottleStateFilePath();
+    QDir().mkpath(QFileInfo(path).absolutePath());
+    QSaveFile file(path);
+    if (!file.open(QIODevice::WriteOnly)) {
+        qCWarning(lcPskReporter) << "could not write HTTP throttle state:"
+                                << path;
+        return;
+    }
+    QJsonObject root;
+    root[QLatin1String("lastRequestMs")] =
+        static_cast<double>(m_lastHttpRequestEpochMs);
+    root[QLatin1String("nextAllowedMs")] =
+        static_cast<double>(m_nextHttpAllowedEpochMs);
+    root[QLatin1String("rateLimitCount")] = m_consecutiveRateLimits;
+    file.write(QJsonDocument(root).toJson(QJsonDocument::Compact));
+    if (!file.commit()) {
+        qCWarning(lcPskReporter) << "could not commit HTTP throttle state:"
+                                << path;
+    }
+}
+
 void PskReporterClient::handleQueryReply(const QByteArray& xml)
 {
     QXmlStreamReader reader(xml);
     int added = 0;
+    int parsedReports = 0;
+    QVector<PskReporterMonitor> monitors;
+    QSet<QString> monitorKeys;
     while (!reader.atEnd()) {
         reader.readNext();
         if (!reader.isStartElement()) {
@@ -257,7 +469,34 @@ void PskReporterClient::handleQueryReply(const QByteArray& xml)
             m_lastSeqNo = attrs.value(QLatin1String("value")).toLongLong();
             continue;
         }
+        if (reader.name() == QLatin1String("activeReceiver")) {
+            PskReporterMonitor monitor;
+            monitor.callsign = attrs.value(QLatin1String("callsign"))
+                                   .toString().trimmed().toUpper().left(32);
+            monitor.locator = attrs.value(QLatin1String("locator"))
+                                  .toString().trimmed().toUpper().left(12);
+            monitor.mode = attrs.value(QLatin1String("mode"))
+                               .toString().trimmed().left(32);
+            monitor.decoderSoftware =
+                attrs.value(QLatin1String("decoderSoftware"))
+                    .toString().trimmed().left(96);
+            monitor.frequencyHz =
+                attrs.value(QLatin1String("frequency")).toLongLong();
+            const QString key = monitor.callsign + QLatin1Char('|')
+                              + monitor.locator;
+            if (!monitor.callsign.isEmpty() && !monitor.locator.isEmpty()
+                && !monitorKeys.contains(key)
+                && monitors.size() < kMaxMonitors) {
+                monitorKeys.insert(key);
+                monitors.append(monitor);
+            }
+            continue;
+        }
         if (reader.name() != QLatin1String("receptionReport")) {
+            continue;
+        }
+        ++parsedReports;
+        if (parsedReports > kMaxSpots) {
             continue;
         }
         PskReporterSpot spot;
@@ -283,12 +522,25 @@ void PskReporterClient::handleQueryReply(const QByteArray& xml)
         }
     }
     pruneOldSpots();
+    if (m_scope == QueryScope::Anyone) {
+        m_monitors = monitors;
+        m_cacheDirty = true;
+    }
+    m_resultsLimited = parsedReports > kMaxSpots;
     qCInfo(lcPskReporter) << "HTTP parsed" << added << "reception reports,"
                           << m_spots.size() << "total, lastSeqNo" << m_lastSeqNo;
     if (reader.hasError()) {
         qCWarning(lcPskReporter) << "XML parse error:" << reader.errorString();
     }
-    emit statusChanged(tr("Updated %1 (%2 new, %3 total)")
+    emit statusChanged(m_scope == QueryScope::Anyone
+                           ? tr("Updated %1 (%2 reports, %3 active monitors)%4")
+                                 .arg(QDateTime::currentDateTime()
+                                          .toString(QStringLiteral("hh:mm")))
+                                 .arg(m_spots.size())
+                                 .arg(m_monitors.size())
+                                 .arg(m_resultsLimited ? tr(" — report limit reached")
+                                                       : QString())
+                           : tr("Updated %1 (%2 new, %3 total)")
                            .arg(QDateTime::currentDateTime()
                                     .toString(QStringLiteral("hh:mm")))
                            .arg(added)
@@ -330,8 +582,10 @@ void PskReporterClient::startMqtt()
     }
     // Live feed has no backfill; seed the window with one HTTP query.
     poll();
-    m_mqtt->setSubscriptions(
-        { QStringLiteral("pskr/filter/v2/+/+/%1/#").arg(m_callsign) });
+    m_mqtt->setSubscriptions({
+        QStringLiteral("pskr/filter/v2/+/+/%1/#").arg(m_callsign),
+        QStringLiteral("pskr/filter/v2/+/+/+/%1/#").arg(m_callsign)
+    });
     m_mqtt->connectToBroker(QString::fromLatin1(kMqttHost), kMqttPort,
                             {}, {}, /*useTls=*/false);
     m_mqttMsgWindow = 0;
@@ -400,12 +654,13 @@ void PskReporterClient::handleMqttMessage(const QString& topic,
 
 void PskReporterClient::appendSpot(const PskReporterSpot& spot)
 {
-    // Replace any older report from the same receiver so the map shows one
-    // marker per reporting station.
+    // Retain one latest report for each sender/receiver pair.  Generic
+    // callsign queries can return reports in either direction, and the
+    // anyone view needs distinct paths rather than one receiver-only record.
     auto it = std::find_if(m_spots.begin(), m_spots.end(),
                            [&spot](const PskReporterSpot& s) {
-                               return s.receiverCallsign
-                                   == spot.receiverCallsign;
+                               return s.receiverCallsign == spot.receiverCallsign
+                                   && s.senderCallsign == spot.senderCallsign;
                            });
     if (it != m_spots.end()) {
         if (spot.flowStartSeconds >= it->flowStartSeconds) {
@@ -434,7 +689,12 @@ void PskReporterClient::pruneOldSpots()
                                  }),
                   m_spots.end());
     while (m_spots.size() > kMaxSpots) {
-        m_spots.removeFirst();
+        const auto oldest = std::min_element(
+            m_spots.begin(), m_spots.end(),
+            [](const PskReporterSpot& a, const PskReporterSpot& b) {
+                return a.flowStartSeconds < b.flowStartSeconds;
+            });
+        m_spots.erase(oldest);
     }
     if (m_spots.size() != before) {
         m_cacheDirty = true;
@@ -445,18 +705,29 @@ QString PskReporterClient::cacheFilePath() const
 {
     const QString dir =
         QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    const QString scopeKey = m_scope == QueryScope::Anyone
+        ? QStringLiteral("anyone")
+        : QString::fromLatin1(QCryptographicHash::hash(
+              m_callsign.toUtf8(), QCryptographicHash::Sha256).toHex().left(16));
     return dir + QDir::separator()
-         + QStringLiteral("psk-reporter-spots.json");
+         + QStringLiteral("psk-reporter-spots-%1.json").arg(scopeKey);
 }
 
 void PskReporterClient::loadCache()
 {
-    if (m_callsign.isEmpty()) {
-        return;
-    }
-    QFile f(cacheFilePath());
+    const QString scopedPath = cacheFilePath();
+    QFile f(scopedPath);
+    bool legacyCache = false;
     if (!f.open(QIODevice::ReadOnly)) {
-        return;
+        // One-time migration from the original shared cache. Its embedded
+        // callsign still prevents cross-scope data from being restored.
+        f.setFileName(QFileInfo(scopedPath).absolutePath()
+                      + QDir::separator()
+                      + QStringLiteral("psk-reporter-spots.json"));
+        if (!f.open(QIODevice::ReadOnly)) {
+            return;
+        }
+        legacyCache = true;
     }
     const QJsonObject root = QJsonDocument::fromJson(f.readAll()).object();
     // Only restore the cache when it belongs to the current callsign.
@@ -488,19 +759,41 @@ void PskReporterClient::loadCache()
             ++loaded;
         }
     }
-    m_cacheDirty = false;
+    const qint64 savedAt = static_cast<qint64>(
+        root.value(QLatin1String("saved")).toDouble());
+    const bool monitorSnapshotFresh = savedAt > 0
+        && savedAt >= QDateTime::currentSecsSinceEpoch()
+                         - (2 * kMinPollMs / 1000);
+    if (m_scope == QueryScope::Anyone && monitorSnapshotFresh) {
+        const QJsonArray monitorArray =
+            root.value(QLatin1String("monitors")).toArray();
+        for (const QJsonValue& value : monitorArray) {
+            const QJsonObject o = value.toObject();
+            PskReporterMonitor monitor;
+            monitor.callsign = o.value(QLatin1String("c")).toString();
+            monitor.locator = o.value(QLatin1String("l")).toString();
+            monitor.mode = o.value(QLatin1String("m")).toString();
+            monitor.decoderSoftware =
+                o.value(QLatin1String("s")).toString();
+            monitor.frequencyHz = static_cast<qint64>(
+                o.value(QLatin1String("f")).toDouble());
+            if (!monitor.callsign.isEmpty() && !monitor.locator.isEmpty()
+                && m_monitors.size() < kMaxMonitors) {
+                m_monitors.append(monitor);
+            }
+        }
+    }
+    m_cacheDirty = legacyCache;
     qCInfo(lcPskReporter) << "loaded" << loaded << "cached spots for"
-                          << m_callsign;
-    if (loaded > 0) {
+                          << m_callsign << "and" << m_monitors.size()
+                          << "cached active monitors";
+    if (loaded > 0 || !m_monitors.isEmpty()) {
         emit spotsUpdated();
     }
 }
 
 void PskReporterClient::saveCache()
 {
-    if (m_callsign.isEmpty()) {
-        return;
-    }
     QJsonArray arr;
     for (const PskReporterSpot& s : std::as_const(m_spots)) {
         QJsonObject o;
@@ -519,6 +812,19 @@ void PskReporterClient::saveCache()
     root[QLatin1String("saved")] =
         static_cast<double>(QDateTime::currentSecsSinceEpoch());
     root[QLatin1String("spots")] = arr;
+    if (m_scope == QueryScope::Anyone) {
+        QJsonArray monitorArray;
+        for (const PskReporterMonitor& monitor : std::as_const(m_monitors)) {
+            QJsonObject o;
+            o[QLatin1String("c")] = monitor.callsign;
+            o[QLatin1String("l")] = monitor.locator;
+            o[QLatin1String("m")] = monitor.mode;
+            o[QLatin1String("s")] = monitor.decoderSoftware;
+            o[QLatin1String("f")] = static_cast<double>(monitor.frequencyHz);
+            monitorArray.append(o);
+        }
+        root[QLatin1String("monitors")] = monitorArray;
+    }
 
     const QString path = cacheFilePath();
     QDir().mkpath(QFileInfo(path).absolutePath());

--- a/src/core/PskReporterClient.cpp
+++ b/src/core/PskReporterClient.cpp
@@ -606,7 +606,11 @@ void PskReporterClient::handleParsedHttpSnapshot(
         }
     }
     pruneOldSpots();
-    m_resultsLimited = snapshot.parsedReports > kMaxSpots;
+    // The request itself asks for kMaxSpots, so receiving exactly that many
+    // is already evidence that more global rows may have been truncated by
+    // the service. Surface the snapshot as capped rather than promising a
+    // complete multi-hour history at global scope.
+    m_resultsLimited = snapshot.parsedReports >= kMaxSpots;
     qCInfo(lcPskReporter) << "HTTP parsed" << added << "reception reports,"
                           << m_spots.size() << "total, lastSeqNo" << m_lastSeqNo;
     if (!snapshot.parseError.isEmpty()) {
@@ -813,8 +817,9 @@ QString PskReporterClient::cacheFilePath() const
 QString PskReporterClient::cacheFilePath(QueryScope scope,
                                          const QString& callsign) const
 {
-    const QString dir =
-        QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    const QString dir = m_cacheDirectoryOverride.isEmpty()
+        ? QStandardPaths::writableLocation(QStandardPaths::CacheLocation)
+        : m_cacheDirectoryOverride;
     const QString scopeKey = scope == QueryScope::Anyone
         ? QStringLiteral("anyone")
         : QString::fromLatin1(QCryptographicHash::hash(

--- a/src/core/PskReporterClient.cpp
+++ b/src/core/PskReporterClient.cpp
@@ -9,6 +9,7 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QFutureWatcher>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -19,6 +20,7 @@
 #include <QStandardPaths>
 #include <QUrlQuery>
 #include <QXmlStreamReader>
+#include <QtConcurrent/QtConcurrentRun>
 
 #include <QLoggingCategory>
 
@@ -116,7 +118,8 @@ void PskReporterClient::setLookbackSeconds(int seconds)
     // covered — is just a display change (the dialog filters spots() by the
     // current lookback), so it costs nothing and won't trip PSK Reporter's
     // rate limiter.
-    if (m_running && clamped > m_fetchedLookbackSec) {
+    if (m_running && m_httpPollingEnabled
+        && clamped > m_fetchedLookbackSec) {
         m_lastSeqNo = -1;  // force a deep backfill at the new depth
         poll();
     }
@@ -237,10 +240,16 @@ void PskReporterClient::poll()
             const int cachedStations = m_spots.size() + m_monitors.size();
             const QString nextTime = nextHttpRequestAt().toLocalTime().toString(
                 QStringLiteral("hh:mm:ss"));
+            const QString queryLabel =
+                m_scope == QueryScope::Anyone ? tr("all stations")
+                                              : m_callsign;
             emit statusChanged(cachedStations > 0
-                ? tr("Showing %1 cached station(s) — HTTP refresh throttled until %2")
-                      .arg(cachedStations).arg(nextTime)
-                : tr("HTTP refresh throttled until %1").arg(nextTime));
+                ? tr("Showing %1 cached station(s) for %2 — refresh queued "
+                     "until %3 by PSK Reporter's five-minute limit")
+                      .arg(cachedStations).arg(queryLabel, nextTime)
+                : tr("%1 filter queued until %2 by PSK Reporter's "
+                     "five-minute retrieval limit")
+                      .arg(queryLabel, nextTime));
             emit connectionStateChanged();
             return;
         }
@@ -253,8 +262,9 @@ void PskReporterClient::poll()
     m_lastHttpStatus = 0;
     m_lastHttpError.clear();
 
+    const QueryScope requestScope = httpQueryScope();
     QUrlQuery query;
-    if (m_scope == QueryScope::Callsign) {
+    if (requestScope == QueryScope::Callsign) {
         // Generic callsign matches both sent-by and received-by reports, as
         // the public PSK Reporter map does.
         query.addQueryItem(QStringLiteral("callsign"), m_callsign);
@@ -292,7 +302,8 @@ void PskReporterClient::poll()
     qCInfo(lcPskReporter) << "HTTP query"
                           << (initial ? "(initial)" : "(incremental)")
                           << "scope"
-                          << (m_scope == QueryScope::Anyone ? "anyone" : "callsign")
+                          << (requestScope == QueryScope::Anyone
+                                  ? "anyone" : "callsign")
                           << m_callsign
                           << "url" << url.toString(QUrl::RemoveQuery);
     emit statusChanged(tr("Updating…"));
@@ -301,7 +312,7 @@ void PskReporterClient::poll()
     m_queryReply = reply;
     const quint64 generation = m_queryGeneration;
     connect(reply, &QNetworkReply::finished, this,
-            [this, reply, initial, fetchDepth, generation] {
+            [this, reply, initial, fetchDepth, generation, requestScope] {
         m_fetchInFlight = false;
         if (m_queryReply == reply) {
             m_queryReply = nullptr;
@@ -382,8 +393,32 @@ void PskReporterClient::poll()
         emit connectionStateChanged();
         const QByteArray body = reply->readAll();
         qCInfo(lcPskReporter) << "HTTP reply" << body.size() << "bytes";
-        handleQueryReply(body);
+        // A global reply can contain thousands of reception reports and
+        // active receivers. Parse it away from the GUI thread so the map and
+        // unrelated waterfall remain responsive while the snapshot arrives.
+        auto* watcher = new QFutureWatcher<ParsedHttpSnapshot>(this);
+        connect(watcher, &QFutureWatcher<ParsedHttpSnapshot>::finished, this,
+                [this, watcher, generation, requestScope] {
+                    ParsedHttpSnapshot snapshot = watcher->result();
+                    watcher->deleteLater();
+                    if (generation != m_queryGeneration) {
+                        return;
+                    }
+                    handleParsedHttpSnapshot(std::move(snapshot),
+                                             requestScope);
+                });
+        watcher->setFuture(QtConcurrent::run(
+            &PskReporterClient::parseHttpSnapshot, body));
     });
+}
+
+PskReporterClient::QueryScope PskReporterClient::httpQueryScope() const
+{
+    // MQTT already supplies the selected callsign in real time. Use its one
+    // HTTP backfill slot for the reusable all-stations snapshot so clearing
+    // the map filter never has to wait another five minutes for global data.
+    return m_intervalMs == kLiveMqtt && m_scope == QueryScope::Callsign
+        ? QueryScope::Anyone : m_scope;
 }
 
 void PskReporterClient::scheduleHttpPollAtAllowedTime()
@@ -452,12 +487,11 @@ void PskReporterClient::saveHttpThrottleState() const
     }
 }
 
-void PskReporterClient::handleQueryReply(const QByteArray& xml)
+PskReporterClient::ParsedHttpSnapshot
+PskReporterClient::parseHttpSnapshot(const QByteArray& xml)
 {
+    ParsedHttpSnapshot snapshot;
     QXmlStreamReader reader(xml);
-    int added = 0;
-    int parsedReports = 0;
-    QVector<PskReporterMonitor> monitors;
     QSet<QString> monitorKeys;
     while (!reader.atEnd()) {
         reader.readNext();
@@ -466,7 +500,8 @@ void PskReporterClient::handleQueryReply(const QByteArray& xml)
         }
         const auto& attrs = reader.attributes();
         if (reader.name() == QLatin1String("lastSequenceNumber")) {
-            m_lastSeqNo = attrs.value(QLatin1String("value")).toLongLong();
+            snapshot.lastSeqNo =
+                attrs.value(QLatin1String("value")).toLongLong();
             continue;
         }
         if (reader.name() == QLatin1String("activeReceiver")) {
@@ -486,17 +521,17 @@ void PskReporterClient::handleQueryReply(const QByteArray& xml)
                               + monitor.locator;
             if (!monitor.callsign.isEmpty() && !monitor.locator.isEmpty()
                 && !monitorKeys.contains(key)
-                && monitors.size() < kMaxMonitors) {
+                && snapshot.monitors.size() < kMaxMonitors) {
                 monitorKeys.insert(key);
-                monitors.append(monitor);
+                snapshot.monitors.append(monitor);
             }
             continue;
         }
         if (reader.name() != QLatin1String("receptionReport")) {
             continue;
         }
-        ++parsedReports;
-        if (parsedReports > kMaxSpots) {
+        ++snapshot.parsedReports;
+        if (snapshot.parsedReports > kMaxSpots) {
             continue;
         }
         PskReporterSpot spot;
@@ -517,22 +552,69 @@ void PskReporterClient::handleQueryReply(const QByteArray& xml)
         spot.flowStartSeconds =
             attrs.value(QLatin1String("flowStartSeconds")).toLongLong();
         if (!spot.receiverCallsign.isEmpty()) {
+            appendSpot(snapshot.spots, spot);
+        }
+    }
+    if (reader.hasError()) {
+        snapshot.parseError = reader.errorString();
+    }
+    return snapshot;
+}
+
+void PskReporterClient::handleQueryReply(const QByteArray& xml,
+                                         QueryScope responseScope)
+{
+    handleParsedHttpSnapshot(parseHttpSnapshot(xml), responseScope);
+}
+
+void PskReporterClient::handleParsedHttpSnapshot(
+    ParsedHttpSnapshot snapshot, QueryScope responseScope)
+{
+    const bool globalBackfillForLiveCall = responseScope == QueryScope::Anyone
+        && m_scope == QueryScope::Callsign && m_intervalMs == kLiveMqtt;
+    int added = 0;
+
+    if (globalBackfillForLiveCall) {
+        // Persist immediately: the user may clear the callsign before the
+        // periodic cache writer runs. The matching rows also seed the current
+        // callsign view until MQTT supplies newer reports.
+        if (snapshot.parseError.isEmpty()) {
+            saveCacheSnapshot(QueryScope::Anyone, QString(), snapshot.spots,
+                              snapshot.monitors);
+        }
+        for (const PskReporterSpot& spot : snapshot.spots) {
+            if (spot.receiverCallsign.compare(
+                    m_callsign, Qt::CaseInsensitive) == 0
+                || spot.senderCallsign.compare(
+                       m_callsign, Qt::CaseInsensitive) == 0) {
+                appendSpot(spot);
+                ++added;
+            }
+        }
+        // A later HTTP fallback must request another complete global
+        // snapshot; an incremental response alone cannot replace the cache.
+        m_lastSeqNo = -1;
+    } else {
+        m_lastSeqNo = snapshot.lastSeqNo;
+        for (const PskReporterSpot& spot : snapshot.spots) {
             appendSpot(spot);
             ++added;
         }
+        if (m_scope == QueryScope::Anyone) {
+            m_monitors = snapshot.monitors;
+            m_cacheDirty = true;
+        }
     }
     pruneOldSpots();
-    if (m_scope == QueryScope::Anyone) {
-        m_monitors = monitors;
-        m_cacheDirty = true;
-    }
-    m_resultsLimited = parsedReports > kMaxSpots;
+    m_resultsLimited = snapshot.parsedReports > kMaxSpots;
     qCInfo(lcPskReporter) << "HTTP parsed" << added << "reception reports,"
                           << m_spots.size() << "total, lastSeqNo" << m_lastSeqNo;
-    if (reader.hasError()) {
-        qCWarning(lcPskReporter) << "XML parse error:" << reader.errorString();
+    if (!snapshot.parseError.isEmpty()) {
+        qCWarning(lcPskReporter) << "XML parse error:" << snapshot.parseError;
     }
-    emit statusChanged(m_scope == QueryScope::Anyone
+    emit statusChanged(globalBackfillForLiveCall
+                           ? tr("Live (MQTT) — global snapshot cached")
+                           : m_scope == QueryScope::Anyone
                            ? tr("Updated %1 (%2 reports, %3 active monitors)%4")
                                  .arg(QDateTime::currentDateTime()
                                           .toString(QStringLiteral("hh:mm")))
@@ -565,23 +647,36 @@ void PskReporterClient::startMqtt()
             emit statusChanged(tr("Live (MQTT) — connected"));
         });
         connect(m_mqtt, &MqttClient::disconnected, this, [this] {
+            if (!m_running) {
+                return;
+            }
             qCWarning(lcPskReporter) << "MQTT disconnected from" << kMqttHost;
             startFallbackPolling();
             emit connectionStateChanged();
-            emit statusChanged(tr("Live — reconnecting (polling meanwhile)…"));
+            emit statusChanged(m_httpPollingEnabled
+                ? tr("Live — reconnecting (polling meanwhile)…")
+                : tr("Live — reconnecting…"));
         });
         connect(m_mqtt, &MqttClient::connectionError, this,
                 [this](const QString& err) {
-                    qCWarning(lcPskReporter) << "MQTT error:" << err
-                                             << "— falling back to HTTP polling";
+                    if (!m_running) {
+                        return;
+                    }
+                    qCWarning(lcPskReporter) << "MQTT error:" << err;
                     m_sawError = true;
                     startFallbackPolling();
                     emit connectionStateChanged();
-                    emit statusChanged(tr("Live unavailable — polling every 5 min"));
+                    emit statusChanged(m_httpPollingEnabled
+                        ? tr("Live unavailable — polling every 5 min")
+                        : tr("Live unavailable — reconnecting…"));
                 });
     }
-    // Live feed has no backfill; seed the window with one HTTP query.
-    poll();
+    // Live feed has no backfill. A standalone client seeds the window with
+    // HTTP; the map's dual-layer mode delegates that cadence to its dedicated
+    // all-stations client instead.
+    if (m_httpPollingEnabled) {
+        poll();
+    }
     m_mqtt->setSubscriptions({
         QStringLiteral("pskr/filter/v2/+/+/%1/#").arg(m_callsign),
         QStringLiteral("pskr/filter/v2/+/+/+/%1/#").arg(m_callsign)
@@ -604,7 +699,8 @@ void PskReporterClient::startFallbackPolling()
 {
     // Only meaningful in Live mode; the explicit poll tiers manage m_timer
     // themselves. Don't double-start.
-    if (m_intervalMs != kLiveMqtt || m_timer.isActive()) {
+    if (!m_running || !m_httpPollingEnabled || m_intervalMs != kLiveMqtt
+        || m_timer.isActive()) {
         return;
     }
     m_timer.start(kFallbackPollMs);
@@ -654,23 +750,31 @@ void PskReporterClient::handleMqttMessage(const QString& topic,
 
 void PskReporterClient::appendSpot(const PskReporterSpot& spot)
 {
+    if (appendSpot(m_spots, spot)) {
+        m_cacheDirty = true;
+    }
+}
+
+bool PskReporterClient::appendSpot(QVector<PskReporterSpot>& spots,
+                                   const PskReporterSpot& spot)
+{
     // Retain one latest report for each sender/receiver pair.  Generic
     // callsign queries can return reports in either direction, and the
     // anyone view needs distinct paths rather than one receiver-only record.
-    auto it = std::find_if(m_spots.begin(), m_spots.end(),
+    auto it = std::find_if(spots.begin(), spots.end(),
                            [&spot](const PskReporterSpot& s) {
                                return s.receiverCallsign == spot.receiverCallsign
                                    && s.senderCallsign == spot.senderCallsign;
                            });
-    if (it != m_spots.end()) {
+    if (it != spots.end()) {
         if (spot.flowStartSeconds >= it->flowStartSeconds) {
             *it = spot;
-            m_cacheDirty = true;
+            return true;
         }
-        return;
+        return false;
     }
-    m_spots.append(spot);
-    m_cacheDirty = true;
+    spots.append(spot);
+    return true;
 }
 
 void PskReporterClient::pruneOldSpots()
@@ -703,12 +807,18 @@ void PskReporterClient::pruneOldSpots()
 
 QString PskReporterClient::cacheFilePath() const
 {
+    return cacheFilePath(m_scope, m_callsign);
+}
+
+QString PskReporterClient::cacheFilePath(QueryScope scope,
+                                         const QString& callsign) const
+{
     const QString dir =
         QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
-    const QString scopeKey = m_scope == QueryScope::Anyone
+    const QString scopeKey = scope == QueryScope::Anyone
         ? QStringLiteral("anyone")
         : QString::fromLatin1(QCryptographicHash::hash(
-              m_callsign.toUtf8(), QCryptographicHash::Sha256).toHex().left(16));
+              callsign.toUtf8(), QCryptographicHash::Sha256).toHex().left(16));
     return dir + QDir::separator()
          + QStringLiteral("psk-reporter-spots-%1.json").arg(scopeKey);
 }
@@ -765,23 +875,8 @@ void PskReporterClient::loadCache()
         && savedAt >= QDateTime::currentSecsSinceEpoch()
                          - (2 * kMinPollMs / 1000);
     if (m_scope == QueryScope::Anyone && monitorSnapshotFresh) {
-        const QJsonArray monitorArray =
-            root.value(QLatin1String("monitors")).toArray();
-        for (const QJsonValue& value : monitorArray) {
-            const QJsonObject o = value.toObject();
-            PskReporterMonitor monitor;
-            monitor.callsign = o.value(QLatin1String("c")).toString();
-            monitor.locator = o.value(QLatin1String("l")).toString();
-            monitor.mode = o.value(QLatin1String("m")).toString();
-            monitor.decoderSoftware =
-                o.value(QLatin1String("s")).toString();
-            monitor.frequencyHz = static_cast<qint64>(
-                o.value(QLatin1String("f")).toDouble());
-            if (!monitor.callsign.isEmpty() && !monitor.locator.isEmpty()
-                && m_monitors.size() < kMaxMonitors) {
-                m_monitors.append(monitor);
-            }
-        }
+        restoreCachedMonitors(
+            root.value(QLatin1String("monitors")).toArray());
     }
     m_cacheDirty = legacyCache;
     qCInfo(lcPskReporter) << "loaded" << loaded << "cached spots for"
@@ -792,10 +887,45 @@ void PskReporterClient::loadCache()
     }
 }
 
+void PskReporterClient::restoreCachedMonitors(
+    const QJsonArray& monitorArray)
+{
+    m_monitors.clear();
+    QSet<QString> monitorKeys;
+    for (const QJsonValue& value : monitorArray) {
+        const QJsonObject o = value.toObject();
+        PskReporterMonitor monitor;
+        monitor.callsign = o.value(QLatin1String("c")).toString();
+        monitor.locator = o.value(QLatin1String("l")).toString();
+        monitor.mode = o.value(QLatin1String("m")).toString();
+        monitor.decoderSoftware =
+            o.value(QLatin1String("s")).toString();
+        monitor.frequencyHz = static_cast<qint64>(
+            o.value(QLatin1String("f")).toDouble());
+        const QString key = monitor.callsign + QLatin1Char('|')
+                          + monitor.locator;
+        if (!monitor.callsign.isEmpty() && !monitor.locator.isEmpty()
+            && !monitorKeys.contains(key)
+            && m_monitors.size() < kMaxMonitors) {
+            monitorKeys.insert(key);
+            m_monitors.append(monitor);
+        }
+    }
+}
+
 void PskReporterClient::saveCache()
 {
+    saveCacheSnapshot(m_scope, m_callsign, m_spots, m_monitors);
+    m_cacheDirty = false;
+}
+
+void PskReporterClient::saveCacheSnapshot(
+    QueryScope scope, const QString& callsign,
+    const QVector<PskReporterSpot>& spots,
+    const QVector<PskReporterMonitor>& monitors) const
+{
     QJsonArray arr;
-    for (const PskReporterSpot& s : std::as_const(m_spots)) {
+    for (const PskReporterSpot& s : spots) {
         QJsonObject o;
         o[QLatin1String("rc")] = s.receiverCallsign;
         o[QLatin1String("rl")] = s.receiverLocator;
@@ -808,13 +938,13 @@ void PskReporterClient::saveCache()
         arr.append(o);
     }
     QJsonObject root;
-    root[QLatin1String("callsign")] = m_callsign;
+    root[QLatin1String("callsign")] = callsign;
     root[QLatin1String("saved")] =
         static_cast<double>(QDateTime::currentSecsSinceEpoch());
     root[QLatin1String("spots")] = arr;
-    if (m_scope == QueryScope::Anyone) {
+    if (scope == QueryScope::Anyone) {
         QJsonArray monitorArray;
-        for (const PskReporterMonitor& monitor : std::as_const(m_monitors)) {
+        for (const PskReporterMonitor& monitor : monitors) {
             QJsonObject o;
             o[QLatin1String("c")] = monitor.callsign;
             o[QLatin1String("l")] = monitor.locator;
@@ -826,7 +956,7 @@ void PskReporterClient::saveCache()
         root[QLatin1String("monitors")] = monitorArray;
     }
 
-    const QString path = cacheFilePath();
+    const QString path = cacheFilePath(scope, callsign);
     QDir().mkpath(QFileInfo(path).absolutePath());
     QSaveFile f(path);
     if (!f.open(QIODevice::WriteOnly)) {
@@ -834,8 +964,9 @@ void PskReporterClient::saveCache()
         return;
     }
     f.write(QJsonDocument(root).toJson(QJsonDocument::Compact));
-    f.commit();
-    m_cacheDirty = false;
+    if (!f.commit()) {
+        qCWarning(lcPskReporter) << "could not commit spot cache:" << path;
+    }
 }
 
 } // namespace AetherSDR

--- a/src/core/PskReporterClient.cpp
+++ b/src/core/PskReporterClient.cpp
@@ -26,6 +26,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <memory>
 
 Q_LOGGING_CATEGORY(lcPskReporter, "aether.pskreporter")
 
@@ -309,10 +310,46 @@ void PskReporterClient::poll()
     emit statusChanged(tr("Updating…"));
     emit connectionStateChanged();
     QNetworkReply* reply = m_nam.get(req);
+    // Drain incrementally so Qt never accumulates the entire decompressed XML
+    // body inside QNetworkReply before finished(). The read buffer is a second
+    // bound around the data waiting to be drained; Qt documents it as a
+    // throttle rather than an exact ceiling, so the accumulator enforces the
+    // authoritative limit below.
+    reply->setReadBufferSize(kHttpReadBufferBytes);
+    auto responseBody = std::make_shared<QByteArray>();
+    auto responseTooLarge = std::make_shared<bool>(false);
+    const auto drainReply = [reply, responseBody, responseTooLarge] {
+        while (!*responseTooLarge && reply->bytesAvailable() > 0) {
+            const qint64 remaining = kMaxHttpResponseBytes
+                - static_cast<qint64>(responseBody->size());
+            const qint64 readSize = qMin(kHttpReadBufferBytes, remaining + 1);
+            const QByteArray chunk = reply->read(readSize);
+            if (chunk.isEmpty()) {
+                break;
+            }
+            if (!appendHttpResponseChunk(*responseBody, chunk)) {
+                *responseTooLarge = true;
+                reply->abort();
+            }
+        }
+    };
+    connect(reply, &QNetworkReply::metaDataChanged, this,
+            [reply, responseTooLarge] {
+        const QVariant contentLength = reply->header(
+            QNetworkRequest::ContentLengthHeader);
+        if (contentLength.isValid()
+            && contentLength.toLongLong() > kMaxHttpResponseBytes) {
+            *responseTooLarge = true;
+            reply->abort();
+        }
+    });
+    connect(reply, &QIODevice::readyRead, this, drainReply);
     m_queryReply = reply;
     const quint64 generation = m_queryGeneration;
     connect(reply, &QNetworkReply::finished, this,
-            [this, reply, initial, fetchDepth, generation, requestScope] {
+            [this, reply, initial, fetchDepth, generation, requestScope,
+             responseBody, responseTooLarge, drainReply] {
+        drainReply();
         m_fetchInFlight = false;
         if (m_queryReply == reply) {
             m_queryReply = nullptr;
@@ -322,6 +359,19 @@ void PskReporterClient::poll()
             if (m_running) {
                 QTimer::singleShot(0, this, &PskReporterClient::poll);
             }
+            return;
+        }
+        if (*responseTooLarge) {
+            m_lastHttpStatus = reply->attribute(
+                QNetworkRequest::HttpStatusCodeAttribute).toInt();
+            m_lastHttpError = tr("Response exceeded the %1 MiB safety limit")
+                                  .arg(kMaxHttpResponseBytes / (1024 * 1024));
+            qCWarning(lcPskReporter) << m_lastHttpError;
+            m_lastHttpOk = false;
+            m_sawError = true;
+            emit connectionStateChanged();
+            emit statusChanged(tr("PSK Reporter error: %1")
+                                   .arg(m_lastHttpError));
             return;
         }
         if (reply->error() != QNetworkReply::NoError) {
@@ -391,7 +441,7 @@ void PskReporterClient::poll()
         m_lastHttpOk = true;
         m_sawError = false;
         emit connectionStateChanged();
-        const QByteArray body = reply->readAll();
+        QByteArray body = std::move(*responseBody);
         qCInfo(lcPskReporter) << "HTTP reply" << body.size() << "bytes";
         // A global reply can contain thousands of reception reports and
         // active receivers. Parse it away from the GUI thread so the map and
@@ -410,6 +460,19 @@ void PskReporterClient::poll()
         watcher->setFuture(QtConcurrent::run(
             &PskReporterClient::parseHttpSnapshot, body));
     });
+}
+
+bool PskReporterClient::appendHttpResponseChunk(QByteArray& response,
+                                                const QByteArray& chunk)
+{
+    const qint64 responseSize = static_cast<qint64>(response.size());
+    const qint64 chunkSize = static_cast<qint64>(chunk.size());
+    if (responseSize > kMaxHttpResponseBytes
+        || chunkSize > kMaxHttpResponseBytes - responseSize) {
+        return false;
+    }
+    response.append(chunk);
+    return true;
 }
 
 PskReporterClient::QueryScope PskReporterClient::httpQueryScope() const

--- a/src/core/PskReporterClient.h
+++ b/src/core/PskReporterClient.h
@@ -9,6 +9,7 @@
 #include <QVector>
 
 class QNetworkReply;
+class QJsonArray;
 
 namespace AetherSDR {
 
@@ -35,7 +36,7 @@ struct PskReporterMonitor {
     qint64 frequencyHz{0};
 };
 
-// Fetches reception reports of our callsign from pskreporter.info.
+// Fetches reception reports for the selected map scope from pskreporter.info.
 //
 // Two transports:
 //   * HTTP polling of https://retrieve.pskreporter.info/query — XML
@@ -44,7 +45,8 @@ struct PskReporterMonitor {
 //     minutes and `lastseqno` is used so repeat polls are incremental.
 //     There is deliberately NO manual-refresh path.
 //   * Live MQTT (mqtt.pskreporter.info, TLS) — the officially sanctioned
-//     real-time feed; used when intervalMs == kLiveMqtt.
+//     real-time callsign feed; used when intervalMs == kLiveMqtt. The map's
+//     separate global client owns the reusable all-stations snapshot.
 class PskReporterClient : public QObject {
     Q_OBJECT
 
@@ -63,6 +65,10 @@ public:
     void setCallsign(const QString& callsign);
     QString callsign() const { return m_callsign; }
     QueryScope queryScope() const { return m_scope; }
+
+    // A dedicated MQTT layer can disable its HTTP seed/fallback when a
+    // separate all-stations client already owns the shared HTTP cadence.
+    void setHttpPollingEnabled(bool enabled) { m_httpPollingEnabled = enabled; }
 
     // Lookback window (seconds): how far back spots are backfilled and
     // retained/displayed. Clamped to the PSK Reporter 24h API ceiling.
@@ -104,9 +110,19 @@ private slots:
 private:
     friend class PskReporterClientTestAccess;
 
-    void handleQueryReply(const QByteArray& xml);
+    struct ParsedHttpSnapshot {
+        QVector<PskReporterSpot> spots;
+        QVector<PskReporterMonitor> monitors;
+        qint64 lastSeqNo{-1};
+        int parsedReports{0};
+        QString parseError;
+    };
+
+    void handleQueryReply(const QByteArray& xml, QueryScope responseScope);
     void handleMqttMessage(const QString& topic, const QByteArray& payload);
     void appendSpot(const PskReporterSpot& spot);
+    static bool appendSpot(QVector<PskReporterSpot>& spots,
+                           const PskReporterSpot& spot);
     void pruneOldSpots();
     void startMqtt();
     void stopMqtt();
@@ -117,13 +133,22 @@ private:
     void loadHttpThrottleState();
     void saveHttpThrottleState() const;
     static qint64 rateLimitBackoffMs(int consecutiveRateLimits);
+    QueryScope httpQueryScope() const;
+    static ParsedHttpSnapshot parseHttpSnapshot(const QByteArray& xml);
+    void handleParsedHttpSnapshot(ParsedHttpSnapshot snapshot,
+                                  QueryScope responseScope);
 
     // Disk persistence: spots survive a client restart within the tombstone
     // window (kSpotTtlSeconds) so the map repopulates immediately on reopen
     // over the course of a day, rather than waiting for fresh reports.
     QString cacheFilePath() const;
+    QString cacheFilePath(QueryScope scope, const QString& callsign) const;
     void loadCache();
     void saveCache();
+    void saveCacheSnapshot(QueryScope scope, const QString& callsign,
+                           const QVector<PskReporterSpot>& spots,
+                           const QVector<PskReporterMonitor>& monitors) const;
+    void restoreCachedMonitors(const QJsonArray& monitorArray);
 
     QNetworkAccessManager m_nam;
     QTimer m_timer;
@@ -139,6 +164,7 @@ private:
     int    m_lookbackSec{kDefaultLookbackSec};
     int    m_fetchedLookbackSec{0};  // deepest window backfilled this session
     bool   m_running{false};
+    bool   m_httpPollingEnabled{true};
     bool   m_fetchInFlight{false};
     QPointer<QNetworkReply> m_queryReply;
     quint64 m_queryGeneration{0};

--- a/src/core/PskReporterClient.h
+++ b/src/core/PskReporterClient.h
@@ -163,6 +163,7 @@ private:
     int    m_intervalMs{kMinPollMs};
     int    m_lookbackSec{kDefaultLookbackSec};
     int    m_fetchedLookbackSec{0};  // deepest window backfilled this session
+    QString m_cacheDirectoryOverride;  // test isolation; empty in production
     bool   m_running{false};
     bool   m_httpPollingEnabled{true};
     bool   m_fetchInFlight{false};

--- a/src/core/PskReporterClient.h
+++ b/src/core/PskReporterClient.h
@@ -134,6 +134,8 @@ private:
     void saveHttpThrottleState() const;
     static qint64 rateLimitBackoffMs(int consecutiveRateLimits);
     QueryScope httpQueryScope() const;
+    static bool appendHttpResponseChunk(QByteArray& response,
+                                        const QByteArray& chunk);
     static ParsedHttpSnapshot parseHttpSnapshot(const QByteArray& xml);
     void handleParsedHttpSnapshot(ParsedHttpSnapshot snapshot,
                                   QueryScope responseScope);
@@ -196,6 +198,10 @@ private:
     static constexpr quint16 kMqttPort = 1883;
     static constexpr int kMaxSpots = 2000;
     static constexpr int kMaxMonitors = 6000;
+    // Bound the decompressed XML body, including activeReceiver rows whose
+    // count is not limited by the PSK Reporter retrieval API.
+    static constexpr qint64 kMaxHttpResponseBytes = 16 * 1024 * 1024;
+    static constexpr qint64 kHttpReadBufferBytes = 64 * 1024;
     // HTTP fallback poll cadence when MQTT can't connect (port blocked etc.).
     static constexpr int kFallbackPollMs = 5 * 60 * 1000;
     static constexpr qint64 kRateLimitBaseMs = 15 * 60 * 1000;

--- a/src/core/PskReporterClient.h
+++ b/src/core/PskReporterClient.h
@@ -3,13 +3,17 @@
 #include <QDateTime>
 #include <QNetworkAccessManager>
 #include <QObject>
+#include <QPointer>
 #include <QString>
 #include <QTimer>
 #include <QVector>
 
+class QNetworkReply;
+
 namespace AetherSDR {
 
 class MqttClient;
+class PskReporterClientTestAccess;
 
 // One reception report of our transmitted signal.
 struct PskReporterSpot {
@@ -21,6 +25,14 @@ struct PskReporterSpot {
     qint64  frequencyHz{0};
     int     snr{-999};        // dB, -999 = not reported
     qint64  flowStartSeconds{0};
+};
+
+struct PskReporterMonitor {
+    QString callsign;
+    QString locator;
+    QString mode;
+    QString decoderSoftware;
+    qint64 frequencyHz{0};
 };
 
 // Fetches reception reports of our callsign from pskreporter.info.
@@ -37,6 +49,11 @@ class PskReporterClient : public QObject {
     Q_OBJECT
 
 public:
+    enum class QueryScope {
+        Callsign,
+        Anyone
+    };
+
     static constexpr int kMinPollMs = 5 * 60 * 1000;   // PSK Reporter policy
     static constexpr int kLiveMqtt  = -1;              // sentinel interval
 
@@ -45,6 +62,7 @@ public:
 
     void setCallsign(const QString& callsign);
     QString callsign() const { return m_callsign; }
+    QueryScope queryScope() const { return m_scope; }
 
     // Lookback window (seconds): how far back spots are backfilled and
     // retained/displayed. Clamped to the PSK Reporter 24h API ceiling.
@@ -59,12 +77,19 @@ public:
 
     // Spots retained in the rolling lookback window, capped.
     const QVector<PskReporterSpot>& spots() const { return m_spots; }
+    const QVector<PskReporterMonitor>& monitors() const { return m_monitors; }
+    bool resultsLimited() const { return m_resultsLimited; }
 
     // Connection state for the UI indicator.
     bool isLive() const { return m_running && m_intervalMs == kLiveMqtt; }
     bool isMqttConnected() const;
     bool lastHttpOk() const { return m_lastHttpOk; }
     bool sawError() const { return m_sawError; }
+    bool httpRequestInFlight() const { return m_fetchInFlight; }
+    int lastHttpStatus() const { return m_lastHttpStatus; }
+    QString lastHttpError() const { return m_lastHttpError; }
+    QDateTime lastHttpRequestAt() const;
+    QDateTime nextHttpRequestAt() const;
     // "MQTT" when the live broker is connected, else "HTTP".
     QString transport() const;
 
@@ -77,6 +102,8 @@ private slots:
     void poll();
 
 private:
+    friend class PskReporterClientTestAccess;
+
     void handleQueryReply(const QByteArray& xml);
     void handleMqttMessage(const QString& topic, const QByteArray& payload);
     void appendSpot(const PskReporterSpot& spot);
@@ -85,6 +112,11 @@ private:
     void stopMqtt();
     // Begin (or keep) HTTP polling as a fallback while MQTT is unavailable.
     void startFallbackPolling();
+    void scheduleHttpPollAtAllowedTime();
+    QString httpThrottleStateFilePath() const;
+    void loadHttpThrottleState();
+    void saveHttpThrottleState() const;
+    static qint64 rateLimitBackoffMs(int consecutiveRateLimits);
 
     // Disk persistence: spots survive a client restart within the tombstone
     // window (kSpotTtlSeconds) so the map repopulates immediately on reopen
@@ -97,17 +129,28 @@ private:
     QTimer m_timer;
     QTimer m_mqttHealthTimer;
     QTimer m_saveTimer;
+    QTimer m_httpThrottleTimer;
     QString m_callsign;
+    QueryScope m_scope{QueryScope::Callsign};
     QVector<PskReporterSpot> m_spots;
+    QVector<PskReporterMonitor> m_monitors;
     qint64 m_lastSeqNo{-1};
     int    m_intervalMs{kMinPollMs};
     int    m_lookbackSec{kDefaultLookbackSec};
     int    m_fetchedLookbackSec{0};  // deepest window backfilled this session
     bool   m_running{false};
     bool   m_fetchInFlight{false};
+    QPointer<QNetworkReply> m_queryReply;
+    quint64 m_queryGeneration{0};
     bool   m_cacheDirty{false};
     bool   m_lastHttpOk{false};
     bool   m_sawError{false};
+    bool   m_resultsLimited{false};
+    int    m_lastHttpStatus{0};
+    QString m_lastHttpError;
+    qint64 m_lastHttpRequestEpochMs{0};
+    qint64 m_nextHttpAllowedEpochMs{0};
+    int m_consecutiveRateLimits{0};
     MqttClient* m_mqtt{nullptr};
 
     // MQTT feed health counters, summarized to the log periodically.
@@ -125,8 +168,11 @@ private:
     // MQTT behaves identically on every platform with no CA handling.
     static constexpr quint16 kMqttPort = 1883;
     static constexpr int kMaxSpots = 2000;
+    static constexpr int kMaxMonitors = 6000;
     // HTTP fallback poll cadence when MQTT can't connect (port blocked etc.).
     static constexpr int kFallbackPollMs = 5 * 60 * 1000;
+    static constexpr qint64 kRateLimitBaseMs = 15 * 60 * 1000;
+    static constexpr qint64 kRateLimitMaxMs = 2 * 60 * 60 * 1000;
     // PSK Reporter's retrieval API caps flowStartSeconds at 24h; the lookback
     // window can't exceed that. Default to 1 hour.
     static constexpr int kMaxLookbackSec = 24 * 60 * 60;

--- a/src/gui/PskReporterMapDialog.cpp
+++ b/src/gui/PskReporterMapDialog.cpp
@@ -174,10 +174,12 @@ QString buildSpotCard(const PskReporterSpot& spot, bool hasHome,
         QString::number(spot.frequencyHz / 1e6, 'f', 3);
     QString html = QStringLiteral("<div style='white-space:nowrap;'>");
 
-    // Line 1 — identity.
-    html += QStringLiteral("<b>%1</b>&nbsp;&nbsp;"
-                           "<span style='color:%2;'>%3</span>")
-                .arg(spot.receiverCallsign.toHtmlEscaped(),
+    // Line 1 — both endpoints. Generic callsign searches include sent and
+    // received reports, so receiver-only wording would be ambiguous.
+    html += QStringLiteral("<b>%1</b> → <b>%2</b>&nbsp;&nbsp;"
+                           "<span style='color:%3;'>%4</span>")
+                .arg(spot.senderCallsign.toHtmlEscaped(),
+                     spot.receiverCallsign.toHtmlEscaped(),
                      QString::fromLatin1(kCardMuted),
                      spot.receiverLocator.toHtmlEscaped());
 
@@ -238,27 +240,43 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
     root->setContentsMargins(6, 6, 6, 6);
     root->setSpacing(6);
 
-    auto* topBar = new QHBoxLayout();
+    auto* filtersBar = new QHBoxLayout();
 
-    topBar->addWidget(new QLabel(tr("Band:"), bodyWidget()));
+    filtersBar->addWidget(new QLabel(tr("Call:"), bodyWidget()));
+    m_queryCallsign = new QLineEdit(bodyWidget());
+    m_queryCallsign->setMaxLength(32);
+    m_queryCallsign->setFixedWidth(100);
+    m_queryCallsign->setObjectName(QStringLiteral("pskReporterCallsign"));
+    m_queryCallsign->setAccessibleName(tr("PSK Reporter map callsign"));
+    m_queryCallsign->setAccessibleDescription(
+        tr("Enter a callsign to show reports sent or received by it; clear "
+           "the field to show reports and active monitors for anyone"));
+    m_queryCallsign->setToolTip(
+        tr("Blank shows all callsigns in the selected timeframe"));
+    // The public map is the default view. A callsign is an explicit filter,
+    // not a mirror of the station setting.
+    m_queryCallsign->clear();
+    filtersBar->addWidget(m_queryCallsign);
+
+    filtersBar->addWidget(new QLabel(tr("Band:"), bodyWidget()));
     m_bandCombo = new QComboBox(bodyWidget());
     m_bandCombo->addItem(tr("All"));
     for (const char* b : { "160m", "80m", "60m", "40m", "30m", "20m",
                            "17m", "15m", "12m", "10m", "6m", "VHF+" }) {
         m_bandCombo->addItem(QString::fromLatin1(b));
     }
-    topBar->addWidget(m_bandCombo);
+    filtersBar->addWidget(m_bandCombo);
 
-    topBar->addWidget(new QLabel(tr("Mode:"), bodyWidget()));
+    filtersBar->addWidget(new QLabel(tr("Mode:"), bodyWidget()));
     m_modeCombo = new QComboBox(bodyWidget());
     m_modeCombo->addItem(tr("All"));
     for (const char* m : { "FT8", "FT4", "WSPR", "JS8", "CW", "PSK",
                            "RTTY", "SSB", "Other" }) {
         m_modeCombo->addItem(QString::fromLatin1(m));
     }
-    topBar->addWidget(m_modeCombo);
+    filtersBar->addWidget(m_modeCombo);
 
-    topBar->addWidget(new QLabel(tr("Lookback:"), bodyWidget()));
+    filtersBar->addWidget(new QLabel(tr("Lookback:"), bodyWidget()));
     m_lookbackCombo = new QComboBox(bodyWidget());
     m_lookbackCombo->addItem(tr("15 min"), 15 * 60);
     m_lookbackCombo->addItem(tr("30 min"), 30 * 60);
@@ -266,9 +284,11 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
     m_lookbackCombo->addItem(tr("2 hours"), 2 * 60 * 60);
     m_lookbackCombo->addItem(tr("4 hours"), 4 * 60 * 60);
     m_lookbackCombo->addItem(tr("8 hours"), 8 * 60 * 60);
-    topBar->addWidget(m_lookbackCombo);
+    filtersBar->addWidget(m_lookbackCombo);
+    filtersBar->addStretch(1);
+    root->addLayout(filtersBar);
 
-    topBar->addSpacing(12);
+    auto* topBar = new QHBoxLayout();
     topBar->addWidget(new QLabel(tr("Update every:"), bodyWidget()));
 
     m_intervalCombo = new QComboBox(bodyWidget());
@@ -283,9 +303,18 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
     topBar->addWidget(m_intervalCombo);
 
     m_pathsCheck = new QCheckBox(tr("Paths"), bodyWidget());
-    m_pathsCheck->setToolTip(tr("Draw great-circle paths from your station to each receiver"));
-    m_pathsCheck->setChecked(pskSettings().value("showPaths").toBool(true));
+    m_pathsCheck->setObjectName(QStringLiteral("pskReporterPaths"));
+    m_pathsCheck->setToolTip(
+        tr("Draw great-circle report paths between transmitting and receiving stations"));
+    m_pathsCheck->setChecked(pskSettings().value("showPaths").toBool(false));
     topBar->addWidget(m_pathsCheck);
+
+    m_terminatorCheck = new QCheckBox(tr("Day/night"), bodyWidget());
+    m_terminatorCheck->setToolTip(tr("Show the current night shadow on the map"));
+    m_terminatorCheck->setAccessibleName(tr("Show day and night terminator"));
+    m_terminatorCheck->setChecked(
+        pskSettings().value("showTerminator").toBool(true));
+    topBar->addWidget(m_terminatorCheck);
 
     // Persistent reception stats, pinned to the top-right corner.
     topBar->addStretch(1);
@@ -300,13 +329,13 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
     beaconRow->setContentsMargins(6, 4, 6, 4);
     beaconRow->setSpacing(6);
 
-    beaconRow->addWidget(new QLabel(tr("Call:"), beaconBox));
+    beaconRow->addWidget(new QLabel(tr("TX call:"), beaconBox));
     m_beaconCallsign = new QLineEdit(beaconBox);
     m_beaconCallsign->setMaxLength(6);
     m_beaconCallsign->setFixedWidth(76);
     m_beaconCallsign->setAccessibleName(tr("WSPR callsign"));
     m_beaconCallsign->setAccessibleDescription(
-        tr("Standard callsign with a one-digit prefix"));
+        tr("Station callsign used for WSPR transmission; changes update the station callsign"));
     beaconRow->addWidget(m_beaconCallsign);
 
     beaconRow->addWidget(new QLabel(tr("Grid:"), beaconBox));
@@ -427,7 +456,10 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
     root->addWidget(beaconBox);
 
     m_mapView = new MapView(bodyWidget());
+    m_mapView->setObjectName(QStringLiteral("pskReporterMap"));
+    m_mapView->setAccessibleName(tr("PSK Reporter map"));
     m_mapView->setPathsVisible(m_pathsCheck->isChecked());
+    m_mapView->setDayNightTerminatorVisible(m_terminatorCheck->isChecked());
     {
         QVector<QPair<QString, QColor>> legend;
         for (const char* m : { "FT8", "FT4", "WSPR", "JS8", "CW", "PSK",
@@ -443,6 +475,14 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
         writePskSetting("showPaths", on);
         m_mapView->setPathsVisible(on);
     });
+    connect(m_terminatorCheck, &QCheckBox::toggled, this, [this](bool on) {
+        writePskSetting("showTerminator", on);
+        m_mapView->setDayNightTerminatorVisible(on);
+    });
+    connect(m_queryCallsign, &QLineEdit::editingFinished,
+            this, &PskReporterMapDialog::applyMapCallsign);
+    connect(m_queryCallsign, &QLineEdit::returnPressed,
+            this, &PskReporterMapDialog::applyMapCallsign);
     connect(m_mapView, &MapView::markerClicked, this,
             [](const MapView::Marker& marker) {
                 if (!marker.clickInfo.isEmpty()) {
@@ -478,6 +518,8 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
     // plus a status bullet (green=connected w/ data, yellow=no data,
     // red=no good connection).
     m_connLabel = new QLabel(bodyWidget());
+    m_connLabel->setObjectName(QStringLiteral("pskReporterConnection"));
+    m_connLabel->setAccessibleName(tr("PSK Reporter connection status"));
     m_connLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     bottomBar->addSpacing(10);
     bottomBar->addWidget(m_connLabel);
@@ -531,8 +573,20 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
             this, [this] { rebuildMarkers(); });
     connect(m_modeCombo, &QComboBox::currentIndexChanged,
             this, [this] { rebuildMarkers(); });
-    connect(m_client, &PskReporterClient::spotsUpdated,
+    // MQTT can deliver several reports in one short burst. Repainting the
+    // complete map for each message wastes work and can keep invalidating a
+    // render that is already in flight. The first report opens a short batch
+    // window; later reports join it rather than postponing it indefinitely.
+    m_markerRefreshTimer = new QTimer(this);
+    m_markerRefreshTimer->setSingleShot(true);
+    m_markerRefreshTimer->setInterval(250);
+    connect(m_markerRefreshTimer, &QTimer::timeout,
             this, &PskReporterMapDialog::rebuildMarkers);
+    connect(m_client, &PskReporterClient::spotsUpdated, this, [this] {
+        if (!m_markerRefreshTimer->isActive()) {
+            m_markerRefreshTimer->start();
+        }
+    });
     connect(m_client, &PskReporterClient::statusChanged,
             m_statusLabel, &QLabel::setText);
     connect(m_beaconButton, &QPushButton::clicked,
@@ -575,26 +629,14 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
         updateHomeFromRadio();
         rebuildMarkers();
     });
-    // The callsign writes through to the STATION callsign rather than to a
-    // beacon-private copy. There is one operator callsign, and splitting it
-    // would let the beacon transmit one identity while PSK Reporter queried
-    // another — which is exactly the confusing half-state this dialog was in:
-    // it queried RadioModel::callsign() for the map and read this field for the
-    // beacon, so on a radio that stores no callsign the map came up empty while
-    // the beacon happily transmitted whatever had been typed here.
-    //
-    // setStationCallsign() emits callsignChanged, which restarts the PSK client
-    // against the new callsign and refreshes the home marker — so typing it in
-    // either place now fixes both.
+    // The WSPR field is station-owned. It remains intentionally separate from
+    // the map-only Call filter above: editing this field updates the persisted
+    // station identity, while editing or clearing the map filter never does.
     connect(m_beaconCallsign, &QLineEdit::editingFinished, this, [this] {
         const QString call = m_beaconCallsign->text().trimmed().toUpper();
         m_beaconCallsign->setText(call);
-        // Empty is "no change", never "erase". Writing through on empty would
-        // let clearing this field wipe the persisted StationCallsign — one
-        // stray select-all-delete and PSK Reporter, the beacon and QRZ
-        // own-callsign lookup all lose the station's identity, with no undo.
-        // (PR #4537 review.) Clearing the field is how an operator retypes it;
-        // it is not how they retire a callsign.
+        // Empty is "no change", never "erase". This preserves the existing
+        // guard against an accidental select-all/delete wiping station state.
         if (call.isEmpty()) {
             return;
         }
@@ -659,14 +701,10 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
     if (m_radioModel != nullptr) {
         connect(m_radioModel, &RadioModel::gpsStatusChanged,
                 this, [this] { updateHomeFromRadio(); });
-        // Pick up a late-arriving or edited callsign without a reopen.
-        // restartClient() (not setCallsign alone) so a callsign that was
-        // empty when the window opened actually starts the client.
+        // A late station callsign updates station-owned features only. The map
+        // query stays empty until the operator explicitly enters a filter.
         connect(m_radioModel, &RadioModel::callsignChanged, this,
                 [this] {
-                    if (m_started) {
-                        restartClient();
-                    }
                     updateHomeFromRadio();
                     updateBeaconDefaults();
                 });
@@ -685,9 +723,7 @@ void PskReporterMapDialog::updateBeaconDefaults()
     if (m_radioModel == nullptr || m_beaconArmed) {
         return;
     }
-    if (m_beaconCallsign->text().trimmed().isEmpty()) {
-        m_beaconCallsign->setText(m_radioModel->callsign().trimmed().toUpper());
-    }
+    m_beaconCallsign->setText(m_radioModel->callsign().trimmed().toUpper());
     if (m_beaconGrid->text().trimmed().isEmpty()) {
         // A GPSDO-derived locator is worth keeping: it seeds the field on a
         // radio that has one, and then persists so a later session on a radio
@@ -1276,11 +1312,21 @@ void PskReporterMapDialog::onLookbackChanged(int index)
 
 void PskReporterMapDialog::restartClient()
 {
-    m_client->setCallsign(m_radioModel != nullptr ? m_radioModel->callsign()
-                                                  : QString());
+    m_appliedMapCallsign = m_queryCallsign->text().trimmed().toUpper();
+    m_client->setCallsign(m_appliedMapCallsign);
     m_client->setLookbackSeconds(m_lookbackCombo->currentData().toInt());
     m_client->start(m_intervalCombo->currentData().toInt());
     m_emptyStateTimer->start();
+}
+
+void PskReporterMapDialog::applyMapCallsign()
+{
+    const QString normalized =
+        m_queryCallsign->text().trimmed().toUpper().left(32);
+    m_queryCallsign->setText(normalized);
+    if (m_started && normalized != m_appliedMapCallsign) {
+        restartClient();
+    }
 }
 
 void PskReporterMapDialog::updateConnectionIndicator()
@@ -1290,7 +1336,8 @@ void PskReporterMapDialog::updateConnectionIndicator()
     //   yellow = connected but no spots yet
     //   red    = no good connection
     const bool up = m_client->isMqttConnected() || m_client->lastHttpOk();
-    const bool hasData = !m_client->spots().isEmpty();
+    const bool hasData = !m_client->spots().isEmpty()
+                      || !m_client->monitors().isEmpty();
     QString color;
     if (!up) {
         color = m_client->sawError() ? QStringLiteral("#e74c3c")    // red
@@ -1304,12 +1351,81 @@ void PskReporterMapDialog::updateConnectionIndicator()
     m_connLabel->setText(
         QStringLiteral("%1 <span style='color:%2;'>&#9679;</span>")
             .arg(m_client->transport(), color));
+
+    QStringList diagnostics;
+    diagnostics.append(tr("Transport: %1").arg(m_client->transport()));
+    diagnostics.append(tr("Scope: %1").arg(
+        m_client->queryScope() == PskReporterClient::QueryScope::Anyone
+            ? tr("all stations")
+            : m_client->callsign()));
+    diagnostics.append(tr("Cached data: %1 report(s), %2 active monitor(s)")
+                           .arg(m_client->spots().size())
+                           .arg(m_client->monitors().size()));
+    if (m_client->httpRequestInFlight()) {
+        diagnostics.append(tr("HTTP request: in progress"));
+    }
+    if (m_client->lastHttpRequestAt().isValid()) {
+        diagnostics.append(tr("Last HTTP request: %1")
+            .arg(m_client->lastHttpRequestAt().toLocalTime().toString(
+                QStringLiteral("yyyy-MM-dd hh:mm:ss"))));
+    }
+    if (m_client->lastHttpStatus() > 0) {
+        diagnostics.append(tr("Last HTTP status: %1")
+                               .arg(m_client->lastHttpStatus()));
+    }
+    if (!m_client->lastHttpError().isEmpty()) {
+        diagnostics.append(tr("Last error: %1")
+                               .arg(m_client->lastHttpError()));
+    }
+    const QDateTime nextRequest = m_client->nextHttpRequestAt();
+    if (nextRequest.isValid()
+        && nextRequest > QDateTime::currentDateTime()) {
+        diagnostics.append(tr("Next HTTP request allowed: %1")
+            .arg(nextRequest.toLocalTime().toString(
+                QStringLiteral("yyyy-MM-dd hh:mm:ss"))));
+    }
+    const QString tooltip = diagnostics.join(QLatin1Char('\n'));
+    m_connLabel->setToolTip(tooltip);
+    m_connLabel->setAccessibleDescription(tooltip);
 }
 
 void PskReporterMapDialog::rebuildMarkers()
 {
     QVector<MapView::Marker> markers;
-    markers.reserve(m_client->spots().size());
+    constexpr int kMaxRenderedMonitors = 3000;
+    const bool anyone = m_client->queryScope()
+                     == PskReporterClient::QueryScope::Anyone;
+
+    // GPS and the saved beacon grid are the preferred station-location
+    // sources. If neither exists, PSK Reporter itself can still tell us the
+    // locator our station advertised in one of its reports. Only use the real
+    // station callsign here: entering some other call in the map field must
+    // not move "home" to that station.
+    if (!m_mapView->hasHomePosition() && m_radioModel != nullptr) {
+        const QString stationCall = m_radioModel->callsign().trimmed();
+        if (!stationCall.isEmpty()) {
+            for (const PskReporterSpot& spot : m_client->spots()) {
+                QString locator;
+                if (spot.senderCallsign.compare(
+                        stationCall, Qt::CaseInsensitive) == 0) {
+                    locator = spot.senderLocator;
+                } else if (spot.receiverCallsign.compare(
+                               stationCall, Qt::CaseInsensitive) == 0) {
+                    locator = spot.receiverLocator;
+                }
+                double stationLat = 0.0;
+                double stationLon = 0.0;
+                if (MaidenheadLocator::toLatLon(
+                        locator, stationLat, stationLon)) {
+                    m_mapView->setHomePosition(
+                        stationLat, stationLon, stationCall);
+                    break;
+                }
+            }
+        }
+    }
+    markers.reserve(m_client->spots().size()
+                    + qMin(m_client->monitors().size(), kMaxRenderedMonitors));
     const QString bandFilter = m_bandCombo->currentIndex() > 0
                                    ? m_bandCombo->currentText()
                                    : QString();
@@ -1326,6 +1442,50 @@ void PskReporterMapDialog::rebuildMarkers()
     double bestKm = -1.0;
     QString farthestCall;
 
+    int renderedMonitors = 0;
+    if (anyone) {
+        for (const PskReporterMonitor& monitor : m_client->monitors()) {
+            if (renderedMonitors >= kMaxRenderedMonitors) {
+                break;
+            }
+            if (!bandFilter.isEmpty()
+                && (monitor.frequencyHz <= 0
+                    || bandName(monitor.frequencyHz) != bandFilter)) {
+                continue;
+            }
+            if (!modeFilter.isEmpty()
+                && (monitor.mode.isEmpty()
+                    || modeGroup(monitor.mode) != modeFilter)) {
+                continue;
+            }
+            double lat = 0.0;
+            double lon = 0.0;
+            if (!MaidenheadLocator::toLatLon(monitor.locator, lat, lon)) {
+                continue;
+            }
+            MapView::Marker marker;
+            marker.lat = lat;
+            marker.lon = lon;
+            marker.isMonitor = true;
+            marker.pathEnabled = false;
+            marker.color = modeColor(monitor.mode);
+            const QString software = monitor.decoderSoftware.isEmpty()
+                ? QString() : QStringLiteral("<br>%1")
+                                      .arg(monitor.decoderSoftware.toHtmlEscaped());
+            marker.tooltip = QStringLiteral(
+                "<div style='white-space:nowrap;'><b>%1</b> %2"
+                "<br>Active monitor · %3%4</div>")
+                .arg(monitor.callsign.toHtmlEscaped(),
+                     monitor.locator.toHtmlEscaped(),
+                     monitor.mode.isEmpty() ? tr("mode not reported")
+                                            : monitor.mode.toHtmlEscaped(),
+                     software);
+            marker.clickInfo = marker.tooltip;
+            markers.append(marker);
+            ++renderedMonitors;
+        }
+    }
+
     for (const PskReporterSpot& spot : m_client->spots()) {
         if (spot.flowStartSeconds < cutoff) {
             continue;
@@ -1336,31 +1496,53 @@ void PskReporterMapDialog::rebuildMarkers()
         if (!modeFilter.isEmpty() && modeGroup(spot.mode) != modeFilter) {
             continue;
         }
+        const QString queryCall = m_client->callsign();
+        const bool queryIsReceiver = !anyone
+            && spot.receiverCallsign.compare(queryCall, Qt::CaseInsensitive) == 0;
+        const QString markerCall = queryIsReceiver ? spot.senderCallsign
+                                                   : spot.receiverCallsign;
+        const QString markerLocator = queryIsReceiver ? spot.senderLocator
+                                                      : spot.receiverLocator;
+        const QString originLocator = queryIsReceiver ? spot.receiverLocator
+                                                      : spot.senderLocator;
         double lat = 0.0;
         double lon = 0.0;
-        if (!MaidenheadLocator::toLatLon(spot.receiverLocator, lat, lon)) {
+        if (!MaidenheadLocator::toLatLon(markerLocator, lat, lon)) {
             continue;
         }
         MapView::Marker m;
         m.lat = lat;
         m.lon = lon;
-        m.label = spot.receiverCallsign;
+        m.label = anyone ? QString() : markerCall;
         m.color = modeColor(spot.mode);
+        double originLat = 0.0;
+        double originLon = 0.0;
+        if (MaidenheadLocator::toLatLon(originLocator, originLat, originLon)) {
+            m.hasPathOrigin = true;
+            m.pathFromLat = originLat;
+            m.pathFromLon = originLon;
+        }
+        const bool queryIsStation = m_radioModel != nullptr
+            && queryCall.compare(m_radioModel->callsign(), Qt::CaseInsensitive) == 0;
+        m.pathEnabled = m.hasPathOrigin || (!anyone && queryIsStation);
         // Same compact card for hover and click.
         const QString card = buildSpotCard(
-            spot, hasHome, m_mapView->homeLat(), m_mapView->homeLon(),
+            spot, m.hasPathOrigin || hasHome,
+            m.hasPathOrigin ? originLat : m_mapView->homeLat(),
+            m.hasPathOrigin ? originLon : m_mapView->homeLon(),
             lat, lon);
         m.tooltip = card;
         m.clickInfo = card;
         markers.append(m);
 
         bandsHeard.insert(bandName(spot.frequencyHz));
-        if (hasHome) {
+        if (m.hasPathOrigin || hasHome) {
             const double km = MaidenheadLocator::distanceKm(
-                m_mapView->homeLat(), m_mapView->homeLon(), lat, lon);
+                m.hasPathOrigin ? originLat : m_mapView->homeLat(),
+                m.hasPathOrigin ? originLon : m_mapView->homeLon(), lat, lon);
             if (km > bestKm) {
                 bestKm = km;
-                farthestCall = spot.receiverCallsign;
+                farthestCall = markerCall;
             }
         }
     }
@@ -1368,8 +1550,16 @@ void PskReporterMapDialog::rebuildMarkers()
 
     // Reception stats (top-right): count · bands · farthest.
     QStringList parts;
-    if (!markers.isEmpty()) {
-        parts << tr("%n spot(s)", nullptr, markers.size());
+    const int reportMarkers = markers.size() - renderedMonitors;
+    if (anyone) {
+        parts << tr("%n report(s)", nullptr, reportMarkers);
+        parts << tr("%n active monitor(s)", nullptr, renderedMonitors);
+        if (m_client->resultsLimited()
+            || m_client->monitors().size() > kMaxRenderedMonitors) {
+            parts << tr("display capped");
+        }
+    } else if (!markers.isEmpty()) {
+        parts << tr("%n spot(s)", nullptr, reportMarkers);
         parts << tr("%n band(s)", nullptr, bandsHeard.size());
         if (bestKm >= 0.0) {
             parts << tr("farthest %1 %L2 km").arg(farthestCall).arg(qRound(bestKm));

--- a/src/gui/PskReporterMapDialog.cpp
+++ b/src/gui/PskReporterMapDialog.cpp
@@ -22,7 +22,9 @@
 #include <QCursor>
 #include <QDateTime>
 #include <QDoubleSpinBox>
+#include <QFrame>
 #include <QGroupBox>
+#include <QHash>
 #include <QLineEdit>
 #include <QPushButton>
 #include <QSet>
@@ -232,34 +234,59 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
     , m_audioEngine(audioEngine)
     , m_radioModel(radioModel)
     , m_client(new PskReporterClient(this))
+    , m_globalClient(new PskReporterClient(this))
     , m_propForecast(propForecast)
 {
+    // The callsign layer is MQTT-only. The independent all-stations client
+    // owns the shared HTTP cadence and its reusable global cache.
+    m_client->setHttpPollingEnabled(false);
     setMinimumSize(720, 480);
 
     auto* root = new QVBoxLayout(bodyWidget());
     root->setContentsMargins(6, 6, 6, 6);
     root->setSpacing(6);
 
-    auto* filtersBar = new QHBoxLayout();
+    auto* reportsBox = new QGroupBox(tr("Reports"), bodyWidget());
+    reportsBox->setAccessibleName(tr("PSK Reporter filters and map layers"));
+    auto* reportsLayout = new QVBoxLayout(reportsBox);
+    reportsLayout->setContentsMargins(6, 4, 6, 4);
+    reportsLayout->setSpacing(4);
 
-    filtersBar->addWidget(new QLabel(tr("Call:"), bodyWidget()));
-    m_queryCallsign = new QLineEdit(bodyWidget());
+    auto* filtersBar = new QHBoxLayout();
+    filtersBar->setSpacing(6);
+
+    filtersBar->addWidget(new QLabel(tr("Call:"), reportsBox));
+    m_queryCallsign = new QLineEdit(reportsBox);
     m_queryCallsign->setMaxLength(32);
     m_queryCallsign->setFixedWidth(100);
     m_queryCallsign->setObjectName(QStringLiteral("pskReporterCallsign"));
     m_queryCallsign->setAccessibleName(tr("PSK Reporter map callsign"));
     m_queryCallsign->setAccessibleDescription(
-        tr("Enter a callsign to show reports sent or received by it; clear "
-           "the field to show reports and active monitors for anyone"));
+        tr("Enter a callsign to add its live sent and received reports"));
     m_queryCallsign->setToolTip(
-        tr("Blank shows all callsigns in the selected timeframe"));
-    // The public map is the default view. A callsign is an explicit filter,
-    // not a mirror of the station setting.
-    m_queryCallsign->clear();
+        tr("A callsign receives immediate live MQTT updates. Clear the field "
+           "to hide the live callsign layer; All Callsigns is independent."));
+    // Seed the map-only filter from the station identity. Subsequent edits do
+    // not write back to the radio, and clearing it explicitly selects the
+    // all-stations view.
+    m_queryCallsign->setText(
+        m_radioModel != nullptr
+            ? m_radioModel->callsign().trimmed().toUpper().left(32)
+            : QString());
     filtersBar->addWidget(m_queryCallsign);
 
-    filtersBar->addWidget(new QLabel(tr("Band:"), bodyWidget()));
-    m_bandCombo = new QComboBox(bodyWidget());
+    m_allCallsignsCheck = new QCheckBox(tr("All Callsigns"), reportsBox);
+    m_allCallsignsCheck->setObjectName(
+        QStringLiteral("pskReporterAllCallsigns"));
+    m_allCallsignsCheck->setAccessibleName(
+        tr("Show all PSK Reporter callsigns"));
+    m_allCallsignsCheck->setToolTip(
+        tr("Show the cached global HTTP snapshot and refresh it no more than "
+           "once every five minutes"));
+    m_allCallsignsCheck->setChecked(
+        pskSettings().value("showAllCallsigns").toBool(false));
+    filtersBar->addWidget(new QLabel(tr("Band:"), reportsBox));
+    m_bandCombo = new QComboBox(reportsBox);
     m_bandCombo->addItem(tr("All"));
     for (const char* b : { "160m", "80m", "60m", "40m", "30m", "20m",
                            "17m", "15m", "12m", "10m", "6m", "VHF+" }) {
@@ -267,8 +294,8 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
     }
     filtersBar->addWidget(m_bandCombo);
 
-    filtersBar->addWidget(new QLabel(tr("Mode:"), bodyWidget()));
-    m_modeCombo = new QComboBox(bodyWidget());
+    filtersBar->addWidget(new QLabel(tr("Mode:"), reportsBox));
+    m_modeCombo = new QComboBox(reportsBox);
     m_modeCombo->addItem(tr("All"));
     for (const char* m : { "FT8", "FT4", "WSPR", "JS8", "CW", "PSK",
                            "RTTY", "SSB", "Other" }) {
@@ -276,8 +303,8 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
     }
     filtersBar->addWidget(m_modeCombo);
 
-    filtersBar->addWidget(new QLabel(tr("Lookback:"), bodyWidget()));
-    m_lookbackCombo = new QComboBox(bodyWidget());
+    filtersBar->addWidget(new QLabel(tr("Lookback:"), reportsBox));
+    m_lookbackCombo = new QComboBox(reportsBox);
     m_lookbackCombo->addItem(tr("15 min"), 15 * 60);
     m_lookbackCombo->addItem(tr("30 min"), 30 * 60);
     m_lookbackCombo->addItem(tr("1 hour"), 60 * 60);
@@ -286,42 +313,56 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
     m_lookbackCombo->addItem(tr("8 hours"), 8 * 60 * 60);
     filtersBar->addWidget(m_lookbackCombo);
     filtersBar->addStretch(1);
-    root->addLayout(filtersBar);
+
+    // Persistent reception stats share the filter row and remain pinned to
+    // the panel's top-right corner, matching the report controls they
+    // summarize.
+    m_dxLabel = new QLabel(reportsBox);
+    m_dxLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    filtersBar->addWidget(m_dxLabel);
+    reportsLayout->addLayout(filtersBar);
 
     auto* topBar = new QHBoxLayout();
-    topBar->addWidget(new QLabel(tr("Update every:"), bodyWidget()));
+    topBar->setSpacing(6);
+    topBar->addWidget(new QLabel(tr("Data:"), reportsBox));
+    topBar->addWidget(m_allCallsignsCheck);
 
-    m_intervalCombo = new QComboBox(bodyWidget());
-    // PSK Reporter policy floors HTTP polling at 5 minutes; "Live" uses
-    // their sanctioned MQTT feed instead of fast polling.
-    m_intervalCombo->addItem(tr("Live (MQTT)"), PskReporterClient::kLiveMqtt);
-    m_intervalCombo->addItem(tr("5 minutes"), 5 * 60 * 1000);
-    m_intervalCombo->addItem(tr("10 minutes"), 10 * 60 * 1000);
-    m_intervalCombo->addItem(tr("15 minutes"), 15 * 60 * 1000);
-    m_intervalCombo->addItem(tr("30 minutes"), 30 * 60 * 1000);
-    m_intervalCombo->addItem(tr("1 hour"), 60 * 60 * 1000);
-    topBar->addWidget(m_intervalCombo);
+    m_activeMonitorsCheck = new QCheckBox(tr("Active monitors"), reportsBox);
+    m_activeMonitorsCheck->setObjectName(
+        QStringLiteral("pskReporterActiveMonitors"));
+    m_activeMonitorsCheck->setAccessibleName(
+        tr("Show active PSK Reporter monitors"));
+    m_activeMonitorsCheck->setToolTip(
+        tr("Show stations that report themselves as listening; these records "
+           "do not contain a transmitting endpoint, so they have no paths"));
+    m_activeMonitorsCheck->setChecked(
+        pskSettings().value("showActiveMonitors").toBool(true));
+    topBar->addWidget(m_activeMonitorsCheck);
 
-    m_pathsCheck = new QCheckBox(tr("Paths"), bodyWidget());
+    auto* dataMapDivider = new QFrame(reportsBox);
+    dataMapDivider->setFrameShape(QFrame::VLine);
+    dataMapDivider->setFrameShadow(QFrame::Sunken);
+    topBar->addSpacing(6);
+    topBar->addWidget(dataMapDivider);
+    topBar->addSpacing(6);
+    topBar->addWidget(new QLabel(tr("Map:"), reportsBox));
+
+    m_pathsCheck = new QCheckBox(tr("Paths"), reportsBox);
     m_pathsCheck->setObjectName(QStringLiteral("pskReporterPaths"));
     m_pathsCheck->setToolTip(
         tr("Draw great-circle report paths between transmitting and receiving stations"));
     m_pathsCheck->setChecked(pskSettings().value("showPaths").toBool(false));
     topBar->addWidget(m_pathsCheck);
 
-    m_terminatorCheck = new QCheckBox(tr("Day/night"), bodyWidget());
+    m_terminatorCheck = new QCheckBox(tr("Day/night"), reportsBox);
     m_terminatorCheck->setToolTip(tr("Show the current night shadow on the map"));
     m_terminatorCheck->setAccessibleName(tr("Show day and night terminator"));
     m_terminatorCheck->setChecked(
         pskSettings().value("showTerminator").toBool(true));
     topBar->addWidget(m_terminatorCheck);
-
-    // Persistent reception stats, pinned to the top-right corner.
     topBar->addStretch(1);
-    m_dxLabel = new QLabel(bodyWidget());
-    m_dxLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    topBar->addWidget(m_dxLabel);
-    root->addLayout(topBar);
+    reportsLayout->addLayout(topBar);
+    root->addWidget(reportsBox);
 
     auto* beaconBox = new QGroupBox(tr("WSPR beacon"), bodyWidget());
     beaconBox->setAccessibleName(tr("WSPR beacon transmitter"));
@@ -475,6 +516,29 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
         writePskSetting("showPaths", on);
         m_mapView->setPathsVisible(on);
     });
+    connect(m_allCallsignsCheck, &QCheckBox::toggled, this, [this](bool on) {
+        writePskSetting("showAllCallsigns", on);
+        m_activeMonitorsCheck->setEnabled(on);
+        if (m_started) {
+            // The global client is prefetched for the entire dialog lifetime,
+            // so this toggle is a cache-only display operation.
+            if (!m_globalClient->isRunning()) {
+                restartGlobalClient();
+            }
+            // start() may restore the cached snapshot and emit spotsUpdated(),
+            // which arms the normal 250 ms burst-coalescing timer. We are
+            // rendering that same snapshot synchronously below, so leaving
+            // the timer armed only cancels the first expensive marker image
+            // and starts it over just as it is about to appear.
+            m_markerRefreshTimer->stop();
+            rebuildMarkers();
+        }
+    });
+    connect(m_activeMonitorsCheck, &QCheckBox::toggled, this, [this](bool on) {
+        writePskSetting("showActiveMonitors", on);
+        m_markerRefreshTimer->stop();
+        rebuildMarkers();
+    });
     connect(m_terminatorCheck, &QCheckBox::toggled, this, [this](bool on) {
         writePskSetting("showTerminator", on);
         m_mapView->setDayNightTerminatorVisible(on);
@@ -483,6 +547,9 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
             this, &PskReporterMapDialog::applyMapCallsign);
     connect(m_queryCallsign, &QLineEdit::returnPressed,
             this, &PskReporterMapDialog::applyMapCallsign);
+    connect(m_queryCallsign, &QLineEdit::textEdited, this, [this] {
+        m_mapCallsignUserEdited = true;
+    });
     connect(m_mapView, &MapView::markerClicked, this,
             [](const MapView::Marker& marker) {
                 if (!marker.clickInfo.isEmpty()) {
@@ -527,6 +594,8 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
 
     connect(m_client, &PskReporterClient::connectionStateChanged,
             this, &PskReporterMapDialog::updateConnectionIndicator);
+    connect(m_globalClient, &PskReporterClient::connectionStateChanged,
+            this, &PskReporterMapDialog::updateConnectionIndicator);
     updateConnectionIndicator();
 
     if (m_propForecast != nullptr) {
@@ -539,22 +608,35 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
     m_emptyStateTimer->setSingleShot(true);
     m_emptyStateTimer->setInterval(2 * 60 * 1000);
     connect(m_emptyStateTimer, &QTimer::timeout, this, [this] {
-        if (m_client->spots().isEmpty()) {
-            m_statusLabel->setText(
-                tr("No reports yet — transmit (e.g. FT8) and reports "
-                   "typically appear within 1–2 minutes."));
+        const bool visibleMonitorsEmpty = !m_activeMonitorsCheck->isChecked()
+                                       || m_globalClient->monitors().isEmpty();
+        const bool globalEmpty = !m_allCallsignsCheck->isChecked()
+            || (m_globalClient->spots().isEmpty() && visibleMonitorsEmpty);
+        if (globalEmpty && m_client->spots().isEmpty()) {
+            if (!m_appliedMapCallsign.isEmpty()) {
+                m_statusLabel->setText(
+                    tr("No live reports yet for %1 — reports typically appear "
+                       "within 1–2 minutes after transmitting.")
+                        .arg(m_appliedMapCallsign));
+            } else if (m_allCallsignsCheck->isChecked()) {
+                m_statusLabel->setText(
+                    tr("No reports or active monitors were returned for the "
+                       "selected timeframe."));
+            } else {
+                m_statusLabel->setText(
+                    tr("Enter a callsign or enable All Callsigns."));
+            }
         }
     });
 
-    const int savedInterval =
-        pskSettings().value("updateIntervalMs").toInt(PskReporterClient::kLiveMqtt);
-    const int idx = m_intervalCombo->findData(savedInterval);
-    m_intervalCombo->setCurrentIndex(idx >= 0 ? idx : 0);
+    m_activeMonitorsCheck->setEnabled(m_allCallsignsCheck->isChecked());
 
     const int savedLookback = pskSettings().value("lookbackSec").toInt(60 * 60);
     const int lbIdx = m_lookbackCombo->findData(savedLookback);
     m_lookbackCombo->setCurrentIndex(lbIdx >= 0 ? lbIdx : 2);  // default 1h
     m_client->setLookbackSeconds(m_lookbackCombo->currentData().toInt());
+    m_globalClient->setLookbackSeconds(
+        m_lookbackCombo->currentData().toInt());
 
     // Debounce rapid Lookback changes into a single deep HTTP query, so
     // spinning through options doesn't hammer PSK Reporter (which 503s).
@@ -563,10 +645,10 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
     m_lookbackDebounce->setInterval(750);
     connect(m_lookbackDebounce, &QTimer::timeout, this, [this] {
         m_client->setLookbackSeconds(m_lookbackCombo->currentData().toInt());
+        m_globalClient->setLookbackSeconds(
+            m_lookbackCombo->currentData().toInt());
     });
 
-    connect(m_intervalCombo, &QComboBox::currentIndexChanged,
-            this, &PskReporterMapDialog::onIntervalChanged);
     connect(m_lookbackCombo, &QComboBox::currentIndexChanged,
             this, &PskReporterMapDialog::onLookbackChanged);
     connect(m_bandCombo, &QComboBox::currentIndexChanged,
@@ -587,8 +669,20 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
             m_markerRefreshTimer->start();
         }
     });
+    connect(m_globalClient, &PskReporterClient::spotsUpdated, this, [this] {
+        if (!m_markerRefreshTimer->isActive()) {
+            m_markerRefreshTimer->start();
+        }
+    });
     connect(m_client, &PskReporterClient::statusChanged,
-            m_statusLabel, &QLabel::setText);
+            this, [this](const QString& status) {
+                m_statusLabel->setText(
+                    tr("Live %1: %2").arg(m_appliedMapCallsign, status));
+            });
+    connect(m_globalClient, &PskReporterClient::statusChanged,
+            this, [this](const QString& status) {
+                m_statusLabel->setText(tr("All Callsigns: %1").arg(status));
+            });
     connect(m_beaconButton, &QPushButton::clicked,
             this, &PskReporterMapDialog::scheduleBeacon);
     connect(m_beaconPower, &QComboBox::currentIndexChanged, this, [this] {
@@ -701,10 +795,21 @@ PskReporterMapDialog::PskReporterMapDialog(AudioEngine* audioEngine,
     if (m_radioModel != nullptr) {
         connect(m_radioModel, &RadioModel::gpsStatusChanged,
                 this, [this] { updateHomeFromRadio(); });
-        // A late station callsign updates station-owned features only. The map
-        // query stays empty until the operator explicitly enters a filter.
         connect(m_radioModel, &RadioModel::callsignChanged, this,
                 [this] {
+                    // Follow a late-arriving station identity only until the
+                    // operator explicitly edits the map-local filter.
+                    if (!m_mapCallsignUserEdited) {
+                        const QString stationCall =
+                            m_radioModel->callsign().trimmed().toUpper().left(32);
+                        if (stationCall != m_queryCallsign->text()) {
+                            m_queryCallsign->setText(stationCall);
+                            if (m_started) {
+                                m_appliedMapCallsign = stationCall;
+                                restartCallsignClient();
+                            }
+                        }
+                    }
                     updateHomeFromRadio();
                     updateBeaconDefaults();
                 });
@@ -723,7 +828,14 @@ void PskReporterMapDialog::updateBeaconDefaults()
     if (m_radioModel == nullptr || m_beaconArmed) {
         return;
     }
-    m_beaconCallsign->setText(m_radioModel->callsign().trimmed().toUpper());
+    const QString stationCall =
+        m_radioModel->callsign().trimmed().toUpper();
+    // A radio status update must not erase or replace an operator's
+    // in-progress edit. An empty station identity is likewise not an erase
+    // command for this TX field.
+    if (!stationCall.isEmpty() && !m_beaconCallsign->isModified()) {
+        m_beaconCallsign->setText(stationCall);
+    }
     if (m_beaconGrid->text().trimmed().isEmpty()) {
         // A GPSDO-derived locator is worth keeping: it seeds the field on a
         // radio that has one, and then persists so a later session on a radio
@@ -1295,13 +1407,6 @@ void PskReporterMapDialog::updateHomeFromRadio()
     m_mapView->setHomePosition(lat, lon, label);
 }
 
-void PskReporterMapDialog::onIntervalChanged(int index)
-{
-    const int intervalMs = m_intervalCombo->itemData(index).toInt();
-    writePskSetting("updateIntervalMs", intervalMs);
-    restartClient();
-}
-
 void PskReporterMapDialog::onLookbackChanged(int index)
 {
     // Persist immediately; defer the (networked) client update so rapid
@@ -1310,13 +1415,38 @@ void PskReporterMapDialog::onLookbackChanged(int index)
     m_lookbackDebounce->start();
 }
 
-void PskReporterMapDialog::restartClient()
+void PskReporterMapDialog::restartClients()
 {
     m_appliedMapCallsign = m_queryCallsign->text().trimmed().toUpper();
+    // Claim the one shared HTTP retrieval slot for the reusable global
+    // snapshot as soon as the map opens. Its cached rows also seed the
+    // prepopulated callsign while MQTT supplies new reports in parallel.
+    restartGlobalClient();
+    restartCallsignClient();
+    m_emptyStateTimer->start();
+}
+
+void PskReporterMapDialog::restartCallsignClient()
+{
+    m_client->stop();
     m_client->setCallsign(m_appliedMapCallsign);
     m_client->setLookbackSeconds(m_lookbackCombo->currentData().toInt());
-    m_client->start(m_intervalCombo->currentData().toInt());
-    m_emptyStateTimer->start();
+    if (!m_appliedMapCallsign.isEmpty()) {
+        m_client->start(PskReporterClient::kLiveMqtt);
+    }
+}
+
+void PskReporterMapDialog::restartGlobalClient()
+{
+    m_globalClient->stop();
+    m_globalClient->setCallsign(QString());
+    m_globalClient->setLookbackSeconds(
+        m_lookbackCombo->currentData().toInt());
+    // Keep this client warm even while its layer is hidden. One global query
+    // can seed the callsign history and makes a later All Callsigns toggle
+    // immediate; subsequent refreshes retain PSK Reporter's five-minute floor.
+    m_globalClient->start(PskReporterClient::kMinPollMs);
+    updateConnectionIndicator();
 }
 
 void PskReporterMapDialog::applyMapCallsign()
@@ -1325,65 +1455,88 @@ void PskReporterMapDialog::applyMapCallsign()
         m_queryCallsign->text().trimmed().toUpper().left(32);
     m_queryCallsign->setText(normalized);
     if (m_started && normalized != m_appliedMapCallsign) {
-        restartClient();
+        m_appliedMapCallsign = normalized;
+        restartCallsignClient();
+        rebuildMarkers();
+        m_emptyStateTimer->start();
     }
 }
 
 void PskReporterMapDialog::updateConnectionIndicator()
 {
-    // Three-state bullet next to the transport label (MQTT/HTTP):
-    //   green  = connected and showing data
-    //   yellow = connected but no spots yet
-    //   red    = no good connection
-    const bool up = m_client->isMqttConnected() || m_client->lastHttpOk();
-    const bool hasData = !m_client->spots().isEmpty()
-                      || !m_client->monitors().isEmpty();
+    const bool globalEnabled = m_allCallsignsCheck->isChecked();
+    const bool globalRunning = m_globalClient->isRunning();
+    const bool callsignEnabled = !m_appliedMapCallsign.isEmpty();
+    const bool up = (globalRunning && m_globalClient->lastHttpOk())
+                 || (callsignEnabled && m_client->isMqttConnected());
+    const bool hasData = (globalRunning
+                          && (!m_globalClient->spots().isEmpty()
+                              || !m_globalClient->monitors().isEmpty()))
+                      || (callsignEnabled && !m_client->spots().isEmpty());
+    const bool sawError = (globalRunning && m_globalClient->sawError())
+                       || (callsignEnabled && m_client->sawError());
     QString color;
     if (!up) {
-        color = m_client->sawError() ? QStringLiteral("#e74c3c")    // red
-                                     : QStringLiteral("#f4c20d");   // connecting
+        color = sawError ? QStringLiteral("#e74c3c")
+                         : QStringLiteral("#f4c20d");
     } else {
-        color = hasData ? QStringLiteral("#2ecc71")                 // green
-                        : QStringLiteral("#f4c20d");                // yellow
+        color = hasData ? QStringLiteral("#2ecc71")
+                        : QStringLiteral("#f4c20d");
     }
-    // Transport word in the normal label color (white in dark themes);
-    // only the bullet carries the status color.
+
+    QStringList transports;
+    if (globalRunning) {
+        transports.append(QStringLiteral("HTTP"));
+    }
+    if (callsignEnabled) {
+        transports.append(QStringLiteral("MQTT"));
+    }
+    if (transports.isEmpty()) {
+        transports.append(tr("Off"));
+    }
     m_connLabel->setText(
         QStringLiteral("%1 <span style='color:%2;'>&#9679;</span>")
-            .arg(m_client->transport(), color));
+            .arg(transports.join(QStringLiteral(" + ")), color));
 
     QStringList diagnostics;
-    diagnostics.append(tr("Transport: %1").arg(m_client->transport()));
-    diagnostics.append(tr("Scope: %1").arg(
-        m_client->queryScope() == PskReporterClient::QueryScope::Anyone
-            ? tr("all stations")
-            : m_client->callsign()));
-    diagnostics.append(tr("Cached data: %1 report(s), %2 active monitor(s)")
-                           .arg(m_client->spots().size())
-                           .arg(m_client->monitors().size()));
-    if (m_client->httpRequestInFlight()) {
-        diagnostics.append(tr("HTTP request: in progress"));
+    diagnostics.append(globalRunning
+        ? tr("Global HTTP cache%1: %2 report(s), %3 active monitor(s)")
+              .arg(globalEnabled ? QString() : tr(" (layer hidden)"))
+              .arg(m_globalClient->spots().size())
+              .arg(m_globalClient->monitors().size())
+        : tr("Global HTTP cache: disabled"));
+    if (globalRunning) {
+        if (m_globalClient->httpRequestInFlight()) {
+            diagnostics.append(tr("Global HTTP request: in progress"));
+        }
+        if (m_globalClient->lastHttpRequestAt().isValid()) {
+            diagnostics.append(tr("Last global HTTP request: %1")
+                .arg(m_globalClient->lastHttpRequestAt().toLocalTime().toString(
+                    QStringLiteral("yyyy-MM-dd hh:mm:ss"))));
+        }
+        if (m_globalClient->lastHttpStatus() > 0) {
+            diagnostics.append(tr("Last global HTTP status: %1")
+                                   .arg(m_globalClient->lastHttpStatus()));
+        }
+        if (!m_globalClient->lastHttpError().isEmpty()) {
+            diagnostics.append(tr("Global HTTP error: %1")
+                                   .arg(m_globalClient->lastHttpError()));
+        }
+        const QDateTime nextRequest = m_globalClient->nextHttpRequestAt();
+        if (nextRequest.isValid()
+            && nextRequest > QDateTime::currentDateTime()) {
+            diagnostics.append(tr("Next global HTTP request allowed: %1")
+                .arg(nextRequest.toLocalTime().toString(
+                    QStringLiteral("yyyy-MM-dd hh:mm:ss"))));
+        }
     }
-    if (m_client->lastHttpRequestAt().isValid()) {
-        diagnostics.append(tr("Last HTTP request: %1")
-            .arg(m_client->lastHttpRequestAt().toLocalTime().toString(
-                QStringLiteral("yyyy-MM-dd hh:mm:ss"))));
-    }
-    if (m_client->lastHttpStatus() > 0) {
-        diagnostics.append(tr("Last HTTP status: %1")
-                               .arg(m_client->lastHttpStatus()));
-    }
-    if (!m_client->lastHttpError().isEmpty()) {
-        diagnostics.append(tr("Last error: %1")
-                               .arg(m_client->lastHttpError()));
-    }
-    const QDateTime nextRequest = m_client->nextHttpRequestAt();
-    if (nextRequest.isValid()
-        && nextRequest > QDateTime::currentDateTime()) {
-        diagnostics.append(tr("Next HTTP request allowed: %1")
-            .arg(nextRequest.toLocalTime().toString(
-                QStringLiteral("yyyy-MM-dd hh:mm:ss"))));
-    }
+    diagnostics.append(callsignEnabled
+        ? tr("Live %1 MQTT: %2 (%3 cached report(s))")
+              .arg(m_appliedMapCallsign,
+                   m_client->isMqttConnected() ? tr("connected")
+                                               : tr("connecting"))
+              .arg(m_client->spots().size())
+        : tr("Live callsign MQTT: disabled"));
     const QString tooltip = diagnostics.join(QLatin1Char('\n'));
     m_connLabel->setToolTip(tooltip);
     m_connLabel->setAccessibleDescription(tooltip);
@@ -1391,10 +1544,69 @@ void PskReporterMapDialog::updateConnectionIndicator()
 
 void PskReporterMapDialog::rebuildMarkers()
 {
+    struct DisplaySpot {
+        const PskReporterSpot* spot{nullptr};
+        bool callsignSpecific{false};
+    };
+
+    QVector<DisplaySpot> displaySpots;
+    QHash<QString, int> spotIndexes;
+    const auto mergeSpot = [&displaySpots, &spotIndexes](
+                               const PskReporterSpot& spot,
+                               bool callsignSpecific) {
+        const QString key = spot.senderCallsign.toUpper()
+                          + QLatin1Char('|')
+                          + spot.receiverCallsign.toUpper()
+                          + QLatin1Char('|')
+                          + QString::number(spot.frequencyHz)
+                          + QLatin1Char('|') + spot.mode.toUpper();
+        const auto existing = spotIndexes.constFind(key);
+        if (existing == spotIndexes.cend()) {
+            spotIndexes.insert(key, displaySpots.size());
+            displaySpots.append({&spot, callsignSpecific});
+            return;
+        }
+        DisplaySpot& current = displaySpots[*existing];
+        if (spot.flowStartSeconds >= current.spot->flowStartSeconds) {
+            current.spot = &spot;
+        }
+        // Preserve live-layer identity even when the five-minute global
+        // snapshot has the newer copy of this same report.
+        current.callsignSpecific = current.callsignSpecific
+                                 || callsignSpecific;
+    };
+    const auto mergeSpots = [&mergeSpot](
+                                const QVector<PskReporterSpot>& spots,
+                                bool callsignSpecific) {
+        for (const PskReporterSpot& spot : spots) {
+            mergeSpot(spot, callsignSpecific);
+        }
+    };
+
+    const bool globalEnabled = m_allCallsignsCheck->isChecked();
+    if (globalEnabled) {
+        mergeSpots(m_globalClient->spots(), false);
+    } else if (!m_appliedMapCallsign.isEmpty()) {
+        // MQTT has no history. Reuse matching rows from the prefetched global
+        // snapshot as callsign-specific data without spending a second HTTP
+        // request slot.
+        for (const PskReporterSpot& spot : m_globalClient->spots()) {
+            if (spot.senderCallsign.compare(
+                    m_appliedMapCallsign, Qt::CaseInsensitive) == 0
+                || spot.receiverCallsign.compare(
+                       m_appliedMapCallsign, Qt::CaseInsensitive) == 0) {
+                mergeSpot(spot, true);
+            }
+        }
+    }
+    if (!m_appliedMapCallsign.isEmpty()) {
+        // Merge the live layer second so an equal-timestamp report is rendered
+        // with callsign-specific labeling and hover behavior.
+        mergeSpots(m_client->spots(), true);
+    }
+
     QVector<MapView::Marker> markers;
     constexpr int kMaxRenderedMonitors = 3000;
-    const bool anyone = m_client->queryScope()
-                     == PskReporterClient::QueryScope::Anyone;
 
     // GPS and the saved beacon grid are the preferred station-location
     // sources. If neither exists, PSK Reporter itself can still tell us the
@@ -1404,7 +1616,8 @@ void PskReporterMapDialog::rebuildMarkers()
     if (!m_mapView->hasHomePosition() && m_radioModel != nullptr) {
         const QString stationCall = m_radioModel->callsign().trimmed();
         if (!stationCall.isEmpty()) {
-            for (const PskReporterSpot& spot : m_client->spots()) {
+            for (const DisplaySpot& displaySpot : displaySpots) {
+                const PskReporterSpot& spot = *displaySpot.spot;
                 QString locator;
                 if (spot.senderCallsign.compare(
                         stationCall, Qt::CaseInsensitive) == 0) {
@@ -1424,8 +1637,11 @@ void PskReporterMapDialog::rebuildMarkers()
             }
         }
     }
-    markers.reserve(m_client->spots().size()
-                    + qMin(m_client->monitors().size(), kMaxRenderedMonitors));
+    markers.reserve(displaySpots.size()
+                    + (globalEnabled
+                           ? qMin(m_globalClient->monitors().size(),
+                                  kMaxRenderedMonitors)
+                           : 0));
     const QString bandFilter = m_bandCombo->currentIndex() > 0
                                    ? m_bandCombo->currentText()
                                    : QString();
@@ -1441,10 +1657,13 @@ void PskReporterMapDialog::rebuildMarkers()
     QSet<QString> bandsHeard;
     double bestKm = -1.0;
     QString farthestCall;
+    MapView::Marker selectedCallsignMarker;
+    qint64 selectedCallsignMarkerTime = -1;
+    bool hasSelectedCallsignMarker = false;
 
     int renderedMonitors = 0;
-    if (anyone) {
-        for (const PskReporterMonitor& monitor : m_client->monitors()) {
+    if (globalEnabled && m_activeMonitorsCheck->isChecked()) {
+        for (const PskReporterMonitor& monitor : m_globalClient->monitors()) {
             if (renderedMonitors >= kMaxRenderedMonitors) {
                 break;
             }
@@ -1486,7 +1705,19 @@ void PskReporterMapDialog::rebuildMarkers()
         }
     }
 
-    for (const PskReporterSpot& spot : m_client->spots()) {
+    int renderedLiveReports = 0;
+    for (const DisplaySpot& displaySpot : displaySpots) {
+        const PskReporterSpot& spot = *displaySpot.spot;
+        const QString queryCall = m_appliedMapCallsign;
+        const bool selectedCallReport = !queryCall.isEmpty()
+            && (spot.senderCallsign.compare(queryCall, Qt::CaseInsensitive) == 0
+                || spot.receiverCallsign.compare(
+                       queryCall, Qt::CaseInsensitive) == 0);
+        // A matching global report belongs to the selected callsign's hover
+        // group too. This matters immediately after enabling All Callsigns,
+        // before MQTT has repeated every report in the HTTP snapshot.
+        const bool callsignSpecific = displaySpot.callsignSpecific
+                                   || selectedCallReport;
         if (spot.flowStartSeconds < cutoff) {
             continue;
         }
@@ -1496,15 +1727,34 @@ void PskReporterMapDialog::rebuildMarkers()
         if (!modeFilter.isEmpty() && modeGroup(spot.mode) != modeFilter) {
             continue;
         }
-        const QString queryCall = m_client->callsign();
-        const bool queryIsReceiver = !anyone
+        const bool queryIsReceiver = callsignSpecific
             && spot.receiverCallsign.compare(queryCall, Qt::CaseInsensitive) == 0;
+        const QString queryLocator = queryIsReceiver ? spot.receiverLocator
+                                                     : spot.senderLocator;
         const QString markerCall = queryIsReceiver ? spot.senderCallsign
                                                    : spot.receiverCallsign;
         const QString markerLocator = queryIsReceiver ? spot.senderLocator
                                                       : spot.receiverLocator;
         const QString originLocator = queryIsReceiver ? spot.receiverLocator
                                                       : spot.senderLocator;
+        double queryLat = 0.0;
+        double queryLon = 0.0;
+        if (callsignSpecific
+            && spot.flowStartSeconds >= selectedCallsignMarkerTime
+            && MaidenheadLocator::toLatLon(queryLocator, queryLat, queryLon)) {
+            selectedCallsignMarker.lat = queryLat;
+            selectedCallsignMarker.lon = queryLon;
+            selectedCallsignMarker.label = queryCall;
+            selectedCallsignMarker.color = modeColor(spot.mode);
+            selectedCallsignMarker.pathEnabled = false;
+            selectedCallsignMarker.pathGroup = queryCall.toUpper();
+            selectedCallsignMarker.hoverShowsPathGroup = true;
+            selectedCallsignMarker.tooltip = buildSpotCard(
+                spot, false, 0.0, 0.0, queryLat, queryLon);
+            selectedCallsignMarker.clickInfo = selectedCallsignMarker.tooltip;
+            selectedCallsignMarkerTime = spot.flowStartSeconds;
+            hasSelectedCallsignMarker = true;
+        }
         double lat = 0.0;
         double lon = 0.0;
         if (!MaidenheadLocator::toLatLon(markerLocator, lat, lon)) {
@@ -1513,8 +1763,9 @@ void PskReporterMapDialog::rebuildMarkers()
         MapView::Marker m;
         m.lat = lat;
         m.lon = lon;
-        m.label = anyone ? QString() : markerCall;
+        m.label = callsignSpecific ? markerCall : QString();
         m.color = modeColor(spot.mode);
+        m.pathGroup = callsignSpecific ? queryCall.toUpper() : QString();
         double originLat = 0.0;
         double originLon = 0.0;
         if (MaidenheadLocator::toLatLon(originLocator, originLat, originLon)) {
@@ -1524,7 +1775,8 @@ void PskReporterMapDialog::rebuildMarkers()
         }
         const bool queryIsStation = m_radioModel != nullptr
             && queryCall.compare(m_radioModel->callsign(), Qt::CaseInsensitive) == 0;
-        m.pathEnabled = m.hasPathOrigin || (!anyone && queryIsStation);
+        m.pathEnabled = m.hasPathOrigin
+                     || (callsignSpecific && queryIsStation);
         // Same compact card for hover and click.
         const QString card = buildSpotCard(
             spot, m.hasPathOrigin || hasHome,
@@ -1534,6 +1786,9 @@ void PskReporterMapDialog::rebuildMarkers()
         m.tooltip = card;
         m.clickInfo = card;
         markers.append(m);
+        if (displaySpot.callsignSpecific) {
+            ++renderedLiveReports;
+        }
 
         bandsHeard.insert(bandName(spot.frequencyHz));
         if (m.hasPathOrigin || hasHome) {
@@ -1546,16 +1801,37 @@ void PskReporterMapDialog::rebuildMarkers()
             }
         }
     }
+    const bool queryIsHomeStation = m_radioModel != nullptr
+        && m_appliedMapCallsign.compare(
+               m_radioModel->callsign(), Qt::CaseInsensitive) == 0;
+    if (hasSelectedCallsignMarker && !(queryIsHomeStation && hasHome)) {
+        // A callsign-specific report renders its opposite endpoint above. Keep
+        // one marker for the queried station too, using its newest valid
+        // advertised locator. The real station's existing home marker remains
+        // authoritative when available, so it is never duplicated or moved by
+        // an arbitrary map query.
+        markers.append(selectedCallsignMarker);
+    }
     m_mapView->setMarkers(markers);
 
     // Reception stats (top-right): count · bands · farthest.
     QStringList parts;
-    const int reportMarkers = markers.size() - renderedMonitors;
-    if (anyone) {
+    const int selectedMarkerCount = hasSelectedCallsignMarker
+                                 && !(queryIsHomeStation && hasHome) ? 1 : 0;
+    const int reportMarkers = markers.size() - renderedMonitors
+                            - selectedMarkerCount;
+    if (globalEnabled) {
         parts << tr("%n report(s)", nullptr, reportMarkers);
-        parts << tr("%n active monitor(s)", nullptr, renderedMonitors);
-        if (m_client->resultsLimited()
-            || m_client->monitors().size() > kMaxRenderedMonitors) {
+        if (m_activeMonitorsCheck->isChecked()) {
+            parts << tr("%n active monitor(s)", nullptr, renderedMonitors);
+        }
+        if (renderedLiveReports > 0) {
+            parts << tr("%1 live: %2")
+                         .arg(m_appliedMapCallsign)
+                         .arg(renderedLiveReports);
+        }
+        if (m_globalClient->resultsLimited()
+            || m_globalClient->monitors().size() > kMaxRenderedMonitors) {
             parts << tr("display capped");
         }
     } else if (!markers.isEmpty()) {
@@ -1609,7 +1885,7 @@ void PskReporterMapDialog::showEvent(QShowEvent* event)
     }
     if (!m_started) {
         m_started = true;
-        restartClient();
+        restartClients();
     }
 }
 
@@ -1620,6 +1896,7 @@ void PskReporterMapDialog::closeEvent(QCloseEvent* event)
     }
     // Stop hitting the network while the window is closed.
     m_client->stop();
+    m_globalClient->stop();
     m_started = false;
     PersistentDialog::closeEvent(event);
 }

--- a/src/gui/PskReporterMapDialog.h
+++ b/src/gui/PskReporterMapDialog.h
@@ -44,9 +44,10 @@ protected:
 private:
     void rebuildMarkers();
     void updateHomeFromRadio();
-    void onIntervalChanged(int index);
     void onLookbackChanged(int index);
-    void restartClient();
+    void restartClients();
+    void restartGlobalClient();
+    void restartCallsignClient();
     void applyMapCallsign();
     void updateBandConditions();
     void updateConnectionIndicator();
@@ -72,9 +73,9 @@ private:
     AudioEngine*         m_audioEngine{nullptr};
     RadioModel*         m_radioModel{nullptr};
     PskReporterClient*  m_client{nullptr};
+    PskReporterClient*  m_globalClient{nullptr};
     PropForecastClient* m_propForecast{nullptr};
     MapView*            m_mapView{nullptr};
-    QComboBox*          m_intervalCombo{nullptr};
     QComboBox*          m_bandCombo{nullptr};
     QComboBox*          m_modeCombo{nullptr};
     QComboBox*          m_lookbackCombo{nullptr};
@@ -83,6 +84,8 @@ private:
     QLabel*             m_dxLabel{nullptr};
     QLabel*             m_connLabel{nullptr};
     QCheckBox*          m_pathsCheck{nullptr};
+    QCheckBox*          m_allCallsignsCheck{nullptr};
+    QCheckBox*          m_activeMonitorsCheck{nullptr};
     QCheckBox*          m_terminatorCheck{nullptr};
     QTimer*             m_emptyStateTimer{nullptr};
     QTimer*             m_lookbackDebounce{nullptr};
@@ -125,6 +128,7 @@ private:
     bool                m_beaconTransmitting{false};
     QLabel*             m_bandCondPills[4]{};
     bool                m_started{false};
+    bool                m_mapCallsignUserEdited{false};
     QString             m_appliedMapCallsign;
 };
 

--- a/src/gui/PskReporterMapDialog.h
+++ b/src/gui/PskReporterMapDialog.h
@@ -47,6 +47,7 @@ private:
     void onIntervalChanged(int index);
     void onLookbackChanged(int index);
     void restartClient();
+    void applyMapCallsign();
     void updateBandConditions();
     void updateConnectionIndicator();
     void scheduleBeacon();
@@ -77,12 +78,15 @@ private:
     QComboBox*          m_bandCombo{nullptr};
     QComboBox*          m_modeCombo{nullptr};
     QComboBox*          m_lookbackCombo{nullptr};
+    QLineEdit*          m_queryCallsign{nullptr};
     QLabel*             m_statusLabel{nullptr};
     QLabel*             m_dxLabel{nullptr};
     QLabel*             m_connLabel{nullptr};
     QCheckBox*          m_pathsCheck{nullptr};
+    QCheckBox*          m_terminatorCheck{nullptr};
     QTimer*             m_emptyStateTimer{nullptr};
     QTimer*             m_lookbackDebounce{nullptr};
+    QTimer*             m_markerRefreshTimer{nullptr};
     QTimer*             m_beaconTimer{nullptr};
     QLineEdit*          m_beaconCallsign{nullptr};
     QLineEdit*          m_beaconGrid{nullptr};
@@ -121,6 +125,7 @@ private:
     bool                m_beaconTransmitting{false};
     QLabel*             m_bandCondPills[4]{};
     bool                m_started{false};
+    QString             m_appliedMapCallsign;
 };
 
 } // namespace AetherSDR

--- a/src/gui/map/MapHoverPathSelection.h
+++ b/src/gui/map/MapHoverPathSelection.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "MapView.h"
+
+namespace AetherSDR::MapHoverPathSelection {
+
+inline QVector<MapView::Marker> pathsForMarker(
+    const QVector<MapView::Marker>& markers, int markerIndex)
+{
+    if (markerIndex < 0 || markerIndex >= markers.size()) {
+        return {};
+    }
+    const MapView::Marker& marker = markers.at(markerIndex);
+    if (!marker.hoverShowsPathGroup || marker.pathGroup.isEmpty()) {
+        return marker.pathEnabled ? QVector<MapView::Marker>{marker}
+                                  : QVector<MapView::Marker>{};
+    }
+
+    QVector<MapView::Marker> paths;
+    for (const MapView::Marker& candidate : markers) {
+        if (candidate.pathEnabled
+            && candidate.pathGroup == marker.pathGroup) {
+            paths.append(candidate);
+        }
+    }
+    return paths;
+}
+
+} // namespace AetherSDR::MapHoverPathSelection

--- a/src/gui/map/MapMarkerBatchItem.cpp
+++ b/src/gui/map/MapMarkerBatchItem.cpp
@@ -1,0 +1,416 @@
+#include "MapMarkerBatchItem.h"
+
+#include <QGeoView/QGVCamera.h>
+#include <QGeoView/QGVMap.h>
+#include <QGeoView/QGVMapQGItem.h>
+#include <QGeoView/QGVMapQGView.h>
+#include <QGeoView/QGVProjection.h>
+
+#include <QFont>
+#include <QFontMetricsF>
+#include <QGraphicsItem>
+#include <QGraphicsScene>
+#include <QHash>
+#include <QPainter>
+#include <QtConcurrent/QtConcurrentRun>
+
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+constexpr double kDotRadius = 5.0;
+constexpr double kMonitorRadius = 7.0;
+constexpr double kHitRadius = 9.0;
+constexpr double kLabelGap = 3.0;
+constexpr int kMaxWorldCopies = 4;
+constexpr int kCacheRebuildDelayMs = 250;
+constexpr int kOverviewRefreshMs = 30000;
+constexpr int kMaxCacheDimension = 3072;
+constexpr int kOverviewCacheDimension = 2048;
+constexpr double kCacheMargin = 0.5;
+
+QFont markerFont()
+{
+    QFont font;
+    font.setPointSizeF(9.0);
+    font.setBold(true);
+    return font;
+}
+
+double radiusFor(const MapView::Marker& marker)
+{
+    return marker.isMonitor ? kMonitorRadius : kDotRadius;
+}
+
+void disableRedundantDeviceCache(QGVDrawItem* drawItem, QGVMap* geoMap)
+{
+    for (QGraphicsItem* item : geoMap->geoView()->scene()->items()) {
+        if (QGVMapQGItem::geoObjectFromQGItem(item) == drawItem) {
+            item->setCacheMode(QGraphicsItem::NoCache);
+            return;
+        }
+    }
+}
+} // namespace
+
+MapMarkerBatchItem::MapMarkerBatchItem(
+    const QVector<MapView::Marker>& markers,
+    const QColor& labelHalo, const QColor& labelText)
+    : m_markers(markers)
+    , m_labelHalo(labelHalo)
+    , m_labelText(labelText)
+{
+    setSelectable(false);
+    m_cacheTimer.setSingleShot(true);
+    m_cacheTimer.setInterval(kCacheRebuildDelayMs);
+    connect(&m_cacheTimer, &QTimer::timeout,
+            this, &MapMarkerBatchItem::rebuildCache);
+    m_overviewRefreshTimer.setSingleShot(true);
+    m_overviewRefreshTimer.setInterval(kOverviewRefreshMs);
+    connect(&m_overviewRefreshTimer, &QTimer::timeout,
+            this, &MapMarkerBatchItem::rebuildOverviewCache);
+}
+
+MapMarkerBatchItem::~MapMarkerBatchItem()
+{
+    if (m_cacheCancelled) {
+        m_cacheCancelled->store(true, std::memory_order_relaxed);
+    }
+    if (m_overviewCancelled) {
+        m_overviewCancelled->store(true, std::memory_order_relaxed);
+    }
+}
+
+void MapMarkerBatchItem::setMarkers(
+    const QVector<MapView::Marker>& markers)
+{
+    if (m_cacheCancelled) {
+        m_cacheCancelled->store(true, std::memory_order_relaxed);
+    }
+    if (m_overviewCancelled) {
+        m_overviewCancelled->store(true, std::memory_order_relaxed);
+    }
+    m_markers = markers;
+    if (getMap() == nullptr) {
+        return;
+    }
+    projectMarkers(getMap()->getProjection());
+    // Keep the existing detail image visible while its replacement renders.
+    // The whole-world overview is only a brief camera-gesture fallback; a
+    // multi-megapixel rebuild for every MQTT report wastes CPU and exposes its
+    // different effective pixel scale between detail frames.
+    rebuildCache();
+    if (!m_overviewRefreshTimer.isActive()) {
+        m_overviewRefreshTimer.start();
+    }
+    refresh();
+}
+
+void MapMarkerBatchItem::projectMarkers(const QGVProjection* projection)
+{
+    m_projected.clear();
+    m_projected.reserve(m_markers.size());
+    for (const MapView::Marker& marker : std::as_const(m_markers)) {
+        m_projected.append(projection->geoToProj(
+            QGV::GeoPos(marker.lat, marker.lon)));
+    }
+}
+
+void MapMarkerBatchItem::onProjection(QGVMap* geoMap)
+{
+    QGVDrawItem::onProjection(geoMap);
+    disableRedundantDeviceCache(this, geoMap);
+    const QGVProjection* projection = geoMap->getProjection();
+    m_worldRect = projection->boundaryProjRect();
+    projectMarkers(projection);
+    rebuildOverviewCache();
+    rebuildCache();
+    resetBoundary();
+    refresh();
+}
+
+void MapMarkerBatchItem::onCamera(const QGVCameraState& oldState,
+                                  const QGVCameraState& newState)
+{
+    QGVDrawItem::onCamera(oldState, newState);
+    if (m_cache.isNull()) {
+        rebuildCache();
+        return;
+    }
+    const bool scaleChanged = m_cacheScale <= 0.0
+        || std::abs(newState.scale() / m_cacheScale - 1.0) > 0.02;
+    const QRectF safeRect = m_cacheRect.adjusted(
+        newState.projRect().width() * 0.25,
+        newState.projRect().height() * 0.25,
+        -newState.projRect().width() * 0.25,
+        -newState.projRect().height() * 0.25);
+    if (scaleChanged || !safeRect.contains(newState.projRect())) {
+        scheduleCacheRebuild();
+    }
+}
+
+void MapMarkerBatchItem::scheduleCacheRebuild()
+{
+    if (m_cacheCancelled) {
+        m_cacheCancelled->store(true, std::memory_order_relaxed);
+    }
+    ++m_cacheGeneration;
+    m_cacheTimer.start();
+}
+
+void MapMarkerBatchItem::rebuildCache()
+{
+    if (getMap() == nullptr || m_worldRect.isEmpty()) {
+        return;
+    }
+    const QGVCameraState& camera = getMap()->getCamera();
+    const QRectF visible = camera.projRect();
+    if (visible.isEmpty() || camera.scale() <= 0.0) {
+        return;
+    }
+    QRectF cacheRect = visible.adjusted(
+        -visible.width() * kCacheMargin,
+        -visible.height() * kCacheMargin,
+        visible.width() * kCacheMargin,
+        visible.height() * kCacheMargin);
+    cacheRect.setTop(qMax(cacheRect.top(), m_worldRect.top()));
+    cacheRect.setBottom(qMin(cacheRect.bottom(), m_worldRect.bottom()));
+    const double cacheScale = qMin(camera.scale(), qMin(
+        static_cast<double>(kMaxCacheDimension) / cacheRect.width(),
+        static_cast<double>(kMaxCacheDimension) / cacheRect.height()));
+
+    const quint64 generation = ++m_cacheGeneration;
+    m_cacheCancelled = std::make_shared<std::atomic_bool>(false);
+    const std::shared_ptr<std::atomic_bool> cancelled = m_cacheCancelled;
+    auto* watcher = new QFutureWatcher<CacheResult>(this);
+    connect(watcher, &QFutureWatcher<CacheResult>::finished, this,
+            [this, watcher, generation] {
+                const CacheResult result = watcher->result();
+                watcher->deleteLater();
+                if (generation != m_cacheGeneration || result.image.isNull()) {
+                    return;
+                }
+                m_cacheRect = result.rect;
+                m_cacheScale = result.scale;
+                m_cache = result.image;
+                repaint();
+            });
+    watcher->setFuture(QtConcurrent::run(
+        &MapMarkerBatchItem::renderCache, m_markers, m_projected, m_worldRect,
+        cacheRect, cacheScale, m_labelHalo, m_labelText, true, cancelled));
+}
+
+void MapMarkerBatchItem::rebuildOverviewCache()
+{
+    if (m_worldRect.isEmpty()) {
+        return;
+    }
+    const double scale = qMin(
+        static_cast<double>(kOverviewCacheDimension) / m_worldRect.width(),
+        static_cast<double>(kOverviewCacheDimension) / m_worldRect.height());
+    const quint64 generation = ++m_overviewGeneration;
+    if (m_overviewCancelled) {
+        m_overviewCancelled->store(true, std::memory_order_relaxed);
+    }
+    m_overviewCancelled = std::make_shared<std::atomic_bool>(false);
+    const std::shared_ptr<std::atomic_bool> cancelled = m_overviewCancelled;
+    auto* watcher = new QFutureWatcher<CacheResult>(this);
+    connect(watcher, &QFutureWatcher<CacheResult>::finished, this,
+            [this, watcher, generation] {
+                const CacheResult result = watcher->result();
+                watcher->deleteLater();
+                if (generation != m_overviewGeneration
+                    || result.image.isNull()) {
+                    return;
+                }
+                m_overviewCache = result.image;
+                repaint();
+            });
+    // Labels belong to the detailed cache. Omitting them here keeps this
+    // whole-world fallback quick and uncluttered; its job is to preserve
+    // geographic coverage while a post-gesture detail render finishes.
+    watcher->setFuture(QtConcurrent::run(
+        &MapMarkerBatchItem::renderCache, m_markers, m_projected, m_worldRect,
+        m_worldRect, scale, QColor(), QColor(), false, cancelled));
+}
+
+MapMarkerBatchItem::CacheResult MapMarkerBatchItem::renderCache(
+    QVector<MapView::Marker> markers, QVector<QPointF> projected,
+    QRectF worldRect, QRectF cacheRect, double cacheScale,
+    QColor labelHalo, QColor labelText, bool renderLabels,
+    std::shared_ptr<std::atomic_bool> cancelled)
+{
+    if (cancelled->load(std::memory_order_relaxed)) {
+        return {};
+    }
+    const QSize imageSize(
+        qMax(1, qCeil(cacheRect.width() * cacheScale)),
+        qMax(1, qCeil(cacheRect.height() * cacheScale)));
+    QImage cache(imageSize, QImage::Format_ARGB32_Premultiplied);
+    cache.fill(Qt::transparent);
+
+    QPainter cachePainter(&cache);
+    cachePainter.setRenderHint(QPainter::Antialiasing);
+    cachePainter.setFont(markerFont());
+    const double worldWidth = worldRect.width();
+
+    struct ShapeGroup {
+        QColor color;
+        bool monitor{false};
+        QPainterPath dots;
+        QPainterPath centers;
+    };
+    struct Label {
+        int markerIndex{-1};
+        QPointF point;
+    };
+    QVector<ShapeGroup> shapeGroups;
+    QVector<Label> labels;
+    QHash<quint64, int> groupIndexes;
+    for (int i = 0; i < markers.size(); ++i) {
+        if (cancelled->load(std::memory_order_relaxed)) {
+            cachePainter.end();
+            return {};
+        }
+        const MapView::Marker& marker = markers.at(i);
+        const QPointF base = projected.at(i);
+        const int firstCopy = static_cast<int>(std::floor(
+            (cacheRect.left() - base.x()) / worldWidth));
+        const int lastCopy = static_cast<int>(std::ceil(
+            (cacheRect.right() - base.x()) / worldWidth));
+        for (int copy = firstCopy; copy <= lastCopy; ++copy) {
+            const QPointF projected(base.x() + copy * worldWidth, base.y());
+            if (!cacheRect.contains(projected)) {
+                continue;
+            }
+            const QPointF point(
+                (projected.x() - cacheRect.left()) * cacheScale,
+                (projected.y() - cacheRect.top()) * cacheScale);
+            const double radius = radiusFor(marker);
+            const quint64 key = (static_cast<quint64>(marker.color.rgba()) << 1)
+                              | (marker.isMonitor ? 1ULL : 0ULL);
+            int groupIndex = groupIndexes.value(key, -1);
+            if (groupIndex < 0) {
+                groupIndex = shapeGroups.size();
+                groupIndexes.insert(key, groupIndex);
+                ShapeGroup group;
+                group.color = marker.color;
+                group.monitor = marker.isMonitor;
+                shapeGroups.append(group);
+            }
+            ShapeGroup& group = shapeGroups[groupIndex];
+            group.dots.addEllipse(point, radius, radius);
+            if (marker.isMonitor) {
+                group.centers.addEllipse(point, 2.0, 2.0);
+            }
+            if (renderLabels && !marker.label.isEmpty()) {
+                labels.append({i, point});
+            }
+        }
+    }
+
+    for (const ShapeGroup& group : std::as_const(shapeGroups)) {
+        QColor outline = group.color.darker(220);
+        outline.setAlpha(180);
+        cachePainter.setPen(QPen(outline, group.monitor ? 1.5 : 1.0));
+        cachePainter.setBrush(group.color);
+        cachePainter.drawPath(group.dots);
+        if (group.monitor) {
+            QColor center = group.color.lighter(250);
+            center.setAlpha(210);
+            cachePainter.setPen(Qt::NoPen);
+            cachePainter.setBrush(center);
+            cachePainter.drawPath(group.centers);
+        }
+    }
+    const QFontMetricsF metrics(cachePainter.font());
+    for (const Label& label : std::as_const(labels)) {
+        if (cancelled->load(std::memory_order_relaxed)) {
+            cachePainter.end();
+            return {};
+        }
+        const MapView::Marker& marker = markers.at(label.markerIndex);
+        const QRectF labelRect(
+            label.point.x() + radiusFor(marker) + kLabelGap,
+            label.point.y() - metrics.height() / 2.0,
+            metrics.horizontalAdvance(marker.label), metrics.height());
+        cachePainter.setPen(labelHalo);
+        for (const QPointF delta : {QPointF{1, 0}, QPointF{-1, 0},
+                                     QPointF{0, 1}, QPointF{0, -1}}) {
+            cachePainter.drawText(labelRect.translated(delta),
+                                  Qt::TextSingleLine, marker.label);
+        }
+        cachePainter.setPen(labelText);
+        cachePainter.drawText(labelRect, Qt::TextSingleLine, marker.label);
+    }
+    cachePainter.end();
+    return {cacheRect, cache, cacheScale};
+}
+
+QPainterPath MapMarkerBatchItem::projShape() const
+{
+    QPainterPath shape;
+    for (int copy = -kMaxWorldCopies; copy <= kMaxWorldCopies; ++copy) {
+        shape.addRect(m_worldRect.translated(copy * m_worldRect.width(), 0.0));
+    }
+    return shape;
+}
+
+void MapMarkerBatchItem::projPaint(QPainter* painter)
+{
+    if ((m_cache.isNull() || m_cacheRect.isEmpty())
+        && m_overviewCache.isNull()) {
+        return;
+    }
+    painter->setRenderHint(QPainter::SmoothPixmapTransform, true);
+    const QRectF visible = getMap() != nullptr
+        ? getMap()->getCamera().projRect() : QRectF();
+    if (!m_overviewCache.isNull() && !visible.isEmpty()
+        && (m_cache.isNull() || !m_cacheRect.contains(visible))) {
+        const double worldWidth = m_worldRect.width();
+        const int firstCopy = static_cast<int>(std::floor(
+            (visible.left() - m_worldRect.right()) / worldWidth));
+        const int lastCopy = static_cast<int>(std::ceil(
+            (visible.right() - m_worldRect.left()) / worldWidth));
+        for (int copy = firstCopy; copy <= lastCopy; ++copy) {
+            painter->drawImage(
+                m_worldRect.translated(copy * worldWidth, 0.0),
+                m_overviewCache);
+        }
+    }
+    if (!m_cache.isNull() && !m_cacheRect.isEmpty()) {
+        painter->drawImage(m_cacheRect, m_cache);
+    }
+}
+
+int MapMarkerBatchItem::markerAt(const QPointF& projPos) const
+{
+    if (getMap() == nullptr || m_worldRect.isEmpty()) {
+        return -1;
+    }
+    const double scale = getMap()->getCamera().scale();
+    if (scale <= 0.0) {
+        return -1;
+    }
+    const double threshold = kHitRadius / scale;
+    const double thresholdSquared = threshold * threshold;
+    const double worldWidth = m_worldRect.width();
+    int nearest = -1;
+    double nearestSquared = thresholdSquared;
+    for (int i = 0; i < m_projected.size(); ++i) {
+        QPointF point = m_projected.at(i);
+        point.rx() += qRound((projPos.x() - point.x()) / worldWidth)
+                    * worldWidth;
+        const double dx = point.x() - projPos.x();
+        const double dy = point.y() - projPos.y();
+        const double distanceSquared = dx * dx + dy * dy;
+        if (distanceSquared <= nearestSquared) {
+            nearestSquared = distanceSquared;
+            nearest = i;
+        }
+    }
+    return nearest;
+}
+
+} // namespace AetherSDR

--- a/src/gui/map/MapMarkerBatchItem.cpp
+++ b/src/gui/map/MapMarkerBatchItem.cpp
@@ -124,7 +124,11 @@ void MapMarkerBatchItem::onProjection(QGVMap* geoMap)
     const QGVProjection* projection = geoMap->getProjection();
     m_worldRect = projection->boundaryProjRect();
     projectMarkers(projection);
-    rebuildOverviewCache();
+    // The current-camera detail is the first useful frame. Rendering the
+    // whole-world gesture fallback at the same time makes two large images
+    // compete for the thread pool and delays initial marker visibility.
+    // Build the overview after this first detail image completes; until then
+    // the detail cache remains visible.
     rebuildCache();
     resetBoundary();
     refresh();
@@ -181,6 +185,9 @@ void MapMarkerBatchItem::rebuildCache()
         static_cast<double>(kMaxCacheDimension) / cacheRect.height()));
 
     const quint64 generation = ++m_cacheGeneration;
+    if (m_cacheCancelled) {
+        m_cacheCancelled->store(true, std::memory_order_relaxed);
+    }
     m_cacheCancelled = std::make_shared<std::atomic_bool>(false);
     const std::shared_ptr<std::atomic_bool> cancelled = m_cacheCancelled;
     auto* watcher = new QFutureWatcher<CacheResult>(this);
@@ -195,6 +202,10 @@ void MapMarkerBatchItem::rebuildCache()
                 m_cacheScale = result.scale;
                 m_cache = result.image;
                 repaint();
+                if (m_overviewCache.isNull()) {
+                    m_overviewRefreshTimer.stop();
+                    rebuildOverviewCache();
+                }
             });
     watcher->setFuture(QtConcurrent::run(
         &MapMarkerBatchItem::renderCache, m_markers, m_projected, m_worldRect,
@@ -258,8 +269,7 @@ MapMarkerBatchItem::CacheResult MapMarkerBatchItem::renderCache(
     struct ShapeGroup {
         QColor color;
         bool monitor{false};
-        QPainterPath dots;
-        QPainterPath centers;
+        QVector<QPointF> points;
     };
     struct Label {
         int markerIndex{-1};
@@ -287,7 +297,6 @@ MapMarkerBatchItem::CacheResult MapMarkerBatchItem::renderCache(
             const QPointF point(
                 (projected.x() - cacheRect.left()) * cacheScale,
                 (projected.y() - cacheRect.top()) * cacheScale);
-            const double radius = radiusFor(marker);
             const quint64 key = (static_cast<quint64>(marker.color.rgba()) << 1)
                               | (marker.isMonitor ? 1ULL : 0ULL);
             int groupIndex = groupIndexes.value(key, -1);
@@ -300,10 +309,7 @@ MapMarkerBatchItem::CacheResult MapMarkerBatchItem::renderCache(
                 shapeGroups.append(group);
             }
             ShapeGroup& group = shapeGroups[groupIndex];
-            group.dots.addEllipse(point, radius, radius);
-            if (marker.isMonitor) {
-                group.centers.addEllipse(point, 2.0, 2.0);
-            }
+            group.points.append(point);
             if (renderLabels && !marker.label.isEmpty()) {
                 labels.append({i, point});
             }
@@ -313,15 +319,24 @@ MapMarkerBatchItem::CacheResult MapMarkerBatchItem::renderCache(
     for (const ShapeGroup& group : std::as_const(shapeGroups)) {
         QColor outline = group.color.darker(220);
         outline.setAlpha(180);
-        cachePainter.setPen(QPen(outline, group.monitor ? 1.5 : 1.0));
-        cachePainter.setBrush(group.color);
-        cachePainter.drawPath(group.dots);
+        const double radius = group.monitor ? kMonitorRadius : kDotRadius;
+        // A single compound QPainterPath containing thousands of ellipses is
+        // expensive for Qt to tessellate, especially when the whole world is
+        // visible. Round-cap point batches produce the same circular markers
+        // without that nonlinear path-fill cost.
+        cachePainter.setPen(QPen(outline, radius * 2.0 + 2.0,
+                                 Qt::SolidLine, Qt::RoundCap));
+        cachePainter.drawPoints(group.points.constData(), group.points.size());
+        cachePainter.setPen(QPen(group.color, radius * 2.0,
+                                 Qt::SolidLine, Qt::RoundCap));
+        cachePainter.drawPoints(group.points.constData(), group.points.size());
         if (group.monitor) {
             QColor center = group.color.lighter(250);
             center.setAlpha(210);
-            cachePainter.setPen(Qt::NoPen);
-            cachePainter.setBrush(center);
-            cachePainter.drawPath(group.centers);
+            cachePainter.setPen(QPen(center, 4.0, Qt::SolidLine,
+                                     Qt::RoundCap));
+            cachePainter.drawPoints(group.points.constData(),
+                                    group.points.size());
         }
     }
     const QFontMetricsF metrics(cachePainter.font());

--- a/src/gui/map/MapMarkerBatchItem.h
+++ b/src/gui/map/MapMarkerBatchItem.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "MapView.h"
+
+#include <QGeoView/QGVDrawItem.h>
+
+#include <QColor>
+#include <QImage>
+#include <QFutureWatcher>
+#include <QTimer>
+
+#include <atomic>
+#include <memory>
+
+class QGVProjection;
+
+namespace AetherSDR {
+
+class MapBatchItemTestAccess;
+
+// Draws every non-home marker in one scene item.  Thousands of individual
+// QGVDrawItems make every camera change walk thousands of QObject/item
+// boundaries; this batch keeps the same marker data and hit testing while the
+// scene only has one camera participant.
+class MapMarkerBatchItem : public QGVDrawItem {
+    Q_OBJECT
+
+public:
+    MapMarkerBatchItem(const QVector<MapView::Marker>& markers,
+                       const QColor& labelHalo, const QColor& labelText);
+    ~MapMarkerBatchItem() override;
+
+    void setMarkers(const QVector<MapView::Marker>& markers);
+    int markerAt(const QPointF& projPos) const;
+    const MapView::Marker& marker(int index) const { return m_markers.at(index); }
+
+private:
+    friend class MapBatchItemTestAccess;
+    struct CacheResult {
+        QRectF rect;
+        QImage image;
+        double scale{0.0};
+    };
+
+    void onProjection(QGVMap* geoMap) override;
+    void onCamera(const QGVCameraState& oldState,
+                  const QGVCameraState& newState) override;
+    QPainterPath projShape() const override;
+    void projPaint(QPainter* painter) override;
+    void rebuildCache();
+    void rebuildOverviewCache();
+    void scheduleCacheRebuild();
+    void projectMarkers(const QGVProjection* projection);
+    static CacheResult renderCache(QVector<MapView::Marker> markers,
+                                   QVector<QPointF> projected,
+                                   QRectF worldRect, QRectF cacheRect,
+                                   double cacheScale, QColor labelHalo,
+                                   QColor labelText, bool renderLabels,
+                                   std::shared_ptr<std::atomic_bool> cancelled);
+
+    QVector<MapView::Marker> m_markers;
+    QVector<QPointF> m_projected;
+    QColor m_labelHalo;
+    QColor m_labelText;
+    QRectF m_worldRect;
+    QRectF m_cacheRect;
+    QImage m_cache;
+    double m_cacheScale{0.0};
+    QImage m_overviewCache;
+    QTimer m_cacheTimer;
+    QTimer m_overviewRefreshTimer;
+    quint64 m_cacheGeneration{0};
+    quint64 m_overviewGeneration{0};
+    std::shared_ptr<std::atomic_bool> m_cacheCancelled;
+    std::shared_ptr<std::atomic_bool> m_overviewCancelled;
+};
+
+} // namespace AetherSDR

--- a/src/gui/map/MapMarkerItem.cpp
+++ b/src/gui/map/MapMarkerItem.cpp
@@ -12,6 +12,7 @@ namespace AetherSDR {
 namespace {
 constexpr double kDotRadius = 5.0;       // px
 constexpr double kHomeRadius = 7.0;      // px
+constexpr double kMonitorRadius = 7.0;   // px
 constexpr double kLabelOffset = 3.0;     // px gap between dot and label
 constexpr double kPulseMaxRadius = 26.0; // px, sonar ring sweep extent
 
@@ -21,6 +22,14 @@ QFont markerFont()
     f.setPointSizeF(9.0);
     f.setBold(true);
     return f;
+}
+
+double markerRadius(const MapView::Marker& marker)
+{
+    if (marker.isHome) {
+        return kHomeRadius;
+    }
+    return marker.isMonitor ? kMonitorRadius : kDotRadius;
 }
 } // namespace
 
@@ -96,7 +105,7 @@ QRectF MapMarkerItem::labelRect() const
     }
     const QFontMetricsF fm(markerFont());
     const QSizeF size = fm.size(Qt::TextSingleLine, m_marker.label);
-    const double r = m_marker.isHome ? kHomeRadius : kDotRadius;
+    const double r = markerRadius(m_marker);
     return { m_projPos.x() + r + kLabelOffset,
              m_projPos.y() - size.height() / 2.0,
              size.width(), size.height() };
@@ -104,7 +113,7 @@ QRectF MapMarkerItem::labelRect() const
 
 QPainterPath MapMarkerItem::projShape() const
 {
-    const double r = m_marker.isHome ? kHomeRadius : kDotRadius;
+    const double r = markerRadius(m_marker);
     QPainterPath path;
     path.addEllipse(m_projPos, r, r);
     if (m_marker.isHome) {
@@ -121,7 +130,7 @@ QPainterPath MapMarkerItem::projShape() const
 void MapMarkerItem::projPaint(QPainter* painter)
 {
     painter->setRenderHint(QPainter::Antialiasing);
-    const double r = m_marker.isHome ? kHomeRadius : kDotRadius;
+    const double r = markerRadius(m_marker);
 
     if (m_marker.isHome && m_pulsePhase >= 0.0) {
         // Sonar pulse: expanding, fading ring.
@@ -143,6 +152,17 @@ void MapMarkerItem::projPaint(QPainter* painter)
         painter->setBrush(m_marker.color);
         painter->setPen(Qt::NoPen);
         painter->drawEllipse(m_projPos, r / 2.5, r / 2.5);
+    } else if (m_marker.isMonitor) {
+        QColor outline = m_marker.color.darker(220);
+        outline.setAlpha(180);
+        painter->setPen(QPen(outline, 1.5));
+        painter->setBrush(m_marker.color);
+        painter->drawEllipse(m_projPos, r, r);
+        QColor center = m_marker.color.lighter(250);
+        center.setAlpha(210);
+        painter->setBrush(center);
+        painter->setPen(Qt::NoPen);
+        painter->drawEllipse(m_projPos, 2.0, 2.0);
     } else {
         painter->setPen(QPen(QColor(0, 0, 0, 160), 1.0));
         painter->setBrush(m_marker.color);

--- a/src/gui/map/MapPathBatchItem.cpp
+++ b/src/gui/map/MapPathBatchItem.cpp
@@ -1,0 +1,493 @@
+#include "MapPathBatchItem.h"
+#include "MapPathGeometry.h"
+
+#include <QGeoView/QGVCamera.h>
+#include <QGeoView/QGVMap.h>
+#include <QGeoView/QGVMapQGItem.h>
+#include <QGeoView/QGVMapQGView.h>
+#include <QGeoView/QGVProjection.h>
+
+#include <QGraphicsItem>
+#include <QGraphicsScene>
+#include <QHash>
+#include <QPainter>
+#include <QSize>
+#include <QtConcurrent/QtConcurrentRun>
+#include <QtMath>
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+constexpr int kSegments = 32;
+constexpr int kMaxWorldCopies = 4;
+constexpr int kCacheRebuildDelayMs = 250;
+constexpr int kOverviewRefreshMs = 30000;
+constexpr int kMaxCacheDimension = 3072;
+constexpr int kOverviewCacheDimension = 1024;
+constexpr double kCacheMargin = 0.5;
+
+QGV::GeoPos slerp(double lat1, double lon1, double lat2, double lon2,
+                  double fraction)
+{
+    const double phi1 = qDegreesToRadians(lat1);
+    const double lambda1 = qDegreesToRadians(lon1);
+    const double phi2 = qDegreesToRadians(lat2);
+    const double lambda2 = qDegreesToRadians(lon2);
+    const double distance = 2.0 * std::asin(std::sqrt(
+        std::pow(std::sin((phi1 - phi2) / 2.0), 2)
+        + std::cos(phi1) * std::cos(phi2)
+              * std::pow(std::sin((lambda1 - lambda2) / 2.0), 2)));
+    if (distance < 1e-9) {
+        return {lat1, lon1};
+    }
+    const double a = std::sin((1.0 - fraction) * distance)
+                   / std::sin(distance);
+    const double b = std::sin(fraction * distance) / std::sin(distance);
+    const double x = a * std::cos(phi1) * std::cos(lambda1)
+                   + b * std::cos(phi2) * std::cos(lambda2);
+    const double y = a * std::cos(phi1) * std::sin(lambda1)
+                   + b * std::cos(phi2) * std::sin(lambda2);
+    const double z = a * std::sin(phi1) + b * std::sin(phi2);
+    return {qRadiansToDegrees(std::atan2(z, std::sqrt(x * x + y * y))),
+            qRadiansToDegrees(std::atan2(y, x))};
+}
+
+QPointF geoToWebMercator(double latitude, double longitude,
+                         const QRectF& worldRect)
+{
+    constexpr double kMaxLatitude = 85.0;
+    const double originShift = worldRect.width() / 2.0;
+    const double lat = std::clamp(latitude, -kMaxLatitude, kMaxLatitude);
+    const double x = longitude * originShift / 180.0;
+    const double preY = -std::log(std::tan(
+        (90.0 + lat) * M_PI / 360.0)) / (M_PI / 180.0);
+    const double y = preY * originShift / 180.0;
+    return {x, y};
+}
+
+void disableRedundantDeviceCache(QGVDrawItem* drawItem, QGVMap* geoMap)
+{
+    for (QGraphicsItem* item : geoMap->geoView()->scene()->items()) {
+        if (QGVMapQGItem::geoObjectFromQGItem(item) == drawItem) {
+            item->setCacheMode(QGraphicsItem::NoCache);
+            return;
+        }
+    }
+}
+} // namespace
+
+MapPathBatchItem::MapPathBatchItem(const QVector<MapView::Marker>& markers,
+                                   bool hasHome, double homeLat, double homeLon)
+    : m_markers(markers)
+    , m_directPaint(markers.size() == 1)
+    , m_hasHome(hasHome)
+    , m_homeLat(homeLat)
+    , m_homeLon(homeLon)
+{
+    setSelectable(false);
+    setZValue(-1);
+    m_cacheTimer.setSingleShot(true);
+    m_cacheTimer.setInterval(kCacheRebuildDelayMs);
+    connect(&m_cacheTimer, &QTimer::timeout,
+            this, &MapPathBatchItem::rebuildCache);
+    m_overviewRefreshTimer.setSingleShot(true);
+    m_overviewRefreshTimer.setInterval(kOverviewRefreshMs);
+    connect(&m_overviewRefreshTimer, &QTimer::timeout,
+            this, &MapPathBatchItem::rebuildOverviewCache);
+}
+
+MapPathBatchItem::~MapPathBatchItem()
+{
+    if (m_projectionCancelled) {
+        m_projectionCancelled->store(true, std::memory_order_relaxed);
+    }
+    if (m_cacheCancelled) {
+        m_cacheCancelled->store(true, std::memory_order_relaxed);
+    }
+    if (m_overviewCancelled) {
+        m_overviewCancelled->store(true, std::memory_order_relaxed);
+    }
+}
+
+void MapPathBatchItem::setMarkers(
+    const QVector<MapView::Marker>& markers,
+    bool hasHome, double homeLat, double homeLon)
+{
+    if (m_cacheCancelled) {
+        m_cacheCancelled->store(true, std::memory_order_relaxed);
+    }
+    if (m_overviewCancelled) {
+        m_overviewCancelled->store(true, std::memory_order_relaxed);
+    }
+    m_markers = markers;
+    m_directPaint = markers.size() == 1;
+    m_hasHome = hasHome;
+    m_homeLat = homeLat;
+    m_homeLon = homeLon;
+    if (getMap() == nullptr) {
+        return;
+    }
+    rebuildProjectedPaths();
+}
+
+void MapPathBatchItem::rebuildProjectedPaths()
+{
+    if (m_worldRect.isEmpty() || !isVisible()) {
+        return;
+    }
+    if (m_projectionCancelled) {
+        m_projectionCancelled->store(true, std::memory_order_relaxed);
+    }
+    const quint64 generation = ++m_projectionGeneration;
+    m_projectionCancelled = std::make_shared<std::atomic_bool>(false);
+    const std::shared_ptr<std::atomic_bool> cancelled = m_projectionCancelled;
+
+    if (m_directPaint) {
+        m_paths = projectPaths(m_markers, m_hasHome, m_homeLat, m_homeLon,
+                               m_worldRect, cancelled);
+        refresh();
+        return;
+    }
+
+    auto* watcher = new QFutureWatcher<QVector<Path>>(this);
+    connect(watcher, &QFutureWatcher<QVector<Path>>::finished, this,
+            [this, watcher, generation] {
+                QVector<Path> paths = watcher->result();
+                watcher->deleteLater();
+                if (generation != m_projectionGeneration || !isVisible()) {
+                    return;
+                }
+                m_paths = std::move(paths);
+                // Retain the old images until their replacements complete.
+                // A whole-world overview is only needed immediately for the
+                // first data set; subsequent MQTT batches refresh it slowly.
+                if (m_overviewCache.isNull()) {
+                    rebuildOverviewCache();
+                } else if (!m_overviewRefreshTimer.isActive()) {
+                    m_overviewRefreshTimer.start();
+                }
+                rebuildCache();
+                refresh();
+            });
+    watcher->setFuture(QtConcurrent::run(
+        &MapPathBatchItem::projectPaths, m_markers, m_hasHome,
+        m_homeLat, m_homeLon, m_worldRect, cancelled));
+}
+
+QVector<MapPathBatchItem::Path> MapPathBatchItem::projectPaths(
+    QVector<MapView::Marker> markers, bool hasHome,
+    double homeLat, double homeLon, QRectF worldRect,
+    std::shared_ptr<std::atomic_bool> cancelled)
+{
+    const double worldWidth = worldRect.width();
+    QVector<Path> paths;
+    paths.reserve(markers.size());
+    for (const MapView::Marker& marker : std::as_const(markers)) {
+        if (cancelled->load(std::memory_order_relaxed)) {
+            return {};
+        }
+        if (!marker.pathEnabled
+            || (!marker.hasPathOrigin && !hasHome)) {
+            continue;
+        }
+        const double fromLat = marker.hasPathOrigin
+            ? marker.pathFromLat : homeLat;
+        const double fromLon = marker.hasPathOrigin
+            ? marker.pathFromLon : homeLon;
+        QPainterPath projectedPath;
+        QPointF previous;
+        for (int segment = 0; segment <= kSegments; ++segment) {
+            const double fraction = static_cast<double>(segment) / kSegments;
+            const QGV::GeoPos geo = slerp(
+                fromLat, fromLon, marker.lat, marker.lon, fraction);
+            QPointF point = geoToWebMercator(
+                geo.latitude(), geo.longitude(), worldRect);
+            if (segment == 0) {
+                projectedPath.moveTo(point);
+            } else {
+                point.setX(MapPathGeometry::unwrapX(
+                    point.x(), previous.x(), worldWidth));
+                projectedPath.lineTo(point);
+            }
+            previous = point;
+        }
+        Path path;
+        path.projected = projectedPath;
+        path.bounds = projectedPath.boundingRect();
+        path.color = marker.color;
+        paths.append(path);
+    }
+    return paths;
+}
+
+void MapPathBatchItem::setDisplayVisible(bool visible)
+{
+    if (isVisible() == visible) {
+        return;
+    }
+    setVisible(visible);
+    if (m_directPaint) {
+        repaint();
+        return;
+    }
+    if (!visible) {
+        m_cacheTimer.stop();
+        ++m_cacheGeneration;
+        ++m_overviewGeneration;
+        ++m_projectionGeneration;
+        if (m_cacheCancelled) {
+            m_cacheCancelled->store(true, std::memory_order_relaxed);
+        }
+        if (m_overviewCancelled) {
+            m_overviewCancelled->store(true, std::memory_order_relaxed);
+        }
+        if (m_projectionCancelled) {
+            m_projectionCancelled->store(true, std::memory_order_relaxed);
+        }
+        return;
+    }
+    // Reuse any completed cache immediately while refreshing geometry for
+    // marker updates or camera changes made while Paths was hidden.
+    rebuildProjectedPaths();
+    repaint();
+}
+
+void MapPathBatchItem::onProjection(QGVMap* geoMap)
+{
+    QGVDrawItem::onProjection(geoMap);
+    // This item already owns a bounded raster cache. QGeoView's default
+    // device-coordinate cache spans the multi-world item and is invalidated
+    // by every smooth trackpad scale step, making it both redundant and
+    // potentially enormous at high zoom.
+    disableRedundantDeviceCache(this, geoMap);
+    m_worldRect = geoMap->getProjection()->boundaryProjRect();
+    rebuildProjectedPaths();
+    resetBoundary();
+    refresh();
+}
+
+void MapPathBatchItem::onCamera(const QGVCameraState& oldState,
+                                const QGVCameraState& newState)
+{
+    QGVDrawItem::onCamera(oldState, newState);
+    if (!isVisible() || m_directPaint) {
+        return;
+    }
+    if (m_cache.isNull()) {
+        rebuildCache();
+        return;
+    }
+    const bool scaleChanged = m_cacheScale <= 0.0
+        || std::abs(newState.scale() / m_cacheScale - 1.0) > 0.02;
+    const QRectF safeRect = m_cacheRect.adjusted(
+        newState.projRect().width() * 0.25,
+        newState.projRect().height() * 0.25,
+        -newState.projRect().width() * 0.25,
+        -newState.projRect().height() * 0.25);
+    if (scaleChanged || !safeRect.contains(newState.projRect())) {
+        scheduleCacheRebuild();
+    }
+}
+
+void MapPathBatchItem::scheduleCacheRebuild()
+{
+    if (m_cacheCancelled) {
+        m_cacheCancelled->store(true, std::memory_order_relaxed);
+    }
+    ++m_cacheGeneration;
+    m_cacheTimer.start();
+}
+
+void MapPathBatchItem::rebuildCache()
+{
+    if (getMap() == nullptr || m_worldRect.isEmpty()) {
+        return;
+    }
+    const QGVCameraState& camera = getMap()->getCamera();
+    const QRectF visible = camera.projRect();
+    if (visible.isEmpty() || camera.scale() <= 0.0) {
+        return;
+    }
+    QRectF cacheRect = visible.adjusted(
+        -visible.width() * kCacheMargin,
+        -visible.height() * kCacheMargin,
+        visible.width() * kCacheMargin,
+        visible.height() * kCacheMargin);
+    cacheRect.setTop(qMax(cacheRect.top(), m_worldRect.top()));
+    cacheRect.setBottom(qMin(cacheRect.bottom(), m_worldRect.bottom()));
+    const double cacheScale = qMin(camera.scale(), qMin(
+        static_cast<double>(kMaxCacheDimension) / cacheRect.width(),
+        static_cast<double>(kMaxCacheDimension) / cacheRect.height()));
+    const quint64 generation = ++m_cacheGeneration;
+    m_cacheCancelled = std::make_shared<std::atomic_bool>(false);
+    const std::shared_ptr<std::atomic_bool> cancelled = m_cacheCancelled;
+    auto* watcher = new QFutureWatcher<CacheResult>(this);
+    connect(watcher, &QFutureWatcher<CacheResult>::finished, this,
+            [this, watcher, generation] {
+                const CacheResult result = watcher->result();
+                watcher->deleteLater();
+                if (generation != m_cacheGeneration || result.image.isNull()) {
+                    return;
+                }
+                m_cacheRect = result.rect;
+                m_cacheScale = result.scale;
+                m_cache = result.image;
+                repaint();
+            });
+    watcher->setFuture(QtConcurrent::run(
+        &MapPathBatchItem::renderCache, m_paths, m_worldRect,
+        cacheRect, cacheScale, cancelled));
+}
+
+void MapPathBatchItem::rebuildOverviewCache()
+{
+    if (m_worldRect.isEmpty() || m_paths.isEmpty()) {
+        return;
+    }
+    if (m_overviewCancelled) {
+        m_overviewCancelled->store(true, std::memory_order_relaxed);
+    }
+    const double scale = qMin(
+        static_cast<double>(kOverviewCacheDimension) / m_worldRect.width(),
+        static_cast<double>(kOverviewCacheDimension) / m_worldRect.height());
+    const quint64 generation = ++m_overviewGeneration;
+    m_overviewCancelled = std::make_shared<std::atomic_bool>(false);
+    const std::shared_ptr<std::atomic_bool> cancelled = m_overviewCancelled;
+    auto* watcher = new QFutureWatcher<CacheResult>(this);
+    connect(watcher, &QFutureWatcher<CacheResult>::finished, this,
+            [this, watcher, generation] {
+                const CacheResult result = watcher->result();
+                watcher->deleteLater();
+                if (generation != m_overviewGeneration
+                    || result.image.isNull()) {
+                    return;
+                }
+                m_overviewCache = result.image;
+                repaint();
+            });
+    watcher->setFuture(QtConcurrent::run(
+        &MapPathBatchItem::renderCache, m_paths, m_worldRect,
+        m_worldRect, scale, cancelled));
+}
+
+MapPathBatchItem::CacheResult MapPathBatchItem::renderCache(
+    QVector<Path> paths, QRectF worldRect, QRectF cacheRect, double cacheScale,
+    std::shared_ptr<std::atomic_bool> cancelled)
+{
+    if (cancelled->load(std::memory_order_relaxed)) {
+        return {};
+    }
+    const QSize imageSize(
+        qMax(1, qCeil(cacheRect.width() * cacheScale)),
+        qMax(1, qCeil(cacheRect.height() * cacheScale)));
+    QImage cache(imageSize, QImage::Format_ARGB32_Premultiplied);
+    cache.fill(Qt::transparent);
+
+    QPainter cachePainter(&cache);
+    cachePainter.setRenderHint(QPainter::Antialiasing);
+    cachePainter.setBrush(Qt::NoBrush);
+    cachePainter.setWorldTransform(QTransform(
+        cacheScale, 0.0, 0.0, cacheScale,
+        -cacheRect.left() * cacheScale,
+        -cacheRect.top() * cacheScale));
+    const double worldWidth = worldRect.width();
+    QRgb activeColor = 0;
+    for (const Path& path : std::as_const(paths)) {
+        if (cancelled->load(std::memory_order_relaxed)) {
+            cachePainter.end();
+            return {};
+        }
+        const int firstCopy = static_cast<int>(std::floor(
+            (cacheRect.left() - path.bounds.right()) / worldWidth));
+        const int lastCopy = static_cast<int>(std::ceil(
+            (cacheRect.right() - path.bounds.left()) / worldWidth));
+        const QRgb pathColor = path.color.rgba();
+        QColor color = path.color;
+        color.setAlpha(120);
+        if (pathColor != activeColor) {
+            QPen pen(color, 2.5);
+            pen.setCosmetic(true);
+            cachePainter.setPen(pen);
+            activeColor = pathColor;
+        }
+        for (int copy = firstCopy; copy <= lastCopy; ++copy) {
+            const QRectF bounds = path.bounds.translated(copy * worldWidth, 0.0);
+            if (!bounds.intersects(cacheRect)) {
+                continue;
+            }
+            cachePainter.save();
+            cachePainter.translate(copy * worldWidth, 0.0);
+            cachePainter.drawPath(path.projected);
+            cachePainter.restore();
+        }
+    }
+    cachePainter.end();
+    return {cacheRect, cache, cacheScale};
+}
+
+QPainterPath MapPathBatchItem::projShape() const
+{
+    QPainterPath shape;
+    for (int copy = -kMaxWorldCopies; copy <= kMaxWorldCopies; ++copy) {
+        shape.addRect(m_worldRect.translated(copy * m_worldRect.width(), 0.0));
+    }
+    return shape;
+}
+
+void MapPathBatchItem::projPaint(QPainter* painter)
+{
+    if (m_directPaint) {
+        if (m_paths.isEmpty() || getMap() == nullptr) {
+            return;
+        }
+        painter->setRenderHint(QPainter::Antialiasing);
+        QColor color = m_paths.first().color;
+        color.setAlpha(170);
+        QPen pen(color, 3.0);
+        pen.setCosmetic(true);
+        painter->setPen(pen);
+        painter->setBrush(Qt::NoBrush);
+        const QRectF visible = getMap()->getCamera().projRect();
+        const double worldWidth = m_worldRect.width();
+        const Path& path = m_paths.first();
+        const int firstCopy = static_cast<int>(std::floor(
+            (visible.left() - path.bounds.right()) / worldWidth));
+        const int lastCopy = static_cast<int>(std::ceil(
+            (visible.right() - path.bounds.left()) / worldWidth));
+        for (int copy = firstCopy; copy <= lastCopy; ++copy) {
+            painter->save();
+            painter->translate(copy * worldWidth, 0.0);
+            painter->drawPath(path.projected);
+            painter->restore();
+        }
+        return;
+    }
+    if ((m_cache.isNull() || m_cacheRect.isEmpty())
+        && m_overviewCache.isNull()) {
+        return;
+    }
+    painter->setRenderHint(QPainter::SmoothPixmapTransform, true);
+    const QRectF visible = getMap() != nullptr
+        ? getMap()->getCamera().projRect() : QRectF();
+    if (!m_overviewCache.isNull() && !visible.isEmpty()
+        && (m_cache.isNull() || !m_cacheRect.contains(visible))) {
+        const double worldWidth = m_worldRect.width();
+        const int firstCopy = static_cast<int>(std::floor(
+            (visible.left() - m_worldRect.right()) / worldWidth));
+        const int lastCopy = static_cast<int>(std::ceil(
+            (visible.right() - m_worldRect.left()) / worldWidth));
+        for (int copy = firstCopy; copy <= lastCopy; ++copy) {
+            painter->drawImage(
+                m_worldRect.translated(copy * worldWidth, 0.0),
+                m_overviewCache);
+        }
+    }
+    if (!m_cache.isNull() && !m_cacheRect.isEmpty()) {
+        painter->drawImage(m_cacheRect, m_cache);
+    }
+}
+
+} // namespace AetherSDR

--- a/src/gui/map/MapPathBatchItem.cpp
+++ b/src/gui/map/MapPathBatchItem.cpp
@@ -322,6 +322,9 @@ void MapPathBatchItem::rebuildCache()
         static_cast<double>(kMaxCacheDimension) / cacheRect.width(),
         static_cast<double>(kMaxCacheDimension) / cacheRect.height()));
     const quint64 generation = ++m_cacheGeneration;
+    if (m_cacheCancelled) {
+        m_cacheCancelled->store(true, std::memory_order_relaxed);
+    }
     m_cacheCancelled = std::make_shared<std::atomic_bool>(false);
     const std::shared_ptr<std::atomic_bool> cancelled = m_cacheCancelled;
     auto* watcher = new QFutureWatcher<CacheResult>(this);

--- a/src/gui/map/MapPathBatchItem.h
+++ b/src/gui/map/MapPathBatchItem.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "MapView.h"
+
+#include <QGeoView/QGVDrawItem.h>
+
+#include <QImage>
+#include <QFutureWatcher>
+#include <QPainterPath>
+#include <QTimer>
+
+#include <atomic>
+#include <memory>
+
+class QGVProjection;
+
+namespace AetherSDR {
+
+class MapBatchItemTestAccess;
+
+class MapPathBatchItem : public QGVDrawItem {
+    Q_OBJECT
+
+public:
+    MapPathBatchItem(const QVector<MapView::Marker>& markers,
+                     bool hasHome, double homeLat, double homeLon);
+    ~MapPathBatchItem() override;
+    void setMarkers(const QVector<MapView::Marker>& markers,
+                    bool hasHome, double homeLat, double homeLon);
+    void setDisplayVisible(bool visible);
+
+private:
+    friend class MapBatchItemTestAccess;
+    struct CacheResult {
+        QRectF rect;
+        QImage image;
+        double scale{0.0};
+    };
+
+    struct Path {
+        QPainterPath projected;
+        QRectF bounds;
+        QColor color;
+    };
+
+    void onProjection(QGVMap* geoMap) override;
+    void onCamera(const QGVCameraState& oldState,
+                  const QGVCameraState& newState) override;
+    QPainterPath projShape() const override;
+    void projPaint(QPainter* painter) override;
+    void rebuildCache();
+    void rebuildOverviewCache();
+    void scheduleCacheRebuild();
+    void rebuildProjectedPaths();
+    static QVector<Path> projectPaths(
+        QVector<MapView::Marker> markers, bool hasHome,
+        double homeLat, double homeLon, QRectF worldRect,
+        std::shared_ptr<std::atomic_bool> cancelled);
+    static CacheResult renderCache(QVector<Path> paths,
+                                   QRectF worldRect, QRectF cacheRect,
+                                   double cacheScale,
+                                   std::shared_ptr<std::atomic_bool> cancelled);
+
+    QVector<MapView::Marker> m_markers;
+    QVector<Path> m_paths;
+    bool m_directPaint{false};
+    bool m_hasHome{false};
+    double m_homeLat{0.0};
+    double m_homeLon{0.0};
+    QRectF m_worldRect;
+    QRectF m_cacheRect;
+    QImage m_cache;
+    double m_cacheScale{0.0};
+    QImage m_overviewCache;
+    QTimer m_cacheTimer;
+    QTimer m_overviewRefreshTimer;
+    quint64 m_cacheGeneration{0};
+    quint64 m_overviewGeneration{0};
+    quint64 m_projectionGeneration{0};
+    std::shared_ptr<std::atomic_bool> m_cacheCancelled;
+    std::shared_ptr<std::atomic_bool> m_overviewCancelled;
+    std::shared_ptr<std::atomic_bool> m_projectionCancelled;
+};
+
+} // namespace AetherSDR

--- a/src/gui/map/MapPathGeometry.h
+++ b/src/gui/map/MapPathGeometry.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <QtMath>
+
+namespace AetherSDR::MapPathGeometry {
+
+// Return the horizontally repeated-world copy of canonicalX nearest to the
+// preceding path sample. This turns an antimeridian jump into a continuous
+// projected curve while leaving ordinary samples unchanged.
+inline double unwrapX(double canonicalX, double previousX, double worldWidth)
+{
+    if (worldWidth <= 0.0) {
+        return canonicalX;
+    }
+    return canonicalX
+         + qRound((previousX - canonicalX) / worldWidth) * worldWidth;
+}
+
+} // namespace AetherSDR::MapPathGeometry

--- a/src/gui/map/MapTerminatorItem.cpp
+++ b/src/gui/map/MapTerminatorItem.cpp
@@ -12,6 +12,7 @@
 #include <QGraphicsScene>
 #include <QPainter>
 #include <QtConcurrent/QtConcurrentRun>
+#include <QtMath>
 
 #include <algorithm>
 #include <cmath>

--- a/src/gui/map/MapTerminatorItem.cpp
+++ b/src/gui/map/MapTerminatorItem.cpp
@@ -1,0 +1,171 @@
+#include "MapTerminatorItem.h"
+
+#include "SolarTerminator.h"
+#include "core/ThemeManager.h"
+
+#include <QGeoView/QGVMap.h>
+#include <QGeoView/QGVMapQGItem.h>
+#include <QGeoView/QGVMapQGView.h>
+#include <QGeoView/QGVProjection.h>
+
+#include <QGraphicsItem>
+#include <QGraphicsScene>
+#include <QPainter>
+#include <QtConcurrent/QtConcurrentRun>
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+namespace {
+constexpr int kRasterWidth = 1440;
+constexpr int kRasterHeight = 720;
+constexpr int kWorldCopies = 4;
+constexpr double kTransitionDot = 0.006;
+
+void disableRedundantDeviceCache(QGVDrawItem* drawItem, QGVMap* geoMap)
+{
+    for (QGraphicsItem* item : geoMap->geoView()->scene()->items()) {
+        if (QGVMapQGItem::geoObjectFromQGItem(item) == drawItem) {
+            item->setCacheMode(QGraphicsItem::NoCache);
+            return;
+        }
+    }
+}
+}
+
+MapTerminatorItem::MapTerminatorItem()
+{
+    setSelectable(false);
+    setZValue(-10);
+    connect(&ThemeManager::instance(), &ThemeManager::themeChanged,
+            this, [this] { rebuildImage(); });
+}
+
+MapTerminatorItem::~MapTerminatorItem()
+{
+    if (m_renderCancelled) {
+        m_renderCancelled->store(true, std::memory_order_relaxed);
+    }
+}
+
+void MapTerminatorItem::setDateTime(const QDateTime& dateTime)
+{
+    m_dateTime = dateTime.toUTC();
+    rebuildImage();
+}
+
+void MapTerminatorItem::onProjection(QGVMap* geoMap)
+{
+    QGVDrawItem::onProjection(geoMap);
+    disableRedundantDeviceCache(this, geoMap);
+    m_worldRect = geoMap->getProjection()->boundaryProjRect();
+    rebuildImage();
+}
+
+void MapTerminatorItem::rebuildImage()
+{
+    if (getMap() == nullptr || m_worldRect.isEmpty()) {
+        return;
+    }
+    if (m_renderCancelled) {
+        m_renderCancelled->store(true, std::memory_order_relaxed);
+    }
+    const quint64 generation = ++m_renderGeneration;
+    m_renderCancelled = std::make_shared<std::atomic_bool>(false);
+    const std::shared_ptr<std::atomic_bool> cancelled = m_renderCancelled;
+    auto* watcher = new QFutureWatcher<QImage>(this);
+    connect(watcher, &QFutureWatcher<QImage>::finished, this,
+            [this, watcher, generation] {
+                const QImage image = watcher->result();
+                watcher->deleteLater();
+                if (generation != m_renderGeneration || image.isNull()) {
+                    return;
+                }
+                m_image = image;
+                resetBoundary();
+                refresh();
+            });
+    watcher->setFuture(QtConcurrent::run(
+        &MapTerminatorItem::renderImage, m_worldRect, m_dateTime,
+        ThemeManager::instance().color("color.background.0"), cancelled));
+}
+
+QImage MapTerminatorItem::renderImage(
+    QRectF worldRect, QDateTime dateTime, QColor night,
+    std::shared_ptr<std::atomic_bool> cancelled)
+{
+    if (cancelled->load(std::memory_order_relaxed)) {
+        return {};
+    }
+    QImage image(kRasterWidth, kRasterHeight,
+                 QImage::Format_ARGB32_Premultiplied);
+    image.fill(Qt::transparent);
+    constexpr int kNightAlpha = 150;
+    const SolarTerminator::Position sun =
+        SolarTerminator::positionAt(dateTime);
+
+    // MapView always uses QGeoView's EPSG:3857 projection. Deriving latitude
+    // and longitude from the immutable world rectangle keeps all million
+    // samples off the GUI-owned QGVProjection object and lets this renderer run
+    // safely on the global worker pool.
+    const double originShift = worldRect.width() / 2.0;
+    QVector<double> hourAngleCosines(kRasterWidth);
+    for (int x = 0; x < kRasterWidth; ++x) {
+        const double projectedX = worldRect.left()
+            + (x + 0.5) * worldRect.width() / kRasterWidth;
+        const double longitude = projectedX / originShift * 180.0;
+        hourAngleCosines[x] = std::cos(
+            qDegreesToRadians(longitude) - sun.subsolarLonRad);
+    }
+    const double sunSin = std::sin(sun.declinationRad);
+    const double sunCos = std::cos(sun.declinationRad);
+    const int red = night.red();
+    const int green = night.green();
+    const int blue = night.blue();
+    for (int y = 0; y < kRasterHeight; ++y) {
+        if (cancelled->load(std::memory_order_relaxed)) {
+            return {};
+        }
+        const double projectedY = worldRect.top()
+            + (y + 0.5) * worldRect.height() / kRasterHeight;
+        const double preLatitude = -projectedY / originShift * 180.0;
+        const double latitude = 2.0 * std::atan(
+            std::exp(qDegreesToRadians(preLatitude))) - M_PI / 2.0;
+        const double latitudeSin = std::sin(latitude);
+        const double latitudeCos = std::cos(latitude);
+        QRgb* pixels = reinterpret_cast<QRgb*>(image.scanLine(y));
+        for (int x = 0; x < kRasterWidth; ++x) {
+            const double elevationDot = latitudeSin * sunSin
+                + latitudeCos * sunCos * hourAngleCosines.at(x);
+            const double coverage = std::clamp(
+                0.5 - elevationDot / (2.0 * kTransitionDot), 0.0, 1.0);
+            if (coverage > 0.0) {
+                const int alpha = qRound(kNightAlpha * coverage);
+                pixels[x] = qPremultiply(qRgba(red, green, blue, alpha));
+            }
+        }
+    }
+    return image;
+}
+
+QPainterPath MapTerminatorItem::projShape() const
+{
+    QPainterPath path;
+    for (int copy = -kWorldCopies; copy <= kWorldCopies; ++copy) {
+        path.addRect(m_worldRect.translated(copy * m_worldRect.width(), 0.0));
+    }
+    return path;
+}
+
+void MapTerminatorItem::projPaint(QPainter* painter)
+{
+    painter->setRenderHint(QPainter::SmoothPixmapTransform, true);
+    for (int copy = -kWorldCopies; copy <= kWorldCopies; ++copy) {
+        painter->drawImage(
+            m_worldRect.translated(copy * m_worldRect.width(), 0.0), m_image);
+    }
+}
+
+} // namespace AetherSDR

--- a/src/gui/map/MapTerminatorItem.h
+++ b/src/gui/map/MapTerminatorItem.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <QGeoView/QGVDrawItem.h>
+
+#include <QDateTime>
+#include <QFutureWatcher>
+#include <QImage>
+
+#include <atomic>
+#include <memory>
+
+namespace AetherSDR {
+
+class MapBatchItemTestAccess;
+
+class MapTerminatorItem : public QGVDrawItem {
+    Q_OBJECT
+
+public:
+    MapTerminatorItem();
+    ~MapTerminatorItem() override;
+    void setDateTime(const QDateTime& dateTime);
+
+private:
+    friend class MapBatchItemTestAccess;
+    void onProjection(QGVMap* geoMap) override;
+    QPainterPath projShape() const override;
+    void projPaint(QPainter* painter) override;
+    void rebuildImage();
+    static QImage renderImage(
+        QRectF worldRect, QDateTime dateTime, QColor night,
+        std::shared_ptr<std::atomic_bool> cancelled);
+
+    QDateTime m_dateTime{QDateTime::currentDateTimeUtc()};
+    QRectF m_worldRect;
+    QImage m_image;
+    quint64 m_renderGeneration{0};
+    std::shared_ptr<std::atomic_bool> m_renderCancelled;
+};
+
+} // namespace AetherSDR

--- a/src/gui/map/MapView.cpp
+++ b/src/gui/map/MapView.cpp
@@ -1,6 +1,9 @@
 #include "MapView.h"
+#include "MapMarkerBatchItem.h"
 #include "MapMarkerItem.h"
-#include "MapPathItem.h"
+#include "MapPathBatchItem.h"
+#include "MapTerminatorItem.h"
+#include "core/ThemeManager.h"
 
 #include <QGeoView/QGVCamera.h>
 #include <QGeoView/QGVLayer.h>
@@ -12,8 +15,11 @@
 #include <QGeoView/QGVWidgetText.h>
 
 #include <QCoreApplication>
+#include <QAbstractAnimation>
+#include <QDateTime>
 #include <QCursor>
 #include <QDir>
+#include <QEasingCurve>
 #include <QEvent>
 #include <QKeyEvent>
 #include <QMouseEvent>
@@ -110,6 +116,19 @@ MapView::MapView(QWidget* parent)
     osmLayer->setHorizontalWrapEnabled(true);
     m_map->addItem(osmLayer);
     m_map->geoView()->setHorizontalWrapEnabled(true);
+    m_map->geoView()->setVerticalBoundsEnabled(true);
+
+    m_terminatorLayer = new QGVLayer();
+    m_terminatorLayer->setName(QStringLiteral("Day/night terminator"));
+    m_map->addItem(m_terminatorLayer);
+    m_terminatorItem = new MapTerminatorItem();
+    m_terminatorLayer->addItem(m_terminatorItem);
+    m_terminatorItem->setVisible(false);
+    m_terminatorTimer = new QTimer(this);
+    m_terminatorTimer->setInterval(60 * 1000);
+    connect(m_terminatorTimer, &QTimer::timeout, this, [this] {
+        m_terminatorItem->setDateTime(QDateTime::currentDateTimeUtc());
+    });
 
     m_markerLayer = new QGVLayer();
     m_markerLayer->setName(QStringLiteral("Markers"));
@@ -123,10 +142,13 @@ MapView::MapView(QWidget* parent)
     m_map->addWidget(new QGVWidgetScale());
 
     m_zoomInBtn = makeOverlayButton(QStringLiteral("+"), tr("Zoom in"));
+    m_zoomInBtn->setObjectName(QStringLiteral("mapZoomInButton"));
     connect(m_zoomInBtn, &QToolButton::clicked, this, &MapView::zoomIn);
     m_zoomOutBtn = makeOverlayButton(QStringLiteral("−"), tr("Zoom out"));
+    m_zoomOutBtn->setObjectName(QStringLiteral("mapZoomOutButton"));
     connect(m_zoomOutBtn, &QToolButton::clicked, this, &MapView::zoomOut);
     m_homeBtn = makeOverlayButton(QStringLiteral("⌂"), tr("Reset to my location (Home)"));
+    m_homeBtn->setObjectName(QStringLiteral("mapHomeButton"));
     connect(m_homeBtn, &QToolButton::clicked, this, &MapView::resetToHome);
 
     // Sonar pulse on the station marker, every 3 s. The animation timer
@@ -161,13 +183,15 @@ MapView::MapView(QWidget* parent)
     // has focus — it would otherwise consume the arrows for scrolling.
     m_map->geoView()->setFocusProxy(this);
 
-    connect(m_map, &QGVMap::itemClicked, this,
-            [this](QGVItem* item, QPointF) {
-                auto* marker = dynamic_cast<MapMarkerItem*>(item);
-                if (marker != nullptr) {
-                    emit markerClicked(marker->marker());
-                }
-            });
+    connect(m_map, &QGVMap::mapMousePress, this, [this](QPointF projPos) {
+        if (m_markerBatch == nullptr) {
+            return;
+        }
+        const int index = m_markerBatch->markerAt(projPos);
+        if (index >= 0) {
+            emit markerClicked(m_markerBatch->marker(index));
+        }
+    });
     // Double-click anywhere: zoom in anchored on the clicked point.
     connect(m_map, &QGVMap::mapMouseDoubleClicked, this,
             [this](QPointF projPos) {
@@ -208,15 +232,17 @@ bool MapView::eventFilter(QObject* watched, QEvent* event)
         if (event->type() == QEvent::MouseMove) {
             auto* me = static_cast<QMouseEvent*>(event);
             if (me->buttons() != Qt::NoButton) {
-                m_hoverMarker = nullptr;
+                m_hoverMarkerIndex = -1;
                 m_hoverCard->hide();
+                clearHoverPath();
                 return QWidget::eventFilter(watched, event);
             }
             // Viewport pixels → scene/projection coordinates for the hit test.
             showHoverTooltip(m_map->geoView()->mapToScene(me->pos()));
         } else if (event->type() == QEvent::Leave) {
-            m_hoverMarker = nullptr;
+            m_hoverMarkerIndex = -1;
             m_hoverCard->hide();
+            clearHoverPath();
         }
     }
     return QWidget::eventFilter(watched, event);
@@ -224,22 +250,18 @@ bool MapView::eventFilter(QObject* watched, QEvent* event)
 
 void MapView::showHoverTooltip(const QPointF& projPos)
 {
-    MapMarkerItem* hit = nullptr;
-    for (QGVDrawItem* item : m_map->search(projPos)) {
-        auto* marker = dynamic_cast<MapMarkerItem*>(item);
-        if (marker != nullptr && !marker->marker().tooltip.isEmpty()) {
-            hit = marker;
-            break;
-        }
-    }
-    if (hit == nullptr) {
-        m_hoverMarker = nullptr;
+    const int hit = m_markerBatch != nullptr
+        ? m_markerBatch->markerAt(projPos) : -1;
+    if (hit < 0 || m_markerBatch->marker(hit).tooltip.isEmpty()) {
+        m_hoverMarkerIndex = -1;
         m_hoverCard->hide();
+        clearHoverPath();
         return;
     }
-    if (hit != m_hoverMarker) {
-        m_hoverMarker = hit;
-        m_hoverCard->setText(hit->marker().tooltip);
+    updateHoverPath(hit);
+    if (hit != m_hoverMarkerIndex) {
+        m_hoverMarkerIndex = hit;
+        m_hoverCard->setText(m_markerBatch->marker(hit).tooltip);
         m_hoverCard->adjustSize();
     }
     // Position near the cursor, clamped to stay fully inside the widget.
@@ -291,16 +313,20 @@ void MapView::setHomeSpanDegrees(double spanDegrees)
 
 void MapView::setMarkers(const QVector<Marker>& markers)
 {
-    clearMarkers();
+    clearHoverPath();
+    m_hoverMarkerIndex = -1;
+    m_hoverCard->hide();
     m_markerData = markers;
-    m_markers.reserve(markers.size() * (2 * m_worldCopyRange + 1));
-    for (const Marker& m : markers) {
-        for (int relativeCopy = -m_worldCopyRange;
-             relativeCopy <= m_worldCopyRange; ++relativeCopy) {
-            auto* item = new MapMarkerItem(m, relativeCopy);
-            m_markers.append(item);
-            m_markerLayer->addItem(item);
-        }
+    if (markers.isEmpty()) {
+        clearMarkers();
+    } else if (m_markerBatch == nullptr) {
+        m_markerBatch = new MapMarkerBatchItem(
+            markers,
+            ThemeManager::instance().color("color.text.primary"),
+            ThemeManager::instance().color("color.background.0"));
+        m_markerLayer->addItem(m_markerBatch);
+    } else {
+        m_markerBatch->setMarkers(markers);
     }
     rebuildPaths();
 }
@@ -311,28 +337,92 @@ void MapView::setPathsVisible(bool visible)
         return;
     }
     m_pathsVisible = visible;
-    rebuildPaths();
+    if (visible) {
+        clearHoverPath();
+    }
+    if (m_pathBatch != nullptr) {
+        m_pathBatch->setDisplayVisible(visible);
+    } else if (visible) {
+        rebuildPaths();
+    }
+}
+
+void MapView::updateHoverPath(int markerIndex)
+{
+    if (m_pathsVisible || markerIndex < 0
+        || markerIndex >= m_markerData.size()) {
+        clearHoverPath();
+        return;
+    }
+    const Marker& marker = m_markerData.at(markerIndex);
+    if (!marker.pathEnabled) {
+        clearHoverPath();
+        return;
+    }
+    if (m_hoverPathBatch != nullptr
+        && m_hoverPathMarkerIndex == markerIndex) {
+        return;
+    }
+    clearHoverPath();
+    m_hoverPathMarkerIndex = markerIndex;
+    m_hoverPathBatch = new MapPathBatchItem(
+        QVector<Marker>{marker}, m_hasHome, m_homeLat, m_homeLon);
+    m_markerLayer->addItem(m_hoverPathBatch);
+}
+
+void MapView::clearHoverPath()
+{
+    m_hoverPathMarkerIndex = -1;
+    if (m_hoverPathBatch == nullptr) {
+        return;
+    }
+    m_markerLayer->removeItem(m_hoverPathBatch);
+    delete m_hoverPathBatch;
+    m_hoverPathBatch = nullptr;
+}
+
+void MapView::setDayNightTerminatorVisible(bool visible)
+{
+    if (m_terminatorItem == nullptr) {
+        return;
+    }
+    m_terminatorItem->setVisible(visible);
+    if (visible) {
+        m_terminatorItem->setDateTime(QDateTime::currentDateTimeUtc());
+        m_terminatorTimer->start();
+    } else {
+        m_terminatorTimer->stop();
+    }
+}
+
+bool MapView::dayNightTerminatorVisible() const
+{
+    return m_terminatorItem != nullptr && m_terminatorItem->isVisible();
 }
 
 void MapView::rebuildPaths()
 {
-    for (MapPathItem* path : std::as_const(m_paths)) {
-        m_markerLayer->removeItem(path);
-        delete path;
-    }
-    m_paths.clear();
-    if (!m_pathsVisible || !m_hasHome) {
+    if (!m_pathsVisible) {
+        if (m_pathBatch != nullptr) {
+            m_markerLayer->removeItem(m_pathBatch);
+            delete m_pathBatch;
+            m_pathBatch = nullptr;
+        }
         return;
     }
-    m_paths.reserve(m_markerData.size() * (2 * m_worldCopyRange + 1));
-    for (const Marker& m : std::as_const(m_markerData)) {
-        for (int relativeCopy = -m_worldCopyRange;
-             relativeCopy <= m_worldCopyRange; ++relativeCopy) {
-            auto* path = new MapPathItem(m_homeLat, m_homeLon,
-                                         m.lat, m.lon, m.color, relativeCopy);
-            m_paths.append(path);
-            m_markerLayer->addItem(path);
+    if (m_markerData.isEmpty()) {
+        if (m_pathBatch != nullptr) {
+            m_markerLayer->removeItem(m_pathBatch);
+            delete m_pathBatch;
+            m_pathBatch = nullptr;
         }
+    } else if (m_pathBatch == nullptr) {
+        m_pathBatch = new MapPathBatchItem(
+            m_markerData, m_hasHome, m_homeLat, m_homeLon);
+        m_markerLayer->addItem(m_pathBatch);
+    } else {
+        m_pathBatch->setMarkers(
+            m_markerData, m_hasHome, m_homeLat, m_homeLon);
     }
 }
 
@@ -367,21 +457,22 @@ void MapView::setLegend(const QVector<QPair<QString, QColor>>& entries)
 
 void MapView::clearMarkers()
 {
-    m_hoverMarker = nullptr;
+    clearHoverPath();
+    m_hoverMarkerIndex = -1;
     if (m_hoverCard != nullptr) {
         m_hoverCard->hide();
     }
-    for (MapMarkerItem* item : std::as_const(m_markers)) {
-        m_markerLayer->removeItem(item);
-        delete item;
+    if (m_markerBatch != nullptr) {
+        m_markerLayer->removeItem(m_markerBatch);
+        delete m_markerBatch;
+        m_markerBatch = nullptr;
     }
-    m_markers.clear();
     m_markerData.clear();
-    for (MapPathItem* path : std::as_const(m_paths)) {
-        m_markerLayer->removeItem(path);
-        delete path;
+    if (m_pathBatch != nullptr) {
+        m_markerLayer->removeItem(m_pathBatch);
+        delete m_pathBatch;
+        m_pathBatch = nullptr;
     }
-    m_paths.clear();
 }
 
 void MapView::resetToHome()
@@ -406,12 +497,25 @@ void MapView::resetToHome()
 
 void MapView::zoomIn()
 {
-    m_map->cameraTo(QGVCameraActions(m_map).scaleBy(kZoomStep), true);
+    animateZoom(kZoomStep);
 }
 
 void MapView::zoomOut()
 {
-    m_map->cameraTo(QGVCameraActions(m_map).scaleBy(1.0 / kZoomStep), true);
+    animateZoom(1.0 / kZoomStep);
+}
+
+void MapView::animateZoom(double factor)
+{
+    if (m_zoomAnimation != nullptr) {
+        m_zoomAnimation->stop();
+    }
+    auto* animation = new QGVCameraSimpleAnimation(
+        QGVCameraActions(m_map).scaleBy(factor), m_map);
+    animation->setDuration(250);
+    animation->setEasingCurve(QEasingCurve::OutCubic);
+    m_zoomAnimation = animation;
+    animation->start(QAbstractAnimation::DeleteWhenStopped);
 }
 
 void MapView::pan(double dxFraction, double dyFraction)

--- a/src/gui/map/MapView.cpp
+++ b/src/gui/map/MapView.cpp
@@ -1,6 +1,7 @@
 #include "MapView.h"
 #include "MapMarkerBatchItem.h"
 #include "MapMarkerItem.h"
+#include "MapHoverPathSelection.h"
 #include "MapPathBatchItem.h"
 #include "MapTerminatorItem.h"
 #include "core/ThemeManager.h"
@@ -354,19 +355,19 @@ void MapView::updateHoverPath(int markerIndex)
         clearHoverPath();
         return;
     }
-    const Marker& marker = m_markerData.at(markerIndex);
-    if (!marker.pathEnabled) {
-        clearHoverPath();
-        return;
-    }
     if (m_hoverPathBatch != nullptr
         && m_hoverPathMarkerIndex == markerIndex) {
         return;
     }
     clearHoverPath();
     m_hoverPathMarkerIndex = markerIndex;
+    const QVector<Marker> hoverMarkers =
+        MapHoverPathSelection::pathsForMarker(m_markerData, markerIndex);
+    if (hoverMarkers.isEmpty()) {
+        return;
+    }
     m_hoverPathBatch = new MapPathBatchItem(
-        QVector<Marker>{marker}, m_hasHome, m_homeLat, m_homeLon);
+        hoverMarkers, m_hasHome, m_homeLat, m_homeLon);
     m_markerLayer->addItem(m_hoverPathBatch);
 }
 

--- a/src/gui/map/MapView.h
+++ b/src/gui/map/MapView.h
@@ -49,6 +49,8 @@ public:
         bool    hasPathOrigin{false};
         double  pathFromLat{0.0};
         double  pathFromLon{0.0};
+        QString pathGroup;       // non-empty groups related hover paths
+        bool    hoverShowsPathGroup{false};
         QString clickInfo;      // rich text shown on click (empty = none)
     };
 

--- a/src/gui/map/MapView.h
+++ b/src/gui/map/MapView.h
@@ -10,6 +10,7 @@
 
 class QGVMap;
 class QGVLayer;
+class QAbstractAnimation;
 class QLabel;
 class QToolButton;
 class QVariantAnimation;
@@ -17,7 +18,9 @@ class QVariantAnimation;
 namespace AetherSDR {
 
 class MapMarkerItem;
-class MapPathItem;
+class MapMarkerBatchItem;
+class MapPathBatchItem;
+class MapTerminatorItem;
 
 // Reusable OpenStreetMap slippy-map widget (#mapping-engine).
 //
@@ -41,6 +44,11 @@ public:
         QString tooltip;     // hover detail
         QColor  color{Qt::red};
         bool    isHome{false};  // drawn as a distinct station marker
+        bool    isMonitor{false}; // larger active-receiver marker
+        bool    pathEnabled{true};
+        bool    hasPathOrigin{false};
+        double  pathFromLat{0.0};
+        double  pathFromLon{0.0};
         QString clickInfo;      // rich text shown on click (empty = none)
     };
 
@@ -63,6 +71,9 @@ public:
     // Great-circle paths from home to every marker.
     void setPathsVisible(bool visible);
     bool pathsVisible() const { return m_pathsVisible; }
+
+    void setDayNightTerminatorVisible(bool visible);
+    bool dayNightTerminatorVisible() const;
 
     // Color/label legend chip, lower-left. Empty list hides it.
     void setLegend(const QVector<QPair<QString, QColor>>& entries);
@@ -95,9 +106,12 @@ private:
     static void ensureTileNetworkManager();
 
     void pan(double dxFraction, double dyFraction);
+    void animateZoom(double factor);
     QToolButton* makeOverlayButton(const QString& text, const QString& tip);
     void layoutOverlayButtons();
     void rebuildPaths();
+    void updateHoverPath(int markerIndex);
+    void clearHoverPath();
     void clampMinZoomToViewport();
     // How many world copies either side of the base one the markers and paths
     // must be replicated into for the widest viewport this widget can reach.
@@ -116,14 +130,17 @@ private:
 
     QGVMap*  m_map{nullptr};
     QGVLayer* m_markerLayer{nullptr};
+    QGVLayer* m_terminatorLayer{nullptr};
+    MapTerminatorItem* m_terminatorItem{nullptr};
+    QTimer* m_terminatorTimer{nullptr};
     QVector<MapMarkerItem*> m_homeMarkers;
-    // QPointer, not a raw pointer: marker items are deleted from more than one
-    // path and this must never outlive the item it names.
-    QPointer<MapMarkerItem> m_hoverMarker;
+    int m_hoverMarkerIndex{-1};
     QLabel* m_hoverCard{nullptr};
-    QVector<MapMarkerItem*> m_markers;
+    MapMarkerBatchItem* m_markerBatch{nullptr};
     QVector<Marker> m_markerData;
-    QVector<MapPathItem*> m_paths;
+    MapPathBatchItem* m_pathBatch{nullptr};
+    MapPathBatchItem* m_hoverPathBatch{nullptr};
+    int m_hoverPathMarkerIndex{-1};
     bool m_pathsVisible{true};
     QLabel* m_legend{nullptr};
 
@@ -140,6 +157,7 @@ private:
     QToolButton* m_zoomInBtn{nullptr};
     QToolButton* m_zoomOutBtn{nullptr};
     QToolButton* m_homeBtn{nullptr};
+    QPointer<QAbstractAnimation> m_zoomAnimation;
 
     // Sonar pulse on the home marker: a short ring animation fired every
     // few seconds. The animation only runs for its ~1s duration, so the

--- a/src/gui/map/SolarTerminator.h
+++ b/src/gui/map/SolarTerminator.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <QDateTime>
+#include <QtMath>
+
+#include <cmath>
+
+namespace AetherSDR::SolarTerminator {
+
+struct Position {
+    double declinationRad{0.0};
+    double subsolarLonRad{0.0};
+};
+
+inline double normalizeDegrees(double degrees)
+{
+    double value = std::fmod(degrees + 180.0, 360.0);
+    if (value < 0.0) {
+        value += 360.0;
+    }
+    return value - 180.0;
+}
+
+// Compact NOAA-style solar position approximation.  It is comfortably more
+// precise than the map's raster resolution and remains deterministic in UTC.
+inline Position positionAt(const QDateTime& dateTime)
+{
+    const double julianDay = dateTime.toUTC().toMSecsSinceEpoch()
+                           / 86400000.0 + 2440587.5;
+    const double days = julianDay - 2451545.0;
+    const double meanLongitude = normalizeDegrees(280.460 + 0.9856474 * days);
+    const double anomaly = qDegreesToRadians(
+        normalizeDegrees(357.528 + 0.9856003 * days));
+    const double eclipticLongitude = qDegreesToRadians(
+        meanLongitude + 1.915 * std::sin(anomaly)
+        + 0.020 * std::sin(2.0 * anomaly));
+    const double obliquity = qDegreesToRadians(23.439 - 0.0000004 * days);
+    const double rightAscension = std::atan2(
+        std::cos(obliquity) * std::sin(eclipticLongitude),
+        std::cos(eclipticLongitude));
+    const double declination = std::asin(
+        std::sin(obliquity) * std::sin(eclipticLongitude));
+    const double siderealDegrees = normalizeDegrees(
+        280.46061837 + 360.98564736629 * days);
+    const double subsolarLon = normalizeDegrees(
+        qRadiansToDegrees(rightAscension) - siderealDegrees);
+    return { declination, qDegreesToRadians(subsolarLon) };
+}
+
+inline double solarElevationDot(double latitudeDeg, double longitudeDeg,
+                                const Position& sun)
+{
+    const double latitude = qDegreesToRadians(latitudeDeg);
+    const double hourAngle = qDegreesToRadians(longitudeDeg)
+                           - sun.subsolarLonRad;
+    return std::sin(latitude) * std::sin(sun.declinationRad)
+         + std::cos(latitude) * std::cos(sun.declinationRad)
+               * std::cos(hourAngle);
+}
+
+inline bool isNight(double latitudeDeg, double longitudeDeg,
+                    const Position& sun)
+{
+    return solarElevationDot(latitudeDeg, longitudeDeg, sun) < 0.0;
+}
+
+} // namespace AetherSDR::SolarTerminator

--- a/tests/map_live_update_test.cpp
+++ b/tests/map_live_update_test.cpp
@@ -1,0 +1,199 @@
+#include "gui/map/MapMarkerBatchItem.h"
+#include "gui/map/MapPathBatchItem.h"
+#include "gui/map/MapTerminatorItem.h"
+
+#include <QGeoView/QGVCamera.h>
+#include <QGeoView/QGVLayer.h>
+#include <QGeoView/QGVMap.h>
+#include <QGeoView/QGVProjection.h>
+
+#include <QApplication>
+#include <QElapsedTimer>
+#include <QThread>
+
+#include <cmath>
+#include <functional>
+#include <iostream>
+
+namespace AetherSDR {
+
+class MapBatchItemTestAccess {
+public:
+    static quint64 cacheKey(const MapMarkerBatchItem& item)
+    {
+        return item.m_cache.cacheKey();
+    }
+
+    static double cacheScale(const MapMarkerBatchItem& item)
+    {
+        return item.m_cacheScale;
+    }
+
+    static bool overviewRefreshScheduled(const MapMarkerBatchItem& item)
+    {
+        return item.m_overviewRefreshTimer.isActive();
+    }
+
+    static quint64 cacheKey(const MapPathBatchItem& item)
+    {
+        return item.m_cache.cacheKey();
+    }
+
+    static double cacheScale(const MapPathBatchItem& item)
+    {
+        return item.m_cacheScale;
+    }
+
+    static bool overviewRefreshScheduled(const MapPathBatchItem& item)
+    {
+        return item.m_overviewRefreshTimer.isActive();
+    }
+
+    static int projectedPathCount(const MapPathBatchItem& item)
+    {
+        return item.m_paths.size();
+    }
+
+    static quint64 imageKey(const MapTerminatorItem& item)
+    {
+        return item.m_image.cacheKey();
+    }
+};
+
+} // namespace AetherSDR
+
+using namespace AetherSDR;
+
+namespace {
+
+bool expect(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+    }
+    return condition;
+}
+
+bool waitUntil(QApplication& app, const std::function<bool()>& predicate,
+               int timeoutMs = 5000)
+{
+    QElapsedTimer elapsed;
+    elapsed.start();
+    while (!predicate() && elapsed.elapsed() < timeoutMs) {
+        app.processEvents();
+        QThread::msleep(10);
+    }
+    app.processEvents();
+    return predicate();
+}
+
+MapView::Marker marker(double lat, double lon, const QColor& color)
+{
+    MapView::Marker value;
+    value.lat = lat;
+    value.lon = lon;
+    value.color = color;
+    value.pathEnabled = true;
+    value.hasPathOrigin = true;
+    value.pathFromLat = 35.0;
+    value.pathFromLon = -78.0;
+    return value;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QApplication app(argc, argv);
+    bool ok = true;
+
+    QGVMap map;
+    map.resize(900, 600);
+    map.show();
+    app.processEvents();
+    const QRectF world = map.getProjection()->boundaryProjRect();
+    map.cameraTo(QGVCameraActions(&map).scaleTo(world), false);
+
+    auto* layer = new QGVLayer;
+    map.addItem(layer);
+    QVector<MapView::Marker> markers{
+        marker(51.5, -0.1, Qt::red),
+        marker(-33.9, 151.2, Qt::cyan),
+    };
+    auto* markerBatch = new MapMarkerBatchItem(
+        markers, QColor(Qt::white), QColor(Qt::black));
+    auto* pathBatch = new MapPathBatchItem(markers, true, 35.0, -78.0);
+    auto* terminator = new MapTerminatorItem;
+    layer->addItem(markerBatch);
+    layer->addItem(pathBatch);
+    layer->addItem(terminator);
+
+    ok &= expect(waitUntil(app, [&] {
+        return MapBatchItemTestAccess::cacheKey(*markerBatch) != 0
+            && MapBatchItemTestAccess::cacheKey(*pathBatch) != 0;
+    }), "initial detail caches complete");
+    ok &= expect(waitUntil(app, [&] {
+        return MapBatchItemTestAccess::imageKey(*terminator) != 0;
+    }), "initial terminator image completes asynchronously");
+
+    const quint64 markerCacheBefore =
+        MapBatchItemTestAccess::cacheKey(*markerBatch);
+    const quint64 pathCacheBefore =
+        MapBatchItemTestAccess::cacheKey(*pathBatch);
+    const double markerScaleBefore =
+        MapBatchItemTestAccess::cacheScale(*markerBatch);
+    const double pathScaleBefore =
+        MapBatchItemTestAccess::cacheScale(*pathBatch);
+    const int itemCountBefore = layer->countItems();
+    const int pathCountBefore =
+        MapBatchItemTestAccess::projectedPathCount(*pathBatch);
+    const quint64 terminatorImageBefore =
+        MapBatchItemTestAccess::imageKey(*terminator);
+
+    markers.append(marker(40.7, -74.0, Qt::yellow));
+    markerBatch->setMarkers(markers);
+    pathBatch->setMarkers(markers, true, 35.0, -78.0);
+
+    ok &= expect(layer->countItems() == itemCountBefore,
+                 "live update reuses the existing scene batches");
+    ok &= expect(MapBatchItemTestAccess::cacheKey(*markerBatch)
+                     == markerCacheBefore,
+                 "marker detail cache remains visible during refresh");
+    ok &= expect(MapBatchItemTestAccess::cacheKey(*pathBatch)
+                     == pathCacheBefore,
+                 "path detail cache remains visible during refresh");
+    ok &= expect(MapBatchItemTestAccess::projectedPathCount(*pathBatch)
+                     == pathCountBefore,
+                 "path geometry remains visible while replacement projects");
+    ok &= expect(waitUntil(app, [&] {
+        return MapBatchItemTestAccess::overviewRefreshScheduled(*markerBatch)
+            && MapBatchItemTestAccess::overviewRefreshScheduled(*pathBatch);
+    }), "slow overview refresh is scheduled without replacing detail");
+
+    terminator->setDateTime(QDateTime::currentDateTimeUtc().addSecs(60));
+    ok &= expect(MapBatchItemTestAccess::imageKey(*terminator)
+                     == terminatorImageBefore,
+                 "terminator image remains visible while replacement renders");
+    ok &= expect(waitUntil(app, [&] {
+        return MapBatchItemTestAccess::imageKey(*terminator)
+            != terminatorImageBefore;
+    }), "replacement terminator image completes asynchronously");
+
+    ok &= expect(waitUntil(app, [&] {
+        return MapBatchItemTestAccess::cacheKey(*markerBatch)
+                   != markerCacheBefore
+            && MapBatchItemTestAccess::cacheKey(*pathBatch)
+                   != pathCacheBefore;
+    }), "replacement detail caches complete");
+    ok &= expect(std::abs(MapBatchItemTestAccess::cacheScale(*markerBatch)
+                          - markerScaleBefore) < 1e-9,
+                 "marker replacement preserves effective pixel scale");
+    ok &= expect(std::abs(MapBatchItemTestAccess::cacheScale(*pathBatch)
+                          - pathScaleBefore) < 1e-9,
+                 "path replacement preserves effective pixel scale");
+    ok &= expect(MapBatchItemTestAccess::projectedPathCount(*pathBatch)
+                     == markers.size(),
+                 "replacement path geometry contains every marker");
+
+    return ok ? 0 : 1;
+}

--- a/tests/map_live_update_test.cpp
+++ b/tests/map_live_update_test.cpp
@@ -1,3 +1,4 @@
+#include "gui/map/MapHoverPathSelection.h"
 #include "gui/map/MapMarkerBatchItem.h"
 #include "gui/map/MapPathBatchItem.h"
 #include "gui/map/MapTerminatorItem.h"
@@ -34,6 +35,17 @@ public:
         return item.m_overviewRefreshTimer.isActive();
     }
 
+    static std::shared_ptr<std::atomic_bool> cacheCancellation(
+        const MapMarkerBatchItem& item)
+    {
+        return item.m_cacheCancelled;
+    }
+
+    static void rebuildDetailCache(MapMarkerBatchItem& item)
+    {
+        item.rebuildCache();
+    }
+
     static quint64 cacheKey(const MapPathBatchItem& item)
     {
         return item.m_cache.cacheKey();
@@ -52,6 +64,17 @@ public:
     static int projectedPathCount(const MapPathBatchItem& item)
     {
         return item.m_paths.size();
+    }
+
+    static std::shared_ptr<std::atomic_bool> cacheCancellation(
+        const MapPathBatchItem& item)
+    {
+        return item.m_cacheCancelled;
+    }
+
+    static void rebuildDetailCache(MapPathBatchItem& item)
+    {
+        item.rebuildCache();
     }
 
     static quint64 imageKey(const MapTerminatorItem& item)
@@ -194,6 +217,50 @@ int main(int argc, char** argv)
     ok &= expect(MapBatchItemTestAccess::projectedPathCount(*pathBatch)
                      == markers.size(),
                  "replacement path geometry contains every marker");
+
+    QVector<MapView::Marker> groupedMarkers;
+    MapView::Marker firstReceiver = marker(51.5, -0.1, Qt::red);
+    firstReceiver.pathGroup = QStringLiteral("VE2AO");
+    groupedMarkers.append(firstReceiver);
+    MapView::Marker secondReceiver = marker(40.7, -74.0, Qt::yellow);
+    secondReceiver.pathGroup = QStringLiteral("VE2AO");
+    groupedMarkers.append(secondReceiver);
+    MapView::Marker unrelated = marker(-33.9, 151.2, Qt::cyan);
+    unrelated.pathGroup = QStringLiteral("OTHER");
+    groupedMarkers.append(unrelated);
+    MapView::Marker selectedStation;
+    selectedStation.pathEnabled = false;
+    selectedStation.pathGroup = QStringLiteral("VE2AO");
+    selectedStation.hoverShowsPathGroup = true;
+    groupedMarkers.append(selectedStation);
+    ok &= expect(MapHoverPathSelection::pathsForMarker(
+                     groupedMarkers, groupedMarkers.size() - 1).size() == 2,
+                 "selected callsign hover includes every grouped path");
+    ok &= expect(MapHoverPathSelection::pathsForMarker(
+                     groupedMarkers, 0).size() == 1,
+                 "receiver hover includes only its own path");
+    MapView::Marker noHoverPath;
+    noHoverPath.pathEnabled = false;
+    groupedMarkers.append(noHoverPath);
+    ok &= expect(MapHoverPathSelection::pathsForMarker(
+                     groupedMarkers, groupedMarkers.size() - 1).isEmpty(),
+                 "marker without a path does not create a hover batch");
+
+    MapBatchItemTestAccess::rebuildDetailCache(*markerBatch);
+    const std::shared_ptr<std::atomic_bool> supersededMarkerRender =
+        MapBatchItemTestAccess::cacheCancellation(*markerBatch);
+    MapBatchItemTestAccess::rebuildDetailCache(*markerBatch);
+    ok &= expect(supersededMarkerRender != nullptr
+                     && supersededMarkerRender->load(std::memory_order_relaxed),
+                 "starting a marker detail render cancels its predecessor");
+
+    MapBatchItemTestAccess::rebuildDetailCache(*pathBatch);
+    const std::shared_ptr<std::atomic_bool> supersededPathRender =
+        MapBatchItemTestAccess::cacheCancellation(*pathBatch);
+    MapBatchItemTestAccess::rebuildDetailCache(*pathBatch);
+    ok &= expect(supersededPathRender != nullptr
+                     && supersededPathRender->load(std::memory_order_relaxed),
+                 "starting a path detail render cancels its predecessor");
 
     return ok ? 0 : 1;
 }

--- a/tests/map_wrap_test.cpp
+++ b/tests/map_wrap_test.cpp
@@ -98,6 +98,26 @@ int main(int argc, char** argv)
     ok &= expect(centerErrorPixels <= 1.0,
                  "wide wrapped camera should reach the dateline without scene clamping");
 
+    // Horizontal repetition must not make the finite Web Mercator surface
+    // vertically pannable. At both poles the viewport edge should stop at the
+    // projection edge rather than exposing the empty QGraphicsScene canvas.
+    map.geoView()->setVerticalBoundsEnabled(true);
+    map.cameraTo(QGVCameraActions(&map)
+                     .scaleTo(wholeWorldScale * 2.0)
+                     .moveTo(QPointF(world.center().x(),
+                                     world.top() - world.height())),
+                 false);
+    QRectF boundedView = map.getCamera().projRect();
+    ok &= expect(boundedView.top() >= world.top() - 1.0,
+                 "northward pan must stop at the projection boundary");
+    map.cameraTo(QGVCameraActions(&map)
+                     .moveTo(QPointF(world.center().x(),
+                                     world.bottom() + world.height())),
+                 false);
+    boundedView = map.getCamera().projRect();
+    ok &= expect(boundedView.bottom() <= world.bottom() + 1.0,
+                 "southward pan must stop at the projection boundary");
+
     // Zoom symmetry: n notches in followed by n notches out must land back on
     // the scale we started from. Upstream's asymmetric in/out exponents lost
     // ~11% per round trip, so the operator drifted away from their own view

--- a/tests/psk_reporter_map_behavior_test.cpp
+++ b/tests/psk_reporter_map_behavior_test.cpp
@@ -3,6 +3,8 @@
 #include "gui/map/SolarTerminator.h"
 
 #include <QCoreApplication>
+#include <QJsonArray>
+#include <QJsonObject>
 #include <QTimeZone>
 
 #include <cmath>
@@ -35,6 +37,50 @@ public:
     {
         return PskReporterClient::rateLimitBackoffMs(count);
     }
+
+    static void handleQueryReply(PskReporterClient& client,
+                                 const QByteArray& xml,
+                                 PskReporterClient::QueryScope responseScope)
+    {
+        client.handleQueryReply(xml, responseScope);
+    }
+
+    static void setInterval(PskReporterClient& client, int intervalMs)
+    {
+        client.m_intervalMs = intervalMs;
+    }
+
+    static PskReporterClient::QueryScope httpQueryScope(
+        const PskReporterClient& client)
+    {
+        return client.httpQueryScope();
+    }
+
+    static void loadCache(PskReporterClient& client)
+    {
+        client.loadCache();
+    }
+
+    static int maxSpots()
+    {
+        return PskReporterClient::kMaxSpots;
+    }
+
+    static int maxMonitors()
+    {
+        return PskReporterClient::kMaxMonitors;
+    }
+
+    static void restoreCachedMonitors(PskReporterClient& client,
+                                      const QJsonArray& monitors)
+    {
+        client.restoreCachedMonitors(monitors);
+    }
+
+    static void discardPendingCacheWrite(PskReporterClient& client)
+    {
+        client.m_cacheDirty = false;
+    }
 };
 
 } // namespace AetherSDR
@@ -54,6 +100,10 @@ bool check(bool condition, const char* message)
 int main(int argc, char** argv)
 {
     QCoreApplication app(argc, argv);
+    QCoreApplication::setOrganizationName(
+        QStringLiteral("AetherSDR-tests"));
+    QCoreApplication::setApplicationName(
+        QStringLiteral("psk-reporter-map-behavior-test"));
     bool ok = true;
 
     PskReporterClient client;
@@ -104,6 +154,103 @@ int main(int argc, char** argv)
     ok &= check(PskReporterClientTestAccess::rateLimitBackoffMs(20)
                     == 2LL * 60 * 60 * 1000,
                 "rate-limit backoff is capped at two hours");
+
+    PskReporterClient parserClient;
+    parserClient.setCallsign(QString());
+    QByteArray xml("<receptionReports>");
+    xml += "<activeReceiver callsign=' k1abc ' locator=' fn42 ' "
+           "mode='FT8' decoderSoftware='Decoder 1' frequency='14074000'/>";
+    xml += "<activeReceiver callsign='K1ABC' locator='FN42' mode='FT4'/>";
+    xml += "<activeReceiver callsign='INVALID'/>";
+    for (int i = 0; i < PskReporterClientTestAccess::maxMonitors() + 10; ++i) {
+        xml += QStringLiteral(
+            "<activeReceiver callsign='M%1' locator='L%1' mode='FT8'/>")
+                   .arg(i).toUtf8();
+    }
+    const qint64 now = QDateTime::currentSecsSinceEpoch();
+    for (int i = 0; i < PskReporterClientTestAccess::maxSpots() + 1; ++i) {
+        xml += QStringLiteral(
+            "<receptionReport receiverCallsign='R%1' receiverLocator='FN42' "
+            "senderCallsign='S%1' senderLocator='CN85' mode='FT8' "
+            "frequency='14074000' flowStartSeconds='%2'/>")
+                   .arg(i).arg(now).toUtf8();
+    }
+    xml += "</receptionReports>";
+    PskReporterClientTestAccess::handleQueryReply(
+        parserClient, xml, PskReporterClient::QueryScope::Anyone);
+    ok &= check(parserClient.monitors().size()
+                    == PskReporterClientTestAccess::maxMonitors(),
+                "activeReceiver parsing enforces the monitor cap");
+    ok &= check(parserClient.monitors().first().callsign
+                    == QStringLiteral("K1ABC")
+                    && parserClient.monitors().first().locator
+                           == QStringLiteral("FN42")
+                    && parserClient.monitors().first().frequencyHz == 14074000,
+                "activeReceiver fields are normalized and parsed");
+    int normalizedMonitorCount = 0;
+    for (const PskReporterMonitor& monitor : parserClient.monitors()) {
+        if (monitor.callsign == QStringLiteral("K1ABC")
+            && monitor.locator == QStringLiteral("FN42")) {
+            ++normalizedMonitorCount;
+        }
+    }
+    ok &= check(normalizedMonitorCount == 1,
+                "activeReceiver parsing deduplicates callsign and locator");
+    ok &= check(parserClient.spots().size()
+                    == PskReporterClientTestAccess::maxSpots()
+                    && parserClient.resultsLimited(),
+                "receptionReport parsing enforces and surfaces the spot cap");
+
+    PskReporterClient cacheClient;
+    QJsonArray cachedMonitors;
+    cachedMonitors.append(QJsonObject{
+        {QStringLiteral("c"), QStringLiteral("K1ABC")},
+        {QStringLiteral("l"), QStringLiteral("FN42")}});
+    cachedMonitors.append(QJsonObject{
+        {QStringLiteral("c"), QStringLiteral("W1AW")},
+        {QStringLiteral("l"), QStringLiteral("FN31")}});
+    cachedMonitors.append(QJsonObject{
+        {QStringLiteral("c"), QStringLiteral("K1ABC")},
+        {QStringLiteral("l"), QStringLiteral("FN42")}});
+    PskReporterClientTestAccess::restoreCachedMonitors(
+        cacheClient, cachedMonitors);
+    const int cachedMonitorCount = cacheClient.monitors().size();
+    PskReporterClientTestAccess::restoreCachedMonitors(
+        cacheClient, cachedMonitors);
+    ok &= check(cachedMonitorCount == 2
+                    && cacheClient.monitors().size() == cachedMonitorCount,
+                "reloading a cache does not duplicate active monitors");
+
+    PskReporterClient liveClient;
+    liveClient.setCallsign(QStringLiteral("K1ABC"));
+    PskReporterClientTestAccess::setInterval(
+        liveClient, PskReporterClient::kLiveMqtt);
+    ok &= check(PskReporterClientTestAccess::httpQueryScope(liveClient)
+                    == PskReporterClient::QueryScope::Anyone,
+                "live callsign mode reserves HTTP for the global snapshot");
+    QByteArray globalXml("<receptionReports>");
+    globalXml += QStringLiteral(
+        "<activeReceiver callsign='W1AW' locator='FN31' mode='FT8'/>"
+        "<receptionReport receiverCallsign='R1' receiverLocator='FN42' "
+        "senderCallsign='K1ABC' senderLocator='CN85' mode='FT8' "
+        "frequency='14074000' flowStartSeconds='%1'/>"
+        "<receptionReport receiverCallsign='R2' receiverLocator='EM10' "
+        "senderCallsign='W1AW' senderLocator='FN31' mode='FT8' "
+        "frequency='14074000' flowStartSeconds='%1'/>"
+        "</receptionReports>").arg(now).toUtf8();
+    PskReporterClientTestAccess::handleQueryReply(
+        liveClient, globalXml, PskReporterClient::QueryScope::Anyone);
+    ok &= check(liveClient.spots().size() == 1
+                    && liveClient.spots().first().senderCallsign
+                           == QStringLiteral("K1ABC"),
+                "global HTTP backfill seeds only the selected live callsign");
+    liveClient.setCallsign(QString());
+    PskReporterClientTestAccess::loadCache(liveClient);
+    ok &= check(liveClient.spots().size() == 2
+                    && liveClient.monitors().size() == 1,
+                "clearing a live callsign immediately restores the cached "
+                "global snapshot");
+    PskReporterClientTestAccess::discardPendingCacheWrite(parserClient);
 
     constexpr double worldWidth = 360.0;
     ok &= check(std::abs(MapPathGeometry::unwrapX(

--- a/tests/psk_reporter_map_behavior_test.cpp
+++ b/tests/psk_reporter_map_behavior_test.cpp
@@ -5,6 +5,7 @@
 #include <QCoreApplication>
 #include <QJsonArray>
 #include <QJsonObject>
+#include <QTemporaryDir>
 #include <QTimeZone>
 
 #include <cmath>
@@ -80,6 +81,12 @@ public:
     static void discardPendingCacheWrite(PskReporterClient& client)
     {
         client.m_cacheDirty = false;
+    }
+
+    static void setCacheDirectory(PskReporterClient& client,
+                                  const QString& directory)
+    {
+        client.m_cacheDirectoryOverride = directory;
     }
 };
 
@@ -199,7 +206,7 @@ int main(int argc, char** argv)
     ok &= check(parserClient.spots().size()
                     == PskReporterClientTestAccess::maxSpots()
                     && parserClient.resultsLimited(),
-                "receptionReport parsing enforces and surfaces the spot cap");
+                "receptionReport parsing enforces and surfaces the request cap");
 
     PskReporterClient cacheClient;
     QJsonArray cachedMonitors;
@@ -222,6 +229,11 @@ int main(int argc, char** argv)
                 "reloading a cache does not duplicate active monitors");
 
     PskReporterClient liveClient;
+    QTemporaryDir cacheDirectory;
+    ok &= check(cacheDirectory.isValid(),
+                "temporary cache directory is available");
+    PskReporterClientTestAccess::setCacheDirectory(
+        liveClient, cacheDirectory.path());
     liveClient.setCallsign(QStringLiteral("K1ABC"));
     PskReporterClientTestAccess::setInterval(
         liveClient, PskReporterClient::kLiveMqtt);

--- a/tests/psk_reporter_map_behavior_test.cpp
+++ b/tests/psk_reporter_map_behavior_test.cpp
@@ -72,6 +72,17 @@ public:
         return PskReporterClient::kMaxMonitors;
     }
 
+    static qint64 maxHttpResponseBytes()
+    {
+        return PskReporterClient::kMaxHttpResponseBytes;
+    }
+
+    static bool appendHttpResponseChunk(QByteArray& response,
+                                        const QByteArray& chunk)
+    {
+        return PskReporterClient::appendHttpResponseChunk(response, chunk);
+    }
+
     static void restoreCachedMonitors(PskReporterClient& client,
                                       const QJsonArray& monitors)
     {
@@ -161,6 +172,19 @@ int main(int argc, char** argv)
     ok &= check(PskReporterClientTestAccess::rateLimitBackoffMs(20)
                     == 2LL * 60 * 60 * 1000,
                 "rate-limit backoff is capped at two hours");
+
+    QByteArray boundedResponse(
+        PskReporterClientTestAccess::maxHttpResponseBytes() - 1, 'x');
+    ok &= check(PskReporterClientTestAccess::appendHttpResponseChunk(
+                    boundedResponse, QByteArray(1, 'x'))
+                    && boundedResponse.size()
+                           == PskReporterClientTestAccess::maxHttpResponseBytes(),
+                "HTTP response accepts bytes through the safety limit");
+    ok &= check(!PskReporterClientTestAccess::appendHttpResponseChunk(
+                    boundedResponse, QByteArray(1, 'x'))
+                    && boundedResponse.size()
+                           == PskReporterClientTestAccess::maxHttpResponseBytes(),
+                "HTTP response rejects bytes beyond the safety limit");
 
     PskReporterClient parserClient;
     parserClient.setCallsign(QString());

--- a/tests/psk_reporter_map_behavior_test.cpp
+++ b/tests/psk_reporter_map_behavior_test.cpp
@@ -1,0 +1,134 @@
+#include "core/PskReporterClient.h"
+#include "gui/map/MapPathGeometry.h"
+#include "gui/map/SolarTerminator.h"
+
+#include <QCoreApplication>
+#include <QTimeZone>
+
+#include <cmath>
+#include <iostream>
+
+using namespace AetherSDR;
+
+namespace AetherSDR {
+
+class PskReporterClientTestAccess {
+public:
+    static QString cacheFilePath(const PskReporterClient& client)
+    {
+        return client.cacheFilePath();
+    }
+
+    static void setHttpDiagnostics(PskReporterClient& client,
+                                   qint64 lastRequestMs,
+                                   qint64 nextAllowedMs,
+                                   int status,
+                                   const QString& error)
+    {
+        client.m_lastHttpRequestEpochMs = lastRequestMs;
+        client.m_nextHttpAllowedEpochMs = nextAllowedMs;
+        client.m_lastHttpStatus = status;
+        client.m_lastHttpError = error;
+    }
+
+    static qint64 rateLimitBackoffMs(int count)
+    {
+        return PskReporterClient::rateLimitBackoffMs(count);
+    }
+};
+
+} // namespace AetherSDR
+
+namespace {
+
+bool check(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+    }
+    return condition;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    bool ok = true;
+
+    PskReporterClient client;
+    client.setCallsign(QStringLiteral("  k1abc  "));
+    ok &= check(client.callsign() == QStringLiteral("K1ABC"),
+                "callsign is normalized for a map-only query");
+    ok &= check(client.queryScope()
+                    == PskReporterClient::QueryScope::Callsign,
+                "non-empty callsign selects callsign scope");
+
+    client.setCallsign(QString());
+    ok &= check(client.callsign().isEmpty(),
+                "clearing the map query preserves an empty value");
+    ok &= check(client.queryScope() == PskReporterClient::QueryScope::Anyone,
+                "empty callsign selects anyone scope");
+    const QString anyoneCache =
+        PskReporterClientTestAccess::cacheFilePath(client);
+    client.setCallsign(QStringLiteral("K1ABC"));
+    const QString callsignCache =
+        PskReporterClientTestAccess::cacheFilePath(client);
+    client.setCallsign(QStringLiteral("W1AW"));
+    const QString otherCallsignCache =
+        PskReporterClientTestAccess::cacheFilePath(client);
+    ok &= check(anyoneCache != callsignCache,
+                "Anyone and callsign snapshots use separate cache files");
+    ok &= check(callsignCache != otherCallsignCache,
+                "each callsign snapshot has an independent cache file");
+
+    const qint64 requestMs = QDateTime::currentMSecsSinceEpoch();
+    PskReporterClientTestAccess::setHttpDiagnostics(
+        client, requestMs, requestMs + PskReporterClient::kMinPollMs,
+        429, QStringLiteral("Too Many Requests"));
+    ok &= check(client.lastHttpRequestAt().toMSecsSinceEpoch() == requestMs,
+                "HTTP diagnostics expose the last request time");
+    ok &= check(client.nextHttpRequestAt().toMSecsSinceEpoch()
+                    == requestMs + PskReporterClient::kMinPollMs,
+                "HTTP diagnostics expose the throttle deadline");
+    ok &= check(client.lastHttpStatus() == 429
+                    && client.lastHttpError()
+                           == QStringLiteral("Too Many Requests"),
+                "HTTP diagnostics expose status and error details");
+    ok &= check(PskReporterClientTestAccess::rateLimitBackoffMs(1)
+                    == 15 * 60 * 1000,
+                "first rate limit backs off for 15 minutes");
+    ok &= check(PskReporterClientTestAccess::rateLimitBackoffMs(2)
+                    == 30 * 60 * 1000,
+                "repeated rate limits back off exponentially");
+    ok &= check(PskReporterClientTestAccess::rateLimitBackoffMs(20)
+                    == 2LL * 60 * 60 * 1000,
+                "rate-limit backoff is capped at two hours");
+
+    constexpr double worldWidth = 360.0;
+    ok &= check(std::abs(MapPathGeometry::unwrapX(
+                            -179.0, 179.0, worldWidth) - 181.0) < 1e-9,
+                "eastbound path stays continuous across the antimeridian");
+    ok &= check(std::abs(MapPathGeometry::unwrapX(
+                            179.0, -179.0, worldWidth) + 181.0) < 1e-9,
+                "westbound path stays continuous across the antimeridian");
+    ok &= check(std::abs(MapPathGeometry::unwrapX(
+                            42.0, 40.0, worldWidth) - 42.0) < 1e-9,
+                "ordinary path samples stay in their canonical world");
+
+    const QDateTime marchEquinox(
+        QDate(2026, 3, 20), QTime(14, 46), QTimeZone::UTC);
+    const SolarTerminator::Position sun =
+        SolarTerminator::positionAt(marchEquinox);
+    ok &= check(std::abs(qRadiansToDegrees(sun.declinationRad)) < 0.5,
+                "solar declination is near zero at the March equinox");
+    const double subsolarLon = qRadiansToDegrees(sun.subsolarLonRad);
+    ok &= check(!SolarTerminator::isNight(0.0, subsolarLon, sun),
+                "subsolar point is in daylight");
+    ok &= check(SolarTerminator::isNight(
+                    0.0, SolarTerminator::normalizeDegrees(subsolarLon + 180.0),
+                    sun),
+                "antipode of subsolar point is at night");
+
+    return ok ? 0 : 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -928,6 +928,40 @@ add_test(NAME map_wrap_test COMMAND map_wrap_test)
 set_tests_properties(map_wrap_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
+# PSK Reporter map query scope and the UTC solar-position math used by the
+# optional day/night overlay. No network access is performed.
+add_executable(psk_reporter_map_behavior_test
+    tests/psk_reporter_map_behavior_test.cpp)
+target_include_directories(psk_reporter_map_behavior_test PRIVATE src)
+target_link_libraries(psk_reporter_map_behavior_test PRIVATE
+    aethercore Qt6::Core)
+add_test(NAME psk_reporter_map_behavior_test
+    COMMAND psk_reporter_map_behavior_test)
+
+# Live PSK Reporter updates must refresh the existing marker/path batches
+# atomically. Replacing them exposes the differently-scaled overview cache and
+# makes every MQTT report pulse between large/small dots and thick/thin paths.
+add_executable(map_live_update_test
+    tests/map_live_update_test.cpp
+    src/gui/map/MapMarkerBatchItem.cpp
+    src/gui/map/MapPathBatchItem.cpp
+    src/gui/map/MapTerminatorItem.cpp
+)
+target_include_directories(map_live_update_test PRIVATE src)
+target_link_libraries(map_live_update_test PRIVATE
+    aethercore
+    qgeoview
+    Qt6::Core
+    Qt6::Concurrent
+    Qt6::Gui
+    Qt6::Widgets
+    Qt6::Network
+)
+set_target_properties(map_live_update_test PROPERTIES AUTOMOC ON)
+add_test(NAME map_live_update_test COMMAND map_live_update_test)
+set_tests_properties(map_live_update_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 # Frameless-window geometry restore (#4328) — blob parse + the caption-free
 # re-clamp.  Windows-only in effect, but the logic is pure, so it is pinned on
 # every platform; case 4 drives a real QWidget so a future Qt changing the

--- a/third_party/QGeoView/AETHERSDR-PATCHES.md
+++ b/third_party/QGeoView/AETHERSDR-PATCHES.md
@@ -82,3 +82,17 @@ this list current when updating the snapshot.
     and keeps the projected point beneath the pinch centroid fixed. Both the
     view and viewport delivery paths are covered because `QGraphicsView`
     input targeting differs by platform.
+
+11. **`lib/src/QGVMapQGView.cpp` — optional vertical camera bounds.**
+    `setVerticalBoundsEnabled()` constrains the camera centre so the viewport
+    cannot move beyond the projection's north or south edge during pan, zoom,
+    or resize. It is off by default, preserving upstream behavior for callers
+    that do not opt in; AetherSDR enables it for the PSK Reporter map.
+
+12. **`lib/src/QGVLayerTiles.cpp` — coalesced tile-set bookkeeping during
+    camera gestures.** Existing tile graphics continue to follow the view
+    transform immediately, while the comparatively expensive active-tile-set
+    rebuild waits until camera input has been idle for 100 ms. Unlike patch 8,
+    this applies with or without horizontal wrapping. A continuous slow pan
+    can therefore defer newly required tile loads until the gesture pauses;
+    this is deliberate so tile scene churn does not stall map interaction.

--- a/third_party/QGeoView/lib/include/QGeoView/QGVLayerTiles.h
+++ b/third_party/QGeoView/lib/include/QGeoView/QGVLayerTiles.h
@@ -21,6 +21,7 @@
 #include "QGVLayer.h"
 
 #include <QElapsedTimer>
+#include <QTimer>
 
 class QGV_LIB_DECL QGVLayerTiles : public QGVLayer
 {
@@ -70,6 +71,7 @@ private:
     QMap<int, QMap<QGV::GeoTilePos, QGVDrawItem*>> mIndex;
 
     QElapsedTimer mLastAnimation;
+    QTimer mCameraUpdateTimer;
     bool mHorizontalWrapEnabled = false;
 
     struct

--- a/third_party/QGeoView/lib/include/QGeoView/QGVMapQGView.h
+++ b/third_party/QGeoView/lib/include/QGeoView/QGVMapQGView.h
@@ -51,6 +51,8 @@ public:
     void setScaleLimits(double minScale, double maxScale);
     void setHorizontalWrapEnabled(bool enabled);
     bool horizontalWrapEnabled() const;
+    void setVerticalBoundsEnabled(bool enabled);
+    bool verticalBoundsEnabled() const;
     void cleanState();
 
 Q_SIGNALS:
@@ -63,6 +65,7 @@ private:
     void cameraScale(const QRectF& projRect);
     void cameraRotate(double azimuth);
     void cameraMove(const QPointF& projPos);
+    QPointF constrainedCameraCenter(const QPointF& projPos) const;
     void updateHorizontalWrapSceneRect(const QPointF& center);
     void blockCameraUpdate();
     void unblockCameraUpdate();
@@ -110,6 +113,7 @@ private:
     double mScale;
     double mAzimuth;
     bool mHorizontalWrapEnabled;
+    bool mVerticalBoundsEnabled;
     QGV::MouseActions mMouseActions;
     QRect mViewRect;
     QGV::MapState mState;

--- a/third_party/QGeoView/lib/src/QGVLayerTiles.cpp
+++ b/third_party/QGeoView/lib/src/QGVLayerTiles.cpp
@@ -24,6 +24,10 @@
 QGVLayerTiles::QGVLayerTiles()
 {
     mCurZoom = -1;
+    mCameraUpdateTimer.setSingleShot(true);
+    mCameraUpdateTimer.setInterval(100);
+    connect(&mCameraUpdateTimer, &QTimer::timeout,
+            this, &QGVLayerTiles::processCamera);
     sendToBack();
 }
 
@@ -102,19 +106,26 @@ void QGVLayerTiles::onCamera(const QGVCameraState& oldState, const QGVCameraStat
     }
 
     if (needUpdate) {
-        processCamera();
+        // Existing tile graphics follow the QGraphicsView transform
+        // immediately. Rebuilding the active tile set for every fractional
+        // trackpad or drag event only churns scene items on the GUI thread.
+        // Coalesce that bookkeeping until input pauses; the final camera is
+        // still processed, while interaction remains responsive.
+        mCameraUpdateTimer.start();
     }
 }
 
 void QGVLayerTiles::onUpdate()
 {
     QGVLayer::onUpdate();
+    mCameraUpdateTimer.stop();
     processCamera();
 }
 
 void QGVLayerTiles::onClean()
 {
     QGVLayer::onClean();
+    mCameraUpdateTimer.stop();
     mCurZoom = -1;
     mCurRect = {};
     mIndex.clear();

--- a/third_party/QGeoView/lib/src/QGVMapQGView.cpp
+++ b/third_party/QGeoView/lib/src/QGVMapQGView.cpp
@@ -50,6 +50,7 @@ QGVMapQGView::QGVMapQGView(QGVMap* geoMap)
     mScale = 1.0;
     mAzimuth = 0.0;
     mHorizontalWrapEnabled = false;
+    mVerticalBoundsEnabled = false;
     mMouseActions = QGV::MouseAction::All;
     mViewRect = viewport()->rect();
     mState = QGV::MapState::Idle;
@@ -140,6 +141,22 @@ bool QGVMapQGView::horizontalWrapEnabled() const
     return mHorizontalWrapEnabled;
 }
 
+void QGVMapQGView::setVerticalBoundsEnabled(bool enabled)
+{
+    if (mVerticalBoundsEnabled == enabled) {
+        return;
+    }
+    mVerticalBoundsEnabled = enabled;
+    if (enabled) {
+        cameraMove(viewRect().center());
+    }
+}
+
+bool QGVMapQGView::verticalBoundsEnabled() const
+{
+    return mVerticalBoundsEnabled;
+}
+
 void QGVMapQGView::cleanState()
 {
     changeState(QGV::MapState::Idle);
@@ -187,7 +204,9 @@ void QGVMapQGView::cameraScale(double scale)
     mScale = newScale;
     if (mHorizontalWrapEnabled) {
         updateHorizontalWrapSceneRect(oldCenter);
-        QGraphicsView::centerOn(oldCenter);
+    }
+    if (mHorizontalWrapEnabled || mVerticalBoundsEnabled) {
+        QGraphicsView::centerOn(constrainedCameraCenter(oldCenter));
     }
     applyCameraUpdate(oldState);
     qgvDebug() << "cameraScale" << scale;
@@ -211,7 +230,7 @@ void QGVMapQGView::cameraMove(const QPointF& projPos)
 {
     const QGVCameraState oldState = getCamera();
     const QPointF oldCenter = viewRect().center();
-    const QPointF target = projPos;
+    const QPointF target = constrainedCameraCenter(projPos);
     if (mHorizontalWrapEnabled) {
         // Keep x continuous instead of snapping the camera back into the base
         // world at the dateline. Tiles and overlays follow the current world
@@ -223,6 +242,26 @@ void QGVMapQGView::cameraMove(const QPointF& projPos)
         applyCameraUpdate(oldState);
         qgvDebug() << "cameraMove" << target;
     }
+}
+
+QPointF QGVMapQGView::constrainedCameraCenter(const QPointF& projPos) const
+{
+    if (!mVerticalBoundsEnabled) {
+        return projPos;
+    }
+
+    const QRectF world = mGeoMap->getProjection()->boundaryProjRect();
+    const double halfViewHeight = viewRect().height() * 0.5;
+    const double minY = world.top() + halfViewHeight;
+    const double maxY = world.bottom() - halfViewHeight;
+
+    QPointF result = projPos;
+    // Scale limits normally keep the viewport shorter than the world. The
+    // midpoint fallback also makes the constraint safe during construction
+    // and resize transitions where that invariant may briefly be false.
+    result.setY(minY <= maxY ? qBound(minY, projPos.y(), maxY)
+                             : world.center().y());
+    return result;
 }
 
 void QGVMapQGView::updateHorizontalWrapSceneRect(const QPointF& center)
@@ -695,7 +734,9 @@ void QGVMapQGView::resizeEvent(QResizeEvent* event)
     mViewRect = viewport()->rect();
     if (mHorizontalWrapEnabled) {
         updateHorizontalWrapSceneRect(oldCenter);
-        QGraphicsView::centerOn(oldCenter);
+    }
+    if (mHorizontalWrapEnabled || mVerticalBoundsEnabled) {
+        QGraphicsView::centerOn(constrainedCameraCenter(oldCenter));
     }
     mGeoMap->anchoreWidgets();
     applyCameraUpdate(oldState);


### PR DESCRIPTION
Closes #5115

## Summary

Improve the PSK Reporter map so it can reproduce the useful global view from pskreporter.info while keeping callsign reports live and the rest of AetherSDR responsive.

- Prepopulate the map-local Call filter from the station callsign without writing map edits back to the radio or saved station identity.
- Run a bounded global HTTP snapshot when the dialog opens, cache it across scope changes, and reuse matching rows as historical context for the selected callsign.
- Keep the selected callsign on live MQTT and merge those reports with the cached global snapshot; All Callsigns remains an independent display layer.
- Respect PSK Reporter's five-minute HTTP floor, coordinate requests across AetherSDR processes, honor `Retry-After`, and persist exponential rate-limit backoff.
- Add independent All Callsigns, Active monitors, Paths, and Day/night controls. With Paths off, endpoint hover shows one path and selected-callsign hover shows all of its displayed paths.
- Parse large HTTP XML snapshots away from the GUI thread; batch markers and paths; cancel superseded render/projection work; and retain completed caches while replacements render.
- Smooth button zooming, constrain vertical panning, preserve horizontal wrapping, repair paths across the antimeridian, and refresh the solar terminator every 60 seconds.
- Reorganize the top controls into a native themed Reports panel with filters/stats together and a separate WSPR beacon section.
- Show combined HTTP + MQTT state and connection/rate-limit diagnostics from the status indicator.

## RFC status

The implementation is complete. The operator standing in for the project maintainer explicitly approved RFC #5115 on 2026-08-20.

## Constitution principle honored

Principle XI - Fixes Are Demonstrated. Regression coverage exercises map wrapping, query scope and throttling behavior, global-cache continuity, grouped hover paths, and cancellation of superseded asynchronous rendering. The completed build was also exercised through the authenticated automation bridge with TX disabled.

## Test plan

- [x] Refreshed and audited against current `upstream/main` (`990f3391`).
- [x] macOS ARM64 application and affected tests build successfully:
  - `/opt/homebrew/bin/cmake --build build-codex-arm64 -j8 --target AetherSDR map_wrap_test psk_reporter_map_behavior_test map_live_update_test`
- [x] Focused tests pass:
  - `ctest --test-dir build-codex-arm64 -R '^(map_wrap_test|psk_reporter_map_behavior_test|map_live_update_test)$' --output-on-failure`
- [x] Strict test-registration check passes.
- [x] Strict engine-boundary check reports zero blocking findings.
- [x] Hardcoded-color ratchet is unchanged from the PR base.
- [x] Accessibility check reports only existing repository warnings.
- [x] Final executable verified as Mach-O ARM64 with no RNNoise x86 translation units.
- [x] Global markers, callsign history/live merge, path toggling, filters, diagnostics, terminator, and the reorganized controls were exercised through the authenticated automation bridge with TX disabled.
- [x] GitHub Actions CI passes for `b1e83809` (Linux, macOS, Windows, and Static Checks).
- [x] RFC #5115 received maintainer-delegate approval on 2026-08-20.

## Checklist

- [x] Commits are signed.
- [x] No new flat-key `AppSettings` calls were added.
- [x] Code is clean-room and not derived from proprietary binaries.
- [x] No transmit behavior was added or exercised.
- [x] `CHANGELOG.md` was not modified.
- [x] QGeoView patches are documented in `third_party/QGeoView/AETHERSDR-PATCHES.md`.
