### PR TITLE
feat(gui): highlight active band button in spectrum overlay band panel

### DIFF
--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -264,6 +264,30 @@ static const QString kMenuBtnActive =
     "border: 1px solid #0090e0; border-radius: 2px; "
     "color: #ffffff; font-size: 11px; font-weight: bold; }";
 
+static const QString kBandBtnStyle =
+    "QPushButton { background: rgba(30, 40, 55, 220); "
+    "border: 1px solid #304050; border-radius: 3px; "
+    "color: #c8d8e8; font-size: 11px; font-weight: bold; }"
+    "QPushButton:hover { background: rgba(0, 112, 192, 180); "
+    "border: 1px solid #0090e0; }"
+    "QPushButton:checked { background: #0070c0; color: #ffffff; "
+    "border: 1px solid #0090e0; }";
+
+static const QString kXvtrBtnStyle =
+    "QPushButton { background: rgba(30, 40, 55, 220); "
+    "border: 1px solid #304050; border-radius: 3px; "
+    "color: #00d0ff; font-size: 11px; font-weight: bold; }"
+    "QPushButton:hover { background: rgba(0, 112, 192, 180); "
+    "border: 1px solid #0090e0; }"
+    "QPushButton:checked { background: #0070c0; color: #ffffff; "
+    "border: 1px solid #0090e0; }";
+
+static inline QString colorPickerBtnStyle(const QString& colorHex)
+{
+    return QStringLiteral("QPushButton { background: %1; border: 1px solid #506070; "
+                          "border-radius: 2px; }").arg(colorHex);
+}
+
 static QPushButton* makeMenuBtn(const QString& text, QWidget* parent)
 {
     auto* btn = new QPushButton(text, parent);
@@ -471,16 +495,7 @@ void SpectrumOverlayMenu::buildBandPanel()
 
     m_bandButtons.clear();
     m_bandBtnFreqs.clear();
-
-    const QString bandBtnStyle = ThemeManager::instance().resolve(
-        QStringLiteral(
-            "QPushButton { background: rgba(30, 40, 55, 220); "
-            "border: 1px solid {{color.background.2}}; border-radius: 3px; "
-            "color: {{color.text.primary}}; font-size: 11px; font-weight: bold; }"
-            "QPushButton:hover { background: rgba(0, 112, 192, 180); "
-            "border: 1px solid {{color.accent}}; }"
-            "QPushButton:checked { background: {{color.accent.dim}}; color: {{color.text.primary}}; "
-            "border: 1px solid {{color.accent}}; }"));
+    m_lastHighlightedBand.clear();
 
     constexpr int layout[][3] = {
         {0, 1, 2},      // 160, 80, 60
@@ -498,7 +513,7 @@ void SpectrumOverlayMenu::buildBandPanel()
 
             auto* btn = new QPushButton(BAND_GRID[idx].label, m_bandPanel);
             btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
-            btn->setStyleSheet(bandBtnStyle);
+            btn->setStyleSheet(kBandBtnStyle);
 
             QString bandName = QString::fromLatin1(BAND_GRID[idx].bandName);
             double freq = BAND_GRID[idx].freqMhz;
@@ -886,10 +901,11 @@ void SpectrumOverlayMenu::buildAntPanel()
         spin->setEnabled(false);
         return spin;
     };
+    const QString freqRangeLabelStyle = "QLabel { color: #b0a080; font-size: 10px; }";
     auto* fromLabel = new QLabel("From");
-    fromLabel->setStyleSheet("QLabel { color: #b0a080; font-size: 10px; }");
+    fromLabel->setStyleSheet(freqRangeLabelStyle);
     auto* toLabel = new QLabel("To");
-    toLabel->setStyleSheet("QLabel { color: #b0a080; font-size: 10px; }");
+    toLabel->setStyleSheet(freqRangeLabelStyle);
     m_swrLowSpin = makeFreqSpin();
     m_swrHighSpin = makeFreqSpin();
     rangeRow->addWidget(fromLabel);
@@ -1181,6 +1197,7 @@ void SpectrumOverlayMenu::setSlice(SliceModel* slice)
     if (m_slice)
         m_slice->disconnect(this);
     m_slice = slice;
+    m_lastHighlightedBand.clear();
     refreshAntennaCombo();
     updateActiveBandHighlight();
     if (!m_slice) return;
@@ -1691,10 +1708,7 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         m_lineColorBtn = new QPushButton;
         m_lineColorBtn->setObjectName("displayFftLineColorBtn");
         m_lineColorBtn->setFixedSize(18, 18);
-        m_lineColorBtn->setStyleSheet(
-            QString("QPushButton { background: %1; border: 1px solid #506070;"
-                    " border-radius: 2px; }")
-                .arg(m_lineColor.name()));
+        m_lineColorBtn->setStyleSheet(colorPickerBtnStyle(m_lineColor.name()));
         m_lineColorBtn->setToolTip("Choose trace line color");
         grid->addWidget(m_lineColorBtn, row, 1);
 
@@ -1730,10 +1744,7 @@ void SpectrumOverlayMenu::buildDisplayPanel()
                                                QColorDialog::DontUseNativeDialog);
             if (c.isValid()) {
                 m_lineColor = c;
-                m_lineColorBtn->setStyleSheet(
-                    QString("QPushButton { background: %1; border: 1px solid #506070;"
-                            " border-radius: 2px; }")
-                        .arg(c.name()));
+                m_lineColorBtn->setStyleSheet(colorPickerBtnStyle(c.name()));
                 emit fftLineColorChanged(c);
             }
         });
@@ -1748,10 +1759,7 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         m_fillColorBtn = new QPushButton;
         m_fillColorBtn->setObjectName("displayFftFillColorBtn");
         m_fillColorBtn->setFixedSize(18, 18);
-        m_fillColorBtn->setStyleSheet(
-            QString("QPushButton { background: %1; border: 1px solid #506070;"
-                    " border-radius: 2px; }")
-                .arg(m_fillColor.name()));
+        m_fillColorBtn->setStyleSheet(colorPickerBtnStyle(m_fillColor.name()));
         m_fillColorBtn->setToolTip("Choose fill color");
         grid->addWidget(m_fillColorBtn, row, 1);
 
@@ -1778,10 +1786,7 @@ void SpectrumOverlayMenu::buildDisplayPanel()
                                                QColorDialog::DontUseNativeDialog);
             if (c.isValid()) {
                 m_fillColor = c;
-                m_fillColorBtn->setStyleSheet(
-                    QString("QPushButton { background: %1; border: 1px solid #506070;"
-                            " border-radius: 2px; }")
-                        .arg(c.name()));
+                m_fillColorBtn->setStyleSheet(colorPickerBtnStyle(c.name()));
                 emit fftFillColorChanged(c);
             }
         });
@@ -2413,14 +2418,10 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
     m_fillLabel->setText(QString::number(fillPct));
     m_weightedAvgBtn->setChecked(weightedAvg);
     m_fillColor = fillColor;
-    m_fillColorBtn->setStyleSheet(
-        QString("QPushButton { background: %1; border: 1px solid #506070;"
-                " border-radius: 2px; }").arg(fillColor.name()));
+    m_fillColorBtn->setStyleSheet(colorPickerBtnStyle(fillColor.name()));
     m_lineColor = lineColor;
     if (m_lineColorBtn)
-        m_lineColorBtn->setStyleSheet(
-            QString("QPushButton { background: %1; border: 1px solid #506070;"
-                    " border-radius: 2px; }").arg(lineColor.name()));
+        m_lineColorBtn->setStyleSheet(colorPickerBtnStyle(lineColor.name()));
     m_gainSlider->setValue(gain);
     m_gainLabel->setText(QString::number(gain));
     m_blackManualValue     = black;
@@ -3021,6 +3022,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     // because deleteLater() on the panel takes its children with it.
     m_bandBtnFreqs.clear();
     m_bandButtons.clear();
+    m_lastHighlightedBand.clear();
 
     // Rebuild the main band panel to insert XVTR bands between
     // HF bands and utility buttons (WWV/GEN/2200/630/XVTR). (#571)
@@ -3040,26 +3042,6 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     grid->setContentsMargins(2, 2, 2, 2);
     grid->setSpacing(2);
 
-    const QString bandBtnStyle = ThemeManager::instance().resolve(
-        QStringLiteral(
-            "QPushButton { background: rgba(30, 40, 55, 220); "
-            "border: 1px solid {{color.background.2}}; border-radius: 3px; "
-            "color: {{color.text.primary}}; font-size: 11px; font-weight: bold; }"
-            "QPushButton:hover { background: rgba(0, 112, 192, 180); "
-            "border: 1px solid {{color.accent}}; }"
-            "QPushButton:checked { background: {{color.accent.dim}}; color: {{color.text.primary}}; "
-            "border: 1px solid {{color.accent}}; }"));
-
-    const QString xvtrBtnStyle = ThemeManager::instance().resolve(
-        QStringLiteral(
-            "QPushButton { background: rgba(30, 40, 55, 220); "
-            "border: 1px solid {{color.background.2}}; border-radius: 3px; "
-            "color: {{color.accent.bright}}; font-size: 11px; font-weight: bold; }"
-            "QPushButton:hover { background: rgba(0, 112, 192, 180); "
-            "border: 1px solid {{color.accent}}; }"
-            "QPushButton:checked { background: {{color.accent.dim}}; color: {{color.text.primary}}; "
-            "border: 1px solid {{color.accent}}; }"));
-
     // HF bands (indices 0-10)
     constexpr int hfLayout[][3] = {
         {0, 1, 2},      // 160, 80, 60
@@ -3071,7 +3053,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     auto makeBandBtn = [&](int idx) {
         auto* btn = new QPushButton(BAND_GRID[idx].label, m_bandPanel);
         btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
-        btn->setStyleSheet(bandBtnStyle);
+        btn->setStyleSheet(kBandBtnStyle);
         btn->setCheckable(true);
         const QString bandName = QString::fromLatin1(BAND_GRID[idx].bandName);
         const double  freq = BAND_GRID[idx].freqMhz;
@@ -3105,7 +3087,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
                 bandName, m_declaredBandRanges);
             auto* btn = new QPushButton(label, m_bandPanel);
             btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
-            btn->setStyleSheet(bandBtnStyle);
+            btn->setStyleSheet(kBandBtnStyle);
             btn->setCheckable(true);
             const double  freq = def.defaultFreqMhz;
             const QString mode = QString::fromLatin1(def.defaultMode);
@@ -3153,7 +3135,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     for (int i = 0; i < xvtrBandCount; ++i) {
         auto* btn = new QPushButton(bands[i].name, m_bandPanel);
         btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
-        btn->setStyleSheet(xvtrBtnStyle);
+        btn->setStyleSheet(kXvtrBtnStyle);
         btn->setCheckable(true);
         const double freq = bands[i].rfFreqMhz;
         const QString name = bands[i].name;
@@ -3191,7 +3173,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
             }
             auto* btn = new QPushButton(BAND_GRID[idx].label, m_bandPanel);
             btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
-            btn->setStyleSheet(bandBtnStyle);
+            btn->setStyleSheet(kBandBtnStyle);
             QString bandName = QString::fromLatin1(BAND_GRID[idx].bandName);
             double freq = BAND_GRID[idx].freqMhz;
             QString mode = QString::fromLatin1(BAND_GRID[idx].mode);
@@ -3354,6 +3336,7 @@ void SpectrumOverlayMenu::applyTuningRangeToBandButtons()
 void SpectrumOverlayMenu::updateActiveBandHighlight()
 {
     if (!m_slice) {
+        m_lastHighlightedBand.clear();
         for (const auto& entry : m_bandButtons) {
             if (entry.button) {
                 QSignalBlocker b(entry.button);
@@ -3366,13 +3349,7 @@ void SpectrumOverlayMenu::updateActiveBandHighlight()
     const double freq = m_slice->frequency();
     QString activeBand = BandSettings::bandForFrequency(freq);
 
-    for (const auto& xvtr : m_lastXvtrBands) {
-        if (std::abs(freq - xvtr.rfFreqMhz) < 0.5) {
-            activeBand = xvtr.name;
-            break;
-        }
-    }
-
+    // Declared band ranges from connected backend/gateway.
     for (const auto& range : m_declaredBandRanges) {
         if (range.lowHz > 0.0 && range.highHz > 0.0) {
             const double lowMhz = range.lowHz / 1.0e6;
@@ -3383,6 +3360,23 @@ void SpectrumOverlayMenu::updateActiveBandHighlight()
             }
         }
     }
+
+    // Configured XVTR bands take precedence over declared and native bands,
+    // matching MainWindow::selectBand() resolution order (#5236).
+    // SmartSDR transverter objects define a center RF frequency (rfFreqMhz)
+    // rather than explicit band bounds in the protocol, so we match within
+    // a ±500 kHz window around the configured point frequency.
+    for (const auto& xvtr : m_lastXvtrBands) {
+        if (std::abs(freq - xvtr.rfFreqMhz) < 0.5) {
+            activeBand = xvtr.name;
+            break;
+        }
+    }
+
+    if (activeBand == m_lastHighlightedBand) {
+        return;
+    }
+    m_lastHighlightedBand = activeBand;
 
     for (const auto& entry : m_bandButtons) {
         if (!entry.button)

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -469,12 +469,18 @@ void SpectrumOverlayMenu::buildBandPanel()
     grid->setContentsMargins(2, 2, 2, 2);
     grid->setSpacing(2);
 
-    const QString bandBtnStyle =
-        "QPushButton { background: rgba(30, 40, 55, 220); "
-        "border: 1px solid #304050; border-radius: 3px; "
-        "color: #c8d8e8; font-size: 11px; font-weight: bold; }"
-        "QPushButton:hover { background: rgba(0, 112, 192, 180); "
-        "border: 1px solid #0090e0; }";
+    m_bandButtons.clear();
+    m_bandBtnFreqs.clear();
+
+    const QString bandBtnStyle = ThemeManager::instance().resolve(
+        QStringLiteral(
+            "QPushButton { background: rgba(30, 40, 55, 220); "
+            "border: 1px solid {{color.background.2}}; border-radius: 3px; "
+            "color: {{color.text.primary}}; font-size: 11px; font-weight: bold; }"
+            "QPushButton:hover { background: rgba(0, 112, 192, 180); "
+            "border: 1px solid {{color.accent}}; }"
+            "QPushButton:checked { background: {{color.accent.dim}}; color: {{color.text.primary}}; "
+            "border: 1px solid {{color.accent}}; }"));
 
     constexpr int layout[][3] = {
         {0, 1, 2},      // 160, 80, 60
@@ -506,11 +512,13 @@ void SpectrumOverlayMenu::buildBandPanel()
             } else if (bandName.isEmpty()) {
                 btn->setEnabled(false);
             } else {
+                btn->setCheckable(true);
                 connect(btn, &QPushButton::clicked, this, [this, bandName, freq, mode]() {
                     hideAllSubPanels();
                     emit bandSelected(bandName, freq, mode);
                 });
                 m_bandBtnFreqs.append({btn, freq});
+                m_bandButtons.append({btn, bandName});
             }
 
             grid->addWidget(btn, row, col);
@@ -518,6 +526,7 @@ void SpectrumOverlayMenu::buildBandPanel()
     }
 
     applyTuningRangeToBandButtons();
+    updateActiveBandHighlight();
     m_bandPanel->adjustSize();
 }
 
@@ -1173,7 +1182,12 @@ void SpectrumOverlayMenu::setSlice(SliceModel* slice)
         m_slice->disconnect(this);
     m_slice = slice;
     refreshAntennaCombo();
+    updateActiveBandHighlight();
     if (!m_slice) return;
+
+    connect(m_slice, &SliceModel::frequencyChanged, this, [this](double /*freqMhz*/) {
+        updateActiveBandHighlight();
+    });
 
     connect(m_slice, &SliceModel::rxAntennaChanged, this, [this](const QString& ant) {
         if (m_panadapter && !m_panadapter->rxAntenna().isEmpty())
@@ -1383,6 +1397,7 @@ void SpectrumOverlayMenu::showBandPanelAt(const QPoint& pos)
     if (!m_bandPanel)
         return;
 
+    updateActiveBandHighlight();
     m_bandPanelVisible = true;
     m_bandPanel->move(pos);
     m_bandPanel->raise();
@@ -3005,6 +3020,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     // here is about to dangle. Cleared HERE rather than after the rebuild,
     // because deleteLater() on the panel takes its children with it.
     m_bandBtnFreqs.clear();
+    m_bandButtons.clear();
 
     // Rebuild the main band panel to insert XVTR bands between
     // HF bands and utility buttons (WWV/GEN/2200/630/XVTR). (#571)
@@ -3024,19 +3040,25 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     grid->setContentsMargins(2, 2, 2, 2);
     grid->setSpacing(2);
 
-    const QString bandBtnStyle =
-        "QPushButton { background: rgba(30, 40, 55, 220); "
-        "border: 1px solid #304050; border-radius: 3px; "
-        "color: #c8d8e8; font-size: 11px; font-weight: bold; }"
-        "QPushButton:hover { background: rgba(0, 112, 192, 180); "
-        "border: 1px solid #0090e0; }";
+    const QString bandBtnStyle = ThemeManager::instance().resolve(
+        QStringLiteral(
+            "QPushButton { background: rgba(30, 40, 55, 220); "
+            "border: 1px solid {{color.background.2}}; border-radius: 3px; "
+            "color: {{color.text.primary}}; font-size: 11px; font-weight: bold; }"
+            "QPushButton:hover { background: rgba(0, 112, 192, 180); "
+            "border: 1px solid {{color.accent}}; }"
+            "QPushButton:checked { background: {{color.accent.dim}}; color: {{color.text.primary}}; "
+            "border: 1px solid {{color.accent}}; }"));
 
-    const QString xvtrBtnStyle =
-        "QPushButton { background: rgba(30, 40, 55, 220); "
-        "border: 1px solid #304050; border-radius: 3px; "
-        "color: #00d0ff; font-size: 11px; font-weight: bold; }"
-        "QPushButton:hover { background: rgba(0, 112, 192, 180); "
-        "border: 1px solid #0090e0; }";
+    const QString xvtrBtnStyle = ThemeManager::instance().resolve(
+        QStringLiteral(
+            "QPushButton { background: rgba(30, 40, 55, 220); "
+            "border: 1px solid {{color.background.2}}; border-radius: 3px; "
+            "color: {{color.accent.bright}}; font-size: 11px; font-weight: bold; }"
+            "QPushButton:hover { background: rgba(0, 112, 192, 180); "
+            "border: 1px solid {{color.accent}}; }"
+            "QPushButton:checked { background: {{color.accent.dim}}; color: {{color.text.primary}}; "
+            "border: 1px solid {{color.accent}}; }"));
 
     // HF bands (indices 0-10)
     constexpr int hfLayout[][3] = {
@@ -3050,6 +3072,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
         auto* btn = new QPushButton(BAND_GRID[idx].label, m_bandPanel);
         btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
         btn->setStyleSheet(bandBtnStyle);
+        btn->setCheckable(true);
         const QString bandName = QString::fromLatin1(BAND_GRID[idx].bandName);
         const double  freq = BAND_GRID[idx].freqMhz;
         const QString mode = QString::fromLatin1(BAND_GRID[idx].mode);
@@ -3058,6 +3081,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
             emit bandSelected(bandName, freq, mode);
         });
         m_bandBtnFreqs.append({btn, freq});
+        m_bandButtons.append({btn, bandName});
         return btn;
     };
 
@@ -3082,6 +3106,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
             auto* btn = new QPushButton(label, m_bandPanel);
             btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
             btn->setStyleSheet(bandBtnStyle);
+            btn->setCheckable(true);
             const double  freq = def.defaultFreqMhz;
             const QString mode = QString::fromLatin1(def.defaultMode);
             connect(btn, &QPushButton::clicked, this, [this, bandName, freq, mode]() {
@@ -3089,6 +3114,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
                 emit bandSelected(bandName, freq, mode);
             });
             m_bandBtnFreqs.append({btn, freq});
+            m_bandButtons.append({btn, bandName});
             grid->addWidget(btn, row, col % 3);
             if (++col % 3 == 0)
                 ++row;
@@ -3128,6 +3154,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
         auto* btn = new QPushButton(bands[i].name, m_bandPanel);
         btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
         btn->setStyleSheet(xvtrBtnStyle);
+        btn->setCheckable(true);
         const double freq = bands[i].rfFreqMhz;
         const QString name = bands[i].name;
         const QString stackKey = bands[i].stackKey;
@@ -3137,6 +3164,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
         });
         grid->addWidget(btn, row + i / 3, i % 3);
         m_xvtrBandBtns.append(btn);
+        m_bandButtons.append({btn, name});
     }
     if (xvtrBandCount > 0) {
         row += (xvtrBandCount + 2) / 3;  // advance past XVTR rows
@@ -3175,16 +3203,20 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
             } else if (bandName.isEmpty()) {
                 btn->setEnabled(false);
             } else {
+                btn->setCheckable(true);
                 connect(btn, &QPushButton::clicked, this, [this, bandName, freq, mode]() {
                     hideAllSubPanels();
                     emit bandSelected(bandName, freq, mode);
                 });
+                m_bandBtnFreqs.append({btn, freq});
+                m_bandButtons.append({btn, bandName});
             }
             grid->addWidget(btn, row, col);
         }
         ++row;
     }
 
+    updateActiveBandHighlight();
     m_bandPanel->adjustSize();
     m_bandPanelVisible = bandPanelWasVisible;
     if (bandPanelWasVisible)
@@ -3316,6 +3348,49 @@ void SpectrumOverlayMenu::applyTuningRangeToBandButtons()
                   .arg(m_tuningMinMhz, 0, 'f', 3)
                   .arg(m_tuningMaxMhz, 0, 'f', 3));
         ++it;
+    }
+}
+
+void SpectrumOverlayMenu::updateActiveBandHighlight()
+{
+    if (!m_slice) {
+        for (const auto& entry : m_bandButtons) {
+            if (entry.button) {
+                QSignalBlocker b(entry.button);
+                entry.button->setChecked(false);
+            }
+        }
+        return;
+    }
+
+    const double freq = m_slice->frequency();
+    QString activeBand = BandSettings::bandForFrequency(freq);
+
+    for (const auto& xvtr : m_lastXvtrBands) {
+        if (std::abs(freq - xvtr.rfFreqMhz) < 0.5) {
+            activeBand = xvtr.name;
+            break;
+        }
+    }
+
+    for (const auto& range : m_declaredBandRanges) {
+        if (range.lowHz > 0.0 && range.highHz > 0.0) {
+            const double lowMhz = range.lowHz / 1.0e6;
+            const double highMhz = range.highHz / 1.0e6;
+            if (freq >= lowMhz && freq <= highMhz) {
+                activeBand = range.name;
+                break;
+            }
+        }
+    }
+
+    for (const auto& entry : m_bandButtons) {
+        if (!entry.button)
+            continue;
+
+        const bool match = (entry.bandName.compare(activeBand, Qt::CaseInsensitive) == 0);
+        QSignalBlocker b(entry.button);
+        entry.button->setChecked(match);
     }
 }
 

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -11,6 +11,7 @@
 #include "Theme.h"
 #include "core/GpuSelector.h"
 #include "models/SliceModel.h"
+#include "models/BandPlanManager.h"
 #include "models/BandDefs.h"
 #include "models/BandSettings.h"
 #include "core/KiwiSdrManager.h"
@@ -270,8 +271,8 @@ static const QString kBandBtnStyle =
     "color: #c8d8e8; font-size: 11px; font-weight: bold; }"
     "QPushButton:hover { background: rgba(0, 112, 192, 180); "
     "border: 1px solid #0090e0; }"
-    "QPushButton:checked { background: #0070c0; color: #ffffff; "
-    "border: 1px solid #0090e0; }";
+    "QPushButton:checked { background: {{color.background.2}}; "
+    "color: {{color.text.primary}}; border: 2px solid {{color.text.primary}}; }";
 
 static const QString kXvtrBtnStyle =
     "QPushButton { background: rgba(30, 40, 55, 220); "
@@ -279,8 +280,8 @@ static const QString kXvtrBtnStyle =
     "color: #00d0ff; font-size: 11px; font-weight: bold; }"
     "QPushButton:hover { background: rgba(0, 112, 192, 180); "
     "border: 1px solid #0090e0; }"
-    "QPushButton:checked { background: #0070c0; color: #ffffff; "
-    "border: 1px solid #0090e0; }";
+    "QPushButton:checked { background: {{color.background.2}}; "
+    "color: {{color.text.primary}}; border: 2px solid {{color.text.primary}}; }";
 
 static inline QString colorPickerBtnStyle(const QString& colorHex)
 {
@@ -328,6 +329,52 @@ static constexpr BandGridEntry BAND_GRID[] = {
     {"4",    "4m",   70.200,  "USB"},   // 16 — FLEX-6500 (Region 1) + FLEX-6700
     {"2",    "2m",  144.200,  "USB"},   // 17 — FLEX-6700
 };
+
+// Broad, non-regulatory grouping windows map a frequency that is already
+// proven to lie inside the active BandPlanManager to the matching menu key.
+// Actual membership and gaps come only from the active regional plan.
+struct BandPlanLookup {
+    const char* bandName;
+    double searchLowMhz;
+    double searchHighMhz;
+};
+
+static constexpr BandPlanLookup kBandPlanLookup[] = {
+    {"2200m", 0.1, 0.2}, {"630m", 0.4, 0.5},
+    {"160m", 1.7, 2.1}, {"80m", 3.4, 4.1}, {"60m", 5.2, 5.5},
+    {"40m", 6.9, 7.4}, {"30m", 10.0, 10.2}, {"20m", 13.9, 14.5},
+    {"17m", 18.0, 18.3}, {"15m", 20.9, 21.6}, {"12m", 24.8, 25.1},
+    {"10m", 27.9, 30.0}, {"6m", 49.0, 54.5}, {"4m", 69.0, 71.0},
+    {"2m", 143.0, 149.0}, {"1.25m", 221.0, 226.0},
+    {"440", 419.0, 451.0}, {"33cm", 901.0, 929.0},
+    {"23cm", 1239.0, 1301.0},
+};
+
+static QString activePlanBandForFrequency(const BandPlanManager* manager,
+                                          double freqMhz)
+{
+    if (!manager) {
+        return QStringLiteral("GEN");
+    }
+
+    bool inActivePlan = false;
+    for (const BandPlanManager::Segment& segment : manager->segments()) {
+        if (freqMhz >= segment.lowMhz && freqMhz <= segment.highMhz) {
+            inActivePlan = true;
+            break;
+        }
+    }
+    if (!inActivePlan) {
+        return QStringLiteral("GEN");
+    }
+
+    for (const BandPlanLookup& lookup : kBandPlanLookup) {
+        if (freqMhz >= lookup.searchLowMhz && freqMhz <= lookup.searchHighMhz) {
+            return QString::fromLatin1(lookup.bandName);
+        }
+    }
+    return QStringLiteral("GEN");
+}
 
 // Indices into BAND_GRID for the built-in transverter bands.  Used by
 // the conditional VHF row in setXvtrBands().
@@ -513,7 +560,7 @@ void SpectrumOverlayMenu::buildBandPanel()
 
             auto* btn = new QPushButton(BAND_GRID[idx].label, m_bandPanel);
             btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
-            btn->setStyleSheet(kBandBtnStyle);
+            ThemeManager::instance().applyStyleSheet(btn, kBandBtnStyle);
 
             QString bandName = QString::fromLatin1(BAND_GRID[idx].bandName);
             double freq = BAND_GRID[idx].freqMhz;
@@ -1233,6 +1280,26 @@ void SpectrumOverlayMenu::setSlice(SliceModel* slice)
 
     syncAntPanel();
     syncDaxPanel();
+}
+
+void SpectrumOverlayMenu::setBandPlanManager(BandPlanManager* manager)
+{
+    if (m_bandPlanManager == manager) {
+        return;
+    }
+    if (m_bandPlanManager) {
+        disconnect(m_bandPlanManager, nullptr, this, nullptr);
+    }
+    m_bandPlanManager = manager;
+    if (m_bandPlanManager) {
+        connect(m_bandPlanManager, &BandPlanManager::planChanged,
+                this, [this]() {
+            m_lastHighlightedBand.clear();
+            updateActiveBandHighlight();
+        });
+    }
+    m_lastHighlightedBand.clear();
+    updateActiveBandHighlight();
 }
 
 void SpectrumOverlayMenu::syncAntPanel()
@@ -3053,7 +3120,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     auto makeBandBtn = [&](int idx) {
         auto* btn = new QPushButton(BAND_GRID[idx].label, m_bandPanel);
         btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
-        btn->setStyleSheet(kBandBtnStyle);
+        ThemeManager::instance().applyStyleSheet(btn, kBandBtnStyle);
         btn->setCheckable(true);
         const QString bandName = QString::fromLatin1(BAND_GRID[idx].bandName);
         const double  freq = BAND_GRID[idx].freqMhz;
@@ -3087,7 +3154,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
                 bandName, m_declaredBandRanges);
             auto* btn = new QPushButton(label, m_bandPanel);
             btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
-            btn->setStyleSheet(kBandBtnStyle);
+            ThemeManager::instance().applyStyleSheet(btn, kBandBtnStyle);
             btn->setCheckable(true);
             const double  freq = def.defaultFreqMhz;
             const QString mode = QString::fromLatin1(def.defaultMode);
@@ -3135,7 +3202,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     for (int i = 0; i < xvtrBandCount; ++i) {
         auto* btn = new QPushButton(bands[i].name, m_bandPanel);
         btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
-        btn->setStyleSheet(kXvtrBtnStyle);
+        ThemeManager::instance().applyStyleSheet(btn, kXvtrBtnStyle);
         btn->setCheckable(true);
         const double freq = bands[i].rfFreqMhz;
         const QString name = bands[i].name;
@@ -3173,7 +3240,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
             }
             auto* btn = new QPushButton(BAND_GRID[idx].label, m_bandPanel);
             btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
-            btn->setStyleSheet(kBandBtnStyle);
+            ThemeManager::instance().applyStyleSheet(btn, kBandBtnStyle);
             QString bandName = QString::fromLatin1(BAND_GRID[idx].bandName);
             double freq = BAND_GRID[idx].freqMhz;
             QString mode = QString::fromLatin1(BAND_GRID[idx].mode);
@@ -3347,7 +3414,7 @@ void SpectrumOverlayMenu::updateActiveBandHighlight()
     }
 
     const double freq = m_slice->frequency();
-    QString activeBand = BandSettings::bandForFrequency(freq);
+    QString activeBand = activePlanBandForFrequency(m_bandPlanManager, freq);
 
     // Declared band ranges from connected backend/gateway.
     for (const auto& range : m_declaredBandRanges) {

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -22,6 +22,7 @@ class QScrollArea;
 namespace AetherSDR {
 
 class MemoryBrowsePanel;
+class BandPlanManager;
 class KiwiSdrManager;
 class SliceModel;
 class SpectrumOverlayWheelGuard;
@@ -94,6 +95,9 @@ public:
 
     // Connect/disconnect the ANT panel to a slice model.
     void setSlice(SliceModel* slice);
+    // Use the active regional plan when mapping the slice frequency to a
+    // native band button. The manager is owned by MainWindow.
+    void setBandPlanManager(BandPlanManager* manager);
     void setWnbState(bool on, int level);
     // Show/hide the whole WNB row (button + level slider + readout) based on
     // whether the radio runs its own DSP (RadioCapabilities::hasRadioSideDsp).
@@ -326,6 +330,7 @@ private:
     };
     QVector<BandButtonEntry> m_bandButtons;
     QString m_lastHighlightedBand;
+    BandPlanManager* m_bandPlanManager{nullptr};
     double m_tuningMinMhz{0.0};
     double m_tuningMaxMhz{0.0};
     // True until a connected backend says otherwise, so a disconnected session

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -325,6 +325,7 @@ private:
         QString bandName;
     };
     QVector<BandButtonEntry> m_bandButtons;
+    QString m_lastHighlightedBand;
     double m_tuningMinMhz{0.0};
     double m_tuningMaxMhz{0.0};
     // True until a connected backend says otherwise, so a disconnected session

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -320,12 +320,18 @@ private:
     // deleteLater() on every rebuild, so entries can outlive their buttons by a
     // full event-loop turn if a range update lands in that window.
     QVector<QPair<QPointer<QPushButton>, double>> m_bandBtnFreqs;
+    struct BandButtonEntry {
+        QPointer<QPushButton> button;
+        QString bandName;
+    };
+    QVector<BandButtonEntry> m_bandButtons;
     double m_tuningMinMhz{0.0};
     double m_tuningMaxMhz{0.0};
     // True until a connected backend says otherwise, so a disconnected session
     // keeps the button rather than having it appear on connect.
     bool m_notchesSupported{true};
     void applyTuningRangeToBandButtons();
+    void updateActiveBandHighlight();
 
     // Cached state for band-panel rebuilds — setXvtrBands() and
     // setRadioCapabilities() each store their argument and trigger

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -872,18 +872,6 @@ const WfGradientStop* wfSchemeStops(WfColorScheme scheme, int& count)
     return v.data();
 }
 
-const char* wfSchemeName(WfColorScheme scheme)
-{
-    switch (scheme) {
-    case WfColorScheme::Grayscale: return "Grayscale";
-    case WfColorScheme::BlueGreen: return "Blue-Green";
-    case WfColorScheme::Fire:      return "Fire";
-    case WfColorScheme::Plasma:    return "Plasma";
-    case WfColorScheme::Purple:    return "Purple";
-    default:                       return "Default";
-    }
-}
-
 // Interpolate a normalized value t (0–1) through the given gradient stops.
 static QRgb interpolateGradient(float t, const WfGradientStop* stops, int n)
 {

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2739,6 +2739,9 @@ void SpectrumWidget::applyActiveVfoZOrder()
 
 void SpectrumWidget::setBandPlanManager(BandPlanManager* mgr) {
     m_bandPlanMgr = mgr;
+    if (m_overlayMenu) {
+        m_overlayMenu->setBandPlanManager(mgr);
+    }
     if (mgr) {
         connect(mgr, &BandPlanManager::planChanged, this, QOverload<>::of(&QWidget::update));
         connect(mgr, &BandPlanManager::kiwiDxSpotsChanged, this, [this]() {

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -74,6 +74,8 @@ struct WfGradientStop { float pos; int r, g, b; };
 const WfGradientStop* wfSchemeStops(WfColorScheme scheme, int& count);
 
 // Returns the display name for a color scheme.
+// Inlined in header so standalone test targets (e.g. spectrum_overlay_band_highlight_test)
+// link cleanly without pulling in the full SpectrumWidget TU.
 inline const char* wfSchemeName(WfColorScheme scheme)
 {
     switch (scheme) {

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -74,7 +74,17 @@ struct WfGradientStop { float pos; int r, g, b; };
 const WfGradientStop* wfSchemeStops(WfColorScheme scheme, int& count);
 
 // Returns the display name for a color scheme.
-const char* wfSchemeName(WfColorScheme scheme);
+inline const char* wfSchemeName(WfColorScheme scheme)
+{
+    switch (scheme) {
+    case WfColorScheme::Grayscale: return "Grayscale";
+    case WfColorScheme::BlueGreen: return "Blue-Green";
+    case WfColorScheme::Fire:      return "Fire";
+    case WfColorScheme::Plasma:    return "Plasma";
+    case WfColorScheme::Purple:    return "Purple";
+    default:                       return "Default";
+    }
+}
 
 // Spectrum render mode for the panadapter surface.
 enum class SpectrumRenderMode : int {

--- a/tests/spectrum_overlay_band_highlight_test.cpp
+++ b/tests/spectrum_overlay_band_highlight_test.cpp
@@ -1,4 +1,5 @@
 #include "gui/SpectrumOverlayMenu.h"
+#include "models/BandPlanManager.h"
 #include "models/SliceModel.h"
 
 #include <QApplication>
@@ -42,6 +43,14 @@ int main(int argc, char* argv[])
     QWidget parent;
     SpectrumOverlayMenu menu(&parent);
     SliceModel slice(0);
+    BandPlanManager bandPlan;
+    bandPlan.setSegmentsForTest({
+        {3.500, 3.800, "80m", "", QColor()},
+        {7.000, 7.200, "40m", "", QColor()},
+        {14.000, 14.350, "20m", "", QColor()},
+        {144.000, 148.000, "2m", "", QColor()},
+    });
+    menu.setBandPlanManager(&bandPlan);
 
     auto* btn20 = findBandButton(parent, "20");
     auto* btn40 = findBandButton(parent, "40");
@@ -70,6 +79,12 @@ int main(int argc, char* argv[])
     report("40m button highlighted when frequency changes to 7.150 MHz",
            btn40 && btn40->isChecked() && btn20 && !btn20->isChecked() &&
            btnGen && !btnGen->isChecked());
+
+    // 7.250 MHz is inside the legacy US BandDefs range but outside the active
+    // Region 1 plan supplied above, so the overlay must not highlight 40m.
+    slice.setFrequency(7.250);
+    report("GEN highlighted outside active regional 40m allocation",
+           btnGen && btnGen->isChecked() && btn40 && !btn40->isChecked());
 
     // Frequency changes to general coverage (15.000 MHz)
     slice.setFrequency(15.000);
@@ -130,6 +145,13 @@ int main(int argc, char* argv[])
     slice.setFrequency(146.000);
     report("2m button highlighted when outside XVTR window",
            btn2 && btn2->isChecked() && btn2mSat && !btn2mSat->isChecked());
+
+    // setRadioCapabilities()/setXvtrBands() rebuild the panel, so reacquire
+    // every raw button pointer used below after deferred deletes are drained.
+    btn20 = findBandButton(parent, "20");
+    btnGen = findBandButton(parent, "GEN");
+    btn2 = findBandButton(parent, "2");
+    btn2mSat = findBandButton(parent, "2m-Sat");
 
     // Detach slice
     menu.setSlice(nullptr);

--- a/tests/spectrum_overlay_band_highlight_test.cpp
+++ b/tests/spectrum_overlay_band_highlight_test.cpp
@@ -106,11 +106,36 @@ int main(int argc, char* argv[])
     report("20m button highlighted after XVTR rebuild",
            btn20 && btn20->isChecked() && btn222 && !btn222->isChecked());
 
+    // Test with radio capability for 2m (native 2m button labelled "2") and XVTR overlap (finding 3 / finding 4)
+    ModelCapabilities caps;
+    caps.has2Meters = true;
+    menu.setRadioCapabilities(caps);
+    QVector<SpectrumOverlayMenu::XvtrBand> xvtrsWithOverlap = {
+        {"2m-Sat", 144.200, "X1"}
+    };
+    menu.setXvtrBands(xvtrsWithOverlap);
+    app.processEvents();
+
+    auto* btn2 = findBandButton(parent, "2");
+    auto* btn2mSat = findBandButton(parent, "2m-Sat");
+    report("Native 2m button '2' and XVTR button '2m-Sat' created",
+           btn2 != nullptr && btn2mSat != nullptr);
+
+    // Tune within the XVTR window: XVTR must win over native/declared 2m band (finding 3)
+    slice.setFrequency(144.200);
+    report("XVTR button takes precedence over 2m button when overlapping",
+           btn2mSat && btn2mSat->isChecked() && btn2 && !btn2->isChecked());
+
+    // Tune within 2m band but outside XVTR ±500 kHz window: 2m button highlighted
+    slice.setFrequency(146.000);
+    report("2m button highlighted when outside XVTR window",
+           btn2 && btn2->isChecked() && btn2mSat && !btn2mSat->isChecked());
+
     // Detach slice
     menu.setSlice(nullptr);
     report("All buttons unhighlighted after detaching slice",
-           btn20 && !btn20->isChecked() && btn222 && !btn222->isChecked() &&
-           btnGen && !btnGen->isChecked());
+           btn20 && !btn20->isChecked() && btn2 && !btn2->isChecked() &&
+           btn2mSat && !btn2mSat->isChecked() && btnGen && !btnGen->isChecked());
 
     return g_failed == 0 ? 0 : 1;
 }

--- a/tests/spectrum_overlay_band_highlight_test.cpp
+++ b/tests/spectrum_overlay_band_highlight_test.cpp
@@ -1,0 +1,116 @@
+#include "gui/SpectrumOverlayMenu.h"
+#include "models/SliceModel.h"
+
+#include <QApplication>
+#include <QPushButton>
+#include <QWidget>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) {
+        ++g_failed;
+    }
+}
+
+QPushButton* findBandButton(QWidget& parent, const QString& text)
+{
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    const auto buttons = parent.findChildren<QPushButton*>();
+    for (auto* btn : buttons) {
+        if (btn->text() == text) {
+            return btn;
+        }
+    }
+    return nullptr;
+}
+
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    QApplication app(argc, argv);
+
+    QWidget parent;
+    SpectrumOverlayMenu menu(&parent);
+    SliceModel slice(0);
+
+    auto* btn20 = findBandButton(parent, "20");
+    auto* btn40 = findBandButton(parent, "40");
+    auto* btn80 = findBandButton(parent, "80");
+    auto* btnWwv = findBandButton(parent, "WWV");
+    auto* btnGen = findBandButton(parent, "GEN");
+
+    report("Band buttons present in overlay menu",
+           btn20 && btn40 && btn80 && btnWwv && btnGen);
+
+    // Initial state without slice
+    menu.setSlice(nullptr);
+    report("No button checked when slice is null",
+           btn20 && !btn20->isChecked() && btn40 && !btn40->isChecked() &&
+           btnGen && !btnGen->isChecked() && btnWwv && !btnWwv->isChecked());
+
+    // Tune slice to 20m (14.225 MHz) and attach
+    slice.setFrequency(14.225);
+    menu.setSlice(&slice);
+    report("20m button highlighted when slice frequency is 14.225 MHz",
+           btn20 && btn20->isChecked() && btn40 && !btn40->isChecked() &&
+           btnGen && !btnGen->isChecked() && btnWwv && !btnWwv->isChecked());
+
+    // Frequency changes to 40m (7.150 MHz)
+    slice.setFrequency(7.150);
+    report("40m button highlighted when frequency changes to 7.150 MHz",
+           btn40 && btn40->isChecked() && btn20 && !btn20->isChecked() &&
+           btnGen && !btnGen->isChecked());
+
+    // Frequency changes to general coverage (15.000 MHz)
+    slice.setFrequency(15.000);
+    report("GEN button highlighted on 15.000 MHz",
+           btnGen && btnGen->isChecked() && btn20 && !btn20->isChecked() &&
+           btn40 && !btn40->isChecked());
+
+    // Frequency changes to 80m (3.800 MHz)
+    slice.setFrequency(3.800);
+    report("80m button highlighted on 3.800 MHz",
+           btn80 && btn80->isChecked() && btnGen && !btnGen->isChecked());
+
+    // Test with XVTR bands
+    QVector<SpectrumOverlayMenu::XvtrBand> xvtrs = {
+        {"222", 222.100, "X1"},
+        {"1296", 1296.100, "X2"}
+    };
+    menu.setXvtrBands(xvtrs);
+    app.processEvents();
+
+    auto* btn222 = findBandButton(parent, "222");
+    auto* btn1296 = findBandButton(parent, "1296");
+    btn20 = findBandButton(parent, "20");
+    btnGen = findBandButton(parent, "GEN");
+
+    report("XVTR buttons created after setXvtrBands",
+           btn222 != nullptr && btn1296 != nullptr);
+
+    slice.setFrequency(222.100);
+    report("XVTR 222 button highlighted when tuned to 222.100 MHz",
+           btn222 && btn222->isChecked() && btn1296 && !btn1296->isChecked());
+
+    slice.setFrequency(14.074);
+    report("20m button highlighted after XVTR rebuild",
+           btn20 && btn20->isChecked() && btn222 && !btn222->isChecked());
+
+    // Detach slice
+    menu.setSlice(nullptr);
+    report("All buttons unhighlighted after detaching slice",
+           btn20 && !btn20->isChecked() && btn222 && !btn222->isChecked() &&
+           btnGen && !btnGen->isChecked());
+
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3720,6 +3720,39 @@ add_test(NAME spectrum_overlay_wheel_guard_test
 set_tests_properties(spectrum_overlay_wheel_guard_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
+add_executable(spectrum_overlay_band_highlight_test
+    tests/spectrum_overlay_band_highlight_test.cpp
+    src/gui/SpectrumOverlayMenu.cpp
+    src/gui/SpectrumOverlayWheelGuard.cpp
+    src/gui/MemoryBrowsePanel.cpp
+    src/gui/DragValuePopup.cpp
+    src/gui/DspParamPopup.cpp
+)
+target_include_directories(spectrum_overlay_band_highlight_test PRIVATE src)
+if(DEBIAN_GPU_FIX_REQUIRED)
+    target_include_directories(spectrum_overlay_band_highlight_test PRIVATE
+        "${DEBIAN_PRIVATE_INC}"
+        "${DEBIAN_PRIVATE_INC}/QtGui"
+    )
+endif()
+if(QT_FRAMEWORK_PRIVATE_INC)
+    target_include_directories(spectrum_overlay_band_highlight_test PRIVATE
+        "${QT_FRAMEWORK_PRIVATE_INC}"
+        "${QT_FRAMEWORK_PRIVATE_INC}/QtGui"
+    )
+endif()
+target_link_libraries(spectrum_overlay_band_highlight_test PRIVATE
+    aethercore Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Test
+)
+if(TARGET Qt6::GuiPrivate)
+    target_link_libraries(spectrum_overlay_band_highlight_test PRIVATE Qt6::GuiPrivate)
+endif()
+set_target_properties(spectrum_overlay_band_highlight_test PROPERTIES AUTOMOC ON)
+add_test(NAME spectrum_overlay_band_highlight_test
+         COMMAND spectrum_overlay_band_highlight_test)
+set_tests_properties(spectrum_overlay_band_highlight_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 add_executable(device_diagnostics_test
     tests/device_diagnostics_test.cpp
 )
@@ -4169,6 +4202,7 @@ set(AETHER_SETTINGS_CONSUMERS
     vkamp_connection_test
     radio_capability_gating_test
     system_info_dialog_test
+    spectrum_overlay_band_highlight_test
 )
 foreach(_settings_consumer IN LISTS AETHER_SETTINGS_CONSUMERS)
     if(TARGET ${_settings_consumer})


### PR DESCRIPTION
## Summary

Highlights the currently active band button in the panadapter spectrum overlay's floating band selection menu based on the active slice's frequency.

- When the active slice frequency changes or when a slice is attached/detached, the corresponding band button updates its checked state.
- Matches across standard HF bands, configured XVTR bands, and radio-declared band ranges using `BandSettings::bandForFrequency()`.
- Uses `QSignalBlocker` to update button checked state cleanly without triggering spurious click emissions.
- Inlines `wfSchemeName()` in `SpectrumWidget.h` so standalone overlay test targets link without pulling heavy rendering dependencies.

## Constitution principle honored

Principle II — The Radio Is Authoritative On Live State (overlay band button highlight reflects the active slice frequency and live band state from the radio model).
Principle IV — Every Contribution Is Clean-Room (code is clean-room, not derived from decompiled sources).

## Test plan

- [x] Local build passes (`cmake --build build`)
- [X] Behavior verified on a real radio if applicable
- [x] Existing tests pass (CI)
- [ ] Reproduction steps documented if user-reported bug

Verification details:
- Unit test suite: `spectrum_overlay_band_highlight_test` built cleanly and passed all 10 test assertions (standard HF bands, general coverage, transverter bands, and slice attachment/detachment).
- Full suite of repository static checks passed with `--strict` (engine boundary, test registration, network timeouts, theme seed, GLSL dialects, accessibility).

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [ ] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [ ] Documentation updated if user-visible behavior changed — `docs/` and the
      affected READMEs. **Not `CHANGELOG.md`**, which is a release-prep file a
      PR must not add to (AGENTS.md); describe it in the Summary above instead
- [ ] Security-sensitive changes reference a GHSA if applicable