### PR TITLE
cmake: mark the Homebrew include path SYSTEM so it cannot shadow vendored headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,17 @@ if(APPLE)
     execute_process(COMMAND brew --prefix OUTPUT_VARIABLE HOMEBREW_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(HOMEBREW_PREFIX)
         link_directories("${HOMEBREW_PREFIX}/lib")
-        include_directories("${HOMEBREW_PREFIX}/include")
+        # SYSTEM is load-bearing, not cosmetic. A plain include_directories()
+        # here is directory-scoped at the TOP level, so it is inherited by every
+        # add_subdirectory() and initialises every target's INCLUDE_DIRECTORIES
+        # ahead of whatever that target adds for itself -- which means
+        # /opt/homebrew/include outranks every vendored include dir in the tree.
+        # Any Homebrew formula whose headers share a basename with a vendored one
+        # then silently wins, reversing the choice USE_SYSTEM_* made in CMake:
+        # ggml.h, whisper.h and fftw3.h are all shadowed on a stock dev machine.
+        # SYSTEM emits -isystem, which the compiler searches AFTER all -I paths,
+        # so Homebrew stays findable and stops taking precedence.
+        include_directories(SYSTEM "${HOMEBREW_PREFIX}/include")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ if(APPLE)
         # /opt/homebrew/include outranks every vendored include dir in the tree.
         # Any Homebrew formula whose headers share a basename with a vendored one
         # then silently wins, reversing the choice USE_SYSTEM_* made in CMake:
-        # ggml.h, whisper.h and fftw3.h are all shadowed on a stock dev machine.
+        # ggml.h and whisper.h are both shadowed on the affected setup.
         # SYSTEM emits -isystem, which the compiler searches AFTER all -I paths,
         # so Homebrew stays findable and stops taking precedence.
         include_directories(SYSTEM "${HOMEBREW_PREFIX}/include")


### PR DESCRIPTION
On macOS with Homebrew's `ggml` installed, a default build fails:

```
third_party/whisper.cpp/ggml/src/ggml.c:684:6:
  error: use of undeclared identifier 'GGML_TYPE_Q2_0'
third_party/whisper.cpp/ggml/src/ggml.c:1428:14:
  error: use of undeclared identifier 'GGML_FTYPE_MOSTLY_Q2_0'
third_party/whisper.cpp/ggml/src/ggml-quants.c:2116:37:
  error: use of undeclared identifier 'GGML_TYPE_Q2_0'
... 7 errors across the two files.
```

`ggml.c` includes `"ggml.h"` with quotes. That searches the including file's own
directory first — `ggml/src/`, which does not contain it — and then the `-I`
list in order. `CMakeLists.txt:84` puts `/opt/homebrew/include` at the head of
that list for every target in the project, so the compiler picks up Homebrew's
**ggml 0.15.2** header instead of the vendored one that the rest of the vendored
sources were written against. `GGML_TYPE_Q2_0` is declared in the vendored
header (`ggml/include/ggml.h:432`, `= 42`) and does not exist in 0.15.2.

The build has deliberately chosen the vendored copy — `USE_SYSTEM_LIBWHISPER`
defaults `OFF` — and is then compiling it against the system's headers. That is
the actual defect: **the choice is made in CMake and silently reversed by the
include path.**

### Confirmed by the compiler, not by reading

`-H` prints the resolved include tree. Same source, same target, one flag
changed:

```
$ cc -fsyntax-only -H -I/opt/homebrew/include -I$SRC -I$SRC/../include ggml.c
.. /opt/homebrew/include/ggml.h                                    <-- wrong

$ cc -fsyntax-only -H -isystem /opt/homebrew/include -I$SRC -I$SRC/../include ggml.c
.. .../third_party/whisper.cpp/ggml/src/../include/ggml.h          <-- vendored
```

and the error count goes from 7 to 0 across the two files.

### The fix

```diff
-        include_directories("${HOMEBREW_PREFIX}/include")
+        # SYSTEM is load-bearing, not cosmetic. A plain include_directories()
+        # here is directory-scoped at the top level, so it is inherited by every
+        # add_subdirectory() and initialises every target's INCLUDE_DIRECTORIES
+        # ahead of whatever that target adds for itself — which means
+        # /opt/homebrew/include outranks every vendored include dir in the tree.
+        # Any Homebrew formula whose headers share a name with a vendored one
+        # then silently wins, reversing the choice USE_SYSTEM_* made in CMake.
+        # SYSTEM emits -isystem, which the compiler searches AFTER all -I paths,
+        # so Homebrew stays findable and stops taking precedence.
+        include_directories(SYSTEM "${HOMEBREW_PREFIX}/include")
```

One keyword. `-isystem` directories are searched after every `-I` directory, so
Homebrew remains available for everything that genuinely needs it (portaudio,
fftw3, hidapi, and the `USE_SYSTEM_*=ON` paths) while no longer outranking the
tree's own headers. Suppressing warnings from third-party headers is a
side-benefit, not the reason.

### This is a class, not an instance — with the count stated honestly

`ggml.h` is the one that fails loudly. It is not the only header this affects,
but the numbers need separating, because "21 headers fixed" would be a claim
this evidence does not support.

**21** vendored public headers share a basename with one in
`/opt/homebrew/include` on this machine. That is a *basename collision count*,
obtained by intersecting two directory listings — it is the size of the hazard,
not the size of the demonstrated fix.

**7 are demonstrated shadowed and fixed**, from `-H` traces on the real compile
lines of `ggml.c`, `ggml-quants.c`, `ggml.cpp` and `whisper.cpp`:

| header | before | after |
|---|---|---|
| `ggml.h` | `/opt/homebrew/include` | vendored |
| `ggml-alloc.h` | `/opt/homebrew/include` | vendored |
| `ggml-backend.h` | `/opt/homebrew/include` | vendored |
| `ggml-cpp.h` | `/opt/homebrew/include` | vendored |
| `ggml-cpu.h` | `/opt/homebrew/include` | vendored |
| `gguf.h` | `/opt/homebrew/include` | vendored |
| **`whisper.h`** | `/opt/homebrew/include` | vendored |

`whisper.h` is the one worth pausing on: whisper.cpp compiled *cleanly* against
Homebrew's header, so nothing announced it. It is the silent case, and it is the
reason this is worth fixing rather than working around.

**The remaining 14 are not claimed.** `ggml-cuda.h`, `-metal.h`, `-vulkan.h`,
`-blas.h`, `-cann.h`, `-sycl.h`, `-rpc.h`, `-openvino.h`, `-webgpu.h`,
`-zendnn.h`, `-virtgpu.h`, `-opt.h` and `parakeet.h` belong to backends this
configuration does not build, so they never entered an include tree here and
their shadowing is **latent, not demonstrated**.

**`fftw3.h` is a different case entirely and is NOT a bug.** On macOS FFTW comes
from pkg-config (`CMakeLists.txt:239-243`); the vendored
`third_party/fftw3/include/fftw3.h` is inside `if(WIN32)` and is never added to
the include path on this platform. So it resolving to Homebrew is *by design*,
and it was never shadowed here. It appeared in the basename intersection and
does not belong in the fixed list.

That distinction matters more than the count: a table with one wrong row invites
a reader to distrust the others, and this one had a row that looked like a bug
and was not.

### Testing

Run on macOS 26.5, Apple clang, Qt 6.8.3, Homebrew `ggml 0.15.2` installed and
left installed — nothing unlinked, nothing removed — with `ENABLE_ASR` at its
default. Before and after in the **same tree**, so the comparison has no second
variable.

- **Before:** building `ggml-base` fails with **7 errors** — 4 in `ggml.c`
  (`GGML_TYPE_Q2_0`, `GGML_FTYPE_MOSTLY_Q2_0`) and 3 in `ggml-quants.c`.
- **After:** full build **exit 0**, 3102 objects, zero errors.
  `[16/3102] Building C object …/ggml.c.o` and `[35/3102] …/ggml-quants.c.o` —
  the two files that previously read `FAILED`.
- **Per-header `-H` evidence** above, taken from the build's own
  `compile_commands.json` rather than reconstructed flags, so the claim is not
  "it builds now" but "it builds now because *this* header is being chosen".

### Scope

macOS only — the block is inside `if(APPLE)`. No behaviour change on Linux or
Windows, and none on macOS beyond include precedence and third-party warning
suppression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtHEsQsghFwhUQEZdwVKUz

