### PR TITLE
fix(midi): report the profile Save outcome (#5077)

### DIFF
--- a/src/core/MidiSettings.cpp
+++ b/src/core/MidiSettings.cpp
@@ -485,7 +485,7 @@ QString MidiSettings::settingsFilePath() const
            + "/AetherSDR/midi.settings";
 }
 
-QString MidiSettings::profileDir() const
+QString MidiSettings::profileDir()
 {
     return QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)
            + "/AetherSDR/midi";
@@ -599,15 +599,19 @@ QVector<MidiBinding> MidiSettings::parseBindingsFromXml(const QString& filePath)
     return result;
 }
 
-void MidiSettings::writeBindingsToXml(const QString& filePath,
-                                       const QVector<MidiBinding>& bindings)
+bool MidiSettings::writeBindingsToXml(const QString& filePath,
+                                      const QVector<MidiBinding>& bindings)
 {
     QDir().mkpath(QFileInfo(filePath).absolutePath());
     QFile file(filePath);
-    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) return;
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) return false;
 
     QXmlStreamWriter xml(&file);
     writeProfileDocument(xml, bindings);
+    // close() flushes the stream: a write that fails after open() (full disk,
+    // revoked permission) surfaces here, not in the open() check. (#5077)
+    file.close();
+    return file.error() == QFileDevice::NoError;
 }
 
 // ── Profiles ────────────────────────────────────────────────────────────────
@@ -656,13 +660,13 @@ QStringList MidiSettings::availableProfiles() const
     return result;
 }
 
-void MidiSettings::saveProfile(const QString& name,
+bool MidiSettings::saveProfile(const QString& name,
                                 const QVector<MidiBinding>& bindings)
 {
     if (!isValidProfileName(name)) {
-        return;
+        return false;
     }
-    writeBindingsToXml(profileDir() + "/" + name + ".xml", bindings);
+    return writeBindingsToXml(profileDir() + "/" + name + ".xml", bindings);
 }
 
 QVector<MidiBinding> MidiSettings::loadProfile(const QString& name) const
@@ -793,11 +797,9 @@ MidiImportResult MidiSettings::importProfile(
     for (int n = 2; taken(unique); ++n)
         unique = name + QStringLiteral(" (%1)").arg(n);
 
-    saveProfile(unique, bindings);
-
-    // The write path returns void, so prove the store took it before
-    // reporting success.
-    if (loadProfile(unique).size() != bindings.size()) {
+    // The write reports failure itself (#5077); the read-back additionally
+    // proves the stored document carries every binding before reporting success.
+    if (!saveProfile(unique, bindings) || loadProfile(unique).size() != bindings.size()) {
         result.errors << QStringLiteral("Couldn't write the profile into %1.")
                              .arg(QDir::toNativeSeparators(profileDir()));
         result.importedCount = 0;

--- a/src/core/MidiSettings.cpp
+++ b/src/core/MidiSettings.cpp
@@ -612,11 +612,15 @@ bool MidiSettings::writeBindingsToXml(const QString& filePath,
     QSaveFile file(filePath);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) return false;
 
-    QXmlStreamWriter xml(&file);
-    writeProfileDocument(xml, bindings);
-    if (xml.hasError()) {
-        file.cancelWriting();
-        return false;
+    // Writer scoped so the document is complete before commit() — same shape
+    // as exportProfile(), so it doesn't rest on the writer's destructor order.
+    {
+        QXmlStreamWriter xml(&file);
+        writeProfileDocument(xml, bindings);
+        if (xml.hasError()) {
+            file.cancelWriting();
+            return false;
+        }
     }
     return file.commit();
 }
@@ -679,6 +683,14 @@ bool MidiSettings::saveProfile(const QString& name,
                                 const QVector<MidiBinding>& bindings)
 {
     if (!isValidProfileName(name)) {
+        return false;
+    }
+    // Refused for the same reason exportProfile() refuses it: an empty set
+    // serializes to a childless <MidiProfile/> that loadProfile() reports as
+    // empty-or-missing, so "saved" would be untrue of what comes back — and
+    // Clear All → Save would otherwise replace a profile with nothing.
+    // importProfile() already guards this before it gets here. (#5077)
+    if (bindings.isEmpty()) {
         return false;
     }
     return writeBindingsToXml(profileDir() + "/" + name + ".xml", bindings);

--- a/src/core/MidiSettings.cpp
+++ b/src/core/MidiSettings.cpp
@@ -603,15 +603,22 @@ bool MidiSettings::writeBindingsToXml(const QString& filePath,
                                       const QVector<MidiBinding>& bindings)
 {
     QDir().mkpath(QFileInfo(filePath).absolutePath());
-    QFile file(filePath);
+    // QSaveFile writes beside the target and renames over it on commit(), so
+    // a failure (unwritable store, full disk) leaves the previous profile
+    // intact instead of a truncated file — the outcome the caller then
+    // reports is true of the disk (Principle XIV). commit() flushes and
+    // returns false on a write error; hasError() covers a failure the stream
+    // writer saw earlier in the document. (#5077)
+    QSaveFile file(filePath);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) return false;
 
     QXmlStreamWriter xml(&file);
     writeProfileDocument(xml, bindings);
-    // close() flushes the stream: a write that fails after open() (full disk,
-    // revoked permission) surfaces here, not in the open() check. (#5077)
-    file.close();
-    return file.error() == QFileDevice::NoError;
+    if (xml.hasError()) {
+        file.cancelWriting();
+        return false;
+    }
+    return file.commit();
 }
 
 // ── Profiles ────────────────────────────────────────────────────────────────
@@ -658,6 +665,14 @@ QStringList MidiSettings::availableProfiles() const
         }
     }
     return result;
+}
+
+bool MidiSettings::profileExists(const QString& name)
+{
+    if (!isValidProfileName(name)) {
+        return false;
+    }
+    return QFile::exists(profileDir() + "/" + name + ".xml");
 }
 
 bool MidiSettings::saveProfile(const QString& name,

--- a/src/core/MidiSettings.h
+++ b/src/core/MidiSettings.h
@@ -72,6 +72,13 @@ public:
     // in a failed-write message. (#5077)
     static QString profileDir();
 
+    // Whether a profile of this name is already on disk — answered by the
+    // filesystem, not by a string compare, so it agrees with what saveProfile()
+    // is about to do on every platform (case-insensitive APFS/NTFS overwrite
+    // "foo" when asked for "Foo"; case-sensitive ext4 creates a second file).
+    // Refused names are never "existing". (#5077)
+    static bool profileExists(const QString& name);
+
     // Import a profile file into the store. Accepts the native <MidiProfile>
     // XML or a SmartSDR iOS/Mac ".map" (auto-detected by content). The store
     // name derives from the file name; an existing name gets a " (2)" style

--- a/src/core/MidiSettings.h
+++ b/src/core/MidiSettings.h
@@ -55,7 +55,9 @@ public:
 
     // Profile management (~/.config/AetherSDR/midi/<name>.xml)
     QStringList availableProfiles() const;
-    void saveProfile(const QString& name, const QVector<MidiBinding>& bindings);
+    // Returns false when the name is refused or the file could not be
+    // written, so a caller can report the outcome instead of assuming it. (#5077)
+    bool saveProfile(const QString& name, const QVector<MidiBinding>& bindings);
     QVector<MidiBinding> loadProfile(const QString& name) const;
     void deleteProfile(const QString& name);
 
@@ -65,6 +67,10 @@ public:
     // drop the file from the listing — and empty). Public so the GUI can
     // validate against the same rule it will be held to.
     static bool isValidProfileName(const QString& name);
+
+    // Where the named profiles live. Public so the GUI can name the location
+    // in a failed-write message. (#5077)
+    static QString profileDir();
 
     // Import a profile file into the store. Accepts the native <MidiProfile>
     // XML or a SmartSDR iOS/Mac ".map" (auto-detected by content). The store
@@ -84,11 +90,10 @@ public:
 private:
     MidiSettings() = default;
     QString settingsFilePath() const;
-    QString profileDir() const;
 
     static QVector<MidiBinding> parseBindingsFromXml(const QString& filePath);
-    static void writeBindingsToXml(const QString& filePath,
-                                    const QVector<MidiBinding>& bindings);
+    static bool writeBindingsToXml(const QString& filePath,
+                                   const QVector<MidiBinding>& bindings);
 
     QString m_lastDevice;
     bool    m_autoConnect{true};

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -330,8 +330,17 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
             // happened — an overwrite is otherwise invisible, because the list
             // refresh changes nothing. Asked of the filesystem, so it matches
             // what the write does on case-insensitive volumes too. (#5077)
-            const bool existed = MidiSettings::profileExists(name);
             const int count = m_manager->bindings().size();
+            if (count == 0) {
+                // The store refuses an empty set (it would replace the profile
+                // with nothing); say so here so the refusal isn't reported as
+                // an unwritable directory.
+                FramelessMessageBox::warning(
+                    this, QStringLiteral("Save Profile"),
+                    QStringLiteral("No bindings to save — add a binding first."));
+                return;
+            }
+            const bool existed = MidiSettings::profileExists(name);
             if (!MidiSettings::instance().saveProfile(name, m_manager->bindings())) {
                 FramelessMessageBox::warning(
                     this, QStringLiteral("Save Profile"),
@@ -351,6 +360,8 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
         btnRow->addWidget(saveProfileBtn);
 
         auto* loadProfileBtn = makeStyledButton("Load");
+        loadProfileBtn->setObjectName(QStringLiteral("midiProfileLoadButton"));
+        loadProfileBtn->setAccessibleName(QStringLiteral("Load MIDI profile"));
         loadProfileBtn->setToolTip(
             QStringLiteral("Apply the selected profile to the current bindings"));
         connect(loadProfileBtn, &QPushButton::clicked, this, [this] {

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -328,9 +328,9 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
             }
             // Sampled before the write so the result can say which success
             // happened — an overwrite is otherwise invisible, because the list
-            // refresh changes nothing. (#5077)
-            const bool existed =
-                MidiSettings::instance().availableProfiles().contains(name);
+            // refresh changes nothing. Asked of the filesystem, so it matches
+            // what the write does on case-insensitive volumes too. (#5077)
+            const bool existed = MidiSettings::profileExists(name);
             const int count = m_manager->bindings().size();
             if (!MidiSettings::instance().saveProfile(name, m_manager->bindings())) {
                 FramelessMessageBox::warning(

--- a/src/gui/MidiMappingDialog.cpp
+++ b/src/gui/MidiMappingDialog.cpp
@@ -292,6 +292,8 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
 
         // Profile management
         m_profileCombo = new QComboBox;
+        m_profileCombo->setObjectName(QStringLiteral("midiProfileCombo"));
+        m_profileCombo->setAccessibleName(QStringLiteral("MIDI profile name"));
         m_profileCombo->setStyleSheet(kComboStyle);
         m_profileCombo->setMinimumWidth(120);
         m_profileCombo->setEditable(true);
@@ -300,11 +302,20 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
         btnRow->addWidget(m_profileCombo);
 
         auto* saveProfileBtn = makeStyledButton("Save");
+        saveProfileBtn->setObjectName(QStringLiteral("midiProfileSaveButton"));
+        saveProfileBtn->setAccessibleName(QStringLiteral("Save MIDI profile"));
         saveProfileBtn->setToolTip(
             QStringLiteral("Save the current bindings as a named profile"));
+        // No name means no target: show that before the click rather than
+        // letting Save silently do nothing. (#5077)
+        saveProfileBtn->setEnabled(!m_profileCombo->currentText().trimmed().isEmpty());
+        connect(m_profileCombo, &QComboBox::currentTextChanged, saveProfileBtn,
+                [saveProfileBtn](const QString& text) {
+                    saveProfileBtn->setEnabled(!text.trimmed().isEmpty());
+                });
         connect(saveProfileBtn, &QPushButton::clicked, this, [this] {
             QString name = m_profileCombo->currentText().trimmed();
-            if (name.isEmpty()) return;
+            if (name.isEmpty()) return;  // unreachable while disabled; kept as the guard
             if (!MidiSettings::isValidProfileName(name)) {
                 // The store refuses these names silently; say why here so the
                 // operator isn't left with a Save that does nothing. (#4975)
@@ -315,8 +326,27 @@ MidiMappingDialog::MidiMappingDialog(MidiControlManager* manager, QWidget* paren
                         .arg(name));
                 return;
             }
-            MidiSettings::instance().saveProfile(name, m_manager->bindings());
+            // Sampled before the write so the result can say which success
+            // happened — an overwrite is otherwise invisible, because the list
+            // refresh changes nothing. (#5077)
+            const bool existed =
+                MidiSettings::instance().availableProfiles().contains(name);
+            const int count = m_manager->bindings().size();
+            if (!MidiSettings::instance().saveProfile(name, m_manager->bindings())) {
+                FramelessMessageBox::warning(
+                    this, QStringLiteral("Save Profile"),
+                    QStringLiteral("Couldn't write profile \"%1\" — check that %2 "
+                                   "is writable.")
+                        .arg(name, QDir::toNativeSeparators(MidiSettings::profileDir())));
+                return;
+            }
             refreshProfileList();
+            FramelessMessageBox::information(
+                this, QStringLiteral("Save Profile"),
+                QStringLiteral("%1 profile \"%2\" (%3 binding%4).")
+                    .arg(existed ? QStringLiteral("Overwrote") : QStringLiteral("Saved"),
+                         name, QString::number(count),
+                         count == 1 ? QString() : QStringLiteral("s")));
         });
         btnRow->addWidget(saveProfileBtn);
 

--- a/tests/midi_settings_test.cpp
+++ b/tests/midi_settings_test.cpp
@@ -757,6 +757,31 @@ int main(int argc, char** argv)
                      && rDotsName.profileName.startsWith("Imported profile"),
                  "import: a refused derived name falls back to the default");
 
+    // ── Profile store: the write reports its outcome (#5077) ────────────────
+
+    ok &= expect(settings.saveProfile("Outcome", saved),
+                 "profile store: a successful save returns true");
+    ok &= expect(settings.saveProfile("Outcome", saved),
+                 "profile store: overwriting an existing profile returns true");
+    ok &= expect(!settings.saveProfile("a/b", saved),
+                 "profile store: a refused name returns false");
+    settings.deleteProfile("Outcome");
+    // Block the store directory with a plain file so mkpath and open both
+    // fail: the failure must reach the caller instead of being swallowed.
+    QDir(appConfigDir + "/midi").removeRecursively();
+    {
+        QFile blocker(appConfigDir + "/midi");
+        if (blocker.open(QIODevice::WriteOnly)) {
+            blocker.write("not a directory");
+            blocker.close();
+        }
+    }
+    ok &= expect(!settings.saveProfile("Blocked", saved),
+                 "profile store: an unwritable store returns false");
+    ok &= expect(!QFile::exists(appConfigDir + "/midi/Blocked.xml"),
+                 "profile store: the failed save left no file");
+    QFile::remove(appConfigDir + "/midi");
+
     QFile::remove(configRoot + "/AetherSDR/midi.settings");
     QDir(configRoot + "/AetherSDR").removeRecursively();
 

--- a/tests/midi_settings_test.cpp
+++ b/tests/midi_settings_test.cpp
@@ -774,11 +774,21 @@ int main(int argc, char** argv)
     // does not — either way it must agree with the path the store writes.
     ok &= expect(MidiSettings::profileExists("Outcome"),
                  "profile store: a saved profile exists");
+    // Compared against what the store itself hands back for that spelling:
+    // on a case-insensitive volume "outcome" loads "Outcome", on a
+    // case-sensitive one it loads nothing — existence must agree either way.
     ok &= expect(MidiSettings::profileExists("outcome")
-                     == QFile::exists(appConfigDir + "/midi/outcome.xml"),
-                 "profile store: existence check agrees with the filesystem on case");
+                     == !settings.loadProfile("outcome").isEmpty(),
+                 "profile store: existence check agrees with loadProfile on case");
     ok &= expect(!MidiSettings::profileExists("a/b"),
                  "profile store: a refused name never exists");
+    // An empty set is refused (as exportProfile refuses it) and, refused,
+    // leaves the existing profile untouched — Clear All → Save must not
+    // replace a profile with nothing.
+    ok &= expect(!settings.saveProfile("Outcome", QVector<MidiBinding>{}),
+                 "profile store: saving an empty binding set returns false");
+    ok &= expect(settings.loadProfile("Outcome").size() == saved.size(),
+                 "profile store: the refused empty save left the profile intact");
     settings.deleteProfile("Outcome");
     ok &= expect(!MidiSettings::profileExists("Outcome"),
                  "profile store: a deleted profile no longer exists");

--- a/tests/midi_settings_test.cpp
+++ b/tests/midi_settings_test.cpp
@@ -9,6 +9,10 @@
 
 #include <iostream>
 
+#ifndef Q_OS_WIN
+#include <unistd.h>
+#endif
+
 using namespace AetherSDR;
 
 namespace {
@@ -765,7 +769,19 @@ int main(int argc, char** argv)
                  "profile store: overwriting an existing profile returns true");
     ok &= expect(!settings.saveProfile("a/b", saved),
                  "profile store: a refused name returns false");
+    // Existence is the filesystem's answer: on a case-insensitive volume
+    // "outcome" names the same file as "Outcome", on a case-sensitive one it
+    // does not — either way it must agree with the path the store writes.
+    ok &= expect(MidiSettings::profileExists("Outcome"),
+                 "profile store: a saved profile exists");
+    ok &= expect(MidiSettings::profileExists("outcome")
+                     == QFile::exists(appConfigDir + "/midi/outcome.xml"),
+                 "profile store: existence check agrees with the filesystem on case");
+    ok &= expect(!MidiSettings::profileExists("a/b"),
+                 "profile store: a refused name never exists");
     settings.deleteProfile("Outcome");
+    ok &= expect(!MidiSettings::profileExists("Outcome"),
+                 "profile store: a deleted profile no longer exists");
     // Block the store directory with a plain file so mkpath and open both
     // fail: the failure must reach the caller instead of being swallowed.
     QDir(appConfigDir + "/midi").removeRecursively();
@@ -778,9 +794,30 @@ int main(int argc, char** argv)
     }
     ok &= expect(!settings.saveProfile("Blocked", saved),
                  "profile store: an unwritable store returns false");
-    ok &= expect(!QFile::exists(appConfigDir + "/midi/Blocked.xml"),
-                 "profile store: the failed save left no file");
     QFile::remove(appConfigDir + "/midi");
+    // A failed overwrite leaves the previous profile intact: write one, make
+    // the store read-only, try to overwrite it, and read the original back.
+#ifndef Q_OS_WIN
+    // Directory permissions do not bind root (CI containers may run as root)
+    // and are not honoured the same way on Windows, so this arm is POSIX
+    // non-root only; the bool contract itself is covered above on every OS.
+    if (::geteuid() != 0) {
+    ok &= expect(settings.saveProfile("Keep", saved), "profile store: original written");
+    QFile::setPermissions(appConfigDir + "/midi",
+                          QFileDevice::ReadOwner | QFileDevice::ExeOwner);
+    QVector<MidiBinding> bigger = saved;
+    bigger.append(saved.first());
+    const bool overwriteFailed = !settings.saveProfile("Keep", bigger);
+    QFile::setPermissions(appConfigDir + "/midi",
+                          QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner);
+    ok &= expect(overwriteFailed, "profile store: overwrite into a read-only store returns false");
+    ok &= expect(settings.loadProfile("Keep").size() == saved.size(),
+                 "profile store: the failed overwrite left the original profile intact");
+    settings.deleteProfile("Keep");
+    } else {
+        std::cout << "[SKIP] profile store: read-only store arm (running as root)\n";
+    }
+#endif
 
     QFile::remove(configRoot + "/AetherSDR/midi.settings");
     QDir(configRoot + "/AetherSDR").removeRecursively();


### PR DESCRIPTION
## Summary

Fixes #5077

The MIDI mapping dialog's profile **Save** was fire-and-forget: an empty name
returned silently above the #4975 name guard, a failed write was
indistinguishable from success because `MidiSettings::saveProfile` and
`writeBindingsToXml` were `void` and swallowed the `open()` failure
(`src/core/MidiSettings.cpp:602-610, 659-666` on main `8301fb37`), and an
overwrite produced no visible change because `refreshProfileList()` is a
no-op when the name already exists.

Root cause: the write path had no return value, so no caller could report an
outcome, and the dialog never tried.

What changed:

- `MidiSettings::writeBindingsToXml` and `saveProfile` return `bool`. The write
  goes through `QSaveFile`: a failed write (unwritable store, full disk) leaves
  the previous profile intact instead of a truncated file (Principle XIV), and
  the result also covers a `QXmlStreamWriter` error earlier in the document —
  not only the open-failure case.
- `profileDir()` is a public `static` accessor so the failure message can name
  the location; `profileExists(name)` asks the filesystem whether the target is
  already there, so Saved vs Overwrote agrees with what the write does on
  case-insensitive volumes (APFS/NTFS overwrite `foo` for `Foo`) and on
  case-sensitive ones (ext4 creates a second file).
- `importProfile` checks the write result ahead of its existing read-back (the
  read-back stays: it proves the stored document carries every binding).
- The dialog disables **Save** while the name is empty (the no-target case is
  visible before the click, as #4464 did for the Profile Manager), reports a
  failed write with a `FramelessMessageBox::warning`, and confirms
  `Saved`/`Overwrote profile "<name>" (N bindings)` with
  `FramelessMessageBox::information` — modal: file operations in this codebase
  report their outcome modally (Memories → Export, `MemoryDialog.cpp:939`; this
  dialog's own Export, `:484`), the call #5077 reserved and @jensenpat made.
  Whether the name existed is sampled from the filesystem before the write so
  the message can say which success happened.
- An empty binding set is refused: `saveProfile` returns `false` (as
  `exportProfile` already refuses it) and the dialog says "No bindings to save"
  before calling the store.
- `m_profileCombo`, the Save button and the Load button gain `objectName`/`accessibleName`
  (`midiProfileCombo`, `midiProfileSaveButton`) — the ride-along from the
  #5077 comment, same convention #4790 applied to `midiParamCombo`. This is
  what let the automation bridge drive the proof below.
- `tests/midi_settings_test.cpp` covers the new `bool`: success, overwrite,
  refused name, unwritable store (store path blocked by a plain file → `false`);
  existence answers that agree with the disk on case; and, on POSIX non-root, a
  failed overwrite into a read-only store that leaves the original profile intact.
  That last arm is the one that discriminates `QSaveFile` from the `QFile` it
  replaced, and it runs on no CI job: the Linux job is the only one that executes
  this test and it runs as root, so the `geteuid()` guard skips it — it is
  evidenced on a developer machine, not by CI.

Out of scope: `deleteProfile`'s identical `void` shape and #4974/#4975 name
handling (both named by the issue), and the export button (already reports via
`exportProfile`).

## Constitution principle honored

Principle XIV — Persist Atomically: the profile XML is a persisted artifact
that `loadProfile` and `availableProfiles` read back, and it is now written in
full and atomically replaced, so the outcome the store reports is true of the
disk.

## Test plan

- [x] Local build passes (`cmake --build build`) — clean configure + full
      build on macOS (Intel, Qt 6.8.3), 2947/2947, no warnings in the touched
      files
- [x] Behavior verified on a real radio if applicable — **n/a**, local file
      I/O + dialog only; no radio involved
- [x] Existing tests pass (CI) — `midi_settings_test` 109/109 locally
      (98 existing + 11 new); CI runs on this PR
- [x] Reproduction steps documented if user-reported bug — #5077 steps 2–4;
      each is one row of the proof below

### Proof — agent automation bridge, macOS, build `3fbe02d5` (Help→About verified)

Driven with the `aethersdr-automation` MCP server; no radio connected. Captured
at the first commit; the follow-up commit changes how "existed" is answered and
how the file is written, not the three message texts — those paths are covered
by the test additions above.

| #5077 path | Bridge action | Reading on this build |
|---|---|---|
| Empty name (step 4) | `dump_tree midiProfile` with combo `value: ""` | `midiProfileSaveButton enabled: false` |
| Name entered | `invoke setCurrentText midiProfileCombo "fb5077-proof"` → `dump_tree` | `enabled: true` |
| First save (step 2) | `invoke click midiProfileSaveButton` → `dump_tree qt_msgbox_label` | `Saved profile "fb5077-proof" (2 bindings).` — file on disk 238 B, 2 `<Binding>` |
| Same name again (step 3) | `invoke click` → `qt_msgbox_label` | `Overwrote profile "fb5077-proof" (2 bindings).` |
| Failed write | store dir `chmod 555` + target file `444` → `invoke click` → `qt_msgbox_label` | `Couldn't write profile "fb5077-proof" — check that <config>/AetherSDR/midi is writable.` |

On main the same clicks produce no dialog in any of the three cases (there is
no message-box call in the handler, `MidiMappingDialog.cpp:305-320`).

Screenshots (`grab_widget`) — About dialog showing `(3fbe02d5)`; the dialog with Save
greyed out on an empty name; the Saved / Overwrote / Couldn't-write boxes:

![About dialog at 3fbe02d5](https://raw.githubusercontent.com/skerker/AetherSDR/fix-5077-assets/.pr-assets/aethersdr-5077-about-3fbe02d5-2026-08-21.png)
![Save disabled while the name is empty](https://raw.githubusercontent.com/skerker/AetherSDR/fix-5077-assets/.pr-assets/aethersdr-5077-dialog-save-disabled-empty-2026-08-21.png)
![Saved](https://raw.githubusercontent.com/skerker/AetherSDR/fix-5077-assets/.pr-assets/aethersdr-5077-save-saved-2026-08-21.png)
![Overwrote](https://raw.githubusercontent.com/skerker/AetherSDR/fix-5077-assets/.pr-assets/aethersdr-5077-save-overwrote-2026-08-21.png)
![Couldn't write](https://raw.githubusercontent.com/skerker/AetherSDR/fix-5077-assets/.pr-assets/aethersdr-5077-save-failed-2026-08-21.png)

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — **n/a**, no settings touched
- [x] Code is clean-room
- [x] All meter UI uses `MeterSmoother` — **n/a**, no meter UI
- [x] Documentation updated if user-visible behavior changed — **n/a**, no
      `docs/` page describes the MIDI profile row (grep: none); behavior is
      described in the Summary
- [x] Security-sensitive changes reference a GHSA — **n/a**

— authored by agent (Claude Code) on behalf of @skerker


