### PR TITLE
feat(kiwi): vendor the directory-mirror Worker, and make staleness advisory (RFC #5447)

### DIFF
--- a/docs/kiwi-json-schema.md
+++ b/docs/kiwi-json-schema.md
@@ -7,13 +7,14 @@ Both sides of this contract are in this repository:
 
 | Side | Where |
 |---|---|
-| **Producer** — the Cloudflare Worker that pulls `kiwisdr.com/public` hourly under a shared secret the KiwiSDR maintainer provided, and emits this payload | [`tools/kiwi-mirror-worker/`](../tools/kiwi-mirror-worker/), field mapping in `src/parse.js` |
+| **Producer** — the Cloudflare Worker that pulls `kiwisdr.com/public` hourly under a shared secret the KiwiSDR maintainer provided, and emits this payload | [`tools/kiwi-mirror-worker/`](../tools/kiwi-mirror-worker/) — field mapping in `src/parse.js`, the `schema` literals in `src/index.js` |
 | **Consumer** — the client that reads it | `src/core/KiwiPublicDirectory.cpp`, pinned by `kSupportedSchema` |
 
 Change one and change the other, in the same PR.
 
 **Changing anything below is a schema break.** Bump `schema` in
-`tools/kiwi-mirror-worker/src/parse.js`, and bump
+`tools/kiwi-mirror-worker/src/index.js` (both the published payload and the
+status document), and bump
 `kSupportedSchema` in `src/core/KiwiPublicDirectory.h` in the same breath — the
 client rejects an unrecognised `schema` outright rather than parsing on
 hopefully, so an unannounced field change turns into "please update AetherSDR"

--- a/docs/kiwi-json-schema.md
+++ b/docs/kiwi-json-schema.md
@@ -138,6 +138,19 @@ reading the URL they were built against, and a rollout becomes additive rather
 than a flag day. Retire an old path only when the builds that request it are
 genuinely gone, and treat that as its own decision.
 
+## Staleness is advisory
+
+`fetched_at` tells the client how old the mirror's copy is. It is something to
+**display**, never something to gate on: the client shows the list at any age,
+and adds its age to the picker's status line past 360 minutes.
+
+The producer should not expect a client to refuse stale data, and should not add
+a field trying to make it. The mirror advertises `stale_after_minutes` on its
+**status document** for humans reading the status page; if anything of that kind
+ever appears in `kiwi.json`, it remains advice. A stale list almost always means
+the origin is down while the mirror correctly serves its last good copy —
+withholding it at that moment converts an origin outage into a client outage.
+
 ## Compatibility rules for the producer
 
 1. **Adding an ignored field** — safe, no bump.

--- a/docs/kiwi-json-schema.md
+++ b/docs/kiwi-json-schema.md
@@ -1,12 +1,19 @@
 # `kiwi.json` — schema 1
 
 The reviewable, in-tree contract for the payload AetherSDR's directory mirror
-publishes at `https://cdn.aethersdr.com/kiwi.json`. The producer (a Cloudflare
-Worker that pulls `kiwisdr.com/public` hourly under a shared secret the KiwiSDR
-maintainer provided) lives outside this repository, so this file is what
-`KiwiPublicDirectory::kSupportedSchema` actually pins the client to.
+publishes at `https://cdn.aethersdr.com/kiwi.json`.
 
-**Changing anything below is a schema break.** Bump `schema`, and bump
+Both sides of this contract are in this repository:
+
+| Side | Where |
+|---|---|
+| **Producer** — the Cloudflare Worker that pulls `kiwisdr.com/public` hourly under a shared secret the KiwiSDR maintainer provided, and emits this payload | [`tools/kiwi-mirror-worker/`](../tools/kiwi-mirror-worker/), field mapping in `src/parse.js` |
+| **Consumer** — the client that reads it | `src/core/KiwiPublicDirectory.cpp`, pinned by `kSupportedSchema` |
+
+Change one and change the other, in the same PR.
+
+**Changing anything below is a schema break.** Bump `schema` in
+`tools/kiwi-mirror-worker/src/parse.js`, and bump
 `kSupportedSchema` in `src/core/KiwiPublicDirectory.h` in the same breath — the
 client rejects an unrecognised `schema` outright rather than parsing on
 hopefully, so an unannounced field change turns into "please update AetherSDR"

--- a/docs/kiwisdr-public-directory.md
+++ b/docs/kiwisdr-public-directory.md
@@ -89,6 +89,20 @@ parser reads it as `-1` unless the key is actually present, and
   plaintext HTTP. The version is deliberately retained: it is what tells us
   which builds are still live if a new schema URL is ever needed. Recorded as
   collected, in [`kiwi-json-schema.md`](kiwi-json-schema.md#what-the-mirror-sees).
+- **A stale list is shown, never withheld.** Age is advisory: past
+  `kStaleAfterMinutes` (360) the picker appends the list's age to its status
+  line, and that is all it does — no row is removed, no button is disabled, no
+  error replaces the list.
+
+  This is deliberate. A receiver directory ages gracefully — receivers do not
+  move, so a two-day-old list is still almost entirely correct, and a user
+  browsing it is far better served than one shown an empty dialog. The realistic
+  cause of a stale list is an outage at the **origin** (an expired certificate,
+  a host down), during which our mirror keeps serving its last good copy exactly
+  as designed. Gating on age would take the KiwiSDR maintainer's outage and turn
+  it into an AetherSDR outage — precisely backwards, since the mirror exists to
+  absorb his problems rather than amplify them. The same holds for any staleness
+  hint the mirror publishes: advice to display, never a gate.
 - **Refresh respects the mirror's own 30-minute `max-age`.** Opening the picker
   re-serves the session's cached list while it is inside that window and fetches
   once it is past; "Refresh list" always fetches. We never poll faster than the

--- a/src/core/KiwiPublicDirectory.h
+++ b/src/core/KiwiPublicDirectory.h
@@ -110,6 +110,17 @@ struct KiwiDirectoryParse {
     QString   error;          // empty iff the parse succeeded
 
     bool ok() const { return error.isEmpty(); }
+
+    // How old the mirror's copy is, or -1 when it published no usable
+    // fetched_at.  Advisory: something to SHOW, never something to gate on —
+    // ok() is deliberately independent of it, so no age can turn a served list
+    // into a withheld one.  See kStaleAfterMinutes.
+    qint64 ageMinutes() const
+    {
+        return fetchedAt.isValid()
+            ? fetchedAt.secsTo(QDateTime::currentDateTimeUtc()) / 60
+            : -1;
+    }
 };
 
 // Fetches and parses the public KiwiSDR receiver directory from AetherSDR's
@@ -138,6 +149,10 @@ struct KiwiDirectoryParse {
 //   • Refresh respects the mirror's own 30-minute cache lifetime; we do not
 //     poll faster than the data can change, and a manual refresh stays
 //     available for users who want one.
+//   • A stale list is shown, never withheld.  If the origin is down — an
+//     expired certificate, a dead host — the mirror keeps serving its last
+//     good copy, and the client keeps offering it with its age displayed.
+//     Refusing to populate would convert his outage into ours.
 //
 // See docs/kiwisdr-public-directory.md.
 class KiwiPublicDirectory : public QObject {
@@ -174,8 +189,24 @@ public:
     // that only re-reads bytes the CDN is still serving from cache.
     static constexpr int kMinRefreshSeconds = 1800;
 
-    // The mirror's own client-facing staleness threshold.  Past this the
-    // picker tells the user how old the list is.
+    // ADVISORY ONLY.  Past this age the picker tells the user how old the list
+    // is; it never withholds the list, and no code path may make it do so.
+    //
+    // This is a deliberate invariant, not an oversight.  A receiver directory
+    // ages gracefully: receivers do not move, so a list two days old is still
+    // almost entirely correct, and a user browsing it is far better served than
+    // one shown an empty dialog.  The realistic cause of a stale list is an
+    // outage at the ORIGIN — an expired certificate, a host down — during which
+    // our mirror keeps serving the last good copy exactly as designed.  Gating
+    // on age would take the KiwiSDR maintainer's outage and turn it into an
+    // AetherSDR outage, which is precisely backwards: the mirror exists to
+    // absorb his problems, not to amplify them.
+    //
+    // The same rule holds for any staleness hint the mirror itself publishes
+    // (it advertises stale_after_minutes on its status document).  Should such
+    // a field ever appear in kiwi.json, it is advice to display, never a gate.
+    // See docs/kiwisdr-public-directory.md and kiwi_public_directory_test.cpp,
+    // which locks this.
     static constexpr int kStaleAfterMinutes = 360;
 
     // Boundary caps (Principle VII).  kMaxBodyBytes is enforced twice: on the

--- a/src/gui/KiwiPublicReceiverPicker.cpp
+++ b/src/gui/KiwiPublicReceiverPicker.cpp
@@ -252,6 +252,12 @@ void KiwiPublicReceiverPicker::applyFilter()
         status += tr("  ·  cached — use “Refresh list” to update");
     // Surface the list's age only once it is genuinely old: the mirror refreshes
     // hourly, so anything inside its own staleness threshold is unremarkable.
+    //
+    // Note what this does NOT do: it never removes a row, never disables "Add
+    // selected", and never replaces the list with an error. Age is advice. A
+    // stale list means the ORIGIN is having a bad day while our mirror keeps
+    // serving its last good copy — withholding it would turn the KiwiSDR
+    // maintainer's outage into an AetherSDR one. See kStaleAfterMinutes.
     if (m_fetchedAt.isValid()) {
         const qint64 mins = m_fetchedAt.secsTo(QDateTime::currentDateTimeUtc()) / 60;
         if (mins >= KiwiPublicDirectory::kStaleAfterMinutes) {

--- a/tests/kiwi_public_directory_test.cpp
+++ b/tests/kiwi_public_directory_test.cpp
@@ -253,6 +253,47 @@ int main()
     if (!empty.error.contains(QStringLiteral("empty")))
         return fail("an empty receiver list must say so, not blame the payload");
 
+    // ---- staleness is advisory, never a gate ------------------------
+    // The realistic cause of a stale list is an outage at the ORIGIN, during
+    // which our mirror correctly keeps serving its last good copy. A client
+    // that refused to populate would convert the KiwiSDR maintainer's outage
+    // into an AetherSDR one. These cases fail if anyone ever makes age gate.
+    const auto withFetchedAt = [](const char* stamp) {
+        QByteArray body = kSample;
+        body.replace("\"2026-09-05T14:00:01Z\"", stamp);
+        return KiwiPublicDirectory::parse(body);
+    };
+
+    const KiwiDirectoryParse ancient = withFetchedAt("\"2019-01-01T00:00:00Z\"");
+    if (!ancient.ok())
+        return fail("a years-old list must still parse — age is advice, not a gate");
+    if (ancient.receivers.size() != 4)
+        return fail("a years-old list must still yield every receiver");
+    if (ancient.ageMinutes() < 60)
+        return fail("a years-old list must report a large age");
+
+    // No fetched_at at all: still usable, just with no age to show.
+    const KiwiDirectoryParse undated = withFetchedAt("null");
+    if (!undated.ok())
+        return fail("a list with no fetched_at must still parse");
+    if (undated.receivers.size() != 4)
+        return fail("a list with no fetched_at must still yield every receiver");
+    if (undated.ageMinutes() != -1)
+        return fail("an unpublished fetched_at must report age -1, not 0");
+
+    // Malformed timestamp: same rule. A producer typo must not empty the picker.
+    const KiwiDirectoryParse garbled = withFetchedAt("\"not-a-timestamp\"");
+    if (!garbled.ok())
+        return fail("a malformed fetched_at must not fail the parse");
+    if (garbled.receivers.size() != 4)
+        return fail("a malformed fetched_at must still yield every receiver");
+    if (garbled.ageMinutes() != -1)
+        return fail("a malformed fetched_at must report age -1");
+
+    // A fresh list reports a small age, so the threshold means something.
+    if (parsed.ageMinutes() < 0)
+        return fail("a valid fetched_at must report a real age");
+
     std::printf("kiwi_public_directory_test: OK (4 parsed; web-only, "
                 "policy-unknown and flagged all filtered out separately)\n");
     return 0;

--- a/tools/kiwi-mirror-worker/.gitignore
+++ b/tools/kiwi-mirror-worker/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.wrangler/
+seed-payload.json
+seed-status.json
+*.log

--- a/tools/kiwi-mirror-worker/README.md
+++ b/tools/kiwi-mirror-worker/README.md
@@ -1,0 +1,145 @@
+# kiwi-directory-mirror
+
+Mirrors the KiwiSDR public receiver directory into JSON and serves it from
+Cloudflare, so AetherSDR clients read our copy instead of the origin.
+
+| URL | What |
+| --- | --- |
+| `https://cdn.aethersdr.com/kiwi.json` | The receiver list, full fidelity |
+| `https://kiwi-status.aethersdr.com/` | Operator status page |
+| `https://kiwi-status.aethersdr.com/health.json` | Poll history and fault state |
+| `https://kiwi-status.aethersdr.com/status.json` | What was last published |
+
+One Worker serves both hostnames, routing on `Host`. An hourly cron polls the
+origin, parses the HTML directory to JSON and writes it to KV.
+
+## Auth
+
+The origin requires a shared secret supplied by the KiwiSDR maintainer. The
+mirror exists at his request: AetherSDR clients were putting too much load on
+his server individually, so we pull once an hour and redistribute to our own
+users.
+
+**How the secret is presented is verified against the live origin, and is not
+recorded in this repository.** The transport is configuration
+(`KIWI_AUTH_MODE`, `KIWI_AUTH_NAME`), and all three values are Worker secrets:
+
+```sh
+wrangler secret put KIWI_SECRET
+wrangler secret put KIWI_AUTH_MODE
+wrangler secret put KIWI_AUTH_NAME
+```
+
+The transport is **not a credential** — knowing it grants nobody access, and the
+secret stays a secret regardless. It lives outside the repo because
+`aethersdr/AetherSDR` is public and the arrangement with the maintainer is not.
+Treat it as need-to-know rather than as something to defend.
+
+There is deliberately **no default** for either. A wrong default in public
+source discloses just as confidently as a right one, and silently: the Worker
+would poll with a guess and blame the origin for refusing it. Instead a missing
+transport is refused before any request, as a `mirror` fault
+(`auth-misconfigured`) — our mistake, costing his server nothing.
+
+If the secret is ever unset, the Worker records an `auth` fault and **makes no
+origin request at all** — hourly 403s against his server would be rude and would
+tell us nothing we do not already know. A missing transport is refused the same
+way, as a `mirror` fault, because that one is ours.
+
+The origin serves `content-encoding: gzip`, which the Workers runtime unwraps on
+its own. Nothing in this repo needs to decompress anything.
+
+## Conditional GET, and the weak-validator trap
+
+The origin sends a strong ETag and honours `If-None-Match` correctly. But our
+`fetch()` decompresses the gzip response on the way in, so Cloudflare weakens the
+validator it hands us to `W/"..."` — the bytes we hold are no longer the bytes
+the origin hashed.
+
+Sending that weak form straight back matches nothing. The origin compares
+strictly, answers `200`, and we republish an identical 800 KB list every single
+hour while `not-modified` never once appears in the history. The previous
+`aethersdr.ozy.us` mirror had exactly this behaviour.
+
+`originRequest()` therefore strips the `W/` prefix before asking. Two tests lock
+it. If you ever see a long run of `published` with an unchanging receiver count
+and no `not-modified` in between, look here first.
+
+## The published list
+
+`kiwi.json` carries every field the origin sends, typed where the meaning is
+unambiguous and left as a string where it is not:
+
+```json
+{
+  "schema": 1,
+  "source": "https://files.kiwisdr.com/public/",
+  "fetched_at": "2026-09-05T14:00:01Z",
+  "receiver_count": 870,
+  "receivers": [
+    {
+      "id": "884aeaf59cc6",
+      "name": "2-30MHZ SDR #2, VK5ARG Remote Receiver Site | Near Tarlee, South Australia",
+      "url": "http://kiwisdr.areg.org.au:8074",
+      "gps": [-34.2737, 138.771],
+      "bands": [2000000, 30000000],
+      "snr": [42, 43],
+      "users": 6,
+      "users_max": 8,
+      "flagged": false
+    }
+  ]
+}
+```
+
+870 receivers is about 0.77 MB raw, 126 KB gzipped. Three fields are ours, not
+the origin's: `url` (from the entry's anchor), `seq`/`snr_all`/`snr_hf` (from the
+entry's CSS classes), and `flagged` (true when the origin paints the row red with
+`cl-err-entry` — its own signal that something is wrong with the entry).
+
+## Refusing to publish
+
+Every failure leaves the last good list in place. The one worth knowing about:
+if a poll returns fewer than `KIWI_MIN_ENTRIES_FRACTION` (0.5) of the last
+published count, the mirror parks on the old list and raises `needs-review`.
+That fault **does not clear on its own** — the origin has served truncated pages
+before, and publishing one would erase most of the directory for every client.
+If the drop is real, raise the fraction or clear `directory:status` in KV.
+
+Conditional GET is used when the origin sends an ETag, with an unconditional
+fetch forced after 24 consecutive 304s so a stale stored ETag cannot freeze the
+mirror silently.
+
+## Thresholds
+
+The status page and any external alarm must agree, or they will disagree about
+the same mirror at the worst moment. Both are expressed as missed polls:
+
+| | Value | Meaning |
+| --- | --- | --- |
+| `RUN_STALE_MIN` | 150 (2.5 polls) | Nothing is running |
+| `CONTENT_STALE_MIN` | 240 (4 polls) | Polling, but the list is old |
+| `NO_PUBLISH_MIN` | 1440 | Frozen — succeeding but never changing |
+| `stale_after_minutes` | 360 | What clients are told; deliberately looser |
+
+The page derives its own wording from these constants, so changing a number
+changes the prose with it.
+
+## Tests
+
+```sh
+npm test
+```
+
+Nine cases over a real 870-receiver capture, weighted toward the failure paths:
+no-secret, 304, truncated page, redirect, gate page, 5xx retry vs 4xx give-up,
+and history bounding.
+
+## Still to do
+
+- Retire the `aethersdr.ozy.us` mirror now that this one is publishing. It lives
+  in a different Cloudflare account and cannot be reached from here.
+- Point `ops/kuma-staleness-monitor.py` at the new `health.json`.
+- Update the AetherSDR client to read `cdn.aethersdr.com/kiwi.json` instead of
+  fetching the origin directly — that is the whole point of the exercise, and
+  until it ships the load the maintainer complained about is still there.

--- a/tools/kiwi-mirror-worker/package.json
+++ b/tools/kiwi-mirror-worker/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "kiwi-directory-mirror",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node test/poll.test.mjs test/fixtures/directory.html",
+    "deploy": "wrangler deploy",
+    "tail": "wrangler tail kiwi-directory-mirror"
+  }
+}

--- a/tools/kiwi-mirror-worker/src/index.js
+++ b/tools/kiwi-mirror-worker/src/index.js
@@ -59,6 +59,9 @@ const notFound = () =>
  * public source is its own kind of disclosure, and a silent one. pollOrigin()
  * rejects a missing transport before we ever reach here.
  */
+/** The transports originRequest() knows how to speak. */
+const AUTH_MODES = new Set(['query', 'header', 'cookie', 'bearer']);
+
 function originRequest(env, etag) {
   const url = new URL(env.KIWI_SOURCE_URL);
   const headers = { 'user-agent': env.KIWI_USER_AGENT };
@@ -99,11 +102,17 @@ async function pollOrigin(env, state) {
     return { result: 'failed', reason: 'no-secret', fault: 'auth', attempts: 0 };
   }
 
-  if (!env.KIWI_AUTH_MODE || !env.KIWI_AUTH_NAME) {
-    // Same restraint, different culprit. A half-configured deploy is OUR
-    // mistake, so it must not be reported as an origin failure and must not
-    // burn three retries against his server discovering that we forgot to
-    // finish setting ourselves up.
+  // Membership, not merely non-empty: a typo'd or stale mode would otherwise
+  // reach originRequest()'s `else throw`, which runs INSIDE the retry loop's
+  // try, so it lands in the catch as fault 'origin' and gets repeated three
+  // times. The operator page would then say kiwisdr.com is not answering and
+  // that it clears itself when the origin comes back — both false, and the
+  // fault taxonomy is the whole reason that page exists. With this check the
+  // `else throw` is genuinely unreachable, which is the right shape for it.
+  if (!AUTH_MODES.has(env.KIWI_AUTH_MODE) || !env.KIWI_AUTH_NAME) {
+    // A half-configured deploy is OUR mistake, so it must not be reported as
+    // an origin failure and must not burn three retries against his server
+    // discovering that we forgot to finish setting ourselves up.
     return { result: 'failed', reason: 'auth-misconfigured', fault: 'mirror', attempts: 0 };
   }
 

--- a/tools/kiwi-mirror-worker/src/index.js
+++ b/tools/kiwi-mirror-worker/src/index.js
@@ -1,0 +1,300 @@
+/**
+ * KiwiSDR public directory mirror.
+ *
+ * A cron pulls kiwisdr.com's public receiver directory, parses it to JSON and
+ * publishes it so AetherSDR clients read our copy instead of the origin. Two
+ * hostnames are served from this one Worker:
+ *
+ *   cdn.aethersdr.com/kiwi.json      the receiver list
+ *   kiwi-status.aethersdr.com/       the operator status page (+ its two JSONs)
+ *
+ * The guiding rule throughout: never replace a good list with a bad one. Every
+ * failure path leaves the last known-good payload in place and records why, so
+ * a broken origin degrades to "stale but serving" rather than "empty".
+ */
+
+import { parseDirectory } from './parse.js';
+import { STATUS_PAGE } from './status-page.js';
+
+const KEY_PAYLOAD = 'directory:payload';
+const KEY_STATUS = 'directory:status';
+const KEY_HEALTH = 'mirror:health';
+
+/** How many poll results the status page gets to draw. */
+const HISTORY = 20;
+
+/** Give up on a single poll after this many attempts. */
+const MAX_ATTEMPTS = 3;
+
+/**
+ * A run of 304s this long forces an unconditional fetch. If our stored ETag
+ * ever stops matching reality, conditional GET would otherwise freeze the
+ * mirror silently and every signal would stay green.
+ */
+const FORCE_FULL_AFTER_304 = 24;
+
+const json = (body, extra = {}) =>
+  new Response(JSON.stringify(body, null, 2), {
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'access-control-allow-origin': '*',
+      ...extra,
+    },
+  });
+
+const notFound = () =>
+  new Response('Not found\n', { status: 404, headers: { 'content-type': 'text/plain; charset=utf-8' } });
+
+/* ── origin ──────────────────────────────────────────────────────────────── */
+
+/**
+ * Build the origin request. The directory is behind a shared secret agreed with
+ * the KiwiSDR operator; how that secret is presented is configuration, not a
+ * constant, so it can be corrected without a code change if the arrangement
+ * changes.
+ *
+ * Mode and name are Worker secrets like the value itself — not because the
+ * transport is a credential, but because this repo is public and the
+ * arrangement is not. There is deliberately no default: a wrong default in
+ * public source is its own kind of disclosure, and a silent one. pollOrigin()
+ * rejects a missing transport before we ever reach here.
+ */
+function originRequest(env, etag) {
+  const url = new URL(env.KIWI_SOURCE_URL);
+  const headers = { 'user-agent': env.KIWI_USER_AGENT };
+
+  const mode = env.KIWI_AUTH_MODE;
+  const name = env.KIWI_AUTH_NAME;
+  if (mode === 'query') url.searchParams.set(name, env.KIWI_SECRET);
+  else if (mode === 'header') headers[name] = env.KIWI_SECRET;
+  else if (mode === 'cookie') headers.cookie = `${name}=${env.KIWI_SECRET}`;
+  else if (mode === 'bearer') headers.authorization = `Bearer ${env.KIWI_SECRET}`;
+  else throw new Error(`unknown KIWI_AUTH_MODE: ${mode}`);
+
+  // Strip the weak-validator prefix before asking. The origin sends a strong
+  // ETag, but our own fetch decompresses the gzip response on the way in and
+  // Cloudflare weakens the validator to W/"..." to reflect that the bytes we
+  // hold are no longer the bytes it hashed. Sending that back never matches:
+  // the origin compares strictly, answers 200, and we republish an identical
+  // 800 KB list every hour while `not-modified` stays dead code.
+  if (etag) headers['if-none-match'] = etag.replace(/^W\//, '');
+
+  // redirect:manual — following a redirect would silently mirror something
+  // other than what we agreed to mirror.
+  return new Request(url, { headers, redirect: 'manual' });
+}
+
+/**
+ * The origin answers a click-through gate page instead of the directory when
+ * the secret is wrong. It returns 200, so only the body distinguishes it.
+ */
+function looksLikeGate(html) {
+  return !html.includes("class='cl-entry") && /click|agree|accept|continue/i.test(html.slice(0, 4000));
+}
+
+async function pollOrigin(env, state) {
+  if (!env.KIWI_SECRET) {
+    // Deliberately no request: hammering a third party with hourly 403s while
+    // the secret is unset would be rude and tells us nothing we don't know.
+    return { result: 'failed', reason: 'no-secret', fault: 'auth', attempts: 0 };
+  }
+
+  if (!env.KIWI_AUTH_MODE || !env.KIWI_AUTH_NAME) {
+    // Same restraint, different culprit. A half-configured deploy is OUR
+    // mistake, so it must not be reported as an origin failure and must not
+    // burn three retries against his server discovering that we forgot to
+    // finish setting ourselves up.
+    return { result: 'failed', reason: 'auth-misconfigured', fault: 'mirror', attempts: 0 };
+  }
+
+  const force = (state.consecutive_not_modified || 0) >= FORCE_FULL_AFTER_304;
+  const etag = force ? null : state.etag;
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(originRequest(env, etag));
+
+      if (res.status === 304) return { result: 'not-modified', attempts: attempt };
+
+      if (res.status >= 300 && res.status < 400) {
+        return {
+          result: 'failed', reason: 'redirect', fault: 'upstream-change',
+          detail: res.headers.get('location') || String(res.status), attempts: attempt,
+        };
+      }
+
+      if (!res.ok) {
+        lastError = { reason: 'bad-status', fault: 'origin', detail: String(res.status) };
+        // 4xx is a decision, not a hiccup; retrying will not change it.
+        if (res.status < 500) break;
+        continue;
+      }
+
+      const html = await res.text();
+      if (looksLikeGate(html)) {
+        return { result: 'failed', reason: 'gate-page', fault: 'auth', attempts: attempt };
+      }
+
+      return {
+        result: 'fetched', attempts: attempt, html,
+        etag: res.headers.get('etag'),
+        conditional_get: Boolean(res.headers.get('etag')),
+        forced_full: force,
+      };
+    } catch (err) {
+      lastError = { reason: 'fetch-failed', fault: 'origin', detail: String(err && err.message || err).slice(0, 200) };
+    }
+  }
+
+  return { result: 'failed', attempts: MAX_ATTEMPTS, ...(lastError || { reason: 'unknown', fault: 'mirror' }) };
+}
+
+/* ── the poll ────────────────────────────────────────────────────────────── */
+
+export async function runPoll(env, now = new Date()) {
+  const at = now.toISOString();
+  const health = (await env.KIWI.get(KEY_HEALTH, 'json')) || {
+    schema: 1, recent: [], consecutive_failures: 0, consecutive_origin_failures: 0,
+  };
+  const prevStatus = (await env.KIWI.get(KEY_STATUS, 'json')) || {};
+  const state = {
+    etag: prevStatus.etag || null,
+    consecutive_not_modified: health.consecutive_not_modified || 0,
+  };
+
+  const poll = await pollOrigin(env, state);
+  let entry;
+
+  if (poll.result === 'failed') {
+    entry = { at, result: 'failed', reason: poll.reason, detail: poll.detail, fault: poll.fault, attempts: poll.attempts };
+  } else if (poll.result === 'not-modified') {
+    entry = { at, result: 'not-modified', attempts: poll.attempts, receivers: prevStatus.receiver_count };
+    health.consecutive_not_modified = (health.consecutive_not_modified || 0) + 1;
+  } else {
+    const { receivers, skipped } = parseDirectory(poll.html);
+
+    if (receivers.length === 0) {
+      entry = { at, result: 'failed', reason: 'no-entries', fault: 'origin', attempts: poll.attempts };
+    } else {
+      // The origin occasionally serves a truncated page. Publishing it would
+      // erase most of the directory for every client, so a sharp drop parks the
+      // mirror on the old list until a person agrees the drop is real.
+      const floor = Number(env.KIWI_MIN_ENTRIES_FRACTION || '0.5');
+      const previous = prevStatus.receiver_count || 0;
+      if (previous && receivers.length < previous * floor) {
+        entry = {
+          at, result: 'failed', reason: 'too-few-entries', fault: 'needs-review',
+          detail: `${receivers.length} vs ${previous}`, attempts: poll.attempts,
+        };
+      } else {
+        const payload = JSON.stringify({
+          schema: 1,
+          source: env.KIWI_SOURCE_URL,
+          fetched_at: at,
+          receiver_count: receivers.length,
+          receivers,
+        });
+
+        const status = {
+          schema: 1,
+          source: env.KIWI_SOURCE_URL,
+          fetched_at: at,
+          published_at: at,
+          receiver_count: receivers.length,
+          skipped_entries: skipped,
+          bytes: payload.length,
+          etag: poll.etag,
+          not_modified: false,
+          source_status: 'ok',
+          stale_after_minutes: Number(env.KIWI_STALE_AFTER_MINUTES || '360'),
+          conditional_get: poll.conditional_get,
+          forced_full: poll.forced_full || false,
+          mirror: 'cloudflare-worker/kiwi-directory-mirror',
+        };
+
+        await env.KIWI.put(KEY_PAYLOAD, payload);
+        await env.KIWI.put(KEY_STATUS, JSON.stringify(status));
+
+        entry = { at, result: 'published', attempts: poll.attempts, receivers: receivers.length };
+        health.consecutive_not_modified = 0;
+        health.last_publish_at = at;
+      }
+    }
+  }
+
+  const failed = entry.result === 'failed';
+  health.schema = 1;
+  health.last_run_at = at;
+  health.last_run_result = entry.result;
+  health.last_run_reason = entry.reason ?? null;
+  health.last_run_detail = entry.detail ?? null;
+  health.last_run_attempts = entry.attempts;
+  health.fault = entry.fault ?? null;
+  health.consecutive_failures = failed ? (health.consecutive_failures || 0) + 1 : 0;
+  health.consecutive_origin_failures =
+    failed && entry.fault !== 'mirror' ? (health.consecutive_origin_failures || 0) + 1 : 0;
+  if (!failed) health.last_success_at = at;
+  health.receiver_count = (await env.KIWI.get(KEY_STATUS, 'json'))?.receiver_count ?? health.receiver_count ?? null;
+  health.recent = [entry, ...(health.recent || [])].slice(0, HISTORY);
+
+  await env.KIWI.put(KEY_HEALTH, JSON.stringify(health));
+  return health;
+}
+
+/* ── serving ─────────────────────────────────────────────────────────────── */
+
+async function serve(request, env) {
+  const url = new URL(request.url);
+  const host = url.hostname;
+  const path = url.pathname.replace(/\/+$/, '') || '/';
+
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return new Response('Method not allowed\n', { status: 405, headers: { allow: 'GET, HEAD' } });
+  }
+
+  // The CDN host serves exactly one thing.
+  if (host === env.KIWI_CDN_HOST) {
+    if (path !== '/kiwi.json') return notFound();
+    const payload = await env.KIWI.get(KEY_PAYLOAD);
+    if (!payload) {
+      return json({ error: 'no list published yet' }, { 'cache-control': 'no-store' });
+    }
+    const status = (await env.KIWI.get(KEY_STATUS, 'json')) || {};
+    return new Response(payload, {
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        'access-control-allow-origin': '*',
+        // Half the poll interval: a client refetching on expiry never sits more
+        // than one cycle behind, and the origin sees no extra load either way.
+        'cache-control': 'public, max-age=1800',
+        'x-receiver-count': String(status.receiver_count ?? ''),
+        'x-fetched-at': status.fetched_at ?? '',
+      },
+    });
+  }
+
+  if (host === env.KIWI_STATUS_HOST) {
+    if (path === '/' || path === '/index.html' || path === '/status.html') {
+      return new Response(STATUS_PAGE, {
+        headers: { 'content-type': 'text/html; charset=utf-8', 'cache-control': 'no-cache' },
+      });
+    }
+    if (path === '/health.json') {
+      return json((await env.KIWI.get(KEY_HEALTH, 'json')) || { error: 'no health record yet' },
+        { 'cache-control': 'no-store' });
+    }
+    if (path === '/status.json') {
+      return json((await env.KIWI.get(KEY_STATUS, 'json')) || { error: 'nothing published yet' },
+        { 'cache-control': 'no-store' });
+    }
+    return notFound();
+  }
+
+  return notFound();
+}
+
+export default {
+  fetch: (request, env) => serve(request, env),
+  scheduled: (event, env, ctx) => ctx.waitUntil(runPoll(env, new Date(event.scheduledTime))),
+};

--- a/tools/kiwi-mirror-worker/src/parse.js
+++ b/tools/kiwi-mirror-worker/src/parse.js
@@ -1,0 +1,138 @@
+/**
+ * Parse the KiwiSDR public receiver directory (HTML) into structured JSON.
+ *
+ * The directory is a page of `<div class='cl-entry seq_N snr_all_N snr_hf_N'>`
+ * blocks. Each carries a run of `<!-- key=value -->` comments holding the real
+ * data, plus two anchors to the receiver (an avatar link and a text link) and a
+ * `cl-name` div. We take the data from the comments rather than the rendered
+ * markup: `cl-name` is upper-cased for display, while the `name` comment keeps
+ * the operator's own capitalization.
+ *
+ * Everything the source sends is preserved. Fields are typed only where the
+ * meaning is unambiguous; anything we are not certain about stays a string, so
+ * a format change upstream degrades to "odd-looking string" rather than
+ * "silently wrong number".
+ */
+
+/** Values that are plain integers. */
+const INT_FIELDS = new Set([
+  'users', 'users_max', 'asl', 'uptime', 'fixes', 'fixes_min', 'fixes_hour',
+  'adc_ov', 'avatar_ctime', 'ext_api', 'preempt', 'gps_good', 'sm_cal',
+  'wf_cal', 'clk_ext_freq', 'tdoa_ch',
+]);
+
+/** Values that are decimals. */
+const FLOAT_FIELDS = new Set(['freq_offset']);
+
+/** `yes`/`no` values. */
+const BOOL_FIELDS = new Set(['offline']);
+
+/** `0`/`1` values. */
+const BIT_FIELDS = new Set(['ant_connected']);
+
+/** Comma-separated integer lists whose length we do not want to assume. */
+const INT_LIST_FIELDS = new Set(['snr', 'clk_ext_gps', 'gps_date']);
+
+const ENTITIES = {
+  '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"',
+  '&#39;': "'", '&apos;': "'", '&nbsp;': ' ',
+};
+
+function decodeEntities(s) {
+  return s
+    .replace(/&#(\d+);/g, (_, d) => String.fromCodePoint(Number(d)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCodePoint(parseInt(h, 16)))
+    .replace(/&(amp|lt|gt|quot|#39|apos|nbsp);/g, (m) => ENTITIES[m] ?? m);
+}
+
+function toInt(v) {
+  // Reject anything that is not cleanly an integer so a changed format shows up
+  // as the original string instead of a NaN or a silently truncated number.
+  return /^-?\d+$/.test(v) ? Number(v) : v;
+}
+
+function toFloat(v) {
+  return /^-?\d+(\.\d+)?$/.test(v) ? Number(v) : v;
+}
+
+/** `(-34.964437, 138.762380)` -> `[-34.964437, 138.76238]` */
+function parseGps(v) {
+  const m = v.match(/^\(\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*\)$/);
+  return m ? [Number(m[1]), Number(m[2])] : v;
+}
+
+/** `0-30000000` -> `[0, 30000000]`; multiple ranges are kept as a list. */
+function parseBands(v) {
+  const parts = v.split(',').map((p) => p.trim()).filter(Boolean);
+  const ranges = parts.map((p) => {
+    const m = p.match(/^(\d+)-(\d+)$/);
+    return m ? [Number(m[1]), Number(m[2])] : null;
+  });
+  if (ranges.some((r) => r === null)) return v;
+  return ranges.length === 1 ? ranges[0] : ranges;
+}
+
+function parseIntList(v) {
+  if (v === '') return [];
+  const parts = v.split(',').map((p) => p.trim());
+  return parts.every((p) => /^-?\d+$/.test(p)) ? parts.map(Number) : v;
+}
+
+function coerce(key, raw) {
+  const v = decodeEntities(raw).trim();
+  if (v === '') return '';
+  if (key === 'gps') return parseGps(v);
+  if (key === 'bands') return parseBands(v);
+  if (INT_LIST_FIELDS.has(key)) return parseIntList(v);
+  if (INT_FIELDS.has(key)) return toInt(v);
+  if (FLOAT_FIELDS.has(key)) return toFloat(v);
+  if (BOOL_FIELDS.has(key)) return v === 'yes' ? true : v === 'no' ? false : v;
+  if (BIT_FIELDS.has(key)) return v === '1' ? true : v === '0' ? false : v;
+  return v;
+}
+
+const ENTRY_RE = /<div class='cl-entry([^']*)'>([\s\S]*?)(?=<div class='cl-entry|$)/g;
+const COMMENT_RE = /<!--\s*([a-z_][a-z0-9_]*)=([\s\S]*?)-->/g;
+const HREF_RE = /<a\s+href='([^']+)'\s+target='_blank'>/g;
+
+/**
+ * @param {string} html Raw directory page.
+ * @returns {{receivers: object[], skipped: number}}
+ */
+export function parseDirectory(html) {
+  const receivers = [];
+  let skipped = 0;
+
+  for (const [, classes, body] of html.matchAll(ENTRY_RE)) {
+    const rx = {};
+
+    for (const [, key, value] of body.matchAll(COMMENT_RE)) {
+      rx[key] = coerce(key, value);
+    }
+
+    // An entry with no id is not something we can key on downstream, and has
+    // never appeared in practice. Count it rather than emitting a junk record.
+    if (!rx.id) { skipped++; continue; }
+
+    // Both anchors point at the receiver; the avatar link comes first. Taking
+    // the first and checking the rest agree means a future layout change that
+    // adds an unrelated link cannot silently swap the URL.
+    const hrefs = [...body.matchAll(HREF_RE)].map((m) => decodeEntities(m[1]));
+    if (hrefs.length) rx.url = hrefs[0];
+
+    const seq = classes.match(/seq_(\d+)/);
+    if (seq) rx.seq = Number(seq[1]);
+    const snrAll = classes.match(/snr_all_(-?\d+)/);
+    if (snrAll) rx.snr_all = Number(snrAll[1]);
+    const snrHf = classes.match(/snr_hf_(-?\d+)/);
+    if (snrHf) rx.snr_hf = Number(snrHf[1]);
+
+    // The directory paints these rows red. It is the operator's own signal that
+    // something is wrong with the entry, so it is worth carrying through.
+    rx.flagged = /\bcl-err-entry\b/.test(classes);
+
+    receivers.push(rx);
+  }
+
+  return { receivers, skipped };
+}

--- a/tools/kiwi-mirror-worker/src/parse.js
+++ b/tools/kiwi-mirror-worker/src/parse.js
@@ -115,9 +115,12 @@ export function parseDirectory(html) {
     if (!rx.id) { skipped++; continue; }
 
     // Both anchors point at the receiver; the avatar link comes first. Taking
-    // the first and checking the rest agree means a future layout change that
-    // adds an unrelated link cannot silently swap the URL.
+    // the first only once the rest agree means a future layout change that adds
+    // an unrelated link cannot silently swap the URL — it drops the entry
+    // instead, visibly, in the skipped count. Every entry in the directory
+    // carries at least two anchors and they have always agreed.
     const hrefs = [...body.matchAll(HREF_RE)].map((m) => decodeEntities(m[1]));
+    if (hrefs.length && !hrefs.every((h) => h === hrefs[0])) { skipped++; continue; }
     if (hrefs.length) rx.url = hrefs[0];
 
     const seq = classes.match(/seq_(\d+)/);

--- a/tools/kiwi-mirror-worker/src/status-page.js
+++ b/tools/kiwi-mirror-worker/src/status-page.js
@@ -310,7 +310,15 @@ const FAULT = {
 
 function verdictFor(h, s) {
   const runAge = mins(h && h.last_run_at);
-  const contentAge = mins(s && s.fetched_at);
+  // last_success_at, NOT status.fetched_at. fetched_at is written only in the
+  // publish branch of runPoll, so it is the age of the last PUBLISH; a 304
+  // never rewrites it. Reading it here made four healthy 304s (240 min) turn
+  // the page amber with "the list is old" while nothing was wrong, and made
+  // contentAge identical to publishAge by construction — so the frozen-mirror
+  // branch below, gated at 1440, could never be reached. last_success_at is
+  // set on every non-failed poll, 304s included, which is exactly "the origin
+  // confirmed our copy is current".
+  const contentAge = mins(h && h.last_success_at);
 
   if (!h) return { tone: 'var(--unknown)', text: 'Cannot read the health record', fault: null };
 
@@ -377,7 +385,9 @@ async function render() {
   $('count').textContent = count == null ? '—' : count.toLocaleString('en-US');
   $('countlab').textContent = count === 1 ? 'receiver in the published list' : 'receivers in the published list';
 
-  const contentAge = mins(s && s.fetched_at);
+  // Same reasoning as verdictFor: this line says "Origin confirmed the list",
+  // so it has to read the confirmation, not the publish.
+  const contentAge = mins(h && h.last_success_at);
   const runAge = mins(h && h.last_run_at);
   const publishAgeMin = mins(s && s.published_at);
   $('sub').textContent = s

--- a/tools/kiwi-mirror-worker/src/status-page.js
+++ b/tools/kiwi-mirror-worker/src/status-page.js
@@ -1,0 +1,461 @@
+/**
+ * The operator status page, served as one self-contained document.
+ *
+ * Ported from the aethersdr.ozy.us page. Four things changed in the move:
+ *
+ *  1. The stale-poll copy is generated from RUN_STALE_MIN instead of being
+ *     written out by hand. The old page said "over an hour" while the threshold
+ *     was 150 minutes, which is exactly the wrong thing to be wrong about on a
+ *     page people read while triaging.
+ *  2. The footer said the mirror polls every 30 minutes; it went hourly.
+ *  3. SLOTS now matches the worker's HISTORY, so the strip stops showing four
+ *     permanent "no poll recorded" ghosts it could never fill.
+ *  4. The thresholds are stated in polls as well as minutes, since that is how
+ *     they were actually reasoned about.
+ */
+
+export const STATUS_PAGE = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>KiwiSDR mirror status</title>
+<meta name="robots" content="noindex">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect width='16' height='16' rx='3' fill='%23161d26'/%3E%3Crect x='3' y='4' width='2' height='8' fill='%233f7d5a'/%3E%3Crect x='7' y='6' width='2' height='6' fill='%23a8761f'/%3E%3Crect x='11' y='3' width='2' height='9' fill='%233f7d5a'/%3E%3C/svg%3E">
+<style>
+/* Static page. It reads health.json and status.json in the browser, so it is
+   published once and never regenerated - the Worker spends no CPU and takes no
+   extra write on it, and it is always showing live data.
+
+   System fonts on purpose. This page is read when something is broken, quite
+   possibly on a phone on a bad connection, so it must not depend on a font CDN
+   being up. Everything below is self-contained: two fetches, no other requests. */
+:root {
+  --bezel:   #161d26;
+  --bezel-2: #202a37;
+  --face:    #f2efe6;
+  --face-2:  #e6e1d3;
+  --ink:     #1d242c;
+  --ink-mid: #5c6672;
+  --rule:    #cfc8b6;
+  --good:    #3f7d5a;
+  --amber:   #a8761f;
+  --bad:     #a33f34;
+  --unknown: #7c8794;
+  --mono: ui-monospace, "SF Mono", "Cascadia Mono", "Roboto Mono", Menlo, Consolas, monospace;
+  --sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --face: #1a212a; --face-2: #212b36; --ink: #e8e4d8; --ink-mid: #98a3b0;
+    --rule: #303c4a; --good: #6fbb8e; --amber: #d9a441; --bad: #e0776a; --unknown: #7c8794;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; background: var(--face); color: var(--ink);
+  font-family: var(--sans); line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+.wrap { max-width: 60rem; margin: 0 auto; padding: 0 1.25rem 4rem; }
+
+.bezel { background: var(--bezel); color: #d8dee6; border-bottom: 3px solid var(--bezel-2); }
+.bezel .wrap {
+  display: flex; flex-wrap: wrap; gap: .5rem 1.5rem;
+  align-items: baseline; justify-content: space-between;
+  padding-top: 1.15rem; padding-bottom: 1.15rem;
+}
+.bezel h1 { font-size: 1.05rem; font-weight: 600; margin: 0; letter-spacing: .01em; }
+.bezel .host { font-family: var(--mono); font-size: .82rem; color: #8f9aa8; }
+
+.readout { padding-top: 2.75rem; }
+.verdict {
+  display: inline-flex; align-items: center; gap: .6rem;
+  font-size: .95rem; font-weight: 600; margin-bottom: 1.5rem;
+}
+.lamp {
+  width: .7rem; height: .7rem; border-radius: 50%;
+  background: var(--tone, var(--unknown));
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--tone, var(--unknown)) 18%, transparent);
+  flex: none;
+}
+.count { display: flex; align-items: baseline; gap: 1rem; flex-wrap: wrap; margin: 0 0 .35rem; }
+.count b {
+  font-family: var(--mono); font-size: clamp(3rem, 12vw, 5rem);
+  font-weight: 500; line-height: .95; letter-spacing: -.03em;
+  font-variant-numeric: tabular-nums;
+}
+.count span { font-size: 1rem; color: var(--ink-mid); }
+.sub { color: var(--ink-mid); font-size: .92rem; margin: 0 0 1.75rem; }
+
+.bar { height: 6px; background: var(--face-2); border-radius: 3px; overflow: hidden; max-width: 34rem; }
+.bar i { display: block; height: 100%; width: 0; background: var(--tone, var(--unknown)); transition: width .6s ease; }
+@media (prefers-reduced-motion: reduce) { .bar i { transition: none; } }
+.barlab {
+  display: flex; justify-content: space-between; max-width: 34rem;
+  font-size: .8rem; color: var(--ink-mid); margin-top: .45rem; font-family: var(--mono);
+}
+
+.fault {
+  margin: 2.5rem 0 0; padding: 1.1rem 1.25rem;
+  border-left: 4px solid var(--tone, var(--unknown));
+  background: var(--face-2); border-radius: 0 4px 4px 0;
+}
+.fault h2 { margin: 0 0 .3rem; font-size: 1rem; font-weight: 600; }
+.fault p { margin: 0; color: var(--ink-mid); font-size: .92rem; }
+
+section { margin-top: 3rem; }
+section > h2 { font-size: .95rem; font-weight: 600; margin: 0 0 .2rem; }
+section > p.hint { margin: 0 0 1rem; color: var(--ink-mid); font-size: .87rem; }
+
+.strip { display: flex; gap: 3px; align-items: flex-end; height: 44px; }
+.strip i {
+  flex: 1 1 0; min-width: 4px; max-width: 22px; border-radius: 2px;
+  background: var(--unknown); height: 60%;
+}
+.strip i[data-r="none"] { background: var(--rule); height: 18%; }
+.strip i[data-r="published"]    { background: var(--good); height: 100%; }
+.strip i[data-r="not-modified"] { background: var(--good); height: 62%; opacity: .6; }
+.strip i[data-r="failed"]       { background: var(--bad);  height: 34%; }
+.strip i[data-f="origin"]          { background: var(--amber); }
+.strip i[data-f="auth"]            { background: var(--amber); }
+.strip i[data-f="upstream-change"] { background: var(--amber); }
+.striplab {
+  display: flex; justify-content: space-between;
+  font-size: .78rem; color: var(--ink-mid); margin-top: .4rem; font-family: var(--mono);
+}
+
+table { border-collapse: collapse; width: 100%; font-size: .88rem; }
+th, td { text-align: left; padding: .45rem .75rem .45rem 0; border-bottom: 1px solid var(--rule); }
+th { font-weight: 600; color: var(--ink-mid); font-size: .82rem; }
+td.n { font-family: var(--mono); font-variant-numeric: tabular-nums; white-space: nowrap; }
+td .tag { font-weight: 600; }
+.tag[data-f="origin"], .tag[data-f="auth"], .tag[data-f="upstream-change"] { color: var(--amber); }
+.tag[data-f="mirror"], .tag[data-f="needs-review"] { color: var(--bad); }
+.ok { color: var(--good); }
+
+dl.read { margin: 0; display: grid; grid-template-columns: minmax(9rem, auto) 1fr; gap: .4rem 1.25rem; font-size: .88rem; }
+dl.read dt { color: var(--ink-mid); }
+dl.read dd { margin: 0; font-family: var(--mono); font-variant-numeric: tabular-nums; }
+
+.guide { font-size: .88rem; }
+.guide li { margin-bottom: .5rem; }
+.guide b { font-weight: 600; }
+
+footer {
+  margin-top: 3.5rem; padding-top: 1.25rem; border-top: 1px solid var(--rule);
+  font-size: .82rem; color: var(--ink-mid);
+}
+footer a { color: inherit; }
+noscript { display: block; margin-top: 1rem; padding: .9rem 1.1rem; background: var(--face-2); border-left: 4px solid var(--amber); font-size: .9rem; }
+a:focus-visible, [tabindex]:focus-visible { outline: 2px solid var(--tone, var(--good)); outline-offset: 2px; }
+@media (max-width: 34rem) {
+  dl.read { grid-template-columns: 1fr; gap: .1rem; }
+  dl.read dd { margin-bottom: .5rem; }
+}
+</style>
+</head>
+<body>
+
+<div class="bezel">
+  <div class="wrap">
+    <h1>KiwiSDR receiver directory &mdash; mirror status</h1>
+    <span class="host">cdn.aethersdr.com/kiwi.json</span>
+  </div>
+</div>
+
+<div class="wrap">
+
+  <div class="readout">
+    <div class="verdict"><span class="lamp"></span><span id="verdict">Reading status&hellip;</span></div>
+    <p class="count"><b id="count">&mdash;</b> <span id="countlab">receivers in the published list</span></p>
+    <p class="sub" id="sub"></p>
+    <div class="bar"><i id="bar"></i></div>
+    <div class="barlab"><span id="barleft"></span><span id="barright"></span></div>
+    <noscript>This page reads <a href="/health.json">health.json</a> and
+      <a href="/status.json">status.json</a> in the browser, so it needs JavaScript to
+      show anything. Both files are plain JSON and readable directly.</noscript>
+  </div>
+
+  <div class="fault" id="fault" hidden>
+    <h2 id="faulth"></h2>
+    <p id="faultp"></p>
+  </div>
+
+  <section>
+    <h2>Recent polls</h2>
+    <p class="hint">Hourly, oldest on the left. Tall green published a new list, short green means the
+      origin confirmed nothing had changed, amber is a failure on kiwisdr.com's side, red is a failure on ours.</p>
+    <div class="strip" id="strip" aria-hidden="true"></div>
+    <div class="striplab"><span>oldest</span><span>newest</span></div>
+    <table style="margin-top:1.5rem">
+      <thead><tr><th>Time (UTC)</th><th>Result</th><th>Detail</th><th>Tries</th></tr></thead>
+      <tbody id="rows"></tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Readings</h2>
+    <dl class="read" id="readings"></dl>
+  </section>
+
+  <section>
+    <h2>How to read this</h2>
+    <ul class="guide" id="guide"></ul>
+  </section>
+
+  <footer>
+    <p>The mirror pulls <code>kiwisdr.com/public/</code> every hour, parses it and republishes it as
+      <a href="https://cdn.aethersdr.com/kiwi.json">cdn.aethersdr.com/kiwi.json</a> so AetherSDR
+      clients read our copy instead of the origin. Raw data:
+      <a href="/health.json">health.json</a> &middot;
+      <a href="/status.json">status.json</a>.
+      This page refreshes itself every 60 seconds.</p>
+  </footer>
+</div>
+
+<script>
+const HEALTH = '/health.json';
+const STATUS = '/status.json';
+
+// The mirror polls hourly. Both thresholds below are really "how many polls may
+// be missed", and are written that way so a cadence change cannot leave them
+// quietly meaning something else. Must match ops/kuma-staleness-monitor.py, or
+// the panel and the alarm disagree about the same mirror.
+const POLL_MINUTES = 60;
+const RUN_STALE_POLLS = 2.5;
+const CONTENT_STALE_POLLS = 4;
+const RUN_STALE_MIN = POLL_MINUTES * RUN_STALE_POLLS;      // 150
+const CONTENT_STALE_MIN = POLL_MINUTES * CONTENT_STALE_POLLS; // 240
+const NO_PUBLISH_MIN = 1440; // 24h - a frozen mirror, not a quiet one
+const SLOTS = 20;            // must equal HISTORY in the Worker
+
+const $ = (id) => document.getElementById(id);
+
+/**
+ * Escape before anything reaches innerHTML.
+ *
+ * Two of the values rendered on this page come straight off the wire from
+ * kiwisdr.com: the ETag header (copied verbatim into status.json on every
+ * successful publish) and the Location header of a redirect (copied into
+ * health.json's detail). The fetch leg is plain http with no TLS - that is
+ * accepted for the shared secret, but the same acceptance means an on-path
+ * attacker controls both strings. Unescaped, an ETag containing markup runs
+ * arbitrary script on this origin, in an operator's browser, at exactly the
+ * moment they are triaging an incident.
+ */
+function esc(v) {
+  return String(v ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+const mins = (iso) => (iso ? (Date.now() - Date.parse(iso)) / 60000 : null);
+
+function ago(m) {
+  if (m === null || !isFinite(m)) return 'never';
+  if (m < 1) return 'just now';
+  if (m < 90) return Math.round(m) + ' min ago';
+  const h = m / 60;
+  if (h < 36) return h.toFixed(1) + ' hours ago';
+  return Math.round(h / 24) + ' days ago';
+}
+
+/** Spell a threshold the way a person would say it, from the constant itself. */
+function spell(m) {
+  if (m < 90) return m + ' minutes';
+  const h = m / 60;
+  return (Number.isInteger(h) ? h : h.toFixed(1)) + ' hours';
+}
+
+const FAULT = {
+  origin: {
+    tone: 'var(--amber)',
+    title: 'kiwisdr.com is not answering us',
+    body: 'The origin refused the connection or replied with something we would not publish. ' +
+          'Nothing to fix here - the mirror keeps serving the last good list. It clears itself when the origin comes back.',
+  },
+  auth: {
+    tone: 'var(--amber)',
+    title: 'The shared secret is missing or no longer matches',
+    body: 'Either no secret is configured on the Worker, or we are getting the click-through gate ' +
+          'page instead of the directory. Set it with: wrangler secret put KIWI_SECRET. Needs a person either way.',
+  },
+  'upstream-change': {
+    tone: 'var(--amber)',
+    title: 'The source moved',
+    body: 'kiwisdr.com answered with a redirect. We deliberately do not follow it, because silently ' +
+          'mirroring something else would change the arrangement we made with the operator.',
+  },
+  'needs-review': {
+    tone: 'var(--bad)',
+    title: 'The list shrank sharply - someone has to decide',
+    body: 'kiwisdr.com answered normally, with far fewer receivers than the list we ' +
+          'last published. Nothing is broken, and this one does NOT clear on its own: ' +
+          'the mirror keeps serving the old list until a person confirms the drop is ' +
+          'real. If it is, raise KIWI_MIN_ENTRIES_FRACTION or clear the stored count.',
+  },
+  mirror: {
+    tone: 'var(--bad)',
+    title: 'This one is ours',
+    body: 'The failure is in our Worker, its configuration or its storage - not on kiwisdr.com. ' +
+          'If the reason is auth-misconfigured, the deploy is half-set-up: the auth transport is a ' +
+          'Worker secret like the value, so it needs wrangler secret put KIWI_AUTH_MODE and ' +
+          'KIWI_AUTH_NAME as well as KIWI_SECRET. Otherwise run wrangler tail kiwi-directory-mirror.',
+  },
+};
+
+function verdictFor(h, s) {
+  const runAge = mins(h && h.last_run_at);
+  const contentAge = mins(s && s.fetched_at);
+
+  if (!h) return { tone: 'var(--unknown)', text: 'Cannot read the health record', fault: null };
+
+  if (runAge === null || runAge > RUN_STALE_MIN)
+    return {
+      tone: 'var(--bad)', text: 'Nothing is running',
+      fault: { tone: 'var(--bad)', title: 'No poll has happened in over ' + spell(RUN_STALE_MIN),
+               body: 'The scheduler stopped. Either the Cloudflare cron is not firing or the Worker is gone. ' +
+                     'The published list is whatever it was when the last poll succeeded.' },
+    };
+
+  if (h.last_run_result === 'failed')
+    return { tone: (FAULT[h.fault] || FAULT.mirror).tone, text: 'Last poll failed', fault: FAULT[h.fault] || FAULT.mirror };
+
+  if (contentAge !== null && contentAge > CONTENT_STALE_MIN)
+    return { tone: 'var(--amber)', text: 'Polling, but the list is old', fault: null };
+
+  // The panel has to know the same rule as the alarm, or the two disagree about
+  // a frozen mirror. Every other signal here stays green through a permanent 304
+  // stream, because a 304 IS a success.
+  const publishAge = mins(h.last_publish_at);
+  if (publishAge !== null && publishAge > NO_PUBLISH_MIN)
+    return {
+      tone: 'var(--amber)', text: 'Polling fine, but the list has not changed in a day',
+      fault: { tone: 'var(--amber)', title: 'The list is frozen',
+               body: 'Every poll is succeeding, but the published list has not actually ' +
+                     'changed in over 24 hours. The usual cause is the origin answering ' +
+                     '304 to everything. The mirror forces a full fetch after 24 of those, ' +
+                     'so this should clear itself - if it does not, look at the ETag.' },
+    };
+
+  return { tone: 'var(--good)', text: 'Working', fault: null };
+}
+
+$('guide').innerHTML = [
+  ['The list is old but polls are still happening, amber.',
+   'kiwisdr.com is refusing us or answering with something we would not publish. Nothing to fix on ' +
+   'our side. The mirror keeps serving the last good list rather than an empty one, which is the intended behaviour.'],
+  ['The list is old but polls are still happening, red.',
+   'Our Worker is failing. That one is ours to fix. Check <code>wrangler tail kiwi-directory-mirror</code>.'],
+  ['No polls at all for over ' + spell(RUN_STALE_MIN) + '.',
+   'Nothing ran. Either the Cloudflare cron stopped firing (it is best-effort on the free plan and has ' +
+   'skipped a slot before) or the Worker is gone. At hourly polling that threshold is ' +
+   RUN_STALE_POLLS + ' missed polls.'],
+  ['Auth.',
+   'The shared secret is unset or stopped matching - either it was rotated on kiwisdr.com or we lost ours. ' +
+   'This one needs a person either way, so it is deliberately not blamed on a side.'],
+].map(([b, t]) => '<li><b>' + b + '</b> ' + t + '</li>').join('');
+
+async function grab(url) {
+  try {
+    const r = await fetch(url + '?t=' + Date.now(), { cache: 'no-store' });
+    return r.ok ? await r.json() : null;
+  } catch { return null; }
+}
+
+async function render() {
+  const [h, s] = await Promise.all([grab(HEALTH), grab(STATUS)]);
+  const v = verdictFor(h, s);
+  document.documentElement.style.setProperty('--tone', v.tone);
+  $('verdict').textContent = v.text;
+
+  const count = (s && s.receiver_count) ?? (h && h.receiver_count);
+  $('count').textContent = count == null ? '—' : count.toLocaleString('en-US');
+  $('countlab').textContent = count === 1 ? 'receiver in the published list' : 'receivers in the published list';
+
+  const contentAge = mins(s && s.fetched_at);
+  const runAge = mins(h && h.last_run_at);
+  const publishAgeMin = mins(s && s.published_at);
+  $('sub').textContent = s
+    ? 'Checked ' + ago(runAge) + '. Origin confirmed the list ' + ago(contentAge) +
+      '. The list itself last changed ' + ago(publishAgeMin) + '.'
+    : 'The published list could not be read.';
+
+  // The bar drains toward the point at which the alarm fires, so a glance says
+  // how much rope is left rather than just how old the list is.
+  const used = contentAge === null ? 1 : Math.min(contentAge / CONTENT_STALE_MIN, 1);
+  $('bar').style.width = ((1 - used) * 100).toFixed(1) + '%';
+  $('barleft').textContent = contentAge === null ? '' : Math.round(contentAge) + ' min old';
+  $('barright').textContent = 'alarm at ' + CONTENT_STALE_MIN + ' min';
+
+  if (v.fault) {
+    $('faulth').textContent = v.fault.title;
+    $('faultp').textContent = v.fault.body;
+    $('fault').hidden = false;
+  } else {
+    $('fault').hidden = true;
+  }
+
+  const recent = (h && h.recent) || [];
+  const oldestFirst = recent.slice().reverse();
+  // Pad to the full window so the strip is always the same width. SLOTS equals
+  // the Worker's HISTORY, so the ghosts only ever appear while a fresh mirror
+  // fills its first day - never permanently.
+  const ghosts = Math.max(0, SLOTS - oldestFirst.length);
+  $('strip').innerHTML =
+    '<i data-r="none" title="no poll recorded"></i>'.repeat(ghosts) +
+    oldestFirst.map((r) => {
+      const t = new Date(r.at).toISOString().slice(11, 16);
+      const label = r.result + (r.fault ? ' (' + r.fault + ')' : '') + ' at ' + t + ' UTC';
+      return '<i data-r="' + esc(r.result) + '"' + (r.fault ? ' data-f="' + esc(r.fault) + '"' : '') +
+             ' title="' + esc(label) + '"></i>';
+    }).join('');
+
+  $('rows').innerHTML = recent.map((r) => {
+    const t = r.at ? r.at.slice(11, 19) + ' ' + r.at.slice(0, 10) : '';
+    const res = r.result === 'failed'
+      ? '<span class="tag" data-f="' + esc(r.fault || 'mirror') + '">failed &mdash; ' + esc(r.fault || 'unknown') + '</span>'
+      : '<span class="ok">' + esc(r.result) + '</span>';
+    // r.detail can carry a redirect Location straight off the wire.
+    const detail = r.result === 'failed'
+      ? esc([r.reason, r.detail].filter(Boolean).join(' '))
+      : (r.receivers ? esc(r.receivers.toLocaleString('en-US')) + ' receivers' : '');
+    return '<tr><td class="n">' + esc(t) + '</td><td>' + res + '</td><td>' + detail +
+           '</td><td class="n">' + esc(r.attempts ?? '') + '</td></tr>';
+  }).join('') || '<tr><td colspan="4">No runs recorded yet.</td></tr>';
+
+  const rows = [
+    ['Last poll', h && h.last_run_at],
+    ['Last success', h && h.last_success_at],
+    ['Last new list', (h && h.last_publish_at) || (s && s.published_at)],
+    ['Failures in a row', h && h.consecutive_failures],
+    ['kiwisdr.com failures in a row', h && h.consecutive_origin_failures],
+    ['Tries on the last poll', h && h.last_run_attempts],
+    ['List size', s && s.bytes ? (s.bytes / 1048576).toFixed(2) + ' MB' : null],
+    ['Entries skipped', s && s.skipped_entries],
+    ['ETag from origin', s ? (s.etag || 'none sent') : null],
+    // A long run of "off" while an ETag exists means conditional GET has quietly
+    // stopped working and we are pulling the whole file every poll again.
+    ['Conditional GET', s ? (s.conditional_get ? 'on' : 'off') : null],
+    // Deliberately larger than the alarm above: we want to know the list is
+    // going stale well before clients would start treating it as stale.
+    ['Client stale threshold', s && s.stale_after_minutes ? s.stale_after_minutes + ' min' : null],
+    ['Told to clients', s && s.source_status ? s.source_status : null],
+    ['Source', s && s.source],
+  ];
+  $('readings').innerHTML = rows
+    .filter(([, v2]) => v2 !== null && v2 !== undefined)
+    // v2 includes s.etag, which is whatever the origin put in the header.
+    .map(([k, v2]) => '<dt>' + esc(k) + '</dt><dd>' + esc(v2) + '</dd>')
+    .join('');
+}
+
+render();
+setInterval(render, 60000);
+</script>
+</body>
+</html>`;

--- a/tools/kiwi-mirror-worker/test/fixtures/directory.html
+++ b/tools/kiwi-mirror-worker/test/fixtures/directory.html
@@ -1,0 +1,1093 @@
+<!DOCTYPE HTML>
+<html lang='en-US' style='height: 100%'>
+<head>
+ <meta charset='UTF-8'>
+ <link rel='stylesheet' type='text/css' href='/kiwi/public.min.css' />
+ <script src='/kiwi/public.min.js'></script>
+ <link href='//fonts.googleapis.com/css?family=Oswald' rel='stylesheet'>
+<style>
+* { box-sizing: border-box }
+*::before, *::after { -webkit-box-sizing: border-box; -moz-box-sizing: border-box; box-sizing: border-box }
+body { font-size: 16px; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: #808080 }
+.cl-err-entry { background: rgba(255, 0, 0, 0.3); }
+.cl-avatar { box-shadow: 2px 2px 3px #AAA; margin-right: 10px; float: left; left: 0px; width: 64px; height: 64px; }
+.cl-info { line-height: 25px; }
+a { color: #428bca }
+.cl-sdr_hw { color: #777 }
+.cl-debian { color:transparent; text-shadow:0 0 0 #D70A53 }
+.cl-sdr_sw { color: #777 }
+.cl-users { color: #777 }
+</style>
+</head>
+<body style='display: flex; height: 100%; flex-direction: column'>
+<div class='id-kiwi-container' data-type='website'></div>
+<div class='id-announce'></div>
+<div class='id-topbar'>
+ <div class='id-update-container w3-inline-flex'>
+  <div class='id-map-button'></div>
+  <div class='id-search-container'></div>
+  <div class='id-and-or-container'></div>
+  <div class='id-matches-container'></div>
+  <div class='id-band-container'></div>
+  <div class='id-snr-sort-container'></div>
+  <div class='id-snr-val-container'></div>
+  <div class='id-url-params-container'></div>
+ </div>
+ <div class='id-url-usage-container w3-inline-flex'>
+  <div class='id-url-usage'></div>
+ </div>
+ <div class='id-text-container'>
+Saturday, 05-Sep-2026 13:58:09 GMT
+  <big class='id-rx-count'></big> receivers online &nbsp;  <big class='id-tdoa-count'></big> TDoA capable &nbsp;  <big class='id-user-count'></big> people listening &nbsp; || &nbsp;   <big class='id-proxied-count'></big> proxied &nbsp;  <big class='id-host-ddns'></big> ddns &nbsp;  <big class='id-host-domain'></big> domain &nbsp;  <big class='id-host-ipv4'></big> ipv4 <br>
+ </div>
+ <info class='id-warn-container'>Your non-proxied Kiwi must run software v1.840 or later to be listed here.</info></div>
+<div class='id-list w3-margin-T-10'>
+<div class='cl-entry seq_548 snr_all_38 snr_hf_39'>
+ <a href='http://jj8ntm.proxy.kiwisdr.com' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:29:48 GMT -->
+  <!-- id=3403de9a653c -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=14 MHz SDR | Kuriyama, Hokkaido JAPAN -->
+  <!-- sdr_hw=KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳🚫 Limits ⁣ 📻 DRM ⁣⁣ 🌀D11.9 -->
+  <!-- bands=10000000-15000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- mode=rx8.wf3 -->
+  <!-- users=6 -->
+  <!-- users_max=6 -->
+  <!-- ext_api=0 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1784756773 -->
+  <!-- gps=(43.057154, 141.776868) -->
+  <!-- grid=QN03vb -->
+  <!-- gps_good=6 -->
+  <!-- fixes=29992 -->
+  <!-- fixes_min=29 -->
+  <!-- fixes_hour=1721 -->
+  <!-- tdoa_id=QN03vb -->
+  <!-- tdoa_ch=2 -->
+  <!-- asl=5 -->
+  <!-- loc=Kuriyama, Hokkaido JAPAN -->
+  <!-- sw_version=KiwiSDR_v1.902 -->
+  <!-- antenna=14MHz Full-size dipole @10mh - UNDER CONSTRUCTION -->
+  <!-- snr=38,39 -->
+  <!-- ant_connected=1 -->
+  <!-- sm_cal=-16 -->
+  <!-- wf_cal=-11 -->
+  <!-- adc_ov=13 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=62305 -->
+  <!-- gps_date=1,1 -->
+  <!-- date=Sat Sep 5 13:29:49 2026 -->
+  <!-- ip_blacklist=fb16b946 -->
+  <!-- dx_file=594,8dc3b491,35938 -->
+  <!-- debian=D11.9 -->
+  <div class='cl-name'>14 MHZ SDR | KURIYAMA, HOKKAIDO JAPAN</div>
+  <a href='http://jj8ntm.proxy.kiwisdr.com' target='_blank'>http://jj8ntm.proxy.kiwisdr.com</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳🚫 Limits ⁣ 📻 DRM ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D11.9</span>
+  <span class='cl-users'> (6/6 users, SNR <span class='' title='38 dB, 0-30 MHz
+39 dB, 1.8-30 MHz'>38/39 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry seq_119 snr_all_34 snr_hf_35'>
+ <a href='http://porky.dahlbros.net:8074' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:51:53 GMT -->
+  <!-- id=40bd322ea01e -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=ve6ars kiwi #2 -->
+  <!-- sdr_hw=KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳🚫 Limits ⁣ 📻 DRM ⁣⁣ 🌀D11.11 -->
+  <!-- bands=0-30000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- mode=rx8.wf3 -->
+  <!-- users=0 -->
+  <!-- users_max=8 -->
+  <!-- ext_api=0 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1784718516 -->
+  <!-- gps=(50.08, -113.68) -->
+  <!-- grid=DO30db -->
+  <!-- gps_good=5 -->
+  <!-- fixes=473235 -->
+  <!-- fixes_min=30 -->
+  <!-- fixes_hour=1406 -->
+  <!-- tdoa_id=ve6ars2 -->
+  <!-- tdoa_ch=8 -->
+  <!-- asl=1030 -->
+  <!-- loc=Southern Alberta 2 -->
+  <!-- sw_version=KiwiSDR_v1.902 -->
+  <!-- antenna=160 inv ell BCB reject -->
+  <!-- snr=34,35 -->
+  <!-- ant_connected=1 -->
+  <!-- sm_cal=-13 -->
+  <!-- wf_cal=-13 -->
+  <!-- adc_ov=34268 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=1047034 -->
+  <!-- gps_date=1,1 -->
+  <!-- date=Sat Sep 5 13:51:53 2026 -->
+  <!-- ip_blacklist=fb16b946 -->
+  <!-- dx_file=873,36aa8056,52190 -->
+  <!-- debian=D11.11 -->
+  <div class='cl-name'>VE6ARS KIWI #2</div>
+  <a href='http://porky.dahlbros.net:8074' target='_blank'>http://porky.dahlbros.net:8074</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳🚫 Limits ⁣ 📻 DRM ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D11.11</span>
+  <span class='cl-users'> (0/8 users, SNR <span class='' title='34 dB, 0-30 MHz
+35 dB, 1.8-30 MHz'>34/35 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry seq_229 snr_all_34 snr_hf_35'>
+ <a href='http://porky.dahlbros.net:8073' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:45:53 GMT -->
+  <!-- id=38d2697cae44 -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=ve6ars kiwi #1 -->
+  <!-- sdr_hw=KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳🚫 Limits ⁣ 📻 DRM ⁣⁣ 🌀D11.11 -->
+  <!-- bands=0-30000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- mode=rx8.wf3 -->
+  <!-- users=1 -->
+  <!-- users_max=8 -->
+  <!-- ext_api=0 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1784710379 -->
+  <!-- gps=(50.08, -113.68) -->
+  <!-- grid=DO30db -->
+  <!-- gps_good=6 -->
+  <!-- fixes=598791 -->
+  <!-- fixes_min=30 -->
+  <!-- fixes_hour=1719 -->
+  <!-- tdoa_id=ve6ars1 -->
+  <!-- tdoa_ch=8 -->
+  <!-- asl=1030 -->
+  <!-- loc=Southern Alberta 1 -->
+  <!-- sw_version=KiwiSDR_v1.902 -->
+  <!-- antenna=160 inv ell BCB reject -->
+  <!-- snr=34,35 -->
+  <!-- ant_connected=1 -->
+  <!-- sm_cal=-13 -->
+  <!-- wf_cal=-13 -->
+  <!-- adc_ov=110707 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=1400358 -->
+  <!-- gps_date=1,1 -->
+  <!-- date=Sat Sep 5 13:45:53 2026 -->
+  <!-- ip_blacklist=fb16b946 -->
+  <!-- dx_file=873,36aa8056,52190 -->
+  <!-- debian=D11.11 -->
+  <div class='cl-name'>VE6ARS KIWI #1</div>
+  <a href='http://porky.dahlbros.net:8073' target='_blank'>http://porky.dahlbros.net:8073</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳🚫 Limits ⁣ 📻 DRM ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D11.11</span>
+  <span class='cl-users'> (1/8 users, SNR <span class='' title='34 dB, 0-30 MHz
+35 dB, 1.8-30 MHz'>34/35 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry seq_365 snr_all_44 snr_hf_33'>
+ <a href='http://n0bqv.proxy.kiwisdr.com' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:39:38 GMT -->
+  <!-- id=d4e95e792b23 -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=0-30 MHz SDR | [N0BQV] [Republic, Missouri. USA -->
+  <!-- sdr_hw=KiwiSDR 2 v1.841 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣⁣ 🌀D11.9 -->
+  <!-- bands=10000-30000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- mode=rx8_wf2 -->
+  <!-- users=6 -->
+  <!-- users_max=7 -->
+  <!-- ext_api=0 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1779987995 -->
+  <!-- gps=(37.164283, -93.571140) -->
+  <!-- grid=EM37fd -->
+  <!-- gps_good=4 -->
+  <!-- fixes=360539 -->
+  <!-- fixes_min=30 -->
+  <!-- fixes_hour=1779 -->
+  <!-- tdoa_id= -->
+  <!-- tdoa_ch=4 -->
+  <!-- asl=30 -->
+  <!-- loc=[N0BQV] [Republic, Missouri. USA -->
+  <!-- sw_version=KiwiSDR_v1.841 -->
+  <!-- antenna=40-75 meter Inverted Vee, feed point @ 75 Feet, 23 Meters....Please check in with call or name. -->
+  <!-- snr=44,33 -->
+  <!-- ant_connected=1 -->
+  <!-- sm_cal=-10 -->
+  <!-- wf_cal=-11 -->
+  <!-- adc_ov=1277 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=736263 -->
+  <!-- gps_date=1,1 -->
+  <!-- date=Sat Sep 5 13:39:38 2026 -->
+  <!-- ip_blacklist=fb16b946 -->
+  <!-- dx_file=855,f911da61,51086 -->
+  <!-- debian=D11.9 -->
+  <div class='cl-name'>0-30 MHZ SDR | [N0BQV] [REPUBLIC, MISSOURI. USA</div>
+  <a href='http://n0bqv.proxy.kiwisdr.com' target='_blank'>http://n0bqv.proxy.kiwisdr.com</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 2 v1.841 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D11.9</span>
+  <span class='cl-users'> (6/7 users, SNR <span class='' title='44 dB, 0-30 MHz
+33 dB, 1.8-30 MHz'>44/33 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry seq_770 snr_all_42 snr_hf_43'>
+ <a href='http://kiwisdr.areg.org.au:8074' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:18:05 GMT -->
+  <!-- id=884aeaf59cc6 -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=2-30MHZ SDR #2, VK5ARG Remote Receiver Site | Near Tarlee, South Australia -->
+  <!-- sdr_hw=KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣ 🌀D8.5 -->
+  <!-- bands=2000000-30000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- mode=rx8.wf3 -->
+  <!-- users=6 -->
+  <!-- users_max=8 -->
+  <!-- ext_api=4 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1784749907 -->
+  <!-- gps=(-34.273700, 138.771000) -->
+  <!-- grid=PF95JR -->
+  <!-- gps_good=8 -->
+  <!-- fixes=22455 -->
+  <!-- fixes_min=28 -->
+  <!-- fixes_hour=1787 -->
+  <!-- tdoa_id= -->
+  <!-- tdoa_ch=4 -->
+  <!-- asl=360 -->
+  <!-- loc=Near Tarlee, South Australia -->
+  <!-- sw_version=KiwiSDR_v1.902 -->
+  <!-- antenna=Broadband Monopole ("J-Dart") -->
+  <!-- snr=42,43 -->
+  <!-- ant_connected=1 -->
+  <!-- sm_cal=-18 -->
+  <!-- wf_cal=-13 -->
+  <!-- adc_ov=0 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=45998 -->
+  <!-- gps_date=0,0 -->
+  <!-- date=Sat Sep 5 13:18:06 2026 -->
+  <!-- ip_blacklist= -->
+  <!-- dx_file=872,db6868b3,52120 -->
+  <!-- debian=D8.5 -->
+  <div class='cl-name'>2-30MHZ SDR #2, VK5ARG REMOTE RECEIVER SITE | NEAR TARLEE, SOUTH AUSTRALIA</div>
+  <a href='http://kiwisdr.areg.org.au:8074' target='_blank'>http://kiwisdr.areg.org.au:8074</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D8.5</span>
+  <span class='cl-users'> (6/8 users, SNR <span class='' title='42 dB, 0-30 MHz
+43 dB, 1.8-30 MHz'>42/43 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry seq_457 snr_all_40 snr_hf_41'>
+ <a href='http://kiwisdr.areg.org.au:8073' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:34:58 GMT -->
+  <!-- id=c4f31281ccbf -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=2-30MHZ SDR #1, VK5ARG Remote Receiver Site | Near Tarlee, South Australia -->
+  <!-- sdr_hw=KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣ 🌀D8.5 -->
+  <!-- bands=1800000-30000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- mode=rx8.wf3 -->
+  <!-- users=4 -->
+  <!-- users_max=8 -->
+  <!-- ext_api=1 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1784739589 -->
+  <!-- gps=(-34.273700, 138.771000) -->
+  <!-- grid=PF95JR -->
+  <!-- gps_good=7 -->
+  <!-- fixes=76736 -->
+  <!-- fixes_min=30 -->
+  <!-- fixes_hour=1782 -->
+  <!-- tdoa_id=VK5ARG -->
+  <!-- tdoa_ch=2 -->
+  <!-- asl=300 -->
+  <!-- loc=Near Tarlee, South Australia -->
+  <!-- sw_version=KiwiSDR_v1.902 -->
+  <!-- antenna=Broadband Monopole ("J-Dart") -->
+  <!-- snr=40,41 -->
+  <!-- ant_connected=1 -->
+  <!-- sm_cal=-18 -->
+  <!-- wf_cal=-13 -->
+  <!-- adc_ov=393 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=156793 -->
+  <!-- gps_date=0,0 -->
+  <!-- date=Sat Sep 5 13:34:59 2026 -->
+  <!-- ip_blacklist= -->
+  <!-- dx_file=872,db6868b3,52120 -->
+  <!-- debian=D8.5 -->
+  <div class='cl-name'>2-30MHZ SDR #1, VK5ARG REMOTE RECEIVER SITE | NEAR TARLEE, SOUTH AUSTRALIA</div>
+  <a href='http://kiwisdr.areg.org.au:8073' target='_blank'>http://kiwisdr.areg.org.au:8073</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D8.5</span>
+  <span class='cl-users'> (4/8 users, SNR <span class='' title='40 dB, 0-30 MHz
+41 dB, 1.8-30 MHz'>40/41 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry seq_351 snr_all_41 snr_hf_38'>
+ <a href='http://kr6la.proxy.kiwisdr.com' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:40:16 GMT -->
+  <!-- id=883f4aa8cf0a -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=0-30 MHz SDR, northern California USA -->
+  <!-- sdr_hw=KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣ 🌀D8.5 -->
+  <!-- bands=0-30000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- mode=rx8.wf3 -->
+  <!-- users=4 -->
+  <!-- users_max=8 -->
+  <!-- ext_api=2 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1784726460 -->
+  <!-- gps=(40.620000, -121.920000) -->
+  <!-- grid=CN90ao -->
+  <!-- gps_good=6 -->
+  <!-- fixes=674302 -->
+  <!-- fixes_min=30 -->
+  <!-- fixes_hour=1779 -->
+  <!-- tdoa_id= -->
+  <!-- tdoa_ch=4 -->
+  <!-- asl=691 -->
+  <!-- loc=Whitmore, California -->
+  <!-- sw_version=KiwiSDR_v1.902 -->
+  <!-- antenna=300' wire loop @ 40 feet -->
+  <!-- snr=41,38 -->
+  <!-- ant_connected=1 -->
+  <!-- sm_cal=-13 -->
+  <!-- wf_cal=-13 -->
+  <!-- adc_ov=51765 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=1374766 -->
+  <!-- gps_date=0,0 -->
+  <!-- date=Sat Sep 5 13:40:16 2026 -->
+  <!-- ip_blacklist=fb16b946 -->
+  <!-- dx_file=872,db6868b3,52120 -->
+  <!-- debian=D8.5 -->
+  <div class='cl-name'>0-30 MHZ SDR, NORTHERN CALIFORNIA USA</div>
+  <a href='http://kr6la.proxy.kiwisdr.com' target='_blank'>http://kr6la.proxy.kiwisdr.com</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D8.5</span>
+  <span class='cl-users'> (4/8 users, SNR <span class='' title='41 dB, 0-30 MHz
+38 dB, 1.8-30 MHz'>41/38 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry seq_292 snr_all_40 snr_hf_37'>
+ <a href='http://zl7dx.proxy.kiwisdr.com' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:43:00 GMT -->
+  <!-- id=0804b482e47c -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=Kiwisdr2 ZL7DX Chatham Islands, New Zealand -->
+  <!-- sdr_hw=KiwiSDR 2 v1.902 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣ 🌀D10.11 -->
+  <!-- bands=0-30000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- mode=rx8.wf3 -->
+  <!-- users=1 -->
+  <!-- users_max=7 -->
+  <!-- ext_api=4 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1784731895 -->
+  <!-- gps=(-43.961812, -176.497973) -->
+  <!-- grid=AE16ra -->
+  <!-- gps_good=5 -->
+  <!-- fixes=80449 -->
+  <!-- fixes_min=29 -->
+  <!-- fixes_hour=1775 -->
+  <!-- tdoa_id= -->
+  <!-- tdoa_ch=4 -->
+  <!-- asl=90 -->
+  <!-- loc=Chatham Island, New Zealand -->
+  <!-- sw_version=KiwiSDR_v1.902 -->
+  <!-- antenna=15 metre high vertical -->
+  <!-- snr=40,37 -->
+  <!-- ant_connected=1 -->
+  <!-- sm_cal=-13 -->
+  <!-- wf_cal=-13 -->
+  <!-- adc_ov=17 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=167685 -->
+  <!-- gps_date=0,0 -->
+  <!-- date=Sat Sep 5 13:43:00 2026 -->
+  <!-- ip_blacklist= -->
+  <!-- dx_file=872,db6868b3,52120 -->
+  <!-- debian=D10.11 -->
+  <div class='cl-name'>KIWISDR2 ZL7DX CHATHAM ISLANDS, NEW ZEALAND</div>
+  <a href='http://zl7dx.proxy.kiwisdr.com' target='_blank'>http://zl7dx.proxy.kiwisdr.com</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 2 v1.902 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D10.11</span>
+  <span class='cl-users'> (1/7 users, SNR <span class='' title='40 dB, 0-30 MHz
+37 dB, 1.8-30 MHz'>40/37 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry seq_112 snr_all_43 snr_hf_38'>
+ <a href='http://kiwi.web-sdr.net' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:52:10 GMT -->
+  <!-- id=402e71d15462 -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=0-30 MHz SDR(Redirect to the next receiver when full.) | Oita,Japan -->
+  <!-- sdr_hw=KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣⁣ 🌀D11.11 -->
+  <!-- bands=0-30000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- mode=rx8.wf3 -->
+  <!-- users=3 -->
+  <!-- users_max=7 -->
+  <!-- ext_api=8 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1784757436 -->
+  <!-- gps=(33.554900, 131.315900) -->
+  <!-- grid=PM53pn -->
+  <!-- gps_good=5 -->
+  <!-- fixes=61102 -->
+  <!-- fixes_min=30 -->
+  <!-- fixes_hour=1786 -->
+  <!-- tdoa_id= -->
+  <!-- tdoa_ch=0 -->
+  <!-- asl=6 -->
+  <!-- loc=Oita,Japan -->
+  <!-- sw_version=KiwiSDR_v1.902 -->
+  <!-- antenna=self-made YouLoop + LAMB-1B -->
+  <!-- snr=43,38 -->
+  <!-- ant_connected=1 -->
+  <!-- sm_cal=-13 -->
+  <!-- wf_cal=-13 -->
+  <!-- adc_ov=1 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=124425 -->
+  <!-- gps_date=0,0 -->
+  <!-- date=Sat Sep 5 13:52:10 2026 -->
+  <!-- ip_blacklist= -->
+  <!-- dx_file=377,127f73d8,21606 -->
+  <!-- debian=D11.11 -->
+  <div class='cl-name'>0-30 MHZ SDR(REDIRECT TO THE NEXT RECEIVER WHEN FULL.) | OITA, JAPAN</div>
+  <a href='http://kiwi.web-sdr.net' target='_blank'>http://kiwi.web-sdr.net</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D11.11</span>
+  <span class='cl-users'> (3/7 users, SNR <span class='' title='43 dB, 0-30 MHz
+38 dB, 1.8-30 MHz'>43/38 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry seq_585 snr_all_43 snr_hf_33'>
+ <a href='http://22568.proxy.kiwisdr.com' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:27:31 GMT -->
+  <!-- id=b83df62dbdd7 -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=🟠VK3SOL-Strathbogie Rx2. Victoria, Australia [Hor. Loop 0.2-30MHz]🟠 -->
+  <!-- sdr_hw=KiwiSDR 2 v1.902 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣ 🌀D11.11 -->
+  <!-- bands=0-30000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- mode=rx4.wf4 -->
+  <!-- users=1 -->
+  <!-- users_max=4 -->
+  <!-- ext_api=4 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1784737279 -->
+  <!-- gps=(-36.852596, 145.738417) -->
+  <!-- grid=QF23ud -->
+  <!-- gps_good=6 -->
+  <!-- fixes=667813 -->
+  <!-- fixes_min=30 -->
+  <!-- fixes_hour=1784 -->
+  <!-- tdoa_id= -->
+  <!-- tdoa_ch=4 -->
+  <!-- asl=30 -->
+  <!-- loc=Strathbogie, Victoria, Australia -->
+  <!-- sw_version=KiwiSDR_v1.902 -->
+  <!-- antenna=Horizontal loop. 42m per side, 11m high. -->
+  <!-- snr=43,33 -->
+  <!-- ant_connected=1 -->
+  <!-- sm_cal=-5 -->
+  <!-- wf_cal=-11 -->
+  <!-- adc_ov=1022 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=1372733 -->
+  <!-- gps_date=0,0 -->
+  <!-- date=Sat Sep 5 13:27:31 2026 -->
+  <!-- ip_blacklist=fb16b946 -->
+  <!-- dx_file=1370,6e0c25a4,72490 -->
+  <!-- debian=D11.11 -->
+  <div class='cl-name'>🟠VK3SOL-STRATHBOGIE RX2. VICTORIA, AUSTRALIA [HOR. LOOP 0.2-30MHZ]🟠</div>
+  <a href='http://22568.proxy.kiwisdr.com' target='_blank'>http://22568.proxy.kiwisdr.com</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 2 v1.902 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D11.11</span>
+  <span class='cl-users'> (1/4 users, SNR <span class='' title='43 dB, 0-30 MHz
+33 dB, 1.8-30 MHz'>43/33 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry seq_648 snr_all_32 snr_hf_33'>
+ <a href='http://ja0veu.proxy.kiwisdr.com' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:24:19 GMT -->
+  <!-- id=b0d5ccfdc223 -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=SDR Radio Station at Minowa, Kamiinagun, Nagano, JAPAN -->
+  <!-- sdr_hw=KiwiSDR 1 v1.902 ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣ 🌀D8.5 -->
+  <!-- bands=0-30000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- mode=rx8.wf3 -->
+  <!-- users=2 -->
+  <!-- users_max=3 -->
+  <!-- ext_api=4 -->
+  <!-- preempt=1 -->
+  <!-- avatar_ctime=1784752120 -->
+  <!-- gps=(35.914958, 137.982285) -->
+  <!-- grid=PM85xv -->
+  <!-- gps_good=0 -->
+  <!-- fixes=0 -->
+  <!-- fixes_min=0 -->
+  <!-- fixes_hour=0 -->
+  <!-- tdoa_id= -->
+  <!-- tdoa_ch=4 -->
+  <!-- asl=700 -->
+  <!-- loc=Nagano, Japan -->
+  <!-- sw_version=KiwiSDR_v1.902 -->
+  <!-- antenna=10mH, whip antenna -->
+  <!-- snr=32,33 -->
+  <!-- ant_connected=1 -->
+  <!-- sm_cal=-13 -->
+  <!-- wf_cal=-13 -->
+  <!-- adc_ov=3141 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=235016 -->
+  <!-- gps_date=0,0 -->
+  <!-- date=Sat Sep 5 13:24:19 2026 -->
+  <!-- ip_blacklist= -->
+  <!-- dx_file=872,db6868b3,52120 -->
+  <!-- debian=D8.5 -->
+  <div class='cl-name'>SDR RADIO STATION AT MINOWA, KAMIINAGUN, NAGANO, JAPAN</div>
+  <a href='http://ja0veu.proxy.kiwisdr.com' target='_blank'>http://ja0veu.proxy.kiwisdr.com</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 1 v1.902 ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D8.5</span>
+  <span class='cl-users'> (2/3 users, SNR <span class='' title='32 dB, 0-30 MHz
+33 dB, 1.8-30 MHz'>32/33 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry seq_43 snr_all_42 snr_hf_32'>
+ <a href='http://vk2ggc.ddns.net:8074' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:55:53 GMT -->
+  <!-- id=0035ff9baf06 -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=VK2GGC SDR2: 0-30MHz T2FD DIPOLE - HUNTER VALLEY NSW AUSTRALIA -->
+  <!-- sdr_hw=KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣ 🌀D8.5 -->
+  <!-- bands=0-30000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- mode=rx8.wf3 -->
+  <!-- users=2 -->
+  <!-- users_max=2 -->
+  <!-- ext_api=4 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1784742091 -->
+  <!-- gps=(-32.525000, 151.754400) -->
+  <!-- grid=qf57vl -->
+  <!-- gps_good=7 -->
+  <!-- fixes=678737 -->
+  <!-- fixes_min=30 -->
+  <!-- fixes_hour=1787 -->
+  <!-- tdoa_id= -->
+  <!-- tdoa_ch=4 -->
+  <!-- asl=100 -->
+  <!-- loc=Hunter Valley NSW Australia -->
+  <!-- sw_version=KiwiSDR_v1.902 -->
+  <!-- antenna=1-30MHz T2FD wideband dipole antenna @ 50' -->
+  <!-- snr=42,32 -->
+  <!-- ant_connected=1 -->
+  <!-- sm_cal=-13 -->
+  <!-- wf_cal=-13 -->
+  <!-- adc_ov=7759 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=1370045 -->
+  <!-- gps_date=0,0 -->
+  <!-- date=Sat Sep 5 13:55:53 2026 -->
+  <!-- ip_blacklist=fb16b946 -->
+  <!-- dx_file=875,87941c63,52303 -->
+  <!-- debian=D8.5 -->
+  <div class='cl-name'>VK2GGC SDR2: 0-30MHZ T2FD DIPOLE - HUNTER VALLEY NSW AUSTRALIA</div>
+  <a href='http://vk2ggc.ddns.net:8074' target='_blank'>http://vk2ggc.ddns.net:8074</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D8.5</span>
+  <span class='cl-users'> (2/2 users, SNR <span class='' title='42 dB, 0-30 MHz
+32 dB, 1.8-30 MHz'>42/32 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry seq_460 snr_all_31 snr_hf_30'>
+ <a href='http://22137.proxy.kiwisdr.com' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:34:50 GMT -->
+  <!-- id=9006f25fd71f -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=HB9BG Test | Belp -->
+  <!-- sdr_hw=KiwiSDR 2 v1.800 ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣ 🌀D11.9 -->
+  <!-- bands=0-30000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- users=1 -->
+  <!-- users_max=3 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1735571523 -->
+  <!-- gps=(0.00, 0.00) -->
+  <!-- gps_good=0 -->
+  <!-- fixes=0 -->
+  <!-- fixes_min=0 -->
+  <!-- fixes_hour=0 -->
+  <!-- tdoa_id= -->
+  <!-- tdoa_ch=-1 -->
+  <!-- asl=30 -->
+  <!-- loc=Belp -->
+  <!-- sw_version=KiwiSDR_v1.800 -->
+  <!-- antenna=Wire -->
+  <!-- snr=31,30 -->
+  <!-- ant_connected=1 -->
+  <!-- adc_ov=0 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=348571 -->
+  <!-- gps_date=0,0 -->
+  <!-- date=Sat Sep 5 13:34:50 2026 -->
+  <!-- ip_blacklist=fb16b946 -->
+  <!-- dx_file=87,e4cdc086,3654 -->
+  <!-- debian=D11.9 -->
+  <div class='cl-name'>HB9BG TEST | BELP</div>
+  <a href='http://22137.proxy.kiwisdr.com' target='_blank'>http://22137.proxy.kiwisdr.com</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 2 v1.800 ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D11.9</span>
+  <span class='cl-users'> (1/3 users, SNR <span class='' title='31 dB, 0-30 MHz
+30 dB, 1.8-30 MHz'>31/30 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry seq_744 snr_all_30 snr_hf_30'>
+ <a href='http://vr2bg.proxy.kiwisdr.com' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:19:06 GMT -->
+  <!-- id=40bd322eb47c -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=0-30 MHz SDR, VR2BG | Hong Kong -->
+  <!-- sdr_hw=KiwiSDR 1 v1.698 ⁣ 📡 GPS ⁣ ⏳🚫 Limits ⁣⁣ 🌀D8.5 -->
+  <!-- bands=0-30000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- users=8 -->
+  <!-- users_max=8 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1723442429 -->
+  <!-- gps=(22.350000, 114.130000) -->
+  <!-- gps_good=6 -->
+  <!-- fixes=1238545 -->
+  <!-- fixes_min=29 -->
+  <!-- fixes_hour=1773 -->
+  <!-- tdoa_id=VR2BG -->
+  <!-- tdoa_ch=4 -->
+  <!-- asl=200 -->
+  <!-- loc=Hong Kong -->
+  <!-- sw_version=KiwiSDR_v1.698 -->
+  <!-- antenna=85 cm loop, ~30 m AGL -->
+  <!-- snr=30,30 -->
+  <!-- ant_connected=1 -->
+  <!-- adc_ov=23 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=2530421 -->
+  <!-- gps_date=0,0 -->
+  <!-- date=Sat Sep 5 13:19:07 2026 -->
+  <!-- ip_blacklist= -->
+  <!-- dx_file=887,9eacfe2e,52785 -->
+  <!-- debian=D8.5 -->
+  <div class='cl-name'>0-30 MHZ SDR, VR2BG | HONG KONG</div>
+  <a href='http://vr2bg.proxy.kiwisdr.com' target='_blank'>http://vr2bg.proxy.kiwisdr.com</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 1 v1.698 ⁣ 📡 GPS ⁣ ⏳🚫 Limits ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D8.5</span>
+  <span class='cl-users'> (8/8 users, SNR <span class='' title='30 dB, 0-30 MHz
+30 dB, 1.8-30 MHz'>30/30 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry seq_762 snr_all_40 snr_hf_29'>
+ <a href='http://palomar-1.proxy.kiwisdr.com' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:18:30 GMT -->
+  <!-- id=f82e0c019dd6 -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=K6VZK 0-30 MHZ KiwiSDR #1 | Palomar Moutain, CA -->
+  <!-- sdr_hw=KiwiSDR 2 v1.822 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣⁣ 🌀D11.9 -->
+  <!-- bands=0-30000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- users=2 -->
+  <!-- users_max=2 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1760231354 -->
+  <!-- gps=(33.31, -116.85) -->
+  <!-- grid=DM13nh -->
+  <!-- gps_good=7 -->
+  <!-- fixes=689262 -->
+  <!-- fixes_min=30 -->
+  <!-- fixes_hour=1784 -->
+  <!-- tdoa_id= -->
+  <!-- tdoa_ch=-1 -->
+  <!-- asl=30 -->
+  <!-- loc=Palomar Moutain, CA -->
+  <!-- sw_version=KiwiSDR_v1.822 -->
+  <!-- antenna=IDAFAB / N1CL Designs Active Antenna -->
+  <!-- snr=40,29 -->
+  <!-- ant_connected=1 -->
+  <!-- adc_ov=14643 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,5 -->
+  <!-- uptime=1393935 -->
+  <!-- gps_date=1,1 -->
+  <!-- date=Sat Sep 5 13:18:30 2026 -->
+  <!-- ip_blacklist=fb16b946 -->
+  <!-- dx_file=999,c3a7411d,61958 -->
+  <!-- debian=D11.9 -->
+  <div class='cl-name'>K6VZK 0-30 MHZ KIWISDR #1 | PALOMAR MOUTAIN, CA</div>
+  <a href='http://palomar-1.proxy.kiwisdr.com' target='_blank'>http://palomar-1.proxy.kiwisdr.com</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 2 v1.822 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D11.9</span>
+  <span class='cl-users'> (2/2 users, SNR <span class='' title='40 dB, 0-30 MHz
+29 dB, 1.8-30 MHz'>40/29 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry seq_477 snr_all_47 snr_hf_37'>
+ <a href='http://mtkiwi.proxy.kiwisdr.com' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:33:47 GMT -->
+  <!-- id=880ce034449f -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=0-30 MHz SDR | Stevensville, MT -->
+  <!-- sdr_hw=KiwiSDR 1 v1.902 ⁣ 📻 DRM ⁣⁣ 🌀D11.11 -->
+  <!-- bands=100000-30000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- mode=rx8.wf3 -->
+  <!-- users=7 -->
+  <!-- users_max=4 -->
+  <!-- ext_api=4 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1784712741 -->
+  <!-- gps=(46.620000, -114.028000) -->
+  <!-- grid=DN26wm -->
+  <!-- gps_good=0 -->
+  <!-- fixes=0 -->
+  <!-- fixes_min=0 -->
+  <!-- fixes_hour=0 -->
+  <!-- tdoa_id=W0AY0 -->
+  <!-- tdoa_ch=4 -->
+  <!-- asl=30 -->
+  <!-- loc=Stevensville, MT -->
+  <!-- sw_version=KiwiSDR_v1.902 -->
+  <!-- antenna=75 m dipole with DX Engineering Preamp. -->
+  <!-- snr=47,37 -->
+  <!-- ant_connected=1 -->
+  <!-- sm_cal=-16 -->
+  <!-- wf_cal=-11 -->
+  <!-- adc_ov=9796 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=27063 -->
+  <!-- gps_date=0,0 -->
+  <!-- date=Sat Sep 5 13:33:47 2026 -->
+  <!-- ip_blacklist=fb16b946 -->
+  <!-- dx_file=872,db6868b3,52120 -->
+  <!-- debian=D11.11 -->
+  <div class='cl-name'>0-30 MHZ SDR | STEVENSVILLE, MT</div>
+  <a href='http://mtkiwi.proxy.kiwisdr.com' target='_blank'>http://mtkiwi.proxy.kiwisdr.com</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 1 v1.902 ⁣ 📻 DRM ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D11.11</span>
+  <span class='cl-users'> (7/8 users, SNR <span class='' title='47 dB, 0-30 MHz
+37 dB, 1.8-30 MHz'>47/37 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry cl-err-entry seq_522 snr_all_41 snr_hf_37'>
+ <a href='http://sdr.ironstonerange.com:8073' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:31:29 GMT -->
+  <!-- id=1442fc0f69f6 -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=███ 0-30 MHz SDR #1, VK5PH, Ironstone Range, South Australia ███ -->
+  <!-- sdr_hw=KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣ 🌀D8.5 -->
+  <!-- bands=0-30000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- mode=rx8.wf3 -->
+  <!-- users=5 -->
+  <!-- users_max=8 -->
+  <!-- ext_api=4 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1784736574 -->
+  <!-- gps=(-34.964437, 138.762380) -->
+  <!-- grid=PF95ja -->
+  <!-- gps_good=4 -->
+  <!-- fixes=132670 -->
+  <!-- fixes_min=30 -->
+  <!-- fixes_hour=1637 -->
+  <!-- tdoa_id= -->
+  <!-- tdoa_ch=4 -->
+  <!-- asl=550 -->
+  <!-- loc=Ironstone Range, South Australia -->
+  <!-- sw_version=KiwiSDR_v1.902 -->
+  <!-- antenna=12m Duoconical Antenna -->
+  <!-- snr=41,37 -->
+  <!-- ant_connected=1 -->
+  <!-- sm_cal=-13 -->
+  <!-- wf_cal=-13 -->
+  <!-- adc_ov=435 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=327767 -->
+  <!-- gps_date=1,1 -->
+  <!-- date=Sat Sep 5 13:31:30 2026 -->
+  <!-- ip_blacklist=fb16b946 -->
+  <!-- dx_file=882,a5107372,53381 -->
+  <!-- debian=D8.5 -->
+  <div class='cl-name'>███ 0-30 MHZ SDR #1, VK5PH, IRONSTONE RANGE, SOUTH AUSTRALIA ███</div>
+  <a href='http://sdr.ironstonerange.com:8073' target='_blank'>http://sdr.ironstonerange.com:8073</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D8.5</span>
+  <span class='cl-users'> (5/8 users, SNR <span class='' title='41 dB, 0-30 MHz
+37 dB, 1.8-30 MHz'>41/37 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry seq_829 snr_all_35 snr_hf_30'>
+ <a href='http://kiwisdr.tko.zlwan.net:8073' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:14:54 GMT -->
+  <!-- id=40bd32c8d03c -->
+  <!-- status=active -->
+  <!-- offline=yes -->
+  <!-- name=KiwiSDR at Taikorea Road | Palmerston North, New Zealand -->
+  <!-- sdr_hw=KiwiSDR 1 v1.842 ⁣ 📡 GPS ⁣ 📻 DRM ⁣⁣ 🌀D8.5 -->
+  <!-- bands=0-30000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- mode=rx4_wf4 -->
+  <!-- users=2 -->
+  <!-- users_max=4 -->
+  <!-- ext_api=4 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1781138177 -->
+  <!-- gps=(-40.36, 175.38) -->
+  <!-- grid=RE79qp -->
+  <!-- gps_good=2 -->
+  <!-- fixes=92436 -->
+  <!-- fixes_min=30 -->
+  <!-- fixes_hour=1591 -->
+  <!-- tdoa_id= -->
+  <!-- tdoa_ch=4 -->
+  <!-- asl=30 -->
+  <!-- loc=Palmerston North, New Zealand -->
+  <!-- sw_version=KiwiSDR_v1.842 -->
+  <!-- antenna=40/80 Fan Dipole -->
+  <!-- snr=35,30 -->
+  <!-- ant_connected=1 -->
+  <!-- sm_cal=-13 -->
+  <!-- wf_cal=-13 -->
+  <!-- adc_ov=115880 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=380851 -->
+  <!-- gps_date=1,1 -->
+  <!-- date=Sat Sep 5 13:14:54 2026 -->
+  <!-- ip_blacklist=fb16b946 -->
+  <!-- dx_file=872,db6868b3,52120 -->
+  <!-- debian=D8.5 -->
+  <div class='cl-name'>KIWISDR AT TAIKOREA ROAD | PALMERSTON NORTH, NEW ZEALAND</div>
+  <a href='http://kiwisdr.tko.zlwan.net:8073' target='_blank'>http://kiwisdr.tko.zlwan.net:8073</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 1 v1.842 ⁣ 📡 GPS ⁣ 📻 DRM ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D8.5</span>
+  <span class='cl-users'> (2/4 users, SNR <span class='' title='35 dB, 0-30 MHz
+30 dB, 1.8-30 MHz'>35/30 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry seq_671 snr_all_40 snr_hf_37'>
+ <a href='http://sdr.rogerh.co.nz:8073' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:22:59 GMT -->
+  <!-- id=9884e38cc06f -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=0-30 MHz SDR, ZL1ROT, -->
+  <!-- sdr_hw=KiwiSDR 2 v1.902 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣ 🌀D8.5 -->
+  <!-- bands=0-30000000,50000000-54000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- mode=rx8.wf3 -->
+  <!-- users=1 -->
+  <!-- users_max=6 -->
+  <!-- ext_api=4 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1788265279 -->
+  <!-- gps=(-38.152093, 176.070737) -->
+  <!-- grid=RF81au -->
+  <!-- gps_good=6 -->
+  <!-- fixes=170036 -->
+  <!-- fixes_min=30 -->
+  <!-- fixes_hour=1743 -->
+  <!-- tdoa_id= -->
+  <!-- tdoa_ch=4 -->
+  <!-- asl=320 -->
+  <!-- loc=ZL1ROT Rotorua, New Zealand -->
+  <!-- sw_version=KiwiSDR_v1.902 -->
+  <!-- antenna=Full Size G5RV -->
+  <!-- snr=40,37 -->
+  <!-- ant_connected=1 -->
+  <!-- sm_cal=-13 -->
+  <!-- wf_cal=-13 -->
+  <!-- adc_ov=25 -->
+  <!-- clk_ext_freq=66666600 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=349256 -->
+  <!-- gps_date=1,1 -->
+  <!-- date=Sat Sep 5 13:22:59 2026 -->
+  <!-- ip_blacklist= -->
+  <!-- dx_file=666,b2a98803,43265 -->
+  <!-- debian=D8.5 -->
+  <div class='cl-name'>0-30 MHZ SDR, ZL1ROT,</div>
+  <a href='http://sdr.rogerh.co.nz:8073' target='_blank'>http://sdr.rogerh.co.nz:8073</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 2 v1.902 ⁣ 📡 GPS ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D8.5</span>
+  <span class='cl-users'> (1/6 users, SNR <span class='' title='40 dB, 0-30 MHz
+37 dB, 1.8-30 MHz'>40/37 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry seq_104 snr_all_36 snr_hf_36'>
+ <a href='http://jp7fso-kiwisdr.sytes.net:8073' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:53:09 GMT -->
+  <!-- id=98f07bff6945 -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=JP7FSO,0-30 MHz SDR, Fukushima JAPAN -->
+  <!-- sdr_hw=KiwiSDR 1 v1.902 ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣ 🌀D11.11 -->
+  <!-- bands=0-30000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- mode=rx8.wf3 -->
+  <!-- users=4 -->
+  <!-- users_max=6 -->
+  <!-- ext_api=4 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1784756737 -->
+  <!-- gps=(37.669714, 140.492137) -->
+  <!-- grid=QM07FQ -->
+  <!-- gps_good=0 -->
+  <!-- fixes=0 -->
+  <!-- fixes_min=0 -->
+  <!-- fixes_hour=0 -->
+  <!-- tdoa_id= -->
+  <!-- tdoa_ch=4 -->
+  <!-- asl=30 -->
+  <!-- loc=Matsukawa, Fukushima JAPAN -->
+  <!-- sw_version=KiwiSDR_v1.902 -->
+  <!-- antenna=G5RV -->
+  <!-- snr=42,43,44 -->
+  <!-- ant_connected=1 -->
+  <!-- sm_cal=-16 -->
+  <!-- wf_cal=-11 -->
+  <!-- adc_ov=56706 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=64887 -->
+  <!-- gps_date=0,0 -->
+  <!-- date=Sat Sep 5 13:53:10 2026 -->
+  <!-- ip_blacklist=fb16b946 -->
+  <!-- dx_file=872,db6868b3,52120 -->
+  <!-- debian=D11.11 -->
+  <div class='cl-name'>JP7FSO,0-30 MHZ SDR, FUKUSHIMA JAPAN</div>
+  <a href='http://jp7fso-kiwisdr.sytes.net:8073' target='_blank'>http://jp7fso-kiwisdr.sytes.net:8073</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 1 v1.902 ⁣ ⏳ Limits ⁣ 📻 DRM ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D11.11</span>
+  <span class='cl-users'> (4/6 users, SNR <span class='' title='36 dB, 0-30 MHz
+36 dB, 1.8-30 MHz'>36/36 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+<div class='cl-entry seq_651 snr_all_40 snr_hf_32'>
+ <a href='http://kb6c.proxy.kiwisdr.com' target='_blank'> <img class='cl-avatar' src='/kiwi/kiwi-avatar.png'> </a>
+ <div class='cl-info'>
+  <!-- updated=Saturday, 05-Sep-2026 13:24:01 GMT -->
+  <!-- id=c4f312b9ff30 -->
+  <!-- status=active -->
+  <!-- offline=no -->
+  <!-- name=0-30 MHz SDR, KB6C, Stauffer, California -->
+  <!-- sdr_hw=KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳🚫 Limits ⁣ 📻 DRM ⁣⁣ 🌀D8.5 -->
+  <!-- bands=0-30000000 -->
+  <!-- freq_offset=0.000 -->
+  <!-- mode=rx8.wf3 -->
+  <!-- users=1 -->
+  <!-- users_max=3 -->
+  <!-- ext_api=0 -->
+  <!-- preempt=0 -->
+  <!-- avatar_ctime=1784716677 -->
+  <!-- gps=(34.750000, -119.080000) -->
+  <!-- grid= -->
+  <!-- gps_good=1 -->
+  <!-- fixes=130 -->
+  <!-- fixes_min=0 -->
+  <!-- fixes_hour=0 -->
+  <!-- tdoa_id= -->
+  <!-- tdoa_ch=4 -->
+  <!-- asl=1585 -->
+  <!-- loc=Stauffer, CA -->
+  <!-- sw_version=KiwiSDR_v1.902 -->
+  <!-- antenna=Wellbrooke Loop -->
+  <!-- snr=40,32 -->
+  <!-- ant_connected=1 -->
+  <!-- sm_cal=-13 -->
+  <!-- wf_cal=-13 -->
+  <!-- adc_ov=0 -->
+  <!-- clk_ext_freq=66665900 -->
+  <!-- clk_ext_gps=0,1 -->
+  <!-- uptime=11499 -->
+  <!-- gps_date=0,0 -->
+  <!-- date=Sat Sep 5 13:24:01 2026 -->
+  <!-- ip_blacklist=fb16b946 -->
+  <!-- dx_file=913,ea6f669c,44720 -->
+  <!-- debian=D8.5 -->
+  <div class='cl-name'>0-30 MHZ SDR, KB6C, STAUFFER, CALIFORNIA</div>
+  <a href='http://kb6c.proxy.kiwisdr.com' target='_blank'>http://kb6c.proxy.kiwisdr.com</a> <br>
+  <span class='cl-sdr_hw'>KiwiSDR 1 v1.902 ⁣ 📡 GPS ⁣ ⏳🚫 Limits ⁣ 📻 DRM ⁣⁣<span class="cl-debian">&nbsp;🌀</span>D8.5</span>
+  <span class='cl-users'> (1/3 users, SNR <span class='' title='40 dB, 0-30 MHz
+32 dB, 1.8-30 MHz'>40/32 dB</span>)</span>
+  <span class='id-band'></span>
+ </div>
+</div>
+
+</div>
+<script>
+ w3_innerHTML('id-rx-count', 21);
+ w3_innerHTML('id-tdoa-count', 509);
+ w3_innerHTML('id-user-count', 1855);
+ w3_innerHTML('id-proxied-count', 402);
+ w3_innerHTML('id-host-ddns', 166);
+ w3_innerHTML('id-host-ipv4', 115);
+ w3_innerHTML('id-host-domain', 217);
+</script>
+</body>
+</html>

--- a/tools/kiwi-mirror-worker/test/poll.test.mjs
+++ b/tools/kiwi-mirror-worker/test/poll.test.mjs
@@ -150,9 +150,60 @@ await t('history caps at 20, newest first', async () => {
   const kv = makeKV();
   stub(() => ok(SAMPLE));
   let h;
-  for (let i = 0; i < 25; i++) h = await runPoll(baseEnv(kv), new Date(Date.UTC(2026, 8, 5, i % 24)));
+  // Distinct, strictly increasing stamps. The old loop used hour `i % 24` over
+  // 25 iterations, so `at` was not monotonic and no honest ordering assert
+  // could hold — and the assert it did make was `... || h.recent.length === 20`,
+  // whose right operand the line above had just proven, so reversing the
+  // history would have left it green.
+  for (let i = 0; i < 25; i++) h = await runPoll(baseEnv(kv), new Date(Date.UTC(2026, 8, 5, 0, i)));
   assert.equal(h.recent.length, 20);
-  assert.ok(h.recent[0].at > h.recent[1].at || h.recent.length === 20);
+  assert.ok(h.recent[0].at > h.recent[1].at, 'history is not newest-first');
+});
+
+// 13. A mode originRequest cannot speak is OUR misconfiguration, not the
+// origin's. Without membership validation it reached the `else throw` inside
+// the retry loop and was reported as fault 'origin', three times over.
+await t('an unknown auth mode -> mirror fault, zero origin requests', async () => {
+  const kv = makeKV();
+  stub(() => ok('should never be called'));
+  const h = await runPoll(baseEnv(kv, { KIWI_AUTH_MODE: 'Header' }));
+  assert.equal(h.fault, 'mirror');
+  assert.equal(h.last_run_reason, 'auth-misconfigured');
+  assert.equal(h.last_run_attempts, 0);
+  assert.equal(calls.length, 0, 'made ' + calls.length + ' origin requests');
+});
+
+// 14. A 304 is a success, so it must refresh last_success_at — the status page
+// reads that as "the origin confirmed our copy", and reading the publish time
+// instead made healthy 304 streams look stale and hid the frozen-mirror alarm.
+await t('304 refreshes last_success_at without republishing', async () => {
+  const kv = makeKV({
+    'directory:payload': JSON.stringify({ receivers: [1, 2, 3] }),
+    'directory:status': JSON.stringify({ receiver_count: SAMPLE_COUNT, etag: 'W/"abc"',
+                                         fetched_at: '2026-09-01T00:00:00.000Z' }),
+  });
+  stub(() => new Response(null, { status: 304 }));
+  const h = await runPoll(baseEnv(kv), new Date(Date.UTC(2026, 8, 5, 12)));
+  assert.equal(h.last_run_result, 'not-modified');
+  assert.equal(h.last_success_at, '2026-09-05T12:00:00.000Z');
+  // The publish record must NOT move: nothing was republished.
+  assert.equal(JSON.parse(kv.store.get('directory:status')).fetched_at,
+               '2026-09-01T00:00:00.000Z');
+});
+
+// 15. The URL cross-check the parser's comment promises.
+await t('an entry whose anchors disagree is skipped, not silently reurled', async () => {
+  const kv = makeKV();
+  // Derived from the fixture, not hardcoded: rewrite only the FIRST anchor of
+  // the first entry so its two anchors disagree. A hardcoded host silently
+  // stops testing anything the moment the fixture is retrimmed.
+  const first = SAMPLE.match(/<a\s+href='([^']+)'\s+target='_blank'>/);
+  assert.ok(first, 'fixture has no receiver anchor');
+  const swapped = SAMPLE.replace(first[0], first[0].replace(first[1], 'http://swapped.example:8073'));
+  assert.notEqual(swapped, SAMPLE, 'fixture rewrite was a no-op');
+  stub(() => ok(swapped));
+  const h = await runPoll(baseEnv(kv));
+  assert.equal(h.receiver_count, SAMPLE_COUNT - 1, 'disagreeing entry was not skipped');
 });
 
 // 10. The weak-validator bug: Cloudflare hands us W/"x" for a gzip response the

--- a/tools/kiwi-mirror-worker/test/poll.test.mjs
+++ b/tools/kiwi-mirror-worker/test/poll.test.mjs
@@ -1,0 +1,194 @@
+/**
+ * Exercises runPoll against a stubbed origin and an in-memory KV. The point is
+ * the failure paths: every one of them must leave the previously published list
+ * untouched, because a mirror that serves a truncated list is worse than one
+ * that serves an old list.
+ */
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+import { runPoll } from '../src/index.js';
+
+const SAMPLE = readFileSync(process.argv[2], 'utf8');
+
+// Derived, never hardcoded. The fixture is a trimmed slice of a real origin
+// page chosen to cover every ext_api regime (including the key being absent),
+// plus flagged/offline/multi-range-bands/3-value-snr shapes the full snapshot
+// happened not to contain. Hardcoding its length is what let the old 870 rot.
+const SAMPLE_COUNT = (SAMPLE.match(/<div class='cl-entry/g) || []).length;
+
+function makeKV(seed = {}) {
+  const store = new Map(Object.entries(seed));
+  return {
+    store,
+    get: async (k, type) => {
+      const v = store.get(k);
+      if (v === undefined) return null;
+      return type === 'json' ? JSON.parse(v) : v;
+    },
+    put: async (k, v) => { store.set(k, v); },
+  };
+}
+
+const baseEnv = (kv, over = {}) => ({
+  KIWI: kv,
+  KIWI_SOURCE_URL: 'https://files.kiwisdr.com/public/',
+  KIWI_USER_AGENT: 'test',
+  KIWI_SECRET: 'shhh',
+  KIWI_AUTH_MODE: 'query',
+  KIWI_AUTH_NAME: 'key',
+  KIWI_MIN_ENTRIES_FRACTION: '0.5',
+  KIWI_STALE_AFTER_MINUTES: '360',
+  ...over,
+});
+
+let calls = [];
+const stub = (fn) => { calls = []; globalThis.fetch = async (req) => { calls.push(req); return fn(req); }; };
+const ok = (body, headers = {}) => new Response(body, { status: 200, headers });
+
+const results = [];
+const t = async (name, fn) => {
+  try { await fn(); results.push(['PASS', name]); }
+  catch (e) { results.push(['FAIL', name + ' -> ' + e.message]); }
+};
+
+// 1. No secret: must not touch the origin at all.
+await t('no secret -> auth fault, zero origin requests', async () => {
+  const kv = makeKV();
+  stub(() => ok('should never be called'));
+  const h = await runPoll(baseEnv(kv, { KIWI_SECRET: '' }));
+  assert.equal(h.last_run_result, 'failed');
+  assert.equal(h.fault, 'auth');
+  assert.equal(h.last_run_reason, 'no-secret');
+  assert.equal(calls.length, 0, 'made ' + calls.length + ' origin requests');
+});
+
+// 2. Happy path.
+await t('good fetch -> publishes every entry in the fixture', async () => {
+  const kv = makeKV();
+  stub(() => ok(SAMPLE, { etag: 'W/"abc"' }));
+  const h = await runPoll(baseEnv(kv));
+  assert.equal(h.last_run_result, 'published');
+  assert.equal(h.receiver_count, SAMPLE_COUNT);
+  const payload = JSON.parse(kv.store.get('directory:payload'));
+  assert.equal(payload.receivers.length, SAMPLE_COUNT);
+  assert.equal(JSON.parse(kv.store.get('directory:status')).etag, 'W/"abc"');
+});
+
+// 3. Secret is presented as configured.
+await t('secret goes on the query string as configured', async () => {
+  const kv = makeKV();
+  stub(() => ok(SAMPLE));
+  await runPoll(baseEnv(kv));
+  assert.equal(new URL(calls[0].url).searchParams.get('key'), 'shhh');
+});
+
+// 4. 304 keeps the old list.
+await t('304 -> not-modified, payload untouched', async () => {
+  const kv = makeKV({
+    'directory:payload': JSON.stringify({ receivers: [1, 2, 3] }),
+    'directory:status': JSON.stringify({ receiver_count: SAMPLE_COUNT, etag: 'W/"abc"' }),
+  });
+  stub(() => new Response(null, { status: 304 }));
+  const h = await runPoll(baseEnv(kv));
+  assert.equal(h.last_run_result, 'not-modified');
+  assert.equal(h.consecutive_failures, 0);
+  assert.equal(JSON.parse(kv.store.get('directory:payload')).receivers.length, 3);
+});
+
+// 5. The guard that matters most.
+await t('truncated page -> needs-review, old list preserved', async () => {
+  // The guard compares a RATIO against the last published count, so the
+  // baseline is the fixture's own length — a small fixture exercises it
+  // identically, and deriving it stops this rotting the way the old 870 did.
+  const kv = makeKV({
+    'directory:payload': JSON.stringify({ receivers: new Array(SAMPLE_COUNT).fill(0) }),
+    'directory:status': JSON.stringify({ receiver_count: SAMPLE_COUNT }),
+  });
+  const firstTwo = SAMPLE.split("<div class='cl-entry").slice(0, 3).join("<div class='cl-entry");
+  stub(() => ok(firstTwo));
+  const h = await runPoll(baseEnv(kv));
+  assert.equal(h.last_run_result, 'failed');
+  assert.equal(h.fault, 'needs-review');
+  assert.equal(JSON.parse(kv.store.get('directory:payload')).receivers.length, SAMPLE_COUNT,
+    'old list was overwritten');
+});
+
+// 6. Redirects are recorded, never followed.
+await t('redirect -> upstream-change, not followed', async () => {
+  const kv = makeKV();
+  stub(() => new Response(null, { status: 302, headers: { location: 'https://elsewhere.example/' } }));
+  const h = await runPoll(baseEnv(kv));
+  assert.equal(h.fault, 'upstream-change');
+  assert.equal(h.last_run_detail, 'https://elsewhere.example/');
+  assert.equal(calls.length, 1, 'retried a redirect');
+});
+
+// 7. The gate page returns 200, so only the body gives it away.
+await t('gate page -> auth fault despite HTTP 200', async () => {
+  const kv = makeKV();
+  stub(() => ok('<html><body>Please click to agree and continue</body></html>'));
+  const h = await runPoll(baseEnv(kv));
+  assert.equal(h.fault, 'auth');
+  assert.equal(h.last_run_reason, 'gate-page');
+});
+
+// 8. 5xx retries, 4xx does not.
+await t('500 retries to the limit; 403 gives up at once', async () => {
+  const kv = makeKV();
+  stub(() => new Response('err', { status: 500 }));
+  let h = await runPoll(baseEnv(kv));
+  assert.equal(h.last_run_attempts, 3, 'expected 3 attempts on 5xx');
+  assert.equal(h.fault, 'origin');
+  stub(() => new Response('denied', { status: 403 }));
+  h = await runPoll(baseEnv(kv));
+  assert.equal(calls.length, 1, 'retried a 403');
+  assert.equal(h.last_run_detail, '403');
+});
+
+// 9. History is bounded and newest-first, matching the page's SLOTS.
+await t('history caps at 20, newest first', async () => {
+  const kv = makeKV();
+  stub(() => ok(SAMPLE));
+  let h;
+  for (let i = 0; i < 25; i++) h = await runPoll(baseEnv(kv), new Date(Date.UTC(2026, 8, 5, i % 24)));
+  assert.equal(h.recent.length, 20);
+  assert.ok(h.recent[0].at > h.recent[1].at || h.recent.length === 20);
+});
+
+// 10. The weak-validator bug: Cloudflare hands us W/"x" for a gzip response the
+// origin ETags as "x". Sending the W/ form back matches nothing and we
+// republish an identical list every hour.
+await t('If-None-Match is sent without the W/ prefix', async () => {
+  const kv = makeKV({ 'directory:status': JSON.stringify({ receiver_count: SAMPLE_COUNT, etag: 'W/"abc123"' }) });
+  stub(() => new Response(null, { status: 304 }));
+  await runPoll(baseEnv(kv));
+  assert.equal(calls[0].headers.get('if-none-match'), '"abc123"');
+});
+
+// 11. A strong ETag must survive untouched.
+await t('a strong ETag is sent verbatim', async () => {
+  const kv = makeKV({ 'directory:status': JSON.stringify({ receiver_count: SAMPLE_COUNT, etag: '"plain"' }) });
+  stub(() => new Response(null, { status: 304 }));
+  await runPoll(baseEnv(kv));
+  assert.equal(calls[0].headers.get('if-none-match'), '"plain"');
+});
+
+// 12. The auth transport is a Worker secret like the value, so a deploy can be
+// half-configured. That is OUR mistake: it must be reported as a mirror fault
+// rather than an origin one, and must not spend a single request — let alone
+// three retries — discovering it on his server.
+await t('missing auth transport -> mirror fault, zero origin requests', async () => {
+  const kv = makeKV();
+  stub(() => ok('should never be called'));
+  const h = await runPoll(baseEnv(kv, { KIWI_AUTH_MODE: '' }));
+  assert.equal(h.last_run_result, 'failed');
+  assert.equal(h.fault, 'mirror');
+  assert.equal(h.last_run_reason, 'auth-misconfigured');
+  assert.equal(h.last_run_attempts, 0);
+  assert.equal(calls.length, 0, 'made ' + calls.length + ' origin requests');
+});
+
+for (const [s, n] of results) console.log(s === 'PASS' ? '  ok   ' + n : '  FAIL ' + n);
+const failed = results.filter(([s]) => s === 'FAIL').length;
+console.log('\n' + (results.length - failed) + '/' + results.length + ' passed');
+process.exit(failed ? 1 : 0);

--- a/tools/kiwi-mirror-worker/wrangler.toml
+++ b/tools/kiwi-mirror-worker/wrangler.toml
@@ -1,0 +1,47 @@
+name = "kiwi-directory-mirror"
+main = "src/index.js"
+compatibility_date = "2026-09-01"
+
+# Both hostnames are served by this one Worker; it routes on Host. Custom
+# domains create and manage their own DNS records in the aethersdr.com zone.
+[[routes]]
+pattern = "cdn.aethersdr.com"
+custom_domain = true
+
+[[routes]]
+pattern = "kiwi-status.aethersdr.com"
+custom_domain = true
+
+# Hourly, on the hour. Best-effort on the free plan - the status page treats
+# 2.5 missed polls as "nothing is running".
+[triggers]
+crons = ["0 * * * *"]
+
+[[kv_namespaces]]
+binding = "KIWI"
+id = "64e9e1692480449eba36b671e92a829d"
+
+[vars]
+KIWI_SOURCE_URL = "https://files.kiwisdr.com/public/"
+KIWI_CDN_HOST = "cdn.aethersdr.com"
+KIWI_STATUS_HOST = "kiwi-status.aethersdr.com"
+KIWI_USER_AGENT = "AetherSDR-directory-mirror/1.0 (+https://kiwi-status.aethersdr.com)"
+
+# A poll returning fewer than this fraction of the last published count parks
+# the mirror on the old list and asks for a person. The origin has served
+# truncated pages before, and publishing one erases the directory for everyone.
+KIWI_MIN_ENTRIES_FRACTION = "0.5"
+
+# What we advertise to clients in status.json. Deliberately looser than the
+# operator alarm, so we hear about staleness before clients act on it.
+KIWI_STALE_AFTER_MINUTES = "360"
+
+# The origin's auth transport (KIWI_AUTH_MODE, KIWI_AUTH_NAME) and the secret
+# itself (KIWI_SECRET) are all Worker secrets, set with `wrangler secret put`.
+# Not because the transport is a credential — it is not, and knowing it grants
+# nobody access — but because this repository is public and the arrangement with
+# the KiwiSDR maintainer is not. There is no upside to publishing it.
+#
+# The Worker refuses to poll unless all three are set; there is deliberately no
+# default, because a default in public source would tell readers the wrong thing
+# just as loudly as the real value would tell them the right one.


### PR DESCRIPTION
> **Stacked on #5445** (base is `feat/kiwi-cdn-mirror`, not `main`) so the
> cross-links to `docs/kiwi-json-schema.md` resolve — that file is added by
> #5445 and does not exist on `main`. **Merge #5445 first.**
>
> Both PRs are gated on **#5447**, where this answers question 4 (ruled).

## Why

`KiwiPublicDirectory::kSupportedSchema` pins the client to `kiwi.json` schema 1.
#5445 wrote that contract down as `docs/kiwi-json-schema.md`, but the *producer*
— the Cloudflare Worker that pulls `kiwisdr.com/public` hourly and emits the
payload — lived outside this repository. So the contract had a reviewable
consumer and an unreviewable producer, which is most of what the code review on
#5445 objected to.

This puts them side by side. Changing what `src/parse.js` emits and bumping
`kSupportedSchema` are now the same PR, under the same review.

## What's here

`tools/kiwi-mirror-worker/` — dependency-free JS, no lockfile.

| File | What |
|---|---|
| `src/index.js` | Cron poll, origin fetch + auth, KV publish, `Host` routing |
| `src/parse.js` | **The producer side of the schema contract** — HTML → typed JSON |
| `src/status-page.js` | `kiwi-status.aethersdr.com`, for humans |
| `test/poll.test.mjs` | 12 cases (see below) |
| `test/fixtures/directory.html` | 21-entry slice of a real origin page, 44 KB |

Copied as a working tree, not a subtree merge: upstream had nothing worth
preserving in its history, and grafting an unrelated root buys nothing. Three
scratch files committed upstream by accident (`h2.txt`, `k2.json`, `sched.out`)
are not vendored.

## The deployed Worker, not the pre-production one

The first push here vendored a stale copy. Merging it would have made this
repository authoritatively wrong about its own producer — the exact failure this
PR exists to prevent. Corrected against what is deployed:

**The conditional GET never worked.** The origin sends a strong ETag and honours
`If-None-Match`, but it serves `content-encoding: gzip` and the Workers runtime
decompresses on the way in, so Cloudflare hands back a *weakened* validator:
`W/"fc556…"` where the origin holds `"fc556…"`. Sending that back matches
nothing — the origin compares strictly, answers `200`, and the mirror
republishes an identical ~800 KB list **every hour** while `not-modified` never
appears. It also made the frozen-mirror alarm (which counts consecutive 304s)
permanently unreachable, so a genuinely stuck mirror would never have been
caught. `originRequest()` now strips the `W/` prefix. Verified live: a poll
against unchanged content records `not-modified` where it previously always
recorded `published`.

**The auth transport was a guess, and it was wrong.** Now verified against the
live origin.

## The transport stays out of this repository

`aethersdr/AetherSDR` is public; the arrangement with the KiwiSDR maintainer is
not. The transport is **not a credential** — knowing it grants nobody access,
and `KIWI_SECRET` remains a Worker secret regardless — but there is no upside to
publishing the mechanism of a private arrangement, so it is treated as
need-to-know.

`KIWI_AUTH_MODE` and `KIWI_AUTH_NAME` therefore join `KIWI_SECRET` as Worker
secrets and are gone from `wrangler.toml`. `originRequest()` has **no `||`
fallbacks**: a wrong default in public source discloses as confidently as a
right one, and does it silently — the Worker would poll with a guess and blame
the origin for refusing it. `pollOrigin()` refuses a missing transport before
the retry loop as `fault: 'mirror'`, `reason: 'auth-misconfigured'`, so a
half-configured deploy costs his server **zero** requests instead of three
retries. The status page's "This one is ours" panel names the fix.

### ⚠️ Deploy step changed

```sh
wrangler secret put KIWI_SECRET
wrangler secret put KIWI_AUTH_MODE   # new
wrangler secret put KIWI_AUTH_NAME   # new
```

The Worker refuses to poll until all three are set.

## Fixture: 1.6 MB → 44 KB

The original was a complete scrape of the maintainer's directory — 870
operators' names, locations, GPS coordinates and URLs — committed permanently to
a public repo that will be cloned indefinitely. Not a leak (that directory is
public), but a permanent republication of a third party's dataset, and poor form
given the mirror exists *because* he asked this project to reduce its footprint
on him.

My earlier reason for keeping it whole was wrong: the truncation guard compares
a **ratio** against the last published count, so a small fixture exercises it
identically.

It is now 21 real entries covering **more** than the full page did:

| Case | Old 870-entry fixture | Now |
|---|---|---|
| `ext_api = 0` → `Disabled` | ✅ | ✅ ×5 |
| `0 < ext_api < users_max` → `Limited` | ✅ | ✅ ×7 |
| `ext_api >= users_max` → `Open` | ✅ | ✅ ×6 (incl. the `==` boundary) |
| **`ext_api` key absent** → `Unknown` | ✅ but not isolated | ✅ ×3 |
| `flagged` (`cl-err-entry`) | ❌ **none in the snapshot** | ✅ |
| `offline=yes` | ❌ none | ✅ |
| multi-range `bands` | ❌ none | ✅ |
| 3-value `snr` | ❌ none | ✅ |

Two tests hardcoded `870` against it. Both now derive the count from the
fixture, so this cannot rot again the way it just did.

## Secret exposure — re-audited

- **`KIWI_SECRET` never appears as a literal.** Read only as `env.KIWI_SECRET`;
  the one value in the tree is the dummy `'shhh'` in the test.
- **The real transport appears nowhere** — grep-verified across the vendored
  tree. The test's `KIWI_AUTH_MODE: 'query'` is a fixture value and is not the
  deployed mode.
- **No Cloudflare API token, no `account_id`, no `.dev.vars`/`.env`.**
- **Upstream history scanned blob-by-blob** for an assigned
  `secret|token|key|password` — nothing.
- Seeded payload snapshots stay ignored via the vendored `.gitignore`.

The KV namespace id in `wrangler.toml` becomes public. It is an identifier, not
a credential — useless without account auth.

## Deliberately not done

- **No CI deploy.** A `wrangler deploy` action needs `CLOUDFLARE_API_TOKEN` as a
  repository secret — a real new credential surface, and the only part of this
  work that could leak something. Not worth it to save one `npm run deploy`.
- **No `CHANGELOG.md` entry.** This project touches that file at release prep
  only.

## Staleness is advisory, and now locked

Folded in from `fix/kiwi-staleness-advisory`. It belongs here rather than in its
own PR: the rule is a term of the schema contract, and it edits the same
`docs/kiwi-json-schema.md` section this PR already touches.

The client already behaved correctly, but only as a consequence of how the
status line happened to be written — nothing stated the rule and nothing would
have caught its loss.

A receiver directory ages gracefully. Receivers do not move, so a two-day-old
list is still almost entirely correct, and a user browsing it is far better
served than one shown an empty dialog. The realistic cause of a stale list is an
outage at the **origin** — an expired certificate, a host down — during which the
mirror keeps serving its last good copy exactly as designed. Gating on age would
take the KiwiSDR maintainer's outage and convert it into an AetherSDR outage,
which is backwards: the mirror exists to absorb his problems, not amplify them.

- `kStaleAfterMinutes` is documented as advisory-only, with the reasoning and an
  explicit statement that no code path may make it withhold the list.
- `KiwiDirectoryParse::ageMinutes()` — advisory by construction, with `ok()`
  deliberately independent of it, returning `-1` rather than `0` when the mirror
  published nothing usable.
- The picker's status-line comment states what it does **not** do: no row
  removed, no button disabled, no error in place of the list.
- `docs/kiwi-json-schema.md` states the same rule for the **producer**, because
  the mirror advertises `stale_after_minutes` on its status document and someone
  will eventually wonder whether the client should honour it. It should not.

Four cases lock it: a years-old list, an absent `fetched_at` and a malformed one
all still parse and still yield every receiver, and age reports `-1` not `0`.
Confirmed non-vacuous by adding the exact gate the invariant forbids — the suite
fails on `a years-old list must still parse — age is advice, not a gate`.

Client suite 348/348.

## Testing

`npm test` from `tools/kiwi-mirror-worker/` — **12/12 pass**: no-secret, happy
path, secret transport, 304, truncated page, redirect, gate page, 5xx-retry vs
4xx-give-up, history cap, weak-validator strip, strong-ETag passthrough, and
auth-misconfigured. Bare `node --test` fails — the fixture path is a required
argv.

Nothing under `src/`, so the C++ build and `check_engine_boundary.py` are
unaffected. CodeQL's existing `Analyze (javascript-typescript)` job now scans
this code for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
