### PR TITLE
ci(windows): package complete Store symbols and fix upload timeout

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -4,17 +4,6 @@ on:
   push:
     tags: ['v*']
   workflow_dispatch:
-    inputs:
-      publish_store_flight:
-        description: 'Publish this main-branch build to the developer Store flight'
-        required: false
-        default: false
-        type: boolean
-  schedule:
-    # Daily developer-flight build at local midnight. The named timezone keeps
-    # the schedule at midnight across Pacific daylight-saving transitions.
-    - cron: '0 0 * * *'
-      timezone: 'America/Los_Angeles'
 
 permissions:
   contents: write
@@ -355,28 +344,6 @@ jobs:
       # established portable-zip + Inno installer delivery path that real
       # users depend on.  When MSIX matures we can promote it back into
       # the hard-required artifact set.
-      - name: Set developer flight MSIX version
-        if: github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.publish_store_flight))
-        run: |
-          $match = Select-String -Path CMakeLists.txt -Pattern '^\s*project\(AetherSDR\s+VERSION\s+([0-9]+(?:\.[0-9]+){1,3})' | Select-Object -First 1
-          if (-not $match) {
-            throw "Could not read the AetherSDR version from CMakeLists.txt."
-          }
-          $parts = @($match.Matches[0].Groups[1].Value.Split('.'))
-          while ($parts.Count -lt 3) {
-            $parts += '0'
-          }
-          $buildNumber = [int]"${{ github.run_number }}"
-          if ($buildNumber -lt 1 -or $buildNumber -gt 65535) {
-            throw "GitHub run number $buildNumber cannot be used as an MSIX version component (1..65535)."
-          }
-          # Flight packages retain the source version's first three components.
-          # The monotonically increasing workflow run number makes daily
-          # packages unique without changing the source-tree version.
-          $flightVersion = "$($parts[0]).$($parts[1]).$($parts[2]).$buildNumber"
-          "AETHERSDR_MSIX_VERSION=$flightVersion" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          Write-Host "Developer flight MSIX version: $flightVersion"
-
       - name: Create MSIX package
         continue-on-error: true
         env:
@@ -497,67 +464,3 @@ jobs:
             --clientId $env:AZURE_AD_APPLICATION_CLIENT_ID `
             --clientSecret $env:AZURE_AD_APPLICATION_SECRET
           powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\publish-store.ps1 -ProductId $env:AETHERSDR_STORE_PRODUCT_ID -UploadTimeoutSeconds 300
-
-  # Daily and explicitly requested main-branch builds are committed to a
-  # restricted Partner Center package flight. This is intentionally a separate
-  # job from the production tag path above: production remains draft-only.
-  publish-store-flight:
-    name: Publish developer Store flight
-    needs: build-windows
-    if: >-
-      github.ref == 'refs/heads/main' &&
-      vars.AETHERSDR_STORE_PRODUCT_ID != '' &&
-      (github.event_name == 'schedule' ||
-       (github.event_name == 'workflow_dispatch' && inputs.publish_store_flight))
-    runs-on: windows-latest
-    permissions:
-      contents: read
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-
-      - name: Download verified Windows package
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          name: Windows-Installer
-          path: flight-package
-
-      - name: Validate developer flight configuration
-        env:
-          AETHERSDR_STORE_FLIGHT_ID: ${{ secrets.AETHERSDR_STORE_FLIGHT_ID }}
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:AETHERSDR_STORE_FLIGHT_ID)) {
-            throw "AETHERSDR_STORE_FLIGHT_ID must contain the Partner Center developer flight ID. Refusing to fall back to a production submission."
-          }
-          $uploads = @(Get-ChildItem flight-package -Recurse -File -Filter "AetherSDR-*.msixupload")
-          if ($uploads.Count -ne 1) {
-            throw "Expected exactly one verified .msixupload in the Windows-Installer artifact; found $($uploads.Count)."
-          }
-          Write-Host "Developer flight configuration and upload artifact are present."
-
-      - name: Setup Microsoft Store Developer CLI
-        uses: microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0
-        with:
-          version: v0.4.1
-
-      - name: Publish developer Store flight
-        env:
-          AZURE_AD_TENANT_ID: ${{ secrets.AZURE_AD_TENANT_ID }}
-          AZURE_AD_APPLICATION_CLIENT_ID: ${{ secrets.AZURE_AD_APPLICATION_CLIENT_ID }}
-          AZURE_AD_APPLICATION_SECRET: ${{ secrets.AZURE_AD_APPLICATION_SECRET }}
-          SELLER_ID: ${{ secrets.SELLER_ID }}
-          AETHERSDR_STORE_PRODUCT_ID: ${{ vars.AETHERSDR_STORE_PRODUCT_ID }}
-          AETHERSDR_STORE_FLIGHT_ID: ${{ secrets.AETHERSDR_STORE_FLIGHT_ID }}
-        run: |
-          msstore --version
-          msstore reconfigure `
-            --tenantId $env:AZURE_AD_TENANT_ID `
-            --sellerId $env:SELLER_ID `
-            --clientId $env:AZURE_AD_APPLICATION_CLIENT_ID `
-            --clientSecret $env:AZURE_AD_APPLICATION_SECRET
-          powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\publish-store.ps1 `
-            -ProductId $env:AETHERSDR_STORE_PRODUCT_ID `
-            -FlightId $env:AETHERSDR_STORE_FLIGHT_ID `
-            -SearchDir flight-package `
-            -UploadTimeoutSeconds 300 `
-            -Commit

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -11,9 +11,10 @@ on:
         default: false
         type: boolean
   schedule:
-    # Daily developer-flight build. GitHub schedules use UTC; choosing a
-    # non-zero minute avoids the heaviest scheduler contention.
-    - cron: '17 13 * * *'
+    # Daily developer-flight build at local midnight. The named timezone keeps
+    # the schedule at midnight across Pacific daylight-saving transitions.
+    - cron: '0 0 * * *'
+      timezone: 'America/Los_Angeles'
 
 permissions:
   contents: write

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -4,6 +4,16 @@ on:
   push:
     tags: ['v*']
   workflow_dispatch:
+    inputs:
+      publish_store_flight:
+        description: 'Publish this main-branch build to the developer Store flight'
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    # Daily developer-flight build. GitHub schedules use UTC; choosing a
+    # non-zero minute avoids the heaviest scheduler contention.
+    - cron: '17 13 * * *'
 
 permissions:
   contents: write
@@ -33,7 +43,16 @@ jobs:
           target: 'desktop'
           # Qt 6.8 LTS dropped MSVC 2019 builds — arch must be msvc2022.
           arch: 'win64_msvc2022_64'
-          modules: 'qtmultimedia qtserialport qtwebsockets qtshadertools'
+          # Base Qt PDBs live in debug_info; each add-on keeps its PDBs in a
+          # separate .debug_information module. Restrict the base archives to
+          # the QtBase/QtSvg binaries AetherSDR actually deploys so release CI
+          # does not download unrelated Qt debug data.
+          modules: 'qtmultimedia qtserialport qtwebsockets qtshadertools debug_info qtmultimedia.debug_information qtserialport.debug_information qtwebsockets.debug_information'
+          # Keep the software OpenGL fallback that the existing Windows package
+          # ships; archive pruning must not change the runtime payload while
+          # adding symbols. d3dcompiler_47 remains intentionally omitted by the
+          # existing windeployqt --no-system-d3d-compiler flag below.
+          archives: 'opengl32sw qtbase qtsvg'
 
       - name: Install Ninja, Inno Setup, and LLVM
         run: choco install ninja innosetup llvm -y
@@ -236,7 +255,10 @@ jobs:
           if (Test-Path "third_party\qtkeychain\bin\qt6keychain.dll") {
             copy third_party\qtkeychain\bin\qt6keychain.dll "$env:QT_ROOT_DIR\bin\"
           }
-          windeployqt deploy\AetherSDR.exe --release --no-translations --no-system-d3d-compiler
+          # --pdb copies symbols only for the exact Qt DLLs/plugins selected by
+          # this deployment pass. The next step removes them from deploy/ and
+          # flattens them beside AetherSDR.pdb for the x64 .appxsym.
+          windeployqt deploy\AetherSDR.exe --release --pdb --no-translations --no-system-d3d-compiler
           if (Test-Path "third_party\fftw3\bin\libfftw3-3.dll") {
             copy third_party\fftw3\bin\libfftw3-3.dll deploy\
           }
@@ -284,6 +306,9 @@ jobs:
           Write-Host "Bundling Vulkan loader: $vkDll"
           copy $vkDll deploy\
 
+      - name: Stage application and Qt debug symbols
+        run: powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\stage-debug-symbols.ps1 -DeployDir deploy -ApplicationPdb build\AetherSDR.pdb -OutputDir symbols -QtRootDir $env:QT_ROOT_DIR
+
       - name: Verify DPI awareness manifest
         run: powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\check-dpi-awareness.ps1 -ExePath deploy\AetherSDR.exe
 
@@ -329,6 +354,28 @@ jobs:
       # established portable-zip + Inno installer delivery path that real
       # users depend on.  When MSIX matures we can promote it back into
       # the hard-required artifact set.
+      - name: Set developer flight MSIX version
+        if: github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.publish_store_flight))
+        run: |
+          $match = Select-String -Path CMakeLists.txt -Pattern '^\s*project\(AetherSDR\s+VERSION\s+([0-9]+(?:\.[0-9]+){1,3})' | Select-Object -First 1
+          if (-not $match) {
+            throw "Could not read the AetherSDR version from CMakeLists.txt."
+          }
+          $parts = @($match.Matches[0].Groups[1].Value.Split('.'))
+          while ($parts.Count -lt 3) {
+            $parts += '0'
+          }
+          $buildNumber = [int]"${{ github.run_number }}"
+          if ($buildNumber -lt 1 -or $buildNumber -gt 65535) {
+            throw "GitHub run number $buildNumber cannot be used as an MSIX version component (1..65535)."
+          }
+          # Flight packages retain the source version's first three components.
+          # The monotonically increasing workflow run number makes daily
+          # packages unique without changing the source-tree version.
+          $flightVersion = "$($parts[0]).$($parts[1]).$($parts[2]).$buildNumber"
+          "AETHERSDR_MSIX_VERSION=$flightVersion" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Host "Developer flight MSIX version: $flightVersion"
+
       - name: Create MSIX package
         continue-on-error: true
         env:
@@ -342,26 +389,34 @@ jobs:
           AETHERSDR_MSIX_INSTALLER_BACKGROUND_COLOR: ${{ vars.AETHERSDR_MSIX_INSTALLER_BACKGROUND_COLOR }}
         run: |
           . .\packaging\windows\store-identity.ps1
-          powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\create-msix.ps1 -DeployDir deploy -OutputDir . -CreateUpload -SkipSign -ExcludeDfnrModel -RequirePdb
+          powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\create-msix.ps1 -DeployDir deploy -OutputDir . -PdbPath symbols\AetherSDR.pdb -SymbolDir symbols -CreateUpload -SkipSign -ExcludeDfnrModel -RequirePdb
 
-      # Hard gate for the PDB-regression class (#3946). The Create MSIX
-      # package step above is continue-on-error (to tolerate MSIX SDK/tool
-      # flakes), which ALSO swallows create-msix.ps1's -RequirePdb throw — so
-      # a missing PDB can't red the build from inside that step. A missing PDB
-      # is not an MSIX hiccup though: it's a build regression (e.g.
-      # CMAKE_BUILD_TYPE flipped back to Release, which omits /Zi + /DEBUG so
-      # no build/AetherSDR.pdb is emitted) that would silently ship
-      # symbol-less .msixupload packages and skip the Windows-Symbols upload.
-      # Re-check the PDB the RelWithDebInfo Build step must emit in a step that
-      # is deliberately NOT continue-on-error, so that regression fails the job
-      # loudly instead of landing on a green build. -RequirePdb is kept above
-      # for local/dev ergonomics; this step is the CI gate that actually reds.
-      - name: Verify debug symbols (PDB) present
+      # The staging step above is a hard gate: it verifies every deployed Qt
+      # DLL/plugin has its same-named PDB before removing symbols from deploy/.
+      # Re-check the high-value symbols independently so a packaging refactor
+      # cannot silently shrink the Store symbol surface.
+      - name: Verify required debug symbols present
         run: |
-          if (-not (Test-Path build\AetherSDR.pdb)) {
-            throw "build/AetherSDR.pdb is missing. The RelWithDebInfo Windows build must emit a PDB for Partner Center crash symbolication (.appxsym) and the standalone Windows-Symbols artifact. If CMAKE_BUILD_TYPE was changed to Release, restore RelWithDebInfo. See #3946 / #3934."
+          $required = @("AetherSDR.pdb", "Qt6Core.pdb", "Qt6Gui.pdb", "Qt6Multimedia.pdb", "Qt6Network.pdb", "Qt6Widgets.pdb", "qwindows.pdb", "windowsmediaplugin.pdb")
+          foreach ($pdb in $required) {
+            if (-not (Test-Path (Join-Path "symbols" $pdb))) {
+              throw "Required Store symbol is missing: symbols\$pdb"
+            }
           }
-          Write-Host "PDB present: build\AetherSDR.pdb"
+          $symbolCount = @(Get-ChildItem symbols -File -Filter "*.pdb").Count
+          Write-Host "Required symbols present; $symbolCount PDBs staged."
+
+      - name: Verify Store symbol package topology
+        if: hashFiles('AetherSDR-*.appxsym') != ''
+        run: |
+          $appxSym = @(Get-ChildItem -File -Filter "AetherSDR-*.appxsym")
+          $msixUpload = @(Get-ChildItem -File -Filter "AetherSDR-*.msixupload")
+          if ($appxSym.Count -ne 1 -or $msixUpload.Count -ne 1) {
+            throw "Expected exactly one .appxsym and one .msixupload. Found $($appxSym.Count) and $($msixUpload.Count)."
+          }
+          $appxSymPath = $appxSym[0].FullName
+          $msixUploadPath = $msixUpload[0].FullName
+          powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\check-symbol-package.ps1 -AppxSymPath $appxSymPath -MsixUploadPath $msixUploadPath
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -374,16 +429,14 @@ jobs:
             AetherSDR-*.msixupload
             AetherSDR-*.appxsym
 
-      # Standalone PDB, kept separately from the .msixupload bundle above so
-      # maintainers can pull matching debug symbols for WinDbg/Visual Studio
-      # without unzipping a Store submission package — same PDB that's zipped
-      # into the .appxsym for Partner Center's crash symbolication.
+      # Complete application + Qt PDB set, kept separately from .msixupload so
+      # maintainers can symbolize local dumps without unpacking Store assets.
       - name: Upload debug symbols
-        if: hashFiles('build/AetherSDR.pdb') != ''
+        if: hashFiles('symbols/AetherSDR.pdb') != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: Windows-Symbols
-          path: build/AetherSDR.pdb
+          path: symbols/
           retention-days: 90
 
       - name: Attach to release
@@ -440,3 +493,63 @@ jobs:
             --clientId $env:AZURE_AD_APPLICATION_CLIENT_ID `
             --clientSecret $env:AZURE_AD_APPLICATION_SECRET
           powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\publish-store.ps1 -ProductId $env:AETHERSDR_STORE_PRODUCT_ID
+
+  # Daily and explicitly requested main-branch builds are committed to a
+  # restricted Partner Center package flight. This is intentionally a separate
+  # job from the production tag path above: production remains draft-only.
+  publish-store-flight:
+    name: Publish developer Store flight
+    needs: build-windows
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      vars.AETHERSDR_STORE_PRODUCT_ID != '' &&
+      (github.event_name == 'schedule' ||
+       (github.event_name == 'workflow_dispatch' && inputs.publish_store_flight))
+    runs-on: windows-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Download verified Windows package
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: Windows-Installer
+          path: flight-package
+
+      - name: Validate developer flight configuration
+        env:
+          AETHERSDR_STORE_FLIGHT_ID: ${{ secrets.AETHERSDR_STORE_FLIGHT_ID }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:AETHERSDR_STORE_FLIGHT_ID)) {
+            throw "AETHERSDR_STORE_FLIGHT_ID must contain the Partner Center developer flight ID. Refusing to fall back to a production submission."
+          }
+          $uploads = @(Get-ChildItem flight-package -Recurse -File -Filter "AetherSDR-*.msixupload")
+          if ($uploads.Count -ne 1) {
+            throw "Expected exactly one verified .msixupload in the Windows-Installer artifact; found $($uploads.Count)."
+          }
+          Write-Host "Developer flight configuration and upload artifact are present."
+
+      - name: Setup Microsoft Store Developer CLI
+        uses: microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0
+
+      - name: Publish developer Store flight
+        env:
+          AZURE_AD_TENANT_ID: ${{ secrets.AZURE_AD_TENANT_ID }}
+          AZURE_AD_APPLICATION_CLIENT_ID: ${{ secrets.AZURE_AD_APPLICATION_CLIENT_ID }}
+          AZURE_AD_APPLICATION_SECRET: ${{ secrets.AZURE_AD_APPLICATION_SECRET }}
+          SELLER_ID: ${{ secrets.SELLER_ID }}
+          AETHERSDR_STORE_PRODUCT_ID: ${{ vars.AETHERSDR_STORE_PRODUCT_ID }}
+          AETHERSDR_STORE_FLIGHT_ID: ${{ secrets.AETHERSDR_STORE_FLIGHT_ID }}
+        run: |
+          msstore reconfigure `
+            --tenantId $env:AZURE_AD_TENANT_ID `
+            --sellerId $env:SELLER_ID `
+            --clientId $env:AZURE_AD_APPLICATION_CLIENT_ID `
+            --clientSecret $env:AZURE_AD_APPLICATION_SECRET
+          powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\publish-store.ps1 `
+            -ProductId $env:AETHERSDR_STORE_PRODUCT_ID `
+            -FlightId $env:AETHERSDR_STORE_FLIGHT_ID `
+            -SearchDir flight-package `
+            -Commit

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -478,6 +478,8 @@ jobs:
       - name: Setup Microsoft Store Developer CLI
         if: startsWith(github.ref, 'refs/tags/') && vars.AETHERSDR_STORE_PRODUCT_ID != ''
         uses: microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0
+        with:
+          version: v0.4.1
 
       - name: Stage Microsoft Store submission (draft)
         if: startsWith(github.ref, 'refs/tags/') && vars.AETHERSDR_STORE_PRODUCT_ID != ''
@@ -488,12 +490,13 @@ jobs:
           SELLER_ID: ${{ secrets.SELLER_ID }}
           AETHERSDR_STORE_PRODUCT_ID: ${{ vars.AETHERSDR_STORE_PRODUCT_ID }}
         run: |
+          msstore --version
           msstore reconfigure `
             --tenantId $env:AZURE_AD_TENANT_ID `
             --sellerId $env:SELLER_ID `
             --clientId $env:AZURE_AD_APPLICATION_CLIENT_ID `
             --clientSecret $env:AZURE_AD_APPLICATION_SECRET
-          powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\publish-store.ps1 -ProductId $env:AETHERSDR_STORE_PRODUCT_ID
+          powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\publish-store.ps1 -ProductId $env:AETHERSDR_STORE_PRODUCT_ID -UploadTimeoutSeconds 300
 
   # Daily and explicitly requested main-branch builds are committed to a
   # restricted Partner Center package flight. This is intentionally a separate
@@ -534,6 +537,8 @@ jobs:
 
       - name: Setup Microsoft Store Developer CLI
         uses: microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0
+        with:
+          version: v0.4.1
 
       - name: Publish developer Store flight
         env:
@@ -544,6 +549,7 @@ jobs:
           AETHERSDR_STORE_PRODUCT_ID: ${{ vars.AETHERSDR_STORE_PRODUCT_ID }}
           AETHERSDR_STORE_FLIGHT_ID: ${{ secrets.AETHERSDR_STORE_FLIGHT_ID }}
         run: |
+          msstore --version
           msstore reconfigure `
             --tenantId $env:AZURE_AD_TENANT_ID `
             --sellerId $env:SELLER_ID `
@@ -553,4 +559,5 @@ jobs:
             -ProductId $env:AETHERSDR_STORE_PRODUCT_ID `
             -FlightId $env:AETHERSDR_STORE_FLIGHT_ID `
             -SearchDir flight-package `
+            -UploadTimeoutSeconds 300 `
             -Commit

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -362,7 +362,8 @@ jobs:
       # The staging step above is a hard gate: it verifies every deployed Qt
       # DLL/plugin has its same-named PDB before removing symbols from deploy/.
       # Re-check the high-value symbols independently so a packaging refactor
-      # cannot silently shrink the Store symbol surface.
+      # cannot silently shrink the Store symbol surface. Keep this list in sync
+      # with check-symbol-package.ps1's default RequiredPdbs list.
       - name: Verify required debug symbols present
         run: |
           $required = @("AetherSDR.pdb", "Qt6Core.pdb", "Qt6Gui.pdb", "Qt6Multimedia.pdb", "Qt6Network.pdb", "Qt6Widgets.pdb", "qwindows.pdb", "windowsmediaplugin.pdb")

--- a/docs/WINDOWS-STORE-MSIX.md
+++ b/docs/WINDOWS-STORE-MSIX.md
@@ -98,8 +98,8 @@ Not fully automatable until account setup:
 Microsoft Store crash reports in Partner Center only resolve to a symbolized
 stack trace if the submitted `.msixupload` carries matching debug symbols.
 There is no separate "upload symbols" step in Partner Center — the symbols
-travel *inside* the upload package as a `.appxsym` file (a zip of the PDB),
-which Partner Center auto-ingests on submission.
+travel *inside* the upload package as a `.appxsym` file (a zip of PDBs), which
+Partner Center ingests with the submission.
 
 The Windows installer workflow produces this automatically:
 
@@ -108,15 +108,42 @@ The Windows installer workflow produces this automatically:
    `build/AetherSDR.pdb` would never exist. `RelWithDebInfo` keeps the same
    `-O2` optimization level (only the inliner threshold, `/Ob1` vs. `/Ob2`,
    differs) while producing a full PDB.
-2. `create-msix.ps1 -CreateUpload -RequirePdb` zips `build/AetherSDR.pdb` into
-   `<package>.appxsym` (`New-AppxSym`) and bundles it alongside the `.msix`
-   into `<package>.msixupload` (`New-MsixUpload`). `-RequirePdb` makes the
-   step fail the build if no PDB was found, instead of silently shipping a
-   symbol-less upload package — CI passes it; local dev builds can omit it.
-3. CI uploads `build/AetherSDR.pdb` as its own **Windows-Symbols** artifact
-   (90-day retention) and the standalone `.appxsym` alongside the other
-   Windows-Installer artifacts, so a maintainer can pull matching symbols for
-   local WinDbg/Visual Studio debugging without unzipping a `.msixupload`.
+2. The Qt install includes the base `debug_info` archive plus each deployed
+   add-on's `.debug_information` companion. `windeployqt --pdb` copies PDBs
+   only for the exact Qt DLLs and plugins selected for the runtime payload.
+3. `stage-debug-symbols.ps1` verifies that every deployed Qt DLL/plugin has
+   its same-named PDB beside it. It then moves those PDBs out of `deploy/` and
+   flattens them beside `AetherSDR.pdb` in `symbols/`. This is important:
+   `deploy/` feeds the portable ZIP, Inno installer, and MSIX, none of which
+   should ship PDB payload files.
+4. `create-msix.ps1 -CreateUpload -RequirePdb -SymbolDir symbols` places all
+   architecture-matching PDBs at the root of `<package>.appxsym`, then places
+   that `.appxsym` beside the `.msix` at the root of `<package>.msixupload`.
+   This mirrors Visual Studio's single-architecture Store upload layout; there
+   is no extra `symbols/` directory inside either archive. Microsoft documents
+   the outer upload/symbol relationship in its
+   [MSIX package requirements](https://learn.microsoft.com/windows/apps/publish/publish-your-app/msix/app-package-requirements),
+   and a Microsoft WinUI engineer's
+   [manual packaging walkthrough](https://github.com/microsoft/microsoft-ui-xaml/discussions/9121)
+   shows all PDBs for one architecture together in one flat `.appxsym`.
+5. `check-symbol-package.ps1` opens both archives and verifies the topology,
+   required AetherSDR/Qt/Windows Multimedia PDBs, and that the `.appxsym`
+   embedded in `.msixupload` is byte-identical to the verified standalone
+   file.
+6. CI uploads the complete `symbols/` directory as **Windows-Symbols** with a
+   SHA-256 manifest (90-day retention), and uploads the standalone `.appxsym`
+   alongside the other Windows-Installer artifacts. Maintainers therefore get
+   the same AetherSDR and Qt PDB set for local WinDbg/Visual Studio debugging
+   without unpacking a `.msixupload`.
+
+The Qt-provided PDBs are packaged unchanged. `windeployqt` selects them from
+the same exact Qt installation that supplied the deployed DLLs; `pdbcopy` is
+not needed to discover or match them. If Partner Center later requires
+public-only/stripped copies, that can be added as a separate transformation
+without changing this archive topology. Store acceptance alone does not prove
+that third-party Qt symbols were indexed, so confirm the first qualifying
+Health report for this package version resolves Qt function names rather than
+only `Qt6*.dll+offset`.
 
 Submitting the `.msixupload` to Partner Center (manually today, or via the
 automated draft-staging flow below) is the only "publish" step needed —
@@ -133,27 +160,28 @@ works cross-platform against the same PDB:
    `%LOCALAPPDATA%\CrashDumps\AetherSDR.exe.<pid>.dmp` (enable full dumps via
    the `HKLM\...\Windows Error Reporting\LocalDumps` key, `DumpType=2`). Store
    Partner Center TSVs are unsymbolized — always request the `.dmp`.
-2. **Get the matching PDB** — it must be the *exact* build that crashed or the
-   debug-id won't match. Pull the `Windows-Symbols` artifact from the
+2. **Get the matching PDBs** — they must be from the *exact* build that crashed
+   or the debug-ids won't match. Pull the `Windows-Symbols` artifact from the
    `windows-installer.yml` CI run for that tag/branch:
    `gh run download <run-id> -R aethersdr/AetherSDR -n Windows-Symbols`.
 3. **Convert + walk.** [`dump_syms`](https://github.com/mozilla/dump_syms)
-   turns the PDB into a Breakpad `.sym`; `minidump-stackwalk` walks the dump
-   and matches modules by debug-id:
+   turns each needed PDB into a Breakpad `.sym`; `minidump-stackwalk` walks
+   the dump and matches modules by debug-id:
    ```sh
    dump_syms --store ./symbols AetherSDR.pdb          # → symbols/AetherSDR.pdb/<id>/AetherSDR.sym
+   dump_syms --store ./symbols Qt6Multimedia.pdb      # matching Qt frames
    minidump-stackwalk --human --symbols-path ./symbols \
      --symbols-url https://msdl.microsoft.com/download/symbols \
      AetherSDR.exe.<pid>.dmp
    ```
-   Our frames symbolize from the `.sym`; the `--symbols-url` resolves Windows
-   system DLLs. Third-party GPU/driver frames (e.g. Intel `igd10iumd64.dll`)
-   stay as `module+offset` — usually enough, since the value is in *our*
-   caller frames leading into the driver. If the crashing thread won't unwind
-   past a driver frame (no CFI), fall back to a manual stack scan: parse the
-   dump's `Memory64ListStream`, find the region containing the thread's `rsp`,
-   and scan 8-byte-aligned values for pointers into `AetherSDR.exe` (resolve
-   offsets against the `.sym` `FUNC` table).
+   AetherSDR and packaged Qt frames symbolize from those `.sym` files; the
+   `--symbols-url` resolves Windows system DLLs. Other third-party GPU/driver
+   frames (e.g. Intel `igd10iumd64.dll`) stay as `module+offset` — usually
+   enough, since the value is in our caller frames leading into the driver. If
+   the crashing thread won't unwind past a driver frame (no CFI), fall back to
+   a manual stack scan: parse the dump's `Memory64ListStream`, find the region
+   containing the thread's `rsp`, and scan 8-byte-aligned values for pointers
+   into `AetherSDR.exe` (resolve offsets against the `.sym` `FUNC` table).
 
 ## Known WACK Follow-Ups
 
@@ -291,6 +319,42 @@ To move from draft to auto-publish, drop `--noCommit` (each tag goes straight to
 certification), or publish to a **flight/insider ring** first with
 `-f <flightId>` and promote manually. Keep the draft gate until the weekly
 cadence has proven stable.
+
+### Daily developer package flight
+
+The Windows Installer workflow has a production-isolated developer flight
+path. Production tag submissions continue to use `--noCommit` and remain
+draft-only. A scheduled run at 13:17 UTC each day builds current `main`, then a
+separate job commits the verified `.msixupload` to the configured Partner
+Center package flight. The same path can be requested manually from
+**Run workflow** by selecting **Publish this main-branch build to the developer
+Store flight**; flight publication is restricted to the `main` ref.
+
+Create the package flight under the existing AetherSDR Store product and attach
+a known-user group containing the developer Microsoft accounts. Keep the
+production package identity and `AETHERSDR_STORE_PRODUCT_ID` unchanged. Add the
+flight's Partner Center ID as this GitHub Actions repository secret:
+
+- `AETHERSDR_STORE_FLIGHT_ID`
+
+The flight ID is not a second Store product or MSIX identity. It is passed to
+`msstore publish` as `-f <flightId>`, while `-Commit` sends that restricted
+submission through certification so flight members can install it. The flight
+job fails before authentication if the secret is absent, rather than risking a
+production fallback.
+
+Daily flight packages retain the first three source-version components and use
+the monotonically increasing GitHub workflow run number as the fourth MSIX
+component (for example, `26.9.1.417`). This makes every Store package version
+unique without modifying `CMakeLists.txt`. A subsequent general release should
+increment the source patch component (for example, `26.9.2.0`), which sorts
+above every `26.9.1.*` flight build.
+
+The flight submission is created and committed through the Store API. Do not
+modify an in-progress API-created flight submission in the Partner Center UI;
+Microsoft warns that mixing the dashboard and API for the same submission can
+leave it in an error state. Manage failures by using the API/CLI to inspect or
+delete the pending flight submission before retrying.
 
 ## Local Sideload Signing
 

--- a/docs/WINDOWS-STORE-MSIX.md
+++ b/docs/WINDOWS-STORE-MSIX.md
@@ -333,43 +333,6 @@ certification), or publish to a **flight/insider ring** first with
 `-f <flightId>` and promote manually. Keep the draft gate until the weekly
 cadence has proven stable.
 
-### Daily developer package flight
-
-The Windows Installer workflow has a production-isolated developer flight
-path. Production tag submissions continue to use `--noCommit` and remain
-draft-only. A timezone-aware scheduled run at midnight in
-`America/Los_Angeles` builds current `main`, then a separate job commits the
-verified `.msixupload` to the configured Partner Center package flight. The
-same path can be requested manually from
-**Run workflow** by selecting **Publish this main-branch build to the developer
-Store flight**; flight publication is restricted to the `main` ref.
-
-Create the package flight under the existing AetherSDR Store product and attach
-a known-user group containing the developer Microsoft accounts. Keep the
-production package identity and `AETHERSDR_STORE_PRODUCT_ID` unchanged. Add the
-flight's Partner Center ID as this GitHub Actions repository secret:
-
-- `AETHERSDR_STORE_FLIGHT_ID`
-
-The flight ID is not a second Store product or MSIX identity. It is passed to
-`msstore publish` as `-f <flightId>`, while `-Commit` sends that restricted
-submission through certification so flight members can install it. The flight
-job fails before authentication if the secret is absent, rather than risking a
-production fallback.
-
-Daily flight packages retain the first three source-version components and use
-the monotonically increasing GitHub workflow run number as the fourth MSIX
-component (for example, `26.9.1.417`). This makes every Store package version
-unique without modifying `CMakeLists.txt`. A subsequent general release should
-increment the source patch component (for example, `26.9.2.0`), which sorts
-above every `26.9.1.*` flight build.
-
-The flight submission is created and committed through the Store API. Do not
-modify an in-progress API-created flight submission in the Partner Center UI;
-Microsoft warns that mixing the dashboard and API for the same submission can
-leave it in an error state. Manage failures by using the API/CLI to inspect or
-delete the pending flight submission before retrying.
-
 ## Local Sideload Signing
 
 Windows requires MSIX packages to be signed with a certificate that is trusted

--- a/docs/WINDOWS-STORE-MSIX.md
+++ b/docs/WINDOWS-STORE-MSIX.md
@@ -116,8 +116,10 @@ The Windows installer workflow produces this automatically:
    flattens them beside `AetherSDR.pdb` in `symbols/`. This is important:
    `deploy/` feeds the portable ZIP, Inno installer, and MSIX, none of which
    should ship PDB payload files.
-4. `create-msix.ps1 -CreateUpload -RequirePdb -SymbolDir symbols` places all
-   architecture-matching PDBs at the root of `<package>.appxsym`, then places
+4. `create-msix.ps1 -CreateUpload -RequirePdb` consumes the staged application
+   PDB and dependency PDBs. Pass `-PdbPath symbols\AetherSDR.pdb` and
+   `-SymbolDir symbols` so both inputs describe the same verified symbol set.
+   The script places the PDBs at the root of `<package>.appxsym`, then places
    that `.appxsym` beside the `.msix` at the root of `<package>.msixupload`.
    This mirrors Visual Studio's single-architecture Store upload layout; there
    is no extra `symbols/` directory inside either archive. Microsoft documents
@@ -237,10 +239,10 @@ On a `v*` tag push the workflow:
 3. `msstore reconfigure` authenticates from the four GitHub secrets.
 4. `packaging/windows/publish-store.ps1` finds the `.msixupload` and runs
    `msstore publish <pkg>.msixupload -id <ProductId> --uploadTimeout 300
-   --verbose --noCommit` — staging a **draft**. `--noCommit` is the safety gate
-   that keeps it out of certification. A maintainer reviews the pending
-   submission in Partner Center and clicks **Submit to Store** to start
-   certification. **CI never publishes to the live channel on its own.**
+   --noCommit` — staging a **draft**. `--noCommit` is the safety gate that keeps
+   it out of certification. A maintainer reviews the pending submission in
+   Partner Center and clicks **Submit to Store** to start certification. **CI
+   never publishes to the live channel on its own.**
 
 Guard rails (all three must pass before Partner Center is touched):
 
@@ -260,11 +262,12 @@ have a regression where omitting `--uploadTimeout` supplies a zero-second Azure
 blob network timeout, producing the characteristic `Uploading Bundle to Azure
 blob: 0%` failure and exit code `-1`
 ([microsoft/msstore-cli#162](https://github.com/microsoft/msstore-cli/issues/162)).
-The script uses the documented workaround of 300 seconds and enables
-`--verbose` so any future upload failure retains its underlying exception in
-the CI log. The affected CLI is pinned to prevent `latest` from silently
-changing publish behavior; advance that pin only after validating a released
-version containing
+The script uses the documented workaround of 300 seconds. It deliberately
+leaves verbose logging disabled because Actions logs are public and expanded
+authentication or upload diagnostics could expose derived credentials that
+GitHub cannot mask by their registered secret values. The affected CLI is
+pinned to prevent `latest` from silently changing publish behavior; advance
+that pin only after validating a released version containing
 [microsoft/msstore-cli#163](https://github.com/microsoft/msstore-cli/pull/163).
 
 ### One-time setup (maintainer, outside the repo)

--- a/docs/WINDOWS-STORE-MSIX.md
+++ b/docs/WINDOWS-STORE-MSIX.md
@@ -232,14 +232,15 @@ On a `v*` tag push the workflow:
 
 1. Builds `AetherSDR.exe`, runs `windeployqt`, packages the MSIX, and creates
    the `.msixupload` (existing steps).
-2. `microsoft/microsoft-store-apppublisher@v1.1` puts the `msstore` CLI on PATH.
+2. The pinned `microsoft/microsoft-store-apppublisher` action puts the pinned
+   `msstore` CLI v0.4.1 on PATH and the workflow logs `msstore --version`.
 3. `msstore reconfigure` authenticates from the four GitHub secrets.
 4. `packaging/windows/publish-store.ps1` finds the `.msixupload` and runs
-   `msstore publish <pkg>.msixupload -id <ProductId> --noCommit` — staging a
-   **draft**. `--noCommit` is the safety gate that keeps it out of
-   certification. A maintainer reviews the pending submission in Partner Center
-   and clicks **Submit to Store** to start certification. **CI never publishes
-   to the live channel on its own.**
+   `msstore publish <pkg>.msixupload -id <ProductId> --uploadTimeout 300
+   --verbose --noCommit` — staging a **draft**. `--noCommit` is the safety gate
+   that keeps it out of certification. A maintainer reviews the pending
+   submission in Partner Center and clicks **Submit to Store** to start
+   certification. **CI never publishes to the live channel on its own.**
 
 Guard rails (all three must pass before Partner Center is touched):
 
@@ -253,6 +254,18 @@ Guard rails (all three must pass before Partner Center is touched):
 If the MSIX packaging step (which is `continue-on-error`) produced no
 `.msixupload`, `publish-store.ps1` warns and exits 0 rather than turning an
 otherwise-successful release red.
+
+The upload timeout is deliberately explicit. `msstore` CLI v0.4.0 and v0.4.1
+have a regression where omitting `--uploadTimeout` supplies a zero-second Azure
+blob network timeout, producing the characteristic `Uploading Bundle to Azure
+blob: 0%` failure and exit code `-1`
+([microsoft/msstore-cli#162](https://github.com/microsoft/msstore-cli/issues/162)).
+The script uses the documented workaround of 300 seconds and enables
+`--verbose` so any future upload failure retains its underlying exception in
+the CI log. The affected CLI is pinned to prevent `latest` from silently
+changing publish behavior; advance that pin only after validating a released
+version containing
+[microsoft/msstore-cli#163](https://github.com/microsoft/msstore-cli/pull/163).
 
 ### One-time setup (maintainer, outside the repo)
 

--- a/docs/WINDOWS-STORE-MSIX.md
+++ b/docs/WINDOWS-STORE-MSIX.md
@@ -324,9 +324,10 @@ cadence has proven stable.
 
 The Windows Installer workflow has a production-isolated developer flight
 path. Production tag submissions continue to use `--noCommit` and remain
-draft-only. A scheduled run at 13:17 UTC each day builds current `main`, then a
-separate job commits the verified `.msixupload` to the configured Partner
-Center package flight. The same path can be requested manually from
+draft-only. A timezone-aware scheduled run at midnight in
+`America/Los_Angeles` builds current `main`, then a separate job commits the
+verified `.msixupload` to the configured Partner Center package flight. The
+same path can be requested manually from
 **Run workflow** by selecting **Publish this main-branch build to the developer
 Store flight**; flight publication is restricted to the `main` ref.
 

--- a/packaging/windows/check-symbol-package.ps1
+++ b/packaging/windows/check-symbol-package.ps1
@@ -1,0 +1,130 @@
+<#
+.SYNOPSIS
+    Verify the Store symbol and upload archive topology.
+
+.DESCRIPTION
+    A single-architecture .appxsym must contain only flat PDB entries. The
+    .msixupload must contain that exact .appxsym beside the .msix at its root.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$AppxSymPath,
+    [Parameter(Mandatory = $true)]
+    [string]$MsixUploadPath,
+    [string[]]$RequiredPdbs = @(
+        "AetherSDR.pdb",
+        "Qt6Core.pdb",
+        "Qt6Gui.pdb",
+        "Qt6Multimedia.pdb",
+        "Qt6Network.pdb",
+        "Qt6Widgets.pdb",
+        "qwindows.pdb",
+        "windowsmediaplugin.pdb"
+    )
+)
+
+$ErrorActionPreference = "Stop"
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+function Resolve-RequiredFile {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        [string]$Description
+    )
+
+    $resolved = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+    if (-not (Test-Path -LiteralPath $resolved -PathType Leaf)) {
+        throw "$Description not found: $resolved"
+    }
+    return $resolved
+}
+
+function Get-ZipEntryNames {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($Path)
+    try {
+        return @($archive.Entries | ForEach-Object { $_.FullName.Replace("\", "/") })
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+
+function Get-EmbeddedEntrySha256 {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ArchivePath,
+        [Parameter(Mandatory = $true)]
+        [string]$EntryName
+    )
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($ArchivePath)
+    try {
+        $entry = $archive.GetEntry($EntryName)
+        if (-not $entry) {
+            throw "Archive $ArchivePath does not contain $EntryName."
+        }
+        $stream = $entry.Open()
+        $sha256 = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            return ([BitConverter]::ToString($sha256.ComputeHash($stream))).Replace("-", "").ToLowerInvariant()
+        }
+        finally {
+            $sha256.Dispose()
+            $stream.Dispose()
+        }
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+
+$resolvedAppxSym = Resolve-RequiredFile -Path $AppxSymPath -Description ".appxsym"
+$resolvedMsixUpload = Resolve-RequiredFile -Path $MsixUploadPath -Description ".msixupload"
+
+$symbolEntries = @(Get-ZipEntryNames -Path $resolvedAppxSym)
+if ($symbolEntries.Count -eq 0) {
+    throw ".appxsym is empty: $resolvedAppxSym"
+}
+
+$invalidSymbolEntries = @($symbolEntries | Where-Object {
+    $_.Contains("/") -or -not $_.EndsWith(".pdb", [System.StringComparison]::OrdinalIgnoreCase)
+})
+if ($invalidSymbolEntries.Count -gt 0) {
+    throw ".appxsym entries must be flat PDB files at the archive root: $($invalidSymbolEntries -join ', ')"
+}
+
+foreach ($requiredPdb in $RequiredPdbs) {
+    if ($symbolEntries -notcontains $requiredPdb) {
+        throw ".appxsym is missing required symbol $requiredPdb. Entries: $($symbolEntries -join ', ')"
+    }
+}
+
+$uploadEntries = @(Get-ZipEntryNames -Path $resolvedMsixUpload)
+$nestedUploadEntries = @($uploadEntries | Where-Object { $_.Contains("/") })
+if ($nestedUploadEntries.Count -gt 0) {
+    throw ".msixupload entries must be at the archive root: $($nestedUploadEntries -join ', ')"
+}
+
+$msixEntries = @($uploadEntries | Where-Object { $_.EndsWith(".msix", [System.StringComparison]::OrdinalIgnoreCase) })
+$appxSymEntries = @($uploadEntries | Where-Object { $_.EndsWith(".appxsym", [System.StringComparison]::OrdinalIgnoreCase) })
+if ($msixEntries.Count -ne 1 -or $appxSymEntries.Count -ne 1 -or $uploadEntries.Count -ne 2) {
+    throw ".msixupload must contain exactly one .msix and one .appxsym at its root. Entries: $($uploadEntries -join ', ')"
+}
+
+$standaloneHash = (Get-FileHash -LiteralPath $resolvedAppxSym -Algorithm SHA256).Hash.ToLowerInvariant()
+$embeddedHash = Get-EmbeddedEntrySha256 -ArchivePath $resolvedMsixUpload -EntryName $appxSymEntries[0]
+if ($standaloneHash -ne $embeddedHash) {
+    throw "The .appxsym embedded in .msixupload does not match the verified standalone .appxsym."
+}
+
+Write-Host "Verified .appxsym: $($symbolEntries.Count) flat PDBs."
+Write-Host "Verified .msixupload: one .msix plus the identical .appxsym at archive root."

--- a/packaging/windows/create-msix.ps1
+++ b/packaging/windows/create-msix.ps1
@@ -10,6 +10,10 @@
     Store identity values are deliberately parameters/env vars so the repo can
     build development packages before Partner Center assigns the final package
     Name and Publisher.
+
+    When -CreateUpload is used, -PdbPath identifies the application PDB and
+    -SymbolDir can add dependency PDBs. All PDBs are flattened at the root of
+    the single-architecture .appxsym.
 #>
 
 [CmdletBinding()]
@@ -34,6 +38,7 @@ param(
 
     [string]$IconSource = "docs/assets/logo-circle.png",
     [string]$PdbPath = "build/AetherSDR.pdb",
+    [string]$SymbolDir,
     [switch]$CreateUpload,
     [switch]$ExcludeDfnrModel,
     [switch]$RequirePdb,
@@ -212,14 +217,28 @@ function New-AppInstallerUx {
 function New-AppxSym {
     param(
         [Parameter(Mandatory = $true)]
-        [string]$InputPdbPath,
+        [string[]]$InputPdbPaths,
         [Parameter(Mandatory = $true)]
         [string]$OutputPath
     )
 
-    if (-not (Test-Path -LiteralPath $InputPdbPath)) {
-        Write-Host "No PDB found at $InputPdbPath; skipping .appxsym creation."
+    $existingPdbPaths = @($InputPdbPaths |
+        Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } |
+        ForEach-Object { (Get-Item -LiteralPath $_).FullName } |
+        Sort-Object -Unique)
+    if ($existingPdbPaths.Count -eq 0) {
+        Write-Host "No PDBs found; skipping .appxsym creation."
         return $null
+    }
+
+    $duplicateNames = @($existingPdbPaths |
+        Group-Object { [System.IO.Path]::GetFileName($_) } |
+        Where-Object { $_.Count -gt 1 })
+    if ($duplicateNames.Count -gt 0) {
+        $details = $duplicateNames | ForEach-Object {
+            "$($_.Name): $(($_.Group) -join ', ')"
+        }
+        throw "PDB names must be unique at the .appxsym archive root: $($details -join '; ')"
     }
 
     $stageDir = Join-Path ([System.IO.Path]::GetDirectoryName($OutputPath)) "appxsym-stage"
@@ -228,7 +247,11 @@ function New-AppxSym {
     }
     New-Item -ItemType Directory -Path $stageDir -Force | Out-Null
 
-    Copy-Item -LiteralPath $InputPdbPath -Destination (Join-Path $stageDir ([System.IO.Path]::GetFileName($InputPdbPath))) -Force
+    foreach ($pdbPath in $existingPdbPaths) {
+        # One .appxsym covers one architecture. Microsoft/Visual Studio place
+        # every architecture-matching PDB together at the archive root.
+        Copy-Item -LiteralPath $pdbPath -Destination (Join-Path $stageDir ([System.IO.Path]::GetFileName($pdbPath))) -Force
+    }
 
     $zipPath = "$OutputPath.zip"
     if (Test-Path -LiteralPath $zipPath) {
@@ -298,6 +321,7 @@ $resolvedPackageRoot = Resolve-InputPath $PackageRoot
 $resolvedOutputDir = Resolve-InputPath $OutputDir
 $resolvedIconSource = Resolve-InputPath $IconSource
 $resolvedPdbPath = Resolve-InputPath $PdbPath
+$resolvedSymbolDir = $(if ([string]::IsNullOrWhiteSpace($SymbolDir)) { $null } else { Resolve-InputPath $SymbolDir })
 
 if (-not (Test-Path -LiteralPath $resolvedDeployDir)) {
     throw "Deploy directory not found: $resolvedDeployDir"
@@ -469,9 +493,20 @@ else {
 
 $appxSymPath = $null
 if ($CreateUpload) {
-    $appxSymPath = New-AppxSym -InputPdbPath $resolvedPdbPath -OutputPath (Join-Path $resolvedOutputDir "$packageBaseName.appxsym")
+    if ($RequirePdb -and -not (Test-Path -LiteralPath $resolvedPdbPath -PathType Leaf)) {
+        throw "RequirePdb was specified but the application PDB was not found at $resolvedPdbPath."
+    }
+    $symbolPdbPaths = @($resolvedPdbPath)
+    if ($resolvedSymbolDir) {
+        if (-not (Test-Path -LiteralPath $resolvedSymbolDir -PathType Container)) {
+            throw "Symbol directory not found: $resolvedSymbolDir"
+        }
+        $symbolPdbPaths += @(Get-ChildItem -LiteralPath $resolvedSymbolDir -Recurse -File -Filter "*.pdb" |
+            ForEach-Object { $_.FullName })
+    }
+    $appxSymPath = New-AppxSym -InputPdbPaths $symbolPdbPaths -OutputPath (Join-Path $resolvedOutputDir "$packageBaseName.appxsym")
     if (-not $appxSymPath -and $RequirePdb) {
-        throw "RequirePdb was specified but no PDB was found at $resolvedPdbPath. The .msixupload would ship without crash symbols for Partner Center. Build with -DCMAKE_BUILD_TYPE=RelWithDebInfo (or otherwise ensure the PDB is emitted) before packaging, or drop -RequirePdb for a deliberately symbol-less dev package."
+        throw "RequirePdb was specified but no PDBs were found. The .msixupload would ship without crash symbols for Partner Center. Build with -DCMAKE_BUILD_TYPE=RelWithDebInfo and stage matching dependency symbols before packaging, or drop -RequirePdb for a deliberately symbol-less dev package."
     }
     $uploadPath = Join-Path $resolvedOutputDir "$packageBaseName.msixupload"
     New-MsixUpload -MsixPath $msixPath -AppxSymPath $appxSymPath -OutputPath $uploadPath

--- a/packaging/windows/publish-store.ps1
+++ b/packaging/windows/publish-store.ps1
@@ -13,6 +13,9 @@
     reviews the pending submission in Partner Center and clicks "Submit to
     Store" to begin certification. Pass -Commit to skip the draft gate and send
     the submission straight to certification (each tag goes live on approval).
+    Pass -FlightId to target an existing Partner Center package flight. The
+    package identity and ProductId remain those of the production app; the
+    flight controls the restricted audience.
 
     Authentication is expected to already be configured via a prior
     `msstore reconfigure` call (tenant/seller/client id + client secret), which
@@ -33,6 +36,11 @@
     Glob used to find the upload package. Defaults to the create-msix.ps1
     naming convention "AetherSDR-*.msixupload".
 
+.PARAMETER FlightId
+    Optional Partner Center package flight Id. Defaults to
+    $env:AETHERSDR_STORE_FLIGHT_ID. When set, msstore publishes the package to
+    that flight instead of the production submission.
+
 .PARAMETER SearchDir
     Directory to search for the upload package. Defaults to the current
     directory (where the workflow runs create-msix.ps1 with -OutputDir .).
@@ -45,6 +53,7 @@
 [CmdletBinding()]
 param(
     [string]$ProductId = $env:AETHERSDR_STORE_PRODUCT_ID,
+    [string]$FlightId = $env:AETHERSDR_STORE_FLIGHT_ID,
     [string]$UploadGlob = "AetherSDR-*.msixupload",
     [string]$SearchDir = ".",
     [switch]$Commit
@@ -74,9 +83,15 @@ if ($uploads.Count -gt 1) {
 
 $upload = $uploads[0].FullName
 Write-Host "Store product Id : $ProductId"
+if (-not [string]::IsNullOrWhiteSpace($FlightId)) {
+    Write-Host "Store flight Id  : $FlightId"
+}
 Write-Host "Upload package   : $upload"
 
 $publishArgs = @("publish", $upload, "-id", $ProductId)
+if (-not [string]::IsNullOrWhiteSpace($FlightId)) {
+    $publishArgs += @("-f", $FlightId)
+}
 if (-not $Commit) {
     # --noCommit (-nc) uploads the package but keeps the submission in DRAFT
     # state; a maintainer commits it from Partner Center. This is the safety
@@ -85,7 +100,12 @@ if (-not $Commit) {
     Write-Host "Mode             : DRAFT (--noCommit; a maintainer submits from Partner Center)"
 }
 else {
-    Write-Host "Mode             : COMMIT (submission sent to certification)"
+    if (-not [string]::IsNullOrWhiteSpace($FlightId)) {
+        Write-Host "Mode             : COMMIT (restricted flight sent to certification)"
+    }
+    else {
+        Write-Host "Mode             : COMMIT (production submission sent to certification)"
+    }
 }
 
 Write-Host "Running: msstore $($publishArgs -join ' ')"
@@ -94,4 +114,9 @@ if ($LASTEXITCODE -ne 0) {
     throw "msstore publish failed with exit code $LASTEXITCODE."
 }
 
-Write-Host "Microsoft Store submission staged successfully."
+if ($Commit) {
+    Write-Host "Microsoft Store submission committed successfully."
+}
+else {
+    Write-Host "Microsoft Store submission staged successfully."
+}

--- a/packaging/windows/publish-store.ps1
+++ b/packaging/windows/publish-store.ps1
@@ -13,9 +13,6 @@
     reviews the pending submission in Partner Center and clicks "Submit to
     Store" to begin certification. Pass -Commit to skip the draft gate and send
     the submission straight to certification (each tag goes live on approval).
-    Pass -FlightId to target an existing Partner Center package flight. The
-    package identity and ProductId remain those of the production app; the
-    flight controls the restricted audience.
 
     Authentication is expected to already be configured via a prior
     `msstore reconfigure` call (tenant/seller/client id + client secret), which
@@ -36,11 +33,6 @@
     Glob used to find the upload package. Defaults to the create-msix.ps1
     naming convention "AetherSDR-*.msixupload".
 
-.PARAMETER FlightId
-    Optional Partner Center package flight Id. Defaults to
-    $env:AETHERSDR_STORE_FLIGHT_ID. When set, msstore publishes the package to
-    that flight instead of the production submission.
-
 .PARAMETER SearchDir
     Directory to search for the upload package. Defaults to the current
     directory (where the workflow runs create-msix.ps1 with -OutputDir .).
@@ -58,7 +50,6 @@
 [CmdletBinding()]
 param(
     [string]$ProductId = $env:AETHERSDR_STORE_PRODUCT_ID,
-    [string]$FlightId = $env:AETHERSDR_STORE_FLIGHT_ID,
     [string]$UploadGlob = "AetherSDR-*.msixupload",
     [string]$SearchDir = ".",
     [ValidateRange(100, 100000)]
@@ -90,9 +81,6 @@ if ($uploads.Count -gt 1) {
 
 $upload = $uploads[0].FullName
 Write-Host "Store product Id : $ProductId"
-if (-not [string]::IsNullOrWhiteSpace($FlightId)) {
-    Write-Host "Store flight Id  : $FlightId"
-}
 Write-Host "Upload package   : $upload"
 Write-Host "Upload timeout   : $UploadTimeoutSeconds seconds"
 
@@ -105,9 +93,6 @@ $publishArgs = @(
     $UploadTimeoutSeconds.ToString([System.Globalization.CultureInfo]::InvariantCulture),
     "--verbose"
 )
-if (-not [string]::IsNullOrWhiteSpace($FlightId)) {
-    $publishArgs += @("-f", $FlightId)
-}
 if (-not $Commit) {
     # --noCommit (-nc) uploads the package but keeps the submission in DRAFT
     # state; a maintainer commits it from Partner Center. This is the safety
@@ -116,12 +101,7 @@ if (-not $Commit) {
     Write-Host "Mode             : DRAFT (--noCommit; a maintainer submits from Partner Center)"
 }
 else {
-    if (-not [string]::IsNullOrWhiteSpace($FlightId)) {
-        Write-Host "Mode             : COMMIT (restricted flight sent to certification)"
-    }
-    else {
-        Write-Host "Mode             : COMMIT (production submission sent to certification)"
-    }
+    Write-Host "Mode             : COMMIT (submission sent to certification)"
 }
 
 Write-Host "Running: msstore $($publishArgs -join ' ')"
@@ -130,9 +110,4 @@ if ($LASTEXITCODE -ne 0) {
     throw "msstore publish failed with exit code $LASTEXITCODE."
 }
 
-if ($Commit) {
-    Write-Host "Microsoft Store submission committed successfully."
-}
-else {
-    Write-Host "Microsoft Store submission staged successfully."
-}
+Write-Host "Microsoft Store submission staged successfully."

--- a/packaging/windows/publish-store.ps1
+++ b/packaging/windows/publish-store.ps1
@@ -45,6 +45,11 @@
     Directory to search for the upload package. Defaults to the current
     directory (where the workflow runs create-msix.ps1 with -OutputDir .).
 
+.PARAMETER UploadTimeoutSeconds
+    Network timeout, in seconds, for each Azure blob upload request. Defaults
+    to 300. This is always passed explicitly because msstore CLI v0.4.0 and
+    v0.4.1 incorrectly use zero when --uploadTimeout is omitted.
+
 .PARAMETER Commit
     Send the submission straight to certification instead of staging a draft.
     Drops the `--noCommit` safety gate.
@@ -56,6 +61,8 @@ param(
     [string]$FlightId = $env:AETHERSDR_STORE_FLIGHT_ID,
     [string]$UploadGlob = "AetherSDR-*.msixupload",
     [string]$SearchDir = ".",
+    [ValidateRange(100, 100000)]
+    [long]$UploadTimeoutSeconds = 300,
     [switch]$Commit
 )
 
@@ -87,8 +94,17 @@ if (-not [string]::IsNullOrWhiteSpace($FlightId)) {
     Write-Host "Store flight Id  : $FlightId"
 }
 Write-Host "Upload package   : $upload"
+Write-Host "Upload timeout   : $UploadTimeoutSeconds seconds"
 
-$publishArgs = @("publish", $upload, "-id", $ProductId)
+$publishArgs = @(
+    "publish",
+    $upload,
+    "-id",
+    $ProductId,
+    "--uploadTimeout",
+    $UploadTimeoutSeconds.ToString([System.Globalization.CultureInfo]::InvariantCulture),
+    "--verbose"
+)
 if (-not [string]::IsNullOrWhiteSpace($FlightId)) {
     $publishArgs += @("-f", $FlightId)
 }

--- a/packaging/windows/publish-store.ps1
+++ b/packaging/windows/publish-store.ps1
@@ -90,8 +90,7 @@ $publishArgs = @(
     "-id",
     $ProductId,
     "--uploadTimeout",
-    $UploadTimeoutSeconds.ToString([System.Globalization.CultureInfo]::InvariantCulture),
-    "--verbose"
+    $UploadTimeoutSeconds.ToString([System.Globalization.CultureInfo]::InvariantCulture)
 )
 if (-not $Commit) {
     # --noCommit (-nc) uploads the package but keeps the submission in DRAFT

--- a/packaging/windows/stage-debug-symbols.ps1
+++ b/packaging/windows/stage-debug-symbols.ps1
@@ -1,0 +1,182 @@
+<#
+.SYNOPSIS
+    Stage application and deployed Qt PDBs for Store and local debugging.
+
+.DESCRIPTION
+    Run this immediately after windeployqt --pdb. The script verifies that
+    every deployed Qt DLL/plugin has the same-named PDB beside it, copies all
+    deployed PDBs plus AetherSDR.pdb into one flat, architecture-specific
+    symbol directory, and removes PDBs from the runtime deploy tree.
+
+    Microsoft Store .appxsym files contain the PDBs for one architecture at
+    the archive root. create-msix.ps1 consumes this directory without adding
+    another path level.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$DeployDir = "deploy",
+    [string]$ApplicationPdb = "build/AetherSDR.pdb",
+    [string]$OutputDir = "symbols",
+    [string]$QtRootDir = $env:QT_ROOT_DIR
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-InputPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    return $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+}
+
+function Get-RelativeDeployPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Root,
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $prefix = $Root.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+    return $Path.Substring($prefix.Length).TrimStart([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar).Replace("\", "/")
+}
+
+$resolvedDeployDir = Resolve-InputPath $DeployDir
+$resolvedApplicationPdb = Resolve-InputPath $ApplicationPdb
+$resolvedOutputDir = Resolve-InputPath $OutputDir
+$resolvedQtRootDir = $(if ([string]::IsNullOrWhiteSpace($QtRootDir)) { $null } else { Resolve-InputPath $QtRootDir })
+
+if (-not (Test-Path -LiteralPath $resolvedDeployDir -PathType Container)) {
+    throw "Deploy directory not found: $resolvedDeployDir"
+}
+if (-not (Test-Path -LiteralPath $resolvedApplicationPdb -PathType Leaf)) {
+    throw "Application PDB not found: $resolvedApplicationPdb"
+}
+if (-not $resolvedQtRootDir -or -not (Test-Path -LiteralPath $resolvedQtRootDir -PathType Container)) {
+    throw "QtRootDir is required and must identify the exact Qt installation used by windeployqt."
+}
+
+# Identify Qt binaries by mapping each deployed relative path back to the exact
+# Qt installation used by windeployqt. This covers new plugin directories
+# automatically instead of maintaining a fragile directory allow-list.
+$qtBinaries = @()
+foreach ($binary in Get-ChildItem -LiteralPath $resolvedDeployDir -Recurse -File -Filter "*.dll") {
+    $relativePath = Get-RelativeDeployPath -Root $resolvedDeployDir -Path $binary.FullName
+    if ($binary.Name -ieq "qt6keychain.dll") {
+        continue # injected into Qt/bin only so windeployqt can scan it; not a Qt SDK binary
+    }
+
+    if ($relativePath.Contains("/")) {
+        $sourcePath = Join-Path (Join-Path $resolvedQtRootDir "plugins") $relativePath.Replace("/", [System.IO.Path]::DirectorySeparatorChar)
+    }
+    else {
+        # Qt's Multimedia module also installs third-party FFmpeg DLLs in
+        # Qt/bin without corresponding Qt PDBs. Root libraries owned by Qt
+        # carry the Qt6 prefix; leave other bundled dependencies out of this
+        # Qt-symbol completeness check.
+        if ($binary.Name -notlike "Qt6*.dll") {
+            continue
+        }
+        $sourcePath = Join-Path (Join-Path $resolvedQtRootDir "bin") $binary.Name
+    }
+
+    if (Test-Path -LiteralPath $sourcePath -PathType Leaf) {
+        $qtBinaries += [pscustomobject]@{
+            Deployed = $binary
+            Source = Get-Item -LiteralPath $sourcePath
+            RelativePath = $relativePath
+        }
+    }
+}
+$qtBinaries = @($qtBinaries | Sort-Object RelativePath)
+
+if ($qtBinaries.Count -eq 0) {
+    throw "No deployed Qt DLLs were found under $resolvedDeployDir. Run windeployqt before staging symbols."
+}
+
+$missingPdbs = @()
+foreach ($binary in $qtBinaries) {
+    $sourcePdbPath = [System.IO.Path]::ChangeExtension($binary.Source.FullName, ".pdb")
+    $deployedPdbPath = [System.IO.Path]::ChangeExtension($binary.Deployed.FullName, ".pdb")
+    if (-not (Test-Path -LiteralPath $sourcePdbPath -PathType Leaf)) {
+        $missingPdbs += "$($binary.RelativePath) (missing from Qt installation)"
+        continue
+    }
+    if (-not (Test-Path -LiteralPath $deployedPdbPath -PathType Leaf)) {
+        $missingPdbs += "$($binary.RelativePath) (not deployed)"
+        continue
+    }
+
+    $sourceHash = (Get-FileHash -LiteralPath $sourcePdbPath -Algorithm SHA256).Hash
+    $deployedHash = (Get-FileHash -LiteralPath $deployedPdbPath -Algorithm SHA256).Hash
+    if ($sourceHash -ne $deployedHash) {
+        throw "Deployed PDB does not match the exact Qt-installation PDB for $($binary.RelativePath)."
+    }
+}
+
+if ($missingPdbs.Count -gt 0) {
+    throw ("windeployqt did not deploy matching PDBs for these Qt binaries: " + ($missingPdbs -join ", ") +
+        ". Install the Qt debug_info and <module>.debug_information archives and run windeployqt --pdb.")
+}
+
+$deployPdbs = @(Get-ChildItem -LiteralPath $resolvedDeployDir -Recurse -File -Filter "*.pdb" | Sort-Object FullName)
+$allPdbs = @((Get-Item -LiteralPath $resolvedApplicationPdb)) + $deployPdbs
+$duplicateNames = @($allPdbs | Group-Object Name | Where-Object { $_.Count -gt 1 })
+if ($duplicateNames.Count -gt 0) {
+    $details = $duplicateNames | ForEach-Object {
+        "$($_.Name): $(($_.Group.FullName) -join ', ')"
+    }
+    throw "PDB names must be unique when flattened into one .appxsym: $($details -join '; ')"
+}
+
+if (Test-Path -LiteralPath $resolvedOutputDir) {
+    Remove-Item -LiteralPath $resolvedOutputDir -Recurse -Force
+}
+New-Item -ItemType Directory -Path $resolvedOutputDir -Force | Out-Null
+
+$manifestEntries = @()
+foreach ($pdb in $allPdbs) {
+    $destination = Join-Path $resolvedOutputDir $pdb.Name
+    Copy-Item -LiteralPath $pdb.FullName -Destination $destination -Force
+
+    $sourceBinary = $null
+    if ($pdb.FullName -eq $resolvedApplicationPdb) {
+        $candidate = Join-Path $resolvedDeployDir "AetherSDR.exe"
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            $sourceBinary = $candidate
+        }
+    }
+    else {
+        $candidate = [System.IO.Path]::ChangeExtension($pdb.FullName, ".dll")
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            $sourceBinary = $candidate
+        }
+    }
+
+    $manifestEntries += [ordered]@{
+        pdb = $pdb.Name
+        pdbSha256 = (Get-FileHash -LiteralPath $destination -Algorithm SHA256).Hash.ToLowerInvariant()
+        binary = $(if ($sourceBinary) { Get-RelativeDeployPath -Root $resolvedDeployDir -Path $sourceBinary } else { $null })
+        binarySha256 = $(if ($sourceBinary) { (Get-FileHash -LiteralPath $sourceBinary -Algorithm SHA256).Hash.ToLowerInvariant() } else { $null })
+    }
+}
+
+$manifestPath = Join-Path $resolvedOutputDir "symbols-manifest.json"
+$manifestEntries | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $manifestPath -Encoding UTF8
+
+# The portable ZIP, Inno installer, and MSIX all consume deploy/. Symbols are
+# Store/debugging metadata and must not ship in those runtime payloads.
+foreach ($pdb in $deployPdbs) {
+    Remove-Item -LiteralPath $pdb.FullName -Force
+}
+
+$remainingPdbs = @(Get-ChildItem -LiteralPath $resolvedDeployDir -Recurse -File -Filter "*.pdb")
+if ($remainingPdbs.Count -gt 0) {
+    throw "PDB files remain in the runtime deploy tree: $(($remainingPdbs.FullName) -join ', ')"
+}
+
+Write-Host "Staged $($allPdbs.Count) PDBs in $resolvedOutputDir ($($qtBinaries.Count) Qt binaries verified)."
+Write-Host "Symbol manifest: $manifestPath"


### PR DESCRIPTION
## Summary

- install the Qt debug-information archives used by the Windows release build and run `windeployqt --pdb`
- stage the AetherSDR and deployed Qt PDBs as one verified, architecture-specific symbol set without shipping PDBs in the runtime payload
- package every staged PDB at the root of the Store `.appxsym`, verify the complete `.msixupload` topology, and retain the same set as the `Windows-Symbols` artifact with a SHA-256 manifest
- pin Microsoft Store CLI v0.4.1 and pass `--uploadTimeout 300`, avoiding its zero-second upload-timeout regression while retaining the production `--noCommit` draft gate and defaulting public CI logs to non-verbose output

The final diff deliberately contains no developer-flight implementation, scheduled build, flight secret, flight version override, or automatic Store commit. Those ideas are deferred to separate follow-up work.

## Why

Partner Center currently receives AetherSDR's application PDB but not the matching Qt PDBs, leaving crashes and shutdown/audio failures inside Qt as module offsets. The Store upload from the last release also matched microsoft/msstore-cli#162: v0.4.0/v0.4.1 use a zero-second Azure blob timeout when `--uploadTimeout` is omitted and fail at 0% with exit code -1.

## Packaging invariants

- every deployed Qt DLL/plugin must have a same-named PDB from the exact Qt installation used by `windeployqt`
- Qt PDB hashes are checked before staging
- `.appxsym` contains flat PDB entries for one architecture
- `.msixupload` contains exactly one `.msix` and the identical verified `.appxsym` at its root
- PDBs are removed from `deploy/`, so the portable ZIP, Inno installer, and MSIX runtime payloads do not grow
- production Store publishing remains draft-only through `--noCommit`
- public Actions logs use the Store CLI's default verbosity; `--verbose` is not enabled

## Validation

- [Windows Installer run 33549467754](https://github.com/aethersdr/AetherSDR/actions/runs/33549467754) against the original PR head completed successfully: 24 PDBs staged, all 23 deployed Qt binaries verified, 24 flat `.appxsym` PDBs verified, and the `.msixupload` contained one `.msix` plus the byte-identical `.appxsym`
- downloaded artifact inspection from that run: zero PDB entries in the standalone `.msix` and portable runtime ZIP, exactly 24 PDBs in `.appxsym`, and an `.msixupload` root containing only the byte-identical `.msix` and `.appxsym`
- `actionlint .github/workflows/windows-installer.yml`
- PowerShell parser validation for all four changed/new scripts
- synthetic symbol staging: application plus two representative Qt binaries, including exact-source hash checks and PDB removal from the runtime tree
- synthetic archive validation: eight required flat PDBs and byte-identical `.appxsym` inside `.msixupload`
- mocked `msstore publish` argument validation: `--uploadTimeout 300 --noCommit`
- `python3 tools/check_test_registration.py --strict`
- `python3 tools/check_engine_boundary.py --strict` (zero blocking findings; existing baseline warnings only)
- `git diff --check origin/main`
- `git merge-tree --write-tree origin/main HEAD`

The workflow-dispatch validation deliberately skipped the Store submission because it ran on a branch rather than a release tag. A subsequent draft submission remains the Partner Center end-to-end check. Store acceptance alone will not prove Microsoft indexed third-party Qt symbols; the first qualifying Partner Center Health report remains the end-to-end symbolication check.

Generated with OpenAI Codex (Daybreak Blue)
