### PR TITLE
feat(models): make the no-command-plane drop loud — Principle VIII

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1552,6 +1552,7 @@ private:
     bool m_hasPaTempTelemetry{false};
     float m_lastPaTempC{0.0f};
     bool m_userDisconnected{false};  // true after explicit disconnect, blocks auto-connect
+    bool m_commandDroppedNoticeShown{false};  // one status-bar notice per connect session (M0, #5263)
     // Auto-reconnect bookkeeping — see maybeAutoConnectToDiscoveredRadio().
     //
     // The slot is driven by radioUpdated as well as radioDiscovered, and

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -669,6 +669,27 @@ void MainWindow::wireRadioModel()
     // set its visibility.
     connect(&m_radioModel, &RadioModel::capabilitiesChanged,
             this, &MainWindow::applyCapabilitiesToUi);
+
+    // Loud drop (M0, #5263): RadioModel emits commandDropped on every
+    // Flex-syntax command it discards for lack of a command plane (HL2, Icom).
+    // The qCWarning in RadioModel carries each occurrence; the operator gets
+    // ONE status-bar notice per connect session, so a single unconverted
+    // surface cannot spam the bar while still never failing silently.
+    connect(&m_radioModel, &RadioModel::connectionStateChanged,
+            this, [this](bool connected) {
+        if (connected)
+            m_commandDroppedNoticeShown = false;
+    });
+    connect(&m_radioModel, &RadioModel::commandDropped,
+            this, [this](const QString&) {
+        if (m_commandDroppedNoticeShown)
+            return;
+        m_commandDroppedNoticeShown = true;
+        statusBar()->showMessage(
+            tr("This radio doesn't support that control — nothing was sent to "
+               "the radio. Further unsupported controls are logged."),
+            8000);
+    });
     // Slice Link: disconnect teardown never emits sliceRemoved (stale slices
     // are staged for reconnect reclaim), so dissolve the link explicitly.
     // Both transitions dissolve — a link never crosses a session boundary

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -8465,8 +8465,13 @@ quint32 RadioModel::sendCmd(const QString& command, ResponseCallback cb)
     // with a `slice tune`, and the tune is Flex wire text), so fail the way the
     // rest of sendCmd's drops do: sequence 0, meaning "not dispatched".
     if (!hasCommandPlane()) {
-        qCDebug(lcProtocol).noquote()
+        // qCWarning, not qCDebug: a dropped command means a control moved and
+        // nothing reached the radio. Silent at default log levels, that is the
+        // HERMES §17 dead-control shape; loud, it is a reportable defect and
+        // the M4 conversion backlog finds its sites from these lines (#5263).
+        qCWarning(lcProtocol).noquote()
             << "RadioModel: no command plane for this backend, dropping" << command;
+        emit commandDropped(command);
         if (cb)
             cb(kNoCommandPlaneCode, QStringLiteral("this radio has no command plane"));
         return 0;

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1156,6 +1156,12 @@ signals:
     void txFilterBlockingAudio(const QString& title,
                                const QString& detail,
                                const QString& panId);
+    // A Flex-syntax command was dropped because this backend has no command
+    // plane (HL2, Icom): the control that emitted it moved and nothing reached
+    // the radio — the HERMES §17 shape, made visible (M0, #5263). Emitted on
+    // EVERY drop; the UI's one-shot-per-session throttling is the consumer's
+    // job, so logs and any non-UI consumers can observe each occurrence.
+    void commandDropped(const QString& command);
     // Emitted when global profile list or active profile changes.
     void globalProfilesChanged();
     void profileDatabaseImportingChanged(bool importing);


### PR DESCRIPTION
## Summary

- Promote no-command-plane Flex-text drops from `qCDebug` to `qCWarning`, retaining the dropped command in the diagnostic.
- Emit `RadioModel::commandDropped` for every drop so consumers can surface the failure.
- Show one status-bar notice per connected session; reconnecting resets the notice latch.

## Issue fit

This is M0 item 1 from #5263. It makes the existing fail-closed path visible without changing Flex command dispatch or adding a radio-family-specific command route.

## Validation

- Rebased onto current `origin/main` and verified with a clean synthetic merge.
- macOS `AetherSDR.app` build passed at `0b61742e` using `-j22`.
- The fake HL2/Flex radio test and its CMake registration were removed at maintainer request; `tests/radio_command_drop_test.cpp` and `tests/tests.cmake` have zero diff from `main`.
- No physical-radio validation is claimed. Automated behavior coverage was removed with the fake test.

## Scope

Only the no-command-plane warning/signal and its one-shot MainWindow presentation remain. No radio protocol encoding, backend behavior, settings, theme colors, or transport code changes.

Generated with OpenAI Codex (Daybreak Blue)
