### PR TITLE
Fix Workspace Canvas pan layout reflow

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -3522,6 +3522,25 @@ actually paint? is the layout right?), because a live spectrum is
 non-deterministic noise and won't golden-match until replay mode (Phase 2)
 lands.
 
+### Workspace pan-layout proof
+
+`workspace pan-layout <id>` drives the same production path as selecting a
+panadapter layout in the UI. It persists `PanadapterLayout`, creates or removes
+pans to reach the layout's count, and reflows Workspace Canvas pan rectangles
+when canvas mode is enabled. Valid IDs are `1`, `2v`, `2h`, `2h1`, `12h`,
+`3v`, `2x2`, `4v`, `3h2`, `2x3`, `4h3`, and `2x4`.
+
+Pan creation and removal settle asynchronously. The initial reply includes
+`targetPanCount`, active-main `panCount`, global `globalPanCount`, and
+`settling`. Poll `workspace status` until the active main surface has the
+target pan count before asserting its live rectangles. Floating pans and pans
+on extra surfaces are outside that count and remain untouched. To prove the
+rectangles persisted, disable and re-enable canvas mode (or restart with the
+same isolated settings profile) and assert the replayed geometry. This action
+returns an error before mutation when the target cannot fit within the radio's
+receiver capacity. It never enables transmit and remains available without
+`AETHER_AUTOMATION_ALLOW_TX`.
+
 ---
 
 ## Gotchas
@@ -3624,7 +3643,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `record` | — | record <start\|stop\|status\|path\|dir> [args] |
 | `testtone` | — | testtone <on\|off> [freqHz levelDb] |
 | `pan` | — | pan <create\|add\|remove\|close\|center\|rfgain\|float\|dock> [value] — float/dock drive PanadapterStack's real reparent path (#4864) |
-| `workspace` | — | workspace <status\|enable\|disable\|edit\|place\|list\|switch\|create\|bind\|import-floats\|palette\|window\|move\|add> — the canvas, its workspaces and its extra windows as data; arg shapes in docs/automation-bridge.md (#4887 ph4/ph6/ph7) |
+| `workspace` | — | workspace <status\|enable\|disable\|edit\|place\|list\|switch\|create\|bind\|import-floats\|pan-layout\|palette\|window\|move\|add> — the canvas, its workspaces and its extra windows as data; arg shapes in docs/automation-bridge.md (#4887 ph4/ph6/ph7) |
 | `layout` | — | layout <rearrange <id>\|get> — splitter layout exerciser |
 | `scale` | — | scale [pct] — report/persist the UI scale factor |
 | `panmessage` | — | panmessage <add\|remove\|clear\|list> <pan> [id timeout [tone=…] title\|detail] |

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -3132,7 +3132,7 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
 
         add("workspace", {},
             "workspace <status|enable|disable|edit|place|list|switch|create|"
-            "bind|import-floats|palette|window|move|add> — the canvas, its "
+            "bind|import-floats|pan-layout|palette|window|move|add> — the canvas, its "
             "workspaces and its extra windows as data; arg shapes in "
             "docs/automation-bridge.md (#4887 ph4/ph6/ph7)",
             parseActionRest,
@@ -3140,7 +3140,7 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
                 Q_UNUSED(s);
                 if (a.action.isEmpty())
                     return err(QStringLiteral(
-                        "workspace requires an action (status|enable|disable|place)"));
+                        "workspace requires an action (status|enable|disable|place|pan-layout)"));
                 QWidget* mw = primaryTopLevelWindow();
                 if (!mw)
                     return err(QStringLiteral("no main window"));

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10143,6 +10143,12 @@ void MainWindow::settleCanvasPanLayout(const QString& layoutId,
         qWarning() << "applyPanLayout: canvas settle expired for" << layoutId
                    << "expected" << expectedPanCount << "pans, found"
                    << actualPanCount;
+        // Expiry is terminal. Only the disabled-canvas path above represents
+        // a suspended selection that may resume when canvas mode returns.
+        // Leaving an expired selection pending would let a later enable
+        // overwrite geometry the operator arranged in the meantime.
+        m_pendingCanvasPanLayoutId.clear();
+        m_pendingCanvasPanLayoutTarget = -1;
         return;
     }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -10017,17 +10017,32 @@ void MainWindow::applyPanLayout(const QString& layoutId)
     if (!m_radioModel.isConnected()) return;
 
     const int needed = panCountForLayoutId(layoutId);
-    const int existing = m_panStack->count();
+    const bool canvasLayout = m_workspaceController
+        && m_workspaceController->isEnabled();
+    const QStringList canvasPanIds = canvasLayout
+        ? m_workspaceController->activeMainPanIdsForLayout() : QStringList{};
+    const int existing = canvasLayout ? canvasPanIds.size() : m_panStack->count();
+    if (!canvasLayout) {
+        ++m_canvasPanLayoutGeneration;
+        m_pendingCanvasPanLayoutId.clear();
+        m_pendingCanvasPanLayoutTarget = -1;
+    }
 
     if (needed < existing) {
         qDebug() << "applyPanLayout: reducing from" << existing << "to" << needed << "pans";
 
         // Close extra pans from the end (keep the first N)
-        auto allApplets = m_panStack->allApplets();
+        QStringList removalCandidates;
+        if (canvasLayout) {
+            removalCandidates = canvasPanIds;
+        } else {
+            for (PanadapterApplet* applet : m_panStack->allApplets()) {
+                removalCandidates.append(applet->panId());
+            }
+        }
         int toRemove = existing - needed;
-        for (int i = allApplets.size() - 1; i >= 0 && toRemove > 0; --i) {
-            auto* applet = allApplets[i];
-            QString panId = applet->panId();
+        for (int i = removalCandidates.size() - 1; i >= 0 && toRemove > 0; --i) {
+            const QString panId = removalCandidates.at(i);
             if (panId == "default") continue;
             qDebug() << "applyPanLayout: closing pan" << panId;
             // Route through removePanadapter so a layout-shrink tears down the
@@ -10039,27 +10054,35 @@ void MainWindow::applyPanLayout(const QString& layoutId)
             --toRemove;
         }
 
+        // Pan removal and slot rekeying arrive asynchronously. Reflow now and
+        // after each settling turn so the final survivors, rather than a pan
+        // that is still waiting to disappear, receive the canonical cells.
+        startCanvasPanLayoutSettle(layoutId, needed);
+
         // Rearrange remaining pans after a short delay for radio to process
         QTimer::singleShot(500, this, [this, layoutId]() {
-            m_panStack->rearrangeLayout(layoutId);
+            if (!m_workspaceController || !m_workspaceController->isEnabled()) {
+                m_panStack->rearrangeLayout(layoutId);
+            }
         });
         return;
     }
     if (needed == existing) {
         // Same count, just rearrange
-        m_panStack->rearrangeLayout(layoutId);
+        if (!canvasLayout) {
+            m_panStack->rearrangeLayout(layoutId);
+        }
+        startCanvasPanLayoutSettle(layoutId, needed);
         return;
     }
 
     // Create additional pans to reach the needed count.
     // Keep existing pan(s) alive — no tear-down, no dangling signals.
-    const int currentSliceCount = static_cast<int>(m_radioModel.slices().size());
-    if (currentSliceCount >= m_radioModel.maxSlices()) {
+    const int toCreate = needed - existing;
+    if (m_panStack->count() + toCreate > m_radioModel.maxPanadapters()) {
         showPanadapterSliceCapacityMessage();
         return;
     }
-
-    const int toCreate = needed - existing;
     auto panIds = std::make_shared<QStringList>();
 
     // Collect existing pan IDs first (they'll be part of the layout)
@@ -10069,7 +10092,66 @@ void MainWindow::applyPanLayout(const QString& layoutId)
     qDebug() << "applyPanLayout: have" << existing << "pans, creating"
              << toCreate << "more for layout" << layoutId;
 
+    if (canvasLayout) {
+        startCanvasPanLayoutSettle(layoutId, needed);
+    }
     createPansSequentially(layoutId, toCreate, panIds, 0);
+}
+
+void MainWindow::startCanvasPanLayoutSettle(const QString& layoutId,
+                                            int expectedPanCount)
+{
+    if (!m_workspaceController || !m_workspaceController->isEnabled()) {
+        return;
+    }
+    m_pendingCanvasPanLayoutId = layoutId;
+    m_pendingCanvasPanLayoutTarget = expectedPanCount;
+    const quint64 generation = ++m_canvasPanLayoutGeneration;
+    settleCanvasPanLayout(layoutId, expectedPanCount, 25, generation);
+}
+
+void MainWindow::settleCanvasPanLayout(const QString& layoutId,
+                                       int expectedPanCount,
+                                       int attemptsRemaining,
+                                       quint64 generation)
+{
+    if (m_shuttingDown || !m_panStack || generation != m_canvasPanLayoutGeneration) {
+        return;
+    }
+
+    if (!m_workspaceController || !m_workspaceController->isEnabled()) {
+        if (attemptsRemaining > 0) {
+            QTimer::singleShot(200, this,
+                               [this, layoutId, expectedPanCount,
+                                attemptsRemaining, generation]() {
+                settleCanvasPanLayout(layoutId, expectedPanCount,
+                                      attemptsRemaining - 1, generation);
+            });
+        }
+        return;
+    }
+
+    m_workspaceController->applyPanLayout(layoutId);
+    const int actualPanCount =
+        m_workspaceController->activeMainPanIdsForLayout().size();
+    if (actualPanCount == expectedPanCount) {
+        m_pendingCanvasPanLayoutId.clear();
+        m_pendingCanvasPanLayoutTarget = -1;
+        return;
+    }
+    if (attemptsRemaining <= 0) {
+        qWarning() << "applyPanLayout: canvas settle expired for" << layoutId
+                   << "expected" << expectedPanCount << "pans, found"
+                   << actualPanCount;
+        return;
+    }
+
+    QTimer::singleShot(200, this,
+                       [this, layoutId, expectedPanCount, attemptsRemaining,
+                        generation]() {
+        settleCanvasPanLayout(layoutId, expectedPanCount,
+                              attemptsRemaining - 1, generation);
+    });
 }
 
 void MainWindow::createPansSequentially(const QString& layoutId, int total,
@@ -10093,7 +10175,10 @@ void MainWindow::createPansSequentially(const QString& layoutId, int total,
             }
 
             // Rearrange splitter structure for the selected layout
-            m_panStack->rearrangeLayout(layoutId);
+            if (!m_workspaceController || !m_workspaceController->isEnabled()) {
+                m_panStack->rearrangeLayout(layoutId);
+            }
+            startCanvasPanLayoutSettle(layoutId, panCountForLayoutId(layoutId));
 
             m_panApplet = m_panStack->activeApplet();
 
@@ -10200,12 +10285,12 @@ void MainWindow::createPansSequentially(const QString& layoutId, int total,
 
 void MainWindow::showPanadapterSliceCapacityMessage()
 {
-    const int limit = m_radioModel.maxSlices();
+    const int limit = m_radioModel.maxPanadapters();
     const QString model = m_radioModel.model().isEmpty()
         ? QStringLiteral("This radio")
         : m_radioModel.model();
     statusBar()->showMessage(
-        QStringLiteral("Slice capacity is full; cannot add another panadapter (%1 supports %2 slice%3)")
+        QStringLiteral("Panadapter capacity is full (%1 supports %2 panadapter%3)")
             .arg(model)
             .arg(limit)
             .arg(limit == 1 ? QString() : QStringLiteral("s")),

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -840,6 +840,9 @@ private:
     void publishRadioStateMqtt();
 #endif
     void applyPanLayout(const QString& layoutId);
+    void startCanvasPanLayoutSettle(const QString& layoutId, int expectedPanCount);
+    void settleCanvasPanLayout(const QString& layoutId, int expectedPanCount,
+                               int attemptsRemaining, quint64 generation);
     void createPansSequentially(const QString& layoutId, int total,
                                 std::shared_ptr<QStringList> panIds, int created);
     void showPanadapterSliceCapacityMessage();
@@ -1266,6 +1269,9 @@ private:
     WorkspaceCanvas*     m_workspaceCanvas{nullptr};
     WorkspaceController* m_workspaceController{nullptr};
     QAction*             m_workspaceCanvasAction{nullptr};
+    quint64              m_canvasPanLayoutGeneration{0};
+    QString              m_pendingCanvasPanLayoutId;
+    int                  m_pendingCanvasPanLayoutTarget{-1};
     // Additional canvas windows (phase 7), keyed by surface id.  A hidden
     // window stays in the map (hide-and-keep reuses its canvas object);
     // only remove/shutdown deletes.

--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -37,6 +37,7 @@
 #include "core/KiwiSdrProtocol.h"
 #include "core/LogManager.h"
 #include "models/SliceModel.h"
+#include "workspace/WorkspaceController.h"
 
 #include <QAbstractSlider>
 #include <QJsonObject>
@@ -667,7 +668,11 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
         if (!m_radioModel.isConnected()) return true;
         int maxPans = m_radioModel.maxPanadapters();
         // Determine current layout from actual pan count, not saved setting
-        int activePanCount = m_panStack ? m_panStack->count() : 1;
+        const bool canvasEnabled = m_workspaceController
+            && m_workspaceController->isEnabled();
+        int activePanCount = canvasEnabled
+            ? m_workspaceController->activeMainPanIdsForLayout().size()
+            : (m_panStack ? m_panStack->count() : 1);
         QString currentLayout = "1";
         if (activePanCount >= 2)
             currentLayout = AppSettings::instance()
@@ -676,9 +681,9 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
         if (dlg.exec() == QDialog::Accepted && !dlg.selectedLayout().isEmpty()) {
             const QString layoutId = dlg.selectedLayout();
             const int requestedPanCount = panCountForLayoutId(layoutId);
-            const int currentSliceCount = static_cast<int>(m_radioModel.slices().size());
-            if (requestedPanCount > activePanCount
-                    && currentSliceCount >= m_radioModel.maxSlices()) {
+            const int additionalPans = qMax(0, requestedPanCount - activePanCount);
+            const int globalPanCount = m_panStack ? m_panStack->count() : 0;
+            if (globalPanCount + additionalPans > m_radioModel.maxPanadapters()) {
                 showPanadapterSliceCapacityMessage();
                 return true;
             }

--- a/src/gui/MainWindow_Workspace.cpp
+++ b/src/gui/MainWindow_Workspace.cpp
@@ -20,6 +20,7 @@
 #include "containers/ContainerManager.h"
 #include "core/AppSettings.h"
 #include "core/LogManager.h"
+#include "workspace/ClassicLayout.h"
 #include "workspace/WorkspaceCanvas.h"
 #include "workspace/WorkspaceController.h"
 #include "workspace/WorkspaceWindow.h"
@@ -409,6 +410,15 @@ void MainWindow::toggleWorkspaceCanvas(bool on, bool preserveEnabledPreference)
             return;
         }
         m_canvasWasOnBeforeMinimal = false;
+
+        // A layout selection may have been suspended while asynchronous pan
+        // creation/removal continued with canvas mode off. Resume only after
+        // enable() has replayed the document and rebuilt live slot membership.
+        if (!m_pendingCanvasPanLayoutId.isEmpty()
+            && m_pendingCanvasPanLayoutTarget >= 0) {
+            startCanvasPanLayoutSettle(m_pendingCanvasPanLayoutId,
+                                       m_pendingCanvasPanLayoutTarget);
+        }
 
         if (bandStackWasVisible) {
             m_workspaceController->setBandStackVisible(true);
@@ -971,6 +981,47 @@ QVariantMap MainWindow::automationWorkspace(const QString& action,
         return out;
     }
 
+    if (action == QLatin1String("pan-layout")) {
+        const QString layoutId = args.trimmed();
+        const int targetPanCount = panCellsForLayout(layoutId).size();
+        if (targetPanCount == 0) {
+            out[QStringLiteral("error")] = QStringLiteral(
+                "pan-layout wants a known layout id (1|2v|2h|2h1|12h|3v|2x2|4v|3h2|2x3|4h3|2x4)");
+            return out;
+        }
+        if (!m_radioModel.isConnected()) {
+            out[QStringLiteral("error")] = QStringLiteral("radio is disconnected");
+            return out;
+        }
+        const bool canvasEnabled = m_workspaceController->isEnabled();
+        const int beforeCount = canvasEnabled
+            ? m_workspaceController->activeMainPanIdsForLayout().size()
+            : (m_panStack ? m_panStack->count() : 0);
+        const int additionalPans = qMax(0, targetPanCount - beforeCount);
+        const int globalPanCount = m_panStack ? m_panStack->count() : 0;
+        if (globalPanCount + additionalPans > m_radioModel.maxPanadapters()) {
+            out[QStringLiteral("error")] = QStringLiteral(
+                "pan-layout needs %1 additional pan(s), but the radio has %2 of %3 panadapter slots in use")
+                .arg(additionalPans)
+                .arg(globalPanCount)
+                .arg(m_radioModel.maxPanadapters());
+            return out;
+        }
+        AppSettings::instance().setValue(QStringLiteral("PanadapterLayout"), layoutId);
+        AppSettings::instance().save();
+        applyPanLayout(layoutId);  // Same production path as the layout selector.
+        const int activeMainPanCount = canvasEnabled
+            ? m_workspaceController->activeMainPanIdsForLayout().size()
+            : (m_panStack ? m_panStack->count() : 0);
+        out[QStringLiteral("layout")] = layoutId;
+        out[QStringLiteral("targetPanCount")] = targetPanCount;
+        out[QStringLiteral("panCount")] = activeMainPanCount;
+        out[QStringLiteral("globalPanCount")] = m_panStack ? m_panStack->count() : 0;
+        out[QStringLiteral("settling")] = (beforeCount != targetPanCount);
+        out[QStringLiteral("canvasEnabled")] = canvasEnabled;
+        return out;
+    }
+
     if (action == QLatin1String("window")) {
         // window new [label] | list | open <id> | close <id> |
         //        remove <id> | rename <id> <label>
@@ -1204,7 +1255,7 @@ QVariantMap MainWindow::automationWorkspace(const QString& action,
 
     out[QStringLiteral("error")] =
         QStringLiteral("unknown workspace action: %1 (status|enable|disable|"
-                       "edit|place|list|switch|create|bind|import-floats|"
+                       "edit|place|list|switch|create|bind|import-floats|pan-layout|"
                        "palette|window|move|add)")
             .arg(action);
     return out;

--- a/src/gui/workspace/WorkspaceController.cpp
+++ b/src/gui/workspace/WorkspaceController.cpp
@@ -1496,6 +1496,149 @@ void WorkspaceController::resetToClassic()
     emit workspacesChanged();   // the window list may have collapsed
 }
 
+QStringList WorkspaceController::activeMainPanIdsForLayout() const
+{
+    if (!m_enabled) {
+        return {};
+    }
+
+    const WorkspaceDocument& doc = m_store.document();
+    const Workspace* ws = nullptr;
+    for (const Workspace& candidate : doc.workspaces) {
+        if (candidate.id == doc.activeWorkspace) {
+            ws = &candidate;
+            break;
+        }
+    }
+    if (!ws) {
+        return {};
+    }
+
+    const WorkspaceSurface* main = nullptr;
+    for (const WorkspaceSurface& surface : ws->surfaces) {
+        if (surface.id == WorkspaceSurface::kMainId) {
+            main = &surface;
+            break;
+        }
+    }
+    if (!main) {
+        return {};
+    }
+
+    QSet<QString> mainItemIds;
+    for (const CanvasItem& item : main->items) {
+        if (item.id.startsWith(kPanItemPrefix)) {
+            mainItemIds.insert(item.id);
+        }
+    }
+
+    QList<QPair<int, QString>> ordered;
+    for (auto it = m_panSlots.cbegin(); it != m_panSlots.cend(); ++it) {
+        const QString itemId = QStringLiteral("pan:%1").arg(it.value());
+        if (!mainItemIds.contains(itemId)
+            || (m_panHost.isFloating && m_panHost.isFloating(it.key()))) {
+            continue;
+        }
+        ordered.append(qMakePair(it.value(), it.key()));
+    }
+    std::sort(ordered.begin(), ordered.end(), [](const auto& lhs, const auto& rhs) {
+        return lhs.first < rhs.first;
+    });
+
+    QStringList panIds;
+    for (const auto& entry : ordered) {
+        panIds.append(entry.second);
+    }
+    return panIds;
+}
+
+bool WorkspaceController::applyPanLayout(const QString& layoutId)
+{
+    if (!m_enabled || panCellsForLayout(layoutId).isEmpty()) {
+        return false;
+    }
+
+    WorkspaceDocument doc = m_store.document();
+    Workspace* ws = nullptr;
+    for (Workspace& candidate : doc.workspaces) {
+        if (candidate.id == doc.activeWorkspace) {
+            ws = &candidate;
+            break;
+        }
+    }
+    WorkspaceSurface* main = nullptr;
+    if (ws) {
+        for (WorkspaceSurface& surface : ws->surfaces) {
+            if (surface.id == WorkspaceSurface::kMainId) {
+                main = &surface;
+                break;
+            }
+        }
+    }
+    if (!main) {
+        return false;
+    }
+
+    // ClassicLayout is the one canonical pan-cell implementation. Build its
+    // result from the eligible main-surface pans, not every known slot: a
+    // floating or extra-surface lower slot must not leave a hole in the
+    // visible canvas arrangement. Unlike resetToClassic(), this must not
+    // change applets or other surfaces.
+    QStringList slotIds;
+    const QStringList panIds = activeMainPanIdsForLayout();
+    for (const QString& panId : panIds) {
+        slotIds.append(QString::number(m_panSlots.value(panId)));
+    }
+    const LegacyLayoutState legacy = readLegacyLayoutState(effectiveKnownAppletIds());
+    const QList<CanvasItem> classic = composeClassic(
+        slotIds, legacy.appletPanelVisible ? legacy.openAppletIds : QStringList{},
+        layoutId, legacy.appletsLeft);
+    QHash<QString, NormRect> rects;
+    for (const CanvasItem& item : classic) {
+        if (item.id.startsWith(kPanItemPrefix)) {
+            rects.insert(item.id, item.rect);
+        }
+    }
+
+    QHash<QString, NormRect> changed;
+    for (CanvasItem& item : main->items) {
+        if (!item.id.startsWith(kPanItemPrefix)) {
+            continue;
+        }
+        const QString panId = panIdForItem(item.id);
+        if (panId.isEmpty()
+            || (m_panHost.isFloating && m_panHost.isFloating(panId))) {
+            continue;
+        }
+        const auto it = rects.constFind(item.id);
+        if (it == rects.constEnd() || item.rect == it.value()) {
+            continue;
+        }
+        item.rect = it.value();
+        changed.insert(item.id, item.rect);
+    }
+
+    if (changed.isEmpty()) {
+        return true;
+    }
+
+    // Persist the complete document before publishing the matching canvas
+    // geometry. The replay signals are descriptions of this write, not edits.
+    const bool wasApplying = m_applying;
+    m_applying = true;
+    m_store.setDocument(doc);
+    for (auto it = changed.cbegin(); it != changed.cend(); ++it) {
+        if (m_canvas->contains(it.key())) {
+            m_canvas->setItemRect(it.key(), it.value());
+        }
+    }
+    m_applying = wasApplying;
+    if (!m_store.flush()) {
+        qWarning() << "WorkspaceController: pan layout did not persist (read-only session?)";
+    }
+    return true;
+}
+
 void WorkspaceController::tidyLayout(WorkspaceCanvas* canvas)
 {
     if (!m_enabled) {

--- a/src/gui/workspace/WorkspaceController.cpp
+++ b/src/gui/workspace/WorkspaceController.cpp
@@ -1622,8 +1622,9 @@ bool WorkspaceController::applyPanLayout(const QString& layoutId)
         return true;
     }
 
-    // Persist the complete document before publishing the matching canvas
-    // geometry. The replay signals are descriptions of this write, not edits.
+    // Make the complete document authoritative before publishing matching
+    // canvas geometry, then flush both as one persisted gesture below. The
+    // replay signals describe this document update; they are not fresh edits.
     const bool wasApplying = m_applying;
     m_applying = true;
     m_store.setDocument(doc);

--- a/src/gui/workspace/WorkspaceController.h
+++ b/src/gui/workspace/WorkspaceController.h
@@ -349,6 +349,19 @@ public:
     // guaranteed way back to a sane shell.
     void resetToClassic();
 
+    // Apply a legacy pan-layout selection to canvas mode without resetting the
+    // workspace. Only live, non-floating pan slots already on the active main
+    // surface are reflowed; applets, extra surfaces, and other workspaces keep
+    // their operator-arranged geometry. Returns false when the canvas is off
+    // or the layout id is not one ClassicLayout understands.
+    bool applyPanLayout(const QString& layoutId);
+
+    // Live radio ids participating in an active-main-surface layout, ordered
+    // by stable canvas slot. Floating and extra-surface pans are intentionally
+    // outside the legacy selector's count/removal domain while canvas mode is
+    // authoritative.
+    QStringList activeMainPanIdsForLayout() const;
+
     // Resolve applet-vs-applet overlaps by minimal downward pushes.  Items
     // overlapping the PAN AREA are left alone on purpose: a meter over the
     // spectrum is a feature, not disorder.

--- a/tests/workspace_controller_test.cpp
+++ b/tests/workspace_controller_test.cpp
@@ -42,9 +42,11 @@
 #include <iostream>
 
 using AetherSDR::AppSettings;
+using AetherSDR::CanvasItem;
 using AetherSDR::ContainerManager;
 using AetherSDR::ContainerWidget;
 using AetherSDR::NormRect;
+using AetherSDR::Workspace;
 using AetherSDR::WorkspaceCanvas;
 using AetherSDR::WorkspaceController;
 using AetherSDR::WorkspaceDocument;
@@ -542,9 +544,149 @@ int main(int argc, char** argv)
                    && canvas.layout().zOf(QStringLiteral("pan:1"))
                           < canvas.layout().zOf(QStringLiteral("applet:TX")));
 
+        // A layout-selector change while canvas mode owns the pans must
+        // replace the stale stored pan rectangles, not merely rearrange the
+        // hidden legacy splitter. It changes only active-main live pans:
+        // applets and extra surfaces remain the operator arranged them.
+        auto* panD2 = new QWidget(&panOwner);
+        auto* panE2 = new QWidget(&panOwner);
+        pans.insert(QStringLiteral("0x40000010"), panD2);
+        pans.insert(QStringLiteral("0x40000011"), panE2);
+        ctl.onPanAdded(QStringLiteral("0x40000010"));
+        ctl.onPanAdded(QStringLiteral("0x40000011"));
+        const QString pan0 = ctl.panItemIdFor(QStringLiteral("0x40000000"));
+        const QString pan1 = ctl.panItemIdFor(QStringLiteral("0x40000002"));
+        const QString pan2 = ctl.panItemIdFor(QStringLiteral("0x40000010"));
+        const QString pan3 = ctl.panItemIdFor(QStringLiteral("0x40000011"));
+        const QString preservedSurface =
+            ctl.addCanvasWindow(QStringLiteral("Pan layout preservation"));
+        const NormRect appletBefore = canvas.itemRect(QStringLiteral("applet:RX"));
+        canvas.setItemRect(pan0, NormRect{0.30, 0.30, 0.60, 0.60});
+        canvas.setItemRect(pan1, NormRect{0.30, 0.30, 0.60, 0.60});
+        canvas.setItemRect(pan2, NormRect{0.30, 0.30, 0.60, 0.60});
+        canvas.setItemRect(pan3, NormRect{0.30, 0.30, 0.60, 0.60});
+        ctl.commitPlacement();
+
+        AppSettings::instance().setValue(QStringLiteral("Applet_RX"), QStringLiteral("True"));
+        AppSettings::instance().setValue(QStringLiteral("Applet_TX"), QStringLiteral("True"));
+        AppSettings::instance().setValue(QStringLiteral("AppletPanelVisible"),
+                                         QStringLiteral("True"));
+        AppSettings::instance().setValue(QStringLiteral("AppletPanelDockedLeft"),
+                                         QStringLiteral("False"));
+        AppSettings::instance().setValue(QStringLiteral("PanadapterLayout"),
+                                         QStringLiteral("4v"));
+        AppSettings::instance().save();
+        report("canvas pan layout accepts canonical 4v",
+               ctl.applyPanLayout(QStringLiteral("4v")));
+        const double classicPanWidth = 1.0 - AetherSDR::kClassicAppletColumnWidth;
+        report("4v replaces stale pan rectangles with canonical cells",
+               nearly(canvas.itemRect(pan0).x, 0.0)
+                   && nearly(canvas.itemRect(pan0).y, 0.0)
+                   && nearly(canvas.itemRect(pan0).w, classicPanWidth)
+                   && nearly(canvas.itemRect(pan0).h, 0.25)
+                   && nearly(canvas.itemRect(pan1).y, 0.25)
+                   && nearly(canvas.itemRect(pan2).y, 0.50)
+                   && nearly(canvas.itemRect(pan3).y, 0.75));
+        report("canvas pan layout preserves applet and extra surface",
+               canvas.itemRect(QStringLiteral("applet:RX")) == appletBefore
+                   && !preservedSurface.isEmpty()
+                   && storedDocument().contains(preservedSurface));
+
+        // A lower-slot pop-out stays untouched and does not leave a blank
+        // canonical cell between the active main-surface pans.
+        floatingPans.insert(QStringLiteral("0x40000002"));
+        ctl.onPanFloated(QStringLiteral("0x40000002"));
+        report("floating pan is outside active-main layout membership",
+               !ctl.activeMainPanIdsForLayout().contains(
+                   QStringLiteral("0x40000002")));
+        AppSettings::instance().setValue(QStringLiteral("PanadapterLayout"),
+                                         QStringLiteral("3v"));
+        AppSettings::instance().save();
+        report("floating lower slot does not consume a canvas layout cell",
+               ctl.applyPanLayout(QStringLiteral("3v"))
+                   && !canvas.contains(pan1)
+                   && nearly(canvas.itemRect(pan0).y, 0.0)
+                   && nearly(canvas.itemRect(pan2).y, 1.0 / 3.0)
+                   && nearly(canvas.itemRect(pan3).y, 2.0 / 3.0));
+        floatingPans.remove(QStringLiteral("0x40000002"));
+        ctl.onPanDocked(QStringLiteral("0x40000002"));
+
+        AppSettings::instance().setValue(QStringLiteral("PanadapterLayout"),
+                                         QStringLiteral("2x2"));
+        AppSettings::instance().save();
+        report("2x2 maps live pan slots in Classic order",
+               ctl.applyPanLayout(QStringLiteral("2x2"))
+                   && nearly(canvas.itemRect(pan0).x, 0.0)
+                   && nearly(canvas.itemRect(pan0).y, 0.0)
+                   && nearly(canvas.itemRect(pan0).w, classicPanWidth / 2.0)
+                   && nearly(canvas.itemRect(pan0).h, 0.5)
+                   && nearly(canvas.itemRect(pan1).x, classicPanWidth / 2.0)
+                   && nearly(canvas.itemRect(pan1).y, 0.0)
+                   && nearly(canvas.itemRect(pan2).x, 0.0)
+                   && nearly(canvas.itemRect(pan2).y, 0.5)
+                   && nearly(canvas.itemRect(pan3).x, classicPanWidth / 2.0)
+                   && nearly(canvas.itemRect(pan3).y, 0.5));
+        WorkspaceDocument persisted;
+        const bool parsedStored = WorkspaceDocument::fromStoredJson(
+            storedDocument().toUtf8(), &persisted);
+        const Workspace* persistedWs = parsedStored
+            ? persisted.workspace(persisted.activeWorkspace) : nullptr;
+        const WorkspaceSurface* persistedMain = persistedWs
+            ? persistedWs->surface(WorkspaceSurface::kMainId) : nullptr;
+        const CanvasItem* persistedPan3 = nullptr;
+        if (persistedMain) {
+            for (const CanvasItem& item : persistedMain->items) {
+                if (item.id == pan3) {
+                    persistedPan3 = &item;
+                    break;
+                }
+            }
+        }
+        report("2x2 canonical geometry reached stored workspace JSON",
+               persistedPan3 && nearly(persistedPan3->rect.x, classicPanWidth / 2.0)
+                   && nearly(persistedPan3->rect.y, 0.5)
+                   && nearly(persistedPan3->rect.w, classicPanWidth / 2.0)
+                   && nearly(persistedPan3->rect.h, 0.5));
+
+        // A shrink can remove a pan whose radio id sorts last even though its
+        // stable canvas slot is in the middle. Re-apply after that actual
+        // removal: surviving non-contiguous slots must fill all 3v cells.
+        ctl.onPanRekeyed(QStringLiteral("0x40000010"),
+                         QStringLiteral("0xf0000010"));
+        pans.insert(QStringLiteral("0xf0000010"),
+                    pans.take(QStringLiteral("0x40000010")));
+        ctl.onPanRemoved(QStringLiteral("0xf0000010"));
+        pans.remove(QStringLiteral("0xf0000010"));
+        report("post-rekey shrink reflows the actual surviving slots",
+               ctl.applyPanLayout(QStringLiteral("3v"))
+                   && nearly(canvas.itemRect(pan0).y, 0.0)
+                   && nearly(canvas.itemRect(pan1).y, 1.0 / 3.0)
+                   && nearly(canvas.itemRect(pan3).y, 2.0 / 3.0));
+
+        // Restore a fourth live pan for the surrounding lifecycle cleanup;
+        // the freed stable slot is reused rather than minting a fifth item.
+        auto* replacementPanD2 = new QWidget(&panOwner);
+        pans.insert(QStringLiteral("0x40000012"), replacementPanD2);
+        ctl.onPanAdded(QStringLiteral("0x40000012"));
+        report("replacement pan reuses the removed stable slot",
+               ctl.panItemIdFor(QStringLiteral("0x40000012")) == pan2);
+        const QString beforeInvalid = storedDocument();
+        report("invalid canvas pan layout is a no-op",
+               !ctl.applyPanLayout(QStringLiteral("not-a-layout"))
+                   && storedDocument() == beforeInvalid);
+        ctl.removeCanvasWindow(preservedSurface);
+        ctl.onPanRemoved(QStringLiteral("0x40000012"));
+        ctl.onPanRemoved(QStringLiteral("0x40000011"));
+        pans.remove(QStringLiteral("0x40000012"));
+        pans.remove(QStringLiteral("0x40000011"));
+
         ctl.onPanRemoved(QStringLiteral("0x40000002"));
         pans.remove(QStringLiteral("0x40000002"));
         ctl.disable();
+        const QString beforeDisabled = storedDocument();
+        report("disabled canvas pan layout is a no-op",
+               !ctl.applyPanLayout(QStringLiteral("4v"))
+                   && storedDocument() == beforeDisabled);
     }
 
     // ── Phase 6: workspaces — CRUD, full-recall switching, bindings ──────
@@ -1048,6 +1190,16 @@ int main(int argc, char** argv)
                        && livePan->parentWidget() == wins.value(sid));
             report("...pans stay below applets on the new surface",
                    wins.value(sid)->layout().zOf(panItem) == 0);
+
+            const NormRect extraPanBefore{0.11, 0.22, 0.33, 0.44};
+            wins.value(sid)->setItemRect(panItem, extraPanBefore);
+            ctl.commitPlacement();
+            report("extra-surface pan is outside active-main layout membership",
+                   !ctl.activeMainPanIdsForLayout().contains(
+                       QStringLiteral("0x40000000")));
+            report("pan layout leaves extra-surface geometry untouched",
+                   ctl.applyPanLayout(QStringLiteral("4v"))
+                       && wins.value(sid)->itemRect(panItem) == extraPanBefore);
 
             // A rect edit on the window canvas persists like any other.
             wins.value(sid)->setItemRect("applet:RX",


### PR DESCRIPTION
Fixes #5150

## Root cause

The panadapter layout selector persisted `PanadapterLayout` and rearranged `PanadapterStack`. When Workspace Canvas was enabled, however, the visible panes were loaned to `WorkspaceController` and their authoritative geometry remained in `WorkspaceDocument`. No selector path reflowed those stored rectangles, so existing panes kept stale/custom geometry and newly created panes received generic cascade rectangles.

## Fix

- Reflow only live, non-floating panadapters on the active workspace's main surface through the canonical `ClassicLayout` cells.
- Preserve applets, floating panes, extra surfaces, and inactive workspaces.
- Settle asynchronous pan creation/removal with a generation-cancelled bounded retry, including canvas disable/re-enable during the transition.
- Keep legacy `PanadapterStack` behavior unchanged when Canvas is disabled.
- Preflight additions against the radio's global `maxPanadapters()` capacity before persisting the selection.
- Add the RX-only `workspace pan-layout <id>` automation verb so the production selector path is directly provable.

## Verification

- ARM64 app build on refreshed `upstream/main` (`8c49e300`):
  - `/opt/homebrew/bin/cmake --build build-codex-arm64 --target AetherSDR workspace_controller_test -j8`
  - host/system processor: `arm64`; final executable: Mach-O 64-bit arm64
  - no RNNoise x86 sources in the Ninja compilation graph
- `ctest --test-dir build-codex-arm64 -R '^workspace_controller_test$' --output-on-failure`: passed (1/1)
- `python3 tools/check_test_registration.py --strict`: passed
- `python3 tools/check_engine_boundary.py --strict`: 0 blocking findings
- `python3 tools/gen_bridge_docs.py`: already up to date (68 verbs)
- `git diff --check`: clean

### Automation-bridge proof

Used disposable HOME/settings/socket paths and the in-process demo backend. `AETHER_AUTOMATION_ALLOW_TX` was never set; every radio readback reported `transmitting:false` and `txPower:0`.

Broken baseline: after selecting `4v`, the persisted setting changed but the visible WorkspaceDocument still held overlapping/cascade rectangles, including `pan:3 = [0.3, 0.3, 0.6, 0.6]`.

Fixed build: `workspace pan-layout 4v` grew from one to four panes even though the demo exposes one slice (pan capacity is four), then settled to:

| item | x | y | w | h |
|---|---:|---:|---:|---:|
| `pan:0` | 0 | 0 | 0.82 | 0.25 |
| `pan:1` | 0 | 0.25 | 0.82 | 0.25 |
| `pan:2` | 0 | 0.50 | 0.82 | 0.25 |
| `pan:3` | 0 | 0.75 | 0.82 | 0.25 |
| `applet:DEMO` | 0.82 | 0 | 0.18 | 1 |

Disable/re-enable replay retained those exact rectangles. A subsequent `4v -> 2v -> 2x2` run removed and regrew panes asynchronously, ended with all four canonical 2x2 cells, preserved the DEMO applet, and remained TX-off.

### Before

![Workspace Canvas retaining stale overlapping rectangles](https://raw.githubusercontent.com/rfoust/AetherSDR/fix-5150-assets/.pr-assets/5150-before.png)

### After

![Workspace Canvas using canonical 4v geometry](https://raw.githubusercontent.com/rfoust/AetherSDR/fix-5150-assets/.pr-assets/5150-after.png)

Generated with OpenAI Codex.
