### PR TITLE
feat(icom): add IC-9700 band power limits and tune guard

### DIFF
--- a/docs/architecture/radio-capabilities-map.md
+++ b/docs/architecture/radio-capabilities-map.md
@@ -327,9 +327,29 @@ automation, so it is **deliberately deferred to its own PR.**
 | Field | Flex | HL2 | Sim | Note |
 |---|:--:|:--:|:--:|---|
 | `sampleRatesHz` | — | 4 rates | `{}` | HL2 populates it honestly; no consumer exists |
-| `txPowerMaxWatts` | — (0.0) | 0.0 | 0.0 | Flex omits it despite transmitting. Wrong, but inert while unread |
+| `txPowerMaxWatts` | — (0.0) | 0.0 | 0.0 | Global fallback ceiling; Flex still omits it despite transmitting, which remains wrong but inert while `txPowerBands` is empty |
 | `hasAmplifier` | — (❌) | ❌ | ❌ | The AMP applet is driven by `TunerModel::presenceChanged`, not by this |
 | `extensions` | — | — | — | The namespaced vendor bag; never populated |
+
+`txPowerBands` is the consumed exception to this section: `RadioModel` reads it
+to update `TransmitModel::maxPowerLevel` when the transmit slice crosses into a
+range with a different PA rating. Flex, HL2 and Sim explicitly leave it empty;
+the IC-9700 declares 144–148 MHz at 100 W, 430–450 MHz at 75 W and 1240–1300
+MHz at 10 W. An empty list preserves the prior global/radio-reported behaviour.
+
+On the Icom side these ratings are not written into `capabilities()` by hand.
+They are read from `bandsFor()` in `IcomModels.cpp` — the same table the tune
+guard (`supportsFrequency` / `nearestSupportedFrequency`) uses to refuse the
+two holes in the IC-9700's envelope, because the ceilings and the tunable
+ranges describe the same three RF decks and must not be able to disagree. An
+empty table is also the predicate the tune path keys on, so a model with one
+continuous range keeps its untouched command path.
+
+What `maxPowerLevel` actually drives on an Icom is the **meter and gauge full
+scale** (`MainWindow_Wiring.cpp`, `VfoWidget::txPowerFullScaleW`). RF power
+itself is a 0–100 % CI-V level, so the radio's own PA governs the watts. This
+field makes a 10 W 23 cm transmission read against a 10 W scale instead of a
+100 W one; it does not clamp the request.
 
 These are the ones to check first when something "should have worked". Note the
 pattern in the Flex column: five fields across this table and the one above are

--- a/src/core/backends/RadioCapabilities.h
+++ b/src/core/backends/RadioCapabilities.h
@@ -8,6 +8,12 @@
 
 namespace AetherSDR {
 
+struct TxPowerBand {
+    double lowHz = 0.0;
+    double highHz = 0.0;
+    double maxWatts = 0.0;
+};
+
 // The honest, self-declared feature set of a connected radio, produced by an
 // IRadioBackend and surfaced to clients (aetherd RFC §4.1 `welcome`). Clients
 // render against what the radio *reports* — a control the radio lacks is
@@ -103,6 +109,21 @@ struct RadioCapabilities {
     // keying intent regardless of client requests.
     bool canTransmit = false;
     double txPowerMaxWatts = 0.0;  // 0 when RX-only
+
+    // Optional per-frequency ceilings for radios whose PA rating changes by
+    // band. Empty means txPowerMaxWatts applies everywhere. The ranges are
+    // inclusive and expressed in Hz, matching the tuning fields above.
+    QVector<TxPowerBand> txPowerBands;
+
+    [[nodiscard]] double txPowerMaxWattsAt(double frequencyHz) const noexcept
+    {
+        for (const TxPowerBand& band : txPowerBands) {
+            if (frequencyHz >= band.lowHz && frequencyHz <= band.highHz) {
+                return band.maxWatts;
+            }
+        }
+        return txPowerMaxWatts;
+    }
 
     // Modes this radio DEMODULATES BUT WILL NOT TRANSMIT IN, in AetherSDR's
     // neutral vocabulary (the same strings SliceModel carries).

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -131,6 +131,7 @@ void FlexBackend::setModelProvider(std::function<QString()> provider)
 RadioCapabilities FlexBackend::capabilities() const
 {
     RadioCapabilities caps;
+    caps.txPowerBands = {};
     caps.family = QStringLiteral("flex");
     caps.manufacturer = QStringLiteral("FlexRadio");
     caps.model = m_modelProvider ? m_modelProvider() : QString();

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -1372,6 +1372,7 @@ Hl2Backend::~Hl2Backend()
 RadioCapabilities Hl2Backend::capabilities() const
 {
     RadioCapabilities c;
+    c.txPowerBands = {};
     c.family = QStringLiteral("hl2");
     c.manufacturer = QStringLiteral("Hermes-Lite");
     c.model = QStringLiteral("Hermes-Lite 2");

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -9,7 +9,9 @@
 #include <array>
 #include <cmath>
 #include <functional>
+#include <limits>
 #include <optional>
+#include <span>
 
 #include "core/backends/icom/IcomControls.h"
 #include "core/backends/icom/IcomSettings.h"
@@ -125,6 +127,19 @@ RadioCapabilities IcomCivBackend::capabilities() const
 
     c.canTransmit = m.hasTransmit;
     c.txPowerMaxWatts = m.txPowerMaxWatts;
+    // Published from the model's own band table rather than a second hand-kept
+    // list, so the ceilings and the tune guard can never describe different
+    // hardware. An empty table (every model but the IC-9700) leaves the vector
+    // empty, which is what RadioModel reads as "txPowerMaxWatts applies
+    // everywhere" — the prior behaviour, unchanged.
+    c.txPowerBands = {};
+    const std::span<const IcomBand> bands = bandsFor(m);
+    c.txPowerBands.reserve(static_cast<int>(bands.size()));
+    for (const IcomBand& band : bands) {
+        c.txPowerBands.append(TxPowerBand{static_cast<double>(band.lowHz),
+                                          static_cast<double>(band.highHz),
+                                          band.maxWatts});
+    }
 
     // THE MODES THIS RADIO RECEIVES BUT WILL NOT TRANSMIT IN — WFM on an
     // IC-705, which covers 76-108 MHz broadcast and whose transmitter does not
@@ -2166,10 +2181,42 @@ void IcomCivBackend::sendUserCommand(const std::vector<std::uint8_t>& frame)
 
 void IcomCivBackend::setSliceFrequency(int, double hz)
 {
-    if (hz <= 0.0)
+    if (!std::isfinite(hz) || hz <= 0.0
+        || hz > static_cast<double>(std::numeric_limits<std::int64_t>::max())) {
         return;
+    }
+    const std::uint64_t roundedHz = static_cast<std::uint64_t>(std::llround(hz));
+    // Only a model that DECLARES discontinuous bands gets this gate. Every
+    // other Icom keeps its existing command path — an empty table is the
+    // predicate, so the day another model's holes are documented, this site
+    // and setPanCenter() below light up together rather than one at a time.
+    if (!bandsFor(*m_model).empty() && !supportsFrequency(*m_model, roundedHz)) {
+        emit configurationWarning(
+            tr("%1 cannot tune %2 MHz; the request is outside its supported bands")
+                .arg(QString::fromUtf8(m_model->name.data(),
+                                       static_cast<int>(m_model->name.size())))
+                .arg(hz / 1.0e6, 0, 'f', 6));
+        // There is no radio-authoritative value to restore until the first
+        // frequency reply arrives. Refuse the command, but do not replace the
+        // optimistic display with the construction default of 0 MHz.
+        if (m_frequencyHz == 0) {
+            return;
+        }
+        // SliceModel has already accepted and announced the operator's request
+        // by the time this seam verb runs. Re-assert the radio's actual VFO on
+        // the next event-loop turn, after that optimistic announcement, so a
+        // refused gap tune cannot leave the display claiming a frequency the
+        // radio never entered. Same ordering contract as setSliceMode().
+        const double actualMhz = static_cast<double>(m_frequencyHz) / 1.0e6;
+        QTimer::singleShot(0, this, [this, actualMhz] {
+            SliceDelta delta;
+            delta.frequency = actualMhz;
+            emit sliceChanged(sliceId(), delta);
+        });
+        return;
+    }
     sendUserCommand(cmdSetFrequency(m_session ? m_session->civAddress() : 0xA4,
-                                    static_cast<std::uint64_t>(std::llround(hz))));
+                                    roundedHz));
 }
 
 void IcomCivBackend::setSliceMode(int, const QString& mode)
@@ -2400,9 +2447,17 @@ void IcomCivBackend::setPanCenter(const QString&, double hz, PanCenterIntent int
         return;
     }
 
+    double tuneHz = requestedHz;
+    if (!bandsFor(*m_model).empty() && std::isfinite(requestedHz)
+        && requestedHz > 0.0
+        && requestedHz <= static_cast<double>(std::numeric_limits<std::int64_t>::max())) {
+        const std::uint64_t roundedHz = static_cast<std::uint64_t>(std::llround(requestedHz));
+        tuneHz = static_cast<double>(nearestSupportedFrequency(*m_model, roundedHz));
+    }
     qCDebug(lcIcomPan) << "pan drag retunes:" << m_scopeCentreHz << "Hz ->"
-                       << requestedHz << "Hz (delta" << deltaHz << ")";
-    setSliceFrequency(sliceId(), requestedHz);
+                       << tuneHz << "Hz (asked" << requestedHz << "Hz, delta"
+                       << deltaHz << ")";
+    setSliceFrequency(sliceId(), tuneHz);
 }
 
 void IcomCivBackend::setPanBandwidth(const QString&, double hz)

--- a/src/core/backends/icom/IcomModels.cpp
+++ b/src/core/backends/icom/IcomModels.cpp
@@ -1,5 +1,6 @@
 #include "core/backends/icom/IcomModels.h"
 
+#include <algorithm>
 #include <array>
 #include <cctype>
 #include <string>
@@ -156,6 +157,27 @@ constexpr IcomModel kUnknown{
     /*hasVfoModeCommand*/ false,
 };
 
+// THE IC-9700's THREE RF DECKS — the one place these numbers live.
+//
+// This radio is not a continuous 144-1300 MHz receiver with a wide tuning
+// range; it is three separate RF decks with two large holes between them, and
+// each deck has its own PA rating. Both facts have to agree, because they
+// describe the same hardware: the tune guard refuses the holes, and
+// IcomCivBackend::capabilities() publishes the ratings as txPowerBands. When
+// those two lists were kept separately, nothing stopped an edge correction
+// landing in one and not the other — a radio that would tune 430-450 while the
+// power scale still described 430-440, or the reverse.
+//
+// Ranges are the US/A version's published coverage. A region whose radio is
+// narrower (the EU 9700 stops at 146 and 440) is REFUSED BY THE RADIO, which
+// is the safe direction to be wrong in: we offer a frequency it declines,
+// rather than silently withholding one it supports.
+constexpr std::array<IcomBand, 3> kIc9700Bands{{
+    {  144'000'000ULL,   148'000'000ULL, 100.0},   // 2 m
+    {  430'000'000ULL,   450'000'000ULL,  75.0},   // 70 cm
+    {1'240'000'000ULL, 1'300'000'000ULL,  10.0},   // 23 cm
+}};
+
 constexpr std::array<ModulationInputChoice, 4> kIc705ModInputs{{
     {0x00, "MIC",     ModSourceMic},
     {0x01, "USB",     ModSourceUsb},
@@ -209,6 +231,56 @@ const IcomModel* modelForName(std::string_view name)
 std::span<const IcomModel> knownModels() { return kModels; }
 
 const IcomModel& unknownModel() { return kUnknown; }
+
+std::span<const IcomBand> bandsFor(const IcomModel& model) noexcept
+{
+    // The IC-9700 is the only row whose min/max envelope contains holes. Every
+    // other model — including the unknown fallback — returns an empty span, and
+    // that emptiness is what keeps their tune path exactly as it was.
+    if (model.civAddress == 0xA2) {
+        return kIc9700Bands;
+    }
+    return {};
+}
+
+bool supportsFrequency(const IcomModel& model, std::uint64_t hz) noexcept
+{
+    if (const std::span<const IcomBand> bands = bandsFor(model); !bands.empty()) {
+        return std::ranges::any_of(bands, [hz](const IcomBand& band) {
+            return hz >= band.lowHz && hz <= band.highHz;
+        });
+    }
+    if (model.tuningMinHz == 0 || model.tuningMaxHz == 0) {
+        return true;
+    }
+    return hz >= model.tuningMinHz && hz <= model.tuningMaxHz;
+}
+
+std::uint64_t nearestSupportedFrequency(const IcomModel& model,
+                                        std::uint64_t hz) noexcept
+{
+    if (supportsFrequency(model, hz)) {
+        return hz;
+    }
+    if (const std::span<const IcomBand> bands = bandsFor(model); !bands.empty()) {
+        std::uint64_t nearest = bands.front().lowHz;
+        std::uint64_t distance = hz > nearest ? hz - nearest : nearest - hz;
+        for (const IcomBand& band : bands) {
+            for (const std::uint64_t edge : {band.lowHz, band.highHz}) {
+                const std::uint64_t edgeDistance = hz > edge ? hz - edge : edge - hz;
+                if (edgeDistance < distance) {
+                    nearest = edge;
+                    distance = edgeDistance;
+                }
+            }
+        }
+        return nearest;
+    }
+    if (model.tuningMinHz == 0 || model.tuningMaxHz == 0) {
+        return hz;
+    }
+    return std::clamp(hz, model.tuningMinHz, model.tuningMaxHz);
+}
 
 std::optional<ModulationProfile> modulationProfileFor(const IcomModel& model)
 {

--- a/src/core/backends/icom/IcomModels.h
+++ b/src/core/backends/icom/IcomModels.h
@@ -152,6 +152,41 @@ modulationProfileFor(const IcomModel& model);
 // still tune and listen.
 [[nodiscard]] const IcomModel& unknownModel();
 
+// One RF deck: a range this model can tune, and the PA rating inside it.
+//
+// A model needs this only when its tunable range is NOT the single continuous
+// interval [tuningMinHz, tuningMaxHz] — which, today, means the IC-9700 alone.
+struct IcomBand {
+    std::uint64_t lowHz = 0;
+    std::uint64_t highHz = 0;
+    double maxWatts = 0.0;
+};
+
+// This model's discontinuous band table, or an EMPTY span when its tuning
+// range is the one continuous tuningMinHz..tuningMaxHz interval.
+//
+// THE SINGLE SOURCE OF TRUTH for both halves of a banded model: the tune
+// guard (supportsFrequency/nearestSupportedFrequency) and the capability
+// ceilings (IcomCivBackend::capabilities) both read this one table, so a
+// corrected edge or PA rating lands in every consumer at once. Two hand-kept
+// copies would have let the guard and the power scale disagree silently —
+// exactly the shape of drift that only shows up on the air.
+//
+// Emptiness is also the predicate the tune path keys on: no table means no
+// holes to refuse, so continuous models keep their untouched command path.
+[[nodiscard]] std::span<const IcomBand> bandsFor(const IcomModel& model) noexcept;
+
+// True when hz lies in a band this model can tune. Unknown models remain
+// permissive because they have no verified range to enforce.
+[[nodiscard]] bool supportsFrequency(const IcomModel& model,
+                                     std::uint64_t hz) noexcept;
+
+// Resolve an arbitrary request to the nearest frequency this model supports.
+// Continuous-range and unknown models preserve their existing min/max policy;
+// the IC-9700 snaps across the two holes between its three RF decks.
+[[nodiscard]] std::uint64_t nearestSupportedFrequency(const IcomModel& model,
+                                                      std::uint64_t hz) noexcept;
+
 // Decode the reply to CI-V 0x19 0x00. Returns the reported address, or nullopt
 // if this is not that reply.
 [[nodiscard]] std::optional<std::uint8_t> parseModelIdReply(const CivFrame& frame);

--- a/src/core/backends/sim/SimBackend.cpp
+++ b/src/core/backends/sim/SimBackend.cpp
@@ -231,6 +231,7 @@ QString SimBackend::familyName()    { return QStringLiteral("sim"); }
 RadioCapabilities SimBackend::capabilities() const
 {
     RadioCapabilities caps;
+    caps.txPowerBands = {};
     caps.family = familyName();
     caps.manufacturer = QStringLiteral("AetherSDR");
     caps.model  = demoModelName();

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1245,6 +1245,7 @@ void RadioModel::setupBackend(const QString& family)
             m_slices.append(s);
             s->applyChanges(mapped);
             m_meterModel.setActiveTxSlice(activeTxSliceNum());
+            refreshTxPowerLimit();
             emit sliceAdded(s);
             return;
         }
@@ -1266,6 +1267,9 @@ void RadioModel::setupBackend(const QString& family)
             // can also move because a slice was REMOVED, which carries no delta
             // at all.
             m_meterModel.setActiveTxSlice(activeTxSliceNum());
+            if (mapped.frequency.has_value() || mapped.txSlice.has_value()) {
+                refreshTxPowerLimit();
+            }
         }
     });
 
@@ -3737,6 +3741,9 @@ bool RadioModel::hasDaxStreams() const
 void RadioModel::publishCapabilities(bool connected)
 {
     const RadioCapabilities caps = backendCapabilities();
+    m_txPowerBands = connected ? caps.txPowerBands : QVector<TxPowerBand>{};
+    m_activeTxPowerBandLowHz = 0.0;
+    m_activeTxPowerBandHighHz = 0.0;
 
     // Capability-driven, not family()!="flex": only a backend that both
     // host-modulates and may transmit collapses the mic source to PC. (#4449)
@@ -3751,8 +3758,46 @@ void RadioModel::publishCapabilities(bool connected)
     // greyed out after unplugging an HL2 would look like a fault. Every
     // capability below follows the same `!connected || caps.x` shape.
     m_transmitModel.setHasTuner(!connected || caps.hasTuner);
+    refreshTxPowerLimit();
 
     emit capabilitiesChanged(connected, caps);
+}
+
+void RadioModel::refreshTxPowerLimit()
+{
+    if (!m_backend || !isConnected()) {
+        return;
+    }
+    if (m_txPowerBands.isEmpty()) {
+        return;
+    }
+
+    const SliceModel* tx = txSlice();
+    if (!tx || tx->frequency() <= 0.0) {
+        return;
+    }
+
+    const double frequencyHz = tx->frequency() * 1.0e6;
+    // The common drag-rate path remains entirely below the capability lookup
+    // and TransmitModel setter while the TX VFO stays inside the same RF deck.
+    if (frequencyHz >= m_activeTxPowerBandLowHz
+        && frequencyHz <= m_activeTxPowerBandHighHz) {
+        return;
+    }
+
+    // The capability ranges are cached at the connect edge, so crossing an RF
+    // deck still performs no backend capability rebuild or QString allocation.
+    for (const TxPowerBand& band : m_txPowerBands) {
+        if (frequencyHz >= band.lowHz && frequencyHz <= band.highHz) {
+            m_activeTxPowerBandLowHz = band.lowHz;
+            m_activeTxPowerBandHighHz = band.highHz;
+            const int maxWatts = qRound(band.maxWatts);
+            if (maxWatts > 0) {
+                m_transmitModel.setMaxPowerLevel(maxWatts);
+            }
+            return;
+        }
+    }
 }
 
 IRadioBackend::HealthSnapshot RadioModel::backendHealthSnapshot() const

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1446,6 +1446,9 @@ private:
     // then emit capabilitiesChanged. Called on every connect/disconnect edge and
     // whenever the backend revises its own capabilities.
     void publishCapabilities(bool connected);
+    // Apply a backend's band-dependent PA ceiling to TransmitModel. Backends
+    // without per-band data leave the existing radio-reported limit alone.
+    void refreshTxPowerLimit();
     // Bind the one producer for rxDemodAudioReady. Idempotent; call after
     // m_backend and m_panStream are both settled for the new family.
     void wireRxDemodAudioBus();
@@ -1459,6 +1462,9 @@ private:
     // decide whether a connect needs a different backend.
     QString m_family;
     std::unique_ptr<IRadioBackend> m_backend;
+    QVector<TxPowerBand> m_txPowerBands;
+    double m_activeTxPowerBandLowHz = 0.0;
+    double m_activeTxPowerBandHighHz = 0.0;
     // RFC #4288 Route A: when true, m_backend is a wire-less SimBackend (the demo
     // simulator) instead of a FlexBackend. Selected per-connection from the target
     // — see connectToRadio(). Also generalizes to future non-Flex backends (HL2).

--- a/tests/IcomFakeRadio.h
+++ b/tests/IcomFakeRadio.h
@@ -281,6 +281,17 @@ public:
             m_name.resize(kMaxNameBytes);
     }
 
+    void frontPanelFrequency(std::uint64_t hz)
+    {
+        m_frequencyHz = hz;
+        std::vector<std::uint8_t> frame{0xFE, 0xFE, kControllerAddress, m_addr,
+                                        cmd::kSetFreqTrx};
+        const std::vector<std::uint8_t> bcd = encodeFreq(hz);
+        frame.insert(frame.end(), bcd.begin(), bcd.end());
+        frame.push_back(kCivEom);
+        pushCiv(frame);
+    }
+
     // A SECOND DEVICE ON THE BUS. Icom's own RS-BA1 server can front a serial
     // CI-V bus carrying another radio, a rotator or an amplifier, and all of
     // them answer a broadcast. Set this and the broadcast draws two replies with
@@ -540,9 +551,9 @@ private:
         // Answer a read-frequency with the radio's frequency, addressed BACK to
         // the controller.
         if (frame->cmd == cmd::kReadFreq) {
-            std::vector<std::uint8_t> reply{0xFE, 0xFE, kControllerAddress, kIc705Addr,
+            std::vector<std::uint8_t> reply{0xFE, 0xFE, kControllerAddress, m_addr,
                                             cmd::kReadFreq};
-            const auto bcd = encodeFreq(kRadioFrequencyHz);
+            const auto bcd = encodeFreq(m_frequencyHz);
             reply.insert(reply.end(), bcd.begin(), bcd.end());
             reply.push_back(kCivEom);
             pushCiv(reply);
@@ -821,6 +832,7 @@ private:
     std::uint16_t m_audioInner = 1;
     // WHICH Icom this is. Defaults to the IC-705 the suite was written against.
     std::uint8_t  m_addr = kIc705Addr;
+    std::uint64_t m_frequencyHz = kRadioFrequencyHz;
     std::uint8_t  m_secondAddr = 0;
     bool          m_civEcho = false;
     std::string   m_name = "IC-705";

--- a/tests/icom_backend_test.cpp
+++ b/tests/icom_backend_test.cpp
@@ -1335,6 +1335,7 @@ int main(int argc, char** argv)
         FakeIc705 radio;
         IcomCivBackend backend;
         double frequencyMHz = 0.0;
+        int frequencyPublications = 0;
         QStringList warnings;
 
         CivCase(std::uint8_t addr, const char* name, bool echo = true)
@@ -1344,7 +1345,10 @@ int main(int argc, char** argv)
             radio.setCivEcho(echo);
             QObject::connect(&backend, &IRadioBackend::sliceChanged, &backend,
                              [this](int, const SliceDelta& d) {
-                                 if (d.frequency) frequencyMHz = *d.frequency;
+                                 if (d.frequency) {
+                                     frequencyMHz = *d.frequency;
+                                     ++frequencyPublications;
+                                 }
                              });
             QObject::connect(&backend, &IRadioBackend::configurationWarning, &backend,
                              [this](const QString& m) { warnings << m; });
@@ -1417,6 +1421,40 @@ int main(int argc, char** argv)
               "auto: and the radio ANSWERS - a frequency arrives, where the "
               "0xA4-hardcoded path produced a permanently blank session");
         check(c.backend.model().civAddress == 0xA2, "auto: resolved as the IC-9700");
+        const RadioCapabilities caps = c.backend.capabilities();
+        check(caps.txPowerBands.size() == 3
+                  && caps.txPowerMaxWattsAt(146'000'000.0) == 100.0
+                  && caps.txPowerMaxWattsAt(432'000'000.0) == 75.0
+                  && caps.txPowerMaxWattsAt(1'296'000'000.0) == 10.0,
+              "auto: IC-9700 capabilities carry all three PA ceilings");
+
+        // cmd::kSetFreq (0x05), NOT cmd::kSetFreqTrx (0x00). 0x00 is the
+        // TRANSCEIVE frame a radio sends the controller when its own VFO
+        // moved; AetherSDR never emits it, so counting it made this assertion
+        // 0 == 0 whether or not the gate existed. Verified by neutering the
+        // gate: with 0x00 the check still passed while a real set-frequency
+        // went out on the wire. cmdSetFrequency() builds 0x05 — CivCodec.cpp.
+        const int tuneCommandsBefore = static_cast<int>(std::ranges::count_if(
+            c.radio.civCommands(), [](const CivFrame& frame) {
+                return frame.cmd == cmd::kSetFreq;
+            }));
+        const int frequencyPublicationsBefore = c.frequencyPublications;
+        const double actualFrequencyBefore = c.frequencyMHz;
+        c.backend.setSliceFrequency(0, 500'000'000.0);
+        check(waitFor([&] {
+                  return c.frequencyPublications > frequencyPublicationsBefore;
+              }),
+              "auto: a rejected IC-9700 gap tune still produces a publication");
+        const int tuneCommandsAfter = static_cast<int>(std::ranges::count_if(
+            c.radio.civCommands(), [](const CivFrame& frame) {
+                return frame.cmd == cmd::kSetFreq;
+            }));
+        check(tuneCommandsAfter == tuneCommandsBefore,
+              "auto: an IC-9700 gap frequency sends no CI-V tune command");
+        check(c.warnedAbout("outside its supported bands"),
+              "auto: an IC-9700 gap frequency explains why it was rejected");
+        check(c.frequencyMHz == actualFrequencyBefore,
+              "auto: the corrective frequency is radio state, not the refused request");
 
         // ONE broadcast per connect. Never polled, never retried on a timer:
         // RFC #4983 attributes an unrecoverable CI-V stall to request volume,
@@ -1424,6 +1462,47 @@ int main(int argc, char** argv)
         const int broadcasts = c.sentTo(kBroadcastAddress);
         check(broadcasts == 1,
               "auto: exactly one broadcast 0x19 0x00 is sent for the whole connect");
+    }
+
+    // ---- THE GATE IS IC-9700-ONLY, PROVEN ON THE WIRE ---------------------
+    //
+    // #5116's non-goals name IC-705 and IC-7300MK2 explicitly: neither may
+    // change tuning behaviour. The gate above keys on `bandsFor()` being
+    // non-empty, which today is the IC-9700 alone — but "the predicate reads
+    // right" is not evidence, and the assertion that WAS meant to carry this
+    // was counting a command AetherSDR never sends.
+    //
+    // So ask it of the wire instead: 500 MHz is above the IC-705's 470 MHz
+    // ceiling AND far above the IC-7300MK2's 74.8 MHz, so a gate that ever
+    // generalised to model.tuningMinHz/tuningMaxHz would silence both. The
+    // discriminating outcome is that the set-frequency still goes out, and no
+    // band warning is raised.
+    for (const auto& [addr, label] :
+         std::array<std::pair<std::uint8_t, const char*>, 2>{{{0xA4, "IC-705"},
+                                                             {0xB6, "IC-7300MK2"}}}) {
+        CivCase c(addr, label);
+        c.backend.connectRadio(c.request());
+        check(waitFor([&] { return c.backend.isConnected(); }),
+              "continuous model: the session comes up");
+        check(waitFor([&] { return c.backend.model().civAddress == addr; }),
+              "continuous model: it resolved to the address under test");
+        check(bandsFor(c.backend.model()).empty(),
+              "continuous model: it declares no discontinuous band table, so "
+              "the IC-9700 gate cannot apply to it");
+
+        const auto setFrequencyCount = [&c] {
+            return static_cast<int>(std::ranges::count_if(
+                c.radio.civCommands(),
+                [](const CivFrame& f) { return f.cmd == cmd::kSetFreq; }));
+        };
+        const int before = setFrequencyCount();
+        const int warningsBefore = static_cast<int>(c.warnings.size());
+        c.backend.setSliceFrequency(0, 500'000'000.0);
+        check(waitFor([&] { return setFrequencyCount() > before; }),
+              "continuous model: a frequency outside its own declared range is "
+              "still sent unchanged — the gate did not leak");
+        check(static_cast<int>(c.warnings.size()) == warningsBefore,
+              "continuous model: and it raises no band warning");
     }
 
     // ---- A DELIBERATELY WRONG TYPED ADDRESS MUST STILL FAIL ----------------

--- a/tests/icom_meters_test.cpp
+++ b/tests/icom_meters_test.cpp
@@ -13,6 +13,7 @@
 #include <array>
 #include <cmath>
 #include <cstdio>
+#include <span>
 #include <string>
 #include <string_view>
 
@@ -295,6 +296,38 @@ static void testModelTable()
     check(modelForCivAddress(0x01) == nullptr,
           "an unrecognised address resolves to nothing — a normal outcome, not an error");
     check(!knownModels().empty(), "the table is populated");
+    if (ic9700) {
+        // ONE TABLE, TWO CONSUMERS. The tune guard and the published PA
+        // ceilings describe the same three RF decks, so they are read from the
+        // same rows — and this is the assertion that keeps them that way. A
+        // future edit that widened a range for power but not for tuning (or
+        // the reverse) used to be invisible; now it fails here.
+        const std::span<const IcomBand> bands = bandsFor(*ic9700);
+        check(bands.size() == 3, "the IC-9700 declares three RF decks");
+        for (const IcomBand& band : bands) {
+            check(supportsFrequency(*ic9700, band.lowHz)
+                      && supportsFrequency(*ic9700, band.highHz),
+                  "every declared IC-9700 power band is tunable end to end");
+            check(band.maxWatts > 0.0,
+                  "every declared IC-9700 band carries a PA rating");
+        }
+        // The other half of the same claim: a continuous model has no table,
+        // and that emptiness is what keeps its tune path untouched. #5116
+        // names both of these as non-goals.
+        for (const std::uint8_t addr : {std::uint8_t(0xA4), std::uint8_t(0xB6)}) {
+            const IcomModel* m = modelForCivAddress(addr);
+            check(m && bandsFor(*m).empty(),
+                  "a continuous model (IC-705, IC-7300MK2) declares no band "
+                  "table, so the IC-9700 gate cannot reach it");
+        }
+        check(nearestSupportedFrequency(*ic9700, 149'000'000ULL) == 148'000'000ULL,
+              "an IC-9700 drag above 2 m clamps to the 148 MHz edge");
+        check(nearestSupportedFrequency(*ic9700, 500'000'000ULL) == 450'000'000ULL,
+              "an IC-9700 drag in the upper gap clamps to the nearest edge");
+        check(nearestSupportedFrequency(*ic9700, 1'296'000'000ULL)
+                  == 1'296'000'000ULL,
+              "an in-band IC-9700 drag remains unchanged");
+    }
     // NO MODEL INHERITS THE 26 00 SHAPE BY ASSUMPTION.
     //
     // This started life as `m.verified || !m.hasVfoModeCommand`, which read the

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -98,6 +98,9 @@
 // with the automation bridge.
 
 #include "models/RadioModel.h"
+#include "IcomFakeRadio.h"
+#include "TestSettingsProfile.h"
+#include "core/AppSettings.h"
 #include "models/ModelCapabilities.h"
 #include "gui/DvkAvailabilityGate.h"
 #include "gui/VoiceModeGate.h"
@@ -105,6 +108,8 @@
 #include "core/backends/flex/FlexBackend.h"
 #include "core/backends/sim/SimBackend.h"
 #include "core/backends/icom/IcomCivBackend.h"
+#include "core/backends/icom/IcomCredentials.h"
+#include "core/backends/icom/IcomSettings.h"
 
 #include "TestEventLoop.h"
 
@@ -208,7 +213,9 @@ static RadioInfo simInfo()
 
 int main(int argc, char** argv)
 {
+    TestSettingsProfile profile(QStringLiteral("radio-capability-gating-test"));
     QCoreApplication app(argc, argv);
+    AppSettings::instance().load();
 
     // ---- Flex declares every gated capability ----------------------------
     //
@@ -224,6 +231,8 @@ int main(int argc, char** argv)
         check(caps.receiveOnlyModes.isEmpty(),
               "Flex declares no receive-only modes (it transmits in everything "
               "it demodulates), so the mode key guard is inert on it");
+        check(caps.txPowerBands.isEmpty(),
+              "Flex explicitly leaves per-band TX power limits empty");
         check(caps.hasDaxStreams,
               "Flex declares hasDaxStreams (DAX audio + DAX IQ)");
         check(caps.hasRadioSideDsp,
@@ -342,6 +351,8 @@ int main(int argc, char** argv)
         check(caps.receiveOnlyModes.isEmpty(),
               "HL2 declares no receive-only modes — it modulates on this host, "
               "so there is no mode it hears and cannot send");
+        check(caps.txPowerBands.isEmpty(),
+              "HL2 explicitly leaves per-band TX power limits empty");
         check(!caps.hasDaxStreams,
               "HL2 declares hasDaxStreams=false (one raw IQ feed, no stream plane)");
         check(!caps.hasExtendedDsp,
@@ -464,6 +475,52 @@ int main(int argc, char** argv)
         }
     }
 
+    // ---- Icom drives the model's actual per-band power consumer -----------
+    {
+        using AetherSDR::icom::test::FakeIc705;
+
+        FakeIc705 radio;
+        radio.setCivAddress(0xA2);
+        radio.setDeviceName("IC-9700");
+        IcomSettings::reset();
+        IcomSettings::setUsername(QStringLiteral("beer"));
+        IcomSettings::setPorts(radio.controlPort(), radio.serialPort(), radio.audioPort());
+        IcomSettings::setCivAddressAuto();
+        IcomCredentials::setSessionPassword(QStringLiteral("beerbeer"));
+
+        RadioInfo info;
+        info.family = QStringLiteral("icom");
+        info.model = QStringLiteral("IC-9700");
+        info.serial = QStringLiteral("capability-gating-ic9700");
+        info.address = QHostAddress::LocalHost;
+        info.port = radio.controlPort();
+        model.connectToRadio(info);
+        check(AetherTest::waitFor([&] { return model.isConnected(); }),
+              "IC-9700 model-level fixture connects through the real backend seam");
+
+        const RadioCapabilities caps = model.backendCapabilities();
+        check(caps.txPowerBands.size() == 3,
+              "Icom declares the three IC-9700 per-band TX power limits");
+
+        const auto expectPowerLimit = [&](std::uint64_t hz, int watts,
+                                          const char* description) {
+            radio.frontPanelFrequency(hz);
+            check(AetherTest::waitFor([&] {
+                      return model.transmitModel().maxPowerLevel() == watts;
+                  }), description);
+        };
+        expectPowerLimit(146'000'000ULL, 100,
+                         "RadioModel applies the IC-9700 2 m 100 W ceiling");
+        expectPowerLimit(432'000'000ULL, 75,
+                         "RadioModel applies the IC-9700 70 cm 75 W ceiling");
+        expectPowerLimit(1'296'000'000ULL, 10,
+                         "RadioModel applies the IC-9700 23 cm 10 W ceiling");
+
+        model.disconnectFromRadio();
+        IcomCredentials::setSessionPassword(QString{});
+        IcomSettings::reset();
+    }
+
     // ---- Sim declares none of them, and is genuinely CONNECTED -----------
     {
         QSignalSpy spy(&model, &RadioModel::capabilitiesChanged);
@@ -499,6 +556,8 @@ int main(int argc, char** argv)
 
         const RadioCapabilities caps = model.backendCapabilities();
         check(!caps.hasProfiles,   "Sim declares hasProfiles=false");
+        check(caps.txPowerBands.isEmpty(),
+              "Sim explicitly leaves per-band TX power limits empty");
         check(!caps.hasDaxStreams, "Sim declares hasDaxStreams=false");
         check(!caps.hasExtendedDsp, "Sim declares hasExtendedDsp=false");
         check(!caps.hasRadioSideDsp, "Sim declares hasRadioSideDsp=false");

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3798,6 +3798,7 @@ set(AETHER_SETTINGS_CONSUMERS
     log_manager_filter_rules_test
     bandplan_voice_labels_test
     vkamp_connection_test
+    radio_capability_gating_test
 )
 foreach(_settings_consumer IN LISTS AETHER_SETTINGS_CONSUMERS)
     if(TARGET ${_settings_consumer})


### PR DESCRIPTION
Closes #5116. Parent integration issue: #5099. Supersedes the per-band-power portion of #5100 and is intentionally coordinated with #5108.

@aethersdr-agent — review findings from commit `7021ebf8` are addressed in `3a68896e`.

## Summary

This fresh-from-`main` change supplies the remaining IC-9700 hardware facts not already owned by #5108: discontinuous tuning validation and per-band PA ceilings.

#5108 already implements Icom identity and declared bands, including the IC-9700's `2m`, `440`, and `23cm` declaration. After review identified the overlap, this PR removed its duplicate identity/band implementation. It no longer writes `RadioDelta::nickname`, cannot overwrite an operator nickname, and does not engage an empty `bandsRaw` optional for other Icom models.

The IC-9700's min/max tuning envelope contains two unsupported gaps. `supportsFrequency()` describes the three inclusive native ranges, and `setSliceFrequency()` rejects an IC-9700 gap request before CI-V encoding. Other Icom models retain their previous command path until their own discontinuous ranges are documented.

`RadioCapabilities` gains optional per-frequency TX-power ceilings:

- 144–148 MHz: 100 W
- 430–450 MHz: 75 W
- 1240–1300 MHz: 10 W

`RadioModel` applies the ceiling when the transmit slice crosses bands. Frequency deltas can arrive at tuning-drag cadence, but `TransmitModel::setMaxPowerLevel()` emits only when the numeric ceiling changes. Flex, HL2, and Sim explicitly declare an empty list and preserve existing behavior.

No `MainWindow` or widget source changes are included. Default modes, utility buttons, antenna presentation, session lifecycle, repeater access, meter units, controls, and polling are out of scope.

The required assignee claim was attempted, but GitHub rejected `w5jwp` with `ReplaceActorsForAssignable` because contributor accounts lack triage permission.

## Review findings addressed

- The Linux failure was `auto: exactly one broadcast`. The new test had cleared the fake radio's CI-V log before that existing assertion. It now compares frequency-write counts before/after rejection without clearing shared history.
- Removed nickname publication, preserving operator-owned state.
- Removed empty `bandsRaw` publication for other Icom models.
- Removed identity/band code and tests overlapping #5108.
- Split gap rejection into separate “no command” and “warning” checks.
- Kept required power/gap evidence in Linux-gated `icom_backend_test`; no new evidence relies on ungated `icom_family_test`.

## Constitution principle honored

Principle II — Radio-Authoritative Live State. Hardware limits are backend declarations consumed through normalized models; no GUI family check is introduced.

Principle VII — Boundary Input Validation. Invalid and IC-9700 gap-frequency requests are refused before transmission.

## Test plan

- [x] Local full build passes
- [x] Original behavior verified on W5JWP's IC-9700 during #5100 testing
- [x] `icom_backend_test` passes in isolation (22.58 s)
- [x] `icom_family_test`, `declared_bands_test`, `sim_backend_test`, and `radio_capability_gating_test` pass
- [x] First combined rerun hit the pre-existing intermittent UDP-fixture bind failure; immediate isolated Icom rerun passed
- [x] `git diff --check`
- [x] Engine-boundary strict check: zero blockers
- [x] Test-registration strict check

## Checklist

- [x] Signed commit; good ED25519 signature for `justin@w5jwp.radio`
- [x] No new `AppSettings` calls
- [x] Clean-room hardware facts
- [x] No meter UI path changed
- [x] Capability-map documentation updated; `CHANGELOG.md` untouched
- [x] No security-sensitive changes
