### PR TITLE
docs(agents): record the test-layer boundary and gate-integrity conventions — Principle VIII.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,52 @@ this at the point of use.
 A test that touches `AppSettings` also needs its target name in the
 `AETHER_SETTINGS_CONSUMERS` list at the bottom of `tests.cmake`.
 
+Every unconditional `add_executable(<name>_test …)` must have a matching
+`add_test`, or carry a `# not registered: <reason>` marker the registration
+checker recognizes (option-gated and manual targets qualify). A test that
+compiles but is never registered reads as coverage while running in no job —
+`issue_report_test`, the GHSA-ccrg-j8cp-qhc4 regression guard, has run in no
+job from its creation to this day (#5101, still open, registers it). This
+becomes checked once the `check_test_registration.py` extension from #5254
+lands; until then it is convention.
+
+A test for a fixed bug should be mutation-checked before the PR goes up:
+break the guard on purpose, watch the test fail, restore it, and say so in
+the PR body.
+
+### Test-layer boundary — where an assertion lives
+
+Decide the layer before writing the test (#5232):
+
+| The assertion proves | It lives in |
+|---|---|
+| Wire encoding, parser bounds, model tables, scheduling, DSP, capability/safety policy | a socket-free CTest in `tests/`, grounded in the official guide or gateware |
+| A refusal, a non-event, a dropped/malformed/disconnected input, a TX guard | a socket-free test that **injects the transport** — feed the frame handler or state machine directly; no `QTcpServer`/`QUdpSocket`, no peer process |
+| A race or lifetime bug under churn | the sanitizer lane (`sanitizers.yml`) — the sanitizer is the point |
+| The app converges with real firmware (session, RX, controls, meter liveness) | the automation bridge + `radiocert` on live hardware. Positive effects only: radiocert is a diagnostic, not pass/fail, and cannot prove an isolated non-event |
+| A closed loop that needs a simulator peer (hpsdrsim TX) | an explicit opt-in target, never registered by default |
+
+**No new synthetic peer standing in for third-party radio or amplifier
+firmware enters the default graph.** A fake radio proves the client agrees
+with our model of the radio, not with the radio; the model freezes while
+firmware moves, so the test fails on correct changes or stays green on real
+divergence (#5232). One legacy exception remains
+(`gui_client_registration_recovery_test`'s fake FLEX-6700 handshake peer),
+tracked for extraction in #5254. Mining a retired fake peer's frame tables as
+*input data* for injected-transport tests is encouraged; running the fake as
+a live socket peer is not. Loopback mocks of documented HTTP APIs
+(`asr_remote_backend_test`) are a different trade — that contract is
+versioned and published; radio firmware behavior is not.
+
+Socket tests where **our own server is the subject** (rigctld, CAT, the TCI
+server, the automation bridge's transport) remain legitimate: the code under
+test is real, the socket is how you reach it.
+
+Prefer behavioral seams over source-text assertions: a test that greps a
+source file for an expression breaks on behavior-preserving refactors and
+gets deleted by whoever it fires on. Applets already link into unit tests,
+so the seam is a `tests.cmake` entry, not a missing capability.
+
 Current version: **26.8.4**.
 Versioning scheme is **CalVer** (`YY.M.patch[.hotfix]`) starting from v26.5.1,
 the 1.0-equivalent. Hotfix sub-patches use a 4th component (e.g. 26.5.2.1).
@@ -304,6 +350,24 @@ AI-assistant instructions (algorithm, anti-patterns, completion
 message). Works for Windows / macOS / Linux / WSL / Raspberry Pi
 contributors. Default to SSH signing; GPG is the fallback for
 contributors with existing GPG workflows.
+
+### Gate integrity
+
+- Every `ctest` invocation in a workflow carries `--no-tests=error`: a `-R`
+  filter that matches nothing exits 0, so a deregistered or renamed test
+  silently shrinks the gate while the job stays green — #5232 demonstrated
+  this live. (The Icom step got the flag in #5232; the remaining steps are
+  tracked in #5254.)
+- Deregistering or renaming a test requires grepping `.github/workflows/`
+  for its name in the same PR. The gate regexes are part of the test's
+  surface.
+- A test joins a PR gate with a comment saying what it guards and what it
+  costs — the existing per-target justifications are the model. Keep timing
+  claims honest or omit them.
+- A flaky gate test gets an issue and, if unresolved, quarantine off the
+  gate — not retrigger commits. One contributor pushed empty retriggers on
+  two open PRs in one day for `icom_backend_test` (#5144, #5137); its
+  socket-free replacement (#5254) is the fix, quarantine is the interim.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,9 +260,11 @@ Decide the layer before writing the test (#5232):
 firmware enters the default graph.** A fake radio proves the client agrees
 with our model of the radio, not with the radio; the model freezes while
 firmware moves, so the test fails on correct changes or stays green on real
-divergence (#5232). One legacy exception remains
-(`gui_client_registration_recovery_test`'s fake FLEX-6700 handshake peer),
-tracked for extraction in #5254. Mining a retired fake peer's frame tables as
+divergence (#5232). Three legacy exceptions remain in
+the default graph, all tracked for socket-free extraction in #5254:
+`vkamp_connection_test` (fake VKAMP amplifier), `hl2_receiver_count_restart_test`
+(fake Metis radio), and `gui_client_registration_recovery_test` (fake FLEX-6700
+handshake peer). Mining a retired fake peer's frame tables as
 *input data* for injected-transport tests is encouraged; running the fake as
 a live socket peer is not. Loopback mocks of documented HTTP APIs
 (`asr_remote_backend_test`) are a different trade — that contract is
@@ -270,12 +272,19 @@ versioned and published; radio firmware behavior is not.
 
 Socket tests where **our own server is the subject** (rigctld, CAT, the TCI
 server, the automation bridge's transport) remain legitimate: the code under
-test is real, the socket is how you reach it.
+test is real, the socket is how you reach it. The carve-out exempts a test
+from the fake-firmware ban, not from visibility: any new socket-owning test
+is disclosed in the PR body, its `tests.cmake` block names the socket it
+binds, reviewers notify the operator before continuing, and the test fails
+fast (or skips, exit 77) when it cannot bind rather than consuming its
+timeout.
 
 Prefer behavioral seams over source-text assertions: a test that greps a
 source file for an expression breaks on behavior-preserving refactors and
 gets deleted by whoever it fires on. Applets already link into unit tests,
 so the seam is a `tests.cmake` entry, not a missing capability.
+
+### Version and release files
 
 Current version: **26.8.4**.
 Versioning scheme is **CalVer** (`YY.M.patch[.hotfix]`) starting from v26.5.1,
@@ -356,18 +365,22 @@ contributors with existing GPG workflows.
 - Every `ctest` invocation in a workflow carries `--no-tests=error`: a `-R`
   filter that matches nothing exits 0, so a deregistered or renamed test
   silently shrinks the gate while the job stays green — #5232 demonstrated
-  this live. (The Icom step got the flag in #5232; the remaining steps are
-  tracked in #5254.)
+  this live. (#5232 swept the flag across all filtered PR-gate steps; the
+  unfiltered sanitizer sweep remains tracked in #5254.)
+- An enumerated gate additionally pins its selection count — the Icom gate
+  asserts `Total Tests: 5` (#5232). `--no-tests=error` only catches a regex
+  matching zero; a regex matching 3 of 5 still exits 0, and the pinned count
+  is what catches that. Prefer the count check wherever a gate enumerates.
 - Deregistering or renaming a test requires grepping `.github/workflows/`
   for its name in the same PR. The gate regexes are part of the test's
   surface.
 - A test joins a PR gate with a comment saying what it guards and what it
   costs — the existing per-target justifications are the model. Keep timing
   claims honest or omit them.
-- A flaky gate test gets an issue and, if unresolved, quarantine off the
-  gate — not retrigger commits. One contributor pushed empty retriggers on
-  two open PRs in one day for `icom_backend_test` (#5144, #5137); its
-  socket-free replacement (#5254) is the fix, quarantine is the interim.
+- A flaky gate test gets an issue naming the root cause and, if unresolved,
+  quarantine off the gate — never empty retrigger commits, which cost every
+  contributor and record nothing. (For `icom_backend_test` the root cause
+  was the socket layer; #5254 is the fix, quarantine the interim.)
 
 ---
 


### PR DESCRIPTION
Companion to #5232 / #5254 — writes the agreed verification model into the file every AI tool reads, per the maintainer's request that the testing-process lessons be recorded in AGENTS.md.

## Agreed in the #5232 review thread (all parties)

- The **test-layer boundary table**: socket-free deterministic tests / injected-transport negative tests / sanitizer lane / bridge+`radiocert` positive convergence / opt-in simulator targets.
- **No new synthetic peer for third-party radio or amplifier firmware in the default graph** — the boundary itself follows from the thread's five-point agreement.
- **`--no-tests=error` on workflow ctest steps** (#5232 added the Icom step; the remainder is a #5254 task, and the text says so).

## Proposed here — not from the thread; object in review if you disagree

- The refinements of the synthetic-peer rule: the legacy-exception list (now **three** default-graph fixtures, all tracked in #5254 — updated per review), the our-own-server carve-out (rigctld/CAT/TCI/bridge) with its permitted-is-not-silent disclosure requirements, and the documented-HTTP-API distinction (`asr_remote_backend_test`). Revision note: review (NF0T, jensenpat) corrected four factual claims in the added prose; commit 82a77930 applies all fixes.

- Every unconditional `add_executable(*_test)` needs a matching `add_test` or a `# not registered: <reason>` marker (enforcement lands with the #5254 checker extension; until then, convention). Motivated by `issue_report_test` — the GHSA-ccrg-j8cp-qhc4 regression guard — which has run in no job from its creation to this day (#5101, still open, registers it).
- Mutation-check culture written down: break the guard, watch the test fail, say so in the PR body.
- Same-PR `.github/workflows/` grep on any test deregistration/rename.
- Gate comments justified and timing-honest; flaky gate tests get an issue + quarantine, not retrigger commits.
- Prefer behavioral seams over source-text assertions.

Placement notes: the testing additions sit inside "Adding a test" (after the `AETHER_SETTINGS_CONSUMERS` paragraph, before the version block, so the version-table's "the table above" cross-reference is undisturbed); gate integrity joins "## CI/CD Workflow".

AGENTS.md is CODEOWNERS Tier 2 — build/test conventions, not governance; nothing here restates or widens Tier-1 policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

