### PR TITLE
feat(gui): persist panadapter button rail collapsed state

### DIFF
--- a/src/gui/DisplaySettings.h
+++ b/src/gui/DisplaySettings.h
@@ -59,6 +59,33 @@ public:
         write(o);
     }
 
+    // The overlay button rail belongs to the client-side display layout. Keep
+    // one value per stable pan slot inside the feature-owned Display document;
+    // radio-assigned pan IDs are not stable across sessions.
+    static bool panMenuExpanded(int panSlotIndex)
+    {
+        if (!isValidPanSlotIndex(panSlotIndex)) {
+            return true;
+        }
+        const QJsonObject slotStates =
+            readObj().value("panMenuExpanded").toObject();
+        return slotStates.value(QString::number(panSlotIndex))
+                   .toString("True") == "True";
+    }
+
+    static void setPanMenuExpanded(int panSlotIndex, bool expanded)
+    {
+        if (!isValidPanSlotIndex(panSlotIndex)) {
+            return;
+        }
+        QJsonObject o = readObj();
+        QJsonObject slotStates = o.value("panMenuExpanded").toObject();
+        slotStates[QString::number(panSlotIndex)] =
+            expanded ? QStringLiteral("True") : QStringLiteral("False");
+        o["panMenuExpanded"] = slotStates;
+        write(o);
+    }
+
     // VFO meter view: false = standard S-meter, true = SmartMTR component.
     // Global (not per-slice) — see MeterViewController for the live-broadcast
     // layer that fans this choice out to every open VFO flag.
@@ -192,6 +219,12 @@ public:
     }
 
 private:
+    static bool isValidPanSlotIndex(int panSlotIndex)
+    {
+        constexpr int kPanSlotCount = 4;
+        return panSlotIndex >= 0 && panSlotIndex < kPanSlotCount;
+    }
+
     static QJsonObject readObj()
     {
         const QString json =

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -989,6 +989,29 @@ void SpectrumOverlayMenu::setPanId(const QString& id)
     refreshAntennaCombo();
 }
 
+void SpectrumOverlayMenu::setPanSlotIndex(int idx)
+{
+    if (m_panSlotIndex == idx)
+        return;
+    m_panSlotIndex = idx;
+
+    // Restore this slot's saved collapsed/expanded state (client-side UI
+    // preference — same per-slot persistence pattern as VfoWidget's
+    // SliceFlagCollapsed_<sliceId>, keyed here by the client-assigned pan
+    // slot rather than a radio-side id).
+    if (m_panSlotIndex < 0)
+        return;
+    auto& s = AppSettings::instance();
+    const bool savedExpanded = s.value(
+        QString("PanMenuExpanded_%1").arg(m_panSlotIndex), "True").toString() == "True";
+    if (savedExpanded != m_expanded) {
+        m_expanded = savedExpanded;
+        if (!m_expanded)
+            hideAllSubPanels();
+        updateLayout();
+    }
+}
+
 void SpectrumOverlayMenu::setRadioModel(RadioModel* model)
 {
     if (m_radioModel)
@@ -1395,6 +1418,14 @@ void SpectrumOverlayMenu::toggle()
     if (!m_expanded)
         hideAllSubPanels();
     updateLayout();
+
+    // Persist per-slot so each panadapter remembers its own collapsed state
+    // across restarts (see setPanSlotIndex()).
+    if (m_panSlotIndex >= 0) {
+        AppSettings::instance().setValue(
+            QString("PanMenuExpanded_%1").arg(m_panSlotIndex),
+            m_expanded ? "True" : "False");
+    }
 }
 
 void SpectrumOverlayMenu::updateLayout()

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1,5 +1,6 @@
 #include "SpectrumOverlayMenu.h"
 #include "DeclaredBandMenuPolicy.h"
+#include "DisplaySettings.h"
 #include "DspParamPopup.h"
 #include "MemoryBrowsePanel.h"
 #include "SpectrumWidget.h"
@@ -12,7 +13,6 @@
 #include "models/SliceModel.h"
 #include "models/BandDefs.h"
 #include "models/BandSettings.h"
-#include "core/AppSettings.h"
 #include "core/KiwiSdrManager.h"
 
 #include <QPushButton>
@@ -991,23 +991,25 @@ void SpectrumOverlayMenu::setPanId(const QString& id)
 
 void SpectrumOverlayMenu::setPanSlotIndex(int idx)
 {
-    if (m_panSlotIndex == idx)
+    if (m_panSlotIndex == idx) {
         return;
+    }
     m_panSlotIndex = idx;
 
     // Restore this slot's saved collapsed/expanded state (client-side UI
     // preference — same per-slot persistence pattern as VfoWidget's
     // SliceFlagCollapsed_<sliceId>, keyed here by the client-assigned pan
     // slot rather than a radio-side id).
-    if (m_panSlotIndex < 0)
+    if (m_panSlotIndex < 0) {
         return;
-    auto& s = AppSettings::instance();
-    const bool savedExpanded = s.value(
-        QString("PanMenuExpanded_%1").arg(m_panSlotIndex), "True").toString() == "True";
+    }
+    const bool savedExpanded =
+        DisplaySettings::panMenuExpanded(m_panSlotIndex);
     if (savedExpanded != m_expanded) {
         m_expanded = savedExpanded;
-        if (!m_expanded)
+        if (!m_expanded) {
             hideAllSubPanels();
+        }
         updateLayout();
     }
 }
@@ -1422,9 +1424,7 @@ void SpectrumOverlayMenu::toggle()
     // Persist per-slot so each panadapter remembers its own collapsed state
     // across restarts (see setPanSlotIndex()).
     if (m_panSlotIndex >= 0) {
-        AppSettings::instance().setValue(
-            QString("PanMenuExpanded_%1").arg(m_panSlotIndex),
-            m_expanded ? "True" : "False");
+        DisplaySettings::setPanMenuExpanded(m_panSlotIndex, m_expanded);
     }
 }
 

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -84,6 +84,14 @@ public:
     void setPanId(const QString& id);
     QString panId() const { return m_panId; }
 
+    // Set the panadapter's stable client-side slot index (SpectrumWidget::panIndex()
+    // — 0, 1, 2, 3 by layout position, distinct from the radio-assigned m_panId
+    // string above). Used to key the persisted collapsed/expanded state of this
+    // menu so each panadapter slot remembers its own preference across restarts
+    // (client-side UI preference, not radio-authoritative — see AGENTS.md
+    // "Settings Authority Policy"). Restores the saved state on first call.
+    void setPanSlotIndex(int idx);
+
     // Connect/disconnect the ANT panel to a slice model.
     void setSlice(SliceModel* slice);
     void setWnbState(bool on, int level);
@@ -255,6 +263,7 @@ signals:
 
 private:
     QString m_panId;
+    int m_panSlotIndex{-1};
     QPointer<PanadapterModel> m_panadapter;
     QMetaObject::Connection m_panRxAntennaConnection;
     QMetaObject::Connection m_panLoopConnection;

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2450,6 +2450,16 @@ QString SpectrumWidget::settingsKey(const QString& base) const
     return QString("%1_%2").arg(base).arg(m_panIndex);
 }
 
+void SpectrumWidget::setPanIndex(int idx)
+{
+    m_panIndex = idx;
+    // Let the overlay menu (the +RX/+TNF/Band/ANT/Display/Memory/DAX button
+    // rail) key its persisted collapsed/expanded state to this slot.
+    if (m_overlayMenu) {
+        m_overlayMenu->setPanSlotIndex(idx);
+    }
+}
+
 void SpectrumWidget::loadSettings()
 {
     auto& s = AppSettings::instance();

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -125,7 +125,7 @@ public:
     ~SpectrumWidget() override;
 
     // Per-pan settings persistence
-    void setPanIndex(int idx) { m_panIndex = idx; }
+    void setPanIndex(int idx);
     int panIndex() const { return m_panIndex; }
     QString settingsKey(const QString& base) const;
     void loadSettings();

--- a/tests/app_settings_safety_test.cpp
+++ b/tests/app_settings_safety_test.cpp
@@ -576,6 +576,41 @@ void testThreeDSliceDepthDefaultAndOptIn()
            "3D Slice Shadow can be disabled again after opting in");
 }
 
+void testPanMenuStateDefaultAndPerSlotPersistence()
+{
+    AppSettings& settings = AppSettings::instance();
+    settings.load();
+
+    expect(DisplaySettings::panMenuExpanded(0),
+           "the panadapter menu defaults expanded when no state exists");
+    expect(DisplaySettings::panMenuExpanded(1),
+           "each additional pan slot defaults expanded independently");
+
+    DisplaySettings::setPanMenuExpanded(0, false);
+    DisplaySettings::setPanMenuExpanded(1, true);
+    expect(!DisplaySettings::panMenuExpanded(0),
+           "slot zero remembers a collapsed menu");
+    expect(DisplaySettings::panMenuExpanded(1),
+           "slot one remains expanded when slot zero is collapsed");
+
+    QString persisted;
+    expect(settings.readAppRowFromDisk(QStringLiteral("Display"), persisted),
+           "pan menu state is committed to the settings database");
+    const QJsonObject slotStates = QJsonDocument::fromJson(persisted.toUtf8())
+                                      .object()
+                                      .value(QStringLiteral("panMenuExpanded"))
+                                      .toObject();
+    expect(slotStates.value(QStringLiteral("0")).toString() == QStringLiteral("False")
+               && slotStates.value(QStringLiteral("1")).toString() == QStringLiteral("True"),
+           "all pan slots share one nested Display configuration object");
+
+    settings.reset();
+    settings.load();
+    expect(!DisplaySettings::panMenuExpanded(0)
+               && DisplaySettings::panMenuExpanded(1),
+           "independent pan menu states survive a settings reload");
+}
+
 // A nickname is stored under a key derived from the radio's MAC, folded to the
 // XML-era sanitized convention by Hl2Discovery::nicknameSettingsKey(). The
 // SQLite store no longer rejects exotic characters, but the sanitized key IS
@@ -816,6 +851,8 @@ int main(int argc, char** argv)
         testDirtyRowSaves();
     } else if (scenario == QStringLiteral("display-slice-depth-default")) {
         testThreeDSliceDepthDefaultAndOptIn();
+    } else if (scenario == QStringLiteral("display-pan-menu-state")) {
+        testPanMenuStateDefaultAndPerSlotPersistence();
     } else if (scenario == QStringLiteral("nickname-key-roundtrip")) {
         testNicknameKeySurvivesDisk();
     } else if (scenario == QStringLiteral("browser-api")) {

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -852,6 +852,7 @@ foreach(APP_SETTINGS_SCENARIO
         newer-schema-readonly
         dirty-row-save
         display-slice-depth-default
+        display-pan-menu-state
         nickname-key-roundtrip
         browser-api)
     add_test(


### PR DESCRIPTION
## Summary
- The VFO flag already persists its collapsed/expanded state per-slice across restarts (`SliceFlagCollapsed_<sliceId>` in `AppSettings`).
- The panadapter's left-side button rail (`+RX`/`+TNF`/`Band`/`ANT`/`Display`/`Memory`/`DAX`, `SpectrumOverlayMenu`) did not — it always reset to expanded on restart. This PR gives it the same treatment.
- State is keyed per-panadapter by the stable client-side slot index (`SpectrumWidget::panIndex()`, 0-3 by layout position — same concept `settingsKey()` already uses for other per-pan client settings), not the radio-assigned pan id, since that id isn't stable across sessions. So Slice A and Slice B panadapters can independently remember collapsed/expanded, matching what's shown in the two attached screenshots.
- This is a client-side UI preference (layout arrangement), not radio-authoritative state, per `AGENTS.md`'s Settings Authority Policy — no toggle needed, it just persists automatically, matching the existing VFO flag behavior.

## Changes
- `SpectrumOverlayMenu`: new `setPanSlotIndex(int)` restores the saved state on assignment; `toggle()` now persists on every collapse/expand.
- `SpectrumWidget::setPanIndex()`: forwards the slot index to its `SpectrumOverlayMenu` (moved out-of-line since the header only forward-declares that class).

## Test plan
- [x] Targeted incremental compile of the two changed translation units (`SpectrumWidget.cpp`, `SpectrumOverlayMenu.cpp`) via ninja/MSVC — clean, no new warnings.
- [ ] Manual: collapse a panadapter's button rail, restart the app, confirm it stays collapsed; confirm a second panadapter's independent state is unaffected.