### PR TITLE
fix(hl2): serialise Hl2Spectrum's FFTW use. Principle VIII.

### DIFF
--- a/src/core/backends/hl2/Hl2Spectrum.cpp
+++ b/src/core/backends/hl2/Hl2Spectrum.cpp
@@ -2,6 +2,8 @@
 
 #include <fftw3.h>
 
+#include "core/dsp/WdspChannel.h"
+
 #include <cmath>
 
 namespace AetherSDR::hl2 {
@@ -29,14 +31,50 @@ Hl2Spectrum::Hl2Spectrum(int fftSize) : m_fftSize(fftSize < 2 ? 2 : fftSize)
     if (m_coherentGain < 1e-9)
         m_coherentGain = 1.0;
 
-    m_in = fftw_malloc(sizeof(fftw_complex) * static_cast<std::size_t>(m_fftSize));
-    m_out = fftw_malloc(sizeof(fftw_complex) * static_cast<std::size_t>(m_fftSize));
-    m_plan = fftw_plan_dft_1d(m_fftSize, static_cast<fftw_complex*>(m_in),
-                              static_cast<fftw_complex*>(m_out), FFTW_FORWARD, FFTW_ESTIMATE);
+    {
+        // FFTW's planner is process-global and NOT thread-safe. Hl2Backend's
+        // beginDspSetup() constructs this on its worker while WdspChannel::open()
+        // builds a WDSP channel — which plans, allocates and frees through FFTW
+        // too — so the two raced with nothing between them. TSan, once Qt and the
+        // vendored C were both instrumented (#5275 S4/S6):
+        //
+        //   Write of size 8 by thread T9:  free <- create_fircore (firmin.c:360)
+        //                                       <- OpenChannel <- WdspChannel::open()
+        //   Previous write     by thread T4:  memalign <- fftw_malloc_plain
+        //                                       <- make_unique<Hl2Spectrum>
+        //
+        // AnanSpectrum, the sibling of this class, has taken this same lock since
+        // it hit the same problem; this one never did.
+        //
+        // The lock covers the ALLOCATIONS as well as the plan, which is wider
+        // than AnanSpectrum's — deliberately. AnanSpectrum's comment records the
+        // mallocs as safe unguarded, but the two frames TSan actually names here
+        // are fftw_malloc_plain and free, not the planner, so a plan-only lock
+        // would leave the reported edge unsynchronised. It costs nothing: this
+        // runs once per spectrum construction, never on the audio path.
+        // execute() below stays unguarded, same as AnanSpectrum and
+        // WdspChannel::processIq().
+        //
+        // The evidence came from radiomodel_pan_id_mapping_test, which failed
+        // this way in 4 of 4 sanitizer runs and has since been removed as
+        // intermittent (#5423). The race is not intermittent and is not about
+        // that test: two threads reach a non-thread-safe planner on every HL2
+        // connect, and nothing tests for it now.
+        auto lock = WdspChannel::fftwSetupLock();
+        m_in = fftw_malloc(sizeof(fftw_complex) * static_cast<std::size_t>(m_fftSize));
+        m_out = fftw_malloc(sizeof(fftw_complex) * static_cast<std::size_t>(m_fftSize));
+        m_plan = fftw_plan_dft_1d(m_fftSize, static_cast<fftw_complex*>(m_in),
+                                  static_cast<fftw_complex*>(m_out), FFTW_FORWARD, FFTW_ESTIMATE);
+    }
 }
 
 Hl2Spectrum::~Hl2Spectrum()
 {
+    // Same lock as the constructor, and over the frees for the same reason: the
+    // race TSan reported was a free on one thread against an allocation on
+    // another, so guarding only destroy_plan would leave the teardown half of
+    // that edge open.
+    auto lock = WdspChannel::fftwSetupLock();
     if (m_plan) fftw_destroy_plan(static_cast<fftw_plan>(m_plan));
     if (m_in) fftw_free(m_in);
     if (m_out) fftw_free(m_out);

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -678,12 +678,14 @@ target_include_directories(hl2_receivers_test PRIVATE src)
 target_link_libraries(hl2_receivers_test PRIVATE Qt6::Core)
 add_test(NAME hl2_receivers_test COMMAND hl2_receivers_test)
 
-# HL2 spectrum (FFT panadapter) — standalone, links FFTW3 directly.
-add_executable(hl2_spectrum_test
-    tests/hl2_spectrum_test.cpp
-    src/core/backends/hl2/Hl2Spectrum.cpp)
+# HL2 spectrum (FFT panadapter). This compiled Hl2Spectrum.cpp standalone
+# against FFTW3 with no Qt at all, which stopped working when the class took
+# WdspChannel::fftwSetupLock() to serialise the process-global FFTW planner:
+# WdspChannel.h includes <QMetaType>, and the lock is defined in
+# WdspChannel.cpp. Links aethercore for both, like its RX-DSP siblings below.
+add_executable(hl2_spectrum_test tests/hl2_spectrum_test.cpp)
 target_include_directories(hl2_spectrum_test PRIVATE src ${FFTW3_INCLUDE_DIRS})
-target_link_libraries(hl2_spectrum_test PRIVATE ${FFTW3_LIBRARIES})
+target_link_libraries(hl2_spectrum_test PRIVATE aethercore Qt6::Core ${FFTW3_LIBRARIES})
 add_test(NAME hl2_spectrum_test COMMAND hl2_spectrum_test)
 
 # HL2 RX DSP — IQ -> WdspChannel demod + Hl2Spectrum. Links aethercore (WDSP+FFTW).


### PR DESCRIPTION
## Summary

One file of production change. `Hl2Spectrum` calls FFTW's planner with **no lock at all** while another thread does the same during every HL2 connect.

FFTW's planner is process-global and not thread-safe. This codebase already treats it that way in two places — `SpectralNR` has its own mutex, and `WdspChannel` exposes `fftwSetupLock()` — and **`AnanSpectrum`, this class's sibling, takes that lock with a comment recording that it hit exactly this problem.** `Hl2Spectrum` never took it.

`Hl2Backend::beginDspSetup()` constructs the spectrum on one worker while `WdspChannel::open()` builds a WDSP channel on another:

```
Write of size 8 by thread T9:   free      <- create_fircore (firmin.c:360)
                                          <- OpenChannel <- WdspChannel::open()
Previous write by thread T4:    memalign  <- fftw_malloc_plain
                                          <- make_unique<Hl2Spectrum>
```

The lock is **wider than `AnanSpectrum`'s**, deliberately: that class guards only the plan call and records the allocations as safe unguarded, but the two frames named here are `fftw_malloc_plain` and `free`, not the planner — a plan-only lock would leave the reported edge open. Constructor holds it across both allocations and the plan; destructor across `destroy_plan` and both frees. Construction and teardown only, never the audio path.

## On the evidence — read this before approving

This was found by `radiomodel_pan_id_mapping_test` failing **4 of 4** sanitizer runs. **That test has since been removed** as intermittent, along with seven others, so this fix now lands with **nothing covering it**.

That is not because the race is unproven. It is because the thing that proved it is gone. The race is not intermittent: two threads reach a non-thread-safe planner on every HL2 connect, and the sibling class has guarded against precisely this, for the same reason, since it hit it first.

So the honest position on verification: **reasoning plus precedent, not a passing test.** The change builds and the tree configures clean. If you want a stronger bar than that, the only routes are restoring a test or reviewing the argument on its merits.

## The second commit: a build-graph fallout, not a second fix

Taking the lock broke the one target that compiled `Hl2Spectrum.cpp` **standalone**. `hl2_spectrum_test` built that TU directly against FFTW3 with no Qt on its include path, so the new `#include "core/dsp/WdspChannel.h"` failed on both Linux and macOS:

```
src/core/dsp/WdspChannel.h:3:10: fatal error: QMetaType: No such file or directory
```

A second failure sat behind that one: `fftwSetupLock()` is defined in `WdspChannel.cpp`, which that target never compiled, so it would have failed at **link** even with Qt's headers found.

`Hl2Spectrum.cpp` is already part of `aethercore` (`CMakeLists.txt:622`), so the target drops its standalone copy of the source and links the library plus `Qt6::Core` — matching `hl2_rxdsp_test`, `hl2_noise_blanker_test` and `hl2_am_dcblock_test` immediately below it.

**Worth naming as a real cost, not waving through:** a test that checks FFT bin geometry now pulls in Qt and WDSP. The cleaner shape is to move the FFTW planner mutex into a small header owned by neither class, since the lock is a property of FFTW rather than of `WdspChannel`. Not done here to keep this PR at one file of production change — say the word if you would rather have it that way.

Separately, and **not introduced by this PR**: `SpectralNR` guards the same process-global planner with its own `s_fftwMutex`, independent of `WdspChannel`'s `g_setupMutex`. Two different mutexes do not serialise against each other, so that pairing is still unprotected. Flagging it rather than fixing it here.

Verified locally: full build clean (2905/2905), `hl2_spectrum_test: all checks passed`.

## What this PR used to be

It carried three commits: a `QueuedSpy` harness fix (30/30 races → 0/30, confirmed in CI) and a spectrum-rate rewrite (0/8 failures under TSan at `--cpus=2`). Both fixed tests that have now been deleted, so both were dropped — the branch was rebuilt on current `main` with only this commit.

Refs #5423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

