### PR TITLE
fix(tnf): route the TNF removal status to removeTnf instead of a re-create

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -10116,11 +10116,25 @@ void RadioModel::onStatusReceived(const QString& object,
     }
 
     // TNF status: "tnf <id> freq=14.100000 width=100 depth=1 permanent=0"
-    static const QRegularExpression tnfRe(R"(^tnf\s+(\d+)$)");
+    //
+    // Removal arrives as "tnf <id> removed" (bare token, whole string lands in
+    // `object`) or "tnf <id> removed=1" (kv form, `object` == "tnf <id>").
+    // SmartSDR DOES send one on `tnf remove` — contrary to the long-standing
+    // assumption that it sends nothing — and feeding it through
+    // applyTnfStatus() re-creates the entry via QMap::operator[], so a
+    // just-removed notch reappears on the panadapter a beat after the click.
+    // Route the removal form to removeTnf() instead (a no-op if the optimistic
+    // removal in requestRemoveTnf() already dropped it).
+    static const QRegularExpression tnfRe(R"(^tnf\s+(\d+)(?:\s+removed)?$)");
     auto tnfMatch = tnfRe.match(object);
     if (tnfMatch.hasMatch()) {
-        int tnfId = tnfMatch.captured(1).toInt();
-        m_tnfModel.applyTnfStatus(tnfId, kvs);
+        const int tnfId = tnfMatch.captured(1).toInt();
+        if (kvs.contains(QStringLiteral("removed"))
+            || object.endsWith(QLatin1String("removed"))) {
+            m_tnfModel.removeTnf(tnfId);
+        } else {
+            m_tnfModel.applyTnfStatus(tnfId, kvs);
+        }
         return;
     }
 

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1545,6 +1545,13 @@ public:
     {
         handleSliceStatus(id, kvs, removed);
     }
+    // Feed a decoded status line straight into the router. Used to pin the TNF
+    // removal-status handling — the wire says the notch is gone, and the router
+    // must not upsert it back into TnfModel.
+    void handleStatusForTest(const QString& object, const QMap<QString, QString>& kvs)
+    {
+        onStatusReceived(object, kvs);
+    }
 
 private:
     PanadapterModel* resolveBackendPan(const QString& backendPanId);

--- a/tests/radiomodel_tnf_removal_status_test.cpp
+++ b/tests/radiomodel_tnf_removal_status_test.cpp
@@ -1,0 +1,65 @@
+// SmartSDR answers `tnf remove <id>` with a status line — "tnf <id> removed"
+// (bare token) or "tnf <id> removed=1" (kv form). The router used to match only
+// "tnf <id>" and hand every match to TnfModel::applyTnfStatus(), which upserts
+// via QMap::operator[]. So the removal status RE-CREATED the entry a beat after
+// the operator's click, and the notch reappeared on the panadapter with the
+// optimistic removal already done.
+//
+// This pins that the router routes both removal forms to removeTnf() and still
+// upserts a genuine "tnf <id> <fields>" line.
+
+#include "models/RadioModel.h"
+#include "models/TnfModel.h"
+
+#include <QCoreApplication>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+static void check(bool ok, const char* what)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", what);
+    if (!ok) ++g_failures;
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    RadioModel model;   // default family is Flex — the command plane this bug lives on
+
+    const QMap<QString, QString> tnf1 {
+        {"freq", "14.100000"}, {"width", "100"}, {"depth", "1"}, {"permanent", "0"},
+    };
+
+    // A normal TNF status creates the entry.
+    model.handleStatusForTest(QStringLiteral("tnf 1"), tnf1);
+    check(model.tnfModel().tnf(1) != nullptr, "a 'tnf 1 <fields>' status creates the entry");
+
+    // kv form: "tnf 1 removed=1" — object is still "tnf 1", removed lands in kvs.
+    model.handleStatusForTest(QStringLiteral("tnf 1"), {{"removed", "1"}});
+    check(model.tnfModel().tnf(1) == nullptr,
+          "'tnf 1 removed=1' removes the entry rather than re-creating it");
+    check(model.tnfModel().tnfs().isEmpty(), "no stray entries left after kv-form removal");
+
+    // Bare form: the whole string lands in `object` as "tnf 1 removed".
+    model.handleStatusForTest(QStringLiteral("tnf 1"), tnf1);
+    check(model.tnfModel().tnf(1) != nullptr, "re-created for the bare-form check");
+    model.handleStatusForTest(QStringLiteral("tnf 1 removed"), {});
+    check(model.tnfModel().tnf(1) == nullptr,
+          "'tnf 1 removed' (bare token) removes the entry");
+
+    // A removal for an id that was already dropped optimistically is a no-op,
+    // not a crash or a resurrected zero-value entry.
+    model.handleStatusForTest(QStringLiteral("tnf 7 removed"), {});
+    check(model.tnfModel().tnf(7) == nullptr, "removal of an unknown id is a harmless no-op");
+
+    // A genuine status still upserts — the removal branch must not have eaten
+    // the normal path.
+    model.handleStatusForTest(QStringLiteral("tnf 2"), tnf1);
+    check(model.tnfModel().tnf(2) != nullptr, "a normal 'tnf 2 <fields>' status still creates an entry");
+
+    if (g_failures == 0) std::printf("ALL PASS\n");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3061,6 +3061,11 @@ target_include_directories(radiomodel_pan_id_mapping_test PRIVATE src)
 target_link_libraries(radiomodel_pan_id_mapping_test PRIVATE aethercore Qt6::Core Qt6::Test)
 add_test(NAME radiomodel_pan_id_mapping_test COMMAND radiomodel_pan_id_mapping_test)
 
+add_executable(radiomodel_tnf_removal_status_test tests/radiomodel_tnf_removal_status_test.cpp)
+target_include_directories(radiomodel_tnf_removal_status_test PRIVATE src)
+target_link_libraries(radiomodel_tnf_removal_status_test PRIVATE aethercore Qt6::Core Qt6::Test)
+add_test(NAME radiomodel_tnf_removal_status_test COMMAND radiomodel_tnf_removal_status_test)
+
 # CAT/rigctld retune policy (#4497). The pan recenter is radio-side and the only
 # lever is the autopan=0 flag on "slice tune", which the CAT integration suites
 # cannot observe — reverting the recenter arm leaves all three of them green. So


### PR DESCRIPTION
## Symptom

Removing a TNF (tracking notch filter) from the panadapter does nothing visible. The command reaches the radio and is accepted, but the notch stays drawn and stays active:

```
TX: "C34603|tnf remove 1"
RX: "R34603|0|"
```

The operator clicks Remove, the radio says OK, and the notch is still there.

## Root cause

`RadioModel::onStatusReceived()` routed TNF status like this:

```cpp
// TNF status: "tnf <id> freq=14.100000 width=100 depth=1 permanent=0"
static const QRegularExpression tnfRe(R"(^tnf\s+(\d+)$)");
auto tnfMatch = tnfRe.match(object);
if (tnfMatch.hasMatch()) {
    int tnfId = tnfMatch.captured(1).toInt();
    m_tnfModel.applyTnfStatus(tnfId, kvs);   // <-- always an upsert
    return;
}
```

`TnfModel::applyTnfStatus()` upserts:

```cpp
void TnfModel::applyTnfStatus(int id, const QMap<QString, QString>& kvs)
{
    auto& t = m_tnfs[id];   // QMap::operator[] — creates the entry if absent
    t.id = id;
    ...
    emit tnfChanged(id);
}
```

SmartSDR **does** answer `tnf remove <id>` with a status line — `tnf <id> removed` (bare token, whole string lands in `object`) or `tnf <id> … removed=1` (kv form, `object` stays `"tnf <id>"`, `removed` lands in `kvs`). Both were fed straight into `applyTnfStatus()`, which **re-created** the entry through `QMap::operator[]` a beat after `TnfModel::requestRemoveTnf()` had already removed it optimistically:

```cpp
void TnfModel::requestRemoveTnf(int id)
{
    emit notchRemoveRequested(id);
    // Radio does not send a removal status — remove optimistically
    removeTnf(id);
}
```

That comment — "Radio does not send a removal status" — is the wrong assumption the whole bug rests on. The radio sends one, and the router read it as an upsert. `MainWindow_Wiring`'s `rebuildTnfMarkers()` is connected to `tnfChanged`, so the re-created entry was immediately redrawn on the panadapter.

The bare form (`tnf 1 removed`) does not even match `^tnf\s+(\d+)$`, so on some firmware it was silently dropped and the optimistic removal happened to stick — which is likely why this went unnoticed for so long. The kv form (`removed=1`) is the one that resurrects.

## Fix

`src/models/RadioModel.cpp` — recognise the removal forms and route them to `TnfModel::removeTnf()` instead of `applyTnfStatus()`:

```cpp
static const QRegularExpression tnfRe(R"(^tnf\s+(\d+)(?:\s+removed)?$)");
auto tnfMatch = tnfRe.match(object);
if (tnfMatch.hasMatch()) {
    const int tnfId = tnfMatch.captured(1).toInt();
    if (kvs.contains(QStringLiteral("removed"))
        || object.endsWith(QLatin1String("removed"))) {
        m_tnfModel.removeTnf(tnfId);
    } else {
        m_tnfModel.applyTnfStatus(tnfId, kvs);
    }
    return;
}
```

- **Both forms handled** — bare trailing token and `removed=1` kv, matching the two-form (`object.endsWith("removed") || kvs.contains("removed")`) pattern already used in this same function for `display pan`, `display waterfall`, `amplifier`, `memory`, and slices.
- **Harmless if the radio sends nothing** on removal — `TnfModel::removeTnf()` guards on `QMap::remove(id)` returning non-zero, so a duplicate of the optimistic removal is a no-op and does not double-emit `tnfRemoved`.
- **A genuine `tnf <id> <fields>` status still upserts** — the removal branch only diverts when a `removed` token is actually present.
- No change to `TnfModel` or the wire; this is purely the client-side status router.

## Tests

New `tests/radiomodel_tnf_removal_status_test.cpp`, wired into `tests/tests.cmake`, plus a `handleStatusForTest()` shim on `RadioModel` alongside the existing `handleSliceStatusForTest()` (the router is a `private slot`):

| Case | Assertion |
|---|---|
| `tnf 1 <fields>` | entry is created |
| `tnf 1 … removed=1` (kv form) | entry is **removed**, not re-created; no stray entries |
| `tnf 1 removed` (bare token) | entry is removed |
| `tnf 7 removed` for an unknown id | harmless no-op, no resurrected zero-value entry |
| `tnf 2 <fields>` after a removal | still upserts — the removal branch didn't eat the normal path |

Passes locally on Windows (MSVC/Qt 6.11). CI builds it on Linux/macOS/Windows.

## Manual testing — FLEX-6600 (Windows)

Verified against a FLEX-6600 with a local Windows build of this branch: placing a TNF and clicking **Remove** now clears it from the panadapter and it stays cleared, with `tnf remove <id>` → `R…|0|` on the wire as before. Before the fix the same sequence left the notch drawn and active.

This one is awkward to reproduce on demand (depends on the radio actually emitting the removal-status line), which is why the regression test pins both documented forms at the router level rather than relying on a live radio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
