### PR TITLE
feat(gui): bring Aether-gate's device controls into the app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -976,6 +976,7 @@ set(GUI_SOURCES
     src/gui/PanLayoutDialog.cpp
     src/gui/AppletPanel.cpp
     src/gui/KiwiSdrApplet.cpp
+    src/gui/AetherGateApplet.cpp
     src/gui/KiwiPublicReceiverPicker.cpp
     src/gui/FavoritesPickerDialog.cpp
     src/gui/RxApplet.cpp

--- a/src/gui/AetherGateApplet.cpp
+++ b/src/gui/AetherGateApplet.cpp
@@ -1,0 +1,434 @@
+#include "AetherGateApplet.h"
+
+#include "core/ThemeManager.h"
+#include "models/RadioModel.h"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QFormLayout>
+#include <QHideEvent>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLabel>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QShowEvent>
+#include <QSignalBlocker>
+#include <QSpinBox>
+#include <QTimer>
+#include <QUrlQuery>
+#include <QVariant>
+#include <QVBoxLayout>
+
+namespace AetherSDR {
+
+// The gate's --ctl-port default. Not discoverable over the Flex protocol, which
+// has no verb to advertise it, so it is a convention shared with the gate.
+static constexpr int kGateControlPort = 8731;
+
+// Give up on a gate after this many consecutive failed polls. One miss is a
+// dropped packet; a run of them means we are talking to a real Flex (or the
+// gate died) and the applet should get out of the way.
+static constexpr int kFailuresBeforeAbsent = 3;
+
+static const char* kRowLabelStyle =
+    "QLabel { color: #8090a0; font-size: 10px; font-weight: bold; }";
+
+namespace {
+
+QString formatHz(double hz)
+{
+    if (hz >= 1.0e6)
+        return QStringLiteral("%1 MHz").arg(hz / 1.0e6, 0, 'f', 3);
+    return QStringLiteral("%1 kHz").arg(hz / 1.0e3, 0, 'f', 1);
+}
+
+QString formatBinWidth(double hz)
+{
+    if (hz >= 1000.0)
+        return QStringLiteral("%1 kHz / bin").arg(hz / 1000.0, 0, 'f', 2);
+    return QStringLiteral("%1 Hz / bin").arg(hz, 0, 'f', 1);
+}
+
+// Repopulate without the refill looking like an operator choice: every control
+// here writes to the radio on change, so an unblocked rebuild would re-send the
+// value the gate just reported back to it, once per poll.
+void setComboItems(QComboBox* combo, const QStringList& items, const QString& current)
+{
+    const QSignalBlocker block(combo);
+    if (combo->count() != items.size()) {
+        combo->clear();
+        combo->addItems(items);
+    }
+    const int idx = combo->findText(current);
+    if (idx >= 0)
+        combo->setCurrentIndex(idx);
+}
+
+} // namespace
+
+AetherGateApplet::AetherGateApplet(QWidget* parent)
+    : QWidget(parent)
+{
+    theme::setContainer(this, QStringLiteral("applet/gate"));
+
+    auto* root = new QVBoxLayout(this);
+    root->setContentsMargins(8, 6, 8, 8);
+    root->setSpacing(6);
+
+    m_status = new QLabel(tr("looking for a gate…"), this);
+    m_status->setStyleSheet(kRowLabelStyle);
+    root->addWidget(m_status);
+
+    // --- panadapter resolution ------------------------------------------
+    // Duplicated with the pan's own zoom on purpose: the zoom is a gesture and
+    // this is a readout you can set exactly, and only this one shows what the
+    // bin width actually came out as.
+    auto* resForm = new QFormLayout;
+    resForm->setContentsMargins(0, 0, 0, 0);
+    resForm->setSpacing(4);
+
+    m_span = new QComboBox(this);
+    m_span->setToolTip(tr("Receiver sample rate. On an SDR the rate IS the "
+                          "panadapter span, so a narrower span means finer bins."));
+    connect(m_span, &QComboBox::currentIndexChanged, this, [this](int) { sendResolution(); });
+
+    m_bins = new QComboBox(this);
+    m_bins->setToolTip(tr("FFT bins across the span. Capped by what one UDP "
+                          "datagram can carry."));
+    connect(m_bins, &QComboBox::currentIndexChanged, this, [this](int) { sendResolution(); });
+
+    m_binWidth = new QLabel(QStringLiteral("—"), this);
+
+    auto* spanLabel = new QLabel(tr("Span"), this);
+    auto* binsLabel = new QLabel(tr("Bins"), this);
+    spanLabel->setStyleSheet(kRowLabelStyle);
+    binsLabel->setStyleSheet(kRowLabelStyle);
+    resForm->addRow(spanLabel, m_span);
+    resForm->addRow(binsLabel, m_bins);
+    resForm->addRow(QString(), m_binWidth);
+    root->addLayout(resForm);
+
+    // --- device controls, built from what the gate reports ---------------
+    m_deviceBox = new QWidget(this);
+    m_deviceForm = new QFormLayout(m_deviceBox);
+    m_deviceForm->setContentsMargins(0, 6, 0, 0);
+    m_deviceForm->setSpacing(4);
+    m_deviceBox->setVisible(false);
+    root->addWidget(m_deviceBox);
+
+    root->addStretch(1);
+
+    m_net = new QNetworkAccessManager(this);
+    m_timer = new QTimer(this);
+    m_timer->setInterval(1000);
+    connect(m_timer, &QTimer::timeout, this, &AetherGateApplet::poll);
+}
+
+void AetherGateApplet::setRadioModel(RadioModel* model)
+{
+    m_model = model;
+    // A new connection may be a different radio entirely, so drop what we know
+    // and re-probe rather than showing the previous gate's controls.
+    m_controlsFingerprint.clear();
+    m_failures = 0;
+    setPresent(false);
+    // Probe even while hidden.  AppletPanel keeps the GATE button out of the
+    // bar until presence is confirmed, so an applet that polled only when
+    // visible could never become visible — it would be waiting on the answer to
+    // a question it had no way to ask.  poll() stops the timer itself once the
+    // question is settled, either way.
+    m_timer->start();
+    poll();
+}
+
+QString AetherGateApplet::baseUrl() const
+{
+    if (!m_model || m_model->ip().isEmpty())
+        return {};
+    return QStringLiteral("http://%1:%2").arg(m_model->ip()).arg(kGateControlPort);
+}
+
+void AetherGateApplet::showEvent(QShowEvent* e)
+{
+    QWidget::showEvent(e);
+    poll();
+    m_timer->start();
+}
+
+void AetherGateApplet::hideEvent(QHideEvent* e)
+{
+    QWidget::hideEvent(e);
+    m_timer->stop();
+}
+
+void AetherGateApplet::get(const QString& path,
+                           void (AetherGateApplet::*handler)(const QByteArray&))
+{
+    const QString base = baseUrl();
+    if (base.isEmpty())
+        return;
+    QNetworkRequest req{QUrl(base + path)};
+    req.setTransferTimeout(2000);
+    req.setAttribute(QNetworkRequest::CacheLoadControlAttribute,
+                     QNetworkRequest::AlwaysNetwork);
+    QNetworkReply* reply = m_net->get(req);
+    connect(reply, &QNetworkReply::finished, this, [this, reply, handler] {
+        reply->deleteLater();
+        if (reply->error() != QNetworkReply::NoError) {
+            if (++m_failures >= kFailuresBeforeAbsent)
+                setPresent(false);
+            return;
+        }
+        m_failures = 0;
+        setPresent(true);
+        (this->*handler)(reply->readAll());
+    });
+}
+
+void AetherGateApplet::setPresent(bool present)
+{
+    if (m_present == present)
+        return;
+    m_present = present;
+    if (!present) {
+        m_status->setText(tr("no Aether-gate on this radio"));
+        m_deviceBox->setVisible(false);
+        m_controlsFingerprint.clear();
+    }
+    emit gatePresenceChanged(present);
+}
+
+void AetherGateApplet::poll()
+{
+    // Off screen the timer exists only to answer "is there a gate on this
+    // radio?".  Once that is answered — found, or missed enough times to call
+    // it — stop: polling a radio nobody is looking at is pure noise on the
+    // network and in the gate's log.  showEvent() restarts it.
+    // No radio address yet (wired at startup, before any connect) — nothing to
+    // probe, and get() would silently drop the request without ever counting a
+    // failure, leaving the timer spinning on a no-op forever.
+    if (baseUrl().isEmpty()) {
+        m_timer->stop();
+        return;
+    }
+    if (!isVisible() && (m_present || m_failures >= kFailuresBeforeAbsent)) {
+        m_timer->stop();
+        return;
+    }
+    get(QStringLiteral("/status"), &AetherGateApplet::applyStatus);
+}
+
+void AetherGateApplet::refreshDeviceControls()
+{
+    get(QStringLiteral("/device"), &AetherGateApplet::applyDeviceControls);
+}
+
+void AetherGateApplet::applyStatus(const QByteArray& json)
+{
+    const QJsonObject root = QJsonDocument::fromJson(json).object();
+    const QJsonObject res = root.value(QStringLiteral("res")).toObject();
+    if (res.isEmpty())
+        return;
+
+    const bool connected = root.value(QStringLiteral("connected")).toBool();
+    const bool streaming = root.value(QStringLiteral("streaming")).toBool();
+    m_status->setText(connected
+                          ? tr("gate connected · %1").arg(streaming ? tr("streaming")
+                                                                    : tr("idle"))
+                          : tr("gate up · waiting for the app"));
+
+    const double spanHz = res.value(QStringLiteral("span_hz")).toDouble();
+    const double binHz = res.value(QStringLiteral("bin_hz")).toDouble();
+    const int bins = res.value(QStringLiteral("bins")).toInt();
+    const int maxBins = res.value(QStringLiteral("max_bins")).toInt(4096);
+    m_binWidth->setText(formatBinWidth(binHz));
+
+    // Span list comes from the device, not from us — see the header comment.
+    // Each entry carries the raw rate as item data: the label is rounded for
+    // reading and must never be what gets sent back.
+    const QJsonArray rates = res.value(QStringLiteral("rates")).toArray();
+    const bool canSetRate = res.value(QStringLiteral("can_set_rate")).toBool();
+    m_span->setEnabled(canSetRate && !rates.isEmpty());
+    if (!rates.isEmpty()) {
+        const QSignalBlocker block(m_span);
+        if (m_span->count() != rates.size()) {
+            m_span->clear();
+            for (const QJsonValue& v : rates)
+                m_span->addItem(formatHz(v.toDouble()), QVariant(v.toDouble()));
+        }
+        const double running = res.value(QStringLiteral("samp_rate")).toDouble(spanHz);
+        const int idx = m_span->findText(formatHz(running));
+        if (idx >= 0)
+            m_span->setCurrentIndex(idx);
+    }
+
+    QStringList binItems;
+    for (int n = 1024; n <= 16384; n *= 2) {
+        if (n <= maxBins)
+            binItems << QString::number(n);
+    }
+    if (!binItems.contains(QString::number(bins)))
+        binItems << QString::number(bins);
+    setComboItems(m_bins, binItems, QString::number(bins));
+
+    // The control SET only changes when the device does, so this is fetched
+    // once rather than on every one-second poll.
+    if (m_controlsFingerprint.isEmpty())
+        refreshDeviceControls();
+}
+
+void AetherGateApplet::sendResolution()
+{
+    const QString base = baseUrl();
+    if (base.isEmpty() || !m_present)
+        return;
+    QUrlQuery q;
+    q.addQueryItem(QStringLiteral("bins"), m_bins->currentText());
+    if (m_span->isEnabled()) {
+        const int idx = m_span->currentIndex();
+        if (idx >= 0)
+            q.addQueryItem(QStringLiteral("rate"),
+                           QString::number(m_span->itemData(idx).toDouble(), 'f', 0));
+    }
+    QUrl url(base + QStringLiteral("/resolution"));
+    url.setQuery(q);
+    QNetworkRequest req{url};
+    req.setTransferTimeout(8000);          // a rate change restarts the stream
+    QNetworkReply* reply = m_net->get(req);
+    connect(reply, &QNetworkReply::finished, reply, &QNetworkReply::deleteLater);
+}
+
+void AetherGateApplet::applyDeviceControls(const QByteArray& json)
+{
+    buildDeviceControls(QJsonDocument::fromJson(json).object());
+}
+
+void AetherGateApplet::buildDeviceControls(const QJsonObject& dev)
+{
+    // Fingerprint the SHAPE (which controls exist), not the values — rebuilding
+    // widgets under the operator's cursor every time a value changed would make
+    // the panel unusable.
+    QStringList shape;
+    const QJsonObject ant = dev.value(QStringLiteral("antenna")).toObject();
+    if (!ant.isEmpty())
+        shape << QStringLiteral("antenna");
+    const QJsonArray settings = dev.value(QStringLiteral("settings")).toArray();
+    for (const QJsonValue& v : settings)
+        shape << v.toObject().value(QStringLiteral("key")).toString();
+    const QString fingerprint = shape.join(QLatin1Char('|'));
+
+    if (fingerprint != m_controlsFingerprint) {
+        m_controlsFingerprint = fingerprint;
+        m_settingWidgets.clear();
+        m_antenna = nullptr;
+        while (m_deviceForm->count() > 0) {
+            QLayoutItem* item = m_deviceForm->takeAt(0);
+            if (QWidget* w = item->widget())
+                w->deleteLater();
+            delete item;
+        }
+
+        if (!ant.isEmpty()) {
+            m_antenna = new QComboBox(m_deviceBox);
+            for (const QJsonValue& o : ant.value(QStringLiteral("options")).toArray())
+                m_antenna->addItem(o.toString());
+            connect(m_antenna, &QComboBox::currentTextChanged, this,
+                    [this](const QString& text) {
+                        QUrlQuery q;
+                        q.addQueryItem(QStringLiteral("antenna"), text);
+                        QUrl url(baseUrl() + QStringLiteral("/device/set"));
+                        url.setQuery(q);
+                        QNetworkReply* r = m_net->get(QNetworkRequest(url));
+                        connect(r, &QNetworkReply::finished, r, &QNetworkReply::deleteLater);
+                    });
+            auto* label = new QLabel(tr("Antenna"), m_deviceBox);
+            label->setStyleSheet(kRowLabelStyle);
+            m_deviceForm->addRow(label, m_antenna);
+        }
+
+        for (const QJsonValue& v : settings) {
+            const QJsonObject so = v.toObject();
+            const QString key = so.value(QStringLiteral("key")).toString();
+            const QString name = so.value(QStringLiteral("name")).toString(key);
+            const QString type = so.value(QStringLiteral("type")).toString();
+            const QJsonArray options = so.value(QStringLiteral("options")).toArray();
+
+            // A write goes out on change and the read-back arrives with the
+            // reply, so the control always ends up showing what the DEVICE
+            // took rather than what we asked for.
+            auto push = [this, key](const QString& value) {
+                QUrlQuery q;
+                q.addQueryItem(QStringLiteral("key"), key);
+                q.addQueryItem(QStringLiteral("value"), value);
+                QUrl url(baseUrl() + QStringLiteral("/device/set"));
+                url.setQuery(q);
+                QNetworkReply* r = m_net->get(QNetworkRequest(url));
+                connect(r, &QNetworkReply::finished, this, [this, r] {
+                    r->deleteLater();
+                    if (r->error() == QNetworkReply::NoError)
+                        applyDeviceControls(r->readAll());
+                });
+            };
+
+            QWidget* w = nullptr;
+            if (!options.isEmpty()) {
+                auto* combo = new QComboBox(m_deviceBox);
+                for (const QJsonValue& o : options)
+                    combo->addItem(o.toString());
+                connect(combo, &QComboBox::currentTextChanged, this, push);
+                w = combo;
+            } else if (type == QLatin1String("0")) {          // Soapy ArgInfo BOOL
+                auto* check = new QCheckBox(m_deviceBox);
+                connect(check, &QCheckBox::toggled, this, [push](bool on) {
+                    push(on ? QStringLiteral("true") : QStringLiteral("false"));
+                });
+                w = check;
+            } else {
+                auto* spin = new QSpinBox(m_deviceBox);
+                spin->setRange(-1000, 1000);
+                spin->setKeyboardTracking(false);   // one write per committed edit
+                connect(spin, &QSpinBox::valueChanged, this, [push](int v) {
+                    push(QString::number(v));
+                });
+                w = spin;
+            }
+            m_settingWidgets.insert(key, w);
+            auto* label = new QLabel(name, m_deviceBox);
+            label->setStyleSheet(kRowLabelStyle);
+            m_deviceForm->addRow(label, w);
+        }
+        m_deviceBox->setVisible(!shape.isEmpty());
+    }
+
+    // Values, every time — blocked so a refresh never re-sends what it reads.
+    if (m_antenna && !ant.isEmpty()) {
+        const QSignalBlocker block(m_antenna);
+        const int idx = m_antenna->findText(ant.value(QStringLiteral("value")).toString());
+        if (idx >= 0)
+            m_antenna->setCurrentIndex(idx);
+    }
+    for (const QJsonValue& v : settings) {
+        const QJsonObject so = v.toObject();
+        QWidget* w = m_settingWidgets.value(so.value(QStringLiteral("key")).toString());
+        if (!w)
+            continue;
+        const QString value = so.value(QStringLiteral("value")).toString();
+        if (auto* combo = qobject_cast<QComboBox*>(w)) {
+            const QSignalBlocker block(combo);
+            const int idx = combo->findText(value);
+            if (idx >= 0)
+                combo->setCurrentIndex(idx);
+        } else if (auto* check = qobject_cast<QCheckBox*>(w)) {
+            const QSignalBlocker block(check);
+            check->setChecked(value == QLatin1String("true"));
+        } else if (auto* spin = qobject_cast<QSpinBox*>(w)) {
+            const QSignalBlocker block(spin);
+            spin->setValue(value.toInt());
+        }
+    }
+}
+
+} // namespace AetherSDR

--- a/src/gui/AetherGateApplet.cpp
+++ b/src/gui/AetherGateApplet.cpp
@@ -130,8 +130,36 @@ AetherGateApplet::AetherGateApplet(QWidget* parent)
 void AetherGateApplet::setRadioModel(RadioModel* model)
 {
     m_model = model;
-    // A new connection may be a different radio entirely, so drop what we know
-    // and re-probe rather than showing the previous gate's controls.
+    if (!m_model)
+        return;
+
+    // infoChanged, NOT connectionStateChanged.  The gate answers at the RADIO's
+    // address, and ip() is filled in by the reply to "info" — which the model
+    // only sends AFTER it announces the connection.  Probing on the connect
+    // edge finds an empty address, and a probe with nowhere to go never counts
+    // a failure, so the applet would give up without ever having asked.  (Same
+    // ordering trap the TX power-scale wiring hit in #4813.)
+    connect(m_model, &RadioModel::infoChanged,
+            this, &AetherGateApplet::reprobe);
+    // A reconnect to the same radio must ask again: the gate may have been
+    // restarted, or replaced by a real Flex at the same address.
+    connect(m_model, &RadioModel::connectionStateChanged, this, [this](bool up) {
+        if (!up)
+            m_probedIp.clear();
+    });
+
+    reprobe();
+}
+
+void AetherGateApplet::reprobe()
+{
+    const QString ip = m_model ? m_model->ip() : QString();
+    if (ip.isEmpty() || ip == m_probedIp)
+        return;                       // nothing to ask, or already asked this one
+
+    // A different address is a different radio: drop what we knew rather than
+    // showing the previous gate's controls.
+    m_probedIp = ip;
     m_controlsFingerprint.clear();
     m_failures = 0;
     setPresent(false);

--- a/src/gui/AetherGateApplet.cpp
+++ b/src/gui/AetherGateApplet.cpp
@@ -33,10 +33,26 @@ static constexpr int kGateControlPort = 8731;
 // gate died) and the applet should get out of the way.
 static constexpr int kFailuresBeforeAbsent = 3;
 
+// Row labels resolve their colour from a theme token instead of a literal, so a
+// user theme can restyle them and a live theme switch repaints them —
+// applyStyleSheet() re-resolves every widget it tracks, which a bare
+// setStyleSheet() never did (docs/style/theme-style-guide.md). It also keeps
+// this file off the hardcoded-colour ratchet in static-checks.yml.
+//
+// color.text.secondary (#8ea8c0) rather than color.text.label (#506070): the
+// literal these labels used, #8090a0, is a light mid-grey, so the label token
+// would have visibly darkened them against every sibling applet. TunerApplet
+// and ProfileSwitcherApplet still carry their own copy of the old literal;
+// converging all three on this token is a follow-up, not this PR's business.
 static const char* kRowLabelStyle =
-    "QLabel { color: #8090a0; font-size: 10px; font-weight: bold; }";
+    "QLabel { color: {{color.text.secondary}}; font-size: 10px; font-weight: bold; }";
 
 namespace {
+
+void styleRowLabel(QLabel* label)
+{
+    ThemeManager::instance().applyStyleSheet(label, QString::fromLatin1(kRowLabelStyle));
+}
 
 QString formatHz(double hz)
 {
@@ -79,7 +95,7 @@ AetherGateApplet::AetherGateApplet(QWidget* parent)
     root->setSpacing(6);
 
     m_status = new QLabel(tr("looking for a gate…"), this);
-    m_status->setStyleSheet(kRowLabelStyle);
+    styleRowLabel(m_status);
     root->addWidget(m_status);
 
     // --- panadapter resolution ------------------------------------------
@@ -104,8 +120,8 @@ AetherGateApplet::AetherGateApplet(QWidget* parent)
 
     auto* spanLabel = new QLabel(tr("Span"), this);
     auto* binsLabel = new QLabel(tr("Bins"), this);
-    spanLabel->setStyleSheet(kRowLabelStyle);
-    binsLabel->setStyleSheet(kRowLabelStyle);
+    styleRowLabel(spanLabel);
+    styleRowLabel(binsLabel);
     resForm->addRow(spanLabel, m_span);
     resForm->addRow(binsLabel, m_bins);
     resForm->addRow(QString(), m_binWidth);
@@ -373,7 +389,7 @@ void AetherGateApplet::buildDeviceControls(const QJsonObject& dev)
                         connect(r, &QNetworkReply::finished, r, &QNetworkReply::deleteLater);
                     });
             auto* label = new QLabel(tr("Antenna"), m_deviceBox);
-            label->setStyleSheet(kRowLabelStyle);
+            styleRowLabel(label);
             m_deviceForm->addRow(label, m_antenna);
         }
 
@@ -425,7 +441,7 @@ void AetherGateApplet::buildDeviceControls(const QJsonObject& dev)
             }
             m_settingWidgets.insert(key, w);
             auto* label = new QLabel(name, m_deviceBox);
-            label->setStyleSheet(kRowLabelStyle);
+            styleRowLabel(label);
             m_deviceForm->addRow(label, w);
         }
         m_deviceBox->setVisible(!shape.isEmpty());

--- a/src/gui/AetherGateApplet.h
+++ b/src/gui/AetherGateApplet.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <QHash>
+#include <QPointer>
+#include <QWidget>
+
+class QCheckBox;
+class QJsonObject;
+class QComboBox;
+class QFormLayout;
+class QLabel;
+class QNetworkAccessManager;
+class QNetworkReply;
+class QSpinBox;
+class QTimer;
+
+namespace AetherSDR {
+
+class RadioModel;
+
+// GATE — Aether-gate device controls.
+//
+// Aether-gate presents non-Flex hardware (an SDRplay RSP, an HPSDR, an Icom) to
+// AetherSDR as a FLEX-6600, which means everything reaches us as Flex wire text.
+// That works for the things Flex has verbs for. It has none for an RSPdx's
+// antenna port, bias-T, MW/DAB notches, HDR mode or AGC setpoint, so those
+// controls could previously only be reached by opening the gate's own web panel
+// in a browser. This applet brings them into the app.
+//
+// Deliberately NOT a fixed set of widgets: the gate reports what the attached
+// device actually offers (it asks the driver — listAntennas/getSettingInfo) and
+// the controls are built from that answer. An RSP1a, an RSPdx and an RTL stick
+// share almost no settings, and hardcoding one device's list is the same
+// mistake as hardcoding its sample rates.
+//
+// Presence is detected by PROBING the gate's control port rather than by
+// sniffing the radio serial: the serial is operator-settable (--serial), so a
+// renamed gate would vanish from the UI. If the endpoint answers, it is a gate.
+class AetherGateApplet : public QWidget {
+    Q_OBJECT
+public:
+    explicit AetherGateApplet(QWidget* parent = nullptr);
+
+    void setRadioModel(RadioModel* model);
+
+    // True once the gate's control port has answered at least once. AppletPanel
+    // uses this to keep the button hidden for operators on a real Flex.
+    bool gatePresent() const { return m_present; }
+
+signals:
+    void gatePresenceChanged(bool present);
+
+protected:
+    void showEvent(QShowEvent* e) override;
+    void hideEvent(QHideEvent* e) override;
+
+private:
+    QString baseUrl() const;
+    void poll();                                  // /status — cheap, on the timer
+    void refreshDeviceControls();                 // /device — only when it can have changed
+    void applyStatus(const QByteArray& json);
+    void applyDeviceControls(const QByteArray& json);
+    void buildDeviceControls(const QJsonObject& dev);
+    void sendResolution();
+    void get(const QString& path, void (AetherGateApplet::*handler)(const QByteArray&));
+    void setPresent(bool present);
+
+    QPointer<RadioModel>   m_model;
+    QNetworkAccessManager* m_net{nullptr};
+    QTimer*                m_timer{nullptr};
+    bool                   m_present{false};
+    int                    m_failures{0};
+
+    // Header
+    QLabel* m_status{nullptr};
+
+    // Resolution
+    QComboBox* m_span{nullptr};
+    QComboBox* m_bins{nullptr};
+    QLabel*    m_binWidth{nullptr};
+
+    // Device controls, rebuilt from whatever the gate reports.
+    QWidget*     m_deviceBox{nullptr};
+    QFormLayout* m_deviceForm{nullptr};
+    QComboBox*   m_antenna{nullptr};
+    QHash<QString, QWidget*> m_settingWidgets;    // Soapy setting key -> control
+    QString      m_controlsFingerprint;           // rebuild only when the SET changes
+};
+
+} // namespace AetherSDR

--- a/src/gui/AetherGateApplet.h
+++ b/src/gui/AetherGateApplet.h
@@ -56,6 +56,7 @@ protected:
 
 private:
     QString baseUrl() const;
+    void reprobe();                               // address changed — ask again
     void poll();                                  // /status — cheap, on the timer
     void refreshDeviceControls();                 // /device — only when it can have changed
     void applyStatus(const QByteArray& json);
@@ -70,6 +71,7 @@ private:
     QTimer*                m_timer{nullptr};
     bool                   m_present{false};
     int                    m_failures{0};
+    QString                m_probedIp;            // the address we last asked
 
     // Header
     QLabel* m_status{nullptr};

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -42,6 +42,7 @@
 #include "ProfileSwitcherApplet.h"
 #include "HealthApplet.h"
 #include "KiwiSdrApplet.h"
+#include "AetherGateApplet.h"
 #ifdef HAVE_RADE
 #include "RadeApplet.h"
 #endif
@@ -978,6 +979,21 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     m_appletOrder.append(makeEntry("KSDR", "KiwiSDR", m_kiwiSdrApplet, false,
                                    m_drawer, m_drawerLayout));
 
+    // Aether-gate device controls.  Hardware-conditional like AG/SS rather
+    // than always-present like KSDR/GHE: on a real Flex there is no gate and
+    // never will be, so the button would be permanently dead weight in the
+    // bar.  Unlike AG/SS the detection is the applet's own — it probes the
+    // gate's control port and reports back through gatePresenceChanged(),
+    // which MainWindow wires to updateHardwareAvailability().  That is why the
+    // applet keeps probing while hidden (see AetherGateApplet::poll).
+    m_aetherGateApplet = new AetherGateApplet;
+    {
+        auto entry = makeEntry("GATE", "Aether-gate", m_aetherGateApplet, false,
+                               m_drawer, m_drawerLayout);
+        markHardwareConditional("GATE");
+        m_appletOrder.append(entry);
+    }
+
 #ifdef HAVE_RADE
     m_radeApplet = new RadeApplet;
     m_appletOrder.append(makeEntry("RADE", "RADE Status", m_radeApplet, false, m_drawer, m_drawerLayout));
@@ -1751,6 +1767,15 @@ void AppletPanel::setVkampVisible(bool visible)
 void AppletPanel::setAgVisible(bool visible)
 {
     updateHardwareAvailability("AG", "Applet_AG", visible);
+    applyBarLayout();
+}
+
+// Driven by AetherGateApplet::gatePresenceChanged rather than by the radio's
+// capability table: the gate is a bridge process sitting beside the radio, not
+// something the radio knows about or reports.
+void AppletPanel::setAetherGateVisible(bool visible)
+{
+    updateHardwareAvailability("GATE", "Applet_GATE", visible);
     applyBarLayout();
 }
 

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -64,6 +64,7 @@ class ProfileSwitcherApplet;
 class HealthApplet;
 class MqttApplet;
 class KiwiSdrApplet;
+class AetherGateApplet;
 class FavoritesPickerDialog;
 #ifdef HAVE_RADE
 class RadeApplet;
@@ -157,6 +158,7 @@ public:
     ProfileSwitcherApplet* profileSwitcherApplet() { return m_profApplet; }
     HealthApplet* healthApplet() { return m_healthApplet; }
     KiwiSdrApplet* kiwiSdrApplet() { return m_kiwiSdrApplet; }
+    AetherGateApplet* aetherGateApplet() { return m_aetherGateApplet; }
 #ifdef HAVE_RADE
     RadeApplet*   radeApplet()   { return m_radeApplet; }
 #endif
@@ -188,6 +190,7 @@ public:
 
     // Show/hide the AG button and applet based on Antenna Genius presence.
     void setAgVisible(bool visible);
+    void setAetherGateVisible(bool visible);
 
     // Show/hide the ShackSwitch applet based on device presence.
     void setShackSwitchVisible(bool visible);
@@ -431,6 +434,7 @@ private:
     ProfileSwitcherApplet* m_profApplet{nullptr};
     HealthApplet* m_healthApplet{nullptr};
     KiwiSdrApplet* m_kiwiSdrApplet{nullptr};
+    AetherGateApplet* m_aetherGateApplet{nullptr};
 #ifdef HAVE_RADE
     RadeApplet*  m_radeApplet{nullptr};
 #endif

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -43,6 +43,7 @@
 #include "HealthApplet.h"
 #include "ImageFileDialog.h"
 #include "MeterApplet.h"
+#include "AetherGateApplet.h"
 #include "ProfileSwitcherApplet.h"
 #include "SMeterWidget.h"
 #include "TunerApplet.h"
@@ -6638,6 +6639,26 @@ void MainWindow::wireMeters()
 
     // ── PROF applet: Global / TX / Mic profile switcher (#3376) ─────────────
     m_appletPanel->profileSwitcherApplet()->setRadioModel(&m_radioModel);
+
+    // ── GATE applet: Aether-gate device controls ───────────────────────────
+    // The applet reaches the gate at the RADIO's address, so whether there is
+    // a gate — and which one — is a property of the current connection, not of
+    // the app.  Re-seed on every connect so a session that moves from a real
+    // Flex to a bridged RSPdx (or back) re-probes instead of showing the
+    // previous radio's controls.  Presence is the applet's own discovery, so
+    // it drives the bar button rather than the capability table.
+    if (auto* gate = m_appletPanel->aetherGateApplet()) {
+        gate->setRadioModel(&m_radioModel);
+        connect(&m_radioModel, &RadioModel::connectionStateChanged, gate,
+                [this, gate](bool connected) {
+                    if (connected)
+                        gate->setRadioModel(&m_radioModel);
+                });
+        connect(gate, &AetherGateApplet::gatePresenceChanged, this,
+                [this](bool present) {
+                    m_appletPanel->setAetherGateVisible(present);
+                });
+    }
 
     // ── HLTH applet: same meter model — derives antenna-health state from
     //    SWR / power trends across radio / tuner / amp sources.

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -6648,12 +6648,10 @@ void MainWindow::wireMeters()
     // previous radio's controls.  Presence is the applet's own discovery, so
     // it drives the bar button rather than the capability table.
     if (auto* gate = m_appletPanel->aetherGateApplet()) {
+        // The applet re-probes on its own (it watches infoChanged for the
+        // radio's address); all this side owns is turning its answer into a
+        // bar button.
         gate->setRadioModel(&m_radioModel);
-        connect(&m_radioModel, &RadioModel::connectionStateChanged, gate,
-                [this, gate](bool connected) {
-                    if (connected)
-                        gate->setRadioModel(&m_radioModel);
-                });
         connect(gate, &AetherGateApplet::gatePresenceChanged, this,
                 [this](bool present) {
                     m_appletPanel->setAetherGateVisible(present);


### PR DESCRIPTION
## Summary

Fixes #5371.

Aether-gate presents non-Flex hardware to AetherSDR as a FLEX-6600, so everything
it can say has to fit a Flex verb. Plenty does not: an RSPdx's antenna port,
bias-T, MW/DAB notches, HDR mode and AGC set-point have no Flex equivalent, and
neither does the panadapter's bin count. Reaching them meant leaving the app for
the gate's web panel — mid-operation.

**GATE** is a normal applet tile that talks to the gate's control port:

* **Controls are built from what the gate reports the attached device offers**,
  not from a fixed list. An RSP1a, an RSPdx and an RTL stick share almost no
  settings, and hardcoding one device's set is the same mistake as hardcoding its
  sample rates.
* **Presence is the applet's own discovery**: it probes the control port at the
  radio's address rather than sniffing the serial, which is operator-settable
  (`--serial`) and would make a renamed gate vanish from the UI. Because
  `AppletPanel` keeps the button out of the bar until presence is confirmed, the
  probe has to run while hidden — it stops itself once the question is answered
  either way, and `showEvent` restarts it.
* The second commit fixes the probe firing at an empty address: the applet
  reaches the gate at the **radio's** address, but `ip()` is filled in by the
  reply to `info`, which `RadioModel` only sends *after* it emits
  `connectionStateChanged(true)`. A probe with nowhere to go returns without
  counting a failure, so the applet stopped its timer and gave up having never
  actually asked. It now watches `infoChanged` and re-probes on address change.
  This is the same ordering trap the TX power-scale wiring hit in #4813.

The diff is **purely additive** (603 insertions, 0 deletions) across one new
applet plus its `AppletPanel` / `MainWindow_Wiring` registration.

### Relationship to #4944

#4944 asks the maintainer to settle where an undiscoverable peripheral gets
configured and when its applet button is visible, after #4905 and #4919 landed
with opposite answers. **This is a third data point, not an attempt to pre-empt
that decision.** It lands on the middle path #4944 itself proposes — hidden until
the device is confirmed present, shown thereafter — and it can do so because a
gate *is* discoverable: it answers on a known port at the radio's address, which
is precisely what #4944 observes was missing for Everyware. Happy to re-shape
this to whatever convention #4944 settles on.

### On RFC scope

Per GOVERNANCE.md this needs no RFC: *"new applets or dialogs that don't change
existing UX"* is explicitly on the no-RFC list, no existing control, shortcut or
default changes behaviour, and nothing appears in the applet bar for users
without a gate. **A waterfall colour-scheme commit that originally sat on this
branch has been deliberately split out and held back**, because changing theme
colours *is* RFC-gated and *"do not open a PR until the RFC issue is approved."*

## Constitution principle honored

**Principle VIII — Evidence Over Assertion.** The third commit exists because I
ran the repo's own gates locally instead of assuming the applet was clean: the
hardcoded-colour ratchet in `static-checks.yml` is a delta against the PR base,
and this applet raised two of three counters (`total_references` +1 from a
`#8090a0` literal, `setstylesheet` +5 from the call sites) — it would have failed
CI. Row labels now resolve through `ThemeManager::applyStyleSheet()` with a
`{{color.text.secondary}}` token, which also makes them restylable by a user
theme and repaint on a live theme switch, neither of which a bare
`setStyleSheet()` did. Re-verified with the exact command CI runs, against the
merge base: `unique_colours 613 (+0), total_references 2724 (+0),
setstylesheet 1090 (+0)`.

**Principle II — The Radio Is Authoritative On Live State.** The control set is
whatever the gate reports its device offers; the applet asserts no device shape
of its own.

## Test plan

- [x] Local build passes (`cmake --build build`) — clean, links exit 0
- [x] Behavior verified on a real radio if applicable — yes: driven against a
      live Aether-gate 0.4.3 fronting an SDRplay **RSPdx-R2**, exercising antenna
      port, bias-T, notches, HDR, AGC set-point and the span/bins resolution
      controls. The antenna-port control in particular was used to run an
      A-vs-B disconnect measurement (25 dB difference between a connected and an
      empty port), so the writes demonstrably reach the hardware
- [x] Existing tests pass (CI) — full local suite: only the two failures that
      reproduce unchanged on clean `main` (`bridge_docs_check`,
      `hl2_state_restore_test`). Repo gates run locally: colour ratchet **+0 on
      all three counters**; `check_engine_boundary.py` → 0 findings would block;
      `check_a11y.py` → no findings in the new file
- [ ] **This PR adds no automated test.** The applet's behaviour is HTTP probe +
      widget construction against a live gate, and there is no existing fixture
      for a fake gate endpoint to build on. Flagging it rather than claiming
      coverage — happy to add one if a reviewer wants a particular shape

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`) — GPG, GitHub reports
      `verified: true`
- [x] No new flat-key `AppSettings` calls — the applet persists nothing; device
      state lives on the gate, which is authoritative for it
- [x] Code is clean-room — AetherSDR's own widget code against public Qt API and
      the gate's own documented control port (Principle IV)
- [x] All meter UI uses `MeterSmoother` — **N/A**, the applet has no meter; its
      readouts are discrete device settings, not continuous levels
- [x] Documentation updated if user-visible behavior changed — the applet is
      self-describing (every control is built from the gate's own reported
      shape, with tooltips), and no existing document describes the applet bar's
      contents as a fixed list. `CHANGELOG.md` deliberately untouched
- [x] Security-sensitive changes reference a GHSA if applicable — **N/A**. Worth
      a reviewer's eye regardless: the applet issues HTTP GETs to the *radio's*
      address on a fixed control port, and renders the returned setting shape.
      It stores no credentials and sends none

---

*Note on the claim protocol (AGENTS.md §Issue / PR Claim Protocol): assignee
changes are rejected for an account without write access to this repo, so the
`Fixes #5371` link is the visible claim on the issue timeline instead.*
