### PR TITLE
ci(sanitizers): fix the TSan suppressions path, which never loaded. Principle VIII.

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -67,7 +67,7 @@ jobs:
             extra_cxx: "-fsanitize=thread -g3 -fno-omit-frame-pointer -O1"
             extra_ld:  "-fsanitize=thread"
             runtime_env: |
-              TSAN_OPTIONS=halt_on_error=0:second_deadlock_stack=1:history_size=7:print_summary=1:suppressions=${{ github.workspace }}/tests/sanitizers/tsan.supp
+              TSAN_OPTIONS=halt_on_error=0:second_deadlock_stack=1:history_size=7:print_summary=1
 
     steps:
       # The job's `container:` is pulled by the runner BEFORE any step runs, so
@@ -177,6 +177,35 @@ jobs:
           done <<'EOF'
           ${{ matrix.sanitizer.runtime_env }}
           EOF
+
+          # The suppressions path is appended HERE, not carried in the matrix's
+          # runtime_env, and both halves of that matter.
+          #
+          # `${{ github.workspace }}` evaluates to the EMPTY STRING when the
+          # matrix is expanded, so the option arrived as
+          # `suppressions=/tests/sanitizers/tsan.supp` — a path at the
+          # filesystem root. TSan refuses to start when it cannot read the file,
+          # so 337 of 344 tests "failed" in 6.14 s with no sanitizer report of
+          # any kind (run 33889703248). It failed loudly, which is the one good
+          # thing about it, but the lane measured nothing.
+          #
+          # $GITHUB_WORKSPACE (the environment variable) IS correct inside the
+          # container, but runtime_env is delivered through a QUOTED heredoc so
+          # nothing inside it expands — hence a separate line here, after the
+          # export loop, where the shell can see it.
+          if [ "${{ matrix.sanitizer.id }}" = "tsan" ]; then
+            supp="$GITHUB_WORKSPACE/tests/sanitizers/tsan.supp"
+            # Fail on a bad path rather than trusting TSan to notice. TSan does
+            # notice today, but a path that exists and is WRONG would silently
+            # suppress nothing, and a suppression file that is quietly not
+            # loaded is the same class of lie this lane exists to stop.
+            if [ ! -r "$supp" ]; then
+              echo "::error::TSan suppressions file not readable at $supp"
+              exit 1
+            fi
+            export TSAN_OPTIONS="${TSAN_OPTIONS}:suppressions=$supp"
+            echo "TSAN_OPTIONS=$TSAN_OPTIONS"
+          fi
           ec=0
           ctest --test-dir build --no-tests=error --output-on-failure 2>&1 | tee sanitizer.log || ec=$?
           echo "exit=$ec" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -201,6 +201,21 @@ jobs:
             # loaded is the same class of lie this lane exists to stop.
             if [ ! -r "$supp" ]; then
               echo "::error::TSan suppressions file not readable at $supp"
+              # Do NOT bare-exit. This step is continue-on-error, so an exit
+              # here does not end the job — it skips `tee sanitizer.log` and the
+              # outputs.exit write. The report chain then runs anyway ('' is
+              # != '0'), against a log that does not exist; the extract step's
+              # `sed` exits 2 under the default `bash -e`, and that takes the
+              # artifact upload AND the tracking issue with it. Red job, no
+              # artifact, nothing to read — strictly worse than the failure this
+              # guard replaces, which at least filed #5420. Leave the chain
+              # something to report (#5421 review).
+              {
+                echo "TSan suppressions file not readable at $supp"
+                echo "The lane did NOT run: the sanitizer runtime refuses to"
+                echo "start without it, so no result in this run is meaningful."
+              } > sanitizer.log
+              echo "exit=1" >> "$GITHUB_OUTPUT"
               exit 1
             fi
             export TSAN_OPTIONS="${TSAN_OPTIONS}:suppressions=$supp"


### PR DESCRIPTION
## Summary

**This PR fixes the failure that #5420 was opened for.** That issue is the sticky the lane filed automatically for this exact signature — `[sanitizer] TSan weekly run failure (fp 4f6c0532f5ba)` — and the fingerprint is the 337-test failure below. Fixing the path resolves the signature, so this closes it.

The first run of the repaired sanitizer lane (`33889703248`, dispatched on `main` at `83714dc0`) failed **337 of 344 tests in 6.14 seconds** with no sanitizer report of any kind:

```
ThreadSanitizer: failed to read suppressions file '/tests/sanitizers/tsan.supp'
```

`${{ github.workspace }}` evaluates to the **empty string** when the matrix is expanded, so the option reached TSan as a path at the filesystem root. TSan refuses to start when it cannot read its suppressions file, so every test aborted before running. The lane measured nothing.

`$GITHUB_WORKSPACE` (the environment variable) *is* correct inside the container, but `runtime_env` is delivered through a **quoted** heredoc, so nothing inside it expands. The option is therefore appended in the ctest step, after the export loop, where the shell can see it.

Also added an explicit readability check that fails the step with a named `::error::`. TSan does fail loudly on a *missing* file — which is the only reason this was caught — but a path that **exists and is wrong** would silently suppress nothing, and a suppression file that is quietly not loaded is the same class of lie this lane exists to stop.

## Verified

- `bash -n` on the step (it caught a missing `fi` on the first attempt).
- Simulated with a correct workspace: `TSAN_OPTIONS=…:suppressions=<ws>/tests/sanitizers/tsan.supp`.
- Simulated with the empty workspace that caused this: **fails with the named error before any test runs**, instead of after 344 aborted tests.

## What that run did establish

The failure was structural rather than about the tests, so the rest of the run is still informative:

- **The instrumented Qt image works.** The `Confirm the sanitizer image` step passed, so `libQt6Core.so.6` really is linked against libtsan. That was the largest open risk in #5411's S6.
- **ASan + UBSan is GREEN**: 344 tests, 0 failures, 831 s of test time. That lane had failed **every scheduled run since 2026-06-08**.
- **The S5 reporting worked on its first real failure.** It opened a new fingerprinted issue (#5420) rather than burying the run in the old untagged sticky, and the body leads with the failed-test list. This run produced **zero** `SUMMARY:` blocks — precisely the case that used to fingerprint `sha256("")` and report nothing.

## Still unknown

Whether the instrumented Qt is clean under TSan, and whether the trimmed suppression file is correct. **The file has never been loaded.** Both become answerable only once this lands and the lane is re-dispatched.

Closes #5420.
Refs #5275, #3462, #5411.

A note on #5420 itself, since it is a useful artifact: it is the **first issue the new fingerprint machinery ever created**. The run produced zero `SUMMARY:` blocks, which under the old code fingerprinted `sha256("")` and appended an empty report to the untagged sticky #3462. Instead it opened its own issue with the failed-test list leading the body. Closing it from this PR is that round trip completing — a distinct failure signature got its own issue, and the fix for that signature closes it rather than leaving a permanently red sticky behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

