### PR TITLE
fix: Stale comment in ensureDaxForTci() names the mixed speaker feed as the T

### DIFF
--- a/COMMITMSG
+++ b/COMMITMSG
@@ -1,0 +1,7 @@
+fix: Stale comment in ensureDaxForTci() names the mixed speaker feed as the
+
+- src\models\RadioModel.h
+
+Fixes #4957
+
+Signed-off-by: Vedant Madane <6527493+VedantMadane@users.noreply.github.com>

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1011,7 +1011,7 @@ signals:
     // Flex never emits this; its audio arrives on the PanadapterStream path.
     void backendAudioFrameReady(const QByteArray& pcm);
     // ONE slice's demodulated audio, relayed from IRadioBackend. The per-slice
-    // counterpart of backendAudioFrameReady, which is the mixed speaker feed.
+    // counterpart of backendAudioFrameReady, which is the TCI audio path.
     // Only a backend that demodulates in this process emits it; Flex per-slice
     // audio arrives as DAX channels instead.
     void backendSliceAudioFrameReady(int sliceId, const QByteArray& pcm);


### PR DESCRIPTION
## Summary

Stale comment in ensureDaxForTci() names the mixed speaker feed as the TCI audio path — untrue since #4545

## Changes

- src\models\RadioModel.h

Fixes #4957
