### PR TITLE
refactor(core): single-source the in-use radio share gate (#4448)

### DIFF
--- a/src/core/backends/ConnectionSharingPolicy.h
+++ b/src/core/backends/ConnectionSharingPolicy.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <QString>
+
+namespace AetherSDR {
+
+// Whether a discovered radio that is ALREADY IN USE by another client may
+// still be joined by this one.
+//
+// Flex is the only family that shares: multiFLEX gives every GUI client its
+// own session, slices and streams. Every other family served today is
+// single-client at the protocol layer — HPSDR Protocol 1 has one host slot
+// (#4448: connecting to a streaming HL2 wedges BOTH clients), and an Icom
+// RS-BA1 session is exclusive — so a busy radio fails closed.
+//
+// Unknown or empty families fail closed too: refusing a share the radio
+// could have taken is a retry; wedging someone's active QSO is not.
+//
+// This predicate exists so the rule has ONE home (it was previously
+// duplicated in ConnectionPanel and MainWindow_Session, drifting apart is
+// how #4448 regresses). It is family-keyed rather than capability-keyed
+// only because it runs at DISCOVERY time, before any backend exists to ask
+// for RadioCapabilities::hasMultiClientSessions — the M5 per-family static
+// descriptors (#5262) replace this with that capability; do not grow this
+// file into a second capability system in the meantime.
+inline bool familySupportsSharedInUseConnect(const QString& family)
+{
+    return family.compare(QLatin1String("flex"), Qt::CaseInsensitive) == 0;
+}
+
+} // namespace AetherSDR

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -1,5 +1,6 @@
 #include "ConnectionPanel.h"
 #include "core/AppSettings.h"
+#include "core/backends/ConnectionSharingPolicy.h"  // in-use share gate (#4448), shared with MainWindow_Session
 #include "core/backends/hl2/Hl2Discovery.h"   // shared nickname + MAC->serial helpers
 #include "core/backends/icom/IcomCredentials.h"  // password -> OS keychain, never settings
 #include "core/backends/icom/IcomSettings.h"     // host/user/ports (Principle V)
@@ -1904,10 +1905,11 @@ void ConnectionPanel::onLocalConnectClicked()
         return;
 
     const RadioInfo& info = m_radios[row];
-    // F5 (#4448): a non-Flex family (HL2) is single-client under HPSDR Protocol 1
-    // — an in-use radio can't be shared, and connecting would wedge both clients.
-    // Fail closed. Flex multiFlex sharing is a separate, Flex-only path.
-    if (info.inUse && info.family != QLatin1String("flex")) {
+    // F5 (#4448): an in-use radio of a single-client family can't be shared,
+    // and connecting would wedge both clients. Fail closed. The rule lives in
+    // ConnectionSharingPolicy.h — one home, shared with the startup
+    // auto-connect gate in MainWindow_Session.
+    if (info.inUse && !AetherSDR::familySupportsSharedInUseConnect(info.family)) {
         setStatusText(QStringLiteral(
             "%1 is already in use by another client and can't be shared.")
             .arg(info.model));

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -31,6 +31,7 @@
 #include "PhoneCwApplet.h"
 #include "SpectrumOverlayMenu.h"
 #include "RfGainPresentation.h"
+#include "core/backends/ConnectionSharingPolicy.h"  // in-use share gate (#4448), shared with ConnectionPanel
 #include "core/backends/sim/SimBackend.h"   // demo owns its audio — see wirePanStreamRxAudioSinks
 #include "core/CwSidetoneGenerator.h"
 #include "core/CwTrace.h"
@@ -504,12 +505,12 @@ void MainWindow::maybeAutoConnectToDiscoveredRadio(const RadioInfo& info)
     if (m_autoConnectAttempts.value(info.serial) >= kMaxAutoConnectAttempts)
         return;
 
-    // Fail closed on a busy non-Flex radio, matching the manual connect gate in
-    // ConnectionPanel (#4448): HPSDR Protocol 1 is single-client, so connecting to
-    // an HL2 that is already streaming wedges both clients. Say so instead of
-    // silently doing nothing — this is the startup path, and the operator is
-    // staring at "Looking for your radio…".
-    if (info.inUse && info.family.compare(QLatin1String("flex"), Qt::CaseInsensitive) != 0) {
+    // Fail closed on a busy single-client radio, matching the manual connect
+    // gate in ConnectionPanel (#4448) — the rule is shared via
+    // ConnectionSharingPolicy.h so the two gates cannot drift. Say so instead
+    // of silently doing nothing — this is the startup path, and the operator
+    // is staring at "Looking for your radio…".
+    if (info.inUse && !AetherSDR::familySupportsSharedInUseConnect(info.family)) {
         m_connPanel->setStatusText(
             QStringLiteral("%1 is already in use by another client and can't be shared.")
                 .arg(info.model));

--- a/tests/connection_sharing_policy_test.cpp
+++ b/tests/connection_sharing_policy_test.cpp
@@ -1,0 +1,59 @@
+// Unit tests for ConnectionSharingPolicy — the fail-closed gate that refuses
+// to join a discovered radio another client is already using (#4448), now
+// single-sourced for the ConnectionPanel manual-connect and
+// MainWindow_Session auto-connect paths (M0, #5263).
+//
+// The load-bearing rows are the fail-closed ones: an unknown or empty family
+// must refuse, because wedging someone's active QSO is worse than making the
+// operator retry after the other client leaves.
+
+#include "core/backends/ConnectionSharingPolicy.h"
+
+#include <QString>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+int g_total = 0;
+
+void report(const char* label, bool ok)
+{
+    ++g_total;
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", label);
+    if (!ok) {
+        ++g_failed;
+    }
+}
+
+} // namespace
+
+int main()
+{
+    // Flex shares: multiFLEX gives each GUI client its own session.
+    report("flex shares", familySupportsSharedInUseConnect(QStringLiteral("flex")));
+    report("flex shares case-insensitively",
+           familySupportsSharedInUseConnect(QStringLiteral("Flex"))
+               && familySupportsSharedInUseConnect(QStringLiteral("FLEX")));
+
+    // Every other family served today is single-client at the protocol layer.
+    report("hl2 refuses (HPSDR Protocol 1 single-client, #4448)",
+           !familySupportsSharedInUseConnect(QStringLiteral("hl2")));
+    report("icom refuses (RS-BA1 session is exclusive)",
+           !familySupportsSharedInUseConnect(QStringLiteral("icom")));
+    report("sim refuses",
+           !familySupportsSharedInUseConnect(QStringLiteral("sim")));
+
+    // Fail closed on anything unrecognized: a future family must OPT IN to
+    // sharing, never inherit it from a default.
+    report("unknown family refuses",
+           !familySupportsSharedInUseConnect(QStringLiteral("yaesu")));
+    report("empty family refuses",
+           !familySupportsSharedInUseConnect(QString()));
+
+    std::printf("%d/%d passed\n", g_total - g_failed, g_total);
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1176,6 +1176,12 @@ target_include_directories(center_lock_rebind_tracker_test PRIVATE src)
 target_link_libraries(center_lock_rebind_tracker_test PRIVATE Qt6::Core)
 add_test(NAME center_lock_rebind_tracker_test COMMAND center_lock_rebind_tracker_test)
 
+# In-use radio share gate (#4448), single-sourced for both connect paths — header-only.
+add_executable(connection_sharing_policy_test tests/connection_sharing_policy_test.cpp)
+target_include_directories(connection_sharing_policy_test PRIVATE src)
+target_link_libraries(connection_sharing_policy_test PRIVATE Qt6::Core)
+add_test(NAME connection_sharing_policy_test COMMAND connection_sharing_policy_test)
+
 # Last-session DAX restore window + quit-time key prune (#4558) — header-only.
 add_executable(dax_restore_policy_test tests/dax_restore_policy_test.cpp)
 target_include_directories(dax_restore_policy_test PRIVATE src)


### PR DESCRIPTION
M0 item 2 of #5263 (migration tracking: #5262).

## What

The fail-closed refusal to join a discovered radio that another client is already using existed as two hand-written family string compares — `ConnectionPanel::onLocalConnectClicked` (manual connect) and the `MainWindow_Session` startup auto-connect gate. Both now call one predicate, `familySupportsSharedInUseConnect()` in `src/core/backends/ConnectionSharingPolicy.h`.

- Flex shares (multiFLEX); hl2/icom/sim refuse; **unknown/empty families fail closed** — a future family must opt in to sharing, never inherit it.
- Family-keyed rather than capability-keyed deliberately: the gate runs at discovery time, before any backend exists to ask for `RadioCapabilities::hasMultiClientSessions`. The M5 per-family static descriptors (#5262) replace this predicate with that capability; the header says so at the point of use.
- No operator-visible behavior change: both sites keep their existing status text and flow.

## Test

`connection_sharing_policy_test` (header-only, Qt6::Core) pins the truth table including case-insensitivity and the fail-closed rows. Registered in `tests/tests.cmake`; `tools/check_test_registration.py --strict` passes.

**Mutation check:** inverting the predicate's comparison (`== 0` → `!= 0`) fails all 7 rows (0/7); restored, 7/7 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)