### PR TITLE
fix(icom): stabilize WSJT-X TCI unkey handling and incident telemetry

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -2570,6 +2570,24 @@ needed).
 ← {"ok":true,"contractVersion":1,"routeOwner":"external",
    "splitRequested":false,"rxSliceId":4,"txSliceId":7,"ownsRoute":false,
    "routeTransitionInFlight":false,"pendingRoutes":[],
+   "ptt":{"owned":false,"requestedOn":false,"confirmedOn":false,
+          "unkeySettling":false,
+          "requestCount":84,"onRequestCount":42,"offRequestCount":42,
+          "acceptedOnCount":42,"confirmedOnCount":41,
+          "confirmationTimeoutCount":1,"lastRequestedOn":true,
+          "unkeySettleCount":6,"suppressedRekeyCount":2,
+          "unkeySettleTimeoutCount":0,
+          "lastRequestAgeMs":1270,"lastAcceptedAgeMs":1268,
+          "lastConfirmedAgeMs":16243,"lastOutcome":"confirmation-timeout",
+          "lastOutcomeAgeMs":20},
+   "lastDisconnect":{"contractVersion":1,"ageMs":520,
+      "closeCode":1006,"closeReason":"","socketState":0,
+      "socketError":1,"socketErrorString":"The remote host closed the connection",
+      "connectionAgeMs":2577940,"lastTextRxAgeMs":53,"lastTextTxAgeMs":28,
+      "lastSocketErrorAgeMs":0,"lastRxCommand":"trx","lastTxCommand":"trx",
+      "ptt":{"owned":true,"requestedOn":false,"confirmedOn":true,
+             "unkeySettling":true,"generation":141,
+             "lastOutcome":"icom-unkey-transient-keyed"}},
    "endpoints":[
      {"trx":0,"sliceId":4,"panId":"0x40000000","frequencyHz":14074000,"tx":false},
      {"trx":1,"sliceId":7,"panId":"0x40000001","frequencyHz":14076000,"tx":true}
@@ -2590,6 +2608,29 @@ tci trace clear
 tci trace export /tmp/tci-trace.json
 tci routes
 ```
+
+The `ptt` counters and ages are payload-free and remain available without TCI
+wire tracing. If `onRequestCount` advances but `acceptedOnCount` does not, the
+request stopped in TCI routing or transmit preflight. If both advance but
+`confirmedOnCount` does not and `confirmationTimeoutCount` advances, TCI handed
+the request to the radio path but radio-authoritative keyed state never returned.
+Read that snapshot beside `civ incident`: together they distinguish WebSocket
+ingress, TCI routing, CI-V scheduling, the serial data pipe, the RS-BA1 lease,
+and broad UDP/socket loss.
+
+For Icom, `unkeySettleCount` counts the bounded TCI presentation barriers used
+after an owned unkey. A growing `suppressedRekeyCount` means delayed CI-V
+readback briefly said the radio was still keyed; AetherSDR kept that truth in
+the model/UI while withholding the transient TCI re-key. If no accepted CI-V
+PTT-off readback arrives within 500 ms, `unkeySettleTimeoutCount` advances,
+ownership is retained, and `trx:true` is published again. The optimistic local
+unkey edge never counts as radio confirmation.
+
+`lastDisconnect` survives after `clientCount` reaches zero. It retains the
+WebSocket close code/reason, socket error, session age, last text-message ages,
+and command names only (arguments and binary payloads are not retained). The
+nested PTT snapshot is taken before fail-closed disconnect cleanup, preserving
+whether the departing client owned a pending or confirmed transmit session.
 
 ### Multiple simulated clients
 
@@ -3148,7 +3189,7 @@ Icom CI-V and RS-BA1 session diagnostics. The read-only actions work in an
 observe-only bridge; raw injection remains TX-gated because arbitrary CI-V can
 key or retune the radio.
 
-**`civ session`** reports the media lease independently of UDP link liveness:
+**`civ session`** reports the media lease and each independent UDP stream:
 
 ```json
 → {"cmd":"civ","action":"session"}
@@ -3161,13 +3202,23 @@ key or retune the radio.
    "acceptedRenewals":14,"reissuedTokens":1,"rejectedRenewals":0,
    "ignoredAuthReplies":0,"ignoredControlPackets":1,
    "initialMaintenanceMs":30000,"initialMaintenancePending":false,
-   "renewalCadenceMs":60000,"ackGraceMs":3000,"deadSessionMs":80000}}
+   "renewalCadenceMs":60000,"ackGraceMs":3000,"deadSessionMs":80000,
+   "transport":{
+     "control":{"rxPackets":921,"txPackets":460,"rttMs":21,
+                "lastRxAgeMs":14,"lastPayloadAgeMs":8123,"socketErrors":0},
+     "serial":{"rxPackets":4821,"txPackets":3370,"rttMs":24,
+               "lastRxAgeMs":11,"lastPayloadAgeMs":11,"socketErrors":0},
+     "audio":{"rxPackets":186402,"txPackets":92160,"rttMs":26,
+              "lastRxAgeMs":3,"lastPayloadAgeMs":3,"socketErrors":0}}}}
 ```
 
-Use this first when the panadapter, CI-V controls, and audio stop together while
-the outer UDP packet counters still move. A healthy result has a recent accepted
-token, response `0x00000000`, and no growing pending/rejected count. The health
-verb shows the same essentials under **RS-BA1 session**.
+Use this first when the panadapter, CI-V controls, and audio stop together. A
+healthy result has a recent accepted token, response `0x00000000`, no growing
+pending/rejected count, recent activity on all three streams, and no growing
+socket-error count. A live control stream beside a stale serial
+`lastPayloadAgeMs` isolates the CI-V data pipe from authentication and broad
+network loss. The health verb shows the lease essentials under **RS-BA1
+session**.
 
 The token-request ID is freshly randomized for each login. On an immediate
 reconnect the radio can answer the initial token request with `0xffffffff` and
@@ -3189,7 +3240,11 @@ producer in isolation:
    "idle":false,"slotMs":25,"readTimeoutMs":350,
    "queueDepth":3,"readInFlight":true,"inFlightKey":"meter.s",
    "queued":812,"dispatched":799,"coalesced":96,
-   "replies":796,"staleReplies":1,"timeouts":2,
+   "replies":796,"staleReplies":1,"lateReplies":1,"unmatchedFrames":3,
+   "timeouts":2,"responseSamples":797,"lastResponseMs":42,
+   "averageResponseMs":38.7,"maxResponseMs":361,
+   "lastResponseAgeMs":18,"lastCompletedKey":"meter.s",
+   "lastTimeoutKey":"control.nr",
    "pendingPttIntent":false}}
 ```
 
@@ -3211,6 +3266,31 @@ operator moves controls, means replies are routinely arriving after their
 transaction expired: read it alongside `queueDepth` and treat the pair, not
 `staleReplies` alone, as the congestion signal. Poll this read-only verb until
 `idle:true` when a test needs deterministic write/readback convergence.
+
+**`civ incident`** returns the last structured Icom incident captured during
+the current session, or a live snapshot if no incident has occurred. The same
+snapshot is written automatically as one `aether.icom.incident` warning when:
+
+- a key-on transaction times out, or the radio still reports unkeyed after its
+  confirmation window;
+- a CI-V timeout occurs with at least eight transactions queued;
+- no CI-V frame arrives for five seconds while the UDP transport remains up;
+- an established RS-BA1 session closes unexpectedly.
+
+The dossier joins the evidence needed to locate the failed layer: correlated
+lease renewal state, independent control/serial/audio packet activity and
+socket errors, scheduler latency aggregates, the last 32 payload-free
+transaction outcomes, and requested versus radio-published PTT. It deliberately
+contains no credentials, network endpoints, session IDs, raw CI-V payloads,
+frequencies, or operator text. This means ordinary support logs can retain it;
+turning on every-frame CI-V or RS-BA1 datagram logging is not required for the
+first reproduction.
+
+Each transaction row reports a semantic `key`, `priority`, `completion`,
+`queueWaitMs`, and `responseMs`. Completions distinguish normal, stale, late,
+late-stale, timed-out, emergency-displaced, and response-free commands. Use the
+per-stream ages to separate socket/transport silence from a live RS-BA1 outer
+session whose CI-V payload pipe alone stopped responding.
 
 **`civ trace [all]`** reads the bounded decoded CI-V frame trace. The default
 omits routine meter traffic; `all` includes it. **`civ send <hex>`** injects

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -2581,7 +2581,7 @@ needed).
           "lastConfirmedAgeMs":16243,"lastOutcome":"confirmation-timeout",
           "lastOutcomeAgeMs":20},
    "lastDisconnect":{"contractVersion":1,"ageMs":520,
-      "closeCode":1006,"closeReason":"","socketState":0,
+      "closeCode":1006,"socketState":0,
       "socketError":1,"socketErrorString":"The remote host closed the connection",
       "connectionAgeMs":2577940,"lastTextRxAgeMs":53,"lastTextTxAgeMs":28,
       "lastSocketErrorAgeMs":0,"lastRxCommand":"trx","lastTxCommand":"trx",

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -3446,9 +3446,9 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
             });
 
         add("civ", {},
-            "civ <send <hex>|trace [all]|session|scheduler> — CI-V inject, frame "
-            "trace, RS-BA1 lease health, or command-scheduler health (Icom; send "
-            "is TX-gated)",
+            "civ <send <hex>|trace [all]|session|scheduler|incident> — CI-V "
+            "inject, frame trace, lease/scheduler health, or last incident "
+            "(Icom; send is TX-gated)",
             parseActionRest,
             [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
                 return s.doCiv(a.action, a.value);
@@ -7965,8 +7965,10 @@ QJsonObject AutomationServer::doCiv(const QString& action, const QString& arg)
     const QString a = action.trimmed().toLower();
     if (a.isEmpty() || (a != QLatin1String("send") && a != QLatin1String("trace")
                         && a != QLatin1String("session")
+                        && a != QLatin1String("incident")
                         && a != QLatin1String("scheduler"))) {
-        return err(QStringLiteral("civ requires an action (send|trace|session|scheduler)"));
+        return err(QStringLiteral(
+            "civ requires an action (send|trace|session|scheduler|incident)"));
     }
     if (a == QLatin1String("send") && !m_txAllowed) {
         return err(QStringLiteral(
@@ -8000,6 +8002,7 @@ QJsonObject AutomationServer::doCiv(const QString& action, const QString& arg)
 
     const QString verb = a == QLatin1String("send") ? QStringLiteral("civ.send")
                        : a == QLatin1String("trace") ? QStringLiteral("civ.trace")
+                       : a == QLatin1String("incident") ? QStringLiteral("civ.incident")
                        : a == QLatin1String("scheduler")
                            ? QStringLiteral("civ.scheduler.status")
                                                      : QStringLiteral("civ.session");

--- a/src/core/IcomTciUnkeySettle.h
+++ b/src/core/IcomTciUnkeySettle.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <cstdint>
+
+namespace AetherSDR {
+
+// Tracks the proof behind TCI's bounded Icom unkey presentation barrier.
+// Local optimistic state never enters this object: only an accepted CI-V
+// PTT-off readback may confirm the active generation.
+class IcomTciUnkeySettle {
+public:
+    enum class Confirmation {
+        Ignored,
+        PendingExpiry,
+        Late,
+    };
+
+    enum class Expiry {
+        Stale,
+        Confirmed,
+        TimedOut,
+    };
+
+    std::uint64_t begin() noexcept
+    {
+        m_activeGeneration = ++m_generation;
+        m_awaitingGeneration = m_activeGeneration;
+        m_confirmedGeneration = 0;
+        return m_activeGeneration;
+    }
+
+    Confirmation confirmOff() noexcept
+    {
+        if (m_awaitingGeneration == 0) {
+            return Confirmation::Ignored;
+        }
+        if (m_activeGeneration == m_awaitingGeneration) {
+            m_confirmedGeneration = m_awaitingGeneration;
+            return Confirmation::PendingExpiry;
+        }
+        m_awaitingGeneration = 0;
+        return Confirmation::Late;
+    }
+
+    Expiry expire(std::uint64_t generation) noexcept
+    {
+        if (generation == 0 || generation != m_activeGeneration) {
+            return Expiry::Stale;
+        }
+        m_activeGeneration = 0;
+        if (m_confirmedGeneration == generation) {
+            m_awaitingGeneration = 0;
+            m_confirmedGeneration = 0;
+            return Expiry::Confirmed;
+        }
+        return Expiry::TimedOut;
+    }
+
+    void cancel() noexcept
+    {
+        ++m_generation;
+        m_activeGeneration = 0;
+        m_awaitingGeneration = 0;
+        m_confirmedGeneration = 0;
+    }
+
+    [[nodiscard]] bool isSettling() const noexcept
+    {
+        return m_activeGeneration != 0;
+    }
+
+    [[nodiscard]] bool isAwaitingConfirmation() const noexcept
+    {
+        return m_awaitingGeneration != 0;
+    }
+
+    [[nodiscard]] std::uint64_t activeGeneration() const noexcept
+    {
+        return m_activeGeneration;
+    }
+
+private:
+    std::uint64_t m_generation = 0;
+    std::uint64_t m_activeGeneration = 0;
+    std::uint64_t m_awaitingGeneration = 0;
+    std::uint64_t m_confirmedGeneration = 0;
+};
+
+} // namespace AetherSDR

--- a/src/core/IcomTciUnkeySettle.h
+++ b/src/core/IcomTciUnkeySettle.h
@@ -6,7 +6,7 @@ namespace AetherSDR {
 
 // Tracks the proof behind TCI's bounded Icom unkey presentation barrier.
 // Local optimistic state never enters this object: only an accepted CI-V
-// PTT-off readback may confirm the active generation.
+// PTT readback may confirm or revoke confirmation of the active generation.
 class IcomTciUnkeySettle {
 public:
     enum class Confirmation {
@@ -29,10 +29,17 @@ public:
         return m_activeGeneration;
     }
 
-    Confirmation confirmOff() noexcept
+    Confirmation confirm(bool transmitting) noexcept
     {
         if (m_awaitingGeneration == 0) {
             return Confirmation::Ignored;
+        }
+        if (transmitting) {
+            // The latest accepted radio state is authoritative. A keyed
+            // readback revokes any earlier off confirmation but keeps waiting
+            // for a later off readback, even after the settle timer expires.
+            m_confirmedGeneration = 0;
+            return Confirmation::PendingExpiry;
         }
         if (m_activeGeneration == m_awaitingGeneration) {
             m_confirmedGeneration = m_awaitingGeneration;

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -16,8 +16,10 @@
 
 #include <QWebSocketServer>
 #include <QWebSocket>
+#include <QAbstractSocket>
 #include <QHostAddress>
 #include <QJsonArray>
+#include <QJsonDocument>
 #include <QStringList>
 #include <QTimer>
 #include <QPointer>
@@ -84,6 +86,40 @@ constexpr qint64 kTxSummaryEveryBlocks = 48;
 // client. With it, the same drag settles to ~20 over 2.8 s.
 constexpr int kPowerRateLimitMs = 100;
 
+// The live IC-7300MK2 capture showed the radio-authoritative CI-V unkey edge
+// settling in 149 ms while an optimistic local edge arrived immediately. Keep
+// the TCI presentation monotonic across one CI-V timeout-sized interval, but
+// resume publishing conservative keyed state well inside the existing 1250 ms
+// PTT contract if an accepted CI-V PTT-off readback never arrives.
+constexpr int kIcomTciUnkeySettleMs = 500;
+
+QString tciCommandName(const QString& message)
+{
+    const QString trimmed = message.trimmed().toLower();
+    const int colon = trimmed.indexOf(QLatin1Char(':'));
+    const int semicolon = trimmed.indexOf(QLatin1Char(';'));
+    int end = trimmed.size();
+    if (colon >= 0) {
+        end = std::min(end, colon);
+    }
+    if (semicolon >= 0) {
+        end = std::min(end, semicolon);
+    }
+
+    QString command;
+    command.reserve(std::min(end, 48));
+    for (const QChar ch : trimmed.left(end)) {
+        if (!(ch.isLetterOrNumber() || ch == QLatin1Char('_'))) {
+            break;
+        }
+        command.append(ch);
+        if (command.size() == 48) {
+            break;
+        }
+    }
+    return command;
+}
+
 // parseStatusHandle / streamStatusBelongsToUs  → StreamStatus.h
 // trx↔slice mapping                            → TciTrxMap (m_trxMap, #4567)
 
@@ -99,6 +135,8 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
     : QObject(parent)
     , m_model(model)
 {
+    m_tciPttTelemetryClock.start();
+
     // Load per-channel RX gains from persistence (decoupled from DaxRxGain<n>, #1627).
     // Migrate DaxRxGain<n> → TciRxGain<n> on first read so existing users keep
     // their current balance when the applets split.
@@ -130,6 +168,8 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
         m_lastRadioTx = m_model->isRadioTransmitting();
         connect(m_model, &RadioModel::radioTransmittingChanged, this,
             &TciServer::onRadioTransmittingChanged);
+        connect(m_model, &RadioModel::radioTransmitConfirmed, this,
+            &TciServer::onRadioTransmitConfirmed);
         connect(&m_model->meterModel(), &MeterModel::txMetersChanged,
                 this, [this](float fwd, float swr, bool swrValid) {
             m_cachedFwdPower = fwd;
@@ -708,6 +748,7 @@ void TciServer::onNewConnection()
         ClientState cs;
         cs.socket = ws;
         cs.protocol = protocol;
+        cs.connectedAtMs = m_tciPttTelemetryClock.elapsed();
         // Resamplers are created lazily per-channel in onDaxAudioReady()
         // so each DAX channel has its own stateful r8brain instance (#1806).
         m_clients.append(cs);
@@ -718,6 +759,10 @@ void TciServer::onNewConnection()
                 this, &TciServer::onBinaryMessage);
         connect(ws, &QWebSocket::disconnected,
                 this, &TciServer::onClientDisconnected);
+        connect(ws, &QWebSocket::errorOccurred, this,
+                [this, ws](QAbstractSocket::SocketError error) {
+                    noteClientSocketError(ws, static_cast<int>(error));
+                });
 
         qCInfo(lcCat) << "TciServer: client connected from"
                       << ws->peerAddress().toString();
@@ -735,6 +780,8 @@ void TciServer::onClientDisconnected()
 
     for (int i = 0; i < m_clients.size(); ++i) {
         if (m_clients[i].socket == ws) {
+            m_lastDisconnect = disconnectSnapshot(m_clients[i], ws);
+            m_lastDisconnectAtMs = m_tciPttTelemetryClock.elapsed();
             if (m_pendingTrxRequest && m_pendingTrxRequest->client == ws) {
                 m_pendingTrxRequest.reset();
             }
@@ -786,6 +833,11 @@ void TciServer::onClientDisconnected()
     // log it so the cause of mid-session RX loss is visible.
     qCWarning(lcCat) << "TciServer: client disconnected (TCP drop),"
                      << m_clients.size() << "remaining";
+    if (!m_lastDisconnect.isEmpty()) {
+        qCWarning(lcCat).noquote()
+            << "TCI disconnect incident"
+            << QJsonDocument(m_lastDisconnect).toJson(QJsonDocument::Compact);
+    }
     emit clientCountChanged(m_clients.size());
     emit clientsChanged();
     if (m_clients.isEmpty()) {
@@ -830,8 +882,86 @@ QVector<TciClientInfo> TciServer::connectedClients() const
     return out;
 }
 
+TciServer::ClientState* TciServer::clientStateFor(QWebSocket* socket)
+{
+    for (ClientState& client : m_clients) {
+        if (client.socket == socket) {
+            return &client;
+        }
+    }
+    return nullptr;
+}
+
+void TciServer::noteClientTextTx(QWebSocket* socket, const QString& message)
+{
+    ClientState* client = clientStateFor(socket);
+    if (!client) {
+        return;
+    }
+    client->lastTextTxAtMs = m_tciPttTelemetryClock.elapsed();
+    client->lastTxCommand = tciCommandName(message);
+}
+
+void TciServer::noteClientSocketError(QWebSocket* socket, int error)
+{
+    ClientState* client = clientStateFor(socket);
+    if (!client) {
+        return;
+    }
+    client->lastSocketError = error;
+    client->lastSocketErrorAtMs = m_tciPttTelemetryClock.elapsed();
+    client->lastSocketErrorString = socket
+        ? socket->errorString().simplified().left(160) : QString();
+}
+
+QJsonObject TciServer::disconnectSnapshot(
+    const ClientState& client, const QWebSocket* socket) const
+{
+    const qint64 now = m_tciPttTelemetryClock.elapsed();
+    const auto age = [now](qint64 atMs) {
+        return atMs >= 0 ? std::max<qint64>(0, now - atMs) : -1;
+    };
+    const QString closeReason = socket
+        ? socket->closeReason().simplified().left(160) : QString();
+    const QString socketError = !client.lastSocketErrorString.isEmpty()
+        ? client.lastSocketErrorString
+        : (socket ? socket->errorString().simplified().left(160) : QString());
+
+    return QJsonObject{
+        {QStringLiteral("contractVersion"), 1},
+        {QStringLiteral("closeCode"), socket
+            ? static_cast<int>(socket->closeCode()) : -1},
+        {QStringLiteral("closeReason"), closeReason},
+        {QStringLiteral("socketState"), socket
+            ? static_cast<int>(socket->state()) : -1},
+        {QStringLiteral("socketError"), client.lastSocketError},
+        {QStringLiteral("socketErrorString"), socketError},
+        {QStringLiteral("connectionAgeMs"), age(client.connectedAtMs)},
+        {QStringLiteral("lastTextRxAgeMs"), age(client.lastTextRxAtMs)},
+        {QStringLiteral("lastTextTxAgeMs"), age(client.lastTextTxAtMs)},
+        {QStringLiteral("lastSocketErrorAgeMs"), age(client.lastSocketErrorAtMs)},
+        {QStringLiteral("lastRxCommand"), client.lastRxCommand},
+        {QStringLiteral("lastTxCommand"), client.lastTxCommand},
+        {QStringLiteral("ptt"), QJsonObject{
+            {QStringLiteral("owned"), client.socket == m_tciPttClient},
+            {QStringLiteral("requestedOn"), m_tciPttRequestedOn},
+            {QStringLiteral("confirmedOn"), m_tciPttConfirmedOn},
+            {QStringLiteral("unkeySettling"), m_icomUnkeySettle.isSettling()},
+            {QStringLiteral("generation"),
+                static_cast<qint64>(m_tciPttGeneration)},
+            {QStringLiteral("lastOutcome"), m_tciPttLastOutcome},
+        }},
+    };
+}
+
 QJsonObject TciServer::routingSnapshot() const
 {
+    const qint64 telemetryNow = m_tciPttTelemetryClock.isValid()
+        ? m_tciPttTelemetryClock.elapsed() : -1;
+    const auto age = [telemetryNow](qint64 atMs) {
+        return telemetryNow >= 0 && atMs >= 0
+            ? std::max<qint64>(0, telemetryNow - atMs) : -1;
+    };
     const auto ownerName = [this]() {
         switch (m_routingState.owner()) {
         case TciRoutingState::TxRouteOwner::External:
@@ -891,8 +1021,33 @@ QJsonObject TciServer::routingSnapshot() const
         {QStringLiteral("requestedOn"), m_tciPttRequestedOn},
         {QStringLiteral("confirmedOn"), m_tciPttConfirmedOn},
         {QStringLiteral("cancelPending"), m_tciPttCancelPending},
+        {QStringLiteral("unkeySettling"), m_icomUnkeySettle.isSettling()},
         {QStringLiteral("generation"), static_cast<qint64>(m_tciPttGeneration)},
+        {QStringLiteral("requestCount"), static_cast<qint64>(m_tciPttRequestCount)},
+        {QStringLiteral("onRequestCount"), static_cast<qint64>(m_tciPttOnRequestCount)},
+        {QStringLiteral("offRequestCount"), static_cast<qint64>(m_tciPttOffRequestCount)},
+        {QStringLiteral("acceptedOnCount"), static_cast<qint64>(m_tciPttAcceptedOnCount)},
+        {QStringLiteral("confirmedOnCount"), static_cast<qint64>(m_tciPttConfirmedOnCount)},
+        {QStringLiteral("confirmationTimeoutCount"),
+            static_cast<qint64>(m_tciPttConfirmationTimeoutCount)},
+        {QStringLiteral("unkeySettleCount"),
+            static_cast<qint64>(m_tciPttUnkeySettleCount)},
+        {QStringLiteral("suppressedRekeyCount"),
+            static_cast<qint64>(m_tciPttSuppressedRekeyCount)},
+        {QStringLiteral("unkeySettleTimeoutCount"),
+            static_cast<qint64>(m_tciPttUnkeySettleTimeoutCount)},
+        {QStringLiteral("lastRequestedOn"), m_tciPttLastRequestedOn},
+        {QStringLiteral("lastRequestAgeMs"), age(m_tciPttLastRequestAtMs)},
+        {QStringLiteral("lastAcceptedAgeMs"), age(m_tciPttLastAcceptedAtMs)},
+        {QStringLiteral("lastConfirmedAgeMs"), age(m_tciPttLastConfirmedAtMs)},
+        {QStringLiteral("lastOutcome"), m_tciPttLastOutcome},
+        {QStringLiteral("lastOutcomeAgeMs"), age(m_tciPttLastOutcomeAtMs)},
     };
+
+    QJsonObject lastDisconnect = m_lastDisconnect;
+    if (!lastDisconnect.isEmpty()) {
+        lastDisconnect.insert(QStringLiteral("ageMs"), age(m_lastDisconnectAtMs));
+    }
 
     return QJsonObject{
         {QStringLiteral("ok"), true},
@@ -915,6 +1070,7 @@ QJsonObject TciServer::routingSnapshot() const
         {QStringLiteral("pendingRoutes"), pendingRoutes},
         {QStringLiteral("lastRouteError"), m_lastRouteError},
         {QStringLiteral("ptt"), ptt},
+        {QStringLiteral("lastDisconnect"), lastDisconnect},
         {QStringLiteral("endpoints"), endpoints},
     };
 }
@@ -943,6 +1099,8 @@ void TciServer::onTextMessage(const QString& msg)
     const QStringList cmds = msg.split(';', Qt::SkipEmptyParts);
     for (const auto& cmd : cmds) {
         QString trimmed = cmd.trimmed().toLower();
+        client.lastTextRxAtMs = m_tciPttTelemetryClock.elapsed();
+        client.lastRxCommand = tciCommandName(trimmed);
 
         // Handle audio start/stop at server level (affects per-client state)
         if (trimmed.startsWith("audio_start")) {
@@ -1157,6 +1315,7 @@ void TciServer::onTextMessage(const QString& msg)
             handleSplitRequest(ws, *request);
         }
         if (const auto request = client.protocol->takeTrxRequest()) {
+            notePttRequest(*request);
             handleTrxRequest(ws, *request);
         }
 
@@ -1164,8 +1323,10 @@ void TciServer::onTextMessage(const QString& msg)
         QString notification = client.protocol->pendingNotification();
         if (!notification.isEmpty()) {
             for (auto& cs : m_clients) {
-                if (cs.socket != ws)
+                if (cs.socket != ws) {
+                    noteClientTextTx(cs.socket, notification);
                     cs.socket->sendTextMessage(notification);
+                }
             }
         }
 
@@ -1925,7 +2086,16 @@ void TciServer::handleTrxRequest(QWebSocket* client, const TciProtocol::TrxReque
     if (!client || !m_model) {
         return;
     }
-    if (request.transmitting && (m_routeTransitionInFlight || m_tciPttCancelPending)) {
+    if (request.transmitting && m_icomUnkeySettle.isAwaitingConfirmation()
+        && !m_icomUnkeySettle.isSettling()) {
+        replyText(client, QStringLiteral("trx:%1,%2;")
+                              .arg(request.trx)
+                              .arg(m_tciPttClient == client ? "true" : "false"));
+        return;
+    }
+    if (request.transmitting
+        && (m_routeTransitionInFlight || m_tciPttCancelPending
+            || m_icomUnkeySettle.isSettling())) {
         m_pendingTrxRequest = PendingTrxRequest { client, request };
         return;
     }
@@ -1955,9 +2125,26 @@ void TciServer::handleTrxRequest(QWebSocket* client, const TciProtocol::TrxReque
             abortTciPtt();
             return;
         }
+        const bool boundedIcomSettle = m_tciPttConfirmedOn
+            && m_model->family() == QLatin1String("icom");
+        if (boundedIcomSettle) {
+            beginIcomUnkeySettle();
+        }
         ++m_tciPttGeneration;
         m_tciPttRequestedOn = false;
         requestTciPttOff();
+        if (m_icomUnkeySettle.isSettling()) {
+            // RadioModel and IcomCivBackend publish an optimistic local false
+            // synchronously. If that edge did not arrive, acknowledge the
+            // release here; either way the settle barrier retains ownership
+            // until delayed CI-V readback has had one bounded chance to land.
+            if (!m_tciPttUnkeyReported) {
+                broadcastActualTxState(false);
+                m_tciPttUnkeyReported = true;
+            }
+            stopTxChrono();
+            return;
+        }
         if (!m_model->isRadioTransmitting()) {
             broadcastActualTxState(false);
             stopTxChrono();
@@ -2118,6 +2305,9 @@ void TciServer::handleTrxRequest(QWebSocket* client, const TciProtocol::TrxReque
         self->m_tciPttWantsAudio = wantsAudio;
         self->m_tciPttRequestedOn = true;
         self->m_tciPttConfirmedOn = false;
+        ++self->m_tciPttAcceptedOnCount;
+        self->m_tciPttLastAcceptedAtMs = self->m_tciPttTelemetryClock.elapsed();
+        self->notePttOutcome(QStringLiteral("key-on-pending"));
         const quint64 generation = ++self->m_tciPttGeneration;
 
         if (wantsAudio) {
@@ -2136,6 +2326,12 @@ void TciServer::handleTrxRequest(QWebSocket* client, const TciProtocol::TrxReque
                 || self->m_tciPttConfirmedOn) {
                 return;
             }
+            ++self->m_tciPttConfirmationTimeoutCount;
+            self->notePttOutcome(QStringLiteral("confirmation-timeout"));
+            qCWarning(lcCat)
+                << "TCI PTT confirmation timeout: radio never reported keyed"
+                << "trx" << request.trx
+                << "generation" << generation;
             self->abortTciPtt();
             if (socket) {
                 self->replyText(socket, QStringLiteral("trx:%1,false;").arg(request.trx));
@@ -2143,6 +2339,70 @@ void TciServer::handleTrxRequest(QWebSocket* client, const TciProtocol::TrxReque
         });
         self->finishRouteTransition(transitionGeneration);
     });
+}
+
+void TciServer::notePttRequest(const TciProtocol::TrxRequest& request)
+{
+    ++m_tciPttRequestCount;
+    if (request.transmitting) {
+        ++m_tciPttOnRequestCount;
+    } else {
+        ++m_tciPttOffRequestCount;
+    }
+    m_tciPttLastRequestedOn = request.transmitting;
+    m_tciPttLastRequestAtMs = m_tciPttTelemetryClock.elapsed();
+}
+
+void TciServer::notePttOutcome(const QString& outcome)
+{
+    m_tciPttLastOutcome = outcome;
+    m_tciPttLastOutcomeAtMs = m_tciPttTelemetryClock.elapsed();
+}
+
+void TciServer::beginIcomUnkeySettle()
+{
+    if (!m_model || m_model->family() != QLatin1String("icom")) {
+        return;
+    }
+
+    m_tciPttUnkeyReported = false;
+    ++m_tciPttUnkeySettleCount;
+    const quint64 generation = m_icomUnkeySettle.begin();
+    notePttOutcome(QStringLiteral("icom-unkey-settling"));
+
+    QPointer<TciServer> self(this);
+    QTimer::singleShot(kIcomTciUnkeySettleMs, this, [self, generation]() {
+        if (self) {
+            self->finishIcomUnkeySettle(generation);
+        }
+    });
+}
+
+void TciServer::finishIcomUnkeySettle(quint64 generation)
+{
+    const IcomTciUnkeySettle::Expiry expiry =
+        m_icomUnkeySettle.expire(generation);
+    if (expiry == IcomTciUnkeySettle::Expiry::Stale) {
+        return;
+    }
+
+    m_tciPttUnkeyReported = false;
+    if (expiry == IcomTciUnkeySettle::Expiry::TimedOut) {
+        ++m_tciPttUnkeySettleTimeoutCount;
+        notePttOutcome(QStringLiteral("icom-unkey-not-confirmed"));
+        qCWarning(lcCat)
+            << "TCI Icom unkey settle expired without authoritative CI-V confirmation"
+            << "generation" << generation;
+        broadcastActualTxState(true);
+        return;
+    }
+
+    notePttOutcome(QStringLiteral("radio-confirmed-unkeyed"));
+    ++m_tciPttGeneration;
+    m_tciPttClient.clear();
+    m_tciPttConfirmedOn = false;
+    m_tciPttWantsAudio = false;
+    drainDeferredRoutingAndPtt();
 }
 
 // ── Binary message handler (TX audio from TCI client) ───────────────────
@@ -2940,7 +3200,9 @@ void TciServer::sendInitBurst(QWebSocket* client)
         // WSJT-X reconciles against on connect; a wrong/late one explains the
         // "TCI failed set rxfreq" some users hit right at WSJT-X startup.
         qCDebug(lcCat).noquote() << "TCI tx→init:" << (cmd + QLatin1Char(';'));
-        client->sendTextMessage(cmd + ';');
+        const QString message = cmd + QLatin1Char(';');
+        noteClientTextTx(client, message);
+        client->sendTextMessage(message);
     }
     qCDebug(lcCat) << "TCI: sent init burst," << commands.size() << "commands";
 }
@@ -2952,6 +3214,7 @@ void TciServer::replyText(QWebSocket* ws, const QString& msg)
     // at the top of onTextMessage via their early `continue`; log them here so
     // every command's response is visible when chasing CAT timeouts (#tci-diag).
     qCDebug(lcCat).noquote() << "TCI tx→client:" << msg.trimmed();
+    noteClientTextTx(ws, msg);
     ws->sendTextMessage(msg);
 }
 
@@ -2961,8 +3224,10 @@ void TciServer::broadcast(const QString& msg)
     // The vfo: echo here is exactly what WSJT-X's do_frequency() waits ≤2s on
     // before it throws "TCI failed set rxfreq" and drops the socket.
     qCDebug(lcCat).noquote() << "TCI tx→all:" << msg.trimmed();
-    for (auto& cs : m_clients)
+    for (auto& cs : m_clients) {
+        noteClientTextTx(cs.socket, msg);
         cs.socket->sendTextMessage(msg);
+    }
     emit tciMessage(QStringLiteral("tx"), msg);
 }
 
@@ -3067,6 +3332,8 @@ void TciServer::abortTciPtt()
     const quint64 generation = m_tciPttGeneration;
     m_tciPttRequestedOn = false;
     m_tciPttCancelPending = m_tciPttCancelPending || pendingKeyUp;
+    m_tciPttUnkeyReported = false;
+    m_icomUnkeySettle.cancel();
 
     // Teardown paths fail closed and bypass optional PTT outro delays.
     if (m_model && hadSession) {
@@ -3078,6 +3345,9 @@ void TciServer::abortTciPtt()
     m_tciPttConfirmedOn = false;
     m_tciPttWantsAudio = false;
     m_tciPttClient.clear();
+    if (hadSession && m_tciPttLastOutcome == QLatin1String("key-on-pending")) {
+        notePttOutcome(QStringLiteral("aborted"));
+    }
 
     if (pendingKeyUp) {
         QPointer<TciServer> self(this);
@@ -3220,6 +3490,19 @@ void TciServer::onRadioTransmittingChanged(bool transmitting)
     m_lastRadioTx = transmitting;
 
     if (transmitting) {
+        if (m_icomUnkeySettle.isSettling()) {
+            // The model/UI has already adopted this radio-authoritative keyed
+            // edge. Suppress only its TCI presentation during the bounded Icom
+            // settle window, preventing one accepted unkey from looking like a
+            // new key request to WSJT-X. If it persists, the timer republishes
+            // true and records the failed unkey.
+            ++m_tciPttSuppressedRekeyCount;
+            notePttOutcome(QStringLiteral("icom-unkey-transient-keyed"));
+            qCWarning(lcCat)
+                << "TCI Icom unkey settle: withheld transient keyed readback"
+                << "generation" << m_icomUnkeySettle.activeGeneration();
+            return;
+        }
         if (m_tciPttCancelPending) {
             // A cancelled key-up won the command race. Do not publish a
             // transient trx:true that clients could interpret as a new owner.
@@ -3232,6 +3515,9 @@ void TciServer::onRadioTransmittingChanged(bool transmitting)
         if (m_tciPttClient && m_tciPttRequestedOn) {
             m_tciPttConfirmedOn = true;
             m_tciPttRequestedOn = false;
+            ++m_tciPttConfirmedOnCount;
+            m_tciPttLastConfirmedAtMs = m_tciPttTelemetryClock.elapsed();
+            notePttOutcome(QStringLiteral("radio-confirmed-keyed"));
             ++m_tciPttGeneration;
             broadcastActualTxState(true);
             if (m_tciPttWantsAudio) {
@@ -3251,6 +3537,20 @@ void TciServer::onRadioTransmittingChanged(bool transmitting)
     if (m_tciPttRequestedOn && !m_tciPttConfirmedOn) {
         return;
     }
+    if (m_icomUnkeySettle.isSettling()) {
+        if (!m_tciPttUnkeyReported) {
+            broadcastActualTxState(false);
+            m_tciPttUnkeyReported = true;
+        }
+        stopTxChrono();
+        return;
+    }
+    if (m_icomUnkeySettle.isAwaitingConfirmation()) {
+        // The bounded window timed out and conservatively republished keyed.
+        // An accepted CI-V readback is delivered separately immediately after
+        // this state edge and is the only event allowed to release ownership.
+        return;
+    }
     const bool cancelledLateKeyUp = m_tciPttCancelPending;
     if (cancelledLateKeyUp) {
         m_tciPttCancelPending = false;
@@ -3260,12 +3560,44 @@ void TciServer::onRadioTransmittingChanged(bool transmitting)
         broadcastActualTxState(false);
     }
     if (m_tciPttClient) {
+        notePttOutcome(QStringLiteral("radio-confirmed-unkeyed"));
         ++m_tciPttGeneration;
         m_tciPttClient.clear();
         m_tciPttConfirmedOn = false;
         m_tciPttWantsAudio = false;
         stopTxChrono();
     }
+    drainDeferredRoutingAndPtt();
+}
+
+void TciServer::onRadioTransmitConfirmed(bool transmitting)
+{
+    if (transmitting) {
+        return;
+    }
+
+    const IcomTciUnkeySettle::Confirmation confirmation =
+        m_icomUnkeySettle.confirmOff();
+    if (confirmation == IcomTciUnkeySettle::Confirmation::Ignored) {
+        return;
+    }
+    if (confirmation == IcomTciUnkeySettle::Confirmation::PendingExpiry) {
+        // Preserve the field-tested 500 ms presentation barrier. The timer now
+        // has authoritative proof to consume instead of inferring success from
+        // the optimistic local false edge.
+        return;
+    }
+
+    // A readback may arrive after the bounded presentation window. The timeout
+    // deliberately retained ownership and republished keyed; retire that
+    // conservative state only when the radio eventually answers PTT off.
+    notePttOutcome(QStringLiteral("radio-confirmed-unkeyed-late"));
+    broadcastActualTxState(false);
+    ++m_tciPttGeneration;
+    m_tciPttClient.clear();
+    m_tciPttConfirmedOn = false;
+    m_tciPttWantsAudio = false;
+    stopTxChrono();
     drainDeferredRoutingAndPtt();
 }
 

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -902,6 +902,15 @@ void TciServer::noteClientTextTx(QWebSocket* socket, const QString& message)
     client->lastTxCommand = tciCommandName(message);
 }
 
+void TciServer::sendClientText(QWebSocket* socket, const QString& message)
+{
+    if (!socket) {
+        return;
+    }
+    noteClientTextTx(socket, message);
+    socket->sendTextMessage(message);
+}
+
 void TciServer::noteClientSocketError(QWebSocket* socket, int error)
 {
     ClientState* client = clientStateFor(socket);
@@ -921,21 +930,18 @@ QJsonObject TciServer::disconnectSnapshot(
     const auto age = [now](qint64 atMs) {
         return atMs >= 0 ? std::max<qint64>(0, now - atMs) : -1;
     };
-    const QString closeReason = socket
-        ? socket->closeReason().simplified().left(160) : QString();
-    const QString socketError = !client.lastSocketErrorString.isEmpty()
-        ? client.lastSocketErrorString
-        : (socket ? socket->errorString().simplified().left(160) : QString());
+    const bool socketErrorObserved = client.lastSocketErrorAtMs >= 0;
 
     return QJsonObject{
         {QStringLiteral("contractVersion"), 1},
         {QStringLiteral("closeCode"), socket
             ? static_cast<int>(socket->closeCode()) : -1},
-        {QStringLiteral("closeReason"), closeReason},
         {QStringLiteral("socketState"), socket
             ? static_cast<int>(socket->state()) : -1},
-        {QStringLiteral("socketError"), client.lastSocketError},
-        {QStringLiteral("socketErrorString"), socketError},
+        {QStringLiteral("socketError"), socketErrorObserved
+            ? client.lastSocketError : -1},
+        {QStringLiteral("socketErrorString"), socketErrorObserved
+            ? client.lastSocketErrorString : QString()},
         {QStringLiteral("connectionAgeMs"), age(client.connectedAtMs)},
         {QStringLiteral("lastTextRxAgeMs"), age(client.lastTextRxAtMs)},
         {QStringLiteral("lastTextTxAgeMs"), age(client.lastTextTxAtMs)},
@@ -1324,8 +1330,7 @@ void TciServer::onTextMessage(const QString& msg)
         if (!notification.isEmpty()) {
             for (auto& cs : m_clients) {
                 if (cs.socket != ws) {
-                    noteClientTextTx(cs.socket, notification);
-                    cs.socket->sendTextMessage(notification);
+                    sendClientText(cs.socket, notification);
                 }
             }
         }
@@ -3201,8 +3206,7 @@ void TciServer::sendInitBurst(QWebSocket* client)
         // "TCI failed set rxfreq" some users hit right at WSJT-X startup.
         qCDebug(lcCat).noquote() << "TCI tx→init:" << (cmd + QLatin1Char(';'));
         const QString message = cmd + QLatin1Char(';');
-        noteClientTextTx(client, message);
-        client->sendTextMessage(message);
+        sendClientText(client, message);
     }
     qCDebug(lcCat) << "TCI: sent init burst," << commands.size() << "commands";
 }
@@ -3214,8 +3218,7 @@ void TciServer::replyText(QWebSocket* ws, const QString& msg)
     // at the top of onTextMessage via their early `continue`; log them here so
     // every command's response is visible when chasing CAT timeouts (#tci-diag).
     qCDebug(lcCat).noquote() << "TCI tx→client:" << msg.trimmed();
-    noteClientTextTx(ws, msg);
-    ws->sendTextMessage(msg);
+    sendClientText(ws, msg);
 }
 
 void TciServer::broadcast(const QString& msg)
@@ -3225,8 +3228,7 @@ void TciServer::broadcast(const QString& msg)
     // before it throws "TCI failed set rxfreq" and drops the socket.
     qCDebug(lcCat).noquote() << "TCI tx→all:" << msg.trimmed();
     for (auto& cs : m_clients) {
-        noteClientTextTx(cs.socket, msg);
-        cs.socket->sendTextMessage(msg);
+        sendClientText(cs.socket, msg);
     }
     emit tciMessage(QStringLiteral("tx"), msg);
 }
@@ -3572,19 +3574,15 @@ void TciServer::onRadioTransmittingChanged(bool transmitting)
 
 void TciServer::onRadioTransmitConfirmed(bool transmitting)
 {
-    if (transmitting) {
-        return;
-    }
-
     const IcomTciUnkeySettle::Confirmation confirmation =
-        m_icomUnkeySettle.confirmOff();
+        m_icomUnkeySettle.confirm(transmitting);
     if (confirmation == IcomTciUnkeySettle::Confirmation::Ignored) {
         return;
     }
     if (confirmation == IcomTciUnkeySettle::Confirmation::PendingExpiry) {
-        // Preserve the field-tested 500 ms presentation barrier. The timer now
-        // has authoritative proof to consume instead of inferring success from
-        // the optimistic local false edge.
+        // Preserve the field-tested 500 ms presentation barrier. An accepted
+        // off readback confirms the generation, while a later accepted keyed
+        // readback revokes that proof so expiry fails safe and republishes true.
         return;
     }
 
@@ -3657,10 +3655,12 @@ void TciServer::broadcastStatus()
                 const int meterIndex = s->sliceId();
                 if (trx >= 0 && meterIndex >= 0 && meterIndex < 8) {
                     float dbm = m_cachedSLevel[meterIndex];
-                    if (dbm > -200.0f)
-                        cs.socket->sendTextMessage(
+                    if (dbm > -200.0f) {
+                        const QString message =
                             QStringLiteral("rx_channel_sensors:%1,0,%2;")
-                                .arg(trx).arg(dbm, 0, 'f', 1));
+                                .arg(trx).arg(dbm, 0, 'f', 1);
+                        sendClientText(cs.socket, message);
+                    }
                 }
             }
         }
@@ -3668,13 +3668,14 @@ void TciServer::broadcastStatus()
             // tx_sensors:trx,mic_dbm,fwd_watts,peak_watts,swr,alc_dbfs
             // alc_dbfs (trailing field, AetherSDR extension) is the SW-ALC
             // peak; index-based parsers safely ignore the extra field.
-            cs.socket->sendTextMessage(
+            const QString message =
                 QStringLiteral("tx_sensors:0,%1,%2,%3,%4,%5;")
                     .arg(m_cachedMicLevel, 0, 'f', 1)
                     .arg(m_cachedFwdPower, 0, 'f', 1)
                     .arg(m_cachedFwdPower, 0, 'f', 1)  // peak ≈ avg for now
                     .arg(m_cachedSwr, 0, 'f', 1)
-                    .arg(m_cachedAlc, 0, 'f', 1));
+                    .arg(m_cachedAlc, 0, 'f', 1);
+            sendClientText(cs.socket, message);
         }
     }
 }

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -231,6 +231,7 @@ private:
     void logTxAudioSummary(const char* reason);
     ClientState* clientStateFor(QWebSocket* socket);
     void noteClientTextTx(QWebSocket* socket, const QString& message);
+    void sendClientText(QWebSocket* socket, const QString& message);
     void noteClientSocketError(QWebSocket* socket, int error);
     QJsonObject disconnectSnapshot(const ClientState& client,
                                    const QWebSocket* socket) const;
@@ -275,7 +276,7 @@ private:
         qint64       lastSocketErrorAtMs{-1};
         QString      lastRxCommand;
         QString      lastTxCommand;
-        int          lastSocketError{0};
+        int          lastSocketError{-1};
         QString      lastSocketErrorString;
     };
 

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -4,6 +4,7 @@
 #include "TciProtocol.h"
 #include "TciRoutingState.h"
 #include "TciTrxMap.h"
+#include "IcomTciUnkeySettle.h"
 
 #include <QObject>
 #include <QPointer>
@@ -160,6 +161,8 @@ private slots:
     void broadcastStatus();
 
 private:
+    struct ClientState;
+
     // Rate-limited drive:/tune_drive: relay (#4161). queue* is the signal
     // entry point; broadcast* does the de-duped send.
     void queuePowerBroadcast();
@@ -210,6 +213,10 @@ private:
     bool hostModulatingBackend() const;
     void prepareTxAudio();
     void startTxChrono(QWebSocket* client, int trx);
+    void notePttRequest(const TciProtocol::TrxRequest& request);
+    void notePttOutcome(const QString& outcome);
+    void beginIcomUnkeySettle();
+    void finishIcomUnkeySettle(quint64 generation);
     void stopTxChrono();
     void requestTciPttOff();
     void abortTciPtt();
@@ -217,10 +224,16 @@ private:
     void finishRouteTransition(quint64 generation);
     void drainDeferredRoutingAndPtt();
     void onRadioTransmittingChanged(bool transmitting);
+    void onRadioTransmitConfirmed(bool transmitting);
     void broadcastActualTxState(bool transmitting);
     void teardownTciRoute();
     void sendTxChronoFrame(QWebSocket* client);
     void logTxAudioSummary(const char* reason);
+    ClientState* clientStateFor(QWebSocket* socket);
+    void noteClientTextTx(QWebSocket* socket, const QString& message);
+    void noteClientSocketError(QWebSocket* socket, int error);
+    QJsonObject disconnectSnapshot(const ClientState& client,
+                                   const QWebSocket* socket) const;
 
     // Build a TCI binary audio frame (64-byte header + float32 samples)
     static QByteArray buildAudioFrame(int receiver, int type,
@@ -253,6 +266,17 @@ private:
         bool         iqEnabled{false};       // client sent IQ_START
         int          iqChannel{0};           // TCI TRX → DAX IQ channel (0-based)
         bool         spectrumEnabled{false}; // client sent spectrum_event:on;
+        // Payload-free lifecycle telemetry retained across disconnect. Command
+        // names are stored without their arguments, so diagnostics can identify
+        // the failing TCI layer without retaining frequencies or operator text.
+        qint64       connectedAtMs{-1};
+        qint64       lastTextRxAtMs{-1};
+        qint64       lastTextTxAtMs{-1};
+        qint64       lastSocketErrorAtMs{-1};
+        QString      lastRxCommand;
+        QString      lastTxCommand;
+        int          lastSocketError{0};
+        QString      lastSocketErrorString;
     };
 
     // Minimum frames to accumulate before flushing to r8brain.
@@ -338,6 +362,34 @@ private:
     bool m_tciPttConfirmedOn { false };
     bool m_tciPttCancelPending { false };
     quint64 m_tciPttGeneration { 0 };
+    // Icom publishes an optimistic local unkey edge before CI-V readback. Hold
+    // the TCI presentation in a short bounded settle window, but complete it
+    // only from the backend's accepted CI-V PTT-off confirmation. No reply
+    // retains ownership and republishes keyed at expiry.
+    bool m_tciPttUnkeyReported { false };
+    IcomTciUnkeySettle m_icomUnkeySettle;
+    quint64 m_tciPttUnkeySettleCount { 0 };
+    quint64 m_tciPttSuppressedRekeyCount { 0 };
+    quint64 m_tciPttUnkeySettleTimeoutCount { 0 };
+    // Payload-free TCI ingress/confirmation telemetry. These counters make
+    // `tci routes` answer whether a WSJT-X key request reached this process,
+    // survived routing/preflight, and was confirmed by radio-authoritative
+    // state without enabling the full TCI wire trace.
+    QElapsedTimer m_tciPttTelemetryClock;
+    quint64 m_tciPttRequestCount { 0 };
+    quint64 m_tciPttOnRequestCount { 0 };
+    quint64 m_tciPttOffRequestCount { 0 };
+    quint64 m_tciPttAcceptedOnCount { 0 };
+    quint64 m_tciPttConfirmedOnCount { 0 };
+    quint64 m_tciPttConfirmationTimeoutCount { 0 };
+    qint64 m_tciPttLastRequestAtMs { -1 };
+    qint64 m_tciPttLastAcceptedAtMs { -1 };
+    qint64 m_tciPttLastConfirmedAtMs { -1 };
+    qint64 m_tciPttLastOutcomeAtMs { -1 };
+    bool m_tciPttLastRequestedOn { false };
+    QString m_tciPttLastOutcome { QStringLiteral("none") };
+    QJsonObject m_lastDisconnect;
+    qint64 m_lastDisconnectAtMs { -1 };
     bool m_txAudioPrepared { false };
     int               m_txChronoTrx{0};
     std::unique_ptr<Resampler> m_txResampler; // 48kHz→24kHz TX downsampler

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -814,6 +814,11 @@ signals:
     // fields the wire reported (across the transmit / interlock / ATU / APD /
     // APD-sampler status planes) and RadioModel drives the TransmitModel.
     void transmitChanged(const TransmitDelta& delta);
+    // An explicit radio readback confirmed the keyed state. This is distinct
+    // from transmitChanged because optimistic state may already equal the
+    // answer and therefore produce no delta. Backends without a separate
+    // command/readback plane need not emit it.
+    void keyingStateConfirmed(bool keyed);
 
     // Normalized power-amplifier status delta (aetherd 2.4 — AmpModel decode
     // split, #4094). Typed + present-only; the backend translates the SmartSDR

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -2,6 +2,7 @@
 
 #include <QDateTime>
 #include <QHash>
+#include <QJsonDocument>
 #include <QLoggingCategory>
 #include <QTimer>
 #include <QVariant>
@@ -31,6 +32,7 @@ Q_LOGGING_CATEGORY(lcIcomPan, "aether.icom.pan")
 // wants to switch on after a hang is the stall warning, and nothing else.
 Q_LOGGING_CATEGORY(lcIcomLink, "aether.icom.link")
 Q_LOGGING_CATEGORY(lcIcomScheduler, "aether.icom.scheduler")
+Q_LOGGING_CATEGORY(lcIcomIncident, "aether.icom.incident")
 
 // Which CI-V address we ended up talking to, and why. Its own category because
 // a wrong address is SILENT — the radio simply never answers — so when the
@@ -75,6 +77,33 @@ constexpr int kLinkTickMs = 1000;
 // zone is needed at all: a click with a pixel of hand movement arrives as a
 // centre request, and without this every stray click moved the dial.
 constexpr double kPanDragDeadZoneFraction = 0.01;
+
+QString priorityName(IcomCivScheduler::Priority priority)
+{
+    switch (priority) {
+    case IcomCivScheduler::Priority::Emergency:   return QStringLiteral("emergency");
+    case IcomCivScheduler::Priority::Operator:    return QStringLiteral("operator");
+    case IcomCivScheduler::Priority::Maintenance: return QStringLiteral("maintenance");
+    case IcomCivScheduler::Priority::Control:     return QStringLiteral("control");
+    case IcomCivScheduler::Priority::Ptt:         return QStringLiteral("ptt");
+    case IcomCivScheduler::Priority::ActiveMeter: return QStringLiteral("active-meter");
+    }
+    return QStringLiteral("unknown");
+}
+
+QString completionName(IcomCivScheduler::Completion completion)
+{
+    switch (completion) {
+    case IcomCivScheduler::Completion::Reply:          return QStringLiteral("reply");
+    case IcomCivScheduler::Completion::StaleReply:     return QStringLiteral("stale-reply");
+    case IcomCivScheduler::Completion::LateReply:      return QStringLiteral("late-reply");
+    case IcomCivScheduler::Completion::LateStaleReply: return QStringLiteral("late-stale-reply");
+    case IcomCivScheduler::Completion::Timeout:        return QStringLiteral("timeout");
+    case IcomCivScheduler::Completion::Displaced:      return QStringLiteral("displaced");
+    case IcomCivScheduler::Completion::NoReply:        return QStringLiteral("no-reply");
+    }
+    return QStringLiteral("unknown");
+}
 
 QByteArray floatBytes(const std::vector<float>& v)
 {
@@ -1188,6 +1217,15 @@ void IcomCivBackend::onSessionConnected(const QString& deviceName)
 {
     m_deviceName = deviceName.trimmed();
     m_connected = true;
+    m_connectedAtMs = nowMs();
+    m_lastIncident.clear();
+    m_civScheduler.clearTransactionHistory();
+    m_pttIncidentReported = false;
+    m_civBacklogIncidentReported = false;
+    m_lastInboundCivAtMs = 0;
+    m_lastOutboundCiv.clear();
+    m_lastOutboundCivKey.clear();
+    m_lastOutboundCivAtMs = 0;
 
     // RESOLVE THE MODEL FROM THE NAME, NOW.
     //
@@ -1463,6 +1501,9 @@ void IcomCivBackend::onSessionDisconnected(const QString& reason)
     m_tuning = false;
     m_preTuneTxPowerPercent = -1;
     const bool was = m_connected;
+    if (was && !reason.isEmpty()) {
+        recordIncident(QStringLiteral("session-disconnected"), reason);
+    }
     m_connected = false;
     ++m_sessionGeneration;
     if (m_session) {
@@ -2513,12 +2554,29 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame,
                     qCWarning(lcIcomScheduler)
                         << "radio reports KEYED after an unkey request; "
                            "publishing radio truth";
+                } else if (!confirmsIntent && *m_pendingPttIntent) {
+                    qCWarning(lcIcomScheduler)
+                        << "radio did not confirm key-on before the PTT intent window expired";
+                    if (!m_pttIncidentReported) {
+                        recordIncident(
+                            QStringLiteral("ptt-not-confirmed"),
+                            QStringLiteral("radio reported unkeyed after key-on confirmation window"));
+                        m_pttIncidentReported = true;
+                    }
+                } else if (confirmsIntent) {
+                    m_pttIncidentReported = false;
                 }
                 m_pendingPttIntent.reset();
                 m_pendingPttUntilMs = 0;
             } else if (observation == IcomCivScheduler::Observation::Stale) {
                 return;
             }
+            // Accepted means this explicit PTT readback belongs to the current
+            // scheduler generation. Publish that proof even when the value is
+            // unchanged from our optimistic edge; TCI's unkey barrier must not
+            // mistake local presentation state for a radio acknowledgement.
+            const bool acceptedReadback =
+                observation == IcomCivScheduler::Observation::Accepted;
             // ON CHANGE ONLY. This is the answer to a poll that runs four times
             // a second, and it used to republish the transmit state on every
             // one of them — a 4 Hz stream of "the radio is transmitting" events
@@ -2528,8 +2586,12 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame,
             // Republishing unchanged state is never merely wasteful on a path
             // this hot: it is indistinguishable, to every consumer, from the
             // state having just changed.
-            if (keyed == m_keyed)
+            if (keyed == m_keyed) {
+                if (acceptedReadback) {
+                    emit keyingStateConfirmed(keyed);
+                }
                 return;
+            }
             const int restoreTunePower = !keyed ? stopTuneProducer() : -1;
             m_keyed = keyed;
             m_meters.setTransmitting(m_keyed);
@@ -2542,6 +2604,9 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame,
             TransmitDelta t;
             t.mox = m_keyed;
             emit transmitChanged(t);
+            if (acceptedReadback) {
+                emit keyingStateConfirmed(keyed);
+            }
             if (restoreTunePower >= 0) {
                 setTxPower(restoreTunePower);
             }
@@ -3002,6 +3067,7 @@ void IcomCivBackend::pumpCiv(qint64 nowMs)
             hex += QStringLiteral("%1 ").arg(dispatch->frame[i], 2, 16, QLatin1Char('0'));
         }
         m_lastOutboundCiv = hex.trimmed();
+        m_lastOutboundCivKey = QString::fromStdString(dispatch->key);
         m_lastOutboundCivAtMs = nowMs;
     }
     m_session->sendCiv(dispatch->frame);
@@ -3023,7 +3089,28 @@ QVariantMap IcomCivBackend::schedulerDiagnostics() const
     out.insert(QStringLiteral("coalesced"), static_cast<qulonglong>(stats.coalesced));
     out.insert(QStringLiteral("replies"), static_cast<qulonglong>(stats.replies));
     out.insert(QStringLiteral("staleReplies"), static_cast<qulonglong>(stats.staleReplies));
+    out.insert(QStringLiteral("lateReplies"), static_cast<qulonglong>(stats.lateReplies));
+    out.insert(QStringLiteral("unmatchedFrames"),
+               static_cast<qulonglong>(stats.unmatchedFrames));
     out.insert(QStringLiteral("timeouts"), static_cast<qulonglong>(stats.timeouts));
+    out.insert(QStringLiteral("responseSamples"),
+               static_cast<qulonglong>(stats.responseSamples));
+    out.insert(QStringLiteral("lastResponseMs"),
+               static_cast<qlonglong>(stats.lastResponseMs));
+    out.insert(QStringLiteral("maxResponseMs"),
+               static_cast<qlonglong>(stats.maxResponseMs));
+    out.insert(QStringLiteral("averageResponseMs"),
+               stats.responseSamples > 0
+                   ? static_cast<double>(stats.totalResponseMs)
+                         / static_cast<double>(stats.responseSamples)
+                   : -1.0);
+    out.insert(QStringLiteral("lastResponseAgeMs"),
+               stats.lastResponseAtMs > 0
+                   ? std::max<qint64>(0, nowMs() - stats.lastResponseAtMs) : -1);
+    out.insert(QStringLiteral("lastCompletedKey"),
+               QString::fromStdString(stats.lastCompletedKey));
+    out.insert(QStringLiteral("lastTimeoutKey"),
+               QString::fromStdString(stats.lastTimeoutKey));
     out.insert(QStringLiteral("cancelledRequests"),
                static_cast<qulonglong>(m_schedulerCancelledRequests));
     out.insert(QStringLiteral("failedRequests"),
@@ -3039,6 +3126,92 @@ QVariantMap IcomCivBackend::schedulerDiagnostics() const
                    std::max<qint64>(0, m_pendingPttUntilMs - nowMs()));
     }
     return out;
+}
+
+QVariantList IcomCivBackend::schedulerTransactionTrace(std::size_t limit) const
+{
+    QVariantList out;
+    const auto& events = m_civScheduler.recentTransactions();
+    const std::size_t begin = events.size() > limit ? events.size() - limit : 0;
+    const qint64 now = nowMs();
+    for (std::size_t i = begin; i < events.size(); ++i) {
+        const IcomCivScheduler::TransactionEvent& event = events[i];
+        QVariantMap row;
+        row.insert(QStringLiteral("key"), QString::fromStdString(event.key));
+        row.insert(QStringLiteral("priority"), priorityName(event.priority));
+        row.insert(QStringLiteral("generation"),
+                   QVariant::fromValue<qulonglong>(event.generation));
+        row.insert(QStringLiteral("completion"), completionName(event.completion));
+        row.insert(QStringLiteral("ageMs"),
+                   std::max<qint64>(0, now - event.completedAtMs));
+        row.insert(QStringLiteral("queueWaitMs"),
+                   static_cast<qlonglong>(event.queueWaitMs));
+        row.insert(QStringLiteral("responseMs"),
+                   static_cast<qlonglong>(event.responseMs));
+        out.push_back(row);
+    }
+    return out;
+}
+
+QVariantMap IcomCivBackend::incidentSnapshot(const QString& kind,
+                                             const QString& reason) const
+{
+    const qint64 now = nowMs();
+    QVariantMap out;
+    out.insert(QStringLiteral("schemaVersion"), 1);
+    out.insert(QStringLiteral("kind"), kind);
+    out.insert(QStringLiteral("reason"), reason);
+    out.insert(QStringLiteral("capturedAtUtc"),
+               QDateTime::currentDateTimeUtc().toString(Qt::ISODateWithMs));
+    out.insert(QStringLiteral("connected"), m_connected);
+    out.insert(QStringLiteral("sessionAgeMs"),
+               m_connectedAtMs > 0 ? std::max<qint64>(0, now - m_connectedAtMs) : -1);
+    out.insert(QStringLiteral("model"),
+               QString::fromUtf8(m_model->name.data(),
+                                 static_cast<int>(m_model->name.size())));
+    out.insert(QStringLiteral("civAddress"),
+               QStringLiteral("0x%1")
+                   .arg(m_session ? m_session->civAddress() : m_model->civAddress,
+                        2, 16, QLatin1Char('0')));
+
+    QVariantMap commandPlane;
+    commandPlane.insert(QStringLiteral("lastInboundAgeMs"),
+                        m_lastInboundCivAtMs > 0
+                            ? std::max<qint64>(0, now - m_lastInboundCivAtMs) : -1);
+    commandPlane.insert(QStringLiteral("lastOutboundAgeMs"),
+                        m_lastOutboundCivAtMs > 0
+                            ? std::max<qint64>(0, now - m_lastOutboundCivAtMs) : -1);
+    commandPlane.insert(QStringLiteral("lastOutboundKey"), m_lastOutboundCivKey);
+    commandPlane.insert(QStringLiteral("scheduler"), schedulerDiagnostics());
+    commandPlane.insert(QStringLiteral("transactions"), schedulerTransactionTrace());
+    out.insert(QStringLiteral("commandPlane"), commandPlane);
+
+    QVariantMap ptt;
+    ptt.insert(QStringLiteral("publishedKeyed"), m_keyed);
+    ptt.insert(QStringLiteral("pendingIntent"), m_pendingPttIntent.has_value());
+    if (m_pendingPttIntent) {
+        ptt.insert(QStringLiteral("intentKeyed"), *m_pendingPttIntent);
+        ptt.insert(QStringLiteral("confirmationRemainingMs"),
+                   std::max<qint64>(0, m_pendingPttUntilMs - now));
+    }
+    out.insert(QStringLiteral("ptt"), ptt);
+
+    if (m_session) {
+        out.insert(QStringLiteral("lease"), m_session->leaseDiagnostics());
+        out.insert(QStringLiteral("transport"), m_session->transportDiagnostics());
+    }
+    return out;
+}
+
+void IcomCivBackend::recordIncident(const QString& kind, const QString& reason)
+{
+    QVariantMap snapshot = incidentSnapshot(kind, reason);
+    snapshot.insert(QStringLiteral("sequence"),
+                    QVariant::fromValue<qulonglong>(++m_incidentSequence));
+    m_lastIncident = snapshot;
+    qCWarning(lcIcomIncident).noquote()
+        << "ICOM INCIDENT"
+        << QJsonDocument::fromVariant(m_lastIncident).toJson(QJsonDocument::Compact);
 }
 
 void IcomCivBackend::serviceSchedulerWaiters(
@@ -4028,6 +4201,7 @@ void IcomCivBackend::setKeying(bool key)
 
     m_pendingPttIntent = key;
     m_pendingPttUntilMs = nowMs() + 1000;
+    m_pttIncidentReported = false;
     sendUserCommand(cmdSetPtt(m_session ? m_session->civAddress() : 0xA4, key));
     // PUBLISH IT. Setting m_keyed silently here and leaving the announcement to
     // the poll does not work now that the poll only speaks on change: our own
@@ -5110,6 +5284,15 @@ void IcomCivBackend::invokeExtension(const QString& ns, const QString& verb, qui
         emit extensionResult(requestId, schedulerDiagnostics());
         return;
     }
+    if (verb == QLatin1String("civ.incident")) {
+        emit extensionResult(
+            requestId,
+            m_lastIncident.isEmpty()
+                ? incidentSnapshot(QStringLiteral("live"),
+                                   QStringLiteral("no incident captured this session"))
+                : m_lastIncident);
+        return;
+    }
     if (verb == QLatin1String("civ.scheduler.wait-idle")) {
         int timeoutMs = arg.toMap().value(QStringLiteral("timeoutMs"), 3000).toInt();
         if (!arg.canConvert<QVariantMap>()) {
@@ -5133,6 +5316,8 @@ void IcomCivBackend::invokeExtension(const QString& ns, const QString& verb, qui
         QVariantMap result;
         if (m_session) {
             result = m_session->leaseDiagnostics();
+            result.insert(QStringLiteral("transport"),
+                          m_session->transportDiagnostics());
         } else {
             result.insert(QStringLiteral("connected"), false);
             result.insert(QStringLiteral("lastRenewalResult"),
@@ -5320,11 +5505,30 @@ void IcomCivBackend::onLinkTick()
     emit linkStatsUpdated(out);
 
     const IcomCivScheduler::Stats schedulerStats = m_civScheduler.stats();
+    if (schedulerStats.queueDepth < 4) {
+        m_civBacklogIncidentReported = false;
+    }
     if (schedulerStats.timeouts > m_schedulerTimeoutsReported) {
         qCWarning(lcIcomScheduler)
             << "CI-V read timeout; scheduler recovered"
             << "timeouts" << schedulerStats.timeouts
-            << "queueDepth" << schedulerStats.queueDepth;
+            << "queueDepth" << schedulerStats.queueDepth
+            << "lastTimeoutKey" << QString::fromStdString(schedulerStats.lastTimeoutKey)
+            << "lastResponseMs" << schedulerStats.lastResponseMs;
+        if (schedulerStats.lastTimeoutKey == "ptt" && m_pendingPttIntent
+            && *m_pendingPttIntent && !m_pttIncidentReported) {
+            recordIncident(
+                QStringLiteral("ptt-confirmation-timeout"),
+                QStringLiteral("CI-V PTT transaction timed out while key-on confirmation was pending"));
+            m_pttIncidentReported = true;
+        }
+        if (schedulerStats.queueDepth >= 8 && !m_civBacklogIncidentReported) {
+            recordIncident(
+                QStringLiteral("civ-timeout-backlog"),
+                QStringLiteral("CI-V read timed out with %1 queued transactions")
+                    .arg(schedulerStats.queueDepth));
+            m_civBacklogIncidentReported = true;
+        }
         m_schedulerTimeoutsReported = schedulerStats.timeouts;
     }
 
@@ -5491,6 +5695,9 @@ void IcomCivBackend::onLinkTick()
         << "The transport is still up (rxPackets" << out.rxPackets
         << "), so this is the command plane alone."
         << "Read `civ trace all` for the frames either side of it.";
+    recordIncident(QStringLiteral("civ-stall"),
+                   QStringLiteral("no CI-V frame for %1 ms while transport remained active")
+                       .arg(silentMs));
 
     // The 0x04 data-pipe restart, scheduler termination, and retry timer are a
     // single model capability.  Profiles without it retain main's warn-only

--- a/src/core/backends/icom/IcomCivBackend.h
+++ b/src/core/backends/icom/IcomCivBackend.h
@@ -269,6 +269,11 @@ private:
     [[nodiscard]] std::optional<std::vector<std::uint8_t>>
         confirmationFor(std::span<const std::uint8_t> frame) const;
     [[nodiscard]] QVariantMap schedulerDiagnostics() const;
+    [[nodiscard]] QVariantList schedulerTransactionTrace(
+        std::size_t limit = 32) const;
+    [[nodiscard]] QVariantMap incidentSnapshot(const QString& kind,
+                                               const QString& reason) const;
+    void recordIncident(const QString& kind, const QString& reason);
     enum class SchedulerWaiterOutcome : std::uint8_t {
         Completed,
         TimedOut,
@@ -386,6 +391,7 @@ private:
     bool m_xfcReleaseRequired = false;
     std::optional<bool> m_pendingPttIntent;
     qint64 m_pendingPttUntilMs = 0;
+    bool m_pttIncidentReported = false;
     bool m_overflow = false;
     double m_vdVolts = 0.0;
     double m_idAmps = 0.0;
@@ -617,11 +623,20 @@ private:
     quint64 m_schedulerTimeoutsReported = 0;
     quint64 m_schedulerCancelledRequests = 0;
     quint64 m_schedulerFailedRequests = 0;
+    bool m_civBacklogIncidentReported = false;
+
+    // Last structured incident survives a dropped session so support can read
+    // it after the sockets are gone. It is replaced only by a newer incident
+    // or a successfully connected new session.
+    QVariantMap m_lastIncident;
+    quint64 m_incidentSequence = 0;
+    qint64 m_connectedAtMs = 0;
 
     // CI-V stall detection. The transport can be healthy while the command
     // plane is dead — see onLinkTick — so these track the command plane alone.
     qint64  m_lastInboundCivAtMs = 0;
     QString m_lastOutboundCiv;      // the last frame we sent, as hex
+    QString m_lastOutboundCivKey;   // payload-free semantic transaction id
     qint64  m_lastOutboundCivAtMs = 0;
     bool    m_civStallReported = false;
     qint64  m_civRecoveryStartedAtMs = 0;

--- a/src/core/backends/icom/IcomCivScheduler.cpp
+++ b/src/core/backends/icom/IcomCivScheduler.cpp
@@ -5,6 +5,41 @@
 
 namespace AetherSDR::icom {
 
+void IcomCivScheduler::recordTransaction(const Queued& request,
+                                         Completion completion,
+                                         std::int64_t completedAtMs,
+                                         std::int64_t responseMs)
+{
+    TransactionEvent event;
+    event.key = request.request.key;
+    event.priority = request.request.priority;
+    event.generation = request.generation;
+    event.completion = completion;
+    event.completedAtMs = completedAtMs;
+    event.queueWaitMs = request.dispatchedAtMs >= 0
+        ? std::max<std::int64_t>(0, request.dispatchedAtMs - request.enqueuedAtMs)
+        : -1;
+    event.responseMs = responseMs;
+    m_recentTransactions.push_back(std::move(event));
+    while (m_recentTransactions.size() > kTransactionHistoryMax) {
+        m_recentTransactions.pop_front();
+    }
+}
+
+void IcomCivScheduler::noteResponse(const Queued& request, std::int64_t nowMs)
+{
+    if (request.dispatchedAtMs < 0) {
+        return;
+    }
+    const std::int64_t responseMs = std::max<std::int64_t>(0, nowMs - request.dispatchedAtMs);
+    ++m_stats.responseSamples;
+    m_stats.totalResponseMs += responseMs;
+    m_stats.lastResponseMs = responseMs;
+    m_stats.maxResponseMs = std::max(m_stats.maxResponseMs, responseMs);
+    m_stats.lastResponseAtMs = nowMs;
+    m_stats.lastCompletedKey = request.request.key;
+}
+
 // Two requests are duplicates only if they ask the SAME register the same way.
 //
 // The semantic key is deliberately coarse — 04, 06, 26 and the transceive
@@ -115,7 +150,12 @@ void IcomCivScheduler::expireRead(std::int64_t nowMs)
     // unmatched-therefore-authoritative at 351 ms, which let an obsolete read
     // overwrite a newer operator write on every register except PTT (which the
     // backend's separate intent window happens to cover).
-    m_expired.push_back(Expired{*m_inFlight, nowMs + kLateReplyGraceMs});
+    const Queued expired = *m_inFlight;
+    const std::int64_t responseMs = std::max<std::int64_t>(0, nowMs - m_inFlightAtMs);
+    recordTransaction(expired, Completion::Timeout, nowMs, responseMs);
+    m_stats.lastCompletedKey = expired.request.key;
+    m_stats.lastTimeoutKey = expired.request.key;
+    m_expired.push_back(Expired{expired, nowMs + kLateReplyGraceMs});
     while (m_expired.size() > kMaxExpiredTracked) {
         m_expired.pop_front();
     }
@@ -166,6 +206,7 @@ std::optional<IcomCivScheduler::Dispatch> IcomCivScheduler::takeNext(std::int64_
     Queued selected = std::move(*best);
     m_queue.erase(best);
     m_lastDispatchMs = nowMs;
+    selected.dispatchedAtMs = nowMs;
     if (selected.request.expectsReply) {
         // A fail-safe unkey is the sole command allowed to interrupt an
         // unanswered transaction.  Displacing that transaction is safe, but it
@@ -174,6 +215,10 @@ std::optional<IcomCivScheduler::Dispatch> IcomCivScheduler::takeNext(std::int64_
         // observe() keeps generation-guarding it instead of treating a late
         // pre-unkey reading as fresh radio truth.
         if (selected.request.priority == Priority::Emergency && m_inFlight) {
+            const Queued displaced = *m_inFlight;
+            recordTransaction(displaced, Completion::Displaced, nowMs,
+                              std::max<std::int64_t>(0, nowMs - m_inFlightAtMs));
+            m_stats.lastCompletedKey = displaced.request.key;
             m_expired.push_back(Expired{*m_inFlight, nowMs + kLateReplyGraceMs});
             while (m_expired.size() > kMaxExpiredTracked) {
                 m_expired.pop_front();
@@ -181,6 +226,9 @@ std::optional<IcomCivScheduler::Dispatch> IcomCivScheduler::takeNext(std::int64_
         }
         m_inFlight = selected;
         m_inFlightAtMs = nowMs;
+    } else {
+        recordTransaction(selected, Completion::NoReply, nowMs);
+        m_stats.lastCompletedKey = selected.request.key;
     }
     ++m_stats.dispatched;
     m_stats.queueDepth = m_queue.size();
@@ -250,6 +298,7 @@ IcomCivScheduler::Observation IcomCivScheduler::observe(const CivFrame& frame,
 
     if (!m_inFlight || !matches(frame, *m_inFlight)) {
         if (generic) {
+            ++m_stats.unmatchedFrames;
             return Observation::Unmatched;
         }
         // Late answer to a transaction we stopped waiting for.  It is only
@@ -262,27 +311,43 @@ IcomCivScheduler::Observation IcomCivScheduler::observe(const CivFrame& frame,
             const auto generation = m_generations.find(it->request.request.key);
             const bool superseded = generation != m_generations.end()
                 && it->request.generation < generation->second;
+            const Queued completed = it->request;
             m_expired.erase(it);
+            ++m_stats.lateReplies;
+            noteResponse(completed, nowMs);
+            recordTransaction(completed,
+                              superseded ? Completion::LateStaleReply
+                                         : Completion::LateReply,
+                              nowMs,
+                              std::max<std::int64_t>(0,
+                                  nowMs - completed.dispatchedAtMs));
             if (superseded) {
                 ++m_stats.staleReplies;
                 return Observation::Stale;
             }
             return Observation::Unmatched;
         }
+        ++m_stats.unmatchedFrames;
         return Observation::Unmatched;
     }
 
     const Queued completed = *m_inFlight;
     m_inFlight.reset();
     ++m_stats.replies;
+    noteResponse(completed, nowMs);
     m_stats.readInFlight = false;
     m_stats.inFlightKey.clear();
 
     const auto generation = m_generations.find(completed.request.key);
     if (generation != m_generations.end() && completed.generation < generation->second) {
         ++m_stats.staleReplies;
+        recordTransaction(completed, Completion::StaleReply, nowMs,
+                          std::max<std::int64_t>(0,
+                              nowMs - completed.dispatchedAtMs));
         return Observation::Stale;
     }
+    recordTransaction(completed, Completion::Reply, nowMs,
+                      std::max<std::int64_t>(0, nowMs - completed.dispatchedAtMs));
     return Observation::Accepted;
 }
 

--- a/src/core/backends/icom/IcomCivScheduler.h
+++ b/src/core/backends/icom/IcomCivScheduler.h
@@ -65,13 +65,49 @@ public:
         Stale,
     };
 
+    // Bounded, payload-free lifecycle events for transactions that actually
+    // reached the wire. A timed-out transaction can have a second event if its
+    // reply later arrives. Raw CI-V bytes remain available through `civ trace
+    // all`; this history answers the different post-mortem question: how long
+    // did each semantic command wait, how long did its reply take, and how did
+    // it terminate? Keeping only the semantic key avoids placing frequencies,
+    // memories, or text payloads into the default support log.
+    enum class Completion : std::uint8_t {
+        Reply,
+        StaleReply,
+        LateReply,
+        LateStaleReply,
+        Timeout,
+        Displaced,
+        NoReply,
+    };
+
+    struct TransactionEvent {
+        std::string key;
+        Priority priority = Priority::Control;
+        std::uint64_t generation = 0;
+        Completion completion = Completion::Reply;
+        std::int64_t completedAtMs = 0;
+        std::int64_t queueWaitMs = -1;
+        std::int64_t responseMs = -1;
+    };
+
     struct Stats {
         std::uint64_t queued = 0;
         std::uint64_t dispatched = 0;
         std::uint64_t coalesced = 0;
         std::uint64_t replies = 0;
         std::uint64_t staleReplies = 0;
+        std::uint64_t lateReplies = 0;
+        std::uint64_t unmatchedFrames = 0;
         std::uint64_t timeouts = 0;
+        std::uint64_t responseSamples = 0;
+        std::int64_t totalResponseMs = 0;
+        std::int64_t lastResponseMs = -1;
+        std::int64_t maxResponseMs = -1;
+        std::int64_t lastResponseAtMs = 0;
+        std::string lastCompletedKey;
+        std::string lastTimeoutKey;
         std::size_t queueDepth = 0;
         bool readInFlight = false;
         std::string inFlightKey;
@@ -107,6 +143,11 @@ public:
     [[nodiscard]] ResetResult reset(
         TerminalOutcome outcome = TerminalOutcome::Cancelled) noexcept;
     [[nodiscard]] Stats stats() const;
+    [[nodiscard]] const std::deque<TransactionEvent>& recentTransactions() const noexcept
+    {
+        return m_recentTransactions;
+    }
+    void clearTransactionHistory() noexcept { m_recentTransactions.clear(); }
     [[nodiscard]] bool idle() const noexcept { return m_queue.empty() && !m_inFlight; }
 
     static constexpr int kSlotMs = 25;
@@ -127,6 +168,7 @@ private:
         std::uint64_t generation = 0;
         std::uint64_t sequence = 0;
         std::int64_t enqueuedAtMs = 0;
+        std::int64_t dispatchedAtMs = -1;
     };
 
     struct Expired {
@@ -140,10 +182,14 @@ private:
                                              std::int64_t nowMs) const noexcept;
     void expireRead(std::int64_t nowMs);
     void dropStaleExpired(std::int64_t nowMs);
+    void recordTransaction(const Queued& request, Completion completion,
+                           std::int64_t completedAtMs, std::int64_t responseMs = -1);
+    void noteResponse(const Queued& request, std::int64_t nowMs);
 
     // Bounded: one ordinary transaction is outstanding at a time and each entry
     // lives only kLateReplyGraceMs, so this cannot grow with queue depth.
     static constexpr std::size_t kMaxExpiredTracked = 16;
+    static constexpr std::size_t kTransactionHistoryMax = 128;
 
     std::deque<Queued> m_queue;
     std::optional<Queued> m_inFlight;
@@ -153,6 +199,7 @@ private:
     std::int64_t m_lastDispatchMs = 0;
     std::int64_t m_inFlightAtMs = 0;
     Stats m_stats;
+    std::deque<TransactionEvent> m_recentTransactions;
 };
 
 }  // namespace AetherSDR::icom

--- a/src/core/backends/icom/IcomSession.cpp
+++ b/src/core/backends/icom/IcomSession.cpp
@@ -816,4 +816,40 @@ QVariantMap IcomSession::leaseDiagnostics() const
     return out;
 }
 
+QVariantMap IcomSession::transportDiagnostics() const
+{
+    const Stats snapshot = stats();
+    const auto streamMap = [](const IcomStream::Counters& counters) {
+        QVariantMap out;
+        out.insert(QStringLiteral("rxBytes"),
+                   QVariant::fromValue<qulonglong>(counters.rxBytes));
+        out.insert(QStringLiteral("txBytes"),
+                   QVariant::fromValue<qulonglong>(counters.txBytes));
+        out.insert(QStringLiteral("rxPackets"),
+                   QVariant::fromValue<qulonglong>(counters.rxPackets));
+        out.insert(QStringLiteral("txPackets"),
+                   QVariant::fromValue<qulonglong>(counters.txPackets));
+        out.insert(QStringLiteral("rxLost"),
+                   QVariant::fromValue<qulonglong>(counters.rxLost));
+        out.insert(QStringLiteral("retransmitsAsked"),
+                   QVariant::fromValue<qulonglong>(counters.retransmitsAsked));
+        out.insert(QStringLiteral("retransmitsServed"),
+                   QVariant::fromValue<qulonglong>(counters.retransmitsServed));
+        out.insert(QStringLiteral("rttMs"), counters.rttMs);
+        out.insert(QStringLiteral("lastRxAgeMs"), counters.lastRxAgeMs);
+        out.insert(QStringLiteral("lastTxAgeMs"), counters.lastTxAgeMs);
+        out.insert(QStringLiteral("lastPayloadAgeMs"), counters.lastPayloadAgeMs);
+        out.insert(QStringLiteral("lastPingReplyAgeMs"), counters.lastPingReplyAgeMs);
+        out.insert(QStringLiteral("socketErrors"),
+                   QVariant::fromValue<qulonglong>(counters.socketErrors));
+        out.insert(QStringLiteral("lastSocketError"), counters.lastSocketError);
+        return out;
+    };
+    QVariantMap out;
+    out.insert(QStringLiteral("control"), streamMap(snapshot.control));
+    out.insert(QStringLiteral("serial"), streamMap(snapshot.serial));
+    out.insert(QStringLiteral("audio"), streamMap(snapshot.audio));
+    return out;
+}
+
 }  // namespace AetherSDR::icom

--- a/src/core/backends/icom/IcomSession.h
+++ b/src/core/backends/icom/IcomSession.h
@@ -111,6 +111,9 @@ public:
     [[nodiscard]] Stats stats() const;
     // Credential-free RS-BA1 lease state for health and automation diagnostics.
     [[nodiscard]] QVariantMap leaseDiagnostics() const;
+    // Per-stream packet activity and socket health. Contains no endpoint,
+    // session id, credential, or payload data, so it is safe in support logs.
+    [[nodiscard]] QVariantMap transportDiagnostics() const;
 
 signals:
     void connected(const QString& deviceName);

--- a/src/core/backends/icom/IcomStream.cpp
+++ b/src/core/backends/icom/IcomStream.cpp
@@ -1,5 +1,6 @@
 #include "core/backends/icom/IcomStream.h"
 
+#include <QAbstractSocket>
 #include <QLoggingCategory>
 #include <QRandomGenerator>
 #include <QTimer>
@@ -45,9 +46,28 @@ bool IcomStream::bindOnly(const Config& config)
 {
     stop();
     m_config = config;
+    m_counters = Counters{};
+    m_activityClock.start();
+    m_lastRxAtMs = -1;
+    m_lastTxAtMs = -1;
+    m_lastPayloadAtMs = -1;
+    m_lastPingReplyAtMs = -1;
 
     m_socket = new QUdpSocket(this);
+    connect(m_socket, &QAbstractSocket::errorOccurred, this,
+            [this](QAbstractSocket::SocketError) {
+                ++m_counters.socketErrors;
+                m_counters.lastSocketError = m_socket
+                    ? m_socket->errorString() : QStringLiteral("socket unavailable");
+                qCWarning(lcIcomStream) << "UDP socket error on role"
+                                        << int(m_config.role) << ':'
+                                        << m_counters.lastSocketError;
+            });
     if (!m_socket->bind(QHostAddress::AnyIPv4, config.localPort)) {
+        if (m_counters.socketErrors == 0) {
+            ++m_counters.socketErrors;
+        }
+        m_counters.lastSocketError = m_socket->errorString();
         emit failed(QStringLiteral("cannot bind local UDP port %1").arg(config.localPort));
         return false;
     }
@@ -78,7 +98,6 @@ bool IcomStream::bindOnly(const Config& config)
     m_gapPending = false;
     m_replay.clear();
     m_reorder.clear();
-    m_counters = Counters{};
     m_idleSince.start();
     return true;
 }
@@ -166,8 +185,11 @@ void IcomStream::sendRaw(std::span<const std::uint8_t> packet)
         return;
     const qint64 n = m_socket->write(reinterpret_cast<const char*>(packet.data()),
                                      static_cast<qint64>(packet.size()));
-    if (n > 0)
+    if (n > 0) {
         m_counters.txBytes += static_cast<quint64>(n);
+        ++m_counters.txPackets;
+        m_lastTxAtMs = m_activityClock.elapsed();
+    }
 }
 
 void IcomStream::flush()
@@ -246,6 +268,7 @@ void IcomStream::onReadyRead()
         buf.resize(static_cast<qsizetype>(n));
         m_counters.rxBytes += static_cast<quint64>(n);
         ++m_counters.rxPackets;
+        m_lastRxAtMs = m_activityClock.elapsed();
         // EVERY inbound datagram, before any dispatch. On first contact with
         // real hardware the failure was a step that produced no reply at all,
         // and no amount of logging at the dispatch sites can distinguish "the
@@ -276,6 +299,7 @@ void IcomStream::handleDatagram(const QByteArray& datagram)
                 // Smooth it: a single sample on WiFi swings enough to make the
                 // readout unreadable, and this number is only ever displayed.
                 m_counters.rttMs = m_counters.rttMs < 0 ? rtt : (m_counters.rttMs + rtt) / 2;
+                m_lastPingReplyAtMs = m_activityClock.elapsed();
             }
         }
         return;
@@ -463,7 +487,27 @@ void IcomStream::onReorderTick()
 
 void IcomStream::deliver(const QByteArray& packet)
 {
+    if (packet.size() > static_cast<qsizetype>(kHeaderSize)) {
+        m_lastPayloadAtMs = m_activityClock.elapsed();
+    }
     emit payloadReady(packet);
+}
+
+IcomStream::Counters IcomStream::counters() const
+{
+    Counters out = m_counters;
+    if (!m_activityClock.isValid()) {
+        return out;
+    }
+    const qint64 now = m_activityClock.elapsed();
+    const auto age = [now](qint64 atMs) {
+        return atMs >= 0 ? std::max<qint64>(0, now - atMs) : -1;
+    };
+    out.lastRxAgeMs = age(m_lastRxAtMs);
+    out.lastTxAgeMs = age(m_lastTxAtMs);
+    out.lastPayloadAgeMs = age(m_lastPayloadAtMs);
+    out.lastPingReplyAgeMs = age(m_lastPingReplyAtMs);
+    return out;
 }
 
 void IcomStream::onIdleTick()

--- a/src/core/backends/icom/IcomStream.h
+++ b/src/core/backends/icom/IcomStream.h
@@ -4,6 +4,7 @@
 #include <QElapsedTimer>
 #include <QHostAddress>
 #include <QMap>
+#include <QString>
 
 #include <deque>
 #include <QObject>
@@ -103,12 +104,19 @@ public:
         quint64 rxBytes = 0;
         quint64 txBytes = 0;
         quint64 rxPackets = 0;
+        quint64 txPackets = 0;
         quint64 rxLost = 0;          // gaps retransmission could not repair
         quint64 retransmitsAsked = 0;
         quint64 retransmitsServed = 0;
         int rttMs = -1;              // negative == not measured
+        qint64 lastRxAgeMs = -1;
+        qint64 lastTxAgeMs = -1;
+        qint64 lastPayloadAgeMs = -1;
+        qint64 lastPingReplyAgeMs = -1;
+        quint64 socketErrors = 0;
+        QString lastSocketError;
     };
-    [[nodiscard]] Counters counters() const { return m_counters; }
+    [[nodiscard]] Counters counters() const;
 
 signals:
     // Handshake complete; the stream will now carry payload.
@@ -202,6 +210,11 @@ private:
 
     QElapsedTimer m_pingSentAt;
     QElapsedTimer m_idleSince;     // time since we last sent anything tracked
+    QElapsedTimer m_activityClock;
+    qint64 m_lastRxAtMs = -1;
+    qint64 m_lastTxAtMs = -1;
+    qint64 m_lastPayloadAtMs = -1;
+    qint64 m_lastPingReplyAtMs = -1;
     Counters m_counters;
 };
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1358,6 +1358,8 @@ void RadioModel::setupBackend(const QString& family)
                     m_cwxModel.adoptSpeed(*delta.cwSpeed);
                 }
             });
+    connect(m_backend.get(), &IRadioBackend::keyingStateConfirmed,
+            this, &RadioModel::radioTransmitConfirmed);
 
     // aetherd 2.4 (#4094): power-amp status decoded in the backend drives AmpModel.
     connect(m_backend.get(), &IRadioBackend::amplifierChanged, this,

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1136,6 +1136,9 @@ signals:
     void txAudioGateChanged(bool transmitting);
     // Raw interlock TX state (regardless of ownership — for DAX passthrough).
     void radioTransmittingChanged(bool transmitting);
+    // A backend's explicit keyed-state readback, including unchanged answers
+    // hidden by the change-gated radioTransmittingChanged signal.
+    void radioTransmitConfirmed(bool transmitting);
     // Operator-driven RF transmit: true while THIS seat is keyed by the local
     // operator in a phone/data mode (MOX, local/hardware PTT, footswitch, VOX)
     // and false otherwise. Deliberately excludes TUNE/two-tone/ATU carriers,

--- a/tests/icom_civ_scheduler_test.cpp
+++ b/tests/icom_civ_scheduler_test.cpp
@@ -72,6 +72,16 @@ int main()
         check(scheduler.observe(reply(0x15, 0x02, 0), 1110)
                   == IcomCivScheduler::Observation::Accepted,
               "matching reply completes the outstanding read");
+        const auto& history = scheduler.recentTransactions();
+        check(history.size() == 1 && history.back().key == "meter.s"
+                  && history.back().completion == IcomCivScheduler::Completion::Reply
+                  && history.back().queueWaitMs == 0
+                  && history.back().responseMs == 110,
+              "completed reads retain payload-free queue and response timing");
+        check(scheduler.stats().responseSamples == 1
+                  && scheduler.stats().lastResponseMs == 110
+                  && scheduler.stats().maxResponseMs == 110,
+              "reply timing contributes to bounded scheduler aggregates");
     }
 
     {
@@ -123,6 +133,11 @@ int main()
         const auto recovered = scheduler.takeNext(4350);
         check(recovered && recovered->key == "meter.s", "scheduler recovers after lost reply");
         check(scheduler.stats().timeouts == 1, "lost reply is counted");
+        const auto& history = scheduler.recentTransactions();
+        check(!history.empty() && history.front().key == "control.nr"
+                  && history.front().completion == IcomCivScheduler::Completion::Timeout
+                  && history.front().responseMs == IcomCivScheduler::kReadTimeoutMs,
+              "a lost reply leaves a timed transaction lifecycle record");
     }
 
     {
@@ -218,6 +233,11 @@ int main()
                   == IcomCivScheduler::Observation::Stale,
               "a reply that misses the timeout is still rejected against a "
               "newer write generation");
+        check(scheduler.recentTransactions().size() == 2
+                  && scheduler.recentTransactions().back().completion
+                      == IcomCivScheduler::Completion::LateStaleReply
+                  && scheduler.stats().lateReplies == 1,
+              "a superseded late reply is distinguished from its timeout");
     }
     {
         // ...but a merely slow reply with nothing newer behind it is not
@@ -228,6 +248,27 @@ int main()
         check(scheduler.observe(reply(0x14, 0x02, 0x50), 360)
                   == IcomCivScheduler::Observation::Unmatched,
               "a late reply with no newer intent behind it is not marked stale");
+        check(scheduler.recentTransactions().size() == 2
+                  && scheduler.recentTransactions().back().completion
+                      == IcomCivScheduler::Completion::LateReply,
+              "an authoritative slow reply remains visible as late, not stale");
+    }
+
+    {
+        IcomCivScheduler scheduler;
+        IcomCivScheduler::Request noReply;
+        noReply.frame = buildFrameSub(0xB6, 0x1C, 0x00, std::array<std::uint8_t, 1>{0});
+        noReply.key = "ptt";
+        noReply.priority = Priority::Emergency;
+        noReply.expectsReply = false;
+        scheduler.enqueue(std::move(noReply), 8000);
+        check(scheduler.takeNext(8000).has_value(),
+              "response-free fail-safe command dispatches");
+        check(scheduler.recentTransactions().size() == 1
+                  && scheduler.recentTransactions().back().completion
+                      == IcomCivScheduler::Completion::NoReply
+                  && scheduler.recentTransactions().back().responseMs == -1,
+              "response-free commands have an explicit terminal outcome");
     }
 
     {

--- a/tests/icom_incident_telemetry_test.cpp
+++ b/tests/icom_incident_telemetry_test.cpp
@@ -1,0 +1,145 @@
+// Socket-free Icom incident telemetry contract.
+//
+// Positive radio/session convergence belongs to the live automation bridge.
+// This test drives only the deterministic backend state transition that turns
+// an expired key-on confirmation into a payload-free support dossier.
+
+#include "core/backends/icom/IcomCivBackend.h"
+
+#include <QCoreApplication>
+#include <QVariantMap>
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+using namespace AetherSDR;
+using namespace AetherSDR::icom;
+
+namespace AetherSDR::icom {
+
+struct IcomCivBackendTestAccess {
+    static void prepareExpiredKeyOn(IcomCivBackend& backend,
+                                    const IcomModel& model,
+                                    std::uint64_t generation)
+    {
+        backend.m_model = &model;
+        backend.m_connected = true;
+        backend.m_sessionGeneration = generation;
+        backend.m_keyed = false;
+        backend.m_pendingPttIntent = true;
+        backend.m_pendingPttUntilMs = backend.nowMs() - 1;
+    }
+
+    static void deliver(IcomCivBackend& backend, const CivFrame& frame,
+                        std::uint64_t generation)
+    {
+        backend.onCivFrame(frame, generation);
+    }
+
+    static QVariantMap incident(const IcomCivBackend& backend)
+    {
+        return backend.m_lastIncident;
+    }
+
+    static void prepareAcceptedPttRead(IcomCivBackend& backend,
+                                       const IcomModel& model,
+                                       std::uint64_t sessionGeneration)
+    {
+        backend.m_model = &model;
+        backend.m_connected = true;
+        backend.m_sessionGeneration = sessionGeneration;
+        const std::vector<std::uint8_t> read =
+            buildFrameSub(model.civAddress, cmd::kControl, control::kPtt);
+        backend.queueRead(read, "ptt", IcomCivScheduler::Priority::Operator);
+        (void)backend.m_civScheduler.takeNext(backend.nowMs());
+    }
+};
+
+}  // namespace AetherSDR::icom
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* message)
+{
+    std::printf("%s  %s\n", condition ? "PASS" : "FAIL", message);
+    if (!condition) {
+        ++failures;
+    }
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    const IcomModel* ic705 = modelForName("IC-705");
+    check(ic705 != nullptr, "incident telemetry resolves the IC-705 profile");
+    if (!ic705) {
+        return 1;
+    }
+
+    IcomCivBackend backend;
+    constexpr std::uint64_t kGeneration = 1;
+    IcomCivBackendTestAccess::prepareExpiredKeyOn(
+        backend, *ic705, kGeneration);
+
+    CivFrame unkeyed;
+    unkeyed.to = kControllerAddress;
+    unkeyed.from = ic705->civAddress;
+    unkeyed.cmd = cmd::kControl;
+    unkeyed.hasSub = true;
+    unkeyed.sub = control::kPtt;
+    unkeyed.data = {0x00};
+    IcomCivBackendTestAccess::deliver(backend, unkeyed, kGeneration);
+
+    const QVariantMap incident = IcomCivBackendTestAccess::incident(backend);
+    const QVariantMap ptt = incident.value(QStringLiteral("ptt")).toMap();
+    const QVariantMap commandPlane =
+        incident.value(QStringLiteral("commandPlane")).toMap();
+    check(incident.value(QStringLiteral("kind")).toString()
+                  == QLatin1String("ptt-not-confirmed")
+              && incident.value(QStringLiteral("model")).toString()
+                  == QLatin1String("IC-705"),
+          "expired key-on records a typed, model-scoped incident");
+    check(ptt.value(QStringLiteral("pendingIntent")).toBool()
+              && ptt.value(QStringLiteral("intentKeyed")).toBool()
+              && !ptt.value(QStringLiteral("publishedKeyed")).toBool(),
+          "incident preserves requested and published PTT state before cleanup");
+    check(commandPlane.contains(QStringLiteral("scheduler"))
+              && commandPlane.contains(QStringLiteral("transactions")),
+          "incident includes scheduler state and bounded transaction history");
+
+    QVariantMap extensionResult;
+    QObject::connect(&backend, &IRadioBackend::extensionResult, &app,
+                     [&extensionResult](quint64 id, const QVariant& result) {
+                         if (id == 0x1C1D) {
+                             extensionResult = result.toMap();
+                         }
+                     });
+    backend.invokeExtension(QStringLiteral("icom"),
+                            QStringLiteral("civ.incident"), 0x1C1D, {});
+    check(extensionResult.value(QStringLiteral("kind")).toString()
+              == QLatin1String("ptt-not-confirmed"),
+          "read-only CI-V incident verb returns the retained dossier");
+
+    IcomCivBackend confirmationBackend;
+    std::vector<bool> confirmations;
+    QObject::connect(&confirmationBackend, &IRadioBackend::keyingStateConfirmed,
+                     &app, [&confirmations](bool keyed) {
+                         confirmations.push_back(keyed);
+                     });
+    IcomCivBackendTestAccess::prepareAcceptedPttRead(
+        confirmationBackend, *ic705, kGeneration);
+    check(confirmations.empty(),
+          "queueing a PTT read publishes no optimistic radio confirmation");
+    IcomCivBackendTestAccess::deliver(
+        confirmationBackend, unkeyed, kGeneration);
+    check(confirmations.size() == 1 && !confirmations.front(),
+          "only an accepted CI-V PTT-off readback publishes confirmation");
+
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/icom_tci_unkey_settle_test.cpp
+++ b/tests/icom_tci_unkey_settle_test.cpp
@@ -29,11 +29,11 @@ int main()
           "an optimistic unkey without CI-V readback times out");
     check(settle.isAwaitingConfirmation(),
           "a no-reply timeout retains the authoritative confirmation barrier");
-    check(settle.confirmOff() == IcomTciUnkeySettle::Confirmation::Late,
+    check(settle.confirm(false) == IcomTciUnkeySettle::Confirmation::Late,
           "a late authoritative PTT-off readback releases the retained barrier");
 
     const std::uint64_t confirmed = settle.begin();
-    check(settle.confirmOff()
+    check(settle.confirm(false)
               == IcomTciUnkeySettle::Confirmation::PendingExpiry,
           "an authoritative readback confirms the active settle generation");
     check(settle.expire(confirmed) == IcomTciUnkeySettle::Expiry::Confirmed,
@@ -43,8 +43,41 @@ int main()
     settle.cancel();
     check(settle.expire(cancelled) == IcomTciUnkeySettle::Expiry::Stale,
           "teardown invalidates an older settle timer");
-    check(settle.confirmOff() == IcomTciUnkeySettle::Confirmation::Ignored,
+    check(settle.confirm(false) == IcomTciUnkeySettle::Confirmation::Ignored,
           "teardown also rejects a late confirmation from the cancelled settle");
+
+    const std::uint64_t rekeyed = settle.begin();
+    check(settle.confirm(false)
+              == IcomTciUnkeySettle::Confirmation::PendingExpiry,
+          "an early off readback initially confirms the settle generation");
+    check(settle.confirm(true)
+              == IcomTciUnkeySettle::Confirmation::PendingExpiry,
+          "a later keyed readback revokes the earlier off confirmation");
+    check(settle.expire(rekeyed) == IcomTciUnkeySettle::Expiry::TimedOut,
+          "off then on before expiry fails safe instead of hiding keyed state");
+    check(settle.isAwaitingConfirmation(),
+          "the re-key timeout retains ownership until a later off readback");
+    check(settle.confirm(false) == IcomTciUnkeySettle::Confirmation::Late,
+          "a post-timeout off readback releases the conservative barrier");
+
+    const std::uint64_t reconfirmed = settle.begin();
+    settle.confirm(false);
+    settle.confirm(true);
+    settle.confirm(false);
+    check(settle.expire(reconfirmed) == IcomTciUnkeySettle::Expiry::Confirmed,
+          "off then on then off uses the latest accepted radio state");
+
+    const std::uint64_t keyedAfterTimeout = settle.begin();
+    check(settle.expire(keyedAfterTimeout)
+              == IcomTciUnkeySettle::Expiry::TimedOut,
+          "a second no-reply generation also times out conservatively");
+    check(settle.confirm(true)
+              == IcomTciUnkeySettle::Confirmation::PendingExpiry,
+          "a keyed readback after timeout keeps waiting for authoritative off");
+    check(settle.isAwaitingConfirmation(),
+          "keyed confirmation after timeout cannot release ownership");
+    check(settle.confirm(false) == IcomTciUnkeySettle::Confirmation::Late,
+          "the later off readback still releases the timed-out generation");
 
     return failures == 0 ? 0 : 1;
 }

--- a/tests/icom_tci_unkey_settle_test.cpp
+++ b/tests/icom_tci_unkey_settle_test.cpp
@@ -1,0 +1,50 @@
+// Socket-free policy coverage for TCI's Icom unkey presentation barrier.
+
+#include "core/IcomTciUnkeySettle.h"
+
+#include <cstdio>
+
+using AetherSDR::IcomTciUnkeySettle;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* message)
+{
+    std::printf("%s  %s\n", condition ? "PASS" : "FAIL", message);
+    if (!condition) {
+        ++failures;
+    }
+}
+
+} // namespace
+
+int main()
+{
+    IcomTciUnkeySettle settle;
+
+    const std::uint64_t noReply = settle.begin();
+    check(settle.expire(noReply) == IcomTciUnkeySettle::Expiry::TimedOut,
+          "an optimistic unkey without CI-V readback times out");
+    check(settle.isAwaitingConfirmation(),
+          "a no-reply timeout retains the authoritative confirmation barrier");
+    check(settle.confirmOff() == IcomTciUnkeySettle::Confirmation::Late,
+          "a late authoritative PTT-off readback releases the retained barrier");
+
+    const std::uint64_t confirmed = settle.begin();
+    check(settle.confirmOff()
+              == IcomTciUnkeySettle::Confirmation::PendingExpiry,
+          "an authoritative readback confirms the active settle generation");
+    check(settle.expire(confirmed) == IcomTciUnkeySettle::Expiry::Confirmed,
+          "the field-tested bounded settle succeeds after CI-V confirmation");
+
+    const std::uint64_t cancelled = settle.begin();
+    settle.cancel();
+    check(settle.expire(cancelled) == IcomTciUnkeySettle::Expiry::Stale,
+          "teardown invalidates an older settle timer");
+    check(settle.confirmOff() == IcomTciUnkeySettle::Confirmation::Ignored,
+          "teardown also rejects a late confirmation from the cancelled settle");
+
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/tci_server_review_test.cpp
+++ b/tests/tci_server_review_test.cpp
@@ -220,6 +220,37 @@ public:
                 == QStringLiteral("capacity test");
     }
 
+    static bool disconnectSnapshotIsPayloadFreeAndUsesUnsetError()
+    {
+        RadioModel model;
+        TciServer server(&model);
+        QWebSocket socket;
+        TciServer::ClientState client;
+        client.socket = &socket;
+
+        const QJsonObject snapshot = server.disconnectSnapshot(client, &socket);
+        return !snapshot.contains(QStringLiteral("closeReason"))
+            && snapshot.value(QStringLiteral("socketError")).toInt() == -1
+            && snapshot.value(QStringLiteral("socketErrorString")).toString().isEmpty()
+            && snapshot.value(QStringLiteral("lastSocketErrorAgeMs")).toInt() == -1;
+    }
+
+    static bool outboundTextAccountingIsCentralized()
+    {
+        RadioModel model;
+        TciServer server(&model);
+        QWebSocket socket;
+        TciServer::ClientState client;
+        client.socket = &socket;
+        server.m_clients.append(client);
+
+        server.sendClientText(
+            &socket, QStringLiteral("rx_channel_sensors:0,0,-73.0;"));
+        return server.m_clients.first().lastTextTxAtMs >= 0
+            && server.m_clients.first().lastTxCommand
+                == QStringLiteral("rx_channel_sensors");
+    }
+
     // ── #4547 PTT routing diagnostic ────────────────────────────────────────
 
     // Two slices, slice 1 holding transmit, and a routing cache still pointing
@@ -1324,6 +1355,10 @@ int main(int argc, char** argv)
         = AetherSDR::TciServerReviewTest::deferredAbortIsClientScoped();
     const bool observableFailure
         = AetherSDR::TciServerReviewTest::routeFailureIsObservable();
+    const bool payloadFreeDisconnect
+        = AetherSDR::TciServerReviewTest::disconnectSnapshotIsPayloadFreeAndUsesUnsetError();
+    const bool outboundTextAccounting
+        = AetherSDR::TciServerReviewTest::outboundTextAccountingIsCentralized();
     const bool pttBindsReceiver
         = AetherSDR::TciServerReviewTest::pttBindsToTheDeclaredAudioReceiver();
     const bool pttUsesStableMap
@@ -1373,6 +1408,10 @@ int main(int argc, char** argv)
                 deferredAbort ? "PASS" : "FAIL");
     std::printf("%s  VFO-B route failure is observable\n",
                 observableFailure ? "PASS" : "FAIL");
+    std::printf("%s  disconnect snapshot omits peer text and uses unset error\n",
+                payloadFreeDisconnect ? "PASS" : "FAIL");
+    std::printf("%s  outbound TCI text accounting is centralized\n",
+                outboundTextAccounting ? "PASS" : "FAIL");
     std::printf("%s  PTT binds to the declared audio receiver (#4547)\n",
                 pttBindsReceiver ? "PASS" : "FAIL");
     std::printf("%s  PTT resolves through the stable trx map (#4547/#4567)\n",
@@ -1421,7 +1460,8 @@ int main(int argc, char** argv)
     std::printf("%s  native 24 kHz TCI RX retains accumulated payload (#4744)\n",
                 native24kPayload ? "PASS" : "FAIL");
 
-    return validProfile && deferredAbort && observableFailure && pttBindsReceiver
+    return validProfile && deferredAbort && observableFailure
+        && payloadFreeDisconnect && outboundTextAccounting && pttBindsReceiver
         && pttUsesStableMap
         && powerRateLimits && trxCacheHolds && cacheResets && flagSeedsDeDups
         && flagSeedSettled && txTrxResets

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -418,6 +418,20 @@ add_executable(icom_civ_scheduler_test
 target_include_directories(icom_civ_scheduler_test PRIVATE src)
 add_test(NAME icom_civ_scheduler_test COMMAND icom_civ_scheduler_test)
 
+# Socket-free backend incident-state transition. Positive session convergence
+# is certified against real firmware through the automation bridge.
+add_executable(icom_incident_telemetry_test
+    tests/icom_incident_telemetry_test.cpp)
+target_include_directories(icom_incident_telemetry_test PRIVATE src)
+target_link_libraries(icom_incident_telemetry_test PRIVATE aethercore Qt6::Core)
+add_test(NAME icom_incident_telemetry_test COMMAND icom_incident_telemetry_test)
+
+# Pure state-machine coverage: no WebSocket, network socket, or radio fixture.
+add_executable(icom_tci_unkey_settle_test
+    tests/icom_tci_unkey_settle_test.cpp)
+target_include_directories(icom_tci_unkey_settle_test PRIVATE src)
+add_test(NAME icom_tci_unkey_settle_test COMMAND icom_tci_unkey_settle_test)
+
 add_executable(icom_scope_test
     tests/icom_scope_test.cpp
     src/core/backends/icom/IcomScope.cpp


### PR DESCRIPTION
## Summary

This change stabilizes WSJT-X PTT over TCI for networked Icom radios and adds enough payload-free telemetry to identify the layer responsible for a future failure.

- Keep the external TCI `trx` presentation monotonic across a bounded 500 ms Icom unkey-settle interval.
- Send the CI-V unkey immediately and continue publishing radio-authoritative state to AetherSDR's internal model/UI.
- If the radio remains keyed at the end of the bound, republish `trx:true` to TCI and record an unkey-settle timeout. The barrier cannot hide a persistent keyed radio.
- Add retained TCI ingress, PTT confirmation, disconnect, RS-BA1 stream, CI-V scheduler, and structured incident diagnostics.
- Add a read-only `civ incident` automation action and document how to use it beside `tci routes`, `civ session`, and `civ scheduler`.

## Failure mode and root cause

During long WSJT-X FT8 sessions, an Icom unkey could be followed by a delayed radio readback that briefly still reported keyed. AetherSDR correctly treated that readback as radio-authoritative state, but TCI exposed the sequence directly to WSJT-X:

```text
trx:false -> delayed CI-V trx:true -> trx:false
```

WSJT-X could interpret the middle `trx:true` as a new transmit transition. After enough cycles this left the external client unable to key reliably, even though the WebSocket, RS-BA1 lease, and CI-V command path remained live.

The fix does not make the radio state optimistic and does not defer the safety-critical unkey. It separates two concerns for the short settle interval:

- AetherSDR's model/UI continues to receive the radio's keyed truth.
- TCI withholds only a transient delayed re-key presentation after a confirmed, TCI-owned Icom unkey.

The behavior is deliberately limited to confirmed TCI-owned PTT on the Icom backend. Flex, HL2, non-TCI keying, key-on behavior, and emergency/unowned unkey behavior are unchanged.

## Safety and state-machine behavior

1. TCI accepts an unkey request from the client that owns the current Icom PTT session.
2. AetherSDR sends CI-V PTT off immediately and starts a 500 ms presentation-settle generation.
3. Radio-authoritative keyed readbacks continue into the internal model and are counted, but transient `trx:true` notifications are withheld from that TCI owner.
4. A confirmed unkey completes the settle normally.
5. If keyed state persists when the bound expires, AetherSDR republishes `trx:true` and increments `unkeySettleTimeoutCount`.
6. Disconnect cleanup remains fail-closed and retains a pre-cleanup PTT dossier for diagnosis.

No retry can key the radio, no CI-V payload is synthesized, and no persistent keyed state is hidden beyond the fixed bound.

## Telemetry added

### TCI

`tci routes` now reports payload-free PTT lifecycle telemetry, including:

- request/on/off, accepted-on, confirmed-on, and confirmation-timeout counts;
- current ownership, requested state, confirmed state, and unkey-settle state;
- settle, suppressed delayed re-key, and settle-timeout counts;
- ages and the last semantic outcome;
- a retained disconnect dossier with close/socket state, message ages, command names, and the PTT state captured before cleanup.

This distinguishes a request that never entered AetherSDR, one rejected by TCI routing/preflight, one accepted but never confirmed by the radio, and a WebSocket disconnect.

### Icom / RS-BA1 / CI-V

- `civ session` now reports independent control, serial, and audio packet/byte/activity ages, RTT, payload activity, and socket-error counts beside lease-renewal state.
- `civ scheduler` now reports response samples, last/average/max response time, late and unmatched frames, last completion/timeout keys, and a bounded semantic transaction history.
- `civ incident` returns the most recent structured incident, or a live snapshot when none has occurred.
- A single `aether.icom.incident` warning is captured for a PTT confirmation failure, a timeout with a significant queue backlog, a CI-V-only stall while transport remains up, or an unexpected established-session disconnect.

Incident records join TCI intent, lease state, per-stream transport liveness, scheduler state, and the last 32 transaction outcomes. They retain semantic command keys and correlation data, but not credentials, network endpoints, raw CI-V/UDP payloads, frequencies, or operator text.

## Verification

### Deterministic exact-head verification

Exact commit: `65ff06f214047b2e1cbbdd00c606f1926994b08f`

- Full macOS `RelWithDebInfo` build: passed with `cmake --build build -j22`.
- Socket-free Icom/TCI protocol and cross-family isolation suite: 9/9 passed headless.
  - `icom_incident_telemetry_test`
  - `icom_civ_scheduler_test`
  - `icom_family_test`
  - `tci_protocol_test`
  - `tci_trxmap_test`
  - `flex_backend_lifecycle_test`
  - `hl2_family_transition_test`
  - `hl2_tx_gate_test`
  - `radio_capability_gating_test`
- Existing Linux CI Icom gate selection: 5/5 passed headless.
- Test registration audit: passed.
- Strict engine-boundary audit: passed with zero blocking findings; only existing tracked legacy warnings remain.
- `git diff --check`: passed.
- Synthetic merge with current `origin/main` (`3addf3b3`): passed.
- Commit contains a valid ED25519 SSH signature and `Signed-off-by` trailer.

The new incident-state test is socket-free, and this PR does not modify the existing socket-based TCI fixtures. In keeping with the layered test boundary established by #5232, deterministic state and cross-family behavior are covered locally while positive transport convergence is proved against real firmware through the automation bridge.

### Real-radio soak

The deployed patch was exercised for approximately four hours with:

- AetherSDR 26.8.4 on the Mac at `192.168.1.12`;
- IC-7300MK2 at `192.168.1.90`;
- both endpoints on Ethernet through the same switch;
- WSJT-X repeatedly alternating CQ and directed calls over TCI.

Observed results:

- 435 PTT-on requests accepted and 435 confirmed;
- 435 unkey-settle intervals completed;
- 36 delayed keyed readbacks suppressed from TCI during those intervals;
- 0 PTT confirmation timeouts;
- 0 unkey-settle timeouts;
- 0 TCI disconnects, with the WSJT-X client still connected at inspection time;
- 227 RS-BA1 renewals accepted, with 0 rejected/pending/retried/ignored renewals;
- all three RS-BA1 streams live with 0 socket errors or reported loss;
- no fatal error, crash, shutdown, or audio-open failure in the active log.

This live proof was collected on the same implementation patch before rebasing over the two newer upstream test/policy commits. The rebase had no implementation conflict; the rebased exact head was then rebuilt and reran through the deterministic checks above.

## Residual observation

The soak recorded two non-PTT CI-V read timeouts across roughly 430,000 scheduler dispatches. One produced the intended `civ-timeout-backlog` incident for an active meter read: 351 ms timeout, 360 ms late reply, queue depth 10. PTT replies around that event remained approximately 10-25 ms and keying continued normally.

That evidence separates the fixed PTT presentation failure from remaining meter/control queue latency. The new incident dossier should make any future scheduler tuning evidence-driven without enabling every-frame CI-V tracing.

## Scope

- No `CHANGELOG.md` entry; this is a feature/fix PR, not release preparation.
- No ONNX/CMake workaround is included. The local build used the repository-staged ONNX Runtime 1.27 dependency, avoiding the incompatible Homebrew 1.28/protobuf pairing encountered during test deployment.
- No raw transport tracing is enabled by default.

Generated with OpenAI Codex (Daybreak Blue)

Fixes #5300
