### PR TITLE
fix(cw): mirror Zero Beat for CWL and let the pitch estimate die with the decoder (#5213)

### DIFF
--- a/src/core/CwDecoder.cpp
+++ b/src/core/CwDecoder.cpp
@@ -62,6 +62,17 @@ void CwDecoder::stop()
     }
 
     m_ggmorse.reset();
+
+    // The estimates died with the ggmorse instance — clear them so a later
+    // Zero Beat can't retune the slice on a pitch from a previous run
+    // (#5213).  Locked values are operator-set state, not estimates: keep
+    // them, or applyDecodeParameters() would feed 0 into a still-pressed
+    // lock button on the next start.
+    if (!m_pitchLocked) m_pitch = 0;
+    if (!m_speedLocked) m_speed = 0;
+    if (!m_pitchLocked || !m_speedLocked)
+        emit statsUpdated(m_pitch, m_speed);
+
     qCDebug(lcDsp) << "CwDecoder: stopped";
 }
 

--- a/src/core/CwDecoder.cpp
+++ b/src/core/CwDecoder.cpp
@@ -70,8 +70,16 @@ void CwDecoder::stop()
     // lock button on the next start.
     if (!m_pitchLocked) m_pitch = 0;
     if (!m_speedLocked) m_speed = 0;
-    if (!m_pitchLocked || !m_speedLocked)
-        emit statsUpdated(m_pitch, m_speed);
+    if (!m_pitchLocked || !m_speedLocked) {
+        // Post the clearing emission through the event queue: the worker's
+        // cross-thread statsUpdated deliveries are queued, so a reading it
+        // posted just before m_running flipped would otherwise arrive AFTER
+        // a direct emit and re-show the dead estimate.  Queued-behind, the
+        // clear always lands last (and dies with the object at shutdown).
+        QMetaObject::invokeMethod(this, [this] {
+            emit statsUpdated(m_pitch, m_speed);
+        }, Qt::QueuedConnection);
+    }
 
     qCDebug(lcDsp) << "CwDecoder: stopped";
 }

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -5723,8 +5723,12 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
         // The beat note sits above the carrier on CWU but below it on CWL,
         // so the correction is mirrored — adding unconditionally doubles a
         // CWL operator's error instead of removing it (#5213).  Same sign
-        // convention as the Kiwi CW BFO (KiwiSdrProtocol.cpp).
-        const int sign = m_radioModel.transmitModel().cwlEnabled() ? -1 : 1;
+        // convention as the Kiwi CW BFO (KiwiSdrProtocol.cpp).  Flex radios
+        // express CWL as mode "CW" plus the transmit flag; Icom/HL2/sim
+        // express it as slice mode "CWL" and never set the flag — honor both.
+        const bool cwl = slice->mode() == QLatin1String("CWL")
+                      || m_radioModel.transmitModel().cwlEnabled();
+        const int sign = cwl ? -1 : 1;
         double offsetMhz = sign * (detected - configured) / 1.0e6;
         applyTuneRequest(slice, slice->frequency() + offsetMhz,
                          TuneIntent::IncrementalTune, "zero-beat");

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -5720,7 +5720,12 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
         float detected = m_cwDecoder.estimatedPitch();
         if (detected <= 0.0f) return;
         int configured = m_radioModel.transmitModel().cwPitch();
-        double offsetMhz = (detected - configured) / 1.0e6;
+        // The beat note sits above the carrier on CWU but below it on CWL,
+        // so the correction is mirrored — adding unconditionally doubles a
+        // CWL operator's error instead of removing it (#5213).  Same sign
+        // convention as the Kiwi CW BFO (KiwiSdrProtocol.cpp).
+        const int sign = m_radioModel.transmitModel().cwlEnabled() ? -1 : 1;
+        double offsetMhz = sign * (detected - configured) / 1.0e6;
         applyTuneRequest(slice, slice->frequency() + offsetMhz,
                          TuneIntent::IncrementalTune, "zero-beat");
     });

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -793,6 +793,8 @@ void PanadapterApplet::setCwStats(float pitchHz, float speedWpm)
 {
     if (pitchHz > 0 && speedWpm > 0)
         m_cwStatsLabel->setText(QString("%1 Hz  %2 WPM").arg(pitchHz, 0, 'f', 0).arg(speedWpm, 0, 'f', 0));
+    else
+        m_cwStatsLabel->clear();   // decoder stopped — don't show a dead estimate (#5213)
 }
 
 void PanadapterApplet::clearCwText()


### PR DESCRIPTION
## Summary

Part of #5213 — a partial fix that stands on its own: it removes the two
behaviors that are outright wrong today. The pitch-window limitation discussed
on the issue is estimator territory and awaits direction; it is not blocked on
this PR and this PR is not blocked on it.

- **CWL sign** (`src/gui/MainWindow_Wiring.cpp`): the handler always *added*
  `(detected − configured)` to the slice frequency. The beat note sits above
  the carrier on CWU but below it on CWL, so on CWL the button doubled the
  error instead of removing it. The offset now mirrors when the slice mode is
  `CWL` **or** the radio reports `cwl_enabled` — Flex expresses CWL as mode
  `CW` plus the transmit flag (`FlexBackend.cpp` is the flag's only producer);
  Icom/HL2/sim express it as the slice mode and never set the flag. The
  mode-string rule is the one the Kiwi CW BFO already uses
  (`src/core/KiwiSdrClient.cpp`, `KiwiSdrProtocol.cpp`).
- **Stale estimate** (`src/core/CwDecoder.cpp`, `src/gui/PanadapterApplet.cpp`):
  `m_pitch` is written by the decode loop and never cleared, so after the
  decoder stops, Zero Beat keeps retuning the slice on the last run's estimate
  and the decode panel keeps showing a dead pitch/WPM reading. `stop()` now
  clears the **unlocked** estimates (locked values are operator-set state, not
  estimates — clearing them would feed 0 into a still-pressed lock button via
  `applyDecodeParameters()`) and emits `statsUpdated` — posted through the
  event queue, so a reading the worker queued just before the stop can never
  land after the clear — and `setCwStats()` resets the label when stats clear.

Deliberately not in this PR (per the staged plan on the issue): the passband
beat-note estimator, a signal-presence threshold, and button feedback — those
are the design decisions the issue comment asks direction on. Restoring the
`959dfa58` enable-gating was considered and dropped for a measured reason:
ggmorse assigns `statistics.estimatedPitch_Hz` unconditionally every frame
(`third_party/ggmorse/src/ggmorse.cpp:703-711`), so while the decoder runs the
estimate is always > 0 (on pure noise it is the loudest bin of the pitch-range
window) and `setEnabled(pitch > 0)` would enable the button on noise; the right
disable condition is exactly the estimator-round threshold question.

## Proof (agent automation bridge, demo radio, RX-only)

Agent-automation-bridge A/B on the demo radio (its non-Plus license path is the only
place the Zero Beat button exists — SmartSDR+ radios show radio-side `Autotune: Once/Loop`
instead, so this code path's whole audience is non-Plus users). Clean builds both arms,
About SHA verified (screenshots in the evidence zip); pitch source = the demo beacon
(beat ≈ 1195 Hz at 14.100 with the decoder's effective default window), configured CW
pitch 600, locks unlocked.

| Arm | Build | Action | Reading |
|---|---|---|---|
| CWU control | main `73738c89` | decoder live (label 1195 Hz), Zero Beat | 14.100000 → 14.100595 (+595 = 1195−600) |
| CWU control | fix `92f27d3f` | same | 14.100000 → 14.1005953 (+595.3) — CWU unchanged; label then re-tracked to 602 Hz (beat ≈ configured pitch: correct end-to-end retune) |
| stale ghost (before) | main `73738c89` | CW panel closed (decoder stopped), Zero Beat | **14.100000 → 14.100595 — retuned on the dead estimate** |
| stale cleared (after) | fix `92f27d3f`, **re-run at head `83e4dad2`** | same | **14.100000 → 14.100000 — no movement** (three reads, both builds) |

The CWL sign arm is not live-benchable on available equipment: the demo sim does not echo
`cw cwl_enabled` (button checks, model state stays false) and SmartSDR+-licensed radios
hide the Zero Beat button. The sign term is verified by code read against the in-repo
precedent (`KiwiSdrProtocol.cpp`, `cwLowerSideband ? -1 : 1`) and the CWU arms above show
the magnitude path unchanged.

## Constitution principle honored

Principle II — the correction consults the radio's live `cwl_enabled` state
instead of assuming a sideband; Principle X — a pitch estimate is a claim that
now dies with the decoder run that produced it.

## Test plan

- [x] Local build passes — clean configure + full build (3009/3009) for BOTH arms,
      macOS (Intel, Qt 6.8.3): fix `92f27d3f` and baseline main `73738c89`
- [x] Behavior verified on a real radio if applicable — **n/a for the button** (the Zero
      Beat button exists only on the non-Plus license branch; available hardware is
      SmartSDR+-licensed) — verified on the demo radio via the agent automation bridge,
      A/B table above
- [x] Existing tests pass (CI) — no test touches this path; **no new unit test**: `m_pitch`
      is written only by the live decode loop or the both-locked `setKnownParameters()`
      path, so an unlocked-clear test has no seam without instrumenting the decoder — the
      bridge A/B is the demonstration layer
- [x] Reproduction steps documented — the issue's own steps; A/B readings above reproduce
      and retire the stale-estimate case

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls — **n/a**, no settings touched
- [x] Code is clean-room
- [x] All meter UI uses `MeterSmoother` — **n/a**
- [x] Documentation updated if user-visible behavior changed — **n/a**: removed behaviors
      (wrong-direction retune, ghost retune) were undocumented defects; no doc page covers
      Zero Beat
- [x] Security-sensitive changes reference a GHSA — **n/a**

[aethersdr-issue5213-zero-beat-ab-2026-08-24.zip](https://github.com/user-attachments/files/31397385/aethersdr-issue5213-zero-beat-ab-2026-08-24.zip)


— authored by agent (Claude Code) on behalf of @skerker


