### PR TITLE
fix(icom): hold SWR and ALC across isolated TX minimum replies

### DIFF
--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -2213,7 +2213,14 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame,
         if (!raw)
             return;
 
-        m_meters.markAnswered(spec->id, nowMs());
+        const qint64 answeredAtMs = nowMs();
+        m_meters.markAnswered(spec->id, answeredAtMs);
+        const bool holdIsolatedMinimums = m_model
+            && profileFor(*m_model).meters.holdIsolatedTxMinimums;
+        if (!m_meters.shouldPublish(spec->id, *raw, answeredAtMs,
+                                    holdIsolatedMinimums)) {
+            return;
+        }
         const double value = meterValue(
             spec->id, *raw, s9ReferenceFor(m_frequencyHz),
             m_model ? profileFor(*m_model).meters.calibration

--- a/src/core/backends/icom/IcomMeters.cpp
+++ b/src/core/backends/icom/IcomMeters.cpp
@@ -274,6 +274,58 @@ void MeterPoller::setVisible(MeterId id, bool visible)
 
 bool MeterPoller::isVisible(MeterId id) const { return stateFor(id).visible; }
 
+void MeterPoller::setTransmitting(bool tx) noexcept
+{
+    if (m_transmitting == tx) {
+        return;
+    }
+    m_transmitting = tx;
+    // A held sample belongs to one keyed interval only. In particular, the
+    // first minimum of a new transmission must not reuse a non-minimum sample
+    // from the previous one.
+    resetMinimumHolds();
+}
+
+bool MeterPoller::shouldPublish(MeterId id, int raw, std::int64_t nowMs,
+                                bool holdIsolatedMinimums)
+{
+    State& state = stateFor(id);
+    const bool minimumHoldMeter = id == MeterId::Swr || id == MeterId::Alc;
+    if (!holdIsolatedMinimums || !m_transmitting || !minimumHoldMeter) {
+        state.hasNonMinimumReading = false;
+        state.minimumCandidateSinceMs = -1;
+        return true;
+    }
+
+    if (raw > 0) {
+        state.hasNonMinimumReading = true;
+        state.minimumCandidateSinceMs = -1;
+        return true;
+    }
+
+    // Before this keyed interval has produced a real sample, minimum is the
+    // honest rest value. There is nothing older to hold.
+    if (!state.hasNonMinimumReading) {
+        return true;
+    }
+
+    if (state.minimumCandidateSinceMs < 0) {
+        state.minimumCandidateSinceMs = nowMs;
+        return false;
+    }
+
+    if (nowMs - state.minimumCandidateSinceMs < kMinimumConfirmationMs) {
+        return false;
+    }
+
+    // The radio has reported minimum continuously for a complete sample
+    // interval. Publish it and stop treating later minimum replies as gaps
+    // until a new non-minimum reading arrives.
+    state.hasNonMinimumReading = false;
+    state.minimumCandidateSinceMs = -1;
+    return true;
+}
+
 std::vector<MeterId> MeterPoller::due(std::int64_t nowMs)
 {
     std::vector<MeterId> out;
@@ -332,6 +384,14 @@ void MeterPoller::reset() noexcept
         s = State{};
     m_transmitting = false;
     m_quietUntilMs = 0;
+}
+
+void MeterPoller::resetMinimumHolds() noexcept
+{
+    for (State& state : m_state) {
+        state.hasNonMinimumReading = false;
+        state.minimumCandidateSinceMs = -1;
+    }
 }
 
 }  // namespace AetherSDR::icom

--- a/src/core/backends/icom/IcomMeters.h
+++ b/src/core/backends/icom/IcomMeters.h
@@ -171,8 +171,17 @@ public:
     void setVisible(MeterId id, bool visible);
     [[nodiscard]] bool isVisible(MeterId id) const;
 
-    void setTransmitting(bool tx) noexcept { m_transmitting = tx; }
+    void setTransmitting(bool tx) noexcept;
     [[nodiscard]] bool isTransmitting() const noexcept { return m_transmitting; }
+
+    // Icom's TX meters are polled one at a time. On the IC-705 and
+    // IC-7300MK2 an isolated 0000 reply can arrive between real SWR/ALC
+    // samples while keyed; publishing it makes the display fall toward its
+    // rest position and then jump back on the next sample. Hold that isolated
+    // minimum, but accept a sustained minimum so a real 1:1 SWR or zero ALC
+    // remains radio-authoritative.
+    [[nodiscard]] bool shouldPublish(MeterId id, int raw, std::int64_t nowMs,
+                                     bool holdIsolatedMinimums);
 
     // Which meters should be requested now. Marks each returned meter in
     // flight, so it will not be returned again until markAnswered() or the
@@ -200,6 +209,9 @@ public:
     static constexpr int kUserGuardMs = 80;
     // A lost reply must eventually be re-asked or the meter dies silently.
     static constexpr int kInFlightTimeoutMs = 1500;
+    // One complete 5 Hz TX-meter interval. The second consecutive minimum is
+    // therefore accepted; only the between-sample placeholder is suppressed.
+    static constexpr int kMinimumConfirmationMs = 200;
 
 private:
     struct State {
@@ -208,9 +220,12 @@ private:
         std::int64_t nextDueMs = 0;
         std::int64_t sentAtMs = 0;
         std::int64_t answeredAtMs = 0;
+        bool hasNonMinimumReading = false;
+        std::int64_t minimumCandidateSinceMs = -1;
     };
     [[nodiscard]] State& stateFor(MeterId id);
     [[nodiscard]] const State& stateFor(MeterId id) const;
+    void resetMinimumHolds() noexcept;
 
     std::array<State, 8> m_state{};
     bool m_transmitting = false;

--- a/src/core/backends/icom/IcomModels.cpp
+++ b/src/core/backends/icom/IcomModels.cpp
@@ -536,7 +536,11 @@ const IcomModelProfile& profileFor(const IcomModel& model) noexcept
         .cwTextKeyer = CwTextKeyerProfile{},
         .setMenu = SetMenuProfile{359, 131},
         .scope = ScopeCommandProfile{true, false, false, false, false},
-        .meters = MeterCalibrationProfile{MeterCalibration::Ic705, 4.0},
+        .meters = MeterCalibrationProfile{
+            .calibration = MeterCalibration::Ic705,
+            .currentFullScaleAmps = 4.0,
+            .holdIsolatedTxMinimums = true,
+        },
         .preampLabels = kHfPreampLabels,
         .attenuatorSteps = kHfAttenuatorSteps,
         .modes = kIc705Modes,
@@ -551,7 +555,10 @@ const IcomModelProfile& profileFor(const IcomModel& model) noexcept
                                        kExtendedFmAccessModes,
                                        true, true, true, true, true, true},
         .scope = ScopeCommandProfile{true, false, false, false, false},
-        .meters = MeterCalibrationProfile{MeterCalibration::Ic9700Voltage, 0.0},
+        .meters = MeterCalibrationProfile{
+            .calibration = MeterCalibration::Ic9700Voltage,
+            .currentFullScaleAmps = 0.0,
+        },
         .civRecovery = CivRecoveryProfile{1000, 3},
         .preampLabels = kIc9700PreampLabels,
     };
@@ -570,7 +577,11 @@ const IcomModelProfile& profileFor(const IcomModel& model) noexcept
         .rxAntenna = RxAntennaProfile{true, false},
         .setMenu = SetMenuProfile{267, 89},
         .scope = ScopeCommandProfile{true, true, true, true, true},
-        .meters = MeterCalibrationProfile{MeterCalibration::Ic7300Mk2, 25.0},
+        .meters = MeterCalibrationProfile{
+            .calibration = MeterCalibration::Ic7300Mk2,
+            .currentFullScaleAmps = 25.0,
+            .holdIsolatedTxMinimums = true,
+        },
         .preampLabels = kHfPreampLabels,
         .attenuatorSteps = kHfAttenuatorSteps,
     };

--- a/src/core/backends/icom/IcomModels.h
+++ b/src/core/backends/icom/IcomModels.h
@@ -376,6 +376,10 @@ struct RxAntennaProfile {
 struct MeterCalibrationProfile {
     MeterCalibration calibration = MeterCalibration::Uncalibrated;
     double currentFullScaleAmps = 4.0;
+    // Live IC-705 and IC-7300MK2 evidence: SWR/ALC can return an isolated
+    // minimum between real keyed samples. Never lend that interpretation to a
+    // model whose own meter stream has not demonstrated it.
+    bool holdIsolatedTxMinimums = false;
     // True only after this model profile both documents and implements a PA
     // temperature meter. Kept model-specific so one Icom cannot lend an
     // unverified instrument to another merely because they share CI-V.

--- a/tests/icom_backend_test.cpp
+++ b/tests/icom_backend_test.cpp
@@ -296,6 +296,52 @@ static void testStaleSessionFrameIsDropped()
 
 }
 
+static void testTxMeterMinimumHoldAtBackendSeam()
+{
+    const IcomModel* ic705 = modelForName("IC-705");
+    check(ic705 != nullptr, "TX meter hold test resolves the IC-705 profile");
+    if (!ic705) {
+        return;
+    }
+
+    IcomCivBackend backend;
+    IcomCivBackendTestAccess::selectModel(backend, *ic705);
+    IcomCivBackendTestAccess::prepareGeneration(backend, 1);
+
+    CivFrame ptt;
+    ptt.to = kControllerAddress;
+    ptt.from = kIc705Addr;
+    ptt.cmd = cmd::kControl;
+    ptt.hasSub = true;
+    ptt.sub = control::kPtt;
+    ptt.data = {0x01};
+    IcomCivBackendTestAccess::expectPttConfirmation(backend, true);
+    IcomCivBackendTestAccess::deliver(backend, ptt, 1);
+
+    CivFrame swr;
+    swr.to = kControllerAddress;
+    swr.from = kIc705Addr;
+    swr.cmd = cmd::kMeter;
+    swr.hasSub = true;
+    swr.sub = meter::kSwr;
+    swr.data = {0x00, 0x80};
+
+    QSignalSpy meterSpy(&backend, &IRadioBackend::meterUpdate);
+    IcomCivBackendTestAccess::deliver(backend, swr, 1);
+    check(meterSpy.count() == 1,
+          "a real keyed IC-705 SWR reply crosses the backend seam");
+
+    swr.data = {0x00, 0x00};
+    IcomCivBackendTestAccess::deliver(backend, swr, 1);
+    check(meterSpy.count() == 1,
+          "an isolated keyed IC-705 SWR minimum is held below the shared meter seam");
+
+    swr.data = {0x00, 0x82};
+    IcomCivBackendTestAccess::deliver(backend, swr, 1);
+    check(meterSpy.count() == 2,
+          "the next real IC-705 SWR reply publishes without UI-side smoothing changes");
+}
+
 static void testPreampWireStateRemainsAuthoritative()
 {
     IcomCivBackend backend;
@@ -393,6 +439,7 @@ int main(int argc, char** argv)
     qRegisterMetaType<AetherSDR::MeterDef>("MeterDef");
 
     testStaleSessionFrameIsDropped();
+    testTxMeterMinimumHoldAtBackendSeam();
     testPreampWireStateRemainsAuthoritative();
     testDestructorCancelsWaiter(app);
     testTerminalWaiterReentrySurvivesReset(app);

--- a/tests/icom_meters_test.cpp
+++ b/tests/icom_meters_test.cpp
@@ -242,6 +242,54 @@ static void testPollerVisibilityIsImmediate()
     check(contains(p.due(5000), MeterId::SMeter), "re-showing polls immediately");
 }
 
+static void testPolledTxMeterMinimumHold()
+{
+    MeterPoller p;
+    p.setTransmitting(true);
+
+    // With no real sample in this keyed interval, minimum is the only truth we
+    // have and must be published rather than replaced with stale state.
+    check(p.shouldPublish(MeterId::Swr, 0, 1000, true),
+          "the first keyed SWR minimum is published when there is nothing to hold");
+    check(p.shouldPublish(MeterId::Alc, 0, 1000, true),
+          "the first keyed ALC minimum is published when there is nothing to hold");
+
+    check(p.shouldPublish(MeterId::Swr, 80, 1200, true),
+          "a real SWR sample is published immediately");
+    check(!p.shouldPublish(MeterId::Swr, 0, 1300, true),
+          "an isolated SWR minimum between samples is held");
+    check(p.shouldPublish(MeterId::Swr, 82, 1350, true),
+          "the next real SWR sample replaces the held placeholder immediately");
+
+    check(p.shouldPublish(MeterId::Alc, 60, 1400, true),
+          "a real ALC sample is published immediately");
+    check(!p.shouldPublish(MeterId::Alc, 0, 1500, true),
+          "an isolated ALC minimum between samples is held");
+    check(!p.shouldPublish(MeterId::Alc, 0,
+                           1500 + MeterPoller::kMinimumConfirmationMs - 1, true),
+          "a minimum remains held for the complete confirmation interval");
+    check(p.shouldPublish(MeterId::Alc, 0,
+                          1500 + MeterPoller::kMinimumConfirmationMs, true),
+          "a sustained ALC minimum becomes authoritative");
+
+    // The policy is deliberately not a family-wide meter smoother. Other
+    // readings, including forward power, keep their existing publication.
+    check(p.shouldPublish(MeterId::Power, 0, 2000, true),
+          "the minimum hold does not alter other Icom meters");
+
+    check(p.shouldPublish(MeterId::Swr, 80, 2050, false)
+              && p.shouldPublish(MeterId::Swr, 0, 2100, false),
+          "a model without the meter-profile facet keeps every SWR sample");
+
+    (void)p.shouldPublish(MeterId::Swr, 48, 2200, true);
+    check(!p.shouldPublish(MeterId::Swr, 0, 2250, true),
+          "a keyed SWR minimum can be held before an edge");
+    p.setTransmitting(false);
+    p.setTransmitting(true);
+    check(p.shouldPublish(MeterId::Swr, 0, 2300, true),
+          "a new keyed interval never inherits the previous transmission's hold");
+}
+
 // ---------------------------------------------------------------------------
 // Phase 5 — the model table
 // ---------------------------------------------------------------------------
@@ -304,6 +352,13 @@ static void testModelTable()
     check(mk2 && mk2->scopePoints == 475 && mk2->scopeMaxAmplitude == 160,
           "475 points, 0..160");
     check(mk2 && mk2->tuningMaxHz == 74'800'000ULL, "0.03 to 74.8 MHz");
+    check(ic705 && mk2
+              && profileFor(*ic705).meters.holdIsolatedTxMinimums
+              && profileFor(*mk2).meters.holdIsolatedTxMinimums,
+          "IC-705 and IC-7300MK2 enable their live-proven TX meter minimum hold");
+    check(ic9700 && !profileFor(*ic9700).meters.holdIsolatedTxMinimums
+              && !profileFor(unknownModel()).meters.holdIsolatedTxMinimums,
+          "IC-9700 and unknown Icoms do not borrow the TX meter minimum hold");
     check(ic7300 && mk2 && ic7300->civAddress != mk2->civAddress,
           "and it is a DIFFERENT CI-V address from the original — 0x94 vs 0xB6");
 
@@ -583,6 +638,7 @@ int main()
     testPollerInFlightTimeout();
     testPollerUserGuard();
     testPollerVisibilityIsImmediate();
+    testPolledTxMeterMinimumHold();
     testModelTable();
     testUnknownModelIsConservative();
     testCapabilityProfiles();


### PR DESCRIPTION
Fixes #5215.

## Summary

- Hold the last useful keyed SWR or ALC reading when an IC-705 or IC-7300MK2 returns one isolated CI-V `0000` reply between real samples.
- Publish the next non-minimum sample immediately and accept a sustained minimum after one 200 ms TX-meter interval, preserving legitimate 1:1 SWR and zero ALC.
- Gate the behavior through model profiles below the shared meter seam so IC-9700, unknown Icom radios, FlexRadio, HL2, and common meter ballistics retain their existing behavior.
- Reset candidate state at every TX/RX edge so no reading can leak between keyed intervals.

## Root cause

The Icom backend polls TX meters individually. On the affected radios, SWR (`15 12`) and ALC (`15 13`) can return an isolated raw minimum between useful keyed readings. The backend previously calibrated and emitted every reply through `meterUpdate`.

The common meter widgets correctly treated that emitted minimum as authoritative. Their normal ballistics then moved the dial toward rest before the next real sample moved it back, producing the visible downward pulse. This was not a shared UI smoothing defect, so changing common meter behavior would have risked FlexRadio and HL2 regressions.

## Implementation

### Model-scoped evidence boundary

`MeterCalibrationProfile::holdIsolatedTxMinimums` defaults false and is enabled only for:

- IC-705
- IC-7300MK2

IC-9700 and unknown/unprofiled Icom models fail closed.

### Raw-reply publication policy

`MeterPoller::shouldPublish` applies only while transmitting and only to SWR/ALC:

- A non-minimum reply publishes immediately and seeds the hold.
- The first isolated minimum after it is suppressed.
- A following real reply publishes immediately and cancels the candidate.
- A minimum sustained for a complete 200 ms TX-meter interval publishes as authoritative.
- A minimum received before any useful sample in a new keyed interval publishes normally.
- TX/RX edges reset all candidate state.

Suppressed replies still call `markAnswered`, so CI-V pacing, in-flight bookkeeping, liveness age, and scheduling remain based on the actual radio response.

### Shared-backend protection

No FlexRadio, HL2, `MeterModel`, `SMeterWidget`, gauge, or shared smoothing code changed. Other Icom meters—including forward power—also bypass this policy.

## Verification

Built on macOS with the required 22-way build:

```text
cmake --build build --target AetherSDR -j22
```

Focused headless tests passed:

- `icom_meters_test`
- `icom_backend_test`
- `icom_protocol_test`
- `icom_civ_test`
- `icom_civ_scheduler_test`
- `meter_model_test`
- `s_meter_geometry_test`
- `phone_cw_level_meter_state_test`
- `cross_needle_meter_test`
- `aetherd_meter_decode_test` — Flex meter-status decode
- `hl2_backend_test`
- `hl2_tx_level_policy_test`

Additional checks:

- `tools/check_engine_boundary.py --strict` passed with zero blocking findings.
- `git diff --check` passed.
- The signed commit was verified locally.
- The long backend test passed on isolated rerun after one unrelated asynchronous write-confirmation assertion transient.
- `icom_session_test` was excluded at maintainer direction; its existing RS-BA1 renewal-cadence failure does not compile or link the changed meter sources.

## Hardware proof boundary

The issue is based on live IC-705 and IC-7300MK2 observations, but this branch has not keyed either radio. Repeating live TX proof requires explicit transmit authorization and a confirmed dummy-load path. The deterministic policy and backend-seam tests exercise the exact real/placeholder/real sequence without RF transmission.

A useful follow-up automation verb would inject a synthetic Icom CI-V meter reply into a test session, allowing the bridge to prove needle-hold behavior without keying hardware.

## Scope

- No shared meter UX or visual changes
- No FlexRadio or HL2 command/state changes
- No settings or persistence changes
- No CHANGELOG entry, per project policy

Generated with OpenAI Codex (Daybreak Blue)
