### PR TITLE
fix(audio): stop a short PortAudio name claiming an explicitly selected sidetone output (#5123)

### DIFF
--- a/src/core/CwSidetoneDeviceMatch.h
+++ b/src/core/CwSidetoneDeviceMatch.h
@@ -17,16 +17,25 @@ inline QString normalizedDeviceName(QString name)
 
 // paName: PaDeviceInfo::name.  qtDescription: QAudioDevice::description().
 //
-// Partial is deliberately asymmetric:
-//   - paName.contains(qtDescription): PortAudio decorates the name
-//     ("Scarlett 2i2 USB Analog Stereo (hw:1,0)").
-//   - paName is a PREFIX of qtDescription: Windows MME truncates device
+// Partial is a PREFIX test in both directions — neither side may match an
+// interior substring:
+//   - paName is a prefix of qtDescription: Windows MME truncates device
 //     names to 31 characters, so the PortAudio name is the head of the
 //     fuller Qt description (#3193 relies on those MME rows being candidates).
-// An interior substring in the second direction is NOT a match.  That is what
-// let the 4-character ALSA plugin "hdmi" claim "Built-in Audio Digital Stereo
-// (HDMI)" and route the sidetone to whichever card defaults.pcm.iec958.card
-// names — a different physical port than the one selected (#5123).
+//   - qtDescription is a prefix of paName: retained for a PortAudio host that
+//     appends decoration to the description it shares with Qt.  No captured
+//     device list in #4978 / #5123 / #5135 holds such a pair — macOS reports
+//     identical strings, and ALSA's form is "<card>: <pcm> (hw:X,Y)" with the
+//     card name first — so the unit test does not pin this arm.
+// Interior substrings are what let the 4-character ALSA plugin "hdmi" claim
+// "Built-in Audio Digital Stereo (HDMI)" and route the sidetone to whichever
+// card defaults.pcm.iec958.card names — a different physical port than the
+// one selected (#5123).  The mirror image — a long PortAudio name claiming a
+// short Qt description it happens to contain — is closed by the first arm
+// being a prefix test as well.  Should a device exist that a prefix test
+// refuses, the cost is a fallback to QAudioSink — the wrong-timing path with
+// the right speakers — rather than a confident match on the wrong port, which
+// is the failure #5123 is about.
 inline DeviceNameMatch classifyDeviceNameMatch(const QString& paName,
                                                const QString& qtDescription)
 {
@@ -36,7 +45,7 @@ inline DeviceNameMatch classifyDeviceNameMatch(const QString& paName,
         return DeviceNameMatch::None;
     if (cand == target)
         return DeviceNameMatch::Exact;
-    if (cand.contains(target) || target.startsWith(cand))
+    if (cand.startsWith(target) || target.startsWith(cand))
         return DeviceNameMatch::Partial;
     return DeviceNameMatch::None;
 }

--- a/src/core/CwSidetoneDeviceMatch.h
+++ b/src/core/CwSidetoneDeviceMatch.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <QString>
+
+namespace AetherSDR {
+
+// How a PortAudio device name relates to the Qt output description the
+// operator selected in Radio Setup.  Pure string predicate — no PortAudio,
+// no Qt Multimedia — so the rule is unit-testable against captured device
+// lists without audio hardware (#5123).
+enum class DeviceNameMatch { None, Exact, Partial };
+
+inline QString normalizedDeviceName(QString name)
+{
+    return name.simplified().toCaseFolded();
+}
+
+// paName: PaDeviceInfo::name.  qtDescription: QAudioDevice::description().
+//
+// Partial is deliberately asymmetric:
+//   - paName.contains(qtDescription): PortAudio decorates the name
+//     ("Scarlett 2i2 USB Analog Stereo (hw:1,0)").
+//   - paName is a PREFIX of qtDescription: Windows MME truncates device
+//     names to 31 characters, so the PortAudio name is the head of the
+//     fuller Qt description (#3193 relies on those MME rows being candidates).
+// An interior substring in the second direction is NOT a match.  That is what
+// let the 4-character ALSA plugin "hdmi" claim "Built-in Audio Digital Stereo
+// (HDMI)" and route the sidetone to whichever card defaults.pcm.iec958.card
+// names — a different physical port than the one selected (#5123).
+inline DeviceNameMatch classifyDeviceNameMatch(const QString& paName,
+                                               const QString& qtDescription)
+{
+    const QString cand = normalizedDeviceName(paName);
+    const QString target = normalizedDeviceName(qtDescription);
+    if (cand.isEmpty() || target.isEmpty())
+        return DeviceNameMatch::None;
+    if (cand == target)
+        return DeviceNameMatch::Exact;
+    if (cand.contains(target) || target.startsWith(cand))
+        return DeviceNameMatch::Partial;
+    return DeviceNameMatch::None;
+}
+
+} // namespace AetherSDR

--- a/src/core/CwSidetonePortAudioSink.cpp
+++ b/src/core/CwSidetonePortAudioSink.cpp
@@ -1,4 +1,5 @@
 #include "CwSidetonePortAudioSink.h"
+#include "CwSidetoneDeviceMatch.h"
 #include "CwSidetoneGenerator.h"
 #include "LogManager.h"
 
@@ -15,15 +16,16 @@ namespace AetherSDR {
 
 namespace {
 
-QString normalizedDeviceName(QString name)
+// Resolve the operator's explicit Qt output selection to a PortAudio device.
+// The name rule lives in CwSidetoneDeviceMatch.h so it is testable without
+// hardware.  `partialMatchName` (optional) receives the PortAudio name when
+// the result came from a PARTIAL match rather than an exact one, so the
+// caller can report the substitution in the sidetone summary instead of it
+// living in one warning line (#5123).
+PaDeviceIndex findPortAudioOutputDevice(const QAudioDevice& device,
+                                        QString* partialMatchName = nullptr)
 {
-    return name.simplified().toCaseFolded();
-}
-
-PaDeviceIndex findPortAudioOutputDevice(const QAudioDevice& device)
-{
-    const QString target = normalizedDeviceName(device.description());
-    if (target.isEmpty())
+    if (normalizedDeviceName(device.description()).isEmpty())
         return paNoDevice;
 
     const PaDeviceIndex count = Pa_GetDeviceCount();
@@ -46,11 +48,11 @@ PaDeviceIndex findPortAudioOutputDevice(const QAudioDevice& device)
             continue;
 
         const QString rawName = QString::fromUtf8(info->name);
-        const QString candidate = normalizedDeviceName(rawName);
-        if (candidate == target)
+        const DeviceNameMatch kind = classifyDeviceNameMatch(rawName, device.description());
+        if (kind == DeviceNameMatch::Exact)
             return i;
 
-        if (candidate.contains(target) || target.contains(candidate)) {
+        if (kind == DeviceNameMatch::Partial) {
             // paInDevelopment (0) is used as a safe "unknown" sentinel when
             // Pa_GetHostApiInfo returns null — it will never equal paWASAPI.
             PaHostApiTypeId apiType = paInDevelopment;
@@ -82,11 +84,12 @@ PaDeviceIndex findPortAudioOutputDevice(const QAudioDevice& device)
     }
 
     if (partials.size() == 1) {
+        if (partialMatchName)
+            *partialMatchName = partials[0].rawName;
         qCWarning(lcAudio) << "CwSidetonePortAudioSink: selected Qt output device"
                            << device.description()
-                           << "partially matched PortAudio output"
-                           << partials[0].rawName
-                           << "by name substring";
+                           << "only partially matched PortAudio output"
+                           << partials[0].rawName;
         return partials[0].idx;
     }
 
@@ -203,9 +206,10 @@ bool CwSidetonePortAudioSink::start(const QAudioDevice& device,
         m_paInitialized = true;
     }
 
+    QString partialMatchName;
     PaDeviceIndex devIdx = device.isNull()
         ? defaultPortAudioOutputDevice()
-        : findPortAudioOutputDevice(device);
+        : findPortAudioOutputDevice(device, &partialMatchName);
     if (!device.isNull() && devIdx == paNoDevice) {
         qCWarning(lcAudio) << "CwSidetonePortAudioSink: selected Qt output device"
                            << device.description()
@@ -226,6 +230,17 @@ bool CwSidetonePortAudioSink::start(const QAudioDevice& device,
         qCWarning(lcAudio) << "CwSidetonePortAudioSink: matched selected Qt output"
                            << device.description()
                            << "to PortAudio output" << devInfo->name;
+    }
+    if (!partialMatchName.isEmpty()) {
+        // A partial name match is a substitution the operator did not make;
+        // surface it in the summary and the support bundle, not only in the
+        // warning above (#5123).
+        m_fallbackOccurred = true;
+        const QString detail = QStringLiteral("selected \"%1\" resolved by partial name match to \"%2\"")
+                                   .arg(device.description(), partialMatchName);
+        m_fallbackReason = m_fallbackReason.isEmpty()
+            ? detail
+            : m_fallbackReason + QStringLiteral("; ") + detail;
     }
     m_deviceDescription = QString::fromLocal8Bit(devInfo->name ? devInfo->name : "");
 

--- a/src/core/CwSidetonePortAudioSink.cpp
+++ b/src/core/CwSidetonePortAudioSink.cpp
@@ -25,7 +25,7 @@ namespace {
 PaDeviceIndex findPortAudioOutputDevice(const QAudioDevice& device,
                                         QString* partialMatchName = nullptr)
 {
-    if (normalizedDeviceName(device.description()).isEmpty())
+    if (device.description().trimmed().isEmpty())
         return paNoDevice;
 
     const PaDeviceIndex count = Pa_GetDeviceCount();
@@ -227,9 +227,18 @@ bool CwSidetonePortAudioSink::start(const QAudioDevice& device,
         return false;
     }
     if (!device.isNull()) {
-        qCWarning(lcAudio) << "CwSidetonePortAudioSink: matched selected Qt output"
-                           << device.description()
-                           << "to PortAudio output" << devInfo->name;
+        if (partialMatchName.isEmpty()) {
+            qCWarning(lcAudio) << "CwSidetonePortAudioSink: matched selected Qt output"
+                               << device.description()
+                               << "to PortAudio output" << devInfo->name;
+        } else {
+            // Not "matched": the operator did not pick this device (#5123).
+            qCWarning(lcAudio) << "CwSidetonePortAudioSink: opening PortAudio output"
+                               << devInfo->name
+                               << "in place of selected Qt output"
+                               << device.description()
+                               << "(partial name match)";
+        }
     }
     if (!partialMatchName.isEmpty()) {
         // A partial name match is a substitution the operator did not make;

--- a/tests/cw_sidetone_device_match_test.cpp
+++ b/tests/cw_sidetone_device_match_test.cpp
@@ -1,0 +1,85 @@
+// CwSidetoneDeviceMatch: the name rule that maps the operator's explicit Qt
+// output selection onto a PortAudio device (#5123).
+//
+// The inputs are measured strings: the 13-device ALSA-only PortAudio list and
+// Qt/PipeWire descriptions captured on the Linux box in #4978, plus the
+// Windows MME truncation shape #3193 depends on.  No PortAudio init, no
+// device — the rule is a pure predicate over two strings.
+
+#include "core/CwSidetoneDeviceMatch.h"
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failures = 0;
+int g_checks = 0;
+
+const char* name(DeviceNameMatch m)
+{
+    switch (m) {
+    case DeviceNameMatch::None:    return "None";
+    case DeviceNameMatch::Exact:   return "Exact";
+    case DeviceNameMatch::Partial: return "Partial";
+    }
+    return "?";
+}
+
+void expectMatch(const char* paName, const char* qtDescription,
+                 DeviceNameMatch expected, const char* why)
+{
+    ++g_checks;
+    const DeviceNameMatch got =
+        classifyDeviceNameMatch(QString::fromUtf8(paName), QString::fromUtf8(qtDescription));
+    if (got == expected) {
+        std::printf("[ OK ] %-8s pa=\"%s\" qt=\"%s\"\n", name(expected), paName, qtDescription);
+    } else {
+        std::printf("[FAIL] pa=\"%s\" qt=\"%s\": got %s, expected %s — %s\n",
+                    paName, qtDescription, name(got), name(expected), why);
+        ++g_failures;
+    }
+}
+
+} // namespace
+
+int main()
+{
+    // #5123: degenerate ALSA plugin names must not claim a long Qt description.
+    // Both replay-table rows from the issue resolve to None -> paNoDevice ->
+    // the documented QAudioSink fallback, not to the `hdmi` plugin.
+    expectMatch("hdmi", "Built-in Audio Digital Stereo (HDMI)", DeviceNameMatch::None,
+                "interior substring of the description is not a match");
+    expectMatch("hdmi", "GA104 High Definition Audio Controller Digital Stereo (HDMI 2)",
+                DeviceNameMatch::None, "interior substring of the description is not a match");
+    expectMatch("pulse", "Built-in Audio Analog Stereo", DeviceNameMatch::None, "unrelated plugin");
+    expectMatch("default", "Scarlett 2i2 USB Analog Stereo", DeviceNameMatch::None, "unrelated plugin");
+    expectMatch("sysdefault", "Built-in Audio Analog Stereo", DeviceNameMatch::None, "unrelated plugin");
+    expectMatch("pipewire", "Built-in Audio Digital Stereo (HDMI)", DeviceNameMatch::None, "unrelated plugin");
+    expectMatch("iec958", "Built-in Audio Digital Stereo (HDMI)", DeviceNameMatch::None, "unrelated plugin");
+    expectMatch("dmix", "Built-in Audio Analog Stereo", DeviceNameMatch::None, "unrelated plugin");
+    // A short token that happens to START the description is still a prefix
+    // match by the rule below — the rule is about direction, not length.
+    expectMatch("HDA NVidia: HDMI 0 (hw:0,3)", "Built-in Audio Digital Stereo (HDMI)",
+                DeviceNameMatch::None, "different vocabulary, no containment either way");
+
+    // Preserved shapes.
+    // PortAudio decorates the name: description is contained in the PA name.
+    expectMatch("Scarlett 2i2 USB Analog Stereo (hw:1,0)", "Scarlett 2i2 USB Analog Stereo",
+                DeviceNameMatch::Partial, "PortAudio-decorated name contains the description");
+    // Windows MME truncates to 31 chars: PA name is a PREFIX of the description.
+    expectMatch("Speakers (Realtek(R) Audio)", "Speakers (Realtek(R) Audio) - 2- High Definition Audio",
+                DeviceNameMatch::Partial, "MME truncation is a prefix (#3193)");
+    // Exact after normalisation (whitespace, case).
+    expectMatch("Built-in Audio Analog Stereo", "Built-in  Audio Analog Stereo",
+                DeviceNameMatch::Exact, "simplified() folds double spaces");
+    expectMatch("MACBOOK PRO SPEAKERS", "MacBook Pro Speakers",
+                DeviceNameMatch::Exact, "toCaseFolded() folds case");
+    // Empty inputs never match.
+    expectMatch("", "Built-in Audio Analog Stereo", DeviceNameMatch::None, "empty PA name");
+    expectMatch("hdmi", "", DeviceNameMatch::None, "empty description");
+
+    std::printf("%d checks, %d failures\n", g_checks, g_failures);
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/cw_sidetone_device_match_test.cpp
+++ b/tests/cw_sidetone_device_match_test.cpp
@@ -60,7 +60,12 @@ int main()
     expectMatch("iec958", "Built-in Audio Digital Stereo (HDMI)", DeviceNameMatch::None, "unrelated plugin");
     expectMatch("dmix", "Built-in Audio Analog Stereo", DeviceNameMatch::None, "unrelated plugin");
     // A short token that happens to START the description is still a prefix
-    // match by the rule below — the rule is about direction, not length.
+    // match — the rule is about direction, not length.  The shape is real on
+    // Qt's plain-ALSA backend, where descriptions are the ALSA hint strings:
+    // alsa-plugins' pulse.conf describes its `pulse` PCM as "PulseAudio Sound
+    // Server", and that IS the pulse plugin, so matching it is correct.
+    expectMatch("pulse", "PulseAudio Sound Server", DeviceNameMatch::Partial,
+                "short PA name that is a prefix of the description");
     expectMatch("HDA NVidia: HDMI 0 (hw:0,3)", "Built-in Audio Digital Stereo (HDMI)",
                 DeviceNameMatch::None, "different vocabulary, no containment either way");
 

--- a/tests/cw_sidetone_device_match_test.cpp
+++ b/tests/cw_sidetone_device_match_test.cpp
@@ -1,10 +1,18 @@
 // CwSidetoneDeviceMatch: the name rule that maps the operator's explicit Qt
 // output selection onto a PortAudio device (#5123).
 //
-// The inputs are measured strings: the 13-device ALSA-only PortAudio list and
-// Qt/PipeWire descriptions captured on the Linux box in #4978, plus the
-// Windows MME truncation shape #3193 depends on.  No PortAudio init, no
-// device — the rule is a pure predicate over two strings.
+// Every device string below is a claim about the world and carries its
+// provenance:
+//   MEASURED    — taken from a captured device list (the 13-device ALSA-only
+//                 PortAudio list and the Qt/PipeWire descriptions from the
+//                 Linux box in #4978; the #5123 replay table).
+//   SOURCED     — the string is quoted from the code or config that produces
+//                 it, not from a captured list.
+//   CONSTRUCTED — not a real device name; exercises only the normalisation
+//                 (whitespace, case) or the empty-input path, never a claim
+//                 that the shape exists in the field.
+// No PortAudio init, no device — the rule is a pure predicate over two
+// strings.
 
 #include "core/CwSidetoneDeviceMatch.h"
 
@@ -49,39 +57,64 @@ int main()
     // #5123: degenerate ALSA plugin names must not claim a long Qt description.
     // Both replay-table rows from the issue resolve to None -> paNoDevice ->
     // the documented QAudioSink fallback, not to the `hdmi` plugin.
+    // MEASURED: PortAudio names are #4978's list (index 9 `hdmi`, 10
+    // `pipewire`, 11 `pulse`, 12 `default`, 0 `HDA NVidia: HDMI 0 (hw:0,3)`);
+    // Qt descriptions are the #5123 replay table.
     expectMatch("hdmi", "Built-in Audio Digital Stereo (HDMI)", DeviceNameMatch::None,
                 "interior substring of the description is not a match");
     expectMatch("hdmi", "GA104 High Definition Audio Controller Digital Stereo (HDMI 2)",
                 DeviceNameMatch::None, "interior substring of the description is not a match");
     expectMatch("pulse", "Built-in Audio Analog Stereo", DeviceNameMatch::None, "unrelated plugin");
     expectMatch("default", "Scarlett 2i2 USB Analog Stereo", DeviceNameMatch::None, "unrelated plugin");
-    expectMatch("sysdefault", "Built-in Audio Analog Stereo", DeviceNameMatch::None, "unrelated plugin");
     expectMatch("pipewire", "Built-in Audio Digital Stereo (HDMI)", DeviceNameMatch::None, "unrelated plugin");
-    expectMatch("iec958", "Built-in Audio Digital Stereo (HDMI)", DeviceNameMatch::None, "unrelated plugin");
-    expectMatch("dmix", "Built-in Audio Analog Stereo", DeviceNameMatch::None, "unrelated plugin");
+    expectMatch("HDA NVidia: HDMI 0 (hw:0,3)", "Built-in Audio Digital Stereo (HDMI)",
+                DeviceNameMatch::None, "different vocabulary, no prefix either way");
+
     // A short token that happens to START the description is still a prefix
-    // match — the rule is about direction, not length.  The shape is real on
-    // Qt's plain-ALSA backend, where descriptions are the ALSA hint strings:
-    // alsa-plugins' pulse.conf describes its `pulse` PCM as "PulseAudio Sound
-    // Server", and that IS the pulse plugin, so matching it is correct.
+    // match — the rule is about direction, not length.
+    // SOURCED, not captured: Qt's plain-ALSA backend reports the ALSA hint
+    // DESC verbatim as description() (qtmultimedia 6.8,
+    // src/multimedia/alsa/qalsaaudiodevices.cpp:58-62), and alsa-plugins
+    // names its `pulse` PCM "PulseAudio Sound Server"
+    // (pulse/50-pulseaudio.conf:16).  That IS the pulse plugin, so matching
+    // it is correct.  No captured list from a plain-ALSA Qt backend exists.
     expectMatch("pulse", "PulseAudio Sound Server", DeviceNameMatch::Partial,
                 "short PA name that is a prefix of the description");
-    expectMatch("HDA NVidia: HDMI 0 (hw:0,3)", "Built-in Audio Digital Stereo (HDMI)",
-                DeviceNameMatch::None, "different vocabulary, no containment either way");
 
-    // Preserved shapes.
-    // PortAudio decorates the name: description is contained in the PA name.
-    expectMatch("Scarlett 2i2 USB Analog Stereo (hw:1,0)", "Scarlett 2i2 USB Analog Stereo",
-                DeviceNameMatch::Partial, "PortAudio-decorated name contains the description");
-    // Windows MME truncates to 31 chars: PA name is a PREFIX of the description.
+    // Shared product string, prefix in neither direction.
+    // Published in our #4978 comment of 2026-08-18 (Linux box): ALSA's form
+    // is "<card>: <pcm> (hw:X,Y)" while Qt reports the PulseAudio
+    // description.  That enumeration is NOT the 13-device list captured in
+    // the same comment (no card 2 there); the capture that would put this
+    // row in the MEASURED class is the Linux box with the Scarlett attached.
+    expectMatch("Scarlett 2i2 USB: Audio (hw:2,0)", "Scarlett 2i2 USB Analog Stereo",
+                DeviceNameMatch::None, "shared product string, prefix in neither direction");
+
+    // Windows MME truncates to 31 chars: PA name is a PREFIX of the description
+    // (#3193 relies on those MME rows being candidates).
+    // Qt side MEASURED by NF0T on his Windows box (PR #5135 review,
+    // 2026-08-26).  PA side CONSTRUCTED: it is the Qt description our own
+    // Windows box reports (#4978, 2026-08-20) standing in for an MME name;
+    // the real MME truncation of the Qt string would be the 31-character
+    // "Speakers (Realtek(R) Audio) - 2", which no published list holds.
     expectMatch("Speakers (Realtek(R) Audio)", "Speakers (Realtek(R) Audio) - 2- High Definition Audio",
                 DeviceNameMatch::Partial, "MME truncation is a prefix (#3193)");
-    // Exact after normalisation (whitespace, case).
+
+    // The other Partial arm — the Qt description as a PREFIX of the PortAudio
+    // name — has no row: no captured device list holds such a pair (see the
+    // header comment in CwSidetoneDeviceMatch.h).  Nothing here pins it.
+
+    // Exact after normalisation.  CONSTRUCTED: the base strings are the
+    // measured Linux "Built-in Audio Analog Stereo" (#4978) and the measured
+    // macOS "MacBook Pro Speakers" (#4978, 2026-08-20); the doubled space and
+    // the all-caps form are not real device names and exercise only
+    // simplified() and toCaseFolded().
     expectMatch("Built-in Audio Analog Stereo", "Built-in  Audio Analog Stereo",
                 DeviceNameMatch::Exact, "simplified() folds double spaces");
     expectMatch("MACBOOK PRO SPEAKERS", "MacBook Pro Speakers",
                 DeviceNameMatch::Exact, "toCaseFolded() folds case");
-    // Empty inputs never match.
+
+    // Empty inputs never match.  CONSTRUCTED.
     expectMatch("", "Built-in Audio Analog Stereo", DeviceNameMatch::None, "empty PA name");
     expectMatch("hdmi", "", DeviceNameMatch::None, "empty description");
 

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -2454,6 +2454,14 @@ add_executable(cw_sidetone_start_policy_test
 target_include_directories(cw_sidetone_start_policy_test PRIVATE src)
 add_test(NAME cw_sidetone_start_policy_test COMMAND cw_sidetone_start_policy_test)
 
+# The explicit-selection name rule (#5123): pure QString predicate, no
+# PortAudio, so the captured Linux/Windows device names are checked on every
+# runner regardless of which audio backends it has.
+add_executable(cw_sidetone_device_match_test tests/cw_sidetone_device_match_test.cpp)
+target_include_directories(cw_sidetone_device_match_test PRIVATE src)
+target_link_libraries(cw_sidetone_device_match_test PRIVATE Qt6::Core)
+add_test(NAME cw_sidetone_device_match_test COMMAND cw_sidetone_device_match_test)
+
 add_executable(cwx_local_keyer_drift_test
     tests/cwx_local_keyer_drift_test.cpp
     src/core/CwxLocalKeyer.cpp


### PR DESCRIPTION
## Summary

Fixes #5123

**What this PR proves.** The issue is a Linux HDMI case: with an HDMI output selected, the sidetone opened on the ALSA `hdmi` *plugin* (whichever card `defaults.pcm.iec958.card` names) instead of the selected port, and reported `fallback=no`. This PR changes the name-matching rule so that pair no longer matches, proven at two levels: the **predicate** level (the issue's exact strings are the first rows of the new unit test — `hdmi` vs `Built-in Audio Digital Stereo (HDMI)` → no match → the documented QAudioSink fallback, which opens the device the user picked), and **end-to-end on Linux** (readings below): with an HDMI output explicitly selected, main `dd13fcf8` reproduces the bug live (`device="hdmi" … fallback=no`) while this branch refuses the match and lands on the documented fallback naming the selected device (`fallback=yes`). The macOS readings are regression checks (default and exact-name selection unchanged).

This implements the fix the issue's triage converged on — its items (1) prefix-not-interior reverse match and (2) an honest surviving partial — rather than an independent choice among the three options the issue listed for maintainers.

`findPortAudioOutputDevice()` accepted a partial name match in **both** directions, so a 4-character ALSA plugin name such as `hdmi` qualified as a match for `Built-in Audio Digital Stereo (HDMI)` and the sidetone opened on whichever card `defaults.pcm.iec958.card` names — a different physical HDMI port than the one selected, reported as `fallback=no`. The reverse direction exists for one shape: Windows MME truncates device names to 31 characters, so the PortAudio name is a *prefix* of the fuller Qt description. PortAudio's own MME host states it (`src/hostapi/wmme/pa_win_wmme.c`, `InitializeOutputDeviceInfo()`: *"the WAVEOUTCAPS.szPname is a null-terminated array of 32 characters, so we are limited to displaying only the first 31 characters of the device name"*) — the MME rows that #3193's WASAPI preference picks between are all of this shape.

What changed (`src/core/CwSidetonePortAudioSink.cpp` + one new header + one test):

- New `src/core/CwSidetoneDeviceMatch.h`: `classifyDeviceNameMatch(paName, qtDescription)` → `None | Exact | Partial`. Partial is a **prefix test in both directions** — `paName.startsWith(qtDescription) || qtDescription.startsWith(paName)` — never an interior substring. The second arm is the MME shape above. The first arm (PortAudio appending decoration to the shared description) is retained from the original rule's rationale; no captured device list in #4978 / #5123 / this PR holds such a pair, the header says so, and the unit test does not pin it. Both HDMI rows of the issue's replay table resolve to `None` → `paNoDevice` → the documented QAudioSink fallback.
- The surviving lone-partial arm is honest: `findPortAudioOutputDevice()` hands the caller the matched name; `start()` sets `m_fallbackOccurred = true` with `selected "<Qt>" resolved by partial name match to "<PA>"` in `m_fallbackReason`, so the CW sidetone summary and the support bundle name the substitution; and the `matched selected Qt output … to PortAudio output …` warning fires only on an exact match — a partial logs `opening PortAudio output <PA> in place of selected Qt output <Qt> (partial name match)`.
- `tests/cw_sidetone_device_match_test.cpp` (new target, links `Qt6::Core`): 13 checks. Every device string carries its provenance in the file — **MEASURED** (the #4978 13-device ALSA list and the #5123 replay table: `hdmi` ×2, `pulse`, `default`, `pipewire`, `HDA NVidia: HDMI 0 (hw:0,3)` → `None`; the Scarlett pair published in #4978 → `None`), **SOURCED** (`pulse` vs `PulseAudio Sound Server` → `Partial`: Qt's plain-ALSA backend reports the ALSA `DESC` hint verbatim, qtmultimedia 6.8 `qalsaaudiodevices.cpp:58-62`, and alsa-plugins names its `pulse` PCM so, `pulse/50-pulseaudio.conf:16`), or **CONSTRUCTED** (the MME-prefix row's PortAudio side, the whitespace/case-fold `Exact` rows, empty inputs — exercising the rule, not claiming a shape exists). Earlier revisions carried three rows (`sysdefault`, `iec958`, `dmix`) naming plugins absent from the captured list; they are removed.

**Cost, named.** An operator whose explicit selection previously resolved by interior substring moves from the PortAudio pull path to the QAudioSink push path — the right device on the worse-timing path (#4978) instead of a confident match on the wrong port. Nothing leaves the machine.

**Windows.** The multi-partial WASAPI-preference branch (`#ifdef Q_OS_WIN`, `:105-112`) returns a substituted device without setting `partialMatchName` — the same reporting hole on a different branch of the function (found in review by @ten9876, measured by @NF0T). It is split into a follow-up: the file does not compile in any stock Windows build today (`HAVE_PORTAUDIO` is undefined there), and #5201 restructures that arbitration on Windows (endpoint-ID match, exact-collection with the WASAPI preference) on the box that can run it. No `ci.yml` change here: `.github/workflows/` is Tier-2 infrastructure and the audio gate postdates this branch's base.

The exact-name escape hatch tracked in #4978 remains the way to target an ALSA plugin on purpose.

## Constitution principle honored

Principle VIII — verified by behavior, not by the implementing agent's confidence: the rule change is demonstrated by the two-SHA Linux A/B below (main reproduces the wrong-device match live; this branch refuses it), with unedited logs attached, and the predicate is pinned by a test over captured strings that fails on main's rule.

## Test plan

- [x] Local build passes — clean configure + full build, macOS (Intel, Qt 6.8.3, PortAudio 19.7.0): `f01e88ed`, `strings` on the binary + About-dialog SHA confirmed before the run
- [x] Behavior verified on a real radio if applicable — Linux FLEX-8400 arm (RX only, dummy load, nothing keyed) and macOS Demo-radio arms below
- [x] Existing tests pass (CI) — `cw_sidetone_device_match_test` is **built** by the Linux and macOS full-build jobs, **not** by the Windows job (explicit target list), and is on **no** `ctest -R` gate, so it runs only on the weekly sanitizers job; locally 13/13 at `f01e88ed`. `cw_sidetone_start_policy_test` unchanged
- [x] Reproduction steps documented — #5123 replay table; the test is the repro; live reproduction on main below

### Proof

**Unit test** `cw_sidetone_device_match_test` at `f01e88ed`: 13 checks, 0 failures. **Mutation-checked** per AGENTS.md: with the predicate reverted to main's `cand.contains(target) || target.contains(cand)` the test fails exactly the two #5123 rows (`hdmi` vs `Built-in Audio Digital Stereo (HDMI)`, `hdmi` vs `GA104 … (HDMI 2)`: got `Partial`, expected `None`; 13 checks, 2 failures) and nothing else; restored, 13/13. A second mutation — the first arm as interior `contains` — passes all 13, which is the unpinned arm stated above.

**Linux end-to-end** (the issue's own case), taken 2026-08-24 0526Z–0556Z at `5720e978` vs main `dd13fcf8`: Linux box, Qt 6.8.3, PipeWire; HDMI sink `alsa_output.pci-0000_00_1f.3.hdmi-stereo` ("Built-in Audio Digital Stereo (HDMI)") enabled via card profile (no monitor attached); explicit selection = `AudioOutputDeviceId` store row written while the app was closed; FLEX-8400 connected (RX only, dummy load, nothing keyed). Both arms: clean configure + full build, SHA verified in-session (binary `strings` before launch + Help→About visual confirm). The commits since `5720e978` narrow the predicate further (`startsWith` ⊂ `contains`) and touch only the partial-match log line and the test, so the fixed arm's result — no match → fallback — is unchanged at `f01e88ed`.

| arm | build | reading (`~/.config/AetherSDR/logs/`) |
|---|---|---|
| fixed, explicit HDMI selection | `5720e978` | `CwSidetonePortAudioSink: no PortAudio output matches "Built-in Audio Digital Stereo (HDMI)" - candidates: "HDA NVidia: HDMI 0 (hw:0,3)" [ALSA], … "hdmi" [ALSA], "pipewire" [ALSA], "pulse" [ALSA], "default" [ALSA]` → `selected Qt output device "Built-in Audio Digital Stereo (HDMI)" was not found in PortAudio; falling back to QAudioSink` → summary `backend="QAudioSink" device="Built-in Audio Digital Stereo (HDMI)" rate=24000Hz path=push` / `fallback=yes (PortAudio failed -> QAudioSink; negotiated 24000Hz Float)` |
| old (main `dd13fcf8`), same selection | `dd13fcf8` | `CwSidetonePortAudioSink: selected Qt output device "Built-in Audio Digital Stereo (HDMI)" partially matched PortAudio output "hdmi" by name substring` → `matched selected Qt output "Built-in Audio Digital Stereo (HDMI)" to PortAudio output hdmi` → `started device= hdmi rate= 48000 Hz` → summary `backend="PortAudio" device="hdmi" rate=48000Hz path=pull` / `fallback=no` |

The candidate list in the fixed arm's warning shows the bare ALSA `hdmi` plugin present and available to be matched — the exact name the old bidirectional substring rule accepts — and the new classifier refuses it, lands on the documented QAudioSink fallback, and names the device the user picked with `fallback=yes`.

Complete unedited logs for both arms (plus the first-launch default-path log) with provenance README:

[aethersdr-pr5135-linux-hdmi-c5-2026-08-24.zip](https://github.com/user-attachments/files/31363303/aethersdr-pr5135-linux-hdmi-c5-2026-08-24.zip)

**macOS regression** via the agent automation bridge, Demo radio (no RF); `980a25aa` rows from the bridge log ring, `f01e88ed` rows from the app's own log files (2026-08-27 0609Z–0611Z, store row written with the app closed, restored after). On this machine every PortAudio name equals its Qt description, so the explicit arm takes the `Exact` early return; the partial-match branch and its reporting are covered by the unit test and the code in `start()`, not by a live observation on any platform.

| arm | build | store `AudioOutputDeviceId` | reading |
|---|---|---|---|
| default | `980a25aa` | *(empty)* | `started device= MacBook Pro Speakers rate= 48000 Hz`; summary `path=pull fallback=no`; no match line |
| explicit, exact name | `980a25aa` | `BuiltInSpeakerDevice` | `matched selected Qt output "MacBook Pro Speakers" to PortAudio output MacBook Pro Speakers`; `started device= MacBook Pro Speakers`; summary `fallback=no` |
| default | `f01e88ed` | *(empty)* | `23:09:44.216 started device= MacBook Pro Speakers rate= 48000 Hz outputLatency= 10.3958 ms`; summary `backend="PortAudio" device="MacBook Pro Speakers" rate=48000Hz path=pull` / `fallback=no`; no match line |
| explicit, exact name | `f01e88ed` | `BuiltInSpeakerDevice` | `23:10:59.341 matched selected Qt output "MacBook Pro Speakers" to PortAudio output MacBook Pro Speakers`; `started device= MacBook Pro Speakers rate= 48000 Hz`; summary `fallback=no` |

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls — **n/a**
- [x] Code is clean-room
- [x] All meter UI uses `MeterSmoother` — **n/a**
- [x] Documentation updated if user-visible behavior changed — **n/a**, log/summary text only
- [x] Security-sensitive changes reference a GHSA — **n/a**

— authored by agent (Claude Code) on behalf of @skerker
