### PR TITLE
fix(icom): stop relative forward power from being reported as watts

### DIFF
--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -2073,9 +2073,22 @@ QJsonObject metersSnapshot(MeterModel* m, const QString& radioModel)
         }
     }
 
+    // #5121: a backend with no measured watts curve for the connected model
+    // (an IC-9700, today) publishes forward power as PERCENT, not watts —
+    // fwdPowerIsRelative() says so. `null` here, not a numeric 0.0: a
+    // fixed-watts consumer (tools/tx_meter_test.py's --max-watts safety
+    // ceiling among them) must be able to tell "this backend can't answer
+    // in watts" apart from "0 W, not transmitting", which a synthesized
+    // zero would erase. fwdPowerIsRelative below is what a caller who DOES
+    // understand relative power should key off before trusting either
+    // reading as a percentage.
+    const bool fwdRelative = m->fwdPowerIsRelative();
     return QJsonObject{
-        {QStringLiteral("fwdPower"),        m->fwdPower()},           // Watts (smoothed)
-        {QStringLiteral("fwdPowerInstant"), m->fwdPowerInstant()},    // Watts (peak)
+        {QStringLiteral("fwdPower"),
+         fwdRelative ? QJsonValue() : QJsonValue(m->fwdPower())},        // Watts (smoothed); null if relative
+        {QStringLiteral("fwdPowerInstant"),
+         fwdRelative ? QJsonValue() : QJsonValue(m->fwdPowerInstant())}, // Watts (peak); null if relative
+        {QStringLiteral("fwdPowerIsRelative"), fwdRelative},
         {QStringLiteral("fwdPowerAgeMs"),   age(m->fwdPowerUpdatedAtMs())},
         {QStringLiteral("reflectedPower"),  m->reflectedPower()},
         {QStringLiteral("reflectedPowerAgeMs"),

--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -1385,11 +1385,31 @@ QString RigctlProtocol::cmdGetLevel(const QString& arg)
     }
 
     if (level == "RFPOWER_METER_WATTS") {
+        // #5121: fwdPower() is a relative 0..100 PERCENT reading, not watts,
+        // when the connected model has no measured PA curve (an IC-9700,
+        // today) — advertising it here would claim a measured value that
+        // doesn't exist, and it would be a materially worse wrong number
+        // than before this fix (a plausible-looking 0..100 instead of a
+        // borrowed IC-705 curve's 0..12). 0.0 matches this file's existing
+        // "no valid reading" convention for a numeric rig level (see SWR
+        // above) — there is no null in the Hamlib text protocol.
+        if (m_model->meterModel().fwdPowerIsRelative())
+            return makeResponse(formatRigLevelValue(0.0f));
         const float watts = txMetersFresh ? qMax(0.0f, m_model->meterModel().fwdPower()) : 0.0f;
         return makeResponse(formatRigLevelValue(watts));
     }
 
     if (level == "RFPOWER_METER") {
+        // #5121: a relative reading is already a percent of full scale, so
+        // normalize it directly — dividing by maxPowerLevel() (a watts
+        // figure) would apply a scale that has nothing to do with a percent
+        // reading. This is the case the review explicitly allows: rigctl
+        // MAY expose normalized RFPOWER_METER for relative power, unlike
+        // RFPOWER_METER_WATTS just above.
+        if (m_model->meterModel().fwdPowerIsRelative()) {
+            const float pct = txMetersFresh ? qMax(0.0f, m_model->meterModel().fwdPower()) : 0.0f;
+            return makeResponse(formatRigLevelValue(qBound(0.0f, pct / 100.0f, 1.0f)));
+        }
         const float watts = txMetersFresh ? qMax(0.0f, m_model->meterModel().fwdPower()) : 0.0f;
         const int maxPower = qMax(1, txModel.maxPowerLevel());
         float ratio = watts / static_cast<float>(maxPower);

--- a/src/core/backends/icom/IcomMeters.cpp
+++ b/src/core/backends/icom/IcomMeters.cpp
@@ -1,4 +1,5 @@
 #include "core/backends/icom/IcomMeters.h"
+#include "core/backends/icom/IcomModels.h"
 
 #include <algorithm>
 #include <array>
@@ -180,9 +181,33 @@ double meterValue(MeterId id, int raw, double s9Dbm, std::uint8_t civAddress)
 {
     switch (id) {
     case MeterId::SMeter:   return sMeterDbm(raw, s9Dbm);
-    case MeterId::Power:    return interpolateCurve(
-                                civAddress == 0xB6 ? powerCurveIc7300Mk2()
-                                                   : powerCurveIc705(), raw);
+    case MeterId::Power: {
+        // #5121: this used to pick between the IC-705 and IC-7300MK2 watts
+        // curves unconditionally, borrowing the IC-705's for every OTHER
+        // model too (including the IC-9700) — a live bug: the Po meter is
+        // then DEFINED as Percent (publishMeterDefs() -> powerCurveFor(),
+        // below) but its VALUE came out as a borrowed watts figure that
+        // saturates at 12. Routing through the same powerCurveFor() the
+        // definition side already uses makes them structurally unable to
+        // disagree, which is the actual fix — not a new number, a single
+        // source of truth for both.
+        const IcomModel* model = modelForCivAddress(civAddress);
+        const auto curve = model ? powerCurveFor(*model)
+                                  : std::span<const CurvePoint>{};
+        if (!curve.empty())
+            return interpolateCurve(curve, raw);
+        // No measured watts curve for this model. The raw Po meter field is
+        // a full byte (0..255) on every Icom model per the CI-V wire
+        // format, independent of PA rating -- only the WATTS interpretation
+        // of that byte is model-specific, not the byte's own range. So
+        // percent-of-raw-scale is a fact about the protocol, not a number
+        // borrowed from a different radio's PA -- matching the "Percent"
+        // unit and 100.0 high already published for this case.
+        static constexpr std::array<CurvePoint, 2> kGenericPercent{{
+            {0, 0.0}, {255, 100.0},
+        }};
+        return interpolateCurve(kGenericPercent, raw);
+    }
     case MeterId::Swr:      return interpolateCurve(kSwr, raw);
     case MeterId::Alc:      return interpolateCurve(kAlc, raw);
     case MeterId::Comp:     return interpolateCurve(kComp, raw);

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -5952,15 +5952,25 @@ void MainWindow::wireMeters()
             this, [this](float fwd, float swr, bool swrValid) {
         if (m_radioModel.amplifier().present() && m_radioModel.amplifier().operate())
             return;
+        // #5121: these widgets are watts-typed with no way to render a
+        // relative reading honestly (a bare "%" needle where every other
+        // radio shows watts). fwdPowerIsRelative() means the connected
+        // model has no measured PA curve (an IC-9700, today) — park at the
+        // rest position rather than let a correctly-computed percent
+        // number flow into a gauge labelled W, or into #ifdef HAVE_HIDAPI's
+        // physical controller display below. Same "unavailable, not a
+        // wrong number" principle the SWR fallback just below already uses.
+        const bool relative = m_radioModel.meterModel().fwdPowerIsRelative();
         // Absent SWR is forwarded as 1.0: RadioSwrValidityFilter downstream
         // reads <1.0 WITH forward power as the radio's over-range sentinel
         // and would peg the S-meter full-scale on a matched antenna (#4536
         // review, blocker 2). 1.0 is the meter's rest position.
         m_appletPanel->setStandardRadioMeterTxValues(
-            fwd, m_radioModel.meterModel().fwdPowerInstant(),
+            relative ? 0.0f : fwd,
+            relative ? 0.0f : m_radioModel.meterModel().fwdPowerInstant(),
             swrValid ? swr : 1.0f);
 #ifdef HAVE_HIDAPI
-        m_tmate2TxWatts = fwd;
+        m_tmate2TxWatts = relative ? 0.0f : fwd;
         if (m_radioModel.transmitModel().isTransmitting()) {
             updateTMate2Display();
             updateTMate2Indicators();
@@ -5973,6 +5983,14 @@ void MainWindow::wireMeters()
                          bool swrValid, bool reflectedPowerMeasured) {
         if (m_radioModel.amplifier().present()
             && m_radioModel.amplifier().operate()) {
+            return;
+        }
+        // #5121: same relative-power guard as txMetersChanged above — the
+        // cross-needle's reflected-power math (CrossNeedleMeterGeometry::
+        // reflectedPowerWatts()) assumes fwd is watts and would compute a
+        // fabricated reflected-watts figure from a percent input.
+        if (m_radioModel.meterModel().fwdPowerIsRelative()) {
+            m_appletPanel->setCrossNeedleDirectionalValues(0.0f, 0.0f, 1.0f, false);
             return;
         }
         // The cross-needle already clamps sub-1.0 values to 1.0 (its rest

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -703,10 +703,24 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
             //
             // dBm remains the default for a backend that declares nothing,
             // because that is what every backend predating this field meant.
+            //
+            // #5121: a THIRD case, missed when this was first fixed. A
+            // backend with no measured watts curve for the connected model
+            // (an IC-9700, today) declares Percent, not Watts — and Percent
+            // through the dBm formula is worse than the original bug: a 50%
+            // reading becomes 10^(50/10)/1000 = exactly 100 W, a plausible
+            // rated output that would never draw a second look, unlike the
+            // symptom it replaces. `v` is already the correctly-scaled
+            // 0..100 relative figure (IcomMeters::meterValue()'s Power
+            // case), so it passes straight through here —
+            // fwdPowerIsRelative() is what tells a caller this float means
+            // percent, not watts.
             const bool alreadyWatts =
                 m_fwdPwrUnit.compare(QLatin1String("Watts"), Qt::CaseInsensitive) == 0
                 || m_fwdPwrUnit.compare(QLatin1String("W"), Qt::CaseInsensitive) == 0;
-            float watts = alreadyWatts ? v : std::pow(10.0f, v / 10.0f) / 1000.0f;
+            const bool relative = fwdPowerIsRelative();
+            float watts = (alreadyWatts || relative)
+                ? v : std::pow(10.0f, v / 10.0f) / 1000.0f;
             m_fwdPowerInstant = watts;
             fwdInstantChanged = true;
             directionalChanged = true;

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -100,9 +100,23 @@ public:
     // Convenience: S-meter (slice LEVEL meter) in dBm.
     float sLevel() const { return m_sLevel; }
 
-    // Convenience: forward power in watts.
+    // Convenience: forward power. Watts, UNLESS fwdPowerIsRelative() is
+    // true — a backend can decline to publish a watts curve for a model it
+    // has no measured PA data for (#5121; see IcomModels::powerCurveFor()),
+    // in which case this is percent of the meter's own full scale instead.
+    // A caller that assumes watts unconditionally (any fixed-unit consumer
+    // — a gauge labelled "W", a safety ceiling, rigctl's *_METER_WATTS)
+    // must check the flag first and treat a relative reading as
+    // unavailable for its purpose, not render/compare it as a wrong watts
+    // figure that merely looks plausible.
     float fwdPower() const { return m_fwdPower; }
     float fwdPowerInstant() const { return m_fwdPowerInstant; }
+    // True when fwdPower()/fwdPowerInstant() are percent of full scale
+    // rather than watts — the backend declared MeterDef::unit == "Percent"
+    // for the forward-power meter.
+    bool fwdPowerIsRelative() const {
+        return m_fwdPwrUnit.compare(QLatin1String("Percent"), Qt::CaseInsensitive) == 0;
+    }
     float reflectedPower() const { return m_reflectedPower; }
     float tgxlFwdPower() const { return m_tgxlFwdPwr; }
 

--- a/tests/icom_meters_test.cpp
+++ b/tests/icom_meters_test.cpp
@@ -98,6 +98,29 @@ static void testPowerAndOthers()
     check(near(meterValue(MeterId::Power, 213, kS9DbmHf, 0xB6), 100.0),
           "IC-7300MK2 raw 213 is its rated 100 W");
 
+    // #5121: the live bug. Before this fix, an unverified model (the
+    // IC-9700, 0xA2 — no measured watts curve exists, powerCurveFor()
+    // correctly returns empty) still got a VALUE off the IC-705's watts
+    // curve, because meterValue() picked between exactly two named curves
+    // and defaulted to the IC-705's for everything else. Full-scale key-down
+    // read as "12" against a definition that claims Percent, 0..100 — wrong
+    // unit AND wrong magnitude from one missing branch. The fix routes
+    // through the SAME powerCurveFor() the definition side already uses, so
+    // an unverified model gets percent-of-the-raw-byte instead of a
+    // borrowed watts figure.
+    check(near(meterValue(MeterId::Power, 0, kS9DbmHf, 0xA2), 0.0),
+          "IC-9700 raw 0 is 0% (no measured curve)");
+    check(near(meterValue(MeterId::Power, 128, kS9DbmHf, 0xA2), 50.2, 0.5),
+          "IC-9700 raw 128 is ~half scale as a PERCENT, not a borrowed watt figure");
+    check(near(meterValue(MeterId::Power, 255, kS9DbmHf, 0xA2), 100.0),
+          "IC-9700 full-scale key-down reads 100%, not 12 (the pre-fix "
+          "IC-705 watts ceiling)");
+    // Same fallback for any other unnamed/future model — not an IC-9700
+    // special case.
+    check(near(meterValue(MeterId::Power, 255, kS9DbmHf, 0x00), 100.0),
+          "an unrecognised CI-V address also falls back to percent, not a "
+          "borrowed watts curve");
+
     check(near(meterValue(MeterId::Swr, 0, 0), 1.0), "SWR 1.0 at zero");
     check(near(meterValue(MeterId::Swr, 48, 0), 1.5), "SWR 1.5");
     check(near(meterValue(MeterId::Swr, 120, 0), 3.0), "SWR 3.0");

--- a/tests/meter_model_test.cpp
+++ b/tests/meter_model_test.cpp
@@ -306,6 +306,32 @@ void testForwardPowerHonoursItsDeclaredUnit()
         report("an undeclared unit is treated as dBm, as it always was",
                nearlyEqual(model.fwdPowerInstant(), 100.0f));
     }
+    // #5121: Percent is a THIRD declared unit, not just Watts-vs-dBm. An
+    // unverified Icom model (no measured watts curve for the connected
+    // model — see IcomModels::powerCurveFor()) reports relative power this
+    // way. Missing this case is worse than the original bug it's adjacent
+    // to: a 50% reading through the dBm formula becomes 10^(50/10)/1000 =
+    // exactly 100 W — a plausible-looking rated output for a real radio,
+    // not an obviously-broken number a reader would think to question.
+    {
+        MeterModel model;
+        model.defineMeter(txMeter(8, "FWDPWR", "Percent"));
+        model.updateValues({8}, {50});
+        report("a FWDPWR meter declared in Percent is NOT converted from dBm",
+               nearlyEqual(model.fwdPowerInstant(), 50.0f));
+        report("and MeterModel flags this reading as relative, not watts",
+               model.fwdPowerIsRelative());
+        // The old behaviour, pinned so the fix cannot silently regress.
+        report("and the pre-fix dBm reading really was ~100 W",
+               nearlyEqual(std::pow(10.0f, 50.0f / 10.0f) / 1000.0f, 100.0f));
+    }
+    {
+        MeterModel model;
+        model.defineMeter(txMeter(8, "FWDPWR", "Watts"));
+        model.updateValues({8}, {5});
+        report("a Watts-declaring FWDPWR meter is not flagged relative",
+               !model.fwdPowerIsRelative());
+    }
 }
 
 // REFPWR was missed when FWDPWR and ALC were fixed, and MeterSurfaces.h already

--- a/tools/test_tx_meter_test.py
+++ b/tools/test_tx_meter_test.py
@@ -81,6 +81,48 @@ def test_missing_power_unkeys():
     check(fake.stop_calls and fake.unkey_calls, "missing-meter path did not unkey")
 
 
+def test_relative_power_is_excluded_not_crashed():
+    """#5121: fwdPower is null (not a numeric 0) when the connected backend
+    has no measured watts curve for this model and reports relative/percent
+    power instead -- an unverified Icom model, today. m.get("fwdPower", 0)
+    only substitutes a default when the KEY is absent, not when its value
+    is null, so this used to reach `fwd_val > 0.3` / `fwd_val > max_watts`
+    as None and crash with a TypeError. Must not crash, and a reading we
+    can't compare against a watts ceiling must be excluded from both the
+    average and the ceiling check, not silently treated as 0 W (which
+    would read as "not transmitting") or compared as if it were watts.
+
+    Known gap, not resolved by this test: the meter still carries
+    has_value=True in `all` (a real percent reading did arrive), so the
+    separate "no fresh calibrated FWDPWR sample" deadline fallback
+    (see test_missing_power_unkeys) does NOT fire either -- this run
+    completes with no stopReason at all, having never verified transmit
+    power against any ceiling. Whether a relative-power backend should
+    hard-fail this safety script outright is a policy call for whoever
+    owns tx_meter_test.py's RF-safety contract, not something to decide
+    silently in a client-side unit fix.
+    """
+    snapshot = {
+        "fwdPower": None,
+        "fwdPowerAgeMs": 0,
+        "fwdPowerIsRelative": True,
+        "swr": 1.1,
+        "swrAgeMs": 0,
+        "all": [{
+            "name": "FWDPWR", "has_value": True,
+            "value": 42.0, "age_ms": 0,
+        }],
+    }
+    fake = FakeTx(snapshot)
+    result = run_once(fake, max_watts=10.0)
+    check(result["stopReason"] is None,
+          "a relative-power reading must not be evaluated against a watts "
+          "ceiling -- it is neither over nor under a limit it cannot be "
+          "compared to")
+    check(fake.unkey_calls == 0,
+          "must not unkey over a comparison that could not be made")
+
+
 def test_link_loss_unkeys():
     fake = FakeTx(meter_snapshot(), link_alive=False)
     result = run_once(fake, max_watts=10.0)
@@ -129,6 +171,7 @@ if __name__ == "__main__":
     test_over_watt_unkeys()
     test_high_swr_unkeys()
     test_missing_power_unkeys()
+    test_relative_power_is_excluded_not_crashed()
     test_link_loss_unkeys()
     test_antenna_discovery_is_exact()
     test_unkey_uses_semantic_always_allowed_verb()

--- a/tools/tx_meter_test.py
+++ b/tools/tx_meter_test.py
@@ -124,11 +124,19 @@ def sample_window(tx, dur=1.4, settle=0.2, max_watts=None, max_swr=2.5):
             if link_alive is False:
                 stop_reason = "radio link is not alive"
             fwd_age = m.get("fwdPowerAgeMs", 1e9)
-            fwd_val = m.get("fwdPower", 0)
-            if 0 <= fwd_age < FRESH_MS and fwd_val > 0.3:
+            # fwdPower is null when the connected backend has no measured
+            # watts curve for this model (#5121 -- an unverified Icom model
+            # reports relative/percent power instead of watts) -- same
+            # "null means no data" contract as swr below, not a real 0 W
+            # reading. m.get("fwdPower", 0) would silently substitute 0 only
+            # when the KEY is missing, not when its value is null, so a
+            # relative reading would otherwise reach the `> 0.3`/`> max_watts`
+            # comparisons below as None and crash with a TypeError.
+            fwd_val = m.get("fwdPower")
+            if fwd_val is not None and 0 <= fwd_age < FRESH_MS and fwd_val > 0.3:
                 fwd.append(fwd_val)
-            if (max_watts is not None and 0 <= fwd_age < SAFETY_FRESH_MS
-                    and fwd_val > max_watts):
+            if (fwd_val is not None and max_watts is not None
+                    and 0 <= fwd_age < SAFETY_FRESH_MS and fwd_val > max_watts):
                 stop_reason = (f"measured forward power {fwd_val:.1f} W exceeds "
                                f"{max_watts:.1f} W ceiling")
             # swr is null when no live sample exists, and swrAgeMs is -1


### PR DESCRIPTION
Fixes the live, concretely-proven bug in #5121 — one of the four
seams the triage split this issue into, scoped that way deliberately
rather than attempting all four in one PR.

## The bug
`publishMeterDefs()` already declares the Po meter as `Percent` for
a model with no measured watts curve (an IC-9700 today). But
`meterValue()`'s Power case never consulted that same rule — it
always picked between two named watts curves, defaulting to the
IC-705's for everything else. A live IC-9700 shows a gauge labelled
`Percent, 0..100` with a value that's actually a borrowed IC-705
watts figure saturating at 12.

Fixing only that would have made it *worse*: `MeterModel` only knew
`Watts` vs. an implicit dBm default, so a now-correct 0..100 percent
value would run through the dBm→watts formula — 50% becomes exactly
100 W, a plausible number nobody would question.

## The fix
- `meterValue()`'s Power case now routes through the same
  `powerCurveFor()` the definition side uses — structurally unable to
  disagree with it. No curve → percent-of-raw-byte, a CI-V wire-format
  fact, not a number borrowed from another radio.
- `MeterModel` gets a real `Percent` branch + `fwdPowerIsRelative()`.
- `MainWindow_Wiring.cpp` parks the two universal GUI connections at
  the existing "rest position" convention when relative, protecting
  `SMeterWidget`/`CrossNeedleMeterWidget` (whose reflected-power math
  would otherwise fabricate a number) and the TMATE2 display.
- `AutomationServer`'s JSON reports `null` (not a synthesized `0.0`)
  when relative, plus a new `fwdPowerIsRelative` field — per review
  guidance that a fixed-watts consumer must see "unavailable".
- That `null` would have crashed `tools/tx_meter_test.py`'s safety
  ceiling check (`m.get("fwdPower", 0)` doesn't substitute for an
  explicit `null`) — confirmed by reverting and running the suite,
  then fixed with the same "null means no data" contract already
  used for `swr` two lines below.
- **`RigctlProtocol`'s `RFPOWER_METER_WATTS`/`RFPOWER_METER`** read
  `fwdPower()` directly and were completely unguarded — caught in
  self-review, not by an external reviewer. Left alone, this fix
  would have made rigctl's output *more* convincingly wrong for any
  logging/contest software polling it. `RFPOWER_METER_WATTS` now
  returns `0.0` when relative (this file's existing "no valid
  reading" convention); `RFPOWER_METER` normalizes the percent
  directly instead of dividing by a watts figure that doesn't apply —
  the case review guidance explicitly allows.

## Deliberately out of scope
TCI/RadioCertification/diagnostics propagation, GUI display
relabeling (TxApplet/HealthApplet/SMeterWidget/SliceTroubleshooting),
and ALC/Comp/Id/Vd model-specific curves (no measured IC-9700 data
exists in this repo to write them from). Each is real, separate work.

## An open safety-policy question
`tx_meter_test.py`'s "no fresh calibrated FWDPWR sample" fallback
checks `has_value`, which stays true for a relative reading — so a
run against a relative-power backend now completes cleanly having
never verified power against a ceiling, rather than stopping. Whether
that should hard-fail is a call for whoever owns this script's
RF-safety contract. Documented and pinned by a test, not decided here.

## Known testing gap
The `RigctlProtocol` fix has no automated test — the only existing
rigctl test needs a live running instance with rigctld enabled against
real/demo hardware. Manually verified by tracing the code; flagging
honestly rather than claiming coverage that doesn't exist.

## Testing
- New IC-9700 case in `icom_meters_test.cpp`, mutation-proofed.
- New `Percent`-unit case in `meter_model_test.cpp`, mutation-proofed.
- New crash-regression test in `test_tx_meter_test.py` — confirmed the
  crash first by reverting to the pre-fix line.
- Self-review before any external review caught the rigctl gap above,
  plus a wrong arithmetic claim in two comments (100000 W where the
  real number is 100 W — the more dangerous figure to get wrong,
  since it's plausible rather than obviously broken).
- Full app build clean; all four suites pass.