### PR TITLE
ci(windows): pin msstore CLI to v0.4.2 now that #162 is fixed

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -447,7 +447,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') && vars.AETHERSDR_STORE_PRODUCT_ID != ''
         uses: microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0
         with:
-          version: v0.4.1
+          version: v0.4.2
 
       - name: Stage Microsoft Store submission (draft)
         if: startsWith(github.ref, 'refs/tags/') && vars.AETHERSDR_STORE_PRODUCT_ID != ''

--- a/docs/WINDOWS-STORE-MSIX.md
+++ b/docs/WINDOWS-STORE-MSIX.md
@@ -235,7 +235,7 @@ On a `v*` tag push the workflow:
 1. Builds `AetherSDR.exe`, runs `windeployqt`, packages the MSIX, and creates
    the `.msixupload` (existing steps).
 2. The pinned `microsoft/microsoft-store-apppublisher` action puts the pinned
-   `msstore` CLI v0.4.1 on PATH and the workflow logs `msstore --version`.
+   `msstore` CLI v0.4.2 on PATH and the workflow logs `msstore --version`.
 3. `msstore reconfigure` authenticates from the four GitHub secrets.
 4. `packaging/windows/publish-store.ps1` finds the `.msixupload` and runs
    `msstore publish <pkg>.msixupload -id <ProductId> --uploadTimeout 300
@@ -257,18 +257,28 @@ If the MSIX packaging step (which is `continue-on-error`) produced no
 `.msixupload`, `publish-store.ps1` warns and exits 0 rather than turning an
 otherwise-successful release red.
 
-The upload timeout is deliberately explicit. `msstore` CLI v0.4.0 and v0.4.1
-have a regression where omitting `--uploadTimeout` supplies a zero-second Azure
-blob network timeout, producing the characteristic `Uploading Bundle to Azure
-blob: 0%` failure and exit code `-1`
+The upload timeout is deliberately explicit, and stays that way — but it is no
+longer a bug workaround. `msstore` CLI v0.4.0 and v0.4.1 had a regression where
+omitting `--uploadTimeout` supplied a zero-second Azure blob network timeout,
+producing the characteristic `Uploading Bundle to Azure blob: 0%` failure and
+exit code `-1`
 ([microsoft/msstore-cli#162](https://github.com/microsoft/msstore-cli/issues/162)).
-The script uses the documented workaround of 300 seconds. It deliberately
-leaves verbose logging disabled because Actions logs are public and expanded
-authentication or upload diagnostics could expose derived credentials that
-GitHub cannot mask by their registered secret values. The affected CLI is
-pinned to prevent `latest` from silently changing publish behavior; advance
-that pin only after validating a released version containing
-[microsoft/msstore-cli#163](https://github.com/microsoft/msstore-cli/pull/163).
+That is fixed by
+[microsoft/msstore-cli#163](https://github.com/microsoft/msstore-cli/pull/163)
+and released in v0.4.2, which the pin above now names, so omitting the option
+would correctly yield the documented 100 s default.
+
+300 seconds is kept because 100 s is genuinely too short for this package. The
+CLI sets no `StorageTransferOptions`, so a `.msixupload` under 256 MiB is
+uploaded as a **single PUT** and the network timeout has to cover the whole
+transfer rather than an individual chunk. AetherSDR's upload is ~200 MB, which
+at 100 s would demand a sustained ~2 MB/s for the entire request.
+
+The workflow deliberately leaves verbose logging disabled because Actions logs
+are public and expanded authentication or upload diagnostics could expose
+derived credentials that GitHub cannot mask by their registered secret values.
+The CLI stays pinned to prevent `latest` from silently changing publish
+behavior.
 
 ### One-time setup (maintainer, outside the repo)
 

--- a/packaging/windows/publish-store.ps1
+++ b/packaging/windows/publish-store.ps1
@@ -39,8 +39,11 @@
 
 .PARAMETER UploadTimeoutSeconds
     Network timeout, in seconds, for each Azure blob upload request. Defaults
-    to 300. This is always passed explicitly because msstore CLI v0.4.0 and
-    v0.4.1 incorrectly use zero when --uploadTimeout is omitted.
+    to 300. The CLI sets no StorageTransferOptions, so a .msixupload under
+    256 MiB is sent as a single PUT and this timeout has to cover the entire
+    transfer rather than one chunk. At ~200 MB the CLI's own 100 s default
+    would require a sustained ~2 MB/s for the whole upload, so this is passed
+    explicitly as a deliberate value.
 
 .PARAMETER Commit
     Send the submission straight to certification instead of staging a draft.


### PR DESCRIPTION
The pin sat on `v0.4.1`, the last release carrying [microsoft/msstore-cli#162](https://github.com/microsoft/msstore-cli/issues/162). That is fixed by [#163](https://github.com/microsoft/msstore-cli/pull/163) and released in **v0.4.2** on 2026-09-02 — the exact condition `docs/WINDOWS-STORE-MSIX.md` set for advancing the pin:

> advance that pin only after validating a released version containing microsoft/msstore-cli#163.

### This is deliberately not a revert of #5345

#5345 was mostly Qt symbol packaging — `stage-debug-symbols.ps1`, `check-symbol-package.ps1`, the `.appxsym` topology work. Only one of its five commits (`ae57707`) was the timeout workaround, and only the pin and its surrounding prose change here.

### `-UploadTimeoutSeconds 300` stays — and it matters here

This one is not just habit. `AzureBlobManager` calls `blobClient.UploadAsync` **without setting `StorageTransferOptions`**, so the SDK's default 256 MiB `InitialTransferSize` applies and a `.msixupload` under that size is sent as a **single PUT**. `Retry.NetworkTimeout` therefore has to cover the entire transfer, not one chunk.

Your published `.msixupload` is **~197 MB** (v26.9.1), and #5345 adds symbols on top. At the CLI's restored 100 s default that would demand a sustained **~2 MB/s for the whole request** — genuinely tight, and it would fail in exactly the same `Uploading Bundle to Azure blob: 0%` shape as #162 did, which would be a miserable thing to re-diagnose.

So the 300 s value is kept and re-documented as a deliberate sizing decision rather than a bug workaround.

### Net effect

- `version: v0.4.1` → `v0.4.2`
- `docs/WINDOWS-STORE-MSIX.md`: the timeout paragraph rewritten, plus the v0.4.1 mention in the numbered flow
- `publish-store.ps1`: `.PARAMETER UploadTimeoutSeconds` help rewritten

No behaviour change beyond the version bump. The note about keeping verbose logging off in public Actions logs is preserved verbatim.

Sent as part of a sweep across the repos that referenced msstore-cli#162.
