### PR TITLE
fix(hl2): scale the forward-power gauges to the radio's 5 W, not 100 W

### DIFF
--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -101,6 +101,14 @@ constexpr int kIqSampleRatesHz[] = {48000, 96000, 192000, 384000};
 // guard.
 constexpr int kMinForwardCountsForSwr = 16;
 
+// The radio's rated output, in watts, as the gauges' full-scale reference.
+//
+// The HL2 wiki's own FAQ: "The Hermes-Lite 2.0 is a QRP transceiver and
+// achieves 5W out on all HF amateur radio bands." A published figure rather
+// than a measurement, which is the right kind of number for a scale — it must
+// be the same on every operator's radio, not a property of one unit's PA.
+constexpr int kHl2RatedOutputWatts = 5;
+
 // Snap a requested span (Hz) to the rate that best matches it.
 //
 // Nearest in the LOG domain, not the linear one: the rates are octave-spaced, so
@@ -1417,6 +1425,30 @@ RadioCapabilities Hl2Backend::capabilities() const
     // rolls off and there is nothing to hear.
     c.tuningMinHz = 100'000.0;
     c.tuningMaxHz = 38'400'000.0;
+    // THE RADIO'S POWER CLASS, which is what every forward-power gauge scales
+    // its arc from. Declared as a band table because that is the seam the
+    // clients already read: RadioModel::refreshTxPowerLimit turns it into
+    // TransmitModel::maxPowerLevel, and TxApplet additionally treats a
+    // non-empty table as permission to draw a face other than the 100 W one
+    // (m_forwardPowerScaleFollowsBandRating).
+    //
+    // WITHOUT IT, TransmitModel kept its compiled-in 100 W default and every
+    // gauge scaled for a 100 W radio: a full-power HL2 transmission sat in the
+    // bottom few percent of the arc, which is indistinguishable from a meter
+    // that does not work — and is what it has been reported as.
+    //
+    // ONE BAND, spanning the whole tuning range, because that is the truth
+    // about this radio rather than a simplification: "The Hermes-Lite 2.0 is a
+    // QRP transceiver and achieves 5W out on ALL HF amateur radio bands" (HL2
+    // wiki, FAQ). Unlike the IC-9700, whose three decks each have their own
+    // ceiling, there is no per-band variation to describe.
+    //
+    // The secondary instrumentation output at RF1 is +17 dBm and is
+    // deliberately NOT what this describes: it is selected in hardware with no
+    // register to read back, so scaling for it would be wrong for every
+    // operator using the normal output.
+    c.txPowerBands = {TxPowerBand{c.tuningMinHz, c.tuningMaxHz,
+                                  static_cast<double>(kHl2RatedOutputWatts)}};
     // Reported from the gate, not hardcoded: the engine's TX guard keys off this,
     // so a build with transmit disabled must look RX-only from above the seam.
     c.canTransmit = m_txAllowed;
@@ -4549,6 +4581,7 @@ void Hl2Backend::pushInitialState()
     // belongs here.
     if (const Receiver* txRx = rx(m_txDdc))
         setTxFrequency(txRx->sliceFreqHz);
+
     // NOT the drive level. connectRadio() already asserts a safe 0 before the
     // link comes up, and by the time this runs RadioModel has pushed the
     // operator's actual RF power — emit connected() above is synchronous, so

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -264,15 +264,20 @@ RadioCapabilities IcomCivBackend::capabilities() const
 
     // Published from the model's own band table rather than a second hand-kept
     // list, so the ceilings and the tune guard can never describe different
-    // hardware. An empty table (every model but the IC-9700) leaves the vector
-    // empty, which is what RadioModel reads as "txPowerMaxWatts applies
-    // everywhere" — the prior behaviour, unchanged.
+    // hardware. IC-705 additionally opts into one continuous rated-output
+    // range so its verified 10 W ceiling drives the low-power face. Other
+    // continuous-range models keep an empty vector and their prior UI path.
     c.txPowerBands = {};
     c.txPowerBands.reserve(static_cast<int>(bands.size()));
     for (const IcomBand& band : bands) {
         c.txPowerBands.append(TxPowerBand{static_cast<double>(band.lowHz),
                                           static_cast<double>(band.highHz),
                                           band.maxWatts});
+    }
+    if (bands.empty() && profile.meters.scaleForwardPowerToRatedOutput
+        && m.hasTransmit && m.txPowerMaxWatts > 0.0) {
+        c.txPowerBands.append(TxPowerBand{c.tuningMinHz, c.tuningMaxHz,
+                                          m.txPowerMaxWatts});
     }
     c.forwardPowerRequiresSmoothing = profile.meters.powerConversion
         != MeterCalibrationProfile::PowerConversion::RelativePercentOfBandRating;

--- a/src/core/backends/icom/IcomModels.cpp
+++ b/src/core/backends/icom/IcomModels.cpp
@@ -598,6 +598,7 @@ const IcomModelProfile& profileFor(const IcomModel& model) noexcept
         .meters = MeterCalibrationProfile{
             .calibration = MeterCalibration::Ic705,
             .currentFullScaleAmps = 4.0,
+            .scaleForwardPowerToRatedOutput = true,
             .holdIsolatedTxMinimums = true,
         },
         .memory = MemoryProfile{MemoryDialect::Ic705, 0, 99, 0, 99, true, "Group"},

--- a/src/core/backends/icom/IcomModels.h
+++ b/src/core/backends/icom/IcomModels.h
@@ -412,6 +412,10 @@ struct MeterCalibrationProfile {
     MeterCalibration calibration = MeterCalibration::Uncalibrated;
     double currentFullScaleAmps = 4.0;
     PowerConversion powerConversion = PowerConversion::NativeWatts;
+    // Opt into a forward-power face derived from this model's published
+    // txPowerMaxWatts even when it has one continuous tuning range. Keep this
+    // model-specific: a low-power face must not leak to sibling Icom profiles.
+    bool scaleForwardPowerToRatedOutput = false;
     // UI exposure is narrower than wire decoding. Several Icom profiles have
     // an Id calibration, but each model must be approved independently before
     // Radio Vitals offers that instrument.

--- a/src/gui/SMeterWidget.cpp
+++ b/src/gui/SMeterWidget.cpp
@@ -17,6 +17,12 @@
 
 namespace AetherSDR {
 
+// Radios at or below this declared output get an arc scaled to their own limit
+// instead of the 120 W one. Deliberately the SAME threshold the cross-needle
+// already uses (CrossNeedleMeterGeometry::rangeMultiplierFor), so a QRP radio
+// cannot end up with one gauge on a QRP scale and the other on a 120 W scale.
+constexpr int kQrpMaxWatts = 20;
+
 SMeterWidgetAccessible::SMeterWidgetAccessible(QWidget* widget)
     : QAccessibleWidget(widget, QAccessible::Indicator)
 {
@@ -1134,6 +1140,23 @@ void SMeterWidget::setPowerScale(int maxWatts, bool hasAmplifier)
     } else if (maxWatts > 100) {
         m_powerScaleMax = 600.0f;
         m_powerRedStart = 500.0f;
+    } else if (maxWatts > 0 && maxWatts <= kQrpMaxWatts) {
+        // QRP. Without this the smallest arc available was 120 W, so a 5 W
+        // Hermes-Lite 2 at full output moved the needle about four percent of
+        // its travel — a working meter that reads as a broken one. The
+        // cross-needle already had a low bucket
+        // (CrossNeedleMeterGeometry::rangeMultiplierFor, maxWatts <= 20); this
+        // is the S-meter's missing counterpart, keyed off the same threshold so
+        // the two gauges cannot end up on different scales for one radio.
+        //
+        // Derived from the radio's declared limit rather than another fixed
+        // arc, because "QRP" spans 1 W to 20 W and a single constant would be
+        // wrong at both ends. The 1.2x headroom and the red zone at the rated
+        // figure reproduce exactly the relationship the 100 W case already
+        // uses (120 max, red from 100), so the meter reads the same way at
+        // every power class.
+        m_powerScaleMax = static_cast<float>(maxWatts) * 1.2f;
+        m_powerRedStart = static_cast<float>(maxWatts);
     } else {
         m_powerScaleMax = 120.0f;
         m_powerRedStart = 100.0f;

--- a/tests/icom_power_derivation_test.cpp
+++ b/tests/icom_power_derivation_test.cpp
@@ -161,8 +161,10 @@ void testIc9700DerivedForwardPowerAcrossBands()
               "IC-705 keeps its native 5 W raw-143 calibration");
         check(backend.capabilities().forwardPowerRequiresSmoothing,
               "IC-705 retains established client-side power ballistics");
-        check(backend.capabilities().txPowerBands.isEmpty(),
-              "IC-705 does not inherit the IC-9700 per-band power ratings");
+        const RadioCapabilities caps = backend.capabilities();
+        check(caps.txPowerBands.size() == 1
+                  && caps.txPowerMaxWattsAt(14'100'000.0) == 10.0,
+              "IC-705 uses only its own continuous 10 W rated-output range");
     }
 
     const IcomModel* ic7300mk2 = modelForCivAddress(0xB6);

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -432,8 +432,9 @@ int main(int argc, char** argv)
         check(caps.receiveOnlyModes.isEmpty(),
               "HL2 declares no receive-only modes — it modulates on this host, "
               "so there is no mode it hears and cannot send");
-        check(caps.txPowerBands.isEmpty(),
-              "HL2 explicitly leaves per-band TX power limits empty");
+        check(caps.txPowerBands.size() == 1
+                  && caps.txPowerMaxWattsAt(14'200'000.0) == 5.0,
+              "HL2 declares its continuous 5 W rated-output range");
         check(!caps.hasDaxStreams,
               "HL2 declares hasDaxStreams=false (one raw IQ feed, no stream plane)");
         check(!caps.hasExtendedDsp,
@@ -618,6 +619,29 @@ int main(int argc, char** argv)
     // ---- Icom model capabilities and CI-V dial lock without a socket -------
     {
         using namespace AetherSDR::icom;
+        const IcomModel* ic705 = modelForName("IC-705");
+        check(ic705 != nullptr, "the IC-705 resolves from the Icom model table");
+        if (ic705) {
+            IcomCivBackend backend;
+            IcomCivBackendTestAccess::selectModel(backend, *ic705);
+            const RadioCapabilities caps = backend.capabilities();
+            check(caps.txPowerBands.size() == 1
+                      && caps.txPowerMaxWattsAt(14'200'000.0) == 10.0,
+                  "IC-705 alone declares its continuous 10 W rated-output range");
+        }
+
+        const IcomModel* ic7300Mk2 = modelForName("IC-7300MK2");
+        check(ic7300Mk2 != nullptr,
+              "the IC-7300MK2 resolves from the Icom model table");
+        if (ic7300Mk2) {
+            IcomCivBackend backend;
+            IcomCivBackendTestAccess::selectModel(backend, *ic7300Mk2);
+            const RadioCapabilities caps = backend.capabilities();
+            check(caps.txPowerBands.isEmpty()
+                      && caps.txPowerMaxWattsAt(14'200'000.0) == 100.0,
+                  "IC-7300MK2 retains its unbanded 100 W capability path");
+        }
+
         const IcomModel* ic9700 = modelForName("IC-9700");
         check(ic9700 != nullptr, "the IC-9700 resolves from the Icom model table");
         // Guarded as a block: without the guard a failed lookup would run the


### PR DESCRIPTION
## Summary

- Declare the Hermes-Lite 2 continuous 5 W rated-output range so forward-power gauges use a 0-6 W face instead of the 100 W default.
- Add the missing low-power branch to the shared S-meter, using 120% of the declared rating and the same <=20 W threshold as the cross-needle meter.
- Opt only the IC-705 into its existing verified 10 W rated-output capability, producing a 0-12 W face.
- Keep the RF Power slider on its existing 0-100% drive scale.

## Radio isolation

- Flex capability and slider paths are unchanged.
- IC-9700 retains its exact three-deck 100 W / 75 W / 10 W table.
- IC-7300MK2 retains its empty band table and existing 100 W face.
- No new test target, socket owner, or CI workload is added.

## Verification

- Full AetherSDR application compilation and link passed on macOS.
- `radio_capability_gating_test`
- `icom_power_derivation_test`
- `s_meter_geometry_test`
- `tx_applet_power_reconciliation_test`

All four focused tests pass headless. Mutation-checking the IC-705 opt-in made both IC-705 isolation assertions fail, and restoring it returned the suite to green. Strict engine-boundary validation reports zero blockers.

Live Hermes-Lite 2 evidence from gateware v7.5 with an N2ADR filter board showed 0-6 W gauges with red beginning at 5 W and readable 0 / 2 / 4 / 5 / 6 TX ticks.

## Related issue

Addresses the fixed 120 W face and IC-705 rated-output portion of #5071. The issue remains open for reading the active 0.5 / 1 / 2.5 / 5 / 10 W configured ceiling and any Watts/Percent selector.

Generated with OpenAI Codex (Daybreak Blue)
