### PR TITLE
feat(plugins): package the Ulanzi Studio plugin as a release asset

### DIFF
--- a/.github/workflows/streamdeck-plugins.yml
+++ b/.github/workflows/streamdeck-plugins.yml
@@ -48,6 +48,17 @@ jobs:
           zip -r ../streamcontroller-aethersdr.zip streamcontroller-aethersdr/ \
             -x "*/__pycache__/*"
 
+      # The Ulanzi Studio plugin ships the same way as the Elgato one: the
+      # bundle directory is zipped as-is. Its `ws` dependency is NOT vendored
+      # into node_modules -- Studio resolves it at load time -- so there is no
+      # install step here, and the packaged file set matches the bundle
+      # exactly. (#3485)
+      - name: Package Ulanzi plugin
+        run: |
+          cd plugins/ulanzi-aethersdr
+          zip -r ../../com.g0jkn.aethersdr.ulanziPlugin.zip \
+            com.g0jkn.aethersdr.ulanziPlugin/
+
       - name: Attach to release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -68,4 +79,5 @@ jobs:
           gh release upload "$TAG" \
             com.aethersdr.radio.streamDeckPlugin \
             streamcontroller-aethersdr.zip \
+            com.g0jkn.aethersdr.ulanziPlugin.zip \
             --clobber

--- a/plugins/ulanzi-aethersdr/com.g0jkn.aethersdr.ulanziPlugin/package.json
+++ b/plugins/ulanzi-aethersdr/com.g0jkn.aethersdr.ulanziPlugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aethersdr-ulanzi-plugin",
-  "version": "0.1.0",
+  "version": "0.1.7",
   "description": "Ulanzi Studio plugin that drives AetherSDR via its TCI WebSocket interface.",
   "type": "module",
   "main": "plugin/app.js",


### PR DESCRIPTION
## The gap

`plugins/ulanzi-aethersdr/README.md` tells users:

> Download the packaged plugin from the [latest AetherSDR release](https://github.com/aethersdr/AetherSDR/releases/latest) (when available).

That asset has never existed. `streamdeck-plugins.yml` packages the Elgato and StreamController plugins on a `v*` tag, but not the Ulanzi one, so "when available" has stayed hypothetical since the plugin landed in-tree.

Raised by @jensenpat while reviewing #5212, where the Windows OEM-variant advisory had nowhere first-party to send users and pointed at a personal repo instead. That link is now removed; this is the other half — giving it somewhere legitimate to point later.

## The change

A third packaging step alongside the existing two, following the Elgato pattern exactly — `cd` into the plugin directory, zip the bundle folder as-is to the workspace root — plus the new zip on the same `gh release upload`.

```yaml
- name: Package Ulanzi plugin
  run: |
    cd plugins/ulanzi-aethersdr
    zip -r ../../com.g0jkn.aethersdr.ulanziPlugin.zip \
      com.g0jkn.aethersdr.ulanziPlugin/
```

**No install step**, and that is deliberate rather than an oversight. The bundle's only dependency (`ws`) is not vendored into `node_modules` — Ulanzi Studio resolves it at load time, which is how the standalone releases have shipped since v0.1.0. The zip is the bundle directory verbatim.

Also syncs `package.json` to **0.1.7** to match `manifest.json` in the same bundle. Only `package.json` was left at 0.1.0, so the packaged zip would have carried two disagreeing version numbers.

## Verified

Built the zip from this tree and diffed it against the published v0.1.7 asset:

| | files | result |
|---|---:|---|
| Published v0.1.7 asset | 72 | — |
| Built from this tree | 72 | same set |

The only difference is the vendored Ulanzi SDK's `LICENSE` vs `LICENSE.txt` filename — a discrepancy in the standalone repo, not something this step introduces.

Workflow YAML parses, and the new step lands between **Package StreamController plugin** and **Attach to release**. Relative paths match Elgato's (`cd plugins/<dir>` then `../../`), so the zip lands in the workspace root where the upload step expects it. `package.json` still parses.

## Not verified

The upload path itself. `upload-plugins` runs only on a `v*` tag push, so a PR cannot exercise it — the same limit that applies to the two existing packaging steps.

## Note for a maintainer

The in-tree plugin is **GPL-3.0-or-later**; the standalone repo it currently ships from is **Apache-2.0**, under the same `com.g0jkn.aethersdr.ulanziPlugin` id. Once the zip ships from this repo that inconsistency should be resolved rather than duplicated, and I'd rather a maintainer ruled on which licence the shipped artifact carries than pick one myself. Happy to follow up either way.

I have not touched `release.yml` or any build-time CI gate — this is a release-time packaging step in the workflow that already owns plugin packaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
