### PR TITLE
build: one tree-wide sanitizer switch, not a per-target hardcode. Principle VIII.

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -46,6 +46,86 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Configure-only gate for the tree-wide sanitizer switch (#5406, #5419).
+  #
+  # Nothing else in CI exercises AETHERSDR_SANITIZER in either state: the
+  # sanitizer lane injects flags through CFLAGS/CXXFLAGS/LDFLAGS and never
+  # passes -D, and every other job builds with the option off. So the one
+  # thing that could silently rot is the option itself.
+  #
+  # Configure-only, deliberately. Every assertion below is decided during
+  # cmake's configure step, which is seconds; building anything would cost
+  # tens of minutes and prove nothing extra about the switch.
+  #
+  # A separate job rather than a step in static-checks: this needs the CI
+  # image for Qt and the rest of the dependency set, and that job is a
+  # containerless stdlib-Python runner. NOTE for branch protection: this is
+  # its own check context, so it does not gate a merge until it is added to
+  # the required list alongside `Static checks`.
+  sanitizer-option:
+    name: Sanitizer option configures
+    runs-on: ubuntu-latest
+    container: ghcr.io/aethersdr/aethersdr-ci:latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: A valid sanitizer configures, an impossible one is refused
+        shell: bash
+        run: |
+          set -u
+          fail=0
+
+          # 1. thread — the configuration that was IMPOSSIBLE before #5419,
+          #    because Debug hardcoded -fsanitize=address onto four targets and
+          #    address cannot coexist with thread. This is the whole point.
+          if cmake -B /tmp/cfg-thread -S . -G Ninja \
+                   -DAETHERSDR_SANITIZER=thread > /tmp/thread.log 2>&1; then
+            grep -q 'sanitizer = thread' /tmp/thread.log \
+              || { echo "::error::configure succeeded but did not report the sanitizer"; fail=1; }
+          else
+            echo "::error::-DAETHERSDR_SANITIZER=thread failed to configure"
+            tail -30 /tmp/thread.log
+            fail=1
+          fi
+
+          # 2. The digital-voice opt-in must STAND DOWN under thread. This is
+          #    the regression #5419 introduced and caught by hand: the guard
+          #    reads CMAKE_{C,CXX}_FLAGS, add_compile_options never lands
+          #    there, and without the third source 77 translation units got
+          #    both -fsanitize=thread and -fsanitize=address,undefined — a
+          #    COMPILE error, invisible to a configure that succeeds. Assert on
+          #    the generated ninja file, not on the log line, so a reworded
+          #    message cannot make this pass vacuously.
+          if [ -f /tmp/cfg-thread/build.ninja ]; then
+            both=$(grep 'fsanitize=address' /tmp/cfg-thread/build.ninja | grep -c 'fsanitize=thread' || true)
+            if [ "${both:-0}" -ne 0 ]; then
+              echo "::error::$both translation units carry BOTH thread and address sanitizers (#4360 shape)"
+              fail=1
+            fi
+          fi
+
+          # 3. address+thread must be refused AT CONFIGURE, with the reason.
+          #    Discovering it at link is what cost five weeks in #4360.
+          if cmake -B /tmp/cfg-both -S . -G Ninja \
+                   -DAETHERSDR_SANITIZER=address,thread > /tmp/both.log 2>&1; then
+            echo "::error::address,thread configured successfully; it must be refused"
+            fail=1
+          else
+            grep -q 'cannot be combined' /tmp/both.log \
+              || { echo "::error::address,thread was refused, but not with the expected reason"; tail -20 /tmp/both.log; fail=1; }
+          fi
+
+          # 4. An unknown value must be refused too, so a typo is not silently
+          #    passed to the compiler.
+          if cmake -B /tmp/cfg-bogus -S . -G Ninja \
+                   -DAETHERSDR_SANITIZER=bogus > /tmp/bogus.log 2>&1; then
+            echo "::error::an unknown sanitizer name configured successfully"
+            fail=1
+          fi
+
+          exit "$fail"
+
   static-checks:
     name: Static checks
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,10 +96,18 @@ set_property(CACHE AETHERSDR_SANITIZER PROPERTY STRINGS
              none address undefined "address,undefined" thread)
 
 if(NOT AETHERSDR_SANITIZER STREQUAL "none")
+    # NOTE: CMake sets MSVC true for clang-cl as well as cl.exe, because
+    # clang-cl simulates the MSVC driver. Refusing both is deliberate: this
+    # block emits only the GNU `-fsanitize=` spelling, and clang-cl wants
+    # `/fsanitize=`, so letting it through would fail later with a worse
+    # message. The wording names clang-cl so someone already using Clang does
+    # not read this as a condition they have satisfied (#5419 review).
     if(MSVC)
         message(FATAL_ERROR
-            "AETHERSDR_SANITIZER=${AETHERSDR_SANITIZER} is not supported with MSVC. "
-            "Use a GCC or Clang build.")
+            "AETHERSDR_SANITIZER=${AETHERSDR_SANITIZER} is not supported with the "
+            "MSVC driver, which includes clang-cl — those need the /fsanitize= "
+            "spelling, and this option emits the GNU -fsanitize= form. Use a "
+            "GNU-driver GCC or Clang build.")
     endif()
     string(REPLACE "," ";" _aether_san_list "${AETHERSDR_SANITIZER}")
     foreach(_aether_san IN LISTS _aether_san_list)
@@ -117,6 +125,15 @@ if(NOT AETHERSDR_SANITIZER STREQUAL "none")
             "collision that broke the TSan lane in #4360; configure one or the "
             "other.")
     endif()
+    # -g3 and -fno-omit-frame-pointer are applied to EVERY configuration here,
+    # not just Debug, and that is deliberate: a sanitizer report without symbols
+    # and frame pointers is a stack of addresses, which is worth roughly
+    # nothing. The consequence to know about is that
+    # `-DAETHERSDR_SANITIZER=address -DCMAKE_BUILD_TYPE=Release` gives you a
+    # Release build carrying full debug info — surprising if you reached for
+    # Release to keep the build small (#5419 review). Reaching for a sanitizer
+    # at all says you want the report legible; the plain Debug flags at the
+    # bottom of this file stay $<CONFIG:Debug>-scoped and are unaffected.
     add_compile_options(-fsanitize=${AETHERSDR_SANITIZER} -fno-omit-frame-pointer -g3)
     add_link_options(-fsanitize=${AETHERSDR_SANITIZER})
     message(STATUS "AetherSDR: sanitizer = ${AETHERSDR_SANITIZER} (whole tree)")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,65 @@ option(ENABLE_ASR "Enable on-device speech-to-text (ASR) via vendored whisper.cp
 option(ASR_USE_PREBUILT_WHISPER_GPU
     "Windows CI: consume prebuilt whisper-gpu asset instead of building from source" OFF)
 option(ENABLE_MQTT "Enable MQTT client support" ON)
+
+# ── Sanitizers: ONE tree-wide switch ─────────────────────────────────────────
+# Applied through add_compile_options/add_link_options so it reaches EVERY
+# target defined below — the app shell, aethercore, the vendored C, and all
+# ~340 test targets — rather than a hand-picked few.
+#
+# It replaces an unconditional `$<$<CONFIG:Debug>:-fsanitize=address>` that sat
+# on four app-shell targets, which was wrong three ways (#5406, #4833, #4360):
+#
+#   - Every plain Debug build was an ASan build whether the developer asked for
+#     one or not.
+#   - It instrumented those four targets but NOT the ~124 test targets that
+#     link aethercore, so a Debug build failed to link on undefined `__asan_*`
+#     symbols (#4833).
+#   - `-fsanitize=address` cannot coexist with `-fsanitize=thread`, so any
+#     Debug + TSan configuration broke at link. That exact collision took the
+#     weekly TSan lane out for five weeks in July (#4360, `ef227cf1`), and the
+#     lane survives today only because it builds RelWithDebInfo.
+#
+# The weekly lane (.github/workflows/sanitizers.yml) does NOT use this option:
+# it injects flags through CFLAGS/CXXFLAGS/LDFLAGS, which is exactly why the
+# hardcode could be removed without touching the workflow. This switch is for
+# local builds and for anyone reproducing a lane finding.
+#
+# Known limit, shared with the lane: add_compile_options does not reach an
+# ExternalProject child (vendored Opus). Those read CFLAGS from the
+# environment, which is how sanitizers.yml instruments them.
+set(AETHERSDR_SANITIZER "none" CACHE STRING
+    "Sanitizer applied to the whole tree: none|address|undefined|address,undefined|thread")
+set_property(CACHE AETHERSDR_SANITIZER PROPERTY STRINGS
+             none address undefined "address,undefined" thread)
+
+if(NOT AETHERSDR_SANITIZER STREQUAL "none")
+    if(MSVC)
+        message(FATAL_ERROR
+            "AETHERSDR_SANITIZER=${AETHERSDR_SANITIZER} is not supported with MSVC. "
+            "Use a GCC or Clang build.")
+    endif()
+    string(REPLACE "," ";" _aether_san_list "${AETHERSDR_SANITIZER}")
+    foreach(_aether_san IN LISTS _aether_san_list)
+        if(NOT _aether_san MATCHES "^(address|undefined|thread)$")
+            message(FATAL_ERROR
+                "AETHERSDR_SANITIZER: unknown sanitizer '${_aether_san}'. "
+                "Valid: none, address, undefined, address,undefined, thread.")
+        endif()
+    endforeach()
+    # The #4360 collision, refused at configure time rather than at link.
+    if("address" IN_LIST _aether_san_list AND "thread" IN_LIST _aether_san_list)
+        message(FATAL_ERROR
+            "AETHERSDR_SANITIZER: address and thread cannot be combined — they "
+            "instrument the same memory accesses incompatibly. This is the "
+            "collision that broke the TSan lane in #4360; configure one or the "
+            "other.")
+    endif()
+    add_compile_options(-fsanitize=${AETHERSDR_SANITIZER} -fno-omit-frame-pointer -g3)
+    add_link_options(-fsanitize=${AETHERSDR_SANITIZER})
+    message(STATUS "AetherSDR: sanitizer = ${AETHERSDR_SANITIZER} (whole tree)")
+    unset(_aether_san_list)
+endif()
 option(ENABLE_RTL "Enable the experimental receive-only RTL-SDR backend" ON)
 option(MQTT_TLS "Enable MQTT TLS via OpenSSL (disable for AppImage)" ON)
 option(LOWER_CASE_BINARY_NAME "Make the output binary lower case. Only affects Linux" OFF)
@@ -2898,13 +2957,14 @@ foreach(_aether_tgt aethercore aetherdesktop_support AetherSDR aetherd)
     if(MSVC)
         target_compile_options(${_aether_tgt} PRIVATE /W3 /Zc:__cplusplus /permissive- /utf-8 /bigobj)
     else()
+        # No -fsanitize here: sanitizers are a tree-wide switch now
+        # (AETHERSDR_SANITIZER, near the top of this file). Instrumenting these
+        # four targets and not the test targets that link them is what made a
+        # plain Debug build fail to link (#4833, #5406).
         target_compile_options(${_aether_tgt} PRIVATE
             -Wall -Wextra -Wpedantic
-            $<$<CONFIG:Debug>:-g3 -fsanitize=address>
+            $<$<CONFIG:Debug>:-g3>
             $<$<CONFIG:Debug>:-fno-omit-frame-pointer>
-        )
-        target_link_options(${_aether_tgt} PRIVATE
-            $<$<CONFIG:Debug>:-fsanitize=address>
         )
     endif()
 endforeach()

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -150,8 +150,11 @@ if((UNIX OR WIN32) AND ENABLE_DSTAR)
     #     appears in the FLAGS variables, so scanning only those two is blind
     #     to it. That blindness re-creates #4360 exactly, and not in theory:
     #     configuring -DAETHERSDR_SANITIZER=thread with the two-source form
-    #     produced 77 translation units carrying both -fsanitize=thread and
-    #     -fsanitize=address,undefined, and this message did not print.
+    #     produced translation units carrying both -fsanitize=thread and
+    #     -fsanitize=address,undefined, and this message did not print. It was
+    #     77 of them when measured (Debug, Linux/GCC, ENABLE_DSTAR on, at
+    #     #5419); the figure tracks the target list below and will drift, so
+    #     treat it as scale rather than as a number to assert on.
     # When the option is "none" the synthesized string is "-fsanitize=none",
     # which matches nothing in the alternation.
     set(_aether_dv_external_sanitizer OFF)

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -140,8 +140,23 @@ if((UNIX OR WIN32) AND ENABLE_DSTAR)
     # `-fsanitize=` substring, `-fsanitize=kernel-address` stops at the hyphen,
     # and `-fsanitize=address` does not contain `hwaddress`. Reordered lists
     # (`-fsanitize=undefined,thread`) still match.
+    #
+    # THREE sources are scanned, because a sanitizer can arrive three ways and
+    # this guard is only as good as its narrowest blind spot:
+    #   - CMAKE_CXX_FLAGS and CMAKE_C_FLAGS, which is how sanitizers.yml
+    #     delivers them (CXXFLAGS/CFLAGS in the job environment);
+    #   - AETHERSDR_SANITIZER, the tree-wide option (CMakeLists.txt). It
+    #     reaches targets through add_compile_options and therefore NEVER
+    #     appears in the FLAGS variables, so scanning only those two is blind
+    #     to it. That blindness re-creates #4360 exactly, and not in theory:
+    #     configuring -DAETHERSDR_SANITIZER=thread with the two-source form
+    #     produced 77 translation units carrying both -fsanitize=thread and
+    #     -fsanitize=address,undefined, and this message did not print.
+    # When the option is "none" the synthesized string is "-fsanitize=none",
+    # which matches nothing in the alternation.
     set(_aether_dv_external_sanitizer OFF)
-    foreach(_aether_dv_flags "${CMAKE_CXX_FLAGS}" "${CMAKE_C_FLAGS}")
+    foreach(_aether_dv_flags
+            "${CMAKE_CXX_FLAGS}" "${CMAKE_C_FLAGS}" "-fsanitize=${AETHERSDR_SANITIZER}")
         if(_aether_dv_flags MATCHES "-fsanitize=[a-z,]*(thread|memory|hwaddress)")
             set(_aether_dv_external_sanitizer ON)
         endif()


### PR DESCRIPTION
## Summary

`CMakeLists.txt` applied `$<$<CONFIG:Debug>:-fsanitize=address>` unconditionally to four app-shell targets (`aethercore`, `aetherdesktop_support`, `AetherSDR`, `aetherd`). That was wrong three ways, and the three are the two issues this closes plus the one that already cost five weeks:

- **Every plain Debug build was an ASan build**, whether the developer asked for one or not.
- **It instrumented those four targets and not the ~124 test targets that link `aethercore`**, so a Debug build failed to link on undefined `__asan_*` (#4833).
- **`-fsanitize=address` cannot coexist with `-fsanitize=thread`**, so any Debug + TSan configuration broke at link. That exact collision took the weekly TSan lane to zero coverage for five weeks in July (#4360, `ef227cf1`).

Replaced with one `AETHERSDR_SANITIZER` cache option — `none|address|undefined|address,undefined|thread` — applied through `add_compile_options` / `add_link_options` so it reaches **every** target rather than four. Default `none`. The address+thread combination is refused at **configure** time with a pointer to #4360, rather than discovered at link.

`sanitizers.yml` is untouched and needs no change: it injects flags through `CFLAGS`/`CXXFLAGS`/`LDFLAGS`, which is precisely why the hardcode could go.

## The bug this change introduced, and how it was caught

Worth reading before approving, because it is the interesting part and it would have re-broken the lane.

`tests/tests.cmake`'s digital-voice opt-in adds ASan+UBSan to 13 targets and stands down when a *conflicting* sanitizer is already present. It detects that by scanning `CMAKE_CXX_FLAGS` and `CMAKE_C_FLAGS`, which is how `sanitizers.yml` delivers them. `add_compile_options` **never lands in those variables**, so the guard was blind to the new option.

Configuring `-DAETHERSDR_SANITIZER=thread` produced **77 translation units carrying both `-fsanitize=thread` and `-fsanitize=address,undefined`**, with the stand-down message absent — #4360 reproduced by the change written to prevent it. Configure succeeds; only the compile fails, so reading the diff would not have found it.

The guard now scans the option as a third source, with the reasoning recorded at the point of use.

## Verification

**Configure matrix** (Debug, this tree):

| `AETHERSDR_SANITIZER` | Result |
|---|---|
| *(unset)* | no sanitizer applied |
| `address` / `thread` / `address,undefined` | applied tree-wide |
| `address,thread` | **refused at configure**, cites #4360 |
| `bogus` | **refused at configure**, lists the valid values |

**Digital-voice guard**, after the fix:

| Setting | Stand-down message | TUs with both flags | dv opt-in preserved |
|---|---|---|---|
| `thread` | yes | 0 | n/a (correctly disarmed) |
| `address` | no | 0 | 77 |
| `none` | no | 0 | 77 |

**#4833 directly**, not inferred:

- On `main`, default Debug: 384 `aethercore` compile rules carry `-fsanitize=address`; `anan_backend_test`'s link line carries none. That is the mismatch.
- With this change: `anan_backend_test` (which links `aethercore`) **builds and links in Debug**, runs to exit 0, and `nm -D` finds no `__asan` symbols.

**Not verified here:** a full Debug build of every target, and a local TSan run. Debug + TSan now *configures*, which it could not before; whether the whole tree then builds clean under TSan locally is untested and is the natural next step for whoever picks up #5409 / #5410.

Closes #5406.
Closes #4833.
Refs #4360, #5275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
