### PR TITLE
feat(icom): add custom UDP port triplets for multi-radio NAT

### DIFF
--- a/src/core/backends/icom/IcomSettings.cpp
+++ b/src/core/backends/icom/IcomSettings.cpp
@@ -124,6 +124,35 @@ void IcomSettings::setPorts(quint16 control, quint16 serial, quint16 audio)
     writeObj(obj);
 }
 
+quint16 IcomSettings::defaultBasePort()
+{
+    return icom::kControlPort;
+}
+
+quint16 IcomSettings::maximumBasePort()
+{
+    return 65533;
+}
+
+bool IcomSettings::usesDefaultPorts()
+{
+    return controlPort() == icom::kControlPort
+        && serialPort() == icom::kSerialPort
+        && audioPort() == icom::kAudioPort;
+}
+
+void IcomSettings::setBasePort(quint16 basePort)
+{
+    if (basePort == 0 || basePort > maximumBasePort()) {
+        setPorts(icom::kControlPort, icom::kSerialPort, icom::kAudioPort);
+        return;
+    }
+
+    setPorts(basePort,
+             static_cast<quint16>(basePort + 1),
+             static_cast<quint16>(basePort + 2));
+}
+
 std::uint8_t IcomSettings::civAddress()
 {
     const int v = readObj().value(QLatin1String(kFieldCivAddress)).toInt(IcomSettings::kDefaultCivAddress);

--- a/src/core/backends/icom/IcomSettings.h
+++ b/src/core/backends/icom/IcomSettings.h
@@ -46,6 +46,14 @@ public:
     static quint16 audioPort();
     static void setPorts(quint16 control, quint16 serial, quint16 audio);
 
+    // Connect-by-IP NAT convenience: the public forwards are one sequential
+    // triplet (control, CI-V, audio). The highest valid base is 65533 so the
+    // derived audio port remains inside the UDP port range.
+    static quint16 defaultBasePort();
+    static quint16 maximumBasePort();
+    static bool usesDefaultPorts();
+    static void setBasePort(quint16 basePort);
+
     // The radio's CI-V address. Seeded here and CORRECTED at runtime from the
     // 0x19 0x00 reply — never trusted as final, because the address is
     // user-changeable and several Icom models speak this same transport.

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -34,6 +34,7 @@
 #include <QScreen>
 #include <QSignalBlocker>
 #include <QSizePolicy>
+#include <QSpinBox>
 #include <QStyle>
 #include <QTcpSocket>
 #include <QHostInfo>
@@ -194,6 +195,18 @@ RadioBindSettings bindSettingsFromProfile(const QJsonObject& profile)
     settings.interfaceName = bind.value("interface_name").toString();
     settings.bindAddress = QHostAddress(bind.value("last_successful_ipv4").toString());
     return settings;
+}
+
+bool icomBasePortFromProfile(const QJsonObject& profile, quint16* basePort)
+{
+    const int stored = profile.value("icom").toObject().value("base_port").toInt(0);
+    if (stored <= 0 || stored > IcomSettings::maximumBasePort()) {
+        return false;
+    }
+    if (basePort) {
+        *basePort = static_cast<quint16>(stored);
+    }
+    return true;
 }
 
 QString staleSelectionText(const RadioBindSettings& settings)
@@ -750,9 +763,49 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     ThemeManager::instance().applyStyleSheet(m_manualIcomPassEdit, lineEditStyle);
     m_manualIcomPassRow = addManualRow(QStringLiteral("Icom password:"), m_manualIcomPassEdit);
 
-    // The CI-V address is the third thing the operator has to read off the
-    // radio, alongside the two above — theirs live in the Network menu, this
-    // one in Connectors > CI-V. Without it the address can only ever be the
+    // The RS-BA1 transport is always three UDP ports: control, CI-V and audio.
+    // NAT deployments commonly forward several radios through one public IP,
+    // so the operator chooses only the first external port and the next two are
+    // derived. The ordinary on-radio triplet remains the zero-effort default.
+    m_manualIcomPortCombo = new QComboBox(manualGroup);
+    m_manualIcomPortCombo->setObjectName(QStringLiteral("connectionManualIcomPortMode"));
+    m_manualIcomPortCombo->setAccessibleName(tr("Icom network ports"));
+    m_manualIcomPortCombo->setAccessibleDescription(
+        tr("Use the standard Icom UDP ports, or choose a custom first port for NAT. "
+           "The CI-V and audio ports are the next two sequential ports."));
+    AetherSDR::applyComboStyle(m_manualIcomPortCombo, comboExtraRules);
+    m_manualIcomPortCombo->addItem(
+        tr("Standard (%1–%2)")
+            .arg(IcomSettings::defaultBasePort())
+            .arg(IcomSettings::defaultBasePort() + 2),
+        QStringLiteral("__standard__"));
+    m_manualIcomPortCombo->addItem(tr("Custom NAT ports..."),
+                                   QStringLiteral("__custom__"));
+    m_manualIcomPortRow =
+        addManualRow(QStringLiteral("Icom ports:"), m_manualIcomPortCombo);
+
+    m_manualIcomBasePortSpin = new QSpinBox(manualGroup);
+    m_manualIcomBasePortSpin->setObjectName(QStringLiteral("connectionManualIcomBasePort"));
+    m_manualIcomBasePortSpin->setAccessibleName(tr("Icom first UDP port"));
+    m_manualIcomBasePortSpin->setAccessibleDescription(
+        tr("First external UDP port forwarded to the radio. AetherSDR also uses the next "
+           "two ports for CI-V and audio."));
+    m_manualIcomBasePortSpin->setRange(1, IcomSettings::maximumBasePort());
+    m_manualIcomBasePortSpin->setValue(IcomSettings::controlPort());
+    m_manualIcomBasePortSpin->setToolTip(
+        tr("First of three sequential UDP ports: control, CI-V, audio"));
+    m_manualIcomPortCustomRow =
+        addManualRow(QStringLiteral("First UDP port:"), m_manualIcomBasePortSpin);
+
+    if (!IcomSettings::usesDefaultPorts()) {
+        m_manualIcomPortCombo->setCurrentIndex(1);
+    }
+    connect(m_manualIcomPortCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, [this](int) { syncIcomPortCustomRow(); });
+
+    // The CI-V address is another value the operator may have to read off the
+    // radio. The network credentials live in the Network menu, while this one
+    // lives in Connectors > CI-V. Without it the address can only ever be the
     // IC-705 default, and every other model in kModels is unreachable: CI-V is
     // addressed, so an IC-9700 on 0xA2 silently ignores everything sent to
     // 0xA4. No ID reply, no model, and the conservative unknown fallback means
@@ -2052,6 +2105,23 @@ void ConnectionPanel::applySavedSourceSelection(const QString& ip, bool restoreF
     if (restoreFamily)
         setManualFamily(familyFromProfile(profile));
 
+    // The external port triplet belongs to the routed endpoint, not to the
+    // physical Icom model. Restore it only when the operator chose a saved
+    // address (or startup restored one), never while an editable address is
+    // being typed character by character.
+    if (restoreFamily
+        && familyFromProfile(profile) == QLatin1String(kFamilyIcom)
+        && m_manualIcomPortCombo && m_manualIcomBasePortSpin) {
+        quint16 basePort = IcomSettings::defaultBasePort();
+        const bool hasSavedBasePort = icomBasePortFromProfile(profile, &basePort);
+        const bool standard = !hasSavedBasePort
+            || basePort == IcomSettings::defaultBasePort();
+        m_manualIcomPortCombo->setCurrentIndex(standard ? 0 : 1);
+        m_manualIcomBasePortSpin->setValue(
+            standard ? IcomSettings::defaultBasePort() : basePort);
+        syncIcomPortCustomRow();
+    }
+
     RadioBindSettings settings = bindSettingsFromProfile(profile);
     if (settings.mode == RadioBindMode::Explicit) {
         const auto resolved = NetworkPathResolver::resolveExplicitSelection(
@@ -2213,23 +2283,49 @@ void ConnectionPanel::syncIcomCivCustomRow()
     m_manualIcomCivCustomRow->setVisible(icom && custom);
 }
 
+void ConnectionPanel::syncIcomPortCustomRow()
+{
+    if (!m_manualIcomPortCombo || !m_manualIcomPortCustomRow) {
+        return;
+    }
+    const bool icom = currentManualFamily() == QLatin1String(kFamilyIcom);
+    const bool custom =
+        m_manualIcomPortCombo->currentData().toString() == QLatin1String("__custom__");
+    m_manualIcomPortCustomRow->setVisible(icom && custom);
+}
+
+quint16 ConnectionPanel::selectedIcomBasePort() const
+{
+    if (m_manualIcomPortCombo && m_manualIcomBasePortSpin
+        && m_manualIcomPortCombo->currentData().toString()
+               == QLatin1String("__custom__")) {
+        return static_cast<quint16>(m_manualIcomBasePortSpin->value());
+    }
+    return IcomSettings::defaultBasePort();
+}
+
 void ConnectionPanel::updateManualFamilyHints()
 {
     const QString family = currentManualFamily();
     const bool hl2  = family == QLatin1String(kFamilyHl2);
     const bool icom = family == QLatin1String(kFamilyIcom);
 
-    // The credential pair belongs to Icom alone. Hiding the row CONTAINERS
-    // rather than the fields keeps their labels from being left behind.
+    // The credentials and network selectors belong to Icom alone. Hiding the
+    // row CONTAINERS rather than the fields keeps their labels from being left
+    // behind.
     if (m_manualIcomUserRow)
         m_manualIcomUserRow->setVisible(icom);
     if (m_manualIcomPassRow)
         m_manualIcomPassRow->setVisible(icom);
+    if (m_manualIcomPortRow) {
+        m_manualIcomPortRow->setVisible(icom);
+    }
     if (m_manualIcomCivRow)
         m_manualIcomCivRow->setVisible(icom);
     // The hex row has a second condition — "Custom..." — so it gets the shared
     // helper rather than a copy of the visibility rule.
     syncIcomCivCustomRow();
+    syncIcomPortCustomRow();
 
     if (icom) {
         // Fill from settings, and read the password out of the keychain — which
@@ -2281,7 +2377,8 @@ void ConnectionPanel::updateManualFamilyHints()
             icom
                 ? QStringLiteral(
                       "Enter the radio address and the network user name and password "
-                      "configured for network control. %1")
+                      "configured for network control. Standard UDP ports are used unless "
+                      "you choose a custom three-port NAT range. %1")
                       .arg(passwordStorageHint)
                 : hl2
                 ? QStringLiteral(
@@ -2359,6 +2456,13 @@ void ConnectionPanel::saveManualProfile(const QString& targetIp,
     bind["interface_name"] = settings.interfaceName;
     bind["last_successful_ipv4"] = lastSuccessfulLocalIp.toString();
     profile["bind"] = bind;
+
+    if (currentManualFamily() == QLatin1String(kFamilyIcom)) {
+        QJsonObject icom;
+        icom["base_port"] = selectedIcomBasePort();
+        profile["icom"] = icom;
+        profile["schema_version"] = 2;
+    }
 
     profiles[targetIp] = profile;
     saveRoutedProfiles(profiles);
@@ -2561,8 +2665,17 @@ void ConnectionPanel::probeRadio(const QString& ip, bool restoreSavedFamily)
             }
         }
 
-        // NOT setLastHost, and NOT save(), until the radio has actually
-        // accepted us.
+        // One operator value describes the complete RS-BA1 forwarding rule.
+        // The radio transport always opens control, CI-V and audio as three
+        // independent UDP streams, in that order. Bound the base in the widget
+        // and again in IcomSettings so base+2 can never wrap past 65535.
+        const quint16 basePort = selectedIcomBasePort();
+        IcomSettings::setBasePort(basePort);
+
+        // Do NOT setLastHost or save the credential until the radio has
+        // actually accepted us. The non-secret port choice is safe to retain
+        // immediately so a retry and the backend's reconnect timer use the
+        // same forwarding triplet.
         //
         // Both used to run here, before the connect was even attempted. One
         // mistyped password therefore replaced a working keychain entry with a
@@ -2608,13 +2721,15 @@ void ConnectionPanel::probeRadio(const QString& ip, bool restoreSavedFamily)
         RadioInfo info;
         info.family   = QString::fromLatin1(kFamilyIcom);
         info.address  = resolved;
-        info.port     = IcomSettings::controlPort();
+        info.port     = basePort;
         info.model    = QStringLiteral("Icom");
         info.name     = info.model;
         // No discovery means no MAC and no reported serial, so the host is the
         // only stable identity this radio has for us. It has to be SOMETHING:
         // the restore/persist scope keys off it.
-        info.serial   = QStringLiteral("icom:%1").arg(resolved.toString());
+        info.serial   = basePort == IcomSettings::defaultBasePort()
+            ? QStringLiteral("icom:%1").arg(resolved.toString())
+            : QStringLiteral("icom:%1:%2").arg(resolved.toString()).arg(basePort);
         info.nickname = info.model;
         // Manual Icom sessions use the same retention path as routed Flex and
         // HL2 sessions. Without this marker MainWindow removes

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -1349,6 +1349,7 @@ void ConnectionPanel::clearPendingIcomCredentials()
     m_pendingIcomPassword.clear();
     m_pendingIcomHost.clear();
     m_pendingIcomResolvedHost.clear();
+    m_pendingIcomBasePort = 0;
     m_pendingIcomBindSettings = RadioBindSettings{};
     m_pendingIcomSessionBindAddress.clear();
 }
@@ -1376,22 +1377,23 @@ void ConnectionPanel::setConnected(bool connected)
             // host and credentials together.
             saveManualProfile(m_pendingIcomHost,
                               m_pendingIcomBindSettings,
-                              m_pendingIcomSessionBindAddress);
+                              m_pendingIcomSessionBindAddress,
+                              m_pendingIcomBasePort);
             if (m_pendingIcomResolvedHost != m_pendingIcomHost) {
                 // MainWindow retains the resolved address in LastRoutedRadioIp.
                 // Mirror the profile under that key as well so a hostname such
                 // as ic-705.local still restores the Icom family at startup.
                 saveManualProfile(m_pendingIcomResolvedHost,
                                   m_pendingIcomBindSettings,
-                                  m_pendingIcomSessionBindAddress);
+                                  m_pendingIcomSessionBindAddress,
+                                  m_pendingIcomBasePort);
             }
         }
     }
     if (!connected || !m_pendingIcomPassword.isEmpty()) {
         // Cleared on BOTH edges: a failed attempt must not commit on the next
         // unrelated connect, and a committed one must not commit twice.
-        m_pendingIcomPassword.clear();
-        m_pendingIcomHost.clear();
+        clearPendingIcomCredentials();
     }
 
     m_connected = connected;
@@ -2436,7 +2438,8 @@ void ConnectionPanel::rememberManualIp(const QString& ip)
 
 void ConnectionPanel::saveManualProfile(const QString& targetIp,
                                         const RadioBindSettings& settings,
-                                        const QHostAddress& lastSuccessfulLocalIp)
+                                        const QHostAddress& lastSuccessfulLocalIp,
+                                        quint16 icomBasePort)
 {
     if (targetIp.trimmed().isEmpty())
         return;
@@ -2459,7 +2462,10 @@ void ConnectionPanel::saveManualProfile(const QString& targetIp,
 
     if (currentManualFamily() == QLatin1String(kFamilyIcom)) {
         QJsonObject icom;
-        icom["base_port"] = selectedIcomBasePort();
+        const quint16 basePort = icomBasePort != 0
+            ? icomBasePort
+            : selectedIcomBasePort();
+        icom["base_port"] = basePort;
         profile["icom"] = icom;
         profile["schema_version"] = 2;
     }
@@ -2691,6 +2697,7 @@ void ConnectionPanel::probeRadio(const QString& ip, bool restoreSavedFamily)
         IcomCredentials::setSessionPassword(pass);
         m_pendingIcomHost = trimmedIp;
         m_pendingIcomPassword = pass;
+        m_pendingIcomBasePort = basePort;
         m_pendingIcomBindSettings = bindSettings;
         m_pendingIcomSessionBindAddress =
             bindSettings.mode == RadioBindMode::Explicit

--- a/src/gui/ConnectionPanel.h
+++ b/src/gui/ConnectionPanel.h
@@ -23,6 +23,7 @@
 class QVBoxLayout;
 class QScreen;
 class QScrollArea;
+class QSpinBox;
 
 namespace AetherSDR {
 
@@ -253,6 +254,8 @@ private:
     // orphan labels behind.
     QWidget*     m_manualIcomUserRow{nullptr};
     QWidget*     m_manualIcomPassRow{nullptr};
+    QWidget*     m_manualIcomPortRow{nullptr};
+    QWidget*     m_manualIcomPortCustomRow{nullptr};
     QWidget*     m_manualIcomCivRow{nullptr};
     // The hex entry's own row, shown only for "Custom...". Separate from the
     // combo's row so the two can be hidden independently — the label column is
@@ -261,6 +264,8 @@ private:
     QWidget*     m_manualIcomCivCustomRow{nullptr};
     QLineEdit*   m_manualIcomUserEdit{nullptr};
     QLineEdit*   m_manualIcomPassEdit{nullptr};
+    QComboBox*   m_manualIcomPortCombo{nullptr};
+    QSpinBox*    m_manualIcomBasePortSpin{nullptr};
     // The model chooser. Non-editable: it enumerates a known set with an escape
     // hatch, which is populateSerialPortCombo's job, not m_manualIpCombo's
     // recent-values history.
@@ -268,6 +273,8 @@ private:
     QLineEdit*   m_manualIcomCivEdit{nullptr};
     void         populateIcomCivCombo();
     void         syncIcomCivCustomRow();
+    void         syncIcomPortCustomRow();
+    quint16      selectedIcomBasePort() const;
     // Staged by probeRadio(), committed by setConnected(true), discarded on
     // failure. A password is only worth persisting once the radio has said it
     // is the right one.

--- a/src/gui/ConnectionPanel.h
+++ b/src/gui/ConnectionPanel.h
@@ -198,7 +198,8 @@ private:
     QScreen* screenFitTarget(QScreen* preferredScreen) const;
     void saveManualProfile(const QString& targetIp,
                            const RadioBindSettings& settings,
-                           const QHostAddress& lastSuccessfulLocalIp);
+                           const QHostAddress& lastSuccessfulLocalIp,
+                           quint16 icomBasePort = 0);
     void saveLowBandwidthPreference(bool enabled);
     void setManualMessage(const QString& text, bool error = false);
     QString formatLocalRadioLabel(const RadioInfo& radio) const;
@@ -285,6 +286,7 @@ private:
     QString      m_pendingIcomPassword;
     QString      m_pendingIcomHost;
     QString      m_pendingIcomResolvedHost;
+    quint16      m_pendingIcomBasePort{0};
     RadioBindSettings m_pendingIcomBindSettings;
     QHostAddress m_pendingIcomSessionBindAddress;
     QLineEdit*   m_manualIpEdit{nullptr};

--- a/tests/connection_panel_size_test.cpp
+++ b/tests/connection_panel_size_test.cpp
@@ -11,6 +11,7 @@
 #include <QApplication>
 #include <QComboBox>
 #include <QFont>
+#include <QJsonDocument>
 #include <QLabel>
 #include <QLayout>
 #include <QLineEdit>
@@ -219,6 +220,12 @@ void checkIcomCustomNatPorts()
     report("custom NAT range derives the audio port",
            IcomSettings::audioPort() == 52003);
 
+    // The authenticated endpoint is the one emitted above. Editing the still-
+    // visible field while that request is in flight must not change what a
+    // later success callback retains for restart.
+    if (basePort) {
+        basePort->setValue(51001);
+    }
     panel.setConnected(true);
     const QJsonObject profiles = QJsonDocument::fromJson(
         settings.value(QStringLiteral("RoutedProfilesJson"), QStringLiteral("{}"))
@@ -226,7 +233,7 @@ void checkIcomCustomNatPorts()
     const int savedBase = profiles.value(QStringLiteral("127.0.0.1"))
                               .toObject().value(QStringLiteral("icom"))
                               .toObject().value(QStringLiteral("base_port")).toInt();
-    report("successful routed profile retains the custom base port", savedBase == 52001);
+    report("successful routed profile retains the requested base port", savedBase == 52001);
 
     if (hadIcom) {
         settings.setValue(QStringLiteral("Icom"), previousIcom);

--- a/tests/connection_panel_size_test.cpp
+++ b/tests/connection_panel_size_test.cpp
@@ -3,6 +3,8 @@
 
 #include "TestSettingsProfile.h"
 #include "core/AppSettings.h"
+#include "core/backends/icom/IcomCredentials.h"
+#include "core/backends/icom/IcomSettings.h"
 #include "gui/ConnectionPanel.h"
 
 #include <QAbstractButton>
@@ -16,6 +18,7 @@
 #include <QScreen>
 #include <QScrollArea>
 #include <QScrollBar>
+#include <QSpinBox>
 #include <QSpacerItem>
 #include <QStyle>
 #include <QToolButton>
@@ -133,6 +136,115 @@ void checkIcomManualGuidanceIsModelNeutral()
     report("Icom address example is model-neutral",
            ip && !ip->placeholderText().contains(QStringLiteral("IC-705"),
                                                   Qt::CaseInsensitive));
+}
+
+void checkIcomCustomNatPorts()
+{
+    auto& settings = AppSettings::instance();
+    const bool hadIcom = settings.contains(QStringLiteral("Icom"));
+    const QVariant previousIcom = settings.value(QStringLiteral("Icom"));
+    const bool hadProfiles = settings.contains(QStringLiteral("RoutedProfilesJson"));
+    const QVariant previousProfiles = settings.value(QStringLiteral("RoutedProfilesJson"));
+    const bool hadRecent = settings.contains(QStringLiteral("RecentConnectByIpAddresses"));
+    const QVariant previousRecent = settings.value(QStringLiteral("RecentConnectByIpAddresses"));
+
+    IcomSettings::reset();
+
+    ConnectionPanel panel;
+    auto* manualMode =
+        panel.findChild<QAbstractButton*>(QStringLiteral("connectionManualModeButton"));
+    auto* radioType =
+        panel.findChild<QComboBox*>(QStringLiteral("connectionManualRadioType"));
+    auto* portMode =
+        panel.findChild<QComboBox*>(QStringLiteral("connectionManualIcomPortMode"));
+    auto* basePort =
+        panel.findChild<QSpinBox*>(QStringLiteral("connectionManualIcomBasePort"));
+    auto* user = panel.findChild<QLineEdit*>(QStringLiteral("connectionManualIcomUser"));
+    auto* password =
+        panel.findChild<QLineEdit*>(QStringLiteral("connectionManualIcomPassword"));
+
+    if (manualMode) {
+        manualMode->click();
+    }
+    const int icomIndex = radioType
+        ? radioType->findData(QString::fromLatin1(ConnectionPanel::kFamilyIcom))
+        : -1;
+    if (radioType && icomIndex >= 0) {
+        radioType->setCurrentIndex(icomIndex);
+    }
+    QApplication::processEvents();
+
+    report("Icom connect-by-IP defaults to standard UDP ports",
+           portMode
+               && portMode->currentData().toString() == QStringLiteral("__standard__"));
+    report("custom NAT base port stays hidden in standard mode",
+           basePort && !basePort->isVisibleTo(&panel));
+
+    const int customIndex = portMode
+        ? portMode->findData(QStringLiteral("__custom__"))
+        : -1;
+    if (portMode && customIndex >= 0) {
+        portMode->setCurrentIndex(customIndex);
+    }
+    if (basePort) {
+        basePort->setValue(52001);
+    }
+    if (user) {
+        user->setText(QStringLiteral("test-user"));
+    }
+    if (password) {
+        password->setText(QStringLiteral("test-password"));
+    }
+    QApplication::processEvents();
+
+    report("custom NAT mode reveals the first UDP port",
+           basePort && basePort->isVisibleTo(&panel));
+
+    bool emitted = false;
+    RadioInfo requested;
+    QObject::connect(&panel, &ConnectionPanel::connectRequested,
+                     [&emitted, &requested](const RadioInfo& info) {
+        emitted = true;
+        requested = info;
+    });
+    panel.probeRadio(QStringLiteral("127.0.0.1"));
+
+    report("custom NAT Icom emits a connection request", emitted);
+    report("custom NAT base port becomes the control destination",
+           emitted && requested.port == 52001);
+    report("custom NAT endpoint has a port-qualified radio identity",
+           emitted && requested.serial == QStringLiteral("icom:127.0.0.1:52001"));
+    report("custom NAT range derives the CI-V port",
+           IcomSettings::serialPort() == 52002);
+    report("custom NAT range derives the audio port",
+           IcomSettings::audioPort() == 52003);
+
+    panel.setConnected(true);
+    const QJsonObject profiles = QJsonDocument::fromJson(
+        settings.value(QStringLiteral("RoutedProfilesJson"), QStringLiteral("{}"))
+            .toString().toUtf8()).object();
+    const int savedBase = profiles.value(QStringLiteral("127.0.0.1"))
+                              .toObject().value(QStringLiteral("icom"))
+                              .toObject().value(QStringLiteral("base_port")).toInt();
+    report("successful routed profile retains the custom base port", savedBase == 52001);
+
+    if (hadIcom) {
+        settings.setValue(QStringLiteral("Icom"), previousIcom);
+    } else {
+        settings.remove(QStringLiteral("Icom"));
+    }
+    if (hadProfiles) {
+        settings.setValue(QStringLiteral("RoutedProfilesJson"), previousProfiles);
+    } else {
+        settings.remove(QStringLiteral("RoutedProfilesJson"));
+    }
+    if (hadRecent) {
+        settings.setValue(QStringLiteral("RecentConnectByIpAddresses"), previousRecent);
+    } else {
+        settings.remove(QStringLiteral("RecentConnectByIpAddresses"));
+    }
+    settings.save();
+    IcomCredentials::clearSession();
 }
 
 bool setScaledApplicationFont(QApplication& app,
@@ -528,6 +640,7 @@ int main(int argc, char** argv)
 
     app.setFont(originalFont);
     checkIcomManualGuidanceIsModelNeutral();
+    checkIcomCustomNatPorts();
     checkIcomUsesRoutedRetention();
     std::printf("\n%s\n", g_failed == 0 ? "ALL PASS" : "FAILURES PRESENT");
     return g_failed == 0 ? 0 : 1;

--- a/tests/icom_settings_test.cpp
+++ b/tests/icom_settings_test.cpp
@@ -49,6 +49,11 @@ int main(int argc, char** argv)
     // ---- the non-secret document round-trips ------------------------------
     IcomSettings::reset();
     check(IcomSettings::username().isEmpty(), "no username by default");
+    check(IcomSettings::defaultBasePort() == icom::kControlPort,
+          "the UI default is the ordinary Icom control port");
+    check(IcomSettings::maximumBasePort() == 65533,
+          "a sequential triplet leaves room for base plus two");
+    check(IcomSettings::usesDefaultPorts(), "the default triplet is reported as standard");
     check(IcomSettings::controlPort() == icom::kControlPort, "default control port 50001");
     check(IcomSettings::serialPort() == icom::kSerialPort, "default serial port 50002");
     check(IcomSettings::audioPort() == icom::kAudioPort, "default audio port 50003");
@@ -61,7 +66,16 @@ int main(int argc, char** argv)
     check(IcomSettings::username() == QStringLiteral("beer"), "username round-trips");
     check(IcomSettings::lastHost() == QStringLiteral("ic-705.local"), "host round-trips");
     check(IcomSettings::serialPort() == 51002, "ports round-trip");
+    check(!IcomSettings::usesDefaultPorts(), "a custom triplet is not reported as standard");
     check(IcomSettings::civAddress() == 0xB6, "the MK2's address round-trips");
+
+    IcomSettings::setBasePort(52001);
+    check(IcomSettings::controlPort() == 52001, "custom base port becomes control");
+    check(IcomSettings::serialPort() == 52002, "custom base plus one becomes CI-V");
+    check(IcomSettings::audioPort() == 52003, "custom base plus two becomes audio");
+
+    IcomSettings::setBasePort(65534);
+    check(IcomSettings::usesDefaultPorts(), "a base that cannot fit three ports fails safe");
 
     // A hand-edited or truncated file must not command a nonsense port — 0 in
     // particular would bind an ephemeral local port and then tell the radio to


### PR DESCRIPTION
## Summary

Add an Icom-only UDP port selector to **Connect by IP** for stations that expose multiple networked Icom radios through one public address.

The standard RS-BA1 triplet remains the default:

- control: `50001`
- CI-V: `50002`
- audio: `50003`

Selecting **Custom NAT ports...** asks for only the first external UDP port. AetherSDR derives the CI-V and audio destinations as `base + 1` and `base + 2`, matching the sequential port-forwarding layout requested in #5051 and #5225.

Closes #5051
Closes #5225

## Operator use case

A station may have an IC-705, IC-9700, and IC-7300MK2 behind the same router. Each radio still listens on its normal internal RS-BA1 ports, while the router exposes distinct external triplets, for example:

| Radio | Public UDP triplet | Internal destination |
| --- | --- | --- |
| IC-705 | `50001-50003` | IC-705 `50001-50003` |
| IC-9700 | `51001-51003` | IC-9700 `50001-50003` |
| IC-7300MK2 | `52001-52003` | IC-7300MK2 `50001-50003` |

The operator enters the shared public IP, chooses **Custom NAT ports...**, and supplies `51001` or `52001`. No `:port` suffix is required in the IP field.

## Implementation

- Add **Icom ports** and conditional **First UDP port** rows to Connect by IP.
- Preserve `50001-50003` as the zero-configuration default.
- Restrict the base to `1-65533`, ensuring the derived audio port cannot overflow the UDP range.
- Apply the derived triplet atomically through `IcomSettings` before constructing the connection request.
- Carry the control port through `RadioInfo::port`; the existing neutral family-parameter seam carries CI-V and audio ports to `IcomCivBackend`.
- Persist the last successful Icom base port in the routed-address profile and treat legacy profiles without that field as standard-port profiles.
- Keep the legacy identity `icom:<address>` for standard-port connections, while custom endpoints use `icom:<address>:<base>` so two radios reached through the same public IP do not share a persistence identity.

## Compatibility and isolation

- The controls are visible only when **Icom (network)** is selected.
- FlexRadio and Hermes-Lite 2 connect paths, identities, profiles, and backend parameters are unchanged.
- No CI-V command, model capability, calibration, scheduler, audio, or meter behavior changes.
- Existing Icom installs continue using `50001-50003` unless the operator explicitly selects the custom NAT option.
- Invalid programmatic base ports fail closed to the standard triplet.

## Verification

- macOS RelWithDebInfo app build with `cmake --build build -j22` — passed at `4b21674c`.
- Headless focused suite — 4/4 passed:
  - `icom_settings_test`
  - `icom_family_test`
  - `radio_capability_gating_test`
  - `connection_panel_size_test`
- Standalone headless `icom_backend_test` — 1/1 passed. It was kept isolated because its UDP fixture binds fixed local ports.
- Automation bridge UI proof:
  - standard mode defaults to `50001-50003` with the custom field hidden;
  - custom mode reveals the field and accepts base `52001`;
  - the derived request uses `52001`, `52002`, and `52003`;
  - both port controls hide after switching the family to FlexRadio;
  - rendered ConnectionPanel inspected with no clipping or overlap.
- Accessibility checker — 0 findings.
- Engine-boundary strict check — no new/blocking findings; the existing tracked `ConnectionPanel.h` Flex include remains the sole legacy warning.
- Test-registration check and `git diff --check` — passed.
- Hosted CI at `4b21674c` — Linux build/tests, macOS Qt 6.8.3, Windows, and Static Checks all passed.
- Review follow-up at `4b21674c`:
  - added the direct `QJsonDocument` include required by Qt 6.8.3;
  - staged the requested base port through authentication and added a timing regression proving a later widget edit cannot change the retained endpoint.

## Proof boundary

The UI, request construction, port derivation, profile retention, backend fixture, and cross-family hiding are covered. No live remote Icom/NAT connection was available for this PR, so hardware proof of three translated WAN forwards remains pending operator validation.

## Follow-up automation opportunity

Extend the bridge `connect ip` verb with an optional Icom base-port argument. That would let future tests exercise the complete NAT connection path without generic widget invocation.

Generated with OpenAI Codex (Daybreak Blue)
