### PR TITLE
feat(icom): expose custom RS-BA1 ports on the manual connect panel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,7 +382,7 @@ jobs:
         # the weekly sanitizers job would repeat the hasVfoModeCommand lesson
         # in the comment above: the assertion existed, nothing on a PR ran it,
         # and all four checks stayed green. ~21 s for the pair.
-        run: ctest --test-dir build -R "^(icom_(civ|civ_scheduler|meters|backend|family)|rf_gain_presentation)_test$" --output-on-failure
+        run: ctest --test-dir build -R "^(icom_(civ|civ_scheduler|meters|backend|family|settings)|rf_gain_presentation)_test$" --output-on-failure
 
       # Mirrors check-windows' "sccache stats" step, and exists for the same
       # reason: #1963 disabled the Windows compiler cache for three months

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -2605,16 +2605,49 @@ void ConnectionPanel::probeRadio(const QString& ip, bool restoreSavedFamily)
         if (m_manualIcomPortsCheck && m_manualIcomPortsCheck->isChecked()
             && m_manualIcomControlPortEdit && m_manualIcomSerialPortEdit
             && m_manualIcomAudioPortEdit) {
-            const QString controlText = m_manualIcomControlPortEdit->text().trimmed();
-            const QString serialText  = m_manualIcomSerialPortEdit->text().trimmed();
-            const QString audioText   = m_manualIcomAudioPortEdit->text().trimmed();
-            const quint16 control = controlText.isEmpty()
-                ? icom::kControlPort : static_cast<quint16>(controlText.toUInt());
-            const quint16 serial = serialText.isEmpty()
-                ? icom::kSerialPort : static_cast<quint16>(serialText.toUInt());
-            const quint16 audio = audioText.isEmpty()
-                ? icom::kAudioPort : static_cast<quint16>(audioText.toUInt());
-            IcomSettings::setPorts(control, serial, audio);
+            // PARSE WITH `ok`, AND REFUSE RATHER THAN SUBSTITUTE — the same
+            // reasoning as the CI-V address below, and for the same reason.
+            //
+            // The QIntValidator on these fields is NOT the range guarantee: Qt
+            // validators gate interactive keystrokes only, so anything that
+            // assigns text directly — the automation bridge's `invoke … setText`,
+            // a restored value, a future programmatic caller — lands unvalidated.
+            // Measured, not assumed: `setText 999999` sticks, and an unguarded
+            // static_cast<quint16> silently truncated it to 16959, which is IN
+            // range, so neither setPorts()'s zero-check nor IcomSettings' own
+            // portOr() read guard would catch it. The operator would then get a
+            // connect timeout blaming the radio for their typo — exactly the
+            // symptom IcomSettings.h says these fields exist to cure.
+            struct PortField {
+                QLineEdit*  edit;
+                quint16     fallback;
+                const char* label;
+            };
+            const PortField fields[] = {
+                {m_manualIcomControlPortEdit, icom::kControlPort, "Control"},
+                {m_manualIcomSerialPortEdit,  icom::kSerialPort,  "CI-V"},
+                {m_manualIcomAudioPortEdit,   icom::kAudioPort,   "Audio"},
+            };
+            quint16 parsed[3] = {};
+            for (int i = 0; i < 3; ++i) {
+                const QString text = fields[i].edit->text().trimmed();
+                if (text.isEmpty()) {
+                    parsed[i] = fields[i].fallback;
+                    continue;
+                }
+                bool ok = false;
+                const uint value = text.toUInt(&ok);
+                if (!ok || value < 1 || value > 65535) {
+                    setStatusText(tr("%1 port \"%2\" is not a number between 1 and 65535 "
+                                     "— not connecting.")
+                                      .arg(QLatin1String(fields[i].label), text));
+                    fields[i].edit->setFocus();
+                    fields[i].edit->selectAll();
+                    return;
+                }
+                parsed[i] = static_cast<quint16>(value);
+            }
+            IcomSettings::setPorts(parsed[0], parsed[1], parsed[2]);
         } else {
             IcomSettings::setPorts(icom::kControlPort, icom::kSerialPort, icom::kAudioPort);
         }

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -2,6 +2,7 @@
 #include "core/AppSettings.h"
 #include "core/backends/hl2/Hl2Discovery.h"   // shared nickname + MAC->serial helpers
 #include "core/backends/icom/IcomCredentials.h"  // password -> OS keychain, never settings
+#include "core/backends/icom/IcomProtocol.h"     // icom::kControlPort/kSerialPort/kAudioPort
 #include "core/backends/icom/IcomSettings.h"     // host/user/ports (Principle V)
 #include "core/backends/icom/IcomModels.h"       // knownModels() -> the chooser's items
 #include "core/backends/hl2/MetisProtocol.h"  // discoveryRequest/parseDiscoveryReply, kMetisPort
@@ -26,6 +27,7 @@
 #include <QFrame>
 #include <QGroupBox>
 #include <QHBoxLayout>
+#include <QIntValidator>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -826,6 +828,64 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     // left in as a comment promising something it does not do.
     connect(m_manualIcomCivCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
             this, [this](int) { syncIcomCivCustomRow(); });
+
+    // Custom RS-BA1 ports — hidden behind a checkbox, same reasoning as the
+    // CI-V custom row above: rarely needed (Icom's own defaults work for a
+    // single radio behind a single IP), but without it a radio whose ports
+    // were moved on the network side — a second Icom behind the same NAT/port-
+    // forward, or a router that only forwards one port group — is completely
+    // unreachable. #5051.
+    m_manualIcomPortsCheck = new QCheckBox(tr("Use non-default ports"), manualGroup);
+    m_manualIcomPortsCheck->setObjectName(QStringLiteral("connectionManualIcomPortsCheck"));
+    m_manualIcomPortsCheck->setAccessibleDescription(
+        tr("Override the RS-BA1 control/CI-V/audio port numbers — needed when the radio's "
+           "own ports were changed, or a router forwards this radio to a different port "
+           "group (e.g. a second Icom behind the same external IP)."));
+    m_manualIcomPortsRow = addManualRow(QStringLiteral("Icom ports:"), m_manualIcomPortsCheck);
+
+    auto* portsRowWidget = new QWidget(manualGroup);
+    auto* portsRow = new QHBoxLayout(portsRowWidget);
+    portsRow->setContentsMargins(0, 0, 0, 0);
+    portsRow->setSpacing(8);
+    // 1-65535 — Icom radios use plain UDP/TCP ports; leaving a field blank
+    // falls back to IcomSettings' own default (the compile-time constant) at
+    // read time, not the empty string being coerced to port 0.
+    auto* portValidator = new QIntValidator(1, 65535, this);
+    const auto makePortField = [&](const QString& objectName, const QString& placeholder,
+                                    const QString& accessibleName) -> QLineEdit* {
+        auto* edit = new QLineEdit(portsRowWidget);
+        edit->setObjectName(objectName);
+        edit->setValidator(portValidator);
+        edit->setPlaceholderText(placeholder);
+        edit->setAccessibleName(accessibleName);
+        edit->setMinimumHeight(kManualFieldHeight);
+        portsRow->addWidget(edit, 1);
+        return edit;
+    };
+    m_manualIcomControlPortEdit = makePortField(
+        QStringLiteral("connectionManualIcomControlPort"),
+        QString::number(icom::kControlPort), tr("Control port"));
+    m_manualIcomSerialPortEdit = makePortField(
+        QStringLiteral("connectionManualIcomCivPort"),
+        QString::number(icom::kSerialPort), tr("CI-V port"));
+    m_manualIcomAudioPortEdit = makePortField(
+        QStringLiteral("connectionManualIcomAudioPort"),
+        QString::number(icom::kAudioPort), tr("Audio port"));
+    m_manualIcomPortsCustomRow =
+        addManualRow(QStringLiteral("Control/CI-V/audio:"), portsRowWidget);
+
+    connect(m_manualIcomPortsCheck, &QCheckBox::toggled, this, [this](bool checked) {
+        if (m_manualIcomPortsCustomRow)
+            m_manualIcomPortsCustomRow->setVisible(checked);
+        if (!checked) {
+            // Blank fields read as "use IcomSettings' defaults" — see
+            // syncIcomPortsRow() — so unchecking clears any half-typed
+            // override rather than leaving stale digits behind a hidden row.
+            if (m_manualIcomControlPortEdit) m_manualIcomControlPortEdit->clear();
+            if (m_manualIcomSerialPortEdit)  m_manualIcomSerialPortEdit->clear();
+            if (m_manualIcomAudioPortEdit)   m_manualIcomAudioPortEdit->clear();
+        }
+    });
 
     // One column, set from the widest label. Rows that are hidden for a family
     // still count: the Icom rows appear and disappear as the operator changes
@@ -2213,6 +2273,37 @@ void ConnectionPanel::syncIcomCivCustomRow()
     m_manualIcomCivCustomRow->setVisible(icom && custom);
 }
 
+// Seeds the checkbox + fields from IcomSettings the first time the Icom
+// family is selected, same isEmpty()-guarded pattern as m_manualIpEdit /
+// m_manualIcomUserEdit above — a value already typed this session is never
+// clobbered by a settings read triggered from elsewhere (applySavedSource-
+// Selection() picking a recent host, for instance).
+void ConnectionPanel::syncIcomPortsRow()
+{
+    if (!m_manualIcomPortsCheck || !m_manualIcomPortsCustomRow)
+        return;
+    if (currentManualFamily() == QLatin1String(kFamilyIcom)
+        && m_manualIcomControlPortEdit && m_manualIcomControlPortEdit->text().isEmpty()
+        && m_manualIcomSerialPortEdit  && m_manualIcomSerialPortEdit->text().isEmpty()
+        && m_manualIcomAudioPortEdit   && m_manualIcomAudioPortEdit->text().isEmpty()
+        && !m_manualIcomPortsCheck->isChecked()) {
+        const quint16 control = IcomSettings::controlPort();
+        const quint16 serial  = IcomSettings::serialPort();
+        const quint16 audio   = IcomSettings::audioPort();
+        const bool nonDefault = control != icom::kControlPort
+                              || serial  != icom::kSerialPort
+                              || audio   != icom::kAudioPort;
+        if (nonDefault) {
+            m_manualIcomControlPortEdit->setText(QString::number(control));
+            m_manualIcomSerialPortEdit->setText(QString::number(serial));
+            m_manualIcomAudioPortEdit->setText(QString::number(audio));
+            const QSignalBlocker blocker(m_manualIcomPortsCheck);
+            m_manualIcomPortsCheck->setChecked(true);
+        }
+    }
+    m_manualIcomPortsCustomRow->setVisible(m_manualIcomPortsCheck->isChecked());
+}
+
 void ConnectionPanel::updateManualFamilyHints()
 {
     const QString family = currentManualFamily();
@@ -2230,6 +2321,9 @@ void ConnectionPanel::updateManualFamilyHints()
     // The hex row has a second condition — "Custom..." — so it gets the shared
     // helper rather than a copy of the visibility rule.
     syncIcomCivCustomRow();
+    if (m_manualIcomPortsRow)
+        m_manualIcomPortsRow->setVisible(icom);
+    syncIcomPortsRow();
 
     if (icom) {
         // Fill from settings, and read the password out of the keychain — which
@@ -2503,6 +2597,27 @@ void ConnectionPanel::probeRadio(const QString& ip, bool restoreSavedFamily)
         }
 
         IcomSettings::setUsername(user);
+        // Unchecked, or checked with every field blank: write the compile-time
+        // defaults back, same as an unset CI-V address falls back to auto below
+        // — an operator who ticked the box, typed nothing and connected anyway
+        // gets the standard ports, not port 0 (an empty QLineEdit::text().toUInt()
+        // is 0, and IcomCivBackend would happily bind that).
+        if (m_manualIcomPortsCheck && m_manualIcomPortsCheck->isChecked()
+            && m_manualIcomControlPortEdit && m_manualIcomSerialPortEdit
+            && m_manualIcomAudioPortEdit) {
+            const QString controlText = m_manualIcomControlPortEdit->text().trimmed();
+            const QString serialText  = m_manualIcomSerialPortEdit->text().trimmed();
+            const QString audioText   = m_manualIcomAudioPortEdit->text().trimmed();
+            const quint16 control = controlText.isEmpty()
+                ? icom::kControlPort : static_cast<quint16>(controlText.toUInt());
+            const quint16 serial = serialText.isEmpty()
+                ? icom::kSerialPort : static_cast<quint16>(serialText.toUInt());
+            const quint16 audio = audioText.isEmpty()
+                ? icom::kAudioPort : static_cast<quint16>(audioText.toUInt());
+            IcomSettings::setPorts(control, serial, audio);
+        } else {
+            IcomSettings::setPorts(icom::kControlPort, icom::kSerialPort, icom::kAudioPort);
+        }
         // Hex, with or without an 0x prefix or a trailing h — the radio's own
         // menu writes it as "A2h", so accept what the operator is looking at.
         // An unparseable or out-of-range entry is IGNORED rather than clamped:

--- a/src/gui/ConnectionPanel.h
+++ b/src/gui/ConnectionPanel.h
@@ -268,6 +268,18 @@ private:
     QLineEdit*   m_manualIcomCivEdit{nullptr};
     void         populateIcomCivCombo();
     void         syncIcomCivCustomRow();
+    // Custom RS-BA1 ports. Off by default: the fields are blank until the
+    // checkbox is ticked, and IcomSettings::setPorts() only writes non-default
+    // values when it is — see syncIcomPortsRow(). #5051 (NAT/port-forwarding
+    // with multiple Icom radios behind one external IP: only the port group
+    // baked into the connect path could be reached).
+    QWidget*     m_manualIcomPortsRow{nullptr};
+    QCheckBox*   m_manualIcomPortsCheck{nullptr};
+    QWidget*     m_manualIcomPortsCustomRow{nullptr};
+    QLineEdit*   m_manualIcomControlPortEdit{nullptr};
+    QLineEdit*   m_manualIcomSerialPortEdit{nullptr};
+    QLineEdit*   m_manualIcomAudioPortEdit{nullptr};
+    void         syncIcomPortsRow();
     // Staged by probeRadio(), committed by setConnected(true), discarded on
     // failure. A password is only worth persisting once the radio has said it
     // is the right one.

--- a/tests/icom_settings_test.cpp
+++ b/tests/icom_settings_test.cpp
@@ -73,6 +73,30 @@ int main(int argc, char** argv)
     check(IcomSettings::serialPort() == icom::kSerialPort, "an out-of-range port falls back too");
     check(IcomSettings::civAddress() == 0xA4, "and so does a zero CI-V address");
 
+    // THE READ GUARD ABOVE CANNOT SEE A TRUNCATED PORT, and that is the point
+    // of this block. setPorts() takes quint16, so an out-of-range value has
+    // already wrapped by the time it arrives: a caller that parses "999999"
+    // with an unguarded static_cast hands over 16959, which is a perfectly
+    // legal port. portOr() accepts it, the document stores it, and every
+    // subsequent connect quietly dials the wrong one — presenting as the
+    // connect timeout that IcomSettings.h says these fields exist to cure.
+    //
+    // The narrow contract this pins: the RANGE CHECK BELONGS TO THE CALLER,
+    // before the quint16 conversion. Asserted here so a future caller that
+    // reintroduces the bare cast has something to fail against — it is not
+    // catchable below this seam (regression: the first revision of the
+    // #5051/#5225 connect-panel port fields did exactly this).
+    IcomSettings::setPorts(static_cast<quint16>(999999u), 50005, 50006);
+    check(IcomSettings::controlPort() == 16959,
+          "setPorts() cannot rescue a value the caller already truncated — "
+          "999999 arrives as 16959 and is stored verbatim");
+    check(IcomSettings::controlPort() != icom::kControlPort,
+          "and it is NOT quietly corrected to the default, which is why the "
+          "caller must range-check before converting");
+
+    // Restore a sane document for the rest of the file.
+    IcomSettings::reset();
+
     // ---- THE SECURITY PROPERTY --------------------------------------------
     //
     // ("Icom", "Password") is registered in SettingsCredentialPolicy, so a


### PR DESCRIPTION
Addresses #5051 (@Davegte) and its duplicate #5225 (@F4CQA): there is no way to override the control / CI-V / audio UDP ports on an Icom network connect, so a second Icom behind the same external IP (NAT / port-forwarding), or a radio whose ports were changed in its own Network menu, cannot be reached at all.

## What was already there

Nearly all of it. The settings document, the persistence, and the connect-request assembly already exist end-to-end:

- `IcomSettings::controlPort()/serialPort()/audioPort()/setPorts()` — `IcomSettings.cpp:101-123`
- `RadioModel::populateFamilyParams()` already reads them into `request.params` — `RadioModel.cpp:614-615`
- `IcomCivBackend::connectRadio()` already prefers `request.port` / `request.params` over the compile-time constants — `IcomCivBackend.cpp:552-556`
- `ConnectionPanel` already reads `IcomSettings::controlPort()` into `info.port` on the manual path

`IcomSettings.h:40-43` says this was the intent from the start:

> The three UDP ports. Defaults are Icom's, and all three are operator-changeable ON THE RADIO — which is why they are settings rather than constants. A mismatch presents as a connect timeout that names the wrong cause, **so the dialog exposes them.**

The dialog never did. `IcomSettings::setPorts()` had no caller anywhere in `src/`. This PR is the missing UI, not new plumbing.

## What this adds

A **"Use non-default ports"** checkbox on the Icom manual-connect rows, unchecked by default, which reveals three validated (`QIntValidator`, 1–65535) port fields — Control / CI-V / Audio — with the standard values as placeholders.

Design notes:

- **Hidden by default**, following the CI-V custom-address row directly above it: this is a rare setting and the common case should not have to look at it.
- **Unticking clears the fields** rather than leaving stale digits behind a hidden row.
- **Ticked-but-blank falls back to the compile-time defaults**, not port 0 — an empty `QLineEdit::text().toUInt()` is `0`, and the backend would bind that.
- **Seeds from settings**: if a non-default port set is already persisted, selecting Icom re-ticks the box and repopulates the fields, guarded by the same `isEmpty()` check the sibling user/password/IP fields use so a value being typed is never clobbered.
- **Stable `objectName`s** on all three fields (`connectionManualIcomControlPort` / `…CivPort` / `…AudioPort`) so the automation bridge can drive them.

## Verification

Built clean (MSVC / Qt 6.10.3) and driven through the automation bridge against **a live IC-9700**, on the exact configuration this feature exists for:

```
invoke connectionManualRadioType setCurrentIndex 2      → "Icom (network)"
invoke connectionManualIcomPortsCheck click             → fields revealed
invoke connectionManualIcomControlPort setText 50004
invoke connectionManualIcomCivPort     setText 50005
invoke connectionManualIcomAudioPort   setText 50006
invoke connectionManualConnectButton click
connect wait 10000
  → {"connected": true, "model": "IC-9700", "serial": "icom:10.0.0.8"}
```

The radio was set to ports **50004/50005/50006** on its own Network menu for this test — a genuine non-default configuration, not a simulated one. Disconnected cleanly afterwards.

## Not exercised

- The **discovery** path — this is the manual / "Connect by IP" panel only. Icom radios are not auto-discovered, so that is the whole surface, but worth stating.
- **Non-Windows** — built and driven on Windows. The change is pure Qt widget code with no platform branches.
- The **persistence round-trip across a restart** was not driven end-to-end; the seeding logic is read-verified rather than relaunch-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)