### PR TITLE
chore: stop tracking .mcp.json, it now carries a per-developer secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ third_party/sherpa-onnx-*.tar.bz2
 
 # macOS Finder metadata
 .DS_Store
+
+# Per-developer MCP config (aethersdr-automation bridge token). Copy
+# .mcp.json.example to .mcp.json and fill in the token from Radio Setup →
+# Network → Access Token; never commit the real one.
+.mcp.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "aethersdr-automation": {
-      "command": "python3",
-      "args": ["tools/aether_mcp.py"]
-    }
-  }
-}

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "aethersdr-automation": {
+      "command": "python3",
+      "args": ["tools/aether_mcp.py"],
+      "env": {
+        "AETHER_MCP_TOKEN": "paste-your-token-from-Radio-Setup-Network-Access-Token-here"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`.mcp.json` (the automation-bridge config) was tracked in git. A local
edit added `AETHER_MCP_TOKEN` — a live credential used to authenticate
against the automation bridge (Radio Setup → Network → Access Token) —
directly into that tracked file. Committing it would put a real secret
into git history permanently, and the same mistake is available to any
contributor who sets up the automation bridge the same way.

Untracks `.mcp.json` (kept on disk, token intact, just no longer
git-tracked), adds it to `.gitignore`, and adds `.mcp.json.example` — a
token-free template with the same shape — so a fresh clone still knows
what to create.

Not part of #4970 — found while setting up the automation bridge for
ANAN bring-up, but applies to every contributor regardless of backend.

## Constitution principle honored

N/A — infrastructure/secrets hygiene, not a feature change.

## Test plan

- [x] `.mcp.json` no longer appears in `git status` after editing it locally
- [x] A fresh checkout still has `.mcp.json.example` to copy from
- [ ] N/A — no behavior change, nothing to build/run

## Checklist

- [x] Commits are signed
- [ ] N/A — no `AppSettings` changes
- [ ] N/A — no protocol/hardware code
- [ ] N/A — no meter UI
- [x] Documentation updated — `.gitignore` comment explains the setup step
- [x] Security-sensitive: no GHSA filed, since no secret was actually
      exposed in a pushed/public history — this is prevention, not a
      disclosed leak. Flagging here rather than silently checking it off.
