### PR TITLE
feat(gui): pop out and resize the CWX window

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -942,6 +942,7 @@ set(GUI_SOURCES
     src/gui/FramelessWindowTitleBar.cpp
     src/gui/FramelessResizer.cpp
     src/gui/PanFloatingWindow.cpp
+    src/gui/CwxFloatingWindow.cpp
     src/gui/DvkPanel.cpp
     src/gui/AmpApplet.cpp
     src/gui/AcomApplet.cpp

--- a/src/gui/CwxFloatingWindow.cpp
+++ b/src/gui/CwxFloatingWindow.cpp
@@ -1,0 +1,52 @@
+#include "CwxFloatingWindow.h"
+#include "CwxPanel.h"
+
+#include <QCloseEvent>
+#include <QVBoxLayout>
+
+namespace AetherSDR {
+
+CwxFloatingWindow::CwxFloatingWindow(QWidget* parent)
+    : PersistentDialog("CWX", "CwxFloatingGeometry", parent)
+{
+    setMinimumSize(220, 260);
+
+    m_layout = new QVBoxLayout(bodyWidget());
+    m_layout->setContentsMargins(0, 0, 0, 0);
+    m_layout->setSpacing(0);
+    setBodyLayoutMargins({0, 0, 0, 0}, {0, 0, 0, 0});
+}
+
+void CwxFloatingWindow::adoptPanel(CwxPanel* panel)
+{
+    if (!panel) return;
+    m_panel = panel;
+
+    // addWidget() calls setParent() internally, so the panel goes straight
+    // from the splitter to this window without an intermediate top-level
+    // state (same reasoning as PanFloatingWindow::adoptApplet).
+    m_layout->addWidget(m_panel, 1);
+}
+
+CwxPanel* CwxFloatingWindow::takePanel()
+{
+    if (!m_panel) return nullptr;
+    auto* p = m_panel;
+    m_layout->removeWidget(p);
+    p->setParent(nullptr);
+    m_panel = nullptr;
+    return p;
+}
+
+void CwxFloatingWindow::closeEvent(QCloseEvent* event)
+{
+    // Run the base class's geometry-save-and-accept first (crash-resilient
+    // disk flush, matching every other PersistentDialog), then override its
+    // acceptance: CWX doesn't destroy on close, it docks back into
+    // MainWindow's splitter — mirrors PanFloatingWindow::closeEvent.
+    PersistentDialog::closeEvent(event);
+    emit dockRequested();
+    event->ignore();
+}
+
+} // namespace AetherSDR

--- a/src/gui/CwxFloatingWindow.h
+++ b/src/gui/CwxFloatingWindow.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "PersistentDialog.h"
+
+class QVBoxLayout;
+
+namespace AetherSDR {
+
+class CwxPanel;
+
+// Top-level, resizable host for a popped-out CwxPanel. Built on
+// PersistentDialog for the standard geometry-persist + frameless-chrome
+// boilerplate (see docs/style/dialog-patterns.md) — CwxFloatingWindow only
+// adds the adopt/take reparenting dance, since (unlike a typical
+// PersistentDialog subclass) its content is an existing, model-bound
+// CwxPanel that must return intact to MainWindow's splitter on dock rather
+// than being destroyed with the window.
+//
+// Created by MainWindow::floatCwxPanel(), destroyed by
+// MainWindow::dockCwxPanel() — mirrors PanFloatingWindow's lifecycle for
+// panadapters, minus the GPU-surface teardown that class needs and CWX's
+// plain QWidget content does not.
+class CwxFloatingWindow : public PersistentDialog {
+    Q_OBJECT
+
+public:
+    explicit CwxFloatingWindow(QWidget* parent = nullptr);
+
+    void adoptPanel(CwxPanel* panel);
+    CwxPanel* takePanel();
+    CwxPanel* panel() const { return m_panel; }
+
+signals:
+    // Emitted when the window is closed (title-bar X, Alt+F4, ...) instead
+    // of actually closing — MainWindow docks the panel back into the
+    // splitter in response, matching PanFloatingWindow's dockRequested.
+    void dockRequested();
+
+protected:
+    void closeEvent(QCloseEvent* event) override;
+
+private:
+    CwxPanel*    m_panel{nullptr};
+    QVBoxLayout* m_layout{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -228,11 +228,39 @@ CwxPanel::CwxPanel(CwxModel* model, QWidget* parent)
     vbox->setContentsMargins(0, 0, 0, 0);
     vbox->setSpacing(0);
 
-    // Title
+    // Title row — label + pop-out/dock toggle
+    auto* titleRow = new QWidget;
+    AetherSDR::ThemeManager::instance().applyStyleSheet(titleRow, "QWidget { background: {{color.background.0}}; }");
+    auto* titleLayout = new QHBoxLayout(titleRow);
+    titleLayout->setContentsMargins(8, 6, 6, 6);
+    titleLayout->setSpacing(4);
+
     m_titleLabel = new QLabel("CWX");
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_titleLabel, "QLabel { color: {{color.accent}}; font-size: 14px; font-weight: bold; "
-                         "padding: 6px 8px; background: {{color.background.0}}; }");
-    vbox->addWidget(m_titleLabel);
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_titleLabel, "QLabel { color: {{color.accent}}; font-size: 14px; font-weight: bold; }");
+    titleLayout->addWidget(m_titleLabel);
+    titleLayout->addStretch();
+
+    // Pop-out / dock toggle (⬈ when docked, ↩ when floating) — same glyph
+    // and \uXXXX-escape convention as PanadapterApplet's pop-out button
+    // (a raw UTF-8 literal here would only decode correctly under the
+    // AetherSDR/aethercore targets' /utf-8 flag, not the standalone test
+    // targets that compile this file directly).
+    m_popOutBtn = new QPushButton(QStringLiteral("\u2b08"));  // ⬈
+    m_popOutBtn->setObjectName(QStringLiteral("cwxPopOutBtn"));
+    m_popOutBtn->setAccessibleName(tr("Pop out CWX"));
+    m_popOutBtn->setToolTip(tr("Pop out CWX"));
+    m_popOutBtn->setFixedSize(18, 16);
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_popOutBtn,
+        "QPushButton { background: transparent; color: {{color.text.label}}; "
+        "border: none; font-size: 11px; padding: 0; }"
+        "QPushButton:hover { color: {{color.text.primary}}; }");
+    connect(m_popOutBtn, &QPushButton::clicked, this, [this]() {
+        if (m_floating) emit dockClicked();
+        else            emit popOutClicked();
+    });
+    titleLayout->addWidget(m_popOutBtn);
+
+    vbox->addWidget(titleRow);
 
     // Stacked widget for Send/Live vs Setup
     m_stack = new QStackedWidget;
@@ -378,6 +406,29 @@ void CwxPanel::setDisplayName(const QString& name)
 QString CwxPanel::displayName() const
 {
     return m_titleLabel ? m_titleLabel->text() : QString{};
+}
+
+void CwxPanel::setFloatingState(bool floating)
+{
+    m_floating = floating;
+    // Docked: fixed 250px width matches the splitter's other left-side
+    // panels (DVK). Floating: free resize inside CwxFloatingWindow, whose
+    // own minimumSize() takes over.
+    if (floating) {
+        setMinimumWidth(0);
+        setMaximumWidth(QWIDGETSIZE_MAX);
+    } else {
+        setFixedWidth(250);
+    }
+    if (m_popOutBtn) {
+        const QString actionName = floating ? tr("Dock CWX") : tr("Pop out CWX");
+        // \uXXXX escapes, not raw UTF-8 literals — see the constructor's
+        // pop-out button comment for why.
+        m_popOutBtn->setText(floating ? QStringLiteral("\u21a9")   // ↩
+                                       : QStringLiteral("\u2b08")); // ⬈
+        m_popOutBtn->setAccessibleName(actionName);
+        m_popOutBtn->setToolTip(actionName);
+    }
 }
 
 void CwxPanel::configureTextKeyer(const QString& name, int minWpm, int maxWpm,

--- a/src/gui/CwxPanel.h
+++ b/src/gui/CwxPanel.h
@@ -103,6 +103,14 @@ public:
     CwxBubble* pendingBubble() const { return m_pendingBubble; }
     int        historyBubbleCount() const;
 
+    // Toggle between the docked (fixed-width, splitter-hosted) and floating
+    // (free-resize, top-level-hosted) presentations. Owner (MainWindow) calls
+    // this after reparenting the panel into/out of a CwxFloatingWindow; the
+    // panel itself only knows how to look right in each state, not how to
+    // get there — matches PanadapterApplet::setFloatingState().
+    void setFloatingState(bool floating);
+    bool isFloating() const { return m_floating; }
+
 protected:
     bool eventFilter(QObject* obj, QEvent* event) override;
 
@@ -110,6 +118,12 @@ private slots:
     void onCharSent(int index);
     void onSpeedChanged(int wpm);
     void onTransmissionCancelled();
+
+signals:
+    // Emitted by the title-row pop-out/dock button; MainWindow owns the
+    // actual reparenting (see MainWindow::floatCwxPanel()/dockCwxPanel()).
+    void popOutClicked();
+    void dockClicked();
 
 private:
     void buildSendView();
@@ -124,6 +138,8 @@ private:
 
     CwxModel*       m_model{nullptr};
     QLabel*         m_titleLabel{nullptr};
+    QPushButton*    m_popOutBtn{nullptr};
+    bool            m_floating{false};
 
     QStackedWidget* m_stack{nullptr};
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4806,6 +4806,10 @@ void MainWindow::buildUI()
     m_cwxPanel->setTransmittingProvider([this]() {
         return m_radioModel.transmitModel().isTransmitting();
     });
+    // Pop-out/dock button in the panel's own title row — see
+    // floatCwxPanel()/dockCwxPanel() (MainWindow_Wiring.cpp).
+    connect(m_cwxPanel, &CwxPanel::popOutClicked, this, &MainWindow::floatCwxPanel);
+    connect(m_cwxPanel, &CwxPanel::dockClicked, this, &MainWindow::dockCwxPanel);
     splitter->addWidget(m_cwxPanel);
     m_cwxPanel->hide();
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -176,6 +176,7 @@ class UlanziDialMacOSManager;
 class UlanziDialBackend;
 #endif
 class CwxPanel;
+class CwxFloatingWindow;
 class DvkPanel;
 #ifdef HAVE_RADE
 class RADEEngine;
@@ -870,6 +871,19 @@ private:
 #ifdef AETHER_ASR_ENABLED
     void showCopyAssist();
 #endif
+    // Show/hide the CWX panel, respecting its persisted docked/floating
+    // preference (CwxPanelFloating in AppSettings) — the counterpart to
+    // MainWindow_Shortcuts.cpp's m_cwxIndicator click handler, which owns
+    // the DVK mutual-exclusion and indicator styling around these calls.
+    void showCwxPanel();
+    void hideCwxPanel();
+    // Reparent the CWX panel between the splitter and a CwxFloatingWindow.
+    // Persists the docked/floating preference so the next showCwxPanel()
+    // (this session or a future one) opens in the same presentation, and —
+    // via CwxFloatingWindow's PersistentDialog base — the floating window's
+    // last size/position.
+    void floatCwxPanel();
+    void dockCwxPanel();
     void scheduleDigitalVoiceAutoStart();
     void stopDigitalVoiceService(bool waitForExit);
     void showPskReporterMapDialog();
@@ -1446,6 +1460,7 @@ private:
     QLabel* m_asrIndicator{nullptr};  // status-bar ASR (Copy Assist) toggle
 #endif
     CwxPanel* m_cwxPanel{nullptr};
+    QPointer<CwxFloatingWindow> m_cwxFloatingWindow;
     DvkPanel* m_dvkPanel{nullptr};
     QLabel* m_dvkIndicator{nullptr};
     QLabel* m_fdxIndicator{nullptr};

--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -572,36 +572,35 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
             m_dvkPanel->hide();
             updateKeyerAvailability();
         }
-        m_cwxPanel->setVisible(show);
+        // Docked/floating presentation and splitter sizing live in
+        // showCwxPanel()/hideCwxPanel() (MainWindow_Wiring.cpp) — this
+        // handler only owns the DVK mutual exclusion and indicator styling.
+        if (show) showCwxPanel();
+        else      hideCwxPanel();
         m_cwxIndicator->setStyleSheet(show
             ? "QLabel { color: #00b4d8; font-weight: bold; font-size: 24px; }"
             : "QLabel { color: #404858; font-weight: bold; font-size: 24px; }");
-        if (show) {
-            auto sizes = m_splitter->sizes();
-            if (sizes.size() >= 4) {
-                int cwxW = 250;
-                int total = sizes[0] + sizes[1] + sizes[2];
-                sizes[0] = cwxW;
-                sizes[1] = 0;
-                sizes[2] = total - cwxW;
-                m_splitter->setSizes(sizes);
-            }
-        }
         return true;
     }
     if (obj == m_dvkIndicator && event->type() == QEvent::MouseButtonPress) {
         if (!m_dvkIndicator->isEnabled()) return true;
         bool show = !m_dvkPanel->isVisible();
-        // Close CWX (mutual exclusion)
+        // Close CWX (mutual exclusion). hideCwxPanel() (not a bare
+        // m_cwxPanel->hide()) so a floating CWX window gets hidden too,
+        // rather than leaving an empty floating window on screen while its
+        // now-hidden content sits reparented inside it.
         if (show && m_cwxPanel->isVisible()) {
-            m_cwxPanel->hide();
+            hideCwxPanel();
             updateKeyerAvailability();
         }
         m_dvkPanel->setVisible(show);
         m_dvkIndicator->setStyleSheet(show
             ? "QLabel { color: #00b4d8; font-weight: bold; font-size: 24px; }"
             : "QLabel { color: #404858; font-weight: bold; font-size: 24px; }");
-        if (show) {
+        // Splitter index 0 is CWX's docked slot — skip this resize while
+        // CWX is floating (detached from the splitter; see floatCwxPanel()),
+        // or sizes[0]=0 would zero out DVK's own slot instead.
+        if (show && !m_cwxFloatingWindow) {
             auto sizes = m_splitter->sizes();
             if (sizes.size() >= 4) {
                 int dvkW = 250;

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -26,6 +26,8 @@
 #include "DisplayStatusGate.h"       // #4261 adaptive-throttle echo gate
 #include "Ax25HfPacketDecodeDialog.h"
 #include "AppletPanel.h"
+#include "CwxFloatingWindow.h"
+#include "CwxPanel.h"
 #include "DbmRangeTransition.h"
 #include "MainWindowHelpers.h"
 #include "OwnedSingleShotTimer.h"
@@ -73,6 +75,7 @@
 #include <QDateTime>
 #include <QElapsedTimer>
 #include <QJsonDocument>
+#include <QSplitter>
 #include <QJsonObject>
 #include <QJsonParseError>
 #include <QPointer>
@@ -6695,6 +6698,115 @@ void MainWindow::onSpectrumReadyForAdaptiveFilter(quint32 streamId,
                 emittedNs);
         }
         break;  // one pan owns this stream id
+    }
+}
+
+// ── CWX docked/floating presentation ──────────────────────────────────────
+//
+// Client-side UI preference (window arrangement), not radio-authoritative
+// state — see AGENTS.md's Settings Authority Policy. Mirrors
+// PanadapterStack::floatPanadapter()/dockPanadapter(), minus the GPU-surface
+// teardown that class needs and CwxPanel's plain QWidget content does not.
+
+void MainWindow::showCwxPanel()
+{
+    if (!m_cwxPanel) return;
+
+    const bool floatingPref = AppSettings::instance()
+        .value("CwxPanelFloating", "False").toString() == "True";
+    if (floatingPref) {
+        floatCwxPanel();
+        return;
+    }
+
+    m_cwxPanel->setVisible(true);
+    if (m_splitter) {
+        auto sizes = m_splitter->sizes();
+        if (sizes.size() >= 4) {
+            const int cwxW = 250;
+            const int total = sizes[0] + sizes[1] + sizes[2];
+            sizes[0] = cwxW;
+            sizes[1] = 0;
+            sizes[2] = total - cwxW;
+            m_splitter->setSizes(sizes);
+        }
+    }
+}
+
+void MainWindow::hideCwxPanel()
+{
+    // Floating: hide the window but keep it alive — the next showCwxPanel()
+    // re-shows the same instance at the same geometry rather than tearing
+    // down and rebuilding.
+    if (m_cwxFloatingWindow) {
+        m_cwxFloatingWindow->hide();
+        return;
+    }
+    if (m_cwxPanel) m_cwxPanel->setVisible(false);
+}
+
+void MainWindow::floatCwxPanel()
+{
+    if (!m_cwxPanel) return;
+
+    if (m_cwxFloatingWindow) {
+        // Already floating (possibly hidden by hideCwxPanel()) — just show it.
+        m_cwxFloatingWindow->show();
+        m_cwxFloatingWindow->raise();
+        m_cwxFloatingWindow->activateWindow();
+        return;
+    }
+
+    auto* fw = new CwxFloatingWindow(this);
+    fw->setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
+    fw->adoptPanel(m_cwxPanel);   // reparents directly out of m_splitter
+    m_cwxPanel->setFloatingState(true);
+    m_cwxPanel->show();
+    m_cwxFloatingWindow = fw;
+    trackPersistentDialog(fw);  // runtime frameless-toggle propagation
+
+    connect(fw, &CwxFloatingWindow::dockRequested, this, &MainWindow::dockCwxPanel);
+
+    auto& s = AppSettings::instance();
+    s.setValue("CwxPanelFloating", "True");
+    s.save();
+
+    fw->show();
+    fw->raise();
+    fw->activateWindow();
+}
+
+void MainWindow::dockCwxPanel()
+{
+    if (!m_cwxFloatingWindow) return;
+
+    CwxFloatingWindow* fw = m_cwxFloatingWindow;
+    m_cwxFloatingWindow = nullptr;
+
+    CwxPanel* panel = fw->takePanel();
+    fw->hide();
+    fw->deleteLater();
+
+    auto& s = AppSettings::instance();
+    s.setValue("CwxPanelFloating", "False");
+    s.save();
+
+    if (!panel) return;
+    panel->setFloatingState(false);
+
+    if (m_splitter) {
+        m_splitter->insertWidget(0, panel);
+        panel->show();
+        auto sizes = m_splitter->sizes();
+        if (sizes.size() >= 4) {
+            const int cwxW = 250;
+            const int total = sizes[0] + sizes[1] + sizes[2];
+            sizes[0] = cwxW;
+            sizes[1] = 0;
+            sizes[2] = total - cwxW;
+            m_splitter->setSizes(sizes);
+        }
     }
 }
 

--- a/tests/cwx_panel_test.cpp
+++ b/tests/cwx_panel_test.cpp
@@ -168,6 +168,49 @@ void testDisplayNameCanFollowTheRadioFamily()
                && speed && speed->minimum() == 5 && speed->maximum() == 100);
 }
 
+void testFloatingStateTogglesPopOutButtonAndWidth()
+{
+    Fixture f;
+    auto* popOutBtn = f.panel.findChild<QPushButton*>(QStringLiteral("cwxPopOutBtn"));
+    report("pop-out button is present", popOutBtn != nullptr);
+    if (!popOutBtn) return;
+
+    report("docked panel has the fixed splitter width",
+           !f.panel.isFloating() && f.panel.maximumWidth() == 250
+               && f.panel.minimumWidth() == 250);
+    const QString dockedTip = popOutBtn->toolTip();
+
+    int popOutClicks = 0, dockClicks = 0;
+    QObject::connect(&f.panel, &CwxPanel::popOutClicked,
+                     [&popOutClicks]() { ++popOutClicks; });
+    QObject::connect(&f.panel, &CwxPanel::dockClicked,
+                     [&dockClicks]() { ++dockClicks; });
+
+    popOutBtn->click();
+    report("clicking the button while docked emits popOutClicked, not dockClicked",
+           popOutClicks == 1 && dockClicks == 0);
+
+    // MainWindow::floatCwxPanel() would call this after reparenting into
+    // CwxFloatingWindow; simulate it directly since this test builds
+    // CwxPanel in isolation.
+    f.panel.setFloatingState(true);
+    report("setFloatingState(true) allows free resize",
+           f.panel.isFloating() && f.panel.maximumWidth() > 250);
+    report("setFloatingState(true) changes the button's tooltip",
+           popOutBtn->toolTip() != dockedTip);
+
+    popOutBtn->click();
+    report("clicking the button while floating emits dockClicked",
+           popOutClicks == 1 && dockClicks == 1);
+
+    f.panel.setFloatingState(false);
+    report("setFloatingState(false) restores the fixed splitter width",
+           !f.panel.isFloating() && f.panel.maximumWidth() == 250
+               && f.panel.minimumWidth() == 250);
+    report("setFloatingState(false) restores the docked tooltip",
+           popOutBtn->toolTip() == dockedTip);
+}
+
 void testSimpleKeyerDoesNotExpandSpeedModifiers()
 {
     CwxModel model;
@@ -501,6 +544,7 @@ int main(int argc, char** argv)
     std::printf("CWX panel behavior test harness\n\n");
 
     testLiveButtonTogglesOff();
+    testFloatingStateTogglesPopOutButtonAndWidth();
     testDisplayNameCanFollowTheRadioFamily();
     testSimpleKeyerDoesNotExpandSpeedModifiers();
     testSendButtonSendsWhenLiveOff();


### PR DESCRIPTION
## Summary
- Adds a pop-out/dock toggle button to the CWX panel's title row (next to the "CWX" label).
- Popping out reparents the panel from `MainWindow`'s splitter into a new `CwxFloatingWindow` — a resizable, non-modal top-level window built on the `PersistentDialog` base (#2605), which gives it geometry persistence and frameless-chrome handling for free.
- Closing the floating window (title-bar X) docks the panel back into the splitter instead of destroying it — mirrors `PanFloatingWindow`'s panadapter float/dock lifecycle, minus the GPU-surface teardown that class needs and CWX's plain `QWidget` content does not.
- **Persistence**: the docked/floating preference (`CwxPanelFloating` in `AppSettings`) and the floating window's last size/position (`CwxFloatingGeometry`, via `PersistentDialog`) both survive restarts. The next time CWX is shown via its status-bar indicator, it reopens in the same presentation (docked or floating) it was last left in, at the same size/location if floating.
- This is a client-side UI/layout preference, not radio-authoritative state, per `AGENTS.md`'s Settings Authority Policy.

## Adjacent fixes
Surfaced while wiring the DVK/CWX mutual exclusion through the new `showCwxPanel()`/`hideCwxPanel()`:
- The DVK indicator handler called `m_cwxPanel->hide()` directly. Once CWX can float, that would leave an empty floating window on screen while its (now hidden) content sits reparented inside it — fixed to call `hideCwxPanel()`, which hides the floating window itself when floating.
- The DVK indicator handler's splitter-resize block unconditionally assumed CWX's docked slot is index 0. Once CWX can be detached from the splitter (floating), that assumption would zero out DVK's own slot instead — now guarded on `!m_cwxFloatingWindow`.

## Files
- New: `src/gui/CwxFloatingWindow.{h,cpp}`
- `src/gui/CwxPanel.{h,cpp}` — pop-out button, `setFloatingState()`, `popOutClicked`/`dockClicked` signals
- `src/gui/MainWindow.{h,cpp}`, `src/gui/MainWindow_Wiring.cpp` — `showCwxPanel()`/`hideCwxPanel()`/`floatCwxPanel()`/`dockCwxPanel()`
- `src/gui/MainWindow_Shortcuts.cpp` — CWX/DVK indicator handlers route through the new show/hide methods
- `CMakeLists.txt` — register the new source file
- `tests/cwx_panel_test.cpp` — covers `setFloatingState()`'s width/tooltip toggling and the pop-out button's click routing (`popOutClicked` while docked, `dockClicked` while floating)

## Test plan
- [x] `cwx_panel_test` extended with focused coverage for the new pop-out button and `setFloatingState()`.
- [ ] Manual, Windows: pop out CWX, resize/move the window, restart the app, confirm it reopens floating at the same size/position. Dock it back, restart, confirm it reopens docked.

Validated via CI (Windows/macOS/Linux + static checks) rather than a local build, per the no-local-compile workflow for this change.