### PR TITLE
fix(cw): stop echoing iambic keyer edges back into the sidetone gate (#4976)

### DIFF
--- a/src/core/CwSidetoneGenerator.cpp
+++ b/src/core/CwSidetoneGenerator.cpp
@@ -73,9 +73,9 @@ void CwSidetoneGenerator::setKeyDown(bool down,
                                      std::chrono::steady_clock::time_point when) noexcept
 {
     // Several threads legitimately produce edges — the iambic and CWX
-    // workers call in directly, and the GUI thread echoes every
-    // radio-bound edge via RadioModel::cwKeyDownChanged — so slot write
-    // and head publish must be exclusive among producers.  A short spin
+    // workers call in directly, and the GUI thread delivers straight-key
+    // sources via RadioModel::cwKeyDownChanged — so slot write and head
+    // publish must be exclusive among producers.  A short spin
     // is cheaper than any blocking primitive at tens of edges per
     // second; process() only consumes the tail and never takes this
     // lock, so the audio thread stays wait-free.  The stamp is resolved
@@ -86,17 +86,10 @@ void CwSidetoneGenerator::setKeyDown(bool down,
     // wall-clock edge from another producer could sit ahead of it in the
     // queue with a later stamp.  The clamp preserves the schedule's exact
     // spacing whenever edges from one producer arrive back-to-back, which
-    // is the #4890 case that matters.
-    // Bound worth knowing: the GUI echo (RadioModel::cwKeyDownChanged →
-    // MainWindow's connect → setCwKeyDown(down)) queues a wall-clock stamp
-    // after each scheduled edge, so the floor sits at wall clock going into
-    // the next one.  Scheduled stamps therefore hold only while that echo
-    // round-trip stays shorter than one element (measured ~2 ms against
-    // 48 ms at 25 WPM).  Should an echo ever land after the following grid
-    // instant, that edge clamps to the echo's stamp and the sidetone
-    // reverts to wall-clock rhythm — the pre-#4890 behaviour, not
-    // corruption.  Removing the coupling means suppressing the echo for
-    // producers that already drove the gate directly.
+    // is the #4890 case that matters.  Keyer edges reach here exactly once
+    // since #4976 (the GUI cwKeyDownChanged echo no longer fires for
+    // RadioModel::sendCwKeyEdge), so the floor between two scheduled
+    // edges is the previous scheduled edge, not a wall-clock echo.
     // Worst case among producers: the GUI thread descheduled inside the
     // section leaves a keying worker spinning until the holder resumes.
     // The section is ~20 instructions, so the window is vanishingly
@@ -151,8 +144,9 @@ void CwSidetoneGenerator::reset() noexcept
     // would be a data race.  Retaining it is also correct: queue ordering
     // is enforced by the max() clamp in setKeyDown(), not by steady_clock's
     // monotonicity — a scheduled instant lies a few ms in the past, so an
-    // edge CAN carry a stamp below a floor a wall-clock echo raised (see
-    // the echo note in setKeyDown()).  The cost of the retained floor is
+    // edge CAN carry a stamp below a floor that a wall-clock edge from
+    // another producer (straight key, stop/abort key-up) raised.  The cost
+    // of the retained floor is
     // bounded and one-sided: the first edge queued after this drain clamps
     // up to it rather than to its own scheduled instant, then the grid
     // re-establishes itself within an element or two.

--- a/src/core/CwSidetoneGenerator.cpp
+++ b/src/core/CwSidetoneGenerator.cpp
@@ -75,21 +75,28 @@ void CwSidetoneGenerator::setKeyDown(bool down,
     // Several threads legitimately produce edges — the iambic and CWX
     // workers call in directly, and the GUI thread delivers straight-key
     // sources via RadioModel::cwKeyDownChanged — so slot write and head
-    // publish must be exclusive among producers.  A short spin
-    // is cheaper than any blocking primitive at tens of edges per
-    // second; process() only consumes the tail and never takes this
-    // lock, so the audio thread stays wait-free.  The stamp is resolved
-    // inside the lock so queue order equals timestamp order — process()
-    // relies on that for its edges-are-time-ordered early-out.  A caller-
-    // supplied scheduled instant lies slightly in the past (wake latency),
-    // so it is clamped against the newest queued stamp: without this, a
+    // publish must be exclusive among producers.  A short spin is cheaper
+    // than any blocking primitive at tens of edges per second; process()
+    // only consumes the tail and never takes this lock, so the audio
+    // thread stays wait-free.  The stamp is resolved inside the lock so
+    // queue order equals timestamp order — process() relies on that for
+    // its edges-are-time-ordered early-out.  A caller-supplied scheduled
+    // instant lies slightly in the past (wake latency), so it is clamped
+    // against the newest queued stamp: without this, a
     // wall-clock edge from another producer could sit ahead of it in the
     // queue with a later stamp.  The clamp preserves the schedule's exact
     // spacing whenever edges from one producer arrive back-to-back, which
-    // is the #4890 case that matters.  Keyer edges reach here exactly once
-    // since #4976 (the GUI cwKeyDownChanged echo no longer fires for
-    // RadioModel::sendCwKeyEdge), so the floor between two scheduled
-    // edges is the previous scheduled edge, not a wall-clock echo.
+    // is the #4890 case that matters.  Since #4976 a keyer element reaches
+    // here exactly once — RadioModel::sendCwKeyEdge no longer echoes back
+    // through the GUI cwKeyDownChanged handler — so back-to-back keyer
+    // edges clamp against the previous *scheduled* edge rather than against
+    // that echo's wall-clock stamp.  The floor itself is still one value
+    // shared by every producer: a wall-clock edge from another one (a CWX
+    // macro draining through the 1-arg setCwKeyDown, a straight key, a
+    // stop/abort key-up) can still raise it past a keyer element's
+    // scheduled instant and clamp that element up to wall clock.  Removing
+    // the echo narrowed the coupling to genuinely concurrent producers; it
+    // did not make the floor per-producer.
     // Worst case among producers: the GUI thread descheduled inside the
     // section leaves a keying worker spinning until the holder resumes.
     // The section is ~20 instructions, so the window is vanishingly
@@ -146,10 +153,10 @@ void CwSidetoneGenerator::reset() noexcept
     // monotonicity — a scheduled instant lies a few ms in the past, so an
     // edge CAN carry a stamp below a floor that a wall-clock edge from
     // another producer (straight key, stop/abort key-up) raised.  The cost
-    // of the retained floor is
-    // bounded and one-sided: the first edge queued after this drain clamps
-    // up to it rather than to its own scheduled instant, then the grid
-    // re-establishes itself within an element or two.
+    // of the retained floor is bounded and one-sided: the first edge queued
+    // after this drain clamps up to it rather than to its own scheduled
+    // instant, then the grid re-establishes itself within an element or
+    // two.
 }
 
 void CwSidetoneGenerator::setSampleRateHz(int hz) noexcept

--- a/src/core/CwSidetoneGenerator.h
+++ b/src/core/CwSidetoneGenerator.h
@@ -39,8 +39,9 @@ public:
     int  sampleRateHz() const noexcept { return m_sampleRateHz; }
 
     // Key state — called from any thread, and concurrently from several
-    // in practice (iambic worker, CWX worker, GUI-thread handlers of
-    // RadioModel::cwKeyDownChanged); producers serialize on a short
+    // in practice (iambic worker, CWX worker, the GUI-thread handler of
+    // RadioModel::cwKeyDownChanged for straight-key sources); producers
+    // serialize on a short
     // spinlock the audio thread never touches.  Each call is timestamped
     // inside the lock and queued; process() applies the transition at
     // the exact sample offset the timestamp maps to, so key edges are no
@@ -103,10 +104,11 @@ private:
     // One timestamped key transition from setKeyDown().  The queue is a
     // fixed-size MPSC ring: producers = the keying threads (head,
     // serialized by m_edgeLock), consumer = the audio thread (tail).
-    // Size 64 is ~16 elements of headroom: 2 slots per element (down + up),
-    // doubled again because every element arrives twice (worker-direct plus
-    // the GUI cwKeyDownChanged echo).  Still far beyond what fits in one
-    // audio block even at 60 WPM.
+    // Size 64 is ~32 elements of headroom at 2 slots per element (down +
+    // up).  It was sized for every element arriving twice (worker-direct
+    // plus a GUI cwKeyDownChanged echo); #4976 removed that echo for keyer
+    // edges, so the doubling is now pure headroom — still far beyond what
+    // fits in one audio block even at 60 WPM.
     struct KeyEdge {
         std::chrono::steady_clock::time_point t;
         bool down;

--- a/src/core/CwSidetoneGenerator.h
+++ b/src/core/CwSidetoneGenerator.h
@@ -41,14 +41,13 @@ public:
     // Key state — called from any thread, and concurrently from several
     // in practice (iambic worker, CWX worker, the GUI-thread handler of
     // RadioModel::cwKeyDownChanged for straight-key sources); producers
-    // serialize on a short
-    // spinlock the audio thread never touches.  Each call is timestamped
-    // inside the lock and queued; process() applies the transition at
-    // the exact sample offset the timestamp maps to, so key edges are no
-    // longer quantized to audio block boundaries (#4809 — up to one
-    // whole block of jitter per edge, and far more on the push-model
-    // QAudioSink sink).  On queue overflow the last-known state still
-    // lands at the next block start (the pre-#4809 behavior) via
+    // serialize on a short spinlock the audio thread never touches.  Each
+    // call is timestamped inside the lock and queued; process() applies
+    // the transition at the exact sample offset the timestamp maps to, so
+    // key edges are no longer quantized to audio block boundaries (#4809
+    // — up to one whole block of jitter per edge, and far more on the
+    // push-model QAudioSink sink).  On queue overflow the last-known state
+    // still lands at the next block start (the pre-#4809 behavior) via
     // m_keyDown.
     // `when` (#4890): producers with an exact element schedule (the iambic
     // keyer's grid) pass the edge's scheduled instant so the rendered

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1427,10 +1427,15 @@ MainWindow::MainWindow(QWidget* parent)
         }
     });
 
-    // Local CW sidetone — every key source (serial, MIDI, TCI, CWX, HID)
-    // funnels through RadioModel::sendCwKey/sendCwPaddle, which emits
-    // cwKeyDownChanged.  Auto-queued connection so the audio thread sees
-    // the state change via atomic without any blocking.
+    // Local CW sidetone catch-all for the key sources that funnel through
+    // RadioModel::sendCwKey/sendCwPaddle — TCI (TciProtocol), MIDI/HID/serial
+    // straight keying (MainWindow_Controllers), Space-PTT and the straight
+    // key (MainWindow) — which emit cwKeyDownChanged.  Deliberately NOT
+    // sendCwKeyEdge: the iambic keyer drives the gate itself with the
+    // element's scheduled instant, so an echo here would re-time it (#4976).
+    // The CWX local keyer likewise drives the gate directly and never
+    // routes through RadioModel.  Auto-queued connection so the audio
+    // thread sees the state change via atomic without any blocking.
     connect(&m_radioModel, &RadioModel::cwKeyDownChanged,
             this, [this](bool down) {
         if (m_audio)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1429,13 +1429,16 @@ MainWindow::MainWindow(QWidget* parent)
 
     // Local CW sidetone catch-all for the key sources that funnel through
     // RadioModel::sendCwKey/sendCwPaddle — TCI (TciProtocol), MIDI/HID/serial
-    // straight keying (MainWindow_Controllers), Space-PTT and the straight
-    // key (MainWindow) — which emit cwKeyDownChanged.  Deliberately NOT
-    // sendCwKeyEdge: the iambic keyer drives the gate itself with the
+    // straight keying (MainWindow_Controllers), and the keyboard straight
+    // key / paddle actions (MainWindow) — which emit cwKeyDownChanged.
+    // (Space-PTT is not one of them: PTT hold asserts MOX via
+    // TransmitModel::requestPttOn and produces no CW key edge.)  Deliberately
+    // NOT sendCwKeyEdge: the iambic keyer drives the gate itself with the
     // element's scheduled instant, so an echo here would re-time it (#4976).
     // The CWX local keyer likewise drives the gate directly and never
-    // routes through RadioModel.  Auto-queued connection so the audio
-    // thread sees the state change via atomic without any blocking.
+    // routes through RadioModel.  Both connection endpoints live on the GUI
+    // thread; the cross-thread handoff to the audio thread happens inside
+    // setCwKeyDown via CwSidetoneGenerator's producer-locked edge queue.
     connect(&m_radioModel, &RadioModel::cwKeyDownChanged,
             this, [this](bool down) {
         if (m_audio)

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -4334,10 +4334,16 @@ void RadioModel::sendCwKeyEdge(bool down, const QString& debugSource,
         sendNetCwCommand(QString("cw key %1").arg(down ? 1 : 0),
                          debugSource, debugTraceId, debugSourceMs, scheduledAt);
     }
-    const bool prev = m_cwKeyActive;
+    // Deliberately no cwKeyDownChanged here.  This is the local iambic
+    // keyer's path, and its producer already drove the sidetone gate at the
+    // element's own scheduled instant (MainWindow_Session.cpp, #4890/#4942).
+    // Echoing would queue a second, wall-clock-stamped edge for the same
+    // element, raising CwSidetoneGenerator's monotonic floor to wake time
+    // and re-timing the following element to the GUI thread's rhythm — or,
+    // when the queued hop lands after the element ended, re-keying the gate
+    // for a spurious blip (#4976).  m_cwKeyActive is still tracked: it feeds
+    // the TX-ownership interlock alongside m_cwxActive.
     m_cwKeyActive = down;
-    if (prev != down)
-        emit cwKeyDownChanged(down);
 }
 
 // ── NetCW stream — VITA-49 UDP delivery with redundant sends ────────────────

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -777,6 +777,13 @@ public:
     // reconstruction input carries the intended rhythm rather than
     // worker-wake plus queued-hop jitter.  Default (epoch zero) = no
     // schedule; send-time stamping is unchanged.
+    // Note the deliberate asymmetry with sendCwKey: this entry point does
+    // NOT emit cwKeyDownChanged.  It is the local iambic keyer's path, and
+    // that producer already drove the sidetone gate at the element's
+    // scheduled instant, so publishing here would queue a second,
+    // wall-clock-stamped edge for the same element (#4976).  m_cwKeyActive
+    // is tracked on both paths either way — it feeds the TX-ownership
+    // interlock.
     void sendCwKeyEdge(bool down, const QString& debugSource = {},
                        quint64 debugTraceId = 0, quint64 debugSourceMs = 0,
                        std::chrono::steady_clock::time_point scheduledAt = {});
@@ -961,8 +968,15 @@ signals:
     // Emitted whenever the backend instance is (re)built — including the
     // connect-time swap between FlexBackend and SimBackend (RFC #4288). The old
     // m_backend is already destroyed and m_backend now points at the new one.
-    // Emitted whenever the local CW key transitions on/off — funnel for
-    // serial CTS/DSR, MIDI Gate, TCI key, CWX, and HID encoder sources.
+    // Emitted whenever a straight-key-shaped local CW source transitions
+    // on/off — the funnel for the serial CW-key line, the TCI `keyer:trx`
+    // command, and the MIDI Gate / keyboard / HID straight-key actions.
+    // All of them reach it through RadioModel::sendCwKey.
+    // NOT the local iambic keyer: sendCwKeyEdge deliberately does not
+    // publish here (#4976), because that producer already drove the
+    // sidetone gate at the element's own scheduled instant.  NOT CWX
+    // either — CwxLocalKeyer calls AudioEngine::setCwKeyDown directly and
+    // never touches RadioModel.
     // Wired to AudioEngine's CwSidetoneGenerator for low-latency local
     // sidetone independent of the radio's own DAX-fed sidetone.
     void cwKeyDownChanged(bool down);

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -479,11 +479,34 @@ int main(int argc, char** argv)
                   "an accepted iambic up does not publish a key-active echo");
             // Straight-key sources still publish: a following sendCwKey down
             // emits even though the keyer edges touched the shared state.
+            // Note this holds because the two keyer edges above are
+            // BALANCED, leaving m_cwKeyActive false again — see the
+            // unbalanced case pinned below.
             model.sendCwKey(true);
             check(keyEdgeSpy.count() == 1
                       && keyEdgeSpy.last().value(0).toBool(),
-                  "a straight-key down after keyer edges still publishes");
+                  "a straight-key down after balanced keyer edges publishes");
             model.sendCwKey(false);
+
+            // Known limitation, pinned deliberately.  NOT a regression:
+            // `main` behaves identically, because sendCwKeyEdge set the
+            // same latch before #4976.  m_cwKeyActive is one bool shared by
+            // both entry points, so an UNBALANCED keyer edge leaves it set
+            // and the next straight-key down of the same polarity publishes
+            // nothing — the radio is keyed while the sidetone gate never
+            // hears the edge.  The interleave is reachable because
+            // straight-key sources are not gated on the iambic keyer
+            // running (TciProtocol's keyer:trx handler,
+            // MainWindow::setCwStraightKeyState) while paddle sources are.
+            // Giving sendCwKeyEdge its own edge-tracking bool is out of
+            // scope for #4976; this assertion is what flips when that
+            // decoupling lands.
+            const int publishedBeforeLatch = keyEdgeSpy.count();
+            model.sendCwKeyEdge(true);   // latches m_cwKeyActive, no echo
+            model.sendCwKey(true);       // prev == true, so nothing emits
+            check(keyEdgeSpy.count() == publishedBeforeLatch,
+                  "KNOWN LATCH: a straight-key down after an unbalanced "
+                  "keyer edge publishes nothing");
         }
     }
 

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -469,9 +469,21 @@ int main(int argc, char** argv)
             check(forwardedSpy.count() == 3
                       && forwardedSpy.last().value(0).toBool(),
                   "the same uninhibited down crosses the backend seam");
-            check(keyEdgeSpy.count() == 1,
-                  "an accepted down publishes one key-active edge");
+            // The iambic keyer drives the sidetone gate itself with the
+            // element's scheduled instant; sendCwKeyEdge must not echo it
+            // through cwKeyDownChanged (#4976).
+            check(keyEdgeSpy.count() == 0,
+                  "an accepted iambic down does not publish a key-active echo");
             model.sendCwKeyEdge(false);
+            check(keyEdgeSpy.count() == 0,
+                  "an accepted iambic up does not publish a key-active echo");
+            // Straight-key sources still publish: a following sendCwKey down
+            // emits even though the keyer edges touched the shared state.
+            model.sendCwKey(true);
+            check(keyEdgeSpy.count() == 1
+                      && keyEdgeSpy.last().value(0).toBool(),
+                  "a straight-key down after keyer edges still publishes");
+            model.sendCwKey(false);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #4976

Every element edge from the local iambic keyer reached the sidetone gate twice:
once from the keyer worker with the element's scheduled instant
(`MainWindow_Session.cpp`, #4890/#4942), then again through
`RadioModel::sendCwKeyEdge()` → `emit cwKeyDownChanged` → the `MainWindow`
catch-all connection → `setCwKeyDown(down)` with a wall-clock stamp. Because
`CwSidetoneGenerator::setKeyDown()` clamps every stamp against a monotonic floor,
the echo raised that floor to wake time going into the next element; and a queued
hop slower than one element re-keyed the gate after the element had ended (the
#4934 micro-blip). The signal has exactly one consumer (that connection) and
`sendCwKeyEdge()` exactly one caller (the keyer wiring).

What changed:

- `RadioModel::sendCwKeyEdge()` no longer emits `cwKeyDownChanged`; it still
  records `m_cwKeyActive` for the TX-ownership interlock. `sendCwKey()` is
  untouched, so TCI, MIDI/HID/serial straight keying and the keyboard straight
  key / paddle actions still reach the gate through the catch-all. (An earlier
  revision of this body also listed Space-PTT here — wrongly: PTT hold asserts
  MOX via `TransmitModel::requestPttOn` and produces no CW key edge; corrected
  along with the `MainWindow.cpp` comment in `7d6b41bc`.) The `cw key N` /
  netcw traffic is unchanged.
- Comments corrected where they described the echo as load-bearing:
  `MainWindow.cpp` (catch-all scope), `CwSidetoneGenerator.h` (queue sizing —
  the ×2 is now headroom, ring size unchanged), `CwSidetoneGenerator.cpp`
  (echo-bound paragraph removed; the floor rationale scoped to back-to-back
  keyer edges, with the cross-producer caveat kept — `m_lastQueuedStamp` is one
  floor shared by every producer, so a CWX macro through the 1-arg
  `setCwKeyDown`, a straight key, or a stop/abort key-up can still raise it past
  a keyer element's scheduled instant).
- `RadioModel.h`: the `cwKeyDownChanged` declaration named CWX as a source, but
  CWX never routed through this signal at all — `CwxLocalKeyer` drives
  `AudioEngine::setCwKeyDown` directly and never touches `RadioModel` — and it
  omitted the iambic exclusion this PR creates. It now names only what reaches
  it through `sendCwKey` and states both exclusions. `sendCwKeyEdge`'s own doc
  records the deliberate no-publish asymmetry against `sendCwKey`.
- `tests/radio_capability_gating_test.cpp`: the assertion that an accepted
  `sendCwKeyEdge(true)` publishes one `cwKeyDownChanged` is inverted to zero for
  both edges. Two straight-key checks sit beside it and hold different things.
  After **balanced** keyer edges a following `sendCwKey(true)` still publishes,
  because `m_cwKeyActive` has returned to false — that is all the earlier
  revision of this check established, and the body previously overstated it.
  After an **unbalanced** keyer edge it publishes nothing, because both entry
  points share that one latch; that case is now pinned explicitly as a known
  limitation. It is not a regression — `main` behaves identically, since
  `sendCwKeyEdge` set the same latch before — and it is live-reachable, because
  straight-key sources are not gated on the keyer running while paddle sources
  are. Giving `sendCwKeyEdge` its own edge-tracking bool is out of scope here;
  that assertion is what flips when the decoupling lands.

## Constitution principle honored

Principle XI — the change is demonstrated by a regression test on the exact
seam (`cwKeyDownChanged` spy), not asserted.

## Test plan

- [x] Local build passes — clean build from a wiped build directory, macOS (Intel, Qt 6.8.3), exit 0; configure records `Build SHA: 606c09ff`, matching the head commit
- [x] Behavior verified on a real radio if applicable — **yes**: operator
      dummy-load keyer bench, Linux + FLEX-8400 (ANT1 → dummy load), on a
      combined build with #5129 — readings in the bench proof section below.
      The behavior change itself is at the signal seam and covered by the test.
- [x] Existing tests pass — full local suite at `606c09ff`: **313/315**, with `radio_capability_gating_test` passing. The two failures, `hl2_state_restore_test` and `phone_tx_filter_numeric_entry_test`, are pre-existing: both fail deterministically (3/3 each) on a separate clean build of `8301fb37`, this branch's merge-base with `main`, in files this diff does not touch. **n/a for CI, stated plainly:** `radio_capability_gating_test` appears in no `ctest -R` filter in `ci.yml`, so CI compiles it but never executes it — the demonstration rests on the local run and the dummy-load bench below, not on a required check
- [x] Reproduction steps documented — source-level issue ([STATIC]); the test is the repro

### Proof

`radio_capability_gating_test` at `606c09ff`: `radio_capability_gating_test: all checks passed`, exit 0 (the suite prints per-check output only on failure). The four #4976 checks are `an accepted iambic down does not publish a key-active echo`, `an accepted iambic up does not publish a key-active echo`, `a straight-key down after balanced keyer edges publishes`, and `KNOWN LATCH: a straight-key down after an unbalanced keyer edge publishes nothing`.

`git grep cwKeyDownChanged` at `606c09ff`: one `emit` (`RadioModel.cpp:4293`, in
`sendCwKey`), one `connect` (`MainWindow.cpp:1442`), one spy (the test) — no
other consumer.

### Proof — Linux dummy-load keyer bench, combined build `bd20052d` (2026-08-24)

Bench build = current `main` (`73738c89`) + this PR's `01465bb5` + #5129's `9b5f447a`
(clean merge — disjoint paths), Help→About verified before any reading. FLEX-8400,
ANT1 into a dummy load, CW, iambic mode B, 25 WPM, sidetone ON; HaliKey paddle over
MIDI (subscription verified via `aconnect` before keying). Sidetone sink row:
`backend="PortAudio" device="default" rate=48000Hz path=pull fallback=no`.

**Iambic sidetone with the echo removed — 74 hand-keyed K's** (from the
`schedMs=` key-edge trace; letters reconstructed from the same trace):

| class | n | min | max | median | mean | SD |
|---|---|---|---|---|---|---|
| dits | 74 | 48 | 48 | 48.0 | 48.00 | 0.00 |
| dahs | 148 | 144 | 144 | 144.0 | 144.00 | 0.00 |
| intra-element space | 148 | 48 | 72 | 48.0 | 49.43 | 3.96 |

dah/dit ratio 3.000; 25.0 WPM vs set 25; 74/74 letters reconstruct as `-.-`;
the app's TX CW decoder read back an unbroken run of K's. Operator by ear:
tone audible, rhythm even, no micro-blips or doubled dits (the #4934 symptom).
Every key edge produced exactly one `cw key 1/0` radio command.

**Catch-all risk surface — three non-keyer sources, each keyed the radio and
produced audible sidetone** (log `source=` on the `cw key` schedule line):
`midi:cwdit` with the radio's iambic OFF (straight-key passthrough,
`localIambic=false`), `keyboard:cwdit`/`keyboard:cwdah`, and `keyboard:cwkey`
(Trigger straight key). Zero WRN/ERR in every keying window of the session log.

The complete unedited session log, About screenshot, and decoder readbacks are
in the evidence zip attached to this PR.

[aethersdr-pr5128-5129-keyer-bench-linux-2026-08-24.zip](https://github.com/user-attachments/files/31384279/aethersdr-pr5128-5129-keyer-bench-linux-2026-08-24.zip)

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls — **n/a**
- [x] Code is clean-room
- [x] All meter UI uses `MeterSmoother` — **n/a**
- [x] Documentation updated if user-visible behavior changed — **n/a**, no user-visible
      control changes; sidetone timing behavior described above
- [x] Security-sensitive changes reference a GHSA — **n/a**

— authored by agent (Claude Code) on behalf of @skerker



