### PR TITLE
fix(ulanzi): name unsupported OEM dial variants instead of "Disconnected" (#3485)

### DIFF
--- a/src/core/UlanziDialWindowsManager.cpp
+++ b/src/core/UlanziDialWindowsManager.cpp
@@ -45,6 +45,24 @@ int hidKbdToLinuxKey(unsigned char keycode)
 
 constexpr const wchar_t* kProductMatch = L"Ulanzi Dial";
 
+// Known Ulanzi OEM variants that enumerate over HID but CANNOT be driven by
+// this backend: their vendor collection is silent unless the Ulanzi Studio
+// app performs its activation handshake, and their keyboard/mouse
+// collections are OS-captured on Windows. Match them so the mapper can say
+// so, instead of sitting on "Disconnected" forever. Note the trap that
+// stalled #3485: the Windows PnP FriendlyName for these units IS
+// "Ulanzi Dial" (the BLE GAP name), but hidapi reports the HID string
+// descriptor, which is the OEM product string below. (#3485)
+struct KnownVariant {
+    unsigned short vid;
+    unsigned short pid;             // 0 = any
+    const wchar_t* displayName;
+};
+constexpr KnownVariant kUnsupportedVariants[] = {
+    {0xFFF1, 0x0000, L"Ulanzi D100H (KEHWIN \"Dial_Lite\", BLE)"},
+    {0x2207, 0x0019, L"Ulanzi D200 (Zkswe \"ulanzi\", USB)"},
+};
+
 } // namespace
 
 UlanziDialWindowsManager::UlanziDialWindowsManager(QObject* parent)
@@ -72,8 +90,20 @@ void UlanziDialWindowsManager::start()
     if (rescan()) {
         m_pollTimer->start();
         emit connectionChanged(true, m_deviceName);
+    } else {
+        notifyVariantIfSeen();
     }
     m_hotplugTimer->start();
+}
+
+void UlanziDialWindowsManager::notifyVariantIfSeen()
+{
+    // Only while no supported device is open, and only once per variant —
+    // hotplugCheck() re-runs rescan() every few seconds. (#3485)
+    if (m_variantSeen.isEmpty() || m_variantSeen == m_variantNotified)
+        return;
+    m_variantNotified = m_variantSeen;
+    emit unsupportedVariantDetected(m_variantSeen);
 }
 
 void UlanziDialWindowsManager::stop()
@@ -86,10 +116,20 @@ void UlanziDialWindowsManager::stop()
 bool UlanziDialWindowsManager::rescan()
 {
     closeAll();
+    m_variantSeen.clear();
     struct hid_device_info* infos = hid_enumerate(0, 0);
     for (auto* info = infos; info; info = info->next) {
         if (!info->product_string) continue;
-        if (wcsstr(info->product_string, kProductMatch) == nullptr) continue;
+        if (wcsstr(info->product_string, kProductMatch) == nullptr) {
+            for (const KnownVariant& v : kUnsupportedVariants) {
+                if (info->vendor_id == v.vid
+                    && (v.pid == 0 || info->product_id == v.pid)) {
+                    m_variantSeen = QString::fromWCharArray(v.displayName);
+                    break;
+                }
+            }
+            continue;
+        }
         hid_device* h = hid_open_path(info->path);
         if (!h) continue;
         hid_set_nonblocking(h, 1);
@@ -128,7 +168,10 @@ void UlanziDialWindowsManager::hotplugCheck()
     if (!m_devices.isEmpty()) return;
     if (rescan()) {
         m_pollTimer->start();
+        m_variantNotified.clear();
         emit connectionChanged(true, m_deviceName);
+    } else {
+        notifyVariantIfSeen();
     }
 }
 

--- a/src/core/UlanziDialWindowsManager.cpp
+++ b/src/core/UlanziDialWindowsManager.cpp
@@ -59,7 +59,7 @@ struct KnownVariant {
     const wchar_t* displayName;
 };
 constexpr KnownVariant kUnsupportedVariants[] = {
-    {0xFFF1, 0x0000, L"Ulanzi D100H (KEHWIN \"Dial_Lite\", BLE)"},
+    {0xFFF1, 0x0082, L"Ulanzi D100H (KEHWIN \"Dial_Lite\", BLE)"},
     {0x2207, 0x0019, L"Ulanzi D200 (Zkswe \"ulanzi\", USB)"},
 };
 

--- a/src/core/UlanziDialWindowsManager.cpp
+++ b/src/core/UlanziDialWindowsManager.cpp
@@ -47,7 +47,6 @@ int hidKbdToLinuxKey(unsigned char keycode)
 
 constexpr const wchar_t* kProductMatch = L"Ulanzi Dial";
 
-
 } // namespace
 
 UlanziDialWindowsManager::UlanziDialWindowsManager(QObject* parent)

--- a/src/core/UlanziDialWindowsManager.cpp
+++ b/src/core/UlanziDialWindowsManager.cpp
@@ -97,12 +97,17 @@ void UlanziDialWindowsManager::publishVariantState()
     // dial that has been unplugged is still present. (#3485)
     QString current;
     {
+        // One lock covers the read of m_variantSeen and the transition test
+        // against m_variantNotified, so the pair cannot be observed
+        // half-updated and neither QString is assigned concurrently.
         QMutexLocker lock(&m_variantMutex);
         current = m_variantSeen;
+        if (!UlanziVariant::shouldPublish(m_variantNotified, current))
+            return;
+        m_variantNotified = current;
     }
-    if (!UlanziVariant::shouldPublish(m_variantNotified, current))
-        return;
-    m_variantNotified = current;
+    // Emit outside the lock: consumers run on the GUI thread and must not
+    // re-enter the manager while it is held.
     emit unsupportedVariantChanged(current);
 }
 

--- a/src/core/UlanziDialWindowsManager.cpp
+++ b/src/core/UlanziDialWindowsManager.cpp
@@ -4,8 +4,10 @@
 #include "UlanziDialWindowsManager.h"
 #include "core/LogManager.h"
 #include "core/UlanziChordDecoder.h"
+#include "core/UlanziVariantTable.h"
 
 #include <QDebug>
+#include <QMutexLocker>
 #include <QTimer>
 
 #include <hidapi/hidapi.h>
@@ -45,23 +47,6 @@ int hidKbdToLinuxKey(unsigned char keycode)
 
 constexpr const wchar_t* kProductMatch = L"Ulanzi Dial";
 
-// Known Ulanzi OEM variants that enumerate over HID but CANNOT be driven by
-// this backend: their vendor collection is silent unless the Ulanzi Studio
-// app performs its activation handshake, and their keyboard/mouse
-// collections are OS-captured on Windows. Match them so the mapper can say
-// so, instead of sitting on "Disconnected" forever. Note the trap that
-// stalled #3485: the Windows PnP FriendlyName for these units IS
-// "Ulanzi Dial" (the BLE GAP name), but hidapi reports the HID string
-// descriptor, which is the OEM product string below. (#3485)
-struct KnownVariant {
-    unsigned short vid;
-    unsigned short pid;             // 0 = any
-    const wchar_t* displayName;
-};
-constexpr KnownVariant kUnsupportedVariants[] = {
-    {0xFFF1, 0x0082, L"Ulanzi D100H (KEHWIN \"Dial_Lite\", BLE)"},
-    {0x2207, 0x0019, L"Ulanzi D200 (Zkswe \"ulanzi\", USB)"},
-};
 
 } // namespace
 
@@ -90,20 +75,36 @@ void UlanziDialWindowsManager::start()
     if (rescan()) {
         m_pollTimer->start();
         emit connectionChanged(true, m_deviceName);
-    } else {
-        notifyVariantIfSeen();
     }
+    // Publish either way: a successful rescan means no variant is the sole
+    // dial present, which is itself a state consumers need. (#3485)
+    publishVariantState();
     m_hotplugTimer->start();
 }
 
-void UlanziDialWindowsManager::notifyVariantIfSeen()
+QString UlanziDialWindowsManager::unsupportedVariantName() const
 {
-    // Only while no supported device is open, and only once per variant —
-    // hotplugCheck() re-runs rescan() every few seconds. (#3485)
-    if (m_variantSeen.isEmpty() || m_variantSeen == m_variantNotified)
+    // Called from the GUI thread; m_variantSeen is written by rescan() on
+    // the ExtControllers thread. (#3485)
+    QMutexLocker lock(&m_variantMutex);
+    return m_variantSeen;
+}
+
+void UlanziDialWindowsManager::publishVariantState()
+{
+    // Emit only on a real transition, in BOTH directions: hotplugCheck()
+    // re-runs rescan() every few seconds, so an unconditional emit would
+    // spam, but skipping the empty case would leave the dialog claiming a
+    // dial that has been unplugged is still present. (#3485)
+    QString current;
+    {
+        QMutexLocker lock(&m_variantMutex);
+        current = m_variantSeen;
+    }
+    if (!UlanziVariant::shouldPublish(m_variantNotified, current))
         return;
-    m_variantNotified = m_variantSeen;
-    emit unsupportedVariantDetected(m_variantSeen);
+    m_variantNotified = current;
+    emit unsupportedVariantChanged(current);
 }
 
 void UlanziDialWindowsManager::stop()
@@ -111,22 +112,34 @@ void UlanziDialWindowsManager::stop()
     m_pollTimer->stop();
     m_hotplugTimer->stop();
     closeAll();
+    // Scanning is off, so nothing will refresh this — drop the variant state
+    // and tell consumers, or the mapper keeps showing the advisory for a dial
+    // we are no longer looking for.  Clearing m_variantNotified via
+    // publishVariantState() also means re-enabling scanning with the same
+    // variant still plugged in emits afresh rather than being deduped. (#3485)
+    {
+        QMutexLocker lock(&m_variantMutex);
+        m_variantSeen.clear();
+    }
+    publishVariantState();
 }
 
 bool UlanziDialWindowsManager::rescan()
 {
     closeAll();
-    m_variantSeen.clear();
+    {
+        QMutexLocker lock(&m_variantMutex);
+        m_variantSeen.clear();
+    }
     struct hid_device_info* infos = hid_enumerate(0, 0);
     for (auto* info = infos; info; info = info->next) {
         if (!info->product_string) continue;
         if (wcsstr(info->product_string, kProductMatch) == nullptr) {
-            for (const KnownVariant& v : kUnsupportedVariants) {
-                if (info->vendor_id == v.vid
-                    && (v.pid == 0 || info->product_id == v.pid)) {
-                    m_variantSeen = QString::fromWCharArray(v.displayName);
-                    break;
-                }
+            const QString variant = UlanziVariant::lookup(info->vendor_id,
+                                                          info->product_id);
+            if (!variant.isEmpty()) {
+                QMutexLocker lock(&m_variantMutex);
+                m_variantSeen = variant;
             }
             continue;
         }
@@ -168,11 +181,12 @@ void UlanziDialWindowsManager::hotplugCheck()
     if (!m_devices.isEmpty()) return;
     if (rescan()) {
         m_pollTimer->start();
-        m_variantNotified.clear();
         emit connectionChanged(true, m_deviceName);
-    } else {
-        notifyVariantIfSeen();
     }
+    // rescan() has already refreshed m_variantSeen (cleared it on success,
+    // or set it if an unsupported variant is the only dial on the bus), so
+    // one call covers appear, disappear and swap. (#3485)
+    publishVariantState();
 }
 
 void UlanziDialWindowsManager::poll()

--- a/src/core/UlanziDialWindowsManager.h
+++ b/src/core/UlanziDialWindowsManager.h
@@ -87,10 +87,15 @@ private:
 
     QVector<OpenDevice> m_devices;
     QString m_deviceName;
-    // m_variantSeen is written by rescan()/stop() on the owning (Ext
-    // Controllers) thread and read by unsupportedVariantName() from the GUI
-    // thread, so every access goes through m_variantMutex.  m_variantNotified
-    // is touched only on the owning thread and needs no guard.
+    // Both members go through m_variantMutex.  m_variantSeen is written by
+    // rescan()/stop() on the owning (Ext Controllers) thread and read by
+    // unsupportedVariantName() from the GUI thread.  m_variantNotified is
+    // only reached from the owning thread on Windows today — the one GUI
+    // caller of stop(), the automation bridge's ulanzi-stop diagnostic at
+    // MainWindow_Session.cpp, is inside #ifdef Q_OS_MAC and does not compile
+    // here — but guarding it costs nothing (publishVariantState() already
+    // holds the lock to read m_variantSeen) and stops the invariant from
+    // depending on a call site in another platform's branch. (#3485)
     mutable QMutex m_variantMutex;
     QString m_variantSeen;          // OEM-variant display name from the last rescan
     QString m_variantNotified;      // last state we emitted, to emit on transitions only

--- a/src/core/UlanziDialWindowsManager.h
+++ b/src/core/UlanziDialWindowsManager.h
@@ -4,6 +4,7 @@
 
 #include "core/UlanziChordDecoder.h"
 
+#include <QMutex>
 #include <QObject>
 #include <QString>
 #include <QStringList>
@@ -43,21 +44,25 @@ public:
     bool isConnected() const { return !m_devices.isEmpty(); }
     QString deviceName() const { return m_deviceName; }
     // Non-empty while an unsupported OEM variant is the only dial present —
-    // lets a dialog that opens after start() recover the state the one-shot
-    // unsupportedVariantDetected signal already reported. (#3485)
-    QString unsupportedVariantName() const { return m_variantSeen; }
+    // lets a dialog that opens after start() recover the state that
+    // unsupportedVariantChanged already reported.  On Windows this object
+    // lives on the ExtControllers thread while callers are on the GUI
+    // thread, so the read is mutex-guarded rather than a bare member
+    // access: rescan() rewrites m_variantSeen from the hotplug timer. (#3485)
+    QString unsupportedVariantName() const;
 
 signals:
     void tuneSteps(int steps);
     void buttonEvent(const QString& signature, int action);
     void connectionChanged(bool connected, const QString& name);
-    // A known Ulanzi OEM variant is present whose firmware cannot be driven
-    // over this HID backend at all (vendor collection silent outside Ulanzi
-    // Studio; keyboard/mouse collections OS-captured) — e.g. the KEHWIN
-    // "Dial_Lite" D100H or the Zkswe D200. Consumers should point the user
-    // at the bundled Ulanzi Studio plugin instead of showing a bare
-    // "Disconnected". (#3485)
-    void unsupportedVariantDetected(const QString& name);
+    // State change for a known Ulanzi OEM variant whose firmware cannot be
+    // driven over this HID backend at all (vendor collection silent outside
+    // Ulanzi Studio; keyboard/mouse collections OS-captured) — e.g. the
+    // KEHWIN "Dial_Lite" D100H or the Zkswe D200.  Emitted with the variant
+    // name when one appears and with an EMPTY string when it goes away
+    // (unplug, or stop()), so consumers can withdraw the advisory instead of
+    // claiming the device is still there. (#3485)
+    void unsupportedVariantChanged(const QString& name);
 
 private slots:
     void poll();
@@ -72,7 +77,7 @@ private:
     };
 
     bool rescan();                      // returns true if at least one device is open
-    void notifyVariantIfSeen();         // emit unsupportedVariantDetected once per variant
+    void publishVariantState();         // emit unsupportedVariantChanged on transitions only
     void closeAll();
     void handleReport(OpenDevice& dev, const unsigned char* data, int len);
 
@@ -82,8 +87,13 @@ private:
 
     QVector<OpenDevice> m_devices;
     QString m_deviceName;
+    // m_variantSeen is written by rescan()/stop() on the owning (Ext
+    // Controllers) thread and read by unsupportedVariantName() from the GUI
+    // thread, so every access goes through m_variantMutex.  m_variantNotified
+    // is touched only on the owning thread and needs no guard.
+    mutable QMutex m_variantMutex;
     QString m_variantSeen;          // OEM-variant display name from the last rescan
-    QString m_variantNotified;      // last variant we emitted for, to avoid re-spamming
+    QString m_variantNotified;      // last state we emitted, to emit on transitions only
     QTimer* m_pollTimer{nullptr};
     QTimer* m_hotplugTimer{nullptr};
 

--- a/src/core/UlanziDialWindowsManager.h
+++ b/src/core/UlanziDialWindowsManager.h
@@ -42,11 +42,22 @@ public:
 
     bool isConnected() const { return !m_devices.isEmpty(); }
     QString deviceName() const { return m_deviceName; }
+    // Non-empty while an unsupported OEM variant is the only dial present —
+    // lets a dialog that opens after start() recover the state the one-shot
+    // unsupportedVariantDetected signal already reported. (#3485)
+    QString unsupportedVariantName() const { return m_variantSeen; }
 
 signals:
     void tuneSteps(int steps);
     void buttonEvent(const QString& signature, int action);
     void connectionChanged(bool connected, const QString& name);
+    // A known Ulanzi OEM variant is present whose firmware cannot be driven
+    // over this HID backend at all (vendor collection silent outside Ulanzi
+    // Studio; keyboard/mouse collections OS-captured) — e.g. the KEHWIN
+    // "Dial_Lite" D100H or the Zkswe D200. Consumers should point the user
+    // at the bundled Ulanzi Studio plugin instead of showing a bare
+    // "Disconnected". (#3485)
+    void unsupportedVariantDetected(const QString& name);
 
 private slots:
     void poll();
@@ -61,6 +72,7 @@ private:
     };
 
     bool rescan();                      // returns true if at least one device is open
+    void notifyVariantIfSeen();         // emit unsupportedVariantDetected once per variant
     void closeAll();
     void handleReport(OpenDevice& dev, const unsigned char* data, int len);
 
@@ -70,6 +82,8 @@ private:
 
     QVector<OpenDevice> m_devices;
     QString m_deviceName;
+    QString m_variantSeen;          // OEM-variant display name from the last rescan
+    QString m_variantNotified;      // last variant we emitted for, to avoid re-spamming
     QTimer* m_pollTimer{nullptr};
     QTimer* m_hotplugTimer{nullptr};
 

--- a/src/core/UlanziVariantTable.h
+++ b/src/core/UlanziVariantTable.h
@@ -7,11 +7,21 @@
 namespace AetherSDR {
 namespace UlanziVariant {
 
-// Known Ulanzi OEM dial variants that enumerate over HID but CANNOT be driven
-// by the native HID backends: their vendor collection stays silent unless the
-// Ulanzi Studio app performs its activation handshake, and their keyboard and
-// mouse collections are captured by the OS.  Recognising them lets the mapper
-// say so instead of sitting on "Disconnected" forever.
+// Known Ulanzi OEM dial variants that enumerate over HID but cannot be driven
+// by the WINDOWS native HID backend: their vendor collection stays silent
+// unless the Ulanzi Studio app performs its activation handshake, and their
+// keyboard/consumer collections are captured by Windows.  Recognising them
+// lets the mapper say so instead of sitting on "Disconnected" forever.
+//
+// ⚠ SCOPE — this is a statement about the Windows backend ONLY, and a macOS
+// port must NOT adopt it wholesale.  macOS drives this exact VID/PID today:
+// UlanziDialMacOSManager pins 0xFFF1/0x0082 as its primary supported device
+// and opens it with kIOHIDOptionsTypeSeizeDevice, suppressing the consumer
+// usages that Windows leaves OS-captured — the capability Windows lacks.
+// Verified on real hardware 2026-08-25: the same physical D100H connects on
+// macOS (shared open, after the Input Monitoring grant — see #5247) while
+// failing to match at all on Windows.  A macOS consumer of this table should
+// use it for IDENTITY only, never as a drivability verdict.
 //
 // The trap that stalled #3485: the Windows PnP FriendlyName for these units IS
 // "Ulanzi Dial" (the BLE GAP name), but hidapi reports the HID string
@@ -30,7 +40,12 @@ struct KnownVariant {
 };
 
 inline constexpr KnownVariant kUnsupportedVariants[] = {
+    // Three independent sightings: live hid_enumerate on Windows, the
+    // reporter's BLE descriptor dump in #5126, and the bench unit behind
+    // UlanziDialMacOSManager's kUlanziVendorId/kUlanziProductId.
     {0xFFF1, 0x0082, "Ulanzi D100H (KEHWIN \"Dial_Lite\", BLE)"},
+    // UNVERIFIED against a physical unit in this round — identity comes from a
+    // single earlier live enumeration.  Confirm before relying on it.
     {0x2207, 0x0019, "Ulanzi D200 (Zkswe \"ulanzi\", USB)"},
 };
 

--- a/src/core/UlanziVariantTable.h
+++ b/src/core/UlanziVariantTable.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <QString>
+
+#include <cstddef>
+
+namespace AetherSDR {
+namespace UlanziVariant {
+
+// Known Ulanzi OEM dial variants that enumerate over HID but CANNOT be driven
+// by the native HID backends: their vendor collection stays silent unless the
+// Ulanzi Studio app performs its activation handshake, and their keyboard and
+// mouse collections are captured by the OS.  Recognising them lets the mapper
+// say so instead of sitting on "Disconnected" forever.
+//
+// The trap that stalled #3485: the Windows PnP FriendlyName for these units IS
+// "Ulanzi Dial" (the BLE GAP name), but hidapi reports the HID string
+// descriptor, which is the OEM product string named below.
+//
+// Both rows pin the PID deliberately.  0xFFF1 is unassigned placeholder VID
+// space that cheap BLE-HID firmware reuses freely, so a vendor-only match
+// there would confidently mislabel unrelated hardware as a D100H — a worse
+// failure than the "Disconnected" it replaces.  `pid == 0` stays available for
+// a vendor later shown to ship one dial under several PIDs; if a row uses it,
+// say why here.  (#3485)
+struct KnownVariant {
+    unsigned short vid;
+    unsigned short pid;             // 0 = any (unused today — see note above)
+    const char*    displayName;
+};
+
+inline constexpr KnownVariant kUnsupportedVariants[] = {
+    {0xFFF1, 0x0082, "Ulanzi D100H (KEHWIN \"Dial_Lite\", BLE)"},
+    {0x2207, 0x0019, "Ulanzi D200 (Zkswe \"ulanzi\", USB)"},
+};
+
+// Display name for a (vid, pid) that is a known-unsupported variant, or an
+// empty string when it is not one.
+inline QString lookup(unsigned short vid, unsigned short pid)
+{
+    for (const KnownVariant& v : kUnsupportedVariants) {
+        if (vid == v.vid && (v.pid == 0 || pid == v.pid))
+            return QString::fromUtf8(v.displayName);
+    }
+    return QString();
+}
+
+// Should a state change be published?  The advisory must fire in BOTH
+// directions: the hotplug timer re-scans every few seconds, so an
+// unconditional emit would spam the dialog, but suppressing the empty case
+// would leave it claiming an unplugged dial is still present.  Emitting only
+// on a genuine transition also means present -> absent -> same variant present
+// notifies again rather than being deduped away.  (#3485)
+inline bool shouldPublish(const QString& lastPublished, const QString& current)
+{
+    return lastPublished != current;
+}
+
+} // namespace UlanziVariant
+} // namespace AetherSDR

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -358,8 +358,37 @@ void MainWindow::buildMenuBar()
 #else
         MidiControlManager* midi = nullptr;
 #endif
+        const bool fresh = !m_ulanziMapperDialog;
         showOrRaisePersistent(m_ulanziMapperDialog, m_dialBackend,
                               &m_shortcutManager, midi);
+#if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
+        // The unsupported-OEM-variant advisory needs to know whether anything
+        // is driving AetherSDR over TCI: these dials work through the Ulanzi
+        // Studio plugin over TCI, so a user whose dial is already working must
+        // not read "unsupported".  MainWindow owns the TciServer and pushes
+        // the state in, keeping the dialog free of any TCI dependency. (#3485)
+        //
+        // showOrRaisePersistent() constructs the dialog only when the QPointer
+        // is null, so `fresh` is true exactly once per dialog instance.  The
+        // clientCountChanged connect MUST be guarded that way: this lambda
+        // runs on every reopen and Qt::UniqueConnection cannot cover a lambda
+        // connect (see the same note at MainWindow.cpp:6703), so an unguarded
+        // connect would stack one slot per open.
+        if (m_ulanziMapperDialog) {
+            if (fresh) {
+                if (TciServer* tci = tciServer()) {
+                    connect(tci, &TciServer::clientCountChanged,
+                            m_ulanziMapperDialog, [this](int count) {
+                                if (m_ulanziMapperDialog)
+                                    m_ulanziMapperDialog->setTciClientConnected(count > 0);
+                            });
+                }
+            }
+            // Push the current state on every open, fresh or raised.
+            TciServer* tci = tciServer();
+            m_ulanziMapperDialog->setTciClientConnected(tci && tci->clientCount() > 0);
+        }
+#endif
     });
     auto* spotsAction = settingsMenu->addAction("SpotHub...");
     connect(spotsAction, &QAction::triggered, this, [this] {

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -358,37 +358,8 @@ void MainWindow::buildMenuBar()
 #else
         MidiControlManager* midi = nullptr;
 #endif
-        const bool fresh = !m_ulanziMapperDialog;
         showOrRaisePersistent(m_ulanziMapperDialog, m_dialBackend,
                               &m_shortcutManager, midi);
-#if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
-        // The unsupported-OEM-variant advisory needs to know whether anything
-        // is driving AetherSDR over TCI: these dials work through the Ulanzi
-        // Studio plugin over TCI, so a user whose dial is already working must
-        // not read "unsupported".  MainWindow owns the TciServer and pushes
-        // the state in, keeping the dialog free of any TCI dependency. (#3485)
-        //
-        // showOrRaisePersistent() constructs the dialog only when the QPointer
-        // is null, so `fresh` is true exactly once per dialog instance.  The
-        // clientCountChanged connect MUST be guarded that way: this lambda
-        // runs on every reopen and Qt::UniqueConnection cannot cover a lambda
-        // connect (see the same note at MainWindow.cpp:6703), so an unguarded
-        // connect would stack one slot per open.
-        if (m_ulanziMapperDialog) {
-            if (fresh) {
-                if (TciServer* tci = tciServer()) {
-                    connect(tci, &TciServer::clientCountChanged,
-                            m_ulanziMapperDialog, [this](int count) {
-                                if (m_ulanziMapperDialog)
-                                    m_ulanziMapperDialog->setTciClientConnected(count > 0);
-                            });
-                }
-            }
-            // Push the current state on every open, fresh or raised.
-            TciServer* tci = tciServer();
-            m_ulanziMapperDialog->setTciClientConnected(tci && tci->clientCount() > 0);
-        }
-#endif
     });
     auto* spotsAction = settingsMenu->addAction("SpotHub...");
     connect(spotsAction, &QAction::triggered, this, [this] {

--- a/src/gui/UlanziDialMapperDialog.cpp
+++ b/src/gui/UlanziDialMapperDialog.cpp
@@ -33,7 +33,7 @@
 
 namespace AetherSDR {
 
-// Shared "attention" style for the status label's advisory states â€” Linux
+// Shared "attention" style for the status label's advisory states — Linux
 // needs-permission and Windows unsupported-variant.  Resolved through
 // ThemeManager against color.accent.warning, which docs/style/
 // theme-style-guide.md designates for warning foregrounds, so the advisory
@@ -41,7 +41,7 @@ namespace AetherSDR {
 static const char kAttentionLabelStyle[] =
     "QLabel { color: {{color.accent.warning}}; }";
 
-// Cached product image â€” loaded once, shared by dialBodyRect (for
+// Cached product image — loaded once, shared by dialBodyRect (for
 // aspect-correct sizing) and the canvas paintEvent.  Falls back to a
 // stylized painted body if the asset isn't present.
 static QPixmap& ulanziDialPixmap()
@@ -92,8 +92,8 @@ private:
 
 namespace {
 
-// Immutable signature â†” pill mapping.  These bindings represent what
-// physical button on the dial emits which kernel event â€” they're a
+// Immutable signature ↔ pill mapping.  These bindings represent what
+// physical button on the dial emits which kernel event — they're a
 // property of the firmware, not user-configurable.  Verified against
 // dial firmware 1.x: changing this table requires re-flashing the dial.
 //
@@ -107,12 +107,12 @@ struct PillSpec {
     double nx, ny;              // anchor on dial body (0..1)
     int    side;                // 0 top, 1 right, 2 bottom, 3 left
 };
-// defaultAction must be one of the action IDs below (not the label) â€”
+// defaultAction must be one of the action IDs below (not the label) —
 // loadActions calls findData() against the combo's stored data role.
 // Default action IDs use the prefixed form ("shortcut:<id>") that
-// MainWindow's dispatcher parses.  The signature â†” pill mapping is a
+// MainWindow's dispatcher parses.  The signature ↔ pill mapping is a
 // firmware property; the function bound to each pill is configurable.
-// Rotary (vfo_tune) is intentionally absent â€” the rotary signal is
+// Rotary (vfo_tune) is intentionally absent — the rotary signal is
 // routed by MainWindow directly, separate from the button mapper.
 constexpr PillSpec kPillSpecs[] = {
     {"top_left",   "Top Left",   "KEY_PREVIOUSSONG",  "shortcut:mox_toggle",   0.21, 0.06, 0},
@@ -162,7 +162,7 @@ UlanziDialMapperDialog::UlanziDialMapperDialog(UlanziDialBackend* manager,
                                                ShortcutManager*     shortcuts,
                                                MidiControlManager*  midi,
                                                QWidget*             parent)
-    : PersistentDialog(tr("Ulanzi Dial â€” Control Mapping"),
+    : PersistentDialog(tr("Ulanzi Dial — Control Mapping"),
                        QStringLiteral("UlanziDialMapperGeom"),
                        parent)
     , m_manager(manager)
@@ -214,7 +214,7 @@ UlanziDialMapperDialog::UlanziDialMapperDialog(UlanziDialBackend* manager,
 
     bottomRow->addStretch(1);
 
-    m_lastEventLabel = new QLabel(tr("Last event: â€”"));
+    m_lastEventLabel = new QLabel(tr("Last event: —"));
     m_lastEventLabel->setStyleSheet("QLabel { color: #8ea8c0; }");
     bottomRow->addWidget(m_lastEventLabel);
 
@@ -222,7 +222,7 @@ UlanziDialMapperDialog::UlanziDialMapperDialog(UlanziDialBackend* manager,
 
     m_resetBtn = new QPushButton(tr("Reset to Defaults"));
     connect(m_resetBtn, &QPushButton::clicked, this, [this] {
-        // Reset each combo to its default action.  The signature â†” pill
+        // Reset each combo to its default action.  The signature ↔ pill
         // binding is hardcoded so there's nothing to reset there.
         for (int i = 0; i < m_pills.size(); ++i) {
             if (!m_pills[i].combo) continue;
@@ -263,7 +263,7 @@ UlanziDialMapperDialog::UlanziDialMapperDialog(UlanziDialBackend* manager,
         onConnectionChanged(m_manager->isConnected(), m_manager->deviceName());
 #if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
         // The manager started long before this dialog existed, so the variant
-        // signal has already fired â€” recover the state.  This must NOT read
+        // signal has already fired — recover the state.  This must NOT read
         // the getter directly: the backend lives on the ExtControllers thread
         // and unsupportedVariantName() would race rescan().  Hop to the
         // backend's own thread, take the (mutex-guarded) snapshot there, and
@@ -288,9 +288,9 @@ QPoint UlanziDialMapperDialog::normalizedAnchor(double nx, double ny)
 
 QRect UlanziDialMapperDialog::dialBodyRect() const
 {
-    // Fixed geometry inside the upper region (620 Ã— 555) of the canvas
-    // (620 Ã— 590). Body honours the trimmed image aspect (512:562 â‰ˆ 0.911)
-    // at 320Ã—352, centered in the upper region to leave vertical space for
+    // Fixed geometry inside the upper region (620 × 555) of the canvas
+    // (620 × 590). Body honours the trimmed image aspect (512:562 ≈ 0.911)
+    // at 320×352, centered in the upper region to leave vertical space for
     // the bottom rotary and single-tap combo controls at y >= 525.
     const int bw = 320;
     const int bh = 352;
@@ -384,7 +384,7 @@ void UlanziDialMapperDialog::buildPills()
         p.combo->setFixedWidth(pillId == QLatin1String("dial_press") ? 180 : 120);
         if (dialogParented) p.combo->raise();
 
-        // (unassigned) â€” always first.
+        // (unassigned) — always first.
         p.combo->addItem(tr("(unassigned)"), QStringLiteral("None"));
 
         // All ShortcutManager actions.  Label format: "[Category] Name"
@@ -398,7 +398,7 @@ void UlanziDialMapperDialog::buildPills()
             }
         }
 
-        // MIDI Toggle/Trigger/Gate params â€” only the discrete-event and gate
+        // MIDI Toggle/Trigger/Gate params — only the discrete-event and gate
         // types make sense on a button.  Continuous params would need a
         // rotary, which is intentionally not bound here.
 #ifdef HAVE_MIDI
@@ -449,15 +449,15 @@ void UlanziDialMapperDialog::layoutPills()
         const int touchGap = 4;       // tiny visible breathing room
         QPoint center;
         if (p.id == QLatin1String("top_left")) {
-            // Dialog-parented â€” hardcoded dialog coords.
+            // Dialog-parented — hardcoded dialog coords.
             p.combo->resize(120, p.combo->sizeHint().height());
             p.combo->move(120, 100);
             p.combo->raise();
             p.pillCenter = QPoint(120 + 60, 100 + p.combo->height() / 2);
             return;
         } else if (p.id == QLatin1String("top_middle")) {
-            // Pill is a dialog child â€” hardcode dialog coords.
-            // Window 640 wide, combo 120 wide â†’ x = 260.
+            // Pill is a dialog child — hardcode dialog coords.
+            // Window 640 wide, combo 120 wide → x = 260.
             // Hardcoded y above the dial body within the dialog.
             p.combo->resize(120, p.combo->sizeHint().height());
             p.combo->move(260, 100);
@@ -465,7 +465,7 @@ void UlanziDialMapperDialog::layoutPills()
             p.pillCenter = QPoint(320, 100 + p.combo->height() / 2);
             return;
         } else if (p.id == QLatin1String("top_right")) {
-            // Dialog-parented â€” hardcoded dialog coords.
+            // Dialog-parented — hardcoded dialog coords.
             p.combo->resize(120, p.combo->sizeHint().height());
             p.combo->move(400, 100);
             p.combo->raise();
@@ -497,7 +497,7 @@ void UlanziDialMapperDialog::layoutPills()
                       center.y() - sz.height() / 2);
     };
 
-    // Bound by m_pills.size() â€” buildPills() calls refreshPillLabel inside
+    // Bound by m_pills.size() — buildPills() calls refreshPillLabel inside
     // its loop, which re-enters layoutPills before every pill exists.
     for (int i = 0; i < m_pills.size(); ++i) {
         place(m_pills[i]);
@@ -515,7 +515,7 @@ void UlanziDialCanvas::paintEvent(QPaintEvent*)
     QPainter p(this);
     p.setRenderHint(QPainter::Antialiasing);
 
-    // Background â€” match the surrounding dialog.
+    // Background — match the surrounding dialog.
     p.fillRect(rect(), QColor("#0f0f1a"));
 
     const QRect body = m_owner->dialBodyRect();
@@ -564,7 +564,7 @@ void UlanziDialCanvas::paintEvent(QPaintEvent*)
         p.drawEllipse(knobCenter, 12, 12);
     }
 
-    // No connector lines / anchor dots â€” pills sit physically next to
+    // No connector lines / anchor dots — pills sit physically next to
     // the dial body so the spatial mapping is conveyed by adjacency.
 }
 
@@ -585,7 +585,7 @@ void UlanziDialMapperDialog::migrateLegacyMappings()
 QString UlanziDialMapperDialog::actionForPill(const QString& pillId)
 {
     // The document is authoritative; an absent entry means "built-in default".
-    // Legacy flat keys are not consulted here â€” migrateLegacyMappings() has
+    // Legacy flat keys are not consulted here — migrateLegacyMappings() has
     // already claimed and deleted them at startup.
     const QString bound = UlanziDialMappings::actionForPill(pillId);
     if (!bound.isEmpty())
@@ -664,7 +664,7 @@ void UlanziDialMapperDialog::onButtonEvent(const QString& signature, int action)
     const QString pillId = pillForSignature(signature);
     const QString suffix = pillId.isEmpty()
         ? tr(" (unmapped)")
-        : QStringLiteral(" â†’ %1").arg(pillId);
+        : QStringLiteral(" → %1").arg(pillId);
     m_lastEventLabel->setText(tr("Last event: %1%2 (%3)")
                                   .arg(signature, suffix,
                                        action == 1 ? "press" : "release"));
@@ -701,13 +701,13 @@ void UlanziDialMapperDialog::onConnectionChanged(bool connected, const QString& 
     if (display.endsWith(QStringLiteral(" Keyboard"), Qt::CaseInsensitive))
         display.chop(QStringLiteral(" Keyboard").size());
     m_statusLabel->setText(connected
-        ? tr("Connected â€” %1").arg(display)
+        ? tr("Connected — %1").arg(display)
         : tr("Disconnected"));
     m_statusLabel->setStyleSheet(connected
         ? "QLabel { color: #4dd87a; }"
         : "QLabel { color: #cc3333; }");
 #ifdef Q_OS_LINUX
-    // Once connected, the access problem is resolved â€” hide the offer.
+    // Once connected, the access problem is resolved — hide the offer.
     if (connected && m_grantAccessBtn)
         m_grantAccessBtn->setVisible(false);
 #endif
@@ -720,7 +720,7 @@ void UlanziDialMapperDialog::onAccessRequired(const QString& deviceName)
     QString display = deviceName;
     if (display.endsWith(QStringLiteral(" Keyboard"), Qt::CaseInsensitive))
         display.chop(QStringLiteral(" Keyboard").size());
-    showAttentionStatus(tr("%1 detected â€” needs permission").arg(display));
+    showAttentionStatus(tr("%1 detected — needs permission").arg(display));
     if (m_grantAccessBtn) {
         m_grantAccessBtn->setVisible(true);
         m_grantAccessBtn->setEnabled(true);
@@ -739,7 +739,7 @@ void UlanziDialMapperDialog::onGrantAccessClicked()
 
     if (m_grantAccessBtn) {
         m_grantAccessBtn->setEnabled(false);
-        m_grantAccessBtn->setText(tr("Authorizingâ€¦"));
+        m_grantAccessBtn->setText(tr("Authorizing…"));
     }
 
     // Install the udev access rule and reload, as root via polkit. The rule
@@ -747,7 +747,7 @@ void UlanziDialMapperDialog::onGrantAccessClicked()
     // as an argv element (not interpolated into the script) to avoid any
     // quoting/injection concern.
     static const QString kRule = QStringLiteral(
-        "# AetherSDR â€” Ulanzi Dial access (#3599)\n"
+        "# AetherSDR — Ulanzi Dial access (#3599)\n"
         "SUBSYSTEM==\"input\", KERNEL==\"event*\", "
         "ATTRS{name}==\"Ulanzi Dial*\", TAG+=\"uaccess\"\n");
     static const QString kScript = QStringLiteral(
@@ -758,7 +758,7 @@ void UlanziDialMapperDialog::onGrantAccessClicked()
 
     auto* proc = new QProcess(this);
     // If pkexec can't even start, QProcess emits errorOccurred and never emits
-    // finished â€” recover the button instead of leaving it stuck on "Authorizingâ€¦".
+    // finished — recover the button instead of leaving it stuck on "Authorizing…".
     connect(proc, &QProcess::errorOccurred, this,
             [this, proc](QProcess::ProcessError) {
         if (proc->state() != QProcess::NotRunning) return;  // started; finished will handle it
@@ -779,7 +779,7 @@ void UlanziDialMapperDialog::onGrantAccessClicked()
         if (m_grantAccessBtn) m_grantAccessBtn->setText(tr("Grant access"));
         if (code == 0) {
             if (m_statusLabel) {
-                m_statusLabel->setText(tr("Access granted â€” connectingâ€¦"));
+                m_statusLabel->setText(tr("Access granted — connecting…"));
                 m_statusLabel->setStyleSheet("QLabel { color: #4dd87a; }");
             }
             // The udev trigger applies the ACL asynchronously; give logind a
@@ -823,27 +823,40 @@ void UlanziDialMapperDialog::onUnsupportedVariant(const QString& deviceName)
         return;
     }
 
-    // Don't downgrade a live connection â€” this state only applies while
+    // Don't downgrade a live connection — this state only applies while
     // nothing supported is open.
     if (m_connected) return;
 
     m_unsupportedVariant = deviceName;
-    // Keep the LABEL short: the dialog is setFixedSize(640, 675) and this
-    // label shares one non-wrapping row with the "last event" readout, so a
-    // sentence of instructions is silently clipped mid-word.  The procedure
-    // lives behind the button instead, where it has room to be read. (#3485)
-    showAttentionStatus(tr("%1 â€” not usable over HID").arg(deviceName));
-    if (m_variantHelpBtn) m_variantHelpBtn->setVisible(true);
+    // The status label gets ~212 px in this fixed 640 px row (measured on the
+    // running dialog: status 212, Setup 69, "Last event:" 93, Reset 127,
+    // Close 57), and it does not wrap or elide.  The device name alone is
+    // wider than that, so it must NOT go in the label — an earlier attempt
+    // put it here and clipped mid-name at
+    // 'Ulanzi D100H (KEHWIN "Dial_Lite",'.  The label is therefore a fixed
+    // short phrase that always fits; the name lives in the button tooltip
+    // and in the Setup dialog, which have room for it. (#3485)
+    // "Unsupported dial" measures 192 px in this label's font; the budget is
+    // 212.  Do not lengthen it without re-measuring — "Not usable over HID"
+    // (228 px) and "Unsupported variant" (228 px) both overflow, and the
+    // label neither wraps nor elides, so overflow is a silent mid-word cut.
+    showAttentionStatus(tr("Unsupported dial"));
+    if (m_variantHelpBtn) {
+        m_variantHelpBtn->setToolTip(
+            tr("%1 — cannot be driven over HID. Click for setup instructions.")
+                .arg(deviceName));
+        m_variantHelpBtn->setVisible(true);
+    }
 }
 
 void UlanziDialMapperDialog::onVariantHelpClicked()
 {
-    // Rich text so the plugin release is a real clickable link â€” retyping a
+    // Rich text so the plugin release is a real clickable link — retyping a
     // URL out of a status label is not a usable acquisition path.  The link
     // points at the plugin's own release, which actually carries the
     // packaged .zip; the AetherSDR release assets do not include it. (#3485)
     QMessageBox box(this);
-    box.setWindowTitle(tr("Ulanzi dial â€” setup required"));
+    box.setWindowTitle(tr("Ulanzi dial — setup required"));
     box.setIcon(QMessageBox::Information);
     box.setTextFormat(Qt::RichText);
     box.setText(tr("<b>%1</b> cannot be driven over HID.")
@@ -851,11 +864,11 @@ void UlanziDialMapperDialog::onVariantHelpClicked()
     box.setInformativeText(
         tr("<p>This variant's vendor collection stays silent unless Ulanzi "
            "Studio performs its activation handshake, and its keyboard and "
-           "mouse collections are captured by Windows â€” so AetherSDR cannot "
+           "mouse collections are captured by Windows — so AetherSDR cannot "
            "read it directly.</p>"
            "<p>Drive it through Ulanzi Studio instead:</p>"
            "<ol>"
-           "<li>Enable TCI: <b>Settings â†’ Autostart TCI with AetherSDR</b>.</li>"
+           "<li>Enable TCI: <b>Settings → Autostart TCI with AetherSDR</b>.</li>"
            "<li>Download <code>com.g0jkn.aethersdr.ulanziPlugin.zip</code> from "
            "<a href=\"https://github.com/nigelfenton/aethersdr-ulanzi-plugin/releases/latest\">"
            "the AetherSDR Ulanzi plugin release</a>.</li>"
@@ -869,12 +882,17 @@ void UlanziDialMapperDialog::onVariantHelpClicked()
 #endif  // Q_OS_WIN && HAVE_HIDAPI
 
 // The one amber call site, shared by every advisory status (Linux
-// needs-permission, Windows unsupported-variant) â€” the colour ratchet
+// needs-permission, Windows unsupported-variant) — the colour ratchet
 // tracks setStyleSheet call sites, so new advisory states reuse this one.
 void UlanziDialMapperDialog::showAttentionStatus(const QString& text)
 {
     if (!m_statusLabel) return;
     m_statusLabel->setText(text);
+    // Safety net for a larger system font or a longer translation: without
+    // this the label cuts mid-word with no ellipsis and no tooltip, which is
+    // how the first two attempts at this advisory shipped unreadable text.
+    // The full string always stays reachable on hover. (#3485)
+    m_statusLabel->setToolTip(text);
     ThemeManager::instance().applyStyleSheet(m_statusLabel,
                                              QString::fromLatin1(kAttentionLabelStyle));
 }

--- a/src/gui/UlanziDialMapperDialog.cpp
+++ b/src/gui/UlanziDialMapperDialog.cpp
@@ -783,8 +783,10 @@ void UlanziDialMapperDialog::onUnsupportedVariant(const QString& deviceName)
     if (m_manager && m_manager->isConnected()) return;
     showAttentionStatus(
         tr("%1 detected — this variant can't be driven over HID. "
-           "Use the bundled Ulanzi Studio plugin instead (see "
-           "plugins/ulanzi-aethersdr in the AetherSDR install/repo).")
+           "Use the Ulanzi Studio TCI plugin instead: enable TCI in "
+           "Settings, then see plugins/ulanzi-aethersdr/README.md in the "
+           "AetherSDR source tree for installation (not yet bundled with "
+           "the installer).")
             .arg(deviceName));
 }
 #endif  // Q_OS_WIN && HAVE_HIDAPI

--- a/src/gui/UlanziDialMapperDialog.cpp
+++ b/src/gui/UlanziDialMapperDialog.cpp
@@ -33,6 +33,12 @@
 
 namespace AetherSDR {
 
+// Shared amber "attention" style for the status label's advisory states —
+// Linux needs-permission and Windows unsupported-variant. ONE literal, reused:
+// the colour ratchet counts occurrences and the theme set has no text/warning
+// token yet; when one lands, this is the single place to swap it in.
+static const char kAttentionLabelStyle[] = "QLabel { color: #e0a030; }";
+
 // Cached product image — loaded once, shared by dialBodyRect (for
 // aspect-correct sizing) and the canvas paintEvent.  Falls back to a
 // stylized painted body if the asset isn't present.
@@ -680,8 +686,7 @@ void UlanziDialMapperDialog::onAccessRequired(const QString& deviceName)
     QString display = deviceName;
     if (display.endsWith(QStringLiteral(" Keyboard"), Qt::CaseInsensitive))
         display.chop(QStringLiteral(" Keyboard").size());
-    m_statusLabel->setText(tr("%1 detected — needs permission").arg(display));
-    m_statusLabel->setStyleSheet("QLabel { color: #e0a030; }");
+    showAttentionStatus(tr("%1 detected — needs permission").arg(display));
     if (m_grantAccessBtn) {
         m_grantAccessBtn->setVisible(true);
         m_grantAccessBtn->setEnabled(true);
@@ -776,14 +781,23 @@ void UlanziDialMapperDialog::onUnsupportedVariant(const QString& deviceName)
     // Don't downgrade a live connection — this state only applies while
     // nothing supported is open.
     if (m_manager && m_manager->isConnected()) return;
-    m_statusLabel->setText(
+    showAttentionStatus(
         tr("%1 detected — this variant can't be driven over HID. "
            "Use the bundled Ulanzi Studio plugin instead (see "
            "plugins/ulanzi-aethersdr in the AetherSDR install/repo).")
             .arg(deviceName));
-    m_statusLabel->setStyleSheet("QLabel { color: #e0a030; }");
 }
 #endif  // Q_OS_WIN && HAVE_HIDAPI
+
+// The one amber call site, shared by every advisory status (Linux
+// needs-permission, Windows unsupported-variant) — the colour ratchet
+// tracks setStyleSheet call sites, so new advisory states reuse this one.
+void UlanziDialMapperDialog::showAttentionStatus(const QString& text)
+{
+    if (!m_statusLabel) return;
+    m_statusLabel->setText(text);
+    m_statusLabel->setStyleSheet(kAttentionLabelStyle);
+}
 
 } // namespace AetherSDR
 

--- a/src/gui/UlanziDialMapperDialog.cpp
+++ b/src/gui/UlanziDialMapperDialog.cpp
@@ -235,7 +235,19 @@ UlanziDialMapperDialog::UlanziDialMapperDialog(UlanziDialBackend* manager,
         connect(m_manager, &UlanziDialBackend::accessRequired,
                 this, &UlanziDialMapperDialog::onAccessRequired);
 #endif
+#if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
+        connect(m_manager, &UlanziDialBackend::unsupportedVariantDetected,
+                this, &UlanziDialMapperDialog::onUnsupportedVariant);
+#endif
         onConnectionChanged(m_manager->isConnected(), m_manager->deviceName());
+#if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
+        // The manager started long before this dialog existed, so the
+        // one-shot variant signal has already fired — recover the state.
+        if (!m_manager->isConnected()
+            && !m_manager->unsupportedVariantName().isEmpty()) {
+            onUnsupportedVariant(m_manager->unsupportedVariantName());
+        }
+#endif
     } else {
         m_statusLabel->setText(tr("Manager unavailable (Linux build only)"));
     }
@@ -756,6 +768,22 @@ void UlanziDialMapperDialog::onGrantAccessClicked()
                          kScript, QStringLiteral("aethersdr"), kRule});
 }
 #endif  // Q_OS_LINUX
+
+#if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
+void UlanziDialMapperDialog::onUnsupportedVariant(const QString& deviceName)
+{
+    if (!m_statusLabel) return;
+    // Don't downgrade a live connection — this state only applies while
+    // nothing supported is open.
+    if (m_manager && m_manager->isConnected()) return;
+    m_statusLabel->setText(
+        tr("%1 detected — this variant can't be driven over HID. "
+           "Use the bundled Ulanzi Studio plugin instead (see "
+           "plugins/ulanzi-aethersdr in the AetherSDR install/repo).")
+            .arg(deviceName));
+    m_statusLabel->setStyleSheet("QLabel { color: #e0a030; }");
+}
+#endif  // Q_OS_WIN && HAVE_HIDAPI
 
 } // namespace AetherSDR
 

--- a/src/gui/UlanziDialMapperDialog.cpp
+++ b/src/gui/UlanziDialMapperDialog.cpp
@@ -831,14 +831,6 @@ void UlanziDialMapperDialog::onUnsupportedVariant(const QString& deviceName)
     refreshVariantStatus();
 }
 
-void UlanziDialMapperDialog::setTciClientConnected(bool connected)
-{
-    if (m_tciClientConnected == connected) return;
-    m_tciClientConnected = connected;
-    if (!m_unsupportedVariant.isEmpty() && !m_connected)
-        refreshVariantStatus();
-}
-
 void UlanziDialMapperDialog::refreshVariantStatus()
 {
     if (m_unsupportedVariant.isEmpty()) return;
@@ -860,18 +852,10 @@ void UlanziDialMapperDialog::refreshVariantStatus()
     showAttentionStatus(tr("Use Ulanzi Studio"));
 
     if (m_variantHelpBtn) {
-        // TciServer reports only peer address/port (TciClientInfo), never an
-        // application name, so a live client cannot be attributed to the
-        // Ulanzi plugin specifically — say "a TCI client", not "your dial".
         m_variantHelpBtn->setToolTip(
-            m_tciClientConnected
-                ? tr("%1 — not driven over HID. A TCI client is connected, so "
-                     "if this dial is mapped in Ulanzi Studio it is already "
-                     "working. Click for setup instructions.")
-                      .arg(m_unsupportedVariant)
-                : tr("%1 — cannot be driven over HID. Click for setup "
-                     "instructions.")
-                      .arg(m_unsupportedVariant));
+            tr("%1 — cannot be driven over HID. Click for setup "
+               "instructions.")
+                .arg(m_unsupportedVariant));
         m_variantHelpBtn->setVisible(true);
     }
 }
@@ -879,10 +863,11 @@ void UlanziDialMapperDialog::refreshVariantStatus()
 
 void UlanziDialMapperDialog::onVariantHelpClicked()
 {
-    // Rich text so the plugin release is a real clickable link — retyping a
-    // URL out of a status label is not a usable acquisition path.  The link
-    // points at the plugin's own release, which actually carries the
-    // packaged .zip; the AetherSDR release assets do not include it. (#3485)
+    // Rich text for the numbered steps.  Deliberately NO download link: the
+    // packaged plugin is not yet published as an AetherSDR release asset, and
+    // a shipping dialog must not point at a contributor's personal repository
+    // (raised by @jensenpat in review).  The in-tree plugin and its install
+    // steps live at plugins/ulanzi-aethersdr/. (#3485)
     QMessageBox box(this);
     box.setWindowTitle(tr("Ulanzi Dial — Setup Required"));
     box.setIcon(QMessageBox::Information);
@@ -897,10 +882,9 @@ void UlanziDialMapperDialog::onVariantHelpClicked()
            "<p>Drive it through Ulanzi Studio instead:</p>"
            "<ol>"
            "<li>Enable TCI: <b>Settings → Autostart TCI with AetherSDR</b>.</li>"
-           "<li>Download <code>com.g0jkn.aethersdr.ulanziPlugin.zip</code> from "
-           "<a href=\"https://github.com/nigelfenton/aethersdr-ulanzi-plugin/releases/latest\">"
-           "the AetherSDR Ulanzi plugin release</a>.</li>"
-           "<li>Unpack it into "
+           "<li>Build the plugin from <code>plugins/ulanzi-aethersdr/</code> in "
+           "the AetherSDR source tree, following the README there.</li>"
+           "<li>Copy the built plugin folder into "
            "<code>%APPDATA%\\Ulanzi\\UlanziDeck\\Plugins\\</code>.</li>"
            "<li>Quit Ulanzi Studio from the system tray and relaunch it.</li>"
            "</ol>"));

--- a/src/gui/UlanziDialMapperDialog.cpp
+++ b/src/gui/UlanziDialMapperDialog.cpp
@@ -16,6 +16,8 @@
 #include <QGuiApplication>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QMessageBox>
+#include <QMetaObject>
 #include <QPainter>
 #include <QPainterPath>
 #include <QPixmap>
@@ -24,8 +26,6 @@
 #include <QVBoxLayout>
 #ifdef Q_OS_LINUX
 #include "core/LogManager.h"
-#include <QMessageBox>
-#include <QMetaObject>
 #include <QProcess>
 #include <QStandardPaths>
 #include <QTimer>
@@ -33,13 +33,15 @@
 
 namespace AetherSDR {
 
-// Shared amber "attention" style for the status label's advisory states —
-// Linux needs-permission and Windows unsupported-variant. ONE literal, reused:
-// the colour ratchet counts occurrences and the theme set has no text/warning
-// token yet; when one lands, this is the single place to swap it in.
-static const char kAttentionLabelStyle[] = "QLabel { color: #e0a030; }";
+// Shared "attention" style for the status label's advisory states â€” Linux
+// needs-permission and Windows unsupported-variant.  Resolved through
+// ThemeManager against color.accent.warning, which docs/style/
+// theme-style-guide.md designates for warning foregrounds, so the advisory
+// re-paints with the active theme instead of pinning one amber. (#3485)
+static const char kAttentionLabelStyle[] =
+    "QLabel { color: {{color.accent.warning}}; }";
 
-// Cached product image — loaded once, shared by dialBodyRect (for
+// Cached product image â€” loaded once, shared by dialBodyRect (for
 // aspect-correct sizing) and the canvas paintEvent.  Falls back to a
 // stylized painted body if the asset isn't present.
 static QPixmap& ulanziDialPixmap()
@@ -90,8 +92,8 @@ private:
 
 namespace {
 
-// Immutable signature ↔ pill mapping.  These bindings represent what
-// physical button on the dial emits which kernel event — they're a
+// Immutable signature â†” pill mapping.  These bindings represent what
+// physical button on the dial emits which kernel event â€” they're a
 // property of the firmware, not user-configurable.  Verified against
 // dial firmware 1.x: changing this table requires re-flashing the dial.
 //
@@ -105,12 +107,12 @@ struct PillSpec {
     double nx, ny;              // anchor on dial body (0..1)
     int    side;                // 0 top, 1 right, 2 bottom, 3 left
 };
-// defaultAction must be one of the action IDs below (not the label) —
+// defaultAction must be one of the action IDs below (not the label) â€”
 // loadActions calls findData() against the combo's stored data role.
 // Default action IDs use the prefixed form ("shortcut:<id>") that
-// MainWindow's dispatcher parses.  The signature ↔ pill mapping is a
+// MainWindow's dispatcher parses.  The signature â†” pill mapping is a
 // firmware property; the function bound to each pill is configurable.
-// Rotary (vfo_tune) is intentionally absent — the rotary signal is
+// Rotary (vfo_tune) is intentionally absent â€” the rotary signal is
 // routed by MainWindow directly, separate from the button mapper.
 constexpr PillSpec kPillSpecs[] = {
     {"top_left",   "Top Left",   "KEY_PREVIOUSSONG",  "shortcut:mox_toggle",   0.21, 0.06, 0},
@@ -160,7 +162,7 @@ UlanziDialMapperDialog::UlanziDialMapperDialog(UlanziDialBackend* manager,
                                                ShortcutManager*     shortcuts,
                                                MidiControlManager*  midi,
                                                QWidget*             parent)
-    : PersistentDialog(tr("Ulanzi Dial — Control Mapping"),
+    : PersistentDialog(tr("Ulanzi Dial â€” Control Mapping"),
                        QStringLiteral("UlanziDialMapperGeom"),
                        parent)
     , m_manager(manager)
@@ -196,10 +198,23 @@ UlanziDialMapperDialog::UlanziDialMapperDialog(UlanziDialBackend* manager,
             this, &UlanziDialMapperDialog::onGrantAccessClicked);
     bottomRow->addWidget(m_grantAccessBtn);
 #endif
+#if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
+    // Shown only when a known-unsupported OEM variant is the sole dial
+    // present.  The status label is one short line in a fixed-width row, so
+    // the actual procedure lives behind this button. (#3485)
+    m_variantHelpBtn = new QPushButton(tr("Setup..."));
+    m_variantHelpBtn->setToolTip(
+        tr("How to drive this dial through Ulanzi Studio and the AetherSDR "
+           "TCI plugin."));
+    m_variantHelpBtn->setVisible(false);
+    connect(m_variantHelpBtn, &QPushButton::clicked,
+            this, &UlanziDialMapperDialog::onVariantHelpClicked);
+    bottomRow->addWidget(m_variantHelpBtn);
+#endif
 
     bottomRow->addStretch(1);
 
-    m_lastEventLabel = new QLabel(tr("Last event: —"));
+    m_lastEventLabel = new QLabel(tr("Last event: â€”"));
     m_lastEventLabel->setStyleSheet("QLabel { color: #8ea8c0; }");
     bottomRow->addWidget(m_lastEventLabel);
 
@@ -207,7 +222,7 @@ UlanziDialMapperDialog::UlanziDialMapperDialog(UlanziDialBackend* manager,
 
     m_resetBtn = new QPushButton(tr("Reset to Defaults"));
     connect(m_resetBtn, &QPushButton::clicked, this, [this] {
-        // Reset each combo to its default action.  The signature ↔ pill
+        // Reset each combo to its default action.  The signature â†” pill
         // binding is hardcoded so there's nothing to reset there.
         for (int i = 0; i < m_pills.size(); ++i) {
             if (!m_pills[i].combo) continue;
@@ -242,17 +257,24 @@ UlanziDialMapperDialog::UlanziDialMapperDialog(UlanziDialBackend* manager,
                 this, &UlanziDialMapperDialog::onAccessRequired);
 #endif
 #if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
-        connect(m_manager, &UlanziDialBackend::unsupportedVariantDetected,
+        connect(m_manager, &UlanziDialBackend::unsupportedVariantChanged,
                 this, &UlanziDialMapperDialog::onUnsupportedVariant);
 #endif
         onConnectionChanged(m_manager->isConnected(), m_manager->deviceName());
 #if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
-        // The manager started long before this dialog existed, so the
-        // one-shot variant signal has already fired — recover the state.
-        if (!m_manager->isConnected()
-            && !m_manager->unsupportedVariantName().isEmpty()) {
-            onUnsupportedVariant(m_manager->unsupportedVariantName());
-        }
+        // The manager started long before this dialog existed, so the variant
+        // signal has already fired â€” recover the state.  This must NOT read
+        // the getter directly: the backend lives on the ExtControllers thread
+        // and unsupportedVariantName() would race rescan().  Hop to the
+        // backend's own thread, take the (mutex-guarded) snapshot there, and
+        // deliver it back through a queued call. (#3485)
+        QMetaObject::invokeMethod(m_manager, [this, mgr = m_manager]() {
+            const QString variant = mgr->unsupportedVariantName();
+            QMetaObject::invokeMethod(this, [this, variant]() {
+                if (!variant.isEmpty())
+                    onUnsupportedVariant(variant);
+            }, Qt::QueuedConnection);
+        }, Qt::QueuedConnection);
 #endif
     } else {
         m_statusLabel->setText(tr("Manager unavailable (Linux build only)"));
@@ -266,9 +288,9 @@ QPoint UlanziDialMapperDialog::normalizedAnchor(double nx, double ny)
 
 QRect UlanziDialMapperDialog::dialBodyRect() const
 {
-    // Fixed geometry inside the upper region (620 × 555) of the canvas
-    // (620 × 590). Body honours the trimmed image aspect (512:562 ≈ 0.911)
-    // at 320×352, centered in the upper region to leave vertical space for
+    // Fixed geometry inside the upper region (620 Ã— 555) of the canvas
+    // (620 Ã— 590). Body honours the trimmed image aspect (512:562 â‰ˆ 0.911)
+    // at 320Ã—352, centered in the upper region to leave vertical space for
     // the bottom rotary and single-tap combo controls at y >= 525.
     const int bw = 320;
     const int bh = 352;
@@ -362,7 +384,7 @@ void UlanziDialMapperDialog::buildPills()
         p.combo->setFixedWidth(pillId == QLatin1String("dial_press") ? 180 : 120);
         if (dialogParented) p.combo->raise();
 
-        // (unassigned) — always first.
+        // (unassigned) â€” always first.
         p.combo->addItem(tr("(unassigned)"), QStringLiteral("None"));
 
         // All ShortcutManager actions.  Label format: "[Category] Name"
@@ -376,7 +398,7 @@ void UlanziDialMapperDialog::buildPills()
             }
         }
 
-        // MIDI Toggle/Trigger/Gate params — only the discrete-event and gate
+        // MIDI Toggle/Trigger/Gate params â€” only the discrete-event and gate
         // types make sense on a button.  Continuous params would need a
         // rotary, which is intentionally not bound here.
 #ifdef HAVE_MIDI
@@ -427,15 +449,15 @@ void UlanziDialMapperDialog::layoutPills()
         const int touchGap = 4;       // tiny visible breathing room
         QPoint center;
         if (p.id == QLatin1String("top_left")) {
-            // Dialog-parented — hardcoded dialog coords.
+            // Dialog-parented â€” hardcoded dialog coords.
             p.combo->resize(120, p.combo->sizeHint().height());
             p.combo->move(120, 100);
             p.combo->raise();
             p.pillCenter = QPoint(120 + 60, 100 + p.combo->height() / 2);
             return;
         } else if (p.id == QLatin1String("top_middle")) {
-            // Pill is a dialog child — hardcode dialog coords.
-            // Window 640 wide, combo 120 wide → x = 260.
+            // Pill is a dialog child â€” hardcode dialog coords.
+            // Window 640 wide, combo 120 wide â†’ x = 260.
             // Hardcoded y above the dial body within the dialog.
             p.combo->resize(120, p.combo->sizeHint().height());
             p.combo->move(260, 100);
@@ -443,7 +465,7 @@ void UlanziDialMapperDialog::layoutPills()
             p.pillCenter = QPoint(320, 100 + p.combo->height() / 2);
             return;
         } else if (p.id == QLatin1String("top_right")) {
-            // Dialog-parented — hardcoded dialog coords.
+            // Dialog-parented â€” hardcoded dialog coords.
             p.combo->resize(120, p.combo->sizeHint().height());
             p.combo->move(400, 100);
             p.combo->raise();
@@ -475,7 +497,7 @@ void UlanziDialMapperDialog::layoutPills()
                       center.y() - sz.height() / 2);
     };
 
-    // Bound by m_pills.size() — buildPills() calls refreshPillLabel inside
+    // Bound by m_pills.size() â€” buildPills() calls refreshPillLabel inside
     // its loop, which re-enters layoutPills before every pill exists.
     for (int i = 0; i < m_pills.size(); ++i) {
         place(m_pills[i]);
@@ -493,7 +515,7 @@ void UlanziDialCanvas::paintEvent(QPaintEvent*)
     QPainter p(this);
     p.setRenderHint(QPainter::Antialiasing);
 
-    // Background — match the surrounding dialog.
+    // Background â€” match the surrounding dialog.
     p.fillRect(rect(), QColor("#0f0f1a"));
 
     const QRect body = m_owner->dialBodyRect();
@@ -542,7 +564,7 @@ void UlanziDialCanvas::paintEvent(QPaintEvent*)
         p.drawEllipse(knobCenter, 12, 12);
     }
 
-    // No connector lines / anchor dots — pills sit physically next to
+    // No connector lines / anchor dots â€” pills sit physically next to
     // the dial body so the spatial mapping is conveyed by adjacency.
 }
 
@@ -563,7 +585,7 @@ void UlanziDialMapperDialog::migrateLegacyMappings()
 QString UlanziDialMapperDialog::actionForPill(const QString& pillId)
 {
     // The document is authoritative; an absent entry means "built-in default".
-    // Legacy flat keys are not consulted here — migrateLegacyMappings() has
+    // Legacy flat keys are not consulted here â€” migrateLegacyMappings() has
     // already claimed and deleted them at startup.
     const QString bound = UlanziDialMappings::actionForPill(pillId);
     if (!bound.isEmpty())
@@ -642,7 +664,7 @@ void UlanziDialMapperDialog::onButtonEvent(const QString& signature, int action)
     const QString pillId = pillForSignature(signature);
     const QString suffix = pillId.isEmpty()
         ? tr(" (unmapped)")
-        : QStringLiteral(" → %1").arg(pillId);
+        : QStringLiteral(" â†’ %1").arg(pillId);
     m_lastEventLabel->setText(tr("Last event: %1%2 (%3)")
                                   .arg(signature, suffix,
                                        action == 1 ? "press" : "release"));
@@ -663,17 +685,29 @@ void UlanziDialMapperDialog::showEvent(QShowEvent* event)
 void UlanziDialMapperDialog::onConnectionChanged(bool connected, const QString& name)
 {
     if (!m_statusLabel) return;
+    m_connected = connected;
+#if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
+    // A supported dial is open, so the unsupported-variant advisory no longer
+    // applies; and while disconnected, let the advisory own the status line
+    // rather than overwriting it with a bare "Disconnected". (#3485)
+    if (connected) {
+        m_unsupportedVariant.clear();
+        if (m_variantHelpBtn) m_variantHelpBtn->setVisible(false);
+    } else if (!m_unsupportedVariant.isEmpty()) {
+        return;
+    }
+#endif
     QString display = name;
     if (display.endsWith(QStringLiteral(" Keyboard"), Qt::CaseInsensitive))
         display.chop(QStringLiteral(" Keyboard").size());
     m_statusLabel->setText(connected
-        ? tr("Connected — %1").arg(display)
+        ? tr("Connected â€” %1").arg(display)
         : tr("Disconnected"));
     m_statusLabel->setStyleSheet(connected
         ? "QLabel { color: #4dd87a; }"
         : "QLabel { color: #cc3333; }");
 #ifdef Q_OS_LINUX
-    // Once connected, the access problem is resolved — hide the offer.
+    // Once connected, the access problem is resolved â€” hide the offer.
     if (connected && m_grantAccessBtn)
         m_grantAccessBtn->setVisible(false);
 #endif
@@ -686,7 +720,7 @@ void UlanziDialMapperDialog::onAccessRequired(const QString& deviceName)
     QString display = deviceName;
     if (display.endsWith(QStringLiteral(" Keyboard"), Qt::CaseInsensitive))
         display.chop(QStringLiteral(" Keyboard").size());
-    showAttentionStatus(tr("%1 detected — needs permission").arg(display));
+    showAttentionStatus(tr("%1 detected â€” needs permission").arg(display));
     if (m_grantAccessBtn) {
         m_grantAccessBtn->setVisible(true);
         m_grantAccessBtn->setEnabled(true);
@@ -705,7 +739,7 @@ void UlanziDialMapperDialog::onGrantAccessClicked()
 
     if (m_grantAccessBtn) {
         m_grantAccessBtn->setEnabled(false);
-        m_grantAccessBtn->setText(tr("Authorizing…"));
+        m_grantAccessBtn->setText(tr("Authorizingâ€¦"));
     }
 
     // Install the udev access rule and reload, as root via polkit. The rule
@@ -713,7 +747,7 @@ void UlanziDialMapperDialog::onGrantAccessClicked()
     // as an argv element (not interpolated into the script) to avoid any
     // quoting/injection concern.
     static const QString kRule = QStringLiteral(
-        "# AetherSDR — Ulanzi Dial access (#3599)\n"
+        "# AetherSDR â€” Ulanzi Dial access (#3599)\n"
         "SUBSYSTEM==\"input\", KERNEL==\"event*\", "
         "ATTRS{name}==\"Ulanzi Dial*\", TAG+=\"uaccess\"\n");
     static const QString kScript = QStringLiteral(
@@ -724,7 +758,7 @@ void UlanziDialMapperDialog::onGrantAccessClicked()
 
     auto* proc = new QProcess(this);
     // If pkexec can't even start, QProcess emits errorOccurred and never emits
-    // finished — recover the button instead of leaving it stuck on "Authorizing…".
+    // finished â€” recover the button instead of leaving it stuck on "Authorizingâ€¦".
     connect(proc, &QProcess::errorOccurred, this,
             [this, proc](QProcess::ProcessError) {
         if (proc->state() != QProcess::NotRunning) return;  // started; finished will handle it
@@ -745,7 +779,7 @@ void UlanziDialMapperDialog::onGrantAccessClicked()
         if (m_grantAccessBtn) m_grantAccessBtn->setText(tr("Grant access"));
         if (code == 0) {
             if (m_statusLabel) {
-                m_statusLabel->setText(tr("Access granted — connecting…"));
+                m_statusLabel->setText(tr("Access granted â€” connectingâ€¦"));
                 m_statusLabel->setStyleSheet("QLabel { color: #4dd87a; }");
             }
             // The udev trigger applies the ACL asynchronously; give logind a
@@ -778,27 +812,71 @@ void UlanziDialMapperDialog::onGrantAccessClicked()
 void UlanziDialMapperDialog::onUnsupportedVariant(const QString& deviceName)
 {
     if (!m_statusLabel) return;
-    // Don't downgrade a live connection — this state only applies while
+
+    // Empty name = the variant went away (unplugged, or scanning stopped).
+    // Withdraw the advisory rather than leaving a stale "detected". (#3485)
+    if (deviceName.isEmpty()) {
+        m_unsupportedVariant.clear();
+        if (m_variantHelpBtn) m_variantHelpBtn->setVisible(false);
+        if (!m_connected)
+            onConnectionChanged(false, QString());
+        return;
+    }
+
+    // Don't downgrade a live connection â€” this state only applies while
     // nothing supported is open.
-    if (m_manager && m_manager->isConnected()) return;
-    showAttentionStatus(
-        tr("%1 detected — this variant can't be driven over HID. "
-           "Use the Ulanzi Studio TCI plugin instead: enable TCI in "
-           "Settings, then see plugins/ulanzi-aethersdr/README.md in the "
-           "AetherSDR source tree for installation (not yet bundled with "
-           "the installer).")
-            .arg(deviceName));
+    if (m_connected) return;
+
+    m_unsupportedVariant = deviceName;
+    // Keep the LABEL short: the dialog is setFixedSize(640, 675) and this
+    // label shares one non-wrapping row with the "last event" readout, so a
+    // sentence of instructions is silently clipped mid-word.  The procedure
+    // lives behind the button instead, where it has room to be read. (#3485)
+    showAttentionStatus(tr("%1 â€” not usable over HID").arg(deviceName));
+    if (m_variantHelpBtn) m_variantHelpBtn->setVisible(true);
+}
+
+void UlanziDialMapperDialog::onVariantHelpClicked()
+{
+    // Rich text so the plugin release is a real clickable link â€” retyping a
+    // URL out of a status label is not a usable acquisition path.  The link
+    // points at the plugin's own release, which actually carries the
+    // packaged .zip; the AetherSDR release assets do not include it. (#3485)
+    QMessageBox box(this);
+    box.setWindowTitle(tr("Ulanzi dial â€” setup required"));
+    box.setIcon(QMessageBox::Information);
+    box.setTextFormat(Qt::RichText);
+    box.setText(tr("<b>%1</b> cannot be driven over HID.")
+                    .arg(m_unsupportedVariant.toHtmlEscaped()));
+    box.setInformativeText(
+        tr("<p>This variant's vendor collection stays silent unless Ulanzi "
+           "Studio performs its activation handshake, and its keyboard and "
+           "mouse collections are captured by Windows â€” so AetherSDR cannot "
+           "read it directly.</p>"
+           "<p>Drive it through Ulanzi Studio instead:</p>"
+           "<ol>"
+           "<li>Enable TCI: <b>Settings â†’ Autostart TCI with AetherSDR</b>.</li>"
+           "<li>Download <code>com.g0jkn.aethersdr.ulanziPlugin.zip</code> from "
+           "<a href=\"https://github.com/nigelfenton/aethersdr-ulanzi-plugin/releases/latest\">"
+           "the AetherSDR Ulanzi plugin release</a>.</li>"
+           "<li>Unpack it into "
+           "<code>%APPDATA%\\Ulanzi\\UlanziDeck\\Plugins\\</code>.</li>"
+           "<li>Quit Ulanzi Studio from the system tray and relaunch it.</li>"
+           "</ol>"));
+    box.setTextInteractionFlags(Qt::TextBrowserInteraction);
+    box.exec();
 }
 #endif  // Q_OS_WIN && HAVE_HIDAPI
 
 // The one amber call site, shared by every advisory status (Linux
-// needs-permission, Windows unsupported-variant) — the colour ratchet
+// needs-permission, Windows unsupported-variant) â€” the colour ratchet
 // tracks setStyleSheet call sites, so new advisory states reuse this one.
 void UlanziDialMapperDialog::showAttentionStatus(const QString& text)
 {
     if (!m_statusLabel) return;
     m_statusLabel->setText(text);
-    m_statusLabel->setStyleSheet(kAttentionLabelStyle);
+    ThemeManager::instance().applyStyleSheet(m_statusLabel,
+                                             QString::fromLatin1(kAttentionLabelStyle));
 }
 
 } // namespace AetherSDR

--- a/src/gui/UlanziDialMapperDialog.cpp
+++ b/src/gui/UlanziDialMapperDialog.cpp
@@ -856,7 +856,7 @@ void UlanziDialMapperDialog::onVariantHelpClicked()
     // points at the plugin's own release, which actually carries the
     // packaged .zip; the AetherSDR release assets do not include it. (#3485)
     QMessageBox box(this);
-    box.setWindowTitle(tr("Ulanzi dial — setup required"));
+    box.setWindowTitle(tr("Ulanzi Dial — Setup Required"));
     box.setIcon(QMessageBox::Information);
     box.setTextFormat(Qt::RichText);
     box.setText(tr("<b>%1</b> cannot be driven over HID.")

--- a/src/gui/UlanziDialMapperDialog.cpp
+++ b/src/gui/UlanziDialMapperDialog.cpp
@@ -828,26 +828,54 @@ void UlanziDialMapperDialog::onUnsupportedVariant(const QString& deviceName)
     if (m_connected) return;
 
     m_unsupportedVariant = deviceName;
-    // The status label gets ~212 px in this fixed 640 px row (measured on the
-    // running dialog: status 212, Setup 69, "Last event:" 93, Reset 127,
-    // Close 57), and it does not wrap or elide.  The device name alone is
-    // wider than that, so it must NOT go in the label — an earlier attempt
-    // put it here and clipped mid-name at
-    // 'Ulanzi D100H (KEHWIN "Dial_Lite",'.  The label is therefore a fixed
-    // short phrase that always fits; the name lives in the button tooltip
-    // and in the Setup dialog, which have room for it. (#3485)
-    // "Unsupported dial" measures 192 px in this label's font; the budget is
-    // 212.  Do not lengthen it without re-measuring — "Not usable over HID"
-    // (228 px) and "Unsupported variant" (228 px) both overflow, and the
-    // label neither wraps nor elides, so overflow is a silent mid-word cut.
-    showAttentionStatus(tr("Unsupported dial"));
+    refreshVariantStatus();
+}
+
+void UlanziDialMapperDialog::setTciClientConnected(bool connected)
+{
+    if (m_tciClientConnected == connected) return;
+    m_tciClientConnected = connected;
+    if (!m_unsupportedVariant.isEmpty() && !m_connected)
+        refreshVariantStatus();
+}
+
+void UlanziDialMapperDialog::refreshVariantStatus()
+{
+    if (m_unsupportedVariant.isEmpty()) return;
+
+    // Wording matters here.  These units are NOT broken — they are driven
+    // through Ulanzi Studio's plugin over TCI, and a user whose dial is
+    // already working that way must not be told it is "unsupported".  So the
+    // label names the path that WORKS rather than the one that does not.
+    //
+    // Budget: the status label gets 212 px of the fixed 640 px bottom row
+    // (measured on the running dialog: status 212, Setup 69, "Last event:" 93,
+    // Reset 127, Close 57) and it neither wraps nor elides, so overflow is a
+    // silent mid-word cut — an earlier attempt put the device name here and
+    // clipped at 'Ulanzi D100H (KEHWIN "Dial_Lite",'.  Measured with
+    // QFontMetrics in the label's own font: "Use Ulanzi Studio" 204 px (fits),
+    // "Studio plugin only" 216 px and "Unsupported variant" 228 px (both
+    // overflow).  Re-measure before lengthening.  The device name lives in the
+    // button tooltip and the Setup dialog, which have room. (#3485)
+    showAttentionStatus(tr("Use Ulanzi Studio"));
+
     if (m_variantHelpBtn) {
+        // TciServer reports only peer address/port (TciClientInfo), never an
+        // application name, so a live client cannot be attributed to the
+        // Ulanzi plugin specifically — say "a TCI client", not "your dial".
         m_variantHelpBtn->setToolTip(
-            tr("%1 — cannot be driven over HID. Click for setup instructions.")
-                .arg(deviceName));
+            m_tciClientConnected
+                ? tr("%1 — not driven over HID. A TCI client is connected, so "
+                     "if this dial is mapped in Ulanzi Studio it is already "
+                     "working. Click for setup instructions.")
+                      .arg(m_unsupportedVariant)
+                : tr("%1 — cannot be driven over HID. Click for setup "
+                     "instructions.")
+                      .arg(m_unsupportedVariant));
         m_variantHelpBtn->setVisible(true);
     }
 }
+
 
 void UlanziDialMapperDialog::onVariantHelpClicked()
 {

--- a/src/gui/UlanziDialMapperDialog.h
+++ b/src/gui/UlanziDialMapperDialog.h
@@ -46,6 +46,20 @@ public:
 
     friend class UlanziDialCanvas;
 
+#if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
+    // Tell the dialog whether any TCI client is currently connected.  The
+    // unsupported-variant advisory means "this HID mapper cannot drive the
+    // dial", NOT "your dial is broken" — these units are driven through
+    // Ulanzi Studio's plugin over TCI, and when that is live the dial is
+    // working.  MainWindow owns the TciServer and pushes the state in, so the
+    // dialog gains no dependency on it. (#3485)
+    //
+    // NOTE: TciServer exposes only peer address/port (TciClientInfo), not an
+    // application name, so this cannot tell the Ulanzi plugin from any other
+    // TCI client.  The wording is therefore hedged accordingly.
+    void setTciClientConnected(bool connected);
+#endif
+
 protected:
     // Re-run layoutPills after the dialog is fully shown.  Until that
     // point, m_canvas->mapTo/mapFrom return values relative to an
@@ -150,6 +164,9 @@ private:
 #if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
     QPushButton* m_variantHelpBtn{nullptr};  // shown only on unsupported variant
     QString m_unsupportedVariant;            // GUI-thread copy, queued-signal fed
+    bool m_tciClientConnected{false};        // pushed in by MainWindow
+    // Re-render the advisory for the current variant + TCI state.
+    void refreshVariantStatus();
 #endif
     // GUI-thread mirror of the backend's connection state.  The advisory
     // handlers must NOT call m_manager->isConnected() directly: on Windows the

--- a/src/gui/UlanziDialMapperDialog.h
+++ b/src/gui/UlanziDialMapperDialog.h
@@ -89,6 +89,11 @@ private slots:
     void onAccessRequired(const QString& deviceName);
     void onGrantAccessClicked();
 #endif
+#if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
+    // A known OEM variant (KEHWIN D100H / Zkswe D200) is present but cannot
+    // be driven over HID — point the user at the Ulanzi Studio plugin. (#3485)
+    void onUnsupportedVariant(const QString& deviceName);
+#endif
 
 private:
     struct Pill {

--- a/src/gui/UlanziDialMapperDialog.h
+++ b/src/gui/UlanziDialMapperDialog.h
@@ -46,20 +46,6 @@ public:
 
     friend class UlanziDialCanvas;
 
-#if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
-    // Tell the dialog whether any TCI client is currently connected.  The
-    // unsupported-variant advisory means "this HID mapper cannot drive the
-    // dial", NOT "your dial is broken" — these units are driven through
-    // Ulanzi Studio's plugin over TCI, and when that is live the dial is
-    // working.  MainWindow owns the TciServer and pushes the state in, so the
-    // dialog gains no dependency on it. (#3485)
-    //
-    // NOTE: TciServer exposes only peer address/port (TciClientInfo), not an
-    // application name, so this cannot tell the Ulanzi plugin from any other
-    // TCI client.  The wording is therefore hedged accordingly.
-    void setTciClientConnected(bool connected);
-#endif
-
 protected:
     // Re-run layoutPills after the dialog is fully shown.  Until that
     // point, m_canvas->mapTo/mapFrom return values relative to an
@@ -164,8 +150,7 @@ private:
 #if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
     QPushButton* m_variantHelpBtn{nullptr};  // shown only on unsupported variant
     QString m_unsupportedVariant;            // GUI-thread copy, queued-signal fed
-    bool m_tciClientConnected{false};        // pushed in by MainWindow
-    // Re-render the advisory for the current variant + TCI state.
+    // Re-render the advisory for the current variant.
     void refreshVariantStatus();
 #endif
     // GUI-thread mirror of the backend's connection state.  The advisory

--- a/src/gui/UlanziDialMapperDialog.h
+++ b/src/gui/UlanziDialMapperDialog.h
@@ -94,6 +94,9 @@ private slots:
     // be driven over HID — point the user at the Ulanzi Studio plugin. (#3485)
     void onUnsupportedVariant(const QString& deviceName);
 #endif
+    // Amber advisory status text — the single styled call site every
+    // advisory state shares (colour-ratchet discipline).
+    void showAttentionStatus(const QString& text);
 
 private:
     struct Pill {

--- a/src/gui/UlanziDialMapperDialog.h
+++ b/src/gui/UlanziDialMapperDialog.h
@@ -91,8 +91,12 @@ private slots:
 #endif
 #if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
     // A known OEM variant (KEHWIN D100H / Zkswe D200) is present but cannot
-    // be driven over HID — point the user at the Ulanzi Studio plugin. (#3485)
+    // be driven over HID — point the user at the Ulanzi Studio plugin.  An
+    // EMPTY name withdraws the advisory (unplugged / scanning off). (#3485)
     void onUnsupportedVariant(const QString& deviceName);
+    // Opens the readable, clickable setup instructions the short status
+    // label has no room for. (#3485)
+    void onVariantHelpClicked();
 #endif
     // Amber advisory status text — the single styled call site every
     // advisory state shares (colour-ratchet discipline).
@@ -143,6 +147,15 @@ private:
 #ifdef Q_OS_LINUX
     QPushButton* m_grantAccessBtn{nullptr};  // shown only on accessRequired
 #endif
+#if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)
+    QPushButton* m_variantHelpBtn{nullptr};  // shown only on unsupported variant
+    QString m_unsupportedVariant;            // GUI-thread copy, queued-signal fed
+#endif
+    // GUI-thread mirror of the backend's connection state.  The advisory
+    // handlers must NOT call m_manager->isConnected() directly: on Windows the
+    // backend lives on the ExtControllers thread and that read would race
+    // rescan(). (#3485)
+    bool m_connected{false};
 };
 
 } // namespace AetherSDR

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3524,6 +3524,15 @@ target_include_directories(ulanzi_chord_decoder_test PRIVATE src)
 target_link_libraries(ulanzi_chord_decoder_test PRIVATE Qt6::Core)
 add_test(NAME ulanzi_chord_decoder_test COMMAND ulanzi_chord_decoder_test)
 
+# Header-only table + transition rule, so no manager source is needed — the
+# Windows manager itself is Q_OS_WIN-gated and calls hid_enumerate directly.
+add_executable(ulanzi_variant_table_test
+    tests/ulanzi_variant_table_test.cpp
+)
+target_include_directories(ulanzi_variant_table_test PRIVATE src)
+target_link_libraries(ulanzi_variant_table_test PRIVATE Qt6::Core)
+add_test(NAME ulanzi_variant_table_test COMMAND ulanzi_variant_table_test)
+
 add_executable(ulanzi_mapping_migration_test
     tests/ulanzi_mapping_migration_test.cpp
     src/core/UlanziDialMappings.cpp

--- a/tests/ulanzi_variant_table_test.cpp
+++ b/tests/ulanzi_variant_table_test.cpp
@@ -1,0 +1,134 @@
+// Ulanzi unsupported-OEM-variant recognition and advisory state transitions.
+//
+// Two invariants, both from the review of #3485's fix:
+//
+//   1. A variant is recognised only on an exact VID/PID pair.  0xFFF1 is
+//      unassigned placeholder VID space that cheap BLE-HID firmware reuses,
+//      so a vendor-only match would confidently mislabel unrelated hardware
+//      as a D100H — worse than the "Disconnected" the advisory replaces.
+//
+//   2. The advisory publishes on transitions in BOTH directions.  The hotplug
+//      timer re-scans every few seconds: emitting unconditionally spams the
+//      dialog, but suppressing the empty case leaves it claiming an unplugged
+//      dial is still present, and deduping on the name alone means
+//      present -> absent -> same variant present never re-notifies.
+//
+// Break them on purpose to see the test earn its keep: in
+// UlanziVariantTable.h, drop the `pid == 0 ||` guard's companion `pid ==
+// v.pid` check so the match is vendor-only and "unknown PID in the shared
+// 0xFFF1 space is not claimed" fails; make shouldPublish() return
+// `!current.isEmpty() && lastPublished != current` and both the withdrawal
+// and the re-notify cases fail.
+
+#include "core/UlanziVariantTable.h"
+
+#include <QString>
+
+#include <iostream>
+
+using namespace AetherSDR;
+
+namespace {
+
+bool expect(bool condition, const char* label)
+{
+    std::cout << (condition ? "[ OK ] " : "[FAIL] ") << label << '\n';
+    return condition;
+}
+
+// Mirrors UlanziDialWindowsManager's publish bookkeeping: the value last
+// emitted, updated only when a transition is published.
+struct Publisher {
+    QString lastPublished;
+    int     emissions = 0;
+    QString lastEmitted;
+
+    void observe(const QString& current)
+    {
+        if (!UlanziVariant::shouldPublish(lastPublished, current))
+            return;
+        lastPublished = current;
+        lastEmitted   = current;
+        ++emissions;
+    }
+};
+
+const QString kD100H = QStringLiteral("Ulanzi D100H (KEHWIN \"Dial_Lite\", BLE)");
+const QString kD200  = QStringLiteral("Ulanzi D200 (Zkswe \"ulanzi\", USB)");
+
+} // namespace
+
+int main()
+{
+    bool ok = true;
+
+    // ---- 1. Recognition is exact-pair, not vendor-wide. ----
+    ok &= expect(UlanziVariant::lookup(0xFFF1, 0x0082) == kD100H,
+                 "KEHWIN D100H is recognised by its exact VID/PID");
+    ok &= expect(UlanziVariant::lookup(0x2207, 0x0019) == kD200,
+                 "Zkswe D200 is recognised by its exact VID/PID");
+
+    // The whole point of pinning the PID: 0xFFF1 is shared placeholder space.
+    ok &= expect(UlanziVariant::lookup(0xFFF1, 0x1234).isEmpty(),
+                 "unknown PID in the shared 0xFFF1 space is not claimed");
+    ok &= expect(UlanziVariant::lookup(0x2207, 0x0001).isEmpty(),
+                 "unknown PID under the Zkswe VID is not claimed");
+    ok &= expect(UlanziVariant::lookup(0x1234, 0x0082).isEmpty(),
+                 "matching PID under an unrelated VID is not claimed");
+
+    // ---- 2. Transition publishing. ----
+
+    // Steady state must not spam: the hotplug timer rescans every few seconds.
+    {
+        Publisher p;
+        p.observe(kD100H);
+        const int afterFirst = p.emissions;
+        for (int i = 0; i < 5; ++i) p.observe(kD100H);
+        ok &= expect(afterFirst == 1 && p.emissions == 1,
+                     "a variant present across repeated rescans emits once");
+    }
+
+    // Disappearance must be published, or the dialog lies about the hardware.
+    {
+        Publisher p;
+        p.observe(kD100H);
+        p.observe(QString());
+        ok &= expect(p.emissions == 2 && p.lastEmitted.isEmpty(),
+                     "unplugging the variant publishes an empty withdrawal");
+
+        for (int i = 0; i < 3; ++i) p.observe(QString());
+        ok &= expect(p.emissions == 2,
+                     "staying absent does not re-emit the withdrawal");
+    }
+
+    // The case the name-only dedupe got wrong.
+    {
+        Publisher p;
+        p.observe(kD100H);
+        p.observe(QString());
+        p.observe(kD100H);
+        ok &= expect(p.emissions == 3 && p.lastEmitted == kD100H,
+                     "present -> absent -> same variant present re-notifies");
+    }
+
+    // Swapping one unsupported dial for another is a transition too.
+    {
+        Publisher p;
+        p.observe(kD100H);
+        p.observe(kD200);
+        ok &= expect(p.emissions == 2 && p.lastEmitted == kD200,
+                     "swapping to a different variant publishes the new name");
+    }
+
+    // A supported dial opening clears the advisory (rescan() empties the name).
+    {
+        Publisher p;
+        p.observe(kD100H);
+        p.observe(QString());
+        ok &= expect(p.lastEmitted.isEmpty(),
+                     "a supported dial taking over withdraws the advisory");
+    }
+
+    std::cout << (ok ? "ALL PASS" : "FAILURES") << '\n';
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
Addresses #3485 (and the closed duplicate #3670).

## The confusion that kept #3485 stuck

Four reporters see the mapper stuck on "Disconnected" with a D100H that Windows itself calls "Ulanzi Dial". Both observations are correct, because Windows keeps **two different name strings**:

- **PnP FriendlyName** = `"Ulanzi Dial"` — the BLE GAP advertised name; what Device Manager and PowerShell show. The backend never sees it.
- **HID product string descriptor** = `"Dial_Lite"` (manufacturer `KEHWIN`, VID `0xFFF1`) — what `hid_enumerate()` returns and what `kProductMatch` tests. Verified live against a physical BLE-paired D100H on Windows 11: hidapi enumerates the unit fine (five collections — BLE-HID is *not* invisible to hidapi), every collection reports `Dial_Lite`, the substring never matches.

## Why this PR does NOT "just fix the matcher"

Recon on the physical unit (60-second capture, all keys + dial, every userland-readable collection open) shows the KEHWIN firmware **cannot be driven over this backend at all**: the vendor collection (usage page `0xFFF1`) sends zero bytes unless the Ulanzi Studio app performs its vendor-mode activation, the keyboard/mouse collections are OS-captured on Windows, and the remaining collection carries firmware heartbeats. Matching it as "Connected" would trade a confusing status for a false one.

## What it does instead

Detect the known OEM variants during rescan — KEHWIN D100H (`0xFFF1`, BLE) and Zkswe D200 (`2207:0019`, USB) — and surface an explicit amber status in the mapper, mirroring the existing Linux "needs permission" third state:

> **Ulanzi D100H (KEHWIN "Dial_Lite", BLE) — not usable over HID**  [ Setup... ]

The status line stays short on purpose: the dialog is `setFixedSize(640, 675)` and the label shares one non-wrapping row, so a full sentence is clipped mid-word. The procedure lives behind the **Setup...** button, which opens the explanation plus a numbered walkthrough pointing at the in-tree plugin.

That's the truthful answer to the issue's actual question ("what is the procedure for making this work?"): these units work through Ulanzi Studio + the in-tree Studio plugin over TCI — confirmed working live today with this same dial.

Mechanics: an `unsupportedVariantChanged` signal that fires on transitions in **both** directions (an empty name withdraws the advisory when the dial is unplugged or scanning stops), a mutex-guarded snapshot getter so a dialog opened after `start()` recovers the state without racing the ExtControllers thread, and the warning label wired under `Q_OS_WIN && HAVE_HIDAPI` through `color.accent.warning`.

**On the plugin pointer (updated `6e2e154e`):** the Setup box originally linked to the standalone plugin repo's release, on the reasoning that it carries the packaged `.zip` while the AetherSDR release assets do not. @jensenpat blocked that in review and was right: a shipping dialog must not point at a contributor's personal repository, and the licences disagree — the in-tree plugin is GPL-3.0-or-later, the standalone repo Apache-2.0, both under the same `com.g0jkn.aethersdr.ulanziPlugin` id. **The link is gone.** The step now points at `plugins/ulanzi-aethersdr/` in the source tree. Packaging that plugin as an AetherSDR release asset remains a real gap — `release.yml` currently packages no plugin zips at all — but that is a separate PR, not a reason to funnel users at a personal account.

## Verified on real hardware (Windows 11, BLE-paired KEHWIN D100H)

The mapper dialog on this branch shows the variant message above, live, with the affected unit — status text captured via the automation bridge from the running build.

## Not exercised

- The Zkswe D200 row (unit not currently paired here — same detection shape, identity constants from earlier live enumeration of that device).
- macOS: current `main`'s `UlanziDialMacOSManager` matches on exact VID/PID, not the product string (the earlier wording here was wrong — thanks @rfoust). The same OEM units exist there, and the variant table is now a shared header (`src/core/UlanziVariantTable.h`) so a macOS port is a lookup call rather than a copied table. Still Windows-only in this PR because I can only hardware-verify Windows — happy to add it if a Mac tester volunteers.
- A supported "Ulanzi Dial"-string unit (none here) — the matched path is unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review round 2 (@rfoust) — all four P2 blockers addressed in `f612f58c`

| # | Blocker | Fix |
|---|---|---|
| 1 | Advisory clipped, no usable acquisition path | Short status + **Setup...** button opening rich-text instructions with the numbered Studio procedure (the download link this row originally added was removed in `6e2e154e` — see above) |
| 2 | Getters race the ExtControllers thread | Queued snapshot hop + `QMutex` on `m_variantSeen`; handlers use a GUI-thread mirror instead of `isConnected()` across the seam |
| 3 | No absent transition | `unsupportedVariantChanged` emits both directions; `stop()` clears and publishes; dedupe resets so present → absent → same variant re-notifies |
| 4 | Bypassed `color.accent.warning` | Resolved via `ThemeManager::applyStyleSheet()`; `#e0a030` literal deleted. Ratchet **−1 unique colours, −1 references, −1 setStyleSheet** vs base |

New `tests/ulanzi_variant_table_test.cpp` — 11 assertions, including the present → absent → same-variant-present case you asked for. **Both invariants proven by breaking them**, not by a green re-run: a vendor-only match fails the two mislabel cases (exit 1), and suppressing the empty publish fails all four withdrawal/re-notify cases (exit 1).

Verified on Windows (MSVC, Qt 6.10.3): `AetherSDR` builds clean (the escape-sequence warning my first draft introduced is fixed), all three ulanzi tests pass with real stdout, colour-ratchet / engine-boundary / a11y green, app launches without crashing.

**Not verified:** no D100H or D200 was attached for this round, so the advisory''s on-screen rendering and the new withdraw-on-unplug path are not hardware-confirmed — the transition logic is covered by the unit test only.

## Hardware verification — full present → absent → present cycle

Run on a BLE-paired KEHWIN D100H (Windows 11, MSVC, Qt 6.10.3) by toggling the host's Bluetooth with the mapper open. Widget geometry read from the running dialog via the automation bridge; the on-screen result matches.

| | HID interfaces | variant matches | status label | Setup button |
|---|---:|---:|---|:--:|
| dial present | 12 | 5 | `Use Ulanzi Studio` (109 px) | shown |
| **BT off → absent** | 7 | 0 | `Disconnected` (85 px) | **hidden** |
| **BT on → present again** | 12 | 5 | `Use Ulanzi Studio` (109 px) | **shown** |

The re-appearance is the case that matters: with the previous name-only dedupe, `m_variantNotified` still held the same variant string, so the advisory would **not** have come back. Transition observed within ~30 s of the hotplug rescan.

`hid_enumerate` reports the dial as **VID `0xFFF1` PID `0x0082`, 5 collections, all `KEHWIN` / `Dial_Lite`** — and the `"Ulanzi Dial"` product-string matcher misses every one, which is #3485's root cause confirmed live.

**Independent corroboration of the identity constants:** `src/core/UlanziDialMacOSManager.cpp:29-30` on current `main` pins the same pair (`kUlanziVendorId = 0xFFF1`, `kUlanziProductId = 0x0082`), sourced per its own comment from the reporter's BLE descriptor dump in #5126 plus a bench unit. Three independent sightings of the same identity.

Also worth noting: #5126 records the same false-`Disconnected` symptom on **macOS** — *"the status under Ulanzi Settings shows Disconnected even though the controller is active, connected, and communicating"* — so this is not a Windows-only confusion.

### Still not exercised

- **macOS.** No dial is paired to the Mac here (BLE pairs to one host at a time), and every code path in this PR is behind `#if defined(Q_OS_WIN) && defined(HAVE_HIDAPI)`, so a macOS build would compile none of it. The shared `UlanziVariantTable.h` makes a future macOS port a lookup call rather than a copied table.
- **The Zkswe D200 row.** No unit here; identity constants come from earlier live enumeration of that device.

## Review round 4 (@jensenpat) — blockers 1 and 4 addressed in `6e2e154e`

| # | Blocker | Outcome |
|---|---|---|
| 1 | Personal-repo download link in a shipping dialog | **Removed.** Step points at `plugins/ulanzi-aethersdr/`; step 3 reworded from "Unpack it" to "Copy the built plugin folder" so the numbered steps still follow |
| 4 | `clientCount > 0` is not "the Ulanzi plugin is driving this dial" | **Removed entirely**, not reworded — `setTciClientConnected()`, `m_tciClientConnected` and the `clientCountChanged` wiring all go. Any TCI peer tripped it, so a WSJT-X or logging client would have told a user their dial was working when nothing was driving it |
| 2 | "Does not fix #3485" | Contested — @ten9876 reviewed this question on 26 Aug and recorded no blockers: *"Naming the device instead of driving it is the right call given the vendor collection stays silent outside Ulanzi Studio."* Driving the dial needs Ulanzi's proprietary activation handshake reverse-engineered; see the recon above. Happy to retitle to make the narrower claim explicit |
| 3 | `UlanziVariantTable.h` should leave `src/core/` | Contested — @ten9876's finding was about the header's unqualified drivability *comment*, scoped to Windows in `dab91a5e`, not its location. Moving it makes `ulanzi_variant_table_test` Windows-only, and that platform-neutral test is the only part of this PR a non-Windows reviewer can execute. Open to renaming it to something identity-only |

Net −60 lines.

**Verified this round** (Windows 11, MSVC, Qt 6.10.3): `AetherSDR` builds and links clean and launches without crashing; all three ulanzi tests pass with real stdout (`ulanzi_variant_table_test` 11/11, chord decoder, mapping migration); colour ratchet run as CI runs it (merge-base worktree, `--strict`) still **−1 unique colours, −1 references, −1 `setStyleSheet`** against base. CI 5/5 green.

**Not verified:** no D100H attached this round, so the reworded Setup box and tooltip are not hardware-confirmed on screen. The present → absent → present cycle above was run on hardware; this round is text and deletions on top of it.
