### PR TITLE
fix(pan): stop treating DIGL as RTTY on the panadapter

### DIFF
--- a/src/gui/SliceToneCues.h
+++ b/src/gui/SliceToneCues.h
@@ -14,9 +14,12 @@ namespace AetherSDR {
 // reasoning MainWindow::refreshRttyDecodeState() already applies when it
 // refuses to open a Baudot decoder on a DIGL slice.
 //
-// Treating DIGL as RTTY also *suppressed the carrier marker entirely*, because
-// the tone cues were drawn instead of the centre line rather than on top of it
-// (#5097). The carrier is now unconditional; this predicate only adds cues.
+// Tone cues *replace* the carrier marker rather than adding to it, which is
+// correct for RTTY — there the RF frequency IS the mark, so the mark cue
+// already marks the tuned frequency and a carrier line would be drawn at the
+// identical x. It was wrong for DIGL, which has no such relationship: including
+// DIGL here suppressed its carrier marker entirely (#5097). Excluding DIGL lets
+// it fall through to the normal carrier path in all three renderers.
 //
 // Lives in its own header so the rule is unit-testable without dragging in
 // SpectrumWidget.h (which pulls QRhiWidget and the DSS renderer).

--- a/src/gui/SliceToneCues.h
+++ b/src/gui/SliceToneCues.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QString>
+
+namespace AetherSDR {
+
+// True when a slice should draw RTTY mark/space tone cues on the panadapter,
+// and when the VFO flag must therefore stay clear of the region left of the
+// carrier where those cues live.
+//
+// DIGL is deliberately NOT included. It is a general lower-sideband *data* mode
+// carrying FT8, JS8, PSK31, VARA, SSTV and RADE, none of which are FSK, so
+// painting mark/space tone markers on them is meaningless. This is the same
+// reasoning MainWindow::refreshRttyDecodeState() already applies when it
+// refuses to open a Baudot decoder on a DIGL slice.
+//
+// Treating DIGL as RTTY also *suppressed the carrier marker entirely*, because
+// the tone cues were drawn instead of the centre line rather than on top of it
+// (#5097). The carrier is now unconditional; this predicate only adds cues.
+//
+// Lives in its own header so the rule is unit-testable without dragging in
+// SpectrumWidget.h (which pulls QRhiWidget and the DSS renderer).
+inline bool drawsRttyToneCues(const QString& mode)
+{
+    return mode == QLatin1String("RTTY");
+}
+
+} // namespace AetherSDR

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -14377,9 +14377,9 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
             };
             // Match drawSliceMarkers / the CPU 3D fallback: the passband band
             // and marker cue(s) are placed independently (an off-screen passband
-            // must not drop an on-screen cue, and vice versa); RTTY adds a
-            // mark+space pair on top of the carrier cue; markerWidth == 0 draws
-            // the passband with no carrier cue at all.
+            // must not drop an on-screen cue, and vice versa); RTTY draws a
+            // mark+space pair rather than a carrier cue; markerWidth == 0 draws
+            // the passband with no cue at all.
             const auto appendShadow = [&](const SliceOverlay& so) {
                 const double shadowMarginMhz =
                     static_cast<double>(shadowUnitMargin) * shadowBandwidthMhz;
@@ -14401,16 +14401,13 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                     !(high < shadowUnitLow || low > shadowUnitHigh);
 
                 struct ShadowCue { float center; QColor color; };
-                // Three: a carrier cue plus, on RTTY, the mark/space pair. The
-                // carrier is additive rather than replaced (#5097), so RTTY can
-                // now need all three at once.
-                static constexpr int kMaxShadowCues = 3;
-                std::array<ShadowCue, kMaxShadowCues> cues;
+                std::array<ShadowCue, 2> cues;
                 int cueCount = 0;
-                if (so.markerWidth > 0) {
-                    cues[cueCount++] = {unitForShadowMhz(so.freqMhz),
-                                        sliceColorForOverlay(so)};
-                }
+                // RTTY keeps its exclusive mark/space pair — the RF frequency
+                // IS the mark, so a carrier cue would be coincident with it and
+                // would spend a third descriptor against kDssMeshShadowSlices
+                // for no visible gain. DIGL now falls through to the carrier
+                // cue instead of being treated as RTTY (#5097).
                 if (drawsRttyToneCues(so.mode)) {
                     // RTTY: RF_frequency IS the mark (radio applies IF shift).
                     const double markMhz = so.freqMhz;
@@ -14421,10 +14418,13 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                     cues[cueCount++] = {unitForShadowMhz(spaceMhz),
                         AetherSDR::ThemeManager::instance().color(
                             "color.accent.danger")};
+                } else if (so.markerWidth > 0) {
+                    cues[cueCount++] = {unitForShadowMhz(so.freqMhz),
+                                        sliceColorForOverlay(so)};
                 }
 
                 // Cull each cue by its own position, matching appendLine.
-                std::array<ShadowCue, kMaxShadowCues> visible;
+                std::array<ShadowCue, 2> visible;
                 int visibleCount = 0;
                 for (int i = 0; i < cueCount; ++i) {
                     if (cues[i].center >= shadowUnitLow
@@ -16924,12 +16924,9 @@ SpectrumWidget::buildDssDepthGeometry(const QRect& specRect,
             }
         };
 
-        // Carrier cue first, tone cues over it — additive, never exclusive
-        // (#5097). Mirrors drawSliceMarkers and appendShadow.
-        if (so.markerWidth > 0) {
-            appendLine(so.freqMhz, markerColor,
-                       std::max<qreal>(1.0, so.markerWidth));
-        }
+        // RTTY keeps its exclusive mark/space pair: the RF frequency IS the
+        // mark, so a carrier cue would land at the identical x. DIGL now falls
+        // through to the carrier cue instead of being treated as RTTY (#5097).
         if (drawsRttyToneCues(so.mode)) {
             // RTTY: RF_frequency IS the mark (radio applies the IF shift).
             const double markMhz = so.freqMhz;
@@ -16942,6 +16939,9 @@ SpectrumWidget::buildDssDepthGeometry(const QRect& specRect,
                 spaceMhz,
                 AetherSDR::ThemeManager::instance().color("color.accent.danger"),
                 1.0);
+        } else if (so.markerWidth > 0) {
+            appendLine(so.freqMhz, markerColor,
+                       std::max<qreal>(1.0, so.markerWidth));
         }
 
     };
@@ -17100,33 +17100,15 @@ void SpectrumWidget::drawSliceMarkers(QPainter& p, const QRect& specRect, const 
             p.drawLine(fX2, specRect.top(), fX2, specRect.bottom());
         }
 
-        // ── Standard VFO center line ─────────────────────────────────────
-        // Drawn for every mode. RTTY tone cues are painted *over* this below,
-        // never instead of it: making the two mutually exclusive is what hid
-        // the carrier marker on RTTY and DIGL slices (#5097).
-        // Skipped entirely when markerWidth == 0 (user chose "Marker: Off") —
-        // passband bracket only.
-        if (so.markerWidth > 0) {
-            int markerX = vfoX;
-
-            // Per-slice VFO marker thickness — user-toggled via VFO flag (#1526)
-            const qreal vfoLineW = static_cast<qreal>(so.markerWidth);
-            p.setPen(QPen(QColor(col.red(), col.green(), col.blue(), 220), vfoLineW));
-            drawFrequencyLine(markerX);
-
-            // ── Triangle marker at top ───────────────────────────────────
-            const int triHalf = 6;
-            const int triH = 10;
-            p.setPen(Qt::NoPen);
-            p.setBrush(col);
-            QPolygon tri;
-            tri << QPoint(markerX - triHalf, specRect.top())
-                << QPoint(markerX + triHalf, specRect.top())
-                << QPoint(markerX, specRect.top() + triH);
-            p.drawPolygon(tri);
-        }
-
-        // ── RTTY mark/space tone cues, on top of the centre line ─────────
+        // ── RTTY: mark/space lines replace the VFO center line ───────────
+        // For RTTY the RF frequency IS the mark (the radio applies the IF
+        // shift), so the mark cue already marks the tuned frequency — a
+        // separate carrier line would sit at the identical x. RTTY rendering
+        // is therefore left exactly as it was.
+        //
+        // DIGL used to be routed here too, which cost it the carrier marker
+        // and gave it two meaningless FSK cues; it now falls through to the
+        // standard centre line below. See drawsRttyToneCues() (#5097).
         if (drawsRttyToneCues(so.mode)) {
             // In RTTY mode, RF_frequency IS the mark (radio applies IF shift).
             const double markMhz  = so.freqMhz;
@@ -17151,6 +17133,27 @@ void SpectrumWidget::drawSliceMarkers(QPainter& p, const QRect& specRect, const 
             p.drawText(markX + 2, specRect.top() + 12, "M");
             p.setPen(AetherSDR::theme::withAlpha("color.accent.danger", 240));
             p.drawText(spaceX + 2, specRect.top() + 12, "S");
+        } else if (so.markerWidth > 0) {
+            // ── Standard VFO center line ─────────────────────────────────
+            // Skipped entirely when markerWidth == 0 (user chose
+            // "Marker: Off") — passband bracket only.
+            int markerX = vfoX;
+
+            // Per-slice VFO marker thickness — user-toggled via VFO flag (#1526)
+            const qreal vfoLineW = static_cast<qreal>(so.markerWidth);
+            p.setPen(QPen(QColor(col.red(), col.green(), col.blue(), 220), vfoLineW));
+            drawFrequencyLine(markerX);
+
+            // ── Triangle marker at top ───────────────────────────────────
+            const int triHalf = 6;
+            const int triH = 10;
+            p.setPen(Qt::NoPen);
+            p.setBrush(col);
+            QPolygon tri;
+            tri << QPoint(markerX - triHalf, specRect.top())
+                << QPoint(markerX + triHalf, specRect.top())
+                << QPoint(markerX, specRect.top() + triH);
+            p.drawPolygon(tri);
         }
 
         // ── RIT/XIT offset lines ──────────────────────────────────────

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1,4 +1,6 @@
 #include "SpectrumWidget.h"
+
+#include "SliceToneCues.h"
 #include "gui/FftHeatMap.h"
 #include "gui/SpectrumGrid.h"
 #include "DbmRangeTransition.h"
@@ -187,7 +189,7 @@ VfoWidget::FlagDir singleVfoFlagDirectionForOverlay(
     int markerX,
     int spectrumWidth)
 {
-    if (overlay.mode == "RTTY" || overlay.mode == "DIGL") {
+    if (drawsRttyToneCues(overlay.mode)) {
         return VfoWidget::ForceRight;
     }
 
@@ -325,7 +327,7 @@ void assignModeForcedDirections(const QVector<SpectrumWidget::SliceOverlay>& ove
                                 QMap<int, VfoWidget::FlagDir>& dirMap)
 {
     for (const SpectrumWidget::SliceOverlay& overlay : overlays) {
-        if (overlay.mode == "RTTY" || overlay.mode == "DIGL") {
+        if (drawsRttyToneCues(overlay.mode)) {
             dirMap[overlay.sliceId] = VfoWidget::ForceRight;
         }
     }
@@ -2386,7 +2388,7 @@ bool SpectrumWidget::vfoFlagOnLeftForSlice(
         if (VfoWidget* widget = m_vfoWidgets.value(overlay.sliceId, nullptr)) {
             const double markerMhz = overlay.sliceId == sliceId ? freqMhz : overlay.freqMhz;
             int x = mhzToX(markerMhz);
-            if (overlay.mode == "RTTY" || overlay.mode == "DIGL") {
+            if (drawsRttyToneCues(overlay.mode)) {
                 const double hiMhz = markerMhz + overlay.filterHighHz / 1.0e6;
                 x = mhzToX(hiMhz) + 4;
             }
@@ -14375,9 +14377,9 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
             };
             // Match drawSliceMarkers / the CPU 3D fallback: the passband band
             // and marker cue(s) are placed independently (an off-screen passband
-            // must not drop an on-screen cue, and vice versa); RTTY/DIGL draws a
-            // mark+space pair rather than a carrier cue; markerWidth == 0 draws
-            // the passband with no cue at all.
+            // must not drop an on-screen cue, and vice versa); RTTY adds a
+            // mark+space pair on top of the carrier cue; markerWidth == 0 draws
+            // the passband with no carrier cue at all.
             const auto appendShadow = [&](const SliceOverlay& so) {
                 const double shadowMarginMhz =
                     static_cast<double>(shadowUnitMargin) * shadowBandwidthMhz;
@@ -14399,15 +14401,19 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                     !(high < shadowUnitLow || low > shadowUnitHigh);
 
                 struct ShadowCue { float center; QColor color; };
-                std::array<ShadowCue, 2> cues;
+                // Three: a carrier cue plus, on RTTY, the mark/space pair. The
+                // carrier is additive rather than replaced (#5097), so RTTY can
+                // now need all three at once.
+                static constexpr int kMaxShadowCues = 3;
+                std::array<ShadowCue, kMaxShadowCues> cues;
                 int cueCount = 0;
-                const bool rtty = so.mode == QStringLiteral("RTTY")
-                    || so.mode == QStringLiteral("DIGL");
-                if (rtty) {
-                    double markMhz = so.freqMhz;
-                    if (so.mode == QStringLiteral("DIGL")) {
-                        markMhz -= so.rttyMark / 1.0e6;
-                    }
+                if (so.markerWidth > 0) {
+                    cues[cueCount++] = {unitForShadowMhz(so.freqMhz),
+                                        sliceColorForOverlay(so)};
+                }
+                if (drawsRttyToneCues(so.mode)) {
+                    // RTTY: RF_frequency IS the mark (radio applies IF shift).
+                    const double markMhz = so.freqMhz;
                     const double spaceMhz = markMhz - so.rttyShift / 1.0e6;
                     cues[cueCount++] = {unitForShadowMhz(markMhz),
                         AetherSDR::ThemeManager::instance().color(
@@ -14415,13 +14421,10 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                     cues[cueCount++] = {unitForShadowMhz(spaceMhz),
                         AetherSDR::ThemeManager::instance().color(
                             "color.accent.danger")};
-                } else if (so.markerWidth > 0) {
-                    cues[cueCount++] = {unitForShadowMhz(so.freqMhz),
-                                        sliceColorForOverlay(so)};
                 }
 
                 // Cull each cue by its own position, matching appendLine.
-                std::array<ShadowCue, 2> visible;
+                std::array<ShadowCue, kMaxShadowCues> visible;
                 int visibleCount = 0;
                 for (int i = 0; i < cueCount; ++i) {
                     if (cues[i].center >= shadowUnitLow
@@ -15248,8 +15251,7 @@ void SpectrumWidget::repositionVfoFlags(const QRect& specRect)
     for (const SliceOverlay& so : m_sliceOverlays) {
         if (VfoWidget* flag = m_vfoWidgets.value(so.sliceId, nullptr)) {
             int x = mhzToX(so.freqMhz);
-            if (so.mode == QStringLiteral("RTTY")
-                || so.mode == QStringLiteral("DIGL")) {
+            if (drawsRttyToneCues(so.mode)) {
                 const double hiMhz =
                     so.freqMhz + so.filterHighHz / 1.0e6;
                 x = mhzToX(hiMhz) + 4;
@@ -16922,13 +16924,15 @@ SpectrumWidget::buildDssDepthGeometry(const QRect& specRect,
             }
         };
 
-        const bool rtty = so.mode == QStringLiteral("RTTY")
-            || so.mode == QStringLiteral("DIGL");
-        if (rtty) {
-            double markMhz = so.freqMhz;
-            if (so.mode == QStringLiteral("DIGL")) {
-                markMhz -= so.rttyMark / 1.0e6;
-            }
+        // Carrier cue first, tone cues over it — additive, never exclusive
+        // (#5097). Mirrors drawSliceMarkers and appendShadow.
+        if (so.markerWidth > 0) {
+            appendLine(so.freqMhz, markerColor,
+                       std::max<qreal>(1.0, so.markerWidth));
+        }
+        if (drawsRttyToneCues(so.mode)) {
+            // RTTY: RF_frequency IS the mark (radio applies the IF shift).
+            const double markMhz = so.freqMhz;
             const double spaceMhz = markMhz - so.rttyShift / 1.0e6;
             appendLine(
                 markMhz,
@@ -16938,9 +16942,6 @@ SpectrumWidget::buildDssDepthGeometry(const QRect& specRect,
                 spaceMhz,
                 AetherSDR::ThemeManager::instance().color("color.accent.danger"),
                 1.0);
-        } else if (so.markerWidth > 0) {
-            appendLine(so.freqMhz, markerColor,
-                       std::max<qreal>(1.0, so.markerWidth));
         }
 
     };
@@ -17099,20 +17100,37 @@ void SpectrumWidget::drawSliceMarkers(QPainter& p, const QRect& specRect, const 
             p.drawLine(fX2, specRect.top(), fX2, specRect.bottom());
         }
 
-        // ── RTTY/DIGL: mark/space lines replace the VFO center line ────
-        const bool isRttyMode = (so.mode == "RTTY" || so.mode == "DIGL");
+        // ── Standard VFO center line ─────────────────────────────────────
+        // Drawn for every mode. RTTY tone cues are painted *over* this below,
+        // never instead of it: making the two mutually exclusive is what hid
+        // the carrier marker on RTTY and DIGL slices (#5097).
+        // Skipped entirely when markerWidth == 0 (user chose "Marker: Off") —
+        // passband bracket only.
+        if (so.markerWidth > 0) {
+            int markerX = vfoX;
 
-        if (isRttyMode) {
-            double markMhz, spaceMhz;
-            if (so.mode == "RTTY") {
-                // In RTTY mode, RF_frequency IS the mark (radio applies IF shift).
-                markMhz  = so.freqMhz;
-                spaceMhz = so.freqMhz - so.rttyShift / 1.0e6;
-            } else {
-                // In DIGL mode, RF_frequency is the carrier (no IF shift).
-                markMhz  = so.freqMhz - so.rttyMark / 1.0e6;
-                spaceMhz = markMhz - so.rttyShift / 1.0e6;
-            }
+            // Per-slice VFO marker thickness — user-toggled via VFO flag (#1526)
+            const qreal vfoLineW = static_cast<qreal>(so.markerWidth);
+            p.setPen(QPen(QColor(col.red(), col.green(), col.blue(), 220), vfoLineW));
+            drawFrequencyLine(markerX);
+
+            // ── Triangle marker at top ───────────────────────────────────
+            const int triHalf = 6;
+            const int triH = 10;
+            p.setPen(Qt::NoPen);
+            p.setBrush(col);
+            QPolygon tri;
+            tri << QPoint(markerX - triHalf, specRect.top())
+                << QPoint(markerX + triHalf, specRect.top())
+                << QPoint(markerX, specRect.top() + triH);
+            p.drawPolygon(tri);
+        }
+
+        // ── RTTY mark/space tone cues, on top of the centre line ─────────
+        if (drawsRttyToneCues(so.mode)) {
+            // In RTTY mode, RF_frequency IS the mark (radio applies IF shift).
+            const double markMhz  = so.freqMhz;
+            const double spaceMhz = so.freqMhz - so.rttyShift / 1.0e6;
             const int markX  = mhzToX(markMhz);
             const int spaceX = mhzToX(spaceMhz);
 
@@ -17133,27 +17151,6 @@ void SpectrumWidget::drawSliceMarkers(QPainter& p, const QRect& specRect, const 
             p.drawText(markX + 2, specRect.top() + 12, "M");
             p.setPen(AetherSDR::theme::withAlpha("color.accent.danger", 240));
             p.drawText(spaceX + 2, specRect.top() + 12, "S");
-        } else if (so.markerWidth > 0) {
-            // ── Standard VFO center line ─────────────────────────────────
-            // Skipped entirely when markerWidth == 0 (user chose
-            // "Marker: Off") — passband bracket only.
-            int markerX = vfoX;
-
-            // Per-slice VFO marker thickness — user-toggled via VFO flag (#1526)
-            const qreal vfoLineW = static_cast<qreal>(so.markerWidth);
-            p.setPen(QPen(QColor(col.red(), col.green(), col.blue(), 220), vfoLineW));
-            drawFrequencyLine(markerX);
-
-            // ── Triangle marker at top ───────────────────────────────────
-            const int triHalf = 6;
-            const int triH = 10;
-            p.setPen(Qt::NoPen);
-            p.setBrush(col);
-            QPolygon tri;
-            tri << QPoint(markerX - triHalf, specRect.top())
-                << QPoint(markerX + triHalf, specRect.top())
-                << QPoint(markerX, specRect.top() + triH);
-            p.drawPolygon(tri);
         }
 
         // ── RIT/XIT offset lines ──────────────────────────────────────

--- a/tests/slice_tone_cues_test.cpp
+++ b/tests/slice_tone_cues_test.cpp
@@ -5,10 +5,14 @@
 // VARA, SSTV and RADE on any lower-sideband band — lost its centre line and
 // triangle and gained two meaningless FSK lines at 2125 / 2295 Hz.
 //
-// That behaviour was introduced by 8fba0f97 (PR #660) and had to be reverted
-// twice over: the carrier is now drawn unconditionally, and only genuine RTTY
-// adds tone cues. This test pins the second half so the DIGL case cannot creep
-// back in.
+// DIGL was added to the RTTY branch by 8fba0f97 (PR #660). Removing it lets a
+// DIGL slice fall through to the normal carrier path in all three renderers
+// (2D painter, GPU shadow cues, 3D CPU fallback). RTTY rendering is unchanged:
+// there the RF frequency IS the mark, so replacing the carrier is correct.
+//
+// This test pins the predicate. The carrier-restored half of the symptom lives
+// inside the three renderers and is not extractable without factoring out cue
+// selection as a pure function — see the note on the PR.
 
 #include "gui/SliceToneCues.h"
 

--- a/tests/slice_tone_cues_test.cpp
+++ b/tests/slice_tone_cues_test.cpp
@@ -1,0 +1,72 @@
+// Regression guard for #5097.
+//
+// The panadapter used to treat DIGL as if it were RTTY and draw mark/space tone
+// cues *instead of* the carrier marker, so every DIGL slice — FT8, JS8, PSK31,
+// VARA, SSTV and RADE on any lower-sideband band — lost its centre line and
+// triangle and gained two meaningless FSK lines at 2125 / 2295 Hz.
+//
+// That behaviour was introduced by 8fba0f97 (PR #660) and had to be reverted
+// twice over: the carrier is now drawn unconditionally, and only genuine RTTY
+// adds tone cues. This test pins the second half so the DIGL case cannot creep
+// back in.
+
+#include "gui/SliceToneCues.h"
+
+#include <cstdio>
+
+using AetherSDR::drawsRttyToneCues;
+
+namespace {
+
+int g_failures = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) {
+        ++g_failures;
+    }
+}
+
+void expectCues(const char* mode, bool expected)
+{
+    const bool actual = drawsRttyToneCues(QString::fromLatin1(mode));
+    char name[96];
+    std::snprintf(name, sizeof(name), "%s %s tone cues", mode,
+                  expected ? "draws" : "does not draw");
+    report(name, actual == expected);
+}
+
+} // namespace
+
+int main()
+{
+    // The only mode that draws them.
+    expectCues("RTTY", true);
+
+    // The regression this test exists for. DIGL is a general LSB *data* mode,
+    // not an FSK mode; it must keep its carrier marker and gain no tone cues.
+    expectCues("DIGL", false);
+
+    // Every other mode the radio advertises (FLEX-8400, fw 4.2.20.41343).
+    for (const char* mode : {"LSB", "USB", "AM", "CW", "DIGU", "SAM",
+                             "FM", "NFM", "DFM", "FDVU", "FDVL"}) {
+        expectCues(mode, false);
+    }
+
+    // Mode strings arrive from the radio in canonical upper case (FlexLib
+    // `slice status mode=`), so matching is deliberately exact — a lower-case
+    // spelling is not a mode this client ever sees, and silently accepting one
+    // would hide a wire-format change rather than surface it.
+    report("matching is case-sensitive",
+           !drawsRttyToneCues(QStringLiteral("rtty")));
+
+    // Defensive: an empty / absent mode must not enable tone cues.
+    report("empty mode draws no tone cues",
+           !drawsRttyToneCues(QString()));
+
+    if (g_failures == 0) {
+        std::printf("All slice tone-cue checks passed\n");
+    }
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -707,6 +707,13 @@ target_include_directories(vfo_flag_placement_test PRIVATE src)
 target_link_libraries(vfo_flag_placement_test PRIVATE Qt6::Widgets)
 add_test(NAME vfo_flag_placement_test COMMAND vfo_flag_placement_test)
 
+add_executable(slice_tone_cues_test
+    tests/slice_tone_cues_test.cpp
+)
+target_include_directories(slice_tone_cues_test PRIVATE src)
+target_link_libraries(slice_tone_cues_test PRIVATE Qt6::Core)
+add_test(NAME slice_tone_cues_test COMMAND slice_tone_cues_test)
+
 add_executable(mac_cursor_compat_test
     tests/mac_cursor_compat_test.cpp
 )


### PR DESCRIPTION
> **Revised after review.** The first version also made the carrier marker
> additive on **RTTY**, which @jensenpat correctly blocked as an out-of-scope
> visual change and @aethersdr-agent flagged as a coincident duplicate. Both were
> right, and the fix is smaller for it — RTTY rendering is now untouched. See
> [What changed in v2](#what-changed-in-v2).

## Problem

Every `DIGL` slice loses its carrier marker — no centre line, no triangle — and
gains two meaningless dashed lines at −2125 Hz and −2295 Hz. That covers FT8,
JS8, PSK31, VARA, SSTV and RADE on any lower-sideband band.

Reported in #5097 as *"Lack of Carrier Marker in RADE for 40 Meters and Below"*.
**Both halves of that title turn out to be wrong**, which is worth stating up
front:

- **Not RADE-specific.** Reproduced with a hand-set `DIGL` and no RADE anywhere.
  RADE is implicated only because it rewrites the slice to `DIGL` or `DIGU`
  (`MainWindow_DigitalModes.cpp:348`).
- **Not a band effect.** `DIGU` on 40 m draws the carrier; `DIGL` on 20 m does
  not. The 40 m/20 m correlation is entirely downstream of RADE choosing its
  sideband from the band.

## Root cause

`SpectrumWidget` treats `DIGL` as if it were `RTTY`:

```cpp
const bool isRttyMode = (so.mode == "RTTY" || so.mode == "DIGL");
if (isRttyMode)              { mark + space }
else if (so.markerWidth > 0) { carrier line + triangle }   // never reached
```

Tone cues **replace** the carrier rather than adding to it. That is correct for
RTTY — there the RF frequency *is* the mark, so the mark cue already marks the
tuned frequency. It is wrong for DIGL, which has no such relationship.

`DIGL` was added to this branch by `8fba0f97` (PR #660, *"Fix RTTY mark/space
overlay and filter presets"*).

## Fix

**Remove `DIGL` from the predicate.** A DIGL slice then falls through to the
normal carrier path in all three renderers. Nothing else changes — the exclusive
`if/else` is preserved, and RTTY renders exactly as it does today.

This is the rule the codebase already states and applies elsewhere, in
`MainWindow::refreshRttyDecodeState()`:

> *"Only auto-activate for explicit RTTY mode. DIGL is a general LSB-data mode
> used for PSK31, FT8, SSTV, etc. — showing a Baudot decoder on those signals
> would be confusing."*

Painting FSK **tone markers** on those same signals is the identical category
error. The decoder honoured the rule; the renderer did not.

## Seven sites, one predicate

The `RTTY || DIGL` test was duplicated in seven places in `SpectrumWidget.cpp`,
in two functional groups:

| Group | Sites |
|---|---|
| Cue rendering | `drawSliceMarkers` (2D painter), `appendShadow` (GPU shadow cues), `buildDssDepthGeometry` (3D CPU fallback) |
| VFO flag placement / anchoring | `singleVfoFlagDirectionForOverlay`, `assignModeForcedDirections`, `vfoFlagOnLeftForSlice`, `repositionVfoFlags` |

All seven now call `AetherSDR::drawsRttyToneCues()` so they cannot drift apart.
The helper lives in a new `src/gui/SliceToneCues.h` rather than on
`SpectrumWidget`, so it is unit-testable without pulling in `QRhiWidget` and the
DSS renderer.

### User-visible side effect worth a maintainer's eye

Including the flag-placement group means **DIGL slices lose `ForceRight` flag
pinning and the `mhzToX(hiMhz) + 4` anchor**. That is logically correct — both
existed to keep the flag clear of the tone-cue region left of the carrier, and
DIGL no longer has one — but it is user-visible: a DIGL flag can now auto-flip
at the pan edges like any other mode. Raised by @aethersdr-agent; called out here
so it is not a surprise. Happy to drop that group if you would rather keep DIGL
flags pinned.

## Evidence

Characterised on **FLEX-8400, fw 4.2.20.41343** through the automation bridge,
capturing the raw pan framebuffer (`grab pan 0`) so the VFO flag panel could not
occlude the marker — the confound that makes the original screenshots ambiguous.

**All 13 radio-advertised modes at 14.110 MHz:**

| Modes | Carrier |
|---|---|
| LSB, USB, AM, CW, DIGU, SAM, FM, NFM, DFM, FDVU, FDVL | ✅ drawn |
| **DIGL, RTTY** | ❌ missing |

Exactly the two mode strings in the conditional, and nothing else. Notably
`FDVL` — also lower-sideband, also digital — is unaffected, so this is a
mode-string bug, not a sideband-family one.

**Mode crossed against band:**

| Freq | Band | Mode | Carrier |
|---|---|---|---|
| 7.182 | 40 m | DIGL | ❌ |
| **7.182** | **40 m** | **DIGU** | **✅** |
| **14.236** | **20 m** | **DIGL** | **❌** |
| 14.236 | 20 m | DIGU | ✅ |

Pixel positions are identical across bands, so the behaviour is exactly
frequency-independent.

Measured cue positions match the source geometry to within 1 px (DIGL mark
predicted x=493.8, measured 494.0; RTTY predicted 651.5, measured 652.0 — and
that RTTY coincidence with the carrier is precisely why v2 leaves RTTY alone).

Reproduced identically in **2D**, **3D**, and **3D with slice-shadow shading**.

## What changed in v2

| v1 | v2 |
|---|---|
| Carrier made additive in all three renderers | **Reverted** — exclusive `if/else` preserved |
| RTTY gained a carrier line + triangle | **Reverted** — RTTY rendering untouched |
| GPU cue array grown 2 → 3 | **Reverted** to 2; no extra `kDssMeshShadowSlices` descriptor |
| Predicate narrowed to `RTTY` | **Kept** — this is the whole fix |

The narrowing alone fully satisfies #5097. The additive change was never needed
for it.

## Test plan

- `tests/slice_tone_cues_test.cpp` pins the predicate, including the specific
  regression (`DIGL` → no tone cues) and all 13 advertised modes. Declared in
  `tests/tests.cmake` per #5002.
- `SpectrumWidget.cpp` syntax-checked in GPU and non-GPU configurations.
- Built locally off this branch (MinGW/Qt 6.11, RelWithDebInfo).
  `slice_tone_cues_test` **passes under `ctest`** (0.18 s), as do
  `vfo_flag_placement_test` and `slice_label_test`.
- Note for reviewers: this repo's `ctest` invocations are `-R`-filtered, so a
  green CI run does **not** mean `slice_tone_cues_test` executed. I confirmed it
  is compiled and linked on macOS and Windows in CI, but not run there — it is
  run locally.
- **On-radio re-verification has NOT been run yet.** The pre-fix baseline above
  characterises the defect; it does not demonstrate the fix. The harness
  (per-mode pan grabs scored against the calibrated carrier/mark/space
  positions) is ready and will be run against this build. Expected result: all
  13 modes draw the carrier, DIGL draws no tone cues, RTTY unchanged.

**Known coverage gap, stated plainly:** the test pins the predicate, not the
carrier-restored symptom. Cue selection is not extractable as a pure function
without a larger refactor. @aethersdr-agent's suggested follow-up — factoring
"which cues does this overlay emit, at what frequencies" into a testable
function — is the right shape for closing it.

No `CHANGELOG.md` entry, per #4707.

Fixes #5097

🤖 Generated with [Claude Code](https://claude.com/claude-code)
