### PR TITLE
Add observe-only headless radio discovery catalogue (#3849)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,6 +478,14 @@ observe-only local handshake/capability service, and a QtWidgets-free
 `resource.subscribe`/`resource.unsubscribe`, per-resource revisions, bounded
 coalescing/session resync, and an independent local-socket hard disconnect cap
 are live over the current-user local transport.
+The headless daemon also owns a bounded, observe-only `radioCatalogue` through
+the normalized `RadioDiscoverySource` seam. Native discovery adapters stay under
+`src/core/backends/`; desktop discovery/autoconnect is unchanged. Discovery is
+passive by default: `--discover-local` opts into Flex/HL2/ANAN LAN discovery and
+available RTL-SDR USB enumeration; `--discover-sim` publishes only demo metadata.
+Neither option connects a radio. Icom manual setup, SmartLink and external
+directories are excluded. Catalogue fields and lifecycle are specified in
+`docs/aetherd-control-resource-v1-catalogue.md`.
 Sessions now require explicit trusted authorization; the local transport grants
 observe permission, and reads/subscriptions enforce it. The revocation hook
 discards pending observations and terminates local delivery; no wire or daemon

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -687,10 +687,10 @@ set(CORE_SOURCES
     src/core/control/ControlSession.cpp       # subscriptions and bounded event queues
     src/core/control/ControlService.cpp       # aetherd v1 observe-only dispatch
     src/core/control/RadioResourceAdapter.cpp # normalized model resources
-    src/core/control/RadioCatalogue.cpp      # bounded normalized discovery resource
-    src/core/discovery/RadioDiscoverySource.h # socket-free discovery interface
-    src/core/backends/LocalRadioDiscoverySource.cpp # native discovery below vendor seam
+    src/core/control/RadioCatalogue.cpp       # bounded normalized discovery resource
     src/core/control/LocalControlServer.cpp   # current-user local transport
+    src/core/discovery/RadioDiscoverySource.h  # socket-free discovery interface (AUTOMOC)
+    src/core/backends/LocalRadioDiscoverySource.cpp  # native discovery below the vendor seam
     src/core/backends/MemoryWireCodec.cpp    # memory kv-set decode, shared by Flex + local bank
     src/core/backends/flex/FlexBackend.cpp   # aetherd RFC step 2.2 (§5.5)
     src/core/backends/sim/SimBackend.cpp     # demo mode — 2nd IRadioBackend (RFC #4288)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -687,6 +687,9 @@ set(CORE_SOURCES
     src/core/control/ControlSession.cpp       # subscriptions and bounded event queues
     src/core/control/ControlService.cpp       # aetherd v1 observe-only dispatch
     src/core/control/RadioResourceAdapter.cpp # normalized model resources
+    src/core/control/RadioCatalogue.cpp      # bounded normalized discovery resource
+    src/core/discovery/RadioDiscoverySource.h # socket-free discovery interface
+    src/core/backends/LocalRadioDiscoverySource.cpp # native discovery below vendor seam
     src/core/control/LocalControlServer.cpp   # current-user local transport
     src/core/backends/MemoryWireCodec.cpp    # memory kv-set decode, shared by Flex + local bank
     src/core/backends/flex/FlexBackend.cpp   # aetherd RFC step 2.2 (§5.5)

--- a/docs/aetherd-control-protocol-v1-design.md
+++ b/docs/aetherd-control-protocol-v1-design.md
@@ -174,6 +174,7 @@ unambiguous.
 V1 begins with the smallest useful canonical set:
 
 - `server` — build/protocol versions, health and transport state;
+- `radioCatalogue` — bounded read-only discovery identities and endpoints;
 - `radioSession` — identity, family, connection state and capabilities;
 - `slice` — frequency, mode, filter, receive controls and ownership;
 - `panadapter` — center, bandwidth, dBm range and display cadence;
@@ -414,6 +415,8 @@ and are reported privately rather than demonstrated against public radios.
    `aetherd` target with a CI assertion that it cannot link QtWidgets.
 3. **Read-only service:** implement negotiation, auth, snapshots, revisions,
    subscriptions, limits and read-only resources over the local transport.
+   The headless discovery catalogue is also observe-only: daemon startup flags
+   opt into LAN/USB discovery or simulator metadata, never radio connection.
 4. **Non-TX control:** add authenticated typed connect/slice/pan methods and
    prove authoritative echo behavior across every supported backend, currently
    Flex, HL2, Icom, Sim, ANAN and RTL-SDR.

--- a/docs/aetherd-control-resource-v1-catalogue.md
+++ b/docs/aetherd-control-resource-v1-catalogue.md
@@ -6,7 +6,7 @@ slice of RFC #3849. It supplements
 the envelope, limits, errors, authentication, and TX rules in that document
 remain normative.
 
-Only the four resource types below exist in this slice. `meter` and
+Only the five resource types below exist in this slice. `meter` and
 `transmitState` remain unimplemented. No method in this catalogue mutates a
 model or can reach a radio backend intent.
 
@@ -16,6 +16,7 @@ An exact identity has one of these shapes:
 
 ```json
 {"type":"server"}
+{"type":"radioCatalogue"}
 {"type":"radioSession","id":"radio-1"}
 {"type":"slice","radioSession":"radio-1","id":"0"}
 {"type":"panadapter","radioSession":"radio-1","id":"0x40000000"}
@@ -25,6 +26,8 @@ An exact identity has one of these shapes:
 an omitted `id` as an all-current-and-future selector for `radioSession`,
 `slice`, or `panadapter`; `slice` and `panadapter` still require
 `radioSession`. Unknown fields and unsupported resource types are rejected.
+`server` and `radioCatalogue` are singletons: neither accepts `id` or
+`radioSession`, including empty or null values.
 
 ## Methods
 
@@ -132,6 +135,64 @@ written; after reconnecting it must establish a new session and baseline.
 
 No endpoint path, process environment, hostname, or filesystem value is
 exported.
+
+### `radioCatalogue`
+
+The daemon owns this singleton through `RadioCatalogue`. It is readable with
+the same `observe` grant as the other resources; `radioCatalogue.read` is
+advertised only while an adapter has published the singleton. Other service
+embedders need not provide a discovery source. No new wire method is added.
+
+- `running`: the catalogue's started/not-stopped lifecycle, **not** a claim
+  that every native source successfully bound a socket or found a device.
+- `sources`: sorted enabled source families. This records startup configuration
+  and build availability, not scan health or the families currently visible.
+- `limited`: a valid new identity was dropped at capacity. It stays true until
+  a new catalogue instance is created, even after entries are lost or stopped.
+- `maxEntries`: 64.
+- `entries`: complete list, sorted by family then serial, of objects with:
+  - `id`: opaque stable identity derived from family plus serial; independent
+    of address, nickname, and arrival order. It is not a resource selector or
+    a connection authorization. Native sources with no unique serial (such as
+    RTL-SDR's USB-index fallback) retain their existing identity limitations.
+  - `family`: 1–16 ASCII lowercase letters/digits, starting with a letter.
+  - `serial`: nonempty, at most 128 UTF-16 code units.
+  - `name`, `model`, `nickname`, `version`: display observations, each at most
+    128 UTF-16 code units; empty means unavailable. Native discovery's existing
+    client-owned nickname behavior is retained for families that use it.
+  - `transport`: `lan`, `usb`, or `sim`.
+  - `address`, `port`: numeric IP address (at most 64 code units) and port
+    1–65535 for LAN; empty address and zero port for USB/simulator.
+  - `inUse`: native discovery's advisory busy observation, not ownership or a
+    control grant.
+
+Text must be valid UTF-16 without NUL or Unicode control characters. Invalid
+observations are discarded, not truncated into potentially colliding identities.
+No credentials, raw packets, connected-client identities, or saved connection
+entries are projected. The entry and string bounds keep the complete catalogue
+within the existing message limit. Unchanged duplicate announcements consume
+no revision; a changed value or loss publishes the complete new catalogue.
+Existing identities can still update at capacity, and newly freed capacity can
+accept another observation. `limited` discloses that the list may be incomplete.
+
+Daemon startup is passive by default (`sources: []`, `entries: []`).
+`--discover-local` explicitly enables existing Flex/HL2/ANAN LAN discovery and
+RTL-SDR USB enumeration when built in. `--discover-sim` independently publishes
+the existing simulator identity without constructing a radio backend or scanning
+LAN/USB. The flags may be combined. No discovered radio is connected. Icom's
+manual address/credentials, SmartLink and external directories are outside this
+slice; desktop discovery and autoconnect remain unchanged.
+
+Only `--discover-local` initializes the daemon's `AppSettings` store, before
+model/discovery consumers are constructed, so client-owned HL2/ANAN Identity
+nicknames remain available. This uses the normal settings load, migration,
+recovery and read-only protections; it does not create discovery entries from
+saved configuration. Passive and simulator-only startup do not load the store.
+
+One adapter/source instance has one lifecycle. `start()` is idempotent;
+`stop()` is terminal, clears observations and ignores late callbacks. Disposal
+removes the singleton. These are internal lifecycle calls, never protocol
+commands. Create a new instance to restart discovery.
 
 ### `radioSession`
 

--- a/docs/aetherd-control-resource-v1-catalogue.md
+++ b/docs/aetherd-control-resource-v1-catalogue.md
@@ -159,7 +159,10 @@ embedders need not provide a discovery source. No new wire method is added.
   - `serial`: nonempty, at most 128 UTF-16 code units.
   - `name`, `model`, `nickname`, `version`: display observations, each at most
     128 UTF-16 code units; empty means unavailable. Native discovery's existing
-    client-owned nickname behavior is retained for families that use it.
+    client-owned nickname behavior is retained for families that use it. Which
+    of these a family populates differs — a Flex publishes an empty `name`, and
+    the simulator an empty `nickname` — so a client renders the first nonempty
+    of `nickname`, `name`, `model`, and falls back to `serial`.
   - `transport`: `lan`, `usb`, or `sim`.
   - `address`, `port`: numeric IP address (at most 64 code units) and port
     1–65535 for LAN; empty address and zero port for USB/simulator.

--- a/docs/aetherd-control-resource-v1-catalogue.md
+++ b/docs/aetherd-control-resource-v1-catalogue.md
@@ -190,7 +190,12 @@ Only `--discover-local` initializes the daemon's `AppSettings` store, before
 model/discovery consumers are constructed, so client-owned HL2/ANAN Identity
 nicknames remain available. This uses the normal settings load, migration,
 recovery and read-only protections; it does not create discovery entries from
-saved configuration. Passive and simulator-only startup do not load the store.
+saved configuration. The flag is not inert against the store, though: the
+daemon and the desktop share one store, so on a machine where the desktop has
+never run, `--discover-local` is what creates `AetherSDR.db` and claims the
+one-shot legacy migration. The store is loaded only after the daemon owns its
+local endpoint, so a daemon that fails to listen never touches it. Passive and
+simulator-only startup do not load the store at all.
 
 One adapter/source instance has one lifecycle. `start()` is idempotent;
 `stop()` is terminal, clears observations and ignores late callbacks. Disposal

--- a/docs/architecture/aetherd-touchpoint-tags.json
+++ b/docs/architecture/aetherd-touchpoint-tags.json
@@ -1,4 +1,16 @@
 {
+ "core/control/RadioCatalogue.h": {
+  "tag": "universal",
+  "note": "Bounded read-only discovery resource projected from normalized observations; no vendor wire types or connection intents.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/discovery/RadioDiscoverySource.h": {
+  "tag": "universal",
+  "note": "QtCore normalized discovery/lifecycle seam; native implementations and vendor payloads stay below the backend boundary.",
+  "split": "",
+  "confidence": "high"
+ },
  "core/AcomConnection.h": {
   "tag": "peripheral(acom)",
   "note": "Direct serial/ser2net client for the ACOM S-series amplifier line (600S primary target, protocol shared across 500S/700S/1200S/2020S) — a standalone RS-232 accessory with no FlexRadio awareness at all, same precedent as core/PgxlConnection.h and core/TgxlConnection.h. Not radio-family wire; a peripheral accessory, NOT behind the IRadioBackend radio seam. See docs/architecture/acom-600s-amplifier-design.md.",

--- a/src/aetherd/DiscoveryStartup.h
+++ b/src/aetherd/DiscoveryStartup.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "core/AppSettings.h"
+#include "core/discovery/RadioDiscoverySource.h"
+
+namespace AetherSDR::aetherd {
+
+// Called once by the daemon at startup, before constructing model consumers.
+// Native discovery reads client-owned Identity nicknames. Use the normal
+// settings lifecycle (including failed/read-only protection), but leave passive
+// and simulator-only startup independent of the operator's settings store.
+[[nodiscard]] inline std::unique_ptr<RadioDiscoverySource> makeDiscoverySource(
+    LocalDiscoveryOptions options)
+{
+    if (options.local) {
+        AppSettings::instance().load();
+    }
+    return makeLocalRadioDiscoverySource(options);
+}
+
+} // namespace AetherSDR::aetherd

--- a/src/aetherd/main.cpp
+++ b/src/aetherd/main.cpp
@@ -1,10 +1,14 @@
+#include "DiscoveryStartup.h"
 #include "core/control/LocalControlServer.h"
 #include "core/control/RadioResourceAdapter.h"
+#include "core/control/RadioCatalogue.h"
 #include "models/RadioSession.h"
 
 #include <QCommandLineParser>
 #include <QCoreApplication>
 #include <QTextStream>
+
+#include <utility>
 
 int main(int argc, char* argv[])
 {
@@ -22,11 +26,24 @@ int main(int argc, char* argv[])
         QStringLiteral("Current-user local socket name."),
         QStringLiteral("name"), QStringLiteral("aetherd-v1"));
     parser.addOption(socketOption);
+    const QCommandLineOption localDiscoveryOption(
+        QStringLiteral("discover-local"),
+        QStringLiteral("Enable LAN discovery and available RTL-SDR USB enumeration; never connect."));
+    const QCommandLineOption simDiscoveryOption(
+        QStringLiteral("discover-sim"),
+        QStringLiteral("Publish the simulator discovery identity without accessing radio hardware."));
+    parser.addOption(localDiscoveryOption);
+    parser.addOption(simDiscoveryOption);
     parser.process(app);
 
+    std::unique_ptr<AetherSDR::RadioDiscoverySource> discoverySource =
+        AetherSDR::aetherd::makeDiscoverySource(
+            {parser.isSet(localDiscoveryOption), parser.isSet(simDiscoveryOption)});
     AetherSDR::RadioSession radioSession;
     radioSession.setSessionId(1);
     AetherSDR::control::LocalControlServer server;
+    AetherSDR::control::RadioCatalogue catalogue(
+        std::move(discoverySource), &server.resourceStore());
     [[maybe_unused]] AetherSDR::control::RadioResourceAdapter resources(
         &radioSession.radioModel(), &server.resourceStore(),
         QStringLiteral("radio-1"));
@@ -35,5 +52,6 @@ int main(int argc, char* argv[])
                             << parser.value(socketOption) << "'\n";
         return 1;
     }
+    catalogue.start();
     return app.exec();
 }

--- a/src/aetherd/main.cpp
+++ b/src/aetherd/main.cpp
@@ -8,8 +8,6 @@
 #include <QCoreApplication>
 #include <QTextStream>
 
-#include <utility>
-
 int main(int argc, char* argv[])
 {
     QCoreApplication app(argc, argv);
@@ -36,14 +34,9 @@ int main(int argc, char* argv[])
     parser.addOption(simDiscoveryOption);
     parser.process(app);
 
-    std::unique_ptr<AetherSDR::RadioDiscoverySource> discoverySource =
-        AetherSDR::aetherd::makeDiscoverySource(
-            {parser.isSet(localDiscoveryOption), parser.isSet(simDiscoveryOption)});
     AetherSDR::RadioSession radioSession;
     radioSession.setSessionId(1);
     AetherSDR::control::LocalControlServer server;
-    AetherSDR::control::RadioCatalogue catalogue(
-        std::move(discoverySource), &server.resourceStore());
     [[maybe_unused]] AetherSDR::control::RadioResourceAdapter resources(
         &radioSession.radioModel(), &server.resourceStore(),
         QStringLiteral("radio-1"));
@@ -52,6 +45,13 @@ int main(int argc, char* argv[])
                             << parser.value(socketOption) << "'\n";
         return 1;
     }
+    // Constructed only once the endpoint is ours: makeDiscoverySource() loads
+    // the shared settings store for --discover-local, and a daemon that never
+    // serves a request must not create or migrate the operator's store.
+    AetherSDR::control::RadioCatalogue catalogue(
+        AetherSDR::aetherd::makeDiscoverySource(
+            {parser.isSet(localDiscoveryOption), parser.isSet(simDiscoveryOption)}),
+        &server.resourceStore());
     catalogue.start();
     return app.exec();
 }

--- a/src/core/backends/LocalRadioDiscoveryMapping.h
+++ b/src/core/backends/LocalRadioDiscoveryMapping.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "core/RadioDiscovery.h"   // RadioInfo
+#include "core/discovery/RadioDiscoverySource.h"
+
+namespace AetherSDR::discovery {
+
+// The single RadioInfo -> DiscoveredRadio projection every native adapter
+// uses. Hoisted out of LocalRadioDiscoverySource so it is reachable from a
+// socket-free test: RadioCatalogue rejects a malformed endpoint silently, so a
+// family that stopped populating `port` would just vanish from the catalogue,
+// indistinguishable from "no radio on the LAN". A pure function of the
+// observation plus its family/transport labels — no vendor payload crosses the
+// seam, and nothing here can reach a radio command.
+[[nodiscard]] inline DiscoveredRadio normalize(const RadioInfo& info, const QString& family,
+                                              const QString& transport)
+{
+    DiscoveredRadio radio;
+    radio.family = family;
+    radio.serial = info.serial;
+    radio.name = info.name;
+    radio.model = info.model;
+    radio.nickname = info.nickname;
+    radio.version = info.version;
+    radio.transport = transport;
+    if (transport == QStringLiteral("lan")) {
+        // Endpoint fields are LAN-only: RadioCatalogue rejects a USB or
+        // simulator entry that carries either one.
+        radio.address = info.address.toString();
+        radio.port = info.port;
+    }
+    radio.inUse = info.inUse;
+    return radio;
+}
+
+} // namespace AetherSDR::discovery

--- a/src/core/backends/LocalRadioDiscoverySource.cpp
+++ b/src/core/backends/LocalRadioDiscoverySource.cpp
@@ -1,4 +1,4 @@
-#include "core/discovery/RadioDiscoverySource.h"
+#include "core/backends/LocalRadioDiscoveryMapping.h"
 
 #include "core/RadioDiscovery.h"
 #include "core/RtlSdrDiscovery.h"
@@ -82,20 +82,7 @@ private:
             if (!m_running) {
                 return;
             }
-            DiscoveredRadio radio;
-            radio.family = family;
-            radio.serial = info.serial;
-            radio.name = info.name;
-            radio.model = info.model;
-            radio.nickname = info.nickname;
-            radio.version = info.version;
-            radio.transport = transport;
-            if (transport == QStringLiteral("lan")) {
-                radio.address = info.address.toString();
-                radio.port = info.port;
-            }
-            radio.inUse = info.inUse;
-            emit radioChanged(radio);
+            emit radioChanged(discovery::normalize(info, family, transport));
         };
         connect(source, &Source::radioDiscovered, this, changed);
         connect(source, &Source::radioUpdated, this, changed);

--- a/src/core/backends/LocalRadioDiscoverySource.cpp
+++ b/src/core/backends/LocalRadioDiscoverySource.cpp
@@ -1,0 +1,125 @@
+#include "core/discovery/RadioDiscoverySource.h"
+
+#include "core/RadioDiscovery.h"
+#include "core/RtlSdrDiscovery.h"
+#include "core/backends/anan/AnanDiscovery.h"
+#include "core/backends/hl2/Hl2Discovery.h"
+#include "core/backends/sim/SimBackend.h"
+
+namespace AetherSDR {
+namespace {
+
+class LocalRadioDiscoverySource final : public RadioDiscoverySource {
+public:
+    explicit LocalRadioDiscoverySource(LocalDiscoveryOptions options) : m_options(options) {}
+    ~LocalRadioDiscoverySource() override { stop(); }
+
+    QStringList enabledSources() const override
+    {
+        QStringList sources;
+        if (m_options.local) {
+            sources = {QStringLiteral("flex"), QStringLiteral("hl2"), QStringLiteral("anan")};
+            if (RtlSdrDiscovery::isAvailable()) {
+                sources.append(QStringLiteral("rtl"));
+            }
+        }
+        if (m_options.simulator) {
+            sources.append(QStringLiteral("sim"));
+        }
+        sources.sort();
+        return sources;
+    }
+
+    void start() override
+    {
+        if (m_started) {
+            return;
+        }
+        m_started = true;
+        m_running = true;
+        if (m_options.local) {
+            m_flex = std::make_unique<RadioDiscovery>();
+            m_hl2 = std::make_unique<hl2::Hl2Discovery>();
+            m_anan = std::make_unique<anan::AnanDiscovery>();
+            wire(m_flex.get(), QStringLiteral("flex"), QStringLiteral("lan"));
+            wire(m_hl2.get(), QStringLiteral("hl2"), QStringLiteral("lan"));
+            wire(m_anan.get(), QStringLiteral("anan"), QStringLiteral("lan"));
+            m_flex->startListening();
+            m_hl2->start();
+            m_anan->start();
+            if (RtlSdrDiscovery::isAvailable()) {
+                m_rtl = std::make_unique<RtlSdrDiscovery>();
+                wire(m_rtl.get(), QStringLiteral("rtl"), QStringLiteral("usb"));
+                m_rtl->start();
+            }
+        }
+        if (m_options.simulator) {
+            DiscoveredRadio demo;
+            demo.family = SimBackend::familyName();
+            demo.serial = SimBackend::demoSerial();
+            demo.name = SimBackend::demoModelName();
+            demo.model = SimBackend::demoModelName();
+            demo.transport = QStringLiteral("sim");
+            emit radioChanged(demo);
+        }
+    }
+
+    void stop() override
+    {
+        m_started = true; // A stopped source is terminal, even before start.
+        m_running = false;
+        if (m_flex) { m_flex->stopListening(); }
+        if (m_hl2) { m_hl2->stop(); }
+        if (m_anan) { m_anan->stop(); }
+        if (m_rtl) { m_rtl->stop(); }
+    }
+
+private:
+    template<typename Source>
+    void wire(Source* source, const QString& family, const QString& transport)
+    {
+        const auto changed = [this, family, transport](const RadioInfo& info) {
+            if (!m_running) {
+                return;
+            }
+            DiscoveredRadio radio;
+            radio.family = family;
+            radio.serial = info.serial;
+            radio.name = info.name;
+            radio.model = info.model;
+            radio.nickname = info.nickname;
+            radio.version = info.version;
+            radio.transport = transport;
+            if (transport == QStringLiteral("lan")) {
+                radio.address = info.address.toString();
+                radio.port = info.port;
+            }
+            radio.inUse = info.inUse;
+            emit radioChanged(radio);
+        };
+        connect(source, &Source::radioDiscovered, this, changed);
+        connect(source, &Source::radioUpdated, this, changed);
+        connect(source, &Source::radioLost, this, [this, family](const QString& serial) {
+            if (m_running) {
+                emit radioLost(family, serial);
+            }
+        });
+    }
+
+    const LocalDiscoveryOptions m_options;
+    bool m_started{false};
+    bool m_running{false};
+    std::unique_ptr<RadioDiscovery> m_flex;
+    std::unique_ptr<hl2::Hl2Discovery> m_hl2;
+    std::unique_ptr<anan::AnanDiscovery> m_anan;
+    std::unique_ptr<RtlSdrDiscovery> m_rtl;
+};
+
+} // namespace
+
+std::unique_ptr<RadioDiscoverySource> makeLocalRadioDiscoverySource(LocalDiscoveryOptions options)
+{
+    return std::make_unique<LocalRadioDiscoverySource>(options);
+}
+
+} // namespace AetherSDR

--- a/src/core/control/ControlService.cpp
+++ b/src/core/control/ControlService.cpp
@@ -45,6 +45,7 @@ std::optional<ProtocolError> parseSelector(
     const QString type = typeValue.toString();
     const QSet<QString> supportedTypes{
         QStringLiteral("server"), QStringLiteral("radioSession"),
+        QStringLiteral("radioCatalogue"),
         QStringLiteral("slice"), QStringLiteral("panadapter")};
     if (!supportedTypes.contains(type)) {
         return ProtocolError{QStringLiteral("request.invalid_params"),
@@ -67,10 +68,10 @@ std::optional<ProtocolError> parseSelector(
 
     const QString radioSession = radioSessionValue.toString();
     const QString id = idValue.toString();
-    if (type == QStringLiteral("server")) {
+    if (type == QStringLiteral("server") || type == QStringLiteral("radioCatalogue")) {
         if (!radioSessionValue.isUndefined() || !idValue.isUndefined()) {
             return ProtocolError{QStringLiteral("request.invalid_params"),
-                                 QStringLiteral("server selector takes only type"), {}, false};
+                                 QStringLiteral("singleton selector takes only type"), {}, false};
         }
     } else if (type == QStringLiteral("radioSession")) {
         if (!radioSessionValue.isUndefined() || (!wildcardAllowed && id.isEmpty())) {
@@ -259,7 +260,7 @@ QJsonObject ControlService::capabilities(const ControlSession& session) const
 {
     const bool observe = session.canObserve();
     const QJsonArray grants = observe ? QJsonArray{QStringLiteral("observe")} : QJsonArray{};
-    const QJsonArray available = observe ? QJsonArray{
+    QJsonArray available = observe ? QJsonArray{
         QStringLiteral("server.read"),
         QStringLiteral("radioSession.read"),
         QStringLiteral("slice.read"),
@@ -267,6 +268,9 @@ QJsonObject ControlService::capabilities(const ControlSession& session) const
         QStringLiteral("resource.get"),
         QStringLiteral("resource.subscribe"),
         QStringLiteral("resource.unsubscribe")} : QJsonArray{};
+    if (observe && m_resources->get({QStringLiteral("radioCatalogue"), {}, {}})) {
+        available.append(QStringLiteral("radioCatalogue.read"));
+    }
     return {
         {QStringLiteral("sessionId"), session.sessionId()},
         {QStringLiteral("version"), 1},

--- a/src/core/control/RadioCatalogue.cpp
+++ b/src/core/control/RadioCatalogue.cpp
@@ -3,10 +3,14 @@
 #include <QCryptographicHash>
 #include <QHostAddress>
 #include <QJsonArray>
+#include <QLoggingCategory>
 
 #include <utility>
 
 namespace AetherSDR::control {
+
+Q_LOGGING_CATEGORY(lcRadioCatalogue, "aether.control.catalogue")
+
 namespace {
 
 const ResourceAddress kCatalogue{QStringLiteral("radioCatalogue"), {}, {}};
@@ -52,7 +56,15 @@ RadioCatalogue::RadioCatalogue(std::unique_ptr<RadioDiscoverySource> source,
                                ControlResourceStore* resources, QObject* parent)
     : QObject(parent), m_source(std::move(source)), m_resources(resources)
 {
-    Q_ASSERT(m_source && m_resources && m_source->thread() == thread());
+    Q_ASSERT(m_source && m_resources);
+    // Reported in release builds too, the same way ControlSession refuses an
+    // off-thread transport binding: a Q_ASSERT vanishes in exactly the build
+    // where an embedder's off-thread source would drive start()/stop() across
+    // a thread boundary unnoticed.
+    if (m_source->thread() != thread()) {
+        qCWarning(lcRadioCatalogue)
+            << "Discovery source must live on the catalogue's owning thread";
+    }
     connect(m_source.get(), &RadioDiscoverySource::radioChanged, this, &RadioCatalogue::upsert);
     connect(m_source.get(), &RadioDiscoverySource::radioLost, this, &RadioCatalogue::remove);
     publish();
@@ -102,8 +114,13 @@ void RadioCatalogue::upsert(const DiscoveredRadio& radio)
     }
     const QString key = identityKey(radio.family, radio.serial);
     if (!m_entries.contains(key) && m_entries.size() >= kMaxEntries) {
-        m_limited = true;
-        publish();
+        // Republishing an already-limited catalogue rebuilds the whole entry
+        // array for a value the store then deduplicates, once per dropped
+        // announcement. Disclose the first drop, then stay quiet.
+        if (!m_limited) {
+            m_limited = true;
+            publish();
+        }
         return;
     }
     const QString id = QString::fromLatin1(

--- a/src/core/control/RadioCatalogue.cpp
+++ b/src/core/control/RadioCatalogue.cpp
@@ -1,0 +1,147 @@
+#include "RadioCatalogue.h"
+
+#include <QCryptographicHash>
+#include <QHostAddress>
+#include <QJsonArray>
+
+#include <utility>
+
+namespace AetherSDR::control {
+namespace {
+
+const ResourceAddress kCatalogue{QStringLiteral("radioCatalogue"), {}, {}};
+
+bool boundedText(const QString& text, qsizetype limit)
+{
+    if (text.size() > limit || !text.isValidUtf16()) {
+        return false;
+    }
+    for (const QChar character : text) {
+        if (character.isNull() || character.category() == QChar::Other_Control) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool validIdentity(const QString& family, const QString& serial)
+{
+    if (family.isEmpty() || family.size() > 16
+        || family.front() < QLatin1Char('a') || family.front() > QLatin1Char('z')
+        || serial.isEmpty()
+        || !boundedText(serial, RadioCatalogue::kMaxTextChars)) {
+        return false;
+    }
+    for (const QChar character : family) {
+        if ((character < QLatin1Char('a') || character > QLatin1Char('z'))
+            && (character < QLatin1Char('0') || character > QLatin1Char('9'))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+QString identityKey(const QString& family, const QString& serial)
+{
+    return family + QChar(0x1f) + serial;
+}
+
+} // namespace
+
+RadioCatalogue::RadioCatalogue(std::unique_ptr<RadioDiscoverySource> source,
+                               ControlResourceStore* resources, QObject* parent)
+    : QObject(parent), m_source(std::move(source)), m_resources(resources)
+{
+    Q_ASSERT(m_source && m_resources && m_source->thread() == thread());
+    connect(m_source.get(), &RadioDiscoverySource::radioChanged, this, &RadioCatalogue::upsert);
+    connect(m_source.get(), &RadioDiscoverySource::radioLost, this, &RadioCatalogue::remove);
+    publish();
+}
+
+RadioCatalogue::~RadioCatalogue()
+{
+    stop();
+    m_resources->remove(kCatalogue);
+}
+
+void RadioCatalogue::start()
+{
+    if (m_started) {
+        return;
+    }
+    m_started = true;
+    m_running = true;
+    publish();
+    m_source->start();
+}
+
+void RadioCatalogue::stop()
+{
+    m_started = true;
+    m_running = false; // Gate callbacks before stopping a source that may emit.
+    m_source->stop();
+    m_entries.clear();
+    publish();
+}
+
+void RadioCatalogue::upsert(const DiscoveredRadio& radio)
+{
+    if (!m_running || !validIdentity(radio.family, radio.serial)
+        || !boundedText(radio.name, kMaxTextChars)
+        || !boundedText(radio.model, kMaxTextChars)
+        || !boundedText(radio.nickname, kMaxTextChars)
+        || !boundedText(radio.version, kMaxTextChars)
+        || !boundedText(radio.address, 64)) {
+        return;
+    }
+    const bool lan = radio.transport == QStringLiteral("lan");
+    if ((!lan && radio.transport != QStringLiteral("usb") && radio.transport != QStringLiteral("sim"))
+        || (lan && (QHostAddress(radio.address).isNull() || radio.port == 0))
+        || (!lan && (!radio.address.isEmpty() || radio.port != 0))) {
+        return;
+    }
+    const QString key = identityKey(radio.family, radio.serial);
+    if (!m_entries.contains(key) && m_entries.size() >= kMaxEntries) {
+        m_limited = true;
+        publish();
+        return;
+    }
+    const QString id = QString::fromLatin1(
+        QCryptographicHash::hash(key.toUtf8(), QCryptographicHash::Sha256).toHex());
+    m_entries.insert(key, {{QStringLiteral("id"), id},
+                           {QStringLiteral("family"), radio.family},
+                           {QStringLiteral("serial"), radio.serial},
+                           {QStringLiteral("name"), radio.name},
+                           {QStringLiteral("model"), radio.model},
+                           {QStringLiteral("nickname"), radio.nickname},
+                           {QStringLiteral("version"), radio.version},
+                           {QStringLiteral("transport"), radio.transport},
+                           {QStringLiteral("address"), radio.address},
+                           {QStringLiteral("port"), radio.port},
+                           {QStringLiteral("inUse"), radio.inUse}});
+    publish();
+}
+
+void RadioCatalogue::remove(const QString& family, const QString& serial)
+{
+    if (m_running && validIdentity(family, serial)
+        && m_entries.remove(identityKey(family, serial)) > 0) {
+        publish();
+    }
+}
+
+void RadioCatalogue::publish()
+{
+    QJsonArray entries;
+    for (const QJsonObject& entry : std::as_const(m_entries)) {
+        entries.append(entry);
+    }
+    m_resources->upsert(kCatalogue,
+        {{QStringLiteral("running"), m_running},
+         {QStringLiteral("sources"), QJsonArray::fromStringList(m_source->enabledSources())},
+         {QStringLiteral("limited"), m_limited},
+         {QStringLiteral("maxEntries"), static_cast<qint64>(kMaxEntries)},
+         {QStringLiteral("entries"), entries}});
+}
+
+} // namespace AetherSDR::control

--- a/src/core/control/RadioCatalogue.cpp
+++ b/src/core/control/RadioCatalogue.cpp
@@ -110,6 +110,20 @@ void RadioCatalogue::upsert(const DiscoveredRadio& radio)
     if ((!lan && radio.transport != QStringLiteral("usb") && radio.transport != QStringLiteral("sim"))
         || (lan && (QHostAddress(radio.address).isNull() || radio.port == 0))
         || (!lan && (!radio.address.isEmpty() || radio.port != 0))) {
+        // Every other reject above is a bounds violation on attacker-reachable
+        // text; this one is the shape a native adapter regression takes, and it
+        // is otherwise invisible — the family simply stops appearing, which
+        // reads exactly like "no radio on the LAN". Warn once per family, and
+        // log no serial or address: `family` is the only field validated above.
+        if (!m_endpointWarnings.contains(radio.family)
+            && m_endpointWarnings.size() < kMaxEntries) {
+            m_endpointWarnings.insert(radio.family);
+            qCWarning(lcRadioCatalogue).nospace()
+                << "Discarding " << radio.family
+                << " discovery observation: transport '" << radio.transport
+                << "' with port " << radio.port
+                << (radio.address.isEmpty() ? " and no address" : " and an address");
+        }
         return;
     }
     const QString key = identityKey(radio.family, radio.serial);

--- a/src/core/control/RadioCatalogue.h
+++ b/src/core/control/RadioCatalogue.h
@@ -4,6 +4,7 @@
 #include "core/discovery/RadioDiscoverySource.h"
 
 #include <QMap>
+#include <QSet>
 
 namespace AetherSDR::control {
 
@@ -31,6 +32,9 @@ private:
     std::unique_ptr<RadioDiscoverySource> m_source;
     ControlResourceStore* m_resources;
     QMap<QString, QJsonObject> m_entries;
+    // Families already warned about a malformed endpoint, so a flood of bad
+    // observations cannot turn diagnosability into a log-volume attack.
+    QSet<QString> m_endpointWarnings;
     bool m_started{false};
     bool m_running{false};
     bool m_limited{false};

--- a/src/core/control/RadioCatalogue.h
+++ b/src/core/control/RadioCatalogue.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "ControlResourceStore.h"
+#include "core/discovery/RadioDiscoverySource.h"
+
+#include <QMap>
+
+namespace AetherSDR::control {
+
+// Bounded, read-only projection of discovery. Owns the source; never owns or
+// connects a radio. All methods and source signals run on the owning thread.
+class RadioCatalogue final : public QObject {
+    Q_OBJECT
+public:
+    static constexpr qsizetype kMaxEntries = 64;
+    static constexpr qsizetype kMaxTextChars = 128;
+
+    RadioCatalogue(std::unique_ptr<RadioDiscoverySource> source,
+                   ControlResourceStore* resources, QObject* parent = nullptr);
+    ~RadioCatalogue() override;
+    // One discovery lifecycle per instance. Repeated start/stop calls are safe;
+    // stop is terminal and clears observations, including late queued updates.
+    void start();
+    void stop();
+
+private:
+    void upsert(const DiscoveredRadio& radio);
+    void remove(const QString& family, const QString& serial);
+    void publish();
+
+    std::unique_ptr<RadioDiscoverySource> m_source;
+    ControlResourceStore* m_resources;
+    QMap<QString, QJsonObject> m_entries;
+    bool m_started{false};
+    bool m_running{false};
+    bool m_limited{false};
+};
+
+} // namespace AetherSDR::control

--- a/src/core/discovery/RadioDiscoverySource.h
+++ b/src/core/discovery/RadioDiscoverySource.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+
+#include <memory>
+
+namespace AetherSDR {
+
+// Normalized discovery data, not a connection request or a backend capability.
+// Vendor payloads, credentials and connected-client metadata stay below this seam.
+struct DiscoveredRadio {
+    QString family;
+    QString serial;
+    QString name;
+    QString model;
+    QString nickname;
+    QString version;
+    QString transport; // lan, usb, or sim
+    QString address;   // LAN address only; empty for USB and simulator entries
+    quint16 port{0};
+    bool inUse{false};
+};
+
+// Owning-thread, single-start lifecycle. Construct a new source to restart.
+// Implementations must not begin discovery until start() is called.
+class RadioDiscoverySource : public QObject {
+    Q_OBJECT
+public:
+    using QObject::QObject;
+    ~RadioDiscoverySource() override = default;
+    [[nodiscard]] virtual QStringList enabledSources() const = 0;
+    virtual void start() = 0;
+    virtual void stop() = 0;
+
+signals:
+    void radioChanged(const AetherSDR::DiscoveredRadio& radio);
+    void radioLost(const QString& family, const QString& serial);
+};
+
+struct LocalDiscoveryOptions {
+    bool local{false}; // Explicit operator opt-in: LAN broadcasts/listening and USB scans.
+    bool simulator{false}; // Demo identity only; never starts an RX/TX backend.
+};
+
+// Implementation lives below the vendor seam. Above-seam consumers see only
+// normalized observations and cannot reach a radio command through this interface.
+[[nodiscard]] std::unique_ptr<RadioDiscoverySource> makeLocalRadioDiscoverySource(
+    LocalDiscoveryOptions options);
+
+} // namespace AetherSDR
+
+Q_DECLARE_METATYPE(AetherSDR::DiscoveredRadio)

--- a/tests/aetherd_discovery_startup_test.cpp
+++ b/tests/aetherd_discovery_startup_test.cpp
@@ -1,0 +1,97 @@
+#include "TestSettingsProfile.h"
+#include "aetherd/DiscoveryStartup.h"
+#include "core/SettingsPaths.h"
+#include "core/backends/anan/AnanDiscovery.h"
+#include "core/backends/hl2/Hl2Discovery.h"
+
+#include <QCoreApplication>
+#include <QFileInfo>
+#include <QProcess>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+const QString kSerial = QStringLiteral("01:02:03:04:05:06");
+const QString kNickname = QStringLiteral("Saved discovery nickname");
+
+int readback()
+{
+    // Construction runs the same startup policy as aetherd, but discovery is
+    // never started: no UDP socket, USB enumeration or firmware peer is used.
+    const std::unique_ptr<RadioDiscoverySource> source =
+        aetherd::makeDiscoverySource({true, false});
+    if (!source || !source->enabledSources().contains(QStringLiteral("hl2"))
+        || !source->enabledSources().contains(QStringLiteral("anan"))) {
+        std::fprintf(stderr, "local discovery sources missing\n");
+        return 1;
+    }
+    if (hl2::Hl2Discovery::effectiveNickname(QStringLiteral("hl2"), kSerial,
+            QStringLiteral("Hermes-Lite 2")) != kNickname
+        || anan::AnanDiscovery::effectiveNickname(QStringLiteral("anan"), kSerial,
+            QStringLiteral("ANAN-G2")) != kNickname) {
+        std::fprintf(stderr, "daemon startup did not load persisted native nicknames\n");
+        return 1;
+    }
+    return 0;
+}
+
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    TestSettingsProfile profile(QStringLiteral("aetherd-discovery-startup"));
+    if (!profile.isValid()) {
+        return 1;
+    }
+    // A readback process gets its own legacy-settings isolation but reads the
+    // parent's explicitly supplied SQLite store, never the operator's profile.
+    const bool child = argc == 3 && QByteArray(argv[1]) == "--readback";
+    if (child) {
+        qputenv("AETHER_SETTINGS_DIR", QByteArray(argv[2]));
+    }
+    QCoreApplication app(argc, argv);
+    QCoreApplication::setApplicationName(QStringLiteral("aetherd"));
+    QCoreApplication::setApplicationVersion(QStringLiteral(AETHERSDR_VERSION));
+    if (child) {
+        return readback();
+    }
+
+    for (const bool simulator : {false, true}) {
+        const std::unique_ptr<RadioDiscoverySource> source =
+            aetherd::makeDiscoverySource({false, simulator});
+        source->start(); // Passive or demo metadata only; no physical discovery.
+        source->stop();
+        if (QFileInfo::exists(SettingsPaths::databasePath())) {
+            std::fprintf(stderr, "passive/simulator startup opened the settings store\n");
+            return 1;
+        }
+    }
+
+    AppSettings& settings = AppSettings::instance();
+    settings.load();
+    for (const QString& family : {QStringLiteral("hl2"), QStringLiteral("anan")}) {
+        if (!settings.setRadioFeature(family, kSerial, QStringLiteral("Identity"), 1,
+                {{QStringLiteral("nickname"), kNickname}})) {
+            std::fprintf(stderr, "could not seed isolated nickname document\n");
+            return 1;
+        }
+    }
+
+    QProcess process;
+    process.start(QCoreApplication::applicationFilePath(),
+        {QStringLiteral("--readback"), SettingsPaths::configDir()});
+    if (!process.waitForFinished(15000)) {
+        process.kill();
+        process.waitForFinished(1000);
+        std::fprintf(stderr, "nickname readback process failed or timed out\n");
+        return 1;
+    }
+    if (process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0) {
+        std::fputs(process.readAllStandardError().constData(), stderr);
+        return 1;
+    }
+    return 0;
+}

--- a/tests/radio_catalogue_test.cpp
+++ b/tests/radio_catalogue_test.cpp
@@ -1,0 +1,212 @@
+#include "core/control/RadioCatalogue.h"
+#include "core/control/ControlService.h"
+
+#include <QCoreApplication>
+#include <QEvent>
+#include <QJsonArray>
+#include <QJsonDocument>
+
+#include <cstdio>
+#include <utility>
+
+using namespace AetherSDR;
+using namespace AetherSDR::control;
+
+namespace {
+const ResourceAddress kCatalogue{QStringLiteral("radioCatalogue"), {}, {}};
+
+bool check(bool condition, const char* message)
+{
+    if (!condition) { std::fprintf(stderr, "%s\n", message); }
+    return condition;
+}
+
+class InjectedSource final : public RadioDiscoverySource {
+public:
+    QStringList enabledSources() const override { return {QStringLiteral("sim")}; }
+    void start() override { ++starts; }
+    void stop() override { ++stops; }
+    int starts{0};
+    int stops{0};
+};
+
+struct Fixture {
+    ControlResourceStore store;
+    ControlService service{&store};
+    std::unique_ptr<InjectedSource> owned{std::make_unique<InjectedSource>()};
+    InjectedSource* source{owned.get()};
+    RadioCatalogue catalogue{std::move(owned), &store};
+    QJsonObject value() const { return store.get(kCatalogue)->value; }
+    QJsonArray entries() const { return value().value(QStringLiteral("entries")).toArray(); }
+    quint64 revision() const { return store.get(kCatalogue)->revision; }
+};
+
+DiscoveredRadio radio(QString family = QStringLiteral("sim"), QString serial = QStringLiteral("one"))
+{
+    DiscoveredRadio result;
+    result.family = std::move(family);
+    result.serial = std::move(serial);
+    result.name = QStringLiteral("Test radio");
+    result.model = QStringLiteral("Model");
+    result.transport = QStringLiteral("sim");
+    return result;
+}
+
+ServiceReply invoke(Fixture& f, ControlSession& session, const QString& method,
+                    const QJsonObject& params)
+{
+    QJsonObject request{{QStringLiteral("v"), 1}, {QStringLiteral("id"), QStringLiteral("test")},
+                        {QStringLiteral("method"), method}, {QStringLiteral("params"), params}};
+    if (method != QStringLiteral("hello")) {
+        request.insert(QStringLiteral("sessionId"), session.sessionId());
+    }
+    return f.service.handle(QJsonDocument(request).toJson(QJsonDocument::Compact), &session);
+}
+
+bool testIdentityAndLifecycle()
+{
+    Fixture f;
+    f.source->radioChanged(radio());
+    if (!check(f.entries().isEmpty() && f.source->starts == 0, "construction must not discover")) {
+        return false;
+    }
+    f.catalogue.start();
+    f.catalogue.start();
+    DiscoveredRadio first = radio(QStringLiteral("hl2"));
+    f.source->radioChanged(first);
+    const quint64 firstRevision = f.revision();
+    const QString firstId = f.entries().first().toObject().value(QStringLiteral("id")).toString();
+    f.source->radioChanged(first);
+    if (!check(f.revision() == firstRevision && f.source->starts == 1,
+               "duplicate announcements/start must not churn revision or restart discovery")) {
+        return false;
+    }
+    f.source->radioChanged(radio(QStringLiteral("flex")));
+    if (!check(f.entries().size() == 2
+                   && f.entries().first().toObject().value(QStringLiteral("family")) == QStringLiteral("flex")
+                   && f.entries().first().toObject().value(QStringLiteral("id")) != firstId,
+               "same serial in two families must remain distinct and deterministically sorted")) {
+        return false;
+    }
+    first.nickname = QStringLiteral("Renamed");
+    first.transport = QStringLiteral("lan");
+    first.address = QStringLiteral("192.0.2.1");
+    first.port = 1024;
+    f.source->radioChanged(first);
+    if (!check(f.entries().last().toObject().value(QStringLiteral("id")) == firstId
+                   && f.entries().last().toObject().value(QStringLiteral("nickname")) == first.nickname
+                   && f.revision() > firstRevision,
+               "address/display updates must preserve identity and publish a new canonical value")) {
+        return false;
+    }
+    f.source->radioLost(QStringLiteral("flex"), first.serial);
+    if (!check(f.entries().size() == 1, "loss must remove only the matching family/serial")) {
+        return false;
+    }
+    // Queue a late source update, then stop before it is dispatched.
+    QMetaObject::invokeMethod(f.source, [&f] { f.source->radioChanged(radio()); }, Qt::QueuedConnection);
+    f.catalogue.stop();
+    const quint64 stoppedRevision = f.revision();
+    f.catalogue.start();
+    f.catalogue.stop();
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::MetaCall);
+    return check(f.entries().isEmpty() && !f.value().value(QStringLiteral("running")).toBool()
+                     && f.revision() == stoppedRevision && f.source->starts == 1,
+                 "stop must clear entries, ignore queued callbacks and be terminal");
+}
+
+bool testBounds()
+{
+    Fixture f;
+    f.catalogue.start();
+    for (int invalid = 0; invalid < 10; ++invalid) {
+        DiscoveredRadio value = radio();
+        switch (invalid) {
+        case 0: value.serial.clear(); break;
+        case 1: value.family = QStringLiteral("bad/family"); break;
+        case 2: value.nickname = QString(129, QLatin1Char('x')); break;
+        case 3: value.serial.append(QChar(0x1f)); break;
+        case 4: value.transport = QStringLiteral("lan"); value.address = QStringLiteral("not-an-IP"); value.port = 1; break;
+        case 5: value.address = QStringLiteral("192.0.2.1"); break;
+        case 6: value.serial = QString(QChar(0xd800)); break;
+        case 7: value.model = QString(QChar(0xdc00)); break;
+        case 8: value.transport = QStringLiteral("unknown"); break;
+        case 9: value.transport = QStringLiteral("lan"); value.address = QStringLiteral("192.0.2.1"); break;
+        }
+        f.source->radioChanged(value);
+    }
+    if (!check(f.entries().isEmpty(), "invalid identities/display text/endpoints must not publish")) {
+        return false;
+    }
+    for (qsizetype i = 0; i < RadioCatalogue::kMaxEntries + 1; ++i) {
+        DiscoveredRadio value = radio(QString(16, QLatin1Char('a')),
+                                      QString(125, QChar(0x800)) + QString::number(i).rightJustified(3, QLatin1Char('0')));
+        value.name = value.model = value.nickname = value.version = QString(128, QChar(0x800));
+        f.source->radioChanged(value);
+    }
+    if (!check(f.entries().size() == RadioCatalogue::kMaxEntries
+                   && f.value().value(QStringLiteral("limited")).toBool()
+                   && QJsonDocument(f.store.get(kCatalogue)->toJson()).toJson(QJsonDocument::Compact).size()
+                       < ProtocolLimits::kMaxMessageBytes,
+               "capacity must be bounded, disclosed, and fit the protocol frame limit")) {
+        return false;
+    }
+    f.source->radioLost(QString(16, QLatin1Char('a')), QString(125, QChar(0x800)) + QStringLiteral("000"));
+    f.source->radioChanged(radio(QStringLiteral("sim"), QStringLiteral("new")));
+    return check(f.entries().size() == RadioCatalogue::kMaxEntries
+                     && f.value().value(QStringLiteral("limited")).toBool(),
+                 "freed capacity must accept new observations without hiding prior incompleteness");
+}
+
+bool testProtocolAndIsolation()
+{
+    Fixture f;
+    f.catalogue.start();
+    ControlSession observer(&f.store, 256 * 1024, SessionAuthorization::Observer);
+    ControlSession second(&f.store, 256 * 1024, SessionAuthorization::Observer);
+    ControlSession denied(&f.store, 256 * 1024, SessionAuthorization::AuthenticatedWithoutGrants);
+    for (ControlSession* session : {&observer, &second, &denied}) {
+        const QJsonObject welcome = invoke(f, *session, QStringLiteral("hello"),
+            {{QStringLiteral("versions"), QJsonArray{1}}}).message.value(QStringLiteral("result")).toObject();
+        if (!check(welcome.value(QStringLiteral("capabilities")).toArray().contains(QStringLiteral("radioCatalogue.read"))
+                       == (session != &denied), "catalogue capability must require observe permission")) {
+            return false;
+        }
+    }
+    const QJsonObject params{{QStringLiteral("resources"), QJsonArray{kCatalogue.toJson()}}};
+    for (ControlSession* session : {&observer, &second}) {
+        const QJsonObject baseline = invoke(f, *session, QStringLiteral("resource.subscribe"), params)
+                                         .message.value(QStringLiteral("result")).toObject();
+        if (!check(baseline.value(QStringLiteral("resources")).toArray().size() == 1,
+                   "catalogue subscription must include its atomic baseline")) { return false; }
+    }
+    const ServiceReply noGrant = invoke(f, denied, QStringLiteral("resource.subscribe"), params);
+    if (!check(noGrant.message.value(QStringLiteral("error")).toObject().value(QStringLiteral("code"))
+                   == QStringLiteral("auth.grant_denied"), "denied clients must not subscribe to discovery")) {
+        return false;
+    }
+    observer.revokeAuthorization();
+    f.source->radioChanged(radio());
+    const QList<QByteArray> frames = second.takePendingFrames();
+    if (!check(observer.takePendingFrames().isEmpty() && denied.takePendingFrames().isEmpty()
+                   && frames.size() == 1
+                   && QJsonDocument::fromJson(frames.first()).object().value(QStringLiteral("value"))
+                       .toObject().value(QStringLiteral("entries")).toArray().size() == 1,
+               "catalogue deltas must reach only active observers")) { return false; }
+    const QJsonObject read = invoke(f, second, QStringLiteral("resource.get"),
+        {{QStringLiteral("resource"), kCatalogue.toJson()}}).message.value(QStringLiteral("result")).toObject();
+    QJsonObject invalidSelector = kCatalogue.toJson();
+    invalidSelector.insert(QStringLiteral("id"), QStringLiteral("not-a-singleton"));
+    const ServiceReply invalid = invoke(f, second, QStringLiteral("resource.get"),
+        {{QStringLiteral("resource"), invalidSelector}});
+    return check(read.value(QStringLiteral("value")).toObject() == f.value()
+                     && invalid.message.contains(QStringLiteral("error")),
+                 "get must return the canonical catalogue and reject non-singleton selectors");
+}
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv);
+    return testIdentityAndLifecycle() && testBounds() && testProtocolAndIsolation() ? 0 : 1;
+}

--- a/tests/radio_catalogue_test.cpp
+++ b/tests/radio_catalogue_test.cpp
@@ -1,10 +1,12 @@
 #include "core/control/RadioCatalogue.h"
 #include "core/control/ControlService.h"
+#include "core/backends/LocalRadioDiscoveryMapping.h"
 
 #include <QCoreApplication>
 #include <QEvent>
 #include <QJsonArray>
 #include <QJsonDocument>
+#include <QLoggingCategory>
 
 #include <cstdio>
 #include <utility>
@@ -158,6 +160,84 @@ bool testBounds()
                  "freed capacity must accept new observations without hiding prior incompleteness");
 }
 
+// One row per shape a native adapter actually emits. RadioCatalogue rejects a
+// malformed endpoint silently, so without this a family that stopped setting
+// `port` would just vanish from the catalogue and read as "no radio on the LAN".
+bool testNativeMapping()
+{
+    struct Row {
+        const char* family;
+        const char* transport;
+        quint16 port;      // as the adapter leaves RadioInfo::port
+        const char* address;
+    };
+    // flex: RadioInfo::port defaults to 4992. hl2: kMetisPort. anan: kRadioPort.
+    // rtl: USB, and its RadioInfo carries an address the projection must drop.
+    const Row rows[] = {{"flex", "lan", 4992, "192.0.2.10"},
+                        {"hl2", "lan", 1024, "192.0.2.11"},
+                        {"anan", "lan", 1024, "192.0.2.12"},
+                        {"rtl", "usb", 0, "192.0.2.13"}};
+    for (const Row& row : rows) {
+        Fixture f;
+        f.catalogue.start();
+        RadioInfo info;
+        info.serial = QStringLiteral("serial-1");
+        info.model = QStringLiteral("Model");
+        info.nickname = QStringLiteral("Nick");
+        info.version = QStringLiteral("1.2.3");
+        info.inUse = true;
+        info.port = row.port;
+        info.address = QHostAddress(QString::fromLatin1(row.address));
+        const DiscoveredRadio radio = discovery::normalize(
+            info, QString::fromLatin1(row.family), QString::fromLatin1(row.transport));
+        const bool lan = radio.transport == QStringLiteral("lan");
+        if (!check(radio.address == (lan ? QString::fromLatin1(row.address) : QString())
+                       && radio.port == (lan ? row.port : quint16{0})
+                       && radio.nickname == info.nickname && radio.inUse,
+                   "endpoint fields are LAN-only and display fields survive the projection")) {
+            return false;
+        }
+        f.source->radioChanged(radio);
+        if (!check(f.entries().size() == 1
+                       && f.entries().first().toObject().value(QStringLiteral("family"))
+                           == QString::fromLatin1(row.family),
+                   "every native adapter shape must survive catalogue validation")) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// The endpoint reject is the one an adapter regression trips, so it warns —
+// once per family, so malformed observations cannot become a log-volume attack.
+int g_warnings = 0;
+bool testRejectDiagnostics()
+{
+    Fixture f;
+    f.catalogue.start();
+    QtMessageHandler previous = qInstallMessageHandler(
+        [](QtMsgType type, const QMessageLogContext& context, const QString&) {
+            if (type == QtWarningMsg && context.category
+                && QLatin1StringView(context.category) == QLatin1StringView("aether.control.catalogue")) {
+                ++g_warnings;
+            }
+        });
+    for (int attempt = 0; attempt < 3; ++attempt) {
+        DiscoveredRadio broken = radio(QStringLiteral("hl2"));
+        broken.transport = QStringLiteral("lan"); // LAN with no endpoint: the regression shape.
+        f.source->radioChanged(broken);
+    }
+    DiscoveredRadio other = radio(QStringLiteral("anan"));
+    other.transport = QStringLiteral("lan");
+    f.source->radioChanged(other);
+    DiscoveredRadio unbounded = radio();
+    unbounded.serial = QString(129, QLatin1Char('x')); // A bounds reject stays silent.
+    f.source->radioChanged(unbounded);
+    qInstallMessageHandler(previous);
+    return check(f.entries().isEmpty() && g_warnings == 2,
+                 "endpoint rejects warn once per family; bounds rejects stay quiet");
+}
+
 bool testProtocolAndIsolation()
 {
     Fixture f;
@@ -208,5 +288,8 @@ bool testProtocolAndIsolation()
 int main(int argc, char* argv[])
 {
     QCoreApplication app(argc, argv);
-    return testIdentityAndLifecycle() && testBounds() && testProtocolAndIsolation() ? 0 : 1;
+    return testIdentityAndLifecycle() && testBounds() && testNativeMapping()
+                   && testRejectDiagnostics() && testProtocolAndIsolation()
+               ? 0
+               : 1;
 }

--- a/tests/radio_discovery_source_test.cpp
+++ b/tests/radio_discovery_source_test.cpp
@@ -1,0 +1,32 @@
+#include "core/control/RadioCatalogue.h"
+
+#include <QCoreApplication>
+#include <QJsonArray>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+using namespace AetherSDR::control;
+
+// The real source factory is the subject. Both cases explicitly disable local
+// discovery: no UDP socket, USB enumeration, radio backend, or settings access.
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv);
+    for (const bool simulator : {false, true}) {
+        ControlResourceStore store;
+        RadioCatalogue catalogue(makeLocalRadioDiscoverySource({false, simulator}), &store);
+        catalogue.start();
+        const QJsonObject value = store.get({QStringLiteral("radioCatalogue"), {}, {}})->value;
+        const QJsonArray entries = value.value(QStringLiteral("entries")).toArray();
+        const QJsonArray sources = value.value(QStringLiteral("sources")).toArray();
+        if (entries.size() != (simulator ? 1 : 0) || sources.size() != (simulator ? 1 : 0)
+            || (simulator && (sources.first() != QStringLiteral("sim")
+                || entries.first().toObject().value(QStringLiteral("serial")) != QStringLiteral("DEMO-0001")
+                || entries.first().toObject().value(QStringLiteral("transport")) != QStringLiteral("sim")))) {
+            std::fprintf(stderr, "production source must honor passive/simulator-only options\n");
+            return 1;
+        }
+    }
+    return 0;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -116,7 +116,8 @@ target_link_libraries(control_resource_service_test PRIVATE
     aethercore Qt6::Core)
 add_test(NAME control_resource_service_test COMMAND control_resource_service_test)
 
-# Socket-free catalogue/protocol tests: injected normalized discovery signals.
+# Socket-free catalogue/protocol tests: injected normalized discovery signals,
+# plus the native RadioInfo -> DiscoveredRadio projection table-tested per family.
 # QtNetwork is used only for QHostAddress validation, never a socket or peer.
 add_executable(radio_catalogue_test
     tests/radio_catalogue_test.cpp

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -116,6 +116,38 @@ target_link_libraries(control_resource_service_test PRIVATE
     aethercore Qt6::Core)
 add_test(NAME control_resource_service_test COMMAND control_resource_service_test)
 
+# Socket-free catalogue/protocol tests: injected normalized discovery signals.
+# QtNetwork is used only for QHostAddress validation, never a socket or peer.
+add_executable(radio_catalogue_test
+    tests/radio_catalogue_test.cpp
+    src/core/discovery/RadioDiscoverySource.h
+    src/core/control/RadioCatalogue.cpp
+    src/core/control/ControlResourceStore.cpp
+    src/core/control/ControlSession.cpp
+    src/core/control/ControlService.cpp
+    src/core/control/ControlProtocolCodec.cpp
+)
+target_include_directories(radio_catalogue_test PRIVATE src)
+target_compile_definitions(radio_catalogue_test PRIVATE AETHERSDR_VERSION="${PROJECT_VERSION}")
+target_link_libraries(radio_catalogue_test PRIVATE Qt6::Core Qt6::Network)
+add_test(NAME radio_catalogue_test COMMAND radio_catalogue_test)
+
+# Real factory wiring, with local=false: simulator metadata only, no sockets,
+# device scans, radio connections or third-party firmware stand-ins.
+add_executable(radio_discovery_source_test tests/radio_discovery_source_test.cpp)
+target_include_directories(radio_discovery_source_test PRIVATE src)
+target_link_libraries(radio_discovery_source_test PRIVATE aethercore Qt6::Core)
+add_test(NAME radio_discovery_source_test COMMAND radio_discovery_source_test)
+
+# Socket-free daemon startup policy: a fresh child process reads isolated saved
+# nicknames through native static helpers; no discovery source is started with
+# local=true and no socket, USB scan or synthetic firmware peer is used.
+add_executable(aetherd_discovery_startup_test tests/aetherd_discovery_startup_test.cpp)
+target_include_directories(aetherd_discovery_startup_test PRIVATE src tests)
+target_compile_definitions(aetherd_discovery_startup_test PRIVATE AETHERSDR_VERSION="${PROJECT_VERSION}")
+target_link_libraries(aetherd_discovery_startup_test PRIVATE aethercore Qt6::Core)
+add_test(NAME aetherd_discovery_startup_test COMMAND aetherd_discovery_startup_test)
+
 # ── Digital-voice / D-STAR tests ─────────────────────────────────────────────
 # Guarded by the same condition as the aether-dv-waveform target they exercise.
 # DIGITAL_VOICE_WAVEFORM_DIR, CRDV_DIR and crdv::crdv are all defined by the time
@@ -4295,6 +4327,7 @@ target_link_libraries(CAT_Flex_test PRIVATE Qt6::Core Qt6::Network)
 # Conditional targets are guarded with if(TARGET ...).
 set(AETHER_SETTINGS_CONSUMERS
     control_resource_service_test
+    aetherd_discovery_startup_test
     slice_label_test
     ulanzi_mapping_migration_test
     theme_manager_test


### PR DESCRIPTION
## Summary

Refs #3849. Continue the approved Stage 3 sequence after #5434 with a bounded, observe-only headless radio catalogue. This is one incremental RFC slice and does not close #3849.

- Add a QtCore normalized discovery interface, with native Flex/HL2/ANAN and optional RTL-SDR adapters below the vendor boundary. Desktop discovery/autoconnect is unchanged.
- Publish singleton `radioCatalogue` through existing `resource.get`, `resource.subscribe` and `resource.unsubscribe`, with observe-gated `radioCatalogue.read` capability. Entries are validated, sorted and bounded to 64; IDs are family+serial-based and survive display/address updates; duplicates do not churn revisions; stop clears entries and rejects late callbacks.
- Keep daemon startup passive. `--discover-local` opts into LAN/USB discovery; `--discover-sim` publishes demo metadata only. Neither option connects a radio. Source/running metadata describes configuration/lifecycle, not successful hardware discovery, and `limited` is sticky for the catalogue lifetime.
- Fix the pre-publication review finding: the daemon loads `AppSettings` only for native discovery, before model/discovery consumers, so saved HL2/ANAN Identity nicknames remain available. Passive/simulator-only startup does not load the store; normal migration, recovery and read-only safeguards remain in force.

No remote listener, credential provisioning, radio commands, receive-control methods, TX surface, meters or desktop adapter are added. Icom manual setup, SmartLink and external receiver directories remain excluded. New public CLI/resource contracts need maintainer review within the accepted RFC.

Coordination: #3849 remains assigned to @ten9876 under the previously confirmed arrangement; the implementation plan is [recorded on the issue](https://github.com/aethersdr/AetherSDR/issues/3849#issuecomment-5556549308). Implementation and local review were Codex-assisted.

## Constitution principle honored

**Principle VII — Validate All Inputs at Trust Boundaries:** bound and validate normalized identity, display and endpoint fields before publishing them; reject invalid UTF-16 and ambiguous identities instead of truncating them.

Also preserve **Principle VI** (discovery cannot connect or key TX) and **Principle XI** (behavioral regression tests and mutation proof).

## Test plan

- [x] macOS ARM64 desktop and daemon build passes using the dedicated ARM64 toolchain/build directory, with RADE enabled. Verified ARM64 host/system/executables, no RNNoise x86 sources and no QtWidgets dependency in `aetherd`.
- [x] Nine focused registered CTests pass: codec, authorization, resource service, catalogue, production passive/sim source, daemon nickname startup, and existing nickname-roundtrip/locked-store/newer-schema settings safeguards.
- [x] New `aetherd_discovery_startup_test` writes isolated Identity documents, then reads them in a fresh process through the real daemon startup helper and native nickname helpers. Native sources are never started. Passive and simulator-only startup are checked without opening the store.
- [x] Mutation proof: omitting the settings load fails persisted nickname recovery; loading unconditionally fails passive-startup isolation. Earlier catalogue/source mutation checks also detect family identity collisions, relaxed capacity, post-stop callbacks, invalid UTF-16 and missing simulator publication.
- [x] Mac headless smoke on the final code: two isolated daemon instances, passive then simulator-only; hello/capabilities/get/subscribe/unsubscribe pass, with 0/1 catalogue entries respectively, `DEMO-0001` for sim, observe-only grants and disconnected radio sessions. Both owned instances stopped. The running desktop app was untouched.
- [x] Strict engine-boundary and test-registration checks, frozen CI-gate check, touchpoint-manifest freshness, and diff whitespace checks pass.
- [x] Final-commit security diff review accounts for all 16 changed files, with no reportable vulnerabilities and no deferred source-review work. Runtime limits below remain explicit.
- [ ] Existing tests pass in PR CI — awaiting remote jobs.
- [ ] Real-radio/physical discovery verification — not performed. No LAN/USB scan, radio connection or TX was used in local verification. Windows/Linux and RTL-enabled runtime remain untested locally.

All three new CTests are socket-free and unconditionally registered in `tests/tests.cmake`; none changes the frozen per-PR test gate. The only socket smoke targets our actual daemon server, is manual, and uses unique current-user local endpoints rather than a synthetic firmware peer. The GUI automation bridge is not a proof path for this slice because the desktop does not consume this headless catalogue yet.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`).
- [x] No new flat-key `AppSettings` calls; existing scoped Identity documents are read.
- [x] Code is clean-room, not derived from a proprietary binary.
- [x] All meter UI uses `MeterSmoother` — no meter/UI changes.
- [x] Protocol/resource and milestone documentation updated; no `CHANGELOG.md` changes.
- [x] Security-sensitive changes reference a GHSA if applicable — no GHSA applies; no vulnerability was found in the final diff review.
