### PR TITLE
Add Settings deep-link button to AetherControl for FlexControl config

### DIFF
--- a/src/gui/FlexControlDialog.cpp
+++ b/src/gui/FlexControlDialog.cpp
@@ -1059,6 +1059,22 @@ FlexControlDialog::FlexControlDialog(QWidget* parent)
     });
     headerLayout->addWidget(m_physicalButton, 0, Qt::AlignVCenter);
 
+#ifdef HAVE_SERIALPORT
+    // Deep-link to the FlexControl Tuning Knob group on the Serial &
+    // Controllers Radio Setup page (#4940). Guarded the same as that page
+    // itself (RadioSetupDialog.cpp) — without HAVE_SERIALPORT the page
+    // doesn't exist, so the button would navigate nowhere.
+    m_settingsButton = new QPushButton(QStringLiteral("Settings…"), header);
+    m_settingsButton->setObjectName(QStringLiteral("OptionButton"));
+    m_settingsButton->setCursor(Qt::PointingHandCursor);
+    m_settingsButton->setToolTip(
+        QStringLiteral("Open the FlexControl Tuning Knob configuration page."));
+    connect(m_settingsButton, &QPushButton::clicked, this, [this] {
+        emit configureRequested();
+    });
+    headerLayout->addWidget(m_settingsButton, 0, Qt::AlignVCenter);
+#endif
+
     m_compactButton = new QPushButton(QStringLiteral("Compact"), header);
     m_compactButton->setObjectName(QStringLiteral("OptionButton"));
     m_compactButton->setCheckable(true);

--- a/src/gui/FlexControlDialog.h
+++ b/src/gui/FlexControlDialog.h
@@ -43,6 +43,10 @@ signals:
     void flexControlSettingsChanged();
     void physicalDetectRequested();
     void physicalDisconnectRequested();
+    // Deep-links to the FlexControl Tuning Knob group on the Serial &
+    // Controllers Radio Setup page (#4940) — a config shortcut, not a
+    // duplicate editor; the fields it opens onto stay the single source.
+    void configureRequested();
 
 public slots:
     void reject() override;
@@ -88,6 +92,9 @@ private:
     QLabel* m_modeLabel{nullptr};
     QLabel* m_pushHintLabel{nullptr};
     QPushButton* m_physicalButton{nullptr};
+#ifdef HAVE_SERIALPORT
+    QPushButton* m_settingsButton{nullptr};
+#endif
     QPushButton* m_compactButton{nullptr};
     QPushButton* m_externalSpinButton{nullptr};
     QPushButton* m_reverseButton{nullptr};

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3219,6 +3219,21 @@ void MainWindow::publishRadioStateMqtt()
 }
 #endif
 
+RadioSetupDialog* MainWindow::openRadioSetupPage(const QString& page)
+{
+    const QString prevComp = m_radioModel.audioCompressionParam();
+    const bool wasFresh = !m_radioSetupDialog;
+    showOrRaisePersistent(m_radioSetupDialog,
+                          &m_radioModel, m_audio,
+                          &m_tgxlConn, &m_pgxlConn, &m_antennaGenius,
+                          m_kiwiSdrManager, &m_acomConn, &m_speConn, &m_vkampConn);
+    if (wasFresh && m_radioSetupDialog)
+        wireRadioSetupDialogSignals(m_radioSetupDialog, prevComp);
+    if (m_radioSetupDialog && !page.isEmpty())
+        m_radioSetupDialog->selectTab(page);
+    return m_radioSetupDialog;
+}
+
 void MainWindow::wireRadioSetupDialogSignals(RadioSetupDialog* dlg, const QString& prevComp)
 {
     if (!dlg) return;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -789,6 +789,15 @@ private:
     // the finished handler can detect a change and recreate the RX audio stream.
     void wireRadioSetupDialogSignals(RadioSetupDialog* dlg, const QString& prevComp);
 
+    // Open (or raise) the persistent RadioSetupDialog and, if given a
+    // non-empty page name, select that page. Collapses the prevComp/wasFresh/
+    // wireRadioSetupDialogSignals dance that used to be copy-pasted at every
+    // call site (Settings → Radio Setup, USB Cables, XVTR overlay,
+    // FlexControl "Settings…") into one place (#4940 follow-up — PR #5157
+    // review). Returns the dialog so a caller needing a page-specific reveal
+    // (e.g. revealFlexControlSettings()) can act on it further.
+    RadioSetupDialog* openRadioSetupPage(const QString& page = {});
+
     // Reorder the main splitter so the applet panel sits on the left or
     // right of the panadapter stack.  Wired from the dock-side icons in
     // the title bar and persisted via "AppletPanelDockedLeft".

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -283,6 +283,24 @@ void MainWindow::showFlexControlDialog()
                 m_flexControlDialog->setPhysicalReady(false);
 #endif
         });
+#ifdef HAVE_SERIALPORT
+        connect(m_flexControlDialog, &FlexControlDialog::configureRequested,
+                this, [this] {
+            // Same deep-link pattern as Settings → USB Cables… (#4940):
+            // open Radio Setup with Serial & Controllers pre-selected,
+            // where the FlexControl Tuning Knob group actually lives.
+            const QString prevComp = m_radioModel.audioCompressionParam();
+            const bool wasFresh = !m_radioSetupDialog;
+            showOrRaisePersistent(m_radioSetupDialog,
+                                  &m_radioModel, m_audio,
+                                  &m_tgxlConn, &m_pgxlConn, &m_antennaGenius,
+                                  m_kiwiSdrManager, &m_acomConn, &m_speConn, &m_vkampConn);
+            if (wasFresh && m_radioSetupDialog)
+                wireRadioSetupDialogSignals(m_radioSetupDialog, prevComp);
+            if (m_radioSetupDialog)
+                m_radioSetupDialog->selectTab(QStringLiteral("Serial & Controllers"));
+        });
+#endif
         connect(m_flexControlDialog, &FlexControlDialog::physicalDisconnectRequested,
                 this, [this] {
 #ifdef HAVE_SERIALPORT

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -286,19 +286,11 @@ void MainWindow::showFlexControlDialog()
 #ifdef HAVE_SERIALPORT
         connect(m_flexControlDialog, &FlexControlDialog::configureRequested,
                 this, [this] {
-            // Same deep-link pattern as Settings → USB Cables… (#4940):
-            // open Radio Setup with Serial & Controllers pre-selected,
-            // where the FlexControl Tuning Knob group actually lives.
-            const QString prevComp = m_radioModel.audioCompressionParam();
-            const bool wasFresh = !m_radioSetupDialog;
-            showOrRaisePersistent(m_radioSetupDialog,
-                                  &m_radioModel, m_audio,
-                                  &m_tgxlConn, &m_pgxlConn, &m_antennaGenius,
-                                  m_kiwiSdrManager, &m_acomConn, &m_speConn, &m_vkampConn);
-            if (wasFresh && m_radioSetupDialog)
-                wireRadioSetupDialogSignals(m_radioSetupDialog, prevComp);
-            if (m_radioSetupDialog)
-                m_radioSetupDialog->selectTab(QStringLiteral("Serial & Controllers"));
+            // Same deep-link pattern as Settings → USB Cables… (#4940), but
+            // scrolled onto the FlexControl Tuning Knob group itself rather
+            // than just landing on top of the page (PR #5157 review).
+            if (RadioSetupDialog* dlg = openRadioSetupPage())
+                dlg->revealFlexControlSettings();
         });
 #endif
         connect(m_flexControlDialog, &FlexControlDialog::physicalDisconnectRequested,

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -126,6 +126,22 @@ void MainWindow::buildMenuBar()
     connect(flexControlAction, &QAction::triggered,
             this, &MainWindow::showFlexControlDialog);
 
+#ifdef HAVE_SERIALPORT
+    // Primary discoverability entry for #4940 — a Settings-menu shortcut
+    // straight to the FlexControl Tuning Knob group, for the user who
+    // browses Settings looking for it rather than opening AetherControl...
+    // first. Guarded the same as the Serial & Controllers page itself
+    // (RadioSetupDialog.cpp) and the AetherControl "Settings…" button
+    // (MainWindow_Controllers.cpp) that offers the same deep-link from
+    // inside the controller window.
+    auto* flexControlKnobAction = settingsMenu->addAction("FlexControl Knob & Buttons...");
+    flexControlKnobAction->setMenuRole(QAction::NoRole);
+    connect(flexControlKnobAction, &QAction::triggered, this, [this] {
+        if (RadioSetupDialog* dlg = openRadioSetupPage())
+            dlg->revealFlexControlSettings();
+    });
+#endif
+
     auto* networkAction = settingsMenu->addAction("Network...");
     connect(networkAction, &QAction::triggered, this, [this] {
         showNetworkDiagnosticsDialog();

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -112,16 +112,7 @@ void MainWindow::buildMenuBar()
     auto* radioSetup = settingsMenu->addAction("Radio Setup...");
     radioSetup->setMenuRole(QAction::PreferencesRole);  // macOS: appears in app menu as Preferences (#883, #1013)
     connect(radioSetup, &QAction::triggered, this, [this] {
-        // Snapshot compression setting before dialog opens — used by the
-        // finished handler to detect a change and recreate the RX audio stream.
-        const QString prevComp = m_radioModel.audioCompressionParam();
-        const bool wasFresh = !m_radioSetupDialog;
-        showOrRaisePersistent(m_radioSetupDialog,
-                              &m_radioModel, m_audio,
-                              &m_tgxlConn, &m_pgxlConn, &m_antennaGenius,
-                              m_kiwiSdrManager, &m_acomConn, &m_speConn, &m_vkampConn);
-        if (wasFresh && m_radioSetupDialog)
-            wireRadioSetupDialogSignals(m_radioSetupDialog, prevComp);
+        openRadioSetupPage();
     });
 
     auto* chooseRadio = settingsMenu->addAction("Connect to Radio...");
@@ -312,16 +303,7 @@ void MainWindow::buildMenuBar()
     });
     auto* usbCablesAction = settingsMenu->addAction("USB Cables...");
     connect(usbCablesAction, &QAction::triggered, this, [this] {
-        const QString prevComp = m_radioModel.audioCompressionParam();
-        const bool wasFresh = !m_radioSetupDialog;
-        showOrRaisePersistent(m_radioSetupDialog,
-                              &m_radioModel, m_audio,
-                              &m_tgxlConn, &m_pgxlConn, &m_antennaGenius,
-                              m_kiwiSdrManager, &m_acomConn, &m_speConn, &m_vkampConn);
-        if (wasFresh && m_radioSetupDialog)
-            wireRadioSetupDialogSignals(m_radioSetupDialog, prevComp);
-        if (m_radioSetupDialog)
-            m_radioSetupDialog->selectTab(QStringLiteral("USB Cables"));
+        openRadioSetupPage(QStringLiteral("USB Cables"));
     });
 #ifdef HAVE_MIDI
     auto* midiAction = settingsMenu->addAction("MIDI Mapping...");

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -5245,16 +5245,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     // XVTR button → open Radio Setup XVTR tab (#571)
     connect(menu, &SpectrumOverlayMenu::xvtrSetupRequested,
             this, [this]() {
-        const QString prevComp = m_radioModel.audioCompressionParam();
-        const bool wasFresh = !m_radioSetupDialog;
-        showOrRaisePersistent(m_radioSetupDialog,
-                              &m_radioModel, m_audio,
-                              &m_tgxlConn, &m_pgxlConn, &m_antennaGenius,
-                              m_kiwiSdrManager, &m_acomConn, &m_speConn, &m_vkampConn);
-        if (wasFresh && m_radioSetupDialog)
-            wireRadioSetupDialogSignals(m_radioSetupDialog, prevComp);
-        if (m_radioSetupDialog)
-            m_radioSetupDialog->selectTab(QStringLiteral("XVTR"));
+        openRadioSetupPage(QStringLiteral("XVTR"));
     });
 
     // ── WNB / RF Gain ────────────────────────────────────────────────────

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -6483,6 +6483,7 @@ QWidget* RadioSetupDialog::buildSerialTab()
     {
         auto* group = new QGroupBox("FlexControl Tuning Knob");
         group->setStyleSheet(kGroupStyle);
+        m_flexControlGroup = group;
         auto* grid = new QGridLayout(group);
         grid->setSpacing(6);
 
@@ -7993,6 +7994,33 @@ void RadioSetupDialog::selectTab(const QString& tabName)
         m_navigation->setCurrentItem(item);
         m_navigation->scrollToItem(item, QAbstractItemView::PositionAtCenter);
     }
+}
+
+void RadioSetupDialog::revealFlexControlSettings()
+{
+    selectTab(QStringLiteral("Serial & Controllers"));
+    if (!m_flexControlGroup) {
+        return;
+    }
+    // selectTab() just switched (and, on first visit, built) the page on
+    // this call stack, but the scroll area it's wrapped in (#3345) hasn't
+    // laid out yet — ensureWidgetVisible() against stale/zero geometry is a
+    // no-op. Defer one event-loop turn so layout has actually happened.
+    QPointer<QGroupBox> group = m_flexControlGroup;
+    QTimer::singleShot(0, this, [group] {
+        if (!group) {
+            return;
+        }
+        // The group lives inside the tab's content widget, which
+        // wrapTabInScrollArea() set as the QScrollArea's viewport child —
+        // walk up the parent chain to find that enclosing scroll area.
+        for (QWidget* w = group->parentWidget(); w; w = w->parentWidget()) {
+            if (auto* area = qobject_cast<QScrollArea*>(w)) {
+                area->ensureWidgetVisible(group);
+                return;
+            }
+        }
+    });
 }
 
 void RadioSetupDialog::refreshFlexControlButtonActions()

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -78,6 +78,8 @@
 #include <QPlainTextEdit>
 #include <QSplitter>
 #include <QScrollArea>
+#include <QScrollBar>
+#include <QPoint>
 #include <QHostAddress>
 #include <QClipboard>
 #include <QDebug>
@@ -8016,7 +8018,19 @@ void RadioSetupDialog::revealFlexControlSettings()
         // walk up the parent chain to find that enclosing scroll area.
         for (QWidget* w = group->parentWidget(); w; w = w->parentWidget()) {
             if (auto* area = qobject_cast<QScrollArea*>(w)) {
-                area->ensureWidgetVisible(group);
+                QWidget* content = area->widget();
+                if (!content) {
+                    return;
+                }
+                // Deliberately not ensureWidgetVisible(): it *centers* a
+                // widget taller than the viewport, and the FlexControl
+                // Tuning Knob group (~450-480px) is tall enough that at the
+                // dialog's 960x680 floor, centering pushes the group's own
+                // title and Status row above the top edge — the opposite of
+                // what "reveal" should do. Scroll its top edge into view
+                // directly instead (PR #5157 review).
+                const int y = group->mapTo(content, QPoint(0, 0)).y();
+                area->verticalScrollBar()->setValue(qMax(0, y - 8));
                 return;
             }
         }

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -50,6 +50,11 @@ public:
                               VkampConnection* vkamp = nullptr,
                               QWidget* parent = nullptr);
     void selectTab(const QString& tabName);
+    // Like selectTab("Serial & Controllers"), but also scrolls the page so
+    // the FlexControl Tuning Knob group is actually in view instead of just
+    // landing at the top of a long, scroll-wrapped page (#4940 follow-up —
+    // PR #5157 review).
+    void revealFlexControlSettings();
     void refreshFlexControlButtonActions();
     void setFlexControlConnectionStatus(bool connected, const QString& port = {});
 
@@ -157,6 +162,7 @@ private:
     QHash<QString, QComboBox*> m_flexControlActionCombos;
     QHash<QString, QString> m_flexControlActionDefaults;
     QLabel* m_flexControlStatusLabel{nullptr};
+    QGroupBox* m_flexControlGroup{nullptr};
     QPushButton* m_flexControlDetectButton{nullptr};
     QPushButton* m_flexControlCloseButton{nullptr};
     QCheckBox* m_flexControlInvertCheck{nullptr};


### PR DESCRIPTION
## What

Adds a **Settings…** button to the AetherControl (virtual FlexControl) window header, next to **Compact**. Clicking it deep-links into Radio Setup → **Serial & Controllers**, where the existing FlexControl Tuning Knob configuration group already lives — reusing the same `showOrRaisePersistent` + `selectTab()` pattern the existing "Settings → USB Cables…" deep-link uses.

No new settings keys, no page moves, no duplicated editors. The existing path (Settings → USB Cables → Serial & Controllers → FlexControl Tuning Knob) is untouched and still works.

Guarded behind `#ifdef HAVE_SERIALPORT`, matching the guard already on the Serial & Controllers page itself — on a build without serial-port support, the button doesn't compile in, so it can never navigate to a page that doesn't exist. `HAVE_SERIALPORT` is set uniformly across platforms (`CMakeLists.txt`), so this doesn't introduce any Windows/macOS/Linux divergence.

Fixes #4940.

## Why this shape

Per triage on the issue (comment from `aethersdr-agent`), the issue's literal ask — a row under a "Settings → Aether Control" list — doesn't map onto the current UI: AetherControl is a window, not a settings list, and there's no parent/child relationship between USB Cables and Serial & Controllers to nest under. The triage comment proposed two options; the issue author (nz1q) confirmed this one explicitly: *"Adding a setting button just under AetherControl for FlexControl."*

## Testing

Manually tested on Windows with a physical FlexControl knob attached:
- AetherControl window shows the new **Settings…** button next to Compact.
- Clicking it opens Radio Setup with Serial & Controllers pre-selected, landing on the FlexControl Tuning Knob group.
- Existing Settings → USB Cables → Serial & Controllers path still works unchanged.
- Radio Setup dialog is raised (not duplicated) if already open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
