### PR TITLE
fix(icom): display SpotHub spots through the client model

### DIFF
--- a/docs/architecture/aetherd-touchpoint-tags.json
+++ b/docs/architecture/aetherd-touchpoint-tags.json
@@ -541,7 +541,7 @@
  },
  "core/SpotCommandPolicy.h": {
   "tag": "ui-support",
-  "note": "Settings-backed passive-spots toggle gating whether client emits spot-add cmds; pure AppSettings policy, no radio state",
+  "note": "Passive-spots policy gates spot-add commands from both the operator toggle and a backend-declared client-side fallback; no radio state",
   "split": "",
   "confidence": "medium"
  },

--- a/docs/architecture/aetherd-touchpoints.md
+++ b/docs/architecture/aetherd-touchpoints.md
@@ -125,7 +125,7 @@ Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine
 | `core/SpeProtocol.h` | 1 | — | unconverted |
 | `core/SpectrogramBuffer.h` | 1 | universal — Ring buffer of FFT frames per panadapter feeding CNN classifier patches; pure spectrum data, radio-agnostic. | unconverted |
 | `core/SpotCollectorClient.h` | 2 | ui-support — UDP listener for DXLab SpotCollector desktop app; external integration feeding DxSpot, not radio state | unconverted |
-| `core/SpotCommandPolicy.h` | 4 | ui-support — Settings-backed passive-spots toggle gating whether client emits spot-add cmds; pure AppSettings policy, no radio state | unconverted |
+| `core/SpotCommandPolicy.h` | 4 | ui-support — Passive-spots policy gates spot-add commands from both the operator toggle and a backend-declared client-side fallback; no radio state | unconverted |
 | `core/SpotModeResolver.h` | 4 | universal — Maps DX-cluster spot mode/comment/band-plan to canonical radio mode; pure spot-to-state logic, no vendor ties. | unconverted |
 | `core/StreamStatus.h` | 1 | vendor(flex) — SmartSDR stream-status parsing: client_handle ownership, DAX RX/TX orphan-stream firmware quirks — pure Flex wire logic | unconverted |
 | `core/SupportBundle.h` | 1 | ui-support — Diagnostics bundle: archives logs/sysinfo and opens email client; client-side support tooling, not radio state | unconverted |

--- a/docs/architecture/radio-capabilities-map.md
+++ b/docs/architecture/radio-capabilities-map.md
@@ -66,6 +66,7 @@ traps and why the DAX crash guard is deliberately *not* the DAX capability.
 | `hasFullDuplex` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | Status-bar FDX indicator |
 | `hasWaveforms` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | File ▸ Waveforms… |
 | `hasMultiClientSessions` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | Settings ▸ multiFLEX… |
+| `alwaysUseClientSideSpots` | ❌ | ❌ | ❌ | `MainWindow_Spots.cpp`, `MainWindow_Wiring.cpp` through `SpotCommandPolicy` | Forces SpotHub and manual spots into the existing passive-local `SpotModel` instead of emitting Flex `spot add` commands. Icom: ✅ because CI-V has no compatible spot service. Flex, HL2, and Sim remain under the existing operator Passive toggle. |
 | `hasSupplyVoltageTelemetry` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | PA supply-voltage readout in the status bar. Icom: ✅ only when the active model profile provides a calibrated Vd curve; unprofiled models neither publish nor poll Vd/Id |
 | `hasPaTemperatureTelemetry` | ✅ | ✅ | ❌ | `MainWindow::applyCapabilitiesToUi` | PA-temperature gauge and °C/°F selector in Radio Vitals. Icom: ❌ until a model profile declares and implements a PA-temperature meter; the IC-9700 has no such declared telemetry |
 | `hasMainFanTelemetry` | ✅ | ❌ | ❌ | `MainWindow::applyCapabilitiesToUi` | Main Fan gauge in Radio Vitals. All current Icom models are ❌ because the backend does not publish fan-speed telemetry |

--- a/src/core/SpotCommandPolicy.cpp
+++ b/src/core/SpotCommandPolicy.cpp
@@ -15,9 +15,9 @@ bool passiveSpotsModeEnabled()
         AppSettings::instance().value(kPassiveSpotsModeKey, "False"));
 }
 
-bool shouldSendSpotAddCommands()
+bool shouldSendSpotAddCommands(bool backendAlwaysUsesClientSideSpots)
 {
-    return !passiveSpotsModeEnabled();
+    return !backendAlwaysUsesClientSideSpots && !passiveSpotsModeEnabled();
 }
 
 } // namespace AetherSDR::SpotCommandPolicy

--- a/src/core/SpotCommandPolicy.h
+++ b/src/core/SpotCommandPolicy.h
@@ -8,6 +8,6 @@ inline constexpr const char* kPassiveSpotsModeKey = "PassiveSpotsMode";
 
 bool passiveModeFromSetting(const QVariant& value);
 bool passiveSpotsModeEnabled();
-bool shouldSendSpotAddCommands();
+bool shouldSendSpotAddCommands(bool backendAlwaysUsesClientSideSpots);
 
 } // namespace AetherSDR::SpotCommandPolicy

--- a/src/core/backends/RadioCapabilities.h
+++ b/src/core/backends/RadioCapabilities.h
@@ -567,6 +567,17 @@ struct RadioCapabilities {
     // configuration UI goes away.
     bool hasMultiClientSessions = false;
 
+    // SpotHub spots must stay in the client's SpotModel rather than being
+    // published through the radio's command plane. True for a backend whose
+    // radio protocol has no compatible spot service and which explicitly
+    // chooses the existing passive-local fallback. False preserves the
+    // operator's Passive toggle and every existing radio-publication path.
+    //
+    // This is intentionally a backend policy, not a `family == "icom"` check
+    // above the seam. It lets Icom declare its CI-V limitation without
+    // changing Flex, HL2, or Sim spot behavior.
+    bool alwaysUseClientSideSpots = false;
+
     // The RADIO reports its own position/time from an on-board GNSS receiver, so
     // a client can offer a live GPS readout and the station-location dashboard
     // it feeds.

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -220,6 +220,7 @@ RadioCapabilities FlexBackend::capabilities() const
     caps.hasFullDuplex = true;
     caps.hasWaveforms = true;            // installable SmartSDR waveforms
     caps.hasMultiClientSessions = true;  // multiFLEX
+    caps.alwaysUseClientSideSpots = false;
     // TNFs. Neither FlexLib nor the `tnf` status declares a ceiling — Radio.cs
     // keeps an unbounded list — so this is a UI-side sanity limit rather than a
     // radio-reported one, and it is set high enough never to be the thing that

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -1473,6 +1473,7 @@ RadioCapabilities Hl2Backend::capabilities() const
     c.hasFullDuplex = false;
     c.hasWaveforms = false;             // no installable plugin surface
     c.hasMultiClientSessions = false;   // one client owns the radio
+    c.alwaysUseClientSideSpots = false;
     // Manual notches, and the one piece of DSP on this radio that is NOT absent
     // just because hasRadioSideDsp is false. The notch runs in WDSP on this
     // host, which is the whole point: the HL2 sends raw IQ, so a notch either

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -332,6 +332,10 @@ RadioCapabilities IcomCivBackend::capabilities() const
     c.hasProfiles = false;
     c.hasWaveforms = false;
     c.hasMultiClientSessions = false;
+    // CI-V has no radio-side spot publication/status service. Keep SpotHub
+    // entries in AetherSDR's existing passive SpotModel so they remain visible
+    // without sending Flex `spot add` commands into this backend.
+    c.alwaysUseClientSideSpots = true;
     c.hasRadioSideWaterfallAutoBlack = false;
     c.persistsMemories = false;
 

--- a/src/core/backends/sim/SimBackend.cpp
+++ b/src/core/backends/sim/SimBackend.cpp
@@ -285,6 +285,7 @@ RadioCapabilities SimBackend::capabilities() const
     caps.hasFullDuplex = false;
     caps.hasWaveforms = false;
     caps.hasMultiClientSessions = false;
+    caps.alwaysUseClientSideSpots = false;
     // No manual notch. The synthetic scene has an auto-notch in its mixer, but
     // nothing implements a placed, tracking null — so the +TNF button and the
     // panadapter's add-notch entries stay hidden here rather than appearing and

--- a/src/gui/MainWindow_Spots.cpp
+++ b/src/gui/MainWindow_Spots.cpp
@@ -438,7 +438,8 @@ void MainWindow::wireSpotSubsystem()
         if (isDuplicateSpot(spot)) return;
         const int lifetimeSec = spotLifetimeSeconds(spot, source);
         const QString spotColor = spotColorForSource(spot, source);
-        if (!SpotCommandPolicy::shouldSendSpotAddCommands()) {
+        if (!SpotCommandPolicy::shouldSendSpotAddCommands(
+                m_radioModel.backendCapabilities().alwaysUseClientSideSpots)) {
             addPassiveSpotToModel(spot, source, spotColor, lifetimeSec);
             return;
         }
@@ -468,7 +469,8 @@ void MainWindow::wireSpotSubsystem()
     spotCmdTimer->start(1000);
     connect(spotCmdTimer, &QTimer::timeout, this, [this] {
         if (m_spotCmdBatch.isEmpty() || !m_radioModel.isConnected()) return;
-        if (!SpotCommandPolicy::shouldSendSpotAddCommands()) {
+        if (!SpotCommandPolicy::shouldSendSpotAddCommands(
+                m_radioModel.backendCapabilities().alwaysUseClientSideSpots)) {
             m_spotCmdBatch.clear();
             return;
         }
@@ -713,7 +715,8 @@ void MainWindow::wireSpotSubsystem()
             cmd += " comment=" + QString(colored.comment).replace(' ', QChar(0x7f));
         if (!colored.color.isEmpty())
             cmd += " color=" + colored.color;
-        if (!SpotCommandPolicy::shouldSendSpotAddCommands()) {
+        if (!SpotCommandPolicy::shouldSendSpotAddCommands(
+                m_radioModel.backendCapabilities().alwaysUseClientSideSpots)) {
             addPassiveSpotToModel(colored, "WSJT-X", colored.color,
                                   spotLifetimeSeconds(colored, "WSJT-X"));
             return;

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -4911,7 +4911,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         QString spotColor = as.value("ManualSpotColor", "#00FF00").toString();
         if (spotColor.length() == 7) spotColor = "#FF" + spotColor.mid(1);
         cmd += " color=" + spotColor;
-        if (SpotCommandPolicy::shouldSendSpotAddCommands()) {
+        if (SpotCommandPolicy::shouldSendSpotAddCommands(
+                m_radioModel.backendCapabilities().alwaysUseClientSideSpots)) {
             m_radioModel.sendCommand(cmd);
         } else {
             QMap<QString, QString> kvs;

--- a/tests/passive_spots_policy_test.cpp
+++ b/tests/passive_spots_policy_test.cpp
@@ -3,6 +3,7 @@
 #include "core/SpotCommandPolicy.h"
 
 #include <QCoreApplication>
+#include <QFile>
 #include <QString>
 #include <cstdio>
 
@@ -56,6 +57,38 @@ void testSendPolicyUsesAppSettings()
            !SpotCommandPolicy::shouldSendSpotAddCommands(true));
 }
 
+void testShippingPublicationCallSites()
+{
+    QFile spotSubsystem(
+        QStringLiteral(AETHER_SOURCE_DIR "/src/gui/MainWindow_Spots.cpp"));
+    report("the policy test can inspect the shipping SpotHub wiring",
+           spotSubsystem.open(QIODevice::ReadOnly));
+    const QByteArray spotWiring = spotSubsystem.readAll();
+
+    report("SpotHub sources gate publication on the backend capability",
+           spotWiring.count(
+               "m_radioModel.backendCapabilities().alwaysUseClientSideSpots") == 3);
+    report("SpotHub sources retain the passive-local SpotModel route",
+           spotWiring.contains(
+               "addPassiveSpotToModel(spot, source, spotColor, lifetimeSec);"));
+    report("WSJT-X retains the passive-local SpotModel route",
+           spotWiring.contains(
+               "addPassiveSpotToModel(colored, \"WSJT-X\", colored.color,"));
+
+    QFile panWiring(
+        QStringLiteral(AETHER_SOURCE_DIR "/src/gui/MainWindow_Wiring.cpp"));
+    report("the policy test can inspect the shipping manual-spot wiring",
+           panWiring.open(QIODevice::ReadOnly));
+    const QByteArray manualWiring = panWiring.readAll();
+
+    report("manual spots gate publication on the backend capability",
+           manualWiring.contains(
+               "m_radioModel.backendCapabilities().alwaysUseClientSideSpots"));
+    report("manual spots retain the passive-local SpotModel route",
+           manualWiring.contains(
+               "m_radioModel.spotModel().applySpotStatus(spotId, kvs);"));
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -69,6 +102,7 @@ int main(int argc, char** argv)
 
     testSettingParsing();
     testSendPolicyUsesAppSettings();
+    testShippingPublicationCallSites();
 
     return g_failed == 0 ? 0 : 1;
 }

--- a/tests/passive_spots_policy_test.cpp
+++ b/tests/passive_spots_policy_test.cpp
@@ -36,15 +36,24 @@ void testSendPolicyUsesAppSettings()
     settings.reset();
 
     report("default policy sends spot add commands",
-           SpotCommandPolicy::shouldSendSpotAddCommands());
+           SpotCommandPolicy::shouldSendSpotAddCommands(false));
+
+    report("backend policy forces client-side spots",
+           !SpotCommandPolicy::shouldSendSpotAddCommands(true));
 
     settings.setValue(SpotCommandPolicy::kPassiveSpotsModeKey, "True");
     report("passive mode suppresses spot add commands",
-           !SpotCommandPolicy::shouldSendSpotAddCommands());
+           !SpotCommandPolicy::shouldSendSpotAddCommands(false));
+
+    report("passive mode remains effective for a client-side backend",
+           !SpotCommandPolicy::shouldSendSpotAddCommands(true));
 
     settings.setValue(SpotCommandPolicy::kPassiveSpotsModeKey, "False");
     report("disabling passive mode resumes spot add commands",
-           SpotCommandPolicy::shouldSendSpotAddCommands());
+           SpotCommandPolicy::shouldSendSpotAddCommands(false));
+
+    report("disabling passive mode does not override backend policy",
+           !SpotCommandPolicy::shouldSendSpotAddCommands(true));
 }
 
 } // namespace

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -899,6 +899,8 @@ int main(int argc, char** argv)
               "RadioCapabilities defaults PA temperature telemetry to absent");
         check(!fresh.hasMainFanTelemetry,
               "RadioCapabilities defaults Main Fan telemetry to absent");
+        check(!fresh.alwaysUseClientSideSpots,
+              "RadioCapabilities defaults to the existing operator spot policy");
 
         // Read from each backend's DECLARATION rather than restating it, so a
         // copy-paste that flips either one reds this suite.
@@ -910,6 +912,15 @@ int main(int argc, char** argv)
         const RadioCapabilities hl2Caps = hl2.capabilities();
         const RadioCapabilities simCaps = sim.capabilities();
         const RadioCapabilities icomCaps = icom.capabilities();
+
+        check(!flexCaps.alwaysUseClientSideSpots,
+              "Flex keeps its radio-side spot publication behavior");
+        check(!hl2Caps.alwaysUseClientSideSpots,
+              "HL2 keeps its existing operator-controlled spot behavior");
+        check(!simCaps.alwaysUseClientSideSpots,
+              "Sim keeps its existing operator-controlled spot behavior");
+        check(icomCaps.alwaysUseClientSideSpots,
+              "Icom forces SpotHub spots through the passive client model");
 
         check(!fresh.hasTxFilterControls,
               "RadioCapabilities defaults TX cutoff controls to absent");

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1755,6 +1755,8 @@ add_executable(passive_spots_policy_test
     src/core/SpotCommandPolicy.cpp
 )
 target_include_directories(passive_spots_policy_test PRIVATE src)
+target_compile_definitions(passive_spots_policy_test PRIVATE
+    AETHER_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(passive_spots_policy_test PRIVATE Qt6::Core)
 add_test(NAME passive_spots_policy_test COMMAND passive_spots_policy_test)
 

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1756,6 +1756,7 @@ add_executable(passive_spots_policy_test
 )
 target_include_directories(passive_spots_policy_test PRIVATE src)
 target_link_libraries(passive_spots_policy_test PRIVATE Qt6::Core)
+add_test(NAME passive_spots_policy_test COMMAND passive_spots_policy_test)
 
 add_executable(spot_mode_resolver_test
     tests/spot_mode_resolver_test.cpp


### PR DESCRIPTION
## Summary

Fixes #5227.

SpotHub's normal publication path sends Flex SmartSDR `spot add` commands and relies on radio spot status to populate AetherSDR's `SpotModel`. Networked Icom radios have no compatible CI-V spot command/status service, so IC-705 and IC-7300MK2 sessions dropped that command path and never received the model update needed to render a panadapter spot.

This change gives radio backends an explicit `alwaysUseClientSideSpots` policy. Icom enables it and feeds SpotHub, WSJT-X, and manual spots through the existing passive/local `SpotModel`; the client retains the existing deduplication, color, click-to-tune, removal, and lifetime-expiry behavior without trying to upload the spot to the radio.

The capability defaults to false. Flex, HL2, and Sim therefore retain their existing behavior, and the operator's global Passive toggle remains authoritative everywhere it already applied.

### Behavior boundary

| Backend | Spot behavior after this PR |
|---|---|
| Flex | Unchanged: native radio `spot add`/status path unless the operator enables Passive mode |
| Icom | SpotHub/WSJT-X/manual spots always stay in the AetherSDR client model; no unsupported CI-V publication attempt |
| HL2 | Unchanged: existing operator-controlled policy |
| Sim | Unchanged: existing operator-controlled policy |

### Implementation details

- Adds a default-false backend capability instead of branching on `family == "icom"` above `IRadioBackend`.
- Enables the capability only in `IcomCivBackend::capabilities()`.
- Combines the backend fallback with the existing `PassiveSpotsMode` policy at every SpotHub/WSJT-X/manual publication call site.
- Extends policy and backend-capability tests to pin the Icom override and the Flex/HL2/Sim defaults.
- Registers the existing `passive_spots_policy_test` executable with CTest; it previously compiled but was not executed by CTest/CI.
- Updates the capability map and aetherd touchpoint descriptions. No `CHANGELOG.md` entry is added.

## Constitution principle honored

Principle II — the radio is authoritative on live state. Icom CI-V does not expose a radio-side spot service, so the client no longer pretends that a Flex command can create radio-owned spot state. Client-only SpotHub state remains explicitly client-owned.

## Test plan

- [x] Local build passes (`cmake --build build -j22`)
- [ ] Behavior verified on a real radio if applicable — maintainer will validate the built app manually on IC-705/IC-7300MK2
- [x] Existing focused tests pass: 4/4 headless
- [x] Reproduction steps and use cases documented in #5227

Focused command:

```text
QT_QPA_PLATFORM=offscreen ctest --test-dir build -j22 -R '^(passive_spots_policy_test|radio_capability_gating_test|spot_mode_resolver_test|spot_auto_scroll_test)$' --output-on-failure
```

Additional validation:

- `git diff --check`
- `python3 -m json.tool docs/architecture/aetherd-touchpoint-tags.json`
- `python3 tools/check_engine_boundary.py --strict` — 0 blocking findings
- `python3 tools/check_test_registration.py --strict`
- Synthetic `git merge-tree --write-tree origin/main HEAD` succeeds against current `origin/main` (`73738c89`)

`icom_backend_test` was not included in the final focused run at the maintainer's request; the Icom capability declaration is exercised by `radio_capability_gating_test`.

### Manual validation recipe

1. Connect to an IC-705 or IC-7300MK2.
2. Leave SpotHub's Passive option off to exercise the backend-forced fallback.
3. Enable a DX Cluster/other SpotHub source or WSJT-X and wait for an in-range spot.
4. Confirm the spot appears on the panadapter, clicking it tunes the receiver, and source removal or lifetime expiry removes it.
5. Optionally connect a FlexRadio and confirm Passive-off spots still use the native radio publication path.

## Checklist

- [x] Commit is signed and verified with the configured ED25519 signing key
- [x] No new flat-key `AppSettings` calls — the existing Passive setting is only read through `SpotCommandPolicy`
- [x] Code is clean-room — based on AetherSDR's existing spot path and public/official Icom protocol references, not proprietary binary analysis
- [x] Meter UI checklist item is not applicable; no meter code or UI changed
- [x] Documentation updated in the capability map and architecture touchpoint inventory; `CHANGELOG.md` is untouched
- [x] Security-sensitive checklist item is not applicable

### Suggested automation follow-up

A future `spots inject|list` automation-bridge verb would allow deterministic source ingestion and rendered-model assertions without waiting for an external spot feed.

Generated with OpenAI Codex (Daybreak Blue)
