### PR TITLE
fix(gui): dim the Flex-only controls that were silently dead off-Flex — Principle II

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7405,6 +7405,25 @@ void MainWindow::applyCapabilitiesToUi(bool connected, const RadioCapabilities& 
         m_multiFlexAction->setVisible(!connected || caps.hasMultiClientSessions);
     }
 
+    // TX Band Settings and Inhibit-during-TUNE drive Flex interlock/band
+    // verbs that a backend with no command plane drops. Doctrine (#5263):
+    // dim, never hide — the entries stay visible on every family, disabled
+    // with a reason where the backend cannot honor them. Permissive on
+    // disconnect like every gate in this function.
+    {
+        const bool cmdPlane = !connected || m_radioModel.hasCommandPlane();
+        const QString why =
+            cmdPlane ? QString() : tr("Not supported by this radio");
+        if (m_txBandAction) {
+            m_txBandAction->setEnabled(cmdPlane);
+            m_txBandAction->setToolTip(why);
+        }
+        if (m_tuneInhibitMenu) {
+            m_tuneInhibitMenu->menuAction()->setEnabled(cmdPlane);
+            m_tuneInhibitMenu->menuAction()->setToolTip(why);
+        }
+    }
+
     // ── GPS: the status-bar position readout and the dialog it opens ────────
     //
     // Family capability and unit presence are separate facts. Flex radios can

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1415,6 +1415,7 @@ private:
     // Menus
     QMenu*           m_profilesMenu{nullptr};
     QAction*         m_txBandAction{nullptr};
+    QMenu*           m_tuneInhibitMenu{nullptr};  // Flex rear-panel TX outputs — dimmed off-Flex (#5263)
     // Settings ▸ "Autostart DAX with AetherSDR". Held so
     // applyCapabilitiesToUi() can hide it on a radio with no DAX streams.
     // Null on platforms without a DAX bridge, where the entry is never created.

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -500,6 +500,15 @@ void MainWindow::handleFlexControlButton(int button, int action)
         setFlexControlHardwareIndicator(button);
     } else if (actionName == "SplitActiveSlice") {
         if (!m_splitActive) {
+            // Same gate the CwxF* macros carry below: split creates its TX
+            // slice with Flex wire text, which a backend with no command plane
+            // drops — a hardware button that silently does nothing. Refuse and
+            // log; the binding stays assignable (M0, #5263).
+            if (!m_radioModel.hasCommandPlane()) {
+                qCDebug(lcDevices) << "SplitActiveSlice ignored:"
+                                   << "this backend takes no Flex slice-create command";
+                return;
+            }
             if (m_radioModel.slices().size() >= m_radioModel.maxSlices()) return;
             auto* s = activeSlice();
             if (!s) return;
@@ -1020,6 +1029,14 @@ void MainWindow::dispatchHidAction(const QString& actionName,
         applyMasterVolume(next);
     } else if (actionName == "SplitActiveSlice") {
         if (!m_splitActive) {
+            // Same refusal as the FlexControl split above: no command plane,
+            // no Flex slice-create — refuse loudly instead of a dead hardware
+            // button (M0, #5263).
+            if (!m_radioModel.hasCommandPlane()) {
+                qCDebug(lcDevices) << "SplitActiveSlice (HID) ignored:"
+                                   << "this backend takes no Flex slice-create command";
+                return;
+            }
             auto* s = activeSlice();
             if (s && m_radioModel.slices().size() < m_radioModel.maxSlices()) {
                 QString panId = s->panId().isEmpty()
@@ -2067,12 +2084,32 @@ void MainWindow::registerMidiParams()
     }
 
     // ── Global ──────────────────────────────────────────────────────────
+    // The mixer verbs drive the RADIO's lineout/headphone hardware outputs, a
+    // Flex command-plane feature — on a backend without one the command is
+    // dropped, which made a mapped MIDI volume knob silently dead. Refuse and
+    // log instead (M0, #5263). Rerouting these to the client-side master
+    // volume would change what the knob MEANS on Flex, so that stays an M4
+    // conversion decision, not a gate.
     reg("global.masterVolume", "Master Volume", "Global", P::Slider, 0, 100,
-        [this](float v) { m_radioModel.sendCommand(QString("mixer lineout gain %1").arg(static_cast<int>(v))); },
+        [this](float v) {
+            if (!m_radioModel.hasCommandPlane()) {
+                qCDebug(lcDevices) << "global.masterVolume ignored:"
+                                   << "radio mixer verbs need a Flex command plane";
+                return;
+            }
+            m_radioModel.sendCommand(QString("mixer lineout gain %1").arg(static_cast<int>(v)));
+        },
         [this]() -> float { return m_radioModel.lineoutGain(); });
 
     reg("global.hpVolume", "Headphone Volume", "Global", P::Slider, 0, 100,
-        [this](float v) { m_radioModel.sendCommand(QString("mixer headphone gain %1").arg(static_cast<int>(v))); },
+        [this](float v) {
+            if (!m_radioModel.hasCommandPlane()) {
+                qCDebug(lcDevices) << "global.hpVolume ignored:"
+                                   << "radio mixer verbs need a Flex command plane";
+                return;
+            }
+            m_radioModel.sendCommand(QString("mixer headphone gain %1").arg(static_cast<int>(v)));
+        },
         [this]() -> float { return m_radioModel.headphoneGain(); });
 
     reg("global.masterMute", "Master Mute", "Global", P::Toggle, 0, 1,

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -559,6 +559,10 @@ void MainWindow::buildMenuBar()
     // Inhibit during TUNE submenu — user selects which TX outputs to suppress.
     // Uses QWidgetAction with QCheckBox so the menu stays open for multi-select.
     auto* tuneInhibitMenu = settingsMenu->addMenu("Inhibit during TUNE");
+    // Kept as a member so applyCapabilitiesToUi can dim it (with TX Band
+    // Settings) on backends with no Flex command plane — doctrine (#5263):
+    // dim, never hide.
+    m_tuneInhibitMenu = tuneInhibitMenu;
 
     auto& settings = AppSettings::instance();
     struct InhibitDef { const char* label; const char* key; };

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -1562,6 +1562,22 @@ QWidget* RadioSetupDialog::buildNetworkTab()
             m_model->sendCommand(
                 QString("radio set enforce_private_ip_connections=%1").arg(on ? 1 : 0));
         });
+        // Doctrine (#5263): dim, never hide. `radio set
+        // enforce_private_ip_connections=` is a Flex command-plane verb; on a
+        // backend without one the button toggled and the command was dropped —
+        // a live-looking dead control. Same refresh shape as the Reboot button
+        // above.
+        auto applyEnforceAvailability = [this, enforceBtn] {
+            const bool ok = m_model->hasCommandPlane();
+            enforceBtn->setEnabled(ok);
+            const QString why = ok ? QString()
+                                   : tr("Not supported by this radio");
+            enforceBtn->setToolTip(why);
+            enforceBtn->setAccessibleDescription(why);
+        };
+        applyEnforceAvailability();
+        connect(m_model, &RadioModel::connectionStateChanged, enforceBtn,
+                [applyEnforceAvailability](bool) { applyEnforceAvailability(); });
         grid->addWidget(enforceBtn, 0, 1);
 
         // 128-bit hex token generator — plenty for a local same-user secret.


### PR DESCRIPTION
M0 item 3 of #5263 (migration tracking: #5262).

## What

Five surfaces emitted Flex wire text with no capability check, so on HL2/Icom the control moved and nothing reached the radio (the HERMES §17 shape, several confirmed live by the architecture review):

| Surface | Before | Now |
|---|---|---|
| Hardware **Split** — FlexControl and RC-28/HID | raw `slice create`, result ignored | refuses + logs when the backend has no command plane (the in-file `CwxF*` gate pattern); binding stays assignable |
| MIDI `global.masterVolume` / `global.hpVolume` | raw `mixer lineout/headphone gain` | same refusal + log |
| **Enforce Private IP Connections** (Radio Setup ▸ Network) | toggled and dropped | disabled + reason tooltip + `accessibleDescription`, refreshed on connection edges (the Reboot-button pattern) |
| **TX Band Settings…** / **Inhibit during TUNE** (Settings menu) | gated on `isConnected()` only | dimmed with a reason via `applyCapabilitiesToUi`, permissive on disconnect |

Doctrine (#5263): **dim, never hide** — every surface stays visible in its place on every family. The MIDI knobs are deliberately *not* rerouted to client-side volume: the Flex verbs drive the radio's hardware outputs, and changing what the knob means on Flex is an M4 conversion decision, not a gate.

Gate predicate is `RadioModel::hasCommandPlane()` (the connection-object truth the drop path itself uses), not a family string.

## Verification

- Builds clean; `tools/check_a11y.py` reports no findings on the touched files.
- No behavior change on Flex/Sim (both own a command plane; every gate passes).
- The refusal paths land on the same drop path PR #5265 makes loud, so an unconverted surface this PR missed still reports itself.
- Headless runtime verification of the dimmed state isn't possible in this environment (sim owns a command plane, so the gates pass on it; HL2/Icom need hardware) — flagging for maintainer eyes on next HL2/Icom session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)