### PR TITLE
feat(kiwi): read the public directory from the AetherSDR CDN mirror

### DIFF
--- a/docs/architecture/aetherd-touchpoint-tags.json
+++ b/docs/architecture/aetherd-touchpoint-tags.json
@@ -271,7 +271,7 @@
  },
  "core/KiwiPublicDirectory.h": {
   "tag": "vendor(kiwi)",
-  "note": "Fetches/parses kiwisdr.com/public directory + per-sysop ext_api policy; KiwiSDR ecosystem discovery only.",
+  "note": "Fetches/parses AetherSDR's kiwi.json mirror of the kiwisdr.com/public directory + per-sysop ext_api policy; KiwiSDR ecosystem discovery only.",
   "split": "",
   "confidence": "high"
  },

--- a/docs/architecture/aetherd-touchpoints.md
+++ b/docs/architecture/aetherd-touchpoints.md
@@ -68,7 +68,7 @@ Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine
 | `core/IConnectionAutomation.h` | 1 | ui-support — Gui-free connect/disconnect/dialog hook the automation bridge drives; bridge plumbing, not radio state. | unconverted |
 | `core/IambicKeyer.h` | 3 | universal — Radio-agnostic software iambic state machine for local sidetone + CW paddle/keying intent; no vendor coupling. | unconverted |
 | `core/IssueReport.h` | 1 | ui-support — Renders a pre-filled GitHub issue body from a SupportBundle snapshot, with PII redaction applied at the render boundary (GHSA-ccrg-j8cp-qhc4). Support and diagnostics tooling; not radio state. | unconverted |
-| `core/KiwiPublicDirectory.h` | 1 | vendor(kiwi) — Fetches/parses kiwisdr.com/public directory + per-sysop ext_api policy; KiwiSDR ecosystem discovery only. | unconverted |
+| `core/KiwiPublicDirectory.h` | 1 | vendor(kiwi) — Fetches/parses AetherSDR's kiwi.json mirror of the kiwisdr.com/public directory + per-sysop ext_api policy; KiwiSDR ecosystem discovery only. | unconverted |
 | `core/KiwiSdrClient.h` | 2 | vendor(kiwi) — KiwiSDR WebSocket protocol client (SND/WF streams, ADPCM, camp/monitor states) — the kiwi backend itself | unconverted |
 | `core/KiwiSdrManager.h` | 8 | vendor(kiwi) — KiwiSDR connection/profile manager: Kiwi protocol state, telemetry, waterfall/audio streams; vendor extension. | unconverted |
 | `core/KiwiSdrProtocol.h` | 8 | vendor(kiwi) — KiwiSDR websocket wire protocol: SND/W/F frame decode, ADPCM, MSG tokens, camp/auth, kiwi command formatting | unconverted |

--- a/docs/kiwi-json-schema.md
+++ b/docs/kiwi-json-schema.md
@@ -1,0 +1,151 @@
+# `kiwi.json` — schema 1
+
+The reviewable, in-tree contract for the payload AetherSDR's directory mirror
+publishes at `https://cdn.aethersdr.com/kiwi.json`. The producer (a Cloudflare
+Worker that pulls `kiwisdr.com/public` hourly under a shared secret the KiwiSDR
+maintainer provided) lives outside this repository, so this file is what
+`KiwiPublicDirectory::kSupportedSchema` actually pins the client to.
+
+**Changing anything below is a schema break.** Bump `schema`, and bump
+`kSupportedSchema` in `src/core/KiwiPublicDirectory.h` in the same breath — the
+client rejects an unrecognised `schema` outright rather than parsing on
+hopefully, so an unannounced field change turns into "please update AetherSDR"
+for every user rather than silent misbehaviour.
+
+See `docs/kiwisdr-public-directory.md` for *why* the mirror exists and how
+AetherSDR honors each operator's policy.
+
+## Transport
+
+| | |
+|---|---|
+| URL | `https://cdn.aethersdr.com/kiwi.json` |
+| Content-Type | `application/json; charset=utf-8` |
+| Cache-Control | `public, max-age=1800` — clients must not poll faster |
+| CORS | open (`access-control-allow-origin: *`) |
+| `x-receiver-count` | receiver count, mirrors `receiver_count` |
+| `x-fetched-at` | mirror pull time, mirrors `fetched_at` |
+| Typical size | ~824 KB raw, ~126 KB gzipped, ~870 receivers |
+
+Mirror health, for humans rather than the client: `https://kiwi-status.aethersdr.com/`.
+
+## Envelope
+
+One JSON **object** — not an array. A top-level array is a hard parse failure.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `schema` | int | **yes** | `1`. Any other value is refused by the client. |
+| `source` | string | no | Origin the mirror pulled, e.g. `https://files.kiwisdr.com/public/` |
+| `fetched_at` | string | no | ISO-8601 UTC, e.g. `2026-09-05T14:00:01Z`. Converted with `toUTC()`, so an offset form is handled correctly. Drives the picker's staleness display at 360 minutes. |
+| `receiver_count` | int | no | Advisory; the client trusts `receivers.length`. |
+| `receivers` | array | **yes** | Objects. See below. |
+
+Client-side bounds (`Principle VII`): body `> 32 MB` or `receivers.length >
+20000` is refused, and an empty `receivers` array is reported as an *empty*
+directory rather than a malformed one.
+
+## Receiver objects
+
+An entry with no `url` is skipped. Every other field is optional — the client
+must never assume presence. Counts below are from the 870-receiver payload of
+2026-09-05.
+
+### Fields AetherSDR reads
+
+| Field | Type | Present | Maps to | Notes |
+|---|---|---|---|---|
+| `url` | string | 870/870 | `url` | `http://host[:port]`. **Required**; may be a `*.proxy.kiwisdr.com` host. |
+| `id` | string | 870/870 | `id` | Origin's stable id, e.g. `884aeaf59cc6` |
+| `name` | string | 870/870 | `name` | Sysop description |
+| `loc` | string | 870/870 | `location` | Free text |
+| `antenna` | string | 870/870 | `antenna` | Free text |
+| `sdr_hw` | string | 870/870 | `sdrHw` | Free text; a whitespace-delimited `Limits` **token** drives `advertisesConnectionLimit()` |
+| `grid` | string | 855/870 | `grid` | Maidenhead. **Optional.** |
+| `users` | int | 870/870 | `users` | Clamped to `>= 0` |
+| `users_max` | int | 870/870 | `usersMax` | Clamped to `>= 0`; denominator of the policy classification |
+| **`ext_api`** | int | **847/870** | `extApi` | **See below — the load-bearing field.** |
+| `offline` | bool | 870/870 | `offline` | Real JSON bool. The string `"yes"`/`"true"` is still accepted for older snapshots. |
+| `flagged` | bool | 870/870 | `flagged` | Origin marks the entry as bad; hidden by the picker (30/870) |
+| `gps` | `[lat, lon]` | 870/870 | `gpsLat`/`gpsLon`/`hasGps` | Numbers. `[0, 0]` means *no fix*, not null island. Out-of-range values leave `hasGps` false. |
+| `bands` | `[low, high]` | 870/870 | `bandLowHz`/`bandHighHz`/`hasBands` | Hz. `high <= low` leaves `hasBands` false. |
+| `snr` | `[all, hf]` | 870/870 | `snrAll`/`snrHf` | dB. Falls back to the scalar `snr_all`/`snr_hf` keys. |
+| `snr_all` | int | 870/870 | `snrAll` | Fallback for `snr[0]` |
+| `snr_hf` | int | 870/870 | `snrHf` | Fallback for `snr[1]` |
+
+Strings are truncated at 512 characters on the way in.
+
+### `ext_api` — the field this contract exists for
+
+`ext_api` is the operator's external-API allowance: the maximum number of
+channels open to non-browser API clients. AetherSDR honors it *before* offering
+a connection.
+
+| Value | `apiPolicy()` | Offered? |
+|---|---|---|
+| `0` | `Disabled` — operator wants web-browser use only | no |
+| `1 … users_max-1` | `Limited` | yes |
+| `>= users_max` | `Open` | yes |
+| **key absent** | `Unknown` — policy not published | no |
+
+**A receiver that does not publish a policy omits the key entirely** — 23 of 870
+today. The producer must keep it that way: emitting `"ext_api": 0` for those
+receivers would tell every client that 23 operators *disabled* their API when in
+fact they said nothing, and emitting `null` or a string would land them in
+`Unknown` by a different route than the one that is tested.
+
+On the client side this is why the parser reads
+`extApiVal.isDouble() ? extApiVal.toInt(-1) : -1` rather than `toInt()`, and why
+`tests/kiwi_public_directory_test.cpp` asserts on `extApi == -1` specifically.
+
+### Fields the origin publishes that AetherSDR ignores
+
+Present in all 870 entries and safe for the producer to keep emitting; the
+client neither reads nor validates them, so adding to this set is **not** a
+schema break:
+
+`adc_ov`, `ant_connected`, `asl`, `avatar_ctime`, `clk_ext_freq`,
+`clk_ext_gps`, `date`, `debian`, `dx_file`, `fixes`, `fixes_hour`, `fixes_min`,
+`freq_offset`, `gps_date`, `gps_good`, `ip_blacklist`, `preempt`, `seq`,
+`status`, `sw_version`, `tdoa_ch`, `tdoa_id`, `updated`, `uptime`
+
+Also optional and unread: `mode` (847/870), `sm_cal` / `wf_cal` (845/870).
+
+## Compatibility rules for the producer
+
+1. **Adding an ignored field** — safe, no bump.
+2. **Removing or retyping a field in "Fields AetherSDR reads"** — schema break.
+3. **Emitting `ext_api: 0` where the key used to be absent** — schema break, and
+   the most damaging one available: it silently misreports operator policy.
+4. **Changing `gps`/`bands`/`snr` from pairs to anything else** — schema break.
+5. **Changing `offline`/`flagged` away from JSON bools** — schema break.
+
+## Example
+
+```json
+{
+  "schema": 1,
+  "source": "https://files.kiwisdr.com/public/",
+  "fetched_at": "2026-09-05T14:00:01Z",
+  "receiver_count": 870,
+  "receivers": [
+    {
+      "id": "884aeaf59cc6",
+      "url": "http://kiwisdr.areg.org.au:8074",
+      "name": "2-30MHZ SDR #2, VK5ARG Remote Receiver Site",
+      "loc": "Near Tarlee, South Australia",
+      "antenna": "Broadband Monopole (\"J-Dart\")",
+      "sdr_hw": "KiwiSDR 1 v1.902 Limits",
+      "grid": "PF95JR",
+      "gps": [-34.2737, 138.771],
+      "bands": [2000000, 30000000],
+      "snr": [42, 43],
+      "users": 6,
+      "users_max": 8,
+      "ext_api": 4,
+      "offline": false,
+      "flagged": false
+    }
+  ]
+}
+```

--- a/docs/kiwi-json-schema.md
+++ b/docs/kiwi-json-schema.md
@@ -111,6 +111,25 @@ schema break:
 
 Also optional and unread: `mode` (847/870), `sm_cal` / `wf_cal` (845/870).
 
+## A new schema ships at a new URL. Always.
+
+**`https://cdn.aethersdr.com/kiwi.json` serves `schema: 1` in perpetuity.** A
+future schema ships at its own path — `kiwi-v2.json` — which only builds that
+understand it ever request.
+
+This is an operational commitment, not a style preference, and it is the reason
+the sole-source design in [RFC #5447](https://github.com/aethersdr/AetherSDR/issues/5447)
+is safe to live with. The client hard-fails on an unrecognised `schema` and has
+no fallback source, so bumping the number *on this URL* would break "Browse
+public receivers" for **every already-shipped AetherSDR simultaneously** — the
+same thundering-herd shape the mirror exists to prevent, aimed at us instead of
+at the origin, and unrecoverable for anyone who cannot update.
+
+Serving each schema from its own path makes that impossible: old builds keep
+reading the URL they were built against, and a rollout becomes additive rather
+than a flag day. Retire an old path only when the builds that request it are
+genuinely gone, and treat that as its own decision.
+
 ## Compatibility rules for the producer
 
 1. **Adding an ignored field** — safe, no bump.
@@ -119,6 +138,19 @@ Also optional and unread: `mode` (847/870), `sm_cal` / `wf_cal` (845/870).
    the most damaging one available: it silently misreports operator policy.
 4. **Changing `gps`/`bands`/`snr` from pairs to anything else** — schema break.
 5. **Changing `offline`/`flagged` away from JSON bools** — schema break.
+
+A schema break is never resolved by bumping `schema` on the existing URL. See
+the section above: publish the new shape at a new path.
+
+## What the mirror sees
+
+Serving the directory ourselves means AetherSDR's own infrastructure now
+receives, on each fetch, what the third-party origin used to: the client's IP
+address and its `AetherSDR/<version>` User-Agent, on a schedule bounded by the
+30-minute `max-age`. Recorded here as **collected, not incidental** — the
+version is useful precisely for judging which builds are still live if a new
+schema URL is ever needed. See `docs/kiwisdr-public-directory.md` for why this
+is an improvement on the arrangement it replaces.
 
 ## Example
 

--- a/docs/kiwisdr-public-directory.md
+++ b/docs/kiwisdr-public-directory.md
@@ -23,7 +23,9 @@ parses it into JSON, and publishes it:
 | `https://kiwi-status.aethersdr.com/` | mirror health, for humans |
 
 `kiwi.json` is one object — `schema`, `source`, `fetched_at`, `receiver_count`
-and a `receivers` array — served with `cache-control: public, max-age=1800`.
+and a `receivers` array — served with `cache-control: public, max-age=1800`. The payload's field-by-field contract
+is **[`kiwi-json-schema.md`](kiwi-json-schema.md)** — the in-tree source of
+truth that `KiwiPublicDirectory::kSupportedSchema` pins to.
 
 **There is deliberately no fallback to `kiwisdr.com`.** Keeping the old
 HTML-scraping path as a CDN-outage fallback would look free, but it would mean
@@ -71,8 +73,10 @@ parser reads it as `-1` unless the key is actually present, and
   never spoofs a browser. With the mirror in place there is no interactive gate
   to pass and no one-time token to replay — the client makes one plain `GET`
   against our own CDN.
-- **Clients never contact `kiwisdr.com`.** Only AetherSDR's mirror and, once the
-  user chooses a receiver, that receiver itself.
+- **Clients never contact the `kiwisdr.com` directory origin.** Only AetherSDR's
+  mirror and, once the user chooses a receiver, that receiver itself — which for
+  a proxied KiwiSDR is itself a `*.proxy.kiwisdr.com` host. That connection is
+  unchanged by this arrangement.
 - **Refresh respects the mirror's own 30-minute `max-age`.** Opening the picker
   re-serves the session's cached list while it is inside that window and fetches
   once it is past; "Refresh list" always fetches. We never poll faster than the

--- a/docs/kiwisdr-public-directory.md
+++ b/docs/kiwisdr-public-directory.md
@@ -1,51 +1,101 @@
 # KiwiSDR public directory — honest, API-policy-aware access
 
-AetherSDR can populate a picker of public KiwiSDR receivers from the project
-directory at `kiwisdr.com/public`. Because AetherSDR connects to a receiver via
-its native (WebSocket "external API") protocol, it must respect each operator's
-choice about whether that API is allowed — *before* offering or attempting a
-connection.
+AetherSDR can populate a picker of public KiwiSDR receivers. The list comes
+from **AetherSDR's own mirror**, `https://cdn.aethersdr.com/kiwi.json`. Because
+AetherSDR connects to a receiver via its native (WebSocket "external API")
+protocol, it must respect each operator's choice about whether that API is
+allowed — *before* offering or attempting a connection.
+
+## Where the list comes from, and why
+
+**The KiwiSDR maintainer asked us to mirror it.** AetherSDR clients were each
+fetching `kiwisdr.com/public` for themselves, and the aggregate load on his
+server was a problem. The mirror is his requested remedy: we pull once, cache,
+and redistribute to our own users, so his server sees **one request per hour**
+instead of hundreds of ad-hoc ones.
+
+A Cloudflare Worker pulls the origin hourly under a shared secret he provided,
+parses it into JSON, and publishes it:
+
+| URL | What |
+|---|---|
+| `https://cdn.aethersdr.com/kiwi.json` | the receiver list (`schema: 1`) |
+| `https://kiwi-status.aethersdr.com/` | mirror health, for humans |
+
+`kiwi.json` is one object — `schema`, `source`, `fetched_at`, `receiver_count`
+and a `receivers` array — served with `cache-control: public, max-age=1800`.
+
+**There is deliberately no fallback to `kiwisdr.com`.** Keeping the old
+HTML-scraping path as a CDN-outage fallback would look free, but it would mean
+that the moment our CDN has a bad day, every AetherSDR install in the world
+reverts to hitting his origin at once — recreating exactly the load he asked us
+to remove, at the least convenient possible moment. When the mirror is
+unreachable, AetherSDR shows the list it already has, or says plainly that the
+directory is unavailable.
 
 ## The operator signal: `ext_api`
 
-Every receiver entry in the public directory publishes an `ext_api` value (it is
-also in each receiver's `/status`). It is the operator's **external-API
-allowance** — the maximum number of channels open to non-browser API clients:
+Every receiver entry publishes an `ext_api` value (it is also in each receiver's
+`/status`). It is the operator's **external-API allowance** — the maximum number
+of channels open to non-browser API clients:
 
 | `ext_api` | meaning |
 |---|---|
 | `0` | **External API disabled** — operator wants web-browser use only |
 | `1 … users_max-1` | API allowed, but some channels reserved for web users |
 | `>= users_max` | all channels open to API |
+| *key absent* | **policy not published** — not the same as `0` |
 
-`src/core/KiwiPublicDirectory.{h,cpp}` reads this and exposes it as
-`KiwiPublicReceiver::apiPolicy()` and the honor predicate
-`mayConnectViaApi()` (`ext_api > 0`).
+That last row is load-bearing. In `kiwi.json` a receiver that does not publish a
+policy has **no `ext_api` key at all** (23 of ~870 entries today). Reading it as
+`obj["ext_api"].toInt()` would yield `0` and silently reclassify every one of
+those operators as having *disabled* the API. That fails safe for the connection
+decision, but it misreports the operator's policy in the badge and in the
+picker's hidden-receiver counts — the thing this code exists to get right. The
+parser reads it as `-1` unless the key is actually present, and
+`tests/kiwi_public_directory_test.cpp` asserts on `extApi == -1` specifically
+(asserting only on `mayConnectViaApi()` would pass with the bug in place).
+
+`src/core/KiwiPublicDirectory.{h,cpp}` exposes this as
+`KiwiPublicReceiver::apiPolicy()` and the honor predicate `mayConnectViaApi()`
+(`ext_api > 0`).
 
 ## How AetherSDR honors it
 
 - **The receiver picker shows only API-permitted receivers.** Receivers with
   `ext_api == 0` are **filtered out entirely** — they are never presented to the
-  user and AetherSDR never attempts a native connection to them.
+  user and AetherSDR never attempts a native connection to them. Receivers that
+  publish no policy are likewise not offered, and are counted separately in the
+  picker's status line. Entries the origin itself has `flagged` are also hidden.
 - AetherSDR identifies **honestly** with an `AetherSDR/<version>` User-Agent and
-  **never spoofs a browser** to get past the directory's interactive gate. If an
-  operator blocks AetherSDR, that is their answer and it is honored.
-- The directory fetch is **strictly manual** — only on an explicit user action
-  (e.g. clicking "Browse public receivers"). No background polling, no timed
-  refresh, no caching-and-redistribution, no enumeration. One human action = one
-  fetch.
-- Only the server-published directory (HTML comments) and per-receiver `/status`
-  are read — never the KiwiSDR source (clean-room, Principle IV).
+  never spoofs a browser. With the mirror in place there is no interactive gate
+  to pass and no one-time token to replay — the client makes one plain `GET`
+  against our own CDN.
+- **Clients never contact `kiwisdr.com`.** Only AetherSDR's mirror and, once the
+  user chooses a receiver, that receiver itself.
+- **Refresh respects the mirror's own 30-minute `max-age`.** Opening the picker
+  re-serves the session's cached list while it is inside that window and fetches
+  once it is past; "Refresh list" always fetches. We never poll faster than the
+  data can actually change. The picker surfaces the list's age once it exceeds
+  the mirror's 360-minute staleness threshold.
+- The client validates the mirror's response at the boundary
+  ([Principle VII](../CONSTITUTION.md#vii-untrusted-input-is-validated-at-the-boundary)):
+  the body size and receiver count are capped, a `schema` other than `1` is
+  rejected with a "please update AetherSDR" message rather than parsed
+  hopefully, and a malformed body fails closed instead of yielding a partial
+  list.
+- Only server-published data is read — never the KiwiSDR source (clean-room,
+  [Principle IV](../CONSTITUTION.md#iv-every-contribution-is-clean-room)).
 
 ## Proof of concept
 
-`tools/kiwi_directory_poc.cpp` (target `kiwi_directory_poc`) performs the honest
-fetch and prints the per-operator policy breakdown and the honor decision for
-each `ext_api == 0` receiver. `tests/kiwi_public_directory_test.cpp` locks the
-parser + policy logic (a web-only receiver must never be API-connectable, and
-must be excluded by the picker filter).
+`tools/kiwi_directory_poc.cpp` (target `kiwi_directory_poc`) fetches the mirror
+and prints the per-operator policy breakdown — including the policy-unknown
+count as its own category — and the honor decision for each `ext_api == 0`
+receiver. `tests/kiwi_public_directory_test.cpp` locks the parser + policy logic
+across all four `ext_api` regimes, and locks the boundary failures.
 
 ```
-$ kiwi_directory_poc            # honest live fetch
-$ kiwi_directory_poc page.html  # offline parse of a saved directory page
+$ kiwi_directory_poc                 # fetch from the AetherSDR mirror
+$ kiwi_directory_poc kiwi.json       # offline parse of a saved payload
 ```

--- a/docs/kiwisdr-public-directory.md
+++ b/docs/kiwisdr-public-directory.md
@@ -27,6 +27,12 @@ and a `receivers` array — served with `cache-control: public, max-age=1800`. T
 is **[`kiwi-json-schema.md`](kiwi-json-schema.md)** — the in-tree source of
 truth that `KiwiPublicDirectory::kSupportedSchema` pins to.
 
+This also moves the browse off a third party. The old client fetched
+`http://kiwisdr.com/public/` — **plaintext HTTP**, so each user's directory
+browse exposed their IP and User-Agent both to an operator we have no agreement
+with and to any on-path observer. The mirror is HTTPS and first-party: the same
+request now goes somewhere the project can actually answer questions about.
+
 **There is deliberately no fallback to `kiwisdr.com`.** Keeping the old
 HTML-scraping path as a CDN-outage fallback would look free, but it would mean
 that the moment our CDN has a bad day, every AetherSDR install in the world

--- a/docs/kiwisdr-public-directory.md
+++ b/docs/kiwisdr-public-directory.md
@@ -83,6 +83,12 @@ parser reads it as `-1` unless the key is actually present, and
   mirror and, once the user chooses a receiver, that receiver itself — which for
   a proxied KiwiSDR is itself a `*.proxy.kiwisdr.com` host. That connection is
   unchanged by this arrangement.
+- **What the mirror sees is stated, not incidental.** Each fetch gives
+  AetherSDR's infrastructure the client's IP and its `AetherSDR/<version>`
+  User-Agent — the same pair the third-party origin used to receive over
+  plaintext HTTP. The version is deliberately retained: it is what tells us
+  which builds are still live if a new schema URL is ever needed. Recorded as
+  collected, in [`kiwi-json-schema.md`](kiwi-json-schema.md#what-the-mirror-sees).
 - **Refresh respects the mirror's own 30-minute `max-age`.** Opening the picker
   re-serves the session's cached list while it is inside that window and fetches
   once it is past; "Refresh list" always fetches. We never poll faster than the

--- a/src/core/KiwiPublicDirectory.cpp
+++ b/src/core/KiwiPublicDirectory.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <memory>
 
 namespace AetherSDR {
 
@@ -183,10 +184,12 @@ KiwiDirectoryParse KiwiPublicDirectory::parse(const QByteArray& json)
         return result;
     }
 
+    // toUTC() converts; setTimeSpec() would only relabel, discarding the offset
+    // of a "+02:00" form and mis-aging the list by exactly that offset.
     result.fetchedAt = QDateTime::fromString(
         boundedString(root.value(QStringLiteral("fetched_at"))), Qt::ISODate);
     if (result.fetchedAt.isValid())
-        result.fetchedAt.setTimeSpec(Qt::UTC);
+        result.fetchedAt = result.fetchedAt.toUTC();
 
     QVector<KiwiPublicReceiver> receivers;
     receivers.reserve(arr.size());
@@ -265,7 +268,7 @@ KiwiDirectoryParse KiwiPublicDirectory::parse(const QByteArray& json)
     }
 
     if (receivers.isEmpty()) {
-        result.error = QStringLiteral("receiver directory contained no usable receivers");
+        result.error = QStringLiteral("the receiver directory is empty");
         return result;
     }
 
@@ -288,8 +291,25 @@ void KiwiPublicDirectory::fetch()
     req.setTransferTimeout(kDirectoryFetchTimeoutMs);
     QNetworkReply* reply = m_net->get(req);
 
-    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+    // Bound the transfer where the bytes actually enter (Principle VII):
+    // QNetworkReply buffers the whole response, so a cap checked only in
+    // parse() would reject an oversized body we had already allocated in full.
+    auto oversized = std::make_shared<bool>(false);
+    connect(reply, &QNetworkReply::downloadProgress, this,
+            [reply, oversized](qint64 received, qint64 total) {
+                if (received <= kMaxBodyBytes && total <= kMaxBodyBytes)
+                    return;
+                *oversized = true;
+                reply->abort();
+            });
+
+    connect(reply, &QNetworkReply::finished, this, [this, reply, oversized]() {
         reply->deleteLater();
+        if (*oversized) {
+            emit failed(QStringLiteral("receiver directory is implausibly large "
+                                       "(over %1 MB)").arg(kMaxBodyBytes / (1024 * 1024)));
+            return;
+        }
         if (reply->error() != QNetworkReply::NoError) {
             emit failed(reply->errorString());
             return;

--- a/src/core/KiwiPublicDirectory.cpp
+++ b/src/core/KiwiPublicDirectory.cpp
@@ -1,11 +1,18 @@
 #include "KiwiPublicDirectory.h"
 
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QJsonValue>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QRegularExpression>
-#include <QRegularExpressionMatchIterator>
 #include <QUrl>
+
+#include <algorithm>
+#include <cmath>
 
 namespace AetherSDR {
 
@@ -13,6 +20,55 @@ namespace {
 // Per-request transfer timeout so a stalled server can't leave the picker stuck
 // on "Loading…" forever (the only escape would otherwise be Cancel).
 constexpr int kDirectoryFetchTimeoutMs = 15000;
+
+// Longest sysop-supplied string we keep.  The body is already capped, but a
+// single pathological field should not reach the UI at megabyte length either
+// (Principle VII — bound it where the bytes enter).
+constexpr int kMaxFieldChars = 512;
+
+QString boundedString(const QJsonValue& v)
+{
+    if (!v.isString())
+        return QString();
+    QString s = v.toString().trimmed();
+    if (s.size() > kMaxFieldChars)
+        s.truncate(kMaxFieldChars);
+    return s;
+}
+
+// The origin publishes offline as a real JSON bool; older snapshots used the
+// string "yes"/"no".  Anything else is "not offline".
+bool readOffline(const QJsonValue& v)
+{
+    if (v.isBool())
+        return v.toBool();
+    if (v.isString()) {
+        const QString s = v.toString().trimmed();
+        return s.compare(QLatin1String("yes"), Qt::CaseInsensitive) == 0
+            || s.compare(QLatin1String("true"), Qt::CaseInsensitive) == 0;
+    }
+    return false;
+}
+
+// A non-negative count, or 0 for anything missing or nonsensical.
+int readCount(const QJsonValue& v)
+{
+    if (!v.isDouble())
+        return 0;
+    const double d = v.toDouble(0.0);
+    if (!std::isfinite(d) || d <= 0.0)
+        return 0;
+    return static_cast<int>(std::min(d, 1.0e6));
+}
+
+// A finite number from a JSON array slot, or fallback.
+double readNumber(const QJsonArray& a, int i, double fallback)
+{
+    if (i >= a.size() || !a.at(i).isDouble())
+        return fallback;
+    const double d = a.at(i).toDouble(fallback);
+    return std::isfinite(d) ? d : fallback;
+}
 } // namespace
 
 QByteArray KiwiPublicDirectory::userAgent()
@@ -61,57 +117,160 @@ QString KiwiPublicReceiver::connectionLimitBadge() const
         : QString();
 }
 
-QVector<KiwiPublicReceiver> KiwiPublicDirectory::parse(const QByteArray& directoryHtml)
+QString KiwiPublicReceiver::bandRangeLabel() const
 {
-    QVector<KiwiPublicReceiver> out;
-    const QString html = QString::fromUtf8(directoryHtml);
+    if (!hasBands)
+        return QString();
+    const auto mhz = [](qint64 hz) {
+        return QString::number(static_cast<double>(hz) / 1e6, 'f', 1);
+    };
+    return QStringLiteral("%1 – %2 MHz").arg(mhz(bandLowHz), mhz(bandHighHz));
+}
 
-    // Each receiver entry is an <a href='http://host:port' target='_blank'>
-    // anchor followed by a block of <!-- key=value --> metadata comments,
-    // running up to the next anchor.
-    static const QRegularExpression anchorRe(
-        QStringLiteral("<a href='(https?://[^']+)'[^>]*target='_blank'[^>]*>"));
-    static const QRegularExpression fieldRe(
-        QStringLiteral("<!--\\s*([A-Za-z_]+)=(.*?)\\s*-->"));
+KiwiDirectoryParse KiwiPublicDirectory::parse(const QByteArray& json)
+{
+    KiwiDirectoryParse result;
 
-    QRegularExpressionMatchIterator anchors = anchorRe.globalMatch(html);
-    while (anchors.hasNext()) {
-        const QRegularExpressionMatch a = anchors.next();
-        const int blockStart = a.capturedEnd();
-        // Block ends at the next anchor (peek without consuming the iterator).
-        const QRegularExpressionMatch nextA = anchorRe.match(html, blockStart);
-        const int blockEnd = nextA.hasMatch() ? nextA.capturedStart() : html.size();
-        const QString block = html.mid(blockStart, blockEnd - blockStart);
+    if (json.isEmpty()) {
+        result.error = QStringLiteral("empty response from the receiver directory");
+        return result;
+    }
+    if (json.size() > kMaxBodyBytes) {
+        result.error = QStringLiteral("receiver directory is implausibly large (%1 bytes)")
+                           .arg(json.size());
+        return result;
+    }
+
+    QJsonParseError perr{};
+    const QJsonDocument doc = QJsonDocument::fromJson(json, &perr);
+    if (perr.error != QJsonParseError::NoError || !doc.isObject()) {
+        result.error = QStringLiteral("receiver directory is not valid JSON (%1)")
+                           .arg(perr.error != QJsonParseError::NoError
+                                    ? perr.errorString()
+                                    : QStringLiteral("expected a JSON object"));
+        return result;
+    }
+    const QJsonObject root = doc.object();
+
+    // Schema gate.  We refuse to parse on hopefully: the fields this class
+    // exists to get right (ext_api above all) could have changed meaning.
+    const QJsonValue schemaVal = root.value(QStringLiteral("schema"));
+    if (!schemaVal.isDouble()) {
+        result.error = QStringLiteral("receiver directory has no schema version");
+        return result;
+    }
+    result.schema = schemaVal.toInt(0);
+    if (result.schema != kSupportedSchema) {
+        result.error = QStringLiteral(
+                           "receiver directory uses schema %1, but this build of "
+                           "AetherSDR understands only schema %2 — please update "
+                           "AetherSDR")
+                           .arg(result.schema)
+                           .arg(kSupportedSchema);
+        return result;
+    }
+
+    const QJsonValue rxVal = root.value(QStringLiteral("receivers"));
+    if (!rxVal.isArray()) {
+        result.error = QStringLiteral("receiver directory has no receiver list");
+        return result;
+    }
+    const QJsonArray arr = rxVal.toArray();
+    if (arr.size() > kMaxReceivers) {
+        result.error = QStringLiteral("receiver directory lists %1 receivers, "
+                                      "far more than any plausible list")
+                           .arg(arr.size());
+        return result;
+    }
+
+    result.fetchedAt = QDateTime::fromString(
+        boundedString(root.value(QStringLiteral("fetched_at"))), Qt::ISODate);
+    if (result.fetchedAt.isValid())
+        result.fetchedAt.setTimeSpec(Qt::UTC);
+
+    QVector<KiwiPublicReceiver> receivers;
+    receivers.reserve(arr.size());
+    for (const QJsonValue& entry : arr) {
+        if (!entry.isObject())
+            continue;
+        const QJsonObject obj = entry.toObject();
 
         KiwiPublicReceiver rx;
-        rx.url = a.captured(1).trimmed();
-        bool haveName = false, haveMax = false;
+        rx.url = boundedString(obj.value(QStringLiteral("url")));
+        if (rx.url.isEmpty())
+            continue;  // an entry with no endpoint is not a receiver
 
-        QRegularExpressionMatchIterator fields = fieldRe.globalMatch(block);
-        while (fields.hasNext()) {
-            const QRegularExpressionMatch f = fields.next();
-            const QString key = f.captured(1);
-            const QString val = f.captured(2).trimmed();
-            if      (key == QLatin1String("name"))      { rx.name = val; haveName = true; }
-            else if (key == QLatin1String("loc"))       rx.location = val;
-            else if (key == QLatin1String("antenna"))   rx.antenna = val;
-            else if (key == QLatin1String("sdr_hw"))    rx.sdrHw = val;
-            else if (key == QLatin1String("grid"))      rx.grid = val;
-            else if (key == QLatin1String("gps"))       rx.gps = val;
-            else if (key == QLatin1String("bands"))     rx.bands = val;
-            else if (key == QLatin1String("snr"))       rx.snr = val;
-            else if (key == QLatin1String("users"))     rx.users = val.toInt();
-            else if (key == QLatin1String("users_max")) { rx.usersMax = val.toInt(); haveMax = true; }
-            else if (key == QLatin1String("ext_api"))   rx.extApi = val.toInt();
-            else if (key == QLatin1String("offline"))   rx.offline = (val == QLatin1String("yes"));
+        rx.id       = boundedString(obj.value(QStringLiteral("id")));
+        rx.name     = boundedString(obj.value(QStringLiteral("name")));
+        rx.location = boundedString(obj.value(QStringLiteral("loc")));
+        rx.antenna  = boundedString(obj.value(QStringLiteral("antenna")));
+        rx.sdrHw    = boundedString(obj.value(QStringLiteral("sdr_hw")));
+        rx.grid     = boundedString(obj.value(QStringLiteral("grid")));
+
+        rx.users    = readCount(obj.value(QStringLiteral("users")));
+        rx.usersMax = readCount(obj.value(QStringLiteral("users_max")));
+
+        // THE field this class exists for.  A receiver that does not publish a
+        // policy has NO ext_api key — obj["ext_api"].toInt() would hand back 0
+        // and silently reclassify every Unknown operator as a Disabled one.
+        // That fails safe for the connection decision but misreports the
+        // operator's policy in the badge and in the picker's hidden counts,
+        // which is exactly what we must not get wrong.
+        const QJsonValue extApiVal = obj.value(QStringLiteral("ext_api"));
+        rx.extApi = extApiVal.isDouble() ? extApiVal.toInt(-1) : -1;
+
+        rx.offline = readOffline(obj.value(QStringLiteral("offline")));
+        rx.flagged = obj.value(QStringLiteral("flagged")).toBool(false);
+
+        const QJsonValue gpsVal = obj.value(QStringLiteral("gps"));
+        if (gpsVal.isArray()) {
+            const QJsonArray gps = gpsVal.toArray();
+            const double lat = readNumber(gps, 0, 0.0);
+            const double lon = readNumber(gps, 1, 0.0);
+            // A null island fix is the origin's "no position", not a position.
+            if (gps.size() >= 2 && std::abs(lat) <= 90.0 && std::abs(lon) <= 180.0
+                && !(lat == 0.0 && lon == 0.0)) {
+                rx.gpsLat = lat;
+                rx.gpsLon = lon;
+                rx.hasGps = true;
+            }
         }
 
-        // Skip non-receiver anchors (nav links etc.) — a real entry always
-        // publishes at least a name and a channel count.
-        if (haveName && haveMax)
-            out.push_back(rx);
+        const QJsonValue bandsVal = obj.value(QStringLiteral("bands"));
+        if (bandsVal.isArray()) {
+            const QJsonArray bands = bandsVal.toArray();
+            const double low  = readNumber(bands, 0, -1.0);
+            const double high = readNumber(bands, 1, -1.0);
+            if (bands.size() >= 2 && low >= 0.0 && high > low) {
+                rx.bandLowHz  = static_cast<qint64>(low);
+                rx.bandHighHz = static_cast<qint64>(high);
+                rx.hasBands   = true;
+            }
+        }
+
+        // snr is [all-band, HF]; the origin also publishes the same pair as
+        // scalar snr_all/snr_hf, which we accept as a fallback.
+        const QJsonValue snrVal = obj.value(QStringLiteral("snr"));
+        if (snrVal.isArray()) {
+            const QJsonArray snr = snrVal.toArray();
+            rx.snrAll = static_cast<int>(readNumber(snr, 0, -1.0));
+            rx.snrHf  = static_cast<int>(readNumber(snr, 1, -1.0));
+        }
+        if (rx.snrAll < 0 && obj.value(QStringLiteral("snr_all")).isDouble())
+            rx.snrAll = obj.value(QStringLiteral("snr_all")).toInt(-1);
+        if (rx.snrHf < 0 && obj.value(QStringLiteral("snr_hf")).isDouble())
+            rx.snrHf = obj.value(QStringLiteral("snr_hf")).toInt(-1);
+
+        receivers.push_back(rx);
     }
-    return out;
+
+    if (receivers.isEmpty()) {
+        result.error = QStringLiteral("receiver directory contained no usable receivers");
+        return result;
+    }
+
+    result.receivers = std::move(receivers);
+    return result;
 }
 
 KiwiPublicDirectory::KiwiPublicDirectory(QObject* parent)
@@ -122,68 +281,25 @@ KiwiPublicDirectory::KiwiPublicDirectory(QObject* parent)
 
 void KiwiPublicDirectory::fetch()
 {
-    // Step 1 — load the gate page and read its one-time interactive token,
-    // exactly as a browser does before the user clicks "show receivers".
-    QNetworkRequest gateReq{QUrl(QString::fromLatin1(kDirectoryUrl))};
-    gateReq.setHeader(QNetworkRequest::UserAgentHeader, userAgent());
-    gateReq.setTransferTimeout(kDirectoryFetchTimeoutMs);
-    QNetworkReply* gate = m_net->get(gateReq);
+    // One GET against AetherSDR's mirror.  There is deliberately no fallback
+    // to kiwisdr.com: see the good-citizen contract in the header.
+    QNetworkRequest req{QUrl(QString::fromLatin1(kDirectoryUrl))};
+    req.setHeader(QNetworkRequest::UserAgentHeader, userAgent());
+    req.setTransferTimeout(kDirectoryFetchTimeoutMs);
+    QNetworkReply* reply = m_net->get(req);
 
-    connect(gate, &QNetworkReply::finished, this, [this, gate]() {
-        gate->deleteLater();
-        if (gate->error() != QNetworkReply::NoError) {
-            emit failed(QStringLiteral("gate: ") + gate->errorString());
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        reply->deleteLater();
+        if (reply->error() != QNetworkReply::NoError) {
+            emit failed(reply->errorString());
             return;
         }
-        const QByteArray body = gate->readAll();
-
-        // If this IP is already past the (IP-based) interactive gate, the very
-        // first GET is the directory itself — parse it directly, no token dance.
-        QVector<KiwiPublicReceiver> direct = parse(body);
-        if (!direct.isEmpty()) {
-            emit ready(direct);
+        const KiwiDirectoryParse parsed = parse(reply->readAll());
+        if (!parsed.ok()) {
+            emit failed(parsed.error);
             return;
         }
-
-        const QString page = QString::fromUtf8(body);
-        static const QRegularExpression tokenRe(
-            QStringLiteral("x-kiwi-auth'\\s*,\\s*'([0-9a-fA-F]+)'"));
-        const QRegularExpressionMatch tm = tokenRe.match(page);
-        if (!tm.hasMatch()) {
-            emit failed(QStringLiteral("gate token not found"));
-            return;
-        }
-        const QByteArray token = tm.captured(1).toLatin1();
-
-        // Step 2 — replay the documented unlock request (token + honest UA),
-        // the network equivalent of the user clicking the button.
-        QNetworkRequest unlockReq{QUrl(QString::fromLatin1(kDirectoryUrl))};
-        unlockReq.setHeader(QNetworkRequest::UserAgentHeader, userAgent());
-        unlockReq.setTransferTimeout(kDirectoryFetchTimeoutMs);
-        unlockReq.setRawHeader("x-kiwi-auth", token);
-        QNetworkReply* unlock = m_net->get(unlockReq);
-
-        connect(unlock, &QNetworkReply::finished, this, [this, unlock]() {
-            unlock->deleteLater();
-            if (unlock->error() != QNetworkReply::NoError) {
-                emit failed(QStringLiteral("unlock: ") + unlock->errorString());
-                return;
-            }
-            // Step 3 — fetch the now-unlocked directory listing.
-            QNetworkRequest listReq{QUrl(QString::fromLatin1(kDirectoryUrl))};
-            listReq.setHeader(QNetworkRequest::UserAgentHeader, userAgent());
-            listReq.setTransferTimeout(kDirectoryFetchTimeoutMs);
-            QNetworkReply* list = m_net->get(listReq);
-
-            connect(list, &QNetworkReply::finished, this, [this, list]() {
-                list->deleteLater();
-                if (list->error() != QNetworkReply::NoError) {
-                    emit failed(QStringLiteral("list: ") + list->errorString());
-                    return;
-                }
-                emit ready(parse(list->readAll()));
-            });
-        });
+        emit ready(parsed.receivers, parsed.fetchedAt);
     });
 }
 

--- a/src/core/KiwiPublicDirectory.cpp
+++ b/src/core/KiwiPublicDirectory.cpp
@@ -305,20 +305,51 @@ void KiwiPublicDirectory::fetch()
 
     connect(reply, &QNetworkReply::finished, this, [this, reply, oversized]() {
         reply->deleteLater();
+
+        // Log every outcome. Without this the only way to answer "did this
+        // build actually read the mirror?" is to catch the socket live — the
+        // request is one sub-second GET that leaves no trace otherwise, and
+        // "the picker looks populated" cannot distinguish a fresh fetch from
+        // the session cache.
+        const QString url = QString::fromLatin1(kDirectoryUrl);
+
         if (*oversized) {
-            emit failed(QStringLiteral("receiver directory is implausibly large "
-                                       "(over %1 MB)").arg(kMaxBodyBytes / (1024 * 1024)));
+            const QString err = QStringLiteral("receiver directory is implausibly large "
+                                               "(over %1 MB)").arg(kMaxBodyBytes / (1024 * 1024));
+            qWarning().noquote() << "KiwiPublicDirectory: refused" << url << "-" << err;
+            emit failed(err);
             return;
         }
         if (reply->error() != QNetworkReply::NoError) {
+            qWarning().noquote() << "KiwiPublicDirectory: fetch of" << url
+                                 << "failed -" << reply->errorString();
             emit failed(reply->errorString());
             return;
         }
-        const KiwiDirectoryParse parsed = parse(reply->readAll());
+        const QByteArray body = reply->readAll();
+        const KiwiDirectoryParse parsed = parse(body);
         if (!parsed.ok()) {
+            qWarning().noquote() << "KiwiPublicDirectory: fetched" << body.size()
+                                 << "bytes from" << url
+                                 << "but could not use them -" << parsed.error;
             emit failed(parsed.error);
             return;
         }
+
+        // The age is the point of logging fetchedAt at all: it separates "our
+        // fetch is stale" from "the mirror itself stopped updating", which look
+        // identical from the picker.
+        const qint64 ageMin = parsed.fetchedAt.isValid()
+            ? parsed.fetchedAt.secsTo(QDateTime::currentDateTimeUtc()) / 60
+            : -1;
+        qInfo().nospace().noquote()
+            << "KiwiPublicDirectory: fetched " << url << " - " << parsed.receivers.size()
+            << " receivers, " << body.size() << " bytes, schema " << parsed.schema
+            << ", mirror fetched_at "
+            << (parsed.fetchedAt.isValid() ? parsed.fetchedAt.toString(Qt::ISODate)
+                                           : QStringLiteral("(not published)"))
+            << (ageMin >= 0 ? QStringLiteral(" (%1 min old)").arg(ageMin) : QString());
+
         emit ready(parsed.receivers, parsed.fetchedAt);
     });
 }

--- a/src/core/KiwiPublicDirectory.h
+++ b/src/core/KiwiPublicDirectory.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QDateTime>
 #include <QObject>
 #include <QString>
 #include <QVector>
@@ -8,25 +9,46 @@ class QNetworkAccessManager;
 
 namespace AetherSDR {
 
-// One receiver from the public KiwiSDR directory (kiwisdr.com/public).
-// Every field is sysop-published in the directory itself; in particular
-// ext_api is the operator's external-API policy, which AetherSDR honors
-// BEFORE ever attempting a connection.
+// One receiver from the public KiwiSDR directory, as republished by the
+// AetherSDR mirror (cdn.aethersdr.com/kiwi.json).  Every field is
+// sysop-published at the origin; in particular ext_api is the operator's
+// external-API policy, which AetherSDR honors BEFORE ever attempting a
+// connection.
 struct KiwiPublicReceiver {
+    QString id;         // origin's stable receiver id
     QString url;        // http://host:port — the receiver endpoint
     QString name;       // sysop description
     QString location;   // human-readable location ("loc")
     QString antenna;
     QString sdrHw;      // "KiwiSDR 1 v1.842 …"
     QString grid;       // Maidenhead
-    QString gps;        // "(lat, lon)"
-    QString bands;      // e.g. "0-30000000"
-    QString snr;
+
+    // Position, published as a [lat, lon] pair.  hasGps is false when the
+    // receiver publishes no usable fix, so 0,0 is never mistaken for one.
+    double gpsLat{0.0};
+    double gpsLon{0.0};
+    bool   hasGps{false};
+
+    // Tuning range, published as a [low, high] Hz pair.
+    qint64 bandLowHz{0};
+    qint64 bandHighHz{0};
+    bool   hasBands{false};
+
+    // Signal-to-noise, published as an [all-band, HF] pair in dB.
+    // -1 = not published.
+    int snrAll{-1};
+    int snrHf{-1};
+
     int  users{0};
     int  usersMax{0};
     int  extApi{-1};    // sysop's max external-API connections.
                         // 0 = API disabled (web-only). -1 = not published.
+                        // In kiwi.json a receiver that does not publish a
+                        // policy has NO ext_api key at all — read it with an
+                        // explicit -1 default, never toInt(), or every Unknown
+                        // silently becomes a Disabled.
     bool offline{false};
+    bool flagged{false};  // the origin itself marks this entry as bad
 
     enum class ApiPolicy {
         Unknown,    // ext_api not published
@@ -51,41 +73,86 @@ struct KiwiPublicReceiver {
     QString apiBadge() const;
     bool advertisesConnectionLimit() const;
     QString connectionLimitBadge() const;
+
+    // "2.0 – 30.0 MHz", or empty when the receiver publishes no range.
+    QString bandRangeLabel() const;
 };
 
-// Fetches and parses the public KiwiSDR receiver directory, exposing each
-// receiver's external-API policy so AetherSDR can honor "web-only" operators
-// up front.
+// Outcome of parsing one kiwi.json body.  Parsing either yields a whole list
+// or fails with a reason — never a partial list built from a truncated or
+// wrong-schema document (Principle VII: fail closed at the boundary).
+struct KiwiDirectoryParse {
+    QVector<KiwiPublicReceiver> receivers;
+    QDateTime fetchedAt;      // when the mirror last pulled the origin (UTC)
+    int       schema{0};
+    QString   error;          // empty iff the parse succeeded
+
+    bool ok() const { return error.isEmpty(); }
+};
+
+// Fetches and parses the public KiwiSDR receiver directory from AetherSDR's
+// mirror, exposing each receiver's external-API policy so AetherSDR can honor
+// "web-only" operators up front.
 //
 // Good-citizen contract (this class is the proof we can show an operator):
-//   • Honest identity — a fixed "AetherSDR/<ver>" User-Agent; it NEVER spoofs
-//     a browser to get past the directory's interactive gate.
-//   • Strictly manual — fetch() is only ever called from an explicit user
-//     action.  No background polling, no timed refresh, no caching-and-
-//     redistribution, no enumeration.  One human click == one fetch.
-//   • Reads only the server-published directory (HTML comments) and the
-//     per-receiver /status — never the KiwiSDR source.
+//   • The mirror exists AT THE KIWISDR MAINTAINER'S REQUEST.  AetherSDR
+//     clients' individual directory fetches were putting real load on his
+//     server; he asked us to pull once and redistribute instead.  A
+//     Cloudflare Worker pulls kiwisdr.com/public hourly under a shared secret
+//     he provided and republishes it as JSON.  His server now sees one hourly
+//     request from us rather than one per user, per browse.
+//   • Clients read AetherSDR's copy and NEVER contact kiwisdr.com.  There is
+//     deliberately no origin fallback: a CDN outage must not turn every
+//     AetherSDR install in the world into a thundering herd aimed at the
+//     server we were asked to relieve.  When the mirror is unreachable we
+//     serve the last list we have, or say so plainly.
+//   • Honest identity — a fixed "AetherSDR/<ver>" User-Agent, unchanged.  No
+//     browser spoofing, no gate token to replay, no HTML to scrape.
+//   • ext_api is still honored client-side: receivers whose operator set
+//     ext_api == 0 are never offered for a native API connection, and a
+//     receiver that publishes no policy at all is not assumed to permit one.
+//   • Refresh respects the mirror's own 30-minute cache lifetime; we do not
+//     poll faster than the data can change, and a manual refresh stays
+//     available for users who want one.
+//
+// See docs/kiwisdr-public-directory.md.
 class KiwiPublicDirectory : public QObject {
     Q_OBJECT
 public:
     explicit KiwiPublicDirectory(QObject* parent = nullptr);
 
-    // Honest interactive fetch: load the gate page (to read its one-time
-    // token), replay the documented unlock request, then GET the list — all
-    // with the AetherSDR User-Agent.  Emits ready() or failed().
+    // Fetch the mirror and emit ready() or failed().  One GET, no gate dance.
     void fetch();
 
-    // Pure parser (no network) — extracts receivers from directory HTML.
-    // Exposed so it can run offline and under test.
-    static QVector<KiwiPublicReceiver> parse(const QByteArray& directoryHtml);
+    // Pure parser (no network).  Exposed so it can run offline and under test.
+    static KiwiDirectoryParse parse(const QByteArray& json);
 
     // The honest User-Agent AetherSDR identifies with.
     static QByteArray userAgent();
 
-    static constexpr const char* kDirectoryUrl = "http://kiwisdr.com/public/";
+    static constexpr const char* kDirectoryUrl = "https://cdn.aethersdr.com/kiwi.json";
+
+    // The only kiwi.json schema this build understands.  A different value is
+    // a hard failure telling the user to update, not something to parse on
+    // hopefully — the fields we honor could have moved under our feet.
+    static constexpr int kSupportedSchema = 1;
+
+    // The mirror publishes cache-control: max-age=1800; refreshing faster than
+    // that only re-reads bytes the CDN is still serving from cache.
+    static constexpr int kMinRefreshSeconds = 1800;
+
+    // The mirror's own client-facing staleness threshold.  Past this the
+    // picker tells the user how old the list is.
+    static constexpr int kStaleAfterMinutes = 360;
+
+    // Boundary caps (Principle VII).  A hostile or corrupt body must not be
+    // able to make us allocate without bound.
+    static constexpr int kMaxBodyBytes = 32 * 1024 * 1024;
+    static constexpr int kMaxReceivers = 20000;
 
 signals:
-    void ready(const QVector<AetherSDR::KiwiPublicReceiver>& receivers);
+    void ready(const QVector<AetherSDR::KiwiPublicReceiver>& receivers,
+               const QDateTime& fetchedAt);
     void failed(const QString& error);
 
 private:

--- a/src/core/KiwiPublicDirectory.h
+++ b/src/core/KiwiPublicDirectory.h
@@ -69,6 +69,28 @@ struct KiwiPublicReceiver {
     // treated conservatively as "do not assume API is allowed".
     bool mayConnectViaApi() const { return extApi > 0; }
 
+    // Why this receiver is, or is not, offered in the picker.  The policy
+    // lives here rather than inside the picker's loop so the GUI and the test
+    // cannot drift apart — a test that re-implements the loop would keep
+    // passing after the loop regressed.
+    enum class Offer {
+        Yes,
+        HiddenOffline,
+        HiddenFlagged,        // the origin itself marks the entry as bad
+        HiddenWebOnly,        // ext_api == 0: operator disabled the API
+        HiddenPolicyUnknown,  // no ext_api published: we can't confirm it's OK
+    };
+    Offer offerDecision() const
+    {
+        if (offline) return Offer::HiddenOffline;
+        if (flagged) return Offer::HiddenFlagged;
+        if (!mayConnectViaApi()) {
+            return apiPolicy() == ApiPolicy::Disabled ? Offer::HiddenWebOnly
+                                                      : Offer::HiddenPolicyUnknown;
+        }
+        return Offer::Yes;
+    }
+
     // Short human-readable badge for the receiver picker.
     QString apiBadge() const;
     bool advertisesConnectionLimit() const;
@@ -101,7 +123,9 @@ struct KiwiDirectoryParse {
 //     Cloudflare Worker pulls kiwisdr.com/public hourly under a shared secret
 //     he provided and republishes it as JSON.  His server now sees one hourly
 //     request from us rather than one per user, per browse.
-//   • Clients read AetherSDR's copy and NEVER contact kiwisdr.com.  There is
+//   • Clients read AetherSDR's copy and NEVER contact the kiwisdr.com
+//     directory origin (a receiver the user then picks may itself be a
+//     *.proxy.kiwisdr.com host — that connection is unchanged).  There is
 //     deliberately no origin fallback: a CDN outage must not turn every
 //     AetherSDR install in the world into a thundering herd aimed at the
 //     server we were asked to relieve.  When the mirror is unreachable we
@@ -135,6 +159,8 @@ public:
     // The only kiwi.json schema this build understands.  A different value is
     // a hard failure telling the user to update, not something to parse on
     // hopefully — the fields we honor could have moved under our feet.
+    // The producer lives outside this repo, so docs/kiwi-json-schema.md is the
+    // in-tree contract this pins to; change one and change the other.
     static constexpr int kSupportedSchema = 1;
 
     // The mirror publishes cache-control: max-age=1800; refreshing faster than
@@ -145,8 +171,11 @@ public:
     // picker tells the user how old the list is.
     static constexpr int kStaleAfterMinutes = 360;
 
-    // Boundary caps (Principle VII).  A hostile or corrupt body must not be
-    // able to make us allocate without bound.
+    // Boundary caps (Principle VII).  kMaxBodyBytes is enforced twice: on the
+    // wire, where fetch() aborts the reply as soon as the advertised or
+    // received length passes it (so an oversized body is never buffered whole),
+    // and again in parse(), which is also reachable with bytes we did not
+    // download — a saved payload handed to the POC.
     static constexpr int kMaxBodyBytes = 32 * 1024 * 1024;
     static constexpr int kMaxReceivers = 20000;
 

--- a/src/core/KiwiPublicDirectory.h
+++ b/src/core/KiwiPublicDirectory.h
@@ -159,8 +159,15 @@ public:
     // The only kiwi.json schema this build understands.  A different value is
     // a hard failure telling the user to update, not something to parse on
     // hopefully — the fields we honor could have moved under our feet.
-    // The producer lives outside this repo, so docs/kiwi-json-schema.md is the
-    // in-tree contract this pins to; change one and change the other.
+    // docs/kiwi-json-schema.md is the in-tree contract this pins to; change one
+    // and change the other.
+    //
+    // The mirror commits to serving schema 1 at kiwi.json in perpetuity, and to
+    // publishing any future schema at its own path (kiwi-v2.json) that only
+    // builds understanding it request. That commitment is what makes failing
+    // closed here safe: because there is no fallback source, bumping the number
+    // on THIS url would break the picker for every shipped install at once —
+    // the thundering herd this class exists to prevent, aimed at us instead.
     static constexpr int kSupportedSchema = 1;
 
     // The mirror publishes cache-control: max-age=1800; refreshing faster than

--- a/src/gui/KiwiPublicReceiverPicker.cpp
+++ b/src/gui/KiwiPublicReceiverPicker.cpp
@@ -1,5 +1,6 @@
 #include "KiwiPublicReceiverPicker.h"
 
+#include <QDateTime>
 #include <QDialogButtonBox>
 #include <QHBoxLayout>
 #include <QHeaderView>
@@ -19,10 +20,25 @@ namespace {
 // Session-scoped cache of the last successful directory fetch, shared across
 // every picker instance opened this run.  Being a process-static, it is NOT
 // persisted to disk — it dies with the app, so a new session always starts
-// fresh.  This is what lets repeat "Browse public…" opens re-serve the list
-// without hitting the operators' servers again; "Refresh list" overwrites it.
+// fresh.
+//
+// The client only ever talks to AetherSDR's own CDN, which is built to be hit,
+// so repeat "Browse public…" opens may refresh — but no faster than the mirror
+// itself updates (cache-control: max-age=1800).  Inside that window we re-serve
+// the cache; past it the next open fetches again.  "Refresh list" always
+// fetches and overwrites.
 QVector<KiwiPublicReceiver> g_sessionCache;
 bool g_haveSessionCache = false;
+QDateTime g_cacheFetchedAt;    // mirror's own fetched_at for the cached list
+QDateTime g_cacheReceivedAt;   // when WE last pulled it (local UTC clock)
+
+bool cacheIsFresh()
+{
+    if (!g_haveSessionCache || !g_cacheReceivedAt.isValid())
+        return false;
+    const qint64 age = g_cacheReceivedAt.secsTo(QDateTime::currentDateTimeUtc());
+    return age >= 0 && age < KiwiPublicDirectory::kMinRefreshSeconds;
+}
 
 enum Column {
     ReceiverColumn,
@@ -97,17 +113,32 @@ KiwiPublicReceiverPicker::KiwiPublicReceiverPicker(QWidget* parent)
     connect(m_search, &QLineEdit::textChanged, this, &KiwiPublicReceiverPicker::applyFilter);
     connect(m_refresh, &QPushButton::clicked, this, &KiwiPublicReceiverPicker::startFetch);
 
-    connect(m_dir, &KiwiPublicDirectory::ready, this, &KiwiPublicReceiverPicker::onReady);
+    connect(m_dir, &KiwiPublicDirectory::ready, this,
+            [this](const QVector<KiwiPublicReceiver>& receivers, const QDateTime& fetchedAt) {
+                g_cacheReceivedAt = QDateTime::currentDateTimeUtc();
+                onReady(receivers, fetchedAt);
+            });
     connect(m_dir, &KiwiPublicDirectory::failed, this, [this](const QString& err) {
-        m_status->setText(tr("Could not load directory: %1").arg(err));
         m_refresh->setEnabled(true);
+        // No origin fallback by design (see KiwiPublicDirectory's good-citizen
+        // contract): show whatever list we already have, or say plainly that we
+        // have none.
+        if (g_haveSessionCache) {
+            m_fromCache = true;
+            onReady(g_sessionCache, g_cacheFetchedAt);
+            m_status->setText(m_status->text()
+                              + tr("  ·  could not refresh: %1").arg(err));
+        } else {
+            m_status->setText(tr("Receiver directory unavailable (%1) — "
+                                 "try again later.").arg(err));
+        }
     });
 
-    // Re-serve the session cache if we already fetched once this run; only the
-    // first browse (or an explicit "Refresh list") touches the network.
-    if (g_haveSessionCache) {
+    // Re-serve the session cache while it is still inside the mirror's own
+    // 30-minute refresh window; otherwise fetch.  "Refresh list" always fetches.
+    if (cacheIsFresh()) {
         m_fromCache = true;
-        onReady(g_sessionCache);
+        onReady(g_sessionCache, g_cacheFetchedAt);
     } else {
         startFetch();
     }
@@ -121,20 +152,29 @@ void KiwiPublicReceiverPicker::startFetch()
     m_dir->fetch();
 }
 
-void KiwiPublicReceiverPicker::onReady(const QVector<KiwiPublicReceiver>& receivers)
+void KiwiPublicReceiverPicker::onReady(const QVector<KiwiPublicReceiver>& receivers,
+                                       const QDateTime& fetchedAt)
 {
     // Populate (or overwrite) the session cache from every successful fetch.
     // Serving from the cache passes the same vector straight back through here,
     // which is a harmless no-op assignment.
     g_sessionCache = receivers;
+    g_cacheFetchedAt = fetchedAt;
     g_haveSessionCache = true;
+    m_fetchedAt = fetchedAt;
 
     m_refresh->setEnabled(true);
     m_apiReceivers.clear();
     m_hiddenWebOnly = 0;
     m_hiddenUnknown = 0;
+    m_hiddenFlagged = 0;
     for (const auto& r : receivers) {
         if (r.offline) continue;
+        // The origin itself marks these entries as bad; don't offer them.
+        if (r.flagged) {
+            ++m_hiddenFlagged;
+            continue;
+        }
         // Honor the operator: only receivers that allow the external API are
         // listed. Web-only (ext_api == 0) are excluded entirely, as are
         // receivers that don't publish a policy (we can't confirm API is OK).
@@ -195,10 +235,22 @@ void KiwiPublicReceiverPicker::applyFilter()
         hiddenParts << tr("%1 web-only").arg(m_hiddenWebOnly);
     if (m_hiddenUnknown > 0)
         hiddenParts << tr("%1 policy-unknown").arg(m_hiddenUnknown);
+    if (m_hiddenFlagged > 0)
+        hiddenParts << tr("%1 flagged").arg(m_hiddenFlagged);
     if (!hiddenParts.isEmpty())
         status += tr(" (%1 hidden)").arg(hiddenParts.join(QStringLiteral(", ")));
     if (m_fromCache)
         status += tr("  ·  cached — use “Refresh list” to update");
+    // Surface the list's age only once it is genuinely old: the mirror refreshes
+    // hourly, so anything inside its own staleness threshold is unremarkable.
+    if (m_fetchedAt.isValid()) {
+        const qint64 mins = m_fetchedAt.secsTo(QDateTime::currentDateTimeUtc()) / 60;
+        if (mins >= KiwiPublicDirectory::kStaleAfterMinutes) {
+            status += (mins >= 2 * 60 * 24)
+                ? tr("  ·  list is %1 days old").arg(mins / (60 * 24))
+                : tr("  ·  list is %1 hours old").arg(mins / 60);
+        }
+    }
     m_status->setText(status);
     m_ok->setEnabled(!m_table->selectedItems().isEmpty());
 }

--- a/src/gui/KiwiPublicReceiverPicker.cpp
+++ b/src/gui/KiwiPublicReceiverPicker.cpp
@@ -125,9 +125,10 @@ KiwiPublicReceiverPicker::KiwiPublicReceiverPicker(QWidget* parent)
         // have none.
         if (g_haveSessionCache) {
             m_fromCache = true;
+            // Held in a member, not appended to the label: applyFilter()
+            // rebuilds the status from scratch on every keystroke.
+            m_refreshError = err;
             onReady(g_sessionCache, g_cacheFetchedAt);
-            m_status->setText(m_status->text()
-                              + tr("  ·  could not refresh: %1").arg(err));
         } else {
             m_status->setText(tr("Receiver directory unavailable (%1) — "
                                  "try again later.").arg(err));
@@ -147,6 +148,7 @@ KiwiPublicReceiverPicker::KiwiPublicReceiverPicker(QWidget* parent)
 void KiwiPublicReceiverPicker::startFetch()
 {
     m_fromCache = false;
+    m_refreshError.clear();
     m_status->setText(tr("Loading public receivers…"));
     m_refresh->setEnabled(false);
     m_dir->fetch();
@@ -168,24 +170,19 @@ void KiwiPublicReceiverPicker::onReady(const QVector<KiwiPublicReceiver>& receiv
     m_hiddenWebOnly = 0;
     m_hiddenUnknown = 0;
     m_hiddenFlagged = 0;
+    // Honor the operator: only receivers that allow the external API are
+    // listed. Web-only (ext_api == 0) are excluded entirely, as are receivers
+    // that don't publish a policy (we can't confirm API is OK) and entries the
+    // origin has flagged. The policy itself lives on KiwiPublicReceiver so the
+    // test locks the same code this loop runs.
     for (const auto& r : receivers) {
-        if (r.offline) continue;
-        // The origin itself marks these entries as bad; don't offer them.
-        if (r.flagged) {
-            ++m_hiddenFlagged;
-            continue;
+        switch (r.offerDecision()) {
+            case KiwiPublicReceiver::Offer::Yes:                 m_apiReceivers.push_back(r); break;
+            case KiwiPublicReceiver::Offer::HiddenFlagged:       ++m_hiddenFlagged; break;
+            case KiwiPublicReceiver::Offer::HiddenWebOnly:       ++m_hiddenWebOnly; break;
+            case KiwiPublicReceiver::Offer::HiddenPolicyUnknown: ++m_hiddenUnknown; break;
+            case KiwiPublicReceiver::Offer::HiddenOffline:       break;
         }
-        // Honor the operator: only receivers that allow the external API are
-        // listed. Web-only (ext_api == 0) are excluded entirely, as are
-        // receivers that don't publish a policy (we can't confirm API is OK).
-        if (!r.mayConnectViaApi()) {
-            if (r.apiPolicy() == KiwiPublicReceiver::ApiPolicy::Disabled)
-                ++m_hiddenWebOnly;
-            else
-                ++m_hiddenUnknown;
-            continue;
-        }
-        m_apiReceivers.push_back(r);
     }
     applyFilter();
 }
@@ -251,6 +248,8 @@ void KiwiPublicReceiverPicker::applyFilter()
                 : tr("  ·  list is %1 hours old").arg(mins / 60);
         }
     }
+    if (!m_refreshError.isEmpty())
+        status += tr("  ·  could not refresh: %1").arg(m_refreshError);
     m_status->setText(status);
     m_ok->setEnabled(!m_table->selectedItems().isEmpty());
 }

--- a/src/gui/KiwiPublicReceiverPicker.cpp
+++ b/src/gui/KiwiPublicReceiverPicker.cpp
@@ -143,6 +143,14 @@ KiwiPublicReceiverPicker::KiwiPublicReceiverPicker(QWidget* parent)
     // 30-minute refresh window; otherwise fetch.  "Refresh list" always fetches.
     if (cacheIsFresh()) {
         m_fromCache = true;
+        // Logged so a populated picker is never mistaken for evidence of a
+        // fetch: inside the mirror's own 30-minute window we deliberately do
+        // not touch the network at all.
+        qInfo().nospace().noquote() << "KiwiPublicDirectory: serving " << g_sessionCache.size()
+                          << " receivers from the session cache ("
+                          << g_cacheReceivedAt.secsTo(QDateTime::currentDateTimeUtc())
+                          << "s old, refresh after "
+                          << KiwiPublicDirectory::kMinRefreshSeconds << "s)";
         onReady(g_sessionCache, g_cacheFetchedAt);
     } else {
         startFetch();

--- a/src/gui/KiwiPublicReceiverPicker.cpp
+++ b/src/gui/KiwiPublicReceiverPicker.cpp
@@ -130,8 +130,12 @@ KiwiPublicReceiverPicker::KiwiPublicReceiverPicker(QWidget* parent)
             m_refreshError = err;
             onReady(g_sessionCache, g_cacheFetchedAt);
         } else {
-            m_status->setText(tr("Receiver directory unavailable (%1) — "
-                                 "try again later.").arg(err));
+            // With no cached list the user has no way to tell a local network
+            // problem from our mirror being down; the status page is published
+            // for precisely this moment.
+            m_status->setText(tr("Receiver directory unavailable (%1) — try again "
+                                 "later, or check %2")
+                                  .arg(err, QStringLiteral("kiwi-status.aethersdr.com")));
         }
     });
 

--- a/src/gui/KiwiPublicReceiverPicker.h
+++ b/src/gui/KiwiPublicReceiverPicker.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QDateTime>
 #include <QVector>
 
 #include "PersistentDialog.h"
@@ -12,11 +13,12 @@ class QTableWidget;
 
 namespace AetherSDR {
 
-// "Browse public KiwiSDRs" picker. Fetches the public directory on open (an
-// explicit user action), and lists ONLY receivers whose operator allows the
-// external API (ext_api > 0). Web-only receivers (ext_api == 0) are filtered
-// out entirely and never shown — AetherSDR honors that policy by not offering
-// them. See docs/kiwisdr-public-directory.md.
+// "Browse public KiwiSDRs" picker. Populates from AetherSDR's directory mirror
+// (cdn.aethersdr.com/kiwi.json), and lists ONLY receivers whose operator allows
+// the external API (ext_api > 0). Web-only receivers (ext_api == 0) are
+// filtered out entirely and never shown — AetherSDR honors that policy by not
+// offering them, and receivers that publish no policy at all are not assumed to
+// permit one. See docs/kiwisdr-public-directory.md.
 class KiwiPublicReceiverPicker : public PersistentDialog {
     Q_OBJECT
 public:
@@ -28,7 +30,7 @@ public:
 
 private:
     void startFetch();
-    void onReady(const QVector<KiwiPublicReceiver>& receivers);
+    void onReady(const QVector<KiwiPublicReceiver>& receivers, const QDateTime& fetchedAt);
     void applyFilter();
     void acceptCurrentRow();
 
@@ -36,7 +38,9 @@ private:
     QVector<KiwiPublicReceiver> m_apiReceivers;  // already filtered to ext_api>0
     int m_hiddenWebOnly{0};
     int m_hiddenUnknown{0};  // dropped because their API policy wasn't published
+    int m_hiddenFlagged{0};  // the origin itself marks these entries as bad
     bool m_fromCache{false};  // current list came from the session cache
+    QDateTime m_fetchedAt;   // when the mirror last pulled the origin (UTC)
 
     QLineEdit*    m_search{nullptr};
     QTableWidget* m_table{nullptr};

--- a/src/gui/KiwiPublicReceiverPicker.h
+++ b/src/gui/KiwiPublicReceiverPicker.h
@@ -41,6 +41,7 @@ private:
     int m_hiddenFlagged{0};  // the origin itself marks these entries as bad
     bool m_fromCache{false};  // current list came from the session cache
     QDateTime m_fetchedAt;   // when the mirror last pulled the origin (UTC)
+    QString m_refreshError;  // last failed refresh, re-rendered by applyFilter()
 
     QLineEdit*    m_search{nullptr};
     QTableWidget* m_table{nullptr};

--- a/tests/kiwi_public_directory_test.cpp
+++ b/tests/kiwi_public_directory_test.cpp
@@ -173,18 +173,36 @@ int main()
     if (silent.hasGps || silent.hasBands) return fail("absent gps/bands must stay unset");
     if (silent.snrAll != -1 || silent.snrHf != -1) return fail("absent snr must stay -1");
 
-    // The picker filter: only API-permitted, unflagged receivers are shown, and
-    // the two hidden-for-policy reasons are counted apart.
+    // The offer policy. This exercises KiwiPublicReceiver::offerDecision() —
+    // the same function KiwiPublicReceiverPicker::onReady() switches on — so a
+    // regression in the picker's filtering shows up here. (A test that
+    // re-implemented the loop would keep passing after the loop broke.)
+    using Offer = KiwiPublicReceiver::Offer;
+    if (web.offerDecision() != Offer::HiddenWebOnly)
+        return fail("ext_api=0 must be hidden as web-only");
+    if (open.offerDecision() != Offer::Yes)
+        return fail("an API-open receiver must be offered");
+    if (limited.offerDecision() != Offer::HiddenFlagged)
+        return fail("a flagged receiver must be hidden, even when API-permitted");
+    if (silent.offerDecision() != Offer::HiddenPolicyUnknown)
+        return fail("a policy-unknown receiver must be hidden as policy-unknown");
+
+    // Offline outranks every other reason, so the picker's status line never
+    // reports an unreachable receiver as an operator policy decision.
+    KiwiPublicReceiver down = open;
+    down.offline = true;
+    if (down.offerDecision() != Offer::HiddenOffline)
+        return fail("an offline receiver must be hidden as offline");
+
     int shown = 0, hiddenWebOnly = 0, hiddenUnknown = 0, hiddenFlagged = 0;
     for (const auto& r : rxs) {
-        if (r.offline) continue;
-        if (r.flagged) { ++hiddenFlagged; continue; }
-        if (!r.mayConnectViaApi()) {
-            if (r.apiPolicy() == ApiPolicy::Disabled) ++hiddenWebOnly;
-            else ++hiddenUnknown;
-            continue;
+        switch (r.offerDecision()) {
+            case Offer::Yes:                 ++shown; break;
+            case Offer::HiddenWebOnly:       ++hiddenWebOnly; break;
+            case Offer::HiddenPolicyUnknown: ++hiddenUnknown; break;
+            case Offer::HiddenFlagged:       ++hiddenFlagged; break;
+            case Offer::HiddenOffline:       break;
         }
-        ++shown;
     }
     if (shown != 1) return fail("exactly 1 receiver should survive the picker filter");
     if (hiddenWebOnly != 1) return fail("exactly 1 web-only hidden");
@@ -211,6 +229,29 @@ int main()
         return fail("a rejected schema must yield no receivers");
     if (!future.error.contains(QStringLiteral("update AetherSDR")))
         return fail("a schema mismatch must tell the user to update AetherSDR");
+
+    // The receiver-count cap is a boundary, so exercise it rather than trusting
+    // the constant: one entry past it must be refused outright, not truncated
+    // to the cap and served as if it were the whole directory.
+    QByteArray flood = QByteArrayLiteral("{\"schema\": 1, \"receivers\": [");
+    for (int i = 0; i <= KiwiPublicDirectory::kMaxReceivers; ++i) {
+        if (i) flood += ',';
+        flood += QByteArrayLiteral("{\"url\":\"http://x:8073\",\"ext_api\":1,\"users_max\":1}");
+    }
+    flood += QByteArrayLiteral("]}");
+    const KiwiDirectoryParse flooded = KiwiPublicDirectory::parse(flood);
+    if (flooded.ok())
+        return fail("a receiver list past kMaxReceivers must be refused");
+    if (!flooded.receivers.isEmpty())
+        return fail("a refused receiver list must yield no receivers, not a truncated one");
+
+    // An empty list is empty, not malformed — the message must not claim the
+    // payload was unparseable.
+    const KiwiDirectoryParse empty =
+        KiwiPublicDirectory::parse(QByteArrayLiteral("{\"schema\": 1, \"receivers\": []}"));
+    if (empty.ok()) return fail("an empty receiver list must not report success");
+    if (!empty.error.contains(QStringLiteral("empty")))
+        return fail("an empty receiver list must say so, not blame the payload");
 
     std::printf("kiwi_public_directory_test: OK (4 parsed; web-only, "
                 "policy-unknown and flagged all filtered out separately)\n");

--- a/tests/kiwi_public_directory_test.cpp
+++ b/tests/kiwi_public_directory_test.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdio>
 
+using AetherSDR::KiwiDirectoryParse;
 using AetherSDR::KiwiPublicDirectory;
 using AetherSDR::KiwiPublicReceiver;
 using ApiPolicy = AetherSDR::KiwiPublicReceiver::ApiPolicy;
@@ -14,69 +15,128 @@ int fail(const char* msg)
     return 1;
 }
 
-// A faithful slice of kiwisdr.com/public in the real on-the-wire format:
-// each receiver is an <a href='host'> anchor followed by <!-- key=value -->
-// comments, up to the next anchor. Includes a non-receiver nav anchor that
-// must be ignored, and the three ext_api regimes.
-const QByteArray kSample = QByteArrayLiteral(
-    "<a href='/about'>nav link (no receiver fields) should be skipped</a>\n"
-    // ext_api=0 -> web-only (operator disabled the external API)
-    "<a href='http://g3sdr.com:8073' target='_blank'> <img src='a.png'> </a>\n"
-    "  <!-- id=c4f312a0a6ef -->\n"
-    "  <!-- status=active -->\n"
-    "  <!-- offline=no -->\n"
-    "  <!-- name=G3SDR, Weston-super-Mare -->\n"
-    "  <!-- sdr_hw=KiwiSDR 1 v1.842 Limits -->\n"
-    "  <!-- bands=0-30000000 -->\n"
-    "  <!-- users=3 -->\n"
-    "  <!-- users_max=4 -->\n"
-    "  <!-- ext_api=0 -->\n"
-    "  <!-- loc=Weston-super-Mare, United Kingdom -->\n"
-    "  <!-- antenna=Parallel dipoles -->\n"
-    // ext_api == users_max -> fully open to API
-    "<a href='http://open.example.com:8073' target='_blank'> </a>\n"
-    "  <!-- name=Open RX -->\n"
-    "  <!-- sdr_hw=KiwiSDR 1 v1.842 -->\n"
-    "  <!-- users=1 -->\n"
-    "  <!-- users_max=4 -->\n"
-    "  <!-- ext_api=4 -->\n"
-    "  <!-- loc=Somewhere -->\n"
-    // 0 < ext_api < users_max -> limited (channels reserved for web)
-    "<a href='http://limited.example.com:8074' target='_blank'> </a>\n"
-    "  <!-- name=Limited RX -->\n"
-    "  <!-- users=2 -->\n"
-    "  <!-- users_max=8 -->\n"
-    "  <!-- ext_api=4 -->\n"
-    "  <!-- loc=Elsewhere -->\n");
+// A faithful slice of cdn.aethersdr.com/kiwi.json in the real published shape:
+// one object with a schema, a fetched_at and a receivers array, each entry
+// carrying typed gps/bands/snr pairs and a real JSON bool for offline.
+//
+// It covers all FOUR ext_api regimes.  The fourth — the key being ABSENT — is
+// the one the origin's HTML never distinguished and the one this migration is
+// most likely to break: QJsonObject::value("ext_api").toInt() returns 0 for a
+// missing key, which would silently reclassify every policy-unknown operator as
+// a policy-disabled one.
+const QByteArray kSample = QByteArrayLiteral(R"JSON({
+  "schema": 1,
+  "source": "https://files.kiwisdr.com/public/",
+  "fetched_at": "2026-09-05T14:00:01Z",
+  "receiver_count": 4,
+  "receivers": [
+    {
+      "id": "c4f312a0a6ef",
+      "url": "http://g3sdr.com:8073",
+      "name": "G3SDR, Weston-super-Mare",
+      "loc": "Weston-super-Mare, United Kingdom",
+      "antenna": "Parallel dipoles",
+      "sdr_hw": "KiwiSDR 1 v1.842 Limits",
+      "grid": "IO81",
+      "gps": [51.3458, -2.9773],
+      "bands": [0, 30000000],
+      "snr": [30, 31],
+      "users": 3,
+      "users_max": 4,
+      "ext_api": 0,
+      "offline": false,
+      "flagged": false
+    },
+    {
+      "id": "0000000000aa",
+      "url": "http://open.example.com:8073",
+      "name": "Open RX",
+      "loc": "Somewhere",
+      "sdr_hw": "KiwiSDR 1 v1.842",
+      "gps": [0, 0],
+      "bands": [2000000, 30000000],
+      "snr": [42, 43],
+      "users": 1,
+      "users_max": 4,
+      "ext_api": 4,
+      "offline": false,
+      "flagged": false
+    },
+    {
+      "id": "0000000000bb",
+      "url": "http://limited.example.com:8074",
+      "name": "Limited RX",
+      "loc": "Elsewhere",
+      "gps": [-34.2737, 138.771],
+      "bands": [10000000, 15000000],
+      "snr": [38, 39],
+      "users": 2,
+      "users_max": 8,
+      "ext_api": 4,
+      "offline": false,
+      "flagged": true
+    },
+    {
+      "id": "0000000000cc",
+      "url": "http://silent.proxy.kiwisdr.com",
+      "name": "Policy-unknown RX",
+      "loc": "Unstated",
+      "users": 0,
+      "users_max": 3,
+      "offline": false,
+      "flagged": false
+    }
+  ]
+})JSON");
 
 } // namespace
 
 int main()
 {
-    const auto rxs = KiwiPublicDirectory::parse(kSample);
+    const KiwiDirectoryParse parsed = KiwiPublicDirectory::parse(kSample);
+    if (!parsed.ok()) return fail("valid kiwi.json must parse");
+    if (parsed.schema != 1) return fail("schema must be read back as 1");
+    if (!parsed.fetchedAt.isValid()) return fail("fetched_at must parse as ISO-8601");
+    if (parsed.fetchedAt.toString(Qt::ISODate) != QStringLiteral("2026-09-05T14:00:01Z"))
+        return fail("fetched_at must round-trip as UTC");
 
-    // The nav anchor (no name/users_max) is skipped; 3 real receivers remain.
-    if (rxs.size() != 3)
-        return fail("expected 3 receivers (nav anchor must be skipped)");
+    const auto& rxs = parsed.receivers;
+    if (rxs.size() != 4) return fail("expected 4 receivers");
 
+    // ---- ext_api == 0 -> Disabled -------------------------------------
     const KiwiPublicReceiver& web = rxs[0];
+    if (web.id != QStringLiteral("c4f312a0a6ef")) return fail("id parse");
     if (web.url != QStringLiteral("http://g3sdr.com:8073")) return fail("url parse");
     if (web.name != QStringLiteral("G3SDR, Weston-super-Mare")) return fail("name parse");
     if (web.location != QStringLiteral("Weston-super-Mare, United Kingdom")) return fail("loc parse");
+    if (web.grid != QStringLiteral("IO81")) return fail("grid parse");
     if (web.users != 3 || web.usersMax != 4) return fail("users/users_max parse");
+    if (web.offline) return fail("offline JSON false must parse as not offline");
     if (web.extApi != 0) return fail("ext_api parse");
     if (web.apiPolicy() != ApiPolicy::Disabled) return fail("ext_api=0 must be Disabled");
     if (!web.advertisesConnectionLimit()) return fail("limits marker parse");
     if (web.connectionLimitBadge() != QStringLiteral("Limits")) return fail("limits badge");
     // THE honor guarantee: a web-only receiver is never API-connectable.
     if (web.mayConnectViaApi()) return fail("ext_api=0 must NOT allow API connect");
+    // Typed fields.
+    if (!web.hasGps) return fail("gps pair must parse");
+    if (web.gpsLat < 51.34 || web.gpsLat > 51.35) return fail("gps lat parse");
+    if (web.gpsLon > -2.97 || web.gpsLon < -2.98) return fail("gps lon parse");
+    if (!web.hasBands || web.bandLowHz != 0 || web.bandHighHz != 30000000)
+        return fail("bands pair must parse");
+    if (web.snrAll != 30 || web.snrHf != 31) return fail("snr pair parse");
 
+    // ---- ext_api >= users_max -> Open ---------------------------------
     const KiwiPublicReceiver& open = rxs[1];
     if (open.extApi != 4 || open.usersMax != 4) return fail("open parse");
     if (open.apiPolicy() != ApiPolicy::Open) return fail("ext_api==users_max must be Open");
     if (open.advertisesConnectionLimit()) return fail("no limits marker should be false");
     if (!open.connectionLimitBadge().isEmpty()) return fail("no limits badge");
     if (!open.mayConnectViaApi()) return fail("open receiver must allow API connect");
+    // A [0, 0] fix is the origin's "no position", not a position on null island.
+    if (open.hasGps) return fail("gps [0,0] must not read as a fix");
+    if (open.bandRangeLabel() != QStringLiteral("2.0 – 30.0 MHz"))
+        return fail("band range label");
 
     // Token match, not substring: a free-form hardware descriptor that merely
     // contains the letters "limits" must not false-positive, but the real marker
@@ -90,17 +150,69 @@ int main()
     if (!tok.advertisesConnectionLimit())
         return fail("case-insensitive Limits token must match");
 
+    // ---- 0 < ext_api < users_max -> Limited ---------------------------
     const KiwiPublicReceiver& limited = rxs[2];
     if (limited.extApi != 4 || limited.usersMax != 8) return fail("limited parse");
     if (limited.apiPolicy() != ApiPolicy::Limited) return fail("0<ext_api<max must be Limited");
     if (!limited.mayConnectViaApi()) return fail("limited receiver must allow API connect");
+    if (!limited.flagged) return fail("flagged JSON true must parse");
 
-    // The picker filter: only API-permitted receivers are shown.
-    int shown = 0;
-    for (const auto& r : rxs)
-        if (r.mayConnectViaApi()) ++shown;
-    if (shown != 2) return fail("exactly 2 of 3 should pass the API-only filter");
+    // ---- ext_api key ABSENT -> Unknown --------------------------------
+    // The regression test for this whole migration. Assert on extApi == -1
+    // specifically: mayConnectViaApi() alone would still pass with the
+    // toInt()-returns-0 bug in place, because Disabled also refuses to connect.
+    const KiwiPublicReceiver& silent = rxs[3];
+    if (silent.extApi != -1)
+        return fail("an absent ext_api key must stay -1, NOT become 0");
+    if (silent.apiPolicy() != ApiPolicy::Unknown)
+        return fail("an absent ext_api key must be Unknown, not Disabled");
+    if (silent.mayConnectViaApi())
+        return fail("policy-unknown receiver must NOT allow API connect");
+    if (!silent.apiBadge().contains(QStringLiteral("unknown")))
+        return fail("policy-unknown receiver must badge as unknown");
+    if (silent.hasGps || silent.hasBands) return fail("absent gps/bands must stay unset");
+    if (silent.snrAll != -1 || silent.snrHf != -1) return fail("absent snr must stay -1");
 
-    std::printf("kiwi_public_directory_test: OK (3 parsed, 1 web-only filtered out)\n");
+    // The picker filter: only API-permitted, unflagged receivers are shown, and
+    // the two hidden-for-policy reasons are counted apart.
+    int shown = 0, hiddenWebOnly = 0, hiddenUnknown = 0, hiddenFlagged = 0;
+    for (const auto& r : rxs) {
+        if (r.offline) continue;
+        if (r.flagged) { ++hiddenFlagged; continue; }
+        if (!r.mayConnectViaApi()) {
+            if (r.apiPolicy() == ApiPolicy::Disabled) ++hiddenWebOnly;
+            else ++hiddenUnknown;
+            continue;
+        }
+        ++shown;
+    }
+    if (shown != 1) return fail("exactly 1 receiver should survive the picker filter");
+    if (hiddenWebOnly != 1) return fail("exactly 1 web-only hidden");
+    if (hiddenUnknown != 1) return fail("exactly 1 policy-unknown hidden");
+    if (hiddenFlagged != 1) return fail("exactly 1 flagged hidden");
+
+    // ---- fail closed at the boundary (Principle VII) ------------------
+    if (KiwiPublicDirectory::parse(QByteArray()).ok())
+        return fail("an empty body must fail, not yield an empty list");
+    if (KiwiPublicDirectory::parse(QByteArrayLiteral("{\"schema\": 1, \"receivers\": [")).ok())
+        return fail("a truncated body must fail cleanly, not yield a partial list");
+    if (KiwiPublicDirectory::parse(QByteArrayLiteral("not json at all")).ok())
+        return fail("a non-JSON body must fail");
+    if (KiwiPublicDirectory::parse(QByteArrayLiteral("[]")).ok())
+        return fail("a top-level array must fail (the document is an object)");
+    if (KiwiPublicDirectory::parse(QByteArrayLiteral("{\"receivers\": []}")).ok())
+        return fail("a body with no schema must fail");
+
+    const KiwiDirectoryParse future = KiwiPublicDirectory::parse(
+        QByteArrayLiteral("{\"schema\": 2, \"receivers\": [{\"url\": \"http://x:8073\"}]}"));
+    if (future.ok())
+        return fail("an unsupported schema must be rejected, not parsed hopefully");
+    if (!future.receivers.isEmpty())
+        return fail("a rejected schema must yield no receivers");
+    if (!future.error.contains(QStringLiteral("update AetherSDR")))
+        return fail("a schema mismatch must tell the user to update AetherSDR");
+
+    std::printf("kiwi_public_directory_test: OK (4 parsed; web-only, "
+                "policy-unknown and flagged all filtered out separately)\n");
     return 0;
 }

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1898,7 +1898,7 @@ target_include_directories(receive_presentation_sync_test PRIVATE src)
 target_link_libraries(receive_presentation_sync_test PRIVATE Qt6::Core)
 add_test(NAME receive_presentation_sync_test COMMAND receive_presentation_sync_test)
 
-# Public-directory parser + external-API (ext_api) policy honoring.
+# Directory-mirror JSON parser + external-API (ext_api) policy honoring.
 add_executable(kiwi_public_directory_test
     tests/kiwi_public_directory_test.cpp
     src/core/KiwiPublicDirectory.cpp
@@ -1909,7 +1909,7 @@ target_compile_definitions(kiwi_public_directory_test PRIVATE AETHERSDR_VERSION=
 set_target_properties(kiwi_public_directory_test PROPERTIES AUTOMOC ON)
 add_test(NAME kiwi_public_directory_test COMMAND kiwi_public_directory_test)
 
-# Demonstration tool: honest, API-policy-aware read of kiwisdr.com/public
+# Demonstration tool: honest, API-policy-aware read of the AetherSDR mirror
 # (proof-of-concept shown to operators — see docs/kiwisdr-public-directory.md).
 add_executable(kiwi_directory_poc
     tools/kiwi_directory_poc.cpp

--- a/tools/kiwi_directory_poc.cpp
+++ b/tools/kiwi_directory_poc.cpp
@@ -1,19 +1,28 @@
 // Proof-of-concept: AetherSDR's honest, API-policy-aware read of the public
-// KiwiSDR directory (kiwisdr.com/public).
+// KiwiSDR directory.
 //
-// Demonstrates exactly how AetherSDR honors each operator's external-API
+// The list comes from AetherSDR's own mirror (cdn.aethersdr.com/kiwi.json),
+// which exists at the KiwiSDR maintainer's request: a Cloudflare Worker pulls
+// kiwisdr.com/public once an hour under a shared secret he provided, and every
+// AetherSDR client reads our copy.  His server sees one hourly request instead
+// of one per user, per browse — which is the load he asked us to remove.  The
+// client never contacts kiwisdr.com, and there is deliberately no fallback that
+// would send it there when our CDN has a bad day.
+//
+// This tool demonstrates how AetherSDR honors each operator's external-API
 // policy (ext_api) BEFORE attempting any connection:
-//   • ext_api == 0  → "web only": AetherSDR will NOT open a native API
-//                     connection; it routes the user to the web client.
-//   • ext_api  > 0  → API permitted (up to that many channels).
+//   • ext_api == 0   → "web only": AetherSDR will NOT open a native API
+//                      connection; it routes the user to the web client.
+//   • ext_api  > 0   → API permitted (up to that many channels).
+//   • ext_api absent → policy not published; treated as "do not assume API is
+//                      allowed".  In kiwi.json this is a MISSING KEY, not a
+//                      zero, and the two must never be conflated.
 //
-// It identifies honestly as "AetherSDR/<ver>" (never a spoofed browser) and
-// fetches only on this explicit invocation — the program IS the single human
-// action; there is no polling, caching, or enumeration.
+// It identifies honestly as "AetherSDR/<ver>" — never a spoofed browser.
 //
 // Usage:
-//   kiwi_directory_poc            # honest live fetch from kiwisdr.com/public
-//   kiwi_directory_poc <file>     # parse a previously-saved directory HTML
+//   kiwi_directory_poc            # fetch from the AetherSDR mirror
+//   kiwi_directory_poc <file>     # parse a previously-saved kiwi.json
 
 #include "core/KiwiPublicDirectory.h"
 
@@ -22,14 +31,18 @@
 #include <QTextStream>
 #include <QTimer>
 
+using AetherSDR::KiwiDirectoryParse;
 using AetherSDR::KiwiPublicDirectory;
 using AetherSDR::KiwiPublicReceiver;
 
-static void report(const QVector<KiwiPublicReceiver>& rxs)
+static void report(const KiwiDirectoryParse& parsed)
 {
     QTextStream out(stdout);
-    int disabled = 0, limited = 0, open = 0, unknown = 0;
+    const auto& rxs = parsed.receivers;
+    int disabled = 0, limited = 0, open = 0, unknown = 0, flagged = 0, offline = 0;
     for (const auto& r : rxs) {
+        if (r.flagged) ++flagged;
+        if (r.offline) ++offline;
         switch (r.apiPolicy()) {
             case KiwiPublicReceiver::ApiPolicy::Disabled: ++disabled; break;
             case KiwiPublicReceiver::ApiPolicy::Limited:  ++limited;  break;
@@ -39,14 +52,23 @@ static void report(const QVector<KiwiPublicReceiver>& rxs)
     }
 
     out << "\n================ AetherSDR — KiwiSDR public directory ================\n";
+    out << "Source          : " << KiwiPublicDirectory::kDirectoryUrl << "\n";
+    out << "                  (AetherSDR's mirror of kiwisdr.com/public, at the\n";
+    out << "                   maintainer's request — clients never hit his server)\n";
     out << "User-Agent sent : " << KiwiPublicDirectory::userAgent() << "\n";
-    out << "Receivers parsed: " << rxs.size() << "\n\n";
+    out << "Schema          : " << parsed.schema << "\n";
+    out << "Mirror fetched  : "
+        << (parsed.fetchedAt.isValid() ? parsed.fetchedAt.toString(Qt::ISODate)
+                                       : QStringLiteral("(not published)")) << "\n";
+    out << "Receivers parsed: " << rxs.size()
+        << "   (" << offline << " offline, " << flagged << " flagged by the origin)\n\n";
     out << "Per-operator external-API policy (read from the directory):\n";
     out << "  web-only (ext_api=0) : " << disabled
         << "   <- AetherSDR will NOT connect via API; uses web client\n";
     out << "  API limited          : " << limited  << "   (some channels reserved for web)\n";
     out << "  API open             : " << open     << "\n";
-    out << "  policy not published : " << unknown  << "\n\n";
+    out << "  policy not published : " << unknown
+        << "   <- no ext_api key at all; NOT the same as 0\n\n";
 
     out << "--- honoring 'web only' operators (first 8 of " << disabled << ") ---\n";
     int shown = 0;
@@ -59,13 +81,25 @@ static void report(const QVector<KiwiPublicReceiver>& rxs)
         if (++shown >= 8) break;
     }
 
+    out << "\n--- policy not published (first 8 of " << unknown << ") ---\n";
+    shown = 0;
+    for (const auto& r : rxs) {
+        if (r.apiPolicy() != KiwiPublicReceiver::ApiPolicy::Unknown) continue;
+        out << "  [UNKNOWN]  " << r.url << "  |  extApi = " << r.extApi
+            << "  |  mayConnectViaApi() = "
+            << (r.mayConnectViaApi() ? "true  (!!)" : "false") << "\n";
+        if (++shown >= 8) break;
+    }
+
     out << "\n--- a few API-permitted operators (AetherSDR streams natively) ---\n";
     shown = 0;
     for (const auto& r : rxs) {
         if (r.apiPolicy() == KiwiPublicReceiver::ApiPolicy::Disabled
             || r.apiPolicy() == KiwiPublicReceiver::ApiPolicy::Unknown) continue;
         out << "  [API OK]   " << r.url << "  |  users " << r.users << "/" << r.usersMax
-            << "  |  " << r.apiBadge() << "\n";
+            << "  |  " << r.apiBadge();
+        if (r.hasBands) out << "  |  " << r.bandRangeLabel();
+        out << "\n";
         if (++shown >= 6) break;
     }
     out << "=====================================================================\n";
@@ -76,21 +110,30 @@ int main(int argc, char* argv[])
     QCoreApplication app(argc, argv);
 
     if (argc > 1) {
-        // Offline parse of a saved directory page.
+        // Offline parse of a saved kiwi.json.
         QFile f(QString::fromLocal8Bit(argv[1]));
         if (!f.open(QIODevice::ReadOnly)) {
             QTextStream(stderr) << "cannot open " << argv[1] << "\n";
             return 1;
         }
-        report(KiwiPublicDirectory::parse(f.readAll()));
+        const KiwiDirectoryParse parsed = KiwiPublicDirectory::parse(f.readAll());
+        if (!parsed.ok()) {
+            QTextStream(stderr) << "parse failed: " << parsed.error << "\n";
+            return 1;
+        }
+        report(parsed);
         return 0;
     }
 
-    // Honest live fetch.
+    // Live fetch from the mirror.
     KiwiPublicDirectory dir;
     QObject::connect(&dir, &KiwiPublicDirectory::ready,
-                     [](const QVector<KiwiPublicReceiver>& rxs) {
-        report(rxs);
+                     [](const QVector<KiwiPublicReceiver>& rxs, const QDateTime& fetchedAt) {
+        KiwiDirectoryParse parsed;
+        parsed.receivers = rxs;
+        parsed.fetchedAt = fetchedAt;
+        parsed.schema = KiwiPublicDirectory::kSupportedSchema;
+        report(parsed);
         QCoreApplication::quit();
     });
     QObject::connect(&dir, &KiwiPublicDirectory::failed, [](const QString& err) {


### PR DESCRIPTION
**Governance:** gated on the RFC issue **#5447** (new external dependency + default UX behavior change, per GOVERNANCE.md). Do not merge before that is approved.

## Why

**The KiwiSDR maintainer asked us to do this.** AetherSDR clients were each
fetching `kiwisdr.com/public` for themselves, and the aggregate load was a
problem for his server. A Cloudflare Worker now pulls the origin hourly under a
shared secret he provided and republishes it as JSON at
`https://cdn.aethersdr.com/kiwi.json`. His server sees one request an hour
instead of one per user, per browse.

`KiwiPublicDirectory` now reads that mirror. The HTML scraping, the anchor regex
and the three-step interactive-gate token replay are all gone.

## The two decisions, made explicitly

**1. The origin fetch path is removed — no fallback.** Keeping the HTML path as
a CDN-outage fallback would look free, but it would mean that the moment our CDN
has a bad day, every AetherSDR install in the world reverts to hammering the
server we were asked to relieve, at the least convenient possible moment and
without the maintainer having any say. When the mirror is unreachable the picker
serves the list it already has, or says the directory is unavailable. This is
written down in `docs/kiwisdr-public-directory.md` where the maintainer could
read it.

**2. Refresh respects the mirror's 30-minute `max-age` rather than staying
strictly manual.** The "one human click == one fetch" rule existed solely to
protect the maintainer's server; the mirror serves that far better. Opening the
picker re-serves the session cache inside that window and fetches past it. The
manual "Refresh list" stays.

## The one thing that must not regress

In `kiwi.json` a receiver that does not publish an external-API policy has **no
`ext_api` key at all** — 23 of the current 870. `obj["ext_api"].toInt()` returns
`0` for a missing key, which would silently reclassify every one of those
operators as having *disabled* the API. That fails safe for the connection
decision, but it misreports the operator's policy in the badge and in the
picker's hidden-receiver counts, which is the thing this class exists to get
right.

The key is read as `-1` unless actually present, and the test asserts on
`extApi == -1` **specifically** — asserting only on `mayConnectViaApi()` would
pass with the bug in place, because `Disabled` also refuses to connect.

## Type changes

Three struct fields held unparsed origin text; the JSON gives them typed. No
consumer outside `KiwiPublicDirectory` / `KiwiPublicReceiverPicker` read them
(`RadioSetupDialog.cpp:5007` only constructs the picker).

| Field | Was | Now |
|---|---|---|
| `gps` | `QString "(lat, lon)"` | `gpsLat` / `gpsLon` / `hasGps` — a `[0,0]` fix reads as *no* fix |
| `bands` | `QString "0-30000000"` | `bandLowHz` / `bandHighHz` / `hasBands`, plus `bandRangeLabel()` |
| `snr` | `QString "42,43"` | `snrAll` / `snrHf`, with the scalar `snr_all`/`snr_hf` keys as fallback |

## Boundary validation — Principle VII

Body size and receiver count are capped, per-field strings are bounded, a
`schema` other than `1` is rejected with a "please update AetherSDR" message
rather than parsed hopefully, and a malformed, truncated or empty body fails
closed instead of yielding a partial list.

## Also

- `flagged` (30 of 870, new) is hidden and counted as its own hidden category
  alongside web-only and policy-unknown.
- The picker surfaces the list's age once it passes the mirror's 360-minute
  staleness threshold.
- The good-citizen contract in the header and in
  `docs/kiwisdr-public-directory.md` is **rewritten, not deleted**. The "no
  caching-and-redistribution" clause was stale: we now do cache and
  redistribute, *because the maintainer asked us to*. It is a stricter
  arrangement than the one the comment described, made with the operator rather
  than around him, and the reason is the most important thing to record.

## Testing

- Full build clean.
- `ctest` **347/347 pass**, including `kiwi_public_directory_test`.
- `kiwi_directory_poc` against the live CDN: **870 receivers**, schema 1,
  `fetched_at 2026-09-05T14:00:01Z` — 135 web-only / 558 limited / 154 open /
  **23 policy-not-published**. The 23 come back as `extApi == -1`, not `0`.
- The POC still accepts a local file argument for offline parsing.
- `check_network_timeouts.py --strict` and `check_engine_boundary.py` clean.

New test coverage: all four `ext_api` regimes (including the absent key), typed
gps/bands/snr, `[0,0]` gps rejection, real-bool `offline` and `flagged`, and the
boundary failures — empty, truncated, non-JSON, top-level array, missing schema,
and `schema: 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)