### PR TITLE
fix(icom): publish IC-9700 supply voltage telemetry

### DIFF
--- a/docs/architecture/aetherd-icom-civ-backend-design.md
+++ b/docs/architecture/aetherd-icom-civ-backend-design.md
@@ -237,7 +237,7 @@ caps.hostModulates          = false;           // the radio modulates
 caps.hasRadioSideDsp        = true;            // NR/NB/notch are 16 xx, in firmware
 caps.hasTuner               = false;           // no INTERNAL ATU; see note
 caps.hasSupplyVoltageTelemetry =
-    profile.meters.calibration != MeterCalibration::Uncalibrated; // 15 15 Vd
+    hasVoltageCalibration(profile.meters.calibration); // explicit model allowlist; 15 15 Vd
 caps.hasDaxStreams          = false;           // NO IQ — see oracle §8.1
 caps.hasGpsLocation         = false;           // GPS exists, protocol won't carry it
 caps.hasProfiles            = false;

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -251,7 +251,7 @@ RadioCapabilities IcomCivBackend::capabilities() const
     c.hasGpsLocation = false;
 
     c.hasSupplyVoltageTelemetry =
-        profile.meters.calibration != MeterCalibration::Uncalibrated;
+        hasVoltageCalibration(profile.meters.calibration);
     c.hasPaTemperatureTelemetry = profile.meters.hasPaTemperatureTelemetry;
 
     // THE ATU BUTTON IS REACHABLE AGAIN.
@@ -4019,8 +4019,10 @@ QVariantList IcomCivBackend::meterMap() const
 
     QVariantList out;
     for (const auto& m : meterSpecs()) {
-        if ((m.id == MeterId::Vd || m.id == MeterId::Id)
-            && profile.meters.calibration == MeterCalibration::Uncalibrated) {
+        if ((m.id == MeterId::Vd
+             && !hasVoltageCalibration(profile.meters.calibration))
+            || (m.id == MeterId::Id
+                && !hasCurrentCalibration(profile.meters.calibration))) {
             continue;
         }
         QVariantMap r;
@@ -4030,7 +4032,7 @@ QVariantList IcomCivBackend::meterMap() const
         QString unit = sv(m.unit);
         double high = m.high;
         if (m.id == MeterId::Power) {
-            const std::span<const CurvePoint> curve = profile.meters.powerCurve;
+            const std::span<const CurvePoint> curve = powerCurveFor(*m_model);
             if (curve.empty()) {
                 unit = QStringLiteral("Percent");
                 high = 100.0;
@@ -4729,16 +4731,19 @@ void IcomCivBackend::publishModeList()
 
 void IcomCivBackend::publishMeterDefs()
 {
-    const bool calibrated = profileFor(*m_model).meters.calibration
-        != MeterCalibration::Uncalibrated;
+    const MeterCalibration calibration =
+        profileFor(*m_model).meters.calibration;
+    const bool hasVoltage = hasVoltageCalibration(calibration);
+    const bool hasCurrent = hasCurrentCalibration(calibration);
     // Poll eligibility follows the active profile too. This runs both for the
     // handshake name and for an authoritative 0x19 identity correction.
-    m_meters.setVisible(MeterId::Vd, calibrated);
-    m_meters.setVisible(MeterId::Id, calibrated);
+    m_meters.setVisible(MeterId::Vd, hasVoltage);
+    m_meters.setVisible(MeterId::Id, hasCurrent);
 
     for (const MeterSpec& s : meterSpecs()) {
         const int index = static_cast<int>(s.id);
-        if ((s.id == MeterId::Vd || s.id == MeterId::Id) && !calibrated) {
+        if ((s.id == MeterId::Vd && !hasVoltage)
+            || (s.id == MeterId::Id && !hasCurrent)) {
             // Meter indices are stable identities, not positions in the
             // currently visible subset. Withdraw old definitions explicitly
             // so a calibrated handshake name corrected to another model cannot

--- a/src/core/backends/icom/IcomMeters.cpp
+++ b/src/core/backends/icom/IcomMeters.cpp
@@ -52,6 +52,12 @@ constexpr std::array<CurvePoint, 3> kVd{{
     {0, 0.0}, {75, 5.0}, {241, 16.0},
 }};
 
+// IC-9700 Vd calibration from the model's CI-V reference guide. This is kept
+// separate from the portable-radio curve: raw 185 is the nominal 13.8 V point.
+constexpr std::array<CurvePoint, 4> kVdIc9700{{
+    {0, 0.0}, {13, 10.0}, {185, 13.8}, {241, 16.0},
+}};
+
 // Id (PA current), raw -> amps. Icom's guide: 0 = 0 A, 121 = 2 A, 241 = 4 A.
 constexpr std::array<CurvePoint, 3> kId{{
     {0, 0.0}, {121, 2.0}, {241, 4.0},
@@ -137,6 +143,34 @@ std::span<const CurvePoint> vdCurve()         { return kVd; }
 std::span<const CurvePoint> idCurve()         { return kId; }
 std::span<const CurvePoint> alcCurve()        { return kAlc; }
 
+std::span<const CurvePoint>
+powerCurveForCalibration(MeterCalibration calibration)
+{
+    switch (calibration) {
+    case MeterCalibration::Ic705:
+        return kPowerIc705;
+    case MeterCalibration::Ic7300Mk2:
+        return kPowerIc7300Mk2;
+    case MeterCalibration::Uncalibrated:
+    case MeterCalibration::Ic9700Voltage:
+        return {};
+    }
+    return {};
+}
+
+bool hasVoltageCalibration(MeterCalibration calibration) noexcept
+{
+    return calibration == MeterCalibration::Ic705
+        || calibration == MeterCalibration::Ic9700Voltage
+        || calibration == MeterCalibration::Ic7300Mk2;
+}
+
+bool hasCurrentCalibration(MeterCalibration calibration) noexcept
+{
+    return calibration == MeterCalibration::Ic705
+        || calibration == MeterCalibration::Ic7300Mk2;
+}
+
 double sMeterDbm(int raw, double s9Dbm)
 {
     // Icom's published breakpoints: 0 = S0, 120 = S9, 241 = S9 + 60 dB.
@@ -182,24 +216,31 @@ double meterValue(MeterId id, int raw, double s9Dbm, MeterCalibration calibratio
     switch (id) {
     case MeterId::SMeter:   return sMeterDbm(raw, s9Dbm);
     case MeterId::Power:
-        if (calibration == MeterCalibration::Uncalibrated) {
-            return std::clamp(raw, 0, 255) * 100.0 / 255.0;
+        if (const std::span<const CurvePoint> curve = powerCurveForCalibration(calibration);
+            !curve.empty()) {
+            return interpolateCurve(curve, raw);
         }
-        return interpolateCurve(desktop ? powerCurveIc7300Mk2()
-                                        : powerCurveIc705(), raw);
+        return std::clamp(raw, 0, 255) * 100.0 / 255.0;
     case MeterId::Swr:      return interpolateCurve(kSwr, raw);
     case MeterId::Alc:      return interpolateCurve(kAlc, raw);
     case MeterId::Comp:     return interpolateCurve(kComp, raw);
     case MeterId::Vd:
-        if (calibration == MeterCalibration::Uncalibrated) {
+        if (!hasVoltageCalibration(calibration)) {
             return 0.0;
         }
-        return interpolateCurve(
-                                desktop
-                                    ? std::span<const CurvePoint>(kVdIc7300Mk2)
-                                    : std::span<const CurvePoint>(kVd), raw);
+        switch (calibration) {
+        case MeterCalibration::Ic705:
+            return interpolateCurve(kVd, raw);
+        case MeterCalibration::Ic9700Voltage:
+            return interpolateCurve(kVdIc9700, raw);
+        case MeterCalibration::Ic7300Mk2:
+            return interpolateCurve(kVdIc7300Mk2, raw);
+        case MeterCalibration::Uncalibrated:
+            return 0.0;
+        }
+        return 0.0;
     case MeterId::Id:
-        if (calibration == MeterCalibration::Uncalibrated) {
+        if (!hasCurrentCalibration(calibration)) {
             return 0.0;
         }
         return interpolateCurve(

--- a/src/core/backends/icom/IcomMeters.h
+++ b/src/core/backends/icom/IcomMeters.h
@@ -131,8 +131,14 @@ struct MeterSpec {
 enum class MeterCalibration : std::uint8_t {
     Uncalibrated,
     Ic705,
+    Ic9700Voltage,
     Ic7300Mk2,
 };
+
+[[nodiscard]] std::span<const CurvePoint>
+powerCurveForCalibration(MeterCalibration calibration);
+[[nodiscard]] bool hasVoltageCalibration(MeterCalibration calibration) noexcept;
+[[nodiscard]] bool hasCurrentCalibration(MeterCalibration calibration) noexcept;
 
 // Convert a raw reading to the spec's unit. `s9Dbm` selects the S-meter
 // reference and is ignored by every other meter.

--- a/src/core/backends/icom/IcomModels.cpp
+++ b/src/core/backends/icom/IcomModels.cpp
@@ -422,7 +422,7 @@ std::optional<std::uint8_t> parseModelIdReply(const CivFrame& frame)
 
 std::span<const CurvePoint> powerCurveFor(const IcomModel& model)
 {
-    return profileFor(model).meters.powerCurve;
+    return powerCurveForCalibration(profileFor(model).meters.calibration);
 }
 
 std::span<const std::string_view> preampLabelsFor(const IcomModel& model)
@@ -530,8 +530,7 @@ const IcomModelProfile& profileFor(const IcomModel& model) noexcept
         .cwTextKeyer = CwTextKeyerProfile{},
         .setMenu = SetMenuProfile{359, 131},
         .scope = ScopeCommandProfile{true, false, false, false, false},
-        .meters = MeterCalibrationProfile{MeterCalibration::Ic705,
-                                          powerCurveIc705(), 4.0},
+        .meters = MeterCalibrationProfile{MeterCalibration::Ic705, 4.0},
         .preampLabels = kHfPreampLabels,
         .attenuatorSteps = kHfAttenuatorSteps,
         .modes = kIc705Modes,
@@ -546,7 +545,7 @@ const IcomModelProfile& profileFor(const IcomModel& model) noexcept
                                        kExtendedFmAccessModes,
                                        true, true, true, true, true, true},
         .scope = ScopeCommandProfile{true, false, false, false, false},
-        .meters = MeterCalibrationProfile{MeterCalibration::Uncalibrated, {}, 0.0},
+        .meters = MeterCalibrationProfile{MeterCalibration::Ic9700Voltage, 0.0},
         .civRecovery = CivRecoveryProfile{1000, 3},
     };
     static const IcomModelProfile kIc7300Mk2Profile{
@@ -564,8 +563,7 @@ const IcomModelProfile& profileFor(const IcomModel& model) noexcept
         .rxAntenna = RxAntennaProfile{true, false},
         .setMenu = SetMenuProfile{267, 89},
         .scope = ScopeCommandProfile{true, true, true, true, true},
-        .meters = MeterCalibrationProfile{MeterCalibration::Ic7300Mk2,
-                                          powerCurveIc7300Mk2(), 25.0},
+        .meters = MeterCalibrationProfile{MeterCalibration::Ic7300Mk2, 25.0},
         .preampLabels = kHfPreampLabels,
         .attenuatorSteps = kHfAttenuatorSteps,
     };

--- a/src/core/backends/icom/IcomModels.h
+++ b/src/core/backends/icom/IcomModels.h
@@ -374,7 +374,6 @@ struct RxAntennaProfile {
 
 struct MeterCalibrationProfile {
     MeterCalibration calibration = MeterCalibration::Uncalibrated;
-    std::span<const CurvePoint> powerCurve;
     double currentFullScaleAmps = 4.0;
     // True only after this model profile both documents and implements a PA
     // temperature meter. Kept model-specific so one Icom cannot lend an

--- a/tests/icom_backend_test.cpp
+++ b/tests/icom_backend_test.cpp
@@ -2174,10 +2174,10 @@ int main(int argc, char** argv)
     };
 
     // A user-visible Network Radio Name is only a handshake hint. The 0x19
-    // reply is authoritative and can move the session from a calibrated
-    // profile to an uncalibrated one. Meter definitions must be replaced by
-    // stable identity, not compacted into new indices, or OVF takes the old Vd
-    // slot and the status bar reads an overflow flag as supply voltage.
+    // reply is authoritative and can replace the hinted model's meter set —
+    // here IC-705 Vd+Id becomes IC-9700 Vd-only. Definitions must be replaced
+    // by stable identity, not compacted into new indices, or OVF takes a former
+    // meter slot and the status bar reads an overflow flag as telemetry.
     {
         CivCase c(0xA2, "IC-705");
         QMap<int, MeterDef> activeMeters;
@@ -2202,24 +2202,30 @@ int main(int argc, char** argv)
         const int vdIndex = static_cast<int>(MeterId::Vd);
         const int idIndex = static_cast<int>(MeterId::Id);
         const int overflowIndex = static_cast<int>(MeterId::Overflow);
-        check(removedMeters.contains(vdIndex) && removedMeters.contains(idIndex),
-              "identity correction: withdrawn Vd and Id definitions are removed explicitly");
-        check(!activeMeters.contains(vdIndex) && !activeMeters.contains(idIndex),
-              "identity correction: uncalibrated Vd and Id do not remain cached");
+        check(!removedMeters.contains(vdIndex) && removedMeters.contains(idIndex),
+              "identity correction: IC-9700 retains Vd and withdraws unsupported Id");
+        check(activeMeters.contains(vdIndex) && !activeMeters.contains(idIndex),
+              "identity correction: IC-9700 publishes voltage without claiming current");
         check(activeMeters.contains(overflowIndex)
                   && activeMeters.value(overflowIndex).name == QStringLiteral("OVF"),
               "identity correction: OVF retains its stable meter identity");
-        check(activeMeters.size() == 6,
-              "identity correction: only calibrated-independent meters remain");
+        check(activeMeters.size() == 7,
+              "identity correction: calibrated-independent meters plus Vd remain");
 
         c.radio.clearCivLog();
-        check(waitFor([&] { return !c.radio.civCommands().empty(); }, 1500),
-              "identity correction: scheduler continues after profile correction");
+        check(waitFor([&] {
+                  return std::ranges::any_of(
+                      c.radio.civCommands(), [](const CivFrame& frame) {
+                          return frame.cmd == cmd::kMeter && frame.hasSub
+                              && frame.sub == meter::kVd;
+                      });
+              }, 2500),
+              "identity correction: IC-9700 schedules its supported Vd poll");
         check(std::ranges::none_of(c.radio.civCommands(), [](const CivFrame& frame) {
                   return frame.cmd == cmd::kMeter && frame.hasSub
-                      && (frame.sub == meter::kVd || frame.sub == meter::kId);
+                      && frame.sub == meter::kId;
               }),
-              "identity correction: uncalibrated Vd and Id are no longer polled");
+              "identity correction: IC-9700 does not poll unsupported Id");
 
         c.backend.disconnectRadio();
     }

--- a/tests/icom_meters_test.cpp
+++ b/tests/icom_meters_test.cpp
@@ -124,6 +124,16 @@ static void testPowerAndOthers()
           "IC-7300MK2 Vd uses its desktop calibration");
     check(near(meterValue(MeterId::Id, 97, 0, MeterCalibration::Ic7300Mk2), 10.0),
           "IC-7300MK2 Id uses its 25 A face");
+    check(near(meterValue(MeterId::Vd, 185, 0,
+                          MeterCalibration::Ic9700Voltage), 13.8),
+          "IC-9700 Vd uses its model-specific calibration");
+    check(near(meterValue(MeterId::Id, 121, 0,
+                          MeterCalibration::Ic9700Voltage), 0.0),
+          "IC-9700 voltage capability does not also claim PA current");
+    check(near(meterValue(MeterId::Power, 213, 0,
+                          MeterCalibration::Ic9700Voltage),
+               213.0 * 100.0 / 255.0),
+          "IC-9700 voltage capability does not borrow another model's watt curve");
 
     // ALC full scale is 120, NOT 255 — the guide says so. Scaling by 255 makes
     // a fully-driven ALC read 47%.
@@ -498,6 +508,11 @@ static void testPowerCurveIsNotShared()
     check(ic9700 && powerCurveFor(*ic9700).empty(),
           "another model gets NO curve rather than the IC-705's");
     check(powerCurveFor(unknownModel()).empty(), "and nor does an unknown radio");
+    check(powerCurveForCalibration(MeterCalibration::Ic7300Mk2).data()
+              == powerCurveIc7300Mk2().data(),
+          "power presentation and conversion share the IC-7300MK2 curve selector");
+    check(powerCurveForCalibration(MeterCalibration::Ic9700Voltage).empty(),
+          "the voltage-only IC-9700 calibration fails closed to relative power");
 }
 
 // The mode vocabulary this backend publishes onto the slice (#5040).

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -511,6 +511,8 @@ int main(int argc, char** argv)
               "Icom declares the three IC-9700 per-band TX power limits");
         check(caps.hasTransmitFrequencyCheck,
               "Icom declares the profiled IC-9700 momentary XFC command");
+        check(caps.hasSupplyVoltageTelemetry,
+              "Icom declares the profiled IC-9700 supply-voltage telemetry");
 
         const auto expectPowerLimit = [&](std::uint64_t hz, int watts,
                                           const char* description) {


### PR DESCRIPTION
Fixes #5169

## Summary

The IC-9700 Radio Vitals voltage gauge previously showed its static `+13.8V` label without a colored fill or live updates. The model profile marked all meter calibration unavailable, so the backend did not declare or poll the radio's read-only CI-V `15 15` (Vd) telemetry.

This PR:

- adds the IC-9700's published voltage calibration as a model-specific, voltage-only profile;
- distinguishes voltage-calibration availability from drain-current calibration availability;
- declares and polls Vd for the IC-9700 through the existing normalized meter seam;
- keeps PA drain current unsupported and unpolled;
- preserves the IC-9700's existing relative-percent RF-power presentation; and
- adds regression coverage for calibration, polling, identity correction, and isolation from other Icom profiles.

There are no GUI source changes, no visual or UX changes, no new dependencies, no settings changes, and no Flex backend changes.

## Maintainer-guidance alignment

This is intentionally one narrow issue and one PR for voltage telemetry:

- **Use the capabilities model:** Vd availability is declared by the IC-9700 model profile and consumed through the existing backend capability/meter path.
- **Do not touch Flex behavior:** no Flex source is modified; all production changes are confined to `src/core/backends/icom/`.
- **Do not bulk UX changes:** the existing Radio Vitals gauge receives normalized live data; no applet, layout, theme, or interaction code changes.
- **Do not claim unsupported telemetry:** Id remains unavailable because this work has evidence only for Vd.
- **Protect other Icom models:** IC-705 and IC-7300MK2 retain their existing calibration selection and polling behavior, with regression coverage around model-specific gating.

## Evidence

### Official Icom protocol evidence

The public IC-9700 CI-V Reference Guide documents supply voltage as command `15 15` and specifies the model calibration points `0 → 0.0 V`, `13 → 10.0 V`, `185 → 13.8 V`, and `241 → 16.0 V`.

### Independent open-source corroboration

wfview independently defines IC-9700 Vd as CI-V `15 15`, carries the same four model-specific calibration points, and uses piecewise-linear interpolation:

- [IC-9700 command definition](https://github.com/wf-group/wfview/blob/f8e0bb5ffda3c1d5720bfda9c76a4ecf0d20dfbf/rigs/IC-9700.rig#L450-L454)
- [IC-9700 voltage table](https://github.com/wf-group/wfview/blob/f8e0bb5ffda3c1d5720bfda9c76a4ecf0d20dfbf/rigs/IC-9700.rig#L1855-L1871)
- [Piecewise-linear interpolation](https://github.com/wf-group/wfview/blob/f8e0bb5ffda3c1d5720bfda9c76a4ecf0d20dfbf/src/rigcommander.cpp#L187-L217)

### Physical IC-9700 verification

Tested over LAN against a physical IC-9700. The live CI-V trace repeatedly returned raw BCD values 176–178:

```text
RX <- 15 15 01 76
RX <- 15 15 01 77
RX <- 15 15 01 78
```

The implemented calibration converted these to approximately 13.60–13.65 V. Radio Vitals displayed that changing live range and its existing gauge fill rendered correctly.

## Constitution principle

**Principle II — The Radio Is Authoritative On Live State.** The displayed voltage now comes from the IC-9700's live CI-V response rather than a plausible static client-side label. Capability exposure remains model-specific and is limited to telemetry supported by evidence.

## Test plan

- [x] Local build completes successfully
- [x] `icom_meters_test`
- [x] `icom_backend_test`
- [x] `icom_family_test`
- [x] `radio_capability_gating_test`
- [x] `git diff --check`
- [x] `python3 tools/check_engine_boundary.py --strict`
- [x] Tested against a physical IC-9700 over LAN
- [x] Confirmed live raw Vd replies and Radio Vitals gauge updates

## Checklist

- [x] The commit is SSH-signed and cites the load-bearing Constitution principle.
- [x] The change is linked to one approved, narrowly scoped issue.
- [x] No `CHANGELOG.md` entry was added.
- [x] No `QSettings`, settings schema, or persistence behavior was added.
- [x] No GUI, theme, layout, UX, Flex, or dependency source was changed.
- [x] Protocol claims are supported by public Icom documentation, an independent open-source implementation, automated tests, and a physical-radio trace.
- [x] Unsupported IC-9700 drain-current telemetry is not surfaced.

@aethersdr-agent please review this model-specific capability and meter-path change, particularly the cross-model isolation and the decision to expose Vd while leaving Id unsupported.
