### PR TITLE
fix(gui): keep connection dialog visible at startup

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2450,7 +2450,7 @@ MainWindow::MainWindow(QWidget* parent)
         m_connPanel->setStatusText("Looking for your radio…");
         setPanadapterConnectionAnimation(true, "Looking for your radio…");
     } else if (!autoConnectToLastRadio) {
-        QTimer::singleShot(0, this, &MainWindow::toggleConnectionDialog);
+        QTimer::singleShot(0, this, &MainWindow::showConnectionDialog);
     }
 
     // Auto-connect to routed radios (probed, not broadcast-discovered)
@@ -2564,8 +2564,8 @@ MainWindow::MainWindow(QWidget* parent)
 
     // Auto-popup connection dialog if no saved radio
     QString lastSerial = s.value("LastConnectedRadioSerial", "").toString();
-    if (lastSerial.isEmpty()) {
-        QTimer::singleShot(500, this, [this]() { toggleConnectionDialog(); });
+    if (lastSerial.isEmpty() && autoConnectToLastRadio) {
+        QTimer::singleShot(500, this, [this]() { showConnectionDialog(); });
     }
 
     // Restore the Memory dialog if it was open when the app last exited.

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2451,6 +2451,10 @@ MainWindow::MainWindow(QWidget* parent)
         setPanadapterConnectionAnimation(true, "Looking for your radio…");
     } else if (!autoConnectToLastRadio) {
         QTimer::singleShot(0, this, &MainWindow::showConnectionDialog);
+    } else {
+        // No saved radio exists for the enabled auto-connect path. Delay until
+        // the main window is mapped, matching the established first-run flow.
+        QTimer::singleShot(500, this, [this]() { showConnectionDialog(); });
     }
 
     // Auto-connect to routed radios (probed, not broadcast-discovered)
@@ -2561,12 +2565,6 @@ MainWindow::MainWindow(QWidget* parent)
         }
         m_splitter->setSizes(sizes);
     });
-
-    // Auto-popup connection dialog if no saved radio
-    QString lastSerial = s.value("LastConnectedRadioSerial", "").toString();
-    if (lastSerial.isEmpty() && autoConnectToLastRadio) {
-        QTimer::singleShot(500, this, [this]() { showConnectionDialog(); });
-    }
 
     // Restore the Memory dialog if it was open when the app last exited.
     QTimer::singleShot(0, this, [this]() {

--- a/tests/connection_panel_size_test.cpp
+++ b/tests/connection_panel_size_test.cpp
@@ -11,6 +11,7 @@
 #include <QApplication>
 #include <QComboBox>
 #include <QFont>
+#include <QFile>
 #include <QJsonDocument>
 #include <QLabel>
 #include <QLayout>
@@ -461,6 +462,23 @@ int main(int argc, char** argv)
         qputenv("QT_QPA_PLATFORM", "offscreen");
     }
     QApplication app(argc, argv);
+
+    // MainWindow is intentionally not linked into this focused widget target.
+    // Pin its two startup call sites instead: both can be scheduled when
+    // auto-connect is disabled and no last-radio serial exists. They must be
+    // idempotent show requests, because a second toggle hides the dialog that
+    // the first timer just opened.
+    QFile mainWindowSource(QStringLiteral(AETHER_SOURCE_DIR "/src/gui/MainWindow.cpp"));
+    report("startup dialog test can inspect MainWindow",
+           mainWindowSource.open(QIODevice::ReadOnly));
+    const QByteArray mainWindowText = mainWindowSource.readAll();
+    report("auto-connect opt-out idempotently shows connection dialog",
+           mainWindowText.contains(
+               "QTimer::singleShot(0, this, &MainWindow::showConnectionDialog);"));
+    report("missing-radio fallback idempotently shows connection dialog",
+           mainWindowText.contains("if (lastSerial.isEmpty() && autoConnectToLastRadio) {")
+               && mainWindowText.contains(
+                   "QTimer::singleShot(500, this, [this]() { showConnectionDialog(); });"));
     AppSettings::instance().load();
     std::printf("ConnectionPanel screen-fit test harness (#4515)\n\n");
 

--- a/tests/connection_panel_size_test.cpp
+++ b/tests/connection_panel_size_test.cpp
@@ -464,21 +464,42 @@ int main(int argc, char** argv)
     QApplication app(argc, argv);
 
     // MainWindow is intentionally not linked into this focused widget target.
-    // Pin its two startup call sites instead: both can be scheduled when
-    // auto-connect is disabled and no last-radio serial exists. They must be
-    // idempotent show requests, because a second toggle hides the dialog that
-    // the first timer just opened.
+    // Pin the consolidated startup policy instead: each settings combination
+    // must schedule at most one idempotent show request, while the two real
+    // operator entry points retain deliberate toggle behavior.
     QFile mainWindowSource(QStringLiteral(AETHER_SOURCE_DIR "/src/gui/MainWindow.cpp"));
     report("startup dialog test can inspect MainWindow",
            mainWindowSource.open(QIODevice::ReadOnly));
     const QByteArray mainWindowText = mainWindowSource.readAll();
+    const qsizetype startupPolicyStart = mainWindowText.indexOf(
+        "// Saved-radio autoconnect is controlled solely");
+    const qsizetype startupPolicyEnd = mainWindowText.indexOf(
+        "// Auto-connect to routed radios", startupPolicyStart);
+    const QByteArray startupPolicy = mainWindowText.mid(
+        startupPolicyStart, startupPolicyEnd - startupPolicyStart);
+    report("connection dialog startup policy remains one adjacent block",
+           startupPolicyStart >= 0 && startupPolicyEnd > startupPolicyStart);
     report("auto-connect opt-out idempotently shows connection dialog",
-           mainWindowText.contains(
+           startupPolicy.contains(
                "QTimer::singleShot(0, this, &MainWindow::showConnectionDialog);"));
     report("missing-radio fallback idempotently shows connection dialog",
-           mainWindowText.contains("if (lastSerial.isEmpty() && autoConnectToLastRadio) {")
-               && mainWindowText.contains(
-                   "QTimer::singleShot(500, this, [this]() { showConnectionDialog(); });"));
+           startupPolicy.contains(
+               "QTimer::singleShot(500, this, [this]() { showConnectionDialog(); });"));
+    report("startup policy never toggles an already-visible dialog",
+           !startupPolicy.contains("toggleConnectionDialog"));
+
+    QFile menuSource(QStringLiteral(AETHER_SOURCE_DIR "/src/gui/MainWindow_Menus.cpp"));
+    report("startup dialog test can inspect the Settings menu",
+           menuSource.open(QIODevice::ReadOnly));
+    report("Settings menu retains deliberate toggle behavior",
+           menuSource.readAll().contains("toggleConnectionDialog();"));
+
+    QFile shortcutSource(
+        QStringLiteral(AETHER_SOURCE_DIR "/src/gui/MainWindow_Shortcuts.cpp"));
+    report("startup dialog test can inspect keyboard shortcuts",
+           shortcutSource.open(QIODevice::ReadOnly));
+    report("keyboard shortcut retains deliberate toggle behavior",
+           shortcutSource.readAll().contains("toggleConnectionDialog();"));
     AppSettings::instance().load();
     std::printf("ConnectionPanel screen-fit test harness (#4515)\n\n");
 

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3638,6 +3638,8 @@ target_include_directories(connection_panel_size_test PRIVATE src tests)
 target_link_libraries(connection_panel_size_test PRIVATE
     aethercore Qt6::Core Qt6::Network Qt6::Widgets Qt6::Test
 )
+target_compile_definitions(connection_panel_size_test PRIVATE
+    AETHER_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 set_target_properties(connection_panel_size_test PROPERTIES AUTOMOC ON)
 add_test(NAME connection_panel_size_test COMMAND connection_panel_size_test)
 set_tests_properties(connection_panel_size_test PROPERTIES


### PR DESCRIPTION
## Summary

- consolidate the connection-window startup policy into one adjacent decision chain;
- make both startup paths call `showConnectionDialog()` instead of toggling visibility;
- limit the delayed no-saved-radio fallback to the auto-connect-enabled case, so each settings combination schedules exactly one show request; and
- extend `connection_panel_size_test` to guard the consolidated startup block while proving the Settings menu and keyboard shortcut retain deliberate toggle behavior.

Fixes #5333.

## Root cause

With `AutoConnectToLastRadio=False` and an empty `LastConnectedRadioSerial`, startup scheduled two calls to `toggleConnectionDialog()`: one immediately and another after 500 ms. The first opened the window and the second closed it. The shared startup code made the defect possible on every platform, while it was observed on macOS.

## Behavior and scope

| Auto-connect | Saved serial | Result after this change |
|---|---|---|
| Off | Present | Show immediately |
| Off | Empty | Show immediately |
| On | Empty | Show after the existing 500 ms delay |
| On | Present | Preserve the existing automatic-connect path |

The Settings menu continues to use `toggleConnectionDialog()` for deliberate operator toggling. No connection, discovery, settings-persistence, visual-design, or radio behavior changes.

## Validation

- `cmake --build /private/tmp/aethersdr-startup-build --target connection_panel_size_test -j6`
- `ctest --test-dir /private/tmp/aethersdr-startup-build --output-on-failure -R '^connection_panel_size_test$' --no-tests=error`
  - 1/1 passed
- Mutation checks: restoring either startup callback to `toggleConnectionDialog()` makes `connection_panel_size_test` fail; restoring the fix makes it pass.
- Full `AetherSDR` target built successfully on macOS after bypassing an unrelated local `iconutil: Invalid Iconset` packaging failure by omitting only the generated icon from the diagnostic build graph. The temporary CMake edit was reverted and is not part of this diff.
- The fixed app was launched with the operator's normal macOS settings database; the operator confirmed the startup behavior is improved and the connection window remains available.
- `python3 tools/check_test_registration.py --strict`
- `python3 tools/check_engine_boundary.py --strict`
  - 0 blocking findings; existing baseline warnings only
- `python3 tools/check_a11y.py`
  - warning-only existing findings; none introduced by this change
- `python3 tools/audit_colours.py --src src --compare-src /private/tmp/aethersdr-startup-base/src --summary-only --strict`
  - 613 unique colors, 2,724 references, and 1,090 `setStyleSheet()` call sites on both trees
- `git diff --check`

## Test boundary

The focused target intentionally does not link the full `MainWindow`. Its source-contract assertions pin the consolidated shipping startup policy, reject any startup toggle, and preserve the Settings-menu and keyboard-shortcut toggle paths. The existing runtime portion continues to exercise `ConnectionPanel` itself. Mutation checks demonstrate that restoring either faulty startup toggle is rejected.

No synthetic radio peer or new socket-owning test was added.

## Documentation read

- `AGENTS.md`
- `CONSTITUTION.md`
- `GOVERNANCE.md`
- `CONTRIBUTING.md`
- `docs/DEVELOPER-GUIDE.md`
- `docs/PR-WORKFLOW.md`
- `docs/a11y.md`
- `docs/architecture/mainwindow-decomposition.md`
- private shared and AetherSDR developer guidance

## Constitution principle honored

Principle XI — the regression is demonstrated by a focused guard and a mutation check that fails when the faulty startup toggle is restored.

## Notes

- No `CHANGELOG.md` entry was added, per project guidance.
- GitHub rejected the required issue self-assignment because `w5jwp` is not an assignable collaborator on the upstream repository. Issue #5333 was confirmed unassigned before the attempt, and the failure was recorded on the issue.
