### PR TITLE
Sanitizer lane recovery: S1–S6 of #5275, plus two defects the working lane found. Principle VIII.

### DIFF
--- a/.github/docker/Dockerfile.tsan
+++ b/.github/docker/Dockerfile.tsan
@@ -47,6 +47,12 @@ RUN apt-get update && apt-get install -y \
     libxcb-xfixes0-dev \
     libxcb-xinerama0-dev \
     libxcb-xkb-dev \
+    # Qt 6's xcb QPA links libxcb-xinput directly (ldd libqxcb.so). The base
+    # image does not carry it: that one installs Qt from aqt BINARIES and never
+    # compiles qtbase, so the gap only appears here. With -DFEATURE_xcb=ON
+    # forced below, a missing xcb dependency is a fatal configure error, not a
+    # silent feature drop (#5411 review).
+    libxcb-xinput-dev \
     libxrender-dev \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.github/docker/Dockerfile.tsan
+++ b/.github/docker/Dockerfile.tsan
@@ -1,0 +1,129 @@
+# ThreadSanitizer variant of the CI image: the same base, with Qt itself
+# built -sanitize thread. Published as ghcr.io/aethersdr/aethersdr-ci:tsan and
+# used only by the TSan entry of .github/workflows/sanitizers.yml.
+#
+# Why a second image exists at all. TSan reasons about happens-before from the
+# synchronization it can see. The prebuilt Qt in the base image is not
+# instrumented, so every lock inside it — the postEvent mutex that hands a
+# queued signal's payload across threads, the raster paint engine's worker
+# handoff — is invisible, and TSan reports each of those handoffs as a data
+# race in whichever of OUR frames touches the payload next. ~95% of the weekly
+# lane's reports were that one artefact (#5275), and there is no honest
+# suppression for it: the frames involved are exactly where a real race in a
+# slot body would show. Building Qt with TSan makes its locks visible and the
+# artefact disappears, leaving the lane reporting what it exists to report.
+#
+# Layout mirrors the base image one directory over: /opt/Qt-tsan/<ver>/gcc_64
+# and /opt/qtkeychain-tsan, with the same ENV names re-pointed, so nothing in
+# the workflow or the build system knows the difference.
+#
+# Modules: exactly the set aqt installs in the base image (qtbase plus
+# qtmultimedia, qtwebsockets, qtserialport, qtshadertools), each cloned at
+# its release tag and built in dependency order with qt-configure-module. No
+# qtdeclarative: nothing in the tree links QML, and it is the largest module.
+# Multimedia has no ffmpeg/gstreamer backend here: AetherSDR uses the audio
+# device classes, which live in QtMultimedia itself, not playback.
+
+FROM ghcr.io/aethersdr/aethersdr-ci:latest
+
+ENV DEBIAN_FRONTEND=noninteractive
+LABEL org.opencontainers.image.source=https://github.com/aethersdr/AetherSDR
+
+# xcb/xkb/gl DEV headers so qtbase still builds its xcb platform plugin and
+# the OpenGL integration the GPU spectrum path compiles against; the base
+# image carries most as runtime libs only because aqt's Qt is prebuilt.
+RUN apt-get update && apt-get install -y \
+    libegl1-mesa-dev \
+    libxcb-cursor-dev \
+    libxcb-glx0-dev \
+    libxcb-icccm4-dev \
+    libxcb-image0-dev \
+    libxcb-keysyms1-dev \
+    libxcb-randr0-dev \
+    libxcb-render-util0-dev \
+    libxcb-shape0-dev \
+    libxcb-sync-dev \
+    libxcb-util-dev \
+    libxcb-xfixes0-dev \
+    libxcb-xinerama0-dev \
+    libxcb-xkb-dev \
+    libxrender-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV QT_TSAN_ROOT=/opt/Qt-tsan/${QT_VERSION}/gcc_64
+ENV QT_GIT=https://code.qt.io/qt
+
+# qtbase. -sanitize thread is Qt's own configure switch (FEATURE_sanitize_thread);
+# -force-debug-info keeps frames symbolised in reports without a Debug build's
+# cost. -no-pch because sanitizer flags and precompiled headers disagree on
+# some GCC versions. Examples/tests off. The build is single-shot and the
+# sources are removed afterwards; nothing is cached because the image is the
+# cache.
+RUN git clone --depth 1 --branch "v${QT_VERSION}" "${QT_GIT}/qtbase.git" /tmp/qtbase-src \
+    && cmake -S /tmp/qtbase-src -B /tmp/qtbase-build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_INSTALL_PREFIX="${QT_TSAN_ROOT}" \
+        -DFEATURE_sanitize_thread=ON \
+        -DBUILD_WITH_PCH=OFF \
+        -DQT_BUILD_EXAMPLES=OFF \
+        -DQT_BUILD_TESTS=OFF \
+        -DFEATURE_xcb=ON \
+        -DFEATURE_opengl=ON \
+        -DINPUT_opengl=desktop \
+    && cmake --build /tmp/qtbase-build --parallel "$(nproc)" \
+    && cmake --install /tmp/qtbase-build \
+    && rm -rf /tmp/qtbase-src /tmp/qtbase-build \
+    && test -x "${QT_TSAN_ROOT}/bin/qmake" \
+    && "${QT_TSAN_ROOT}/bin/qmake" -query QT_VERSION \
+    # Proof the instrumentation is really in: libtsan must be a DT_NEEDED of
+    # QtCore, or the whole image is a slower copy of the base one.
+    && ldd "${QT_TSAN_ROOT}/lib/libQt6Core.so.6" | grep -q libtsan
+
+# Addon modules, dependency order: shadertools before multimedia. Each is
+# configured through the installed qtbase (qt-configure-module), which
+# carries the sanitizer feature over.
+RUN for m in qtshadertools qtwebsockets qtserialport qtmultimedia; do \
+        git clone --depth 1 --branch "v${QT_VERSION}" "${QT_GIT}/${m}.git" "/tmp/${m}-src" \
+        && "${QT_TSAN_ROOT}/bin/qt-configure-module" "/tmp/${m}-src" -- \
+            -B "/tmp/${m}-build" \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DQT_BUILD_EXAMPLES=OFF \
+            -DQT_BUILD_TESTS=OFF \
+        && cmake --build "/tmp/${m}-build" --parallel "$(nproc)" \
+        && cmake --install "/tmp/${m}-build" \
+        && rm -rf "/tmp/${m}-src" "/tmp/${m}-build" \
+        || exit 1; \
+    done \
+    && for m in Multimedia WebSockets SerialPort ShaderTools; do \
+           test -f "${QT_TSAN_ROOT}/lib/cmake/Qt6${m}/Qt6${m}Config.cmake" \
+           || { echo "Qt6${m} did not install"; exit 1; }; \
+       done
+
+# qtkeychain against THAT Qt, itself instrumented, same pin as the base image.
+ENV QTKEYCHAIN_TSAN_ROOT=/opt/qtkeychain-tsan
+RUN git clone --depth 1 --branch "${QTKEYCHAIN_VERSION}" \
+        https://github.com/frankosterfeld/qtkeychain.git /tmp/qtkeychain-src \
+    && test "$(git -C /tmp/qtkeychain-src rev-parse HEAD)" = "${QTKEYCHAIN_COMMIT}" \
+    && CXXFLAGS="-fsanitize=thread -fno-omit-frame-pointer" LDFLAGS="-fsanitize=thread" \
+       cmake -B /tmp/qtkeychain-build -S /tmp/qtkeychain-src -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DBUILD_WITH_QT6=ON \
+        -DBUILD_SHARED_LIBS=ON \
+        -DBUILD_TRANSLATIONS=OFF \
+        -DLIBSECRET_SUPPORT=OFF \
+        -DCMAKE_PREFIX_PATH="${QT_TSAN_ROOT}" \
+        -DCMAKE_INSTALL_PREFIX="${QTKEYCHAIN_TSAN_ROOT}" \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+    && cmake --build /tmp/qtkeychain-build -j"$(nproc)" \
+    && cmake --install /tmp/qtkeychain-build \
+    && test -f "${QTKEYCHAIN_TSAN_ROOT}/lib/cmake/Qt6Keychain/Qt6KeychainConfig.cmake" \
+    && rm -rf /tmp/qtkeychain-src /tmp/qtkeychain-build
+
+# Re-point every discovery variable the base image set, so a workflow that
+# says `container: …:tsan` gets the instrumented Qt with no other change.
+ENV QT_ROOT=${QT_TSAN_ROOT}
+ENV QTKEYCHAIN_ROOT=${QTKEYCHAIN_TSAN_ROOT}
+ENV CMAKE_PREFIX_PATH=${QT_TSAN_ROOT}:${QTKEYCHAIN_TSAN_ROOT}
+ENV Qt6_DIR=${QT_TSAN_ROOT}/lib/cmake/Qt6
+ENV PATH=${QT_TSAN_ROOT}/bin:${PATH}
+ENV LD_LIBRARY_PATH=${QT_TSAN_ROOT}/lib:${QTKEYCHAIN_TSAN_ROOT}/lib

--- a/.github/workflows/docker-ci-image.yml
+++ b/.github/workflows/docker-ci-image.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - '.github/docker/Dockerfile'
+      - '.github/docker/Dockerfile.tsan'
     branches: [main]
   workflow_dispatch:
 
@@ -84,4 +85,42 @@ jobs:
         run: |
           echo "Published ghcr.io/aethersdr/aethersdr-ci"
           echo "  tags:   latest, sha-${{ github.sha }}"
+          echo "  digest: ${{ steps.build.outputs.digest }}"
+
+  # The TSan variant (Qt built -sanitize thread; see Dockerfile.tsan). Runs
+  # AFTER the base image so it layers on the :latest just published, and
+  # regardless of whether the base build was needed (a Dockerfile.tsan-only
+  # push still rebuilds it on the existing :latest). A Qt source build on a
+  # hosted runner is a couple of hours; the timeout is a backstop, not a
+  # budget.
+  build-tsan:
+    needs: build
+    if: ${{ !cancelled() && needs.build.result != 'failure' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 330
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (tsan)
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        with:
+          context: .github/docker
+          file: .github/docker/Dockerfile.tsan
+          push: true
+          tags: |
+            ghcr.io/aethersdr/aethersdr-ci:tsan
+            ghcr.io/aethersdr/aethersdr-ci:tsan-sha-${{ github.sha }}
+
+      - name: Report published digest
+        run: |
+          echo "Published ghcr.io/aethersdr/aethersdr-ci"
+          echo "  tags:   tsan, tsan-sha-${{ github.sha }}"
           echo "  digest: ${{ steps.build.outputs.digest }}"

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -170,7 +170,16 @@ jobs:
             const fs = require('fs');
             const report = fs.readFileSync('report.txt', 'utf8');
             const title  = `[sanitizer] ${process.env.SAN_LABEL} weekly run failure`;
+            // Lookup key only — see the listForRepo call below. Do not add
+            // labels here: anything extra in this list also has to be on the
+            // existing sticky issue, or the lookup misses it and a duplicate
+            // is opened.
             const labels = ['sanitizer', process.env.SAN_ID];
+            // What a NEW sticky issue opens with. A red weekly lane is the only
+            // full-suite signal the project has (no PR job runs the Linux
+            // tests), so it opens at high priority; a maintainer can triage it
+            // down by hand and the weekly append will not fight that.
+            const createLabels = [...labels, 'bug', 'priority: high'];
             const sha    = context.sha.substring(0, 7);
             const date   = new Date().toISOString().split('T')[0];
 
@@ -215,7 +224,7 @@ jobs:
                 owner: context.repo.owner,
                 repo:  context.repo.repo,
                 title,
-                labels,
+                labels: createLabels,
                 body,
               });
               core.notice(`Opened #${created.data.number}`);

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -70,6 +70,35 @@ jobs:
               TSAN_OPTIONS=halt_on_error=0:second_deadlock_stack=1:history_size=7:print_summary=1:suppressions=${{ github.workspace }}/tests/sanitizers/tsan.supp
 
     steps:
+      # The job's `container:` is pulled by the runner BEFORE any step runs, so
+      # a missing or broken image fails the job with every step skipped —
+      # including the tracking-issue step, which is gated on
+      # steps.ctest.outputs.exit and therefore never fires. The lane would go
+      # dead silently, which is the failure class this whole effort exists to
+      # end (#5411 review). This step cannot prevent that, but it makes the
+      # image an explicit, named precondition in the log rather than an
+      # inference from "the job died instantly", and it fails loudly if the
+      # image is present but not the one we think it is.
+      - name: Confirm the sanitizer image
+        run: |
+          set -e
+          echo "image: ${{ matrix.sanitizer.image }}"
+          if [ "${{ matrix.sanitizer.id }}" = "tsan" ]; then
+            # S6's whole point: TSan must be linking a Qt that is itself
+            # instrumented. If libtsan is not a DT_NEEDED of QtCore we are on
+            # the wrong image and every Qt handoff would report as a race.
+            qtcore=$(find /opt -name 'libQt6Core.so.6' 2>/dev/null | head -1)
+            if [ -z "$qtcore" ]; then
+              echo "::error::no libQt6Core.so.6 in this image — expected the tsan image"
+              exit 1
+            fi
+            if ! ldd "$qtcore" | grep -q libtsan; then
+              echo "::error::$qtcore is not TSan-instrumented. This is not the :tsan image (or build-tsan published a stale one); tests/sanitizers/tsan.supp assumes an instrumented Qt and would be wrong here."
+              exit 1
+            fi
+            echo "ok: $qtcore is linked against libtsan"
+          fi
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Configure
@@ -159,29 +188,46 @@ jobs:
           # Then the sanitizer error blocks. Each ends with a `SUMMARY:` line;
           # ~80 lines of leading context per match is enough for the full
           # stack on ASan/UBSan/TSan output.
-          grep -B 80 '^SUMMARY:' sanitizer.log >> report.txt || true
-          if [ "$(wc -c < report.txt)" -lt 200 ]; then
+          # Gated on the SUMMARY block EXISTING, not on the report's size. A
+          # size gate measures the wrong thing now that the report always opens
+          # with the ctest verdict: five plain assertion failures are already
+          # ~330 bytes, so any size threshold small enough to be meaningful is
+          # already exceeded and the tail never runs — leaving the issue with
+          # test names and no assertion text, which is the #5031 case this
+          # rewrite exists for (#5411 review).
+          if grep -q '^SUMMARY:' sanitizer.log; then
+            grep -B 80 '^SUMMARY:' sanitizer.log >> report.txt
+          else
+            echo '--- last 50 KB of ctest output ---' >> report.txt
             tail -c 50000 sanitizer.log >> report.txt
           fi
           # Cap at ~45KB to stay well under GitHub's ~65KB issue-body limit
           # once we wrap it in markdown.
           head -c 45000 report.txt > report.trim && mv report.trim report.txt
-          # Stable fingerprint, used to decide whether a run is the same bug:
-          # the first sanitizer SUMMARY line when there is one. When there is
-          # none — the job also fails on plain test assertions, which print
-          # no SUMMARY — hash ctest's own failed-test list instead of the
-          # empty string (which is what #4330 collected twice: the sha256 of
-          # "" is e3b0c44298fc, a fingerprint of nothing).
+          # Stable fingerprint, used to decide whether a run is the same bug.
+          # WHICH TESTS FAILED, sorted, by NAME — not the first SUMMARY line
+          # and not ctest's ordinals (#5411 review):
+          #   - `grep -m1 SUMMARY` picks whichever race printed FIRST, and with
+          #     dozens of concurrent reports that order is scheduling-dependent,
+          #     so the fingerprint (now in the title) would churn a fresh sticky
+          #     issue most weeks — the opposite of what S5 wants.
+          #   - ctest prints `263 - name`, and that ordinal shifts whenever a
+          #     test is added earlier in tests.cmake, so an UNCHANGED set of
+          #     failures would fingerprint differently and duplicate the issue.
+          #     #5405 makes adding tests friction-free, so that is a matter of
+          #     time rather than a corner case.
+          # The SUMMARY hash stays as the fallback for a run that dies without
+          # producing a failed-test list at all (never the empty string, which
+          # is what #4330 collected twice: sha256("") is e3b0c44298fc).
+          failed=$(sed -n '/^The following tests FAILED:/,$p' sanitizer.log \
+                   | grep -oE '[0-9]+ - [A-Za-z0-9_.-]+' | sed 's/^[0-9]* - //' | sort -u || true)
           summary=$(grep -m1 '^SUMMARY:' sanitizer.log || true)
-          if [ -n "$summary" ]; then
+          if [ -n "$failed" ]; then
+            fp=$(printf '%s' "$failed" | sha256sum | cut -c1-12)
+          elif [ -n "$summary" ]; then
             fp=$(printf '%s' "$summary" | sha256sum | cut -c1-12)
           else
-            failed=$(sed -n '/^The following tests FAILED:/,$p' sanitizer.log | grep -oE '[0-9]+ - [A-Za-z0-9_.-]+' | sort || true)
-            if [ -n "$failed" ]; then
-              fp=$(printf '%s' "$failed" | sha256sum | cut -c1-12)
-            else
-              fp=unknown
-            fi
+            fp=unknown
           fi
           echo "fingerprint=${fp}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -8,7 +8,10 @@ name: Sanitizers
 
 on:
   schedule:
-    - cron: '0 7 * * 1'  # Mondays 07:00 UTC
+    # Saturdays 02:00 Pacific. GitHub cron is UTC and ignores DST, so this is
+    # 02:00 PDT / 01:00 PST; a fixed early-Saturday slot is the point, not the
+    # exact minute.
+    - cron: '0 9 * * 6'
   workflow_dispatch:
 
 permissions:
@@ -132,19 +135,33 @@ jobs:
           ${{ matrix.sanitizer.runtime_env }}
           EOF
           ec=0
-          ctest --test-dir build --output-on-failure 2>&1 | tee sanitizer.log || ec=$?
+          ctest --test-dir build --no-tests=error --output-on-failure 2>&1 | tee sanitizer.log || ec=$?
           echo "exit=$ec" >> "$GITHUB_OUTPUT"
 
       - name: Extract failure report
         id: extract
         if: steps.ctest.outputs.exit != '0'
         run: |
-          # Sanitizer error blocks all end with a `SUMMARY:` line. Capture
-          # ~80 lines of leading context per match, which is enough for the
-          # full stack on ASan/UBSan/TSan output.
-          grep -B 80 '^SUMMARY:' sanitizer.log > report.txt || true
-          if [ ! -s report.txt ]; then
-            tail -c 50000 sanitizer.log > report.txt
+          # ctest's own verdict goes FIRST, so the 45 KB cap below can never
+          # trim it: the "N tests passed, M failed out of T" line and the
+          # "The following tests FAILED:" list. Before this the body was only
+          # the sanitizer blocks — and once a standing UBSan report sat at
+          # test ~178 of 334, every append from 2026-08-03 on was 80 lines of
+          # context around it and nothing else. radio_capability_gating_test
+          # failed a plain assertion on 2026-08-31 and #4330 never named it.
+          # The lane has to be legible in the issue, not only in a 30-day
+          # artifact.
+          {
+            grep -E '^[0-9]+% tests passed' sanitizer.log || true
+            sed -n '/^The following tests FAILED:/,$p' sanitizer.log
+            echo
+          } > report.txt
+          # Then the sanitizer error blocks. Each ends with a `SUMMARY:` line;
+          # ~80 lines of leading context per match is enough for the full
+          # stack on ASan/UBSan/TSan output.
+          grep -B 80 '^SUMMARY:' sanitizer.log >> report.txt || true
+          if [ "$(wc -c < report.txt)" -lt 200 ]; then
+            tail -c 50000 sanitizer.log >> report.txt
           fi
           # Cap at ~45KB to stay well under GitHub's ~65KB issue-body limit
           # once we wrap it in markdown.

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -57,13 +57,23 @@ jobs:
             extra_cxx: "-fsanitize=thread -g3 -fno-omit-frame-pointer -O1"
             extra_ld:  "-fsanitize=thread"
             runtime_env: |
-              TSAN_OPTIONS=halt_on_error=0:second_deadlock_stack=1:history_size=7:print_summary=1
+              TSAN_OPTIONS=halt_on_error=0:second_deadlock_stack=1:history_size=7:print_summary=1:suppressions=${{ github.workspace }}/tests/sanitizers/tsan.supp
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Configure
         env:
+          # CFLAGS as well as CXXFLAGS. The tree is not all C++: WDSP and its
+          # Win32 port, liquid-dsp, rnnoise and the other vendored C libraries
+          # compile as C, and until CFLAGS was set here every one of them was
+          # built UNINSTRUMENTED in both lanes — ASan blind to their heap
+          # accesses, TSan blind to their atomics. For TSan that is the
+          # difference between a report and a fix: WDSP's teardown handshakes
+          # (Interlocked* on volatile longs, the port's __atomic builtins) are
+          # invisible to it without this, so it reports every channel close
+          # as a race whether or not one exists (#5275 S3 verification).
+          CFLAGS:   ${{ matrix.sanitizer.extra_cxx }}
           CXXFLAGS: ${{ matrix.sanitizer.extra_cxx }}
           LDFLAGS:  ${{ matrix.sanitizer.extra_ld }}
         run: |
@@ -84,6 +94,11 @@ jobs:
         continue-on-error: true
         env:
           QT_QPA_PLATFORM: offscreen
+          # No glib event dispatcher. The distro glib is uninstrumented and its
+          # eventfd doorbell shows up as ~290 TSan reports per run on the fd's
+          # shadow cell — not memory, not ours. Qt's own dispatcher is a
+          # supported configuration and costs no suppression (#5275 S4).
+          QT_NO_GLIB: "1"
         # The container image's /bin/sh is Dash, which doesn't understand
         # `set -o pipefail` or ${PIPESTATUS[0]} — without `shell: bash`
         # the step exits at code 2 before reaching ctest, the

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -19,13 +19,19 @@ jobs:
   sanitize:
     name: ${{ matrix.sanitizer.label }}
     runs-on: ubuntu-latest
-    container: ghcr.io/aethersdr/aethersdr-ci:latest
+    # Per-entry image: the TSan entry runs on the image whose Qt is itself
+    # built with -sanitize thread (.github/docker/Dockerfile.tsan). A TSan
+    # binary against an uninstrumented Qt reports every cross-thread queued
+    # signal as a race, because Qt's own locks are invisible to it; there is
+    # no honest suppression for that class (#5275 S6).
+    container: ${{ matrix.sanitizer.image }}
     strategy:
       fail-fast: false
       matrix:
         sanitizer:
           - id: asan-ubsan
             label: ASan + UBSan
+            image: ghcr.io/aethersdr/aethersdr-ci:latest
             build_type: Debug
             # ON here too, not only under TSan: the churn test's documented
             # failure class is a heap use-after-free on the receiver vector,
@@ -50,6 +56,7 @@ jobs:
               LSAN_OPTIONS=print_suppressions=0
           - id: tsan
             label: TSan
+            image: ghcr.io/aethersdr/aethersdr-ci:tsan
             # TSan cannot coexist with ASan, so build RelWithDebInfo and
             # inject the TSan flags ourselves.
             build_type: RelWithDebInfo
@@ -142,10 +149,24 @@ jobs:
           # Cap at ~45KB to stay well under GitHub's ~65KB issue-body limit
           # once we wrap it in markdown.
           head -c 45000 report.txt > report.trim && mv report.trim report.txt
-          # Stable fingerprint from the first SUMMARY line, used to detect
-          # whether a re-run is the same bug.
-          fp=$(grep -m1 '^SUMMARY:' sanitizer.log | sha256sum | cut -c1-12)
-          echo "fingerprint=${fp:-unknown}" >> "$GITHUB_OUTPUT"
+          # Stable fingerprint, used to decide whether a run is the same bug:
+          # the first sanitizer SUMMARY line when there is one. When there is
+          # none — the job also fails on plain test assertions, which print
+          # no SUMMARY — hash ctest's own failed-test list instead of the
+          # empty string (which is what #4330 collected twice: the sha256 of
+          # "" is e3b0c44298fc, a fingerprint of nothing).
+          summary=$(grep -m1 '^SUMMARY:' sanitizer.log || true)
+          if [ -n "$summary" ]; then
+            fp=$(printf '%s' "$summary" | sha256sum | cut -c1-12)
+          else
+            failed=$(sed -n '/^The following tests FAILED:/,$p' sanitizer.log | grep -oE '[0-9]+ - [A-Za-z0-9_.-]+' | sort || true)
+            if [ -n "$failed" ]; then
+              fp=$(printf '%s' "$failed" | sha256sum | cut -c1-12)
+            else
+              fp=unknown
+            fi
+          fi
+          echo "fingerprint=${fp}" >> "$GITHUB_OUTPUT"
 
       - name: Upload sanitizer artifacts
         if: steps.ctest.outputs.exit != '0'
@@ -169,7 +190,13 @@ jobs:
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('report.txt', 'utf8');
-            const title  = `[sanitizer] ${process.env.SAN_LABEL} weekly run failure`;
+            const fp     = process.env.FP;
+            // The fingerprint is in the title so that a NEW failure signature
+            // opens a NEW issue instead of arriving as comment N+1 on an
+            // already-red one, where it reads as more of the same (#5032,
+            // #5275 S5). One open issue per (sanitizer, fingerprint).
+            const fpTag  = fp && fp !== 'unknown' ? ` (fp ${fp})` : '';
+            const title  = `[sanitizer] ${process.env.SAN_LABEL} weekly run failure${fpTag}`;
             // Lookup key only — see the listForRepo call below. Do not add
             // labels here: anything extra in this list also has to be on the
             // existing sticky issue, or the lookup misses it and a duplicate
@@ -209,7 +236,13 @@ jobs:
               labels: labels.join(','),
               per_page: 100,
             });
-            const existing = open.data[0];
+            // Within the label bucket the fingerprint tag in the title picks
+            // the issue. An open issue with no tag is a pre-fingerprint sticky
+            // (#4330, #3462) and absorbs only runs whose fingerprint could not
+            // be computed — a run with a known signature gets its own issue.
+            const tagged   = open.data.find(i => fpTag && i.title.includes(fpTag));
+            const untagged = open.data.find(i => !/\(fp [0-9a-f]{12}\)/.test(i.title));
+            const existing = tagged || (fpTag ? undefined : untagged);
 
             if (existing) {
               await github.rest.issues.createComment({

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -126,6 +126,20 @@ jobs:
             -DAETHER_ENABLE_HL2_TX_LOOPBACK_TEST=ON
 
       - name: Build
+        # The SAME sanitizer flags as Configure, because this step also runs
+        # configure: vendored Opus is an ExternalProject_Add, so its child
+        # CMake project configures during the parent's BUILD, when a Configure-
+        # only env is long gone. third_party/radae/cmake/BuildOpus.cmake does
+        # not forward CMAKE_C_FLAGS through OPUS_CMAKE_ARGS either, so before
+        # this the bundled codec was built uninstrumented while the rest of the
+        # C tree was instrumented — a hole in S4's "every vendored C library"
+        # claim, and an invisible slice of the audio surface (#5411
+        # second-opinion review, verified with a marker flag that reached the
+        # outer CMakeCache.txt but not build_opus-cfgcmd.txt).
+        env:
+          CFLAGS:   ${{ matrix.sanitizer.extra_cxx }}
+          CXXFLAGS: ${{ matrix.sanitizer.extra_cxx }}
+          LDFLAGS:  ${{ matrix.sanitizer.extra_ld }}
         run: cmake --build build --parallel
 
       - name: Run tests under sanitizer

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -3820,7 +3820,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `audioCapture` | — | audioCapture <start\|stop\|status\|read\|probeNr2Stereo\|probeDspStereo> [args] — RN2 probe accepts rate=Legacy24k\|Native48k output=PreserveRxStereo\|ProcessedMono blocks=<frames,...> |
 | `txwaterfall` | — | txwaterfall <on\|off> — show keyed TX in the waterfall |
 | `liveness` | — | liveness — per-class data ages and the producer->consumer meter join |
-| `civ` | — | civ <send <hex>\|trace [all]\|session\|scheduler> — CI-V inject, frame trace, RS-BA1 lease health, or command-scheduler health (Icom; send is TX-gated) |
+| `civ` | — | civ <send <hex>\|trace [all]\|session\|scheduler\|incident> — CI-V inject, frame trace, lease/scheduler health, or last incident (Icom; send is TX-gated) |
 | `controls` | — | controls <map\|meters\|scrub [id\|plane]> — the CI-V control and meter registry joined against what is actually wired, and a linkage check that drives every settable control without moving any of them (Icom) |
 | `radiocert` | — | radiocert <tune\|rx\|tx\|meters\|all> [freqMhz] — radio bring-up diagnostic, in dependency order (tx/meters key) |
 | `transmit` | — | transmit <rfpower\|tunepower> <0..100> — transmit drive (TX-gated) |

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -6045,7 +6045,7 @@ QJsonObject AutomationServer::doConnect(const QString& action,
 
             QPointer<QObject> guard(conn->asQObject());
             QPointer<AutomationServer> self(this);
-            QTimer::singleShot(0, qApp, [guard, self, conn, selectedSerial] {
+            QTimer::singleShot(0, QCoreApplication::instance(), [guard, self, conn, selectedSerial] {
                 if (!guard) {
                     return;
                 }
@@ -6075,7 +6075,7 @@ QJsonObject AutomationServer::doConnect(const QString& action,
 
                 QPointer<QObject> guard(conn->asQObject());
                 QPointer<AutomationServer> self(this);
-                QTimer::singleShot(0, qApp, [guard, self, conn, serial] {
+                QTimer::singleShot(0, QCoreApplication::instance(), [guard, self, conn, serial] {
                     if (!guard) {
                         return;
                     }
@@ -6183,7 +6183,7 @@ QJsonObject AutomationServer::doConnect(const QString& action,
 
         QPointer<QObject> guard(conn->asQObject());
         QPointer<AutomationServer> self(this);
-        QTimer::singleShot(0, qApp, [guard, self, conn, target, family] {
+        QTimer::singleShot(0, QCoreApplication::instance(), [guard, self, conn, target, family] {
             if (!guard) {
                 return;
             }
@@ -6230,7 +6230,7 @@ QJsonObject AutomationServer::doConnectDialog(const QString& action)
     const bool wasVisible = conn && conn->automationDialogVisible();
     QPointer<QObject> guardedHost = host;
     QPointer<QObject> guard(conn ? conn->asQObject() : nullptr);
-    QTimer::singleShot(0, qApp, [guardedHost, guard, conn, show] {
+    QTimer::singleShot(0, QCoreApplication::instance(), [guardedHost, guard, conn, show] {
         if (guardedHost) {
             const char* method = show ? "showConnectionDialog" : "hideConnectionDialog";
             if (QMetaObject::invokeMethod(guardedHost, method, Qt::DirectConnection)) {
@@ -6268,7 +6268,7 @@ QJsonObject AutomationServer::doDisconnect()
 
     QPointer<QObject> guard(conn->asQObject());
     QPointer<AutomationServer> self(this);
-    QTimer::singleShot(0, qApp, [guard, self, conn] {
+    QTimer::singleShot(0, QCoreApplication::instance(), [guard, self, conn] {
         if (!guard) {
             return;
         }

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -54,6 +54,13 @@ public:
     // and applied during connect/pushInitialState; capture reports through
     // currentOperatingState() + operatingStateChanged().
     void applyRestoredState(const RestoredRadioState& state) override;
+    // The validated document applyRestoredState() kept — what the session will
+    // seed from at linkUp. Test seam only: currentOperatingState() reads the
+    // RECEIVERS, which are seeded at linkUp and not before, so a pre-connect
+    // test asserting on the snapshot sees construction defaults regardless of
+    // what the validator did (#5031). Assert here for validator behaviour;
+    // assert on the snapshot only after a connect has settled.
+    const RestoredRadioState& restoredStateForTest() const { return m_restoredState; }
     RestoredRadioState currentOperatingState() const override;
     void disconnectRadio() override;
     bool isConnected() const override;

--- a/src/gui/GuardedSlider.h
+++ b/src/gui/GuardedSlider.h
@@ -288,8 +288,9 @@ public:
         // in the CI container; newer Qt builds happen not to query early,
         // which is how this passed locally and shipped (#5064, #4896).
         if (QAccessibleInterface* cached = QAccessible::queryAccessibleInterface(this)) {
-            if (cached->role() != QAccessible::Button)
+            if (cached->role() != QAccessible::Button) {
                 QAccessible::deleteAccessibleInterface(QAccessible::uniqueId(cached));
+            }
         }
     }
     bool isEditable() const { return m_editable; }

--- a/src/gui/GuardedSlider.h
+++ b/src/gui/GuardedSlider.h
@@ -278,6 +278,19 @@ public:
             s_accessibilityFactoryInstalled = true;
             QAccessible::installFactory(scrollableLabelAccessibleFactory);
         }
+        // Evict a STALE cached interface. QAccessible caches one interface per
+        // object for its lifetime, and on Qt 6.8.3 (the shipped Qt) the widget
+        // machinery queries this label before setEditable() runs — so the
+        // cache already holds QLabel's StaticText interface, the factory
+        // above is never consulted for this object again, and every screen
+        // reader announces an editable readout as plain text. Measured, not
+        // theorised: role 41 (StaticText) before eviction, 43 (Button) after,
+        // in the CI container; newer Qt builds happen not to query early,
+        // which is how this passed locally and shipped (#5064, #4896).
+        if (QAccessibleInterface* cached = QAccessible::queryAccessibleInterface(this)) {
+            if (cached->role() != QAccessible::Button)
+                QAccessible::deleteAccessibleInterface(QAccessible::uniqueId(cached));
+        }
     }
     bool isEditable() const { return m_editable; }
     int  editMinimum() const { return m_min; }

--- a/tests/hl2_state_restore_test.cpp
+++ b/tests/hl2_state_restore_test.cpp
@@ -687,8 +687,13 @@ int main(int argc, char** argv)
         stale.filterHighHz = 850.0;
         backend.applyRestoredState(stale);
 
-        const RestoredRadioState snap = backend.currentOperatingState();
-        check(snap.filterLowHz < 0.0 && snap.filterHighHz > 0.0,
+        // Assert on the VALIDATED DOCUMENT, not on currentOperatingState():
+        // that snapshot reads the receivers, and the receivers are seeded from
+        // the document at linkUp — not before. Pre-connect, the snapshot shows
+        // construction defaults whatever the validator did, which is how these
+        // three checks were born red and shipped that way (#5031).
+        const RestoredRadioState& kept = backend.restoredStateForTest();
+        check(kept.filterLowHz < 0.0 && kept.filterHighHz > 0.0,
               "a pre-#4914 CW passband is dropped for one that contains the carrier");
 
         // The same pair under a NON-CW mode is legitimate and must survive:
@@ -699,8 +704,8 @@ int main(int argc, char** argv)
         ssb.filterLowHz  = 350.0;
         ssb.filterHighHz = 850.0;
         usb.applyRestoredState(ssb);
-        const RestoredRadioState usbSnap = usb.currentOperatingState();
-        check(usbSnap.filterLowHz == 350.0 && usbSnap.filterHighHz == 850.0,
+        const RestoredRadioState& usbKept = usb.restoredStateForTest();
+        check(usbKept.filterLowHz == 350.0 && usbKept.filterHighHz == 850.0,
               "a one-sided passband under USB is untouched by the CW guard");
 
         // And a NEW-domain CW pair must pass through unchanged, or the guard
@@ -711,8 +716,8 @@ int main(int argc, char** argv)
         fresh.filterLowHz  = -150.0;
         fresh.filterHighHz =  150.0;
         cw.applyRestoredState(fresh);
-        const RestoredRadioState cwSnap = cw.currentOperatingState();
-        check(cwSnap.filterLowHz == -150.0 && cwSnap.filterHighHz == 150.0,
+        const RestoredRadioState& cwKept = cw.restoredStateForTest();
+        check(cwKept.filterLowHz == -150.0 && cwKept.filterHighHz == 150.0,
               "a new-domain CW passband survives the guard unchanged");
     }
 

--- a/tests/phone_tx_filter_numeric_entry_test.cpp
+++ b/tests/phone_tx_filter_numeric_entry_test.cpp
@@ -445,10 +445,22 @@ int main(int argc, char** argv)
 
     // Qt::Key_Cancel is the same gesture on platforms that send it; VfoWidget
     // treats the two together and so do we.
+    //
+    // Delivered by hand, not QTest::keyClick(): testlib maps a key to its ASCII
+    // text through a table that has no entry for Key_Cancel and aborts on the
+    // miss (QTEST_ASSERT), in every build configuration. Production never goes
+    // through that table — the platform sends a real QKeyEvent — and the
+    // handler keys on the press (GuardedSlider.h eventFilter), so a press and a
+    // release through QApplication::sendEvent is the same delivery the app sees.
     model.setTxFilter(150, 3300);
     if (QLineEdit* ed = openEditor(low)) {
         ed->setText(QStringLiteral("2000"));
-        QTest::keyClick(ed, Qt::Key_Cancel);
+        QKeyEvent cancelOverride(QEvent::ShortcutOverride, Qt::Key_Cancel, Qt::NoModifier);
+        QApplication::sendEvent(ed, &cancelOverride);
+        QKeyEvent cancelPress(QEvent::KeyPress, Qt::Key_Cancel, Qt::NoModifier);
+        QApplication::sendEvent(ed, &cancelPress);
+        QKeyEvent cancelRelease(QEvent::KeyRelease, Qt::Key_Cancel, Qt::NoModifier);
+        QApplication::sendEvent(ed, &cancelRelease);
     }
     check(!low->isEditing() && model.txFilterLow() == 150,
           "Key_Cancel abandons the edit the same way Esc does");

--- a/tests/phone_tx_filter_numeric_entry_test.cpp
+++ b/tests/phone_tx_filter_numeric_entry_test.cpp
@@ -448,10 +448,15 @@ int main(int argc, char** argv)
     //
     // Delivered by hand, not QTest::keyClick(): testlib maps a key to its ASCII
     // text through a table that has no entry for Key_Cancel and aborts on the
-    // miss (QTEST_ASSERT), in every build configuration. Production never goes
-    // through that table — the platform sends a real QKeyEvent — and the
-    // handler keys on the press (GuardedSlider.h eventFilter), so a press and a
-    // release through QApplication::sendEvent is the same delivery the app sees.
+    // miss. On the Qt we ship, 6.8.3, that is fatal — the CI container's own
+    // log is `ASSERT: "false" in .../src/testlib/qasciikey.cpp, line 470`.
+    // Later Qt does not abort (6.11 passes the keyClick), so the reverting
+    // mutation looks green on a dev box; this delivery is correct on every
+    // version rather than only on the one that happens to be installed.
+    // Production never goes through that table — the platform sends a real
+    // QKeyEvent — and the handler keys on the press (GuardedSlider.h
+    // eventFilter), so a press and a release through QApplication::sendEvent
+    // is the same delivery the app sees.
     model.setTxFilter(150, 3300);
     if (QLineEdit* ed = openEditor(low)) {
         ed->setText(QStringLiteral("2000"));

--- a/tests/sanitizers/tsan.supp
+++ b/tests/sanitizers/tsan.supp
@@ -1,38 +1,28 @@
 # ThreadSanitizer suppressions for the weekly sanitizer lane
 # (.github/workflows/sanitizers.yml, TSAN_OPTIONS=suppressions=<this file>).
 #
-# The lane links the stock prebuilt Qt 6.8.3 and the distro's glib and pulse.
-# None of them is TSan-instrumented, and their synchronization is raw futex
-# — invisible to TSan — so every cross-thread handoff INSIDE those libraries
-# is reported as a race whether or not one exists. This file lists exactly
-# the entries that survived adversarial review in #5275: each names a frame
-# inside the uninstrumented library, never one of ours, so a real race in
-# AetherSDR code that happens to run under a queued slot still reports.
+# ONE consumer: the TSan matrix entry, which since #5411 S6 runs on
+# ghcr.io/aethersdr/aethersdr-ci:tsan — an image whose Qt (qtbase and the four
+# modules we link) is itself built with -sanitize thread. That is why this file
+# is SHORT. The Qt entries it used to carry were justified by "the lane links a
+# stock prebuilt Qt and none of it is instrumented"; S6 makes that false, and
+# keeping them would have suppressed exactly the reports the multi-hour image
+# build exists to produce (#5411 review). They are listed in DO-NOT-ADD below
+# so the reasoning is not rediscovered.
 #
-# Every entry carries its caveat. Read it before widening anything.
+# What is left is what is still genuinely outside our instrumentation. Each
+# entry names a frame inside an uninstrumented library, never one of ours, and
+# carries its caveat. Read it before widening anything.
+#
+# If the instrumented Qt produces a new noise class, TRIAGE it — a stack, an
+# issue, and a narrow anchored entry with a caveat. Do not reach for
+# called_from_lib on a library we deliberately instrumented.
 
 # libpulse: the original #3462 finding (June 2026), triaged as pa_mutex_lock
-# on an uninstrumented mutex. Blinds nothing of ours: no AetherSDR code runs
+# on an uninstrumented mutex. The tsan image does not rebuild PulseAudio, so
+# this one is unchanged by S6. Blinds nothing of ours: no AetherSDR code runs
 # inside libpulsecommon.
 called_from_lib:libpulsecommon
-
-# QtGui's threaded raster paint engine hands QImage backing stores between
-# the GUI thread and its raster workers under an uninstrumented lock.
-# ~370 reports per run, all the same handoff. CAVEAT: this also blinds a
-# real cross-thread QImage sharing bug in our code IF the racing access
-# happens inside libQt6Gui's own frames (ours still report). Documented
-# trade; revisit when Qt is built with -sanitize thread (#5275 S6).
-called_from_lib:libQt6Gui.so.6
-
-# Queued-metacall payload handoff: QMetaCallEvent carries the argument copies
-# across the thread boundary, and QMetaType::create/destroy build and tear
-# them down. The synchronization is Qt's own postEvent lock, uninstrumented.
-# These match the CARRIER, not the slot body: a race inside the slot that
-# runs afterwards is in our frames and still reports.
-race:QMetaCallEvent
-race:QCoreApplicationPrivate::sendPostedEvents
-race:QMetaType::create
-race:QMetaType::destroy
 
 # WDSP's io ring buffer (third_party/wdsp/upstream/iobuffs.c). Visible only
 # now that the C sources are instrumented: fexchange2()/upslew2() write the
@@ -42,19 +32,33 @@ race:QMetaType::destroy
 # has no synchronization at all — upstream relies on the ring being deep
 # enough that the writer never laps the reader. That is a by-construction
 # ordering TSan cannot prove, in upstream's real-time path, and a handoff
-# there is a DSP change, not a teardown fix. Exactly these two upstream
-# functions, anchored: a race anywhere else in WDSP still reports.
-# CAVEAT: a ring too shallow for the configured rates would be a real
-# overrun and would hide behind this line; the audible symptom is the tell.
+# there is a DSP change, not a teardown fix.
+#
+# WRITER SIDE ONLY, deliberately. A `race:` entry matches ANY frame in EITHER
+# access's stack, so naming the writer alone still suppresses the whole
+# writer-vs-dexchange slot-reuse report — while leaving the reader side free to
+# report on its own. That matters because dexchange() is also what memcpys the
+# r1/r2 base pointers that destroy_iobuffs() frees, so `race:^dexchange$` would
+# have blinded the teardown use-after-free that patch 4 fixes: a regression of
+# our own fix would have been swallowed by our own suppression (#5411 review).
+# CAVEAT: a ring too shallow for the configured rates would be a real overrun
+# and would hide behind this line; the audible symptom is the tell.
 race:^upslew2$
-race:^dexchange$
+race:^fexchange2$
 
-# ── DO NOT ADD — rejected in #5275 review, each would blind the lane ──────
+# ── DO NOT ADD — rejected in #5275 and #5411 review, each would blind the lane ─
 # Every entry below matches a frame that OUR code executes inside, so a real
 # race whose access sits in a queued slot body — the sendCmd and audio-atomics
 # paths this lane exists to guard — would be swallowed with the false
 # positive. The glib cluster is handled by QT_NO_GLIB=1 in the workflow env
-# instead of a suppression, with zero debt.
+# instead of a suppression, with zero debt. The Qt entries below were REMOVED
+# by #5411: they predate S6's instrumented Qt and now negate it.
+#   race:^dexchange$              <- reader side; hides patch 4's own UAF class
+#   called_from_lib:libQt6Gui.so.6
+#   race:QMetaCallEvent
+#   race:QCoreApplicationPrivate::sendPostedEvents
+#   race:QMetaType::create
+#   race:QMetaType::destroy       <- matches any frame; swallows our destructors
 #   race:qobjectdefs_impl.h
 #   race:QtPrivate::FunctorCall
 #   race:QtPrivate::QCallableObject

--- a/tests/sanitizers/tsan.supp
+++ b/tests/sanitizers/tsan.supp
@@ -34,6 +34,21 @@ race:QCoreApplicationPrivate::sendPostedEvents
 race:QMetaType::create
 race:QMetaType::destroy
 
+# WDSP's io ring buffer (third_party/wdsp/upstream/iobuffs.c). Visible only
+# now that the C sources are instrumented: fexchange2()/upslew2() write the
+# next block into the r1 ring on the caller's thread while wdspmain()'s
+# dexchange() memcpy reads the previous one; the write→read edge is the
+# Sem_BuffReady semaphore, but slot REUSE (reader done → writer overwrites)
+# has no synchronization at all — upstream relies on the ring being deep
+# enough that the writer never laps the reader. That is a by-construction
+# ordering TSan cannot prove, in upstream's real-time path, and a handoff
+# there is a DSP change, not a teardown fix. Exactly these two upstream
+# functions, anchored: a race anywhere else in WDSP still reports.
+# CAVEAT: a ring too shallow for the configured rates would be a real
+# overrun and would hide behind this line; the audible symptom is the tell.
+race:^upslew2$
+race:^dexchange$
+
 # ── DO NOT ADD — rejected in #5275 review, each would blind the lane ──────
 # Every entry below matches a frame that OUR code executes inside, so a real
 # race whose access sits in a queued slot body — the sendCmd and audio-atomics

--- a/tests/sanitizers/tsan.supp
+++ b/tests/sanitizers/tsan.supp
@@ -1,0 +1,50 @@
+# ThreadSanitizer suppressions for the weekly sanitizer lane
+# (.github/workflows/sanitizers.yml, TSAN_OPTIONS=suppressions=<this file>).
+#
+# The lane links the stock prebuilt Qt 6.8.3 and the distro's glib and pulse.
+# None of them is TSan-instrumented, and their synchronization is raw futex
+# — invisible to TSan — so every cross-thread handoff INSIDE those libraries
+# is reported as a race whether or not one exists. This file lists exactly
+# the entries that survived adversarial review in #5275: each names a frame
+# inside the uninstrumented library, never one of ours, so a real race in
+# AetherSDR code that happens to run under a queued slot still reports.
+#
+# Every entry carries its caveat. Read it before widening anything.
+
+# libpulse: the original #3462 finding (June 2026), triaged as pa_mutex_lock
+# on an uninstrumented mutex. Blinds nothing of ours: no AetherSDR code runs
+# inside libpulsecommon.
+called_from_lib:libpulsecommon
+
+# QtGui's threaded raster paint engine hands QImage backing stores between
+# the GUI thread and its raster workers under an uninstrumented lock.
+# ~370 reports per run, all the same handoff. CAVEAT: this also blinds a
+# real cross-thread QImage sharing bug in our code IF the racing access
+# happens inside libQt6Gui's own frames (ours still report). Documented
+# trade; revisit when Qt is built with -sanitize thread (#5275 S6).
+called_from_lib:libQt6Gui.so.6
+
+# Queued-metacall payload handoff: QMetaCallEvent carries the argument copies
+# across the thread boundary, and QMetaType::create/destroy build and tear
+# them down. The synchronization is Qt's own postEvent lock, uninstrumented.
+# These match the CARRIER, not the slot body: a race inside the slot that
+# runs afterwards is in our frames and still reports.
+race:QMetaCallEvent
+race:QCoreApplicationPrivate::sendPostedEvents
+race:QMetaType::create
+race:QMetaType::destroy
+
+# ── DO NOT ADD — rejected in #5275 review, each would blind the lane ──────
+# Every entry below matches a frame that OUR code executes inside, so a real
+# race whose access sits in a queued slot body — the sendCmd and audio-atomics
+# paths this lane exists to guard — would be swallowed with the false
+# positive. The glib cluster is handled by QT_NO_GLIB=1 in the workflow env
+# instead of a suppression, with zero debt.
+#   race:qobjectdefs_impl.h
+#   race:QtPrivate::FunctorCall
+#   race:QtPrivate::QCallableObject
+#   race:QObject::event
+#   called_from_lib:libQt6Core.so.6
+#   called_from_lib:libglib
+#   race:CloseHandle
+#   race:wdspmain

--- a/tests/thumbdv_queue_test.c
+++ b/tests/thumbdv_queue_test.c
@@ -4,7 +4,6 @@
 #include "utils.h"
 
 #include <pthread.h>
-#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -13,6 +12,13 @@
 #include <errno.h>
 #include <poll.h>
 #include <pty.h>
+// Linux-only, with the atomics it declares: every use is inside the
+// __linux__ fake-DV3000 block below. MSVC's vcruntime_c11_stdatomic.h is a
+// hard #error below C11 and this TU compiles at the MSVC default, so an
+// unconditional include breaks check-windows even though Windows compiles
+// none of the code that needs it. <pthread.h> above survives only because
+// smartsdr-dsp/compat/windows shims it; there is no shim for this one.
+#include <stdatomic.h>
 #include <unistd.h>
 #endif
 

--- a/tests/thumbdv_queue_test.c
+++ b/tests/thumbdv_queue_test.c
@@ -4,6 +4,7 @@
 #include "utils.h"
 
 #include <pthread.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -25,7 +26,11 @@ void sched_waveform_setHandle(FT_HANDLE * handle)
 #if defined(__linux__)
 typedef struct fake_dv3000 {
     int master_fd;
-    volatile int stop;
+    // atomic, not volatile: volatile is not a synchronization primitive and
+    // TSan (rightly) reports the main thread's store racing this thread's
+    // load. responses is written by this thread only and read by main only
+    // AFTER pthread_join, which is the happens-before that makes it safe.
+    atomic_int stop;
     unsigned int responses;
 } fake_dv3000;
 
@@ -48,7 +53,7 @@ static int read_exact(int fd, unsigned char * buffer, size_t length)
 static void * fake_dv3000_thread(void * opaque)
 {
     fake_dv3000 * fake = (fake_dv3000 *)opaque;
-    while (!fake->stop) {
+    while (!atomic_load(&fake->stop)) {
         struct pollfd pfd = { .fd = fake->master_fd, .events = POLLIN, .revents = 0 };
         const int ready = poll(&pfd, 1, 100);
         if (ready <= 0 || (pfd.revents & POLLIN) == 0) {
@@ -107,11 +112,12 @@ static int test_serial_probe(void)
 
     setenv("AETHER_DV_THUMBDV_SERIAL", slave_name, 1);
     failed += thumbDV_probeConfiguredSerial() != 0;
-    failed += fake.responses < 2U;
     unsetenv("AETHER_DV_THUMBDV_SERIAL");
 
-    fake.stop = 1;
+    atomic_store(&fake.stop, 1);
     pthread_join(fake_thread, NULL);
+    // Read the count only after the join: the fake thread is the sole writer.
+    failed += fake.responses < 2U;
     close(master_fd);
     close(slave_fd);
     return failed;

--- a/third_party/wdsp/AETHERSDR-PATCHES.md
+++ b/third_party/wdsp/AETHERSDR-PATCHES.md
@@ -2,7 +2,7 @@
 
 The source snapshot is pinned to TAPR/OpenHPSDR-wdsp commit
 `584e8aca5ba1c4c6bc66fc0cc164ce567c8ba1e3` (`Release Version 2.00`).
-AetherSDR carries three teardown fixes in the otherwise exact `Source/*.[ch]`
+AetherSDR carries four teardown fixes in the otherwise exact `Source/*.[ch]`
 snapshot:
 
 1. `upstream/nbp.c`: `destroy_notchdb()` now frees the `notchdb` object after
@@ -11,10 +11,29 @@ snapshot:
    member allocations.
 3. `upstream/cfir.c`: `cfir_impulse()` now frees its temporary transition table
    before returning the generated impulse.
+4. `upstream/channel.h`, `upstream/main.c`, `upstream/channel.c`: an exit
+   handshake between `wdspmain()` and `pre_main_destroy()`. Upstream's only
+   barrier between the detached worker's exit and `destroy_main()` /
+   `post_main_destroy()` freeing the semaphore, mutex and buffers it still
+   touches was `Sleep(25)` — a scheduling bet, not synchronization, and under
+   load or a sanitizer the worker is still in `pthread_cond_wait()` on freed
+   memory. `struct _ch` gains `mainExited`; `wdspmain()` stores 1 to it as its
+   last statement; `start_thread()` resets it before every `_beginthread`
+   (so the `SetInputBuffsize` / `SetDSPBuffsize` / `SetInputSamplerate` /
+   `SetDSPSamplerate` rebuilds are covered too); `pre_main_destroy()` polls it
+   with a 1 s cap and then falls through, because upstream ignores thread-
+   creation failure and an unbounded wait would hang `CloseChannel()`. The
+   port's Interlocked shims are seq_cst `__atomic_*` builtins, so the edge is
+   real to TSan, not merely quiet. `flushChannel()` has the same detached
+   shape and no handshake; it has not surfaced, and gets the same treatment
+   if it does.
 
 Without these lines, opening and closing one RX channel leaks one `notchdb`
 object and two NURBS objects, while one TX channel leaks one transition table.
 `wdsp_channel_test` detects both paths deterministically.
+Without the fourth, every channel close is a use-after-free race on the
+worker thread; `wdsp_channel_test` and the HL2 backend tests show it under
+ThreadSanitizer.
 
 When refreshing WDSP, first check whether upstream contains equivalent frees.
 If it does, drop the corresponding local patch. Otherwise reapply only these

--- a/third_party/wdsp/AETHERSDR-PATCHES.md
+++ b/third_party/wdsp/AETHERSDR-PATCHES.md
@@ -32,18 +32,24 @@ snapshot:
 
    Three details are not obvious and were all found in review of #5411:
 
-   - **The worker has two exits, not one.** `dexchange()` (`iobuffs.c`) begins
-     `if (!_InterlockedAnd (&ch[channel].run, 1)) _endthread();`, so a worker
-     that is inside the DSP switch when `run` clears terminates there and never
-     reaches `wdspmain()`'s tail. That site now releases `csDSP` — which
-     `_endthread()` does not unwind, leaving `post_main_destroy()` to call
-     `DeleteCriticalSection` on a held section — and completes the same
-     handshake.
+   - **The worker had two exits; it now has one.** `dexchange()` (`iobuffs.c`)
+     began `if (!_InterlockedAnd (&ch[channel].run, 1)) _endthread();`, so a
+     worker inside the DSP switch when `run` cleared terminated there: with
+     `csDSP` held, since `_endthread()` does not unwind and `wdspmain()` calls
+     `dexchange()` inside the section, leaving `post_main_destroy()` to call
+     `DeleteCriticalSection` on a locked section — and without ever reaching
+     the exit handshake. `dexchange()` now **returns** non-zero instead
+     (`int` rather than `void`, two call sites, both in `main.c`) and
+     `wdspmain()` unlocks and leaves the loop, so the tail is the single exit.
+     Making it single is what lets the handshake store a generation held in a
+     **local**: an abandoned worker must not read its generation back out of
+     `ch[]`, because by then that slot can belong to its successor and the
+     acknowledgement would be made on the successor's behalf.
    - **`pre_main_destroy()` sets `exec_bypass` BEFORE clearing `run`**, the
      reverse of upstream's order, so a worker that has not yet read the bypass
-     takes the bypass branch rather than `dexchange()`'s `_endthread()`. That
-     narrows the window; it does not close it, which is why the `_endthread()`
-     site stores the handshake too.
+     takes the bypass branch rather than unwinding through `dexchange()`. That
+     narrows the window and saves a wakeup; correctness does not rest on it,
+     because either route now leaves through `wdspmain()`'s tail.
    - **The flag is generation-valued, not 0/1.** If a wait ever falls through
      its cap the old worker is still alive and will store eventually. With a
      0/1 flag that late store would land on the *next* worker's slot and

--- a/third_party/wdsp/AETHERSDR-PATCHES.md
+++ b/third_party/wdsp/AETHERSDR-PATCHES.md
@@ -11,22 +11,48 @@ snapshot:
    member allocations.
 3. `upstream/cfir.c`: `cfir_impulse()` now frees its temporary transition table
    before returning the generated impulse.
-4. `upstream/channel.h`, `upstream/main.c`, `upstream/channel.c`: an exit
-   handshake between `wdspmain()` and `pre_main_destroy()`. Upstream's only
-   barrier between the detached worker's exit and `destroy_main()` /
-   `post_main_destroy()` freeing the semaphore, mutex and buffers it still
-   touches was `Sleep(25)` — a scheduling bet, not synchronization, and under
-   load or a sanitizer the worker is still in `pthread_cond_wait()` on freed
-   memory. `struct _ch` gains `mainExited`; `wdspmain()` stores 1 to it as its
-   last statement; `start_thread()` resets it before every `_beginthread`
-   (so the `SetInputBuffsize` / `SetDSPBuffsize` / `SetInputSamplerate` /
-   `SetDSPSamplerate` rebuilds are covered too); `pre_main_destroy()` polls it
-   with a 1 s cap and then falls through, because upstream ignores thread-
-   creation failure and an unbounded wait would hang `CloseChannel()`. The
-   port's Interlocked shims are seq_cst `__atomic_*` builtins, so the edge is
-   real to TSan, not merely quiet. `flushChannel()` has the same detached
-   shape and no handshake; it has not surfaced, and gets the same treatment
-   if it does.
+4. `upstream/channel.h`, `upstream/main.c`, `upstream/channel.c`,
+   `upstream/iobuffs.c`: an exit handshake between the DSP worker and
+   `pre_main_destroy()`. Upstream's only barrier between the detached worker's
+   exit and `destroy_main()` / `post_main_destroy()` freeing the semaphore,
+   mutex and buffers it still touches was `Sleep(25)` — a scheduling bet, not
+   synchronization, and under load or a sanitizer the worker is still in
+   `pthread_cond_wait()` on freed memory.
+
+   `struct _ch` gains `mainGen`, `mainRunGen` and `mainExited`.
+   `start_thread()` increments `mainGen` before every `_beginthread` (so the
+   `SetInputBuffsize` / `SetDSPBuffsize` / `SetInputSamplerate` /
+   `SetDSPSamplerate` rebuilds are covered too); `wdspmain()` publishes that
+   value in `mainRunGen` at entry and stores it into `mainExited` as its last
+   statement; `pre_main_destroy()` polls until `mainExited == mainGen`, with a
+   1 s cap and then falls through, because upstream ignores thread-creation
+   failure and an unbounded wait would hang `CloseChannel()`. The port's
+   Interlocked shims are seq_cst `__atomic_*` builtins, so the edge is real to
+   TSan, not merely quiet.
+
+   Three details are not obvious and were all found in review of #5411:
+
+   - **The worker has two exits, not one.** `dexchange()` (`iobuffs.c`) begins
+     `if (!_InterlockedAnd (&ch[channel].run, 1)) _endthread();`, so a worker
+     that is inside the DSP switch when `run` clears terminates there and never
+     reaches `wdspmain()`'s tail. That site now releases `csDSP` — which
+     `_endthread()` does not unwind, leaving `post_main_destroy()` to call
+     `DeleteCriticalSection` on a held section — and completes the same
+     handshake.
+   - **`pre_main_destroy()` sets `exec_bypass` BEFORE clearing `run`**, the
+     reverse of upstream's order, so a worker that has not yet read the bypass
+     takes the bypass branch rather than `dexchange()`'s `_endthread()`. That
+     narrows the window; it does not close it, which is why the `_endthread()`
+     site stores the handshake too.
+   - **The flag is generation-valued, not 0/1.** If a wait ever falls through
+     its cap the old worker is still alive and will store eventually. With a
+     0/1 flag that late store would land on the *next* worker's slot and
+     satisfy the following wait for free, silently disabling the handshake for
+     the rest of the channel's life. A stale generation never equals the
+     current `mainGen`, so it is inert.
+
+   `flushChannel()` has the same detached shape and no handshake; it has not
+   surfaced, and gets the same treatment if it does.
 
 Without these lines, opening and closing one RX channel leaks one `notchdb`
 object and two NURBS objects, while one TX channel leaks one transition table.

--- a/third_party/wdsp/upstream/channel.c
+++ b/third_party/wdsp/upstream/channel.c
@@ -30,6 +30,9 @@ struct _ch ch[MAX_CHANNELS];
 
 void start_thread (int channel)
 {
+	// AetherSDR patch 4: arm the exit handshake before the thread exists, on every
+	// (re)build path — OpenChannel and the SetInput*/SetDSP* rebuilds all come here.
+	InterlockedExchange (&ch[channel].mainExited, 0);
 	HANDLE handle = (HANDLE) _beginthread(wdspmain, 0, (void *)(uintptr_t)channel);
 	//SetThreadPriority(handle, THREAD_PRIORITY_HIGHEST);
 }
@@ -107,7 +110,23 @@ void pre_main_destroy (int channel)
 	InterlockedBitTestAndReset (&ch[channel].run, 0);
 	InterlockedBitTestAndSet (&ch[channel].iob.pc->exec_bypass, 0);
 	ReleaseSemaphore (a->Sem_BuffReady, 1, 0);
-	Sleep (25);
+	// AetherSDR patch 4. Upstream slept 25 ms here as its only barrier between
+	// the worker's exit and destroy_main()/post_main_destroy() freeing the
+	// semaphore, mutex and buffers the worker is still touching. A sleep is a
+	// scheduling bet, not synchronization: a starved worker leaves
+	// pthread_cond_wait() on freed memory (TSan: 116 reports, 21 failing tests
+	// across the HL2/WDSP family, #5275). Wait for the worker's own exit store
+	// instead. BOUNDED, because upstream ignores thread-creation failure and an
+	// unbounded wait would then hang CloseChannel() forever; falling through
+	// after the cap restores upstream's behaviour exactly, no worse.
+	{
+		int waited = 0;
+		while (!_InterlockedAnd (&ch[channel].mainExited, 1) && waited < 1000)
+		{
+			Sleep (1);
+			++waited;
+		}
+	}
 }
 
 void post_main_destroy (int channel)

--- a/third_party/wdsp/upstream/channel.c
+++ b/third_party/wdsp/upstream/channel.c
@@ -116,12 +116,13 @@ void pre_main_destroy (int channel)
 	// AetherSDR patch 4: exec_bypass BEFORE run, which is the reverse of
 	// upstream's order. The worker reads exec_bypass and then, inside
 	// dexchange(), reads run (iobuffs.c). Clearing run first opens a window
-	// where it sees "not bypassed" and then "not running" and takes
-	// dexchange()'s _endthread() — an exit that is not wdspmain()'s. Setting
-	// the bypass first makes the bypass branch win for any worker that has not
-	// yet read it. The window is narrowed, not closed (a worker can read
-	// exec_bypass just before this line), which is why iobuffs.c's
-	// _endthread() site also stores the handshake.
+	// where it sees "not bypassed" and then "not running" and unwinds through
+	// dexchange()'s early return. Setting the bypass first makes the bypass
+	// branch win for any worker that has not yet read it. The window is
+	// narrowed, not closed — a worker can read exec_bypass just before this
+	// line — but either way the worker leaves through wdspmain()'s tail and
+	// performs the handshake there, so correctness does not rest on the
+	// ordering; it only saves a wakeup.
 	InterlockedBitTestAndSet (&ch[channel].iob.pc->exec_bypass, 0);
 	InterlockedBitTestAndReset (&ch[channel].run, 0);
 	ReleaseSemaphore (a->Sem_BuffReady, 1, 0);

--- a/third_party/wdsp/upstream/channel.c
+++ b/third_party/wdsp/upstream/channel.c
@@ -32,7 +32,13 @@ void start_thread (int channel)
 {
 	// AetherSDR patch 4: arm the exit handshake before the thread exists, on every
 	// (re)build path — OpenChannel and the SetInput*/SetDSP* rebuilds all come here.
-	InterlockedExchange (&ch[channel].mainExited, 0);
+	// A GENERATION, not a 0/1 flag. If a previous pre_main_destroy() fell through
+	// its cap, that worker is still alive and will store eventually; with a flag
+	// its late store would land on the NEW worker's slot and satisfy the next
+	// wait for free, silently disabling the handshake for the rest of the
+	// channel's life (#5411 review). Storing the generation makes a stale store
+	// inert: it writes an old number that never equals the current mainGen.
+	InterlockedIncrement (&ch[channel].mainGen);
 	HANDLE handle = (HANDLE) _beginthread(wdspmain, 0, (void *)(uintptr_t)channel);
 	//SetThreadPriority(handle, THREAD_PRIORITY_HIGHEST);
 }
@@ -107,8 +113,17 @@ void pre_main_destroy (int channel)
 {
 	IOB a = ch[channel].iob.pc;
 	InterlockedBitTestAndReset (&ch[channel].exchange, 0);
-	InterlockedBitTestAndReset (&ch[channel].run, 0);
+	// AetherSDR patch 4: exec_bypass BEFORE run, which is the reverse of
+	// upstream's order. The worker reads exec_bypass and then, inside
+	// dexchange(), reads run (iobuffs.c). Clearing run first opens a window
+	// where it sees "not bypassed" and then "not running" and takes
+	// dexchange()'s _endthread() — an exit that is not wdspmain()'s. Setting
+	// the bypass first makes the bypass branch win for any worker that has not
+	// yet read it. The window is narrowed, not closed (a worker can read
+	// exec_bypass just before this line), which is why iobuffs.c's
+	// _endthread() site also stores the handshake.
 	InterlockedBitTestAndSet (&ch[channel].iob.pc->exec_bypass, 0);
+	InterlockedBitTestAndReset (&ch[channel].run, 0);
 	ReleaseSemaphore (a->Sem_BuffReady, 1, 0);
 	// AetherSDR patch 4. Upstream slept 25 ms here as its only barrier between
 	// the worker's exit and destroy_main()/post_main_destroy() freeing the
@@ -120,8 +135,9 @@ void pre_main_destroy (int channel)
 	// unbounded wait would then hang CloseChannel() forever; falling through
 	// after the cap restores upstream's behaviour exactly, no worse.
 	{
+		const long gen = _InterlockedAnd (&ch[channel].mainGen, ~0L);
 		int waited = 0;
-		while (!_InterlockedAnd (&ch[channel].mainExited, 1) && waited < 1000)
+		while (_InterlockedAnd (&ch[channel].mainExited, ~0L) != gen && waited < 1000)
 		{
 			Sleep (1);
 			++waited;

--- a/third_party/wdsp/upstream/channel.h
+++ b/third_party/wdsp/upstream/channel.h
@@ -34,8 +34,7 @@ struct _ch
 	volatile long run;			// when 1, thread loops; when 0, thread terminates
 	volatile long exchange;		// when 1, fexchange() operates; when 0, it just returns
 	volatile long mainGen;		// AetherSDR patch 4: launch sequence; start_thread() increments it per worker
-	volatile long mainRunGen;	// AetherSDR patch 4: the generation the live worker is running as
-	volatile long mainExited;	// AetherSDR patch 4: the worker stores ITS OWN generation here as its last act; pre_main_destroy() waits for it to equal mainGen. Generation-valued rather than 0/1 so a late store from an abandoned worker cannot satisfy a later wait
+	volatile long mainExited;	// AetherSDR patch 4: the worker stores ITS OWN generation (held in a local, never read back from ch[]) here as its last act; pre_main_destroy() waits for it to equal mainGen. Generation-valued rather than 0/1 so a late store from an abandoned worker cannot satisfy a later wait
 	int in_rate;				// input samplerate
 	int out_rate;				// output samplerate
 	int in_size;				// input buffsize (complex samples) in a fexchange() operation

--- a/third_party/wdsp/upstream/channel.h
+++ b/third_party/wdsp/upstream/channel.h
@@ -33,7 +33,9 @@ struct _ch
 	int type;
 	volatile long run;			// when 1, thread loops; when 0, thread terminates
 	volatile long exchange;		// when 1, fexchange() operates; when 0, it just returns
-	volatile long mainExited;	// AetherSDR patch 4: set by wdspmain() as its last act; pre_main_destroy() waits on it instead of Sleep(25)
+	volatile long mainGen;		// AetherSDR patch 4: launch sequence; start_thread() increments it per worker
+	volatile long mainRunGen;	// AetherSDR patch 4: the generation the live worker is running as
+	volatile long mainExited;	// AetherSDR patch 4: the worker stores ITS OWN generation here as its last act; pre_main_destroy() waits for it to equal mainGen. Generation-valued rather than 0/1 so a late store from an abandoned worker cannot satisfy a later wait
 	int in_rate;				// input samplerate
 	int out_rate;				// output samplerate
 	int in_size;				// input buffsize (complex samples) in a fexchange() operation

--- a/third_party/wdsp/upstream/channel.h
+++ b/third_party/wdsp/upstream/channel.h
@@ -33,6 +33,7 @@ struct _ch
 	int type;
 	volatile long run;			// when 1, thread loops; when 0, thread terminates
 	volatile long exchange;		// when 1, fexchange() operates; when 0, it just returns
+	volatile long mainExited;	// AetherSDR patch 4: set by wdspmain() as its last act; pre_main_destroy() waits on it instead of Sleep(25)
 	int in_rate;				// input samplerate
 	int out_rate;				// output samplerate
 	int in_size;				// input buffsize (complex samples) in a fexchange() operation

--- a/third_party/wdsp/upstream/iobuffs.c
+++ b/third_party/wdsp/upstream/iobuffs.c
@@ -580,23 +580,27 @@ void fexchange2 (int channel, INREAL *Iin, INREAL *Qin, OUTREAL *Iout, OUTREAL *
 	}
 }
 
-void dexchange (int channel, double* in, double* out)
+int dexchange (int channel, double* in, double* out)
 {
 	int n;
 	IOB a = ch[channel].iob.pd;
 	if (!_InterlockedAnd (&ch[channel].run, 1))
 	{
-		// AetherSDR patch 4: wdspmain() calls us with csDSP HELD, and
-		// _endthread() does not unwind — upstream left the section locked for
-		// post_main_destroy()'s DeleteCriticalSection() to find. Release it,
-		// then complete the SAME exit handshake wdspmain()'s tail performs, or
-		// pre_main_destroy() waits out its full cap on a worker that is already
-		// gone and then falls through with no barrier at all (#5411 review).
-		// mainRunGen is this worker's own generation, published at entry.
-		LeaveCriticalSection (&ch[channel].csDSP);
-		InterlockedExchange (&ch[channel].mainExited,
-		                     _InterlockedAnd (&ch[channel].mainRunGen, ~0L));
-		_endthread();
+		// AetherSDR patch 4: upstream called _endthread() here — terminating
+		// the worker mid-function, with csDSP HELD (wdspmain() calls us inside
+		// it and _endthread() does not unwind, so post_main_destroy() later
+		// found a locked section to DeleteCriticalSection), and skipping
+		// wdspmain()'s exit handshake entirely, so pre_main_destroy() waited
+		// out its full cap on a thread that was already gone and then fell
+		// through with no barrier at all.
+		//
+		// RETURN instead, and let the caller unwind. That makes wdspmain()'s
+		// tail the worker's single exit, which is what lets the handshake
+		// store a generation held in a LOCAL — shared state would be wrong
+		// here: after a fall-through the abandoned worker is still alive, and
+		// anything it reads from ch[] could belong to its successor (#5411
+		// second-opinion review).
+		return 1;
 	}
 
 	EnterCriticalSection (&a->r2_ControlSection);
@@ -614,4 +618,5 @@ void dexchange (int channel, double* in, double* out)
 	memcpy (out, a->r1_baseptr + 2 * a->r1_outidx, a->r1_outsize * sizeof (complex));
 	if ((a->r1_outidx += a->r1_outsize) == a->r1_active_buffsize)
 		a->r1_outidx = 0;
+	return 0;
 }

--- a/third_party/wdsp/upstream/iobuffs.c
+++ b/third_party/wdsp/upstream/iobuffs.c
@@ -584,7 +584,20 @@ void dexchange (int channel, double* in, double* out)
 {
 	int n;
 	IOB a = ch[channel].iob.pd;
-	if (!_InterlockedAnd (&ch[channel].run, 1)) _endthread();
+	if (!_InterlockedAnd (&ch[channel].run, 1))
+	{
+		// AetherSDR patch 4: wdspmain() calls us with csDSP HELD, and
+		// _endthread() does not unwind — upstream left the section locked for
+		// post_main_destroy()'s DeleteCriticalSection() to find. Release it,
+		// then complete the SAME exit handshake wdspmain()'s tail performs, or
+		// pre_main_destroy() waits out its full cap on a worker that is already
+		// gone and then falls through with no barrier at all (#5411 review).
+		// mainRunGen is this worker's own generation, published at entry.
+		LeaveCriticalSection (&ch[channel].csDSP);
+		InterlockedExchange (&ch[channel].mainExited,
+		                     _InterlockedAnd (&ch[channel].mainRunGen, ~0L));
+		_endthread();
+	}
 
 	EnterCriticalSection (&a->r2_ControlSection);
 	a->r2_havesamps += a->r2_insize;

--- a/third_party/wdsp/upstream/iobuffs.h
+++ b/third_party/wdsp/upstream/iobuffs.h
@@ -92,6 +92,6 @@ void fexchange0 (int channel, double* in, double* out, int* error);
 PORT	// separate I/Q buffers
 extern void fexchange2 (int channel, INREAL *Iin, INREAL *Qin, OUTREAL *Iout, OUTREAL *Qout, int* error);
 
-extern void dexchange (int channel, double* in, double* out);
+extern int dexchange (int channel, double* in, double* out);	// AetherSDR patch 4: non-zero means "run cleared, unwind"; upstream called _endthread() here
 
 #endif

--- a/third_party/wdsp/upstream/main.c
+++ b/third_party/wdsp/upstream/main.c
@@ -58,6 +58,9 @@ void wdspmain (void *pargs)
 		LeaveCriticalSection (&ch[channel].csDSP);
 	}
 	if (hTask != 0) AvRevertMmThreadCharacteristics (hTask);
+	// AetherSDR patch 4: the LAST statement. After this store the thread touches
+	// nothing in ch[channel] or its iob, so pre_main_destroy() may free them.
+	InterlockedExchange (&ch[channel].mainExited, 1);
 }
 
 void create_main (int channel)

--- a/third_party/wdsp/upstream/main.c
+++ b/third_party/wdsp/upstream/main.c
@@ -34,28 +34,40 @@ void wdspmain (void *pargs)
 	else SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST);
 
 	int channel = (int)(uintptr_t)pargs;
-	// AetherSDR patch 4: this worker's generation, published so the OTHER exit
-	// path (dexchange()'s _endthread(), iobuffs.c) can store the same value.
+	// AetherSDR patch 4: this worker's generation, read once and kept in a
+	// LOCAL for the exit store below. Deliberately not published anywhere in
+	// ch[]: a successor worker would overwrite it, and an abandoned worker
+	// would then acknowledge on the successor's behalf (#5411 second-opinion
+	// review). dexchange() returning rather than calling _endthread() is what
+	// makes one local sufficient.
 	const long myGen = _InterlockedAnd (&ch[channel].mainGen, ~0L);
-	InterlockedExchange (&ch[channel].mainRunGen, myGen);
 	while (_InterlockedAnd (&ch[channel].run, 1))
 	{
 		WaitForSingleObject(ch[channel].iob.pd->Sem_BuffReady,INFINITE);
 		EnterCriticalSection (&ch[channel].csDSP);
 		if (!_InterlockedAnd (&ch[channel].iob.pd->exec_bypass, 1))
 		{
+			// AetherSDR patch 4: dexchange() reports "run cleared, unwind"
+			// rather than calling _endthread() mid-function. Unlock and leave
+			// the loop so the tail below runs — the worker's single exit.
+			int stop = 0;
 			switch (ch[channel].type)
 			{
 			case 0:		// rxa
-				dexchange (channel, rxa[channel].outbuff, rxa[channel].inbuff);
-				xrxa (channel);
+				stop = dexchange (channel, rxa[channel].outbuff, rxa[channel].inbuff);
+				if (!stop) xrxa (channel);
 				break;
 			case 1:		// txa
-				dexchange (channel, txa[channel].outbuff, txa[channel].inbuff);
-				xtxa (channel);
+				stop = dexchange (channel, txa[channel].outbuff, txa[channel].inbuff);
+				if (!stop) xtxa (channel);
 				break;
 			case 31:	//
 
+				break;
+			}
+			if (stop)
+			{
+				LeaveCriticalSection (&ch[channel].csDSP);
 				break;
 			}
 		}

--- a/third_party/wdsp/upstream/main.c
+++ b/third_party/wdsp/upstream/main.c
@@ -34,6 +34,10 @@ void wdspmain (void *pargs)
 	else SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST);
 
 	int channel = (int)(uintptr_t)pargs;
+	// AetherSDR patch 4: this worker's generation, published so the OTHER exit
+	// path (dexchange()'s _endthread(), iobuffs.c) can store the same value.
+	const long myGen = _InterlockedAnd (&ch[channel].mainGen, ~0L);
+	InterlockedExchange (&ch[channel].mainRunGen, myGen);
 	while (_InterlockedAnd (&ch[channel].run, 1))
 	{
 		WaitForSingleObject(ch[channel].iob.pd->Sem_BuffReady,INFINITE);
@@ -60,7 +64,9 @@ void wdspmain (void *pargs)
 	if (hTask != 0) AvRevertMmThreadCharacteristics (hTask);
 	// AetherSDR patch 4: the LAST statement. After this store the thread touches
 	// nothing in ch[channel] or its iob, so pre_main_destroy() may free them.
-	InterlockedExchange (&ch[channel].mainExited, 1);
+	// Stores THIS worker's generation, so a store from an abandoned worker can
+	// never satisfy a later generation's wait.
+	InterlockedExchange (&ch[channel].mainExited, myGen);
 }
 
 void create_main (int channel)


### PR DESCRIPTION
## Summary

Implements the full #5275 plan (S1–S6) and the S5 decisions taken 2026-09-03, then acts on what the repaired lane immediately found. Status comment with the same content: https://github.com/aethersdr/AetherSDR/issues/5275#issuecomment-5535372069

**S1 — UBSan** `AutomationServer`: the five connect-path timers used `qApp` (a `static_cast<QApplication*>`) under a `QCoreApplication` host; `QCoreApplication::instance()`. The ASan job's only genuine sanitizer finding.

**S2 — born-red tests** `hl2_state_restore_test` asserts on the validated document via a `restoredStateForTest()` seam (the snapshot it read is seeded at linkUp, not before — #5031). `phone_tx_filter_numeric_entry_test` delivers Key_Cancel by hand (testlib's key table aborts on it). `docs/automation-bridge.md` regenerated (`bridge_docs_check` was red on main). `hl2_backend_test` item is moot — that target is inside a retired bracket comment and not built.

**S3 — WDSP vendored patch 4** `mainExited` exit handshake replacing `Sleep(25)` in `pre_main_destroy()`, bounded at 1 s. **A/B under TSan with C instrumented: 45 CloseHandle / wdspAlignedFree reports → 0.** Documented in `AETHERSDR-PATCHES.md`. Grows the vendored diff — maintainer review.

**S4 — lane config** `tests/sanitizers/tsan.supp` (the six surviving entries + DO-NOT-ADD block), `QT_NO_GLIB=1`, and **`CFLAGS`**: the lane only ever set `CXXFLAGS`, so every vendored C library (WDSP, its port, liquid-dsp, rnnoise…) was uninstrumented in both jobs. That is what made WDSP's own handshakes invisible to TSan.

**Report body (moved here from #5405).** The sticky-issue body was `grep -B 80 SUMMARY`, so once a standing UBSan report sat at test ~178 of 334, every append from 2026-08-03 on was 80 lines of context around it and nothing else — ctest's own verdict never reached the issue. `radio_capability_gating_test` failed a plain assertion on 2026-08-31 and #4330 does not name it. The body now leads with the pass/fail line and the failed-test list, which is what the S5 fingerprint work needs above it. `--no-tests=error` on the unfiltered run. The weekly cron moves to Saturday 02:00 Pacific. #5405 no longer touches `sanitizers.yml`.

**S5 — hygiene** Fingerprint in the sticky-issue title so a new signature opens a new issue; plain-test-failure runs fingerprint ctest's failed list instead of `sha256("")`. Narrow anchored suppression for WDSP's ring-buffer slot reuse (`^upslew2$`, `^dexchange$`). New issues open at `priority: high`. #4360 closed; #5406 / #5407 / #5408 filed.

**S6 — TSan-built Qt** `.github/docker/Dockerfile.tsan`: Qt 6.8.3 (qtbase, shadertools, websockets, serialport, multimedia) with `FEATURE_sanitize_thread`, qtkeychain rebuilt against it, `ldd` assertion that libtsan is a DT_NEEDED of QtCore; published as `aethersdr-ci:tsan` by a second job in `docker-ci-image.yml`; the TSan matrix entry uses it via a per-entry `container:`.

## What the working lane found (both fixed here)

- **Shipped a11y defect.** On Qt 6.8.3 — the Qt every release uses — `QAccessible` caches QLabel's StaticText interface for a `ScrollableLabel` before `setEditable()` runs, so the factory is never consulted and screen readers announce editable readouts as plain text with no press action (docs/a11y.md contract from #5064; #4896). Red in the CI container on every run, masked on dev machines by a newer Qt. `setEditable()` now evicts the stale interface. Measured in the image: role 41 → 43.
- `thumbdv_queue_test`: the test's own volatile stop flag and a count read before the join.

Remaining TSan findings, filed and NOT addressed here (no closing keyword intended) — #5409 (`test_event_loop_test` QSignalSpy cross-thread), #5410 (`hl2_spectrum_rate_test` wall-clock under slowdown).

## Verification

| Run | Result |
|---|---|
| ASan+UBSan, full suite, C instrumented, local | **344/344, zero reports** |
| TSan A/B on 5 WDSP/HL2 tests, C instrumented | 45 reports without S3 → 0 with |
| TSan, full suite, **inside the TSan image** (Qt instrumented) | 342 tests, **6 reports total**, 338 pass; the 4 failures are the two repairs above plus the two filed issues, #5409 and #5410 |

Last week's run: ~1,300 reports, 68 failing tests.

## Merge ordering

`aethersdr-ci:tsan` does not exist until `docker-ci-image.yml` runs on main after this merges (a Qt source build, a couple of hours on a hosted runner). A Saturday sanitizer run before that completes fails at image pull — let the image job finish, then dispatch the sanitizer workflow by hand if you want the result before Saturday. Caching that build is a follow-up (split Qt image + registry layer cache), discussed and not in this PR.

**Merge order: this PR is first of three.** #5412 (post-merge full suite) then #5405 (freeze the per-PR gate) follow, and #5405's premise — that a demoted test still runs somewhere a failure is legible — is only true once this lands. The `priority: high` label commit, the Saturday cron and the report-body fix all live here now; #5405 no longer touches `sanitizers.yml`.

Refs #5275, #5032, #4330, #3462, #5031, #4896.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

