### PR TITLE
Restore Flex PA temperature in the status bar

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2260,10 +2260,12 @@ MainWindow::MainWindow(QWidget* parent)
         // not yet received a meter definition is still not entitled to print a
         // number. Same separation as the DAX capability and its crash guard.
         const auto& meters = m_radioModel.meterModel();
+        const bool presentPaCurrent =
+            m_paCurrentStatusPreferred && meters.hasPaCurrentMeter();
         m_supplyVoltLabel->setText(
             meters.hasSupplyVoltage()
                 ? QStringLiteral("%1%2 V")
-                      .arg(meters.hasPaCurrentMeter()
+                      .arg(presentPaCurrent
                                ? QStringLiteral("Vd ") : QString(),
                            QString::number(supplyVolts, 'f', 2))
                 : QStringLiteral("—"));
@@ -4438,7 +4440,7 @@ void MainWindow::showQuickAddMemoryDialog(const QString& preferredPanId)
 void MainWindow::updatePaTempLabel()
 {
     const auto& meters = m_radioModel.meterModel();
-    if (meters.hasPaCurrentMeter()) {
+    if (m_paCurrentStatusPreferred && meters.hasPaCurrentMeter()) {
         const bool liveTxCurrent =
             (m_radioModel.transmitModel().isTransmitting()
              || m_radioModel.transmitModel().isTuning())
@@ -7118,6 +7120,14 @@ void MainWindow::applyCapabilitiesToUi(bool connected, const RadioCapabilities& 
     // with the rest of the identity block.
     m_radioManufacturer = connected ? caps.manufacturer : QString();
     refreshRadioIdentityLabels();
+
+    // The compact status stack gives PA temperature priority whenever the
+    // active backend declares it. Flex also publishes a PACURRENT meter, but
+    // that reading clips and must not replace its authoritative PATEMP value.
+    // Radios without temperature retain the established Vd/Id presentation
+    // when their calibrated meter definitions arrive.
+    m_paCurrentStatusPreferred = connected && !caps.hasPaTemperatureTelemetry;
+    updatePaTempLabel();
 
     // ── Mic sources: MIC / BAL / LINE / ACC are Flex connectors ────────────
     // A radio that cannot have its input chosen by a client collapses to PC.

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1550,6 +1550,7 @@ private:
     bool m_useSystemClock{true};     // true when no GPS installed
     bool m_paTempUseFahrenheit{true};
     bool m_hasPaTempTelemetry{false};
+    bool m_paCurrentStatusPreferred{false};
     float m_lastPaTempC{0.0f};
     bool m_userDisconnected{false};  // true after explicit disconnect, blocks auto-connect
     // Auto-reconnect bookkeeping — see maybeAutoConnectToDiscoveredRadio().


### PR DESCRIPTION
## Summary

- restore PA temperature as the primary Flex status-bar field even though Flex also publishes a PACURRENT meter definition
- remove the Icom-specific Vd prefix from the Flex supply-voltage field
- preserve the existing Vd/Id presentation for radios without PA-temperature telemetry, including supported Icom models

## Root cause

The compact status stack selected Vd/Id from the presence of a PACURRENT meter definition alone. Flex publishes that definition, but its current reading is known to clip and the backend deliberately exposes PATEMP as the authoritative presentation. The shared status-bar branch therefore replaced working Flex temperature telemetry with the Icom-oriented current display.

This change records the status presentation preference from normalized capabilities and gives declared PA-temperature telemetry priority. Meter sample validity remains authoritative for the numeric values.

## Validation

- macOS application build passed with `cmake --build build -j22` at signed commit `44763baf`
- `git diff --check` passed
- no tests added or run, per maintainer direction
- runtime automation-bridge validation could not start because the local Homebrew ONNX Runtime links a removed `libprotobuf-lite.35.1.0.dylib`; no live-radio proof is claimed

Generated with OpenAI Codex (Daybreak Blue)