### PR TITLE
Improve CTCSS tone dropdown readability and scrolling affordance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,6 +386,19 @@ jobs:
           test "$(ctest --test-dir build -N -R "$ICOM_GATE" | sed -n 's/^Total Tests: //p')" = "7"
           ctest --test-dir build -R "$ICOM_GATE" --no-tests=error --output-on-failure
 
+      # The CTCSS list is a shared RX/VFO presentation surface used by every
+      # backend that publishes FM tone controls. This test renders the custom
+      # item delegate, verifies the popup row cap and pins both shipping
+      # consumers to the shared population path. Merely building it would not
+      # exercise any of those claims on a pull request.
+      - name: Test shared CTCSS tone presentation
+        env:
+          QT_QPA_PLATFORM: offscreen
+          CTCSS_PRESENTATION_GATE: "^ctcss_tone_label_test$"
+        run: |
+          test "$(ctest --test-dir build -N -R "$CTCSS_PRESENTATION_GATE" | sed -n 's/^Total Tests: //p')" = "1"
+          ctest --test-dir build -R "$CTCSS_PRESENTATION_GATE" --no-tests=error --output-on-failure
+
       # Mirrors check-windows' "sccache stats" step, and exists for the same
       # reason: #1963 disabled the Windows compiler cache for three months
       # without anyone noticing, because nothing made the hit rate visible.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,15 +388,16 @@ jobs:
 
       # The CTCSS list is a shared RX/VFO presentation surface used by every
       # backend that publishes FM tone controls. This test renders the custom
-      # item delegate, verifies the popup row cap and pins both shipping
-      # consumers to the shared population path. Merely building it would not
-      # exercise any of those claims on a pull request.
+      # item delegate and verifies the popup row cap. The existing focused
+      # wiring contract pins both full-desktop consumers to the shared
+      # population, label and style paths; merely building either test would
+      # not exercise those claims on a pull request.
       - name: Test shared CTCSS tone presentation
         env:
           QT_QPA_PLATFORM: offscreen
-          CTCSS_PRESENTATION_GATE: "^ctcss_tone_label_test$"
+          CTCSS_PRESENTATION_GATE: "^(ctcss_tone_label_test|fm_tone_presentation_contract)$"
         run: |
-          test "$(ctest --test-dir build -N -R "$CTCSS_PRESENTATION_GATE" | sed -n 's/^Total Tests: //p')" = "1"
+          test "$(ctest --test-dir build -N -R "$CTCSS_PRESENTATION_GATE" | sed -n 's/^Total Tests: //p')" = "2"
           ctest --test-dir build -R "$CTCSS_PRESENTATION_GATE" --no-tests=error --output-on-failure
 
       # Mirrors check-windows' "sccache stats" step, and exists for the same

--- a/src/core/CtcssTones.h
+++ b/src/core/CtcssTones.h
@@ -8,10 +8,11 @@
 // downstream says no.
 //
 // The set is the one #5140 landed on main for the Icom backend: the Motorola
-// PL tones plus the EIA interstitials. An interstitial has no PL code or
-// designation, so it carries code 0 and an empty designation, and callers
-// that render a label fall back to the bare frequency for those (see
-// RxApplet). Hoisting it here rather than keeping a per-widget copy is the
+// PL tones plus the EIA interstitials. CISA AUXFOG Appendix G independently
+// confirms the Motorola WZ designation for 69.3 Hz. Entries outside the
+// original numbered sequence retain code 0; designation is independent, and
+// callers render a bare frequency only when that designation is empty.
+// Hoisting the table here rather than keeping a per-widget copy is the
 // point of this file: main now offers 50 tones in two dropdowns, and the
 // bridge has to accept exactly those.
 
@@ -27,7 +28,7 @@ struct CtcssTone {
 };
 
 inline constexpr CtcssTone kCtcssTones[] = {
-    { 1, "XZ", 67.0},  { 0, "", 69.3},    { 2, "XA", 71.9},  { 3, "WA", 74.4},
+    { 1, "XZ", 67.0},  { 0, "WZ", 69.3},  { 2, "XA", 71.9},  { 3, "WA", 74.4},
     { 4, "XB", 77.0},
     { 5, "WB", 79.7},  { 6, "YZ", 82.5},  { 7, "YA", 85.4},  { 8, "YB", 88.5},
     { 9, "ZZ", 91.5},  {10, "ZA", 94.8},  {11, "ZB", 97.4},  {12, "1Z",100.0},

--- a/src/gui/CtcssToneLabel.h
+++ b/src/gui/CtcssToneLabel.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include "core/CtcssTones.h"
+
+#include <QAbstractItemView>
+#include <QApplication>
+#include <QComboBox>
+#include <QFontMetrics>
+#include <QModelIndex>
+#include <QPainter>
+#include <QPalette>
+#include <QRect>
+#include <QSize>
+#include <QString>
+#include <QStyle>
+#include <QStyleOptionViewItem>
+#include <QStyledItemDelegate>
+
+#include <algorithm>
+
+namespace AetherSDR {
+
+inline constexpr int kCtcssTonePopupRows = 18;
+inline constexpr int kCtcssToneRowHeight = 22;
+inline constexpr int kCtcssToneHorizontalPadding = 8;
+inline constexpr int kCtcssToneFrequencyRole = Qt::UserRole + 1;
+inline constexpr int kCtcssToneDesignationRole = Qt::UserRole + 2;
+
+inline QString ctcssToneLabel(const QString& frequency, const QString& designation)
+{
+    if (designation.isEmpty()) {
+        return frequency;
+    }
+    return QStringLiteral("%1 %2")
+        .arg(frequency, designation);
+}
+
+inline QString ctcssToneLabel(const CtcssTone& tone)
+{
+    return ctcssToneLabel(QString::number(tone.frequency, 'f', 1),
+                          QString::fromLatin1(tone.designation));
+}
+
+inline QString ctcssToneComboStyleRules()
+{
+    return QStringLiteral(
+        "QComboBox { combobox-popup: 0; }"
+        "QComboBox QAbstractItemView QScrollBar:vertical {"
+        " background: {{color.background.0}}; width: 12px; margin: 2px; }"
+        "QComboBox QAbstractItemView QScrollBar::handle:vertical {"
+        " background: {{color.background.3}}; border-radius: 4px;"
+        " min-height: 28px; }"
+        "QComboBox QAbstractItemView QScrollBar::handle:vertical:hover {"
+        " background: {{color.accent.bright}}; }"
+        "QComboBox QAbstractItemView QScrollBar::add-line:vertical,"
+        "QComboBox QAbstractItemView QScrollBar::sub-line:vertical {"
+        " height: 0; }");
+}
+
+inline int ctcssToneFrequencyColumnWidth(const QFontMetrics& metrics)
+{
+    int width = 0;
+    for (const CtcssTone& tone : kCtcssTones) {
+        width = std::max(
+            width,
+            metrics.horizontalAdvance(QString::number(tone.frequency, 'f', 1)));
+    }
+    return width;
+}
+
+class CtcssToneItemDelegate final : public QStyledItemDelegate
+{
+public:
+    explicit CtcssToneItemDelegate(QObject* parent = nullptr)
+        : QStyledItemDelegate(parent)
+    {
+    }
+
+    QSize sizeHint(const QStyleOptionViewItem& option,
+                   const QModelIndex& index) const override
+    {
+        QSize size = QStyledItemDelegate::sizeHint(option, index);
+        size.setHeight(std::max(size.height(), kCtcssToneRowHeight));
+        return size;
+    }
+
+    void paint(QPainter* painter, const QStyleOptionViewItem& option,
+               const QModelIndex& index) const override
+    {
+        QStyleOptionViewItem backgroundOption(option);
+        initStyleOption(&backgroundOption, index);
+        backgroundOption.text.clear();
+        const QStyle* style = option.widget ? option.widget->style()
+                                            : QApplication::style();
+        style->drawControl(QStyle::CE_ItemViewItem, &backgroundOption,
+                           painter, option.widget);
+
+        const QString frequency = index.data(kCtcssToneFrequencyRole).toString();
+        const QString designation = index.data(kCtcssToneDesignationRole).toString();
+        if (frequency.isEmpty()) {
+            return;
+        }
+
+        painter->save();
+        painter->setFont(option.font);
+        const QPalette::ColorGroup group = !(option.state & QStyle::State_Enabled)
+            ? QPalette::Disabled
+            : option.state & QStyle::State_Active ? QPalette::Active
+                                                   : QPalette::Inactive;
+        const QPalette::ColorRole role = option.state & QStyle::State_Selected
+            ? QPalette::HighlightedText : QPalette::Text;
+        painter->setPen(option.palette.color(group, role));
+
+        const QFontMetrics metrics(option.font);
+        const int frequencyWidth = ctcssToneFrequencyColumnWidth(metrics);
+        const int gap = metrics.horizontalAdvance(QLatin1Char(' ')) * 3;
+        const QRect content = option.rect.adjusted(
+            kCtcssToneHorizontalPadding, 0, -kCtcssToneHorizontalPadding, 0);
+        const QRect frequencyRect(content.left(), content.top(), frequencyWidth,
+                                  content.height());
+        const QRect designationRect(frequencyRect.right() + gap, content.top(),
+                                    content.right() - frequencyRect.right() - gap,
+                                    content.height());
+        painter->drawText(frequencyRect, Qt::AlignRight | Qt::AlignVCenter, frequency);
+        painter->drawText(designationRect, Qt::AlignLeft | Qt::AlignVCenter, designation);
+        painter->restore();
+    }
+};
+
+inline void populateCtcssToneCombo(QComboBox* combo)
+{
+    combo->setMaxVisibleItems(kCtcssTonePopupRows);
+    combo->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+    combo->setItemDelegate(new CtcssToneItemDelegate(combo));
+    for (const CtcssTone& tone : kCtcssTones) {
+        const QString frequency = QString::number(tone.frequency, 'f', 1);
+        const QString designation = QString::fromLatin1(tone.designation);
+        combo->addItem(ctcssToneLabel(tone), frequency);
+        const int row = combo->count() - 1;
+        combo->setItemData(row, frequency, kCtcssToneFrequencyRole);
+        combo->setItemData(row, designation, kCtcssToneDesignationRole);
+    }
+}
+
+} // namespace AetherSDR

--- a/src/gui/CtcssToneLabel.h
+++ b/src/gui/CtcssToneLabel.h
@@ -24,9 +24,8 @@ namespace AetherSDR {
 inline constexpr int kCtcssTonePopupRows = 18;
 inline constexpr int kCtcssToneRowHeight = 22;
 inline constexpr int kCtcssToneHorizontalPadding = 8;
-inline constexpr int kCtcssToneFrequencyRole = Qt::UserRole + 1;
-inline constexpr int kCtcssToneDesignationRole = Qt::UserRole + 2;
-inline constexpr int kCtcssTonePrefixRole = Qt::UserRole + 3;
+inline constexpr int kCtcssToneDesignationRole = Qt::UserRole + 1;
+inline constexpr int kCtcssTonePrefixRole = Qt::UserRole + 2;
 
 inline QString ctcssToneLabel(const QString& frequency, const QString& designation)
 {
@@ -82,18 +81,8 @@ public:
                    const QModelIndex& index) const override
     {
         QSize size = QStyledItemDelegate::sizeHint(option, index);
-        updateMetrics(option.font);
-        const QFontMetrics metrics(option.font);
-        const QString prefix = index.data(kCtcssTonePrefixRole).toString();
-        const int prefixWidth = metrics.horizontalAdvance(prefix);
-        const int prefixGap = prefix.isEmpty()
-            ? 0 : metrics.horizontalAdvance(QLatin1Char(' '));
-        const int designationGap = m_designationWidth == 0
-            ? 0 : metrics.horizontalAdvance(QLatin1Char(' ')) * 3;
-        size.setWidth(std::max(
-            size.width(), kCtcssToneHorizontalPadding * 2 + prefixWidth
-                + prefixGap + m_frequencyWidth + designationGap
-                + m_designationWidth));
+        const ColumnLayout layout = columns(option, index);
+        size.setWidth(std::max(size.width(), layout.requiredWidth));
         size.setHeight(std::max(size.height(), kCtcssToneRowHeight));
         return size;
     }
@@ -109,7 +98,7 @@ public:
         style->drawControl(QStyle::CE_ItemViewItem, &backgroundOption,
                            painter, option.widget);
 
-        const QString frequency = index.data(kCtcssToneFrequencyRole).toString();
+        const QString frequency = index.data(Qt::UserRole).toString();
         const QString designation = index.data(kCtcssToneDesignationRole).toString();
         const QString prefix = index.data(kCtcssTonePrefixRole).toString();
         if (frequency.isEmpty()) {
@@ -126,30 +115,48 @@ public:
             ? QPalette::HighlightedText : QPalette::Text;
         painter->setPen(option.palette.color(group, role));
 
-        const QFontMetrics metrics(option.font);
-        updateMetrics(option.font);
-        const int prefixWidth = metrics.horizontalAdvance(prefix);
-        const int prefixGap = prefix.isEmpty()
-            ? 0 : metrics.horizontalAdvance(QLatin1Char(' '));
-        const int designationGap = metrics.horizontalAdvance(QLatin1Char(' ')) * 3;
-        const QRect content = option.rect.adjusted(
-            kCtcssToneHorizontalPadding, 0, -kCtcssToneHorizontalPadding, 0);
-        const QRect prefixRect(content.left(), content.top(), prefixWidth,
-                               content.height());
-        const int frequencyLeft = content.left() + prefixWidth + prefixGap;
-        const QRect frequencyRect(frequencyLeft, content.top(),
-                                  m_frequencyWidth,
-                                  content.height());
-        const QRect designationRect(frequencyRect.right() + designationGap,
-                                    content.top(), m_designationWidth,
-                                    content.height());
-        painter->drawText(prefixRect, Qt::AlignLeft | Qt::AlignVCenter, prefix);
-        painter->drawText(frequencyRect, Qt::AlignRight | Qt::AlignVCenter, frequency);
-        painter->drawText(designationRect, Qt::AlignLeft | Qt::AlignVCenter, designation);
+        const ColumnLayout layout = columns(option, index);
+        painter->drawText(layout.prefix, Qt::AlignLeft | Qt::AlignVCenter, prefix);
+        painter->drawText(layout.frequency, Qt::AlignRight | Qt::AlignVCenter, frequency);
+        painter->drawText(layout.designation, Qt::AlignLeft | Qt::AlignVCenter, designation);
         painter->restore();
     }
 
 private:
+    struct ColumnLayout {
+        QRect prefix;
+        QRect frequency;
+        QRect designation;
+        int requiredWidth = 0;
+    };
+
+    ColumnLayout columns(const QStyleOptionViewItem& option,
+                         const QModelIndex& index) const
+    {
+        updateMetrics(option.font);
+        const QFontMetrics metrics(option.font);
+        const QString prefix = index.data(kCtcssTonePrefixRole).toString();
+        const int prefixWidth = metrics.horizontalAdvance(prefix);
+        const int prefixGap = prefix.isEmpty()
+            ? 0 : metrics.horizontalAdvance(QLatin1Char(' '));
+        const int designationGap = m_designationWidth == 0
+            ? 0 : metrics.horizontalAdvance(QLatin1Char(' ')) * 3;
+        const QRect content = option.rect.adjusted(
+            kCtcssToneHorizontalPadding, 0, -kCtcssToneHorizontalPadding, 0);
+        ColumnLayout layout;
+        layout.prefix = QRect(content.left(), content.top(), prefixWidth,
+                              content.height());
+        const int frequencyLeft = content.left() + prefixWidth + prefixGap;
+        layout.frequency = QRect(frequencyLeft, content.top(), m_frequencyWidth,
+                                 content.height());
+        layout.designation = QRect(layout.frequency.right() + designationGap,
+                                   content.top(), m_designationWidth,
+                                   content.height());
+        layout.requiredWidth = kCtcssToneHorizontalPadding * 2 + prefixWidth
+            + prefixGap + m_frequencyWidth + designationGap + m_designationWidth;
+        return layout;
+    }
+
     void updateMetrics(const QFont& font) const
     {
         if (m_hasCachedMetrics && font == m_cachedFont) {
@@ -183,7 +190,6 @@ inline void populateCtcssToneCombo(QComboBox* combo)
         const QString designation = QString::fromLatin1(tone.designation);
         combo->addItem(ctcssToneLabel(tone), frequency);
         const int row = combo->count() - 1;
-        combo->setItemData(row, frequency, kCtcssToneFrequencyRole);
         combo->setItemData(row, designation, kCtcssToneDesignationRole);
     }
 }
@@ -197,8 +203,7 @@ inline void configureCtcssToneComboLabels(QComboBox* combo,
                                  : QStringLiteral("RX:")
         : QString();
     for (int i = 0; i < combo->count(); ++i) {
-        const QString frequency = combo->itemData(
-            i, kCtcssToneFrequencyRole).toString();
+        const QString frequency = combo->itemData(i, Qt::UserRole).toString();
         const QString designation = combo->itemData(
             i, kCtcssToneDesignationRole).toString();
         const QString toneLabel = ctcssToneLabel(frequency, designation);

--- a/src/gui/CtcssToneLabel.h
+++ b/src/gui/CtcssToneLabel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/CtcssTones.h"
+#include "gui/FmTonePresentation.h"
 
 #include <QAbstractItemView>
 #include <QApplication>
@@ -25,6 +26,7 @@ inline constexpr int kCtcssToneRowHeight = 22;
 inline constexpr int kCtcssToneHorizontalPadding = 8;
 inline constexpr int kCtcssToneFrequencyRole = Qt::UserRole + 1;
 inline constexpr int kCtcssToneDesignationRole = Qt::UserRole + 2;
+inline constexpr int kCtcssTonePrefixRole = Qt::UserRole + 3;
 
 inline QString ctcssToneLabel(const QString& frequency, const QString& designation)
 {
@@ -80,6 +82,18 @@ public:
                    const QModelIndex& index) const override
     {
         QSize size = QStyledItemDelegate::sizeHint(option, index);
+        updateMetrics(option.font);
+        const QFontMetrics metrics(option.font);
+        const QString prefix = index.data(kCtcssTonePrefixRole).toString();
+        const int prefixWidth = metrics.horizontalAdvance(prefix);
+        const int prefixGap = prefix.isEmpty()
+            ? 0 : metrics.horizontalAdvance(QLatin1Char(' '));
+        const int designationGap = m_designationWidth == 0
+            ? 0 : metrics.horizontalAdvance(QLatin1Char(' ')) * 3;
+        size.setWidth(std::max(
+            size.width(), kCtcssToneHorizontalPadding * 2 + prefixWidth
+                + prefixGap + m_frequencyWidth + designationGap
+                + m_designationWidth));
         size.setHeight(std::max(size.height(), kCtcssToneRowHeight));
         return size;
     }
@@ -97,6 +111,7 @@ public:
 
         const QString frequency = index.data(kCtcssToneFrequencyRole).toString();
         const QString designation = index.data(kCtcssToneDesignationRole).toString();
+        const QString prefix = index.data(kCtcssTonePrefixRole).toString();
         if (frequency.isEmpty()) {
             return;
         }
@@ -112,19 +127,50 @@ public:
         painter->setPen(option.palette.color(group, role));
 
         const QFontMetrics metrics(option.font);
-        const int frequencyWidth = ctcssToneFrequencyColumnWidth(metrics);
-        const int gap = metrics.horizontalAdvance(QLatin1Char(' ')) * 3;
+        updateMetrics(option.font);
+        const int prefixWidth = metrics.horizontalAdvance(prefix);
+        const int prefixGap = prefix.isEmpty()
+            ? 0 : metrics.horizontalAdvance(QLatin1Char(' '));
+        const int designationGap = metrics.horizontalAdvance(QLatin1Char(' ')) * 3;
         const QRect content = option.rect.adjusted(
             kCtcssToneHorizontalPadding, 0, -kCtcssToneHorizontalPadding, 0);
-        const QRect frequencyRect(content.left(), content.top(), frequencyWidth,
+        const QRect prefixRect(content.left(), content.top(), prefixWidth,
+                               content.height());
+        const int frequencyLeft = content.left() + prefixWidth + prefixGap;
+        const QRect frequencyRect(frequencyLeft, content.top(),
+                                  m_frequencyWidth,
                                   content.height());
-        const QRect designationRect(frequencyRect.right() + gap, content.top(),
-                                    content.right() - frequencyRect.right() - gap,
+        const QRect designationRect(frequencyRect.right() + designationGap,
+                                    content.top(), m_designationWidth,
                                     content.height());
+        painter->drawText(prefixRect, Qt::AlignLeft | Qt::AlignVCenter, prefix);
         painter->drawText(frequencyRect, Qt::AlignRight | Qt::AlignVCenter, frequency);
         painter->drawText(designationRect, Qt::AlignLeft | Qt::AlignVCenter, designation);
         painter->restore();
     }
+
+private:
+    void updateMetrics(const QFont& font) const
+    {
+        if (m_hasCachedMetrics && font == m_cachedFont) {
+            return;
+        }
+        const QFontMetrics metrics(font);
+        m_frequencyWidth = ctcssToneFrequencyColumnWidth(metrics);
+        m_designationWidth = 0;
+        for (const CtcssTone& tone : kCtcssTones) {
+            m_designationWidth = std::max(
+                m_designationWidth,
+                metrics.horizontalAdvance(QString::fromLatin1(tone.designation)));
+        }
+        m_cachedFont = font;
+        m_hasCachedMetrics = true;
+    }
+
+    mutable QFont m_cachedFont;
+    mutable int m_frequencyWidth = 0;
+    mutable int m_designationWidth = 0;
+    mutable bool m_hasCachedMetrics = false;
 };
 
 inline void populateCtcssToneCombo(QComboBox* combo)
@@ -139,6 +185,25 @@ inline void populateCtcssToneCombo(QComboBox* combo)
         const int row = combo->count() - 1;
         combo->setItemData(row, frequency, kCtcssToneFrequencyRole);
         combo->setItemData(row, designation, kCtcssToneDesignationRole);
+    }
+}
+
+inline void configureCtcssToneComboLabels(QComboBox* combo,
+                                          FmTonePresentation presentation,
+                                          FmToneRole role)
+{
+    const QString prefix = presentation == FmTonePresentation::Ctcss
+        ? role == FmToneRole::Tx ? QStringLiteral("TX:")
+                                 : QStringLiteral("RX:")
+        : QString();
+    for (int i = 0; i < combo->count(); ++i) {
+        const QString frequency = combo->itemData(
+            i, kCtcssToneFrequencyRole).toString();
+        const QString designation = combo->itemData(
+            i, kCtcssToneDesignationRole).toString();
+        const QString toneLabel = ctcssToneLabel(frequency, designation);
+        combo->setItemData(i, prefix, kCtcssTonePrefixRole);
+        combo->setItemText(i, fmToneDisplayLabel(presentation, role, toneLabel));
     }
 }
 

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -1,5 +1,5 @@
 #include "RxApplet.h"
-#include "core/CtcssTones.h"
+#include "gui/CtcssToneLabel.h"
 
 #include "gui/FilterStepMath.h"
 #include "gui/FmTonePresentation.h"
@@ -280,16 +280,6 @@ static const ModeSettings& modeSettingsFor(const QString& mode)
     if (mode.startsWith("FDV"))          return digSettings;  // FreeDV digital voice
     return ssbSettings;  // fallback for unknown modes
 }
-
-// ── Standard CTCSS tone table (EIA/TIA-603) ──────────────────────────────────
-
-// The tone table moved to core/CtcssTones.h so the automation bridge's
-// `slice tone` verb validates against the same set this dropdown offers
-// (#5102). Aliased rather than renamed at every use site.
-using CTCSSTone = AetherSDR::CtcssTone;
-static constexpr auto& CTCSS_TONES = AetherSDR::kCtcssTones;
-static constexpr int CTCSS_COUNT =
-    static_cast<int>(AetherSDR::kCtcssToneCount);
 
 // Small checkable button used throughout the applet.
 static QPushButton* mkToggle(const QString& text, QWidget* parent = nullptr)
@@ -732,15 +722,9 @@ void RxApplet::buildUI()
         // CTCSS tone value dropdown
         {
             m_toneValueCmb = new GuardedComboBox;
-            for (int i = 0; i < CTCSS_COUNT; ++i) {
-                const auto& t = CTCSS_TONES[i];
-                const QString frequency = QString::number(t.frequency, 'f', 1);
-                const QString label = t.code > 0
-                    ? QString("%1 %2 %3").arg(t.code).arg(t.designation).arg(frequency)
-                    : frequency;
-                m_toneValueCmb->addItem(label, frequency);
-            }
-            AetherSDR::applyComboStyle(m_toneValueCmb);
+            AetherSDR::populateCtcssToneCombo(m_toneValueCmb);
+            AetherSDR::applyComboStyle(
+                m_toneValueCmb, AetherSDR::ctcssToneComboStyleRules());
             m_toneValueCmb->setEnabled(false);  // enabled only when CTCSS TX
             m_fmLayout->addWidget(m_toneValueCmb);
 
@@ -752,16 +736,10 @@ void RxApplet::buildUI()
             });
 
             m_toneRxValueCmb = new GuardedComboBox;
-            for (int i = 0; i < CTCSS_COUNT; ++i) {
-                const auto& t = CTCSS_TONES[i];
-                const QString frequency = QString::number(t.frequency, 'f', 1);
-                const QString label = t.code > 0
-                    ? QString("%1 %2 %3").arg(t.code).arg(t.designation).arg(frequency)
-                    : frequency;
-                m_toneRxValueCmb->addItem(label, frequency);
-            }
+            AetherSDR::populateCtcssToneCombo(m_toneRxValueCmb);
             m_toneRxValueCmb->setAccessibleName("Receive CTCSS tone frequency");
-            AetherSDR::applyComboStyle(m_toneRxValueCmb);
+            AetherSDR::applyComboStyle(
+                m_toneRxValueCmb, AetherSDR::ctcssToneComboStyleRules());
             m_toneRxValueCmb->setVisible(false);
             m_fmLayout->addWidget(m_toneRxValueCmb);
             connect(m_toneRxValueCmb, QOverload<int>::of(&QComboBox::currentIndexChanged),
@@ -1954,12 +1932,12 @@ void RxApplet::configureFmToneControls()
         ? m_radioModel->backendCapabilities() : RadioCapabilities{};
     const FmTonePresentation presentation = connected
         ? caps.fmTonePresentation : FmTonePresentation::Legacy;
-    for (int i = 0; i < CTCSS_COUNT; ++i) {
-        const CTCSSTone& tone = CTCSS_TONES[i];
-        const QString frequency = QString::number(tone.frequency, 'f', 1);
-        const QString toneLabel = tone.code > 0
-            ? QString("%1 %2 %3").arg(tone.code).arg(tone.designation).arg(frequency)
-            : frequency;
+    for (int i = 0; i < m_toneValueCmb->count(); ++i) {
+        const QString frequency = m_toneValueCmb->itemData(
+            i, kCtcssToneFrequencyRole).toString();
+        const QString designation = m_toneValueCmb->itemData(
+            i, kCtcssToneDesignationRole).toString();
+        const QString toneLabel = ctcssToneLabel(frequency, designation);
         m_toneValueCmb->setItemText(
             i, fmToneDisplayLabel(presentation, FmToneRole::Tx, toneLabel));
         m_toneRxValueCmb->setItemText(

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -1932,17 +1932,10 @@ void RxApplet::configureFmToneControls()
         ? m_radioModel->backendCapabilities() : RadioCapabilities{};
     const FmTonePresentation presentation = connected
         ? caps.fmTonePresentation : FmTonePresentation::Legacy;
-    for (int i = 0; i < m_toneValueCmb->count(); ++i) {
-        const QString frequency = m_toneValueCmb->itemData(
-            i, kCtcssToneFrequencyRole).toString();
-        const QString designation = m_toneValueCmb->itemData(
-            i, kCtcssToneDesignationRole).toString();
-        const QString toneLabel = ctcssToneLabel(frequency, designation);
-        m_toneValueCmb->setItemText(
-            i, fmToneDisplayLabel(presentation, FmToneRole::Tx, toneLabel));
-        m_toneRxValueCmb->setItemText(
-            i, fmToneDisplayLabel(presentation, FmToneRole::Rx, toneLabel));
-    }
+    configureCtcssToneComboLabels(
+        m_toneValueCmb, presentation, FmToneRole::Tx);
+    configureCtcssToneComboLabels(
+        m_toneRxValueCmb, presentation, FmToneRole::Rx);
     const QString sliceMode = m_slice ? m_slice->mode() : QString();
     const bool modeEligible = sliceMode == QLatin1String("FM")
         || sliceMode == QLatin1String("NFM") || sliceMode == QLatin1String("DFM");

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1,6 +1,6 @@
 #include "VfoWidget.h"
 #include "FmTonePresentation.h"
-#include "core/CtcssTones.h"
+#include "gui/CtcssToneLabel.h"
 #include "PhaseKnob.h"
 #include "VoiceModeGate.h"   // isCwMode() — one CW-mode list, not thirteen
 #include "SmartMtrWidget.h"
@@ -2322,25 +2322,21 @@ void VfoWidget::buildTabContent()
             // Tone value — from core/CtcssTones.h, the same table the RX
             // applet's dropdown and the automation bridge's `slice tone`
             // validation use. This list used to be a third hand-typed copy of
-            // the same 41 doubles; the values agreed, which is exactly how a
+            // the same 50 doubles; the values agreed, which is exactly how a
             // copy survives long enough to stop agreeing.
             m_fmToneValueCmb = new GuardedComboBox;
             m_fmToneValueCmb->setAccessibleName("FM tone frequency");
-            for (const AetherSDR::CtcssTone& t : AetherSDR::kCtcssTones) {
-                m_fmToneValueCmb->addItem(QString::number(t.frequency, 'f', 1),
-                                           QString::number(t.frequency, 'f', 1));
-            }
-            AetherSDR::applyComboStyle(m_fmToneValueCmb);
+            AetherSDR::populateCtcssToneCombo(m_fmToneValueCmb);
+            AetherSDR::applyComboStyle(
+                m_fmToneValueCmb, AetherSDR::ctcssToneComboStyleRules());
             m_fmToneValueCmb->setEnabled(false);
             toneRow->addWidget(m_fmToneValueCmb, 1);
 
             m_fmToneRxValueCmb = new GuardedComboBox;
             m_fmToneRxValueCmb->setAccessibleName("Receive CTCSS tone frequency");
-            for (const AetherSDR::CtcssTone& t : AetherSDR::kCtcssTones) {
-                const QString frequency = QString::number(t.frequency, 'f', 1);
-                m_fmToneRxValueCmb->addItem(frequency, frequency);
-            }
-            AetherSDR::applyComboStyle(m_fmToneRxValueCmb);
+            AetherSDR::populateCtcssToneCombo(m_fmToneRxValueCmb);
+            AetherSDR::applyComboStyle(
+                m_fmToneRxValueCmb, AetherSDR::ctcssToneComboStyleRules());
             m_fmToneRxValueCmb->setVisible(false);
             m_fmToneRxContainer = new QWidget;
             auto* toneRxRow = new QHBoxLayout(m_fmToneRxContainer);
@@ -6286,11 +6282,15 @@ void VfoWidget::configureFmToneControls()
     const FmTonePresentation presentation = connected
         ? caps.fmTonePresentation : FmTonePresentation::Legacy;
     for (int i = 0; i < m_fmToneValueCmb->count(); ++i) {
-        const QString frequency = m_fmToneValueCmb->itemData(i).toString();
+        const QString frequency = m_fmToneValueCmb->itemData(
+            i, kCtcssToneFrequencyRole).toString();
+        const QString designation = m_fmToneValueCmb->itemData(
+            i, kCtcssToneDesignationRole).toString();
+        const QString toneLabel = ctcssToneLabel(frequency, designation);
         m_fmToneValueCmb->setItemText(
-            i, fmToneDisplayLabel(presentation, FmToneRole::Tx, frequency));
+            i, fmToneDisplayLabel(presentation, FmToneRole::Tx, toneLabel));
         m_fmToneRxValueCmb->setItemText(
-            i, fmToneDisplayLabel(presentation, FmToneRole::Rx, frequency));
+            i, fmToneDisplayLabel(presentation, FmToneRole::Rx, toneLabel));
     }
     const bool modeEligible = m_slice && hasFmToneControls(m_slice->mode());
     const QString selected = m_slice

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -6281,17 +6281,10 @@ void VfoWidget::configureFmToneControls()
         ? m_radioModel->backendCapabilities() : RadioCapabilities{};
     const FmTonePresentation presentation = connected
         ? caps.fmTonePresentation : FmTonePresentation::Legacy;
-    for (int i = 0; i < m_fmToneValueCmb->count(); ++i) {
-        const QString frequency = m_fmToneValueCmb->itemData(
-            i, kCtcssToneFrequencyRole).toString();
-        const QString designation = m_fmToneValueCmb->itemData(
-            i, kCtcssToneDesignationRole).toString();
-        const QString toneLabel = ctcssToneLabel(frequency, designation);
-        m_fmToneValueCmb->setItemText(
-            i, fmToneDisplayLabel(presentation, FmToneRole::Tx, toneLabel));
-        m_fmToneRxValueCmb->setItemText(
-            i, fmToneDisplayLabel(presentation, FmToneRole::Rx, toneLabel));
-    }
+    configureCtcssToneComboLabels(
+        m_fmToneValueCmb, presentation, FmToneRole::Tx);
+    configureCtcssToneComboLabels(
+        m_fmToneRxValueCmb, presentation, FmToneRole::Rx);
     const bool modeEligible = m_slice && hasFmToneControls(m_slice->mode());
     const QString selected = m_slice
         ? m_slice->fmToneMode() : m_fmToneModeCmb->currentData().toString();

--- a/tests/ctcss_tone_label_test.cpp
+++ b/tests/ctcss_tone_label_test.cpp
@@ -5,7 +5,6 @@
 #include <QApplication>
 #include <QComboBox>
 #include <QColor>
-#include <QFile>
 #include <QImage>
 #include <QPainter>
 #include <QScrollBar>
@@ -75,15 +74,6 @@ int dominantPixels(const QImage& image, const QRect& rect, DominantChannel chann
     return count;
 }
 
-QString readSource(const char* relativePath)
-{
-    QFile file(QStringLiteral(AETHER_SOURCE_DIR) + QString::fromLatin1(relativePath));
-    if (!file.open(QIODevice::ReadOnly)) {
-        return {};
-    }
-    return QString::fromUtf8(file.readAll());
-}
-
 } // namespace
 
 int main(int argc, char** argv)
@@ -111,6 +101,9 @@ int main(int argc, char** argv)
                  "an interstitial without a PL designation renders as frequency only");
 
     QComboBox combo;
+    QFont stressFont = combo.font();
+    stressFont.setPointSize(std::max(14, stressFont.pointSize() + 4));
+    combo.setFont(stressFont);
     AetherSDR::populateCtcssToneCombo(&combo);
     ok &= expect(combo.count() == static_cast<int>(AetherSDR::kCtcssToneCount),
                  "the shared population helper exposes every legal tone");
@@ -146,11 +139,14 @@ int main(int argc, char** argv)
     palette.setColor(QPalette::Disabled, QPalette::Text, Qt::blue);
     combo.setPalette(palette);
 
+    AetherSDR::configureCtcssToneComboLabels(
+        &combo, AetherSDR::FmTonePresentation::Ctcss,
+        AetherSDR::FmToneRole::Tx);
+    ok &= expect(combo.itemText(codedRow) == QStringLiteral("TX: 123.0 3Z")
+                     && combo.itemData(codedRow, AetherSDR::kCtcssTonePrefixRole)
+                            == QStringLiteral("TX:"),
+                 "CTCSS TX presentation preserves its role prefix in the popup model");
     const QImage expected = renderRow(combo, codedRow, selectedState);
-    combo.setItemText(codedRow, QStringLiteral("OVERLAY SENTINEL"));
-    const QImage displayRoleChanged = renderRow(combo, codedRow, selectedState);
-    ok &= expect(expected == displayRoleChanged,
-                 "the delegate paints only the separate columns, never an overlaid display label");
 
     const QFontMetrics metrics(combo.font());
     const int frequencyWidth = AetherSDR::ctcssToneFrequencyColumnWidth(metrics);
@@ -160,16 +156,39 @@ int main(int argc, char** argv)
                              QString::number(tone.frequency, 'f', 1)),
                      "the frequency column accommodates every rendered tone value");
     }
-    const int gap = metrics.horizontalAdvance(QLatin1Char(' ')) * 3;
-    const QRect frequencyRect(AetherSDR::kCtcssToneHorizontalPadding, 0,
+    const int prefixWidth = metrics.horizontalAdvance(QStringLiteral("TX:"));
+    const int prefixGap = metrics.horizontalAdvance(QLatin1Char(' '));
+    const int designationGap = metrics.horizontalAdvance(QLatin1Char(' ')) * 3;
+    const QRect prefixRect(AetherSDR::kCtcssToneHorizontalPadding, 0,
+                           prefixWidth, expected.height());
+    const QRect frequencyRect(prefixRect.x() + prefixWidth + prefixGap, 0,
                               frequencyWidth, expected.height());
-    const QRect designationRect(frequencyRect.right() + gap, 0,
-                                expected.width() - frequencyRect.right() - gap
+    const QRect designationRect(frequencyRect.right() + designationGap, 0,
+                                expected.width() - frequencyRect.right() - designationGap
                                     - AetherSDR::kCtcssToneHorizontalPadding,
                                 expected.height());
-    ok &= expect(dominantPixels(expected, frequencyRect, DominantChannel::Red) > 0
+    ok &= expect(dominantPixels(expected, prefixRect, DominantChannel::Red) > 0
+                     && dominantPixels(expected, frequencyRect, DominantChannel::Red) > 0
                      && dominantPixels(expected, designationRect, DominantChannel::Red) > 0,
-                 "active selected rendering paints both aligned columns with active text");
+                 "active selected rendering paints the role and both aligned columns");
+
+    QStyleOptionViewItem sizeOption;
+    sizeOption.font = combo.font();
+    sizeOption.fontMetrics = metrics;
+    sizeOption.widget = combo.view();
+    const QSize codedSize = combo.itemDelegate()->sizeHint(
+        sizeOption, combo.model()->index(codedRow, 0));
+    int maximumDesignationWidth = 0;
+    for (const AetherSDR::CtcssTone& tone : AetherSDR::kCtcssTones) {
+        maximumDesignationWidth = std::max(
+            maximumDesignationWidth,
+            metrics.horizontalAdvance(QString::fromLatin1(tone.designation)));
+    }
+    const int requiredWidth = AetherSDR::kCtcssToneHorizontalPadding * 2
+        + prefixWidth + prefixGap + frequencyWidth + designationGap
+        + maximumDesignationWidth;
+    ok &= expect(codedSize.width() >= requiredWidth,
+                 "the delegate size hint accommodates the complete prefixed row");
 
     const QImage inactive = renderRow(
         combo, codedRow, QStyle::State_Enabled | QStyle::State_Selected);
@@ -186,6 +205,21 @@ int main(int argc, char** argv)
     ok &= expect(dominantPixels(uncoded, frequencyRect, DominantChannel::Red) > 0
                      && dominantPixels(uncoded, designationRect, DominantChannel::Red) == 0,
                  "an uncoded row paints frequency ink and leaves the designation column blank");
+
+    AetherSDR::configureCtcssToneComboLabels(
+        &combo, AetherSDR::FmTonePresentation::Ctcss,
+        AetherSDR::FmToneRole::Rx);
+    ok &= expect(combo.itemText(codedRow) == QStringLiteral("RX: 123.0 3Z")
+                     && combo.itemData(codedRow, AetherSDR::kCtcssTonePrefixRole)
+                            == QStringLiteral("RX:"),
+                 "CTCSS RX presentation remains distinguishable in the popup model");
+    AetherSDR::configureCtcssToneComboLabels(
+        &combo, AetherSDR::FmTonePresentation::Legacy,
+        AetherSDR::FmToneRole::Tx);
+    ok &= expect(combo.itemText(codedRow) == QStringLiteral("123.0 3Z")
+                     && combo.itemData(codedRow, AetherSDR::kCtcssTonePrefixRole)
+                            .toString().isEmpty(),
+                 "legacy presentation removes the role prefix without changing tone data");
 
     QString renderedPopupRules = AetherSDR::ctcssToneComboStyleRules();
     renderedPopupRules.replace(QStringLiteral("{{color.background.0}}"),
@@ -227,22 +261,6 @@ int main(int argc, char** argv)
                      && popupHeight <= rowHeight * AetherSDR::kCtcssTonePopupRows + 4,
                  "the rendered popup does not exceed 18 visible tone rows");
     combo.hidePopup();
-
-    // These are deliberately narrow source-contract checks, not widget
-    // behavior tests. Constructing either shipping surface requires its full
-    // radio/session graph, so the rendered delegate and popup behavior are
-    // exercised above while these assertions only prevent either consumer
-    // from drifting back to a private population or styling path.
-    const QString rxSource = readSource("/src/gui/RxApplet.cpp");
-    const QString vfoSource = readSource("/src/gui/VfoWidget.cpp");
-    for (const auto& [source, label] : {
-             std::pair{rxSource, "RX applet"},
-             std::pair{vfoSource, "VFO widget"}}) {
-        ok &= expect(source.count(QStringLiteral("populateCtcssToneCombo(")) == 2,
-                     qPrintable(QStringLiteral("%1 routes both tone selectors through the shared population path").arg(label)));
-        ok &= expect(source.count(QStringLiteral("ctcssToneComboStyleRules()")) == 2,
-                     qPrintable(QStringLiteral("%1 applies the shared popup styling to both tone selectors").arg(label)));
-    }
 
     const QString popupRules = AetherSDR::ctcssToneComboStyleRules();
     ok &= expect(popupRules.contains(QStringLiteral("combobox-popup: 0;")),

--- a/tests/ctcss_tone_label_test.cpp
+++ b/tests/ctcss_tone_label_test.cpp
@@ -1,0 +1,258 @@
+#include "core/CtcssTones.h"
+#include "gui/CtcssToneLabel.h"
+
+#include <QAbstractItemView>
+#include <QApplication>
+#include <QComboBox>
+#include <QColor>
+#include <QFile>
+#include <QImage>
+#include <QPainter>
+#include <QScrollBar>
+#include <QString>
+#include <QStyleOptionViewItem>
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <iterator>
+#include <utility>
+
+namespace {
+
+bool expect(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+    }
+    return condition;
+}
+
+const AetherSDR::CtcssTone* toneFor(double frequency)
+{
+    const auto it = std::ranges::find_if(
+        AetherSDR::kCtcssTones,
+        [frequency](const AetherSDR::CtcssTone& tone) {
+            return std::abs(tone.frequency - frequency) < 0.05;
+        });
+    return it == std::end(AetherSDR::kCtcssTones) ? nullptr : &*it;
+}
+
+QImage renderRow(QComboBox& combo, int row, QStyle::State state)
+{
+    QImage image(180, 28, QImage::Format_ARGB32_Premultiplied);
+    image.fill(Qt::transparent);
+    QPainter painter(&image);
+    QStyleOptionViewItem option;
+    option.rect = image.rect();
+    option.font = combo.font();
+    option.fontMetrics = QFontMetrics(combo.font());
+    option.palette = combo.palette();
+    option.state = state;
+    option.widget = combo.view();
+    combo.itemDelegate()->paint(&painter, option, combo.model()->index(row, 0));
+    return image;
+}
+
+enum class DominantChannel { Red, Green, Blue };
+
+int dominantPixels(const QImage& image, const QRect& rect, DominantChannel channel)
+{
+    int count = 0;
+    const QRect bounded = rect.intersected(image.rect());
+    for (int y = bounded.top(); y <= bounded.bottom(); ++y) {
+        for (int x = bounded.left(); x <= bounded.right(); ++x) {
+            const QColor color = image.pixelColor(x, y);
+            const int selected = channel == DominantChannel::Red ? color.red()
+                : channel == DominantChannel::Green ? color.green() : color.blue();
+            const int otherA = channel == DominantChannel::Red ? color.green() : color.red();
+            const int otherB = channel == DominantChannel::Blue ? color.green() : color.blue();
+            if (selected > 32 && selected > otherA * 2 && selected > otherB * 2) {
+                ++count;
+            }
+        }
+    }
+    return count;
+}
+
+QString readSource(const char* relativePath)
+{
+    QFile file(QStringLiteral(AETHER_SOURCE_DIR) + QString::fromLatin1(relativePath));
+    if (!file.open(QIODevice::ReadOnly)) {
+        return {};
+    }
+    return QString::fromUtf8(file.readAll());
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QApplication app(argc, argv);
+    bool ok = true;
+
+    const AetherSDR::CtcssTone* coded = toneFor(123.0);
+    ok &= expect(coded && coded->code == 18
+                     && QString::fromLatin1(coded->designation) == QStringLiteral("3Z"),
+                 "123.0 Hz carries the authoritative 3Z PL designation");
+    ok &= expect(coded && AetherSDR::ctcssToneLabel(*coded) == QStringLiteral("123.0 3Z"),
+                 "coded tones render as frequency followed by PL designation");
+
+    const AetherSDR::CtcssTone* wz = toneFor(69.3);
+    ok &= expect(wz && wz->code == 0
+                     && QString::fromLatin1(wz->designation) == QStringLiteral("WZ")
+                     && AetherSDR::ctcssToneLabel(*wz) == QStringLiteral("69.3 WZ"),
+                 "69.3 Hz retains its documented WZ designation");
+
+    const AetherSDR::CtcssTone* interstitial = toneFor(159.8);
+    ok &= expect(interstitial && interstitial->code == 0
+                     && interstitial->designation[0] == '\0'
+                     && AetherSDR::ctcssToneLabel(*interstitial) == QStringLiteral("159.8"),
+                 "an interstitial without a PL designation renders as frequency only");
+
+    QComboBox combo;
+    AetherSDR::populateCtcssToneCombo(&combo);
+    ok &= expect(combo.count() == static_cast<int>(AetherSDR::kCtcssToneCount),
+                 "the shared population helper exposes every legal tone");
+    ok &= expect(combo.maxVisibleItems() == AetherSDR::kCtcssTonePopupRows,
+                 "the shared popup is capped at the reviewed visible-row count");
+    ok &= expect(combo.view()->verticalScrollBarPolicy() == Qt::ScrollBarAlwaysOn,
+                 "the shared popup always exposes a visible vertical scrollbar");
+    const int codedRow = combo.findData(QStringLiteral("123.0"));
+    ok &= expect(codedRow >= 0
+                     && combo.itemText(codedRow) == QStringLiteral("123.0 3Z")
+                     && combo.itemData(codedRow, AetherSDR::kCtcssToneFrequencyRole)
+                            == QStringLiteral("123.0")
+                     && combo.itemData(codedRow, AetherSDR::kCtcssToneDesignationRole)
+                            == QStringLiteral("3Z"),
+                 "the shared combo retains separate frequency and designation columns");
+    const int interstitialRow = combo.findData(QStringLiteral("159.8"));
+    ok &= expect(interstitialRow >= 0
+                     && combo.itemText(interstitialRow) == QStringLiteral("159.8")
+                     && combo.itemData(interstitialRow,
+                                       AetherSDR::kCtcssToneDesignationRole).toString().isEmpty(),
+                 "the shared combo leaves an uncoded designation column blank");
+
+    const QStyle::State selectedState = QStyle::State_Enabled
+        | QStyle::State_Active | QStyle::State_Selected;
+    QPalette palette = combo.palette();
+    for (QPalette::ColorGroup group : {
+             QPalette::Active, QPalette::Inactive, QPalette::Disabled}) {
+        palette.setColor(group, QPalette::Base, Qt::black);
+        palette.setColor(group, QPalette::Highlight, Qt::black);
+    }
+    palette.setColor(QPalette::Active, QPalette::HighlightedText, Qt::red);
+    palette.setColor(QPalette::Inactive, QPalette::HighlightedText, Qt::green);
+    palette.setColor(QPalette::Disabled, QPalette::Text, Qt::blue);
+    combo.setPalette(palette);
+
+    const QImage expected = renderRow(combo, codedRow, selectedState);
+    combo.setItemText(codedRow, QStringLiteral("OVERLAY SENTINEL"));
+    const QImage displayRoleChanged = renderRow(combo, codedRow, selectedState);
+    ok &= expect(expected == displayRoleChanged,
+                 "the delegate paints only the separate columns, never an overlaid display label");
+
+    const QFontMetrics metrics(combo.font());
+    const int frequencyWidth = AetherSDR::ctcssToneFrequencyColumnWidth(metrics);
+    for (const AetherSDR::CtcssTone& tone : AetherSDR::kCtcssTones) {
+        ok &= expect(frequencyWidth
+                         >= metrics.horizontalAdvance(
+                             QString::number(tone.frequency, 'f', 1)),
+                     "the frequency column accommodates every rendered tone value");
+    }
+    const int gap = metrics.horizontalAdvance(QLatin1Char(' ')) * 3;
+    const QRect frequencyRect(AetherSDR::kCtcssToneHorizontalPadding, 0,
+                              frequencyWidth, expected.height());
+    const QRect designationRect(frequencyRect.right() + gap, 0,
+                                expected.width() - frequencyRect.right() - gap
+                                    - AetherSDR::kCtcssToneHorizontalPadding,
+                                expected.height());
+    ok &= expect(dominantPixels(expected, frequencyRect, DominantChannel::Red) > 0
+                     && dominantPixels(expected, designationRect, DominantChannel::Red) > 0,
+                 "active selected rendering paints both aligned columns with active text");
+
+    const QImage inactive = renderRow(
+        combo, codedRow, QStyle::State_Enabled | QStyle::State_Selected);
+    ok &= expect(dominantPixels(inactive, frequencyRect, DominantChannel::Green) > 0
+                     && dominantPixels(inactive, designationRect, DominantChannel::Green) > 0,
+                 "inactive selected rendering uses the inactive palette for both columns");
+
+    const QImage disabled = renderRow(combo, codedRow, QStyle::State_None);
+    ok &= expect(dominantPixels(disabled, frequencyRect, DominantChannel::Blue) > 0
+                     && dominantPixels(disabled, designationRect, DominantChannel::Blue) > 0,
+                 "disabled rendering uses the disabled palette for both columns");
+
+    const QImage uncoded = renderRow(combo, interstitialRow, selectedState);
+    ok &= expect(dominantPixels(uncoded, frequencyRect, DominantChannel::Red) > 0
+                     && dominantPixels(uncoded, designationRect, DominantChannel::Red) == 0,
+                 "an uncoded row paints frequency ink and leaves the designation column blank");
+
+    QString renderedPopupRules = AetherSDR::ctcssToneComboStyleRules();
+    renderedPopupRules.replace(QStringLiteral("{{color.background.0}}"),
+                               QStringLiteral("#010203"));
+    renderedPopupRules.replace(QStringLiteral("{{color.background.3}}"),
+                               QStringLiteral("#506070"));
+    renderedPopupRules.replace(QStringLiteral("{{color.accent.bright}}"),
+                               QStringLiteral("#00c8f0"));
+    combo.setStyleSheet(renderedPopupRules);
+    combo.resize(180, 24);
+    combo.show();
+    combo.showPopup();
+    QApplication::processEvents();
+    const int rowHeight = combo.view()->sizeHintForRow(0);
+    const int popupHeight = combo.view()->height();
+    QScrollBar* const popupScrollBar = combo.view()->verticalScrollBar();
+    ok &= expect(rowHeight >= AetherSDR::kCtcssToneRowHeight,
+                 "tone rows retain the reviewed vertical breathing room");
+    ok &= expect(combo.view()->verticalScrollBar()->maximum() > 0,
+                 "the capped popup scrolls to the remaining tones");
+    ok &= expect(popupScrollBar->isVisible() && popupScrollBar->width() == 12,
+                 "the production popup rules render the always-visible 12 px scrollbar");
+    QImage scrollBarImage(popupScrollBar->size(), QImage::Format_ARGB32_Premultiplied);
+    scrollBarImage.fill(Qt::transparent);
+    QPainter scrollBarPainter(&scrollBarImage);
+    popupScrollBar->render(&scrollBarPainter);
+    scrollBarPainter.end();
+    int themedThumbPixels = 0;
+    for (int y = 0; y < scrollBarImage.height(); ++y) {
+        for (int x = 0; x < scrollBarImage.width(); ++x) {
+            if (scrollBarImage.pixelColor(x, y).rgb() == QColor("#506070").rgb()) {
+                ++themedThumbPixels;
+            }
+        }
+    }
+    ok &= expect(themedThumbPixels > 0,
+                 "the production popup rules visibly render the themed scrollbar thumb");
+    ok &= expect(rowHeight > 0
+                     && popupHeight <= rowHeight * AetherSDR::kCtcssTonePopupRows + 4,
+                 "the rendered popup does not exceed 18 visible tone rows");
+    combo.hidePopup();
+
+    // These are deliberately narrow source-contract checks, not widget
+    // behavior tests. Constructing either shipping surface requires its full
+    // radio/session graph, so the rendered delegate and popup behavior are
+    // exercised above while these assertions only prevent either consumer
+    // from drifting back to a private population or styling path.
+    const QString rxSource = readSource("/src/gui/RxApplet.cpp");
+    const QString vfoSource = readSource("/src/gui/VfoWidget.cpp");
+    for (const auto& [source, label] : {
+             std::pair{rxSource, "RX applet"},
+             std::pair{vfoSource, "VFO widget"}}) {
+        ok &= expect(source.count(QStringLiteral("populateCtcssToneCombo(")) == 2,
+                     qPrintable(QStringLiteral("%1 routes both tone selectors through the shared population path").arg(label)));
+        ok &= expect(source.count(QStringLiteral("ctcssToneComboStyleRules()")) == 2,
+                     qPrintable(QStringLiteral("%1 applies the shared popup styling to both tone selectors").arg(label)));
+    }
+
+    const QString popupRules = AetherSDR::ctcssToneComboStyleRules();
+    ok &= expect(popupRules.contains(QStringLiteral("combobox-popup: 0;")),
+                 "the shared style disables the native uncapped popup");
+    ok &= expect(popupRules.contains(QStringLiteral("QScrollBar::handle:vertical"))
+                     && popupRules.contains(QStringLiteral("{{color.background.3}}"))
+                     && popupRules.contains(QStringLiteral("{{color.accent.bright}}")),
+                 "the shared scrollbar has themed resting and hover contrast");
+
+    std::cerr << (ok ? "ctcss_tone_label_test PASSED\n"
+                     : "ctcss_tone_label_test FAILED\n");
+    return ok ? 0 : 1;
+}

--- a/tests/ctcss_tone_label_test.cpp
+++ b/tests/ctcss_tone_label_test.cpp
@@ -74,6 +74,16 @@ int dominantPixels(const QImage& image, const QRect& rect, DominantChannel chann
     return count;
 }
 
+int rightmostDominantPixel(const QImage& image, DominantChannel channel)
+{
+    for (int x = image.width() - 1; x >= 0; --x) {
+        if (dominantPixels(image, QRect(x, 0, 1, image.height()), channel) > 0) {
+            return x;
+        }
+    }
+    return -1;
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -114,8 +124,7 @@ int main(int argc, char** argv)
     const int codedRow = combo.findData(QStringLiteral("123.0"));
     ok &= expect(codedRow >= 0
                      && combo.itemText(codedRow) == QStringLiteral("123.0 3Z")
-                     && combo.itemData(codedRow, AetherSDR::kCtcssToneFrequencyRole)
-                            == QStringLiteral("123.0")
+                     && combo.itemData(codedRow, Qt::UserRole) == QStringLiteral("123.0")
                      && combo.itemData(codedRow, AetherSDR::kCtcssToneDesignationRole)
                             == QStringLiteral("3Z"),
                  "the shared combo retains separate frequency and designation columns");
@@ -172,23 +181,26 @@ int main(int argc, char** argv)
                      && dominantPixels(expected, designationRect, DominantChannel::Red) > 0,
                  "active selected rendering paints the role and both aligned columns");
 
-    QStyleOptionViewItem sizeOption;
-    sizeOption.font = combo.font();
-    sizeOption.fontMetrics = metrics;
-    sizeOption.widget = combo.view();
-    const QSize codedSize = combo.itemDelegate()->sizeHint(
-        sizeOption, combo.model()->index(codedRow, 0));
-    int maximumDesignationWidth = 0;
-    for (const AetherSDR::CtcssTone& tone : AetherSDR::kCtcssTones) {
-        maximumDesignationWidth = std::max(
-            maximumDesignationWidth,
-            metrics.horizontalAdvance(QString::fromLatin1(tone.designation)));
-    }
-    const int requiredWidth = AetherSDR::kCtcssToneHorizontalPadding * 2
-        + prefixWidth + prefixGap + frequencyWidth + designationGap
-        + maximumDesignationWidth;
-    ok &= expect(codedSize.width() >= requiredWidth,
-                 "the delegate size hint accommodates the complete prefixed row");
+    const int firstAlignedRow = combo.findData(QStringLiteral("165.5"));
+    const int secondAlignedRow = combo.findData(QStringLiteral("199.5"));
+    AetherSDR::configureCtcssToneComboLabels(
+        &combo, AetherSDR::FmTonePresentation::Legacy,
+        AetherSDR::FmToneRole::Tx);
+    combo.setItemData(firstAlignedRow, QStringLiteral("1.5"), Qt::UserRole);
+    combo.setItemData(secondAlignedRow, QStringLiteral("111.5"), Qt::UserRole);
+    const QImage firstBareFrequency = renderRow(combo, firstAlignedRow, selectedState);
+    const QImage secondBareFrequency = renderRow(combo, secondAlignedRow, selectedState);
+    const int firstFrequencyRight = rightmostDominantPixel(
+        firstBareFrequency, DominantChannel::Red);
+    const int secondFrequencyRight = rightmostDominantPixel(
+        secondBareFrequency, DominantChannel::Red);
+    ok &= expect(firstAlignedRow >= 0 && secondAlignedRow >= 0
+                     && firstFrequencyRight >= 0
+                     && firstFrequencyRight == secondFrequencyRight,
+                 "different bare frequencies share the same rendered right edge");
+    AetherSDR::configureCtcssToneComboLabels(
+        &combo, AetherSDR::FmTonePresentation::Ctcss,
+        AetherSDR::FmToneRole::Tx);
 
     const QImage inactive = renderRow(
         combo, codedRow, QStyle::State_Enabled | QStyle::State_Selected);

--- a/tests/fm_tone_presentation_contract_test.py
+++ b/tests/fm_tone_presentation_contract_test.py
@@ -20,7 +20,7 @@ def fail(message: str) -> None:
     raise SystemExit(1)
 
 
-def check_surface(path: Path) -> None:
+def check_surface(path: Path, ctcss_members: tuple[str, str]) -> None:
     source = path.read_text(encoding="utf-8")
     if "const QString selected = m_slice" not in source:
         fail(f"{path.name} no longer derives the displayed mode from radio-backed slice state")
@@ -38,6 +38,22 @@ def check_surface(path: Path) -> None:
         fail(f"{path.name} bypasses the model-specific DTCS capability vocabulary")
     if "fmToneUsesDtcsTx(mode)" not in source:
         fail(f"{path.name} no longer places DTCS controls according to their TX/RX role")
+    for member in ctcss_members:
+        population = re.compile(rf"populateCtcssToneCombo\(\s*{member}\s*\)")
+        labels = re.compile(
+            rf"configureCtcssToneComboLabels\(\s*{member}\s*,\s*"
+            r"presentation\s*,\s*FmToneRole::(?:Tx|Rx)\s*\)"
+        )
+        style = re.compile(
+            rf"applyComboStyle\(\s*{member}\s*,\s*"
+            r"AetherSDR::ctcssToneComboStyleRules\(\)\s*\)"
+        )
+        if not population.search(source):
+            fail(f"{path.name} no longer populates {member} through the shared CTCSS path")
+        if not labels.search(source):
+            fail(f"{path.name} no longer configures {member} through the shared label path")
+        if not style.search(source):
+            fail(f"{path.name} no longer applies shared popup styling to {member}")
 
 
 def main() -> int:
@@ -45,8 +61,11 @@ def main() -> int:
         fail("usage: fm_tone_presentation_contract_test.py <source-root>")
     source_root = Path(sys.argv[1])
     rx_path = source_root / "src/gui/RxApplet.cpp"
-    check_surface(rx_path)
-    check_surface(source_root / "src/gui/VfoWidget.cpp")
+    check_surface(rx_path, ("m_toneValueCmb", "m_toneRxValueCmb"))
+    check_surface(
+        source_root / "src/gui/VfoWidget.cpp",
+        ("m_fmToneValueCmb", "m_fmToneRxValueCmb"),
+    )
     rx_source = rx_path.read_text(encoding="utf-8")
     radio_model_source = (source_root / "src/models/RadioModel.cpp").read_text(
         encoding="utf-8"

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3526,6 +3526,17 @@ target_include_directories(memory_field_values_test PRIVATE src)
 target_link_libraries(memory_field_values_test PRIVATE Qt6::Core)
 add_test(NAME memory_field_values_test COMMAND memory_field_values_test)
 
+add_executable(ctcss_tone_label_test
+    tests/ctcss_tone_label_test.cpp
+)
+target_include_directories(ctcss_tone_label_test PRIVATE src)
+target_link_libraries(ctcss_tone_label_test PRIVATE Qt6::Widgets)
+target_compile_definitions(ctcss_tone_label_test PRIVATE
+    AETHER_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+add_test(NAME ctcss_tone_label_test COMMAND ctcss_tone_label_test)
+set_tests_properties(ctcss_tone_label_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 add_executable(local_memory_store_test
     tests/local_memory_store_test.cpp
     src/core/LocalMemoryStore.cpp

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3531,8 +3531,6 @@ add_executable(ctcss_tone_label_test
 )
 target_include_directories(ctcss_tone_label_test PRIVATE src)
 target_link_libraries(ctcss_tone_label_test PRIVATE Qt6::Widgets)
-target_compile_definitions(ctcss_tone_label_test PRIVATE
-    AETHER_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 add_test(NAME ctcss_tone_label_test COMMAND ctcss_tone_label_test)
 set_tests_properties(ctcss_tone_label_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")


### PR DESCRIPTION
## Summary

- Replace the RX and VFO CTCSS dropdowns' separate formatting with one shared `frequency designation` presentation.
- Preserve the established `TX:` and `RX:` role prefixes in both closed controls and open popups.
- Cap the popup at 18 visible rows and add an always-visible themed scrollbar.
- Align complete prefix, frequency, and designation columns using cached active-font metrics, including the delegate width hint.
- Correct the existing 69.3 Hz entry to its documented `WZ` PL designation without changing its numeric metadata.
- Gate both the rendered presentation and the established full-desktop wiring contract in CI.

## Why

The previous RX dropdown exposed internal numeric indexes, ordered its fields differently from the VFO dropdown, expanded into an exceptionally long popup, and offered no visible indication that more tones could be reached by scrolling. The revised presentation is shorter, consistent, easier to scan, and makes navigation discoverable.

The selectable frequencies remain the existing 50-tone set from #5140. PL designations were checked against Appendix G of the [CISA Auxiliary Communications Field Operations Guide](https://www.cisa.gov/sites/default/files/publications/AUXFOG%20June%202016%20-%20508%20Reviewed%20-%20Final%20%282-16-17%29_0.pdf), including `69.3 WZ`, `123.0 3Z`, and the M-series designations.

DTCS controls and protocol behavior remain explicitly outside this PR. The newer DTCS implementation from current `main` was preserved unchanged during the rebase.

## Scope and compatibility

This is shared FM-control presentation, not an IC-9700-only change. It affects every backend that exposes the RX or VFO CTCSS controls.

The bare frequency remains the combo-box item data. No radio commands, automation values, persistence semantics, tone ordering, or radio-authoritative behavior change.

Review follow-up on the rebased head:

- The delegate now paints an explicit popup-role field, so `TX:` and `RX:` remain distinguishable.
- `sizeHint()` covers the complete rendered row under a stress font.
- Frequency and designation widths are cached per font instead of scanning all 50 tones during every paint.
- The test no longer opens production source through a build-layout-dependent `__FILE__` path. Rendered behavior is tested directly; the repository's existing focused wiring contract pins each RX/VFO combo to the shared population, label, and style paths.
- The new two-test CTCSS CI gate has an exact selection-count pin.

## Visual comparison

Before: internal indexes, inconsistent field ordering, a full-height popup, and no visible scrollbar.

<img width="149" height="1124" alt="before" src="https://github.com/user-attachments/assets/c4d8fe89-eb29-4a7b-ace7-e92989c112c4" />

After: aligned frequency/designation columns, consistent spacing, an 18-row cap, and an always-visible themed scrollbar.

<img width="314" height="944" alt="CleanShot 2026-08-26 at 08 10 52@2x" src="https://github.com/user-attachments/assets/2bc70709-b54d-4cb7-b986-fc01c8e5e724" />

## Validation

- Rebased onto current `main` at `be5b5a54`.
- CTCSS presentation gate: 2/2 passed (`ctcss_tone_label_test`, `fm_tone_presentation_contract`).
- `python3 tools/check_engine_boundary.py --strict`: passed with tracked legacy warnings only.
- `python3 tools/check_test_registration.py --strict`: passed.
- Exact colour ratchet against `be5b5a54`: 613 unique colours, 2724 references, 1090 `setStyleSheet()` sites; all deltas zero.
- `git diff --check`: passed.
- Both rebased commits have verified SSH signatures.
- The full macOS target build reached packaging but remains blocked by the pre-existing local `iconutil: Invalid Iconset` failure; the focused Qt target builds and runs successfully. Fresh Linux, Windows, and macOS CI is pending on the new exact head.
- Manual IC-9700 validation previously covered alignment, spacing, popup height, scrolling, and scrollbar contrast. The restored open-popup role prefixes require fresh visual confirmation.

## Guidance read

Repository `AGENTS.md`, Constitution, Governance, contributing guide, developer guide, theme style guide, accessibility guidance, and the shared/project private developer guidance were applied. The private current-state file is an uninitialized placeholder; live Git and GitHub state were used instead.

Fixes #5258
