### PR TITLE
fix(hl2): bound and log the DSP-setup phase (refs #5413)

### DIFF
--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -56,6 +56,11 @@ struct Hl2Backend::PendingConnect {
     // How long this phase has been running. Belongs to the connect rather than
     // to the backend so a superseded build cannot report the new one's elapsed.
     QElapsedTimer clock;
+    // Set when the phase watchdog has already released the caller with a
+    // dspSetupFinished(). The build is still running and finishDspSetup() will
+    // reach its stale branch later; this stops that branch emitting a second
+    // end-of-phase edge for one connect.
+    bool finishSignalled = false;
 };
 
 // What the I/O thread carries back. Parallel arrays indexed by DDC rather than
@@ -2109,16 +2114,30 @@ void Hl2Backend::onDspSetupWatchdog()
     // INVALIDATE, DO NOT TEAR DOWN. The I/O thread may be inside configure() on
     // these very chains — WDSP's OpenChannel does not return early, so the build
     // cannot be cancelled — and freeing them from this thread would be a
-    // use-after-free. Bumping the generation is the same one-liner
-    // disconnectRadio() uses: the build runs to completion and finishDspSetup()
-    // takes its stale branch, which releases what it built. (#5413 triage.)
+    // use-after-free. So do exactly what disconnectRadio() does: bump the
+    // generation and LEAVE m_pendingConnect SET. The build runs to completion,
+    // finishDspSetup() takes its stale branch, and that branch is what releases
+    // the chains and re-drives anything queued behind them.
+    //
+    // Resetting pending here instead would disable the very mechanism this
+    // comment relies on: finishDspSetup() would return at its
+    // `if (!m_pendingConnect)` guard, tearDownReceivers() would never run, and
+    // every timed-out connect would leak its WDSP channels out of the 32-slot
+    // pool. Worse, connectRadio() queues behind an in-flight build only while
+    // m_pendingConnect is set, so a retry after this error would call
+    // buildReceivers() on the chains the I/O thread is still opening — a
+    // use-after-free reached by the ordinary "connect failed, try again"
+    // gesture. (#5413 triage; #5415 review.)
     ++m_connectGeneration;
-    m_pendingConnect.reset();
+    // Before the emits, not after: a connectionError handler can re-enter this
+    // object, and the stale branch must see this flag whatever it does.
+    m_pendingConnect->finishSignalled = true;
     emit connectionError(
         tr("Hermes-Lite 2: the DSP setup did not finish within %1 seconds")
             .arg(AetherSDR::hl2::kDspSetupFailMs / 1000));
     // So a caller waiting on the phase is released rather than left hanging on
-    // a signal that now never comes.
+    // a signal that now never comes. The build is still running; the flag above
+    // keeps the stale branch from emitting this a second time.
     emit dspSetupFinished();
 }
 
@@ -2142,11 +2161,16 @@ void Hl2Backend::finishDspSetup(const DspSetupResult& result)
     if (m_pendingConnect->generation != m_connectGeneration) {
         qCInfo(lcHl2) << "HL2: connect superseded while the DSP was opening —"
                       << "releasing the chains it built";
+        // Read before the reset: the phase watchdog may already have ended the
+        // phase for a caller that could not wait for this moment.
+        const bool alreadyFinished = m_pendingConnect->finishSignalled;
         m_pendingConnect.reset();
         // Safe to block inside here: the build has finished, so the I/O thread
         // is back at its event loop and publishIoDsps() returns promptly.
         tearDownReceivers();
-        emit dspSetupFinished();
+        if (!alreadyFinished) {
+            emit dspSetupFinished();
+        }
         // A connect that arrived mid-build has been waiting for exactly this.
         if (m_queuedConnect) {
             const RadioConnectRequest queued = *m_queuedConnect;

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -2096,12 +2096,14 @@ void Hl2Backend::onDspSetupWatchdog()
         return;
     case AetherSDR::hl2::DspSetupAction::Warn:
         // NOT a failure. A machine's first WDSP open measures its FFT plans
-        // rather than loading them and is legitimately slow (#5052), so this
-        // says so and keeps waiting — the alternative is failing a connect that
-        // is working.
+        // rather than loading them and is legitimately slow (#5052) — 98 s on a
+        // quiet machine, 188 s under load — so this says so and keeps waiting;
+        // the alternative is failing a connect that is working. It repeats,
+        // because the wait it is reporting can be minutes long.
         qCWarning(lcHl2) << "HL2 DSP setup: still opening after" << elapsed
                          << "ms — a first open on this machine can be slow;"
-                         << "will fail at" << AetherSDR::hl2::kDspSetupFailMs << "ms";
+                         << "will fail at"
+                         << AetherSDR::hl2::kDspSetupFailMs / 1000 << "s";
         m_dspSetupWatchdog->start(
             static_cast<int>(AetherSDR::hl2::dspSetupNextCheckMs(elapsed)));
         return;

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -8,6 +8,7 @@
 
 #include "core/backends/hl2/Hl2RxDsp.h"
 #include "core/backends/hl2/Hl2TxDsp.h"
+#include "core/backends/hl2/Hl2DspSetupPolicy.h"
 #include "core/backends/hl2/Hl2TxLevelPolicy.h"
 #include "core/backends/hl2/MetisClient.h"
 #include "core/backends/hl2/MetisProtocol.h"
@@ -52,6 +53,9 @@ struct Hl2Backend::PendingConnect {
     // m_connectGeneration; a build whose generation is stale on completion
     // tears itself down instead of starting a wire nobody asked for.
     quint64 generation = 0;
+    // How long this phase has been running. Belongs to the connect rather than
+    // to the backend so a superseded build cannot report the new one's elapsed.
+    QElapsedTimer clock;
 };
 
 // What the I/O thread carries back. Parallel arrays indexed by DDC rather than
@@ -1990,6 +1994,13 @@ void Hl2Backend::beginDspSetup()
     }
 
     emit dspSetupProgress(tr("Preparing the receive chain…"), 0, total);
+    // MIRRORED TO THE LOG, because dspSetupProgress has exactly one consumer in
+    // the tree and it is MainWindow — so the phase is visible to an operator
+    // watching a dialog and invisible to everyone else, which is why a headless
+    // run showed nothing between here and the wire. (#5413.)
+    qCInfo(lcHl2) << "HL2 DSP setup: opening" << total << "receive chain(s)";
+    m_pendingConnect->clock.start();
+    armDspSetupWatchdog();
 
     const Hl2TxDsp::Config tc = m_pendingConnect->tc;
     Hl2TxDsp* txDsp = m_txDsp;
@@ -2054,10 +2065,76 @@ void Hl2Backend::beginDspSetup()
     }, Qt::QueuedConnection);
 }
 
+void Hl2Backend::armDspSetupWatchdog()
+{
+    if (!m_dspSetupWatchdog) {
+        m_dspSetupWatchdog = new QTimer(this);
+        m_dspSetupWatchdog->setSingleShot(true);
+        connect(m_dspSetupWatchdog, &QTimer::timeout, this,
+                &Hl2Backend::onDspSetupWatchdog);
+    }
+    m_dspSetupWatchdog->start(
+        static_cast<int>(AetherSDR::hl2::dspSetupNextCheckMs(0)));
+}
+
+void Hl2Backend::onDspSetupWatchdog()
+{
+    if (!m_pendingConnect) {
+        return;               // finished between the fire and this slot
+    }
+    const qint64 elapsed = m_pendingConnect->clock.elapsed();
+    switch (AetherSDR::hl2::dspSetupAction(elapsed)) {
+    case AetherSDR::hl2::DspSetupAction::None:
+        // Fired early (a timer can). Look again at the point that matters.
+        m_dspSetupWatchdog->start(
+            static_cast<int>(AetherSDR::hl2::dspSetupNextCheckMs(elapsed)));
+        return;
+    case AetherSDR::hl2::DspSetupAction::Warn:
+        // NOT a failure. A machine's first WDSP open measures its FFT plans
+        // rather than loading them and is legitimately slow (#5052), so this
+        // says so and keeps waiting — the alternative is failing a connect that
+        // is working.
+        qCWarning(lcHl2) << "HL2 DSP setup: still opening after" << elapsed
+                         << "ms — a first open on this machine can be slow;"
+                         << "will fail at" << AetherSDR::hl2::kDspSetupFailMs << "ms";
+        m_dspSetupWatchdog->start(
+            static_cast<int>(AetherSDR::hl2::dspSetupNextCheckMs(elapsed)));
+        return;
+    case AetherSDR::hl2::DspSetupAction::Fail:
+        break;
+    }
+
+    qCWarning(lcHl2) << "HL2 DSP setup: gave up after" << elapsed << "ms";
+
+    // INVALIDATE, DO NOT TEAR DOWN. The I/O thread may be inside configure() on
+    // these very chains — WDSP's OpenChannel does not return early, so the build
+    // cannot be cancelled — and freeing them from this thread would be a
+    // use-after-free. Bumping the generation is the same one-liner
+    // disconnectRadio() uses: the build runs to completion and finishDspSetup()
+    // takes its stale branch, which releases what it built. (#5413 triage.)
+    ++m_connectGeneration;
+    m_pendingConnect.reset();
+    emit connectionError(
+        tr("Hermes-Lite 2: the DSP setup did not finish within %1 seconds")
+            .arg(AetherSDR::hl2::kDspSetupFailMs / 1000));
+    // So a caller waiting on the phase is released rather than left hanging on
+    // a signal that now never comes.
+    emit dspSetupFinished();
+}
+
 void Hl2Backend::finishDspSetup(const DspSetupResult& result)
 {
-    if (!m_pendingConnect)
+    // Stopped on EVERY exit below, including the two early returns — a timer
+    // left running past the phase it measures would fail a connect that had
+    // already succeeded.
+    if (m_dspSetupWatchdog) {
+        m_dspSetupWatchdog->stop();
+    }
+    if (!m_pendingConnect) {
         return;
+    }
+    qCInfo(lcHl2) << "HL2 DSP setup: chains open after"
+                  << m_pendingConnect->clock.elapsed() << "ms";
     // A disconnect, or a second connect, arrived while the chains were opening.
     // The wire was never started, so there is nothing to stop — but the chains
     // ARE open, and leaving them open would leak WDSP channels out of the
@@ -2196,6 +2273,11 @@ void Hl2Backend::disconnectRadio()
     // cancelled — WDSP's OpenChannel does not return early — so it runs to
     // completion on the I/O thread and finishDspSetup() releases what it built.
     ++m_connectGeneration;
+    // The phase watchdog goes with it: the operator has left, so a later fire
+    // would report a failure for a connect nobody is waiting on.
+    if (m_dspSetupWatchdog) {
+        m_dspSetupWatchdog->stop();
+    }
     // And a connect PARKED BEHIND that build is stale for the same reason: the
     // operator has since asked to be disconnected. Leaving it here made
     // finishDspSetup()'s supersede branch re-drive it — a second full build

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -181,6 +181,8 @@ private:
     // the note above buildReceivers() and docs/HERMES.md §20.8). The sequence stays
     // serial on the I/O thread; only the GUI thread stopped waiting for it.
     void beginDspSetup();
+    void armDspSetupWatchdog();
+    void onDspSetupWatchdog();
 
     // Everything the async build needs to carry across event-loop turns (the
     // wire params, the RX and TX configs, and which connect it belongs to). A
@@ -193,6 +195,10 @@ private:
     void finishDspSetup(const DspSetupResult& result);
 
     std::unique_ptr<PendingConnect> m_pendingConnect;
+    // Watches the window between beginDspSetup() returning and finishDspSetup()
+    // being posted back — the one stretch of the connect that no other timer
+    // covers, because MetisClient's watchdog is armed after it (#5413).
+    QTimer* m_dspSetupWatchdog = nullptr;
     // A connect that arrived while m_pendingConnect was still building. Held
     // rather than served inline — see the guard at the top of connectRadio().
     std::unique_ptr<RadioConnectRequest> m_queuedConnect;

--- a/src/core/backends/hl2/Hl2DspSetupPolicy.h
+++ b/src/core/backends/hl2/Hl2DspSetupPolicy.h
@@ -1,0 +1,72 @@
+#pragma once
+
+// How long the DSP-setup phase may run before it is worth saying something, and
+// before it is worth giving up — as a pure decision.
+//
+// THE PHASE HAS NO TIMEOUT AT ALL TODAY, and that is the defect (#5413).
+// beginDspSetup() hands the WDSP opens to the I/O thread and returns to the
+// event loop; finishDspSetup() is posted back when they finish. Between those
+// two points nothing in Hl2Backend is watching. The only connect watchdog lives
+// in MetisClient::start(), which is reached AFTER this phase, so a stall here is
+// outside every guard in the path — the caller sees the same reply a successful
+// connect gives and then silence.
+//
+// TWO STAGES, NOT ONE NUMBER, and the reason is that a slow first open is
+// legitimate rather than broken. A machine's first WDSP/FFTW open measures its
+// plans instead of loading them, which is genuinely expensive (#5052;
+// MetisClient.cpp cites ~19 s), and a single tight timeout would turn a working
+// first launch into a failed connect. So: warn early and keep going, fail only
+// far out.
+//
+// A pure function so the timing behaviour is testable without a radio, a socket
+// or a running event loop — the layer #5358 asks for.
+
+#include <cstdint>
+
+namespace AetherSDR::hl2 {
+
+enum class DspSetupAction {
+    None,   // still inside the expected window; say nothing
+    Warn,   // slow enough to be worth a log line, NOT a failure
+    Fail,   // long enough that the caller deserves an error instead of silence
+};
+
+// Default stages. Deliberately far apart: the gap between them is where a
+// legitimately slow first open lives.
+inline constexpr std::int64_t kDspSetupWarnMs = 10'000;
+inline constexpr std::int64_t kDspSetupFailMs = 90'000;
+
+inline DspSetupAction dspSetupAction(std::int64_t elapsedMs,
+                                     std::int64_t warnMs = kDspSetupWarnMs,
+                                     std::int64_t failMs = kDspSetupFailMs)
+{
+    // Fail is checked FIRST so a misconfigured pair (fail <= warn) still fails
+    // rather than warning forever. The ordering is the guard, not an assert:
+    // this runs on a timer in a connect path and must not abort a session.
+    if (elapsedMs >= failMs) {
+        return DspSetupAction::Fail;
+    }
+    if (elapsedMs >= warnMs) {
+        return DspSetupAction::Warn;
+    }
+    return DspSetupAction::None;
+}
+
+// How long to wait before looking again, given that `elapsedMs` has just been
+// judged. Returning the REMAINDER rather than a fixed poll keeps the watchdog
+// to two wake-ups for a whole connect — one at the warn point, one at the fail
+// point — instead of ticking through a ninety-second window.
+inline std::int64_t dspSetupNextCheckMs(std::int64_t elapsedMs,
+                                        std::int64_t warnMs = kDspSetupWarnMs,
+                                        std::int64_t failMs = kDspSetupFailMs)
+{
+    if (elapsedMs < warnMs) {
+        return warnMs - elapsedMs;
+    }
+    if (elapsedMs < failMs) {
+        return failMs - elapsedMs;
+    }
+    return 0;   // nothing further to wait for
+}
+
+}  // namespace AetherSDR::hl2

--- a/src/core/backends/hl2/Hl2DspSetupPolicy.h
+++ b/src/core/backends/hl2/Hl2DspSetupPolicy.h
@@ -18,6 +18,60 @@
 // first launch into a failed connect. So: warn early and keep going, fail only
 // far out.
 //
+// WHERE "FAR OUT" IS, MEASURED. The first bound here was 90 s, chosen against a
+// single observation that an uncached open was "still running at 150 s". It was
+// wrong, and wrong in the direction that fails working connects. On an IDLE
+// machine — 21 load samples between 3.3 and 4.1 — a cold first open measured
+// 98269 ms, against HERMES §22.3's documented 18865 ms
+// (streams/hl2-telemetry/runs/d57_bench_quiet_result.txt). So 90 s failed a
+// connect that was working, on a quiet machine, every time.
+//
+// The same series measured that load roughly doubles it: 188128 ms for the open
+// at one-minute load 38-40, and four cold CONNECTS at load 31-44 came in at
+// 193 / 195 / 214 / 219 s (streams/hl2-telemetry/runs/d57_quiet_connect.py).
+// 98.3 s is therefore a FLOOR from one sample on one machine, not a typical
+// case — and the cost being measured is FFTW timing candidate plans, which
+// varies several-fold across hardware. A laptop or a CI runner will be slower.
+//
+// AND THE LARGEST DOCUMENTED FIGURE IS NOT OURS. #4877 -- closed, titled "every
+// run re-measures 190 s of PATIENT plans" -- reports 178.7 s on an i9-13980HX
+// and 188-190 s across four consecutive CI runs. So ~190 s is an EXPECTED cold
+// cost in at least one shipped configuration, independently of this bench, and
+// the 188.1 s above reproduces it rather than discovering it. Read the range as
+// 19 s to 190 s across binaries and platforms before a slower CPU is counted —
+// with the low end as the outlier rather than an equal member: three
+// independent cold measurements sit between 98 and 190 s (this bench's 98.3 s,
+// wdsp_channel_test's 165.1 s, #4877's 178.7 s and its 188-190 s CI runs),
+// while HERMES §22.3's 18.9 s and its 22.4 s companion stand alone.
+//
+// One caveat on treating those as one number: HERMES.md notes that the app's
+// plan set and the tests' plan set are different FFTW problems, so #4877's
+// figure and a connect are not strictly the same measurement. That cuts toward
+// a wider bound, not a narrower one.
+//
+// WHAT NONE OF THOSE FIGURES COVER: MORE THAN ONE RECEIVER. beginDspSetup()
+// opens one chain per receiver — `for (int i = 0; i < actualNumRx; ++i)` — and
+// the transmit path opens none, so the cost scales with actualNumRx. Every
+// measurement above is a ONE-receiver connect. Plan sets overlap heavily (the
+// same bench's second, third and fourth cold opens, at other rates, cost
+// 1862 / 1223 / 739 ms after that first 98 s), so receivers 2..N at the same
+// rate are probably nearly free — but that is an expectation, not a
+// measurement, and the board reports four. If a four-receiver first connect
+// ever fails this bound, that is the number to go and measure, not evidence
+// that the bound was set too low on the evidence available.
+//
+// Hence 600 s: an order of magnitude over the quiet floor, ~3x over the largest
+// documented cold cost, ~2.7x over the worst measured working connect, and
+// still finite. The asymmetry justifies the
+// generosity — failing a connect that would have succeeded loses the session,
+// while a late error on a true hang only delays a message the operator can
+// already see coming from the warn line.
+//
+// WHICH IS WHY THE WARN REPEATS. A single line at 10 s followed by ten minutes
+// of silence is barely better than the unbounded phase this replaces, so after
+// the first warning the watchdog re-warns on a fixed cadence until it either
+// finishes or fails. The schedule below is what produces that.
+//
 // A pure function so the timing behaviour is testable without a radio, a socket
 // or a running event loop — the layer #5358 asks for.
 
@@ -32,9 +86,15 @@ enum class DspSetupAction {
 };
 
 // Default stages. Deliberately far apart: the gap between them is where a
-// legitimately slow first open lives.
+// legitimately slow first open lives — measured at 98.3 s quiet and 188 s under
+// load, so the gap is the working case, not the pathological one.
 inline constexpr std::int64_t kDspSetupWarnMs = 10'000;
-inline constexpr std::int64_t kDspSetupFailMs = 90'000;
+inline constexpr std::int64_t kDspSetupFailMs = 600'000;
+
+// How often to repeat the warning once the phase is past the warn point. Not a
+// stage: it changes nothing about what dspSetupAction() decides, only how often
+// the caller wakes up to hear the same Warn again.
+inline constexpr std::int64_t kDspSetupWarnRepeatMs = 30'000;
 
 inline DspSetupAction dspSetupAction(std::int64_t elapsedMs,
                                      std::int64_t warnMs = kDspSetupWarnMs,
@@ -53,20 +113,32 @@ inline DspSetupAction dspSetupAction(std::int64_t elapsedMs,
 }
 
 // How long to wait before looking again, given that `elapsedMs` has just been
-// judged. Returning the REMAINDER rather than a fixed poll keeps the watchdog
-// to two wake-ups for a whole connect — one at the warn point, one at the fail
-// point — instead of ticking through a ninety-second window.
+// judged.
+//
+// Before the warn point this is the exact REMAINDER, not a poll: a connect that
+// is going to finish in four seconds costs zero wake-ups. After it, the cadence
+// is what keeps the ten-minute window from being silent — but the last wait is
+// clamped to the remainder so the fail point is hit exactly rather than
+// overshot by up to a repeat interval.
 inline std::int64_t dspSetupNextCheckMs(std::int64_t elapsedMs,
                                         std::int64_t warnMs = kDspSetupWarnMs,
-                                        std::int64_t failMs = kDspSetupFailMs)
+                                        std::int64_t failMs = kDspSetupFailMs,
+                                        std::int64_t repeatMs = kDspSetupWarnRepeatMs)
 {
     if (elapsedMs < warnMs) {
         return warnMs - elapsedMs;
     }
-    if (elapsedMs < failMs) {
-        return failMs - elapsedMs;
+    if (elapsedMs >= failMs) {
+        return 0;   // nothing further to wait for
     }
-    return 0;   // nothing further to wait for
+    const std::int64_t remaining = failMs - elapsedMs;
+    // A non-positive cadence would arm a zero-delay timer and spin the event
+    // loop for the rest of the phase. Fall back to the old single-shot
+    // behaviour rather than doing that.
+    if (repeatMs <= 0) {
+        return remaining;
+    }
+    return remaining < repeatMs ? remaining : repeatMs;
 }
 
 }  // namespace AetherSDR::hl2

--- a/src/core/backends/hl2/Hl2DspSetupPolicy.h
+++ b/src/core/backends/hl2/Hl2DspSetupPolicy.h
@@ -49,16 +49,30 @@
 // figure and a connect are not strictly the same measurement. That cuts toward
 // a wider bound, not a narrower one.
 //
-// WHAT NONE OF THOSE FIGURES COVER: MORE THAN ONE RECEIVER. beginDspSetup()
-// opens one chain per receiver — `for (int i = 0; i < actualNumRx; ++i)` — and
-// the transmit path opens none, so the cost scales with actualNumRx. Every
-// measurement above is a ONE-receiver connect. Plan sets overlap heavily (the
-// same bench's second, third and fourth cold opens, at other rates, cost
-// 1862 / 1223 / 739 ms after that first 98 s), so receivers 2..N at the same
-// rate are probably nearly free — but that is an expectation, not a
-// measurement, and the board reports four. If a four-receiver first connect
-// ever fails this bound, that is the number to go and measure, not evidence
-// that the bound was set too low on the evidence available.
+// WHAT NONE OF THOSE FIGURES COVER: MORE THAN ONE RECEIVER — and the exposure
+// is much narrower than "the board reports four". beginDspSetup() opens one
+// chain per receiver, `for (int i = 0; i < actualNumRx; ++i)`, and the transmit
+// path opens none, so the cost does scale with actualNumRx. But three things
+// bound how it can exceed 1 inside this window:
+//
+//   * connectRadio() sets `m_requestedNumRx = 1` unconditionally and raises it
+//     only for an explicit `numRx` CONNECT PARAM. A saved count is deliberately
+//     not re-imposed (see the comment there). Nothing in RadioModel passes the
+//     param, so an ordinary app connect opens exactly one chain.
+//   * A receiver added later is outside this timer entirely: createPanadapter()
+//     refuses before m_connected, so its chain opens after the phase this
+//     watchdog measures.
+//   * receiverCeiling() is min(board, maxReceiversAtRate(rate, board)), so at
+//     384 kHz — the rate every measurement above used — a 4-receiver board is
+//     honestly 3. A four-receiver run would have to change the rate, and would
+//     then not be comparable to the figures above at all.
+//
+// So the reachable case is an automation or embedder caller that passes numRx>1
+// at connect: the same class of entry point as #5402's lnaGainDb. Plan sets
+// overlap heavily (this bench's second, third and fourth cold opens, at other
+// rates, cost 1862 / 1223 / 739 ms after that first 98 s), so chains 2..N at
+// one rate are probably nearly free — an expectation, not a measurement. If
+// such a connect ever fails this bound, that is the number to go and measure.
 //
 // Hence 600 s: an order of magnitude over the quiet floor, ~3x over the largest
 // documented cold cost, ~2.7x over the worst measured working connect, and

--- a/tests/hl2_dsp_setup_policy_test.cpp
+++ b/tests/hl2_dsp_setup_policy_test.cpp
@@ -117,6 +117,17 @@ int main()
 
     // ---- The measured reality this exists to tolerate ----------------------
     //
+    // WHAT WOULD HAVE TO CHANGE FOR THESE TO STOP BEING WORTH ASSERTING: the
+    // cost itself. They are load-bearing because a cold FFTW_PATIENT plan
+    // measurement really does take minutes (#4877, still the largest documented
+    // figure). If that issue's fix lands — CI caching the wisdom file — or WDSP
+    // stops planning with FFTW_PATIENT, these durations stop describing
+    // anything real. They would still PASS, because they only assert that such
+    // durations must not fail, so they would go green and pointless rather than
+    // green and wrong. That is the better of the two failure modes, but it is
+    // still a reason to re-read this block rather than trust it, if the cold
+    // cost is ever fixed at the source.
+    //
     // These are the numbers that moved the bound from 90 s to 600 s. A cold
     // first open on a QUIET machine is 98.3 s; under load the same open is
     // 188.1 s and a whole cold connect is 193-219 s. Every one of those is a

--- a/tests/hl2_dsp_setup_policy_test.cpp
+++ b/tests/hl2_dsp_setup_policy_test.cpp
@@ -1,0 +1,106 @@
+// When the DSP-setup phase is worth a warning, and when it is worth failing.
+//
+// The phase this governs had NO timeout at all (#5413): beginDspSetup() hands
+// the WDSP opens to the I/O thread and returns, finishDspSetup() is posted back
+// when they finish, and between those points nothing was watching. The only
+// connect watchdog lives in MetisClient::start(), which is reached after this
+// phase — so a stall here was outside every guard in the path and a caller got
+// the same reply a successful connect gives, then silence.
+//
+// Timing behaviour is otherwise reachable only by running a radio, which is why
+// it is a pure function here — the layer #5358 asks for.
+//
+// THE TWO STAGES ARE THE POINT. A first WDSP open on a machine with no FFTW
+// wisdom cache measures 35 plans per channel with FFTW_PATIENT and legitimately
+// takes minutes; with the cache it is seconds. Measured on this bench: 4.1 s
+// with the cache, still unfinished at 150 s without it. A single tight timeout
+// would therefore fail a connect that is working, so the warn stage exists to
+// say "slow, still going" and only the far stage fails.
+
+#include "core/backends/hl2/Hl2DspSetupPolicy.h"
+
+#include <cstdio>
+
+using AetherSDR::hl2::DspSetupAction;
+using AetherSDR::hl2::dspSetupAction;
+using AetherSDR::hl2::dspSetupNextCheckMs;
+using AetherSDR::hl2::kDspSetupFailMs;
+using AetherSDR::hl2::kDspSetupWarnMs;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool ok, const char* what)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", what);
+    if (!ok) {
+        ++g_failures;
+    }
+}
+
+}  // namespace
+
+int main()
+{
+    // ---- Inside the expected window, say nothing --------------------------
+    check(dspSetupAction(0) == DspSetupAction::None,
+          "a phase that has just started is not reported");
+    check(dspSetupAction(kDspSetupWarnMs - 1) == DspSetupAction::None,
+          "one ms before the warn point is still silent");
+
+    // ---- Slow, but NOT a failure ------------------------------------------
+    //
+    // This is the stage that keeps a working first open from being killed.
+    check(dspSetupAction(kDspSetupWarnMs) == DspSetupAction::Warn,
+          "at the warn point it warns — the boundary is inclusive");
+    check(dspSetupAction(kDspSetupFailMs - 1) == DspSetupAction::Warn,
+          "one ms before the fail point it is STILL only a warning");
+
+    // ---- Far out, fail ----------------------------------------------------
+    check(dspSetupAction(kDspSetupFailMs) == DspSetupAction::Fail,
+          "at the fail point it fails");
+    check(dspSetupAction(kDspSetupFailMs * 10) == DspSetupAction::Fail,
+          "and stays failed however long it runs");
+
+    // ---- A misconfigured pair fails rather than warning forever -----------
+    //
+    // The ordering inside the function is the guard. This runs on a timer in a
+    // connect path, so an assert would abort a session; getting the answer
+    // wrong quietly would leave the phase unbounded again, which is the very
+    // defect.
+    check(dspSetupAction(5000, /*warnMs=*/9000, /*failMs=*/1000) == DspSetupAction::Fail,
+          "fail <= warn still fails, rather than warning forever");
+
+    // ---- The schedule: two wake-ups for a whole connect --------------------
+    //
+    // Returning the REMAINDER rather than a fixed poll interval is what keeps
+    // the watchdog to one wake-up at the warn point and one at the fail point,
+    // instead of ticking through a ninety-second window.
+    check(dspSetupNextCheckMs(0) == kDspSetupWarnMs,
+          "from the start, the next look is exactly the warn point");
+    check(dspSetupNextCheckMs(kDspSetupWarnMs) == kDspSetupFailMs - kDspSetupWarnMs,
+          "from the warn point, the next look is exactly the fail point");
+    check(dspSetupNextCheckMs(kDspSetupWarnMs / 2) == kDspSetupWarnMs - kDspSetupWarnMs / 2,
+          "an early wake-up reschedules to the warn point, not to a fixed tick");
+    check(dspSetupNextCheckMs(kDspSetupFailMs) == 0,
+          "past the fail point there is nothing left to wait for");
+
+    // ---- The measured reality this exists to tolerate ----------------------
+    //
+    // 4.1 s with an FFTW wisdom cache, still running at 150 s without one.
+    // The first must be silent; the second must have warned and not yet failed.
+    check(dspSetupAction(4'100) == DspSetupAction::None,
+          "a cached first open (4.1 s measured) is silent");
+    check(dspSetupAction(150'000) == DspSetupAction::Fail,
+          "an uncached open still running at 150 s has failed");
+    check(dspSetupAction(20'000) == DspSetupAction::Warn,
+          "and ~19 s, the documented first-open cost, warns without failing");
+
+    if (g_failures == 0) {
+        std::printf("\nALL PASS\n");
+        return 0;
+    }
+    std::printf("\nFAILURES PRESENT\n");
+    return 1;
+}

--- a/tests/hl2_dsp_setup_policy_test.cpp
+++ b/tests/hl2_dsp_setup_policy_test.cpp
@@ -12,10 +12,22 @@
 //
 // THE TWO STAGES ARE THE POINT. A first WDSP open on a machine with no FFTW
 // wisdom cache measures 35 plans per channel with FFTW_PATIENT and legitimately
-// takes minutes; with the cache it is seconds. Measured on this bench: 4.1 s
-// with the cache, still unfinished at 150 s without it. A single tight timeout
-// would therefore fail a connect that is working, so the warn stage exists to
-// say "slow, still going" and only the far stage fails.
+// takes minutes; with the cache it is seconds. A single tight timeout would
+// therefore fail a connect that is working, so the warn stage exists to say
+// "slow, still going" and only the far stage fails.
+//
+// THE NUMBERS BELOW ARE MEASUREMENTS, AND THEY MOVED THE BOUND. The first
+// version of this file asserted that an open still running at 150 s "has
+// failed", against a 90 s bound. Both were wrong: a cold first open on an IDLE
+// machine measures 98269 ms
+// (streams/hl2-telemetry/runs/d57_bench_quiet_result.txt, 21 load samples
+// between 3.3 and 4.1), so 90 s failed a working connect every time on a quiet
+// machine, and 150 s is inside the working range rather than outside it. Under
+// load the same open is 188128 ms and whole cold connects are 193-219 s
+// (streams/hl2-telemetry/runs/d57_quiet_connect.py). And the largest figure is
+// not this bench's at all: #4877, closed, reports 178.7 s on an i9-13980HX and
+// 188-190 s across four CI runs as the EXPECTED cold cost. Hence the checks
+// here run against 600 s.
 
 #include "core/backends/hl2/Hl2DspSetupPolicy.h"
 
@@ -26,6 +38,7 @@ using AetherSDR::hl2::dspSetupAction;
 using AetherSDR::hl2::dspSetupNextCheckMs;
 using AetherSDR::hl2::kDspSetupFailMs;
 using AetherSDR::hl2::kDspSetupWarnMs;
+using AetherSDR::hl2::kDspSetupWarnRepeatMs;
 
 namespace {
 
@@ -72,30 +85,58 @@ int main()
     check(dspSetupAction(5000, /*warnMs=*/9000, /*failMs=*/1000) == DspSetupAction::Fail,
           "fail <= warn still fails, rather than warning forever");
 
-    // ---- The schedule: two wake-ups for a whole connect --------------------
+    // ---- The schedule ------------------------------------------------------
     //
-    // Returning the REMAINDER rather than a fixed poll interval is what keeps
-    // the watchdog to one wake-up at the warn point and one at the fail point,
-    // instead of ticking through a ninety-second window.
+    // Before the warn point, the exact REMAINDER: a connect that finishes in
+    // four seconds costs no wake-ups at all. After it, a fixed cadence, because
+    // the window it is covering is ten minutes wide and one line at 10 s
+    // followed by silence is barely better than no watchdog.
     check(dspSetupNextCheckMs(0) == kDspSetupWarnMs,
           "from the start, the next look is exactly the warn point");
-    check(dspSetupNextCheckMs(kDspSetupWarnMs) == kDspSetupFailMs - kDspSetupWarnMs,
-          "from the warn point, the next look is exactly the fail point");
     check(dspSetupNextCheckMs(kDspSetupWarnMs / 2) == kDspSetupWarnMs - kDspSetupWarnMs / 2,
           "an early wake-up reschedules to the warn point, not to a fixed tick");
+    check(dspSetupNextCheckMs(kDspSetupWarnMs) == kDspSetupWarnRepeatMs,
+          "from the warn point, it re-warns on the cadence");
+    check(dspSetupNextCheckMs(kDspSetupWarnMs + kDspSetupWarnRepeatMs) == kDspSetupWarnRepeatMs,
+          "and keeps re-warning on it");
     check(dspSetupNextCheckMs(kDspSetupFailMs) == 0,
           "past the fail point there is nothing left to wait for");
 
+    // The last wait is the remainder, not the cadence — otherwise the fail
+    // point is overshot by up to one interval and the bound is not the bound.
+    check(dspSetupNextCheckMs(kDspSetupFailMs - 1) == 1,
+          "the final wait lands exactly on the fail point, not past it");
+    check(dspSetupNextCheckMs(kDspSetupFailMs - kDspSetupWarnRepeatMs) == kDspSetupWarnRepeatMs,
+          "one full cadence out, the cadence is still exactly right");
+
+    // A zero or negative cadence must not arm a zero-delay timer and spin the
+    // event loop for the rest of the phase. It falls back to a single wait.
+    check(dspSetupNextCheckMs(kDspSetupWarnMs, kDspSetupWarnMs, kDspSetupFailMs,
+                              /*repeatMs=*/0) == kDspSetupFailMs - kDspSetupWarnMs,
+          "a zero cadence degrades to one long wait, not to a spin");
+
     // ---- The measured reality this exists to tolerate ----------------------
     //
-    // 4.1 s with an FFTW wisdom cache, still running at 150 s without one.
-    // The first must be silent; the second must have warned and not yet failed.
+    // These are the numbers that moved the bound from 90 s to 600 s. A cold
+    // first open on a QUIET machine is 98.3 s; under load the same open is
+    // 188.1 s and a whole cold connect is 193-219 s. Every one of those is a
+    // connect that WORKED, so every one of them must warn rather than fail.
     check(dspSetupAction(4'100) == DspSetupAction::None,
           "a cached first open (4.1 s measured) is silent");
-    check(dspSetupAction(150'000) == DspSetupAction::Fail,
-          "an uncached open still running at 150 s has failed");
     check(dspSetupAction(20'000) == DspSetupAction::Warn,
-          "and ~19 s, the documented first-open cost, warns without failing");
+          "~19 s, HERMES 22.3's documented first-open cost, warns without failing");
+    check(dspSetupAction(98'269) == DspSetupAction::Warn,
+          "98.3 s, a cold open measured on an IDLE machine, must NOT fail");
+    check(dspSetupAction(150'000) == DspSetupAction::Warn,
+          "150 s, the observation the 90 s bound was built on, is inside the working range");
+    check(dspSetupAction(188'128) == DspSetupAction::Warn,
+          "188.1 s, the same open under load, must NOT fail");
+    check(dspSetupAction(219'000) == DspSetupAction::Warn,
+          "219 s, the slowest cold CONNECT measured, must NOT fail");
+    check(dspSetupAction(190'000) == DspSetupAction::Warn,
+          "190 s, #4877's expected cold cost on an i9 and in CI, must NOT fail");
+    check(dspSetupAction(600'000) == DspSetupAction::Fail,
+          "and the phase is still bounded — 600 s fails");
 
     if (g_failures == 0) {
         std::printf("\nALL PASS\n");

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3968,6 +3968,11 @@ add_executable(host_voice_chain_policy_test
 )
 target_include_directories(host_voice_chain_policy_test PRIVATE src)
 add_test(NAME host_voice_chain_policy_test COMMAND host_voice_chain_policy_test)
+add_executable(hl2_dsp_setup_policy_test
+    tests/hl2_dsp_setup_policy_test.cpp
+)
+target_include_directories(hl2_dsp_setup_policy_test PRIVATE src)
+add_test(NAME hl2_dsp_setup_policy_test COMMAND hl2_dsp_setup_policy_test)
 add_executable(hl2_tx_level_policy_test
     tests/hl2_tx_level_policy_test.cpp
 )


### PR DESCRIPTION
Refs #5413 — implements the DSP-setup watchdog and phase logging (items 1 and 2). #5416 remains open for bridge-visible connect state, so this PR must not close #5413.

`beginDspSetup()` opens the receive DSP chains asynchronously before `MetisClient::start()` can arm its connection watchdog. This PR covers that previously unwatched phase with a single-shot timer: warn after 10 seconds, repeat the warning every 30 seconds, and report failure after 600 seconds. Beginning and completing the phase also write categorized log entries, including the chain count and elapsed time.

Cold FFTW planning can legitimately take minutes. The author reported 98–219-second cold opens/connects, with independent historical figures around 179–190 seconds in #4877; the original 90-second limit was therefore raised to 600 seconds. These timing measurements were not independently repeated during the takeover review.

On timeout the backend invalidates the connect generation and leaves the pending build alive. WDSP cannot cancel an in-flight OpenChannel safely; cleanup runs only when the existing completion path receives the stale build. Retrying while it is opening queues behind it, preserving the DSP objects. A flag suppresses a duplicate dspSetupFinished signal. The watchdog stops on completion and disconnect.

### Validation at 18b49e65ffbc016b9000145b51a78fa400bdf5f4

- Linux, macOS, Windows, and both static CI checks passed; relevant configure/build steps ran successfully.
- The socket-free policy test compiled locally with Clang, C++20, and warnings as errors: 23 assertions passed.
- Five scratch-only mutations were detected: disabled decisions (12 failed assertions), original 90-second bound (5), exclusive boundaries (3), fixed polling (1), and removed final-interval clamp (1).
- Engine-boundary strict check: zero blocking findings; 102 tracked legacy findings.
- Test registration strict check and diff whitespace check passed.
- All five commits have valid GitHub-verified signatures.
- A clean three-way merge with main at bc8017740de7cce1ddbc90bbb69bbfafa00ec44b preserves intervening HL2 changes.

### Coverage and remaining limitations

The timing policy is tested; production timer arming, asynchronous cleanup, and signal ordering were inspected in code rather than reproduced in a stalled backend. No full local application build, GUI session, live-radio session, or TX test was performed; the demo backend does not exercise HL2 DSP setup. No socket-owning test is added or modified.

A permanently stuck WDSP build remains stuck: after the reported failure, later retries can queue without another watchdog, and shutdown/family switching can still wait for the worker. For an explicit multi-receiver connect, later progress signals can reopen the setup dialog after timeout. Those existing review observations remain non-blocking limitations, not claims of fixes delivered here. Ordinary application connects start with one receiver; multi-receiver cold planning was not measured independently.

The diff is limited to Hl2Backend.cpp/.h, Hl2DspSetupPolicy.h, its policy test, and registration in tests/tests.cmake. No CHANGELOG entry or unrelated code changes.

Principle VIII: Evidence Over Assertion.
