### PR TITLE
fix(icom): name the target and the likely cause when the RS-BA1 handshake fails

### DIFF
--- a/src/core/backends/icom/IcomStream.cpp
+++ b/src/core/backends/icom/IcomStream.cpp
@@ -42,6 +42,23 @@ bool IcomStream::start(const Config& config)
     return true;
 }
 
+namespace {
+
+// The three RS-BA1 streams fail independently and for different reasons, so a
+// failure that does not say which one failed sends the operator to the wrong
+// setting. Logged as a bare int() elsewhere in this file; a name costs nothing.
+const char* roleName(IcomStream::Role r)
+{
+    switch (r) {
+    case IcomStream::Role::Control: return "control";
+    case IcomStream::Role::Serial:  return "CI-V";
+    case IcomStream::Role::Audio:   return "audio";
+    }
+    return "?";
+}
+
+}  // namespace
+
 bool IcomStream::bindOnly(const Config& config)
 {
     stop();
@@ -59,8 +76,8 @@ bool IcomStream::bindOnly(const Config& config)
                 ++m_counters.socketErrors;
                 m_counters.lastSocketError = m_socket
                     ? m_socket->errorString() : QStringLiteral("socket unavailable");
-                qCWarning(lcIcomStream) << "UDP socket error on role"
-                                        << int(m_config.role) << ':'
+                qCWarning(lcIcomStream) << "UDP socket error on the"
+                                        << roleName(m_config.role) << "stream:"
                                         << m_counters.lastSocketError;
             });
     if (!m_socket->bind(QHostAddress::AnyIPv4, config.localPort)) {
@@ -101,23 +118,6 @@ bool IcomStream::bindOnly(const Config& config)
     m_idleSince.start();
     return true;
 }
-
-namespace {
-
-// The three RS-BA1 streams fail independently and for different reasons, so a
-// failure that does not say which one failed sends the operator to the wrong
-// setting. Logged as a bare int() elsewhere in this file; a name costs nothing.
-const char* roleName(IcomStream::Role r)
-{
-    switch (r) {
-    case IcomStream::Role::Control: return "control";
-    case IcomStream::Role::Serial:  return "CI-V";
-    case IcomStream::Role::Audio:   return "audio";
-    }
-    return "?";
-}
-
-}  // namespace
 
 void IcomStream::beginHandshake()
 {
@@ -160,23 +160,46 @@ void IcomStream::beginHandshake()
                 // is the one cause the old message never suggested. A raw probe
                 // to the default port can even answer while the radio listens for
                 // RS-BA1 somewhere else, which reads as proof the port is right.
+                // The control stream is the one that proves the session-wide
+                // conditions. Media streams only handshake from
+                // openMediaStreams(), which is reached after m_authOk AND a
+                // granted stream request -- so by then Network Control is
+                // demonstrably on, the credentials are demonstrably good, and
+                // nobody else holds the session. Repeating those causes for a
+                // CI-V or audio timeout would point the operator at three
+                // settings that are provably fine, which is the misdirection
+                // this message exists to remove.
+                const QString causes = (m_config.role == Role::Control)
+                    ? QStringLiteral(
+                        "Check the radio's Network menu: that its port for this "
+                        "stream matches the one above, that Network Control is "
+                        "ON, that the user/password are set, and that no other "
+                        "client holds the session")
+                    : QStringLiteral(
+                        "The control stream connected, so Network Control and "
+                        "the credentials are good — check that this stream's "
+                        "port on the radio matches the one above");
                 emit failed(QStringLiteral(
                     "no answer from %1:%2 (%3 stream) after %4 attempts — the "
-                    "radio is not answering RS-BA1 on that port. Check the "
-                    "radio's Network menu: that its port for this stream matches "
-                    "the one above, that Network Control is ON, that the "
-                    "user/password are set, and that no other client holds the "
-                    "session")
+                    "radio is not answering RS-BA1 on that port. %5")
                         .arg(m_config.host.toString())
                         .arg(m_config.remotePort)
                         .arg(QString::fromLatin1(roleName(m_config.role)))
-                        .arg(kHandshakeAttempts));
+                        .arg(kHandshakeAttempts)
+                        .arg(causes));
                 return;
             }
             // Name the target on every line. Six identical lines that do not say
             // where they were sent read as an AetherSDR networking fault; the
             // address and port are what turn them into a radio-side check.
-            qCWarning(lcIcomStream)
+            //
+            // Deliberately still INF. A retry is not yet a failure -- a connect
+            // that succeeds on attempt 2 is a normal connect, and warning on
+            // each one would put up to 18 warnings on the log for a single
+            // failed connect across three streams. The terminal failure is the
+            // event worth the level, and IcomSession::fail already logs that at
+            // qCWarning. What was missing here was the TARGET, not the severity.
+            qCInfo(lcIcomStream)
                 << "no IAmHere from"
                 << QStringLiteral("%1:%2").arg(m_config.host.toString())
                                           .arg(m_config.remotePort)
@@ -313,7 +336,7 @@ void IcomStream::onReadyRead()
         // and no amount of logging at the dispatch sites can distinguish "the
         // radio said nothing" from "we ignored what it said".
         if (!isPing(asSpan(buf))) {
-            qCDebug(lcIcomStream) << "role" << int(m_config.role) << "RX" << buf.size()
+            qCDebug(lcIcomStream) << "role" << roleName(m_config.role) << "RX" << buf.size()
                                   << "bytes:" << buf.left(64).toHex(' ');
         }
         handleDatagram(buf);
@@ -351,7 +374,7 @@ void IcomStream::handleDatagram(const QByteArray& datagram)
         if (parseIAmHere(pkt, remote)) {
             m_remoteSid = remote;
             m_gotRemoteSid = true;
-            qCInfo(lcIcomStream) << int(m_config.role) << "got i-am-here, remote sid"
+            qCInfo(lcIcomStream) << roleName(m_config.role) << "got i-am-here, remote sid"
                                  << Qt::hex << remote;
             sendRawTwice(buildAreYouReady(m_localSid, m_remoteSid));
         }
@@ -363,7 +386,7 @@ void IcomStream::handleDatagram(const QByteArray& datagram)
             m_ready = true;
             if (m_handshakeTimer)
                 m_handshakeTimer->stop();
-            qCInfo(lcIcomStream) << int(m_config.role) << "handshake complete on local port"
+            qCInfo(lcIcomStream) << roleName(m_config.role) << "handshake complete on local port"
                                  << m_boundPort;
 
             // NO PERIODIC IDLES ON THE AUDIO STREAM.

--- a/src/core/backends/icom/IcomStream.cpp
+++ b/src/core/backends/icom/IcomStream.cpp
@@ -102,6 +102,23 @@ bool IcomStream::bindOnly(const Config& config)
     return true;
 }
 
+namespace {
+
+// The three RS-BA1 streams fail independently and for different reasons, so a
+// failure that does not say which one failed sends the operator to the wrong
+// setting. Logged as a bare int() elsewhere in this file; a name costs nothing.
+const char* roleName(IcomStream::Role r)
+{
+    switch (r) {
+    case IcomStream::Role::Control: return "control";
+    case IcomStream::Role::Serial:  return "CI-V";
+    case IcomStream::Role::Audio:   return "audio";
+    }
+    return "?";
+}
+
+}  // namespace
+
 void IcomStream::beginHandshake()
 {
     if (!m_socket)
@@ -136,14 +153,36 @@ void IcomStream::beginHandshake()
                 // simply says nothing. A deadline is the only way to report it,
                 // and now it is a deadline the radio has been asked repeatedly
                 // to beat.
+                //
+                // Port mismatch leads the causes because custom port triplets
+                // shipped in #5230: the radio and this client can now disagree
+                // about the port while both are configured and reachable, and it
+                // is the one cause the old message never suggested. A raw probe
+                // to the default port can even answer while the radio listens for
+                // RS-BA1 somewhere else, which reads as proof the port is right.
                 emit failed(QStringLiteral(
-                    "no answer from the radio after %1 attempts — check Network "
-                    "control is ON, the user/password are set, and no other "
-                    "client holds the session").arg(kHandshakeAttempts));
+                    "no answer from %1:%2 (%3 stream) after %4 attempts — the "
+                    "radio is not answering RS-BA1 on that port. Check the "
+                    "radio's Network menu: that its port for this stream matches "
+                    "the one above, that Network Control is ON, that the "
+                    "user/password are set, and that no other client holds the "
+                    "session")
+                        .arg(m_config.host.toString())
+                        .arg(m_config.remotePort)
+                        .arg(QString::fromLatin1(roleName(m_config.role)))
+                        .arg(kHandshakeAttempts));
                 return;
             }
-            qCInfo(lcIcomStream) << "no IAmHere yet — retrying AreYouThere, attempt"
-                                 << (m_handshakeAttempts + 1) << "of" << kHandshakeAttempts;
+            // Name the target on every line. Six identical lines that do not say
+            // where they were sent read as an AetherSDR networking fault; the
+            // address and port are what turn them into a radio-side check.
+            qCWarning(lcIcomStream)
+                << "no IAmHere from"
+                << QStringLiteral("%1:%2").arg(m_config.host.toString())
+                                          .arg(m_config.remotePort)
+                << "on the" << roleName(m_config.role) << "stream — retrying"
+                << "AreYouThere, attempt" << (m_handshakeAttempts + 1)
+                << "of" << kHandshakeAttempts;
             sendRawTwice(buildAreYouThere(m_localSid));
         });
     }


### PR DESCRIPTION
Closes #5253.

A handshake that gets no reply logged six identical `INF` lines and stopped, naming the
symptom (`no IAmHere`) but never the address, the port, or which of the three streams
failed. I spent about an hour treating a port mismatch as an AetherSDR networking bug.

## What the operator sees now

Before — six of these, then silence:

```
INF aether.icom.stream: no IAmHere yet — retrying AreYouThere, attempt 2 of 6
```

After:

```
WRN aether.icom.stream: no IAmHere from 10.0.0.8:50001 on the control stream —
    retrying AreYouThere, attempt 2 of 6
```

and the terminal failure, which reaches the operator through `IcomSession::fail`:

```
no answer from 10.0.0.8:50001 (control stream) after 6 attempts — the radio is not
answering RS-BA1 on that port. Check the radio's Network menu: that its port for this
stream matches the one above, that Network Control is ON, that the user/password are
set, and that no other client holds the session
```

## The framing in #5253 needs correcting, and the case is stronger than it was

The issue argued that **#5229** would make port mismatch more common once users could set
custom ports. That is out of date: #5229 was closed unmerged — I withdrew it after finding
a `QIntValidator` Principle VII defect in my own revision — and @jensenpat superseded it
with **#5230**, *"custom UDP port triplets for multi-radio NAT"*, which **merged on
2026-08-25**. `controlPort` is in `IcomSession.h:39` on `main` today.

So this is not a diagnostic gap ahead of a feature that might land. The feature landed
three days ago, and the mismatch these six identical lines fail to diagnose is a live
condition on current `main`. That is why port mismatch now **leads** the candidate causes
rather than being absent from them.

## Three changes, all log text

1. **Retry line names the target and the stream, and logs at `WRN`.** A stalled connect is
   not informational, and at `INF` it is easy to lose among the retries. `errorOccurred`
   directly above already uses `qCWarning`, so this matches its neighbour.
2. **Terminal failure names `host:port` and the role**, and leads with the port check.
3. **`roleName()`** replaces the bare `int()` the three streams are logged as elsewhere in
   this file — a failure now says `control` / `CI-V` / `audio` rather than `0` or `2`.
   The three streams fail independently and for different reasons, so a failure that does
   not say which one failed sends the operator to the wrong setting.

## Why the message has to say the port out loud

The intermediate evidence actively misleads. A raw UDP `AreYouThere` to the default
`:50001` returned a correct 16-byte `IAmHere` while the radio was listening for RS-BA1 on
custom ports — which I took as proof the port was right. I was one step from filing a bogus
"AetherSDR can't receive a datagram PowerShell can" issue.

## Deliberately not done

**No port probing.** Scanning 50001/50002/50003 for a listener would defeat the purpose of
#5230's custom ports, and probing a radio is a poor default. The problem was never that
AetherSDR could not find the port — it is that it would not say which port it used.

**No behaviour change.** Retry cadence, attempt count, and the handshake itself are
untouched. `roleName()` is file-local in an anonymous namespace.

## Verification

- **Builds clean** — `aethercore` via the project's `build.bat`, 54 steps, links, exit 0.
  No warnings on the changed file. I confirmed the object file postdates the edit rather
  than trusting the exit code; three earlier "successful" builds on this box had in fact
  compiled nothing.
- **Both strings rendered with their arguments substituted** and read end to end, rather
  than eyeballing the format string. An earlier revision reused `%2` twice; I removed that
  rather than rely on `.arg()` replacing every occurrence of the lowest marker, since I
  could not verify that behaviour in this build and there is no precedent for it in this
  tree. Each marker is now used exactly once, four `.arg()` calls.
- **UTF-8 checked** — 16 em dashes, 0 mojibake sequences; edited with Python, not
  PowerShell.

**Not exercised against hardware.** This is log text on a failure path, and reproducing it
means putting the IC-9700 back onto mismatched ports. I can do that on request, but I did
not think it justified for a string change that cannot alter control flow.
