### PR TITLE
fix(gui): WheelApf no-ops while APF is off; dim APF row labels when disabled (#4658)

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1593,6 +1593,9 @@ private:
     int  m_adaptiveFpsCap{0};             // current cap (> 0 when throttle active); shown in network label
     QTimer* m_layoutRestoreTimer{nullptr}; // debounced layout rearrange after pans added on connect
     qint64 m_layoutRestoreUntilMs{0};
+    // WheelApf-while-off hint: wall-clock until which the notice is already
+    // on screen, so a spinning knob does not re-upsert the card per detent (#4658).
+    qint64 m_apfOffHintUntilMs{0};
     // User layout choices should suppress startup rearrange, but still allow
     // the pending timer to restore saved floating pan windows.
     bool m_suppressStartupPanLayoutRearrange{false};

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -1450,10 +1450,15 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
             // #4658: the level only reaches audio while the APF filter is in
             // circuit. Writing apf_level into a disengaged filter — and showing
             // an "APF 42" overlay that reads as the radio acknowledging it — is
-            // the controller-side twin of the GUI slider defect fixed in #4660.
-            // No-op here and tell the operator why, mirroring the slider's
-            // greyed-with-reason treatment. ToggleApf remains the way in.
+            // the controller-side twin of the GUI slider defect (#4658, fixed
+            // for the slider by #4660). No-op here and tell the operator why,
+            // mirroring the slider's greyed-with-reason treatment: the status
+            // bar reaches every controller (FlexControl, RC-28, Ulanzi, the
+            // virtual wheel); the TMate 2 additionally gets it on its own
+            // display. ToggleApf remains the way in.
             if (!s->apfOn()) {
+                statusBar()->showMessage(
+                    QStringLiteral("APF level: turn APF on first"), 3000);
 #ifdef HAVE_HIDAPI
                 triggerTMate2TextOverlay(QStringLiteral("APF OFF"));
 #endif

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -38,6 +38,7 @@
 #include "UlanziDialMapperDialog.h"
 #include "RxApplet.h"
 #include "SpectrumWidget.h"
+#include "PanadapterMessageOverlay.h"
 #include "TitleBar.h"
 #include "models/SliceModel.h"
 
@@ -1465,9 +1466,18 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
             // follow-up for that layout. ToggleApf remains the way in.
             if (!s->apfOn()) {
                 if (SpectrumWidget* sw = spectrumForSlice(s)) {
-                    sw->showTxFilterNotification(QStringLiteral("APF level"),
-                                                 QStringLiteral("Turn APF on first"),
-                                                 1500);
+                    // Own id and Info tone: this is a control hint, not a
+                    // warning, and it must neither evict nor be evicted by
+                    // the TX-filter ("txfilter.audio-loss") or interlock
+                    // cards — re-keying only replaces an earlier APF hint.
+                    PanadapterOverlayMessage card;
+                    card.id = QStringLiteral("apf.level-off");
+                    card.title = QStringLiteral("APF level");
+                    card.detail = QStringLiteral("Turn APF on first");
+                    card.timeoutMs = 1500;
+                    card.dismissible = true;
+                    card.tone = PanadapterOverlayMessageTone::Info;
+                    sw->upsertOverlayMessage(std::move(card));
                 } else {
                     statusBar()->showMessage(
                         QStringLiteral("APF level: turn APF on first"), 1500);

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -1459,12 +1459,23 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
             // permanent widget — TX indicator, PA temperature — for its whole
             // duration, and a spinning dead knob would retrigger it
             // continuously); the status bar is only the no-panadapter
-            // fallback. That reaches every controller family (FlexControl,
+            // (null-pan) fallback. That reaches every controller family (FlexControl,
             // RC-28, Ulanzi, the virtual wheel); a TMate 2 additionally gets
             // it on its own display. Minimal mode shows neither surface —
             // a slice-level signal consumed by the applet panel is the
             // follow-up for that layout. ToggleApf remains the way in.
             if (!s->apfOn()) {
+                // One notice per window, not one per detent: a timed card is
+                // not deduplicated by the overlay (its re-assert early-out is
+                // for untimed cards only), so each re-upsert would re-sort it
+                // to the top of the stack and relayout the others under a
+                // spinning knob — the #4649 objection, moved to a better
+                // surface. Show once, then stay quiet until it has expired.
+                constexpr int kApfOffHintMs = 1500;
+                const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+                if (nowMs < m_apfOffHintUntilMs)
+                    return;
+                m_apfOffHintUntilMs = nowMs + kApfOffHintMs;
                 if (SpectrumWidget* sw = spectrumForSlice(s)) {
                     // Own id and Info tone: this is a control hint, not a
                     // warning, and it must neither evict nor be evicted by
@@ -1474,13 +1485,17 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
                     card.id = QStringLiteral("apf.level-off");
                     card.title = QStringLiteral("APF level");
                     card.detail = QStringLiteral("Turn APF on first");
-                    card.timeoutMs = 1500;
+                    card.timeoutMs = kApfOffHintMs;
                     card.dismissible = true;
                     card.tone = PanadapterOverlayMessageTone::Info;
                     sw->upsertOverlayMessage(std::move(card));
                 } else {
+                    // Null-pan edge only: spectrumForSlice() still returns a
+                    // (hidden) widget in minimal mode, so that layout lands in
+                    // the branch above with nothing on screen — see the
+                    // comment at the top of this block.
                     statusBar()->showMessage(
-                        QStringLiteral("APF level: turn APF on first"), 1500);
+                        QStringLiteral("APF level: turn APF on first"), kApfOffHintMs);
                 }
 #ifdef HAVE_HIDAPI
                 triggerTMate2TextOverlay(QStringLiteral("APF OFF"));

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -1452,13 +1452,26 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
             // an "APF 42" overlay that reads as the radio acknowledging it — is
             // the controller-side twin of the GUI slider defect (#4658, fixed
             // for the slider by #4660). No-op here and tell the operator why,
-            // mirroring the slider's greyed-with-reason treatment: the status
-            // bar reaches every controller (FlexControl, RC-28, Ulanzi, the
-            // virtual wheel); the TMate 2 additionally gets it on its own
-            // display. ToggleApf remains the way in.
+            // mirroring the slider's greyed-with-reason treatment. The notice
+            // goes on the slice's panadapter as a transient card, NOT the
+            // status bar (#4649: a QStatusBar temporary message hides every
+            // permanent widget — TX indicator, PA temperature — for its whole
+            // duration, and a spinning dead knob would retrigger it
+            // continuously); the status bar is only the no-panadapter
+            // fallback. That reaches every controller family (FlexControl,
+            // RC-28, Ulanzi, the virtual wheel); a TMate 2 additionally gets
+            // it on its own display. Minimal mode shows neither surface —
+            // a slice-level signal consumed by the applet panel is the
+            // follow-up for that layout. ToggleApf remains the way in.
             if (!s->apfOn()) {
-                statusBar()->showMessage(
-                    QStringLiteral("APF level: turn APF on first"), 3000);
+                if (SpectrumWidget* sw = spectrumForSlice(s)) {
+                    sw->showTxFilterNotification(QStringLiteral("APF level"),
+                                                 QStringLiteral("Turn APF on first"),
+                                                 1500);
+                } else {
+                    statusBar()->showMessage(
+                        QStringLiteral("APF level: turn APF on first"), 1500);
+                }
 #ifdef HAVE_HIDAPI
                 triggerTMate2TextOverlay(QStringLiteral("APF OFF"));
 #endif

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -1464,6 +1464,11 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
             // it on its own display. Minimal mode shows neither surface —
             // a slice-level signal consumed by the applet panel is the
             // follow-up for that layout. ToggleApf remains the way in.
+            // APF is CW-only: the DSP grid does not even mount the button in
+            // other modes (VfoWidget hides m_apfBtn unless isCw), so a hint
+            // to "turn APF on" there would point at nothing. Stay silent.
+            if (!isCwMode(s->mode()))
+                return;
             if (!s->apfOn()) {
                 // One notice per window, not one per detent: a timed card is
                 // not deduplicated by the overlay (its re-assert early-out is

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -1447,6 +1447,18 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
         }
     } else if (actionId == "WheelApf") {
         if (auto* s = activeSlice()) {
+            // #4658: the level only reaches audio while the APF filter is in
+            // circuit. Writing apf_level into a disengaged filter — and showing
+            // an "APF 42" overlay that reads as the radio acknowledging it — is
+            // the controller-side twin of the GUI slider defect fixed in #4660.
+            // No-op here and tell the operator why, mirroring the slider's
+            // greyed-with-reason treatment. ToggleApf remains the way in.
+            if (!s->apfOn()) {
+#ifdef HAVE_HIDAPI
+                triggerTMate2TextOverlay(QStringLiteral("APF OFF"));
+#endif
+                return;
+            }
             const int next = std::clamp(s->apfLevel() + steps, 0, 100);
             s->setApfLevel(next);
 #ifdef HAVE_HIDAPI

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -458,19 +458,17 @@ static const QString kModeBtn =
     "QPushButton:checked { background: #0070c0; color: #ffffff; border: 1px solid #0090e0; }"
     "QPushButton:hover { border: 1px solid #0090e0; }";
 
-// Template, not a literal stylesheet: the :disabled rule resolves through
-// ThemeManager so a disabled row (the APF level row while APF is off) dims
-// its caption and value label together with its slider — a stylesheet
-// colour otherwise beats the disabled palette (#4658). Apply with
-// applyLabelStyle(), never setStyleSheet() directly.
+// Shared :disabled rule: a stylesheet colour beats the disabled palette, so
+// a label in a disabled row stays bright unless the sheet says otherwise.
+// #5e6e7c is ~0.45 of the normal text over the flag background. Used by
+// kLabelStyle (so the APF level row dims as a unit while APF is off, #4658)
+// and by makeOptLabel() below.
+static const QString kDisabledLabelRule =
+    "QLabel:disabled { color: #5e6e7c; }";
+
 static const QString kLabelStyle =
     "QLabel { background: transparent; border: none; color: #8aa8c0; font-size: 13px; }"
-    "QLabel:disabled { color: {{color.text.disabled}}; }";
-
-static void applyLabelStyle(QWidget* label)
-{
-    AetherSDR::ThemeManager::instance().applyStyleSheet(label, kLabelStyle);
-}
+    + kDisabledLabelRule;
 
 // Meter-view selector buttons.  Unselected look matches the DSP NR/NB/ANF
 // toggles exactly (kDspToggle base + hover); the selected/checked look matches
@@ -1281,11 +1279,10 @@ void VfoWidget::buildUI()
         auto* lbl = new QLabel(text);
         // :disabled dims the label when its row is disabled — a render()-compatible
         // replacement for the old QGraphicsOpacityEffect (which QWidget::render()
-        // can't rasterize, so it blanked these rows in GPU flag sprites). #5e6e7c is
-        // ~0.45 of the normal text over the flag background.
+        // can't rasterize, so it blanked these rows in GPU flag sprites).
         lbl->setStyleSheet("QLabel { background: transparent; border: none; "
                            "color: #c8d8e8; font-size: 12px; }"
-                           "QLabel:disabled { color: #5e6e7c; }");
+                           + kDisabledLabelRule);
         return lbl;
     };
 
@@ -1569,7 +1566,7 @@ void VfoWidget::buildTabContent()
         applyPrimarySliderStyle(m_afGainSlider);
         gainRow->addWidget(m_afGainSlider, 1);
         auto* afVal = new QLabel("0");
-        applyLabelStyle(afVal);
+        afVal->setStyleSheet(kLabelStyle);
         afVal->setFixedWidth(20);
         afVal->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
         gainRow->addWidget(afVal);
@@ -1591,7 +1588,7 @@ void VfoWidget::buildTabContent()
         applyPrimarySliderStyle(m_sqlSlider);
         sqlRow->addWidget(m_sqlSlider, 1);
         m_sqlValueLbl = new QLabel("20");
-        applyLabelStyle(m_sqlValueLbl);
+        m_sqlValueLbl->setStyleSheet(kLabelStyle);
         m_sqlValueLbl->setFixedWidth(20);
         m_sqlValueLbl->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
         sqlRow->addWidget(m_sqlValueLbl);
@@ -1615,7 +1612,7 @@ void VfoWidget::buildTabContent()
         applyPrimarySliderStyle(m_agcTSlider);
         agcRow->addWidget(m_agcTSlider, 1);
         m_agcValueLbl = new QLabel("65");
-        applyLabelStyle(m_agcValueLbl);
+        m_agcValueLbl->setStyleSheet(kLabelStyle);
         m_agcValueLbl->setFixedWidth(20);
         m_agcValueLbl->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
         agcRow->addWidget(m_agcValueLbl);
@@ -1633,7 +1630,7 @@ void VfoWidget::buildTabContent()
         m_divBtn->setVisible(false);  // shown only on dual-SCU radios
         panRow->addWidget(m_divBtn);
         auto* panL = new QLabel("L");
-        applyLabelStyle(panL);
+        panL->setStyleSheet(kLabelStyle);
         panL->setFixedWidth(10);
         panL->setAlignment(Qt::AlignCenter);
         panRow->addWidget(panL);
@@ -1643,7 +1640,7 @@ void VfoWidget::buildTabContent()
         applyPrimarySliderStyle(m_panSlider);
         panRow->addWidget(m_panSlider, 1);
         auto* panR = new QLabel("R");
-        applyLabelStyle(panR);
+        panR->setStyleSheet(kLabelStyle);
         panR->setFixedWidth(10);
         panR->setAlignment(Qt::AlignCenter);
         panRow->addWidget(panR);
@@ -1678,7 +1675,7 @@ void VfoWidget::buildTabContent()
         m_escBtn->setStyleSheet(kDspToggle);
         escTopRow->addWidget(m_escBtn);
         auto* phaseLbl = new QLabel("P");
-        applyLabelStyle(phaseLbl);
+        phaseLbl->setStyleSheet(kLabelStyle);
         escTopRow->addWidget(phaseLbl);
         m_escPhaseSlider = new GuardedSlider(Qt::Horizontal);
         m_escPhaseSlider->setAccessibleName("ESC phase");
@@ -1687,7 +1684,7 @@ void VfoWidget::buildTabContent()
         applyPrimarySliderStyle(m_escPhaseSlider);
         escTopRow->addWidget(m_escPhaseSlider, 1);
         m_escPhaseLbl = new QLabel("0\u00B0");
-        applyLabelStyle(m_escPhaseLbl);
+        m_escPhaseLbl->setStyleSheet(kLabelStyle);
         m_escPhaseLbl->setFixedWidth(28);
         m_escPhaseLbl->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
         escTopRow->addWidget(m_escPhaseLbl);
@@ -1709,7 +1706,7 @@ void VfoWidget::buildTabContent()
         auto* gainCol = new QVBoxLayout;
         gainCol->setSpacing(1);
         m_escGainLbl = new QLabel("1.00");
-        applyLabelStyle(m_escGainLbl);
+        m_escGainLbl->setStyleSheet(kLabelStyle);
         m_escGainLbl->setAlignment(Qt::AlignHCenter);
         gainCol->addWidget(m_escGainLbl);
         m_escGainSlider = new GuardedSlider(Qt::Vertical);
@@ -1719,7 +1716,7 @@ void VfoWidget::buildTabContent()
         applyPrimarySliderStyle(m_escGainSlider);
         gainCol->addWidget(m_escGainSlider, 1);
         auto* gainLbl = new QLabel("G");
-        applyLabelStyle(gainLbl);
+        gainLbl->setStyleSheet(kLabelStyle);
         gainLbl->setAlignment(Qt::AlignHCenter);
         gainCol->addWidget(gainLbl);
         escBodyRow->addLayout(gainCol);
@@ -2059,7 +2056,7 @@ void VfoWidget::buildTabContent()
             apfVb->setSpacing(3);
 
             auto* lbl = new QLabel("APF");
-            applyLabelStyle(lbl);
+            lbl->setStyleSheet(kLabelStyle);
             lbl->setFixedWidth(26);
             apfVb->addWidget(lbl);
             m_apfSlider = new GuardedSlider(Qt::Horizontal);
@@ -2071,7 +2068,7 @@ void VfoWidget::buildTabContent()
             m_apfSlider->setToolTip("Adjusts APF bandwidth. Higher values narrow the peak for better CW selectivity. Enabled when APF is on in the DSP grid.");
             apfVb->addWidget(m_apfSlider, 1);
             m_apfValueLbl = new QLabel("50");
-            applyLabelStyle(m_apfValueLbl);
+            m_apfValueLbl->setStyleSheet(kLabelStyle);
             m_apfValueLbl->setFixedWidth(20);
             m_apfValueLbl->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
             apfVb->addWidget(m_apfValueLbl);
@@ -2361,7 +2358,7 @@ void VfoWidget::buildTabContent()
             auto* offRow = new QHBoxLayout;
             offRow->setSpacing(4);
             auto* offLbl = new QLabel("Offset:");
-            applyLabelStyle(offLbl);
+            offLbl->setStyleSheet(kLabelStyle);
             offRow->addWidget(offLbl);
             m_fmOffsetSpin = new QDoubleSpinBox;
             m_fmOffsetSpin->setAccessibleName("Repeater offset");
@@ -2757,7 +2754,7 @@ void VfoWidget::buildTabContent()
         auto* row = new QHBoxLayout;
         row->setSpacing(3);
         auto* lbl = new QLabel("DAX Ch");
-        applyLabelStyle(lbl);
+        lbl->setStyleSheet(kLabelStyle);
         row->addWidget(lbl);
         m_daxCmb = new GuardedComboBox;
         populateDaxCombo();  // capacity-gated; rebuilt on connect (setRadioModel)

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -458,8 +458,12 @@ static const QString kModeBtn =
     "QPushButton:checked { background: #0070c0; color: #ffffff; border: 1px solid #0090e0; }"
     "QPushButton:hover { border: 1px solid #0090e0; }";
 
+// :disabled rule so a disabled row (APF level while APF is off, SQL in
+// CW/DIG) dims its caption and value label together with its slider — a
+// stylesheet colour otherwise beats the disabled palette (#4658).
 static const QString kLabelStyle =
-    "QLabel { background: transparent; border: none; color: #8aa8c0; font-size: 13px; }";
+    "QLabel { background: transparent; border: none; color: #8aa8c0; font-size: 13px; }"
+    "QLabel:disabled { color: #5e6e7c; }";
 
 // Meter-view selector buttons.  Unselected look matches the DSP NR/NB/ANF
 // toggles exactly (kDspToggle base + hover); the selected/checked look matches
@@ -2053,7 +2057,7 @@ void VfoWidget::buildTabContent()
             apfVb->addWidget(lbl);
             m_apfSlider = new GuardedSlider(Qt::Horizontal);
             m_apfSlider->setAccessibleName("APF bandwidth");
-            m_apfSlider->setAccessibleDescription("CW audio peaking filter bandwidth");
+            m_apfSlider->setAccessibleDescription("CW audio peaking filter bandwidth. Enabled when APF is on in the DSP grid.");
             m_apfSlider->setRange(0, 100);
             m_apfSlider->setValue(50);
             applyPrimarySliderStyle(m_apfSlider);

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -458,12 +458,19 @@ static const QString kModeBtn =
     "QPushButton:checked { background: #0070c0; color: #ffffff; border: 1px solid #0090e0; }"
     "QPushButton:hover { border: 1px solid #0090e0; }";
 
-// :disabled rule so a disabled row (APF level while APF is off, SQL in
-// CW/DIG) dims its caption and value label together with its slider — a
-// stylesheet colour otherwise beats the disabled palette (#4658).
+// Template, not a literal stylesheet: the :disabled rule resolves through
+// ThemeManager so a disabled row (the APF level row while APF is off) dims
+// its caption and value label together with its slider — a stylesheet
+// colour otherwise beats the disabled palette (#4658). Apply with
+// applyLabelStyle(), never setStyleSheet() directly.
 static const QString kLabelStyle =
     "QLabel { background: transparent; border: none; color: #8aa8c0; font-size: 13px; }"
-    "QLabel:disabled { color: #5e6e7c; }";
+    "QLabel:disabled { color: {{color.text.disabled}}; }";
+
+static void applyLabelStyle(QWidget* label)
+{
+    AetherSDR::ThemeManager::instance().applyStyleSheet(label, kLabelStyle);
+}
 
 // Meter-view selector buttons.  Unselected look matches the DSP NR/NB/ANF
 // toggles exactly (kDspToggle base + hover); the selected/checked look matches
@@ -1562,7 +1569,7 @@ void VfoWidget::buildTabContent()
         applyPrimarySliderStyle(m_afGainSlider);
         gainRow->addWidget(m_afGainSlider, 1);
         auto* afVal = new QLabel("0");
-        afVal->setStyleSheet(kLabelStyle);
+        applyLabelStyle(afVal);
         afVal->setFixedWidth(20);
         afVal->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
         gainRow->addWidget(afVal);
@@ -1584,7 +1591,7 @@ void VfoWidget::buildTabContent()
         applyPrimarySliderStyle(m_sqlSlider);
         sqlRow->addWidget(m_sqlSlider, 1);
         m_sqlValueLbl = new QLabel("20");
-        m_sqlValueLbl->setStyleSheet(kLabelStyle);
+        applyLabelStyle(m_sqlValueLbl);
         m_sqlValueLbl->setFixedWidth(20);
         m_sqlValueLbl->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
         sqlRow->addWidget(m_sqlValueLbl);
@@ -1608,7 +1615,7 @@ void VfoWidget::buildTabContent()
         applyPrimarySliderStyle(m_agcTSlider);
         agcRow->addWidget(m_agcTSlider, 1);
         m_agcValueLbl = new QLabel("65");
-        m_agcValueLbl->setStyleSheet(kLabelStyle);
+        applyLabelStyle(m_agcValueLbl);
         m_agcValueLbl->setFixedWidth(20);
         m_agcValueLbl->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
         agcRow->addWidget(m_agcValueLbl);
@@ -1626,7 +1633,7 @@ void VfoWidget::buildTabContent()
         m_divBtn->setVisible(false);  // shown only on dual-SCU radios
         panRow->addWidget(m_divBtn);
         auto* panL = new QLabel("L");
-        panL->setStyleSheet(kLabelStyle);
+        applyLabelStyle(panL);
         panL->setFixedWidth(10);
         panL->setAlignment(Qt::AlignCenter);
         panRow->addWidget(panL);
@@ -1636,7 +1643,7 @@ void VfoWidget::buildTabContent()
         applyPrimarySliderStyle(m_panSlider);
         panRow->addWidget(m_panSlider, 1);
         auto* panR = new QLabel("R");
-        panR->setStyleSheet(kLabelStyle);
+        applyLabelStyle(panR);
         panR->setFixedWidth(10);
         panR->setAlignment(Qt::AlignCenter);
         panRow->addWidget(panR);
@@ -1671,7 +1678,7 @@ void VfoWidget::buildTabContent()
         m_escBtn->setStyleSheet(kDspToggle);
         escTopRow->addWidget(m_escBtn);
         auto* phaseLbl = new QLabel("P");
-        phaseLbl->setStyleSheet(kLabelStyle);
+        applyLabelStyle(phaseLbl);
         escTopRow->addWidget(phaseLbl);
         m_escPhaseSlider = new GuardedSlider(Qt::Horizontal);
         m_escPhaseSlider->setAccessibleName("ESC phase");
@@ -1680,7 +1687,7 @@ void VfoWidget::buildTabContent()
         applyPrimarySliderStyle(m_escPhaseSlider);
         escTopRow->addWidget(m_escPhaseSlider, 1);
         m_escPhaseLbl = new QLabel("0\u00B0");
-        m_escPhaseLbl->setStyleSheet(kLabelStyle);
+        applyLabelStyle(m_escPhaseLbl);
         m_escPhaseLbl->setFixedWidth(28);
         m_escPhaseLbl->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
         escTopRow->addWidget(m_escPhaseLbl);
@@ -1702,7 +1709,7 @@ void VfoWidget::buildTabContent()
         auto* gainCol = new QVBoxLayout;
         gainCol->setSpacing(1);
         m_escGainLbl = new QLabel("1.00");
-        m_escGainLbl->setStyleSheet(kLabelStyle);
+        applyLabelStyle(m_escGainLbl);
         m_escGainLbl->setAlignment(Qt::AlignHCenter);
         gainCol->addWidget(m_escGainLbl);
         m_escGainSlider = new GuardedSlider(Qt::Vertical);
@@ -1712,7 +1719,7 @@ void VfoWidget::buildTabContent()
         applyPrimarySliderStyle(m_escGainSlider);
         gainCol->addWidget(m_escGainSlider, 1);
         auto* gainLbl = new QLabel("G");
-        gainLbl->setStyleSheet(kLabelStyle);
+        applyLabelStyle(gainLbl);
         gainLbl->setAlignment(Qt::AlignHCenter);
         gainCol->addWidget(gainLbl);
         escBodyRow->addLayout(gainCol);
@@ -2052,7 +2059,7 @@ void VfoWidget::buildTabContent()
             apfVb->setSpacing(3);
 
             auto* lbl = new QLabel("APF");
-            lbl->setStyleSheet(kLabelStyle);
+            applyLabelStyle(lbl);
             lbl->setFixedWidth(26);
             apfVb->addWidget(lbl);
             m_apfSlider = new GuardedSlider(Qt::Horizontal);
@@ -2064,7 +2071,7 @@ void VfoWidget::buildTabContent()
             m_apfSlider->setToolTip("Adjusts APF bandwidth. Higher values narrow the peak for better CW selectivity. Enabled when APF is on in the DSP grid.");
             apfVb->addWidget(m_apfSlider, 1);
             m_apfValueLbl = new QLabel("50");
-            m_apfValueLbl->setStyleSheet(kLabelStyle);
+            applyLabelStyle(m_apfValueLbl);
             m_apfValueLbl->setFixedWidth(20);
             m_apfValueLbl->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
             apfVb->addWidget(m_apfValueLbl);
@@ -2354,7 +2361,7 @@ void VfoWidget::buildTabContent()
             auto* offRow = new QHBoxLayout;
             offRow->setSpacing(4);
             auto* offLbl = new QLabel("Offset:");
-            offLbl->setStyleSheet(kLabelStyle);
+            applyLabelStyle(offLbl);
             offRow->addWidget(offLbl);
             m_fmOffsetSpin = new QDoubleSpinBox;
             m_fmOffsetSpin->setAccessibleName("Repeater offset");
@@ -2750,7 +2757,7 @@ void VfoWidget::buildTabContent()
         auto* row = new QHBoxLayout;
         row->setSpacing(3);
         auto* lbl = new QLabel("DAX Ch");
-        lbl->setStyleSheet(kLabelStyle);
+        applyLabelStyle(lbl);
         row->addWidget(lbl);
         m_daxCmb = new GuardedComboBox;
         populateDaxCombo();  // capacity-gated; rebuilt on connect (setRadioModel)

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -460,9 +460,11 @@ static const QString kModeBtn =
 
 // Shared :disabled rule: a stylesheet colour beats the disabled palette, so
 // a label in a disabled row stays bright unless the sheet says otherwise.
-// #5e6e7c is ~0.45 of the normal text over the flag background. Used by
-// kLabelStyle (so the APF level row dims as a unit while APF is off, #4658)
-// and by makeOptLabel() below.
+// #5e6e7c is ~0.45 of makeOptLabel()'s #c8d8e8 over the flag background (a
+// lighter step, ~0.65, from kLabelStyle's #8aa8c0). Used by kLabelStyle and
+// by makeOptLabel() below. Note the rule only bites a label whose row is
+// disabled as a container: today that is the APF level row while APF is off
+// (#4658); rows that disable just their slider (SQL) keep a bright label.
 static const QString kDisabledLabelRule =
     "QLabel:disabled { color: #5e6e7c; }";
 

--- a/tests/ulanzi_mapping_migration_test.cpp
+++ b/tests/ulanzi_mapping_migration_test.cpp
@@ -196,7 +196,9 @@ int main(int argc, char** argv)
     ok &= expect(allKnown, "every action in knownWheelActions registry is recognized by isKnownWheelAction");
 
     // ── drift detection: assert every actionId handled by applyFlexControlWheelAction is registered ─
-    auto extractDispatchActions = []() -> QStringList {
+    // Loads applyFlexControlWheelAction's body out of the source. Shared by
+    // the drift check below and the #4658 guard check after it.
+    auto loadWheelDispatchBody = []() -> QString {
         // AETHER_SOURCE_DIR comes from CMake so this works for an
         // out-of-source build too; the relative forms are the fallback for a
         // hand-compiled run from the source root or a build directory.
@@ -229,7 +231,12 @@ int main(int argc, char** argv)
         // pass, which is worse than no check at all.
         const int end = content.indexOf(QStringLiteral("\n}\n"), start);
         if (end < 0) return {};
-        const QString fnBody = content.mid(start, end - start);
+        return content.mid(start, end - start);
+    };
+
+    auto extractDispatchActions = [&loadWheelDispatchBody]() -> QStringList {
+        const QString fnBody = loadWheelDispatchBody();
+        if (fnBody.isEmpty()) return {};
 
         // The optional wrapper matters: `actionId == QLatin1String("...")` is
         // used in this very file at ~:2549 and is the dominant form in
@@ -274,6 +281,26 @@ int main(int argc, char** argv)
     }
     ok &= expect(allRegisteredDispatched,
                  "every action in UlanziDialMappings::knownWheelActions() is handled in applyFlexControlWheelAction");
+
+    // ── #4658: the WheelApf branch must bail on a disengaged filter before it
+    // writes apf_level. A level written into a filter that is not in circuit
+    // reaches no audio, and on a TMate 2 the overlay then confirms a change
+    // that never happened. Source-level, like the drift check above, so the
+    // guard survives a refactor of the else-if chain without a GUI harness.
+    {
+        const QString fnBody = loadWheelDispatchBody();
+        const int apfStart = fnBody.indexOf(QStringLiteral("actionId == \"WheelApf\""));
+        int apfEnd = apfStart < 0 ? -1
+                   : fnBody.indexOf(QStringLiteral("} else if (actionId =="), apfStart + 1);
+        if (apfStart >= 0 && apfEnd < 0) apfEnd = fnBody.size();
+        const QString apfBranch = apfStart < 0 ? QString() : fnBody.mid(apfStart, apfEnd - apfStart);
+        const int guard = apfBranch.indexOf(QStringLiteral("apfOn()"));
+        const int write = apfBranch.indexOf(QStringLiteral("setApfLevel("));
+        const bool guarded = apfStart >= 0 && guard >= 0 && write > guard
+            && apfBranch.mid(guard, write - guard).contains(QStringLiteral("return;"));
+        ok &= expect(guarded,
+                     "WheelApf branch checks apfOn() and returns before setApfLevel() (#4658)");
+    }
 
     std::cout << (ok ? "ALL PASS" : "FAILURES") << '\n';
     return ok ? 0 : 1;

--- a/tests/ulanzi_mapping_migration_test.cpp
+++ b/tests/ulanzi_mapping_migration_test.cpp
@@ -300,10 +300,21 @@ int main(int argc, char** argv)
         const QString apfBranch = apfStart < 0 ? QString() : fnBody.mid(apfStart, apfEnd - apfStart);
         const int guard = apfBranch.indexOf(QStringLiteral("apfOn()"));
         const int write = apfBranch.indexOf(QStringLiteral("setApfLevel("));
-        const bool guarded = apfStart >= 0 && guard >= 0 && write > guard
-            && apfBranch.mid(guard, write - guard).contains(QStringLiteral("return;"));
+        const QString guardRegion = (apfStart >= 0 && guard >= 0 && write > guard)
+            ? apfBranch.mid(guard, write - guard) : QString();
+        const bool guarded = !guardRegion.isEmpty() && guardRegion.contains(QStringLiteral("return;"));
         ok &= expect(guarded,
                      "WheelApf branch checks apfOn() and returns before setApfLevel() (#4658)");
+        // The guard must stay OUTSIDE any #ifdef: the overlay is HAVE_HIDAPI-only,
+        // the write is not, and a guard moved inside that block would silently
+        // regress every non-hidapi build while the positional check above still
+        // passed. "Outside" = every #if opened before the guard line is closed
+        // again before it; the overlay's own #ifdef inside the guard body is fine.
+        const QString beforeGuard = apfStart < 0 || guard < 0 ? QString() : apfBranch.left(guard);
+        const bool guardOutsideIfdef = guarded
+            && beforeGuard.count(QStringLiteral("#if")) == beforeGuard.count(QStringLiteral("#endif"));
+        ok &= expect(guardOutsideIfdef,
+                     "WheelApf guard is not inside a preprocessor conditional (#4658)");
     }
 
     std::cout << (ok ? "ALL PASS" : "FAILURES") << '\n';

--- a/tests/ulanzi_mapping_migration_test.cpp
+++ b/tests/ulanzi_mapping_migration_test.cpp
@@ -298,7 +298,10 @@ int main(int argc, char** argv)
                    : fnBody.indexOf(QStringLiteral("} else if (actionId"), apfStart + 1);
         if (apfStart >= 0 && apfEnd < 0) apfEnd = fnBody.size();
         const QString apfBranch = apfStart < 0 ? QString() : fnBody.mid(apfStart, apfEnd - apfStart);
-        const int guard = apfBranch.indexOf(QStringLiteral("apfOn()"));
+        // The literal negated test, not any mention of apfOn(): an inverted
+        // guard (`if (s->apfOn())`) or a comment naming the accessor must not
+        // satisfy this pin.
+        const int guard = apfBranch.indexOf(QStringLiteral("if (!s->apfOn())"));
         const int write = apfBranch.indexOf(QStringLiteral("setApfLevel("));
         const QString guardRegion = (apfStart >= 0 && guard >= 0 && write > guard)
             ? apfBranch.mid(guard, write - guard) : QString();

--- a/tests/ulanzi_mapping_migration_test.cpp
+++ b/tests/ulanzi_mapping_migration_test.cpp
@@ -289,9 +289,13 @@ int main(int argc, char** argv)
     // guard survives a refactor of the else-if chain without a GUI harness.
     {
         const QString fnBody = loadWheelDispatchBody();
-        const int apfStart = fnBody.indexOf(QStringLiteral("actionId == \"WheelApf\""));
+        // Same optional-wrapper tolerance as the drift check: a branch written
+        // as `actionId == QLatin1String("WheelApf")` must not fail this pin.
+        static const QRegularExpression apfRx(QStringLiteral(
+            "actionId\\s*==\\s*(?:QLatin1String\\(|QStringLiteral\\()?\"WheelApf\""));
+        const int apfStart = fnBody.indexOf(apfRx);
         int apfEnd = apfStart < 0 ? -1
-                   : fnBody.indexOf(QStringLiteral("} else if (actionId =="), apfStart + 1);
+                   : fnBody.indexOf(QStringLiteral("} else if (actionId"), apfStart + 1);
         if (apfStart >= 0 && apfEnd < 0) apfEnd = fnBody.size();
         const QString apfBranch = apfStart < 0 ? QString() : fnBody.mid(apfStart, apfEnd - apfStart);
         const int guard = apfBranch.indexOf(QStringLiteral("apfOn()"));


### PR DESCRIPTION
## Summary

References #4658 (does not close it — that issue is ten9876's CW weak-signal umbrella).
This PR takes the one code defect still open there: the controller-wheel path NF0T raised in
review of #4660 and proposed as "roadmap item 12", which the triage bot confirmed as the only
remaining defect in the issue. #4660 fixed the GUI slider, but the wheel path still wrote
`slice set N apf_level=V` with the APF filter disengaged — the same symptom through a
different control. All wheel sources (FlexControl, TMate2, StreamDeck+, the virtual
AetherControl knob) funnel through `MainWindow::applyFlexControlWheelAction`, so one guard
covers them: when `!slice->apfOn()` the write is skipped and a 1.5 s transient card on the
slice's panadapter says "APF level — Turn APF on first" (the #4649 pattern: a
`PanadapterOverlayMessage` with its own id and the Info tone via `upsertOverlayMessage`, with the
status bar only as the no-panadapter fallback — a `QStatusBar` message would hide the TX indicator and PA telemetry for its whole
duration, and minimal mode hides the status bar outright), so the reason reaches every
controller family — FlexControl, RC-28, Ulanzi, the virtual wheel; a TMate2 additionally shows
`APF OFF` on its own display instead of a value. Known limit: minimal mode shows neither the
panadapter nor the status bar, so a non-TMate2 controller gets no on-screen notice there — a
slice-level signal consumed by the applet panel (the `notifyTuneBlockedByLock()` shape) is the
follow-up for that layout, not this PR. The guard wraps the write,
not only the `#ifdef HAVE_HIDAPI` overlay, so builds without hidapi are covered
(`src/gui/MainWindow_Controllers.cpp:1449-1515`). `ToggleApf` is unchanged and remains the way
in. rigctl's `L APF <val>` (`RigctlProtocol.cpp:1609`) is deliberately left as-is: hamlib treats
`set_level` and `set_func` as orthogonal, and a script may set the level before enabling APF.

Also in scope, beyond the title: the APF slider's accessible description now carries the
"enabled when APF is on in the DSP grid" reason that was tooltip-only — the screen-reader half
of the same disabled state.

Two cosmetic items from the #4660 review ride along: the `kLabelStyle` shared by the VFO's
value labels gains a `QLabel:disabled` rule so the "APF" caption and value label dim with the
slider. It reaches only labels that are themselves disabled — e.g. the APF row container; the
SQL row disables just its button and slider, so its value label is unchanged. The rule is the
`#5e6e7c` one `makeOptLabel()` already used, hoisted into a shared `kDisabledLabelRule` so the
colour-reference count stays level with main (the ratchet caught a duplicated literal on the
first push; an interim commit tokenised it, the third commit replaces that with the hoist per
review — tokenising these labels is left to the theming migration, RFC #3076). And the APF
slider's accessible description is covered above.

Verification (demo radio, CW, AetherControl knob mapped to APF, operator-turned):
- Baseline `38f68df3`, APF off: a quarter turn moved `apfLevel` 50→76 with `apf=false` —
  the defect reproduced.
- Fix `ee422382`, same setup: APF off → `apfLevel` stays 50 and the row dims as a unit;
  APF on → 50→96. Accessible description reads as intended. Commits 2–3 touch only the
  stylesheet constant (the disabled shade at the head is the same `#5e6e7c`); commit 4 adds
  the notice and the test; commits 6–7 move the notice from the status bar to the panadapter
  card per the second review, with its own overlay id (`apf.level-off`) and the Info tone so it
  neither evicts nor is evicted by the TX-filter or interlock cards; commit 8 (third review) shows
  the hint once per 1.5 s window rather than once per detent — a timed card is not deduplicated by
  the overlay's re-assert early-out, so a spinning knob would otherwise re-sort it to the top of
  the stack on every wheel event — and hardens the test pin so a guard moved inside the
  `HAVE_HIDAPI` block fails it (every `#if` opened before the guard line must be closed before it;
  the overlay's own `#ifdef` inside the guard body is allowed — checked both ways). Commit 9
  (fourth review): the branch stays silent outside CW — APF is CW-only and the DSP grid does not
  mount the button elsewhere, so a "turn APF on" hint there would point at nothing — and the pin
  now looks for the literal `if (!s->apfOn())`, so an inverted guard or a comment naming the
  accessor no longer satisfies it (fails on the inverted form; checked). One item deliberately
  not changed: the TMate2 text `APF OFF` is the string NF0T prescribed on #4658; it is also what
  `ToggleApf` shows when the operator switches APF off, so a spun level knob and a real
  switch-off read the same on that display — a maintainer's call whether to separate them
  (`APF IS OFF` / `TURN APF ON`). Benched on clean builds
  (demo, APF off, virtual knob turned): on `d0317cc6` the status-bar form read
  `statusMessage='APF level: turn APF on first'`; on `32794069` the card appeared on the slice's
  panadapter — close button `panOverlayMessageClose_apf_level_off`, blue ⓘ Info styling,
  "APF level / Turn APF on first", 1.5 s countdown — and `apfLevel` stayed 50 each time.
- The TMate2 overlay branch is verified by inspection and a no-hidapi `-fsyntax-only`
  compile — no TMate2 here; whether "APF OFF" fits its segment display needs someone with the
  device.
- Regression pin: `ulanzi_mapping_migration_test` gains two source-level assertions — the
  `WheelApf` branch contains the literal `if (!s->apfOn())` and returns before `setApfLevel()`
  (tolerating the `QLatin1String("…")` branch form like the drift check beside it), and that
  guard sits outside any preprocessor conditional. Checked locally: pass on head; fail with the
  guard removed; fail with the guard inverted; fail with the guard moved inside
  `#ifdef HAVE_HIDAPI`; pass with the `QLatin1String` form. It runs on the weekly sanitizer job,
  not the PR gate (`ci.yml:313`) — a textual pin, not a behavioural test. That test runs on the
  weekly sanitizer job, not the PR gate (`ci.yml:313`). Wire-level proof (`TX: slice set … apf_level` absent) pending a
  FLEX-8400 session; the demo radio has no command plane.

## Constitution principle honored

Principle II — live state stays the radio's: the client no longer pushes a level into a
filter the radio isn't running. Principle XI — reproduction and fix are demonstrated below.

## Test plan

- [x] Local build passes (`cmake --build build`) — clean RelWithDebInfo, macOS 15 Intel, Qt 6.8.3
- [x] Behavior verified on a real radio if applicable — **n/a so far:** demo radio arms A–F
      (UI + model state); 8400 wire-level run pending, will be added here
- [x] Existing tests pass (CI); `ulanzi_mapping_migration_test` run locally: pass, and fails with the guard removed
- [x] Reproduction steps documented if user-reported bug — above (Arm A) + #4658 / NF0T's comment

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`) — SSH
- [x] No new flat-key `AppSettings` calls — **n/a, no settings touched**
- [x] Code is clean-room — yes
- [x] All meter UI uses `MeterSmoother` — **n/a, no meter UI**
- [x] Documentation updated if user-visible behavior changed — **n/a:** no documented
      behaviour changes; the wheel now does what the slider already does
- [x] Security-sensitive changes reference a GHSA — **n/a**

— authored by agent (Claude Code) on behalf of @skerker
