### PR TITLE
fix(gui): prevent Icom CWK updates from stealing VFO focus

### DIFF
--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -370,7 +370,12 @@ void CwxPanel::configureTextKeyer(const QString& name, int minWpm, int maxWpm,
         m_setupBtn->setVisible(supportsStoredMacros);
         if (!supportsStoredMacros) {
             m_setupBtn->setChecked(false);
-            showSendView();
+            // Capability updates are radio-driven and may arrive while the
+            // operator is editing an unrelated control. Select the only
+            // supported page without showSendView()'s user-action focus grab.
+            if (m_stack->currentWidget() != m_sendPage) {
+                m_stack->setCurrentWidget(m_sendPage);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Keep radio-driven CWK capability synchronization focus-neutral.
- Continue selecting the Send page when stored macros are unavailable without invoking the user-action focus path.
- Preserve focus on the VFO entry and other operator controls during periodic Icom status updates.

## Root cause

PR #5113 added `configureTextKeyer()` to capability application. On radios such as the IC-705, `cwTextHasStoredMacros` is false, so every capability refresh called `showSendView()`. That helper calls `m_textEdit->setFocus()`, allowing the inactive CWK editor to repeatedly take focus from the VFO entry.

This change selects the supported page directly during capability synchronization. Explicit CWK actions still use `showSendView()` and retain their existing editor-focus behavior.

## Verification

- Incremental `AetherSDR` application build passed on macOS.
- Existing headless `cwx_panel_test` passed in full.
- Live IC-705 before fix: clicking or typing in the VFO repeatedly lost focus to the CWK text editor.
- Live IC-705 after fix: complete frequency entry and repeated clicks remained stable; maintainer confirmed it "works perfect."
- No transmit operation was performed.
- A focused regression test used during diagnosis was removed at maintainer request before filing this PR.

## Agent automation bridge

The fixed build was launched with the agent automation bridge active. The bridge does not currently expose application focus ownership, so the decisive before/after proof was the live operator test. A future focused-widget property would make this regression directly bridge-verifiable.

## Related

- Regression introduced by #5113.
- #5117 tune-guard behavior is unrelated; it does not run for the IC-705.

Generated with OpenAI Codex (Daybreak Blue)
