### PR TITLE
fix(meter): clear Phone/CW Level before telemetry

### DIFF
--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -1622,10 +1622,11 @@ void AppletPanel::setRadioFilterWidths(const QList<int>& widthsHz)
         m_rxApplet->setRadioFilterWidths(widthsHz);
 }
 
-void AppletPanel::setMicLevelMeterAvailable(bool available)
+void AppletPanel::setMicLevelMeterState(MicMeterSessionState session,
+                                        bool available)
 {
     if (m_phoneCwApplet)
-        m_phoneCwApplet->setMicLevelMeterAvailable(available);
+        m_phoneCwApplet->setMicLevelMeterState(session, available);
 }
 
 void AppletPanel::setSelectableMicInputs(bool selectable)

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -37,6 +37,7 @@ class SpeApplet;
 class VkampApplet;
 class TxApplet;
 class PhoneCwApplet;
+enum class MicMeterSessionState;
 class PhoneApplet;
 class EqApplet;
 class WaveApplet;
@@ -201,7 +202,7 @@ public:
     void setProfilesVisible(bool visible);
     // Capability passthrough to the Phone/CW applet — same shape as above.
     void setSelectableMicInputs(bool selectable);
-    void setMicLevelMeterAvailable(bool available);
+    void setMicLevelMeterState(MicMeterSessionState session, bool available);
     void setRadioFilterWidths(const QList<int>& widthsHz);
 
     // Show/hide the DAX and DAX-IQ buttons and applets based on whether the

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7129,8 +7129,10 @@ void MainWindow::applyCapabilitiesToUi(bool connected, const RadioCapabilities& 
             phone->setTxFilterEdges(connected ? caps.txFilterLowEdgesHz : QList<int>{},
                                     connected ? caps.txFilterHighEdgesHz : QList<int>{});
         }
-        m_appletPanel->setMicLevelMeterAvailable(
-            !connected || m_radioModel.meterModel().hasMicPeakMeter());
+        m_appletPanel->setMicLevelMeterState(
+            connected ? MicMeterSessionState::Connected
+                      : MicMeterSessionState::Disconnected,
+            m_radioModel.meterModel().hasMicPeakMeter());
     }
 
     // ── Display dBm scale: who owns it ─────────────────────────────────────

--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -93,6 +93,7 @@ static constexpr const char* kInsetEditStyle =
     "QLineEdit:focus { border: 1px solid #00b4d8; }";
 
 static constexpr float kAlcGaugeFloorDbfs = -20.0f;
+static constexpr float kLevelGaugeFloorDbfs = -40.0f;
 
 // Mouse-over readout formatter for the ALC gauges — one decimal of dBFS so a
 // transmitting operator can read the exact SSB-peak level off the bar rather
@@ -178,13 +179,29 @@ void PhoneCwApplet::setSelectableMicInputs(bool selectable)
                          "Its own input selection is made on the radio."));
 }
 
-void PhoneCwApplet::setMicLevelMeterAvailable(bool available)
+void PhoneCwApplet::setMicLevelMeterState(MicMeterSessionState session,
+                                          bool available)
 {
-    if (m_micLevelMeterAvailable == available)
-        return;   // idempotent: this rides capabilitiesChanged, which repeats
+    const bool stateChanged = session != m_micLevelMeterSession
+                              || available != m_micLevelMeterAvailable;
+    m_micLevelMeterSession = session;
     m_micLevelMeterAvailable = available;
-    if (m_levelGauge)
-        m_levelGauge->setVisible(available);
+    if (!m_levelGauge) {
+        return;
+    }
+
+    const bool connected = session == MicMeterSessionState::Connected;
+
+    // A meter reading belongs to one radio session. MeterModel::clear()
+    // resets its cached values on disconnect but emits no mic-meter update, so
+    // explicitly discard the prior radio's fill and peak at the lifecycle
+    // boundary. An unsupported connected radio gets the same reset before the
+    // gauge is hidden. Reset only on a state edge: repeated capability
+    // publications while disconnected must not erase live PC-mic telemetry.
+    if (stateChanged && (!connected || !available)) {
+        resetLevelMeter();
+    }
+    m_levelGauge->setVisible(!connected || available);
 }
 
 void PhoneCwApplet::setDaxVisible(bool visible)
@@ -206,9 +223,11 @@ void PhoneCwApplet::buildPhonePanel()
     vbox->setSpacing(2);
 
     // ── Level gauge (mic peak, dBFS: -40 to +10) ────────────────────────
-    m_levelGauge = new HGauge(-40.0f, 10.0f, 0.0f, "Level", "dB",
+    m_levelGauge = new HGauge(kLevelGaugeFloorDbfs, 10.0f, 0.0f, "Level", "dB",
         {{-40, "-40dB"}, {-30, "-30"}, {-20, "-20"}, {-10, "-10"}, {0, "0"}, {5, "+5"}, {10, "+10"}},
         nullptr, -10.0f);
+    m_levelGauge->setObjectName(QStringLiteral("phoneMicLevelGauge"));
+    resetLevelMeter();
     m_levelGauge->setAccessibleName("Microphone level gauge");
     m_levelGauge->setAccessibleDescription("Microphone input level in dBFS");
     // Mouse-over readout: exact mic peak in dB. (#3936)
@@ -949,6 +968,12 @@ void PhoneCwApplet::applyLevelMeterReceiveGate()
         m_levelGauge->setValue(-150.0f);
         m_levelGauge->setPeakValue(-150.0f);
     }
+}
+
+void PhoneCwApplet::resetLevelMeter()
+{
+    m_levelGauge->setValueImmediate(kLevelGaugeFloorDbfs);
+    m_levelGauge->clearPeak();
 }
 
 void PhoneCwApplet::updateCompression(float compPeak)

--- a/src/gui/PhoneCwApplet.h
+++ b/src/gui/PhoneCwApplet.h
@@ -14,6 +14,11 @@ namespace AetherSDR {
 class HGauge;
 class TransmitModel;
 
+enum class MicMeterSessionState {
+    Disconnected,
+    Connected,
+};
+
 // P/CW applet — mode-aware panel that shows Phone controls (default) or CW
 // controls when the active slice is in CW/CWL mode.  Both sub-panels live
 // inside a QStackedWidget beneath a shared "P/CW" title bar.
@@ -27,7 +32,7 @@ public:
     // Show or hide the mic-level gauge. False on a radio that defines no
     // microphone-peak meter at all — the face would be permanently at its floor
     // and read as a fault rather than as an absence.
-    void setMicLevelMeterAvailable(bool available);
+    void setMicLevelMeterState(MicMeterSessionState session, bool available);
     void setDaxVisible(bool visible);
     explicit PhoneCwApplet(QWidget* parent = nullptr);
 
@@ -70,6 +75,7 @@ private:
     void syncPhoneFromModel();
     void syncCwFromModel();
     void applyLevelMeterReceiveGate();
+    void resetLevelMeter();
 
     TransmitModel* m_model{nullptr};
     QStackedWidget* m_stack{nullptr};
@@ -79,6 +85,7 @@ private:
     // ── Phone sub-panel widgets ──────────────────────────────────────────
 
     HGauge* m_levelGauge{nullptr};
+    MicMeterSessionState m_micLevelMeterSession{MicMeterSessionState::Disconnected};
     bool m_micLevelMeterAvailable{true};
     HGauge* m_compGauge{nullptr};
 

--- a/tests/phone_cw_level_meter_state_test.cpp
+++ b/tests/phone_cw_level_meter_state_test.cpp
@@ -1,0 +1,83 @@
+// The Phone/CW microphone Level gauge must remain empty until live telemetry
+// arrives and must not carry a prior radio's reading across disconnect.
+
+#include "TestSettingsProfile.h"
+#include "gui/HGauge.h"
+#include "gui/PhoneCwApplet.h"
+
+#include <QApplication>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* description)
+{
+    std::printf("%s %s\n", condition ? "[ OK ]" : "[FAIL]", description);
+    if (!condition) {
+        ++failures;
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    qputenv("AETHER_AUTOMATION", "1");
+    TestSettingsProfile profile(QStringLiteral("phone-cw-level-meter-state-test"));
+    QApplication app(argc, argv);
+    PhoneCwApplet applet;
+
+    QWidget* levelWidget =
+        applet.findChild<QWidget*>(QStringLiteral("phoneMicLevelGauge"));
+    check(levelWidget != nullptr, "Phone/CW exposes the microphone Level gauge");
+    if (!levelWidget) {
+        return failures;
+    }
+    auto* levelGauge = static_cast<HGauge*>(levelWidget);
+
+    check(levelGauge->value() == -40.0f,
+          "the disconnected Level gauge starts at its floor");
+    check(levelGauge->filledFraction() == 0.0f,
+          "the disconnected Level gauge starts visually empty");
+
+    applet.updateMeters(-12.0f, 0.0f, -8.0f, 0.0f);
+    check(levelGauge->value() == -12.0f,
+          "a live microphone sample reaches the Level gauge");
+
+    applet.setMicLevelMeterState(MicMeterSessionState::Disconnected, false);
+    check(!levelGauge->isHidden(),
+          "disconnect keeps the permissive Level surface visible");
+    check(levelGauge->value() == -40.0f,
+          "disconnect clears the previous radio's Level reading");
+    check(levelGauge->filledFraction() == 0.0f,
+          "disconnect snaps the Level gauge back to empty");
+
+    applet.setMicLevelMeterState(MicMeterSessionState::Connected, true);
+    check(!levelGauge->isHidden(),
+          "a later capable radio exposes the Level gauge");
+    check(levelGauge->value() == -40.0f,
+          "a later capable radio waits for its own microphone sample");
+
+    applet.updateMeters(-18.0f, 0.0f, -14.0f, 0.0f);
+    check(levelGauge->value() == -18.0f,
+          "the later radio's own sample updates the Level gauge");
+
+    applet.setMicLevelMeterState(MicMeterSessionState::Connected, false);
+    check(levelGauge->isHidden(),
+          "a connected radio without a microphone meter hides the gauge");
+    check(levelGauge->value() == -40.0f,
+          "hiding an unsupported gauge also clears its stale reading");
+
+    applet.setMicLevelMeterState(MicMeterSessionState::Disconnected, false);
+    applet.updateMeters(-16.0f, 0.0f, -12.0f, 0.0f);
+    applet.setMicLevelMeterState(MicMeterSessionState::Disconnected, false);
+    check(levelGauge->value() == -16.0f,
+          "a repeated disconnected state preserves live PC-mic telemetry");
+
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3742,6 +3742,21 @@ add_test(NAME phone_cw_mic_gain_authority_test
 set_tests_properties(phone_cw_mic_gain_authority_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
+add_executable(phone_cw_level_meter_state_test
+    tests/phone_cw_level_meter_state_test.cpp
+    src/gui/PhoneCwApplet.cpp
+    src/gui/DragValuePopup.cpp
+)
+target_include_directories(phone_cw_level_meter_state_test PRIVATE src)
+target_link_libraries(phone_cw_level_meter_state_test PRIVATE
+    aethercore Qt6::Core Qt6::Widgets
+)
+set_target_properties(phone_cw_level_meter_state_test PROPERTIES AUTOMOC ON)
+add_test(NAME phone_cw_level_meter_state_test
+         COMMAND phone_cw_level_meter_state_test)
+set_tests_properties(phone_cw_level_meter_state_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 add_executable(container_manager_test
     tests/container_manager_test.cpp
     src/gui/FramelessResizer.cpp


### PR DESCRIPTION
## Summary

Fixes #5178.

The Phone/CW microphone **Level** gauge currently appears substantially filled before any radio is connected. `HGauge` initializes its value to `0`; on this gauge's `-40…+10 dBFS` face, that generic initializer paints most of the bar and looks like a strong live microphone signal even though no telemetry exists.

The same surface can retain a prior radio's final reading after disconnect because `MeterModel::clear()` resets cached microphone state without emitting a final `micMetersChanged` repaint.

This PR makes the existing meter lifecycle truthful:

- before connection: empty at the existing `-40 dBFS` floor;
- after a valid sample: normal live Level and peak presentation;
- after disconnect: value and peak immediately return to the floor;
- on a later capable radio: remain empty until that radio's own sample;
- on a connected radio without a microphone-peak meter: clear stale state, then hide the gauge as before.

### Why this is a bug fix, not a redesign

A filled meter asserts that signal energy was measured. Before connection, no radio or sample exists to support that assertion. The correction changes only the state used before telemetry and at a session boundary.

It does **not** alter the gauge's face, colors, thresholds, label, layout, smoothing, peak behavior, hover formatting, or presentation after live samples arrive. Compression and ALC are intentionally untouched:

- Compression's reversed face already presents its neutral state empty.
- ALC already initializes explicitly at its `-20 dBFS` floor.

### Implementation and maintainer alignment

- Initializes the existing Level value and peak marker at the existing `-40 dBFS` floor.
- Extends the existing microphone-meter availability passthrough with the connection state already owned by `applyCapabilitiesToUi()`.
- Resets only at disconnected or unsupported lifecycle states.
- Adds no signal route, backend hook, capability field, radio profile, setting, dependency, style, or layout.
- Uses no Flex-, Icom-, or model-specific UI branch.
- Adds a focused state-transition test instead of folding unrelated Phone/CW behavior into the change.

The `MainWindow` change is limited to passing `connected` through the existing capability/application call. Backend declarations and meter decoding remain behind their existing seams.

### Physical-radio and open-source evidence

- **Icom IC-9700:** verified on a physical radio over LAN/CI-V. Live microphone/meter activity drives the Phone/CW presentation after connection; the disconnected pre-fix state showed unsupported fill.
- **FlexRadio FLEX-8600:** verified on a physical radio. The existing Flex microphone-meter path continues to drive the Level gauge from live samples; the desired no-radio state is empty.
- Compared with open-source radio-client implementations, including **wfview**'s Icom meter handling. The relevant shared behavior is sample-driven presentation: decoded radio reports produce meter state, while a client initializer is not evidence of measured microphone level.
- No SDR9700-derived evidence or proprietary/decompiled sources were used.

## Constitution principle honored

**Principle II — The Radio Is Authoritative On Live State.** The Level gauge no longer presents signal energy until radio/client microphone telemetry actually supplies it, and one radio's live value cannot survive into another session.

The focused lifecycle assertions also support Principle VIII, Evidence Over Assertion.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR`)
- [x] Behavior verified on physical IC-9700 and FLEX-8600 radios
- [ ] Existing tests pass (CI — pending this PR)
- [x] Reproduction steps documented in #5178

Local verification completed:

```text
phone_cw_level_meter_state_test      PASS
phone_cw_mic_gain_authority_test     PASS
full AetherSDR build                 PASS
test registration --strict          PASS
engine boundary --strict             PASS (known baseline warnings only)
git diff --check                     PASS
```

The focused test proves:

1. startup value is `-40 dBFS` and the painted fraction is zero;
2. a real microphone sample reaches the gauge;
3. disconnect clears the previous value and snaps the bar empty;
4. a later capable radio waits for its own sample and then updates normally; and
5. an unsupported connected radio hides and clears the gauge.

## Checklist

- [x] Commit is signed and verified (`9d191802`, SSH signature for `justin@w5jwp.radio`)
- [x] No new `AppSettings` keys or persistence behavior
- [x] Code is clean-room — based on observed physical-radio behavior, public open-source comparison, and existing AetherSDR model contracts (Principle IV)
- [x] All meter fill remains routed through `HGauge`/`MeterSmoother`; lifecycle reset uses the established immediate-reset method
- [x] User-visible behavior is documented here and in #5178; `CHANGELOG.md` is intentionally untouched
- [x] No security-sensitive changes

@aethersdr-agent please review this focused telemetry-state fix, particularly the session-boundary reset, unchanged live Flex/Icom paths, lack of family-specific UI logic, and regression coverage.
