### PR TITLE
fix(meter): wait for real supply-voltage telemetry

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7291,6 +7291,9 @@ void MainWindow::applyCapabilitiesToUi(bool connected, const RadioCapabilities& 
     // meter, and MeterModel emits hwTelemetryChanged whenever EITHER half
     // changes — so on a radio that reports only PA temperature the volts half
     // arrives as its 0.0f initialiser on every tick.
+    if (m_appletPanel) {
+        m_appletPanel->meterApplet()->setSupplyVoltageTelemetryState(connected);
+    }
     if (m_supplyVoltLabel) {
         m_supplyVoltLabel->setVisible(!connected || caps.hasSupplyVoltageTelemetry);
         if (!connected) {

--- a/src/gui/MeterApplet.cpp
+++ b/src/gui/MeterApplet.cpp
@@ -131,9 +131,10 @@ MeterApplet::MeterApplet(QWidget* parent)
     vbox->addWidget(m_paTempGauge);
 
     // ── Supply voltage gauge ───────────────────────────────────────────────────
-    m_supplyGauge = new HGauge(10.0f, 16.0f, 15.0f, "+13.8V", "",
+    m_supplyGauge = new HGauge(10.0f, 16.0f, 15.0f, "Supply Voltage", "",
         {{10.5f, "10.5"}, {12, "12"}, {13.8f, "13.8"}, {15, "15"}},
         this, 14.1f);
+    m_supplyGauge->setObjectName(QStringLiteral("mtrSupplyVoltageGauge"));
     m_supplyGauge->setAccessibleName(tr("Supply voltage"));
     vbox->addWidget(m_supplyGauge);
 
@@ -163,8 +164,13 @@ void MeterApplet::setMeterModel(MeterModel* model)
             m_paTempGauge->setLabel(formatTemp(paTemp, m_tempFahrenheit));
         }
 
-        m_supplyGauge->setValue(supplyV);
-        m_supplyGauge->setLabel(QString("+%1V").arg(supplyV, 0, 'f', 2));
+        // hwTelemetryChanged carries PA temperature and supply voltage
+        // together. A temperature-only update must not format MeterModel's
+        // 0.0 V initialiser as though the radio reported it.
+        if (m_model->hasSupplyVoltage()) {
+            m_supplyGauge->setValue(supplyV);
+            m_supplyGauge->setLabel(QStringLiteral("+%1V").arg(supplyV, 0, 'f', 2));
+        }
     });
 
     connect(model, &MeterModel::meterUpdated,
@@ -188,6 +194,23 @@ void MeterApplet::setPaTemperatureTelemetryState(bool connected, bool available)
     const bool visible = !connected || available;
     m_paTempGauge->setVisible(visible);
     m_tempUnitBtn->setVisible(visible);
+}
+
+void MeterApplet::setSupplyVoltageTelemetryState(bool connected)
+{
+    // A reading belongs to one extant meter in one radio session.
+    // MeterModel::clear() and removeMeter() drop the sample-validity sentinel
+    // without a telemetry update, so restore the neutral label when the shared
+    // capability lifecycle reports either transition.
+    if (!connected || !m_model || !m_model->hasSupplyVoltage()) {
+        resetSupplyVoltageDisplay();
+    }
+}
+
+void MeterApplet::resetSupplyVoltageDisplay()
+{
+    m_supplyGauge->setValueImmediate(0.0f);
+    m_supplyGauge->setLabel(QStringLiteral("Supply Voltage"));
 }
 
 void MeterApplet::resolveIndices()

--- a/src/gui/MeterApplet.h
+++ b/src/gui/MeterApplet.h
@@ -24,11 +24,13 @@ public:
 
     void setMeterModel(MeterModel* model);
     void setPaTemperatureTelemetryState(bool connected, bool available);
+    void setSupplyVoltageTelemetryState(bool connected);
 
 private:
     void resolveIndices();
     void onMeterUpdated(int index, float value);
     void updatePaTempDisplay();
+    void resetSupplyVoltageDisplay();
 
     MeterModel* m_model{nullptr};
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1088,11 +1088,14 @@ void RadioModel::setupBackend(const QString& family)
     connect(m_backend.get(), &IRadioBackend::meterRemoved, this,
             [this](int index) {
         const bool hadMicPeak = m_meterModel.hasMicPeakMeter();
+        const bool hadSupplyVoltage = m_meterModel.hasSupplyVoltage();
         m_meterModel.removeMeter(index);
         // Symmetric on purpose: a meter that goes away must hide the face
         // again, or a radio swap leaves a dead gauge on screen.
-        if (hadMicPeak != m_meterModel.hasMicPeakMeter())
+        if (hadMicPeak != m_meterModel.hasMicPeakMeter()
+            || hadSupplyVoltage != m_meterModel.hasSupplyVoltage()) {
             publishCapabilities(isConnected());
+        }
     });
 
     // A backend may revise its own capabilities mid-session (SimBackend does so

--- a/tests/meter_applet_voltage_state_test.cpp
+++ b/tests/meter_applet_voltage_state_test.cpp
@@ -1,0 +1,102 @@
+// Radio Vitals must not present a nominal or zero supply voltage before the
+// connected radio has supplied a real telemetry sample.
+
+#include "gui/HGauge.h"
+#include "gui/MeterApplet.h"
+#include "models/MeterModel.h"
+#include "TestSettingsProfile.h"
+
+#include <QApplication>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* description)
+{
+    std::printf("%s %s\n", condition ? "[ OK ]" : "[FAIL]", description);
+    if (!condition) {
+        ++failures;
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    qputenv("AETHER_AUTOMATION", "1");
+    TestSettingsProfile settingsProfile(
+        QStringLiteral("aether-meter-applet-voltage-state-test"));
+    QApplication app(argc, argv);
+    MeterApplet applet;
+
+    QWidget* supplyWidget =
+        applet.findChild<QWidget*>(QStringLiteral("mtrSupplyVoltageGauge"));
+    check(supplyWidget != nullptr, "Radio Vitals exposes a supply-voltage gauge");
+    if (!supplyWidget) {
+        return failures;
+    }
+    auto* supplyGauge = static_cast<HGauge*>(supplyWidget);
+
+    check(supplyGauge->property("gaugeLabel").toString()
+              == QStringLiteral("Supply Voltage"),
+          "the disconnected gauge starts with a neutral label");
+
+    MeterModel model;
+    MeterDef paTemp;
+    paTemp.index = 1;
+    paTemp.source = QStringLiteral("RAD");
+    paTemp.name = QStringLiteral("PATEMP");
+    paTemp.unit = QStringLiteral("degC");
+    model.defineMeter(paTemp);
+    applet.setMeterModel(&model);
+
+    model.updateValues({1}, {static_cast<qint16>(55 * 64)});
+    check(supplyGauge->property("gaugeLabel").toString()
+              == QStringLiteral("Supply Voltage"),
+          "unrelated hardware telemetry does not fabricate a voltage");
+
+    MeterDef supply;
+    supply.index = 2;
+    supply.source = QStringLiteral("RAD");
+    supply.name = QStringLiteral("+13.8A");
+    supply.unit = QStringLiteral("Volts");
+    model.defineMeter(supply);
+    model.updateValues({2}, {static_cast<qint16>(13.5f * 256.0f)});
+    check(model.hasSupplyVoltage(), "the model records receipt of a voltage sample");
+    check(supplyGauge->property("gaugeLabel").toString()
+              == QStringLiteral("+13.50V"),
+          "a real telemetry sample replaces the neutral label");
+
+    applet.setSupplyVoltageTelemetryState(true);
+    check(supplyGauge->property("gaugeLabel").toString()
+              == QStringLiteral("+13.50V"),
+          "a live sample survives a mid-session capability republish");
+
+    model.removeMeter(2);
+    applet.setSupplyVoltageTelemetryState(true);
+    check(supplyGauge->property("gaugeLabel").toString()
+              == QStringLiteral("Supply Voltage"),
+          "removing the voltage meter clears its stale reading");
+
+    model.defineMeter(supply);
+    model.updateValues({2}, {static_cast<qint16>(13.5f * 256.0f)});
+    model.clear();
+    applet.setSupplyVoltageTelemetryState(false);
+    check(supplyGauge->property("gaugeLabel").toString()
+              == QStringLiteral("Supply Voltage"),
+          "disconnect clears the previous radio's voltage");
+    check(supplyGauge->value() == 0.0f,
+          "disconnect clears the previous radio's gauge value");
+
+    applet.setSupplyVoltageTelemetryState(true);
+    check(supplyGauge->property("gaugeLabel").toString()
+              == QStringLiteral("Supply Voltage"),
+          "a new session waits for its own telemetry sample");
+
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -2735,6 +2735,29 @@ add_test(NAME meter_applet_capability_test COMMAND meter_applet_capability_test)
 set_tests_properties(meter_applet_capability_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
+add_executable(meter_applet_voltage_state_test
+    tests/meter_applet_voltage_state_test.cpp
+    src/gui/MeterApplet.cpp
+    src/gui/DragValuePopup.cpp
+    src/models/MeterModel.cpp
+    src/core/ThemeManager.cpp
+    src/core/ThemeSeedGenerated.cpp
+    ${AETHER_SETTINGS_SOURCES}
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+)
+target_include_directories(meter_applet_voltage_state_test PRIVATE src)
+target_link_libraries(meter_applet_voltage_state_test PRIVATE
+    Qt6::Core Qt6::Gui Qt6::Widgets
+)
+if(UNIX)
+    target_link_libraries(meter_applet_voltage_state_test PRIVATE pthread)
+endif()
+set_target_properties(meter_applet_voltage_state_test PROPERTIES AUTOMOC ON)
+add_test(NAME meter_applet_voltage_state_test COMMAND meter_applet_voltage_state_test)
+set_tests_properties(meter_applet_voltage_state_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 # Demo-mode SimBackend lifecycle test (RFC #4288, Phase 1). SimBackend was once
 # wire-free, but Path B (RFC #4288) had it own a RadioConnection + PanadapterStream,
 # so it no longer links against a hand-picked subset of sources: those pull in
@@ -3877,6 +3900,7 @@ set(AETHER_SETTINGS_CONSUMERS
     meter_model_test
     health_applet_test
     meter_applet_capability_test
+    meter_applet_voltage_state_test
     perf_telemetry_test
     local_memory_bank_test
     transmit_model_apd_test


### PR DESCRIPTION
## Summary

Fixes #5175.

Radio Vitals currently initializes its supply-voltage gauge with `+13.8V`, which looks like live telemetry even when no radio is connected. The same surface also listens to the combined `hwTelemetryChanged` signal: a PA-temperature update can arrive before a supply-voltage sample and expose the model's `0.0` initializer unless presentation is gated on sample validity.

This PR makes the gauge follow the neutral-label convention already used by its neighbors:

- disconnected: `Supply Voltage`
- connected but awaiting the first valid sample: `Supply Voltage`
- after a real sample: the radio-reported value, such as `+13.62V`
- after disconnect: immediately back to `Supply Voltage`

The distinction matters because `+13.8V` is a nominal station-supply value, not evidence that the connected radio measured 13.8 volts. `0.00V` would be equally misleading before a sample. `Supply Voltage` identifies the instrument without asserting a measurement, while remaining consistent with the existing `PA Temp` and `Main Fan` neutral labels.

### Implementation and scope

- Initializes the supply gauge with the neutral `Supply Voltage` label.
- Gates numeric presentation on the existing `MeterModel::hasSupplyVoltage()` sample-validity contract.
- Uses the existing `applyCapabilitiesToUi()` connection lifecycle to clear the prior session on disconnect; it does not add a new signal route.
- Adds a focused GUI/model test for startup, unrelated hardware telemetry, valid voltage telemetry, disconnect, and a later session awaiting its own sample.

This deliberately does **not** change:

- backend commands or parsing;
- voltage calibration;
- capability declarations;
- meter smoothing, thresholds, tick marks, colors, or layout;
- Flex, IC-705, IC-7300MK2, HL2, Sim, or IC-9700 family-specific behavior.

The UI consumes only normalized `MeterModel` validity and connection lifecycle state. There are no radio-family conditionals above the backend seam.

### Evidence

- A physical IC-9700 was exercised over the LAN/CI-V backend while the station supply was changed between 13.8 V and 14.5 V. AetherSDR received changing radio voltage telemetry and replaced the gauge label with decoded live values once samples arrived.
- The open-source **wfview** Icom implementation was reviewed as an independent comparison. Its meter presentation is driven by received Icom meter data; it does not support treating a nominal disconnected `13.8V` constructor string as live state.
- The new startup/disconnect/no-sample behavior is covered by the focused automated lifecycle test below. The PR does not rely on SDR9700 evidence or proprietary/decompiled sources.

## Constitution principle honored

**Principle II — The Radio Is Authoritative On Live State.** AetherSDR no longer presents a numeric supply voltage until the radio has actually supplied a valid sample, and the prior radio's value is discarded at the session boundary.

The test coverage also supports Principle VIII (Evidence Over Assertion): each state transition claimed above is exercised directly rather than inferred from the constructor or capability declaration.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR`)
- [x] Behavior verified with a physical IC-9700: live voltage telemetry was observed and displayed; the new no-sample/disconnect transitions are additionally covered by the focused automated test
- [ ] Existing tests pass (CI — pending this PR)
- [x] Reproduction steps documented in #5175

Local verification completed:

```text
meter_applet_voltage_state_test  PASS
meter_model_test                 PASS
radio_capability_gating_test     PASS (with required loopback socket access)
full AetherSDR build             PASS
test registration --strict      PASS
engine boundary --strict         PASS (known baseline warnings only)
hardcoded-colour audit           no new colors introduced
git diff --check                 PASS
```

The focused test specifically proves:

1. the disconnected gauge starts at `Supply Voltage`;
2. PA-temperature-only telemetry cannot fabricate a voltage;
3. a valid voltage sample changes the label to the measured value;
4. disconnect clears both the prior label and gauge value; and
5. a later session waits for its own sample.

## Checklist

- [x] Commit is signed and verified (`f66c9c01`, SSH signature for `justin@w5jwp.radio`)
- [x] No new `AppSettings` keys or persistence behavior
- [x] Code is clean-room — based on public open-source comparison, observed radio behavior, and existing AetherSDR model contracts; not decompiled or disassembled (Principle IV)
- [x] Existing `HGauge`/`MeterSmoother` behavior is retained
- [x] User-visible behavior is documented here and in #5175; no product documentation page describes disconnected meter placeholders, and `CHANGELOG.md` is intentionally untouched
- [x] No security-sensitive changes

@aethersdr-agent please review this focused telemetry-presentation fix, particularly the sample-validity gate, disconnect lifecycle, family-neutral seam usage, and regression coverage.
