### PR TITLE
fix(icom): a refused tune must not read as a successful one

### DIFF
--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -1858,6 +1858,49 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame,
         return;
     }
 
+    // A REFUSED TUNE MUST NOT READ AS A SUCCESSFUL ONE.
+    //
+    // FA is the radio's NG. Until now nothing consumed it: observe() treats
+    // FB and FA identically (both merely retire the transaction and carry no
+    // state), so a refused write left the optimistic frequency standing in the
+    // model and the operator looking at a number the radio never entered.
+    //
+    // The IC-9700 makes this reachable in ordinary use. It has three bands and
+    // two receivers, so a receiver cannot be tuned to a band the other one
+    // already holds; the radio answers cmd 05 with FA and stays put. Measured
+    // on hardware 2026-08-29 — six cross-band sets, six FAs, and the display
+    // followed all six. See #4840.
+    //
+    // Correct on every model, not just that one: FA on a frequency write means
+    // the write did not take, whatever the reason.
+    //
+    // Deliberately narrow. Only a frequency write is corrected here, because
+    // that is the case with hardware evidence and a known-good restoration
+    // value (m_frequencyHz, which is radio-authoritative). Other refused
+    // writes are a separate question and are left alone rather than guessed at.
+    if (frame.isNg() && m_civScheduler.stats().lastCompletedKey == "frequency"
+        && m_frequencyHz != 0) {
+        // Re-assert the radio's real VFO one event-loop turn later, exactly as
+        // the out-of-band gate in setSliceFrequency() and the refused mode in
+        // setSliceMode() already do: SliceModel has accepted and announced the
+        // operator's request by now, so a direct emit would be overwritten by
+        // that announcement and the indicator would keep lying.
+        const double actualMhz = static_cast<double>(m_frequencyHz) / 1.0e6;
+        qCWarning(lcIcomLink)
+            << "radio refused the frequency write (CI-V FA); restoring"
+            << actualMhz << "MHz";
+        QTimer::singleShot(0, this, [this, actualMhz] {
+            SliceDelta delta;
+            delta.frequency = actualMhz;
+            emit sliceChanged(sliceId(), delta);
+        });
+        emit configurationWarning(
+            tr("The radio refused the tune. It is still on %1 MHz — on this "
+               "model a receiver cannot move to a band the other receiver "
+               "already holds.")
+                .arg(actualMhz, 0, 'f', 6));
+    }
+
     noteControlSeen(frame.cmd, frame.sub, frame.hasSub);
 
     switch (frame.cmd) {

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -1878,7 +1878,22 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame,
     // that is the case with hardware evidence and a known-good restoration
     // value (m_frequencyHz, which is radio-authoritative). Other refused
     // writes are a separate question and are left alone rather than guessed at.
-    if (frame.isNg() && m_civScheduler.stats().lastCompletedKey == "frequency"
+    // ⚠ BOTH halves of the predicate are load-bearing, and `lastCompletedKey`
+    // alone is NOT enough. observe() sets it only when a frame MATCHES the
+    // in-flight transaction; an unmatched FA returns Observation::Unmatched and
+    // leaves the key at its previous value. Frequency writes are the most
+    // common transaction, so `lastCompletedKey == "frequency"` is usually true
+    // from the last real tune — and a later stray or duplicate NG, or an NG for
+    // a transaction that already expired, would fire this block with no
+    // frequency write refused at all: a false "the radio refused the tune"
+    // toast plus a redundant re-assert. That is precisely the lying-indicator
+    // failure this block exists to remove, inverted.
+    //
+    // Observation::Accepted is the signal that THIS frame completed the
+    // in-flight transaction; the key then says WHICH transaction it was.
+    if (frame.isNg()
+        && observation == IcomCivScheduler::Observation::Accepted
+        && m_civScheduler.stats().lastCompletedKey == "frequency"
         && m_frequencyHz != 0) {
         // Re-assert the radio's real VFO one event-loop turn later, exactly as
         // the out-of-band gate in setSliceFrequency() and the refused mode in
@@ -1894,11 +1909,19 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame,
             delta.frequency = actualMhz;
             emit sliceChanged(sliceId(), delta);
         });
-        emit configurationWarning(
-            tr("The radio refused the tune. It is still on %1 MHz — on this "
-               "model a receiver cannot move to a band the other receiver "
-               "already holds.")
-                .arg(actualMhz, 0, 'f', 6));
+        // The dual-receiver explanation is TRUE ONLY WHERE THERE ARE TWO.
+        // This block fires on every Icom model, so an IC-705 refusing a write
+        // for some other reason was being handed a reason that cannot apply to
+        // it. State the refusal generically and append the cause only where the
+        // profile actually has a second receiver to collide with.
+        QString why = tr("The radio refused the tune. It is still on %1 MHz.")
+                          .arg(actualMhz, 0, 'f', 6);
+        if (m_model && m_model->receivers > 1) {
+            why += QLatin1Char(' ');
+            why += tr("On this model a receiver cannot move to a band the "
+                      "other receiver already holds.");
+        }
+        emit configurationWarning(why);
     }
 
     noteControlSeen(frame.cmd, frame.sub, frame.hasSub);

--- a/src/core/backends/icom/IcomCivBackend.cpp
+++ b/src/core/backends/icom/IcomCivBackend.cpp
@@ -1878,7 +1878,7 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame,
     // that is the case with hardware evidence and a known-good restoration
     // value (m_frequencyHz, which is radio-authoritative). Other refused
     // writes are a separate question and are left alone rather than guessed at.
-    // ⚠ BOTH halves of the predicate are load-bearing, and `lastCompletedKey`
+    // ⚠ EVERY clause of the predicate is load-bearing, and `lastCompletedKey`
     // alone is NOT enough. observe() sets it only when a frame MATCHES the
     // in-flight transaction; an unmatched FA returns Observation::Unmatched and
     // leaves the key at its previous value. Frequency writes are the most
@@ -1891,9 +1891,16 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame,
     //
     // Observation::Accepted is the signal that THIS frame completed the
     // in-flight transaction; the key then says WHICH transaction it was.
+    //
+    // The key alone is still one step too coarse: semanticKey() folds the
+    // poll's 03 READ and the +60 ms confirmation read onto "frequency" as
+    // well, and matches() retires ANY in-flight transaction on an FA. An NG
+    // to a read is not a refused tune, so the command byte of the retired
+    // frame has to say 05 before this is allowed to speak.
     if (frame.isNg()
         && observation == IcomCivScheduler::Observation::Accepted
         && m_civScheduler.stats().lastCompletedKey == "frequency"
+        && m_civScheduler.stats().lastCompletedCmd == cmd::kSetFreq
         && m_frequencyHz != 0) {
         // Re-assert the radio's real VFO one event-loop turn later, exactly as
         // the out-of-band gate in setSliceFrequency() and the refused mode in
@@ -1904,11 +1911,7 @@ void IcomCivBackend::onCivFrame(const CivFrame& frame,
         qCWarning(lcIcomLink)
             << "radio refused the frequency write (CI-V FA); restoring"
             << actualMhz << "MHz";
-        QTimer::singleShot(0, this, [this, actualMhz] {
-            SliceDelta delta;
-            delta.frequency = actualMhz;
-            emit sliceChanged(sliceId(), delta);
-        });
+        scheduleFrequencyRestore();
         // The dual-receiver explanation is TRUE ONLY WHERE THERE ARE TWO.
         // This block fires on every Icom model, so an IC-705 refusing a write
         // for some other reason was being handed a reason that cannot apply to
@@ -3822,6 +3825,31 @@ void IcomCivBackend::sendUserCommand(const std::vector<std::uint8_t>& frame)
     pumpCiv(now);
 }
 
+// Re-assert the radio's real VFO one event-loop turn from now.
+//
+// Deferred because SliceModel has already accepted and announced the
+// operator's request by the time a seam verb or a CI-V reply runs; a direct
+// emit would be applied and then announced away, and the indicator would keep
+// lying. Same ordering contract as setSliceMode().
+//
+// Read at FIRE time, not captured: a 03 reply can land in the gap and move
+// m_frequencyHz, and the radio's newest word is the one to publish. Guarded
+// by m_tuneEpoch: if the operator issued a newer tune in that gap, the
+// correction is for a request they have already abandoned and re-asserting it
+// would drag the readout back behind a write that may well succeed.
+void IcomCivBackend::scheduleFrequencyRestore()
+{
+    const std::uint64_t epoch = m_tuneEpoch;
+    QTimer::singleShot(0, this, [this, epoch] {
+        if (epoch != m_tuneEpoch || m_frequencyHz == 0) {
+            return;
+        }
+        SliceDelta delta;
+        delta.frequency = static_cast<double>(m_frequencyHz) / 1.0e6;
+        emit sliceChanged(sliceId(), delta);
+    });
+}
+
 void IcomCivBackend::setSliceFrequency(int, double hz)
 {
     if (!std::isfinite(hz) || hz <= 0.0
@@ -3829,6 +3857,10 @@ void IcomCivBackend::setSliceFrequency(int, double hz)
         return;
     }
     const std::uint64_t roundedHz = static_cast<std::uint64_t>(std::llround(hz));
+    // Every operator tune opens a new epoch: any frequency re-assert still
+    // deferred from an earlier refusal now belongs to a request the operator
+    // has already moved past, and must not fire on top of this one.
+    ++m_tuneEpoch;
     // Only a model that DECLARES discontinuous bands gets this gate. Every
     // other Icom keeps its existing command path — an empty table is the
     // predicate, so the day another model's holes are documented, this site
@@ -3850,12 +3882,7 @@ void IcomCivBackend::setSliceFrequency(int, double hz)
         // the next event-loop turn, after that optimistic announcement, so a
         // refused gap tune cannot leave the display claiming a frequency the
         // radio never entered. Same ordering contract as setSliceMode().
-        const double actualMhz = static_cast<double>(m_frequencyHz) / 1.0e6;
-        QTimer::singleShot(0, this, [this, actualMhz] {
-            SliceDelta delta;
-            delta.frequency = actualMhz;
-            emit sliceChanged(sliceId(), delta);
-        });
+        scheduleFrequencyRestore();
         return;
     }
     sendUserCommand(cmdSetFrequency(m_session ? m_session->civAddress() : 0xA4,

--- a/src/core/backends/icom/IcomCivBackend.h
+++ b/src/core/backends/icom/IcomCivBackend.h
@@ -280,6 +280,7 @@ private:
     void queueEmergencyWriteNoReply(const std::vector<std::uint8_t>& frame,
                                     const std::string& key);
     void pumpCiv(qint64 nowMs);
+    void scheduleFrequencyRestore();
     // Monotonic milliseconds since construction. THE clock for this backend:
     // every interval here (dispatch slot, reply timeout, poll period, stall
     // threshold, trace age) is measured against it, and none of them survives
@@ -409,6 +410,10 @@ private:
     QString m_deviceName;
     QString m_memoryImportSource;
     std::uint64_t m_frequencyHz = 0;
+    // Bumped by every operator tune. A deferred frequency re-assert captures
+    // it and fires only if no newer tune arrived in the one-turn gap, so a
+    // correction for a refused write cannot stomp a later successful one.
+    std::uint64_t m_tuneEpoch = 0;
     CivMode m_mode = CivMode::Usb;
     bool m_dataMode = false;
     bool m_connected = false;

--- a/src/core/backends/icom/IcomCivScheduler.cpp
+++ b/src/core/backends/icom/IcomCivScheduler.cpp
@@ -38,6 +38,8 @@ void IcomCivScheduler::noteResponse(const Queued& request, std::int64_t nowMs)
     m_stats.maxResponseMs = std::max(m_stats.maxResponseMs, responseMs);
     m_stats.lastResponseAtMs = nowMs;
     m_stats.lastCompletedKey = request.request.key;
+    m_stats.lastCompletedCmd = request.request.frame.size() > 4
+        ? request.request.frame[4] : std::uint8_t{0};
 }
 
 // Two requests are duplicates only if they ask the SAME register the same way.

--- a/src/core/backends/icom/IcomCivScheduler.h
+++ b/src/core/backends/icom/IcomCivScheduler.h
@@ -109,6 +109,10 @@ public:
         std::int64_t maxResponseMs = -1;
         std::int64_t lastResponseAtMs = 0;
         std::string lastCompletedKey;
+        // Command byte of the frame that lastCompletedKey retired. The key is
+        // semantic and deliberately coarse (a frequency READ and WRITE share
+        // "frequency"); a consumer that must tell them apart reads this.
+        std::uint8_t lastCompletedCmd = 0;
         std::string lastTimeoutKey;
         std::size_t queueDepth = 0;
         bool readInFlight = false;

--- a/tests/icom_incident_telemetry_test.cpp
+++ b/tests/icom_incident_telemetry_test.cpp
@@ -7,10 +7,13 @@
 #include "core/backends/icom/IcomCivBackend.h"
 
 #include <QCoreApplication>
+#include <QStringList>
 #include <QVariantMap>
 
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
+#include <string>
 #include <vector>
 
 using namespace AetherSDR;
@@ -40,6 +43,34 @@ struct IcomCivBackendTestAccess {
     static QVariantMap incident(const IcomCivBackend& backend)
     {
         return backend.m_lastIncident;
+    }
+
+    // A backend that has a radio-authoritative frequency and one frequency
+    // write outstanding on the wire — the state a refused tune arrives into.
+    static void prepareOutstandingFrequencyWrite(IcomCivBackend& backend,
+                                                 const IcomModel& model,
+                                                 std::uint64_t generation,
+                                                 std::uint64_t heldHz)
+    {
+        backend.m_model = &model;
+        backend.m_connected = true;
+        backend.m_sessionGeneration = generation;
+        backend.m_frequencyHz = heldHz;
+        IcomCivScheduler::Request request;
+        request.frame = cmdSetFrequency(model.civAddress, heldHz + 1'000'000);
+        request.key = "frequency";
+        request.expectsReply = true;
+        request.acceptsGenericReply = true;
+        backend.m_civScheduler.enqueue(request, backend.nowMs());
+        // Take it off the queue so it is genuinely in flight: observe() only
+        // retires a transaction that was actually dispatched, and the whole
+        // point is that the FA below completes THIS request.
+        (void)backend.m_civScheduler.takeNext(backend.nowMs());
+    }
+
+    static std::string lastCompletedKey(const IcomCivBackend& backend)
+    {
+        return backend.m_civScheduler.stats().lastCompletedKey;
     }
 
     static void prepareAcceptedPttRead(IcomCivBackend& backend,
@@ -140,6 +171,61 @@ int main(int argc, char** argv)
         confirmationBackend, unkeyed, kGeneration);
     check(confirmations.size() == 1 && !confirmations.front(),
           "only an accepted CI-V PTT-off readback publishes confirmation");
+
+    // ---- A REFUSED TUNE IS NOT A SUCCESSFUL ONE --------------------------
+    //
+    // FA is the radio's NG. observe() retires FB and FA identically — both
+    // merely release the slot and carry no state — so before this, nothing in
+    // the backend consumed a refusal and the optimistic frequency stood.
+    // isNg() existed in CivCodec.h with no caller in the backend at all.
+    //
+    // Reachable in ordinary use on an IC-9700: three bands, two receivers, so
+    // a receiver cannot take a band the other one already holds. The radio
+    // answers cmd 05 with FA and does not move. Measured on hardware
+    // 2026-08-29 — six cross-band sets, six FAs, display followed all six
+    // (#4840).
+    {
+        constexpr std::uint64_t kHeldHz = 145'030'000;
+        IcomCivBackend refusedBackend;
+        std::vector<double> published;
+        QObject::connect(&refusedBackend, &IRadioBackend::sliceChanged, &app,
+                         [&published](int, const SliceDelta& delta) {
+                             if (delta.frequency)
+                                 published.push_back(*delta.frequency);
+                         });
+        QStringList warnings;
+        QObject::connect(&refusedBackend, &IRadioBackend::configurationWarning,
+                         &app, [&warnings](const QString& w) { warnings << w; });
+
+        IcomCivBackendTestAccess::prepareOutstandingFrequencyWrite(
+            refusedBackend, *ic705, kGeneration, kHeldHz);
+
+        CivFrame refused;
+        refused.to = kControllerAddress;
+        refused.from = ic705->civAddress;
+        refused.cmd = kCivNg;
+        IcomCivBackendTestAccess::deliver(refusedBackend, refused, kGeneration);
+
+        // The correction is deferred one event-loop turn, for the same reason
+        // setSliceFrequency()'s out-of-band gate defers it: SliceModel has
+        // already announced the operator's request, so a direct emit would be
+        // announced away and the indicator would keep lying.
+        QCoreApplication::processEvents();
+
+        check(IcomCivBackendTestAccess::lastCompletedKey(refusedBackend)
+                  == "frequency",
+              "the FA retires the outstanding frequency write");
+        check(!warnings.isEmpty()
+                  && warnings.constLast().contains(QLatin1String("refused")),
+              "a refused tune TELLS the operator the radio said no");
+        // The load-bearing assertion: a backend that ignores FA publishes
+        // nothing here, and the display keeps the frequency the radio rejected.
+        check(published.size() == 1
+                  && std::llround(published.front() * 1.0e6)
+                         == static_cast<long long>(kHeldHz),
+              "a refused tune republishes the radio's real VFO, not the "
+              "frequency the radio rejected");
+    }
 
     return failures == 0 ? 0 : 1;
 }

--- a/tests/icom_incident_telemetry_test.cpp
+++ b/tests/icom_incident_telemetry_test.cpp
@@ -227,5 +227,67 @@ int main(int argc, char** argv)
               "frequency the radio rejected");
     }
 
+    // AN UNMATCHED FA MUST NOT FIRE THE CORRECTION.
+    //
+    // The regression this pins: gating only on `lastCompletedKey == "frequency"`
+    // is wrong, because observe() sets that key ONLY when a frame matches the
+    // in-flight transaction. An unmatched FA returns Observation::Unmatched and
+    // leaves the key at its previous value — and since frequency writes are the
+    // most common transaction, the key is usually "frequency" from the last real
+    // tune. So a stray or duplicate NG, or an NG for a transaction that already
+    // expired, would fire the block with NO frequency write refused: a false
+    // "the radio refused the tune" toast and a redundant re-assert.
+    //
+    // That is the lying-indicator failure this fix exists to remove, inverted —
+    // which is why it gets its own row rather than being left to the Accepted
+    // path above (that one passes either way, with or without the gate).
+    {
+        constexpr std::uint64_t kHeldHz = 145'030'000;
+        IcomCivBackend strayBackend;
+        std::vector<double> published;
+        QObject::connect(&strayBackend, &IRadioBackend::sliceChanged, &app,
+                         [&published](int, const SliceDelta& delta) {
+                             if (delta.frequency)
+                                 published.push_back(*delta.frequency);
+                         });
+        QStringList warnings;
+        QObject::connect(&strayBackend, &IRadioBackend::configurationWarning,
+                         &app, [&warnings](const QString& w) { warnings << w; });
+
+        IcomCivBackendTestAccess::prepareOutstandingFrequencyWrite(
+            strayBackend, *ic705, kGeneration, kHeldHz);
+
+        CivFrame refused;
+        refused.to = kControllerAddress;
+        refused.from = ic705->civAddress;
+        refused.cmd = kCivNg;
+
+        // First FA: matches the in-flight write, retires it, corrects the
+        // display. This is the legitimate case and it must still work.
+        IcomCivBackendTestAccess::deliver(strayBackend, refused, kGeneration);
+        QCoreApplication::processEvents();
+        const std::size_t afterReal = published.size();
+        const int warningsAfterReal = warnings.size();
+
+        check(afterReal == 1 && warningsAfterReal == 1,
+              "the matched FA still corrects exactly once");
+
+        // Second FA: nothing is in flight now, so observe() returns Unmatched
+        // and leaves lastCompletedKey at "frequency" from the write above.
+        // Under the old predicate this fires again; under the Accepted gate it
+        // must do nothing at all.
+        check(IcomCivBackendTestAccess::lastCompletedKey(strayBackend)
+                  == "frequency",
+              "the stale key really does still read \"frequency\"");
+
+        IcomCivBackendTestAccess::deliver(strayBackend, refused, kGeneration);
+        QCoreApplication::processEvents();
+
+        check(published.size() == afterReal,
+              "an unmatched FA republishes NOTHING (no redundant re-assert)");
+        check(warnings.size() == warningsAfterReal,
+              "an unmatched FA does not tell the operator a tune was refused");
+    }
+
     return failures == 0 ? 0 : 1;
 }

--- a/tests/icom_incident_telemetry_test.cpp
+++ b/tests/icom_incident_telemetry_test.cpp
@@ -52,12 +52,40 @@ struct IcomCivBackendTestAccess {
                                                  std::uint64_t generation,
                                                  std::uint64_t heldHz)
     {
+        prepareOutstandingFrequencyRequest(
+            backend, model, generation, heldHz,
+            cmdSetFrequency(model.civAddress, heldHz + 1'000'000));
+    }
+
+    // Same state, but the in-flight transaction is the poll's 03 READ. It
+    // shares the "frequency" key with the write, and an FA retires it just the
+    // same — which is exactly why the fix must look past the key.
+    static void prepareOutstandingFrequencyRead(IcomCivBackend& backend,
+                                                const IcomModel& model,
+                                                std::uint64_t generation,
+                                                std::uint64_t heldHz)
+    {
+        prepareOutstandingFrequencyRequest(backend, model, generation, heldHz,
+                                           cmdReadFrequency(model.civAddress));
+    }
+
+    static void setHeldFrequency(IcomCivBackend& backend, std::uint64_t hz)
+    {
+        backend.m_frequencyHz = hz;
+    }
+
+    static void prepareOutstandingFrequencyRequest(IcomCivBackend& backend,
+                                                   const IcomModel& model,
+                                                   std::uint64_t generation,
+                                                   std::uint64_t heldHz,
+                                                   std::vector<std::uint8_t> frame)
+    {
         backend.m_model = &model;
         backend.m_connected = true;
         backend.m_sessionGeneration = generation;
         backend.m_frequencyHz = heldHz;
         IcomCivScheduler::Request request;
-        request.frame = cmdSetFrequency(model.civAddress, heldHz + 1'000'000);
+        request.frame = std::move(frame);
         request.key = "frequency";
         request.expectsReply = true;
         request.acceptsGenericReply = true;
@@ -287,6 +315,118 @@ int main(int argc, char** argv)
               "an unmatched FA republishes NOTHING (no redundant re-assert)");
         check(warnings.size() == warningsAfterReal,
               "an unmatched FA does not tell the operator a tune was refused");
+    }
+
+    // AN FA TO A FREQUENCY *READ* IS NOT A REFUSED TUNE.
+    //
+    // semanticKey() folds the poll's 03 read and the +60 ms confirmation read
+    // onto the same "frequency" key as the 05 write, and matches() retires any
+    // in-flight transaction on an FA. So `Accepted && key == "frequency"` is
+    // also true when the radio NGs a READ — and that must not tell the
+    // operator a tune was refused, nor republish anything.
+    {
+        constexpr std::uint64_t kHeldHz = 145'030'000;
+        IcomCivBackend readBackend;
+        std::vector<double> published;
+        QObject::connect(&readBackend, &IRadioBackend::sliceChanged, &app,
+                         [&published](int, const SliceDelta& delta) {
+                             if (delta.frequency)
+                                 published.push_back(*delta.frequency);
+                         });
+        QStringList warnings;
+        QObject::connect(&readBackend, &IRadioBackend::configurationWarning,
+                         &app, [&warnings](const QString& w) { warnings << w; });
+
+        IcomCivBackendTestAccess::prepareOutstandingFrequencyRead(
+            readBackend, *ic705, kGeneration, kHeldHz);
+
+        CivFrame refused;
+        refused.to = kControllerAddress;
+        refused.from = ic705->civAddress;
+        refused.cmd = kCivNg;
+        IcomCivBackendTestAccess::deliver(readBackend, refused, kGeneration);
+        QCoreApplication::processEvents();
+
+        check(IcomCivBackendTestAccess::lastCompletedKey(readBackend)
+                  == "frequency",
+              "the FA retires the outstanding frequency read under the same key");
+        check(published.empty(),
+              "an FA to a frequency READ republishes nothing");
+        check(warnings.isEmpty(),
+              "an FA to a frequency READ does not claim a tune was refused");
+    }
+
+    // THE DEFERRED CORRECTION MUST NOT STOMP A NEWER TUNE.
+    //
+    // The re-assert is one event-loop turn behind the FA. If the operator
+    // issues another tune inside that gap, the correction is for a request
+    // they have already moved past; firing it anyway drags the readout back
+    // behind a write that may well succeed. The epoch guard drops it.
+    {
+        constexpr std::uint64_t kHeldHz = 145'030'000;
+        IcomCivBackend raceBackend;
+        std::vector<double> published;
+        QObject::connect(&raceBackend, &IRadioBackend::sliceChanged, &app,
+                         [&published](int, const SliceDelta& delta) {
+                             if (delta.frequency)
+                                 published.push_back(*delta.frequency);
+                         });
+        QStringList warnings;
+        QObject::connect(&raceBackend, &IRadioBackend::configurationWarning,
+                         &app, [&warnings](const QString& w) { warnings << w; });
+
+        IcomCivBackendTestAccess::prepareOutstandingFrequencyWrite(
+            raceBackend, *ic705, kGeneration, kHeldHz);
+
+        CivFrame refused;
+        refused.to = kControllerAddress;
+        refused.from = ic705->civAddress;
+        refused.cmd = kCivNg;
+        IcomCivBackendTestAccess::deliver(raceBackend, refused, kGeneration);
+        // A newer operator tune lands before the deferred correction fires.
+        // (No session is attached, so nothing goes on the wire; the epoch
+        // bump at the top of the seam verb is the part under test.)
+        raceBackend.setSliceFrequency(0, 145'500'000.0);
+        QCoreApplication::processEvents();
+
+        check(warnings.size() == 1,
+              "the refusal is still reported even when a newer tune follows");
+        check(published.empty(),
+              "a correction overtaken by a newer tune does not fire");
+    }
+
+    // THE CORRECTION PUBLISHES THE RADIO'S NEWEST WORD, NOT A SNAPSHOT.
+    //
+    // A 03 reply can land in the same gap and move m_frequencyHz. Capturing
+    // the value at FA time would then publish a frequency the radio has
+    // already left; reading it at fire time publishes where the radio is.
+    {
+        constexpr std::uint64_t kHeldHz = 145'030'000;
+        constexpr std::uint64_t kMovedHz = 145'040'000;
+        IcomCivBackend freshBackend;
+        std::vector<double> published;
+        QObject::connect(&freshBackend, &IRadioBackend::sliceChanged, &app,
+                         [&published](int, const SliceDelta& delta) {
+                             if (delta.frequency)
+                                 published.push_back(*delta.frequency);
+                         });
+
+        IcomCivBackendTestAccess::prepareOutstandingFrequencyWrite(
+            freshBackend, *ic705, kGeneration, kHeldHz);
+
+        CivFrame refused;
+        refused.to = kControllerAddress;
+        refused.from = ic705->civAddress;
+        refused.cmd = kCivNg;
+        IcomCivBackendTestAccess::deliver(freshBackend, refused, kGeneration);
+        IcomCivBackendTestAccess::setHeldFrequency(freshBackend, kMovedHz);
+        QCoreApplication::processEvents();
+
+        check(published.size() == 1
+                  && std::llround(published.front() * 1.0e6)
+                         == static_cast<long long>(kMovedHz),
+              "a deferred correction publishes the frequency the radio holds "
+              "when it fires, not the one it held at FA time");
     }
 
     return failures == 0 ? 0 : 1;


### PR DESCRIPTION
## What this fixes

`FA` is CI-V's NG — the radio's "no". Nothing in the backend consumed it. `IcomCivScheduler::observe()` treats `FB` and `FA` identically (both merely retire the transaction and carry no state), and `isNg()` existed in `CivCodec.h:77` with **no caller in the backend at all**. So a refused frequency write left the optimistic frequency standing in the model, and the operator was looking at a number the radio never entered.

## Why it is reachable in ordinary use

The IC-9700 has three bands and two receivers, and **only two bands can be live at once** — so a receiver cannot be tuned to a band the other receiver already holds. The radio answers `cmd 05` with `FA` and stays put.

Measured on hardware 2026-08-29: **six cross-band sets, six `FA`s, and the display followed all six.** The radio never moved. See #4840.

The fix is correct on every model, not just that one: `FA` on a frequency write means the write did not take, whatever the reason.

## What it does

On `FA` completing an outstanding `"frequency"` transaction, re-assert the radio's real VFO from `m_frequencyHz` (which is radio-authoritative) and tell the operator:

> The radio refused the tune. It is still on 145.030000 MHz — on this model a receiver cannot move to a band the other receiver already holds.

The correction is deferred one event-loop turn via `QTimer::singleShot(0, ...)`, exactly as the out-of-band gate in `setSliceFrequency()` and the refused mode in `setSliceMode()` already do — `SliceModel` has accepted and announced the operator's request by then, so a direct emit would be overwritten by that announcement and the indicator would keep lying.

**Deliberately narrow.** Only a frequency write is corrected, because that is the case with hardware evidence *and* a known-good restoration value. Other refused writes are a separate question and are left alone rather than guessed at.

## Test

`tests/icom_incident_telemetry_test.cpp` — drives a genuinely in-flight frequency write (enqueued *and* dispatched, since `observe()` only retires a dispatched transaction), delivers an `FA`, and asserts three things:

1. the `FA` retires the outstanding frequency write
2. the operator is told the radio refused
3. **the load-bearing one:** exactly one frequency is republished, and it is the radio's held VFO — not the frequency the radio rejected

Assertion 3 is what fails on `main`: a backend that ignores `FA` publishes *nothing* there, and the display keeps the rejected frequency.

## What this does NOT fix

**`rigctl` still answers `RPRT 0` for a refused tune.** `RigctlProtocol::cmdSetFreq` replies synchronously and then marshals the real work through a `QueuedConnection`, so the NAK is structurally unobservable at the point the return code is written. That is a second bug with the same root symptom, and it is untouched here — this PR corrects the *display*, not rigctl's return code. Flagging it so a reviewer does not go looking for a rigctl change and fail to find one.

## Verification limits

- The `FA` path is proven by the unit test above and by the six-refusal hardware session on 2026-08-29 (IC-9700 over RS-BA1).
- The warning string is not exercised against a live radio in this PR — the hardware session predates the user-facing message, which was written afterwards from what that session measured.
- No transmitter was keyed in producing this change.
