### PR TITLE
fix(tests): give every registered test a default 300s TIMEOUT — Principle VIII

### DIFF
--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -4094,3 +4094,31 @@ foreach(_aether_target IN LISTS _aether_test_targets)
         target_link_libraries(${_aether_target} PRIVATE aether_test_wisdom_isolation)
     endif()
 endforeach()
+
+# ── Default test timeout — every test gets a ceiling ────────────────────────
+#
+# No suite-wide timeout existed before this: `enable_testing()` without
+# `include(CTest)` configures none, so a hung test blocked its CI gate
+# indefinitely — map_live_update_test ran 35 minutes producing nothing before
+# it was killed by hand (#5271). A timeout turns a hang into a fast, LOGGED
+# failure: ctest counts it as failed, so --output-on-failure finally prints
+# the captured output that a hang withholds.
+#
+# 300s is data-derived, not a guess: across the last 10 gate-lane runs and
+# the 4 most recent full-suite sanitizer runs, 90% of tests average under
+# ~3s and the slowest legitimate completion ever recorded is spectral_nr_test
+# at 276.6s under the sanitizer lane (#5271 has the tables). If a test
+# legitimately outgrows 300s, give IT a bigger explicit TIMEOUT below its
+# add_test — never raise this default for one test's sake.
+#
+# The loop only fills the gap: a test that already declares its own TIMEOUT
+# (vkamp_connection_test, asr_gpu_probe_test) keeps it. A CMake TIMEOUT
+# property always beats a `ctest --timeout` flag, so this is authoritative
+# in every lane — gate steps, sanitizers, and local dev alike.
+get_directory_property(_aether_registered_tests TESTS)
+foreach(_aether_test IN LISTS _aether_registered_tests)
+    get_test_property(${_aether_test} TIMEOUT _aether_existing_timeout)
+    if(NOT _aether_existing_timeout)
+        set_tests_properties(${_aether_test} PROPERTIES TIMEOUT 300)
+    endif()
+endforeach()


### PR DESCRIPTION
Closes #5271's actionable half (the timeout gap; the one-off hang itself passed on rerun and stays documented there).

## What

A fill-the-gap loop at the end of `tests/tests.cmake`: every registered test without an explicit `TIMEOUT` property gets **300 s**. Tests that already declare one (`vkamp_connection_test` 120 s, `asr_gpu_probe_test` 180 s) keep theirs. A CMake property is authoritative in every lane — the 19 gate steps, the sanitizer lane, and local dev — and always beats a `ctest --timeout` flag, so this is one change instead of twenty.

## Why 300 s (data, not a guess)

Measured from the last 10 gate-lane runs (320 samples, 31 tests) and the 4 most recent full-suite sanitizer runs (~1,060 samples, 221 tests) — full tables in #5271:

| Lane | p90 of per-test averages | Observed max |
|---|---|---|
| CI gate | 2.8 s | 23.1 s (`spectral_nr_test`) |
| Sanitizers | 3.1 s | **276.6 s** (`spectral_nr_test`) |

300 s clears the slowest legitimate completion ever recorded, with the per-test explicit `TIMEOUT` as the escape hatch if a test outgrows it — raise *that test's* property, never the default. Maintainer-selected over the initially proposed 600 s.

Why it matters beyond hang-killing: ctest counts a timeout as a **failure**, so `--output-on-failure` finally prints the captured output a hang withholds — the 35-minute silent hang on #5266 becomes a 5-minute failure with diagnosis material.

## Verification

- Generated `CTestTestfile.cmake`: 326 of 328 registered tests carry `TIMEOUT "300"`; the two explicit properties survive (120/180). 326+2 = 328 — full coverage.
- **Enforcement demonstrated end-to-end (mutation check):** dropping `spectral_nr_test`'s generated timeout to 1 s makes ctest kill it and report `(Timeout)` as a failure; restored via reconfigure, it passes normally (9.3 s locally).
- `tools/check_test_registration.py --strict` passes.

Heads-up recorded in #5271 and worth its own attention: the **sanitizer lane has failed every weekly run since June 1** — the lane where the 276.6 s tail lives is currently dark, so `spectral_nr_test`'s margin under TSAN can't be watched until that's fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)