### PR TITLE
fix(tci): bound TX_CHRONO catch-up so FT8 stalls don't dump or starve

### DIFF
--- a/docs/TCI-CHRONO.md
+++ b/docs/TCI-CHRONO.md
@@ -1,0 +1,523 @@
+# TCI TX_CHRONO pacing — investigation notes (#5133)
+
+Date: 2026-09-03
+Branch: `fix/5133-tci-ft8-tx-spikes`
+Base: `origin/main` @ `52a0f3dc`
+Issue: [aethersdr/AetherSDR#5133](https://github.com/aethersdr/AetherSDR/issues/5133)
+Status: read-only findings. No code change yet.
+
+Related: [`docs/architecture/tx-audio-signal-path.md`](architecture/tx-audio-signal-path.md),
+[`docs/architecture/audio-pipeline.md`](architecture/audio-pipeline.md),
+Thetis TCI oracle (`/Users/patj/oracles/thetis-tci-oracle.md`, TX audio / chrono section).
+
+---
+
+## Symptom
+
+FT8 over TCI (WSJT-X or JTDX) produces a short wideband spur on the panadapter
+and waterfall, typically **one to two seconds into the over**. The rest of the
+transmission is a clean constant-envelope tone and usually **decodes**.
+
+This is a **shared TX-audio clocking** problem, not an Icom-only path. The
+GitHub reports are Flex:
+
+| Reporter | Radio | Client | OS | Notes |
+|---|---|---|---|---|
+| KN7K | FLEX-8600 fw 4.1.5 | JTDX | Win11 | Random bars; predates 26.8.3 |
+| g0cgl / EI4KF | FLEX-8400M fw 4.2.20 | JTDX | Win11 | Same op, two sessions 2026-09-01: CAT bundle (17:35) + Desktop perf log (15:19). PGXL+TGXL. |
+| skerker | FLEX-8400 | WSJT-X | — | No PGXL, no APD, **no** burst events |
+| local (Pat) | IC-7300MK2 | WSJT-X | macOS | Same 1–2 s spur, consistent. Gold chrono log: `aethersdr-20260901-204049.log`. |
+| local (Pat) | FLEX-8400M KI6BCJ | TCI | macOS | `aethersdr-20260830-174437.log` — only 2 chronos, confirms Mac Flex path. |
+
+FT8 is a continuous tone. Any dropped, doubled, or zero-padded block is a
+timebase discontinuity and shows as a short splatter tick. Average rate can
+still be 48 kHz, which is why the decoder survives.
+
+---
+
+## The path
+
+WSJT-X / JTDX do **not** push TX audio. AetherSDR pulls it.
+
+1. Client: `trx:0,true,tci;`
+2. `TciServer` keys via `setTransmit(..., PttSource::Dax)` (audio source) and
+   waits for radio-confirmed TX.
+3. On confirm, `startTxChrono()` sends type-3 **TX_CHRONO** frames to that
+   WebSocket.
+4. Client answers each chrono with one type-2 **TX_AUDIO** block.
+5. `onBinaryMessage()` classifies layout, resamples 48 kHz → 24 kHz, applies
+   TCI gain, and `QMetaObject::invokeMethod`s `AudioEngine::feedDaxTxAudio`.
+6. `feedDaxTxAudioInternal()` packetizes **immediately, unpaced**:
+   - Flex (not host-modulating): VITA-49 `dax_tx` (PCC 0x0123 int16 mono).
+   - Icom / HL2 (`takesTxAudioOverSeam`): `txFinalMonitorPcmReady` →
+     `RadioModel::submitTxAudio`. Icom `TxPacketizer` then clocks RS-BA1 at
+     10 ms, cap 250 ms, drop-oldest.
+
+`TciServer` has **no thread of its own**. The chrono timer runs on the GUI
+event loop. `AudioEngine` is on the audio thread.
+
+---
+
+## Chrono as implemented
+
+```cpp
+// src/core/TciServer.cpp
+constexpr int kTxChronoSamples = 2048;       // float payload length to the client
+constexpr int kTxChronoStereoFrames = 1024;  // 2048 floats = 1024 L/R pairs
+constexpr qint64 kTxChronoPeriodNs =
+    (kTxChronoStereoFrames * 1'000'000'000LL) / 48000LL;  // 21.333… ms
+constexpr int kTxChronoPollMs = 5;
+```
+
+A fixed 21 ms `QTimer` would run ~1.6 % fast and warp digital tones, so the
+pacer polls at 5 ms (`Qt::PreciseTimer`) and emits from a monotonic
+accumulator:
+
+```cpp
+m_txChronoAccumNs += m_txChronoClock.nsecsElapsed();
+m_txChronoClock.restart();
+while (m_txChronoAccumNs >= kTxChronoPeriodNs) {
+    sendTxChronoFrame(client);
+    m_txChronoAccumNs -= kTxChronoPeriodNs;
+}
+```
+
+That `while` is **unbounded**. After a GUI stall of N ms it fires
+`floor(N / 21.333)` chrono frames back-to-back. There is no outstanding-request
+cap and no forget/reset of backlog.
+
+`startTxChrono()` also sends one chrono immediately, then starts the timer.
+
+### What Thetis does (authority we follow)
+
+From the Thetis TCI oracle, TX chrono:
+
+- targets the negotiated buffering interval **plus 50 ms**;
+- permits **at most 64 outstanding** requests;
+- forgets stuck outstanding counts after `max(250 ms, 4 × buffering)`.
+
+Conformance line in the same oracle: *“TX chrono pacing recovers from missing
+responses without unbounded growth.”* We fail that today.
+
+The Opus TX path already solved the sibling problem for itself:
+`OpusTxPacer` with `kMaxPacketsPerDrain = 3` and a ~200 ms queue cap. DAX/TCI
+has no equivalent.
+
+---
+
+## Evidence corpus
+
+Win+Mac × Flex+Icom. GitHub zips unpacked under `/tmp/issue-5133-logs/`.
+Desktop log stays on `~/Desktop/`. Mac pulls live under
+`/private/tmp/aethersdr-logpull/20260903-165337/` (not in git).
+
+| Source | Who | Radio / OS | `aether.cat` | `aether.perf` | What it is good for |
+|---|---|---|---|---|---|
+| `support-bundle-20260821-094759.zip` | KN7K | FLEX-8600 / Win11 | off | **on** | GUI stall rates (~every 2.2 s) |
+| `support-bundle-20260821-112251.zip` | KN7K | FLEX-8600 / Win11 | **on** | **on** | Six FT8 overs + APD insanity overlay |
+| `support-bundle-20260901-181521.zip` | g0cgl / EI4KF | FLEX-8400M / Win11 | **on** (CAT-only) | off | 14 TCI overs; extra chrono in second second |
+| `~/Desktop/aethersdr-20260901-151922.log` | g0cgl / EI4KF | FLEX-8400M / Win11 | off | **on** | Same day, earlier session. Stalls *during* live overs; PTT bounce |
+| `aethersdr-20260901-204049.log` | Pat | IC-7300MK2 / macOS | **on** | — | **Gold:** 56 chrono / 53 full FT8; first extra at +2–3 s in 67 % |
+| `aethersdr-20260830-174437.log` | Pat | FLEX-8400M / macOS | **on** | — | Mac Flex path exists; only 2 chronos |
+| newest 5 Mac logs (2026-09-02/03) | Pat | IC-7300MK2 / macOS | on, no client | — | Not FT8. Icom `dropping xmit` / CI-V backlog only |
+| `support-bundle-20260830-152309.zip` (#5340) | WA8PAM | FLEX-6400 / Win11, **2 pans + 2 TCI clients** | **on** | off | Slice B `trx=1`. Same +2–3 s extra chrono as #5133 |
+| `support-bundle-20260830-153508.zip` (#5340) | WA8PAM | same | **on** | off | Slice A `trx=0`. Same extras, same audio level as B |
+
+`logTxAudioSummary()` is `aether.cat` info. Without that category the TCI
+numbers are invisible. Enable **TCI/CAT/rigctld** in Settings → Logging for
+any follow-up bundle.
+
+`logTxAudioSummary()` is `aether.cat` info. Without that category the TCI
+numbers are invisible. Enable **TCI/CAT/rigctld** in Settings → Logging for
+any follow-up bundle.
+
+### KN7K perf (first bundle, ~36 h)
+
+GUI event-loop overruns (`uiLagMaxMs`), 1-second windows:
+
+| Stall | Count | Meaning for chrono |
+|---|---|---|
+| > 25 ms | 90,541 / 129,838 (70 %) | ≥ 1 missed 21.3 ms tick |
+| > 50 ms | 16,893 (13 %) | ≥ 2 missed ticks |
+| > 100 ms | 36 | |
+| max | 1,675 ms | 78 frames if replayed unbounded |
+
+`PerfStall kind=uiHeartbeat` ~1,600/hour during operating hours, median 53 ms,
+p99 80 ms — **one stall every ~2.2 s**. A 12.64 s FT8 over statistically
+contains several. The first one after key-up is the 1–2 s spur.
+
+### TCI TX summaries (g0cgl + KN7K second bundle)
+
+Per-second bins look healthy:
+
+- ~48 audio blocks/s (`kTxSummaryEveryBlocks = 48`)
+- `inputFramesSrc = blocks × 1024` on every over
+- `layout=duplicated-stereo`, `clips=0`
+- end-of-over `effective48k` ≈ 48.00–48.07 kHz
+- PTT → chrono start on Flex: **70–100 ms** (not the 1–2 s delay)
+
+That **clears**:
+
+1. **Block-size mismatch.** We ack `audio_stream_samples:` verbatim but keep
+   hardcoded 2048. WSJT-X/JTDX in these bundles used 1024 stereo frames. A 2:1
+   mismatch would show `inputFramesSrc` vs `requested48k` diverging for the
+   whole over. It does not.
+2. **Per-block mono/stereo flip.** A mono classification adds +1024 to
+   `inputFramesSrc` over `requested48k`. The delta is never positive across
+   thousands of blocks.
+
+That does **not** clear catch-up. The summaries are **1-second bins**. A 50 ms
+stall that emits 3 chronos at once, then three TX_AUDIO blocks in one shot,
+still averages to 48 blocks/s.
+
+What the bins *do* show is extra **requests**, not extra **audio**:
+
+- g0cgl: most overs have seconds with `dreq=50176` (49 chronos) vs
+  `dinf=49152` (48 audio blocks), often in the **second second** of TX.
+  Occasional `dreq=51200` (two extra chronos in one second).
+- KN7K first-second `effective48k` (this field is **chrono request rate**,
+  `requested48k / elapsed`, not audio delivery rate): n=6, mean **46623**,
+  worst **45302**. Chrono running ahead of the client at the start of the over.
+
+`effective48k` in `logTxAudioSummary()`:
+
+```text
+effectiveRate48k = m_txChronoRequestedFrames / elapsedSec
+```
+
+So a low first-second number is “we asked slower than 48 kHz for this window
+because start-up / stall stretched elapsed,” or, when `requested48k` is
+*ahead* of `inputFramesSrc`, “we asked for more blocks than the client
+answered.” Either shape is a discontinuity waiting to happen; the 1 s bin
+cannot say whether the answers later arrived as a clump.
+
+### g0cgl session faults (CAT-only, 14 overs)
+
+1. **17:41:30** `trx:true` then `trx:false` 47 ms later. One silent block
+   (`peak=0`, `blocks=1`). PTT bounce, not a mid-tone spur.
+2. Several overs with two extra chronos in one second.
+3. TX 13 started at `:30.615` (late into the slot).
+
+One GUI watchdog line in that bundle, at process start (`~1234 ms`), not
+during an over. `aether.perf` was off, so intra-over stalls are not recorded.
+
+---
+
+## Follow-up logs (2026-09-03)
+
+Same-day Windows Flex log from EI4KF on the Desktop, plus the Mac/Icom
+sessions pulled from `patj@mac.jensencloud.net`. Together with the GitHub
+bundles this is Win+Mac × Flex+Icom.
+
+### EI4KF Desktop — `~/Desktop/aethersdr-20260901-151922.log`
+
+Same operator as the 17:35 CAT bundle (Erik EI4KF, FLEX-8400M, 26.9.1,
+Win11, Ryzen 9 7950X, PGXL 3.9.1 + TGXL). **Different session** (15:19–15:24).
+`aether.cat` is off, so no chrono summaries. `aether.perf` is on.
+
+Three `xmit` cycles:
+
+| TX | Window | Duration | uiHeartbeat stalls in window |
+|---|---|---|---|
+| 1 | 15:22:01.619 → 15:22:02.486 | **0.867 s** | none (uiLagMax 22.7 ms) |
+| 2 | 15:22:30.709 → 15:22:43.721 | 13.012 s (full FT8) | four: **+7.90 / +8.81 / +9.40 / +9.50 s**, 59–84 ms |
+| 3 | 15:23:00.023 → 15:23:13.690 | 13.667 s (full FT8) | none in-window; first 2.5 s uiLagMax 27–30 ms |
+
+TX 1 is the same PTT-bounce class as 17:41:30 in the CAT bundle. TX 2 proves
+the GUI thread still hiccups **during** a live over on this machine (enough
+to emit 3–4 extra chronos if the pacer had been running). TX 3’s first-two-second
+uiLag (~30 ms) is only one missed tick — the 1–2 s spur does not require a
+heroic stall, just the unbounded `while`.
+
+No `apd insanity` in this file (`aether.connection` status decode is not
+verbose enough here). PGXL came ready at 15:21:55, immediately before the
+bounces.
+
+### Mac logpull — `/private/tmp/aethersdr-logpull/20260903-165337/`
+
+Newest five files on the test Mac were **not** FT8/TCI sessions (connect,
+volume, short local PTT). `TciServer` was listening but there was no
+`client connected` and no `TX_CHRONO started`. Remote grep found the real
+overs; those two files were pulled as well.
+
+Audio-summary presence (skill check, newest five):
+
+| log | startup | rx | tx | cw | aux | failure | category |
+|---|---|---|---|---|---|---|---|
+| 20260902-203157 | yes | yes | yes | yes | yes | no | yes |
+| 20260902-203328 | yes | yes | yes | yes | yes | no | yes |
+| 20260902-212828 | yes | yes | yes | yes | yes | no | yes |
+| 20260903-072440 | yes | yes | yes | yes | yes | no | yes |
+| 20260903-152458 | yes | no | no | no | no | no | yes |
+
+20260903-152458 never connected a radio (shutdown-only). TX/CW/aux present
+on the others is event-dependent and expected.
+
+Icom-specific noise in the newest files, **not** the FT8 spur:
+
+- `RadioModel: no command plane for this backend, dropping xmit 1/0` and
+  `dropping transmit set dax=1` — Flex text still emitted at Icom, then
+  dropped. TCI still broadcasts `trx:0,true` from model state.
+- `civ-timeout-backlog` incidents (queueDepth 14–24, `lastResponseMs` 427–1025).
+  20260903-072440 has five short keys (1.3–3.3 s), no chrono, no TCI client.
+
+### Mac Icom FT8 — `aethersdr-20260901-204049.log` (the money log)
+
+| | |
+|---|---|
+| Build | 26.9.1 |
+| OS | macOS 26.6, Apple M5 |
+| Radio | IC-7300MK2 (`family=icom`) |
+| Client | TCI from `::ffff:*.*.*.1` at 20:48:39 |
+| Overs | **56 chrono sessions, 53 full ~13.6 s FT8** |
+
+Same 1-second-bin health as Flex: `layout=duplicated-stereo`, `clips=0`,
+stop `effective48k` 47.9–48.05 k, `inputFramesSrc = blocks × 1024`.
+`trx:true` → chrono start is **0–2 ms** (Icom `setKeying` is optimistic).
+
+Catch-up is **not** rare. 210 extra-chrono seconds across 53 full overs
+(`dreq=50176` or `51200` vs `dinf=49152` — one or two unanswered chronos
+in that second). Extra events run the whole over (GUI keeps hitching);
+the **first** one is what matches the waterfall tick:
+
+| First extra at | Count (of 55) |
+|---|---|
+| **+2.0 s** | 13 |
+| **+3.0 s** | 24 |
+| +4.0 s | 6 |
+| +5.0 s | 7 |
+| later | 5 |
+
+All extra-chrono events (not just first), 0.5 s bins: +2.0 (13), +3.0 (27),
++4.0 (11), +5.0 (24), then 12–26 per second through +13.0. The pacer
+replays a stall whenever one happens; the spur people notice is the
+**first** replay.
+
+**37 / 55 = 67 % of overs put the first extra chrono at +2–3 s.** That is
+the local Mac + IC-7300MK2 + WSJT-X symptom (“usually a second or two in”)
+in the same numbers we already had from g0cgl’s Flex CAT log. Family does
+not matter; the pacer does.
+
+First-second `effective48k` (chrono *request* rate): n=56, min **46802**,
+p50 48003, max 48959. Worst first seconds are ~2.5 % slow, then the extra
+chrono at +2–3 s is the catch-up.
+
+`trx:0,true` count is 113 vs 56 chrono starts — extra true/false pairs are
+short keys or bounces, same class as EI4KF’s 0.87 s `xmit` and g0cgl’s
+47 ms abort, not the mid-tone spur.
+
+### Mac Flex — `aethersdr-20260830-174437.log`
+
+Same Mac, `family=flex`, FLEX-8400M KI6BCJ. TCI client connected; only
+**two** chrono sessions. Too small to histogram; confirms the Mac also
+runs the Flex path.
+
+---
+
+## Issue #5340 — two slices, two WSJT-X, same chrono (2026-08-30)
+
+[#5340](https://github.com/aethersdr/AetherSDR/issues/5340) is a *different
+user-facing claim* (Slice B gets ~20 PSK Reporter spots vs Slice A ~200;
+ALC gauge floors at −20 dBFS on B) on a **two-slice / two-pan** station.
+Pulled both attached bundles:
+
+| Zip | Reporter label | Radio |
+|---|---|---|
+| `support-bundle-20260830-152309.zip` | Slice B TX | FLEX-6400 fw 4.2.18, WA8PAM, 26.9.1, Win11, **GTX 1050 Ti**, `PanadapterLayout2v` |
+| `support-bundle-20260830-153508.zip` | Slice A TX | same station, same settings |
+
+`aether.cat` on, `aether.perf` **off**. Unpacked under `/tmp/issue-5340-logs/`.
+
+### Load that #5133 single-slice logs did not have
+
+- **Two SpectrumWidgets** (`slice added 0` and `slice added 1`, two waterfall
+  pipelines 1262×64 / 1383×64).
+- **Two TCI clients** from `::1` in every session: `audio_start:0` then
+  `audio_start:1`. Two WSJT-X instances, `trx_count:2`,
+  `trx0=slice0/dax1 trx1=slice1/dax2`.
+- Chrono still runs on the **GUI thread**. Two pans + two RX-audio TCI
+  pumps is exactly the event-loop backlog the unbounded `while` is
+  sensitive to. GPU is a 1050 Ti.
+
+PTT routing is clean — not a wrong-slice key:
+
+```
+trx=1 rxSlice=1(trx1) -> txSlice=1(trx1) (the requested slice)
+trx=0 rxSlice=0(trx0) -> txSlice=0(trx0) (the requested slice)
+```
+
+### Chrono extras — same signature as #5133, on **both** slices
+
+| | Slice B (trx=1) | Slice A (trx=0) |
+|---|---|---|
+| Full-ish overs | 4 (one 7.6 s abort) | 4 (one 4.3 s abort) |
+| Extra-chrono seconds (`dreq−dinf ≥ 1024`, ~1 s bin) | **14** | **12** |
+| Typical first extra | **+2.07 / +3.08–3.10 s** | **+2.07 / +3.09–3.10 s** |
+| Stop `effective48k` | 48.00–48.04 k | 48.01–48.07 k |
+| peak / rms / gain | 0.976–0.983 / ~0.66 / 0.99 | 0.976–1.000 / ~0.66 / 0.99 |
+| clips | 0 | 2 samples on one over |
+
+First extra at +2–3 s is the same bin as the Mac IC-7300MK2 gold log
+(67 %) and g0cgl’s Flex CAT log. Catch-up is **not** unique to slice B.
+If anything the two-pan + two-client load makes extras *routine on every
+over of both slices* — which is what the graphics-backlog hypothesis
+predicts, and what a single-slice quieter station (skerker) did not see.
+
+`aether.perf` is off, so we cannot count `uiHeartbeat` inside the overs.
+The only stalls in these files are startup `MainThreadWatchdog` ~1.8–2.0 s
+(connect / first paint), not the mid-over hitch. The 1 s `dreq=50176`
+lines are still the catch-up proxy.
+
+### What #5340 is *not*
+
+Audio leaving AetherSDR is the same on A and B (Pat’s in-thread reading
+holds). The ALC −20 on B is the **last-definition-wins ALC meter index**
+(`MeterModel` stores `ALC` as a scalar; `COMPPEAK` is already per-slice).
+That is #3830, not chrono.
+
+The 20-vs-200 spot split is **not** explained by chrono: the discontinuity
+hits both slices equally. Reporter later reproduced the spot split on
+SmartSDR 4.2.2 as well, with a local friend seeing equal on-air level —
+so that half is not AetherSDR TX audio. Chrono can still put a short
+spur on *every* over of a two-pan station; it just is not the A-vs-B
+discriminator.
+
+### Implication for the #5133 fix
+
+Two pans + two TCI clients is a **forced** GUI-load case for the pacer.
+A clamp that is clean on a single-pan Mac Icom session still has to be
+clean here: extras per over should drop on *both* trx=0 and trx=1. This
+is the busy-window regression test we already wanted, with a real
+two-slice operator log instead of a synthetic “make the waterfall fast.”
+
+---
+
+## Root cause (current best)
+
+**Primary, family-independent:** TX_CHRONO is a wall-clock accumulator on the
+GUI event loop with **unbounded catch-up**, and DAX/TCI emission is **unpaced**.
+
+After a 50–80 ms stall (panadapter / waterfall / any GUI hitch):
+
+1. The `while` loop emits several chrono frames in one timer tick.
+2. The client answers with a burst of TX_AUDIO (or a short / zero-padded
+   block if it has nothing ready).
+3. Those blocks are queued to the audio thread and packetized immediately.
+4. Flex: a clump of `dax_tx` VITA packets hits the radio in one shot.
+   Icom: the same clump hits `TxPacketizer` (250 ms, drop-oldest; underflow
+   is silence, which the radio jitter buffer treats as a discontinuity).
+5. The radio sees a phase/timebase step → short wideband spur.
+6. Average rate stays ~48 kHz, so the rest of the over decodes.
+
+**Why ~1–2 s in:** first GUI stall *after* the over is already keyed, not the
+PTT handshake. Flex PTT→chrono is ~80 ms; Icom is 0–2 ms (optimistic key).
+The Mac IC-7300MK2 session puts the **first extra chrono at +2–3 s in 67 %
+of overs**. KN7K’s heartbeat stalls were every ~2.2 s. Same clock, both
+families.
+
+This is the same clocking defect on Flex, Icom, and HL2. Downstream packetizers
+differ; the burst is produced above them.
+
+---
+
+## Ruled out (for this spur)
+
+| Hypothesis | Why not |
+|---|---|
+| Icom-only PTT / unkey settle / 1250 ms confirmation timeout | Would abort or bounce the over, not tick a live tone. Flex reports have the same spur. |
+| `audio_stream_samples` false ack (2× rate) | Bundles show 1024-frame blocks matching chrono. Still a real defect — see below. |
+| Per-block L/R layout flip | Frame counts never show a 2× jump. `layout=` is a sticky OR, but `inputFramesSrc` would move. |
+| APD failing to converge | KN7K-only overlay (bars every ~3.3 s, 119 `apd insanity` pairs, `equalizer_active=0`). Does not explain g0cgl, skerker, or Icom. |
+| Mic bleed before `tciAudioFresh()` | Plausible on Icom/macOS for the first ~20–50 ms after key, not a 1–2 s mid-tone tick. Do not start there. |
+| Icom `dropping xmit 1` / `dropping transmit set dax=1` | Flex command-plane text at an Icom. Separate seam leak. TCI still keys via `setKeying`; 53 full overs on the money log prove audio flowed. |
+
+### APD is a separate Flex defect
+
+KN7K had APD enabled with no usable sampler. The radio sampled at +3.3, +6.5,
++9.7, +13.0 s into each over and rejected the model every time (`PA gain
+characteristic is nonmonotonic`, `Excessive uncorrected frequency error`, …).
+
+`apd insanity "reason", "reason"` contains no `=`, so the status splitter puts
+the whole body in `object`. `RadioModel` folds tokens into junk bare-flag keys;
+`FlexBackend::decodeApdStatus()` ignores them. **No log line, no UI.** Fix
+visibility separately from chrono. Do not treat APD as the TCI spur.
+
+---
+
+## Code defects to fix (chrono first)
+
+1. **Clamp chrono catch-up.** 1 frame per poll tick; cap `m_txChronoAccumNs`
+   to a bounded backlog (Thetis-shaped outstanding window, not unbounded
+   replay). Forget stuck outstanding counts after a few hundred ms.
+2. **Pace DAX/TCI emission** in `feedDaxTxAudioInternal()` the way
+   `OpusTxPacer` paces Opus (`kMaxPacketsPerDrain`, queue cap).
+3. **Stop lying about `audio_stream_samples:` / `tx_stream_audio_buffering:`.**
+   Echoing the request while the pacer stays on hardcoded 2048 is a false ack.
+   Reply with the value in force, or honor the client per session.
+4. **Latch mono/stereo for the TX session** from the first non-silent blocks;
+   skip silence in the vote. Not implicated in these logs, still a landmine.
+5. **Intra-second telemetry.** One line per poll (or on burst): chrono frames
+   emitted *this tick*, TX_AUDIO gap since last block, accumulator ns.
+   1-second summaries cannot prove or disprove a clump. Needs `aether.cat`.
+6. **APD insanity visibility** (separate PR): intercept before the bare-flag
+   fold; `qCWarning(lcTransmit)` so it lands in a default support bundle.
+7. **Icom command-plane leak** (separate): stop sending Flex `xmit` /
+   `transmit set dax=` through `RadioModel::sendCommand` on a backend with
+   no command plane. Logged on every recent Mac Icom connect; not the spur.
+
+---
+
+## How to prove a fix
+
+Primary reproduction is the local Mac + IC-7300MK2 + WSJT-X path that wrote
+`aethersdr-20260901-204049.log` (first extra chrono at +2–3 s in 67 % of
+overs). Secondary is EI4KF/g0cgl Flex+JTDX on Windows.
+
+1. Enable **TCI/CAT/rigctld** (`aether.cat`) and **Performance** (`aether.perf`).
+2. FT8 over TCI, same radio, waterfall at a normal FPS.
+3. Watch for `TCI TX summary` plus the new burst line: `chrono_this_tick>1`
+   aligned with a waterfall tick ~1–2 s in. The 1 s `dreq=50176` vs
+   `dinf=49152` line is the current proxy for that burst.
+4. After the clamp: `chrono_this_tick` never exceeds 1–2; first extra-chrono
+   histogram at +2–3 s goes to ~0; no spur; decode still succeeds;
+   `effective48k` at stop stays ~48000.
+5. Repeat with the window busy (fast waterfall) and minimized. The busy case
+   is the regression test; minimized is the control. EI4KF TX 2 (stalls at
+   +8–9.5 s) is the “busy mid-over” shape. #5340 (two pans, two WSJT-X,
+   GTX 1050 Ti) is the real two-slice busy case — extras must drop on
+   **both** trx=0 and trx=1.
+6. Automation: no TX-keying verb is required to *see* chrono, but a live over
+   still keys the radio. Use dummy load / ANT2 gate. A useful new verb would be
+   a read-only `tci chrono` snapshot (outstanding, accum ns, last gap).
+
+Do not use 1-second `blocks=48` as proof of cleanliness. That was the mistake
+in the in-thread Flex analysis of KN7K’s second bundle. Do not use the newest
+Mac logs as a TCI-FT8 sample — they have no client and no chrono.
+
+---
+
+## Local references
+
+Code:
+
+- Pacer: `src/core/TciServer.cpp` (`m_txChronoTimer` ctor ~457, `startTxChrono`
+  ~3375, `sendTxChronoFrame` ~3428, `logTxAudioSummary` ~3446)
+- False ack: `TciServer.cpp` `audio_stream_samples:` / `tx_stream_audio_buffering:`
+  ~1283
+- Layout vote: `TciServer.cpp` `onBinaryMessage` ~2486
+- Unpaced DAX TX: `src/core/AudioEngine.cpp` `feedDaxTxAudioInternal` ~9045
+- Bounded Opus pacer: `src/core/OpusTxPacer.h`
+- Icom packetizer (downstream only): `src/core/backends/icom/IcomAudio.h`
+  `TxPacketizer::kMaxPendingBytes = 24000`
+- Thetis chrono contract: `/Users/patj/oracles/thetis-tci-oracle.md`
+  (“TX audio and `trx`”, outstanding-request cap)
+
+Logs (this round):
+
+- GitHub zips: `/tmp/issue-5133-logs/`
+- EI4KF Desktop: `/Users/patj/Desktop/aethersdr-20260901-151922.log`
+- Mac pull: `/private/tmp/aethersdr-logpull/20260903-165337/`
+  - gold Icom FT8: `aethersdr-20260901-204049.log`
+  - Mac Flex: `aethersdr-20260830-174437.log`
+- #5340 zips: `/tmp/issue-5340-logs/` (`152309` = slice B trx=1,
+  `153508` = slice A trx=0)

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -485,11 +485,11 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
         for (int i = 0; i < tick.framesToSend; ++i) {
             sendTxChronoFrame(client);
         }
-        // Intra-second burst line (#5133 item 3). 1-second TCI TX summaries
-        // cannot show a 50 ms clump; this fires when the unbounded while
-        // would have emitted more than one frame, or when the pacer drops
-        // backlog / refuses because the client is behind.
-        if (tick.wouldHaveSent > 1 || tick.droppedNs > 0
+        // Intra-second burst line (#5133). A 5K-display GUI fires this
+        // timer at 20–40 ms, so would_have_sent=2 is routine — do not log
+        // that. Log when the unbounded while would have dumped ≥3 frames,
+        // when we actually discarded time, or when the client is behind.
+        if (tick.wouldHaveSent >= 3 || tick.droppedNs > 0
             || tick.outstandingCapped || tick.forgotStuck) {
             qCInfo(lcCat).nospace()
                 << "TCI TX chrono burst"

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -1,6 +1,7 @@
 #ifdef HAVE_WEBSOCKETS
 #include "TciServer.h"
 #include "TciProtocol.h"
+#include "TciTxChronoPacer.h"
 #include "StreamStatus.h"
 #include "AudioEngine.h"
 #include "AppSettings.h"
@@ -73,10 +74,9 @@ static_assert(sizeof(TciAudioHeader) == 64, "TCI audio header must be 64 bytes")
 
 namespace {
 
-constexpr int kTxChronoSamples = 2048; // float payload length sent to WSJT-X
-constexpr int kTxChronoStereoFrames = kTxChronoSamples / 2;
-constexpr qint64 kTxChronoPeriodNs =
-    (static_cast<qint64>(kTxChronoStereoFrames) * 1000000000LL) / 48000LL;
+constexpr int kTxChronoSamples = TciTxChronoPacer::kStereoFrames * 2; // float payload
+constexpr int kTxChronoStereoFrames = TciTxChronoPacer::kStereoFrames;
+constexpr qint64 kTxChronoPeriodNs = TciTxChronoPacer::kPeriodNs;
 constexpr int kTxChronoPollMs = 5;
 constexpr qint64 kTxSummaryEveryBlocks = 48;
 
@@ -475,12 +475,36 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
             return;
         }
 
-        m_txChronoAccumNs += m_txChronoClock.nsecsElapsed();
+        const qint64 elapsedNs = m_txChronoClock.nsecsElapsed();
         m_txChronoClock.restart();
-
-        while (m_txChronoAccumNs >= kTxChronoPeriodNs) {
+        const qint64 audioGapNs = m_txAudioClock.isValid()
+            ? m_txAudioClock.nsecsElapsed()
+            : static_cast<qint64>(-1);
+        const TciTxChronoPacer::TickResult tick =
+            m_txChronoPacer.tick(elapsedNs, audioGapNs);
+        for (int i = 0; i < tick.framesToSend; ++i) {
             sendTxChronoFrame(client);
-            m_txChronoAccumNs -= kTxChronoPeriodNs;
+        }
+        // Intra-second burst line (#5133 item 3). 1-second TCI TX summaries
+        // cannot show a 50 ms clump; this fires when the unbounded while
+        // would have emitted more than one frame, or when the pacer drops
+        // backlog / refuses because the client is behind.
+        if (tick.wouldHaveSent > 1 || tick.droppedNs > 0
+            || tick.outstandingCapped || tick.forgotStuck) {
+            qCInfo(lcCat).nospace()
+                << "TCI TX chrono burst"
+                << " chrono_this_tick=" << tick.framesToSend
+                << " would_have_sent=" << tick.wouldHaveSent
+                << " dropped_ns=" << tick.droppedNs
+                << " accum_ns=" << tick.accumNs
+                << " outstanding=" << tick.outstanding
+                << " audio_gap_ms="
+                << (audioGapNs >= 0
+                        ? static_cast<double>(audioGapNs) / 1.0e6
+                        : -1.0)
+                << " forgot_stuck=" << (tick.forgotStuck ? "true" : "false")
+                << " outstanding_capped="
+                << (tick.outstandingCapped ? "true" : "false");
         }
     });
 }
@@ -2575,6 +2599,8 @@ void TciServer::onBinaryMessage(const QByteArray& data)
     }
 
     ++m_txAudioBlocks;
+    m_txChronoPacer.onAudioBlock();
+    m_txAudioClock.start();
     m_txInputFrames += inputFramesSrcRate;
     m_txOutputFrames += outputStereoFrames;
     m_txClipSamples += clipSamples;
@@ -3276,8 +3302,9 @@ void TciServer::prepareTxAudio()
         if (!ok || rawMode < 0 || rawMode > 2) rawMode = 0;
         m_overflowMode = static_cast<OverflowMode>(rawMode);
     }
-    m_txChronoAccumNs = 0;
+    m_txChronoPacer.reset();
     m_txChronoRequestedFrames = 0;
+    m_txAudioClock.invalidate();
     m_txAudioBlocks = 0;
     m_txInputFrames = 0;
     m_txOutputFrames = 0;
@@ -3387,6 +3414,8 @@ void TciServer::startTxChrono(QWebSocket* client, int trx)
     m_txChronoClient = client;
     m_txChronoTrx = trx;
 
+    m_txChronoPacer.reset();
+    m_txAudioClock.invalidate();
     m_txChronoClock.start();
     m_txChronoSessionClock.start();
     m_txChronoTimer->start();
@@ -3409,7 +3438,8 @@ void TciServer::stopTxChrono()
     m_txChronoClient = nullptr;
     m_txChronoClock.invalidate();
     m_txChronoSessionClock.invalidate();
-    m_txChronoAccumNs = 0;
+    m_txAudioClock.invalidate();
+    m_txChronoPacer.reset();
 
     // Do NOT send `transmit set dax=0` here. The radio's status echo
     // flips m_daxTxMode to false via updateDaxTxMode, which blocks the
@@ -3441,6 +3471,7 @@ void TciServer::sendTxChronoFrame(QWebSocket* client)
     std::memcpy(frame.data(), &hdr, sizeof(hdr));
     client->sendBinaryMessage(frame);
     m_txChronoRequestedFrames += kTxChronoStereoFrames;
+    m_txChronoPacer.onChronoSent();
 }
 
 void TciServer::logTxAudioSummary(const char* reason)
@@ -3471,7 +3502,8 @@ void TciServer::logTxAudioSummary(const char* reason)
         << " peak=" << m_txAudioPeak
         << " rms=" << rms
         << " clips=" << m_txClipSamples
-        << " layout=" << (m_txSawDuplicatedStereo ? "duplicated-stereo" : "mono-or-stereo");
+        << " layout=" << (m_txSawDuplicatedStereo ? "duplicated-stereo" : "mono-or-stereo")
+        << " outstanding=" << m_txChronoPacer.outstanding();
 }
 
 void TciServer::broadcastActualTxState(bool transmitting)

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -5,6 +5,7 @@
 #include "TciRoutingState.h"
 #include "TciTrxMap.h"
 #include "IcomTciUnkeySettle.h"
+#include "TciTxChronoPacer.h"
 
 #include <QObject>
 #include <QPointer>
@@ -396,7 +397,8 @@ private:
     std::unique_ptr<Resampler> m_txResampler; // 48kHz→24kHz TX downsampler
     QElapsedTimer     m_txChronoClock;
     QElapsedTimer     m_txChronoSessionClock;
-    qint64            m_txChronoAccumNs{0};
+    QElapsedTimer     m_txAudioClock; // last TX_AUDIO block this over
+    TciTxChronoPacer  m_txChronoPacer;
     qint64            m_txChronoRequestedFrames{0};
     bool              m_txUseRadioRoute{true};
     float             m_txGain{1.0f};

--- a/src/core/TciTxChronoPacer.h
+++ b/src/core/TciTxChronoPacer.h
@@ -1,20 +1,29 @@
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 
 namespace AetherSDR {
 
 // TX_CHRONO pull-pacer for TCI digital-mode audio (#5133).
 //
-// WSJT-X / JTDX send one TX_AUDIO block per type-3 chrono. The old TciServer
-// loop repaid a GUI stall as an unbounded burst of chrono frames on the next
-// 5 ms tick, which dumped a clump of audio onto Flex dax_tx / Icom TxPacketizer
-// and showed up as a 1–2 s FT8 spur. Thetis (TCI authority) caps outstanding
-// requests and forgets stuck counts after max(250 ms, 4×buffering).
+// WSJT-X / JTDX send one TX_AUDIO block per type-3 chrono. Two failure
+// modes have shown up on the air:
 //
-// This pacer:
-//   * emits at most one chrono per poll tick
-//   * caps the time accumulator so a stall is dropped, not replayed
+//   * Unbounded catch-up: a GUI stall is repaid as N chrono frames in one
+//     tick → a clump of TX_AUDIO hits Flex dax_tx / Icom TxPacketizer
+//     (1–2 s FT8 spur).
+//   * Dropping owed time: capping the accumulator at two periods under a
+//     loaded 5K-display GUI (~20–40 ms ticks) discarded ~25 % of the
+//     clock (effective48k ≈ 36 k) → Icom underflow holes → 7–8 spurs.
+//
+// Thetis (TCI authority) caps outstanding requests and forgets stuck
+// counts after max(250 ms, 4×buffering). OpusTxPacer already solved the
+// sibling problem with kMaxPacketsPerDrain = 3. This pacer:
+//
+//   * pays back stalls at most three frames per poll (bounded catch-up)
+//   * keeps up to ~213 ms of backlog so a 5K hitch is repaid, not dropped
+//   * only discards pathological backlogs (seconds)
 //   * refuses new chronos while too many are unanswered
 //   * forgets a stuck outstanding count after 250 ms without TX_AUDIO
 class TciTxChronoPacer {
@@ -24,13 +33,14 @@ public:
     static constexpr std::int64_t kPeriodNs =
         (static_cast<std::int64_t>(kStereoFrames) * 1000000000LL)
         / static_cast<std::int64_t>(kSampleRateHz);
-    static constexpr int kMaxFramesPerTick = 1;
-    // Two periods (~42.7 ms): enough to absorb one 5 ms poll jitter, not a
-    // waterfall stall. Excess is dropped.
-    static constexpr std::int64_t kMaxBacklogNs = 2 * kPeriodNs;
-    // ~64 ms of unanswered chrono. Thetis allows 64; that is the burst we are
-    // closing. Three is one extra after a missed tick plus margin.
-    static constexpr int kMaxOutstanding = 3;
+    // Same bound OpusTxPacer uses for a late audio-thread drain.
+    static constexpr int kMaxFramesPerTick = 3;
+    // Ten periods (~213 ms). A 50–80 ms 5K/GPU hitch fits; a 1.6 s
+    // watchdog stall does not get replayed in full.
+    static constexpr std::int64_t kMaxBacklogNs = 10 * kPeriodNs;
+    // ~170 ms of unanswered chrono. Under Icom TxPacketizer's 250 ms cap
+    // so a catch-up clump cannot overflow the radio queue.
+    static constexpr int kMaxOutstanding = 8;
     static constexpr std::int64_t kForgetStuckNs = 250000000; // 250 ms
 
     struct TickResult {
@@ -63,23 +73,28 @@ public:
             out.wouldHaveSent = static_cast<int>(m_accumNs / kPeriodNs);
         }
 
-        if (m_accumNs > kMaxBacklogNs) {
-            out.droppedNs = m_accumNs - kMaxBacklogNs;
-            m_accumNs = kMaxBacklogNs;
-        }
-
         if (m_outstanding > 0 && audioGapNs >= kForgetStuckNs) {
             m_outstanding = 0;
             out.forgotStuck = true;
         }
 
-        if (m_accumNs >= kPeriodNs) {
-            if (m_outstanding >= kMaxOutstanding) {
-                out.outstandingCapped = true;
-            } else {
-                out.framesToSend = kMaxFramesPerTick;
-                m_accumNs -= kPeriodNs;
-            }
+        const int owed = (m_accumNs >= kPeriodNs)
+            ? static_cast<int>(m_accumNs / kPeriodNs)
+            : 0;
+        const int room = kMaxOutstanding - m_outstanding;
+        int send = std::min({owed, kMaxFramesPerTick, std::max(room, 0)});
+        if (owed > 0 && send == 0 && m_outstanding >= kMaxOutstanding) {
+            out.outstandingCapped = true;
+        }
+        if (send > 0) {
+            m_accumNs -= static_cast<std::int64_t>(send) * kPeriodNs;
+        }
+        out.framesToSend = send;
+
+        // Drop only after paying this tick, and only the pathological tail.
+        if (m_accumNs > kMaxBacklogNs) {
+            out.droppedNs = m_accumNs - kMaxBacklogNs;
+            m_accumNs = kMaxBacklogNs;
         }
 
         out.accumNs = m_accumNs;

--- a/src/core/TciTxChronoPacer.h
+++ b/src/core/TciTxChronoPacer.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <cstdint>
+
+namespace AetherSDR {
+
+// TX_CHRONO pull-pacer for TCI digital-mode audio (#5133).
+//
+// WSJT-X / JTDX send one TX_AUDIO block per type-3 chrono. The old TciServer
+// loop repaid a GUI stall as an unbounded burst of chrono frames on the next
+// 5 ms tick, which dumped a clump of audio onto Flex dax_tx / Icom TxPacketizer
+// and showed up as a 1–2 s FT8 spur. Thetis (TCI authority) caps outstanding
+// requests and forgets stuck counts after max(250 ms, 4×buffering).
+//
+// This pacer:
+//   * emits at most one chrono per poll tick
+//   * caps the time accumulator so a stall is dropped, not replayed
+//   * refuses new chronos while too many are unanswered
+//   * forgets a stuck outstanding count after 250 ms without TX_AUDIO
+class TciTxChronoPacer {
+public:
+    static constexpr int kStereoFrames = 1024;
+    static constexpr int kSampleRateHz = 48000;
+    static constexpr std::int64_t kPeriodNs =
+        (static_cast<std::int64_t>(kStereoFrames) * 1000000000LL)
+        / static_cast<std::int64_t>(kSampleRateHz);
+    static constexpr int kMaxFramesPerTick = 1;
+    // Two periods (~42.7 ms): enough to absorb one 5 ms poll jitter, not a
+    // waterfall stall. Excess is dropped.
+    static constexpr std::int64_t kMaxBacklogNs = 2 * kPeriodNs;
+    // ~64 ms of unanswered chrono. Thetis allows 64; that is the burst we are
+    // closing. Three is one extra after a missed tick plus margin.
+    static constexpr int kMaxOutstanding = 3;
+    static constexpr std::int64_t kForgetStuckNs = 250000000; // 250 ms
+
+    struct TickResult {
+        int framesToSend{0};
+        int wouldHaveSent{0};   // unbounded while-loop count (telemetry)
+        std::int64_t droppedNs{0};
+        bool forgotStuck{false};
+        bool outstandingCapped{false};
+        std::int64_t accumNs{0};
+        int outstanding{0};
+    };
+
+    void reset()
+    {
+        m_accumNs = 0;
+        m_outstanding = 0;
+    }
+
+    // elapsedNs: nsecs since the previous poll (or since start).
+    // audioGapNs: nsecs since the last TX_AUDIO block; <0 if none this over.
+    TickResult tick(std::int64_t elapsedNs, std::int64_t audioGapNs)
+    {
+        TickResult out;
+        if (elapsedNs < 0) {
+            elapsedNs = 0;
+        }
+        m_accumNs += elapsedNs;
+
+        if (m_accumNs >= kPeriodNs) {
+            out.wouldHaveSent = static_cast<int>(m_accumNs / kPeriodNs);
+        }
+
+        if (m_accumNs > kMaxBacklogNs) {
+            out.droppedNs = m_accumNs - kMaxBacklogNs;
+            m_accumNs = kMaxBacklogNs;
+        }
+
+        if (m_outstanding > 0 && audioGapNs >= kForgetStuckNs) {
+            m_outstanding = 0;
+            out.forgotStuck = true;
+        }
+
+        if (m_accumNs >= kPeriodNs) {
+            if (m_outstanding >= kMaxOutstanding) {
+                out.outstandingCapped = true;
+            } else {
+                out.framesToSend = kMaxFramesPerTick;
+                m_accumNs -= kPeriodNs;
+            }
+        }
+
+        out.accumNs = m_accumNs;
+        out.outstanding = m_outstanding;
+        return out;
+    }
+
+    void onChronoSent()
+    {
+        if (m_outstanding < kMaxOutstanding) {
+            ++m_outstanding;
+        }
+    }
+
+    void onAudioBlock()
+    {
+        if (m_outstanding > 0) {
+            --m_outstanding;
+        }
+    }
+
+    std::int64_t accumNs() const { return m_accumNs; }
+    int outstanding() const { return m_outstanding; }
+
+private:
+    std::int64_t m_accumNs{0};
+    int m_outstanding{0};
+};
+
+} // namespace AetherSDR

--- a/tests/tci_tx_chrono_pacer_test.cpp
+++ b/tests/tci_tx_chrono_pacer_test.cpp
@@ -1,0 +1,151 @@
+#include "core/TciTxChronoPacer.h"
+
+#include <cstdio>
+
+using AetherSDR::TciTxChronoPacer;
+
+namespace {
+
+bool expect(bool cond, const char* what)
+{
+    if (!cond) {
+        std::printf("FAIL: %s\n", what);
+    }
+    return cond;
+}
+
+bool testSteadyPollEmitsEveryPeriod()
+{
+    TciTxChronoPacer pacer;
+    int sent = 0;
+    // 21.333 ms period, 5 ms poll. Four quiet polls then one emit.
+    for (int i = 0; i < 20; ++i) {
+        const TciTxChronoPacer::TickResult r =
+            pacer.tick(5 * 1000000LL, /*audioGapNs=*/i * 5 * 1000000LL);
+        if (!expect(r.framesToSend <= 1, "steady poll never bursts")
+            || !expect(r.droppedNs == 0, "steady poll drops nothing")
+            || !expect(r.wouldHaveSent <= 1, "steady poll would_have_sent<=1")) {
+            return false;
+        }
+        if (r.framesToSend == 1) {
+            pacer.onChronoSent();
+            ++sent;
+            pacer.onAudioBlock(); // client answers promptly
+        }
+    }
+    return expect(sent >= 4 && sent <= 5, "about one chrono per 21.3 ms");
+}
+
+bool testStallDoesNotReplayUnbounded()
+{
+    TciTxChronoPacer pacer;
+    // 53 ms GUI stall (KN7K median uiHeartbeat). Old while would send 2–3.
+    const TciTxChronoPacer::TickResult r =
+        pacer.tick(53 * 1000000LL, /*audioGapNs=*/-1);
+    if (!expect(r.framesToSend == 1, "stall emits at most one chrono")
+        || !expect(r.wouldHaveSent >= 2, "telemetry records the unbounded count")
+        || !expect(r.droppedNs > 0, "excess stall is dropped not banked")) {
+        std::printf("got frames=%d would=%d dropped=%lld\n",
+                    r.framesToSend, r.wouldHaveSent,
+                    static_cast<long long>(r.droppedNs));
+        return false;
+    }
+    pacer.onChronoSent();
+    if (!expect(pacer.outstanding() == 1, "one unanswered after stall tick")) {
+        return false;
+    }
+    return true;
+}
+
+bool testLongStallStillOneFrame()
+{
+    TciTxChronoPacer pacer;
+    // 1675 ms outlier from KN7K. Old while would send ~78 frames.
+    const TciTxChronoPacer::TickResult r =
+        pacer.tick(1675 * 1000000LL, /*audioGapNs=*/-1);
+    return expect(r.framesToSend == 1, "1.6 s stall still one frame")
+        && expect(r.wouldHaveSent >= 70, "would_have_sent captures the old burst")
+        && expect(r.droppedNs > TciTxChronoPacer::kPeriodNs,
+                  "most of the stall is discarded");
+}
+
+bool testOutstandingCapRefusesMoreChrono()
+{
+    TciTxChronoPacer pacer;
+    for (int i = 0; i < TciTxChronoPacer::kMaxOutstanding; ++i) {
+        const TciTxChronoPacer::TickResult r =
+            pacer.tick(TciTxChronoPacer::kPeriodNs, /*audioGapNs=*/0);
+        if (!expect(r.framesToSend == 1, "fill outstanding with one per period")) {
+            return false;
+        }
+        pacer.onChronoSent();
+    }
+    const TciTxChronoPacer::TickResult blocked =
+        pacer.tick(TciTxChronoPacer::kPeriodNs, /*audioGapNs=*/10 * 1000000LL);
+    if (!expect(blocked.framesToSend == 0, "no chrono while at outstanding cap")
+        || !expect(blocked.outstandingCapped, "outstanding_capped is set")) {
+        return false;
+    }
+    pacer.onAudioBlock();
+    const TciTxChronoPacer::TickResult resumed =
+        pacer.tick(TciTxChronoPacer::kPeriodNs, /*audioGapNs=*/5 * 1000000LL);
+    return expect(resumed.framesToSend == 1, "audio reply unblocks chrono");
+}
+
+bool testForgetStuckOutstanding()
+{
+    TciTxChronoPacer pacer;
+    const TciTxChronoPacer::TickResult first =
+        pacer.tick(TciTxChronoPacer::kPeriodNs, /*audioGapNs=*/-1);
+    if (!expect(first.framesToSend == 1, "first chrono")) {
+        return false;
+    }
+    pacer.onChronoSent();
+    const TciTxChronoPacer::TickResult forgot =
+        pacer.tick(TciTxChronoPacer::kPeriodNs,
+                   TciTxChronoPacer::kForgetStuckNs);
+    return expect(forgot.forgotStuck, "250 ms without audio forgets outstanding")
+        && expect(forgot.framesToSend == 1, "chrono resumes after forget")
+        && expect(pacer.outstanding() == 0
+                      || forgot.outstanding == 0,
+                  "outstanding cleared before the new send");
+}
+
+bool testAudioBlockDecrementsOutstanding()
+{
+    TciTxChronoPacer pacer;
+    pacer.tick(TciTxChronoPacer::kPeriodNs, -1);
+    pacer.onChronoSent();
+    pacer.onChronoSent(); // defensive: startTxChrono sends one immediately
+    pacer.onAudioBlock();
+    pacer.onAudioBlock();
+    pacer.onAudioBlock(); // extra reply must not underflow
+    return expect(pacer.outstanding() == 0, "outstanding floors at zero");
+}
+
+bool testResetClearsState()
+{
+    TciTxChronoPacer pacer;
+    pacer.tick(80 * 1000000LL, -1);
+    pacer.onChronoSent();
+    pacer.reset();
+    return expect(pacer.accumNs() == 0, "reset accum")
+        && expect(pacer.outstanding() == 0, "reset outstanding");
+}
+
+} // namespace
+
+int main()
+{
+    if (!testSteadyPollEmitsEveryPeriod()
+        || !testStallDoesNotReplayUnbounded()
+        || !testLongStallStillOneFrame()
+        || !testOutstandingCapRefusesMoreChrono()
+        || !testForgetStuckOutstanding()
+        || !testAudioBlockDecrementsOutstanding()
+        || !testResetClearsState()) {
+        return 1;
+    }
+    std::printf("tci_tx_chrono_pacer_test passed\n");
+    return 0;
+}

--- a/tests/tci_tx_chrono_pacer_test.cpp
+++ b/tests/tci_tx_chrono_pacer_test.cpp
@@ -18,55 +18,91 @@ bool testSteadyPollEmitsEveryPeriod()
 {
     TciTxChronoPacer pacer;
     int sent = 0;
-    // 21.333 ms period, 5 ms poll. Four quiet polls then one emit.
     for (int i = 0; i < 20; ++i) {
         const TciTxChronoPacer::TickResult r =
             pacer.tick(5 * 1000000LL, /*audioGapNs=*/i * 5 * 1000000LL);
-        if (!expect(r.framesToSend <= 1, "steady poll never bursts")
-            || !expect(r.droppedNs == 0, "steady poll drops nothing")
-            || !expect(r.wouldHaveSent <= 1, "steady poll would_have_sent<=1")) {
+        if (!expect(r.framesToSend <= 1, "steady 5 ms poll never catch-up bursts")
+            || !expect(r.droppedNs == 0, "steady poll drops nothing")) {
             return false;
         }
-        if (r.framesToSend == 1) {
+        for (int n = 0; n < r.framesToSend; ++n) {
             pacer.onChronoSent();
             ++sent;
-            pacer.onAudioBlock(); // client answers promptly
+            pacer.onAudioBlock();
         }
     }
     return expect(sent >= 4 && sent <= 5, "about one chrono per 21.3 ms");
 }
 
-bool testStallDoesNotReplayUnbounded()
+bool testLateGuiPollDoesNotDrop()
 {
     TciTxChronoPacer pacer;
-    // 53 ms GUI stall (KN7K median uiHeartbeat). Old while would send 2–3.
-    const TciTxChronoPacer::TickResult r =
-        pacer.tick(53 * 1000000LL, /*audioGapNs=*/-1);
-    if (!expect(r.framesToSend == 1, "stall emits at most one chrono")
-        || !expect(r.wouldHaveSent >= 2, "telemetry records the unbounded count")
-        || !expect(r.droppedNs > 0, "excess stall is dropped not banked")) {
-        std::printf("got frames=%d would=%d dropped=%lld\n",
-                    r.framesToSend, r.wouldHaveSent,
-                    static_cast<long long>(r.droppedNs));
-        return false;
+    // 5K Studio Display: timer fires at ~40 ms, not 5 ms.
+    int sent = 0;
+    std::int64_t elapsed = 0;
+    for (int i = 0; i < 10; ++i) {
+        const TciTxChronoPacer::TickResult r =
+            pacer.tick(40 * 1000000LL, /*audioGapNs=*/2 * 1000000LL);
+        elapsed += 40 * 1000000LL;
+        if (!expect(r.droppedNs == 0, "40 ms poll must not drop owed time")
+            || !expect(r.framesToSend >= 1 && r.framesToSend <= 3,
+                       "40 ms poll pays 1–2 frames, not zero")) {
+            std::printf("tick %d frames=%d dropped=%lld would=%d\n",
+                        i, r.framesToSend,
+                        static_cast<long long>(r.droppedNs), r.wouldHaveSent);
+            return false;
+        }
+        for (int n = 0; n < r.framesToSend; ++n) {
+            pacer.onChronoSent();
+            ++sent;
+            pacer.onAudioBlock();
+        }
     }
-    pacer.onChronoSent();
-    if (!expect(pacer.outstanding() == 1, "one unanswered after stall tick")) {
+    const double hz = static_cast<double>(sent) * TciTxChronoPacer::kStereoFrames
+        / (static_cast<double>(elapsed) / 1.0e9);
+    if (!expect(hz > 45000.0 && hz < 51000.0, "late polls still average ~48 kHz")) {
+        std::printf("effective48k=%.1f sent=%d elapsed_ms=%.1f\n",
+                    hz, sent, elapsed / 1.0e6);
         return false;
     }
     return true;
 }
 
-bool testLongStallStillOneFrame()
+bool testFiftyMsStallPaysTwoNotOne()
 {
     TciTxChronoPacer pacer;
-    // 1675 ms outlier from KN7K. Old while would send ~78 frames.
+    const TciTxChronoPacer::TickResult r =
+        pacer.tick(53 * 1000000LL, /*audioGapNs=*/-1);
+    if (!expect(r.framesToSend == 2, "53 ms stall pays two periods")
+        || !expect(r.wouldHaveSent == 2, "would_have_sent matches owed")
+        || !expect(r.droppedNs == 0, "53 ms fits in the 213 ms backlog")) {
+        std::printf("got frames=%d would=%d dropped=%lld\n",
+                    r.framesToSend, r.wouldHaveSent,
+                    static_cast<long long>(r.droppedNs));
+        return false;
+    }
+    return true;
+}
+
+bool testLongStallIsBoundedNotDroppedToOne()
+{
+    TciTxChronoPacer pacer;
+    // 1675 ms outlier. Unbounded while ≈ 78 frames; we send 3 and keep ~213 ms.
     const TciTxChronoPacer::TickResult r =
         pacer.tick(1675 * 1000000LL, /*audioGapNs=*/-1);
-    return expect(r.framesToSend == 1, "1.6 s stall still one frame")
-        && expect(r.wouldHaveSent >= 70, "would_have_sent captures the old burst")
-        && expect(r.droppedNs > TciTxChronoPacer::kPeriodNs,
-                  "most of the stall is discarded");
+    if (!expect(r.framesToSend == TciTxChronoPacer::kMaxFramesPerTick,
+                "long stall still bounded per tick")
+        || !expect(r.wouldHaveSent >= 70, "telemetry records the unbounded count")
+        || !expect(r.droppedNs > TciTxChronoPacer::kPeriodNs,
+                   "seconds of stall are discarded after keeping ~213 ms")) {
+        std::printf("got frames=%d would=%d dropped=%lld accum=%lld\n",
+                    r.framesToSend, r.wouldHaveSent,
+                    static_cast<long long>(r.droppedNs),
+                    static_cast<long long>(r.accumNs));
+        return false;
+    }
+    return expect(pacer.accumNs() == TciTxChronoPacer::kMaxBacklogNs,
+                  "backlog sits at the cap after a watchdog stall");
 }
 
 bool testOutstandingCapRefusesMoreChrono()
@@ -89,7 +125,7 @@ bool testOutstandingCapRefusesMoreChrono()
     pacer.onAudioBlock();
     const TciTxChronoPacer::TickResult resumed =
         pacer.tick(TciTxChronoPacer::kPeriodNs, /*audioGapNs=*/5 * 1000000LL);
-    return expect(resumed.framesToSend == 1, "audio reply unblocks chrono");
+    return expect(resumed.framesToSend >= 1, "audio reply unblocks chrono");
 }
 
 bool testForgetStuckOutstanding()
@@ -105,10 +141,7 @@ bool testForgetStuckOutstanding()
         pacer.tick(TciTxChronoPacer::kPeriodNs,
                    TciTxChronoPacer::kForgetStuckNs);
     return expect(forgot.forgotStuck, "250 ms without audio forgets outstanding")
-        && expect(forgot.framesToSend == 1, "chrono resumes after forget")
-        && expect(pacer.outstanding() == 0
-                      || forgot.outstanding == 0,
-                  "outstanding cleared before the new send");
+        && expect(forgot.framesToSend >= 1, "chrono resumes after forget");
 }
 
 bool testAudioBlockDecrementsOutstanding()
@@ -116,10 +149,10 @@ bool testAudioBlockDecrementsOutstanding()
     TciTxChronoPacer pacer;
     pacer.tick(TciTxChronoPacer::kPeriodNs, -1);
     pacer.onChronoSent();
-    pacer.onChronoSent(); // defensive: startTxChrono sends one immediately
+    pacer.onChronoSent();
     pacer.onAudioBlock();
     pacer.onAudioBlock();
-    pacer.onAudioBlock(); // extra reply must not underflow
+    pacer.onAudioBlock();
     return expect(pacer.outstanding() == 0, "outstanding floors at zero");
 }
 
@@ -138,8 +171,9 @@ bool testResetClearsState()
 int main()
 {
     if (!testSteadyPollEmitsEveryPeriod()
-        || !testStallDoesNotReplayUnbounded()
-        || !testLongStallStillOneFrame()
+        || !testLateGuiPollDoesNotDrop()
+        || !testFiftyMsStallPaysTwoNotOne()
+        || !testLongStallIsBoundedNotDroppedToOne()
         || !testOutstandingCapRefusesMoreChrono()
         || !testForgetStuckOutstanding()
         || !testAudioBlockDecrementsOutstanding()

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1698,6 +1698,12 @@ target_include_directories(opus_tx_pacer_test PRIVATE src)
 target_link_libraries(opus_tx_pacer_test PRIVATE Qt6::Core)
 add_test(NAME opus_tx_pacer_test COMMAND opus_tx_pacer_test)
 
+add_executable(tci_tx_chrono_pacer_test
+    tests/tci_tx_chrono_pacer_test.cpp
+)
+target_include_directories(tci_tx_chrono_pacer_test PRIVATE src)
+add_test(NAME tci_tx_chrono_pacer_test COMMAND tci_tx_chrono_pacer_test)
+
 add_executable(adaptive_filter_test
     tests/adaptive_filter_test.cpp
     src/core/OccupiedRegion.cpp


### PR DESCRIPTION
## Why this was reported

Operators run **FT8 (and other WSJT-X / JTDX modes) over TCI**, not CAT-audio. They key the radio from the digital app, watch their own signal on AetherSDR’s panadapter and waterfall, and expect a clean constant-envelope tone — the same picture SmartSDR shows.

What they actually saw: **short wideband ticks** a second or two into an otherwise good over. The rest of the transmission still decodes, so it looks like a small spur, not a failed QSO. That is enough to fail a PSK Reporter / RBN glance, worry about splatter, and file a bug.

[#5133](https://github.com/aethersdr/AetherSDR/issues/5133) is that report (JTDX on a FLEX-8600, then a FLEX-8400M; same shape on a Mac IC-7300MK2 + WSJT-X). [#5340](https://github.com/aethersdr/AetherSDR/issues/5340) is the two-slice / two-WSJT-X load case (same ticks on **both** slices; the ALC −20 / spot-count split is a different bug).

The use case is “digital mode over TCI while the GUI is busy” (waterfall, second pan, 5K display). Chrono is a GUI-thread timer. Any hitch becomes a timebase error on a mode that cannot hide one.

## Summary

TCI digital-mode TX (WSJT-X / JTDX) pulls audio: we emit type-3 **TX_CHRONO** frames and the client answers with type-2 TX_AUDIO. That pacer lived as an **unbounded `while`** on the GUI thread. After any event-loop hitch it repaid the whole stall as a burst of chrono frames; those audio blocks hit Flex `dax_tx` / Icom `TxPacketizer` unpaced. FT8 is a constant-envelope tone, so one discontinuity is a short waterfall spur even when the rest of the over decodes.

This PR replaces that loop with `TciTxChronoPacer` (same idea as `OpusTxPacer::kMaxPacketsPerDrain`): **bounded catch-up**, a ~213 ms bank, drop only pathological (seconds-long) stalls, cap unanswered chronos, forget stuck outstanding after 250 ms (Thetis-shaped).

It does **not** move TX_CHRONO off the GUI thread. Idle / 5K-display TX is now ~48 kHz and clean. **Live window-resize still starves chrono** (GUI blocked 200–600 ms). That residual is called out below; it is architecture (new thread / marshal), not this pacer.

Fixes the AetherSDR-side clock of [#5133](https://github.com/aethersdr/AetherSDR/issues/5133). Related load case: two-pan / two-WSJT-X in [#5340](https://github.com/aethersdr/AetherSDR/issues/5340) (same chrono signature on **both** slices; ALC −20 and A-vs-B PSK spots are **not** this bug).

## What changed (code)

| File | Role |
|---|---|
| `src/core/TciTxChronoPacer.h` | Header-only pacer. Unit-testable, no Qt. |
| `src/core/TciServer.cpp` | 5 ms `PreciseTimer` calls `tick()`; sends `framesToSend` chronos; logs `TCI TX chrono burst` when `would_have_sent >= 3` or time was dropped. |
| `src/core/TciServer.h` | Owns `TciTxChronoPacer` + `m_txAudioClock`. |
| `tests/tci_tx_chrono_pacer_test.cpp` | Steady poll, 40 ms late GUI ticks stay ~48 kHz, 53 ms stall pays 2, 1.6 s stall bounded to 3 + cap, outstanding cap, forget-stuck. |
| `docs/TCI-CHRONO.md` | Investigation notes + log corpus (reviewer context, not user-facing). |

Two commits on purpose (the first clamp was wrong on a loaded 5K display; keep the history):

1. `e701c28d` — clamp to 1 frame/tick, drop backlog past two periods (~43 ms).
2. `38e901e4` — repay stalls (3/tick, ~213 ms bank). **This is the code to review.**

### Pacer rules (as shipped in commit 2)

| Rule | Value | Why |
|---|---|---|
| Max frames per wake | **3** | Same bound as `OpusTxPacer::kMaxPacketsPerDrain`. Pays a hitch; does not dump 78 frames. |
| Keep backlog | **10 × 21.333 ms ≈ 213 ms** | A 40–80 ms 5K stall is repaid, not discarded. Under Icom `TxPacketizer` 250 ms cap. |
| Drop only | stalls of **seconds** | Watchdog outliers. Not 20–40 ms GUI jitter. |
| Unanswered chronos | cap **8** (~170 ms) | Don’t pile asks if WSJT-X hasn’t answered. |
| Forget stuck | **250 ms** with no TX_AUDIO | Thetis: forget after `max(250 ms, 4 × buffering)`. |
| Burst log | `would_have_sent >= 3` or `dropped_ns > 0` or outstanding/forget | 1-second `TCI TX summary` cannot show a clump. Do not log routine `would_have_sent=2`. |

Old loop (removed):

```cpp
m_txChronoAccumNs += elapsed;
while (m_txChronoAccumNs >= kTxChronoPeriodNs) {
    sendTxChronoFrame(client);
    m_txChronoAccumNs -= kTxChronoPeriodNs;
}
```

## Why two iterations (reviewer: do not restore commit 1’s drop)

WSJT-X only sends TX audio when we ask. Too fast → clump (splatter). Too slow → radio underrun (holes). Both are waterfall ticks.

**Commit 1** stopped the clump by emitting at most one chrono per tick and **dropping** anything over ~43 ms. On a 5K Studio Display the 5 ms GUI timer actually fires every 20–40 ms. Every late tick looked like a “stall,” we discarded ~10 ms, and the over ran at **~36 kHz** (25 % short). Icom underflow = 7–8 holes in one FT8.

**Commit 2** pays those late ticks back (up to 3 frames) and only drops seconds-long stalls. Idle 5K TX returned to **~47.9 kHz**.

## Hardware / log evidence (all CAT on unless noted)

Corpus and paths: `docs/TCI-CHRONO.md`. Headline numbers:

### Pre-fix (unbounded `while`)

| Source | Radio / OS | What we saw |
|---|---|---|
| #5133 KN7K bundles | FLEX-8600 Win11 | `uiHeartbeat` median 53 ms, ~every 2.2 s. Extra chrono (`dreq=50176` vs `dinf=49152`) often in the **second second** of TX. APD insanity is a **separate** overlay (bars every ~3.3 s). |
| #5133 g0cgl CAT bundle | FLEX-8400M Win11 JTDX | 14 overs, ~48 kHz average, extra chrono in second second. PTT→chrono ~70–100 ms. |
| EI4KF Desktop `aethersdr-20260901-151922.log` | same op, perf on, CAT off | Full FT8 overs + `xmit` bounce. Stalls **during** TX2 at +7.9–9.5 s (59–84 ms). |
| Mac gold `aethersdr-20260901-204049.log` | IC-7300MK2 macOS WSJT-X | **56 chrono / 53 full FT8**. First extra chrono at **+2–3 s in 67 %** of overs. PTT→chrono 0–2 ms. Stop rate ~48.0 k. |
| #5340 WA8PAM | FLEX-6400, **2 pans + 2 TCI clients**, GTX 1050 Ti | Same extra-chrono on **trx=0 and trx=1**. Audio peak/rms/gain identical. Chrono is a load multiplier, not a per-slice gain bug. |

### Commit 1 on 5K display (too tight) — `aethersdr-20260903-173930.log`

One FT8, overlay `2180×1412 @ dpr 2`, Studio Display:

- Stop `effective48k=36126`, blocks=478 (should be ~636)
- **330** `TCI TX chrono burst` lines in 13.6 s
- `chrono_this_tick=1`, `would_have_sent=2` on 326/330 ticks, mean `dropped_ns=10.1 ms`
- 330 × 10.1 ms ≈ 3.3 s discarded → 24 % → 36 kHz. Matches the summary.
- Result on air: 7–8 spurs.

### Commit 2 idle vs resize — `aethersdr-20260903-180616.log`

| TX | Start | Stop `effective48k` | Blocks | Notes |
|---|---|---|---|---|
| 1 | 18:08:01 | **47.94 k** | 565 | Idle — clean |
| 2 | 18:08:30 | **47.90 k** | 636 | Idle — clean |
| 3 | 18:09:00 | **47.96 k** | 635 | Idle / light hitch — clean |
| 4 | 18:09:30 | **29.72 k** | 393 | Live window-resize (shake corner) |
| 5 | 18:10:00 | **40.73 k** | 540 | Still resizing |

Resize bursts: `would_have_sent` median **12**, max **28** (250–600 ms since last tick); `chrono_this_tick=3` on 134/143; `audio_gap_ms` max **746**; `forgot_stuck` 21×. Timer cannot run while the GUI thread is in live layout/paint. **Out of scope for this PR.**

## Tests

`tci_tx_chrono_pacer_test` (no Qt, in `tests/tests.cmake`):

- 5 ms polls → ~1 chrono per 21.3 ms, no drop
- **40 ms polls** (5K GUI) → no drop, effective rate 45–51 kHz
- 53 ms stall → **2** frames, no drop
- 1675 ms stall → **3** frames this tick, backlog at cap, rest dropped
- outstanding cap refuses; audio reply unblocks
- 250 ms without TX_AUDIO forgets outstanding
- outstanding floors at 0; `reset()` clears

Run: `QT_QPA_PLATFORM=offscreen ./build/tci_tx_chrono_pacer_test`

Live: enable **TCI/CAT/rigctld**. Idle FT8 `TCI TX summary` `effective48k` ~48000, `blocks` ~630. Burst lines should be rare at idle. Resize during TX will still show `would_have_sent>=3` and a low effective rate — that is the known residual.

## Not in this PR (do not ask to fold them in)

| Item | Why separate |
|---|---|
| Pace `feedDaxTxAudioInternal` (`OpusTxPacer` for DAX/TCI) | Next clock step after chrono is honest. Icom 250 ms queue can absorb a 3-frame catch-up; Flex unpaced VITA still could clump. |
| Move TX_CHRONO off the GUI thread | Architecture (new thread / `QWebSocket` thread affinity). Needed for live-resize. Maintainer call. |
| False ack of `audio_stream_samples:` | Landmine, not the spur in these logs (clients used 1024). |
| Latch mono/stereo | Not implicated (`duplicated-stereo`, frame counts clean). |
| #5340 ALC last-definition-wins | Display −20 dBFS on slice B. `#3830`. Not TX audio. |
| #5340 20 vs 200 PSK spots | Same TCI level both slices; reporter reproduced on SmartSDR. |
| `apd insanity` dropped on the floor | KN7K-only overlay. |
| Icom `dropping xmit` / `transmit set dax=` | Flex text at a backend with no command plane. |

## Reviewer checklist

- [ ] Do not restore the unbounded `while`.
- [ ] Do not restore commit 1’s “drop everything over 43 ms” — that is the 36 kHz over.
- [ ] `tick()` pays `min(owed, 3, room)` **before** capping backlog.
- [ ] `onChronoSent` / `onAudioBlock` are the only outstanding mutators; `sendTxChronoFrame` calls `onChronoSent`.
- [ ] Burst log threshold is `>= 3`, not `> 1`.
- [ ] No new thread, no new GUI→core include, no `QSettings`.
- [ ] Residual “shake the window during FT8” is documented, not a silent hole.

## How to prove after merge

1. Idle FT8 over TCI, CAT on, 5K display sitting still: stop `effective48k` ~48 k, ~636 blocks, no waterfall ticks.
2. Same over while live-resizing: expect starvation in the log (`would_have_sent` 10–20). That is **not** a regression of this pacer; it is the GUI-thread residual.
3. Two-slice / two-WSJT-X (#5340 load): extras should not be a 1-second-bin 2× dump; idle rate still ~48 k on both trx.

Tested: Mac IC-7300MK2 + WSJT-X + Studio Display (idle clean, resize still dirty). Pre-fix corpus: Flex 8600/8400/6400 Windows + Mac Icom gold log (see `docs/TCI-CHRONO.md`).

Built with Grok 4.6
