### PR TITLE
Synchronize TGXL startup state before presence

### DIFF
--- a/src/core/backends/TunerDelta.h
+++ b/src/core/backends/TunerDelta.h
@@ -18,6 +18,7 @@ namespace AetherSDR {
 // "tuner.*", …) (#4092). The direct port-9010 relay/antenna fast-path and the
 // direct-connection fwd-power/SWR meters are set outside this decode.
 struct TunerDelta {
+    std::optional<QString> handle;       // normalized tuner identity
     std::optional<QString> serialNum;    // "serial_num"
     std::optional<QString> model;
     std::optional<QString> ip;

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -985,9 +985,9 @@ void FlexBackend::decodeAmplifierStatus(const QString& handle, const QString& mo
 
 void FlexBackend::decodeTunerStatus(const QString& handle, const QMap<QString, QString>& kvs)
 {
-    // Cache the TGXL handle for the encode path (#4198). RadioModel passes the
-    // handle it already extracted+sanitized (never the 0x00000000 placeholder),
-    // so the tuner intents no longer carry a Flex identifier through the seam.
+    // Cache the TGXL handle for the encode path (#4198). A first status can
+    // carry 0x00000000 before the real handle is assigned; carry that identity
+    // in the delta for parity, but never cache it for outgoing tuner commands.
     if (!handle.isEmpty() && handle != QLatin1String("0x00000000"))
         m_tunerHandle = handle;
     // Present-only, strict parity with the prior TunerModel::applyStatus: bools

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -986,15 +986,15 @@ void FlexBackend::decodeAmplifierStatus(const QString& handle, const QString& mo
 void FlexBackend::decodeTunerStatus(const QString& handle, const QMap<QString, QString>& kvs)
 {
     // Cache the TGXL handle for the encode path (#4198). A first status can
-    // carry 0x00000000 before the real handle is assigned; carry that identity
-    // in the delta for parity, but never cache it for outgoing tuner commands.
+    // carry 0x00000000 before the real handle is assigned; keep that SmartSDR
+    // placeholder out of both the neutral delta and outgoing tuner commands.
     if (!handle.isEmpty() && handle != QLatin1String("0x00000000"))
         m_tunerHandle = handle;
     // Present-only, strict parity with the prior TunerModel::applyStatus: bools
     // are "1"-equality, ints are unguarded toInt() (matching val.toInt()), text
     // is verbatim. The change-gating / edge signals live in TunerModel::applyChanges.
     TunerDelta d;
-    if (!handle.isEmpty()) {
+    if (!handle.isEmpty() && handle != QLatin1String("0x00000000")) {
         d.handle = handle;
     }
     if (kvs.contains(QStringLiteral("serial_num")))

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -994,6 +994,9 @@ void FlexBackend::decodeTunerStatus(const QString& handle, const QMap<QString, Q
     // are "1"-equality, ints are unguarded toInt() (matching val.toInt()), text
     // is verbatim. The change-gating / edge signals live in TunerModel::applyChanges.
     TunerDelta d;
+    if (!handle.isEmpty()) {
+        d.handle = handle;
+    }
     if (kvs.contains(QStringLiteral("serial_num")))
         d.serialNum = kvs.value(QStringLiteral("serial_num"));
     if (kvs.contains(QStringLiteral("model")))

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -10039,12 +10039,21 @@ void RadioModel::onStatusReceived(const QString& object,
             if (model == "TunerGeniusXL" || handle == m_tunerModel.handle()) {
                 // Decode identity and state as one delta so first presence
                 // observers cannot read default operate/bypass values.
-                if (handle != "0x00000000" && handle != m_tunerModel.handle()) {
-                    m_meterModel.setTgxlHandle(handle.toUInt(nullptr, 0));
-                } else if (m_tunerModel.handle().isEmpty()) {
+                if (handle != "0x00000000"
+                    && handle != m_tunerModel.handle()) {
                     m_meterModel.setTgxlHandle(handle.toUInt(nullptr, 0));
                 }
-                if (m_flexBackend) m_flexBackend->decodeTunerStatus(handle, kvs);   // #4092/#4198
+                if (m_flexBackend) {
+                    m_flexBackend->decodeTunerStatus(handle, kvs);   // #4092/#4198
+                } else if (!handle.isEmpty()
+                           && handle != QLatin1String("0x00000000")) {
+                    // Captured status replay in demo/sim has no Flex decoder.
+                    // Preserve the old backend-neutral identity path without
+                    // teaching RadioModel to decode SmartSDR tuner fields.
+                    TunerDelta identity;
+                    identity.handle = handle;
+                    m_tunerModel.applyChanges(identity);
+                }
             }
             // Power amplifier (PGXL / any non-TGXL amp) → AmpModel. `else` of the
             // tuner branch: a TGXL status is already routed above and would only

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -9961,11 +9961,14 @@ void RadioModel::onStatusReceived(const QString& object,
     static const QRegularExpression atuRe(R"(^atu\s+(\S+)$)");
     if (object.startsWith("atu")) {
         const auto m = atuRe.match(object);
-        if (m.hasMatch() && m_tunerModel.handle().isEmpty())
-            m_tunerModel.setHandle(m.captured(1));
         if (m_flexBackend) m_flexBackend->decodeAtuStatus(kvs);   // radio's own ATU → TransmitModel
-        if (m_tunerModel.isPresent() && m_flexBackend)
-            m_flexBackend->decodeTunerStatus(m_tunerModel.handle(), kvs);  // external TGXL → TunerModel (#4092/#4198)
+        QString tunerHandle = m_tunerModel.handle();
+        if (m.hasMatch() && tunerHandle.isEmpty()) {
+            tunerHandle = m.captured(1);
+        }
+        if ((!tunerHandle.isEmpty() || m_tunerModel.isPresent()) && m_flexBackend) {
+            m_flexBackend->decodeTunerStatus(tunerHandle, kvs);  // external TGXL → TunerModel (#4092/#4198)
+        }
         return;
     }
 
@@ -10034,16 +10037,14 @@ void RadioModel::onStatusReceived(const QString& object,
 
             // Route TunerGeniusXL to TunerModel
             if (model == "TunerGeniusXL" || handle == m_tunerModel.handle()) {
-                // Always update handle — first status may arrive with 0x00000000
-                // before the real handle is assigned
+                // Decode identity and state as one delta so first presence
+                // observers cannot read default operate/bypass values.
                 if (handle != "0x00000000" && handle != m_tunerModel.handle()) {
-                    m_tunerModel.setHandle(handle);
                     m_meterModel.setTgxlHandle(handle.toUInt(nullptr, 0));
                 } else if (m_tunerModel.handle().isEmpty()) {
-                    m_tunerModel.setHandle(handle);
                     m_meterModel.setTgxlHandle(handle.toUInt(nullptr, 0));
                 }
-                if (m_flexBackend) m_flexBackend->decodeTunerStatus(m_tunerModel.handle(), kvs);   // #4092/#4198
+                if (m_flexBackend) m_flexBackend->decodeTunerStatus(handle, kvs);   // #4092/#4198
             }
             // Power amplifier (PGXL / any non-TGXL amp) → AmpModel. `else` of the
             // tuner branch: a TGXL status is already routed above and would only

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -10036,10 +10036,7 @@ void RadioModel::onStatusReceived(const QString& object,
             }
 
             // Route TunerGeniusXL to TunerModel
-            const bool replacingPlaceholder =
-                m_tunerModel.handle() == QLatin1String("0x00000000");
-            if (model == "TunerGeniusXL" || handle == m_tunerModel.handle()
-                || replacingPlaceholder) {
+            if (model == "TunerGeniusXL" || handle == m_tunerModel.handle()) {
                 // Decode identity and state as one delta so first presence
                 // observers cannot read default operate/bypass values.
                 if (handle != "0x00000000" && handle != m_tunerModel.handle()) {

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -10036,7 +10036,10 @@ void RadioModel::onStatusReceived(const QString& object,
             }
 
             // Route TunerGeniusXL to TunerModel
-            if (model == "TunerGeniusXL" || handle == m_tunerModel.handle()) {
+            const bool replacingPlaceholder =
+                m_tunerModel.handle() == QLatin1String("0x00000000");
+            if (model == "TunerGeniusXL" || handle == m_tunerModel.handle()
+                || replacingPlaceholder) {
                 // Decode identity and state as one delta so first presence
                 // observers cannot read default operate/bypass values.
                 if (handle != "0x00000000" && handle != m_tunerModel.handle()) {

--- a/src/models/TunerModel.cpp
+++ b/src/models/TunerModel.cpp
@@ -36,8 +36,8 @@ void TunerModel::applyChanges(const TunerDelta& d)
     // antennaAChanged (key "antA") precedes tuningChanged (key "tuning").
     const bool wasPresent = isPresent();
     bool changed = false;
-    std::optional<int> antennaAChanged;
-    std::optional<bool> tuningChanged;
+    std::optional<int> pendingAntennaA;
+    std::optional<bool> pendingTuning;
 
     if (d.handle && m_handle != *d.handle)           { m_handle = *d.handle;       changed = true; }
     if (d.serialNum && m_serialNum != *d.serialNum) { m_serialNum = *d.serialNum; changed = true; }
@@ -47,12 +47,12 @@ void TunerModel::applyChanges(const TunerDelta& d)
     if (d.antennaA && m_antennaA != *d.antennaA) {
         m_antennaA = *d.antennaA;
         changed = true;
-        antennaAChanged = m_antennaA;
+        pendingAntennaA = m_antennaA;
     }
     if (d.tuning && m_tuning != *d.tuning) {
         m_tuning = *d.tuning;
         changed = true;
-        tuningChanged = m_tuning;
+        pendingTuning = m_tuning;
     }
     if (d.relayC1 && m_relayC1 != *d.relayC1) { m_relayC1 = *d.relayC1; changed = true; }
     if (d.relayC2 && m_relayC2 != *d.relayC2) { m_relayC2 = *d.relayC2; changed = true; }
@@ -64,11 +64,11 @@ void TunerModel::applyChanges(const TunerDelta& d)
     if (wasPresent != nowPresent) {
         emit presenceChanged(nowPresent);
     }
-    if (antennaAChanged) {
-        emit this->antennaAChanged(*antennaAChanged);  // "antA" sorts before "tuning"
+    if (pendingAntennaA) {
+        emit antennaAChanged(*pendingAntennaA);  // "antA" sorts before "tuning"
     }
-    if (tuningChanged) {
-        emit this->tuningChanged(*tuningChanged);
+    if (pendingTuning) {
+        emit tuningChanged(*pendingTuning);
     }
     if (changed) {
         emit stateChanged();

--- a/src/models/TunerModel.cpp
+++ b/src/models/TunerModel.cpp
@@ -34,8 +34,10 @@ void TunerModel::applyChanges(const TunerDelta& d)
     // fields (nickname/version/ant/dhcp/netmask/gateway/ptta/pttb) are dropped there.
     // Edge-signal emit order matches the old QMap key-sorted iteration:
     // antennaAChanged (key "antA") precedes tuningChanged (key "tuning").
+    const bool wasPresent = isPresent();
     bool changed = false;
 
+    if (d.handle && m_handle != *d.handle)           { m_handle = *d.handle;       changed = true; }
     if (d.serialNum && m_serialNum != *d.serialNum) { m_serialNum = *d.serialNum; changed = true; }
     if (d.model && m_model != *d.model)             { m_model = *d.model;         changed = true; }
     if (d.operate && m_operate != *d.operate)       { m_operate = *d.operate;     changed = true; }
@@ -56,8 +58,13 @@ void TunerModel::applyChanges(const TunerDelta& d)
     if (d.oneByThree && m_oneByThree != *d.oneByThree) { m_oneByThree = *d.oneByThree; changed = true; }
     if (d.ip && m_tgxlIp != *d.ip)                     { m_tgxlIp = *d.ip;              changed = true; }
 
-    if (changed)
+    const bool nowPresent = isPresent();
+    if (wasPresent != nowPresent) {
+        emit presenceChanged(nowPresent);
+    }
+    if (changed) {
         emit stateChanged();
+    }
 }
 
 // ── Commands ─────────────────────────────────────────────────────────────────

--- a/src/models/TunerModel.cpp
+++ b/src/models/TunerModel.cpp
@@ -36,6 +36,8 @@ void TunerModel::applyChanges(const TunerDelta& d)
     // antennaAChanged (key "antA") precedes tuningChanged (key "tuning").
     const bool wasPresent = isPresent();
     bool changed = false;
+    std::optional<int> antennaAChanged;
+    std::optional<bool> tuningChanged;
 
     if (d.handle && m_handle != *d.handle)           { m_handle = *d.handle;       changed = true; }
     if (d.serialNum && m_serialNum != *d.serialNum) { m_serialNum = *d.serialNum; changed = true; }
@@ -45,12 +47,12 @@ void TunerModel::applyChanges(const TunerDelta& d)
     if (d.antennaA && m_antennaA != *d.antennaA) {
         m_antennaA = *d.antennaA;
         changed = true;
-        emit antennaAChanged(m_antennaA);        // "antA" sorts before "tuning"
+        antennaAChanged = m_antennaA;
     }
     if (d.tuning && m_tuning != *d.tuning) {
         m_tuning = *d.tuning;
         changed = true;
-        emit tuningChanged(m_tuning);
+        tuningChanged = m_tuning;
     }
     if (d.relayC1 && m_relayC1 != *d.relayC1) { m_relayC1 = *d.relayC1; changed = true; }
     if (d.relayC2 && m_relayC2 != *d.relayC2) { m_relayC2 = *d.relayC2; changed = true; }
@@ -61,6 +63,12 @@ void TunerModel::applyChanges(const TunerDelta& d)
     const bool nowPresent = isPresent();
     if (wasPresent != nowPresent) {
         emit presenceChanged(nowPresent);
+    }
+    if (antennaAChanged) {
+        emit this->antennaAChanged(*antennaAChanged);  // "antA" sorts before "tuning"
+    }
+    if (tuningChanged) {
+        emit this->tuningChanged(*tuningChanged);
     }
     if (changed) {
         emit stateChanged();

--- a/tests/aetherd_tuner_decode_test.cpp
+++ b/tests/aetherd_tuner_decode_test.cpp
@@ -16,10 +16,11 @@ static int g_failures = 0;
 #define CHECK(cond) do { if (!(cond)) { \
     std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failures; } } while (0)
 
-static TunerDelta decode(FlexBackend& b, const QMap<QString, QString>& kvs)
+static TunerDelta decode(FlexBackend& b, const QMap<QString, QString>& kvs,
+                         const QString& handle = QStringLiteral("0x2000"))
 {
     QSignalSpy spy(&b, &IRadioBackend::tunerChanged);
-    b.decodeTunerStatus(QStringLiteral("0x2000"), kvs);
+    b.decodeTunerStatus(handle, kvs);
     if (spy.count() != 1) return {};
     return spy.takeFirst().at(0).value<TunerDelta>();
 }
@@ -55,6 +56,16 @@ int main(int argc, char** argv)
         CHECK(d.operate.has_value() && *d.operate == true);
         CHECK(!d.bypass.has_value() && !d.relayC1.has_value()
               && !d.model.has_value() && !d.antennaA.has_value());
+    }
+
+    // ---- SmartSDR's placeholder never becomes neutral tuner identity ----
+    {
+        const TunerDelta d = decode(b, {{"model", "TunerGeniusXL"},
+                                        {"operate", "1"}},
+                                    QStringLiteral("0x00000000"));
+        CHECK(!d.handle.has_value());
+        CHECK(d.model.has_value() && *d.model == "TunerGeniusXL");
+        CHECK(d.operate.has_value() && *d.operate == true);
     }
 
     // ---- informational keys (nickname/version/gateway/…) are dropped ----

--- a/tests/aetherd_tuner_decode_test.cpp
+++ b/tests/aetherd_tuner_decode_test.cpp
@@ -16,10 +16,11 @@ static int g_failures = 0;
 #define CHECK(cond) do { if (!(cond)) { \
     std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failures; } } while (0)
 
-static TunerDelta decode(FlexBackend& b, const QMap<QString, QString>& kvs)
+static TunerDelta decode(FlexBackend& b, const QMap<QString, QString>& kvs,
+                         const QString& handle = QStringLiteral("0x2000"))
 {
     QSignalSpy spy(&b, &IRadioBackend::tunerChanged);
-    b.decodeTunerStatus(QStringLiteral("0x2000"), kvs);
+    b.decodeTunerStatus(handle, kvs);
     if (spy.count() != 1) return {};
     return spy.takeFirst().at(0).value<TunerDelta>();
 }
@@ -47,6 +48,18 @@ int main(int argc, char** argv)
         CHECK(d.antennaA.has_value() && *d.antennaA == 2);
         CHECK(d.oneByThree.has_value() && *d.oneByThree == true);
         CHECK(d.ip.has_value() && *d.ip == "10.0.0.5");
+    }
+
+    // ---- placeholder identity is carried until a real handle arrives ----
+    {
+        const TunerDelta placeholder = decode(
+            b, {{"model", "TunerGeniusXL"}}, QStringLiteral("0x00000000"));
+        CHECK(placeholder.handle.has_value()
+              && *placeholder.handle == "0x00000000");
+
+        const TunerDelta real = decode(
+            b, {{"operate", "1"}}, QStringLiteral("0x2001"));
+        CHECK(real.handle.has_value() && *real.handle == "0x2001");
     }
 
     // ---- present-only: absent keys stay disengaged ----

--- a/tests/aetherd_tuner_decode_test.cpp
+++ b/tests/aetherd_tuner_decode_test.cpp
@@ -19,7 +19,7 @@ static int g_failures = 0;
 static TunerDelta decode(FlexBackend& b, const QMap<QString, QString>& kvs)
 {
     QSignalSpy spy(&b, &IRadioBackend::tunerChanged);
-    b.decodeTunerStatus(QStringLiteral("0x2000"), kvs);   // handle unused by these delta-field checks (#4198)
+    b.decodeTunerStatus(QStringLiteral("0x2000"), kvs);
     if (spy.count() != 1) return {};
     return spy.takeFirst().at(0).value<TunerDelta>();
 }
@@ -37,6 +37,7 @@ int main(int argc, char** argv)
             {"operate", "1"}, {"bypass", "0"}, {"tuning", "1"},
             {"relayC1", "20"}, {"relayC2", "5"}, {"relayL", "12"},
             {"antA", "2"}, {"one_by_three", "1"}, {"ip", "10.0.0.5"}});
+        CHECK(d.handle.has_value() && *d.handle == "0x2000");
         CHECK(d.serialNum.has_value() && *d.serialNum == "TG9");
         CHECK(d.model.has_value() && *d.model == "TunerGeniusXL");
         CHECK(d.operate.has_value() && *d.operate == true);

--- a/tests/aetherd_tuner_decode_test.cpp
+++ b/tests/aetherd_tuner_decode_test.cpp
@@ -16,11 +16,10 @@ static int g_failures = 0;
 #define CHECK(cond) do { if (!(cond)) { \
     std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failures; } } while (0)
 
-static TunerDelta decode(FlexBackend& b, const QMap<QString, QString>& kvs,
-                         const QString& handle = QStringLiteral("0x2000"))
+static TunerDelta decode(FlexBackend& b, const QMap<QString, QString>& kvs)
 {
     QSignalSpy spy(&b, &IRadioBackend::tunerChanged);
-    b.decodeTunerStatus(handle, kvs);
+    b.decodeTunerStatus(QStringLiteral("0x2000"), kvs);
     if (spy.count() != 1) return {};
     return spy.takeFirst().at(0).value<TunerDelta>();
 }
@@ -48,18 +47,6 @@ int main(int argc, char** argv)
         CHECK(d.antennaA.has_value() && *d.antennaA == 2);
         CHECK(d.oneByThree.has_value() && *d.oneByThree == true);
         CHECK(d.ip.has_value() && *d.ip == "10.0.0.5");
-    }
-
-    // ---- placeholder identity is carried until a real handle arrives ----
-    {
-        const TunerDelta placeholder = decode(
-            b, {{"model", "TunerGeniusXL"}}, QStringLiteral("0x00000000"));
-        CHECK(placeholder.handle.has_value()
-              && *placeholder.handle == "0x00000000");
-
-        const TunerDelta real = decode(
-            b, {{"operate", "1"}}, QStringLiteral("0x2001"));
-        CHECK(real.handle.has_value() && *real.handle == "0x2001");
     }
 
     // ---- present-only: absent keys stay disengaged ----

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -825,6 +825,22 @@ int main(int argc, char** argv)
               "relay: capabilitiesChanged fired on the connect edge");
         check(model.isConnected(),
               "synthetic demo connect reached the connected state");
+
+        // Captured SmartSDR status can be replayed while SimBackend is active.
+        // The neutral identity path must not depend on a live FlexBackend.
+        const QString tunerObject = QStringLiteral("amplifier 0x2000");
+        const QMap<QString, QString> tunerStatus{
+            {QStringLiteral("model"), QStringLiteral("TunerGeniusXL")}
+        };
+        check(QMetaObject::invokeMethod(
+                  &model, "onStatusReceived", Qt::DirectConnection,
+                  QGenericArgument("QString", &tunerObject),
+                  QGenericArgument("QMap<QString,QString>", &tunerStatus)),
+              "demo TGXL status fixture reached RadioModel");
+        check(model.tunerModel().handle() == QStringLiteral("0x2000")
+                  && model.tunerModel().isPresent(),
+              "demo TGXL status preserves backend-neutral tuner identity");
+        model.tunerModel().setHandle({});
         if (spy.count() > 0) {
             const QList<QVariant> args = spy.last();
             check(args.value(0).toBool(),

--- a/tests/tuner_model_test.cpp
+++ b/tests/tuner_model_test.cpp
@@ -24,7 +24,19 @@ int main(int argc, char** argv)
     {
         TunerModel t;
         QSignalSpy st(&t, &TunerModel::stateChanged);
+        bool operateAtPresence = false;
+        bool bypassAtPresence = false;
+        QString ipAtPresence;
+        QObject::connect(&t, &TunerModel::presenceChanged, &t,
+                         [&t, &operateAtPresence, &bypassAtPresence, &ipAtPresence](bool present) {
+            if (present) {
+                operateAtPresence = t.isOperate();
+                bypassAtPresence = t.isBypass();
+                ipAtPresence = t.tgxlIp();
+            }
+        });
         TunerDelta d;
+        d.handle = "0x2000";
         d.model = "TunerGeniusXL"; d.serialNum = "TG123";
         d.operate = true; d.bypass = false;
         d.relayC1 = 20; d.relayC2 = 5; d.relayL = 12;
@@ -34,6 +46,8 @@ int main(int argc, char** argv)
         CHECK(t.isOperate() && !t.isBypass());
         CHECK(t.relayC1() == 20 && t.relayC2() == 5 && t.relayL() == 12);
         CHECK(t.antennaA() == 1 && t.hasAntennaSwitch() && t.tgxlIp() == "10.0.0.5");
+        CHECK(t.isPresent() && operateAtPresence && !bypassAtPresence);
+        CHECK(ipAtPresence == "10.0.0.5");
         CHECK(st.count() == 1);
         t.applyChanges(d);                // identical → change-gated, no re-emit
         CHECK(st.count() == 1);

--- a/tests/tuner_model_test.cpp
+++ b/tests/tuner_model_test.cpp
@@ -4,6 +4,7 @@
 // translation is covered separately by aetherd_tuner_decode_test.
 
 #include "models/TunerModel.h"
+#include "core/TgxlConnection.h"
 
 #include <QCoreApplication>
 #include <QSignalSpy>
@@ -62,6 +63,42 @@ int main(int argc, char** argv)
         TunerDelta b; b.operate = true;   // operate unchanged; relayC1 not present
         t.applyChanges(b);
         CHECK(t.relayC1() == 5 && st.count() == 0);
+    }
+
+    // ---- placeholder identity is replaced without a second presence edge ----
+    {
+        TunerModel t;
+        QSignalSpy presence(&t, &TunerModel::presenceChanged);
+        TunerDelta initial;
+        initial.handle = "0x00000000";
+        initial.operate = true;
+        initial.ip = "10.0.0.5";
+        t.applyChanges(initial);
+        CHECK(t.isPresent() && t.handle() == "0x00000000" && t.isOperate());
+        CHECK(presence.count() == 1);
+
+        TunerDelta assigned;
+        assigned.handle = "0x2000";
+        assigned.bypass = true;
+        t.applyChanges(assigned);
+        CHECK(t.handle() == "0x2000" && t.isBypass());
+        CHECK(presence.count() == 1);
+    }
+
+    // ---- direct presence with no radio handle survives a handle-less delta ----
+    {
+        TunerModel t;
+        TgxlConnection direct;
+        t.setDirectConnection(&direct);
+        QSignalSpy presence(&t, &TunerModel::presenceChanged);
+        CHECK(QMetaObject::invokeMethod(&direct, "connected", Qt::DirectConnection));
+        CHECK(t.isPresent() && t.handle().isEmpty() && presence.count() == 1);
+
+        TunerDelta directState;
+        directState.operate = true;
+        t.applyChanges(directState);
+        CHECK(t.isPresent() && t.handle().isEmpty() && t.isOperate());
+        CHECK(presence.count() == 1);
     }
 
     // ---- tuning + antenna edges emit their signals before stateChanged ----

--- a/tests/tuner_model_test.cpp
+++ b/tests/tuner_model_test.cpp
@@ -25,21 +25,28 @@ int main(int argc, char** argv)
     {
         TunerModel t;
         QSignalSpy st(&t, &TunerModel::stateChanged);
+        QSignalSpy antennaEdge(&t, &TunerModel::antennaAChanged);
+        QSignalSpy tuningEdge(&t, &TunerModel::tuningChanged);
         bool operateAtPresence = false;
         bool bypassAtPresence = false;
+        bool edgesDeferredAtPresence = false;
         QString ipAtPresence;
         QObject::connect(&t, &TunerModel::presenceChanged, &t,
-                         [&t, &operateAtPresence, &bypassAtPresence, &ipAtPresence](bool present) {
+                         [&t, &antennaEdge, &tuningEdge, &operateAtPresence,
+                          &bypassAtPresence, &edgesDeferredAtPresence,
+                          &ipAtPresence](bool present) {
             if (present) {
                 operateAtPresence = t.isOperate();
                 bypassAtPresence = t.isBypass();
+                edgesDeferredAtPresence = antennaEdge.count() == 0
+                    && tuningEdge.count() == 0;
                 ipAtPresence = t.tgxlIp();
             }
         });
         TunerDelta d;
         d.handle = "0x2000";
         d.model = "TunerGeniusXL"; d.serialNum = "TG123";
-        d.operate = true; d.bypass = false;
+        d.operate = true; d.bypass = false; d.tuning = true;
         d.relayC1 = 20; d.relayC2 = 5; d.relayL = 12;
         d.antennaA = 1; d.oneByThree = true; d.ip = "10.0.0.5";
         t.applyChanges(d);
@@ -47,8 +54,10 @@ int main(int argc, char** argv)
         CHECK(t.isOperate() && !t.isBypass());
         CHECK(t.relayC1() == 20 && t.relayC2() == 5 && t.relayL() == 12);
         CHECK(t.antennaA() == 1 && t.hasAntennaSwitch() && t.tgxlIp() == "10.0.0.5");
-        CHECK(t.isPresent() && operateAtPresence && !bypassAtPresence);
+        CHECK(t.isPresent() && operateAtPresence && !bypassAtPresence
+              && edgesDeferredAtPresence);
         CHECK(ipAtPresence == "10.0.0.5");
+        CHECK(antennaEdge.count() == 1 && tuningEdge.count() == 1);
         CHECK(st.count() == 1);
         t.applyChanges(d);                // identical → change-gated, no re-emit
         CHECK(st.count() == 1);
@@ -63,26 +72,6 @@ int main(int argc, char** argv)
         TunerDelta b; b.operate = true;   // operate unchanged; relayC1 not present
         t.applyChanges(b);
         CHECK(t.relayC1() == 5 && st.count() == 0);
-    }
-
-    // ---- placeholder identity is replaced without a second presence edge ----
-    {
-        TunerModel t;
-        QSignalSpy presence(&t, &TunerModel::presenceChanged);
-        TunerDelta initial;
-        initial.handle = "0x00000000";
-        initial.operate = true;
-        initial.ip = "10.0.0.5";
-        t.applyChanges(initial);
-        CHECK(t.isPresent() && t.handle() == "0x00000000" && t.isOperate());
-        CHECK(presence.count() == 1);
-
-        TunerDelta assigned;
-        assigned.handle = "0x2000";
-        assigned.bypass = true;
-        t.applyChanges(assigned);
-        CHECK(t.handle() == "0x2000" && t.isBypass());
-        CHECK(presence.count() == 1);
     }
 
     // ---- direct presence with no radio handle survives a handle-less delta ----


### PR DESCRIPTION
## Summary

Fixes #5338.

Carry the normalized TGXL handle in `TunerDelta` so identity, operate/bypass state, and IP from the initial radio status are applied as one model snapshot. `TunerModel` now publishes first presence only after those fields are current.

SmartSDR's `0x00000000` startup placeholder is filtered in `FlexBackend`, so it cannot become tuner identity, overwrite a real handle, create false presence, or capture a PGXL placeholder status. Captured TGXL status replay under demo/sim preserves the prior backend-neutral identity path without duplicating SmartSDR field decoding in `RadioModel`.

Route both external-TGXL discovery paths through the atomic delta and extend the existing socket-free tuner model, backend decode, and `RadioModel` routing coverage. This preserves direct presence without a radio handle, meter routing, removal paths, and demo/sim identity.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The model test observes state from `presenceChanged(true)`; it fails when atomic handle application is removed and passes after restoration. Dedicated regressions cover placeholder filtering and backend-neutral demo/sim identity.

## Test plan

- [x] Rebased onto current `origin/main`
- [x] Modified `aethercore` sources compile while building the focused targets
- [x] Focused tests pass (`ctest --test-dir build -R '^(tuner_model_test|aetherd_tuner_decode_test|aetherd_amp_tuner_encode_test|radio_capability_gating_test)$' --output-on-failure --no-tests=error`)
- [x] Registration check passes (`python3 tools/check_test_registration.py --strict`)
- [x] Engine-boundary check reports no blockers (`python3 tools/check_engine_boundary.py --strict`)
- [x] Diff whitespace check passes (`git diff --check`)
- [x] Atomic initial-snapshot regression assertion mutation-checked
- [x] Placeholder rejection, demo/sim identity, direct-presence/no-radio-handle behavior, and post-presence edge-signal ordering covered
- [ ] Real TGXL hardware verification; this issue was identified by code audit and the invariant is tested at socket-free model and routing boundaries

## Checklist

- [x] Commit is signed (`docs/COMMIT-SIGNING.md`)
- [x] No new `AppSettings` calls
- [x] Code is clean-room and follows the existing normalized backend-delta architecture
- [x] No meter UI changes
- [x] Reproduction and behavior are documented in the linked issue and this PR; `CHANGELOG.md` is unchanged
- [x] No security-sensitive changes
