### PR TITLE
fix(icom): show the radio network name in the status bar

### DIFF
--- a/docs/architecture/aetherd-icom-civ-backend-design.md
+++ b/docs/architecture/aetherd-icom-civ-backend-design.md
@@ -1041,8 +1041,8 @@ their own right (CERTIFICATION.md §1.29):
 | | CW speed / pitch / break-in | ❌ no seam verb (`14 0C`, `14 09` mapped; `16 47` unmapped) |
 | **Status bar** | voltage | ✅ `RAD:+13.8A` |
 | | temperature / current | IC-705: no temperature; IC-7300MK2: `Id` from `15 16` while transmitting |
-| | radio name / model | ✅ from the handshake + `19 00` |
-| | hostname / alias | ⚠️ shows the connect address; the radio's own name is in the capabilities packet and unused |
+| | radio nickname / model | ✅ **verified on IC-705** — Network Radio Name from the RS-BA1 handshake; canonical model from `19 00` |
+| | network hostname | ⚠️ shows the connect address; no separate host alias is published |
 
 ### D.3 One control, two registers
 
@@ -1070,29 +1070,26 @@ CERTIFICATION.md §1.31 because it generalises to any fanned-out control.
 4. **AGC threshold** is accepted and discarded; the radio has no threshold
    register. Better to advertise it as unavailable than keep a live slider that
    does nothing.
-5. **The radio's own name** arrives in the capabilities packet and is unused;
-   the status bar shows the connect address instead.
-
 **Implemented and NOT proven on hardware** — the distinction this appendix
 exists to keep visible:
 
-6. **The TUNE carrier.** Synthesised, built, never keyed into a tuner.
-7. **Mic gain and TX monitor on IC-705.** The shared paths are live-proven on
+5. **The TUNE carrier.** Synthesised, built, never keyed into a tuner.
+6. **Mic gain and TX monitor on IC-705.** The shared paths are live-proven on
    IC-7300MK2; an IC-705 UI/effect pass is still outstanding.
-8. **The three filter buttons**, on screen with the applet open.
-9. **Connect-time state adoption**, beyond confirming the values arrive: whether
+7. **The three filter buttons**, on screen with the applet open.
+8. **Connect-time state adoption**, beyond confirming the values arrive: whether
    each one lands on the control an operator is looking at is a separate
    question, and it is the §1.27 gap in a different costume.
-10. **XIT.** RIT was driven and observed on the wire; XIT shares the offset
-    register and was not.
+9. **XIT.** RIT was driven and observed on the wire; XIT shares the offset
+   register and was not.
 
 **Open defects**
 
-11. **Transmit cuts out roughly once a second on FT8** — see CERTIFICATION.md
+10. **Transmit cuts out roughly once a second on FT8** — see CERTIFICATION.md
     §2.6. The radio stays keyed and ALC stays active, so this is not a keying
     or an audio-delivery fault; what remains is real RF pulsing or a low-drive
     meter artefact, and those want a higher-power run to separate.
-12. **A revoked session still looks healthy.** The backend swallows a post-grant
+11. **A revoked session still looks healthy.** The backend swallows a post-grant
     auth failure as "the previous session's teardown" — right for a reconnect,
     wrong when the radio really has withdrawn this one. It should disconnect.
 

--- a/docs/architecture/aetherd-icom-civ-backend-design.md
+++ b/docs/architecture/aetherd-icom-civ-backend-design.md
@@ -1070,6 +1070,7 @@ CERTIFICATION.md §1.31 because it generalises to any fanned-out control.
 4. **AGC threshold** is accepted and discarded; the radio has no threshold
    register. Better to advertise it as unavailable than keep a live slider that
    does nothing.
+
 **Implemented and NOT proven on hardware** — the distinction this appendix
 exists to keep visible:
 

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -299,8 +299,15 @@ void IcomCivBackend::publishCapabilities() { emit capabilitiesChanged(); }
 void IcomCivBackend::publishIdentity()
 {
     RadioDelta r;
-    r.model = QString::fromUtf8(m_model->name.data(),
-                                static_cast<int>(m_model->name.size()));
+    const QString modelName = QString::fromUtf8(m_model->name.data(),
+                                                static_cast<int>(m_model->name.size()));
+    r.model = modelName;
+    // The RS-BA1 handshake carries the radio's operator-configured Network
+    // Radio Name. It is the Icom equivalent of the nickname this neutral delta
+    // exposes, and is distinct from both the network hostname and the station
+    // callsign. Fall back to the CI-V-resolved model only when the radio leaves
+    // that field blank; never retain ConnectionPanel's generic "Icom" seed.
+    r.nickname = m_deviceName.isEmpty() ? modelName : m_deviceName;
     // ALWAYS SET, even when the row declares nothing. bandsRaw is a present-only
     // field, so omitting it leaves whatever the last radio declared standing —
     // and an empty declaration is a real answer here: it means "use the built-in
@@ -977,7 +984,7 @@ void IcomCivBackend::adoptReportedCivAddress(std::uint8_t reported)
 
 void IcomCivBackend::onSessionConnected(const QString& deviceName)
 {
-    m_deviceName = deviceName;
+    m_deviceName = deviceName.trimmed();
     m_connected = true;
 
     // RESOLVE THE MODEL FROM THE NAME, NOW.
@@ -993,7 +1000,7 @@ void IcomCivBackend::onSessionConnected(const QString& deviceName)
     // The capabilities packet already told us the name during the handshake, so
     // use it. The address query still runs and still wins — it is the
     // authority, this is just early enough to be useful.
-    m_modelByName = modelForName(deviceName.toStdString());
+    m_modelByName = modelForName(m_deviceName.toStdString());
     if (m_modelByName) {
         m_model = m_modelByName;
         // And declare the bands NOW, for the same reason the model is resolved
@@ -1004,6 +1011,15 @@ void IcomCivBackend::onSessionConnected(const QString& deviceName)
         // unidentified radio declares nothing and keeps the HF grid, rather
         // than announcing itself as "Unknown Icom" with no bands at all.
         publishIdentity();
+    } else {
+        // A custom Network Radio Name is intentionally not a model name. Publish
+        // it before connected() anyway so the status bar never exposes the
+        // manual-connect placeholder while the broadcast 0x19 0x00 query learns
+        // the canonical model. A present-but-empty nickname also clears that
+        // placeholder; publishIdentity() supplies the model fallback later.
+        RadioDelta r;
+        r.nickname = m_deviceName;
+        emit radioChanged(r);
     }
 
     // WRONG DEVICE, said as early as it can be said.

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -116,9 +116,7 @@ RadioCapabilities IcomCivBackend::capabilities() const
     RadioCapabilities c;
     c.family = QStringLiteral("icom");
     c.manufacturer = QStringLiteral("Icom");
-    c.model  = m_deviceName.isEmpty() ? QString::fromUtf8(m.name.data(),
-                                                          static_cast<int>(m.name.size()))
-                                      : m_deviceName;
+    c.model = QString::fromUtf8(m.name.data(), static_cast<int>(m.name.size()));
 
     c.maxSlices = m.receivers;
     c.maxPanadapters = m.hasScope ? m.receivers : 0;

--- a/tests/icom_backend_test.cpp
+++ b/tests/icom_backend_test.cpp
@@ -1662,6 +1662,66 @@ int main(int argc, char** argv)
           "disconnect aborts radio-buffered CW with 17 FF before teardown");
     check(!backend.isConnected(), "the backend disconnects cleanly");
 
+    // A NETWORK RADIO NAME IS A NICKNAME, NOT A MODEL DESIGNATION.
+    //
+    // The primary fake above deliberately uses "IC 705", which resolves through
+    // modelForName() and therefore cannot exercise the custom-name branch. Use a
+    // name that no model table can recognise, snapshot the seam on connected(),
+    // then let the authoritative 0x19 0x00 response arrive. This pins all three
+    // promises of the identity split: the nickname beats the connect edge, the
+    // later model response does not overwrite it, and capabilities keep reporting
+    // the hardware model rather than reclassifying the nickname as one.
+    {
+        FakeIc705 namedRadio;
+        namedRadio.setDeviceName("Shack 705");
+        IcomCivBackend namedBackend;
+
+        QString publishedNickname;
+        QString publishedModel;
+        QString nicknameAtConnect;
+        QString modelAtConnect;
+        QObject::connect(&namedBackend, &IRadioBackend::radioChanged, &app,
+                         [&](const RadioDelta& d) {
+                             if (d.nickname) {
+                                 publishedNickname = *d.nickname;
+                             }
+                             if (d.model) {
+                                 publishedModel = *d.model;
+                             }
+                         });
+        QObject::connect(&namedBackend, &IRadioBackend::connected, &app, [&] {
+            nicknameAtConnect = publishedNickname;
+            modelAtConnect = publishedModel;
+        });
+
+        RadioConnectRequest namedRequest;
+        namedRequest.host = QStringLiteral("127.0.0.1");
+        namedRequest.port = namedRadio.controlPort();
+        namedRequest.params.insert(QStringLiteral("icom.serialPort"),
+                                   namedRadio.serialPort());
+        namedRequest.params.insert(QStringLiteral("icom.audioPort"),
+                                   namedRadio.audioPort());
+        namedRequest.params.insert(QStringLiteral("icom.username"), QStringLiteral("beer"));
+        namedRequest.params.insert(QStringLiteral("icom.password"), QStringLiteral("beerbeer"));
+        namedRequest.params.insert(QStringLiteral("icom.civAddress"), 0xA4);
+
+        namedBackend.connectRadio(namedRequest);
+        check(waitFor([&] { return namedBackend.isConnected(); }),
+              "a radio with a custom Network Radio Name connects");
+        check(nicknameAtConnect == QStringLiteral("Shack 705"),
+              "and publishes that custom name as its nickname before connected()");
+        check(modelAtConnect.isEmpty(),
+              "without misreporting the custom nickname as an early hardware model");
+        check(waitFor([&] { return publishedModel == QStringLiteral("IC-705"); }),
+              "then adopts the canonical model from the authoritative 0x19 0x00 response");
+        check(publishedNickname == QStringLiteral("Shack 705"),
+              "without overwriting the custom nickname during model resolution");
+        check(namedBackend.capabilities().model == QStringLiteral("IC-705"),
+              "and reports the resolved hardware model through RadioCapabilities");
+
+        namedBackend.disconnectRadio();
+        check(!namedBackend.isConnected(), "the custom-name backend disconnects cleanly");
+    }
 
     // =======================================================================
     // CI-V ADDRESS RESOLUTION


### PR DESCRIPTION
## Summary

- Publish the operator-configured Icom **Network Radio Name** from the RS-BA1 handshake as the backend-neutral radio nickname.
- Publish custom radio names before the backend emits `connected()`, so the status bar does not retain the manual-connect placeholder.
- Preserve the radio nickname when the later CI-V identity response supplies the authoritative model, with the canonical model as the fallback when the handshake name is blank.
- Document the distinct sources for the nickname, model, network address, and station callsign, including the successful live IC-705 UI verification.

## Root cause

Manual Icom connection setup seeds the shared radio state with a generic `Icom` nickname. The RS-BA1 session handshake already decoded the radio's configured name, but `IcomCivBackend` used that value only for early model lookup and never published it through `RadioDelta::nickname`. Depending on connection timing and later identity updates, the status bar could therefore retain `Icom` or become blank.

## Behavior after this change

- **Nickname:** the Icom Network Radio Name carried by the RS-BA1 handshake.
- **Model:** the model resolved from CI-V command `19 00`; this remains authoritative for capabilities.
- **Network identity:** the configured connection address remains separate.
- **Callsign:** the AetherSDR station callsign remains separate and is not used as the radio nickname.

A custom Network Radio Name does not need to resemble a model name. It is published immediately, while the subsequent CI-V response independently resolves the radio model and republishes identity without overwriting the nickname.

## Validation

- `cmake --build build --target AetherSDR icom_backend_test -j22`
- `QT_QPA_PLATFORM=offscreen ctest --test-dir build -j22 -R '^icom_backend_test$' --output-on-failure` — 1/1 passed
- Reviewer follow-up: fresh macOS ARM64 `icom_backend_test` build and focused run — 1/1 passed
- `python3 tools/check_engine_boundary.py --strict` — 0 blocking findings
- `python3 tools/check_test_registration.py --strict` — passed
- `git merge-tree --write-tree origin/main HEAD` — clean
- Live IC-705 run: the center status bar displayed the radio-configured Network Radio Name correctly.

## Scope and safety

- Production change is confined to `IcomCivBackend`; no GUI behavior or layout code changes.
- Regression coverage in `tests/icom_backend_test.cpp` pins custom nickname publication and authoritative model resolution.
- No persistence or callsign behavior changes.
- No changes to CI-V Transceive, CI-V Output, transmit, or audio behavior.
- Preserves radio-authoritative identity and capability handling under Constitution Principle II.

Generated with OpenAI Codex (Daybreak Blue)
