### PR TITLE
Fix macOS Ulanzi input without seizing trackpads

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -2275,19 +2275,18 @@ the radio.
 External-device diagnostics and bounded lifecycle control. `devices list`
 reports the available diagnostic names; `devices ulanzi` probes the exact
 macOS HID match used by the Ulanzi backend and joins that inventory with the
-backend's access and system-event suppression state. It never returns unrelated
-HID devices.
+backend's access and system-event suppression state. The inventory is limited
+to devices selected by the production VID/PID dictionary.
 
 ```json
 → {"cmd":"devices","action":"ulanzi"}
 ← {"ok":true,"diagnostic":"ulanzi","platform":"macos","supported":true,
    "enabled":true,
-   "expectedMatch":{"vendorId":65521,"productId":130},
-   "matchedCount":1,"expectedMatchCount":1,"unexpectedMatchCount":0,
-   "matchScopeSafe":true,
+   "productionMatch":{"vendorId":65521,"productId":130},
+   "matchedCount":1,
    "matchedDevices":[{"product":"Ulanzi Dial","vendorId":65521,
                       "productId":130,"primaryUsagePage":1,
-                      "primaryUsage":6,"expected":true}],
+                      "primaryUsage":6}],
    "inventoryAvailable":true,"accessMode":"shared",
    "exclusiveOpenStatus":"notPrivileged","sharedOpenStatus":"success",
    "systemEventsSuppressed":true,"suppressionStatus":"active",
@@ -2296,14 +2295,13 @@ HID devices.
 ```
 
 `matchedCount` is the number of devices currently inside the production match
-dictionary. `unexpectedMatchCount` must be zero before treating an exclusive
-claim as safely scoped; the Apple trackpad regression in #5126 produced
-unexpected matches here. `inventoryAvailable` describes the temporary
-read-only inventory query, while `exclusiveOpen*`, `sharedOpen*`, and
-`accessMode` describe the real backend's access attempts. If macOS rejects an
-exclusive claim for the Bluetooth keyboard-class dial, the backend opens only
-the exact matched device in shared mode and applies a device-scoped system key
-mapping. `systemEventsSuppressed` and `suppressionStatus` report that state;
+dictionary; `matchedDevices` exposes the selected devices' identity and primary
+usage for audit. `inventoryAvailable` describes the temporary read-only
+inventory query, while `exclusiveOpen*`, `sharedOpen*`, and `accessMode`
+describe the real backend's access attempts. If macOS rejects an exclusive
+claim for the Bluetooth keyboard-class dial, the backend opens only the exact
+matched device in shared mode and applies a device-scoped system key mapping.
+`systemEventsSuppressed` and `suppressionStatus` report that state;
 `previousMappingPreserved` and `eventSystemClientRetained` are the restoration
 ownership guards.
 

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -2271,6 +2271,42 @@ the default Layer-A inventory and `radio`/`inventory` reads remain available;
 tally, while `resync`/`refresh` send the `sub pan all` subscription command to
 the radio.
 
+### `devices`
+Read-only external-device diagnostics. `devices list` reports the available
+diagnostic names; `devices ulanzi` probes the exact macOS HID match used by the
+Ulanzi backend and joins that inventory with the backend's exclusive-claim
+state. It never enumerates or returns unrelated HID devices.
+
+```json
+→ {"cmd":"devices","action":"ulanzi"}
+← {"ok":true,"diagnostic":"ulanzi","platform":"macos","supported":true,
+   "enabled":true,
+   "expectedMatch":{"vendorId":65521,"productId":130},
+   "matchedCount":1,"expectedMatchCount":1,"unexpectedMatchCount":0,
+   "matchScopeSafe":true,
+   "matchedDevices":[{"product":"Ulanzi Dial","vendorId":65521,
+                      "productId":130,"primaryUsagePage":1,
+                      "primaryUsage":6,"expected":true}],
+   "inventoryAvailable":true,
+   "openAttempted":true,"lastOpenResult":0,"lastOpenStatus":"success",
+   "exclusiveClaimActive":true,"connected":true,"deviceName":"Ulanzi Dial"}
+```
+
+`matchedCount` is the number of devices currently inside the production match
+dictionary. `unexpectedMatchCount` must be zero before treating an exclusive
+claim as safely scoped; the Apple trackpad regression in #5126 produced
+unexpected matches here. `inventoryAvailable` describes the temporary
+read-only inventory query, while `lastOpen*` and `exclusiveClaimActive`
+describe the real backend's seize attempt. The inventory query does not open or
+claim any device.
+A denied Input Monitoring permission therefore reads as a populated inventory
+plus `lastOpenStatus:"notPrivileged"` and `exclusiveClaimActive:false`, rather
+than being confused with a bad match.
+
+The verb is available in **Observe only** mode and never keys the transmitter.
+On non-macOS platforms it returns `supported:false` because those backends do
+not use the affected IOKit claim path.
+
 ### `memprofile`
 Cross-platform process and subsystem memory profiling for long-running leak
 investigations. An instant snapshot combines the operating system's native
@@ -3537,7 +3573,7 @@ lands.
 The complete registry, generated from the `add(...)` table in `AutomationServer.cpp` by `tools/gen_bridge_docs.py`. CI fails if this drifts from the code.
 
 <!-- BEGIN GENERATED VERB TABLE (tools/gen_bridge_docs.py) -->
-<!-- Do not edit by hand — run tools/gen_bridge_docs.py. 67 verbs. -->
+<!-- Do not edit by hand — run tools/gen_bridge_docs.py. 68 verbs. -->
 
 | Verb | Aliases | Description |
 |---|---|---|
@@ -3586,6 +3622,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `panmessage` | — | panmessage <add\|remove\|clear\|list> <pan> [id timeout [tone=…] title\|detail] |
 | `dss` | — | dss <snapshot\|reset\|inject\|scrollback\|live> [pan] [args] |
 | `streams` | — | streams [radio\|inventory\|resync\|refresh\|reset] — stream diagnostics |
+| `devices` | — | devices <list\|ulanzi> — read-only external-device diagnostics |
 | `modem` | `aethermodem` | modem <status\|profile hf300\|profile vhf1200\|on\|off\|preamble <flags\|auto>> — AetherModem demod profile, TXDELAY, RX tap, and decoder health |
 | `link` | `ax25` | link <status\|connect <call> [via <digi>]\|disconnect\|mycall <call>\|listen <call>\|alias <call>\|pms on\|off> — connected-mode AX.25 terminal + mailbox, with measured RTT vs configured T1 |
 | `memprofile` | — | memprofile <snapshot\|start\|sample\|status\|report\|samples\|stop\|reset> [intervalMs maxSamples] |

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -2272,10 +2272,11 @@ tally, while `resync`/`refresh` send the `sub pan all` subscription command to
 the radio.
 
 ### `devices`
-Read-only external-device diagnostics. `devices list` reports the available
-diagnostic names; `devices ulanzi` probes the exact macOS HID match used by the
-Ulanzi backend and joins that inventory with the backend's exclusive-claim
-state. It never enumerates or returns unrelated HID devices.
+External-device diagnostics and bounded lifecycle control. `devices list`
+reports the available diagnostic names; `devices ulanzi` probes the exact
+macOS HID match used by the Ulanzi backend and joins that inventory with the
+backend's access and system-event suppression state. It never returns unrelated
+HID devices.
 
 ```json
 → {"cmd":"devices","action":"ulanzi"}
@@ -2287,25 +2288,34 @@ state. It never enumerates or returns unrelated HID devices.
    "matchedDevices":[{"product":"Ulanzi Dial","vendorId":65521,
                       "productId":130,"primaryUsagePage":1,
                       "primaryUsage":6,"expected":true}],
-   "inventoryAvailable":true,
-   "openAttempted":true,"lastOpenResult":0,"lastOpenStatus":"success",
-   "exclusiveClaimActive":true,"connected":true,"deviceName":"Ulanzi Dial"}
+   "inventoryAvailable":true,"accessMode":"shared",
+   "exclusiveOpenStatus":"notPrivileged","sharedOpenStatus":"success",
+   "systemEventsSuppressed":true,"suppressionStatus":"active",
+   "previousMappingPreserved":true,"eventSystemClientRetained":true,
+   "connected":true,"deviceName":"Ulanzi Dial"}
 ```
 
 `matchedCount` is the number of devices currently inside the production match
 dictionary. `unexpectedMatchCount` must be zero before treating an exclusive
 claim as safely scoped; the Apple trackpad regression in #5126 produced
 unexpected matches here. `inventoryAvailable` describes the temporary
-read-only inventory query, while `lastOpen*` and `exclusiveClaimActive`
-describe the real backend's seize attempt. The inventory query does not open or
-claim any device.
-A denied Input Monitoring permission therefore reads as a populated inventory
-plus `lastOpenStatus:"notPrivileged"` and `exclusiveClaimActive:false`, rather
-than being confused with a bad match.
+read-only inventory query, while `exclusiveOpen*`, `sharedOpen*`, and
+`accessMode` describe the real backend's access attempts. If macOS rejects an
+exclusive claim for the Bluetooth keyboard-class dial, the backend opens only
+the exact matched device in shared mode and applies a device-scoped system key
+mapping. `systemEventsSuppressed` and `suppressionStatus` report that state;
+`previousMappingPreserved` and `eventSystemClientRetained` are the restoration
+ownership guards.
 
-The verb is available in **Observe only** mode and never keys the transmitter.
-On non-macOS platforms it returns `supported:false` because those backends do
-not use the affected IOKit claim path.
+`devices ulanzi-stop` restores the prior mapping and closes the backend;
+`devices ulanzi-start` starts it again. These lifecycle actions are blocked in
+Observe only mode. A successful stop reports `restorationStatus:"success"`,
+`systemEventsSuppressed:false`, and `eventSystemClientRetained:false`.
+
+The read-only diagnostic is available in **Observe only** mode; none of these
+actions keys the transmitter. On non-macOS platforms it returns
+`supported:false` because those backends do not use the affected IOKit claim
+path.
 
 ### `memprofile`
 Cross-platform process and subsystem memory profiling for long-running leak
@@ -3622,7 +3632,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `panmessage` | — | panmessage <add\|remove\|clear\|list> <pan> [id timeout [tone=…] title\|detail] |
 | `dss` | — | dss <snapshot\|reset\|inject\|scrollback\|live> [pan] [args] |
 | `streams` | — | streams [radio\|inventory\|resync\|refresh\|reset] — stream diagnostics |
-| `devices` | — | devices <list\|ulanzi> — read-only external-device diagnostics |
+| `devices` | — | devices <list\|ulanzi\|ulanzi-start\|ulanzi-stop> — external-device diagnostics and lifecycle control |
 | `modem` | `aethermodem` | modem <status\|profile hf300\|profile vhf1200\|on\|off\|preamble <flags\|auto>> — AetherModem demod profile, TXDELAY, RX tap, and decoder health |
 | `link` | `ax25` | link <status\|connect <call> [via <digi>]\|disconnect\|mycall <call>\|listen <call>\|alias <call>\|pms on\|off> — connected-mode AX.25 terminal + mailbox, with measured RTT vs configured T1 |
 | `memprofile` | — | memprofile <snapshot\|start\|sample\|status\|report\|samples\|stop\|reset> [intervalMs maxSamples] |

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -2559,7 +2559,7 @@ bool isReadOnlyRequest(const QString& name, const QString& action)
         QStringLiteral("grab"),     QStringLiteral("get"),
         QStringLiteral("floors"),   QStringLiteral("hitTest"),
         // Reads backend telemetry; keys nothing and sets nothing.
-        QStringLiteral("health"),
+        QStringLiteral("health"),   QStringLiteral("devices"),
     };
     if (kSafe.contains(name)) {
         return true;
@@ -3237,6 +3237,13 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
             parseActionOnly,
             [](AutomationServer& s, A& a, QLocalSocket*) {
                 return s.doStreams(a.action);
+            });
+
+        add("devices", {},
+            "devices <list|ulanzi> — read-only external-device diagnostics",
+            parseActionOnly,
+            [](AutomationServer& s, A& a, QLocalSocket*) {
+                return s.doDeviceDiagnostics(a.action);
             });
 
         add("modem", {"aethermodem"},
@@ -11242,6 +11249,27 @@ QJsonObject AutomationServer::doWhoami() const
         {QStringLiteral("readOnly"), m_readOnly},
         {QStringLiteral("version"), QCoreApplication::applicationVersion()},
     };
+}
+
+QJsonObject AutomationServer::doDeviceDiagnostics(const QString& action) const
+{
+    const QString normalized = action.trimmed().toLower();
+    if (normalized.isEmpty() || normalized == QLatin1String("list")) {
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("diagnostics"),
+             QJsonArray{QStringLiteral("ulanzi")}},
+            {QStringLiteral("providerAvailable"),
+             static_cast<bool>(m_deviceDiagnosticsHandler)},
+        };
+    }
+    if (normalized != QLatin1String("ulanzi")) {
+        return err(QStringLiteral("devices requires list|ulanzi"));
+    }
+    if (!m_deviceDiagnosticsHandler) {
+        return err(QStringLiteral("Ulanzi device diagnostics unavailable"));
+    }
+    return m_deviceDiagnosticsHandler(normalized);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -3240,7 +3240,7 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
             });
 
         add("devices", {},
-            "devices <list|ulanzi> — read-only external-device diagnostics",
+            "devices <list|ulanzi|ulanzi-start|ulanzi-stop> — external-device diagnostics and lifecycle control",
             parseActionOnly,
             [](AutomationServer& s, A& a, QLocalSocket*) {
                 return s.doDeviceDiagnostics(a.action);
@@ -11263,11 +11263,17 @@ QJsonObject AutomationServer::doDeviceDiagnostics(const QString& action) const
              static_cast<bool>(m_deviceDiagnosticsHandler)},
         };
     }
-    if (normalized != QLatin1String("ulanzi")) {
-        return err(QStringLiteral("devices requires list|ulanzi"));
+    const bool lifecycle = normalized == QLatin1String("ulanzi-start")
+        || normalized == QLatin1String("ulanzi-stop");
+    if (normalized != QLatin1String("ulanzi") && !lifecycle) {
+        return err(QStringLiteral(
+            "devices requires list|ulanzi|ulanzi-start|ulanzi-stop"));
     }
     if (!m_deviceDiagnosticsHandler) {
         return err(QStringLiteral("Ulanzi device diagnostics unavailable"));
+    }
+    if (lifecycle && m_readOnly) {
+        return err(QStringLiteral("device lifecycle control is unavailable in read-only mode"));
     }
     return m_deviceDiagnosticsHandler(normalized);
 }

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -332,6 +332,11 @@ public:
     {
         m_tciRouteSnapshotHandler = std::move(handler);
     }
+    void setDeviceDiagnosticsHandler(
+        std::function<QJsonObject(const QString&)> handler)
+    {
+        m_deviceDiagnosticsHandler = std::move(handler);
+    }
 
     // Shared-secret auth (#3646). When set to a non-empty token, every verb
     // except `ping` must carry a matching `token` field or it's rejected —
@@ -392,6 +397,7 @@ private:
     static QString verbNamesJoined();
 
     QJsonObject doDumpTree() const;
+    QJsonObject doDeviceDiagnostics(const QString& action) const;
     QJsonObject doFloors() const;
     QJsonObject doGrab(const QString& target, const QString& path) const;
     // grab pan <index> [path]: capture the raw SpectrumWidget framebuffer for a
@@ -763,6 +769,7 @@ private:
     std::function<QJsonObject()> m_kiwiSdrSnapshotHandler;
     std::function<QJsonObject()> m_txTimerSnapshotHandler;
     std::function<QJsonObject()> m_tciRouteSnapshotHandler;
+    std::function<QJsonObject(const QString&)> m_deviceDiagnosticsHandler;
     QJsonObject m_lastWaveformCommand;
 
     // Agent station identity (#3646). The bridge sets the per-GUI-client station

--- a/src/core/UlanziDialMacOSManager.cpp
+++ b/src/core/UlanziDialMacOSManager.cpp
@@ -43,16 +43,23 @@ int hidKbdToLinuxKey(int usage)
     }
 }
 
-// Build a matching dictionary so IOHIDManager only surfaces our dial,
-// not every keyboard on the machine.  Match by product-name substring
-// "Ulanzi Dial".
+// Build a matching dictionary so IOHIDManager only surfaces the Ulanzi Dial,
+// not unrelated Apple HID devices. Product-only matching was not sufficiently
+// specific for an exclusive claim on macOS 26 (#5126), so use the dial's
+// observed numeric vendor and product identifiers.
 CFMutableDictionaryRef makeMatchDict()
 {
     CFMutableDictionaryRef d = CFDictionaryCreateMutable(
         kCFAllocatorDefault, 0,
         &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-    CFStringRef product = CFSTR("Ulanzi Dial");
-    CFDictionarySetValue(d, CFSTR(kIOHIDProductKey), product);
+    constexpr int kVendorId = 0xFFF1;
+    constexpr int kProductId = 0x0082;
+    CFNumberRef vendor = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &kVendorId);
+    CFNumberRef product = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &kProductId);
+    CFDictionarySetValue(d, CFSTR(kIOHIDVendorIDKey), vendor);
+    CFDictionarySetValue(d, CFSTR(kIOHIDProductIDKey), product);
+    CFRelease(vendor);
+    CFRelease(product);
     return d;
 }
 
@@ -68,7 +75,10 @@ void UlanziDialMacOSManager::start()
     if (m_manager) return;
     IOHIDManagerRef mgr = IOHIDManagerCreate(kCFAllocatorDefault,
                                              kIOHIDOptionsTypeNone);
-    m_manager = mgr;
+    if (!mgr) {
+        qCWarning(lcDevices) << "UlanziDialMacOSManager: failed to create HID manager";
+        return;
+    }
 
     CFMutableDictionaryRef match = makeMatchDict();
     IOHIDManagerSetDeviceMatching(mgr, match);
@@ -83,9 +93,18 @@ void UlanziDialMacOSManager::start()
 
     IOHIDManagerScheduleWithRunLoop(mgr, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
 
-    // Open with seize-device so the dial's events stop reaching the
+    // Seize only the numerically matched dial so its events stop reaching the
     // OS keyboard stack — the macOS equivalent of Linux EVIOCGRAB.
-    IOHIDManagerOpen(mgr, kIOHIDOptionsTypeSeizeDevice);
+    const IOReturn result = IOHIDManagerOpen(mgr, kIOHIDOptionsTypeSeizeDevice);
+    if (result != kIOReturnSuccess) {
+        qCWarning(lcDevices)
+            << "UlanziDialMacOSManager: failed to open HID manager" << result;
+        IOHIDManagerClose(mgr, kIOHIDOptionsTypeNone);
+        IOHIDManagerUnscheduleFromRunLoop(mgr, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+        CFRelease(mgr);
+        return;
+    }
+    m_manager = mgr;
 }
 
 void UlanziDialMacOSManager::stop()

--- a/src/core/UlanziDialMacOSManager.cpp
+++ b/src/core/UlanziDialMacOSManager.cpp
@@ -13,6 +13,10 @@
 #include <IOKit/hid/IOHIDKeys.h>
 #include <IOKit/hid/IOHIDValue.h>
 #include <IOKit/hid/IOHIDElement.h>
+#include <IOKit/hid/IOHIDProperties.h>
+#include <IOKit/hidsystem/IOHIDEventSystemClient.h>
+#include <IOKit/hidsystem/IOHIDParameter.h>
+#include <IOKit/hidsystem/IOHIDServiceClient.h>
 
 #include <vector>
 
@@ -22,6 +26,32 @@ namespace {
 
 constexpr int kUlanziVendorId = 0xFFF1;
 constexpr int kUlanziProductId = 0x0082;
+
+struct HidUsage {
+    uint32_t page;
+    uint32_t usage;
+};
+
+constexpr HidUsage kSuppressedUsages[] = {
+    {0x0C, 0xCD}, {0x0C, 0xE2}, {0x0C, 0xB5}, {0x0C, 0xB6},
+    {0x0C, 0xE9}, {0x0C, 0xEA}, {0x07, 0x06}, {0x07, 0x19},
+    {0x07, 0x1C}, {0x07, 0x1D}, {0x07, 0xE0}, {0x07, 0xE4},
+};
+
+quint64 usageCode(uint32_t page, uint32_t usage)
+{
+    return (static_cast<quint64>(page) << 32) | usage;
+}
+
+bool isSuppressedUsage(quint64 code)
+{
+    for (const HidUsage& usage : kSuppressedUsages) {
+        if (code == usageCode(usage.page, usage.usage)) {
+            return true;
+        }
+    }
+    return false;
+}
 
 int hidConsumerToLinuxKey(int usage)
 {
@@ -80,6 +110,73 @@ qint64 deviceNumber(IOHIDDeviceRef device, CFStringRef key)
     return value;
 }
 
+qint64 serviceNumber(IOHIDServiceClientRef service, CFStringRef key)
+{
+    CFTypeRef property = IOHIDServiceClientCopyProperty(service, key);
+    if (!property || CFGetTypeID(property) != CFNumberGetTypeID()) {
+        if (property) {
+            CFRelease(property);
+        }
+        return -1;
+    }
+    qint64 value = -1;
+    CFNumberGetValue(static_cast<CFNumberRef>(property), kCFNumberSInt64Type, &value);
+    CFRelease(property);
+    return value;
+}
+
+CFMutableArrayRef makeSuppressionMapping(CFTypeRef previous)
+{
+    if (previous && CFGetTypeID(previous) != CFArrayGetTypeID()) {
+        return nullptr;
+    }
+
+    CFMutableArrayRef mapping = CFArrayCreateMutable(
+        kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+    if (previous) {
+        const CFArrayRef previousArray = static_cast<CFArrayRef>(previous);
+        const CFIndex count = CFArrayGetCount(previousArray);
+        for (CFIndex index = 0; index < count; ++index) {
+            const CFTypeRef entry = static_cast<CFTypeRef>(CFArrayGetValueAtIndex(previousArray, index));
+            bool replace = false;
+            if (CFGetTypeID(entry) == CFDictionaryGetTypeID()) {
+                const CFTypeRef source = static_cast<CFTypeRef>(CFDictionaryGetValue(
+                    static_cast<CFDictionaryRef>(entry), CFSTR(kIOHIDKeyboardModifierMappingSrcKey)));
+                if (source && CFGetTypeID(source) == CFNumberGetTypeID()) {
+                    quint64 sourceCode = 0;
+                    CFNumberGetValue(static_cast<CFNumberRef>(source),
+                                     kCFNumberSInt64Type, &sourceCode);
+                    replace = isSuppressedUsage(sourceCode);
+                }
+            }
+            if (!replace) {
+                CFArrayAppendValue(mapping, entry);
+            }
+        }
+    }
+
+    for (const HidUsage& usage : kSuppressedUsages) {
+        const quint64 sourceCode = usageCode(usage.page, usage.usage);
+        // Keyboard usage 0 is reserved and produces no system event. The raw
+        // IOHIDManager value callback still receives the original usage.
+        const quint64 destinationCode = usageCode(0x07, 0x00);
+        CFNumberRef source = CFNumberCreate(
+            kCFAllocatorDefault, kCFNumberSInt64Type, &sourceCode);
+        CFNumberRef destination = CFNumberCreate(
+            kCFAllocatorDefault, kCFNumberSInt64Type, &destinationCode);
+        CFMutableDictionaryRef entry = CFDictionaryCreateMutable(
+            kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks,
+            &kCFTypeDictionaryValueCallBacks);
+        CFDictionarySetValue(entry, CFSTR(kIOHIDKeyboardModifierMappingSrcKey), source);
+        CFDictionarySetValue(entry, CFSTR(kIOHIDKeyboardModifierMappingDstKey), destination);
+        CFArrayAppendValue(mapping, entry);
+        CFRelease(entry);
+        CFRelease(destination);
+        CFRelease(source);
+    }
+    return mapping;
+}
+
 QString deviceString(IOHIDDeviceRef device, CFStringRef key)
 {
     CFTypeRef property = IOHIDDeviceGetProperty(device, key);
@@ -119,45 +216,307 @@ QString openResultName(bool attempted, qint32 result)
 UlanziDialMacOSManager::UlanziDialMacOSManager(QObject* parent)
     : QObject(parent) {}
 
-UlanziDialMacOSManager::~UlanziDialMacOSManager() { stop(); }
+UlanziDialMacOSManager::~UlanziDialMacOSManager()
+{
+    stop();
+    // A failed property write retains the service and original mapping so
+    // teardown can retry. If all attempts fail, tell the operator exactly how
+    // to recover; the event-system mapping otherwise lasts until reconnect.
+    for (int attempt = 0; attempt < 2 && m_suppressedService; ++attempt) {
+        restoreSystemEventSuppression();
+    }
+    if (m_suppressedService) {
+        qCWarning(lcDevices)
+            << "UlanziDialMacOSManager: prior key mapping could not be restored;"
+               " reconnect the Ulanzi Dial to clear the temporary suppression";
+    }
+    discardSystemEventSuppression();
+}
 
 void UlanziDialMacOSManager::start()
 {
     if (m_manager) return;
-    IOHIDManagerRef mgr = IOHIDManagerCreate(kCFAllocatorDefault,
-                                             kIOHIDOptionsTypeNone);
+    if (m_suppressedService) {
+        restoreSystemEventSuppression();
+        if (m_suppressedService) {
+            qCWarning(lcDevices)
+                << "UlanziDialMacOSManager: cannot restart before restoring the prior key mapping";
+            return;
+        }
+    }
+    m_accessMode = AccessMode::None;
+    m_openAttempted = false;
+    m_lastOpenResult = 0;
+    m_exclusiveOpenResult = 0;
+    m_sharedOpenAttempted = false;
+    m_sharedOpenResult = 0;
+    m_systemEventsSuppressed = false;
+    m_previousMappingPreserved = false;
+    m_suppressionStatus = QStringLiteral("notNeeded");
+    m_restorationStatus = QStringLiteral("notNeeded");
+
+    const auto createManager = [this]() -> IOHIDManagerRef {
+        IOHIDManagerRef manager = IOHIDManagerCreate(kCFAllocatorDefault,
+                                                     kIOHIDOptionsTypeNone);
+        if (!manager) {
+            qCWarning(lcDevices) << "UlanziDialMacOSManager: failed to create HID manager";
+            return nullptr;
+        }
+
+        CFMutableDictionaryRef match = makeMatchDict();
+        IOHIDManagerSetDeviceMatching(manager, match);
+        CFRelease(match);
+
+        IOHIDManagerRegisterDeviceMatchingCallback(manager,
+            reinterpret_cast<IOHIDDeviceCallback>(&UlanziDialMacOSManager::devMatchedCb), this);
+        IOHIDManagerRegisterDeviceRemovalCallback(manager,
+            reinterpret_cast<IOHIDDeviceCallback>(&UlanziDialMacOSManager::devRemovedCb), this);
+        IOHIDManagerRegisterInputValueCallback(manager,
+            reinterpret_cast<IOHIDValueCallback>(&UlanziDialMacOSManager::hidValueCb), this);
+        IOHIDManagerScheduleWithRunLoop(manager, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+        return manager;
+    };
+
+    IOHIDManagerRef mgr = createManager();
     if (!mgr) {
-        qCWarning(lcDevices) << "UlanziDialMacOSManager: failed to create HID manager";
         return;
     }
-
-    CFMutableDictionaryRef match = makeMatchDict();
-    IOHIDManagerSetDeviceMatching(mgr, match);
-    CFRelease(match);
-
-    IOHIDManagerRegisterDeviceMatchingCallback(mgr,
-        reinterpret_cast<IOHIDDeviceCallback>(&UlanziDialMacOSManager::devMatchedCb), this);
-    IOHIDManagerRegisterDeviceRemovalCallback(mgr,
-        reinterpret_cast<IOHIDDeviceCallback>(&UlanziDialMacOSManager::devRemovedCb), this);
-    IOHIDManagerRegisterInputValueCallback(mgr,
-        reinterpret_cast<IOHIDValueCallback>(&UlanziDialMacOSManager::hidValueCb), this);
-
-    IOHIDManagerScheduleWithRunLoop(mgr, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
 
     // Seize only the numerically matched dial so its events stop reaching the
     // OS keyboard stack — the macOS equivalent of Linux EVIOCGRAB.
     const IOReturn result = IOHIDManagerOpen(mgr, kIOHIDOptionsTypeSeizeDevice);
     m_openAttempted = true;
+    m_exclusiveOpenResult = static_cast<qint32>(result);
     m_lastOpenResult = static_cast<qint32>(result);
-    if (result != kIOReturnSuccess) {
+    if (result == kIOReturnSuccess) {
+        m_manager = mgr;
+        m_accessMode = AccessMode::Exclusive;
+        return;
+    }
+
+    IOHIDManagerClose(mgr, kIOHIDOptionsTypeNone);
+    IOHIDManagerUnscheduleFromRunLoop(mgr, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+    CFRelease(mgr);
+
+    if (result != kIOReturnNotPrivileged) {
         qCWarning(lcDevices)
-            << "UlanziDialMacOSManager: failed to open HID manager" << result;
+            << "UlanziDialMacOSManager: failed to exclusively open HID manager" << result;
+        return;
+    }
+
+    qCWarning(lcDevices)
+        << "UlanziDialMacOSManager: exclusive HID access denied; opening shared";
+    mgr = createManager();
+    if (!mgr) {
+        return;
+    }
+
+    const IOReturn sharedResult = IOHIDManagerOpen(mgr, kIOHIDOptionsTypeNone);
+    m_sharedOpenAttempted = true;
+    m_sharedOpenResult = static_cast<qint32>(sharedResult);
+    m_lastOpenResult = static_cast<qint32>(sharedResult);
+    if (sharedResult != kIOReturnSuccess) {
+        qCWarning(lcDevices)
+            << "UlanziDialMacOSManager: failed to open HID manager in shared mode" << sharedResult;
         IOHIDManagerClose(mgr, kIOHIDOptionsTypeNone);
         IOHIDManagerUnscheduleFromRunLoop(mgr, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
         CFRelease(mgr);
         return;
     }
+
     m_manager = mgr;
+    m_accessMode = AccessMode::Shared;
+    if (m_anyOpen) {
+        applySystemEventSuppression();
+    }
+}
+
+QString UlanziDialMacOSManager::accessModeName() const
+{
+    switch (m_accessMode) {
+        case AccessMode::Exclusive:
+            return QStringLiteral("exclusive");
+        case AccessMode::Shared:
+            return QStringLiteral("shared");
+        case AccessMode::None:
+            return QStringLiteral("none");
+    }
+    return QStringLiteral("none");
+}
+
+void UlanziDialMacOSManager::applySystemEventSuppression()
+{
+    if (m_accessMode != AccessMode::Shared || m_systemEventsSuppressed) {
+        return;
+    }
+
+    m_suppressionStatus = QStringLiteral("serviceUnavailable");
+    m_restorationStatus = QStringLiteral("notAttempted");
+
+    IOHIDEventSystemClientRef client =
+        IOHIDEventSystemClientCreateSimpleClient(kCFAllocatorDefault);
+    if (!client) {
+        qCWarning(lcDevices)
+            << "UlanziDialMacOSManager: failed to create HID event-system client";
+        return;
+    }
+
+    CFArrayRef services = IOHIDEventSystemClientCopyServices(client);
+    IOHIDServiceClientRef matchedService = nullptr;
+    int matchedCount = 0;
+    if (services) {
+        const CFIndex count = CFArrayGetCount(services);
+        for (CFIndex index = 0; index < count; ++index) {
+            IOHIDServiceClientRef service = static_cast<IOHIDServiceClientRef>(
+                const_cast<void*>(CFArrayGetValueAtIndex(services, index)));
+            if (serviceNumber(service, CFSTR(kIOHIDVendorIDKey)) == kUlanziVendorId
+                && serviceNumber(service, CFSTR(kIOHIDProductIDKey)) == kUlanziProductId) {
+                matchedService = service;
+                ++matchedCount;
+            }
+        }
+    }
+
+    if (matchedCount != 1 || !matchedService) {
+        m_suppressionStatus = matchedCount > 1
+            ? QStringLiteral("ambiguousServices")
+            : QStringLiteral("serviceUnavailable");
+        qCWarning(lcDevices)
+            << "UlanziDialMacOSManager: expected one Ulanzi HID event service, found"
+            << matchedCount;
+        if (services) {
+            CFRelease(services);
+        }
+        CFRelease(client);
+        return;
+    }
+
+    CFTypeRef previous = IOHIDServiceClientCopyProperty(
+        matchedService, CFSTR(kIOHIDUserKeyUsageMapKey));
+    CFMutableArrayRef mapping = makeSuppressionMapping(previous);
+    if (!mapping) {
+        m_suppressionStatus = QStringLiteral("unsupportedPreviousMapping");
+        qCWarning(lcDevices)
+            << "UlanziDialMacOSManager: existing Ulanzi key mapping has an unsupported type";
+        if (previous) {
+            CFRelease(previous);
+        }
+        CFRelease(services);
+        CFRelease(client);
+        return;
+    }
+
+    // IOHIDServiceClient may return a cached property-list object whose
+    // contents change when the service property is replaced. Preserve an
+    // immutable value snapshot, not the live object, for later restoration.
+    CFPropertyListRef previousSnapshot = nullptr;
+    if (previous) {
+        previousSnapshot = CFPropertyListCreateDeepCopy(
+            kCFAllocatorDefault, previous, kCFPropertyListImmutable);
+        CFRelease(previous);
+        previous = nullptr;
+        if (!previousSnapshot) {
+            CFRelease(mapping);
+            m_suppressionStatus = QStringLiteral("snapshotFailed");
+            qCWarning(lcDevices)
+                << "UlanziDialMacOSManager: failed to snapshot the prior key mapping";
+            CFRelease(services);
+            CFRelease(client);
+            return;
+        }
+    }
+
+    const bool applied = IOHIDServiceClientSetProperty(
+        matchedService, CFSTR(kIOHIDUserKeyUsageMapKey), mapping);
+    CFRelease(mapping);
+    if (!applied) {
+        m_suppressionStatus = QStringLiteral("setFailed");
+        qCWarning(lcDevices)
+            << "UlanziDialMacOSManager: failed to suppress Ulanzi system key events";
+        if (previousSnapshot) {
+            CFRelease(previousSnapshot);
+        }
+        CFRelease(services);
+        CFRelease(client);
+        return;
+    }
+
+    m_suppressedService = matchedService;
+    CFRetain(static_cast<CFTypeRef>(m_suppressedService));
+    // IOHIDServiceClient is owned by its event-system client. Retaining only
+    // the service leaves its internal client lock dangling and crashes a later
+    // restore write. Keep the create reference until restoration/disconnect.
+    m_eventSystemClient = client;
+    m_previousUserKeyMapping = const_cast<void*>(previousSnapshot);
+    m_previousMappingPreserved = true;
+    m_systemEventsSuppressed = true;
+    m_suppressionStatus = QStringLiteral("active");
+
+    CFRelease(services);
+}
+
+void UlanziDialMacOSManager::restoreSystemEventSuppression()
+{
+    if (!m_suppressedService) {
+        return;
+    }
+
+    CFArrayRef emptyMapping = nullptr;
+    CFTypeRef restoreValue = static_cast<CFTypeRef>(m_previousUserKeyMapping);
+    if (!restoreValue) {
+        emptyMapping = CFArrayCreate(
+            kCFAllocatorDefault, nullptr, 0, &kCFTypeArrayCallBacks);
+        restoreValue = emptyMapping;
+    }
+
+    const bool restored = IOHIDServiceClientSetProperty(
+        static_cast<IOHIDServiceClientRef>(m_suppressedService),
+        CFSTR(kIOHIDUserKeyUsageMapKey), restoreValue);
+    if (emptyMapping) {
+        CFRelease(emptyMapping);
+    }
+    if (!restored) {
+        qCWarning(lcDevices)
+            << "UlanziDialMacOSManager: failed to restore the prior Ulanzi key mapping";
+    }
+    m_restorationStatus = restored ? QStringLiteral("success")
+                                   : QStringLiteral("failed");
+    m_systemEventsSuppressed = !restored;
+    m_suppressionStatus = restored ? QStringLiteral("restored")
+                                   : QStringLiteral("restoreFailed");
+    if (!restored) {
+        return;
+    }
+
+    if (m_previousUserKeyMapping) {
+        CFRelease(static_cast<CFTypeRef>(m_previousUserKeyMapping));
+        m_previousUserKeyMapping = nullptr;
+    }
+    CFRelease(static_cast<CFTypeRef>(m_suppressedService));
+    m_suppressedService = nullptr;
+    CFRelease(static_cast<CFTypeRef>(m_eventSystemClient));
+    m_eventSystemClient = nullptr;
+    m_previousMappingPreserved = false;
+}
+
+void UlanziDialMacOSManager::discardSystemEventSuppression()
+{
+    if (m_previousUserKeyMapping) {
+        CFRelease(static_cast<CFTypeRef>(m_previousUserKeyMapping));
+        m_previousUserKeyMapping = nullptr;
+    }
+    if (m_suppressedService) {
+        CFRelease(static_cast<CFTypeRef>(m_suppressedService));
+        m_suppressedService = nullptr;
+    }
+    if (m_eventSystemClient) {
+        CFRelease(static_cast<CFTypeRef>(m_eventSystemClient));
+        m_eventSystemClient = nullptr;
+    }
+    m_previousMappingPreserved = false;
+    m_systemEventsSuppressed = false;
+    m_suppressionStatus = QStringLiteral("deviceRemoved");
+    m_restorationStatus = QStringLiteral("notNeeded");
 }
 
 QJsonObject UlanziDialMacOSManager::diagnostics() const
@@ -222,24 +581,39 @@ QJsonObject UlanziDialMacOSManager::diagnostics() const
         {QStringLiteral("matchScopeSafe"), unexpectedMatchCount == 0},
         {QStringLiteral("matchedDevices"), devices},
         {QStringLiteral("inventoryAvailable"), inventoryAvailable},
-        {QStringLiteral("exclusiveClaimActive"), m_manager != nullptr},
+        {QStringLiteral("accessMode"), accessModeName()},
+        {QStringLiteral("exclusiveClaimActive"), m_accessMode == AccessMode::Exclusive},
         {QStringLiteral("connected"), m_anyOpen},
         {QStringLiteral("deviceName"), m_deviceName},
         {QStringLiteral("openAttempted"), m_openAttempted},
         {QStringLiteral("lastOpenResult"), m_lastOpenResult},
         {QStringLiteral("lastOpenStatus"),
          openResultName(m_openAttempted, m_lastOpenResult)},
+        {QStringLiteral("exclusiveOpenResult"), m_exclusiveOpenResult},
+        {QStringLiteral("exclusiveOpenStatus"),
+         openResultName(m_openAttempted, m_exclusiveOpenResult)},
+        {QStringLiteral("sharedOpenAttempted"), m_sharedOpenAttempted},
+        {QStringLiteral("sharedOpenResult"), m_sharedOpenResult},
+        {QStringLiteral("sharedOpenStatus"),
+         openResultName(m_sharedOpenAttempted, m_sharedOpenResult)},
+        {QStringLiteral("systemEventsSuppressed"), m_systemEventsSuppressed},
+        {QStringLiteral("suppressionStatus"), m_suppressionStatus},
+        {QStringLiteral("previousMappingPreserved"), m_previousMappingPreserved},
+        {QStringLiteral("restorationStatus"), m_restorationStatus},
+        {QStringLiteral("eventSystemClientRetained"), m_eventSystemClient != nullptr},
     };
 }
 
 void UlanziDialMacOSManager::stop()
 {
+    restoreSystemEventSuppression();
     if (!m_manager) return;
     IOHIDManagerRef mgr = static_cast<IOHIDManagerRef>(m_manager);
     IOHIDManagerClose(mgr, kIOHIDOptionsTypeNone);
     IOHIDManagerUnscheduleFromRunLoop(mgr, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
     CFRelease(mgr);
     m_manager = nullptr;
+    m_accessMode = AccessMode::None;
     if (m_anyOpen) {
         const QString name = m_deviceName;
         m_deviceName.clear();
@@ -286,10 +660,14 @@ void UlanziDialMacOSManager::onDeviceMatching(const QString& productName)
     if (!productName.isEmpty()) m_deviceName = productName;
     qCInfo(lcDevices) << "UlanziDialMacOSManager: attached" << m_deviceName;
     emit connectionChanged(true, m_deviceName);
+    applySystemEventSuppression();
 }
 
 void UlanziDialMacOSManager::onDeviceRemoval()
 {
+    // The mapping belongs to the removed service and vanishes with it. Do not
+    // try to restore through a stale service; a reconnect gets fresh state.
+    discardSystemEventSuppression();
     qCInfo(lcDevices) << "UlanziDialMacOSManager: detached";
     const QString name = m_deviceName;
     m_deviceName.clear();

--- a/src/core/UlanziDialMacOSManager.cpp
+++ b/src/core/UlanziDialMacOSManager.cpp
@@ -6,6 +6,7 @@
 #include "core/UlanziChordDecoder.h"
 
 #include <QDebug>
+#include <QJsonArray>
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/hid/IOHIDManager.h>
@@ -13,9 +14,14 @@
 #include <IOKit/hid/IOHIDValue.h>
 #include <IOKit/hid/IOHIDElement.h>
 
+#include <vector>
+
 namespace AetherSDR {
 
 namespace {
+
+constexpr int kUlanziVendorId = 0xFFF1;
+constexpr int kUlanziProductId = 0x0082;
 
 int hidConsumerToLinuxKey(int usage)
 {
@@ -52,15 +58,60 @@ CFMutableDictionaryRef makeMatchDict()
     CFMutableDictionaryRef d = CFDictionaryCreateMutable(
         kCFAllocatorDefault, 0,
         &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-    constexpr int kVendorId = 0xFFF1;
-    constexpr int kProductId = 0x0082;
-    CFNumberRef vendor = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &kVendorId);
-    CFNumberRef product = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &kProductId);
+    CFNumberRef vendor =
+        CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &kUlanziVendorId);
+    CFNumberRef product =
+        CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &kUlanziProductId);
     CFDictionarySetValue(d, CFSTR(kIOHIDVendorIDKey), vendor);
     CFDictionarySetValue(d, CFSTR(kIOHIDProductIDKey), product);
     CFRelease(vendor);
     CFRelease(product);
     return d;
+}
+
+qint64 deviceNumber(IOHIDDeviceRef device, CFStringRef key)
+{
+    CFTypeRef property = IOHIDDeviceGetProperty(device, key);
+    if (!property || CFGetTypeID(property) != CFNumberGetTypeID()) {
+        return -1;
+    }
+    qint64 value = -1;
+    CFNumberGetValue(static_cast<CFNumberRef>(property), kCFNumberSInt64Type, &value);
+    return value;
+}
+
+QString deviceString(IOHIDDeviceRef device, CFStringRef key)
+{
+    CFTypeRef property = IOHIDDeviceGetProperty(device, key);
+    if (!property || CFGetTypeID(property) != CFStringGetTypeID()) {
+        return {};
+    }
+    const CFStringRef text = static_cast<CFStringRef>(property);
+    const CFIndex length = CFStringGetLength(text);
+    const CFIndex bytes =
+        CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8) + 1;
+    QByteArray utf8(static_cast<qsizetype>(bytes), '\0');
+    if (!CFStringGetCString(text, utf8.data(), bytes, kCFStringEncodingUTF8)) {
+        return {};
+    }
+    return QString::fromUtf8(utf8.constData());
+}
+
+QString openResultName(bool attempted, qint32 result)
+{
+    if (!attempted) {
+        return QStringLiteral("notAttempted");
+    }
+    if (result == kIOReturnSuccess) {
+        return QStringLiteral("success");
+    }
+    if (result == kIOReturnNotPrivileged) {
+        return QStringLiteral("notPrivileged");
+    }
+    if (result == kIOReturnExclusiveAccess) {
+        return QStringLiteral("exclusiveAccess");
+    }
+    return QStringLiteral("error");
 }
 
 } // namespace
@@ -96,6 +147,8 @@ void UlanziDialMacOSManager::start()
     // Seize only the numerically matched dial so its events stop reaching the
     // OS keyboard stack — the macOS equivalent of Linux EVIOCGRAB.
     const IOReturn result = IOHIDManagerOpen(mgr, kIOHIDOptionsTypeSeizeDevice);
+    m_openAttempted = true;
+    m_lastOpenResult = static_cast<qint32>(result);
     if (result != kIOReturnSuccess) {
         qCWarning(lcDevices)
             << "UlanziDialMacOSManager: failed to open HID manager" << result;
@@ -105,6 +158,78 @@ void UlanziDialMacOSManager::start()
         return;
     }
     m_manager = mgr;
+}
+
+QJsonObject UlanziDialMacOSManager::diagnostics() const
+{
+    QJsonArray devices;
+    int expectedMatchCount = 0;
+    int unexpectedMatchCount = 0;
+
+    IOHIDManagerRef probe = IOHIDManagerCreate(kCFAllocatorDefault,
+                                               kIOHIDOptionsTypeNone);
+    const bool inventoryAvailable = probe != nullptr;
+    if (probe) {
+        CFMutableDictionaryRef match = makeMatchDict();
+        IOHIDManagerSetDeviceMatching(probe, match);
+        CFRelease(match);
+
+        CFSetRef matched = IOHIDManagerCopyDevices(probe);
+        const CFIndex count = matched ? CFSetGetCount(matched) : 0;
+        std::vector<const void*> values(static_cast<std::size_t>(count));
+        if (matched) {
+            CFSetGetValues(matched, values.data());
+        }
+        for (const void* value : values) {
+            IOHIDDeviceRef device = static_cast<IOHIDDeviceRef>(const_cast<void*>(value));
+            const qint64 vendorId = deviceNumber(device, CFSTR(kIOHIDVendorIDKey));
+            const qint64 productId = deviceNumber(device, CFSTR(kIOHIDProductIDKey));
+            const bool expected = vendorId == kUlanziVendorId
+                && productId == kUlanziProductId;
+            if (expected) {
+                ++expectedMatchCount;
+            } else {
+                ++unexpectedMatchCount;
+            }
+            devices.append(QJsonObject{
+                {QStringLiteral("product"), deviceString(device, CFSTR(kIOHIDProductKey))},
+                {QStringLiteral("vendorId"), vendorId},
+                {QStringLiteral("productId"), productId},
+                {QStringLiteral("primaryUsagePage"),
+                 deviceNumber(device, CFSTR(kIOHIDPrimaryUsagePageKey))},
+                {QStringLiteral("primaryUsage"),
+                 deviceNumber(device, CFSTR(kIOHIDPrimaryUsageKey))},
+                {QStringLiteral("expected"), expected},
+            });
+        }
+        if (matched) {
+            CFRelease(matched);
+        }
+        CFRelease(probe);
+    }
+
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("diagnostic"), QStringLiteral("ulanzi")},
+        {QStringLiteral("platform"), QStringLiteral("macos")},
+        {QStringLiteral("supported"), true},
+        {QStringLiteral("expectedMatch"),
+         QJsonObject{{QStringLiteral("vendorId"), kUlanziVendorId},
+                     {QStringLiteral("productId"), kUlanziProductId}}},
+        {QStringLiteral("matchedCount"), devices.size()},
+        {QStringLiteral("expectedMatchCount"), expectedMatchCount},
+        {QStringLiteral("unexpectedMatchCount"), unexpectedMatchCount},
+        {QStringLiteral("matchScopeSafe"), unexpectedMatchCount == 0},
+        {QStringLiteral("matchedDevices"), devices},
+        {QStringLiteral("inventoryAvailable"), inventoryAvailable},
+        {QStringLiteral("exclusiveClaimActive"), m_manager != nullptr},
+        {QStringLiteral("connected"), m_anyOpen},
+        {QStringLiteral("deviceName"), m_deviceName},
+        {QStringLiteral("openAttempted"), m_openAttempted},
+        {QStringLiteral("lastOpenResult"), m_lastOpenResult},
+        {QStringLiteral("lastOpenStatus"),
+         openResultName(m_openAttempted, m_lastOpenResult)},
+    };
 }
 
 void UlanziDialMacOSManager::stop()

--- a/src/core/UlanziDialMacOSManager.cpp
+++ b/src/core/UlanziDialMacOSManager.cpp
@@ -24,6 +24,8 @@ namespace AetherSDR {
 
 namespace {
 
+// Reporter's Bluetooth LE descriptor dump in #5126 records VendorID 65521
+// (0xFFF1) and ProductID 130 (0x0082); the bench device reports the same pair.
 constexpr int kUlanziVendorId = 0xFFF1;
 constexpr int kUlanziProductId = 0x0082;
 
@@ -522,8 +524,6 @@ void UlanziDialMacOSManager::discardSystemEventSuppression()
 QJsonObject UlanziDialMacOSManager::diagnostics() const
 {
     QJsonArray devices;
-    int expectedMatchCount = 0;
-    int unexpectedMatchCount = 0;
 
     IOHIDManagerRef probe = IOHIDManagerCreate(kCFAllocatorDefault,
                                                kIOHIDOptionsTypeNone);
@@ -543,13 +543,6 @@ QJsonObject UlanziDialMacOSManager::diagnostics() const
             IOHIDDeviceRef device = static_cast<IOHIDDeviceRef>(const_cast<void*>(value));
             const qint64 vendorId = deviceNumber(device, CFSTR(kIOHIDVendorIDKey));
             const qint64 productId = deviceNumber(device, CFSTR(kIOHIDProductIDKey));
-            const bool expected = vendorId == kUlanziVendorId
-                && productId == kUlanziProductId;
-            if (expected) {
-                ++expectedMatchCount;
-            } else {
-                ++unexpectedMatchCount;
-            }
             devices.append(QJsonObject{
                 {QStringLiteral("product"), deviceString(device, CFSTR(kIOHIDProductKey))},
                 {QStringLiteral("vendorId"), vendorId},
@@ -558,7 +551,6 @@ QJsonObject UlanziDialMacOSManager::diagnostics() const
                  deviceNumber(device, CFSTR(kIOHIDPrimaryUsagePageKey))},
                 {QStringLiteral("primaryUsage"),
                  deviceNumber(device, CFSTR(kIOHIDPrimaryUsageKey))},
-                {QStringLiteral("expected"), expected},
             });
         }
         if (matched) {
@@ -572,13 +564,10 @@ QJsonObject UlanziDialMacOSManager::diagnostics() const
         {QStringLiteral("diagnostic"), QStringLiteral("ulanzi")},
         {QStringLiteral("platform"), QStringLiteral("macos")},
         {QStringLiteral("supported"), true},
-        {QStringLiteral("expectedMatch"),
+        {QStringLiteral("productionMatch"),
          QJsonObject{{QStringLiteral("vendorId"), kUlanziVendorId},
                      {QStringLiteral("productId"), kUlanziProductId}}},
         {QStringLiteral("matchedCount"), devices.size()},
-        {QStringLiteral("expectedMatchCount"), expectedMatchCount},
-        {QStringLiteral("unexpectedMatchCount"), unexpectedMatchCount},
-        {QStringLiteral("matchScopeSafe"), unexpectedMatchCount == 0},
         {QStringLiteral("matchedDevices"), devices},
         {QStringLiteral("inventoryAvailable"), inventoryAvailable},
         {QStringLiteral("accessMode"), accessModeName()},

--- a/src/core/UlanziDialMacOSManager.h
+++ b/src/core/UlanziDialMacOSManager.h
@@ -12,7 +12,7 @@ namespace AetherSDR {
 // macOS backend for the Ulanzi Dial using IOKit HID Manager.  Mirrors
 // the Linux evdev / Windows hidapi backends' Qt signal contract.
 //
-// Key advantage over Windows: IOHIDDeviceOpen with kIOHIDOptionsTypeSeizeDevice
+// Key advantage over Windows: IOHIDManagerOpen with kIOHIDOptionsTypeSeizeDevice
 // is the documented exclusive-claim mechanism on Darwin.  When seized,
 // the dial's input is delivered only to AetherSDR — the OS keyboard
 // stack stops receiving it — so the dial's media keys don't leak to the

--- a/src/core/UlanziDialMacOSManager.h
+++ b/src/core/UlanziDialMacOSManager.h
@@ -17,7 +17,9 @@ namespace AetherSDR {
 // is the documented exclusive-claim mechanism on Darwin.  When seized,
 // the dial's input is delivered only to AetherSDR — the OS keyboard
 // stack stops receiving it — so the dial's media keys don't leak to the
-// focused window.
+// focused window. If macOS specifically denies the exclusive claim, the
+// manager reopens the same matched device in shared mode and temporarily
+// suppresses that service's system key mapping instead.
 class UlanziDialMacOSManager : public QObject {
     Q_OBJECT
 public:
@@ -37,6 +39,12 @@ signals:
     void connectionChanged(bool connected, const QString& name);
 
 private:
+    enum class AccessMode {
+        None,
+        Exclusive,
+        Shared,
+    };
+
     // Wired from the IOKit C callback shims.  Each call is one usage
     // transition (page + usage + value).
     void onHidValue(int usagePage, int usage, int value);
@@ -45,12 +53,27 @@ private:
 
     // Chord assembly state — same logic as the other two backends.
     void emitKeyTransition(int linuxKey, int value);
+    QString accessModeName() const;
+    void applySystemEventSuppression();
+    void restoreSystemEventSuppression();
+    void discardSystemEventSuppression();
 
     void* m_manager{nullptr};   // IOHIDManagerRef
+    void* m_eventSystemClient{nullptr}; // IOHIDEventSystemClientRef
+    void* m_suppressedService{nullptr}; // IOHIDServiceClientRef
+    void* m_previousUserKeyMapping{nullptr}; // CFTypeRef
     QString m_deviceName;
     bool m_anyOpen{false};
+    AccessMode m_accessMode{AccessMode::None};
     bool m_openAttempted{false};
     qint32 m_lastOpenResult{0};
+    qint32 m_exclusiveOpenResult{0};
+    bool m_sharedOpenAttempted{false};
+    qint32 m_sharedOpenResult{0};
+    bool m_systemEventsSuppressed{false};
+    bool m_previousMappingPreserved{false};
+    QString m_suppressionStatus{QStringLiteral("notNeeded")};
+    QString m_restorationStatus{QStringLiteral("notNeeded")};
 
     // Chord assembly and signature formatting are shared with the Linux and
     // Windows backends (ulanzi_chord_decoder_test covers all three).

--- a/src/core/UlanziDialMacOSManager.h
+++ b/src/core/UlanziDialMacOSManager.h
@@ -4,6 +4,7 @@
 
 #include "core/UlanziChordDecoder.h"
 
+#include <QJsonObject>
 #include <QObject>
 #include <QString>
 
@@ -28,6 +29,7 @@ public:
 
     bool isConnected() const { return m_anyOpen; }
     QString deviceName() const { return m_deviceName; }
+    QJsonObject diagnostics() const;
 
 signals:
     void tuneSteps(int steps);
@@ -47,6 +49,8 @@ private:
     void* m_manager{nullptr};   // IOHIDManagerRef
     QString m_deviceName;
     bool m_anyOpen{false};
+    bool m_openAttempted{false};
+    qint32 m_lastOpenResult{0};
 
     // Chord assembly and signature formatting are shared with the Linux and
     // Windows backends (ulanzi_chord_decoder_test covers all three).

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3285,6 +3285,9 @@ void MainWindow::wireRadioSetupDialogSignals(RadioSetupDialog* dlg, const QStrin
             s.value("UlanziDialEnabled", "False").toString() == "True") {
             QMetaObject::invokeMethod(m_dialBackend, &UlanziDialBackend::start,
                                       Qt::QueuedConnection);
+        } else if (m_dialBackend) {
+            QMetaObject::invokeMethod(m_dialBackend, &UlanziDialBackend::stop,
+                                      Qt::QueuedConnection);
         }
 #ifdef HAVE_HIDAPI
         if (m_hidEncoder &&

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3691,6 +3691,15 @@ void MainWindow::changeEvent(QEvent* event)
 void MainWindow::closeEvent(QCloseEvent* event)
 {
     ShutdownTrace closeEventTrace("main_window.close_event");
+#ifdef Q_OS_MAC
+    // Shared Ulanzi access temporarily remaps only the dial's system key
+    // events. Restore that mapping while the macOS HID event system and Qt
+    // event loop are still live; ~MainWindow runs only after app.exec().
+    if (m_dialBackend) {
+        ShutdownTrace trace("controllers.dial.stop");
+        m_dialBackend->stop();
+    }
+#endif
     // Release the TGXL/PGXL native control sockets explicitly so the radio
     // can resume polling them on behalf of other clients (e.g. Maestro).
     // The radio-disconnect handler does this via a queued connection on

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -2588,7 +2588,7 @@ bool MainWindow::startAutomationBridge(const QString& sockName)
             {QStringLiteral("ok"), true},
             {QStringLiteral("diagnostic"), QStringLiteral("ulanzi")},
             {QStringLiteral("supported"), false},
-            {QStringLiteral("error"),
+            {QStringLiteral("message"),
              QStringLiteral("Ulanzi HID diagnostics are currently macOS-only")},
         };
 #endif

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -2554,7 +2554,9 @@ bool MainWindow::startAutomationBridge(const QString& sockName)
         return tciServer()->routingSnapshot();
     });
     m_automation->setDeviceDiagnosticsHandler([this](const QString& diagnostic) {
-        if (diagnostic != QLatin1String("ulanzi")) {
+        if (diagnostic != QLatin1String("ulanzi")
+            && diagnostic != QLatin1String("ulanzi-start")
+            && diagnostic != QLatin1String("ulanzi-stop")) {
             return QJsonObject{
                 {QStringLiteral("ok"), false},
                 {QStringLiteral("error"), QStringLiteral("unknown device diagnostic")},
@@ -2567,7 +2569,13 @@ bool MainWindow::startAutomationBridge(const QString& sockName)
                 {QStringLiteral("error"), QStringLiteral("Ulanzi backend unavailable")},
             };
         }
+        if (diagnostic == QLatin1String("ulanzi-start")) {
+            m_dialBackend->start();
+        } else if (diagnostic == QLatin1String("ulanzi-stop")) {
+            m_dialBackend->stop();
+        }
         QJsonObject snapshot = m_dialBackend->diagnostics();
+        snapshot[QStringLiteral("operation")] = diagnostic;
         snapshot[QStringLiteral("enabled")] =
             AppSettings::instance()
                     .value(QStringLiteral("UlanziDialEnabled"),

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -38,6 +38,7 @@
 #include "core/IambicKeyer.h"
 #include "core/PerfTelemetry.h"
 #if defined(Q_OS_MAC)
+#include "core/UlanziDialMacOSManager.h"
 #include "core/VirtualAudioBridge.h"
 #elif defined(HAVE_PIPEWIRE)
 #include "core/PipeWireAudioBridge.h"
@@ -2551,6 +2552,38 @@ bool MainWindow::startAutomationBridge(const QString& sockName)
             };
         }
         return tciServer()->routingSnapshot();
+    });
+    m_automation->setDeviceDiagnosticsHandler([this](const QString& diagnostic) {
+        if (diagnostic != QLatin1String("ulanzi")) {
+            return QJsonObject{
+                {QStringLiteral("ok"), false},
+                {QStringLiteral("error"), QStringLiteral("unknown device diagnostic")},
+            };
+        }
+#ifdef Q_OS_MAC
+        if (!m_dialBackend) {
+            return QJsonObject{
+                {QStringLiteral("ok"), false},
+                {QStringLiteral("error"), QStringLiteral("Ulanzi backend unavailable")},
+            };
+        }
+        QJsonObject snapshot = m_dialBackend->diagnostics();
+        snapshot[QStringLiteral("enabled")] =
+            AppSettings::instance()
+                    .value(QStringLiteral("UlanziDialEnabled"),
+                           QStringLiteral("False"))
+                    .toString()
+            == QLatin1String("True");
+        return snapshot;
+#else
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("diagnostic"), QStringLiteral("ulanzi")},
+            {QStringLiteral("supported"), false},
+            {QStringLiteral("error"),
+             QStringLiteral("Ulanzi HID diagnostics are currently macOS-only")},
+        };
+#endif
     });
 
     // The access token lives in the OS secret store (QtKeychain), which reads

--- a/tests/automation_device_diagnostics_test.cpp
+++ b/tests/automation_device_diagnostics_test.cpp
@@ -1,0 +1,92 @@
+#include "core/AudioEngine.h"
+#include "core/QsoRecorder.h"
+#include "models/RadioModel.h"
+#include "core/AutomationServer.h"
+
+#include <QCoreApplication>
+#include <QJsonArray>
+#include <QJsonObject>
+
+#include <cstdio>
+
+namespace AetherSDR {
+
+class AutomationServerTestAccess
+{
+public:
+    static QJsonObject handleLine(AutomationServer& server, const QByteArray& line)
+    {
+        return server.handleLine(line, nullptr);
+    }
+};
+
+} // namespace AetherSDR
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* description)
+{
+    std::printf("%s  %s\n", condition ? "PASS" : "FAIL", description);
+    if (!condition) {
+        ++failures;
+    }
+}
+
+QJsonObject request(AetherSDR::AutomationServer& server, const QString& line)
+{
+    return AetherSDR::AutomationServerTestAccess::handleLine(server, line.toUtf8());
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    AetherSDR::AutomationServer server;
+
+    const QJsonObject list = request(server, QStringLiteral("devices list"));
+    check(list.value(QStringLiteral("ok")).toBool()
+              && list.value(QStringLiteral("diagnostics")).toArray().contains(
+                  QStringLiteral("ulanzi")),
+          "devices list advertises the Ulanzi diagnostic");
+
+    const QJsonObject unavailable = request(server, QStringLiteral("devices ulanzi"));
+    check(!unavailable.value(QStringLiteral("ok")).toBool()
+              && unavailable.value(QStringLiteral("error")).toString().contains(
+                  QStringLiteral("unavailable")),
+          "devices ulanzi fails clearly without a provider");
+
+    int calls = 0;
+    server.setDeviceDiagnosticsHandler([&calls](const QString& diagnostic) {
+        ++calls;
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("diagnostic"), diagnostic},
+            {QStringLiteral("matchedCount"), 1},
+            {QStringLiteral("unexpectedMatchCount"), 0},
+            {QStringLiteral("exclusiveClaimActive"), true},
+        };
+    });
+
+    server.setReadOnly(true);
+    const QJsonObject snapshot = request(server, QStringLiteral("devices ulanzi"));
+    check(snapshot.value(QStringLiteral("ok")).toBool()
+              && snapshot.value(QStringLiteral("diagnostic")).toString()
+                     == QLatin1String("ulanzi")
+              && snapshot.value(QStringLiteral("matchedCount")).toInt() == 1
+              && snapshot.value(QStringLiteral("unexpectedMatchCount")).toInt() == 0
+              && snapshot.value(QStringLiteral("exclusiveClaimActive")).toBool()
+              && calls == 1,
+          "devices ulanzi dispatches its provider in observe-only mode");
+
+    const QJsonObject unknown = request(server, QStringLiteral("devices trackpad"));
+    check(!unknown.value(QStringLiteral("ok")).toBool()
+              && unknown.value(QStringLiteral("error")).toString().contains(
+                  QStringLiteral("list|ulanzi"))
+              && calls == 1,
+          "unknown device diagnostics are rejected before provider dispatch");
+
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/automation_device_diagnostics_test.cpp
+++ b/tests/automation_device_diagnostics_test.cpp
@@ -65,7 +65,7 @@ int main(int argc, char** argv)
             {QStringLiteral("ok"), true},
             {QStringLiteral("diagnostic"), diagnostic},
             {QStringLiteral("matchedCount"), 1},
-            {QStringLiteral("unexpectedMatchCount"), 0},
+            {QStringLiteral("accessMode"), QStringLiteral("shared")},
             {QStringLiteral("exclusiveClaimActive"), true},
         };
     });
@@ -76,7 +76,8 @@ int main(int argc, char** argv)
               && snapshot.value(QStringLiteral("diagnostic")).toString()
                      == QLatin1String("ulanzi")
               && snapshot.value(QStringLiteral("matchedCount")).toInt() == 1
-              && snapshot.value(QStringLiteral("unexpectedMatchCount")).toInt() == 0
+              && snapshot.value(QStringLiteral("accessMode")).toString()
+                     == QLatin1String("shared")
               && snapshot.value(QStringLiteral("exclusiveClaimActive")).toBool()
               && calls == 1,
           "devices ulanzi dispatches its provider in observe-only mode");

--- a/tests/automation_device_diagnostics_test.cpp
+++ b/tests/automation_device_diagnostics_test.cpp
@@ -81,11 +81,28 @@ int main(int argc, char** argv)
               && calls == 1,
           "devices ulanzi dispatches its provider in observe-only mode");
 
+    const QJsonObject blockedStop = request(
+        server, QStringLiteral("devices ulanzi-stop"));
+    check(!blockedStop.value(QStringLiteral("ok")).toBool()
+              && blockedStop.value(QStringLiteral("error")).toString().contains(
+                  QStringLiteral("read-only"))
+              && calls == 1,
+          "devices ulanzi-stop is blocked in read-only mode");
+
+    server.setReadOnly(false);
+    const QJsonObject stopped = request(
+        server, QStringLiteral("devices ulanzi-stop"));
+    check(stopped.value(QStringLiteral("ok")).toBool()
+              && stopped.value(QStringLiteral("diagnostic")).toString()
+                     == QLatin1String("ulanzi-stop")
+              && calls == 2,
+          "devices ulanzi-stop dispatches lifecycle control when writable");
+
     const QJsonObject unknown = request(server, QStringLiteral("devices trackpad"));
     check(!unknown.value(QStringLiteral("ok")).toBool()
               && unknown.value(QStringLiteral("error")).toString().contains(
                   QStringLiteral("list|ulanzi"))
-              && calls == 1,
+              && calls == 2,
           "unknown device diagnostics are rejected before provider dispatch");
 
     return failures == 0 ? 0 : 1;

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -2299,6 +2299,19 @@ target_link_libraries(automation_json_id_test PRIVATE
 )
 add_test(NAME automation_json_id_test COMMAND automation_json_id_test)
 
+# Read-only external-device diagnostic registry and provider dispatch. The
+# platform-specific Ulanzi HID snapshot is supplied by MainWindow on macOS;
+# this test pins the bridge contract without requiring physical hardware.
+add_executable(automation_device_diagnostics_test
+    tests/automation_device_diagnostics_test.cpp
+)
+target_include_directories(automation_device_diagnostics_test PRIVATE src)
+target_link_libraries(automation_device_diagnostics_test PRIVATE
+    aethercore Qt6::Core Qt6::Network
+)
+add_test(NAME automation_device_diagnostics_test
+         COMMAND automation_device_diagnostics_test)
+
 # `connect ip` family resolution + the `family` field on `connect list` (#4912).
 # Pure verb-level test against a fake IConnectionAutomation — no socket, no radio.
 add_executable(automation_connect_family_test


### PR DESCRIPTION
## Summary

- match the Ulanzi Dial by the reporter- and bench-observed numeric VID/PID before opening the macOS HID manager, so Apple trackpads are outside the production match
- try the normal exclusive HID claim first; when macOS specifically returns `kIOReturnNotPrivileged` for the Bluetooth keyboard-class dial, reopen that exact production match in shared mode
- suppress only the dial's recognized keyboard/media usages with a device-scoped macOS key mapping while preserving raw HID input for AetherSDR
- snapshot and restore the user's prior mapping on disable and normal app exit, retaining the owning HID event-system client for the full service-handle lifetime
- make disabling Ulanzi support actually stop the backend and restore the mapping
- add `devices ulanzi`, `devices ulanzi-start`, and `devices ulanzi-stop` agent automation bridge diagnostics/lifecycle proof

Fixes #5126

## Root cause

There were two macOS-specific layers:

1. The old product-name match did not constrain the affected system's `IOHIDManager`; its manager contained 31 HID services, including the internal Apple trackpad and Magic Trackpad. Opening that manager with `kIOHIDOptionsTypeSeizeDevice` suppressed every enumerated device.
2. The corrected VID/PID match contains only the Ulanzi Dial, but macOS 26 rejects exclusive access to this Bluetooth keyboard-class device with `kIOReturnNotPrivileged`. A shared open receives the dial events, but the normal macOS keyboard/media stack also receives them and changes system volume.

The reporter's Bluetooth LE descriptor and the bench device both report VID `0xFFF1` (65521) / PID `0x0082` (130). The fallback activates only for the specific privilege result above. It uses the public, service-scoped `UserKeyMapping` mechanism for that device, suppressing only the usages AetherSDR consumes. The previous mapping is copied before mutation and restored on stop. The event-system client is retained alongside its service handle; a shutdown proof caught that retaining the service alone leaves an invalid internal client lock.

## Why the lifecycle and bridge changes are in scope

The exact HID match prevents the trackpad lockout, but it is not sufficient by itself on the affected macOS/device combination: exclusive access is denied, shared access leaks the dial's media keys to macOS, and failing to restore the temporary device mapping can leave system behavior changed after AetherSDR stops using the dial. The shared-mode suppression, symmetric restoration, disable/close lifecycle handling, and owning-client lifetime fix are therefore required for the feature to work rather than merely avoid freezing the trackpad.

The agent automation bridge additions are the bounded proof surface for those otherwise invisible OS-lifecycle states. `devices ulanzi` exposes only the production-match inventory and backend access/restoration status. `devices ulanzi-start` and `devices ulanzi-stop` were needed to prove restoration without repeatedly restarting the process. The read is allowed in Observe only mode; lifecycle actions are blocked there, and none of the verbs can key the transmitter. The diagnostic contract deliberately does not publish a tautological `unexpectedMatchCount`/`matchScopeSafe` value: the production inventory is already filtered by exact VID/PID and reports the matched devices directly.

## Agent automation bridge proof

The final ARM64 build ran with TX automation disabled.

Active state from `devices ulanzi`:

```json
{
  "matchedCount": 1,
  "matchedDevices": [{
    "product": "Ulanzi Dial",
    "vendorId": 65521,
    "productId": 130,
    "primaryUsagePage": 1,
    "primaryUsage": 6
  }],
  "accessMode": "shared",
  "connected": true,
  "exclusiveOpenStatus": "notPrivileged",
  "sharedOpenStatus": "success",
  "systemEventsSuppressed": true,
  "suppressionStatus": "active",
  "previousMappingPreserved": true,
  "eventSystemClientRetained": true
}
```

The operator then physically verified all three acceptance conditions:

- the dial continued controlling AetherSDR
- macOS volume remained unchanged
- the Apple trackpad continued working

`devices ulanzi-stop` then exercised restoration while the app remained alive:

```json
{
  "accessMode": "none",
  "connected": false,
  "restorationStatus": "success",
  "systemEventsSuppressed": false,
  "suppressionStatus": "restored",
  "previousMappingPreserved": false,
  "eventSystemClientRetained": false
}
```

An external `hidutil` readback showed `UserKeyMapping = ()`. A separate run reached the active state again, then closed `AetherSDR::MainWindow` through the bridge; the app exited without crashing and the mapping again read back empty.

## Validation

- full native ARM64 RelWithDebInfo build completed with RADE enabled
- final executable: Mach-O 64-bit arm64
- `automation_device_diagnostics_test`, `ulanzi_chord_decoder_test`, and `ulanzi_mapping_migration_test`: passed after the review follow-up
- bridge docs registry and strict test-registration checks: passed
- engine-boundary `--strict`: 0 blockers (tracked legacy warnings only)
- `git diff --check`: passed
- exact production HID inventory: one Ulanzi match; no Apple trackpad in the matched set
- operator hardware proof: AetherSDR input works, macOS volume is unchanged, and the trackpad works
- no TX was enabled or exercised

This is a non-visual input/transport fix, so there is no meaningful screenshot artifact.

Generated with OpenAI Codex.
