### PR TITLE
feat(rtty): sensitivity slider on the RTTY decoder bar (#5028)

### DIFF
--- a/docs/rtty-decoder-implementation.md
+++ b/docs/rtty-decoder-implementation.md
@@ -46,10 +46,13 @@ Appears automatically when the active slice enters RTTY or DIGL mode; hides on e
 | Shift | 45, 50, 75, 100, **170**, 182, 200, 240, 425, 450, 500, 850 Hz |
 | Baud | **45.45**, 50, 75, 100, 110, 150, 300 |
 | REV | Space above mark (LSB / inverted polarity) |
+| Sens | 0–100 display squelch (#5028): drops decoded characters below a confidence threshold (0 = show everything, the default; ~38 filters what the stats bar calls UNLOCK; 100 = near-certain only). Mapping in `src/gui/RttyDecoderSensitivity.h` |
 
 Stats bar updates ~2×/second: `M:xx% S:xx% SNR:xxdB  LOCKED/UNLOCK`
 
-All settings persisted to AppSettings (flat key names — see bug #4 below).
+Mark/Shift/Baud/REV persist to AppSettings as flat key names (grandfathered —
+see bug #4 below); Sens persists as one nested JSON object under the root key
+`RttyDecoder` per Constitution Principle V.
 
 ---
 

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -516,7 +516,12 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     m_rttySensSlider->setObjectName(QStringLiteral("rttySensSlider"));
     m_rttySensSlider->setAccessibleName(QStringLiteral("RTTY decoder sensitivity"));
     m_rttySensSlider->setToolTip(QStringLiteral(
-        "Drop low-confidence characters (0 = show everything, 100 = only near-certain copy)"));
+        "Squelch for the decoded text: drops characters the decoder is not confident\n"
+        "about, so noise between transmissions stops filling the pane with gibberish.\n"
+        "0 (default) shows every decoded character — exactly the behavior before this\n"
+        "control existed. Higher values drop more; ~38 filters what the stats bar\n"
+        "calls UNLOCK; 100 keeps only near-certain copy. Affects display only —\n"
+        "nothing is retuned and no audio changes."));
     m_rttySensSlider->setRange(0, 100);
     const int savedRttySens = readRttySensitivity();
     m_rttySensSlider->setValue(savedRttySens);

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -1022,7 +1022,9 @@ void PanadapterApplet::appendRttyText(const QString& text, float confidence)
     // the CR/LF handling on purpose: Baudot CR and LF are ordinary codepoints
     // that noise hits as often as any other, and a dropped character must
     // not still spray blank lines down the pane. (#5028)
-    if (confidence < m_rttyConfThreshold) return;
+    if (confidence < m_rttyConfThreshold) {
+        return;
+    }
 
     // CR is a no-op in a wrapped text view; LF becomes a line break.
     // Standard RTTY sends CR+LF pairs — discarding CR and converting LF

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -1,4 +1,7 @@
 #include "PanadapterApplet.h"
+#include "RttyDecoderSensitivity.h"
+#include <QJsonDocument>
+#include <QJsonObject>
 #include "CallsignCard.h"
 #ifdef AETHER_ASR_ENABLED
 #include "CopyAssistPanel.h"
@@ -33,6 +36,35 @@
 #include <algorithm>
 
 namespace AetherSDR {
+
+namespace {
+
+// RTTY decoder sensitivity lives as one field of a single nested object under
+// the root key "RttyDecoder" (Constitution Principle V: new configuration is
+// never another loose flat key).  The pane's older Mark/Shift/Baud/Reverse
+// keys stay grandfathered as flat keys until they are migrated as a unit.
+const QString kRttyDecoderRootKey = QStringLiteral("RttyDecoder");
+const QString kRttySensitivityField = QStringLiteral("sensitivity");
+
+int readRttySensitivity()
+{
+    const QJsonObject o = QJsonDocument::fromJson(
+        AppSettings::instance().value(kRttyDecoderRootKey).toString().toUtf8()).object();
+    return qBound(0, o.value(kRttySensitivityField).toInt(kRttySensitivityDefault), 100);
+}
+
+void writeRttySensitivity(int v)
+{
+    auto& s = AppSettings::instance();
+    QJsonObject o = QJsonDocument::fromJson(
+        s.value(kRttyDecoderRootKey).toString().toUtf8()).object();
+    o.insert(kRttySensitivityField, v);
+    s.setValue(kRttyDecoderRootKey,
+               QString::fromUtf8(QJsonDocument(o).toJson(QJsonDocument::Compact)));
+    s.save();
+}
+
+} // namespace
 
 PanadapterApplet::PanadapterApplet(QWidget* parent)
     : QWidget(parent)
@@ -475,6 +507,27 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     });
     rttyBar->addWidget(m_rttyRevBtn);
 
+    // Sensitivity slider — drops low-confidence characters so noise between
+    // transmissions is not rendered (#5028).  Mirrors the CW pane's control.
+    auto* rttySensLabel = new QLabel("Sens:");
+    AetherSDR::ThemeManager::instance().applyStyleSheet(rttySensLabel, "QLabel { color: {{color.text.label}}; font-size: 9px; background: transparent; }");
+    rttyBar->addWidget(rttySensLabel);
+    m_rttySensSlider = new GuardedSlider(Qt::Horizontal);
+    m_rttySensSlider->setObjectName(QStringLiteral("rttySensSlider"));
+    m_rttySensSlider->setAccessibleName(QStringLiteral("RTTY decoder sensitivity"));
+    m_rttySensSlider->setToolTip(QStringLiteral(
+        "Drop low-confidence characters (0 = show everything, 100 = only near-certain copy)"));
+    m_rttySensSlider->setRange(0, 100);
+    const int savedRttySens = readRttySensitivity();
+    m_rttySensSlider->setValue(savedRttySens);
+    m_rttySensSlider->setFixedWidth(60);
+    applyPrimarySliderStyle(m_rttySensSlider);
+    m_rttyConfThreshold = rttyConfThresholdFor(savedRttySens);
+    connectSliderSetting(m_rttySensSlider,
+        [this](int v) { m_rttyConfThreshold = rttyConfThresholdFor(v); },
+        [](int v) { writeRttySensitivity(v); });
+    rttyBar->addWidget(m_rttySensSlider);
+
     // Stats
     m_rttyStatsLabel = new QLabel;
     m_rttyStatsLabel->setTextFormat(Qt::RichText);
@@ -520,6 +573,8 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
 
     // ── Text area ─────────────────────────────────────────────────────────
     m_rttyText = new QTextEdit;
+    m_rttyText->setObjectName(QStringLiteral("rttyDecodeText"));
+    m_rttyText->setAccessibleName(QStringLiteral("RTTY decoded text"));
     m_rttyText->setReadOnly(true);
     m_rttyText->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     AetherSDR::ThemeManager::instance().applyStyleSheet(m_rttyText,
@@ -958,6 +1013,12 @@ bool PanadapterApplet::rttyReverse() const
 
 void PanadapterApplet::appendRttyText(const QString& text, float confidence)
 {
+    // Filter by sensitivity threshold — drop low-confidence decodes.  Above
+    // the CR/LF handling on purpose: Baudot CR and LF are ordinary codepoints
+    // that noise hits as often as any other, and a dropped character must
+    // not still spray blank lines down the pane. (#5028)
+    if (confidence < m_rttyConfThreshold) return;
+
     // CR is a no-op in a wrapped text view; LF becomes a line break.
     // Standard RTTY sends CR+LF pairs — discarding CR and converting LF
     // to <br> produces exactly one new line per pair.

--- a/src/gui/PanadapterApplet.h
+++ b/src/gui/PanadapterApplet.h
@@ -197,7 +197,7 @@ private:
     QComboBox*    m_rttyBaudCombo{nullptr};
     QPushButton*  m_rttyRevBtn{nullptr};
     QSlider*      m_rttySensSlider{nullptr};
-    float         m_rttyConfThreshold{0.671f};   // slider default 38 ≈ the decoder's 3 dB lock point
+    float         m_rttyConfThreshold{0.5f};   // slider default 0 = the confidence floor: never drops
 };
 
 } // namespace AetherSDR

--- a/src/gui/PanadapterApplet.h
+++ b/src/gui/PanadapterApplet.h
@@ -90,6 +90,10 @@ public:
     int   rttyShiftHz() const;
     float rttyBaud()    const;
     bool  rttyReverse() const;
+    // Per-character confidence below which appendRttyText() drops the
+    // character (#5028).  Confidence is max(mark,space)/(mark+space), so it
+    // lives in [0.5, 1.0]; the slider maps 0..100 onto 0.50..0.95.
+    float rttyConfThreshold() const { return m_rttyConfThreshold; }
 
     QSize sizeHint() const override { return {800, 316}; }
 
@@ -192,6 +196,8 @@ private:
     QComboBox*    m_rttyShiftCombo{nullptr};
     QComboBox*    m_rttyBaudCombo{nullptr};
     QPushButton*  m_rttyRevBtn{nullptr};
+    QSlider*      m_rttySensSlider{nullptr};
+    float         m_rttyConfThreshold{0.671f};   // slider default 38 ≈ the decoder's 3 dB lock point
 };
 
 } // namespace AetherSDR

--- a/src/gui/RttyDecoderSensitivity.h
+++ b/src/gui/RttyDecoderSensitivity.h
@@ -1,0 +1,25 @@
+#pragma once
+
+// RTTY decoder sensitivity: the slider→threshold mapping behind the RTTY
+// pane's "Sens:" control (#5028).  Pure and header-only so the mapping is
+// pinned by a test without a widget.
+//
+// RttyDecoder reports per-character confidence as max(mark,space)/(mark+space),
+// which can never fall below 0.5 (it is the larger of two envelopes over their
+// sum) and is 1.0 for a clean tone.  The CW pane's cost runs the other way
+// ([0,1], lower = better), so its mapping cannot be copied verbatim: a slider
+// at 0 must still mean "show everything".  0..100 maps onto 0.50..0.95, and
+// the default of 38 lands the threshold at ~0.67 — the decoder's own 3 dB
+// "locked" point (snrDb == 10*log10(c/(1-c))), so out-of-the-box filtering
+// agrees with what the stats bar already calls UNLOCK.
+namespace AetherSDR {
+
+constexpr int kRttySensitivityDefault = 38;
+
+constexpr float rttyConfThresholdFor(int sens)
+{
+    const int clamped = sens < 0 ? 0 : (sens > 100 ? 100 : sens);
+    return 0.5f + (static_cast<float>(clamped) / 100.0f) * 0.45f;
+}
+
+} // namespace AetherSDR

--- a/src/gui/RttyDecoderSensitivity.h
+++ b/src/gui/RttyDecoderSensitivity.h
@@ -8,13 +8,17 @@
 // which can never fall below 0.5 (it is the larger of two envelopes over their
 // sum) and is 1.0 for a clean tone.  The CW pane's cost runs the other way
 // ([0,1], lower = better), so its mapping cannot be copied verbatim: a slider
-// at 0 must still mean "show everything".  0..100 maps onto 0.50..0.95, and
-// the default of 38 lands the threshold at ~0.67 — the decoder's own 3 dB
-// "locked" point (snrDb == 10*log10(c/(1-c))), so out-of-the-box filtering
-// agrees with what the stats bar already calls UNLOCK.
+// at 0 must still mean "show everything".  0..100 maps onto 0.50..0.95.
+//
+// The default is 0: threshold 0.50 is the confidence floor, so `confidence <
+// threshold` can never fire and out-of-the-box behavior is provably identical
+// to the pane before this control existed — filtering is strictly opt-in.
+// A useful starting value when noise floods the pane is 38, which lands the
+// threshold at ~0.67 — the decoder's own 3 dB "locked" point
+// (snrDb == 10*log10(c/(1-c))), i.e. filter what the stats bar calls UNLOCK.
 namespace AetherSDR {
 
-constexpr int kRttySensitivityDefault = 38;
+constexpr int kRttySensitivityDefault = 0;
 
 constexpr float rttyConfThresholdFor(int sens)
 {

--- a/tests/rtty_decoder_sensitivity_test.cpp
+++ b/tests/rtty_decoder_sensitivity_test.cpp
@@ -28,7 +28,9 @@ int main()
         const bool ok = std::fabs(got - expected) < 0.0005f;
         std::printf("[%s] sens=%3d -> %.4f (expected %.4f) %s\n",
                     ok ? " OK " : "FAIL", sens, got, expected, why);
-        if (!ok) ++failures;
+        if (!ok) {
+            ++failures;
+        }
     };
     expectNear(0,   0.500f, "floor (and the default): every character passes");
     expectNear(38,  0.671f, "documented starting value: the decoder's ~3 dB lock point (snr = 10*log10(c/(1-c)))");

--- a/tests/rtty_decoder_sensitivity_test.cpp
+++ b/tests/rtty_decoder_sensitivity_test.cpp
@@ -1,0 +1,43 @@
+// RTTY decoder sensitivity mapping (#5028): slider 0..100 -> confidence
+// threshold 0.50..0.95 on RttyDecoder's own [0.5, 1.0] confidence scale.
+// Pure and constexpr, so the load-bearing rows are also checked at compile time.
+
+#include "gui/RttyDecoderSensitivity.h"
+
+#include <cmath>
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static_assert(rttyConfThresholdFor(0) == 0.5f,
+              "0 = show everything: the threshold is the confidence floor");
+static_assert(rttyConfThresholdFor(100) == 0.95f,
+              "100 = only near-certain copy");
+static_assert(kRttySensitivityDefault == 38, "default documented in the header");
+
+int main()
+{
+    int failures = 0;
+    auto expectNear = [&](int sens, float expected, const char* why) {
+        const float got = rttyConfThresholdFor(sens);
+        const bool ok = std::fabs(got - expected) < 0.0005f;
+        std::printf("[%s] sens=%3d -> %.4f (expected %.4f) %s\n",
+                    ok ? " OK " : "FAIL", sens, got, expected, why);
+        if (!ok) ++failures;
+    };
+    expectNear(0,   0.500f, "floor: every character passes");
+    expectNear(38,  0.671f, "default: the decoder's ~3 dB lock point (snr = 10*log10(c/(1-c)))");
+    expectNear(50,  0.725f, "midpoint");
+    expectNear(100, 0.950f, "ceiling");
+    expectNear(-5,  0.500f, "clamped below");
+    expectNear(250, 0.950f, "clamped above");
+    // Monotonic: more sensitivity never lets MORE noise through.
+    for (int s = 1; s <= 100; ++s) {
+        if (!(rttyConfThresholdFor(s) > rttyConfThresholdFor(s - 1))) {
+            std::printf("[FAIL] not strictly increasing at %d\n", s);
+            ++failures;
+        }
+    }
+    std::printf("%s (%d failures)\n", failures ? "FAIL" : "OK", failures);
+    return failures ? 1 : 0;
+}

--- a/tests/rtty_decoder_sensitivity_test.cpp
+++ b/tests/rtty_decoder_sensitivity_test.cpp
@@ -13,7 +13,12 @@ static_assert(rttyConfThresholdFor(0) == 0.5f,
               "0 = show everything: the threshold is the confidence floor");
 static_assert(rttyConfThresholdFor(100) == 0.95f,
               "100 = only near-certain copy");
-static_assert(kRttySensitivityDefault == 38, "default documented in the header");
+static_assert(kRttySensitivityDefault == 0,
+              "the default is a provable no-op: confidence is >= 0.5 by "
+              "construction, so nothing can fall below the floor threshold — "
+              "out-of-the-box behavior is identical to the pane before #5028");
+static_assert(rttyConfThresholdFor(kRttySensitivityDefault) == 0.5f,
+              "default threshold sits exactly on the confidence floor");
 
 int main()
 {
@@ -25,8 +30,8 @@ int main()
                     ok ? " OK " : "FAIL", sens, got, expected, why);
         if (!ok) ++failures;
     };
-    expectNear(0,   0.500f, "floor: every character passes");
-    expectNear(38,  0.671f, "default: the decoder's ~3 dB lock point (snr = 10*log10(c/(1-c)))");
+    expectNear(0,   0.500f, "floor (and the default): every character passes");
+    expectNear(38,  0.671f, "documented starting value: the decoder's ~3 dB lock point (snr = 10*log10(c/(1-c)))");
     expectNear(50,  0.725f, "midpoint");
     expectNear(100, 0.950f, "ceiling");
     expectNear(-5,  0.500f, "clamped below");

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -2611,10 +2611,6 @@ add_test(NAME cw_sidetone_test COMMAND cw_sidetone_test)
 # header-only policy, so the whole truth table is a compile-time assertion; the
 # "saved device that IS the system default still takes the name-match path" row
 # pins the documented reach of the fix.
-add_executable(rtty_decoder_sensitivity_test tests/rtty_decoder_sensitivity_test.cpp)
-target_include_directories(rtty_decoder_sensitivity_test PRIVATE src)
-add_test(NAME rtty_decoder_sensitivity_test COMMAND rtty_decoder_sensitivity_test)
-
 add_executable(cw_sidetone_start_policy_test
     tests/cw_sidetone_start_policy_test.cpp
 )
@@ -2628,6 +2624,13 @@ add_executable(cw_sidetone_device_match_test tests/cw_sidetone_device_match_test
 target_include_directories(cw_sidetone_device_match_test PRIVATE src)
 target_link_libraries(cw_sidetone_device_match_test PRIVATE Qt6::Core)
 add_test(NAME cw_sidetone_device_match_test COMMAND cw_sidetone_device_match_test)
+
+# #5028 — the RTTY sensitivity slider's confidence mapping. Pure, header-only;
+# the floor/default/ceiling rows are compile-time static_asserts, so every CI
+# build enforces them even outside the ctest gates.
+add_executable(rtty_decoder_sensitivity_test tests/rtty_decoder_sensitivity_test.cpp)
+target_include_directories(rtty_decoder_sensitivity_test PRIVATE src)
+add_test(NAME rtty_decoder_sensitivity_test COMMAND rtty_decoder_sensitivity_test)
 
 add_executable(cwx_local_keyer_drift_test
     tests/cwx_local_keyer_drift_test.cpp

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -2611,6 +2611,10 @@ add_test(NAME cw_sidetone_test COMMAND cw_sidetone_test)
 # header-only policy, so the whole truth table is a compile-time assertion; the
 # "saved device that IS the system default still takes the name-match path" row
 # pins the documented reach of the fix.
+add_executable(rtty_decoder_sensitivity_test tests/rtty_decoder_sensitivity_test.cpp)
+target_include_directories(rtty_decoder_sensitivity_test PRIVATE src)
+add_test(NAME rtty_decoder_sensitivity_test COMMAND rtty_decoder_sensitivity_test)
+
 add_executable(cw_sidetone_start_policy_test
     tests/cw_sidetone_start_policy_test.cpp
 )


### PR DESCRIPTION
## Summary

Fixes #5028

The RTTY decoder emits every framed character and the pane rendered all of them —
confidence only chose the text colour — so between transmissions noise filled the
pane with gibberish. This adds the CW pane's control to the RTTY bar: a
**Sens:** slider whose threshold drops low-confidence characters before they reach
the text view.

What changed (`src/gui/PanadapterApplet.{h,cpp}` only — no decoder/DSP change):

- A `GuardedSlider` (`rttySensSlider`) on the RTTY bar between **REV** and the
  stats, 0–100, wired with `connectSliderSetting` like the CW slider.
- Mapping on RTTY's own scale: confidence is `max(mark,space)/(mark+space)`, so
  it lives in `[0.5, 1.0]` with higher = better — the inverse of CW's cost. The
  slider maps `0..100 → 0.50..0.95`, so 0 shows everything (as on CW) and 100
  keeps only near-certain copy.
- **The default is 0 — filtering is strictly opt-in** (`9c3df50a`; an earlier
  revision defaulted to 38). Threshold 0.50 is the confidence floor, so at the
  default `confidence < threshold` can never fire: out-of-the-box behaviour is
  provably identical to the pane before this control existed, pinned by two
  static_asserts. 38 — the decoder's own 3 dB `locked` point, i.e. filter what
  the stats bar calls UNLOCK — stays documented in the header, the test, and
  the tooltip as the recommended starting value when noise floods the pane.
- The drop is the **first** statement of `appendRttyText()`, above the CR/LF
  handling: Baudot CR/LF are ordinary codepoints noise hits as often as any
  other, and a dropped character must not still spray blank lines.
- Persistence per Constitution Principle V: the value is one field of a single
  nested object under root key `RttyDecoder` (`{"sensitivity": 0}`), not a new
  flat key. The pane's older `RttyDecoderMarkHz/ShiftHz/Baud/Reverse` flat keys are
  left grandfathered; folding them into the object is a separate migration.
- The slider→threshold mapping lives in `src/gui/RttyDecoderSensitivity.h`
  (constexpr) and is pinned by `rtty_decoder_sensitivity_test`: 0 → 0.50,
  38 → 0.671, 100 → 0.95, strictly increasing, clamped.
- Ride-along: `rttyDecodeText` objectName/accessibleName on the text view so the
  automation bridge can address it.
- `docs/rtty-decoder-implementation.md`'s UI Panel table gains the Sens row and
  its persistence sentence now distinguishes the grandfathered flat keys from
  the nested `RttyDecoder` object (`ec9f27bf` — an earlier revision of this
  body wrongly claimed no docs page covered the RTTY bar).

Not in this PR (follow-up, as the triage recommended): a carrier squelch on
`locked`/`snrDb`, which needs a hold because `statsUpdated` runs at 500 ms and a
45.45-baud character is ~163 ms.

## Constitution principle honored

Principle V — the new setting is a field of a single owned object under one root
key, not a loose flat key.

## Test plan

- [x] Local build passes — clean configure + full build, macOS (Intel, Qt 6.8.3): clean 2952/2952, then reconfigure+rebuild at the commit
- [x] Behavior verified on a real radio if applicable — verified on the Demo radio via
      the agent automation bridge (RX only, no RF), two sittings: macOS Demo radio
      (control/persistence, readings below — taken when the default was still 38) and a
      Linux FLEX-8400 noise-floor bench at `9c3df50a` that demonstrates the render gate
      itself and the new default-0 first show (proof section below)
- [x] Existing tests pass (CI) — `rtty_decoder_sensitivity_test` passes locally (compile-time
      rows + runtime table); not in a CI `-R` gate; CI compiles it
- [x] Reproduction steps documented — #5028 (noise between transmissions). **Not reproduced
      here:** the Demo radio's synthetic RX audio framed no Baudot characters in >2 min at
      sensitivity 0 with the decoder running (`1dB UNLOCK`), so the render gate's before/after
      is not shown on that source; the gate is one statement at the top of `appendRttyText()`
      and the mapping it applies is test-pinned

### Proof — agent automation bridge, macOS, build `20be1eb7` (Help→About verified)

Demo radio (RX only, no RF), slice set to RTTY via the bridge so the pane auto-shows:

| Claim | Bridge reading |
|---|---|
| Control exists on the RTTY bar | `dump_tree rttySensSlider`: `QSlider`, accessibleName `RTTY decoder sensitivity`, range 0–100, tooltip `Drop low-confidence characters (0 = show everything, 100 = only near-certain copy)` |
| Default | `value: "38"` on first show |
| Live change | `invoke setValue 73` → `value: "73"` |
| Persistence (Principle V shape) | `app_settings` row `RttyDecoder` = `{"sensitivity":73}` within the 500 ms debounce; no new flat key |
| Survives relaunch | store held `{"sensitivity":73}` before launch; after relaunch at `20be1eb7` and setting the slice to RTTY, `dump_tree rttySensSlider` read `value: "73"`; restored to 38 afterwards (`{"sensitivity":38}`) |

The mapping the gate applies: `rtty_decoder_sensitivity_test` —
`sens=0 -> 0.5000`, `sens=38 -> 0.6710`, `sens=50 -> 0.7250`, `sens=100 -> 0.9500`,
clamped at both ends, strictly increasing over 0..100.

(The default rows above were measured when the default was 38; the Linux bench below
re-verified the first-show default as 0 after `9c3df50a`.)

Screenshots (About at `20be1eb7`; the RTTY bar after relaunch with the slider at 73):

![About dialog at 20be1eb7](https://raw.githubusercontent.com/skerker/AetherSDR/feat-5028-assets/.pr-assets/aethersdr-5028-about-20be1eb7-2026-08-21.png)
![RTTY bar after relaunch — Sens slider at 73, decoder running on the Demo feed](https://raw.githubusercontent.com/skerker/AetherSDR/feat-5028-assets/.pr-assets/aethersdr-5028-rtty-bar-sens73-relaunch-2026-08-21.png)

### Proof — the render gate on a real radio's noise floor, Linux, build `9c3df50a` (Help→About verified)

Linux box, FLEX-8400, ANT1 into a dummy load, **RX only — nothing keyed**: the
receiver's own noise floor is exactly the input #5028 is about, so the gate's
before/after is demonstrable without a signal. Clean configure + full build at
`9c3df50a`; slice set to RTTY via the automation bridge; slider driven with
`invoke setValue`; pane cleared between arms; ~40–45 s accumulation each:

| Sensitivity | Pane after the window |
|---|---|
| **0 (the default, first show — fresh store, no `RttyDecoder` key)** | four lines of continuous noise gibberish — the reported symptom, and the proof that the default renders everything exactly as before this PR |
| **38** (the documented starting value) | three stray characters |
| **100** | empty |

Persistence re-verified on this box: `app_settings` row `RttyDecoder` =
`{"sensitivity":100}` after `setValue 100` (the 500 ms debounce), restored to
`{"sensitivity":0}` afterwards. `rtty_decoder_sensitivity_test` at `9c3df50a`:
all rows OK, exit 0. Zero WRN/ERR in the decode windows. The evidence zip
(complete unedited log, About screenshot, all three pane screenshots, test
output, store reading) is attached to this PR.


[aethersdr-pr5132-rtty-noise-gate-2026-08-24.zip](https://github.com/user-attachments/files/31389469/aethersdr-pr5132-rtty-noise-gate-2026-08-24.zip)

**Sensitivity 0 (the default) — ~40 s of the dummy-load noise floor: every noise character renders, the #5028 symptom:**
![Pane at sensitivity 0](https://raw.githubusercontent.com/skerker/AetherSDR/feat-5028-assets/.pr-assets/aethersdr-5132-rtty-N1-sens0-2026-08-24.png)
**Sensitivity 38 (the documented starting value) — same noise floor, same window: three stray characters:**
![Pane at 38](https://raw.githubusercontent.com/skerker/AetherSDR/feat-5028-assets/.pr-assets/aethersdr-5132-rtty-N2-sens38-2026-08-24.png)
**Sensitivity 100 — same noise floor, same window: empty:**
![Pane at 100](https://raw.githubusercontent.com/skerker/AetherSDR/feat-5028-assets/.pr-assets/aethersdr-5132-rtty-N3-sens100-2026-08-24.png)

Still not demonstrated (needs a live RTTY signal, i.e. an antenna session): a
real transmission decoding *above* threshold while noise stays suppressed.

**Why 38, and the expectation on a real signal.** 38 is derived, not picked: the
decoder's stats bar computes `snrDb = 10*log10(c/(1-c))` and declares LOCKED at
3 dB, which is confidence `c = 2/3`; 38 is the slider position whose threshold
(0.671) sits on that boundary, so the recommended starting value drops exactly
the characters the decoder itself calls UNLOCK. On a clean, tuned RTTY signal
the mark/space envelopes separate strongly, so per-character confidence rides
well above 0.67 — the expectation, not yet measured, is that real copy survives
38 while between-over noise (c ≈ 0.5–0.6, as the bench above shows) does not.
On marginal signals confidence will straddle any threshold and some real
characters will drop — inherent to a squelch, and the reason this is a slider
with an opt-in default of 0 rather than a fixed gate; the CW pane's identical
control already fills this role in the field.

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls — nested object under `RttyDecoder`
- [x] Code is clean-room
- [x] All meter UI uses `MeterSmoother` — **n/a**
- [x] Documentation updated if user-visible behavior changed — yes:
      `docs/rtty-decoder-implementation.md` UI Panel table + persistence note
      (`ec9f27bf`); tooltip in-app
- [x] Security-sensitive changes reference a GHSA — **n/a**

— authored by agent (Claude Code) on behalf of @skerker




