### PR TITLE
ci(windows): surface missing MSIX upload artifact

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -344,6 +344,17 @@ jobs:
           . .\packaging\windows\store-identity.ps1
           powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\create-msix.ps1 -DeployDir deploy -OutputDir . -CreateUpload -SkipSign -ExcludeDfnrModel -RequirePdb
 
+      - name: Verify MSIX upload artifact present
+        if: always()
+        shell: pwsh
+        run: |
+          $upload = Get-ChildItem -Filter 'AetherSDR-*.msixupload' -ErrorAction SilentlyContinue
+          if (-not $upload) {
+            Write-Host '::warning::No .msixupload produced - Store submission artifact will be missing from this release.'
+          } else {
+            Write-Host "MSIX upload artifact: $($upload.Name)"
+          }
+
       # Hard gate for the PDB-regression class (#3946). The Create MSIX
       # package step above is continue-on-error (to tolerate MSIX SDK/tool
       # flakes), which ALSO swallows create-msix.ps1's -RequirePdb throw — so

--- a/docs/WINDOWS-STORE-MSIX.md
+++ b/docs/WINDOWS-STORE-MSIX.md
@@ -283,7 +283,10 @@ Each Store submission must carry a higher `Identity.Version` than the live one.
 The MSIX version is derived from `project(AetherSDR VERSION ...)` in
 `CMakeLists.txt` and normalized to four parts. Within a single month, weekly
 releases must bump the CalVer **patch** (and the 4th hotfix component if
-needed), or Partner Center will reject the package as not newer.
+needed), or Partner Center will reject the package as not newer. That
+rejection happens after the GitHub tag and release artifacts are created, so
+bump the CalVer version and re-tag; the existing release is not retracted
+automatically.
 
 ### Promoting to fully automatic later
 


### PR DESCRIPTION
## Summary
- warn in the workflow when the optional MSIX packaging step does not create its `.msixupload` artifact
- document the re-tag recovery path when Partner Center rejects a non-incremented version

Fixes #3406

## Verification
- `git diff --check`
- Ruby YAML parse of `.github/workflows/windows-installer.yml`
- static assertions for the workflow ordering, warning command, and documentation recovery guidance

The workflow remains non-blocking for MSIX failures; this only surfaces the missing release artifact. Principle VIII.