### PR TITLE
fix: assert stream tx=1 on hosted-DAX/TCI/AX.25 dax_tx streams

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -11013,10 +11013,33 @@ bool RadioModel::ensureDaxTxStream(DaxTxRequestReason reason)
         return false;
     }
 
+    // Reasons that actually push samples down this stream on their own
+    // (no Windows-DAX2-style external owner to defer to) and therefore need
+    // the radio told "this stream is live" — as opposed to WSPR, which has
+    // its own explicit ownership flag below, or a route-only/recreate probe
+    // that isn't transmitting anything. Closes a real gap reported on a
+    // FLEX-8400 (VARA HF) — see aethersdr/AetherSDR#4554, #4510 — where the
+    // radio never reflects `tx=1` on a freshly created stream without this
+    // assertion. NOT independently confirmed against that report's hardware:
+    // a FLEX-6600 repro of the same *symptom* turned out to have an unrelated
+    // client-side root cause and reproduces the tx flag already defaulting to
+    // 1 on stream creation, so this radio/firmware never exercised the gap.
+    const bool isInteractiveTxRoute = reason == DaxTxRequestReason::HostedDaxBridge
+        || reason == DaxTxRequestReason::TciTxAudio
+        || reason == DaxTxRequestReason::AetherModemAx25Tx;
+
     const bool existingStreamIsOurs = m_daxTxStreamId != 0
         && (m_daxTxClientHandle == 0 || m_daxTxClientHandle == ourHandle);
-    if (existingStreamIsOurs || m_daxTxCreatePending)
+    if (existingStreamIsOurs || m_daxTxCreatePending) {
+        // The radio can silently drop our tx flag (another client claims the
+        // slot, a brief reconnect) without us noticing until the next
+        // transmit goes out over an unflagged stream and produces no RF.
+        // Re-assert whenever status says we're not currently the tx owner.
+        if (existingStreamIsOurs && !m_daxTxActive && isInteractiveTxRoute) {
+            sendCmd(QStringLiteral("stream set %1 tx=1").arg(hexId(m_daxTxStreamId)));
+        }
         return true;
+    }
 
     m_daxTxCreatePending = true;
     qCInfo(lcDax).noquote()
@@ -11024,7 +11047,7 @@ bool RadioModel::ensureDaxTxStream(DaxTxRequestReason reason)
         << QStringLiteral("reason=%1").arg(daxTxRequestReasonName(reason));
     sendCmd(
         "stream create type=dax_tx",
-        [this, reason](int code, const QString& body) {
+        [this, reason, isInteractiveTxRoute](int code, const QString& body) {
             m_daxTxCreatePending = false;
             if (code != 0) {
                 qCWarning(lcDax).noquote()
@@ -11062,6 +11085,13 @@ bool RadioModel::ensureDaxTxStream(DaxTxRequestReason reason)
             } else if (m_wsprTxReleaseWhenReady) {
                 sendCmd(QStringLiteral("stream set %1 tx=0").arg(hexId(id)));
                 m_wsprTxReleaseWhenReady = false;
+            } else if (isInteractiveTxRoute) {
+                // The stream now exists, but the radio still treats it as
+                // inactive until told otherwise — WSPR always knew this
+                // (above); the interactive routes never did, so audio
+                // reached the radio's dax_tx slot and was silently
+                // discarded on every packet. This is the fix for that.
+                sendCmd(QStringLiteral("stream set %1 tx=1").arg(hexId(id)));
             }
         });
     return true;


### PR DESCRIPTION
## Summary

Refs #4554, #4510 — **not marked "Fixes" below deliberately, see Validation.** The hosted-DAX TX stream (and TCI / AetherModem AX.25's) is created but never told the radio it's the active transmit source: `ensureDaxTxStream()` only sends `stream set <id> tx=1` on the WSPR beacon path. For every other interactive route, real VITA-49 audio packets go out on the stream, and on a radio/firmware that doesn't default a fresh `dax_tx` stream to `tx=1`, they'd be silently discarded — PTT, CAT, and mode all working normally, indistinguishable from a healthy TX chain producing 0 W. That code gap is real; I read it directly.

## Validation — read before merging

I do **not** have independent on-air confirmation that this fixes the original #4554/#4510 symptom. My own repro (FLEX-6600, Nexus, AetherSDR's rigctld CAT relay — reached this bug from an unrelated client-side cpal enumeration issue on the Nexus side) turned out to be resolved entirely by that client-side fix, with this tx=1 gap never actually biting: isolation-tested with this patch reverted and RF output was identical either way, and the logs show my FLEX-6600 already reports `tx=1` on the stream-create response *before* AetherSDR ever sends the assertion — i.e. this radio/firmware appears to default new `dax_tx` streams to `tx=1` on creation.

So this PR closes a genuine, confirmed-by-reading-the-code gap that matches the *shape* of #4554/#4510 exactly, and is a safe, idempotent fix regardless (re-asserting a flag that's already true costs nothing) — but whether it's actually *the* fix for the FLEX-8400 in #4554 depends on whether that radio/firmware shares my FLEX-6600's apparent default. Would appreciate the original reporter re-testing against this branch before it's treated as closing #4554.

## Constitution principle honored

Principle II — The Radio Is Authoritative On Live State. The fix reads the radio's own reported `tx` flag on the `dax_tx` stream status (`m_daxTxActive`) before deciding whether to (re-)assert ownership, rather than assuming the client's side of the handshake was sufficient — and re-asserts if the radio ever reports the flag cleared while we still hold the stream (a client that trusted its own optimistic "I created a stream, so it must be live" state is exactly the failure mode this principle rules out).

## What changed

In `RadioModel::ensureDaxTxStream()`:
- Send `stream set <id> tx=1` at stream-creation time for the interactive TX reasons (`HostedDaxBridge`, `TciTxAudio`, `AetherModemAx25Tx`) — mirroring what the WSPR path already did.
- On the early-return path for an already-owned stream, re-assert `tx=1` if radio status currently reports `tx=0` for a stream we still hold (covers the radio silently clearing the flag on a reconnect or another client's claim — the same "write-only flag, never re-asserted" shape noted in #4152).

No changes to CAT, PTT, mode handling, or the DAX RX path.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Verified on a real radio (FLEX-6600) that the code path now fires correctly — `stream set <id> tx=1` sent and acknowledged in logs at the right point in `ensureDaxTxStream()`
- [ ] **Not verified**: that this is what makes RF output appear on hardware where the bug actually bites (my hardware defaults `tx=1` already — see Validation above)
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented (this PR + #4554 + #4510)

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room
- [x] N/A — no meter UI touched
- [ ] Documentation — none of the user-facing behavior changed (this restores documented behavior), so no doc update needed
- [ ] N/A — not security-sensitive
