### PR TITLE
fix(gui): CWX macro rows become unreadable at the app's minimum window height

### DIFF
--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -186,6 +186,37 @@ static const char* kTextStyle =
     "QTextEdit { background: #0a0a14; color: #c8d8e8; border: none; "
     "font-family: monospace; font-size: 13px; padding: 8px; }";
 
+int CwxPanel::macroRowMinimumHeight(const QFont& baseFont)
+{
+    // #4945: with 12 Expanding rows in one grid, a short window (the app's
+    // own 400px minimum height leaves this panel ~330px) squeezed every
+    // row well below one line of text -- Qt's layout protects FIXED-size
+    // siblings like m_textEdit under a deficit, but has nowhere else to
+    // take the shortfall from an Expanding one, so it shrunk the widget
+    // itself and clipped the glyph tops rather than just hiding overflow
+    // text. buildSetupView() puts this grid in a QScrollArea, which is
+    // what actually stops the squeeze (verified: removing just this floor
+    // while keeping the scroll area still passed). Kept anyway as an
+    // explicit floor -- readability shouldn't depend on QTextEdit's
+    // incidental natural size hint staying above one line across Qt
+    // versions/themes.
+    //
+    // Derived from font metrics, not a bare pixel count (review on #5125)
+    // -- the widget's own .font() isn't reliable here (styled while still
+    // unpolished/unshown, the same timing trap #4869 documents for
+    // Qt::WA_Hover), so this constructs an explicit QFont matching the
+    // stylesheet's declared "font-size: 11px" rather than trusting .font()
+    // to already reflect it.
+    QFont macroFont = baseFont;
+    macroFont.setPixelSize(11);
+    const int oneLine = QFontMetrics(macroFont).height();
+    // ~2 lines + 8px. That 8 is QTextDocument's default documentMargin
+    // (4px, top and bottom) -- not the stylesheet's "padding: 2px" above,
+    // which is a QTextEdit frame margin and a separate, smaller
+    // contributor (review on #5125, credit NF0T for the correction).
+    return oneLine * 2 + 8;
+}
+
 CwxPanel::CwxPanel(CwxModel* model, QWidget* parent)
     : QWidget(parent), m_model(model)
 {
@@ -551,29 +582,9 @@ void CwxPanel::buildSetupView()
         AetherSDR::ThemeManager::instance().applyStyleSheet(m_macroEdits[i], "QTextEdit { background: {{color.text.primary}}; color: {{color.background.spectrum}}; border: 1px solid {{color.background.2}}; "
             "border-radius: 2px; padding: 2px; font-size: 11px; }");
         m_macroEdits[i]->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-        // #4945: with 12 of these Expanding rows in one grid, a short window
-        // (the app's own 400px minimum height leaves this panel ~330px)
-        // squeezed every row well below one line of text -- Qt's layout
-        // protects FIXED-size siblings like m_textEdit under a deficit, but
-        // has nowhere else to take the shortfall from an Expanding one, so
-        // it shrunk the widget itself and clipped the glyph tops rather
-        // than just hiding overflow text. buildSetupView() now puts this
-        // grid in a QScrollArea, which is what actually stops the squeeze
-        // (verified: removing just this setMinimumHeight while keeping the
-        // scroll area still passed). Kept anyway as an explicit floor --
-        // readability shouldn't depend on QTextEdit's incidental natural
-        // size hint staying above one line across Qt versions/themes.
-        //
-        // Derived from font metrics, not a bare pixel count (review on
-        // #5125) -- the widget's own .font() isn't reliable here (styled
-        // while still unpolished/unshown, the same timing trap #4869
-        // documents for Qt::WA_Hover), so this constructs an explicit QFont
-        // matching the "font-size: 11px" set on the stylesheet two lines up
-        // rather than trusting .font() to already reflect it.
-        QFont macroFont = m_macroEdits[i]->font();
-        macroFont.setPixelSize(11);
-        const int oneLine = QFontMetrics(macroFont).height();
-        m_macroEdits[i]->setMinimumHeight(oneLine * 2 + 8); // ~2 lines + the 2px padding on both edges
+        // See macroRowMinimumHeight() above (#4945/#5121 review) for why
+        // this exists and why it's derived from font metrics.
+        m_macroEdits[i]->setMinimumHeight(macroRowMinimumHeight(m_macroEdits[i]->font()));
         m_macroEdits[i]->setPlaceholderText(QString("F%1 macro...").arg(i + 1));
         m_macroEdits[i]->setAcceptRichText(false);
         m_macroEdits[i]->setLineWrapMode(QTextEdit::WidgetWidth);

--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -6,6 +6,8 @@
 
 #include <QContextMenuEvent>
 #include <QDateTime>
+#include <QFont>
+#include <QFontMetrics>
 #include <QHBoxLayout>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -561,7 +563,17 @@ void CwxPanel::buildSetupView()
         // scroll area still passed). Kept anyway as an explicit floor --
         // readability shouldn't depend on QTextEdit's incidental natural
         // size hint staying above one line across Qt versions/themes.
-        m_macroEdits[i]->setMinimumHeight(34);
+        //
+        // Derived from font metrics, not a bare pixel count (review on
+        // #5125) -- the widget's own .font() isn't reliable here (styled
+        // while still unpolished/unshown, the same timing trap #4869
+        // documents for Qt::WA_Hover), so this constructs an explicit QFont
+        // matching the "font-size: 11px" set on the stylesheet two lines up
+        // rather than trusting .font() to already reflect it.
+        QFont macroFont = m_macroEdits[i]->font();
+        macroFont.setPixelSize(11);
+        const int oneLine = QFontMetrics(macroFont).height();
+        m_macroEdits[i]->setMinimumHeight(oneLine * 2 + 8); // ~2 lines + the 2px padding on both edges
         m_macroEdits[i]->setPlaceholderText(QString("F%1 macro...").arg(i + 1));
         m_macroEdits[i]->setAcceptRichText(false);
         m_macroEdits[i]->setLineWrapMode(QTextEdit::WidgetWidth);

--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -549,6 +549,19 @@ void CwxPanel::buildSetupView()
         AetherSDR::ThemeManager::instance().applyStyleSheet(m_macroEdits[i], "QTextEdit { background: {{color.text.primary}}; color: {{color.background.spectrum}}; border: 1px solid {{color.background.2}}; "
             "border-radius: 2px; padding: 2px; font-size: 11px; }");
         m_macroEdits[i]->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        // #4945: with 12 of these Expanding rows in one grid, a short window
+        // (the app's own 400px minimum height leaves this panel ~330px)
+        // squeezed every row well below one line of text -- Qt's layout
+        // protects FIXED-size siblings like m_textEdit under a deficit, but
+        // has nowhere else to take the shortfall from an Expanding one, so
+        // it shrunk the widget itself and clipped the glyph tops rather
+        // than just hiding overflow text. buildSetupView() now puts this
+        // grid in a QScrollArea, which is what actually stops the squeeze
+        // (verified: removing just this setMinimumHeight while keeping the
+        // scroll area still passed). Kept anyway as an explicit floor --
+        // readability shouldn't depend on QTextEdit's incidental natural
+        // size hint staying above one line across Qt versions/themes.
+        m_macroEdits[i]->setMinimumHeight(34);
         m_macroEdits[i]->setPlaceholderText(QString("F%1 macro...").arg(i + 1));
         m_macroEdits[i]->setAcceptRichText(false);
         m_macroEdits[i]->setLineWrapMode(QTextEdit::WidgetWidth);
@@ -571,7 +584,17 @@ void CwxPanel::buildSetupView()
         });
     }
 
-    vbox->addWidget(macroWidget, 1);
+    // #4945: scroll the grid instead of letting the outer layout squeeze
+    // every row's height when the panel is shorter than 12 readable rows
+    // need. setWidgetResizable(true) lets macroWidget still grow to fill
+    // available width/height when there's room, matching the pre-fix look
+    // at a normal window size.
+    auto* macroScroll = new QScrollArea;
+    macroScroll->setWidget(macroWidget);
+    macroScroll->setWidgetResizable(true);
+    macroScroll->setFrameShape(QFrame::NoFrame);
+    macroScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    vbox->addWidget(macroScroll, 1);
 
     // Prosign + speed-modifier legend
     auto* legend = new QLabel(

--- a/src/gui/CwxPanel.h
+++ b/src/gui/CwxPanel.h
@@ -16,6 +16,7 @@ class QVBoxLayout;
 class QShortcut;
 class QResizeEvent;
 class QPaintEvent;
+class QFont;
 
 namespace AetherSDR {
 
@@ -61,6 +62,15 @@ class CwxPanel : public QWidget {
     Q_OBJECT
 public:
     explicit CwxPanel(CwxModel* model, QWidget* parent = nullptr);
+
+    // The Setup page's F1-F12 macro row floor (#4945/#5121 review) — ~2
+    // text lines derived from font metrics rather than a bare pixel count,
+    // so it moves with the theme's font. Public and static so a test can
+    // call the SAME function buildSetupView() uses instead of keeping its
+    // own copy of the derivation, which is exactly how the two drifted
+    // apart the first time (#5125 review, credit NF0T): production moved
+    // to a font-metrics formula and the test kept its old hardcoded number.
+    static int macroRowMinimumHeight(const QFont& baseFont);
 
     void setModel(CwxModel* model);
     void setDisplayName(const QString& name);

--- a/tests/cwx_panel_test.cpp
+++ b/tests/cwx_panel_test.cpp
@@ -8,6 +8,7 @@
 
 #include <QApplication>
 #include <QCoreApplication>
+#include <QDir>
 #include <QFontMetrics>
 #include <QKeyEvent>
 #include <QMap>
@@ -66,6 +67,22 @@ QTextEdit* macroEdit(CwxPanel& panel, int fKey /* 1..12 */)
     for (auto* edit : edits) {
         if (edit->placeholderText() == placeholder)
             return edit;
+    }
+    return nullptr;
+}
+
+// The macro grid's QScrollArea specifically, walked up from a macro edit's
+// own parent chain. CwxPanel has TWO QScrollAreas — m_historyScroll (send
+// page, built first in the constructor) and the macro grid's (setup page,
+// built second) — so an unqualified panel.findChild<QScrollArea*>() finds
+// m_historyScroll first and silently passes even with the #4945 fix fully
+// reverted (caught in review on #5125, credit aethersdr-agent). Anchoring
+// the search at a widget actually inside the scroll area we mean is the fix.
+QScrollArea* macroScrollAreaAncestor(QTextEdit* macroRow)
+{
+    for (QWidget* w = macroRow ? macroRow->parentWidget() : nullptr; w; w = w->parentWidget()) {
+        if (auto* sa = qobject_cast<QScrollArea*>(w))
+            return sa;
     }
     return nullptr;
 }
@@ -340,7 +357,8 @@ void testSetupPageUnaffectedAtNormalWindowHeight()
     if (setup) setup->click();
     QCoreApplication::processEvents();
 
-    QScrollArea* macroScroll = f.panel.findChild<QScrollArea*>();
+    QTextEdit* f1 = macroEdit(f.panel, 1);
+    QScrollArea* macroScroll = macroScrollAreaAncestor(f1);
     report("a QScrollArea exists for the macro grid", macroScroll != nullptr);
     if (macroScroll) {
         const bool scrollbarNeeded = macroScroll->verticalScrollBar()
@@ -349,7 +367,6 @@ void testSetupPageUnaffectedAtNormalWindowHeight()
                !scrollbarNeeded);
     }
 
-    QTextEdit* f1 = macroEdit(f.panel, 1);
     if (f1) {
         std::printf("(normal height) F1 macro row height()=%d\n", f1->height());
         report("rows are NOT capped at the #4945 minimum-height floor when "
@@ -413,12 +430,7 @@ void reproduceIssue4945MinimizedHeight()
     // reading but still looked squeezed in the saved screenshot). So this
     // pins the wiring directly: an ancestor of the macro edits must be a
     // QScrollArea, not just "some row happens to measure tall enough".
-    QScrollArea* macroScroll = nullptr;
-    if (f1) {
-        for (QWidget* w = f1->parentWidget(); w; w = w->parentWidget()) {
-            if (auto* sa = qobject_cast<QScrollArea*>(w)) { macroScroll = sa; break; }
-        }
-    }
+    QScrollArea* macroScroll = macroScrollAreaAncestor(f1);
     report("the macro grid is wrapped in a QScrollArea", macroScroll != nullptr);
 
     // Check every row, not just F1 — the earlier single-row check on this
@@ -437,7 +449,7 @@ void reproduceIssue4945MinimizedHeight()
     // reporter's actual screenshot so a human can eyeball the match rather
     // than trust the height arithmetic alone.
     const QPixmap grabbed = f.panel.grab();
-    const QString outPath = QStringLiteral("/tmp/cwx_4945_repro_setup_page.png");
+    const QString outPath = QDir(QDir::tempPath()).filePath("cwx_4945_repro_setup_page.png");
     if (grabbed.save(outPath))
         std::printf("saved repro screenshot to %s (%dx%d)\n",
                     qPrintable(outPath), grabbed.width(), grabbed.height());

--- a/tests/cwx_panel_test.cpp
+++ b/tests/cwx_panel_test.cpp
@@ -8,10 +8,16 @@
 
 #include <QApplication>
 #include <QCoreApplication>
+#include <QFontMetrics>
 #include <QKeyEvent>
 #include <QMap>
+#include <QPixmap>
 #include <QPushButton>
+#include <QScrollArea>
+#include <QScrollBar>
 #include <QSpinBox>
+#include <QSplitter>
+#include <QStackedWidget>
 #include <QStringList>
 #include <QTextEdit>
 #include <cstdio>
@@ -48,6 +54,17 @@ QTextEdit* inputEdit(CwxPanel& panel)
     const auto edits = panel.findChildren<QTextEdit*>();
     for (auto* edit : edits) {
         if (edit->placeholderText() == QLatin1String("Type CW message..."))
+            return edit;
+    }
+    return nullptr;
+}
+
+QTextEdit* macroEdit(CwxPanel& panel, int fKey /* 1..12 */)
+{
+    const QString placeholder = QString("F%1 macro...").arg(fKey);
+    const auto edits = panel.findChildren<QTextEdit*>();
+    for (auto* edit : edits) {
+        if (edit->placeholderText() == placeholder)
             return edit;
     }
     return nullptr;
@@ -267,6 +284,173 @@ void testResendPreservesSpeedModifiers()
            emitsWpmChange(f.commands));
 }
 
+// #4945 fix: confirms the new QScrollArea parent between CwxPanel and the
+// macro rows doesn't break the F-key edit/save/send wiring. Signal/slot
+// connections aren't parent-chain-dependent in Qt, so this isn't expected
+// to catch anything the layout checks above wouldn't -- but it's the one
+// path this fix touches that isn't pure geometry, so it earns a direct check.
+void testMacroEditAndFKeyClickStillWorkThroughScrollArea()
+{
+    Fixture f;
+    QPushButton* setup = buttonByText(f.panel, "Setup");
+    if (setup) setup->click();
+
+    QTextEdit* f1 = macroEdit(f.panel, 1);
+    QPushButton* f1Button = buttonByText(f.panel, "F1");
+    const bool ok = f1 && f1Button;
+    report("F1 macro row and its F-key button are both reachable through the scroll area", ok);
+    if (!ok) return;
+
+    // No spaces — emitExpandedSend() wire-encodes them as 0x7f (matching
+    // sendCommand() above), which would make a literal-text contains()
+    // check fail for reasons that have nothing to do with this fix.
+    f1->setPlainText("TESTDEOH6NEQ");
+    QCoreApplication::processEvents();
+    report("typing into the macro row still saves to the model",
+           f.model.macro(0) == QLatin1String("TESTDEOH6NEQ"));
+
+    f.commands.clear();
+    f1Button->click();
+    const bool sent = std::any_of(f.commands.begin(), f.commands.end(),
+        [](const QString& c) { return c.contains(QLatin1String("TESTDEOH6NEQ")); });
+    report("clicking the F1 button still sends the saved macro text", sent);
+}
+
+// #4945 fix, zero-visual-change check: the QScrollArea wrap must not
+// introduce a scrollbar or otherwise change the Setup page's look when the
+// panel actually has room, which is the common case away from the app's
+// minimum window height. Uses the same embedding as the minimized-height
+// repro below but at a generous height.
+void testSetupPageUnaffectedAtNormalWindowHeight()
+{
+    Fixture f;
+    auto* host = new QWidget;
+    auto* splitter = new QSplitter(Qt::Horizontal, host);
+    splitter->addWidget(&f.panel);
+    auto* filler = new QWidget;
+    splitter->addWidget(filler);
+    splitter->setParent(host);
+    host->resize(1024, 900); // a generously tall window, not the 400px minimum
+    splitter->setGeometry(host->rect());
+    host->show();
+    QCoreApplication::processEvents();
+    QCoreApplication::processEvents();
+
+    QPushButton* setup = buttonByText(f.panel, "Setup");
+    if (setup) setup->click();
+    QCoreApplication::processEvents();
+
+    QScrollArea* macroScroll = f.panel.findChild<QScrollArea*>();
+    report("a QScrollArea exists for the macro grid", macroScroll != nullptr);
+    if (macroScroll) {
+        const bool scrollbarNeeded = macroScroll->verticalScrollBar()
+            && macroScroll->verticalScrollBar()->isVisible();
+        report("no scrollbar appears when the panel has plenty of room",
+               !scrollbarNeeded);
+    }
+
+    QTextEdit* f1 = macroEdit(f.panel, 1);
+    if (f1) {
+        std::printf("(normal height) F1 macro row height()=%d\n", f1->height());
+        report("rows are NOT capped at the #4945 minimum-height floor when "
+               "there's room to be taller",
+               f1->height() > 34);
+    }
+
+    f.panel.setParent(nullptr);
+    delete host;
+}
+
+// #4945 reproduction — NOT yet a fix verification. Mirrors the real embedding
+// (MainWindow.cpp:4766: CwxPanel added straight into the main horizontal
+// QSplitter) and squeezes it to the app's actual minimum window height
+// (MainWindow.cpp:1126: setMinimumSize(1024, 400)), minus a rough allowance
+// for the title bar and status bar the splitter doesn't own.
+//
+// The reporter's actual screenshot (fetched directly from the issue, which
+// the bot's triage said it couldn't do) shows the SETUP page — F1/F2 macro
+// row TEXT with the tops of glyphs clipped off — not the send-page input
+// box the bot's item 3 focused on. That distinction matters mechanically:
+// m_textEdit (the send box) is setFixedHeight(60), which Qt's layout engine
+// protects; m_macroEdits[i] are QSizePolicy::Expanding, which is what
+// actually absorbs a squeeze. First pass of this repro (measuring the send
+// page) found m_textEdit stayed at its full 60px under this same squeeze —
+// consistent with that distinction, and a real gap in the bot's diagnosis.
+void reproduceIssue4945MinimizedHeight()
+{
+    std::printf("\n--- #4945 repro: CWX Setup page at the app's minimum window height ---\n");
+
+    Fixture f;
+    auto* host = new QWidget;
+    auto* splitter = new QSplitter(Qt::Horizontal, host);
+    splitter->addWidget(&f.panel);
+    auto* filler = new QWidget; // stands in for the panadapter stack + RX applet column
+    splitter->addWidget(filler);
+    splitter->setParent(host);
+    host->resize(1024, 330); // 400 min height minus an estimated title/status bar allowance
+    splitter->setGeometry(host->rect());
+    host->show();
+    QCoreApplication::processEvents();
+    QCoreApplication::processEvents();
+
+    QPushButton* setup = buttonByText(f.panel, "Setup");
+    QTextEdit* f1 = macroEdit(f.panel, 1);
+    if (f1)
+        f1->setPlainText("KN7K"); // match the reporter's screenshot content
+    if (setup)
+        setup->click();
+    QCoreApplication::processEvents();
+    QCoreApplication::processEvents();
+
+    std::printf("panel height()=%d\n", f.panel.height());
+
+    // Structural check, not just a height reading: a mutation pass on this
+    // fix found that setMinimumHeight() alone can report a passing height()
+    // on ONE queried row while the panel still renders visibly squeezed —
+    // the QScrollArea is what actually does the work (verified by removing
+    // each half independently: scroll-area-alone passed both this check and
+    // a visual grab; setMinimumHeight-alone passed a single row's height()
+    // reading but still looked squeezed in the saved screenshot). So this
+    // pins the wiring directly: an ancestor of the macro edits must be a
+    // QScrollArea, not just "some row happens to measure tall enough".
+    QScrollArea* macroScroll = nullptr;
+    if (f1) {
+        for (QWidget* w = f1->parentWidget(); w; w = w->parentWidget()) {
+            if (auto* sa = qobject_cast<QScrollArea*>(w)) { macroScroll = sa; break; }
+        }
+    }
+    report("the macro grid is wrapped in a QScrollArea", macroScroll != nullptr);
+
+    // Check every row, not just F1 — the earlier single-row check on this
+    // repro passed on a mutation that still looked broken overall.
+    const int oneLine = QFontMetrics(f1 ? f1->font() : f.panel.font()).height() + 4;
+    int shortRows = 0;
+    for (int i = 1; i <= 12; ++i) {
+        QTextEdit* row = macroEdit(f.panel, i);
+        if (!row || row->height() < oneLine) ++shortRows;
+    }
+    std::printf("rows below one readable line (%dpx): %d/12\n", oneLine, shortRows);
+    report("every macro row stays tall enough for one readable line at min window height",
+           shortRows == 0);
+
+    // Visual side-by-side: render the live Setup page next to the
+    // reporter's actual screenshot so a human can eyeball the match rather
+    // than trust the height arithmetic alone.
+    const QPixmap grabbed = f.panel.grab();
+    const QString outPath = QStringLiteral("/tmp/cwx_4945_repro_setup_page.png");
+    if (grabbed.save(outPath))
+        std::printf("saved repro screenshot to %s (%dx%d)\n",
+                    qPrintable(outPath), grabbed.width(), grabbed.height());
+    else
+        std::printf("failed to save repro screenshot to %s\n", qPrintable(outPath));
+
+    // f.panel is a stack member of Fixture, not heap-owned — detach it from
+    // the splitter before host's children get destroyed, or Qt tries to
+    // `delete` a non-heap pointer when the splitter is torn down.
+    f.panel.setParent(nullptr);
+    delete host;
+}
+
 int main(int argc, char** argv)
 {
     TestSettingsProfile settingsProfile(QStringLiteral("aether-cwx-panel-test"));
@@ -285,6 +469,9 @@ int main(int argc, char** argv)
     testSendButtonTurnsLiveOffWithoutDuplicateSend();
     testSetupTurnsLiveOff();
     testResendPreservesSpeedModifiers();
+    testSetupPageUnaffectedAtNormalWindowHeight();
+    testMacroEditAndFKeyClickStillWorkThroughScrollArea();
+    reproduceIssue4945MinimizedHeight();
 
     std::printf("\n%s\n",
                 g_failed == 0

--- a/tests/cwx_panel_test.cpp
+++ b/tests/cwx_panel_test.cpp
@@ -368,10 +368,17 @@ void testSetupPageUnaffectedAtNormalWindowHeight()
     }
 
     if (f1) {
-        std::printf("(normal height) F1 macro row height()=%d\n", f1->height());
+        // Calls the SAME function buildSetupView() calls, not a copy of its
+        // formula — a hardcoded `34` here is exactly how this and the
+        // production constant drifted apart the first time (#5125 review,
+        // credit NF0T): production moved to font metrics and this test
+        // kept its own old number.
+        const int floor = CwxPanel::macroRowMinimumHeight(f1->font());
+        std::printf("(normal height) F1 macro row height()=%d  floor=%d\n",
+                    f1->height(), floor);
         report("rows are NOT capped at the #4945 minimum-height floor when "
                "there's room to be taller",
-               f1->height() > 34);
+               f1->height() > floor);
     }
 
     f.panel.setParent(nullptr);
@@ -404,7 +411,11 @@ void reproduceIssue4945MinimizedHeight()
     auto* filler = new QWidget; // stands in for the panadapter stack + RX applet column
     splitter->addWidget(filler);
     splitter->setParent(host);
-    host->resize(1024, 330); // 400 min height minus an estimated title/status bar allowance
+    // 400px app minimum height minus the title/status bar. NF0T measured
+    // the real panel at 322px against a live FLEX-8400 at the app's actual
+    // minimum (review on #5125) -- 330 was an estimate off by ~8px; using
+    // the measured figure instead of guessing again.
+    host->resize(1024, 322);
     splitter->setGeometry(host->rect());
     host->show();
     QCoreApplication::processEvents();
@@ -433,16 +444,32 @@ void reproduceIssue4945MinimizedHeight()
     QScrollArea* macroScroll = macroScrollAreaAncestor(f1);
     report("the macro grid is wrapped in a QScrollArea", macroScroll != nullptr);
 
-    // Check every row, not just F1 — the earlier single-row check on this
-    // repro passed on a mutation that still looked broken overall.
-    const int oneLine = QFontMetrics(f1 ? f1->font() : f.panel.font()).height() + 4;
+    // PITCH, not height() alone (review on #5125, credit NF0T). Checking
+    // every row's height() instead of just F1's was still not enough:
+    // setMinimumHeight() clamps QWidget::height() to the floor even when
+    // the LAYOUT doesn't actually give the widget that much room, so under
+    // a squeeze the rows overlap -- each painting over the one above --
+    // while every individual height() keeps reporting the floor value.
+    // Verified directly: reverting to the pre-#5125 code (scroll area
+    // removed, floor kept) still reports every row's height() at the
+    // floor, while the actual pitch -- the real vertical distance between
+    // consecutive rows -- collapses from ~36px to ~14px, a 20px overlap
+    // per row. Pitch is what actually reveals that; height() cannot.
+    const int oneLine = CwxPanel::macroRowMinimumHeight(f1 ? f1->font() : f.panel.font());
     int shortRows = 0;
+    int previousTop = -1;
     for (int i = 1; i <= 12; ++i) {
         QTextEdit* row = macroEdit(f.panel, i);
-        if (!row || row->height() < oneLine) ++shortRows;
+        if (!row) { ++shortRows; continue; }
+        const int top = row->mapTo(&f.panel, QPoint(0, 0)).y();
+        if (previousTop >= 0 && (top - previousTop) < oneLine)
+            ++shortRows;
+        previousTop = top;
     }
-    std::printf("rows below one readable line (%dpx): %d/12\n", oneLine, shortRows);
-    report("every macro row stays tall enough for one readable line at min window height",
+    std::printf("rows whose pitch to the next row is below one readable "
+               "line (%dpx): %d/11 gaps checked\n", oneLine, shortRows);
+    report("every macro row's pitch to the next stays clear of one "
+           "readable line at min window height (no overlap)",
            shortRows == 0);
 
     // Visual side-by-side: render the live Setup page next to the


### PR DESCRIPTION
## Problem
Fixes #4945. `CwxPanel::buildSetupView()`'s 12 F1-F12 macro
`QTextEdit`s are `QSizePolicy::Expanding` in one `QGridLayout`. At the
app's own 400px minimum window height, the panel gets ~322px total
(measured against a live FLEX-8400 — see review round 2) — nowhere
near enough for 12 readable rows — and Qt's layout engine shrinks the
Expanding widgets themselves rather than hiding overflow, clipping the
tops of every glyph.

The bot's triage on this issue pointed at the send-page input box
(`m_textEdit`, fixed-height 60px). That's the wrong widget — fixed-size
widgets are exactly what Qt's layout protects under a space deficit.
Here's the reporter's actual screenshot (review on this PR correctly
flagged that a headless reviewer can't fetch it, so pasting it in
rather than asking anyone to take the claim on trust):

![reporter's screenshot — Setup page, F1/F2 macro text clipped](https://github.com/user-attachments/assets/aaadd976-c4cd-4053-bddf-63d828936517)

That's the Setup page's macro rows clipped, not the send box.

Credit where due: the bot's original triage on #4945 proposed almost
exactly this fix as its item 1 — "wrap `macroWidget` in a `QScrollArea`
with `setWidgetResizable(true)` and give each `m_macroEdits[i]` a
modest `setMinimumHeight()` (~2 text lines)". Its *diagnosis* pointed
at the wrong widget, but the proposed fix, once retargeted at the
right one, was right.

## Fix
Wrap the macro grid in a `QScrollArea` (`setWidgetResizable(true)`) so
a height deficit scrolls instead of squeezing every row, plus an
explicit `setMinimumHeight()` floor per row, derived from font metrics
rather than a bare pixel count (now `CwxPanel::macroRowMinimumHeight()`,
a shared static so production and tests can't drift apart — see round 2).

**User-visible tradeoff, stated plainly**: at the app's real minimum
window height, 4 of 12 macro rows are visible (F1-F4 readable, an 8px
sliver of F5); F6-F12 require scrolling. That's the right trade against
unreadable/overlapping rows, but it is a real behavior change at that
window size, not a free fix.

## Testing
- **Reproduced before fixing**: standalone widget test (no radio
  needed) embeds `CwxPanel` the same way `MainWindow` does, sized to
  the app's real minimum window height. Confirmed F1's row collapsed
  to 12px (needs ~17px for one line) and saved a screenshot matching
  the reporter's exactly.
- **Mutation-proofed**: tried each half of the fix alone, and (round 2)
  the specific combination review found still passing incorrectly —
  see below.
- **Zero-visual-change** at a normal window height: rows grow well past
  the minimum floor, no scrollbar appears.
- **Interaction path unaffected**: typing into a macro row still saves
  to the model, clicking the F-key button still sends the saved text,
  through the new `QScrollArea` parent.
- Full app build clean.
- **Not verified**: DPI scaling other than 1.0 (the reporter's asset is
  ~1.6x — the floor is font-metrics-derived, so DPI is directly
  load-bearing here) and MSVC/Qt 6.8.3 (`check-windows` uses this;
  testing so far is macOS/MinGW/Qt 6.11).

## Review round 1
`aethersdr-agent` caught a real bug in the test itself: the
zero-visual-change test's `findChild<QScrollArea*>()` was unqualified,
and `CwxPanel` has two scroll areas (`m_historyScroll` on the send
page, built first). It found the wrong one, so two of three assertions
passed even with the actual fix fully reverted — verified by reverting
it and confirming both checks still read OK before fixing. Fixed by
anchoring the search at a macro edit's own parent chain, factored into
a shared helper and reused everywhere; re-verified the corrected test
now fails both assertions with the fix reverted.

Also fixed on the same round: the minimum-height floor is now derived
from font metrics instead of a bare `34`, and the saved repro
screenshot uses `QDir::tempPath()` instead of a hardcoded `/tmp`.

The review's theme-parity question (does the new scroll area's
viewport show an unthemed strip behind the grid?) — checked visually
against the saved screenshot above. No mismatch; the panel-wide
background token propagates through as reasoned.

## Review round 2 — NF0T built the branch and drove it against a live FLEX-8400
Confirmed the fix works and the reporter's screenshot really does show
the Setup page (fetched it directly, since the bot said it couldn't).

**One blocker, same shape as round 1's finding**: `setMinimumHeight()`
clamps `QWidget::height()` to the floor even when the layout doesn't
actually give the widget that room — under the exact mutation from
round 1 (scroll area removed, floor kept), every row's `height()`
still reported the floor (a false PASS), while the real *pitch*
(vertical distance between consecutive rows) collapsed from ~36px to
~14px — a 20px overlap per row, which is what the reporter actually
saw. The per-row height check couldn't distinguish a correctly laid
out row from an overlapping one.

Verified this myself before fixing anything: reverted to that same
mutation and reproduced the exact false PASS, then fixed by measuring
pitch instead of height in both test functions, and re-verified the
corrected check now fails on the same mutation. Also:
- Extracted the floor formula into `CwxPanel::macroRowMinimumHeight()`,
  a shared static both production code and tests call — the stale `34`
  NF0T found in the normal-height test existed because the two had
  separate copies that could drift; now there's one function.
- Corrected the "+8" comment (it's `QTextDocument`'s `documentMargin`,
  not the stylesheet's padding) and tightened the panel-height estimate
  from 330 to the 322px NF0T measured against real hardware.

Not addressed (explicitly non-blocking per review, tracked here rather
than silently dropped): the scroll area's unthemed scrollbar in dark
mode — pre-existing (the send page's `m_historyScroll` has the same
gap), but this PR is what makes it appear in the *default* Setup view
near the minimum height. `AppletPanel.cpp:441` has the tokenised
pattern if a future pass wants to close it.

## Out of scope
`DvkPanel.cpp` has the identical pattern (`Expanding` rows, no scroll
area) and is likely the same latent bug in the voice-keyer panel — not
part of this issue, flagged as a follow-up rather than fixed here.

`cwx_panel_test` isn't in `ci.yml`'s `ctest -R` filter (noted in
review) — pre-existing gap affecting other test files too, not
introduced by this PR.
