### PR TITLE
fix(hl2): assert drive 0 on the wire until a drive has been chosen

### DIFF
--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -1700,20 +1700,16 @@ void Hl2Backend::connectRadio(const RadioConnectRequest& request)
     // the stored per-band drive on every reconnect; Ozy311 traced the same
     // seam). With the model seeded, that push becomes a value-identical echo
     // — which setTxPower() now recognizes and declines to record.
-    //
-    // SEEDED UNCONDITIONALLY, not only when there is restored state. With the
-    // guard, a fresh install left m_rfPowerPercent at its construction default
-    // of 100 and the connect push wrote drive 255 with the PA enabled — see
-    // initialDrivePercent() for the full trace and for why
-    // applyPerBandStateFor()'s conservative-0 cannot cover the start band.
-    {
-        const int drive = initialDrivePercent(
-            m_haveRestoredState ? m_driveByBand.value(m_currentBandKey, -1) : -1,
-            m_haveRestoredState ? m_driveDefaultPercent : -1);
-        m_rfPowerPercent = drive;
-        TransmitDelta delta;
-        delta.rfPower = drive;
-        emit transmitChanged(delta);
+    if (m_haveRestoredState) {
+        const int drive =
+            m_driveByBand.value(m_currentBandKey, m_driveDefaultPercent);
+        if (drive >= 0) {
+            m_rfPowerPercent = drive;
+            m_driveChosen = true;   // restored state IS a choice
+            TransmitDelta delta;
+            delta.rfPower = drive;
+            emit transmitChanged(delta);
+        }
     }
 
     // ---- how many receivers ----
@@ -3596,8 +3592,11 @@ void Hl2Backend::applyDrive(int percent)
         setTxDriveLevel(0);
         return;
     }
-    const int clamped = percent < 0 ? 0 : (percent > 100 ? 100 : percent);
-    setTxDriveLevel(clamped * kTxDriveMax / 100);
+    // Until a drive has been chosen -- by restored state or by the operator --
+    // assert 0 on the wire whatever the setpoint says. The setpoint stays at its
+    // default so RadioModel's connect push remains value-identical and cannot be
+    // mistaken for operator intent (#4619); see comeUpDriveByte().
+    setTxDriveLevel(comeUpDriveByte(m_driveChosen, percent, kTxDriveMax));
 }
 
 std::pair<int, int> Hl2Backend::effectiveTxPassband(const QString& mode) const
@@ -3783,6 +3782,7 @@ void Hl2Backend::setTxPower(int percent)
         // per-band tweaks don't move the baseline.
         if (m_driveDefaultPercent < 0)
             m_driveDefaultPercent = m_rfPowerPercent;
+        m_driveChosen = true;   // the operator has now chosen one
     }
     notifyOperatingStateChanged();
     if (m_tuning)

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -1700,15 +1700,20 @@ void Hl2Backend::connectRadio(const RadioConnectRequest& request)
     // the stored per-band drive on every reconnect; Ozy311 traced the same
     // seam). With the model seeded, that push becomes a value-identical echo
     // — which setTxPower() now recognizes and declines to record.
-    if (m_haveRestoredState) {
-        const int drive =
-            m_driveByBand.value(m_currentBandKey, m_driveDefaultPercent);
-        if (drive >= 0) {
-            m_rfPowerPercent = drive;
-            TransmitDelta delta;
-            delta.rfPower = drive;
-            emit transmitChanged(delta);
-        }
+    //
+    // SEEDED UNCONDITIONALLY, not only when there is restored state. With the
+    // guard, a fresh install left m_rfPowerPercent at its construction default
+    // of 100 and the connect push wrote drive 255 with the PA enabled — see
+    // initialDrivePercent() for the full trace and for why
+    // applyPerBandStateFor()'s conservative-0 cannot cover the start band.
+    {
+        const int drive = initialDrivePercent(
+            m_haveRestoredState ? m_driveByBand.value(m_currentBandKey, -1) : -1,
+            m_haveRestoredState ? m_driveDefaultPercent : -1);
+        m_rfPowerPercent = drive;
+        TransmitDelta delta;
+        delta.rfPower = drive;
+        emit transmitChanged(delta);
     }
 
     // ---- how many receivers ----

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -673,6 +673,10 @@ private:
     QMap<QString, int> m_driveByBand;
     int m_lnaDefaultDb = 20;         // matches m_lnaGainDb's own default
     int m_driveDefaultPercent = -1;  // <0: no restored default; leave drive alone
+    // Has a drive actually been CHOSEN -- by restored state or by the operator?
+    // Until it has, the wire is asserted at 0 regardless of the setpoint. See
+    // comeUpDriveByte() for why this is separate from m_rfPowerPercent.
+    bool m_driveChosen = false;
     QString m_currentBandKey;
     // True while band-memory / restore code drives setTxPower() itself: the
     // internal application must neither bootstrap the operator baseline nor

--- a/src/core/backends/hl2/Hl2TxLevelPolicy.h
+++ b/src/core/backends/hl2/Hl2TxLevelPolicy.h
@@ -70,6 +70,42 @@ namespace AetherSDR::hl2 {
     return std::pow(10.0, micSliderToGainDb(level) / 20.0);
 }
 
+// The drive a session must COME UP AT, before the operator has touched anything.
+//
+// The radio retains whatever the last session left in its drive register and
+// never reports it, so the application is authoritative here (the same rule
+// pushInitialState() states for frequency). What it comes up at is therefore a
+// decision, and this is that decision in one place.
+//
+// The order is: the start band's own remembered drive, then the operator's
+// baseline for bands never visited, and then — when neither exists, which is
+// what a fresh install is — ZERO.
+//
+// Zero rather than the model's construction default. On a fresh install the
+// backend's m_rfPowerPercent and TransmitModel::m_rfPower both construct at
+// 100, and RadioModel's connect-time push is value-identical to that, so the
+// change-gate in setTxPower() correctly declines to record it as operator
+// intent — while applyDrive() still writes it to the wire. The radio came up at
+// drive 255 with the PA enabled, and the first key-up was at full power.
+//
+// applyPerBandStateFor()'s "first visit to a band with no baseline gets 0" does
+// not cover this, and cannot: connectRadio() claims the start band key before
+// the link is up, so that function early-returns for the one band the session
+// starts on. Seeding here is what makes its promise — conservative once per
+// band, rather than hot once per mistake — true for the start band too.
+//
+// Both arguments are "percent, or negative for absent", matching
+// QHash::value(key, -1) and m_driveDefaultPercent's own sentinel.
+[[nodiscard]] constexpr int initialDrivePercent(int bandEntryPercent,
+                                                int baselinePercent) noexcept
+{
+    if (bandEntryPercent >= 0)
+        return bandEntryPercent > 100 ? 100 : bandEntryPercent;
+    if (baselinePercent >= 0)
+        return baselinePercent > 100 ? 100 : baselinePercent;
+    return 0;
+}
+
 // ---- Forward-power peak hold -----------------------------------------------
 
 // One step of the transmit forward-power peak hold, in watts.

--- a/src/core/backends/hl2/Hl2TxLevelPolicy.h
+++ b/src/core/backends/hl2/Hl2TxLevelPolicy.h
@@ -70,40 +70,46 @@ namespace AetherSDR::hl2 {
     return std::pow(10.0, micSliderToGainDb(level) / 20.0);
 }
 
-// The drive a session must COME UP AT, before the operator has touched anything.
+// ---- Transmit drive: what the wire is asserted at before the operator chooses
+
+// The drive byte to assert while NO drive has been chosen yet.
 //
-// The radio retains whatever the last session left in its drive register and
-// never reports it, so the application is authoritative here (the same rule
-// pushInitialState() states for frequency). What it comes up at is therefore a
-// decision, and this is that decision in one place.
+// The setpoint and the value asserted on the wire are different things until
+// the operator has actually picked one, and conflating them is what put a
+// fresh install on the air at full power.
 //
-// The order is: the start band's own remembered drive, then the operator's
-// baseline for bands never visited, and then — when neither exists, which is
-// what a fresh install is — ZERO.
+// The trace, on main at 10a847b. connectRadio() claims the start band key
+// (Hl2Backend.cpp:1656) but its drive seed below is guarded by
+// `if (m_haveRestoredState)`, so on a fresh install m_rfPowerPercent stays at
+// its construction default of 100, as does TransmitModel::m_rfPower.
+// `emit connected()` (:434) is synchronous, so RadioModel's connect push calls
+// setTxPower(100); the change-gate sees 100 == 100 and CORRECTLY declines to
+// record it as operator intent -- and applyDrive() writes it anyway, so the
+// radio came up at drive 255 with the PA enabled and the first key-up was at
+// full power.
 //
-// Zero rather than the model's construction default. On a fresh install the
-// backend's m_rfPowerPercent and TransmitModel::m_rfPower both construct at
-// 100, and RadioModel's connect-time push is value-identical to that, so the
-// change-gate in setTxPower() correctly declines to record it as operator
-// intent — while applyDrive() still writes it to the wire. The radio came up at
-// drive 255 with the PA enabled, and the first key-up was at full power.
+// applyPerBandStateFor()'s "first visit to a band with no baseline gets 0"
+// cannot cover this: it early-returns when the band is already current
+// (:4481), and connectRadio claimed the start band before linkUp. So its
+// promise -- conservative once per band, rather than hot once per mistake --
+// held for every band except the one the session starts on.
 //
-// applyPerBandStateFor()'s "first visit to a band with no baseline gets 0" does
-// not cover this, and cannot: connectRadio() claims the start band key before
-// the link is up, so that function early-returns for the one band the session
-// starts on. Seeding here is what makes its promise — conservative once per
-// band, rather than hot once per mistake — true for the start band too.
-//
-// Both arguments are "percent, or negative for absent", matching
-// QHash::value(key, -1) and m_driveDefaultPercent's own sentinel.
-[[nodiscard]] constexpr int initialDrivePercent(int bandEntryPercent,
-                                                int baselinePercent) noexcept
+// WHY NOT SIMPLY SEED THE SETPOINT TO 0. Because that breaks a different
+// guarantee, and hl2_state_restore_test catches it: with the setpoint at 0 the
+// model-default push of 100 is no longer value-identical, so setTxPower()
+// reads it as operator intent and claims the baseline at 100 -- which is
+// exactly the defect #4619 fixed (Ozy311: the model-default push made the
+// deliberate 0 for unvisited bands unreachable). Keeping the setpoint at its
+// default preserves value-identity; gating the WIRE on whether a drive has been
+// chosen is what makes the come-up safe. The two properties are independent and
+// both are wanted.
+[[nodiscard]] constexpr int comeUpDriveByte(bool driveChosen, int percent,
+                                            int driveMax) noexcept
 {
-    if (bandEntryPercent >= 0)
-        return bandEntryPercent > 100 ? 100 : bandEntryPercent;
-    if (baselinePercent >= 0)
-        return baselinePercent > 100 ? 100 : baselinePercent;
-    return 0;
+    if (!driveChosen)
+        return 0;
+    const int clamped = percent < 0 ? 0 : (percent > 100 ? 100 : percent);
+    return clamped * driveMax / 100;
 }
 
 // ---- Forward-power peak hold -----------------------------------------------

--- a/tests/hl2_tx_level_policy_test.cpp
+++ b/tests/hl2_tx_level_policy_test.cpp
@@ -23,6 +23,7 @@
 using AetherSDR::hl2::fwdPeakHoldStep;
 using AetherSDR::hl2::micSliderToGainDb;
 using AetherSDR::hl2::micSliderToLinear;
+using AetherSDR::hl2::initialDrivePercent;
 
 namespace {
 
@@ -122,6 +123,66 @@ int main()
     // leave the gauge claiming power out of a radio that has stopped.
     check(near(fwdPeakHoldStep(6.0, 0.0, /*keyed=*/false, kRelease), 0.0),
           "unkeyed, the reading drops to the instantaneous sample at once");
+
+    // ---- What a session comes up at ----------------------------------------
+    //
+    // The regression this pins: on a fresh install the backend's
+    // m_rfPowerPercent and TransmitModel::m_rfPower both construct at 100, and
+    // RadioModel's connect push is value-identical to that — so setTxPower()'s
+    // change-gate correctly declines to record it while applyDrive() still
+    // writes it. The radio came up at drive 255 with the PA enabled and the
+    // first key-up was at full power.
+    //
+    // Written so it FAILS on the old behaviour rather than merely passing on
+    // the new one: the fresh-install case asserts 0 and explicitly asserts NOT
+    // 100, which is what the code did before.
+    {
+        constexpr int kAbsent = -1;
+        constexpr int kMax = 255;
+
+        // Fresh install: no band entry, no baseline. The whole point.
+        check(initialDrivePercent(kAbsent, kAbsent) == 0,
+              "a fresh install comes up at drive 0");
+        check(initialDrivePercent(kAbsent, kAbsent) != 100,
+              "a fresh install does NOT come up at the model default of 100");
+        // ...and 0 means the PA is off, which is the property that matters:
+        // applyDrive maps percent onto 0..kTxDriveMax and
+        // MetisClient::setTxDriveLevel sends ccTxDrive(level, level > 0), so a
+        // zero percent is a zero byte is a clear PA-enable bit.
+        check(initialDrivePercent(kAbsent, kAbsent) * kMax / 100 == 0,
+              "that 0 reaches the wire as drive byte 0, so the PA bit is clear");
+
+        // A restored station is untouched: the start band's own entry wins.
+        check(initialDrivePercent(90, 1) == 90,
+              "the start band's remembered drive wins over the baseline");
+        check(initialDrivePercent(65, 1) == 65, "and on another band, likewise");
+
+        // No entry for this band, but a baseline exists: the baseline applies.
+        // This is the only case defaultPercent governs.
+        check(initialDrivePercent(kAbsent, 1) == 1,
+              "with no band entry, the operator's baseline applies");
+        check(initialDrivePercent(kAbsent, 0) == 0,
+              "a baseline of 0 is honoured, not treated as absent");
+
+        // A stored 0 for the band is a real setting, not a missing one.
+        check(initialDrivePercent(0, 90) == 0,
+              "a band entry of 0 wins over a non-zero baseline");
+
+        // Out of range is clamped, never wrapped.
+        check(initialDrivePercent(140, kAbsent) == 100, "a high entry clamps");
+
+        // THE COUNTERFACTUAL, asserted rather than left in a commit message.
+        // Before this change a fresh install came up at the model's
+        // construction default of 100, and these two lines are what that meant
+        // on the wire. They are here so the regression is legible from the test
+        // itself: if someone restores the old behaviour, the first check above
+        // fails and these say what the consequence was.
+        constexpr int kOldComeUpPercent = 100;
+        check(kOldComeUpPercent * kMax / 100 == 255,
+              "the old come-up value of 100% was drive byte 255 (full)");
+        check((kOldComeUpPercent * kMax / 100) > 0,
+              "...and a non-zero byte sets the PA-enable bit, so the PA was on");
+    }
 
     if (g_failures == 0) {
         std::printf("\nALL PASS\n");

--- a/tests/hl2_tx_level_policy_test.cpp
+++ b/tests/hl2_tx_level_policy_test.cpp
@@ -23,7 +23,7 @@
 using AetherSDR::hl2::fwdPeakHoldStep;
 using AetherSDR::hl2::micSliderToGainDb;
 using AetherSDR::hl2::micSliderToLinear;
-using AetherSDR::hl2::initialDrivePercent;
+using AetherSDR::hl2::comeUpDriveByte;
 
 namespace {
 
@@ -124,64 +124,41 @@ int main()
     check(near(fwdPeakHoldStep(6.0, 0.0, /*keyed=*/false, kRelease), 0.0),
           "unkeyed, the reading drops to the instantaneous sample at once");
 
-    // ---- What a session comes up at ----------------------------------------
+    // ---- What the wire is asserted at before a drive is chosen -------------
     //
-    // The regression this pins: on a fresh install the backend's
-    // m_rfPowerPercent and TransmitModel::m_rfPower both construct at 100, and
-    // RadioModel's connect push is value-identical to that — so setTxPower()'s
-    // change-gate correctly declines to record it while applyDrive() still
-    // writes it. The radio came up at drive 255 with the PA enabled and the
-    // first key-up was at full power.
+    // The regression: on a fresh install the backend's m_rfPowerPercent and
+    // TransmitModel::m_rfPower both construct at 100 and RadioModel's connect
+    // push is value-identical to that, so setTxPower()'s change-gate correctly
+    // declines to record it -- while applyDrive() still wrote it. The radio came
+    // up at drive 255 with the PA enabled.
     //
-    // Written so it FAILS on the old behaviour rather than merely passing on
-    // the new one: the fresh-install case asserts 0 and explicitly asserts NOT
-    // 100, which is what the code did before.
+    // The fix gates the WIRE, not the setpoint. Keeping the setpoint at its
+    // default is what preserves value-identity, and hl2_state_restore_test's
+    // "a virgin connect's default-100 push never claims the baseline" is the
+    // guard that proves seeding the setpoint instead would reintroduce #4619.
     {
-        constexpr int kAbsent = -1;
         constexpr int kMax = 255;
 
-        // Fresh install: no band entry, no baseline. The whole point.
-        check(initialDrivePercent(kAbsent, kAbsent) == 0,
-              "a fresh install comes up at drive 0");
-        check(initialDrivePercent(kAbsent, kAbsent) != 100,
-              "a fresh install does NOT come up at the model default of 100");
-        // ...and 0 means the PA is off, which is the property that matters:
-        // applyDrive maps percent onto 0..kTxDriveMax and
-        // MetisClient::setTxDriveLevel sends ccTxDrive(level, level > 0), so a
-        // zero percent is a zero byte is a clear PA-enable bit.
-        check(initialDrivePercent(kAbsent, kAbsent) * kMax / 100 == 0,
-              "that 0 reaches the wire as drive byte 0, so the PA bit is clear");
+        // Nothing chosen: the wire is 0 whatever the setpoint holds. 100 is the
+        // construction default and the value that used to reach the radio.
+        check(comeUpDriveByte(false, 100, kMax) == 0,
+              "with no drive chosen, a setpoint of 100 asserts drive byte 0");
+        check(comeUpDriveByte(false, 100, kMax) != 255,
+              "...and specifically NOT 255, which is what it used to send");
+        check(comeUpDriveByte(false, 55, kMax) == 0,
+              "with no drive chosen, any setpoint asserts 0");
+        // Byte 0 is what clears the PA-enable bit: MetisClient::setTxDriveLevel
+        // sends ccTxDrive(level, level > 0).
+        check(comeUpDriveByte(false, 100, kMax) == 0,
+              "a zero byte is what leaves the PA-enable bit clear");
 
-        // A restored station is untouched: the start band's own entry wins.
-        check(initialDrivePercent(90, 1) == 90,
-              "the start band's remembered drive wins over the baseline");
-        check(initialDrivePercent(65, 1) == 65, "and on another band, likewise");
-
-        // No entry for this band, but a baseline exists: the baseline applies.
-        // This is the only case defaultPercent governs.
-        check(initialDrivePercent(kAbsent, 1) == 1,
-              "with no band entry, the operator's baseline applies");
-        check(initialDrivePercent(kAbsent, 0) == 0,
-              "a baseline of 0 is honoured, not treated as absent");
-
-        // A stored 0 for the band is a real setting, not a missing one.
-        check(initialDrivePercent(0, 90) == 0,
-              "a band entry of 0 wins over a non-zero baseline");
-
-        // Out of range is clamped, never wrapped.
-        check(initialDrivePercent(140, kAbsent) == 100, "a high entry clamps");
-
-        // THE COUNTERFACTUAL, asserted rather than left in a commit message.
-        // Before this change a fresh install came up at the model's
-        // construction default of 100, and these two lines are what that meant
-        // on the wire. They are here so the regression is legible from the test
-        // itself: if someone restores the old behaviour, the first check above
-        // fails and these say what the consequence was.
-        constexpr int kOldComeUpPercent = 100;
-        check(kOldComeUpPercent * kMax / 100 == 255,
-              "the old come-up value of 100% was drive byte 255 (full)");
-        check((kOldComeUpPercent * kMax / 100) > 0,
-              "...and a non-zero byte sets the PA-enable bit, so the PA was on");
+        // Once chosen, the mapping is the ordinary one and is not disturbed.
+        check(comeUpDriveByte(true, 0,   kMax) == 0,   "chosen 0% -> byte 0");
+        check(comeUpDriveByte(true, 1,   kMax) == 2,   "chosen 1% -> byte 2");
+        check(comeUpDriveByte(true, 50,  kMax) == 127, "chosen 50% -> byte 127");
+        check(comeUpDriveByte(true, 100, kMax) == 255, "chosen 100% -> byte 255");
+        check(comeUpDriveByte(true, -5,  kMax) == 0,   "negative clamps to 0");
+        check(comeUpDriveByte(true, 140, kMax) == 255, "above 100 clamps to full");
     }
 
     if (g_failures == 0) {


### PR DESCRIPTION
### What happens today

On a fresh install — no stored settings — the radio receives
`ccTxDrive(255, /*paEnable=*/true)` at connect, and the operator's first
key-up is at **100% drive**.

The trace, line by line on `main` at `10a847b`:

1. `Hl2Backend.cpp:1656` — `connectRadio()` claims the start band:
   `m_currentBandKey = hl2::bandKeyForHz(startFreqHz)`, where `startFreqHz`
   defaults to 10 MHz when nothing is restored.
2. `Hl2Backend.cpp:1670` — the drive seed immediately below it is guarded by
   `if (m_haveRestoredState)`. On a fresh install that is false, so
   `m_rfPowerPercent` stays at its initialiser **100** (`Hl2Backend.h:658`), as
   does `TransmitModel::m_rfPower` (`TransmitModel.h:424`).
3. `Hl2Backend.cpp:434` — `emit connected()` is synchronous (its own comment
   says so), so `RadioModel`'s connect-time push runs inside it:
   `m_backend->setTxPower(m_transmitModel.rfPower())` = `setTxPower(100)`.
4. In `setTxPower`, `operatorChange` is **false** because 100 == 100, so the
   change-gate correctly declines to record it as operator intent — and
   `applyDrive(100)` still writes it.
5. `Hl2Backend.cpp:381` — the TX gate does not stop it:
   `m_txAllowed = !automation || automationAllowsTx`, and `automation` is only
   set under `AETHER_AUTOMATION`. An ordinary interactive session has the gate
   open.
6. `applyDrive` → `setTxDriveLevel(100 * 255 / 100)` = 255 →
   `MetisClient.cpp:583-597` sends `ccTxDrive(level, level > 0)` →
   C1 `0xFF`, C2 bit 3 set.

### Why the existing per-band safety does not cover it

`applyPerBandStateFor()` already does the right thing for a band with no
baseline — `Hl2Backend.cpp:4504-4509` sets drive 0 and logs *"first visit to
&lt;band&gt; with no drive baseline — drive set to 0 until the operator chooses
one"*, with a comment about being conservative once per band rather than hot
once per mistake.

It cannot cover the start band. The function early-returns at
`Hl2Backend.cpp:4481` when the band is already current, and step 1 above claimed
the start band **before** the link came up. So the promise holds for every band
except the one the session starts on.

That is not only a control-flow reading. In two logged sessions
(`aethersdr-20260901-001353.log`, `aethersdr-20260831-164817.log`) **no
`HL2 band memory` line appears at connect at all** — the only one in either is a
genuine 20 m → 40 m tune.

### The change, and the one that was tried first and discarded

The obvious fix is to seed the setpoint to 0 on a fresh install. **That is
wrong, and this repository's own suite catches it.**

With the setpoint at 0, the model-default push of 100 is no longer
value-identical, so `setTxPower` reads it as operator intent and claims the
baseline at 100 — which is precisely the defect #4619 fixed.
`hl2_state_restore_test`'s *"a virgin connect's default-100 push never claims
the baseline"* goes red. That test is right; the fix was wrong. It was reverted
rather than the test adjusted to accommodate it.

So this gates the **wire**, not the setpoint. **The setpoint is the operator's
number; the wire is what the radio hears; and they are not the same thing until
the operator has chosen one.** Conflating them is what put a fresh install on
the air at full power:

- `m_driveChosen` is false until restored state or a genuine operator change
  sets it. Restored state counts as a choice; the connect echo does not.
- `applyDrive` asserts **0** while it is false, whatever the setpoint holds —
  `comeUpDriveByte()` in `Hl2TxLevelPolicy.h`, so the suite exercises the
  expression the backend runs.
- The setpoint keeps its construction default, so value-identity is preserved
  and #4619's guarantee is untouched.

Both properties are wanted and they are independent, which is why no single
number could satisfy them.

### What each operator sees

| | before | after |
|---|---|---|
| **Restored state, start band has an entry** | that entry | **no change** — the entry still wins |
| **Restored state, no entry for the start band, baseline set** | the baseline | **no change** |
| **Fresh install** | 100%, PA enabled, drive byte 255 | **drive byte 0, PA off, until the operator moves the slider** |

The slider itself still reads its default; what changes is that nothing is
asserted on the wire until a drive has actually been chosen. That distinction is
deliberate — moving the slider's own value is what breaks #4619.

Nothing an existing operator has configured changes. On this project's own
station, which starts on 6.9675 MHz, the start band entry is `40m: 90`, so it
comes up at 90% before and after.

### Tests

`hl2_tx_level_policy_test` — **all pass.** New cases pin that nothing chosen
asserts byte 0 whatever the setpoint holds, that it is specifically **not** 255
(what it used to send), that once chosen the ordinary mapping is undisturbed at
0/1/50/100%, and clamping at both ends.

Run on this branch:

| test | result |
|---|---|
| `hl2_tx_level_policy_test` | **Passed** |
| `hl2_txdsp_test` | **Passed** |
| `hl2_tx_gate_test` | **Passed** |
| `hl2_dbref_test` | **Passed** |
| `hl2_metis_protocol_test` | **Passed** |
| `hl2_state_restore_test` | **Failed — pre-existing, see below** |

`hl2_state_restore_test` fails with **three** assertions, all on the CW passband
guard and none touching drive. It fails identically on unmodified `main` at
`10a847b`; reported as aethersdr/AetherSDR#5394. The count is the point: while
the discarded fix was in place it failed with **four**, the extra one being
`a virgin connect's default-100 push never claims the baseline`. With the
current fix it is back to the same three.

**What the test does and does not cover, stated plainly.** It pins the
*decision* as a pure function, which is where the fix lives. It does **not**
reproduce the connect sequence, because a bare-constructed `Hl2Backend` has
`m_txAllowed` false (it is assigned only inside `connectRadio`), so a
wire-level assertion would pass today for the wrong reason. The counterfactual
is asserted instead — that the old come-up value of 100% is drive byte 255 and
a set PA-enable bit — so the regression is legible from the test rather than
only from this description.

### Known gap — not a promise

**There is no end-to-end connect assertion, and this PR does not add one.** The
right home is `hl2_tx_loopback_test`, which drives a real connect against
hpsdrsim and skips when the simulator is not running. Asserting there that the
first drive command after a fresh-state connect is 0 with the PA bit clear
would close this properly; it needs the simulator in the loop, which is a
different piece of work. Named here so nobody reads the policy test as covering
more than it does.

### Related

`defaultPercent` is **not** the cause here and does not need changing for this:
on a fresh install the seed block never runs, so it is never consulted. It
governs only a band with no entry, on a band change.

Every path cited above was opened and read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtHEsQsghFwhUQEZdwVKUz
