### PR TITLE
docs(bridge): document the get dsp backend read-back from #5401

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -333,7 +333,7 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 | | [`midi cc <0-127>`](#midi) | Inject a learned VFO Tune Knob CC event (RX-only). |
 | | [`scrollTo <target>`](#scrollto-alias-ensurevisible) | Scroll a widget into its scroll-area viewport. |
 | **State (`get`)** | [`get audio`](#get) | Audio-engine stream/buffer snapshot. |
-| | [`get dsp`](#get-dsp) | Client-side AetherDSP NR state (NR2…BNR). |
+| | [`get dsp`](#get-dsp) | Client-side AetherDSP NR state (NR2…BNR), plus the backend's own DSP read-back. |
 | | [`get radio \| transmit \| eq \| meters`](#get) | Radio / TX-chain / EQ / meters snapshots. |
 | | [`get gps`](#get) | GPS fix, location, satellite-count, time, course, and reference snapshot. |
 | | [`get slice[s] \| pan[s]`](#get) | Slice & panadapter model snapshots. |
@@ -719,7 +719,7 @@ connects).
 | `model` | `selector` | returns |
 |---|---|---|
 | `audio` | — | audio-engine snapshot (RX/TX stream state, mute, buffer counters, Opus TX pacing counters, KiwiSDR TX mute gate, Receive Presentation output-signal counters) |
-| `dsp` | — | client-side AetherDSP noise-reduction state — see [`get dsp`](#get-dsp) |
+| `dsp` | — | client-side AetherDSP noise-reduction state, **plus a `backend` object** carrying the radio-side DSP read-back (`family` and a `chains` list, each entry naming its `chain` and its `level`) when the active backend reports one — see [`get dsp`](#get-dsp) |
 | `radio` | — | radio snapshot (name, model, version, connected, **connectState**, fullDuplex, transmitting, txPower, paTemp, slice/pan counts) — see [`connectState`](#connectstate) |
 | `gps` | — | GPS status, backend-normalized `positionValid` and `source`, tracked/visible counts, grid, radio-format coordinates, altitude, speed, course, UTC time and date, frequency error, the Flex-hosted `ntpServerAddress`, the radio-owned NTP client state (`ntpClientEnabled`, `ntpClientServer`, `gpsTimeCorrection`, `ntpSyncStatus` — IC-705), and oscillator-reference state. This authenticated diagnostic response contains precise location data; the compact status bar and tooltip do not. |
 | `transmit` | — | TX-chain snapshot: RF/tune power, mic/processor/monitor, VOX/AM/DEXP, TX filter, CW (speed/pitch/break-in/delay/sidetone/iambic mode/paddle swap/CWL/monitor gain+pan), ATU, APD. Validate that a TX/Phone/CW applet control reached the radio model. |
@@ -1206,6 +1206,9 @@ radio-side `nr`/`nb`/`anf` in `get slice`. There is no widget that exposes which
 of the six AudioEngine NR modules is active and how it's tuned, so this is the
 only non-screenshot way to assert it.
 
+The response also carries **`backend`** — what the *radio's* DSP is configured
+with, which is a different question from everything else here (#5401).
+
 ```json
 → {"cmd":"get","model":"dsp"}
 ← {"ok":true,"model":"dsp","dsp":{
@@ -1222,7 +1225,23 @@ only non-screenshot way to assert it.
      "nr4":{"reductionDb":10,"smoothing":0,"whitening":0,"maskingDepth":50,"suppression":50,"noiseMethod":0,"adaptiveNoise":true},
      "mnr":{"strength":1},
      "dfnr":{"attenLimitDb":100,"postFilterBeta":0},
-     "bnr":{"intensity":1}}}}
+     "bnr":{"intensity":1}},
+   "backend":{
+     "family":"hl2",
+     "chains":[
+       {"chain":"rx-wdsp","receiver":0,"level":"channel-config",
+        "inputRateHz":48000,"dspRateHz":48000,"outputRateHz":48000,
+        "inputBlockSize":512,"dspBlockSize":512,"outputBlockSize":512,
+        "filterLowHz":150,"filterHighHz":2850,
+        "agcMode":"fast","agcMaxGainDb":90,"agcSlopeDb":0,"agcFixedGainDb":10,
+        "wdspNotchCount":0,"appliedNoiseBlanker":false},
+       {"chain":"rx-wdsp","receiver":1,"level":"not-configured"},
+       {"chain":"hl2-tx","level":"dsp-config",
+        "inputRateHz":48000,"outputRateHz":48000,"dspBlockSize":512,
+        "filterLowHz":300,"filterHighHz":2700,
+        "alcEnabled":true,"alcTargetPeak":0.9,"alcMaxGainDb":20,
+        "alcAttackSec":0.005,"alcReleaseSec":0.25,"alcHoldBelowDbfs":-45,
+        "micGainLinear":1}]}}}
 ```
 
 - `active` — the name of the **one** enabled module (the modules are mutually
@@ -1234,7 +1253,53 @@ only non-screenshot way to assert it.
   persisted `bnr` intensity, merged with the AppSettings-persisted
   NR2/NR4/DFNR-beta values. (BNR is the in-process NVIDIA AFX denoiser since
   #3902 — no container, so it exposes only `intensity`.)
-- A trailing property narrows it: `get dsp active` → `{"value":"NR2"}`.
+- `backend` — **the radio-side DSP read-back**, and the one part of this
+  response that is not about the client. Everything above describes AetherDSP's
+  own chain in `AudioEngine`; this is what the DSP *on the radio* is configured
+  with. `family` is the connected backend's family (`"hl2"` above), and `chains`
+  is a list with one entry per DSP chain that backend runs. It exists because
+  the recurring defect on a new backend is model/DSP divergence — a control
+  moves, the model records it, nothing reaches the DSP, and the symptom is "the
+  control does nothing". Every other `get` model answers from the **model**, so
+  none of them can see it.
+- `backend.chains[].chain` — **which** chain the entry describes: on a
+  Hermes-Lite 2, `rx-wdsp` (WDSP on receive) or `hl2-tx` (a hand-written phasing
+  modulator on transmit, whose config is a different struct entirely). A backend
+  may run more than one chain and they need not share a vocabulary, so key off
+  `chain` rather than guessing from which fields are present. `rx-wdsp` entries
+  also carry `receiver` — the **DDC index**, not a slice id.
+- `backend.chains[].level` — **how close to the DSP the values came from**.
+  "Read-back" is used loosely, and the difference decides what a mismatch
+  proves:
+  - `channel-config` — what the channel was **opened** with, after any clamping
+    or refusal. One level below the model and one above a query into WDSP
+    itself.
+  - `dsp-config` — the DSP's **own state**.
+  - `not-configured` — a chain that **exists with nothing behind it**. Reported
+    present-but-unconfigured rather than omitted, and deliberately **without**
+    the configuration fields, so there are no stale or default values to
+    mistake for a real setting: a receiver with no channel behind it, or a
+    transmit chain that has never been configured, refused its `configure()`, or
+    been torn down by a disconnect, is exactly the state worth seeing.
+- **`dsp-config` describes the DSP, not the wire.** It is not liveness and not
+  keying. Normal unkeying and transient link loss retain the applied
+  configuration and still report `dsp-config`; for link state read
+  [`connectState`](#connectstate) on `get radio`.
+- **`backend` is absent entirely when the gather is empty.** No backend
+  attached, a backend that does not implement the read-back, and a gather that
+  could not be made all produce **no `backend` key at all** — never an empty
+  object and never an empty `chains` list, because an empty object would read as
+  "we asked, and the answer is nothing". `get dsp backend` errors with
+  `unknown property 'backend' for dsp` in exactly the cases the bare form omits
+  it. **A caller must not read the absence as "this radio has no chains"** — it
+  means the question went unanswered, which is a different fact. Both directions
+  are pinned by `tests/automation_dsp_backend_readback_test.cpp`.
+- A trailing property narrows it: `get dsp active` → `{"value":"NR2"}`, and
+  `get dsp backend` returns the identical object the bare form reports. The
+  read-back is merged into the snapshot **before** the property branch for that
+  reason: `assert_state` and `wait_for` only ever issue property reads, so a
+  field reachable only from the bare form is a field no automation client can
+  assert on.
 
 ### `get wavestats`
 Per-scope paint/append counters from every `WaveformWidget` instance — the

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -719,7 +719,7 @@ connects).
 | `model` | `selector` | returns |
 |---|---|---|
 | `audio` | — | audio-engine snapshot (RX/TX stream state, mute, buffer counters, Opus TX pacing counters, KiwiSDR TX mute gate, Receive Presentation output-signal counters) |
-| `dsp` | — | client-side AetherDSP noise-reduction state, **plus a `backend` object** carrying the radio-side DSP read-back (`family` and a `chains` list, each entry naming its `chain` and its `level`) when the active backend reports one — see [`get dsp`](#get-dsp) |
+| `dsp` | — | client-side AetherDSP noise-reduction state, **plus a `backend` object** carrying the backend-owned DSP read-back (`family` and a `chains` list, each entry naming its `chain` and its `level`) when the active backend reports one — see [`get dsp`](#get-dsp) |
 | `radio` | — | radio snapshot (name, model, version, connected, **connectState**, fullDuplex, transmitting, txPower, paTemp, slice/pan counts) — see [`connectState`](#connectstate) |
 | `gps` | — | GPS status, backend-normalized `positionValid` and `source`, tracked/visible counts, grid, radio-format coordinates, altitude, speed, course, UTC time and date, frequency error, the Flex-hosted `ntpServerAddress`, the radio-owned NTP client state (`ntpClientEnabled`, `ntpClientServer`, `gpsTimeCorrection`, `ntpSyncStatus` — IC-705), and oscillator-reference state. This authenticated diagnostic response contains precise location data; the compact status bar and tooltip do not. |
 | `transmit` | — | TX-chain snapshot: RF/tune power, mic/processor/monitor, VOX/AM/DEXP, TX filter, CW (speed/pitch/break-in/delay/sidetone/iambic mode/paddle swap/CWL/monitor gain+pan), ATU, APD. Validate that a TX/Phone/CW applet control reached the radio model. |
@@ -1206,8 +1206,9 @@ radio-side `nr`/`nb`/`anf` in `get slice`. There is no widget that exposes which
 of the six AudioEngine NR modules is active and how it's tuned, so this is the
 only non-screenshot way to assert it.
 
-The response also carries **`backend`** — what the *radio's* DSP is configured
-with, which is a different question from everything else here (#5401).
+The response also carries **`backend`** — the backend-owned DSP configuration,
+separate from AudioEngine's AetherDSP chain. For HL2, these DSP chains run
+inside AetherSDR on the host, not in radio firmware (#5401).
 
 ```json
 → {"cmd":"get","model":"dsp"}
@@ -1253,15 +1254,17 @@ with, which is a different question from everything else here (#5401).
   persisted `bnr` intensity, merged with the AppSettings-persisted
   NR2/NR4/DFNR-beta values. (BNR is the in-process NVIDIA AFX denoiser since
   #3902 — no container, so it exposes only `intensity`.)
-- `backend` — **the radio-side DSP read-back**, and the one part of this
-  response that is not about the client. Everything above describes AetherDSP's
-  own chain in `AudioEngine`; this is what the DSP *on the radio* is configured
-  with. `family` is the connected backend's family (`"hl2"` above), and `chains`
+- `backend` — **the backend-owned DSP read-back**. Everything above describes
+  AetherDSP's chain in `AudioEngine`; this object describes the backend's
+  separate DSP chains. For HL2, both `rx-wdsp` and `hl2-tx` run on AetherSDR's
+  host I/O thread, so this is host DSP configuration, not firmware read-back.
+  `family` is the connected backend's family (`"hl2"` above), and `chains`
   is a list with one entry per DSP chain that backend runs. It exists because
   the recurring defect on a new backend is model/DSP divergence — a control
   moves, the model records it, nothing reaches the DSP, and the symptom is "the
-  control does nothing". Every other `get` model answers from the **model**, so
-  none of them can see it.
+  control does nothing". Reading the requested values from `get slice` alone
+  cannot prove that they reached the DSP; backend read-backs such as this object
+  and `get hostnb` expose that distinction.
 - `backend.chains[].chain` — **which** chain the entry describes: on a
   Hermes-Lite 2, `rx-wdsp` (WDSP on receive) or `hl2-tx` (a hand-written phasing
   modulator on transmit, whose config is a different struct entirely). A backend
@@ -1273,7 +1276,8 @@ with, which is a different question from everything else here (#5401).
   proves:
   - `channel-config` — what the channel was **opened** with, after any clamping
     or refusal. One level below the model and one above a query into WDSP
-    itself.
+    itself. Within this entry, `wdspNotchCount` and `appliedNoiseBlanker`
+    are exceptions: they query WDSP directly.
   - `dsp-config` — the DSP's **own state**.
   - `not-configured` — a chain that **exists with nothing behind it**. Reported
     present-but-unconfigured rather than omitted, and deliberately **without**


### PR DESCRIPTION
## Summary

#5401 added a `backend` object to the bridge's `get dsp` payload — `family` plus a `chains` list, each entry naming its `chain` and its `level` — and never taught `docs/automation-bridge.md` about it. On `main` today the `### get dsp` section and the `get` model table row still describe only the client-side AetherDSP payload, so the only account of the new surface is [`docs/HERMES.md` §8](https://github.com/aethersdr/AetherSDR/blob/main/docs/HERMES.md), an audit document rather than the bridge reference an automation author actually reads.

This is the docs-only follow-up I committed to in https://github.com/aethersdr/AetherSDR/pull/5401#issuecomment-5562392390 — the `get dsp` section, the model table row, and one example response showing `backend.family` and a `chains` entry of each level. It is the same nit @Ozy311 raised against #5416 for `connectState`, which landed sixteen minutes later with its doc section written; I simply did not apply it here.

**Docs only. One file. No code change, no test change, generated block untouched.**

### The check cannot see this, and that is worth knowing on its own

`tools/gen_bridge_docs.py --check` does three things: regenerate the verb table between the `<!-- BEGIN/END GENERATED VERB TABLE -->` markers from the `add(...)` registrations in `AutomationServer.cpp`, lint duplicate `###`/`####` headings, and check slice sub-actions in both directions. **It never looks at snapshot payload schemas.** I verified the boundary rather than taking it on trust: in the file on `main` the generated block runs lines 3866–3944, while `### get dsp` is at line 1203 and the `get` model table at 719–743 — both well outside it. A payload description can therefore drift indefinitely while the check stays green, which is exactly what happened here.

So the check is green before this PR and green after, and that fact is not evidence the docs were right:

```
$ python3 tools/gen_bridge_docs.py --check     # before (10a566e3)
ok: docs verb table matches the registry (72 verbs), no duplicate headings, all 19 slice actions documented
$ echo $?
0

$ python3 tools/gen_bridge_docs.py --check     # after
ok: docs verb table matches the registry (72 verbs), no duplicate headings, all 19 slice actions documented
$ echo $?
0
```

Identical output, byte for byte. Flagged because it generalises past this field: any future snapshot key added outside the generated block is invisible to CI the same way.

### What is documented

In the vocabulary `HERMES.md` §8 and the `IRadioBackend::dspChains()` contract comment already use — no new terms invented:

- **`backend.family` and `backend.chains`**, with the example response extended to carry one entry of **each** level.
- **`chain`** — `rx-wdsp` / `hl2-tx`, and that a reader keys off `chain` rather than guessing from which fields are present. `rx-wdsp` entries also carry `receiver`, which is the **DDC index**, not a slice id.
- **`level`** — `channel-config` is what the channel was **opened** with after clamping or refusal; `dsp-config` is the DSP's own state; `not-configured` is a chain that exists with nothing behind it, reported present-but-unconfigured rather than omitted and deliberately without the configuration fields, so there are no stale defaults to mistake for real settings.
- **`dsp-config` describes the DSP, not the wire.** Not liveness, not keying — normal unkeying and transient link loss retain the applied configuration and still report `dsp-config`. `HERMES.md` §8 says this; the bridge reference did not.
- **`backend` is absent entirely when the gather is empty** — no backend attached, a backend that does not implement the read-back, or a gather that could not be made all produce no `backend` key at all, never an empty object and never an empty `chains` list. **A caller must not read the absence as "this radio has no chains"**; it means the question went unanswered, which is a different fact.
- The property form: `get dsp backend` returns the identical object, and *why* the read-back is merged before the property branch (`assert_state` and `wait_for` only ever issue property reads).

**One item beyond the three I named in the comment**, called out so it is not a surprise in review: the `State (get)` index table near the top of the same file summarised `get dsp` as "Client-side AetherDSP NR state (NR2…BNR)", which is the same half-truth as the model table row. It is one line in the one file this PR touches; leaving it stale seemed worse than the small scope increase. Happy to drop it if you would rather the PR match the comment exactly.

## Constitution principle honored

**Principle VIII — Evidence Over Assertion.** A docs PR is only as good as whether its prose matches the code, and fluent-but-wrong is the exact failure mode here. Every claim above was checked against the merged tree at `10a566e3` rather than transcribed from the #5401 summary:

- `Hl2Backend::gatherDspChains()` — for the chain names, the three level values, which fields each level emits, and that an unconfigured RX slot or TX chain emits `not-configured` with no config fields.
- The `model == "dsp"` branch of `AutomationServer::doGet()` — for `family` coming from `RadioModel::family()`, and for the `if (!chains.isEmpty())` guard that makes absence the honest answer.
- `tests/automation_dsp_backend_readback_test.cpp` — for the absence claim in both directions. It asserts it twice over: with no backend attached, and with a backend that reports an empty chain list, each time checking both that the bare form omits the key and that the property form refuses it rather than answering an empty object.

The example response was additionally parsed as JSON and its field sets diffed against the gather, so the three entries carry exactly the keys the code emits for `channel-config` (17), `not-configured` (3) and `dsp-config` (14).

**Principle X** is satisfied trivially: branched off current `origin/main` at `10a566e3` in a dedicated worktree, and the only file touched is one no other in-flight work is editing.

**Nothing in the merged code contradicted what I set out to document.**

## Test plan

- [x] `tools/gen_bridge_docs.py --check` green before and after — output above
- [x] Example response validated as parseable JSON, field sets diffed against `gatherDspChains()`
- [x] Every documented claim read off the merged source and the merged test at `10a566e3`
- [ ] Local build — n/a, no code or test change (`git show --stat` is one `.md` file)
- [ ] Behavior on a real radio — n/a, documentation of existing merged behavior

## Checklist

- [x] Commits are signed (SSH)
- [x] No new flat-key `AppSettings` calls — no code change
- [x] Code is clean-room — no code change
- [x] All meter UI uses `MeterSmoother` — no UI change
- [x] Documentation updated — this PR *is* the documentation update; `CHANGELOG.md` deliberately untouched
- [x] Security-sensitive changes reference a GHSA — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TtnKQu6QGrSeBirGeAsAs
