### PR TITLE
 docs: point AETHER_MCP_TOKEN at shell export, not file-based MCP config

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -167,10 +167,16 @@ that should have changed → `grab_widget` for a visual check.
 random token (stored in your OS secret store via QtKeychain — macOS
 Keychain / Windows Credential Manager / libsecret-KWallet, never in the
 settings store — RFC #4603 bans credentials from it outright). Copy it
-into your assistant's MCP config as the
-`AETHER_MCP_TOKEN` environment variable; the bridge then rejects every
-verb except `ping` without a matching token. Headless/CI can supply the
-token via `AETHER_MCP_TOKEN` directly, which overrides the keychain.
+and `export AETHER_MCP_TOKEN=<token>` in the shell that launches your
+assistant — `tools/aether_mcp.py` inherits it from the parent process
+environment automatically, so there is no file to edit. In particular,
+**do not** add an `env` block to `.mcp.json` (or any other MCP config
+file) to carry this token — that puts a live credential in a file on
+disk instead of your OS keychain, undoing the point of storing it there
+in the first place, and risks it landing in a commit if that file is
+tracked. The bridge rejects every verb except `ping` without a matching
+token. Headless/CI can supply the token via `AETHER_MCP_TOKEN` directly,
+which overrides the keychain.
 
 ### Secure fresh-build handoff
 

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -166,17 +166,16 @@ that should have changed → `grab_widget` for a visual check.
 **Access token.** Enabling the bridge in Radio Setup → Network mints a
 random token (stored in your OS secret store via QtKeychain — macOS
 Keychain / Windows Credential Manager / libsecret-KWallet, never in the
-settings store — RFC #4603 bans credentials from it outright). Copy it
-and `export AETHER_MCP_TOKEN=<token>` in the shell that launches your
-assistant — `tools/aether_mcp.py` inherits it from the parent process
-environment automatically, so there is no file to edit. In particular,
-**do not** add an `env` block to `.mcp.json` (or any other MCP config
-file) to carry this token — that puts a live credential in a file on
-disk instead of your OS keychain, undoing the point of storing it there
-in the first place, and risks it landing in a commit if that file is
-tracked. The bridge rejects every verb except `ping` without a matching
-token. Headless/CI can supply the token via `AETHER_MCP_TOKEN` directly,
-which overrides the keychain.
+settings store — RFC #4603 bans credentials from it outright). Make it
+available as `AETHER_MCP_TOKEN` only in the shell session that launches
+your assistant, using a secret-safe input method that does not record the
+value in shell history. `tools/aether_mcp.py` inherits it from the parent
+process environment automatically, so no file needs to carry it. **Do not**
+put the literal token in a shell profile or add an `env` block to `.mcp.json`
+(or any other MCP config file) — those put a live credential on disk instead
+of keeping it in your OS keychain and risk it landing in a commit. The bridge
+rejects every verb except `ping` without a matching token. Headless/CI can
+supply the token via `AETHER_MCP_TOKEN` directly, which overrides the keychain.
 
 ### Secure fresh-build handoff
 

--- a/tools/aether_mcp.py
+++ b/tools/aether_mcp.py
@@ -26,12 +26,12 @@ no MCP client can key a live radio by accident.
 
 Auth: if the operator set an access token in Radio Setup → Network, the
 bridge rejects every verb (except ping) without a matching token. This
-process inherits AETHER_MCP_TOKEN from whatever shell launched your
-assistant — export it there (e.g. in your shell profile) and this server
-picks it up automatically. No file needs to carry it: nothing here reads
-an "env" block from an MCP config file, so there's no reason to put the
-token in one. Without the right token the app cannot be driven — that's
-what stops a random local agent from touching the radio.
+process inherits AETHER_MCP_TOKEN from the environment that launched your
+assistant. Set it only for the current session using a secret-safe input
+method; do not put the literal token in a shell profile or command history.
+Nothing here reads an "env" block from an MCP config file, so no file needs
+to carry it. Without the right token the app cannot be driven — that's what
+stops a random local agent from touching the radio.
 
 Env:
     AETHER_MCP_SOCKET   override the bridge socket path (else discovery)
@@ -1002,10 +1002,11 @@ def handle_tool(name, args):
                 status["hint"] = ("This bridge requires a token, but "
                                   "AETHER_MCP_TOKEN is not set for this server. "
                                   "Copy the token from Radio Setup → Network → "
-                                  "Access Token, then export AETHER_MCP_TOKEN=<token> "
-                                  "in the shell that launches your assistant -- no "
-                                  "file needs to carry it, this process inherits "
-                                  "the shell environment automatically.")
+                                  "Access Token, then set AETHER_MCP_TOKEN only for "
+                                  "the current shell session using secret-safe input "
+                                  "that does not record it in history. Do not put the "
+                                  "literal token in a shell profile or MCP config; "
+                                  "this process inherits the session environment.")
             if status.get("bridge_read_only"):
                 status["read_only_note"] = (
                     "This bridge is observe-only. Read verbs work; every "

--- a/tools/aether_mcp.py
+++ b/tools/aether_mcp.py
@@ -25,10 +25,13 @@ AETHER_AUTOMATION_ALLOW_TX — that gate lives in the app, not here, so
 no MCP client can key a live radio by accident.
 
 Auth: if the operator set an access token in Radio Setup → Network, the
-bridge rejects every verb (except ping) without a matching token. Put
-that token in AETHER_MCP_TOKEN and this server attaches it to every
-request. Without the right token the app cannot be driven — that's what
-stops a random local agent from touching the radio.
+bridge rejects every verb (except ping) without a matching token. This
+process inherits AETHER_MCP_TOKEN from whatever shell launched your
+assistant — export it there (e.g. in your shell profile) and this server
+picks it up automatically. No file needs to carry it: nothing here reads
+an "env" block from an MCP config file, so there's no reason to put the
+token in one. Without the right token the app cannot be driven — that's
+what stops a random local agent from touching the radio.
 
 Env:
     AETHER_MCP_SOCKET   override the bridge socket path (else discovery)
@@ -999,8 +1002,10 @@ def handle_tool(name, args):
                 status["hint"] = ("This bridge requires a token, but "
                                   "AETHER_MCP_TOKEN is not set for this server. "
                                   "Copy the token from Radio Setup → Network → "
-                                  "Access Token and set it in this MCP server's "
-                                  "env config.")
+                                  "Access Token, then export AETHER_MCP_TOKEN=<token> "
+                                  "in the shell that launches your assistant -- no "
+                                  "file needs to carry it, this process inherits "
+                                  "the shell environment automatically.")
             if status.get("bridge_read_only"):
                 status["read_only_note"] = (
                     "This bridge is observe-only. Read verbs work; every "


### PR DESCRIPTION
## Summary

The automation-bridge docs and `aether_mcp.py`'s own runtime hint told
contributors to put their access token "in your assistant's MCP config"
/ "this MCP server's env config" — read as: add an `env` block to
`.mcp.json`. That's unnecessary and works against the point of storing
the token in the OS keychain in the first place: `tools/aether_mcp.py`
already inherits `AETHER_MCP_TOKEN` from the parent shell environment,
so no file needs to carry it at all.

**Supersedes #5141**, which proposed untracking `.mcp.json` to guard
against a locally-edited token landing in a commit. Review on that PR
found the tracked file has never actually contained a token in any of
its 5 historical versions, and — more importantly — that the file-based
approach the docs pointed toward was never required to begin with.
Fixing the guidance removes the underlying risk at its source (nothing
points contributors toward file-based storage anymore) without any
tracking change, migration hazard for existing checkouts, or the
`.mcp.json.example` template #5141 would have added — which itself
modeled the same anti-pattern (a token placeholder in a file) it was
meant to prevent.

Not part of #4970 — found while setting up the automation bridge for
ANAN bring-up, but applies to every contributor regardless of backend.

## Constitution principle honored

N/A — documentation/guidance fix, no code behavior change.

## Test plan

- [x] `python3 tools/test_aether_mcp.py` — 42/43 checks pass; the one
      failure (`test_secure_app_instance`) reproduces identically on
      unmodified `main` (verified via `git stash`/`git stash pop` before
      committing) — it's a sandboxed dev-environment limitation writing
      to a fixed `/tmp/aether-mcp-*.sock` path, unrelated to this change
- [x] `python3 -m py_compile tools/aether_mcp.py` — syntax OK
- [ ] N/A — no behavior change, doc/hint text only

## Checklist

- [x] Commits are signed
- [ ] N/A — no `AppSettings` changes
- [ ] N/A — no protocol/hardware code
- [ ] N/A — no meter UI
- [x] Documentation updated (this PR *is* the documentation fix)
- [x] Security-sensitive: this closes a guidance gap that could have led
      a contributor to put a live credential in a file on disk; no
      credential was actually exposed by the docs themselves (they never
      showed a real token), so no GHSA is warranted — flagging here
      rather than silently checking it off.
