### PR TITLE
fix: Guard AdifParser field length against signed overflow

### DIFF
--- a/COMMITMSG
+++ b/COMMITMSG
@@ -1,0 +1,8 @@
+fix: Guard AdifParser field length against overflow
+
+Reject non-numeric / negative ADIF field lengths and avoid signed
+addition overflow when slicing the value from the record block.
+
+Fixes #4411
+
+Signed-off-by: Vedant Madane <6527493+VedantMadane@users.noreply.github.com>

--- a/COMMITMSG
+++ b/COMMITMSG
@@ -1,8 +1,0 @@
-fix: Guard AdifParser field length against overflow
-
-Reject non-numeric / negative ADIF field lengths and avoid signed
-addition overflow when slicing the value from the record block.
-
-Fixes #4411
-
-Signed-off-by: Vedant Madane <6527493+VedantMadane@users.noreply.github.com>

--- a/src/core/AdifParser.cpp
+++ b/src/core/AdifParser.cpp
@@ -23,9 +23,14 @@ static QString extractField(const QString& block, const QString& fieldName)
         QRegularExpression::CaseInsensitiveOption);
     auto m = re.match(block);
     if (!m.hasMatch()) return {};
-    int len = m.captured(1).toInt();
-    int start = m.capturedEnd(0);
-    if (start + len > block.length()) return {};
+    // Field lengths are non-negative. toInt() can return 0 on overflow/underflow
+    // and negative values on crafted input — reject those before sizing.
+    bool ok = false;
+    const int len = m.captured(1).toInt(&ok);
+    if (!ok || len < 0) return {};
+    const int start = m.capturedEnd(0);
+    // Guard signed addition overflow and out-of-range slice.
+    if (len > block.length() - start) return {};
     return block.mid(start, len);
 }
 


### PR DESCRIPTION
## Summary

Guard AdifParser field length against signed overflow

## Changes

- AdifParser: parse field lengths as unsigned with overflow/size guards

Fixes #4411
