### PR TITLE
Split synthetic transport tests by verification layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
       - name: Test meter geometry and gauge scaling
         env:
           QT_QPA_PLATFORM: offscreen
-        run: ctest --test-dir build -R "cross_needle_meter_test|hgauge_range_test|hgauge_hover_popup_test" --output-on-failure
+        run: ctest --test-dir build -R "cross_needle_meter_test|hgauge_range_test|hgauge_hover_popup_test" --no-tests=error --output-on-failure
 
       # band_edges_test joins the gate for the reason stated above the meter
       # tests: it pins a defect that every existing assertion in the tree was
@@ -220,7 +220,7 @@ jobs:
       # emission token out of a 60m segment fails here rather than showing up as
       # voice markers that quietly never appear.
       - name: Test band edges and band-plan voice labels
-        run: ctest --test-dir build -R "band_edges_test|bandplan_voice_labels_test" --output-on-failure
+        run: ctest --test-dir build -R "band_edges_test|bandplan_voice_labels_test" --no-tests=error --output-on-failure
 
       # The workspace-canvas suites (RFC #4887) join the gate on the same
       # rationale, and for a specific reason: their whole value proposition is
@@ -244,7 +244,7 @@ jobs:
       - name: Test workspace canvas
         env:
           QT_QPA_PLATFORM: offscreen
-        run: ctest --test-dir build -R "^workspace_" --output-on-failure
+        run: ctest --test-dir build -R "^workspace_" --no-tests=error --output-on-failure
 
       # Slippy-map world wrap. Same reasoning as the step above: the target is
       # already linked by Build, the test runs in milliseconds, and it touches
@@ -256,19 +256,19 @@ jobs:
       - name: Test map wrap
         env:
           QT_QPA_PLATFORM: offscreen
-        run: ctest --test-dir build -R "^map_wrap_test$" --output-on-failure
+        run: ctest --test-dir build -R "^map_wrap_test$" --no-tests=error --output-on-failure
 
       # PSK Reporter query scope, parser bounds, rate-limit backoff, path
       # unwrapping, and solar-position math. Pure Core test with no network.
       - name: Test PSK Reporter map behavior
-        run: ctest --test-dir build -R "^psk_reporter_map_behavior_test$" --output-on-failure
+        run: ctest --test-dir build -R "^psk_reporter_map_behavior_test$" --no-tests=error --output-on-failure
 
       # Async marker/path/terminator cache replacement must retain visible
       # content and cancel superseded work. Offscreen GUI test, no network.
       - name: Test PSK Reporter map live updates
         env:
           QT_QPA_PLATFORM: offscreen
-        run: ctest --test-dir build -R "^map_live_update_test$" --output-on-failure
+        run: ctest --test-dir build -R "^map_live_update_test$" --no-tests=error --output-on-failure
 
       # The demo RX engine's worker-thread contract (#4878): affinity, 24 kHz
       # pacing on a coarse timer, keyed-mute, stallscope. This is the fix for
@@ -278,7 +278,7 @@ jobs:
       - name: Test demo backend threading
         env:
           QT_QPA_PLATFORM: offscreen
-        run: ctest --test-dir build -R "^sim_signal_source_test$" --output-on-failure
+        run: ctest --test-dir build -R "^sim_signal_source_test$" --no-tests=error --output-on-failure
 
       # The MIDI settings store and the #4888 profile import/export boundary:
       # the .map/XML importers (a parser fed contributor-supplied files —
@@ -296,19 +296,19 @@ jobs:
       # (RelWithDebInfo, Intel Mac), against a target the Build step already
       # linked.
       - name: Test MIDI settings and profile import/export
-        run: ctest --test-dir build -R "^midi_settings_test$" --output-on-failure
+        run: ctest --test-dir build -R "^midi_settings_test$" --no-tests=error --output-on-failure
 
       # NR2's AGC recovery and settings migration claims are deterministic,
       # headless, and already built by the Linux `all` target. Run them on PRs
       # so a compiled-but-unexecuted regression cannot merge unnoticed.
       - name: Test NR2 DSP and settings migration
-        run: ctest --test-dir build -R "^(spectral_nr|nr2_settings_model)_test$" --output-on-failure
+        run: ctest --test-dir build -R "^(spectral_nr|nr2_settings_model)_test$" --no-tests=error --output-on-failure
 
       # Restored after #4877 bounded FFTW planning for every test. This step was
       # previously 188-190 s on a cold runner; it now measures ~3 s while still
       # exercising six four-second AM/SAM audio bursts through the real HL2 DSP.
       - name: Test HL2 AM/SAM DC blocker
-        run: ctest --test-dir build -R "^hl2_am_dcblock_test$" --output-on-failure
+        run: ctest --test-dir build -R "^hl2_am_dcblock_test$" --no-tests=error --output-on-failure
 
       # ulanzi_mapping_migration_test was on this gate (added by #4834) and is
       # not any more. Unlike hl2_am_dcblock_test above it was not costing
@@ -338,7 +338,7 @@ jobs:
       # target the Build step already linked. The one event-loop wait polls to
       # a deadline, so a loaded runner makes it slower rather than red.
       - name: Test TCI protocol parsing and malformed-input rejection
-        run: ctest --test-dir build -R "^tci_protocol_test$" --output-on-failure
+        run: ctest --test-dir build -R "^tci_protocol_test$" --no-tests=error --output-on-failure
 
       # The TX capture path joins the gate for the reason stated above the TCI
       # step: its defects are the invisible kind. Capture negotiation has no UI
@@ -356,7 +356,7 @@ jobs:
       # no audio device, no event loop, no wall clock -- and run in well under a
       # second against targets the Build step already linked.
       - name: Test TX capture format negotiation and voice-strip framing
-        run: ctest --test-dir build -R "^(audio_format_negotiation_test|tx_mic_channel_normalizer_test|tx_voice_processor_test)$" --output-on-failure
+        run: ctest --test-dir build -R "^(audio_format_negotiation_test|tx_mic_channel_normalizer_test|tx_voice_processor_test)$" --no-tests=error --output-on-failure
 
       # THE CI-V MODE MAP IS INVISIBLE FROM THE UI. A missing arm in
       # modeFromNeutral() does not throw, does not log, and does not fail to
@@ -375,10 +375,16 @@ jobs:
       # file ran that target either. A capability flag that gates which frame
       # reaches the radio is exactly the kind of claim worth failing a merge on.
       - name: Test Icom CI-V codec, model table and command scheduler
-        # Enumerate every retained target and fail if the expression ever
-        # selects none. ctest otherwise exits 0 for an empty selection, which
-        # let the retired icom_backend_test disappear from this gate silently.
-        run: ctest --test-dir build -R "^(icom_civ_test|icom_civ_scheduler_test|icom_meters_test|icom_family_test|rf_gain_presentation_test)$" --no-tests=error --output-on-failure
+        # Guard both erosion modes. --no-tests=error fails an EMPTY selection,
+        # but ctest still exits 0 when a proper subset matches — which is
+        # exactly how the retired icom_backend_test disappeared from this gate
+        # while four other names kept it green. The count pin below fails the
+        # step the moment any single enumerated target stops registering.
+        env:
+          ICOM_GATE: "^(icom_civ_test|icom_civ_scheduler_test|icom_meters_test|icom_family_test|rf_gain_presentation_test)$"
+        run: |
+          test "$(ctest --test-dir build -N -R "$ICOM_GATE" | sed -n 's/^Total Tests: //p')" = "5"
+          ctest --test-dir build -R "$ICOM_GATE" --no-tests=error --output-on-failure
 
       # Mirrors check-windows' "sccache stats" step, and exists for the same
       # reason: #1963 disabled the Windows compiler cache for three months
@@ -666,7 +672,7 @@ jobs:
         run: cmake --build build -j $env:NUMBER_OF_PROCESSORS --target AetherSDR aether-dv-waveform thumbdv_queue_test dstar_model_test digital_voice_waveform_process_test cross_needle_meter_test
 
       - name: Test ThumbDV portability paths
-        run: ctest --test-dir build -R "aether_dv_waveform_no_args|thumbdv_queue_test|dstar_model_test|digital_voice_waveform_process_test" --output-on-failure
+        run: ctest --test-dir build -R "aether_dv_waveform_no_args|thumbdv_queue_test|dstar_model_test|digital_voice_waveform_process_test" --no-tests=error --output-on-failure
 
       # cross_needle_meter_test renders widgets; the offscreen platform makes
       # its measurements deterministic (verified bit-identical across
@@ -678,7 +684,7 @@ jobs:
       - name: Test cross-needle meter geometry
         env:
           QT_QPA_PLATFORM: offscreen
-        run: ctest --test-dir build -R "cross_needle_meter_test" --output-on-failure
+        run: ctest --test-dir build -R "cross_needle_meter_test" --no-tests=error --output-on-failure
 
       - name: sccache stats
         if: always()
@@ -913,7 +919,7 @@ jobs:
         run: cmake --build build -j$(sysctl -n hw.ncpu)
 
       - name: Run macOS MNR regression test
-        run: ctest --test-dir build -R '^mac_nr_filter_test$' --output-on-failure
+        run: ctest --test-dir build -R '^mac_nr_filter_test$' --no-tests=error --output-on-failure
 
       - name: Run ASR GPU probe test (#4535 regression)
         # arm64 runner = Apple Silicon: exercises the real Metal device init and
@@ -928,7 +934,7 @@ jobs:
         # library-path line in the log, where a reviewer can actually see them.
         env:
           AETHER_ASR_EXPECT_PRECOMPILED: "1"
-        run: ctest --test-dir build -R asr_gpu_probe_test -V
+        run: ctest --test-dir build -R asr_gpu_probe_test -V --no-tests=error
 
       - name: Compile ASR Metal kernels with the Intel-DMG flag set
         # This job passes no CMAKE_OSX_DEPLOYMENT_TARGET, so it always takes the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,15 +374,11 @@ jobs:
       # command shape" and all four checks stayed green, because nothing in this
       # file ran that target either. A capability flag that gates which frame
       # reaches the radio is exactly the kind of claim worth failing a merge on.
-      - name: Test Icom CI-V codec, model table, command scheduler and backend
-        # icom_civ_scheduler_test and icom_backend_test are on this gate
-        # deliberately. The scheduler arbitrates PTT and the operator's control
-        # writes on a single serial command plane, and icom_backend_test is
-        # where every convergence claim about it is asserted. Leaving them to
-        # the weekly sanitizers job would repeat the hasVfoModeCommand lesson
-        # in the comment above: the assertion existed, nothing on a PR ran it,
-        # and all four checks stayed green. ~21 s for the pair.
-        run: ctest --test-dir build -R "^(icom_(civ|civ_scheduler|meters|backend|family)|rf_gain_presentation)_test$" --output-on-failure
+      - name: Test Icom CI-V codec, model table and command scheduler
+        # Enumerate every retained target and fail if the expression ever
+        # selects none. ctest otherwise exits 0 for an empty selection, which
+        # let the retired icom_backend_test disappear from this gate silently.
+        run: ctest --test-dir build -R "^(icom_civ_test|icom_civ_scheduler_test|icom_meters_test|icom_family_test|rf_gain_presentation_test)$" --no-tests=error --output-on-failure
 
       # Mirrors check-windows' "sccache stats" step, and exists for the same
       # reason: #1963 disabled the Windows compiler cache for three months

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -27,6 +27,7 @@ jobs:
           - id: asan-ubsan
             label: ASan + UBSan
             build_type: Debug
+            receiver_churn: "OFF"
             # ASan + UBSan applied via CXXFLAGS / LDFLAGS so the flags
             # reach every target the build produces — including the
             # standalone unit-test executables (declared in
@@ -48,6 +49,7 @@ jobs:
             # TSan cannot coexist with ASan, so build RelWithDebInfo and
             # inject the TSan flags ourselves.
             build_type: RelWithDebInfo
+            receiver_churn: "ON"
             extra_cxx: "-fsanitize=thread -g3 -fno-omit-frame-pointer -O1"
             extra_ld:  "-fsanitize=thread"
             runtime_env: |
@@ -62,7 +64,8 @@ jobs:
           LDFLAGS:  ${{ matrix.sanitizer.extra_ld }}
         run: |
           cmake -B build -G Ninja \
-            -DCMAKE_BUILD_TYPE=${{ matrix.sanitizer.build_type }}
+            -DCMAKE_BUILD_TYPE=${{ matrix.sanitizer.build_type }} \
+            -DAETHER_ENABLE_HL2_RECEIVER_CHURN_TEST=${{ matrix.sanitizer.receiver_churn }}
 
       - name: Build
         run: cmake --build build --parallel

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -27,7 +27,11 @@ jobs:
           - id: asan-ubsan
             label: ASan + UBSan
             build_type: Debug
-            receiver_churn: "OFF"
+            # ON here too, not only under TSan: the churn test's documented
+            # failure class is a heap use-after-free on the receiver vector,
+            # and a sequential UAF produces no TSan report — catching it is
+            # ASan's job. See HERMES §20.15.
+            receiver_churn: "ON"
             # ASan + UBSan applied via CXXFLAGS / LDFLAGS so the flags
             # reach every target the build produces — including the
             # standalone unit-test executables (declared in
@@ -63,9 +67,14 @@ jobs:
           CXXFLAGS: ${{ matrix.sanitizer.extra_cxx }}
           LDFLAGS:  ${{ matrix.sanitizer.extra_ld }}
         run: |
+          # The TX loopback flag is compile coverage only: without an hpsdrsim
+          # answering discovery the test exits 77 and ctest reports it Skipped.
+          # Building it weekly keeps the source honest against API drift now
+          # that it is out of the default graph.
           cmake -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=${{ matrix.sanitizer.build_type }} \
-            -DAETHER_ENABLE_HL2_RECEIVER_CHURN_TEST=${{ matrix.sanitizer.receiver_churn }}
+            -DAETHER_ENABLE_HL2_RECEIVER_CHURN_TEST=${{ matrix.sanitizer.receiver_churn }} \
+            -DAETHER_ENABLE_HL2_TX_LOOPBACK_TEST=ON
 
       - name: Build
         run: cmake --build build --parallel

--- a/docs/HERMES.md
+++ b/docs/HERMES.md
@@ -3192,11 +3192,12 @@ Two consequences worth carrying forward:
 
 `tests/hl2_receiver_churn_test.cpp` gives this a place to be seen: it adds and
 closes receivers against a flowing fake EP6 stream, which is the contended
-window. It stays out of the default build and is enabled only in the weekly
-TSan configuration with `-DAETHER_ENABLE_HL2_RECEIVER_CHURN_TEST=ON` until a
-socket-free concurrency harness replaces the peer. A plain pass is not race
-proof; under TSan, read the differential rather than the absolute Qt artifact
-count described above.
+window. It stays out of the default build and is enabled in both weekly
+sanitizer lanes with `-DAETHER_ENABLE_HL2_RECEIVER_CHURN_TEST=ON` — TSan for
+the race, ASan for the sequential use-after-free the allocator otherwise hides
+— until a socket-free concurrency harness replaces the peer. A plain pass is
+not race proof; under TSan, read the differential rather than the absolute Qt
+artifact count described above.
 
 ### 20.16 What is proven, and what is not
 
@@ -3414,9 +3415,10 @@ Against the HL2 at 192.168.1.21, RX-only:
 
 The former `hl2_link_stats_test` and `hl2_link_stats_model_test` fake-radio
 fixtures covered the seam and consumer halves of this contract. They are
-retired from the build; telemetry liveness, disconnect clearing, and the
-readouts must be verified through the automation bridge against real HL2
-hardware.
+retired from the build; telemetry liveness and the readouts are verified
+through the automation bridge against real HL2 hardware, while the
+disconnect-edge clearing and RTT refuse-to-claim predicates — non-events a
+live run cannot prove — await socket-free injected replacements (#5254).
 
 ---
 

--- a/docs/HERMES.md
+++ b/docs/HERMES.md
@@ -239,9 +239,10 @@ Two consequences worth remembering:
   Otherwise leaving CW strands every other mode a pitch high, which reads as
   "the radio is off frequency" long after the operator left CW behind.
 
-Pinned by `hl2_cw_bfo_test` (audio actually lands on the pitch, and a signal a
-pitch away from the marker is rejected) and by `hl2_backend_test` (the seam
-reports symmetric cuts, and a pitch change does not move them).
+Pinned offline by `hl2_cw_bfo_test` (audio actually lands on the pitch, and a
+signal a pitch away from the marker is rejected). The former fake-radio seam
+coverage in `hl2_backend_test` is retired; symmetric-cut and pitch-change
+convergence must be verified on real hardware through the automation bridge.
 
 ### AGC
 
@@ -1381,9 +1382,9 @@ The snap is **nearest by RATIO, not linear distance**. The rates are
 octave-spaced and zoom is multiplicative, so linear-nearest biases every request
 toward the wider neighbour: between 96 and 192 kHz the geometric mean is
 135.8 kHz but the arithmetic mean is 144 kHz, and a 140 kHz request belongs to
-192 kHz by ratio and to 96 kHz by distance. `hl2_backend_test` pins exactly that
-case — every other row in its table agrees under both rules, so without it the
-`log()` could be deleted and the suite would stay green.
+192 kHz by ratio and to 96 kHz by distance. The retired `hl2_backend_test`
+fixture pinned exactly that case — every other row in its table agrees under
+both rules. That boundary case now belongs in the real-radio automation sweep.
 
 **Do NOT send a filter-pipeline reset (`0x39`) on a rate change.** See
 `MetisClient::requestPipelineReset` — doing that on every geometry change wedged
@@ -1739,7 +1740,7 @@ reason: **the test shared an assumption with the code.**
 - The panadapter FFT keeps working at any rate because it never touches
   `WdspChannel`, so **a healthy display is not evidence of a healthy receiver.**
   That is what made the audio fault look like a display-side change.
-- The span-snap table in `hl2_backend_test` would pass under either
+- Before its retirement, the span-snap table in `hl2_backend_test` would pass under either
   ratio-nearest or linear-nearest for every row except the one deliberately
   placed between the geometric and arithmetic means. Without that row the
   `log()` could be deleted and the suite would stay green.
@@ -2906,8 +2907,9 @@ the pacer for all of it, and the gateware watchdog halts the stream when EP2
 stops arriving; it also stalls the EP6 reader, so the connect watchdog can time
 out against a radio that is answering perfectly well.
 
-This was caught by `hl2_backend_test`, which stopped seeing `connected()` at all.
-It is the same lesson as §15.4 from the other direction: EP2 is not best-effort.
+This was caught before retirement by `hl2_backend_test`, which stopped seeing
+`connected()` at all. It is the same lesson as §15.4 from the other direction:
+EP2 is not best-effort.
 
 The count therefore comes from a **static** `MetisClient::effectiveNumRx(Params)`
 — the same clamp the running client applies to the same struct. The demux and
@@ -3109,7 +3111,10 @@ section and the easiest to regress.
     connected throughout, and `get_log` shows no `linkDown`. The stream restart
     re-sends metis-start, that datagram is as losable as the one at connect, and
     without a retry one lost packet ends the session ~2 s later on the silence
-    watchdog. Covered in-tree by `hl2_receiver_count_restart_test`.
+    watchdog. Covered in-tree by the retained
+    `hl2_receiver_count_restart_test` until the dropped-start assertion has a
+    socket-free injected transport replacement; a live run cannot prove that
+    the first datagram was ignored.
 17. A restart is not a reconnect. Exactly one `connected()` per session — a
     spurious one makes RadioModel stage every pane as previous-session leftovers
     and rebuild the operator's layout mid-click.
@@ -3169,8 +3174,8 @@ happens-before edge a `Qt::BlockingQueuedConnection` establishes (a `QSemaphore`
 inside QtCore) is invisible to TSan. Every blocking invoke therefore reports the
 callee's read of the caller's captures as a data race, with `QtCore` frames
 printed as `<null>`. This is pre-existing and abundant, not new:
-`hl2_backend_test`, which predates the multi-receiver work, reports 57 races
-under `-fsanitize=thread`, 32 of them in the queued-functor dispatcher.
+Before retirement, `hl2_backend_test` reported 57 races under
+`-fsanitize=thread`, 32 of them in the queued-functor dispatcher.
 
 Two consequences worth carrying forward:
 
@@ -3185,12 +3190,13 @@ Two consequences worth carrying forward:
   blocking-invoke reports unchanged either side. The absolute count is dominated
   by the Qt artifact and says nothing.
 
-`tests/hl2_receiver_churn_test.cpp` exists to give this a place to be seen: it
-is the only test that adds and closes receivers against a live EP6 stream, which
-is the contended window. It passes on a plain build regardless of the fix, and
-that is worth being blunt about — a use-after-free on a four-element vector
-usually reads memory the allocator handed straight back. Its value is under a
-sanitizer, and it reports 30 of the pre-existing Qt artifacts when run there.
+`tests/hl2_receiver_churn_test.cpp` gives this a place to be seen: it adds and
+closes receivers against a flowing fake EP6 stream, which is the contended
+window. It stays out of the default build and is enabled only in the weekly
+TSan configuration with `-DAETHER_ENABLE_HL2_RECEIVER_CHURN_TEST=ON` until a
+socket-free concurrency harness replaces the peer. A plain pass is not race
+proof; under TSan, read the differential rather than the absolute Qt artifact
+count described above.
 
 ### 20.16 What is proven, and what is not
 
@@ -3406,15 +3412,11 @@ Against the HL2 at 192.168.1.21, RX-only:
 - 353 544 EP6 packets, 0 sequence gaps, 12.8 Mbps RX / 3.2 Mbps TX, arrival gap
   1 ms, RTT `not measured on this link` in all four places.
 
-`hl2_link_stats_test` covers the seam contract, including the silent-link case
-and the honesty invariant. `hl2_link_stats_model_test` covers the half that is
-downstream of it, because the backend can publish a perfect snapshot while every
-readout still lies: it drives a real `RadioModel` against a fake HL2 and pins the
-readouts leaving their structural zero, the predicates on **both** sides of the
-disconnect edge, and the per-session reset the two scoring-session entry points
-share. Per §7 that is necessary and not sufficient — but the RTT and category
-predicates are decisions about what we *refuse* to claim, which is one of the few
-things a fixture can check honestly.
+The former `hl2_link_stats_test` and `hl2_link_stats_model_test` fake-radio
+fixtures covered the seam and consumer halves of this contract. They are
+retired from the build; telemetry liveness, disconnect clearing, and the
+readouts must be verified through the automation bridge against real HL2
+hardware.
 
 ---
 

--- a/docs/architecture/aetherd-icom-civ-backend-design.md
+++ b/docs/architecture/aetherd-icom-civ-backend-design.md
@@ -510,10 +510,10 @@ load-bearing**:
 | Channel duplication | `TciServer` divides by `2 * sizeof(float)` and sees half the frames it has. |
 
 Both failures are **silent** — audio flows, meters move, the session is healthy.
-That is why `icom_backend_test` asserts the ratio (4800 mono samples in at 48 kHz
-→ ~2400 stereo frames out at 24 kHz) rather than merely asserting that audio
-arrived, and why it also asserts the *negative*: a passthrough would emit ~4800
-frames, so the test fails a backend that skipped the conversion.
+The retired `icom_backend_test` fake-radio fixture asserted the ratio (4800 mono
+samples in at 48 kHz → ~2400 stereo frames out at 24 kHz) rather than merely
+asserting that audio arrived. This conversion and its negative passthrough case
+now require automation-bridge validation against a real Icom radio.
 
 `Resampler::processMonoToStereo` does both halves in one call. It is stateful
 (r8brain), so the instance is built once at connect — a fresh one per callback

--- a/docs/architecture/aetherd-icom-civ-backend-design.md
+++ b/docs/architecture/aetherd-icom-civ-backend-design.md
@@ -512,8 +512,11 @@ load-bearing**:
 Both failures are **silent** — audio flows, meters move, the session is healthy.
 The retired `icom_backend_test` fake-radio fixture asserted the ratio (4800 mono
 samples in at 48 kHz → ~2400 stereo frames out at 24 kHz) rather than merely
-asserting that audio arrived. This conversion and its negative passthrough case
-now require automation-bridge validation against a real Icom radio.
+asserting that audio arrived. The resampler half stays covered by the retained
+`tx_mic_channel_normalizer_test`; the backend-level negative passthrough
+assertion (a backend that skips the conversion emits ~4800 frames) awaits a
+socket-free injected replacement (#5254) — live validation cannot prove that
+non-event.
 
 `Resampler::processMonoToStereo` does both halves in one call. It is stateful
 (r8brain), so the instance is built once at connect — a fresh one per callback

--- a/docs/architecture/hl2-multi-ddc-test-matrix.md
+++ b/docs/architecture/hl2-multi-ddc-test-matrix.md
@@ -181,19 +181,22 @@ Enable *Settings → Autostart TCI*.
 | 7.3 | Kill the app at 4 DDCs (SIGTERM) | Radio released; reconnect works without a power cycle | **HW** |
 | 7.4 | Pull the ethernet at 4 DDCs | Clean disconnect, no hang | **HW** |
 | 7.5 | CPU at 4 DDCs | Four WDSP channels + four FFTs — record the number | TODO |
-| 7.6 | Add/close on a LOSSY link (wifi, or a shaped path) | Link stays up. The stream restart's metis-start is retried on loss; unretried, one dropped datagram ended the session ~2 s later on the silence watchdog | `hl2_receiver_count_restart_test` |
-| 7.7 | ~10 add/close cycles, then check every survivor | Spectrum and audio still arrive for each. Closing the middle renumbers every later DDC, and a chain wired to an index goes quiet with nothing logged | `hl2_receiver_churn_test` |
-| 7.8 | 7.7 under `-fsanitize=thread` | No race naming the receiver vector. Read the DIFFERENTIAL, not the count — QtCore is uninstrumented, so every `BlockingQueuedConnection` reports as a race (`hl2_backend_test` alone: 57). See HERMES §20.15.1 | TODO |
+| 7.6 | Add/close on a LOSSY link (wifi, or a shaped path) | Link stays up. The stream restart's metis-start is retried on loss; unretried, one dropped datagram ended the session ~2 s later on the silence watchdog | `hl2_receiver_count_restart_test` (retained pending socket-free injection) |
+| 7.7 | ~10 add/close cycles, then check every survivor | Spectrum and audio still arrive for each. Closing the middle renumbers every later DDC, and a chain wired to an index goes quiet with nothing logged | Live bridge + `hl2_receiver_churn_test` |
+| 7.8 | 7.7 under `-fsanitize=thread` | No race naming the receiver vector. Read the DIFFERENTIAL, not the count — QtCore is uninstrumented, so every `BlockingQueuedConnection` reports as a race (`hl2_backend_test` alone measured 57 before retirement). See HERMES §20.15.1 | Weekly TSan with receiver churn enabled |
 
 Row 7.3 matters: the SIGTERM wedge was fixed by `Hl2EmergencyStop` (#4503,
 now in main). `kill -9` still wedges the radio — that is expected, not a bug.
 
-Rows 7.6–7.8 came out of review rather than operation, and 7.8 is the only one
-here that needs a special build:
+Rows 7.6–7.8 came out of review rather than operation. Row 7.6 remains in the
+default suite until its dropped-packet assertion has a socket-free injected
+replacement. Receiver churn stays out of ordinary builds and is re-enabled by
+the TSan workflow with:
 
 ```bash
 CXXFLAGS="-fsanitize=thread -g -fno-omit-frame-pointer -O1" LDFLAGS="-fsanitize=thread" \
-  cmake -B build-tsan -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+  cmake -B build-tsan -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DAETHER_ENABLE_HL2_RECEIVER_CHURN_TEST=ON
 ```
 
 ---

--- a/docs/architecture/hl2-multi-ddc-test-matrix.md
+++ b/docs/architecture/hl2-multi-ddc-test-matrix.md
@@ -191,7 +191,7 @@ now in main). `kill -9` still wedges the radio — that is expected, not a bug.
 Rows 7.6–7.8 came out of review rather than operation. Row 7.6 remains in the
 default suite until its dropped-packet assertion has a socket-free injected
 replacement. Receiver churn stays out of ordinary builds and is re-enabled by
-the TSan workflow with:
+both weekly sanitizer lanes; to reproduce the TSan leg locally:
 
 ```bash
 CXXFLAGS="-fsanitize=thread -g -fno-omit-frame-pointer -O1" LDFLAGS="-fsanitize=thread" \
@@ -230,14 +230,17 @@ pre-#4471 panadapter that drew the raw wire. #4471 added the receive-side
 conjugation and the expectation went stale. The run-to-run variation was the
 hardcoded `192.168.1.12` reaching a simulator on another machine.
 
-No exclusion is needed any more — run the whole suite:
+The test is no longer part of a default configure: it must be enabled with
+`-DAETHER_ENABLE_HL2_TX_LOOPBACK_TEST=ON` (the weekly sanitizer lanes do, for
+compile coverage). On a build configured that way, run the whole suite:
 
 ```bash
 QT_QPA_PLATFORM=offscreen ctest --test-dir build -j22
 ```
 
-It SKIPS cleanly when no simulator is running, so it is safe in CI and on a
-machine connected to real hardware — and the skip is honest rather than silent:
-it exits 77, and `SKIP_RETURN_CODE` on the `add_test` makes ctest report
-`***Skipped`. A run that measured nothing cannot be mistaken for one that keyed
-and passed.
+When enabled it SKIPS cleanly when no simulator is running, so it is safe in CI
+and on a machine connected to real hardware — and the skip is honest rather
+than silent: it exits 77, and `SKIP_RETURN_CODE` on the `add_test` makes ctest
+report `***Skipped`. A run that measured nothing cannot be mistaken for one
+that keyed and passed. On a default configure the test is not registered at
+all, so a green whole-suite run says nothing about TX loopback either way.

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,6 +32,44 @@ Putting a test target in the root `CMakeLists.txt` instead fails two ways, on
 purpose: `tests.cmake` aborts the CMake configure step with a message pointing
 here, and `tools/check_test_registration.py --strict` fails the PR in CI.
 
+## Network-fixture boundary
+
+Backend and automation behavior that depends on a local synthetic network peer
+is retired from the default graph along three lines: deterministic protocol,
+codec, model, and policy assertions stay socket-free in this suite; dropped
+packets, refusals, disconnect edges, and TX interlocks are expressed as
+injected transport/state-machine tests rather than socket fixtures; and
+positive convergence against real firmware is proven through the automation
+bridge and `radiocert`, which certify by effect and cannot prove a non-event.
+
+The following 12 positive-convergence fixtures remain in source and as bracket
+comments in `tests.cmake` for history, but are not configured, compiled, or
+registered with CTest:
+
+- Icom: `icom_session_test` and `icom_backend_test`.
+- HL2: `hl2_signal_stop_test` and its helper, `hl2_metis_client_test`,
+  `hl2_backend_test`, `hl2_link_stats_test`, and
+  `hl2_link_stats_model_test`.
+- Automation server: `automation_json_id_test`,
+  `automation_connect_wait_phase_test`, `automation_double_click_test`,
+  `automation_fm_repeater_verbs_test`, and `automation_drag_at_test`.
+
+Three socket fixtures remain registered until their negative assertions have
+socket-free replacements: `vkamp_connection_test` (bypass/antenna interlocks),
+`automation_server_gesture_test` (TX-keying refusals and cleanup), and
+`hl2_receiver_count_restart_test` (dropped Metis-start retry). The fake IC-9700
+connection in `radio_capability_gating_test` is replaced by a socket-free model
+table assertion for its 100/75/10 W band ceilings.
+
+Two HL2 tests are explicit rather than part of the default graph:
+
+- Weekly TSan enables `hl2_receiver_churn_test` with
+  `-DAETHER_ENABLE_HL2_RECEIVER_CHURN_TEST=ON` so the receiver-vector race
+  remains reachable while a socket-free concurrency harness is designed.
+- An operator running `./hpsdrsim -hermeslite2 -P1` may enable and run
+  `hl2_tx_loopback_test` with `-DAETHER_ENABLE_HL2_TX_LOOPBACK_TEST=ON`.
+  The test fingerprints the simulator before it can key.
+
 **Not to be confused with [`/docs/qa/`](../docs/qa/)**, which holds
 *manual* QA checklists and test plans — human procedures for features
 that need a real radio to exercise. Different artifact, different

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,7 +1,9 @@
 # tests/
 
 Automated unit tests — `*_test.cpp` files compiled by CMake and run
-in CI. To run the suite locally:
+in CI, except the retired fixtures listed under "Network-fixture
+boundary" below, which stay in source for history but are not
+configured or compiled. To run the suite locally:
 
 ```sh
 cmake -B build -S .
@@ -58,17 +60,22 @@ Three socket fixtures remain registered until their negative assertions have
 socket-free replacements: `vkamp_connection_test` (bypass/antenna interlocks),
 `automation_server_gesture_test` (TX-keying refusals and cleanup), and
 `hl2_receiver_count_restart_test` (dropped Metis-start retry). The fake IC-9700
-connection in `radio_capability_gating_test` is replaced by a socket-free model
-table assertion for its 100/75/10 W band ceilings.
+connection in `radio_capability_gating_test` is replaced by a socket-free
+capability-table assertion of its 100/75/10 W band ceilings; RadioModel's
+application of that ceiling to the transmit model currently has no registered
+test, and its socket-free replacement is tracked in #5254.
 
 Two HL2 tests are explicit rather than part of the default graph:
 
-- Weekly TSan enables `hl2_receiver_churn_test` with
-  `-DAETHER_ENABLE_HL2_RECEIVER_CHURN_TEST=ON` so the receiver-vector race
-  remains reachable while a socket-free concurrency harness is designed.
+- Both weekly sanitizer lanes enable `hl2_receiver_churn_test` with
+  `-DAETHER_ENABLE_HL2_RECEIVER_CHURN_TEST=ON` — TSan for the receiver-vector
+  race, ASan for the use-after-free class — while a socket-free concurrency
+  harness is designed.
 - An operator running `./hpsdrsim -hermeslite2 -P1` may enable and run
   `hl2_tx_loopback_test` with `-DAETHER_ENABLE_HL2_TX_LOOPBACK_TEST=ON`.
-  The test fingerprints the simulator before it can key.
+  The test fingerprints the simulator before it can key. The weekly sanitizer
+  lanes build it for compile coverage; without a simulator it skips honestly
+  (exit 77, reported by ctest as Skipped).
 
 **Not to be confused with [`/docs/qa/`](../docs/qa/)**, which holds
 *manual* QA checklists and test plans — human procedures for features

--- a/tests/TestDspBuildWait.h
+++ b/tests/TestDspBuildWait.h
@@ -26,11 +26,11 @@
 namespace AetherSDR::test {
 
 // A BACKSTOP, not a budget: reaching it means something is wrong, not that the
-// machine was slow. Sized from measurement rather than taste — one cold
-// hl2_backend_test spent ~70 s of its 88 s wall time on plan measurement alone,
-// on a 32-core box under load ~26, and `ctest -j8` puts several cold-cache tests
-// through the planner at once. 120 s left too little between "slow host" and
-// "hung".
+// machine was slow. Sized from measurement rather than taste — before that
+// fixture was retired, one cold hl2_backend_test spent ~70 s of its 88 s wall
+// time on plan measurement alone, on a 32-core box under load ~26, and
+// `ctest -j8` puts several cold-cache tests through the planner at once. 120 s
+// left too little between "slow host" and "hung".
 constexpr int kDspBuildTimeoutMs = 240000;
 
 inline bool spinUntil(const std::function<bool()>& done,

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -103,7 +103,6 @@
 // with the automation bridge.
 
 #include "models/RadioModel.h"
-#include "IcomFakeRadio.h"
 #include "TestSettingsProfile.h"
 #include "core/AppSettings.h"
 #include "models/ModelCapabilities.h"
@@ -114,8 +113,6 @@
 #include "core/backends/hl2/Hl2Backend.h"
 #include "core/backends/sim/SimBackend.h"
 #include "core/backends/icom/IcomCivBackend.h"
-#include "core/backends/icom/IcomCredentials.h"
-#include "core/backends/icom/IcomSettings.h"
 
 #include "TestEventLoop.h"
 
@@ -125,6 +122,20 @@
 #include <cstdio>
 
 using namespace AetherSDR;
+
+namespace AetherSDR::icom {
+
+// Select model-table data without opening an IcomSession or any socket. The
+// backend already grants this focused test accessor for deterministic state
+// injection; each test binary supplies only the operations it needs.
+struct IcomCivBackendTestAccess {
+    static void selectModel(IcomCivBackend& backend, const IcomModel& model)
+    {
+        backend.m_model = &model;
+    }
+};
+
+}  // namespace AetherSDR::icom
 
 static int g_failures = 0;
 static void check(bool ok, const char* what)
@@ -497,56 +508,30 @@ int main(int argc, char** argv)
         }
     }
 
-    // ---- Icom drives the model's actual per-band power consumer -----------
+    // ---- Icom publishes the IC-9700 power clamp without a socket ----------
     {
-        using AetherSDR::icom::test::FakeIc705;
-
-        FakeIc705 radio;
-        radio.setCivAddress(0xA2);
-        radio.setDeviceName("IC-9700");
-        IcomSettings::reset();
-        IcomSettings::setUsername(QStringLiteral("beer"));
-        IcomSettings::setPorts(radio.controlPort(), radio.serialPort(), radio.audioPort());
-        IcomSettings::setCivAddressAuto();
-        IcomCredentials::setSessionPassword(QStringLiteral("beerbeer"));
-
-        RadioInfo info;
-        info.family = QStringLiteral("icom");
-        info.model = QStringLiteral("IC-9700");
-        info.serial = QStringLiteral("capability-gating-ic9700");
-        info.address = QHostAddress::LocalHost;
-        info.port = radio.controlPort();
-        model.connectToRadio(info);
-        check(AetherTest::waitFor([&] { return model.isConnected(); }),
-              "IC-9700 model-level fixture connects through the real backend seam");
-
-        const RadioCapabilities caps = model.backendCapabilities();
+        using namespace AetherSDR::icom;
+        const IcomModel* ic9700 = modelForName("IC-9700");
+        check(ic9700 != nullptr, "the IC-9700 resolves from the Icom model table");
+        IcomCivBackend backend;
+        if (ic9700) {
+            IcomCivBackendTestAccess::selectModel(backend, *ic9700);
+        }
+        const RadioCapabilities caps = backend.capabilities();
         check(caps.txPowerBands.size() == 3,
               "Icom declares the three IC-9700 per-band TX power limits");
+        check(caps.txPowerMaxWattsAt(146'000'000.0) == 100.0,
+              "the IC-9700 2 m capability clamps TX power to 100 W");
+        check(caps.txPowerMaxWattsAt(432'000'000.0) == 75.0,
+              "the IC-9700 70 cm capability clamps TX power to 75 W");
+        check(caps.txPowerMaxWattsAt(1'296'000'000.0) == 10.0,
+              "the IC-9700 23 cm capability clamps TX power to 10 W");
         check(caps.hasTransmitFrequencyCheck,
               "Icom declares the profiled IC-9700 momentary XFC command");
         check(caps.hasSupplyVoltageTelemetry,
               "Icom declares the profiled IC-9700 supply-voltage telemetry");
         check(!caps.hasMainFanTelemetry,
               "Icom declares no Main Fan telemetry family-wide");
-
-        const auto expectPowerLimit = [&](std::uint64_t hz, int watts,
-                                          const char* description) {
-            radio.frontPanelFrequency(hz);
-            check(AetherTest::waitFor([&] {
-                      return model.transmitModel().maxPowerLevel() == watts;
-                  }), description);
-        };
-        expectPowerLimit(146'000'000ULL, 100,
-                         "RadioModel applies the IC-9700 2 m 100 W ceiling");
-        expectPowerLimit(432'000'000ULL, 75,
-                         "RadioModel applies the IC-9700 70 cm 75 W ceiling");
-        expectPowerLimit(1'296'000'000ULL, 10,
-                         "RadioModel applies the IC-9700 23 cm 10 W ceiling");
-
-        model.disconnectFromRadio();
-        IcomCredentials::setSessionPassword(QString{});
-        IcomSettings::reset();
     }
 
     // ---- Sim declares none of them, and is genuinely CONNECTED -----------

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -513,25 +513,28 @@ int main(int argc, char** argv)
         using namespace AetherSDR::icom;
         const IcomModel* ic9700 = modelForName("IC-9700");
         check(ic9700 != nullptr, "the IC-9700 resolves from the Icom model table");
-        IcomCivBackend backend;
+        // Guarded as a block: without the guard a failed lookup would run the
+        // six checks below against the constructor's unknownModel() seed and
+        // report six misleading capability failures for one missing table row.
         if (ic9700) {
+            IcomCivBackend backend;
             IcomCivBackendTestAccess::selectModel(backend, *ic9700);
+            const RadioCapabilities caps = backend.capabilities();
+            check(caps.txPowerBands.size() == 3,
+                  "Icom declares the three IC-9700 per-band TX power limits");
+            check(caps.txPowerMaxWattsAt(146'000'000.0) == 100.0,
+                  "the IC-9700 2 m capability clamps TX power to 100 W");
+            check(caps.txPowerMaxWattsAt(432'000'000.0) == 75.0,
+                  "the IC-9700 70 cm capability clamps TX power to 75 W");
+            check(caps.txPowerMaxWattsAt(1'296'000'000.0) == 10.0,
+                  "the IC-9700 23 cm capability clamps TX power to 10 W");
+            check(caps.hasTransmitFrequencyCheck,
+                  "Icom declares the profiled IC-9700 momentary XFC command");
+            check(caps.hasSupplyVoltageTelemetry,
+                  "Icom declares the profiled IC-9700 supply-voltage telemetry");
+            check(!caps.hasMainFanTelemetry,
+                  "Icom declares no Main Fan telemetry family-wide");
         }
-        const RadioCapabilities caps = backend.capabilities();
-        check(caps.txPowerBands.size() == 3,
-              "Icom declares the three IC-9700 per-band TX power limits");
-        check(caps.txPowerMaxWattsAt(146'000'000.0) == 100.0,
-              "the IC-9700 2 m capability clamps TX power to 100 W");
-        check(caps.txPowerMaxWattsAt(432'000'000.0) == 75.0,
-              "the IC-9700 70 cm capability clamps TX power to 75 W");
-        check(caps.txPowerMaxWattsAt(1'296'000'000.0) == 10.0,
-              "the IC-9700 23 cm capability clamps TX power to 10 W");
-        check(caps.hasTransmitFrequencyCheck,
-              "Icom declares the profiled IC-9700 momentary XFC command");
-        check(caps.hasSupplyVoltageTelemetry,
-              "Icom declares the profiled IC-9700 supply-voltage telemetry");
-        check(!caps.hasMainFanTelemetry,
-              "Icom declares no Main Fan telemetry family-wide");
     }
 
     // ---- Sim declares none of them, and is genuinely CONNECTED -----------

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -672,8 +672,9 @@ add_test(NAME hl2_link_stats_model_test COMMAND hl2_link_stats_model_test)
 # path its own copy (m_ioDsps) and blocks until the I/O thread has taken it, so
 # the reshape never mutates a container a fan-out is walking. (There is no
 # fenceIo() — an earlier draft named one and this comment outlived it.)
-# It stays out of the default graph and is enabled explicitly by the TSan
-# workflow until a socket-free concurrency harness replaces the fake EP6 peer.
+# It stays out of the default graph and is enabled explicitly by both weekly
+# sanitizer lanes — TSan for the race, ASan for the sequential use-after-free
+# — until a socket-free concurrency harness replaces the fake EP6 peer.
 option(AETHER_ENABLE_HL2_RECEIVER_CHURN_TEST
        "Build the fake-EP6 receiver churn test for sanitizer runs" OFF)
 if(AETHER_ENABLE_HL2_RECEIVER_CHURN_TEST)
@@ -2971,6 +2972,12 @@ add_test(NAME radio_certification_math_test COMMAND radio_certification_math_tes
 # because it requires the external GPL simulator and intentionally keys its
 # simulated transmitter. Enable only after starting `./hpsdrsim -hermeslite2
 # -P1`; the source fingerprints the simulator before allowing keying.
+#
+# An option() rather than the EXCLUDE_FROM_ALL convention the live probes
+# above use, on purpose: when enabled this must stay a REGISTERED test so the
+# SKIP_RETURN_CODE 77 accounting below keeps a missing simulator visibly
+# Skipped rather than silently green. The weekly sanitizer lanes enable it for
+# compile coverage; without a simulator it skips honestly there.
 option(AETHER_ENABLE_HL2_TX_LOOPBACK_TEST
        "Build and register the opt-in hpsdrsim HL2 TX loopback test" OFF)
 if(AETHER_ENABLE_HL2_TX_LOOPBACK_TEST)

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -443,6 +443,12 @@ add_executable(icom_meters_test
 target_include_directories(icom_meters_test PRIVATE src)
 add_test(NAME icom_meters_test COMMAND icom_meters_test)
 
+# Retired fake-radio fixtures. Positive session and backend convergence is
+# certified against real firmware through the automation bridge and radiocert;
+# deterministic protocol/model policy stays in socket-free tests. Keep these
+# declarations as source history, but do not configure, compile, or register
+# them: they add network-fixture compile and wait cost to every default build.
+#[==[
 # IcomCIV phases 0-3 end to end — the session against a fake IC-705 on
 # localhost. This is what proves the ORDER of the RS-BA1 handshake, which is the
 # part of the protocol Icom documents nowhere.
@@ -464,6 +470,7 @@ add_executable(icom_backend_test tests/icom_backend_test.cpp)
 target_include_directories(icom_backend_test PRIVATE src tests)
 target_link_libraries(icom_backend_test PRIVATE aethercore Qt6::Core Qt6::Network Qt6::Test)
 add_test(NAME icom_backend_test COMMAND icom_backend_test)
+]==]
 
 # IcomCIV live probe — REQUIRES A REAL RADIO, so deliberately NOT registered
 # with add_test(). Receive-only: it never sends a PTT command.
@@ -502,6 +509,10 @@ add_executable(hl2_live_band_filter_probe EXCLUDE_FROM_ALL
 target_include_directories(hl2_live_band_filter_probe PRIVATE src)
 target_link_libraries(hl2_live_band_filter_probe PRIVATE aethercore Qt6::Core Qt6::Network)
 
+# Retired fake-radio fixtures. Positive HL2 lifecycle and transport convergence
+# moves to the automation bridge; socket-free protocol and policy tests remain.
+# Keep the declarations for history without making them build or test targets.
+#[==[
 # A killed AetherSDR must still release the radio. A child process runs a real
 # MetisClient against a fake radio; the Python driver kills it and requires a
 # metis-stop datagram to arrive. End-to-end on purpose — see the .py header.
@@ -521,9 +532,12 @@ add_executable(hl2_metis_client_test tests/hl2_metis_client_test.cpp)
 target_include_directories(hl2_metis_client_test PRIVATE src)
 target_link_libraries(hl2_metis_client_test PRIVATE aethercore Qt6::Core Qt6::Network Qt6::Test)
 add_test(NAME hl2_metis_client_test COMMAND hl2_metis_client_test)
+]==]
 
 # HL2 receiver-count restart — a fake radio that "loses" a metis-start, proving
 # the restart retries it and that the recovery is not mistaken for a reconnect.
+# Retained until the same dropped-packet assertion has a socket-free injected
+# transport/state-machine replacement; radiocert cannot prove this non-event.
 add_executable(hl2_receiver_count_restart_test tests/hl2_receiver_count_restart_test.cpp)
 target_include_directories(hl2_receiver_count_restart_test PRIVATE src)
 target_link_libraries(hl2_receiver_count_restart_test
@@ -621,6 +635,11 @@ add_test(NAME hl2_trim_autorepeat_test COMMAND hl2_trim_autorepeat_test)
 set_tests_properties(hl2_trim_autorepeat_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
+# Retired fake-radio fixtures. Positive backend and telemetry convergence is
+# certified against real hardware; deterministic assertions that survive are
+# extracted into socket-free tests rather than keeping a localhost peer in the
+# default compile and CTest graph.
+#[==[
 # HL2 backend — IRadioBackend seam contract against a capped fake HL2.
 add_executable(hl2_backend_test tests/hl2_backend_test.cpp)
 target_include_directories(hl2_backend_test PRIVATE src)
@@ -644,6 +663,7 @@ add_executable(hl2_link_stats_model_test tests/hl2_link_stats_model_test.cpp)
 target_include_directories(hl2_link_stats_model_test PRIVATE src tests)
 target_link_libraries(hl2_link_stats_model_test PRIVATE aethercore Qt6::Core Qt6::Network Qt6::Test)
 add_test(NAME hl2_link_stats_model_test COMMAND hl2_link_stats_model_test)
+]==]
 
 # HL2 receiver churn — add/close receivers against a LIVE EP6 stream. The only
 # test that puts the m_rx reshape and the I/O-thread fan-out in contention, which
@@ -652,10 +672,17 @@ add_test(NAME hl2_link_stats_model_test COMMAND hl2_link_stats_model_test)
 # path its own copy (m_ioDsps) and blocks until the I/O thread has taken it, so
 # the reshape never mutates a container a fan-out is walking. (There is no
 # fenceIo() — an earlier draft named one and this comment outlived it.)
-add_executable(hl2_receiver_churn_test tests/hl2_receiver_churn_test.cpp)
-target_include_directories(hl2_receiver_churn_test PRIVATE src tests)
-target_link_libraries(hl2_receiver_churn_test PRIVATE aethercore Qt6::Core Qt6::Network Qt6::Test)
-add_test(NAME hl2_receiver_churn_test COMMAND hl2_receiver_churn_test)
+# It stays out of the default graph and is enabled explicitly by the TSan
+# workflow until a socket-free concurrency harness replaces the fake EP6 peer.
+option(AETHER_ENABLE_HL2_RECEIVER_CHURN_TEST
+       "Build the fake-EP6 receiver churn test for sanitizer runs" OFF)
+if(AETHER_ENABLE_HL2_RECEIVER_CHURN_TEST)
+    add_executable(hl2_receiver_churn_test tests/hl2_receiver_churn_test.cpp)
+    target_include_directories(hl2_receiver_churn_test PRIVATE src tests)
+    target_link_libraries(hl2_receiver_churn_test
+        PRIVATE aethercore Qt6::Core Qt6::Network Qt6::Test)
+    add_test(NAME hl2_receiver_churn_test COMMAND hl2_receiver_churn_test)
+endif()
 
 # HL2 connect re-entrancy — a connect or a disconnect landing while the WDSP
 # chains are still opening. Needs no radio; see the file header.
@@ -1248,6 +1275,8 @@ add_test(NAME radio_discovery_test COMMAND radio_discovery_test)
 # Agent automation bridge phaseful-gesture lifecycle (#4353). Uses two real
 # QLocalSocket clients so the regression proves an independent request can run
 # while a QSlider remains genuinely down, plus auth/read-only/TX cleanup rails.
+# Retained until its refusal and TX-cleanup assertions have a socket-free
+# injected replacement; live automation cannot prove that a non-event occurred.
 add_executable(automation_server_gesture_test
     tests/automation_server_gesture_test.cpp
 )
@@ -1907,6 +1936,8 @@ add_test(NAME vkamp_protocol_test COMMAND vkamp_protocol_test)
 # hostname resolution for the UDP telemetry port, and TX-gated telemetry
 # expiry. Isolated settings dir per the CMake contract: LogManager pulls in
 # AppSettings.
+# Retained until the refusal/interlock assertions have a socket-free injected
+# replacement; radiocert certifies positive effects, not refused commands.
 add_executable(vkamp_connection_test
     tests/vkamp_connection_test.cpp
     src/core/VkampConnection.cpp
@@ -2309,6 +2340,9 @@ if(PYTHON3_EXECUTABLE)
                      ${CMAKE_CURRENT_SOURCE_DIR}/tools/gen_bridge_docs.py --check)
 endif()
 
+# Retired local-listener fixture. Positive behavior is covered through the live
+# bridge; deterministic boundary behavior belongs in socket-free tests.
+#[==[
 # JSON boundary regression for shared bridge `id` normalization. Exercises the
 # real QLocalSocket request path and tune dispatcher without touching a radio.
 add_executable(automation_json_id_test
@@ -2319,6 +2353,7 @@ target_link_libraries(automation_json_id_test PRIVATE
     aethercore Qt6::Core Qt6::Network
 )
 add_test(NAME automation_json_id_test COMMAND automation_json_id_test)
+]==]
 
 # Read-only external-device diagnostic registry and provider dispatch. The
 # platform-specific Ulanzi HID snapshot is supplied by MainWindow on macOS;
@@ -2344,6 +2379,9 @@ target_link_libraries(automation_connect_family_test PRIVATE
 )
 add_test(NAME automation_connect_family_test COMMAND automation_connect_family_test)
 
+# Retired local-listener fixture. Positive behavior is covered through the live
+# bridge; deterministic boundary behavior belongs in socket-free tests.
+#[==[
 # `connect wait` phase reporting + deferred connect-failure delivery (#4912).
 add_executable(automation_connect_wait_phase_test
     tests/automation_connect_wait_phase_test.cpp
@@ -2354,6 +2392,7 @@ target_link_libraries(automation_connect_wait_phase_test PRIVATE
 )
 add_test(NAME automation_connect_wait_phase_test
          COMMAND automation_connect_wait_phase_test)
+]==]
 
 add_executable(gui_client_identity_policy_test
     tests/gui_client_identity_policy_test.cpp
@@ -2843,6 +2882,9 @@ target_include_directories(owned_single_shot_timer_test PRIVATE src)
 target_link_libraries(owned_single_shot_timer_test PRIVATE Qt6::Core Qt6::Test)
 add_test(NAME owned_single_shot_timer_test COMMAND owned_single_shot_timer_test)
 
+# Retired local-listener fixtures. Their positive verb behavior is covered by
+# the live bridge; deterministic boundary behavior belongs in socket-free tests.
+#[==[
 # The bridge preserves dragAt, target-tune, memory-recall, and authenticated
 # positional requests across its bare and JSON protocol forms.
 # doubleClick / doubleClickAt verbs (#5068) — asserts the real Qt sequence
@@ -2877,6 +2919,7 @@ set_target_properties(automation_drag_at_test PROPERTIES AUTOMOC ON)
 add_test(NAME automation_drag_at_test COMMAND automation_drag_at_test)
 set_tests_properties(automation_drag_at_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+]==]
 
 # aetherd RFC 2.3 template — pan decode/normalize chain (incl. wnb_level guard).
 add_executable(aetherd_pan_decode_test tests/aetherd_pan_decode_test.cpp)
@@ -2924,16 +2967,21 @@ add_executable(radio_certification_math_test tests/radio_certification_math_test
 target_include_directories(radio_certification_math_test PRIVATE src)
 add_test(NAME radio_certification_math_test COMMAND radio_certification_math_test)
 
-add_executable(hl2_tx_loopback_test tests/hl2_tx_loopback_test.cpp)
-target_include_directories(hl2_tx_loopback_test PRIVATE src)
-target_link_libraries(hl2_tx_loopback_test PRIVATE aethercore Qt6::Core Qt6::Network)
-add_test(NAME hl2_tx_loopback_test COMMAND hl2_tx_loopback_test)
-# This test is a no-op without an hpsdrsim answering discovery, which is the
-# normal state of every machine that has not deliberately started one. Without
-# this property that no-op reports as Passed, which is indistinguishable from a
-# run that actually keyed and measured — the exact silent-green this test was
-# fixed to stop. Same convention as crdv_quarantined_test above.
-set_tests_properties(hl2_tx_loopback_test PROPERTIES SKIP_RETURN_CODE 77)
+# Explicit opt-in hpsdrsim TX proof. It is excluded from the default graph
+# because it requires the external GPL simulator and intentionally keys its
+# simulated transmitter. Enable only after starting `./hpsdrsim -hermeslite2
+# -P1`; the source fingerprints the simulator before allowing keying.
+option(AETHER_ENABLE_HL2_TX_LOOPBACK_TEST
+       "Build and register the opt-in hpsdrsim HL2 TX loopback test" OFF)
+if(AETHER_ENABLE_HL2_TX_LOOPBACK_TEST)
+    add_executable(hl2_tx_loopback_test tests/hl2_tx_loopback_test.cpp)
+    target_include_directories(hl2_tx_loopback_test PRIVATE src)
+    target_link_libraries(hl2_tx_loopback_test
+        PRIVATE aethercore Qt6::Core Qt6::Network)
+    add_test(NAME hl2_tx_loopback_test COMMAND hl2_tx_loopback_test)
+    # A missing simulator is an honest skip, never a passing TX proof.
+    set_tests_properties(hl2_tx_loopback_test PROPERTIES SKIP_RETURN_CODE 77)
+endif()
 
 add_executable(hl2_tx_gate_test tests/hl2_tx_gate_test.cpp)
 target_include_directories(hl2_tx_gate_test PRIVATE src)
@@ -4033,9 +4081,10 @@ set(AETHER_TEST_WISDOM_DIR "${CMAKE_BINARY_DIR}/test-fftw-wisdom")
 # That failure is invisible to the isolation re-check documented above: the
 # wisdom REDIRECT still works with the bound dead, so no file appears under
 # $HOME/.cache/aethersdr and the check passes. It is also invisible to the test
-# suite, which still passes — just slowly. Measured cold on macOS/arm64,
-# hl2_backend_test: 124.8 s with the variable undefined, 22.5 s with it set
-# here, of which only 2.4 s is CPU. The rest is socket and timer waits.
+# suite, which still passes — just slowly. A cold macOS/arm64 measurement of the
+# now-retired hl2_backend_test was 124.8 s with the variable undefined and
+# 22.5 s with it set here, of which only 2.4 s was CPU. The rest was socket and
+# timer waits.
 #
 # 0.001 s per plan, not per process — FFTW cannot interrupt a measurement in
 # progress, so the total still scales with the number of distinct plans.

--- a/tools/check_test_registration.py
+++ b/tools/check_test_registration.py
@@ -35,6 +35,12 @@ CANONICAL = Path("tests/tests.cmake")
 # Strip # comments before scanning: the root file's tombstone comment names the
 # very patterns below, on purpose, so that a grep for them lands on the sign that
 # says where they went.
+# CMake bracket comments (#[=[ ... ]=]) span lines and are now a load-bearing
+# idiom in tests.cmake (retired fixture declarations live inside them). Strip
+# them FIRST: the line-comment regex below only eats the opener's own line, so
+# without this pass a bracket-commented add_executable/add_test elsewhere would
+# be reported as a live stray declaration.
+BRACKET_COMMENT = re.compile(r"#\[(=*)\[.*?\]\1\]", re.S)
 COMMENT = re.compile(r"#[^\n]*")
 
 TEST_TARGET = re.compile(r"^\s*add_executable\s*\(\s*([A-Za-z0-9_-]+_test)\b", re.M)
@@ -81,7 +87,8 @@ def main() -> int:
         # not cover either, since that one scans only the root listfile.
         if rel.parent == Path("tests") and rel.name.startswith(("run_", "verify_")):
             continue
-        code = COMMENT.sub("", path.read_text(encoding="utf-8", errors="replace"))
+        code = COMMENT.sub(
+            "", BRACKET_COMMENT.sub("", path.read_text(encoding="utf-8", errors="replace")))
         for match in TEST_TARGET.finditer(code):
             line = code[:match.start()].count("\n") + 1
             strays.append((rel, line, f"add_executable({match.group(1)} ...)"))


### PR DESCRIPTION
## Summary

This revision implements the review's agreed split instead of retiring all 17 socket-owning fixtures:

- **12 positive-convergence fixtures retire** from the default configure/build/CTest graph.
- **5 negative, sanitizer, or simulator-only targets stay** until their coverage is replaced or deliberately invoked.
- The IC-9700 100/75/10 W `txPowerBands` clamp now has a socket-free capability-table assertion.
- The Icom CI gate names only retained tests and uses `--no-tests=error`, so future regex erosion fails closed.
- The README and backend test documents now describe the same three-layer verification boundary.

There are no production-code changes.

## Why this boundary

The Icom and HL2 fake-radio fixtures were generated during the initial bring-up of those radio families, before an independently proven live automation-bridge and `radiocert` baseline existed. The client and synthetic peer therefore evolved together. Those fixtures are useful scaffolding, but a pass proves agreement with the peer encoded in the test—not compatibility with current or future radio firmware.

The replacement is deliberately not “live tests for everything”:

1. Keep protocol encodings, capability tables, safety policy, refusals, and injected faults deterministic and socket-free.
2. Use sanitizer and simulator lanes only for claims that require them.
3. Use the automation bridge and `radiocert` for positive convergence against the real application, radio, and firmware.

`radiocert` cannot prove a non-event, deterministically drop a datagram, or substitute for TSan. That is why the five targets below do not retire in this PR.

## Disposition and recorded wall time

The wall-time column is the local CTest recorded average from a recent full-registration Mac Studio build (`CTestCostData.txt`). It is historical measurement, not a CI-runtime guarantee; tests can overlap under `ctest -j22`, and cold DSP planning can materially increase the HL2 figures.

| Disposition | CTest target | Recorded wall time | Placement after this PR |
|---|---|---:|---|
| Retired | `icom_session_test` | 0.71 s | Positive live-session convergence → bridge + `radiocert` |
| Retired | `icom_backend_test` | 8.17 s | Positive firmware convergence → bridge + `radiocert`; capability clamp extracted |
| Retired | `hl2_signal_stop_test` | 13.37 s | Positive process/transport convergence → live validation |
| Retired | `hl2_metis_client_test` | 3.16 s | Positive transport convergence → live validation |
| Retired | `hl2_backend_test` | 114.04 s | Positive backend convergence → bridge + `radiocert` |
| Retired | `hl2_link_stats_test` | 92.72 s | Positive link telemetry → live validation |
| Retired | `hl2_link_stats_model_test` | 91.09 s | Positive model convergence → live validation |
| Retired | `automation_json_id_test` | 2.63 s | Bridge exercised through real automation workflows |
| Retired | `automation_connect_wait_phase_test` | 6.29 s | Bridge exercised through real automation workflows |
| Retired | `automation_double_click_test` | 6.31 s | Bridge exercised through real automation workflows |
| Retired | `automation_fm_repeater_verbs_test` | 6.75 s | Bridge exercised through real automation workflows |
| Retired | `automation_drag_at_test` | 2.60 s | Bridge exercised through real automation workflows |
| Stays | `vkamp_connection_test` | 15.36 s | Default CTest until refusals/interlocks are socket-free |
| Stays | `automation_server_gesture_test` | 2.48 s | Default CTest until TX-keying refusals are socket-free |
| Stays | `hl2_receiver_count_restart_test` | 3.18 s | Default CTest until dropped-start retry is socket-free |
| Stays | `hl2_receiver_churn_test` | 91.20 s | Built/registered only by the weekly TSan workflow |
| Stays | `hl2_tx_loopback_test` | Not measured | Explicit opt-in; skips unless `./hpsdrsim -hermeslite2 -P1` is running |

Follow-up issue #5254 tracks replacement and final disposition of the five retained targets.

## CI and documentation changes

- Default configure no longer builds the 12 retired targets.
- `AETHER_ENABLE_HL2_RECEIVER_CHURN_TEST=ON` is enabled by `sanitizers.yml`, preserving TSan reach without charging every build.
- `AETHER_ENABLE_HL2_TX_LOOPBACK_TEST=ON` is required to build/register the simulator TX loop.
- The Icom PR gate now runs exactly:
  `icom_civ_test`, `icom_civ_scheduler_test`, `icom_meters_test`, `icom_family_test`, and `rf_gain_presentation_test`.
- `tests/README.md`, `docs/HERMES.md`, and the HL2/Icom design matrices describe the same retained/retired split.

## Validation

- Exact head: `f659bcbfc368239a315b7e2ef20d285045034e1b` (signed commit).
- `cmake --build build -j22` — passed.
- `python3 tools/check_test_registration.py --strict` — passed.
- Workflow YAML parse — passed.
- Default registration audit — only the three ordinary retained fixtures are present among the 17-target set.
- Focused headless default tests — 8/9 passed: IC-9700 capability clamp, five retained Icom gate tests, HL2 dropped-start retry, and gesture refusal passed.
- Opt-in `hl2_receiver_churn_test` — passed under the opt-in build.
- Opt-in `hl2_tx_loopback_test` — skipped honestly because no simulator was running.

The one local failure was the unchanged `vkamp_connection_test`. Across two runs it remained timing-sensitive at its trailing out-of-range/post-disconnect command assertions. This PR keeps that target registered; #5254 prioritizes replacing its socket timing with deterministic injection. This validation does not claim the focused suite is fully green.

## Risk and rollback

Production behavior is unchanged. The verification risk is bounded by retaining every assertion class that `radiocert` cannot structurally replace, preserving receiver churn in TSan, and keeping simulator TX explicit. Rollback is restoring the 12 target declarations.

Generated with OpenAI Codex (Daybreak Blue)
