### PR TITLE
hl2: decode the TX FIFO status word as the gateware sends it

### DIFF
--- a/docs/HERMES.md
+++ b/docs/HERMES.md
@@ -743,7 +743,7 @@ receiver, and **backend teardown**, which waits out an in-flight DSP build.
 | ADC overload bit + clip counter (§6) | Addendum 2 §A3: the CORRECT driver for any gain decision. Audio level in one slice says nothing about what saturates a converter seeing 0–38.4 MHz |
 | Discovery telemetry (§1) | Temperature, power, clip count, PTT are pollable WITHOUT a stream — cheapest possible first increment, and a diagnostic when the stream itself is broken |
 | ~~Receiver count at discovery `0x13`~~ | **DONE — §19.** Read and clamped against; skimmer variants 9–12 with NO transmit are still untested |
-| TX FIFO depth (§6) | "The most important number in the protocol." TX pacing must servo against it, not a host timer — clock domains drift |
+| TX FIFO status (§6) | The oracle calls a FIFO depth "the most important number in the protocol", but **this radio does not send one**: `dsiq_status` is a recovery flag plus the top 7 bits of the fill level (`fifos.v:100-110` at `883a338`). Useful as coarse occupancy and a pacing-fault flag; **not servo-ready** until one unit of that field is measured in samples |
 | Wideband bandscope (§7) | Unimplemented by piHPSDR (dead code) and declined by SDR Console. A differentiation opportunity, with the 4-vs-32 packets-per-block trap already documented |
 
 ### 11.5 Smaller corrections
@@ -950,7 +950,7 @@ Effort is rough: **XS** under an hour, **S** a session, **M** a few sessions,
 | 14 | ADC overload bit + clip counter | O §6, A2 §A3 | The *correct* driver for gain decisions — audio level in one slice says nothing about what saturates a converter seeing 0–38.4 MHz | S |
 | 15 | Discovery-reply telemetry (temp, power, PTT, clip) | O §1 | Pollable **without a stream** — cheapest first increment, and a diagnostic when the stream is broken | S |
 | 16 | Pair WDSP `RXA_ADC_PK` with the hardware clip indicator | A3 §7 | Post-DDC slice vs pre-DDC full spectrum. They disagree by design; A3 calls this the most useful diagnostic pairing on the HL2 | S |
-| 17 | TX IQ FIFO depth + servo | O §6, A1 §B3 | "The most important number in the protocol." TX pacing must servo against it, not a host timer — clock domains drift | M |
+| 17 | TX IQ FIFO servo | O §6, A1 §B3 | The oracle wants pacing servoed against a FIFO depth rather than a host timer. **The wire carries no depth** — `dsiq_status` is a recovery flag plus the top 7 bits of the fill level. So this item first has to establish what one unit of that field is worth in samples; until then there is nothing to servo against | M |
 | 18 | Wideband bandscope (endpoint `0x04`) | O §7, A1 §A1 | Unimplemented by piHPSDR (dead code) and declined by SDR Console — a differentiation opportunity. **4 packets/block on HL2, not 32** | M |
 | ~~19~~ | ~~Filter board band switching (J16 / I2C `0x20`)~~ **DONE** — PA bias + config EEPROM still open | O §8 | Band filters auto-select from the slice frequency (`Hl2Backend::applyBandFilter`). PA bias and the config EEPROM are untouched and still want the RQST/ACK path | — |
 | 20 | ~~Multi-slice: index-space mapping object~~ | A3 §3 | **DONE — §19.** `Hl2Receivers.h`. The WDSP channel really is not the DDC index: ids come from a shared 32-slot pool, so after a TX channel has come and gone receiver 0 is routinely not channel 0 | S |
@@ -1177,7 +1177,7 @@ consistent with each other while both disagreed with the rest of the band:
 | `hl2_tx_loopback_test` through hpsdrsim | tone at the expected bin | passed, measuring the sim's feedback in wire order |
 | Panadapter during TX, live radio | clean single sideband, correct side of centre | looked perfect |
 | Forward power, USB vs LSB at 14.200 | 3875 vs 3876 | identical, both "working" |
-| TX FIFO depth | stable 27–31, no under/overflow | refuted the starvation theory |
+| TX FIFO "depth" *(as the client then reported it)* | stable 27–31, no under/overflow | refuted the starvation theory. **Both figures were misread**: the field is a recovery flag plus a coarse fill level, and the client's under/overflow split decoded a distinction the gateware does not carry. The verdict happens to survive — a steady value is still a steady value — but it was reached from a number that was not what it was labelled |
 
 It was found by an operator with a second receiver: *"I heard the LSB side of
 AetherSDR on the USB side of the Yaesu."*

--- a/docs/radio-certification.md
+++ b/docs/radio-certification.md
@@ -247,7 +247,7 @@ from Tune Power, not RF Power.
 |---|---|---|
 | ADC overload | `0x00[24]` | clipping the converter; invisible in any audio meter |
 | ADC clip count | discovery `0x1B[1:0]` | saturating counter — "did we clip at all recently" |
-| TX IQ FIFO depth | RADDR `0x00` | the oracle calls it the most important number in the protocol |
+| TX IQ FIFO status | RADDR `0x00`, `DATA[15:8]` | recovery flag + coarse fill (top 7 bits), **not a depth** — see `MetisProtocol.cpp`. Not servo-ready |
 | TX inhibit | `0x00[25]`, **active low** | the radio refusing to key, distinct from us not asking |
 
 ---

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -3936,14 +3936,22 @@ IRadioBackend::HealthSnapshot Hl2Backend::healthSnapshot() const
     put("ptt", QStringLiteral("PTT (radio)"), m_telemetry.ptt);
     put("keyed", QStringLiteral("Keyed (app)"), m_keyed);
     put("tuning", QStringLiteral("Tune carrier"), m_tuning);
-    // "The most important number in the protocol" (oracle §6): the depth of the
-    // FPGA's transmit sample buffer. Drifting up means we are sending faster
-    // than the radio consumes; drifting down is an impending underrun.
-    put("txFifoCount", QStringLiteral("TX FIFO depth"), opt(m_telemetry.txFifoCount));
-    put("txFifoUnderflow", QStringLiteral("TX FIFO underflow"),
-        opt(m_telemetry.txFifoUnderflow));
-    put("txFifoOverflow", QStringLiteral("TX FIFO overflow"),
-        opt(m_telemetry.txFifoOverflow));
+    // The FPGA's transmit sample buffer. The oracle calls its depth "the most
+    // important number in the protocol"; the gateware at 883a338 does not send
+    // a depth. It sends the TOP 7 BITS of the fill level and one fault flag
+    // (fifos.v:100-110) — so this reads as a level out of 127, not a count, and
+    // the label says so rather than inviting the reader to treat 64 as samples.
+    // Rising means we are sending faster than the radio consumes; falling is an
+    // impending underrun. See MetisProtocol.cpp's apply() for the full layout
+    // and for what the previous three rows here got wrong.
+    put("txFifoFillMsbs", QStringLiteral("TX FIFO fill (0-127, coarse)"),
+        opt(m_telemetry.txFifoFillMsbs));
+    // ONE bit for TWO faults: ran empty, or writes blocked after filling. The
+    // gateware does not distinguish them, so this must not be split into an
+    // underflow row and an overflow row — the two rows that stood here reported
+    // opposite faults for the same flag depending on fill-level bit 6.
+    put("txFifoRecovery", QStringLiteral("TX pacing fault (under OR overrun)"),
+        opt(m_telemetry.txFifoRecovery));
 
     // DRIVE: WHAT WAS ASKED FOR, AND WHAT WAS WRITTEN (#4912).
     //
@@ -4879,14 +4887,14 @@ void Hl2Backend::publishTelemetry(const Hl2Telemetry& t)
                          << "-> fwd" << directionalWatts(*t.forwardPowerRaw) << "W"
                          << "(uncalibrated reference curve)";
     }
-    // TX IQ FIFO depth — the oracle calls this the most important number in the
-    // protocol. A queue-fed transmission can starve the radio's buffer in a way
-    // a per-packet generated tone never can, so this is what distinguishes
-    // "the audio is wrong" from "the audio never arrived".
-    if (m_keyed && t.txFifoCount)
-        qCDebug(lcHl2Tx) << "HL2 fifo:" << *t.txFifoCount
-                         << "under" << t.txFifoUnderflow.value_or(false)
-                         << "over" << t.txFifoOverflow.value_or(false);
+    // TX IQ FIFO — a queue-fed transmission can starve the radio's buffer in a
+    // way a per-packet generated tone never can, so this is what distinguishes
+    // "the audio is wrong" from "the audio never arrived". `fill` is the top 7
+    // bits of the level, 0-127, not a sample count; `pacingFault` is the one
+    // flag the gateware sends for both underrun and blocked writes.
+    if (m_keyed && t.txFifoFillMsbs)
+        qCDebug(lcHl2Tx) << "HL2 fifo: fill" << *t.txFifoFillMsbs << "/127"
+                         << "pacingFault" << t.txFifoRecovery.value_or(false);
     if (t.temperatureRaw) {
         const double c = temperatureCelsius(*t.temperatureRaw);
         // The instrumentation ADC's low bits are noisy enough that the displayed

--- a/src/core/backends/hl2/MetisClient.h
+++ b/src/core/backends/hl2/MetisClient.h
@@ -272,8 +272,12 @@ signals:
     // driving it from a timer here.
     void linkCountersUpdated(const AetherSDR::hl2::MetisClient::LinkCounters& c);
     // Radio telemetry decoded from the EP6 C&C bytes: forward/reverse power,
-    // temperature, TX FIFO depth, ADC overload, PTT. Free-running, so it
+    // temperature, TX FIFO status, ADC overload, PTT. Free-running, so it
     // arrives without us issuing a request.
+    //
+    // "status", not "depth": the wire carries a recovery flag plus the top 7
+    // bits of the fill level, and no sample count at all. See
+    // Hl2Telemetry::apply().
     void telemetryUpdated(const AetherSDR::hl2::Hl2Telemetry& t);
     // No EP6 arrived within kConnectTimeoutMs of start() — the radio is off,
     // unreachable, or already streaming to a different client.

--- a/src/core/backends/hl2/MetisProtocol.cpp
+++ b/src/core/backends/hl2/MetisProtocol.cpp
@@ -221,19 +221,46 @@ void Hl2Telemetry::apply(const Ep6Response& r) noexcept
         // ACTIVE LOW on the wire: the bit is SET when transmit is permitted.
         // Decoded here so nothing above this layer has to remember the inversion.
         txInhibited     = (r.data & (1u << 25)) == 0;
-        // TX IQ FIFO depth. hpsdrsim writes a 15-bit count as C2[6:0]:C3[7:0],
-        // i.e. DATA[22:8], and that is what this decodes because it is what we
-        // can actually verify.
+        // TX IQ FIFO status. CHECKED against the gateware at 883a338, which is
+        // what the comment that stood here asked for and did not have. It said
+        // hpsdrsim writes a 15-bit count at DATA[22:8], that the oracle's §6
+        // disagreed with itself about bit 14, and that nothing should servo on
+        // this field until someone read the RTL. Read; all three of the old
+        // fields were wrong.
         //
-        // THE ORACLE DISAGREES: §6 lists [14:8] as "FIFO count MSBs" and [15:14]
-        // as an under/overflow code, which overlaps bit 14 and cannot both be
-        // right. The gateware RTL is the authority and this has NOT been checked
-        // against it. Do not build FIFO-servoed TX pacing on this field until it
-        // has been — a pacing loop driven by a misread depth is exactly the kind
-        // of unverified assumption that wedged a radio once already.
-        txFifoCount     = static_cast<int>((r.data >> 8) & 0x7FFF);
-        txFifoUnderflow = ((r.data >> 14) & 0x3) == 0x2;
-        txFifoOverflow  = ((r.data >> 14) & 0x3) == 0x3;
+        // control.v:472 builds this slot as
+        //
+        //   data = {6'b000111, ~ext_txinhibit, (&clip_cnt), 8'h00,
+        //    bits    31:26     25              24           23:16
+        //           dsiq_status, VERSION_MAJOR}
+        //           15:8         7:0
+        //
+        // The FIFO field is DATA[15:8] and nothing more. DATA[23:16] is a
+        // constant zero, which is exactly why the old expression survived:
+        // (data >> 8) & 0x7FFF returns dsiq_status itself, the right number
+        // under a name claiming fifteen bits of sample count. Nothing it ever
+        // displayed looked absurd, so nothing ever prompted the read.
+        //
+        // dsiq_fifo composes the byte at fifos.v:100-110 as
+        // {recovery_flag_d1, rd_count[6:0]}, so:
+        //
+        //   [7]   one recovery flag, set by the FIFO running empty OR by its
+        //         writes being blocked after it filled. The gateware carries no
+        //         under/overflow distinction, so the two old booleans were
+        //         decoding a difference that is not on the wire — and they
+        //         disagreed with each other on the same event depending on
+        //         fill-level bit 6, reporting "underflow" at 0x80 and
+        //         "overflow" at 0xC0.
+        //   [6:0] the TOP 7 bits of the read-side fill level: coarse occupancy,
+        //         not a count of samples.
+        //
+        // Still NOT established, and so still not safe to servo on: what one
+        // unit of [6:0] is worth. rdbits is 12 for this board's
+        // DSIQ_FIFO_DEPTH of 16384 (hermeslite_core.v:136), making the unit 32
+        // read-side words, but words-to-samples is an inference. #17 needs that
+        // number measured before a pacing loop uses this field.
+        txFifoFillMsbs  = static_cast<int>((r.data >> 8) & 0x7F);
+        txFifoRecovery  = ((r.data >> 15) & 0x1) != 0;
         break;
     case 0x01:
         temperatureRaw  = static_cast<int>((r.data >> 16) & 0xFFFF);

--- a/src/core/backends/hl2/MetisProtocol.h
+++ b/src/core/backends/hl2/MetisProtocol.h
@@ -387,9 +387,23 @@ struct Hl2Telemetry {
     std::optional<int>  firmwareVersion;
     std::optional<bool> adcOverload;
     std::optional<bool> txInhibited;      // register bit is ACTIVE LOW; decoded here
-    std::optional<int>  txFifoCount;
-    std::optional<bool> txFifoUnderflow;
-    std::optional<bool> txFifoOverflow;
+
+    // TX IQ FIFO status: DATA[15:8] of RADDR 0, the gateware's `dsiq_status`.
+    // Settled against the gateware at 883a338; see apply() for the layout and
+    // for what the old txFifoCount/txFifoUnderflow/txFifoOverflow got wrong.
+    //
+    // Coarse occupancy: the TOP 7 bits of the read-side fill level, 0..127
+    // (fifos.v:101, `rd_count <= rd_tlength[(rdbits-1):(rdbits-7)]`). NOT a
+    // sample count, and deliberately not converted to one — the words-to-
+    // samples mapping is an inference this layer has not established. #17's
+    // pacing servo needs that conversion; nothing else does.
+    std::optional<int>  txFifoFillMsbs;
+    // ONE flag for TWO faults: the FIFO ran empty (`rd_tvalidn`) OR its writes
+    // were blocked because it filled (`~allow_push`) — fifos.v:105-106. The
+    // gateware does not distinguish them, so neither do we. A consumer that
+    // wants to say which one happened cannot get it from this word, and must
+    // say "TX pacing fault" rather than pick a side.
+    std::optional<bool> txFifoRecovery;
     std::optional<int>  temperatureRaw;
     std::optional<int>  forwardPowerRaw;
     std::optional<int>  reversePowerRaw;

--- a/tests/hl2_live_band_filter_probe.cpp
+++ b/tests/hl2_live_band_filter_probe.cpp
@@ -228,12 +228,12 @@ int main(int argc, char** argv)
     {
         const Observation o = observe(client, 1000);
         const Hl2Telemetry& t = o.telemetry;
-        std::printf("\n  telemetry: fw=%s adcOvl=%s txInh=%s fifo=%s tempRaw=%s "
+        std::printf("\n  telemetry: fw=%s adcOvl=%s txInh=%s fifoFill=%s tempRaw=%s "
                     "fwd=%s rev=%s bias=%s\n",
                     t.firmwareVersion ? qPrintable(QString::number(*t.firmwareVersion)) : "-",
                     t.adcOverload ? (*t.adcOverload ? "yes" : "no") : "-",
                     t.txInhibited ? (*t.txInhibited ? "yes" : "no") : "-",
-                    t.txFifoCount ? qPrintable(QString::number(*t.txFifoCount)) : "-",
+                    t.txFifoFillMsbs ? qPrintable(QString::number(*t.txFifoFillMsbs)) : "-",
                     t.temperatureRaw ? qPrintable(QString::number(*t.temperatureRaw)) : "-",
                     t.forwardPowerRaw ? qPrintable(QString::number(*t.forwardPowerRaw)) : "-",
                     t.reversePowerRaw ? qPrintable(QString::number(*t.reversePowerRaw)) : "-",

--- a/tests/hl2_metis_protocol_test.cpp
+++ b/tests/hl2_metis_protocol_test.cpp
@@ -578,7 +578,7 @@ int main()
         // This is the check MetisProtocol.cpp's own comment above txFifoCount
         // asked someone to do ("The gateware RTL is the authority and this has
         // NOT been checked against it"). Done, against the gateware at
-        // 883a338, and the current decode is wrong on all three fields.
+        // 883a338, and the pre-fix decode was wrong on all three fields.
         //
         // control.v:472 builds slot RADDR 0 as
         //

--- a/tests/hl2_metis_protocol_test.cpp
+++ b/tests/hl2_metis_protocol_test.cpp
@@ -572,6 +572,86 @@ int main()
         t.apply(*parseEp6Response(frame(0x10, (100u << 16) | 42u).data()));
         check(t.reversePowerRaw.value_or(-1) == 100, "reverse power from DATA[31:16]");
         check(t.biasCurrentRaw.value_or(-1) == 42, "bias current from DATA[15:0]");
+
+        // ---- TX FIFO status: RADDR 0, DATA[15:8] ----
+        //
+        // This is the check MetisProtocol.cpp's own comment above txFifoCount
+        // asked someone to do ("The gateware RTL is the authority and this has
+        // NOT been checked against it"). Done, against the gateware at
+        // 883a338, and the current decode is wrong on all three fields.
+        //
+        // control.v:472 builds slot RADDR 0 as
+        //
+        //   data = {6'b000111, ~ext_txinhibit, (&clip_cnt), 8'h00,
+        //    bits    31:26     25              24           23:16
+        //           dsiq_status, VERSION_MAJOR}
+        //           15:8         7:0
+        //
+        // so the whole FIFO field is DATA[15:8] — eight bits, not fifteen. The
+        // reason the old decode was not obviously wrong is that DATA[23:16] is
+        // a constant zero, so (data >> 8) & 0x7FFF happens to come out equal to
+        // dsiq_status. It reads the right number under a name that claims it is
+        // something else, which is why no reading of it ever looked absurd.
+        //
+        // dsiq_fifo composes dsiq_status at fifos.v:100-110:
+        //
+        //   rd_count <= rd_tlength[(rdbits-1):(rdbits-7)];   // TOP 7 bits
+        //   ...
+        //   end else if (rd_tvalidn | ~allow_push) recovery_flag <= 1'b1;
+        //   assign rd_status = {recovery_flag_d1, rd_count};
+        //
+        // Two facts follow, and the old decode contradicts both:
+        //
+        //   [6:0] is the TOP 7 bits of the read-side fill level — a coarse
+        //   occupancy, not a count of samples. Nothing in this word is a
+        //   15-bit depth.
+        //
+        //   [7] is ONE flag covering BOTH "the FIFO ran empty" (rd_tvalidn)
+        //   and "writes were blocked because it filled" (~allow_push,
+        //   fifos.v:55-61). The gateware does not distinguish underflow from
+        //   overflow anywhere. Two booleans cannot be decoded from a
+        //   distinction the wire does not carry.
+        //
+        // NOT established, and deliberately not asserted here: what one unit of
+        // [6:0] is worth in samples or milliseconds. rdbits is 12 for this
+        // board's DSIQ_FIFO_DEPTH of 16384 (hermeslite_core.v:136, not
+        // overridden by variants/hl2b5up_main/hermeslite.v), which makes the
+        // unit 32 read-side words — but the words-to-samples mapping is an
+        // inference, not a read. #17's pacing servo needs that number; this
+        // decode does not, and must not pretend to it.
+        auto raddr0 = [&](std::uint8_t dsiqStatus) {
+            return frame(0x00, (1u << 25) | (std::uint32_t(dsiqStatus) << 8) | 0x15u);
+        };
+
+        // Recovery flag set, FIFO empty. The old decode reports a depth of 128
+        // for an empty FIFO, because it reads the flag as bit 7 of a count.
+        t.apply(*parseEp6Response(raddr0(0x80).data()));
+        check(t.txFifoCount.value_or(-1) == 0x00,
+              "dsiq_status 0x80: fill level is 0 — the set bit is the flag, not a count");
+        check(t.txFifoUnderflow.value_or(true) == false,
+              "dsiq_status 0x80: gateware claims no underflow — it has no such bit");
+
+        // Same flag, a fill level with bit 6 set. The old decode flips its
+        // verdict from 'underflow' to 'overflow' purely on a fill-level bit —
+        // two opposite diagnoses of one recovery event, chosen by how full the
+        // FIFO happened to be.
+        t.apply(*parseEp6Response(raddr0(0xC0).data()));
+        check(t.txFifoCount.value_or(-1) == 0x40,
+              "dsiq_status 0xC0: fill level is 0x40, not 0xC0");
+        check(t.txFifoOverflow.value_or(true) == false,
+              "dsiq_status 0xC0: gateware claims no overflow — it has no such bit");
+
+        // Flag clear across the full range of the fill field.
+        t.apply(*parseEp6Response(raddr0(0x7F).data()));
+        check(t.txFifoCount.value_or(-1) == 0x7F, "dsiq_status 0x7F: fill level saturates at 127");
+        t.apply(*parseEp6Response(raddr0(0x00).data()));
+        check(t.txFifoCount.value_or(-1) == 0x00, "dsiq_status 0x00: empty, no recovery");
+
+        // The recovery flag itself has nowhere to go today. That is the third
+        // half of this defect: the one bit the gateware DOES carry — the only
+        // honest signal that TX pacing went wrong — is the one field the
+        // decode does not expose. The fix adds it; there is nothing to assert
+        // against until it does.
     }
 
     // ---- SWR ----

--- a/tests/hl2_metis_protocol_test.cpp
+++ b/tests/hl2_metis_protocol_test.cpp
@@ -623,35 +623,45 @@ int main()
             return frame(0x00, (1u << 25) | (std::uint32_t(dsiqStatus) << 8) | 0x15u);
         };
 
-        // Recovery flag set, FIFO empty. The old decode reports a depth of 128
-        // for an empty FIFO, because it reads the flag as bit 7 of a count.
-        t.apply(*parseEp6Response(raddr0(0x80).data()));
-        check(t.txFifoCount.value_or(-1) == 0x00,
-              "dsiq_status 0x80: fill level is 0 — the set bit is the flag, not a count");
-        check(t.txFifoUnderflow.value_or(true) == false,
-              "dsiq_status 0x80: gateware claims no underflow — it has no such bit");
+        Hl2Telemetry f;
+        check(!f.txFifoFillMsbs.has_value() && !f.txFifoRecovery.has_value(),
+              "FIFO status starts unknown, not empty-and-healthy");
 
-        // Same flag, a fill level with bit 6 set. The old decode flips its
-        // verdict from 'underflow' to 'overflow' purely on a fill-level bit —
-        // two opposite diagnoses of one recovery event, chosen by how full the
-        // FIFO happened to be.
-        t.apply(*parseEp6Response(raddr0(0xC0).data()));
-        check(t.txFifoCount.value_or(-1) == 0x40,
+        // Recovery flag set, FIFO empty. The old decode reported a depth of 128
+        // for an empty FIFO, because it read the flag as bit 7 of a count.
+        f.apply(*parseEp6Response(raddr0(0x80).data()));
+        check(f.txFifoFillMsbs.value_or(-1) == 0x00,
+              "dsiq_status 0x80: fill level is 0 — the set bit is the flag, not a count");
+        check(f.txFifoRecovery.value_or(false), "dsiq_status 0x80: recovery flag from bit 7");
+
+        // Same flag, a fill level with bit 6 set. The old decode flipped its
+        // verdict from 'underflow' to 'overflow' purely on this fill-level bit
+        // — two opposite diagnoses of one recovery event, chosen by how full
+        // the FIFO happened to be. Now it is one flag either way, and the fill
+        // level is read separately from it.
+        f.apply(*parseEp6Response(raddr0(0xC0).data()));
+        check(f.txFifoFillMsbs.value_or(-1) == 0x40,
               "dsiq_status 0xC0: fill level is 0x40, not 0xC0");
-        check(t.txFifoOverflow.value_or(true) == false,
-              "dsiq_status 0xC0: gateware claims no overflow — it has no such bit");
+        check(f.txFifoRecovery.value_or(false),
+              "dsiq_status 0xC0: same recovery flag as 0x80, not a different fault");
 
         // Flag clear across the full range of the fill field.
-        t.apply(*parseEp6Response(raddr0(0x7F).data()));
-        check(t.txFifoCount.value_or(-1) == 0x7F, "dsiq_status 0x7F: fill level saturates at 127");
-        t.apply(*parseEp6Response(raddr0(0x00).data()));
-        check(t.txFifoCount.value_or(-1) == 0x00, "dsiq_status 0x00: empty, no recovery");
+        f.apply(*parseEp6Response(raddr0(0x7F).data()));
+        check(f.txFifoFillMsbs.value_or(-1) == 0x7F, "dsiq_status 0x7F: fill saturates at 127");
+        check(f.txFifoRecovery.value_or(true) == false,
+              "dsiq_status 0x7F: a full FIFO is not by itself a recovery event");
+        f.apply(*parseEp6Response(raddr0(0x00).data()));
+        check(f.txFifoFillMsbs.value_or(-1) == 0x00, "dsiq_status 0x00: empty");
+        check(f.txFifoRecovery.value_or(true) == false, "dsiq_status 0x00: no recovery");
 
-        // The recovery flag itself has nowhere to go today. That is the third
-        // half of this defect: the one bit the gateware DOES carry — the only
-        // honest signal that TX pacing went wrong — is the one field the
-        // decode does not expose. The fix adds it; there is nothing to assert
-        // against until it does.
+        // The fill level must not borrow bits from its neighbours. RADDR 0
+        // carries the ADC-overload bit at 24 and the TX-inhibit bit at 25
+        // directly above the constant zero byte; a decode that widened past
+        // DATA[15:8] again would pick them up here.
+        f.apply(*parseEp6Response(frame(0x00, 0xFFFFFFFFu).data()));
+        check(f.txFifoFillMsbs.value_or(-1) == 0x7F,
+              "all-ones DATA: fill level still 7 bits, not widened into DATA[23:16]");
+        check(f.txFifoRecovery.value_or(false), "all-ones DATA: recovery flag set");
     }
 
     // ---- SWR ----


### PR DESCRIPTION
`Hl2Telemetry::apply()` decodes RADDR 0's `DATA[22:8]` as a 15-bit TX FIFO
sample count, and `DATA[15:14]` as an under/overflow code. Neither field exists
on the wire. The comment above that code says so itself, and asks for the check
this PR carries out:

> ```
> // THE ORACLE DISAGREES: §6 lists [14:8] as "FIFO count MSBs" and [15:14]
> // as an under/overflow code, which overlaps bit 14 and cannot both be
> // right. The gateware RTL is the authority and this has NOT been checked
> // against it. Do not build FIFO-servoed TX pacing on this field until it
> // has been — a pacing loop driven by a misread depth is exactly the kind
> // of unverified assumption that wedged a radio once already.
> ```

Checked, against Hermes-Lite 2 gateware at
[`883a338`](https://github.com/softerhardware/Hermes-Lite2/tree/883a338) — the
SHA in the discovery string `20231230_74p2_883a338`, gateware 74.2, the current
stable. Board variant `hl2b5up_main`. The oracle is wrong about both fields, and
so is the code.

### What the gateware actually sends

`gateware/rtl/control.v:472` builds the RADDR 0 response:

```verilog
2'b00: iresp <= {3'b000,resp_addr, ext_cwkey, 1'b0, ptt_resp,
                 6'b000111, ~ext_txinhibit, (&clip_cnt), 8'h00,
                 dsiq_status, VERSION_MAJOR};
```

Eight bits of C0 then 32 of data, so:

| bits | field |
|---|---|
| `DATA[31:26]` | constant `6'b000111` |
| `DATA[25]` | `~ext_txinhibit` |
| `DATA[24]` | `(&clip_cnt)` — the ADC-overload bit |
| `DATA[23:16]` | **constant `8'h00`** |
| `DATA[15:8]` | `dsiq_status` — the entire FIFO field, eight bits |
| `DATA[7:0]` | `VERSION_MAJOR` |

`dsiq_status` is composed in `gateware/rtl/fifos.v:100-110`:

```verilog
always @ (posedge rd_clk) begin
  if (rd_sample) begin
    rd_count <= rd_tlength[(rdbits-1):(rdbits-7)];   // top 7 bits of the fill level
    recovery_flag <= 1'b0;
    recovery_flag_d1 <= recovery_flag;
  end else if (rd_tvalidn | ~allow_push) begin
    recovery_flag <= 1'b1;
  end
end

assign rd_status = {recovery_flag_d1,rd_count};
```

Two consequences:

1. **`[6:0]` is the top 7 bits of the read-side fill level** — a coarse
   occupancy, 0–127. There is no sample count anywhere in this word.
2. **`[7]` is one flag for two faults.** `rd_tvalidn` is the FIFO having run
   empty; `~allow_push` is writes being dropped after it filled
   (`fifos.v:55-61`). The gateware never distinguishes them, so an under/overflow
   *code* cannot be decoded from this word by anyone.

### Why the existing decode looked fine

`DATA[23:16]` is a constant zero, so `(data >> 8) & 0x7FFF` returns
`dsiq_status` itself. The displayed number was the right byte carrying a wrong
name — it never took an absurd value, so nothing ever prompted the read.

What an operator actually saw:

- A recovery event set bit 7, which the decode read as part of the count, so
  **"TX FIFO depth" jumped by 128 on an empty FIFO.**
- The same recovery flag was reported as **"underflow" when fill-level bit 6 was
  clear and "overflow" when it was set** — two opposite diagnoses of one event,
  selected by how full the buffer happened to be.

### The change

```
txFifoCount      (optional<int>)   -> txFifoFillMsbs  (optional<int>)   = DATA[14:8]
txFifoUnderflow  (optional<bool>)  -> txFifoRecovery  (optional<bool>)  = DATA[15]
txFifoOverflow   (optional<bool>)  -> removed
```

The diagnostics pane goes from three rows to two: `TX FIFO fill (0-127, coarse)`
and `TX pacing fault (under OR overrun)`. The label carries the ambiguity the
wire has, rather than resolving it in the reader's favour — a consumer that
wants to know *which* fault occurred cannot get it from this word and should not
be encouraged to guess.

### What this PR deliberately does **not** do

It does not convert the fill level into samples or milliseconds. `rdbits` is 12
for this board's `DSIQ_FIFO_DEPTH` of 16384 (`hermeslite_core.v:136`, not
overridden by `variants/hl2b5up_main/hermeslite.v`), which makes one unit 32
read-side FIFO words — but the words-to-samples mapping is an inference from the
FIFO's port widths, not something read out of the RTL. The original comment's
warning stands until that is measured: **do not servo TX pacing on this field
yet.** This PR makes the field honest; it does not make it sufficient.

### Tests

`tests/hl2_metis_protocol_test.cpp` gains ten checks over hand-built
`dsiq_status` words. Four of them fail on `main` before the fix:

```
FAIL: dsiq_status 0x80: fill level is 0 — the set bit is the flag, not a count
FAIL: dsiq_status 0x80: gateware claims no underflow — it has no such bit
FAIL: dsiq_status 0xC0: fill level is 0x40, not 0xC0
FAIL: dsiq_status 0xC0: gateware claims no overflow — it has no such bit
```

The `0x40` and `0x7F` cases pass both before and after — kept deliberately,
because they are the reason this survived: they are exactly the values where the
old expression's accident holds. An all-ones `DATA` case pins the field width so
a future widening cannot silently pick up the ADC-overload and TX-inhibit bits
sitting just above the constant zero byte.

### Scope

Gateware read at `883a338` and the AetherSDR source. **Nothing here is
measured** — no radio was keyed to produce a recovery event, and this PR makes
no claim about how often one occurs or what causes it. It is a decode
correction, and the test is a decode test.

---

## Notes for the orchestrator, not for the PR body

- Sizes as XS. Touches `MetisProtocol.h`, `MetisProtocol.cpp`, four lines of
  `Hl2Backend.cpp` (a diagnostics `put()` block and one `qCDebug`), one line of
  `hl2_live_band_filter_probe.cpp`, and the test.
- **`Hl2Backend.cpp` overlap check:** both edits are in `publishTelemetry` and
  the diagnostics table, not in the drive path `tx-dynamics` holds on
  `fix/hl2-initial-drive`. Worth a rebase check before either goes up.
- **Verified on the PR branch itself**, not only on the feature branch it came
  from — red at `ebf6c66`, green at `505f575`, same four failures:

  ```
  $ clang++ -std=c++20 -Isrc -o t tests/hl2_metis_protocol_test.cpp \
        src/core/backends/hl2/MetisProtocol.cpp && ./t
  # at ebf6c66 (test only, fix not applied):
  FAIL: dsiq_status 0x80: fill level is 0 — the set bit is the flag, not a count
  FAIL: dsiq_status 0x80: gateware claims no underflow — it has no such bit
  FAIL: dsiq_status 0xC0: fill level is 0x40, not 0xC0
  FAIL: dsiq_status 0xC0: gateware claims no overflow — it has no such bit
  # at 505f575 (fix applied):
  hl2_metis_protocol_test: all checks passed
  ```

  The standalone build is the right citation here: the target is two
  translation units with no Qt and no `aethercore`, which is why it is fast
  enough to run at both commits.
- **Also verified in a full build**, on `feat/hl2-telemetry` where these two
  commits are the base: `cmake --build` exit 0 over 2952 objects, and
  `ctest -R hl2` 22/23 with `hl2_metis_protocol_test` **passing in the real
  tree**. The single failure is `hl2_state_restore_test`'s three pre-existing
  CW-passband-guard assertions (#5394), which fail identically on unmodified
  upstream `main`. That build used `ENABLE_ASR=OFF`, the standard on this
  machine, and `CMAKE_IGNORE_PREFIX_PATH=/opt/homebrew;/opt/local`.
- The full build has **not** been re-run on `fix/tx-fifo-status-decode` itself;
  it carries the same two commits against the same base, and the standalone
  test was run there directly. Say so rather than implying otherwise if asked.
- `gh api user --jq .login` must read `on8st` before any push, ever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtHEsQsghFwhUQEZdwVKUz
